### PR TITLE
fix(lane-claim,#10881): lint clauses paths: mal formees + reducteur multi-marqueurs par ligne

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -210,125 +210,115 @@ class ClaimEvent(dict):
         return self.get("unparseable_scope") or []
 
 
-def parse_claim_event(comment: dict) -> ClaimEvent | None:
-    """Classify one issue comment into a claim event, or None if not a marker.
+def _line_for_match(body: str, m: re.Match) -> str:
+    """Return the verbatim source line carrying a marker match (marker included).
 
-    The decisive marker is the LAST bracketed one in the body (final intent).
-    The lane is read by `extract_lane`; None when the body carries no lane token
-    (surfaced as "unattributed", never guessed). The timestamp is the comment's
-    server `createdAt` -- the Defaut-2 fix: body stamps are not trusted.
-
-    `#10342`/`#10419 scope`: when the marker line carries a `paths: <comma-list>`
-    clause, the parsed list is attached to the event as `paths`. Originally
-    [OVERRIDE]-only (#10342); #10419 extended recognition to [CLAIMED] and
-    [RELEASED]. For [CLAIMED] the scope makes two lanes with DISJOINT paths free
-    to work the same issue in parallel (multi-instance audits, one lane per
-    notebook). For [RELEASED] the clause is attached for symmetry but the
-    reducer treats release as a full lane-close (partial release is a non-goal).
-
-    `#10395 Variante 1`: the marker LINE (the line carrying the last bracketed
-    marker, not the whole body) is also passed to `extract_lane` as the
-    fallback search scope. Comment forms that omit the literal `lane` keyword
-    -- e.g. `[CLAIMED] #9764 - myia-po-2025:CoursIA 2026-08-07T00:52Z` --
-    are recognised by their marker-line token instead of being mis-attributed.
-
-    `#10395 Variante 2`: the marker-line body excerpt (with the `[MARKER]`
-    stripped) is attached as `intent` -- gives a BLOCKED verdict enough
-    context to discriminate "two lanes on disjoint notebooks of the same EPIC"
-    (legitimate) from "two lanes on the same file" (real collision).
+    Walks from the end of the match to the end of its line so the caller sees
+    any trailing content (e.g. `[CLAIMED] #9764 - myia-po-2025:CoursIA`). This
+    is the per-marker generalisation of the old `_last_marker_line`: the
+    #10881 addendum fix reads EACH marker line, not just the last one.
     """
-    body = comment.get("body") or ""
-    marks = _MARKER_RE.findall(body)
-    if not marks:
-        return None
-    marker = marks[-1].upper()  # last marker = final intent in that comment
-    if marker in _OPEN:
-        action = "open"
-    elif marker in _OVERRIDE:
-        action = "override"
-    else:
-        action = "close"
-    author = (comment.get("author") or {}).get("login")
-    marker_line = _last_marker_line(body, marker)
-    # `paths:` clause (#10342 OVERRIDE, #10419 CLAIMED/RELEASED): parsed from the
-    # marker line so a stray `paths:` in body prose cannot arm a false scope.
-    paths = _extract_paths_clause(marker_line) if marker_line else None
-    intent = _extract_marker_intent(body) if marker_line else None
-    return ClaimEvent(
-        lane=extract_lane(body, marker_line=marker_line),
-        action=action,
-        marker=marker,
-        created_at=comment.get("createdAt"),
-        author=author,
-        url=comment.get("url"),
-        paths=paths,
-        # #10597 hardener -- preserve the unparseable subset of the scope
-        # (residual `{` or `}` after `_expand_brace_groups`). The reducer
-        # and check layer use this to lift the claim back to EPIC-WIDE
-        # when the scope cannot be matched by fnmatch. Without this field
-        # an unclosed-brace scope would silently degrade to "non-blocking
-        # accidental empty" -- the exact defect that motivated #10597.
-        unparseable_scope=_unparseable_scope_in(paths) if paths else [],
-        intent=intent,
-    )
-
-
-def _last_marker_line(body: str, marker_upper: str) -> str | None:
-    r"""Return the line (verbatim, including the marker) that carries the LAST
-    ``[MARKER]`` in `body`, restricted to the canonical marker set
-    (CLAIMED/RELEASED/CANCELLED/ABANDONED/DONE/OVERRIDE). Returns None if the
-    last bracketed marker does not match the canonical set.
-
-    Used by `parse_claim_event` to scope the `#10395 Variante 1` fallback
-    search: the marker line is the human-stated intent of the claim, and
-    restricting the fallback to that line keeps URLs / time stamps / code
-    tokens that contain colons from being mistaken for lane IDs.
-    """
-    last_line: str | None = None
-    for m in _MARKER_RE.finditer(body):
-        # Group 1 carries the marker text (case-insensitive matched by the
-        # compiled regex; uppercase it for the comparison).
-        if m.group(1).upper() == marker_upper:
-            last_line = m.group(0)
-            # Walk forward to the end of the line so the fallback sees any
-            # trailing content (e.g. `[CLAIMED] #9764 - myia-po-2025:CoursIA`).
-            tail = body[m.end():]
-            nl = tail.find("\n")
-            last_line = (m.group(0) + (tail if nl == -1 else tail[:nl])).rstrip("\r")
-    return last_line
-
-
-def _extract_marker_intent(body: str) -> str | None:
-    r"""Extract the human-readable INTENT of a claim comment (#10395 Variante 2).
-
-    The intent is the marker line with the bracketed marker stripped, leading
-    punctuation / whitespace trimmed, and capped at 120 chars. Examples:
-
-      `[CLAIMED] lane myia-po-2025:CoursIA-2 — taxonomy coverage analysis notebook`
-        -> `lane myia-po-2025:CoursIA-2 — taxonomy coverage analysis notebook`
-
-    The point is to make a BLOCKED verdict actionable: instead of saying
-    "another lane holds an active claim on #10355", the tool can show the
-    claim's scope ("taxonomy coverage analysis notebook") so a coordinator
-    reads "three disjoint notebooks on the same EPIC" instead of "three
-    blocking claims". Returns None when the body carries no bracketed marker.
-    """
-    last_marker: tuple[str, int, int] | None = None
-    for m in _MARKER_RE.finditer(body or ""):
-        last_marker = (m.group(1).upper(), m.end(), m.end())
-    if last_marker is None:
-        return None
-    _, after_marker, _ = last_marker
-    # Walk forward to the end of the same line.
-    tail = body[after_marker:]
+    tail = body[m.end():]
     nl = tail.find("\n")
-    text = tail if nl == -1 else tail[:nl]
+    return (m.group(0) + (tail if nl == -1 else tail[:nl])).rstrip("\r")
+
+
+def _intent_from_line(line: str | None) -> str | None:
+    """Marker-line excerpt with the bracketed marker stripped (#10395 V2).
+
+    The per-marker variant of the old `_extract_marker_intent`: strips the
+    `[MARKER]` from a single line, trims leading punctuation, caps at 120
+    chars. Returns None for a bare `[CLAIMED]` (nothing after the bracket).
+    """
+    if not line:
+        return None
+    text = _MARKER_RE.sub("", line, count=1)
     text = text.strip().lstrip(":—-•| ").strip()
     if not text:
         return None
     if len(text) > 120:
         text = text[:120].rstrip() + "…"
     return text
+
+
+def _parse_claim_events(comment: dict) -> list[ClaimEvent]:
+    """One ClaimEvent per bracketed marker line -- the #10881 reducer fix.
+
+    A comment can LEGITIMATELY carry markers for several lanes: the natural
+    shape of a coordinator arbitration is `[RELEASED] lane A` then
+    `[CLAIMED] lane B -- paths: X`. The legacy single-event reader kept only
+    the LAST marker (final intent): every marker of the comment was attributed
+    to ONE lane (the first `lane <token>` in the whole body) with the LAST
+    marker's paths clause, and intermediate `[RELEASED]`s were lost. Measured
+    on #10678 2026-08-14 (ai-01's 07:30:08Z comment): po-2024:CoursIA-2 was
+    credited with ai-01's gate-file scope while its own two notebooks were
+    claimed by no one, and ai-01's epic-wide 07:06:23Z claim stayed active
+    against every other lane.
+
+    This function treats each marker line independently, with the lane ITS
+    OWN LINE names (marker line first, whole body as fallback), its own
+    paths clause, its own intent. `compute_active_claims` walks these events
+    in order, so a comment can release one lane and open another, and a
+    `[CLAIMED]\n[DONE]` sequence on separate lines still reduces to inactive
+    (open then close). Per-marker fields keep the #10342/#10419 scope, the
+    #10395 Variante-1 fallback and the #10597 hardener semantics.
+    """
+    body = comment.get("body") or ""
+    author = (comment.get("author") or {}).get("login")
+    created_at = comment.get("createdAt")
+    url = comment.get("url")
+    events: list[ClaimEvent] = []
+    for m in _MARKER_RE.finditer(body):
+        marker = m.group(1).upper()
+        line = _line_for_match(body, m)
+        if marker in _OPEN:
+            action = "open"
+        elif marker in _OVERRIDE:
+            action = "override"
+        else:
+            action = "close"
+        paths = _extract_paths_clause(line) if line else None
+        # Lane attribution per marker line: the marker's OWN line first, then
+        # the whole body as fallback. The line-first order is the fix -- the
+        # legacy whole-body search always picked the FIRST `lane <token>` of
+        # the comment, mis-attributing every later marker to that lane.
+        lane = extract_lane(line, marker_line=line)
+        if lane is None:
+            lane = extract_lane(body, marker_line=line)
+        events.append(ClaimEvent(
+            lane=lane,
+            action=action,
+            marker=marker,
+            created_at=created_at,
+            author=author,
+            url=url,
+            paths=paths,
+            # #10597 hardener -- preserve the unparseable subset of the scope
+            # (residual `{` or `}` after `_expand_brace_groups`). The reducer
+            # and check layer use this to lift the claim back to EPIC-WIDE
+            # when the scope cannot be matched by fnmatch. Without this field
+            # an unclosed-brace scope would silently degrade to "non-blocking
+            # accidental empty" -- the exact defect that motivated #10597.
+            unparseable_scope=_unparseable_scope_in(paths) if paths else [],
+            intent=_intent_from_line(line),
+        ))
+    return events
+
+
+def parse_claim_event(comment: dict) -> ClaimEvent | None:
+    """Classify one issue comment into a claim event, or None if not a marker.
+
+    Legacy single-event view: the LAST bracketed marker of the comment is the
+    final intent (backward-compatible with every existing caller and the
+    Defaut-2 / lane / scope semantics). The full reader is `_parse_claim_events`
+    -- one event per marker line (#10881 addendum), used by `_sort_events`; for
+    a single-marker comment the two views are identical. The lane is read by
+    `extract_lane`; None when the body carries no lane token (surfaced as
+    "unattributed", never guessed). The timestamp is the comment's server
+    `createdAt` -- the Defaut-2 fix: body stamps are not trusted.
+    """
+    events = _parse_claim_events(comment)
+    return events[-1] if events else None
 
 
 def _split_paths_brace_aware(raw: str) -> list[str]:
@@ -503,10 +493,19 @@ def _gh_issue_comments(issue: str) -> dict:
 
 
 def _sort_events(payload: dict) -> list[ClaimEvent]:
-    """Parse + chronologically sort claim events from an `gh issue view` payload."""
+    """Parse + chronologically sort claim events from a `gh issue view` payload.
+
+    Uses `_parse_claim_events` -- one event per marker line (#10881) -- so a
+    comment carrying markers for several lanes reduces correctly instead of
+    collapsing to a single (mis-attributed) event. Events from the same comment
+    share the server `createdAt`; the stable sort preserves their in-comment
+    marker order, so the walk-order reducer sees `[CLAIMED] X\n[DONE] X` as
+    open-then-close (final state inactive), exactly as before.
+    """
     events = [
-        ev for c in payload.get("comments", [])
-        if (ev := parse_claim_event(c)) is not None
+        ev
+        for c in payload.get("comments", [])
+        for ev in _parse_claim_events(c)
     ]
     # Server createdAt, ISO 8601 UTC -> lexicographic order == chronological.
     events.sort(key=lambda e: e.created_at or "")
@@ -656,6 +655,115 @@ def _scope_zero_coverage_warning(
     return {"scope": scope, "tracked_count": len(tracked)}
 
 
+# --- #10881 lint: malformed paths: clauses -----------------------------------
+# 2026-08-14 morning on #10678: four markers, all misread SILENTLY, two lanes
+# blocked 1.5h. The lint fires on stderr when a marker is READ -- visible to
+# any lane running the check, NEVER changing a verdict. Three checks:
+#   1. marker without a `paths:` clause -> INFO naming the epic-wide effect
+#      (the information that was missing in all four cases).
+#   2. implausible glob (em-dash, colon-space, escaped comma, >120 chars) ->
+#      WARN "glob suspect (prose avalée ?)" -- the prose-after-clause trap.
+#   3. glob matching zero tracked files -> WARN "glob sans correspondance".
+#      A dead glob is almost always a typo or prose. Best-effort: when the
+#      git walk fails (not a repo), the no-match check silently skips.
+# Selectivity is the acceptance's core ("la moitié qui compte"): a well-formed
+# marker (`paths: a/b.lean, a/c.lean`, two existing files) produces NOTHING.
+
+_IMPLAUSIBLE_SUBSTRINGS = ("—", "–", "\\,")
+
+
+def _glob_implausible(glob: str) -> bool:
+    """True when a `paths:` entry cannot plausibly be a repo path (prose)."""
+    if len(glob) > 120:
+        return True
+    if any(s in glob for s in _IMPLAUSIBLE_SUBSTRINGS):
+        return True
+    if re.search(r":\s", glob):  # colon followed by whitespace = prose
+        return True
+    return False
+
+
+def _git_tracked_files(repo_root: str | None = None) -> list[str] | None:
+    """Best-effort `git ls-files` under repo_root (cwd default). None on failure.
+
+    Mirrors the walk of `_scope_zero_coverage_warning` -- the one source of
+    "which files does the repo track" for both callers.
+    """
+    if repo_root is None:
+        repo_root = os.getcwd()
+    try:
+        proc = subprocess.run(
+            ["git", "-C", repo_root, "ls-files"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    tracked = [ln for ln in proc.stdout.splitlines() if ln]
+    return tracked or None
+
+
+def _glob_matches_tracked(glob: str, tracked: list[str]) -> bool:
+    """True when at least one tracked file matches the glob (fnmatch, basename-or-full)."""
+    for path in tracked:
+        if _path_matches(path, [glob]):
+            return True
+    return False
+
+
+def _lint_claim_events(
+    events: list[ClaimEvent],
+    issue_number: int | None,
+    repo_root: str | None = None,
+) -> None:
+    """Emit WARN/INFO lines for malformed claim markers (#10881). Non-blocking.
+
+    Runs on OPEN and OVERRIDE markers only: a close marker is always a full
+    lane-close (its scope is informational, #10419), so an epic-wide release
+    is semantically identical to a scoped one -- nothing to warn about. The
+    lint only prints to stderr; verdicts are untouched.
+    """
+    tracked = _git_tracked_files(repo_root)
+    for ev in events:
+        if ev.get("action") not in ("open", "override"):
+            continue
+        if ev.paths is None:
+            print(
+                f"INFO: marqueur {ev.marker} epic-wide (pas de clause paths:) "
+                f"-- il bloque toutes les autres lanes sur #{issue_number} "
+                f"(lane {ev.lane or '?'}).",
+                file=sys.stderr,
+            )
+            continue
+        for g in ev.paths:
+            if _glob_implausible(g):
+                print(
+                    f'WARN: glob suspect (prose avalée ?) : "{g}" '
+                    f"(lane {ev.lane or '?'})",
+                    file=sys.stderr,
+                )
+            if tracked is not None and not _glob_matches_tracked(g, tracked):
+                print(
+                    f'WARN: glob sans correspondance : "{g}" '
+                    f"(lane {ev.lane or '?'})",
+                    file=sys.stderr,
+                )
+
+
+def _warn_bare_integer_paths(paths: list[str]) -> list[str]:
+    """Return the `--paths` entries that are bare integers (#10881 trap).
+
+    `--paths` uses `nargs='+'` and swallows a TRAILING positional issue
+    number: `--lane X --paths a b 10678` puts `"10678"` into the paths list,
+    switches to path mode, and prints a reassuring CLEAR that measured
+    nothing. A bare integer in the list is almost always that trap -- the
+    correct form is `check_lane_claim.py 10678 --lane X --paths a b`
+    (positional FIRST).
+    """
+    return [p for p in paths if p.isdigit()]
+
+
 # --- modes -------------------------------------------------------------------
 
 def _claim_age_hours(created_at: str | None, now: datetime) -> float | None:
@@ -713,6 +821,11 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             disjointness, so we conservatively over-block).
     """
     events = _sort_events(payload)
+    # #10881 lint -- malformed paths: clauses surface on stderr when the
+    # marker is read: visible to every lane running the check, never changing
+    # a verdict. The four 2026-08-14 markers on #10678 shared the defect the
+    # three checks name (epic-wide by accident / prose swallowed as globs).
+    _lint_claim_events(events, payload.get("number"))
     active, unattributed = compute_active_claims(events)
     others = {ln: ev for ln, ev in active.items() if ln != my_lane}
     mine = active.get(my_lane)
@@ -1103,6 +1216,22 @@ def main(argv: list[str] | None = None) -> int:
     act.add_argument("--release", nargs="?", const="", default=None,
                      metavar="NOTE", help="post a [RELEASED] comment")
     args = p.parse_args(argv)
+
+    # #10881 -- `nargs='+'` on --paths swallows a TRAILING positional issue
+    # number (`--lane X --paths a b 10678` puts "10678" into the paths list,
+    # switches to path mode, and prints a reassuring CLEAR that measured
+    # nothing). Warn loudly when a paths entry is a bare integer; the warning
+    # is non-blocking (the caller may have meant a numeric path), but the
+    # measured trap is precisely this shape.
+    if args.paths is not None:
+        for entry in _warn_bare_integer_paths(args.paths):
+            print(
+                f"WARN: --paths entry {entry!r} is a bare integer -- an issue "
+                f"number swallowed by nargs='+' (#10881). Correct form: "
+                f"`check_lane_claim.py {entry} --lane <lane> --paths ...` "
+                f"(positional FIRST).",
+                file=sys.stderr,
+            )
 
     # Path-only mode (#9959) does NOT require an issue number -- it is the
     # missing leg of L898 dispatched pre-claim to detect cross-lane PR

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -1797,3 +1797,299 @@ def test_run_check_no_warning_when_no_active_claim(capsys):
     assert rc == 0
     captured = capsys.readouterr()
     assert "SCOPE_ZERO_COVERAGE" not in captured.err
+
+
+# --- #10881: lint of malformed paths: clauses ---------------------------------
+#
+# 2026-08-14 morning on #10678: four markers, all misread SILENTLY, two lanes
+# blocked 1.5h. The lint fires on stderr when a marker is READ -- visible to
+# every lane running the check, NEVER changing a verdict. Fixtures are the
+# REAL comment bodies (marker lines verbatim from #10678). The acceptance's
+# decisive half ("la moitié qui compte") is the negative: a well-formed marker
+# (`paths: <two existing files>`) produces NOTHING -- a lint that yells at
+# correct markers would be worse than no lint.
+
+F1_OVERRIDE_NO_PATHS = (
+    "[OVERRIDE] lane myia-ai-01:CoursIA — arbitrage sur le gate interp "
+    "(`check_interp_positioning.py` + `interp_positioning_baseline.json`)\n\n"
+    "Deux PRs ont vise le meme blocage a 4 minutes d'intervalle. Je tranche "
+    "ici, et je commence par ce qui n'est pas en cause.\n"
+)
+
+F2_PROSE_AFTER_CLAUSE = (
+    "[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: "
+    "MyIA.AI.Notebooks/GameTheory/**, MyIA.AI.Notebooks/GenAI/**, "
+    "MyIA.AI.Notebooks/SymbolicAI/**, MyIA.AI.Notebooks/Probas/**, "
+    "MyIA.AI.Notebooks/Search/**, MyIA.AI.Notebooks/ML/**, "
+    "MyIA.AI.Notebooks/QuantConnect/**, MyIA.AI.Notebooks/RL/**, "
+    "MyIA.AI.Notebooks/Sudoku/** — Phase 2 : repositionnement des 39 interps "
+    "survivants (baseline #10864) sur 29 notebooks, markdown-only, partition "
+    "par famille (G.4). Scope notebooks disjoint du gate couvert par "
+    "l'override ai-01 (`check_interp_positioning.py` + "
+    "`interp_positioning_baseline.json`).\n"
+)
+
+F3_FAMILY_GLOBS = (
+    "[CLAIMED] lane myia-po-2023:CoursIA-2 -- paths: "
+    "MyIA.AI.Notebooks/GameTheory/**, MyIA.AI.Notebooks/SymbolicAI/**, "
+    "MyIA.AI.Notebooks/Search/**, MyIA.AI.Notebooks/QuantConnect/**, "
+    "MyIA.AI.Notebooks/Sudoku/**\n\n"
+    "Claim paths-scoped conforme a la partition de l'arbitrage ai-01 : mes 15 "
+    "findings / 14 notebooks des familles GameTheory, SymbolicAI, Search, "
+    "QuantConnect, Sudoku.\n"
+)
+
+F4_PROSE_GRABBED_AS_CLAUSE = (
+    "[CLAIMED] lane myia-ai-01:CoursIA -- arbitrage du gate interp uniquement "
+    "(correctif #10864 + baseline 39) -- scope-narrowing de mon [OVERRIDE] du "
+    "05:53:20Z, qui n'avait pas de clause paths: et bloquait donc les deux "
+    "lanes epic-wide. Les tranches notebooks de la Phase 2 ne m'appartiennent "
+    "pas : elles sont partitionnees entre po-2024:CoursIA-2 (GenAI/Probas/ML/"
+    "RL) et po-2023:CoursIA-2 (GameTheory/SymbolicAI/Search/QuantConnect/"
+    "Sudoku).\r\n\r\n(check_lane_claim #9774 -- server-stamped UTC.)\r\n"
+)
+
+WELL_FORMED_MARKER = (
+    "[CLAIMED] lane myia-po-2024:CoursIA -- paths: "
+    "scripts/check_lane_claim.py, scripts/grain_tag.py"
+)
+
+
+def test_lint_override_without_paths_emits_info(capsys):
+    # F1 -- the 05:53:20Z [OVERRIDE]: no `paths:` clause -> epic-wide. The
+    # INFO line names the blocking effect; the verdict itself is unchanged
+    # (the override still blocks a third lane).
+    p = payload(comment(F1_OVERRIDE_NO_PATHS, "2026-08-14T05:53:20Z"),
+                number=10678)
+    rc = clc._run_check(p, "myia-po-2026:CoursIA")
+    assert rc == 1  # verdict unchanged: the override blocks
+    err = capsys.readouterr().err
+    assert "INFO: marqueur OVERRIDE epic-wide (pas de clause paths:)" in err
+    assert "il bloque toutes les autres lanes sur #10678" in err
+
+
+def test_lint_prose_after_clause_warns_suspect_and_dead_globs(capsys):
+    # F2 -- the 06:41:00Z [CLAIMED]: prose after the clause was swallowed as
+    # three parasite globs; the last real glob (`Sudoku/** — Phase 2 : ...`)
+    # is dead. The lint must WARN citing the faulty excerpt verbatim.
+    p = payload(comment(F2_PROSE_AFTER_CLAUSE, "2026-08-14T06:41:00Z"),
+                number=10678)
+    rc = clc._run_check(p, "myia-po-2025:CoursIA")
+    assert rc == 1  # verdict unchanged
+    err = capsys.readouterr().err
+    assert "WARN: glob suspect (prose avalée ?)" in err
+    assert "Sudoku/** — Phase 2 : repositionnement des 39 interps survivants" in err
+    assert "WARN: glob sans correspondance" in err
+    assert "markdown-only" in err
+
+
+def test_lint_family_globs_are_silent(capsys):
+    # F3 -- the 06:55:07Z [CLAIMED]: family globs, all matching tracked files,
+    # prose on a SEPARATE line (not swallowed). The lint must be SILENT: the
+    # defect here is over-breadth (the globs catch unrelated OPEN PRs), which
+    # is a SEMANTIC judgement the lint deliberately does not make -- this is
+    # exactly the selectivity the acceptance's "la moitié qui compte" pins.
+    p = payload(comment(F3_FAMILY_GLOBS, "2026-08-14T06:55:07Z"), number=10678)
+    rc = clc._run_check(p, "myia-po-2025:CoursIA")
+    assert rc == 1  # verdict unchanged: po-2023's claim blocks
+    err = capsys.readouterr().err
+    assert "WARN:" not in err
+    assert "INFO:" not in err
+
+
+def test_lint_prose_mentioning_paths_warns_suspect(capsys):
+    # F4 -- the 07:06:23Z [CLAIMED]: the prose literally says "clause paths:"
+    # and `_PATHS_CLAUSE_RE` grabs everything after it as ONE bogus glob. The
+    # lint surfaces it as a swallowed-prose WARN (the machine reads a clause
+    # where the author wrote prose -- not the INFO path, but the defect is
+    # caught and named).
+    p = payload(comment(F4_PROSE_GRABBED_AS_CLAUSE, "2026-08-14T07:06:23Z"),
+                number=10678)
+    rc = clc._run_check(p, "myia-po-2025:CoursIA")
+    assert rc == 1  # verdict unchanged
+    err = capsys.readouterr().err
+    assert "WARN: glob suspect (prose avalée ?)" in err
+    assert "et bloquait donc les deux lanes epic-wide" in err
+    assert "WARN: glob sans correspondance" in err
+
+
+def test_lint_well_formed_marker_produces_nothing(capsys):
+    # The acceptance's decisive negative: a well-formed marker with two
+    # EXISTING files produces NO warning at all -- the lint must not cry wolf
+    # on correct markers.
+    p = payload(comment(WELL_FORMED_MARKER, "2026-08-14T08:00:00Z"),
+                number=10678)
+    rc = clc._run_check(p, "myia-po-2025:CoursIA")
+    assert rc == 1  # verdict unchanged: the claim blocks
+    err = capsys.readouterr().err
+    assert "WARN:" not in err
+    assert "INFO:" not in err
+
+
+# --- #10881 addendum: multi-marker comments reduce per line ------------------
+#
+# A comment can LEGITIMATELY carry markers for several lanes -- the natural
+# shape of a coordinator arbitration. The legacy single-event reader kept
+# only the LAST marker: every marker was attributed to ONE lane (the first
+# `lane <token>` of the body) with the LAST marker's paths clause, and
+# intermediate `[RELEASED]`s were lost. Acceptance (11): `[RELEASED] lane A`
+# + `[CLAIMED] lane B -- paths: X` must produce exactly "A released, B
+# claims X".
+
+def test_release_a_claim_b_reduces_exactly():
+    # Acceptance (11) verbatim. Pre-fix this produced ONE event with
+    # lane=A:CoursIA and paths=X (A holding B's scope, B never claiming).
+    body = (
+        "[RELEASED] lane A:CoursIA -- done\n"
+        "[CLAIMED] lane B:CoursIA-2 -- paths: scripts/foo.py\n"
+    )
+    events = clc._parse_claim_events(comment(body, "2026-08-14T07:30:08Z"))
+    assert [(e.marker, e.lane) for e in events] == [
+        ("RELEASED", "A:CoursIA"),
+        ("CLAIMED", "B:CoursIA-2"),
+    ]
+    assert events[1].paths == ["scripts/foo.py"]
+    active, unattrib = clc.compute_active_claims(events)
+    assert not unattrib
+    assert set(active) == {"B:CoursIA-2"}
+    assert active["B:CoursIA-2"].paths == ["scripts/foo.py"]
+
+
+def test_coordinator_arbitration_comment_reduces_per_lane():
+    # The L22/L31/L33 shape ai-01 measured on #10678 (its own account): one
+    # comment releasing lane A, claiming lane B (the ML/RL notebooks), and
+    # re-claiming lane A scoped to the gate files. Legacy: ONE event with
+    # lane=po-2024:CoursIA-2 (first body token) and paths=the gate files
+    # (last marker) -- po-2024 credited with ai-01's scope, ai-01's epic-wide
+    # 07:06:23Z claim left ACTIVE against every other lane, and the ML/RL
+    # notebooks claimed by no one. Multi-event: po-2024 owns the notebooks,
+    # ai-01 owns the gate files only.
+    body = (
+        "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
+        "paths: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb, "
+        "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb\n"
+        "[RELEASED] lane myia-ai-01:CoursIA — annule mes marqueurs du "
+        "05:53:20Z et du 07:06:23Z\n"
+        "[CLAIMED] lane myia-ai-01:CoursIA -- "
+        "paths: scripts/notebook_tools/check_interp_positioning.py, "
+        "scripts/notebook_tools/interp_positioning_baseline.json\n"
+    )
+    events = clc._parse_claim_events(comment(body, "2026-08-14T07:30:08Z"))
+    assert [(e.marker, e.lane) for e in events] == [
+        ("CLAIMED", "myia-po-2024:CoursIA-2"),
+        ("RELEASED", "myia-ai-01:CoursIA"),
+        ("CLAIMED", "myia-ai-01:CoursIA"),
+    ]
+    assert events[0].paths == [
+        "MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb",
+        "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb",
+    ]
+    assert events[2].paths == [
+        "scripts/notebook_tools/check_interp_positioning.py",
+        "scripts/notebook_tools/interp_positioning_baseline.json",
+    ]
+    # Full issue state: ai-01's prior epic-wide override + claim, then this
+    # arbitration comment. Walk order releases the epic-wide claims and opens
+    # the two scoped claims -- the exact final state ai-01 then had to build
+    # by hand with three separate comments.
+    p = payload(
+        comment("[OVERRIDE] lane myia-ai-01:CoursIA — arbitrage",
+                "2026-08-14T05:53:20Z"),
+        comment("[CLAIMED] lane myia-ai-01:CoursIA -- arbitrage",
+                "2026-08-14T07:06:23Z"),
+        comment(body, "2026-08-14T07:30:08Z"),
+        number=10678,
+    )
+    active, unattrib = clc.compute_active_claims(clc._sort_events(p))
+    assert not unattrib
+    assert set(active) == {"myia-po-2024:CoursIA-2", "myia-ai-01:CoursIA"}
+    assert active["myia-po-2024:CoursIA-2"].paths == [
+        "MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb",
+        "MyIA.AI.Notebooks/RL/rl_4_multi_armed_bandits.ipynb",
+    ]
+    assert active["myia-ai-01:CoursIA"].paths == [
+        "scripts/notebook_tools/check_interp_positioning.py",
+        "scripts/notebook_tools/interp_positioning_baseline.json",
+    ]
+
+
+def test_third_lane_disjoint_paths_clear_after_release_reclaim(capsys):
+    # Practical consequence of the addendum: the released epic-wide claim no
+    # longer ghosts against a THIRD lane. Post-fix, ai-01's scoped gate claim
+    # does not block a lane whose `--paths` are disjoint from the gate files.
+    body = (
+        "[RELEASED] lane myia-ai-01:CoursIA — annule et remplace mes "
+        "marqueurs du 05:53:20Z et du 07:06:23Z\n"
+        "\n"
+        "[CLAIMED] lane myia-ai-01:CoursIA -- paths: "
+        "scripts/notebook_tools/check_interp_positioning.py\n"
+    )
+    p = payload(
+        comment("[OVERRIDE] lane myia-ai-01:CoursIA — arbitrage",
+                "2026-08-14T05:53:20Z"),
+        comment("[CLAIMED] lane myia-ai-01:CoursIA -- arbitrage",
+                "2026-08-14T07:06:23Z"),
+        comment(body, "2026-08-14T07:30:08Z"),
+        number=10678,
+    )
+    rc = clc._run_check(
+        p, "myia-po-2026:CoursIA",
+        my_paths=["MyIA.AI.Notebooks/Sudoku/Sudoku-9.ipynb"],
+    )
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "CLEAR" in captured.out
+    assert "BLOCKED" not in captured.err
+
+
+def test_parse_claim_event_legacy_returns_last_event():
+    # parse_claim_event (the backward-compatible wrapper) still answers the
+    # "final intent" question for callers that read one event per comment,
+    # with the lane of ITS OWN line.
+    ev = clc.parse_claim_event(comment(
+        "[CLAIMED] lane X:CoursIA -- oops\n[DONE] lane X:CoursIA",
+        "2026-08-14T07:30:08Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is False
+    assert ev.marker == "DONE"
+    assert ev.lane == "X:CoursIA"
+
+
+# --- #10881: --paths bare-integer trap ---------------------------------------
+# `--paths` uses `nargs='+'` and swallows a TRAILING positional issue number:
+# `--lane X --paths a b 10678` puts `"10678"` into the paths list, switches to
+# path mode, and prints a reassuring CLEAR that measured nothing. The correct
+# form is the positional FIRST. The lint warns on bare-integer entries.
+
+def test_warn_bare_integer_paths_helper():
+    assert clc._warn_bare_integer_paths(
+        ["scripts/foo.py", "10678", "a/b.py"]) == ["10678"]
+    assert clc._warn_bare_integer_paths(["scripts/foo.py", "a/b.py"]) == []
+    assert clc._warn_bare_integer_paths([]) == []
+
+
+def test_main_paths_bare_integer_warns(monkeypatch, capsys):
+    # The exact trap from the issue: `--paths a.py 10678` (no positional).
+    # The warning must fire before the path-mode branch, so it is visible
+    # whatever the mode does next.
+    monkeypatch.setattr(clc, "_run_check_paths",
+                        lambda paths, my_lane, **kw: 0)
+    rc = clc.main(["--lane", "myia-po-2024:CoursIA",
+                   "--paths", "a.py", "10678"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "bare integer" in err
+    assert "10678" in err
+    assert "positional FIRST" in err
+
+
+def test_main_paths_correct_form_no_warning(monkeypatch, capsys):
+    # Correct form (positional issue FIRST, no bare integer in paths) emits
+    # no trap warning.
+    monkeypatch.setattr(clc, "_run_check_paths",
+                        lambda paths, my_lane, **kw: 0)
+    rc = clc.main(["--lane", "myia-po-2024:CoursIA",
+                   "--paths", "a.py", "b.py"])
+    assert rc == 0
+    assert "bare integer" not in capsys.readouterr().err


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/notebook-python #10883

## Summary

Fix #10881 — linter les clauses `paths:` mal formées + réduire les commentaires multi-marqueurs par ligne. Trois pièces :

1. **Lint non-bloquant** (stderr, au moment où le marqueur est lu) :
   - INFO quand un marqueur **open/override** n'a pas de clause `paths:` — nomme l'effet epic-wide (`il bloque toutes les autres lanes sur #N`), l'information qui manquait dans les 4 cas de la matinée.
   - WARN sur glob suspect (prose avalée après une clause `paths:` : tiret cadratin, colonne+espace, virgule échappée, >120 chars) → `glob suspect (prose avalée ?)`.
   - WARN sur glob sans correspondance dans le repo (meilleure-effort `git ls-files`, skip silencieux hors repo).
   - **Sélectivité = la moitié qui compte** : un marqueur bien formé (`paths: a/b.lean, a/c.lean`, deux fichiers existants) ne produit RIEN.
2. **Réducteur multi-marqueurs** : un commentaire d'arbitrage coordinateur porte légitimement plusieurs marqueurs pour plusieurs lanes (`[RELEASED] lane A` puis `[CLAIMED] lane B -- paths: X`). L'ancien lecteur single-event attribuait TOUS les marqueurs à la première lane du corps avec le `paths` du dernier marqueur, et perdait les `[RELEASED]` intermédiaires — mesuré sur le commentaire 07:30:08Z d'ai-01 sur #10678 (po-2024 crédité du scope gate d'ai-01, ses 2 notebooks réclamés par personne). `_parse_claim_events` traite chaque ligne de marqueur indépendamment (lane de SA ligne d'abord, corps en fallback ; son paths, son intent) ; `parse_claim_event` reste le wrapper single-event rétro-compatible (aucun appelant cassé).
3. **Piège `--paths`** : `nargs='+'` avale un numéro d'issue positionnel final (`--lane X --paths a b 10678`) → mode path + CLEAR rassurant qui ne mesurait rien. WARN sur entrée entier-nu avec la forme correcte (positionnel en premier).

## Validation

- `python -m pytest scripts/tests/test_check_lane_claim.py -q` → **114 passed** (12 nouveaux tests fixtures : 4 marqueurs réels de #10678 + marqueur bien formé + acceptance (11) `[RELEASED] A` / `[CLAIMED] B` + arbitrage L22/L31/L33 + 3ᵉ lane à paths disjoints CLEAR + legacy wrapper + piège entier-nu).
- `python -m pytest scripts/tests/test_lane_claim_required.py scripts/tests/test_grain_tag.py -q` → **66 passed**.
- **180/180, zéro changement de verdict** — les fixtures utilisent les BODY RÉELS des marqueurs (verbatim depuis #10678), vérifiés G.1 contre le comportement machine (F4 : la prose contient littéralement « clause paths: » → attrapé par le regex comme clause boguée → WARN et non INFO ; F3 : globs famille tous correspondants → silencieux, sélectivité assumée).

## Files

- `scripts/check_lane_claim.py` (+347/−109)
- `scripts/tests/test_check_lane_claim.py` (+296)

## Test plan

- [x] Tests unitaires : 180/180
- [x] Aucun changement de verdict sur le corpus existant

See #10881 — l'arbitrage merge reste au coordinateur (lint = signal, jamais verdict).
