### PR TITLE
docs(sl,#10646): SL-12 CompiledLogicNet gcc install — add macOS/Linux hints

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12-DifferentiableLogicGateNetworks.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-12-DifferentiableLogicGateNetworks.ipynb
@@ -809,7 +809,7 @@
     "\n",
     "Cette voie est marquee **RECOVERABLE-MACHINE** car elle necessite :\n",
     "\n",
-    "1. `gcc` dans le PATH (installable via `choco install mingw`)\n",
+    "1. `gcc` dans le PATH (installable via `choco install mingw` sur Windows, `brew install gcc` ou `xcode-select --install` sur macOS, `sudo apt install gcc` sur Linux)\n",
     "2. Un modèle déjà entraine et fige (eval mode)\n",
     "3. Données d'entree booleennes (numpy ou torch)\n",
     "\n",


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2023:CoursIA -- prev: LIGHT/docs #10649

## Summary

Part of EPIC #10643 (cross-platform Linux/macOS support). Adresses the **SL-12** half of #10646 (applicative notebooks with Windows-only content).

The `CompiledLogicNet` section of SL-12 (RECOVERABLE-MACHINE, advanced) documented `gcc` as installable only via `choco install mingw` (Windows). A macOS/Linux reader reaching that section had no install hint for their platform — even though the code cell is already functionally cross-platform (`shutil.which("gcc")` works everywhere; once gcc is in the PATH by any means, the `else` branch runs and compiles).

**Fix** (markdown-only, 1 insertion / 1 deletion): the single gcc-install bullet now covers all three OSes:
- Windows : `choco install mingw`
- macOS : `brew install gcc` ou `xcode-select --install`
- Linux : `sudo apt install gcc`

## Why markdown-only (code cell left untouched)

The neighbouring code cell (`cell-16`, the RECOVERABLE-MACHINE stub) also contains a Windows-only print string (`"Pour activer : choco install mingw puis re-executer."`). It is intentionally **not** modified here: that cell depends on upstream training variables (`model`, `test_loader`) which would require a full GPU difflogic/MNIST re-exec to reproduce — disproportionate for a documentation fix. The code path itself is already OS-agnostic (`shutil.which("gcc")` + `gcc` in PATH works regardless of how gcc was installed), so the print string is a non-blocking secondary detail, not a functional defect.

## ⚠️ G.1 reassessment — #10646 inventory is largely false-positive

Reading the 8 target notebooks firsthand (not trusting the regex inventory) corrects the #10646 scope significantly:

| Notebook | Inventory claim | Reality (firsthand) |
|---|---|---|
| Sudoku-11-Choco-Csharp | `choco` (Win pkg mgr) | **False positive** — `choco` = Choco-solver Java CP lib (the notebook's subject), not Chocolatey. Install is `pip install jpype1` + Maven JAR download. **Already cross-platform.** |
| Sudoku-11-Choco-Python | `choco` | Same — **already cross-platform.** |
| SL-5-InverseResolution-Py | `winget` | The cell already has an OS branch: `"Windows : winget install SWI-Prolog ; Linux : apt install swi-prolog"`. **Already cross-platform.** |
| SL-5-InverseResolution-Csharp | (listed) | No real Win-only signal. **Already cross-platform.** |
| **SL-12-LogicGates** | `choco install mingw` | **Real defect** — gcc install Windows-only. → **This PR.** |
| SMT-10-Witness | `.ps1 ref` | **Path absent** on origin/main (inventory path wrong). |
| GenAI-Image-QwenEdit | `.ps1 ref` | **Path absent** on origin/main. |
| GenAI-Audio-Basic | Win pkg mgr | **Path absent** on origin/main. |
| **Search-10-Automata** | `choco install graphviz` | **Real defect** — Graphviz install Windows-only. → **Next PR** (separate, different domain). |

➡️ Only **2 of 8** notebooks have a real cross-platform defect: SL-12 (gcc, this PR) and Search-10 (graphviz, next PR). The rest are false positives (choco-solver ≠ Chocolatey) or already guarded (SL-5 OS branch) or path-inventory errors. The substantive scope of #10646 is far smaller than the inventory suggested.

## Validation

- [x] Markdown-only edit (C.2 exception — no re-exec): raw-text surgery, not json round-trip.
- [x] C.3 byte-identical: 1 insertion / 1 deletion, exactly the targeted gcc-install bullet. 0 code cell, 0 output, 0 `execution_count`, 0 papermill-metadata drift.
- [x] JSON valid post-edit.
- [x] French + accents preserved, backticks preserved.

## Test plan

- [ ] CI `pr-gate` flips CLEAN (markdown-only, no code path changed).

See #10646, #10643 (EPIC). Not `Closes` — #10646 also covers Search-10 (graphviz, separate PR) plus the 4 path-inventory items to re-verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
