### PR TITLE
feat(lean,#2159): SitePoints.lean — 7 bridges type-sig (Point/presheafFiber/toPresheafFiber/Point.Hom/trivial/discrete/jointly_surjective)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints.lean
@@ -312,4 +312,100 @@ theorem discrete_topology_eq_top (C : Type u) [Category.{v} C] :
     GrothendieckTopology.discrete C = ⊤ :=
   CategoryTheory.GrothendieckTopology.discrete_eq_top
 
+/-!
+## 10. Bridges : la forme abstraite des points de Grothendieck
+
+Les 7 bridges ci-dessous ferment le répertoire `#check` documentaire du
+module : la **structure** `Point` (le « foncteur tige » `Φ.fiber` cofiltre
+rencontrant tout crible couvrant), le **foncteur fibre préfaisceau**
+`Φ.presheafFiber` (la colimite sur la catégorie des éléments) et son
+**inclusion canonique** `Φ.toPresheafFiber`, la **catégorie des points**
+`Point.Hom` (les morphismes entre points, SGA 4 IV 3.2), les topologies
+**triviale** et **discrète**, et la **condition de couverture**
+`jointly_surjective` (SGA 4 IV 6.3). Chacun est un re-export type-sig de
+l'API Mathlib (pattern winner L902 ★★ Tier 5) : args résidents
+(`{C : Type u} [Category.{v} C]` + `(Φ : GrothendieckTopology.Point.{w} J)`),
+instances structurelles uniquement, zéro constructeur polymorphe d'univers.
+
+Universe note (leçon c.1301+143-L1) : `Point.{w} J` vit dans
+`Type (max (max u v) (w + 1))` — le 3ᵉ univers `w` est celui des fibres
+(`Φ.fiber : C ⥤ Type w`). Le foncteur fibre préfaisceau exige en sus la
+cocomplétude de la cible (`HasColimitsOfSize`), que la catégorie des types
+`Type (max u w)` satisfait toujours ; il est `noncomputable` (le colimite
+n'a pas de choix canonique).
+-/
+
+/-- Bridge : la **structure de point** d'un site `(C, J)` — un foncteur
+    `Φ.fiber : C ⥤ Type w` dont la catégorie des éléments est cofiltre
+    (ce qui assure l'exactitude : commutation aux limites finies) et qui
+    rencontre tout crible couvrant. C'est la généralisation
+    grothendieckienne du point d'un espace topologique (SGA 4 IV 6.3).
+    Type-sig re-export de `GrothendieckTopology.Point.{w} J`. -/
+def point_field {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) : Type _ :=
+  GrothendieckTopology.Point.{w} J
+
+/-- Bridge : le **foncteur fibre des préfaisceaux** en un point `Φ` —
+    évalue un préfaisceau `P` en prenant la colimite de `P` sur la
+    catégorie des éléments de `Φ.fiber`. Intuitivement, `presheafFiber.obj P`
+    est la « tige de P en Φ », la colimite filtrée sur toutes les paires
+    `(X, x)` avec `x : Φ.fiber.obj X`. Re-export type-sig de
+    `GrothendieckTopology.Point.presheafFiber` (le type cible est la
+    catégorie des types de notre univers fibre `Type (max u w)`). -/
+noncomputable def presheaf_fiber_field {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{w} J) :
+    (Cᵒᵖ ⥤ Type (max u w)) ⥤ Type (max u w) :=
+  Φ.presheafFiber
+
+/-- Bridge : l'**inclusion canonique** dans la fibre — pour un témoin
+    `x : Φ.fiber.obj X`, le morphisme `P.obj (op X) ⟶ Φ.presheafFiber.obj P`
+    envoyant une section en la classe de `(X, x)` dans la colimite. C'est
+    la lég du cocône colimite qui définit `presheafFiber`. Re-export
+    type-sig de `GrothendieckTopology.Point.toPresheafFiber`. -/
+noncomputable def to_presheaf_fiber_field {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{w} J)
+    (X : C) (x : Φ.fiber.obj X) (P : Cᵒᵖ ⥤ Type (max u w)) :
+    P.obj (Opposite.op X) ⟶ Φ.presheafFiber.obj P :=
+  Φ.toPresheafFiber X x P
+
+/-- Bridge : les **morphismes entre points** d'un site — une
+    transformation naturelle en sens inverse entre les foncteurs fibres
+    (SGA 4 IV 3.2). Les points d'un site forment une catégorie : c'est ce
+    qui permet de comparer les « sondes » d'un site entre elles.
+    Type-sig re-export de `GrothendieckTopology.Point.Hom`. -/
+def point_hom_field {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} (Φ₁ Φ₂ : GrothendieckTopology.Point.{w} J) :
+    Type _ :=
+  GrothendieckTopology.Point.Hom Φ₁ Φ₂
+
+/-- Bridge : la **topologie triviale** sur `C` — la plus grossière : tout
+    crible est couvrant, donc tout préfaisceau est un faisceau (cf
+    `trivial_topology_eq_bot` : `trivial C = ⊥`). Re-export type-sig de
+    `GrothendieckTopology.trivial`. -/
+def trivial_field (C : Type u) [Category.{v} C] :
+    GrothendieckTopology C :=
+  GrothendieckTopology.trivial C
+
+/-- Bridge : la **topologie discrète** sur `C` — la plus fine : seul le
+    crible maximal est couvrant, donc seul le préfaisceau terminal est un
+    faisceau (cf `discrete_topology_eq_top` : `discrete C = ⊤`). Re-export
+    type-sig de `GrothendieckTopology.discrete`. -/
+def discrete_field (C : Type u) [Category.{v} C] :
+    GrothendieckTopology C :=
+  GrothendieckTopology.discrete C
+
+/-- Bridge : la **condition de couverture** d'un point (SGA 4 IV 6.3) —
+    pour tout objet `X` et tout crible couvrant `R ∈ J X`, tout élément
+    `x : Φ.fiber.obj X` provient d'un élément de la fibre au-dessus d'une
+    flèche couvrante : `∃ Y f, R.arrows f ∧ ∃ y, Φ.fiber.map f y = x`.
+    C'est ce qui relie la topologie au foncteur fibre — sans elle, le
+    foncteur fibre ne « verrait » pas les recouvrements. Re-export type-sig
+    du champ `GrothendieckTopology.Point.jointly_surjective`. -/
+def jointly_surjective_field {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{w} J) :
+    ∀ {X : C}, ∀ R ∈ J X, ∀ x : Φ.fiber.obj X,
+      ∃ (Y : C) (f : Y ⟶ X), ∃ (_ : R.arrows f), ∃ y : Φ.fiber.obj Y,
+        Φ.fiber.map f y = x :=
+  Φ.jointly_surjective
+
 end Grothendieck

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SitePoints_en.lean
@@ -305,4 +305,100 @@ theorem discrete_topology_eq_top (C : Type u) [Category.{v} C] :
     GrothendieckTopology.discrete C = ⊤ :=
   CategoryTheory.GrothendieckTopology.discrete_eq_top
 
+/-!
+## 10. Bridges: the abstract shape of Grothendieck points
+
+The 7 bridges below close the `#check` documentary repertoire of this
+module: the **structure** `Point` (the "stalk functor" `Φ.fiber`, cofiltered
+and meeting every covering sieve), the **presheaf fiber functor**
+`Φ.presheafFiber` (the colimit over the category of elements) with its
+**canonical inclusion** `Φ.toPresheafFiber`, the **category of points**
+`Point.Hom` (morphisms between points, SGA 4 IV 3.2), the **trivial** and
+**discrete** topologies, and the **coverage condition** `jointly_surjective`
+(SGA 4 IV 6.3). Each is a type-sig re-export of the Mathlib API (pattern
+winner L902 ★★ Tier 5): resident arguments (`{C : Type u} [Category.{v} C]`
+plus `(Φ : GrothendieckTopology.Point.{w} J)`), structural instances only,
+no polymorphic universe constructor.
+
+Universe note (lesson c.1301+143-L1): `Point.{w} J` lives in
+`Type (max (max u v) (w + 1))` — the third universe `w` is that of the
+fibers (`Φ.fiber : C ⥤ Type w`). The presheaf fiber functor additionally
+requires cocompleteness of the target (`HasColimitsOfSize`), which the
+category of types `Type (max u w)` always satisfies; it is `noncomputable`
+(a colimit has no canonical choice).
+-/
+
+/-- Bridge: the **structure of a point** of a site `(C, J)` — a functor
+    `Φ.fiber : C ⥤ Type w` whose category of elements is cofiltered (which
+    ensures exactness: commutation with finite limits) and which meets
+    every covering sieve. This is the Grothendieck generalization of the
+    point of a topological space (SGA 4 IV 6.3). Type-sig re-export of
+    `GrothendieckTopology.Point.{w} J`. -/
+def point_field {C : Type u} [Category.{v} C]
+    (J : GrothendieckTopology C) : Type _ :=
+  GrothendieckTopology.Point.{w} J
+
+/-- Bridge: the **presheaf fiber functor** at a point `Φ` — evaluates a
+    presheaf `P` by taking the colimit of `P` over the category of elements
+    of `Φ.fiber`. Intuitively, `presheafFiber.obj P` is the "stalk of P at
+    Φ", the filtered colimit over all pairs `(X, x)` with `x : Φ.fiber.obj X`.
+    Type-sig re-export of `GrothendieckTopology.Point.presheafFiber` (the
+    target type is the category of types in our fiber universe
+    `Type (max u w)`). -/
+noncomputable def presheaf_fiber_field {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{w} J) :
+    (Cᵒᵖ ⥤ Type (max u w)) ⥤ Type (max u w) :=
+  Φ.presheafFiber
+
+/-- Bridge: the **canonical inclusion** into the fiber — for a witness
+    `x : Φ.fiber.obj X`, the morphism `P.obj (op X) ⟶ Φ.presheafFiber.obj P`
+    sending a section to the class of `(X, x)` in the colimit. This is the
+    leg of the colimit cocone that defines `presheafFiber`. Type-sig
+    re-export of `GrothendieckTopology.Point.toPresheafFiber`. -/
+noncomputable def to_presheaf_fiber_field {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{w} J)
+    (X : C) (x : Φ.fiber.obj X) (P : Cᵒᵖ ⥤ Type (max u w)) :
+    P.obj (Opposite.op X) ⟶ Φ.presheafFiber.obj P :=
+  Φ.toPresheafFiber X x P
+
+/-- Bridge: **morphisms between points** of a site — a natural
+    transformation in the reverse direction between the fiber functors
+    (SGA 4 IV 3.2). The points of a site form a category: this is what
+    allows comparing the "probes" of a site with each other. Type-sig
+    re-export of `GrothendieckTopology.Point.Hom`. -/
+def point_hom_field {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} (Φ₁ Φ₂ : GrothendieckTopology.Point.{w} J) :
+    Type _ :=
+  GrothendieckTopology.Point.Hom Φ₁ Φ₂
+
+/-- Bridge: the **trivial topology** on `C` — the coarsest one: every
+    sieve is covering, so every presheaf is a sheaf (cf
+    `trivial_topology_eq_bot`: `trivial C = ⊥`). Type-sig re-export of
+    `GrothendieckTopology.trivial`. -/
+def trivial_field (C : Type u) [Category.{v} C] :
+    GrothendieckTopology C :=
+  GrothendieckTopology.trivial C
+
+/-- Bridge: the **discrete topology** on `C` — the finest one: only the
+    maximal sieve is covering, so only the terminal presheaf is a sheaf
+    (cf `discrete_topology_eq_top`: `discrete C = ⊤`). Type-sig re-export
+    of `GrothendieckTopology.discrete`. -/
+def discrete_field (C : Type u) [Category.{v} C] :
+    GrothendieckTopology C :=
+  GrothendieckTopology.discrete C
+
+/-- Bridge: the **coverage condition** of a point (SGA 4 IV 6.3) — for
+    every object `X` and every covering sieve `R ∈ J X`, every element
+    `x : Φ.fiber.obj X` comes from an element of the fiber above a covering
+    arrow: `∃ Y f, R.arrows f ∧ ∃ y, Φ.fiber.map f y = x`. This is what
+    links the topology to the fiber functor — without it, the fiber
+    functor would not "see" coverings. Type-sig re-export of the field
+    `GrothendieckTopology.Point.jointly_surjective`. -/
+def jointly_surjective_field {C : Type u} [Category.{v} C]
+    {J : GrothendieckTopology C} (Φ : GrothendieckTopology.Point.{w} J) :
+    ∀ {X : C}, ∀ R ∈ J X, ∀ x : Φ.fiber.obj X,
+      ∃ (Y : C) (f : Y ⟶ X), ∃ (_ : R.arrows f), ∃ y : Φ.fiber.obj Y,
+        Φ.fiber.map f y = x :=
+  Φ.jointly_surjective
+
 end Grothendieck_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10818 (c.1301+142 KanExtensions)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 7 nouveaux **bridges propres in-file** dans `SitePoints.lean` (Partie 15 — points d'un site, foncteurs fibres) fermant le répertoire `#check` documentaire du module : la **structure de point** (`point_field` — `GrothendieckTopology.Point.{w} J`, le « foncteur tige » `Φ.fiber : C ⥤ Type w` cofiltre rencontrant tout crible couvrant), le **foncteur fibre préfaisceau** (`presheaf_fiber_field` — `Φ.presheafFiber`, la colimite sur la catégorie des éléments : la « tige de P en Φ »), son **inclusion canonique** (`to_presheaf_fiber_field` — `Φ.toPresheafFiber X x P`, la lég du cocône colimite), la **catégorie des points** (`point_hom_field` — `Point.Hom Φ₁ Φ₂`, morphismes entre points, SGA 4 IV 3.2), les topologies **triviale** (`trivial_field` — `GrothendieckTopology.trivial`) et **discrète** (`discrete_field` — `GrothendieckTopology.discrete`) et la **condition de couverture** (`jointly_surjective_field` — `Φ.jointly_surjective`, SGA 4 IV 6.3). 6/7 `def` type-sig + 1 `noncomputable def` data (presheafFiber/toPresheafFiber). Tous L902 ★★ safe — args résidents `{C : Type u} [Category.{v} C]` + `(Φ : GrothendieckTopology.Point.{w} J)` (style des decls existantes du module), instances structurelles uniquement.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.SitePoints` + `_en` SUCCESS (1340 jobs chacun, 0 warning) + `lake build` full SUCCESS (2823 jobs, **21ᵉ réutilisation du cache AZ** via hardlink-copy du `.lake` pré-construit).

Suite logique de la re-pioche des modules Grothendieck : le module avait déjà 9 decls (faisceautisation des fibres : iso `sheaf_fiber_presheaf_fiber_iso`, cocône/colimite, extensionalité, naturalités, topologies triviale/discrète dans le treillis) couvrant le #check `sheafFiber` (promu en iso prouvé, #10629) mais la **forme abstraite** (structure Point, foncteur fibre, catégorie des points, condition de couverture) restait documentaire par `#check`. Les 7 bridges ferment le tableau : **structure Point → foncteur fibre préfaisceau (colimite) → inclusion canonique → foncteur fibre des faisceaux → morphismes entre points (catégorie) → topologies extrêmes → condition de couverture (SGA 4 IV 6.3)** est désormais entièrement exposé par des déclarations propres in-file.

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `SitePoints.lean` | FR sibling canonical | 9 decls | 16 decls | +96 insertions, -0 |
| `SitePoints_en.lean` | EN sibling mirror | 9 decls | 16 decls | +96 insertions, -0 |

**Total : +192 insertions net / -0, 2 fichiers, 7 nouveaux bridges (7+7 symétriques FR/EN).** Aucun autre fichier touché. Zéro suppression. Les 7 `#check` documentaires + 9 decls existantes conservés.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (SitePoints.lean = module Partie 15, reliquat #check du scan pool) | claim paths-scoped `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: SitePoints.lean, SitePoints_en.lean` (issuecomment-5285631679) | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 7 bridges ajoutés (`point_field` / `presheaf_fiber_field` / `to_presheaf_fiber_field` / `point_hom_field` / `trivial_field` / `discrete_field` / `jointly_surjective_field`), les 7 `#check` documentaires conservés, les 9 decls existantes conservées | ✅ |
| Anti-§D : 0 `sorry` ajouté | `grep -c sorry` FR = 1, EN = 1 — **identique à main** (vérifié `git show origin/main` = 1) : docstring header pré-existante (« Toutes les `sorry` éliminées à la création ») — aucune tactique `sorry` | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | args : `(J : GrothendieckTopology C)` (structure) ou `(Φ : GrothendieckTopology.Point.{w} J)` — defs bridées opèrent sur les univers résidents `v u w`, univers explicite `{w}` aligné sur la déclaration `Point.{w}` des decls existantes | ✅ |
| Bridges valides | 6/7 re-export direct type-sig + 1 data (pattern `has_enough_points_field` c.1301+139 ; `point_hom_field` = re-export de la structure `Point.Hom` de `Sites.Point.Category`) | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.SitePoints` + `_en` SUCCESS (1340 jobs chacun, 0 warning) + full SUCCESS (2823 jobs, 21ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py .../Grothendieck` (depuis le worktree) = SitePoints OK, 33/34 byte-identical, 0 drift, 0 orphan | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 15 uniquement | 2 fichiers modifiés uniquement, +192/-0 | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "SitePoints.lean"` = 0 OPEN (PRs historiques #10629/#10739/#9398/#6345/#2830 MERGED) — aucune collision cross-lane | ✅ |

## Les 7 bridges ajoutés — highlights

- **`point_field`** : la **structure de point** — un foncteur `Φ.fiber : C ⥤ Type w` dont la catégorie des éléments est cofiltre (exactitude : commutation aux limites finies) et qui rencontre tout crible couvrant. C'est la généralisation grothendieckienne du point d'un espace topologique (SGA 4 IV 6.3) : un « foncteur tige » qui évalue les faisceaux fibre par fibre sans requérir un espace topologique sous-jacent. Type-sig re-export de `GrothendieckTopology.Point.{w} J`.
- **`presheaf_fiber_field`** : le **foncteur fibre des préfaisceaux** — évalue un préfaisceau `P` en prenant la colimite de `P` sur la catégorie des éléments de `Φ.fiber`. Intuitivement, `presheafFiber.obj P` est la « tige de P en Φ », la colimite filtrée sur toutes les paires `(X, x)`. `noncomputable` (la colimite n'a pas de choix canonique — tell `dependsOnNoncomputable`, leçon c.1301+143-L2 ★).
- **`to_presheaf_fiber_field`** : l'**inclusion canonique** dans la fibre — pour un témoin `x : Φ.fiber.obj X`, le morphisme `P.obj (op X) ⟶ Φ.presheafFiber.obj P` envoyant une section en la classe de `(X, x)` dans la colimite : la lég du cocône colimite. `noncomputable` (idem).
- **`point_hom_field`** : la **catégorie des points** — les morphismes entre points sont des transformations naturelles en sens inverse entre les foncteurs fibres (SGA 4 IV 3.2). C'est ce qui permet de comparer les « sondes » d'un site entre elles. Type-sig re-export de la structure `GrothendieckTopology.Point.Hom` (module `Sites.Point.Category`, importé par le module — le #check du module était `@GrothendieckTopology.Point.Hom`, absent de `Point.Basic`).
- **`trivial_field`** / **`discrete_field`** : les **topologies extrêmes** — la topologie triviale (la plus grossière : tout crible est couvrant, donc tout préfaisceau est un faisceau) et la topologie discrète (la plus fine : seul le crible maximal est couvrant). Elles complètent les théorèmes existants `trivial_topology_eq_bot`/`discrete_topology_eq_top` (les identités `trivial C = ⊥` / `discrete C = ⊤` dans le treillis) en exposant les topologies elles-mêmes comme objets.
- **`jointly_surjective_field`** : la **condition de couverture** — pour tout objet `X` et tout crible couvrant `R ∈ J X`, tout élément `x : Φ.fiber.obj X` provient d'un élément de la fibre au-dessus d'une flèche couvrante : `∃ Y f, R.arrows f ∧ ∃ y, Φ.fiber.map f y = x`. C'est ce qui relie la topologie au foncteur fibre — sans elle, le foncteur fibre ne « verrait » pas les recouvrements. Re-export type-sig du **champ** `Point.jointly_surjective` (Prop à binders : type inféré, PAS une annotation `Prop` atomique — tell `Type mismatch` sur `: Prop`, leçon c.1301+143-L1 ★).

**Tell Mathlib (nouveaux — leçons c.1301+143-L1/L2 ★)** : (L1) `Point.jointly_surjective` est un **champ à binders** (`∀ {X : C}, ∀ R ∈ J X, ...`) — un type-sig `: Prop :=` échoue (`Type mismatch` : le champ est une fonction à sort `Prop`, pas une Prop atomique) ; la solution est le **type inféré** (pas d'annotation) ou le type ∀ complet. (L2) `presheafFiber`/`toPresheafFiber` sont **`noncomputable`** dans Mathlib — un bridge `def` qui les appelle échoue sur `dependsOnNoncomputable` ; il faut `noncomputable def`. (L3) `Point.Hom` vit dans `Sites.Point.Category`, PAS dans `Point.Basic` — le scratch doit importer les mêmes modules que le fichier cible (leçon c.1301+142-L1 étendue : reproduire imports + variable scope exacts).

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. Les points de Grothendieck sont l'outil qui relie la topologie d'un site à la théorie des faisceaux « sonde par sonde » : le foncteur fibre d'un point est la généralisation du stalk d'un faisceau sur un espace topologique, et la condition de couverture (SGA 4 IV 6.3) est ce qui fait que les points « voient » les recouvrements. Les 7 bridges exposent la **forme abstraite** (structure, foncteurs fibres, catégorie des points, topologies extrêmes, condition de couverture) qui fonde les decls existantes (iso faisceautisé, cocônes, naturalités).

**G-VAR-3** : grains précédents (cycles c.1301+137..+142) = DEEP/lean #10805 (Equivalences), #10808 (MonoidalCategories), #10811 (Conservative s12), #10815 (Conservative s13), #10816 (Limits), #10818 (KanExtensions). Ce grain = DEEP/lean sur SitePoints (Partie 15). **21ᵉ DEEP/lean consécutif** MAIS **substance genuinement distincte** : la structure Point, les foncteurs fibres (colimites sur la catégorie des éléments), la catégorie des points et la condition de couverture sont des constructions distinctes des sections précédentes (chaque bridge requiert de distinguer data `Type _` vs data `noncomputable` vs Prop à binders — et le point-hom field vit dans un module Mathlib différent, `Point.Category`). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (les tells `dependsOnNoncomputable` et `Type mismatch` sur le champ à binders sont des décisions par bridge, les 7 #check voisins ne les révèlent pas). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 15. Le module avait déjà 9 decls (le foncteur fibre des faisceaux, le cocône/la colimite, l'extensionalité, les naturalités, les topologies dans le treillis) mais la **forme abstraite** (structure Point, foncteur fibre préfaisceau, catégorie des points, condition de couverture) restait documentaire par `#check`. Les 7 bridges ferment le tableau : **structure Point → foncteur fibre préfaisceau → inclusion canonique → foncteur fibre des faisceaux → morphismes entre points → topologies extrêmes → condition de couverture** est désormais entièrement exposé par des déclarations propres in-file.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "SitePoints.lean"` = 0 OPEN + PRs historiques #10629/#10739/#9398/#6345/#2830 MERGED. Aucune collision cross-lane. Claim paths-scoped posté sur #2159 (issuecomment-5285631679, paths SitePoints.lean/SitePoints_en.lean, lane myia-po-2025) — disjoint des claims KanExtensions.lean et Limits.lean existants.
- **Base main à jour** : branche `feature/c1301x143-2159-sitepoints` créée depuis `origin/main` (HEAD 747dcf8ac, 2026-08-13) — module DIFFÉRENT des grains précédents → pas de stacking. Rebase frais conforme R2 catalog-pr-hygiene.
- **Hors scope po-2026** : le dashboard liste po-2026 sur YonedaLemma/LeftExact/Calibration/CategoryAndSites/MathlibMap/SchemesTour — SitePoints n'y figure pas (L898 + dashboard vérifiés).
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x143_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +192/-0. ✅
- **L279 ★★** : push 403 (compte gh actif = jsboigeEpita) → `gh auth switch -u jsboige` → push → switch back. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `grep -c sorry` FR/EN = 1 chacun, **identique à main** (vérifié `git show origin/main`) — docstring header pré-existante (« Toutes les `sorry` éliminées à la création »), pas une tactique
- 0 `rfl` KO (les 7 bridges = re-export type-sig de types/Prop/champs Mathlib)
- Toutes les preuves = re-export direct (pattern `has_enough_points_field` c.1301+139)
- Aucune suppression de `#check` ou de defs/théorèmes existants (7 `#check` documentaires + 9 decls existantes conservés — le `grep -c "#check"` à 9 = 7 réels + 2 références textuelles : ligne 104 pré-existante + la mention dans la docstring de ma section 10)
- Aucun universe supplémentaire ajouté (les bridges opèrent sur les univers résidents `v u w`)
- Zéro deletion au diff (+192/-0)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 15 (SitePoints) expose désormais **16 déclarations propres in-file** (9 existantes + 7 bridges), couvrant le **cycle complet de la théorie des points de Grothendieck** : (a) la structure de point (`point_field`) et sa condition de couverture (`jointly_surjective_field`), (b) le foncteur fibre préfaisceau (`presheaf_fiber_field`) et son inclusion canonique (`to_presheaf_fiber_field`), (c) les propriétés de colimite (`presheaf_fiber_cocone`, `is_colimit_presheaf_fiber`, `presheaf_fiber_hom_ext`), (d) la faisceautisation du foncteur fibre (`sheaf_fiber_presheaf_fiber_iso`, `fiber_yoneda_iso`), (e) les naturalités (`to_presheaf_fiber_w`, `to_presheaf_fiber_naturality`), (f) la catégorie des points (`point_hom_field`), (g) les topologies extrêmes (`trivial_field`/`discrete_field` + les identités `trivial C = ⊥` / `discrete C = ⊤`). Chaque bridge documente en FR+EN la relation entre l'API Mathlib sous-jacente et son restatement in-file, fondant le pont points de Grothendieck → foncteurs fibres → faisceaux sonde par sonde → cohomologie des faisceaux au cœur de la géométrie algébrique grothendieckienne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
