### PR TITLE
docs(notebook,#10289): PT-01 intro — ref serie PT-02 SFT sur Qwen3.5-0.8B (migration serie PostTraining)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_01_intro_post_training.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_01_intro_post_training.ipynb
@@ -601,7 +601,7 @@
     "\n",
     "| Notebook | Sujet |\n",
     "|----------|-------|\n",
-    "| PT-02 | SFT baseline avec `trl.SFTTrainer` sur Qwen-0.5B |\n",
+    "| PT-02 | SFT baseline avec `trl.SFTTrainer` sur Qwen3.5-0.8B |\n",
     "| PT-03 | DPO avec `trl.DPOTrainer` post-SFT |\n",
     "| PT-04 | **GRPO (livrable cle)** avec `trl.GRPOTrainer` |\n",
     "| PT-05 | RLVR avec verificateur sympy/pytest |\n",


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA-2 — prev: LIGHT/notebook-python #10822

## Summary

Migration PT-01 (intro série) — dernière ref de série stale « Qwen-0.5B » de la série PostTraining (mandat **#10289**). Suite directe de PT-08 (#10821) et PT-09 (#10822).

**cell 19** (markdown, table « Suite de la serie ») : `| PT-02 | SFT baseline avec \`trl.SFTTrainer\` sur Qwen-0.5B |` → `... sur Qwen3.5-0.8B |` — fausse depuis la migration de PT-02 vers Qwen3.5-0.8B (#10813, vrai SFT QLoRA GPU).

**Honnêteté sur l'état de la série** : les 5 PRs de migration #10289 (#10813 PT-02 / #10817 PT-04 / #10819 PT-06 / #10821 PT-08 / #10822 PT-09) sont OPEN en attente de merge ai-01. La ref pointe la **cible** de la série (Qwen3.5-0.8B), cohérente avec les refs déjà posées dans PT-08/PT-09 — livrer « Qwen-0.5B » créerait une incohérence de série (PT-08/09 pointent 3.5-0.8B, PT-01 pointerait 0.5B).

**Scope** : cells 5/10 (échelle de coûts pédagogique « VRAM relative (Qwen-0.5B) » — ratios relatifs entre techniques à modèle fixé, convention de comparaison, pas une ref de série) **conservées** — classe « méthode » = GARDER (leçon c.1331+138-L1), C.4 (markdown-align sur données calculées interdit).

## Validation

- [x] Markdown-only (C.3 : outputs préservés, pas de re-exécution) — `git diff` : 1+/1-, zéro ligne `outputs`/`execution_count` touchée
- [x] Round-trip JSON byte-identique vérifié avant édition (indent=1, LF, pas de BOM)
- [x] `execution_count` [1,2,1,3,1,4,1] intacts, 0 erreur, notebook valide (`json.loads` OK, 20 cells, ids OK)
- [x] 0 CRLF (fichier LF propre)
- [x] Cell 19 = la seule ligne markdown modifiée ; cells 5/10 code intacts (échelle de coûts)

## Issues

See #10289 (mandat migration Qwen3.5 — série PostTraining : PT-01/02/04/06/08/09 migrés par cette lane, PT-05 restant claimé ai-01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
