### PR TITLE
fix(interp,#10678): Planners-9-HTN cell#29 — suppression duplicata interp (contenu préservé par cell#24)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-9-HTN.ipynb
@@ -1410,41 +1410,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cell-20",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003173,
-     "end_time": "2026-06-09T16:13:58.398254+00:00",
-     "exception": false,
-     "start_time": "2026-06-09T16:13:58.395081+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation du plan HTN\n",
-    "\n",
-    "Le solveur HTN a decompose la tâche abstraite en actions primitives :\n",
-    "\n",
-    "| Étape | Action | Etat résultat |\n",
-    "|-------|--------|---------------|\n",
-    "| 1 | `load(pkg1, truck1, depot)` | pkg1 est dans truck1 |\n",
-    "| 2 | `drive(truck1, depot, store)` | truck1 est maintenant au store |\n",
-    "| 3 | `unload(pkg1, truck1, store)` | pkg1 est au store |\n",
-    "\n",
-    "**Analyse de la decomposition** :\n",
-    "1. La méthode `m_deliver_direct` a ete choisie (preconditions satisfaites)\n",
-    "2. Les sous-tâches ont ete executees sequentiellement\n",
-    "3. Chaque action primitive verifie ses preconditions avant exécution\n",
-    "\n",
-    "**Limitation de ce solveur simplifie** :\n",
-    "- Le solveur ne gere pas le repositionnement automatique du vehicule\n",
-    "- Pour livrer pkg2 (depuis warehouse), il faudrait que le camion y soit déjà\n",
-    "- Un solveur HTN complet aurait une méthode `reposition_vehicle` pour gerer ce cas"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "htn-aries-intro",
    "metadata": {
     "papermill": {

--- a/scripts/notebook_tools/twin_pairs.d/planners-9-htn.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-9-htn.yaml
@@ -10,6 +10,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 8efefd483570bca7815d101844863f71f9f3c436
       csharp_sha: a502d4c462d6667187a8ec6d827bfe1027271e9f
+    - date: "2026-08-14"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 31b734ee3f8b767a6069bd1f69ef5adff014da42
+      csharp_sha: a502d4c462d6667187a8ec6d827bfe1027271e9f
+      content_python_sha: 8799d27d95a3ba205ee59b07ffa12251345eeab00993b60ce653b925fde413a5
+      content_csharp_sha: 4e0aecd3c9ed7d742a6113c92aef6a0acbff3befb1d373361c03d50641f4cf15
   known_differences:
     - "Concept : Hierarchical Task Network (decomposition de taches, methodes, backtracking)."
     - "Python : unified-planning HTN. C# : from-scratch BCL .NET (Predicat grounde, Etat, decomposition de methodes)."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10890

## Résumé

See #10678 (partition v2, issuecomment-5290564224) — correction de l'interp mal ancrée dans `Planners-9-HTN.ipynb` :

- **cell#29 « Interpretation du plan HTN »** était un **duplicata sémantique** de **cell#24 « Interpretation : Résolution HTN réussie »**. Les deux citent le même output de la cellule de code cell#23 : plan trouvé en 3 actions `load(pkg1,truck1,depot)` → `drive(truck1,depot,store)` → `unload(pkg1,truck1,store)`, domaine `m_deliver_direct`, limitation de repositionnement de pkg2. La cellule cell#24 est correctement ancrée immédiatement après le code [23] (ancre EXECUTION, output réel).
- Aucune position ne rendait cell#29 non-redondante : après [24] = doublon adjacent ; ailleurs = séparée de son ancre par un header section (le scanner `check_interp_positioning.py` la flaggait `misplaced_before_section`).
- **Fix : suppression textuelle de cell#29** (duplicata). **Preuve de préservation anti-régression** : cell#24 couvre 100 % du contenu de cell#29 (valeurs citées identiques, vérifié par lecture des deux cellules + output de cell#23).
- **Désordre structurel signalé, hors scope** : headers 5.x mal ordonnés (cell[25] « ### 5.3 backtracking » avant cell[28] « ### 5.1 Definition du domaine » avant cell[30] « ### 5.2 vrai planificateur SOTA ») = grain reorg séparé, non traité ici (scope interp only).

## Validation

- `check_interp_positioning.py <fichier>` : **findings total : 0** (avant : 1 `misplaced_before_section` cell#29).
- Multiset byte-identique : 57/57 cellules courantes présentes dans les 58 de `origin/main` (hashes sha1 par cellule, `json.dumps separators=(',',':')`) — la seule absente = la cellule supprimée (le duplicata interp).
- `detect_md_content_loss.py` : findings=0. md_cells 42→41 (baisse = le duplicata retiré ; normalized_chars 24713→23992), aucune perte de contenu unique — le duplicata est 100 % couvert par cell#24.
- `scan_cell_ordering.py` : clean, 0 finding.
- Diff minimal : −35 lignes (suppression pure, aucune source modifiée).
- 0 CRLF (LF-only), UTF-8 no BOM.
- Notebook markdown-only : aucune cellule code modifiée, outputs intacts (C.3 exception markdown-only).
- H.3 : 16 cellules code, aucune avec `execution_count` null + outputs vides.

## Tests

- Pre-commit H.3 : Passed (gitleaks + H.3 + strip banners).
- Detector interp positioning : findings=0.
