### PR TITLE
feat(lean,#2159): Comma.lean — 5 bridges type-sig (Comma/CommaMorphism/commaCategory/Over/StructuredArrow)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Comma.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Comma.lean
@@ -174,4 +174,66 @@ theorem snd_map_comp {X Y Z : CategoryTheory.Comma L R} (f : X ⟶ Y) (g : Y ⟶
     (sndFunctor).map (f ≫ g) = (sndFunctor).map f ≫ (sndFunctor).map g :=
   (sndFunctor).map_comp f g
 
+/-!
+## 5. Bridges : les structures comma et leurs cas particuliers
+
+Les 5 bridges ci-dessous ferment le répertoire `#check` documentaire du
+module : la **structure** `Comma L R` (objets = triplets `(a, b, f)` avec
+`f : L.obj a ⟶ R.obj b`), les **morphismes** `CommaMorphism` (carrés
+commutatifs), l'**instance de catégorie** `commaCategory`, et les deux cas
+particuliers canoniques — la **catégorie slice** `Over X` et les **flèches
+structurées** `StructuredArrow S F`. Chacun est un re-export type-sig de
+l'API Mathlib (pattern winner L902 ★★ Tier 5) : les variables résidentes du
+module (`{A B T L R}`), instances structurelles uniquement, zéro
+constructeur polymorphe d'univers.
+
+Universe note (leçon c.1301+144-L1) : `Comma L R` vit dans
+`Type (max u₁ u₂ v₃)` — les univers des deux catégories sources et celui
+des morphismes du but ; `CommaMorphism X Y` dans `Type (max v₁ v₂)`, et
+`Over X` / `StructuredArrow S F` dans `Type (max u₃ v₃)`. Tous alignés
+sur les univers résidents du module — aucun univers supplémentaire.
+-/
+
+/-- Bridge : la **structure d'objet comma** — un triplet `(a, b, f)` avec
+    `a : A`, `b : B` et `f : L.obj a ⟶ R.obj b` (un morphisme de `T`).
+    C'est l'encodage d'une flèche « à source dans l'image de `L`, à but
+    dans l'image de `R` » — la donnée universelle des familles indexées par
+    un morphisme. Type-sig re-export de `CategoryTheory.Comma L R`. -/
+def comma_field : Type _ :=
+  CategoryTheory.Comma L R
+
+/-- Bridge : les **morphismes de la catégorie comma** — un carré commutatif
+    entre deux objets comma `X` et `Y` : un couple `(left, right)` de
+    flèches `X.left ⟶ Y.left` dans `A` et `X.right ⟶ Y.right` dans `B` tel
+    que `L.map left ≫ Y.hom = X.hom ≫ R.map right`. Type-sig re-export de
+    `CategoryTheory.CommaMorphism`. -/
+def comma_morphism_field (X Y : CategoryTheory.Comma L R) : Type _ :=
+  CategoryTheory.CommaMorphism X Y
+
+/-- Bridge : la donnée de `Comma L R` comme **catégorie** — identités,
+    composition, et lois de catégorie. Instance Mathlib `commaCategory`,
+    re-exportée en `def` `@[reducible]` (une def de type classe doit être
+    marquée `@[reducible]` pour satisfaire le linter). C'est ce qui rend
+    tous les morphismes de `Comma L R` composables. -/
+@[reducible] def comma_category_field : Category (CategoryTheory.Comma L R) :=
+  CategoryTheory.commaCategory
+
+/-- Bridge : la **catégorie slice** `Over X` — le cas particulier de
+    catégorie comma `Comma (𝟙 T) (const X)` dont les objets sont les
+    flèches `Y ⟶ X` dans `T` et les morphismes les triangles commutatifs.
+    C'est l'encodage standard des objets « au-dessus de X » (fibrés,
+    espaces au-dessus d'un schéma). Type-sig re-export de
+    `CategoryTheory.Over X`. -/
+def over_field (X : T) : Type _ :=
+  CategoryTheory.Over X
+
+/-- Bridge : les **flèches structurées** `StructuredArrow S F` — le cas
+    particulier de catégorie comma `Comma (const S) F` dont les objets sont
+    les flèches `S ⟶ F.obj Y` dans `T` et les morphismes les triangles
+    commutatifs. C'est l'encodage des « flèches à source fixe S » (pointé,
+    initial, base). Type-sig re-export de
+    `CategoryTheory.StructuredArrow S F` pour un endofoncteur `F : T ⥤ T`. -/
+def structured_arrow_field (S : T) (F : T ⥤ T) : Type _ :=
+  CategoryTheory.StructuredArrow S F
+
 end Grothendieck.Comma

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Comma_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Comma_en.lean
@@ -172,4 +172,66 @@ theorem snd_map_comp {X Y Z : CategoryTheory.Comma L R} (f : X ⟶ Y) (g : Y ⟶
     (sndFunctor).map (f ≫ g) = (sndFunctor).map f ≫ (sndFunctor).map g :=
   (sndFunctor).map_comp f g
 
+/-!
+## 5. Bridges: the comma structures and their classical special cases
+
+The 5 bridges below close the `#check` documentary repertoire of this
+module: the **structure** `Comma L R` (objects = triples `(a, b, f)` with
+`f : L.obj a ⟶ R.obj b`), the **morphisms** `CommaMorphism` (commutative
+squares), the **category instance** `commaCategory`, and the two canonical
+special cases — the **slice category** `Over X` and the **structured
+arrows** `StructuredArrow S F`. Each is a type-sig re-export of the
+Mathlib API (pattern winner L902 ★★ Tier 5): the resident variables of the
+module (`{A B T L R}`), structural instances only, no polymorphic universe
+constructor.
+
+Universe note (lesson c.1301+144-L1): `Comma L R` lives in
+`Type (max u₁ u₂ v₃)` — the universes of the two source categories and of
+the morphisms of the target; `CommaMorphism X Y` lives in
+`Type (max v₁ v₂)`, and `Over X` / `StructuredArrow S F` in
+`Type (max u₃ v₃)`. All aligned on the resident universes of the module —
+no additional universe.
+-/
+
+/-- Bridge: the **comma object structure** — a triple `(a, b, f)` with
+    `a : A`, `b : B` and `f : L.obj a ⟶ R.obj b` (a morphism of `T`).
+    This encodes an arrow "with source in the image of `L`, target in the
+    image of `R`" — the universal datum of families indexed by a morphism.
+    Type-sig re-export of `CategoryTheory.Comma L R`. -/
+def comma_field : Type _ :=
+  CategoryTheory.Comma L R
+
+/-- Bridge: the **morphisms of the comma category** — a commutative square
+    between two comma objects `X` and `Y`: a pair `(left, right)` of arrows
+    `X.left ⟶ Y.left` in `A` and `X.right ⟶ Y.right` in `B` such that
+    `L.map left ≫ Y.hom = X.hom ≫ R.map right`. Type-sig re-export of
+    `CategoryTheory.CommaMorphism`. -/
+def comma_morphism_field (X Y : CategoryTheory.Comma L R) : Type _ :=
+  CategoryTheory.CommaMorphism X Y
+
+/-- Bridge: the structure of `Comma L R` as a **category** — identities,
+    composition, and the category laws. Mathlib instance `commaCategory`,
+    re-exported as a `@[reducible]` `def` (a def of class type must be
+    marked `@[reducible]` to satisfy the linter). This is what makes all
+    morphisms of `Comma L R` composable. -/
+@[reducible] def comma_category_field : Category (CategoryTheory.Comma L R) :=
+  CategoryTheory.commaCategory
+
+/-- Bridge: the **slice category** `Over X` — the special case of comma
+    category `Comma (𝟙 T) (const X)` whose objects are the arrows `Y ⟶ X`
+    in `T` and whose morphisms are the commutative triangles. This is the
+    standard encoding of objects "over X" (fiber bundles, spaces over a
+    scheme). Type-sig re-export of `CategoryTheory.Over X`. -/
+def over_field (X : T) : Type _ :=
+  CategoryTheory.Over X
+
+/-- Bridge: the **structured arrows** `StructuredArrow S F` — the special
+    case of comma category `Comma (const S) F` whose objects are the arrows
+    `S ⟶ F.obj Y` in `T` and whose morphisms are the commutative triangles.
+    This is the encoding of "arrows with fixed source S" (pointed, initial,
+    base). Type-sig re-export of `CategoryTheory.StructuredArrow S F` for an
+    endofunctor `F : T ⥤ T`. -/
+def structured_arrow_field (S : T) (F : T ⥤ T) : Type _ :=
+  CategoryTheory.StructuredArrow S F
+
 end Grothendieck.Comma_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10820 (c.1301+143 SitePoints)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 5 nouveaux **bridges propres in-file** dans `Comma.lean` (Partie 27 — catégories comma) fermant le répertoire `#check` documentaire du module : la **structure d'objet comma** (`comma_field` — `Comma L R`, les triplets `(a, b, f)` avec `f : L.obj a ⟶ R.obj b`), les **morphismes comma** (`comma_morphism_field` — `CommaMorphism X Y`, les carrés commutatifs), l'**instance de catégorie** (`comma_category_field` — `commaCategory`, `@[reducible]`), et les deux cas particuliers canoniques — la **catégorie slice** (`over_field` — `Over X`, objets « au-dessus de X ») et les **flèches structurées** (`structured_arrow_field` — `StructuredArrow S F`, flèches à source fixe). 5/5 `def` type-sig. Tous L902 ★★ safe — variables résidentes du module (`{A B T L R}`), instances structurelles uniquement, zéro constructeur polymorphe d'univers.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.Comma` + `_en` SUCCESS (630 jobs chacun, 0 warning) + `lake build` full SUCCESS (2823 jobs, **22ᵉ réutilisation du cache AZ** via hardlink-copy du `.lake` pré-construit).

Suite logique de la re-pioche des modules Grothendieck : le module avait déjà 7 decls (projections `fstFunctor`/`sndFunctor`, transformation naturelle canonique, lois fonctorielles) mais les **structures** (Comma, CommaMorphism, commaCategory, Over, StructuredArrow) restaient documentaires par `#check`. Les 5 bridges ferment le tableau : **structure comma → morphismes (carrés commutatifs) → instance de catégorie → projections/naturalité → cas particuliers (slice/structurées)** est désormais entièrement exposé par des déclarations propres in-file.

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `Comma.lean` | FR sibling canonical | 7 decls | 12 decls | +62 insertions, -0 |
| `Comma_en.lean` | EN sibling mirror | 7 decls | 12 decls | +62 insertions, -0 |

**Total : +124 insertions net / -0, 2 fichiers, 5 nouveaux bridges (5+5 symétriques FR/EN).** Aucun autre fichier touché. Zéro suppression. Les 5 `#check` documentaires + 7 decls existantes conservés.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (Comma.lean = module Partie 27, reliquat #check du scan pool) | claim paths-scoped `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: Comma.lean, Comma_en.lean` (issuecomment-5285698823) | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 5 bridges ajoutés (`comma_field` / `comma_morphism_field` / `comma_category_field` / `over_field` / `structured_arrow_field`), les 5 `#check` documentaires conservés, les 7 decls existantes conservées | ✅ |
| Anti-§D : 0 `sorry` ajouté | `grep -c sorry` FR = 1, EN = 1 — **identique à main** (vérifié `git show origin/main` = 1) : docstring header pré-existante (« Aucun `sorry` à la création ») — aucune tactique `sorry` | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | variables résidentes du module (`{A B T L R}`) — defs bridées opèrent sur les univers résidents `v₁ v₂ v₃ u₁ u₂ u₃` | ✅ |
| Bridges valides | 5/5 re-export direct type-sig (pattern `has_enough_points_field` c.1301+139 ; `comma_category_field` = instance re-exportée `@[reducible]`, leçon c.1301+138-L1 ★★) | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.Comma` + `_en` SUCCESS (630 jobs chacun, 0 warning) + full SUCCESS (2823 jobs, 22ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py .../Grothendieck` (depuis le worktree) = Comma OK, 33/34 byte-identical, 0 drift, 0 orphan | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 27 uniquement | 2 fichiers modifiés uniquement, +124/-0 | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "Comma.lean"` = 0 OPEN (PRs historiques #10640/#7668 MERGED) — aucune collision cross-lane | ✅ |

## Les 5 bridges ajoutés — highlights

- **`comma_field`** : la **structure d'objet comma** — un triplet `(a, b, f)` avec `a : A`, `b : B` et `f : L.obj a ⟶ R.obj b` (un morphisme de `T`). C'est l'encodage d'une flèche « à source dans l'image de `L`, à but dans l'image de `R` » — la donnée universelle des familles indexées par un morphisme (espace annelé, champs, foncteurs fibres). Type-sig re-export de `CategoryTheory.Comma L R`.
- **`comma_morphism_field`** : les **morphismes de la catégorie comma** — un carré commutatif entre deux objets comma `X` et `Y` : un couple `(left, right)` de flèches `X.left ⟶ Y.left` dans `A` et `X.right ⟶ Y.right` dans `B` tel que `L.map left ≫ Y.hom = X.hom ≫ R.map right`. C'est la flèche structurelle qui rend la catégorie comma « catégorie des carrés commutatifs ».
- **`comma_category_field`** : la donnée de `Comma L R` comme **catégorie** — identités, composition, lois de catégorie. Instance Mathlib `commaCategory`, re-exportée en `def` `@[reducible]` (leçon c.1301+138-L1 ★★ : une def de type classe doit être marquée `@[reducible]` pour satisfaire le linter). C'est ce qui rend tous les morphismes composables.
- **`over_field`** : la **catégorie slice** `Over X` — le cas particulier de catégorie comma `Comma (𝟙 T) (const X)` dont les objets sont les flèches `Y ⟶ X` dans `T` et les morphismes les triangles commutatifs. L'encodage standard des objets « au-dessus de X » (fibrés, espaces au-dessus d'un schéma).
- **`structured_arrow_field`** : les **flèches structurées** `StructuredArrow S F` — le cas particulier `Comma (const S) F` dont les objets sont les flèches `S ⟶ F.obj Y`. L'encodage des « flèches à source fixe S » (pointé, initial, base).

**Tell Mathlib (nouveau — leçon c.1301+144-L1 ★)** : les univers des structures comma sont **composés** (`Comma L R : Type (max u₁ u₂ v₃)` — les univers des deux catégories sources ET des morphismes du but ; `CommaMorphism X Y : Type (max v₁ v₂)` ; `Over X`/`StructuredArrow S F : Type (max u₃ v₃)`) — le `Type _` du type-sig les infère tous, alignés sur les univers résidents du module, sans univers supplémentaire.

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. Les catégories comma sont la construction universelle que Grothendieck utilisait massivement (cas particuliers : catégories slices, flèches structurées) pour encoder les familles d'objets indexées par un morphisme — fondement des espaces annelés et des champs. Les 5 bridges exposent les **structures** (objet, morphisme, catégorie, cas particuliers) qui fondent les decls existantes (projections, naturalité).

**G-VAR-3** : grains précédents (cycles c.1301+137..+143) = DEEP/lean #10805 (Equivalences), #10808 (MonoidalCategories), #10811/#10815 (Conservative), #10816 (Limits), #10818 (KanExtensions), #10820 (SitePoints). Ce grain = DEEP/lean sur Comma (Partie 27). **22ᵉ DEEP/lean consécutif** MAIS **substance genuinement distincte** : la structure comma, ses morphismes (carrés commutatifs), l'instance de catégorie et les cas particuliers slice/structurées sont des constructions distinctes des sections précédentes (chaque bridge requiert de distinguer structure data vs instance de type classe — le `@[reducible]` sur `comma_category_field` est la seule def de type classe du grain, les 4 autres sont des `Type _`). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (le linter `Definition of class type` sur `comma_category_field` est une décision par bridge, les 5 #check voisins ne la révèlent pas). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 27. Le module avait déjà 7 decls (projections, transformation naturelle, lois fonctorielles) mais les **structures** (Comma, CommaMorphism, commaCategory, Over, StructuredArrow) restaient documentaires par `#check`. Les 5 bridges ferment le tableau : **structure → morphismes → catégorie → projections → cas particuliers** est désormais entièrement exposé par des déclarations propres in-file.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "Comma.lean"` = 0 OPEN + PRs historiques #10640/#7668 MERGED. Aucune collision cross-lane. Claim paths-scoped posté sur #2159 (issuecomment-5285698823, paths Comma.lean/Comma_en.lean, lane myia-po-2025) — disjoint des claims SitePoints.lean, KanExtensions.lean et Limits.lean existants.
- **Base main à jour** : branche `feature/c1301x144-2159-comma` créée depuis `origin/main` (HEAD 747dcf8ac, 2026-08-13) — module DIFFÉRENT des grains précédents → pas de stacking. Rebase frais conforme R2 catalog-pr-hygiene.
- **Hors scope po-2026** : le dashboard liste po-2026 sur YonedaLemma/LeftExact/Calibration/CategoryAndSites/MathlibMap/SchemesTour — Comma n'y figure pas (L898 + dashboard vérifiés).
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x144_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +124/-0. ✅
- **L279 ★★** : push 403 (compte gh actif = jsboigeEpita) → `gh auth switch -u jsboige` → push → switch back. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `grep -c sorry` FR/EN = 1 chacun, **identique à main** (vérifié `git show origin/main`) — docstring header pré-existante (« Aucun `sorry` à la création »), pas une tactique
- 0 `rfl` KO (les 5 bridges = re-export type-sig de structures/instances Mathlib)
- Toutes les preuves = re-export direct (pattern `has_enough_points_field` c.1301+139)
- Aucune suppression de `#check` ou de defs/théorèmes existants (5 `#check` documentaires + 7 decls existantes conservés)
- Aucun universe supplémentaire ajouté (les bridges opèrent sur les univers résidents `v₁ v₂ v₃ u₁ u₂ u₃`)
- Zéro deletion au diff (+124/-0)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 27 (Comma) expose désormais **12 déclarations propres in-file** (7 existantes + 5 bridges), couvrant le **cycle complet de la théorie des catégories comma** : (a) la structure d'objet (`comma_field`) et ses morphismes (`comma_morphism_field`), (b) l'instance de catégorie (`comma_category_field`), (c) les projections `fstFunctor`/`sndFunctor` et la transformation naturelle canonique (`natTransCanonical`), (d) les lois fonctorielles (`fst_map_id`/`fst_map_comp`/`snd_map_comp`/`natTrans_app_apply`), (e) les cas particuliers canoniques (`over_field`/`structured_arrow_field`). Chaque bridge documente en FR+EN la relation entre l'API Mathlib sous-jacente et son restatement in-file, fondant le pont catégories comma → adjonctions → familles indexées par un morphisme → espaces annelés et champs au cœur de la géométrie algébrique grothendieckienne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
