### PR TITLE
feat(sk-grothendieck,#2159): Limits.lean section 10 — 7 bridges sur les classes de completude et de preservation

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits.lean
@@ -339,4 +339,83 @@ theorem colimit_ι_desc (F : J ⥤ C) [HasColimit F] (c : Cocone F) (j : J) :
     colimit.ι F j ≫ colimit.desc F c = c.ι.app j :=
   CategoryTheory.Limits.colimit.ι_desc c j
 
+/-!
+## 10. Ponts sur les classes de complétude et de préservation
+
+Les 7 bridges suivants ferment les sections 4-6 du répertoire documentaire
+(`#check`) : les classes de **complétude** (`HasLimitsOfSize`/
+`HasColimitsOfSize`), les **formes classiques** (`HasProducts`/
+`HasBinaryProducts`/`HasEqualizers`) et la **préservation** des limites
+(`PreservesLimitsOfSize`/`PreservesColimitsOfSize`). Chacun est un re-export
+type-sig de la classe Prop Mathlib (pattern winner L902 ★★ Tier 5) : args
+résidents (les univers du diagramme `v v' u u'`), instances structurelles
+uniquement, pas de constructeur polymorphe d'univers.
+
+Note univers (leçon c.1301+141-L1) : `HasLimitsOfSize.{u, v} C` prend **deux**
+univers explicites — l'univers du Shape (`J : Type u`) et l'univers des
+morphismes du Shape (`[Category.{v} J]`) — et couvre exactement nos diagrammes.
+`HasProducts.{u} C` prend **un** univers explicite (l'univers des types
+d'indices du produit, `HasProducts := ∀ J : Type w, HasLimitsOfShape
+(Discrete J) C`), aligné sur notre Shape univers ; l'omettre produit
+`universe level metavariables`. `HasBinaryProducts`/`HasEqualizers` ont des
+shapes fixes (`Discrete WalkingPair`/`WalkingParallelPair`) — aucun univers
+explicite.
+-/
+
+/-- Pont : la catégorie `C` est **complete** — tout diagramme indexé par une
+    petite catégorie de notre Shape univers (`J : Type u` avec
+    `[Category.{v} J]`) admet une limite. C'est l'assertion de complétude des
+    catégories de diagrammes de taille `(u, v)`, re-export type-sig de la
+    classe Mathlib `HasLimitsOfSize.{u, v} C`. Les limites y sont stables par
+    les constructions catégoriques utiles (catégories de faisceaux, catégories
+    de foncteurs). -/
+def has_limits_of_size_field : Prop :=
+  HasLimitsOfSize.{u, v} C
+
+/-- Pont : la catégorie `C` est **cocomplete** — tout diagramme indexé par une
+    petite catégorie de notre Shape univers admet une colimite. Duale de
+    `has_limits_of_size_field`, re-export type-sig de la classe Mathlib
+    `HasColimitsOfSize.{u, v} C`. -/
+def has_colimits_of_size_field : Prop :=
+  HasColimitsOfSize.{u, v} C
+
+/-- Pont : la catégorie `C` a tous les **produits** indexés par des types de
+    notre Shape univers — les limites sur les types discrétisés `Discrete J`
+    avec `J : Type u`. Un théorème de Freyd ramène la complétude (petite) à
+    l'existence des produits et des égaliseurs — d'où leur centralité.
+    Re-export type-sig de la classe Mathlib `HasProducts.{u} C`. -/
+def has_products_field : Prop :=
+  HasProducts.{u} C
+
+/-- Pont : la catégorie `C` a tous les **produits binaires** — les limites
+    sur le shape fixe `Discrete WalkingPair` (la paire à deux objets).
+    Re-export type-sig de la classe Mathlib `HasBinaryProducts C` (aucun
+    univers explicite : le shape est fixe). -/
+def has_binary_products_field : Prop :=
+  HasBinaryProducts C
+
+/-- Pont : la catégorie `C` a tous les **égaliseurs** — les limites sur le
+    shape fixe `WalkingParallelPair` (la paire de flèches parallèles), la
+    seconde brique du théorème de Freyd avec les produits. Re-export type-sig
+    de la classe Mathlib `HasEqualizers C` (aucun univers explicite). -/
+def has_equalizers_field : Prop :=
+  HasEqualizers C
+
+/-- Pont : un endofoncteur `F : C ⥤ C` **préserve les limites** de taille
+    `(u, v)` — l'image par `F` d'un cône limite en est encore une. C'est
+    précisément la propriété des adjoints à droite (cf module
+    `Grothendieck.Adjunction`) : le foncteur « sections globales » Γ préserve
+    ainsi les limites de faisceaux. Re-export type-sig de la classe Mathlib
+    `PreservesLimitsOfSize.{u, v} F`. -/
+def preserves_limits_of_size_field (F : C ⥤ C) : Prop :=
+  PreservesLimitsOfSize.{u, v} F
+
+/-- Pont : un endofoncteur `F : C ⥤ C` **préserve les colimites** de taille
+    `(u, v)` — l'image par `F` d'un cocône colimite en est encore une. C'est
+    la propriété des adjoints à gauche. Duale de
+    `preserves_limits_of_size_field`, re-export type-sig de la classe Mathlib
+    `PreservesColimitsOfSize.{u, v} F`. -/
+def preserves_colimits_of_size_field (F : C ⥤ C) : Prop :=
+  PreservesColimitsOfSize.{u, v} F
+
 end Grothendieck.Limits

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Limits_en.lean
@@ -338,4 +338,81 @@ theorem colimit_ι_desc (F : J ⥤ C) [HasColimit F] (c : Cocone F) (j : J) :
     colimit.ι F j ≫ colimit.desc F c = c.ι.app j :=
   CategoryTheory.Limits.colimit.ι_desc c j
 
+/-!
+## 10. Bridges on completeness and preservation classes
+
+The 7 bridges below close sections 4-6 of the `#check` documentary
+repertoire: the **completeness** classes (`HasLimitsOfSize`/
+`HasColimitsOfSize`), the **classical shapes** (`HasProducts`/
+`HasBinaryProducts`/`HasEqualizers`) and **preservation** of limits
+(`PreservesLimitsOfSize`/`PreservesColimitsOfSize`). Each is a type-sig
+re-export of the Mathlib Prop class (pattern winner L902 ★★ Tier 5): resident
+arguments (the diagram universes `v v' u u'`), structural instances only, no
+polymorphic universe constructor.
+
+Universe note (lesson c.1301+141-L1): `HasLimitsOfSize.{u, v} C` takes **two**
+explicit universes — the Shape universe (`J : Type u`) and the Shape morphism
+universe (`[Category.{v} J]`) — and covers exactly our diagrams.
+`HasProducts.{u} C` takes **one** explicit universe (the universe of product
+index types, `HasProducts := ∀ J : Type w, HasLimitsOfShape (Discrete J) C`),
+aligned on our Shape universe; omitting it yields `universe level
+metavariables`. `HasBinaryProducts`/`HasEqualizers` have fixed shapes
+(`Discrete WalkingPair`/`WalkingParallelPair`) — no explicit universe.
+-/
+
+/-- Bridge: the category `C` is **complete** — every diagram indexed by a
+    small category in our Shape universe (`J : Type u` with
+    `[Category.{v} J]`) has a limit. This is the completeness assertion for
+    diagram categories of size `(u, v)`, a type-sig re-export of the Mathlib
+    class `HasLimitsOfSize.{u, v} C`. Completeness is stable under the
+    useful categorical constructions (sheaf categories, functor categories). -/
+def has_limits_of_size_field : Prop :=
+  HasLimitsOfSize.{u, v} C
+
+/-- Bridge: the category `C` is **cocomplete** — every diagram indexed by a
+    small category in our Shape universe has a colimit. Dual of
+    `has_limits_of_size_field`, type-sig re-export of the Mathlib class
+    `HasColimitsOfSize.{u, v} C`. -/
+def has_colimits_of_size_field : Prop :=
+  HasColimitsOfSize.{u, v} C
+
+/-- Bridge: the category `C` has all **products** indexed by types in our
+    Shape universe — limits over the discretised types `Discrete J` with
+    `J : Type u`. A Freyd theorem reduces (small) completeness to products
+    and equalizers — hence their centrality. Type-sig re-export of the
+    Mathlib class `HasProducts.{u} C`. -/
+def has_products_field : Prop :=
+  HasProducts.{u} C
+
+/-- Bridge: the category `C` has all **binary products** — limits over the
+    fixed shape `Discrete WalkingPair` (the two-object pair). Type-sig
+    re-export of the Mathlib class `HasBinaryProducts C` (no explicit
+    universe: the shape is fixed). -/
+def has_binary_products_field : Prop :=
+  HasBinaryProducts C
+
+/-- Bridge: the category `C` has all **equalizers** — limits over the fixed
+    shape `WalkingParallelPair` (the parallel-arrow pair), the second brick
+    of the Freyd theorem together with products. Type-sig re-export of the
+    Mathlib class `HasEqualizers C` (no explicit universe). -/
+def has_equalizers_field : Prop :=
+  HasEqualizers C
+
+/-- Bridge: an endofunctor `F : C ⥤ C` **preserves limits** of size `(u, v)`
+    — the image by `F` of a limit cone is still a limit cone. This is
+    precisely the property of right adjoints (cf the `Grothendieck.Adjunction`
+    module): the "global sections" functor Γ thus preserves limits of
+    sheaves. Type-sig re-export of the Mathlib class
+    `PreservesLimitsOfSize.{u, v} F`. -/
+def preserves_limits_of_size_field (F : C ⥤ C) : Prop :=
+  PreservesLimitsOfSize.{u, v} F
+
+/-- Bridge: an endofunctor `F : C ⥤ C` **preserves colimits** of size `(u, v)`
+    — the image by `F` of a colimit cocone is still a colimit cocone. This is
+    the property of left adjoints. Dual of `preserves_limits_of_size_field`,
+    type-sig re-export of the Mathlib class
+    `PreservesColimitsOfSize.{u, v} F`. -/
+def preserves_colimits_of_size_field (F : C ⥤ C) : Prop :=
+  PreservesColimitsOfSize.{u, v} F
+
 end Grothendieck.Limits_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10815 (c.1301+140 Conservative)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 7 nouveaux **bridges propres in-file** dans `Limits.lean` (Partie 28 — limites et colimites, au-delà de Yoneda) fermant les **sections 4-6 documentaires** (`#check`) du module : les classes de **complétude** (`has_limits_of_size_field` / `has_colimits_of_size_field` — `HasLimitsOfSize.{u, v} C` / `HasColimitsOfSize.{u, v} C`), les **formes classiques** (`has_products_field` / `has_binary_products_field` / `has_equalizers_field` — produits indexés `HasProducts.{u} C`, produits binaires `HasBinaryProducts C`, égaliseurs `HasEqualizers C`) et la **préservation** (`preserves_limits_of_size_field` / `preserves_colimits_of_size_field` — `PreservesLimitsOfSize.{u, v} F` / `PreservesColimitsOfSize.{u, v} F` sur un endofoncteur `F : C ⥤ C`). 7/7 `def` type-sig (Prop) re-export direct de classe Mathlib. Tous L902 ★★ safe — args résidents `(F : C ⥤ C)` uniquement pour la préservation, zéro argument pour les classes de complétude (variable `C` du module), instances structurelles `[Category.{v'} C]`.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.Limits` + `_en` SUCCESS (647 jobs chacun, 0 warning) + `lake build` full SUCCESS (2823 jobs, **19ᵉ réutilisation du cache AZ** via hardlink-copy du `.lake` pré-construit).

Suite logique de la re-pioche des modules Grothendieck : le module avait déjà 16 decls (sections 7-9 : objet limite/colimite, projections/injections, factorisations, naturalité) couvrant les #check des sections 1-3, mais les **classes de complétude et de préservation** (sections 4-6) restaient documentaires par `#check`. Les 7 bridges ferment le tableau : **cône → limite → complétude (produits/égaliseurs, théorème de Freyd) → préservation (continuité des adjoints à droite, Γ sections globales)** est désormais entièrement exposé par des déclarations propres in-file.

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `Limits.lean` | FR sibling canonical | 16 decls | 23 decls | +79 insertions, -0 |
| `Limits_en.lean` | EN sibling mirror | 16 decls | 23 decls | +77 insertions, -0 |

**Total : +156 insertions net / -0, 2 fichiers, 7 nouveaux bridges (7+7 symétriques FR/EN).** Aucun autre fichier touché. Zéro suppression. Les 23 `#check` documentaires + 16 decls existantes conservés.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (Limits.lean = module Partie 28, reliquat #check du scan pool) | claim paths-scoped `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: Limits.lean, Limits_en.lean` (issuecomment-5285336846) | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 7 bridges ajoutés (`has_limits_of_size_field` / `has_colimits_of_size_field` / `has_products_field` / `has_binary_products_field` / `has_equalizers_field` / `preserves_limits_of_size_field` / `preserves_colimits_of_size_field`), les 23 `#check` documentaires conservés, les 16 decls existantes conservées | ✅ |
| Anti-§D : 0 `sorry` ajouté | `grep -c sorry` FR = 1 (docstring header pré-existante « Tous les `sorry`s éliminés à la création ») ; EN = 1 (idem) — aucune tactique `sorry` | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | args : aucun (classes de complétude, variable `C` du module) ou `(F : C ⥤ C)` (préservation) — defs bridées opèrent sur les univers résidents `v v' u u'`, univers explicites des classes = ceux du module (`HasLimitsOfSize.{u, v}` = Shape `J : Type u` + morphismes `[Category.{v} J]` ; `HasProducts.{u}` = indices alignés sur le Shape) | ✅ |
| Bridges valides | 7/7 re-export type-sig direct de classe Prop (pattern `has_enough_points_field` c.1301+139) | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.Limits` + `_en` SUCCESS (647 jobs chacun, 0 warning) + full SUCCESS (2823 jobs, 19ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py .../Grothendieck` (depuis le worktree) = Limits OK, 33/34 byte-identical, 0 drift, 0 orphan | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 28 uniquement | 2 fichiers modifiés uniquement, +156/-0 | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "Limits.lean"` = 0 OPEN (PRs historiques #10751/#10625/#7676 MERGED) — aucune collision cross-lane | ✅ |

## Les 7 bridges ajoutés — highlights

- **`has_limits_of_size_field`** : la **complétude** — tout diagramme indexé par une petite catégorie de notre Shape univers (`J : Type u` avec `[Category.{v} J]`) admet une limite. Re-export type-sig de `HasLimitsOfSize.{u, v} C`, la classe qui fonde la stabilité des limites par les constructions catégoriques (catégories de faisceaux, catégories de foncteurs). **Tell Mathlib (nouveau — leçon c.1301+141-L1 ★)** : `HasLimitsOfSize` prend **deux** univers explicites (Shape + Shape morphisms) ; `HasLimitsOfSize.{u, v} C` les fixe sur nos diagrammes.
- **`has_colimits_of_size_field`** : la **cocomplétude** — duale de la précédente (`HasColimitsOfSize.{u, v} C`).
- **`has_products_field`** : les **produits indexés** par des types de notre Shape univers (`Discrete J`, `J : Type u`). **Tell Mathlib (leçon c.1301+141-L1 ★)** : `HasProducts := ∀ J : Type w, HasLimitsOfShape (Discrete J) C` est univers-paramétré avec un univers **implicite non inférable** — omettre `.{u}` produit `universe level metavariables` (même classe d'erreur que `HasEnoughPoints` au cycle c.1301+139, leçon L2). C'est la première brique du théorème de Freyd (complétude ⇔ produits + égaliseurs).
- **`has_binary_products_field`** : les **produits binaires** — limites sur le shape fixe `Discrete WalkingPair`. Aucun univers explicite (shape fixe) — contraste direct avec `has_products_field`.
- **`has_equalizers_field`** : les **égaliseurs** — limites sur le shape fixe `WalkingParallelPair`, la seconde brique du théorème de Freyd. Aucun univers explicite.
- **`preserves_limits_of_size_field`** : la **préservation des limites** par un endofoncteur `F : C ⥤ C` — l'image par `F` d'un cône limite en est encore une. C'est précisément la propriété des adjoints à droite (lien vers le module `Grothendieck.Adjunction`) : le foncteur « sections globales » Γ préserve ainsi les limites de faisceaux, ce qui under-grit la continuité des foncteurs cohomologiques.
- **`preserves_colimits_of_size_field`** : la **préservation des colimites** — la propriété des adjoints à gauche, duale de la précédente.

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. Les classes de complétude et de préservation complètent le pont limites/colimites vers la géométrie algébrique : la complétude (produits/égaliseurs — théorème de Freyd) est ce qui rend les catégories de faisceaux exploitables, et la préservation par les adjoints à droite (Γ) fonde la cohomologie comme foncteur dérivé.

**G-VAR-3** : grains précédents (cycles c.1301+137..+141) = DEEP/lean #10805 (Equivalences), #10808 (MonoidalCategories), #10811 (Conservative section 12), #10815 (Conservative section 13). Ce grain = DEEP/lean sur Limits (Partie 28). **19ᵉ DEEP/lean consécutif** MAIS **substance genuinement distincte** : les 7 classes de complétude/péservation sont des constructions distinctes des sections précédentes (chaque bridge requiert de distinguer le nombre d'univers explicites — 2 pour `HasLimitsOfSize`/`PreservesLimitsOfSize`, 1 pour `HasProducts`, 0 pour `HasBinaryProducts`/`HasEqualizers` — et la forme d'argument : zéro argument vs `(F : C ⥤ C)`). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (le tell `universe level metavariables` sur `HasProducts` est une décision par bridge, les 23 #check voisins ne la révèlent pas). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 28. Le module avait déjà 16 decls (sections 7-9 : les théorèmes ponts sur l'objet/projections/factorisations) mais les **classes de complétude** (sections 4-6) restaient documentaires par `#check`. Les 7 bridges ferment le tableau : **limite/colimite (sections 1-3, 7-9) → complétude (4) → formes classiques, théorème de Freyd (5) → préservation, adjoints (6)** est désormais entièrement exposé par des déclarations propres in-file.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "Limits.lean"` = 0 OPEN + PRs historiques #10751/#10625/#7676/#7682/#7461/#10640/#10635/#10660/#10642/#10662 MERGED. Aucune collision cross-lane. Claim paths-scoped posté sur #2159 (issuecomment-5285336846, paths Limits.lean/Limits_en.lean, lane myia-po-2025) — disjoint du claim Conservative.lean existant.
- **Base main à jour** : branche `feature/c1301x141-2159-limits` créée depuis `origin/main` (HEAD 747dcf8ac, 2026-08-12) — module DIFFÉRENT de Conservative → pas de stacking nécessaire (contrairement à c.1301+140). Rebase frais conforme R2 catalog-pr-hygiene.
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x141_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +156/-0. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `grep -c sorry` FR/EN = 1 chacun (docstring header pré-existante « Tous les `sorry`s éliminés à la création », pas une tactique)
- 0 `rfl` KO (les 7 bridges = re-export type-sig de classe Prop)
- Toutes les preuves = re-export direct de classes Mathlib (pattern `has_enough_points_field` c.1301+139)
- Aucune suppression de `#check` ou de defs/théorèmes existants (23 `#check` documentaires + 16 decls existantes conservés — le `grep -c "#check"` à 24 = 23 réels + 1 référence textuelle dans la docstring de section)
- Aucun universe supplémentaire ajouté (les bridges opèrent sur les univers résidents `v v' u u'` ; les univers explicites des classes = ceux du module)
- Zéro deletion au diff (+156/-0)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 28 (Limits) expose désormais **23 déclarations propres in-file** (16 existantes + 7 bridges), couvrant le **cycle complet de la théorie des limites** : (a) les cônes/cocônes et propriétés universelles (sections 1-3), (b) l'objet limite/colimite et ses projections/injections (`limit_object`/`limit_projection`...), (c) les factorisations universelles (`cone_factorisation`/`cocone_factorisation`...), (d) la naturalité (`limit_w_natural`/`colimit_w_natural`), (e) les critères d'extension (`limit_hom_ext_apply`), (f) la complétude/cocomplétude (`has_limits_of_size_field`/`has_colimits_of_size_field`), (g) les formes classiques et le théorème de Freyd (`has_products_field`/`has_binary_products_field`/`has_equalizers_field`), (h) la préservation par les adjoints (`preserves_limits_of_size_field`/`preserves_colimits_of_size_field`). Chaque bridge documente en FR+EN la relation entre la classe Mathlib sous-jacente et son restatement in-file, fondant le pont cônes → limites → complétude → continuité des adjoints au cœur de la géométrie algébrique grothendieckienne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
