### PR TITLE
fix(ict,#4588): ICT-15h/15i title chain-shift -1 (internal title != filename)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15h-Bridge1bis-AsymmetricFamily.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15h-Bridge1bis-AsymmetricFamily.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# ICT-15g -- Pont #1-bis (chantier 2/3) : le regime asymetrique confirme le negatif de $\\sigma$\n",
+    "# ICT-15h -- Pont #1-bis (chantier 2/3) : le regime asymetrique confirme le negatif de $\\sigma$\n",
     "\n",
     "*See [#9531](https://github.com/jsboige/CoursIA/issues/9531).*\n",
     "\n",

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15i-Bridge1bis-2DLandscape.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15i-Bridge1bis-2DLandscape.ipynb
@@ -14,10 +14,10 @@
     "tags": []
    },
    "source": [
-    "# ICT-15h -- Pont #1-bis : le paysage 2D anisotrope clot l'Epic\n",
+    "# ICT-15i -- Pont #1-bis : le paysage 2D anisotrope clot l'Epic\n",
     "\n",
     "*See [#9531].* Les chantiers 1/3 (`ICT-15f`, double-puits symetrique 1D) et 2/3\n",
-    "(`ICT-15g`, double-puits asymetrique 1D) ont tranche **CONFIRMED-NEGATIVE** : la\n",
+    "(`ICT-15h`, double-puits asymetrique 1D) ont tranche **CONFIRMED-NEGATIVE** : la\n",
     "courbure locale $\\sigma$ n'a aucun pouvoir predictif propre pour la\n",
     "recuperabilite une fois la largeur ET la barriere controlees.\n",
     "\n",


### PR DESCRIPTION
Grain: LIGHT/docs -- lane myia-po-2023:CoursIA -- prev: MED/docs #10664

## Summary

Fix de cohérence : les titres internes (cellule markdown 0) des notebooks **ICT-15h** et **ICT-15i** souffraient d'un **chain-shift -1** (le titre interne ne correspondait pas au nom de fichier). Le bug se propageait au corps de 15i (conclusion référençant le mauvais prédécesseur).

## Diagnostic (audit + G.1 firsthand)

Audit read-only ICT-15b→15i (sous-agent sonnet) a identifié le chain-shift ; vérifié firsthand sur `origin/main` :
- **ICT-15h** cell[0] titrait `# ICT-15g -- Pont #1-bis (chantier 2/3)` → devrait dire `ICT-15h`
- **ICT-15i** cell[0] titrait `# ICT-15h -- Pont #1-bis : le paysage 2D anisotrope clot l'Epic` → devrait dire `ICT-15i`
- **ICT-15i** conclusion référençait `(\`ICT-15g\`, double-puits asymetrique 1D)` → devrait dire `ICT-15h` (le double-puits asymétrique 1D est 15h, pas 15g)

ICT-15g est **correct** (pas touché) — le bug ne touchait que 15h et 15i (décalage -1 propagé).

## Changements

3 lignes modifiées (raw-text surgery, byte-identity préservée sur le reste) :
- 15h : titre `ICT-15g` → `ICT-15h`
- 15i : titre `ICT-15h` → `ICT-15i` + référence `ICT-15g` → `ICT-15h`

Markdown-only (exception C.2, pas de re-exec). JSON validé (21 cells chacun, structure intacte).

## Scope

Fix **factuel** de cohérence (titre interne = nom de fichier), distinct des **consolidations** 15g→15b et 15h→15i recommandées par l'audit mais qui restent **décision coordinateur** (impact pédagogique, redistribution de contenu) — voir addendum #4588 2026-08-13 « Dette de dilution post-arc ».

## Test plan
- [x] JSON valide (21 cells par notebook)
- [x] Diff chirurgical (3 insertions / 3 deletions, byte-identity préservée)
- [x] Pas de code cell touché (markdown-only, exception C.2)
- [x] Unicité des chaînes remplacées vérifiée (count=1 chacune, pas de nav-link collision)

See #4588 (Epic ICT — addendum dette de dilution).
