### PR TITLE
fix(qc,#10909): ML-Classification — joblib.loads->joblib.load(BytesIO) + 2 bugs runtime bloquants

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/ML-Classification/main.py
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/ML-Classification/main.py
@@ -58,9 +58,11 @@ class MLClassificationAlgorithm(QCAlgorithm):
             if not self.ObjectStore.ContainsKey(self.MODEL_KEY):
                 raise Exception(f"Modele non trouve dans ObjectStore: {self.MODEL_KEY}")
 
-            # Charger le modele
+            # Charger le modele (producer = pickle.dumps dans quantbook.ipynb;
+            # joblib.load lit un flux pickle, contrairement a joblib.loads qui
+            # n'existe pas)
             model_bytes = self.ObjectStore.ReadBytes(self.MODEL_KEY)
-            self.model = joblib.loads(bytes(model_bytes))
+            self.model = joblib.load(BytesIO(bytes(model_bytes)))
 
             # Charger la configuration
             if self.ObjectStore.ContainsKey(self.CONFIG_KEY):
@@ -88,16 +90,16 @@ class MLClassificationAlgorithm(QCAlgorithm):
 
     def setup_indicators(self):
         """Configurer les indicateurs techniques pour les features."""
-        # RSI
-        self.rsi = self.RSI(self.symbol, 14, Resolution.Daily)
+        # RSI (resolution en mot-cle: 3e positionnel = moving_average_type)
+        self.rsi = self.RSI(self.symbol, 14, resolution=Resolution.Daily)
 
         # EMA
         self.ema10 = self.EMA(self.symbol, 10, Resolution.Daily)
         self.ema20 = self.EMA(self.symbol, 20, Resolution.Daily)
         self.ema50 = self.EMA(self.symbol, 50, Resolution.Daily)
 
-        # MACD
-        self.macd = self.MACD(self.symbol, 12, 26, 9, Resolution.Daily)
+        # MACD (resolution en mot-cle: 5e positionnel = moving_average_type)
+        self.macd = self.MACD(self.symbol, 12, 26, 9, resolution=Resolution.Daily)
 
         # Historique des prix pour les returns et volatilite
         self.price_history = []
@@ -111,7 +113,8 @@ class MLClassificationAlgorithm(QCAlgorithm):
         if self.IsWarmingUp or self.model is None:
             return
 
-        if not data.ContainsKey(self.symbol):
+        # ContainsKey peut etre True avec une valeur None (jour de gap/delist)
+        if not data.ContainsKey(self.symbol) or data[self.symbol] is None:
             return
 
         # Mettre a jour l'historique des prix


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2024:CoursIA-2 — prev: MED/guard #10911

## Fix #10909 : `joblib.loads` -> `joblib.load(BytesIO(...))` dans ML-Classification

`joblib.loads` n'existe pas (`joblib.load` lit un flux pickle). Le producer
`quantbook.ipynb` écrit `pickle.dumps(model)` dans ObjectStore : on charge donc
avec `joblib.load(BytesIO(bytes(model_bytes)))`. Vérifié : c'est la **seule**
occurrence de `joblib.loads` dans `projects/ML-Classification/**` (acceptance
point 2). Preuve format pickle vérifiée localement (RandomForest du producer,
`predict_proba` OK).

### Backtest QC Cloud — preuve end-to-end (acceptance point 1)

Projet **35167230**, fenêtre alignée #1630 (2018-01-01 → 2025-01-01), 1761 jours.
Chaque run a révélé un bug runtime pré-existant supplémentaire, corrigé dans la
même partition :

| Run | Erreur | Fix |
|---|---|---|
| v1 | `joblib.loads` inexistant (le bug de l'issue) | `joblib.load(BytesIO(bytes(...)))` |
| v2 | `TypeError` RSI/MACD : `Resolution.Daily` en positionnel (3e/5e arg = `moving_average_type`) | mot-clé `resolution=...` (EMA, 3e positionnel = resolution, était correct) |
| v3 | `'NoneType' object has no attribute 'Close'` (`ContainsKey` True avec valeur None, jour de gap/delist) | guard `data[self.symbol] is None` |

**Résultat v3 : `Completed`** — 1761 jours, **27 ordres**, Sharpe **0.631**,
CAGR **16.633 %**, MaxDD **33.7 %**, net profit **+193.8 %** ($193.8k),
PSR 9.6 %.

Les 27 ordres = prédictions émises = `self.model` chargé depuis ObjectStore =
**`joblib.load` exécuté au runtime** : le fix est prouvé end-to-end, pas
seulement en compilation. Verdict : `EXEC_PROVED`.

### Périmètre

- Partition respectée : uniquement `projects/ML-Classification/main.py`
  (10 insertions / 7 suppressions).
- `docs/qc/qc-strategies-status.md` est **HOLD par la lane myia-po-2024:CoursIA**
  (partition #10909) — non touché ici.
- Note honnête : ObjectStore de ce projet contient déjà un modèle (d'où les
  27 ordres) ; sur un projet à ObjectStore vide, le chemin honnête
  `self.model = None` → 0 trade est préservé par le try/except.

## Tests

- `py_compile` : OK.
- Preuve locale du format : `joblib.load(BytesIO(pickle.dumps(model)))` +
  `predict_proba` contre le format du producer.

## Voir

- Issue #10909 — See #10909
