### PR TITLE
enrich(qc-py,#10488): QC-Py-30-LSTM-Training density 450→566 (multi-scale features + temporal split + attention WHY)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
@@ -765,7 +765,9 @@
     "tags": []
    },
    "source": [
-    "## 3. Feature engineering et preprocessing"
+    "## 3. Feature engineering et preprocessing\n",
+    "\n",
+    "**Pourquoi construire des features explicites plutôt que de laisser le LSTM tout déduire ?** Un LSTM brut ne reçoit que les prix bruts : il doit alors, à lui seul, redécouvrir des notions comme le momentum, la volatilité ou le mean-reversion à chaque entraînement. En lui fournissant des **features multi-échelles** (rendements calculés sur 1, 5, 20 jours), on injecte directement les horizons pertinents — court terme (réaction à un choc), moyen terme (tendance hebdomadaire), long terme (régime de marché). Le modèle converge plus vite et généralise mieux, car il combine ses propres representations séquentielles avec des signaux financiers interprétables plutôt que de tout réinventer depuis les prix.\n"
    ]
   },
   {
@@ -920,7 +922,9 @@
     "tags": []
    },
    "source": [
-    "## 4. Split temporel strict et normalisation"
+    "## 4. Split temporel strict et normalisation\n",
+    "\n",
+    "**Pourquoi un split temporel (train = passé, test = futur) et non un split aléatoire ?** C'est le piège classique du machine learning financier. Un `train_test_split` aléatoire mélange des points du futur parmi les données d'entraînement : le modèle peut alors « tricher » en regardant l'avenir pour prédire le passé, et afficher une accuracy artificiellement haute qui s'effondrera en production. Le **split temporel strict** reproduit la réalité du trading — à chaque instant, on ne connaît que le passé — et garantit que la performance mesurée sur le set de test est une estimation honnête de la performance future. La normalisation (moyenne/écart-type) est **ajustée sur le train seul** pour la même raison : utiliser les statistiques du test serait une fuite d'information.\n"
    ]
   },
   {
@@ -1068,7 +1072,9 @@
     "tags": []
    },
    "source": [
-    "## 5. Modèle LSTM avec attention"
+    "## 5. Modèle LSTM avec attention\n",
+    "\n",
+    "**Pourquoi ajouter un mécanisme d'attention au-dessus du LSTM ?** Un LSTM encode toute la séquence de 60 jours, mais traite chaque position de manière relativement homogène : il « oublie » parfois quelles journées ont vraiment compté pour la prévision. La couche d'**attention** apprend, pour chaque prédiction, une **pondération** qui met en évidence les positions les plus informatives (un jour d'annonce macro, un creux de volatilité) et étouffe le bruit. C'est un double gain : en **performance** (le modèle se concentre sur le signal) et en **interprétabilité** — on peut visualiser les poids d'attention pour comprendre *quelles journées* ont conduit à une prévision donnée, ce qu'un LSTM pur ne permet pas.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/lean #10724

# enrich(qc-py,#10488): QC-Py-30-LSTM-Training density 450→566 — WHY for multi-scale features, temporal split, attention

See #10488 (density ratchet)

## What

`QC-Py-30-LSTM-Training.ipynb` (standalone torch-CPU notebook — **not a QuantBook**, uses `torch`+`yfinance`+`sklearn`; 19 code cells, all with committed outputs) had density 450 chars/code-cell — among the thinnest QC pedagogical notebooks. Its section headers were **WHAT-only titles** with no motivation, at 3 conceptually pivotal moments. Enriched each with the **WHY** (genuine ML/finance reasoning, not padding).

| Cell | Section (before) | WHY added |
|---|---|---|
| c[7] | §3 Feature engineering (title only) | **Pourquoi des features multi-échelles explicites ?** Un LSTM brut ne reçoit que les prix et doit redécouvrir momentum/volatilité/mean-reversion à chaque entraînement. Les features 1/5/20 jours injectent les horizons pertinent (court/moyen/long terme) → convergence plus rapide, meilleure généralisation, signaux financiers interprétables. |
| c[12] | §4 Split temporel strict (title only) | **Pourquoi pas un split aléatoire ?** Le piège classique : un `train_test_split` aléatoire mélange le futur dans le train → le modèle « triche » en regardant l'avenir, accuracy artificiellement haute qui s'effondre en production. Le split temporel (train=passé, test=futur) reproduit la réalité du trading ; la normalisation ajustée sur le **train seul** évite la fuite d'information. |
| c[15] | §5 Modèle LSTM avec attention (title only) | **Pourquoi ajouter l'attention au LSTM ?** Le LSTM encode la séquence mais traite les positions de manière homogène. L'attention apprend une pondération qui met en évidence les positions informatives et étouffe le bruit → double gain : **performance** (focus sur le signal) + **interprétabilité** (visualiser quelles journées pèsent sur la prévision). |

## Substance, pas padding (litmus G-VAR-3)

Le litmus LIGHT (« pourrais-je générer une douzaine en scannant le notebook suivant ? ») : **NON**. Chaque enrichissement articule un concept ML/finance distinct :
- c[7] : **conception de features** (quoi injecter au modèle pour qu'il ne réinvente pas la finance).
- c[12] : **intégrité de l'évaluation** (le data-leakage temporel, erreur n°1 en ML financier).
- c[13] : **architecture** (pourquoi attention = focus + interprétabilité).

Trois concepts différents (design d'input / méthodologie d'évaluation / choix d'architecture), pas une recette dupliquée.

## Non-QuantBook, non-twin — markdown-only safe

- **Pas un QuantBook** : aucune cellule n'appelle `QuantBook()`. C'est du `torch`+`yfinance`+`sklearn` standard, exécutable sur CPU (torch CPU-only). La règle C.2 « quantbooks = exécution QC Cloud » **ne s'applique pas**.
- **Pas un twin** (absent de `scripts/notebook_tools/twin_pairs.d/`) → l'édition markdown-only ne déclenche **pas** de DRIFT twin-parity (pas de rebaseline YAML requis). Mémoire `twin-parity-markdown-only-edit-still-triggers-drift` vérifiée.
- **§G (backtest QC) ne s'applique pas** : aucune modification de code stratégie, uniquement du markdown pédagogique. Les 19 cellules code sont byte-identiques.

## Validation

- `git diff --stat` : 1 fichier, 9 insertions / 3 deletions (markdown source uniquement).
- **0 ligne de source code modifiée** (`git diff | grep -c '^\+\s*"source".*code'` = 0) → markdown-only, exception C.3 (pas de re-exec). Les 19 cellules code sont **byte-identiques** (source, execution_count, outputs intacts).
- `validate_pr_notebooks.py origin/main` : **PASS** (19 cells).
- `detect_md_content_loss.py --base origin/main` : **0 finding** (md_cells 31=31 stable, chars 7259→9117 — hausse, contenu préservé).
- Canonical `json.dumps(ensure_ascii=False, indent=1)` round-trip **byte-identical** vérifié avant édition.

## Scope honnête

Densité 450 → **566** (+116 c/cell). Amélioration partielle — QC-Py-30 reste sous le seuil ratchet 1200. D'autres headers WHAT-only restent éligibles (c[1], c[18], c[24], c[27], c[30], c[33], c[36], c[40]) pour un enrichissement ultérieur. Ce PR adresse les **3 concepts les plus structurants** (feature design, evaluation integrity, architecture) où le WHY manquait le plus, pas un ratissage.

See #10488.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
