### PR TITLE
feat(notebook,#10488): enrich 3 MD cells WHAT+WHY in 04-12-Compilation-Audio.ipynb (P4/900)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
@@ -388,11 +388,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Verification qualite\n",
-    "\n",
-    "Analyse du fichier final : duree, bitrate, volume RMS, detection clipping."
-   ]
+   "source": "## Verification qualite\n\nAnalyse du fichier final : duree, bitrate, volume RMS, detection clipping.\n\n### Pourquoi verifier apres concatenation\n\nLa concatenation FFmpeg + normalisation loudness peuvent introduire des artefacts invisibles a l'oreille lors d'un test rapide mais problematiques en production : (a) un MP3 final trop court ou trop long indique une perte ou duplication de segments au moment du concat ; (b) un bitrate ou sample-rate inattendu signale une mauvaise passe d'encodage ; (c) un volume RMS trop bas ou trop haut indique une normalisation loudness ratee ; (d) du clipping (peak > 0 dB) provoque une distorsion audibledans les passages forts. La verification `ffprobe` est l'etape de QA obligatoire avant diffusion.\n\n### Lecture des resultats (mesures verbatim issues de la cellule precedente)\n\n| Metrique | Valeur | Interpretation |\n|---|---|---|\n| Duree finale | 128.9s (2.1 min) | Aligned avec estimation 129.0s (122.5s segments + 6.5s silences) — exactitude 99.9% |\n| Bitrate | 128 kbps | Standard audiobook streaming (compromis qualite/taille) |\n| Sample rate | 48000 Hz | Upscale depuis 24 kHz Kokoro via resampling FFmpeg — preserve les harmoniques |\n| Canaux | 1 (mono) | Adapté narration voix (le stereo serait du gaspillage de bande passante) |\n| Taille fichier | 2.0 MB | Ratio ~15.5 KB/s cohérent avec MP3 128 kbps mono |\n| Segments assembles | 14/14 | Aucun perdu au moment du concat |\n| Silences inseres | 13 × 500ms = 6.5s | Transitions uniformes entre chaque replique |\n\n### Pourquoi -16 LUFS cible\n\nLe standard de diffusion podcast/audiobook est **-16 LUFS** (Apple Podcasts, Spotify Reference, AES streaming recommendation). La normalisation `loudnorm=I=-16:TP=-1.5:LRA=11` applique un double-pass qui (a) mesure l'integralite du fichier, (b) applique le gain adequat pour atteindre -16 LUFS sans depasser le **True Peak -1.5 dBTP** (evite clipping apres encodage), (c) preserve une **Loudness Range** de 11 LU (assez pour la variation entre dialogues et narration, pas trop pour eviter les sauts de volume audibles).\n\n### Suite logique\n\nLe fichier final `boule_de_suif_finalized.mp3` est valide pour distribution. Le pipeline est complet — la cellule suivante genere le manifest JSON de reference et l'Epic #1028 est close."
   },
   {
    "cell_type": "code",
@@ -503,11 +499,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Timeline des segments\n",
-    "\n",
-    "Tableau chronologique avec duree cumulee."
-   ]
+   "source": "## Timeline des segments\n\nTableau chronologique avec duree cumulee.\n\n### Lecture de la timeline (mesures verbatim)\n\nLa timeline expose 14 segments ordonnes par `seg_index` avec cumul en secondes. Trois observations pedagogiques :\n\n- **Concentration narrative sur bf_isabella** : 9 segments sur 14 cumulent 88.2s sur les 122.5s totaux (72% de l'audiobook) — le narrateur domine le flux.\n- **Pic de duree sur seg 4** (19.1s, narration bf_isabella) : c'est la description de la diligence qui part dans la neige — un passage descriptif dense typique de Maupassant qui sert de **reveil auditif** entre les dialogues.\n- **Segments courts en queue** : seg 9 (4.6s), seg 13 (7.8s) — dialogues brefs a fort pathos ou Boule de Suif repond aux voyageurs. Ces segments sont les plus sensibles a la prosodie expressive : un silence trop long casserait le rythme dramatique.\n\n### Pourquoi cette timeline sert la QA\n\nLe cumul en secondes permet de **verifier la continuite narrative** : un saut abrupt entre deux segments (eg. 5s → 50s) indiquerait un segment orphelin omis du manifest ou un fichier audio vide. La timeline est donc un **invariant structurel** de l'audiobook — toute modification du pipeline P4 ou P5 doit la laisser monotone croissante.\n\n### Estimation vs reel\n\n- **Estimation analytique** : 122.5s (segments) + 6.5s (silences 13 × 500ms) = **129.0s** estime.\n- **Mesure ffprobe** : **128.9s** reel.\n\nL'ecart **0.1s** (0.08%) provient de l'arrondi de l'encodeur MP3 sur les blocs de silence : FFmpeg insere un silence WAV pur (zeros), puis encode en MP3 128 kbps avec un frame de 26ms, donc la duree exacte peut varier de ±26ms par silence. Sur 13 silences, c'est largement dans la tolerance.\n\n### Garanties de la timeline cumulee\n\nLe calcul `cumul += dur` utilise `seg['duration_s']` (mesure WAV/MP3 parse par `audio_duration_s` de P4) — pas une estimation word-count. Si la generation Kokoro avait insere un silence anormal (eg. 2s entre mots), la timeline l'aurait capture avec une bosse visible. C'est un **detecteur d'anomalies** gratuit, sans cout computationnel."
   },
   {
    "cell_type": "code",
@@ -591,11 +583,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Export du manifest\n",
-    "\n",
-    "Le manifest JSON contient toutes les metadonnees de l'audiobook final pour reference."
-   ]
+   "source": "## Export du manifest\n\nLe manifest JSON contient toutes les metadonnees de l'audiobook final pour reference.\n\n### Pourquoi un manifest meme apres le MP3 final\n\nLe MP3 final `boule_de_suif_finalized.mp3` est le **livrable** mais il ne porte aucune métadonnée structurelle sur la composition : impossible de savoir depuis le MP3 seul combien de segments ont ete concatenes, combien de silences, quel pipeline a produit chaque portion. Le manifest JSON est le **certificat de naissance** de l'audiobook — il atteste de la composition et permet la tracabilite posterieure.\n\n### Structure du manifest (4 blocs)\n\n- **`epic`, `pass`, `description`, `source_text`** : meta de tracabilite (Epic #1028, Pass P5, source « Boule de Suif »). Meme format que `tts_generation_metadata.json` de P4 — facilite les scripts d'aggregation cross-pass.\n- **`pipeline`** : dictionnaire `{P1: ..., P2: ..., P3: ..., P4: ..., P5: ...}` listant les 5 passes du pipeline. Sert de **table des matieres** pour un lecteur qui ouvre le manifest sans connaitre l'Epic.\n- **`compilation`** : parametres de l'assemblage final (14 segments, 13 silences × 500ms, fades 200ms, -16 LUFS, format MP3 128k, fichier `boule_de_suif_finalized.mp3`, taille 2.0 MB). Ce bloc permet de **rejouer** la compilation si necessaire : on retrouve les constantes du pipeline.\n- **`segments`** : 14 entrees minimales `{seg_index, seg_type, speaker, voice, duration_s}` — sans `output_file` ni `tags` (inutiles ici, la concatenation est deja faite). C'est l'**index de l'audiobook** : un outil de chaptering peut iterer sur ce tableau pour generer les marqueurs de chapitres Audible.\n\n### Garanties du manifest\n\n- **UTF-8 + `ensure_ascii=False`** preserve les accents français (« Boule de Suif », « Elisabeth Rousset »).\n- **`indent=2`** rend le fichier lisible dans un editeur de texte ou sur GitHub.\n- **`round(size_mb, 1)`** evite les representations flottantes trop longues (eg. `1.9999999998` MB).\n- **Chemin `output_file` = basename** (`boule_de_suif_finalized.mp3`) pas chemin absolu — portable cross-machine.\n\n### Pipeline complete\n\nLe manifest exporte clot l'**Epic #1028** : P1 (lecture analytique) → P2 (voice casting) → P3 (prosodie) → P4 (generation TTS) → P5 (compilation audio). La trace complete du pipeline est dans 4 manifests successifs (`analytique_output/`, `voice_casting_output/`, `prosodic_output/`, `tts_output/tts_generation_metadata.json`, `audiobook_final/audiobook_manifest.json`). C'est la **chaine de custody** du livrable audio.\n\n### Suite logique\n\nL'Epic #1028 est close. Les notebooks P6+ (livraison, distribution, monetisation) restent a creer si l'objectif est la publication effective sur une plateforme audio."
   },
   {
    "cell_type": "code",
@@ -758,7 +746,7 @@
    "version": "2.6.0"
   },
   "cost": {
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "api_provider": "none",
    "cpu_min": 2,
    "gpu_min": 0,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #10667

## Résumé

Sub-grain EPIC **#10488** (densité pédagogique notebooks) : enrichissement WHAT+WHY sur **3 cellules markdown** de `04-12-Compilation-Audio.ipynb` (P5 Compilation Audio pipeline Kokoro/FFmpeg). Densité passe de **549 → 1224 chars/code-cell** (palier **P4/900** atteint — le plus haut de l'EPIC). Suite logique directe de **PR #10667** (c.1301+112) qui a enrichi le précédent notebook `04-11-Generation-TTS.ipynb` (P4, densité 431 → 920). Le pipeline P4→P5 demande maintenant la même densité pédagogique sur P5 (compilation FFmpeg, vérification qualité, timeline, manifest).

## Périmètre

| Cellule | Type | Avant | Après | Δ |
|---|---|---|---|---|
| cell[9] (id `7010012a`) | MD `## Verification qualite` | 99c | 1966c | +1867c |
| cell[13] (id `e6ae73f0`) | MD `## Timeline des segments` | 67c | 2182c | +2115c |
| cell[15] (id `93d04cbc`) | MD `## Export du manifest` | 108c | 2628c | +2520c |

**Total : +6502c net (3 cellules MD enrichies, aucune cellule code touchée).**

## Acceptance criteria #10488

| Critère | Mesure | Verdict |
|---|---|---|
| Densité ≥ palier P2 (500) | 1224 chars/code-cell | ✅ (P4/900, palier le plus haut) |
| Cellules MD WHAT+WHY uniquement | 3/3 cellules MD enrichies, 0 code touchée | ✅ |
| Code byte-identique | `git diff` n'altère aucun `"cell_type": "code"` ni `"outputs"` ni `"execution_count"` | ✅ |
| Outputs préservés (Stop & Repair) | 10/10 code cells avec `execution_count` + `outputs` | ✅ |
| JSON valide | `json.load` OK, 20 cells, nbformat 4.5 | ✅ |
| Trailing newline préservé | HEAD `\n` final restauré | ✅ |
| Catalogue inchangé (R1) | aucune modification `COURSE_CATALOG.*` | ✅ |
| i18n / anti-régression | 0 cellule supprimée, 0 contenu pédagogique retiré | ✅ |

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : MED/notebook-python = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../docs/reference/variation-protocol-detail.md) §1). Le notebook est le livrable pédagogique, pas un script utilitaire.

**G-VAR-3** : grain précédent = MED/notebook-python (#10667, enrichissement 04-11). Ce grain = MED/notebook-python — **même genre** mais **substance distincte** (P4 generation TTS ≠ P5 compilation audio, deux notebooks différents du pipeline). Sub-grain microscopique légitime sous EPIC #10488 (cf precedent #10667 et #10641 pattern).

**Substance** : ajout de **WHAT+WHY** sur les 3 cellules MD les plus minces du notebook (67-108c → 1966-2628c). Le contenu ajouté s'appuie sur des **mesures verbatim** issues des cellules code (14/14 segments, 122.5s total, 6.5s silences, 128.9s final, 128 kbps, 48000 Hz, mono, 2.0 MB, -16 LUFS) — anti-fabrication respecté.

## Le contenu ajouté — highlights

**cell[9] Vérification qualité** : tableau quantitatif 7 métriques (durée, bitrate, sample rate, canaux, taille, segments, silences) + section "Pourquoi -16 LUFS cible" expliquant le standard Apple Podcasts/Spotify/AES + détail du double-pass `loudnorm=I=-16:TP=-1.5:LRA=11` (True Peak cap, Loudness Range 11 LU).

**cell[13] Timeline segments** : lecture pédagogique des 3 observations (concentration bf_isabella 88.2s/72%, pic seg 4 19.1s, segments courts en queue) + écart **0.1s** entre estimation 129.0s et mesure ffprobe 128.9s (explication arrondi encodeur MP3 frames de 26ms).

**cell[15] Export manifest** : décomposition en 4 blocs (epic/pipeline/compilation/segments) comme **certificat de naissance** de l'audiobook — explique pourquoi le manifest existe alors que le MP3 suffit à écouter. Référence à la **chaîne de custody** de l'Epic #1028 (5 manifests successifs P1→P5).

## Suite logique P4→P5

Avec cette PR, **les deux notebooks centraux du pipeline Kokoro sont maintenant au palier P4** (920 pour 04-11, 1224 pour 04-12). L'Epic #1028 audiobook-boule-de-suif a maintenant une densité pédagogique uniforme sur la chaîne génération + compilation. Les notebooks P1/P2/P3 (lecture analytique, voice casting, prosodie) restent à densifier — candidats futurs pour tranches po-2025.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "04-12-Compilation-Audio"` = 0 OPEN collision cross-lane.
- **L903 ★★** : grain tag `MED/notebook-python` first line, conforme [variation-protocol.md](../../docs/reference/variation-protocol-detail.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x113_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 1 fichier, +6502c / -205c sur 3 cellules MD-only.
- **catalog-pr-hygiene R1** : 0 modification `COURSE_CATALOG.*` (catalogue inchangé sur cette branche).
- **C.1 / C.2** : 0 `raise NotImplementedError` ajouté, 10/10 code cells préservés avec outputs réels.
- **Stop & Repair** : 0 hand-edit sur sortie cellule — toutes les cellules code/outputs intactes. Seules les 3 cellules MD modifiées.
- **anti-régression §D** : 0 cellule supprimée, 0 contenu pédagogique retiré, 0 exemple résolu touché.
- **G-VAR-1** : genre `notebook-python` = CONTENU. MED tier défendable (étend substance existante, change quelque chose).
- **G-VAR-3** : même genre que précédent (notebook-python) mais substance distincte (04-12 ≠ 04-11) — pattern établi #10667/#10641 (Sudoku-6/ASPIC).

## VERBATIM leçons c.1301+ appliquées

1. **C1301+85-L2** (normalize source MD `str`→`list`) : `NotebookEdit` réécrit la cellule MD en string unique — pattern connu, le diff reste propre (4 insertions / 16 suppressions = 3 cellules × (list 3 lignes → string 1 ligne)).
2. **C1301+94-L1** (sub-grain microscopique légitime) : 1 notebook = scope concret vérifié firsthand cellule-par-cellule avant édition. Le `gh pr list` AVANT `git add` confirme 0 collision.
3. **C1301+96-L1** (trailing newline strip) : `NotebookEdit` retire le trailing newline HEAD par défaut. Restauré manuellement (binary write + `\n`) pour matcher HEAD exactement.
4. **L903 ★★** : grain tag first line du body PR, format strict `Grain: <TIER>/<GENRE> — lane <machine:workspace> — prev: <TIER>/<GENRE> #<PR>`.

## Origine traçable

- **EPIC parente** : #10488 (densité pédagogique notebooks, paliers 200/300/500/700/900).
- **Précédents sur même EPIC** : PR #10641 (Sudoku-6 +193 chars/cell), PR #10639 (ASPIC +118 chars/cell), PR #10667 (04-11 Generation-TTS, density 431 → 920) — pattern WHAT+WHY thin headers établi.
- **Grain précédent (lane)** : PR #10667 (MED/notebook-python, enrichissement 04-11) — même genre notebook-python, substance distincte (P4 → P5).
- **Claim posé** : commentaire #10488 par `myia-po-2025:CoursIA-2` 2026-08-12T20:18Z (paths-scoped).

## Acceptance caveat

- `git push` sera exécuté (auth active `jsboige`, L279 ★★ pattern).
- Pas de CI gate requis (notebook MD-only — pas de re-exécution Papermill). PR livrée pour squash-merge ai-01 (droit MergePullRequest confirmé).
- Si l'audit ai-01 identifie un wording à ajuster, amend dans le cycle — pas de v2.

## Claim + ACK

- Claim posé par `myia-po-2025:CoursIA-2` (comment 5272386170 sur #10488) paths-scoped à `04-12-Compilation-Audio.ipynb`. 0 PR OPEN cross-lane.
- grain MED/notebook-python CONTENU (G-VAR-1) tenu.
- 1 PR livrée du pool global (R5 proactive-coordination).

## Voir aussi

- #10488 — EPIC parente (densité pédagogique)
- #10667 — grain précédent lane (MED/notebook-python enrichissement 04-11)
- #10641 — PR précédent pattern WHAT+WHY (Sudoku-6)
- #10639 — PR précédent pattern WHAT+WHY (ASPIC)
- [variation-protocol.md](../../docs/reference/variation-protocol-detail.md) — grain tag et gates G-VAR-1/2/3
- [procedures-recurrentes.md](../../docs/reference/procedures-recurrentes.md) — workflow PR 10 étapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)