### PR TITLE
feat(genai,#10488): enrich medical_chatbot markdown density (5 empty section headers fronting code)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Medical-Chatbot/medical_chatbot.ipynb
@@ -105,9 +105,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Import des bibliothèques\n"
-   ]
+   "source": "## Import des bibliothèques\n\nNous importons les briques de Semantic Kernel nécessaires à l'orchestration multi-agent : le `Kernel` (conteneur de services et de plugins), `ChatCompletionAgent` et `AgentGroupChat` (agents et orchestrateur de groupe), `TerminationStrategy` (fin de dialogue), le décorateur `@kernel_function` (pour exposer des fonctions comme outils) et `FunctionChoiceBehavior` (pour l'appel automatique de plugins par le LLM). Le type `Annotated` sert à documenter les paramètres de ces fonctions-plugin."
   },
   {
    "cell_type": "markdown",
@@ -288,9 +286,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Création du kernel Semantic Kernel"
-   ]
+   "source": "## Création du kernel Semantic Kernel\n\nLe `Kernel` est le conteneur central de Semantic Kernel : il regroupe le service d'IA et les plugins. La fonction `create_kernel()` instancie un kernel vierge puis y enregistre un service `OpenAIChatCompletion` (modèle `gpt-4o-mini`, clé API lue depuis l'environnement — jamais codée en dur). Factoriser cette construction dans une fonction permet de créer plusieurs kernels, par exemple un par agent si l'on souhaite les isoler."
   },
   {
    "cell_type": "code",
@@ -491,9 +487,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Création du Kernel"
-   ]
+   "source": "## Création du Kernel\n\nOn instancie ici le kernel **partagé** que les trois agents et leurs plugins utiliseront. Tous les `add_plugin` et toutes les créations d'agents qui suivent s'appuient sur cette même instance : c'est ce qui permet à l'IA médicale d'invoquer, via le kernel, les fonctions exposées par les plugins du médecin et du pharmacien."
   },
   {
    "cell_type": "code",
@@ -543,9 +537,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Ajout des plugins pour chaque agent"
-   ]
+   "source": "## Ajout des plugins pour chaque agent\n\n`kernel.add_plugin()` enregistre une instance de plugin sous un nom. Chaque plugin expose ses méthodes `@kernel_function` au kernel, qui les rend discoverable par le LLM. On enregistre ici les trois plugins médicaux (`doctor`, `medical`, `pharmacist`) sur le kernel partagé — ils seront invoquables automatiquement grâce au `FunctionChoiceBehavior.Auto()` configuré plus bas."
   },
   {
    "cell_type": "code",
@@ -775,9 +767,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Configuration pour que l'agent médical appelle automatiquement les plugins\n"
-   ]
+   "source": "## Configuration pour que l'agent médical appelle automatiquement les plugins\n\nPar défaut, un agent ne s'appuie que sur ses instructions textuelles. Pour qu'il puisse **invoquer les plugins** enregistrés dans le kernel, on active `FunctionChoiceBehavior.Auto()` dans ses `KernelArguments` : le LLM décide alors de lui-même, selon le contexte, d'appeler telle ou telle `@kernel_function` (gravité d'un symptôme, recommandation médicamenteuse…). On applique ce réglage à l'agent `IA_Medicale`, puis on crée le pharmacien sur le même modèle."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10630

## Summary

Tranche densite pedagogique #10488 sur `medical_chatbot.ipynb` (GenAI CaseStudies, suite de la tranche Fort-Boyard #10630). Le notebook est structurellement correct (3 exercices stubbes C.1, outputs reels, multi-agent SK avec plugins) mais **5 en-tetes de section etaient vides** : un titre `## ...` isole (21-78c) collant directement au code sans aucune introduction du concept.

Cette PR enrichit les 5 cellules avec une prose **WHAT/WHY** qui pose le concept Semantic Kernel avant le code (pattern densite #10479), en francais (FR = source de verite ; le twin `_en` est regenere par le cron translation-sync post-merge).

## Scope chirurgical : seules les 5 cellules dont l'en-tete colle au code

Le notebook comporte en realite 9 en-tetes de section vides, mais **4 ont deja une cellule d'introduction riche qui les suit immediatement** (prose WHAT/WHY deja presente dans la cellule markdown suivante). Enrichir ces 4 titres creerait de la **redondance**. Cette PR cible donc uniquement les 5 en-tetes qui precedent **directement du code** sans aucune explication intermediaire :

| Cell | Titre (avant) | Chars avant->apres | Concept SK introduit |
|---|---|---|---|
| [3] 4392065a | Import des bibliotheques | 28 -> 520 | briques SK importees (Kernel, agents, plugins, FunctionChoiceBehavior, Annotated) |
| [9] 6ee57404 | Creation du kernel SK | 37 -> 468 | `create_kernel()` factory : Kernel + OpenAIChatCompletion ; pourquoi factoriser |
| [16] c6adcae8 | Creation du Kernel | 21 -> 347 | instantiation du kernel **partage** (tous agents/plugins) |
| [18] 27e18741 | Ajout des plugins | 38 -> 415 | `kernel.add_plugin()` enregistre les 3 plugins medicaux (doctor/medical/pharmacist) |
| [27] f026c6bd | Config appel auto plugins | 78 -> 538 | `FunctionChoiceBehavior.Auto()` = le LLM decide d'invoquer les @kernel_function |

Les 4 en-tetes vides restants ([24] Creation agents, [29] Strategie terminaison, [34] Chat groupe, [37] Fonction dialogue) sont **exclus** : chacun est suivi d'une cellule markdown riche qui explique deja le concept. Les enrichir serait du padding redondant (interdit).

## Validation

- **Markdown-only (exception C.2)** : script de verification firsthand -- `0 cellule code changee` (assert `mc == wc` par cellule code), seules les 5 cibles markdown touchees, metadata + nbformat (4, minor 5) inchanges.
- **nbformat valide** : `nbformat.validate` PASS, 42 cellules (compte inchange).
- **3 exercices preserves** : stubs C.1 intacts (`result = None # TODO`, `print("Exercice a completer")`), aucun `raise NotImplementedError`, outputs preserves. Le notebook s'execute end-to-end.
- **Pas de DRIFT twin** : `medical_chatbot.ipynb` absent de `scripts/notebook_tools/twin_pairs.d/` (verifie). Le twin `_en` FR->EN est gere par le cron translation-sync (FR = source de verite, regenere post-merge ; translation-guard ne se declenche que sur hand-edit `_en`, translation-parity est advisory `continue-on-error`).
- **Pas de collision** : aucune PR ouverte sur `Medical-Chatbot/` (verifie `gh pr list --search`). Disjoint du claim po-2023 sur `ML/DataScienceWithAgents` (poche differente du meme epic #10488).

## Notes review

- Markdown-only : aucune re-execution necessaire (C.2 exception ; aucune cellule code modifiee, outputs anterieurs valides).
- Substance distincte de #10630 (Fort-Boyard) : concepts differents (plugins `@kernel_function` + `FunctionChoiceBehavior.Auto()` ici, vs `AgentGroupChat`+`TerminationStrategy` seuls la-bas), notebook different. Tranche legitime de l'epic densite #10488.

## Scope

1 fichier, +prose markdown uniquement. `See #10488` (tranche partielle -- 5/9 en-tetes vides ; les 4 restants ont deja leur prose en cellule suivante).

See #10488 (partial).

---

Co-authored-by: Claude-Code <noreply@anthropic.com>
