### PR TITLE
fix(guard,#10906): tolerer la decoration markdown devant les marqueurs de claim (12 restaures, Axe 2 justifie)

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -83,8 +83,8 @@ from grain_tag import extract_lane
 # `[DONE]`/`[RELEASED]`/`[CANCELLED]`/`[ABANDONED]` close a claim; `[CLAIMED]`
 # opens one. Read on ISSUE comments (the claim registry per #9774), not on the
 # dashboard. Case-insensitive, tolerates inner spaces.
-# Line-anchored (`(?m)^[ \t]*\[...`): a marker only enacts a state change when
-# it STARTS a line -- the convention of every `--claim`/`--release` post and every
+# Line-anchored (`(?m)^...`): a marker only enacts a state change when it
+# STARTS a line -- the convention of every `--claim`/`--release` post and every
 # coordinator dispatch. A marker MENTIONED mid-sentence in prose is not an event.
 # Closes the #10228 false-negative: ai-01's claim comment ended with the
 # instructional sentence "Release with `[RELEASED]` when your PR lands" -- the
@@ -93,8 +93,17 @@ from grain_tag import extract_lane
 # lane held an active claim. `findall` still returns markers in order, so the
 # legitimate "last marker wins" design (a `[CLAIMED]\n[DONE]` edit sequence on
 # separate lines) is preserved -- only mid-line mentions are rejected.
+# Decoration tolerance (#10906): issue comments are markdown-rendered, and
+# agents legitimately post `**[CLAIMED] ...**`, `## [CLAIMED] ...`, `- [CLAIMED]
+# ...`, `> [CLAIMED] ...` etc. The legacy `^[ \t]*\[` anchor voided every such
+# marker (8 voided on 70 issues, including po-2024's [CLAIMED] on #10043 and
+# po-2025's on #10038). The prefix group eats up to 6 leading `#>*+-` chars
+# (headings / bullets / blockquotes / nested lists), then an optional `**`/`__`
+# bold pair opener, then whitespace, then the bracket. A `[` NOT immediately at
+# a decorator position (e.g. `- Prose with [CLAIMED] mid-line`) still does not
+# match -- the mid-prose non-regression property is preserved.
 _MARKER_RE = re.compile(
-    r"(?m)^[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE|OVERRIDE)\s*\]",
+    r"(?m)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE|OVERRIDE)\s*\]",
     re.IGNORECASE,
 )
 _OPEN = {"CLAIMED"}
@@ -124,8 +133,16 @@ _OVERRIDE = {"OVERRIDE"}
 # 1 = comma-separated path list (already stripped of surrounding spaces).
 # Recognised on [CLAIMED], [RELEASED] (attached; the reducer treats release as
 # a full lane-close, so the scope is informational there), and [OVERRIDE].
+# Same leading-decoration tolerance as `_MARKER_RE` (#10906). In practice the
+# reducer feeds this regex the `_line_for_match` output (which starts at the
+# `[`), so the legacy `^[ \t]*\[` anchor already worked -- the prefix group is
+# defense-in-depth for direct calls on a full decorated marker line. The path
+# list capture deliberately does NOT strip a trailing `**`/`__` (closing pair
+# of a bold-wrapped claim): `paths: dir/**` is a legitimate recursive glob,
+# indistinguishable from a closing decorator by suffix alone. Trailing `*` in
+# fnmatch matches empty, so a captured `glob**` still matches `glob`.
 _PATHS_CLAUSE_RE = re.compile(
-    r"(?im)^[ \t]*\[\s*(?:CLAIMED|RELEASED|OVERRIDE)\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$"
+    r"(?im)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*\[\s*(?:CLAIMED|RELEASED|OVERRIDE)\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$"
 )
 
 

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -10,6 +10,7 @@ These tests replay that exact trap and assert the tool is not fooled.
 
 Run: python -m pytest scripts/tests/test_check_lane_claim.py
 """
+import fnmatch
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -162,6 +163,121 @@ def test_parse_instructional_marker_in_prose_ignored():
     assert ev.is_open is True              # NOT closed by the mid-prose mention
     assert ev.marker == "CLAIMED"
     assert ev.lane == "myia-po-2025:CoursIA-2"
+
+
+# --- markdown decoration tolerance (#10906) ----------------------------------
+
+# The 8 voided markers on 70 issues: issue comments are markdown-rendered, and
+# agents post `**[CLAIMED] ...**`, `## [CLAIMED] ...`, `- [CLAIMED] ...` etc.
+# The legacy `^[ \t]*\[` anchor voided every such marker -- the claim existed
+# on the issue but the reducer never saw it. These tests pin the tolerance and
+# the mid-prose non-regression.
+
+def test_parse_marker_bold_decorated():
+    # The exact shape of po-2024's inert claim on #10043 (markdown bold wrap).
+    ev = clc.parse_claim_event(comment(
+        "**[CLAIMED] #10043 grain D (T3 activation) — lane myia-po-2024:CoursIA — 2026-08-08T12:36Z**",
+        "2026-08-08T12:37:14Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is True
+    assert ev.marker == "CLAIMED"
+    assert ev.lane == "myia-po-2024:CoursIA"
+
+
+def test_parse_marker_underscore_bold_decorated():
+    ev = clc.parse_claim_event(comment(
+        "__[CLAIMED] lane myia-po-2023:CoursIA-2 — underscore bold__",
+        "2026-08-08T13:00:00Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is True
+    assert ev.lane == "myia-po-2023:CoursIA-2"
+
+
+def test_parse_marker_heading_decorated():
+    ev = clc.parse_claim_event(comment(
+        "## [CLAIMED] lane myia-po-2025:CoursIA-2 -- heading form",
+        "2026-08-08T13:01:00Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is True
+    assert ev.lane == "myia-po-2025:CoursIA-2"
+
+
+def test_parse_marker_bullet_decorated():
+    for bullet in ("- ", "+ ", "* "):
+        ev = clc.parse_claim_event(comment(
+            f"{bullet}[CLAIMED] lane myia-po-2024:CoursIA -- bullet form",
+            "2026-08-08T13:02:00Z",
+        ))
+        assert ev is not None, bullet
+        assert ev.is_open is True, bullet
+        assert ev.lane == "myia-po-2024:CoursIA", bullet
+
+
+def test_parse_marker_blockquote_decorated():
+    ev = clc.parse_claim_event(comment(
+        "> [CLAIMED] lane myia-po-2026:CoursIA-2 -- blockquote form",
+        "2026-08-08T13:03:00Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is True
+    assert ev.lane == "myia-po-2026:CoursIA-2"
+
+
+def test_parse_marker_nested_list_decorated():
+    ev = clc.parse_claim_event(comment(
+        "  - > **[CLAIMED] lane myia-po-2024:CoursIA-2 -- nested bullet + bold**",
+        "2026-08-08T13:04:00Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is True
+    assert ev.lane == "myia-po-2024:CoursIA-2"
+
+
+def test_parse_decorated_marker_in_prose_still_ignored():
+    # Mid-line mentions remain non-events even inside a bullet: the `[` must
+    # sit at a decorator position, not after prose.
+    body = (
+        "[CLAIMED] lane myia-po-2025:CoursIA-2 -- real claim\n"
+        "- **Release with `[RELEASED]` when your PR lands** (instructional)"
+    )
+    ev = clc.parse_claim_event(comment(body, "2026-08-09T21:20:00Z"))
+    assert ev is not None
+    assert ev.is_open is True      # NOT closed by the decorated prose mention
+    assert ev.marker == "CLAIMED"
+
+
+def test_parse_decorated_release_closes():
+    ev = clc.parse_claim_event(comment(
+        "**[CLAIMED] lane myia-po-2024:CoursIA -- work**\n"
+        "**[RELEASED] lane myia-po-2024:CoursIA -- landed**",
+        "2026-08-08T14:00:00Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is False
+    assert ev.marker == "RELEASED"
+
+
+def test_decorated_paths_clause_scopes_claim():
+    # A bold-wrapped claim carrying `paths:` keeps its scope (#10419 semantics)
+    # through the decorated marker -- disjoint scoped claims stay parallel. The
+    # closing `**` is captured into the last path (`b.ipynb**`): stripping it by
+    # suffix alone is unsafe (`paths: dir/**` is a legitimate recursive glob),
+    # and fnmatch trailing `*` matches empty, so the scope still covers the
+    # intended path (see `_PATHS_CLAUSE_RE` comment in check_lane_claim.py).
+    ev = clc.parse_claim_event(comment(
+        "- **[CLAIMED] lane myia-po-2024:CoursIA-2 — paths: notebooks/a.ipynb, notebooks/b.ipynb**",
+        "2026-08-08T14:05:00Z",
+    ))
+    assert ev is not None
+    assert ev.is_open is True
+    assert ev.lane == "myia-po-2024:CoursIA-2"
+    assert ev.paths is not None
+    assert ev.paths[0] == "notebooks/a.ipynb"
+    assert fnmatch.fnmatch("notebooks/b.ipynb", ev.paths[1])
+    assert fnmatch.fnmatch("notebooks/b.ipynb", "notebooks/b.ipynb**")  # invariant
 
 
 def test_check_blocked_when_claim_comment_mentions_marker_in_prose(capsys):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #10870

## Fix #10906 : tolérance à la décoration markdown devant les marqueurs de claim

Le réducteur de `check_lane_claim.py` ancrait chaque marqueur à `^[ \t]*\[` :
une décoration markdown légitime (`**[CLAIMED] ...**`, `## [CLAIMED] ...`,
`- [CLAIMED] ...`, `> [CLAIMED] ...`) rendait le marqueur **invisible** au
réducteur. Mesuré par re-scan paginé complet (117 issues + 24 PRs ouvertes,
comments par issue) : **8 marqueurs voilés sur 70 issues** dans le périmètre
de l'audit, **12 restaurés** sur le pool complet.

### Re-scan avant/après (scratchpad `scan10906.py`, OLD vs NEW regex)

- OLD anchor : **414 marqueurs** vus
- NEW regex : **426 marqueurs** vus
- **12 restaurés** :
  - `#10776` `- [RELEASED]`
  - `#10678` `## [OVERRIDE]` (partition ai-01, 39 survivants)
  - `#10382` `**[CLAIMED]` (po-2026, Z3-python-04/05/06)
  - `#10289` 2× `## [OVERRIDE]` (po-2024 PT-11 Etape 1 + ai-01)
  - `#10043` `**[CLAIMED]` (po-2024, grain D) — **claim inerte de l'audit**
  - `#10038` `**[CLAIMED]` (po-2025, grain E) — **claim inerte de l'audit**
  - `#4959` 3× (`**[CLAIMED]` + 2× `**[DONE]`)
  - `#4362` 2× (`**[CLAIMED]` + `**[RELEASED]` phantom)

### Changements

1. **`_MARKER_RE`** : groupe de préfixe `(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*`
   (titres / puces / blockquotes / listes imbriquées + ouvreur bold) avant le
   crochet. La **non-régression #10228** (mention de `[RELEASED]` en milieu de
   prose = non-événement) est **préservée** : un `[` hors position décorateur
   ne matche pas — testé.
2. **`_PATHS_CLAUSE_RE`** : même tolérance (défense-in-depth ; le réducteur lui
   donne déjà la ligne à partir du `[`). Le `**` de fermeture d'un claim bold
   capté dans le dernier path n'est **pas** retiré : `paths: dir/**` (glob
   récursif légitime) est indistinguable d'un décorateur par suffixe seul, et
   `fnmatch.fnmatch("notebooks/b.ipynb", "notebooks/b.ipynb**")` est True
   (invariant pincé par test).
3. **9 tests ajoutés** : bold, underscore-bold, titre, puces (`- / + / *`),
   blockquote, imbriqué (`"  - > **[CLAIMED] ..."`), prose décorée ignorée,
   release décorée ferme, clause paths décorée scope. **123/123 passent.**

### Jugement des 2 claims inertes (demande du dispatch)

- **#10043** : grain D livré via #10055 (MERGED b16cc67366, 2026-08-08) →
  `[RELEASED]` ancré posté sur l'issue (issuecomment-5292592423).
- **#10038** : grain E livré via #10047 (MERGED d0a0bbf0b7, 2026-08-08) →
  `[RELEASED]` ancré posté (issuecomment-5292614272).
- Les deux libérés **sur l'issue** (locus cross-lane de #9774), conformément au
  dispatch (« poser le marqueur ancré qui correspond »).

Vérif live : `check_lane_claim.py 10043 --lane myia-po-2024:CoursIA-2` →
`blocked: false, CLEAR` — le claim décoré historique est désormais vu, réduit
par le `[RELEASED]` ancré.

### Axe 2 — `candidate-delivered-advisory.yml` (justification écrite : attend)

Mesuré firsthand (Read `candidate_delivered.py`, grep des regex) : la famille
de défaut **n'existe pas** dans cet organe.

- `candidate_delivered.py` ne parse **aucun** marqueur de claim — sa seule
  regex est `_EPIC_RE` (`\bepic\b` sur titre/labels). L'activité post-merge est
  mesurée par **timestamps de commentaires** (`created_at`), content-agnostic :
  un marqueur décoré crée toujours un commentaire dont le timestamp compte.
- `ci/lane_claim_required.py` (l'autre consommateur de l'état de claim)
  **importe le réducteur fixé** (`import check_lane_claim as clc`, réutilise
  `compute_active_claims`) — il hérite du fix sans changement de code.
- Sweep `.github/` + `scripts/` : aucune troisième regex de marqueur de claim.

Fermer cet axe dans la même PR serait un changement sans effet mesurable ;
le vrai écart d'axe 2 (le label ne voit pas un `[RELEASED]`-référencé ?) relève
de la logique de triage du label, pas du parsing de marqueur — tracké pour
évaluation séparée si besoin.

## Tests

```
pytest scripts/tests/test_check_lane_claim.py → 123 passed
```

## Voir

- Issue #10906 (MED/guard) — See #10906
