### PR TITLE
docs(xplat,#10648): alternative Linux/macOS dans Probas/Infer + SemanticWeb READMEs

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/README.md
+++ b/MyIA.AI.Notebooks/Probas/Infer/README.md
@@ -98,13 +98,22 @@ dotnet tool install -g Microsoft.dotnet-interactive
 dotnet interactive jupyter install
 ```
 
-### 3. Ou utiliser le script PowerShell (recommandé)
+### 3. Ou utiliser le script d'environnement (recommandé)
 
 ```bash
-# Installe dotnet-interactive, papermill et enregistre les kernels :
+# Windows (PowerShell) — installe dotnet-interactive, papermill et enregistre les kernels :
 cd MyIA.AI.Notebooks/Probas/Infer/scripts
 .\setup_environment.ps1
+
+# Linux / macOS (bash) — jumeau du dépôt (même périmètre : dotnet-interactive,
+# papermill, kernels Jupyter) :
+./scripts/environment/setup_environment.sh --auto-fix
 ```
+
+> Le script de série `setup_environment.ps1` est Windows-only. Sur Linux/macOS, le
+> jumeau [`setup_environment.sh`](../../../scripts/environment/setup_environment.sh)
+> couvre le même setup. Guide d'installation complet 3 OS :
+> [`docs/reference/setup-linux-macos.md`](../../../docs/reference/setup-linux-macos.md).
 
 ### 4. Extension VS Code
 

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md
@@ -430,6 +430,7 @@ dotnet interactive jupyter install
 ```bash
 python -m venv venv
 venv\Scripts\activate  # Windows
+source venv/bin/activate  # Linux / macOS
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #10844

## Summary

Résiduel de **#10648** (EPIC #10643, support Linux/macOS — docs & READMEs) : complète le critère d'acceptance 2 « Chaque doc d'install P0 propose les 3 OS (Windows / Linux / macOS) ou référence un doc central ».

**Audit G.9 complet** (signaux Win-only `winget/choco/scoop/Set-ExecutionPolicy/.ps1/C:\` sur `docs/` + `**/README.md`) — **9 fichiers déjà cross-OS vérifiés** (aucun patch) : `scripts/environment/README.md` (tableau paires .ps1/.sh), `scripts/README.md` (section Install paires), `scripts/lean/README.md` (jumeau .sh §278), `Z3-Linq2Z3/README.md` (« ou le .sh »), `Probas/Infer/README.md` §6 Graphviz (choco+brew+apt), `GenAI/Video/README.md` (winget+brew+apt / conda), `SymbolicAI/README.md` + `GenAI/Vibe-Coding/README.md` (lien `setup-linux-macos.md`). **2 corrigés** :

1. **`MyIA.AI.Notebooks/Probas/Infer/README.md`** §3 — `.\setup_environment.ps1` (Windows-only) sans alternative. Fix : jumeau [`setup_environment.sh`](../../../scripts/environment/setup_environment.sh) documenté (même périmètre vérifié : dotnet-interactive + papermill + kernels Jupyter) + lien [`docs/reference/setup-linux-macos.md`](../../../docs/reference/setup-linux-macos.md) (guide central 3 OS).
2. **`MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/README.md`** §2 — `venv\Scripts\activate  # Windows` sans alternative. Fix : `+ source venv/bin/activate  # Linux / macOS`.

## Validation (post-fix, relancée)

- [x] `python scripts/check_docs_links.py --check` : **OK — 0 new broken links (4693 total)** (le gate CI `docs-link-check` tourne sur `**/README.md`)
- [x] Liens relatifs résolus vérifiés (`../../../scripts/...` et `../../../docs/...` depuis `Probas/Infer/`)
- [x] Diff : **2 fichiers, +12/−2** — FR-first (les 2 READMEs sont déjà FR), aucun contenu non lié touché
- [x] CRLF : 0 (LF propre)

## Notes

- Claim po-2025 (13/08, `setup-linux-macos.md`) = **résolu de fait** : le guide central a été livré par #10664 (MERGED 12/08, commit c5cda10459) AVANT le claim. Documenté sur l'issue + `[CLAIMED] paths:` (2 fichiers) posté pour ce grain.
- Grain META (docs) : pool contenu drainé 7 cycles (4 lanes), mes PRs CONTENU en queue (#10837/#10836/#10833/#10830) portent le plancher G-VAR-1 au prochain batch ai-01.

See #10648 (2 fichiers restants patchés — candidate à closure par ai-01 si l'inventaire complet est jugé satisfait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
