### PR TITLE
feat(guard,#10918): detecteur livrable orphelin base != main (signal PR + scan periodique)

### DIFF
--- a/.github/workflows/base-not-main-advisory.yml
+++ b/.github/workflows/base-not-main-advisory.yml
@@ -1,0 +1,50 @@
+name: Base-not-main advisory
+
+# Part (a) of issue #10918: a PR whose base is NOT `main` delivers its content
+# onto a branch. If that branch is never wired to main afterwards, the
+# deliverable is orphaned -- exists, executed, referenced by a closed issue,
+# visible to nobody. Measured firsthand 2026-08-14: #10770 and #10684 orphaned
+# deliverables exactly this way (recovered via #10764/#10916).
+#
+# This workflow runs on EVERY pull_request event, but only acts when the PR's
+# base != main: it labels the PR `base-not-main` and posts/updates an advisory
+# comment that names the base and counts the open PRs from that base towards
+# main -- 1+ = legitimate stack, 0 = orphan in formation.
+#
+# ADVISORY, never blocking (#10918): label + comment only, the job exits 0
+# regardless. Idempotent: the comment is marker-guarded and updated (not
+# re-posted) on synchronize.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: base-not-main-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  signal:
+    name: "Flag PR targeting a non-main base (advisory)"
+    runs-on: ubuntu-latest
+    # Skip the runner entirely for the ~95% of PRs whose base is main. The
+    # event's OWN base ref drives the guard (not whatever main is at run time).
+    if: github.event.pull_request.base.ref != 'main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Signal base != main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/base_not_main.py --pr "${{ github.event.pull_request.number }}"

--- a/.github/workflows/orphan-branch-scan.yml
+++ b/.github/workflows/orphan-branch-scan.yml
@@ -1,0 +1,73 @@
+name: Orphan branch scan
+
+# The missing ORGAN for issue #10918: a PR merged into a base != main delivers
+# its content onto a branch. If that branch is never wired to main afterwards,
+# the deliverable is orphaned -- it exists, it is executed, it is referenced by
+# a closed issue, and no reader ever sees it. Measured firsthand 2026-08-14 on
+# the last 200 merged PRs: 3 with base != main, 2 orphaned a deliverable
+# (#10770 -> Lean-20 absent from main; #10684 -> Z3-Python-13 enrichment
+# differs from main). The third (#10791) had byte-identical content -- NOT a
+# loss, and NOT flagged: the verdict is on CONTENT IDENTITY, not ancestrality.
+#
+# This scheduled sweep lists the branches that received a merged PR with a
+# base != main, checks integration (ancestor of main) and the existence of an
+# open PR from that branch towards main (a legitimate stack), and -- only when
+# both are negative -- diffs the branch against main, reporting the files whose
+# content is ABSENT or DIFFERS (SAME files dropped: the #10791 case). The
+# report is upserted as a marker-guarded comment on the issue-register #10918.
+#
+# ADVISORY, never blocking (same posture as candidate-delivered-advisory.yml):
+#   - The job ALWAYS exits 0. The actionable payload is the report comment,
+#     NEVER the green conclusion.
+#   - It does NOT auto-fix, does NOT close issues: it signals, a human (or
+#     ai-01) decides (acceptance #4).
+
+on:
+  schedule:
+    # Daily, off-:00 minute (anti-stampede). 05:57 UTC.
+    - cron: '57 5 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log only, post no report'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  issues: write
+  contents: read
+
+concurrency:
+  group: orphan-branch-scan
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: "Scan orphaned branch deliverables (advisory)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch ALL remote heads
+        # actions/checkout@v4 only fetches the default branch. The scan diffs
+        # each base!=main branch against main, so every remote head's objects
+        # must be present locally.
+        run: |
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Run scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DRY=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then DRY="--dry-run"; fi
+          python scripts/orphan_branch_scan.py $DRY --limit 200

--- a/scripts/base_not_main.py
+++ b/scripts/base_not_main.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Base-not-main PR signaler -- part (a) of issue #10918.
+
+A PR whose base is NOT ``main`` delivers its content onto a branch. If that
+branch is never wired to main afterwards, the deliverable is orphaned (see
+orphan_branch_scan.py, part (b)). This tool signals the risk AT PR TIME: it
+labels the PR ``base-not-main`` and posts an advisory comment telling the
+reader whether the base currently has an open PR towards main.
+
+The count of open PRs on the base is what makes the warning useful:
+
+  - 1+ open PR from the base towards main  -> a legitimate stack, the
+    deliverable is in flight (comment says so);
+  - 0 open PRs                            -> an orphan in formation, nothing
+    is scheduled to carry this content to main (comment says so).
+
+ADVISORY, never blocking: label + comment only, exit 0 always. Idempotent:
+re-runs (synchronize events) update the marker-guarded comment, never spam.
+
+Usage::
+
+    python scripts/base_not_main.py --pr 10770 --dry-run
+    python scripts/base_not_main.py --pr 10770          # apply (CI)
+
+Exit code is always 0 (advisory).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+
+LABEL_NAME = "base-not-main"
+LABEL_COLOR = "fbca04"  # yellow -- "targets a non-main base, orphan risk"
+LABEL_DESC = "PR dont la base != main : livraison sur branche, risque d'orphelin (#10918)"
+
+MARKER_START = "<!-- BASE-NOT-MAIN:START -->"
+MARKER_END = "<!-- BASE-NOT-MAIN:END -->"
+
+
+def count_open_prs_on_base(repo: str, base: str) -> int:
+    """Open PRs whose head is ``base`` and that target ``main`` (the stack)."""
+    data = _gh_json([
+        "pr", "list", "--repo", repo, "--state", "open",
+        "--search", f'head:"{base}" base:main',
+        "--json", "number",
+    ]) or []
+    return len(data)
+
+
+def build_comment(base: str, open_count: int, title: str) -> str:
+    if open_count > 0:
+        stack = (
+            f"Cette PR ne livre pas sur `main` : son contenu attend le merge de "
+            f"`{base}`. **{open_count} PR ouverte(s)** de `{base}` vers `main` "
+            f"existe(nt) a cet instant -- c'est un **stack legitime**, le "
+            f"contenu est en vol. Verifier au moment du merge que la base est "
+            f"effectivement reliee a `main`."
+        )
+    else:
+        stack = (
+            f"Cette PR ne livre pas sur `main` : son contenu attend le merge de "
+            f"`{base}`. **Aucune PR ouverte** de `{base}` vers `main` a cet "
+            f"instant -- si la base n'est jamais mergee, le livrable "
+            f"(`{title}`) devient un **orphelin** (personne ne le verra jamais, "
+            f"cf. #10918). Remede : ouvrir une PR de `{base}` vers `main`, ou "
+            f"rebaser cette PR sur `main`."
+        )
+    return "\n".join([
+        MARKER_START,
+        "## Base != main (advisory, #10918)",
+        "",
+        stack,
+        MARKER_END,
+    ])
+
+
+# ---------------------------------------------------------------------------
+# gh wiring
+# ---------------------------------------------------------------------------
+
+def _gh_json(args: list[str]) -> object:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True,
+                          check=False, encoding="utf-8")
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh failed ({proc.returncode}): {proc.stderr.strip() or proc.stdout.strip()}")
+    if not proc.stdout.strip():
+        return None
+    return json.loads(proc.stdout)
+
+
+def ensure_label(repo: str, dry_run: bool) -> None:
+    if dry_run:
+        return
+    subprocess.run(
+        ["gh", "label", "create", LABEL_NAME, "--repo", repo,
+         "--color", LABEL_COLOR, "--description", LABEL_DESC, "--force"],
+        capture_output=True, text=True, check=False, encoding="utf-8",
+    )
+
+
+def existing_comment(repo: str, number: int) -> int | None:
+    comments = _gh_json(["pr", "view", str(number), "--repo", repo,
+                         "--json", "comments"]) or {}
+    for c in (comments.get("comments") or []):
+        if MARKER_START in (c.get("body") or ""):
+            return c["id"]
+    return None
+
+
+def update_comment(repo: str, comment_id: int, body: str) -> None:
+    subprocess.run(
+        ["gh", "api", f"repos/{repo}/issues/comments/{comment_id}",
+         "-X", "PATCH", "-f", f"body={body}"],
+        capture_output=True, text=True, check=False, encoding="utf-8",
+    )
+
+
+def post_comment(repo: str, number: int, body: str) -> None:
+    subprocess.run(
+        ["gh", "pr", "comment", str(number), "--repo", repo, "--body", body],
+        capture_output=True, text=True, check=False, encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--pr", type=int, required=True, help="PR number to signal")
+    ap.add_argument("--dry-run", action="store_true", help="log only, apply nothing")
+    ap.add_argument("--repo", default=None, help="repo (default: gh default / GITHUB_REPOSITORY)")
+    args = ap.parse_args(argv)
+
+    repo = args.repo or (subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        capture_output=True, text=True, encoding="utf-8").stdout.strip()
+        or "jsboige/CoursIA")
+
+    pr = _gh_json(["pr", "view", str(args.pr), "--repo", repo,
+                   "--json", "baseRefName,title"]) or {}
+    base = pr.get("baseRefName", "")
+    title = pr.get("title", "")
+
+    if not base or base == "main":
+        print(f"[base-not-main] #{args.pr} base={base or '?'} -- pas un defaut, rien a faire")
+        return 0
+
+    open_count = count_open_prs_on_base(repo, base)
+    print(f"[base-not-main] #{args.pr} base={base} open_prs_to_main={open_count} "
+          f"mode={'dry-run' if args.dry_run else 'apply'}")
+    if args.dry_run:
+        print(build_comment(base, open_count, title))
+        return 0
+
+    ensure_label(repo, False)
+    body = build_comment(base, open_count, title)
+    cid = existing_comment(repo, args.pr)
+    if cid is not None:
+        update_comment(repo, cid, body)
+        print(f"[base-not-main] comment updated ({cid})")
+    else:
+        post_comment(repo, args.pr, body)
+        print("[base-not-main] comment posted")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/orphan_branch_scan.py
+++ b/scripts/orphan_branch_scan.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Orphan-branch deliverable scanner -- the missing ORGAN for issue #10918.
+
+A PR merged into a base OTHER than ``main`` delivers its content onto a
+branch. If that branch is never wired to main afterwards, the deliverable is
+orphaned: it exists, it is executed, it is referenced by a closed issue -- and
+no reader ever sees it. Nothing in the harness signals it today.
+
+Measured firsthand on the last 200 merged PRs (2026-08-14, issue #10918): 3
+with ``baseRefName != main``, of which 2 orphaned a deliverable:
+
+  - #10770 (base feature/c8266-sendov-theoremes): Lean-20 notebook ABSENT on main
+  - #10684 (base fix/gitleaks-pin-8243):      Z3-Python-13 enrichment DIFFERS from main
+  - #10791 (base feature/c245-lean17-knots-headers-phase2): content IDENTICAL to main
+    (non-ancestor, yet nothing lost) -- must NOT be flagged
+
+Two signals combine into one, and the verdict is on CONTENT IDENTITY, not on
+ancestrality: ``git merge-base --is-ancestor <tip> origin/main`` alone produces
+false positives (#10791 is a non-ancestor with byte-identical content). The
+scan therefore:
+
+  1. lists merged PRs whose base != main (the branches that received a merge);
+  2. for each such branch, checks integration (ancestor of main) and the
+     existence of an open PR from that branch to main (a legitimate stack);
+  3. only when BOTH are negative, diffs the branch against main and reports
+     the files whose content is ABSENT or DIFFERS -- SAME files are dropped
+     (the #10791 case).
+
+ADVISORY, never blocking (same posture as candidate-delivered-advisory.yml):
+the job always exits 0; the actionable payload is the report (comment on the
+issue-register), NEVER the green conclusion.
+
+Usage::
+
+    python scripts/orphan_branch_scan.py --dry-run      # log only, no comment
+    python scripts/orphan_branch_scan.py                # upsert report (CI)
+    python scripts/orphan_branch_scan.py --limit 200    # merged PRs to scan
+
+Exit code is always 0 (advisory).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Iterable
+
+REPORT_ISSUE = 10918  # the issue-register where the periodic report is upserted
+MARKER_START = "<!-- ORPHAN-BRANCH-SCAN:START -->"
+MARKER_END = "<!-- ORPHAN-BRANCH-SCAN:END -->"
+
+# A file whose branch content is byte-identical to main is NOT a lost
+# deliverable (the #10791 case) -- only ABSENT / DIFF count.
+STATUS_SAME, STATUS_DIFF, STATUS_ABSENT = "SAME", "DIFF", "ABSENT"
+
+
+def classify_branch(
+    branch: str,
+    *,
+    exists: bool,
+    is_ancestor_of_main: bool,
+    open_prs_to_main: int,
+    content: list[dict],
+) -> tuple[str, str]:
+    """Classify one base!=main branch that received a merged PR.
+
+    Args:
+        branch: the branch name (base of the merged PR).
+        exists: does the branch still exist on the remote?
+        is_ancestor_of_main: is ``refs/heads/<branch>`` an ancestor of main?
+        open_prs_to_main: open PRs from this branch towards main.
+        content: ``[{"path": str, "status": STATUS_*}...]`` -- the branch-vs-main
+                 content diff (SAME entries pre-filtered or kept, see caller).
+
+    Returns:
+        ``(verdict, detail)`` where verdict is one of:
+        ``"gone"``      -- branch deleted after merge (content may live in the
+            squash commit already merged, or be lost -- unverifiable)
+        ``"integrated"``-- branch is an ancestor of main: content is on main
+        ``"stacked"``   -- an open PR from this branch to main exists: a
+            legitimate stack, the deliverable is in flight
+        ``"orphan"``    -- the defect: not integrated, no open PR, and content
+            ABSENT or DIFFERS from main
+        ``"same"``      -- not integrated, no open PR, but content is
+            byte-identical to main (the #10791 false-positive trap)
+    """
+    if not exists:
+        return ("gone", f"{branch}: branche supprimee apres merge")
+    if is_ancestor_of_main:
+        return ("integrated", f"{branch}: ancetre de main, contenu integre")
+    if open_prs_to_main > 0:
+        return ("stacked", f"{branch}: {open_prs_to_main} PR(s) ouverte(s) vers main (stack)")
+    lost = [c for c in content if c["status"] in (STATUS_DIFF, STATUS_ABSENT)]
+    if not lost:
+        return ("same", f"{branch}: contenu byte-identique a main (#10791)")
+    return ("orphan", f"{branch}: {len(lost)} fichier(s) absent(s)/divergent(s) de main")
+
+
+# ---------------------------------------------------------------------------
+# gh / git wiring
+# ---------------------------------------------------------------------------
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, encoding="utf-8")
+
+
+def _gh_json(args: list[str]) -> object:
+    """Run a gh command, return parsed JSON (or None if empty). Raise on failure."""
+    proc = _run(["gh", *args])
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh failed ({proc.returncode}): {proc.stderr.strip() or proc.stdout.strip()}")
+    if not proc.stdout.strip():
+        return None
+    return json.loads(proc.stdout)
+
+
+def merged_nonmain_bases(repo: str, limit: int) -> list[str]:
+    """Unique base branches of the `limit` most recent merged PRs (base != main).
+
+    Paginates `pulls?state=closed&sort=updated&direction=desc` and stops once
+    `limit` merged PRs have been seen (the branch list is then bounded).
+    """
+    bases: list[str] = []
+    seen_merged = 0
+    page = 1
+    while seen_merged < limit and page <= 20:  # hard ceiling against runaway
+        data = _gh_json([
+            "api",
+            f"repos/{repo}/pulls?state=closed&sort=updated&direction=desc"
+            f"&per_page=100&page={page}",
+        ]) or []
+        if not data:
+            break
+        merged = [pr for pr in data if pr.get("merged_at")]
+        seen_merged += len(merged)
+        for pr in merged:
+            base = (pr.get("base") or {}).get("ref") or ""
+            if base and base != "main" and base not in bases:
+                bases.append(base)
+        if len(data) < 100:
+            break
+        page += 1
+    return bases
+
+
+def remote_branches(repo: str) -> dict[str, str]:
+    """Map branch name -> tip SHA for all remote heads (ls-remote)."""
+    proc = _run(["git", "ls-remote", "--heads", f"https://github.com/{repo}.git"])
+    out: dict[str, str] = {}
+    if proc.returncode == 0:
+        for line in proc.stdout.splitlines():
+            sha, ref = line.split("\t", 1)
+            if ref.startswith("refs/heads/"):
+                out[ref[len("refs/heads/"):]] = sha
+    return out
+
+
+def open_prs_towards_main(repo: str, branch: str) -> int:
+    """Open PRs from ``branch`` towards main (the stack signal)."""
+    data = _gh_json([
+        "pr", "list", "--repo", repo, "--state", "open",
+        "--search", f'head:"{branch}"',
+        "--json", "number,baseRefName",
+    ]) or []
+    return sum(1 for pr in data if (pr.get("baseRefName") == "main"))
+
+
+def is_ancestor_of_main(branch_tip: str, main_ref: str = "origin/main") -> bool:
+    proc = _run(["git", "merge-base", "--is-ancestor", branch_tip, main_ref])
+    return proc.returncode == 0
+
+
+def content_diff(branch: str, branch_tip: str, main_ref: str = "origin/main") -> list[dict]:
+    """Per-file content verdict: branch vs main, via the merge-base diff.
+
+    For each file the branch changed since its merge-base with main, compare the
+    branch blob against the main blob: SAME (byte-identical, drop), DIFF
+    (different content), ABSENT (does not exist on main). Files not in the
+    branch's own diff (main-only changes) are not reported.
+    """
+    result: list[dict] = []
+    mb = _run(["git", "merge-base", main_ref, branch_tip]).stdout.strip()
+    if not mb:
+        return result
+    files = _run(["git", "diff", "--name-status", mb, branch_tip]).stdout.splitlines()
+    for line in files:
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        path = parts[-1]
+        if not _run(["git", "cat-file", "-e", f"{branch_tip}:{path}"]).returncode == 0:
+            # Deleted on the branch (D) -- content was there, now absent. A
+            # deletion vs main that is not on main is still a divergence.
+            status = STATUS_ABSENT
+        elif not _run(["git", "cat-file", "-e", f"{main_ref}:{path}"]).returncode == 0:
+            status = STATUS_ABSENT
+        elif _run(["git", "diff", "--quiet", main_ref, branch_tip, "--", path]).returncode == 0:
+            status = STATUS_SAME
+        else:
+            status = STATUS_DIFF
+        result.append({"path": path, "status": status})
+    return result
+
+
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--dry-run", action="store_true", help="log classifications, post no comment")
+    ap.add_argument("--repo", default=None, help="repo (default: gh default / GITHUB_REPOSITORY)")
+    ap.add_argument("--limit", type=int, default=200, help="merged PRs to scan (0 = no cap)")
+    ap.add_argument("--main-ref", default="origin/main", help="local main ref (CI checks out full)")
+    args = ap.parse_args(argv)
+
+    repo = args.repo or (subprocess.run(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+        capture_output=True, text=True, encoding="utf-8").stdout.strip()
+        or "jsboige/CoursIA")
+
+    branches = merged_nonmain_bases(repo, args.limit)
+    tips = remote_branches(repo)
+
+    counts = {"orphan": 0, "same": 0, "integrated": 0, "stacked": 0, "gone": 0, "unknown": 0}
+    reports: list[dict] = []
+    print(f"[orphan-branch-scan] repo={repo} mode={'dry-run' if args.dry_run else 'apply'} "
+          f"branches={len(branches)} limit={args.limit}")
+
+    for branch in branches:
+        tip = tips.get(branch)
+        if not tip:
+            counts["gone"] += 1
+            print(f"  {branch:<55} GONE     branche absente du remote")
+            continue
+        ancestor = is_ancestor_of_main(tip, args.main_ref)
+        open_prs = open_prs_towards_main(repo, branch)
+        content = content_diff(branch, tip, args.main_ref) if not ancestor and open_prs == 0 else []
+        verdict, why = classify_branch(
+            branch, exists=True, is_ancestor_of_main=ancestor,
+            open_prs_to_main=open_prs, content=content,
+        )
+        counts[verdict] = counts.get(verdict, 0) + 1
+        if verdict == "orphan":
+            lost = [c for c in content if c["status"] != STATUS_SAME]
+            reports.append({"branch": branch, "files": lost})
+            for c in lost:
+                print(f"  {branch:<55} {c['status']:<7} {c['path']}")
+        else:
+            print(f"  {branch:<55} {verdict.upper():<11} {why}")
+
+    print(f"[orphan-branch-scan] done: {counts}")
+    if reports and not args.dry_run:
+        _upsert_report(repo, reports)
+    return 0
+
+
+def _upsert_report(repo: str, reports: list[dict]) -> None:
+    """Post/update the marker-guarded report on the issue-register (#10918)."""
+    lines = [MARKER_START, "## Orphan-branch scan (advisory, #10918)", ""]
+    for r in reports:
+        lines.append(f"**{r['branch']}**")
+        for c in r["files"]:
+            lines.append(f"- `{c['status']}` `{c['path']}`")
+        lines.append("")
+    lines.append(MARKER_END)
+    body = "\n".join(lines)
+
+    comments = _gh_json(["issue", "view", str(REPORT_ISSUE), "--repo", repo,
+                         "--json", "comments"]) or {}
+    for c in (comments.get("comments") or []):
+        if MARKER_START in (c.get("body") or ""):
+            _run(["gh", "api", f"repos/{repo}/issues/comments/{c['id']}",
+                  "-X", "PATCH", "-f", f"body={body}"])
+            print(f"[orphan-branch-scan] report updated (comment {c['id']})")
+            return
+    _run(["gh", "issue", "comment", str(REPORT_ISSUE), "--repo", repo, "--body", body])
+    print("[orphan-branch-scan] report posted")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_base_not_main.py
+++ b/scripts/tests/test_base_not_main.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure core of base_not_main.py (#10918 part a).
+
+``build_comment`` is network-free; the gh wiring is exercised end-to-end in CI
+on real PRs. The two comment variants encode the acceptance behaviour: a base
+with an open PR towards main is a legitimate stack (noted), a base with none is
+an orphan in formation (remedy named).
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from base_not_main import build_comment, MARKER_START, MARKER_END  # noqa: E402
+
+
+def test_comment_stack_when_open_pr_exists():
+    body = build_comment("feature/c8266-sendov-theoremes", 1, "Lean-20 notebook")
+    assert MARKER_START in body and MARKER_END in body
+    assert "stack legitime" in body
+    assert "1 PR ouverte" in body
+    assert "aucune PR ouverte" not in body
+
+
+def test_comment_orphan_risk_when_no_open_pr():
+    body = build_comment("fix/gitleaks-pin-8243", 0, "Z3-Python-13 enrichment")
+    assert "Aucune PR ouverte" in body
+    assert "orphelin" in body
+    assert "rebaser cette PR sur `main`" in body

--- a/scripts/tests/test_orphan_branch_scan.py
+++ b/scripts/tests/test_orphan_branch_scan.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure classification core of orphan_branch_scan.py (#10918).
+
+The ``classify_branch`` function is network-free; ``main`` (the gh/git wiring)
+is exercised end-to-end in CI dry-runs, not here. The fixtures encode the three
+test cases measured firsthand on 2026-08-14 (issue #10918, last 200 merged
+PRs): #10770 and #10684 orphaned deliverables (must surface), #10791 did NOT
+(byte-identical content despite being a non-ancestor -- the ancestrality trap).
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from orphan_branch_scan import classify_branch, STATUS_SAME, STATUS_DIFF, STATUS_ABSENT  # noqa: E402
+
+
+def _content(*statuses):
+    """Build a content diff from status->path pairs like (STATUS_ABSENT, 'x.ipynb')."""
+    return [{"path": p, "status": s} for s, p in statuses]
+
+
+def test_orphan_absent_file():
+    # Mirrors #10770: Lean-20 absent on main, not ancestor, no open PR.
+    verdict, _ = classify_branch(
+        "feature/c8266-sendov-theoremes",
+        exists=True, is_ancestor_of_main=False, open_prs_to_main=0,
+        content=_content((STATUS_ABSENT, "Lean-20-Analysis-I-Tao-Workflow.ipynb"),
+                         (STATUS_SAME, "Lean-19-Sendov-Complex-Analysis.ipynb")),
+    )
+    assert verdict == "orphan"
+
+
+def test_orphan_diff_file():
+    # Mirrors #10684: Z3-Python-13 enrichment differs from main.
+    verdict, _ = classify_branch(
+        "fix/gitleaks-pin-8243",
+        exists=True, is_ancestor_of_main=False, open_prs_to_main=0,
+        content=_content((STATUS_DIFF, "Z3-Python-13-UnsatCores.ipynb")),
+    )
+    assert verdict == "orphan"
+
+
+def test_same_content_not_flagged():
+    # Mirrors #10791: non-ancestor but byte-identical content -- NOT orphan.
+    verdict, why = classify_branch(
+        "feature/c245-lean17-knots-headers-phase2",
+        exists=True, is_ancestor_of_main=False, open_prs_to_main=0,
+        content=_content((STATUS_SAME, "Lean-17-Knots-a-Conway-and-Proofs.ipynb")),
+    )
+    assert verdict == "same"
+    assert "byte-identique" in why
+
+
+def test_integrated_ancestor_not_flagged():
+    verdict, _ = classify_branch(
+        "feature/merged-long-ago",
+        exists=True, is_ancestor_of_main=True, open_prs_to_main=0, content=[],
+    )
+    assert verdict == "integrated"
+
+
+def test_legitimate_stack_not_flagged():
+    # An open PR towards main exists -- the deliverable is in flight.
+    verdict, _ = classify_branch(
+        "feature/in-flight",
+        exists=True, is_ancestor_of_main=False, open_prs_to_main=1,
+        content=_content((STATUS_DIFF, "x.ipynb")),
+    )
+    assert verdict == "stacked"
+
+
+def test_branch_gone():
+    verdict, _ = classify_branch(
+        "feature/deleted", exists=False, is_ancestor_of_main=False,
+        open_prs_to_main=0, content=[],
+    )
+    assert verdict == "gone"
+
+
+def test_empty_content_is_same_not_orphan():
+    # Branch that changed nothing vs main: no lost deliverable.
+    verdict, _ = classify_branch(
+        "feature/empty", exists=True, is_ancestor_of_main=False,
+        open_prs_to_main=0, content=[],
+    )
+    assert verdict == "same"


### PR DESCRIPTION
## Summary

L'organe manquant pour le mode de defaillance le plus silencieux du cycle : une PR mergee vers une base **`!= main`** livre son contenu sur une **branche**. Si la branche n'est jamais reliee a `main`, le livrable devient **orphelin** : il existe, il est execute, il est reference par une issue fermee — et aucun lecteur ne le voit. Rien dans le harnais ne le signale aujourd'hui. Deux signaux combinables en un (mesure #10918) :

- **(a) signal au moment de la PR** — `scripts/base_not_main.py` + `.github/workflows/base-not-main-advisory.yml` : sur tout `pull_request` dont la base != main, label `base-not-main` + commentaire advisory qui **compte les PR ouvertes de la base vers main** : 1+ = stack legitime (contenu en vol, verifier au merge), 0 = orphelin en formation (remède nomme : ouvrir une PR de la base vers main, ou rebaser sur main).
- **(b) balayage periodique** — `scripts/orphan_branch_scan.py` + `.github/workflows/orphan-branch-scan.yml` : enumere les bases != main des PR mergees, verifie l'integration (ancetre de main) et l'existence d'une PR ouverte vers main, et **seulement si les deux sont negatifs**, diff le contenu branche vs main — verdict sur **IDENTITE DE CONTENU**, pas l'ancestralite (cas #10791 : non-ancetre mais contenu byte-identique = rien perdu, non flagge). Rapport upsert (commentaire marque) sur l'issue-registre #10918.

## Mesure firsthand (2026-08-14, 200 dernieres PR mergees)

3 PR avec base != main, 2 livrables orphelins, 1 non-pertede — exactement le ratio de l'issue :

| Base (PR mergee) | Verdict | Preuve |
|---|---|---|
| `feature/c8266-sendov-theoremes` (#10770) | **orphelin** | Lean-20 **ABSENT** sur main (recovery via #10764) |
| `fix/gitleaks-pin-8243` (#10684) | **orphelin** | Z3-Python-13 **DIFF** de main (recovery via #10916) |
| `feature/c245-lean17-knots-headers-phase2` (#10791) | **exclu (same)** | contenu byte-identique a main — le cas non-ancestralite sans perte |

**4e cas decouvert** (signal advisory genuin, arbitrage humain) : `feature/c1331x77-multiseed-pt11` — commits non-integres post-squash #10503 (ex. `2877934fc` re-exec GPU), DIFF de main qui a evolue independamment (#10626). Le scan le signale ; la decision (rebaser / abandonner / laisser) appartient a un humain (acceptance #4).

## Validation

- **9 tests unitaires** (7 `test_orphan_branch_scan.py` + 2 `test_base_not_main.py`) : les 3 cas-temoins ci-dessus + variantes `integrated` / `stacked` / `gone` / contenu vide — 9/9 verts.
- **Dry-run live** sur les 3 cas + #10791 : classifications correctes, 0 faux positif.
- **144 tests `scripts/tests/`** verts (aucune regression sur le reste du depot).
- **pre-commit** sur les 4 fichiers : tous les hooks passent (gitleaks 8.24.3 inclus).

## Advisory, jamais bloquant

- Les deux jobs **exit 0 en toute circonstance** ; le payload actionnable = label + commentaire/report, jamais le vert du job (meme posture que `candidate-delivered-advisory.yml`).
- **Idempotent** : commentaires marque-marque (`<!-- ...:START -->`), mis a jour (PATCH) sur re-run, jamais re-postes.
- Ne corrige rien, ne ferme rien : il signale, un humain (ou ai-01) decide.

## Separation des grains (hygiene PR)

Ce grain (#10918) a d'abord ete committe sur la branche de la PR #10929 (#10928) ; corrige sans force push — cherry-pick ici (commit `e87ec935f`), revert `944200eb4` sur la branche de #10929 dont le diff net est reduit au seul grain #10928. Note dans le body de #10929 pour le reviewer.

Grain: MED/guard — lane myia-po-2026:CoursIA
Closes #10918

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
