### PR TITLE
enrich(rl,#10488): RL-1 cartpole density 550->691 — 5 thin cells WHY (imports/eval/video/conclusion)

### DIFF
--- a/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
+++ b/MyIA.AI.Notebooks/RL/rl_1_intro_cartpole.ipynb
@@ -150,9 +150,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Imports"
-   ]
+   "source": "## Imports\n\nLes imports qui suivent articulent les **trois piliers** d'un script de reinforcement learning sous Stable-Baselines3 : l'environnement (`gymnasium`), l'algorithme (`PPO`) et l'architecture de politique (`MlpPolicy`). Les cellules détaillées ci-après expliquent le rôle de chacun."
   },
   {
    "cell_type": "markdown",
@@ -413,9 +411,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Nous créons une fonction utilitaire pour évaluer l’agent :"
-   ]
+   "source": "Nous créons d'abord **à la main** une fonction utilitaire pour évaluer l'agent :\n\nPourquoi l'écrire soi-même alors que Stable-Baselines3 fournit `evaluate_policy` (utilisé juste après) ? Parce que dérouler explicitement la boucle d'évaluation — `reset`, puis `step` jusqu'à la fin de l'épisode, en cumulant les récompenses sur N épisodes — est le moyen le plus direct de **comprendre ce que mesure la métrique**. La « récompense moyenne sur 100 épisodes » n'est pas un score abstrait : c'est l'espérance empirique du retour cumulé de la politique. Une fois ce mécanisme intériorisé, l'utilitaire de la librairie devient un simple raccourci, plus un mystère."
   },
   {
    "cell_type": "code",
@@ -666,9 +662,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Evaluation de l'agent entraine sur 100 episodes."
-   ]
+   "source": "Évaluation de l'agent entraîné sur 100 épisodes.\n\nL'agent a maintenant vu 10 000 pas d'interaction. **Qu'attendons-nous ?** CartPole-v1 donne +1 par pas où la perche reste dressée, et un épisode dure 500 pas au maximum. Un agent aléatoire plafonnait autour de ~9-10 (cellule précédente) ; un agent correctement entraîné doit approcher le plafond de 500. C'est ce saut — de plusieurs ordres de grandeur — que l'évaluation ci-dessous doit confirmer. Un score qui resterait bas signalerait un budget d'entraînement insuffisant ou des hyperparamètres inadaptés."
   },
   {
    "cell_type": "code",
@@ -953,9 +947,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Visualiser l’agent entraîné\n"
-   ]
+   "source": "### Visualiser l'agent entraîné\n\nLa récompense moyenne est une métrique **quantitative**, mais elle ne dit pas tout. Deux politiques peuvent atteindre un score voisin de 500 avec des comportements très différents : l'une corrige en douceur, l'autre oscille au bord de la chute. Enregistrer une vidéo permet une évaluation **qualitative** du comportement — un diagnostic complémentaire particulièrement utile pour repérer des pathologies (tremblements, stratégies dégénérées) qu'une moyenne masque."
   },
   {
    "cell_type": "code",
@@ -1358,15 +1350,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "Dans ce notebook, nous avons vu :\n",
-    "- comment définir et entraîner un modèle RL à l’aide de Stable Baselines3 (en une seule ligne de code) ;)\n",
-    "\n",
-    "---\n",
-    "**Retour au sommaire** : [Index RL](README.md)\n"
-   ]
+   "source": "## Conclusion\n\nDans ce notebook, nous avons :\n- **instancié** un environnement Gym (`CartPole-v1`) et un agent PPO via Stable-Baselines3 ;\n- **évalué** l'agent avant et après entraînement, en constatant le saut de récompense (~10 → ~430) ;\n- **enregistré une vidéo** pour compléter la métrique quantitative par un diagnostic qualitatif du comportement ;\n- vu le **raccourci monoline** qui crée et entraîne un modèle en une seule expression.\n\n**À retenir** : PPO est un algorithme *on-policy* — il n'apprend que sur des trajectoires générées par sa politique courante, ce qui le rend stable mais éventuellement gourmand en interactions. La frontière entre un agent médiocre et un agent optimal tient souvent à peu de choses (budget de pas, learning rate, réseau de politique) ; les exercices suivants permettent justement de sonder cette sensibilité.\n\nLa suite logique ([RL-2 Wrappers](rl_2_wrappers_sauvegarde_callbacks.ipynb)) aborde les **wrappers** d'environnement ainsi que la sauvegarde et le chargement de modèles — l'outillage nécessaire pour industrialiser l'entraînement au-delà du notebook d'introduction.\n\n---\n**Retour au sommaire** : [Index RL](README.md)"
   }
  ],
  "metadata": {
@@ -1405,7 +1389,7 @@
    "version": "2.6.0"
   },
   "cost": {
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "api_provider": "none",
    "qcc_tokens_est": 0,
    "cpu_min": 4,


### PR DESCRIPTION
Grain: MED/notebook -- lane myia-po-2026:CoursIA

## Summary

Markdown-only density enrichment of `RL/rl_1_intro_cartpole.ipynb` (EPIC #10488). Five thin WHAT-only cells become WHAT+WHY:

| Cell | Before | After (added) |
|------|--------|---------------|
| `54c32632` `## Imports` (bare header) | 10ch | three-pillars framing (env/algo/policy), points to detailed cells |
| `9e198490` "fonction utilitaire" (transition) | 58ch | WHY hand-roll `evaluate` before the lib's `evaluate_policy` (pedagogical transparency of the eval loop) |
| `fe09ec5d` "Evaluation agent entraîné" (transition) | 48ch | pre-eval hypothesis (expect ~10 -> ~500, what a low score would mean) |
| `640999f5` `### Visualiser l'agent` (bare header) | 32ch | WHY qualitative video complements the quantitative reward metric |
| `60eb43d4` `## Conclusion` (incomplete) | 207ch | accurate synthesis + on-policy takeaway + forward link to RL-2 |

**Density:** 550 -> 691 chars/code-cell (+2815 md chars). Complements merged PR #10738 (which enriched the OTHER cells: random-policy + reward-semantics, 484->550). No content overlap.

## Proofs

- **Code cells byte-identical** (20/20: source + `execution_count` + `outputs` all match origin/main) -> markdown-only edit, no re-execution needed (C.3-safe).
- **Content-loss detector:** `findings=0`, md cells 24->24, normalized chars 9537->11949 (pure addition). ID-mode stable.
- **C.1 clean:** no `raise NotImplementedError` / `assert False` / `1/0`.
- **Not a registered twin** -> no parity drift.

## Note on the --stat line count

The `git diff --stat` shows `7 insertions, 23 deletions` — this is the **notebook JSON reserialization artifact** (NotebookEdit collapses multi-element source arrays into single strings), NOT content loss. Verified via: cell count 44->44, code cells byte-identical, normalized markdown chars GREW (+2412). Verify cell count + chars, not `--stat`, for notebook PRs.

See #10488

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>