### PR TITLE
fix(scripts,#10840): [Text.Encoding]::Latin1 = null en PS 5.1 → GetEncoding(28591) (2 scripts build forks SMT)

### DIFF
--- a/scripts/environment/automata-build-deploy.ps1
+++ b/scripts/environment/automata-build-deploy.ps1
@@ -94,7 +94,7 @@ if (-not (Test-Path $builtDll)) {
 }
 
 # Sanity: confirm the fork core (CharSetSolver) is in the built DLL.
-$bytes = [System.IO.File]::ReadAllText($builtDll, [System.Text.Encoding]::Latin1)
+$bytes = [System.IO.File]::ReadAllText($builtDll, [System.Text.Encoding]::GetEncoding(28591))
 if ($bytes -notmatch "CharSetSolver") {
     Write-Host "WARNING: built Microsoft.Automata.dll lacks CharSetSolver — is the submodule at the fork commit?" -ForegroundColor Yellow
     Write-Host "  Expected commit 4a7b7f0 (MyIntelligenceAgency/Automata, surface &/~ + uncapped witness)." -ForegroundColor Gray

--- a/scripts/environment/z3-build-deploy.ps1
+++ b/scripts/environment/z3-build-deploy.ps1
@@ -94,7 +94,7 @@ if (-not (Test-Path $builtWrapper)) {
 }
 
 # Sanity: confirm the fork feature (CollectionHandling) is in the built DLL.
-$bytes = [System.IO.File]::ReadAllText($builtWrapper, [System.Text.Encoding]::Latin1)
+$bytes = [System.IO.File]::ReadAllText($builtWrapper, [System.Text.Encoding]::GetEncoding(28591))
 if ($bytes -notmatch "CollectionHandling") {
     Write-Host "WARNING: built Z3.Linq.dll lacks CollectionHandling — is the submodule at the fork commit?" -ForegroundColor Yellow
     Write-Host "  Expected commit 096a6383 (MyIntelligenceAgency/Z3.Linq int[][] fork)." -ForegroundColor Gray


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet #10837

## Summary

Fix #10840 — bug reel mesure pendant #10837 (c.1331+145) : `[System.Text.Encoding]::Latin1` est une propriete statique **.NET Core 3.0+** ; en **Windows PowerShell 5.1** (le PowerShell par defaut de Windows) elle retourne **null** → `[System.IO.File]::ReadAllText($dll, $null)` leve `ArgumentNullException` → `$ErrorActionPreference = "Stop"` arrete le script **AVANT la creation de .deploy/**.

**Impact** : les 2 scripts de build des forks SMT (`automata-build-deploy.ps1` L97, `z3-build-deploy.ps1` L97) plantaient a l'etape sanity-check sur Windows — les notebooks Z3 (`10_Witness_Generation_Automata`, `06_Meal_Planner`) ne pouvaient pas etre depleyes via la voie documentee (.ps1). Le jumeau `.sh` n'a pas ce bug (bash).

**Fix** : `[System.Text.Encoding]::GetEncoding(28591)` (ISO-8859-1) — disponible en .NET Framework 4.x (PS 5.1) **et** .NET Core (pwsh). Diff minimal : +2/-2 (1 ligne par script).

## Validation

- [x] **Re-exec reelle post-fix** (binaire reexecute, pas de log invoque) : `automata-build-deploy.ps1` → `CharSetSolver present (fork core OK)` → `.deploy/` cree (Microsoft.Automata.dll 1138 Ko + System.CodeDom.dll 180 Ko) ; `z3-build-deploy.ps1` → `CollectionHandling present` → `.deploy/` cree (4 DLL dont libz3.dll 15.8 Mo). Les 2 scripts se terminent par `=== build complete ===` sans erreur — exactement l'etape qui plantait avant.
- [x] Avant-fix reproduit (constate c.1331+145) : meme commande → `Exception lors de l'appel de ReadAllText : La valeur ne peut pas etre null` a la ligne 97, .deploy/ absent.
- [x] Diff minimal : 2 fichiers, +2/-2 ; LF propres ; pas de changement de comportement hors la ligne sanity-check.

## Diagnostic derive

N/A — pas de sortie de notebook realignee (fix de script d'environnement, hors regles notebook C.4).

## Issues

Closes #10840 (bug resolu entierement — les 2 scripts reexecutes de bout en bout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
