### PR TITLE
feat(slides,#10762): visuels position:absolute slides 133-134 S3-acculturation

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -2064,6 +2064,9 @@ Un seul paradigme, plusieurs modalités — un modèle peut générer et compren
 - **Audio** : synthèse vocale et transcription (`GenAI/Audio/` — Whisper, Kokoro, XTTS)
 - **Vidéo** : génération et analyse (`GenAI/Video/` — Hunyuan, LTX, AnimateDiff)
 
+<img src="./images/img_102.png" style="position:absolute; top:150px; right:20px; width:240px;" alt="Portraits generes par StyleGAN" />
+<img src="./images/img_103.png" style="position:absolute; top:150px; right:280px; width:240px;" alt="Visages synthetiques" />
+
 ```mermaid
 graph TD
     A[Modèle de fondation multimodal] --> B[Texte]
@@ -2084,6 +2087,11 @@ graph TD
 - Phase retour : le modèle apprend à retirer le bruit pas à pas
 - À partir d'un bruit pur, il reconstruit une image cohérente
 - Diffusion latente : opérer dans un espace compact (moins de calcul)
+
+<img src="./images/img_110.png" style="position:absolute; top:160px; right:20px; width:220px;" alt="Generation par diffusion" />
+<img src="./images/img_111.png" style="position:absolute; top:160px; right:260px; width:220px;" alt="Exemples de resultats" />
+<img src="./images/img_112.png" style="position:absolute; top:270px; right:20px; width:220px;" alt="Diffusion latente" />
+<img src="./images/img_113.png" style="position:absolute; top:270px; right:260px; width:220px;" alt="Conditionnement multimodal" />
 
 ```mermaid
 graph LR

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -2064,8 +2064,8 @@ Un seul paradigme, plusieurs modalités — un modèle peut générer et compren
 - **Audio** : synthèse vocale et transcription (`GenAI/Audio/` — Whisper, Kokoro, XTTS)
 - **Vidéo** : génération et analyse (`GenAI/Video/` — Hunyuan, LTX, AnimateDiff)
 
-<img src="./images/img_102.png" style="position:absolute; top:150px; right:20px; width:240px;" alt="Portraits generes par StyleGAN" />
-<img src="./images/img_103.png" style="position:absolute; top:150px; right:280px; width:240px;" alt="Visages synthetiques" />
+<img src="./images/img_111.png" style="position:absolute; top:150px; right:20px; width:360px;" alt="Architecture CLIP : encodeurs texte et image alignes dans un espace partage" />
+<img src="./images/img_110.png" style="position:absolute; top:380px; right:20px; width:360px;" alt="Paires image-legende : le modele relie chaque image a sa description textuelle" />
 
 ```mermaid
 graph TD
@@ -2088,10 +2088,8 @@ graph TD
 - À partir d'un bruit pur, il reconstruit une image cohérente
 - Diffusion latente : opérer dans un espace compact (moins de calcul)
 
-<img src="./images/img_110.png" style="position:absolute; top:160px; right:20px; width:220px;" alt="Generation par diffusion" />
-<img src="./images/img_111.png" style="position:absolute; top:160px; right:260px; width:220px;" alt="Exemples de resultats" />
-<img src="./images/img_112.png" style="position:absolute; top:270px; right:20px; width:220px;" alt="Diffusion latente" />
-<img src="./images/img_113.png" style="position:absolute; top:270px; right:260px; width:220px;" alt="Conditionnement multimodal" />
+<img src="./images/img_112.png" style="position:absolute; top:150px; right:20px; width:360px;" alt="Processus de diffusion : bruitage progressif puis debruitage inverse" />
+<img src="./images/img_113.png" style="position:absolute; top:380px; right:20px; width:360px;" alt="Architecture latent diffusion : encodeur, U-Net de debruitage dans l'espace latent, decodeur" />
 
 ```mermaid
 graph LR

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -2088,7 +2088,7 @@ graph TD
 - À partir d'un bruit pur, il reconstruit une image cohérente
 - Diffusion latente : opérer dans un espace compact (moins de calcul)
 
-<img src="./images/img_112.png" style="position:absolute; top:150px; right:20px; width:360px;" alt="Processus de diffusion : bruitage progressif puis debruitage inverse" />
+<img src="./images/img_112.png" style="position:absolute; top:150px; right:20px; width:500px;" alt="Processus de diffusion : bruitage progressif puis debruitage inverse" />
 <img src="./images/img_113.png" style="position:absolute; top:380px; right:20px; width:360px;" alt="Architecture latent diffusion : encodeur, U-Net de debruitage dans l'espace latent, decodeur" />
 
 ```mermaid


### PR DESCRIPTION
# Slides S3-acculturation — visuels des slides IA générative multimodale / Modèles de diffusion

Grain: MED/genai — lane myia-po-2026:CoursIA-2 — prev: DEEP/lean #10798

Complément visuel de la livraison #10769 (100% Mermaid) : les images de la table de contenu de #10762, déjà présentes dans `slides/S3-acculturation/images/`, sont affichées sur les 2 slides multimodaux via `position:absolute` — texte existant **inchangé**.

## Scope (post-review #10861)

`slides/S3-acculturation/slides.md` : **2 slides modifiées** (images uniquement, aucun texte touché)

- **Slide « IA générative multimodale »** : `img_111.png` (architecture CLIP) + `img_110.png` (paires image-légende), haut-droit, `width:360px`. `img_102`/`img_103` (portraits GAN) **retirées** — hors sujet multimodalité (elles restent dans la galerie d'images et sur le slide GANs).
- **Slide « Modèles de diffusion »** : `img_112.png` (processus DDPM) + `img_113.png` (architecture Latent Diffusion), haut-droit. `img_112` à `width:500px` (exception : ratio 5.93 — 587×99 px, à 360px le schéma `p_theta(x_{t-1}|x_t)` ne fait que ~61 px de haut ; 500px = 84 px, lisible), `img_113` à `width:360px`. La grille 2×2 antérieure (4 images mal assorties) est remplacée par 2 figures pertinentes.
- Aucun texte existant modifié (contenu mergé de #10769 préservé)
- Catalogue `COURSE_CATALOG.*` : **byte-identique à main** (0 fichier catalogue touché)
- `See #10762` — complément visuel uniquement ; les captations réelles de la stack GenAI restent un follow-up séparé (hors scope)

## Validation

- **Build Slidev SUCCESS** : `node @slidev/cli/bin/slidev.mjs build slides/S3-acculturation/slides.md` — `✓ built`, exit 0 (relancé APRÈS l'ajustement width img_112)
- **QA visuel post-edit (mandat ai-01 : « re-regarde chaque figure apres l'edit »)** — les 4 images sources relues visuellement, alt vérifié contre le contenu réel :
  - `img_111.png` = **architecture CLIP** (encodeurs texte et image alignés dans un espace partagé) → alt conforme
  - `img_110.png` = **paires image/légende** (chaque image reliée à sa description textuelle) → alt conforme
  - `img_112.png` = **processus de diffusion DDPM** (bruitage progressif puis débruitage inverse) → alt conforme
  - `img_113.png` = **architecture Latent Diffusion** (encodeur, U-Net de débruitage dans l'espace latent, décodeur) → alt conforme
- Les 4 images + les 4 alts sont confirmés dans les chunks du build statique (preuve structurelle que les edits sont dans le deck)
- Note QA : l'export PNG de ces 2 slides est quasi blanc (images `position:absolute` lazy-loadées non capturées par `slidev export`) — la QA passe par la lecture directe des images sources, faite ci-dessus
- Le deck ne contenait aucune balise `position:absolute` existante : style propre à cette PR, conforme à la règle de positionnement image des slides (pleine largeur de texte, pas de layout deux-colonnes)
