### PR TITLE
fix(harness,#10752): replace stale `Claude <Model> <ver>` Co-Authored-By with `Claude-Code` in 2 templates

### DIFF
--- a/.claude/agents/notebook-iterative-builder.md
+++ b/.claude/agents/notebook-iterative-builder.md
@@ -673,7 +673,7 @@ if auto_commit and current_score >= quality_target:
 - Cells modified: {cells_modified}
 - Cells added: {cells_added}
 
-Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
+Co-Authored-By: Claude-Code <noreply@anthropic.com>
 """
 
     run_command(f"git add {notebook_path}")

--- a/.claude/skills/review-student-prs/SKILL.md
+++ b/.claude/skills/review-student-prs/SKILL.md
@@ -129,7 +129,7 @@ For each VALID exercise (skip if `--dry-run`):
    - Reviewed and validated during TP <date>
 
    Co-Authored-By: <Student Name> <student-email-if-available>
-   Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+   Co-Authored-By: Claude-Code <noreply@anthropic.com>
    ```
 
 5. **Push** to main (after all PRs for the session are processed)


### PR DESCRIPTION
fix(harness,#10752): replace stale `Claude <Model> <ver>` Co-Authored-By with `Claude-Code` in 2 templates

Grain: LIGHT/docs — lane myia-po-2024:CoursIA-2 — prev: MED/test #10710

## Symptôme (firsthand, mesuré c.1331+124)

Deux fichiers du harnais (.claude/) référençaient un modèle de Claude **en dur** dans leur template `Co-Authored-By`, alors qu'aucun de ces modèles n'a tourné depuis > 6 mois :

- `.claude/skills/review-student-prs/SKILL.md:132` → `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` (template de commit, suivi verbatim par chaque PR étudiante mergée via ce skill).
- `.claude/agents/notebook-iterative-builder.md:676` → `Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>` (exemple dans la docstring de l'agent).

Conséquence : chaque commit signé par ces 2 outils embarquait le **mensonge matériel** d'un co-auteur `Claude Opus 4.6` ou `Claude Sonnet 4.5` — alors que :
1. **Aucun de ces modèles n'a tourné depuis des mois** (cf CLAUDE.md global §Git ligne 27 qui prescrit `Co-Authored-By: Claude-Code <noreply@anthropic.com>` sans version).
2. Aujourd'hui (2026-08-13), le forfait Anthropic est **plafonné** et le failover passe Qwen 3.8 → GLM.

La convention `Claude-Code` existe déjà dans CLAUDE.md global et a été adoptée par les commits récents ; elle n'avait juste pas été propagée à ces 2 fichiers.

## Cause

Migration du bot `Claude Code` → `Opus 4.6` → `Sonnet 4.5` → `Opus 4.7` → ... → `Opus 5.x` (avec failover Qwen/GLM en 2026-08) **sans mise à jour systématique des fichiers `.claude/skills/*/SKILL.md` et `.claude/agents/*.md`**.

C'est un **trou dans la raquette** : la règle "ne pas citer de modèle fixe" était appliquée au niveau global (CLAUDE.md §27) mais ces 2 fichiers du harnais étaient passés entre les gouttes.

## Correctif (Phase 1 de #10752)

Substitution textuelle dans 2 fichiers :

| Fichier | Ligne | Avant | Après |
|---|---|---|---|
| `.claude/skills/review-student-prs/SKILL.md` | 132 | `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` | `Co-Authored-By: Claude-Code <noreply@anthropic.com>` |
| `.claude/agents/notebook-iterative-builder.md` | 676 | `Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>` | `Co-Authored-By: Claude-Code <noreply@anthropic.com>` |

## Validation locale

```bash
# Test post-fix : aucune référence "Claude (Opus|Sonnet|Haiku) <version>" dans .claude/
$ grep -rnE 'Co-Authored-By.*Claude (Opus|Sonnet|Haiku) [0-9]+\.[0-9]+' .claude/
(aucun résultat)
```

```bash
# Test post-fix : seules les références canoniques "Claude-Code" subsistent
$ grep -rn 'Co-Authored-By.*Claude' .claude/
.claude/skills/review-student-prs/SKILL.md:132:   Co-Authored-By: Claude-Code <noreply@anthropic.com>
.claude/agents/notebook-iterative-builder.md:676:Co-Authored-By: Claude-Code <noreply@anthropic.com>
```

```bash
$ git diff --stat
 .claude/agents/notebook-iterative-builder.md | 2 +-
 .claude/skills/review-student-prs/SKILL.md   | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
```

## Phase 2 (recommandée, pas dans cette PR)

Issue #10752 propose aussi Phase 2 = ajouter un grep guard dans la CI (`G-VAR` ou `pre-commit`) qui rougit sur tout `Co-Authored-By: Claude (Opus|Sonnet|Haiku) [0-9]+\.[0-9]+` dans `.claude/**`. Cette PR ne contient que la Phase 1 (substitution) pour rester sub-LIGHT/docs. La Phase 2 pourra être livrée séparément (grain `guard`) si le coordinateur le provisionne.

## Phase 3 (optionnelle, hors `.claude/`)

Issue #10752 mentionne aussi 2 références dans `MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_SUMMARY.md` et `RESEARCH_FINDINGS.md` ("**Auteur**: Claude Opus 4.6 (qc-research-notebook agent)"). Ces fichiers ne sont pas dans `.claude/` mais portent la même étiquette obsolète. **Hors scope de cette PR** (grain différent, partition QC = po-2023), à traiter dans une PR séparée si le sujet intéresse.

## Anti-régression (CRITICAL)

- **PAS de modification catalogue** : aucun fichier `COURSE_CATALOG.generated.*` touché (catalog-pr-hygiene R1).
- **PAS de modification de notebooks** : pure édition de 2 fichiers markdown du harnais.
- **PAS de changement de comportement fonctionnel** : seuls les strings de signature de commit changent. Aucun code Python/C#/Lean exécuté, aucun test exécuté, aucun notebook re-exécuté.
- **PAS de modification de PRs historiques** : les commits antérieurs restent avec leur signature d'époque (pas de rewrite history). La correction prend effet à partir de ce commit.

## Conformité règles

- **catalog-pr-hygiene R1** : 0 modif catalogue (pure harnais). ✓
- **proactive-coordination R5** : L940 ★ triage appliqué, pool drainé pour ma partition CPU/.NET, livraison d'un vrai bug fix first-hand identifié. ✓
- **variation-protocol G-VAR-1** : grain LIGHT/docs (sub-LIGHT) **ne satisfait pas le plancher G-VAR-1** par conception (pas de grain DEEP/MED CONTENTU disponible, R7 honnête). Signalé explicitement dans le rapport [DONE] dashboard. ✓
- **variation-protocol G-VAR-3** : grain précédent = MED/test #10710 (c.1331+123). Ce grain = LIGHT/docs. **Genres distincts** (test vs docs) → G-VAR-3 OK. ✓
- **git-workflow** : branche `feature/c1331x124-harness-coauthor-stale` créée depuis origin/main, worktree isolé, pas de force push attendu (premier push). ✓
- **CLAUDE.md global "Read Body Before Any Action"** : body de cette PR décrit ce qui est modifié ; pas de claim non-vérifié. ✓
- **L677-L4 ★★** : body PR généré HORS worktree (scratchpad path), via `--body-file`. ✓
- **L898 ★★★** : `gh pr list --search "Co-Authored-By Claude 4.6 OR review-student-prs OR notebook-iterative-builder"` = 0 collision cross-lane. ✓
- **secrets-hygiene** : aucune clé, aucun secret, juste 2 strings de signature. ✓

## Scope total

- **+2/-2 lignes, 2 fichiers**. Largement sous les seuils CHANGES_REQUESTED (3000 lignes / 15 fichiers / 4 features / 1 domaine).
- **0 nouvelle dep, 0 script, 0 notebook, 0 test** — pure édition textuelle du harnais.
- **Partition** : `harnais` (.claude/skills + .claude/agents) = sous-domaine de la lane `CoursIA-2` (CLAUDE.md §A "agents review et merge").

## Origine

Issue **#10752** créée c.1331+124 après signalement user 2026-08-13 ("il doit y avoir un template obsolète quelque part... on a déjà du changer une fois pour mettre 'Co-Authored-By: Claude-Code'... visiblement il y avait un trou dans la raquette"). Mesuré firsthand par `grep -rnE 'Co-Authored-By.*Claude' .claude/` qui a révélé les 2 fichiers.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
