### PR TITLE
fix(twin-registry,#10439): remove duplicate bridge_verdict keys in 5 GT pairs (blocks CI)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15-cooperativegames.yaml
@@ -3,8 +3,6 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-15-CooperativeGames-Csharp.ipynb
   parity_level: semantic
-  bridge_verdict: SOTA-OK
-  bridge_verdict_reason: "Modele #10382 solver-free par conception : theorie des jeux algorithmique enseignee from-scratch des deux cotes (l algorithme - induction arriere, existence Nash, SPE, formes extensive/combinatoire/cooperative - EST la lecon ; il n existe pas de bibliotheque .NET canonique de solveur de jeu a invoquer, contrairement aux paires lib-vs-lib comme PyMC/Infer.NET ou scikit/ML.NET). Les deux cotes atteignent le SOTA de leur ecosysteme pour cet objectif pedagogique : reimplementation didactique du formalisme mathematique. Pair verifiee firsthand (census moteur : CS=scratch, PY=scratch)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-15c-cooperativegames.yaml
@@ -3,8 +3,6 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-15c-CooperativeGames-Csharp.ipynb
   parity_level: semantic
-  bridge_verdict: SOTA-OK
-  bridge_verdict_reason: "Modele #10382 solver-free par conception : theorie des jeux algorithmique enseignee from-scratch des deux cotes (l algorithme - induction arriere, existence Nash, SPE, formes extensive/combinatoire/cooperative - EST la lecon ; il n existe pas de bibliotheque .NET canonique de solveur de jeu a invoquer, contrairement aux paires lib-vs-lib comme PyMC/Infer.NET ou scikit/ML.NET). Les deux cotes atteignent le SOTA de leur ecosysteme pour cet objectif pedagogique : reimplementation didactique du formalisme mathematique. Pair verifiee firsthand (census moteur : CS=scratch, PY=scratch)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4c-nashexistence.yaml
@@ -3,8 +3,6 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-4c-NashExistence-Csharp.ipynb
   parity_level: semantic
-  bridge_verdict: SOTA-OK
-  bridge_verdict_reason: "Modele #10382 solver-free par conception : theorie des jeux algorithmique enseignee from-scratch des deux cotes (l algorithme - induction arriere, existence Nash, SPE, formes extensive/combinatoire/cooperative - EST la lecon ; il n existe pas de bibliotheque .NET canonique de solveur de jeu a invoquer, contrairement aux paires lib-vs-lib comme PyMC/Infer.NET ou scikit/ML.NET). Les deux cotes atteignent le SOTA de leur ecosysteme pour cet objectif pedagogique : reimplementation didactique du formalisme mathematique. Pair verifiee firsthand (census moteur : CS=scratch, PY=scratch)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-6c-repeatedgames-folktheorem.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-6c-repeatedgames-folktheorem.yaml
@@ -3,8 +3,6 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-6c-RepeatedGames-FolkTheorem-Csharp.ipynb
   parity_level: semantic
-  bridge_verdict: SOTA-OK
-  bridge_verdict_reason: "Modele #10382 solver-free par conception : theorie des jeux algorithmique enseignee from-scratch des deux cotes (l algorithme - induction arriere, existence Nash, SPE, formes extensive/combinatoire/cooperative - EST la lecon ; il n existe pas de bibliotheque .NET canonique de solveur de jeu a invoquer, contrairement aux paires lib-vs-lib comme PyMC/Infer.NET ou scikit/ML.NET). Les deux cotes atteignent le SOTA de leur ecosysteme pour cet objectif pedagogique : reimplementation didactique du formalisme mathematique. Pair verifiee firsthand (census moteur : CS=scratch, PY=scratch)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-8c-combinatorialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-8c-combinatorialgames.yaml
@@ -3,8 +3,6 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-8c-CombinatorialGames-Csharp.ipynb
   parity_level: semantic
-  bridge_verdict: SOTA-OK
-  bridge_verdict_reason: "Modele #10382 solver-free par conception : theorie des jeux algorithmique enseignee from-scratch des deux cotes (l algorithme - induction arriere, existence Nash, SPE, formes extensive/combinatoire/cooperative - EST la lecon ; il n existe pas de bibliotheque .NET canonique de solveur de jeu a invoquer, contrairement aux paires lib-vs-lib comme PyMC/Infer.NET ou scikit/ML.NET). Les deux cotes atteignent le SOTA de leur ecosysteme pour cet objectif pedagogique : reimplementation didactique du formalisme mathematique. Pair verifiee firsthand (census moteur : CS=scratch, PY=scratch)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/notebook-dotnet #10563

## Defaut sur main : cle dupliquee `bridge_verdict` dans 5 paires GT

Le test `test_twin_registry_integrity.py::test_no_duplicate_keys_anywhere` FAIL sur main depuis le merge de #10592 (tranche 10 GT variantes).

**Cause** : deux tranches ont annoté les mêmes 5 paires sans que git ne détecte le conflit :
- `#10577` (tranche 5, merged) a écrit `bridge_verdict: SOTA-OK` juste après `parity_level:` (bloc générique "solver-free")
- `#10592` (tranche 10, merged) a écrit `bridge_verdict: RECOVERABLE-LOCAL` après `audits:` (verdict pair-par-pair détaillé)

Les deux blocs coexistent dans le YAML → clé dupliquée → le loader strict de CI lève `ConstructorError`.

## Correction

**Garder le verdict `RECOVERABLE-LOCAL` de #10592** (le plus récent, le plus spécifique, pair-par-pair) et supprimer le bloc `SOTA-OK` de #10577 (bloc générique blanket).

Raison : #10592 a fait l'analyse pair-par-pair (numpy/scipy/matplotlib vs System.Linq, asymétrie de medium/visualisation). Le verdict SOTA-OK de #10577 était un blanket-annotation du modèle "solver-free" — il est moins précis que l'analyse individuelle de #10592.

## Preuve

- `test_no_duplicate_keys_anywhere` : **29/29 passed** localement après fix (était FAIL sur main)
- `yaml.safe_load` valide sur les 5 fichiers corrigés
- Scan dup-key sur les 158 fichiers du registre : **0 FAIL**
- `check_twin_parity.py --check` : à confirmer en CI

## Périmètre

5 fichiers `scripts/notebook_tools/twin_pairs.d/gametheory-*.yaml` : suppression du bloc `bridge_verdict: SOTA-OK` + `bridge_verdict_reason` générique (2 lignes chacun). **Aucun notebook modifié.**

See #10439 (registre twin-parity). See #10382.
