### PR TITLE
feat(twin-parity,#10439): tranche 11 Tweety/IKVM-JPype - bridge_verdict 5 paires SOTA-OK

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/tweety-2-basic-logics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-2-basic-logics.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (Thimm 2012) : C# branche IKVM 8.15.0 + tweety-pl.dll (tracked 0,55 Mo) + 7 refs `org.tweetyproject.*` actifs (using + classes instantiatees), bytecode Java traduit en .NET sans JVM au runtime. Python branche JPype + `from org.tweetyproject.logics.pl.* import` + `from org.tweetyproject.logics.fol.* import`. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : les deux cotes invoquent la meme bibliotheque Java TweetyProject (sat solvers FOL, parser FOPL, raisonneur), seules les idioms de pont different (bytecode .NET vs JVM runtime). DLL source-recompilee (release 8) selon pattern c.220 IKVM causal causal rebuild — pas de maven-shade bytecode 59."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -10,6 +12,12 @@
       csharp_sha: 91f537b4dabe9e9846e6474d42af960bf5288122
     - date: "2026-08-06"
       by: myia-po-2023:CoursIA
+      python_sha: db6e66674e180e9146b7698a17549da121b99df1
+      csharp_sha: 91f537b4dabe9e9846e6474d42af960bf5288122
+      content_python_sha: 9ea706f03d4f0eb8408bda6760ace8de24c999a3bdc75019d713633ad2031ad1
+      content_csharp_sha: 28db117646b3940d869d29bccaa6ad4fda169c22af3d0443a17876c36a8ac998
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA-2
       python_sha: db6e66674e180e9146b7698a17549da121b99df1
       csharp_sha: 91f537b4dabe9e9846e6474d42af960bf5288122
       content_python_sha: 9ea706f03d4f0eb8408bda6760ace8de24c999a3bdc75019d713633ad2031ad1

--- a/scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml
@@ -3,11 +3,19 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (logiques conditionnelle, modale, QBF) : C# branche IKVM 8.14.0 + tweety-advanced-logics.dll (tracked) + 8 refs `org.tweetyproject.logics.cl.reasoner` etc. actifs (3 cellules avec using explicite, classes instantiatees). Python branche JPype + `from org.tweetyproject.logics.cl.reasoner import SimpleCReasoner` + meme classe Java `SimpleCReasoner` invoquee. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : les deux cotes appellent le meme solveur TweetyProject (Thimm 2012), pont IKVM-bytecode .NET vs JPype-JVM-runtime. Meme dynamique que tweety-2 et c.220 #10544 dialogues."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 26ba41f102395886cb452772ebd7a1df8bdcc584
       csharp_sha: 52fd778d91449e795a6abe56218dda183b008190
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 26ba41f102395886cb452772ebd7a1df8bdcc584
+      csharp_sha: 52fd778d91449e795a6abe56218dda183b008190
+      content_python_sha: 079abdf6ba8ed92125087f2d94ddfc38817c14fe5504e92e8bd593b3f840c691
+      content_csharp_sha: 9c3920e259aa31d326dd9ef4c43290314d715449eccc02629d140e497c7efd3b
   known_differences:
     - "Socle commun : logiques avancees (conditionnelle, modale, QBF) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-advanced-logics.dll\"` + `using org.tweetyproject.logics.cl.reasoner` etc.). Python via JPype (`from org.tweetyproject.logics.cl.reasoner import SimpleCReasoner`). Meme moteur Java TweetyProject, deux ponts (IKVM traduit vs JPype JVM)."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (revision des croyances AGM, contraction/revision) : C# branche IKVM 8.15.0 + tweety-beliefdynamics.dll (tracked) + 8 refs `org.tweetyproject.*` actifs (3 cellules avec using explicite + classes Java `SimpleKbReiter`, `DefaultRevisionOperator` invoquees). Python branche JPype + `from java.util import ArrayList, HashSet` + `from org.tweetyproject.beliefdynamics.* import` + meme bibliotheque Java TweetyProject. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : les deux cotes operent sur la meme base de connaissances Java (BeliefSet) avec les memes operateurs de revision, pont IKVM-bytecode vs JPype-JVM-runtime."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -12,6 +14,12 @@
       by: myia-po-2024:CoursIA
       python_sha: 9199041fda10f4ea0691c2130d0b77b7530ffea6
       csharp_sha: a1787c539d0e66bfb4f097a519e55c15dfb9e217
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 9199041fda10f4ea0691c2130d0b77b7530ffea6
+      csharp_sha: a1787c539d0e66bfb4f097a519e55c15dfb9e217
+      content_python_sha: 3397c3499d41f331f9917039d1b006be638d069490079ec8567b04cd826c64c4
+      content_csharp_sha: 56beaf6154fcb031066bc2c38ade50dc672fd7a8ff2d70e419c6b78d2f56a20b
   known_differences:
     - "Socle commun : revision des croyances (AGM, contraction/revision) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`using org.tweetyproject.*`). Python via JPype (`from java.util import ArrayList, HashSet` + `from jpype.types import *`). Meme fondement Java, idiomatique de pont differente."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-6-structured-argumentation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-6-structured-argumentation.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-6-Structured-Argumentation-Csharp.ipynb
   parity_level: native-both
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (argumentation structuree ASPIC+) : C# branche IKVM 8.15.0 + tweety-aspic.dll (tracked) + 8 refs `org.tweetyproject.arg.aspic.*` actifs (2 cellules avec using explicite + `AspicArgumentationTheory.asDungTheory()` invoquee). Python branche JPype + `from org.tweetyproject.arg.aspic.* import` + meme bibliotheque Java. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : la paire est deja documentee native-both (PR #10385, 2026-08-11) avec parite 3-voies PROUVEE (C# from-scratch <=> C# IKVM <=> Python JPype convergent sur le meme AAF). Verdict SOTA-OK : lib-vs-lib meme moteur, le C# preserve en plus la tranche from-scratch pedagogique (gabarit Tweety-5-Csharp)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/tweety-7b-ranking-probabilistic.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-7b-ranking-probabilistic.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (semantiques de rangement ranking + probabilistes + division) : C# branche IKVM 8.14.0 + tweety-rpcl.dll (tracked) + 23 refs `org.tweetyproject.*` actifs (3 cellules avec using explicite, classes Dung Division, RankingSemantics Java invoquees). Python branche JPype + `from org.tweetyproject.arg.dung.divisions import Division` + meme moteur Java. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : 23 refs = la plus grosse utilisation TweetyProject parmi les paires Tweety du registre (audited individu M-XX), les deux cotes operent sur les memes semantiques ranking (Categorizer-based, Burden-based) avec les memes theorems de comparaison."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -12,6 +14,12 @@
       by: myia-po-2024:CoursIA
       python_sha: fb7670e9ebe474a93db4534f4f76ded9f8c0e581
       csharp_sha: c0b08647723dabc8be38dde312640cc43ea67a96
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA-2
+      python_sha: fb7670e9ebe474a93db4534f4f76ded9f8c0e581
+      csharp_sha: c0b08647723dabc8be38dde312640cc43ea67a96
+      content_python_sha: aa2249365da0a457aed062df1dd745cbeeddb781e7e582c0bd7d6d4c2d5b932c
+      content_csharp_sha: 054003552b11b663d7de0056c2e460a6c75ae0cff647ad8b03ca24e2d477a9b4
   known_differences:
     - "Socle commun : semantiques de rangement et probabilistes (ranking, division) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-rpcl.dll\"`). Python via JPype (`from org.tweetyproject.arg.dung.divisions import Division`). Meme moteur Java."


### PR DESCRIPTION
Grain: MED/ledger — lane myia-po-2023:CoursIA-2 — prev: MED/guard #10604

## Résumé

feat(twin-parity,#10439) — tranche 11 sur la famille **Tweety/IKVM-JPype** (Thimm 2012) : 5 paires bridgées en **SOTA-OK** (lib-vs-lib meme moteur Java TweetyProject, pont IKVM-bytecode vs JPype-JVM-runtime).

| # | Paire | DLL IKVM C# | JPype Python | Verdict |
|---|---|---|---|---|
| 1 | Tweety-2 Basic-Logics | tweety-pl.dll | FOPL parser/reasoner | SOTA-OK |
| 2 | Tweety-3 Advanced-Logics | tweety-advanced-logics.dll | SimpleCReasoner | SOTA-OK |
| 3 | Tweety-4 Belief-Revision | tweety-beliefdynamics.dll | SimpleKbReiter | SOTA-OK |
| 4 | Tweety-6 Structured-Argumentation | tweety-aspic.dll | arg.aspic.* | SOTA-OK (native-both) |
| 5 | Tweety-7b Ranking-Probabilistic | tweety-rpcl.dll | arg.dung.divisions | SOTA-OK (23 refs actifs) |

## Pourquoi SOTA-OK (pas RECOVERABLE-*)

Les 5 paires C# chargent le `*.dll` IKVM-bridged de TweetyProject et **instancient des classes Java Tweety** (`SimpleCReasoner`, `SimpleKbReiter`, `AspicArgumentationTheory.asDungTheory()`, `Division`). Les 5 paires Python utilisent **JPype** vers la meme bibliotheque Java. Meme moteur, deux idioms de pont :

- C# : IKVM traduit le bytecode Java en .NET (pas de JVM au runtime, `#r "nuget: IKVM, 8.15.0"` + DLL tracked).
- Python : JPype demarre une JVM et importe `org.tweetyproject.*` comme modules Python.

Les DLLs source-recompilees selon pattern c.220 IKVM causal rebuild (`javac --release 8`) — pas de maven-shade bytecode 59.

## Méthode de vérification (G.9 firsthand)

Pour chaque paire :

1. **Analyse des imports C#** : `using org.tweetyproject.*` count par cellule (5/5 ont ≥2 cellules avec using explicite).
2. **Vérification DLL tracked** : `ls MyIA.AI.Notebooks/SymbolicAI/Tweety/*.dll` confirme que les DLLs référencees existent sur disque (11 DLLs tracked au total).
3. **Analyse des imports Python** : grep `from org.tweetyproject.* import` dans le twin Python pour confirmer le pattern JPype attendu.
4. **Pinning SHA** : `git ls-tree HEAD` pour les SHAs blob, `json.dumps(metadata-less) sha256` pour les content_sha (anti-regression pattern #9399).

## Verdict par paire (résumé du `bridge_verdict_reason`)

**Tweety-2** : `bridge_verdict: SOTA-OK`. 7 refs `org.tweetyproject.*` actifs. FOPL parser/reasoner charge des deux cotes.

**Tweety-3** : `bridge_verdict: SOTA-OK`. 8 refs actifs, 3 cellules avec using explicite. `SimpleCReasoner` (logique conditionnelle) invoqué des deux cotes.

**Tweety-4** : `bridge_verdict: SOTA-OK`. 8 refs actifs, 3 cellules avec using explicite. `SimpleKbReiter` (revision AGM) invoqué des deux cotes.

**Tweety-6** : `bridge_verdict: SOTA-OK`. 8 refs actifs, 2 cellules avec using explicite. `AspicArgumentationTheory.asDungTheory()` (ASPIC+ -> AAF) — la paire est deja native-both (PR #10385, 2026-08-11) avec **parite 3-voies PROUVEE firsthand** (C# from-scratch tranche 1 <=> C# IKVM tranche 2 <=> Python JPype convergent sur le meme AAF). Verdict SOTA-OK : lib-vs-lib meme moteur ; le C# preserve en plus la tranche from-scratch pedagogique (gabarit Tweety-5-Csharp).

**Tweety-7b** : `bridge_verdict: SOTA-OK`. **23 refs actifs** = la plus grosse utilisation TweetyProject parmi les paires Tweety du registre (audited individu M-XX). Les deux cotes operent sur les memes semantiques ranking (Categorizer-based, Burden-based) avec les memes theorems de comparaison.

## 3 paires Tweety reste non-bridgees (deferred tranche 12)

| Paire | Statut | Verdict probable |
|---|---|---|
| tweety-5 Abstract-Argumentation | C# from-scratch (BCL pure, 0 NuGet) + Python JPype | **INTRINSIC** (engine mismatch, C# n'utilise PAS tweety-dung.dll malgré la mention dans setup) |
| tweety-7a Extended-Frameworks | C# Prong B from-scratch (0 IKVM, 0 JVM) + Python JPype | **INTRINSIC** (Prong B impose from-scratch, c'est explicite dans le source) |
| tweety-9 Preferences | C# has Theory/Reasoner localement (pas de `using org.tweetyproject`) + Python JPype | **INTRINSIC** (engine mismatch, IKVM setup non-utilisé) |
| tweety-10 MLN | C# only Formula symbol (pas de `Reasoner`/`Theory`) + Python JPype | **INTRINSIC** (engine mismatch) |

Ces 4 paires forment une **tranche 12 INTRINSIC** naturelle (4 paires + 1 supplémentaire possible depuis une autre famille). À planifier dans un cycle futur.

## Verification hermétique

```
$ python scripts/notebook_tools/check_twin_parity.py --summary-by-verdict
Summary by bridge_verdict (157 paires) :
  (non-rompu)             42 ACTIONNABLE
  SOTA-OK                 83     (avant 78, +5)
  RECOVERABLE-LOCAL       31 ACTIONNABLE
  INTRINSIC                1
  actionnables (a bridger)  73  = total - INTRINSIC - SOTA-OK

$ python scripts/notebook_tools/check_twin_parity.py | grep -E "Tweety-(2|3|4|6|7b)"
[OK] Tweety-2 Basic-Logics (Tweety/IKVM-JPype, semantic)
[OK] Tweety-3 Advanced-Logics (Tweety/IKVM-JPype, semantic)
[OK] Tweety-4 Belief-Revision (Tweety/IKVM-JPype, semantic)
[OK] Tweety-6 Structured-Argumentation (Tweety/IKVM-JPype, native-both)
[OK] Tweety-7b Ranking-Probabilistic (Tweety/IKVM-JPype, semantic)
```

5/5 OK. Coverage progress : SOTA-OK 78 → 83 (+5). Actionnable 78 → 73 (-5).

## Diff stat

```
scripts/notebook_tools/twin_pairs.d/tweety-2-basic-logics.yaml           | +8
scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml        | +8
scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml        | +8
scripts/notebook_tools/twin_pairs.d/tweety-6-structured-argumentation.yaml | +2
scripts/notebook_tools/twin_pairs.d/tweety-7b-ranking-probabilistic.yaml | +8
5 files changed, 34 insertions(+)
```

Bien sous §A (< 3000 lignes / < 15 fichiers / 1 feature = bridge_verdict tranche).

## Scope catalog-pr-hygiene R1

`COURSE_CATALOG.generated.{json,md}` byte-identique à `main`. Marqueurs `<!-- CATALOG-STATUS -->` inchangés. 0 fichier hors `twin_pairs.d/tweety-*.yaml` modifié.

## G-VAR-1 floor

`MED/ledger` = genuine ledger entry (ajoute des `bridge_verdict` au registre, avec audit entry + content_sha + reason). Plancher CONTENT tenu.

## Suite (tranche 12)

4 paires Tweety INTRINSIC (5/7a/9/10) — engine mismatch C# from-scratch vs Python JPype. Verdict à écrire avec reason "engine mismatch, ne peut etre bridge sans changer la formulation pedagogique du C#". Tranche naturelle pour le prochain cycle ou pour un autre worker.

## Références

- Issue #10439 — twin-parity bridge_verdict mechanism
- Issue #10381 — Tweety IKVM causal (#10471) et dialogues (#10544)
- c.220 PR #10544 — pattern IKVM causal rebuild (source-recompile release 8)
- PR #10385 — Tweety-6 native-both parite 3-voies (po-2023:CoursIA-2)
- Schema `_schema.yaml` ligne 42-62 — 5 verdicts enumeration

🤖 Generated with [Claude Code](https://claude.com/claude-code)