### PR TITLE
feat(sk-grothendieck,#2159): KanExtensions.lean section 9 — 7 bridges sur les categories d'extensions, proprietes universelles, typeclasses et densite

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions.lean
@@ -396,4 +396,86 @@ theorem dense_left_kan_unit_iso_app (F : C ⥤ D) [F.IsDense] (X : C) :
         F.rightUnitor.inv.app X :=
   CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom_app F X
 
+/-!
+## 9. Ponts sur les catégories d'extensions, les propriétés universelles et la densité
+
+Les 7 bridges suivants ferment les sections 1-3 et 7 du répertoire documentaire
+(`#check`) : les **catégories d'extensions** (`LeftExtension`/`RightExtension`),
+les **propriétés universelles** (`IsLeftKanExtension`/`IsRightKanExtension`)
+et les **typeclasses d'existence** (`HasLeftKanExtension`/`HasRightKanExtension`),
+plus la **densité** (`IsDense`) qui relie Yoneda aux extensions de Kan. Les
+extensions choisies, unités/coïnités, la descente, la bijection d'adjonction
+et le foncteur `lan` sont déjà bridgés par les sections 8 (decls existantes) ;
+ces 7 bridges complètent le tableau par la **forme abstraite** (catégories,
+Propositions, typeclasses) sur laquelle la forme choisie repose.
+
+Forme retenue (L902 ★★ Tier 5) : les deux catégories sont des re-exports
+type-sig de data (`Type _` inféré), les deux propriétés universelles sont des
+Prop à args explicites (`F'` puis `η`/`ε`, appliquées par `F'.IsLeftKanExtension
+η`), les deux typeclasses d'existence sont des Prop type-sig (pattern
+`has_enough_points_field` c.1301+139), et la densité est une Prop type-sig sur
+`F : C ⥤ D` (classe Mathlib, `F.IsDense`). Args résidents (univers
+`v₁ v₂ v₃ u₁ u₂ u₃`), instances structurelles, pas de constructeur polymorphe
+d'univers.
+-/
+
+/-- Pont : la **catégorie des extensions à gauche** de `F` le long de `L` —
+    les paires `(F' : D ⥤ H, η : F ⟶ L ⋙ F')`, dont les objets initiaux sont
+    exactement les extensions de Kan à gauche. Re-export type-sig de la
+    catégorie Mathlib `CategoryTheory.Functor.LeftExtension L F`. -/
+def left_extension_field (L : C ⥤ D) (F : C ⥤ H) : Type _ :=
+  CategoryTheory.Functor.LeftExtension L F
+
+/-- Pont : la **catégorie des extensions à droite** de `F` le long de `L` —
+    les paires `(F' : D ⥤ H, ε : L ⋙ F' ⟶ F)`, dont les objets terminaux
+    sont exactement les extensions de Kan à droite. Duale de
+    `left_extension_field`, re-export type-sig de la catégorie Mathlib
+    `CategoryTheory.Functor.RightExtension L F`. -/
+def right_extension_field (L : C ⥤ D) (F : C ⥤ H) : Type _ :=
+  CategoryTheory.Functor.RightExtension L F
+
+/-- Pont : la **propriété universelle d'être une extension de Kan à gauche** —
+    `(F', η)` est **initial** dans `LeftExtension L F` : pour tout concurrent
+    `(G, F ⟶ L ⋙ G)`, il existe un unique morphisme `F' ⟶ G` factorisant la
+    transformation. Re-export type-sig de la Prop Mathlib
+    `F'.IsLeftKanExtension η` (l'unicité est partie de la définition).
+    Args explicites : `F'` puis `η`. -/
+def is_left_kan_extension_field (L : C ⥤ D) (F : C ⥤ H) (F' : D ⥤ H) (η : F ⟶ L ⋙ F') : Prop :=
+  F'.IsLeftKanExtension η
+
+/-- Pont : la **propriété universelle d'être une extension de Kan à droite** —
+    `(F', ε)` est **terminal** dans `RightExtension L F` : tout concurrent
+    se factorise de manière unique à travers `F'`. Duale de
+    `is_left_kan_extension_field`, re-export type-sig de la Prop Mathlib
+    `F'.IsRightKanExtension ε`. Args explicites : `F'` puis `ε`. -/
+def is_right_kan_extension_field (L : C ⥤ D) (F : C ⥤ H) (F' : D ⥤ H) (ε : L ⋙ F' ⟶ F) : Prop :=
+  F'.IsRightKanExtension ε
+
+/-- Pont : la **typeclasse d'existence** `F` admet une extension de Kan à
+    gauche le long de `L` — `HasInitial (LeftExtension L F)` : la catégorie
+    des extensions à gauche a un objet initial. Ce n'est pas garanti en
+    général (cela dépend de la complétude de `H`). Re-export type-sig de la
+    Prop Mathlib `HasLeftKanExtension L F`, sur laquelle repose l'extension
+    **choisie** `kan_extension_left` (section 8). -/
+def has_left_kan_extension_field (L : C ⥤ D) (F : C ⥤ H) : Prop :=
+  CategoryTheory.Functor.HasLeftKanExtension L F
+
+/-- Pont : la **typeclasse d'existence** duale — `F` admet une extension de
+    Kan à droite le long de `L` (`HasTerminal (RightExtension L F)`).
+    Re-export type-sig de la Prop Mathlib `HasRightKanExtension L F`, sur
+    laquelle repose l'extension choisie `kan_extension_right` (section 8). -/
+def has_right_kan_extension_field (L : C ⥤ D) (F : C ⥤ H) : Prop :=
+  CategoryTheory.Functor.HasRightKanExtension L F
+
+/-- Pont : la **densité** — `F : C ⥤ D` est dense si l'identité de `D` est
+    une extension de Kan à gauche de `F` le long de lui-même. C'est le fait
+    fondamental qui relie Yoneda aux extensions de Kan : le plongement de
+    Yoneda est dense, donc tout foncteur sur `C` se récupère comme extension
+    de Kan (colimite pondérée) du plongement — les objets de `C`
+    « engendrent » tout préfaisceau. Re-export type-sig de la classe Mathlib
+    `F.IsDense` (utilisée en bracket par `dense_left_kan_unit_iso`/`_app`,
+    section 8). -/
+def is_dense_field (F : C ⥤ D) : Prop :=
+  F.IsDense
+
 end Grothendieck.KanExtensions

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/KanExtensions_en.lean
@@ -390,4 +390,83 @@ theorem dense_left_kan_unit_iso_app (F : C ⥤ D) [F.IsDense] (X : C) :
         F.rightUnitor.inv.app X :=
   CategoryTheory.Functor.IsDense.leftKanExtensionUnit_leftKanExtensionIso_hom_app F X
 
+/-!
+## 9. Bridges on extension categories, universal properties and density
+
+The 7 bridges below close sections 1-3 and 7 of the `#check` documentary
+repertoire: the **extension categories** (`LeftExtension`/`RightExtension`),
+the **universal properties** (`IsLeftKanExtension`/`IsRightKanExtension`),
+the **existence typeclasses** (`HasLeftKanExtension`/`HasRightKanExtension`),
+and **density** (`IsDense`) which ties Yoneda to Kan extensions. The chosen
+extensions, units/counits, descent, the adjunction bijection and the `lan`
+functor are already bridged by section 8 (existing decls); these 7 bridges
+complete the picture with the **abstract form** (categories, Propositions,
+typeclasses) on which the chosen form rests.
+
+Retained form (L902 ★★ Tier 5): the two categories are type-sig re-exports of
+data (`Type _` inferred), the two universal properties are Props with explicit
+args (`F'` then `η`/`ε`, applied as `F'.IsLeftKanExtension η`), the two
+existence typeclasses are type-sig Props (pattern `has_enough_points_field`
+c.1301+139), and density is a type-sig Prop on `F : C ⥤ D` (Mathlib class,
+`F.IsDense`). Resident arguments (universes `v₁ v₂ v₃ u₁ u₂ u₃`), structural
+instances, no polymorphic universe constructor.
+-/
+
+/-- Bridge: the **category of left extensions** of `F` along `L` — pairs
+    `(F' : D ⥤ H, η : F ⟶ L ⋙ F')`, whose initial objects are exactly the
+    left Kan extensions. Type-sig re-export of the Mathlib category
+    `CategoryTheory.Functor.LeftExtension L F`. -/
+def left_extension_field (L : C ⥤ D) (F : C ⥤ H) : Type _ :=
+  CategoryTheory.Functor.LeftExtension L F
+
+/-- Bridge: the **category of right extensions** of `F` along `L` — pairs
+    `(F' : D ⥤ H, ε : L ⋙ F' ⟶ F)`, whose terminal objects are exactly the
+    right Kan extensions. Dual of `left_extension_field`, type-sig re-export
+    of the Mathlib category `CategoryTheory.Functor.RightExtension L F`. -/
+def right_extension_field (L : C ⥤ D) (F : C ⥤ H) : Type _ :=
+  CategoryTheory.Functor.RightExtension L F
+
+/-- Bridge: the **universal property of being a left Kan extension** —
+    `(F', η)` is **initial** in `LeftExtension L F`: for every concurrent
+    `(G, F ⟶ L ⋙ G)`, there is a unique morphism `F' ⟶ G` factoring the
+    transformation. Type-sig re-export of the Mathlib Prop
+    `F'.IsLeftKanExtension η` (uniqueness is part of the definition).
+    Explicit args: `F'` then `η`. -/
+def is_left_kan_extension_field (L : C ⥤ D) (F : C ⥤ H) (F' : D ⥤ H) (η : F ⟶ L ⋙ F') : Prop :=
+  F'.IsLeftKanExtension η
+
+/-- Bridge: the **universal property of being a right Kan extension** —
+    `(F', ε)` is **terminal** in `RightExtension L F`: every concurrent
+    factors uniquely through `F'`. Dual of `is_left_kan_extension_field`,
+    type-sig re-export of the Mathlib Prop `F'.IsRightKanExtension ε`.
+    Explicit args: `F'` then `ε`. -/
+def is_right_kan_extension_field (L : C ⥤ D) (F : C ⥤ H) (F' : D ⥤ H) (ε : L ⋙ F' ⟶ F) : Prop :=
+  F'.IsRightKanExtension ε
+
+/-- Bridge: the **existence typeclass** — `F` has a left Kan extension along
+    `L`, i.e. `HasInitial (LeftExtension L F)`: the category of left
+    extensions has an initial object. This is not guaranteed in general (it
+    depends on the completeness of `H`). Type-sig re-export of the Mathlib
+    Prop `HasLeftKanExtension L F`, on which the **chosen** extension
+    `kan_extension_left` (section 8) rests. -/
+def has_left_kan_extension_field (L : C ⥤ D) (F : C ⥤ H) : Prop :=
+  CategoryTheory.Functor.HasLeftKanExtension L F
+
+/-- Bridge: the dual **existence typeclass** — `F` has a right Kan extension
+    along `L` (`HasTerminal (RightExtension L F)`). Type-sig re-export of the
+    Mathlib Prop `HasRightKanExtension L F`, on which the chosen extension
+    `kan_extension_right` (section 8) rests. -/
+def has_right_kan_extension_field (L : C ⥤ D) (F : C ⥤ H) : Prop :=
+  CategoryTheory.Functor.HasRightKanExtension L F
+
+/-- Bridge: **density** — `F : C ⥤ D` is dense if the identity of `D` is a
+    left Kan extension of `F` along itself. This is the fundamental fact
+    tying Yoneda to Kan extensions: the Yoneda embedding is dense, so every
+    functor on `C` is recovered as a Kan extension (weighted colimit) of the
+    embedding — the objects of `C` "generate" every presheaf. Type-sig
+    re-export of the Mathlib class `F.IsDense` (used as a bracket by
+    `dense_left_kan_unit_iso`/`_app`, section 8). -/
+def is_dense_field (F : C ⥤ D) : Prop :=
+  F.IsDense
+
 end Grothendieck.KanExtensions_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10816 (c.1301+141 Limits)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 7 nouveaux **bridges propres in-file** dans `KanExtensions.lean` (Partie 26 — extensions de Kan) fermant les **sections 1-3 et 7 documentaires** (`#check`) du module : les **catégories d'extensions** (`left_extension_field` / `right_extension_field` — `Functor.LeftExtension L F` / `RightExtension L F`, les paires `(F', F ⟶ L ⋙ F')` / `(F', L ⋙ F' ⟶ F)` dont les objets initiaux/terminaux sont les Kan), les **propriétés universelles** (`is_left_kan_extension_field` / `is_right_kan_extension_field` — `F'.IsLeftKanExtension η` / `F'.IsRightKanExtension ε`, initialité/terminalité), les **typeclasses d'existence** (`has_left_kan_extension_field` / `has_right_kan_extension_field` — `HasLeftKanExtension L F` / `HasRightKanExtension L F` = `HasInitial (LeftExtension L F)` / `HasTerminal (RightExtension L F)`) et la **densité** (`is_dense_field` — `F.IsDense`, le lien Yoneda-Kan : le plongement de Yoneda est dense, tout foncteur se récupère comme extension de Kan du plongement). 7/7 `def` type-sig (2 data + 5 Prop). Tous L902 ★★ safe — args résidents `(L : C ⥤ D) (F : C ⥤ H)` (style des decls section 8), instances structurelles `[Category.{v₁} C]` etc.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.KanExtensions` + `_en` SUCCESS (947 jobs chacun, 0 warning) + `lake build` full SUCCESS (2823 jobs, **20ᵉ réutilisation du cache AZ** via hardlink-copy du `.lake` pré-construit).

Suite logique de la re-pioche des modules Grothendieck : le module avait déjà 15 decls (section 8 : extensions choisies `kan_extension_left/right`, unités/coïnités, foncteur `lan`, descente `kan_descent`, bijection `kan_right_hom_equiv`, densité appliquée `dense_left_kan_unit_iso`/`_app`) mais la **forme abstraite** (catégories d'extensions, Propositions universelles, typeclasses d'existence, densité) restait documentaire par `#check`. Les 7 bridges ferment le tableau : **problème (étendre le long de L) → catégories d'extensions → propriété universelle (initial/terminal) → existence (typeclasses) → extension choisie → descente/bijection → lan (adjonction) → ponctuel → densité (Yoneda)** est désormais entièrement exposé par des déclarations propres in-file.

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `KanExtensions.lean` | FR sibling canonical | 15 decls | 22 decls | +82 insertions, -0 |
| `KanExtensions_en.lean` | EN sibling mirror | 15 decls | 22 decls | +79 insertions, -0 |

**Total : +161 insertions net / -0, 2 fichiers, 7 nouveaux bridges (7+7 symétriques FR/EN).** Aucun autre fichier touché. Zéro suppression. Les 22 `#check` documentaires + 15 decls existantes conservés.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (KanExtensions.lean = module Partie 26, reliquat #check du scan pool) | claim paths-scoped `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: KanExtensions.lean, KanExtensions_en.lean` (issuecomment-5285459956) | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 7 bridges ajoutés (`left_extension_field` / `right_extension_field` / `is_left_kan_extension_field` / `is_right_kan_extension_field` / `has_left_kan_extension_field` / `has_right_kan_extension_field` / `is_dense_field`), les 22 `#check` documentaires conservés, les 15 decls existantes conservées | ✅ |
| Anti-§D : 0 `sorry` ajouté | `grep -c sorry` FR = 2, EN = 2 — **identique à main** (vérifié `git show origin/main` = 2) : docstrings header pré-existantes (« Tous les `sorry`s éliminés à la création » ×2) — aucune tactique `sorry` | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | args : `(L : C ⥤ D) (F : C ⥤ H)` (+ `(F' : D ⥤ H)` et `η`/`ε` pour les Props universelles) — defs bridées opèrent sur les univers résidents `v₁ v₂ v₃ u₁ u₂ u₃`, instances structurelles `[Category.{v₁} C]` etc. | ✅ |
| Bridges valides | 7/7 re-export direct de type/Prop/typeclasse Mathlib (pattern `has_enough_points_field` c.1301+139) | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.KanExtensions` + `_en` SUCCESS (947 jobs chacun, 0 warning) + full SUCCESS (2823 jobs, 20ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py .../Grothendieck` (depuis le worktree) = KanExtensions OK, 33/34 byte-identical, 0 drift, 0 orphan | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 26 uniquement | 2 fichiers modifiés uniquement, +161/-0 | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "KanExtensions.lean"` = 0 OPEN (PRs historiques #10756/#10623/#7703 MERGED) — aucune collision cross-lane | ✅ |

## Les 7 bridges ajoutés — highlights

- **`left_extension_field`** / **`right_extension_field`** : les **catégories d'extensions** — la donnée de tous les candidats `(F', η : F ⟶ L ⋙ F')` (resp. `(F', ε : L ⋙ F' ⟶ F)`) comme catégorie, dont les objets initiaux (resp. terminaux) sont exactement les extensions de Kan. C'est le cadre dans lequel la propriété universelle devient « initial »/« terminal » — la définition purement universelle des Kan. Re-export type-sig de data (`Type _` inféré sur les univers résidents).
- **`is_left_kan_extension_field`** : la **propriété universelle** — `(F', η)` est initial dans `LeftExtension L F` : pour tout concurrent `(G, F ⟶ L ⋙ G)`, il existe un **unique** morphisme `F' ⟶ G` factorisant la transformation. L'unicité est partie de la définition (Prop, pas donnée). Args explicites : `L F` (style section 8) puis `F'` et `η`.
- **`is_right_kan_extension_field`** : duale — terminalité dans `RightExtension L F`.
- **`has_left_kan_extension_field`** / **`has_right_kan_extension_field`** : les **typeclasses d'existence** — `HasInitial (LeftExtension L F)` / `HasTerminal (RightExtension L F)`. Non garanties en général (dépendent de la complétude de `H`) ; quand elles tiennent, l'extension **choisie** `kan_extension_left/right` (section 8) est disponible. Re-export type-sig des Props Mathlib.
- **`is_dense_field`** : la **densité** — `F : C ⥤ D` est dense si l'identité de `D` est une extension de Kan à gauche de `F` le long de lui-même. C'est le **fait fondamental qui relie Yoneda aux extensions de Kan** : le plongement de Yoneda est dense, donc tout foncteur sur `C` se récupère comme extension de Kan (colimite pondérée) du plongement — les objets de `C` « engendrent » tout préfaisceau. Re-export type-sig de la classe Mathlib `F.IsDense` (utilisée en bracket par les decls existantes `dense_left_kan_unit_iso`/`_app`).

**Tell Mathlib (nouveau — leçon c.1301+142-L1 ★)** : le module ne déclare **pas** `variable (L : C ⥤ D) (F : C ⥤ H)` — seules les variables C/D/H existent. Un bridge qui référence `L`/`F` dans son type retour ou son corps doit les prendre en **args explicites** (style des decls section 8 : `kan_extension_left (L : C ⥤ D) (F : C ⥤ H)`), sinon tell `Unknown identifier L` / `autoImplicit` est à `false` dans le module. Mon fichier #check de pré-validation avait ajouté `variable (L) (F)` en tête — il a donc **masqué** l'erreur (leçon : le scratch doit reproduire le variable scope exact du fichier cible).

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. Les extensions de Kan sont une des constructions les plus universelles de la théorie des catégories : limites/colimites comme Kan le long du foncteur vers la catégorie terminale, lemme de Yoneda comme Kan de l'identité, foncteurs dérivés (Cartan-Eilenberg puis Grothendieck) comme Kan, densité du plongement de Yoneda. Les 7 bridges exposent la **forme abstraite** (catégories + propriétés universelles + existence + densité) qui fonde toute la forme choisie déjà bridgée.

**G-VAR-3** : grains précédents (cycles c.1301+137..+142) = DEEP/lean #10805 (Equivalences), #10808 (MonoidalCategories), #10811 (Conservative s12), #10815 (Conservative s13), #10816 (Limits). Ce grain = DEEP/lean sur KanExtensions (Partie 26). **20ᵉ DEEP/lean consécutif** MAIS **substance genuinement distincte** : les catégories d'extensions, les Propositions universelles, les typeclasses d'existence et la densité sont des constructions distinctes des sections précédentes (chaque bridge requiert de distinguer la forme — data `Type _` vs Prop à args explicites (`F'`, `η`) vs Prop type-sig — et l'argumentation : `(L) (F)` pour la plupart, `(F)` seul pour `is_dense_field`). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (le tell `Unknown identifier L` avec `autoImplicit = false` est une décision par module — le scratch trop laxiste l'a masqué au premier coup). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 26. Le module avait déjà 15 decls (section 8 : les objets choisis et leurs propriétés) mais la **forme abstraite** (sections 1-3, 7) restait documentaire par `#check`. Les 7 bridges ferment le tableau : **problème → catégories → propriétés universelles → existence → choix → descente → lan → densité** est désormais entièrement exposé par des déclarations propres in-file.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "KanExtensions.lean"` = 0 OPEN + PRs historiques #10756/#10623/#7703 MERGED. Aucune collision cross-lane. Claim paths-scoped posté sur #2159 (issuecomment-5285459956, paths KanExtensions.lean/KanExtensions_en.lean, lane myia-po-2025) — disjoint des claims Limits.lean et Conservative.lean existants.
- **Base main à jour** : branche `feature/c1301x142-2159-kanext` créée depuis `origin/main` (HEAD 747dcf8ac, 2026-08-13) — module DIFFÉRENT des grains précédents → pas de stacking. Rebase frais conforme R2 catalog-pr-hygiene.
- **Hors scope po-2026** : le dashboard liste po-2026 sur YonedaLemma/LeftExact/Calibration/CategoryAndSites/MathlibMap — KanExtensions n'y figure pas (L898 + dashboard vérifiés).
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x142_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +161/-0. ✅
- **L279 ★★** : push 403 (compte gh actif = jsboigeEpita) → `gh auth switch -u jsboige` → push → switch back. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `grep -c sorry` FR/EN = 2 chacun, **identique à main** (vérifié `git show origin/main`) — docstrings header pré-existantes, pas une tactique
- 0 `rfl` KO (les 7 bridges = re-export type-sig de types/Props/typeclasses Mathlib)
- Toutes les preuves = re-export direct (pattern `has_enough_points_field` c.1301+139)
- Aucune suppression de `#check` ou de defs/théorèmes existants (22 `#check` documentaires + 15 decls existantes conservés — le `grep -c "#check"` à 23 = 22 réels + 1 référence textuelle dans la docstring de section, vérifié ligne 403)
- Aucun universe supplémentaire ajouté (les bridges opèrent sur les univers résidents `v₁ v₂ v₃ u₁ u₂ u₃`)
- Zéro deletion au diff (+161/-0)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 26 (KanExtensions) expose désormais **22 déclarations propres in-file** (15 existantes + 7 bridges), couvrant le **cycle complet de la théorie des extensions de Kan** : (a) les catégories d'extensions (`left_extension_field`/`right_extension_field`), (b) les propriétés universelles (`is_left_kan_extension_field`/`is_right_kan_extension_field`), (c) les typeclasses d'existence (`has_left_kan_extension_field`/`has_right_kan_extension_field`), (d) les extensions choisies et unités/coïnités (`kan_extension_left/right`, `kan_extension_left_unit`/`right_counit`), (e) le foncteur `lan` et son adjonction à la précomposition (`lan_functor`, `lan_functor_is_left_adjoint_to_precomp`), (f) la descente et la bijection (`kan_descent`, `kan_right_hom_equiv`, `kan_descent_fac`), (g) la densité et le lien Yoneda (`is_dense_field`, `dense_functor_left_kan_extension_iso_id`, `dense_left_kan_unit_iso`/`_app`). Chaque bridge documente en FR+EN la relation entre l'API Mathlib sous-jacente et son restatement in-file, fondant le pont extensions de Kan → limites/colimites → Yoneda → foncteurs dérivés au cœur de la géométrie algébrique grothendieckienne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
