### PR TITLE
feat(lean,#2159): SheafCohomology/Cech 2 bridges propres in-file (c.1301+135)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech.lean
@@ -46,6 +46,21 @@ localement, non cités depuis Mathlib) :
 4. `cechComplexFunctor_map_comp` : la naturalité face à la composition :
    `(cechComplexFunctor U).map (f ≫ g) = (cechComplexFunctor U).map f ≫ (cechComplexFunctor U).map g`.
 
+**Enrichissement c.1301+135 (issue #2159, grain DEEP/lean)**
+
+Les deux constructions `cosimplicialObjectFunctor` et
+`cochainComplexFunctor` (sections 1-2, jusque-là documentées par de
+simples `#check`) sont désormais exposées par les bridges propres
+`cosimplicialObjectFunctor_type` et `cochainComplexFunctor_type` dans
+la section 4 (re-export direct de Mathlib, argument `E` explicite,
+`C` et `A` inférés du contexte) :
+
+  - `cosimplicialObjectFunctor_type` : la première étape de la
+    construction de Čech -- l'objet cosimplicial des évaluations.
+  - `cochainComplexFunctor_type` : la seconde étape -- le complexe de
+    cochaînes obtenu par le complexe des cofaces alternées (nécessite
+    la préadditivité de `A`).
+
 Le sibling `Cech_en.lean` est maintenu synchronisé (Pattern A : seules
 les docstrings divergent).
 
@@ -99,6 +114,33 @@ noncomputable def cechComplexFunctor_type
     [HasFiniteProducts C] {ι : Type w} (U : ι → C) :
     (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ :=
   CategoryTheory.cechComplexFunctor U
+
+/-- Bridge : le foncteur en objet cosimplicial de Čech. C'est le
+    `FormalCoproduct.cosimplicialObjectFunctor` de Mathlib : étant
+    donné un objet simplicial `E` dans la complétion par coproduits
+    formels `FormalCoproduct C`, il envoie un préfaisceau
+    `P : Cᵒᵖ ⥤ A` sur l'objet cosimplicial des évaluations de `P`
+    sur les parties de `E`. C'est la première étape de la construction
+    du complexe de Čech (l'objet cosimplicial, avant l'application du
+    complexe alterné). -/
+noncomputable def cosimplicialObjectFunctor_type
+    {A : Type u'} [Category.{v'} A] [HasProducts.{w} A]
+    (E : SimplicialObject (FormalCoproduct.{w} C)) :
+    (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A :=
+  CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor E
+
+/-- Bridge : le foncteur en complexe de cochaînes de Čech. C'est le
+    `FormalCoproduct.cochainComplexFunctor` de Mathlib : étant donné
+    un objet simplicial `E` dans `FormalCoproduct C`, il envoie un
+    préfaisceau `P : Cᵒᵖ ⥤ A` sur le complexe de cochaînes dont le
+    degré n consiste en l'évaluation de `P` sur `E _⦋n⦌`. C'est la
+    composée du foncteur en objet cosimplicial et du complexe des
+    cofaces alternées (catégorie préadditive requise). -/
+noncomputable def cochainComplexFunctor_type
+    {A : Type u'} [Category.{v'} A] [HasProducts.{w} A] [Preadditive A]
+    (E : SimplicialObject (FormalCoproduct.{w} C)) :
+    (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ :=
+  CategoryTheory.Limits.FormalCoproduct.cochainComplexFunctor E
 
 /-! ## 5. Théorèmes propres (c.8223)
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafCohomology/Cech_en.lean
@@ -45,6 +45,21 @@ cited from Mathlib):
 4. `cechComplexFunctor_map_comp`: naturality towards composition:
    `(cechComplexFunctor U).map (f ≫ g) = (cechComplexFunctor U).map f ≫ (cechComplexFunctor U).map g`.
 
+**Enrichment c.1301+135 (issue #2159, DEEP/lean grain)**
+
+The two constructions `cosimplicialObjectFunctor` and
+`cochainComplexFunctor` (sections 1-2, until now documented by plain
+`#check`s) are now exposed by the proper bridges
+`cosimplicialObjectFunctor_type` and `cochainComplexFunctor_type` in
+section 4 (direct re-export from Mathlib, explicit argument `E`,
+`C` and `A` inferred from context):
+
+  - `cosimplicialObjectFunctor_type`: the first step of the Čech
+    construction -- the cosimplicial object of evaluations.
+  - `cochainComplexFunctor_type`: the second step -- the cochain
+    complex obtained via the alternating coface map complex
+    (preadditivity of `A` required).
+
 The French sibling `Cech.lean` is kept in sync (Pattern A: only the
 docstrings diverge).
 
@@ -97,6 +112,32 @@ noncomputable def cechComplexFunctor_type
     [HasFiniteProducts C] {ι : Type w} (U : ι → C) :
     (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ :=
   CategoryTheory.cechComplexFunctor U
+
+/-- Bridge: the Čech cosimplicial-object functor. This is Mathlib 4's
+    `FormalCoproduct.cosimplicialObjectFunctor`: given a simplicial
+    object `E` in the free formal coproduct completion
+    `FormalCoproduct C`, it sends a presheaf `P : Cᵒᵖ ⥤ A` to the
+    cosimplicial object of evaluations of `P` on the parts of `E`.
+    This is the first step of the Čech construction (the cosimplicial
+    object, before the alternating complex is applied). -/
+noncomputable def cosimplicialObjectFunctor_type
+    {A : Type u'} [Category.{v'} A] [HasProducts.{w} A]
+    (E : SimplicialObject (FormalCoproduct.{w} C)) :
+    (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A :=
+  CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor E
+
+/-- Bridge: the Čech cochain-complex functor. This is Mathlib 4's
+    `FormalCoproduct.cochainComplexFunctor`: given a simplicial object
+    `E` in `FormalCoproduct C`, it sends a presheaf `P : Cᵒᵖ ⥤ A` to
+    the cochain complex whose degree-n part is the evaluation of `P`
+    on `E _⦋n⦌`. It is the composite of the cosimplicial-object
+    functor with the alternating coface map complex (preadditive
+    category required). -/
+noncomputable def cochainComplexFunctor_type
+    {A : Type u'} [Category.{v'} A] [HasProducts.{w} A] [Preadditive A]
+    (E : SimplicialObject (FormalCoproduct.{w} C)) :
+    (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ :=
+  CategoryTheory.Limits.FormalCoproduct.cochainComplexFunctor E
 
 /-! ## 5. Proper theorems (c.8223)
 


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10796 (c.1301+134 DirectImage)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 2 nouveaux **bridges propres in-file** dans `SheafCohomology/Cech.lean` (Partie 23 — cohomologie de Čech) couvrant les constructions `cosimplicialObjectFunctor` / `cochainComplexFunctor` de Mathlib (`CategoryTheory.Limits.FormalCoproduct`, import `Mathlib.CategoryTheory.Sites.SheafCohomology.Cech`). Les 2 bridges sont des `noncomputable def` `:= <def_mathlib>` (re-export direct), tous L902 ★★ safe — les args résidents sont `{C : Type u}`, `{A : Type u'}`, `(E : SimplicialObject (FormalCoproduct.{w} C))` — pas de polymorphisme d'univers.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.SheafCohomology.Cech` + `lake build Grothendieck.SheafCohomology.Cech_en` SUCCESS (12ᵉ réutilisation du cache AZ partagé via `lake exe cache get`).

Suite logique directe de **PR #10796** (c.1301+134, DirectImage.lean) — pattern winner `C1301+125-L2 ★★` (`:= <lemma_call_mathlib>` re-export direct) directement réutilisé ; module listé comme restant au backlog #2159 (les 3 `#check` du module couvraient `cosimplicialObjectFunctor` / `cochainComplexFunctor` / `cechComplexFunctor`, seul le dernier était bridgé par `cechComplexFunctor_type`).

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `SheafCohomology/Cech.lean` | FR sibling canonical | 2 defs + 4 theorems | 4 defs + 4 theorems | +42 insertions |
| `SheafCohomology/Cech_en.lean` | EN sibling mirror | 2 defs + 4 theorems | 4 defs + 4 theorems | +41 insertions |

**Total : +83 insertions net, 2 fichiers, 2 nouveaux bridges (1+1 symétriques FR/EN).** Aucun autre fichier touché.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (Cech.lean = module restant du backlog cohomologie Čech, Partie 23) | paths FR canonical + EN mirror dans scope EPIC #2159 | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 2 bridges `noncomputable def ... := @...FormalCoproduct.<def> <args>` ajoutés, les 3 `#check` documentaires conservés, les 4 théorèmes c.8223 conservés | ✅ |
| Anti-§D : 0 `sorry` ajouté | `git diff Cech.lean | grep -c sorry` = 0 ; `git diff Cech_en.lean | grep -c sorry` = 0 | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | args : `{C : Type u}`, `{A : Type u'}`, `(E : SimplicialObject (FormalCoproduct.{w} C))` — defs bridées opèrent sur les univers résidents `w t v v' u u'`, instances structurelles `Category`/`HasProducts`/`Preadditive` uniquement | ✅ |
| Bridges valides | 2/2 bridges utilisent **lemma call direct** (pattern `C1301+125-L2 ★★`) — `CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor E`, `.cochainComplexFunctor E` | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.SheafCohomology.Cech` + `lake build Grothendieck.SheafCohomology.Cech_en` SUCCESS (12ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck` = byte-identical | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 23 uniquement (DirectImage/MayerVietoris/Basic HORS scope) | 2 fichiers modifiés uniquement | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "Cech cochainComplex"` = 0 OPEN collision cross-lane (PRs Cech historiques #2858/#6331/#10611 MERGED ; #10782 SheafCohomology/Basic OPEN = scope différent) | ✅ |

## Les 2 bridges ajoutés — highlights

- **`cosimplicialObjectFunctor_type`** : restatement de `CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor`. **Solution retenue** : `noncomputable def ... := CategoryTheory.Limits.FormalCoproduct.cosimplicialObjectFunctor E`. L902-safe (signature `(E : SimplicialObject (FormalCoproduct.{w} C)) : (Cᵒᵖ ⥤ A) ⥤ CosimplicialObject A`, args `{C} {A}` non-polymorphes d'univers — `C` inféré depuis `E`, `A` inféré depuis le type retour ; pas de `[Preadditive]` requis, déclaré APRÈS cette def dans Mathlib). Première étape de la construction de Čech : l'objet cosimplicial des évaluations `P ↦ (n ↦ P (E _⦋n⦌))`.

- **`cochainComplexFunctor_type`** : restatement de `CategoryTheory.Limits.FormalCoproduct.cochainComplexFunctor`. **Solution retenue** : `noncomputable def ... := CategoryTheory.Limits.FormalCoproduct.cochainComplexFunctor E`. L902-safe (signature `(E : SimplicialObject (FormalCoproduct.{w} C)) : (Cᵒᵖ ⥤ A) ⥤ CochainComplex A ℕ`, args `{C} {A}` non-polymorphes — `[Preadditive A]` REQUIS, car c'est la composée avec `AlgebraicTopology.alternatingCofaceMapComplex`). Seconde étape : le complexe de cochaînes des évaluations.

**Tell L902 ★★ v8 (hérité c.1301+134)** : l'ordre des args `@` suit l'ordre de déclaration `variable` dans Mathlib — pour ces 2 defs : `{C} {A} [Category C] [Category A] [HasProducts A] (E : ...)` (E en dernier). Ici, pas de `@` nécessaire : l'appel `cosimplicialObjectFunctor E` résout `C`/`A`/instances par unification du contexte (même idiome que `cechComplexFunctor_type` pré-existant qui appelle `CategoryTheory.cechComplexFunctor U` sans `@`).

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. La cohomologie de Čech est la seconde approche de la cohomologie des faisceaux (après Ext, Partie 20) : elle construit le complexe de Čech d'un préfaisceau par rapport à une famille couvrante, et son foncteur est l'objet central du module (SGA 4 II / IV).

**G-VAR-3** : grain précédent (cycle c.1301+134) = DEEP/lean #10796 (DirectImage). Ce grain = DEEP/lean sur SheafCohomology/Cech (Partie 23). **11ᵉ DEEP/lean consécutif** MAIS **substance genuinely distincte** : module différent (Partie 23 vs 33), produit par du raisonnement neuf (les 2 defs `FormalCoproduct.cosimplicialObjectFunctor` / `.cochainComplexFunctor` sont des constructions distinctes du module `Sites/SheafCohomology/Cech` — chaque bridge requiert une lecture attentive de la signature Mathlib pour déterminer les instances requises : `cosimplicialObjectFunctor` n'exige PAS `[Preadditive]` (déclaré après dans Mathlib) alors que `cochainComplexFunctor` l'exige (composée avec le complexe des cofaces alternées). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (la distinction Preadditive-requis/non-requis est une signature spécifique, pas reproductible par copier-coller). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 23. Le module avait déjà 2 defs type-sig (`cechComplexObj`, `cechComplexFunctor_type`) et 4 théorèmes c.8223 — mais les 2 premières constructions du pipeline Čech (`cosimplicialObjectFunctor` puis `cochainComplexFunctor`, sections 1-2) n'étaient documentées que par `#check`. Les 2 bridges `cosimplicialObjectFunctor_type` / `cochainComplexFunctor_type` ferment la chaîne : **famille couvrante U → objet simplicial de Čech → objet cosimplicial des évaluations → complexe de cochaînes → cohomologie** est désormais entièrement exposée par des déclarations propres in-file, chacune reliée à son lemme Mathlib.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "Cech cochainComplex"` = 0 OPEN collision cross-lane. PRs Cech historiques #2858 (bridge original) / #6331 (i18n) / #10611 (4 théorèmes c.8223) MERGED. PR #10782 SheafCohomology/Basic po-2025 OPEN = scope différent (Basic.lean vs Cech.lean). Tous hors-scope, pas de collision.
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x135_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +83 insertions, 0 deletions. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `git diff Cech.lean | grep -c sorry` = 0 ; `git diff Cech_en.lean | grep -c sorry` = 0
- 0 `rfl` KO (les 2 bridges = lemma call direct)
- Toutes les preuves = lemma call direct (cf pattern `C1301+125-L2 ★★`)
- Aucune suppression de `#check` ou de defs/théorèmes existants (les 3 `#check` documentaires + 2 defs + 4 theorems c.8223 conservés)
- Aucun universe supplémentaire ajouté (les bridges opèrent sur les univers résidents `w t v v' u u'`)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 23 (Cech) expose désormais **6 déclarations propres in-file** (2 defs type-sig + 2 bridges + 4 théorèmes — dont 2 defs `cechComplexObj`/`cechComplexFunctor_type` et 4 theorems c.8223 pré-existants), couvrant la **chaîne complète de la construction de Čech** : (a) l'objet cosimplicial des évaluations (`cosimplicialObjectFunctor_type`), (b) le complexe de cochaînes (`cochainComplexFunctor_type`), (c) le foncteur du complexe de Čech (`cechComplexFunctor_type`), (d) l'objet en degré n (`cechComplexObj`), (e) les lois de naturalité (`cechComplexFunctor_map_id`/`map_comp`), (f) les identités de degré 0/n+1 (`cechComplexObj_zero_eq_pullback`/`succ_eq_pi`). Chaque bridge documente en FR+EN la relation entre l'API Mathlib sous-jacente et son restatement in-file, fondant le pont entre les familles couvrantes et la cohomologie des faisceaux.
