### PR TITLE
fix(ci,#10433): re-aggregate pr-gate on Lane Claim Guard completion (body-edit stale-BLOCKED)

### DIFF
--- a/.github/workflows/pr-gate-rerun.yml
+++ b/.github/workflows/pr-gate-rerun.yml
@@ -12,10 +12,22 @@ name: PR gate (re-aggregate)
 # from _pull_request_trigger and continues).
 #
 # What this fixes: pr-gate.yml aggregates once on pull_request with up to a
-# 90-min settle window. If a required guard (Variation Tag Guard) flips green
-# AFTER that aggregation, the PR stays BLOCKED on a stale FAIL until a manual
-# `gh run rerun`. This workflow re-aggregates the CURRENT check set when that
-# guard completes and POSTs the fresh verdict onto the PR head SHA.
+# 90-min settle window. If a required guard (Variation Tag Guard, Lane Claim
+# Guard) flips green AFTER that aggregation, the PR stays BLOCKED on a stale
+# FAIL until a manual `gh run rerun`. This workflow re-aggregates the CURRENT
+# check set when such a guard completes and POSTs the fresh verdict onto the
+# PR head SHA.
+#
+# Why Lane Claim Guard is also a trigger (#10433 follow-up): lane-claim-guard
+# listens to the `edited` activity type, so it re-runs when a PR body is
+# edited (e.g. a closing-ref `Closes #N` fixed to `See #N` to resolve a
+# lane collision). pr-gate.yml does NOT listen to `edited` (its trigger is
+# the default opened/synchronize/reopened), so its aggregate stays stale on
+# the pre-edit FAIL even though lane-claim-guard now passes. Without this
+# re-aggregation trigger, the PR stays falsely BLOCKED until a manual rerun
+# -- observed 4x on 2026-08-12 (twin-parite tranches #10588/#10592/#10599/
+# #10601, unblocked by hand). Re-aggregating on Lane Claim Guard completion
+# closes the loop automatically.
 #
 # Why an explicit check-run POST (not the job's auto check-run): a workflow_run
 # job runs on the DEFAULT branch, so GITHUB_SHA is the default-branch commit and
@@ -26,7 +38,7 @@ name: PR gate (re-aggregate)
 
 on:
   workflow_run:
-    workflows: ["Variation Tag Guard"]
+    workflows: ["Variation Tag Guard", "Lane Claim Guard"]
     types: [completed]
   # Manual dispatch for testing the re-aggregation path without waiting for a
   # guard run. PR_NUMBER/HEAD_SHA default to empty; the job then no-ops unless


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: LIGHT/docs #10624

## Summary

Follow-up de #10433 item-1 : le path de re-aggregation `pr-gate-rerun.yml` ne se declenchait que sur `workflow_run: [Variation Tag Guard]`. Il manquait **Lane Claim Guard** -- pourtant le 2e garde dont le verdict peut flipper apres l'aggregation initiale de `pr-gate.yml`, et qui est la cause observee de PRs faussement BLOCKED ce cycle.

## Le defect (observe 4x le 2026-08-12)

`pr-gate.yml` agregate une fois sur `pull_request` (trigger default = opened/synchronize/reopened, **pas `edited`**) avec une fenetre de settle de 90 min. `lane-claim-guard.yml`, lui, ecoute `edited` -- donc il re-run quand un body PR est edite (typiquement un closing-ref `Closes #N` corrige en `See #N` pour resoudre une collision de lane #10223). Quand lane-claim-guard flippe vert apres ce fix de body, **rien ne re-agrege `pr-gate.yml`** : son verdict reste sur le FAIL stale d'avant l'edit, et la PR reste BLOCKED jusqu'a un `gh run rerun` manuel.

Reproduit firsthand ce cycle sur 4 PRs substantielles (~20 paires twin-parite, epics #10439/#10382) : #10588, #10592, #10599, #10601. Diagnostic verifie airtight : `closingIssuesReferences` LIVE = vide pour les 4 (GitHub a re-parse le body fixe, ne fermera plus), le guard fetche cet etat EN LIVE au run (ligne 101 `lane-claim-guard.yml`, fix #10323). Les 4 debloquees a la main via `gh run rerun` -> completed:success -> CLEAN MERGEABLE.

## Le fix (1 ligne de trigger + commentaire)

Ajouter `"Lane Claim Guard"` a la liste `workflow_run.workflows` de `pr-gate-rerun.yml` :

```yaml
on:
  workflow_run:
    workflows: ["Variation Tag Guard", "Lane Claim Guard"]
    types: [completed]
```

Quand lane-claim-guard complete (y compris apres un `edited`), `pr-gate-rerun` re-agrege le check set COURANT et POST un verdict frais "PR gate" sur le PR head SHA. Si lane-claim-guard passe desormais (closingRefs vide), l'agregat frais passe -> la PR se debloque **automatiquement**, sans rerun manuel.

## Pourquoi le re-aggregator (pas `edited` sur pr-gate.yml)

Deux options envisagees :
- **(A)** ajouter `edited` aux activity types de `pr-gate.yml` : re-run du heavyweight aggregator (fenetre 90 min) sur chaque edit de body. Plus cher, et `pr-gate.yml` est le workflow que le canary `derive_always_on_jobs` scrute (risque d'effet de bord sur l'alarme #9858).
- **(B, retenue)** ajouter Lane Claim Guard au trigger `workflow_run` du **lightweight re-aggregator** : re-aggregation cheap (lecture check-runs + POST 1 check-run), architecturalement consistante avec l'entree Variation Tag Guard existante, et `pr-gate-rerun.yml` n'a PAS de trigger `pull_request` donc le canary le skip (documente lignes 4-12).

Le commentaire d'en-tete (lignes 14-18) documentait deja le defect stale-rollup mais seulement pour Variation Tag Guard ; il est etendu pour couvrir Lane Claim Guard + le scenario body-edit, avec reference aux 4 PRs observees.

## Securite

- **Pas de boucle** : lane-claim-guard se declenche sur events `pull_request` (opened/synchronize/reopened/edited), pas sur `check_run` -- poster un check-run depuis pr-gate-rerun ne re-arme pas lane-claim-guard.
- **Storm maitrise** : le concurrency group `pr-gate-rerun-<PR#>` (ligne 65, `cancel-in-progress`) -- le commentaire explicite « a later guard-completion supersedes an in-flight one for the same PR ». Design deja prevu pour plusieurs guards.
- **Trigger-independant** : `pr_gate.py` lit `github.event.workflow_run.head_sha` et agrege sans se soucier du NOM du guard declencheur (verifie firsthand) -- ajouter Lane Claim Guard ne change pas la logique d'aggregation.

## Validation

- **YAML valide** : `yaml.safe_load` parse, `workflow_run.workflows = ['Variation Tag Guard', 'Lane Claim Guard']`, `types = [completed]`.
- **46/46 tests `test_pr_gate.py` PASS** (re-aggregation POST path + derive_always_on_jobs canary) -- rien casse.
- **pr_gate.py trigger-independant** : verifie firsthand (lit `workflow_run.head_sha`, n'examine pas le guard source).
- **Concurrency group** gere le burst (1 re-aggregation par PR, cancel-in-progress).
- **Diff chirurgical** : +17/-5 sur 1 fichier (1 mot dans la ligne trigger + commentaire etendu). Aucun code Python touche.

## Scope

1 fichier, +17/-5. `See #10433` (follow-up item-1 -- l'issue reste ouverte pour les autres items du stale-rollup defect).

See #10433 (follow-up).

---

Co-authored-by: Claude-Code <noreply@anthropic.com>
