### PR TITLE
fix(search,#3801): Search-11 Prong-B intro Sphere 2D -> Rastrigin 2D (degenerate -> multimodal)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics.ipynb
@@ -305,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "mealpy-basics",
    "metadata": {
     "execution": {
@@ -323,397 +323,397 @@
     },
     "tags": []
    },
-   "outputs": [
+      "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: OriginalPSO(epoch=50, pop_size=20, c1=2.05, c2=2.05, w=0.4)\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: OriginalPSO(epoch=50, pop_size=20, c1=2.05, c2=2.05, w=0.4)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 1, Current best: 0.8544016729187397, Global best: 0.8544016729187397, Runtime: 0.00214 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 1, Current best: 6.697871149751119, Global best: 6.697871149751119, Runtime: 0.00277 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 2, Current best: 0.09876076266075642, Global best: 0.09876076266075642, Runtime: 0.00240 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 2, Current best: 2.573868551103004, Global best: 2.573868551103004, Runtime: 0.00249 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 3, Current best: 0.09876076266075642, Global best: 0.09876076266075642, Runtime: 0.00153 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 3, Current best: 2.573868551103004, Global best: 2.573868551103004, Runtime: 0.00311 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 4, Current best: 0.09876076266075642, Global best: 0.09876076266075642, Runtime: 0.00153 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 4, Current best: 2.573868551103004, Global best: 2.573868551103004, Runtime: 0.00273 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 5, Current best: 0.09054765059413095, Global best: 0.09054765059413095, Runtime: 0.00149 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 5, Current best: 2.573868551103004, Global best: 2.573868551103004, Runtime: 0.00386 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 6, Current best: 0.05627387963070656, Global best: 0.05627387963070656, Runtime: 0.00289 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 6, Current best: 2.573868551103004, Global best: 2.573868551103004, Runtime: 0.00384 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 7, Current best: 0.006349402307666002, Global best: 0.006349402307666002, Runtime: 0.00246 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 7, Current best: 2.2850527129723304, Global best: 2.2850527129723304, Runtime: 0.00381 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 8, Current best: 0.006349402307666002, Global best: 0.006349402307666002, Runtime: 0.00190 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 8, Current best: 2.25216273202836, Global best: 2.25216273202836, Runtime: 0.00514 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 9, Current best: 0.006349402307666002, Global best: 0.006349402307666002, Runtime: 0.00190 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 9, Current best: 1.6838873348767436, Global best: 1.6838873348767436, Runtime: 0.00352 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 10, Current best: 0.004007395382454317, Global best: 0.004007395382454317, Runtime: 0.00156 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 10, Current best: 1.6838873348767436, Global best: 1.6838873348767436, Runtime: 0.00353 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 11, Current best: 0.003433965415809011, Global best: 0.003433965415809011, Runtime: 0.00189 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 11, Current best: 1.0065474159414443, Global best: 1.0065474159414443, Runtime: 0.00307 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 12, Current best: 0.0007430935148185295, Global best: 0.0007430935148185295, Runtime: 0.00225 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 12, Current best: 1.0065474159414443, Global best: 1.0065474159414443, Runtime: 0.00310 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 13, Current best: 0.0004326069799593442, Global best: 0.0004326069799593442, Runtime: 0.00156 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 13, Current best: 1.0065474159414443, Global best: 1.0065474159414443, Runtime: 0.00246 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 14, Current best: 0.00011705296594473962, Global best: 0.00011705296594473962, Runtime: 0.00162 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 14, Current best: 0.9967216925834492, Global best: 0.9967216925834492, Runtime: 0.00280 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 15, Current best: 0.00011705296594473962, Global best: 0.00011705296594473962, Runtime: 0.00167 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 15, Current best: 0.9967216925834492, Global best: 0.9967216925834492, Runtime: 0.00256 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 16, Current best: 8.837189197281913e-07, Global best: 8.837189197281913e-07, Runtime: 0.00236 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 16, Current best: 0.9967216925834492, Global best: 0.9967216925834492, Runtime: 0.00227 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 17, Current best: 8.837189197281913e-07, Global best: 8.837189197281913e-07, Runtime: 0.00151 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 17, Current best: 0.9962818712024628, Global best: 0.9962818712024628, Runtime: 0.00258 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 18, Current best: 3.4642262457853235e-08, Global best: 3.4642262457853235e-08, Runtime: 0.00175 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 18, Current best: 0.9950856349914545, Global best: 0.9950856349914545, Runtime: 0.00272 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 19, Current best: 3.4642262457853235e-08, Global best: 3.4642262457853235e-08, Runtime: 0.00238 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 19, Current best: 0.9950856349914545, Global best: 0.9950856349914545, Runtime: 0.00277 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 20, Current best: 3.4642262457853235e-08, Global best: 3.4642262457853235e-08, Runtime: 0.00140 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 20, Current best: 0.9950856349914545, Global best: 0.9950856349914545, Runtime: 0.00273 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 21, Current best: 3.4642262457853235e-08, Global best: 3.4642262457853235e-08, Runtime: 0.00153 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 21, Current best: 0.9950856349914545, Global best: 0.9950856349914545, Runtime: 0.00264 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 22, Current best: 1.0788321297746315e-08, Global best: 1.0788321297746315e-08, Runtime: 0.00176 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 22, Current best: 0.9950856349914545, Global best: 0.9950856349914545, Runtime: 0.00209 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 23, Current best: 3.4975635066736277e-10, Global best: 3.4975635066736277e-10, Runtime: 0.00213 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 23, Current best: 0.9950097022509965, Global best: 0.9950097022509965, Runtime: 0.00281 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 24, Current best: 3.4975635066736277e-10, Global best: 3.4975635066736277e-10, Runtime: 0.00138 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 24, Current best: 0.9950097022509965, Global best: 0.9950097022509965, Runtime: 0.00210 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 25, Current best: 3.4975635066736277e-10, Global best: 3.4975635066736277e-10, Runtime: 0.00191 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 25, Current best: 0.9949916106479932, Global best: 0.9949916106479932, Runtime: 0.00290 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 26, Current best: 3.2856615034979095e-10, Global best: 3.2856615034979095e-10, Runtime: 0.00175 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 26, Current best: 0.9949832632349782, Global best: 0.9949832632349782, Runtime: 0.00230 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 27, Current best: 3.2856615034979095e-10, Global best: 3.2856615034979095e-10, Runtime: 0.00237 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 27, Current best: 0.9949674992800297, Global best: 0.9949674992800297, Runtime: 0.00210 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 28, Current best: 3.2856615034979095e-10, Global best: 3.2856615034979095e-10, Runtime: 0.00217 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 28, Current best: 0.9949594793204426, Global best: 0.9949594793204426, Runtime: 0.00272 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 29, Current best: 3.1007680172827384e-10, Global best: 3.1007680172827384e-10, Runtime: 0.00160 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 29, Current best: 0.9949594793204426, Global best: 0.9949594793204426, Runtime: 0.00223 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 30, Current best: 2.687271399652119e-10, Global best: 2.687271399652119e-10, Runtime: 0.00177 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 30, Current best: 0.9949591587363535, Global best: 0.9949591587363535, Runtime: 0.00251 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 31, Current best: 2.0089025449424811e-10, Global best: 2.0089025449424811e-10, Runtime: 0.00166 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 31, Current best: 0.9949591587363535, Global best: 0.9949591587363535, Runtime: 0.00339 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 32, Current best: 1.8576997786655788e-10, Global best: 1.8576997786655788e-10, Runtime: 0.00153 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 32, Current best: 0.9949591473104746, Global best: 0.9949591473104746, Runtime: 0.00252 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 33, Current best: 7.93438815052637e-11, Global best: 7.93438815052637e-11, Runtime: 0.00152 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 33, Current best: 0.9949591473104746, Global best: 0.9949591473104746, Runtime: 0.00210 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 34, Current best: 8.91856844051393e-12, Global best: 8.91856844051393e-12, Runtime: 0.00152 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 34, Current best: 0.9949590983786649, Global best: 0.9949590983786649, Runtime: 0.00254 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 35, Current best: 8.91856844051393e-12, Global best: 8.91856844051393e-12, Runtime: 0.00143 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 35, Current best: 0.9949590918142803, Global best: 0.9949590918142803, Runtime: 0.00229 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 36, Current best: 8.91856844051393e-12, Global best: 8.91856844051393e-12, Runtime: 0.00148 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 36, Current best: 0.9949590918142803, Global best: 0.9949590918142803, Runtime: 0.00399 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 37, Current best: 8.91856844051393e-12, Global best: 8.91856844051393e-12, Runtime: 0.00152 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 37, Current best: 0.994959069865164, Global best: 0.994959069865164, Runtime: 0.00339 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 38, Current best: 1.2199630070426774e-12, Global best: 1.2199630070426774e-12, Runtime: 0.00150 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 38, Current best: 0.9949590661861833, Global best: 0.9949590661861833, Runtime: 0.00457 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 39, Current best: 1.2199630070426774e-12, Global best: 1.2199630070426774e-12, Runtime: 0.00157 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 39, Current best: 0.9949590661861833, Global best: 0.9949590661861833, Runtime: 0.00734 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 40, Current best: 3.924865596357087e-13, Global best: 3.924865596357087e-13, Runtime: 0.00154 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 40, Current best: 0.994959064203556, Global best: 0.994959064203556, Runtime: 0.00744 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 41, Current best: 3.101136461633753e-14, Global best: 3.101136461633753e-14, Runtime: 0.00153 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 41, Current best: 0.994959058434759, Global best: 0.994959058434759, Runtime: 0.00619 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 42, Current best: 3.101136461633753e-14, Global best: 3.101136461633753e-14, Runtime: 0.00175 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 42, Current best: 0.994959057505227, Global best: 0.994959057505227, Runtime: 0.00659 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 43, Current best: 5.128228311941282e-15, Global best: 5.128228311941282e-15, Runtime: 0.00148 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 43, Current best: 0.994959057481065, Global best: 0.994959057481065, Runtime: 0.00377 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 44, Current best: 5.128228311941282e-15, Global best: 5.128228311941282e-15, Runtime: 0.00168 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 44, Current best: 0.994959057159857, Global best: 0.994959057159857, Runtime: 0.00286 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:53 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 45, Current best: 5.128228311941282e-15, Global best: 5.128228311941282e-15, Runtime: 0.00165 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 45, Current best: 0.994959057159857, Global best: 0.994959057159857, Runtime: 0.00381 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:54 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 46, Current best: 5.128228311941282e-15, Global best: 5.128228311941282e-15, Runtime: 0.00228 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 46, Current best: 0.994959057113391, Global best: 0.994959057113391, Runtime: 0.00312 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:54 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 47, Current best: 5.128228311941282e-15, Global best: 5.128228311941282e-15, Runtime: 0.00156 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 47, Current best: 0.9949590571056994, Global best: 0.9949590571056994, Runtime: 0.00263 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:54 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 48, Current best: 1.4685919970485477e-17, Global best: 1.4685919970485477e-17, Runtime: 0.00152 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 48, Current best: 0.9949590570972511, Global best: 0.9949590570972511, Runtime: 0.00253 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:54 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 49, Current best: 1.4685919970485477e-17, Global best: 1.4685919970485477e-17, Runtime: 0.00156 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 49, Current best: 0.9949590570961746, Global best: 0.9949590570961746, Runtime: 0.00338 seconds\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026/06/05 02:55:54 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 50, Current best: 1.4685919970485477e-17, Global best: 1.4685919970485477e-17, Runtime: 0.00149 seconds\n"
+      "2026/08/12 08:51:55 PM, INFO, mealpy.swarm_based.PSO.OriginalPSO: >>>Problem: P, Epoch: 50, Current best: 0.9949590570958335, Global best: 0.9949590570958335, Runtime: 0.00271 seconds\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Resultat PSO sur fonction quadratique:\n",
-      "  Solution: [0. 0.]\n",
-      "  Objectif: 0.000000\n",
-      "  Optimal attendu: [0, 0] avec f=0\n"
+      "Resultat PSO sur Rastrigin 2D (fonction multimodale):\n  Solution: [ 0.995 -0.   ]\n  Objectif: 0.994959\n  Optimal global: [0, 0] avec f=0 (mais optima locaux nombreux)\n"
      ]
     }
    ],
-   "source": [
-    "# Exemple simple : optimiser une fonction quadratique\n",
-    "def simple_quadratic(solution):\n",
-    "    \"\"\"Fonction quadratique simple : f(x) = sum(x^2).\"\"\"\n",
-    "    return np.sum(solution**2)\n",
+      "source": [
+    "# Exemple : optimiser une fonction multimodale (Rastrigin)\n",
+    "def rastrigin(solution):\n",
+    "    \"\"\"Fonction de Rastrigin : f(x) = 10*n + sum(x**2 - 10*cos(2*pi*x)).\n",
+    "    Multimodale : un optimum global en [0, 0] mais des dizaines d'optima locaux.\"\"\"\n",
+    "    n = len(solution)\n",
+    "    return 10*n + np.sum(solution**2 - 10*np.cos(2*np.pi*solution))\n",
     "\n",
     "# Definir le probleme (MEALPy 3.0.2 API)\n",
-    "bounds = [FloatVar(lb=-10, ub=10), FloatVar(lb=-10, ub=10)]\n",
+    "# Bornes canoniques de Rastrigin : [-5.12, 5.12]\n",
+    "bounds = [FloatVar(lb=-5.12, ub=5.12), FloatVar(lb=-5.12, ub=5.12)]\n",
     "problem = Problem(\n",
     "    bounds=bounds,\n",
     "    minmax=\"min\",\n",
-    "    obj_func=simple_quadratic\n",
+    "    obj_func=rastrigin\n",
     ")\n",
     "\n",
-    "# Resoudre avec PSO\n",
+    "# Resoudre avec PSO : la swarm doit echapper aux optima locaux\n",
     "model = PSO.OriginalPSO(epoch=50, pop_size=20)\n",
     "result = model.solve(problem)\n",
     "\n",
-    "print(\"Resultat PSO sur fonction quadratique:\")\n",
+    "print(\"Resultat PSO sur Rastrigin 2D (fonction multimodale):\")\n",
     "print(f\"  Solution: {result.solution.round(4)}\")\n",
     "print(f\"  Objectif: {result.target.fitness:.6f}\")\n",
-    "print(f\"  Optimal attendu: [0, 0] avec f=0\")"
+    "print(f\"  Optimal global: [0, 0] avec f=0 (mais optima locaux nombreux)\")"
    ]
   },
   {
@@ -729,22 +729,24 @@
     },
     "tags": []
    },
-   "source": [
+      "source": [
     "### Interpretation : Premier contact avec MEALPy\n",
     "\n",
-    "**Sortie obtenue** : PSO trouve une solution proche de [0, 0].\n",
+    "**Sortie obtenue** : PSO trouve une solution proche de l’optimum global [0, 0], mais pas toujours exactement. Rastrigin est **multimodale** : elle regorge d’optima locaux (les cuvettes du paysage cosinusoïdal), et selon l’initialisation la swarm peut s’y piéger — la valeur objectif est alors de l’ordre de 1 à 2, pas 0.\n",
     "\n",
     "| élément | Valeur | Signification |\n",
     "|---------|--------|---------------|\n",
-    "| Solution | Vecteur de 2 valeurs | Position dans l'espace 2D |\n",
-    "| Objectif | Valeur proche de 0 | Qualite de la solution |\n",
-    "| Optimal attendu | [0, 0], f=0 | Solution théorique |\n",
+    "| Solution | Vecteur de 2 valeurs | Position dans l’espace 2D |\n",
+    "| Objectif | ≈0 si échappée, ~1-2 si piégée | Qualité de la solution |\n",
+    "| Optimal global | [0, 0], f=0 | Solution théorique |\n",
+    "\n",
+    "C’est précisément la difficulté qui **justifie une métaheuristique** : une descente de gradient se figerait dans le premier optimum local rencontré, tandis que la swarm de PSO explore plusieurs régions et peut en sortir. Le prochain notebook approfondit comment l’équilibre exploration/exploitation y contribue.\n",
     "\n",
     "**Points cles** :\n",
-    "1. L'API MEALPy 3.0.2 utilise `FloatVar` pour définir les bornes de recherche\n",
+    "1. L’API MEALPy 3.0.2 utilise `FloatVar` pour définir les bornes de recherche\n",
     "2. La fonction objectif recoit un vecteur numpy et retourne un scalaire\n",
     "3. Le résultat contient `solution` (vecteur) et `target.fitness` (valeur)\n",
-    "4. Le paramètre `bounds` remplace les anciens paramètres `lb` et `ub` separes"
+    "4. Le paramètre `bounds` remplace les anciens paramètres `lb` et `ub` séparés"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
@@ -25,6 +25,12 @@
       csharp_sha: ac366782eb567725eea37d1aa9fe0264a3ab1541
       content_python_sha: f32ad054a97210011f3cb1b6d3776a0c85521c28c813183d6d319277a64fb6ca
       content_csharp_sha: dce689a469dd323686332ca9508192b5f6f410f7511d562dc87bbead6c45dcc8
+    - date: "2026-08-12"
+      by: myia-po-2025:CoursIA
+      python_sha: cf7c0c90de2c19135cf22e6274fa4e3e8ef971b1
+      csharp_sha: ac366782eb567725eea37d1aa9fe0264a3ab1541
+      content_python_sha: ce983432ad9240c487af0a22fd4cae25fa7e6ff8a3e69af5316a0bebdc35e5a6
+      content_csharp_sha: dce689a469dd323686332ca9508192b5f6f410f7511d562dc87bbead6c45dcc8
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: |
     Python = MEALPy (librairie metaheuristique 40+ algos, MIT) -- vrai SOTA ecosysteme Python. C# = GeneticSharp (librairie .NET GA/evolutionnaire reference, LGPL) post Tranche 2 -- vrai SOTA ecosysteme .NET. Les DEUX cotes branchent une librairie native de leur ecosysteme (mealpy + geneticsharp). Tranche 1 C# from-scratch (PSO/SA/GA) preservee + Tranche 2 ajoute GeneticSharp sur 4 fonctions benchmark -- lib-vs-lib cote-a-cote avec from-scratch. Asymetrie de couverture (ABC + BRO cote Python, GA + TSP cote C#) asumee native-both parity_level. Verdict SOTA-OK.
@@ -33,3 +39,4 @@
     - "Bibliotheque vs from-scratch : Python invoque MEALPy (librairie metaheuristique, 40+ algorithmes) pour PSO/ABC/SA/BRO ; C# implemente PSO/SA/GA from-scratch PUIS, en Tranche 2 (§10), branche GeneticSharp (librairie .NET de reference pour l'evolutionnaire, socle de MetaGeneticSharp) sur les 4 fonctions de benchmark -- lib-vs-lib cote-a-cote avec le from-scratch. Les deux jumeaux invoquent desormais une librairie native (mealpy cote Python, GeneticSharp cote C#)."
     - "Asymetrie de couverture algorithmique : Python couvre PSO + ABC (Artificial Bee Colony) + SA + BRO (Brownian) via MEALPy ; C# couvre PSO + SA + GA (Genetic Algorithm) + un exemple TSP (recuit simule). GA et TSP sont propres au C# ; ABC et BRO sont propres au Python."
     - "Stochasticite : les deux cotes sont sedeables mais non deterministes (optimisation stochastique) -- parite conceptuelle (meme famille d'algorithmes, memes fonctions de benchmark), pas bitwise."
+    - "Intro Prong-B catch-up (2026-08-12, #3801) : l'intro MEALPy Python (cellule mealpy-basics) portait PSO sur Sphere 2D (degenere -- optimum unique convexe, la capacite swarm d'echapper aux optima locaux invisible). Remplacee par Rastrigin 2D (multimodale, 10n + sum(x^2-10cos(2pi*x)), bornes [-5.12,5.12]) -- G.9 mesure 3/5 runs pieges sur un optimum local (fitness ~1-2, pas 0). C# twin INCHANGE ce grain (pas de cellule intro Sphere equivalente modifiee). Les cellules 11-13 Python (benchmarks) utilisaient deja Rastrigin -- l'intro etait l'incoherence residuelle."


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet

# fix(search,#3801): Search-11 Prong-B — PSO intro Sphere 2D (degenerate) -> Rastrigin 2D (multimodal)

See #3801

## What

`Search-11-Metaheuristics.ipynb` (Python) opened its MEALPy introduction running PSO on **Sphere 2D** (`f(x) = sum(x^2)`): a convex single-optimum bowl where PSO's distinctive swarm capability (escaping local optima) is invisible — the swarm converges to [0,0] instantly, indistinguishable from a trivial gradient descent. This is the canonical Prong-B degeneracy (cf sota-not-workaround.md: BFS vs A* on uniform-cost graph, commit 8905f8845).

The markdown cell `exploration-exploitation` (immediately before) teaches "escape local optima", "explore broadly at the start", No Free Lunch — directly contradicted by a Sphere demo where there is nothing to escape. The rest of the notebook (cells 11-13) already uses **Rastrigin** (multimodal). The intro cell was the outlier.

**Fix**: intro objective Sphere 2D -> **Rastrigin 2D** (`f(x) = 10n + sum(x^2 - 10cos(2pi*x))`, canonical bounds [-5.12, 5.12]) — multimodal, riddled with local optima. PSO's exploration/exploitation tradeoff is now exercised visibly.

## G.9 anti-fabrication — measured discrimination firsthand

PSO on Rastrigin 2D, 5 seeds (epoch=50, pop_size=20), miniconda3 / mealpy 3.0.2:
- run 0: fitness 0.995 (trapped, local optimum [-0.995, 0])
- run 1: fitness 1.990 (trapped, [-0.995, 0.995])
- run 2: fitness 0.000 (global optimum)
- run 3: fitness 0.000 (global optimum)
- run 4: fitness 0.995 (trapped, [0, -0.995])

**3 of 5 runs stay trapped** on a local optimum (fitness ~1-2). On Sphere, every run = 0 instantly (no local optima exist). The swarm-capacity is exercised and the residual is visible. This grounds the interp cell claim "peut s'y piéger — fitness de l'ordre de 1 à 2".

## Changes (2 cells)

1. **Code cell `mealpy-basics`** (idx 8): `simple_quadratic` (Sphere) -> `rastrigin` (multimodal), bounds [-10,10] -> [-5.12,5.12], print labels updated. Re-executed (exec_count 4 -> 5).
2. **Markdown cell `interp-mealpy-basics`** (idx 9): interp rewritten — "sortie proche de [0,0]" -> multimodal explanation (swarm can be trapped ~1-2) + paragraph justifying why a metaheuristic beats gradient descent here. Points cles (API MEALPy) preserved.

## Validation

- **C.2 re-exec**: papermill on kernel miniconda3-base (mealpy 3.0.2) — SUCCESS. Output shows PSO trapped at fitness ~0.99 on local optimum [-0.995, 0] (consistent with the 3/5-trapped measurement).
- **C.3 scope**: injected ONLY mealpy-basics outputs into the worktree notebook; all other cells (benchmarks, plots) byte-preserved — zero churn on unmodified cells. Method: papermill -> scratchpad, extract single cell outputs, raw-text surgical inject.
- **md-content-loss gate** (`detect_md_content_loss.py --base origin/main --check`): **0 findings**, stable=True, normalized_chars 23525 -> 24020 (grew, no truncation).
- **JSON integrity**: notebook re-parses OK; French accents verified firsthand (`cosinusoïdal`, `piéger`, `échappée`, `précisément`, `métamodale` absent -> c'est "multimodale" sans accent, `séparés`).
- **C.1**: no `raise NotImplementedError` / `assert False` / `1/0`.
- **Method**: raw-text surgical by cell-id (escape-aware extraction + json.dumps rebuild), NOT json.load/dump (reser-destroy rule, PR #10170).

## L898 / scope

- Search-11 Python untouched by any open PR (`gh pr list --search "Search-11"` = 0 on this notebook). The C# twin (#6701 Tranche 2 GeneticSharp) is on `Search-11-Metaheuristics-Csharp.ipynb` — distinct file, no collision. The `feature/search11-lib-vs-lib` branch (#10382) has zero diff on this file.
- #3801 (Prong-B problem-richness) is CLOSED but sota-not-workaround.md remains active — this enforces the standing rule, not the epic.
- Twin parity: rebaselined via `check_twin_parity.py --update` (python_sha moved by the edit); known_differences line added documenting the Prong-B intro catch-up.

See #3801 (rule standing, epic closed — pas Closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
