### PR TITLE
feat(genai,#10913): presenter AI Engine par son API — instance jetable + 1er notebook

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/.env.example
@@ -1,0 +1,33 @@
+# Instance jetable « Maison Valmont » — variables d'environnement
+# Copier vers .env et remplir. NE JAMAIS commiter .env.
+# Les notebooks lisent instance-jetable/.env (base URL + app password).
+
+# --- Reseau ---------------------------------------------------------------
+# Port public de l'instance WordPress
+VALMONT_PORT=8093
+
+# URL de base vue depuis la machine hote (les notebooks l'utilisent)
+VALMONT_BASE_URL=http://localhost:8093
+
+# --- Base de donnees (valeurs par defaut du compose) -----------------------
+VALMONT_DB_USER=valmont
+VALMONT_DB_PASSWORD=valmont_db_pass
+VALMONT_DB_NAME=valmont
+VALMONT_DB_ROOT_PASSWORD=valmont_root_pass
+
+# --- Compte admin WordPress (etape 3 du README) ----------------------------
+VALMONT_ADMIN_USER=admin
+VALMONT_ADMIN_PASSWORD=change-me-strong-password
+VALMONT_ADMIN_EMAIL=admin@example.test
+
+# --- LLM local compatible OpenAI (etape 4, seed) ---------------------------
+# Docker Desktop : http://host.docker.internal:<port>/v1
+# Linux natif    : http://172.17.0.1:<port>/v1
+VALMONT_LLM_BASE_URL=http://host.docker.internal:11434/v1
+VALMONT_LLM_API_KEY=sk-local
+VALMONT_LLM_MODEL=qwen3.6-35b-a3b
+VALMONT_LLM_MODEL_NAME=Qwen 3.6 35B A3B
+
+# --- Authentification API pour les notebooks ------------------------------
+# Application password cree a l'etape 5 du README (wp user application-password create)
+VALMONT_APP_PASSWORD=

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/README.md
@@ -1,0 +1,101 @@
+# Instance jetable « Maison Valmont »
+
+Instance WordPress jetable, dediee a la serie de notebooks
+`presenter-ai-engine-par-son-api.ipynb` et suivants : ils presentent
+**AI Engine par son API** — fonctionnalites de base et avancees, et ce qu'on
+en a fait dans le projet Livres Agites.
+
+Pourquoi une instance dediee : les notebooks appellent une API reelle.
+L'instance du projet contient des donnees client (livres, noms, manuscrits) —
+elle est donc exclue du depôt public. Cette instance-ci est 100 % jetable
+(`docker compose down -v` efface tout) et peuplée d'un corpus synthetique
+« Maison Valmont », maison d'edition fictive.
+
+## Contenu
+
+| Fichier | Role |
+|---------|------|
+| `docker-compose.jetable.example.yml` | Pile WordPress 6.8.3 + MariaDB + wp-cli, port 8093 |
+| `seed-valmont.php` | Branche AI Engine sur le LLM local, cree le chatbot « valmont », active l'API publique |
+| `.env.example` | Variables attendues (copier vers `.env`, ne jamais commiter `.env`) |
+
+## Prérequis
+
+- Docker (Desktop sur Windows/macOS, ou daemon natif sous Linux) ;
+- Un **LLM local compatible OpenAI** (`/v1/chat/completions`) : Ollama
+  (`http://localhost:11434/v1`), vLLM, LM Studio, ... — la variable
+  `VALMONT_LLM_BASE_URL` le decrit ;
+- Python 3.10+ avec `requests` et `python-dotenv` pour executer les notebooks.
+
+## Montage en 5 étapes
+
+### 1. Configurer `.env`
+
+```powershell
+Copy-Item .env.example .env
+# puis editer .env : port, admin, URL du LLM local (host.docker.internal pour Docker Desktop)
+```
+
+> Sur Linux natif, `host.docker.internal` n'existe pas : utiliser l'IP de la
+> passerelle Docker, par exemple `http://172.17.0.1:11434/v1`.
+
+### 2. Lancer la pile
+
+```powershell
+docker compose -f docker-compose.jetable.example.yml up -d
+# attendre que wordpress soit healthy (docker ps)
+```
+
+### 3. Installer WordPress + AI Engine
+
+```powershell
+# URL a aligner sur VALMONT_PORT
+docker exec valmont-wordpress_cli-1 sh -c "wp core install --url=http://localhost:8093 --title='Maison Valmont' --admin_user=$env:VALMONT_ADMIN_USER --admin_password=$env:VALMONT_ADMIN_PASSWORD --admin_email=$env:VALMONT_ADMIN_EMAIL --skip-email --allow-root"
+
+# AI Engine 3.7.0 — version gratuite, telechargee depuis wordpress.org (reproductible)
+docker exec valmont-wordpress_cli-1 sh -c "curl -sL -o /tmp/ai-engine.zip https://downloads.wordpress.org/plugin/ai-engine.3.7.0.zip && wp plugin install /tmp/ai-engine.zip --activate --allow-root"
+```
+
+### 4. Peupler (seed)
+
+```powershell
+docker cp seed-valmont.php valmont-wordpress_cli-1:/tmp/seed-valmont.php
+docker exec valmont-wordpress_cli-1 sh -c "php /tmp/seed-valmont.php"
+```
+
+Le seed branche AI Engine sur le LLM local (`VALMONT_LLM_*`), cree le chatbot
+« valmont » et autorise les application passwords.
+
+### 5. Creer l'application password, puis executer les notebooks
+
+```powershell
+docker exec valmont-wordpress_cli-1 sh -c "wp user application-password create $env:VALMONT_ADMIN_USER notebooks --porcelain --allow-root"
+# -> copier la cle dans .env, variable VALMONT_APP_PASSWORD
+```
+
+Les notebooks lisent `instance-jetable/.env` (base URL + admin + app password).
+Rien d'autre n'est requis : ils appellent l'API de l'instance en HTTP local.
+
+## Verification rapide
+
+```powershell
+curl http://localhost:8093/wp-json/    # repond {name: "Maison Valmont", ...}
+```
+
+Pour verifier l'acces authentifie (chatbots, completions), executer
+`presenter-ai-engine-par-son-api.ipynb` : c'est exactement ce que font ses
+cellules 3 a 6, avec l'application password lu depuis `.env`.
+
+## Nettoyage
+
+```powershell
+docker compose -f docker-compose.jetable.example.yml down -v   # detruit volumes et donnees
+```
+
+## Regles du chantier (rappel)
+
+- Aucune donnee client, aucun secret, aucune IP de provider dans le depôt :
+  tout passe par `.env` (exemple versionne, valeurs reelles jamais commitees).
+- Les sorties commitees des notebooks proviennent d'executions reelles contre
+  cette instance ; les reponses du modele sont normalisees par du code
+  (le LLM local peut emettre des emojis/markdown malgre les consignes).

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/docker-compose.jetable.example.yml
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/docker-compose.jetable.example.yml
@@ -1,0 +1,87 @@
+# Instance jetable « Maison Valmont » — pile WordPress + AI Engine pour la
+# serie de notebooks de presentation (presenter-ai-engine-par-son-api.ipynb).
+#
+# Usage :
+#   1. cp .env.example .env   (remplir les variables, dont l'URL du LLM local)
+#   2. docker compose -f docker-compose.jetable.example.yml up -d
+#   3. suivre instance-jetable/README.md (etapes 3 a 5 : install WP, seed, app password)
+#
+# L'instance est 100 % jetable : docker compose -f ... down -v detruit volumes
+# et donnees. Aucune donnee cliente — corpus synthetique « Maison Valmont ».
+# Le provider LLM (Ollama, vLLM, ...) doit etre compatible OpenAI
+# (/v1/chat/completions) et joignable depuis le conteneur wordpress :
+#   - Docker Desktop (Windows/macOS) : http://host.docker.internal:<port>/v1
+#   - Linux natif : IP de la passerelle, ex. http://172.17.0.1:<port>/v1
+
+services:
+  wordpress:
+    image: wordpress:6.8.3-php8.2-apache
+    container_name: valmont-wordpress-1
+    restart: unless-stopped
+    ports:
+      - "${VALMONT_PORT:-8093}:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: ${VALMONT_DB_USER:-valmont}
+      WORDPRESS_DB_PASSWORD: ${VALMONT_DB_PASSWORD:-valmont_db_pass}
+      WORDPRESS_DB_NAME: ${VALMONT_DB_NAME:-valmont}
+      WORDPRESS_CONFIG_EXTRA: |
+        define('WP_MEMORY_LIMIT', '512M');
+        define('WP_MAX_MEMORY_LIMIT', '512M');
+        @ini_set('display_errors', 0);
+        define('FORCE_SSL_ADMIN', false);
+    volumes:
+      - valmont-wp-data:/var/www/html
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  db:
+    image: mariadb:10.11
+    container_name: valmont-db-1
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: ${VALMONT_DB_ROOT_PASSWORD:-valmont_root_pass}
+      MYSQL_DATABASE: ${VALMONT_DB_NAME:-valmont}
+      MYSQL_USER: ${VALMONT_DB_USER:-valmont}
+      MYSQL_PASSWORD: ${VALMONT_DB_PASSWORD:-valmont_db_pass}
+    volumes:
+      - valmont-db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "root", "-p${VALMONT_DB_ROOT_PASSWORD:-valmont_root_pass}"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  wordpress_cli:
+    image: wordpress:cli-2.9.0-php8.2
+    container_name: valmont-wordpress_cli-1
+    restart: unless-stopped
+    user: "0:0"
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["tail -f /dev/null"]
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: ${VALMONT_DB_USER:-valmont}
+      WORDPRESS_DB_PASSWORD: ${VALMONT_DB_PASSWORD:-valmont_db_pass}
+      WORDPRESS_DB_NAME: ${VALMONT_DB_NAME:-valmont}
+      VALMONT_LLM_BASE_URL: ${VALMONT_LLM_BASE_URL:-http://host.docker.internal:11434/v1}
+      VALMONT_LLM_API_KEY: ${VALMONT_LLM_API_KEY:-sk-local}
+      VALMONT_LLM_MODEL: ${VALMONT_LLM_MODEL:-qwen3.6-35b-a3b}
+      VALMONT_LLM_MODEL_NAME: ${VALMONT_LLM_MODEL_NAME:-Qwen 3.6 35B A3B}
+    volumes:
+      - valmont-wp-data:/var/www/html
+    depends_on:
+      - db
+      - wordpress
+
+volumes:
+  valmont-db-data:
+    driver: local
+  valmont-wp-data:
+    driver: local

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/seed-valmont.php
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/seed-valmont.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Seed de l'instance jetable « Maison Valmont ».
+ *
+ * Branche AI Engine sur un provider LLM local compatible OpenAI
+ * (Ollama, vLLM, ...), active les modules et cree le chatbot « valmont ».
+ * Cree aussi un mu-plugin qui autorise les application passwords sans HTTPS
+ * (exigence WordPress 6.8 : wp_is_application_passwords_available).
+ *
+ * Usage (apres installation de WordPress et activation d'AI Engine, cf. README) :
+ *
+ *   docker cp seed-valmont.php valmont-wordpress_cli-1:/tmp/seed-valmont.php
+ *   docker exec valmont-wordpress_cli-1 sh -c "php /tmp/seed-valmont.php"
+ *
+ * Variables d'environnement attendues (propagees par docker-compose depuis .env) :
+ *   VALMONT_LLM_BASE_URL   endpoint OpenAI-compatible du LLM (ex: http://host.docker.internal:11434/v1)
+ *   VALMONT_LLM_API_KEY    cle d'API (ou 'sk-local' pour un serveur local sans cle)
+ *   VALMONT_LLM_MODEL      identifiant du modele (ex: qwen3.6-35b-a3b)
+ *   VALMONT_LLM_MODEL_NAME libelle affiche dans l'interface
+ *
+ * L'URL exacte du provider ne doit JAMAIS etre ecrite en dur dans ce script :
+ * elle passe par l'environnement. Rien dans ce fichier n'est un secret.
+ */
+
+require '/var/www/html/wp-load.php';
+
+$base_url  = getenv('VALMONT_LLM_BASE_URL')  ?: 'http://host.docker.internal:11434/v1';
+$api_key   = getenv('VALMONT_LLM_API_KEY')   ?: 'sk-local';
+$model     = getenv('VALMONT_LLM_MODEL')     ?: 'qwen3.6-35b-a3b';
+$model_name = getenv('VALMONT_LLM_MODEL_NAME') ?: 'Qwen 3.6 35B A3B';
+
+// 1. Options globales AI Engine ----------------------------------------------
+$opts = get_option('mwai_options', array());
+if (!is_array($opts)) { $opts = array(); }
+
+// Environnement LLM : type "custom" = compatible OpenAI. Les champs reels
+// utilises par AI Engine sont 'endpoint' (pas 'url') et 'models'.
+$opts['ai_envs'] = array(
+  array(
+    'name'     => 'LLM local (OpenAI-compatible)',
+    'type'     => 'custom',
+    'endpoint' => $base_url,
+    'apikey'   => $api_key,
+    'models'   => array(array('model' => $model, 'name' => $model_name)),
+    'id'       => 'llm-local',
+  ),
+);
+$opts['ai_default_env']   = 'llm-local';
+$opts['ai_default_model'] = $model;
+
+// Modules demonstres par la serie de notebooks
+$opts['module_chatbots']   = true;
+$opts['module_embeddings'] = true;
+$opts['module_mcp']        = true;
+$opts['module_forms']      = true;
+$opts['module_workspace']  = true;
+$opts['module_statistics'] = true;
+
+// API publique REST (les endpoints mwai/v1 répondent aux clients)
+$opts['public_api'] = true;
+
+update_option('mwai_options', $opts);
+
+// 2. Chatbot « valmont » -----------------------------------------------------
+// mwai_chatbots est une LISTE de configurations completes (pas un dict par
+// botId). On pousse une config complete, fidèle a celle produite par
+// l'interface admin.
+$chatbots = get_option('mwai_chatbots', array());
+if (!is_array($chatbots)) { $chatbots = array(); }
+$chatbots[] = array(
+  'aiName'               => 'Valmont: ',
+  'userName'             => 'Vous: ',
+  'guestName'            => 'Visiteur: ',
+  'textSend'             => 'Envoyer',
+  'textClear'            => 'Effacer',
+  'textInputPlaceholder' => 'Posez votre question a la maison...',
+  'textInputMaxLength'   => 512,
+  'startSentence'        => 'Bonjour, bienvenue a la Maison Valmont. Comment puis-je vous renseigner ?',
+  'themeId'              => 'chatgpt',
+  'window'               => false,
+  'icon'                 => '',
+  'iconText'             => '',
+  'iconPosition'         => 'bottom-right',
+  'botId'                => 'valmont',
+  'instructions'         => "IMPORTANT: repondez en francais en texte brut. INTERDIT: emoji, symbole unicode, gras, italique, titre, liste a puces, tableau, markdown. Seulement des phrases simples separees par des retours a la ligne.",
+  'scope'                => 'chatbot',
+  'mode'                 => 'chat',
+  'contentAware'         => false,
+  'embeddingsEnvId'      => '',
+  'model'                => $model,
+  'temperature'          => 0.6,
+  'maxMessages'          => 15,
+  'maxTokens'            => 1024,
+  'maxResults'           => 1,
+  'functions'            => array(),
+  'mcpServers'           => array(),
+  'name'                 => 'Valmont',
+  'fileUpload'           => false,
+  'maxUploads'           => 1,
+  'fileUploads'          => 0,
+  'imageUpload'          => false,
+);
+update_option('mwai_chatbots', $chatbots);
+
+// 3. mu-plugin : application passwords sans HTTPS (WordPress 6.8) ------------
+$mu_dir  = '/var/www/html/wp-content/mu-plugins';
+$mu_file = $mu_dir . '/force-app-passwords.php';
+if (!is_dir($mu_dir)) { mkdir($mu_dir, 0755, true); }
+if (!file_exists($mu_file)) {
+  file_put_contents($mu_file, "<?php add_filter( 'wp_is_application_passwords_available', '__return_true' );" . PHP_EOL);
+}
+
+echo "OK: env 'llm-local' branché sur " . $base_url . PHP_EOL;
+echo "OK: default_env=" . $opts['ai_default_env'] . ", default_model=" . $opts['ai_default_model'] . PHP_EOL;
+echo "OK: chatbot 'valmont' (" . count($chatbots) . " chatbot(s) au total)" . PHP_EOL;
+echo "OK: mu-plugin application passwords en place" . PHP_EOL;
+echo "SUIVANT: creer un application password (cf. README, etape 5)." . PHP_EOL;

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/presenter-ai-engine-par-son-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/presenter-ai-engine-par-son-api.ipynb
@@ -1,0 +1,589 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e3e44e9c",
+   "metadata": {},
+   "source": [
+    "# Presenter AI Engine par son API — instance jetable Maison Valmont\n",
+    "\n",
+    "Ce notebook ouvre la serie systematique de presentation d'**AI Engine**, le\n",
+    "plugin WordPress d'assistant IA : fonctionnalites de base, fonctionnalites\n",
+    "avancees, et ce qu'on en a fait dans le projet Livres Agites. Toute la serie\n",
+    "appelle **reellement** l'API REST de l'instance jetable *Maison Valmont*\n",
+    "(montage en 5 etapes : `instance-jetable/README.md`).\n",
+    "\n",
+    "Ce premier notebook pose le socle : decouvrir l'instance, son API, ses\n",
+    "chatbots, puis obtenir une **premiere completion reelle** — un vrai appel au\n",
+    "modele de langage, avec le compte de tokens a l'appui.\n",
+    "\n",
+    "> Les sorties de ce notebook proviennent d'une execution reelle contre\n",
+    "> l'instance locale (voir « Provenance et limites », en fin de fichier).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a24bec25",
+   "metadata": {},
+   "source": [
+    "## La serie « AI Engine par son API »\n",
+    "\n",
+    "Le projet Livres Agites a mis AI Engine au coeur d'une maison d'edition :\n",
+    "bot d'accueil, agents d'ateliers, bibliothecaire documentee par RAG,\n",
+    "formulaires dynamiques. Cette serie presente le plugin de maniere\n",
+    "reproductible — **sans jamais exposer de donnees client** :\n",
+    "\n",
+    "| Notebook | Contenu |\n",
+    "|----------|---------|\n",
+    "| `presenter-ai-engine-par-son-api` (ce notebook) | instance, API, chatbots, premiere completion |\n",
+    "| notebooks suivants | completion avancee, RAG/embeddings, agents MCP, formulaires |\n",
+    "\n",
+    "Trois niveaux de lecture, dans chaque notebook :\n",
+    "\n",
+    "1. **Decouverte** — ce que fait la fonctionnalite, vue par l'API ;\n",
+    "2. **Branchement** — comment on l'a branchee dans le projet ;\n",
+    "3. **Exercice** — reutiliser le pattern sur un cas voisin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "47ea6ce3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:35.796026Z",
+     "iopub.status.busy": "2026-08-14T11:34:35.795497Z",
+     "iopub.status.idle": "2026-08-14T11:34:36.190876Z",
+     "shell.execute_reply": "2026-08-14T11:34:36.189073Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
+      "Base URL : http://localhost:8093\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et helpers. Aucune cle ni adresse de provider n'est stockee\n",
+    "# dans ce fichier : tout vient de instance-jetable/.env (README, etape 5).\n",
+    "\n",
+    "import base64\n",
+    "import os\n",
+    "import re\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Localisation du .env : a cote du notebook (instance-jetable/.env),\n",
+    "# sinon dans le repertoire courant.\n",
+    "charges = []\n",
+    "for candidat in (Path(\"instance-jetable/.env\"), Path(\".env\")):\n",
+    "    if candidat.exists():\n",
+    "        load_dotenv(candidat)\n",
+    "        charges.append(str(candidat))\n",
+    "print(\"Fichiers .env charges :\", charges or \"(aucun)\")\n",
+    "\n",
+    "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
+    "ADMIN_USER = os.getenv(\"VALMONT_ADMIN_USER\", \"\")\n",
+    "APP_PASSWORD = os.getenv(\"VALMONT_APP_PASSWORD\", \"\")\n",
+    "print(\"Base URL :\", BASE_URL)\n",
+    "\n",
+    "\n",
+    "def api(route, method=\"GET\", payload=None):\n",
+    "    \"\"\"Appel REST WordPress. route est relative, ex. '/mwai/v1/ai/completions'.\"\"\"\n",
+    "    url = BASE_URL + \"/wp-json\" + route\n",
+    "    entetes = {\"Content-Type\": \"application/json\"}\n",
+    "    if ADMIN_USER and APP_PASSWORD:\n",
+    "        creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
+    "        entetes[\"Authorization\"] = \"Basic \" + creds\n",
+    "    reponse = requests.request(method, url, headers=entetes, json=payload, timeout=120)\n",
+    "    reponse.raise_for_status()\n",
+    "    return reponse.json()\n",
+    "\n",
+    "\n",
+    "# Normalisation des sorties du modele : les LLM locaux emettent parfois des\n",
+    "# emojis ou du markdown malgre les consignes. On normalise l'affichage par du\n",
+    "# code (jamais de sortie retouchee a la main).\n",
+    "_EMOJIS = re.compile(\n",
+    "    \"[\\U0001F000-\\U0001FAFF\\U00002600-\\U000027BF\\U0001F300-\\U0001F5FF\"\n",
+    "    \"\\U0001F680-\\U0001F6FF\\U0001F900-\\U0001F9FF\\U00002B00-\\U00002BFF\"\n",
+    "    \"\\U0000FE00-\\U0000FE0F]+\",\n",
+    "    re.UNICODE,\n",
+    ")\n",
+    "\n",
+    "def clean_text(texte):\n",
+    "    \"\"\"Retire emojis, symboles markdown et espacements superflus.\"\"\"\n",
+    "    if not isinstance(texte, str):\n",
+    "        return texte\n",
+    "    texte = _EMOJIS.sub(\" \", texte)\n",
+    "    texte = re.sub(r\"[*_#>`~]+\", \" \", texte)\n",
+    "    return re.sub(r\"\\s+\", \" \", texte).strip()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed738352",
+   "metadata": {},
+   "source": [
+    "## L'API : un point d'entree REST, des routes par famille\n",
+    "\n",
+    "AI Engine expose une centaine de routes sous le namespace `mwai/v1`. Deux\n",
+    "conventions restent vraies pour toute la serie :\n",
+    "\n",
+    "- **Authentification** : les routes de lecture/ecriture demandent un compte\n",
+    "  avec les bonnes capacites. Ici on utilise un *application password*\n",
+    "  WordPress (Basic auth) — la methode recommandee pour un client HTTP.\n",
+    "- **Format** : presque toutes les reponses ont la forme\n",
+    "  `{ \"success\": bool, ...donnees }`. Quand `success` vaut `false`, un champ\n",
+    "  `message` donne la raison.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1517c6a9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:36.194621Z",
+     "iopub.status.busy": "2026-08-14T11:34:36.194101Z",
+     "iopub.status.idle": "2026-08-14T11:34:36.267653Z",
+     "shell.execute_reply": "2026-08-14T11:34:36.266645Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Nom du site   : Maison Valmont\n",
+      "Description   : \n",
+      "URL publique  : http://localhost:8093\n",
+      "Namespaces    : 7 - namespace mwai/v1 : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1. L'identite de l'instance (route publique /wp-json/)\n",
+    "info = api(\"/\")\n",
+    "print(\"Nom du site   :\", info.get(\"name\"))\n",
+    "print(\"Description   :\", info.get(\"description\"))\n",
+    "print(\"URL publique  :\", info.get(\"url\"))\n",
+    "espaces = info.get(\"namespaces\", [])\n",
+    "print(\"Namespaces    :\", len(espaces), \"- namespace mwai/v1 :\", \"mwai/v1\" in espaces)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54ff7c60",
+   "metadata": {},
+   "source": [
+    "### Fonctionnalites de base et avancees\n",
+    "\n",
+    "Le catalogue des routes fait apparaitre les familles — on y reviendra\n",
+    "notebook par notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ac772cff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:36.271188Z",
+     "iopub.status.busy": "2026-08-14T11:34:36.270683Z",
+     "iopub.status.idle": "2026-08-14T11:34:36.328435Z",
+     "shell.execute_reply": "2026-08-14T11:34:36.327246Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Routes mwai/v1 : 99\n",
+      "- inference (ai/*) : 11\n",
+      "- chatbots : 4\n",
+      "- mcp : 2\n",
+      "- formulaires (forms/*) : 5\n",
+      "- reglages (settings/*) : 5\n",
+      "- assistant (helpers/*) : 33\n",
+      "- workspace : 11\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2. Le catalogue des routes mwai/v1\n",
+    "catalogue = api(\"/mwai/v1\")\n",
+    "routes = sorted(catalogue.get(\"routes\", {}).keys())\n",
+    "print(\"Routes mwai/v1 :\", len(routes))\n",
+    "\n",
+    "familles = {\n",
+    "    \"inference (ai/*)\": [r for r in routes if \"/ai/\" in r],\n",
+    "    \"chatbots\": [r for r in routes if \"chatbot\" in r.lower() or r.endswith(\"/start_session\")],\n",
+    "    \"mcp\": [r for r in routes if \"/mcp/\" in r],\n",
+    "    \"formulaires (forms/*)\": [r for r in routes if \"/forms/\" in r],\n",
+    "    \"reglages (settings/*)\": [r for r in routes if \"/settings/\" in r],\n",
+    "    \"assistant (helpers/*)\": [r for r in routes if \"/helpers/\" in r],\n",
+    "    \"workspace\": [r for r in routes if \"/workspace/\" in r],\n",
+    "}\n",
+    "for nom, fam in familles.items():\n",
+    "    print(f\"- {nom} : {len(fam)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "03b634cf",
+   "metadata": {},
+   "source": [
+    "### Lecture\n",
+    "\n",
+    "Les familles `ai/*` (inference) et `settings/*` (reglage) portent les\n",
+    "fonctionnalites de base : completer, generer une image, moderer, tester la\n",
+    "connexion. Les familles `mcp`, `forms`, `helpers` et `workspace` sont les\n",
+    "briques avancees : catalogues d'outils, formulaires dynamiques, taches,\n",
+    "postes de travail. On illustre maintenant deux familles en direct.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "0e1cc382",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:36.332171Z",
+     "iopub.status.busy": "2026-08-14T11:34:36.331638Z",
+     "iopub.status.idle": "2026-08-14T11:34:36.374359Z",
+     "shell.execute_reply": "2026-08-14T11:34:36.373360Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chatbots configures : 2\n",
+      "- default | Default | modele=gpt-5.5 | temperature=0.8 | maxTokens=4096\n",
+      "- valmont | Valmont | modele=qwen3.6-35b-a3b | temperature=0.6 | maxTokens=1024\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 3. Les chatbots configures (famille settings)\n",
+    "donnees = api(\"/mwai/v1/settings/chatbots\")\n",
+    "bots = donnees.get(\"chatbots\", [])\n",
+    "print(\"Chatbots configures :\", len(bots))\n",
+    "for b in bots:\n",
+    "    print(f\"- {b.get('botId')} | {b.get('name')} | modele={b.get('model')} | \"\n",
+    "          f\"temperature={b.get('temperature')} | maxTokens={b.get('maxTokens')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c01d1c6",
+   "metadata": {},
+   "source": [
+    "Le chatbot `valmont` est celui de la maison : consignes strictes (francais,\n",
+    "texte brut), temperature basse (0.6), budget de tokens borne (1024). Le\n",
+    "chatbot `default` est le gabarit d'origine. On interroge le premier.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4662cafc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:36.377867Z",
+     "iopub.status.busy": "2026-08-14T11:34:36.377867Z",
+     "iopub.status.idle": "2026-08-14T11:34:47.927045Z",
+     "shell.execute_reply": "2026-08-14T11:34:47.925702Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "success : True\n",
+      "reponse : Fondée en 1975 en Suisse, Maison Valmont est une marque de cosmétiques de luxe réputée pour ses soins dermatologiques d'exception et son approche scientifique de l'anti-âge. Distribuée dans les pharmacies et grands magasins sélectionnés, elle allie innovation technologique et élégance pour répondre aux besoins des peaux les plus exigeantes.\n",
+      "usage   : {'prompt_tokens': 22, 'completion_tokens': 710, 'total_tokens': 732}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4. Une completion reelle : on interroge le chatbot valmont\n",
+    "requete = {\n",
+    "    \"botId\": \"valmont\",\n",
+    "    \"message\": \"Bonjour. Presentez la Maison Valmont en deux phrases.\",\n",
+    "}\n",
+    "reponse = api(\"/mwai/v1/ai/completions\", method=\"POST\", payload=requete)\n",
+    "print(\"success :\", reponse.get(\"success\"))\n",
+    "print(\"reponse :\", clean_text(reponse.get(\"data\")))\n",
+    "usage = reponse.get(\"usage\") or {}\n",
+    "print(\"usage   :\", {k: usage[k] for k in (\"prompt_tokens\", \"completion_tokens\", \"total_tokens\") if k in usage})\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4f4f512",
+   "metadata": {},
+   "source": "### Ce que dit la reponse\n\n`data` contient le texte genere par le LLM local, a travers AI Engine : un\nappel HTTP de plus, pas de cle a ecrire, pas de SDK — le plugin fait la\nmachinerie (contexte, temperature, comptage). Le bloc `usage` detaille les\ntokens consommes ; c'est lui qui alimente les compteurs du tableau de bord.\n\nRemarque : le modele ne connait pas notre maison d'edition fictive — il\nrepond par sa connaissance du monde (une marque reelle homonyme). C'est le\nprobleme d'ancrage des LLM : on le resoudra avec le RAG (bibliothecaire\ndocumentee) dans un prochain notebook de la serie.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "211a86c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:47.930219Z",
+     "iopub.status.busy": "2026-08-14T11:34:47.930219Z",
+     "iopub.status.idle": "2026-08-14T11:34:47.987973Z",
+     "shell.execute_reply": "2026-08-14T11:34:47.987386Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Outils MCP exposes : 42\n",
+      "- wp_list_plugins [AI Engine (Core)] - acces read\n",
+      "- wp_get_users [AI Engine (Core)] - acces admin\n",
+      "- wp_create_user [AI Engine (Core)] - acces admin\n",
+      "- wp_update_user [AI Engine (Core)] - acces admin\n",
+      "- wp_get_comments [AI Engine (Core)] - acces read\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5. La famille avancee : le catalogue MCP (outils exposes aux agents)\n",
+    "mcp = api(\"/mwai/v1/mcp/functions\")\n",
+    "outils = mcp.get(\"functions\", [])\n",
+    "print(\"Outils MCP exposes :\", mcp.get(\"count\"))\n",
+    "for o in outils[:5]:\n",
+    "    print(f\"- {o.get('name')} [{o.get('category')}] - acces {o.get('accessLevel')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "37028d27",
+   "metadata": {},
+   "source": [
+    "MCP = le protocole qui donne des outils aux chatbots (lire un article,\n",
+    "interroger la base, ...). AI Engine expose ici le catalogue des outils\n",
+    "enregistres par les plugins. Les notebooks suivants de la serie brancheront\n",
+    "des outils sur mesure et montreront un chatbot qui les utilise vraiment.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "bba37fc7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:47.992010Z",
+     "iopub.status.busy": "2026-08-14T11:34:47.991002Z",
+     "iopub.status.idle": "2026-08-14T11:34:48.050097Z",
+     "shell.execute_reply": "2026-08-14T11:34:48.048962Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formulaires declares : []\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 6. La famille formulaires : vide sur une instance neuve, c'est normal\n",
+    "formulaires = api(\"/mwai/v1/forms/list\")\n",
+    "print(\"Formulaires declares :\", formulaires.get(\"forms\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4f5c05d",
+   "metadata": {},
+   "source": [
+    "`forms` gere des formulaires pilotables par l'IA (champs dynamiques, saisie\n",
+    "guidee). Sur une instance neuve, la liste est vide : la reponse `[]` est le\n",
+    "resultat attendu — c'est deja une information (aucun formulaire n'est en\n",
+    "service).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8071739",
+   "metadata": {},
+   "source": [
+    "## Ce qu'on en a fait dans le projet Livres Agites\n",
+    "\n",
+    "Le projet (maison d'edition) exploite exactement ces familles — sans qu'aucune\n",
+    "donnee client ne soit reproduite ici :\n",
+    "\n",
+    "| Famille de routes | Usage dans le projet |\n",
+    "|-------------------|----------------------|\n",
+    "| `ai/completions` | bot d'accueil « Laura », agents d'atelier (Clara, Antoine, Elise, Victor) |\n",
+    "| `settings/chatbots` | 6 chatbots : accueil, ateliers, bibliothecaire, par defaut |\n",
+    "| `mcp/functions` | 24 outils custom : manuscrits, livres, statistiques, RAG, notifications |\n",
+    "| `forms` | formulaire de soumission de manuscrit |\n",
+    "| embeddings (hors REST) | bibliothecaire documentee : indexation des extraits de livres |\n",
+    "\n",
+    "Chaque notebook suivant de la serie approfondit une famille, toujours contre\n",
+    "cette instance jetable, avec un corpus synthetique.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95718af6",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "### Exercice 1 — poser une question a n'importe quel chatbot\n",
+    "\n",
+    "`poser_question(bot_id, message)` reutilise le pattern de la section 4 :\n",
+    "appeler `/mwai/v1/ai/completions`, retourner la reponse normalisee.\n",
+    "Indice : `api(\"/mwai/v1/ai/completions\", method=\"POST\", payload={...})`\n",
+    "puis `clean_text(...)`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "1ed59563",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:48.053935Z",
+     "iopub.status.busy": "2026-08-14T11:34:48.053398Z",
+     "iopub.status.idle": "2026-08-14T11:34:48.065520Z",
+     "shell.execute_reply": "2026-08-14T11:34:48.064217Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def poser_question(bot_id, message):\n",
+    "    \"\"\"Retourne la reponse propre (texte normalise) du chatbot donne.\"\"\"\n",
+    "    # A COMPLETER : appel /ai/completions + clean_text\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6604292",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — filtrer le catalogue MCP par niveau d'acces\n",
+    "\n",
+    "`outils_par_acces(niveau)` charge `/mwai/v1/mcp/functions` et retourne la\n",
+    "liste des noms d'outils dont `accessLevel` vaut le niveau demande\n",
+    "(ex. `\"read\"`, `\"write\"`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6e500cc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:48.068917Z",
+     "iopub.status.busy": "2026-08-14T11:34:48.068404Z",
+     "iopub.status.idle": "2026-08-14T11:34:48.080525Z",
+     "shell.execute_reply": "2026-08-14T11:34:48.079412Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def outils_par_acces(niveau):\n",
+    "    \"\"\"Retourne la liste des noms d'outils MCP avec accessLevel == niveau.\"\"\"\n",
+    "    # A COMPLETER : charger le catalogue, filtrer, retourner les noms\n",
+    "    return []\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d342b614",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — un mini bilan de sante de l'API\n",
+    "\n",
+    "`sante_api()` verifie les endpoints cles de l'instance (racine, completions,\n",
+    "catalogue MCP, formulaires) et retourne `{route: ok}`. Une route est OK si\n",
+    "l'appel reussit et que la reponse contient `success == True` (ou, pour la\n",
+    "racine, que le namespace `mwai/v1` est present).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "a8739615",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T11:34:48.084269Z",
+     "iopub.status.busy": "2026-08-14T11:34:48.083744Z",
+     "iopub.status.idle": "2026-08-14T11:34:48.096172Z",
+     "shell.execute_reply": "2026-08-14T11:34:48.094656Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def sante_api():\n",
+    "    \"\"\"Retourne un dict {route: bool} indiquant l'etat de chaque endpoint cle.\"\"\"\n",
+    "    # A COMPLETER : boucler sur les routes, tester success, retourner le dict\n",
+    "    return {}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b5f4c9d",
+   "metadata": {},
+   "source": [
+    "## Provenance et limites\n",
+    "\n",
+    "- **Instance testee** : `http://localhost:8093`, montee via\n",
+    "  `instance-jetable/docker-compose.jetable.example.yml`, AI Engine 3.7.0\n",
+    "  (version gratuite, wordpress.org), corpus synthetique « Maison Valmont ».\n",
+    "- **Provider** : LLM local compatible OpenAI — l'adresse et la cle restent\n",
+    "  dans `.env`, jamais dans ce notebook.\n",
+    "- **Sorties commitees** : executions reelles contre l'instance. Les reponses\n",
+    "  d'un LLM sont non deterministes : votre execution peut differer, c'est\n",
+    "  normal.\n",
+    "- Le modele local peut emettre des emojis ou du markdown malgre les consignes\n",
+    "  du chatbot : `clean_text()` normalise l'affichage par du code.\n",
+    "- **Endpoints verifies ici (firsthand)** : `/`, `/mwai/v1`,\n",
+    "  `/mwai/v1/settings/chatbots`, `/mwai/v1/ai/completions`,\n",
+    "  `/mwai/v1/mcp/functions`, `/mwai/v1/forms/list`.\n",
+    "- **Frontieres** : pas de donnees client, pas de secret, pas d'IP de\n",
+    "  provider — regles du chantier CoursIA.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Quoi:

Grain socle de la serie « AI Engine par son API » demandee par le retour user
du 14/08 : une **instance jetable dediee** (Maison Valmont, corpus 100 %
synthetique, aucune donnee client) et le **premier notebook de la serie** qui
appelle reellement l'API de cette instance.

- `AI-Engine-WordPress/instance-jetable/` : `docker-compose.jetable.example.yml`
  (wordpress 6.8.3 + mariadb + cli, port 8093, noms neutres, variables sans
  secret), `seed-valmont.php` (env LLM local type custom avec les champs
  reels `endpoint` + `models`, chatbot « valmont », API publique, mu-plugin
  application passwords), `README.md` (montage en 5 etapes),
  `.env.example` (aucune valeur reelle).
- `AI-Engine-WordPress/presenter-ai-engine-par-son-api.ipynb` : decouverte
  REST de l'instance, catalogue des 99 routes `mwai/v1`, chatbots configures,
  **completion reelle** via `/ai/completions` (avec compte de tokens), catalogue
  MCP (42 outils), formulaires ; 3 exercices a stubs ; sorties commitees
  issues d'une execution reelle contre l'instance jetable locale.

## Preuve:

- Notebook execute de bout en bout contre l'instance locale (localhost:8093) :
  10 cellules de code, execution_count != null partout, 0 erreur, aucune
  sortie contenant emoji/homoglyphe (normalisation par `clean_text()`).
- Endpoints verifies firsthand : `/wp-json/`, `/wp-json/mwai/v1` (99 routes),
  `/mwai/v1/settings/chatbots` (2 chatbots), `/mwai/v1/ai/completions`
  (success + usage), `/mwai/v1/mcp/functions` (42 outils),
  `/mwai/v1/forms/list` (liste vide, attendu sur instance neuve).
- Pre-commit CI local : gitleaks passe, H.3 (notebooks executes) passe.
- Le `.env` local (valeurs reelles de dev) n'est pas commite : couvert par le
  `.gitignore` du depot, verifie par `git status` et dry-run `git add`.

## Perimetre:

- Aucune donnee client : corpus synthetique Maison Valmont uniquement.
- Aucun secret, aucune IP de provider dans le depot : tout passe par `.env`
  (exemple versionne, valeurs reelles jamais commitees).
- Le notebook n'affiche jamais l'adresse ni la cle du provider LLM.
- Les sorties du modele sont normalisees par du code (le LLM local peut
  emettre des emojis/markdown malgre les consignes) — jamais retouchees a la
  main.
- Hors perimetre : les notebooks suivants de la serie (completion avancee,
  RAG, agents MCP, formulaires) — grains a venir.

Closes #10913

Grain: MED/notebook-python — lane myia-ai-01:LivresAgites — prev: MED/notebook-python #10787
