### PR TITLE
fix(genai-audio,#10831): tts-api telecharge en_core_web_sm au demarrage (idempotent) + doc convention shared

### DIFF
--- a/docker-configurations/services/tts-api/README.md
+++ b/docker-configurations/services/tts-api/README.md
@@ -116,7 +116,7 @@ Les voix Kokoro natives (`af_sky`, `af_bella`, `am_adam`, `am_michael`) sont aus
 ## Architecture
 
 - **Chargement paresseux** : le modele est charge au premier appel et decharge automatiquement apres la periode d'inactivite (`IDLE_TIMEOUT`). Un checker en arriere-plan tourne toutes les 60 s.
-- **Modules partages** : utilise `../shared/` pour `lazy_model.py` (gestion du cycle de vie) et `auth_middleware.py` (authentification Bearer).
+- **Modules partages** : utilise `../shared/` pour `lazy_model.py` (gestion du cycle de vie) et `auth_middleware.py` (authentification Bearer). Ces modules sont fournis par **bind-mount** dans `docker-compose*.yml` (convention stack, partagee par 6 services : demucs, funasr, musicgen, qwen-asr, tts, whisper) : le Dockerfile seul ne les inclut pas, l'API ne demarre pas en build pur (`docker compose up` est le chemin canonique).
 - **Fallback CUDA** : si CUDA n'est pas disponible, le modele bascule sur CPU (`TTS_DEVICE=cpu`).
 
 ## Fichiers

--- a/docker-configurations/services/tts-api/start.sh
+++ b/docker-configurations/services/tts-api/start.sh
@@ -5,5 +5,13 @@ echo "Starting TTS API..."
 echo "Device: ${TTS_DEVICE}"
 echo "Default Voice: ${DEFAULT_TTS_VOICE}"
 
+# Kokoro requires the spaCy English model (en_core_web_sm); download it if absent
+# (idempotent: skips on subsequent starts). Missing model = OSError E050 on first
+# inference even though `pip install kokoro` pulled spacy itself.
+if ! python -c "import spacy; spacy.load('en_core_web_sm')" 2>/dev/null; then
+    echo "Downloading spaCy model en_core_web_sm..."
+    python -m spacy download en_core_web_sm --quiet
+fi
+
 # Start uvicorn
 exec uvicorn app:app --host 0.0.0.0 --port 8191 --log-level info


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #10830

## Summary

Fix #10831 — l'API TTS Kokoro (docker-configurations/services/tts-api) echoue a la **premiere inference** avec `OSError: [E050] Can't find model 'en_core_web_sm'` : `pip install kokoro` tire spacy en dependance transitive mais **pas** le modele linguistique, requis par `KPipeline`. Bug reel, reproduit sur les deux chemins de run (build local + image pre-build ghcr).

**`start.sh`** : download idempotent `en_core_web_sm` avant `exec uvicorn` — garde `python -c "import spacy; spacy.load('en_core_web_sm')"` (skip si deja present, ~12 Mo, ~30 s sur conteneur froid). Le fix porte au **runtime** (pas au Dockerfile) pour couvrir aussi l'image pre-build hybride, qui ne sera pas rebuiltee par cette PR.

**`README.md`** : note convention stack — les modules `shared/` (`lazy_model.py`, `auth_middleware.py`) sont fournis par **bind-mount** dans `docker-compose*.yml` (convention partagee par 6 services : demucs, funasr, musicgen, qwen-asr, tts, whisper) ; le Dockerfile seul ne les inclut pas (`docker compose up` = chemin canonique). Point 1 de #10831 = doc, pas un bug (le bind-mount est la convention, pas un oubli).

## Validation

- [x] **Re-exec reelle** : image rebuiltee (`docker compose build`, cache couches), conteneur **froid** (volume cache neuf) → logs : `Downloading spaCy model en_core_web_sm...` → `Download and installation successful` → `Uvicorn running`
- [x] **Generation TTS reelle** : `POST /v1/audio/speech` (voix af_sky, mp3) → **HTTP 200, 115 Ko, 16.4 s** (CPU, Kokoro-82M, premier chargement lazy — exerce exactement le chemin E050)
- [x] **Garde idempotente** : restart du conteneur → **2 boots uvicorn / 1 seul download** (le check `spacy.load` skip)
- [x] Scope = claim paths : 2 fichiers (+9/−1), aucun catalogue/README de serie touche
- [x] LF propres, pas de BOM ; `set -e` preserve (le guard `! ... if` ne declenche pas d'exit)

## Diagnostic derive

N/A — pas de sortie de notebook realignee (fix infra docker, hors regles notebook C.4).

## Issues

See #10831 (fix apporte ; reste hors scope : rebuild/push de l'image pre-build ghcr, orchestration du run GPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
