### PR TITLE
docs(rules,#10459): checklist 6 axes obligatoire pour verdict INTRINSIC (NEW c.8243)

### DIFF
--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -22,6 +22,25 @@ Avant de committer une sortie degradee, repondre **par ecrit (body PR)** par 1 d
 
 Le defaut paresseux (« ASCII art / reimplementation jouet / 'Java absent' / 'kernel not available locally' ») committe **sans avoir verifie RECOVERABLE-*** = manquement grave.
 
+### Procedure d'etablissement INTRINSIC — checklist 6 axes obligatoire (NEW c.8243, #10459)
+
+Un verdict `INTRINSIC` est le plus restrictif des 5 (il declare une impossibilite), et c'est **le plus dangéreux** a laisser passer sans verification : il justifie une substitution durable dans le code, qui devient invisible pour les auditeurs suivants. Pour cette raison, **chaque verdict `INTRINSIC` doit repondre nominativement les 6 axes** suivants, par « non applicable, parce que… » ou « oui, mais testé, résultat : ... » :
+
+| # | Axe | Question a repondre dans le body PR |
+|---|---|---|
+| 1 | **Binding .NET / NuGet** | Un package officiel existe-t-il pour la cible ? (ex : `OR-Tools`, `Accord.NET`) |
+| 2 | **`P/Invoke`** | Une API C stable est-elle exposee par la lib ? (cf `libtesseract`, `libsodium`) |
+| 3 | **CLI `Process.Start`** | Un binaire invocable existe-t-il ? (ex : `gambit`, `minizinc`, `clingo`) |
+| 4 | **`IKVM`** (pont Java) | La lib est-elle en Java ? Si oui, est-elle deja shadee ? ([`docs/ledgers/`](docs/ledgers/3801-sota-axe2.md)) |
+| 5 | **`PythonNet`** (pont CPython) **(NEW c.8243)** | **La lib a-t-elle un binding Python ?** Si oui, le pont `.NET → CPython → pyspiel`-like est disponible via `pythonnet 3.0.5` + `Runtime.PythonDLL` — pas d'`INTRINSIC` sans l'avoir teste. |
+| 6 | **Lib differente a role equivalent** | Un autre moteur SOTA .NET tient-il le role ? (cf PyMC ↔ Infer.NET, OR-Tools ↔ choco, mealpy ↔ MetaGeneticSharp) |
+
+**Regle d'enforcement** : un verdict `INTRINSIC` dont le body **ne repond pas nominativement les 6 axes** (y compris « axe 5 N/A parce que la cible n'a pas de binding Python, vérifié sur PyPI/X au commit SHA … ») est **incomplet** → **`CHANGES_REQUESTED`** ([pr-review-discipline.md](pr-review-discipline.md) §H). La liste des 5 verdicts est conservee, c'est **la procedure d'etablissement** d'`INTRINSIC` qui se durcit.
+
+**Origine de la 6ᵉ entree** (incident fondateur #10459) : trois verdicts `INTRINSIC` OpenSpiel convergent dans 3 PRs distinctes (#10390/#10394/#10454) — aucun n'avait examine l'axe PythonNet. Le depot certifiait deja le pont ailleurs (`MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb`, `SOTA-OK` au ledger #3801), et le user l'a rappele verbatim 2026-08-11 (« PythonNet pour bridger est tout a fait acceptable, fonctionne plutot bien … overhead negligeable »). La deuxieme omission d'axe (la premiere etait `IKVM`) demontre qu'une regle non explicite ne se corrige pas par plus de vigilance : elle demande un **organe** (la checklist).
+
+**Preuve d'execution par l'axe 5** : voir #10464/#10470/#10496/#10585/#10598 — 5 PRs MERGED sur `main` posant le pont `.NET → CPython → pyspiel` (CFR expl 0.008226, MCTS action=4, rollout Kuhn, kuhn_poker NashConv 0.0230, axelrod strategie). Plus la precedente SK-09 (PythonNet 3.0.5 + DLL loading SOTA-OK, documente au ledger #3801). La porte etait fermee a tort ; elle est desormais **prouvee**, avec cinq mesures distinctes.
+
 ### Stop & Repair — JAMAIS hand-editer une sortie de cellule (mandat user 2026-06-22)
 
 Le workaround le plus insidieux = **scrubber / hand-editer la SORTIE de cellule committee** (redacter chemin machine / prefixe de cle / render casse dans `outputs`) au lieu de re-executer = **falsifier la preuve d'execution = malhonnete, BANNI**. On **repare la cause** (env/cwd, outil manquant, source qui imprime) et on **RE-EXECUTE** — jamais maquiller. Seules exceptions : quantbooks QC (non-executables via MCP) + `metadata.papermill.input/output_path` au `basename`. Une PR qui hand-edite une sortie hors ces deux cas = `CHANGES_REQUESTED` (`APPROVED` = complaisance). Regle complete (triage cause A/B/C + incidents) : [secrets-hygiene.md](secrets-hygiene.md) regle 6 + [[feedback-no-cell-output-scrubbing]].
@@ -59,3 +78,4 @@ Les bots **DOIVENT** poster `CHANGES_REQUESTED` quand une PR notebook (interne/c
 - [anti-regression.md](anti-regression.md) — ne pas stripper le code reel
 - [three-exercises-per-notebook.md](three-exercises-per-notebook.md) — richesse pedagogique (exercices)
 - **EPIC #3801** — registre axe-2 SOTA + problem-richness, par famille (GenAI/po-2023 en tete)
+- **#10459** — omission d'axe PythonNet dans la taxonomie bucket-3 (3 verdicts INTRINSIC OpenSpiel reclasses, 5 PRs livrees). La checklist 6 axes de ce fichier est l'organe qui ferme la classe d'incidents.

--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -31,7 +31,7 @@ Un verdict `INTRINSIC` est le plus restrictif des 5 (il declare une impossibilit
 | 1 | **Binding .NET / NuGet** | Un package officiel existe-t-il pour la cible ? (ex : `OR-Tools`, `Accord.NET`) |
 | 2 | **`P/Invoke`** | Une API C stable est-elle exposee par la lib ? (cf `libtesseract`, `libsodium`) |
 | 3 | **CLI `Process.Start`** | Un binaire invocable existe-t-il ? (ex : `gambit`, `minizinc`, `clingo`) |
-| 4 | **`IKVM`** (pont Java) | La lib est-elle en Java ? Si oui, est-elle deja shadee ? ([`docs/ledgers/`](docs/ledgers/3801-sota-axe2.md)) |
+| 4 | **`IKVM`** (pont Java) | La lib est-elle en Java ? Si oui, est-elle deja shadee ? ([`../../docs/ledgers/3801-sota-axe2.md`](../../docs/ledgers/3801-sota-axe2.md)) |
 | 5 | **`PythonNet`** (pont CPython) **(NEW c.8243)** | **La lib a-t-elle un binding Python ?** Si oui, le pont `.NET → CPython → pyspiel`-like est disponible via `pythonnet 3.0.5` + `Runtime.PythonDLL` — pas d'`INTRINSIC` sans l'avoir teste. |
 | 6 | **Lib differente a role equivalent** | Un autre moteur SOTA .NET tient-il le role ? (cf PyMC ↔ Infer.NET, OR-Tools ↔ choco, mealpy ↔ MetaGeneticSharp) |
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #10668 (SheafHom)

# docs(rules,#10459): checklist 6 axes obligatoire pour verdict INTRINSIC (NEW c.8243)

## Substance

Procedure d'etablissement INTRINSIC **dureie** : 6 axes obligatoires a repondre nominativement dans le body PR, au-dela de la liste 5 verdicts existante.

| # | Axe | Question repondue dans le body PR |
|---|---|---|
| 1 | **Binding .NET / NuGet** | Un package officiel existe-t-il pour la cible ? |
| 2 | **`P/Invoke`** | Une API C stable est-elle exposee par la lib ? |
| 3 | **CLI `Process.Start`** | Un binaire invocable existe-t-il ? |
| 4 | **`IKVM`** (pont Java) | La lib est-elle en Java ? Deja shadee ? |
| 5 | **`PythonNet`** (pont CPython) **NEW c.8243** | La lib a-t-elle un binding Python ? Pont `.NET → CPython → pyspiel`-like via `pythonnet 3.0.5` + `Runtime.PythonDLL` disponible. |
| 6 | **Lib differente a role equivalent** | Un autre moteur SOTA .NET tient-il le role ? |

## Origine (incident fondateur #10459)

Trois verdicts `INTRINSIC` OpenSpiel convergent dans 3 PRs distinctes (#10390 / #10394 / #10454) — **aucun n'avait examine l'axe PythonNet**.

Le depot certifiait deja le pont ailleurs :
- `MyIA.AI.Notebooks/GenAI/SemanticKernel/09-SemanticKernel-Building-CLR.ipynb` — SOTA-OK au ledger #3801
- 5 PRs MERGED sur `main` posant le pont `.NET → CPython → pyspiel` : #10464 (GT-17), #10470 (GT-13), #10496 (Search-7), #10585 (GT-6), #10598 (GT-7)

User verbatim 2026-08-11 : « *PythonNet pour bridger est tout a fait acceptable, fonctionne plutot bien … overhead negligeable* ».

La deuxieme omission d'axe (la premiere etait `IKVM`) demontre qu'une regle non explicite ne se corrige pas par plus de vigilance : elle demande un **organe** (la checklist).

## Enforcement

Verdict `INTRINSIC` dont le body **ne repond pas nominativement les 6 axes** (y compris « axe 5 N/A parce que la cible n'a pas de binding Python, verifie sur PyPI/X au commit SHA … ») = **incomplet** → **`CHANGES_REQUESTED`** ([pr-review-discipline.md](pr-review-discipline.md) §H).

La liste des 5 verdicts reste inchangee. C'est **la procedure d'etablissement** d'INTRINSIC qui se durcit, pas le verdict lui-meme.

## Scope

- **Single-file** PR (atomique, G-VAR-3 OK) : `.claude/rules/sota-not-workaround.md`
- **+20 / -0** insertions only
- **Voir aussi** ajoute en queue de fichier : entree `#10459` avec contexte fondateur

## Liens

- Issue #10459 (Tache 1 = ce regle)
- Issue #10459 (Taches 2-4 = deja livrees : gate, verdicts reclasses, 5 PythonNet bridges)
- EPIC #3801 (registre axe-2 SOTA)
- [pr-review-discipline.md](pr-review-discipline.md) §H (enforcement cible)
- [sota-not-workaround.md](.claude/rules/sota-not-workaround.md) (la regle modifiee)

## Anti-pattern ecartes

- **Pas de regen catalogue** : PR ne touche pas `COURSE_CATALOG.generated.json/.md` (catalog-pr-hygiene regle 1)
- **Pas de modif autres fichiers** : 1 fichier / 1 sujet / 1 PR (catalog-pr-hygiene regle 3)
- **Branch single-lane** : `feature/c8243-sotax-pythonnet` rebas frais `origin/main d2d495a77` (L904 ★★)
- **Lane claim via issue comment #10459** (L898 ★★★) — paths-scoped a `.claude/rules/sota-not-workaround.md`
- **Body PR hors worktree** (L677-L4 ★★)
- **`See #10459` (pas `Closes`)** — contribution partielle a une epic (L883 ★)
