### PR TITLE
fix(interp,#10678): repositionner 5 interps mal ancrees — tranche Probas

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
@@ -1818,51 +1818,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bace8761",
-   "metadata": {
-    "papermill": {
-     "duration": 0.010778,
-     "end_time": "2026-06-22T19:19:37.770615",
-     "exception": false,
-     "start_time": "2026-06-22T19:19:37.759837",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Visualisation : Reward Shaping avec Potentiel\n",
-    "\n",
-    "Le reward shaping ajoute une recompense de guidage F(s, a, s') sans modifier la politique optimale :\n",
-    "\n",
-    "```\n",
-    "                SANS Shaping                     AVEC Shaping (Φ = -distance au but)\n",
-    "                                  \n",
-    "    ┌─────────────────────────┐           ┌─────────────────────────┐\n",
-    "    │                    ★ +1 │           │                    ★ +1 │\n",
-    "    │                         │           │      F=+0.5   F=+1.0    │\n",
-    "    │                    ×-1  │           │         ↘       ↘       │\n",
-    "    │   R=-0.04  R=-0.04      │           │   R'≈0.5  R'≈0.8  ×-1  │\n",
-    "    │      ↓        ↓         │           │      ↓        ↓         │\n",
-    "    │   R=-0.04  R=-0.04      │           │   R'≈0.3  R'≈0.6       │\n",
-    "    │      ↓        ↓         │           │      ↓        ↓         │\n",
-    "    │   R=-0.04  R=-0.04      │           │   R'≈0.1  R'≈0.4       │\n",
-    "    │      ↑                   │           │      ↑                   │\n",
-    "    │   START                  │           │   START                  │\n",
-    "    └─────────────────────────┘           └─────────────────────────┘\n",
-    "    \n",
-    "    Recompense sparse :                    Recompense dense :\n",
-    "    - Longue exploration                   - Gradient vers le but\n",
-    "    - Signaux retardes                     - Apprentissage accelere\n",
-    "```\n",
-    "\n",
-    "**Theoreme de Ng et al.** :\n",
-    "Si F(s, a, s') = γΦ(s') - Φ(s), alors π* est preservee.\n",
-    "\n",
-    "Intuition : Le shaping recompense les \"progres\" sans créer de raccourcis."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "f524c19b",
    "metadata": {
     "papermill": {
@@ -1908,6 +1863,51 @@
     "| Solution exacte requise | Value Itération classique |\n",
     "| Temps de calcul limite | RTDP (anytime) |\n",
     "| Tous les etats importants | Value/Policy Itération |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bace8761",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010778,
+     "end_time": "2026-06-22T19:19:37.770615",
+     "exception": false,
+     "start_time": "2026-06-22T19:19:37.759837",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Visualisation : Reward Shaping avec Potentiel\n",
+    "\n",
+    "Le reward shaping ajoute une recompense de guidage F(s, a, s') sans modifier la politique optimale :\n",
+    "\n",
+    "```\n",
+    "                SANS Shaping                     AVEC Shaping (Φ = -distance au but)\n",
+    "                                  \n",
+    "    ┌─────────────────────────┐           ┌─────────────────────────┐\n",
+    "    │                    ★ +1 │           │                    ★ +1 │\n",
+    "    │                         │           │      F=+0.5   F=+1.0    │\n",
+    "    │                    ×-1  │           │         ↘       ↘       │\n",
+    "    │   R=-0.04  R=-0.04      │           │   R'≈0.5  R'≈0.8  ×-1  │\n",
+    "    │      ↓        ↓         │           │      ↓        ↓         │\n",
+    "    │   R=-0.04  R=-0.04      │           │   R'≈0.3  R'≈0.6       │\n",
+    "    │      ↓        ↓         │           │      ↓        ↓         │\n",
+    "    │   R=-0.04  R=-0.04      │           │   R'≈0.1  R'≈0.4       │\n",
+    "    │      ↑                   │           │      ↑                   │\n",
+    "    │   START                  │           │   START                  │\n",
+    "    └─────────────────────────┘           └─────────────────────────┘\n",
+    "    \n",
+    "    Recompense sparse :                    Recompense dense :\n",
+    "    - Longue exploration                   - Gradient vers le but\n",
+    "    - Signaux retardes                     - Apprentissage accelere\n",
+    "```\n",
+    "\n",
+    "**Theoreme de Ng et al.** :\n",
+    "Si F(s, a, s') = γΦ(s') - Φ(s), alors π* est preservee.\n",
+    "\n",
+    "Intuition : Le shaping recompense les \"progres\" sans créer de raccourcis."
    ]
   },
   {
@@ -4500,6 +4500,47 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ce194610",
+   "metadata": {
+    "papermill": {
+     "duration": 0.026007,
+     "end_time": "2026-06-22T19:19:41.647375",
+     "exception": false,
+     "start_time": "2026-06-22T19:19:41.621368",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation de la maintenance predictive bayesienne\n",
+    "\n",
+    "**Scénario simule :** Observations = [Normal, Anormal, Anormal]\n",
+    "\n",
+    "**Evolution du belief et des decisions :**\n",
+    "\n",
+    "| Pas | Observation | P(Bon) | P(Degrade) | P(Defaillant) | Decision |\n",
+    "|-----|-------------|--------|------------|---------------|----------|\n",
+    "| 1 | Normal | 96% | 4% | 0.2% | Continuer (EU=97) |\n",
+    "| 2 | Anormal | 30% | 53% | 18% | Maintenance (EU=27) |\n",
+    "| 3 | Anormal | 2% | 56% | 42% | Maintenance (EU=23) |\n",
+    "\n",
+    "**Ce que montre Infer.NET :**\n",
+    "- Le moteur calcule automatiquement les posterieurs bayesiens\n",
+    "- La boucle prediction-correction est le coeur des filtres bayesiens (Kalman, particule)\n",
+    "\n",
+    "**Declenchement de la maintenance :**\n",
+    "- L'observation \"Normal\" au pas 1 **renforce** le belief que le système est bon\n",
+    "- Les observations \"Anormal\" aux pas 2-3 **degradent** progressivement le belief\n",
+    "- La decision passe de \"Continuer\" a \"Maintenance\" quand P(Degrade) + P(Defaillant) devient significatif\n",
+    "\n",
+    "**Application industrielle :**\n",
+    "- Ce pattern est utilise en **maintenance predictive** (Industry 4.0)\n",
+    "- Les capteurs IoT fournissent des observations en continu\n",
+    "- Le système decide automatiquement quand intervenir, avant la panne"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "41b5c234",
    "metadata": {
     "papermill": {
@@ -4545,47 +4586,6 @@
     "1. Une observation \"Normal\" renforce P(Bon) (capteur fiable si système ok)\n",
     "2. Deux observations \"Anormal\" font basculer vers P(Degrade) majoritaire\n",
     "3. La decision optimale passe de \"Continuer\" a \"Maintenance\" quand l'incertitude sur l'etat est resolue"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ce194610",
-   "metadata": {
-    "papermill": {
-     "duration": 0.026007,
-     "end_time": "2026-06-22T19:19:41.647375",
-     "exception": false,
-     "start_time": "2026-06-22T19:19:41.621368",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation de la maintenance predictive bayesienne\n",
-    "\n",
-    "**Scénario simule :** Observations = [Normal, Anormal, Anormal]\n",
-    "\n",
-    "**Evolution du belief et des decisions :**\n",
-    "\n",
-    "| Pas | Observation | P(Bon) | P(Degrade) | P(Defaillant) | Decision |\n",
-    "|-----|-------------|--------|------------|---------------|----------|\n",
-    "| 1 | Normal | 96% | 4% | 0.2% | Continuer (EU=97) |\n",
-    "| 2 | Anormal | 30% | 53% | 18% | Maintenance (EU=27) |\n",
-    "| 3 | Anormal | 2% | 56% | 42% | Maintenance (EU=23) |\n",
-    "\n",
-    "**Ce que montre Infer.NET :**\n",
-    "- Le moteur calcule automatiquement les posterieurs bayesiens\n",
-    "- La boucle prediction-correction est le coeur des filtres bayesiens (Kalman, particule)\n",
-    "\n",
-    "**Declenchement de la maintenance :**\n",
-    "- L'observation \"Normal\" au pas 1 **renforce** le belief que le système est bon\n",
-    "- Les observations \"Anormal\" aux pas 2-3 **degradent** progressivement le belief\n",
-    "- La decision passe de \"Continuer\" a \"Maintenance\" quand P(Degrade) + P(Defaillant) devient significatif\n",
-    "\n",
-    "**Application industrielle :**\n",
-    "- Ce pattern est utilise en **maintenance predictive** (Industry 4.0)\n",
-    "- Les capteurs IoT fournissent des observations en continu\n",
-    "- Le système decide automatiquement quand intervenir, avant la panne"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-2-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/PyMC/DecPyMC-2-Utility-Money.ipynb
@@ -355,24 +355,7 @@
     "\n",
     "Le gain moyen empirique **diverge** (croit logarithmiquement avec N) car les gains extremes ($2^{30}$, $2^{40}$...) dominent la somme. En revanche, l'equivalent certain calcul avec $U(x) = \\ln(x)$ **converge rapidement** vers la valeur théorique de ~4 EUR.\n",
     "\n",
-    "> **Lecon** : La fonction d'utilite logarithmique \"compresse\" les gains extremes et restaure la convergence. C'est précisément ce mécanisme qui resout le paradoxe de Saint-Petersbourg."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-6",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006727,
-     "end_time": "2026-06-15T04:28:49.134486+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T04:28:49.127759+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Pourquoi la moyenne ne converge pas\n",
+    "> **Lecon** : La fonction d'utilite logarithmique \"compresse\" les gains extremes et restaure la convergence. C'est précisément ce mécanisme qui resout le paradoxe de Saint-Petersbourg.\n",
     "\n",
     "La moyenne empirique croit lentement (en $\\log_2(n)$) car les gains extremement rares mais astronomiques ($2^{30}$, $2^{40}$...) dominent la somme. Avec l'utilite logarithmique, ces gains extremes sont \"compresses\" et l'esperance reste finie.\n",
     "\n",
@@ -1979,6 +1962,34 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cell-28",
+   "metadata": {
+    "papermill": {
+     "duration": 0.016069,
+     "end_time": "2026-06-15T04:29:17.131428+00:00",
+     "exception": false,
+     "start_time": "2026-06-15T04:29:17.115359+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Inference du profil de risque\n",
+    "\n",
+    "| Élément | Valeur | Interpretation |\n",
+    "|---------|--------|----------------|\n",
+    "| Prior | Beta(2, 2) | Legerement centre autour de 0.5 |\n",
+    "| Données | 3/10 choix risques | Taux observe = 30% |\n",
+    "| Posterior | Beta(5, 9) | E[theta] = 5/14 ~ 0.357 |\n",
+    "| CI 89% | ~[0.18, 0.52] | Incertitude significative |\n",
+    "\n",
+    "Le posterior est **tire vers les données** mais reste influence par le prior. Avec 10 decisions seulement, l'incertitude est importante.\n",
+    "\n",
+    "> **Pour aller plus loin** : Avec plus de decisions observees, le posterior se concentre. On peut aussi modeliser theta comme une fonction de variables explicatives (age, revenus, etc.) via une regression logistique bayesienne."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
    "id": "e6514730",
@@ -2097,34 +2108,6 @@
     "| **Trace plot** | \"hairy caterpillar\" | Les 4 chaînes explorent le même espace |\n",
     "\n",
     "> **Pourquoi verifier ?** Un MCMC mal converge peut donner des résultats trompeurs. Les diagnostics ArviZ sont l'equivalent PyMC des tests de convergence des message passing algorithms d'Infer.NET."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "cell-28",
-   "metadata": {
-    "papermill": {
-     "duration": 0.016069,
-     "end_time": "2026-06-15T04:29:17.131428+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T04:29:17.115359+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Inference du profil de risque\n",
-    "\n",
-    "| Élément | Valeur | Interpretation |\n",
-    "|---------|--------|----------------|\n",
-    "| Prior | Beta(2, 2) | Legerement centre autour de 0.5 |\n",
-    "| Données | 3/10 choix risques | Taux observe = 30% |\n",
-    "| Posterior | Beta(5, 9) | E[theta] = 5/14 ~ 0.357 |\n",
-    "| CI 89% | ~[0.18, 0.52] | Incertitude significative |\n",
-    "\n",
-    "Le posterior est **tire vers les données** mais reste influence par le prior. Avec 10 decisions seulement, l'incertitude est importante.\n",
-    "\n",
-    "> **Pour aller plus loin** : Avec plus de decisions observees, le posterior se concentre. On peut aussi modeliser theta comme une fonction de variables explicatives (age, revenus, etc.) via une regression logistique bayesienne."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
@@ -270,24 +270,7 @@
    "source": [
     "### Lecture du résultat : données sparse pédagogiques\n",
     "\n",
-    "La sortie montre **8 observations** réparties sur 4 utilisateurs et 5 items. Avec 40 % de densité (8/20), c'est une matrice volontairement « remplie » pour l'apprentissage — dans la vraie vie, la densité descend sous 1 %. La structure sparse est précisément ce qui rend la factorisation latente nécessaire : on doit reconstruire les 60 % de notes manquantes à partir des 40 % observées, en exploitant les **corrélations latentes** entre utilisateurs et items."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "42700676",
-   "metadata": {
-    "papermill": {
-     "duration": 0.012401,
-     "end_time": "2026-06-15T03:48:37.036558+00:00",
-     "exception": false,
-     "start_time": "2026-06-15T03:48:37.024157+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interprétation des données\n",
+    "La sortie montre **8 observations** réparties sur 4 utilisateurs et 5 items. Avec 40 % de densité (8/20), c'est une matrice volontairement « remplie » pour l'apprentissage — dans la vraie vie, la densité descend sous 1 %. La structure sparse est précisément ce qui rend la factorisation latente nécessaire : on doit reconstruire les 60 % de notes manquantes à partir des 40 % observées, en exploitant les **corrélations latentes** entre utilisateurs et items.\n",
     "\n",
     "| Statistique | Valeur |\n",
     "|-------------|--------|\n",

--- a/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
@@ -32,7 +32,14 @@
       csharp_sha: 32356c6e35ab1bd843d3f17983a8128e5cb16db0
       content_python_sha: 850aa3d6cf6bf23d4f250a0498c360602ee7971638f6a37b90aaa9b35ed8ebda
       content_csharp_sha: 1abb9c10f86a15c0ac2a15055724b1bbbca37d72c9416fac8e6102af9fc57512
+    - date: "2026-08-14"
+      by: myia-po-2024:CoursIA-2
+      python_sha: dbda0bd86553b7134bab94e17c3f381cd4d581ee
+      csharp_sha: 32356c6e35ab1bd843d3f17983a8128e5cb16db0
+      content_python_sha: 2b2e5901d1b5c7a12438d4ac87305504d1c44406e5af911fc30b647023bd1815
+      content_csharp_sha: 1abb9c10f86a15c0ac2a15055724b1bbbca37d72c9416fac8e6102af9fc57512
   known_differences:
+  - 'Re-baseline 2026-08-14 (myia-po-2024:CoursIA-2, #10876) : SHA Python avance d34f279b -> dbda0bd8 (repositionnement 5 cellules d''interp markdown mal ancrees — tranche Probas, #10678). Markdown-only, aucun code touche, axe de parite semantic (Infer.NET EP + concepts de recommandation) inchange. Drift verifie parite-preserving.'
   - 'Socle pedagogique commun : systemes de recommandation (filtrage collaboratif) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational
     Message Passing, modele compile en code d''inference) ; Python PyMC = echantillonnage MCMC (NUTS/HMC par defaut) + ADVI


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #10875

## Summary

Phase 2 de #10678 (backlog de 39 interps mal positionnees) — tranche **Probas** (3 notebooks, 5 findings).

Restitution de la forme canonique `header -> code -> interp` selon la taxonomie :
- **C1 post-hoc** (interp decrivant l'output, separee de son code par un contenu intercale) : interp descendue juste sous son code —
  `DecInfer-8` (interp RTDP sous le code RTDP, interp maintenance predictive sous le code Belief State), `DecPyMC-2` (interp "Inference du profil de risque" sous son code inference, avant le code Diagnostics + son interp).
- **C2** (deux interps consecutives du meme output) : fusion — `DecPyMC-2` ("Pourquoi la moyenne ne converge pas" -> "Divergence vs convergence"), `PyMC-15` ("Interpretation des donnees" -> "Lecture du resultat : donnees sparse", tableau des stats preserve).

**Markdown-only** (C.3 : aucune re-execution) : 0 `outputs` modifie, 0 `execution_count` touche, aucune cellule code editee. Verification : `check_interp_positioning.py --family Probas` = **0 findings**.

## Validation

- [x] Scanner post-fix : 0 finding Probas (hash-stable, `--report`)
- [x] Diff markdown-only : 118 insertions / 152 suppressions, 0 ligne `outputs`/`execution_count` (grep verifie)
- [x] Aucune cellule code modifiee (C.1/C.2 non sollicites)
- [x] Contenus fusionnes verifies firsthand : aucun contenu unique perdu, titres conserves
- [x] Body via `See #10678` (livraison partielle d'epic — l'epic reste ouverte, gate `check_interp_positioning.py` reste propriete ai-01)

## Residuel

Tranches suivantes a venir (PR separees par famille, G.4) : SymbolicAI (6), Misc (6).
