### PR TITLE
fix(notebooks,#10678): SC-15-Zero-Knowledge-Proofs — ancrer l'interp des paramètres après le code

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -238,37 +238,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8199e832",
-   "metadata": {
-    "papermill": {
-     "duration": 0.003249,
-     "end_time": "2026-08-01T17:10:16.774674",
-     "exception": false,
-     "start_time": "2026-08-01T17:10:16.771425",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Interpretation : Paramètres du groupe (version simplifiée)\n",
-    "\n",
-    "La démo interactive ci-dessus (cellule 7) utilise un groupe multiplicatif **simplifié**, à visée pédagogique :\n",
-    "\n",
-    "| Paramètre | Rôle | Ce que la cellule 7 génère réellement |\n",
-    "|-----------|------|-----------|\n",
-    "| **p** (256 bits) | Module du groupe | Nombre premier aléatoire via `getPrime(256)` — **pas un safe prime** |\n",
-    "| **q = p − 1** (256 bits) | Ordre du groupe multiplicatif Z_p* | **Non premier** (p − 1 est pair) ; c'est l'ordre du groupe complet |\n",
-    "| **g** (256 bits) | Générateur | Élément aléatoire de Z_p* via `getRandomRange(2, p − 1)` |\n",
-    "\n",
-    "Le protocole reste **mathématiquement valide** dans ce groupe complet : le petit théorème de Fermat garantit g^(p−1) ≡ 1 (mod p), donc la vérification g^s ≡ R · y^c (mod p) tient avec s = r + c·x mod (p−1). L'identification fonctionne, la preuve aussi.\n",
-    "\n",
-    "**Pourquoi cette version n'est pas suffisante en production ?** Travailler dans Z_p* complet (d'ordre p−1 composite) expose aux **attaques par sous-groupe petit (Pohlig-Hellman)** : un attaquant décompose le logarithme discret modulo chaque facteur premier de p−1. La parade standard est le **safe prime** p = 2q + 1 (avec q premier), en se restreignant au sous-groupe d'ordre q via un générateur g = h² mod p. C'est précisément ce qu'implémente la **section 3** ci-dessous (classe `SchnorrZKP`, cellule 12) : génération d'un vrai safe prime et d'un générateur d'ordre q premier.\n",
-    "\n",
-    "**Note** : 256 bits est pédagogique ici. En production, on utilise des groupes d'ordre premier ≥ 256 bits (courbes 25519, RFC 7919) pour une sécurité équivalente à AES-128.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "dlog-transition",
    "metadata": {
     "papermill": {
@@ -434,6 +403,37 @@
     "print(\"  - Le secret x n'a JAMAIS ete transmis au verificateur\")\n",
     "print(\"  - Chaque round utilise un nonce r different (aleatoire)\")\n",
     "print(\"  - s = r + c*x est masque par r, impossible de deduire x\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8199e832",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003249,
+     "end_time": "2026-08-01T17:10:16.774674",
+     "exception": false,
+     "start_time": "2026-08-01T17:10:16.771425",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interpretation : Paramètres du groupe (version simplifiée)\n",
+    "\n",
+    "La démo interactive ci-dessus (cellule 6) utilise un groupe multiplicatif **simplifié**, à visée pédagogique :\n",
+    "\n",
+    "| Paramètre | Rôle | Ce que la cellule 6 génère réellement |\n",
+    "|-----------|------|-----------|\n",
+    "| **p** (256 bits) | Module du groupe | Nombre premier aléatoire via `getPrime(256)` — **pas un safe prime** |\n",
+    "| **q = p − 1** (256 bits) | Ordre du groupe multiplicatif Z_p* | **Non premier** (p − 1 est pair) ; c'est l'ordre du groupe complet |\n",
+    "| **g** (256 bits) | Générateur | Élément aléatoire de Z_p* via `getRandomRange(2, p − 1)` |\n",
+    "\n",
+    "Le protocole reste **mathématiquement valide** dans ce groupe complet : le petit théorème de Fermat garantit g^(p−1) ≡ 1 (mod p), donc la vérification g^s ≡ R · y^c (mod p) tient avec s = r + c·x mod (p−1). L'identification fonctionne, la preuve aussi.\n",
+    "\n",
+    "**Pourquoi cette version n'est pas suffisante en production ?** Travailler dans Z_p* complet (d'ordre p−1 composite) expose aux **attaques par sous-groupe petit (Pohlig-Hellman)** : un attaquant décompose le logarithme discret modulo chaque facteur premier de p−1. La parade standard est le **safe prime** p = 2q + 1 (avec q premier), en se restreignant au sous-groupe d'ordre q via un générateur g = h² mod p. C'est précisément ce qu'implémente la **section 3** ci-dessous (classe `SchnorrZKP`, cellule 12) : génération d'un vrai safe prime et d'un générateur d'ordre q premier.\n",
+    "\n",
+    "**Note** : 256 bits est pédagogique ici. En production, on utilise des groupes d'ordre premier ≥ 256 bits (courbes 25519, RFC 7919) pour une sécurité équivalente à AES-128.\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10893

## Résumé

See #10678 (partition v2, issuecomment-5290564224) — repositionnement de l'interp mal ancrée dans `SC-15-Zero-Knowledge-Proofs.ipynb` :

- **cell#5 « Interpretation : Paramètres du groupe (version simplifiée) »** commentait l'output de la cellule de code « Parametres Discrete Log avec import guards » (cell#7 : `p` premier via `getPrime(256)`, `g` via `getRandomRange(2, p−1)`, `x` secret NON REVELE, `h = g^x mod p`, 10 rounds `g^s == R*y^c ? OK`, « CONVAINCU ») — mais était placée **avant** ce code, juste avant le header « ### Exécution du protocole interactif ». Le scanner `check_interp_positioning.py` la flaggait `misplaced_before_section` (la remontée `_is_anchored_to_code` casse sur le header intercalaire).
- **Fix : déplacement textuel de la cellule après le code cell#7** (ancre EXECUTION — les valeurs citées dans l'interp apparaissent dans l'output réel de cell#7). Ordre canonique rétabli : section 2 + description protocole (cell#4) → header « ### Exécution du protocole interactif » (cell#6) → code paramètres + rounds (cell#7) → interp Paramètres du groupe (cell#5 déplacée) → section « ### Et si le prouveur triche ? » (cell#8).
- **Références « cellule 7 » → « cellule 6 »** : la cellule déplacée référençait le code par son ancien index (prose « La démo interactive ci-dessus (cellule 7) » + en-tête de tableau « Ce que la cellule 7 génère réellement »). Après déplacement, le code est à l'index 6. Indices ≥ 8 inchangés (move interne au bloc 5-7) : la référence « cellule 12 » (classe `SchnorrZKP`, section 3) reste exacte — aucune autre prose touchée.

## Validation

- `check_interp_positioning.py <fichier>` : **findings total : 0** (avant : 1 `misplaced_before_section` cell#5).
- Multiset byte-identique : 45 cellules courantes — 44/45 byte-identiques à `origin/main` (hashes sha1 par cellule, `json.dumps separators=(',',':')`), 1 modifiée = la cellule déplacée (2 références d'index mises à jour, aucun contenu sémantique changé). Aucune cellule code modifiée.
- `detect_md_content_loss.py` : findings=0. md_cells 30→30 stable, normalized_chars 21503→21503 identiques (remplacement « 7 » → « 6 », même longueur).
- `scan_cell_ordering.py` : clean, 0 finding.
- Diff minimal : +31/−31 lignes (move pur du bloc + 2 refs d'index).
- 0 CRLF (LF-only), UTF-8 no BOM.
- Notebook markdown-only : aucune cellule code modifiée, outputs intacts (C.3 exception markdown-only).
- H.3 : 15 cellules code, aucune avec `execution_count` null + outputs vides.

## Tests

- Pre-commit H.3 : Passed (gitleaks + H.3 + strip banners).
- Detector interp positioning : findings=0.
