### PR TITLE
fix(pymc-15,#10685): réordonner 5 cellules d'interprétation MISPLACED (Phase 2 Epic #10678)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
@@ -132,16 +132,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "interp-c7fbd5f1",
-   "metadata": {},
-   "source": [
-    "### Lecture du résultat : données sparse pédagogiques\n",
-    "\n",
-    "La sortie montre **8 observations** réparties sur 4 utilisateurs et 5 items. Avec 40 % de densité (8/20), c'est une matrice volontairement « remplie » pour l'apprentissage — dans la vraie vie, la densité descend sous 1 %. La structure sparse est précisément ce qui rend la factorisation latente nécessaire : on doit reconstruire les 60 % de notes manquantes à partir des 40 % observées, en exploitant les **corrélations latentes** entre utilisateurs et items."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "3d633d35",
    "metadata": {
     "papermill": {
@@ -275,16 +265,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "interp-21aaaf9e",
+   "id": "interp-c7fbd5f1",
    "metadata": {},
    "source": [
-    "### Lecture du résultat : 163 divergences — diagnostic critique\n",
+    "### Lecture du résultat : données sparse pédagogiques\n",
     "\n",
-    "La sortie révèle **163 divergences** après tuning — c'est un **signal d'alarme**. Une divergence signifie que NUTS a détecté un problème numérique dans l'exploration (la trajectoire hamiltonienne diverge), indiquant un postérieur mal conditionné. Causes probables ici :\n",
-    "- **Modèle sous-contraint** : peu de données (8 obs) pour beaucoup de paramètres (U 4×2 + V 5×2 + sigma = 21 params), ratio ~0.4.\n",
-    "- **Priors trop larges** : les gaussiennes laissent les traits dériver vers des régions pathologiques.\n",
-    "\n",
-    "Le warning PyMC le dit explicitement : « Increase `target_accept` or reparameterize ». La section suivante (modèle corrigé avec biais) montrera comment réduire ces divergences — c'est la **leçon de diagnostic MCMC** centrale de ce notebook."
+    "La sortie montre **8 observations** réparties sur 4 utilisateurs et 5 items. Avec 40 % de densité (8/20), c'est une matrice volontairement « remplie » pour l'apprentissage — dans la vraie vie, la densité descend sous 1 %. La structure sparse est précisément ce qui rend la factorisation latente nécessaire : on doit reconstruire les 60 % de notes manquantes à partir des 40 % observées, en exploitant les **corrélations latentes** entre utilisateurs et items."
    ]
   },
   {
@@ -386,21 +372,6 @@
     "print(\"Modele de factorisation defini.\")\n",
     "print(f\"  Variables : U({n_users}x{n_traits}), V({n_items}x{n_traits}), sigma\")\n",
     "print(f\"  Observations : {n_obs} notes\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "interp-35dca21b",
-   "metadata": {},
-   "source": [
-    "### Lecture du résultat : divergences 163 → 5, l'amélioration spectaculaire\n",
-    "\n",
-    "Le modèle corrigé (avec biais user/item) ne produit plus que **5 divergences** (vs 163 précédemment) — une réduction d'un facteur 32. Trois leviers expliquent cette convergence :\n",
-    "- **Biais additifs** : capturer les tendances systématiques soulage les traits latents (ils n'ont plus à tout expliquer).\n",
-    "- **Plus de données** : 25 observations (ratio 1.2×) mieux conditionnent le postérieur.\n",
-    "- **Reparamétrisation** : l'ajout de structure réduit les corrélations pathologiques entre paramètres.\n",
-    "\n",
-    "C'est la leçon pratique du diagnostic MCMC : les divergences ne sont pas une fatalité, elles **orientent** l'amélioration du modèle. Le warning « reparameterize » du modèle naïf pointait exactement vers cette correction."
    ]
   },
   {
@@ -591,6 +562,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-21aaaf9e",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : 163 divergences — diagnostic critique\n",
+    "\n",
+    "La sortie révèle **163 divergences** après tuning — c'est un **signal d'alarme**. Une divergence signifie que NUTS a détecté un problème numérique dans l'exploration (la trajectoire hamiltonienne diverge), indiquant un postérieur mal conditionné. Causes probables ici :\n",
+    "- **Modèle sous-contraint** : peu de données (8 obs) pour beaucoup de paramètres (U 4×2 + V 5×2 + sigma = 21 params), ratio ~0.4.\n",
+    "- **Priors trop larges** : les gaussiennes laissent les traits dériver vers des régions pathologiques.\n",
+    "\n",
+    "Le warning PyMC le dit explicitement : « Increase `target_accept` or reparameterize ». La section suivante (modèle corrigé avec biais) montrera comment réduire ces divergences — c'est la **leçon de diagnostic MCMC** centrale de ce notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "71dd779a",
    "metadata": {
     "papermill": {
@@ -683,16 +668,6 @@
     "        print(f\"{R_pred[u, i]:>5.2f}{marker}\", end=\" \")\n",
     "    print()\n",
     "print(\"(* = observation, autres = prediction)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "interp-d603db24",
-   "metadata": {},
-   "source": [
-    "### Lecture du résultat : cold-start, reco Item 0\n",
-    "\n",
-    "Pour un nouvel utilisateur (âge=0.4, genre=F) **sans aucun historique de notation**, le modèle prédit les scores et recommande **Item 0 (score 3.192)**. C'est la démonstration que le cold-start conditionné par features **généralise au-delà des données** : les poids `W_user` appris relient les features démographiques aux traits latents, permettant d'estimer `U[new_user]` puis de scorer les items. Sans ce mécanisme, un nouvel utilisateur serait invisible au système jusqu'à ce qu'il note assez d'items."
    ]
   },
   {
@@ -921,16 +896,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "interp-909ef32d",
-   "metadata": {},
-   "source": [
-    "### Lecture du résultat : classement final fusionné\n",
-    "\n",
-    "Le classement final réconcilie les deux sources (jugements humains moyens 3.75, taux de clics 0.63) en un ordre unique : **Doc 4 gagne** (score latent 4.988, juge 5.0, clics 0.90). Les deux sources sont cohérentes ici, d'où un score latent confiant. Le cadre bayésien se distingue d'une simple moyenne : si une source était bruitée, le modèle la pénaliserait automatiquement via son `sigma` élevé — c'est l'**auto-pondération par fiabilité** qui fait la puissance de la fusion probabiliste."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "4ecb1709",
    "metadata": {
     "papermill": {
@@ -1051,6 +1016,21 @@
     "                          return_inferencedata=True)\n",
     "\n",
     "print(\"Inference terminee.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-35dca21b",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : divergences 163 → 5, l'amélioration spectaculaire\n",
+    "\n",
+    "Le modèle corrigé (avec biais user/item) ne produit plus que **5 divergences** (vs 163 précédemment) — une réduction d'un facteur 32. Trois leviers expliquent cette convergence :\n",
+    "- **Biais additifs** : capturer les tendances systématiques soulage les traits latents (ils n'ont plus à tout expliquer).\n",
+    "- **Plus de données** : 25 observations (ratio 1.2×) mieux conditionnent le postérieur.\n",
+    "- **Reparamétrisation** : l'ajout de structure réduit les corrélations pathologiques entre paramètres.\n",
+    "\n",
+    "C'est la leçon pratique du diagnostic MCMC : les divergences ne sont pas une fatalité, elles **orientent** l'amélioration du modèle. Le warning « reparameterize » du modèle naïf pointait exactement vers cette correction."
    ]
   },
   {
@@ -1596,6 +1576,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-d603db24",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : cold-start, reco Item 0\n",
+    "\n",
+    "Pour un nouvel utilisateur (âge=0.4, genre=F) **sans aucun historique de notation**, le modèle prédit les scores et recommande **Item 0 (score 3.192)**. C'est la démonstration que le cold-start conditionné par features **généralise au-delà des données** : les poids `W_user` appris relient les features démographiques aux traits latents, permettant d'estimer `U[new_user]` puis de scorer les items. Sans ce mécanisme, un nouvel utilisateur serait invisible au système jusqu'à ce qu'il note assez d'items."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4fc5c586",
    "metadata": {
     "papermill": {
@@ -2031,6 +2021,16 @@
     "for rank, doc in enumerate(classement):\n",
     "    print(f\"{rank+1:>5} {doc:>5} {scores_post[doc]:>8.3f} \"\n",
     "          f\"{judgements[doc]:>8.1f} {click_rates[doc]:>8.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-909ef32d",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : classement final fusionné\n",
+    "\n",
+    "Le classement final réconcilie les deux sources (jugements humains moyens 3.75, taux de clics 0.63) en un ordre unique : **Doc 4 gagne** (score latent 4.988, juge 5.0, clics 0.90). Les deux sources sont cohérentes ici, d'où un score latent confiant. Le cadre bayésien se distingue d'une simple moyenne : si une source était bruitée, le modèle la pénaliserait automatiquement via son `sigma` élevé — c'est l'**auto-pondération par fiabilité** qui fait la puissance de la fusion probabiliste."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/pedagogy — lane myia-po-2025:CoursIA (user-directed) — prev: MED/readme (#10674)

# fix(pymc-15,#10685): réordonner 5 cellules d'interprétation MISPLACED (Phase 2 Epic #10678)

See #10685, #10678

## What

Le notebook `PyMC-15-Recommenders.ipynb` portait **5 cellules markdown d'interprétation** (`### Lecture du résultat : …`) insérées chacune après une cellule de code **arbitraire** au lieu de la cellule dont elles commentent l'output (bug introduit par l'enrichissement density #10580 / EPIC #10488). Exemple le plus grave : la cellule qui interprète le **classement final du Click Model (§5)** se trouvait 26 cellules plus haut, collée après la **définition du modèle de factorisation (§2)** — illisible.

**Fix** : déplacement des 5 cellules vers leur position correcte, ancrées sur la cellule de code dont elles interprètent réellement l'output (ancrage déterminé firsthand en lisant les outputs réels, pas en devinant).

## G.1 ancrage autoritatif (output-anchored, pas positionnel)

Chaque cellule d'interprétation cite une valeur chiffrée (163 divergences, 3.192, 4.988…). J'ai grepé les **outputs** des cellules de code pour trouver laquelle produit chaque valeur, puis déplacé l'interp juste après :

| interp cell | valeur citée | output trouvé dans la cellule code… | déplacement |
|---|---|---|---|
| `interp-c7fbd5f1` « données sparse 8 obs » | « 8 observations » | `21aaaf9e` (e=3, data) | après imports → après data |
| `interp-21aaaf9e` « 163 divergences » | « There were 163 divergences » | `26039705` (e=5, inference naive) | après data → après inference naive |
| `interp-35dca21b` « 163→5 » | « There were 5 divergences » | `edb046fe` (e=10, inference corrigée) | après déf. modèle 1 → après inference corrigée |
| `interp-d603db24` « cold-start Item 0 » | « Item 0 : 3.192 » | `2ab9dcd4` (e=16, prédiction cold-start) | après extraction → après prédiction cold-start |
| `interp-909ef32d` « classement Doc 4 » | « 4 … 4.988 … 0.90 » | `65ef7e87` (e=21, classement Click) | après déf. modèle 2 → après classement Click |

## Validation

- **24 cellules de code BYTE-IDENTIQUES** (fingerprint SHA1 source+outputs+exec_count avant/après = identique). 0 ligne `execution_count` touchée dans le diff.
- **Markdown-only** (C.3 exception) : déplacement de cellules, pas de re-exec. Les outputs sont préservés tels quels.
- `validate_pr_notebooks.py origin/main <nb>` : **PASS** (24/24 cells).
- C.1 : 0 pattern banni. exec_count null : 0. nbformat 4.5 valide.
- Post-order vérifié : chacune des 5 interp suit bien son ancre de code (assertion programmée).
- Round-trip JSON byte-identique vérifié AVANT réordonnancement (`json.dumps(ensure_ascii=False, indent=1)` reproduit le fichier à l'octet) → pas de churn de formatage, le seul diff est le déplacement.
- +52/-52 sur 1 fichier (symétrique = relocation de 5 cellules × ~10 lignes).

## Review visuelle humaine OBLIGATOIRE

L'Epic #10678 exige une review visuelle humaine pour ce fix (le check automatiste de positionnement n'existe pas encore — Phase 3). Le reviewer doit confirmer en lisant le notebook que chaque `### Lecture du résultat` tombe au bon endroit.

## Complémentaire, pas doublon

- Phase 1 audit (#10678 commentaire) a mesuré 40 notebooks / 83 cellules « Lecture du résultat » : le bug MISPLACED grave est **isolé à PyMC-15** (5/5) + 1 cas mineur Audiobook (hors scope de cette PR). 38/40 notebooks sont corrects — ce fix traite le seul cas grave.
- L'angle mort review (aucun check de position sémantique nulle part) reste ouvert → Phase 3 #10678 (check CI `check_interp_positioning.py`).

See #10685 (Phase 2 sub-issue), See #10678 (Epic — reste ouvert pour Phase 3 check CI + Phase 4 renforcement review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
