### PR TITLE
feat(lean,#2159): add MayerVietorisSquare def bridges (to_pullback_obj, mv_short_complex)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare.lean
@@ -296,4 +296,43 @@ theorem shortComplex_shortExact_field
     S.shortComplex.ShortExact :=
   CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex_shortExact S
 
+/-!
+## 8. Bridges additionnels (defs)
+
+Deux bridges definitionnels completent le tableau. Les theoremes de restriction
+de la section recollée (`map_f₂₄_op_glue` / `map_f₃₄_op_glue`) ont ete livres
+par #10743 sous les noms `sheafCondition_map_f₂₄_op_glue_field` et
+`sheafCondition_map_f₃₄_op_glue_field` — on ne les duplique pas ici.
+
+  - `to_pullback_obj` : l'application canonique de P(X₄) vers le produit fibre.
+  - `mv_short_complex` : le court complexe ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄].
+
+Pattern winner (cf. L947 ★ c.8261) : univers explicites, alias directs Mathlib.
+-/
+
+/-- Bridge : l'application canonique de P(X₄) vers le produit fibré des fibres
+    `P.map S.f₁₂.op` et `P.map S.f₁₃.op` des restrictions du préfaisceau P.
+    C'est la flèche dont la bijectivité est équivalente à la condition de
+    faisceau (cf. `sheaf_condition_iff_bijective`).
+    Utilise `MayerVietorisSquare.toPullbackObj` de Mathlib. -/
+noncomputable def to_pullback_obj
+    [HasWeakSheafify J (Type v)]
+    (S : J.MayerVietorisSquare)
+    (P : Cᵒᵖ ⥤ Type v') :
+    P.obj (op S.X₄) →
+      CategoryTheory.Limits.Types.PullbackObj (P.map S.f₁₂.op) (P.map S.f₁₃.op) :=
+  S.toPullbackObj P
+
+
+/-- Bridge : le court complexe ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄] associé à un
+    carré de Mayer-Vietoris S. C'est l'entrée de la suite exacte longue de
+    Mayer-Vietoris en cohomologie des faisceaux (Partie 22).
+    Utilise `MayerVietorisSquare.shortComplex` de Mathlib. -/
+noncomputable def mv_short_complex
+    [HasWeakSheafify J (Type v)]
+    [HasSheafify J AddCommGrpCat.{v}]
+    (S : J.MayerVietorisSquare) :
+    ShortComplex (Sheaf J AddCommGrpCat.{v}) :=
+  S.shortComplex
+
 end Grothendieck.MayerVietorisSquare

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MayerVietorisSquare_en.lean
@@ -304,4 +304,43 @@ theorem shortComplex_shortExact_field
     S.shortComplex.ShortExact :=
   CategoryTheory.GrothendieckTopology.MayerVietorisSquare.shortComplex_shortExact S
 
+/-!
+## 8. Additional bridges (defs)
+
+Two definitional bridges complete the picture. The gluing-restriction theorems
+(`map_f₂₄_op_glue` / `map_f₃₄_op_glue`) were already delivered by #10743 under
+the names `sheafCondition_map_f₂₄_op_glue_field` and
+`sheafCondition_map_f₃₄_op_glue_field` — they are not duplicated here.
+
+  - `to_pullback_obj`: the canonical map from P(X₄) to the fiber product.
+  - `mv_short_complex`: the short complex ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄].
+
+Pattern winner (cf. L947 ★ c.8261): explicit universes, direct Mathlib aliases.
+-/
+
+/-- Bridge: the canonical map from P(X₄) to the fiber product of the
+    fibers of the presheaf P along `P.map S.f₁₂.op` and `P.map S.f₁₃.op`.
+    This is the map whose bijectivity is equivalent to the sheaf condition
+    (cf. `sheaf_condition_iff_bijective`).
+    Uses `MayerVietorisSquare.toPullbackObj` from Mathlib. -/
+noncomputable def to_pullback_obj
+    [HasWeakSheafify J (Type v)]
+    (S : J.MayerVietorisSquare)
+    (P : Cᵒᵖ ⥤ Type v') :
+    P.obj (op S.X₄) →
+      CategoryTheory.Limits.Types.PullbackObj (P.map S.f₁₂.op) (P.map S.f₁₃.op) :=
+  S.toPullbackObj P
+
+
+/-- Bridge: the short complex ℤ[X₁] ⟶ ℤ[X₂] ⊞ ℤ[X₃] ⟶ ℤ[X₄] associated to a
+    Mayer-Vietoris square S. This is the input for the Mayer-Vietoris long
+    exact sequence in sheaf cohomology (Part 22).
+    Uses `MayerVietorisSquare.shortComplex` from Mathlib. -/
+noncomputable def mv_short_complex
+    [HasWeakSheafify J (Type v)]
+    [HasSheafify J AddCommGrpCat.{v}]
+    (S : J.MayerVietorisSquare) :
+    ShortComplex (Sheaf J AddCommGrpCat.{v}) :=
+  S.shortComplex
+
 end Grothendieck_en.MayerVietorisSquare


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #10741 c.8261

See #2159

## Scope

Sub-grain EPIC #2159 (Grothendieck Lean formalization) : `Grothendieck/MayerVietorisSquare.lean` + sibling `_en` — 2 bridges definitionnels (Partie 21 hommage Grothendieck, carres de Mayer-Vietoris).

**Trim post-rebase (collision cross-lane #10743)** : la PR originale portait 4 bridges (2 defs + 2 theoremes de restriction de la section recollée). #10743 (po-2025) a ete mergee entre-temps et a livre les 2 theoremes de restriction sous les noms `sheafCondition_map_f₂₄_op_glue_field` / `sheafCondition_map_f₃₄_op_glue_field` — restatements des lemmes Mathlib `SheafCondition.map_f₂₄_op_glue` / `map_f₃₄_op_glue`, en doublon des miens. Resolution honnete : **garder les 2 defs additives** (`to_pullback_obj`, `mv_short_complex`) que `main` n'expose que sous forme de theoremes, **abandonner les theoremes dupliques**. Delta vs `main` = +78 lignes (39 FR + 39 EN), rien d'autre.

## 2 defs

| # | Def | Mathlib source | Substance |
|---|---|---|---|
| 1 | `to_pullback_obj` | `MayerVietorisSquare.toPullbackObj` | Application canonique `P(X₄) → PullbackObj` — la fleche dont la bijectivite caracterise la condition de faisceau |
| 2 | `mv_short_complex` | `MayerVietorisSquare.shortComplex` | Court complexe `ℤ[X₁] → ℤ[X₂] ⊞ ℤ[X₃] → ℤ[X₄]` (entree de la suite exacte longue MV) |

## Acceptance

| Critere | Valeur |
|---|---|
| Fichiers modifies | 2 (MayerVietorisSquare.lean + MayerVietorisSquare_en.lean) |
| Insertions | +78 net (FR 39 + EN 39) |
| Deletions | 0 |
| `grep -c sorry` (actif) | 0 (preserve avant/apres) |
| Lake build SUCCESS | c.8262 original : 1714 jobs `Grothendieck.MayerVietorisSquare` SUCCESS (4 bridges, y compris les 2 defs conservees). Trim = suppression pure de 2 theoremes — un sous-ensemble de declarations qui compilent compile |
| check_i18n_siblings.py | 1/1 paire byte-identical, 0 drift, 0 orphan (post-rebase) |
| L947 ★ | SAFE (univers explicites `v v' u u'` alignes sur scope Mathlib) |
| Anti-regression §D | OK (0 preuve remplacee par sorry) |

## Anti-regression (CLAUDE.md §D)

- **0 cellule de code existante touchee** : ajout de 2 defs en fin de fichier (avant `end Grothendieck.MayerVietorisSquare`). Les 5 theoremes de `main` (section « Theoremes propres », issus de #10743) sont preserves byte-pour-bit.
- **`grep -c sorry` avant / apres** : 0/0 (actif ; seul match dans docstring).
- **L398 ★★** : `git diff origin/main...HEAD --stat` = 2 fichiers, +78 insertions, 0 deletions.
- **L882 ★★** : FR+EN lockstep preserve (check_i18n_siblings.py 1/1 byte-identical apres rebase).

## L947 ★ Tier mechanics (c.8261 lesson applied)

- **Univers explicites partages** : scope MayerVietorisSquare `universe w v v' u u'` (deja present).
- **`PullbackObj` namespace** : `CategoryTheory.Limits.Types.PullbackObj` (pas `CategoryTheory.Types`).
- **`HasSheafify J AddCommGrpCat.{v}`** instance requise pour `shortComplex` — ajoutee a la signature de `mv_short_complex`.
- **Fields simples, L902 ★★ Tier 6 SAFE** : `S.toPullbackObj P`, `S.shortComplex`.

## L898 ★★★ collision guard (retrospectif)

Collision reelle avec #10743 (po-2025) : PR ouverte 08:18, mergee 10:07, meme fichier. L898 avait ete passe sur « MayerVietorisSquare » (0 OPEN a l'instant du check) — la fenetre decision→push d'une lane voisine a livre 5 theoremes pendant la mienne. Resolution : rebase + trim aux 2 defs additives (voir Scope). Pas de doublon livre.

## G-VAR audit

- **G-VAR-1 PLATEAU** : DEEP/lean = CONTENU.
- **G-VAR-2 OK** : 0 LIGHT ce cycle.
- **G-VAR-3 OK** : grain precedent c.8261 = DEEP/lean #10741 SheafBasics. Sub-grain c.8262 = DEEP/lean MayerVietorisSquare (def bridges). Substance genuinely distincte.

## Suite possible c.8262+1

Pivot Out : relever 1-2 modules parmi les restants (Calibration, CategoryAndSites, DenseTopology, LeftExact, MathlibMap, SchemesTour, SheafHom, SieveGenerate, SieveLattice, SieveOps, Subcanonical, YonedaLemma, ZariskiSite, Adjunction, Monads, ConstantSheaf, Equivalences, Conservative, DirectImage, Comma).

## L883 ★ `See #N` (sub-grain)

Contribution a EPIC #2159 (GOL Plot parent). Issue #2159 reste ouverte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
