### PR TITLE
feat(ci,#10332): translation-guard override via dual-key (label + marker)

### DIFF
--- a/.github/workflows/translation-guard.yml
+++ b/.github/workflows/translation-guard.yml
@@ -129,8 +129,71 @@ jobs:
             echo "violated=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Fail if violated
+      # Override path (#10332): when the violation path fires, the override
+      # gate consults the dual-key (label `translation-override` AND comment
+      # marker `[TRANSLATION-OVERRIDE] <motif>`). Both required -- the
+      # cliquet is not disarmed. The decision lives in
+      # `scripts/ci/translation_override_required.py` (testable, injectable
+      # fetchers -- unit tests never touch the network).
+      - name: Resolve translation-guard override (#10332)
+        id: override
         if: steps.check.outputs.violated == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          echo "::error title=Translation guard FAILED::This PR modifies translation-owned (derived) files. Restore them with: git checkout origin/main -- translations/ <lang-notebooks>, and edit the source notebook instead."
+          set -uo pipefail
+          python3 scripts/ci/translation_override_required.py \
+            --pr-number "$PR_NUMBER" > /tmp/override.json
+          RC=$?
+          echo "--- override verdict ---"
+          cat /tmp/override.json
+          OVERRIDE_APPLIED=$(python3 -c "import json; print(json.load(open('/tmp/override.json')).get('override_applied', False))")
+          if [ "$OVERRIDE_APPLIED" = "True" ]; then
+            MOTIF=$(python3 -c "import json; print(json.load(open('/tmp/override.json')).get('motif',''))")
+            echo "override_applied=true" >> "$GITHUB_OUTPUT"
+            echo "motif=$MOTIF" >> "$GITHUB_OUTPUT"
+          else
+            echo "override_applied=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Exit code of the python script decides: 0 = pass, 1 = block.
+          # We always proceed to the next step so we can print a structured
+          # log either way; the `Fail if violated (or unsatisfied override)`
+          # step below reads `override_applied`.
+          exit 0
+
+      - name: Fail if violated (or unsatisfied override)
+        if: steps.check.outputs.violated == 'true' && steps.override.outputs.override_applied != 'true'
+        run: |
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/override.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error title=Translation guard FAILED::$REASON"
+          gh pr comment "${{ github.event.pull_request.number }}" --body "$(cat <<EOF
+          <!-- translation-guard-violation -->
+          **Translation guard violation (#10332).**
+
+          $REASON
+
+          Three exits to clear this gate:
+          1. Restore the derived files (\`git checkout origin/main -- translations/ <lang-notebooks>\`) and edit the source notebook instead -- the bot re-derives.
+          2. Add the **\`translation-override\` label** AND a PR comment whose FIRST line is **\`[TRANSLATION-OVERRIDE] <motif>\`** (both required -- dual-key, see #10332).
+          3. Ask the coordinator to re-arbitrate (override motif must be journalised in this gate's log; a bare admin bypass leaves no trace).
+
+          See #10332 for the override protocol.
+          EOF
+          )" 2>/dev/null || true
           exit 1
+
+      - name: Journalise accepted override (#10332)
+        if: steps.override.outputs.override_applied == 'true'
+        run: |
+          MOTIF="${{ steps.override.outputs.motif }}"
+          echo "::notice title=Translation guard::OVERRIDE accepted -- motif: $MOTIF. The override is auditable; see #10332."
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "## Translation Guard OVERRIDE accepted (#10332)" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Dual-key satisfied: label \`translation-override\` AND comment marker \`[TRANSLATION-OVERRIDE]\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Motif:** $MOTIF" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "See [#10332](https://github.com/${{ github.repository }}/issues/10332) for the override protocol." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/ci/translation_override_required.py
+++ b/scripts/ci/translation_override_required.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+r"""translation_override_required.py -- gate logic for the translation-guard
+override marker (#10332).
+
+## Why this exists
+
+The ``translation-guard.yml`` workflow guards **derived files** (the CSV
+sync files and the ``*_<lang>.ipynb`` rendered notebooks). It rightly fires
+when a non-bot author hand-edits those files on a feature branch -- the next
+run of ``translation-sync.yml`` would silently overwrite the hand-edit.
+
+But two occurrences the same cycle showed the guard was sometimes bypassed
+through admin merges without a structured trace (#10299: 13 ``*_en.ipynb``
+hand-rendered by po-2025 because the bot pipeline had been broken for 31
+runs; #10304: 2 lines added to ``translations/genai/finetuning.csv`` to repair
+#10297). The bypass was indistinguishable from a complacent merge, and the
+decision lived only in a PR comment that nothing forced anyone to write.
+
+## The discriminator -- LABEL + COMMENT MARKER, both required
+
+The repair proposes a **structured override** matching the precedent set by
+the lane-claim ``[OVERRIDE]`` marker (#10223):
+
+  - A label ``translation-override`` on the PR. The label alone is too easy
+    (a single click), so it is **not sufficient** by itself.
+  - A comment on the PR bearing the marker ``[TRANSLATION-OVERRIDE] <motif>``
+    in its first line. A comment without the label is also insufficient.
+  - **Both required** -- the same dual-key pattern that ``[OVERRIDE]``
+    + ``lane-claim-conflict`` adjudication uses elsewhere (#10223).
+  - When **both** are present, the guard **bypasses** with a structured
+    ``::notice title=Translation guard::OVERRIDE — <motif>`` log line. The
+    motif is **journalised** in the job summary; the override is **auditable**
+    without being **easy**.
+  - When either is missing, the guard keeps FAILING -- the cliquet is not
+    disarmed. This is criterion 4 of #10332.
+
+## Why a separate script (not inline bash)
+
+The verdict is the same shape as the other CI scripts (``scripts/ci/...``):
+JSON on stdout, exit 0/1, the YAML reduces to plumbing. The script is
+**injectable** so unit tests pass dict-based fetchers and never touch the
+network.
+
+## Run locally
+
+    python scripts/ci/translation_override_required.py \
+        --body-file body.txt \
+        --pr-number 1234 \
+        --labels-file labels.json
+
+The label fetcher calls ``gh pr view --json labels`` (CI). The comment
+fetcher calls ``gh api .../issues/<n>/comments``.
+
+Exit codes: 0 pass / 1 fail (override not satisfied).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+
+# Make shared modules importable from anywhere in the repo.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Marker carried in the FIRST LINE of a PR comment. The line is what the
+# override detector greps for: a single-line marker is the irreducible unit
+# of an audit decision, mirroring the lane-claim ``[OVERRIDE]`` precedent
+# (#10223). Multi-line variants would let the marker hide in a sea of prose
+# and break the "single reader / single reducer" discipline.
+_MARKER_RE = re.compile(
+    r"^\s*\[TRANSLATION-OVERRIDE\]\s+(?P<motif>\S.*)$",
+    re.MULTILINE,
+)
+
+# Label name on the PR. Matches the wording of #10332's repair.
+OVERRIDE_LABEL = "translation-override"
+
+
+# ---------------------------------------------------------------------------
+# Fetchers (default = gh; injectable for tests).
+# ---------------------------------------------------------------------------
+
+LabelFetcher = Callable[[int], list[str]]
+CommentFetcher = Callable[[int], list[dict]]
+
+
+def gh_label_fetcher(pr_number: int) -> list[str]:
+    """Fetch the label NAMES attached to a PR via the ``gh`` CLI.
+
+    Returns an empty list on any failure (auth, rate-limit, network) -- the
+    verdict treats a fetch failure as "label not present" (fail-closed on the
+    override: a missing label never satisfies the dual-key, so an unknown state
+    cannot widen the bypass).
+    """
+    repo = os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        return []
+    try:
+        out = subprocess.run(
+            [
+                "gh", "pr", "view", str(pr_number),
+                "--json", "labels",
+                "--jq", "[.labels[].name]",
+            ],
+            capture_output=True, text=True, timeout=20,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if out.returncode != 0:
+        return []
+    try:
+        names = json.loads(out.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return [str(n) for n in names if isinstance(n, str)]
+
+
+def gh_comment_fetcher(pr_number: int) -> list[dict]:
+    """Fetch the COMMENTS of a PR via the ``gh`` CLI.
+
+    Each comment is returned as ``{author, body, createdAt}``. Returns an empty
+    list on any failure. The dual-key verdict treats a fetch failure as
+    "comment with marker not present" (fail-closed) -- same rationale as
+    ``gh_label_fetcher``.
+    """
+    repo = os.environ.get("GH_REPO") or os.environ.get("GITHUB_REPOSITORY")
+    if not repo:
+        return []
+    try:
+        out = subprocess.run(
+            [
+                "gh", "api", f"repos/{repo}/issues/{pr_number}/comments",
+                "--jq", "[.[] | {author: .user.login, body: .body, createdAt: .created_at}]",
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if out.returncode != 0:
+        return []
+    try:
+        comments = json.loads(out.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    return comments
+
+
+# ---------------------------------------------------------------------------
+# Pure decision.
+# ---------------------------------------------------------------------------
+
+
+def _extract_marker(body: str | None) -> str | None:
+    """Return the motif after ``[TRANSLATION-OVERRIDE]`` in ``body`` or None.
+
+    The marker must appear on its own line (the regex anchors with ``^``).
+    We return the **first** hit -- the override is a single decision, and the
+    dual-key already restricts its scope.
+    """
+    if not body:
+        return None
+    m = _MARKER_RE.search(body)
+    return m.group("motif").strip() if m else None
+
+
+def check(
+    pr_number: int,
+    comment_bodies: list[str] | None = None,
+    label_names: list[str] | None = None,
+    comment_fetcher: CommentFetcher | None = None,
+    label_fetcher: LabelFetcher | None = None,
+) -> dict:
+    """Pure decision: does the PR carry the dual-key override (#10332)?
+
+    Args:
+        pr_number: the PR number. Used by the default fetchers; tests inject
+            fetcher functions and pass a placeholder.
+        comment_bodies: optional pre-fetched list of comment-body strings.
+            When supplied, ``comment_fetcher`` is bypassed (test fast-path).
+        label_names: optional pre-fetched list of label names. When supplied,
+            ``label_fetcher`` is bypassed.
+        comment_fetcher: ``int -> list[dict]``. Default ``gh_comment_fetcher``.
+        label_fetcher: ``int -> list[str]``. Default ``gh_label_fetcher``.
+
+    Returns the JSON verdict on stdout -- the YAML reads exit code:
+
+        {
+          "guard_pass": True|False,
+          "reason": str,
+          "override_applied": bool,
+          "label_present": bool,
+          "marker_present": bool,
+          "motif": str|None,
+          "warnings": [str, ...]
+        }
+
+    ``guard_pass`` is True iff the dual-key is satisfied (label AND marker).
+    The override is the **only** way the guard can pass once ``violated=true``
+    has been computed upstream by ``translation-guard.yml`` itself; on a clean
+    PR (no derived files touched), ``translation-guard.yml`` short-circuits
+    before this script is consulted -- this helper exists for the
+    ``violated=true`` path.
+    """
+    labels = (
+        label_names
+        if label_names is not None
+        else (label_fetcher or gh_label_fetcher)(pr_number)
+    )
+    label_present = OVERRIDE_LABEL in labels
+
+    bodies: list[str]
+    if comment_bodies is not None:
+        bodies = list(comment_bodies)
+    else:
+        comments = (comment_fetcher or gh_comment_fetcher)(pr_number)
+        bodies = [c.get("body", "") for c in comments if isinstance(c, dict)]
+
+    marker: str | None = None
+    for body in bodies:
+        marker = _extract_marker(body)
+        if marker is not None:
+            break
+    marker_present = marker is not None
+
+    warnings: list[str] = []
+    if not label_present and not marker_present:
+        return {
+            "guard_pass": False,
+            "reason": (
+                f"translation-guard violation: no override label '{OVERRIDE_LABEL}' "
+                f"and no comment marker '[TRANSLATION-OVERRIDE] <motif>'. "
+                f"Edit the source notebook instead and let translation-sync re-derive. "
+                f"See #10332."
+            ),
+            "override_applied": False,
+            "label_present": False,
+            "marker_present": False,
+            "motif": None,
+            "warnings": warnings,
+        }
+    if not label_present:
+        return {
+            "guard_pass": False,
+            "reason": (
+                f"translation-guard violation: comment marker present but label "
+                f"'{OVERRIDE_LABEL}' missing. Both required (dual-key). See #10332."
+            ),
+            "override_applied": False,
+            "label_present": False,
+            "marker_present": True,
+            "motif": marker,
+            "warnings": warnings,
+        }
+    if not marker_present:
+        return {
+            "guard_pass": False,
+            "reason": (
+                f"translation-guard violation: label '{OVERRIDE_LABEL}' present but "
+                f"no comment with marker '[TRANSLATION-OVERRIDE] <motif>'. Both "
+                f"required (dual-key). See #10332."
+            ),
+            "override_applied": False,
+            "label_present": True,
+            "marker_present": False,
+            "motif": None,
+            "warnings": warnings,
+        }
+
+    # Both keys satisfied: the override applies.
+    assert motif_safe(marker), "marker validated by regex"  # nosec - regex anchored
+    return {
+        "guard_pass": True,
+        "reason": (
+            f"translation-guard OVERRIDE accepted: label '{OVERRIDE_LABEL}' "
+            f"and comment marker '[TRANSLATION-OVERRIDE]' both present. "
+            f"Motif: {marker!r}. The override is journalised in this job's log; "
+            f"see #10332 for the protocol."
+        ),
+        "override_applied": True,
+        "label_present": True,
+        "marker_present": True,
+        "motif": marker,
+        "warnings": warnings,
+    }
+
+
+def motif_safe(motif: str | None) -> bool:
+    """Light sanity check on the motif: must be non-empty after stripping."""
+    return bool(motif) and bool(motif.strip())
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing.
+# ---------------------------------------------------------------------------
+
+
+def _read_labels_file(path: str) -> list[str]:
+    """Read a labels file as a JSON array of strings (test path).
+
+    Empty/missing -> empty list (treat as no labels present).
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(data, list):
+        return [str(x) for x in data]
+    return []
+
+
+def _read_comments_file(path: str) -> list[str]:
+    """Read a comments file as a JSON array of comment-body strings (test path).
+
+    Empty/missing -> empty list.
+    """
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return []
+    if isinstance(data, list):
+        return [str(x) for x in data]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="translation-guard override decision (#10332)"
+    )
+    parser.add_argument("--pr-number", type=int, required=True)
+    parser.add_argument(
+        "--labels-file",
+        default=None,
+        help="JSON array of label names (skips the gh label fetch).",
+    )
+    parser.add_argument(
+        "--comments-file",
+        default=None,
+        help="JSON array of comment-body strings (skips the gh comment fetch).",
+    )
+    args = parser.parse_args(argv)
+
+    labels = _read_labels_file(args.labels_file) if args.labels_file else None
+    comments = _read_comments_file(args.comments_file) if args.comments_file else None
+
+    verdict = check(
+        pr_number=args.pr_number,
+        comment_bodies=comments,
+        label_names=labels,
+    )
+    print(json.dumps(verdict, indent=1, ensure_ascii=False))
+    return 0 if verdict["guard_pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_translation_override_required.py
+++ b/scripts/tests/test_translation_override_required.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Unit tests for ``translation_override_required.py`` (#10332).
+
+The script is a pure decision over (labels, comments) -> verdict. Fetchers are
+default ``gh``-based and injectable; these tests pass dict-based fixtures so
+the test runner never touches the network.
+
+Coverage map (mirrors the acceptance criteria of #10332):
+  - test_override_pass_label_and_marker       : pass / override_applied True
+  - test_override_fail_label_only             : label present, no marker -> fail
+  - test_override_fail_marker_only            : marker present, no label -> fail
+  - test_override_fail_neither                : nothing -> fail (cliquet)
+  - test_override_fail_empty_motif            : marker present but empty motif
+  - test_override_pass_picks_first_marker     : multiple markers -> first wins
+  - test_override_motif_extraction            : regex anchoring (not in prose)
+  - test_override_label_case_sensitive        : case-sensitive label match
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ci.translation_override_required import (  # noqa: E402
+    OVERRIDE_LABEL,
+    _extract_marker,
+    check,
+)
+
+
+def test_override_pass_label_and_marker():
+    """Dual-key satisfied: pass with the motif journalised in the verdict."""
+    verdict = check(
+        pr_number=999,
+        comment_bodies=["[TRANSLATION-OVERRIDE] hand-edit finetuning.csv ligne 42-44\n"],
+        label_names=[OVERRIDE_LABEL, "other-label"],
+    )
+    assert verdict["guard_pass"] is True, verdict
+    assert verdict["override_applied"] is True
+    assert verdict["label_present"] is True
+    assert verdict["marker_present"] is True
+    assert verdict["motif"] == "hand-edit finetuning.csv ligne 42-44"
+
+
+def test_override_fail_label_only():
+    """Label without marker: the dual-key is unsatisfied -> fail."""
+    verdict = check(
+        pr_number=999,
+        comment_bodies=["This is just a comment without the marker."],
+        label_names=[OVERRIDE_LABEL],
+    )
+    assert verdict["guard_pass"] is False
+    assert verdict["override_applied"] is False
+    assert verdict["label_present"] is True
+    assert verdict["marker_present"] is False
+    assert verdict["motif"] is None
+    assert "label" in verdict["reason"].lower()
+    assert "marker" in verdict["reason"].lower()
+
+
+def test_override_fail_marker_only():
+    """Marker without label: dual-key unsatisfied -> fail."""
+    verdict = check(
+        pr_number=999,
+        comment_bodies=["[TRANSLATION-OVERRIDE] legitimate override #10299"],
+        label_names=["unrelated-label"],
+    )
+    assert verdict["guard_pass"] is False
+    assert verdict["override_applied"] is False
+    assert verdict["label_present"] is False
+    assert verdict["marker_present"] is True
+    assert verdict["motif"] == "legitimate override #10299"
+    assert "label" in verdict["reason"].lower()
+
+
+def test_override_fail_neither():
+    """No label, no marker: cliquet non disarmé -> fail (criterion 4 of #10332)."""
+    verdict = check(
+        pr_number=999,
+        comment_bodies=["Some unrelated comment", "Another one"],
+        label_names=["random-label"],
+    )
+    assert verdict["guard_pass"] is False
+    assert verdict["override_applied"] is False
+    assert verdict["label_present"] is False
+    assert verdict["marker_present"] is False
+    assert verdict["motif"] is None
+
+
+def test_override_fail_empty_motif():
+    """A marker line whose motif is whitespace-only: fail (no journalable decision)."""
+    verdict = check(
+        pr_number=999,
+        comment_bodies=["[TRANSLATION-OVERRIDE]    \n"],
+        label_names=[OVERRIDE_LABEL],
+    )
+    # The regex requires \S after the marker -- a whitespace-only motif does
+    # not match. marker_present should be False; dual-key unsatisfied -> fail.
+    assert verdict["guard_pass"] is False
+    assert verdict["override_applied"] is False
+    assert verdict["marker_present"] is False
+
+
+def test_override_pass_picks_first_marker():
+    """Two marker comments: the FIRST one is the override decision."""
+    verdict = check(
+        pr_number=999,
+        comment_bodies=[
+            "[TRANSLATION-OVERRIDE] first decision (motif A)",
+            "[TRANSLATION-OVERRIDE] second decision (motif B)",
+        ],
+        label_names=[OVERRIDE_LABEL],
+    )
+    assert verdict["guard_pass"] is True
+    assert verdict["motif"] == "first decision (motif A)"
+
+
+def test_override_motif_extraction():
+    """The marker must appear on its own LINE -- mid-prose markers do not count."""
+    # The regex anchors with ^ + MULTILINE. A marker buried in prose does not
+    # match because the line starts with prose text.
+    body = (
+        "Long paragraph that mentions [TRANSLATION-OVERRIDE] in passing "
+        "but the marker is not on its own line.\n"
+    )
+    assert _extract_marker(body) is None
+
+    # But a marker on its own line, with leading whitespace tolerated, matches.
+    body2 = "   [TRANSLATION-OVERRIDE]   motif with leading and trailing\n"
+    assert _extract_marker(body2) == "motif with leading and trailing"
+
+
+def test_override_label_case_sensitive():
+    """Label match is case-sensitive -- 'Translation-Override' != 'translation-override'."""
+    verdict = check(
+        pr_number=999,
+        comment_bodies=["[TRANSLATION-OVERRIDE] motif"],
+        label_names=["Translation-Override"],  # capitalised, NOT the canonical form
+    )
+    assert verdict["guard_pass"] is False
+    assert verdict["label_present"] is False
+    assert verdict["marker_present"] is True


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: IDLE/idle-pivot c.1301+104

## Résumé

Ajoute un **mécanisme d'arbitrage tracé** au translation-guard : un override via dual-key (label `translation-override` + marqueur commentaire `[TRANSLATION-OVERRIDE] <motif>`) qui rend l'override audit-able sans le rendre facile. Les deux clés sont requises, aucune seule ne suffit, le cliquet n'est pas désarmé.

## Périmètre

| Fichier | Type | Lignes |
|---|---|---|
| `scripts/ci/translation_override_required.py` | nouveau (décision pure, fetchers injectables) | +362 |
| `scripts/tests/test_translation_override_required.py` | nouveau (8 tests pytest) | +142 |
| `.github/workflows/translation-guard.yml` | modifié (ajout 3 steps + restructuration du step FAIL) | +65 / -2 |

**Total : 3 fichiers, +569/-2.**

## Acceptance criteria de #10332 — couverture mesurée

| # | Critère | Test / Mesure | Verdict |
|---|---|---|---|
| 1 | Label + marqueur passent, motif journalisé | `test_override_pass_label_and_marker` | ✅ |
| 2 | Label seul échoue | `test_override_fail_label_only` | ✅ |
| 3 | Marqueur seul échoue | `test_override_fail_marker_only` | ✅ |
| 4 | Sans l'un ni l'autre échoue (cliquet non désarmé) | `test_override_fail_neither` | ✅ |
| 5 | Motif vide rejeté | `test_override_fail_empty_motif` | ✅ |
| 6 | Premier marqueur gagne | `test_override_pass_picks_first_marker` | ✅ |
| 7 | Regex anchored sur ligne propre, prose ignorée | `test_override_motif_extraction` | ✅ |
| 8 | Label case-sensitive | `test_override_label_case_sensitive` | ✅ |

**8/8 tests verts.** Le motif vide n'est pas une régression gratuite — un override sans motif est un override sans audit, c'est précisément la faille que le dual-key ferme.

## Pourquoi cette forme

- **Label seul** = trop facile (un clic). Un clic ne motive pas l'arbitrage écrit.
- **Marqueur seul** = non machine-readable. Le job ne peut pas distinguer un commentaire « j'explique pourquoi » d'une décision d'override.
- **Les deux ensemble** = la décision est tracée à deux endroits : un label visible dans la timeline PR + un commentaire horodaté qui porte le motif. Le réducteur (le script) lit les deux et journalise le motif dans le job log.

C'est le même modèle que `[OVERRIDE]` pour lane-claim (#10223) : un marqueur écrit que le gate sait lire, pas une dérogation de compte.

## Garde-fous

- **R1 catalog-pr-hygiene** : `COURSE_CATALOG.generated.{json,md}` byte-identique à `main`. Mesuré : `git diff origin/main -- COURSE_CATALOG.*` = 0 lignes.
- **Carve-out « nouveau fichier dérivé » (#10306)** : intact. Un nouveau `*_<lang>.ipynb` jamais présent sur `main` reste bypass (premier rendu légitime).
- **Cliquet non désarmé** (criterion 4 de #10332) : testé explicitement par `test_override_fail_neither`. Le FAIL du jour reste le FAIL si rien n'est posé.
- **G-VAR-3** : genre `guard` ≠ `lean` (genre précédent = IDLE/idle-pivot), pas d'adjacence à surveiller.
- **G-VAR-1** : genre `guard` dans la classe **META**. Pour ce cycle je l'assume comme grain plancher car (a) la fabrication LIGHT serait plus illégitime (label-only sans décision ne peut pas rougir au bon moment), (b) ce grain-là est une **décision** sur le harnais existante, pas un guard de plus — il peut rougir, et rougit dès qu'on l'ouvre sans la dual-key.

## Diff scope (L890 ★★)

```
.github/workflows/translation-guard.yml            |  67 ++++++++++++++++++++++++++++++++-
scripts/ci/translation_override_required.py        | 362 +++++++++++++++++++++++++++++++++++++++++++++++
scripts/tests/test_translation_override_required.py| 142 +++++++++++++++++++++++++++++++
3 files changed, 569 insertions(+), 2 deletions(-)
```

Pas de touche hors scope : aucun notebook, aucune autre CI, aucune modification de translation-sync bot.

## Claim + ACK

- `[CLAIMED]` posé sur #10332 (comment 5267409851, lane `myia-po-2025:CoursIA-2`).
- Per DM ai-01 `msg-20260812T131455-p30c5i` (HIGH, 15:14Z) — pivot hors-Lean G-VAR-3 après 4 grains Lean consécutifs (#10479 Lean-2/3/4/5/6), argumentum/i18n proposé.
- Ce grain est i18n-infra (le `guard` qui protège les dérivés i18n), pas argumentum au sens propre — mais la famille logique est la bonne.

## Voir aussi

- #10332 — l'issue qui demande la réparation
- #10038 — i18n umbrella
- #10042 — grain C (translation-sync auto-commit bot + derived-file guard)
- #10323 — GitHub-authoritative closing refs (précedent pour le cross-check API)
- #10223 — lane-claim `[OVERRIDE]` precedent (le modèle dual-key)
- #10299 + #10304 — les deux bypasses légitimes qui ont motivé l'issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)