### PR TITLE
feat(genai,#10488): barbie-schreck density 508->1809 md-words — enrichissement markdown-only FR (c.8268)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/CaseStudies/Barbie-Schreck/barbie-schreck.ipynb
@@ -65,9 +65,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Notebook utilisant Semantic Kernel pour un débat contraint avec génération d'images\n"
-   ]
+   "source": "Notebook utilisant **Semantic Kernel** pour organiser un débat contraint entre deux agents — Barbie et l'Âne de Shrek — avec **génération d'images DALL-E** à chaque réplique de l'Âne.\n\nLe fil conducteur pédagogique en 4 actes :\n\n1. **Contrainte** — un style linguistique (rime, Shakespeare, chanson) est tiré au sort et imposé aux deux agents via leurs instructions système ;\n2. **Agents** — deux `ChatCompletionAgent` aux personnalités opposées, chacun sur son propre kernel ;\n3. **Plugin** — un `ImagePlugin` branché sur l'Âne illustre chaque réplique ;\n4. **Orchestration** — un `AgentGroupChat` + une stratégie de terminaison font tourner le duel jusqu'à `MAX_TURNS`.\n\nLes trois exercices font évoluer ce socle : nouvelles contraintes, troisième agent arbitre, terminaison dynamique par mots-clés."
   },
   {
    "cell_type": "code",
@@ -128,10 +126,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Configuration initiale\n",
-    "Chargement des variables d'environnement et initialisation des services\n"
-   ]
+   "source": "## Configuration initiale\n\nCette cellule importe toutes les briques nécessaires et prépare l'environnement :\n\n- **`os`, `random`, `logging`** — utilitaires standard (variables d'env, tirage de contrainte, logs) ;\n- **`dotenv`** — `load_dotenv()` charge les clés API depuis le fichier `.env` local (voir `OPENAI_API_KEY` utilisée plus bas) ;\n- **`semantic_kernel`** — le cœur : `Kernel`, `ChatCompletionAgent`, `AgentGroupChat`, les connecteurs OpenAI (chat + texte-à-image), `kernel_function`, `ChatMessageContent`/`AuthorRole`.\n\nLe `logging.basicConfig(level=logging.INFO)` active les logs INFO qui rendront l'exécution du débat lisible (sélection d'agent, usage API). L'output `Imports et configuration OK` confirme que toutes les dépendances sont présentes sur la machine d'exécution.\n\nLa cellule `# Import guards` précédente joue un rôle de pré-vol : elle vérifie la disponibilité de `IPython`, `dotenv` et `semantic_kernel` et définit des flags (`IPYTHON_AVAILABLE`, etc.) sans interrompre le notebook si une dépendance manque."
   },
   {
    "cell_type": "code",
@@ -193,10 +188,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Définition des contraintes linguistiques\n",
-    "Sélection aléatoire d'une contrainte pour le débat\n"
-   ]
+   "source": "## Définition des contraintes linguistiques\n\nLe débat ne gagne en intérêt que si les répliques obéissent à une règle. La liste `CONTRAINTES` définit **trois styles possibles**, chacun sous la forme d'un tuple `(nom, description)` :\n\n| Nom | Règle |\n|---|---|\n| `Rime` | Chaque réplique contient une rime parfaite |\n| `Shakespeare` | Imiter le style théâtral de Shakespeare |\n| `Chanson` | Répondre sur l'air d'I'm a Believer |\n\n`random.choice` tire une contrainte au sort à chaque exécution — l'output montre que la **Rime** a été choisie, et les répliques du débat riment effectivement. La structure en tuples `(nom, description)` est celle que l'Exercice 1 demande d'étendre : la description est interpolée dans les instructions des agents, donc toute nouvelle entrée de la liste se répercute automatiquement sur le comportement des deux duellistes."
   },
   {
    "cell_type": "code",
@@ -275,10 +267,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Création du kernel\n",
-    "Initialisation des services OpenAI pour le chat et les images\n"
-   ]
+   "source": "## Création du kernel\n\n`create_kernel()` instancie un `Kernel` Semantic Kernel et y enregistre **deux services OpenAI distincts**, identifiés par leur `service_id` :\n\n- **`chat`** : `OpenAIChatCompletion` — le modèle de conversation (id lu depuis `OPENAI_CHAT_MODEL_ID`) ;\n- **`dalle`** : `OpenAITextToImage` — le modèle de génération d'images `gpt-image-1`, codé en dur ici.\n\nLe pattern `service_id` est central : c'est lui qui permet ensuite à `kernel.get_service(\"dalle\", OpenAITextToImage)` (dans `ImagePlugin`) et aux agents de retrouver le bon service, même quand un kernel en porte plusieurs.\n\nLes clés API sont lues depuis l'environnement (`os.getenv`) — jamais en dur dans le notebook — conformément à l'hygiène des secrets du dépôt. La fonction est appelée **deux fois** (un kernel par agent) : chaque duelliste dispose de sa propre pile de services, ce qui isole leurs appels."
   },
   {
    "cell_type": "code",
@@ -342,10 +331,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Plugin de génération d'images\n",
-    "Implémentation de la fonctionnalité de création d'illustrations\n"
-   ]
+   "source": "## Plugin de génération d'images\n\n`ImagePlugin` encapsule l'appel au service DALL-E du kernel sous forme de **fonction invocable** Semantic Kernel. Le décorateur `@kernel_function(name=\"generate_image\", description=\"...\")` expose la méthode `generate` comme une capacité que le kernel peut invoquer par nom.\n\nDétails de l'implémentation :\n\n- **récupération du service** : `kernel.get_service(\"dalle\", OpenAITextToImage)` retrouve le service ajouté dans `create_kernel()` par son `service_id` ;\n- **style appliqué** : chaque image est générée avec le préfixe `\"Style cartoon comique - \"` + la réplique de l'Âne en contexte — c'est ce qui produit des illustrations cohérentes avec le duel ;\n- **dimensions** : `1024x1024` (carré), le format natif de `gpt-image-1` ;\n- **robustesse** : en cas d'échec, l'exception est loggée (`logger.error`) et la méthode retourne une chaîne vide — le débat continue sans illustration plutôt que de crasher.\n\nL'output de la cellule montre la classe définie avec succès, prête à être branchée sur un kernel."
   },
   {
    "cell_type": "code",
@@ -413,10 +399,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Configuration des agents\n",
-    "Création des personnages avec leurs instructions spécifiques\n"
-   ]
+   "source": "## Configuration des agents\n\nChaque duelliste est un `ChatCompletionAgent` avec son **propre kernel** (`kernel_barbie`, `kernel_ane`) et des instructions système distinctes :\n\n- **Barbie** : « Défends des positions optimistes avec élégance » — le ton soigné ;\n- **L'Âne de Shrek** : « Utilise l'humour absurde et décalé » — le ton débridé.\n\nLes deux instructions embarquent la contrainte linguistique choisie (`contrainte_choisie[1]`), interpolée dans le prompt système : c'est ce qui garantit que **chaque** réplique, quel que soit l'agent, respecte la règle du débat.\n\nPoint de câblage important : le plugin `ImagePlugin` est ajouté **uniquement au kernel de l'Âne** (`kernel_ane.add_plugin(...)`). Barbie parle, l'Âne parle *et* illustre — la dissymétrie est volontaire et montre que les plugins sont attachés par kernel, pas globalement."
   },
   {
    "cell_type": "code",
@@ -517,10 +500,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Stratégie de terminaison\n",
-    "Arrêt du débat après 5 échanges\n"
-   ]
+   "source": "## Stratégie de terminaison\n\nSans règle d'arrêt, un `AgentGroupChat` tournerait indéfiniment. `DebateTerminationStrategy` sous-classe `TerminationStrategy` et implémente `should_terminate` : le débat s'arrête dès que l'historique atteint `MAX_TURNS = 5` messages.\n\nDeux détails d'implémentation à noter :\n\n- **`ClassVar[int]`** : `MAX_TURNS` est une constante de classe, pas un champ d'instance — l'annotation `ClassVar` évite le conflit avec le mécanisme d'annotations de Semantic Kernel ;\n- **le contrat d'`async`** : `should_terminate` est `async def`, ce qui permettrait plus tard une terminaison dynamique (interroger le contenu du dernier message, un service externe, etc.) — c'est exactement la piste de l'Exercice 3.\n\nLa stratégie est passée à l'`AgentGroupChat` au moment de sa construction, et est consultée après chaque message ajouté à l'historique."
   },
   {
    "cell_type": "code",
@@ -581,10 +561,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Lancement du débat\n",
-    "Exécution de la conversation avec génération d'images\n"
-   ]
+   "source": "## Lancement du débat\n\nL'`AgentGroupChat` rassemble les deux agents (`barbie`, `ane`) et la stratégie de terminaison définie plus haut. L'appel `add_chat_message` amorce la conversation — Semantic Kernel exige un historique non vide — puis `group_chat.invoke()` fait tourner le duel :\n\n- chaque agent produit sa réplique à tour de rôle, conformément à la stratégie de sélection séquentielle ;\n- **spécificité pédagogique** : à chaque réplique de l'Âne de Shrek, le code invoque le plugin `image_gen` (`generate_image`) avec le contenu de la réplique en contexte, puis affiche l'image DALL-E générée (`width=300`).\n\nC'est ici que se matérialise la boucle « parler puis illustrer » : le texte d'un agent devient l'argument d'un appel d'image, reliant les deux services OpenAI (chat + génération) dans le même débat."
   },
   {
    "cell_type": "code",
@@ -916,6 +893,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "71023d39",
+   "source": "### Lecture du résultat : le duel verbal réel\n\nL'exécution montre le protocole complet en action, tour par tour :\n\n- **Sélection séquentielle des agents** : les logs `Selected agent at index 0/1` alternent Barbie puis l'Âne de Shrek, conformément à `AgentGroupChat` avec sa stratégie de sélection par défaut.\n- **Contrainte de rime respectée** : Barbie répond « sourire intact, prête à te mener vers la victoire » puis « talons bien posés, cap sur la victoire » ; l'Âne rime « je veux du bruit et du fromage » puis « j'te réponds au galop, c'est la bagarre ». Chaque paire de vers obéit à la contrainte `Rime` tirée au sort — l'instruction système portée par l'agent suffit à contraindre la génération.\n- **Consommation API mesurée** : chaque réplique textuelle consomme entre **95 et 512 tokens** (`CompletionUsage` visible dans les logs) ; chaque image DALL-E `gpt-image-1` consomme **4160 output tokens** et ~**37-40 s** de génération (durées 37.48 s et 39.95 s observées).\n- **Le plugin d'image n'est branché que sur l'Âne** : seul `Ane_Shrek` déclenche `image_gen-generate_image`, conformément au câblage `kernel_ane.add_plugin(...)` de la configuration des agents.\n- **La terminaison fonctionne** : après 5 messages d'historique, `DebateTerminationStrategy.should_terminate` coupe la boucle.\n\nLa sortie est donc la **preuve de bout en bout** du montage : deux agents contraints, un plugin d'image, une stratégie de terminaison — le tout orchestré par Semantic Kernel.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "c827dcb0",
    "metadata": {
     "papermill": {
@@ -927,17 +910,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "Ce notebook a permis d explorer les aspects essentiels de barbie schreck. Les points cles :\n",
-    "\n",
-    "- Les concepts fondamentaux ont ete presentes et illustres\n",
-    "- Les exercices proposent une mise en pratique progressive\n",
-    "- Les résultats obtenus permettent de valider la comprehension\n",
-    "\n",
-    "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d autres domaines."
-   ]
+   "source": "## Conclusion\n\nCe notebook a démontré un **débat multi-agents contraint** avec Semantic Kernel : deux `ChatCompletionAgent` (Barbie et l'Âne de Shrek) s'affrontent en respectant une contrainte linguistique tirée au sort (ici la **Rime**), et l'Âne illustre chacune de ses répliques par une image DALL-E générée à la volée.\n\n**Points clés observés dans l'exécution réelle** :\n\n- **Le protocole de sélection séquentielle** alterne les agents (Barbie → Âne → Barbie → Âne) via `SequentialSelectionStrategy`, les logs `Selected agent at index N` traçant chaque tour.\n- **La contrainte linguistique est respectée** : les répliques produites riment (« je vise la victoire » / « prépare ta langue au fromage », « cap sur la victoire » / « c'est la bagarre »), preuve que l'instruction système portant la contrainte est suivie par le modèle.\n- **La génération d'images est coûteuse mais fiable** : chaque illustration consomme **4160 output tokens** DALL-E (usage observé) et prend **~37-40 s** — l'appel `text_to_image` est le goulot d'étranglement du débat.\n- **La stratégie de terminaison fonctionne** : le débat s'arrête après `MAX_TURNS = 5` messages d'historique.\n\n**Pour aller plus loin** : les trois exercices proposent d'étendre le système — nouvelles contraintes (Exercice 1), un troisième agent arbitre (Exercice 2), et une terminaison dynamique par mots-clés (Exercice 3). L'architecture (kernel + plugin + stratégie de terminaison) est réutilisable telle quelle pour d'autres formats de joute (débat politique, concours de poésie, improvisation théâtrale)."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #10798

Sub-grain de l'EPIC **#10488** (montée progressive du plancher de densité pédagogique), tranche `GenAI/CaseStudies` : enrichissement markdown-only du notebook `barbie-schreck.ipynb` (débat multi-agents Semantic Kernel Barbie vs Âne de Shrek + génération d'images DALL-E).

## Scope

**Densité 508 → 1809 mots MD** (palier P2 = 500, cible > 700 — dépassée ×2.5). 9 sections minces (9-13 mots chacune) enrichies avec substance pédagogique ancrée sur l'output réel :

| Cellule | Avant | Après |
|---|---|---|
| Intro (da30ce89) | 12w | fil conducteur en 4 actes (contrainte/agents/plugin/orchestration) |
| Config initiale (a7548b48) | 11w | imports, dotenv, logging, rôle des import guards |
| Contraintes linguistiques (e9592b88) | 12w | table des 3 styles + mécanique random.choice → interpolation dans les instructions |
| Création du kernel (8d4bd174) | 13w | pattern service_id, 2 services OpenAI, clés env (hygiène secrets) |
| Plugin images (6a189386) | 13w | @kernel_function, get_service par id, style cartoon, robustesse |
| Config agents (82f29e01) | 10w | 2 kernels séparés, instructions distinctes, dissymétrie plugin Âne-only |
| Stratégie terminaison (8736c2ad) | 9w | ClassVar, contrat async, piste Exercice 3 |
| Lancement du débat (8514a144) | 11w | AgentGroupChat, add_chat_message, boucle parler-puis-illustrer |
| Conclusion (c827dcb0) | 58w | points clés observés : sélection séquentielle, rimes respectées, coût image |

**+ 1 cellule d'interprétation insérée** (`### Lecture du résultat`, après le run réel) — ancrage sémantique (cell-interpretation-ordering) sur les valeurs de l'output `run_debate` :

- tokens usage textuels : 95 / 316 / 278 / 512 (`CompletionUsage` dans les logs)
- 2 images DALL-E × **4160 output tokens** (usage observé `output_tokens=4160`)
- durées de génération : **37.48 s** et **39.95 s**
- répliques rimees verbatim (« sourire intact, prête à te mener vers la victoire » / « je veux du bruit et du fromage »)

## Validation

| Critère | Résultat |
|---|---|
| Cellules code touchées | **0/12** (byte-identiques à origin/main, vérifié `git show origin/main:...` vs courant) |
| C.1 erreurs volontaires | 0 (`grep raise/assert/1/0` : clean) — 3 stubs exercices préservés |
| C.2 outputs | conservés (markdown-only → exception C.3, pas de re-exec requise) |
| scan_cell_ordering | 1 clean, 0 finding (interp après code, exercices ordonnés) |
| check_prose_quantitative_claims --diff --strict | `[OK] aucun compteur quantitatif en prose` |
| Catalogue | byte-identique à main (0 fichier catalogue touché) |

## Décision i18n — scope FR seul

Le sibling `barbie-schreck_en.ipynb` est **supprimé par la PR #10772** (rollback 14 `*_en.ipynb`, hold i18n, décision user 2026-08-12 : « le contenu des notebooks bouge trop en ce moment »). Travailler le miroir EN serait du travail jeté + collision avec #10772 → enrichissement **FR source uniquement**, conforme au hold.

## Anti-collision L898 ★★★

- `gh pr list --state open --json files` : seule PR touchant `barbie-schreck*` = **#10772** (suppression du sibling EN uniquement, pas le FR) — aucun conflit avec cette PR-ci.
- Claim `[CLAIMED]` posé sur #10488 (issuecomment-5284216948) avec `paths:` restreint au fichier FR.
- Tranche GenAI/CaseStudies : Fort-Boyard/Medical-Chatbot/Recipe-Maker claimés par po-2024 — Barbie-Schreck était libre.

## Acceptance

| Critère | Valeur |
|---|---|
| Fichiers modifiés | 1 (`barbie-schreck.ipynb`) |
| Insertions / Deletions | +16 / −43 (remplacement cellules entières par NotebookEdit) |
| Densité finale | 1809 mots MD (cible > 700) |
| Cellules code | 12/12 byte-identiques |
| i18n | FR seul (hold #10772) |

See #10488 (l'epic reste ouvert — le plancher CI et les autres tranches vivent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
