### PR TITLE
enrich(ml,#10488): Lab12-DS-Star-Workshop density 495->908 (DS-STAR workshop)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -50,7 +50,9 @@
     "tags": []
    },
    "source": [
-    "## 1. Configuration"
+    "## 1. Configuration\n",
+    "\n",
+    "Ce workshop assemble le **pipeline DS-STAR complet** (FileAnalyzer -> Planner -> Coder -> Executor -> Verifier) et l'exerce sur un dataset de ventes. La configuration importe les briques standards (`pandas`, `numpy`), les structures de contrat (`dataclass`, `Enum`) et le client LLM partagé (`LLMClient`). Comme dans les labs précédents, le `sys.path.insert` expose les modules `config` et `utils` communs à la série Track2-GoogleADK."
    ]
   },
   {
@@ -98,7 +100,7 @@
     "tags": []
    },
    "source": [
-    "Chargement des paramètres de configuration."
+    "`get_settings()` charge la configuration du provider LLM (clé, endpoint, modèle actif). L'affichage du provider (`openrouter` ici) est un diagnostic rapide : avant de lancer un pipeline multi-agent coûteux en appels, on vérifie que le bon backend est branché."
    ]
   },
   {
@@ -149,7 +151,14 @@
     "tags": []
    },
    "source": [
-    "## 2. Imports des Modules DS-STAR"
+    "## 2. Imports des Modules DS-STAR\n",
+    "\n",
+    "On définit ici les **structures de données** qui circulent entre les agents — le contrat d'interface du pipeline. Comparé au Lab 11 (Planner-Coder isolé), ce workshop enrichit `FileMetadata` d'un champ `sample_data` : le FileAnalyzer collectera désormais un échantillon des 3 premières lignes pour nourrir le contexte du Planner.\n",
+    "\n",
+    "- **`Plan`** : étapes + raisonnement produits par le Planner.\n",
+    "- **`ExecutionResult`** : sortie de l'Executor (succès, stdout, erreur, code).\n",
+    "- **`FileMetadata`** : métadonnées du fichier + `sample_data` (nouveauté du workshop).\n",
+    "- **`VerificationStatus`** : verdict (`SUCCESS` / `NEEDS_REFINEMENT` / `FAILED`) qui pilote la boucle."
    ]
   },
   {
@@ -197,7 +206,11 @@
     "tags": []
    },
    "source": [
-    "## 3. FileAnalyzer Module"
+    "## 3. FileAnalyzer Module\n",
+    "\n",
+    "Le **FileAnalyzer** est l'entrée du pipeline : il lit le fichier, en extrait un contexte riche et le transmet aux agents suivants. Sa richesse conditionne la qualité de toute la chaîne. Cette version est **plus complète** que celle du Lab 10 : pour chaque colonne numérique, elle calcule des statistiques (`min`/`max`/`mean`) et un taux de valeurs manquantes (`missing_pct`), et elle stocke un échantillon de 3 lignes (`sample_data`).\n",
+    "\n",
+    "Le format `.xlsx` (Excel) est désormais supporté en plus du CSV et JSON — d'où l'attribut `SUPPORTED` à 3 entrées. La méthode `generate_context` synthétise ces métadonnées en un texte court (nom, format, taille en KB, 5 premières colonnes) que le Planner et le Coder « verront » du dataset."
    ]
   },
   {
@@ -245,7 +258,15 @@
     "tags": []
    },
    "source": [
-    "## 4. Planner-Coder-Verifier Modules"
+    "## 4. Planner-Coder-Verifier Modules\n",
+    "\n",
+    "Cette section définit les trois agents de raisonnement du pipeline DS-STAR. Ils partagent tous le même client LLM (injecté à la construction) mais utilisent des **températures différentes** selon leur rôle :\n",
+    "\n",
+    "- **Planner** (température 0.3) : décompose la question en étapes — un peu de variabilité   pour explorer des plans, mais assez peu pour rester cohérent.\n",
+    "- **Coder** (température 0.2) : génère du code Python — quasi-déterministe, on veut de la fiabilité.\n",
+    "- **Verifier** (température 0.1) : juge si le résultat répond à la question — le plus   froid possible pour un verdict stable.\n",
+    "\n",
+    "L'**Executor** et le **Verifier** complètent la boucle : exécution sandbox puis validation. Le Verifier court-circuite en `FAILED` sans appeler le LLM si l'exécution a levé une exception — une économie d'appels quand le code ne tourne pas."
    ]
   },
   {
@@ -293,7 +314,9 @@
     "tags": []
    },
    "source": [
-    "Composant Planner et Coder du pipeline DS-Star."
+    "Le **Planner** reçoit le contexte du fichier + la question et produit un `Plan`. Le prompt impose un format structuré (`REASONING:` / `STEPS:` numérotés) que le parseur par regex extrait — approche simple mais fragile, comme le montreront les tests des sections 7 et 8 où le contexte incomplet cause des échecs. La fenêtre de contexte est tronquée à 800 caractères pour rester dans les limites du prompt.\n",
+    "\n",
+    "Le **Coder** traduit ensuite ce plan en code Python."
    ]
   },
   {
@@ -341,7 +364,9 @@
     "tags": []
    },
    "source": [
-    "Composant Coder : generation de code Python par le LLM."
+    "Le **Coder** génère du code Python à partir du plan. Le prompt précise qu'un `DataFrame df` est disponible (l'Executor l'injecte dans son namespace) et demande un bloc ` ```python ` extrait par regex. Notez le fallback : si le LLM ne respecte pas le format de bloc, le Coder renvoie la réponse brute plutôt qu'une chaîne vide — choix qui évite les silences mais peut produire du code non isolé.\n",
+    "\n",
+    "Ce code est exécuté en sandbox par l'**Executor**."
    ]
   },
   {
@@ -389,7 +414,9 @@
     "tags": []
    },
    "source": [
-    "Composant Executor : exécution du code genere dans un sandbox."
+    "L'**Executor** exécute le code généré dans un namespace isolé (`df`, `pd`, `np`, `print`). La redirection de `sys.stdout` vers un `StringIO` capture la sortie standard pour que le Verifier puisse l'inspecter. Toute exception est attrapée et encapsulée dans `ExecutionResult.error` — le pipeline ne plante jamais, il signale (pattern fail-soft indispensable à un agent autonome).\n",
+    "\n",
+    "Le **Verifier** examine ensuite ce résultat."
    ]
   },
   {
@@ -437,7 +464,11 @@
     "tags": []
    },
    "source": [
-    "## 5. DS-STAR Orchestrator Complet"
+    "## 5. DS-STAR Orchestrator Complet\n",
+    "\n",
+    "La classe `DSStarPipeline` assemble les cinq composants en une boucle **Analyze -> Plan -> Code -> Execute -> Verify**. C'est le cœur du workshop : là où les labs précédents isolaient un composant (Lab 10 FileAnalyzer, Lab 11 Planner-Coder), celui-ci montre la **composition** et surtout la **boucle d'itération**.\n",
+    "\n",
+    "Le mécanisme clé : à chaque itération, si le Verifier renvoie `NEEDS_REFINEMENT`, le contexte est enrichi du résultat partiel (`Resultat partiel: ...`) avant de retenter. C'est l'implémentation du pattern « plan-execute-verify-refine » de la littérature. Avec `max_iterations=1` (tests sections 7-8), aucune retente n'est possible — c'est volontaire pour observer les modes d'échec. Le défaut `max_iterations=2` laisse une seconde chance."
    ]
   },
   {
@@ -485,7 +516,11 @@
     "tags": []
    },
    "source": [
-    "## 6. Creation d'un Dataset de Test"
+    "## 6. Creation d'un Dataset de Test\n",
+    "\n",
+    "Dataset synthétique de ventes (150 lignes, produits Widget A/B/Gadget X, régions Nord/Sud/Est/Ouest, revenus et unités aléatoires). Le `np.random.seed(42)` garantit la **reproductibilité** : chaque exécution du workshop produit le même fichier, donc les modes d'échec commentés dans les interprétations des sections 7 et 8 restent stables d'une exécution à l'autre.\n",
+    "\n",
+    "Ce dataset est volontairement simple pour que les questions d'analyse (produit le plus rentable, évolution mensuelle) soient claires — la difficulté du workshop vient de l'agent, pas des données."
    ]
   },
   {
@@ -552,7 +587,9 @@
     "tags": []
    },
    "source": [
-    "## 7. Test du Pipeline DS-STAR"
+    "## 7. Test du Pipeline DS-STAR\n",
+    "\n",
+    "Premier test : question d'agrégation simple (« Quel produit génère le plus de revenu total ? ») avec `max_iterations=1`. L'interprétation suivante détaille un **mode d'échec révélateur** : le code généré tente d'ouvrir `sales.csv` par nom relatif alors que le fichier vit dans un répertoire temporaire — le contexte transmis au Coder ne contient pas le chemin absolu. C'est le genre de bug d'interface entre agents qu'une boucle d'itération avec contexte enrichi pourrait corriger, mais `max_iterations=1` l'interdit."
    ]
   },
   {
@@ -650,7 +687,9 @@
     "tags": []
    },
    "source": [
-    "## 8. Test avec Question Complexe"
+    "## 8. Test avec Question Complexe\n",
+    "\n",
+    "Second test : question d'analyse temporelle (« Montre l'évolution des revenus par mois »). L'interprétation suivante documente un autre mode d'échec typique des agents LLM : une **confusion de nom de colonne** (`revenu` vs `revenue`) dans le code généré. Ce type d'erreur de schéma est fréquent quand le LLM oscille entre conventions FR/EN ou singulier/pluriel — la boucle d'itération est précisément conçue pour le rattraper, à condition que `max_iterations` le permette."
    ]
   },
   {
@@ -737,7 +776,9 @@
     "tags": []
    },
    "source": [
-    "## 9. Nettoyage"
+    "## 9. Nettoyage\n",
+    "\n",
+    "Suppression du répertoire temporaire contenant le dataset de test. Bonne pratique pour les notebooks qui créent des fichiers éphémères : on évite d'encombrer le système de fichiers du runner et on garantit qu'une exécution suivante repart d'un état propre."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook — lane myia-po-2025:CoursIA — prev: MED/notebook (Lab17 #10839, même poche, substance distincte)

## Summary

Enrichissement markdown-only du notebook **Lab12-DS-Star-Workshop** (pipeline DS-STAR workshop, analyse multi-fichiers, Track2-GoogleADK Day5-DS-Star) dans la poche `ML/DataScienceWithAgents` de l'Epic density #10488.

**Densité** : 495 -> 908 chars/code-cell (+83 %).

## Ce qui est enrichi (13 cellules markdown)

- 6 **headers de section** nus (`## 1` à `## 9` couvrant Configuration, Imports, FileAnalyzer, Planner-Coder-Verifier, Orchestrator, Dataset, Tests, Nettoyage) -> WHAT + WHY.
- 5 **transitions composants** one-liner (Planner, Coder, Executor, Verifier, FileAnalyzer) -> rôle + température + connexion au composant suivant.
- 2 **headers de test** (section 7 path-bug, section 8 column-confusion) -> anticipation du mode d'échec documenté dans l'interprétation qui suit.

Prose spécifique (distincte de Lab17 #10839) : FileAnalyzer enrichi (`missing_pct`, stats `min`/`max`/`mean` pour colonnes numériques, `sample_data` head(3), support `.xlsx` en plus de CSV/JSON), températures par agent (0.3 Planner / 0.2 Coder / 0.1 Verifier), namespace Executor, seed 42, et les 2 modes d'échec pédagogiques (path relatif test-7, confusion `revenu`/`revenue` test-8).

## Validation

- **nbformat v4** : VALID
- **Code cells byte-identiques** : sha256 guard before/after (16/16 inchangées)
- **0 changement** `execution_count` / `outputs` (grep diff = 0)
- **Markdown-only** (C.3 exception) : pas de re-exécution
- **C.1** : aucun `raise NotImplementedError`/`assert False` introduit
- **Diff** : +54/-13, 1 fichier, exclusivement du `source` markdown

## Contexte G-VAR-3

Lab12 est le **2ᵉ notebook MED/notebook consécutif** de cette lane (après Lab17 #10839). Autorisé car la substance est **genuinely distincte** : Lab17 était le *capstone* (ReportGenerator + thème hallucination), Lab12 est le *workshop* (FileAnalyzer enrichi + multi-fichiers + 2 modes d'échec différents). Notebooks différents, raisonnement de domaine neuf par notebook — le litmus LIGHT (« générable en série par scan ») ne s'applique pas : chaque prose est ancrée au code réel du notebook spécifique.

## Contexte de la poche

Poche `ML/DataScienceWithAgents` de l'Epic #10488 (8 notebooks sous 600). po-2023 avait livré Lab10/11/13/14 puis pivoté vers Search/CSP. Lab12 et Lab17 (les 2 plus sous-denses) sont désormais tous deux enrichis par cette lane.

See #10488 (l'Epic ratchet reste ouvert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
