### PR TITLE
feat(case-studies,#10488): enrich Oncology-Planning markdown density (2 empty section headers, Search/Probas)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
@@ -39,9 +39,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Installation des Dépendances"
-   ]
+   "source": "## Installation des Dépendances\n\nCe cas d'étude assemble **trois paradigmes d'IA** distincts, chacun porté par une librairie Python dédiée : **RDFLib** (représentation des connaissances et raisonnement sur l'ontologie des médicaments), **OR-Tools** et son solveur **CP-SAT** (optimisation combinatoire pour planifier les cures sous contraintes de capacité), et **Pyro** (inférence bayésienne probabiliste sur le profil du patient). Pyro repose sur **PyTorch** comme backend tensoriel. Les dépendances sont pré-provisionnées via `CaseStudies/requirements.txt` : aucun `pip install` n'est requis, les imports se font directement à la cellule suivante."
   },
   {
    "cell_type": "code",
@@ -158,9 +156,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Partie 1 : Le Pharmacien Symbolique"
-   ]
+   "source": "## Partie 1 : Le Pharmacien Symbolique\n\nLa première partie relève de l'**IA symbolique** : on représente explicitement les connaissances du domaine (médicaments, toxicités, interactions) et on raisonne dessus par des règles déterministes. Elle se décompose en deux sous-parties complémentaires :\n\n- **1.1. Ontologie des médicaments (RDFLib)** — on construit une base de connaissances sous forme de graphe RDF (triplets sujet-prédicat-objet) qui encode la néphrotoxicité et les incompatibilités médicamenteuses, puis on l'interroge pour valider qu'une prescription est sûre.\n- **1.2. Planification des cures (OR-Tools CP-SAT)** — une fois les prescriptions validées, il faut les **placer dans le temps** : plusieurs protocoles concurrents se partagent des lits en nombre limité. CP-SAT co-optimise les dates de début pour respecter la capacité journalière tout en minimisant le makespan.\n\nL'approche symbolique garantit la **sûreté** (une interaction interdite est détectée à coup sûr), mais elle est rigide : elle ne sait pas gérer l'incertitude sur l'état réel du patient — ce sera le rôle de la Partie 2 (probabiliste)."
   },
   {
    "cell_type": "markdown",
@@ -1165,7 +1161,7 @@
    "version": "2.7.0"
   },
   "cost": {
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "api_provider": null,
    "cpu_min": 5,
    "gpu_min": 0,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10631

## Summary

Tranche densite pedagogique #10488 sur `Oncology-Planning.ipynb` (CaseStudies, devoir EPF 2026 OncoPlan). **Pivot de famille R6** : apres 2 tranches GenAI CaseStudies (#10630 Fort-Boyard, #10631 Medical-Chatbot, famille Semantic Kernel), celle-ci cible la famille **Search/Probas** (ontologie RDF + OR-Tools CP-SAT + inférence bayésienne Pyro) -- concepts substantiellement distincts.

Le notebook (version solution) est structurellement riche (3 exercices stubbes C.1, outputs reels, bilan detaillé) mais **2 en-tetes de section etaient vides** : un titre isole collant directement au code ou a un sous-en-tete, sans aucune introduction du concept.

## Scope chirurgical : 2 cellules genuinely-thin, 1 exclue (deja riche)

3 en-tetes vides detectes au scan, mais **1 est exclue** :

| Cell | Titre | Decision | Raison |
|---|---|---|---|
| [1] a08547b6 | Installation des Dependances | **ENRICHIE** | frontait le code d'imports (rdflib/ortools/pyro/torch) sans expliquer la stack 3-paradigmes |
| [6] c90453dc | Partie 1 : Le Pharmacien Symbolique | **ENRICHIE** | frontait directement le sous-en-tete `### 1.1` sans intro de partie (1.1 Ontologie + 1.2 Planification CP-SAT) |
| [18] b3f68345 | Partie 2 : Le Médecin Probabiliste (Pyro) | **EXCLUE** | immediatement suivie de `heading21onco` qui a DEJA une intro riche ("Dans cette deuxieme partie... modelise son incertitude...") -- enrichir = redondance |

## Defects (2) -- concept explique

| Cell | Chars avant->apres | Concept introduit |
|---|---|---|
| [1] a08547b6 | 31 -> 649 | stack 3 paradigmes : RDFLib (ontologie) + OR-Tools CP-SAT (optimisation combinatoire) + Pyro (bayésien, backend PyTorch) ; deps pre-provisionnees |
| [6] c90453dc | 38 -> 1121 | intro de partie : IA symbolique = 1.1 Ontologie RDF (base de connaissances, sûreté) + 1.2 Planification CP-SAT (co-optimisation capacité/makespan) ; lien vers Partie 2 probabiliste |

## Validation

- **Markdown-only (exception C.2)** : script de verification firsthand -- `0 cellule code changee` (assert `mc == wc` par cellule code), seules les 2 cibles markdown touchees, metadata + nbformat (4) inchanges. Aucune re-execution necessaire (aucune cellule code modifiee, outputs anterieurs valides).
- **nbformat valide** : `nbformat.validate` PASS, 30 cellules (compte inchange).
- **3 exercices preserves** : stubs C.1 intacts (`result = None # TODO`, `pass # TODO etudiant`, `print("Exercice a completer")`), aucun `raise NotImplementedError`. Le notebook s'execute end-to-end.
- **Pas de DRIFT twin** : `Oncology-Planning.ipynb` absent de `scripts/notebook_tools/twin_pairs.d/` (verifie). Pas de jumeau `_en` (cas-study EPF, non traduit). Pas de collision (aucune PR ouverte sur `Oncology-Planning/`, verifie `gh pr list`).
- **Pas de redondance** : la Partie 2 (cellule [18] exclue) a deja son intro riche ; la Partie 1 (enrichie) introduit les sous-parties 1.1/1.2 sans repeter le contenu du bilan final (cellule `cell-49e71cf1`).

## Notes review

- Famille differente de #10630/#10631 (Search/Probas vs GenAI Semantic Kernel) -- pivot R6, substance genuinement distincte. Genres/paradigmes differents (ontologie + CP-SAT + bayésien vs multi-agent SK).
- Pattern density markdown-only, 2 cellules. Markdown-only valide sans re-exec (regle F safe : aucune dependence d'execution).

## Scope

1 fichier, +prose markdown uniquement. `See #10488` (tranche partielle -- 1 notebook CaseStudies de la famille Search/Probas).

See #10488 (partial).

---

Co-authored-by: Claude-Code <noreply@anthropic.com>
