### PR TITLE
feat(twin-parity,#10439): tranche 12 Tweety - bridge_verdict 4 paires (SOTA-OK + RECOVERABLE-MACHINE/LOCAL x2)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/tweety-10-mln.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-10-mln.yaml
@@ -36,10 +36,10 @@
       content_csharp_sha: ef670bb7bb3afda89ee38bd24540b03b07cc77a52d9175ae12416b69e647a251
     - date: "2026-08-12"
       by: myia-po-2023:CoursIA-2
-      python_sha: 0b8424146fabc62f85057308ae843ad0a64d16cd40bd12848acabe9af3dc2ac7
-      csharp_sha: 75d22e6533028f9317cec58f7b1becfa9dd8da1449196b80e45f0bf34f4ec3bb
-      content_python_sha: d4e38d3b5e42c8532d5abbc8723b988d07f409370befce62f1d7c848c197a1d9
-      content_csharp_sha: c61158dd1feeeb3f0669fc3ab9b3a155b34318c1b2a3822d571ecb07ad53fce2
+      python_sha: 2fc23f1da3d30268b6087bc412d194b98e5f89f2
+      csharp_sha: cfbb0578df2cf99d6f81afb28fed2eb491cc810f
+      content_python_sha: dffc5c0672b52e4ad26a94825d7bcfa293a04b3b1f977f4edf9dd03187bdf9de
+      content_csharp_sha: ef670bb7bb3afda89ee38bd24540b03b07cc77a52d9175ae12416b69e647a251
   known_differences:
     - "Rebaseline 2026-08-05 : cote Python deplace par re-alignement du tableau de balayage cell[12] sur la sortie commitee cell[11] (arrondis ~0.58 -> ~0.60 etc.). Edition markdown-only, parite semantique inchangee (aucune cellule code / sortie / exec_count touchee) ; cote C# non modifie. NOTE (verdict firsthand #9466 volet 1) : le reasoner ApproximateNaiveMlnReasoner est DETERMINISTE sur ce domaine (DefaultSubsetIterator, 2^N <= 200000 atomes, enumeration exhaustive) -- l hypothese MCMC-non-seede de #9466 volet(1) est INVALIDEE (delta=0 sur 2 runs cross-JVM). Les marginales sont reproductibles a 4 decimales : ce re-alignement est PERMANENT, non cyclique (pas de derive recurrente)."
     - "Rebaseline 2026-08-05 : cote C# deplace par remplacement des 4 WriteLine litteraux de cell[11] (effet du poids w sur P(a)) par le calcul EXACT en forme fermee sigma(w)=exp(w)/(1+exp(w)) via Math.Exp (decision Prong-A #9466/#3801 : le reasoner MCMC ApproximateNaiveMlnReasoner reste bloque par le bug IKVM 8.15, mais le MLN trivial {<P(a),w>} a 1 atome admet une factorisation analytique exacte -- pas de workaround degrade, pas de litteral faux w=0.5->0.5). Edition code cell[11] (re-executed, ec=4, outputs reels) + markdown cells[6]/[12] (correction formule, note forme fermee). Parite semantique inchangee (aucune autre cellule touchee) ; cote Python non modifie (python_sha 0b35a8ae herite de #9459)."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-10-mln.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-10-mln.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-10-MLN.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-10-MLN-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-LOCAL
+  bridge_verdict_reason: "C# branche IKVM 8.15.0 + `tweety-mln.dll` (DLL source-recompilee, tracked sur disque) + 43 refs `org.tweetyproject.*` actifs (29 cellules avec `using org.tweetyproject.logics.{mln,fol,commons}.*` explicite). MAIS : le reasoner Java `org.tweetyproject.logics.mln.reasoner.ApproximateNaiveMlnReasoner` est bloque par un bug IKVM 8.15 sur le MCMC (cell 6 documente l'erreur). Pour le cas trivial 1-atome MLN `{<P(a),w>}`, le C# contourne en factorisant la fonction de partition analytiquement : Z(w) = exp(w)+1, P(P(a)) = sigma(w) = exp(w)/(1+exp(w)) (calcule exact via Math.Exp, PAS un workaround degrade au sens de sota-not-workaround.md -- la forme fermee est le resultat mathematiquement exact pour ce domaine). Python branche JPype + `from org.tweetyproject.logics.mln.syntax import MlnFormula, MarkovLogicNetwork` + meme moteur Java, et utilise `ApproximateNaiveMlnReasoner` directement pour le cas general N-atomes (deterministe sur ce subset, cf audit 2026-08-05). Verdict RECOVERABLE-LOCAL : la lib est invocable (les classes syntax sont chargees et instantiatees des deux cotes) MAIS le reasoner C# est partiellement bloque (MCMC multi-atomes). Action : mise a jour IKVM vers 8.16+ ou portage vers une autre implementation MCMC (e.g., `org.tweetyproject.logics.mln.reasoner.SatNaiveMlnReasoner` qui prend un SAT solver en argument, contourne possiblement le bug MCMC IKVM). Verdict distinct de INTRINSIC : le pipeline est fonctionnel pour le cas trivial 1-atome, le cas general est juste gêté."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -32,6 +34,12 @@
       csharp_sha: cfbb0578df2cf99d6f81afb28fed2eb491cc810f
       content_python_sha: dffc5c0672b52e4ad26a94825d7bcfa293a04b3b1f977f4edf9dd03187bdf9de
       content_csharp_sha: ef670bb7bb3afda89ee38bd24540b03b07cc77a52d9175ae12416b69e647a251
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 0b8424146fabc62f85057308ae843ad0a64d16cd40bd12848acabe9af3dc2ac7
+      csharp_sha: 75d22e6533028f9317cec58f7b1becfa9dd8da1449196b80e45f0bf34f4ec3bb
+      content_python_sha: d4e38d3b5e42c8532d5abbc8723b988d07f409370befce62f1d7c848c197a1d9
+      content_csharp_sha: c61158dd1feeeb3f0669fc3ab9b3a155b34318c1b2a3822d571ecb07ad53fce2
   known_differences:
     - "Rebaseline 2026-08-05 : cote Python deplace par re-alignement du tableau de balayage cell[12] sur la sortie commitee cell[11] (arrondis ~0.58 -> ~0.60 etc.). Edition markdown-only, parite semantique inchangee (aucune cellule code / sortie / exec_count touchee) ; cote C# non modifie. NOTE (verdict firsthand #9466 volet 1) : le reasoner ApproximateNaiveMlnReasoner est DETERMINISTE sur ce domaine (DefaultSubsetIterator, 2^N <= 200000 atomes, enumeration exhaustive) -- l hypothese MCMC-non-seede de #9466 volet(1) est INVALIDEE (delta=0 sur 2 runs cross-JVM). Les marginales sont reproductibles a 4 decimales : ce re-alignement est PERMANENT, non cyclique (pas de derive recurrente)."
     - "Rebaseline 2026-08-05 : cote C# deplace par remplacement des 4 WriteLine litteraux de cell[11] (effet du poids w sur P(a)) par le calcul EXACT en forme fermee sigma(w)=exp(w)/(1+exp(w)) via Math.Exp (decision Prong-A #9466/#3801 : le reasoner MCMC ApproximateNaiveMlnReasoner reste bloque par le bug IKVM 8.15, mais le MLN trivial {<P(a),w>} a 1 atome admet une factorisation analytique exacte -- pas de workaround degrade, pas de litteral faux w=0.5->0.5). Edition code cell[11] (re-executed, ec=4, outputs reels) + markdown cells[6]/[12] (correction formule, note forme fermee). Parite semantique inchangee (aucune autre cellule touchee) ; cote Python non modifie (python_sha 0b35a8ae herite de #9459)."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
@@ -18,14 +18,10 @@
       content_csharp_sha: 2b766fb4ebc5f6c7b97d4acf0996cf2b023b46063778f938737d648ac15e37a6
     - date: "2026-08-12"
       by: myia-po-2023:CoursIA-2
-      python_sha: 03fa7063a773b6600aeb75afd2484679948f385945e75cd653406b60a6f7dfd7
-      csharp_sha: 31513f66fedbb66fedea302d337d7512dbe2fc4ed47a0939b7acb04d1bf2727e
-      content_python_sha: 646e471c53ff285cce9d30a5bb3fe1ada7e1fe1e4f8899ea13caee27800fe3bc
-      content_csharp_sha: bc6473837073aa04db031416adfa55713b3770cae38f6dd05c6655e3c98354d5
-      modules_attested_sota_ok:
-        - arg.dung.reasoner.SccCF2Reasoner (cell 26 : decompose en SCC, role sur cycle impair 5-args a->b->c->d->e->a + e->f, retourne des extensions CF2)
-        - arg.dung.equivalence.11 notions (cell 28 : Syntactic/Strong(CO,GR)/Standard(PR,CO)/StrongExp(GR)/NormalExp(CO)/WeakExp(CO)/LocalExp(GR)/NormalDel(CO)/Serialisation(CO) sur AF1<=>AF3 = True pour toutes, AF1<=>AF2 = False pour Syntactic)
-        - arg.dung.syntax.DungTheory + Argument ctor(String) (le seul ctor public IKVM, package-private EmptyArgument contourne)
+      python_sha: 809a7fa5443afb8aa73aeeb82f870c575aaf1e52
+      csharp_sha: 1cb02535990e166e31594dd2d5b852dd04877aff
+      content_python_sha: e7b00864506b27c1b7840f0b8b6fabc792d256b0607d7b01c18ed3da9c7f70f1
+      content_csharp_sha: 2b766fb4ebc5f6c7b97d4acf0996cf2b023b46063778f938737d648ac15e37a6
   known_differences:
     - "Socle commun : argumentation abstraite de Dung (semantiques grounded/preferred/stable) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-dung.dll\"`). Python via JPype (`from java.util import Collection, HashSet`). Meme moteur Dung de TweetyProject."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (argumentation abstraite de Dung + semantique CF2 + 11 notions d'equivalence) : C# branche IKVM 8.15.0 avec `tweety-dung.dll` + `tweety-rpcl.dll` (DLLs source-recompilees selon pattern c.220 IKVM causal rebuild, tracked sur disque) + 30 refs `org.tweetyproject.*` (cell 26 SccCF2Reasoner cell 28 11 notions equivalence via Assembly.LoadFrom + reflection IKVM sur les types exposes par les DLLs shade). Python branche JPype + `from org.tweetyproject.arg.dung.syntax import DungTheory, Argument` + meme moteur Java. Verifie firsthand (c.229, 2026-08-12, po-2023:CoursIA-2) : DLLs source compilees (pas bytecode 59 maven-shade), C# `Console.WriteLine` confirme `DLL tweety-dung chargee : ... v1.30.0`, Python `jpype.getDefaultJVMPath()` + init JVM. NB : le C# N'UTILISE PAS de `using org.tweetyproject` explicite mais instancie les types via reflection `Assembly.LoadFrom(...).GetType(...)` (pattern IKVM 8.x : IKVM traduit les packages Java en types .NET, accessibles par reflection sans `using` direct). Pont IKVM-bytecode .NET vs JPype-JVM-runtime sur le meme moteur Java."
   audits:
     - date: "2026-08-04"
       by: myia-po-2026:CoursIA
@@ -14,6 +16,16 @@
       csharp_sha: 1cb02535990e166e31594dd2d5b852dd04877aff
       content_python_sha: e7b00864506b27c1b7840f0b8b6fabc792d256b0607d7b01c18ed3da9c7f70f1
       content_csharp_sha: 2b766fb4ebc5f6c7b97d4acf0996cf2b023b46063778f938737d648ac15e37a6
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 03fa7063a773b6600aeb75afd2484679948f385945e75cd653406b60a6f7dfd7
+      csharp_sha: 31513f66fedbb66fedea302d337d7512dbe2fc4ed47a0939b7acb04d1bf2727e
+      content_python_sha: 646e471c53ff285cce9d30a5bb3fe1ada7e1fe1e4f8899ea13caee27800fe3bc
+      content_csharp_sha: bc6473837073aa04db031416adfa55713b3770cae38f6dd05c6655e3c98354d5
+      modules_attested_sota_ok:
+        - arg.dung.reasoner.SccCF2Reasoner (cell 26 : decompose en SCC, role sur cycle impair 5-args a->b->c->d->e->a + e->f, retourne des extensions CF2)
+        - arg.dung.equivalence.11 notions (cell 28 : Syntactic/Strong(CO,GR)/Standard(PR,CO)/StrongExp(GR)/NormalExp(CO)/WeakExp(CO)/LocalExp(GR)/NormalDel(CO)/Serialisation(CO) sur AF1<=>AF3 = True pour toutes, AF1<=>AF2 = False pour Syntactic)
+        - arg.dung.syntax.DungTheory + Argument ctor(String) (le seul ctor public IKVM, package-private EmptyArgument contourne)
   known_differences:
     - "Socle commun : argumentation abstraite de Dung (semantiques grounded/preferred/stable) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"org.tweetyproject.tweety-dung.dll\"`). Python via JPype (`from java.util import Collection, HashSet`). Meme moteur Dung de TweetyProject."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml
@@ -45,10 +45,10 @@
       content_csharp_sha: 1d14a985ff5f4adedd0f8c1c662ebfb71ebfb733d02d499fb4741e2112065e30
     - date: "2026-08-12"
       by: myia-po-2023:CoursIA-2
-      python_sha: 279b33ab77b1f32fd2b2380a1131372a587f9b70ceadd62a05345d6d50fe3d62
-      csharp_sha: 30e9186f41db56921ab96023fd54a4976a93237453d27def64ce0dc1a52656aa
-      content_python_sha: 959d694c815d56e903bf5f291d09198804f5ab8d6b995d7036510b31bff150f7
-      content_csharp_sha: e5bc937aef385ab8775bf50ccdc95f95c57836b1cb996abe34e4ad3688c50320
+      python_sha: 25a8e8d7427c1a8415b03f70cc26dee4a2d4956a
+      csharp_sha: e61bed63a509773591f6115a4a127526a4c4afef
+      content_python_sha: 23231ed062cb3a39f85805af0f75dffbe0360e014d3a08b065dc25d9c9200c5a
+      content_csharp_sha: 1d14a985ff5f4adedd0f8c1c662ebfb71ebfb733d02d499fb4741e2112065e30
   known_differences:
     - "Socle commun : frameworks d'argumentation etendus (bipolaire, valeur-based) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (helpers `#!import` chargeant les DLL TweetyProject traduites). Python via JPype (`from java.util import HashSet, Set as JavaSet`). Meme moteur Java."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml
@@ -3,6 +3,8 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-MACHINE
+  bridge_verdict_reason: "Lib-vs-lib MEME moteur Java TweetyProject MAIS shade fat jar C# pas livre dans le repo (libs/ gitignored, dotnet-build/build-Tweety7aShade.csproj exige JAVA_HOME + `dotnet build` pour produire libs/org.tweetyproject.tweety-7a.dll = 608 types, 740 KB, cf PR #10499 pour 5 modules individuels et PR #10410 pour le verdict RECOVERABLE-MACHINE precedent). C# branche IKVM 8.15.0 + shade DLL attendue + 113 refs `org.tweetyproject.*` actifs (14 cellules avec `using org.tweetyproject.arg.{dung,adf,weighted,social}` explicite) + patterns cell 23/24/25 (Dung/Weighted/Social) executes par c.208/c.209 (attestation `modules_attested_sota_ok`). Python branche JPype + `from org.tweetyproject.arg.dung.reasoner import SimpleGroundedReasoner` (cf cell 17) + meme bibliotheque Java. Verdict RECOVERABLE-MACHINE (et non RECOVERABLE-LOCAL) : le shade fat jar est deja livre en PR #10499 via shade Maven IKVM, mais la DLL finale n'est pas sur disque dans la machine worker (cf constat c.229, 2026-08-12, po-2023:CoursIA-2) -- action = `cd MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build && dotnet build build-Tweety7aShade.csproj -c Release` sur la machine qui livrera les demos (po-2023 ou po-2024 avec JAVA_HOME=/path/to/jdk). Verdict distinct de INTRINSIC : la lib est invocable, juste pas buildable localement. Sub-grain ADF SAT reste INTRINSIC (UnsatisfiedLinkError sur NativeLingelingSolver, pre-requis IncrementalSatSolver natif)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -41,6 +43,12 @@
       csharp_sha: e61bed63a509773591f6115a4a127526a4c4afef
       content_python_sha: 23231ed062cb3a39f85805af0f75dffbe0360e014d3a08b065dc25d9c9200c5a
       content_csharp_sha: 1d14a985ff5f4adedd0f8c1c662ebfb71ebfb733d02d499fb4741e2112065e30
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 279b33ab77b1f32fd2b2380a1131372a587f9b70ceadd62a05345d6d50fe3d62
+      csharp_sha: 30e9186f41db56921ab96023fd54a4976a93237453d27def64ce0dc1a52656aa
+      content_python_sha: 959d694c815d56e903bf5f291d09198804f5ab8d6b995d7036510b31bff150f7
+      content_csharp_sha: e5bc937aef385ab8775bf50ccdc95f95c57836b1cb996abe34e4ad3688c50320
   known_differences:
     - "Socle commun : frameworks d'argumentation etendus (bipolaire, valeur-based) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (helpers `#!import` chargeant les DLL TweetyProject traduites). Python via JPype (`from java.util import HashSet, Set as JavaSet`). Meme moteur Java."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
@@ -12,10 +12,10 @@
       csharp_sha: 3e015103eb4cddb301a19f10dd1b8940eefe0fbb
     - date: "2026-08-12"
       by: myia-po-2023:CoursIA-2
-      python_sha: f51b57eb8b950fa956be39d470289c933b0f2bbf77bb067cb6a525dfbfe60651
-      csharp_sha: 79e8c2084432473bfce9c64a70f78741fdafafea1af94af0fe35c0bde45bf68b
-      content_python_sha: 6595750b1c571120eaaa98fc56eafd9a87082dd7fad17a3fb466f1e9ffc89f89
-      content_csharp_sha: f49a46cb2b20a64183a3e99987c3a2db586e6e65fce0073d1c80970cd436908b
+      python_sha: c2f0fd49cc676439ac5d626abd51f39dca5680a0
+      csharp_sha: 3e015103eb4cddb301a19f10dd1b8940eefe0fbb
+      content_python_sha: 29245004b87519c32cb37bed43227fd2b8af2ade9de7a368a9ddad76dd67e2e9
+      content_csharp_sha: 5a7dfff560e3dc513ce623f8ccc6c4f91962cc442f38c0abcec33afe3a73257b
   known_differences:
     - "Socle commun : argumentation preferentielle (PreferenceReasoner) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"nuget: IKVM.Image, 8.15.0\"` + Assembly.LoadFrom tweety-preferences.dll). Python via JPype (`from org.tweetyproject.arg.dung.reasoner import SimplePreferredReasoner`). Meme moteur Java."

--- a/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
@@ -3,12 +3,21 @@
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences-Csharp.ipynb
   parity_level: semantic
+  bridge_verdict: RECOVERABLE-LOCAL
+  bridge_verdict_reason: "C# branche IKVM mais `org.tweetyproject.tweety-preferences.dll` PAS BUILT sur disque (constat c.229, 2026-08-12, po-2023:CoursIA-2). Le csproj `dotnet-build/build-TweetyPreferencesShade.csproj` existe (IkvmReference sur `tweety-preferences-full-1.30.jar`, IKVM 8.15.0, cible net8.0) mais le jar source n'est pas livre dans le repo (gitignored, doit etre telecharge depuis Maven Central `org.tweetyproject:tweety-preferences-full:1.30` ou compile depuis les sources Maven `git+https://github.com/TweetyProject/TweetyProject`). C# charge `dotnet-build/bin/Release/net8.0/org.tweetyproject.tweety-preferences.dll` via Assembly.LoadFrom (cell 3), reference 76 refs `org.tweetyproject.*` actifs (4 cellules : 3, 6, 12, 20). Python branche JPype + `from org.tweetyproject.arg.dung.reasoner import SimplePreferredReasoner` (5 cellules avec imports JPype) + meme moteur Java. Verdict RECOVERABLE-LOCAL (et non RECOVERABLE-MACHINE) : la lib est installable sur la machine worker (regle F), juste pas buildable sans telechargement du jar source. Action = `curl -O https://repo1.maven.org/maven2/org/tweetyproject/tweety-preferences-full/1.30/tweety-preferences-full-1.30.jar && cd dotnet-build && dotnet build build-TweetyPreferencesShade.csproj -c Release` suivi d'un re-exec du notebook C# pour verifier la parite lib-vs-lib."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: c2f0fd49cc676439ac5d626abd51f39dca5680a0
       csharp_sha: 3e015103eb4cddb301a19f10dd1b8940eefe0fbb
+    - date: "2026-08-12"
+      by: myia-po-2023:CoursIA-2
+      python_sha: f51b57eb8b950fa956be39d470289c933b0f2bbf77bb067cb6a525dfbfe60651
+      csharp_sha: 79e8c2084432473bfce9c64a70f78741fdafafea1af94af0fe35c0bde45bf68b
+      content_python_sha: 6595750b1c571120eaaa98fc56eafd9a87082dd7fad17a3fb466f1e9ffc89f89
+      content_csharp_sha: f49a46cb2b20a64183a3e99987c3a2db586e6e65fce0073d1c80970cd436908b
   known_differences:
     - "Socle commun : argumentation preferentielle (PreferenceReasoner) via TweetyProject."
-    - "Lib-vs-lib : C# via IKVM (`#r \"nuget: IKVM.Image, 8.15.0\"`). Python via JPype (`from org.tweetyproject.arg.dung.reasoner import SimplePreferredReasoner`). Meme moteur Java."
+    - "Lib-vs-lib : C# via IKVM (`#r \"nuget: IKVM.Image, 8.15.0\"` + Assembly.LoadFrom tweety-preferences.dll). Python via JPype (`from org.tweetyproject.arg.dung.reasoner import SimplePreferredReasoner`). Meme moteur Java."
     - "Re-baseline 2026-07-25 (po-2024, consolidation #8264) : SHA Python avance depuis l'audit 2026-07-23 via #8170 (markdown hyphenation (Note-de-parite)) ; drift verifie paraphite-preservant (ne touche pas l'axe de parite semantic)."
+    - "DLL C# tweety-preferences non built sur disque (c.229, 2026-08-12) : le csproj IKVM shade existe (build-TweetyPreferencesShade.csproj) + le pattern de build est documente (twins `tweety-{dung,pl,rpcl,etc}.dll` deja livres par c.220 #10544 et c.208 #10499), mais le jar source `tweety-preferences-full-1.30.jar` n'est pas telecharge. Action RECOVERABLE-LOCAL sur la machine worker : telecharger le jar depuis Maven Central ou compiler depuis les sources, puis `dotnet build` le csproj, puis re-exec le notebook C# pour verifier la parite lib-vs-lib (les 2 cotes appellent les memes classes Java `org.tweetyproject.preferences.*` instantiatees via IKVM ou JPype)."


### PR DESCRIPTION
Grain: MED/ledger — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-dotnet #10612

## Update c.230 (15:25Z, fix post-CI)

Deuxième commit `fix(twin-parity,#10614): rebaseline content_*_sha after c.229 audit used wrong hash` (3219eb84) : corrige les audit entries du premier commit dont les `python_sha`/`csharp_sha` étaient par erreur 64-char SHA-256 au lieu de 40-char git blob SHA. La CI `Scripts Tests (CPU)` (`test_audit_shas_are_git_blob_shas`) et `Twin parity audit (#8057)` ont tous deux FAIL sur c.229 commit (drift_introduced=4). Fix = `check_twin_parity.py --update --pair <X> --by myia-po-2023:CoursIA-2` × 4 + suppression des audit entries boguées. Vérifié localement : `pytest test_twin_registry_integrity.py` 29/29 verts, `--per-pair --base origin/main` drift_introduced=0 ok=157/157, `--check` 157/157 OK. Force-pushed (single-lane branch, autorisé per git-workflow). Awaiting CI rerun (queue #10600 bottleneck).

## Résumé

feat(twin-parity,#10439) — tranche 12 Tweety/IKVM-JPype : 4 paires bridgées avec verdicts distribués après audit **firsthand** des sources (my c.227 PR body avait prédit INTRINSIC pour les 4, mais l'audit direct du contenu a corrigé).

| # | Paire | Verdict | Justification firsthand |
|---|---|---|---|
| 1 | Tweety-5 Abstract-Argumentation | **SOTA-OK** | DLLs `tweety-dung.dll` + `tweety-rpcl.dll` IKVM-bridged tracked sur disque + Python JPype `from org.tweetyproject.arg.dung.syntax import DungTheory, Argument` + reflection IKVM sur 11 notions d'équivalence + `SccCF2Reasoner` |
| 2 | Tweety-7a Extended-Frameworks | **RECOVERABLE-MACHINE** | shade fat jar `tweety-7a.dll` non built sur disque (libs/ gitignored) — csproj IKVM existe + 113 refs `org.tweetyproject.*` actifs + 14 `using` explicites, action = `dotnet build build-Tweety7aShade.csproj` |
| 3 | Tweety-9 Preferences | **RECOVERABLE-LOCAL** | DLL `tweety-preferences.dll` non built — csproj existe mais jar source absent du repo, action = `curl -O tweety-preferences-full-1.30.jar` + `dotnet build` |
| 4 | Tweety-10 MLN | **RECOVERABLE-LOCAL** | DLL `tweety-mln.dll` tracked + 29 `using org.tweetyproject.logics.{mln,fol,commons}.*` actifs MAIS reasoner `ApproximateNaiveMlnReasoner` bloqué par bug IKVM 8.15 sur MCMC multi-atomes (cas trivial 1-atome factorisé analytiquement via Math.Exp, valide math) |

## Pourquoi pas INTRINSIC (correction de mon c.227)

Mon PR #10608 body c.227 listait les 4 paires comme **tranche 12 INTRINSIC deferred** avec comme raison "engine mismatch C# from-scratch vs Python JPype". **L'audit firsthand c.229 corrige** : aucun des 4 jumeaux C# n'est from-scratch — ils utilisent tous IKVM + DLLs Java TweetyProject (avec quelques variations : pattern `using org.tweetyproject` direct, pattern `Assembly.LoadFrom + reflection`, pattern mixte).

- **tweety-5** : 0 `using org.tweetyproject.*` explicite, MAIS 30 refs actifs via `Assembly.LoadFrom("org.tweetyproject.tweety-dung.dll").GetType("org.tweetyproject.arg.dung.reasoner.SccCF2Reasoner")` — pattern IKVM 8.x (les packages Java sont traduits en types .NET, accessibles par reflection sans `using` direct).
- **tweety-7a** : 113 refs + 14 `using org.tweetyproject.arg.{dung,adf,weighted,social}.*` explicites + shade fat jar attendu (mais pas livré en repo, d'où RECOVERABLE-MACHINE).
- **tweety-9** : 76 refs via Assembly.LoadFrom sur `tweety-preferences.dll` attendue (mais pas built, d'où RECOVERABLE-LOCAL).
- **tweety-10** : 43 refs + 29 `using org.tweetyproject.logics.{mln,fol,commons}.*` explicites + DLL tracked, MAIS MCMC reasoner bloqué par bug IKVM 8.15.

## Méthode de vérification (G.9 firsthand)

Pour chaque paire :

1. **Analyse des imports C#** : `using org.tweetyproject.*` count par cellule + `Assembly.LoadFrom` + DLLs référencées.
2. **Vérification DLLs sur disque** : `ls MyIA.AI.Notebooks/SymbolicAI/Tweety/*.dll` confirme quelles DLLs sont tracked et présentes.
3. **Analyse des imports Python** : grep `from org.tweetyproject.* import` dans le twin Python pour confirmer le pattern JPype attendu.
4. **csproj availability** : pour les paires RECOVERABLE-*, vérifier que `dotnet-build/build-Tweety*Shade.csproj` existe avec `IkvmReference` sur le bon jar.
5. **Pinning SHA** : `git ls-tree HEAD` pour les blob SHAs, `json.dumps(cells, separators=(',', ':')).encode('utf-8')` SHA256 pour les content_sha (anti-regression pattern #9399).
6. **L898 PRE-WRITE 3 cmds** : `git worktree list` + `gh pr list --search "tweety-5 OR tweety-7a OR tweety-9 OR tweety-10"` (16 PRs trouvées, aucune en collision avec mon plan) + `gh pr list --state open --json files` sur les paths YAMLs visés.

## Diff stat

```
scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml    | +8
scripts/notebook_tools/twin_pairs.d/tweety-7a-extended-frameworks.yaml     | +8
scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml              | +10
scripts/notebook_tools/twin_pairs.d/tweety-10-mln.yaml                     | +8
4 files changed, 34 insertions(+)
```

Bien sous §A (< 3000 lignes / < 15 fichiers / 1 feature = bridge_verdict tranche).

## Coverage progress

| Verdict | Avant c.229 | Après c.229 | Delta |
|---|---|---|---|
| SOTA-OK | 78 | **79** | +1 (tweety-5) |
| RECOVERABLE-LOCAL | 31 | **33** | +2 (tweety-9/10) |
| RECOVERABLE-MACHINE | 0 | **1** | +1 (tweety-7a) |
| INTRINSIC | 1 | 1 | 0 |
| Actionnables | 78 | **77** | -4 |

## Scope catalog-pr-hygiene R1

`COURSE_CATALOG.generated.{json,md}` byte-identique à `main`. Marqueurs `<!-- CATALOG-STATUS -->` inchangés. 0 fichier hors `twin_pairs.d/tweety-{5,7a,9,10}.yaml` modifié.

## G-VAR-1 floor

`MED/ledger` = genuine ledger entry (ajoute des `bridge_verdict` au registre, avec audit entry + content_sha + reason). Plancher CONTENT tenu (registre twin_pairs.d est contenu, pas META).

## Suite

- **tweety-7a** : demande ai-01 pour activer le build du shade fat jar sur la machine qui livrera les demos (probable po-2023 ou po-2024).
- **tweety-9** : `tweety-preferences-full-1.30.jar` à télécharger depuis Maven Central, puis build csproj.
- **tweety-10** : upgrade IKVM vers 8.16+ ou portage vers `SatNaiveMlnReasoner` (contourne possiblement le bug MCMC).
- **tweety-1** : le notebook Setup (référence) pourrait être audité à son tour pour vérifier qu'il documente bien le pattern de chargement JVM/IKVM.

## Références

- Issue #10439 — twin-parity bridge_verdict mechanism
- c.227 PR #10608 — tranche 11 (SOTA-OK x5)
- c.228 PR #10612 — GT-5 Tranche 3 Gambit (DEEP/notebook-dotnet)
- c.208 PR #10450 — Tweety-7a tranche 2 IKVM bridge
- c.209 PR #10450 — Tweety-7a 3 sub-fixes ai-01 CHANGES_REQUESTED
- c.210 PR #10471 — Tweety IKVM causal shade DLL pattern
- c.220 PR #10544 — IKVM causal rebuild source-recompile pattern (référence)
- PR #10499 — 5 IKVM shade DLLs bipolar/social/weighted/setaf/extended
- PR #10410 — Tweety-7a verdict RECOVERABLE-MACHINE précedent
- Schema `_schema.yaml` ligne 42-62 — 5 verdicts enumeration
- L898 ★★★ collision guard BEFORE-WRITE 3 cmds

🤖 Generated with [Claude Code](https://claude.com/claude-code)