### PR TITLE
feat(genai,#10802,#10473): notebook CSharpRepl — hot-patch d'un process .NET vivant

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb
@@ -1,0 +1,615 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "48a8f1f8",
+   "metadata": {},
+   "source": [
+    "# CSharpRepl attache a un process .NET vivant\n",
+    "\n",
+    "> Grain **DEEP/notebook-dotnet** — axe CSharpRepl de la serie *The Unexpected AI Stack: C#/.NET* (Part 1, Charles Chen 08/2026). Epic **#10473**, issue **#10802**. See #10473.\n",
+    "\n",
+    "CSharpRepl est un REPL C# qui ne se contente pas d'executer du code dans un processus isole : il peut **s'attacher a une application .NET vivante** et **patcher ses methodes a chaud** — sans l'arreter, sans la redemarrer, sans recompiler.\n",
+    "\n",
+    "Ce notebook demontre la capacite distinctive : un service de commandes tourne (avec `DOTNET_STARTUP_HOOKS`), le notebook s'y attache, lit son etat, **remplace puis enveloppe une methode a chaud**, et observe l'application changer de comportement *pendant qu'elle tourne*.\n",
+    "\n",
+    "**Prerequis** : `dotnet tool install -g csharprepl` (le binaire est resolu automatiquement par le notebook).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1aa0de93",
+   "metadata": {},
+   "source": [
+    "## Pourquoi c'est non-trivial (parite Python)\n",
+    "\n",
+    "| Capacite | Python | C#/.NET (cette demo) |\n",
+    "|---|---|---|\n",
+    "| Recharger du code | `%autoreload` (reimporte le module, ne touche pas aux objets existants) | **CSharpRepl** : `#replace` / `#wrap` sur une methode **deja chargee** |\n",
+    "| Attacher un debogueur | `pdb` (attache un debogueur, n'evalue pas dans le contexte du process) | `csharprepl connect <pid>` : evalue **dans** le process vivant, accede a ses statiques et services |\n",
+    "| Modifier le comportement a chaud | requiert de redeployer / reimporter | patch MonoMod applique **immediatement** et **persiste** jusqu'a `#revert` ou exit |\n",
+    "\n",
+    "Le point distinctif : `%autoreload` recharge un *module* dans le process courant du notebook — il ne peut pas modifier une methode d'un *autre* process en cours d'execution. CSharpRepl le peut, via le hook de demarrage .NET.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e1136ab",
+   "metadata": {},
+   "source": [
+    "## 1. Le hook de demarrage\n",
+    "\n",
+    "`csharprepl connect init` imprime les deux variables d'environnement qui activent le connecteur dans l'application cible. On les pose **dans le shell qui lance l'application** (jamais system-wide).\n",
+    "\n",
+    "Le programme de demonstration (`csharprepl-demo/`) est une application console qui boucle en imprimant le prix calcule par `OrderService.CalculatePrice(3, 10m)` toutes les 500 ms — exactement le genre de service qu'on ne veut pas arreter pour changer une regle de pricing.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "76e7d1f8",
+   "metadata": {},
+   "source": [
+    "// 0. Setup : helpers partages (l'etat persiste entre les cellules .NET Interactive)\n",
+    "#nullable enable\n",
+    "using System.Diagnostics;\n",
+    "using System.IO;\n",
+    "using System.Linq;\n",
+    "using System.Threading;\n",
+    "using System.Collections.Generic;\n",
+    "\n",
+    "// Execute une commande et retourne stdout+stderr.\n",
+    "string Run(string fileName, string arguments)\n",
+    "{\n",
+    "    var psi = new ProcessStartInfo(fileName, arguments)\n",
+    "    {\n",
+    "        UseShellExecute = false,\n",
+    "        RedirectStandardOutput = true,\n",
+    "        RedirectStandardError = true,\n",
+    "        CreateNoWindow = true,\n",
+    "    };\n",
+    "    using var p = Process.Start(psi)!;\n",
+    "    var stdout = p.StandardOutput.ReadToEnd();\n",
+    "    var stderr = p.StandardError.ReadToEnd();\n",
+    "    p.WaitForExit();\n",
+    "    return stdout + (stderr.Length > 0 ? \"\\n[stderr] \" + stderr : \"\");\n",
+    "}\n",
+    "\n",
+    "// Resout CSharpRepl.exe dans le store dotnet tools global (version-agnostique).\n",
+    "string FindReplExe()\n",
+    "{\n",
+    "    var store = Path.Combine(\n",
+    "        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),\n",
+    "        \".dotnet\", \"tools\", \".store\", \"csharprepl\");\n",
+    "    if (!Directory.Exists(store)) throw new FileNotFoundException(\"store csharprepl introuvable: \" + store);\n",
+    "    var exe = Directory.EnumerateFiles(store, \"CSharpRepl.exe\", SearchOption.AllDirectories)\n",
+    "        .FirstOrDefault(f => f.EndsWith(Path.Combine(\"net10.0\", \"win-x64\", \"CSharpRepl.exe\")));\n",
+    "    if (exe is null) throw new FileNotFoundException(\"CSharpRepl.exe introuvable dans le store\");\n",
+    "    return exe;\n",
+    "}\n",
+    "\n",
+    "// Parse une ligne `$env:KEY = \"value\"` de la sortie de `connect init`.\n",
+    "string ParseEnvLine(string output, string key)\n",
+    "{\n",
+    "    var line = output.Split('\\n').First(l => l.Contains(\"$env:\" + key + \" =\"));\n",
+    "    return line.Split('=', 2)[1].Trim().Trim('\"').Trim();\n",
+    "}\n",
+    "\n",
+    "// Racine du repo (marchee ascendante depuis le repertoire courant).\n",
+    "string FindRepoRoot()\n",
+    "{\n",
+    "    var dir = new DirectoryInfo(Directory.GetCurrentDirectory());\n",
+    "    while (dir != null)\n",
+    "    {\n",
+    "        if (File.Exists(Path.Combine(dir.FullName, \"MyIA.CoursIA.sln\"))) return dir.FullName;\n",
+    "        dir = dir.Parent;\n",
+    "    }\n",
+    "    throw new DirectoryNotFoundException(\"racine du repo introuvable (MyIA.CoursIA.sln)\");\n",
+    "}\n",
+    "\n",
+    "string _replExe = FindReplExe();          // binaire CSharpRepl\n",
+    "string WorkingDir = FindRepoRoot();       // racine du repo\n",
+    "string Repl(string args) => Run(_replExe, args);\n",
+    "\n",
+    "Process? _app = null;                     // process de l'application demo\n",
+    "int _pid = 0;                             // PID de l'application demo\n",
+    "List<string> _appLog = new();             // stdout/stderr capture de l'application demo"
+   ],
+   "execution_count": 1,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "3ba6e41a",
+   "metadata": {},
+   "source": [
+    "// 1a. Recuperer le chemin du hook (sortie de `connect init`, auto-detection machine)\n",
+    "var initOut = Run(_replExe, \"connect init --shell pwsh\");\n",
+    "var hook = ParseEnvLine(initOut, \"DOTNET_STARTUP_HOOKS\");\n",
+    "var hosting = ParseEnvLine(initOut, \"ASPNETCORE_HOSTINGSTARTUPASSEMBLIES\");\n",
+    "Console.WriteLine($\"hook     : {Path.GetFileName(hook)}\");\n",
+    "Console.WriteLine($\"hosting  : {hosting}\");"
+   ],
+   "execution_count": 2,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "hook     : CSharpRepl.InjectedHook.dll\r\n"
+     ]
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "hosting  : CSharpRepl.InjectedHook\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "1b6d8760",
+   "metadata": {},
+   "source": [
+    "// 1b. Lancer l'application cible AVEC le hook (stdout capture -> _appLog)\n",
+    "var psi = new ProcessStartInfo(\"dotnet\", \"run --project MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo\")\n",
+    "{\n",
+    "    UseShellExecute = false,\n",
+    "    RedirectStandardOutput = true,\n",
+    "    RedirectStandardError = true,\n",
+    "    WorkingDirectory = WorkingDir,\n",
+    "};\n",
+    "psi.Environment[\"DOTNET_STARTUP_HOOKS\"] = hook;\n",
+    "psi.Environment[\"ASPNETCORE_HOSTINGSTARTUPASSEMBLIES\"] = hosting;\n",
+    "_app = Process.Start(psi)!;\n",
+    "_app.OutputDataReceived += (_, e) => { if (e.Data is not null) lock (_appLog) _appLog.Add(e.Data); };\n",
+    "_app.ErrorDataReceived += (_, e) => { if (e.Data is not null) lock (_appLog) _appLog.Add(\"[err] \" + e.Data); };\n",
+    "_app.BeginOutputReadLine();\n",
+    "_app.BeginErrorReadLine();\n",
+    "\n",
+    "// Attendre la ligne \"PID=\" (le build `dotnet run` precede le demarrage)\n",
+    "var deadline = DateTime.UtcNow.AddSeconds(90);\n",
+    "while (DateTime.UtcNow < deadline)\n",
+    "{\n",
+    "    lock (_appLog)\n",
+    "    {\n",
+    "        var pidLine = _appLog.FirstOrDefault(l => l.Contains(\"PID=\"));\n",
+    "        if (pidLine is not null) { _pid = int.Parse(pidLine.Split(\"PID=\")[1]); break; }\n",
+    "    }\n",
+    "    Thread.Sleep(200);\n",
+    "}\n",
+    "Console.WriteLine($\"Application demarree, PID={_pid}\");"
+   ],
+   "execution_count": 3,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Application demarree, PID=531940\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "adeb0d0a",
+   "metadata": {},
+   "source": [
+    "## 2. Attacher le REPL au process vivant\n",
+    "\n",
+    "`connect list` enumere les processus attachables. `connect <pid>` s'y attache ; on peut alors **evaluer des expressions dans le contexte du process** — acceder a ses types, ses statiques, ses services, ses donnees. Remarque : une expression **sans point-virgule** fait imprimer son resultat par le REPL.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "25fd2be7",
+   "metadata": {},
+   "source": [
+    "// 2a. Lister les processus attachables\n",
+    "Console.WriteLine(Repl(\"connect list\"));"
+   ],
+   "execution_count": 4,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "                         \r\n",
+      "  PID    │ Process       \r\n",
+      " ────────┼────────────── \r\n",
+      "  531940 │ LiveOrderApp  \r\n",
+      "  541428 │ dotnet        \r\n",
+      "                         \r\n",
+      "Connect with csharprepl connect <PID>.\r\n",
+      "Hint: you most likely want to connect to the 'LiveOrderApp' process (PID \r\n",
+      "531940).\r\n",
+      "\r\n",
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "583b0c8d",
+   "metadata": {},
+   "source": [
+    "// 2b. Evaluer DANS le process vivant : appeler la methode du service\n",
+    "// (le process n'est ni arrete ni redemarre)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.CalculatePrice(5, 7m)\\\"\"));"
+   ],
+   "execution_count": 5,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "35\r\n",
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d320a20",
+   "metadata": {},
+   "source": [
+    "## 3. Lire l'etat vivant du process\n",
+    "\n",
+    "On peut aussi lire les **statiques** du process — l'etat reel, pas une copie.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "0f4b3625",
+   "metadata": {},
+   "source": [
+    "// 3. Lire un compteur statique vivant (ici : nombre de calculs effectues)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.ComputeCount\\\"\"));"
+   ],
+   "execution_count": 6,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "6\r\n",
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "20a29be1",
+   "metadata": {},
+   "source": [
+    "## 4. Patcher une methode a chaud (`#replace`)\n",
+    "\n",
+    "On definit d'abord une **methode de remplacement** (meme signature que la cible), puis `#replace` l'applique au process **immediatement**. L'application continue de tourner — et son comportement change.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "546da49f",
+   "metadata": {},
+   "source": [
+    "// 4a. Definir la methode de remplacement (remise de 20%)\n",
+    "// (signature identique : int, decimal -> decimal)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"decimal salePrice(int q, decimal u) => q * u * 0.8m;\\\"\"));"
+   ],
+   "execution_count": 7,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "018919c8",
+   "metadata": {},
+   "source": [
+    "// 4b. Appliquer le patch a chaud\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#replace LiveOrderApp.OrderService.CalculatePrice with salePrice\\\"\"));"
+   ],
+   "execution_count": 8,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "patched static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  salePrice  (patch #1)\r\n",
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "06a0cf35",
+   "metadata": {},
+   "source": [
+    "// 4c. Observer le changement dans l'application VIVANTE (log capture en memoire)\n",
+    "Thread.Sleep(1200);\n",
+    "lock (_appLog)\n",
+    "{\n",
+    "    var tail = _appLog.Where(l => l.Contains(\"price=\")).TakeLast(3);\n",
+    "    Console.WriteLine(string.Join(Environment.NewLine, tail));\n",
+    "}"
+   ],
+   "execution_count": 9,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "[7] price=30\r\n",
+      "[8] price=24,0\r\n",
+      "[9] price=24,0\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63540d2d",
+   "metadata": {},
+   "source": [
+    "## 5. Envelopper (`#wrap`), inventaire (`#patches`), annuler (`#revert`)\n",
+    "\n",
+    "`#wrap` enveloppe la methode courante : le wrapper recoit `orig` (le delegate original) en premier parametre — c'est le pattern documente pour le wrapping d'une methode statique. `#patches` liste les patches actifs ; `#revert all` les annule tous.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "7643815e",
+   "metadata": {},
+   "source": [
+    "// 5a. Definir le wrapper de journalisation (le delegate `orig` vient en premier parametre)\n",
+    "// (les `\\\\\\\"` sont l'echappement CommandLineToArgvW : quotes litterales dans l'argv du process cible)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"decimal logged(Func<int, decimal, decimal> orig, int q, decimal u) {{ System.Console.WriteLine(\\\\\\\"repl-log: \\\\\\\" + q + \\\\\\\" x \\\\\\\" + u); return orig(q, u); }}\\\"\"));"
+   ],
+   "execution_count": 10,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "6403c448",
+   "metadata": {},
+   "source": [
+    "// 5b. Appliquer le wrap\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#wrap LiveOrderApp.OrderService.CalculatePrice with logged\\\"\"));"
+   ],
+   "execution_count": 11,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "wrapped static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  logged  (patch #2)\r\n",
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "e9a93517",
+   "metadata": {},
+   "source": [
+    "// 5c. Inventaire des patches actifs\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#patches\\\"\"));"
+   ],
+   "execution_count": 12,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "  #1  [Replace]  static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  salePrice\r\n",
+      "  #2  [Wrap]  static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  logged\r\n",
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "b3449a07",
+   "metadata": {},
+   "source": [
+    "// 5d. Annuler tous les patches -> l'application revient au comportement original\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#revert all\\\"\"));"
+   ],
+   "execution_count": 13,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "reverted 2 patch(es).\r\n",
+      "\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b22e8a7",
+   "metadata": {},
+   "source": [
+    "## Exercice 1 : patch `#replace` d'un calcul de TVA\n",
+    "\n",
+    "L'application `LiveOrderApp` calcule `price = quantity * unitPrice` (TVA incluse a 20%). Ajoutez une methode `withVat` qui applique 20% de TVA en plus, puis `#replace` `OrderService.CalculatePrice`. L'application doit commencer a imprimer `price=36` (3 × 10 × 1,2) au lieu de `price=30`.\n",
+    "\n",
+    "**Indice** : reprenez exactement le pattern de la section 4 (methode de meme signature, puis `#replace`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "f103ba26",
+   "metadata": {},
+   "source": [
+    "// Exercice a completer : definir withVat puis #replace OrderService.CalculatePrice\n",
+    "// decimal withVat(int q, decimal u) => ...;\n",
+    "// #replace LiveOrderApp.OrderService.CalculatePrice with withVat\n",
+    "// Verifier dans le log que price passe a 36.\n",
+    "Console.WriteLine(\"Exercice a completer\");"
+   ],
+   "execution_count": 14,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d0f387a",
+   "metadata": {},
+   "source": [
+    "## Exercice 2 : `#wrap` avec journalisation\n",
+    "\n",
+    "Enveloppez `OrderService.CalculatePrice` avec un wrapper qui **journalise chaque appel** (quantite + prix unitaire) avant de deleguer a l'original — puis `#patches` pour verifier que le wrap est actif.\n",
+    "\n",
+    "**Indice** : le wrapper recoit `orig` (le delegate original) en premier parametre.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "f9c84d3b",
+   "metadata": {},
+   "source": [
+    "// Exercice a completer : wrapper de journalisation puis #wrap\n",
+    "// decimal logged(Func<int, decimal, decimal> orig, int q, decimal u) { ... ; return orig(q, u); }\n",
+    "// #wrap LiveOrderApp.OrderService.CalculatePrice with logged\n",
+    "Console.WriteLine(\"Exercice a completer\");"
+   ],
+   "execution_count": 15,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba8f3a01",
+   "metadata": {},
+   "source": [
+    "## Exercice 3 : lecture d'etat vivant multi-cible\n",
+    "\n",
+    "La liste `connect list` peut montrer plusieurs processus attachables (par ex. le kernel .NET Interactive lui-meme). Ecrivez un snippet qui : (1) liste les processus, (2) s'attache a celui de `LiveOrderApp`, (3) lit le compteur statique `OrderService.ComputeCount` a deux instants distants de 1,5 s pour constater qu'il augmente — preuve que le process vit et que le REPL lit son etat reel.\n",
+    "\n",
+    "**Indice** : `connect <pid> -e \"...\"` retourne le resultat de l'expression (sans point-virgule).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "19dc04f1",
+   "metadata": {},
+   "source": [
+    "// Exercice a completer : mesurer ComputeCount a deux instants\n",
+    "// var c1 = int.Parse(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.ComputeCount\\\"\").Trim());\n",
+    "// Thread.Sleep(1500);\n",
+    "// var c2 = ...;\n",
+    "// Console.WriteLine($\"count: {c1} -> {c2}\");\n",
+    "Console.WriteLine(\"Exercice a completer\");"
+   ],
+   "execution_count": 16,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f050498",
+   "metadata": {},
+   "source": [
+    "## 6. Arret propre\n",
+    "\n",
+    "On detache le REPL (`exit` ou EOF) et on arrete l'application de demonstration.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "521411fb",
+   "metadata": {},
+   "source": [
+    "// 6. Arreter proprement l'application vivante\n",
+    "_app?.Kill(entireProcessTree: true);\n",
+    "Console.WriteLine(\"Application arretee.\");"
+   ],
+   "execution_count": 17,
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "Application arretee.\r\n"
+     ]
+    }
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9952cfde",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Nous avons demontre, **avec du code execute** : CSharpRepl s'attache a un process .NET vivant, y evalue des expressions, lit son etat, **patche une methode a chaud** (`#replace`), l'**enveloppe** (`#wrap`) et **annule** (`#revert`) — l'application changeant de comportement en continu, sans arret ni redemarrage.\n",
+    "\n",
+    "C'est la ligne « Introspection d'un process vivant » de la table de parite de l'Epic **#10473** : ce que `%autoreload` / `pdb` ne font pas cote Python, le REPL attache le fait nativement cote .NET — la verification et la modification se font **dans** le process, pas en post-processing.\n",
+    "\n",
+    "*Rappel securite* : `csharprepl connect` equivaut a executer du code arbitraire dans le process cible, avec ses privileges. Outil de developpement et de diagnostic — jamais sur un process de production.\n"
+   ]
+  }
+ ]
+}

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo/LiveOrderApp.csproj
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo/LiveOrderApp.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo/Program.cs
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo/Program.cs
@@ -1,0 +1,38 @@
+// Application de demonstration : un "service de commandes" vivant que le
+// notebook va attacher, inspecter et patcher a chaud via CSharpRepl.
+//
+// Le hook CSharpRepl (DOTNET_STARTUP_HOOKS) est injecte par le notebook ;
+// ce programme n'a aucune dependance vers CSharpRepl.
+
+namespace LiveOrderApp;
+
+public static class OrderService
+{
+    // Compteur d'appels : etat vivant que le notebook lit a chaud via
+    // `csharprepl connect <pid> -e "OrderService.ComputeCount"` (sans point-
+    // virgule : le REPL imprime le resultat de l'expression).
+    public static int ComputeCount;
+
+    // Methode cible du hot-patch : le notebook la remplacera / enveloppera
+    // a chaud via `#replace` / `#wrap` sans arreter le process.
+    public static decimal CalculatePrice(int quantity, decimal unitPrice)
+    {
+        ComputeCount++;
+        return quantity * unitPrice;
+    }
+}
+
+public static class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine("LiveOrderApp demarre, PID=" + Environment.ProcessId);
+        var tick = 0;
+        while (true)
+        {
+            var price = OrderService.CalculatePrice(3, 10m);
+            Console.WriteLine($"[{++tick}] price={price}");
+            Thread.Sleep(500);
+        }
+    }
+}


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #10799

## Summary

Notebook **CSharpRepl-Live-Patching.ipynb** (kernel `.net-csharp`) : l'axe CSharpRepl de la serie *The Unexpected AI Stack: C#/.NET* (Epic **#10473**). Issue **#10802**.

Demo executee : une application console `LiveOrderApp` tourne avec `DOTNET_STARTUP_HOOKS` ; le notebook s'y attache (`csharprepl connect <pid>`), lit son etat vivant (statique `OrderService.ComputeCount`), **remplace une methode a chaud** (`#replace`, remise 20%) et l'**enveloppe** (`#wrap`, journalisation via delegate `orig`) — l'application changeant de comportement *pendant qu'elle tourne*, sans arret ni redemarrage (log : `[7] price=30` -> `[8] price=24,0`).

## Files

| Fichier | Role |
|---|---|
| `MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb` | Notebook 29 cellules (17 code executees), 3 exercices |
| `MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo/LiveOrderApp.csproj` | App console net10.0 (aucune dependance CSharpRepl) |
| `MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo/Program.cs` | Service de commandes vivant (`OrderService.CalculatePrice` + `ComputeCount`) |

## Prong A — verdict SOTA-OK

Le vrai outil est invoque : `CSharpRepl.exe` (0.9.2, store dotnet tools, resolu automatiquement) via `connect init` / `connect list` / `connect <pid>` / `#replace` / `#wrap` / `#patches` / `#revert all`. Aucune sortie degradee.

## Prong B — probleme non-trivial

La capacite distinctive est demontree sur un cas reel : patcher une methode **d'un process .NET different du notebook**, en continu. Ce que `%autoreload` / `pdb` ne font pas cote Python (parite documentee dans le notebook). Les 3 exercices exercent la meme capacite (TVA `#replace` -> price=36, `#wrap` journalise, lecture `ComputeCount` a 2 instants).

## Validation (H.1 / C.2 / C.1)

- **Execution reelle** : `exec_dotnet_persist.py` — **17/17 cellules code OK, 0 erreur** (kernel .net-csharp)
- **C.2** : `execution_count` 1..17 coherents, outputs presents sur chaque cellule code
- **C.1** : stubs exercices = `Console.WriteLine("Exercice a completer")` (aucun `raise NotImplementedError`), notebook executable de bout en bout
- **Prong-B anti-fabrication** : hot-patch verifie firsthand (patch price 30 -> 24 dans le log de l'app vivante)
- **Hygiene sorties** : 0 chemins machine dans outputs/sources (scan regex), `strip_probe_banner --scan` = 0 banner
- **Quoting Windows** : invocation exe direct (pas de shim `.cmd`), echappement `\\\"` CommandLineToArgvW verifie firsthand
- **BOM** : csproj sans BOM UTF-8

## Anti-regression

0 suppression ; 3 fichiers ajoutes seulement (+290 lignes, notebooks compris). Aucun fichier existant modifie. Catalogue non touche (le cron l'inscrira).

## References

- Issue **#10802** — grain CSharpRepl de l'Epic #10473 (acceptance : notebook .NET, demo reelle avec outputs, >= 3 exercices, verdict SOTA ecrit)
- PR soeur **#10502** — axe Roslyn de la meme serie (pattern nbformat 4.5 repris)
- Epic **#10473** — "The Unexpected AI Stack: C#/.NET" (table de parite, ligne « Introspection d'un process vivant »)

See #10802
See #10473
