### PR TITLE
fix(gametheory,#10725): add stable cell_ids to 3 interp cells (reorder-safe content-loss matching)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/SocialChoice/03-Voting-Methods-Csharp.ipynb
@@ -311,6 +311,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-430df777",
    "metadata": {},
    "source": [
     "### Interprétation : la majorité pairwise est intransitive\n",
@@ -694,6 +695,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-985a0aaa",
    "metadata": {},
    "source": [
     "### Interprétation : la règle de vote choisit le gagnant\n",
@@ -897,6 +899,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-d81e3c82",
    "metadata": {},
    "source": [
     "### Interprétation : liberté, Pareto et cohérence sont incompatibles\n",

--- a/scripts/notebook_tools/twin_pairs.d/socialchoice-3-voting-methods.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/socialchoice-3-voting-methods.yaml
@@ -20,6 +20,12 @@
       csharp_sha: a3ffeb7397f987b9dfce0ea8aee79dae946d3be5
       content_python_sha: 44b742b5f9cb1974b925f64a5b7f8ee3de1ead02a9d9095c857e4d27e620aa36
       content_csharp_sha: 5a5cf03b54274ac7c4440db6cf1662404b96830f97ad5d7db5042ce94982b195
+    - date: "2026-08-14"
+      by: myia-po-2026:CoursIA
+      python_sha: 0b4e212a66f03f2eec2247e17f55db061bd2b247
+      csharp_sha: 61a795b41ff56c9144bfe105d85cd7dc8d05e98f
+      content_python_sha: 44b742b5f9cb1974b925f64a5b7f8ee3de1ead02a9d9095c857e4d27e620aa36
+      content_csharp_sha: def3dcfc2a1df43b5178bd5551c7caab0f09ff8af7a0f9a3681da1ea49bda4bf
   bridge_verdict: RECOVERABLE-LOCAL
   bridge_verdict_reason: "Python = demonstrations riches (44 cellules, classe Profile from-scratch dataclass-like + simulation Arrow + Lady Chatterley/Sen). C# = pur System.* (System / System.Collections.Generic / System.Linq / System.Globalization, 0 NuGet, 29 cellules, implementation compacte presentation tabulaire autour de 10 sections canoniques). Verdict RECOVERABLE-LOCAL : socle pedagogique paritable (theorie du choix social classique : Condorcet 1785, Arrow 1951, Sen 1970, Black/Downs). Meme socle theorique, parite algorithmique sur les regles de vote from-scratch (Plurality/Borda/Condorcet/IRV/Copeland). L'asymetrie reside dans la LEVEE pedagogique -- simulation empirique d'Arrow + contexte litteraire cote Python vs structure tabulaire compacte BCL pure sans viz cote C#. Aucune lib SOTA partagee (numpy vs System.Linq from-scratch). parity_level: semantic preserve."
   known_differences:


### PR DESCRIPTION
## Summary

3 markdown cells in `03-Voting-Methods-Csharp.ipynb` lacked an nbformat `id` (all "Interprétation" cells). The content-loss detector's reorder-safe ID matching (`detect_md_content_loss._compare_cells`, c.8254) requires **all** md cells to carry an id; 3 missing ids forced the whole notebook into index-based matching, so PR #10725's pure cell reorder (5 section-header cells permuted, each preserving id + full source) produced 2 false `TRUNCATED_CELL` findings (ratio 0.724, 0.656) blocking its merge.

Added 3 deterministic `interp-<sha1[:8]>` ids matching the existing scheme for neighbouring interp cells. **Metadata-only**: no source, output, or execution_count touched.

## Proof (empirical, `detect_md_content_loss._compare_cells` on real base/head)

| Mode | TRUNCATED_CELL findings |
|------|-------------------------|
| WITH ids (this fix) | **0** (id multiset equal → ID-mode → each cell matched to itself → ratio 1.0) |
| INDEX-mode (current, no ids) | 2 (the exact FPs on #10725: cell ratio 0.724, 0.656) |

After this lands, rebasing #10725 clears its residual content-loss gate.

## Twin parity

Adding a cell `id` **does** shift the pair's `_content_sha` : cell ids enter the cell-level hash (notebook-level metadata immunity does not cover them, cf `check_twin_parity.py:333`). The pair `SocialChoice-3 Voting-Methods` is registered on main (since 400ce4e3b), so the audit correctly reported `DRIFT_INTRODUCED` (5a5cf03b -> def3dcfc). Re-attested in last commit ec22f8f5d via `--update --pair` (157/157 pairs OK, DRIFT=0 replayed locally). An earlier version of this body argued there was no drift — both premises of that argument were wrong (pair IS on main; immunity is notebook-level only).

## Diff

`+3` lines (one `"id"` per cell, correct key position `cell_type, id, metadata, source`). No other bytes changed (verified byte-canonical round-trip).

Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- See #10725

