### PR TITLE
enrich(sudoku,#10488): Sudoku-6-AIMA-CSP density 641->834 c/cell — 6 thin WHAT headers -> WHAT+WHY

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb
@@ -203,6 +203,14 @@
    "source": [
     "## 2. Classe CSP générique\n",
     "\n",
+    "L'intérêt d'une classe *générique* est précisément l'abstraction : variables, domaines et\n",
+    "contraintes suffisent à décrire le problème, sans rien savoir de Sudoku. C'est ce qui\n",
+    "permet au même solveur AIMA de traiter indifféremment Sudoku, N-Queens ou coloration de\n",
+    "carte : seul change l'instanciation (variables = cases, domaines = 1..9, contraintes =\n",
+    "lignes/colonnes/blocs). Se restreindre aux contraintes *binaires* (entre paires) n'est\n",
+    "pas une limite pratique mais un choix standard : toute contrainte n-aire se ramène à un\n",
+    "réseau binaire équivalent, sur lequel AC-3 et le forward checking s'appliquent directement.\n",
+    "\n",
     "Nous définissons une classe CSP générique inspiree du livre AIMA. Cette classe represente un **CSP binaire** (contraintes entre paires de variables)."
    ]
   },
@@ -449,6 +457,14 @@
    },
    "source": [
     "## 4. Backtracking simple\n",
+    "\n",
+    "Ce backtracking « naïf » (DFS sur l'arbre des assignations, dans un ordre fixe) est surtout\n",
+    "la **ligne de base** par rapport à laquelle chaque amélioration se mesure. Sans lui, on ne\n",
+    "pourrait pas chiffrer le gain apporté par MRV, le forward checking ou MAC : le benchmark\n",
+    "le compare systématiquement aux variantes optimisées. Il explore un arbre de taille\n",
+    "exponentielle et ne détecte un conflit qu'au moment d'assigner une variable fautive —\n",
+    "c'est ce coût que les heuristiques suivantes vont réduire en coupant les branches mortes\n",
+    "le plus tôt possible.\n",
     "\n",
     "L'algorithme de **backtracking** est la base de toute résolution CSP. Il explore recursivement l'espace des assignations, détectant les conflits au fur et à mesure."
    ]
@@ -706,6 +722,15 @@
    "source": [
     "## 6. Backtracking améliore (MRV + LCV)\n",
     "\n",
+    "Le gain vient de la complémentarité des deux axes. **MRV** (Minimum Remaining Values)\n",
+    "choisit la variable la plus contrainte en premier — stratégie « échouer vite » : en\n",
+    "attaquant la cellule au domaine le plus petit, on détecte une impasse dès qu'elle\n",
+    "apparaît, au lieu de l'approfondir plus loin dans l'arbre. **LCV** (Least Constraining\n",
+    "Value) fait l'inverse côté valeurs : choisir la valeur qui élimine le moins d'options\n",
+    "pour les voisins, pour laisser le problème résoluble le plus longtemps possible.\n",
+    "Combinées, ces deux heuristiques d'ordonnancement réduisent la taille de l'arbre\n",
+    "exploré de plusieurs ordres de grandeur sur les puzzles difficiles.\n",
+    "\n",
     "Nous combinons les deux heuristiques pour obtenir un solveur beaucoup plus efficace."
    ]
   },
@@ -808,6 +833,14 @@
    },
    "source": [
     "## 7. Forward Checking\n",
+    "\n",
+    "Le bénéfice est temporel : le forward checking remonte l'instant de détection d'une\n",
+    "impasse d'un niveau. Au lieu d'attendre d'assigner un voisin incompatible pour\n",
+    "découvrir le conflit (backtracking simple), on élimine aussitôt les valeurs devenues\n",
+    "impossibles dans les domaines voisins. Si un domaine voisin se vide, on sait déjà que\n",
+    "la branche courante est morte et l'on revient en arrière immédiatement. Cela coupe\n",
+    "l'arbre « un étage plus haut » — d'où le saut de performance observé sur les puzzles\n",
+    "moyens, que confirme le benchmark ci-dessous.\n",
     "\n",
     "Le **Forward Checking** propage l'assignation d'une variable vers ses voisins immediats, reduisant leurs domaines et détectant les échecs plus tot."
    ]
@@ -1238,6 +1271,13 @@
    "source": [
     "## 10. Solveur AIMA pour Sudoku\n",
     "\n",
+    "Cette encapsulation est le vrai retour sur investissement du cadre AIMA : aucun solveur\n",
+    "ad hoc à écrire pour Sudoku. La classe ne fait que *brancher* le modèle Sudoku (variables,\n",
+    "domaines, contraintes) sur le backtracking générique et ses variantes — FC, AC-3, MAC.\n",
+    "L'interface `ISudokuSolver` garantit que tous les solveurs de la série (humain, Norvig,\n",
+    "CP-SAT…) sont interchangeables : on les compare alors sur le même puzzle, ce qui rend la\n",
+    "comparaison de performance honnête et reproductible.\n",
+    "\n",
     "Nous encapsulons tous les algorithmes dans une classe `AIMASolver` implementant `ISudokuSolver`."
    ]
   },
@@ -1336,6 +1376,14 @@
    },
    "source": [
     "## 11. Test et benchmark\n",
+    "\n",
+    "Le benchmark est ce qui rend les gains algorithmiques *visibles* plutôt que théoriques.\n",
+    "Sur un puzzle facile, les quatre stratégies atteignent la parité : le puzzle est si peu\n",
+    "contraint que même le backtracking naïf le résout vite, et l'écart se noie dans le bruit.\n",
+    "C'est sur les puzzles difficiles (peu de données initiales, beaucoup de retours en\n",
+    "arrière) que la hiérarchie se creuse : plain ≪ FC ≪ MAC, l'écart pouvant atteindre un\n",
+    "ordre de grandeur. Comparer sur *plusieurs* difficultés évite ainsi le piège d'une\n",
+    "conclusion tirée d'un seul puzzle, qui masquerait ou exagérerait les différences.\n",
     "\n",
     "Comparons les quatre stratégies sur des puzzles de différentes difficultés."
    ]

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-6-aima-csp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-6-aima-csp.yaml
@@ -8,7 +8,14 @@
       by: myia-po-2023:CoursIA
       python_sha: fe336af927a925430b9b91f845559017e8caddbc
       csharp_sha: 5fcb492875082155fdb8d9b04c7ce0fb450dfbb5
+    - date: "2026-08-12"
+      by: myia-po-2025:CoursIA
+      python_sha: fe336af927a925430b9b91f845559017e8caddbc
+      csharp_sha: f49a3f524bde652f648bf1723642b0c0e04be872
+      content_python_sha: 1005d0eeed15d6c02f845f062f3038639890e4248be4454e71a37f8c7eeb9820
+      content_csharp_sha: a3a208cc87cbcdb3d4a162facf7278097165110fced07fa99d946f9313107e64
   known_differences:
+    - "Edition C# twin 2026-08-12 (myia-po-2025:CoursIA, #10488 density ratchet) : enrichissement markdown du jumeau C# seul (641->834 c/cell, 6 en-tetes WHAT->WHAT+WHY : theorie CSP/backtracking -- genericite-abstraction, backtracking-naif comme baseline mesuree, MRV fail-fast + LCV leave-options-open, forward checking un niveau plus tot, ROI du framework AIMA, benchmark rend les gains visibles). Rattrapage PARTIEL du Python twin, deja dense (1011 c/cell, sections 'Interpretation' natives que le C# n'avait pas). Aucune divergence algorithmique : C.3 byte-identique (0 cellule code touchee, sources+outputs+exec_count inchanges) -- divergence markdown-only, le C# comble son retard pedagogique vers le Python, pas l'inverse."
     - "Socle pedagogique commun : resolution de Sudoku comme probleme de satisfaction de contraintes (CSP), suivant le formalisme AIMA (Artificial Intelligence: A Modern Approach) -- AC-3 (arc consistency / propagation de contraintes), backtracking avec heuristiques (MRV, LCV), assign/eliminate (Norvig-style propagation). Meme concept mathematique (variables, domaines, contraintes binaires, arc consistency), meme cas canonique (Sudoku). Les deux couvrent AC3, backtracking, Norvig, AIMA, csp."
     - "Divergence d'implementation : le Python (numpy, 19 cellules code) implemente le framework CSP a la AIMA (classe CSP, AC-3, backtracking) ; le C# (pur System.* stdlib, 0 NuGet, 18 cellules code) implemente le meme framework CSP (AC-3, backtracking, assign/eliminate) sans dependance externe. Paire proche d'une traduction native (meme algorithmes, meme structure AIMA), mais les 2 implementations restent independantes (idiomes langage, structures de donnees), d'ou parity_level semantic et non native-both."
     - "Idiomes framework : Python = numpy, 19 cellules code ; C# = pur System.* (System / System.Collections.Generic / System.Linq), 0 NuGet, 18 cellules code. Meme enseignement (CSP AIMA + AC-3 + backtracking), implementations independantes."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-python (#10639 ASPIC)

# enrich(sudoku,#10488): Sudoku-6-AIMA-CSP density 641->834 c/cell — 6 thin WHAT headers -> WHAT+WHY

See #10488

## What

Tranche of the density burn-down (#10488): `MyIA.AI.Notebooks/Sudoku/Sudoku-6-AIMA-CSP-Csharp.ipynb` sat at **641 markdown-chars/code-cell**, with 6 section headers that state WHAT the code does but never WHY it matters. Each is enriched with a grounded "pourquoi" block (CSP / backtracking theory), not generic padding. This is a **different family** from the same lane's just-delivered #10639 (Argument_Analysis) — genuine R6 family rotation, two distinct domain reasonings.

## The 6 enriched headers

| Header | WHY added (grounded in CSP/backtracking theory) |
|---|---|
| `## 2. Classe CSP générique` | Genericity is the point: variables+domains+constraints describe the problem knowing nothing of Sudoku → same AIMA solver handles N-Queens, map-coloring; binary constraints are the standard reducible form for AC-3/FC |
| `## 4. Backtracking simple` | Naive DFS is the **baseline** against which every optimization is measured; exponential tree, conflict detected only at assignment time — the cost MRV/FC/MAC reduce |
| `## 6. Backtracking amélioré (MRV + LCV)` | MRV = "fail fast" (most-constrained variable first), LCV = "leave options open" (least-constraining value); complementary orderings cut the tree by orders of magnitude |
| `## 7. Forward Checking` | Temporal benefit: detects dead-ends one level earlier by pruning neighbors' domains on assignment; empty neighbor domain = immediate backtrack, cuts the tree "one storey higher" |
| `## 10. Solveur AIMA pour Sudoku` | The ROI of the AIMA framework: no ad-hoc Sudoku solver — just plug the model into generic backtracking+variants; `ISudokuSolver` makes all series solvers interchangeable for honest comparison |
| `## 11. Test et benchmark` | Benchmarking is what makes algorithmic gains *visible*: easy puzzles reach parity (noise hides differences), hard puzzles reveal plain ≪ FC ≪ MAC; comparing across difficulties avoids single-puzzle bias |

## Validation

- **markdown-only edit (C.3 re-exec exception)**: `git diff` = `1 file changed, 48 insertions(+)`; `git diff | grep -cE '"(execution_count|outputs)"'` = **0** (no code cell source/output/exec_count touched — .NET Interactive markdown-only, no re-exec needed per §D advisory).
- **md-content-loss gate** (`detect_md_content_loss.py --base origin/main --check <nb>`): **0 findings**, all enriched cells grew (normalized_chars 9746 -> 12676, `stable=True`).
- **JSON integrity**: notebook re-parses OK; French accents verified firsthand (`précisément`, `échouer vite`, `naïf`, `≪` all present, no mojibake).
- **Method**: raw-text surgical by cell-index (exact-string replace on unique header lines), NOT `json.load`/`dump` (reser-destroy rule).

## Density delta

- BEFORE: 641 c/cell (md=11543, code_cells=18)
- AFTER: 834 c/cell (md=15019, code_cells=18) — **+3476 chars, +30%**

Residual below the ~1200 target remains (the notebook is inherently code-heavy: 18 C# solver/benchmark cells). The tranche targets the 6 genuinely-thin WHAT-sans-WHY headers.

## L898 / scope

- Sudoku-6-AIMA-CSP has **no** #10488 density PR (historical PRs are accents #2876, twin-parity #10439, benchmark #8242/#7787 — none density).
- Family rotation (R6): Sudoku (CSP/backtracking) is distinct from the same lane's #10639 (Argument_Analysis/ASPIC). Two MED/notebook tranches, two distinct domain reasonings, two different families — not monoculture.
- Atomic: 1 notebook, 1 subject (Sudoku-6 density tranche).

See #10488 (epic multi-lane, contribution partielle — pas Closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
