### PR TITLE
docs(lean,#10645): Lean-1-Setup WSL sections — mark Windows-only + macOS/Linux skip notes

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
@@ -1430,9 +1430,11 @@
    "source": [
     "---\n",
     "\n",
-    "### Configuration du kernel Lean 4 (WSL)\n",
+    "### Configuration du kernel Lean 4 (WSL) — Windows uniquement\n",
     "\n",
     "Le kernel **Lean 4 (WSL)** est utilisé pour les notebooks Lean natifs (Lean-2 à Lean-6).\n",
+    "\n",
+    "> **macOS / Linux** : passez cette section. WSL est spécifique à Windows ; sur macOS/Linux, le kernel `lean4` natif (configuré à la section précédente) fonctionne directement. La cellule ci-dessous se termine immédiatement (`[OK] Vous n'etes pas sur Windows`).\n",
     "\n",
     "Exécutez la cellule suivante pour configurer automatiquement ce kernel :"
    ]
@@ -1820,9 +1822,11 @@
     "tags": []
    },
    "source": [
-    "### Configuration du kernel Python WSL (pour notebooks 7-8)\n",
+    "### Configuration du kernel Python WSL (pour notebooks 7-8) — Windows uniquement\n",
     "\n",
     "Les notebooks **Lean-7-LLM-Integration** et **Lean-8-Agentic-Proving** utilisent un kernel Python qui s'execute dans WSL pour avoir acces a l'environnement Lean.\n",
+    "\n",
+    "> **macOS / Linux** : passez cette section. Sur macOS/Linux, la cellule ci-dessous détecte la plateforme et installe directement les packages via `pip` dans votre environnement Python courant (Lean étant déjà accessible via `elan`) — aucun kernel WSL nécessaire.\n",
     "\n",
     "**Packages installes automatiquement :**\n",
     "- `python-dotenv` - Chargement des variables d'environnement\n",


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA-2 — prev: LIGHT/docs #10579

## Summary

Part of EPIC #10643 (cross-platform Linux/macOS support). Adresses the **Lean-1-Setup** half of #10645.

The two WSL kernel-configuration markdown sections — "Configuration du kernel Lean 4 (WSL)" and "Configuration du kernel Python WSL (pour notebooks 7-8)" — did **not** signal they are Windows-only. A macOS/Linux reader could believe WSL configuration was required before proceeding, when in fact the corresponding code cells already guard on `platform.system()` and skip cleanly.

**Fix** (markdown-only, 6 insertions / 2 deletions):
- Added `— Windows uniquement` suffix to both section titles.
- Added a blockquote `> **macOS / Linux** : passez cette section…` note pointing to the native `lean4` kernel (for the Lean-4-WSL section) and to direct `pip` install (for the Python-WSL section), mirroring the style already used by GameTheory-1-Setup cell 2.7.

## ⚠️ Reassessment (G.1) — the setup notebooks are NOT the big work

Reading the notebooks firsthand corrects the #10645 inventory, which claimed `wsl.exe×8` makes Lean-1-Setup "block Mac/Linux at the first cell". That is **false**:

| Cell | Cross-platform status |
|------|----------------------|
| `LeanInstaller` (cell 5) | ✅ Handles Windows (PowerShell + `elan-init.ps1`) AND macOS/Linux (`curl … elan-init.sh`) via `_install_elan_windows` / `_install_elan_unix` |
| SIGPIPE patch (cell 14) | ✅ `if platform.system() != "Windows": print("non necessaire"); return True` |
| `WSLKernelManager.run_diagnostic` (cell 16) | ✅ `if not self.is_windows: print("[OK] Utilisez le kernel lean4 standard"); return` |
| Python-WSL cell (after 9f3d4507) | ✅ `if platform.system() == "Windows": … else: pip install direct` |

**GameTheory-1-Setup is already exemplary** — explicit per-OS table (cell 4), "(Windows uniquement)" marker on its WSL section (cell 26), and a dedicated `else: print("Plateforme Linux/Mac - OpenSpiel installe directement.")` branch. **No change needed there.**

➡️ The substantive cross-platform work of EPIC #10643 lives in **#10644** (`scripts/environment/` `.sh` companions — `setup_environment.sh` is the real bootstrap blocker for a Mac/Linux user), **not** in the setup notebooks. This PR closes the small markdown-clarity gap in #10645 honestly rather than padding it.

## Validation

- [x] Markdown-only edit (C.2 exception — no re-exec needed): raw-text surgery, **not** a json round-trip, to avoid the source-list-collapse + `papermill.duration 0.0 → 0` metadata drift that `NotebookEdit` introduces on this file.
- [x] C.3 byte-identical: 0 code cell, 0 output, 0 `execution_count`, 0 papermill-metadata line touched. Diff = 6 insertions / 2 deletions, exactly the 2 targeted markdown source blocks.
- [x] JSON valid post-edit.
- [x] French content + accents preserved (à, é, è, — cadratin, backticks).
- [x] 0 `raise NotImplementedError` / `assert False` / `1/0` (C.1 — unchanged, none introduced).

## Test plan

- [ ] CI `pr-gate` flips CLEAN (markdown-only, no code path changed).
- [ ] Visual: open the notebook, confirm both WSL sections now display the Windows-only marker and the macOS/Linux skip note.

See #10645, #10643 (EPIC). Not `Closes` — #10645 also covers GameTheory-1-Setup, which needs no change but the sub-issue stays open until the Epic acceptance is reviewed by the coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

