### PR TITLE
feat(audio,#10775): 04-12 publie laudiobook sous le nom canonique attendu par 04-11 (chaine jouable)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
@@ -35,10 +35,10 @@
    "id": "c3bee5ce",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-17T23:37:16.381300Z",
-     "iopub.status.busy": "2026-05-17T23:37:16.380828Z",
-     "iopub.status.idle": "2026-05-17T23:37:16.398549Z",
-     "shell.execute_reply": "2026-05-17T23:37:16.397207Z"
+     "iopub.execute_input": "2026-08-13T22:25:47.143719Z",
+     "iopub.status.busy": "2026-08-13T22:25:47.143442Z",
+     "iopub.status.idle": "2026-08-13T22:25:47.153030Z",
+     "shell.execute_reply": "2026-08-13T22:25:47.152138Z"
     },
     "papermill": {
      "duration": 0.025276,
@@ -54,9 +54,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "TTS output dir: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Audio\\04-Applications\\tts_output\n",
+      "TTS output dir: tts_output\n",
       "TTS metadata: True\n",
-      "Audiobook output: D:\\Dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\Audio\\04-Applications\\audiobook_final\n"
+      "Audiobook output: audiobook_final\n"
      ]
     }
    ],
@@ -66,6 +66,7 @@
     "import struct\n",
     "import wave\n",
     "import subprocess\n",
+    "import shutil\n",
     "from pathlib import Path\n",
     "from dataclasses import dataclass, asdict\n",
     "from typing import Optional\n",
@@ -77,9 +78,9 @@
     "AUDIOBOOK_DIR = BASE_DIR / \"audiobook_final\"\n",
     "AUDIOBOOK_DIR.mkdir(exist_ok=True, parents=True)\n",
     "\n",
-    "print(f\"TTS output dir: {TTS_OUTPUT_DIR.resolve()}\")\n",
+    "print(f\"TTS output dir: {TTS_OUTPUT_DIR}\")\n",
     "print(f\"TTS metadata: {TTS_METADATA.exists()}\")\n",
-    "print(f\"Audiobook output: {AUDIOBOOK_DIR.resolve()}\")"
+    "print(f\"Audiobook output: {AUDIOBOOK_DIR}\")"
    ]
   },
   {
@@ -123,10 +124,10 @@
    "id": "5d9b3231",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-17T23:37:16.416539Z",
-     "iopub.status.busy": "2026-05-17T23:37:16.416071Z",
-     "iopub.status.idle": "2026-05-17T23:37:16.435835Z",
-     "shell.execute_reply": "2026-05-17T23:37:16.434542Z"
+     "iopub.execute_input": "2026-08-13T22:25:47.155385Z",
+     "iopub.status.busy": "2026-08-13T22:25:47.155067Z",
+     "iopub.status.idle": "2026-08-13T22:25:47.165536Z",
+     "shell.execute_reply": "2026-08-13T22:25:47.164399Z"
     },
     "papermill": {
      "duration": 0.025916,
@@ -206,10 +207,10 @@
    "id": "6902891f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-17T23:37:16.457396Z",
-     "iopub.status.busy": "2026-05-17T23:37:16.456754Z",
-     "iopub.status.idle": "2026-05-17T23:37:18.019574Z",
-     "shell.execute_reply": "2026-05-17T23:37:18.018343Z"
+     "iopub.execute_input": "2026-08-13T22:25:47.167985Z",
+     "iopub.status.busy": "2026-08-13T22:25:47.167573Z",
+     "iopub.status.idle": "2026-08-13T22:25:47.268060Z",
+     "shell.execute_reply": "2026-08-13T22:25:47.266952Z"
     },
     "papermill": {
      "duration": 1.570739,
@@ -277,10 +278,10 @@
    "id": "e32c0c71",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-17T23:37:18.032132Z",
-     "iopub.status.busy": "2026-05-17T23:37:18.031408Z",
-     "iopub.status.idle": "2026-05-17T23:37:22.338587Z",
-     "shell.execute_reply": "2026-05-17T23:37:22.336622Z"
+     "iopub.execute_input": "2026-08-13T22:25:47.270346Z",
+     "iopub.status.busy": "2026-08-13T22:25:47.270022Z",
+     "iopub.status.idle": "2026-08-13T22:25:49.963201Z",
+     "shell.execute_reply": "2026-08-13T22:25:49.962481Z"
     },
     "papermill": {
      "duration": 4.315035,
@@ -313,7 +314,8 @@
      "output_type": "stream",
      "text": [
       "Final audiobook: 2.0 MB\n",
-      "Output: audiobook_final\\boule_de_suif_finalized.mp3\n"
+      "Output: audiobook_final\\boule_de_suif_finalized.mp3\n",
+      "Canonical audiobook: audiobook_kokoro.mp3 (2.0 MB)\n"
      ]
     }
    ],
@@ -350,30 +352,46 @@
     "else:\n",
     "    final_size = OUTPUT_FINAL.stat().st_size / 1024 / 1024\n",
     "    print(f\"Final audiobook: {final_size:.1f} MB\")\n",
-    "    print(f\"Output: {OUTPUT_FINAL}\")"
+    "    print(f\"Output: {OUTPUT_FINAL}\")\n",
+    "\n",
+    "# Step 3: Publish under the canonical name consumed by 04-11 (audiobook comparison)\n",
+    "AUDIOBOOK_KOKORO = BASE_DIR / \"audiobook_kokoro.mp3\"\n",
+    "if OUTPUT_FINAL.exists():\n",
+    "    shutil.copy2(OUTPUT_FINAL, AUDIOBOOK_KOKORO)\n",
+    "    kb = AUDIOBOOK_KOKORO.stat().st_size / 1024 / 1024\n",
+    "    print(f\"Canonical audiobook: {AUDIOBOOK_KOKORO.name} ({kb:.1f} MB)\")\n",
+    "else:\n",
+    "    print(\"Normalization skipped — canonical audiobook not published\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "811c6eae",
-   "source": "### Exercice : Paramètres de transition adaptes au type de segment\n\n**Duree estimee :** 15 minutes\n\n**Objectif** : Modifier le pipeline de concatenation pour utiliser des transitions différentes selon les types de segments adjacents. Un silence de 300 ms entre deux dialogues du même locuteur, 500 ms entre un dialogue et une narration, et 800 ms entre deux scenes différentes.\n\n**Contexte** : Le silence uniforme de 500 ms ne reflete pas les variations naturelles de rythme narratif. Une transition trop courte entre deux personnages différents rend le dialogue confus, tandis qu'un silence trop long dans un monologue casse le rythme.\n\n- **Étape 1 :** Définir les règles de duree de silence selon les types de segments adjacents\n- **Étape 2 :** Generer des fichiers de silence de différentes durees (300ms, 500ms, 800ms)\n- **Étape 3 :** Construire la liste de concatenation avec les silences adaptes\n\n**Indice :** La cle de transition = (type_seg_n, type_seg_n+1, locuteur_identique)\n**Indice :** Les segments sont tries par seg_index et contiennent le champ seg_type et speaker\n**Indice :** La liste de concatenation contient alternativement un segment et un silence",
-   "metadata": {}
+   "metadata": {},
+   "source": "### Exercice : Paramètres de transition adaptes au type de segment\n\n**Duree estimee :** 15 minutes\n\n**Objectif** : Modifier le pipeline de concatenation pour utiliser des transitions différentes selon les types de segments adjacents. Un silence de 300 ms entre deux dialogues du même locuteur, 500 ms entre un dialogue et une narration, et 800 ms entre deux scenes différentes.\n\n**Contexte** : Le silence uniforme de 500 ms ne reflete pas les variations naturelles de rythme narratif. Une transition trop courte entre deux personnages différents rend le dialogue confus, tandis qu'un silence trop long dans un monologue casse le rythme.\n\n- **Étape 1 :** Définir les règles de duree de silence selon les types de segments adjacents\n- **Étape 2 :** Generer des fichiers de silence de différentes durees (300ms, 500ms, 800ms)\n- **Étape 3 :** Construire la liste de concatenation avec les silences adaptes\n\n**Indice :** La cle de transition = (type_seg_n, type_seg_n+1, locuteur_identique)\n**Indice :** Les segments sont tries par seg_index et contiennent le champ seg_type et speaker\n**Indice :** La liste de concatenation contient alternativement un segment et un silence"
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "9a024663",
-   "source": "# TODO etudiant : transitions adaptees au type de segment\n# Etape 1 : Regles de duree de silence\nTRANSITION_RULES = {}  # TODO etudiant : {(type1, type2, same_speaker): duration_ms}\n\n# Etape 2 : Fonction de selection du silence\ndef get_transition_duration(seg_a, seg_b):\n    \"\"\"Retourne la duree de silence adaptee entre deux segments consecutifs.\"\"\"\n    # TODO etudiant : utiliser TRANSITION_RULES\n    return 500  # TODO etudiant\n\n# Etape 3 : Construire la liste de concatenation adaptee\ndef build_adaptive_concat_list(segments_list, output_dir):\n    \"\"\"Genere les fichiers de silence et la liste FFmpeg avec transitions adaptees.\"\"\"\n    # TODO etudiant\n    return []  # TODO etudiant : liste de paths (segments + silences)\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T22:25:49.965393Z",
+     "iopub.status.busy": "2026-08-13T22:25:49.965166Z",
+     "iopub.status.idle": "2026-08-13T22:25:49.968720Z",
+     "shell.execute_reply": "2026-08-13T22:25:49.968123Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
-   ]
+   ],
+   "source": "# TODO etudiant : transitions adaptees au type de segment\n# Etape 1 : Regles de duree de silence\nTRANSITION_RULES = {}  # TODO etudiant : {(type1, type2, same_speaker): duration_ms}\n\n# Etape 2 : Fonction de selection du silence\ndef get_transition_duration(seg_a, seg_b):\n    \"\"\"Retourne la duree de silence adaptee entre deux segments consecutifs.\"\"\"\n    # TODO etudiant : utiliser TRANSITION_RULES\n    return 500  # TODO etudiant\n\n# Etape 3 : Construire la liste de concatenation adaptee\ndef build_adaptive_concat_list(segments_list, output_dir):\n    \"\"\"Genere les fichiers de silence et la liste FFmpeg avec transitions adaptees.\"\"\"\n    # TODO etudiant\n    return []  # TODO etudiant : liste de paths (segments + silences)\n\nprint(\"Exercice a completer\")"
   },
   {
    "cell_type": "markdown",
@@ -392,14 +410,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "a84e368a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-17T23:37:22.365752Z",
-     "iopub.status.busy": "2026-05-17T23:37:22.365128Z",
-     "iopub.status.idle": "2026-05-17T23:37:23.962895Z",
-     "shell.execute_reply": "2026-05-17T23:37:23.960988Z"
+     "iopub.execute_input": "2026-08-13T22:25:49.970445Z",
+     "iopub.status.busy": "2026-08-13T22:25:49.970244Z",
+     "iopub.status.idle": "2026-08-13T22:25:50.030975Z",
+     "shell.execute_reply": "2026-08-13T22:25:50.030243Z"
     },
     "papermill": {
      "duration": 1.607927,
@@ -467,24 +485,31 @@
   {
    "cell_type": "markdown",
    "id": "eada37c7",
-   "source": "### Exercice : Calculer des metriques de qualite audio\n\n**Duree estimee :** 15-20 minutes\n\n**Objectif** : Implementer des fonctions qui calculent des metriques de qualite audio directement a partir du fichier MP3 : niveau RMS (volume moyen), peak (volume maximum), et dynamic range (ecart entre peak et RMS). Ces metriques permettent de verifier que l'audiobook est bien normalise.\n\n**Contexte** : La normalisation FFmpeg vise -16 LUFS, mais il est utile de verifier le résultat en calculant le volume RMS reel du fichier final.\n\n- **Étape 1 :** Utiliser ffprobe pour extraire le volume RMS du fichier audio\n- **Étape 2 :** Calculer le dynamic range (peak - RMS) en dB\n- **Étape 3 :** Comparer les metriques avant et après normalisation (audiobook_raw vs audiobook_final)\n\n**Indice :** ffmpeg -i input.mp3 -af \"volumedetect\" -f null /dev/null 2>&1 affiche mean_volume et max_volume\n**Indice :** Le dynamic range sain pour un audiobook est entre 10 et 20 dB\n**Indice :** Utilisez subprocess.run() pour executer ffprobe/ffmpeg depuis Python",
-   "metadata": {}
+   "metadata": {},
+   "source": "### Exercice : Calculer des metriques de qualite audio\n\n**Duree estimee :** 15-20 minutes\n\n**Objectif** : Implementer des fonctions qui calculent des metriques de qualite audio directement a partir du fichier MP3 : niveau RMS (volume moyen), peak (volume maximum), et dynamic range (ecart entre peak et RMS). Ces metriques permettent de verifier que l'audiobook est bien normalise.\n\n**Contexte** : La normalisation FFmpeg vise -16 LUFS, mais il est utile de verifier le résultat en calculant le volume RMS reel du fichier final.\n\n- **Étape 1 :** Utiliser ffprobe pour extraire le volume RMS du fichier audio\n- **Étape 2 :** Calculer le dynamic range (peak - RMS) en dB\n- **Étape 3 :** Comparer les metriques avant et après normalisation (audiobook_raw vs audiobook_final)\n\n**Indice :** ffmpeg -i input.mp3 -af \"volumedetect\" -f null /dev/null 2>&1 affiche mean_volume et max_volume\n**Indice :** Le dynamic range sain pour un audiobook est entre 10 et 20 dB\n**Indice :** Utilisez subprocess.run() pour executer ffprobe/ffmpeg depuis Python"
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "29b62ec6",
-   "source": "# TODO etudiant : metriques de qualite audio\n# Etape 1 : Extraire le volume RMS\ndef measure_volume(filepath):\n    \"\"\"Mesure le volume moyen (RMS) et peak d'un fichier audio via ffmpeg.\"\"\"\n    # TODO etudiant : utiliser ffmpeg -af volumedetect\n    return {\"mean_db\": None, \"max_db\": None}  # TODO etudiant\n\n# Etape 2 : Calculer le dynamic range\ndef dynamic_range(mean_db, max_db):\n    \"\"\"Calcule le dynamic range en dB.\"\"\"\n    # TODO etudiant\n    return None  # TODO etudiant\n\n# Etape 3 : Comparaison avant/apres normalisation\n# TODO etudiant : mesurer OUTPUT_RAW et OUTPUT_FINAL, afficher le tableau\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T22:25:50.032621Z",
+     "iopub.status.busy": "2026-08-13T22:25:50.032458Z",
+     "iopub.status.idle": "2026-08-13T22:25:50.036969Z",
+     "shell.execute_reply": "2026-08-13T22:25:50.036336Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
-   ]
+   ],
+   "source": "# TODO etudiant : metriques de qualite audio\n# Etape 1 : Extraire le volume RMS\ndef measure_volume(filepath):\n    \"\"\"Mesure le volume moyen (RMS) et peak d'un fichier audio via ffmpeg.\"\"\"\n    # TODO etudiant : utiliser ffmpeg -af volumedetect\n    return {\"mean_db\": None, \"max_db\": None}  # TODO etudiant\n\n# Etape 2 : Calculer le dynamic range\ndef dynamic_range(mean_db, max_db):\n    \"\"\"Calcule le dynamic range en dB.\"\"\"\n    # TODO etudiant\n    return None  # TODO etudiant\n\n# Etape 3 : Comparaison avant/apres normalisation\n# TODO etudiant : mesurer OUTPUT_RAW et OUTPUT_FINAL, afficher le tableau\n\nprint(\"Exercice a completer\")"
   },
   {
    "cell_type": "markdown",
@@ -503,14 +528,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "2122c85a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-17T23:37:24.000538Z",
-     "iopub.status.busy": "2026-05-17T23:37:23.999662Z",
-     "iopub.status.idle": "2026-05-17T23:37:24.011690Z",
-     "shell.execute_reply": "2026-05-17T23:37:24.009957Z"
+     "iopub.execute_input": "2026-08-13T22:25:50.038641Z",
+     "iopub.status.busy": "2026-08-13T22:25:50.038494Z",
+     "iopub.status.idle": "2026-08-13T22:25:50.042753Z",
+     "shell.execute_reply": "2026-08-13T22:25:50.042160Z"
     },
     "papermill": {
      "duration": 0.021425,
@@ -587,14 +612,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "dc0a39c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-17T23:37:24.038335Z",
-     "iopub.status.busy": "2026-05-17T23:37:24.037197Z",
-     "iopub.status.idle": "2026-05-17T23:37:24.050491Z",
-     "shell.execute_reply": "2026-05-17T23:37:24.048862Z"
+     "iopub.execute_input": "2026-08-13T22:25:50.044331Z",
+     "iopub.status.busy": "2026-08-13T22:25:50.044149Z",
+     "iopub.status.idle": "2026-08-13T22:25:50.049872Z",
+     "shell.execute_reply": "2026-08-13T22:25:50.049066Z"
     },
     "papermill": {
      "duration": 0.022633,
@@ -660,24 +685,31 @@
   {
    "cell_type": "markdown",
    "id": "13adaf3a",
-   "source": "### Exercice : Generer un manifest avec marqueurs de chapitres\n\n**Duree estimee :** 15 minutes\n\n**Objectif** : Enrichir le manifest JSON avec des marqueurs de chapitres calcules automatiquement. Les chapitres sont delimites par les segments de type \"narration\" longs (> 10 secondes) qui précédent un changement de type de segment. Le manifest enrichi inclut les timestamps de debut et fin de chaque chapitre.\n\n**Contexte** : Les plateformes audio (Audible, Apple Podcasts) utilisent les marqueurs de chapitres pour la navigation. Ceux-ci doivent etre generes automatiquement a partir de la structure du texte.\n\n- **Étape 1 :** Identifier les frontieres de chapitres (narration longue suivie d'un dialogue)\n- **Étape 2 :** Calculer les timestamps cumules (en secondes) pour chaque frontiere\n- **Étape 3 :** Ajouter les chapitres au manifest et exporter en JSON\n\n**Indice :** Un chapitre commence quand un segment narration (> 10s) est suivi d'un dialogue\n**Indice :** Les timestamps cumules = somme des durees des segments précédents + silences\n**Indice :** Le format chapter = {\"title\": \"Chapitre N\", \"start_s\": float, \"end_s\": float}",
-   "metadata": {}
+   "metadata": {},
+   "source": "### Exercice : Generer un manifest avec marqueurs de chapitres\n\n**Duree estimee :** 15 minutes\n\n**Objectif** : Enrichir le manifest JSON avec des marqueurs de chapitres calcules automatiquement. Les chapitres sont delimites par les segments de type \"narration\" longs (> 10 secondes) qui précédent un changement de type de segment. Le manifest enrichi inclut les timestamps de debut et fin de chaque chapitre.\n\n**Contexte** : Les plateformes audio (Audible, Apple Podcasts) utilisent les marqueurs de chapitres pour la navigation. Ceux-ci doivent etre generes automatiquement a partir de la structure du texte.\n\n- **Étape 1 :** Identifier les frontieres de chapitres (narration longue suivie d'un dialogue)\n- **Étape 2 :** Calculer les timestamps cumules (en secondes) pour chaque frontiere\n- **Étape 3 :** Ajouter les chapitres au manifest et exporter en JSON\n\n**Indice :** Un chapitre commence quand un segment narration (> 10s) est suivi d'un dialogue\n**Indice :** Les timestamps cumules = somme des durees des segments précédents + silences\n**Indice :** Le format chapter = {\"title\": \"Chapitre N\", \"start_s\": float, \"end_s\": float}"
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "b67ab4fe",
-   "source": "# TODO etudiant : manifest avec marqueurs de chapitres\nCHAPTER_THRESHOLD_S = 10.0  # Duree minimale d'un segment narration pour former un chapitre\n\n# Etape 1 : Identifier les frontieres\ndef detect_chapter_boundaries(segments_list, threshold_s=CHAPTER_THRESHOLD_S):\n    \"\"\"Detecte les indices de debut de chapitre.\"\"\"\n    # TODO etudiant\n    return []  # TODO etudiant\n\n# Etape 2 : Calculer les timestamps\ndef compute_chapter_timestamps(segments_list, boundaries, silence_ms=SILENCE_MS):\n    \"\"\"Calcule les timestamps de debut/fin pour chaque chapitre.\"\"\"\n    # TODO etudiant\n    return []  # TODO etudiant\n\n# Etape 3 : Enrichir le manifest\n# TODO etudiant : ajouter les chapitres au manifest et sauvegarder\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-13T22:25:50.051521Z",
+     "iopub.status.busy": "2026-08-13T22:25:50.051367Z",
+     "iopub.status.idle": "2026-08-13T22:25:50.055256Z",
+     "shell.execute_reply": "2026-08-13T22:25:50.054608Z"
+    }
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
-   ]
+   ],
+   "source": "# TODO etudiant : manifest avec marqueurs de chapitres\nCHAPTER_THRESHOLD_S = 10.0  # Duree minimale d'un segment narration pour former un chapitre\n\n# Etape 1 : Identifier les frontieres\ndef detect_chapter_boundaries(segments_list, threshold_s=CHAPTER_THRESHOLD_S):\n    \"\"\"Detecte les indices de debut de chapitre.\"\"\"\n    # TODO etudiant\n    return []  # TODO etudiant\n\n# Etape 2 : Calculer les timestamps\ndef compute_chapter_timestamps(segments_list, boundaries, silence_ms=SILENCE_MS):\n    \"\"\"Calcule les timestamps de debut/fin pour chaque chapitre.\"\"\"\n    # TODO etudiant\n    return []  # TODO etudiant\n\n# Etape 3 : Enrichir le manifest\n# TODO etudiant : ajouter les chapitres au manifest et sauvegarder\n\nprint(\"Exercice a completer\")"
   },
   {
    "cell_type": "markdown",
@@ -716,6 +748,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "N/A",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-23T09:30Z",
+   "network": false,
+   "notes": "Compilation audio post-TTS : FFmpeg concat demuxer pour joindre segments P4 (14 MP3)\navec transitions (silence 500ms, fade in/out 200ms) -> masterisation audiobook MP3.\nChargement metadata JSON de P4 -> filtrage success segments -> tri seg_index ->\nconcatenation deterministe.\nCout = 0 ; peut tourner offline complet.\n---\n",
+   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb",
+   "reproducibility": "HIGH",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -731,7 +780,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
@@ -744,23 +793,6 @@
    "parameters": {},
    "start_time": "2026-05-17T23:37:13.418355",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0,
-   "api_provider": "none",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "N/A",
-   "reduced_pedagogical": "GenAI/Audio/01-Foundation/01-3-Basic-Audio-Operations.ipynb",
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-23T09:30Z",
-   "validator": "papermill",
-   "notes": "Compilation audio post-TTS : FFmpeg concat demuxer pour joindre segments P4 (14 MP3)\navec transitions (silence 500ms, fade in/out 200ms) -> masterisation audiobook MP3.\nChargement metadata JSON de P4 -> filtrage success segments -> tri seg_index ->\nconcatenation deterministe.\nCout = 0 ; peut tourner offline complet.\n---\n"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #10832

## Summary

Suite de #10775 (lecteurs audio morts) — **mismatch de contrat cross-notebook** : la section « Livres audio complets » de 04-11 (cell 34, `kokoro_audiobook = BASE_DIR / "audiobook_kokoro.mp3"`, present aussi sur main) ne trouvait **jamais** son fichier, parce que 04-12 Compilation-Audio ecrit `audiobook_final/boule_de_suif_finalized.mp3`. Meme avec la chaine TTS complete, la section restait morte — player fantome silencieux, pas une erreur.

**Cell 6 — Step 3** : publie le livrable sous le nom canonique attendu par 04-11 (`shutil.copy2` → `BASE_DIR/audiobook_kokoro.mp3`). L'output propre de 04-12 (`audiobook_final/boule_de_suif_finalized.mp3`) est conserve — c'est lui que la section qualite et le manifest referencent.

**Cell 1** : `import shutil` + prints de chemins en **relatif** (`{TTS_OUTPUT_DIR}` au lieu de `{TTS_OUTPUT_DIR.resolve()}`) — la re-exec exposait un chemin machine (D:\Dev\CoursIA\... → C:\dev\CoursIA-tts-audio\...) dans les outputs committes ; corrige a la source (secrets-hygiene regle 6 cas A), pas scrubbe.

## Validation

- [x] **Re-exec reelle** (kernel declare `python3`, chaine amont reelle 14/14 segments tts_output/) : 10/10 cellules executees, **0 erreur**
- [x] `audiobook_kokoro.mp3` (2.0 MB) cree a la racine — le contrat 04-11 est desormais satisfait
- [x] Qualite honnete : concat 128.9s (2.1 min), 128 kbps, 48 kHz, mono, 14 segments, 13 x 500ms silences, -16 LUFS — sorties reelles, pas de markdown-align (C.4)
- [x] **0 chemin machine** dans les outputs (grep `C:`/`D:` = False) ; sources restituees a leur forme d'origine (list/string par cellule, diff lisible)
- [x] Outputs gitignores (`tts_output/`, `audiobook_final/*.mp3`, `audiobook_*.mp3`) — rien de binaire committe ; `output_analytique/` (non ignore) laisse hors diff (C.3)
- [x] Round-trip JSON byte-identique verifie avant edition ; LF propre, pas de BOM

## Issues

See #10775 (contribution : chaine 04-11/04-12 completement jouable apres merge de #10830 + cette PR ; FishAudio 04-13 hors scope GPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
