### PR TITLE
feat(lean,#2159): SheafHom — 2 bridges data (bijection sections-morphismes + iso canonique)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom.lean
@@ -233,4 +233,41 @@ noncomputable def sheaf_hom_bridge (F G : Sheaf J A) : Sheaf J (Type _) :=
 noncomputable def sheaf_hom_underscore_bridge (F G : Sheaf J A) : Cᵒᵖ ⥤ Type _ :=
   sheafHom' F G
 
+/-!
+## Bridges finaux : la bijection sections-morphismes et l'iso canonique
+
+Les 2 bridges ci-dessous ferment le répertoire `#check` documentaire du
+module : la **bijection sections-morphismes** `sheafHomSectionsEquiv` (les
+sections du faisceau hom interne s'identifient aux morphismes de faisceaux
+`F ⟶ G` — le cœur de la structure cartésienne fermée de `Sheaf J (Type _)`)
+et l'**iso canonique** `sheafHom'Iso` (le préfaisceau sous-jacent du hom
+interne est isomorphe au hom interne de préfaisceaux). Chacun est un
+re-export direct data (pattern winner L902 ★★ Tier 5) : variables résidentes
+du module (`{C J A}`), instances structurelles uniquement, zéro constructeur
+polymorphe d'univers. `noncomputable` (un `Equiv`/`≅` n'a pas de choix
+canonique — tell `dependsOnNoncomputable`, leçon c.1301+143-L2).
+-/
+
+/-- Bridge : la **bijection sections-morphismes** du hom interne — les
+    sections globales du faisceau `sheafHom F G` s'identifient aux
+    morphismes de faisceaux `F ⟶ G`. C'est l'équivalence qui rend la
+    catégorie des faisceaux enrichie sur elle-même (structure cartésienne
+    fermée de `Sheaf J (Type _)`), et qui fonde les decls existantes
+    `sheafHomSectionOfHom`/`sheafHomOfSection` (les deux directions) et les
+    roundtrip theorems. Re-export data de `sheafHomSectionsEquiv`. -/
+noncomputable def sheaf_hom_sections_equiv_field (F G : Sheaf J A) :
+    (sheafHom F G).1.sections ≃ (F ⟶ G) :=
+  sheafHomSectionsEquiv F G
+
+/-- Bridge : l'**iso canonique** entre le préfaisceau sous-jacent du hom
+    interne de faisceaux et le hom interne de préfaisceaux —
+    `sheafHom' F G ≅ presheafHom F.1 G.1`. C'est le fait technique qui
+    relie les deux niveaux (préfaisceaux/faisceaux) : le hom interne de
+    faisceaux est le faisceautisé du hom interne de préfaisceaux. La decl
+    existante `sheafHom'_iso_presheafHom` l'enveloppait dans `Nonempty` ;
+    ce bridge expose l'iso lui-même. Re-export data de `sheafHom'Iso`. -/
+noncomputable def sheaf_hom'_iso_field (F G : Sheaf J A) :
+    sheafHom' F G ≅ presheafHom F.1 G.1 :=
+  sheafHom'Iso F G
+
 end Grothendieck.SheafHom

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SheafHom_en.lean
@@ -232,4 +232,41 @@ noncomputable def sheaf_hom_bridge (F G : Sheaf J A) : Sheaf J (Type _) :=
 noncomputable def sheaf_hom_underscore_bridge (F G : Sheaf J A) : Cᵒᵖ ⥤ Type _ :=
   sheafHom' F G
 
+/-!
+## Final bridges: the sections-morphisms bijection and the canonical iso
+
+The 2 bridges below close the `#check` documentary repertoire of this
+module: the **sections-morphisms bijection** `sheafHomSectionsEquiv` (the
+sections of the sheaf internal hom identify with sheaf morphisms `F ⟶ G` —
+the core of the cartesian closed structure of `Sheaf J (Type _)`) and the
+**canonical iso** `sheafHom'Iso` (the presheaf underlying the internal hom
+is isomorphic to the presheaf internal hom). Each is a direct data re-export
+(pattern winner L902 ★★ Tier 5): resident variables of the module
+(`{C J A}`), structural instances only, no polymorphic universe constructor.
+`noncomputable` (an `Equiv`/`≅` has no canonical choice — tell
+`dependsOnNoncomputable`, lesson c.1301+143-L2).
+-/
+
+/-- Bridge: the **sections-morphisms bijection** of the internal hom — the
+    global sections of the sheaf `sheafHom F G` identify with sheaf
+    morphisms `F ⟶ G`. This is the equivalence that makes the category of
+    sheaves enriched over itself (cartesian closed structure of
+    `Sheaf J (Type _)`), and it underlies the existing decls
+    `sheafHomSectionOfHom`/`sheafHomOfSection` (the two directions) and the
+    roundtrip theorems. Data re-export of `sheafHomSectionsEquiv`. -/
+noncomputable def sheaf_hom_sections_equiv_field (F G : Sheaf J A) :
+    (sheafHom F G).1.sections ≃ (F ⟶ G) :=
+  sheafHomSectionsEquiv F G
+
+/-- Bridge: the **canonical iso** between the presheaf underlying the sheaf
+    internal hom and the presheaf internal hom — `sheafHom' F G ≅
+    presheafHom F.1 G.1`. This is the technical fact linking the two levels
+    (presheaves/sheaves): the sheaf internal hom is the sheafification of
+    the presheaf internal hom. The existing decl `sheafHom'_iso_presheafHom`
+    wrapped it in `Nonempty`; this bridge exposes the iso itself. Data
+    re-export of `sheafHom'Iso`. -/
+noncomputable def sheaf_hom'_iso_field (F G : Sheaf J A) :
+    sheafHom' F G ≅ presheafHom F.1 G.1 :=
+  sheafHom'Iso F G
+
 end Grothendieck.SheafHom_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10823 (c.1301+144 Comma)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 2 nouveaux **bridges propres in-file** dans `SheafHom.lean` (Partie 17 — hom interne des faisceaux) fermant le répertoire `#check` documentaire du module : la **bijection sections-morphismes** (`sheaf_hom_sections_equiv_field` — `sheafHomSectionsEquiv F G : (sheafHom F G).1.sections ≃ (F ⟶ G)`, le cœur de la structure cartésienne fermée de `Sheaf J (Type _)`) et l'**iso canonique** (`sheaf_hom'_iso_field` — `sheafHom'Iso F G : sheafHom' F G ≅ presheafHom F.1 G.1`, le lien préfaisceaux/faisceaux du hom interne). 2/2 `noncomputable def` data (re-export direct de `Equiv`/`≅`). Tous L902 ★★ safe — variables résidentes du module (`{C J A}`), instances structurelles uniquement.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.SheafHom` + `_en` SUCCESS (1267 jobs chacun, 0 warning) + `lake build` full SUCCESS (2823 jobs, **23ᵉ réutilisation du cache AZ** via hardlink-copy du `.lake` pré-construit).

Suite logique de la re-pioche des modules Grothendieck : le module avait déjà 15 decls (ponts de construction `presheaf_hom_bridge`/`sheaf_hom_bridge`/`sheaf_hom_underscore_bridge`, théorèmes de faisceautisation, sections↔morphismes dans les deux directions, roundtrips, naturalité) couvrant la plupart des `#check`, mais deux objets data restaient documentaires : la **bijection** elle-même (`sheafHomSectionsEquiv`) et l'**iso** (`sheafHom'Iso` — la decl existante `sheafHom'_iso_presheafHom` l'enveloppait dans `Nonempty`). Les 2 bridges ferment le tableau : **hom interne préfaisceau → faisceautisation → bijection sections-morphismes → roundtrips → iso canonique** est désormais entièrement exposé par des déclarations propres in-file.

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `SheafHom.lean` | FR sibling canonical | 15 decls | 17 decls | +37 insertions, -0 |
| `SheafHom_en.lean` | EN sibling mirror | 15 decls | 17 decls | +37 insertions, -0 |

**Total : +74 insertions net / -0, 2 fichiers, 2 nouveaux bridges (2+2 symétriques FR/EN).** Aucun autre fichier touché. Zéro suppression. Les 7 `#check` documentaires + 15 decls existantes conservés.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (SheafHom.lean = module Partie 17, reliquat #check du scan pool) | claim paths-scoped `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: SheafHom.lean, SheafHom_en.lean` (issuecomment-5285800333) | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 2 bridges ajoutés (`sheaf_hom_sections_equiv_field` / `sheaf_hom'_iso_field`), les 7 `#check` documentaires conservés, les 15 decls existantes conservées | ✅ |
| Anti-§D : 0 `sorry` ajouté | `grep -c sorry` FR = 1, EN = 1 — **identique à main** (vérifié `git show origin/main` = 1) : docstring header pré-existante — aucune tactique `sorry` | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | variables résidentes du module (`{C : Type u} [Category.{v} C] {J : GrothendieckTopology C} {A : Type u'} [Category.{v'} A]`) — defs bridées opèrent sur les univers résidents `v v' u u'` | ✅ |
| Bridges valides | 2/2 re-export data direct de `Equiv`/`≅` Mathlib (pattern `has_enough_points_field` c.1301+139 ; `noncomputable` — leçon c.1301+143-L2) | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.SheafHom` + `_en` SUCCESS (1267 jobs chacun, 0 warning) + full SUCCESS (2823 jobs, 23ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py .../Grothendieck` (depuis le worktree) = SheafHom OK, 33/34 byte-identical, 0 drift, 0 orphan | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 17 uniquement | 2 fichiers modifiés uniquement, +74/-0 | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "SheafHom.lean"` = 0 OPEN (PRs historiques #10668/#10666/#6291/#2836 MERGED) — aucune collision cross-lane | ✅ |

## Les 2 bridges ajoutés — highlights

- **`sheaf_hom_sections_equiv_field`** : la **bijection sections-morphismes** — les sections globales du faisceau `sheafHom F G` s'identifient aux morphismes de faisceaux `F ⟶ G`. C'est l'équivalence qui rend la catégorie des faisceaux enrichie sur elle-même (structure cartésienne fermée de `Sheaf J (Type _)`), et qui fonde les decls existantes `sheafHomSectionOfHom`/`sheafHomOfSection` (les deux directions) et les roundtrip theorems. Re-export data de `sheafHomSectionsEquiv`.
- **`sheaf_hom'_iso_field`** : l'**iso canonique** entre le préfaisceau sous-jacent du hom interne de faisceaux et le hom interne de préfaisceaux — `sheafHom' F G ≅ presheafHom F.1 G.1`. C'est le fait technique qui relie les deux niveaux : le hom interne de faisceaux est le faisceautisé du hom interne de préfaisceaux. La decl existante `sheafHom'_iso_presheafHom` l'enveloppait dans `Nonempty` (`⟨sheafHom'Iso F G⟩`) ; ce bridge expose l'iso lui-même, directement réutilisable. Re-export data de `sheafHom'Iso`.

**Tell Mathlib (rappel leçon c.1301+143-L2 ★)** : les re-export de `Equiv`/`≅` sont des data noncomputable (pas de choix canonique) → `noncomputable def`, pas `def`. Le type retour `.1.sections` (= `.obj.sections`) a été vérifié par #check avant le type-sig.

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. Le hom interne des faisceaux est la construction qui rend la catégorie des faisceaux enrichie sur elle-même (structure cartésienne fermée) — un outil central de la théorie des topos de Grothendieck. Les 2 bridges exposent la **bijection** et l'**iso** qui structurent toute la théorie du hom interne.

**G-VAR-3** : grains précédents (cycles c.1301+137..+144) = DEEP/lean #10805 (Equivalences), #10808 (MonoidalCategories), #10811/#10815 (Conservative), #10816 (Limits), #10818 (KanExtensions), #10820 (SitePoints), #10823 (Comma). Ce grain = DEEP/lean sur SheafHom (Partie 17). **23ᵉ DEEP/lean consécutif** MAIS **substance genuinement distincte** : la bijection sections-morphismes et l'iso canonique sont des constructions distinctes des sections précédentes (chaque bridge requiert de distinguer le type retour data `≃` vs `≅` — et de constater que le #check `sheafHom'Iso` était partiellement couvert par la decl `Nonempty`-enveloppée, décision d'exposer l'iso nu). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (la distinction Nonempty-enveloppé vs iso nu est une décision de lecture du module, les 7 #check voisins ne la révèlent pas). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 17. Le module avait déjà 15 decls (ponts de construction, théorèmes de faisceautisation, directions de la bijection, roundtrips, naturalité) mais la **bijection elle-même** et l'**iso canonique** restaient documentaires par `#check` (l'iso n'était visible que via `Nonempty`). Les 2 bridges ferment le tableau : **hom interne → bijection → roundtrips → iso** est désormais entièrement exposé par des déclarations propres in-file.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "SheafHom.lean"` = 0 OPEN + PRs historiques #10668/#10666/#6291/#2836 MERGED. Aucune collision cross-lane. Claim paths-scoped posté sur #2159 (issuecomment-5285800333, paths SheafHom.lean/SheafHom_en.lean, lane myia-po-2025) — disjoint des claims SitePoints.lean, Comma.lean, KanExtensions.lean et Limits.lean existants.
- **Base main à jour** : branche `feature/c1301x145-2159-sheafhom` créée depuis `origin/main` (HEAD 747dcf8ac, 2026-08-13) — module DIFFÉRENT des grains précédents → pas de stacking. Rebase frais conforme R2 catalog-pr-hygiene.
- **Hors scope po-2026** : le dashboard liste po-2026 sur YonedaLemma/LeftExact/Calibration/CategoryAndSites/MathlibMap/SchemesTour — SheafHom n'y figure pas (L898 + dashboard vérifiés).
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x145_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +74/-0. ✅
- **L279 ★★** : push 403 (compte gh actif = jsboigeEpita) → `gh auth switch -u jsboige` → push → switch back. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `grep -c sorry` FR/EN = 1 chacun, **identique à main** (vérifié `git show origin/main`) — docstring header pré-existante, pas une tactique
- 0 `rfl` KO (les 2 bridges = re-export data direct de `Equiv`/`≅` Mathlib)
- Toutes les preuves = re-export direct (pattern `has_enough_points_field` c.1301+139)
- Aucune suppression de `#check` ou de defs/théorèmes existants (7 `#check` documentaires + 15 decls existantes conservés)
- Aucun universe supplémentaire ajouté (les bridges opèrent sur les univers résidents `v v' u u'`)
- Zéro deletion au diff (+74/-0)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 17 (SheafHom) expose désormais **17 déclarations propres in-file** (15 existantes + 2 bridges), couvrant le **cycle complet de la théorie du hom interne des faisceaux** : (a) le hom interne de préfaisceaux (`presheaf_hom_bridge`/`presheaf_hom_sections_equiv_bridge`), (b) la faisceautisation du hom (`presheafHom_isSheaf_of_isSheaf`, `sheaf_hom_bridge`, `sheafHom_isSheaf`), (c) la bijection sections-morphismes (`sheaf_hom_sections_equiv_field` + les deux directions `sheafHomSectionOfHom`/`sheafHomOfSection` + les roundtrips), (d) l'iso canonique (`sheaf_hom'_iso_field`, `sheafHom'_iso_presheafHom`), (e) les naturalités (`sheaf_hom_map_app_*`). Chaque bridge documente en FR+EN la relation entre l'API Mathlib sous-jacente et son restatement in-file, fondant le pont hom interne → structure cartésienne fermée des topos → catégories de faisceaux enrichies sur elles-mêmes au cœur de la géométrie algébrique grothendieckienne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
