### PR TITLE
feat(lean,#2159): MayerVietorisSquare sheafCondition_iff #check -> proven theorem

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare.lean
@@ -103,7 +103,22 @@ l'application `toPullbackObj` de P(X₄) vers le produit fibré.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toPullbackObj
 
 -- Condition de faisceau ssi toPullbackObj est bijective (préfaisceaux à valeurs Type).
-#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_iff_bijective_toPullbackObj
+-- On promeut ce `#check` en une déclaration prouvée ci-dessous : c'est le fait
+-- pédagogique central du module (la prose l'annonçait sans preuve formelle).
+
+/-- Théorème pont : un préfaisceau de types P satisfait la condition de faisceau
+    de Mayer-Vietoris pour le carré S si et seulement si l'application canonique
+    `toPullbackObj` (de P(X₄) vers le produit fibré des fibres) est bijective.
+    C'est le critère concret qui relie la condition abstraite de carré pullback
+    à une énumération mesurable des sections. La preuve délègue au lemme nommé
+    `sheafCondition_iff_bijective_toPullbackObj` de Mathlib
+    (`CategoryTheory.Sites.MayerVietorisSquare`). -/
+theorem sheaf_condition_iff_bijective
+    [HasWeakSheafify J (Type v)]
+    (S : J.MayerVietorisSquare)
+    (P : Cᵒᵖ ⥤ Type v') :
+    S.SheafCondition P ↔ Function.Bijective (S.toPullbackObj P) :=
+  CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_iff_bijective_toPullbackObj S P
 
 /-! ## 4. Conséquences de la condition de faisceau
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
@@ -112,7 +112,22 @@ map `toPullbackObj P` from P(X₄) to the fiber product.
 #check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.toPullbackObj
 
 -- Sheaf condition iff toPullbackObj is bijective (Type-valued presheaves).
-#check @CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_iff_bijective_toPullbackObj
+-- We promote this `#check` into a proven declaration below: it is the central
+-- pedagogical fact of the module (the prose announced it without formal proof).
+
+/-- Bridge theorem: a Type-valued presheaf P satisfies the Mayer-Vietoris sheaf
+    condition for the square S if and only if the canonical map `toPullbackObj`
+    (from P(X₄) to the fiber product of the fibers) is bijective. This is the
+    concrete criterion relating the abstract pullback-square condition to a
+    measurable enumeration of sections. The proof delegates to the named lemma
+    `sheafCondition_iff_bijective_toPullbackObj` of Mathlib
+    (`CategoryTheory.Sites.MayerVietorisSquare`). -/
+theorem sheaf_condition_iff_bijective
+    [HasWeakSheafify J (Type v)]
+    (S : J.MayerVietorisSquare)
+    (P : Cᵒᵖ ⥤ Type v') :
+    S.SheafCondition P ↔ Function.Bijective (S.toPullbackObj P) :=
+  CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_iff_bijective_toPullbackObj S P
 
 /-! ## 4. Consequences of the sheaf condition
 


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA-2 — prev: MED/lean #10629

## feat(lean,#2159): MayerVietorisSquare sheafCondition_iff — `#check` → théorème prouvé

See #2159 (grain provisionné par ai-01, paths MayerVietorisSquare.lean dans mon claim ai-01). See EPIC #1646 Phase 9. **Grain MED/lean CONTENU** : transforme un `#check` de démo en un théorème prouvé (un préfaisceau satisfait la condition MV ssi `toPullbackObj` est bijective), avec `lake build` SUCCESS et 0 sorry.

**Substance genuinely distincte de #10629** (G-VAR-3) : #10629 portait sur SitePoints (foncteur fibre d'un point, namespace Mathlib `Point.Basic` / `sheafToPresheafCompPresheafFiberIso`). Ce grain porte sur MayerVietorisSquare (condition de recollement d'un carré pullback, namespace Mathlib `Sites.MayerVietorisSquare` / `sheafCondition_iff_bijective_toPullbackObj`). Modules et contenu mathématique différents.

## Livré

`MayerVietorisSquare.lean` — conversion du `#check ...sheafCondition_iff_bijective_toPullbackObj` en :

```lean
theorem sheaf_condition_iff_bijective
    [HasWeakSheafify J (Type v)]
    (S : J.MayerVietorisSquare)
    (P : Cᵒᵖ ⥤ Type v') :
    S.SheafCondition P ↔ Function.Bijective (S.toPullbackObj P) :=
  CategoryTheory.GrothendieckTopology.MayerVietorisSquare.sheafCondition_iff_bijective_toPullbackObj S P
```

Un préfaisceau P satisfait la condition de faisceau de Mayer-Vietoris ssi l'application canonique `toPullbackObj` (de P(X₄) vers le produit fibré des fibres) est bijective. C'est le fait pédagogique central du module — la prose l'introduisait déjà (« cela équivaut à la bijectivité de l'application `toPullbackObj` ») sans preuve formelle.

La preuve référence directement le lemme nommé Mathlib `sheafCondition_iff_bijective_toPullbackObj` (S passé explicite), suivant le pattern des 2 bridge theorems existants du fichier (`sheaf_satisfies_MV_condition` ligne 182, `glue_sections` ligne 193).

## Anti-régression (D)

- **0 sorry ajouté** : `grep -c sorry` avant/après = 0/0 réel (1 mention en commentaire d'en-tête « Tous les sorry éliminés à la création »).
- Aucune preuve/implémentation existante remplacée par `sorry`/stub : on **ajoute** une déclaration prouvée, on retire un `#check` de démo.
- `#check` count : 14 → 13 (sheafCondition_iff converti).
- Bridge theorem pattern canonique (le fichier en a déjà 2 ; c'est le 3ᵉ).

## Validation réelle

- `lake build Grothendieck.MayerVietorisSquare` : **SUCCESS** (post-modif, toolchain `leanprover/lean4:v4.31.0-rc1`, Mathlib v4.31.0-rc1).
- `grep -c sorry MayerVietorisSquare.lean` : 0 réel (avant et après).
- i18n EPIC #4980 : docstring FR par défaut, nom de déclaration + tactique en anglais.

## Sibling EN lockstep (i18n EPIC #4980)

[À confirmer post-build : même changement appliqué à `MayerVietorisSquare_en.lean` (`namespace Grothendieck_en.MayerVietorisSquare`), byte-identity sur la déclaration, docstring EN.]

## Critères d'acceptation #2159 (ai-01 dispatch)

- [x] ≥ 1 théorème/lemme propre ajouté dans MayerVietorisSquare.lean (transformation d'un `#check` en déclaration prouvée).
- [x] `lake build` SUCCESS (autorité CI confirmée firsthand sur la machine).
- [x] 0 sorry ajouté.
- [x] Tag Grain ligne 1 : `MED/lean — lane myia-po-2024:CoursIA-2 — prev: MED/lean #10629`.

## Garde-fous respectés

- **L898 ★★★** : pre-claim path-scan (aucune PR concurrente sur MayerVietorisSquare.lean ; claim posé commentaire issue #2159).
- **lane-claim** : paths globs séparés par virgules, jamais d'accolades (consigne ai-01).
- **catalog-pr-hygiene** : 0 catalogue touché.
- **L677-L4** : body PR HORS worktree (scratchpad).
- **anti-régression D** : 0 sorry, `lake build` SUCCESS.

## Liens

- Issue #2159 : https://github.com/jsboige/CoursIA/issues/2159
- EPIC #1646 (Grothendieck homage) : https://github.com/jsboige/CoursIA/issues/1646
- PR #10629 (SitePoints, cycle prec.) : https://github.com/jsboige/CoursIA/pull/10629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
