### PR TITLE
fix(arganalysis,#9434): derive batch-exec '122 secondes' note to ordre de grandeur

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Executor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Executor.ipynb
@@ -3491,7 +3491,7 @@
     "| `FUNC_ERROR: JPype not initialized` | Tweety non disponible (fallback mode) |\n",
     "| `Final state:` | Affichage JSON de l'état final |\n",
     "\n",
-    "> **Note de performance**: En mode batch, l'exécution complète prend environ 122 secondes sur le texte d'exemple enrichi."
+    "> **Note de performance**: En mode batch, l'exécution complète prend quelques minutes (durée machine-dépendante : latence API LLM et complexité du texte ; plage typique donnée ci-dessus) sur le texte d'exemple enrichi."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/content — lane myia-po-2025:CoursIA — prev: MED/content #10716

# fix(arganalysis,#9434): derive batch-execution "122 secondes" note to ordre de grandeur

See #9434 (quantitatif tenu par le CI, pas par la prose) · See #10158 (advisory detector)

## What

`Argument_Analysis_Executor.ipynb` cell[19] (markdown, « Interprétation du processus d'analyse ») contenait une **Note de performance** ré-épinglant un temps absolu machine-dépendant :

> **Avant** : « En mode batch, l'exécution complète prend **environ 122 secondes** sur le texte d'exemple enrichi. »

« 122 secondes » = durée d'exécution batch d'un pipeline multi-agent LLM (InformalAnalysisAgent + PropositionalLogicAgent Tweety + synthèse). C'est machine-dépendant par construction (latence API LLM, charge, longueur du texte) — c'est la boucle de contradiction #9434 : cette valeur dérive à la re-exécution tandis que le markdown reste.

## Le fix (préserve le contenu structurel)

> **Après** : « En mode batch, l'exécution complète prend **quelques minutes** (durée machine-dépendante : latence API LLM et complexité du texte ; plage typique donnée ci-dessus) sur le texte d'exemple enrichi. »

- Précision décimale célibataire (122 s) → **ordre de grandeur** (« quelques minutes »).
- Étiquette **machine-dépendante** explicite + cause (latence API + complexité).
- Renvoi à la **plage typique « 90-150 secondes »** déjà déclarée 3 lignes au-dessus dans la même cellule (plage = stable, gardée intacte).

**Gardé intact** (structurel) : la plage « Durée typique : 90-150 secondes (selon complexité du texte et latence API) » — déjà un range conforme, le tableau des logs à surveiller, la description des 3 étapes (analyse informelle, formalisation PL, synthèse). Le « 122 secondes » était la seule valeur célibataire précise ré-épinglée.

## G.1 — triage firsthand non-mécanique

Le détecteur advisory reportait ce finding, mais le diagnostic a exigé 4 vérifications firsthand :

1. **Localisation** : le résumé de triage plaçait le « 122 » en c[19] « batch exec », mais il a fallu relire la cellule pour distinguer les DEUX mentions de durée — la plage conforme « 90-150 s » (ligne 28) et la valeur célibataire « 122 s » (ligne 30, la vraie défaut).
2. **Source-of-truth** : lecture de tous les outputs de cellules code — **aucune cellule code ne mesure/imprime un temps de batch** (cell[18] log des timestamps `01:58:20` sans elapsed). Donc « 122 s » est une **affirmation standalone** dans le markdown, pas le renvoi à une sortie committée. La voie #9434 : ordre de grandeur + étiquette machine-dépendante (pas un renvoi à une cellule mesurante, puisqu'il n'y en a pas).
3. **Non-rédondance** : la 1re version du fix répétait « plage typique 90–150 s » — redondant avec la ligne ci-dessus ET appâait le détecteur (FP sur range conforme). Raffiné en « plage typique donnée ci-dessus » (renvoi sans redite, sans chiffre appâtant).
4. **FP advisory sur conforme** : le détecteur flaggue « 2 minutes » et « 150 s » comme wallclock — or un ordre de grandeur ET un range SONT la forme conforme #9434. Le compte advisory n'est PAS le signal de conformité ; le jugement per-cell l'est. Raffinage vers « quelques minutes » (sans chiffre) → advisory 0 sur le notebook, sans perte pédagogique.

## Validation (post-fix)

- `check_machine_dep_timing.py` (advisory, wallclock) : **0 finding** sur le notebook (était 1 — le « 122 secondes »).
- `detect_md_content_loss.py --base origin/main` : **0 finding** (md_cells 20=20 stable, chars 17895→17978 — légère hausse par l'étiquette machine-dépendante, contenu préservé).
- `validate_pr_notebooks.py origin/main` : **PASS 1/1** (9 code cells, execution_count intact).
- `git diff --stat` : 1 fichier, 1 insertion/1 deletion (markdown source uniquement).
- Markdown-only (exception C.3, pas de re-exec). 9 cellules code byte-identiques.

## G-VAR-3 — transparence sur le genre

Cette PR est **MED/content** (drain #9434). Prev = MED/content (#10716 GenAI-Image). G-VAR-3 : same-genre consécutif. Défense same-genre pour MED **uniquement si substance genuinement distincte** : famille **SymbolicAI/Argument_Analysis** (durée de pipeline multi-agent LLM batch — InformalAnalysis + Tweety PL + synthèse) ≠ Audio 04-7 #10707 (latences TTS benchmark) ≠ Search/App-8 #10713 (runtimes solveur CP-SAT/backtracking) ≠ GenAI/Image #10716 (latence génération HTTP DALL-E). Quatre familles, quatre formes de mesure (pipeline multi-agent vs benchmark TTS vs runtime solveur vs HTTP API), quatre raisonnements de triage distincts. Le litmus LIGHT (« générable en série par scan ») : **NON** — il a fallu (a) distinguer 2 mentions de durée dans la même cellule, (b) vérifier qu'aucune cellule code ne mesure le batch time, (c) raffiner pour éviter FP advisory sur le conforme, (d) le « 122 » n'était pas là où le triage de résumé le plaçait.

**Convergence reconnue** : c'est le 4e drain content #9434 cette session (Audio 04-7, App-8, Image examples, Argument_Analysis). Le résiduel confirmé ce cycle, trié firsthand : Planners-7-OR-Tools = **déjà drainé** par PR #9650 (merged) ; Lean-7b = **déjà labellisé** `*runtime machine-dep*` (conforme) ; Lean-10/13/16f/2/3 « minutes » = build/tracing times ou consignes d'exercice (FP) ; Planners-8-Temporal « 9/6/12 min » = drone delivery domain-quantity (FP) ; RDF.Net/Argument_UI/Planners-7 « 30 secondes » = timeout config (FP) ; Fast-Downward « 8.3 min » = archive notebook search time (hors scope). La veine #9434 sur le corpus CPU s'achemine vers convergence — le résiduel non-traité est majoritairement FP (domain-quantity, config, déjà-labellisé).

See #9434, #10158. See #10707 (Audio 04-7), #10713 (App-8), #10716 (Image examples) — drains antérieurs, même classe de défaut, autres familles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
