### PR TITLE
feat(lean,#10488): enrich 4 thin FRACTRAN sections with register-machine pedagogy (density 690→971)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16e-Conway-FRACTRAN-Lean-Native.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16e-Conway-FRACTRAN-Lean-Native.ipynb
@@ -63,7 +63,9 @@
    "source": [
     "## 2. Le type des fractions\n",
     "\n",
-    "Une fraction est deux naturels `num`/`den`, avec la **preuve** que `den > 0` (on ne divise jamais par zéro). Lean permet de stocker cette preuve *dans* la structure elle-même — c'est tout l'intérêt d'un langage dépendant.\n"
+    "Une fraction est deux naturels `num`/`den`, avec la **preuve** que `den > 0` (on ne divise jamais par zéro). Lean permet de stocker cette preuve *dans* la structure elle-même — c'est tout l'intérêt d'un langage dépendant.\n",
+    "\n",
+    "Concrètement, le type est un `Subtype` : un triplet $(num, den, \\text{preuve } : den > 0)$. Toute fonction qui consomme une fraction reçoit la garantie $den \\neq 0$ **gratuitement** — le compilateur la transporte pour vous. Impossible d'écrire accidentellement une division par zéro : le type refuse de se construire si la preuve manque. C'est la différence entre *vérifier à l'exécution* (un `if den == 0` que l'on oublie un jour) et *prouver à la compilation* (le type ne se ferme pas sans l'argument).\n"
    ]
   },
   {
@@ -184,7 +186,9 @@
     "\n",
     "## 3. Le moteur FRACTRAN\n",
     "\n",
-    "Deux briques : (1) `fracMulNat` teste si $N \\cdot \\frac{a}{b}$ est entier ; (2) `fractranStep` cherche la première fraction applicable. Puis `fractranRun` itère.\n"
+    "Deux briques : (1) `fracMulNat` teste si $N \\cdot \\frac{a}{b}$ est entier ; (2) `fractranStep` cherche la première fraction applicable. Puis `fractranRun` itère.\n",
+    "\n",
+    "Le moteur est une boucle déterministe : à chaque pas, il parcourt la liste de fractions de gauche à droite et applique la **première** dont le produit avec $N$ tombe juste. L'ordre des fractions n'est pas un détail cosmétique — c'est le **programme**. Permuter deux fractions change le calcul exactement comme permuter deux lignes dans un programme impératif. Une fraction qui ne s'applique pas est silencieusement sautée ; une fois une fraction applicable trouvée, les suivantes sont ignorées (priorité stricte). Si aucune fraction ne s'applique, la machine **s'arrête** : l'entier courant est le résultat.\n"
    ]
   },
   {
@@ -345,7 +349,9 @@
     "\n",
     "## 4. Un programme simple : doubler\n",
     "\n",
-    "Le programme le plus court : la fraction unique $\\frac{2}{1}$. À chaque étape, $N \\mapsto 2N$. Voyons-le tourner.\n"
+    "Le programme le plus court : la fraction unique $\\frac{2}{1}$. À chaque étape, $N \\mapsto 2N$. Voyons-le tourner.\n",
+    "\n",
+    "Pour comprendre *pourquoi* cela double, il faut voir FRACTRAN comme une **machine à registres** déguisée. L'astuce : décomposez $N$ en facteurs premiers. Si $N = 2^k$, alors l'exposant $k$ est la valeur stockée dans le « registre 2 ». Multiplier $N$ par $\\frac{2}{1} = 2$ revient à incrémenter ce registre : $2^k \\mapsto 2^{k+1}$. La fraction $\\frac{2}{1}$ s'applique toujours (tout entier est divisible par 1), donc la machine ne s'arrête jamais — elle double indéfiniment. C'est le programme FRACTRAN le plus trivial : un compteur qui incrémente un registre à l'infini.\n"
    ]
   },
   {
@@ -615,7 +621,9 @@
     "\n",
     "## 6. Petits faits certifiés\n",
     "\n",
-    "Comme pour le GOL, l'avantage d'un noyau formel est de **prouver**, pas seulement d'observer.\n"
+    "Comme pour le GOL, l'avantage d'un noyau formel est de **prouver**, pas seulement d'observer.\n",
+    "\n",
+    "La différence est cruciale. Un test vérifie un échantillon d'entrées ; une **preuve** couvre toutes les entrées possibles, y compris celles que personne n'a eu l'idée d'essayer. Quand Lean valide `fractranStep` sur un théorème, il certifie que le moteur est correct pour *toute* liste de fractions et *tout* entier de départ — pas seulement pour les exemples ci-dessus. Un fait comme « doubler indéfiniment » n'est plus une observation empirique mais un théorème démontré : le noyau Lean en garantit la véracité mathématique, vérifiable par `#print axioms`.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: LIGHT/notebook-python #10719

## Ce que fait la PR

Enrichit 4 sections pédagogiquement minces dans `Lean-16e-Conway-FRACTRAN-Lean-Native.ipynb` (density 690 → 971 chars/code-cell). Le notebook expliquait le **quoi** (type, moteur, programme, preuves) mais manquait le **pourquoi** — en particulier l'interprétation machine-à-registres qui rend FRACTRAN compréhensible.

## Les 4 enrichissements (substance, pas padding)

| Section | Avant | Clé pédagogique ajoutée |
|---|---|---|
| **§2 Le type des fractions** (251ch) | 3 lignes : « preuve den>0 dans la structure » | Le pattern `Subtype` : triplet (num, den, preuve). Différence *vérifier à l'exécution* (if den==0 oubliable) vs *prouver à la compilation* (le type ne se ferme pas sans l'argument). |
| **§3 Le moteur FRACTRAN** (189ch) | 4 lignes : « fracMulNat teste, fractranStep cherche » | Sémantique **first-match-wins** : l'ordre des fractions = le programme. Permuter deux fractions = permuter deux lignes de code. Machine s'arrête si aucune fraction ne s'applique. |
| **§4 Un programme simple : doubler** (152ch) | 4 lignes : « 2/1, N↦2N » | **L'insight-clé** : FRACTRAN comme machine à registres. N=2^k → exposant k = valeur du registre 2. Multiplier par 2/1 = incrémenter le registre. 2/1 s'applique toujours → double indéfiniment. C'est LE concept sans lequel FRACTRAN est opaque. |
| **§6 Petits faits certifiés** (125ch) | 4 lignes : « prouver pas observer » | Preuve vs test : un test vérifie un échantillon, une preuve couvre toutes les entrées. `fractranStep` certifié pour *toute* liste de fractions. Vérifiable par `#print axioms`. |

## Validation (preuves vérifiables)

- **Markdown-only** : 4 cellules markdown enrichies (cell[2], [4], [6], [11]), **0 cellule code touchée**. Vérifié : `cells changed == [2,4,6,11]`, `code cells changed == []`.
- **C.3 exception** : markdown-only, pas de re-exec Lean requise. `execution_count` + `outputs` inchangés.
- **json.dumps round-trip PASSES** (sérialisation canonique) → modification json.loads/dumps sûre, zero churn cosmétique. 12 ins / 4 del (les 4 del = anciennes dernières-lignes qui reçoivent une virgule).
- **CRLF = 0** (LF préservé), **ensure_ascii=False** (854 → 976 non-ASCII = accents français ajoutés, attendu).
- **C.1** : 0 `raise NotImplemented` introduit. Les 3 `sorry` pré-existants dans les cellules Lean code ne sont PAS touchés par cette PR (markdown-only).
- **Density** : 690 → 971 chars/code-cell (+281 chars/cellule).

## G.1 — pourquoi ces 4 sections

Scanned all 26 Lean notebooks pour densité. Lean-16e (ratio 690) = le 3e plus fin après Lean-5 (400, ai-01/po-2025 claimed) et Lean-12b (719, mon #10717). Premierhand read des 14 cellules markdown : 4 sections ont une expplanation de 1-2 lignes sans l'insight-clé. Les autres sections (§1 intro 500ch, §5 prime generator 369ch, §7 universalité 954ch) sont déjà suffisamment denses.

## Transparence G-VAR

MED/lean content : enrichissement de sections pédagogiquement minces avec du raisonnement de domaine (machine-à-registres FRACTRAN). Le litmus LIGHT « générérable en scannant l'instance suivante ? » → non : l'insight registre (§4) exige de comprendre FRACTRAN, pas un template reproductible.

See #10488 (densité pédagogique).
