### PR TITLE
feat(lean,#2159): Limits.lean — 4 theoremes/decls ponts additionnels

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits.lean
@@ -280,4 +280,63 @@ theorem colimit_w_natural (F : J ⥤ C) [HasColimit F] {j j' : J} (f : j' ⟶ j)
     F.map f ≫ colimit.ι F j = colimit.ι F j' := by
   rw [CategoryTheory.Limits.colimit.w]
 
+/-!
+## 9. Ponts additionnels : factorisation des cônes, extension, et cônes limites
+
+Les 4 ponts suivants complètent le tableau des lemmes Mathlib 4 fondamentaux
+sur les limites et colimites :
+  - `limit_lift_π` : la projection `limit.π F j` après « lift » d'un cône
+    arbitraire redonne exactement la composante du cône — tige que fournit
+    tout cône sur `F`.
+  - `limit_hom_ext_apply` : critère d'extension « **deux morphismes dans la
+    limite qui coïncident sur chaque projection sont égaux** », application
+    du `@[ext] lemma limit.hom_ext`.
+  - `limit_lift_cone` : le « lift » du cône limite est l'identité — la limite
+    est **point fixe** de sa propre opération de factorisation.
+  - `colimit_ι_desc` : dual côté colimites — l'« desc » suivi de `colimit.ι F j`
+    d'un cocône arbitraire redonne la composante du cocône.
+
+Pattern winner (L902 ★★ c.8261) : univers explicites, alias directs Mathlib,
+signatures alignées sur le lemme source. Pour `limit.hom_ext` (`@[ext]`),
+l'application donne le lemme d'égalité, pas une fonction — on l'écrit
+explicitement avec ses args pointwise.
+-/
+
+/-- Pont : pour tout cône `c` sur `F`, la projection `limit.π F j` composée
+    avec le `limit.lift F c` redonne la `j`-ème composante du cône. C'est la
+    **tige que fournit tout cône** sur le diagramme, démontré par le lemme
+    Mathlib `@[reassoc, simp] lemma CategoryTheory.Limits.limit.lift_π F c j`.
+    Namespace theorem (L902 ★★ Tier 4) — alias direct. -/
+theorem limit_lift_π (F : J ⥤ C) [HasLimit F] (c : Cone F) (j : J) :
+    limit.lift F c ≫ limit.π F j = c.π.app j :=
+  CategoryTheory.Limits.limit.lift_π c j
+
+/-- Pont : critère d'extension entre la limite et le cône — étant donné
+    deux morphismes `f, f' : X ⟶ limit F`, s'ils coïncident sur chaque
+    projection `limit.π F j`, alors `f = f'`. C'est le lemme
+    `@[ext] lemma CategoryTheory.Limits.limit.hom_ext F {X} (w : ∀ j, ...) :
+    f = f'`. Namespace theorem (L902 ★★ Tier 4) — alias direct. -/
+theorem limit_hom_ext_apply (F : J ⥤ C) [HasLimit F] {X : C} {f f' : X ⟶ limit F}
+    (w : ∀ j, f ≫ limit.π F j = f' ≫ limit.π F j) : f = f' :=
+  CategoryTheory.Limits.limit.hom_ext w
+
+/-- Pont : le `limit.lift` du cône limite est l'identité — la limite est
+    point fixe de sa propre factorisation. Démontré par le lemme Mathlib
+    `@[simp] lemma CategoryTheory.Limits.limit.lift_cone {F : J ⥤ C}
+    [HasLimit F] : limit.lift F (limit.cone F) = 𝟙 (limit F)`. Le `F` est
+    implicite — on omet l'argument explicite pour laisser Lean l'unifier. -/
+theorem limit_lift_cone (F : J ⥤ C) [HasLimit F] :
+    limit.lift F (limit.cone F) = 𝟙 (limit F) :=
+  CategoryTheory.Limits.limit.lift_cone
+
+/-- Pont : dual côté colimites — pour tout cocône `c` sur `F`, l'injection
+    `colimit.ι F j` composée avec le `colimit.desc F c` redonne la `j`-ème
+    composante du cocône. C'est la **tige que fournit tout cocône** sur le
+    diagramme, démontré par le lemme Mathlib
+    `@[reassoc, simp] lemma CategoryTheory.Limits.colimit.ι_desc F c j`.
+    Namespace theorem (L902 ★★ Tier 4) — alias direct. -/
+theorem colimit_ι_desc (F : J ⥤ C) [HasColimit F] (c : Cocone F) (j : J) :
+    colimit.ι F j ≫ colimit.desc F c = c.ι.app j :=
+  CategoryTheory.Limits.colimit.ι_desc c j
+
 end Grothendieck.Limits

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits_en.lean
@@ -278,4 +278,64 @@ theorem colimit_w_natural (F : J ⥤ C) [HasColimit F] {j j' : J} (f : j' ⟶ j)
     F.map f ≫ colimit.ι F j = colimit.ι F j' := by
   rw [CategoryTheory.Limits.colimit.w]
 
+/-!
+## 9. Additional bridges: cone factorisation, extension, and limit cones
+
+The 4 following bridges complete the picture of the fundamental Mathlib 4
+lemmas on limits and colimits:
+  - `limit_lift_π`: the projection `limit.π F j` followed by the `limit.lift`
+    of an arbitrary cone returns exactly the `j`-th component of the cone —
+    the leg that any cone on `F` provides.
+  - `limit_hom_ext_apply`: extension criterion — **two morphisms into the
+    limit that agree on every projection are equal**, application of the
+    `@[ext] lemma limit.hom_ext`.
+  - `limit_lift_cone`: the `limit.lift` of the limit cone is the identity —
+    the limit is a **fixed point** of its own factorisation operation.
+  - `colimit_ι_desc`: dual on the colimit side — the `colimit.desc F c`
+    followed by `colimit.ι F j` of an arbitrary cocone returns the `j`-th
+    component of the cocone.
+
+Pattern winner (L902 ★★ c.8261): explicit universes, direct Mathlib aliases,
+signatures aligned with the source lemma. For `limit.hom_ext` (`@[ext]`),
+application gives the equality lemma, not a function — written explicitly
+with its pointwise arguments.
+-/
+
+/-- Bridge: for any cone `c` on `F`, the projection `limit.π F j` composed
+    with `limit.lift F c` returns the `j`-th component of the cone. This is the
+    **leg that any cone** on the diagram provides, witnessed by the Mathlib
+    lemma `@[reassoc, simp] lemma CategoryTheory.Limits.limit.lift_π F c j`.
+    Namespace theorem (L902 ★★ Tier 4) — direct alias. -/
+theorem limit_lift_π (F : J ⥤ C) [HasLimit F] (c : Cone F) (j : J) :
+    limit.lift F c ≫ limit.π F j = c.π.app j :=
+  CategoryTheory.Limits.limit.lift_π c j
+
+/-- Bridge: extension criterion between the limit and the cone — given
+    two morphisms `f, f' : X ⟶ limit F`, if they coincide on every projection
+    `limit.π F j`, then `f = f'`. This is the lemma
+    `@[ext] lemma CategoryTheory.Limits.limit.hom_ext F {X} (w : ∀ j, ...) :
+    f = f'`. Namespace theorem (L902 ★★ Tier 4) — direct alias. -/
+theorem limit_hom_ext_apply (F : J ⥤ C) [HasLimit F] {X : C} {f f' : X ⟶ limit F}
+    (w : ∀ j, f ≫ limit.π F j = f' ≫ limit.π F j) : f = f' :=
+  CategoryTheory.Limits.limit.hom_ext w
+
+/-- Bridge: the `limit.lift` of the limit cone is the identity — the limit
+    is a fixed point of its own factorisation. Witnessed by the Mathlib lemma
+    `@[simp] lemma CategoryTheory.Limits.limit.lift_cone {F : J ⥤ C}
+    [HasLimit F] : limit.lift F (limit.cone F) = 𝟙 (limit F)`. The `F`
+    is implicit — we omit the explicit argument to let Lean unify it. -/
+theorem limit_lift_cone (F : J ⥤ C) [HasLimit F] :
+    limit.lift F (limit.cone F) = 𝟙 (limit F) :=
+  CategoryTheory.Limits.limit.lift_cone
+
+/-- Bridge: dual on the colimit side — for any cocone `c` on `F`, the
+    injection `colimit.ι F j` composed with `colimit.desc F c` returns the
+    `j`-th component of the cocone. This is the **leg that any cocone** on
+    the diagram provides, witnessed by the Mathlib lemma
+    `@[reassoc, simp] lemma CategoryTheory.Limits.colimit.ι_desc F c j`.
+    Namespace theorem (L902 ★★ Tier 4) — direct alias. -/
+theorem colimit_ι_desc (F : J ⥤ C) [HasColimit F] (c : Cocone F) (j : J) :
+    colimit.ι F j ≫ colimit.desc F c = c.ι.app j :=
+  CategoryTheory.Limits.colimit.ι_desc c j
+
 end Grothendieck.Limits_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #10749 c.8263

See #2159

## Scope

Sub-grain EPIC #2159 (Grothendieck Lean formalization) : `Grothendieck/Limits.lean` + sibling `_en` — 4 bridges additionnels (factorisation des cônes, critère d'extension, point fixe du `limit.lift`, dual colimite).

**Pivot Out DEEP/lean post-c.8263** : après Adjunction (c.8263, 9→13 theoremes), c.8264 cible Limits (Partie 6 hommage Grothendieck, limite/colimite — fondations de la géométrie algébrique). Module riche en #check (12 theos, 23 #check — biggest pull), substance genuinely distincte.

**Justification EPIC #2159** : EPIC parent = GOL (Grothendieck Omnibus Lean), ma lane lead (po-2026 Lean lead explicit). Limits = Partie 6 du plan Grothendieck (33 modules cibles).

## 4 bridges

| # | Theorem/Def | Mathlib source | Substance |
|---|---|---|---|
| 1 | `limit_lift_π` | `@[reassoc, simp] limit.lift_π` | Pour tout cône `c` sur `F`, `limit.lift F c ≫ limit.π F j = c.π.app j` — tige que fournit tout cône sur le diagramme. |
| 2 | `limit_hom_ext_apply` | `@[ext] limit.hom_ext` | Critère d'extension entre limite et cône : deux morphismes coïncidant sur chaque projection sont égaux. |
| 3 | `limit_lift_cone` | `@[simp] limit.lift_cone` | Le `limit.lift` du cône limite est l'identité — la limite est point fixe de sa propre factorisation. |
| 4 | `colimit_ι_desc` | `@[reassoc, simp] colimit.ι_desc` | Dual côté colimites : pour tout cocône `c`, `colimit.ι F j ≫ colimit.desc F c = c.ι.app j`. |

## Acceptance

| Critère | Valeur |
|---|---|
| Fichiers modifiés | 2 (Limits.lean + Limits_en.lean) |
| Insertions | +119 net (FR 59 + EN 60) |
| Deletions | 0 |
| `grep -c sorry` (actif) | 1 (préservé avant/après — match dans docstring "No sorry at creation") |
| Lake build SUCCESS | ✔ 2823 jobs Grothendieck (full) + 647 jobs Grothendieck.Limits (target) |
| check_i18n_siblings.py | OK Limits_en (33/34 pairs byte-identity, 1 consumer-pattern) |
| L947 ★ | SAFE (namespace theorems à args explicites (c, j), signatures alignées sur le lemme source) |
| L902 ★★ Tier 4 | SAFE (Mathlib namespace theorems `limit.lift_π` / `limit.hom_ext` / `limit.lift_cone` / `colimit.ι_desc` à args explicites (c, j) ou `(w : ...)`) |
| L'« allowlist » whitelist axioms | inchangé (native_decide 0, sorryAx 0, Classical.choice 0) |
| Anti-régression §D | OK (0 preuve remplacée par sorry, 0 cellule code touchée existante) |

## Anti-régression (CLAUDE.md §D)

- **0 cellule code touchée existante** : ajout de 4 bridges en section 9 du fichier (avant `end Grothendieck.Limits`), 12 theoremes existants préservés byte-pour-bit (`limit_object`, `colimit_object`, `limit_is_universal`, `colimit_is_universal`, `limit_projection`, `colimit_injection`, `cone_factorisation`, `cocone_factorisation`, `limit_lift_eq`, `colimit_desc_eq`, `limit_w_natural`, `colimit_w_natural`).
- **`grep -c sorry` avant / après** : Limits.lean 1/1 (actif ; match dans docstring `"No sorry at creation"`).
- **L398 ★★** : `git diff --stat` = 2 fichiers, +119 insertions, 0 deletions.
- **L930 ★★** : FR+EN lockstep préservé (check_i18n_siblings.py OK).
- **L903 ★★** : grain tag first line body.

## L902 ★★ Tier mechanics (c.8261 lesson applied)

- **Univers explicites partagés** : scope Limits `universe v₁ v₂ u₁ u₂` (déjà présent) — aligné avec scope Mathlib `Mathlib/CategoryTheory/Limits/HasLimits.lean`.
- **Namespace theorems à args implicites** : `limit.lift_π {F}` / `limit.hom_ext {F} [HasLimit F] {X} {f f'}` / `limit.lift_cone {F}` / `colimit.ι_desc {F}` — la première itération c.8264 a **explicitement passé `F`** alors qu'il est implicite, déclenchant **3 erreurs de type** :
  1. `limit.hom_ext F w` : "expected Prop (= ∀ j ...)" — `F` est appliqué à la place de `w` ;
  2. `limit.lift_cone F` : "Function expected, this is Prop" — `F` est appliqué à la place de l'instance HasLimit ;
  3. `colimit.ι_desc F c j` : "expected Cocone" — `F` est appliqué à la place de `c`.
- **Fix** : omettre l'argument implicite `{F}` dans le corps, laisser Lean l'unifier avec le `F` du bridge.

**Leçon** : pour un namespace theorem Mathlib `{F : J ⥤ C} [HasLimit F] (c : Cone F) (j : J) : ...`, le bridge propre est `(c j)`, **PAS `(F c j)`**. La signature implicite doit rester implicite. C'est l'inverse de la convention « on rend tout explicite pour la lisibilité » qui s'applique aux structures mais pas aux namespaces theorem.

## Tell d'erreur (c.8264 leçon non-encore-ancrée)

Si un bridge de la forme `:= CategoryTheory.X.foo` produit l'une des 3 erreurs ci-dessus (et que les signatures semblent par ailleurs correctes), c'est **PAS un pb de namespace shadow** mais **un pb de passage d'args implicites explicites**. Vérifier la signature source et omettre les `{X}` du corps du bridge.

## B.2 ★★ Lake build SUCCESS post-modif

`lake exe cache get` : 43434 ms cache AZ partagé, déjà populé par les builds antérieurs (8473 fichiers Mathlib — cache stable). Limits.lean + _en.lean rebuild = 647 jobs pour la cible (rebuild du fichier et de ses imports directs), final = lake complet 2823 jobs SUCCESS. 0 erreur compile, 0 warning. Les `info:` en sortie sont les `#check` du fichier qui impriment les types — comportement attendu (Info, pas warning).

## L945 ★ (c.8257) reuse pattern

Append-only modification : 4 bridges ajoutés en section 9 du fichier (avant `end Grothendieck.Limits`), pas de reformat, pas de ré-écriture des theoremes existants. Préserve list-of-strings du source. Diff minimal +119/0.

## G-VAR audit

- **G-VAR-1 PLATEAU** : DEEP/lean = CONTENU (substance genuinely distincte = bridges alias Mathlib propres in-file, pas regen catalogue).
- **G-VAR-2 OK** : 0 LIGHT ce cycle.
- **G-VAR-3 OK** : grain précédent c.8263 = DEEP/lean #10749 Adjunction (free/forget adjunctions + equivalence promotion + constructor coherence). Sub-grain c.8264 = DEEP/lean Limits (limites/colimites, factorisation + extension + point fixe + dual colimite). **Substance genuinely distincte** : (a) Adjunction = unit/counit components + equivalence criterion + constructor preservation, Limits = cone factorisation + ext criterion + fixed point + dual colimit ; (b) batteries Mathlib distinctes (`Adjunction/Basic.lean` vs `Limits/HasLimits.lean`) ; (c) 4 bridges Adjunction ≠ 4 bridges Limits.

## Suite possible c.8264+1

- **Pivot Out** : relever 1-2 modules parmi les ~16 restants (Monads #10730 OPEN, ConstantSheaf #10679 OPEN, Equivalences #10718 OPEN, Conservative, DirectImage, Comma, YonedaLemma, SieveOps #10747 OPEN par autre lane, SieveLattice, SieveGenerate, LeftExact, CategoryAndSites, SchemesTour, Subcanonical, ZariskiSite, Calibration, MathlibMap) — candidats riches en #check après exclusions.
- **Limits suite** : ~12 #check restants après ce PR = bridges supplémentaires possibles (`HasLimits` instances, `limit.cone_morphism`, `limit.cone_pt`, `Limit.lift_uniq`, `Limit.ext`, `colimit.cocone_morphism`, `colimit.cocone_pt`, `Colimit.desc_uniq`, `Colimit.ext`, etc.).

## L883 ★ `See #N` (sub-grain)

Cette PR est une contribution à EPIC #2159 (GOL Plot parent). Suivre 6 bridges batches antérieurs : Construction #10666 MERGED, SheafHom #10668 MERGED, SitePoints #10739 MERGED, SheafBasics #10741 MERGED, MayerVietorisSquare #10744 MERGED, Adjunction #10749 MERGED. Issue #2159 reste ouverte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
