### PR TITLE
enrich(lean,#10488): Lean-16d Conway-GoL-Native density 744→872 (candidate-set + axiom-transparency WHY)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb
@@ -443,7 +443,9 @@
     "\n",
     "## 4. Le moteur d'évolution\n",
     "\n",
-    "Une étape (`step`) : on rassemble les cellules candidates (vivantes + leurs voisins), on garde celles qui satisfont `aliveNext`, et on déduplique. Puis `evolve` itère `step`.\n"
+    "Une étape (`step`) : on rassemble les cellules candidates (vivantes + leurs voisins), on garde celles qui satisfont `aliveNext`, et on déduplique. Puis `evolve` itère `step`.\n",
+    "\n",
+    "**Pourquoi les cellules mortes sont-elles candidates ?** C'est l'insight algorithmique central du moteur. Une cellule vivante ne peut que *survivre* ou *mourir* : itérer la seule liste des vivantes suffirait à appliquer la règle **S23**. Mais la règle **B3** fait **naître** une cellule morte lorsqu'elle compte exactement 3 voisins vivants. Or ces nouveaux-nés n'apparaissent dans aucune liste de cellules vivantes — il faut donc énumérer les *voisins* des cellules vivantes (mortes incluses) pour ne rater aucune naissance. Le moteur parcourt ainsi l'union « vivantes ∪ voisins », évalue `aliveNext` sur chacune, puis **déduplique** : une même cellule morte peut être voisine de plusieurs cellules vivantes et serait comptée deux fois sans cette étape.\n"
    ]
   },
   {
@@ -1153,7 +1155,9 @@
     "\n",
     "## 9. La frontière du prouvé : transparence\n",
     "\n",
-    "Les théorèmes ci-dessus ne dépendent **d'aucun axiome caché** — en particulier pas de `sorry`. Vérifions-le :\n"
+    "Les théorèmes ci-dessus ne dépendent **d'aucun axiome caché** — en particulier pas de `sorry`. Vérifions-le :\n",
+    "\n",
+    "**Pourquoi cela compte-t-il ?** En Lean, une tactique comme `decide` ou `native_decide` ferme un but en *évaluant* un terme, mais la confiance que l'on accorde au résultat repose sur ce que le noyau accepte. La commande `#print axioms` est l'**ancre de confiance** : elle liste tous les axiomes dont un théorème dépend transitivement. Si elle renvoie une liste vide, le théorème est **auto-contenu** — prouvé à partir des seules règles du calcul des constructions. Une preuve qui admettrait un axiome ad hoc (ou un `sorry` masqué) apparaîtrait ici. C'est précisément ce qui distingue une **formalisation** (le noyau certifie, tous les cas couverts) d'un **test** (on a vérifié un échantillon d'entrées) : le test peut rater un contre-exemple, la formalization ne le peut pas.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2025:CoursIA — prev: MED/content #10721

# enrich(lean,#10488): Lean-16d Conway-GoL-Native density 744→872 — WHY for candidate-set + axiom-transparency

See #10488 (density ratchet) · See #10479 (Lean intro density, separate scope)

## What

`Lean-16d-Conway-Game-of-Life-Lean-Native.ipynb` (standalone, density 744 chars/code-cell — among the thinnest Lean notebooks) had 2 markdown sections that stated **WHAT** the code does without the **WHY** — at the two conceptually hardest moments of the notebook. Enriched both with genuine domain reasoning (not padding).

| Cell | Section | Gap (WHAT-only) | Enrichment (the WHY added) |
|---|---|---|---|
| c[7] | §4 Le moteur d'évolution | "on rassemble les cellules candidates (vivantes + leurs voisins)… et on déduplique" | **Pourquoi les cellules mortes sont-elles candidates ?** — l'insight algorithmique central : une vivante ne fait que survivre/mourir (S23 suffit à l'itérer), mais B3 fait **naître** une morte à 3 voisins ; ces nouveaux-nés ne sont dans aucune liste de vivantes → il faut énumérer les voisins (mortes incluses). La déduplication s'ensuit : une morte voisine de plusieurs vivantes serait comptée N fois. |
| c[21] | §9 La frontière du prouvé | "ne dépendent d'aucun axiome caché… Vérifions-le" (avant `#print axioms`) | **Pourquoi cela compte-t-il ?** — `#print axioms` est l'**ancre de confiance** : il liste les axiomes dont un théorème dépend transitivement ; liste vide = auto-contenu (calcul des constructions seul). Distinction **formalisation** (noyau certifie, tous les cas) vs **test** (échantillon, peut rater un contre-exemple). |

## Substance, pas padding (litmus G-VAR-3)

Le litmus LIGHT (« pourrais-je générer une douzaine en scannant le notebook suivant ? ») : **NON**. Chaque enrichissement exige du raisonnement de domaine Lean/GoL :
- c[7] : relier la règle **B3** (naissances) à la nécessité d'énumérer les voisins morts — c'est le pont entre la spec GoL et l'implémentation `step`. Un scan superficiel verrait « on rassemble les candidats » comme suffisant.
- c[21] : relier `decide`/`native_decide` (qui *évaluent*) à la base de confiance du noyau, et articuler formalization-vs-test — le même concept que FRACTRAN §6 (#10722) mais sur un axiome-goal différent (`#print axioms` vs preuve-exemples).

Deux concepts distincts (algorithme candidat-set vs transparence axiomatique), pas une recette dupliquée.

## Validation

- `git diff --stat` : 1 fichier, 6 insertions / 2 deletions (markdown source uniquement).
- **0 ligne de source code ajoutée** (`git diff | grep -c '^\+\s*"source"' = 0`) → markdown-only, exception C.3 (pas de re-exec).
- 12 cellules code **byte-identiques** (execution_count, outputs, source intacts).
- `validate_pr_notebooks.py origin/main` : **PASS** (12 cells, kernel lean4-wsl).
- `detect_md_content_loss.py --base origin/main` : **0 finding** (md_cells 20=20 stable, chars 7532→8827 — hausse, contenu préservé).
- `check_machine_dep_timing.py` : 0 finding wallclock.
- Canonical `json.dumps(ensure_ascii=False, indent=1)` round-trip **byte-identical** vérifié avant édition (méthode éprouvée, même famille que #10722).

## Scope honnête

Densité 744 → **872** (+128 c/cell). C'est une amélioration partielle, **pas** la fermeture du ratchet 1200 pour ce notebook — Lean-16d reste sous le seuil. D'autres sections minces (c[10] 191c, c[13] 168c, c[16] 200c, c[19] 257c — transitions entre motifs GoL) restent éligibles à un enrichissement ultérieur. Ce PR adresse les **2 concepts les plus denses** (insight candidat-set + transparence axiomatique) où le WHY manquait le plus, pas un ratissage. Voir #10488.

Lean-16d = **standalone** (pas twin, pas d'_en sibling) → markdown-only sans DRIFT twin-parity (pas de rebaseline YAML requis). See #10488, #10479.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
