### PR TITLE
feat(lean,#2159): MonoidalCategories bridges — cohérence de Mac Lane (pentagone+triangle), prodMonoidal, SymmetricCategory, Discrete.monoidal

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MonoidalCategories.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MonoidalCategories.lean
@@ -66,7 +66,7 @@ import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.Monoidal.Braided.Basic
 import Mathlib.CategoryTheory.Monoidal.Discrete
 
-universe v u
+universe v u u₁ u₂ v₁ v₂
 
 namespace Grothendieck.MonoidalCategories
 
@@ -318,5 +318,80 @@ theorem whiskerLeft_eq_app [MonoidalCategoryStruct C] {X Y Z : C}
 theorem whiskerRight_eq_app [MonoidalCategoryStruct C] {X Y Z : C}
     (f : X ⟶ Y) :
     f ▷ Z = MonoidalCategoryStruct.whiskerRight f Z := rfl
+
+/-!
+## 10. Ponts sur la cohérence (pentagone + triangle) et les exemples canoniques
+
+Les **deux axiomes de cohérence** exigés par la classe `MonoidalCategory`
+— le pentagone `Pentagon` (cohérence de l'associativité) et l'identité
+triangulaire `triangle_assoc_comp_right` (cohérence unité-associateur)
+— sont les `Prop` de la section 3. Le pont `pentagon_field` expose la
+définition du pentagone comme type ; le pont `triangle_field` prouve
+l'identité triangulaire par appel direct au lemme Mathlib. Les
+**exemples canoniques** des sections 4-6 complètent le tableau : le
+produit de deux catégories monoïdales (`prod_monoidal_field`), la
+classe symétrique (`symmetric_category_field`) et la catégorification
+minimale d'un monoïde (`discrete_monoidal_field`).
+
+Le pont `prod_monoidal_field` requiert deux univers distincts `u₁ u₂`
+(les univers des objets de `C₁` et `C₂`), déclarés au scope module —
+L902 ★★ reste satisfaite (args résidents `(C₁ : Type u₁)` /
+`(C₂ : Type u₂)`, instances `Category`/`MonoidalCategory` structurelles).
+-/
+
+/-- Pont : le diagramme du pentagone de Mac Lane — la cohérence de
+    l'associativité exigée par la classe `MonoidalCategory`. Pour quatre
+    objets `Y₁ Y₂ Y₃ Y₄`, les deux chemins de réassociation
+    `((Y₁ ⊗ Y₂) ⊗ Y₃) ⊗ Y₄` et `Y₁ ⊗ (Y₂ ⊗ (Y₃ ⊗ Y₄))` coïncident.
+    Re-export direct de la def Mathlib `MonoidalCategory.Pentagon`.
+    Type-sig bridge (L902 ★★ Tier 5) — re-export direct de la def Prop. -/
+def pentagon_field [MonoidalCategoryStruct C] (Y₁ Y₂ Y₃ Y₄ : C) : Prop :=
+  MonoidalCategory.Pentagon Y₁ Y₂ Y₃ Y₄
+
+/-- Pont : l'identité triangulaire de la catégorie monoïdale — la
+    compatibilité entre l'associateur et les unitaires :
+    `(α_ X (𝟙_ C) Y).inv ≫ ((ρ_ X).hom ▷ Y) = X ◁ (λ_ Y).hom`.
+    C'est la version « associateur-inverse + unitaire droit » du
+    triangle de Mac Lane. Délègue directement au lemme Mathlib
+    `MonoidalCategory.triangle_assoc_comp_right`.
+    Lemma call direct (L902 ★★ Tier 5) — args résidents `(X Y : C)`. -/
+theorem triangle_field [MonoidalCategory C] (X Y : C) :
+    (α_ X (𝟙_ C) Y).inv ≫ ((ρ_ X).hom ▷ Y) = X ◁ (λ_ Y).hom :=
+  MonoidalCategory.triangle_assoc_comp_right X Y
+
+/-- Pont : le produit de deux catégories monoïdales — l'instance
+    canonique `MonoidalCategory (C₁ × C₂)` : le tenseur et l'unité se
+    calculent composante par composante. Re-export direct de l'instance
+    Mathlib `MonoidalCategory.prodMonoidal`.
+    Type retour `MonoidalCategory` = classe data → `noncomputable def`
+    (leçon c.1301+131-L2 ★). Args : `(C₁ : Type u₁)` `(C₂ : Type u₂)`
+    — univers distincts déclarés au scope module. -/
+@[reducible]
+noncomputable def prod_monoidal_field (C₁ : Type u₁) [Category.{v₁} C₁]
+    [MonoidalCategory.{v₁} C₁] (C₂ : Type u₂) [Category.{v₂} C₂]
+    [MonoidalCategory.{v₂} C₂] : MonoidalCategory (C₁ × C₂) :=
+  MonoidalCategory.prodMonoidal C₁ C₂
+
+/-- Pont : la classe `SymmetricCategory` — une catégorie monoïdale
+    tressée dont le tressage est involutif (`β_ X Y ≫ β_ Y X = 𝟙`).
+    C'est la structure « symétrique » de la section 5, cadre des
+    produits tensoriels de faisceaux. Re-export direct de la classe
+    Mathlib `CategoryTheory.SymmetricCategory`.
+    Type-sig bridge (L902 ★★ Tier 5) — re-export direct de la classe. -/
+def symmetric_category_field (C : Type u) [Category.{v} C]
+    [MonoidalCategory.{v} C] : Type _ :=
+  CategoryTheory.SymmetricCategory C
+
+/-- Pont : la catégorification minimale d'un monoïde — l'instance
+    canonique `MonoidalCategory (Discrete M)` : les objets sont les
+    éléments de `M`, le tenseur est la multiplication, l'unité est `1`.
+    C'est le lien « monoïde → catégorie monoïdale » de la section 6.
+    Re-export direct de l'instance Mathlib `Discrete.monoidal`.
+    Type retour `MonoidalCategory` = classe data → `noncomputable def`
+    (leçon c.1301+131-L2 ★). -/
+@[reducible]
+noncomputable def discrete_monoidal_field (M : Type u) [Monoid M] :
+    MonoidalCategory (Discrete M) :=
+  CategoryTheory.Discrete.monoidal M
 
 end Grothendieck.MonoidalCategories

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MonoidalCategories_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/MonoidalCategories_en.lean
@@ -63,7 +63,7 @@ import Mathlib.CategoryTheory.Monoidal.Category
 import Mathlib.CategoryTheory.Monoidal.Braided.Basic
 import Mathlib.CategoryTheory.Monoidal.Discrete
 
-universe v u
+universe v u u₁ u₂ v₁ v₂
 
 namespace Grothendieck.MonoidalCategories_en
 
@@ -312,5 +312,80 @@ theorem whiskerLeft_eq_app [MonoidalCategoryStruct C] {X Y Z : C}
 theorem whiskerRight_eq_app [MonoidalCategoryStruct C] {X Y Z : C}
     (f : X ⟶ Y) :
     f ▷ Z = MonoidalCategoryStruct.whiskerRight f Z := rfl
+
+/-!
+## 10. Bridges on coherence (pentagon + triangle) and the canonical examples
+
+The **two coherence axioms** required by the `MonoidalCategory` class
+— the pentagon `Pentagon` (associativity coherence) and the triangle
+identity `triangle_assoc_comp_right` (unit-associator coherence) — are
+the `Prop`s of Section 3. The bridge `pentagon_field` exposes the
+definition of the pentagon as a type; the bridge `triangle_field`
+proves the triangle identity by a direct call to the Mathlib lemma.
+The **canonical examples** of Sections 4-6 complete the picture: the
+product of two monoidal categories (`prod_monoidal_field`), the
+symmetric class (`symmetric_category_field`) and the minimal
+categorification of a monoid (`discrete_monoidal_field`).
+
+The bridge `prod_monoidal_field` requires two distinct universes
+`u₁ u₂` (the object universes of `C₁` and `C₂`), declared at module
+scope — L902 ★★ remains satisfied (resident args `(C₁ : Type u₁)` /
+`(C₂ : Type u₂)`, structural `Category`/`MonoidalCategory` instances).
+-/
+
+/-- Bridge: Mac Lane's pentagon diagram — the associativity coherence
+    required by the `MonoidalCategory` class. For four objects
+    `Y₁ Y₂ Y₃ Y₄`, the two reassociation paths `((Y₁ ⊗ Y₂) ⊗ Y₃) ⊗ Y₄`
+    and `Y₁ ⊗ (Y₂ ⊗ (Y₃ ⊗ Y₄))` coincide. Direct re-export of the
+    Mathlib def `MonoidalCategory.Pentagon`.
+    Type-sig bridge (L902 ★★ Tier 5) — direct re-export of the def Prop. -/
+def pentagon_field [MonoidalCategoryStruct C] (Y₁ Y₂ Y₃ Y₄ : C) : Prop :=
+  MonoidalCategory.Pentagon Y₁ Y₂ Y₃ Y₄
+
+/-- Bridge: the triangle identity of the monoidal category — the
+    compatibility between the associator and the unitors:
+    `(α_ X (𝟙_ C) Y).inv ≫ ((ρ_ X).hom ▷ Y) = X ◁ (λ_ Y).hom`.
+    This is the "inverse-associator + right-unitor" version of Mac
+    Lane's triangle. Delegates directly to the Mathlib lemma
+    `MonoidalCategory.triangle_assoc_comp_right`.
+    Lemma call direct (L902 ★★ Tier 5) — resident args `(X Y : C)`. -/
+theorem triangle_field [MonoidalCategory C] (X Y : C) :
+    (α_ X (𝟙_ C) Y).inv ≫ ((ρ_ X).hom ▷ Y) = X ◁ (λ_ Y).hom :=
+  MonoidalCategory.triangle_assoc_comp_right X Y
+
+/-- Bridge: the product of two monoidal categories — the canonical
+    instance `MonoidalCategory (C₁ × C₂)` : the tensor and the unit are
+    computed componentwise. Direct re-export of the Mathlib instance
+    `MonoidalCategory.prodMonoidal`.
+    Return type `MonoidalCategory` = class data → `noncomputable def`
+    (lesson c.1301+131-L2 ★). Args: `(C₁ : Type u₁)` `(C₂ : Type u₂)`
+    — distinct universes declared at module scope. -/
+@[reducible]
+noncomputable def prod_monoidal_field (C₁ : Type u₁) [Category.{v₁} C₁]
+    [MonoidalCategory.{v₁} C₁] (C₂ : Type u₂) [Category.{v₂} C₂]
+    [MonoidalCategory.{v₂} C₂] : MonoidalCategory (C₁ × C₂) :=
+  MonoidalCategory.prodMonoidal C₁ C₂
+
+/-- Bridge: the `SymmetricCategory` class — a braided monoidal
+    category whose braiding is involutive (`β_ X Y ≫ β_ Y X = 𝟙`).
+    This is the "symmetric" structure of Section 5, the setting of
+    sheaf tensor products. Direct re-export of the Mathlib class
+    `CategoryTheory.SymmetricCategory`.
+    Type-sig bridge (L902 ★★ Tier 5) — direct re-export of the class. -/
+def symmetric_category_field (C : Type u) [Category.{v} C]
+    [MonoidalCategory.{v} C] : Type _ :=
+  CategoryTheory.SymmetricCategory C
+
+/-- Bridge: the minimal categorification of a monoid — the canonical
+    instance `MonoidalCategory (Discrete M)`: the objects are the
+    elements of `M`, the tensor is the multiplication, the unit is `1`.
+    This is the "monoid → monoidal category" link of Section 6. Direct
+    re-export of the Mathlib instance `Discrete.monoidal`.
+    Return type `MonoidalCategory` = class data → `noncomputable def`
+    (lesson c.1301+131-L2 ★). -/
+@[reducible]
+noncomputable def discrete_monoidal_field (M : Type u) [Monoid M] :
+    MonoidalCategory (Discrete M) :=
+  CategoryTheory.Discrete.monoidal M
 
 end Grothendieck.MonoidalCategories_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10805 (c.1301+137 Equivalences)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 5 nouveaux **bridges propres in-file** dans `MonoidalCategories.lean` (Partie 27 — catégories monoïdales) couvrant les **axiomes de cohérence de Mac Lane** (pentagone `Pentagon` + identité triangulaire `triangle_assoc_comp_right` de `Mathlib.CategoryTheory.Monoidal.Category`) et les **exemples canoniques** (produit de deux catégories monoïdales `prodMonoidal`, classe symétrique `SymmetricCategory` de `Mathlib.CategoryTheory.Monoidal.Braided.Basic`, catégorification minimale d'un monoïde `Discrete.monoidal` de `Mathlib.CategoryTheory.Monoidal.Discrete`). 1/5 `theorem` lemma call direct (Prop), 2/5 `noncomputable def` lemma call direct (data, instances), 2/5 `def` type-sig (1 Prop + 1 classe data). Tous L902 ★★ safe — args résidents `(Y₁ Y₂ Y₃ Y₄ : C)`, `(X Y : C)`, `(C₁ : Type u₁)`, `(C₂ : Type u₂)`, `(M : Type u)` — pas de constructeur polymorphe d'univers.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.MonoidalCategories` + `_en` SUCCESS (634 jobs chacun, 0 warning) + `lake build` full SUCCESS (2823 jobs, 16ᵉ réutilisation du cache AZ via hardlink-copy du `.lake` pré-construit).

Suite logique directe de **PR #10805** (c.1301+137, Equivalences Partie 29) : la boucle monades → adjonctions → équivalences est bouclée, ce grain attaque les **catégories monoïdales** — la structure algébrique au socle des topos (section 6 du module : CCC, correspondance de Curry-Howard-Lambek, topos élémentaires).

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `MonoidalCategories.lean` | FR sibling canonical | 12 decls | 17 decls | +76 insertions, -1 (ligne `universe` étendue) |
| `MonoidalCategories_en.lean` | EN sibling mirror | 12 decls | 17 decls | +76 insertions, -1 (ligne `universe` étendue) |

**Total : +152 insertions net / -2 (lignes universe), 2 fichiers, 5 nouveaux bridges (5+5 symétriques FR/EN).** Aucun autre fichier touché.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (MonoidalCategories.lean = module Partie 27, reliquat #check du scan pool) | paths FR canonical + EN mirror dans scope EPIC #2159 (issuecomment-5284878613) | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 5 bridges ajoutés (`pentagon_field` / `triangle_field` / `prod_monoidal_field` / `symmetric_category_field` / `discrete_monoidal_field`), les 18 `#check` documentaires conservés, les 12 decls existantes conservées | ✅ |
| Anti-§D : 0 `sorry` ajouté | `grep -c sorry` FR = 1 (docstring header pré-existante « Tous les `sorry`s éliminés à la création ») ; EN = 1 (idem) — aucune tactique `sorry` | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | args : `(Y₁ Y₂ Y₃ Y₄ : C)`, `(X Y : C)`, `(C₁ : Type u₁)`, `(C₂ : Type u₂)`, `(M : Type u)` — defs bridées opèrent sur les univers résidents, instances `Category`/`MonoidalCategory`/`Monoid` structurelles | ✅ |
| Bridges valides | 1/5 lemma call direct (field pointwise `triangle_assoc_comp_right X Y`) + 2/5 lemma call direct (instances `prodMonoidal C₁ C₂` / `Discrete.monoidal M`) + 2/5 type-sig re-export direct (`Pentagon` / `SymmetricCategory`) | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.MonoidalCategories` + `_en` SUCCESS (634 jobs chacun, 0 warning) + full SUCCESS (2823 jobs, 16ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py .../Grothendieck` (depuis le worktree) = MonoidalCategories OK, 33/34 byte-identical, 0 drift, 0 orphan | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 27 uniquement | 2 fichiers modifiés uniquement, +152/-2 | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "MonoidalCategories.lean"` = 0 OPEN (PRs #10718/#10638/#7708 MERGED) + `check_lane_claim.py --paths` = CLEAR | ✅ |

## Les 5 bridges ajoutés — highlights

- **`pentagon_field`** : le **diagramme du pentagone de Mac Lane** — la cohérence de l'associativité exigée par la classe `MonoidalCategory`. Pour quatre objets `Y₁ Y₂ Y₃ Y₄`, les deux chemins de réassociation `((Y₁ ⊗ Y₂) ⊗ Y₃) ⊗ Y₄` et `Y₁ ⊗ (Y₂ ⊗ (Y₃ ⊗ Y₄))` coïncident. **Solution retenue** : `def ... : Prop := MonoidalCategory.Pentagon Y₁ Y₂ Y₃ Y₄` (type-sig re-export direct de la def Prop — pas une preuve du pentagone, mais l'exposition de sa définition). L902-safe (Prop → def type-sig).

- **`triangle_field`** : l'**identité triangulaire** de la catégorie monoïdale — la compatibilité entre l'associateur et les unitaires : `(α_ X (𝟙_ C) Y).inv ≫ ((ρ_ X).hom ▷ Y) = X ◁ (λ_ Y).hom`. C'est la version « associateur-inverse + unitaire droit » du triangle de Mac Lane. **Solution retenue** : `theorem ... := MonoidalCategory.triangle_assoc_comp_right X Y` (lemma call direct). L902-safe (Prop → theorem). Complète le pont cohérence : pentagone (associativité) + triangle (unité) = les deux axiomes de la classe `MonoidalCategory`.

- **`prod_monoidal_field`** : le **produit de deux catégories monoïdales** — l'instance canonique `MonoidalCategory (C₁ × C₂)` : le tenseur et l'unité se calculent composante par composante. **Solution retenue** : `@[reducible] noncomputable def ... := MonoidalCategory.prodMonoidal C₁ C₂`. Type retour `MonoidalCategory` = classe data → `noncomputable def` (leçon c.1301+131-L2 ★). **Tell linter Mathlib (nouveau)** : une def de type classe doit être marquée `@[reducible]` ou `@[implicit_reducible]` (`Definition ... of class type must be marked with @[reducible]`) — fix : `@[reducible]` avant les 2 defs data retournant `MonoidalCategory ...`.

- **`symmetric_category_field`** : la classe `SymmetricCategory` — une catégorie monoïdale tressée dont le tressage est **involutif** (`β_ X Y ≫ β_ Y X = 𝟙`). C'est la structure « symétrique » de la section 5, cadre des produits tensoriels de faisceaux. **Solution retenue** : `def ... : Type _ := CategoryTheory.SymmetricCategory C`. L902-safe (classe data → type-sig).

- **`discrete_monoidal_field`** : la **catégorification minimale d'un monoïde** — l'instance canonique `MonoidalCategory (Discrete M)` : les objets sont les éléments de `M`, le tenseur est la multiplication, l'unité est `1`. C'est le lien « monoïde → catégorie monoïdale » de la section 6. **Solution retenue** : `@[reducible] noncomputable def ... := CategoryTheory.Discrete.monoidal M`. L902-safe (data, instance structurelle).

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. Les catégories monoïdales sont le socle algébrique de la géométrie algébrique grothendieckienne : le théorème de cohérence de Mac Lane garantit qu'on peut manipuler les parenthèses comme si la structure était stricte, ce qui rend la théorie praticable (topos = CCC avec classifiant de sous-objets).

**G-VAR-3** : grains précédents (cycles c.1301+135..+137) = DEEP/lean #10800 (Cech), #10801 (Monads), #10804 (Adjunction), #10805 (Equivalences). Ce grain = DEEP/lean sur MonoidalCategories (Partie 27). **16ᵉ DEEP/lean consécutif** MAIS **substance genuinely distincte** : module différent (Partie 27 vs 29/25/26/23), produit par du raisonnement neuf — les axiomes de cohérence (pentagone + triangle) et les exemples canoniques (produit, symétrie, discret) sont des constructions distinctes des équivalences/adjonctions (chaque bridge requiert de distinguer le namespace (`Pentagon`/`triangle_assoc_comp_right`/`prodMonoidal` sous `MonoidalCategory`, `SymmetricCategory` sous `CategoryTheory`, `Discrete.monoidal` sous `CategoryTheory.Discrete`), la forme d'argument (le field pointwise vs l'instance à 2 univers vs l'instance monoïde), le type retour (Prop vs data → `def` type-sig vs `noncomputable def`), et le marqueur linter (`@[reducible]` pour les defs de type classe)). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (le choix du namespace et du marqueur `@[reducible]` sont des décisions par bridge). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 27. Le module avait déjà 12 decls (bridges sections 7-9 : tenseur/unité/associateur/unitaires/tressage + théorèmes propres eq) mais les **axiomes de cohérence** (pentagone + triangle — le cœur du théorème de Mac Lane) et les **exemples canoniques** (produit, symétrie, discret) restaient documentaires par `#check`. Les 5 bridges ferment le tableau : **données monoïdales (⊗, 𝟙_, α_, λ_, ρ_) → cohérence (pentagone + triangle) → exemples (produit, symétrique, discret)** est désormais entièrement exposé par des déclarations propres in-file.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "MonoidalCategories.lean"` = 0 OPEN collision cross-lane. PRs MonoidalCategories historiques #7708 (module original) / #10638 / #10718 (théorèmes propres) MERGED. Tous hors-scope, pas de collision.
- **Lane claim protocol** : `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: MonoidalCategories.lean, MonoidalCategories_en.lean` posté sur #2159 (issuecomment-5284878613) ; `check_lane_claim.py --paths` = CLEAR.
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x138_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +152/-2. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `grep -c sorry` FR/EN = 1 chacun (docstring header pré-existante « Tous les `sorry`s éliminés à la création », pas une tactique)
- 0 `rfl` KO (les 5 bridges = lemma call direct / re-export direct)
- Toutes les preuves = lemma call direct (cf pattern `C1301+125-L2 ★★`) ; les 2 type-sig = re-export direct de def/classe
- Aucune suppression de `#check` ou de defs/théorèmes existants (18 `#check` documentaires + 12 decls existantes conservés)
- Les seules deletions = lignes `universe v u` → `universe v u u₁ u₂ v₁ v₂` (FR+EN, byte-identity préservée)
- 2 warnings linter corrigés : `@[reducible]` ajouté sur les 2 defs de type classe (build 0 warning)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 27 (MonoidalCategories) expose désormais **17 déclarations propres in-file** (12 existantes + 5 bridges), couvrant le **cycle complet de la théorie des catégories monoïdales** : (a) les données brutes (`tensor_product`/`tensor_unit_obj`/`associator_iso`/`left_unitor_iso`/`right_unitor_iso`/`braiding_iso`), (b) les égalités définitionnelles (théorèmes propres sections 8-9), (c) la cohérence de Mac Lane (`pentagon_field`/`triangle_field`), (d) les exemples canoniques (`prod_monoidal_field`/`symmetric_category_field`/`discrete_monoidal_field`). Chaque bridge documente en FR+EN la relation entre l'API Mathlib sous-jacente et son restatement in-file, fondant le pont monoïdes → catégories monoïdales → topos au cœur de la géométrie algébrique grothendieckienne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
