### PR TITLE
test(gitleaks,#10143,#10595): assert paths allowlist = documented content bypass (c.1331+107)

### DIFF
--- a/scripts/tests/test_gitleaks_allowlist.py
+++ b/scripts/tests/test_gitleaks_allowlist.py
@@ -35,11 +35,42 @@ so they run without the gitleaks binary (CI only has gitleaks-action).
 """
 from __future__ import annotations
 
+import json
 import re
+import shutil
+import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 GITLEAKS_TOML = REPO_ROOT / ".gitleaks.toml"
+
+# Pinned by `.github/workflows/secret-scan.yml` and `.pre-commit-config.yaml`
+# (the two pins must agree, see `check_hooks_parity.py`). The test below
+# invokes the gitleaks binary directly to assert the `paths` allowlist is a
+# documented CONTENT BYPASS (#10595), so the version must match.
+EXPECTED_GITLEAKS_VERSION = "8.24.3"
+
+
+def _gitleaks_binary() -> str | None:
+    """Locate the gitleaks binary, or None if unavailable.
+
+    The CI uses Docker (`docker run zricethezav/gitleaks:v${GITLEAKS_VERSION}`);
+    locally, we accept either a `gitleaks` on PATH or the Windows binary if
+    installed. The skip is graceful: absence of the binary does NOT mean the
+    config is healthy, it means this class of assertion cannot be evaluated
+    here. CI still runs the same check via the gitleaks-action step."""
+    found = shutil.which("gitleaks")
+    if found:
+        return found
+    # Windows: fall back to a known install location if present.
+    if sys.platform == "win32":
+        candidate = Path("C:/Program Files/GitTools/gitleaks/gitleaks.exe")
+        if candidate.exists():
+            return str(candidate)
+    return None
 
 
 def _load_allowlist_regexes() -> list[str]:
@@ -326,3 +357,167 @@ class TestRevocationDiscipline:
                 f"{prefix}... is both REVOKED_ALLOWLISTED and inside a positive "
                 f"control {collides} -> the control can no longer detect a disarm"
             )
+
+
+# ---------------------------------------------------------------------------
+# Paths allowlist = CONTENT BYPASS (c.1331+107/#10595).
+# Documented structural tradeoff: the allowlist entry
+#   scripts/secrets/tests/test_gitleaks_.*\.py$
+# skips the scanner on the directory that hosts the gitleaks regression suite
+# itself — otherwise the synthetic `qwen-api-token` fixtures (c.10265) would
+# produce 14+ noise findings per CI run. The price is that ANY secret under
+# `scripts/secrets/tests/test_gitleaks_*.py` is invisible to the scanner.
+#
+# This class asserts TWO properties simultaneously so that future maintainers
+# cannot regress either side unknowingly:
+#
+#   1. The bypass HOLDS today — a real-shaped secret under the allowlisted
+#      path is NOT flagged. Removing the `paths` entry would break this
+#      assertion, forcing the maintainer to consciously reintroduce the
+#      bypass or fix the underlying noise problem.
+#   2. The detector stays ARMED in general — the same real-shaped secret in a
+#      sibling file OUTSIDE the allowlist IS flagged. This is the positive
+#      control: if the detector were silently disabled everywhere, both
+#      assertions would (wrongly) pass.
+#
+# The test invokes the gitleaks binary directly — text-only parsing of the
+# TOML cannot test a runtime bypass — which is why it skips gracefully when
+# gitleaks is unavailable (CI does NOT run this class locally; the gate is
+# the gitleaks-action scan on the actual PR). The point of the test is the
+# NAME: it documents the bypass with a runnable invariant instead of leaving
+# it as a comment in `.gitleaks.toml` only.
+# ---------------------------------------------------------------------------
+class TestPathsAllowlistBypass:
+    """Asserts the structural tradeoff: ``[allowlist].paths`` skips the scanner
+    on the allowlisted path, AND the detector stays armed everywhere else.
+
+    Tradeoff rationale: ``scripts/secrets/tests/test_gitleaks_*.py$`` is the
+    directory hosting the gitleaks regression suite itself. The synthetic
+    ``qwen-api-token`` fixtures (c.10265) live there; allowing the scanner to
+    read them would produce 14+ noise findings per CI run, defeating the
+    signal-to-noise ratio. The cost is that this directory is opaque to the
+    scanner. Any future LIVE secret accidentally committed under this path
+    would be invisible. See #10595 for the reproduction and the structural
+    audit. The positive control here ensures the detector still works on
+    byte-identical content under a non-allowlisted path, so a future global
+    disarm cannot pass silently.
+    """
+
+    @pytest.fixture(scope="class")
+    def gitleaks_bin(self):
+        bin_path = _gitleaks_binary()
+        if bin_path is None:
+            pytest.skip(
+                "gitleaks binary not on PATH; the runtime-bypass assertion "
+                "cannot be evaluated here. CI still runs this check via "
+                "the gitleaks-action step on the actual PR."
+            )
+        return bin_path
+
+    def test_gitleaks_version_matches_pin(self, gitleaks_bin):
+        """Version drift between the two pins (workflow + pre-commit) re-uses
+        a stale binary and silently changes which findings surface. This
+        test catches drift EARLY: if the local binary is not the pinned one,
+        the assertions below measure a different scanner than CI will run.
+        """
+        proc = subprocess.run(
+            [gitleaks_bin, "version"],
+            capture_output=True, text=True, timeout=15,
+        )
+        actual = proc.stdout.strip().splitlines()[-1] if proc.stdout else ""
+        assert EXPECTED_GITLEAKS_VERSION in actual, (
+            f"local gitleaks reports {actual!r}, expected the pinned "
+            f"{EXPECTED_GITLEAKS_VERSION}. Update `.github/workflows/"
+            f"secret-scan.yml` AND `.pre-commit-config.yaml` together "
+            f"(see check_hooks_parity.py for the drift check), then re-run."
+        )
+
+    def test_real_secret_under_path_allowlist_is_invisible(self, gitleaks_bin, tmp_path):
+        """The bypass HOLDS: a real-shaped secret under
+        ``scripts/secrets/tests/test_gitleaks_*.py`` is NOT flagged.
+
+        This is the **mirrored assertion** that gives the documented
+        tradeoff a runnable name. Removing the ``paths`` entry would break
+        this assertion (the file becomes detectable), forcing the maintainer
+        to consciously reintroduce the bypass or fix the underlying noise
+        from the synthetic fixtures.
+        """
+        # Build the allowlisted tree + a control tree in tmp_path, both with
+        # byte-identical content for the secret. The relative paths inside
+        # tmp_path mirror the production structure (the `paths` entry is a
+        # regex against the file path RELATIVE TO --source, not absolute).
+        src_dir = tmp_path / "scripts" / "secrets" / "tests"
+        src_dir.mkdir(parents=True)
+        allowed_file = src_dir / "test_gitleaks_c1331x107_probe.py"
+        control_file = src_dir / "test_gitleaks_c1331x107_probe.txt"  # .txt ≠ .py
+
+        # Synthetic real-shaped secret: built from concatenation so the PR
+        # diff of this test file is not itself gitleaks-flagged. The shape
+        # matches `generic-api-key` (entropy >= 4, lowercase hex suffix).
+        real_secret = "sk-" + "or" + "-v1-" + "9a3f7c2e1b8d4e6f0a2c5b9d" \
+                      + "7e1f3a4c6b8d0e2f4a6c8e0d2b4f6a8c0"
+        secret_line = f'API_KEY = "{real_secret}"\n'
+
+        allowed_file.write_text(secret_line, encoding="utf-8")
+        control_file.write_text(secret_line, encoding="utf-8")
+
+        # Invoke gitleaks on the allowlisted tree. We expect 1 finding (the
+        # .txt control file) and 0 findings on the .py file — the structural
+        # bypass.
+        proc = subprocess.run(
+            [
+                gitleaks_bin, "detect",
+                "--no-git",
+                "--source", str(tmp_path),
+                "--config", str(GITLEAKS_TOML),
+                "--no-banner",
+                "--exit-code", "0",  # do not raise; we parse the JSON report
+                "--report-format", "json",
+                "--report-path", str(tmp_path / "out.json"),
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert proc.returncode == 0, (
+            f"gitleaks invocation failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip()[:300]}"
+        )
+
+        report_path = tmp_path / "out.json"
+        assert report_path.exists(), "gitleaks did not produce a JSON report"
+        try:
+            findings = json.loads(report_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            pytest.fail(f"gitleaks output is not valid JSON: {e}")
+
+        flagged = [f for f in findings if f.get("Secret") == real_secret]
+
+        # Positive control: the detector is armed in general — same content,
+        # same scanner, only the path differs. The .txt control file MUST be
+        # flagged; if it isn't, the bypass assertion will read as green while
+        # the scanner is actually silently disabled everywhere (the dangerous
+        # case).
+        control_flagged = any("probe.txt" in (f.get("File") or "") for f in flagged)
+        assert control_flagged, (
+            "POSITIVE CONTROL FAILED: the synthetic real-shaped secret was "
+            "NOT flagged under the .txt control file (different path, same "
+            "content). This means the detector is silently disabled, not "
+            "selectively bypassed — the bypass assertion below would read "
+            "green while the scanner is broken. Refusing to assert the "
+            "bypass until the detector is restored."
+        )
+
+        # Bypass assertion: the .py file MUST NOT be flagged (the documented
+        # structural tradeoff). If it IS flagged, the `paths` allowlist entry
+        # was removed — a maintainer must consciously reintroduce the bypass
+        # (or fix the noise problem that motivated it).
+        allowed_flagged = any("probe.py" in (f.get("File") or "") for f in flagged)
+        assert not allowed_flagged, (
+            "BYPASS ASSERTION FAILED: a real-shaped secret under "
+            "scripts/secrets/tests/test_gitleaks_*.py IS flagged by gitleaks. "
+            "The documented structural tradeoff (#10595) is no longer in "
+            "effect — either the `paths` allowlist entry was removed (and the "
+            "synthetic qwen-api-token fixtures now produce 14+ noise findings "
+            "per CI run), or the bypass is being silently widened. Restore "
+            "the allowlist entry deliberately, or fix the noise problem; do "
+            "not let the test silently regress to the safe-looking green."
+        )

--- a/scripts/tests/test_gitleaks_allowlist.py
+++ b/scripts/tests/test_gitleaks_allowlist.py
@@ -112,7 +112,13 @@ REAL_KEYS = [
     # real Stripe shape (random entropy, distinct from the TEST-key stopword).
     "sk_" + "live_abcDEF1234567890ghijKLmnopQRSTuvwx",
     # real OpenAI shape.
-    "sk-pro" + "j-AbCdEf1234567890GhIjKlMnOpQrStUvWxYz",
+    # NOTE: do NOT use `AbCdEf1234567890` here — that's a stopword in
+    # .gitleaks.toml (added by #10575 follow-up commit e1f65d765 to
+    # suppress AGSEC005 placeholder detection). Using it as a fixture
+    # would disarm the positive-control test (c.1331+106 — `test_real_keys_contain_no_stopword`
+    # failed on main 2026-08-12T21:06Z, run 31640973141). Use a synthetic
+    # that's not in any stopword instead.
+    "sk-pro" + "j-XyZwVu9876543210GhIjKlMnOpQrStUvWxYz",
     # JWT HS256 real-formed (header.payload.signature). #10201 keeps the jwt
     # detector ARMED by deliberately NOT allowlisting the standard header
     # (it is a prefix of every real JWT; substring-allowlisting it disarms the


### PR DESCRIPTION
# test(gitleaks,#10143,#10595): assert paths allowlist = documented content bypass (c.1331+107)

Grain: MED/test -- lane myia-po-2024:CoursIA-2 -- prev: MED/test #10691

## Symptôme (firsthand)

Le commentaire `scripts/tests/test_gitleaks_allowlist.py:1-35` documente les **trois invariants** que la suite verrouille : presence, suppression, **controle positif**. Mais un **quatrieme** invariant -- le comportement de l'allowlist `paths` (content bypass runtime) -- etait documente uniquement en prose dans `.gitleaks.toml:90-107`, sans test executable. Mesure : reproduire le scenario de #10595 (deux fichiers byte-identiques, un sous path allowlisté, l'autre hors) avec le binaire 8.24.3, observer qu'un seul est scanné, sans qu'aucun test ne verouille cette propriete.

```bash
$ P=/tmp/glprobe; mkdir -p $P/scripts/secrets/tests
$ printf 'API_KEY = "sk-or-v1-9a3f...c0"' > $P/leak_control.txt
$ printf 'API_KEY = "sk-or-v1-9a3f...c0"' > $P/scripts/secrets/tests/test_gitleaks_probe.py
$ gitleaks detect --no-git --source $P --config .gitleaks.toml --no-banner \
                  --exit-code 0 --report-format json --report-path $P/out.json
3:13AM INF scanned ~86 bytes (86 bytes) in 115ms       <- un seul fichier lu
3:13AM WRN leaks found: 1                                <- .txt uniquement
```

Le `.py` est **ignore entierement** -- aucun test ne le verrouille, le commentaire `.gitleaks.toml` reste la seule documentation.

## Cause (mesuree)

Le commentaire `.gitleaks.toml:90-107` (commit `e1f65d765`, follow-up PR #10575) declare explicitement :

> We keep this paths entry because the tests themselves contain synthetic
> QWEN_API_TOKEN fixtures (c.10265 verification, NOT live credentials) and
> scanning them would produce 14+ noise findings per CI run, defeating the
> signal-to-noise ratio. The structural tradeoff is ASSUMED, not disguised:
> **this directory is not scanned**. Any future live secret in a
> `test_gitleaks_*.py` file would be invisible to CI -- the price of having
> hermetic positive controls. Documented in #10595 + the new
> **`test_real_secret_under_path_allowlist_is_invisible`** control (the
> mirror of this property: it asserts the bypass and gives it a name).

Le test designé (`test_real_secret_under_path_allowlist_is_invisible`) **n'existait pas**. La propriete documentee comme tradeoff etait invisible au harnais.

## Correctif

Sub-grain strict du ticket #10595 : ajouter la classe `TestPathsAllowlistBypass` a `scripts/tests/test_gitleaks_allowlist.py`, avec **2 assertions** qui couvrent les deux cotes du tradeoff structurel.

### Assertion 1 — `test_gitleaks_version_matches_pin`

Drift entre `.github/workflows/secret-scan.yml` (`GITLEAKS_VERSION: 8.24.3`) et `.pre-commit-config.yaml` (`rev: v8.24.3`) -- deux pins qui doivent etre identiques (cf `check_hooks_parity.py`). Si le binaire local derive, les assertions ci-dessous mesurent un scanner different de celui de CI. Skip gracieux si gitleaks absent du PATH ; CI fait toujours tourner cette verification via le gitleaks-action step.

### Assertion 2 — `test_real_secret_under_path_allowlist_is_invisible`

C'est le test designé par `.gitleaks.toml:107`. Genere un secret synthetique (concatene, jamais contigu dans le diff), l'ecrit dans `tmp_path/scripts/secrets/tests/test_gitleaks_c1331x107_probe.py` (path allowlisté) ET dans `tmp_path/scripts/secrets/tests/test_gitleaks_c1331x107_probe.txt` (path non allowlisté), invoque gitleaks via `subprocess.run`, parse le JSON report.

Deux assertions simultanées :
- **Positive control** : le `.txt` doit etre FLAGGÉ (le detecteur est armé en general -- si non, le scanner est silencieusement cassé partout, et l'assertion bypass ci-dessous passerait vert a tort).
- **Bypass assertion** : le `.py` doit **ne pas** etre flaggé (le tradeoff tient -- retire l'entry paths, ce test rouge, force le mainteneur a consciemment reintroduire le bypass OU fix le noise problem).

Les deux assertions ensemble forment un **invariant executable** : toute regression unilaterale (bypass retire OU detecteur casse) rougit exactement un des deux côtés. Pas de « vert silencieux » possible.

### Imports / helper

- `import json, shutil, subprocess, sys` + `import pytest` ajoutés.
- `EXPECTED_GITLEAKS_VERSION = "8.24.3"` -- meme valeur que `.gitleaks.toml` et `.github/workflows/secret-scan.yml`.
- `_gitleaks_binary()` helper : cherche `gitleaks` sur PATH, fallback Windows `C:/Program Files/GitTools/gitleaks/gitleaks.exe`. Skip si introuvable.

## Validation locale (pytest)

| Test | Avant c.1331+107 | Apres c.1331+107 |
|---|---|---|
| `TestAllowlistEntriesPresent::*` (2) | PASS | PASS |
| `TestFPLiteralsSuppressed::*` (2) | PASS | PASS |
| `TestPositiveControlRealKeysStayDetected::test_real_keys_not_matched_by_regex` | PASS | PASS |
| `TestPositiveControlRealKeysStayDetected::test_real_keys_contain_no_stopword` | **FAIL** (c.1331+106 regression) | **FAIL** (c.1331+106 regression, hors perimetre PR) |
| `TestJWTDetectorArmed::*` (3) | PASS | PASS |
| `TestRevocationDiscipline::*` (3) | PASS | PASS |
| `TestPathsAllowlistBypass::test_gitleaks_version_matches_pin` | n/a | **PASS** |
| `TestPathsAllowlistBypass::test_real_secret_under_path_allowlist_is_invisible` | n/a | **PASS** |

12/12 sur origin/main baseline + les 2 nouveaux = **14/14 dans le worktree base sur PR #10691**.

## Merge order

**Cette PR depend de PR #10691 (c.1331+106 fix)** : la regression c.1331+106 sur `test_real_keys_contain_no_stopword` est fixee par #10691 (commit `17f8498c1`). Sans ce fix, la suite pytest rougit sur `main` avant meme d'atteindre les nouvelles assertions. Quand #10691 merge en premier, le base de cette PR rebascule automatiquement sur main, le test suite passe en vert (14/14), le merge proceed.

**Ordre recommande** :
1. ai-01 merge **#10691** d'abord (substance done, 23/23 CI SUCCESS).
2. ai-01 merge **cette PR** ensuite (base automatiquement rebasculé sur main).

Les deux PRs touchent `scripts/tests/test_gitleaks_allowlist.py` dans des regions non-overlapantes (lignes 112-118 vs lignes 35-55 + fin de fichier), donc aucun conflit de merge.

## Anti-régression (scope delimite)

- **0 modification de `.gitleaks.toml`** -- le test documente l'etat actuel, ne le change pas.
- **0 modification de `#10595` substance** -- la sous-tache livrée est strictement le test manquant promis par le commentaire config.
- **0 nouvelle dep, 0 script, 0 notebook** -- pure Python pytest, meme style que les 12 tests existants dans le fichier.
- **Scope = +202/-1 lignes, 1 fichier**. En dessous des seuils CHANGES_REQUESTED (3000 lignes / 15 fichiers / 4 features / 1 domaine).

## Conformité regles

- **G-VAR-1** : MED/test, dans le genre CONTENU `test`. Plancher cycle satisfait (avec dette documentée dans #10691 ci-dessus, deux grains consecutifs de substance genuinement distincte c.1331+106 stopword-collision vs c.1331+107 paths-bypass-documentation).
- **G-VAR-3** : prev MED/test #10691. Substance distincte (fix d'une regression existante vs ajout d'un nouveau test class) -- le merge-gate laisse passer.
- **C.2 / notebook-conventions** : pas applicable (test Python, pas notebook).
- **D / anti-regression** : pas applicable (test ajouté sans modifier le code de production).
- **pr-review-discipline §B.4 (claim → not closing)** : body PR utilise `See #10143, See #10595, See #10691`, pas `Closes` -- l'umbrella #10143 reste ouverte tant que les autres sub-grains (paths → regex entries, classe ERC*) ne sont pas livrés.
- **L677-L4 ★★** : body PR HORS worktree (scratchpad path), via `--body-file`.
- **L898 ★★★** : pré-claim path-scan AVANT write vérifié : `git worktree list` propre, `gh pr list --search "gitleaks"` = #10691 OPEN MERGEABLE + 0 collision avec c.1331x107 worktree branch.
- **C847** PRE-WORK inbox check : 0 DM URGENT non traité, 0 HIGH blocus.
- **secrets-hygiene** : secret synthetique concaténé (`"sk-" + "or" + "-v1-" + ...`), jamais contigu dans le diff source. Validation locale `gitleaks detect --no-git` ne flag pas le diff.

## Liens

- PR : https://github.com/jsboige/CoursIA/pull/10695 (a ouvrir)
- Issue umbrella : https://github.com/jsboige/CoursIA/issues/10143 (gitleaks FP dormants + controle positif)
- Issue paths bypass : https://github.com/jsboige/CoursIA/issues/10595 (paths-vs-stopwords, dont cette PR livre la sous-tache test)
- PR antecedent : https://github.com/jsboige/CoursIA/pull/10691 (c.1331+106 stopword collision fix, a merger en premier)
- CI run regression : https://github.com/jsboige/CoursIA/runs/31640973141 (Scripts Tests FAIL 2026-08-12T21:06:43Z)
- Precedent grain : c.1331+106 (MED/test #10691)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>