### PR TITLE
fix(notebook,#10643,#10645): add Plateformes supportées cell to Lean-1 + GT-1 Setup

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb
@@ -44,7 +44,8 @@
     "- Python 3.9+ installe\n",
     "- Connaissances basiques en Python et NumPy\n",
     "\n",
-    "### Duree estimee : 20 minutes"   ]
+    "### Duree estimee : 20 minutes"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -66,6 +67,27 @@
     "\n",
     "Commencons par detecter le système d'exploitation et la configuration Python."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plateformes supportées\n",
+    "\n",
+    "Ce notebook supporte **Windows**, **macOS** et **Linux**. La cellule de détection\n",
+    "ci-dessous identifie votre plateforme et adapte les étapes d'installation :\n",
+    "\n",
+    "| Plateforme | Installation OpenSpiel | Kernel Jupyter |\n",
+    "|------------|------------------------|----------------|\n",
+    "| **Windows** | Via WSL (recommandé) ou `game_theory_utils.py` (fallback Python pur) | Python normal (le notebook fonctionne sans OpenSpiel) |\n",
+    "| **macOS** | `pip install open_spiel` | Python normal |\n",
+    "| **Linux** | `pip install open_spiel` | Python normal |\n",
+    "\n",
+    "La section 2.7 (Configuration WSL) est marquée **(Windows uniquement)** ;\n",
+    "sur Mac/Linux, elle affiche un message d'information et s'arrête.\n",
+    ""
+   ],
+   "id": "a0803db8d985da29"
   },
   {
    "cell_type": "code",
@@ -1304,7 +1326,6 @@
     "\n",
     "## 3. Structure de la serie\n",
     "\n",
-    
     "\n",
     "### Partie 1 : Fondations (Notebooks 1-6)\n",
     "| # | Notebook | Contenu | Requis |\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
@@ -149,6 +149,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plateformes supportées\n",
+    "\n",
+    "Ce notebook supporte **Windows**, **macOS** et **Linux**. Les commandes s'adaptent automatiquement\n",
+    "via `platform.system()` :\n",
+    "\n",
+    "| Plateforme | Installation | Kernel Jupyter |\n",
+    "|------------|--------------|----------------|\n",
+    "| **Windows** | `elan-init.ps1` via PowerShell | `lean4_jupyter` natif (avec patch SIGPIPE) **ou** kernel WSL (recommandé) |\n",
+    "| **macOS** | `elan-init.sh` via curl | `lean4_jupyter` natif |\n",
+    "| **Linux** | `elan-init.sh` via curl | `lean4_jupyter` natif |\n",
+    "\n",
+    "Les sections marquées **(Windows uniquement)** contiennent du code `wsl.exe` / `powershell` ;\n",
+    "elles affichent un message d'information et s'arrêtent proprement sur Mac/Linux.\n",
+    "\n",
+    "Exécutez la cellule de diagnostic ci-dessous pour identifier votre plateforme.\n",
+    ""
+   ],
+   "id": "5241b28010e04157"
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "id": "78848c0a",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #10687

## Phase 2 — Support Linux/macOS des notebooks Setup (P0, #10645)

Issue cible : **#10645** (Part of #10643 [EPIC]). Les deux notebooks d'entrée
(`Lean-1-Setup.ipynb`, `GameTheory-1-Setup.ipynb`) **annoncent** un support
multi-plateforme dans leurs cellules existantes, mais **n'en font pas
l'explicitation narrative au lecteur**. Sur Mac/Linux, l'utilisateur ne sait
pas qu'il est supporté avant d'arriver aux cellules 5+ (Lean) ou 16+ (GT)
qui contiennent les branches OS déjà codées.

### Diagnostic du défaut (firsthand `origin/main` `d2d495a77`)

| Notebook | Diagnostic existant ? | `wsl.exe`/`powershell` brut | Branche OS codée ? |
|---|---|---|---|
| `Lean-1-Setup.ipynb` | cell[4] (7270 chars, diag complet) | cell[5] `_install_elan_windows` (`powershell` ×3, `.ps1` ×2) + cell[16] `WSLKernelManager` (`wsl.exe` ×7) | ✅ cell[5] a `_install_elan_windows`/`_install_elan_unix` ; ✅ cell[16] `run_diagnostic` ligne 211 a `if not self.is_windows: return` |
| `GameTheory-1-Setup.ipynb` | cell[3] (détection OS_NAME, IS_WINDOWS, IS_LINUX, IS_MAC) | cell[27] (WSL kernel config, `wsl.exe` ×5) | ✅ cell[16] `install_openspiel` branches `IS_LINUX or IS_MAC` vs Windows ; ✅ cell[27] marquée "(Windows uniquement)" |

**Les deux notebooks sont déjà cross-platform** côté code. Le défaut est **narratif** :
un utilisateur Mac/Linux ouvrant `Lean-1-Setup.ipynb` ne lit aucune indication
qu'il est supporté avant les sections 3-5 ; un utilisateur Windows lisant
`GameTheory-1-Setup.ipynb` ne voit pas explicitement qu'il peut sauter la
section 2.7 WSL s'il n'a pas besoin d'OpenSpiel.

### Fix — cellule markdown "Plateformes supportées" dans chacun

Insertion d'une **cellule markdown unique** dans chaque notebook, juste après
l'introduction, qui résume les chemins d'installation par OS. La cellule :

- **Ne modifie aucun code** (anti-régression §D, aucune cellule code touchée).
- **Ne modifie aucun output existant** (cellule markdown-only, C.3 exception).
- **Ne déclare pas les paths Mac/Linux comme validés sur ma machine** — je
  suis sous Windows, je n'exécute pas les branches Mac/Linux. Le claim est
  que **le code Mac/Linux existe déjà** (vérifié ci-dessus), donc le **seul
  ajout est la signalisation narrative**, pas l'installation.

### Diff

```
MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb             | 23 ++++++++++++++++++++
MyIA.AI.Notebooks/GameTheory/GameTheory-1-Setup.ipynb            | 25 ++++++++++++++++++++--
2 files changed, 46 insertions(+), 2 deletions(-)
```

**+46/-2 net** : +46 = contenu des 2 nouvelles cellules ; -2 = nettoyage
d'une ligne avec trailing whitespace dans `GameTheory-1-Setup.ipynb` cell[1]
(préexistant, pas introduit par cette PR — le `json.dump` reformate en
supprimant les espaces de fin).

### Acceptance vs critères de #10645

| Critère | État | Preuve |
|---|---|---|
| Chaque cellule Windows-only propose les deux chemins OS | ✅ pré-existant | `_install_elan_unix` L106 (cell[5]) ; `IS_LINUX or IS_MAC` cell[16] (GT) ; `if not self.is_windows: return` L211 (cell[16] Lean) |
| 0 `raise NotImplementedError` / `assert False` / `1/0` introduit | ✅ | Aucun ajout de code, uniquement markdown |
| Notebooks re-exécutés (C.2) | N/A | Cellules markdown-only (C.3 exception) ; les outputs existants sont préservés intacts |
| `bash -n` syntax check sur snippets shell | N/A | Aucun snippet shell ajouté dans cette PR |
| `wsl.exe` n'est plus la seule voie documentée | ✅ | La cellule ajoutée documente explicitement `elan-init.sh` (curl) pour Linux/macOS + kernel `lean4_jupyter` natif |

### Hors scope (honnêtement)

- **Pas de re-exécution Papermill sur Linux/macOS** : je suis sous Windows,
  ces branches n'ont pas été exercées par moi. Un user Mac/Linux qui ouvre
  la PR pourra confirmer en local ; le code sous-jacent (`_install_elan_unix`,
  `install_openspiel` Linux/Mac branches) est pré-existant et inchangé.
- **Pas de fix de `WSLKernelManager` cell[16] côté Windows** : le code
  fonctionne (les 7 `wsl.exe` calls sont guarded par `is_windows`). Le seul
  ajout est narratif.
- **Pas de traduction EN** : la cellule ajoutée est en français, cohérente
  avec le reste du notebook. Si le projet décide un jour de basculer ce
  notebook en `.en.md` sibling-pair, ce sera via Epic #1650.

### Conventions

- **L903 ★★** : grain tag première ligne.
- **L898 ★★★** : `paths:` clause sur le claim `[CLAIMED]` (#10645).
- **L904 ★★** : worktree sur `origin/main` frais (`d2d495a77`).
- **L677-L4 ★★** : body de PR en scratchpad (`<scratchpad-dir>/c8246_pr_body.md`).
- **L883 ★** : `Part of #10643`, `See #10645` (l'epic reste ouverte pour les
  autres sous-tâches #10646/#10647/#10648).
- **L934 ★** : JSON write via `f.write(text.encode('utf-8'))` en mode
  binaire → LF préservé, 0 CRLF.
- **anti-régression §D** : aucune cellule code touchée, pure markdown.
- **C.3** : scope strict = 2 notebooks, cellules markdown-only.
- **catalog-pr-hygiene R1** : catalogue non régénéré.

### Liens

- Issue : #10645 (Part of #10643 [EPIC])
- Phase 2 repair precedent : #10687 (PyMC-15 + Audiobook MISPLACED, c.8245)
- Claim : issuecomment-5274509871 (paths-scoped Lean-1-Setup + GT-1-Setup)