### PR TITLE
feat(lean,#2159): Equivalences.lean 5 bridges propres — critère d'équivalence (Full+Faithful+EssSurj) + identité triangulaire (Partie 29, c.1301+137)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences.lean
@@ -277,4 +277,62 @@ theorem equivalence_symm_unit (e : C ≌ D) :
   cases e
   rfl
 
+/-!
+## 9. Ponts sur le critère d'équivalence et l'identité triangulaire
+
+Le **critère pratique d'équivalence** (section 4) est la classe
+`Functor.IsEquivalence F` = `F.Faithful` + `F.Full` + `F.EssSurj` : un
+foncteur est une équivalence ssi il est pleinement fidèle et essentiellement
+surjectif. Les classes `FullyFaithful` (structure data contenant les
+preimages) et `EssSurj` (classe Prop) en sont les deux ingrédients.
+L'**identité triangulaire** `functor_unitIso_comp` (field pointwise de la
+structure `Equivalence`) relie l'unité et la coïnité le long du foncteur :
+c'est l'analogue pour les équivalences de `left_triangle` pour les
+adjonctions. `Equivalence.refl` donne l'équivalence identité 𝟭 C.
+-/
+
+/-- Pont : l'identité triangulaire d'une équivalence, en version **pointwise**
+    (composante en un objet) : `functor.map (unitIso.hom.app X) ≫
+    counitIso.hom.app (functor.obj X) = 𝟙 (functor.obj X)`. C'est le field
+    `functor_unitIso_comp` de la structure `Equivalence` — l'analogue exact,
+    pour les équivalences, de l'identité triangulaire gauche des adjonctions
+    (`Grothendieck.Adjunction.left_triangle`). Délègue directement au field.
+    Field pointwise de la structure (L902 ★★ Tier 5). -/
+theorem equivalence_triangle_field (e : C ≌ D) (X : C) :
+    e.functor.map (e.unitIso.hom.app X) ≫ e.counitIso.hom.app (e.functor.obj X) =
+      𝟙 (e.functor.obj X) :=
+  e.functor_unitIso_comp X
+
+/-- Pont : l'équivalence identité `𝟭 C ≌ 𝟭 C` via `Equivalence.refl`. C'est
+    l'élément neutre de la structure de (2-)groupeoïde des catégories. Re-export
+    direct de la def Mathlib `Equivalence.refl`.
+    Type retour `≌` = structure `Equivalence` = data → `noncomputable def`
+    (leçon c.1301+131-L2 ★). -/
+noncomputable def equivalence_refl_field (C : Type u₁) [Category.{v₁} C] : C ≌ C :=
+  CategoryTheory.Equivalence.refl (C := C)
+
+/-- Pont : la structure `Functor.FullyFaithful` — le témoignage data qu'un
+    foncteur bijecte les Hom (avec les preimages `preimage`, `map_preimage`,
+    `preimage_map`). C'est la moitié « pleine et fidèle » du critère
+    d'équivalence (avec `EssSurj`).
+    Type-sig bridge (L902 ★★ Tier 5) — re-export direct de la structure. -/
+def fully_faithful_field (F : C ⥤ D) : Type _ :=
+  CategoryTheory.Functor.FullyFaithful F
+
+/-- Pont : la classe `Functor.EssSurj` — la propriété pour un foncteur d'être
+    essentiellement surjectif (tout objet de D est isomorphe à l'image d'un
+    objet de C). C'est la moitié « surjectivité » du critère d'équivalence.
+    Type-sig bridge (L902 ★★ Tier 5) — re-export direct de la classe. -/
+def ess_surj_field (F : C ⥤ D) : Prop :=
+  CategoryTheory.Functor.EssSurj F
+
+/-- Pont : la classe `Functor.IsEquivalence` — la propriété pour un foncteur
+    d'être une équivalence (plein `F.Full` + fidèle `F.Faithful` +
+    essentiellement surjectif `F.EssSurj`). C'est l'énoncé exact du critère
+    pratique : « un foncteur est une équivalence ssi il est pleinement fidèle
+    et essentiellement surjectif ».
+    Type-sig bridge (L902 ★★ Tier 5) — re-export direct de la classe. -/
+def is_equivalence_field (F : C ⥤ D) : Prop :=
+  CategoryTheory.Functor.IsEquivalence F
+
 end Grothendieck.Equivalences

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Equivalences_en.lean
@@ -273,4 +273,62 @@ theorem equivalence_symm_unit (e : C ≌ D) :
   cases e
   rfl
 
+/-!
+## 9. Bridges on the equivalence criterion and the triangle identity
+
+The **practical equivalence criterion** (Section 4) is the class
+`Functor.IsEquivalence F` = `F.Faithful` + `F.Full` + `F.EssSurj`: a
+functor is an equivalence iff it is fully faithful and essentially
+surjective. The classes `FullyFaithful` (data structure containing the
+preimages) and `EssSurj` (Prop class) are its two ingredients. The
+**triangle identity** `functor_unitIso_comp` (pointwise field of the
+`Equivalence` structure) relates the unit and counit along the functor:
+it is the equivalence analogue of `left_triangle` for adjunctions.
+`Equivalence.refl` gives the identity equivalence 𝟭 C.
+-/
+
+/-- Bridge: the triangle identity of an equivalence, in its **pointwise**
+    version (component at an object): `functor.map (unitIso.hom.app X) ≫
+    counitIso.hom.app (functor.obj X) = 𝟙 (functor.obj X)`. This is the
+    `functor_unitIso_comp` field of the `Equivalence` structure — the exact
+    analogue, for equivalences, of the left triangle identity of adjunctions
+    (`Grothendieck.Adjunction.left_triangle`). Delegates directly to the field.
+    Pointwise field of the structure (L902 ★★ Tier 5). -/
+theorem equivalence_triangle_field (e : C ≌ D) (X : C) :
+    e.functor.map (e.unitIso.hom.app X) ≫ e.counitIso.hom.app (e.functor.obj X) =
+      𝟙 (e.functor.obj X) :=
+  e.functor_unitIso_comp X
+
+/-- Bridge: the identity equivalence `𝟭 C ≌ 𝟭 C` via `Equivalence.refl`. It
+    is the neutral element of the (2-)groupoid structure of categories.
+    Direct re-export of the Mathlib def `Equivalence.refl`.
+    Return type `≌` = structure `Equivalence` = data → `noncomputable def`
+    (lesson c.1301+131-L2 ★). -/
+noncomputable def equivalence_refl_field (C : Type u₁) [Category.{v₁} C] : C ≌ C :=
+  CategoryTheory.Equivalence.refl (C := C)
+
+/-- Bridge: the structure `Functor.FullyFaithful` — the data witness that a
+    functor bijects the Homs (with the preimages `preimage`, `map_preimage`,
+    `preimage_map`). This is the "full and faithful" half of the equivalence
+    criterion (together with `EssSurj`).
+    Type-sig bridge (L902 ★★ Tier 5) — direct re-export of the structure. -/
+def fully_faithful_field (F : C ⥤ D) : Type _ :=
+  CategoryTheory.Functor.FullyFaithful F
+
+/-- Bridge: the class `Functor.EssSurj` — the property for a functor of being
+    essentially surjective (every object of D is isomorphic to the image of an
+    object of C). This is the "surjectivity" half of the equivalence criterion.
+    Type-sig bridge (L902 ★★ Tier 5) — direct re-export of the class. -/
+def ess_surj_field (F : C ⥤ D) : Prop :=
+  CategoryTheory.Functor.EssSurj F
+
+/-- Bridge: the class `Functor.IsEquivalence` — the property for a functor of
+    being an equivalence (full `F.Full` + faithful `F.Faithful` +
+    essentially surjective `F.EssSurj`). This is the exact statement of the
+    practical criterion: "a functor is an equivalence iff it is fully faithful
+    and essentially surjective".
+    Type-sig bridge (L902 ★★ Tier 5) — direct re-export of the class. -/
+def is_equivalence_field (F : C ⥤ D) : Prop :=
+  CategoryTheory.Functor.IsEquivalence F
+
 end Grothendieck.Equivalences_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10804 (c.1301+136 Adjunction)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 5 nouveaux **bridges propres in-file** dans `Equivalences.lean` (Partie 29 — équivalences de catégories) couvrant le **critère pratique d'équivalence** (classes `Functor.FullyFaithful` / `Functor.EssSurj` / `Functor.IsEquivalence` de Mathlib) et l'**identité triangulaire** pointwise `functor_unitIso_comp` + l'équivalence identité `Equivalence.refl` (`Mathlib.CategoryTheory.Equivalence`). 1/5 `theorem` lemma call direct (field pointwise, Prop), 1/5 `noncomputable def` lemma call direct (data `≌`), 3/5 `def` type-sig (2 Prop + 1 structure data). Tous L902 ★★ safe — les args résidents sont `{C : Type u₁}`, `{D : Type u₂}`, `(e : C ≌ D)`, `(F : C ⥤ D)` — pas de polymorphisme d'univers.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.Equivalences` + `_en` SUCCESS (497 jobs chacun) + `lake build` full SUCCESS (2823 jobs, 15ᵉ réutilisation du cache AZ via hardlink-copy du `.lake` pré-construit).

Suite logique directe de **PR #10804** (c.1301+136, Adjunction Partie 25) : l'équivalence est une adjonction dont l'unité et la coïnité sont des isomorphismes — ce grain boucle le pont adjonctions ↔ équivalences avec le critère d'équivalence (Full + Faithful + EssSurj) et l'identité triangulaire de l'équivalence (analogue de `left_triangle` des adjonctions).

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `Equivalences.lean` | FR sibling canonical | 12 decls | 17 decls | +58 insertions, -0 |
| `Equivalences_en.lean` | EN sibling mirror | 13 decls | 18 decls | +58 insertions, -0 |

**Total : +116 insertions net / -0, 2 fichiers, 5 nouveaux bridges (5+5 symétriques FR/EN).** Aucun autre fichier touché. Zéro suppression.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (Equivalences.lean = module Partie 29, reliquat #check du scan pool) | paths FR canonical + EN mirror dans scope EPIC #2159 (issuecomment-5284591756) | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 5 bridges ajoutés (`equivalence_triangle_field` / `equivalence_refl_field` / `fully_faithful_field` / `ess_surj_field` / `is_equivalence_field`), les 14 `#check` documentaires conservés, les 12 decls existantes conservées | ✅ |
| Anti-§D : 0 `sorry` ajouté | `grep -c sorry` FR = 1 (docstring header pré-existante « Tous les `sorry`s éliminés à la création ») ; EN = 1 (idem) — aucune tactique `sorry` | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | args : `{C : Type u₁}`, `{D : Type u₂}`, `(e : C ≌ D)`, `(F : C ⥤ D)` — defs bridées opèrent sur les univers résidents, instances `Category` structurelles | ✅ |
| Bridges valides | 1/5 lemma call direct (field `e.functor_unitIso_comp X`) + 1/5 lemma call direct (`Equivalence.refl (C := C)`) + 3/5 type-sig re-export direct (`Functor.FullyFaithful` / `Functor.EssSurj` / `Functor.IsEquivalence`) | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.Equivalences` + `_en` SUCCESS (497 jobs chacun) + full SUCCESS (2823 jobs, 15ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py .../Grothendieck` (depuis le worktree) = Equivalences OK, 33/34 byte-identical, 0 drift, 0 orphan | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 29 uniquement | 2 fichiers modifiés uniquement, +116/-0 | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "Equivalences.lean"` = 0 OPEN (PRs #10718/#10638/#7682/#10659 MERGED) | ✅ |

## Les 5 bridges ajoutés — highlights

- **`equivalence_triangle_field`** : l'identité triangulaire d'une équivalence, en version **pointwise** — `functor.map (unitIso.hom.app X) ≫ counitIso.hom.app (functor.obj X) = 𝟙 (functor.obj X)`. C'est le field `functor_unitIso_comp` de la structure `Equivalence` (Mathlib le déclare comme famille d'égalités de morphismes, pas comme égalité de NatTrans, « to avoid abusing defeq »). **Solution retenue** : `theorem ... := e.functor_unitIso_comp X` (lemma call direct sur le field pointwise). L902-safe (Prop → theorem). Complète le pont adjonctions ↔ équivalences : c'est l'analogue exact de `left_triangle` des adjonctions (bridgé à la section 9 de `Adjunction.lean`, PR #10804).

- **`equivalence_refl_field`** : l'équivalence identité `𝟭 C ≌ 𝟭 C` via `Equivalence.refl` — l'élément neutre de la structure de (2-)groupeoïde. **Solution retenue** : `noncomputable def ... := CategoryTheory.Equivalence.refl (C := C)`. L902-safe (type retour `≌` = structure = data → noncomputable def). **Tell L902 v10 ★ (nouveau)** : `Equivalence` nu est **ombragé par `_root_.Equivalence`** (la relation d'équivalence Prop de Mathlib) — `Equivalence.refl C` → `Application type mismatch ... expected to have type _root_.Equivalence ?m.4` ; et même qualifié `CategoryTheory.Equivalence.refl C` → `Function expected ... has type ?m.3 ≌ ?m.3` (les implicites sont résolus en métavariables). **Fix** : `CategoryTheory.Equivalence.refl (C := C)` — l'argument implicite nommé.

- **`fully_faithful_field`** : la structure `Functor.FullyFaithful` — le témoignage **data** qu'un foncteur bijecte les Hom (avec les preimages `preimage`, `map_preimage`, `preimage_map`). C'est la moitié « pleine et fidèle » du critère d'équivalence. **Solution retenue** : `def ... : Type _ := CategoryTheory.Functor.FullyFaithful F` (structure = data, pas Prop — le type est `Type (max (max u₁ u₂) v₁ v₂)` selon le #check pp.all). Type-sig bridge.

- **`ess_surj_field`** : la classe `Functor.EssSurj` (définie dans `Mathlib.CategoryTheory.EssentialImage`) — la propriété pour un foncteur d'être essentiellement surjectif (tout objet de D est isomorphe à l'image d'un objet de C). **Solution retenue** : `def ... : Prop := CategoryTheory.Functor.EssSurj F`. L902-safe (classe = Prop, re-export direct).

- **`is_equivalence_field`** : la classe `Functor.IsEquivalence` — la propriété d'être une équivalence (plein `F.Full` + fidèle `F.Faithful` + essentiellement surjectif `F.EssSurj`). C'est l'énoncé exact du critère pratique de la section 4 du module. **Solution retenue** : `def ... : Prop := CategoryTheory.Functor.IsEquivalence F`. L902-safe (classe = Prop, re-export direct).

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. Les équivalences de catégories sont l'outil de sameness de la géométrie algébrique grothendieckienne (Yoneda, anti-équivalence schémas affines ↔ anneaux, topos = catégories de faisceaux).

**G-VAR-3** : grains précédents (cycles c.1301+135/+135b/+136) = DEEP/lean #10800 (Cech), #10801 (Monads), #10804 (Adjunction). Ce grain = DEEP/lean sur Equivalences (Partie 29). **15ᵉ DEEP/lean consécutif** MAIS **substance genuinely distincte** : module différent (Partie 29 vs 25/26/23), produit par du raisonnement neuf — le critère d'équivalence (Full + Faithful + EssSurj) et l'identité triangulaire de l'équivalence sont des constructions distinctes des adjonctions (chaque bridge requiert de distinguer le namespace (`Equivalence` ombragé par `_root_.Equivalence`), la forme d'argument (le field pointwise vs le constructor `refl` dont les implicites doivent être nommés `(C := C)`), et le type retour (Prop vs data → `theorem` vs `def`)). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (les deux tells d'élaboration `Equivalence`/`refl` sont des décisions par bridge). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 29. Le module avait déjà 12 decls (bridges sections 5-8 : functor/inverse/unit/counit/symm/trans + théorèmes propres symm_*/trans_*) mais les 4 constructions fondamentales du **critère d'équivalence** restaient documentaires par `#check` : la classe `IsEquivalence` (avec ses ingrédients `FullyFaithful` et `EssSurj`) et l'identité triangulaire `functor_unitIso_comp`. Le 5ᵉ bridge (`equivalence_refl_field`) complète la structure de (2-)groupeoïde (refl manquait — les 2 lemmes `Equivalence.refl_*` avaient été retirés en v4 pour cause de `rfl` KO sur constructor polymorphe, mais le **re-export def** est possible avec `(C := C)`). Le tableau est désormais complet : **équivalence C ≌ D → functor/inverse → unité/coïnité (iso) → identité triangulaire → critère pratique (Full + Faithful + EssSurj) → équivalence identité** est entièrement exposé par des déclarations propres in-file.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "Equivalences.lean"` = 0 OPEN collision cross-lane. PRs Equivalences historiques #10718 / #10638 / #7682 / #10659 MERGED. Tous hors-scope, pas de collision.
- **Lane claim protocol** : `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: Equivalences.lean, Equivalences_en.lean` posté sur #2159 (issuecomment-5284591756) ; `check_lane_claim.py --paths` = CLEAR (disjoint du claim po-2026 KanExtensions paths-scoped et des claims #10804 Adjunction paths-scoped de cette lane).
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x137_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +116/-0. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `grep -c sorry` FR/EN = 1 chacun (docstring header pré-existante « Tous les `sorry`s éliminés à la création », pas une tactique)
- 0 `rfl` KO (les 5 bridges = lemma call direct / re-export direct)
- Toutes les preuves = lemma call direct (cf pattern `C1301+125-L2 ★★`) ; les 3 type-sig = re-export direct de classe/structure
- Aucune suppression de `#check` ou de defs/théorèmes existants (14 `#check` documentaires + 12 decls existantes conservés)
- Aucun universe supplémentaire ajouté (les bridges opèrent sur les univers résidents `v₁ v₂ u₁ u₂`)
- Zéro deletion au diff (+116/-0)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 29 (Equivalences) expose désormais **17 déclarations propres in-file** (12 existantes + 5 bridges), couvrant le **cycle complet de la théorie des équivalences** : (a) les deux foncteurs quasi-inverses (`equivalence_functor`/`equivalence_inverse`), (b) l'unité et la coïnité naturelles (`equivalence_unit`/`equivalence_counit`), (c) l'identité triangulaire (`equivalence_triangle_field`), (d) la structure de (2-)groupeoïde (`equivalence_symm`/`equivalence_trans`/`equivalence_refl_field`), (e) le critère pratique d'équivalence (`fully_faithful_field`/`ess_surj_field`/`is_equivalence_field`), (f) les théorèmes propres de cohérence (`equivalence_symm_functor`/`equivalence_symm_inverse`/`equivalence_symm_symm`/`equivalence_trans_functor`/`equivalence_trans_inverse`/`equivalence_symm_unit`). Chaque bridge documente en FR+EN la relation entre l'API Mathlib sous-jacente et son restatement in-file, bouclant le pont adjonctions ↔ équivalences au cœur de la géométrie algébrique grothendieckienne.
