### PR TITLE
Notebook: mesurer la dérive d'un copilot (Copilot Gutenberg — chaîne vs gate)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -119,6 +119,20 @@ chemin (champ mort). La leçon : le schéma n'est pas le formulaire — les
 trois grandeurs (chemins, coût LLM, champs morts) sont émergentes. stdlib
 pure, aucune clé, aucun réseau.
 
+Un dernier notebook compagnon [`mesurer-la-derive-dun-copilot.ipynb`](mesurer-la-derive-dun-copilot.ipynb)
+traite le **Copilot Gutenberg** (Parcours 1) — la seconde et dernière
+fonctionnalité GenAI cœur qui restait sans notebook. Thèse : *le gate humain
+à chaque étape ne protège pas de la dérive d'une chaîne*. Les six
+transformations du Copilot (résumé, enhancement, traduction, rewriting,
+image, alt text) ont des effets informationnels distincts — certaines
+ajoutent, d'autres réécrivent, d'autres **détruisent** (résumé, traduction).
+Le notebook modélise chaque transformation comme une fonction vectorielle
+déterministe et mesure le **rappel de l'original** (projection normalisée,
+bornée) après des séquences validées : une chaîne de transformations
+destructrices complémentaires perd environ la moitié du document, quand une
+chaîne de réversibles préserve 100 % — alors que chaque étape, isolément,
+passait le gate. numpy, sans clé ni réseau ; fixture synthétique 100 %.
+
 ---
 
 ## Sections
@@ -238,6 +252,8 @@ attendues.
   fuite cross-environnement et accident de réindexation, mesurés sur un vector store partitionné
 - [`auditer-un-formulaire-conditionnel.ipynb`](auditer-un-formulaire-conditionnel.ipynb) —
   AI Forms conditionnelles comme machine à états, énumération des chemins et champs morts
+- [`mesurer-la-derive-dun-copilot.ipynb`](mesurer-la-derive-dun-copilot.ipynb) —
+  Copilot Gutenberg : dérive d'une chaîne de transformations, le gate par étape ne protège pas la chaîne
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -130,6 +130,19 @@ catalogue), pas pour le cœur éditorial.
 > la valeur dans un déploiement donné. Cartographier les *flux de
 > texte réels* avant de choisir les modules à activer.
 
+> **Notebook compagnon.** [`mesurer-la-derive-dun-copilot.ipynb`](mesurer-la-derive-dun-copilot.ipynb)
+> creuse le **gate humain** du Copilot (« valide ou rejette »). Les six
+> transformations n'ont pas le même effet informationnel : certaines
+> ajoutent (image, alt text), d'autres réécrivent sans perdre (enhancement,
+> rewriting), d'autres **détruisent** de l'information (résumé, traduction).
+> Le notebook modélise chaque transformation par une fonction vectorielle
+> déterministe (fixture Maison Valmont) et mesure le **rappel de l'original**
+> après des séquences validées. Leçon : une chaîne de transformations
+> destructrices complémentaires perd près de la moitié du document, quand
+> une chaîne de réversibles en préserve l'intégralité — alors que chaque
+> étape, isolément, passait le gate. *Le gate est local (étape par étape) ;
+> la dérive est globale (chaîne).*
+
 ---
 
 ## Parcours 2 — RAG sur corpus, et le piège du multi-environnement

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/mesurer-la-derive-dun-copilot.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/mesurer-la-derive-dun-copilot.ipynb
@@ -1,0 +1,785 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d4c8d56c",
+   "metadata": {},
+   "source": [
+    "# Mesurer la dérive d'un copilot — le gate par étape ne protège pas la chaîne\n",
+    "\n",
+    "*Recycler la documentation du projet LivresAgités (en sommeil) vers le dépôt\n",
+    "pédagogique. Ce notebook illustre le **Copilot Gutenberg** d'AI-Engine — la\n",
+    "seconde et dernière fonctionnalité GenAI cœur du dossier qui n'avait pas de\n",
+    "notebook compagnon (l'autre, AI Forms, a été traitée par le grain précédent).\n",
+    "Il est le compagnon exécutable du **Parcours 1** de\n",
+    "[`AI-Engine-WordPress`](./livresagites-parcours.md).*\n",
+    "\n",
+    "> **Thèse.** Le Copilot propose six transformations de texte — résumé,\n",
+    "> enhancement, traduction, rewriting, image, alt text — et un **gate\n",
+    "> humain** (« valide ou rejette l'insertion ») à chaque étape. Ce gate\n",
+    "> donne l'illusion d'une sûreté pas-à-pas. Mais les six transformations\n",
+    "> n'ont pas le même **effet informationnel** : certaines ajoutent (image,\n",
+    "> alt text), d'autres réécrivent sans perdre (enhancement, rewriting),\n",
+    "> d'autres encore **détruisent** de l'information (résumé, traduction). Et\n",
+    "> l'effet d'une transformation dépend de ce sur quoi elle s'applique : un\n",
+    "> résumé d'un résumé collapse, une traduction d'un texte déjà résumé perd\n",
+    "> le peu qu'il restait. **Le gate est local (étape par étape) ; la dérive\n",
+    "> est globale (chaîne).** Un Copilot ne protège pas de la dérive — il la\n",
+    "> rend consentie.\n",
+    "\n",
+    "Ce notebook ne dépend d'aucun service : pas de réseau, pas de modèle, pas\n",
+    "de clé. Les transformations sont **simulées** par des fonctions\n",
+    "déterministes sur des vecteurs (fréquences de termes) — ce qui est enseigné\n",
+    "est la *structure* de la dérive, pas une mesure sur un modèle particulier.\n",
+    "Le fixture est synthétique (« Maison Valmont »).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "204d5d87",
+   "metadata": {},
+   "source": [
+    "## 1. Le Copilot Gutenberg en une phrase\n",
+    "\n",
+    "AI-Engine ajoute un panneau **Copilot** dans l'éditeur Gutenberg de\n",
+    "WordPress. Le rédacteur écrit un brouillon ; le Copilot propose une\n",
+    "transformation ; le rédacteur *valide* ou *rejette*. Six transformations\n",
+    "sont offertes :\n",
+    "\n",
+    "| Transformation | Ce qu'elle fait |\n",
+    "|----------------|-----------------|\n",
+    "| **Résumé** | Condense un texte long en un paragraphe |\n",
+    "| **Enhancement** stylistique | Clarifie, reformule, ajuste le ton |\n",
+    "| **Traduction** | Traduit en préservant le registre |\n",
+    "| **Rewriting** | Propose plusieurs variantes d'un paragraphe |\n",
+    "| **Image d'en-tête** | Génère une illustration depuis un prompt |\n",
+    "| **Alt text** | Décrit une image en quelques mots |\n",
+    "\n",
+    "La pièce maîtresse, pédagogiquement, n'est aucune de ces transformations\n",
+    "prise isolément — c'est le **gate humain**. « Aucune réécriture\n",
+    "automatique, le brouillon reste sous contrôle humain. » C'est vrai à\n",
+    "l'échelle d'une transformation. Ce notebook demande : *et à l'échelle d'une\n",
+    "chaîne de transformations ?*\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bb93a3f",
+   "metadata": {},
+   "source": [
+    "## 2. Quatre natures informationnelles — pas six\n",
+    "\n",
+    "Les six transformations se classent en **quatre natures** selon leur effet\n",
+    "sur l'information du document source. Cette classification n'est pas\n",
+    "cosmétique : elle détermine ce que le gate humain peut, ou ne peut pas,\n",
+    "protéger.\n",
+    "\n",
+    "| Nature | Transformations | Effet sur l'original | Gate peut restaurer ? |\n",
+    "|--------|-----------------|----------------------|-----------------------|\n",
+    "| **Synthèse additive** | image, alt text | Ajoute du contenu dérivé (axe nouveau) | Oui (on retire l'ajout) |\n",
+    "| **Réécriture réversible** | enhancement, rewriting | Bruit de forme, fond préservé | Oui (on garde l'original) |\n",
+    "| **Projection partielle** | traduction | Perte du registre stylistique | Non (le registre est détruit) |\n",
+    "| **Réduction destructive** | résumé | Perte des thèmes mineurs, irréversible | Non (l'info mineure est détruite) |\n",
+    "\n",
+    "La ligne qui sépare les deux premières des deux dernières est la **frontière\n",
+    "de réversibilité**. En-deçà (synthèse, réécriture), le gate humain est une\n",
+    "vraie garantie : on peut toujours revenir. Au-delà (projection, réduction),\n",
+    "le gate est une **approbation d'une perte** : valider un résumé, c'est\n",
+    "consentir à ne jamais revoir les nuances qu'il a tu — même si on rejette\n",
+    "l'étape suivante.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aae38fbb",
+   "metadata": {},
+   "source": [
+    "## 3. Le fixture — un document et son vecteur\n",
+    "\n",
+    "On représente un document par un **vecteur de fréquences de termes** sur un\n",
+    "vocabulaire fixe. C'est une représentation rudimentaire (pas de syntaxe, pas\n",
+    "d'ordre) mais suffisante pour mesurer la dérive : ce qui nous intéresse est\n",
+    "*combien de l'original survit*, pas la qualité littéraire.\n",
+    "\n",
+    "Le fixture est une page de catalogue Valmont : la fiche d'un livre, décrit\n",
+    "par la fréquence de dix termes éditoriaux.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b12a8721",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.654155Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.653629Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.742696Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.742173Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Document source (sommet de la fiche du livre) :\n",
+      "  recit : 3\n",
+      "  personnage : 2\n",
+      "  style : 4\n",
+      "  intrigue : 2\n",
+      "  plume : 1\n",
+      "  chapitre : 2\n",
+      "  denouement : 1\n",
+      "  voix : 3\n",
+      "  rythme : 1\n",
+      "  image : 0\n",
+      "  norme au carree : 49.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Aucune dependance externe hors numpy.\n",
+    "import numpy as np\n",
+    "\n",
+    "# Vocabulaire d'une page catalogue Valmont (10 termes editoriaux).\n",
+    "VOCABULAIRE = [\"recit\", \"personnage\", \"style\", \"intrigue\", \"plume\",\n",
+    "               \"chapitre\", \"denouement\", \"voix\", \"rythme\", \"image\"]\n",
+    "\n",
+    "# Document source : fiche d'un livre (frequence de chaque terme).\n",
+    "# Note : 'image' est a 0 -- la page texte ne decrit pas d'image. Les axes\n",
+    "# d'ajout (image, alt_text) sont donc vraiment orthogonaux a l'original.\n",
+    "v0 = np.array([3.0, 2.0, 4.0, 2.0, 1.0, 2.0, 1.0, 3.0, 1.0, 0.0])\n",
+    "\n",
+    "print(\"Document source (sommet de la fiche du livre) :\")\n",
+    "for terme, freq in zip(VOCABULAIRE, v0):\n",
+    "    print(\"  \" + terme + \" : \" + str(int(freq)))\n",
+    "print(\"  norme au carree : \" + str(float(v0 @ v0)))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c282e62f",
+   "metadata": {},
+   "source": [
+    "### La métrique : le rappel de l'original\n",
+    "\n",
+    "Pour mesurer la dérive, on calcule le **rappel** — la fraction de l'original\n",
+    "qui survit dans le vecteur courant. Concrètement : la projection du vecteur\n",
+    "courant sur le vecteur original, normalisée.\n",
+    "\n",
+    "$$\\text{rappel}(v) = \\frac{v \\cdot v_0}{v_0 \\cdot v_0}$$\n",
+    "\n",
+    "- Si $v = v_0$ : rappel = 1,0 (rien n'a bougé).\n",
+    "- Si $v$ ajoute du contenu **orthogonal** (une image sur un axe nouveau) :\n",
+    "  rappel = 1,0 (l'original est intact, juste dilué — le rappel *ne pénalise\n",
+    "  pas l'ajout*).\n",
+    "- Si $v$ atténue ou supprime des composantes de $v_0$ : rappel < 1,0 (perte).\n",
+    "\n",
+    "C'est cette propriété qui rend le rappel supérieur au cosinus pour notre\n",
+    "propos : le cosinus confond *perte* et *dilution* (les deux le font baisser) ;\n",
+    "le rappel isole la perte. Une synthèse additive (image) et une réduction\n",
+    "(résumé) baissent toutes deux le cosinus, mais pour des raisons opposées —\n",
+    "seul le rappel les distingue.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7a24d72e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.744324Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.743802Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.750064Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.749548Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rappel(v0, v0) = 1.0  (doit valoir 1.0)\n",
+      "rappel(v0 + ajout_image, v0) = 1.0  (doit valoir 1.0 : ajout non penalise)\n",
+      "cosinus(v0 + ajout_image, v0) = 0.868  (baisse : dilution)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def rappel(v_courant, v_original):\n",
+    "    \"\"\"Fraction de l'original qui survit dans v_courant.\n",
+    "\n",
+    "    Projection normalisee : (v_courant . v_original) / (v_original . v_original).\n",
+    "    Vaut 1.0 si l'original est intact (memes composantes), < 1.0 si de l'information\n",
+    "    de l'original a ete perdue, = 1.0 si on a seulement ajoute du contenu orthogonal.\n",
+    "    \"\"\"\n",
+    "    denom = float(v_original @ v_original)\n",
+    "    if denom == 0.0:\n",
+    "        return 0.0\n",
+    "    # Plafonne a 1.0 : une fraction de l'original ne peut pas depasser 100 %.\n",
+    "    # Le bruit additif (enhancement, rewriting) pousse legerement au-dessus ;\n",
+    "    # c'est un artefact, pas une retention superieure a l'original.\n",
+    "    return min(1.0, float(v_courant @ v_original) / denom)\n",
+    "\n",
+    "\n",
+    "def cosinus(a, b):\n",
+    "    \"\"\"Cosinus entre deux vecteurs (mesure de dilution, pas de perte).\"\"\"\n",
+    "    na, nb = np.linalg.norm(a), np.linalg.norm(b)\n",
+    "    if na == 0 or nb == 0:\n",
+    "        return 0.0\n",
+    "    return float(a @ b / (na * nb))\n",
+    "\n",
+    "\n",
+    "# Sanity check.\n",
+    "print(\"rappel(v0, v0) = \" + str(rappel(v0, v0)) + \"  (doit valoir 1.0)\")\n",
+    "v_ajout = v0.copy()\n",
+    "v_ajout[9] += 4.0   # ajout orthogonal sur l'axe 'image'\n",
+    "print(\"rappel(v0 + ajout_image, v0) = \" + str(round(rappel(v_ajout, v0), 3)) + \"  (doit valoir 1.0 : ajout non penalise)\")\n",
+    "print(\"cosinus(v0 + ajout_image, v0) = \" + str(round(cosinus(v_ajout, v0), 3)) + \"  (baisse : dilution)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38d7223c",
+   "metadata": {},
+   "source": [
+    "## 4. Les six transformations, en vecteurs\n",
+    "\n",
+    "Chaque transformation est modélisée par une **fonction déterministe sur le\n",
+    "vecteur**. Ce ne sont pas de vraies transformations de texte — ce sont des\n",
+    "*fables vectorielles* qui capturent la **nature informationnelle** de\n",
+    "chacune. Le résumé seuille (garde les $k$ plus grandes composantes) ; la\n",
+    "traduction atténue les dimensions de registre ; l'image ajoute sur un axe\n",
+    "nouveau. La reproductibilité est garantie par des graines fixes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2d2af733",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.751650Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.751650Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.756275Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.756275Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def resume(v, k=4):\n",
+    "    \"\"\"REDUCTION destructive : garde les k plus grandes composantes,\n",
+    "    annule les autres. L'information mineure est detruite.\"\"\"\n",
+    "    w = np.zeros_like(v)\n",
+    "    idx = np.argsort(v)[::-1][:k]\n",
+    "    w[idx] = v[idx]\n",
+    "    return w\n",
+    "\n",
+    "\n",
+    "def enhancement(v):\n",
+    "    \"\"\"REECRITURE reversible : bruit leger proportionnel au poids.\n",
+    "    L'information principale est preservee.\"\"\"\n",
+    "    rng = np.random.RandomState(7)\n",
+    "    return v + 0.10 * rng.randn(len(v)) * np.abs(v)\n",
+    "\n",
+    "\n",
+    "def rewriting(v):\n",
+    "    \"\"\"REECRITURE plus marquee qu'enhancement. Reversible mais bruyante.\"\"\"\n",
+    "    rng = np.random.RandomState(13)\n",
+    "    return v + 0.15 * rng.randn(len(v)) * np.abs(v)\n",
+    "\n",
+    "\n",
+    "def traduction(v):\n",
+    "    \"\"\"PROJECTION partielle : attenuation des dimensions de registre\n",
+    "    (style, plume, voix) + leger bruit. Perte du registre, fond preserve.\"\"\"\n",
+    "    w = v.copy()\n",
+    "    for i in [2, 4, 7]:   # style, plume, voix\n",
+    "        w[i] *= 0.5\n",
+    "    rng = np.random.RandomState(11)\n",
+    "    return w + 0.05 * rng.randn(len(v)) * np.abs(v)\n",
+    "\n",
+    "\n",
+    "def image(v):\n",
+    "    \"\"\"SYNTHESE additive : ajoute une description image sur un axe orthogonal.\"\"\"\n",
+    "    w = v.copy()\n",
+    "    w[9] += 4.0   # axe 'image'\n",
+    "    return w\n",
+    "\n",
+    "\n",
+    "def alt_text(v):\n",
+    "    \"\"\"SYNTHESE additive courte : comme image, amplitude plus faible.\"\"\"\n",
+    "    w = v.copy()\n",
+    "    w[9] += 2.5\n",
+    "    return w\n",
+    "\n",
+    "\n",
+    "TRANSFORMATIONS = {\n",
+    "    \"resume\":      resume,\n",
+    "    \"enhancement\": enhancement,\n",
+    "    \"rewriting\":   rewriting,\n",
+    "    \"traduction\":  traduction,\n",
+    "    \"image\":       image,\n",
+    "    \"alt_text\":    alt_text,\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "1186da05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.758279Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.758279Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.765189Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.764671Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rappel de l'original apres une transformation unique :\n",
+      "\n",
+      "  transformationrappel   cosinus   nature (rappel + norme)\n",
+      "  ----------------------------------------------------------------\n",
+      "  resume        0.776    0.881     perte (rappel < 0.85)\n",
+      "  enhancement   1.0      0.994     reecriture reversible (norme stable)\n",
+      "  rewriting     1.0      0.996     reecriture reversible (norme stable)\n",
+      "  traduction    0.732    0.941     perte (rappel < 0.85)\n",
+      "  image         1.0      0.868     synthese additive (norme en hausse)\n",
+      "  alt_text      1.0      0.942     synthese additive (norme en hausse)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Profil de chaque transformation appliquee SEULE au document source.\n",
+    "def nature_transformation(v_original, v_courant):\n",
+    "    \"\"\"Classe une transformation par son effet informationnel.\n",
+    "\n",
+    "    Le rappel seul ne distingue pas une reecriture (bruit, norme stable)\n",
+    "    d'une synthese additive (ajout, norme en hausse) -- les deux ont un\n",
+    "    rappel ~1.0. On ajoute donc le ratio de norme pour separer.\n",
+    "    \"\"\"\n",
+    "    r = rappel(v_courant, v_original)\n",
+    "    if r < 0.85:\n",
+    "        return \"perte (rappel < 0.85)\"\n",
+    "    ratio_norme = np.linalg.norm(v_courant) / np.linalg.norm(v_original)\n",
+    "    if ratio_norme > 1.05:\n",
+    "        return \"synthese additive (norme en hausse)\"\n",
+    "    return \"reecriture reversible (norme stable)\"\n",
+    "\n",
+    "\n",
+    "print(\"Rappel de l'original apres une transformation unique :\")\n",
+    "print()\n",
+    "print(\"  \" + \"transformation\".ljust(14) + \"rappel   cosinus   nature (rappel + norme)\")\n",
+    "print(\"  \" + \"-\" * 64)\n",
+    "for nom, f in TRANSFORMATIONS.items():\n",
+    "    w = f(v0)\n",
+    "    r = rappel(w, v0)\n",
+    "    c = cosinus(w, v0)\n",
+    "    print(\"  \" + nom.ljust(14) + str(round(r, 3)).ljust(9) + str(round(c, 3)).ljust(10) + nature_transformation(v0, w))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1185191f",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Le tableau rend la §2 lisible par les nombres. Trois groupes se séparent\n",
+    "nettement sur le **rappel** :\n",
+    "\n",
+    "- **Synthèse additive** (`image`, `alt_text`) : rappel = 1,0 — l'original est\n",
+    "  intact, le vecteur a juste grossi sur un axe nouveau. Le cosinus baisse\n",
+    "  (dilution), mais c'est un artefact, pas une perte.\n",
+    "- **Réécriture réversible** (`enhancement`, `rewriting`) : rappel élevé\n",
+    "  (~0,9+) — du bruit sur la forme, le fond préservé.\n",
+    "- **Perte** (`résumé`, `traduction`) : rappel abaissé — de l'information de\n",
+    "  l'original a été effectivement détruite.\n",
+    "\n",
+    "Une seule mesure (le rappel) fait le travail que la lecture du menu\n",
+    "« six transformations » ne fait pas : elle révèle que le résumé et l'image,\n",
+    "présentés côte à côte dans le panneau Copilot, n'ont **rien à voir** — l'un\n",
+    "détruit, l'autre ajoute.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "182d533a",
+   "metadata": {},
+   "source": [
+    "## 5. La chaîne — la dérive est cumulative\n",
+    "\n",
+    "C'est ici que le gate humain montre sa limite. Appliquons non plus une\n",
+    "transformation, mais une **séquence** — chacune validée par le rédacteur —\n",
+    "et mesurons le rappel à la fin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d8463e36",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.766744Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.766744Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.772936Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.772417Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rappel final apres chaque chaine :\n",
+      "\n",
+      "  A (destructrice)       -> rappel 0.548    (45 % de l'original perdu)\n",
+      "  B (benigne)            -> rappel 1.0      (0 % de l'original perdu)\n",
+      "  C (collapse)           -> rappel 0.776    (22 % de l'original perdu)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def rappel_apres_chaine(v_original, chaine):\n",
+    "    \"\"\"Applique une chaine de transformations (par nom) a l'original,\n",
+    "    renvoie le rappel final.\n",
+    "    \"\"\"\n",
+    "    v = v_original.copy()\n",
+    "    for nom in chaine:\n",
+    "        v = TRANSFORMATIONS[nom](v)\n",
+    "    return rappel(v, v_original)\n",
+    "\n",
+    "\n",
+    "# Trois chaines candidates, chacune plausible pour un redacteur.\n",
+    "chaines = {\n",
+    "    \"A (destructrice)\":      [\"resume\", \"traduction\", \"enhancement\"],\n",
+    "    \"B (benigne)\":           [\"enhancement\", \"rewriting\", \"alt_text\"],\n",
+    "    \"C (collapse)\":          [\"resume\", \"resume\"],\n",
+    "}\n",
+    "\n",
+    "print(\"Rappel final apres chaque chaine :\")\n",
+    "print()\n",
+    "for nom, chaine in chaines.items():\n",
+    "    r = rappel_apres_chaine(v0, chaine)\n",
+    "    pertes = round((1.0 - r) * 100)\n",
+    "    print(\"  \" + nom.ljust(22) + \" -> rappel \" + str(round(r, 3)).ljust(7) + \"  (\" + str(pertes) + \" % de l'original perdu)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2adeada2",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Les trois chaînes ont la même longueur (deux ou trois étapes), et **chaque\n",
+    "étape individuelle passait le gate humain** — aucune n'aurait été rejetée à\n",
+    "la lecture, car chaque transformation prise seule est légitime. Et pourtant :\n",
+    "\n",
+    "- **Chaîne A** (résumé → traduction → enhancement) perd environ la moitié de\n",
+    "  l'original. Le résumé a retiré les nuances ; la traduction a écrasé le\n",
+    "  registre qu'il restait ; l'enhancement a bruité le tout. Le rédacteur a\n",
+    "  validé trois fois, et la moitié du document est partie.\n",
+    "- **Chaîne B** (enhancement → rewriting → alt text) préserve l'original à\n",
+    "  100 %. Trois transformations, mais toutes réversibles ou additives : le\n",
+    "  fond tient, le rappel reste au plafond.\n",
+    "- **Chaîne C** (résumé → résumé) ne perd **rien de plus** qu'un seul\n",
+    "  résumé. Ce n'est pas que la chaîne soit sûre — c'est qu'il n'y a plus\n",
+    "  rien à perdre : le premier résumé a déjà tué les nuances, et le second\n",
+    "  bute sur le même plancher. La destruction a un **point bas**, et le\n",
+    "  résumé d'un résumé le confirme.\n",
+    "\n",
+    "C'est l'enseignement central : **le gate humain est local, la dérive est\n",
+    "globale**. La chaîne A perd deux fois (deux destructrices *complémentaires*\n",
+    "tuent des informations différentes), la chaîne C ne perd qu'une fois (la\n",
+    "deuxième destructive est *redondante* avec la première). Dans les deux cas,\n",
+    "aucune des étapes n'aurait été rejetée isolément — et dans les deux cas, le\n",
+    "résultat global n'est pas la somme des résultats locaux. Un Copilot sans\n",
+    "vision de la chaîne — sans afficher « il reste X % de l'original » — laisse\n",
+    "le rédacteur approuver une perte qu'il n'aurait pas acceptée d'un coup.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81d2c30f",
+   "metadata": {},
+   "source": [
+    "## 6. Où la dérive se produit — le profil étape par étape\n",
+    "\n",
+    "Le rappel final est un verdict ; le **profil** (rappel après chaque étape)\n",
+    "est le diagnostic. Où la dérive se produit-elle ? D'un seul tenant, ou\n",
+    "répartie ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "de3a6fd5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.775040Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.775040Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.780203Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.779689Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  A (destructrice)       initial=1.0  resume=0.78  traduction=0.53  enhancement=0.55  \n",
+      "  B (benigne)            initial=1.0  enhancement=1.0  rewriting=1.0  alt_text=1.0  \n",
+      "  C (collapse)           initial=1.0  resume=0.78  resume=0.78  \n"
+     ]
+    }
+   ],
+   "source": [
+    "def profil_chaine(v_original, chaine):\n",
+    "    \"\"\"Renvoie la liste des rappels apres chaque etape (incluant l'etat\n",
+    "    initial 1.0 en tete).\n",
+    "    \"\"\"\n",
+    "    profil = [1.0]\n",
+    "    v = v_original.copy()\n",
+    "    for nom in chaine:\n",
+    "        v = TRANSFORMATIONS[nom](v)\n",
+    "        profil.append(rappel(v, v_original))\n",
+    "    return profil\n",
+    "\n",
+    "\n",
+    "for nom, chaine in chaines.items():\n",
+    "    p = profil_chaine(v0, chaine)\n",
+    "    etiquettes = [\"initial\"] + chaine\n",
+    "    ligne = \"  \" + nom.ljust(22) + \" \"\n",
+    "    for e, r in zip(etiquettes, p):\n",
+    "        ligne += e + \"=\" + str(round(r, 2)) + \"  \"\n",
+    "    print(ligne)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ce3cca6",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Le profil révèle ce que le verdict final masque : **la dérive n'est pas\n",
+    "uniforme, elle a une géométrie**. Trois formes caractéristiques apparaissent :\n",
+    "\n",
+    "- **Chaîne A** : un escalier qui descend à chaque destructrice. Le résumé\n",
+    "  ampute (marche 1), la traduction finit le travail sur le registre\n",
+    "  (marche 2), et l'enhancement — réversible — n'ajoute qu'un plat. La\n",
+    "  dérive est *complète avant la dernière étape* : un Copilot qui afficherait\n",
+    "  le profil permettrait au rédacteur de voir que le dommage est fait dès la\n",
+    "  traduction.\n",
+    "- **Chaîne B** : une ligne plate au plafond. Trois étapes validées, zéro\n",
+    "  perte. C'est le profil d'une chaîne qui ne franchit jamais la frontière\n",
+    "  de réversibilité — exactement ce qu'on veut pour des contenus où le fond\n",
+    "  compte.\n",
+    "- **Chaîne C** : une seule marche, puis un plat. Le deuxième résumé ne\n",
+    "  descend pas plus que le premier. Le profil plat après la première marche\n",
+    "  est la *signature d'une transformation idempotente* — il n'y a plus rien\n",
+    "  à extraire.\n",
+    "\n",
+    "C'est la contre-mesure pédagogique : si le Copilot affichait le profil —\n",
+    "« après cette validation, il reste X % du document original » — le rédacteur\n",
+    "verrait le point de rupture (chaîne A), la préservation (chaîne B) ou le\n",
+    "plancher (chaîne C), et pourrait décider en connaissance de cause. Le gate\n",
+    "humain *pourrait* protéger la chaîne, à la condition expresse de l'instrumenter\n",
+    "avec une mémoire de la chaîne. Sans cette mémoire, le gate est une suite\n",
+    "d'approbations locales qui ne voient pas la dérive globale.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5271dc84",
+   "metadata": {},
+   "source": [
+    "## 7. Provenance et limites\n",
+    "\n",
+    "**Ce que ce notebook mesure.** La *structure* de la dérive d'un document\n",
+    "soumis à une chaîne de transformations : quelles transformations détruisent\n",
+    "(rappel baisse), lesquelles préservent (rappel stable), et comment l'effet\n",
+    "cumulé d'une chaîne validée étape par étape diffère de la somme des effets\n",
+    "individuels. Tout est déterministe sur fixture synthétique.\n",
+    "\n",
+    "**Ce qu'il ne mesure pas.** La qualité réelle des transformations (un\n",
+    "résumé vrai peut être excellent et sa perte acceptable ; un enhancement\n",
+    "vrai peut dégrader le style). Les transformations sont des *fables\n",
+    "vectorielles* qui capturent la nature informationnelle, pas le rendu\n",
+    "littéraire. La représentation par fréquences de termes ignore l'ordre, la\n",
+    "syntaxe, le sens — elle ne mesure que la *matière informationnelle*.\n",
+    "\n",
+    "**La limite du propos.** Le gate humain n'est pas inutile — il empêche les\n",
+    "dérives les plus visibles (un résumé faux, une traduction absurde). Ce\n",
+    "notebook ne dit pas « le gate ne sert à rien » ; il dit « le gate local ne\n",
+    "voit pas la dérive globale, et cette limite appelle une instrumentation ».\n",
+    "C'est une leçon de conception, pas un réquisitoire.\n",
+    "\n",
+    "**Pour aller plus loin.**\n",
+    "- [`auditer-un-formulaire-conditionnel.ipynb`](auditer-un-formulaire-conditionnel.ipynb) —\n",
+    "  autre angle sur le « comportement émergent non-lisible sur la définition\n",
+    "  statique » : un formulaire conditionnel comme machine à états.\n",
+    "- [`livresagites-parcours.md`](livresagites-parcours.md) Parcours 1 — la\n",
+    "  prose dont ce notebook est l'illustration exécutable, et sa leçon\n",
+    "  transposable (« cartographier les flux de texte réels »).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3501a50",
+   "metadata": {},
+   "source": [
+    "## 8. Exercices\n",
+    "\n",
+    "Les trois exercices suivants manipulent le document source, les six\n",
+    "transformations (`TRANSFORMATIONS`) et la métrique (`rappel`). Les stub\n",
+    "sont à compléter — `return None` ou `pass`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f05c8f4",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — rappel après une chaîne\n",
+    "\n",
+    "Écrire une fonction `rappel_chaine` qui, étant donné un vecteur original et\n",
+    "une liste de noms de transformations, renvoie le rappel final après\n",
+    "application de la chaîne complète. (Vous pouvez vous aider de\n",
+    "`rappel_apres_chaine` défini plus haut, ou le réécrire.)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "a972dbde",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.782236Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.781231Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.784219Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.784219Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def rappel_chaine(v_original, chaine):\n",
+    "    \"\"\"Renvoie le rappel de l'original apres application d'une chaine\n",
+    "    de transformations (liste de noms).\n",
+    "    \"\"\"\n",
+    "    # TODO : appliquer chaque transformation de la chaine, puis mesurer le rappel.\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c0a68b2e",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — la chaîne la plus destructrice\n",
+    "\n",
+    "Étant donné un vecteur original et une **liste de chaînes candidates**\n",
+    "(chacune une liste de noms de transformations), écrire\n",
+    "`chaine_la_plus_destructrice` qui renvoie la chaîne dont le rappel final\n",
+    "est le plus bas (celle qui détruit le plus d'information).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9d3449bd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.786276Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.785223Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.789804Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.789220Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def chaine_la_plus_destructrice(v_original, candidates):\n",
+    "    \"\"\"Parmi plusieurs chaines candidates, renvoie celle dont le rappel\n",
+    "    final est le plus bas (la plus destructrice).\n",
+    "    \"\"\"\n",
+    "    # TODO : calculer le rappel de chaque candidate, garder le min.\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b98f8bd",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — le profil étape par étape\n",
+    "\n",
+    "Écrire une fonction `profil` qui renvoie la liste des rappels après chaque\n",
+    "étape d'une chaîne (en tête la valeur 1,0 pour l'état initial). Permet de\n",
+    "localiser le point de rupture — là où la dérive se concentre.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "d581e6cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:20:57.791343Z",
+     "iopub.status.busy": "2026-08-13T01:20:57.791343Z",
+     "iopub.status.idle": "2026-08-13T01:20:57.794964Z",
+     "shell.execute_reply": "2026-08-13T01:20:57.794443Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def profil(v_original, chaine):\n",
+    "    \"\"\"Renvoie la liste des rappels apres chaque etape, en tete 1.0\n",
+    "    (etat initial). Le point de rupture est la marche ou le rappel\n",
+    "    chute le plus fort.\n",
+    "    \"\"\"\n",
+    "    # TODO : accumuler le rappel apres chaque transformation.\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fceb250",
+   "metadata": {},
+   "source": [
+    "## 9. Ce que ce notebook enseigne, en une ligne\n",
+    "\n",
+    "> **Un gate humain à chaque étape ne protège pas de la dérive d'une chaîne.**\n",
+    "> Le résumé détruit, l'image ajoute, l'enhancement bruite — et le rédacteur\n",
+    "> qui valide pas-à-pas ne voit pas qu'il a traversé une frontière de\n",
+    "> réversibilité. Le remède n'est pas plus de gate, c'est un gate qui se\n",
+    "> souvienne de la chaîne.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #10620

**Quoi:** Septième notebook du dossier `AI-Engine-WordPress/` : `mesurer-la-derive-dun-copilot.ipynb`. Compagnon du **Parcours 1** (Copilot Gutenberg) — la seconde et dernière fonctionnalité GenAI cœur qui restait sans notebook (la première, AI Forms, a été traitée au grain précédent #10620). Thèse : *le gate humain à chaque étape ne protège pas de la dérive d'une chaîne*. Les six transformations du Copilot (résumé, enhancement, traduction, rewriting, image, alt text) ont des effets informationnels distincts — certaines ajoutent (image, alt text), d'autres réécrivent sans perdre (enhancement, rewriting), d'autres **détruisent** de l'information (résumé, traduction).

**Preuve:** Exécuté avec le kernel `coursia-sae`, 9 cellules code, 0 erreur, 5 sorties. HEAD testé `5ababfa14`. Chaque transformation est une fonction vectorielle déterministe sur un fixture synthétique (Maison Valmont, vecteur de fréquences sur 10 termes ; `numpy`, graines fixes). Métrique = **rappel de l'original** = projection normalisée `(v·v0)/(v0·v0)`, **bornée à 1,0** (une fraction ne dépasse pas 100 % ; le bruit additif d'enhancement/rewriting qui la poussait au-dessus est un artefact neutralisé). Un classifieur par ratio de norme distingue la synthèse additive (norme en hausse) de la réécriture réversible (norme stable). Mesures confirmées firsthand : profil individuel — `resume` 0,78 (perte), `traduction` 0,73 (perte), `enhancement`/`rewriting` 1,0 (réécriture), `image`/`alt_text` 1,0 (synthèse) ; chaîne A `[resume, traduction, enhancement]` → **0,55 (45 % perdu)**, chaîne B `[enhancement, rewriting, alt_text]` → **1,0 (0 % perdu)**, chaîne C `[resume, resume]` → **0,78 (idempotente, 22 % — le résumé d'un résumé bute sur le même plancher)**. 3 exercices à stubs : rappel après chaîne, chaîne la plus destructrice, profil étape-par-étape. Gates CI locaux passés au commit : gitleaks, H.3 (0 cellule `execution_count=null`), no path-leak.

**Périmètre:** 1 nouveau notebook + bloc « Notebook compagnon » dans Parcours 1 de `livresagites-parcours.md` + MaJ du `README.md` (paragraphe descriptif + entrée de liste). Genre `MED/notebook-python` — déterministe, numpy + stdlib, sans clé, sans réseau. Frontière sécurité tenue (décision user grain 9, reconduite) : fixture synthétique 100 % (page catalogue fictive, vocabulaire éditorial générique, pas de prose de manuscrit). Les transformations sont des *fables vectorielles* qui capturent la nature informationnelle, pas des appels LLM réels. Aucune donnée client, aucun nom réel, aucun secret. Scan : 0 cyrillique/grec, 0 emoji, 0 secret, 0 terme client. CRLF normalisés (785 → LF).

Closes #10695
