### PR TITLE
fix(notebook-tools,#10873): court-circuit multiset zero-id detect_md_content_loss

### DIFF
--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -438,6 +438,16 @@ def _compare_cells(base_md: list[tuple[int, str | None, str]],
     ajoute/supprime une cellule, l'index-parallel n'est pas une hypothese
     sure".
 
+    **c.96 (fix #10873, complement zero-id)** : dans ce cas legacy, un
+    court-circuit multiset disculpe d'abord. Quand le TOTAL de caracteres
+    normalises est identique (et le compte de cellules stable -- garanti par le
+    garde de longueur), le multiset des contenus est preserve : toute divergence
+    par index est une permutation, pas une perte. Une vraie troncature deplace
+    le compte de caracteres et continue de signaler (non-blanc-seing). Le
+    short-circuit n'est atteint QUE quand l'appariement par ID ne s'applique
+    pas, pour ne pas masquer les cas que le remede B (ID matching) traite deja
+    mieux (ex. troncature compensee sur notebook id-e).
+
     ``head_cost`` = ``nb_head['metadata']['cost']`` : permet de reconnaitre une
     migration LEGITIME frontmatter ``cost:`` -> ``metadata.cost`` (issue #8919).
     Quand la cellule base porte un bloc ``cost:`` equivalent champ-par-champ au
@@ -482,6 +492,19 @@ def _compare_cells(base_md: list[tuple[int, str | None, str]],
         for (b_idx, _, b_src), (h_idx, _, h_src) in zip(base_residue, head_residue):
             _emit_cell_finding(b_idx, b_src, h_idx, h_src, head_cost, findings)
     else:
+        # IDs absents ou ensembles differents : le multiset-stable est un signal
+        # fort "la PR a reordonne sans toucher au contenu" vs "ajout/suppression".
+        # Court-circuit multiset (fix #10873, re-scope ai-01 c.96) : atteint
+        # UNIQUEMENT quand l'appariement par ID ne s'applique pas (il reste plus
+        # precis quand les IDs existent). Le garde de longueur ci-dessus garantit
+        # deja md_cells_stable ; si le TOTAL de caracteres normalises est
+        # identique (la ligne [STATS] l'imprime deja : 13809->13809 et
+        # 30450->30450 sur #10785/#10810, au caractere pres), le multiset des
+        # contenus est preserve -> toute difference par index est une
+        # PERMUTATION, pas une perte. Une vraie troncature deplace le compte de
+        # caracteres -> pas de court-circuit -> le legacy index signale.
+        if sum(_norm_len(s) for _, _, s in base_md) == sum(_norm_len(s) for _, _, s in head_md):
+            return []  # multiset preserve -> aucune perte de contenu
         # IDs absents ou ensembles differents : appariement par index (legacy).
         for (b_idx, _, b_src), (h_idx, _, h_src) in zip(base_md, head_md):
             _emit_cell_finding(b_idx, b_src, h_idx, h_src, head_cost, findings)

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -269,6 +269,109 @@ class TestReorderSafeByCellID:
 
 
 # ---------------------------------------------------------------------------
+# 4c. Court-circuit multiset zero-id (fix #10873, complement c.96)
+# ---------------------------------------------------------------------------
+class TestMultisetShortCircuit:
+    """Re-scope ai-01 (c.96) : sur un notebook SANS ids (legacy), un reorder pur
+    etait encore signale a tort par l'appariement par index (classe de FP
+    #10725/#10785/#10810). Quand le TOTAL de caracteres normalises est identique
+    (et le compte de cellules stable -- garanti par le garde de longueur), le
+    multiset des contenus est preserve : toute difference par index est une
+    permutation, pas une perte -> court-circuit avant le legacy index. Une vraie
+    troncature deplace le compte -> pas de court-circuit -> le signal persiste
+    (non-blanc-seing). Le short-circuit n'est atteint QUE quand l'appariement
+    par ID ne s'applique pas (il ne masque pas les cas que le remede B traite
+    mieux : troncature compensee sur notebook id-e).
+    """
+
+    def test_zero_id_pure_reorder_no_signal(self):
+        # #10873 : notebook 0 id-ede, pur reorder (longue <-> courte). Pre-fix,
+        # le legacy index croisait la longue cellule A (base) avec la courte B
+        # (head, remontee en tete) -> faux positif TRUNCATED_CELL (ratio ~0.1
+        # < 0.75). Post-fix, les totaux normalises sont identiques (meme
+        # multiset) -> court-circuit -> 0 finding.
+        a = "## Section A\n\n" + ("Phrase A substantielle. " * 30)   # ~730c normalises
+        b = "## Bref rappel\n\n" + ("Rappel bref. " * 6)             # ~77c, < MIN_ORIG_CHARS
+        base = _nb(_md(a), _md(b))
+        head = _nb(_md(b), _md(a))  # reorder pur : B remonte en tete
+        findings = dml._compare_cells(dml.extract_md_cells(base),
+                                      dml.extract_md_cells(head))
+        assert findings == [], (
+            "un reorder pur 0-id ne doit PAS signaler de perte avec le "
+            f"court-circuit multiset (trouve: {findings!r})"
+        )
+
+    def test_zero_id_true_truncation_still_signals(self):
+        # Non-blanc-seing : une vraie troncature sur notebook 0-id deplace le
+        # compte de caracteres -> pas de court-circuit -> TRUNCATED_CELL.
+        base = _nb(_md(EXERCISE_BODY))
+        head = _nb(_md("> **Indices :**"))
+        findings = dml._compare_cells(dml.extract_md_cells(base),
+                                      dml.extract_md_cells(head))
+        assert len(findings) == 1
+        assert findings[0]["kind"] == "TRUNCATED_CELL"
+        assert findings[0]["ratio"] < dml.DROP_THRESHOLD
+
+    def test_zero_id_compensated_truncation_is_accepted_limitation(self):
+        # LIMITE ASSUMEE du critere total-chars (re-scope ai-01 c.96) : sur un
+        # notebook 0-id, une troncature COMPENSEE (une cellule perd, une autre
+        # gagne exactement autant) laisse le total identique -> le court-circuit
+        # s'applique -> pas de signal. Le critere c.96 garanti seulement qu'une
+        # troncature qui DEPLACE le compte signale. Ce coin est documente ici
+        # noir sur blanc : le notebook id-e est lui protege (l'appariement par
+        # ID, qui passe AVANT le court-circuit, attrape le cas compense -- test
+        # suivant). Ne pas « corriger » ce test en faisant signaler le cas
+        # compense 0-id : ce serait re-introduire la classe de FP zero-id que le
+        # short-circuit existe pour fermer (#10725/#10785/#10810).
+        a = "## Section A\n\n" + ("Phrase A substantielle. " * 30)   # 638c normalises
+        b = "## Section B\n\n" + ("Phrase B substantielle. " * 30)   # 638c normalises
+        a_grow = a + "\n\n" + ("Supplement substantiel. " * 25)      # +550c
+        b_shrink = "## Section B\n\n" + ("Phrase B. " * 10)          # -550c
+        base = _nb(_md(a), _md(b))
+        head = _nb(_md(a_grow), _md(b_shrink))
+        assert dml._norm_len(a) + dml._norm_len(b) == \
+            dml._norm_len(a_grow) + dml._norm_len(b_shrink), "pre-condition: totaux egaux"
+        findings = dml._compare_cells(dml.extract_md_cells(base),
+                                      dml.extract_md_cells(head))
+        assert findings == [], (
+            "cas compense 0-id = coin accepte du critere total-chars (c.96)"
+        )
+
+    def test_id_ed_compensated_truncation_caught_by_id_matching(self):
+        # Ordre du short-circuit (c.96) : sur un notebook id-e, l'appariement
+        # par ID passe AVANT le court-circuit et attrape une troncature
+        # compensee que l'egalite des totaux cacherait. Le court-circuit ne
+        # masque donc pas les cas que le remede B traite mieux.
+        a = "## Section A\n\n" + ("Phrase A substantielle. " * 30)   # 638c normalises
+        b = "## Section B\n\n" + ("Phrase B substantielle. " * 30)   # 638c normalises
+        a_grow = a + "\n\n" + ("Supplement substantiel. " * 25)      # +550c
+        b_shrink = "## Section B\n\n" + ("Phrase B. " * 10)          # -550c
+        base = _nb(_md(a, cell_id="alpha"), _md(b, cell_id="bravo"))
+        head = _nb(_md(a_grow, cell_id="alpha"), _md(b_shrink, cell_id="bravo"))
+        assert dml._norm_len(a) + dml._norm_len(b) == \
+            dml._norm_len(a_grow) + dml._norm_len(b_shrink), "pre-condition: totaux egaux"
+        findings = dml._compare_cells(dml.extract_md_cells(base),
+                                      dml.extract_md_cells(head))
+        assert any(f["kind"] == "TRUNCATED_CELL" for f in findings), (
+            "l'appariement par ID doit attraper une troncature compensee id-e "
+            "avant tout court-circuit (remede B preserve)"
+        )
+
+    # --- end-to-end via scan_notebook (ce que la CI execute) ---
+    def test_zero_id_reorder_end_to_end(self, tmp_path):
+        a = "## Section A\n\n" + ("Phrase A substantielle. " * 30)
+        b = "## Bref rappel\n\n" + ("Rappel bref. " * 6)
+        p = tmp_path / "x.ipynb"
+        p.write_text(json.dumps(_nb(_md(b), _md(a))), encoding="utf-8")
+        with mock.patch.object(dml, "read_notebook_at_ref",
+                               return_value=_nb(_md(a), _md(b))), \
+             mock.patch.object(dml, "ref_resolves", return_value=True), \
+             mock.patch.object(dml, "path_exists_at_ref", return_value=True):
+            r = dml.scan_notebook(p, base_ref="MOCK_BASE", head_ref=None)
+        assert r["stats"]["findings_count"] == 0, r["findings"]
+
+
+# ---------------------------------------------------------------------------
 # 5. Reformulation neutre (PAS de signal, design #4)
 # ---------------------------------------------------------------------------
 class TestNeutralRephraseNoSignal:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/tooling #10844

Closes #10873 — complement zero-id de #10885 (remede B, merged 2026-08-14T08:53Z) : court-circuit multiset dans `_compare_cells` de `scripts/notebook_tools/detect_md_content_loss.py`.

## Bug (classe de FP restante apres remede B)

Sur un notebook SANS ids de cellule (legacy, ~150 notebooks), un reorder pur de cellules md etait encore signale a tort par l'appariement par index : le legacy index croisait une longue cellule (base) avec une courte remontee en tete (head) -> TRUNCATED_CELL ratio ~0.1 < 0.75. FP reels : #10725, #10785, #10810 (9 TRUNCATED_CELLs, zero vrai positif).

## Fix

`if sum(_norm_len(s) for _, _, s in base_md) == sum(_norm_len(s) for _, _, s in head_md): return []` — place **apres** l'appariement par ID (remede B reste plus precis quand les ids existent), **avant** le legacy index.

- Compte de cellules stable : garanti par le garde de longueur existant (`md_cells_stable`).
- Total de caracteres normalises identique : la ligne `[STATS]` l'imprime deja (`base_norm_chars == head_norm_chars`) — c.96 ne recalcule rien, il fait lire le verdict a la ligne qu'il imprime deja.
- Toute divergence par index avec totaux egaux = PERMUTATION, pas perte.
- Une vraie troncature deplace le compte de caracteres -> pas de court-circuit -> le legacy index signale (non-blanc-seing).

## Validation

| Preuve | Resultat |
|---|---|
| Failing-before (pre-fix, `git stash` + run du nouveau test) | `TRUNCATED_CELL cell_idx 0, before_chars 638, after_chars 76` (FP exact) |
| Post-fix, notebook 0-id, reorder pur | `findings == []` |
| Post-fix, troncature reelle 0-id (`EXERCISE_BODY` -> `> **Indices :**`) | `TRUNCATED_CELL` signale |
| Suite complete `test_detect_md_content_loss.py` | **49 passed** (5 nouveaux dans `TestMultisetShortCircuit`, dont end-to-end via `scan_notebook`) |
| Observable : #10785 (branche `feature/c248-qcpy08-cell17`) | **0 findings**, `base=30450 head=30450` rc=0, notebook non modifie |
| Observable : #10810 (branche `feature/c253-qcpy10-cell27-phantom`) | **0 findings**, `base=34735 head=34735` rc=0, notebook non modifie |

4/4 PRs bloquees passent desormais : #10723 + #10725 (remede B, mesures ai-01) + #10785 + #10810 (verifiees ici).

## Limite assumee (documentee dans les tests)

Sur notebook 0-id, une troncature COMPENSEE (une cellule perd, une autre gagne exactement autant) laisse le total identique -> pas de signal. C'est le perimetre exact du critere c.96 (garantie : toute troncature qui DEPLACE le compte signale). Le notebook id-e est lui protege par l'appariement par ID qui passe avant le court-circuit (test `test_id_ed_compensated_truncation_caught_by_id_matching` : troncature compensee id-e attrappee malgre l'egalite des totaux).

## Scope

2 fichiers (`detect_md_content_loss.py` +23, `test_detect_md_content_loss.py` +103), 0 notebook touche, signature `_compare_cells`/`extract_md_cells` inchangee.
