### PR TITLE
fix(qc,#10230): scan_window_drift directory-scan crash — acceptance « lancer sur l'arbre QC entier »

### DIFF
--- a/scripts/notebook_tools/scan_window_drift.py
+++ b/scripts/notebook_tools/scan_window_drift.py
@@ -406,7 +406,18 @@ def main(argv: list[str] | None = None) -> int:
         nb_path = Path(args.notebook)
         if not nb_path.is_absolute():
             nb_path = root / args.notebook
-        records = [classify_notebook(nb_path)]
+        if nb_path.is_dir():
+            # Acceptance #10230 : « lancer sur l'arbre QC entier ». Un chemin de
+            # répertoire scanne tous les .ipynb qu'il contient (hors checkpoints),
+            # au lieu de crasher en ERREUR (read_text sur un dir).
+            paths = [p for p in sorted(nb_path.rglob("*.ipynb"))
+                     if ".ipynb_checkpoints" not in p.parts]
+            if not paths:
+                print(f"[scan_window_drift] aucun notebook sous {nb_path}", file=sys.stderr)
+                return 2
+            records = [classify_notebook(p) for p in paths]
+        else:
+            records = [classify_notebook(nb_path)]
     else:
         paths = list(_iter_notebooks(root, args.family))
         if not paths:

--- a/scripts/notebook_tools/tests/test_scan_window_drift.py
+++ b/scripts/notebook_tools/tests/test_scan_window_drift.py
@@ -225,3 +225,38 @@ def test_cli_check_exit_one_on_drift(tmp_path):
     assert r.returncode == 1
     payload = json.loads(r.stdout)
     assert payload["records"][0]["verdict"] == "DRIFT"
+
+
+def test_cli_directory_arg_scans_tree_not_crash(tmp_path):
+    """Un chemin de répertoire scanne tous les .ipynb dedans (acceptance #10230 :
+    « lancer sur l'arbre QC entier ») au lieu de crasher en ERREUR.
+
+    Régression : avant ce fix, ``main`` appelait ``classify_notebook(dir_path)``
+    qui faisait ``dir.read_text()`` -> IsADirectoryError -> verdict ERREUR.
+    """
+    import subprocess
+    # arbre synthétique : 2 notebooks (1 DRIFT timedelta, 1 N-A sans API QC)
+    # + un sous-dossier + un .ipynb_checkpoints (qui doit être exclu).
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    drift_cells = [("code", "qb = QuantBook()\nh = qb.History('SPY', timedelta(365), Resolution.Daily)")]
+    na_cells = [("code", "import pandas as pd\nprint('no QC api here')")]
+    (tmp_path / "drift.ipynb").write_text(json.dumps(_nb(drift_cells)), encoding="utf-8")
+    (sub / "na.ipynb").write_text(json.dumps(_nb(na_cells)), encoding="utf-8")
+    checkpoints = tmp_path / ".ipynb_checkpoints"
+    checkpoints.mkdir()
+    (checkpoints / "ignored.ipynb").write_text(json.dumps(_nb(drift_cells)), encoding="utf-8")
+
+    r = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent.parent / "scan_window_drift.py"),
+         str(tmp_path), "--json"],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, f"directory scan crashed: {r.stderr}"
+    payload = json.loads(r.stdout)
+    records = payload["records"]
+    # 2 notebooks classés (le checkpoints est exclu), aucun verdict ERREUR.
+    assert len(records) == 2, f"expected 2 records (checkpoints excluded), got {len(records)}: {records}"
+    verdicts = {rec["verdict"] for rec in records}
+    assert "ERREUR" not in verdicts, f"directory path crashed a record: {records}"
+    assert verdicts == {"DRIFT", "N-A"}, f"expected DRIFT+N-A, got {verdicts}"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA

## Summary

Bug firsthand dans le détecteur `scan_window_drift.py` (livré par #10235 sur #10230) : le CLI crashait quand on lui passait un **répertoire** au lieu d'un notebook file. Or l'acceptance #10230 dit explicitement « Le lancer sur l'arbre QC entier : coller la répartition obtenue dans le body » — ce qui était impossible depuis la CLI.

**Cause** : `main()` (L405-409) appelait `classify_notebook(nb_path)` même quand `nb_path` était un dir → `nb_path.read_text()` → `IsADirectoryError` → verdict `ERREUR`.

**Fix** : si `nb_path.is_dir()`, `rglob` les `.ipynb` (hors `.ipynb_checkpoints`, même filtre que `_iter_notebooks`) et classifie chaque notebook.

## Firsthand verification (worktree frais, origin/main 74ce18351)

```
$ python scan_window_drift.py MyIA.AI.Notebooks/QuantConnect/partner-course-quant-trading/
# AVANT le fix : "ERREUR : 1" (crash IsADirectoryError)
# APRÈS le fix :
--- DRIFT : 8 ---  (partner-course/examples/* : kit-transitoire, Research-Executor, etc.)
--- PINNED : 3 ---
--- N-A : 1 ---
Répartition: DRIFT=8 PINNED=3 N-A=1, exit 0
```

## Test plan

- [x] `python -m pytest scripts/notebook_tools/tests/test_scan_window_drift.py` → **15 passed** (14 existants + 1 nouveau)
- [x] Nouveau test `test_cli_directory_arg_scans_tree_not_crash` : arbre synthétique (2 notebooks + sous-dossier + `.ipynb_checkpoints` exclu) → assert 2 records, aucun `ERREUR`, verdicts == `{DRIFT, N-A}`
- [x] Repro réel sur `partner-course-quant-trading/` : exit 0, 12 notebooks classés (was crash)
- [x] Pas de catalogue drift (seulement `scripts/notebook_tools/scan_window_drift.py` + test touchés)

## Datapoint annexe — refus de propager un faux positif

Le notebook `partner-course/examples/Crypto-MultiCanal/research.ipynb` (celui de #10318) est classifié **PINNED** par le détecteur. Confirmé à la source :

```python
# c3 L14-15
start_date = datetime(2022, 1, 1)
end_date = datetime(2025, 4, 21)
# c3 L18
bars_df = qb.History(btc_symbol, start_date, end_date, Resolution.Hour)
```

Bornes littérales concrètes = fenêtre figée. L'inventaire manuel de #10230 listait ce notebook avec marqueur `NL` (now/lookback) comme DRIFT : c'était un **faux positif de l'heuristique manuelle** de l'issue, pas un bug du détecteur. Le détecteur a raison.

See #10230 (follow-up bug fix sur le détecteur livré par #10235 ; l'issue reste ouverte pour la tâche 4 QC Cloud, hors scope ici).
See #9768 (EPIC D2), #9772 (probe mesure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
