### PR TITLE
enrich(qc,#10488): QC-Py-30 LSTM Training density 565->873 — 10 bare section headers WHY

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
@@ -52,9 +52,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 1. Configuration PyTorch et GPU"
-   ]
+   "source": "## 1. Configuration PyTorch et GPU\n\nCette cellule fixe deux choses d'un coup : l'**environnement d'exécution** (détection CUDA — un entraînement LSTM sur CPU serait des ordres de grandeur trop lent pour 30 epochs) et les **hyperparamètres globaux** (`SEQ_LEN`, `PRED_LEN`, `HIDDEN_DIM`...) qui régissent toute la suite. Les valeurs sont volontairement **modérées** (`BATCH_SIZE=32`, `EPOCHS=30`) pour rester dans une enveloppe thermique acceptable sur un GPU laptop tout en produisant un modèle significatif. Retenir l'articulation : la fenêtre `SEQ_LEN=60` jours (~un trimestre de bourse) est l'horizon sur lequel le LSTM cherche des patterns, et `PRED_LEN=5` jours est ce qu'il prédit."
   },
   {
    "cell_type": "code",
@@ -170,9 +168,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 2. Chargement des données multi-asset (Top 50 SP500)"
-   ]
+   "source": "## 2. Chargement des données multi-asset (Top 50 SP500)\n\nPourquoi un **univers multi-asset** plutôt qu'une seule action ? Prédire AAPL isolément donne un LSTM qui apprend un seul régime de marché ; en confrontant le modèle à ~50 actions simultanément, on l'entraîne à des patterns **génériques** (relations rendement/volatilité, mean-reversion) qui transfèrent mieux à des actifs non vus. On télécharge 11 ans de prix ajustés via `yfinance`, puis on filtre les colonnes trop creuses (introductions récentes) pour ne pas laisser des `NaN` polluer les séquences."
   },
   {
    "cell_type": "code",
@@ -1269,9 +1265,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 6. Entrainement GPU"
-   ]
+   "source": "## 6. Entrainement GPU\n\nCette section assemble les **composants d'entraînement** — `Dataset`/`DataLoader` PyTorch, fonctions de perte, optimiseur — avant de lancer la boucle. Trois choix méritent attention : `HuberLoss` pour la régression (robuste aux outliers, fréquents en finance), `BCELoss` pour la classification directionnelle, et `AdamW` + `CosineAnnealingLR` pour un taux d'apprentissage qui décroît doucement (évite de stagner dans un minimum plat). La perte totale pondère les deux tâches (`loss_reg + 0.5 * loss_cls`) : le modèle apprend simultanément l'ampleur du rendement **et** sa direction."
   },
   {
    "cell_type": "code",
@@ -1601,9 +1595,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 7. Courbes d'apprentissage"
-   ]
+   "source": "## 7. Courbes d'apprentissage\n\nLes courbes de loss sont le **diagnostic premier** d'un entraînement. Trois graphes séparent les régimes : (1) loss totale train vs val — un écart grandissant signale du surapprentissage ; (2) décomposition régression/classification — pour vérifier quelle tâche domine la perte ; (3) accuracy directionnelle vs la baseline 50% (pile-ou-face). En finance, une accuracy de 53-55% sur la direction est déjà un signal exploitable : le marché étant quasi-marché aléatoire à court terme, **tout** ce qui dépasse significativement 50% a de la valeur."
   },
   {
    "cell_type": "code",
@@ -1713,9 +1705,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 8. Evaluation sur le set de test"
-   ]
+   "source": "## 8. Evaluation sur le set de test\n\nL'évaluation sur le set de test (jamais vu à l'entraînement ni à la validation) est le **seul** chiffre à croire. Deux familles de métriques cohabitent : la **régression** (MSE, MAE, corrélation prédit/réel — la corrélation est la plus parlante, un modèle nul donne ~0) et la **classification directionnelle** (accuracy globale + précisions par classe haussier/baissier). Le ratio Up/Down révèle un piège classique : un modèle qui prédit « haussier » partout affiche ~54% d'accuracy globale mais 0% de précision baissière — c'est un modèle **dégénéré**, pas un modèle qui marche."
   },
   {
    "cell_type": "code",
@@ -1824,9 +1814,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 9. Visualisation des predictions"
-   ]
+   "source": "## 9. Visualisation des predictions\n\nAu-delà des métriques chiffrées, deux visualisations confirment (ou infirment) la santé du modèle : un **scatter plot** prédit vs réel (une corrélation forte serrerait les points autour de la diagonale) et l'**histogramme des probabilités prédites** par classe réelle. Si les deux distributions (UP réel vs DOWN réel) se chevauchent fortement autour de 0.5, le modèle ne sépare pas les classes — ses 54% d'accuracy sont alors du bruit, pas du signal."
   },
   {
    "cell_type": "code",
@@ -1917,9 +1905,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 10. Visualisation des poids d'attention"
-   ]
+   "source": "## 10. Visualisation des poids d'attention\n\nL'attention est ici un **gains d'interprétabilité**, pas seulement de performance. Visualiser les poids appris par chaque head répond à la question : *quels jours, dans la fenêtre de 60, le modèle juge-t-il décisifs pour sa prévision ?* On s'attend à ce que certaines heads se concentrent sur les positions récentes (proches de la prédiction), d'autres sur des points plus anciens (un creux de volatilité, une cassure de tendance). Une head dont les poids seraient quasi-uniformes n'a rien appris d'utile — c'est un signe que ce head pourrait être élagué."
   },
   {
    "cell_type": "code",
@@ -2027,9 +2013,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 11. Backtest simplifie du signal"
-   ]
+   "source": "## 11. Backtest simplifie du signal\n\nLe backtest traduit la **prédiction** (une probabilité) en **décision** (investi ou non) puis en **courbe de capital**, la métrique finale d'un système de trading. Le Sharpe ratio rapporte le rendement annualisé à la volatilité — c'est la métrique de référence (un Sharpe > 1 est considéré correct, > 2 excellent). **Lecture critique indispensable** : comparer le Sharpe stratégie au Sharpe Buy & Hold sur la même période. Si les deux coïncident, la stratégie n'a en fait jamais désinvesti (elle a juste reproduit le marché) — le « alpha » est illusoire. Un backtest honnête doit aussi inclure les **coûts de transaction** et vérifier que le MaxDD est dans des bornes réalistes (un drawdown > 100% signale un bug de calcul, pas un résultat de marché)."
   },
   {
    "cell_type": "code",
@@ -2228,9 +2212,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 12. Sauvegarde du modèle"
-   ]
+   "source": "## 12. Sauvegarde du modèle\n\nLa sauvegarde ne se limite pas aux **poids** du réseau : elle embarque aussi le `StandardScaler` (sans lui, l'inférence en production recevrait des features non normalisées), la liste des colonnes et tous les hyperparamètres. C'est ce **paquet autoportant** qui rend le modèle déployable ailleurs (notamment sur QuantConnect Cloud, section suivante) sans reconstruire le pipeline à la main. La traçabilité des métriques de test dans le même fichier permet de vérifier, au chargement, quelles performances étaient attendues."
   },
   {
    "cell_type": "code",
@@ -2347,9 +2329,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 13. Integration QuantConnect Cloud"
-   ]
+   "source": "## 13. Integration QuantConnect Cloud\n\nCette dernière cellule génère le **code de production** — un `QCAlgorithm` complet, prêt à coller dans l'IDE QuantConnect. Le passage du notebook au cloud impose quelques adaptations : univers réduit (top 10 au lieu de 50, pour limiter les appels), rebalancement **hebdomadaire** plutôt que quotidien (réduit les coûts de transaction), et chargement des poids pré-entraînés depuis le Object Store QC. L'architecture du modèle est dupliquée à l'identique (mêmes classes `AttentionHead`/`LSTMWithAttention`) pour garantir la compatibilité du `state_dict`. Ce pont recherche→production est l'aboutissement du notebook : un signal validé hors-ligne, désormais exécutable sur des données live."
   },
   {
    "cell_type": "code",
@@ -2715,7 +2695,7 @@
    "version": "2.7.0"
   },
   "cost": {
-   "api_usd_est": 0.0,
+   "api_usd_est": 0,
    "api_provider": "none",
    "cpu_min": 4,
    "gpu_min": 5,


### PR DESCRIPTION
Grain: MED/notebook -- lane myia-po-2026:CoursIA

## Summary

Markdown-only density enrichment of `QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb` (EPIC #10488). Ten bare `## N. Title` section headers become WHAT+WHY framings, matching the style already present in sections 3/4/5:

| Section | Header | Added framing |
|---|---|---|
| 1 | Configuration PyTorch et GPU | env detection + hyperparam articulation (SEQ_LEN/PRED_LEN meaning) |
| 2 | Chargement multi-asset | WHY multi-asset (generic vs single-regime patterns) + NaN filtering |
| 6 | Entrainement GPU | training components (HuberLoss/BCELoss/AdamW rationale) |
| 7 | Courbes d'apprentissage | loss curves as diagnostic + 53-55% direction = exploitable |
| 8 | Evaluation test set | two metric families + degenerate-model pitfall (Up-only = 0% Down prec) |
| 9 | Visualisation predictions | scatter + histogram overlap interpretation |
| 10 | Poids d'attention | interpretability gain + uniform-weights = prunable head |
| 11 | Backtest simplifie | critical reading: Sharpe==B&H means no alpha, MaxDD>100% = bug |
| 12 | Sauvegarde | self-contained bundle (scaler+cols+hyperparams) for deployability |
| 13 | Integration QC Cloud | research->production bridge (weekly rebalance, Object Store) |

**Density:** 565 -> 873 chars/code-cell (+5845 md chars).

## Proofs

- **Code cells byte-identical** (19/19: source + `execution_count` + `outputs` all match origin/main) -> markdown-only edit, no re-execution needed (C.3-safe).
- **Content-loss detector:** `findings=0`, md cells 31->31, normalized chars 9117->14078 (pure addition). stable=True.
- **C.1 clean:** no `raise NotImplementedError` / `assert False` / `1/0`.
- **Not a registered twin** -> no parity drift.
- **No collision:** 0 open PRs on QC-Py-30.

## Note on the --stat line count

The `git diff --stat` shows `12 insertions, 32 deletions` — this is the **notebook JSON reserialization artifact** (NotebookEdit collapses multi-element source arrays into single strings), NOT content loss. Verified: cell count 50->50, code cells byte-identical, normalized markdown chars GREW (+4961).

## Scope note (out of this PR)

The notebook's committed backtest output is degenerate (Sharpe stratégie == Sharpe B&H because always-invested; MaxDD -104% = broken formula). Section 11's new prose frames how to **read** such a backtest critically rather than masking it — but fixing the backtest logic itself is out of scope for a density PR (separate issue).

See #10488

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>