### PR TITLE
feat(ci,#10903): testpaths drift guard — pytest.ini vs run lists des workflows pytest

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -124,9 +124,10 @@ jobs:
 
       - name: Run tests
         # Scope to the scripts/ + notebook_tools/ suites this job is named for.
-        # The repo-wide pytest.ini testpaths also list tests/, GameTheory/tests,
-        # and QuantConnect/scripts/tests; those are included below as they share
-        # the same lightweight dep profile. The ML-Training-Pipeline suite is
+        # The repo-wide pytest.ini testpaths also list GameTheory/tests,
+        # QuantConnect/scripts/tests and DataScienceWithAgents/tests; those are
+        # included below as they share the same lightweight dep profile. The
+        # ML-Training-Pipeline suite is
         # owned by ml-tests.yml and intentionally excluded here (it duplicates
         # torch on its own job).
         #
@@ -157,4 +158,14 @@ jobs:
             MyIA.AI.Notebooks/QuantConnect/scripts/tests \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py \
+            MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests \
             --tb=short -q
+      # CI-EXCLUDED — testpaths pytest.ini non couverts par ce run, garde #10903.
+      # Retirer la ligne du répertoire câblé (et l'ajouter au run ci-dessus) quand
+      # l'herméticité est démontrée sur runner nu. Chaque raison est vérifiée
+      # firsthand (2026-08-14, po-2024) :
+      # CI-EXCLUDED: scripts/audit/tests — 4 échecs env-dépendants (test_regen_img1_dalle3.py, clé DALLE-3/OpenAI requise), 405 passent
+      # CI-EXCLUDED: scripts/translation/tests — 1 échec STRUCTURE_DRIFT actif (test_full_repo_state_passes_parity, cellule supprimée 71023d39) — drift à résoudre avant câblage
+      # CI-EXCLUDED: scripts/quantconnect/tests — deps yfinance + fichiers de données externes, non hermétique sur runner nu
+      # CI-EXCLUDED: scripts/secrets/tests — 4/6 fichiers non couverts par secret-scan.yml (render_envs/render_settings_json) ; scan gitleaks = 2 fichiers dédiés
+      # CI-EXCLUDED: GradeBookApp — deps openpyxl/rapidfuzz/unidecode non installées dans ce job ; PII grading hors CI publique

--- a/.github/workflows/testpaths-coverage-guard.yml
+++ b/.github/workflows/testpaths-coverage-guard.yml
@@ -1,0 +1,35 @@
+name: testpaths-coverage-guard
+
+on:
+  pull_request:
+    paths:
+      - 'pytest.ini'
+      - 'scripts/check_testpaths_coverage.py'
+      - '.github/workflows/scripts-tests.yml'
+      - '.github/workflows/ml-tests.yml'
+      - '.github/workflows/secret-scan.yml'
+      - '.github/workflows/ict-tests.yml'
+      - '.github/workflows/testpaths-coverage-guard.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: testpaths vs CI coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Check testpaths coverage
+        # Garde de dérive (#10903) : tout testpath pytest.ini ni couvert par un
+        # workflow pytest ni déclaré `# CI-EXCLUDED: <path> — <raison>` fait
+        # échouer la PR. Le script vérifie aussi que chaque cible déclarée
+        # apparaît verbatim dans son workflow (dérive dans les deux sens).
+        run: python scripts/check_testpaths_coverage.py --verbose

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,5 @@
 [pytest]
 testpaths =
-    tests
     scripts/notebook_tools/tests
     scripts/lean/tests
     MyIA.AI.Notebooks/GameTheory/tests

--- a/scripts/check_testpaths_coverage.py
+++ b/scripts/check_testpaths_coverage.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Guard de dérive : testpaths pytest.ini vs couverture CI.
+
+Compare les testpaths déclarés dans pytest.ini (les suites du dépôt) à la
+couverture réelle des workflows qui invoquent pytest. Rougit sur tout
+testpath ni couvert par un workflow ni déclaré `CI-EXCLUDED`.
+
+Couverture = cibles déclarées dans WORKFLOW_COVERAGE. Chaque cible déclarée
+doit apparaître littéralement dans son fichier workflow : si un run perd une
+cible sans mise à jour ici, le guard le détecte (dérive workflow sans
+mise à jour du guard, dans les deux sens).
+
+Exclusions = marqueurs `# CI-EXCLUDED: <testpath> — <raison>` lus dans les
+fichiers workflows (co-localisés avec les runs qu'ils exemptent).
+
+Usage:
+    python scripts/check_testpaths_coverage.py [--verbose] [--repo-root DIR]
+
+Exit 0 = aucune dérive. Exit 1 = au moins un testpath non couvert non exclu,
+ou une cible déclarée disparue de son workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYTEST_INI = REPO_ROOT / "pytest.ini"
+
+# Cibles pytest par workflow (déclarées, source de vérité du guard). Chacune
+# doit apparaître verbatim dans le fichier : le guard échoue si une cible
+# disparaît du workflow sans mise à jour ici. Les cibles FICHIER (ex.
+# test_gitleaks_*.py) ne couvrent aucun testpath (un testpath = un dossier
+# entier) — elles sont déclarées pour la vérification verbatim, pas pour la
+# couverture.
+WORKFLOW_COVERAGE: dict[str, list[str]] = {
+    ".github/workflows/scripts-tests.yml": [
+        "scripts/tests",
+        "scripts/notebook_tools/tests",
+        "scripts/lean/tests",
+        "MyIA.AI.Notebooks/GameTheory/tests",
+        "MyIA.AI.Notebooks/QuantConnect/scripts/tests",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py",
+        "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py",
+        "MyIA.AI.Notebooks/ML/DataScienceWithAgents/01-PythonForDataScience/tests",
+    ],
+    ".github/workflows/ml-tests.yml": [
+        "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests",
+    ],
+    ".github/workflows/secret-scan.yml": [
+        "scripts/secrets/tests/test_gitleaks_qwen_rule.py",
+        "scripts/secrets/tests/test_gitleaks_10143_classes.py",
+    ],
+    # ict-tests.yml : scopé à MyIA.AI.Notebooks/IIT/ICT-Series (test-cwd
+    # local, test-args relatifs) — ne couvre aucun testpath de la racine.
+    # Présent dans le dict avec liste vide = inspecté et tranché volontaire.
+    ".github/workflows/ict-tests.yml": [],
+}
+
+# Marqueur d'exclusion : `# CI-EXCLUDED: <testpath> — <raison>` en commentaire
+# d'un workflow. L'em-dash "—" est le séparateur (format #10903).
+CI_EXCLUDED_MARKER = re.compile(r"^\s*#\s*CI-EXCLUDED:\s*(\S+?)\s*—\s*(.+)$")
+
+
+def load_testpaths(pytest_ini: Path) -> list[str]:
+    """Lit les testpaths de pytest.ini (ordre de déclaration préservé)."""
+    parser = configparser.ConfigParser()
+    with pytest_ini.open(encoding="utf-8") as fh:
+        parser.read_file(fh)
+    raw = parser.get("pytest", "testpaths")
+    return [line.strip() for line in raw.splitlines() if line.strip()]
+
+
+def load_ci_excluded(repo_root: Path) -> dict[str, str]:
+    """Lit les marqueurs CI-EXCLUDED dans tous les workflows."""
+    excluded: dict[str, str] = {}
+    for wf in sorted((repo_root / ".github/workflows").glob("*.yml")):
+        for line in wf.read_text(encoding="utf-8").splitlines():
+            m = CI_EXCLUDED_MARKER.match(line)
+            if m:
+                path, reason = m.group(1), m.group(2).strip()
+                if path in excluded:
+                    raise SystemExit(
+                        f"CI-EXCLUDED dupliqué pour {path} "
+                        f"({excluded[path]} vs {reason})"
+                    )
+                excluded[path] = reason
+    return excluded
+
+
+def extract_run_targets(text: str) -> set[str]:
+    """Extrait les arguments de chemins des blocs `run:` d'un workflow.
+
+    Ne considère QUE les lignes sous un `run: |` (ou une commande `run: pytest ...`
+    sur une ligne) — pas les commentaires qui mentionnent un chemin. Retourne les
+    tokens qui ressemblent à un chemin relatif (contient un `/` ou `.py`).
+    Gère la continuation par backslash : on reste dans le bloc tant que la
+    ligne est indentée, la commande pytest elle-même (avec ou sans backslash
+    final) incluse.
+    """
+    targets: set[str] = set()
+    in_run_block = False
+    for line in text.splitlines():
+        if in_run_block:
+            # Fin du bloc : ligne non indentée non vide
+            if line.strip() and not line.startswith((" ", "\t")):
+                in_run_block = False
+            else:
+                stripped = line.strip()
+                if stripped and not stripped.startswith("#"):
+                    for token in stripped.split():
+                        if token in ("\\",):
+                            continue
+                        if "/" in token or token.endswith(".py"):
+                            targets.add(token)
+                continue
+        stripped = line.strip()
+        if stripped.startswith("run: |"):
+            in_run_block = True
+            continue
+        # run: pytest <cibles> sur une seule ligne (pas de pipe)
+        if stripped.startswith("run: pytest"):
+            for token in stripped.split()[2:]:
+                if "/" in token or token.endswith(".py"):
+                    targets.add(token)
+    return targets
+
+
+def verify_declared_targets(repo_root: Path, verbose: bool) -> list[str]:
+    """Vérifie que chaque cible déclarée apparaît dans un bloc `run:` réel.
+
+    Le check se fait sur les cibles extraites des blocs `run:` (pas une
+    recherche verbatim dans le fichier : un commentaire mentionnant un chemin
+    ne satisfait pas la couverture — c'est précisément la dérive que le garde
+    doit attraper).
+    """
+    problems: list[str] = []
+    for wf_rel, targets in WORKFLOW_COVERAGE.items():
+        wf_path = repo_root / wf_rel
+        if not wf_path.exists():
+            problems.append(f"workflow déclaré introuvable: {wf_rel}")
+            continue
+        run_targets = extract_run_targets(wf_path.read_text(encoding="utf-8"))
+        for target in targets:
+            if target not in run_targets:
+                problems.append(
+                    f"cible déclarée disparue du run réel: {wf_rel} -> {target} "
+                    f"(retirée du run ? mettre à jour WORKFLOW_COVERAGE)"
+                )
+            elif verbose:
+                print(f"  [ok] {wf_rel} couvre {target}")
+    return problems
+
+
+def is_covered(testpath: str, covered_dirs: list[str]) -> bool:
+    """Un testpath est couvert si une cible-dossier lui est égale ou ancêtre."""
+    return any(
+        testpath == c or testpath.startswith(c + "/") for c in covered_dirs
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--verbose", action="store_true")
+    ap.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    args = ap.parse_args()
+
+    repo_root = args.repo_root.resolve()
+    testpaths = load_testpaths(repo_root / "pytest.ini")
+    excluded = load_ci_excluded(repo_root)
+
+    # Cibles-dossier uniquement (les cibles fichier ne couvrent aucun testpath).
+    covered_dirs = sorted(
+        {
+            t
+            for targets in WORKFLOW_COVERAGE.values()
+            for t in targets
+            if not t.endswith(".py")
+        }
+    )
+
+    if args.verbose:
+        print(f"[info] {len(testpaths)} testpaths, "
+              f"{len(covered_dirs)} cibles-dossier, "
+              f"{len(excluded)} exclusions CI-EXCLUDED")
+
+    problems = verify_declared_targets(repo_root, args.verbose)
+
+    uncovered: list[str] = []
+    for tp in testpaths:
+        if is_covered(tp, covered_dirs):
+            if args.verbose:
+                print(f"  [ok] couvert: {tp}")
+        elif tp in excluded:
+            if args.verbose:
+                print(f"  [ok] exclu:   {tp} — {excluded[tp]}")
+        else:
+            uncovered.append(tp)
+
+    if uncovered:
+        print("Testpaths non couverts et non CI-EXCLUDED :")
+        for tp in uncovered:
+            print(f"  FAIL {tp}")
+    elif args.verbose:
+        print("[ok] tous les testpaths sont couverts ou exclus")
+
+    if problems:
+        print("Dérives de cibles déclarées :")
+        for p in problems:
+            print(f"  FAIL {p}")
+
+    return 1 if (uncovered or problems) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_testpaths_coverage.py
+++ b/scripts/tests/test_check_testpaths_coverage.py
@@ -1,0 +1,77 @@
+"""Tests du garde de dérive testpaths (#10903).
+
+Le garde vit dans scripts/check_testpaths_coverage.py : il compare les
+testpaths de pytest.ini aux cibles pytest réelles des workflows CI et rougit
+sur tout testpath ni couvert ni déclaré CI-EXCLUDED.
+"""
+
+from __future__ import annotations
+
+from scripts.check_testpaths_coverage import (
+    extract_run_targets,
+    is_covered,
+    load_ci_excluded,
+    load_testpaths,
+)
+from scripts.check_testpaths_coverage import REPO_ROOT
+
+
+def test_extract_run_targets_multiline_backslash() -> None:
+    """La continuation par backslash d'un bloc run: | ne coupe pas l'extraction."""
+    wf = (REPO_ROOT / ".github/workflows/scripts-tests.yml").read_text(encoding="utf-8")
+    targets = extract_run_targets(wf)
+    assert "scripts/tests" in targets
+    assert "MyIA.AI.Notebooks/GameTheory/tests" in targets
+    assert "MyIA.AI.Notebooks/QuantConnect/scripts/tests" in targets
+
+
+def test_extract_run_targets_single_line() -> None:
+    """Un `run: pytest <chemin>` sur une ligne est extrait."""
+    text = """      - name: Run tests
+        run: pytest MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests --tb=short -v
+"""
+    assert extract_run_targets(text) == {
+        "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/tests"
+    }
+
+
+def test_extract_run_targets_ignores_comments() -> None:
+    """Un commentaire mentionnant un chemin ne compte pas comme couverture."""
+    text = """      # scripts/tests est couvert par le run ci-dessous
+        run: |
+          pytest \\
+            scripts/lean/tests \\
+            --tb=short -q
+"""
+    targets = extract_run_targets(text)
+    assert "scripts/lean/tests" in targets
+    # Le commentaire seul n'ajoute rien (déjà couvert par le run, mais on
+    # vérifie que les chemins ne sortent pas des blocs run).
+    assert len({t for t in targets if t.startswith("scripts/")}) == 1
+
+
+def test_is_covered_exact_and_ancestor() -> None:
+    assert is_covered("scripts/tests", ["scripts/tests"])
+    assert is_covered("scripts/lean/tests", ["scripts"])  # ancêtre
+    assert not is_covered("scripts/audit/tests", ["scripts/tests"])  # voisin
+    assert not is_covered("GradeBookApp", ["scripts/tests"])
+
+
+def test_guard_green_on_current_main() -> None:
+    """Sur l'état actuel, tous les testpaths sont couverts ou exclus."""
+    testpaths = load_testpaths(REPO_ROOT / "pytest.ini")
+    excluded = load_ci_excluded(REPO_ROOT)
+    from scripts.check_testpaths_coverage import WORKFLOW_COVERAGE
+
+    covered_dirs = sorted(
+        {
+            t
+            for targets in WORKFLOW_COVERAGE.values()
+            for t in targets
+            if not t.endswith(".py")
+        }
+    )
+    uncovered = [tp for tp in testpaths if not is_covered(tp, covered_dirs) and tp not in excluded]
+    assert uncovered == [], f"testpaths non couverts: {uncovered}"
+    # Le testpath `tests` racine a été retiré de pytest.ini (reliquat vide).
+    assert "tests" not in testpaths

--- a/scripts/tests/test_check_testpaths_coverage.py
+++ b/scripts/tests/test_check_testpaths_coverage.py
@@ -7,13 +7,19 @@ sur tout testpath ni couvert ni déclaré CI-EXCLUDED.
 
 from __future__ import annotations
 
-from scripts.check_testpaths_coverage import (
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from check_testpaths_coverage import (  # noqa: E402
+    REPO_ROOT,
+    WORKFLOW_COVERAGE,
     extract_run_targets,
     is_covered,
     load_ci_excluded,
     load_testpaths,
 )
-from scripts.check_testpaths_coverage import REPO_ROOT
 
 
 def test_extract_run_targets_multiline_backslash() -> None:
@@ -61,7 +67,6 @@ def test_guard_green_on_current_main() -> None:
     """Sur l'état actuel, tous les testpaths sont couverts ou exclus."""
     testpaths = load_testpaths(REPO_ROOT / "pytest.ini")
     excluded = load_ci_excluded(REPO_ROOT)
-    from scripts.check_testpaths_coverage import WORKFLOW_COVERAGE
 
     covered_dirs = sorted(
         {


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: DEEP/training #10930

## Summary

Garde de dérive testpaths (#10903) : un job CI qui compare les testpaths de `pytest.ini` aux cibles pytest **réelles** des workflows (`scripts-tests.yml`, `ml-tests.yml`, `secret-scan.yml`, `ict-tests.yml`), et rougit sur tout testpath ni couvert ni déclaré `CI-EXCLUDED`.

**Livrables** :
- `scripts/check_testpaths_coverage.py` — le garde : lit `pytest.ini` (configparser), extrait les cibles des blocs `run:` réels (pas les commentaires — un chemin en commentaire ne compte pas comme couverture, c'est la dérive à attraper), vérifie la présence verbatim de chaque cible déclarée dans son workflow (dérive dans **les deux** sens : testpath ajouté sans câblage, OU cible retirée d'un run sans mise à jour du garde), lit les exclusions `# CI-EXCLUDED: <path> — <raison>`.
- `.github/workflows/testpaths-coverage-guard.yml` — le job, déclenché sur `pull_request` touchant `pytest.ini`, les 4 workflows pytest, ou le garde lui-même (+ `workflow_dispatch`).
- `scripts/tests/test_check_testpaths_coverage.py` — 5 tests unitaires (extraction multi-lignes `\`, run sur une ligne, commentaires ignorés, sémantique ancêtre/voisin, état vert courant).
- `pytest.ini` — retrait du testpath `tests` (racine) : **reliquat vide** (0 fichier suivi, vérifié `git ls-files | grep -c "^tests/"` = 0 ; le commentaire de scripts-tests.yml prétendait l'inclure dans le run mais le run ne le listait pas — la dérive exacte que ce garde attrape).
- `.github/workflows/scripts-tests.yml` — **câblage** de `DataScienceWithAgents/01-PythonForDataScience/tests` (herméticité démontrée : 2 tests numpy/pandas, deps déjà installées dans le job, run local 2 passed en 1.59s) + bloc `# CI-EXCLUDED` pour les 5 répertoires restants avec raisons vérifiées firsthand.

## Herméticité mesurée (2026-08-14, po-2024)

| Testpath | Verdict | Preuve |
|---|---|---|
| DataScienceWithAgents/01-PythonForDataScience/tests | **CÂBLÉ** | 2 passed, numpy/pandas (deps déjà dans le job) |
| scripts/audit/tests | **CI-EXCLUDED** | 405/409 passent ; 4 échecs `test_regen_img1_dalle3.py` env-dépendants (clé DALLE-3/OpenAI requise) |
| scripts/translation/tests | **CI-EXCLUDED** | 296/297 passent ; 1 échec STRUCTURE_DRIFT actif (`test_full_repo_state_passes_parity`, cellule supprimée 71023d39) — drift réel à résoudre avant câblage |
| scripts/quantconnect/tests | **CI-EXCLUDED** | deps yfinance + fichiers de données externes, non hermétique sur runner nu |
| scripts/secrets/tests | **CI-EXCLUDED** | 4/6 fichiers non couverts par secret-scan.yml (render_envs/render_settings_json) ; le scan gitleaks cible 2 fichiers dédiés |
| GradeBookApp | **CI-EXCLUDED** | deps openpyxl/rapidfuzz/unidecode non installées dans le job ; PII grading hors CI publique |

## Validation

- Garde vert sur l'état courant : `python scripts/check_testpaths_coverage.py --verbose` → exit 0, 12 testpaths (13 − 1 reliquat), 6 couverts, 5 exclus.
- **Deux directions de dérive testées** : (1) ajout d'un testpath non couvert → exit 1 avec la liste ; (2) retrait d'une cible d'un run (via suppression de ligne, CRLF-safe) → exit 1 « cible déclarée disparue du run réel ».
- Tests unitaires : `python -W error::SyntaxWarning -m pytest scripts/tests/test_check_testpaths_coverage.py -q` → 5 passed.
- `git diff --stat` : 5 fichiers, 1 sujet (garde #10903), 1 domaine (CI/harnais) — sous les seuils G.4.
- Les 5 autres testpaths non couverts sont déclarés en exclusions **avec raisons** — le garde ne les exige pas câblés d'un coup (design de l'issue : « un garde de dérive, pas un élargissement aveugle »).

## Note pour le reviewer

Le câblage séquentiel des 5 répertoires restants (retirer la ligne CI-EXCLUDED + ajouter au run quand l'herméticité est démontrée) est le plan de l'issue — chaque câblage est une PR dédiée avec sa preuve d'herméticité, comme DataScienceWithAgents dans celle-ci.

Closes #10903 — le garde couvre les deux directions de dérive (testpath orphelin + cible retirée d'un run), les exclusions sont déclarées co-localisées avec les runs, et le mécanisme câblage/exclusion est démontré de bout en bout.

## Grain de contenu du cycle suivant (merge-gate G-VAR-1)

PR META (guard) — plancher de contenu nommé dans le même geste : **m15_lstm_rv §C port** (DEEP/training, lane myia-po-2024) — portage `loss_fn="linear"` DM + champs agrégés §C (`edge_std_pct`, `dm_p_median`, `verdict_sc`) dans `m15_lstm_rv.py`, puis run BTC-only multi-seed + REGISTRY entry. Bloque sur le merge de #10930 (dm_test.py `loss_fn` y vit, pas encore sur main).
