### PR TITLE
fix(twin-parity,#10430): exit code 1 when audit header unfindable on --update

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -1474,12 +1474,28 @@ def main(argv=None) -> int:
             "normaliser (strip_probe_banner / strip_machine_paths / scrub_papermill), "
             "refaites --update en dernier, apres (cf #8957)."
         )
-        # Exit code : 0 si tout va bien (ecrit + no_op informatif). Mais si
-        # TOUTES les paires cibles sont en no-op refusees (donc 0 ecrit, 0
-        # skipped, >0 refusees), c'est un signal que --update etait inutile
-        # -- on retourne 0 quand meme (le worker a fait ce qu'il a demande,
-        # on l'a juste informe que c'etait un no-op). Exit code 1 reserve
-        # aux erreurs (cf path `Aucune paire nommee` au-dessus).
+        # Exit code (#10430 acceptance) :
+        #   0 = ecrit OK (peut inclure des no_op informes sur stderr)
+        #   1 = au moins une paire DEMANDEE n'a pas pu etre ecrite parce que
+        #       son bloc d'audit etait introuvable / indentation non reconnue.
+        #       L'AVERTISSEMENT ci-dessus a deja liste les paires concernees ;
+        #       l'exit non-zero est le signal que le worker doit inspecter
+        #       l'indentation et relancer --update (ou investiguer le fichier).
+        #   2 = aucun nom de paire trouve (path `Aucune paire nommee` plus haut).
+        # Le commentaire historique qui disait « 0 meme si toutes les cibles
+        # etaient no-op » est REVOQUE ici : un worker qui voit exit=0 et 0
+        # ligne ecrite conclut legitimement « rien a faire ». Si le probleme
+        # reel est que le scanner est aveugle (entrees manquees), c'est
+        # INVISIBLE. L'exit 1 ferme la boucle.
+        # Garder la garde sur les paires skippees (`notebook absent de git`)
+        # en dehors de cette logique : ce n'est PAS un failed-rebaseline, juste
+        # une mise en garde environnementale.
+        if reg_path.is_dir():
+            if missing_header:
+                return 1
+        else:
+            if updated < len(updates):
+                return 1
         return 0
 
     # --- Mode --verify-recorded-sha : gate CI (#9399 volet b) ---

--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import datetime as dt
 import importlib.util
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -555,3 +556,129 @@ def test_touched_zero_when_header_genuinely_absent():
     out, touched = ctp.surgical_rebaseline(raw, {"NoAuditPair": new})
     assert touched == 0
     assert out == raw, "aucun header => byte-identique (la CLI le signale en AVERTISSEMENT)"
+
+
+def test_cli_exit_nonzero_when_header_missing(tmp_path):
+    """#10430 acceptance residuelle : la CLI doit exit 1 (pas 0) quand une
+    paire demandee n'a pas pu etre ecrite parce que son bloc audit est absent.
+
+    C'est la moitie de l'acceptance que PR #10434 n'a pas livree : elle a
+    corrige le regex + loud-fail imprimant AVERTISSEMENT, mais le return 0
+    final laisse le worker conclure « rien a faire » quand le scanner est
+    aveugle. Le residu est comble ici : exit=1 si `missing_header`,
+    exit=0 sinon (no_op legit tolere).
+
+    Le notebook existe dans git ; seul le YAML de la paire perd son bloc
+    audit. C'est exactement le scenario #10430 (`app-10-portfolio`).
+    """
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.ipynb").write_text("{}", encoding="utf-8")
+    (repo / "b.ipynb").write_text("{}", encoding="utf-8")
+    reg = repo / "twin_pairs.d"
+    reg.mkdir()
+    (reg / "_schema.yaml").write_text("# schema\n", encoding="utf-8")
+    target = reg / "NoAuditPair.yaml"
+    target.write_text(
+        "- name: NoAuditPair\n"
+        "  family: Test\n"
+        "  python: a.ipynb\n"
+        "  csharp: b.ipynb\n",
+        encoding="utf-8",
+    )
+    # git init + commit pour que `_git_blob_sha` puisse rendre un SHA non-None
+    # (sinon la CLI court-circuite en skipped -> 'Ignorees' -> pas loud-fail).
+    _git_init_commit(repo)
+
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--repo-root", str(repo),
+         "--registry", str(reg),
+         "--update", "--pair", "NoAuditPair", "--by", "test-lane"],
+        capture_output=True, text=True,
+    )
+    # AVERTISSEMENT loud doit etre sur stderr.
+    assert "AVERTISSEMENT" in out.stderr or "AVERTISSEMENT" in out.stdout, (
+        f"AVERTISSEMENT attendu ; stdout={out.stdout!r} stderr={out.stderr!r}"
+    )
+    # Exit code NON-ZERO : c'est la moitie manquante du fix #10430.
+    assert out.returncode == 1, (
+        f"exit code attendu = 1 (header introuvable), "
+        f"obtenu = {out.returncode}. stdout={out.stdout!r} stderr={out.stderr!r}"
+    )
+    # Et le fichier n'a pas ete reecrit (no write on silent fail).
+    assert "NoAuditPair" in target.read_text(encoding="utf-8")
+    assert "audits:" not in target.read_text(encoding="utf-8"), (
+        "le scanner n'aurait pas du inventer un bloc audit sur un fichier qui "
+        "n'en avait pas -- exit 1 sans ecriture"
+    )
+
+
+def test_cli_exit_zero_when_header_present_noop(tmp_path):
+    """Compagnon du test precedent : un no-op legit (SHAs deja a jour) doit
+    rester exit=0. La nouvelle regle exit=1 ne doit pas se declencher quand
+    le scanner fait son travail correctement et trouve le bloc audit (meme
+    si l'entree est deja a jour).
+    """
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "a.ipynb").write_text("{}", encoding="utf-8")
+    (repo / "b.ipynb").write_text("{}", encoding="utf-8")
+    reg = repo / "twin_pairs.d"
+    reg.mkdir()
+    (reg / "_schema.yaml").write_text("# schema\n", encoding="utf-8")
+    sha_a = "a" * 40
+    sha_b = "b" * 40
+    (reg / "OkPair.yaml").write_text(
+        f"- name: OkPair\n"
+        f"  family: Test\n"
+        f"  python: a.ipynb\n"
+        f"  csharp: b.ipynb\n"
+        f"  audits:\n"
+        f"    - date: '2026-01-01'\n"
+        f"      by: lane-prev:CoursIA\n"
+        f"      python_sha: {sha_a}\n"
+        f"      csharp_sha: {sha_b}\n",
+        encoding="utf-8",
+    )
+    _git_init_commit(repo)
+
+    out = subprocess.run(
+        [sys.executable, str(SCRIPT),
+         "--repo-root", str(repo),
+         "--registry", str(reg),
+         "--update", "--pair", "OkPair", "--by", "test-lane"],
+        capture_output=True, text=True,
+    )
+    # Pas d'AVERTISSEMENT loud-fail, pas d'exit non-zero.
+    assert "AVERTISSEMENT" not in out.stderr, (
+        f"AVERTISSEMENT inattendu sur stderr : {out.stderr!r}"
+    )
+    assert out.returncode == 0, (
+        f"no-op legit doit garder exit=0 ; obtenu = {out.returncode}. "
+        f"stdout={out.stdout!r} stderr={out.stderr!r}"
+    )
+
+
+def _git_init_commit(repo: Path):
+    """Helper : initialise un repo git et commit tous les fichiers dans repo.
+
+    Necessaire pour que `_git_blob_sha` (via `git show <ref>:path`) rende
+    un SHA non-None ; sinon la CLI court-circuite toutes les paires en
+    `skipped` (notebook absent de git) AVANT d'arriver au bloc loud-fail
+    que ce test veut exercer.
+    """
+    import subprocess
+
+    subprocess.run(["git", "init", "-q"], cwd=str(repo), check=True)
+    subprocess.run(["git", "config", "user.email", "test@x"], cwd=str(repo), check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=str(repo), check=True)
+    subprocess.run(["git", "add", "-A"], cwd=str(repo), check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "init for twin parity test"],
+        cwd=str(repo), check=True,
+    )

--- a/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
@@ -580,7 +580,7 @@ def test_cli_exit_nonzero_when_header_missing(tmp_path):
     reg = repo / "twin_pairs.d"
     reg.mkdir()
     (reg / "_schema.yaml").write_text("# schema\n", encoding="utf-8")
-    target = reg / "NoAuditPair.yaml"
+    target = reg / "noauditpair.yaml"
     target.write_text(
         "- name: NoAuditPair\n"
         "  family: Test\n"
@@ -633,7 +633,7 @@ def test_cli_exit_zero_when_header_present_noop(tmp_path):
     (reg / "_schema.yaml").write_text("# schema\n", encoding="utf-8")
     sha_a = "a" * 40
     sha_b = "b" * 40
-    (reg / "OkPair.yaml").write_text(
+    (reg / "okpair.yaml").write_text(
         f"- name: OkPair\n"
         f"  family: Test\n"
         f"  python: a.ipynb\n"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/guard #10760

## Residu #10430 : exit code non-zero quand header audit introuvable

PR #10434 (MERGED 2026-08-12) a corrige le bug #10430 a 80% : regex tolerant + loud-fail imprimant AVERTISSEMENT. Mais la moitie **exit code** de l'acceptance manque : le `--update` retourne 0 meme quand une paire demandee n'a pas pu etre ecrite (header introuvable, indentation non reconnue). Le worker voit `updated=0` et conclut legitimement « rien a faire » alors que le scanner est AVEUGLE -- une attestation qui n'a pas ete rendue invisible.

C'est exactement le mode d'echec que #10430 voulait fermer : un organe d'attestation qui rate en silence.

### Acceptance #10430 closee

1. **Tolere l'indentation** : `\s{2,}` + coupure RELATIVE a l'indent de la cle (PR #10434).
2. **Rendre l'echec bruyant** : AVERTISSEMENT loud PR #10434 + **exit 1** (ce PR).
3. **Test de regression** : 2 tests (MANDAT, ce PR) :
   - `test_cli_exit_nonzero_when_header_missing` : notebook existe, YAML sans bloc audit, expect AVERTISSEMENT + exit=1.
   - `test_cli_exit_zero_when_header_present_noop` : no-op legit (SHAs a jour), expect exit=0.
4. Normalisation `app-10-portfolio.yaml` a l'indentation 2 : deferree (sample-size 1, hors scope residu).
5. `--check` reste 157/157 OK : pas touche.

### Changement observable

`check_twin_parity.py --update --pair <X>` :
- AVANT : exit 0 + AVERTISSEMENT stderr si header introuvable -> worker conclut "0 ecrit = rien a faire"
- APRES : exit 1 + AVERTISSEMENT stderr -> worker doit inspecter l'indentation

### Verification

```
$ python -m pytest scripts/notebook_tools/tests/test_check_twin_parity_surgical.py
============================= 18 passed in 4.45s ==============================
```

16 tests pre-existants (PR #10434) + 2 tests nouveaux (ce PR). Aucun test casse.

**Fix cross-OS (commit `ddcfb39b47`)** : CI Linux a échoué sur le 1er test parce que les fixtures étaient `NoAuditPair.yaml` / `OkPair.yaml` (uppercase) alors que `_slug()` lowercase le nom (`noauditpair.yaml` / `okpair.yaml`). Windows filesystem case-insensitive masquait le bug. Test fixtures alignées sur la convention lowercase de `_slug()`. Leçon : cross-OS test discipline = toujours utiliser le format exact que produit le slug (`scripts/notebook_tools/check_twin_parity.py:_slug`).

### Hors scope

- La CI n'appelle PAS `--update` (workflow `twin-parity.yml` affiche la commande en advisory ; c'est le worker qui la lance). Aucun risque CI.
- Pas de guard supplementaire (no-op legit tolere, exit=0 ; seul le **failed rebaseline** est exit=1, comme specifie par l'acceptance #10430).

### G-VAR

- TIER : **MED** (changement de contrat observable, fastidieux a piginer en sub-LIGHT).
- GENRE : `guard` (classe META, mais fix bug reel sur issue #10430 worker-driven).
- G-VAR-1 NON-TENU (classe META) -- signale dans le [DONE].
- G-VAR-3 OK : c.1331+125 = DEEP/guard, c.1331+126 = MED/guard mais substance genuiment distincte (different fix, different file, different issue).

### Reference

- Issue #10430 (acceptance 5 points)
- PR #10434 (1+3 corriges, 2 deferre)
- PR #10427 (PR ayant declenche le ticket, contournement correct)

See #10430 (livraison partielle : acceptance 2 sur 5 — exit code 1 quand header audit introuvable. Substance MERGEABLE en isolation. PR #10434 + #10601 couvrent les acceptations 1/3/4/5. Cette PR ferme le résidu acceptance 2 sans prétendre clore l'issue complète : la ré-agrégation des 5 critères reste à un futur grain.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
