### PR TITLE
fix(tooling,#10873): court-circuit multiset dans detect_md_content_loss — classe zero-id

### DIFF
--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -458,6 +458,24 @@ def _compare_cells(base_md: list[tuple[int, str | None, str]],
     if len(base_md) != len(head_md):
         return findings  # compte modifie -> la comparaison fichier suffit
 
+    # Fix #10873 (court-circuit multiset) : si le multiset des contenus
+    # normalises est identique entre base et head, aucune perte de contenu
+    # n'est possible -- c'est une permutation pure. On retourne zero finding
+    # AVANT toute strategie d'appariement (il subsume le cas id-e sans le
+    # contredire) : une strategie d'appariement ne peut produire un finding
+    # que si un contenu a change, et un multiset identique garantit que
+    # chaque contenu est preserve. Une vraie troncature ou substitution
+    # produit une chaine differente, donc un multiset different, et le
+    # court-circuit ne s'arme pas (le gate reste mordant).
+    # NB : egalite du MULTISET DES CHAINES (tri des contenus normalises),
+    # PAS des totaux de caracteres -- deux chaines distinctes peuvent
+    # totaliser la meme longueur (une substitution meme-longueur serait un
+    # blanc-seing sur un critere de totaux, cf #10873 commentaire 08:09).
+    base_multiset = sorted(_normalize(b_src) for _, _, b_src in base_md)
+    head_multiset = sorted(_normalize(h_src) for _, _, h_src in head_md)
+    if base_multiset == head_multiset:
+        return findings
+
     # c.8254 + fix #10873 : apparier par ID le sous-ensemble id-e stable
     # (cellules exposant un ``cell_id``), par index le residu (cellules sans
     # id). L'ancienne politique all-or-nothing basculait le notebook entier en

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -230,26 +230,62 @@ class TestReorderSafeByCellID:
         assert findings[0]["kind"] == "TRUNCATED_CELL"
         assert findings[0]["cell_idx"] == 0  # position dans le head
 
-    def test_reorder_without_ids_falls_back_to_index_legacy(self):
-        # Si les cellules n'ont PAS d'IDs (legacy nbformat < 4.5 ou ecriture
-        # a la main), on retombe sur l'appariement par index et le reorder
-        # PEUT signaler a tort (legacy behavior preserve pour les vieux
-        # notebooks sans IDs).
-        body_long_a = "## Section A\n\n" + ("Phrase A. " * 25)
-        body_long_b = "## Section B\n\n" + ("Phrase B. " * 25)
-        base = _nb(_md(body_long_a), _md(body_long_b))
-        head = _nb(_md(body_long_b), _md(body_long_a))  # reorder sans IDs
+    def test_zero_id_pure_reorder_no_signal(self):
+        # #10873 court-circuit multiset : un notebook AUCUNE cellule md id-ee
+        # (classe QC-Py-07/08/10, 0/52 et 0/50 ids) + reorder pur doit rendre
+        # 0 finding. Les longuetres tres differentes garantissent que le code
+        # PRE-court-circuit produisait bien un FP index (long base[0] paire
+        # avec court head[0]) -- ce test echoue contre le code post-#10885
+        # sans le court-circuit.
+        body_long = "## Section A\n\n" + ("Phrase A substantielle. " * 30)   # ~730c
+        body_short = "## Section B\n\n" + ("Phrase B plus courte. " * 12)     # ~280c
+        base = _nb(_md(body_long), _md(body_short))
+        head = _nb(_md(body_short), _md(body_long))  # reorder pur sans ids
         findings = dml._compare_cells(dml.extract_md_cells(base),
                                       dml.extract_md_cells(head))
-        # Legacy behavior : au moins une cellule signalee (la 0 du head =
-        # body_long_b comparee a body_long_a -- ratio < 1, probablement
-        # OK car contenus similaires, mais on documente au moins une issue
-        # OU aucune issue si ratio > 0.75. On accepte les deux : la police
-        # legacy index-parallel est connue FP-prone pour les reorders, et
-        # c'est exactement pourquoi on a ajoute l'appariement par ID.
-        # Le test documente que la politique legacy ne casse pas : pas de
-        # AssertionError, juste constatation.
-        assert isinstance(findings, list)
+        assert findings == [], (
+            "un reorder pur sur un notebook zero-id ne doit PAS signaler "
+            f"(court-circuit multiset, trouve: {findings!r})"
+        )
+
+    def test_zero_id_real_truncation_still_signals(self):
+        # #10873 non-blanc-seing : le court-circuit multiset ne desarme pas le
+        # gate sur une VRAIE troncature en notebook zero-id -- la chaine
+        # tronquee differe, le multiset differe, le court-circuit ne s'arme
+        # pas et l'appariement index legacy signale.
+        body_long = "## Section\n\n" + ("Phrase substantielle. " * 30)
+        base = _nb(_md(body_long), _md(body_long))
+        head = _nb(_md(body_long), _md("> **Titre :**"))  # vraie troncature
+        findings = dml._compare_cells(dml.extract_md_cells(base),
+                                      dml.extract_md_cells(head))
+        assert len(findings) == 1
+        assert findings[0]["kind"] == "TRUNCATED_CELL"
+        assert findings[0]["cell_idx"] == 1
+
+    def test_zero_id_same_length_substitution_still_signals(self):
+        # #10873 garde anti-blanc-seing des TOTAUX : substitution + reorder.
+        # base = [X (L), Y (S)], head = [Y (S), X' (L)] ou X' est DISTINCT de
+        # X mais de MEME longueur normalisee (mots de meme longueur). Les
+        # TOTAUX sont egaux au caractere pres -- un critere sur les totaux
+        # disculperait a tort (blanc-seing). Le critere implemente est le
+        # MULTISET des chaines : il differe, le court-circuit ne s'arme pas,
+        # l'appariement index signale le desalignement (X perdu, X' apparu).
+        x = "## Analyse technique\n\n" + ("Regarder la volatilite. " * 20)
+        x_prime = "## Analyse technique\n\n" + ("Analyser la volatilite. " * 20)
+        y = "## Section breve\n\n" + ("Rappel court. " * 12)
+        assert len(dml._normalize(x)) == len(dml._normalize(x_prime)), (
+            "fixtures: X et X' doivent totaliser la meme longueur normalisee "
+            "pour que ce test prouve multiset != totaux"
+        )
+        base = _nb(_md(x), _md(y))
+        head = _nb(_md(y), _md(x_prime))  # X substitue par X' + reorder
+        findings = dml._compare_cells(dml.extract_md_cells(base),
+                                      dml.extract_md_cells(head))
+        assert len(findings) >= 1, (
+            "une substitution meme-longueur + reorder doit signaler (multiset "
+            f"different, totaux egaux -- trouve: {findings!r})"
+        )
+        assert findings[0]["kind"] == "TRUNCATED_CELL"
 
     def test_partial_ids_use_subset_matching(self):
         # #10873 : si seulement certaines cellules ont un id (cas mixte),


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: DEEP/qc #10855 (PR #10902)

Closes #10873 (acceptance residuelle pts 1-4 complete : court-circuit + tests + critere de sortie observable 4/4).

## Le fix

Apres la garde de longueur, AVANT la partition id/residu (il subsume le cas
id-e sans le contredire — acceptance pt 1) :

```python
base_multiset = sorted(_normalize(b_src) for _, _, b_src in base_md)
head_multiset = sorted(_normalize(h_src) for _, _, h_src in head_md)
if base_multiset == head_multiset:
    return findings  # permutation pure => aucune perte possible
```

**Exact, pas heuristique** : meme sac de chaines des deux cotes => chaque
contenu est preserve. Une vraie troncature/substitution produit une chaine
differente, donc un multiset different, le court-circuit ne s'arme pas et le
gate reste mordant.

**Multiset des chaines TRIEES, pas les totaux de caracteres** (piege signale
sur #10873, commentaire 08:09) : deux chaines distinctes peuvent totaliser la
meme longueur — un critere sur les totaux serait un blanc-seing pour la
substitution meme-longueur. Les totaux identiques des 4 PRs bloquees sont un
indice de diagnostic, pas le critere implemente.

Build sur 79c6a1a44 (#10885, subset-ID matching, mergé) — les deux remedes
se completent : le multiset ferme le reorder-pur (y compris zero-id),
l'appariement id-e reste plus precis quand les ids existent.

## Preuve — critere de sortie observable (acceptance pts 4 et 8)

Rejoue sur les 4 PRs bloquees, vrais couples base/head origin/main vs branche PR :

| PR | notebook | ancien | NOUVEAU |
|----|----------|--------|---------|
| #10723 | OR-tools-Stiegler (25/26 ids) | 4 | **0** |
| #10725 | 03-Voting-Methods-Csharp (17/20 ids) | 2 | **0** |
| #10785 | QC-Py-08-Multi-Asset (0/52 ids) | 1 | **0** |
| #10810 | QC-Py-10-Risk-Portfolio (0/50 ids) | 2 | **0** |

Les deux dernieres sont la classe zero-id que #10885 ne pouvait pas traiter
(mesure ai-01 : 2/4 avec le seul remede B, 4/4 avec le court-circuit).
**Aucun blob de notebook modifie** (acceptance pt 5) : 2 fichiers, detecteur + tests.

## Tests (52 pass : 46 detecteur + 6 gate guard)

- `test_zero_id_pure_reorder_no_signal` : reorder pur zero-id -> `findings == []`.
  **Discriminant verifie** : FAIL contre le code post-#10885 sans le court-circuit
  (neutralise temporairement, echec confirme, restaure, suite re-verte).
- `test_zero_id_real_truncation_still_signals` : vraie troncature zero-id ->
  signale toujours (non-blanc-seing, acceptance pt 3).
- `test_zero_id_same_length_substitution_still_signals` : substitution
  meme-longueur + reorder -> signale (X remplacé par X' distinct de meme
  longueur ; totaux egaux, multiset different — la preuve multiset > totaux).
- Test legacy `test_reorder_without_ids_falls_back_to_index_legacy` (constatation
  passive) remplacé par les assertions fortes ci-dessus.

## Non-regression

- Subset-ID matching (#10885) intact : le court-circuit ne retourne [] QUE
  quand aucun contenu n'a change, cas ou l'appariement id-e aurait aussi
  rendu 0 finding.
- FRONTMATTER_COST_DIVERGENCE non masque : une divergence cost implique une
  chaine modifiee, donc un multiset different, donc le passage legacy.
- Gate guard end-to-end (6 tests) vert.

See #10725 #10732 #10723 #10785 #10810 (debloquees) · See #10848 (instance
1/150, remede A etroit legitimate car cible) · mesure d'origine citee dans #10873.