### PR TITLE
fix(notebooks,#10678): SC-11-LLM-Assisted — retirer 2 interps dupliquées, fusionner ReentrancyGuard

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -724,33 +724,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70c66512",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006021,
-     "end_time": "2026-06-05T14:04:23.821834",
-     "exception": false,
-     "start_time": "2026-06-05T14:04:23.815813",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation\n",
-    "\n",
-    "Le contrat genere devrait inclure :\n",
-    "\n",
-    "| Élément | Description |\n",
-    "|---------|-------------|\n",
-    "| **SPDX License** | Identifiant de licence MIT |\n",
-    "| **Pragma** | Version Solidity ciblee |\n",
-    "| **NatSpec** | Documentation des fonctions |\n",
-    "| **Event** | ValueChanged pour tracking |\n",
-    "| **Modifier** | onlyOwner pour access control |"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "a18b790b",
    "metadata": {
     "papermill": {
@@ -988,36 +961,7 @@
     "}\n",
     "```\n",
     "\n",
-    "La règle est simple : toute mise a jour de l'etat (**Effects**) doit preceder tout appel externe (**Interactions**). La variable `amount` est lue avant la mise a zero (**Checks**), garantissant que le reappel trouve un solde a zero."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "97eaea3a",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006523,
-     "end_time": "2026-06-05T14:04:23.927436",
-     "exception": false,
-     "start_time": "2026-06-05T14:04:23.920913",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation\n",
-    "\n",
-    "L'audit LLM devrait identifier la **reentrancy vulnerability** dans le contrat ci-dessus :\n",
-    "\n",
-    "```\n",
-    "1. Utilisateur A appelle withdraw()\n",
-    "2. Le contrat envoie les fonds a A\n",
-    "3. A est un contrat malveillant qui reappelle withdraw()\n",
-    "4. Le solde n'a pas encore ete mis a jour (toujours > 0)\n",
-    "5. Le contrat envoie les fonds une deuxieme fois !\n",
-    "```\n",
-    "\n",
-    "**Correction recommandee** : Pattern Checks-Effects-Interactions ou ReentrancyGuard."
+    "La règle est simple : toute mise a jour de l'etat (**Effects**) doit preceder tout appel externe (**Interactions**). La variable `amount` est lue avant la mise a zero (**Checks**), garantissant que le reappel trouve un solde a zero.\nAlternative plus robuste : le modifier `ReentrancyGuard` d'OpenZeppelin centralise cette protection."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10891

## Résumé

See #10678 (partition v2, issuecomment-5290564224) — correction des interps mal ancrées dans `SC-11-LLM-Assisted.ipynb` :

- **cell#16 « Interpretation »** était un **duplicata sémantique** de **cell#15 « Interpretation : Generation de contrat par LLM »**. Les deux commentent le même output de la cellule de code cell#14 (génération du contrat mock : SPDX MIT, Pragma ^0.8.20, NatSpec, Event ValueChanged, Modifier onlyOwner). La cellule cell#15 est correctement ancrée immédiatement après le code [14] (ancre EXECUTION) ; cell#16 est 100 % couverte par cell#15.
- **cell#22 « Interpretation : Audit de VulnerableVault »** était un **duplicata sémantique** de **cell#21** (même output de la cellule de code cell#20 : reentrancy en 5 étapes + correction Checks-Effects-Interactions). Un seul élément de contenu propre à cell#22 : la mention du modifier **`ReentrancyGuard`** d'OpenZeppelin.
- **Fix : fusion de l'élément unique (« Alternative plus robuste : le modifier \`ReentrancyGuard\` d'OpenZeppelin centralise cette protection. ») dans cell#21, puis suppression textuelle des 2 duplicatas (cell#16, cell#22).** Preuve de préservation anti-régression : chaque duplicata est 100 % couvert par sa cellule sœur après fusion.
- Aucune position ne rendait les duplicatas non-redondants (après la cellule sœur = doublon adjacent ; ailleurs = séparés de leur ancre par un header section — le scanner `check_interp_positioning.py` les flaggait `misplaced_before_section`).

## Validation

- `check_interp_positioning.py <fichier>` : **findings total : 0** (avant : 2 `misplaced_before_section` cell#16, cell#22).
- Multiset byte-identique : 52 cellules courantes — 51/52 byte-identiques à `origin/main` (hashes sha1 par cellule, `json.dumps separators=(',',':')`), les 2 absentes = les duplicatas supprimés, 1 modifiée = cell#21 (fusion ReentrancyGuard, ajout d'une ligne). Aucune cellule code modifiée.
- `detect_md_content_loss.py` : findings=0. md_cells 34→32 (baisse = les 2 duplicatas retirés ; normalized_chars 13276→12717), aucune perte de contenu unique.
- `scan_cell_ordering.py` : clean, 0 finding.
- Diff minimal : +1/−57 lignes (2 suppressions + 1 ligne de fusion).
- 0 CRLF (LF-only), UTF-8 no BOM.
- Notebook markdown-only : aucune cellule code modifiée, outputs intacts (C.3 exception markdown-only).
- H.3 : 20 cellules code, aucune avec `execution_count` null + outputs vides.

## Tests

- Pre-commit H.3 : Passed (gitleaks + H.3 + strip banners).
- Detector interp positioning : findings=0.
