### PR TITLE
refactor(census,#9485): parse_grain diverged from canonical Grain reader — delegate to grain_tag

### DIFF
--- a/scripts/tests/test_variation_genre_recensement.py
+++ b/scripts/tests/test_variation_genre_recensement.py
@@ -1,0 +1,191 @@
+"""Tests for `variation_genre_recensement.py` pure parsers + drift heuristics.
+
+Background (why this file exists): the census `parse_grain` used a local
+`_GRAIN_RE` that DIVERGED from the canonical form-tolerant reader
+`grain_tag.parse_grain_tag` (#9485). It silently dropped the tolerated forms
+(`**Grain:**`, `## Grain`, `` `Grain` `` no-colon), undercounting the universe
+and biasing the monoculture census that motivated `variation-protocol.md`.
+These tests pin the contract: `parse_grain` MUST agree with the canonical
+reader on every form the CI guard accepts.
+"""
+import os
+import sys
+
+# Make scripts/ importable (sibling of tests/), same pattern as test_grain_tag.py
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import variation_genre_recensement as vgr  # noqa: E402
+from variation_genre_recensement import (  # noqa: E402
+    file_family,
+    has_interpretation_cue,
+    only_notebook,
+    parse_grain,
+    zero_code_modif,
+)
+
+# Canonical PR-body fixtures spanning every form the CI guard tolerates.
+# Lane token included where the canonical reader would see it, but parse_grain
+# only returns (tier, genre) — the lane is parsed elsewhere.
+CANONICAL = "Grain: LIGHT/guard -- lane myia-po-2023:CoursIA"
+BOLD = "**Grain:** LIGHT/guard - lane myia-ai-01:CoursIA"
+TITLE_HASH = "## Grain\n\nLIGHT/guard ... lane myia-po-2024:CoursIA-2"
+NO_COLON = "`Grain` LIGHT/guard ... lane myia-po-2025:CoursIA"
+DEEP_LEAN = "Grain: DEEP/lean -- lane myia-po-2026:CoursIA"
+MED_NB = "Grain: MED/notebook-python -- lane myia-po-2024:CoursIA-2"
+
+
+# --- parse_grain: MUST agree with the canonical reader on every form --------
+
+def test_parse_grain_canonical():
+    assert parse_grain(CANONICAL) == ("LIGHT", "guard")
+
+
+def test_parse_grain_bold_form():
+    """`**Grain:**` (bold) — tolerated by the CI guard, must parse here too.
+
+    This was the headline divergence: the local _GRAIN_RE missed it, so the
+    census undercounted any PR using the bold form.
+    """
+    assert parse_grain(BOLD) == ("LIGHT", "guard")
+
+
+def test_parse_grain_title_hash_form():
+    """`## Grain` then tag on next line — tolerated by CI guard via hash-strip."""
+    assert parse_grain(TITLE_HASH) == ("LIGHT", "guard")
+
+
+def test_parse_grain_no_colon_form():
+    """`` `Grain` `` with no colon — tolerated by CI guard."""
+    assert parse_grain(NO_COLON) == ("LIGHT", "guard")
+
+
+def test_parse_grain_deep_lean():
+    assert parse_grain(DEEP_LEAN) == ("DEEP", "lean")
+
+
+def test_parse_grain_med_notebook():
+    assert parse_grain(MED_NB) == ("MED", "notebook-python")
+
+
+def test_parse_grain_absent():
+    assert parse_grain("No grain tag here, just a body.") == (None, None)
+
+
+def test_parse_grain_empty_body():
+    assert parse_grain("") == (None, None)
+
+
+def test_parse_grain_none_body():
+    assert parse_grain(None) == (None, None)
+
+
+def test_parse_grain_agrees_with_canonical_reader_on_all_forms():
+    """The single contract: census parse_grain == grain_tag.parse_grain_tag.
+
+    If this fails, the two readers have drifted again — exactly the #9485
+    failure mode. The census must NOT carry its own Grain regex.
+    """
+    import grain_tag
+
+    bodies = [CANONICAL, BOLD, TITLE_HASH, NO_COLON, DEEP_LEAN, MED_NB, "", None]
+    for body in bodies:
+        census = parse_grain(body)
+        canon = grain_tag.parse_grain_tag(body)
+        canon_tuple = (canon["tier"], canon["genre"]) if canon else (None, None)
+        assert census == canon_tuple, (
+            f"census/parser drift on body={body!r}: "
+            f"census={census} canonical={canon_tuple}"
+        )
+
+
+# --- file_family -------------------------------------------------------------
+
+def test_file_family_two_segments():
+    paths = ["MyIA.AI.Notebooks/SymbolicAI/Lean/SL-1.ipynb"]
+    assert file_family(paths) == "SymbolicAI/Lean"
+
+
+def test_file_family_single_segment():
+    # NOTE: shallow paths (3 segments) return "family/file" — a latent quirk
+    # where parts[1:3] captures the filename. The deep-path case (4+ segments,
+    # e.g. SymbolicAI/Lean) is correct. Out of scope for the parse_grain fix;
+    # documented here to pin current behavior.
+    paths = ["MyIA.AI.Notebooks/ML/ml.cs"]
+    assert file_family(paths) == "ML/ml.cs"
+
+
+def test_file_family_no_notebooks():
+    assert file_family(["scripts/foo.py", "README.md"]) is None
+
+
+def test_file_family_empty():
+    assert file_family([]) is None
+
+
+def test_file_family_mixed_uses_notebook():
+    paths = ["scripts/foo.py", "MyIA.AI.Notebooks/GenAI/Image/x.ipynb"]
+    assert file_family(paths) == "GenAI/Image"
+
+
+# --- only_notebook -----------------------------------------------------------
+
+def test_only_notebook_all_ipynb():
+    assert only_notebook(["a.ipynb", "b.ipynb"]) is True
+
+
+def test_only_notebook_mixed():
+    assert only_notebook(["a.ipynb", "b.py"]) is False
+
+
+def test_only_notebook_empty():
+    assert only_notebook([]) is False
+
+
+# --- has_interpretation_cue --------------------------------------------------
+
+def test_interpretation_cue_enrichissement():
+    assert has_interpretation_cue("Ajout d'un enrichissement pedagogique.") is True
+
+
+def test_interpretation_cue_markdown_header():
+    assert has_interpretation_cue("blabla\n# Interpretation\nsuite") is True
+
+
+def test_interpretation_cue_plain():
+    assert has_interpretation_cue("Fix a bug in the solver.") is False
+
+
+# --- zero_code_modif ---------------------------------------------------------
+
+def test_zero_code_modif_no_patch_small_addition():
+    pr = {"files": [{"path": "a.ipynb", "additions": 5, "deletions": 0}]}
+    assert zero_code_modif(pr) is True
+
+
+def test_zero_code_modif_no_patch_has_deletion():
+    pr = {"files": [{"path": "a.ipynb", "additions": 2, "deletions": 3}]}
+    assert zero_code_modif(pr) is False
+
+
+def test_zero_code_modif_no_nb_files():
+    pr = {"files": [{"path": "README.md", "additions": 50, "deletions": 10}]}
+    assert zero_code_modif(pr) is True
+
+
+def test_zero_code_modif_patch_with_code_cell_added():
+    """A patch that adds a `"cell_type": "code"` line is NOT zero-code-modif."""
+    patch = '+  {\n+    "cell_type": "code",\n+    "source": "print(1)"\n+  }'
+    pr = {"files": [{"path": "a.ipynb"}], "_patch": patch}
+    assert zero_code_modif(pr) is False
+
+
+def test_zero_code_modif_patch_markdown_only():
+    """A patch touching only markdown cells IS zero-code-modif."""
+    patch = '+  {\n+    "cell_type": "markdown",\n+    "source": "# Intro"\n+  }'
+    pr = {"files": [{"path": "a.ipynb"}], "_patch": patch}
+    assert zero_code_modif(pr) is True
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/scripts/variation_genre_recensement.py
+++ b/scripts/variation_genre_recensement.py
@@ -44,6 +44,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import os
 import random
 import re
 import sys
@@ -51,18 +52,23 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-# --- grain parsing (shared vocabulary) ---------------------------------------
+# Ensure the sibling `grain_tag` module (canonical `Grain:` reader, #9485) is
+# importable whether this file is run as a script (scripts/ auto on sys.path)
+# or imported from elsewhere (e.g. from scripts/tests/).
+try:
+    from grain_tag import parse_grain_tag
+except ImportError:  # pragma: no cover - path bootstrap for non-script invocation
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from grain_tag import parse_grain_tag
 
-# Same shapes accepted by scripts/variation_light_cap.py:
-#   Grain: LIGHT/guard -- lane myia-po-2023:CoursIA      (em-dash)
-#   **Grain:** LIGHT/guard - lane myia-ai-01:CoursIA     (bold, hyphen)
-#   `Grain: LIGHT/refs` . **Lane:** myia-po-2024:CoursIA-2  (backticks, middot)
-_GRAIN_RE = re.compile(
-    r"[`*]?\s*Grain\s*:\s*[`*]?\s*"
-    r"(?P<tier>DEEP|MED|LIGHT)\s*/\s*(?P<genre>[\w-]+)"
-    r"\s*[`*]?",
-    re.IGNORECASE,
-)
+# --- grain parsing (shared vocabulary) ---------------------------------------
+# The `Grain:` tag is read by the CANONICAL form-tolerant reader
+# `grain_tag.parse_grain_tag` (single source of truth, #9485), which handles
+# every tolerated form (`**Grain:**`, `## Grain`, `` `Grain` `` no-colon).
+# This module previously carried its own `_GRAIN_RE` that diverged from the
+# canonical reader and silently dropped those forms — undercounting the census
+# universe and biasing the monoculture analysis that motivated
+# variation-protocol.md. `parse_grain` below delegates to the canonical reader.
 
 # Subset of genres that are LIGHT per G-VAR-2 (#10031, #10285):
 # guard / ledger / docs / readme / test / refs.
@@ -101,11 +107,18 @@ class PRRow:
 
 
 def parse_grain(body: str) -> tuple[str | None, str | None]:
-    """Return (tier, genre) from `Grain:` tag in body, or (None, None)."""
-    m = _GRAIN_RE.search(body or "")
-    if not m:
+    """Return (tier, genre) from `Grain:` tag in body, or (None, None).
+
+    Delegates to the canonical form-tolerant reader `grain_tag.parse_grain_tag`
+    (#9485) so the census agrees with the CI guard on EVERY tolerated form
+    (`**Grain:**`, `## Grain`, `` `Grain` `` no-colon). The local `_GRAIN_RE`
+    that used to live here diverged and undercounted those forms, biasing the
+    monoculture census.
+    """
+    tag = parse_grain_tag(body or "")
+    if not tag:
         return None, None
-    return m.group("tier").upper(), m.group("genre").lower()
+    return tag["tier"], tag["genre"]
 
 
 def file_family(paths: list[str]) -> str | None:


### PR DESCRIPTION
Grain: MED/refactor — lane myia-po-2025:CoursIA — prev: MED/content #10707

# refactor(census,#9485): variation_genre_recensement.parse_grain diverged from the canonical Grain reader — delegate to grain_tag

See #9485 (canonical single-reader) · See #10290 (the census that this tool produces)

## What — a divergent `Grain:` parser, exactly the #9485 failure mode

`scripts/variation_genre_recensement.py` (the census that motivated `variation-protocol.md`, delivered #10293) carried its OWN local regex `_GRAIN_RE` to read the `Grain: TIER/GENRE` tag. It DIVERGED from the canonical form-tolerant reader `grain_tag.parse_grain_tag` (#9485) — the single reader the CI guard uses — and silently dropped every form that required tolerance.

#9485 was created precisely to eliminate "TWO divergent implementations" of the Grain reader. The census re-introduced one.

### Evidence — 3 tolerated forms MISSED, measured firsthand

| Form | Example body | `_GRAIN_RE` (before) | canonical reader |
|---|---|---|---|
| canonical | `Grain: LIGHT/guard -- lane ...` | `LIGHT/guard` ✓ | `LIGHT/guard` ✓ |
| **bold** | `**Grain:** LIGHT/guard - lane ...` | **MISSED** ✗ | `LIGHT/guard` ✓ |
| **title-hash** | `## Grain\n\nLIGHT/guard ...` | **MISSED** ✗ | `LIGHT/guard` ✓ |
| **no-colon** | `` `Grain` LIGHT/guard ... `` | **MISSED** ✗ | `LIGHT/guard` ✓ |

The census's own header comment (L57-59) *claimed* "Same shapes accepted ... `**Grain:**` (bold)" — but the regex never matched it. The claim was aspirational, the behavior defective.

### Consequence — the monoculture census was biased

Any PR whose body used a tolerated form (`**Grain:**` is common — it's the form the `## What`/`**Grain:**` templates produce) was INVISIBLE to the census. The universe was undercounted, and the genre distribution that motivated the variation-protocol ratchet was computed on an incomplete sample. The directional finding (monoculture exists) still holds — but the precise counts that fed the ratchet thresholds undercounted the bold-form population.

## The fix — delegate to the canonical reader, delete the local regex

`parse_grain()` now calls `grain_tag.parse_grain_tag()` (the single source of truth, #9485) and maps its `{tier, genre, lane}` dict to the `(tier, genre)` tuple the census expects. The local `_GRAIN_RE` is removed (dead after delegation). A path-safe import bootstrap ensures `grain_tag` resolves whether the census is run as a script or imported from `scripts/tests/`.

| File | Change |
|---|---|
| `scripts/variation_genre_recensement.py` | `parse_grain` delegates to `parse_grain_tag`; `_GRAIN_RE` + its false comment removed; `import os` + path-safe `from grain_tag import parse_grain_tag` added |
| `scripts/tests/test_variation_genre_recensement.py` | **NEW** — 26 tests (TDD): the 3 divergence forms + a `parse_grain_agrees_with_canonical_reader_on_all_forms` contract test that fails on ANY future drift |

## Validation (TDD — test fails before fix, passes after)

- **Before fix**: 5 failures (bold, title-hash, no-colon, canonical-agreement, file-family-expectation). The first 4 are the divergence.
- **After fix**: **26/26 PASS** (including `test_parse_grain_agrees_with_canonical_reader_on_all_forms` — the drift-prevention contract).
- **No-regression**: `test_grain_tag.py` 39/39 (canonical reader untouched); `test_variation_light_cap.py` 73/73 (sibling vocab untouched).
- **Smoke**: module imports cleanly, `parse_grain('**Grain:** MED/refs ...')` → `('MED', 'refs')`, CLI `--help` works.
- `git diff --stat`: 1 modified (+28/−15) + 1 new test file. Catalogue byte-identique to main.

## G.1 — triage firsthand, not a sweep

Found by reading the census source while assessing test coverage of `scripts/*.py`. The header comment's claim ("Same shapes accepted ... bold") vs the regex's actual behavior was the tell — verified by running both parsers on the 4 form fixtures before writing any fix. The divergence is a real defect with a real consequence (biased census), not a cosmetic refactor.

## Scope — two latent issues documented, NOT fixed here (separate PRs)

- **`file_family` shallow-path quirk**: a 3-segment path (`MyIA.AI.Notebooks/ML/ml.cs`) returns `"ML/ml.cs"` (includes the filename) because `parts[1:3]` captures it. Deep paths (4+ segments) are correct. Pinned by test with a `NOTE` comment; out of scope for the parser fix.
- **2 pre-existing `SyntaxWarning: invalid escape sequence \` `** (lines 2, 153 — module + `zero_code_modif` docstrings). Unrelated to this fix; left untouched.

## G-VAR-3 — transparence sur le pivot

Cycle 17 (prev PR #10707) s'est clos sur un engagement écrit : « Prochain cycle je pivote vers un genre non-content (tooling/refactor/test). » Cette PR honore ce pivot : **MED/refactor** (tooling), substance genuinement distincte des 3 MED/content précédents (table-pipe #10700, quant-drift #10707, audio-drift). La divergence d'un parser Grain est un défaut de fond (le census qui a motivé le variation-protocol était biaisé), pas un sweep scan-générable.

See #9485, #10290. See #10293 (census delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
