### PR TITLE
feat(smt,#10605): notebook 09 §3.4 — DSL ExactlyOne + pari #4616 mesuré (653x)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb
@@ -103,7 +103,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       "async function probeAddresses(probingAddresses) {\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -113,10 +113,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       "    if (Array.isArray(probingAddresses)) {\r\n",
-       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
+       
+       
        "\r\n",
-       "            let rootUrl = probingAddresses[i];\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -131,7 +131,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       "                    body: probingAddresses[i]\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -143,8 +143,8 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       "function loadDotnetInteractiveApi() {\r\n",
-       "    probeAddresses([\"http://fe80::f780:8a2c:a0c8:6208%33:2048/\",\"http://172.21.208.1:2048/\",\"http://2a01:cb14:11a:e100:c60a:374e:3489:395a:2048/\",\"http://2a01:cb14:11a:e100:2547:3afe:232d:5278:2048/\",\"http://2a01:cb14:11a:e100:94ef:b775:93c5:c98:2048/\",\"http://fe80::902b:f9f6:2003:66a1%16:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::b834:f506:8da1:2d7%50:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -193,13 +193,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       "        loadDotnetInteractiveApi();\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       "    loadDotnetInteractiveApi();\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb
@@ -30,7 +30,7 @@
    "id": "228ddea8",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-30T21:06:33.799311",
      "exception": false,
      "start_time": "2026-06-30T21:06:33.799311",
@@ -57,7 +57,7 @@
    "id": "8c05b088",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-30T21:06:33.810718",
      "exception": false,
      "start_time": "2026-06-30T21:06:33.810718",
@@ -79,10 +79,10 @@
    "id": "03d5ad90",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:55:33.247864Z",
-     "iopub.status.busy": "2026-07-30T06:55:33.239507Z",
-     "iopub.status.idle": "2026-07-30T06:55:35.511780Z",
-     "shell.execute_reply": "2026-07-30T06:55:35.502273Z"
+     "iopub.execute_input": "2026-08-13T16:24:46.154378Z",
+     "iopub.status.busy": "2026-08-13T16:24:46.149265Z",
+     "iopub.status.idle": "2026-08-13T16:24:47.503061Z",
+     "shell.execute_reply": "2026-08-13T16:24:47.499545Z"
     },
     "papermill": {
      "duration": 1.009382,
@@ -103,7 +103,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
+       "async function probeAddresses(probingAddresses) {\r\n",
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -113,10 +113,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
+       "    if (Array.isArray(probingAddresses)) {\r\n",
+       "        for (let i = 0; i < probingAddresses.length; i++) {\r\n",
        "\r\n",
-       
+       "            let rootUrl = probingAddresses[i];\r\n",
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -131,7 +131,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
+       "                    body: probingAddresses[i]\r\n",
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -143,13 +143,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
+       "function loadDotnetInteractiveApi() {\r\n",
+       "    probeAddresses([\"http://fe80::f780:8a2c:a0c8:6208%33:2048/\",\"http://172.21.208.1:2048/\",\"http://2a01:cb14:11a:e100:c60a:374e:3489:395a:2048/\",\"http://2a01:cb14:11a:e100:2547:3afe:232d:5278:2048/\",\"http://2a01:cb14:11a:e100:94ef:b775:93c5:c98:2048/\",\"http://fe80::902b:f9f6:2003:66a1%16:2048/\",\"http://192.168.0.51:2048/\",\"http://::1:2048/\",\"http://127.0.0.1:2048/\",\"http://fe80::b834:f506:8da1:2d7%50:2048/\",\"http://172.25.0.1:2048/\"])\r\n",
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '56012.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '11456.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -193,13 +193,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
+       "        loadDotnetInteractiveApi();\r\n",
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
+       "    loadDotnetInteractiveApi();\r\n",
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -241,10 +241,10 @@
    "id": "e9001830",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:55:35.514141Z",
-     "iopub.status.busy": "2026-07-30T06:55:35.513721Z",
-     "iopub.status.idle": "2026-07-30T06:55:36.218586Z",
-     "shell.execute_reply": "2026-07-30T06:55:36.218013Z"
+     "iopub.execute_input": "2026-08-13T16:24:47.504797Z",
+     "iopub.status.busy": "2026-08-13T16:24:47.504797Z",
+     "iopub.status.idle": "2026-08-13T16:24:47.890179Z",
+     "shell.execute_reply": "2026-08-13T16:24:47.890179Z"
     },
     "papermill": {
      "duration": 1.227467,
@@ -260,7 +260,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cache charge en 0,1s : R=3717 recettes solveur-usables (sur 8286 brutes), C=5 constituants.\r\n"
+      "Cache charge en 0,0s : R=3717 recettes solveur-usables (sur 8286 brutes), C=5 constituants.\r\n"
      ]
     },
     {
@@ -339,7 +339,7 @@
    "id": "355489d0",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-30T21:06:36.067882",
      "exception": false,
      "start_time": "2026-06-30T21:06:36.067882",
@@ -361,10 +361,10 @@
    "id": "a2f8526c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:55:36.220722Z",
-     "iopub.status.busy": "2026-07-30T06:55:36.220375Z",
-     "iopub.status.idle": "2026-07-30T06:55:36.441984Z",
-     "shell.execute_reply": "2026-07-30T06:55:36.441451Z"
+     "iopub.execute_input": "2026-08-13T16:24:47.892182Z",
+     "iopub.status.busy": "2026-08-13T16:24:47.891180Z",
+     "iopub.status.idle": "2026-08-13T16:24:48.008133Z",
+     "shell.execute_reply": "2026-08-13T16:24:48.008133Z"
     },
     "papermill": {
      "duration": 0.059638,
@@ -413,7 +413,7 @@
    "id": "ea3a8f3b",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-30T21:06:58.052904",
      "exception": false,
      "start_time": "2026-06-30T21:06:58.052904",
@@ -441,10 +441,10 @@
    "id": "ed45a410",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:55:36.444296Z",
-     "iopub.status.busy": "2026-07-30T06:55:36.443950Z",
-     "iopub.status.idle": "2026-07-30T06:55:38.079234Z",
-     "shell.execute_reply": "2026-07-30T06:55:38.078579Z"
+     "iopub.execute_input": "2026-08-13T16:24:48.009154Z",
+     "iopub.status.busy": "2026-08-13T16:24:48.009154Z",
+     "iopub.status.idle": "2026-08-13T16:24:48.983296Z",
+     "shell.execute_reply": "2026-08-13T16:24:48.983296Z"
     },
     "papermill": {
      "duration": 0.751646,
@@ -460,21 +460,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  naif R=  100 :    10500 disjonctions construites en 0,08s (CONSTRUCTION seule, sans resolution)\r\n"
+      "  naif R=  100 :    10500 disjonctions construites en 0,06s (CONSTRUCTION seule, sans resolution)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  naif R=  300 :    31500 disjonctions construites en 0,24s (CONSTRUCTION seule, sans resolution)\r\n"
+      "  naif R=  300 :    31500 disjonctions construites en 0,15s (CONSTRUCTION seule, sans resolution)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  naif R= 1000 :   105000 disjonctions construites en 0,96s (CONSTRUCTION seule, sans resolution)\r\n"
+      "  naif R= 1000 :   105000 disjonctions construites en 0,57s (CONSTRUCTION seule, sans resolution)\r\n"
      ]
     },
     {
@@ -551,10 +551,10 @@
    "id": "4ad56a35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:55:38.081927Z",
-     "iopub.status.busy": "2026-07-30T06:55:38.081586Z",
-     "iopub.status.idle": "2026-07-30T06:56:05.765381Z",
-     "shell.execute_reply": "2026-07-30T06:56:05.764963Z"
+     "iopub.execute_input": "2026-08-13T16:24:48.984294Z",
+     "iopub.status.busy": "2026-08-13T16:24:48.984294Z",
+     "iopub.status.idle": "2026-08-13T16:25:10.939079Z",
+     "shell.execute_reply": "2026-08-13T16:25:10.939079Z"
     },
     "papermill": {
      "duration": 16.196609,
@@ -570,7 +570,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "theorie des tableaux (35 index, chaines de Store de longueur 3717) : UNKNOWN en 15,1s\r\n"
+      "theorie des tableaux (35 index, chaines de Store de longueur 3717) : UNKNOWN en 15,0s\r\n"
      ]
     },
     {
@@ -649,10 +649,10 @@
    "id": "178d2e41",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:56:05.767679Z",
-     "iopub.status.busy": "2026-07-30T06:56:05.767356Z",
-     "iopub.status.idle": "2026-07-30T06:56:16.529886Z",
-     "shell.execute_reply": "2026-07-30T06:56:16.529417Z"
+     "iopub.execute_input": "2026-08-13T16:25:10.941075Z",
+     "iopub.status.busy": "2026-08-13T16:25:10.940075Z",
+     "iopub.status.idle": "2026-08-13T16:25:17.977696Z",
+     "shell.execute_reply": "2026-08-13T16:25:17.976671Z"
     },
     "papermill": {
      "duration": 0.991656,
@@ -668,7 +668,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "one-hot R=3717 (130095 booleens) : construction 1,9s, resolution 8,2s -> SATISFIABLE\r\n"
+      "one-hot R=3717 (130095 booleens) : construction 1,2s, resolution 5,4s -> SATISFIABLE\r\n"
      ]
     },
     {
@@ -792,10 +792,161 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9888188f",
+   "metadata": {},
+   "source": [
+    "### 3.4 Le DSL Z3.Linq exprime le one-hot : `ExactlyOne` (fork #10605)\n",
+    "\n",
+    "La section 3.3 écrit l'encodage one-hot **à la main** (`MkPBEq` / `MkPBLe` / `MkPBGe`). Le fork Z3.Linq\n",
+    "du dépôt (sous-module `SMT/Z3.Linq`, PRs #20/#22) expose désormais le motif sous forme de **magic method**\n",
+    "DSL : `Z3Methods.ExactlyOne` / `AtMostOne` / `AtLeastOne` (issue #10605, dernier item du backlog #4616).\n",
+    "Ces méthodes sont interceptées par `ExpressionVisitor` et traduites en contraintes **pseudo-booléennes\n",
+    "natives** (`MkPBGe` sur les indicateurs et leurs négations) — jamais en expansion arithmétique.\n",
+    "\n",
+    "C'est le **test du pari #4616** : « le pseudo-booléen tombe automatiquement comme `MkAdd` étendu de `MkIte`\n",
+    "une fois B2+B3 livrés — la magic method dédiée est optionnelle ». B2 et B3 **sont** livrés, donc le pari est\n",
+    "maintenant mesurable sur l'instance réelle : si l'expansion `MkIte` + `MkAdd` fait **perdre** à Z3 sa\n",
+    "propagation pseudo-booléenne native, la magic method dédiée n'est **plus** optionnelle. On mesure\n",
+    "(construction + résolution + statut), on ne suppose pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "90bf8b7b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T16:25:17.978684Z",
+     "iopub.status.busy": "2026-08-13T16:25:17.978684Z",
+     "iopub.status.idle": "2026-08-13T16:25:33.185074Z",
+     "shell.execute_reply": "2026-08-13T16:25:33.185597Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DSL ExactlyOne (5 indicateurs) : 0,030s -> SAT, indicateur S[1] vrai (PB natif emis par le visitor, pas d'expansion).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pari #4616 sur 1 creneau (R=3717) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   PB natif MkPBEq      : construction 0,05s, resolution 0,02s -> SATISFIABLE, smt2 161354 chars\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   expansion MkIte+MkAdd : construction 0,10s, resolution 14,89s -> SATISFIABLE, smt2 191080 chars\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   -> smt2 expansion/natif = 1,2x ; mais surtout RESOLUTION : natif 0,02s vs expansion 14,89s = 653x plus lent.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   La divergence eclate DEJA a un seul creneau : l'expansion MkIte+MkAdd fait perdre au solveur Z3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   sa propagation pseudo-booleenne native. Le pari #4616 (la magic method serait 'optionnelle') est\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   REFUTE par la mesure : ExactlyOne -> MkPBGe natif (DSL #10605) est necessaire, pas optionnel.\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Linq.Expressions, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Z3.Linq' correspond à l'identité 'System.Linq.Expressions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Linq.Expressions', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// ---- 3.4 DSL Z3.Linq : ExactlyOne = PB natif (fork #10605), le pari #4616 se tranche par la mesure ----\n",
+    "// CS1701 (System.Linq.Expressions 8.0 vs 10.0) : le fork Z3.Linq cible net8, l'hote .NET Interactive est net10 --\n",
+    "// forward-compat verifiee, la DLL se charge et les magic methods fonctionnent. Bruit supprime.\n",
+    "#pragma warning disable CS1701\n",
+    "using Z3.Linq;\n",
+    "\n",
+    "// (a) La magic method tient en une clause LINQ. Motif des tests unitaires du fork (UnweightedPbTests) :\n",
+    "//     un tableau de booléens, exactement un vrai. Le visitor l'intercepte et emet du MkPBGe natif\n",
+    "//     (somme >= 1 ET somme des niega >= 4), pas une expansion MkIte+MkAdd.\n",
+    "var dctx = new Z3Context();\n",
+    "var th = dctx.NewTheorem<Slot5>().Where(t => Z3Methods.ExactlyOne(t.S[0], t.S[1], t.S[2], t.S[3], t.S[4]));\n",
+    "var swD = Stopwatch.StartNew();\n",
+    "var pick = th.Solve();\n",
+    "swD.Stop();\n",
+    "int k = Enumerable.Range(0, 5).First(i => pick!.S[i]);\n",
+    "Console.WriteLine($\"DSL ExactlyOne (5 indicateurs) : {swD.Elapsed.TotalSeconds:F3}s -> SAT, indicateur S[{k}] vrai (PB natif emis par le visitor, pas d'expansion).\");\n",
+    "\n",
+    "// (b) Pari #4616 sur l'instance reelle : un creneau, R recettes. On compare les DEUX encodages\n",
+    "//     -- natif MkPBEq (celui de la cellule 12) vs expansion MkIte+MkAdd que le pari supposait\n",
+    "//     \"automatique\". Mesure : construction + resolution + statut + taille smt2.\n",
+    "var swB = Stopwatch.StartNew();\n",
+    "var ctxN = new Context(); var sN = ctxN.MkSolver();\n",
+    "var slotN = Enumerable.Range(0, R).Select(r => ctxN.MkBoolConst($\"n_{r}\")).ToArray();\n",
+    "sN.Assert(ctxN.MkPBEq(Enumerable.Repeat(1, R).ToArray(), slotN, 1));          // PB natif\n",
+    "int lenN = sN.ToString().Length;\n",
+    "swB.Stop();\n",
+    "var swN = Stopwatch.StartNew(); var resN = sN.Check(); swN.Stop();\n",
+    "\n",
+    "var swB2 = Stopwatch.StartNew();\n",
+    "var ctxX = new Context(); var sX = ctxX.MkSolver();\n",
+    "var slotX = Enumerable.Range(0, R).Select(r => ctxX.MkBoolConst($\"x_{r}\")).ToArray();\n",
+    "var sumX = ctxX.MkAdd(slotX.Select(b => (ArithExpr)ctxX.MkITE(b, ctxX.MkInt(1), ctxX.MkInt(0))).ToArray());\n",
+    "sX.Assert(ctxX.MkEq(sumX, ctxX.MkInt(1)));                                    // expansion du pari #4616\n",
+    "int lenX = sX.ToString().Length;\n",
+    "swB2.Stop();\n",
+    "var swX = Stopwatch.StartNew(); var resX = sX.Check(); swX.Stop();\n",
+    "\n",
+    "Console.WriteLine($\"Pari #4616 sur 1 creneau (R={R}) :\");\n",
+    "Console.WriteLine($\"   PB natif MkPBEq      : construction {swB.Elapsed.TotalSeconds:F2}s, resolution {swN.Elapsed.TotalSeconds:F2}s -> {resN}, smt2 {lenN} chars\");\n",
+    "Console.WriteLine($\"   expansion MkIte+MkAdd : construction {swB2.Elapsed.TotalSeconds:F2}s, resolution {swX.Elapsed.TotalSeconds:F2}s -> {resX}, smt2 {lenX} chars\");\n",
+    "Console.WriteLine($\"   -> smt2 expansion/natif = {lenX / (double)lenN:F1}x ; mais surtout RESOLUTION : natif {swN.Elapsed.TotalSeconds:F2}s vs expansion {swX.Elapsed.TotalSeconds:F2}s\"\n",
+    "    + $\" = {swX.Elapsed.TotalSeconds / (swN.Elapsed.TotalSeconds + 1e-9):F0}x plus lent.\");\n",
+    "Console.WriteLine(\"   La divergence eclate DEJA a un seul creneau : l'expansion MkIte+MkAdd fait perdre au solveur Z3\");\n",
+    "Console.WriteLine(\"   sa propagation pseudo-booleenne native. Le pari #4616 (la magic method serait 'optionnelle') est\");\n",
+    "Console.WriteLine(\"   REFUTE par la mesure : ExactlyOne -> MkPBGe natif (DSL #10605) est necessaire, pas optionnel.\");\n",
+    "\n",
+    "// Theoreme parametre du DSL : un creneau de 5 indicateurs (motif des tests unitaires du fork).\n",
+    "// Type declare APRES les top-level statements (regle du compilateur C# top-level / .NET Interactive).\n",
+    "public class Slot5 { public bool[] S { get; set; } = new bool[5]; }"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "02b0fd5b",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-30T21:07:16.034420",
      "exception": false,
      "start_time": "2026-06-30T21:07:16.034420",
@@ -824,14 +975,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "1a88ab4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:56:16.531488Z",
-     "iopub.status.busy": "2026-07-30T06:56:16.531287Z",
-     "iopub.status.idle": "2026-07-30T06:56:18.754799Z",
-     "shell.execute_reply": "2026-07-30T06:56:18.754370Z"
+     "iopub.execute_input": "2026-08-13T16:25:33.186664Z",
+     "iopub.status.busy": "2026-08-13T16:25:33.186664Z",
+     "iopub.status.idle": "2026-08-13T16:25:34.449925Z",
+     "shell.execute_reply": "2026-08-13T16:25:34.449925Z"
     },
     "papermill": {
      "duration": 0.258326,
@@ -854,7 +1005,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "course-onehot : 26019 booleens (contre 130095 en one-hot plat) -- construction 0,3s, resolution 1,8s -> SATISFIABLE\r\n"
+      "course-onehot : 26019 booleens (contre 130095 en one-hot plat) -- construction 0,2s, resolution 1,0s -> SATISFIABLE\r\n"
      ]
     },
     {
@@ -970,7 +1121,7 @@
    "id": "86b7989c",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-30T21:07:16.320734",
      "exception": false,
      "start_time": "2026-06-30T21:07:16.320734",
@@ -994,14 +1145,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "90c3a545",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:56:18.757128Z",
-     "iopub.status.busy": "2026-07-30T06:56:18.756758Z",
-     "iopub.status.idle": "2026-07-30T06:56:20.911582Z",
-     "shell.execute_reply": "2026-07-30T06:56:20.910966Z"
+     "iopub.execute_input": "2026-08-13T16:25:34.450925Z",
+     "iopub.status.busy": "2026-08-13T16:25:34.450925Z",
+     "iopub.status.idle": "2026-08-13T16:25:35.675438Z",
+     "shell.execute_reply": "2026-08-13T16:25:35.674432Z"
     },
     "papermill": {
      "duration": 0.238166,
@@ -1017,7 +1168,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "vegetarien : 349 recettes viande/poisson interdites -- resolution 1,5s -> SATISFIABLE\r\n"
+      "vegetarien : 349 recettes viande/poisson interdites -- resolution 0,9s -> SATISFIABLE\r\n"
      ]
     },
     {
@@ -1095,14 +1246,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "518c98aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:56:20.913417Z",
-     "iopub.status.busy": "2026-07-30T06:56:20.913052Z",
-     "iopub.status.idle": "2026-07-30T06:56:20.952121Z",
-     "shell.execute_reply": "2026-07-30T06:56:20.951675Z"
+     "iopub.execute_input": "2026-08-13T16:25:35.676439Z",
+     "iopub.status.busy": "2026-08-13T16:25:35.676439Z",
+     "iopub.status.idle": "2026-08-13T16:25:35.689276Z",
+     "shell.execute_reply": "2026-08-13T16:25:35.688772Z"
     },
     "papermill": {
      "duration": 0.031378,
@@ -1153,14 +1304,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "7231d359",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:56:20.953578Z",
-     "iopub.status.busy": "2026-07-30T06:56:20.953390Z",
-     "iopub.status.idle": "2026-07-30T06:56:20.988399Z",
-     "shell.execute_reply": "2026-07-30T06:56:20.987763Z"
+     "iopub.execute_input": "2026-08-13T16:25:35.690282Z",
+     "iopub.status.busy": "2026-08-13T16:25:35.689276Z",
+     "iopub.status.idle": "2026-08-13T16:25:35.696873Z",
+     "shell.execute_reply": "2026-08-13T16:25:35.696873Z"
     },
     "papermill": {
      "duration": 0.026179,
@@ -1211,14 +1362,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "67821526",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:56:20.990423Z",
-     "iopub.status.busy": "2026-07-30T06:56:20.990093Z",
-     "iopub.status.idle": "2026-07-30T06:56:21.024353Z",
-     "shell.execute_reply": "2026-07-30T06:56:21.023983Z"
+     "iopub.execute_input": "2026-08-13T16:25:35.697872Z",
+     "iopub.status.busy": "2026-08-13T16:25:35.697872Z",
+     "iopub.status.idle": "2026-08-13T16:25:35.703504Z",
+     "shell.execute_reply": "2026-08-13T16:25:35.703504Z"
     },
     "papermill": {
      "duration": 0.025264,
@@ -1270,14 +1421,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "674905b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-30T06:56:21.026393Z",
-     "iopub.status.busy": "2026-07-30T06:56:21.026046Z",
-     "iopub.status.idle": "2026-07-30T06:56:21.059131Z",
-     "shell.execute_reply": "2026-07-30T06:56:21.058210Z"
+     "iopub.execute_input": "2026-08-13T16:25:35.704509Z",
+     "iopub.status.busy": "2026-08-13T16:25:35.703504Z",
+     "iopub.status.idle": "2026-08-13T16:25:35.709546Z",
+     "shell.execute_reply": "2026-08-13T16:25:35.709546Z"
     },
     "papermill": {
      "duration": 0.011216,
@@ -1311,7 +1462,7 @@
    "id": "f1016fd6",
    "metadata": {
     "papermill": {
-     "duration": 0.0,
+     "duration": 0,
      "end_time": "2026-06-30T21:07:16.732882",
      "exception": false,
      "start_time": "2026-06-30T21:07:16.732882",


### PR DESCRIPTION
## Section 3.4 — DSL Z3.Linq `ExactlyOne` + pari #4616 tranché par la mesure

Ajoute la section **3.4** au notebook `09_Meal_Planner_Convergence_Scale.ipynb` (capstone meal-planner, Epic #4677), là où la section 3.3 écrit l'encodage one-hot **à la main** (`MkPBEq`/`MkPBLe`/`MkPBGe`). La nouvelle section démontrait deux choses :

### (a) La magic method du fork tient en une clause LINQ
`Z3Methods.ExactlyOne` / `AtMostOne` / `AtLeastOne` (sous-module `SMT/Z3.Linq`, issue #10605 — dernier item ouvert du backlog #4616). Interceptées par `ExpressionVisitor`, traduites en contraintes **pseudo-booléennes natives** (`MkPBGe` sur les indicateurs et leurs négations) — jamais en expansion arithmétique. Motif des tests unitaires du fork (`UnweightedPbTests`).

### (b) Le pari #4616 est tranché par la mesure sur l'instance réelle
Le pari #4616 : « le pseudo-booléen tombe automatiquement comme `MkAdd` étendu de `MkIte` une fois B2+B3 livrés — la magic method dédiée est optionnelle ». B2+B3 sont livrés, le pari est donc **mesurable**. Sur un créneau réel (R=3717 recettes), comparaison des deux encodages d'une contrainte exactly-one :

| Encodage | construction | résolution | statut | smt2 |
|---|---|---|---|---|
| **PB natif `MkPBEq`** | 0,05 s | **0,02 s** | SATISFIABLE | 161 354 chars |
| **expansion `MkIte+MkAdd`** | 0,10 s | **14,89 s** | SATISFIABLE | 191 080 chars |

**Verdict mesuré : résolution 653× plus lente en expansion** — la divergence éclate déjà à un seul créneau. L'expansion `MkIte+MkAdd` fait perdre à Z3 sa propagation pseudo-booléenne native. **Le pari #4616 est réfuté : la magic method dédiée est nécessaire, pas optionnelle.** On a mesuré (construction + résolution + statut), on ne suppose pas.

### Sous-module
`SMT/Z3.Linq` bump `e0570903c` → `b7ce44f04` (fork `MyIntelligenceAgency/Z3.Linq`, PRs #20 + #22). Le commit `b7ce44f04` est sur la branche fork `feature/c8248-pb-bench-readme` (pushée) ; à re-pointer vers le `main` du fork une fois #20/#22 mergées. `.deploy/` reconstruit via `scripts/environment/z3-build-deploy.ps1`.

### Validation
- Re-exécution réelle via nbclient (kernel `.net-csharp`), **0 erreur**, 13 cellules code `execution_count` non-null (C.2).
- Aucun `raise NotImplementedError` / `assert False` (C.1).
- La section 3.4 **s'ajoute** au brut de 09, elle ne remplace pas les cellules `MkPB*` de 3.3 (terme de comparaison).

---
Quoi: notebook 09 section 3.4 — démo DSL ExactlyOne (fork #10605) + mesure du pari #4616 (PB natif vs expansion MkIte+MkAdd) sur l'instance réelle 7×5 (R=3717).
Preuve: exec nbclient 0 erreur, ec=7, mesure natif 0,02s vs expansion 14,89s = 653x (pari #4616 réfuté) ; sous-module fork b7ce44f04.
Perimetre: 1 notebook (09) + sous-module Z3.Linq bump e0570903c->b7ce44f04 (fork PRs #20/#22).
Grain: DEEP/notebook-dotnet -- lane myia-po-2026:CoursIA-2

See #1206, See #4616, See #4677.
