### PR TITLE
feat(sc,#10488): enrich SC-12 Foundry-Testing density 613->728 (3 concept sections WHY)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -293,7 +293,7 @@
     "\n",
     "## 2. Structure d'un projet Foundry\n",
     "\n",
-    "La commande `forge init` crée une structure standard."
+    "La commande `forge init` crée une structure standard.\n\n**Pourquoi cette structure est un contrat, pas une suggestion.** `foundry.toml` mappe les noms logiques aux dossiers physiques : `src` (vos contrats de production), `out` (les artifacts de compilation ABI + bytecode), `libs` (où forge cherche les imports). Renommer un dossier sans mettre à jour `foundry.toml` casse silencieusement la compilation ou la résolution d'imports. Les **remappings** (`forge-std/=lib/forge-std/src/`) sont la pièce qui rend les imports Solidity lisibles : au lieu de chemins relatifs fragiles, vos contrats écrivent `import 'forge-std/Test.sol'` et forge le récrit vers le chemin physique. Cette convention-over-configuration est aussi pourquoi `forge init` installe `lib/forge-std/` par défaut : la librairie standard de test attend ce chemin exact."
    ]
   },
   {
@@ -1054,7 +1054,7 @@
     "\n",
     "## 4. Cheatcodes (vm)\n",
     "\n",
-    "Les cheatcodes sont des fonctions speciales accessibles via l'objet `vm` pour manipuler l'etat du test."
+    "Les cheatcodes sont des fonctions speciales accessibles via l'objet `vm` pour manipuler l'etat du test.\n\n**Pourquoi les cheatcodes existent (et pourquoi tester en Solidity sans eux serait impossible).** Trois valeurs que le code de production lit sont cryptographiquement ou physiquement impossibles à forger depuis un contrat : `msg.sender` (lié à la signature de la transaction, vous ne pouvez pas signer comme Alice sans sa clé privée), `block.timestamp` / `block.number` (fixés par le réseau), et les soldes ETH (comptabilisés par l'EVM). Sans cheatcodes, tester 'que fait mon contrat si Alice l'appelle dans 30 jours avec 5 ETH' nécessiterait de générer une signature valide et d'attendre -- rendant tout test non-déterministe. `vm.prank`, `vm.deal`, `vm.warp` court-circuitent l'EVM : forge intercepte l'appel au niveau de la VM de test (anvil) et injecte la valeur mockée directement, **sans passer par la cryptographie**. C'est l'API de test de la VM ; c'est ce qui rend les tests Foundry déterministes et ce qui les distingue des suites JS (Hardhat) où il faut câbler des signers et des helpers."
    ]
   },
   {
@@ -1708,7 +1708,7 @@
     "\n",
     "## 5. Assertions et Logging\n",
     "\n",
-    "Foundry fournit un ensemble complet d'assertions et de fonctions de logging."
+    "Foundry fournit un ensemble complet d'assertions et de fonctions de logging.\n\n**Pourquoi les assertions sont natives et le logging est votre debugger.** Les tests sont écrits **en Solidity** -- donc `assertEq(a, b)` s'exécute directement dans l'EVM pendant le run de test, sans round-trip RPC vers un harnais JS qui comparerait les valeurs. Zéro latence réseau, et l'égalité se compare au niveau du type on-chain (uint256, address, bytes) avec la sémantique exacte du runtime de production. Le logging (`emit log_*`) existe parce que **l'EVM n'a pas de points d'arrêt** : impossible de poser un breakpoint dans une fonction Solidity. Les logs sont votre `printf` debugging -- ils atterrissent dans les traces forge (`-vvv`), qui reconstruct la stack d'appels et les valeurs aux points de log. C'est pourquoi `verbosity` dans `foundry.toml` est un paramètre de premier ordre : il contrôle combien de contexte de trace vous voyez à l'échec."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/content -- lane myia-po-2023:CoursIA -- prev: MED/content #10742

## Summary

SC-12-Foundry-Testing (density 613, sub-palier P4/900) — 3 sections conceptuelles WHAT-only enrichies avec WHY groundé dans le code Foundry réel du notebook. Famille SmartContract, complètement nouvelle pour cette lane (rotation R6 depuis QC-Py-40 #10742). Pas du padding : chaque bloc explique le **pourquoi** d'un concept Foundry que le code cell adjacent documente.

## Cellules enrichies (3)

- **cell[6] §2 Structure projet** : pourquoi la structure `forge init` est un contrat pas une suggestion. `foundry.toml` mappe src/out/libs aux dossiers physiques ; les remappings (`forge-std/=lib/forge-std/src/`) rendent les imports Solidity lisibles au lieu de chemins relatifs fragiles ; convention-over-configuration explique pourquoi forge-std attend `lib/forge-std/`.
- **cell[22] §4 Cheatcodes (vm)** : pourquoi les cheatcodes existent. `msg.sender` (lié à la signature, infalsifiable sans clé privée), `block.timestamp`/`block.number`, soldes ETH — trois valeurs impossibles à forger depuis Solidity. `vm.prank`/`vm.deal`/`vm.warp` court-circuitent l'EVM au niveau de la VM de test (anvil), injectant la valeur mockée sans cryptographie. C'est ce qui rend les tests Foundry déterministes vs suites JS (Hardhat signers/helpers).
- **cell[36] §5 Assertions/Logging** : pourquoi les assertions sont natives (tests en Solidity → `assertEq` s'exécute dans l'EVM, zéro round-trip RPC) et pourquoi le logging `emit log_*` est le debugger (l'EVM n'a pas de breakpoints, les logs vont dans les traces `-vvv` qui reconstruct la stack d'appels).

## Validation (G.1 firsthand sur worktree frais origin/main 9e8c76d55)

- [x] JSON valide (60 cells, inchangé)
- [x] **Code cells byte-identical** : 0 changée (23 cells, source + outputs préservés)
- [x] 3 markdown cells modifiées (les 3 sections ciblées)
- [x] Diff chirurgical : 3 ins / 3 del, 1 fichier
- [x] C.1 clean : 0 `raise NotImplementedError`/`assert False`/`1/0`
- [x] 0 CRLF (LF only)
- [x] **Markdown-only (C.3 exception)** : aucune cellule code touchée → pas de re-exec (les code cells sont des strings Python qui documentent du Solidity, pas du code foundry exécuté)
- [x] **Standalone** : SC-12 absent du registre twin-parity → pas de drift, markdown-only truly CLEAN
- [x] Repo validator `notebook_tools.py validate` : **OK 1, Warnings 0, Errors 0**
- [x] Density 613 → 728 (+115 c/cell)

## Scope honnête

- Enrichissement partiel (613→728, sous P4/900) : d'autres sections WHAT-only restent éligibles pour PRs ultérieures.
- Genre rotation R6 : famille SmartContract nouvelle pour cette lane (mes PRs précédentes : QC-Py-40 density #10742, pipe-notation QC/RL/Probas/Search/IIT/ML). Variété famille respectée.
- À-côté plafonné 1/lane/jour respecté (2e density PR en 2 jours, familles distinctes).

See #10488 (density pedagogique).

## Test plan

- [x] Validator `notebook_tools.py validate` PASS
- [x] 23 code cells byte-identiques (round-trip préservé)
- [x] 3 markdown cells : WHY grounded dans code Foundry adjacent (foundry.toml remappings, vm.prank crypto, assertEq in-EVM)
