### PR TITLE
fix(probas,#10097): LaTeX conditional + cardinality pipes break GFM tables (DecPyMC-7/PyMC-14)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-7-Sequential.ipynb
@@ -160,7 +160,7 @@
     "|---------|----------|-------------|\n",
     "| Etats | $S$ | Ensemble fini d'etats |\n",
     "| Actions | $A$ | Actions possibles dans chaque etat |\n",
-    "| Transitions | $P(s'|s,a)$ | Probabilite d'atteindre $s'$ depuis $s$ via $a$ |\n",
+    "| Transitions | $P(s'\\mid s,a)$ | Probabilite d'atteindre $s'$ depuis $s$ via $a$ |\n",
     "| Recompenses | $R(s,a,s')$ | Recompense pour la transition |\n",
     "| Facteur d'escompte | $\\gamma \\in [0,1)$ | Pondere les recompenses futures |"
    ]
@@ -344,7 +344,7 @@
     "      V*   V*   V*    <- valeurs recues (backed up)\n",
     "```\n",
     "\n",
-    "A chaque itération, $V(s)$ est mis a jour en regardant \"un pas en avant\" : on évalue chaque action $a$, on calcule l'esperance sur les succèsseurs pondérés par $P(s'|s,a)$, et on retient le maximum. C'est le principe de **programmation dynamique** applique aux MDPs.\n",
+    "A chaque itération, $V(s)$ est mis a jour en regardant \"un pas en avant\" : on évalue chaque action $a$, on calcule l'esperance sur les succèsseurs pondérés par $P(s'\\mid s,a)$, et on retient le maximum. C'est le principe de **programmation dynamique** applique aux MDPs.\n",
     "\n",
     "> **Lien avec Q-Learning (RL)** : Quand $P$ et $R$ sont inconnus, on apprend $Q(s,a)$ directement par interaction avec l'environnement. Le Q-Learning est la version \"model-free\" de Value Itération."
    ]
@@ -935,10 +935,10 @@
     "|---------|----------------|-----------------|\n",
     "| **Principe** | Iterer sur $V(s)$ directement | Alterner évaluation + amélioration de $\\pi$ |\n",
     "| **Convergence** | Asymptotique ($\\varepsilon$-optimal) | Exacte en few itérations |\n",
-    "| **Cout par itération** | $O(|S|^2 |A|)$ | $O(|S|^3 + |S|^2 |A|)$ |\n",
+    "| **Cout par itération** | $O(\\vert S\\vert^2 \\vert A\\vert)$ | $O(\\vert S\\vert^3 + \\vert S\\vert^2 \\vert A\\vert)$ |\n",
     "| **Nb itérations typique** | $\\sim 10$-$20$ | $\\sim 2$-$5$ |\n",
     "| **Initialisation** | $V = 0$ | $\\pi$ arbitraire |\n",
-    "| **Meilleur quand** | Grand $|S|$, petit $|A|$ | Petit $|S|$, grand $|A|$ |\n",
+    "| **Meilleur quand** | Grand $\\vert S\\vert$, petit $\\vert A\\vert$ | Petit $\\vert S\\vert$, grand $\\vert A\\vert$ |\n",
     "| **Garantie** | $V \\to V^*$ | $\\pi \\to \\pi^*$ |\n",
     "\n",
     "**En pratique** : Policy Itération converge généralement en moins d'itérations, mais chaque itération resout un système lineaire (couteux en $O(|S|^3)$). Value Itération est plus simple a implementer et plus adapte aux grands espaces d'etats."
@@ -1548,8 +1548,8 @@
     "\n",
     "| Méthode | Complexite/iter | Nb itérations | Avantage |\n",
     "|---------|-----------------|---------------|----------|\n",
-    "| **Value Itération** | $O(|S|^2 |A|)$ | ~14 | Simple, garantit convergence |\n",
-    "| **Policy Itération** | $O(|S|^3 + |S|^2|A|)$ | ~3 | Très rapide pour peu d'etats |\n",
+    "| **Value Itération** | $O(\\vert S\\vert^2 \\vert A\\vert)$ | ~14 | Simple, garantit convergence |\n",
+    "| **Policy Itération** | $O(\\vert S\\vert^3 + \\vert S\\vert^2\\vert A\\vert)$ | ~3 | Très rapide pour peu d'etats |\n",
     "| **RTDP** | $O(\\text{traj})$ | Variable | Echantillonne, pas besoin de tout explorer |"
    ]
   },
@@ -4523,7 +4523,7 @@
     "\n",
     "### Serie RL : Extension a l'apprentissage\n",
     "\n",
-    "Quand $P(s'|s,a)$ et $R(s,a)$ sont inconnus, on utilise l'apprentissage par renforcement (Sutton & Barto, 2018) :\n",
+    "Quand $P(s'\\mid s,a)$ et $R(s,a)$ sont inconnus, on utilise l'apprentissage par renforcement (Sutton & Barto, 2018) :\n",
     "- **Q-Learning** : apprend $Q(s,a)$ par interaction\n",
     "- **Deep RL** : approxime Q avec un reseau de neurones\n",
     "- **Policy Gradient** : optimise directement la politique"
@@ -4651,7 +4651,7 @@
     "| Concept | Description |\n",
     "|---------|-------------|\n",
     "| **MDP** | $(S, A, P, R, \\gamma)$ - cadre formel pour decisions séquentielles |\n",
-    "| **Bellman** | $V^*(s) = \\max_a [R(s,a) + \\gamma \\sum P(s'|s,a) V^*(s')]$ |\n",
+    "| **Bellman** | $V^*(s) = \\max_a [R(s,a) + \\gamma \\sum P(s'\\mid s,a) V^*(s')]$ |\n",
     "| **Value Itération** | Itération sur les valeurs jusqu'a convergence |\n",
     "| **Policy Itération** | Alternance évaluation / amélioration de politique |\n",
     "| **RTDP** | Planification en ligne, echantillonne les trajectoires |\n",
@@ -4694,13 +4694,13 @@
     "\n",
     "DecPyMC-7 franchit le seuil qui sépare la **modélisation** de l'incertitude — le fil rouge de toute la série depuis DecPyMC-1 — de l'**action** sous incertitude au cours du temps. Trois idées forces structurent ce notebook.\n",
     "\n",
-    "**1. Le MDP comme cadre formel de la planification.** Un Processus de Décision Markovien $(S, A, P, R, \\gamma)$ ramène la décision séquentielle à une équation fonctionnelle, l'équation de Bellman, résolue exactement par *Value Itération* et *Policy Itération* lorsque l'espace d'états reste tabulaire. La propriété de Markov — $P(s'|s,a)$ ne dépend que de l'état présent — est ce qui rend la décomposition calculable : elle transforme un horizon infini en une récurrence sur les valeurs. *RTDP* étend cette planification aux grands espaces en échantillonnant des trajectoires en ligne, et le *reward shaping* accélère la convergence sans altérer la politique optimale.\n",
+    "**1. Le MDP comme cadre formel de la planification.** Un Processus de Décision Markovien $(S, A, P, R, \\gamma)$ ramène la décision séquentielle à une équation fonctionnelle, l'équation de Bellman, résolue exactement par *Value Itération* et *Policy Itération* lorsque l'espace d'états reste tabulaire. La propriété de Markov — $P(s'\\mid s,a)$ ne dépend que de l'état présent — est ce qui rend la décomposition calculable : elle transforme un horizon infini en une récurrence sur les valeurs. *RTDP* étend cette planification aux grands espaces en échantillonnant des trajectoires en ligne, et le *reward shaping* accélère la convergence sans altérer la politique optimale.\n",
     "\n",
     "**2. Le compromis exploration/exploitation, résolu bayésiennement.** Les bandits multi-bras concentrent la tension fondamentale de toute décision adaptative : exploiter l'option qui semble la meilleure, ou explorer pour en découvrir de meilleures. Les quatre stratégies comparées (greedy, $\\varepsilon$-greedy, UCB1, Thompson Sampling) dessinent une progression du hasard vers l'inférence. Le Thompson Sampling — qui échantillonne une action depuis le posterior du modèle — est le pont direct vers le cœur probabiliste de la série : une décision séquentielle pilotée par un modèle bayésien, implémentable via PyMC par MCMC dès que la conjugaison disparaît.\n",
     "\n",
     "**3. L'observabilité partielle ramène tout à l'inférence.** Dans le cas réaliste du POMDP, l'état véritable est caché : on ne décide plus sur $s$ mais sur une **croyance** $b(s)$, mise à jour à chaque observation. La boucle se referme alors sur le reste de la série : le posterior predictive de la section 10 transforme un problème de maintenance prédictive en un filtre bayésien qui ré-estime l'état de dégradation à chaque mesure, puis décide — continuer, surveiller, ou maintenir. Les mêmes outils de diagnostic (ArviZ, R-hat, ESS) qui servent à contrôler un posterior tout au long de la série servent ici à **piloter une décision**.\n",
     "\n",
-    "**Vers l'apprentissage par renforcement.** Ce notebook suppose $P(s'|s,a)$ et $R(s,a)$ *connus*. Dès qu'ils ne le sont plus, il faut les apprendre par interaction : c'est l'objet de la série RL (Q-Learning, Deep RL, policy gradient — Sutton & Barto, 2018). DecPyMC-7 en fournit les fondations théoriques.\n",
+    "**Vers l'apprentissage par renforcement.** Ce notebook suppose $P(s'\\mid s,a)$ et $R(s,a)$ *connus*. Dès qu'ils ne le sont plus, il faut les apprendre par interaction : c'est l'objet de la série RL (Q-Learning, Deep RL, policy gradient — Sutton & Barto, 2018). DecPyMC-7 en fournit les fondations théoriques.\n",
     "\n",
     "**Arc de la série.** En vingt notebooks, le parcours est allé de l'installation de PyMC (DecPyMC-1) à la décision séquentielle sous observabilité partielle (DecPyMC-7), en passant par l'estimation, les modèles hiérarchiques, la compétence (TrueSkill, IRT), la classification, la sélection de modèle et toute la théorie de la décision (utilité, valeur de l'information, systèmes experts). Le fil rouge demeure : l'incertitude n'est pas un bruit à éliminer, mais une quantité à *représenter*, *inférer*, puis sur laquelle *agir*."
    ]

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Sequences.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Sequences.ipynb
@@ -1589,12 +1589,12 @@
     "\n",
     "| Concept | Formule | Méthode |\n",
     "|---------|---------|--------|\n",
-    "| **Classification independante** | $P(z_t=k|x_t) \\propto P(x_t|z_t=k) \\cdot P(z_t=k)$ | Bayes par timestep |\n",
-    "| **Forward pass** | $\\alpha_t(k) = P(x_t|z_t=k) \\sum_j \\alpha_{t-1}(j) A_{jk}$ | Recursion avant |\n",
-    "| **Backward pass** | $\\beta_t(k) = \\sum_j A_{kj} P(x_{t+1}|z_{t+1}=j) \\beta_{t+1}(j)$ | Recursion arriere |\n",
-    "| **Posterior lisse** | $P(z_t=k|x_{1:T}) \\propto \\alpha_t(k) \\cdot \\beta_t(k)$ | Forward-Backward |\n",
-    "| **Viterbi** | $\\arg\\max P(z_{1:T}|x_{1:T})$ | Programmation dynamique |\n",
-    "| **Motif finding** | $P(kmer|Motif) / P(kmer|Background) > 1$ | Likelihood ratio |"
+    "| **Classification independante** | $P(z_t=k\\mid x_t) \\propto P(x_t\\mid z_t=k) \\cdot P(z_t=k)$ | Bayes par timestep |\n",
+    "| **Forward pass** | $\\alpha_t(k) = P(x_t\\mid z_t=k) \\sum_j \\alpha_{t-1}(j) A_{jk}$ | Recursion avant |\n",
+    "| **Backward pass** | $\\beta_t(k) = \\sum_j A_{kj} P(x_{t+1}\\mid z_{t+1}=j) \\beta_{t+1}(j)$ | Recursion arriere |\n",
+    "| **Posterior lisse** | $P(z_t=k\\mid x_{1:T}) \\propto \\alpha_t(k) \\cdot \\beta_t(k)$ | Forward-Backward |\n",
+    "| **Viterbi** | $\\arg\\max P(z_{1:T}\\mid x_{1:T})$ | Programmation dynamique |\n",
+    "| **Motif finding** | $P(kmer\\mid Motif) / P(kmer\\mid Background) > 1$ | Likelihood ratio |"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
@@ -10,6 +10,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 81c45947b4322974083d5dedaff85a5aa8dc97d8
       csharp_sha: 1780a6871a8dd4eb0d5fbc8a8a137c229bf67ae7
+    - date: "2026-08-13"
+      by: myia-ai-01:CoursIA
+      python_sha: fc662a501dc293442f03ed0736cb5d77680c5358
+      csharp_sha: 1780a6871a8dd4eb0d5fbc8a8a137c229bf67ae7
+      content_python_sha: 540ed1f01cccd6ae7e9373ba529535efbf3296d5a37657c69583870facf3f730
+      content_csharp_sha: fa14bf0b264bfabdcc190ba03c58b8a2e6de6528d621d23eeec83956932e5cb5
   known_differences:
   - 'Socle pedagogique commun : modeles de sequences (chaines de Markov cachees / HMM) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: MED/content -- lane myia-po-2023:CoursIA -- prev: MED/content #10709

## Summary

**12 defects COL_MISMATCH** dans 2 notebooks Probas : deux sous-classes de notation LaTeX cassaient le parsing GFM des tables — (1) probabilité conditionnelle `$P(s'|s,a)$` et (2) cardinalité `$O(|S|^2|A|)$`. Le `|` littéral ajoutait des colonnes fantômes. Même defect-class que #10704 (QC-Py `\mid`) et #10709 (RL `\mid`), étendue à la famille Probas/DecisionTheory.

## Diagnostic (scan column-mismatch + G.1 firsthand)

Scanner backtick+escape-aware sur Probas/** + GameTheory/DecisionTheory/**. Résultat : **12 defects dans Probas (DecPyMC-7 + PyMC-14), 0 dans GameTheory/DecisionTheory**.

| Notebook | Cell | Sub-classe | Ligne défectueuse |
|---|---|---|---|
| DecPyMC-7 | cell[4] | conditionnel `\mid` | `P(s'\|s,a)` dans table MDP |
| DecPyMC-7 | cell[19] | cardinalité `\vert` | `O(\|S\|^2 \|A\|)` complexité |
| DecPyMC-7 | cell[29] | cardinalité `\vert` | `O(\|S\|^2\|A\|)` Value/Policy Iteration |
| DecPyMC-7 | cell[65] | conditionnel `\mid` | `P(s'\|s,a)` dans équation Bellman |
| PyMC-14 | cell[35] | conditionnel `\mid` | 6 lignes HMM (Forward/Backward/Viterbi/Motif) |

## Fix

Deux commandes LaTeX selon la sous-classe :
- **`\mid`** pour probabilité conditionnelle (`P(s'\mid s,a)`) — idiomatique `P(A|B)`, rendu `|` par KaTeX
- **`\vert`** pour cardinalité/abs-value (`\vert S\vert^2`) — idiomatique `|S|`, rendu `|` par KaTeX

Les deux rendent identiquement au pipe original, sans caractère pipe littéral → GFM parse correctement. Markdown-only (C.3 exception, no re-exec). Raw-text surgery, byte-identity préservée.

## Validation

- [x] Column-mismatch scan : **12 → 0** sur les 2 notebooks (DecPyMC-7 + PyMC-14)
- [x] JSON valide (DecPyMC-7 68 cells, PyMC-14 39 cells — structure intacte)
- [x] Diff chirurgical (16 insertions / 16 deletions)
- [x] 0 code cell touchée (markdown-only)
- [x] 0 CRLF (LF only)
- [x] Rendu KaTeX vérifié : `\mid` → `|` (conditional), `\vert` → `|` (cardinality)

## Scope — defect-class triangulation (4 PRs cette session)

La defect-class math-pipe LaTeX est now couverte sur 4 familles :
- **QC-Py** : #10701 (backtick fix QC-Py-20/24), #10704 (`\mid` QC-Py-25)
- **RL** : #10709 (`\mid` rl_6b/6d)
- **Probas** : cette PR (`\mid` + `\vert` DecPyMC-7/PyMC-14)

Résiduel candidat : Search/Sudoku/SymbolicWeb/GameTheory (scan cross-famille à faire).

## Test plan

- [x] Column-mismatch scan 0 sur DecPyMC-7 + PyMC-14
- [x] Rendu KaTeX : complexité MDP et HMM tables s'affichent avec bonnes colonnes

See #10097 (markdown rendering quality). Sibling de #10704 + #10709.

