### PR TITLE
docs(scripts,#10644): de-stale xplat README equivalences (.sh twins delivered)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,11 +23,13 @@ scripts/
 │   ├── scripts/                 # Scripts de diagnostic
 │   └── config/                  # Variables critiques
 │
-├── environment/                 # Scripts environnement
-│   ├── audit_environment.ps1    # Audit environnement Windows
-│   ├── setup_environment.ps1    # Setup environnement Windows
-│   ├── install-ffmpeg.ps1       # Installation FFmpeg Windows
-│   └── install-ffmpeg.sh        # Installation FFmpeg Linux/macOS
+├── environment/                 # Scripts environnement (jumeaux .ps1/.sh)
+│   ├── setup_environment.{ps1,sh}    # Setup de base (Python, .NET, kernels)
+│   ├── audit_environment.{ps1,sh}    # Diagnostic de l'environnement
+│   ├── automata-build-deploy.{ps1,sh}  # Build/déploiement des automates
+│   ├── install-ffmpeg.{ps1,sh}       # Installation FFmpeg
+│   ├── z3-build-deploy.{ps1,sh}      # Build du wrapper Z3.Linq forké
+│   └── README.md                # Équivalences Linux/macOS (#10644)
 │
 ├── translation/                 # Synchro traduction multilingue (#4957 / #1650)
 │   └── extract_cells_to_csv.py  # Extraction cellules -> CSV (drift-detection)
@@ -105,15 +107,21 @@ resync par le moteur Argumentum (T3, gated #1650 Phase 1) viennent dans les tran
 ## Installation
 
 ```bash
-# Windows - FFmpeg
+# Windows (PowerShell) — FFmpeg + audit + setup de base
 ./scripts/environment/install-ffmpeg.ps1
-
-# Audit environnement
 ./scripts/environment/audit_environment.ps1
-
-# Setup environnement
 ./scripts/environment/setup_environment.ps1
+
+# Linux / macOS (bash) — jumeaux équivalents
+./scripts/environment/install-ffmpeg.sh
+./scripts/environment/audit_environment.sh
+./scripts/environment/setup_environment.sh --auto-fix
 ```
+
+Chaque script PowerShell possède un jumeau bash de comportement équivalent
+(`scripts/environment/README.md` documente les différences de port). Le seul
+script Windows-only du dépôt est `scripts/genai-stack/Configure-IISAuthentication.ps1`
+(IIS n'existe pas sur Mac/Linux) — pas de jumeau bash prévu.
 
 ## Validation Lean
 

--- a/scripts/environment/README.md
+++ b/scripts/environment/README.md
@@ -12,14 +12,14 @@ jumeau bash (`.sh`, Linux/macOS) de comportement équivalent.
 | Script | Windows | Linux / macOS | Rôle |
 |--------|---------|---------------|------|
 | Setup de base | `setup_environment.ps1` | `setup_environment.sh` | Installe packages Python, .NET Interactive, kernels Jupyter (checkpoints/resume) |
-| Audit | `audit_environment.ps1` | `_audit_environment.sh` *(à venir)* | Diagnostic complet de l'environnement |
-| Automata (build/déploiement) | `automata-build-deploy.ps1` | `_automata-build-deploy.sh` *(à venir)* | Build et déploiement des automates |
+| Audit | `audit_environment.ps1` | `audit_environment.sh` | Diagnostic complet de l'environnement |
+| Automata (build/déploiement) | `automata-build-deploy.ps1` | `automata-build-deploy.sh` | Build et déploiement des automates |
 | FFmpeg | `install-ffmpeg.ps1` | `install-ffmpeg.sh` | Installation de FFmpeg |
 | Z3 (build fork) | `z3-build-deploy.ps1` | `z3-build-deploy.sh` | Build du wrapper Z3.Linq forké |
 
-Les lignes « *(à venir)* » sont des jumeaux bash pas encore écrits — suivis
-dans #10644. Les scripts préfixés `_` ci-dessus sont des placeholders
-indicatifs, **ils ne sont pas commités** tant que le jumeau n'est pas écrit.
+Les cinq jumeaux bash sont **livrés et commités** (PRs #10650, #10657, #10670,
+#10673 + FFmpeg/Z3 préexistants). Le préfixe `_` « placeholder » est désormais
+obsolète : tous les scripts ci-dessus existent sur `main`.
 
 ## Usage
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA — prev: DEEP/lean #10781

## Summary

Finalise l'acceptance de #10644 (jumeaux Linux/macOS scripts/) : les 5 jumeaux
`.sh` sont **tous livrés et mergés** (#10650 setup, #10657 audit, #10670
shared_mathlib, #10673 Manage-ApiKeys, + FFmpeg/Z3 préexistants), MAIS les 2
README qui devaient les documenter restaient **stale** — marquant `audit` et
`automata` comme `*(à venir)*` avec placeholders `_` inexistants.

Audit fichier-entier §E ([pr-review-discipline](../../.claude/rules/pr-review-discipline.md) §E) : 2 fichiers, 3 blocs stale.

### Fix

**`scripts/environment/README.md`** (équivalences) :
- `audit_environment.sh` : `_audit_environment.sh *(à venir)*` → `audit_environment.sh`
- `automata-build-deploy.sh` : `_automata-build-deploy.sh *(à venir)*` → `automata-build-deploy.sh`
- Note `_` « placeholders pas commités » → note « 5 jumeaux livrés et commités » (cite les 4 PRs)

**`scripts/README.md`** (audit §E fichier-entier) :
- Structure tree §environment : 3 lignes stale (audit/setup/install-ffmpeg, 1 seul `.sh`) → 6 entrées jumeaux `.ps1/.sh` (setup, audit, automata, install-ffmpeg, z3) + ligne README.md cross-ref
- Section §Installation : commandes Windows-only → Windows **et** Linux/macOS (les 3 jumeaux `.sh`), + note cas Windows-only `Configure-IISAuthentication.ps1` (IIS intrinsèque à Windows, pas de jumeau prévu)

### Cas Windows-only (acceptance #10644 « README croisé documentant IIS »)

`scripts/genai-stack/Configure-IISAuthentication.ps1` est le **seul** script
du dépôt intrinsèquement Windows-only (IIS n'existe pas sur Mac/Linux). Ce
cas était documenté dans `scripts/environment/README.md` §65-70 (déjà correct)
mais **absent** de `scripts/README.md` §Installation. La note ajoutée dans
`scripts/README.md` comble ce gap (acceptance explicitement demandée).

### Audit §E — ce qui a été vérifié

- `ls scripts/environment/` firsthand : 10 fichiers (5 `.ps1` + 5 `.sh`), aucune exclusion
- `ls scripts/genai-stack/` firsthand : `Manage-ApiKeys.{ps1,sh}` jumeaux livrés, `Configure-IISAuthentication.ps1` seul sans jumeau (Windows-only légitime)
- `grep -iE "iis|windows-only"` `scripts/genai-stack/README.md` : vide (IIS non documenté → comblé par cette PR dans `scripts/README.md`)
- Le bloc `genai-stack` §15-16 de `scripts/README.md` pointe déjà vers son README dédié → pas touché
- Autres sections de `scripts/README.md` (notebook_tools, genai.py, translation, validation) : à jour, pas touchées

### Diff

2 fichiers, +23/-15. Catalogue byte-identique à `origin/main` (0 fichier catalogue touché). Pas de code, pas de notebook.

See #10644, #10643 (EPIC).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
