### PR TITLE
feat(tooling,#10466): random picker 3-urnes pour le choix idle — defait la troncature du pool

### DIFF
--- a/.claude/rules/proactive-coordination.md
+++ b/.claude/rules/proactive-coordination.md
@@ -13,7 +13,27 @@ S'applique à **tous les workers du cluster CoursIA** (po-2023/2024/2025/2026) e
 
 5. **Pool = TOUT l'ouvert, cross-lane, jamais siloté (HARD).** Cette règle **domine 1-4** : le backlog n'est PAS ta « famille » ni ta « lane », c'est **`gh issue list --state open` en entier**. Ta lane (`machine × workspace`) est une étiquette de **reporting**, PAS une frontière de travail. Fil courant épuisé → tu **NE demandes PAS un grain au coordinateur** : `gh issue list --state open`, prends **n'importe quelle issue techniquement exécutable** (autre famille, autre langage, autre lane — **rien n'est « le turf d'un autre »**), pose `[CLAIMED] <#N> — <machine:workspace> <ts>` (anti-double-claim), livre. **Conclure « rien à faire » alors que `gh issue list` renvoie >0 = échec de méthode.** Sur-te-spécialiser = te starver toi-même.
 
-**Filtre `candidate-delivered` (#10466)** : une part du pool ouvert est du travail **déjà livré mais non fermé** (la PR de livraison écrit `See #N` même en cas de résolution complète → GitHub ne ferme pas). Le workflow `candidate-delivered-advisory.yml` pose le label `candidate-delivered` sur ces issues (référencées par une PR **merged** + aucune activité post-merge, EPICs exclus). Au scan de pool, **filtrer** : `gh issue list --state open --search '-label:candidate-delivered'`. Le label **signale**, il ne ferme pas — ai-01 tranche en lecture body (G.9). Ne pas re-piocher une issue `candidate-delivered` sans avoir vérifié firsthand qu'elle est vivante.
+**Filtre `candidate-delivered` (#10466)** : une part du pool ouvert est du travail **déjà livré mais non fermé** (la PR de livraison écrit `See #N` même en cas de résolution complète → GitHub ne ferme pas). Le workflow `candidate-delivered-advisory.yml` pose le label `candidate-delivered` sur ces issues (référencées par une PR **merged** + aucune activité post-merge, EPICs exclus). Le label **signale**, il ne ferme pas — ai-01 tranche en lecture body (G.9). Ne pas re-piocher une issue `candidate-delivered` sans avoir vérifié firsthand qu'elle est vivante.
+
+**Le pool ne se scanne plus à la main — il se TIRE (mandat user 2026-08-14).** `gh issue list` plafonne à **30 résultats**, triés par récence. Mesuré le 2026-08-14 sur un pool de 140 : **89 issues créées dans les 7 derniers jours**, donc un worker qui « scanne le pool » ne voit **rien de plus vieux que ~6 jours** — il repioche mécaniquement dans ce que le coordinateur vient de créer, ce qui referme la boucle de monoculture que [variation-protocol.md](variation-protocol.md) cherche à ouvrir. La troncature ne se corrige pas par plus de vigilance : elle demande un organe.
+
+```bash
+python scripts/pick_idle_grain.py --lane <machine:workspace> --prev-genre <genre du grain précédent>
+```
+
+Le picker fait **une** requête à `--limit 300` (troncature défaite par construction) et tire une poignée de candidats dans **trois urnes**, parce que le pool n'est pas homogène — même mesure : 44 grains unitaires, 29 EPIC/umbrella, 67 `candidate-delivered`.
+
+| Urne | Ce que le tirage rend | Ce que l'agent en fait |
+|---|---|---|
+| **grain** | issue unitaire exécutable | la livrer |
+| **umbrella** | un EPIC | piocher ou **créer un sous-grain dedans** — jamais claim l'EPIC entier |
+| **delivered** | une issue `candidate-delivered` | vérifier firsthand que la PR livrante satisfait l'acceptance → `gh issue close` avec preuve, **sinon retirer le label en disant pourquoi** |
+
+L'urne **umbrella** est ce qui rend la variété atteignable : au 2026-08-14, **aucun** grain unitaire du pool n'avait plus de 30 jours — tout l'ancien (#1453 prover, #1454 training, #2159 Grothendieck, #2874 Knot, #1621 QC, #1206 Z3.Linq) est umbrella. Une urne unique ne l'aurait jamais montré. L'urne **delivered** est ce qui fait *refluer* le compte sans batch-close aveugle (le batch-close endort une série — cf. précédent ICT).
+
+Pondération : trois facteurs doux, tous imprimés à côté du candidat — ancienneté (`1+log2(1+j/7)`), pénalité ×0.25 sur le genre du grain précédent (**G-VAR-3 au tirage** plutôt qu'en HOLD a posteriori), bonus ×2 aux genres CONTENU (**G-VAR-1 au tirage**). Graine = `(lane, heure UTC, reroll)` : deux lanes tirent différemment à la même minute, une même lane retrouve son tirage dans l'heure (idempotent), `--reroll N` redistribue.
+
+**Le picker ne décide pas.** Il propose ; l'agent tranche selon les critères de variété de sa lane, et pose son `[CLAIMED]` (`check_lane_claim.py` avant d'**éditer**, cf [lane-claim-protocol.md](lane-claim-protocol.md)). Un tirage dont aucun candidat ne convient se rejoue (`--reroll`) — il ne justifie **jamais** un `[ASK coordinator]` ni un statut idle.
 
 6. **Variété obligatoire — le tarissement est structurellement interdit (HARD).** Les règles 1-5 interdisent l'idle ; celle-ci interdit la **monotonie**, et pose l'auto-alimentation comme **principe**, pas comme rattrapage du coordinateur. Une lane ne PEUT PAS se tarir : le worker pioche **de lui-même**, **varié**, même si le coordinateur est absent plusieurs cycles.
    - **Substance en plat principal** : chaque cycle, viser un grain d'EPIC de fond (preuve Lean, backtest/training, série notebook, moteur SOTA, sécu/infra).

--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Tirage aleatoire pondere d'une poignee de grains dans le pool d'issues ouvertes.
+
+Pourquoi cet organe existe
+--------------------------
+`gh issue list` plafonne a 30 resultats par defaut, tries par recence. Avec un
+pool de 140 issues dont 89 creees dans les 7 derniers jours, un worker qui
+scanne le pool ne voit **rien de plus vieux que ~6 jours** -- il repioche
+mecaniquement dans ce que le coordinateur vient de creer, ce qui referme la
+boucle de monoculture que `.claude/rules/variation-protocol.md` cherche a
+ouvrir. Le picker defait la troncature par construction (`--limit 300`, une
+seule requete) et rend la selection *aleatoire ponderee* au lieu de
+*recente-d'abord*.
+
+Il **ne decide pas**. Il tire une poignee de candidats et laisse a l'agent le
+choix final selon les criteres de variete de sa lane courante (G-VAR-1/2/3).
+
+Trois urnes, parce que le pool n'est pas homogene
+-------------------------------------------------
+- **grains**    : issues unitaires, directement executables.
+- **umbrella**  : EPIC / conteneurs. Le tirage rend l'EPIC ; l'agent pioche ou
+                  cree un sous-grain dedans. C'est la que vit le DEEP/CONTENU
+                  ancien -- une urne unique ne le montrerait jamais.
+- **delivered** : issues portant `candidate-delivered` (livrees par une PR
+                  mergee mais jamais fermees). Les offrir a chaque tirage est
+                  ce qui fait *refluer* le compte sans batch-close aveugle :
+                  l'agent verifie firsthand (G.9) puis ferme avec preuve, ou
+                  retire le label en disant pourquoi.
+
+Usage
+-----
+    python scripts/pick_idle_grain.py --lane myia-po-2026:CoursIA
+    python scripts/pick_idle_grain.py --lane myia-po-2023:CoursIA-2 --prev-genre guard
+    python scripts/pick_idle_grain.py --lane <l> --reroll 1        # nouveau tirage
+    python scripts/pick_idle_grain.py --lane <l> --check-claims    # + verif claims
+    python scripts/pick_idle_grain.py --lane <l> --json            # sortie machine
+
+Le tirage est **deterministe par (lane, heure UTC, reroll)** : deux lanes
+tirent des candidats differents a la meme minute, et une meme lane qui relance
+dans l'heure retrouve son tirage (idempotent, pas de thrash). `--reroll N`
+decale la graine quand aucun candidat ne convient.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import math
+import random
+import re
+import subprocess
+import sys
+
+REPO = "jsboige/CoursIA"
+
+# Enumeration CLOSE de variation-protocol.md, partitionnee CONTENU / META.
+CONTENU = {
+    "lean", "qc", "training", "genai",
+    "notebook-python", "notebook-dotnet", "research-code",
+}
+META = {"guard", "tooling", "ledger", "docs", "readme", "test", "refactor"}
+
+# Inference de genre : (regex sur titre+labels, genre). Premiere qui matche.
+# Volontairement grossier -- le genre infere est une *aide au tri*, pas un
+# verdict : l'agent pose le vrai tag Grain: lui-meme.
+GENRE_RULES: list[tuple[str, str]] = [
+    (r"\.lean\b|\blean[-_ ]|\blake\b|sorry|mathlib|grothendieck|knot|hashlife|tao\b", "lean"),
+    (r"quantconnect|\bqc[-_ (]|backtest|quantbook|lean-cli|sharpe", "qc"),
+    (r"training|post[- ]?training|\bppo\b|fine[- ]?tun|checkpoint|walk[- ]?forward", "training"),
+    (r"genai|comfyui|diffusion|audiobook|\btts\b|whisper|acestep|voice|image gener", "genai"),
+    (r"\.ipynb|notebook", "notebook-python"),
+    (r"c#|csharp|\.net|dotnet|roslyn|aspire|nuget|semantickernel", "notebook-dotnet"),
+    (r"z3|solveur|solver|automat|opensp|tweety|pymc|infer\.net|prover", "research-code"),
+    (r"workflow|\bci\b|gate\b|guard|gitleaks|check-|advisory", "guard"),
+    (r"script|tooling|organe|cli\b|papermill|render_envs", "tooling"),
+    (r"readme", "readme"),
+    (r"\bdocs?\b|documentation|resync doc|cadrage", "docs"),
+    (r"\btests?\b|pytest|vitest", "test"),
+    (r"ledger|registre|inventaire|catalog", "ledger"),
+    (r"refactor|consolidation|migration", "refactor"),
+]
+
+NOW = dt.datetime.now(dt.timezone.utc)
+
+
+def infer_genre(title: str, labels: list[str]) -> str:
+    hay = (title + " " + " ".join(labels)).lower()
+    for pattern, genre in GENRE_RULES:
+        if re.search(pattern, hay):
+            return genre
+    return "docs"
+
+
+def age_days(created: str) -> int:
+    created_dt = dt.datetime.fromisoformat(created.replace("Z", "+00:00"))
+    return max(0, (NOW - created_dt).days)
+
+
+def fetch_pool() -> list[dict]:
+    """Une seule requete, limite haute -- c'est ce qui defait la troncature."""
+    out = subprocess.run(
+        ["gh", "issue", "list", "--repo", REPO, "--state", "open", "--limit", "300",
+         "--json", "number,title,labels,createdAt,updatedAt"],
+        capture_output=True, text=True, encoding="utf-8", check=True,
+    ).stdout
+    raw = json.loads(out)
+    pool = []
+    for it in raw:
+        labels = [lb["name"] for lb in it.get("labels", [])]
+        title = it["title"]
+        is_umbrella = "EPIC" in labels or title.upper().lstrip("[").startswith("EPIC")
+        pool.append({
+            "number": it["number"],
+            "title": title,
+            "labels": labels,
+            "age": age_days(it["createdAt"]),
+            "genre": infer_genre(title, labels),
+            "klass": (
+                "delivered" if "candidate-delivered" in labels
+                else "umbrella" if is_umbrella
+                else "grain"
+            ),
+        })
+    return pool
+
+
+def weight(item: dict, prev_genre: str | None) -> float:
+    """Trois facteurs, tous doux, tous explicables en une ligne.
+
+    Trop de ponderation reproduirait une monoculture avec des etapes en plus :
+    on se limite a ce que les gates du variation-protocol demandent deja.
+    """
+    # Anciennete : sert "faire refluer doucement" -- la traine est la ou le
+    # compte s'accumule. 6 mois pesent ~4x une issue de la semaine.
+    w = 1.0 + math.log2(1.0 + item["age"] / 7.0)
+    # G-VAR-3 au tirage plutot qu'en HOLD a posteriori.
+    if prev_genre and item["genre"] == prev_genre:
+        w *= 0.25
+    # G-VAR-1 : le plancher exige DEEP/MED **et** CONTENU.
+    if item["genre"] in CONTENU:
+        w *= 2.0
+    return w
+
+
+def draw(items: list[dict], n: int, rng: random.Random, prev_genre: str | None) -> list[dict]:
+    """Tirage pondere sans remise (Efraimidis-Spirakis : cle = u^(1/w))."""
+    if not items:
+        return []
+    keyed = []
+    for it in items:
+        w = weight(it, prev_genre)
+        u = rng.random() or 1e-12
+        keyed.append((u ** (1.0 / w), w, it))
+    keyed.sort(key=lambda t: t[0], reverse=True)
+    picked = []
+    for _, w, it in keyed[:n]:
+        it = dict(it)
+        it["weight"] = round(w, 2)
+        picked.append(it)
+    return picked
+
+
+def check_claims(numbers: list[int]) -> dict[int, str]:
+    """Verif claims sur les seuls candidats tires (N appels, pas 140)."""
+    verdicts = {}
+    for n in numbers:
+        try:
+            r = subprocess.run(
+                [sys.executable, "scripts/check_lane_claim.py", str(n)],
+                capture_output=True, text=True, encoding="utf-8", timeout=60,
+            )
+            head = (r.stdout or r.stderr or "").strip().splitlines()
+            verdicts[n] = head[0][:60] if head else f"exit={r.returncode}"
+        except Exception as exc:  # noqa: BLE001 - diagnostic best-effort
+            verdicts[n] = f"(check indisponible: {type(exc).__name__})"
+    return verdicts
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--lane", required=True, help="machine:workspace, ex. myia-po-2026:CoursIA")
+    ap.add_argument("--prev-genre", default=None,
+                    help="genre du grain precedent de la lane (penalise ce genre au tirage)")
+    ap.add_argument("--grains", type=int, default=4, help="candidats urne 'grain' (defaut 4)")
+    ap.add_argument("--umbrellas", type=int, default=2, help="candidats urne 'umbrella' (defaut 2)")
+    ap.add_argument("--delivered", type=int, default=2, help="candidats urne 'delivered' (defaut 2)")
+    ap.add_argument("--reroll", type=int, default=0, help="decale la graine pour un nouveau tirage")
+    ap.add_argument("--check-claims", action="store_true", help="verifie les claims sur les tires")
+    ap.add_argument("--json", action="store_true", help="sortie machine")
+    args = ap.parse_args()
+
+    pool = fetch_pool()
+    by_class = {k: [it for it in pool if it["klass"] == k]
+                for k in ("grain", "umbrella", "delivered")}
+
+    # Graine : (lane, heure UTC, reroll). Lanes differentes -> tirages
+    # differents ; meme lane dans l'heure -> tirage identique (idempotent).
+    stamp = NOW.strftime("%Y-%m-%dT%H")
+    seed_src = f"{args.lane}|{stamp}|{args.reroll}"
+    seed = int(hashlib.sha256(seed_src.encode()).hexdigest()[:16], 16)
+    rng = random.Random(seed)
+
+    picks = (
+        draw(by_class["grain"], args.grains, rng, args.prev_genre)
+        + draw(by_class["umbrella"], args.umbrellas, rng, args.prev_genre)
+        + draw(by_class["delivered"], args.delivered, rng, None)
+    )
+
+    claims = check_claims([p["number"] for p in picks]) if args.check_claims else {}
+
+    if args.json:
+        print(json.dumps({
+            "lane": args.lane, "seed_src": seed_src,
+            "pool": {k: len(v) for k, v in by_class.items()},
+            "picks": picks, "claims": {str(k): v for k, v in claims.items()},
+        }, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"Pool ouvert : {len(pool)} issues  "
+          f"= {len(by_class['grain'])} grains "
+          f"+ {len(by_class['umbrella'])} umbrella "
+          f"+ {len(by_class['delivered'])} candidate-delivered")
+    print(f"Lane {args.lane} | graine {stamp}"
+          + (f" | reroll {args.reroll}" if args.reroll else "")
+          + (f" | genre precedent penalise : {args.prev_genre}" if args.prev_genre else ""))
+    print()
+    header = f"{'urne':<10} {'issue':<8} {'age':>5}  {'genre':<16} {'p':>5}  titre"
+    print(header)
+    print("-" * len(header))
+    for p in picks:
+        mark = "*" if p["genre"] in CONTENU else " "
+        print(f"{p['klass']:<10} #{p['number']:<7} {p['age']:>4}j  "
+              f"{p['genre']:<15}{mark} {p['weight']:>5}  {p['title'][:62]}")
+        if p["number"] in claims:
+            print(f"{'':>10} {'':>8} {'':>5}  claim: {claims[p['number']]}")
+    print()
+    print("* = genre CONTENU (seul un genre CONTENU en DEEP/MED tient le plancher G-VAR-1).")
+    print("umbrella  -> pioche ou cree un SOUS-grain dedans, ne claim pas l'EPIC entier.")
+    print("delivered -> verifie firsthand que la PR livrante satisfait l'acceptance :")
+    print("             si oui `gh issue close`, sinon retire le label en disant pourquoi.")
+    print("Avant d'EDITER : python scripts/check_lane_claim.py <N>  (lane-claim-protocol).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/coord

## Le problème, mesuré

Mandat user 2026-08-14 : *« les agents ne piochent pas de façon équilibrée dans ces issues qu'ils ne voient sans doute pas dans leur intégralité du fait de la troncature »*.

Vérifié firsthand sur le pool réel du jour (140 issues ouvertes) :

| Classe | N | Nature |
|---|---|---|
| `candidate-delivered` | **67** (48 %) | livrée par une PR mergée, jamais fermée (`See #N`) — dette de comptabilité |
| EPIC / umbrella | **29** | conteneurs, pas des grains |
| **grains unitaires** | **44** | dont **39 ≤ 7 j**, 5 de 8-30 j, **zéro > 30 j** |

**Deux causes, pas une.**

1. `gh issue list` plafonne à **30 résultats**, triés par récence. Avec **89 issues créées dans les 7 derniers jours**, un worker qui « scanne le pool » ne voit littéralement rien de plus vieux que ~6 jours. Il repioche dans ce que le coordinateur vient de créer — la boucle de monoculture se referme sur elle-même.
2. **Il n'y a pas de vieille traîne unitaire à piocher.** Tout l'ancien est *umbrella* : #1453 prover (82 j), #1454 training (82 j), #2159 Grothendieck (72 j), #2874 Knot (62 j), #1621 QC (78 j), #1206 Z3.Linq (89 j), #1028 Audiobook (92 j), #569 masterclass Jared (107 j). Un picker à urne unique ne les aurait **jamais** montrés — il aurait rejoué la monoculture avec un dé.

## L'organe

`scripts/pick_idle_grain.py` — **une** requête `--limit 300` (troncature défaite par construction), puis tirage pondéré sans remise (Efraimidis-Spirakis) dans **trois urnes** :

| Urne | Ce que le tirage rend | Ce que l'agent en fait |
|---|---|---|
| **grain** | issue unitaire exécutable | la livrer |
| **umbrella** | un EPIC | piocher ou **créer un sous-grain dedans** — jamais claim l'EPIC entier |
| **delivered** | une `candidate-delivered` | vérifier firsthand l'acceptance → `gh issue close` avec preuve, **sinon retirer le label en disant pourquoi** |

L'urne *umbrella* est ce qui rend la variété atteignable. L'urne *delivered* est ce qui fait **refluer** le compte sans batch-close aveugle — le batch-close endort une série (précédent ICT : 24 fermetures justifiées item par item, série endormie).

**Pondération** : trois facteurs doux, tous **imprimés** à côté du candidat pour être auditables —
- ancienneté `1 + log2(1 + j/7)` (sert « faire refluer doucement » : la traîne est là où le compte s'accumule) ;
- **×0.25 sur le genre du grain précédent** → G-VAR-3 appliqué **au tirage**, plus en HOLD a posteriori ;
- **×2 sur les genres CONTENU** → G-VAR-1 appliqué **au tirage**, contre la dérive méta mesurée (`scripts/` 3 % → 45 % en six semaines).

**Graine = `(lane, heure UTC, reroll)`** : deux lanes tirent différemment à la même minute (pas de collision par construction), une même lane retrouve son tirage dans l'heure (idempotent, pas de thrash), `--reroll N` redistribue quand aucun candidat ne convient.

**Le picker ne décide pas.** Il propose ; l'agent tranche selon les critères de variété de sa lane, et pose son `[CLAIMED]`. Un tirage qui ne convient pas se rejoue — il ne justifie **jamais** un `[ASK coordinator]` ni un statut idle.

## Vérification

60 tirages simulés (6 lanes × 10 heures) :

```
122/140 issues distinctes surfacées
  grain      43/44 couverts
  umbrella   25/29 couverts
  delivered  54/67 couverts
umbrella la plus tirée : #1203 à 11 %  (aucune monopolisation)
genres : docs 103 · lean 90 · notebook-python 73 · genai 53 · qc 48 · training 26 · guard 21 · notebook-dotnet 21
part CONTENU : 69 %
```

Sortie réelle sur deux lanes à la même minute (tirages bien disjoints, `#1454` — invisible à la troncature — remonté par l'urne umbrella) : voir le commit.

## Portée

- `scripts/pick_idle_grain.py` (nouveau, 1 fichier)
- `.claude/rules/proactive-coordination.md` R5 — le pointeur qui rend l'organe obligatoire au lieu d'optionnel

Pas de régénération de catalogue, pas de notebook touché.

See #10466
