### PR TITLE
fix(audio-04-7,#9434): derive residual ms re-pins in Lecture-du-tableau cells to ordres de grandeur

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-7-TTS-Voice-Benchmark.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-7-TTS-Voice-Benchmark.ipynb
@@ -1266,7 +1266,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Lecture du tableau comparatif** — le résumé par modèle donne un verdict tranché : **Kokoro** avg **2970 ms** (min 2736, max 3174), **OpenAI/tts-1** avg **4244 ms** (min 3644, max 4846). Le modèle local est **~30 % plus rapide** que l'API cloud sur ces trois extraits. **Qwen3 TTS** est absent du tableau (erreur 503 sur les trois tests) — honnêtement exclu plutôt que moyenné avec des timeouts.\n",
+    "**Lecture du tableau comparatif** — le résumé par modèle donne un verdict tranché : **Kokoro** avg **~3 s**, **OpenAI/tts-1** avg **~4 s** (latences précises consignées par la cellule de benchmark ci-dessus — cf. tableau, source unique mise à jour à chaque exécution). Le modèle local est **~30 % plus rapide** que l'API cloud sur ces trois extraits. **Qwen3 TTS** est absent du tableau (erreur 503 sur les trois tests) — honnêtement exclu plutôt que moyenné avec des timeouts.\n",
     "\n",
     "**Ce que cet output démontre sur la méthode benchmark** : le détail par échantillon révèle que la sélection de la **voix** varie par genre — Kokoro utilise `af_sky` (narration/dialogue) puis `af_bella` (monologue), OpenAI alterne `alloy`/`nova`. La latence ne dépend donc pas seulement du modèle mais du couple modèle-voix. Notez aussi la taille audio (253-371 KB) qui fluctue avec la voix, pas avec le texte seul. Un benchmark TTS sérieux doit fixer la voix et le texte pour isoler la variable modèle — c'est ce que fait ce notebook."
    ]
@@ -1454,7 +1454,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Lecture du tableau des specs** — les caractéristiques techniques confirment l'inversion de latence observée au §7 : **Kokoro** est un modèle local de **82M paramètres** (~1 GB VRAM), tandis qu'**OpenAI tts-1** est une API cloud sans empreinte locale. C'est pourquoi Kokoro (avg **2970 ms**) bat OpenAI (avg **4244 ms**) d'environ **30 %** malgré des paramètres moindres : le modèle local évite le round-trip réseau vers `api.openai.com`.\n",
+    "**Lecture du tableau des specs** — les caractéristiques techniques confirment l'inversion de latence observée au §7 : **Kokoro** est un modèle local de **82M paramètres** (~1 GB VRAM), tandis qu'**OpenAI tts-1** est une API cloud sans empreinte locale. C'est pourquoi Kokoro (avg **~3 s**) bat OpenAI (avg **~4 s**) d'environ **30 %** malgré des paramètres moindres : le modèle local évite le round-trip réseau vers `api.openai.com`.\n",
     "\n",
     "**Ce que cet output démontre sur le compromis local-vs-cloud** : la latence d'un service TTS n'est pas une propriété intrinsèque du modèle, mais de **l'architecture de déploiement**. Un petit modèle local bien servi (Kokoro sur GPU à `localhost:8191`) surpasse une API cloud pour les charges interactives — au prix d'un footprint VRAM fixe. Ce résultat oriente le choix production : pour un audiobook généré en lot (latence non critique), OpenAI cloud économise le GPU ; pour une voix en temps réel, Kokoro local est indispensable."
    ]


### PR DESCRIPTION
Grain: MED/content — lane myia-po-2025:CoursIA — prev: MED/content #10702

# fix(audio-04-7,#9434): derive residual ms re-pins in Lecture-du-tableau cells to ordres de grandeur

See #9434 (quantitatif tenu par le CI, pas par la prose) · See #8052 (prose-vs-output coherence)

## What

2 cellules markdown d'interprétation de `04-7-TTS-Voice-Benchmark.ipynb` ré-épinglaient des **latences précises en ms** (2970/2736/3174/4244/3644/4846) **commitées par les cellules DataFrame ci-dessus** (c26 `df = pd.DataFrame(benchmark_results)`, c27 détail par échantillon). C'est la boucle de contradiction #8052 : à la re-exécution sur une autre machine, les outputs code dérivent mais le markdown reste — d'où les vagues répétées de PR "ré-aligner la prose".

## Ces 2 cellules ont été manquées par les drains #9434 antérieurs sur CE notebook

| PR antérieure | cellules drainées | statut |
|---|---|---|
| #9715 | cell[33] (intro specs) + cell[40] (conclusion) | MERGED |
| #10550 | cell[18] (transition dialogue) — a gardé `(mesure : 3174ms)` délibérément | MERGED |
| **cette PR** | **cell[28] (Lecture du tableau comparatif) + cell[35] (Lecture du tableau des specs)** — **résiduel non touché** | — |

c28 et c35 sont les cellules "Lecture du tableau" qui interprètent DIRECTEMENT le DataFrame de benchmark juste au-dessus — le cas canonique du critère d'acceptation #9434 : « Aucun temps absolu en ms ne subsiste dans une cellule markdown d'interprétation quand la cellule de mesure est juste au-dessus. »

## Le fix (préserve le contenu structurel, dérive le machine-dep)

| Cellule | Avant (machine-dep, dérive) | Après (structurel stable) |
|---|---|---|
| c28 | `Kokoro avg **2970 ms** (min 2736, max 3174), OpenAI/tts-1 avg **4244 ms** (min 3644, max 4846)` | `Kokoro avg **~3 s**, OpenAI/tts-1 avg **~4 s** (latences précises consignées par la cellule de benchmark ci-dessus — cf. tableau, source unique)` |
| c35 | `Kokoro (avg **2970 ms**) bat OpenAI (avg **4244 ms**)` | `Kokoro (avg **~3 s**) bat OpenAI (avg **~4 s**)` |

**Gardé intact** (structurel = stable machine-to-machine) : le ratio `~30 % plus rapide`, `82M paramètres`, `~1 GB VRAM`, la conclusion architecturelle local-vs-cloud (round-trip réseau vs footprint VRAM).

c18 **laissée telle quelle** : #10550 a délibérément conservé `(mesure : 3174ms)` comme référence précise + caveat Note — je ne contre-dis pas ce choix délibéré d'une PR mergée.

## G.1 firsthand (pas un sweep scanner)

Le classifier `scan_quant_classify.py` (#9800) reportait **4196 findings** sur l'Audio family, **~99 % de FP** (numéros de module `01-audio`, numéros d'étape `1.`, fréquences Hz `80 hz`, % `100% python`, plages déjà-correctes `1-3s`). J'ai trié chaque candidat firsthand et isolé la **vraie classe de défaut** : valeurs absolues célibataires ré-épinglant des outputs commités. Les 30 notebooks Audio sont par ailleurs **largement conformes** au #9434 (presque tous les timings machine-dep sont déjà en plages `~2-3s` + label `*runtime machine-dep*`). 04-7 était le résiduel clair.

## Validation (post-fix)

- `detect_md_content_loss.py --base origin/main --check <nb>` : **0 finding** (md_cells 23=23 stable, chars 10209→10272 — légère hausse par le texte de renvoi, contenu préservé).
- `validate_pr_notebooks.py origin/main <nb>` : **PASS 22/22 code cells**.
- `git diff --stat` : 1 fichier, 2 insertions/2 deletions (c28 + c35 markdown source uniquement).
- Markdown-only (exception C.3, pas de re-exec). 22 cellules code byte-identiques.

## G-VAR-3 — transparence sur le genre

Cette PR est **MED/content** (fix markdown pédagogique). Prev = MED/content (#10702 table-pipe). G-VAR-3 autorise MED same-genre *uniquement si substance genuinement distincte*. Défense :
- **Mandat différent** : #9434 (machine-dep quant-drift) ≠ #10097 (GFM table syntax). Deux axes, deux critères d'acceptation, deux scanners.
- **Raisonnement de domaine différent** : distinguer structurel-stable vs machine-dep-dérivant vs ré-pin-d'output vs plage-déjà-correcte — vs wrapper des math-pipe en code spans. Le litmus LIGHT (« générable en série par scan ») : pour quant-drift, NON (jugement per-cell requis), pour table-pipe, OUI.
- **Triage firsthand non-mécanique** : 4196 findings → 2 vrais résiduels via lecture de chaque contexte.

Je reconnais que c'est la limite de la veine content-markdown. **Prochain cycle je pivote vers un genre non-content** (tooling/refactor/test).

See #9434, #8052. See #9715, #10550 (drains antérieurs sur ce notebook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
