### PR TITLE
feat(probas,#10488): enrich DecPyMC-2 diminishing-marginal-utility section (Jensen → risk aversion)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-2-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-2-Utility-Money.ipynb
@@ -395,7 +395,9 @@
    "source": [
     "## 2. Utilite Marginale Decroissante\n",
     "\n",
-    "L'utilite marginale decroissante signifie que chaque euro supplementaire apporte moins d'utilite que le précédent. Graphiquement, U(x) est **concave**."
+    "L'utilite marginale decroissante signifie que chaque euro supplementaire apporte moins d'utilite que le précédent. Graphiquement, U(x) est **concave**.",
+    "\n",
+    "Pourquoi cette concavité produit-elle de l’aversion au risque ? Par l’**inégalité de Jensen** : pour $U$ concave, $\\mathbb{E}[U(X)] \\leq U(\\mathbb{E}[X])$. Un agent face à un jeu équitable $X$ préfère donc le montant certain $\\mathbb{E}[X]$ au jeu lui-même — il exige une **prime de risque** pour accepter l’incertitude. Plus $U$ est courbée (forte aversion), plus la prime grimpe. C’est ce mécanisme qui rend toute la théorie de l’utilité espérée opérationnelle : la forme de $U$ code directement le comportement face au risque."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10726

## Ce que fait la PR

Enrichit la section §2 « Utilite Marginale Decroissante » (189ch) dans `DecPyMC-2-Utility-Money.ipynb` (Probas/DecisionTheory, kernel python3). La section énonçait que $U(x)$ est concave sans jamais expliquer **pourquoi** la concavité produit l'aversion au risque — le concept fondateur qui relie la forme de l'utilité au comportement face au risque.

## Concept ajouté (substance, pas padding)

**L'inégalité de Jensen** : pour $U$ concave, $\mathbb{E}[U(X)] \leq U(\mathbb{E}[X])$. Un agent face à un jeu équitable $X$ préfère donc le montant certain $\mathbb{E}[X]$ au jeu lui-même — il exige une **prime de risque** pour accepter l'incertitude. Plus $U$ est courbée (forte aversion), plus la prime grimpe. C'est ce mécanisme qui rend toute la théorie de l'utilité espérée opérationnelle : la forme de $U$ code directement le comportement face au risque.

C'est le chaînon manquant : sans Jensen, la concavité de $U$ est une observation graphique arbitraire ; avec Jensen, elle devient le **mécanisme** qui produit l'aversion au risque et justifie toute la suite du notebook (équivalent certain, prime de risque, coefficients d'Arrow-Pratt).

## Validation (preuves vérifiables)

- **Markdown-only** : cell[9] enrichie (3 éléments source ajoutés), **0 cellule code touchée**. Vérifié : `cells changed == [9]`, `code cells changed == []`.
- **C.3 exception** : markdown-only, pas de re-exec requise. `execution_count` + `outputs` inchangés.
- **Raw-text surgical** (json.dumps round-trip FAILS — indent non-uniforme) : splice dans les bytes origin/main via la région source-array. **3 ins / 1 del**, zero churn cosmétique.
- **CRLF = 0** (LF préservé), **ensure_ascii=False** (66 non-ASCII, inchangé — les nouveaux accents utilisent des apostrophes courbes `'` qui sont ASCII-safe).
- **C.1** : 0 violation. Density 725 → 744 chars/code-cell.

## G.1 + transparence G-VAR

Scanned les notebooks Python non-Lean pour sections conceptuelles minces. DecPyMC-2 (ratio 725, Probas/DecisionTheory) — premierhand read des 36 cellules markdown : la plupart ont des "Interpretation" adéquates (300-900ch), mais §2 « Utilite Marginale Decroissante » (189ch) manque l'insight-clé (Jensen → aversion au risque). Les « 8 gaps code→code » détectés par scan = FAUX POSITIFS (cellules pipeline séquentielles avec headers descriptifs, pas des interprétations manquantes).

Genre MED/notebook-python, famille Probas/DecisionTheory (≠ Lean #10722/#10726 = variété R6). Le litmus LIGHT « générérable en scannant l'instance suivante ? » → non : Jensen → aversion au risque exige de comprendre la théorie de l'utilité espérée, pas un template.

See #10488 (densité pédagogique).
