### PR TITLE
fix(ml,#10097): plain-text abs-value \| in GFM table renders stray backslash (ML-7)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
@@ -933,9 +933,9 @@
     "| Métrique | Définition | Interprétation |\n",
     "|----------|-----------|---------------|\n",
     "| **RMSE** | √(Moyenne((note_prédite - note_réelle)²)) | Erreur de prédiction (plus bas = mieux) |\n",
-    "| **MAE** | Moyenne(\\|note_prédite - note_réelle\\|) | Erreur absolue moyenne |\n",
-    "| **Precision@K** | \\|Recommandations pertinentes\\| / K | Proportion de recommandations utiles |\n",
-    "| **Recall@K** | \\|Recommandations pertinentes\\| / \\|Total pertinent\\| | Couverture des items pertinents |\n",
+    "| **MAE** | Moyenne(`|note_prédite - note_réelle|`) | Erreur absolue moyenne |\n",
+    "| **Precision@K** | `|Recommandations pertinentes|` / K | Proportion de recommandations utiles |\n",
+    "| **Recall@K** | `|Recommandations pertinentes|` / `|Total pertinent|` | Couverture des items pertinents |\n",
     "| **NDCG@K** | Normalized DCG | Qualité du classement |\n",
     "\n",
     "### Split Train/Test pour l'évaluation"

--- a/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
@@ -17,6 +17,12 @@
       csharp_sha: be8497a406d3e43570235c9f5604f02f498f79e0
       content_python_sha: e49f24a57c52ec6ff167091f332a28ddc61c663f1a49c0b10bda9101a23c06ca
       content_csharp_sha: ae1b3ee7d7ec475bb28133fb29e007bd32990aa346ae7b2eafaf73fb64370e46
+    - date: "2026-08-13"
+      by: myia-ai-01:CoursIA
+      python_sha: 77524721813b30cc81946ec94cf4f9ed6c69531a
+      csharp_sha: 89d2ce8ff271e2d5a28df4064488f51a9d8e659a
+      content_python_sha: e49f24a57c52ec6ff167091f332a28ddc61c663f1a49c0b10bda9101a23c06ca
+      content_csharp_sha: 8bf58b4802a5ad2cb524d73d902bb02dd2b14f3fb081fee1c2e45e09e4369549
   known_differences:
     - "Socle pedagogique commun : filtrage collaboratif par factorisation de matrices (recommandation user-item, K facteurs latents)."
     - "Idiomes framework : C# = `mlContext.Recommendation().Trainers.MatrixFactorization` (trainer dedie + MapValueToKey pour UserId/MovieId). Python = `sklearn.decomposition.NMF` (Non-negative Matrix Factorization generique, init='nndsvda', solver='mu') avec erreur de reconstruction explicite."


### PR DESCRIPTION
Grain: LIGHT/content -- lane myia-po-2023:CoursIA -- prev: LIGHT/content #10727

## Summary

ML-7-Recommendation metrics table utilisait `\|note_prédite - note_réelle\|` et `\|Recommandations pertinentes\|` (pipes GFM-échappés) pour la notation abs-value. La table ne cassait pas (pipes correctement échappés), MAIS le rendu montrait un **backslash parasite** : `\|note_prédite - note_réelle\|` au lieu d'un propre `|note_prédite - note_réelle|`. Défaut de rendu markdown (#10097), sous-classe distincte des fixes LaTeX `\mid`/`\vert` (plain-text, pas math `$...$`).

## Diagnostic (G.1 firsthand sur origin/main)

cell[17] table Métrique/Définition/Interprétation, 3 rows affectées :
- **MAE** : `Moyenne(\|note_prédite - note_réelle\|)` → backslash parasite
- **Precision@K** : `\|Recommandations pertinentes\| / K` → backslash parasite
- **Recall@K** : `\|Recommandations pertinentes\| / \|Total pertinent\|` → 2 backslashes parasites

Les 3 rows ont pipe count = 4 (match header, table ne casse pas), donc le scanner COL_MISMATCH ne les flaggue pas. Mais visuellement, `\|` dans du plain text (pas LaTeX) rend le `\` littéralement — moche et incorrect.

## Fix

Wrap les expressions abs-value en **backtick code spans** `` `|...|` ``, qui rendent `|...|` proprement sans escaping. C'est la forme idiomatique pour une notation plain-text dans une cellule markdown de table GFM.

## Validation

- [x] 3 rows fixées (MAE, Precision@K, Recall@K), backticks en place
- [x] Plus de `\|` parasite dans les 3 rows
- [x] Pipe count préservé (table structure intacte, header match)
- [x] Diff chirurgical (3 insertions / 3 deletions, 1 fichier)
- [x] 0 CRLF (LF only)
- [x] JSON valide (38 cells)
- [x] Markdown-only (C.3 exception, no re-exec)

## Scope — defect-class triangulation (7 PRs cette session, 3 surfaces)

La defect-class « pipe notation in GFM tables » est now couverte sur 3 surfaces distinctes :
- **LaTeX `\mid`** (conditional prob) : QC-Py-25 (#10704), RL (#10709), Probas (#10711)
- **LaTeX `\vert`** (cardinality/abs-value) : QC-Py-20/24 (#10701), Search (#10712), IIT README (#10727)
- **Plain-text backtick** (abs-value notation) : ML-7 (cette PR)

Résiduel documenté : 0 (scans exhaustifs notebooks + READMEs cross-dépôt).

## Test plan

- [x] ML-7 metrics table : 3 rows rendent `|...|` proprement (plus de backslash parasite)
- [x] Structure table préservée (4 pipes/header, 4 pipes/row)

See #10097 (markdown rendering quality). Sibling de #10712 + #10727.

