### PR TITLE
feat(lean,#10488): enrich Lean-17b knot-theory sections (Mostow-Prasad rigidity, unknotting number)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17-Knots-b-Invariants-Companion.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17-Knots-b-Invariants-Companion.ipynb
@@ -272,6 +272,10 @@
     "variété $S^3 \\setminus K$ munie de sa géométrie hyperbolique canonique\n",
     "(théorème de hyperbolisation de Thurston).\n",
     "\n",
+    "Pourquoi est-ce un invariant *topologique* et non une quantité géométrique arbitraire ? Le théorème de **rigidité de Mostow-Prasad** : deux variétés hyperboliques de volume fini et de même volume sont isométriques. Conséquence — le volume ne dépend pas du diagramme choisi pour $K$ : deux nœuds hyperboliques de volumes différents sont **nécessairement distincts**, et ce verdict est absolu (pas une coïncidence numérique). C'est cette propriété qui rend le volume hyperbolique si discriminant : là où le polynôme d'Alexander peut coincider pour deux nœuds différents, deux volumes hyperboliques distincts prouvent la distinction.\n",
+    "\n",
+    "Propriété additionnelle : le volume est **additif** sous la somme connexe, $\\text{vol}(K_1 \\# K_2) = \\text{vol}(K_1) + \\text{vol}(K_2)$, ce qui en fait aussi un invariant additif des nœuds composés.\n",
+    "\n",
     "SnapPy peut calculer ce volume directement à partir du PD-code.\n"
    ]
   },
@@ -380,7 +384,9 @@
     "## 3. K11n102 (Lidman) — Tabulation Complète\n",
     "\n",
     "Le papier de Lidman (2014) démontre que $u(11n102) = 2$. Voici tous les\n",
-    "invariants connus, vérifiés contre [Knot Atlas](https://katlas.org/wiki/K11n102).\n"
+    "invariants connus, vérifiés contre [Knot Atlas](https://katlas.org/wiki/K11n102).\n",
+    "\n",
+    "Rappel : le **nombre de dénouement** $u(K)$ est le nombre minimal de changements de croisements nécessaires pour transformer $K$ en nœud trivial. Déterminer $u(K)$ exactement est un problème notoirement difficile — la borne inférieure est facile (via la signature, le polynôme, etc.) mais prouver qu'elle est *atteignable* exige souvent une analyse fine. Pour $11n102$, Lidman a combiné la borne inférieure (qui donne $u \\geq 2$) avec la construction explicite d'une séquence de deux changements menant au nœud trivial, fermant ainsi l'écart et établissant $u = 2$.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/lean #10722

## Ce que fait la PR

Enrichit 2 sections pédagogiquement minces dans `Lean-17-Knots-b-Invariants-Companion.ipynb` (notebook compagnon python3/SnapPy, ratio 844 → 922). Les sections mentionnaient les résultats sans expliquer les concepts-clés de théorie des nœuds qui les rendent compréhensibles.

## Les 2 enrichissements (substance, pas padding)

| Section | Avant | Concept ajouté |
|---|---|---|
| **§2 Volume Hyperbolique** (292ch) | « volume de $S^3\setminus K$, Thurston » | **Rigidité de Mostow-Prasad** : deux variétés hyperboliques de volume fini et même volume sont isométriques → le volume est un invariant *topologique* (indépendant du diagramme), discriminant là où le polynôme d'Alexander coincide. + additivité sous somme connexe. |
| **§3 K11n102 (Lidman)** (200ch) | « u(11n102)=2 » | **Nombre de dénouement** $u(K)$ : nombre minimal de changements de croisements vers le nœud trivial. Pourquoi $u$ exact est dur (borne inférieure facile via signature, prouver l'atteignabilité exige une construction explicite — Lidman a fermé l'écart $u\geq 2$ + séquence 2 changements). |

## Validation (preuves vérifiables)

- **Markdown-only** : 2 cellules markdown enrichies (cell[4], cell[6]), **0 cellule code touchée**. Vérifié : `cells changed == [4,6]`, `code cells changed == []`.
- **C.3 exception** : markdown-only, pas de re-exec SnapPy requise. `execution_count` + `outputs` inchangés.
- **json.dumps round-trip PASSES** (canonical serialization) → zero churn cosmétique. 7 ins / 1 del.
- **CRLF = 0** (LF préservé), **ensure_ascii=False** (510 → 1190 non-ASCII = accents français, attendu).
- **C.1** : 0 violation. Density 844 → 922 chars/code-cell.

## G.1 — pourquoi ce notebook + genre

Scanned les 26 notebooks Lean pour densité. Lean-17b (844) = compagnion python3 (kernel python3, calcule les invariants via SnapPy). **Genre = notebook-python** (le côté computation/compagnion), distinct de mon #10722 MED/lean (Lean-16e). Premierhand read des 23 cellules markdown : les §2 et §3 sont des intros de concept sans l'insight (rigidité de Mostow / définition de u). Les autres sections (§4 dichotomie 652ch, §5 Alexander 838ch, §6 visualisations + interprétations 886-1589ch) sont déjà denses.

## Transparence G-VAR

MED/notebook-python content : enrichissement avec raisonnement de domaine (théorie des nœuds : rigidité de Mostow-Prasad, nombre de dénouement). Le litmus LIGHT « générérable en scannant l'instance suivante ? » → non : la rigidité de Mostow exige de comprendre la géométrie hyperbolique 3D, pas un template reproductible.

See #10488 (densité pédagogique).
