### PR TITLE
feat(twin-parity,#10382): App-6 Minesweeper C# -- OR-Tools CP-SAT bridge (tranche 2)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb
@@ -95,7 +95,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -105,10 +105,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -123,7 +123,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -135,8 +135,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://2a01:cb14:11a:e100:1173:a4f3:3c59:d15d:2048/\",\"http://2a01:cb14:11a:e100:f478:1a67:b85e:4d27:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::4050:b6c1:81f8:3162%22:2048/\",\"http://172.23.64.1:2048/\",\"http://fe80::afda:56aa:343:c6af%49:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -185,13 +185,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb
@@ -79,13 +79,128 @@
    "id": "22b109cc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:53.655470Z",
-     "iopub.status.busy": "2026-07-07T14:18:53.650518Z",
-     "iopub.status.idle": "2026-07-07T14:18:55.680285Z",
-     "shell.execute_reply": "2026-07-07T14:18:55.671226Z"
+     "iopub.execute_input": "2026-08-12T11:33:07.583422Z",
+     "iopub.status.busy": "2026-08-12T11:33:07.574718Z",
+     "iopub.status.idle": "2026-08-12T11:33:09.817930Z",
+     "shell.execute_reply": "2026-08-12T11:33:09.813107Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       "async function probeAddresses(probingAddresses) {\r\n",
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       "\r\n",
+       "            let rootUrl = probingAddresses[i];\r\n",
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       "                    body: probingAddresses[i]\r\n",
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://2a01:cb14:11a:e100:1173:a4f3:3c59:d15d:2048/\",\"http://2a01:cb14:11a:e100:f478:1a67:b85e:4d27:2048/\",\"http://fe80::1a3e:4483:b69e:11bc%12:2048/\",\"http://192.168.0.46:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::4050:b6c1:81f8:3162%22:2048/\",\"http://172.23.64.1:2048/\",\"http://fe80::afda:56aa:343:c6af%49:2048/\",\"http://172.26.208.1:2048/\"])\r\n",
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '47268.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       "        loadDotnetInteractiveApi();\r\n",
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       "    loadDotnetInteractiveApi();\r\n",
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -226,10 +341,10 @@
    "id": "7464a302",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:55.681989Z",
-     "iopub.status.busy": "2026-07-07T14:18:55.681781Z",
-     "iopub.status.idle": "2026-07-07T14:18:55.799208Z",
-     "shell.execute_reply": "2026-07-07T14:18:55.760393Z"
+     "iopub.execute_input": "2026-08-12T11:33:09.819605Z",
+     "iopub.status.busy": "2026-08-12T11:33:09.819342Z",
+     "iopub.status.idle": "2026-08-12T11:33:09.948003Z",
+     "shell.execute_reply": "2026-08-12T11:33:09.907209Z"
     }
    },
    "outputs": [
@@ -1569,10 +1684,10 @@
    "id": "d46939ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:55.800805Z",
-     "iopub.status.busy": "2026-07-07T14:18:55.800611Z",
-     "iopub.status.idle": "2026-07-07T14:18:55.879602Z",
-     "shell.execute_reply": "2026-07-07T14:18:55.864607Z"
+     "iopub.execute_input": "2026-08-12T11:33:09.949708Z",
+     "iopub.status.busy": "2026-08-12T11:33:09.949471Z",
+     "iopub.status.idle": "2026-08-12T11:33:10.036563Z",
+     "shell.execute_reply": "2026-08-12T11:33:10.020295Z"
     }
    },
    "outputs": [
@@ -2332,10 +2447,10 @@
    "id": "2a7c756d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:55.881170Z",
-     "iopub.status.busy": "2026-07-07T14:18:55.880971Z",
-     "iopub.status.idle": "2026-07-07T14:18:56.084604Z",
-     "shell.execute_reply": "2026-07-07T14:18:56.084452Z"
+     "iopub.execute_input": "2026-08-12T11:33:10.038692Z",
+     "iopub.status.busy": "2026-08-12T11:33:10.038397Z",
+     "iopub.status.idle": "2026-08-12T11:33:10.241535Z",
+     "shell.execute_reply": "2026-08-12T11:33:10.241340Z"
     }
    },
    "outputs": [
@@ -2493,6 +2608,244 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1t2ranche2md",
+   "metadata": {},
+   "source": [
+    "## 4bis. Tranche 2 — solveur CSP via OR-Tools CP-SAT\n",
+    "\n",
+    "La §4 ci-dessus implémente le solveur CSP **à la main** : énumération backtracking\n",
+    "des `2^k` affectations d'une frontière de taille *k*. C'est fidèle au concept, mais\n",
+    "le coût explose et la recherche reste *brute* (aucune propagation). Le **twin Python**\n",
+    "délègue, lui, cette énumération à la lib `python-constraint` (`getSolutions()`).\n",
+    "\n",
+    "**Cette tranche branche le vrai moteur de production de l'écosystème .NET :\n",
+    "[Google OR-Tools](https://developers.google.com/optimization/cp/cp_solver) et son\n",
+    "solveur CP-SAT.** On reprend **exactement le même modèle CSP** (variables binaires\n",
+    "0/1 par cellule-frontière, contraintes `ExactSum` sur les voisins), mais on laisse\n",
+    "CP-SAT faire le travail de propagation + apprentissage de clauses (CDCL) qu'un\n",
+    "backtracking manuel ne sait pas faire.\n",
+    "\n",
+    "**Deux apports pédagogiques du moteur, que le solveur §4 from-scratch n'a pas :**\n",
+    "\n",
+    "1. **Déduction par test d'inconsistance (UNSAT).** Pour savoir si une cellule `v`\n",
+    "   est **forcée**, on n'énumère plus les `2^k` solutions : on teste si `v == 0`\n",
+    "   est réalisable, puis si `v == 1` l'est. Si l'un est `INFEASIBLE`, `v` est forcée\n",
+    "   à l'autre valeur. C'est `O(k)` résolutions CP-SAT (chacune tronquée par\n",
+    "   propagation) au lieu de `O(2^k)` — l'apprentissage de clauses de CP-SAT prouve\n",
+    "   l'inconsistance sans explorer l'arbre. La Démo 1 confirme le verdict §4 par\n",
+    "   cette voie indépendante.\n",
+    "2. **Contrainte globale sur le total des mines.** Le solveur §4 n'utilise que les\n",
+    "   contraintes *locales* (une par cellule révélée). CP-SAT accepte en plus une\n",
+    "   contrainte globale « la somme des mines de la frontière ≤ mines restantes »\n",
+    "   — c'est l'objectif de l'Exercice 1 ci-dessous, qu'un moteur CSP intègre nativement\n",
+    "   alors qu'il demanderait une refonte du backtracking manuel. La Démo 2 la mobilise.\n",
+    "\n",
+    "> **Verdict SOTA (Prong A).** OR-Tools CP-SAT est le solveur CSP/SAT de production\n",
+    "> du dépôt (déjà bridgé sur App-1, App-8, App-10, Sudoku-9…). La §4 from-scratch\n",
+    "> reste pour enseigner la mécanique de la recherche ; cette tranche montre le\n",
+    "> moteur réel qui propage et qui passe à l'échelle. `bridge_verdict: RECOVERABLE-LOCAL`\n",
+    "> — l'écart était comblable par un NuGet first-class, c'est fait."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a1t2ranche2code",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T11:33:10.243074Z",
+     "iopub.status.busy": "2026-08-12T11:33:10.242852Z",
+     "iopub.status.idle": "2026-08-12T11:33:13.892326Z",
+     "shell.execute_reply": "2026-08-12T11:33:13.892031Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Google.OrTools, 9.15.6755</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Démo 1 : déduction OR-Tools CP-SAT (tests UNSAT), frontière=19 ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules forcées sûres  : 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules forcées mines  : 0\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Temps                   : 668,9 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(Le solveur §4 from-scratch trouvait aussi 0 forcées sur ce plateau :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " confirmation indépendante par propagation CP-SAT, sans énumérer 2^k.)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- Démo 2 : même déduction AVEC contrainte globale (RemainingMines=9) ---\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules forcées sûres  : 0  (avec contrainte globale)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cellules forcées mines  : 0  (avec contrainte globale)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Temps                   : 590,0 ms\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(La contrainte globale restreint l'espace : le compte de forcées peut augmenter.)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Tranche 2 : solveur CSP via OR-Tools CP-SAT (pont moteur de production) ===\n",
+    "// Reprend le modele CSP de la §4 (variables binaires frontieres, contraintes\n",
+    "// ExactSum) et delegue la deduction a Google.OrTools CP-SAT.\n",
+    "#r \"nuget: Google.OrTools\"\n",
+    "using Google.OrTools.Sat;\n",
+    "\n",
+    "// OrToolsCSPSolver : deduction par propagation (tests UNSAT), la technique\n",
+    "// qu'un moteur CSP apporte et qu'un backtracking scolaire (§4, 2^k) n'a pas.\n",
+    "public class OrToolsCSPSolver\n",
+    "{\n",
+    "    public MinesweeperBoard Board;\n",
+    "    public OrToolsCSPSolver(MinesweeperBoard board) { Board = board; }\n",
+    "\n",
+    "    // Reutilise la definition de frontiere et de contraintes de CSPSolver.\n",
+    "    public HashSet<(int r, int c)> Frontier() => new CSPSolver(Board).Frontier();\n",
+    "    public List<(List<(int r, int c)> vars, int sum)> Constraints(HashSet<(int r, int c)> f)\n",
+    "        => new CSPSolver(Board).Constraints(f);\n",
+    "\n",
+    "    // Construit le modele CP-SAT : BoolVar par cellule-frontiere, contrainte\n",
+    "    // LinearExpr.Sum(voisins) == remaining pour chaque cellule revelee.\n",
+    "    // withGlobalTotal : ajoute la contrainte globale (Exercice 1) \"somme des mines\n",
+    "    // de la frontiere <= RemainingMines\" -- hors-portee du from-scratch, natif CP-SAT.\n",
+    "    private (CpModel model, Dictionary<(int r, int c), BoolVar> vars) BuildModel(bool withGlobalTotal = false)\n",
+    "    {\n",
+    "        var frontier = Frontier();\n",
+    "        var model = new CpModel();\n",
+    "        var vars = new Dictionary<(int r, int c), BoolVar>();\n",
+    "        foreach (var cell in frontier) vars[cell] = model.NewBoolVar($\"m_{cell.r}{cell.c}\");\n",
+    "        foreach (var (vs, sum) in Constraints(frontier))\n",
+    "        {\n",
+    "            var terms = vs.Where(v => vars.ContainsKey(v)).Select(v => (LinearExpr)vars[v]).ToArray();\n",
+    "            if (terms.Length > 0) model.Add(LinearExpr.Sum(terms) == sum);\n",
+    "        }\n",
+    "        if (withGlobalTotal && frontier.Count > 0)\n",
+    "        {\n",
+    "            var allTerms = frontier.Select(c => (LinearExpr)vars[c]).ToArray();\n",
+    "            model.Add(LinearExpr.Sum(allTerms) <= Board.RemainingMines);\n",
+    "        }\n",
+    "        return (model, vars);\n",
+    "    }\n",
+    "\n",
+    "    // Deduction par tests UNSAT : une cellule est FORCEE si v==0 (ou v==1) est\n",
+    "    // INFEASIBLE. O(k) resolutions CP-SAT tronquees par propagation (CDCL) --\n",
+    "    // c'est l'apprentissage de clauses qu'un backtracking manuel n'a pas.\n",
+    "    // Retourne (safe, mines, status) ; status<0 si le modele de base est vide/infeasible.\n",
+    "    public (HashSet<(int r, int c)> safe, HashSet<(int r, int c)> mines, int status) DeduceByUnsat(bool withGlobalTotal = false)\n",
+    "    {\n",
+    "        var safe = new HashSet<(int r, int c)>();\n",
+    "        var mines = new HashSet<(int r, int c)>();\n",
+    "        var solver = new CpSolver();\n",
+    "        var (baseModel, _) = BuildModel(withGlobalTotal);\n",
+    "        var baseStatus = solver.Solve(baseModel);\n",
+    "        if (baseStatus == CpSolverStatus.Infeasible) return (safe, mines, -1);\n",
+    "        if (baseStatus == CpSolverStatus.Unknown) return (safe, mines, -2);\n",
+    "        foreach (var cell in Frontier())\n",
+    "        {\n",
+    "            var (mSafe, vSafe) = BuildModel(withGlobalTotal); mSafe.Add(vSafe[cell] == 0);\n",
+    "            var (mMine, vMine) = BuildModel(withGlobalTotal); mMine.Add(vMine[cell] == 1);\n",
+    "            var sSafe = solver.Solve(mSafe);\n",
+    "            var sMine = solver.Solve(mMine);\n",
+    "            if (sSafe == CpSolverStatus.Infeasible) mines.Add(cell);      // v==0 impossible -> mine\n",
+    "            else if (sMine == CpSolverStatus.Infeasible) safe.Add(cell);  // v==1 impossible -> safe\n",
+    "        }\n",
+    "        return (safe, mines, 0);\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// DÉMO 1 : meme plateau bloque que la §4, deduction par propagation CP-SAT.\n",
+    "// Doit confirmer le verdict du from-scratch (0 forcees sur ce plateau a ce stade)\n",
+    "// par une VOIE INDEPENDANTE (propagation + UNSAT, pas enumeration brute).\n",
+    "var boardOt = board0.Copy();\n",
+    "var rsOt = new RuleBasedSolver(boardOt); rsOt.Solve();\n",
+    "var otFrontier0 = new OrToolsCSPSolver(boardOt).Frontier();\n",
+    "Console.WriteLine($\"--- Démo 1 : déduction OR-Tools CP-SAT (tests UNSAT), frontière={otFrontier0.Count} ---\");\n",
+    "var swOt = System.Diagnostics.Stopwatch.StartNew();\n",
+    "var (safeOt, minesOt, stOt) = new OrToolsCSPSolver(boardOt).DeduceByUnsat();\n",
+    "swOt.Stop();\n",
+    "Console.WriteLine($\"Cellules forcées sûres  : {safeOt.Count}\");\n",
+    "Console.WriteLine($\"Cellules forcées mines  : {minesOt.Count}\");\n",
+    "Console.WriteLine($\"Temps                   : {swOt.Elapsed.TotalMilliseconds:F1} ms\");\n",
+    "Console.WriteLine(\"(Le solveur §4 from-scratch trouvait aussi 0 forcées sur ce plateau :\");\n",
+    "Console.WriteLine(\" confirmation indépendante par propagation CP-SAT, sans énumérer 2^k.)\");\n",
+    "\n",
+    "// DÉMO 2 : avec la contrainte GLOBALE total-mines (Exercice 1, TODO étudiant).\n",
+    "// Le solveur §4 n'utilise que les contraintes locales ; CP-SAT l'accepte nativement\n",
+    "// et restreint l'espace, ce qui peut révéler des cellules forcées supplémentaires.\n",
+    "Console.WriteLine($\"--- Démo 2 : même déduction AVEC contrainte globale (RemainingMines={boardOt.RemainingMines}) ---\");\n",
+    "var swG = System.Diagnostics.Stopwatch.StartNew();\n",
+    "var (safeG, minesG, stG) = new OrToolsCSPSolver(boardOt).DeduceByUnsat(withGlobalTotal: true);\n",
+    "swG.Stop();\n",
+    "Console.WriteLine($\"Cellules forcées sûres  : {safeG.Count}  (avec contrainte globale)\");\n",
+    "Console.WriteLine($\"Cellules forcées mines  : {minesG.Count}  (avec contrainte globale)\");\n",
+    "Console.WriteLine($\"Temps                   : {swG.Elapsed.TotalMilliseconds:F1} ms\");\n",
+    "Console.WriteLine(\"(La contrainte globale restreint l'espace : le compte de forcées peut augmenter.)\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3d618f42",
    "metadata": {},
    "source": [
@@ -2510,14 +2863,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "7e15d5b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:56.085998Z",
-     "iopub.status.busy": "2026-07-07T14:18:56.085789Z",
-     "iopub.status.idle": "2026-07-07T14:18:56.216276Z",
-     "shell.execute_reply": "2026-07-07T14:18:56.215914Z"
+     "iopub.execute_input": "2026-08-12T11:33:13.894028Z",
+     "iopub.status.busy": "2026-08-12T11:33:13.893807Z",
+     "iopub.status.idle": "2026-08-12T11:33:14.094102Z",
+     "shell.execute_reply": "2026-08-12T11:33:14.093847Z"
     }
    },
    "outputs": [
@@ -2628,14 +2981,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "73c294ad",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:56.217735Z",
-     "iopub.status.busy": "2026-07-07T14:18:56.217502Z",
-     "iopub.status.idle": "2026-07-07T14:18:56.297359Z",
-     "shell.execute_reply": "2026-07-07T14:18:56.297033Z"
+     "iopub.execute_input": "2026-08-12T11:33:14.095501Z",
+     "iopub.status.busy": "2026-08-12T11:33:14.095266Z",
+     "iopub.status.idle": "2026-08-12T11:33:14.257578Z",
+     "shell.execute_reply": "2026-08-12T11:33:14.257398Z"
     }
    },
    "outputs": [
@@ -2759,14 +3112,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "1b4322d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:56.299344Z",
-     "iopub.status.busy": "2026-07-07T14:18:56.299011Z",
-     "iopub.status.idle": "2026-07-07T14:18:56.474286Z",
-     "shell.execute_reply": "2026-07-07T14:18:56.473836Z"
+     "iopub.execute_input": "2026-08-12T11:33:14.258896Z",
+     "iopub.status.busy": "2026-08-12T11:33:14.258697Z",
+     "iopub.status.idle": "2026-08-12T11:33:14.516075Z",
+     "shell.execute_reply": "2026-08-12T11:33:14.515869Z"
     }
    },
    "outputs": [
@@ -2831,7 +3184,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps moyen : 0,4 ms/partie\r\n"
+      "  Temps moyen : 0,5 ms/partie\r\n"
      ]
     },
     {
@@ -2866,7 +3219,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps moyen : 0,6 ms/partie\r\n"
+      "  Temps moyen : 1,0 ms/partie\r\n"
      ]
     },
     {
@@ -2945,14 +3298,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "112f7ffd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:56.475785Z",
-     "iopub.status.busy": "2026-07-07T14:18:56.475573Z",
-     "iopub.status.idle": "2026-07-07T14:18:56.537738Z",
-     "shell.execute_reply": "2026-07-07T14:18:56.537485Z"
+     "iopub.execute_input": "2026-08-12T11:33:14.517749Z",
+     "iopub.status.busy": "2026-08-12T11:33:14.517512Z",
+     "iopub.status.idle": "2026-08-12T11:33:14.566596Z",
+     "shell.execute_reply": "2026-08-12T11:33:14.566406Z"
     }
    },
    "outputs": [
@@ -2984,14 +3337,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "5c3a7770",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:56.538897Z",
-     "iopub.status.busy": "2026-07-07T14:18:56.538707Z",
-     "iopub.status.idle": "2026-07-07T14:18:56.563470Z",
-     "shell.execute_reply": "2026-07-07T14:18:56.563297Z"
+     "iopub.execute_input": "2026-08-12T11:33:14.567914Z",
+     "iopub.status.busy": "2026-08-12T11:33:14.567668Z",
+     "iopub.status.idle": "2026-08-12T11:33:14.601129Z",
+     "shell.execute_reply": "2026-08-12T11:33:14.600864Z"
     }
    },
    "outputs": [
@@ -3027,14 +3380,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "2c26c775",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T14:18:56.564668Z",
-     "iopub.status.busy": "2026-07-07T14:18:56.564502Z",
-     "iopub.status.idle": "2026-07-07T14:18:56.593617Z",
-     "shell.execute_reply": "2026-07-07T14:18:56.593822Z"
+     "iopub.execute_input": "2026-08-12T11:33:14.602445Z",
+     "iopub.status.busy": "2026-08-12T11:33:14.602228Z",
+     "iopub.status.idle": "2026-08-12T11:33:14.649449Z",
+     "shell.execute_reply": "2026-08-12T11:33:14.649169Z"
     }
    },
    "outputs": [

--- a/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
@@ -18,6 +18,12 @@
       csharp_sha: 89ba0b8a84e7c78be14863f0d157d8b66224d048
       content_python_sha: 978d28eba04e9e4b4a0ad721fabcd6fbdf4065369283ba1161fbd9af8bc5f361
       content_csharp_sha: 16031e17f733de392603be72a8405b4ae5638e503f649876daa6091c9f61183e
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA
+      python_sha: 9a419818be0202ee8388220cf718cdacddbf45c1
+      csharp_sha: 92daf0e4e4656e7797a270dea53821f61da04c5e
+      content_python_sha: 978d28eba04e9e4b4a0ad721fabcd6fbdf4065369283ba1161fbd9af8bc5f361
+      content_csharp_sha: 553aef7ba8521eafc3026b1ec6c8e6bb94254acb958682c72c5d5cfa932c80dd
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Resolved 2026-08-12 (myia-po-2023:CoursIA, tranche 2). Le C# desormais branche Google.OR-Tools CP-SAT (#r nuget:Google.OrTools), le meme solveur de production que le twin Python. Le verdict RECOVERABLE-LOCAL pose par #10588 (ecart = NuGet first-class manquant) est clot : le port est livre. Le solveur from-scratch (section 4) reste pour enseigner la mecanique ; la tranche 2 (section 4bis) demontre la deduction par propagation UNSAT + la contrainte globale total-mines (Exercice 1), deux capacites que le backtracking manuel n'a pas. parity_level passe semantic -> native-both : les deux twins invoquent maintenant le solveur natif de leur ecosysteme (OR-Tools)."
   known_differences:

--- a/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-6-minesweeper.yaml
@@ -2,7 +2,7 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-6-Minesweeper-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - python_sha: 20ead2ac4fe55a2ec0d7dc3ad3434113aa3b8bab
       csharp_sha: 7435be2a68253f66e9e4a6639efc2a44d4aab4bd
@@ -12,7 +12,16 @@
       csharp_sha: 7435be2a68253f66e9e4a6639efc2a44d4aab4bd
       content_python_sha: 978d28eba04e9e4b4a0ad721fabcd6fbdf4065369283ba1161fbd9af8bc5f361
       content_csharp_sha: 67526f92dd60d122ab1a83fbd913a601453037c2ff6e312733849351dc5b7f87
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA
+      python_sha: 9a419818be0202ee8388220cf718cdacddbf45c1
+      csharp_sha: 89ba0b8a84e7c78be14863f0d157d8b66224d048
+      content_python_sha: 978d28eba04e9e4b4a0ad721fabcd6fbdf4065369283ba1161fbd9af8bc5f361
+      content_csharp_sha: 16031e17f733de392603be72a8405b4ae5638e503f649876daa6091c9f61183e
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Resolved 2026-08-12 (myia-po-2023:CoursIA, tranche 2). Le C# desormais branche Google.OR-Tools CP-SAT (#r nuget:Google.OrTools), le meme solveur de production que le twin Python. Le verdict RECOVERABLE-LOCAL pose par #10588 (ecart = NuGet first-class manquant) est clot : le port est livre. Le solveur from-scratch (section 4) reste pour enseigner la mecanique ; la tranche 2 (section 4bis) demontre la deduction par propagation UNSAT + la contrainte globale total-mines (Exercice 1), deux capacites que le backtracking manuel n'a pas. parity_level passe semantic -> native-both : les deux twins invoquent maintenant le solveur natif de leur ecosysteme (OR-Tools)."
   known_differences:
     - "Socle pedagogique commun : Demineur (CSP : contraintes sommes exactes, library python-constraint) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
-    - "Idiomes framework : Python = library python-constraint (ExactSum) + OR-Tools ; C# = BCL pure (System.*), 0 NuGet."
-    - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents."
+    - "Idiomes framework : Python = library python-constraint (ExactSum) + OR-Tools CP-SAT + matplotlib ; C# = from-scratch en BCL pure (System.*, section 4) + bridge OR-Tools CP-SAT (NuGet Google.OrTools, section 4bis ajoute 2026-08-12)."
+    - "Asymetrie pedagogique : Python met l'accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l'implementation from-scratch en BCL pure (section 4, pour la mecanique de recherche) PUIS branche le meme solveur OR-Tools CP-SAT (section 4bis, pour la propagation + contrainte globale). Meme socle theorique, le C# couvre desormais les deux niveaux (manuel puis moteur)."
+    - "Tranche 2 OR-Tools (section 4bis, 2026-08-12) : le C# ajoute le bridge Google.ORTools CP-SAT sur le meme modele CSP. Deux demos : (1) deduction par tests UNSAT (O(k) resolutions tronquees par propagation CDCL vs O(2^k) enumeration), confirme les 0 cellules forcees du from-scratch par voie independante ; (2) contrainte globale total-mines (Exercice 1 TODO), native pour CP-SAT, hors-portee du from-scratch. CP-SAT n'enumerant pas toutes les solutions par defaut, les probabilites restent calculees par le from-scratch (section 4, enumeration bornee a frontiere<=22)."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2023:CoursIA

## Summary

App-6 Minesweeper C# twin -- add **tranche 2**: a bridge to Google.OR-Tools CP-SAT, the production CSP/SAT solver already used on App-1/App-8/App-10/Sudoku-9. The from-scratch solver (section 4) is preserved byte-identical; tranche 2 is appended as **section 4bis**.

Contributes to the twin-parity burndown epic #10382 (bucket 1: .NET motor exists & in service). After this PR the pair moves from `parity_level: semantic` to **`native-both`** (both twins now invoke OR-Tools CP-SAT), and the `bridge_verdict` #10588 annotated as RECOVERABLE-LOCAL is resolved to **SOTA-OK** (the NuGet first-class gap is closed).

### What tranche 2 adds (2 cells, inserted after section 4)

**Cell 9 (markdown, section 4bis header)** -- verbatim first lines:
```
## 4bis. Tranche 2 — solveur CSP via OR-Tools CP-SAT
La §4 ci-dessus implémente le solveur CSP **à la main** : énumération backtracking
des `2^k` affectations...
**Cette tranche branche le vrai moteur de production de l'écosystème .NET :
[Google OR-Tools](...) et son solveur CP-SAT.**
```

**Cell 10 (code, `OrToolsCSPSolver` + 2 demos)** -- verbatim key signature:
```csharp
#r "nuget: Google.OrTools"
using Google.OrTools.Sat;
public class OrToolsCSPSolver {
    // ... BuildModel, DeduceByUnsat(withGlobalTotal) ...
}
```

Two demos on the same blocked board as section 4:

- **Démo 1 -- deduction by UNSAT propagation.** For each frontier cell, test whether `v==0` and `v==1` are feasible; `INFEASIBLE` => forced. O(k) CDCL-truncated solves instead of O(2^k) enumeration. Independently confirms the from-scratch verdict (**0 forced cells** on this board) without enumerating the 23 solutions.
- **Démo 2 -- global total-mines constraint (Exercice 1 TODO).** CP-SAT accepts natively `sum(frontier vars) <= RemainingMines`, a constraint the local-only from-scratch solver cannot exploit.

### Honest SOTA design note (Prong A)

An earlier draft tried a callback-based `AllSolutions` enumeration to compute probabilities, but CP-SAT **does not enumerate all solutions by default** -- the callback collected only 2 of the 23 solutions, producing biased probabilities. Removed in favour of the two capabilities above (UNSAT deduction, global constraint), which are what CP-SAT genuinely contributes. Probabilities stay computed by the from-scratch section 4 (bounded enumeration, frontier <= 22). The verdict is `SOTA-OK`: the real tool is invoked, its true output is committed.

### Execution proof (C.2 / H.3)

Re-executed end-to-end on .NET 10.0.111 + dotnet-interactive 1.0.707101 (kernel `.net-csharp`). Notebook is clean: **24 cells, 0 errors, all code cells carry `execution_count` and outputs**. Section 4 from-scratch output intact (19-cell frontier, 23 solutions enumerated, 0 forced); tranche 2 cross-validates (0 forced via propagation, ~600 ms). No `raise NotImplementedError` / `assert False` / `1/0` (C.1).

### YAML interaction with #10588

Both PRs annotate `app-6-minesweeper.yaml`. #10588 adds `bridge_verdict: RECOVERABLE-LOCAL` (pre-bridge state); this PR supersedes it with `SOTA-OK` + bumps `parity_level` to `native-both` since the bridge is delivered. Conflict is localized to the `audits`/`known_differences` region of one yaml; whoever merges second keeps `SOTA-OK` + `native-both`.

## Test plan

- [x] `check_twin_parity --check` passes 157/157 OK, DRIFT=0
- [x] `check_twin_parity --verify-recorded-sha` on App-6 matches HEAD (only pre-existing Sudoku-14 mismatch, unrelated)
- [x] Notebook executes end-to-end, 0 errors, all code cells have outputs (C.2/H.3)
- [x] Tranche 2 output cross-validates section 4 (both report 0 forced cells)
- [x] C.1 scan: no forbidden patterns
- [ ] CI green

See #10382 (epic stays open -- this is one pair of the 51-pair native-both burndown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

