### PR TITLE
enrich(tweety,#10488): WHY markdown for FOL polymorphism + existential (Tweety-2c .NET)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2c-FOL-Csharp.ipynb
@@ -274,7 +274,9 @@
     "`FolAtom` accepte une liste variable de termes (`Predicate`, `params Term[]`) — l'arité du prédicat\n",
     "doit correspondre au nombre de termes fournis. `Term` est une **interface** (`...syntax.interfaces.Term`)\n",
     "implémentée à la fois par `Variable` et `Constant` : un atome est donc polymorphe sur ses arguments.\n",
-    "\n"
+    "\n",
+    "\n",
+    "**Pourquoi distinguer `Variable` et `Constant` via une interface commune ?** C'est ce polymorphisme qui rend l'**unification** possible — le mécanisme au cœur du raisonnement FOL. Face à la règle `Homme(X) ⇒ Mortel(X)` et au fait `Homme(Socrate)`, le raisonneur *unifie* la variable `X` avec la constante `Socrate` : il substitue `X` partout où elle apparaît dans la règle, puis déduit `Mortel(Socrate)`. Une `Variable` est un *trou à remplir* (liée par un quantificateur, instanciée à l'unification) ; une `Constant` est un *individu figé* (`Socrate`, `Platon`). Exposer les deux derrière la même interface `Term` permet au moteur de manipuler atomes et substitutions sans distinguer les cas : c'est exactement ce que ferait un Prolog ou le raisonner de Tweety en interne.\n"
    ]
   },
   {
@@ -397,7 +399,9 @@
     "### 3.2 Existential : « il existe un mortel »\n",
     "\n",
     "`∃X Mortel(X)` ne quantifie qu'un atome. On réutilise le même atome `mortelX` (qui porte la variable `X`).\n",
-    "\n"
+    "\n",
+    "\n",
+    "**Pourquoi le quantificateur existentiel compte-t-il ?** `∃X Mortel(X)` affirme qu'**au moins un** mortel existe, *sans nommer qui*. C'est précisément ce gain d'expressiveness qui distingue la logique du premier ordre de la logique propositionnelle : en propositionnel, il faudrait énumérer `Mortel(Socrate) ∨ Mortel(Platon) ∨ …` — une disjunction finie qui ne capture jamais l'existence en général. L'existential, lui, porte sur le domaine tout entier. Deux conséquences concrètes pour le raisonnement : (1) **généralisation existentielle** — de `Mortel(Socrate)` on déduit `∃X Mortel(X)` sans connaître les autres mortels ; (2) **dualité avec le universel** (De Morgan) : `¬∀X P(X)` équivaut à `∃X ¬P(X)`, et `¬∃X P(X)` à `∀X ¬P(X)`. Le raisonneur exploite ces équivalences pour réécrire les négations et déduire des existentiels à partir d'universels.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-python

## Summary

Enrich two thin markdown cells of **Tweety-2c-FOL-Csharp.ipynb** (standalone .NET, not a twin) with pedagogical WHY content — the .NET notebook-density rollout (#10488), distinct genre from this morning's notebook-python QC-Py-30 (#10728).

### Changes (markdown-only)

- **c[8] "Atomes, prédicats et types de termes"** (354c → enriched): WHY `Term` is an interface implemented by both `Variable` and `Constant` — this polymorphism is precisely what makes **unification** possible. Concrete example: facing `Homme(X) ⇒ Mortel(X)` + fact `Homme(Socrate)`, the reasoner unifies `X` with `Socrate` (substitutes everywhere) and deduces `Mortel(Socrate)`. A `Variable` is a hole-to-fill; a `Constant` is a frozen individual. Exposing both behind `Term` lets the engine handle atoms + substitutions without case-splitting — exactly what Prolog / Tweety's reasoner do internally.

- **c[12] "Existential"** (155c → enriched): WHY the existential quantifier counts. `∃X Mortel(X)` asserts at least one mortal exists *without naming who* — the expressiveness leap that separates FOL from propositional logic (which can only enumerate `Mortel(Socrate) ∨ Mortel(Platon) ∨ …`, a finite disjunction that never captures existence in general). Two concrete consequences for reasoning: (1) **existential generalization** — from `Mortel(Socrate)` deduce `∃X Mortel(X)`; (2) **duality with universal** (De Morgan): `¬∀X P(X)` ≡ `∃X ¬P(X)`, exploited to rewrite negations.

## Validation (all green)

| Check | Result |
|-------|--------|
| `validate_pr_notebooks.py` | PASS (15/15 code cells, .net-csharp) |
| Code cells byte-identical to base | TRUE (15 now / 15 base) |
| `execution_count` | all non-null, exec_null=0 (fully executed preserved) |
| Markdown-only diff | 6 ins / 2 del (no code churn) |
| `detect_md_content_loss.py` | findings=0 (md 7390→8779 normalized, gain no loss) |
| `check_machine_dep_timing.py` advisory | 0 (wallclock/distribution/domain/ambiguous all 0) |
| Density | 578 → 687 chars/code-cell |
| Canonical json.dumps round-trip | BYTE-IDENTICAL (trailing nl) verified pre-edit |

## Rules compliance

- **C.1**: no voluntary error (markdown-only, code untouched).
- **C.2**: outputs preserved (code cells byte-identical, exec_null=0).
- **C.3**: only the 2 modified markdown cells touched; no re-execution of unchanged code.
- **#9434**: no quantitative machine-dependent values introduced (advisory 0).
- **L898**: no OPEN/MERGED PR touches this notebook (all prior PRs MERGED/CLOSED, last = #9222 cost metadata already on base).
- **Catalogue**: byte-identique to main (no catalog files touched).

See #10488. Base: `origin/main` fresh.
