### PR TITLE
feat(lean,#6724): BR4a one-jump assembly — one_jump_toGrid_correct (sorry-free)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical.lean
@@ -395,6 +395,35 @@ theorem evolve_shift (v : Int × Int) (n : Nat) (g : Grid) :
   | zero => simp [evolve]
   | succ k ih => rw [evolve_succ, step_shift, ih, ← evolve_succ]
 
+/-- Composition des translations : appliquer `w` puis `v` equivaut a la
+    translation de somme composante par composante. Enonce avec composantes
+    explicites (plutot qu'en paires) pour que la reecriture produise des
+    sommes directement, sans projections `(a, b).1`. -/
+theorem shift_shift (a1 a2 b1 b2 : Int) (g : Grid) :
+    shift (a1, a2) (shift (b1, b2) g) = shift (a1 + b1, a2 + b2) g := by
+  apply Canonical.ext
+  · exact canonical_shift (a1, a2) (shift (b1, b2) g)
+  · exact canonical_shift (a1 + b1, a2 + b2) g
+  · intro p
+    rw [mem_shift, mem_shift, mem_shift]
+    have hp : ((p.1 - a1) - b1, (p.2 - a2) - b2)
+        = (p.1 - (a1 + b1), p.2 - (a2 + b2)) := by ext <;> omega
+    rw [hp]
+
+/-- Translater de zero est l'identite sur les grilles canoniques : le
+    `sortDedup` de `shift` re-trie une liste deja triee sans doublons. Inset
+    du pont de localite (a) de #6724 : la composition des trois translations
+    du saut unique s'annule en le vecteur nul, et c'est `shift_zero` qui
+    elimine cette identite residuelle. -/
+theorem shift_zero {g : Grid} (hg : Canonical g) : shift (0, 0) g = g := by
+  apply Canonical.ext
+  · exact canonical_shift (0, 0) g
+  · exact hg
+  · intro p
+    rw [mem_shift]
+    have hp : (p.1 - 0, p.2 - 0) = p := by ext <;> omega
+    rw [hp]
+
 /-! ## Congruence extensionnelle de `step` / `evolve`
 
 Deux grilles à appartenance extensionnellement egale (meme ensemble de

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/GridCanonical_en.lean
@@ -254,6 +254,35 @@ theorem evolve_shift (v : Int × Int) (n : Nat) (g : Grid) :
   | zero => simp [evolve]
   | succ k ih => rw [evolve_succ, step_shift, ih, ← evolve_succ]
 
+/-- Composition of translations: applying `w` then `v` equals the
+    componentwise-sum translation. Stated with explicit components (rather
+    than pairs) so that rewriting produces sums directly, without `(a, b).1`
+    projections. -/
+theorem shift_shift (a1 a2 b1 b2 : Int) (g : Grid) :
+    shift (a1, a2) (shift (b1, b2) g) = shift (a1 + b1, a2 + b2) g := by
+  apply Canonical.ext
+  · exact canonical_shift (a1, a2) (shift (b1, b2) g)
+  · exact canonical_shift (a1 + b1, a2 + b2) g
+  · intro p
+    rw [mem_shift, mem_shift, mem_shift]
+    have hp : ((p.1 - a1) - b1, (p.2 - a2) - b2)
+        = (p.1 - (a1 + b1), p.2 - (a2 + b2)) := by ext <;> omega
+    rw [hp]
+
+/-- Translating by zero is the identity on canonical grids: the `sortDedup`
+    of `shift` re-sorts an already sorted duplicate-free list. Inset of the
+    locality bridge (a) of #6724: the composition of the one-jump's three
+    translations cancels to the zero vector, and `shift_zero` eliminates
+    that residual identity. -/
+theorem shift_zero {g : Grid} (hg : Canonical g) : shift (0, 0) g = g := by
+  apply Canonical.ext
+  · exact canonical_shift (0, 0) g
+  · exact hg
+  · intro p
+    rw [mem_shift]
+    have hp : (p.1 - 0, p.2 - 0) = p := by ext <;> omega
+    rw [hp]
+
 /-! ## Extensional congruence of `step` / `evolve`
 
 Two grids with extensionally equal membership (same set of live cells,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness/Foundation.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness/Foundation.lean
@@ -1409,6 +1409,22 @@ theorem wf_of_cellWf {c : MacroCell} (h : cellWf c) : c.wf = true := by
     simp only [MacroCell.wf, ihnw, ihne, ihsw, ihse, ← hne_lvl, ← hsw_lvl, ← hse_lvl,
                beq_self_eq_true, Bool.true_and, Bool.and_true]
 
+/-- Tout `buildFromGrid` produit une `MacroCell` bien formee : les quatre
+    sous-arbres sont construits au meme niveau (donc de niveaux egaux par
+    `level_buildFromGrid`) et recursivement bien formes. Inset manquant du
+    pont de localite (a) de #6724 : la brique un-saut
+    `hashlifeJump_correct_of_captured` exige `c.wf = true`, et le moteur
+    alimente `hashlifeJump` avec `gridToMacroCellWithOffset g` — un
+    `buildFromGrid` sur le cadre de `g`. (Place ici, pas dans
+    `MacroCell.lean`, car `MacroCell.wf` est defini dans ce fichier qui
+    importe MacroCell — l'inverse serait circulaire.) -/
+theorem buildFromGrid_wf (g : Grid) (r0 c0 : Int) (lvl : Nat) :
+    (MacroCell.buildFromGrid g r0 c0 lvl).wf = true := by
+  induction lvl generalizing r0 c0 with
+  | zero => rfl
+  | succ n ih =>
+      simp [MacroCell.buildFromGrid, MacroCell.wf, ih, level_buildFromGrid]
+
 /-- A malformed level-2 cell: `nw` is a level-1 node but `ne`/`sw`/`se`
     are bare leaves. `level` only inspects `nw`, so
     `malformedLevel2.level = 2` satisfies the unrestricted P4 hypothesis

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/JumpCapture.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/JumpCapture.lean
@@ -346,5 +346,90 @@ theorem hashlifeJump_correct_of_captured (c : MacroCell)
     _ = evolve (2 ^ c.level) ((padCenter2 c).toGrid (0, 0)) :=
         restrictGridTo_eq_self _ _ _ ((jumpCaptured_iff c).mp hcap)
 
+/-! ### BR4a : assemblage du saut unique (pont de localite (a), #6724)
+
+La brique `hashlifeJump_correct_of_captured` ci-dessus est ancree sur
+`(2^k, 2^k)` avec l'entree rembourree `(padCenter2 c).toGrid (0, 0)`. Le
+moteur, lui, calcule `(hashlifeJump mc).toGrid (jumpResultOff off k)` a
+partir de la grille originale `g`. Cet assemblage rejoint les deux par la
+chaine complete du pont de localite (a) :
+
+- BR2 (`toGrid_shift_grid`) re-ancre la sortie du saut de `jumpResultOff`
+  vers `(2^k, 2^k)` en une translation `δ = newOff − (2^k, 2^k)` ;
+- BR3 (`padCenter2_toGrid_shift`) deplie le rembourrage en une translation
+  `pad = 3·2^(k−1)` ; `evolve_shift` la fait sortir de `evolve` ;
+- BR2 a nouveau exprime `mc.toGrid (0, 0)` comme translation `−off` de
+  `mc.toGrid off` ; `evolve_shift` la fait sortir ;
+- BR5 (`evolve_congr`, #10895) + BR1 convertissent l'equivalence
+  d'appartenance `mc.toGrid off ↔ g` en egalite des trajectoires `evolve` ;
+- la composition `shift_shift` des trois translations donne le vecteur net
+  `δ + pad + (−off)` dont chaque coordonnee s'annule EXACTEMENT
+  (`−2^(k−1) − 2^k + 3·2^(k−1) = 2·2^(k−1) − 2^k = 0` pour `k ≥ 1`), et
+  `shift_zero` elimine l'identite residuelle sur la grille canonique
+  `evolve (2^k) g`.
+
+Reste ouvert pour `p5_large_n_jumpN` : l'invariant multi-sauts (b) — la
+preservation de `jumpCaptured` a travers le re-tramage — puis l'induction
+sur le fuel de `evolveHashlifeFastAux`. -/
+
+/-- **Assemblage du saut unique** : pour toute `MacroCell` `mc` dont l'image
+    `toGrid off` a la meme appartenance que `g` (hypothese fournie par BR1,
+    `mem_toGrid_gridToMacroCellWithOffset`), bien formee, de niveau ≥ 1 et
+    sous capture, le saut du moteur produit exactement `evolve (jumpSize k) g`
+    — la generation cible du saut, sans translation residuelle. C'est la
+    forme exacte du bras de saut de `evolveHashlifeFastAux` (Hashlife.lean,
+    `g' := jumped.toGrid newOff`). -/
+theorem one_jump_toGrid_correct (g : Grid) (off : Int × Int) (mc : MacroCell)
+    (hmem : ∀ p, p ∈ mc.toGrid off ↔ p ∈ g)
+    (hwf : mc.wf = true) (hlvl : 1 ≤ mc.level)
+    (hcap : jumpCaptured mc = true) :
+    (hashlifeJump mc).toGrid (jumpResultOff off mc.level)
+      = evolve (jumpSize mc.level) g := by
+  have hk1 : mc.level - 1 + 1 = mc.level := by omega
+  have hnjs : 0 < 2 ^ mc.level := Nat.two_pow_pos _
+  have h1js : 1 ≤ 2 ^ mc.level := by omega
+  have h2k : ((2 ^ mc.level : Nat) : Int)
+      = 2 * ((2 ^ (mc.level - 1) : Nat) : Int) := by
+    have hp : (2 : Nat) ^ (mc.level - 1 + 1) = 2 ^ (mc.level - 1) * 2 := by
+      rw [Nat.pow_succ]
+    rw [hk1] at hp
+    rw [hp, Nat.cast_mul]
+    push_cast
+    ring
+  have hbrick := hashlifeJump_correct_of_captured mc hwf hlvl hcap
+  have hnew : jumpResultOff off mc.level
+      = (off.1 - (2 ^ (mc.level - 1) : Nat),
+         off.2 - (2 ^ (mc.level - 1) : Nat)) := by
+    unfold jumpResultOff
+    split
+    · next h0 =>
+        exfalso
+        have hb : Nat.beq mc.level 0 = true := by simpa [BEq] using h0
+        have hz : mc.level = 0 := Nat.eq_of_beq_eq_true hb
+        omega
+    · rfl
+  have hmc0 : mc.toGrid (0, 0)
+      = shift (0 - off.1, 0 - off.2) (mc.toGrid (off.1, off.2)) :=
+    toGrid_shift_grid mc 0 0 off.1 off.2
+  have hmem' : ∀ p, p ∈ mc.toGrid (off.1, off.2) ↔ p ∈ g := by
+    simpa using hmem
+  simp only [jumpSize]
+  rw [hnew,
+    toGrid_shift_grid (hashlifeJump mc) _ _ (2 ^ mc.level : Nat)
+      (2 ^ mc.level : Nat),
+    hbrick, padCenter2_toGrid_shift mc hlvl, ← evolve_shift, hmc0,
+    ← evolve_shift, evolve_congr hmem' h1js, shift_shift, shift_shift]
+  have hpow : (2 : Int) ^ (mc.level - 1) = ((2 ^ (mc.level - 1) : Nat) : Int) := by
+    exact (Nat.cast_pow (2 : Nat) (mc.level - 1)).symm
+  have hz1 : (off.1 - (2 ^ (mc.level - 1) : Nat)) - (2 ^ mc.level : Nat)
+      + 3 * (2 ^ (mc.level - 1) : Int) + (0 - off.1) = 0 := by
+    rw [hpow, h2k]
+    omega
+  have hz2 : (off.2 - (2 ^ (mc.level - 1) : Nat)) - (2 ^ mc.level : Nat)
+      + 3 * (2 ^ (mc.level - 1) : Int) + (0 - off.2) = 0 := by
+    rw [hpow, h2k]
+    omega
+  rw [hz1, hz2, shift_zero (canonical_evolve_of_pos hnjs g)]
+
 end Life
 end Conway


### PR DESCRIPTION
Grain: DEEP/lean -- lane myia-po-2025:CoursIA -- prev: DEEP/lean #10895 (c.53, BR5)

## What

**BR4a — the one-jump assembly** (#6724, EPIC #3846): `one_jump_toGrid_correct`, the theorem that the engine's jump arm computes **exactly** `evolve (jumpSize k) g` with zero residual translation. This assembles the full locality-bridge chain (a) proven across #10877 (BR1-BR3) and #10895 (BR5) around the already-proved one-jump brick (`hashlifeJump_correct_of_captured`, same file):

> For any `mc` whose `toGrid off` image has the same membership as `g` (supplied by BR1), with `mc.wf`, `1 ≤ mc.level`, `jumpCaptured mc`:
> `(hashlifeJump mc).toGrid (jumpResultOff off mc.level) = evolve (jumpSize mc.level) g`

**Proof chain** (each link a named theorem now on this branch):
1. `toGrid_shift_grid` (BR2) re-anchors the jump output from `jumpResultOff off k` to the brick's anchor `(2^k, 2^k)` — a translation `δ = newOff − (2^k, 2^k)`;
2. brick gives `= evolve (2^k) ((padCenter2 mc).toGrid (0,0))`;
3. `padCenter2_toGrid_shift` (BR3) unfolds the padding as translation `pad = 3·2^(k−1)`; `evolve_shift` pulls it out;
4. BR2 again writes `mc.toGrid (0,0)` as translation `−off` of `mc.toGrid off`; `evolve_shift` pulls it out;
5. `evolve_congr` (BR5) + BR1's membership equivalence convert `evolve js (mc.toGrid off)` into `evolve js g`;
6. `shift_shift` composes the three translations into `δ + pad + (−off)`; each coordinate cancels exactly (`−2^(k−1) − 2^k + 3·2^(k−1) = 0` for `k ≥ 1`, via `2^k = 2·2^(k−1)` fed to `omega`); `shift_zero` drops the residual identity on the canonical grid `evolve (2^k) g`.

**New helper insets** (each the missing piece the assembly needed):
- `buildFromGrid_wf` (Foundation.lean): any `buildFromGrid` is well-formed — the brick requires `c.wf = true` and the engine feeds it `gridToMacroCellWithOffset g` (a `buildFromGrid` over the frame). Lives in Foundation, not MacroCell, because `MacroCell.wf` is *defined* in Foundation (which imports MacroCell — the reverse placement would be circular). Proof: induction on `lvl` **generalizing the offsets** (`generalizing r0 c0`) since the four subtrees recurse at shifted origins; the naive fixed-offset IH leaves the `ne`/`sw`/`se` conjuncts unrewritten.
- `shift_shift` (GridCanonical + _en twin): translation composition, stated with explicit components so rewrites produce sums, no `(a, b).1` projections.
- `shift_zero` (GridCanonical + _en twin): `shift (0,0) g = g` on canonical grids (the `sortDedup` of `shift` re-sorts an already-sorted list).

Statement is engine-exact: it matches `evolveHashlifeFastAux`'s jump arm (`g' := jumped.toGrid newOff`, Hashlife.lean) — the remaining gap to `p5_large_n_jumpN` is the multi-jump invariant (b) (`jumpCaptured` preservation through re-framing) plus the fuel induction.

## Files

- `Conway/Life/HashlifeCorrectness/Foundation.lean`: +`buildFromGrid_wf` (no `_en` twin exists for this file)
- `Conway/Life/GridCanonical.lean` + `GridCanonical_en.lean`: +`shift_shift`, +`shift_zero` (byte-identical pair, checker-verified)
- `Conway/Life/JumpCapture.lean`: +`one_jump_toGrid_correct` (no `_en` twin exists for this file)

Zero existing-code modification (insertions only). Sorry count unchanged: 1 (`p5_large_n_jumpN`).

## Build proof

On warm Mathlib v4.31.0-rc1 (junction `.lake`): `lake build Conway.Life.HashlifeCorrectness.Foundation Conway.Life.JumpCapture` → **Build completed successfully (8506 jobs)**. Only remaining sorries: the two pre-existing ones (`HashlifeCorrectness.lean:1247` `p5_large_n_jumpN` — the target — and `HashlifeMarginFragment.lean:158`). Sorry count per touched file identical to `origin/main` baseline (JumpCapture 1 / GridCanonical 2 / GridCanonical_en 1 / Foundation 26): **0 new sorries**. i18n: `check_i18n_siblings.py GridCanonical_en.lean` → `1/1 pairs byte-identical | 0 drift | 0 orphan` (Foundation/JumpCapture have no `_en` twin). Rebased onto fresh `origin/main` (BR5 commit auto-skipped as already-applied via #10895 squash; 4 BR4a files verified byte-identical built-tree ↔ rebased-tree).

## CI

25 checks — `i18n sibling drift` ✓ (1/1 byte-identical), `Require Grain tag` ✓, `G-VAR-2 light cap` ✓, `Gitleaks` ✓. Lean jobs pending: `ci / Lean CI (conway_lean)`, `proof-integrity` (+ audit), `target-coverage`. Per ai-01 c.97 §B.3: the blocking `proof-integrity` job targets `Conway.KochenSpecker, Conway.FreeWillTheorem`, not the BR4a modules — `target-coverage` confirms the import closure; status updated at merge-gate once green.

## Scope

Stack fully landed: #10868 (BR0) ← #10877 (BR1-BR3) ← #10895 (BR5) all MERGED to main; this PR rebased directly onto main. See #6724. Not `Closes` (multi-jump invariant (b) remains for `p5_large_n_jumpN`).

<!-- BODY:AI:GEN -->
