### PR TITLE
feat(twin-parity,#10382): ML-6 ONNX bridge_verdict SOTA-OK + reclass native-both

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml
@@ -2,7 +2,10 @@
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
-  parity_level: semantic
+  parity_level: native-both
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: |
+    Les DEUX cotes pontent le MEME engine d'inference ONNX Runtime (par Microsoft) via les bindings officiels natifs de leur ecosysteme. Python = onnxruntime (20 refs sur 6 cells : InferenceSession, inference iris_model.onnx) + skl2onnx (export) + onnx (inspection). C# = #r "nuget: Microsoft.ML.OnnxRuntime, 1.16.0" + Microsoft.ML.OnnxTransformer 3.0.0 + using Microsoft.ML.Transforms.Onnx, exec_count=1/2 (ApplyOnnxModel sur iris_model.onnx reellement execute). Verdict SOTA-OK : vrai moteur SOTA installe ET invoque des deux cotes (regle sota-not-workaround Prong A). Reclass semantic -> native-both : les deux jumeaux invoquent un engine externe de production (le critere #10382). L'asymetrie export-vs-load (Python producteur via skl2onnx, C# consommateur) reste documentee dans known_differences et n'affecte pas le pont inference (le coeur SOTA). Firsthand G.1 worktree origin/main, myia-po-2025:CoursIA 2026-08-12.
   audits:
     - date: "2026-08-04"
       by: myia-po-2024:CoursIA-2


### PR DESCRIPTION
Grain: MED/twin — lane myia-po-2025:CoursIA — prev: MED/docs (#10665)

# feat(twin-parity,#10382): ML-6 ONNX bridge_verdict SOTA-OK + reclass native-both

See #10382, #10439

## What

`scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml` portait `parity_level: semantic` **sans aucun `bridge_verdict`** (1 des 13 paires du registre sans verdict). Le registre documentait pourtant deja dans `known_differences` que les deux cotes pontent ONNX Runtime -- sans jamais l'avoir verdicte ni reclassifie.

**Fix** : ajout `bridge_verdict: SOTA-OK` + `bridge_verdict_reason` (evidence-cited) + reclass `semantic -> native-both`.

## G.1 audit firsthand (worktree frais origin/main 6f54b8498)

Les DEUX jumeaux invoquent le **meme engine d'inference ONNX Runtime (par Microsoft)** via les bindings officiels natifs de leur ecosysteme :

- **Python** (`ML/ML.Net/ML-6-ONNX-Python.ipynb`) : `import onnxruntime` -- **20 refs sur 6 cells** (`InferenceSession`, inference `iris_model.onnx`) + `skl2onnx` (export sklearn->ONNX) + `onnx` (inspection structurelle). Vrai engine SOTA.
- **C#** (`ML/ML.Net/ML-6-ONNX.ipynb`) : `#r "nuget: Microsoft.ML.OnnxRuntime, 1.16.0"` + `#r "nuget: Microsoft.ML.OnnxTransformer, 3.0.0"` + `using Microsoft.ML.Transforms.Onnx`, **exec_count=1/2** (`mlContext.Transforms.ApplyOnnxModel` sur `iris_model.onnx` reellement execute). Vrai engine SOTA.

Verdict **SOTA-OK** : vrai moteur installe ET invoque des deux cotes (regle [sota-not-workaround](../blob/main/.claude/rules/sota-not-workaround.md) Prong A -- ni workaround degrade, ni cas degenere). Reclass `semantic -> native-both` : les deux jumeaux invoquent un engine externe de production (le critere #10382).

## Complementaire, pas doublon

L'**asymetrie export-vs-load** (Python = producteur via `skl2onnx`, C# = consommateur du `iris_model.onnx` pre-exporte) reste documentee dans `known_differences` (deja present, inchange) et **n'affecte pas le pont inference** -- le coeur SOTA (ONNX Runtime) est branche des deux cotes. C'est exactement la parite PyMC-vs-Infer.NET citee en exemple nominal par l'owner sur #10382 : 2 moteurs qui brillent chacun de leur cote.

## Validation

- `python scripts/notebook_tools/check_twin_parity.py --check --family "ML.NET/Python"` : **OK=9 DRIFT=0 MISSING=0**, exit 0. ML-6 affiche `[OK] ML-6 ONNX Integration (ML.NET/Python, native-both)`.
- `pytest scripts/notebook_tools/tests/ -k duplicate_keys` : **1 passed** (le guard `test_no_duplicate_keys_anywhere` qui avait casse #10656 sur gametheory-15 -- ici pas de cle dupliquee, ajout net).
- YAML valide (single-item list, parse OK), `bridge_verdict_reason` block-scalar evidence-cited.
- 0 notebook modifie, 0 re-exec (yaml registry-only). +4/-1 sur 1 fichier.

See #10382 (Epic lib-vs-lib, See pas Closes -- 131 paires residuelles), #10439 (twin-parity verdict mechanisme).

Genere avec [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
