### PR TITLE
fix(ci,#10445c): jauge machine-dep-timing hors PRs -> commentaire periodique EPIC #9434

### DIFF
--- a/.github/workflows/machine-dep-timing-advisory.yml
+++ b/.github/workflows/machine-dep-timing-advisory.yml
@@ -3,20 +3,25 @@ name: machine-dep-timing-advisory
 # Organe de signalisation (label-driven) pour le drainage progressif des temps
 # d'horloge machine-dependants en prose de notebook (cf. EPIC #9434 + #10158).
 #
-# Mode advisory : exit 0 en TOUTE circonstance, le signal est porte par deux
-# labels sur la PR. Bloquer le merge sur ces labels releve de la politique de
-# la lane, pas du CI.
+# Mode advisory : exit 0 en TOUTE circonstance, le signal est porte par un
+# label (le delta) sur la PR. Bloquer le merge sur ce label releve de la
+# politique de la lane, pas du CI.
 #
 # Pourquoi advisory : #9434 inventorie 1397 findings wallclock a drainer dans
 # 355 notebooks -- un check bloquant fermerait systematiquement toutes les
 # PRs touchant la prose. Le drainage est progressif (cf. backlog dedie).
 #
-# Deux signaux distincts (fix #10445 partie a) :
-#   * ``machine-dep-timing-inventory: <N>`` -- total absolu du depot (jauge de
-#     drainage flotte-wide ; baisse a mesure qu'on draine).
-#   * ``machine-dep-timing-delta: <sign>N (<M> files)`` -- findings wallclock
-#     ajoutes (+) / draines (-) par les .ipynb de la PR elle-meme, vs main.
-#     0 files = PR sans .ipynb ; delta 0 = PR neutre pour le drainage.
+# Fix #10445 (complet) :
+#   * Partie (a) : le label est un DELTA signe -- ``machine-dep-timing-delta:
+#     <sign>N (<M> files)`` -- findings wallclock ajoutes (+) / draines (-) par
+#     les .ipynb de la PR elle-meme, vs main (merge-base). 0 files = PR sans
+#     .ipynb ; delta 0 = PR neutre pour le drainage.
+#   * Partie (c) : la jauge depot-entier (le total absolu) NE SE LIT PAS sur une
+#     PR -- elle mesure la flotte, pas le grain, et un label identique sur des
+#     PRs sans rapport apprenait au lecteur a ignorer le signal. Elle vit dans
+#     un commentaire periodique sur l'EPIC #9434, mis a jour par
+#     machine-dep-timing-inventory.yml (edit du meme commentaire, pas un
+#     nouveau par run).
 # Avant, un seul label ``count`` portait le total absolu sur chaque PR --
 # identique sur 2 PRs sans rapport (#10442 1 notebook, #10357 39 notebooks =
 # meme valeur) -- et trompait le reviewer au merge-gate.
@@ -57,22 +62,12 @@ jobs:
               run: |
                   set +e
                   # ====================================================================
-                  # Deux signaux distincts (fix #10445 partie a) :
-                  #   1. INVENTAIRE --all : total absolu du depot (jauge de drainage
-                  #      flotte-wide, EPIC #9434). Baisse au fur et a mesure qu'on draine.
-                  #   2. DELTA signe sur les fichiers .ipynb modifies par la PR : ce que
-                  #      la PR change reellement (+N ajouts, -N drainage, 0 neutre).
-                  # Avant, un seul label `count` portait le total absolu sur chaque PR --
-                  # identique sur 2 PRs radicalement differentes (#10442 1 notebook qui
-                  # contribuait 0, #10357 39 notebooks = 215 sur les 2) et trompait le
-                  # reviewer au merge-gate. Le commentaire original disait « delta vs main
-                  # porte par le label » : le code mentait, on le rend honnete.
+                  # Fix #10445 partie (c) : le scan --all (jauge depot-entier) a quitte
+                  # ce workflow -- il vit dans machine-dep-timing-inventory.yml
+                  # (commentaire periodique sur l'EPIC #9434). Ici, UN SEUL signal : le
+                  # DELTA signe sur les .ipynb modifies par la PR -- ce que la PR change
+                  # reellement (+N ajouts, -N drainage, 0 neutre).
                   # ====================================================================
-                  python scripts/notebook_tools/check_machine_dep_timing.py --all --json > /tmp/inventory.json
-                  rc_inv=$?
-                  echo "inventory detector exit (ignored in advisory mode): $rc_inv"
-                  inventory=$(python -c "import json; d=json.load(open('/tmp/inventory.json')); print(d['summary']['wallclock'])")
-                  echo "inventory_wallclock=$inventory" >> "$GITHUB_OUTPUT"
 
                   # Delta signe : pour chaque .ipynb modifie par la PR, comparer le
                   # compte de findings wallclock sur la version PR (HEAD) vs la version
@@ -110,19 +105,19 @@ jobs:
               with:
                   script: |
                       // ========================================================================
-                      // Apply signal labels (advisory, never blocking) -- fix #10445 partie a
+                      // Apply signal label (advisory, never blocking) -- fix #10445
                       // ========================================================================
-                      // Deux labels sementiquement honnetes (avant, un seul label `count`
-                      // portait le total absolu -- identique sur des PRs sans rapport, et
-                      // trompait le reviewer au merge-gate). actions/github-script@v7 expose
-                      // `github.rest` (Octokit REST), PAS `github.api`.
+                      // UN SEUL label sementiquement honnete : le DELTA signe (avant, un
+                      // seul label `count` portait le total absolu du depot -- identique sur
+                      // des PRs sans rapport, et trompait le reviewer au merge-gate). La
+                      // jauge depot-entier vit dans le commentaire periodique de l'EPIC
+                      // #9434 (machine-dep-timing-inventory.yml). actions/github-script@v7
+                      // expose `github.rest` (Octokit REST), PAS `github.api`.
                       // ========================================================================
-                      const inventory = '${{ steps.scan.outputs.inventory_wallclock }}';
                       const delta = '${{ steps.scan.outputs.delta_wallclock }}';
                       const deltaSign = '${{ steps.scan.outputs.delta_sign }}';
                       const prFiles = '${{ steps.scan.outputs.pr_files }}';
 
-                      const inventoryLabel = `machine-dep-timing-inventory: ${inventory}`;
                       // Delta signe : +N (ajouts), -N (drainage), 0 (neutre). Le nombre de
                       // fichiers scannes donne le contexte (0 = PR sans .ipynb -> delta 0).
                       const deltaLabel = `machine-dep-timing-delta: ${deltaSign}${delta} (${prFiles} files)`;
@@ -138,7 +133,8 @@ jobs:
                       };
 
                       // Cleanup : retirer les anciens labels machine-dep-timing-*
-                      // (count:* = ancien nom trompeur ; inventory/delta = runs precedents).
+                      // (count:* = ancien nom trompeur ; inventory = jauge deportee en
+                      // #10445(c) ; delta = runs precedents).
                       let existing = [];
                       try {
                           existing = await listLabels();
@@ -162,8 +158,8 @@ jobs:
                           }
                       }
 
-                      // Poser les deux nouveaux labels.
-                      for (const label of [inventoryLabel, deltaLabel]) {
+                      // Poser le label delta (le seul signal par-PR).
+                      for (const label of [deltaLabel]) {
                           try {
                               await github.rest.issues.addLabels({
                                   owner: context.repo.owner,
@@ -178,4 +174,4 @@ jobs:
                           }
                       }
 
-                      core.info(`Advisory labels set: ${inventoryLabel} | ${deltaLabel}`);
+                      core.info(`Advisory label set: ${deltaLabel}`);

--- a/.github/workflows/machine-dep-timing-inventory.yml
+++ b/.github/workflows/machine-dep-timing-inventory.yml
@@ -1,0 +1,119 @@
+name: machine-dep-timing-inventory
+
+# Jauge d'inventaire depot-entier des temps d'horloge machine-dependants en
+# prose de notebook (EPIC #9434). Fix #10445 partie (c) : la jauge NE SE LIT
+# PAS sur une PR -- elle mesure la flotte, pas le grain, et un label identique
+# sur des PRs sans rapport (#10442 1 notebook, #10357 39 notebooks = meme
+# valeur) apprenait au lecteur a ignorer le signal. Elle vit dans un
+# commentaire periodique sur l'EPIC #9434, mis a jour par CE workflow (edit du
+# meme commentaire marque, pas un nouveau par run -- decision ai-01
+# 2026-08-14).
+#
+# Le label par-PR ne garde que le delta signe -- porte par
+# machine-dep-timing-advisory.yml, qui a ete allegera : le scan --all
+# depot-entier (le plus cher) est desormais la seule responsabilite de ce job
+# quotidien, plus execute sur chaque PR.
+#
+# Mode advisory : exit 0 en TOUTE circonstance. Le commentaire est de la
+# signalisation, pas un gate.
+
+on:
+  schedule:
+    # Quotidien, hors creneau catalog-cron (37 3 * * *) et hors heures rondes.
+    - cron: '17 4 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  inventory:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run inventory scan (advisory, exit 0)
+        id: scan
+        run: |
+          set +e
+          python scripts/notebook_tools/check_machine_dep_timing.py --all --json > /tmp/inventory.json
+          rc=$?
+          echo "inventory detector exit (ignored in advisory mode): $rc"
+          python -c "import json; d=json.load(open('/tmp/inventory.json')); print('scanned:', d['scanned'], '| wallclock:', d['summary']['wallclock'], '| total:', d['summary']['total'])"
+          set -e
+
+      - name: Upsert periodic comment on EPIC #9434
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // ========================================================================
+            // Edit du MEME commentaire marque, pas un nouveau par run (#10445 partie
+            // c). Pattern d'upsert : notebook-execution-required.yml (listComments ->
+            // updateComment / createComment). Contexte = evenement schedule : pas de
+            // context.issue, l'EPIC est une constante.
+            // ========================================================================
+            const EPIC = 9434;
+            const MARKER = '<!-- MACHINE-DEP-TIMING-INVENTORY:START -->';
+
+            const fs = require('fs');
+            const inv = JSON.parse(fs.readFileSync('/tmp/inventory.json', 'utf8'));
+            const s = inv.summary;
+            const filesWithFindings = Object.keys(inv.findings || {}).length;
+
+            const body = [
+              MARKER,
+              '## Jauge machine-dep-timing (inventaire depot-entier)',
+              '',
+              '_Commentaire periodique, mis a jour par `machine-dep-timing-inventory.yml`',
+              '_(quotidien, edit du meme commentaire -- fix #10445 partie c). La jauge mesure',
+              '_la flotte (EPIC #9434), pas un grain : elle ne parait pas sur les PRs._',
+              '',
+              '| Metrique | Valeur |',
+              '|---|---|',
+              `| findings wallclock (cible drainage) | ${s.wallclock} |`,
+              `| distribution_param | ${s.distribution_param} |`,
+              `| domain_quantity | ${s.domain_quantity} |`,
+              `| ambiguous | ${s.ambiguous} |`,
+              `| total findings | ${s.total} |`,
+              `| notebooks scannes | ${inv.scanned} |`,
+              `| fichiers avec findings | ${filesWithFindings} |`,
+              '',
+              `Derniere mise a jour : ${new Date().toISOString()} (UTC).`,
+              '',
+              'Le label par-PR `machine-dep-timing-delta` (machine-dep-timing-advisory.yml)',
+              'porte seul le delta signe de chaque PR : +N ajouts, -N drainage, 0 neutre.',
+              '<!-- MACHINE-DEP-TIMING-INVENTORY:END -->',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: EPIC,
+            });
+            const botComment = comments.find(
+              (c) => c.user.type === 'Bot' && c.body.includes(MARKER)
+            );
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body,
+              });
+              core.info(`inventory comment updated: ${botComment.html_url}`);
+            } else {
+              const { data: created } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: EPIC,
+                body: body,
+              });
+              core.info(`inventory comment created: ${created.html_url}`);
+            }


### PR DESCRIPTION
## Summary

Partie **(c)** de #10445 (design-gate tranché par ai-01, commentaire 2026-08-14) : la jauge d'inventaire dépôt-entier ne se lit pas sur une PR — elle mesure la flotte, pas le grain, et un label identique sur des PRs sans rapport apprenait au lecteur à ignorer le signal (#10442 1 notebook vs #10357 39 notebooks = même `215`).

- **`machine-dep-timing-advisory.yml`** : suppression du label `machine-dep-timing-inventory: <N>` (et du scan `--all` dépôt-entier qui le nourrissait — le plus cher du workflow). Le label par-PR ne garde que `machine-dep-timing-delta: <sign>N (<M> files)`. Le cleanup retire toujours les labels `machine-dep-timing-*` résiduels (la jauge disparaît des PRs au fil des runs).
- **`machine-dep-timing-inventory.yml`** (nouveau) : workflow quotidien (cron `17 4 * * *`, hors créneau catalog-cron + `workflow_dispatch`) qui scanne `--all --json` et **upsert** un commentaire périodique sur l'EPIC **#9434** — edit du même commentaire marqué (`<!-- MACHINE-DEP-TIMING-INVENTORY:START -->`), pas un nouveau par run. Pattern d'upsert repris de `notebook-execution-required.yml`. Permissions minimales : `issues: write`.

Mesure réelle à l'instant sur main (a15827594) : `scanned 1003 | wallclock 214 | distribution_param 60 | domain_quantity 36 | ambiguous 0 | total 310 | fichiers avec findings 114` — la jauge draine (215→214 vs l'ouverture de #10445).

## Test plan

- YAML valide (parsing Python des deux fichiers, structure `on`/`jobs`/`permissions` contrôlée).
- Blocs JS des deux `github-script` validés par `node --check` (SYNTAX OK).
- Bloc bash delta simulé localement sur la branche (off origin/main) : `PR .ipynb scanned: 0 | delta: 0` — cohérent.
- (a)+(b) vérifiés sur main avant de clore : label delta présent dans `machine-dep-timing-advisory.yml` (ligne `machine-dep-timing-delta: ${deltaSign}${delta}`), CLI `check_machine_dep_timing.py:470` `if args.paths and not args.all:` + tests pinés.

## Grain

Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: DEEP/notebook-dotnet #10914

Closes #10445