### PR TITLE
docs(qc,#10752): Phase 3 — metadata auteur stale Claude Opus 4.6 -> Claude-Code (2 RESEARCH docs)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_FINDINGS.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_FINDINGS.md
@@ -389,7 +389,7 @@ But remember: **Complexity is not always better**. The research proves it.
 **Execution Time**: ~3 minutes
 **Data Source**: Yahoo Finance (BTC-USD)
 **Period**: 2019-01-01 → 2026-02-17 (2417 days)
-**Author**: Claude Opus 4.6 (qc-research-notebook agent)
+**Author**: Claude-Code (qc-research-notebook agent)
 **Date**: 2026-02-17
 
 ---

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_SUMMARY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-BTC-MACD-ADX/RESEARCH_SUMMARY.md
@@ -348,6 +348,6 @@ Le notebook génère:
 
 **Execution**: En cours...
 
-**Auteur**: Claude Opus 4.6 (qc-research-notebook agent)
+**Auteur**: Claude-Code (qc-research-notebook agent)
 
 **Date**: 2026-02-17


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2025:CoursIA — prev: DEEP/sota #10786

## Summary

Clôture la **Phase 3** de #10752 (Phases 1+2 déjà mergées #10754 + #10760).
Les métadonnées de recherche des 2 documents du projet QuantConnect
`CSharp-BTC-MACD-ADX` citaient **`Claude Opus 4.6`** comme auteur — une
étiquette stale datant d'avant la migration du bot (Opus 4.6 → 4.7 → 4.8 →
5.x → failover Qwen/GLM). Aucun agent Opus 4.6 n'a tourné depuis >6 mois
(incident vérifié user 2026-08-13), donc l'étiquette est devenue un
**mensonge matériel**.

### Fix

Alignement sur la convention actuelle (CLAUDE.md global §Git L27) :
`Co-Authored-By: Claude-Code <noreply@anthropic.com>` — pas de version, pas
de modèle.

| Fichier | Avant | Après |
|---|---|---|
| `RESEARCH_SUMMARY.md:351` | `**Auteur**: Claude Opus 4.6 (qc-research-notebook agent)` | `**Auteur**: Claude-Code (qc-research-notebook agent)` |
| `RESEARCH_FINDINGS.md:392` | `**Author**: Claude Opus 4.6 (qc-research-notebook agent)` | `**Author**: Claude-Code (qc-research-notebook agent)` |

Le contexte fonctionnel `(qc-research-notebook agent)` est préservé —
seule l'étiquette de modèle stale change.

### Scope Phase 3 (décision au cas par cas, issue #10752)

- `RESEARCH_SUMMARY.md` + `RESEARCH_FINDINGS.md` → corrigés (cette PR).
- `slides/S7-lean/slides.md:267` (`model="claude-opus-4-6"`) → **gardé** :
  c'est un exemple pédagogique de code illustrant la syntaxe d'un appel
  API, pas une signature de commit ni une métadonnée d'auteur.
- `RESEARCH_FINDINGS.md:453` (`**Auteur** : po-2025 (...)`) → **non touché** :
  correct ( Bras robustesse, mandat user EPIC #9768 — c'est po-2025, pas
  Claude Opus 4.6).

### Diff

2 fichiers, +2/-2. 0 autre cellule/ligne touchée. Grep résiduel
`Claude (Opus|Sonnet|Haiku) [0-9]` dans `CSharp-BTC-MACD-ADX/` = vide
après fix.

See #10752 (Phases 1+2+3 toutes traitees; fermeture manuelle au merge par ai-01, gate #10101/#10223).

