### PR TITLE
fix(interp,#10678): App-14-ConnectFour move synthesis interp after tournament

### DIFF
--- a/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
+++ b/MyIA.AI.Notebooks/Search/Applications/Search/App-14-ConnectFour-Adversarial.ipynb
@@ -1805,36 +1805,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "interpretation-section",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005967,
-     "end_time": "2026-04-25T15:33:49.123755",
-     "exception": false,
-     "start_time": "2026-04-25T15:33:49.117788",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interprétation des résultats\n",
-    "\n",
-    "| Algorithme | Points forts | Points faibles | Usage recommande |\n",
-    "|------------|--------------|----------------|------------------|\n",
-    "| **Minimax** | Simple, optimal | Explosion combinatoire | Petits jeux, enseignement |\n",
-    "| **Alpha-Beta** | efficace, optimal | Ordonnancement critique | Jeux a branchement moyen |\n",
-    "| **MCTS** | Pas d'heuristique, parallèle | probabiliste | grands espaces, jeux complexes |\n",
-    "\n",
-    "**observations cles** :\n",
-    "\n",
-    "1. **Alpha-Beta** réduit drastiquement le nombre de noeuds (facteur 5-20x selon la profondeur)\n",
-    "2. **L'ordonnancement** des coups est crucial pour maximiser l'elagage\n",
-    "3. **MCTS** converge vers de bons coups sans fonction d'évaluation explicite\n",
-    "4. Pour un temps donne, Alpha-Beta profond bat souvent MCTS sur Connect Four"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "tournament-section",
    "metadata": {
     "papermill": {
@@ -2235,6 +2205,36 @@
     "\n",
     "> **Note** : Avec seulement 6 parties par match, les résultats peuvent varier.\n",
     "> Pour une évaluation robuste, utiliser 50+ parties."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interpretation-section",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005967,
+     "end_time": "2026-04-25T15:33:49.123755",
+     "exception": false,
+     "start_time": "2026-04-25T15:33:49.117788",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation des résultats\n",
+    "\n",
+    "| Algorithme | Points forts | Points faibles | Usage recommande |\n",
+    "|------------|--------------|----------------|------------------|\n",
+    "| **Minimax** | Simple, optimal | Explosion combinatoire | Petits jeux, enseignement |\n",
+    "| **Alpha-Beta** | efficace, optimal | Ordonnancement critique | Jeux a branchement moyen |\n",
+    "| **MCTS** | Pas d'heuristique, parallèle | probabiliste | grands espaces, jeux complexes |\n",
+    "\n",
+    "**observations cles** :\n",
+    "\n",
+    "1. **Alpha-Beta** réduit drastiquement le nombre de noeuds (facteur 5-20x selon la profondeur)\n",
+    "2. **L'ordonnancement** des coups est crucial pour maximiser l'elagage\n",
+    "3. **MCTS** converge vers de bons coups sans fonction d'évaluation explicite\n",
+    "4. Pour un temps donne, Alpha-Beta profond bat souvent MCTS sur Connect Four"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/app-14-connectfour-adversarial.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-14-connectfour-adversarial.yaml
@@ -14,6 +14,12 @@
       csharp_sha: 2ec088ff8d391f7e8bc39e967730ca6c7c821b01
       content_python_sha: 0d78a79a6eebc9b67bfabaf672db29c5234839f181fa7aa0530e399896d430a3
       content_csharp_sha: 05c4ceeb8195f16696d454bfeeebb757fcd886c9e2edab6240dcb96f6cff148b
+    - date: "2026-08-14"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 651c26698806a76a278f5b7a15f82949944b97a4
+      csharp_sha: 2ec088ff8d391f7e8bc39e967730ca6c7c821b01
+      content_python_sha: f042bb4c91dc7dbbd8a5648e3deb94a11a9f97ec17b86c444cce712c179f4580
+      content_csharp_sha: 05c4ceeb8195f16696d454bfeeebb757fcd886c9e2edab6240dcb96f6cff148b
   bridge_verdict: RECOVERABLE-LOCAL
   bridge_verdict_reason: "Python = collections + typing (variant Connect-4 adversarial, 18 cellules code). C# = BCL pure (System.*, 0 NuGet, from-scratch, 10 cellules code) pour Connect-4 adversarial. Verdict RECOVERABLE-LOCAL : socle pedagogique paritable (Puissance 4 adversarial, IA jeux combinatoires variant). L'asymetrie reside dans la couverture (Python 18 cellules code avec viz matplotlib/pandas, C# 10 cellules compactes BCL pure) mais ni Python ni C# n'invoque de moteur SOTA partage -- les deux cotes implement l'algorithme adversariale from-scratch (minimax/alpha-beta). parity_level: semantic preserve."
   known_differences:


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10886

## Résumé

See #10678 (partition v2, issuecomment-5290564224) — repositionnement de l'interp mal ancrée dans `App-14-ConnectFour-Adversarial.ipynb` :

- **cell#29 « Interprétation des résultats »** (synthèse comparative Minimax/Alpha-Beta/MCTS) était placée en fin de section 6, *avant* le tournoi (section 7) qu'elle référence — l'observation 4 « Alpha-Beta profond bat souvent MCTS sur Connect Four » est un résultat du tournoi. Le scanner `check_interp_positioning.py` la flaggait `misplaced_before_section` (la remontée `_is_anchored_to_code` casse sur l'interp voisine cell#28 avant d'atteindre le code).
- **Fix : déplacement de la cellule** — la synthèse passe après l'« Analyse du tournoi » (cell#34) et avant « ## Exercices ». Suivie de `## Exercices` (marqueur de fin de document whitelisté), elle n'est plus signalée ; sémantiquement, elle clôt désormais la comparaison des 3 algorithmes après le tournoi qui la justifie.

## Validation

- `check_interp_positioning.py <fichier>` : **findings total : 0** (avant : 1 `misplaced_before_section`).
- Multiset byte-identique : 50/50 cellules source identiques (ordre seul changé) — vérifié par hashes sha1 par cellule vs `origin/main`.
- `detect_md_content_loss.py` : findings=0, md_cells 32→32 stable, normalized_chars 21677→21677 identiques.
- Diff minimal : +31/−31 lignes (déplacement pur, aucune modification de source).
- 0 CRLF (LF-only), UTF-8 no BOM.
- Notebook markdown-only : aucune cellule code modifiée, outputs intacts (C.3 exception markdown-only).
- H.3 : 18 cellules code avec `execution_count` non-null et outputs (aucune nulle).
- `scan_cell_ordering.py` : clean, 0 finding.

## Tests

- Pre-commit H.3 : Passed.
- Detector interp positioning : findings=0.
