### PR TITLE
fix(gametheory,#10488,#10595): mirror Gibbard-Satterthwaite cells in C# twin to restore twin parity on PR #10699 (c.1331+109)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign-Csharp.ipynb
@@ -53,128 +53,22 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '1520016.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
-     },
+     "output_type": "display_data",
      "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "data": {
       "text/plain": [
        "Utilite si alloue a 10, paiement 6 : u = 4 (doit valoir 4)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     },
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Utilite si non-alloue (allocation=0), paiement 0 : u = 0 (doit valoir 0)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -227,6 +121,8 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        " Enchérisseur | Valeur | 1er-prix (gagne/paie) | Vickrey (gagne/paie)\r\n",
@@ -236,27 +132,25 @@
        "    2        |    6   |             non / 0 | non / 0\r\n",
        "    3        |    4   |             non / 0 | non / 0\r\n"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     },
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "1er-prix : gagnant 0 paie 10 (utilite 0,0 ; sincerity: NON, sous-encherir est utile)."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     },
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Vickrey : gagnant 0 paie 8 (utilite 2,0 ; sincerity: OUI, r=v est dominant)."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -341,6 +235,8 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "  v  |  m  | meilleure enchere r |  u optimale  | sincere optimal ?\r\n",
@@ -350,18 +246,16 @@
        "  7 |   7 |  r >=   7 (ex.  0,0) |       0,00 | OUI\r\n",
        " 12 |   3 |  r >=   3 (ex.  3,0) |       9,00 | OUI\r\n"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     },
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Verdict : dans tous les cas, declarer r=v atteint l'utilite optimale. Vickrey est sincere (strategy-proof)."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -423,6 +317,8 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        " Objet | Enchérisseur gagnant | Valeur | Paiement VCG | Utilite\r\n",
@@ -431,18 +327,16 @@
        "  1   |        1            |    9   |     6,0    | 3,0\r\n",
        "  2   |        2            |    7   |     3,0    | 4,0\r\n"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     },
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Somme des paiements VCG = 17,0 (regle de Clarke : chaque gagnant paie son externalite sur les autres)."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -547,6 +441,8 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        " Homme | Femme (cote-H optimal)\r\n",
@@ -556,18 +452,16 @@
        "   2   |   2\r\n",
        "   3   |   3\r\n"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     },
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Nombre de paires bloquantes : 0 (doit valoir 0 => matching stable)"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -694,6 +588,8 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        " v_b | c_s | Echange | Prix | Surplus acheteur | Surplus vendeur\r\n",
@@ -703,18 +599,16 @@
        "  7 |   7 |  OUI   |  7,0 |             0,0 |            0,0\r\n",
        " 12 |  12 |  OUI   | 12,0 |             0,0 |            0,0\r\n"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     },
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Verdict : echange efficace (OUI ssi v_b >= c_s). Le prix median partage le surplus."
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -759,6 +653,319 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### 5.1 Gibbard-Satterthwaite : Borda manipulable + dictature strategy-proof\n",
+    "\n",
+    "La section 6 (impossibilites) du jumeau Python enonce le theoreme de **Gibbard-Satterthwaite** : pour toute fonction de choix social sur au moins 3 alternatives, **non-dictatoriale** et **surjective**, il existe un profil ou un electeur a interet a mentir. C'est un resultat d'impossibilite : il ne montre pas *comment* manipuler, il affirme que l'occasion existe.\n",
+    "\n",
+    "Nous le **verifions computatoirement** sur la regle de **Borda** (non-dictatoriale, surjective, $\\geq 3$ alternatives -- donc dans le scope du theoreme) : pour chaque profil sincere de 3 electeurs sur 3 alternatives, nous cherchons par **enumeration force brute** si un electeur peut, en declarant un bulletin different de ses vraies preferences, faire elire un candidat qu'il prefere au gagnant sincere. Si le theoreme est exact, l'enumeration doit trouver un temoin.\n",
+    "\n",
+    "Puis nous verifions que la **dictature** (l'electeur 0 decide seul) est strategy-proof sur les memes 216 profils : c'est le contre-point du theoreme -- les seules regles strategy-proof sur $\\geq 3$ alternatives sont dictatoriales."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "Gibbard-Satterthwaite - demonstration computatoire"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "================================================================"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "[1] Regle de Borda (non-dictatoriale, surjective, >= 3 alternatives) :"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "    Profil sincere : ((A,B,C), (A,B,C), (B,A,C))"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "    Gagnant sincere : A"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "    L'electeur 2 (prefs vraies (B,A,C)) declare (B,C,A)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "    -> Nouveau gagnant : B (qu'il prefere a A)"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "    => Borda est MANIPULABLE. Temoin trouve par enumeration des 216 profils."
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": []
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "[2] Dictature (l'electeur 0 decide seul) :"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "    Aucune manipulation sur les 216 profils -> la dictature est STRATEGY-PROOF."
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": []
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "[3] Gibbard-Satterthwaite en acte :"
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "    Borda (non-dictatorial) = manipulable ; Dictature = strategy-proof."
+      ]
+     }
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": [
+       "    Sur >= 3 alternatives, les SEULS mecanismes strategy-proof sont dictatoriaux."
+      ]
+     }
+    }
+   ],
+   "source": [
+    "// Gibbard-Satterthwaite - demonstration computatoire (C# / .NET 9 BCL pur).\n",
+    "// 3 alternatives, regle de Borda (points m-1 ... 0, ex aequo resolus\n",
+    "// alphabetiquement). Permutations generees recursivement (sans NuGet).\n",
+    "char[] ALTS = {'A', 'B', 'C'};\n",
+    "int m = ALTS.Length;\n",
+    "\n",
+    "// Generation recursive des permutations sur un tableau de T.\n",
+    "// Variante non-generique (char[]) pour compatibilite top-level statements.\n",
+    "// NOTE: pas de `static` ici -- en .NET Interactive top-level, m et ALTS sont\n",
+    "// des champs d'instance de la classe implicite ; static ne les verrait pas.\n",
+    "List<char[]> Permute(char[] items)\n",
+    "{\n",
+    "    var result = new List<char[]>();\n",
+    "    void Rec(char[] prefix, char[] rest)\n",
+    "    {\n",
+    "        if (rest.Length == 0)\n",
+    "        {\n",
+    "            result.Add(prefix.ToArray());\n",
+    "            return;\n",
+    "        }\n",
+    "        for (int i = 0; i < rest.Length; i++)\n",
+    "        {\n",
+    "            var newPrefix = prefix.Concat(new[] { rest[i] }).ToArray();\n",
+    "            var newRest = rest.Where((_, idx) => idx != i).ToArray();\n",
+    "            Rec(newPrefix, newRest);\n",
+    "        }\n",
+    "    }\n",
+    "    Rec(new char[0], items);\n",
+    "    return result;\n",
+    "}\n",
+    "\n",
+    "// Regle de Borda : points = m-1-rank par electeur, gagnant = max(score, -ord).\n",
+    "char BordaWinner(char[][] ballots)\n",
+    "{\n",
+    "    var score = new Dictionary<char, int> { ['A'] = 0, ['B'] = 0, ['C'] = 0 };\n",
+    "    foreach (var ballot in ballots)\n",
+    "        for (int rank = 0; rank < ballot.Length; rank++)\n",
+    "            score[ballot[rank]] += (m - 1 - rank);\n",
+    "    char best = ALTS[0];\n",
+    "    int bestScore = -1, bestOrd = 0;\n",
+    "    foreach (var a in ALTS)\n",
+    "    {\n",
+    "        int sc = score[a];\n",
+    "        int ord = -(int)a;\n",
+    "        if (sc > bestScore || (sc == bestScore && ord < bestOrd))\n",
+    "        {\n",
+    "            bestScore = sc;\n",
+    "            bestOrd = ord;\n",
+    "            best = a;\n",
+    "        }\n",
+    "    }\n",
+    "    return best;\n",
+    "}\n",
+    "\n",
+    "// Position d'une alternative dans un ranking (0 = la preferee).\n",
+    "int Rang(char[] prefs, char alt)\n",
+    "{\n",
+    "    for (int i = 0; i < prefs.Length; i++)\n",
+    "        if (prefs[i] == alt) return i;\n",
+    "    return -1;\n",
+    "}\n",
+    "\n",
+    "// Cherche un electeur qui gagne a mentir. Retourne le tuple temoin ou null.\n",
+    "// (profile, i, vraies, mensonge, gs, gn) -- gs = gagnant sincere, gn = gagnant sous mensonge.\n",
+    "(char[][] profile, int i, char[] vraies, char[] mensonge, char gs, char gn)?\n",
+    "    TrouverManipulation(char[][] profile, Func<char[][], char> regle)\n",
+    "{\n",
+    "    char gs = regle(profile);\n",
+    "    for (int i = 0; i < profile.Length; i++)\n",
+    "    {\n",
+    "        var vraies = profile[i];\n",
+    "        foreach (var mensonge in Permute(ALTS))\n",
+    "        {\n",
+    "            if (mensonge.SequenceEqual(vraies)) continue;\n",
+    "            var nouveau = new char[profile.Length][];\n",
+    "            for (int k = 0; k < profile.Length; k++) nouveau[k] = profile[k];\n",
+    "            nouveau[i] = mensonge;\n",
+    "            char gn = regle(nouveau);\n",
+    "            if (Rang(vraies, gn) < Rang(vraies, gs))\n",
+    "                return (profile, i, vraies, mensonge, gs, gn);\n",
+    "        }\n",
+    "    }\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "char GagnantDictature(char[][] profile) { return profile[0][0]; }\n",
+    "\n",
+    "// --- Demonstration ---\n",
+    "\"Gibbard-Satterthwaite - demonstration computatoire\".Display();\n",
+    "new string('=', 64).Display();\n",
+    "\n",
+    "var toutesPrefs = Permute(ALTS);\n",
+    "// Generer les 6^3 = 216 profils (3 electeurs, chacun choisit une permutation de 3 alternatives).\n",
+    "var profilesBorda = new List<char[][]>();\n",
+    "foreach (var p0 in toutesPrefs)\n",
+    "    foreach (var p1 in toutesPrefs)\n",
+    "        foreach (var p2 in toutesPrefs)\n",
+    "            profilesBorda.Add(new[] { p0, p1, p2 });\n",
+    "\n",
+    "\"[1] Regle de Borda (non-dictatoriale, surjective, >= 3 alternatives) :\".Display();\n",
+    "var temoin = (object)null;\n",
+    "foreach (var profile in profilesBorda)\n",
+    "{\n",
+    "    var r = TrouverManipulation(profile, BordaWinner);\n",
+    "    if (r != null) { temoin = r; break; }\n",
+    "}\n",
+    "if (temoin != null)\n",
+    "{\n",
+    "    var t = ((char[][], int, char[], char[], char, char))temoin;\n",
+    "    var profile = t.Item1;\n",
+    "    var i = t.Item2;\n",
+    "    var vraies = t.Item3;\n",
+    "    var mensonge = t.Item4;\n",
+    "    var gs = t.Item5;\n",
+    "    var gn = t.Item6;\n",
+    "    $\"    Profil sincere : (({string.Join(\",\", profile[0])}), ({string.Join(\",\", profile[1])}), ({string.Join(\",\", profile[2])}))\".Display();\n",
+    "    $\"    Gagnant sincere : {gs}\".Display();\n",
+    "    $\"    L'electeur {i} (prefs vraies ({string.Join(\",\", vraies)})) declare ({string.Join(\",\", mensonge)})\".Display();\n",
+    "    $\"    -> Nouveau gagnant : {gn} (qu'il prefere a {gs})\".Display();\n",
+    "    \"    => Borda est MANIPULABLE. Temoin trouve par enumeration des 216 profils.\".Display();\n",
+    "}\n",
+    "else\n",
+    "{\n",
+    "    \"    Aucune manipulation trouvee.\".Display();\n",
+    "}\n",
+    "\n",
+    "\"\".Display();\n",
+    "\"[2] Dictature (l'electeur 0 decide seul) :\".Display();\n",
+    "bool manipDict = false;\n",
+    "foreach (var profile in profilesBorda)\n",
+    "{\n",
+    "    if (TrouverManipulation(profile, GagnantDictature) != null) { manipDict = true; break; }\n",
+    "}\n",
+    "(manipDict ? \"    Manipulation trouvee (!)\" : \"    Aucune manipulation sur les 216 profils -> la dictature est STRATEGY-PROOF.\").Display();\n",
+    "\n",
+    "\"\".Display();\n",
+    "\"[3] Gibbard-Satterthwaite en acte :\".Display();\n",
+    "\"    Borda (non-dictatorial) = manipulable ; Dictature = strategy-proof.\".Display();\n",
+    "\"    Sur >= 3 alternatives, les SEULS mecanismes strategy-proof sont dictatoriaux.\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Lecture : le theoreme en acte\n",
+    "\n",
+    "L'enumeration a trouve un **temoin de manipulation** : sur un profil sincere donne, Borda elirait le candidat $g_s$. L'electeur $i$ (dont les vraies preferences sont $v$) a interet a declarer $m \\neq v$ : Borda elire alors $g_n$ que l'electeur prefere strictement a $g_s$. Le mensonge rationnel est recompense -- et c'est l'enumeration qui l'a decouvert, non une construction ad hoc.\n",
+    "\n",
+    "La deuxieme mesure est le **contre-point** du theoreme : la **dictature** (l'electeur 0 decide seul) est **strategy-proof** sur les 216 profils. Le dictateur n'a rien a gagner a mentir (son choix sincere gagne deja), et les autres electeurs sont ignores. C'est exactement la conclusion de Gibbard-Satterthwaite : **les seules regles strategy-proof sur $\\geq 3$ alternatives sont dictatoriales**.\n",
+    "\n",
+    "**Pourquoi Vickrey et VCG echappent-ils au theoreme ?** Parce qu'ils utilisent des **transferts monetaires** -- le theoreme de Gibbard-Satterthwaite porte sur les fonctions de choix social *sans paiements*. Des qu'on autorise un paiement (l'enchere au second prix, le critere de Clarke), on sort du cadre d'impossibilite et l'incitativite redevient possible.\n",
+    "\n",
+    "**Note sur le temoin** : l'ordre des permutations en C# (`Permute` recursif) differe de l'ordre Python (`itertools.permutations`), donc le **premier temoin** renvoye peut varier entre les deux jumeaux. C'est attendu : le theoreme garantit l'**existence** d'un temoin, pas un temoin specifique. Les deux jumeaux trouvent un temoin valide et aboutissent a la meme conclusion (Borda manipulable, Dictature strategy-proof)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "540ca063-c44e-4449-8026-99da1c5c2a93",
    "metadata": {},
    "source": [
@@ -777,7 +984,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "d910b87d-6577-4fe6-bc79-8afceb980e4d",
    "metadata": {
     "execution": {
@@ -789,13 +996,13 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Exercice a completer"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -826,7 +1033,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "807afaf2-a67e-46d8-9e05-f0cc7d8efc86",
    "metadata": {
     "execution": {
@@ -838,13 +1045,13 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Exercice a completer"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [
@@ -875,7 +1082,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "66caa810-586c-4655-89db-51b8b79b0565",
    "metadata": {
     "execution": {
@@ -887,13 +1094,13 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": [
        "Exercice a completer"
       ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
+     }
     }
    ],
    "source": [

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb
@@ -5,10 +5,10 @@
    "id": "0e6d711f",
    "metadata": {
     "papermill": {
-     "duration": 0.004237,
-     "end_time": "2026-06-04T17:59:02.282893+00:00",
+     "duration": 0.005276,
+     "end_time": "2026-08-13T01:40:56.339824+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:02.278656+00:00",
+     "start_time": "2026-08-13T01:40:56.334548+00:00",
      "status": "completed"
     },
     "tags": []
@@ -47,10 +47,10 @@
    "id": "880df48c",
    "metadata": {
     "papermill": {
-     "duration": 0.002546,
-     "end_time": "2026-06-04T17:59:02.288324+00:00",
+     "duration": 0.004851,
+     "end_time": "2026-08-13T01:40:56.351775+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:02.285778+00:00",
+     "start_time": "2026-08-13T01:40:56.346924+00:00",
      "status": "completed"
     },
     "tags": []
@@ -86,16 +86,16 @@
    "id": "92e64b79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:14.271734Z",
-     "iopub.status.busy": "2026-07-21T01:30:14.271505Z",
-     "iopub.status.idle": "2026-07-21T01:30:23.115247Z",
-     "shell.execute_reply": "2026-07-21T01:30:23.114481Z"
+     "iopub.execute_input": "2026-08-13T01:40:56.362213Z",
+     "iopub.status.busy": "2026-08-13T01:40:56.361998Z",
+     "iopub.status.idle": "2026-08-13T01:41:10.819939Z",
+     "shell.execute_reply": "2026-08-13T01:41:10.818706Z"
     },
     "papermill": {
-     "duration": 8.850329,
-     "end_time": "2026-07-21T01:30:23.116242+00:00",
+     "duration": 14.46459,
+     "end_time": "2026-08-13T01:41:10.820818+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:14.265913+00:00",
+     "start_time": "2026-08-13T01:40:56.356228+00:00",
      "status": "completed"
     },
     "tags": []
@@ -133,10 +133,10 @@
    "id": "e1ceb27f",
    "metadata": {
     "papermill": {
-     "duration": 0.002475,
-     "end_time": "2026-06-04T17:59:05.695648+00:00",
+     "duration": 0.008627,
+     "end_time": "2026-08-13T01:41:10.835293+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:05.693173+00:00",
+     "start_time": "2026-08-13T01:41:10.826666+00:00",
      "status": "completed"
     },
     "tags": []
@@ -166,10 +166,10 @@
    "id": "ee4546a7",
    "metadata": {
     "papermill": {
-     "duration": 0.002319,
-     "end_time": "2026-06-04T17:59:05.700388+00:00",
+     "duration": 0.008681,
+     "end_time": "2026-08-13T01:41:10.850507+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:05.698069+00:00",
+     "start_time": "2026-08-13T01:41:10.841826+00:00",
      "status": "completed"
     },
     "tags": []
@@ -194,16 +194,16 @@
    "id": "20ab78af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:23.149797Z",
-     "iopub.status.busy": "2026-07-21T01:30:23.149420Z",
-     "iopub.status.idle": "2026-07-21T01:30:23.159402Z",
-     "shell.execute_reply": "2026-07-21T01:30:23.158523Z"
+     "iopub.execute_input": "2026-08-13T01:41:10.868057Z",
+     "iopub.status.busy": "2026-08-13T01:41:10.867650Z",
+     "iopub.status.idle": "2026-08-13T01:41:10.877951Z",
+     "shell.execute_reply": "2026-08-13T01:41:10.877084Z"
     },
     "papermill": {
-     "duration": 0.01784,
-     "end_time": "2026-07-21T01:30:23.160330+00:00",
+     "duration": 0.018688,
+     "end_time": "2026-08-13T01:41:10.878704+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:23.142490+00:00",
+     "start_time": "2026-08-13T01:41:10.860016+00:00",
      "status": "completed"
     },
     "tags": []
@@ -305,10 +305,10 @@
    "id": "bb881f0a",
    "metadata": {
     "papermill": {
-     "duration": 0.002459,
-     "end_time": "2026-06-04T17:59:05.717930+00:00",
+     "duration": 0.006043,
+     "end_time": "2026-08-13T01:41:10.890342+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:05.715471+00:00",
+     "start_time": "2026-08-13T01:41:10.884299+00:00",
      "status": "completed"
     },
     "tags": []
@@ -337,10 +337,10 @@
    "id": "ce1c7815",
    "metadata": {
     "papermill": {
-     "duration": 0.002713,
-     "end_time": "2026-06-04T17:59:05.723415+00:00",
+     "duration": 0.005385,
+     "end_time": "2026-08-13T01:41:10.901122+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:05.720702+00:00",
+     "start_time": "2026-08-13T01:41:10.895737+00:00",
      "status": "completed"
     },
     "tags": []
@@ -363,16 +363,16 @@
    "id": "4d48b757",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:23.187931Z",
-     "iopub.status.busy": "2026-07-21T01:30:23.187746Z",
-     "iopub.status.idle": "2026-07-21T01:30:23.196033Z",
-     "shell.execute_reply": "2026-07-21T01:30:23.195221Z"
+     "iopub.execute_input": "2026-08-13T01:41:10.915140Z",
+     "iopub.status.busy": "2026-08-13T01:41:10.914785Z",
+     "iopub.status.idle": "2026-08-13T01:41:10.925328Z",
+     "shell.execute_reply": "2026-08-13T01:41:10.924518Z"
     },
     "papermill": {
-     "duration": 0.013707,
-     "end_time": "2026-07-21T01:30:23.196688+00:00",
+     "duration": 0.01876,
+     "end_time": "2026-08-13T01:41:10.926082+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:23.182981+00:00",
+     "start_time": "2026-08-13T01:41:10.907322+00:00",
      "status": "completed"
     },
     "tags": []
@@ -486,10 +486,10 @@
    "id": "d6a05bf7",
    "metadata": {
     "papermill": {
-     "duration": 0.00329,
-     "end_time": "2026-06-04T17:59:05.746581+00:00",
+     "duration": 0.005272,
+     "end_time": "2026-08-13T01:41:10.937114+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:05.743291+00:00",
+     "start_time": "2026-08-13T01:41:10.931842+00:00",
      "status": "completed"
     },
     "tags": []
@@ -523,10 +523,10 @@
    "id": "ex-allpay-md",
    "metadata": {
     "papermill": {
-     "duration": 0.002911,
-     "end_time": "2026-06-04T17:59:05.752284+00:00",
+     "duration": 0.005249,
+     "end_time": "2026-08-13T01:41:10.947598+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:05.749373+00:00",
+     "start_time": "2026-08-13T01:41:10.942349+00:00",
      "status": "completed"
     },
     "tags": []
@@ -550,16 +550,16 @@
    "id": "ex-allpay-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:23.229819Z",
-     "iopub.status.busy": "2026-07-21T01:30:23.229553Z",
-     "iopub.status.idle": "2026-07-21T01:30:23.235066Z",
-     "shell.execute_reply": "2026-07-21T01:30:23.234341Z"
+     "iopub.execute_input": "2026-08-13T01:41:10.958249Z",
+     "iopub.status.busy": "2026-08-13T01:41:10.958052Z",
+     "iopub.status.idle": "2026-08-13T01:41:10.963087Z",
+     "shell.execute_reply": "2026-08-13T01:41:10.962338Z"
     },
     "papermill": {
-     "duration": 0.013677,
-     "end_time": "2026-07-21T01:30:23.236140+00:00",
+     "duration": 0.011171,
+     "end_time": "2026-08-13T01:41:10.963694+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:23.222463+00:00",
+     "start_time": "2026-08-13T01:41:10.952523+00:00",
      "status": "completed"
     },
     "tags": []
@@ -607,16 +607,16 @@
    "id": "6b3cf3b5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:23.248727Z",
-     "iopub.status.busy": "2026-07-21T01:30:23.248350Z",
-     "iopub.status.idle": "2026-07-21T01:30:23.254714Z",
-     "shell.execute_reply": "2026-07-21T01:30:23.253691Z"
+     "iopub.execute_input": "2026-08-13T01:41:10.974029Z",
+     "iopub.status.busy": "2026-08-13T01:41:10.973818Z",
+     "iopub.status.idle": "2026-08-13T01:41:10.978837Z",
+     "shell.execute_reply": "2026-08-13T01:41:10.978245Z"
     },
     "papermill": {
-     "duration": 0.013446,
-     "end_time": "2026-07-21T01:30:23.255522+00:00",
+     "duration": 0.010891,
+     "end_time": "2026-08-13T01:41:10.979374+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:23.242076+00:00",
+     "start_time": "2026-08-13T01:41:10.968483+00:00",
      "status": "completed"
     },
     "tags": []
@@ -680,10 +680,10 @@
    "id": "f6996cee",
    "metadata": {
     "papermill": {
-     "duration": 0.002456,
-     "end_time": "2026-06-04T17:59:05.779571+00:00",
+     "duration": 0.004885,
+     "end_time": "2026-08-13T01:41:10.989213+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:05.777115+00:00",
+     "start_time": "2026-08-13T01:41:10.984328+00:00",
      "status": "completed"
     },
     "tags": []
@@ -715,16 +715,16 @@
    "id": "9a7ea6e9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:23.279058Z",
-     "iopub.status.busy": "2026-07-21T01:30:23.278805Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.418595Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.417580Z"
+     "iopub.execute_input": "2026-08-13T01:41:10.999562Z",
+     "iopub.status.busy": "2026-08-13T01:41:10.999357Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.088428Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.087540Z"
     },
     "papermill": {
-     "duration": 1.148407,
-     "end_time": "2026-07-21T01:30:24.419324+00:00",
+     "duration": 1.095309,
+     "end_time": "2026-08-13T01:41:12.089057+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:23.270917+00:00",
+     "start_time": "2026-08-13T01:41:10.993748+00:00",
      "status": "completed"
     },
     "tags": []
@@ -826,10 +826,10 @@
    "id": "173357d6",
    "metadata": {
     "papermill": {
-     "duration": 0.003583,
-     "end_time": "2026-06-04T17:59:06.320167+00:00",
+     "duration": 0.004893,
+     "end_time": "2026-08-13T01:41:12.099377+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.316584+00:00",
+     "start_time": "2026-08-13T01:41:12.094484+00:00",
      "status": "completed"
     },
     "tags": []
@@ -861,10 +861,10 @@
    "id": "f29c453a",
    "metadata": {
     "papermill": {
-     "duration": 0.00348,
-     "end_time": "2026-06-04T17:59:06.327274+00:00",
+     "duration": 0.00522,
+     "end_time": "2026-08-13T01:41:12.109467+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.323794+00:00",
+     "start_time": "2026-08-13T01:41:12.104247+00:00",
      "status": "completed"
     },
     "tags": []
@@ -900,10 +900,10 @@
    "id": "f4c01e4e",
    "metadata": {
     "papermill": {
-     "duration": 0.003336,
-     "end_time": "2026-06-04T17:59:06.334058+00:00",
+     "duration": 0.005519,
+     "end_time": "2026-08-13T01:41:12.120200+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.330722+00:00",
+     "start_time": "2026-08-13T01:41:12.114681+00:00",
      "status": "completed"
     },
     "tags": []
@@ -930,16 +930,16 @@
    "id": "463ef68e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.458997Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.458722Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.468088Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.467461Z"
+     "iopub.execute_input": "2026-08-13T01:41:12.134744Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.134442Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.145582Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.144717Z"
     },
     "papermill": {
-     "duration": 0.015357,
-     "end_time": "2026-07-21T01:30:24.468806+00:00",
+     "duration": 0.020248,
+     "end_time": "2026-08-13T01:41:12.146403+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.453449+00:00",
+     "start_time": "2026-08-13T01:41:12.126155+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1107,10 +1107,10 @@
    "id": "a1e306b7",
    "metadata": {
     "papermill": {
-     "duration": 0.003407,
-     "end_time": "2026-06-04T17:59:06.357884+00:00",
+     "duration": 0.005677,
+     "end_time": "2026-08-13T01:41:12.157542+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.354477+00:00",
+     "start_time": "2026-08-13T01:41:12.151865+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1141,16 +1141,16 @@
    "id": "23930cab",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.490741Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.490429Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.496211Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.495504Z"
+     "iopub.execute_input": "2026-08-13T01:41:12.172231Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.171947Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.177617Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.177046Z"
     },
     "papermill": {
-     "duration": 0.012774,
-     "end_time": "2026-07-21T01:30:24.496839+00:00",
+     "duration": 0.014728,
+     "end_time": "2026-08-13T01:41:12.178284+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.484065+00:00",
+     "start_time": "2026-08-13T01:41:12.163556+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1219,10 +1219,10 @@
    "id": "db7c683a",
    "metadata": {
     "papermill": {
-     "duration": 0.00373,
-     "end_time": "2026-06-04T17:59:06.378192+00:00",
+     "duration": 0.005468,
+     "end_time": "2026-08-13T01:41:12.189314+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.374462+00:00",
+     "start_time": "2026-08-13T01:41:12.183846+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1252,7 +1252,16 @@
   {
    "cell_type": "markdown",
    "id": "a80f4d0c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005805,
+     "end_time": "2026-08-13T01:41:12.200994+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.195189+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4.5 Piege de VCG : non-monotonie du revenu (Conitzer-Sandholm)\n",
     "\n",
@@ -1270,7 +1279,16 @@
   {
    "cell_type": "markdown",
    "id": "bb9bc01d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00611,
+     "end_time": "2026-08-13T01:41:12.213181+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.207071+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Mise en situation : 2 objets {A, B} avec complementarites\n",
     "\n",
@@ -1288,18 +1306,19 @@
    "id": "37e8ba52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.559286Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.559009Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.570673Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.569540Z"
+     "iopub.execute_input": "2026-08-13T01:41:12.229403Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.229025Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.239993Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.239044Z"
     },
     "papermill": {
-     "duration": 0.020779,
-     "end_time": "2026-07-21T01:30:24.571489+00:00",
+     "duration": 0.020838,
+     "end_time": "2026-08-13T01:41:12.240864+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.550710+00:00",
+     "start_time": "2026-08-13T01:41:12.220026+00:00",
      "status": "completed"
-    }
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1409,7 +1428,16 @@
   {
    "cell_type": "markdown",
    "id": "3222d3d9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006692,
+     "end_time": "2026-08-13T01:41:12.254279+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.247587+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation des resultats\n",
     "\n",
@@ -1432,7 +1460,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "087761b0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007556,
+     "end_time": "2026-08-13T01:41:12.268249+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.260693+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4.6 Sandholm (SAGT 2009) : quand le Byzantine ameliore les choses\n",
     "\n",
@@ -1447,12 +1485,21 @@
     "2. Pour **tout** outcome $\\hat{o}$ qui peut apparaitre quand un agent *devie* de son equilibre, l'utilite du concepteur $\\mathcal{M}(\\hat{o}) > \\mathcal{M}(o^*)$ (l'utilite a l'equilibre optimal).\n",
     "\n",
     "Dit autrement : on accepte de perdre un peu quand tous jouent rationnel, pour **gagner systematiquement** des qu'un seul agent fait une erreur.\n"
-   ],
-   "id": "087761b0"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "ea383085",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007491,
+     "end_time": "2026-08-13T01:41:12.282738+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.275247+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4.6.1 Possibilite : Proposition 6 (Othman-Sandholm 2009)\n",
     "\n",
@@ -1476,26 +1523,27 @@
     "| $o_4$   | 3 | 0 | 0 | 0 |\n",
     "\n",
     "**Observation cle** : rapporter $a'$ est une **strategie strictement dominante** pour les deux types des deux agents (chaque agent gagne plus a rapporter $a'$ quel que soit le rapport de l'autre). Par le principe de revelation, on peut \"boxer\" ce mecanisme en un mecanisme truthful $M_1$ qui choisit systematiquement $o_1$. **Mais** quand un agent de type $a$ joue $a$ au lieu de $a'$, le bien-etre social de l'outcome produit est strictement superieur a celui de $o_1$ -- peu importe le rapport de l'autre agent.\n"
-   ],
-   "id": "ea383085"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "c13c2ef2",
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:41:12.300548Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.300111Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.308933Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.307688Z"
+    },
     "papermill": {
-     "duration": 0.018287,
-     "end_time": "2026-07-21T01:30:24.639718+00:00",
+     "duration": 0.01787,
+     "end_time": "2026-08-13T01:41:12.309940+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.621431+00:00",
+     "start_time": "2026-08-13T01:41:12.292070+00:00",
      "status": "completed"
     },
-    "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.630861Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.630398Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.638875Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.637927Z"
-    }
+    "tags": []
    },
    "outputs": [
     {
@@ -1563,12 +1611,21 @@
     "    sw_o1 = sw_at_mom[(\"o1\", tr, tc)]\n",
     "    better = [o for o in outcomes if sw_at_mom[(o, tr, tc)] > sw_o1]\n",
     "    print(f\"  Profil ({tr},{tc}) : SW(o1) = {sw_o1}, outcomes > SW(o1) : {better}\")\n"
-   ],
-   "id": "c13c2ef2"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "7431dd9b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006753,
+     "end_time": "2026-08-13T01:41:12.323252+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.316499+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4.6.3 Interpretation : la Caracteristique 2 tient en charpie\n",
     "\n",
@@ -1580,12 +1637,21 @@
     "- Profil $(a', a')$ : $o_1$ reste optimal ($SW = 7$), aucun outcome ne le surpasse.\n",
     "\n",
     "C'est la **Caracteristique 2** du strict MOM : des qu'un agent byzantin (joue $a$ au lieu de $a'$) apparait, le mecanisme beneficie d'un outcome strictement meilleur. **Le \"mieux avec Byzantine\" est realise.**\n"
-   ],
-   "id": "7431dd9b"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "92df305f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0068,
+     "end_time": "2026-08-13T01:41:12.337215+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.330415+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4.6.4 La Caracteristique 1 : M_1 est Pareto-indomine parmi les mecanismes truthful\n",
     "\n",
@@ -1596,18 +1662,17 @@
     "> **Lien pedagogique avec VCG (section 4.5)** : VCG est truthful par construction, donc son outcome depend des rapports ; il maximise le bien-etre social *quand* tous les agents sont truthful. Mais VCG n'a aucune propriete \"byzantine-friendly\" -- il optimise, il ne gagne pas *plus* quand un agent fait une erreur. Le concept de MOM est orthogonal : il accepte de payer un cout en bien-etre sur les profils \"tout-byzantin-joue-optimal\" pour gagner *quand* un byzantin apparait.\n",
     "\n",
     "**Voir aussi** : Issue CoursIA #1469 Track 3 (\"Sandholm references : << Better with Byzantine >> -- enonce fini\"). La formalisation Lean (Track 2) reste a faire -- le domaine fini 2x2 de la Proposition 6 est un candidat ideal pour `decide` (cf section `MechanismDesign.lean`).\n"
-   ],
-   "id": "92df305f"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "7d636530",
    "metadata": {
     "papermill": {
-     "duration": 0.003956,
-     "end_time": "2026-06-04T17:59:06.386307+00:00",
+     "duration": 0.006225,
+     "end_time": "2026-08-13T01:41:12.350943+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.382351+00:00",
+     "start_time": "2026-08-13T01:41:12.344718+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1638,10 +1703,10 @@
    "id": "c47c2063",
    "metadata": {
     "papermill": {
-     "duration": 0.003844,
-     "end_time": "2026-06-04T17:59:06.394849+00:00",
+     "duration": 0.006236,
+     "end_time": "2026-08-13T01:41:12.363350+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.391005+00:00",
+     "start_time": "2026-08-13T01:41:12.357114+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1671,16 +1736,16 @@
    "id": "ce876a28",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.703964Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.703635Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.711700Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.711142Z"
+     "iopub.execute_input": "2026-08-13T01:41:12.377622Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.377384Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.386970Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.386077Z"
     },
     "papermill": {
-     "duration": 0.01559,
-     "end_time": "2026-07-21T01:30:24.712489+00:00",
+     "duration": 0.017827,
+     "end_time": "2026-08-13T01:41:12.387580+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.696899+00:00",
+     "start_time": "2026-08-13T01:41:12.369753+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1834,10 +1899,10 @@
    "id": "9865b266",
    "metadata": {
     "papermill": {
-     "duration": 0.004455,
-     "end_time": "2026-06-04T17:59:06.423505+00:00",
+     "duration": 0.006279,
+     "end_time": "2026-08-13T01:41:12.400052+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.419050+00:00",
+     "start_time": "2026-08-13T01:41:12.393773+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1869,10 +1934,10 @@
    "id": "ex-blocking-md",
    "metadata": {
     "papermill": {
-     "duration": 0.004461,
-     "end_time": "2026-06-04T17:59:06.432212+00:00",
+     "duration": 0.006204,
+     "end_time": "2026-08-13T01:41:12.412672+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.427751+00:00",
+     "start_time": "2026-08-13T01:41:12.406468+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1896,16 +1961,16 @@
    "id": "ex-blocking-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.747613Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.747367Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.752860Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.752255Z"
+     "iopub.execute_input": "2026-08-13T01:41:12.427477Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.427224Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.432051Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.431412Z"
     },
     "papermill": {
-     "duration": 0.013118,
-     "end_time": "2026-07-21T01:30:24.753565+00:00",
+     "duration": 0.012995,
+     "end_time": "2026-08-13T01:41:12.432677+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.740447+00:00",
+     "start_time": "2026-08-13T01:41:12.419682+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1959,16 +2024,16 @@
    "id": "6eb1ca70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.765706Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.765519Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.771824Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.771151Z"
+     "iopub.execute_input": "2026-08-13T01:41:12.444842Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.444648Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.451054Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.450434Z"
     },
     "papermill": {
-     "duration": 0.013601,
-     "end_time": "2026-07-21T01:30:24.772558+00:00",
+     "duration": 0.013346,
+     "end_time": "2026-08-13T01:41:12.451802+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.758957+00:00",
+     "start_time": "2026-08-13T01:41:12.438456+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2055,10 +2120,10 @@
    "id": "ead0df55",
    "metadata": {
     "papermill": {
-     "duration": 0.004342,
-     "end_time": "2026-06-04T17:59:06.471279+00:00",
+     "duration": 0.005917,
+     "end_time": "2026-08-13T01:41:12.463328+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.466937+00:00",
+     "start_time": "2026-08-13T01:41:12.457411+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2096,10 +2161,10 @@
    "id": "b766b4ca",
    "metadata": {
     "papermill": {
-     "duration": 0.004332,
-     "end_time": "2026-06-04T17:59:06.479898+00:00",
+     "duration": 0.006019,
+     "end_time": "2026-08-13T01:41:12.475516+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.475566+00:00",
+     "start_time": "2026-08-13T01:41:12.469497+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2133,10 +2198,10 @@
    "id": "a47845c0",
    "metadata": {
     "papermill": {
-     "duration": 0.004302,
-     "end_time": "2026-06-04T17:59:06.488641+00:00",
+     "duration": 0.005685,
+     "end_time": "2026-08-13T01:41:12.487315+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.484339+00:00",
+     "start_time": "2026-08-13T01:41:12.481630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2154,21 +2219,187 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "416d589b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005854,
+     "end_time": "2026-08-13T01:41:12.498965+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.493111+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Illustration : Gibbard-Satterthwaite - pourquoi Borda est manipulable\n",
+    "\n",
+    "La section 6.1 enonce le theoreme de **Gibbard-Satterthwaite** : pour toute fonction de choix social sur au moins 3 alternatives, **non-dictatoriale** et **surjective**, il existe un profil ou un electeur a interet a mentir sur ses preferences. C'est un resultat d'impossibilite : il ne montre pas *comment* un electeur manipule, il affirme que l'occasion existe toujours.\n",
+    "\n",
+    "Plutot que de l'admettre, nous le **verifions computatoirement** sur un cas concret : la regle de **Borda** (non-dictatoriale, surjective, $\\geq 3$ alternatives - donc dans le scope du theoreme). Pour chaque profil sincere de 3 electeurs sur 3 alternatives, nous cherchons par **enumeration force brute** si un electeur peut, en declarant un bulletin different de ses vraies preferences, faire elire un candidat qu'il prefere au gagnant sincere. Si le theoreme est exact, l'enumeration doit trouver un temoin.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "3c26d2ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T01:41:12.511681Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.511471Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.520466Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.519624Z"
+    },
+    "papermill": {
+     "duration": 0.016449,
+     "end_time": "2026-08-13T01:41:12.521202+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.504753+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gibbard-Satterthwaite - demonstration computatoire\n",
+      "================================================================\n",
+      "[1] Regle de Borda (non-dictatoriale, surjective, >= 3 alternatives) :\n",
+      "    Profil sincere : (('A', 'B', 'C'), ('B', 'A', 'C'), ('C', 'B', 'A'))\n",
+      "    Gagnant sincere : B\n",
+      "    L'electeur 0 (prefs vraies ('A', 'B', 'C')) declare ('A', 'C', 'B')\n",
+      "    -> Nouveau gagnant : A (qu'il prefere a B)\n",
+      "    => Borda est MANIPULABLE. Temoin trouve par enumeration des 216 profils.\n",
+      "\n",
+      "[2] Dictature (l'electeur 0 decide seul) :\n",
+      "    Aucune manipulation sur les 216 profils -> la dictature est STRATEGY-PROOF.\n",
+      "\n",
+      "[3] Gibbard-Satterthwaite en acte :\n",
+      "    Borda (non-dictatorial) = manipulable ; Dictature = strategy-proof.\n",
+      "    Sur >= 3 alternatives, les SEULS mecanismes strategy-proof sont dictatoriaux.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from itertools import permutations\n",
+    "\n",
+    "# 3 alternatives, regle de Borda (points m-1 ... 0, ex aequo resolus alphabetiquement).\n",
+    "ALTS = ('A', 'B', 'C')\n",
+    "m = len(ALTS)\n",
+    "\n",
+    "def borda_winner(ballots):\n",
+    "    score = {a: 0 for a in ALTS}\n",
+    "    for ballot in ballots:\n",
+    "        for rank, a in enumerate(ballot):\n",
+    "            score[a] += (m - 1 - rank)\n",
+    "    return max(ALTS, key=lambda a: (score[a], -ord(a)))\n",
+    "\n",
+    "def rang(prefs, alt):\n",
+    "    \"\"\"Position de alt dans prefs (0 = le meilleur).\"\"\"\n",
+    "    return prefs.index(alt)\n",
+    "\n",
+    "def trouver_manipulation(profile, regle):\n",
+    "    \"\"\"Cherche un electeur qui gagne a mentir. Retourne (electeur, gagnant_sincere, mensonge, nouveau_gagnant) ou None.\"\"\"\n",
+    "    g_sincere = regle(profile)\n",
+    "    for i in range(len(profile)):\n",
+    "        vraies = profile[i]\n",
+    "        for mensonge in permutations(ALTS):\n",
+    "            if tuple(mensonge) == vraies:\n",
+    "                continue\n",
+    "            nouveau_profile = list(profile)\n",
+    "            nouveau_profile[i] = tuple(mensonge)\n",
+    "            nouveau_g = regle(nouveau_profile)\n",
+    "            # l'electeur prefere-t-il strictement nouveau_g au gagnant sincere ?\n",
+    "            if rang(vraies, nouveau_g) < rang(vraies, g_sincere):\n",
+    "                return (i, vraies, tuple(mensonge), g_sincere, nouveau_g)\n",
+    "    return None\n",
+    "\n",
+    "toutes_prefs = list(permutations(ALTS))\n",
+    "\n",
+    "# [1] Borda (non-dictatorial) : enumeration force brute sur les 6^3 = 216 profils.\n",
+    "print('Gibbard-Satterthwaite - demonstration computatoire')\n",
+    "print('=' * 64)\n",
+    "print('[1] Regle de Borda (non-dictatoriale, surjective, >= 3 alternatives) :')\n",
+    "temoin = None\n",
+    "for profile in permutations(toutes_prefs, 3):\n",
+    "    r = trouver_manipulation(profile, borda_winner)\n",
+    "    if r:\n",
+    "        temoin = (profile, r)\n",
+    "        break\n",
+    "if temoin:\n",
+    "    profile, (i, vraies, mensonge, gs, gn) = temoin\n",
+    "    print(f'    Profil sincere : {profile}')\n",
+    "    print(f'    Gagnant sincere : {gs}')\n",
+    "    print(f\"    L'electeur {i} (prefs vraies {vraies}) declare {mensonge}\")\n",
+    "    print(f'    -> Nouveau gagnant : {gn} (qu\\'il prefere a {gs})')\n",
+    "    print('    => Borda est MANIPULABLE. Temoin trouve par enumeration des 216 profils.')\n",
+    "else:\n",
+    "    print('    Aucune manipulation trouvee.')\n",
+    "\n",
+    "# [2] Dictature (l'electeur 0 decide seul) : verifions qu'elle est strategy-proof.\n",
+    "def gagnant_dictature(profile):\n",
+    "    return profile[0][0]  # le premier choix de l'electeur 0\n",
+    "\n",
+    "print()\n",
+    "print('[2] Dictature (l\\'electeur 0 decide seul) :')\n",
+    "manip_dict = False\n",
+    "for profile in permutations(toutes_prefs, 3):\n",
+    "    if trouver_manipulation(profile, gagnant_dictature):\n",
+    "        manip_dict = True\n",
+    "        break\n",
+    "print('    Aucune manipulation sur les 216 profils -> la dictature est STRATEGY-PROOF.' if not manip_dict\n",
+    "      else '    Manipulation trouvee (!)')\n",
+    "\n",
+    "# [3] Synthese : le theoreme en acte.\n",
+    "print()\n",
+    "print('[3] Gibbard-Satterthwaite en acte :')\n",
+    "print('    Borda (non-dictatorial) = manipulable ; Dictature = strategy-proof.')\n",
+    "print('    Sur >= 3 alternatives, les SEULS mecanismes strategy-proof sont dictatoriaux.')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9698e90b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005432,
+     "end_time": "2026-08-13T01:41:12.532085+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.526653+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : le theoreme en acte\n",
+    "\n",
+    "L'enumeration a trouve un **temoin de manipulation** : avec le profil sincere $(A \\succ B \\succ C),\\ (B \\succ A \\succ C),\\ (C \\succ B \\succ A)$, Borda elirait **B**. L'electeur 0, dont les vraies preferences sont $A \\succ B \\succ C$, a interet a declarer $A \\succ C \\succ B$ : Borda elire alors **A**, que l'electeur prefere a B. Le mensonge rationnel est recompense - et c'est l'enumeration qui l'a decouvert, non une construction ad hoc.\n",
+    "\n",
+    "La deuxieme mesure est le **contre-point** du theoreme : la **dictature** (l'electeur 0 decide seul) est **strategy-proof** - sur les 216 profils, aucun electeur ne peut manipuler. Le dictateur n'a rien a gagner a mentir (son choix sincere gagne deja), et les autres electeurs sont ignores. C'est exactement la conclusion de Gibbard-Satterthwaite : **les seules regles strategy-proof sur $\\geq 3$ alternatives sont dictatoriales**.\n",
+    "\n",
+    "**Pourquoi Vickrey et VCG echappent-ils au theoreme ?** Parce qu'ils utilisent des **transferts monetaires** - le theoreme de Gibbard-Satterthwaite porte sur les fonctions de choix social *sans paiements*. Des qu'on autorise un paiement (l'enchere au second prix, le critere de Clarke), on sort du cadre d'impossibilite et l'incitativite redevient possible. D'ou la section 6.2 : les mecanismes VCG sont l'exception qui confirme la regle.\n",
+    "\n",
+    "**Lien avec la formalisation Lean** : la parente formelle est le theoreme d'impossibilite d'**Arrow** (formalise dans `game_theory_lean/SocialChoice/`), dont Gibbard-Satterthwaite est le pendant strategique - Arrow = l'aggregation honnete est impossible ; Gibbard-Satterthwaite = l'aggregation *truthful* (incitative) est impossible. Les deux borneent ce qu'un concepteur de mecanisme peut atteindre sans transferts.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
    "id": "999f1f96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.823389Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.823157Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.832367Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.831698Z"
+     "iopub.execute_input": "2026-08-13T01:41:12.543836Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.543485Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.551235Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.550557Z"
     },
     "papermill": {
-     "duration": 0.017564,
-     "end_time": "2026-07-21T01:30:24.833120+00:00",
+     "duration": 0.014487,
+     "end_time": "2026-08-13T01:41:12.551776+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.815556+00:00",
+     "start_time": "2026-08-13T01:41:12.537289+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2309,10 +2540,10 @@
    "id": "17e5c100",
    "metadata": {
     "papermill": {
-     "duration": 0.003885,
-     "end_time": "2026-06-04T17:59:06.514314+00:00",
+     "duration": 0.005255,
+     "end_time": "2026-08-13T01:41:12.562554+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.510429+00:00",
+     "start_time": "2026-08-13T01:41:12.557299+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2339,10 +2570,10 @@
    "id": "345b1a9e",
    "metadata": {
     "papermill": {
-     "duration": 0.003928,
-     "end_time": "2026-06-04T17:59:06.522251+00:00",
+     "duration": 0.005032,
+     "end_time": "2026-08-13T01:41:12.572757+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.518323+00:00",
+     "start_time": "2026-08-13T01:41:12.567725+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2377,10 +2608,10 @@
    "id": "ddd647b4",
    "metadata": {
     "papermill": {
-     "duration": 0.003978,
-     "end_time": "2026-06-04T17:59:06.530363+00:00",
+     "duration": 0.005369,
+     "end_time": "2026-08-13T01:41:12.582912+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.526385+00:00",
+     "start_time": "2026-08-13T01:41:12.577543+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2407,20 +2638,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "9b44a0c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-21T01:30:24.878975Z",
-     "iopub.status.busy": "2026-07-21T01:30:24.878704Z",
-     "iopub.status.idle": "2026-07-21T01:30:24.883568Z",
-     "shell.execute_reply": "2026-07-21T01:30:24.882560Z"
+     "iopub.execute_input": "2026-08-13T01:41:12.595151Z",
+     "iopub.status.busy": "2026-08-13T01:41:12.594965Z",
+     "iopub.status.idle": "2026-08-13T01:41:12.599318Z",
+     "shell.execute_reply": "2026-08-13T01:41:12.598402Z"
     },
     "papermill": {
-     "duration": 0.012903,
-     "end_time": "2026-07-21T01:30:24.884304+00:00",
+     "duration": 0.011785,
+     "end_time": "2026-08-13T01:41:12.600007+00:00",
      "exception": false,
-     "start_time": "2026-07-21T01:30:24.871401+00:00",
+     "start_time": "2026-08-13T01:41:12.588222+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2471,10 +2702,10 @@
    "id": "09801677",
    "metadata": {
     "papermill": {
-     "duration": 0.005136,
-     "end_time": "2026-06-04T17:59:06.552782+00:00",
+     "duration": 0.005385,
+     "end_time": "2026-08-13T01:41:12.610827+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.547646+00:00",
+     "start_time": "2026-08-13T01:41:12.605442+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2498,10 +2729,10 @@
    "id": "7ae4d320",
    "metadata": {
     "papermill": {
-     "duration": 0.004097,
-     "end_time": "2026-06-04T17:59:06.561116+00:00",
+     "duration": 0.005665,
+     "end_time": "2026-08-13T01:41:12.621846+00:00",
      "exception": false,
-     "start_time": "2026-06-04T17:59:06.557019+00:00",
+     "start_time": "2026-08-13T01:41:12.616181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2552,7 +2783,16 @@
   {
    "cell_type": "markdown",
    "id": "d1ea3388",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005464,
+     "end_time": "2026-08-13T01:41:12.632832+00:00",
+     "exception": false,
+     "start_time": "2026-08-13T01:41:12.627368+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "> **Lien avec la formalisation Lean** : L'incitativite de l'enchere de Vickrey est prouvee formellement dans [`game_theory_lean/SocialChoice/MechanismDesign.lean`](game_theory_lean/SocialChoice/MechanismDesign.lean) (0 sorry). On y trouve la fonction d'utilite pour 2 et 3 encherisseurs, les theoremes `vickrey_truthful_bidder0/1` (stratégie dominante de verite) prouves par `omega` + `split_ifs`, et le contre-exemple `first_price_not_truthful` prouve par `native_decide`. Le notebook s'inscrit dans la serie Lean du choix social ([`game_theory_lean/SocialChoice/`](game_theory_lean/SocialChoice/)) qui formalise également les theoremes d'Arrow (0 sorry), de Sen (0 sorry) et les méthodes de vote (0 sorry)."
    ]
@@ -2574,18 +2814,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.202716,
-   "end_time": "2026-06-04T17:59:06.785341+00:00",
+   "duration": 18.822155,
+   "end_time": "2026-08-13T01:41:12.979322+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "GameTheory-16-MechanismDesign.ipynb",
-   "output_path": "GameTheory-16-MechanismDesign.ipynb",
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb.executed.ipynb",
    "parameters": {},
-   "start_time": "2026-06-04T17:59:01.582625+00:00",
+   "start_time": "2026-08-13T01:40:54.157167+00:00",
    "version": "2.7.0"
   }
  },

--- a/scripts/_insert_cs_mirror.py
+++ b/scripts/_insert_cs_mirror.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Insert 3 cells (md intro + C# code + md interpretation) into the C# twin
+of GameTheory-16-MechanismDesign to mirror the Python twin's Gibbard-Satterthwaite
+addition from PR #10699.
+
+Position: insert AFTER cell 16 (Lecture du resultat : efficacite et partage
+du surplus) and BEFORE cell 17 (## 6. Exercices).
+
+This is a SEMANTIC twin mirror -- the C# cells explain the same theorem
+(Gibbard-Satterthwaite: Borda manipulable + Dictature strategy-proof) using
+C# idioms (BCL .NET 9 pur, 0 NuGet, s.Display()) rather than Python idioms.
+"""
+import json
+import sys
+from pathlib import Path
+
+NB_PATH = Path('MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign-Csharp.ipynb')
+
+# ---- Cell 1: Markdown intro (mirrors Python md "Illustration : Gibbard-Satterthwaite...")
+md1_source = (
+    "### 5.1 Gibbard-Satterthwaite : Borda manipulable + dictature strategy-proof\n"
+    "\n"
+    "La section 6 (impossibilites) du jumeau Python enonce le theoreme de "
+    "**Gibbard-Satterthwaite** : pour toute fonction de choix social sur au moins "
+    "3 alternatives, **non-dictatoriale** et **surjective**, il existe un profil "
+    "ou un electeur a interet a mentir. C'est un resultat d'impossibilite : il "
+    "ne montre pas *comment* manipuler, il affirme que l'occasion existe.\n"
+    "\n"
+    "Nous le **verifions computatoirement** sur la regle de **Borda** (non-"
+    "dictatoriale, surjective, $\\geq 3$ alternatives -- donc dans le scope du "
+    "theoreme) : pour chaque profil sincere de 3 electeurs sur 3 alternatives, "
+    "nous cherchons par **enumeration force brute** si un electeur peut, en "
+    "declarant un bulletin different de ses vraies preferences, faire elire un "
+    "candidat qu'il prefere au gagnant sincere. Si le theoreme est exact, "
+    "l'enumeration doit trouver un temoin.\n"
+    "\n"
+    "Puis nous verifions que la **dictature** (l'electeur 0 decide seul) est "
+    "strategy-proof sur les memes 216 profils : c'est le contre-point du "
+    "theoreme -- les seules regles strategy-proof sur $\\geq 3$ alternatives "
+    "sont dictatoriales."
+)
+
+# ---- Cell 2: C# code (mirrors Python enumeration brute-force, BCL .NET 9 pur)
+code_source = (
+    "// Gibbard-Satterthwaite - demonstration computatoire (C# / .NET 9 BCL pur).\n"
+    "// 3 alternatives, regle de Borda (points m-1 ... 0, ex aequo resolus\n"
+    "// alphabetiquement). Permutations generees recursivement (sans NuGet).\n"
+    "char[] ALTS = {'A', 'B', 'C'};\n"
+    "int m = ALTS.Length;\n"
+    "\n"
+    "// Generation recursive des permutations sur un tableau de T.\n"
+    "// Variante non-generique (char[]) pour compatibilite top-level statements.\n"
+    "// NOTE: pas de `static` ici -- en .NET Interactive top-level, m et ALTS sont\n"
+    "// des champs d'instance de la classe implicite ; static ne les verrait pas.\n"
+    "List<char[]> Permute(char[] items)\n"
+    "{\n"
+    "    var result = new List<char[]>();\n"
+    "    void Rec(char[] prefix, char[] rest)\n"
+    "    {\n"
+    "        if (rest.Length == 0)\n"
+    "        {\n"
+    "            result.Add(prefix.ToArray());\n"
+    "            return;\n"
+    "        }\n"
+    "        for (int i = 0; i < rest.Length; i++)\n"
+    "        {\n"
+    "            var newPrefix = prefix.Concat(new[] { rest[i] }).ToArray();\n"
+    "            var newRest = rest.Where((_, idx) => idx != i).ToArray();\n"
+    "            Rec(newPrefix, newRest);\n"
+    "        }\n"
+    "    }\n"
+    "    Rec(new char[0], items);\n"
+    "    return result;\n"
+    "}\n"
+    "\n"
+    "// Regle de Borda : points = m-1-rank par electeur, gagnant = max(score, -ord).\n"
+    "char BordaWinner(char[][] ballots)\n"
+    "{\n"
+    "    var score = new Dictionary<char, int> { ['A'] = 0, ['B'] = 0, ['C'] = 0 };\n"
+    "    foreach (var ballot in ballots)\n"
+    "        for (int rank = 0; rank < ballot.Length; rank++)\n"
+    "            score[ballot[rank]] += (m - 1 - rank);\n"
+    "    char best = ALTS[0];\n"
+    "    int bestScore = -1, bestOrd = 0;\n"
+    "    foreach (var a in ALTS)\n"
+    "    {\n"
+    "        int sc = score[a];\n"
+    "        int ord = -(int)a;\n"
+    "        if (sc > bestScore || (sc == bestScore && ord < bestOrd))\n"
+    "        {\n"
+    "            bestScore = sc;\n"
+    "            bestOrd = ord;\n"
+    "            best = a;\n"
+    "        }\n"
+    "    }\n"
+    "    return best;\n"
+    "}\n"
+    "\n"
+    "// Position d'une alternative dans un ranking (0 = la preferee).\n"
+    "int Rang(char[] prefs, char alt)\n"
+    "{\n"
+    "    for (int i = 0; i < prefs.Length; i++)\n"
+    "        if (prefs[i] == alt) return i;\n"
+    "    return -1;\n"
+    "}\n"
+    "\n"
+    "// Cherche un electeur qui gagne a mentir. Retourne le tuple temoin ou null.\n"
+    "// (profile, i, vraies, mensonge, gs, gn) -- gs = gagnant sincere, gn = gagnant sous mensonge.\n"
+    "(char[][] profile, int i, char[] vraies, char[] mensonge, char gs, char gn)?\n"
+    "    TrouverManipulation(char[][] profile, Func<char[][], char> regle)\n"
+    "{\n"
+    "    char gs = regle(profile);\n"
+    "    for (int i = 0; i < profile.Length; i++)\n"
+    "    {\n"
+    "        var vraies = profile[i];\n"
+    "        foreach (var mensonge in Permute(ALTS))\n"
+    "        {\n"
+    "            if (mensonge.SequenceEqual(vraies)) continue;\n"
+    "            var nouveau = new char[profile.Length][];\n"
+    "            for (int k = 0; k < profile.Length; k++) nouveau[k] = profile[k];\n"
+    "            nouveau[i] = mensonge;\n"
+    "            char gn = regle(nouveau);\n"
+    "            if (Rang(vraies, gn) < Rang(vraies, gs))\n"
+    "                return (profile, i, vraies, mensonge, gs, gn);\n"
+    "        }\n"
+    "    }\n"
+    "    return null;\n"
+    "}\n"
+    "\n"
+    "char GagnantDictature(char[][] profile) { return profile[0][0]; }\n"
+    "\n"
+    "// --- Demonstration ---\n"
+    "\"Gibbard-Satterthwaite - demonstration computatoire\".Display();\n"
+    "new string('=', 64).Display();\n"
+    "\n"
+    "var toutesPrefs = Permute(ALTS);\n"
+    "// Generer les 6^3 = 216 profils (3 electeurs, chacun choisit une permutation de 3 alternatives).\n"
+    "var profilesBorda = new List<char[][]>();\n"
+    "foreach (var p0 in toutesPrefs)\n"
+    "    foreach (var p1 in toutesPrefs)\n"
+    "        foreach (var p2 in toutesPrefs)\n"
+    "            profilesBorda.Add(new[] { p0, p1, p2 });\n"
+    "\n"
+    "\"[1] Regle de Borda (non-dictatoriale, surjective, >= 3 alternatives) :\".Display();\n"
+    "var temoin = (object)null;\n"
+    "foreach (var profile in profilesBorda)\n"
+    "{\n"
+    "    var r = TrouverManipulation(profile, BordaWinner);\n"
+    "    if (r != null) { temoin = r; break; }\n"
+    "}\n"
+    "if (temoin != null)\n"
+    "{\n"
+    "    var t = ((char[][], int, char[], char[], char, char))temoin;\n"
+    "    var profile = t.Item1;\n"
+    "    var i = t.Item2;\n"
+    "    var vraies = t.Item3;\n"
+    "    var mensonge = t.Item4;\n"
+    "    var gs = t.Item5;\n"
+    "    var gn = t.Item6;\n"
+    "    $\"    Profil sincere : (({string.Join(\",\", profile[0])}), ({string.Join(\",\", profile[1])}), ({string.Join(\",\", profile[2])}))\".Display();\n"
+    "    $\"    Gagnant sincere : {gs}\".Display();\n"
+    "    $\"    L'electeur {i} (prefs vraies ({string.Join(\",\", vraies)})) declare ({string.Join(\",\", mensonge)})\".Display();\n"
+    "    $\"    -> Nouveau gagnant : {gn} (qu'il prefere a {gs})\".Display();\n"
+    "    \"    => Borda est MANIPULABLE. Temoin trouve par enumeration des 216 profils.\".Display();\n"
+    "}\n"
+    "else\n"
+    "{\n"
+    "    \"    Aucune manipulation trouvee.\".Display();\n"
+    "}\n"
+    "\n"
+    "\"\".Display();\n"
+    "\"[2] Dictature (l'electeur 0 decide seul) :\".Display();\n"
+    "bool manipDict = false;\n"
+    "foreach (var profile in profilesBorda)\n"
+    "{\n"
+    "    if (TrouverManipulation(profile, GagnantDictature) != null) { manipDict = true; break; }\n"
+    "}\n"
+    "(manipDict ? \"    Manipulation trouvee (!)\" : \"    Aucune manipulation sur les 216 profils -> la dictature est STRATEGY-PROOF.\").Display();\n"
+    "\n"
+    "\"\".Display();\n"
+    "\"[3] Gibbard-Satterthwaite en acte :\".Display();\n"
+    "\"    Borda (non-dictatorial) = manipulable ; Dictature = strategy-proof.\".Display();\n"
+    "\"    Sur >= 3 alternatives, les SEULS mecanismes strategy-proof sont dictatoriaux.\".Display();"
+)
+
+# ---- Cell 3: Markdown interpretation (mirrors Python md "Interpretation : le theoreme en acte")
+md2_source = (
+    "### Lecture : le theoreme en acte\n"
+    "\n"
+    "L'enumeration a trouve un **temoin de manipulation** : sur un profil sincere "
+    "donne, Borda elirait le candidat $g_s$. L'electeur $i$ (dont les vraies "
+    "preferences sont $v$) a interet a declarer $m \\neq v$ : Borda elire alors "
+    "$g_n$ que l'electeur prefere strictement a $g_s$. Le mensonge rationnel est "
+    "recompense -- et c'est l'enumeration qui l'a decouvert, non une construction "
+    "ad hoc.\n"
+    "\n"
+    "La deuxieme mesure est le **contre-point** du theoreme : la **dictature** "
+    "(l'electeur 0 decide seul) est **strategy-proof** sur les 216 profils. Le "
+    "dictateur n'a rien a gagner a mentir (son choix sincere gagne deja), et les "
+    "autres electeurs sont ignores. C'est exactement la conclusion de Gibbard-"
+    "Satterthwaite : **les seules regles strategy-proof sur $\\geq 3$ alternatives "
+    "sont dictatoriales**.\n"
+    "\n"
+    "**Pourquoi Vickrey et VCG echappent-ils au theoreme ?** Parce qu'ils "
+    "utilisent des **transferts monetaires** -- le theoreme de Gibbard-Satterthwaite "
+    "porte sur les fonctions de choix social *sans paiements*. Des qu'on autorise "
+    "un paiement (l'enchere au second prix, le critere de Clarke), on sort du cadre "
+    "d'impossibilite et l'incitativite redevient possible.\n"
+    "\n"
+    "**Note sur le temoin** : l'ordre des permutations en C# (`Permute` recursif) "
+    "differe de l'ordre Python (`itertools.permutations`), donc le **premier "
+    "temoin** renvoye peut varier entre les deux jumeaux. C'est attendu : le "
+    "theoreme garantit l'**existence** d'un temoin, pas un temoin specifique. "
+    "Les deux jumeaux trouvent un temoin valide et aboutissent a la meme "
+    "conclusion (Borda manipulable, Dictature strategy-proof)."
+)
+
+# ---- Build cell objects (un-executed; will be re-executed by .NET Interactive)
+def make_md_cell(source):
+    src_list = source.split('\n')
+    # nbformat expects list with newlines preserved between lines except the last
+    src = [line + '\n' for line in src_list[:-1]] + [src_list[-1]]
+    return {
+        "cell_type": "markdown",
+        "metadata": {"tags": []},
+        "source": src
+    }
+
+def make_code_cell(source):
+    src_list = source.split('\n')
+    src = [line + '\n' for line in src_list[:-1]] + [src_list[-1]]
+    return {
+        "cell_type": "code",
+        "execution_count": None,
+        "metadata": {"tags": []},
+        "outputs": [],
+        "source": src
+    }
+
+new_md1 = make_md_cell(md1_source)
+new_code = make_code_cell(code_source)
+new_md2 = make_md_cell(md2_source)
+
+# ---- Load notebook, find insertion point (BEFORE cell 17 = "## 6. Exercices")
+nb = json.loads(NB_PATH.read_text(encoding='utf-8'))
+cells = nb['cells']
+
+# Find insertion index: first cell whose source contains "## 6. Exercices"
+ins_idx = None
+for i, c in enumerate(cells):
+    src = ''.join(c.get('source', [])) if isinstance(c.get('source'), list) else c.get('source', '')
+    if c['cell_type'] == 'markdown' and src.startswith('## 6. Exercices'):
+        ins_idx = i
+        break
+if ins_idx is None:
+    print("ERROR: could not find insertion point ('## 6. Exercices')", file=sys.stderr)
+    sys.exit(1)
+
+# Insert 3 cells at ins_idx (markdown, code, markdown)
+new_cells = cells[:ins_idx] + [new_md1, new_code, new_md2] + cells[ins_idx:]
+nb['cells'] = new_cells
+
+# Write back
+NB_PATH.write_text(json.dumps(nb, indent=1, ensure_ascii=False), encoding='utf-8')
+print(f"OK: inserted 3 cells before cell {ins_idx} ('## 6. Exercices')")
+print(f"Total cells: {len(cells)} -> {len(new_cells)}")


### PR DESCRIPTION
# fix(gametheory,#10488,#10595): mirror Gibbard-Satterthwaite cells in C# twin to restore twin parity on PR #10699 (c.1331+109)

Grain: MED/test — lane myia-po-2024:CoursIA-2 — prev: MED/test #10697

## Symptôme (firsthand)

PR #10699 (commit `f42082e45e`, c.1331+108 GT-16 Gibbard-Satterthwaite Python-only demo) a fait passer la `twin parity audit (#8057)` au ROUGE :

```
[pr-gate] FAIL -- failing checks: Twin parity audit (#8057)
```

Diagnostic log :
> "La PR a introduit 1 paire(s) en DRIFT/MISSING qui etaient OK au base-ref origin/main. Lance EXACTEMENT : `python scripts/notebook_tools/check_twin_parity.py --update --pair "GameTheory-16 MechanismDesign" --by "<machine:workspace>"`"

Mesure firsthand (sur le branch tip `f42082e45e`) :

| Cote | Cells / code-cells | SHA blob (registry c.1331+107) |
|---|---|---|
| Python twin `GameTheory-16-MechanismDesign.ipynb` | 49 → **52** (+3) / 15 → **16** | `557e00388f...` → `ff17528ee7...` |
| C# twin `GameTheory-16-MechanismDesign-Csharp.ipynb` | 24 / 9 (UNCHANGED) | `fd5fd04b33...` (unchanged) |

Le registre twin_parity_pairs.d/gametheory-16-mechanismdesign.yaml declare la paire `parity_level: semantic`, `bridge_verdict: SOTA-OK` (c.1331+103 cense maintenir la parite). L'asymetrie documentee ("Python 49/15 couvre principes fondamentaux et revelation ; C# 24/9 ajoute Gale-Shapley et double-auction") ne couvre PAS le Gibbard-Satterthwaite : la section 6.1 du Python est nommee "Theoreme d'Impossibilite" et le jumeau C# n'a pas de section analogue — le 3-cell add est donc substantiel, pas cosmetic.

## Cause (mesuree)

Le commit c.1331+108 (PR #10699) a ajoute 3 cellules au jumeau Python SANS ajouter les cellules miroirs au jumeau C#. Le C# twin n'a meme pas de section "6. Impossibilites" — la section 5 est "Double auction" (Myerson-Satterthwaite bilateral) puis section 6 = Exercices.

Le **miroir semantique** s'impose : il existe une section 5 dans les deux jumeaux (C#: double-auction Myerson-Satterthwaite), c'est l'endroit naturel pour inserer la demo Gibbard-Satterthwaite cote C#.

## Correctif

Ajout des **3 cellules miroirs** au jumeau C# `GameTheory-16-MechanismDesign-Csharp.ipynb`, apres la cellule 16 ("Lecture du resultat : efficacite et partage du surplus") et avant la cellule 17 ("## 6. Exercices"). Total 24 → **27** cellules.

### Cellule 1 — Markdown `### 5.1 Gibbard-Satterthwaite : Borda manipulable + dictature strategy-proof`

Enonce le theoreme (>=3 alternatives, non-dictatoriale + surjective => non-strategy-proof), annonce la verification computatoire sur la regle de Borda, et le contre-point sur la dictature.

### Cellule 2 — Code C# (BCL .NET 9 pur, 0 NuGet)

```csharp
char[] ALTS = {'A', 'B', 'C'};
int m = ALTS.Length;
List<char[]> Permute(char[] items) { /* recursive, BCL only */ }
char BordaWinner(char[][] ballots) { /* points m-1-rank, tie-break -ord */ }
int Rang(char[] prefs, char alt) { /* position 0 = best */ }
(char[][], int, char[], char[], char, char)? TrouverManipulation(...) { /* enumere tous les mensonges */ }
char GagnantDictature(char[][] profile) { return profile[0][0]; }

// Demonstration
//   [1] Borda non-dictatoriale : enumeration 6^3 = 216 profils -> temoin trouve
//   [2] Dictature : aucune manipulation possible -> strategy-proof
//   [3] Synthese : GS en acte
```

Implementation subtile : **methodes top-level NON-static** en .NET Interactive (m et ALTS sont des champs d'instance de la classe implicite ; `static` donnerait CS0120 "Une reference d'objet est requise pour la propriete, la methode ou le champ non statique 'm'/'ALTS'").

### Cellule 3 — Markdown `### Lecture : le theoreme en acte`

Interpretation : temoin = preuve par enumeration, contre-point dictature, **pourquoi Vickrey et VCG echappent** (transferts monetaires), **note sur le temoin** : l'ordre des permutations en C# (recursive Permute) differe de l'ordre Python (itertools.permutations), donc le premier temoin varie entre jumeaux — c'est attendu, le theoreme garantit l'**existence** d'un temoin, pas un temoin specifique.

## Validation

### Re-execution .NET Interactive (`exec_dotnet_persist.py`, kernel `.net-csharp`)

```
Cell 2: OK (0.3s, 2 outputs)
Cell 4: OK (0.2s, 3 outputs)
Cell 7: OK (0.2s, 2 outputs)
Cell 9: OK (0.1s, 2 outputs)
Cell 12: OK (0.1s, 2 outputs)
Cell 15: OK (0.0s, 2 outputs)
Cell 18: OK (0.2s, 15 outputs)         <- nouvelle cellule C# GS demo
Cell 21: OK (0.0s, 1 outputs)
Cell 23: OK (0.0s, 1 outputs)
Cell 25: OK (0.0s, 1 outputs)
Done: 10 cells executed, 0 errors, saved to GameTheory-16-MechanismDesign-Csharp.ipynb
```

### Sortie cell 18 (verifiee firsthand)

```
Gibbard-Satterthwaite - demonstration computatoire
================================================================
[1] Regle de Borda (non-dictatoriale, surjective, >= 3 alternatives) :
    Profil sincere : ((A,B,C), (A,B,C), (B,A,C))
    Gagnant sincere : A
    L'electeur 2 (prefs vraies (B,A,C)) declare (B,C,A)
    -> Nouveau gagnant : B (qu'il prefere a A)
    => Borda est MANIPULABLE. Temoin trouve par enumeration des 216 profils.

[2] Dictature (l'electeur 0 decide seul) :
    Aucune manipulation sur les 216 profils -> la dictature est STRATEGY-PROOF.

[3] Gibbard-Satterthwaite en acte :
    Borda (non-dictatorial) = manipulable ; Dictature = strategy-proof.
    Sur >= 3 alternatives, les SEULS mecanismes strategy-proof sont dictatoriaux.
```

### Twin parity audit (verifiee firsthand)

```
$ python scripts/notebook_tools/check_twin_parity.py --check --pair "GameTheory-16 MechanismDesign"
[OK] GameTheory-16 MechanismDesign (GameTheory/.NET-Parity, semantic)
Total : 157 paire(s) | OK=157 DRIFT=0 MISSING=0
exit-code: 0
```

### Quality gates

| Gate | Avant c.1331+109 | Apres c.1331+109 |
|---|---|---|
| nbformat | 4.5 | 4.5 |
| Cells C# twin | 24 | **27** (+3) |
| Code cells C# twin | 9 | **10** (+1) |
| Cell 18 outputs | n/a | **15** (display_data x14 + stream stderr vide) |
| Errors / warnings | n/a | **0 / 0** |
| CRLF bytes (C# twin) | 0 | **0** (normalise LF post-re-exec, avant commit) |
| probeAddresses banner | 0 | **0** |
| CJK leak (regex strict) | 0 | **0** |
| Twin parity (--check) | DRIFT | **OK** (exit 0) |

## Scope delimite

- **+1081/-367/3 fichiers** (C# notebook + Python notebook cherry-picked + script helper).
- **Python notebook change = cherry-pick de f42082e45e** (commit deja review par NanoClaw et accepte COMMENTED LGTM sur PR #10699). Substance identique, juste re-appliquee sur le fix branch.
- **C# notebook change = +3 cellules miroirs semantiques** (substance nouvelle, le fix).
- **script `_insert_cs_mirror.py` = +267 lignes** (helper reproductible, source-de-verite de l'insertion).
- 0 modification de `.gitleaks.toml`, 0 modif de `check_twin_parity.py`, 0 modif de `.github/workflows/`.
- En dessous des seuils CHANGES_REQUESTED (3000 lignes / 15 fichiers / 4 features / 1 domaine).

## Lecons c.1331+109

### c.1331+109-L1 ★★ — Semantic twin mirror doit suivre l'ajout semantique, pas la lettre

Le PR #10699 a ajoute une **section semantique nouvelle** (Gibbard-Satterthwaite, sous le titre "6.1 Impossibilite") au Python twin sans miroir. Le twin parity audit #8057 detecte le DRIFT par **comptage cellules + comparaison SHA**, pas par comprehension semantique.

**Tell d'auto-detection** : apres toute PR qui ajoute une **section semantique nouvelle** (pas une modification in-place) a un twin `parity_level: semantic` :
1. Identifier le cote reciproque (FR vs EN, Python vs C#, etc.).
2. Si la nouvelle section correspond a un **theme** dejab presente sur l'autre cote (meme titre informel), ajouter le miroir sur l'autre cote directement dans la meme PR.
3. Si la nouvelle section est **uniquement cote Python** (theme propre, sans analogue cote C#), ajouter une note `known_differences` au registre yaml via PR dediee, OU specifier dans le body PR que la parite est asymetrique et update le registre dans la meme PR.

**Anti-pattern** : laisser la parite en DRIFT en postant le PR, attendre que CI rougisse, puis ouvrir une PR dediee "fix twin parity" -> c'est **2 PRs au lieu d'1**, scope double, 2x review, 2x merge. Mieux : **detecter au moment du PR original** en lancant `python scripts/notebook_tools/check_twin_parity.py --check --pair "<X>"` AVANT `gh pr create`.

### c.1331+109-L2 ★★ — .NET Interactive top-level = instance methods, pas static

`static` sur une methode top-level en .NET Interactive top-level statements **ne peut pas acceder aux champs** declares en top-level (m, ALTS, etc. sont des champs d'instance de la classe implicite generee par le compilateur). Symptome : `CS0120: Une reference d'objet est requise pour la propriete, la methode ou le champ non statique 'm'/'ALTS'`.

**Pattern correct** : declarer les methodes top-level **sans** `static` :
```csharp
// top-level statements
char[] ALTS = {'A', 'B', 'C'};
int m = ALTS.Length;
List<char[]> Permute(char[] items) { /* uses ALTS, m via implicit 'this' */ }
```

**Anti-pattern** : copier/coller du code de `class Program { static void Main() {...} }` sans adaptation au contexte top-level.

**Tell d'auto-detection** : si on importe un pattern C# standard `class Program { static ... }` dans une cellule `.NET Interactive`, **revoir le `static`** sur les methodes qui accedent a des variables top-level.

### c.1331+109-L3 ★ — CRLF drift sur re-exec .NET Interactive (Windows)

`exec_dotnet_persist.py` ecrit le notebook en binaire sur Windows, ce qui peut inserer des `\r\n` la ou les cellules source etaient en `\n`. Per c.1331+101-L2 ★★ et `.gitattributes` (`*.ipynb text eol=lf`), il faut **normaliser LF apres toute re-exec .NET avant commit** :

```python
content = open(path, 'rb').read()
new = content.replace(b'\\r\\n', b'\\n')
open(path, 'wb').write(new)
```

Sur la presente PR : CRLF count = 1165 apres re-exec, 0 apres normalisation. Sans cette etape, CI `Check base branch staleness` ou un futur diff base-vs-PR pourrait rougir sur les bytes CRLF inattendus.

## Conformite regles

- **G-VAR-1** : MED/test, dans le genre CONTENU `test` (verification twin parity). Plancher cycle satisfait.
- **G-VAR-3** : prev MED/test #10697. Substance **genuinement distincte** : (1) #10697 = ajout test class runtime `subprocess.run(gitleaks)` pour allowlist `paths` ; (2) c.1331+109 = ajout miroir semantique C# sur twin parity DRIFT detecte par CI. Merge-gate laisse passer.
- **pr-review-discipline §B.4** : body PR utilise `See #10488, See #10595`, pas `Closes` -- l'umbrella #10488 reste ouverte tant que d'autres tranches ne sont pas livrees.
- **pr-review-discipline §C.4** : re-execution reelle documentee (Papermill Python non applicable ici ; .NET Interactive `exec_dotnet_persist.py` est l'equivalent pour la cible C#, cf verbatim de la sortie ci-dessus).
- **L677-L4 ★★** : body PR HORS worktree (scratchpad path), via `--body-file`.
- **L898 ★★★** : pre-claim path-scan AVANT write verifie : `git worktree list` propre (worktree `c1331x109-gt16-twin-fix`), `gh pr list --search "gt16"` = #10699 OPEN + 0 collision avec cette branche.
- **C847** PRE-WORK inbox check : 0 DM URGENT non traite.
- **lane-claim §6 paths-mode** : claim sur #10488 avec `paths: MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign-Csharp.ipynb` (scope disjoint avec PR #10699 qui touche le twin Python).
- **secrets-hygiene** : 0 literal-secret, 0 machine-path dans le diff. Banner `probeAddresses` strip : pas applicable (la cellule C# n'enumere pas les interfaces reseau).

## Liens

- PR : https://github.com/jsboige/CoursIA/pull/10700 (a ouvrir)
- Issue umbrella : https://github.com/jsboige/CoursIA/issues/10488 (densite pedagogique EPIC)
- Issue paths bypass : https://github.com/jsboige/CoursIA/issues/10595 (le c.1331+107 livre le test runtime, ce PR livre le miroir semantique)
- PR antecedent : https://github.com/jsboige/CoursIA/pull/10699 (c.1331+108 GT-16 GS Python-only demo)
- PR sibling precedent : https://github.com/jsboige/CoursIA/pull/10697 (c.1331+107 paths bypass test)
- Run CI failure : https://github.com/jsboige/CoursIA/runs/31658710393 (PR gate FAIL sur twin parity)
- Precedent grain : c.1331+107 (MED/test #10697)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>