### PR TITLE
fix(interp,#10678): hmm_alpha cell#23 interp États cachés → après cell#21 (plot decoded states)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb
@@ -898,25 +898,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "699a91db",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006147,
-     "end_time": "2026-07-31T20:23:15.057223",
-     "exception": false,
-     "start_time": "2026-07-31T20:23:15.051076",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Visualisation de la performance\n",
-    "\n",
-    "Comparaison graphique des rendements cumules entre la stratégie HMM et le buy-and-hold."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "6d1b978a",
    "metadata": {
     "papermill": {
@@ -941,6 +922,25 @@
     "La **matrice de transition** indique la persistance de chaque régime : des probabilités diagonales élevées (proches de 1) signifient que les régimes sont stables, ce qui est desirable pour la génération de signaux. Des régimes trop volatils (transitions frequentes) produisent trop de trades.\n",
     "\n",
     "> **Note technique** : L'assignation état 0 = bull et état 1 = bear n'est pas garantie -- l'algorithme EM peut inverser les labels. Il faut toujours verifier les moyennes pour identifier l'état \"long\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "699a91db",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006147,
+     "end_time": "2026-07-31T20:23:15.057223",
+     "exception": false,
+     "start_time": "2026-07-31T20:23:15.051076",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Visualisation de la performance\n",
+    "\n",
+    "Comparaison graphique des rendements cumules entre la stratégie HMM et le buy-and-hold."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-dotnet #10846

## Résumé

See #10678 (partition v2, issuecomment-5290564224) — repositionnement de l'interp mal ancrée dans `hmm_alpha_research.ipynb` :

- **cell#23 « Interprétation : États cachés du HMM a 2 états »** était séparée de son code par le header « Visualisation de la performance » (cell#22), et coiffait la section 5 (le scanner `check_interp_positioning.py` la flaggait `misplaced_before_section`).
- **Fix : swap cellules 22 ↔ 23.** L'interp suit maintenant immédiatement la cellule de code cell#21 (`# Plot decoded states over BTC price` — scatter des 2 états sur BTC-USD) dont elle commente l'output ; le header « Visualisation de la performance » (dont le code est cell#31 en section 5) passe après l'interp.

## Validation

- `check_interp_positioning.py --report` : **findings total : 0** (avant : 1 `misplaced_before_section`).
- Multiset byte-identique : 65/65 cellules source identiques (ordre seul changé).
- Diff minimal : +20/−20 lignes (swap pur des 2 blocs).
- 0 CRLF (LF-only), UTF-8 no BOM.
- Notebook markdown-only : aucune cellule code modifiée, outputs intacts (C.3 exception markdown-only), H.3 passé.

## Tests

- Pre-commit H.3 : Passed.
- Detector interp positioning : findings=0.
