### PR TITLE
fix(xplat,#10646): Qwen-Image-Edit cell[3] — replace dead .ps1 ref with cross-OS genai.py auth

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
@@ -140,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 14,
    "id": "244bd967",
    "metadata": {
     "execution": {
@@ -160,14 +160,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": "Toutes les dependances sont disponibles\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": ".env charge depuis: D:\\dev\\CoursIA\\MyIA.AI.Notebooks\\GenAI\\.env\nConfiguration chargee\nAPI: http://127.0.0.1:8188 (LOCAL_MODE=True)\nClient ID: 2a455690-7c04-438b-9ced-499d323663cb\nToken: configuré\n"
+     "name": "stdout",
+     "text": "WARNING: .env non trouve, utilisation variables environnement\nWARNING: COMFYUI_API_TOKEN non trouve - connexion sans authentification\n\nPour activer l'authentification :\n   1. Creez un fichier .env dans MyIA.AI.Notebooks/GenAI/\n   2. Ajoutez : COMFYUI_API_TOKEN=votre_token_ici\n   3. Obtenez le token via : python scripts/genai-stack/genai.py auth init (cross-OS)\n\nLe notebook fonctionnera en mode degrade (si serveur non securise)\n"
     }
    ],
    "source": [
@@ -245,7 +245,7 @@
     "    env_path = current_path / \".env\"\n",
     "    if env_path.exists():\n",
     "        load_dotenv(env_path)\n",
-    "        print(f\".env charge depuis: {env_path}\")\n",
+    "        print(f\".env charge depuis: {env_path.name}\")\n",
     "        env_loaded = True\n",
     "        break\n",
     "    if current_path.name == \"GenAI\" or len(current_path.parts) <= 1:\n",
@@ -270,14 +270,14 @@
     "    print(\"\\nPour activer l'authentification :\")\n",
     "    print(\"   1. Creez un fichier .env dans MyIA.AI.Notebooks/GenAI/\")\n",
     "    print(\"   2. Ajoutez : COMFYUI_API_TOKEN=votre_token_ici\")\n",
-    "    print(\"   3. Obtenez le token via scripts/genai-auth/extract-bearer-tokens.ps1\")\n",
+    "    print(\"   3. Obtenez le token via : python scripts/genai-stack/genai.py auth init (cross-OS)\")\n",
     "    print(\"\\nLe notebook fonctionnera en mode degrade (si serveur non securise)\")\n",
     "    COMFYUI_API_TOKEN = None\n",
     "else:\n",
     "    print(\"Configuration chargee\")\n",
     "    print(f\"API: {API_BASE_URL} (LOCAL_MODE={LOCAL_MODE})\")\n",
     "    print(f\"Client ID: {CLIENT_ID}\")\n",
-    "    print(\"Token: configuré\" if len(COMFYUI_API_TOKEN) > 20 else f\"Token: (court)\")"
+    "    print(\"Token: configure\" if len(COMFYUI_API_TOKEN) > 20 else f\"Token: (court)\")"
    ]
   },
   {


### PR DESCRIPTION
Grain: LIGHT/xplat -- lane myia-po-2025:CoursIA -- prev: MED/twin-rebaseline #10845 (c.48)

## Summary

Correction xplat + fix lien mort dans `01-5-Qwen-Image-Edit.ipynb` cell[3] (config/dépendances), Epic support multiplateforme #10646.

La cellule d'aide référençait `scripts/genai-auth/extract-bearer-tokens.ps1` : (a) **lien mort** — ce dossier n'existe pas sur `origin/main` (`git ls-tree` confirme), (b) **Windows-only** (extension `.ps1`). Remplacé par la **commande cross-OS réelle** `python scripts/genai-stack/genai.py auth init` (le vrai backend d'auth, vérifié dans `commands/auth.py` : sous-commandes `init` / `get-token`, Python cross-OS).

## Changements (cell[3], 3 edits source + re-exec outputs)

1. `Obtenez le token via scripts/genai-auth/extract-bearer-tokens.ps1` -> `Obtenez le token via : python scripts/genai-stack/genai.py auth init (cross-OS)` — fix lien mort + xplat.
2. `print(f".env charge depuis: {env_path}")` -> `{env_path.name}` — corrige un leak de chemin machine (`D:\dev\CoursIA\...`) dans les outputs préexistants.
3. `print("Token: configuré"...)` -> `"Token: configure"` — uniformisation ASCII (cohérence avec le reste du notebook qui évite les accents dans les prints).

## Validation (re-execution réelle)

- **Re-exécution cell[3]** via kernel `mcp-jupyter` (python), status=**ok**. Cellule config-only (imports PIL/requests/matplotlib/numpy/dotenv + chargement `.env`), aucune dépendance serveur ComfyUI.
- **Outputs réels** injectés (le vrai résultat d'exécution) — le message corrigé `genai.py auth init` apparaît dans le stream stdout.
- **nbformat v4** : VALID (30 cells, IDs préservés, source au format list-of-lines original).
- **Diff chirurgical** : +7/-7 (préservation du format source list-multi-lignes de l'original, pas de reformatting whitespace parasite).
- **C.1** : aucun `raise NotImplementedError`/`assert False`/`1/0` introduit.
- **Stop & Repair** : outputs CLEAN (0 leak chemin machine — le `D:\dev\CoursIA` préexistant est éliminé).

## G.1 firsthand — autres cibles #10646 auditées (hors scope)

- `01-3-Basic-Audio-Operations` cell[25] : **déjà xplat** (3 branches OS `winget`/`apt`/`brew` dans les prints) — faux signal grep.
- `SL-12-DifferentiableLogicGateNetworks` cell-16 : **déjà xplat** (`platform.system()` 3 branches) — faux signal.

See #10646 (l'Epic xplat reste ouvert). Grain LIGHT/xplat — G-VAR-2 cap 1 LIGHT/lane/jour respecté (pas de LIGHT livrée ce lane-jour avant celle-ci).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
