### PR TITLE
feat(density,#10488): SL-2-Csharp density 639->1591 md-words — enrichissement markdown-only FR (c.8269)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-2-KnowledgeBasedLearning-Csharp.ipynb
@@ -54,13 +54,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 1. Les 4 contraintes d'apprentissage\n",
-    "\n",
-    "AIMA distingue 4 façons dont la connaissance interagit avec l'apprentissage. On les\n",
-    "vérifie par **énumération de modèles** sur un mini-monde propositionnel à 3 atomes\n",
-    "(`pointu`, `perce`, `tue`) — l'exemple du bâton de Zog."
-   ]
+   "source": "## 1. Les 4 contraintes d'apprentissage\n\nAIMA distingue 4 façons dont la connaissance interagit avec l'apprentissage, selon\nce qui est **déjà connu** avant l'apprentissage et ce que l'exemple doit apporter.\nLa cellule ci-dessous les vérifie par **énumération de modèles** sur un mini-monde\npropositionnel à 3 atomes (`pointu`, `perce`, `tue`) — l'exemple du bâton de Zog :\nune flèche pointue perce une peau molle, et percer un être vivant le tue.\n\n1. **Induction pure** (héritée de SL-1) : l'hypothèse `H` plus la description\n   `Desc` entraînent la classification. Ici `pointu => tue` avec l'observation\n   `pointu` implique `tue` — l'apprentissage *à partir des données seules*.\n2. **EBL** (*Explanation-Based Learning*) : la connaissance de fond `Background`\n   (les deux implications `pointu => perce`, `perce => tue`) entraîne déjà\n   l'hypothèse `pointu => tue`. EBL **ne découvre rien de nouveau** : il *compile*\n   une déduction que le fond rendait possible, pour l'accélérer ensuite.\n3. **RBL** (*Relevance-Based Learning*) : le fond **plus** l'observation **plus**\n   la classification entraînent l'hypothèse. L'exemple contraint la sélection :\n   parmi les hypothèses compatibles avec le fond, celles qui expliquent l'observation.\n4. **KBIL** (*Knowledge-Based Inductive Learning*) : le fond plus l'hypothèse plus\n   la description entraînent la classification — l'hypothèse candidate est *testée*\n   contre les données.\n\nL'output affiche les 4 verdicts, tous `True` sur ce mini-monde : sur l'exemple de\nZog, les 4 formes d'apprentissage sont toutes **cohérentes** avec la connaissance\nde fond. C'est le **rôle différent** de la connaissance de fond qui les distingue,\npas le résultat final : EBL s'appuie sur le fond sans données, RBL et KBIL croisent\nfond et observation, l'induction pure ignore le fond."
   },
   {
    "cell_type": "code",
@@ -231,13 +225,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 2. EBL : chaînage avant avec unification\n",
-    "\n",
-    "EBL **explique** un exemple en rejouant la déduction à partir des règles de fond.\n",
-    "On implémente un moteur de **chaînage avant** avec unification (pattern matching\n",
-    "de prédicats à variables) jusqu'au point fixe. L'exemple : le bâton pointu de Zog."
-   ]
+   "source": "## 2. EBL : chaînage avant avec unification\n\nEBL **explique** un exemple en rejouant la déduction à partir des règles de fond :\nau lieu d'apprendre un classifieur, il *déroule* la chaîne d'inférences qui relie\nles faits observés à la classification. On implémente un moteur de **chaînage\navant** avec unification (pattern matching de prédicats à variables) jusqu'au\npoint fixe. L'exemple : le bâton pointu de Zog.\n\nLes règles de fond encodent le mécanisme causal :\n`Pointu(x) => Perce(x)`, `Perce(x) ^ PeauMolle(y) => TraversePeau(x,y)`,\n`TraversePeau(x,y) ^ Vivant(y) => Hemorragie(y)`, `Hemorragie(y) => Meurt(y)`.\nLes faits observés (`Pointu(Baton)`, `PeauMolle(Gibier)`, `Vivant(Gibier)`) sont\ndes atomes **clos** ; les règles utilisent des **variables** (`x`, `y` en\nminuscules) que l'unification instancie par les faits.\n\nL'output montre la trace d'inférence complète, de `Pointu(Baton)` jusqu'à\n`Meurt(Gibier)` en 4 dérivations. Chaque étape matérialise une règle de fond\ninstanciée : la première (`Pointu(Baton) => Perce(Baton)`) lie `x` à `Baton` ;\nla seconde enchaîne avec `PeauMolle(Gibier)` en liant `y` à `Gibier`. La\nclassification `Meurt(Gibier)` est finalement dérivée (`True`)."
   },
   {
    "cell_type": "code",
@@ -418,13 +406,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 3. EBL sur la simplification arithmétique\n",
-    "\n",
-    "Un 2e exemple d'EBL : simplifier `1*(0+x)` en `x`. On représente les expressions\n",
-    "comme des chaînes et les règles de fond comme des réécritures (`1*u → u`, `0+u → u`).\n",
-    "L'arbre de preuve explique chaque étape ; la **variabilisation** le généralise."
-   ]
+   "source": "## 3. EBL sur la simplification arithmétique\n\nUn 2e exemple d'EBL : simplifier `1*(0+x)` en `x`. On représente les expressions\ncomme des chaînes et les règles de fond comme des réécritures (`1*u → u`,\n`0+u → u`). L'arbre de preuve explique chaque étape ; la **variabilisation** le\ngénéralise en une règle réutilisable.\n\nLa cellule définit d'abord le type `RewriteRule` (nom, pattern, résultat) et la\nnotion de forme **primitive** : une expression sans aucun opérateur `+ - * /`.\nLes tests affichés vérifient le prédicat : `IsPrimitive('x') = True` (une\nvariable seule), `IsPrimitive('0+x') = False` (l'opérateur `+` est présent),\n`IsPrimitive('42') = True` (une constante seule).\n\n`SimplifyStep` applique la **première** règle dont le pattern est contenu dans\nl'expression. Sur `1*(0+x)`, la règle `1*u → u` (pattern `1*`) s'applique\nimmédiatement : le résultat affiché est `('(0+x)', 1*u -> u)` — le `1*` disparaît\net l'expression restante `(0+x)` attend la règle `0+u → u` à l'étape suivante.\nL'ordre des règles compte : la réécriture est dirigée, pas commutative."
   },
   {
    "cell_type": "code",
@@ -547,13 +529,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### 3.1 Arbre de preuve + variabilisation\n",
-    "\n",
-    "`build_proof` applique `SimplifyStep` jusqu'à atteindre un primitif, en enregistrant\n",
-    "chaque étape. `variabilize_proof` remplace les constantes par des variables pour\n",
-    "généraliser la règle."
-   ]
+   "source": "### 3.1 Arbre de preuve + variabilisation\n\n`BuildProof` applique `SimplifyStep` jusqu'à atteindre un primitif, en enregistrant\nchaque étape. `VariabilizeProof` remplace ensuite les constantes par des variables\npour généraliser la règle.\n\nSur `1*(0+x)`, l'arbre de preuve affiché comporte **2 étapes** :\n1. `1*(0+x) → (0+x)` par la règle `1*u → u` ;\n2. `(0+x) → (x)` par la règle `0+u → u`.\n\nL'expression finale `(x)` est primitive : la simplification s'arrête. C'est la\n**trace** de cette dérivation que EBL va compiler.\n\nLa variabilisation remplace les constantes par des variables selon un mapping\n(`1 → a`, `0 → b`, `x → c`) : la preuve devient `a*(b+c) → (b+c) → (c)`, et la\nrègle compilée affichée est `a*(b+c) -> c`. Les constantes de l'exemple\n(`1`, `0`, `x`) sont ainsi *abstraites* : la règle apprise ne dépend plus de\nl'exemple particulier qui l'a produite — c'est le cœur de l'apprentissage EBL."
   },
   {
    "cell_type": "code",
@@ -691,13 +667,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 4. Mesurer le speedup EBL\n",
-    "\n",
-    "L'intérêt d'EBL : une fois les règles apprises (compilées), la simplification de\n",
-    "nouvelles expressions est **plus rapide** car on évite de re-dériver la preuve.\n",
-    "On chronomètre la simplification AVEC vs SANS les règles apprises."
-   ]
+   "source": "## 4. Mesurer le speedup EBL\n\nL'intérêt d'EBL : une fois les règles apprises (compilées), la simplification de\nnouvelles expressions est **plus rapide** car on évite de re-dériver la preuve.\nOn compare le coût de simplification AVEC vs SANS les règles apprises.\n\nLa cellule compare deux stratégies sur 8 expressions de test :\n- **SANS règles apprises** : on re-déroule la preuve complète à chaque fois,\n  simulé par un facteur de coût 3× par étape (le coût de re-dériver).\n- **AVEC règles apprises** : on applique directement la règle compilée\n  `EBL: a*(b+c)->c` (pattern `1*(0+`) puis on finit avec les règles de base.\n\nL'output affiche le coût agrégé sur les 8 expressions : **42 sans EBL contre 8\navec**, soit un speedup de `42/8 = 5.25x`. Le gain vient de la **compilation** :\nla chaîne de déduction (2 étapes dans l'exemple §3.1) est remplacée par une seule\napplication de règle. EBL ne rend pas la connaissance plus *vraie* — il la rend\nplus *rapide* à utiliser."
   },
   {
    "cell_type": "code",
@@ -795,13 +765,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 5. RBL : vérification de détermination\n",
-    "\n",
-    "RBL (Relevance-Based Learning) identifie les **attributs déterminants** : un ensemble\n",
-    "`det_attrs` *détermine* `target_attr` si, pour chaque combinaison de valeurs de\n",
-    "`det_attrs`, il existe **exactement une** valeur de `target_attr` dans les données."
-   ]
+   "source": "## 5. RBL : vérification de détermination\n\nRBL (Relevance-Based Learning) identifie les **attributs déterminants** : un ensemble\n`det_attrs` *détermine* `target_attr` si, pour chaque combinaison de valeurs de\n`det_attrs`, il existe **exactement une** valeur de `target_attr` dans les données.\nC'est une forme de découverte de dépendances fonctionnelles dans les données.\n\nSur le domaine restaurant (le classique *WillWait* d'AIMA), la cellule teste trois\nensembles candidats :\n- `(Patrons) -> WillWait ? False` : la valeur de `Patrons` ne suffit pas — `Some`\n  apparaît avec `Yes` et `No` dans les données.\n- `(Type) -> WillWait ? True` : chaque type de restaurant a une seule réponse\n  (`French` → `Yes`, `Thai` → `Yes`, `Burger` → `No`, `Italian` → `Yes`).\n- `(Patrons, Type) -> WillWait ? True` : la combinaison détermine aussi la réponse.\n\nLe résultat remarquable est que `Type` seul est déjà déterminant sur ce petit jeu\n(`True`) alors que `Patrons` seul ne l'est pas (`False`) : la détermination dépend\ndes **données observées**, pas d'une intuition a priori. C'est ce que RBL cherche\nà extraire : l'ensemble minimal d'attributs qui prédit la cible."
   },
   {
    "cell_type": "code",
@@ -889,12 +853,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Exercice : EBL sur la différentiation symbolique\n",
-    "\n",
-    "Appliquez EBL à un nouveau domaine : la différentiation. Variabilisez la preuve de\n",
-    "`d/dx(x^2) = 2x` en une règle générale `d/dx(u^2) = 2u`."
-   ]
+   "source": "## Exercice : EBL sur la différentiation symbolique\n\nAppliquez EBL à un nouveau domaine : la différentiation. Variabilisez la preuve de\n`d/dx(x^2) = 2x` en une règle générale `d/dx(u^2) = 2u`.\n\n**Contexte** : vous avez vu en §2 le chaînage avant avec unification et en §3.1\nl'arbre de preuve + variabilisation. Cet exercice transpose le même mécanisme\n(règles de réécriture + arbre de preuve + généralisation) aux règles de dérivation\nusuelles : `d/dx(u^n) = n*u^(n-1)`, `d/dx(const) = 0`, `d/dx(u+v) = du/dx + dv/dx`.\n\n**Indices** :\n- # Étape 1 : définir les règles de réécriture de différentiation (comme §3).\n- # Étape 2 : construire l'arbre de preuve de `d/dx(x^2)` avec `BuildProof`.\n- # Étape 3 : variabiliser (`x → u`, `2 → n`) pour généraliser la règle.\n- # Indice : réutiliser `RewriteRule`, `BuildProof` et `VariabilizeProof` de §3."
   },
   {
    "cell_type": "code",

--- a/scripts/notebook_tools/twin_pairs.d/sl-2-knowledgebasedlearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-2-knowledgebasedlearning.yaml
@@ -14,6 +14,12 @@
       csharp_sha: 275bd7259ed84ce600bb09308af699878965cf38
       content_python_sha: 33e772bc2fed219e7f3678b45c1546df9fefff8a76a8ba2761e1684f7fcb05af
       content_csharp_sha: 4a95daeedc65a24191ef177bc556490e919295a63abb56a4acab88d764ce3713
+    - date: "2026-08-13"
+      by: myia-po-2026:CoursIA-2
+      python_sha: e4b8acd30ddeb07469b8e41b837f6aee1c730a9d
+      csharp_sha: 7e9b7973f88757c01c0e2ab637392eba38ad9af9
+      content_python_sha: 33e772bc2fed219e7f3678b45c1546df9fefff8a76a8ba2761e1684f7fcb05af
+      content_csharp_sha: e63cf371037f476f0327cb61114e2d203ed1df5ab83131f7b19bc9f847c156dd
   bridge_verdict: RECOVERABLE-LOCAL
   bridge_verdict_reason: "Python = BCL from-scratch + implementation EBL complete multi-etapes (variabilisation, simplification arithmetique, extraction de regle, speedup) + RBL introduction aux determinations. C# = BCL .NET from-scratch (`Dictionary<string,string>` + unification maison) pour EBL (chainage avant avec unification, speedup) + RBL (verification de determination). Les deux cotes codent l'unification et le chainage avant from-scratch (pas de moteur Prolog). Verdict RECOVERABLE-LOCAL : le coeur pedagogique (EBL = Explanation-Based Learning, RBL = Relevance-Based Learning, determinations, unification, chainage avant) est PARITABLE des deux cotes (memes concepts AIMA, meme domaine d'application), l'asymetrie reside dans la portee (Python = implementation EBL complete + speedup multi-etapes ; C# = version focalisee sur les 2 algorithmes avec exercice commun de differentiation symbolique). Le BCL C# preserve le socle from-scratch comme choix pedagogique assume. `parity_level: semantic` preserve."
   known_differences:


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #10803

Sub-grain de l'EPIC **#10488** (montée progressive du plancher de densité pédagogique), tranche `SymbolicAI/SymbolicLearning` : enrichissement markdown-only du jumeau C# `SL-2-KnowledgeBasedLearning-Csharp.ipynb` (EBL & RBL, AIMA §19.3-19.4).

## Scope

**Densité 639 → 1591 mots MD** (palier P2 = 500, cible > 700 — dépassée ×2.5). 7 cellules markdown minces (230-292 chars chacune) enrichies avec substance pédagogique ancrée sur les outputs réels :

| Cellule | Avant | Après |
|---|---|---|
| §1 Les 4 contraintes (dfb36b89) | 263c | distinction induction/EBL/RBL/KBIL par rôle de la connaissance de fond + lecture des 4 verdicts True |
| §2 EBL chaînage avant (e11f0b6d) | 290c | règles causales + unification (variables vs faits clos) + lecture de la trace 4 dérivations Meurt(Gibier) |
| §3 Simplification arithmétique (76864c51) | 292c | RewriteRule + forme primitive + application de la 1re règle (IsPrimitive x/0+x/42, ('(0+x)', 1*u -> u)) |
| §3.1 Arbre de preuve + variabilisation (cd660084) | 230c | 2 étapes de preuve + abstraction 1→a, 0→b, x→c → règle compilée a*(b+c)->c |
| §4 Mesurer le speedup (a9fe7947) | 257c | coût simulé 42 vs 8 = 5.25x, compilation vs re-dérivation |
| §5 RBL détermination (8eff589b) | 292c | lecture contre-intuitive : Type seul True, Patrons seul False, (Patrons,Type) True |
| Exercice différentiation (ee11c81a) | 192c | contexte AIMA + indices (réutiliser RewriteRule/BuildProof/VariabilizeProof) |

## Validation

| Critère | Résultat |
|---|---|
| Cellules code touchées | **0/9** (byte-identiques à origin/main, vérifié `git show origin/main:...` vs courant) |
| Cellules totales | 18/18 inchangées (7 markdowns remplacés, 0 insertion/suppression) |
| C.1 erreurs volontaires | 0 — 3 stubs exercices préservés (`print("Exercice à compléter")` / `return new List<ProofStep>()` / `return false` / `return learnedRules`) |
| C.2 outputs | conservés (markdown-only → exception C.3, pas de re-exec requise) |
| scan_cell_ordering | 1 clean, 0 finding |
| check_prose_quantitative_claims --diff --strict | `[OK] aucun compteur quantitatif en prose` |
| Twin-parity #10439 | rebaseline `--update --pair "SL-2 KnowledgeBasedLearning"` → **157/157 OK, DRIFT 0** |
| Catalogue | byte-identique à main (0 fichier catalogue touché) |

## Finding structurel signalé (hors scope densité)

Les stubs **Exercice 2** (cell-67d68a8d) et **Exercice 3** (cell-711161da) n'ont **pas de cellule markdown amont** : leurs présentations (« RBL robuste au bruit », « Seuil de désapprentissage ») sont reléguées dans le Bilan, **après** les stubs — contraire à `three-exercises-per-notebook.md` (« Chaque exercice **précède d'un markdown** : contexte + objectif + indices »). Non corrigé ici (scope densité = markdown-only sans insertion) → candidat pour un grain #10678/three-exercises séparé.

## Anti-collision L898 ★★★

- `gh pr list --state open --json files` : **aucune** PR OPEN touchant `SL-2*` (seule #10807 touche SL-5, chemin disjoint).
- Claim `[CLAIMED]` posé sur #10488 (issuecomment-5284837672) avec `paths:` restreint au fichier C#.
- Genres récents lane : DEEP/lean ×3 → MED/notebook-python (#10803) → **MED/notebook-dotnet** (pivot R6, variété).

## Acceptance

| Critère | Valeur |
|---|---|
| Fichiers modifiés | 2 (notebook + `twin_pairs.d/sl-2-knowledgebasedlearning.yaml`) |
| Insertions / Deletions | notebook +8/−49 (remplacement 7 cellules), YAML +6/−0 |
| Densité finale | 1591 mots MD (cible > 700) |
| Cellules code | 9/9 byte-identiques |
| Twin-parity | 157/157 OK après rebaseline |

See #10488 (l'epic reste ouvert — d'autres notebooks < 700 restent à remédier : Oncology-Planning student 589, SL-3-Csharp 719).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
