### PR TITLE
fix(genai-audio,#10678): merge 4 duplicated interp cells in 04-1-Educational-Audio-Content (42->38)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb
@@ -560,34 +560,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-section1-interpretation",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003498,
-     "end_time": "2026-06-23T22:40:03.186056",
-     "exception": false,
-     "start_time": "2026-06-23T22:40:03.182558",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Generation de scripts\n",
-    "\n",
-    "| Aspect | Observation | Signification |\n",
-    "|--------|-------------|---------------|\n",
-    "| Temps LLM | *runtime machine-dep* : Typiquement < 5s | GPT-4o-mini est rapide pour cette tâche |\n",
-    "| Marqueurs | [PAUSE], [NARRATEUR], [EXPERT] | Permettent le contrôle fin de la narration |\n",
-    "| Longueur | Script ~2x plus long que le texte source | L'oral necessite plus de mots que l'ecrit |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Le LLM adapte naturellement le registre ecrit vers l'oral\n",
-    "2. Les marqueurs structurent le script pour le pipeline TTS\n",
-    "3. La temperature 0.7 donne un bon equilibre naturel/fidele"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "a4c79308",
    "metadata": {
     "papermill": {
@@ -1002,6 +974,8 @@
     "\n",
     "> **Bon a savoir** : Pour les contenus plus complexes, vous pouvez ajouter d'autres rôles (EXEMPLE, DEFINITION, CONCLUSION) avec des voix distinctes (echo, shimmer, fable).\n",
     "\n",
+    "**En complement — benefice pedagogique** : la multi-voix rend le contenu plus dynamique qu'un narrateur unique, en maintenant l'attention de l'auditeur sur les changements de role.\n",
+    "\n",
     "---\n",
     "\n",
     "## Section 2 : Narration multi-voix\n",
@@ -1017,34 +991,6 @@
     "| Exemples / Illustrations | `echo` (F) ou `shimmer` (F) | Cas pratiques, analogies, ton plus leger |\n",
     "\n",
     "Nous allons parser le script genere par le LLM pour identifier les segments par rôle (marqueurs `[NARRATEUR]`, `[EXPERT]`), puis generer chaque segment avec la voix OpenAI appropriee."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-section2-interpretation",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005439,
-     "end_time": "2026-06-23T22:40:22.994817",
-     "exception": false,
-     "start_time": "2026-06-23T22:40:22.989378",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Narration multi-voix\n",
-    "\n",
-    "| Aspect | Valeur | Signification |\n",
-    "|--------|--------|---------------|\n",
-    "| Segments | Variable (4-10 typique) | Chaque changement de rôle créé un segment |\n",
-    "| Temps par segment | *runtime machine-dep* : ~1-3s | L'API est rapide même pour du texte long |\n",
-    "| Differenciation | Voix distinctes par rôle | Ameliore la comprehension et l'engagement |\n",
-    "\n",
-    "**Points cles** :\n",
-    "1. Le parsing des marqueurs [RÔLE] permet une attribution automatique des voix\n",
-    "2. Les pauses [PAUSE] sont converties en ellipses pour un rythme naturel\n",
-    "3. La multi-voix rend le contenu plus dynamique qu'un narrateur unique"
    ]
   },
   {
@@ -1319,31 +1265,6 @@
     "| **TTS direct multilingue** | Fournir texte traduit, synthetiser direct | Plus simple, une seule étape | Qualite depend de la traduction source |\n",
     "\n",
     "Nous utilisons la première approche (traduction LLM) pour garantir que le contenu reste pedagogique et naturel dans chaque langue cible. Le prompt de traduction inclut le contexte \"educatif\" pour preserver le ton."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-section3-interpretation",
-   "metadata": {
-    "papermill": {
-     "duration": 0.010296,
-     "end_time": "2026-06-23T22:40:31.067504",
-     "exception": false,
-     "start_time": "2026-06-23T22:40:31.057208",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Contenu multilingue\n",
-    "\n",
-    "| Aspect | Valeur | Signification |\n",
-    "|--------|--------|---------------|\n",
-    "| Qualite FR | Excellente | Voix OpenAI optimisees pour le francais |\n",
-    "| Qualite EN | Excellente | Langue native du modèle |\n",
-    "| Traduction LLM | Fidele au contenu | GPT-4o-mini conserve le ton pedagogique |\n",
-    "\n",
-    "> **Note technique** : Pour des langues moins bien supportees, tester la qualite avec un locuteur natif avant production."
    ]
   },
   {
@@ -1861,6 +1782,8 @@
     "\n",
     "> **Note technique** : Pour des cours plus longs, decouper en chapitres de 3-5 minutes chacun avec des titres intermediaires.\n",
     "\n",
+    "**En complement — dependance outil** : pydub utilise ffmpeg en arriere-plan ; assurez-vous que ffmpeg est installe dans votre environnement avant l'assemblage.\n",
+    "\n",
     "---\n",
     "\n",
     "## Section 5 : Assemblage d'un cours narre complet\n",
@@ -1874,32 +1797,6 @@
     "5. **Exporter** en format final (MP3 192kbps)\n",
     "\n",
     "Cette approche créé une expérience d'ecoute fluide et professionnelle."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-section5-interpretation",
-   "metadata": {
-    "papermill": {
-     "duration": 0.031349,
-     "end_time": "2026-06-23T22:40:45.588097",
-     "exception": false,
-     "start_time": "2026-06-23T22:40:45.556748",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Assemblage\n",
-    "\n",
-    "| Aspect | Valeur | Signification |\n",
-    "|--------|--------|---------------|\n",
-    "| Silences inter-segments | 800ms | Pause naturelle entre phrases |\n",
-    "| Silences inter-sections | 1500ms | Marque un changement de locuteur/sujet |\n",
-    "| Normalisation | -20 dBFS | Volume confortable pour l'ecoute |\n",
-    "| Format final | MP3 192kbps | Bon compromis qualite/taille |\n",
-    "\n",
-    "> **Note technique** : pydub utilise ffmpeg en arriere-plan. Assurez-vous que ffmpeg est installe dans votre environnement."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10771

## Ce que fait la PR

Corrige le **désordre d'interprétation** de `04-1-Educational-Audio-Content.ipynb` (GenAI/Audio) détecté dans le cadre de l'EPIC **#10678** (plainte user 2026-08-13 « les cellules sont en désordre » — désordre massif introduit par les enrichissements density #10488).

**Défaut vérifié firsthand** : 4 paires de cellules markdown d'interprétation **dupliquées**, empilées consécutivement — chaque paire = une interprétation riche (A) suivie de sa jumelle legacy (B) interprétant le **même** output de code. Ex. cell[10] `### Interpretation : Generation de scripts par LLM` + cell[11] `### Interpretation : Generation de scripts` (tous deux sur la sortie de la cellule code 9, génération de script 6.6s / 577 tokens).

**Fix = fusion, zéro perte de contenu (anti-régression)** : chaque paire fusionnée en **une** cellule — le contenu riche A est conservé, et les **faits pédagogiques uniques de B** sont ajoutés en bloc « En complément » :
- (10,11) : B **entièrement subsumé** par A (temp 0.7, marqueurs, adaptation écrit→oral déjà présents dans A) → suppression pure, zéro perte
- (16,17) : le bénéfice pédagogique « la multi-voix rend le contenu plus dynamique qu'un narrateur unique »
- (20,21) : B **entièrement subsumé** par A (qualité FR/EN, note technique langues natives déjà dans A) → suppression pure, zéro perte
- (27,28) : la dépendance outil « pydub utilise ffmpeg en arrière-plan — assurez-vous que ffmpeg est installé »

## Validation (preuves vérifiables)

- **Markdown-only** : 2 cellules A enrichies + 4 cellules B legacy supprimées (42 → 38 cellules). **0 cellule code touchée** — vérifié programmatiquement : `code-cell drift: []`, `execution_count` + `outputs` byte-identiques sur les 15 cellules code (15/15 exécutées).
- **`validate_pr_notebooks.py` SUCCESS** : `forensic_verdict: EXEC_PROVED`, 0 erreur, 0 null-exec.
- **Round-trip byte-exact** : `json.dumps(indent=1, separators=(",", ": "), ensure_ascii=False) + "\n"` == raw (vérifié), CRLF = 0, pas de churn cosmétique.
- **nbformat valide** (nbformat.validate OK).
- **Plus aucune paire consécutive** après fix : re-scan `interpr[ée]tation` (IGNORECASE) → `remaining consecutive pairs: []`.
- **Pas de jumeau** `_en.ipynb` ni d'entrée twin registry pour ce notebook → pas de rebaseline twin nécessaire.

## G.1 + transparence

Vérifié sur `origin/main` frais : les 4 paires listées avec leur contenu complet avant édition, et l'output réel de la cellule code précédente pour chaque paire (le doublon interprète bien le même output). Les paires (10,11) et (20,21) sont des cas où **B est entièrement subsumé par A** → suppression pure sans bloc « En complément » (zéro perte quand même) : ne pas exiger un complément pour chaque paire.

Audit EPIC #10678 phase 1 (scan corpus complet, regex `^#+\s*(lecture du (r[ée]sultat|taux)|interpr[ée]tation)` IGNORECASE sur cellules markdown + indices consécutifs) : **33 notebooks** portent encore le pattern après cette PR — top : 02-1-Chatterbox-TTS [3x], 7_Code_Interpreter [3x], SC-19-Ripple-XRP [3x], 04-Computational-Aggregation-SAT-Z3 [4x, PR #10771 en attente merge].

`Closes #10678` non posé : l'EPIC couvre 33+ notebooks, cette PR n'en traite qu'un → `See #10678`.

See #10488 (density) · #10678 (EPIC remise en ordre) · #10766 (même pattern, Search-10) · #10771 (même pattern, SAT-Z3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
