### PR TITLE
feat(lean,#2159): Construction — 2 bridges type-sig (grothendieck_field ∫F + grothendieck_hom_field Hom)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Construction.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Construction.lean
@@ -218,4 +218,39 @@ def iso_mk_bridge {X Y : CategoryTheory.Grothendieck F}
     X ≅ Y :=
   CategoryTheory.Grothendieck.isoMk e₁ e₂
 
+/-!
+## 8. Bridges finaux : la structure de la catégorie totale et ses morphismes
+
+Les 2 bridges ci-dessous ferment le répertoire `#check` documentaire du
+module : la **structure** `Grothendieck F` (la catégorie totale ∫ F dont les
+objets sont les couples `(c, x)` avec `c : C` et `x : F(c)`) et les
+**morphismes** `Grothendieck.Hom X Y` (les couples `(f, φ)` — flèche de base
+et flèche de fibre). Chacun est un re-export type-sig (pattern winner L902 ★★
+Tier 5) : variables résidentes du module (`{C F}`), instances structurelles
+uniquement, zéro constructeur polymorphe d'univers.
+
+Note d'univers (leçon c.1301+144-L1) : `Grothendieck F` vit dans
+`Type (max u u₂)` (les univers de la base `C` et de la catégorie cible de
+`F : C ⥤ Cat.{v₂, u₂}`) et `Grothendieck.Hom X Y` dans `Type (max v v₂)` —
+le `Type _` du type-sig les infère tous, alignés sur les univers résidents
+du module.
+-/
+
+/-- Bridge : la **structure de la catégorie totale** ∫ F de la construction de
+    Grothendieck — les objets sont les couples `(c, x)` avec `c : C` et
+    `x : F(c)`, où `F : C ⥤ Cat`. C'est la réification des familles
+    paramétrées d'objets : une famille indexée par les objets de C devient un
+    objet interne de ∫ F. Type-sig re-export de `CategoryTheory.Grothendieck F`. -/
+def grothendieck_field : Type _ :=
+  CategoryTheory.Grothendieck F
+
+/-- Bridge : les **morphismes de la catégorie totale** ∫ F — pour `X Y : ∫ F`,
+    un morphisme `X ⟶ Y` est un couple `(f, φ)` avec `f : X.base ⟶ Y.base`
+    dans C (flèche de base) et `φ : X.fiber ⟶ (F.map f).toFunctor.obj Y.fiber`
+    dans la fibre (flèche de fibre). C'est la donnée qui fait de la
+    construction de Grothendieck une catégorie fibrée. Type-sig re-export de
+    `CategoryTheory.Grothendieck.Hom`. -/
+def grothendieck_hom_field (X Y : CategoryTheory.Grothendieck F) : Type _ :=
+  CategoryTheory.Grothendieck.Hom X Y
+
 end Grothendieck.Construction

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Construction_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/Construction_en.lean
@@ -219,4 +219,39 @@ def iso_mk_bridge {X Y : CategoryTheory.Grothendieck F}
     X ≅ Y :=
   CategoryTheory.Grothendieck.isoMk e₁ e₂
 
+/-!
+## 8. Final bridges: the total category structure and its morphisms
+
+The 2 bridges below close the `#check` documentary repertoire of this
+module: the **structure** `Grothendieck F` (the total category ∫ F whose
+objects are the pairs `(c, x)` with `c : C` and `x : F(c)`) and the
+**morphisms** `Grothendieck.Hom X Y` (the pairs `(f, φ)` — base arrow and
+fiber arrow). Each is a type-sig re-export (pattern winner L902 ★★ Tier 5):
+resident variables of the module (`{C F}`), structural instances only, no
+polymorphic universe constructor.
+
+Universe note (lesson c.1301+144-L1): `Grothendieck F` lives in
+`Type (max u u₂)` (the universes of the base `C` and of the target category
+of `F : C ⥤ Cat.{v₂, u₂}`) and `Grothendieck.Hom X Y` in `Type (max v v₂)` —
+the `Type _` of the type-sig infers them all, aligned on the resident
+universes of the module.
+-/
+
+/-- Bridge: the **structure of the total category** ∫ F of the Grothendieck
+    construction — objects are pairs `(c, x)` with `c : C` and `x : F(c)`,
+    where `F : C ⥤ Cat`. This is the reification of parametrized families of
+    objects: a family indexed by the objects of C becomes an internal object
+    of ∫ F. Type-sig re-export of `CategoryTheory.Grothendieck F`. -/
+def grothendieck_field : Type _ :=
+  CategoryTheory.Grothendieck F
+
+/-- Bridge: the **morphisms of the total category** ∫ F — for `X Y : ∫ F`, a
+    morphism `X ⟶ Y` is a pair `(f, φ)` with `f : X.base ⟶ Y.base` in C
+    (base arrow) and `φ : X.fiber ⟶ (F.map f).toFunctor.obj Y.fiber` in the
+    fiber (fiber arrow). This is the datum that makes the Grothendieck
+    construction a fibered category. Type-sig re-export of
+    `CategoryTheory.Grothendieck.Hom`. -/
+def grothendieck_hom_field (X Y : CategoryTheory.Grothendieck F) : Type _ :=
+  CategoryTheory.Grothendieck.Hom X Y
+
 end Grothendieck.Construction_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #10824 (c.1301+145 SheafHom)

## Résumé

Sub-grain EPIC **#2159** (Grothendieck Lean formalisation) : 2 nouveaux **bridges propres in-file** dans `Construction.lean` (Partie 30 — la construction de Grothendieck, catégories fibrées) fermant le répertoire `#check` documentaire du module : la **structure de la catégorie totale** (`grothendieck_field` — `Grothendieck F`, les objets = couples `(c, x)` avec `c : C` et `x : F(c)`) et les **morphismes de la catégorie totale** (`grothendieck_hom_field` — `Grothendieck.Hom X Y`, les couples `(f, φ)` : flèche de base + flèche de fibre). 2/2 `def` type-sig. Tous L902 ★★ safe — variables résidentes du module (`{C F}`), instances structurelles uniquement.

**Validation Lake build SUCCESS B.2 ★★ post-modif** : `lake build Grothendieck.Construction` + `_en` SUCCESS (640 jobs chacun, 0 warning) + `lake build` full SUCCESS (2823 jobs, **24ᵉ réutilisation du cache AZ** via hardlink-copy du `.lake` pré-construit).

Suite logique de la re-pioche des modules Grothendieck : le module avait déjà 8 decls (foncteur d'oubli `forget_family`, fonctorialité `map_family`, transport cartésien `transport_family`/`to_transport_bridge`, iso `iso_mk_bridge`, extensionalité `ext_bridge`, lois fonctorielles) couvrant la plupart des `#check`, mais les deux **structures** (∫ F et ses morphismes) restaient documentaires par `#check`. Les 2 bridges ferment le tableau : **structure de la catégorie totale → morphismes (flèche de base + flèche de fibre) → foncteur d'oubli → transport cartésien → fonctorialité → isos** est désormais entièrement exposé par des déclarations propres in-file.

## Périmètre

| Fichier | Type | Avant | Après | Δ |
|---|---|---|---|---|
| `Construction.lean` | FR sibling canonical | 8 decls | 10 decls | +35 insertions, -0 |
| `Construction_en.lean` | EN sibling mirror | 8 decls | 10 decls | +35 insertions, -0 |

**Total : +70 insertions net / -0, 2 fichiers, 2 nouveaux bridges (2+2 symétriques FR/EN).** Aucun autre fichier touché. Zéro suppression. Les 7 `#check` documentaires + 8 decls existantes conservés.

## Acceptance criteria #2159

| Critère | Mesure | Verdict |
|---|---|---|
| Claim posé sur #2159 (Construction.lean = module Partie 30, reliquat #check du scan pool) | claim paths-scoped `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: Construction.lean, Construction_en.lean` (issuecomment-5285868350) | ✅ |
| Remplacer `#check` par bridges propres (acceptance dispatch) | 2 bridges ajoutés (`grothendieck_field` / `grothendieck_hom_field`), les 7 `#check` documentaires conservés, les 8 decls existantes conservées | ✅ |
| Anti-§D : 0 `sorry` ajouté | `grep -c sorry` FR = 1, EN = 1 — **identique à main** (vérifié `git show origin/main` = 1) : docstring header pré-existante (« Tous les `sorry` éliminés à la création ») — aucune tactique `sorry` | ✅ |
| L902 ★★ Tier 5 : 0 constructeur polymorphe d'univers | variables résidentes du module (`{C : Type u} [Category.{v} C] (F : C ⥤ Cat.{v₂, u₂})`) — defs bridées opèrent sur les univers résidents `v v₂ u u₂` | ✅ |
| Bridges valides | 2/2 re-export type-sig direct (pattern `has_enough_points_field` c.1301+139) | ✅ |
| **B.2 ★★ Lake build SUCCESS post-modif** | `lake build Grothendieck.Construction` + `_en` SUCCESS (640 jobs chacun, 0 warning) + full SUCCESS (2823 jobs, 24ᵉ réutilisation cache AZ) | ✅ |
| i18n sibling pair (#4980) : byte-identity sauf docstrings | `python scripts/lean/check_i18n_siblings.py .../Grothendieck` (depuis le worktree) = Construction OK, 33/34 byte-identical, 0 drift, 0 orphan | ✅ |
| Catalogue inchangé (R1, [catalog-pr-hygiene](../../.claude/rules/catalog-pr-hygiene.md)) | 0 modification `COURSE_CATALOG.*` | ✅ |
| Scope strict : module Partie 30 uniquement | 2 fichiers modifiés uniquement, +70/-0 | ✅ |
| L898 ★★★ systematic check | `gh pr list --state all --search "Construction.lean"` = 0 OPEN (PRs historiques #10666/#7480 MERGED) — aucune collision cross-lane | ✅ |

## Les 2 bridges ajoutés — highlights

- **`grothendieck_field`** : la **structure de la catégorie totale** ∫ F de la construction de Grothendieck — les objets sont les couples `(c, x)` avec `c : C` et `x : F(c)`, où `F : C ⥤ Cat`. C'est la réification des familles paramétrées d'objets : une famille indexée par les objets de C devient un objet interne de ∫ F. Type-sig re-export de `CategoryTheory.Grothendieck F`.
- **`grothendieck_hom_field`** : les **morphismes de la catégorie totale** ∫ F — pour `X Y : ∫ F`, un morphisme `X ⟶ Y` est un couple `(f, φ)` avec `f : X.base ⟶ Y.base` dans C (flèche de base) et `φ : X.fiber ⟶ (F.map f).toFunctor.obj Y.fiber` dans la fibre (flèche de fibre). C'est la donnée qui fait de la construction de Grothendieck une catégorie fibrée. Type-sig re-export de `CategoryTheory.Grothendieck.Hom`.

**Tell Mathlib (rappel leçon c.1301+144-L1 ★)** : les univers des structures de la construction de Grothendieck sont **composés** (`Grothendieck F : Type (max u u₂)` — les univers de la base et de la catégorie cible de `F : C ⥤ Cat.{v₂, u₂}` ; `Grothendieck.Hom X Y : Type (max v v₂)`) — le `Type _` du type-sig les infère tous, alignés sur les univers résidents du module, sans univers supplémentaire.

## Pourquoi cette forme (G-VAR-1 / G-VAR-3 justification)

**G-VAR-1** : DEEP/lean = **CONTENU** (genre classé CONTENU per [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1). Module Grothendieck = livrable pédagogique de fond. La construction de Grothendieck — le « yoga des foncteurs » — est l'une des idées les plus fécondes de Grothendieck : le langage des catégories fibrées, central dans la théorie de la descente (SGA 1) et les champs algébriques. Les 2 bridges exposent les **structures** (catégorie totale + morphismes) qui fondent toutes les decls existantes (forget, transport, map, iso).

**G-VAR-3** : grains précédents (cycles c.1301+137..+145) = DEEP/lean #10805 (Equivalences), #10808 (MonoidalCategories), #10811/#10815 (Conservative), #10816 (Limits), #10818 (KanExtensions), #10820 (SitePoints), #10823 (Comma), #10824 (SheafHom). Ce grain = DEEP/lean sur Construction (Partie 30). **24ᵉ DEEP/lean consécutif** MAIS **substance genuinement distincte** : la structure de la catégorie totale et ses morphismes (flèche de base + flèche de fibre) sont des constructions distinctes des sections précédentes (le type retour `∫ F` est une structure data avec univers composé, pas une classe Prop ni une instance de catégorie — discriminant des grains Comma/SitePoints/SheafHom). Tell décisif du litmus LIGHT : **non-générable en scannant l'instance d'à-côté** (le choix type-sig data pour les 2 structures est une décision de lecture du module, les 7 #check voisins ne la révèlent pas). G-VAR-3 autorise les 10ᵉ+ DEEP/lean substantifs.

**Substance** : ajout de **bridges propres** (et non de simples `#check`) sur le module Partie 30. Le module avait déjà 8 decls (foncteur d'oubli, fonctorialité, transport, iso, extensionalité, lois) mais les **structures** (∫ F et ses morphismes) restaient documentaires par `#check`. Les 2 bridges ferment le tableau : **structure → morphismes → oubli → transport → fonctorialité → isos** est désormais entièrement exposé par des déclarations propres in-file.

## Garde-fous

- **L898 ★★★** : `gh pr list --state all --search "Construction.lean"` = 0 OPEN + PRs historiques #10666/#7480 MERGED. Aucune collision cross-lane. Claim paths-scoped posté sur #2159 (issuecomment-5285868350, paths Construction.lean/Construction_en.lean, lane myia-po-2025) — disjoint des claims SitePoints.lean, Comma.lean, SheafHom.lean, KanExtensions.lean et Limits.lean existants.
- **Base main à jour** : branche `feature/c1301x146-2159-construction` créée depuis `origin/main` (HEAD 747dcf8ac, 2026-08-13) — module DIFFÉRENT des grains précédents → pas de stacking. Rebase frais conforme R2 catalog-pr-hygiene.
- **Hors scope po-2026** : le dashboard liste po-2026 sur YonedaLemma/LeftExact/Calibration/CategoryAndSites/MathlibMap/SchemesTour — Construction n'y figure pas (L898 + dashboard vérifiés).
- **L903 ★★** : grain tag `DEEP/lean` first line, conforme [variation-protocol.md](../../.claude/rules/variation-protocol.md) §1.
- **L677-L4 ★★** : PR body dans scratchpad `<scratchpad>/c1301x146_pr_body.md`, pas dans worktree.
- **L398 ★★** : `git diff --stat` AVANT `git add` = 2 fichiers, +70/-0. ✅
- **L279 ★★** : push 403 (compte gh actif = jsboigeEpita) → `gh auth switch -u jsboige` → push → switch back. ✅

## Anti-régression §D

- 0 `sorry` ajouté : `grep -c sorry` FR/EN = 1 chacun, **identique à main** (vérifié `git show origin/main`) — docstring header pré-existante, pas une tactique
- 0 `rfl` KO (les 2 bridges = re-export type-sig de structures Mathlib)
- Toutes les preuves = re-export direct (pattern `has_enough_points_field` c.1301+139)
- Aucune suppression de `#check` ou de defs/théorèmes existants (7 `#check` documentaires + 8 decls existantes conservés)
- Aucun universe supplémentaire ajouté (les bridges opèrent sur les univers résidents `v v₂ u u₂`)
- Zéro deletion au diff (+70/-0)

## Note d'accessibilité (Epics #1452/#1453)

Le module Partie 30 (Construction) expose désormais **10 déclarations propres in-file** (8 existantes + 2 bridges), couvrant le **cycle complet de la construction de Grothendieck** : (a) la structure de la catégorie totale (`grothendieck_field`) et ses morphismes (`grothendieck_hom_field`), (b) le foncteur d'oubli (`forget_family`), (c) le transport cartésien (`transport_family`/`to_transport_bridge`), (d) la fonctorialité en F (`map_family`/`functor_comp_forget_bridge`/`map_id_eq_bridge`/`map_comp_eq_bridge`), (e) les isos (`iso_mk_bridge`) et l'extensionalité (`ext_bridge`). Chaque bridge documente en FR+EN la relation entre l'API Mathlib sous-jacente et son restatement in-file, fondant le pont construction de Grothendieck → catégories fibrées → descente (SGA 1) → champs algébriques au cœur de la géométrie algébrique grothendieckienne.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
