### PR TITLE
chore(gitignore,#1396): ignorer lib-ikvm/ (sortie ikvmc ~330 MB) dans dotnet-build

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/.gitignore
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/.gitignore
@@ -8,6 +8,8 @@ target/
 tweety-preferences-full-1.30.jar
 # DLL IKVM output (rebuilt by `dotnet build`)
 *.dll
+# IKVM working dir produced at build time (ikvmc output, ~330 MB, never tracked)
+lib-ikvm/
 # Maven shade plugin output (committed JARs live in ../libs/, not here)
 META-INF/
 # Maven local cache + extracted sources (rebuilt by rebuild-5shades.sh / rebuild-causal.sh)


### PR DESCRIPTION
# .gitignore dotnet-build : ignorer `lib-ikvm/` (sortie ikvmc ~330 MB)

Grain: LIGHT/guard — lane myia-po-2026:CoursIA-2 — prev: MED/docs #10861

Comble une lacune recurrente : les builds IKVM de `MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/` produisent un repertoire de travail `lib-ikvm/` (~330 MB, sortie par defaut d'`ikvmc`) qui ressortait en untracked a chaque `dotnet build`.

## Scope

- `MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/.gitignore` : **+2 lignes** (commentaire + pattern `lib-ikvm/`)
- Aucun autre fichier touche. Catalogue byte-identique a main.

## Validation

- `lib-ikvm/` n'a **jamais** ete tracke dans l'index (`git ls-files` = 0 resultat) : l'ignorer est sans effet sur l'historique.
- Le pattern s'ajoute dans le `.gitignore` **local** de dotnet-build, la ou vivent deja `bin/`, `obj/`, `*.dll` et les autres artefacts de build.
- Les POM shade `build-tweety-*-shade.pom.xml` restent **trackes** par design (reproductibilite, cf README dotnet-build) — hors scope de cette PR.

## Anti-regression

- Aucun code de production touche. Nettoyage statut : 12 pom accidentellement supprimes au tri des untracked ont ete **restaures** (`git checkout`) avant cette PR — le diff ne contient que le .gitignore.
