### PR TITLE
enrich(ml,#10488): Lab17-Final-Project density 470->870 (DS-STAR capstone)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day7-Production/Lab17-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day7-Production/Lab17-Final-Project.ipynb
@@ -56,7 +56,11 @@
     "tags": []
    },
    "source": [
-    "## 1. Configuration"
+    "## 1. Configuration\n",
+    "\n",
+    "Cette section importe les briques techniques du pipeline DS-STAR : types standards (`pandas`, `numpy`) pour la manipulation de données, structures (`dataclass`, `Enum`) pour faire circuler l'information entre les agents, et surtout le client LLM (`LLMClient` de `utils`) qui sera partagé par les six composants. L'objectif est de n'avoir **qu'une seule instance de LLM** pour tout le pipeline — cela garantit une configuration cohérente (provider, modèle, température) et évite les fuites de connexion.\n",
+    "\n",
+    "Notez le `sys.path.insert(0, '..')` : les modules `config` et `utils` vivent un niveau au-dessus, partagés avec les autres labs de la série Track2-GoogleADK."
    ]
   },
   {
@@ -104,7 +108,7 @@
     "tags": []
    },
    "source": [
-    "Chargement des paramètres de configuration."
+    "Chargement effectif des paramètres via `get_settings()` : cette fonction lit la configuration du provider LLM (clé API, endpoint, modèle actif) depuis l'environnement. L'affichage du provider actif (`openrouter` ici) permet de vérifier instantanément que le bon backend est branché avant de lancer le pipeline — un diagnostic utile quand une exécution échoue silencieusement à cause d'une clé manquante."
    ]
   },
   {
@@ -155,7 +159,16 @@
     "tags": []
    },
    "source": [
-    "## 2. Data Classes"
+    "## 2. Data Classes\n",
+    "\n",
+    "Avant de construire les agents, on définit les **structures de données** qui circulent entre eux. Dans un système multi-agent, la qualité du contrat de données conditionne la robustesse de l'orchestration : chaque composant consomme la sortie du précédent selon un type explicite, ce qui évite les erreurs à l'exécution et facilite le débogage.\n",
+    "\n",
+    "- **`Plan`** capture la décomposition produite par le Planner : les étapes + le raisonnement.\n",
+    "- **`ExecutionResult`** encapsule la sortie de l'Executor : succès, stdout capturé, erreur éventuelle, code exécuté.\n",
+    "- **`FileMetadata`** décrit le fichier analysé (lignes, colonnes, types) — c'est le contexte passé au Planner.\n",
+    "- **`VerificationStatus`** est l'énumération des verdicts du Verifier (`SUCCESS` / `NEEDS_REFINEMENT` / `FAILED`), qui pilote la boucle d'itération du pipeline.\n",
+    "\n",
+    "Ces quatre types forment le **vocabulaire de communication** des agents : un Plan devient du code, qui devient un ExecutionResult, qui devient un verdict, qui décide de recommencer ou non."
    ]
   },
   {
@@ -260,7 +273,9 @@
     "tags": []
    },
    "source": [
-    "Composant FileAnalyzer et pipeline d'orchestration."
+    "**FileAnalyzer** est l'entrée du pipeline : il lit le fichier (CSV ou JSON), en extrait les métadonnées (nombre de lignes, colonnes, types) et produit un *contexte* textuel consommé par tous les agents suivants. Sa méthode `generate_context` est cruciale — c'est elle qui décide de l'information que le Planner et le Coder « verront » du dataset. Un contexte trop paubre entraîne des plans génériques ; un contexte trop riche dilue la question.\n",
+    "\n",
+    "Le composant suivant, le **Planner**, reçoit ce contexte et décompose la question d'analyse en étapes concrètes."
    ]
   },
   {
@@ -308,7 +323,9 @@
     "tags": []
    },
    "source": [
-    "Composant Planner : decomposition du problème en étapes."
+    "**Planner** est le cerveau stratégique du pipeline : il prend la question de l'utilisateur + le contexte du fichier et produit un `Plan` (étapes + raisonnement). Notez le prompt structuré (`REASONING:` / `STEPS:`) et le parsing par expression régulière — c'est une approche fragile (visible dans l'interprétation de la section 6 : si le LLM ne respecte pas le format, l'extraction échoue), mais simple à implémenter. La température basse (0.3) favorise des plans cohérents et reproductibles.\n",
+    "\n",
+    "Le **Coder** reçoit ce plan et génère le code Python correspondant."
    ]
   },
   {
@@ -356,7 +373,9 @@
     "tags": []
    },
    "source": [
-    "Composant Coder : generation de code d'analyse."
+    "**Coder** traduit chaque étape du plan en code Python exécutable. Le prompt demande explicitement un bloc ` ```python ` et une extraction par regex isole le code. Le `DataFrame df` est fourni comme contexte pour que le code généré suppose qu'un `df` existe déjà. La température 0.2 rend la génération presque déterministe — on veut du code fiable, pas de la créativité.\n",
+    "\n",
+    "Ce code est ensuite exécuté en sandbox par l'**Executor**."
    ]
   },
   {
@@ -404,7 +423,9 @@
     "tags": []
    },
    "source": [
-    "Composant Executor : exécution sandbox du code genere."
+    "**Executor** exécute le code généré dans un espace de noms isolé (`namespace` contenant `df`, `pd`, `np`, `print`). La redirection de `sys.stdout` vers un `StringIO` capture la sortie standard pour que le Verifier puisse l'inspecter. Si une exception est levée, elle est attrapée et encapsulée dans `ExecutionResult.error` — le pipeline ne plante jamais, il signale. C'est le pattern « fail-soft » indispensable à un agent autonome.\n",
+    "\n",
+    "Le **Verifier** examine ensuite ce résultat."
    ]
   },
   {
@@ -452,7 +473,9 @@
     "tags": []
    },
    "source": [
-    "Composant Verifier : validation des résultats par le LLM."
+    "**Verifier** est le garde-fou qualitatif : il demande au LLM si le résultat répond à la question (`SUCCESS` ou `NEEDS_REFINEMENT`). Son verdict pilote la boucle d'itération du pipeline — si le résultat est incomplet, le contexte est enrichi de la sortie précédente et une nouvelle itération est tentée (jusqu'à `max_iterations`). Notez que si l'exécution a échoué (`result.success == False`), le Verifier court-circuite et renvoie `FAILED` sans appeler le LLM — une économie d'appels bienvenue.\n",
+    "\n",
+    "Enfin, le **ReportGenerator** synthétise les résultats en un rapport Markdown."
    ]
   },
   {
@@ -500,7 +523,11 @@
     "tags": []
    },
    "source": [
-    "## 4. Pipeline Complet"
+    "## 4. Pipeline Complet\n",
+    "\n",
+    "La classe `DSStarPipeline` est l'**orchestrateur** qui assemble les six composants en une boucle cohérente. C'est le cœur du lab : là où les sections précédentes isolaient chaque agent, cette section montre comment les **composer** — l'apport spécifique d'un projet final par rapport aux labs monocomposant (Lab 10 FileAnalyzer, Lab 11 Planner-Coder).\n",
+    "\n",
+    "La boucle d'itération (`for i in range(self.max_iterations)`) est le mécanisme clé : à chaque tour, Planner → Coder → Executor → Verifier s'enchaînent, et si le Verifier demande un raffinement (`NEEDS_REFINEMENT`), le contexte est enrichi du résultat précédent avant de retenter. C'est l'implémentation concrète du pattern « plan-execute-verify-refine » de la littérature sur les agents (cf. référence DS-STAR)."
    ]
   },
   {
@@ -548,7 +575,11 @@
     "tags": []
    },
    "source": [
-    "## 5. Dataset de Test"
+    "## 5. Dataset de Test\n",
+    "\n",
+    "Pour exercer le pipeline de façon reproductible, on génère un dataset synthétique de ventes (200 lignes, produits A/B/C/D, régions Nord/Sud/Est/Ouest, revenus et unités aléatoires). Le `np.random.seed(42)` garantit que chaque exécution du lab produit le **même** fichier — indispensable pour que les interprétations des sections 6 et 7 (qui commentent les sorties réelles) restent valables d'une exécution à l'autre.\n",
+    "\n",
+    "Ce dataset est volontairement simple (colonnes catégorielles + numériques) : il permet de poser des questions d'agrégation claires (« analyse les ventes par région ») sans complexité de nettoyage de données."
    ]
   },
   {
@@ -612,7 +643,11 @@
     "tags": []
    },
    "source": [
-    "## 6. Exécution du Pipeline"
+    "## 6. Exécution du Pipeline\n",
+    "\n",
+    "On lance maintenant le pipeline complet sur le dataset de test avec `max_iterations=1`. Ce paramètre est volontairement restrictif : il permet d'observer une **exécution unique** et d'étudier ce qui se passe quand le premier essai ne suffit pas — un cas très fréquent avec des agents LLM. L'interprétation qui suit détaille pourquoi le Planner peut produire 0 étape et comment le Verifier réagit à ce cas.\n",
+    "\n",
+    "Pour un comportement plus robuste, l'exercice final proposera d'augmenter `max_iterations` à 2 ou 3 et de comparer les résultats — c'est l'objet du benchmark de la section Exercices."
    ]
   },
   {
@@ -688,7 +723,9 @@
     "tags": []
    },
    "source": [
-    "## 7. Résultats"
+    "## 7. Résultats\n",
+    "\n",
+    "Cette section affiche le rapport final généré par le `ReportGenerator`. C'est ici qu'apparaît le phénomène central d'**hallucination** commenté dans l'interprétation suivante : faute d'accès aux chiffres réels produits par l'Executor, le LLM invente des montants plausibles mais faux. Ce défaut — et sa correction par injection des données réelles — est précisément le sujet du 3ᵉ exercice (`SafeReportGenerator` anti-hallucination)."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook — lane myia-po-2025:CoursIA — prev: LIGHT/guard (c.39 i18n sync)

## Summary

Enrichissement markdown-only du notebook capstone **Lab17-Final-Project** (pipeline DS-STAR complet, Track2-GoogleADK Day7-Production) dans la poche `ML/DataScienceWithAgents` de l'Epic density #10488.

**Densité** : 470 -> 870 chars/code-cell (+85 %).

## Ce qui est enrichi (12 cellules markdown)

- 6 **headers de section** nus (`## 1. Configuration`, `## 2. Data Classes`, `## 4. Pipeline Complet`, `## 5. Dataset de Test`, `## 6. Exécution`, `## 7. Résultats`) -> WHAT + WHY ancré au code réel.
- 5 **transitions composants** one-liner (FileAnalyzer, Planner, Coder, Executor, Verifier) -> rôle + responsabilité + connexion au composant suivant.
- 1 **transition config** (chargement settings) -> diagnostic provider.

Prose spécifique (pas générique) : températures LLM par composant (0.3 Planner, 0.2 Coder, 0.1 Verifier), parsing regex du Planner, contenu du namespace Executor (`df`/`pd`/`np`), `np.random.seed(42)` reproductibilité, sémantique `max_iterations`, phénomène d'hallucination du ReportGenerator (raccord avec le 3e exercice `SafeReportGenerator`).

## Validation

- **nbformat v4** : VALID
- **Code cells byte-identiques** : sha256 guard before/after (17/17 inchangées)
- **0 changement** `execution_count` / `outputs` (grep diff = 0 occurrences)
- **Markdown-only** (C.3 exception) : pas de re-exécution -- les 17 cellules code conservent leurs outputs et execution_count intacts
- **C.1** : aucun `raise NotImplementedError`/`assert False` introduit (markdown uniquement)
- **Diff** : +49/-12, 1 fichier, exclusivement du `source` markdown

## Contexte de la poche

Poche `ML/DataScienceWithAgents` de l'Epic #10488 (8 notebooks sous 600). po-2023 avait livré Lab10 (#10524), Lab11 (#10529), Lab13 (#10556), Lab14 (#10584) puis a pivoté vers Search/CSP (R6 rotation, 2026-08-12). Lab17 (470) et Lab12 (495) restaient les 2 plus sous-denses non-réclamés. L898 sec sur Lab17 (aucune PR density antérieure).

## Anti-regression

Aucune cellule code modifiée, aucune cellule `# Solution` / interprétation supprimée. Les 2 cellules d'interprétation existantes (Exécution pipeline / Rapport LLM) sont laissées intactes et correctement placées après leur code.

See #10488 (l'Epic ratchet reste ouvert -- paliers P1-P4 portent sur ~491 notebooks ; celle-ci est 1 notebook de la poche DataScienceWithAgents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
