### PR TITLE
fix(gitleaks,#10143): positive-control fixture 'sk-proj-AbCdEf1234567890' was disarmed by stopword added in #10575 follow-up (c.1331+106)

### DIFF
--- a/scripts/tests/test_gitleaks_allowlist.py
+++ b/scripts/tests/test_gitleaks_allowlist.py
@@ -112,7 +112,13 @@ REAL_KEYS = [
     # real Stripe shape (random entropy, distinct from the TEST-key stopword).
     "sk_" + "live_abcDEF1234567890ghijKLmnopQRSTuvwx",
     # real OpenAI shape.
-    "sk-pro" + "j-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz",
+    # NOTE: do NOT use `AbCdEf1234567890` here — that's a stopword in
+    # .gitleaks.toml (added by #10575 follow-up commit e1f65d765 to
+    # suppress AGSEC005 placeholder detection). Using it as a fixture
+    # would disarm the positive-control test (c.1331+106 — `test_real_keys_contain_no_stopword`
+    # failed on main 2026-08-12T21:06Z, run 31640973141). Use a synthetic
+    # that's not in any stopword instead.
+    "sk-pro" + "j-XyZwVu9876543210GhIjKlMnOpQrStUvWxYz",
     # JWT HS256 real-formed (header.payload.signature). #10201 keeps the jwt
     # detector ARMED by deliberately NOT allowlisting the standard header
     # (it is a prefix of every real JWT; substring-allowlisting it disarms the


### PR DESCRIPTION
# fix(gitleaks,#10143): positive-control fixture `sk-proj-AbCdEf1234567890` was disarmed by stopword added in #10575 follow-up (c.1331+106)

Grain: MED/test — lane myia-po-2024:CoursIA-2 — prev: DEEP/lean #10679

## Symptôme (firsthand)

`scripts/tests/test_gitleaks_allowlist.py::TestPositiveControlRealKeysStayDetected::test_real_keys_contain_no_stopword` FAIL depuis 2026-08-12T21:06:43Z (run CI 31640973141 sur `main`). Le test ne protégeait plus rien : un vrai secret partagé contenant le stopword `AbCdEf1234567890` passerait le scan (scanner disarmed).

```
AssertionError: a real-shaped key contains an allowlist stopword -> scanner disarmed:
[('sk-proj-AbCdEf1234567890GhIj...', ['AbCdEf1234567890'])]
(see #10143 positive-control requirement)
```

## Cause (mesurée)

Le fixture `REAL_KEYS[2]` à `scripts/tests/test_gitleaks_allowlist.py:115` utilisait le substring littéral `AbCdEf1234567890`. Le commit `e1f65d765` (follow-up de #10575, *"add stopwords for AGSEC005 test fixture placeholders"*) a ajouté ce **même string** comme stopword global dans `.gitleaks.toml:245` (pour supprimer les FP sur les tests AGSEC005 xUnit du projet Roslyn).

Résultat : un substring matchait un substring, le contrôle positif était neutralisé, et la PR gate `Scripts Tests (CPU)` rougissait sur **main**.

## Cascade observée

PR #10673 (`po-2024 Manage-ApiKeys.sh`, CLEAN MERGEABLE par ailleurs) devenait BLOCKED parce que `PR gate` agrège `Scripts Tests` en required check. C'est ce cycle qui m'a fait découvrir le défaut (après avoir vu le log CI agrégé).

## Correctif

Substituer `AbCdEf1234567890` par `XyZwVu9876543210` dans `REAL_KEYS[2]`. Le nouveau fixture :

1. Conserve la même **forme** (mixed-case + digits, 14 chars post-préfixe `sk-proj-`) — l'enveloppe `openai-style` reste plausible
2. N'est substring d'**aucun stopword** ni regex du `.gitleaks.toml` (vérifié par grep)
3. N'est pas un secret réel — toujours construit via concaténation de chaînes (`"sk-pro" + "j-XyZwVu..."`) pour que le diff ne contienne pas le littéral complet
4. Commente explicitement le piège (`NOTE: do NOT use 'AbCdEf1234567890' here ...`) pour qu'un futur PR ne réintroduise pas la collision

## Validation

```
$ python -m pytest scripts/tests/test_gitleaks_allowlist.py
============================= 12 passed in 0.10s =============================
```

| Test | Résultat |
|---|---|
| `test_class_regex_present` | PASS |
| `test_stopwords_present` | PASS |
| `test_class_regex_suppresses_uppercase_placeholder` | PASS |
| `test_each_stopword_is_self_suppressing` | PASS |
| `test_real_keys_not_matched_by_regex` | PASS |
| **`test_real_keys_contain_no_stopword`** | **PASS** (était FAIL avant) |
| `test_header_not_in_allowlist_regexes` | PASS |
| `test_header_not_in_stopwords` | PASS |
| `test_real_jwt_stays_detected` | PASS |
| `test_revoked_entries_are_actually_in_the_allowlist` | PASS |
| `test_revoked_entries_document_their_rotation` | PASS |
| `test_revoked_values_are_not_positive_controls` | PASS |

## Anti-régression

Le commentaire en place sur `REAL_KEYS[2]` documente **pourquoi** `AbCdEf1234567890` est interdit, en référençant le commit fautif et le ticket #10143. Le prochain ajout de stopword touchera au moins un œil qui aura vu cette note.

## Périmètre

- 1 fichier modifié : `scripts/tests/test_gitleaks_allowlist.py`
- 0 modification de `.gitleaks.toml` — la liste des stopwords reste **inchangée** (AGSEC005 placeholders toujours supprimés comme voulu par #10575).
- Aucun impact sur les notebooks, scripts, docs.
- Pas de dépendance externe (pure Python `pytest`).

## Liens

- PR : https://github.com/jsboige/CoursIA/pull/10694 (à ouvrir)
- Issue #10143 : gitleaks FP dormants + contrôle positif
- Issue #10595 : paths vs stopwords (related mais distinct — paths-allowlist est un content bypass ; ce PR ne touche pas à ce débat)
- PR #10575 : AGSEC005 (commit fautif `e1f65d765`)
- PR #10606 : paths → stopwords conversion (CONFLICTING, distinct)
- PR #10673 : Manage-ApiKeys.sh — CLEAN après ce fix

## L1 ★ c.1331+106 (nouvelle leçon ancrée)

**Gitleaks stopwords = substring global. Ajouter un stopword qui apparaît dans un fixture de test = casser le contrôle positif en silence.**

Tell d'auto-détection : après tout ajout à `.gitleaks.toml [allowlist].stopwords`, lancer `pytest scripts/tests/test_gitleaks_allowlist.py -v` AVANT commit. Si `test_real_keys_contain_no_stopword` rougit → le stopword collide avec un fixture. Fix immédiat : substituer le fixture (préféré), ou ré-écrire le stopword en regex avec anchor plus précis (`[allowlist].regexes` au lieu de `stopwords`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>