### PR TITLE
feat(lean,#2159): KanExtensions.lean — 4 theoremes/decls ponts additionnels

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions.lean
@@ -324,4 +324,76 @@ noncomputable def dense_functor_left_kan_extension_iso_id (F : C ⥤ D) [F.IsDen
     F.leftKanExtension F ≅ 𝟭 D :=
   CategoryTheory.Functor.IsDense.leftKanExtensionIso F
 
+/-!
+## 9. Ponts additionnels : factorisation duale, bijection naturelle, densité Yoneda
+
+Les 4 ponts suivants complètent le tableau des lemmes Mathlib 4 fondamentaux
+sur les extensions de Kan, en couvrant les branches symétriques des bridges
+existants (10 → 14 theoremes/decls) :
+  - `kan_lift_fac` : dual côté **droite** de `kan_descent_fac` — la factorisation
+    universelle d'un Kan droite vérifie sa condition de factorisation.
+  - `kan_right_hom_equiv` : bijection naturelle `(G ⟶ F') ≃ (L ⋙ G ⟶ F)` pour
+    une Kan droite — symétrique pointwise du `homEquiv` de l'adjonction.
+  - `dense_left_kan_unit_iso` : pour un foncteur dense `F`, l'unité de son
+    extension de Kan gauche le long de lui-même composée avec l'isomorphisme
+    `leftKanExtension F ≅ 𝟭 D` vaut `rightUnitor.inv` (NatTrans-level).
+  - `dense_left_kan_unit_iso_app` : version pointwise du précédent, descendu
+    à `app X` pour `X : C` — la cohérence vue sur chaque objet.
+
+Pattern winner (L902 ★★ c.8261) : univers explicites, alias directs Mathlib,
+signatures alignées sur le lemme source. Pour les lemmes dans `section`
+Mathlib (lift/homEquiv sont sous `variable (F') {L F} (α) [IsRightKanExtension α]`)
+on **doit** passer toutes les variables en argument.
+-/
+
+/-- Pont : dual côté **droite** de `kan_descent_fac` — pour une extension de
+    Kan à droite `(F', α)`, la factorisation universelle
+    `liftOfIsRightKanExtension α G β : G ⟶ F'` vérifie sa condition de
+    factorisation `whiskerLeft L (lift) ≫ α = β`. C'est le symétrique
+    de `kan_descent_fac` (côté gauche), démontré par le lemme Mathlib
+    `@[reassoc, simp] lemma CategoryTheory.Functor.liftOfIsRightKanExtension_fac`.
+    Namespace theorem (L902 ★★ Tier 4) — alias direct avec args explicites
+    (lemme dans une `section` Mathlib, toutes les variables doivent
+    être passées). -/
+theorem kan_lift_fac {L : C ⥤ D} {F : C ⥤ H} {F' : D ⥤ H}
+    (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α] (G : D ⥤ H) (β : L ⋙ G ⟶ F) :
+    CategoryTheory.Functor.whiskerLeft L (F'.liftOfIsRightKanExtension α G β) ≫ α = β :=
+  CategoryTheory.Functor.liftOfIsRightKanExtension_fac F' α G β
+
+/-- Pont : bijection naturelle `(G ⟶ F') ≃ (L ⋙ G ⟶ F)` pour une extension
+    de Kan à droite `(F', α)`. Symétrique pointwise de l'homEquiv d'une
+    adjonction — la propriété universelle encodée comme **équivalence**
+    (et non comme deux flèches adjointes). C'est le lemme Mathlib
+    `@[simps!] noncomputable def CategoryTheory.Functor.homEquivOfIsRightKanExtension`.
+    Namespace def (L902 ★★ Tier 4) — alias direct, args explicites. -/
+noncomputable def kan_right_hom_equiv {L : C ⥤ D} {F : C ⥤ H} {F' : D ⥤ H}
+    (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α] (G : D ⥤ H) :
+    (G ⟶ F') ≃ (L ⋙ G ⟶ F) :=
+  CategoryTheory.Functor.homEquivOfIsRightKanExtension F' α G
+
+/-- Pont : pour un foncteur dense `F : C ⥤ D`, l'unité de son extension de
+    Kan gauche le long de lui-même composée avec l'isomorphisme
+    `leftKanExtension F ≅ 𝟭 D` vaut `rightUnitor.inv` au niveau NatTrans.
+    C'est le lemme Mathlib
+    `@[reassoc, simp] lemma CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom`.
+    Namespace theorem (L902 ★★ Tier 4) — alias direct. -/
+theorem dense_left_kan_unit_iso (F : C ⥤ D) [F.IsDense] :
+    F.leftKanExtensionUnit F ≫
+      F.whiskerLeft (Functor.IsDense.leftKanExtensionIso F).hom = F.rightUnitor.inv :=
+  CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom F
+
+/-- Pont : version pointwise de `dense_left_kan_unit_iso` — descendu à
+    `app X` pour `X : C`, la cohérence devient :
+    `(leftKanExtensionUnit F).app X ≫ (leftKanExtensionIso F).hom.app (F.obj X)
+     = F.rightUnitor.inv.app X`.
+    C'est le lemme Mathlib
+    `@[reassoc, simp] lemma CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom_app`.
+    Namespace theorem (L902 ★★ Tier 4) — alias direct. Le `{F.IsDense}`
+    implicite est auto-déduit du scope du bridge. -/
+theorem dense_left_kan_unit_iso_app (F : C ⥤ D) [F.IsDense] (X : C) :
+    (F.leftKanExtensionUnit F).app X ≫
+      (Functor.IsDense.leftKanExtensionIso F).hom.app (F.obj X) =
+        F.rightUnitor.inv.app X :=
+  CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom_app F X
+
 end Grothendieck.KanExtensions

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions_en.lean
@@ -318,4 +318,76 @@ noncomputable def dense_functor_left_kan_extension_iso_id (F : C ⥤ D) [F.IsDen
     F.leftKanExtension F ≅ 𝟭 D :=
   CategoryTheory.Functor.IsDense.leftKanExtensionIso F
 
+/-!
+## 9. Additional bridges: dual factorisation, natural bijection, Yoneda density
+
+The 4 following bridges complete the picture of the fundamental Mathlib 4
+lemmas on Kan extensions, covering the symmetric branches of the existing
+bridges (10 → 14 theorems/decls):
+  - `kan_lift_fac`: dual on the **right** side of `kan_descent_fac` — the
+    universal factorisation of a right Kan verifies its factorisation
+    condition.
+  - `kan_right_hom_equiv`: natural bijection `(G ⟶ F') ≃ (L ⋙ G ⟶ F)` for
+    a right Kan — pointwise symmetric of the adjunction `homEquiv`.
+  - `dense_left_kan_unit_iso`: for a dense functor `F`, the unit of its
+    left Kan extension along itself composed with the isomorphism
+    `leftKanExtension F ≅ 𝟭 D` equals `rightUnitor.inv` (NatTrans-level).
+  - `dense_left_kan_unit_iso_app`: pointwise version of the previous one,
+    descended to `app X` for `X : C` — the coherence seen on each object.
+
+Pattern winner (L902 ★★ c.8261): explicit universes, direct Mathlib aliases,
+signatures aligned with the source lemma. For lemmas in Mathlib `section`
+(lift/homEquiv are under `variable (F') {L F} (α) [IsRightKanExtension α]`)
+all variables must be passed explicitly.
+-/
+
+/-- Bridge: dual on the **right** side of `kan_descent_fac` — for a right
+    Kan extension `(F', α)`, the universal factorisation
+    `liftOfIsRightKanExtension α G β : G ⟶ F'` verifies its factorisation
+    condition `whiskerLeft L (lift) ≫ α = β`. This is the symmetric of
+    `kan_descent_fac` (left side), witnessed by the Mathlib lemma
+    `@[reassoc, simp] lemma CategoryTheory.Functor.liftOfIsRightKanExtension_fac`.
+    Namespace theorem (L902 ★★ Tier 4) — direct alias with explicit args
+    (lemma inside a Mathlib `section`, all variables must be passed). -/
+theorem kan_lift_fac {L : C ⥤ D} {F : C ⥤ H} {F' : D ⥤ H}
+    (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α] (G : D ⥤ H) (β : L ⋙ G ⟶ F) :
+    CategoryTheory.Functor.whiskerLeft L (F'.liftOfIsRightKanExtension α G β) ≫ α = β :=
+  CategoryTheory.Functor.liftOfIsRightKanExtension_fac F' α G β
+
+/-- Bridge: natural bijection `(G ⟶ F') ≃ (L ⋙ G ⟶ F)` for a right Kan
+    extension `(F', α)`. Pointwise symmetric of the adjunction `homEquiv` —
+    the universal property encoded as an **equivalence** (not as two
+    adjoint arrows). This is the Mathlib lemma
+    `@[simps!] noncomputable def CategoryTheory.Functor.homEquivOfIsRightKanExtension`.
+    Namespace def (L902 ★★ Tier 4) — direct alias, explicit args. -/
+noncomputable def kan_right_hom_equiv {L : C ⥤ D} {F : C ⥤ H} {F' : D ⥤ H}
+    (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α] (G : D ⥤ H) :
+    (G ⟶ F') ≃ (L ⋙ G ⟶ F) :=
+  CategoryTheory.Functor.homEquivOfIsRightKanExtension F' α G
+
+/-- Bridge: for a dense functor `F : C ⥤ D`, the unit of its left Kan
+    extension along itself composed with the isomorphism
+    `leftKanExtension F ≅ 𝟭 D` equals `rightUnitor.inv` at the NatTrans
+    level. This is the Mathlib lemma
+    `@[reassoc, simp] lemma CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom`.
+    Namespace theorem (L902 ★★ Tier 4) — direct alias. -/
+theorem dense_left_kan_unit_iso (F : C ⥤ D) [F.IsDense] :
+    F.leftKanExtensionUnit F ≫
+      F.whiskerLeft (Functor.IsDense.leftKanExtensionIso F).hom = F.rightUnitor.inv :=
+  CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom F
+
+/-- Bridge: pointwise version of `dense_left_kan_unit_iso` — descended to
+    `app X` for `X : C`, the coherence becomes:
+    `(leftKanExtensionUnit F).app X ≫ (leftKanExtensionIso F).hom.app (F.obj X)
+     = F.rightUnitor.inv.app X`.
+    This is the Mathlib lemma
+    `@[reassoc, simp] lemma CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom_app`.
+    Namespace theorem (L902 ★★ Tier 4) — direct alias. The `{F.IsDense}`
+    implicit is auto-deduced from the bridge scope. -/
+theorem dense_left_kan_unit_iso_app (F : C ⥤ D) [F.IsDense] (X : C) :
+    (F.leftKanExtensionUnit F).app X ≫
+      (Functor.IsDense.leftKanExtensionIso F).hom.app (F.obj X) =
+        F.rightUnitor.inv.app X :=
+  CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom_app F X
+
 end Grothendieck.KanExtensions_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #10751 c.8264

See #2159

## Scope

Sub-grain EPIC #2159 (Grothendieck Lean formalization) : `Grothendieck/KanExtensions.lean` + sibling `_en` — 4 bridges additionnels (factorisation duale droite, bijection naturelle, cohérence densité Yoneda au niveau NatTrans + pointwise).

**Pivot Out DEEP/lean post-c.8264** : après Limits (c.8264, 12→16 theoremes), c.8265 cible KanExtensions (Partie 31 — la table des matières dit 31, le README dit 28 — je laisse 31, le code source module fait foi). Module 10 theos + 22 #check, 18 #check restants post-c.8228 (4 bridges MERGED). Plan : 4 nouveaux bridges symétriques aux bridges existants (fact gauche `kan_descent_fac` ⇄ fact droite `kan_lift_fac`).

**Justification EPIC #2159** : EPIC parent = GOL (Grothendieck Omnibus Lean), ma lane lead (po-2026 Lean lead explicit). KanExtensions = module post-Limits dans le plan Grothendieck (33 modules cibles).

## 4 bridges

| # | Theorem/Def | Mathlib source | Substance |
|---|---|---|---|
| 1 | `kan_lift_fac` | `@[reassoc, simp] liftOfIsRightKanExtension_fac` | Dual côté **droite** de `kan_descent_fac` — la factorisation `liftOfIsRightKanExtension α G β : G ⟶ F'` vérifie `whiskerLeft L (lift) ≫ α = β`. Symétrie pointwise. |
| 2 | `kan_right_hom_equiv` | `@[simps!] noncomputable def homEquivOfIsRightKanExtension` | Bijection naturelle `(G ⟶ F') ≃ (L ⋙ G ⟶ F)` pour une Kan droite — symétrique de l'homEquiv d'adjonction (équivalence au lieu de deux flèches adjointes). |
| 3 | `dense_left_kan_unit_iso` | `@[reassoc, simp] IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom` | Pour un foncteur dense `F`, l'unité de son extension de Kan gauche le long de lui-même composée avec l'isomorphisme `leftKanExtension F ≅ 𝟭 D` vaut `rightUnitor.inv` (NatTrans-level). |
| 4 | `dense_left_kan_unit_iso_app` | `@[reassoc, simp] IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom_app` | Version pointwise du précédent, descendu à `app X` pour `X : C` — la cohérence vue sur chaque objet. |

## Acceptance

| Critère | Valeur |
|---|---|
| Fichiers modifiés | 2 (KanExtensions.lean + KanExtensions_en.lean) |
| Insertions | +144 net (FR 72 + EN 72) |
| Deletions | 0 |
| `grep -c sorry` (actif) | 0 (2 matches inactifs dans docstrings "sorry éliminés") |
| Lake build SUCCESS | ✔ 2823 jobs Grothendieck (full) + 947 jobs Grothendieck.KanExtensions |
| check_i18n_siblings.py | 33/34 pairs byte-identical, 1 consumer-pattern, 0 drift |
| L947 ★ | SAFE (namespace theorems / defs explicites, signatures alignées sur le lemme source) |
| L902 ★★ Tier 4 | SAFE (lemmes dans `section` Mathlib ⇒ args toutes passées explicitement) |
| L'« allowlist » whitelist axioms | inchangé (native_decide 0, sorryAx 0, Classical.choice 0) |
| Anti-régression §D | OK (0 preuve remplacée par sorry, 0 cellule code touchée existante) |

## Anti-régression (CLAUDE.md §D)

- **0 cellule code touchée existante** : ajout de 4 bridges en section 9 du fichier (avant `end Grothendieck.KanExtensions`), 10 theoremes/decls existants préservés byte-pour-bit (`kan_extension_left`, `kan_extension_right`, `kan_extension_left_unit`, `kan_extension_right_counit`, `lan_functor`, `kan_descent`, `lan_functor_is_left_adjoint_to_precomp`, `lan_unit_eq_lan_adjunction_unit`, `kan_descent_fac`, `dense_functor_left_kan_extension_iso_id`).
- **`grep -c sorry` avant / après** : 2/2 (inactifs dans docstrings "sorry éliminés", pas de sorry actif).
- **L398 ★★** : `git diff --stat` = 2 fichiers, +144 insertions, 0 deletions.
- **L930 ★★** : FR+EN lockstep préservé (check_i18n_siblings.py OK).
- **L903 ★★** : grain tag first line body.

## L902 ★★ Tier mechanics (c.8261 lesson applied)

- **Univers explicites partagés** : scope KanExtensions `universe v₁ v₂ v₃ u₁ u₂ u₃` (déjà présent) — aligné avec scope Mathlib `Mathlib/CategoryTheory/Functor/KanExtension/Basic.lean` et `Dense.lean`.
- **Namespace theorem vs field** : lift/homEquiv lemmes sont dans une `section` Mathlib avec `variable (F') {L F} (α) [IsRightKanExtension α]`. Le bridge doit donc passer **toutes les variables** explicitement : `CategoryTheory.Functor.liftOfIsRightKanExtension_fac F' α G β` et `CategoryTheory.Functor.homEquivOfIsRightKanExtension F' α G`. Symétrique à L950 (args implicites) mais distinct : L950 = omettre l'arg implicite, ici c'est **passer l'arg de section** explicitement.
- **Tell d'erreur symétrique** : `Unknown identifier 'whiskerLeft'`. `whiskerLeft` est dans `namespace Functor` (`Mathlib/CategoryTheory/Whiskering.lean`), pas `CategoryTheory`. **Fix** : `CategoryTheory.Functor.whiskerLeft L ...`. C'est la même leçon qu'en c.8263 (Adjunction) — `whiskerLeft`/`whiskerRight` namespace `Functor`, pas `CategoryTheory`.

## Point d'attention (L902 ★★ NEW c.8265)

Pour les lemmes Mathlib sous `section` Mathlib (ex. `liftOfIsRightKanExtension_fac`), toutes les variables de la section doivent être passées en argument du bridge. Le corps du bridge :

```lean
theorem kan_lift_fac {L : C ⥤ D} {F : C ⥤ H} {F' : D ⥤ H}
    (α : L ⋙ F' ⟶ F) [F'.IsRightKanExtension α] (G : D ⥤ H) (β : L ⋙ G ⟶ F) :
    CategoryTheory.Functor.whiskerLeft L (F'.liftOfIsRightKanExtension α G β) ≫ α = β :=
  CategoryTheory.Functor.liftOfIsRightKanExtension_fac F' α G β
```

Note : `L` est `{L}` (implicite) dans la signature du bridge mais passé **explicitement** dans `CategoryTheory.Functor.whiskerLeft L` (notation fonction) puis **implicite** dans `CategoryTheory.Functor.liftOfIsRightKanExtension_fac F' α G β` (le `L` est absorbé par la `section` Mathlib). Différence subtile entre namespace-resolve et field-resolve.

## Tell d'erreur symétrique c.8265

`error: Unknown identifier 'whiskerLeft'` ⇒ `whiskerLeft`/`whiskerRight` namespace `CategoryTheory.Functor`, pas `CategoryTheory`. **Fix** : `CategoryTheory.Functor.whiskerLeft`. Souvenir c.8263 (Adjunction).

## B.2 ★★ Lake build SUCCESS post-modif

`lake exe cache get` : 51517 ms cache AZ partagé, déjà populé par c.8260-c.8264 (8473 fichiers Mathlib). KanExtensions.lean + _en.lean rebuild = 947 jobs pour la cible, final = lake complet 2823 jobs SUCCESS. 0 erreur compile, 0 warning. Les `info:` en sortie sont les `#check` du fichier — comportement attendu.

## L945 ★ (c.8257) reuse pattern

Append-only modification : 4 bridges ajoutés en section 9 du fichier (avant `end Grothendieck.KanExtensions`), pas de reformat, pas de ré-écriture des theoremes existants. Diff minimal +144/0.

## G-VAR audit

- **G-VAR-1 PLATEAU** : DEEP/lean = CONTENU (substance genuinely distincte = bridges alias Mathlib propres in-file, pas regen catalogue).
- **G-VAR-2 OK** : 0 LIGHT ce cycle.
- **G-VAR-3 OK** : grain précédent c.8264 = DEEP/lean #10751 Limits (factorisation cônes + extension + point fixe + dual colimite). Sub-grain c.8265 = DEEP/lean KanExtensions (factorisation droite + bijection naturelle + densité Yoneda NatTrans + pointwise). **Substance genuinely distincte** : (a) Limits = cone factorisation + ext criterion + fixed point + dual colimit, KanExtensions = right Kan factorisation + natural bijection + density coherence NatTrans + pointwise. (b) batteries Mathlib distinctes (`Limits/HasLimits.lean` vs `Functor/KanExtension/{Basic,Dense}.lean`). (c) 4 bridges Limits ≠ 4 bridges KanExtensions.

## Pachinko c.8265

Initial pivot Out #10430 (check_twin_parity silent no-op) abandonné à cause de PR #10434 MERGED (fae68665b) — **L898 ★★★ aurait dû attraper avant claim**. Issue #10430 marquée `[RELEASED]`. Re-pivot Out vers KanExtensions. Leçon : **`gh pr list --search` n'attrape pas les PRs MERGED par défaut** — toujours croiser avec `--state all` pour les PRs de guard/tooling qui auraient pu être mergées récemment.

## Suite possible c.8265+1

- **Pivot Out** : relever 1 module parmi les ~14 restants (DirectImage, Comma, YonedaLemma, LeftExact, CategoryAndSites, SchemesTour, Subcanonical, ZariskiSite, Calibration, MathlibMap) — tous clean (pas de PR ouverte).
- **KanExtensions suite** : 18 #check restants post-c.8265 — bridges supplémentaires possibles (`hom_ext_of_isRightKanExtension` symétrie de `hom_ext_of_isLeftKanExtension`, `IsDense.iff_of_iso`, `IsDense.comp_left_iff_of_isEquivalence`, `IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom` symétrie droite, etc.).

## L883 ★ `See #N` (sub-grain)

Cette PR est une contribution à EPIC #2159 (GOL Plot parent). Suivre 7 bridges batches antérieurs : Construction #10666 MERGED, SheafHom #10668 MERGED, SitePoints #10739 MERGED, SheafBasics #10741 MERGED, MayerVietorisSquare #10744 MERGED, Adjunction #10749 MERGED, Limits #10751 MERGED. Issue #2159 reste ouverte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
