### PR TITLE
fix(twin-registry,#10732): _build_blob_history misses merge-introduced blobs (-m)

### DIFF
--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -348,8 +348,17 @@ def _build_blob_history(repo_root: Path) -> tuple[dict, dict]:
     """
     import subprocess
 
+    # ``-m`` : montre le diff des merge commits contre chaque parent. Sans cette
+    # option, ``git log --raw`` supprime les diffs de merge -> un blob dont la
+    # premiere apparition est le RESULTAT d'une resolution de merge (typique des
+    # PRs twin ou un merge ``origin/main`` combine un header-hoist + un fix de
+    # runtime en un nouveau blob unique) est invisible au walker, et la rebaseline
+    # de ce blob echoue sur ``test_audit_shas_exist_in_file_history`` alors que le
+    # sha est un vrai blob git (``git cat-file`` / ``git ls-tree`` le confirment).
+    # ``-m`` reste dans les ancetres de HEAD (determinisme CI/local preserve, cf
+    # note supra sur le rejet de ``--all``) ; le parser deduplique via ``set()``.
     proc = subprocess.run(
-        ["git", "log", "HEAD", "--raw", "--no-renames", "--abbrev=40", "--format="],
+        ["git", "log", "HEAD", "-m", "--raw", "--no-renames", "--abbrev=40", "--format="],
         cwd=repo_root, capture_output=True, text=True,
     )
     path_blobs: dict[str, set[str]] = {}
@@ -908,3 +917,57 @@ def test_update_pair_partial_drift_is_not_noop(tmp_path, monkeypatch):
         "Partial drift (one side content_sha differs) is a real change "
         "and must NOT be flagged as no-op."
     )
+
+
+def test_build_blob_history_sees_merge_introduced_blob(tmp_path):
+    """Regression #10732 : un blob dont la 1re apparition est le RESULTAT d'un
+    merge commit doit etre vu par ``_build_blob_history``.
+
+    Sans ``-m``, ``git log --raw`` supprime les diffs de merge -> le walker ne
+    voit jamais le blob merge-resolved, et ``test_audit_shas_exist_in_file_history``
+    le classe ``fabricated`` (alors que ``git cat-file`` / ``git ls-tree`` le
+    confirment reel). Ce scenario est quotidien sur les PRs twin ou un merge
+    ``origin/main`` combine un header-hoist + un fix de runtime en un nouveau
+    blob. Constructeur : deux branches divergent editent le meme fichier, le
+    merge est resolu en un contenu unique absent des deux parents.
+    """
+    import subprocess
+
+    def _git(*args):
+        return subprocess.run(
+            ["git", *args], cwd=tmp_path, capture_output=True, text=True, check=True,
+        )
+
+    _git("init", "-q")
+    _git("config", "user.email", "t@t"); _git("config", "user.name", "t")
+    _git("config", "commit.gpgsign", "false")
+    (tmp_path / "f.txt").write_text("line1\nline3\n", encoding="utf-8")
+    _git("add", "f.txt"); _git("commit", "-qm", "init")
+    main_branch = _git("symbolic-ref", "--short", "HEAD").stdout.strip()
+    _git("checkout", "-q", "-b", "branch")
+    (tmp_path / "f.txt").write_text("line1\nlineB\nline3\n", encoding="utf-8")
+    _git("commit", "-qam", "branch edit")
+    _git("checkout", "-q", main_branch)
+    # divergence cote main pour forcer un vrai merge a 2 parents
+    (tmp_path / "f.txt").write_text("lineMAIN1\nline3\n", encoding="utf-8")
+    _git("commit", "-qam", "main edit")
+    # le merge produit un conflit (sortie non-zero attendue) -> etat de merge
+    subprocess.run(
+        ["git", "merge", "-q", "--no-ff", "branch"],
+        cwd=tmp_path, capture_output=True, text=True,
+    )
+    # resolution manuelle en un CONTENU UNIQUE absent des deux parents
+    (tmp_path / "f.txt").write_text("lineMAIN1\nlineB\nline3\nMERGED-UNIQUE\n", encoding="utf-8")
+    _git("add", "f.txt"); _git("commit", "-qm", "merge resolved unique")
+    merge_blob = _git("rev-parse", "HEAD:f.txt").stdout.strip()
+    assert len(merge_blob) == 40, "blob SHA attendu (40 hex)"
+
+    path_blobs, _blob_paths = _build_blob_history(tmp_path)
+    assert merge_blob in path_blobs.get("f.txt", set()), (
+        f"le blob merge-introduced {merge_blob[:12]} est invisible au walker "
+        f"(f.txt a eu les blobs {sorted(s[:12] for s in path_blobs.get('f.txt', set()))}). "
+        f"Cause : ``git log --raw`` sans ``-m`` supprime les diffs de merge -> un sha "
+        f"atteste dont la 1re apparition est une resolution de merge est classe "
+        f"``fabricated`` a tort par ``test_audit_shas_exist_in_file_history``."
+    )
+


### PR DESCRIPTION
Grain: MED/ci-fix -- lane myia-po-2026:CoursIA -- prev: MED/deblock #10720/#10725/#10732 (c.54)

See #10732 (App-8 MiniZinc rebaseline blocked by this test bug).

## What — `_build_blob_history` is blind to merge-introduced blobs

`scripts/notebook_tools/tests/test_twin_registry_integrity.py::_build_blob_history` ran `git log HEAD --raw` **without `-m`**. Default `git log --raw` **suppresses merge-commit diffs**, so a blob whose first appearance is the *result* of a merge resolution is invisible to the walker. The attested SHA then gets misclassified `fabricated` by `test_audit_shas_exist_in_file_history` — even though `git cat-file` confirms it is a real blob and `git ls-tree <tip>` matches.

## Root cause (measured firsthand, c.54)

PR #10732 (App-8 MiniZinc header hoist) rebaselined the pair with `csharp_sha: e62f4d4e9c5c`. The twin-parity check confirmed the drift was real and the SHA matched the branch-tip blob. But `Scripts Tests (CPU)` failed:

```
FAILED test_audit_shas_exist_in_file_history
  AssertionError: sha(s) du dernier audit jamais apparu(s) comme blob :
  ["App-8 MiniZinc.csharp_sha = e62f4d4e9c5c (jamais blob d'aucun fichier)"]
```

Tracing the blob introduction:
- `git cat-file -t e62f4d4e9c5c` → `blob` (it exists)
- `git ls-tree <branch-tip> App-8-MiniZinc-Csharp.ipynb` → `e62f4d4e9c5c` (matches the registry)
- `git log --raw -- <file>` (no `-m`) → blob **absent** (only the 5 non-merge-edit blobs visible)
- `git log --raw -m -- <file>` → blob **present** (introduced by merge `067fd9fd7` that combined the header-hoist + a runtime fix)

The blob is correct; the test can't see it. Previous audits passed because their blobs were introduced by non-merge commits.

## Fix — add `-m` (minimal)

`-m` shows merge-commit diffs against each parent. It still walks HEAD ancestors only (the `--all` determinism concern in the existing comment is preserved — CI vs local clone divergence stays avoided). The line parser already dedups via `set()`, so the per-parent raw entries are harmless.

```diff
-        ["git", "log", "HEAD", "--raw", "--no-renames", "--abbrev=40", "--format="],
+        ["git", "log", "HEAD", "-m", "--raw", "--no-renames", "--abbrev=40", "--format="],
```

## Regression test (TDD — fails before, passes after)

`test_build_blob_history_sees_merge_introduced_blob`: constructs a real mini git repo in `tmp_path` where two branches diverge-edit the same file and the merge resolves to content unique to neither parent, then asserts the merge-result blob appears in `path_blobs`.

- **Without `-m`** (original): FAIL — only the 3 parent-side blobs visible; the merge-result blob is missed.
- **With `-m`** (fix): PASS.

## Validation

- Full `test_twin_registry_integrity.py` suite: **30/30 PASS** (29 original + 1 new). No regression — `_build_blob_history` is internal to this test file, blast radius contained.
- **Unblock proof**: re-applied the #10732 App-8 rebaseline on a branch with the fixed test → `test_audit_shas_exist_in_file_history` now PASSES (previously the failure that blocked the rebaseline).

## Cluster-wide impact

This unblocks not just #10732 but **any** twin rebaseline whose current blob was introduced via a merge commit (common on long-lived twin PRs that merge `origin/main` mid-flight). The catch-22 (twin-parity gate blocks the merge on drift; the rebaseline that clears it was blocked by this test bug) is resolved.

## Scope

One file, +64/-1 (1 flag + explanatory comment + 1 regression test). No production code touched. Catalogue byte-identical to main. `git diff --stat`: 1 file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)