### PR TITLE
docs(xplat,#10648): cross-ref setup-linux-macos.md depuis common-commands + READMEs Win-only residuels

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md
@@ -316,6 +316,8 @@ cd MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code
 ./Scripts/prepare-workspaces.ps1 -UserName "VotreNom"
 ```
 
+> **macOS / Linux** : `prepare-workspaces.ps1` est un script PowerShell (Windows-only). Le setup du poste contributeur Mac/Linux (kernels, clés, stack GenAI) : [setup-linux-macos.md](../../../docs/reference/setup-linux-macos.md).
+
 Si `UserName` contient des espaces, l'entourer de guillemets. Les workspaces sont créés dans le dossier `workspaces/` de chaque sous-répertoire (Claude Code et Roo Code séparent leurs espaces).
 
 ### NanoClaw / OpenClaw : comment déployer un agent autonome ?

--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -481,6 +481,8 @@ dotnet interactive jupyter install
 
 > **Windows Policy** : Si `dotnet-interactive.exe` est bloque (Win32Exception 4551), exécuter en admin PowerShell :
 > `Set-ExecutionPolicy -Scope CurrentUser RemoteSigned` puis relancer.
+>
+> **macOS / Linux** : pas de politique d'exécution de scripts — le workaround Windows ne s'applique pas. Setup complet du poste contributeur : [setup-linux-macos.md](../../docs/reference/setup-linux-macos.md).
 
 ### Tweety
 

--- a/docs/reference/common-commands.md
+++ b/docs/reference/common-commands.md
@@ -2,9 +2,12 @@
 
 ## Environment Setup
 
+Ce document est centré Windows (paths `C:\`, `venv\Scripts`). Pour le setup d'un poste contributeur **macOS / Linux** (équivalents `brew`/`apt` des commandes `winget`/`choco`, `elan` Lean sans WSL, backend MPS sur Apple Silicon), cf [setup-linux-macos.md](setup-linux-macos.md). Les kernels .NET Interactive, Python et Lean 4 sont cross-OS ; les notebooks s'exécutent à l'identique modulo le backend GPU.
+
 ```bash
 # Python
-python -m venv venv && venv\Scripts\activate
+python -m venv venv && venv\Scripts\activate   # Windows
+# python -m venv venv && source venv/bin/activate   # macOS / Linux
 pip install -r MyIA.AI.Notebooks/GenAI/requirements.txt
 
 # C# (.NET 9.0)


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: MED/docs #10769

## Summary

Complète la slice #10648 de l'EPIC #10643 (Support multiplateforme Linux/macOS) :
le fichier central `docs/reference/setup-linux-macos.md` + 3 READMEs ont été
créés/traités par PR #10664 (autre lane, merged 2026-08-13T07:33Z) ; le résiduel
de cette slice était le **cross-ref depuis le point d'entrée P0** `common-commands.md`
+ les READMEs restants à vrais signaux d'install Windows-only non couverts.

### Changements (3 fichiers, 8 ins / 1 del)

| Fichier | Changement |
|---------|-----------|
| `docs/reference/common-commands.md` | § Environment Setup : cross-ref `setup-linux-macos.md` + ligne Python cross-OS (`venv\Scripts\activate` Windows vs `source venv/bin/activate` macOS/Linux) |
| `MyIA.AI.Notebooks/SymbolicAI/README.md` | workaround `Set-ExecutionPolicy` : note macOS/Linux (pas de policy d'exécution) + cross-ref |
| `MyIA.AI.Notebooks/GenAI/Vibe-Coding/README.md` | scripts `prepare-workspaces.ps1` (Windows-only) : note macOS/Linux + cross-ref |

## Validation

| Check | Résultat |
|-------|----------|
| Chemins relatifs des 3 cross-refs | résolution vérifiée (`test -f` sur chaque cible depuis le fichier source) |
| Pattern chemins | aligné sur le pattern existant du même fichier (`../../../docs/reference/`) et #10664 |
| Scope | uniquement signaux Win-only réels (`Set-ExecutionPolicy` / `venv\Scripts`), pas `dotnet tool install` (cross-OS) |
| Diff | 8 ins / 1 del, 3 fichiers, même EPIC #10643, catalogue intouché |
| Exclusions documentées | `GenAI/Vibe-Coding/Roo-Code/**/scripts-multiplateforme/` (Set-ExecutionPolicy) = domaine #10644 (po-2024) — hors scope |

## Rules compliance

- **Catalogue**: byte-identique à main (aucun fichier catalogue touché), branche
  fraîche sur `origin/main` (6de271475).
- **L898**: `gh pr list --search "xplat-docs"` + revue des 60 PRs ouvertes → aucune
  collision sur les 3 fichiers.
- **L677-L4**: body hors worktree (scratchpad).
- **#10648**: slice claimée 05:52Z — partie (a) (création du fichier central) absorbée
  par #10664, partie (b) (cross-ref P0) = cette PR.

See #10648. See #10643. Base: `origin/main` (6de271475).