### PR TITLE
fix(tooling): --check-claims du picker renvoyait un usage error, jamais un verdict

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -162,17 +162,56 @@ def draw(items: list[dict], n: int, rng: random.Random, prev_genre: str | None) 
     return picked
 
 
-def check_claims(numbers: list[int]) -> dict[int, str]:
-    """Verif claims sur les seuls candidats tires (N appels, pas 140)."""
+def _summarize_claim(out: str, returncode: int) -> str:
+    """Reduit la sortie de ``check_lane_claim.py`` a un verdict d'une ligne.
+
+    La sortie melange une phrase humaine (uniquement quand c'est bloque) puis
+    un objet JSON. Prendre la premiere ligne telle quelle affichait ``{`` des
+    que le grain etait libre -- soit exactement le cas ou le tirage a besoin
+    d'un verdict lisible. On lit donc le JSON, qui porte les deux cas.
+    """
+    brace = out.find("{")
+    if brace != -1:
+        # ``raw_decode`` et pas ``loads`` : la sortie porte une phrase humaine
+        # APRES l'objet (``CLEAR: no other lane claims #N.``), et ``loads``
+        # echoue sur ce suffixe -- c'est ce qui laissait passer un ``{``.
+        try:
+            data, _ = json.JSONDecoder().raw_decode(out[brace:])
+        except json.JSONDecodeError:
+            data = None
+        if isinstance(data, dict):
+            blocking = data.get("blocking_lanes") or []
+            if blocking:
+                return "BLOQUE par " + ", ".join(blocking)
+            if data.get("my_active_claim"):
+                return "deja claim par cette lane"
+            stale = data.get("stale_claims") or []
+            if stale:
+                return f"libre (claim perime : {', '.join(map(str, stale))})"
+            return "libre"
+    first = out.strip().splitlines()
+    if first:
+        return first[0][:60]
+    return f"exit={returncode}"
+
+
+def check_claims(numbers: list[int], lane: str) -> dict[int, str]:
+    """Verif claims sur les seuls candidats tires (N appels, pas 140).
+
+    ``--lane`` est **requis** par ``check_lane_claim.py`` : sans lui, l'appel
+    sort en erreur d'usage et chaque candidat affichait ``usage: ...`` a la
+    place de son verdict -- un check qui ne peut pas rougir, donc pas un check.
+    """
     verdicts = {}
     for n in numbers:
         try:
             r = subprocess.run(
-                [sys.executable, "scripts/check_lane_claim.py", str(n)],
+                [sys.executable, "scripts/check_lane_claim.py",
+                 "--lane", lane, str(n)],
                 capture_output=True, text=True, encoding="utf-8", timeout=60,
             )
-            head = (r.stdout or r.stderr or "").strip().splitlines()
-            verdicts[n] = head[0][:60] if head else f"exit={r.returncode}"
+            verdicts[n] = _summarize_claim(r.stdout or r.stderr or "",
+                                           r.returncode)
         except Exception as exc:  # noqa: BLE001 - diagnostic best-effort
             verdicts[n] = f"(check indisponible: {type(exc).__name__})"
     return verdicts
@@ -209,7 +248,7 @@ def main() -> int:
         + draw(by_class["delivered"], args.delivered, rng, None)
     )
 
-    claims = check_claims([p["number"] for p in picks]) if args.check_claims else {}
+    claims = check_claims([p["number"] for p in picks], args.lane) if args.check_claims else {}
 
     if args.json:
         print(json.dumps({
@@ -241,7 +280,7 @@ def main() -> int:
     print("umbrella  -> pioche ou cree un SOUS-grain dedans, ne claim pas l'EPIC entier.")
     print("delivered -> verifie firsthand que la PR livrante satisfait l'acceptance :")
     print("             si oui `gh issue close`, sinon retire le label en disant pourquoi.")
-    print("Avant d'EDITER : python scripts/check_lane_claim.py <N>  (lane-claim-protocol).")
+    print("Avant d'EDITER : python scripts/check_lane_claim.py --lane <machine:workspace> <N>")
     return 0
 
 


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/tooling #10864

## Summary

`--check-claims` de `pick_idle_grain.py` (livre hier, #10853) n'a **jamais** renvoye de verdict. Je l'ai decouvert en m'en servant pour provisionner une lane ce matin : les huit candidats tires portaient tous la meme ligne, `claim: usage: check_lane_claim.py [-h] --lane LANE [--from-json FIL`.

Le flag existe pour eviter qu'une lane commence sur un grain deja tenu par une autre — c'est-a-dire pour rougir. Il rendait la meme chaine que le grain soit libre ou bloque. **Un check qui ne peut pas rougir n'est pas un check** ; celui-la avait en plus l'apparence de fonctionner, ce qui est pire qu'un flag absent.

## Trois defauts empiles

| # | Defaut | Effet observe |
|---|---|---|
| 1 | `check_lane_claim.py` exige `--lane` (argument **requis**) ; le picker l'appelait sans | sortie = erreur d'usage, pour tous les candidats |
| 2 | verdict pris comme `stdout.splitlines()[0]`, or la phrase humaine n'est emise **que quand c'est bloque** | un grain libre commencait par le JSON -> colonne `{` |
| 3 | `json.loads` echoue sur le suffixe `CLEAR: no other lane claims #N.` emis **apres** l'objet | fallback silencieux vers `{` |

Le 1 masquait les 2 et 3 : corriger `--lane` seul faisait passer l'affichage de `usage:` a `{`, ce qui est toujours vide d'information. Les trois devaient tomber ensemble.

## Fix

`_summarize_claim()` lit le JSON avec `raw_decode` (tolerant au suffixe) et rend un verdict d'une ligne dans les quatre cas que le reducteur distingue : `BLOQUE par <lane>` / `deja claim par cette lane` / `libre (claim perime : ...)` / `libre`.

## Preuve (firsthand, 8 candidats tires a l'instant)

```
grain      #6724   claim: BLOQUE par myia-po-2025:CoursIA
grain      #10158  claim: libre
grain      #9983   claim: BLOQUE par myia-po-2025:CoursIA-2
grain      #569    claim: libre
umbrella   #9790   claim: BLOQUE par myia-po-2025:CoursIA-2
umbrella   #1453   claim: libre
delivered  #5635   claim: libre
delivered  #5105   claim: BLOQUE par myia-po-2024:CoursIA
```

Les quatre `BLOQUE` sont concordants avec les `[CLAIMED]` lisibles sur les issues correspondantes (verifie sur #6724 : `myia-po-2025:CoursIA`, `2026-08-11 14:56:33 UTC`, commentaire 5254857118).

## Note de variation, que je m'applique a moi-meme

C'est mon **troisieme grain META consecutif** de ce cycle (`MED/tooling #10853`, `MED/docs #10858`, `MED/tooling #10864`, celui-ci). G-VAR-1 n'est donc pas tenu **de mon fait** : le plancher CONTENU du cycle est porte par #10865 (po-2024, QC Cloud) et #10859 (po-2025:CoursIA-2), pas par moi. Le protocole nomme exactement ce cas — c'est un defaut de **provisionnement** cote coordinateur, et je le note ici plutot que de le laisser se lire comme une flotte saine.

La circonstance attenuante est mince mais reelle : ce fix repare un organe que je viens de demander a toute la flotte d'utiliser pour choisir ses grains. Le laisser casse aurait propage un faux « libre » sur des issues tenues — precisement la collision que `lane-claim-protocol` existe pour empecher.

See #10853
