### PR TITLE
feat(genai,#10488): enrich Fort-Boyard-python markdown density (6 empty section headers)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Fort-Boyard/fort-boyard-python.ipynb
@@ -128,9 +128,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Configuration des agents"
-   ]
+   "source": "## Configuration des agents\n\nLe **Kernel** est le cœur de Semantic Kernel : un conteneur d'injection de dépendances qui regroupe les services d'IA et les fonctions (plugins) qu'un agent peut invoquer. Avant de créer un agent, il faut donc lui brancher un service de complétion de chat — ici `OpenAIChatCompletion`, paramétré par le modèle et la clé API lus depuis l'environnement (jamais codés en dur, cf. règle secrets-hygiene).\n\nCette cellule fixe aussi `MOT_A_DEVINER`, le mot secret que le Père Fouras fera deviner à Laurent Jalabert tout au long de la partie."
   },
   {
    "cell_type": "code",
@@ -181,9 +179,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Définition des prompts"
-   ]
+   "source": "## Définition des prompts\n\nChaque agent conversationnel est piloté par un **prompt système** (ses *instructions*) qui définit son rôle, sa personnalité et les règles qu'il doit respecter. Ces instructions conditionnent tout le comportement de l'agent au fil du dialogue : un même Kernel peut produire deux interlocuteurs radicalement différents selon le prompt qu'on lui donne.\n\nIci, le prompt du Père Fouras injecte le mot secret via une f-string (`{MOT_A_DEVINER}`) et lui interdit de le révéler directement : il doit guider par des charades. Celui de Laurent Jalabert le contraint à poser des **questions fermées** (Oui/Non), ce qui transforme la devinette en un problème de réduction d'incertitude tour par tour."
   },
   {
    "cell_type": "code",
@@ -257,9 +253,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Création des agents avec stratégies personnalisées"
-   ]
+   "source": "## Création des agents avec stratégies personnalisées\n\nUn `ChatCompletionAgent` concrétise l'association entre un Kernel (le moteur), un `name` (son identité dans le dialogue) et des `instructions` (son prompt système). Une fois instanciés, les deux agents peuvent produire des messages, mais ils ne savent pas encore *quand* parler ni *quand* s'arrêter — c'est le groupe de discussion qui le décidera (voir plus bas).\n\nNotez que chaque agent reçoit son propre Kernel via `create_kernel()` : ils partagent le même service OpenAI mais restent des entités indépendantes, ce qui laisse la porte ouverte à les brancher plus tard sur des modèles ou des plugins différents."
   },
   {
    "cell_type": "code",
@@ -310,9 +304,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Stratégie de terminaison personnalisée"
-   ]
+   "source": "## Stratégie de terminaison personnalisée\n\nDans un dialogue multi-agent, il faut décider **quand s'arrêter**. Semantic Kernel délègue cette décision à une `TerminationStrategy` : après chaque tour, la méthode asynchrone `should_agent_terminate` est invoquée et renvoie un booléen qui détermine si la boucle se clôt.\n\nNotre stratégie métier est simple : la partie se termine dès que le mot secret apparaît dans le dernier message — c'est-à-dire quand Laurent Jalabert a deviné correctement. On ne teste la terminaison que sur l'agent concerné (le devineur), pas sur le Père Fouras qui n'a pas vocation à révéler la solution."
   },
   {
    "cell_type": "code",
@@ -391,9 +383,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Configuration du groupe de discussion"
-   ]
+   "source": "## Configuration du groupe de discussion\n\n`AgentGroupChat` est l'orchestrateur multi-agent : il fait tourner les agents à tour de rôle selon une **stratégie de sélection** (quel agent parle ensuite) et s'arrête selon une **stratégie de terminaison** (quand arrêter). Par défaut, la sélection alterne simplement les agents dans l'ordre de la liste.\n\nOn lui passe ici les deux agents et notre `FortBoyardTerminationStrategy`, bornée à `maximum_iterations=20` : c'est le filet de sécurité qui empêche une partie de boucler indéfiniment si le mot n'est jamais trouvé. La stratégie de terminaison ne s'applique qu'à `laurent_jalabert` — c'est lui le devineur, c'est donc son tour qui peut clore la partie."
   },
   {
    "cell_type": "code",
@@ -440,9 +430,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Lancement de la partie !"
-   ]
+   "source": "## Lancement de la partie !\n\nLe groupe est configuré, on peut lancer la partie. On sème le dialogue avec un **message utilisateur initial** (`add_chat_message`) — sinon les agents n'ont rien à quoi réagir — puis on itère asynchronement sur `chat.invoke()`, qui produit chaque message tour à tour.\n\nL'itération s'arrêtera automatiquement soit quand Laurent aura trouvé le mot (terminaison métier), soit au bout de 20 itérations (garde-fou). `await` est obligatoire car les appels au LLM sont asynchrones : chaque tour effectue une véritable requête HTTP vers l'API OpenAI, dont on voit la latence dans les logs (plusieurs secondes par réponse)."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/guard #10628

## Summary

Tranche densite pedagogique #10488 sur `fort-boyard-python.ipynb` (GenAI CaseStudies). Le notebook est structurellement correct (3 exercices stubbes conformes C.1, outputs reels ec=1-8, no twin) mais **6 en-tetes de section etaient vides** : un titre `## ...` isole de 25-53c sans aucun texte. Chaque section precede un concept cible de Semantic Kernel (Kernel, prompt systeme, ChatCompletionAgent, TerminationStrategy, AgentGroupChat, boucle invoke async) sans l'introduire.

Cette PR enrichit les 6 cellules markdown avec une prose **WHAT/WHY** qui pose le concept avant le code (pattern densite #10479), en francais (FR = source de verite, le twin `_en` est regenere par le cron translation-sync post-merge).

## Defects (6) -- section vide -> concept explique

| Cell | Titre (avant) | Chars avant->apres | Concept SK introduit |
|---|---|---|---|
| [3] 48b0b793 | Configuration des agents | 27 -> 564 | Kernel = conteneur DI (services + plugins) ; `MOT_A_DEVINER` fixe ici |
| [5] f0496c5b | Definition des prompts | 25 -> 716 | prompt systeme = instructions ; f-string injecte le mot ; questions fermees = reduction d'incertitude |
| [9] 6a8dbe2b | Creation des agents... | 53 -> 667 | `ChatCompletionAgent` = (Kernel, name, instructions) ; kernel dedie par agent |
| [11] 4a00c813 | Strategie de terminaison... | 41 -> 623 | `TerminationStrategy.should_agent_terminate` ; test sur le devineur seulement |
| [15] c61e7f51 | Configuration du groupe... | 40 -> 700 | `AgentGroupChat` = selection + terminaison ; `maximum_iterations=20` garde-fou |
| [17] ada98689 | Lancement de la partie ! | 27 -> 643 | message seed `add_chat_message` ; `async for chat.invoke()` ; await = latence HTTP reelle |

Densite markdown globale : ~245 -> **640 c/cellule** (moyenne sur 10 cellules markdown).

## Validation

- **Markdown-only (exception C.2)** : script de verification firsthand -- `0 cellule code changee` (assert `mc == wc` par cellule code), seules les 6 cibles markdown touchees, metadata + nbformat inchanges. Preuve : `git diff -- '*.ipynb' | grep execution_count` = vide ; le diff raw montre 6 hunks purs (prose ajoutee), les lignes `"cell_type": "code"` sont du **contexte** adjacent (ligne d'ouverture de la cellule suivante), pas des changements.
- **nbformat valide** : `nbformat.validate` PASS, 4.5, 21 cellules (compte inchange).
- **md table syntax** : `scan_md_table_syntax.py` -> 0 defaut (aucune table dans le notebook).
- **Seria** : `json.dumps(nb, ensure_ascii=False, indent=1)` round-trip verifie == fichier sur disque (serializer standard respecte).
- **3 exercices preserves** : stubs C.1 intacts (`print("Exercice a completer")`, `result = None # TODO`), aucun `raise NotImplementedError`, outputs des stubs preserves. Le notebook s'execute end-to-end.
- **Pas de DRIFT twin** : `fort-boyard-python.ipynb` absent de `scripts/notebook_tools/twin_pairs.d/` (verifie). La version C# (`fort-boyard-csharp.ipynb`) est un notebook separe, deja enrichi par #10573 (MERGED). Le twin `_en` FR->EN est gere par le cron translation-sync (FR = source de verite, `*_en.ipynb` regenere post-merge ; translation-guard ne se declenche QUE sur hand-edit `_en`, translation-parity est advisory `continue-on-error`).

## Notes review

- NotebookEdit stocke la source enrichie sous forme de **string** JSON (vs array 1-element dans l'original). Format nbformat valide (`source` accepte string OU array). Artefact standard de NotebookEdit, commun a travers le repo. Aucune cellule non-cible touchee.
- Pas de re-execution necessaire (C.2 exception markdown-only : aucune cellule code modifiee, outputs anterieurs valides).

## Scope

1 fichier, +prose markdown uniquement. `See #10488` (tranche partielle -- 1 notebook de la famille GenAI CaseStudies ; l'epic densite #10479/#10488 reste ouvert pour les autres notebooks thin).

See #10488 (partial).

---

Co-authored-by: Claude-Code <noreply@anthropic.com>
