### PR TITLE
Notebook: auditer un formulaire conditionnel (AI Forms — énumération des chemins)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -107,6 +107,18 @@ mesurée par un taux de fuite — et (2) **l'accident de réindexation** —
 voisin. Déterministe, numpy, sans clé ni réseau ; fixture synthétique à 100 %
 (Maison Valmont).
 
+Un notebook compagnon [`auditer-un-formulaire-conditionnel.ipynb`](auditer-un-formulaire-conditionnel.ipynb)
+traite la feature **AI Forms** — l'une des deux fonctionnalités GenAI cœur
+qui n'avait ni section de parcours ni notebook. Thèse : *un formulaire à
+logique de branchement est une machine à états implicite*. Le notebook
+construit un formulaire de soumission synthétique (Maison Valmont) à champs
+conditionnels et **énumère les chemins terminaux atteignables** : sept
+champs engendrent treize états distincts, dont près des deux tiers
+déclenchent un appel LLM, et un champ déclaré n'est visible sur aucun
+chemin (champ mort). La leçon : le schéma n'est pas le formulaire — les
+trois grandeurs (chemins, coût LLM, champs morts) sont émergentes. stdlib
+pure, aucune clé, aucun réseau.
+
 ---
 
 ## Sections
@@ -224,6 +236,8 @@ attendues.
   les deux sens du fil MCP, chevauchement cross-catalogue et risque de double-écrit
 - [`separer-les-environnements-de-vecteurs.ipynb`](separer-les-environnements-de-vecteurs.ipynb) —
   fuite cross-environnement et accident de réindexation, mesurés sur un vector store partitionné
+- [`auditer-un-formulaire-conditionnel.ipynb`](auditer-un-formulaire-conditionnel.ipynb) —
+  AI Forms conditionnelles comme machine à états, énumération des chemins et champs morts
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/auditer-un-formulaire-conditionnel.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/auditer-un-formulaire-conditionnel.ipynb
@@ -1,0 +1,693 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0700dde0",
+   "metadata": {},
+   "source": [
+    "# Auditer un formulaire conditionnel — l'état que vous ne voyez pas\n",
+    "\n",
+    "*Recycler la documentation du projet LivresAgités (en sommeil) vers le dépôt\n",
+    "pédagogique. Ce notebook illustre la feature **AI Forms** d'AI-Engine — l'une\n",
+    "des deux fonctionnalités GenAI cœur du dossier qui n'avait, jusqu'ici, ni\n",
+    "section de parcours ni notebook compagnon (l'autre étant le Copilot\n",
+    "Gutenberg, Parcours 1).*\n",
+    "\n",
+    "> **Thèse.** Un formulaire à logique conditionnelle — dont les champs\n",
+    "> apparaissent ou disparaissent selon les réponses antérieures — est une\n",
+    "> **machine à états implicite**. Le schéma se lit comme une simple liste de\n",
+    "> champs, mais le comportement réel est *émergent* : quels chemins existent,\n",
+    "> lesquels terminent, lesquels déclenchent un appel au LLM, ne se déduisent\n",
+    "> pas de la lecture du schéma. Ils s'énumèrent. Et leur nombre peut être\n",
+    "> **exponentiel** dans le nombre de conditions.\n",
+    "\n",
+    "Ce notebook ne dépend d'aucun service : pas de réseau, pas de modèle, pas de\n",
+    "clé. Le formulaire et son moteur d'énumération sont construits en mémoire,\n",
+    "sur le fixture synthétique « Maison Valmont ». Ce qui est enseigné est la\n",
+    "*structure* du comportement d'un formulaire conditionnel, pas une mesure sur\n",
+    "une instance réelle.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ffc6bb5",
+   "metadata": {},
+   "source": [
+    "## 1. AI Forms en une phrase\n",
+    "\n",
+    "**AI Forms** est le module d'AI-Engine qui pousse les formulaires WordPress\n",
+    "au-delà de la simple collecte : chaque soumission peut être **traitée par un\n",
+    "LLM** (synthèse, extraction, classification, traduction) avant stockage ou\n",
+    "notification. La pièce maîtresse, pédagogiquement, n'est pas le LLM — c'est\n",
+    "la **logique conditionnelle** : la visibilité d'un champ dépend des réponses\n",
+    "données aux champs précédents. Un même formulaire présente donc des « pages »\n",
+    "différentes selon qui le remplit et comment.\n",
+    "\n",
+    "C'est cette logique conditionnelle qui transforme un formulaire en machine à\n",
+    "états. Et comme toute machine à états, son comportement effectif (les\n",
+    "chemins atteignables) ne se lit pas sur la définition statique : il se\n",
+    "calcule.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3968653e",
+   "metadata": {},
+   "source": [
+    "## 2. Le fixture — un formulaire de soumission de manuscrit\n",
+    "\n",
+    "On monte la « Maison Valmont » : un formulaire de dépôt de manuscrit à\n",
+    "**sept champs**, dont la visibilité est conditionnelle. Les conditions sont\n",
+    "représentées en **données** (des tuples), pas en code (pas de `lambda`) —\n",
+    "c'est plus long à écrire, mais cela rend le formulaire **inspectable** : on\n",
+    "peut lire une condition comme on lit une donnée, sans exécuter de fonction.\n",
+    "\n",
+    "Chaque champ porte :\n",
+    "- une **condition** (tuple) — predicat sur les réponses antérieures ;\n",
+    "- des **valeurs** possibles (l'énumération se branche sur chacune) ;\n",
+    "- une **action** — `None` (rien) ou un identifiant d'action LLM.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "17ebf7c0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.003158Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.002633Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.012224Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.011711Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formulaire de 7 champs.\n",
+      "  courriel | cond=('true',) | 1 valeurs | action=-\n",
+      "  genre | cond=('true',) | 3 valeurs | action=-\n",
+      "  nb_pages | cond=('in', 'genre', ('prose', 'essai')) | 3 valeurs | action=-\n",
+      "  resume_long | cond=('gt', 'nb_pages', 200) | 2 valeurs | action=llm_synthese\n",
+      "  deja_edite | cond=('eq', 'genre', 'prose') | 2 valeurs | action=-\n",
+      "  nom_editeur | cond=('eq', 'deja_edite', True) | 1 valeurs | action=llm_verification\n",
+      "  note_lecture | cond=('lt', 'nb_pages', 0) | 3 valeurs | action=-\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Aucune dependance externe. Tout est en memoire.\n",
+    "\n",
+    "# --- Formulaire de soumission Valmont (7 champs conditionnels) ---\n",
+    "# Condition = un tuple (operateur, champ_anterieur, valeur)\n",
+    "#   (\"true\",)                  -> toujours vrai\n",
+    "#   (\"eq\",  champ, val)        -> reponses[champ] == val\n",
+    "#   (\"in\",  champ, (v1, v2))   -> reponses[champ] dans le tuple\n",
+    "#   (\"gt\",  champ, val)        -> reponses.get(champ, 0) > val\n",
+    "#   (\"lt\",  champ, val)        -> reponses.get(champ, 0) < val\n",
+    "formulaire = {\n",
+    "    \"courriel\":     {\"condition\": (\"true\",),                  \"valeurs\": [\"auteur@valmont.org\"], \"action\": None},\n",
+    "    \"genre\":        {\"condition\": (\"true\",),                  \"valeurs\": [\"poesie\", \"prose\", \"essai\"], \"action\": None},\n",
+    "    \"nb_pages\":     {\"condition\": (\"in\", \"genre\", (\"prose\", \"essai\")), \"valeurs\": [40, 120, 250], \"action\": None},\n",
+    "    \"resume_long\":  {\"condition\": (\"gt\", \"nb_pages\", 200),     \"valeurs\": [\"resume_a\", \"resume_b\"], \"action\": \"llm_synthese\"},\n",
+    "    \"deja_edite\":   {\"condition\": (\"eq\", \"genre\", \"prose\"),    \"valeurs\": [True, False], \"action\": None},\n",
+    "    \"nom_editeur\":  {\"condition\": (\"eq\", \"deja_edite\", True),  \"valeurs\": [\"editeur_x\"], \"action\": \"llm_verification\"},\n",
+    "    \"note_lecture\": {\"condition\": (\"lt\", \"nb_pages\", 0),       \"valeurs\": [1, 2, 3], \"action\": None},\n",
+    "}\n",
+    "\n",
+    "print(\"Formulaire de \" + str(len(formulaire)) + \" champs.\")\n",
+    "for nom, c in formulaire.items():\n",
+    "    act = c[\"action\"] if c[\"action\"] else \"-\"\n",
+    "    print(\"  \" + nom + \" | cond=\" + str(c[\"condition\"]) + \" | \" + str(len(c[\"valeurs\"])) + \" valeurs | action=\" + str(act))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7a13061",
+   "metadata": {},
+   "source": [
+    "### Lire le schéma\n",
+    "\n",
+    "Sept champs, à l'œil un formulaire modeste. Déjà, à la lecture, on devine\n",
+    "que `resume_long` n'apparaît que pour les manuscrits de plus de 200 pages,\n",
+    "et que `nom_editeur` ne sort que pour la prose déjà éditée. Mais **combien\n",
+    "de chemins distincts** ce formulaire génère-t-il ? La lecture ne le dit pas.\n",
+    "C'est la question que ce notebook pose — et résout par énumération.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c62f2ebd",
+   "metadata": {},
+   "source": [
+    "## 3. Le moteur — évaluer une condition, énumérer les chemins\n",
+    "\n",
+    "Deux fonctions suffisent. La première **évalue** une condition (le tuple)\n",
+    "contre un ensemble de réponses. La seconde **énumère** tous les chemins\n",
+    "terminaux : pour chaque champ, si sa condition est satisfaite on se\n",
+    "ramifie sur chaque valeur possible, sinon on passe (champ masqué).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1de69776",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.014412Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.014412Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.019144Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.018616Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nb_pages=40  > 200 ? False\n",
+      "nb_pages=250 > 200 ? True\n",
+      "genre=prose in (prose,essai) ? True\n",
+      "genre=poesie in (prose,essai) ? False\n"
+     ]
+    }
+   ],
+   "source": [
+    "def condition_satisfaite(cond, reponses):\n",
+    "    \"\"\"Evalue un tuple-condition contre les reponses anterieures.\"\"\"\n",
+    "    op = cond[0]\n",
+    "    if op == \"true\":\n",
+    "        return True\n",
+    "    champ, val = cond[1], cond[2]\n",
+    "    if op == \"eq\":\n",
+    "        return reponses.get(champ) == val\n",
+    "    if op == \"ne\":\n",
+    "        return reponses.get(champ) != val\n",
+    "    if op == \"gt\":\n",
+    "        return reponses.get(champ, 0) > val\n",
+    "    if op == \"lt\":\n",
+    "        return reponses.get(champ, 0) < val\n",
+    "    if op == \"in\":\n",
+    "        return reponses.get(champ) in val\n",
+    "    return False\n",
+    "\n",
+    "\n",
+    "# Sanity check : la condition \"nb_pages > 200\" sur un manuscrit de 40 pages.\n",
+    "print(\"nb_pages=40  > 200 ? \" + str(condition_satisfaite((\"gt\", \"nb_pages\", 200), {\"nb_pages\": 40})))\n",
+    "print(\"nb_pages=250 > 200 ? \" + str(condition_satisfaite((\"gt\", \"nb_pages\", 200), {\"nb_pages\": 250})))\n",
+    "print(\"genre=prose in (prose,essai) ? \" + str(condition_satisfaite((\"in\", \"genre\", (\"prose\", \"essai\")), {\"genre\": \"prose\"})))\n",
+    "print(\"genre=poesie in (prose,essai) ? \" + str(condition_satisfaite((\"in\", \"genre\", (\"prose\", \"essai\")), {\"genre\": \"poesie\"})))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7e0370e6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.021261Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.020720Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.025403Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.024899Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chemins terminaux atteignables : 13\n"
+     ]
+    }
+   ],
+   "source": [
+    "def enumerer_chemins(formulaire):\n",
+    "    \"\"\"Enumere tous les chemins terminaux atteignables du formulaire.\n",
+    "\n",
+    "    Un chemin = un dict d'affectations des champs VISIBLES sur ce chemin.\n",
+    "    Pour chaque champ : si sa condition est satisfaite, on se ramifie sur\n",
+    "    chacune de ses valeurs ; sinon le champ est masque et on continue.\n",
+    "    \"\"\"\n",
+    "    chemins = [{}]\n",
+    "    for nom, champ in formulaire.items():\n",
+    "        suivants = []\n",
+    "        for reponses in chemins:\n",
+    "            if condition_satisfaite(champ[\"condition\"], reponses):\n",
+    "                for valeur in champ[\"valeurs\"]:\n",
+    "                    r2 = dict(reponses)\n",
+    "                    r2[nom] = valeur\n",
+    "                    suivants.append(r2)\n",
+    "            else:\n",
+    "                suivants.append(reponses)\n",
+    "        chemins = suivants\n",
+    "    return chemins\n",
+    "\n",
+    "\n",
+    "chemins = enumerer_chemins(formulaire)\n",
+    "print(\"Chemins terminaux atteignables : \" + str(len(chemins)))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26ad1d3a",
+   "metadata": {},
+   "source": [
+    "## 4. L'explosion — combien de chemins pour sept champs ?\n",
+    "\n",
+    "Sept champs, et pourtant le formulaire n'engendre pas sept états. Il en\n",
+    "engendre bien plus, parce que chaque condition crée un point de branchement.\n",
+    "Mesurons.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fce618f2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.027496Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.027496Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.033480Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.032957Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nombre de chemins terminaux : 13\n",
+      "\n",
+      "Distribution des longueurs (champs visibles par chemin) :\n",
+      "  2 champs : 1 chemin(s)\n",
+      "  3 champs : 2 chemin(s)\n",
+      "  4 champs : 4 chemin(s)\n",
+      "  5 champs : 4 chemin(s)\n",
+      "  6 champs : 2 chemin(s)\n",
+      "\n",
+      "Produit cartesien brut (si AUCUNE condition) : 108\n",
+      "Avec conditions : 13 -> 12% du brut.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "print(\"Nombre de chemins terminaux : \" + str(len(chemins)))\n",
+    "print()\n",
+    "\n",
+    "# Distribution des longueurs (nombre de champs visibles par chemin).\n",
+    "longueurs = Counter(len(c) for c in chemins)\n",
+    "print(\"Distribution des longueurs (champs visibles par chemin) :\")\n",
+    "for k in sorted(longueurs):\n",
+    "    print(\"  \" + str(k) + \" champs : \" + str(longueurs[k]) + \" chemin(s)\")\n",
+    "print()\n",
+    "\n",
+    "# A titre de comparaison : le produit cartesien brut de toutes les valeurs.\n",
+    "import math\n",
+    "produit_brut = 1\n",
+    "for champ in formulaire.values():\n",
+    "    produit_brut *= len(champ[\"valeurs\"])\n",
+    "print(\"Produit cartesien brut (si AUCUNE condition) : \" + str(produit_brut))\n",
+    "print(\"Avec conditions : \" + str(len(chemins)) + \" -> \" + str(round(100 * len(chemins) / produit_brut)) + \"% du brut.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "473309f1",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Sept champs engendrent **13 chemins terminaux atteignables** (contre un\n",
+    "produit cartésien brut de 108 si aucune condition ne masquait jamais rien).\n",
+    "Le conditionnel réduit l'espace — c'est sa raison d'être — mais il le rend\n",
+    "surtout **non lisible** : aucune des 13 combinaisons n'est visible sur le\n",
+    "schéma. On lit « sept champs » ; l'utilisateur rencontre l'un des **treize\n",
+    "formulaires différents** que ce dispositif produit réellement.\n",
+    "\n",
+    "C'est le premier enseignement : la taille apparente du formulaire (le\n",
+    "nombre de champs déclarés) ne dit rien de sa taille effective (le nombre\n",
+    "d'états distincts). Pour un petit formulaire c'est une curiosité ; pour un\n",
+    "formulaire administratif de cinquante champs conditionnels, c'est une\n",
+    "explosion combinatoire que personne n'audite.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1f1bb5c",
+   "metadata": {},
+   "source": [
+    "## 5. Les chemins qui invoquent le LLM — le coût caché\n",
+    "\n",
+    "AI Forms peut déclencher une action LLM à la soumission. Ici, deux champs\n",
+    "portent une action : `resume_long` (synthèse) et `nom_editeur` (vérification\n",
+    "de l'éditeur). Mais **un champ ne s'exécute que s'il est visible** — donc\n",
+    "l'action LLM ne se déclenche que sur les chemins où le champ apparaît. Le\n",
+    "coût en appels LLM est, lui aussi, émergent.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "dfbe0680",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.035004Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.035004Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.041287Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.041287Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Répartition des chemins par nombre d'appels LLM :\n",
+      "  0 appel(s) LLM : 5 chemin(s)\n",
+      "  1 appel(s) LLM : 6 chemin(s)\n",
+      "  2 appel(s) LLM : 2 chemin(s)\n",
+      "\n",
+      "Chemins invoquant AU MOINS un appel LLM : 8 / 13\n",
+      "  -> 62 % des chemins coûtent un appel LLM.\n",
+      "\n",
+      "Chemins à double appel LLM (2) :\n",
+      "  {'courriel': 'auteur@valmont.org', 'genre': 'prose', 'nb_pages': 250, 'resume_long': 'resume_a', 'deja_edite': True, 'nom_editeur': 'editeur_x'}\n",
+      "  {'courriel': 'auteur@valmont.org', 'genre': 'prose', 'nb_pages': 250, 'resume_long': 'resume_b', 'deja_edite': True, 'nom_editeur': 'editeur_x'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cout_llm(chemin, formulaire):\n",
+    "    \"\"\"Nombre d'appels LLM declenches par un chemin = nombre de champs\n",
+    "    visibles portant une action non-None.\"\"\"\n",
+    "    return sum(1 for nom in chemin if formulaire[nom][\"action\"] is not None)\n",
+    "\n",
+    "\n",
+    "coûts = Counter(cout_llm(c, formulaire) for c in chemins)\n",
+    "print(\"Répartition des chemins par nombre d'appels LLM :\")\n",
+    "for k in sorted(coûts):\n",
+    "    print(\"  \" + str(k) + \" appel(s) LLM : \" + str(coûts[k]) + \" chemin(s)\")\n",
+    "print()\n",
+    "\n",
+    "nb_avec_llm = sum(1 for c in chemins if cout_llm(c, formulaire) > 0)\n",
+    "print(\"Chemins invoquant AU MOINS un appel LLM : \" + str(nb_avec_llm) + \" / \" + str(len(chemins)))\n",
+    "print(\"  -> \" + str(round(100 * nb_avec_llm / len(chemins))) + \" % des chemins coûtent un appel LLM.\")\n",
+    "print()\n",
+    "\n",
+    "# Detail des chemins a 2 appels (les plus couteux).\n",
+    "double = [c for c in chemins if cout_llm(c, formulaire) == 2]\n",
+    "print(\"Chemins à double appel LLM (\" + str(len(double)) + \") :\")\n",
+    "for c in double:\n",
+    "    print(\"  \" + str(c))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd0855e8",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Sur 13 chemins, **8 déclenchent au moins un appel LLM — près des deux\n",
+    "tiers**. Et **2 chemins en déclenchent deux** (synthèse *et* vérification :\n",
+    "la prose de plus de 200 pages, déjà éditée). Lu sur le schéma, on voit\n",
+    "« deux champs LLM ». Mesuré sur les chemins, on découvre que **le formulaire\n",
+    "le plus coûteux paie deux appels là où le moins coûteux n'en paie aucun** —\n",
+    "pour un écart que rien, dans la définition statique, ne signalait.\n",
+    "\n",
+    "C'est le second enseignement : le coût d'exploitation d'un formulaire AI\n",
+    "Forms est une propriété des chemins, pas des champs. Un audit qui se borne à\n",
+    "lister les champs à action LLM sous-estime le coût réel (il ignore les\n",
+    "chemins à appels multiples) et le surévalue (il compte un champ qui n'est\n",
+    "visible sur aucun chemin).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f2b4f0d",
+   "metadata": {},
+   "source": [
+    "## 6. Les champs morts — ce que personne ne verra jamais\n",
+    "\n",
+    "Dernière catégorie, la plus sournoise : un champ peut être **déclaré mais\n",
+    "jamais visible**, parce que sa condition n'est jamais satisfaite quel que\n",
+    "soit le chemin. Le champ `note_lecture` (condition `nb_pages < 0`) en est\n",
+    "l'exemple : aucun manuscrit n'a un nombre de pages négatif, donc le champ\n",
+    "n'apparaît jamais. Il vit dans le schéma, pas dans le formulaire effectif.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "d5f2ce39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.044304Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.044304Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.048867Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.048337Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "note_lecture present dans au moins un chemin : False\n",
+      "\n",
+      "Visibilite de chaque champ :\n",
+      "  courriel : 13 / 13 chemins\n",
+      "  genre : 13 / 13 chemins\n",
+      "  nb_pages : 12 / 13 chemins\n",
+      "  resume_long : 6 / 13 chemins\n",
+      "  deja_edite : 8 / 13 chemins\n",
+      "  nom_editeur : 4 / 13 chemins\n",
+      "  note_lecture : 0 / 13 chemins  <-- CHAMP MORT\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Verifions a la main : note_lecture apparait-il dans un seul chemin ?\n",
+    "present = any(\"note_lecture\" in c for c in chemins)\n",
+    "print(\"note_lecture present dans au moins un chemin : \" + str(present))\n",
+    "print()\n",
+    "\n",
+    "# Plus generalement : pour chaque champ, dans combien de chemins apparait-il ?\n",
+    "print(\"Visibilite de chaque champ :\")\n",
+    "for nom in formulaire:\n",
+    "    nb = sum(1 for c in chemins if nom in c)\n",
+    "    marqueur = \"  <-- CHAMP MORT\" if nb == 0 else \"\"\n",
+    "    print(\"  \" + nom + \" : \" + str(nb) + \" / \" + str(len(chemins)) + \" chemins\" + marqueur)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f20444f5",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "`note_lecture` apparaît dans **0 chemin sur 12** : c'est un champ mort. Il\n",
+    "ne consomme rien (pas d'action LLM), mais il **trompe l'audit** : un lecteur\n",
+    "du schéma le comptera comme une fonctionnalité live, alors qu'il est\n",
+    "inaccessible. Dans un formulaire administratif réel, les champs morts\n",
+    "s'accumulent avec les évolutions — une condition durcie ici, un champ\n",
+    "renommé là — et transforment le schéma en palimpseste où l'effective et\n",
+    "l'inerte cohabitent sans distinction.\n",
+    "\n",
+    "C'est le troisième enseignement : **le schéma n'est pas le formulaire**.\n",
+    "Trois grandeurs mesurées ce notebook (chemins, coût LLM, champs morts) sont\n",
+    "toutes des propriétés *émergentes* qu'aucune lecture statique ne donne.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bd95cf9",
+   "metadata": {},
+   "source": [
+    "## 7. Provenance et limites\n",
+    "\n",
+    "**Ce que ce notebook mesure.** La *structure du comportement* d'un\n",
+    "formulaire conditionnel : étant donné un schéma (champs + conditions +\n",
+    "actions), combien d'états terminaux il produit, combien coûtent ces états\n",
+    "en appels LLM, et quels champs déclarés ne servent jamais. Tout est\n",
+    "déterministe sur fixture synthétique.\n",
+    "\n",
+    "**Ce qu'il ne mesure pas.** L'ergonomie réelle du formulaire vu par\n",
+    "l'utilisateur (un chemin peut être rare mais jamais emprunté en pratique),\n",
+    "la latence des appels LLM, les validations croisées entre champs. La\n",
+    "représentation des conditions par tuples est volontairement simpliste — un\n",
+    "vrai moteur de conditions supporte des expressions booléennes imbriquées ;\n",
+    "le principe (énumérer pour auditer) est identique.\n",
+    "\n",
+    "**La limite du procédé.** L'énumération exhaustive a un coût : un\n",
+    "formulaire de $N$ champs conditionnels peut produire un nombre de chemins\n",
+    "exponentiel en $N$. Auditer en énumérant devient prohibitif sur les gros\n",
+    "formulaires — c'est précisément pourquoi cette auditabilité est rarement\n",
+    "faite, et pourquoi les champs morts et les chemins coûteux s'y cachent.\n",
+    "\n",
+    "**Pour aller plus loin.**\n",
+    "- [`auditer-un-serveur-mcp.ipynb`](auditer-un-serveur-mcp.ipynb) — même\n",
+    "  esprit d'audit (mesurer une propriété non-lisible sur la définition\n",
+    "  statique) appliqué à un catalogue d'outils MCP.\n",
+    "- [`consommer-vs-exposer-le-mcp.ipynb`](consommer-vs-exposer-le-mcp.ipynb) —\n",
+    "  l'autre face MCP : comparer deux catalogues.\n",
+    "- [`livresagites-parcours.md`](livresagites-parcours.md) Parcours 4 — la\n",
+    "  prose dont ce notebook est l'illustration exécutable.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "991c24c7",
+   "metadata": {},
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "Les trois exercices suivants manipulent le formulaire synthétique et son\n",
+    "moteur (`enumerer_chemins`, `condition_satisfaite`). Les stub sont à\n",
+    "compléter — `return None` ou `pass`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52ec7c2c",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — distribution des longueurs\n",
+    "\n",
+    "Écrire une fonction `compter_par_longueur(formulaire)` qui renvoie un dict\n",
+    "`{longueur: nombre_de_chemins}` — pour chaque longueur possible (nombre de\n",
+    "champs visibles), combien de chemins terminaux ont exactement cette\n",
+    "longueur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "5ff231a5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.050967Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.050442Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.054057Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.053536Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def compter_par_longueur(formulaire):\n",
+    "    \"\"\"Renvoie {longueur: nb_chemins} -- distribution du nombre de champs\n",
+    "    visibles par chemin terminal.\n",
+    "    \"\"\"\n",
+    "    # TODO : utiliser enumerer_chemins() et regrouper par len(chemin).\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb524890",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — regrouper les chemins par coût LLM\n",
+    "\n",
+    "Écrire une fonction `regrouper_par_cout(formulaire)` qui renvoie un dict\n",
+    "`{cout: [chemins]}` — les chemins terminaux groupés par nombre d'appels LLM\n",
+    "(0, 1, 2…). Permet d'isoler les chemins les plus coûteux.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c78e99b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.056665Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.056147Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.059862Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.059285Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def regrouper_par_cout(formulaire):\n",
+    "    \"\"\"Renvoie {cout_llm: [chemins]} -- chemins terminaux groupes par\n",
+    "    nombre d'appels LLM qu'ils declenchent.\n",
+    "    \"\"\"\n",
+    "    # TODO : utiliser enumerer_chemins() et cout_llm().\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a8d30b0",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — détecter les champs morts\n",
+    "\n",
+    "Écrire une fonction `champs_jamais_visibles(formulaire)` qui renvoie la\n",
+    "liste des champs déclarés mais absents de **tous** les chemins terminaux\n",
+    "(leurs conditions ne sont jamais satisfaites). `note_lecture` doit y\n",
+    "figurer.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cfab2e78",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-12T13:20:43.061904Z",
+     "iopub.status.busy": "2026-08-12T13:20:43.061400Z",
+     "iopub.status.idle": "2026-08-12T13:20:43.065511Z",
+     "shell.execute_reply": "2026-08-12T13:20:43.064983Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def champs_jamais_visibles(formulaire):\n",
+    "    \"\"\"Renvoie la liste des champs declares mais presents dans aucun\n",
+    "    chemin terminal atteignable.\n",
+    "    \"\"\"\n",
+    "    # TODO : enumerer les chemins, puis chercher les champs absents de tous.\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1d1bfe5",
+   "metadata": {},
+   "source": [
+    "## 9. Ce que ce notebook enseigne, en une ligne\n",
+    "\n",
+    "> **Un formulaire conditionnel n'est pas une liste de champs, c'est un graphe\n",
+    "> d'états.** Le lire comme une liste fait rater trois choses : combien\n",
+    "> d'états existent, combien ils coûtent, et lesquels sont morts. Trois\n",
+    "> réponses qui ne viennent que de l'énumération.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -295,6 +295,70 @@ Deux remarques valables pour tout déploiement :
 
 ---
 
+## Parcours 4 — AI Forms, ou le formulaire comme machine à états
+
+### Ce que c'est
+
+**AI Forms** est le module d'AI-Engine qui pousse les formulaires WordPress
+au-delà de la collecte passive. Deux propriétés le distinguent d'un
+formulaire WordPress classique :
+
+1. **Logique conditionnelle** — la visibilité d'un champ dépend des
+   réponses données aux champs antérieurs. Un même formulaire présente des
+   « pages » différentes selon qui le remplit et comment.
+2. **Traitement LLM à la soumission** — chaque soumission peut être
+   synthétisée, classée, traduite ou enrichie par un LLM avant stockage ou
+   notification.
+
+### Comment ça marche
+
+Le rédacteur du formulaire déclare une liste de champs, chacun avec une
+*règle de visibilité* (un prédicat sur les réponses antérieures) et,
+optionnellement, une *action* déclenchée à la soumission. À l'exécution,
+le moteur évalue chaque règle à mesure que l'utilisateur répond : un champ
+apparaît, disparaît, ou rend une section entière pertinente ou caduque.
+
+Le piège conceptuel est que **ce moteur est une machine à états implicite**.
+Chaque règle de visibilité est un point de branchement ; le formulaire
+effectif — l'ensemble des chemins qu'un utilisateur peut réellement
+emprunter — n'est pas la liste des champs déclarés, mais le graphe qu'ils
+engendrent. Et ce graphe, rien ne l'expose : il se calcule.
+
+### Comparaison OWUI
+
+Open WebUI **n'a pas d'équivalent** : c'est un client de conversation, pas
+un moteur de formulaires. Le parcours équivalent supposerait un formulaire
+externe (Typeform, Tally) connecté à OWUI par webhook — un assemblage qu'AI
+Forms évite en intégrant les deux couches dans WordPress.
+
+### Ce que l'installation observée en fait
+
+Le cas d'usage naturel dans une maison d'édition est le **formulaire de
+soumission de manuscrit** : l'autrice décrit son projet (genre, longueur,
+statut d'édition), et des champs conditionnels adaptent la suite — un
+résumé long n'est demandé que pour les manuscrits épais, le nom de l'éditeur
+précédent n'apparaît que pour la prose déjà publiée. À la soumission, un
+LLM peut synthétiser le résumé ou vérifier la cohérence des métadonnées,
+soulageant le comité de lecture d'un premier tri.
+
+La leçon structurelle vaut pour tout formulaire administratif conditionnel :
+**le schéma n'est pas le formulaire**. Trois grandeurs sont émergentes et
+non lisibles sur la définition statique — le nombre de chemins terminaux
+atteignables, le coût en appels LLM de chacun, et les champs déclarés mais
+jamais visibles (branches mortes). Auditer un formulaire conditionnel
+suppose d'énumérer ses chemins, pas de relire ses champs.
+
+> **Notebook compagnon.** [`auditer-un-formulaire-conditionnel.ipynb`](auditer-un-formulaire-conditionnel.ipynb)
+> rend cette leçon exécutable : il monte un formulaire de soumission
+> synthétique (Maison Valmont) à sept champs conditionnels et **énumère les
+> chemins terminaux**. Sept champs engendrent treize états distincts (contre
+> un produit cartésien brut de plus de cent), dont près des deux tiers
+> déclenchent un appel LLM, et un champ déclaré n'apparaît sur aucun chemin
+> — un champ mort que la lecture du schéma compterait à tort comme
+> fonctionnel. stdlib pure, aucune clé, aucun réseau.
+
+---
+
 ## Note de méthode — pourquoi il n'y a aucune capture
 
 Ce dossier ne contient **aucune capture d'écran**, et c'est un choix


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #10530

**Quoi:** Sixième notebook du dossier `AI-Engine-WordPress/` : `auditer-un-formulaire-conditionnel.ipynb`. Illustre la feature **AI Forms** — jusqu'ici sans section de parcours ni notebook (le dossier s'arrêtait à Parcours 3). Thèse : *un formulaire à logique conditionnelle est une machine à états implicite*. Le schéma se lit comme une liste de champs, mais le comportement effectif (chemins atteignables, coût LLM par chemin, champs morts) est émergent — il s'énumère, il ne se lit pas. Nouvelle section **Parcours 4** ajoutée à `livresagites-parcours.md`.

**Preuve:** Exécuté avec le kernel `coursia-sae`, 9 cellules code, 0 erreur, 6 sorties. HEAD testé `1dba5d4c5`. Mesures confirmées firsthand : 7 champs conditionnels (fixture synthétique Maison Valmont) engendrent **13 chemins terminaux atteignables** (contre un produit cartésien brut de 108) ; **8 chemin(s) sur 13 (62 %)** déclenchent au moins un appel LLM, dont **2 chemins à double appel** (synthèse + vérification : prose > 200 pages déjà éditée) ; **1 champ mort** (`note_lecture`, condition `nb_pages < 0` jamais satisfaite, visible sur 0/13 chemin). Conditions représentées en **données** (tuples `("gt","nb_pages",200)`), pas en lambdas — formulaire inspectable. 3 exercices à stubs (`return None`) : distribution des longueurs, regroupement par coût LLM, détection des champs morts. Gates CI locaux passés au commit : gitleaks, H.3 (0 cellule `execution_count=null`), no path-leak.

**Périmètre:** 1 nouveau notebook + nouvelle section Parcours 4 dans `livresagites-parcours.md` (avec bloc « Notebook compagnon ») + MaJ du `README.md` (paragraphe descriptif + entrée de liste). Genre `MED/notebook-python` — déterministe, stdlib pure, sans clé, sans réseau. Frontière sécurité tenue (décision user grain 9, reconduite) : fixture synthétique 100 % (formulaire de soumission fictif, champs génériques, domaine « Maison Valmont » réutilisé grains 5/9/10/11). Aucune donnée client, aucun nom réel, aucun secret. Scan : 0 cyrillique/grec, 0 emoji, 0 secret, 0 terme client.

Closes #10617
