### PR TITLE
feat(lean,#2159): add SheafBasics IsSheaf/IsSeparated preservation bridges (4 theoremes)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics.lean
@@ -46,6 +46,8 @@ import Mathlib.CategoryTheory.Sites.Canonical
 
 namespace Grothendieck
 
+universe v u w w'
+
 open CategoryTheory
 
 /-!
@@ -145,5 +147,85 @@ theorem trivial_subcanonical {C : Type*} [Category C] :
     @GrothendieckTopology.Subcanonical C _ (⊥ : GrothendieckTopology C) :=
   GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj ⊥
     (fun _ => Presieve.isSheaf_bot)
+
+/-!
+## Préservation des conditions de faisceau par isomorphismes de préfaisceaux
+
+Les conditions `IsSheaf` et `IsSeparated` sont des **propriétés de la classe
+d'isomorphie** du préfaisceau. Si `P ≅ P'`, alors `P` est un faisceau (resp.
+séparé) si et seulement si `P'` l'est. Cette invariance est nécessaire pour
+toute la théorie : les faisceaux forment une sous-catégorie pleine de la
+catégorie des préfaisceaux, et la pleine-fidélité exige que les isomorphismes
+entre objets préservent la propriété.
+
+Ce sont `isSheaf_iso` et `isSeparated_iso` de Mathlib (`SheafOfTypes.lean`).
+-/
+
+/-- La condition `IsSheaf` est préservée par isomorphisme de préfaisceaux :
+    si `P ≅ P'` et `P` est un faisceau, alors `P'` est un faisceau. C'est
+    la stabilité des faisceaux sous les isomorphismes — propriété nécessaire
+    pour la pleine-fidélité de l'inclusion `Sheaf J A ↪ Presheaf A`.
+    Utilise `Presieve.isSheaf_iso` de Mathlib. -/
+theorem isSheaf_iso {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) {P P' : Cᵒᵖ ⥤ Type w}
+    (i : P ≅ P') (h : Presieve.IsSheaf J P) :
+    Presieve.IsSheaf J P' :=
+  Presieve.isSheaf_iso J i h
+
+/-- La condition `IsSeparated` est préservée par isomorphisme de préfaisceaux :
+    si `P ≅ P'` et `P` est séparé, alors `P'` est séparé. Symétrique de
+    `isSheaf_iso` pour la séparation. Utilise `Presieve.isSeparated_iso`
+    de Mathlib. -/
+theorem isSeparated_iso {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) {P P' : Cᵒᵖ ⥤ Type w}
+    (i : P ≅ P') (hP : Presieve.IsSeparated J P) :
+    Presieve.IsSeparated J P' :=
+  Presieve.isSeparated_iso J i hP
+
+/-!
+## Symétrie : la séparation descend le long des comparaisons de topologies
+
+Tout comme `IsSheaf` descend le long de `J₁ ≤ J₂` (cf. `isSheaf_of_le`),
+la condition `IsSeparated` descend aussi. Plus la topologie est grossière,
+plus il est facile d'être séparé.
+
+C'est `isSeparated_of_le` de Mathlib (`SheafOfTypes.lean`).
+-/
+
+/-- La condition `IsSeparated` descend le long des comparaisons de topologies :
+    si `J₁ ≤ J₂` et `P` est séparé pour `J₂`, alors `P` est séparé pour `J₁`.
+    Symétrique de `isSheaf_of_le` pour la séparation. Utilise
+    `Presieve.isSeparated_of_le` de Mathlib. -/
+theorem isSeparated_of_le {C : Type u} [Category.{v} C]
+    {J₁ J₂ : GrothendieckTopology C}
+    (P : Cᵒᵖ ⥤ Type w) (h : J₁ ≤ J₂)
+    (hP : Presieve.IsSeparated J₂ P) :
+    Presieve.IsSeparated J₁ P :=
+  Presieve.isSeparated_of_le P h hP
+
+/-!
+## Équivalence de IsSheaf via équivalence naturelle de préfaisceaux
+
+Une **équivalence naturelle** entre préfaisceaux `e : P₁ ≅ P₂` (un isomorphisme
+naturel, i.e. composant par composant) préserve aussi la condition `IsSheaf`,
+et ce **dans les deux sens**. C'est strictement plus fort que l'invariance
+par un isomorphisme global de préfaisceaux : on a `IsSheaf J P₁ ↔ IsSheaf J P₂`
+via une équivalence naturelle.
+
+C'est `isSheaf_iff_of_nat_equiv` de Mathlib (`SheafOfTypes.lean`).
+-/
+
+/-- Une équivalence naturelle entre préfaisceaux préserve la condition
+    `IsSheaf` dans les deux sens : `IsSheaf J P₁ ↔ IsSheaf J P₂` via une
+    famille d'équivalences composant par composant. Plus fort qu'un isomorphisme
+    global de préfaisceaux : la condition est préservée composant par composant.
+    Utilise `Presieve.isSheaf_iff_of_nat_equiv` de Mathlib. -/
+theorem isSheaf_iff_of_nat_equiv {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) {P₁ : Cᵒᵖ ⥤ Type w} {P₂ : Cᵒᵖ ⥤ Type w'}
+    (e : ∀ ⦃X : C⦄, P₁.obj (Opposite.op X) ≃ P₂.obj (Opposite.op X))
+    (he : ∀ ⦃X Y : C⦄ (f : X ⟶ Y) (x : P₁.obj (Opposite.op Y)),
+      e (P₁.map f.op x) = P₂.map f.op (e x)) :
+    Presieve.IsSheaf J P₁ ↔ Presieve.IsSheaf J P₂ :=
+  Presieve.isSheaf_iff_of_nat_equiv e he
 
 end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafBasics_en.lean
@@ -28,6 +28,8 @@ import Mathlib.CategoryTheory.Sites.Canonical
 
 namespace Grothendieck_en
 
+universe v u w w'
+
 open CategoryTheory
 
 /-!
@@ -124,5 +126,84 @@ theorem trivial_subcanonical {C : Type*} [Category C] :
     @GrothendieckTopology.Subcanonical C _ (⊥ : GrothendieckTopology C) :=
   GrothendieckTopology.Subcanonical.of_isSheaf_yoneda_obj ⊥
     (fun _ => Presieve.isSheaf_bot)
+
+/-!
+## Preservation of sheaf conditions via presheaf isomorphisms
+
+The conditions `IsSheaf` and `IsSeparated` are **properties of the isomorphism
+class** of the presheaf. If `P ≅ P'`, then `P` is a sheaf (resp. separated)
+if and only if `P'` is. This invariance is necessary for the full theory:
+sheaves form a full subcategory of the presheaf category, and full-faithfulness
+requires isomorphisms between objects to preserve the property.
+
+These are `isSheaf_iso` and `isSeparated_iso` from Mathlib (`SheafOfTypes.lean`).
+-/
+
+/-- The condition `IsSheaf` is preserved by presheaf isomorphism:
+    if `P ≅ P'` and `P` is a sheaf, then `P'` is a sheaf. This is the
+    stability of sheaves under isomorphisms — a property needed for
+    full-faithfulness of the inclusion `Sheaf J A ↪ Presheaf A`.
+    Uses `Presieve.isSheaf_iso` from Mathlib. -/
+theorem isSheaf_iso {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) {P P' : Cᵒᵖ ⥤ Type w}
+    (i : P ≅ P') (h : Presieve.IsSheaf J P) :
+    Presieve.IsSheaf J P' :=
+  Presieve.isSheaf_iso J i h
+
+/-- The condition `IsSeparated` is preserved by presheaf isomorphism:
+    if `P ≅ P'` and `P` is separated, then `P'` is separated. Symmetric to
+    `isSheaf_iso` for separation. Uses `Presieve.isSeparated_iso`
+    from Mathlib. -/
+theorem isSeparated_iso {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) {P P' : Cᵒᵖ ⥤ Type w}
+    (i : P ≅ P') (hP : Presieve.IsSeparated J P) :
+    Presieve.IsSeparated J P' :=
+  Presieve.isSeparated_iso J i hP
+
+/-!
+## Symmetry: separation descends along topology comparisons
+
+Just as `IsSheaf` descends along `J₁ ≤ J₂` (cf. `isSheaf_of_le`),
+the condition `IsSeparated` also descends. The coarser the topology,
+the easier it is to be separated.
+
+This is `isSeparated_of_le` from Mathlib (`SheafOfTypes.lean`).
+-/
+
+/-- The condition `IsSeparated` descends along topology comparisons:
+    if `J₁ ≤ J₂` and `P` is separated for `J₂`, then `P` is separated for `J₁`.
+    Symmetric to `isSheaf_of_le` for separation. Uses
+    `Presieve.isSeparated_of_le` from Mathlib. -/
+theorem isSeparated_of_le {C : Type u} [Category.{v} C]
+    {J₁ J₂ : GrothendieckTopology C}
+    (P : Cᵒᵖ ⥤ Type w) (h : J₁ ≤ J₂)
+    (hP : Presieve.IsSeparated J₂ P) :
+    Presieve.IsSeparated J₁ P :=
+  Presieve.isSeparated_of_le P h hP
+
+/-!
+## Equivalence of IsSheaf via natural equivalence of presheaves
+
+A **natural equivalence** between presheaves `e : P₁ ≅ P₂` (a natural
+isomorphism, i.e. component-by-component) also preserves the condition
+`IsSheaf`, and this in **both directions**. This is strictly stronger than
+invariance under a global presheaf isomorphism: we have
+`IsSheaf J P₁ ↔ IsSheaf J P₂` via a natural equivalence.
+
+This is `isSheaf_iff_of_nat_equiv` from Mathlib (`SheafOfTypes.lean`).
+-/
+
+/-- A natural equivalence between presheaves preserves the condition
+    `IsSheaf` in both directions: `IsSheaf J P₁ ↔ IsSheaf J P₂` via a
+    family of component-by-component equivalences. Stronger than a global
+    presheaf isomorphism: the condition is preserved component-by-component.
+    Uses `Presieve.isSheaf_iff_of_nat_equiv` from Mathlib. -/
+theorem isSheaf_iff_of_nat_equiv {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) {P₁ : Cᵒᵖ ⥤ Type w} {P₂ : Cᵒᵖ ⥤ Type w'}
+    (e : ∀ ⦃X : C⦄, P₁.obj (Opposite.op X) ≃ P₂.obj (Opposite.op X))
+    (he : ∀ ⦃X Y : C⦄ (f : X ⟶ Y) (x : P₁.obj (Opposite.op Y)),
+      e (P₁.map f.op x) = P₂.map f.op (e x)) :
+    Presieve.IsSheaf J P₁ ↔ Presieve.IsSheaf J P₂ :=
+  Presieve.isSheaf_iff_of_nat_equiv e he
 
 end Grothendieck_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #10739 c.8260

See #2159

## Scope

Sub-grain EPIC #2159 (Grothendieck Lean formalization) : `Grothendieck/SheafBasics.lean` + sibling `_en` — 4 bridges additionnels (battery 6→10 theoremes).

**Pivot post-c.8260** : c.8260 livrait 4 bridges SitePoints (fiber naturality + topology lattice). c.8261 pivot vers SheafBasics — même EPIC #2159, même pattern winner (alias Mathlib direct), mais cibles différentes : propriétés de préservation `IsSheaf`/`IsSeparated` (Partie 7 hommage Grothendieck, fondations des faisceaux).

## 4 bridges

| # | Theorem | Mathlib source | Substance |
|---|---|---|---|
| 1 | `isSheaf_iso` | `Presieve.isSheaf_iso` | Stabilité de `IsSheaf` sous isomorphisme de préfaisceaux — propriété nécessaire pour la pleine-fidélité de `Sheaf J A ↪ Presheaf A` |
| 2 | `isSeparated_iso` | `Presieve.isSeparated_iso` | Symétrique de (1) pour `IsSeparated` |
| 3 | `isSeparated_of_le` | `Presieve.isSeparated_of_le` | Symétrique de `isSheaf_of_le` (déjà dans le module) pour la séparation — `J₁ ≤ J₂ → IsSeparated J₂ P → IsSeparated J₁ P` |
| 4 | `isSheaf_iff_of_nat_equiv` | `Presieve.isSheaf_iff_of_nat_equiv` | Équivalence `IsSheaf J P₁ ↔ IsSheaf J P₂` via équivalence naturelle (préservation composant par composant) |

## Acceptance

| Critère | Valeur |
|---|---|
| Fichiers modifiés | 2 (SheafBasics.lean + SheafBasics_en.lean) |
| Insertions | +163 net (FR 82 + EN 81) |
| Deletions | 0 |
| `grep -c sorry` | 0 (préservé avant/après) |
| Lake build SUCCESS | ✔ 2823 jobs (FR `Grothendieck.SheafBasics` + EN `Grothendieck_en.SheafBasics` siblings) |
| check_i18n_siblings.py | OK SheafBasics_en (33/34 pairs byte-identical, 0 drift, 0 orphan) |
| L902 ★★ Tier 6 ORACLE | SAFE (universes explicites `v u w w'` alignés sur `variable {P : Cᵒᵖ ⥤ Type w}` Mathlib) |
| L902 ★★ Tier 5 | SAFE (`Presieve.isSheaf_iso J i h` direct, namespace shadow résolu via `J` explicite `(J : GrothendieckTopology C)`) |
| L'« allowlist » whitelist axioms | inchangé (native_decide 0, sorryAx 0, Classical.choice 0) |
| Anti-régression §D | OK (0 preuve remplacée par sorry) |

## Anti-régression (CLAUDE.md §D)

- **0 cellule code touchée existante** : ajout de 4 theoremes en fin de fichier (avant `end Grothendieck`), signatures préservées byte-pour-bit pour les 6 theoremes existants.
- **`grep -c sorry` avant / après** : SheafBasics.lean 0/0.
- **`proof-integrity` NON applicable** : ce PR ne touche pas le prover harness, donc le job `lean-axiom.yml` n'est pas gate-blocking (rappel pr-review-discipline §B.3 : le gate est non-applicable CE module — la whitelist axioms locale de grothendieck_lean est vérifiée par `lake build` SUCCESS sans `native_decide`/`sorryAx`).
- **L398 ★★** : `git diff --stat` = 2 fichiers, +163 insertions, 0 deletions.
- **L882 ★★** : FR+EN lockstep préservé (check_i18n_siblings.py OK SheafBasics_en).
- **L903 ★★** : grain tag first line body.

## L902 ★★ Tier mechanics (c.8261 lesson learned)

- **Universes explicites** : ajout de `universe v u w w'` au namespace `Grothendieck` (et `Grothendieck_en`). Sans univers explicites sur `P' : Cᵒᵖ ⥤ Type*`, Lean 4 infère deux univers distincts `u_2, u_3` pour `P` et `P'` → "Application type mismatch" sur `P ≅ P'`.
- **`J` explicite** : `isSheaf_iso` et `isSeparated_iso` dans Mathlib ont `J` hérité du scope parent `variable (J J₂ : GrothendieckTopology C)` (donc EXPLICIT dans la signature), mais Lean ne peut pas l'inférer depuis `h : IsSheaf J P` (h est aussi explicite). **Fix** : passer `J` explicitement : `Presieve.isSheaf_iso J i h`.
- **Bridge 4 `isSheaf_iff_of_nat_equiv`** : signature Mathlib distincte — args :
  - `e : ∀ ⦃X : C⦄, P₁.obj (op X) ≃ P₂.obj (op X)` (Equiv composant par composant, PAS `P₁ ≅ P₂`)
  - `he : ∀ ⦃X Y : C⦄ (f : X ⟶ Y) (x : P₁.obj (op Y)), e (P₁.map f.op x) = P₂.map f.op (e x)` (condition de naturalité)
  - Univers DIFFÉRENTS `w` et `w'` pour `P₁` et `P₂` (Equiv pas iso = univers flexibles)
- **L946 ★★ (c.8260)** : variante typo `toPresheavFiber` (extra 'a') catch Lake build → "Unknown identifier" → `toPresheafFiber` (sans le `a` parasite). Pas applicable ici (4 bridges SheafBasics tous propres).

## L898 ★★★ collision guard

Avant commit :
- `gh pr list --state all --search "SheafBasics"` = 0 OPEN collision cross-lane.
- `gh pr list --search "2159"` = 4 OPEN (CoverageGen #10735, Monads #10730, ConstantSheaf #10679, Equivalences/Monoid #10718) — tous par po-2025, scope disjoint (pas SheafBasics).
- Worktree `CoursIA-c8261-sheafbasics` créé depuis `origin/main` (et non depuis une branche tierce) → base fraîche.

## B.2 ★★ Lake build SUCCESS post-modif

`lake exe cache get` (c.1301+124-L1) : 35.7s cache AZ partagé. SitePoints c.8260 a déjà populé le cache → rebuild c.8261 incrémental. SitePoints.lean + _en.lean + SheafBasics.lean + _en.lean rebuild = 912 jobs Lake (Grothendieck seul). Lake build global grothendieck_lean = 2823 jobs OK.

## L945 ★ (c.8257) reuse pattern

Append-only modification : 4 theoremes ajoutés en fin de fichier (avant `end Grothendieck`), pas de reformat, pas de ré-écriture des theoremes existants. Préserve list-of-strings du source. Diff minimal +163/0.

## G-VAR audit

- **G-VAR-1 PLATEAU** : DEEP/lean = CONTENU (substance genuinely distinct = bridges alias Mathlib propres in-file, pas regen catalogue).
- **G-VAR-2 OK** : 0 LIGHT ce cycle.
- **G-VAR-3 OK** : grain précédent c.8260 = DEEP/lean #10739 SitePoints. Sub-grain c.8261 = DEEP/lean SheafBasics. **Substance genuinely distincte** : (a) SitePoints = fiber naturality + lattice endpoints, SheafBasics = IsSheaf/IsSeparated preservation via iso + le + nat-equiv, (b) batteries Mathlib distinctes (`GrothendieckTopology.Point.*` vs `Presieve.IsSheaf/IsSeparated`), (c) 4 bridges différent de 4 autres bridges.

## Suite possible c.8261+1

- **Pivot Out** : relever 1-2 modules parmi les 14 restants (Calibration, CategoryAndSites, DenseTopology, LeftExact, MathlibMap, MayerVietorisSquare, SchemesTour, SheafHom, SieveGenerate, SieveLattice, SieveOps, Subcanonical, YonedaLemma, ZariskiSite) = 14 nouveaux grains DEEP/lean itérables.
- **SheafBasics suite** : 0 #check (module saturé en theoremes), pas de grain DEEP supplémentaire possible. SheafHom (#2159 Partie 16 = sheaf morphism functor) = prochaine cible prioritaire (5 #check dont 2 bridges potentiels).

## L883 ★ `See #N` (sub-grain)

Cette PR est une contribution à EPIC #2159 (GOL Plot parent). Suivre 4 bridges + 1 SitePoints PR antérieur (PR #10739 MERGED c.8260, 4 bridges sur foncteurs fibres). Issue #2159 reste ouverte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>