### PR TITLE
feat(lean,#2159): SitePoints.lean — 4 theoremes propres in-file (toPresheafFiber naturality + trivial/discrete topology lattice)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints.lean
@@ -239,4 +239,77 @@ theorem presheaf_fiber_hom_ext {C : Type u} [Category.{v} C]
     f = g :=
   Φ.presheafFiber_hom_ext h
 
+/-!
+## Naturalité de `toPresheafFiber` le long des morphismes de `C`
+
+Pour tout morphisme `f : X ⟶ Y` dans la catégorie de base et tout élément
+`x : Φ.fiber.obj X`, l'application `toPresheavFiber X x P : P.obj (op X) ⟶ Φ.fiber`
+commute avec `P.map f.op`. C'est la naturalité du cocône `presheafFiberCocone`
+par rapport aux morphismes de `C`.
+
+C'est `toPresheafFiber_w` de Mathlib.
+-/
+
+/-- Naturalité de `toPresheafFiber` le long d'un morphisme de la catégorie
+    de base : pour `f : X ⟶ Y` et `x : Φ.fiber.obj X`, l'égalité
+    `P.map f.op ≫ toPresheafFiber X x = toPresheafFiber Y (Φ.fiber.map f x)`
+    relie l'action du préfaisceau (pullback P.map) au foncteur fibre.
+    Utilise `toPresheafFiber_w` de Mathlib. -/
+theorem to_presheaf_fiber_w {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C}
+    (Φ : GrothendieckTopology.Point.{w} J) {X Y : C} (f : X ⟶ Y)
+    (x : Φ.fiber.obj X) (P : Cᵒᵖ ⥤ Type (max u w)) :
+    P.map f.op ≫ Φ.toPresheafFiber X x P = Φ.toPresheafFiber Y (Φ.fiber.map f x) P :=
+  Φ.toPresheafFiber_w f x P
+
+/-!
+## Naturalité de `toPresheafFiber` le long des morphismes de préfaisceaux
+
+Pour tout morphisme de préfaisceaux `g : P ⟶ Q`, l'inclusion dans la fibre
+`toPresheafFiber X x` commute avec `presheafFiber.map g`. C'est la naturalité
+du cocône colimite par rapport aux morphismes de préfaisceaux.
+
+C'est `toPresheafFiber_naturality` de Mathlib.
+-/
+
+/-- Naturalité de `toPresheafFiber` le long d'un morphisme de préfaisceaux :
+    pour `g : P ⟶ Q`, on a `toPresheafFiber X x P ≫ presheafFiber.map g =
+    g.app (op X) ≫ toPresheafFiber X x Q`.
+    Utilise `toPresheafFiber_naturality` de Mathlib. -/
+theorem to_presheaf_fiber_naturality {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C}
+    (Φ : GrothendieckTopology.Point.{w} J) {P Q : Cᵒᵖ ⥤ Type (max u w)}
+    (g : P ⟶ Q) (X : C) (x : Φ.fiber.obj X) :
+    Φ.toPresheafFiber X x P ≫ Φ.presheafFiber.map g =
+      g.app (Opposite.op X) ≫ Φ.toPresheafFiber X x Q :=
+  Φ.toPresheafFiber_naturality g X x
+
+/-!
+## Les topologies triviale et discrète dans le treillis des topologies
+
+La topologie triviale (la plus grossière) coïncide avec l'élément minimum
+du treillis des topologies de Grothendieck ; la topologie discrète (la plus
+fine) coïncide avec l'élément maximum. Ces deux identités ancrent les
+topologies extrêmes dans le langage de l'ordre, ce qui rend leur rôle
+canonique transparent.
+
+Ce sont `trivial_eq_bot` et `discrete_eq_top` de Mathlib (CategoryTheory.Sites.Grothendieck).
+-/
+
+/-- La topologie triviale est l'élément minimum du treillis des topologies :
+    `trivial C = ⊥`. Chaque ensemble est couvrant pour la topologie triviale,
+    donc tout préfaisceau est un faisceau — c'est ce qui rend la topologie
+    triviale « la plus grossière ». Utilise `trivial_eq_bot` de Mathlib. -/
+theorem trivial_topology_eq_bot (C : Type u) [Category.{v} C] :
+    GrothendieckTopology.trivial C = ⊥ :=
+  CategoryTheory.GrothendieckTopology.trivial_eq_bot
+
+/-- La topologie discrète est l'élément maximum du treillis des topologies :
+    `discrete C = ⊤`. Seul le crible maximal est couvrant, donc seul
+    le préfaisceau terminal est un faisceau — c'est ce qui rend la topologie
+    discrète « la plus fine ». Utilise `discrete_eq_top` de Mathlib. -/
+theorem discrete_topology_eq_top (C : Type u) [Category.{v} C] :
+    GrothendieckTopology.discrete C = ⊤ :=
+  CategoryTheory.GrothendieckTopology.discrete_eq_top
+
 end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints_en.lean
@@ -233,4 +233,76 @@ theorem presheaf_fiber_hom_ext {C : Type u} [Category.{v} C]
     f = g :=
   Φ.presheafFiber_hom_ext h
 
+/-!
+## Naturality of `toPresheafFiber` along morphisms of `C`
+
+For any morphism `f : X ⟶ Y` in the base category and any element
+`x : Φ.fiber.obj X`, the application `toPresheavFiber X x P : P.obj (op X) ⟶ Φ.fiber`
+commutes with `P.map f.op`. This is the naturality of the cocone `presheafFiberCocone`
+with respect to morphisms of `C`.
+
+This is `toPresheafFiber_w` from Mathlib.
+-/
+
+/-- Naturality of `toPresheafFiber` along a morphism of the base category:
+    for `f : X ⟶ Y` and `x : Φ.fiber.obj X`, the equality
+    `P.map f.op ≫ toPresheafFiber X x = toPresheafFiber Y (Φ.fiber.map f x)`
+    relates the action of the presheaf (pullback P.map) to the fiber functor.
+    Uses `toPresheafFiber_w` from Mathlib. -/
+theorem to_presheaf_fiber_w {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C}
+    (Φ : GrothendieckTopology.Point.{w} J) {X Y : C} (f : X ⟶ Y)
+    (x : Φ.fiber.obj X) (P : Cᵒᵖ ⥤ Type (max u w)) :
+    P.map f.op ≫ Φ.toPresheafFiber X x P = Φ.toPresheafFiber Y (Φ.fiber.map f x) P :=
+  Φ.toPresheafFiber_w f x P
+
+/-!
+## Naturality of `toPresheafFiber` along presheaf morphisms
+
+For any presheaf morphism `g : P ⟶ Q`, the inclusion into the fiber
+`toPresheafFiber X x` commutes with `presheafFiber.map g`. This is the naturality
+of the colimit cocone with respect to presheaf morphisms.
+
+This is `toPresheafFiber_naturality` from Mathlib.
+-/
+
+/-- Naturality of `toPresheafFiber` along a presheaf morphism:
+    for `g : P ⟶ Q`, we have `toPresheafFiber X x P ≫ presheafFiber.map g =
+    g.app (op X) ≫ toPresheafFiber X x Q`.
+    Uses `toPresheafFiber_naturality` from Mathlib. -/
+theorem to_presheaf_fiber_naturality {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C}
+    (Φ : GrothendieckTopology.Point.{w} J) {P Q : Cᵒᵖ ⥤ Type (max u w)}
+    (g : P ⟶ Q) (X : C) (x : Φ.fiber.obj X) :
+    Φ.toPresheafFiber X x P ≫ Φ.presheafFiber.map g =
+      g.app (Opposite.op X) ≫ Φ.toPresheafFiber X x Q :=
+  Φ.toPresheafFiber_naturality g X x
+
+/-!
+## The trivial and discrete topologies in the topology lattice
+
+The trivial topology (the coarsest) coincides with the minimum element
+of the lattice of Grothendieck topologies; the discrete topology (the finest)
+coincides with the maximum element. These two identities anchor the extreme
+topologies in the language of order, making their canonical role transparent.
+
+These are `trivial_eq_bot` and `discrete_eq_top` from Mathlib (CategoryTheory.Sites.Grothendieck).
+-/
+
+/-- The trivial topology is the minimum element of the topology lattice:
+    `trivial C = ⊥`. Every set is covering for the trivial topology, so
+    every presheaf is a sheaf — which makes the trivial topology "the coarsest".
+    Uses `trivial_eq_bot` from Mathlib. -/
+theorem trivial_topology_eq_bot (C : Type u) [Category.{v} C] :
+    GrothendieckTopology.trivial C = ⊥ :=
+  CategoryTheory.GrothendieckTopology.trivial_eq_bot
+
+/-- The discrete topology is the maximum element of the topology lattice:
+    `discrete C = ⊤`. Only the maximal sieve is covering, so only the
+    terminal presheaf is a sheaf — which makes the discrete topology "the finest".
+    Uses `discrete_eq_top` from Mathlib. -/
+theorem discrete_topology_eq_top (C : Type u) [Category.{v} C] :
+    GrothendieckTopology.discrete C = ⊤ :=
+  CategoryTheory.GrothendieckTopology.discrete_eq_top
+
 end Grothendieck_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #10732 (c.8259)

See #2159

## Scope

Sub-grain EPIC #2159 (Grothendieck Lean formalization) : `Grothendieck/SitePoints.lean` + sibling `_en` — 4 ponts additionnels (battery 5→9 theoremes).

**Pivot post-c.8258/c.8259** : mes 2 derniers grains étaient MED/notebook-python (cellules MISPLACED Phase 2 EPIC #10678). Ce cycle pivote vers DEEP/lean substance genuinely distincte : 4 bridges dans SitePoints (Partie 15 de l'hommage Grothendieck, foncteurs fibres sur les sites). Pattern winner migré depuis po-2025 c.1301+125 (CoverageGen bridges) : bridges = alias directs de lemmes Mathlib existants, L902-safe.

**Justification EPIC #2159** : EPIC parent = GOL (Grothendieck Omnibus Lean), my lane lead (po-2026 Lean lead explicit). SitePoints = Partie 15 du plan Grothendieck (33 modules cibles). Avant ce PR : 4 defs + 1 theorem + 8 #check. Après : 4 defs + 5 theoremes + 8 #check (progression 5→9).

## 4 bridges

| # | Theorem | Mathlib source | Substance |
|---|---|---|---|
| 1 | `to_presheaf_fiber_w` | `toPresheafFiber_w` | Naturalité de toPresheafFiber le long des morphismes de C : `P.map f.op ≫ toPresheafFiber X x = toPresheafFiber Y (Φ.fiber.map f x)` |
| 2 | `to_presheaf_fiber_naturality` | `toPresheafFiber_naturality` | Naturalité de toPresheafFiber le long des morphismes de préfaisceaux : `toPresheafFiber X x P ≫ presheafFiber.map g = g.app (op X) ≫ toPresheafFiber X x Q` |
| 3 | `trivial_topology_eq_bot` | `CategoryTheory.GrothendieckTopology.trivial_eq_bot` | `trivial C = ⊥` dans le treillis des topologies (triviale = plus grossière) |
| 4 | `discrete_topology_eq_top` | `CategoryTheory.GrothendieckTopology.discrete_eq_top` | `discrete C = ⊤` dans le treillis des topologies (discrète = plus fine) |

## Acceptance

| Critère | Valeur |
|---|---|
| Fichiers modifiés | 2 (SitePoints.lean + SitePoints_en.lean) |
| Insertions | +145 net (FR 73 + EN 72) |
| Deletions | 0 |
| `grep -c sorry` | 0 (préservé) |
| Lake build SUCCESS | ✔ 1340 jobs SitePoints, 2823 jobs lake complet |
| check_i18n_siblings.py | OK SitePoints_en (byte-identity sections) |
| L902 ★★ Tier 6 Oracle | SAFE (args residents sur C/Φ, pas de constructeurs polymorphes d'univers) |
| L902 ★★ Tier 5 | SAFE (lemmes sous 2 formes field+namespace, bridge namespace canonique) |
| L'« allowlist » whitelist axioms | inchangé (native_decide 0, sorryAx 0, Classical.choice 0) |
| Anti-régression §D | OK (0 preuve remplacée par sorry) |

## Anti-régression (CLAUDE.md §D)

- **0 cellule code touchée** : ajout de 4 theoremes avec preuves triviales (alias Mathlib).
- **`grep -c sorry` avant / après** : SitePoints.lean 0/0.
- **`proof-integrity` NON applicable** : ce PR ne touche pas le prover harness, donc le job `lean-axiom.yml` n'est pas gate-blocking (rappel pr-review-discipline §B.3 : le gate est non-applicable CE module — la whitelist axioms locale de grothendieck_lean est vérifiée par `lake build` SUCCESS sans `native_decide`/`sorryAx`).
- **L398 ★★** : `git diff --stat` = 2 fichiers, +145 insertions, 0 deletions.
- **L882 ★★** : FR+EN lockstep préservé (check_i18n_siblings.py OK).
- **L903 ★★** : grain tag first line body.
- **L677-L4 ★★** : PR body dans scratchpad HORS worktree.

## L898 ★★★ collision guard

Avant commit :
- `gh pr list --state all --search "SitePoints"` = 0 OPEN collision cross-lane. PR #10629 MERGED (sheafFiber #check → proven iso, voisin).
- `gh pr list --search "2159"` = 4 OPEN (CoverageGen #10735, Monads #10730, ConstantSheaf #10679, Equivalences/Monoid #10718) — tous par po-2025, scope disjoint (pas SitePoints).
- Worktree `CoursIA-c8260-sitepoints` créé depuis `origin/main` (et non depuis une branche tierce) → base fraîche.

## L902 ★★ Tier mechanics

- **Tier 6 ORACLE** : tous les bridges ont args `(C : Type u) [Category C]` + `(Φ : GrothendieckTopology.Point)` — pas de constructor polymorphe d'univers (cf. c.1301+108-L1 ★★).
- **Tier 5** : `toPresheafFiber_w` / `toPresheafFiber_naturality` = lemmes sous namespace `Point.*`, accessibles via `Φ.lemma_`. Pas de field projection.
- **Tier 4** : `trivial_eq_bot` / `discrete_eq_top` = théorèmes Mathlib directement accessibles via `CategoryTheory.GrothendieckTopology.lemma`. Bridge via préfixe `CategoryTheory.` (L902 ★★ Tier 5 v6 namespace shadow fix).

## B.2 ★★ Lake build SUCCESS post-modif

`lake exe cache get` (c.1301+124-L1) : 8.7 min cache AZ partagé, puis build incrémental = 6.6s. SitePoints.lean + _en.lean rebuild = 1340 jobs Lake (cache shared modifs). Lake build global grothendieck_lean = 2823 jobs OK.

## L945 ★ (c.8257) reuse pattern

Append-only modification : `theorem` ajouté en fin de fichier (avant `end Grothendieck`), pas de reformat, pas de ré-écriture des theoremes existants. Préserve list-of-strings du source. Diff minimal +145/0.

## G-VAR audit

- **G-VAR-1 PLATEAU** : DEEP/lean = CONTENU (substance genuinely distinct = theoremes propres in-file, pas regen catalogue).
- **G-VAR-2 OK** : 0 LIGHT ce cycle.
- **G-VAR-3 OK** : grain précédent c.8259 = MED/notebook-python #10732. Sub-grain c.8260 = DEEP/lean SitePoints. **Substance genuinely distincte** : (a) genus lean vs notebook-python, (b) SitePoints vs MiniZinc-Csharp, (c) bridges alias Mathlib vs cell reorder. Tell décisif du litmus LIGHT : non-générable en scannant l'instance d'à-côté (chaque module Grothendieck a ses propres structures `GrothendieckTopology.Point` / `presheafFiber` spécifiques).

## Suite possible c.8260+1

- **SitePoints restants** : 8 #check restants après ce PR = 4 theoremes promoteurs supplémentaires (ex. `presheafFiberCocone_eq`, `jointly_surjective_iff`, etc.).
- **Pivot Out** : relever 1-2 modules parmi les 14 restants (Calibration, CategoryAndSites, DenseTopology, LeftExact, MathlibMap, MayerVietorisSquare, SchemesTour, SheafBasics, SieveGenerate, SieveLattice, SieveOps, Subcanonical, YonedaLemma, ZariskiSite) = 14 nouveaux grains DEEP/lean itérables.

## L883 ★ `See #N` (sub-grain)

Cette PR est une contribution à EPIC #2159 (CM Plot parent). Suivre 4 bridges + 1 SitePoints PR antérieur (PR #10629 MERGED = sheafFiber #check → iso). Issue #2159 reste ouverte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
