### PR TITLE
fix(tooling,#10873): subset-ID matching dans detect_md_content_loss — fin des FP reorder (150 notebooks)

### DIFF
--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -423,14 +423,18 @@ def _compare_cells(base_md: list[tuple[int, str | None, str]],
     produirait des faux positifs position-par-position (26 FP observes sur
     10_LocalLlama.ipynb, cite dans l'issue). Retourne les cellules tronquees.
 
-    **c.8254 (reorder-safe matching)** : si base et head exposent un ``cell_id``
-    (attribut nbformat 4.5+ ``id``) **et** que le multiset d'IDs est identique
-    entre les deux versions, on apparie par ID -- un reorder pur qui preserve
-    les IDs (cf. EPIC #10678 Phase 2, ordonner des cellules pour respecter la
-    convention "interp follows the code it interprets") n'est plus confondu
-    avec une perte de contenu. Sinon on retombe sur l'appariement par index
-    (legacy). Cette double politique preservee car le multiset-stable est un
-    signal fort : "la PR a reordonne, sans toucher au contenu" vs "la PR a
+    **c.8254 (reorder-safe matching)** : l'appariement par ``cell_id``
+    (attribut nbformat 4.5+ ``id``) porte sur le **sous-ensemble id-e stable** :
+    les cellules qui exposent un ``id`` sont appariees par ID quand les deux
+    versions ont le **meme ensemble** d'IDs (non vide) ; les cellules **sans
+    id** (le residu) sont appariees par index. Un reorder pur n'est donc plus
+    confondu avec une perte de contenu **meme quand une seule cellule markdown
+    manque d'``id``** (fix #10873) -- l'ancienne politique all-or-nothing
+    basculait le notebook entier en mode index des qu'une cellule etait sans
+    id (150/1017 notebooks exposes, FP #10725). Si les ensembles d'IDs
+    different ou sont vides des deux cotes (substitution, ajout/suppression),
+    on retombe sur l'appariement par index (legacy) : le multiset-stable est
+    un signal fort "la PR a reordonne, sans toucher au contenu" vs "la PR a
     ajoute/supprime une cellule, l'index-parallel n'est pas une hypothese
     sure".
 
@@ -454,25 +458,31 @@ def _compare_cells(base_md: list[tuple[int, str | None, str]],
     if len(base_md) != len(head_md):
         return findings  # compte modifie -> la comparaison fichier suffit
 
-    # c.8254 : choisir la strategie d'appariement (ID si stable, sinon index).
-    base_ids = [cid for _, cid, _ in base_md]
-    head_ids = [cid for _, cid, _ in head_md]
-    ids_available = (
-        all(cid is not None for cid in base_ids)
-        and all(cid is not None for cid in head_ids)
-    )
-    if ids_available and sorted(base_ids) == sorted(head_ids):
-        # Multiset d'IDs identique : on apparie par ID. Un reorder pur (memes
-        # cellules, ordre different) ne produit plus de faux positifs.
-        base_by_id = {cid: (b_idx, b_src) for b_idx, cid, b_src in base_md}
-        # On itere sur head_md (ordre head, donc h_idx = position actuelle de
-        # la cellule dans le notebook modifie, ce que le reviewer veut voir)
-        # et on retrouve le couple (b_idx, b_src) par ID.
-        for h_idx, h_cid, h_src in head_md:
+    # c.8254 + fix #10873 : apparier par ID le sous-ensemble id-e stable
+    # (cellules exposant un ``cell_id``), par index le residu (cellules sans
+    # id). L'ancienne politique all-or-nothing basculait le notebook entier en
+    # mode index des qu'une cellule md etait sans id.
+    base_with_id = [(b_idx, cid, b_src) for b_idx, cid, b_src in base_md if cid is not None]
+    head_with_id = [(h_idx, cid, h_src) for h_idx, cid, h_src in head_md if cid is not None]
+    base_id_set = {cid for _, cid, _ in base_with_id}
+    head_id_set = {cid for _, cid, _ in head_with_id}
+    if base_id_set == head_id_set and base_id_set:
+        # Meme ensemble d'IDs (non vide) : on apparie par ID le sous-ensemble
+        # id-e (iterant sur head, donc h_idx = position actuelle dans le
+        # notebook modifie, ce que le reviewer veut voir), puis par index le
+        # residu sans id (compte identique garanti par le garde de longueur
+        # ci-dessus : len(base_with_id) == len(head_with_id) car les deux
+        # ensembles d'IDs sont egaux et de meme cardinal).
+        base_by_id = {cid: (b_idx, b_src) for b_idx, cid, b_src in base_with_id}
+        for h_idx, h_cid, h_src in head_with_id:
             b_idx, b_src = base_by_id[h_cid]
             _emit_cell_finding(b_idx, b_src, h_idx, h_src, head_cost, findings)
+        base_residue = [t for t in base_md if t[1] is None]
+        head_residue = [t for t in head_md if t[1] is None]
+        for (b_idx, _, b_src), (h_idx, _, h_src) in zip(base_residue, head_residue):
+            _emit_cell_finding(b_idx, b_src, h_idx, h_src, head_cost, findings)
     else:
-        # Pas d'IDs exploitables : appariement par index (legacy).
+        # IDs absents ou ensembles differents : appariement par index (legacy).
         for (b_idx, _, b_src), (h_idx, _, h_src) in zip(base_md, head_md):
             _emit_cell_finding(b_idx, b_src, h_idx, h_src, head_cost, findings)
     return findings

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -145,6 +145,12 @@ class TestReorderSafeByCellID:
     par index croisait des cellules differentes apres decalage). Le multiset
     d'IDs identique est un signal fort "reorder sans modif de contenu" et
     merite appariement par ID, pas par index.
+
+    Fix #10873 : l'appariement par ID porte sur le **sous-ensemble id-e stable**
+    (cellules exposant un ``id``) ; les cellules sans id (residu) restent
+    appariees par index. L'ancienne politique all-or-nothing basculait le
+    notebook entier en mode index des qu'une cellule md etait sans id
+    (150/1017 notebooks exposes, FP #10725).
     """
 
     def test_reorder_with_stable_ids_no_signal(self):
@@ -184,6 +190,46 @@ class TestReorderSafeByCellID:
         assert findings[0]["kind"] == "TRUNCATED_CELL"
         assert findings[0]["cell_idx"] == 1  # position dans le head
 
+    def test_reorder_with_single_missing_id_no_signal(self):
+        # #10873 : une SEULE cellule md sans id (residu) ne doit plus basculer
+        # le notebook entier en mode index. L'ancienne politique all-or-nothing
+        # (`ids_available` exigeait que TOUTES les cellules aient un id)
+        # retombait en index : la position 0 pairerait la LONGUE cellule A
+        # (base) avec la COURTE cellule B (head, remontee en tete par le
+        # reorder) -> faux positif TRUNCATED_CELL. Le fix apparie le
+        # sous-ensemble id-e (alpha, charlie) par id et le residu (b, sans
+        # id) par index -> 0 finding.
+        a = "## Section A\n\n" + ("Phrase A substantielle. " * 30)   # ~730c normalises
+        b = "## Bref rappel\n\n" + ("Rappel bref. " * 6)             # ~90c, sans id
+        c = "## Section C\n\n" + ("Phrase C substantielle. " * 30)   # ~730c
+        base = _nb(_md(a, cell_id="alpha"),
+                   _md(b),                     # residu sans id
+                   _md(c, cell_id="charlie"))
+        head = _nb(_md(b),                     # reorder pur : B remonte en tete
+                   _md(a, cell_id="alpha"),
+                   _md(c, cell_id="charlie"))
+        findings = dml._compare_cells(dml.extract_md_cells(base),
+                                      dml.extract_md_cells(head))
+        assert findings == [], (
+            "un reorder pur avec 1 cellule md sans id ne doit PAS signaler "
+            f"(trouve: {findings!r})"
+        )
+
+    def test_partial_id_truncation_still_signals(self):
+        # #10873 : le sous-ensemble id-e est apparie par id, mais une vraie
+        # troncature sur une cellule id-e doit continuer a signaler (le fix
+        # n'est pas un blanc-seing pour la cellule id-e elle-meme).
+        body_long = "## Section\n\n" + ("Phrase substantielle. " * 30)
+        base = _nb(_md(body_long, cell_id="alpha"),
+                   _md(body_long))                # residu sans id
+        head = _nb(_md("> **Titre :**", cell_id="alpha"),  # alpha reellement tronquee
+                   _md(body_long))
+        findings = dml._compare_cells(dml.extract_md_cells(base),
+                                      dml.extract_md_cells(head))
+        assert len(findings) == 1
+        assert findings[0]["kind"] == "TRUNCATED_CELL"
+        assert findings[0]["cell_idx"] == 0  # position dans le head
+
     def test_reorder_without_ids_falls_back_to_index_legacy(self):
         # Si les cellules n'ont PAS d'IDs (legacy nbformat < 4.5 ou ecriture
         # a la main), on retombe sur l'appariement par index et le reorder
@@ -205,19 +251,21 @@ class TestReorderSafeByCellID:
         # AssertionError, juste constatation.
         assert isinstance(findings, list)
 
-    def test_partial_id_overlap_falls_back_to_index(self):
-        # Si seulement certaines cellules ont un id (cas mixte), on NE PEUT
-        # PAS se rabattre sur l'appariement par ID (multiset pas comparable) :
-        # on retombe sur l'index legacy. Ce test documente la politique
-        # conservative : mieux vaut un FP qu'un blanc-seing.
+    def test_partial_ids_use_subset_matching(self):
+        # #10873 : si seulement certaines cellules ont un id (cas mixte),
+        # l'appariement par ID porte sur le sous-ensemble id-e (alpha),
+        # l'index sur le residu sans id. Notebooks identiques -> 0 finding
+        # (l'ancienne politique all-or-nothing retombait en mode index).
         body_long = "## Section\n\n" + ("Phrase. " * 25)
         base = _nb(_md(body_long, cell_id="alpha"), _md(body_long))
         head = _nb(_md(body_long, cell_id="alpha"), _md(body_long))
         # IDs partiels : alpha en base[0] et head[0], mais base[1]/head[1] = None.
         findings = dml._compare_cells(dml.extract_md_cells(base),
                                       dml.extract_md_cells(head))
-        # Pas d'assertion stricte : on documente qu'on ne casse pas en mode mixte.
-        assert isinstance(findings, list)
+        assert findings == [], (
+            "un notebook mixte identique ne doit PAS signaler avec le subset "
+            f"matching (trouve: {findings!r})"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #10882

## Summary

See #10873 — remede **B** : `_compare_cells` apparie par `cell_id` le sous-ensemble id-e stable, par index le residu sans id.

**Bug** : l'ancienne politique all-or-nothing (`ids_available` = toutes les cellules md DOIVENT avoir un id, sinon notebook entier en mode index) exposait 150/1017 notebooks (14.7 %, pire cas QC-Py-07-Futures-Forex 57/57 sans id) a des faux positifs TRUNCATED_CELL sur tout reorder de cellules md — FP #10725. Une seule cellule sans id neutralisait l'appariement par ID pour tout le notebook.

**Fix** (`scripts/notebook_tools/detect_md_content_loss.py`) :
- Partition base/head en sous-ensemble **id-e** (cellules exposant un `cell_id`) + **residu** (sans id).
- Si les ensembles d'IDs sont **egaux et non vides** : appariement par ID du sous-ensemble id-e (h_idx = position head, ce que le reviewer voit) + appariement par index du residu (compte identique garanti par le garde de longueur).
- Ensembles d'IDs differents ou vides des deux cotes (substitution, ajout/suppression) : legacy index preserve (pas de blanc-seing, multiset-stable reste le signal "reorder").

**Complementarite** : disjoint de #10848 (remede A etroit, cell_ids sur 3 cellules de Voting-Methods-Csharp — fichiers notebook vs script). Les deux se cumulent : A re-repare les notebooks blesses, B blinde le detecteur pour tous.

## Validation

- [x] **Test de non-regression** (`test_reorder_with_single_missing_id_no_signal`) : reorder pur avec 1 cellule md sans id -> 0 finding. **Verifie contre l'ancien code** (`git show origin/main:...`) : echoue avec le FP exact #10873 (TRUNCATED_CELL, cell_idx 0, ratio 0.119 — longue A vs courte B croisees par l'index) — le test discrimine reellement.
- [x] `test_partial_ids_use_subset_matching` renforce (was `test_partial_id_overlap_falls_back_to_index`, assertion faible) : notebook mixte identique -> `findings == []`.
- [x] `test_partial_id_truncation_still_signals` (nouveau) : une vraie troncature sur une cellule id-e continue de signaler (le fix n'est pas un blanc-seing).
- [x] Suite detecteur : **44 passed** (42 baseline + 2 nouveaux) ; gate-guard : **6 passed** ; `py_compile` OK.
- [x] Scope : 2 fichiers, +89/−31, 0 notebook touche, aucun changement de signature (`_compare_cells`/`extract_md_cells` inchanges).
- [x] ~~`Closes #10873` : l'issue est entierement resolue par ce remede B~~ → **`See #10873`** (requalifie par ai-01, c.96). Mesure firsthand contre les 4 PR bloquees : **#10723 4→0** et **#10725 2→0** debloquees ; **#10785 1→1** et **#10810 2→2** inchangees, parce qu'elles ont **0/52** et **0/50** cellules md avec id — le garde de non-vacuite (`and base_id_set`, correct par ailleurs) laisse la classe zero-id en appariement legacy. Remede B = 2/4 ; le complement zero-id (court-circuit multiset, point 6 de l'acceptance) reste a livrer, donc #10873 reste ouverte. Detail : commentaire ai-01 du 2026-08-14.

