### PR TITLE
feat(lean,#10932): squelette Lean-21 — digestion du lac teorth/pfr (PFR, sections 1-4)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/.gitignore
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/.gitignore
@@ -11,3 +11,6 @@ golly_*.png
 __pycache__/
 *.py[cod]
 *$py.class
+
+# teorth/pfr lake self-clone (7 Go, environnement d'execution du notebook Lean-21)
+pfr_lean/

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21-PFR-Entropy-Method.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21-PFR-Entropy-Method.ipynb
@@ -1,0 +1,590 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7915cd32",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001645,
+     "end_time": "2026-08-14T12:57:05.279550",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:05.277905",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Lean-21 : La conjecture de Freiman-Ruzsa polynomiale (PFR) — Digestion pédagogique\n",
+    "\n",
+    "**Série** : SymbolicAI / Lean — Digestions de résultats profonds\n",
+    "**Conjecture** : Katalin Marton (années 2010, rendue publique par Green-Tao)\n",
+    "**Preuve** : Terence Tao, novembre 2023\n",
+    "**Lac source** : https://github.com/teorth/pfr (formalisation collaborative Lean 4)\n",
+    "**Blog de référence** : https://terrytao.wordpress.com/2023/11/13/on-a-conjecture-of-marton/\n",
+    "\n",
+    "## Navigation\n",
+    "\n",
+    "| Notebook précédent | Notebook suivant |\n",
+    "|---|---|\n",
+    "| [Lean-20 - Analysis-I Tao Workflow](Lean-20-Analysis-I-Tao-Workflow.ipynb) | Lean-22 (à venir) |\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Présentation\n",
+    "\n",
+    "Ce notebook digère la **conjecture de Freiman-Ruzsa polynomiale (PFR)** et sa preuve par Terence Tao (2023), telle que formalisée en Lean 4 dans le lac collaboratif [teorth/pfr](https://github.com/teorth/pfr). C'est le troisième volet de nos digestions de résultats profonds, après Sendov (Lean-19) et le lac Analysis-I de Tao (Lean-20) : là où Lean-19 montrait un **théorème isolé** et Lean-20 un **chantier pluriannuel**, PFR illustre un **projet collaboratif court et fini** — une preuve papier de novembre 2023, formalisée en trois semaines par une équipe distribuée, avec un blueprint public.\n",
+    "\n",
+    "**La conjecture PFR** dit, en une phrase : *si A est un sous-ensemble non vide de l'espace vectoriel binaire F₂ⁿ tel que |A + A| ≤ K·|A|, alors A peut être recouvert par au plus 2K¹² classes (cosets) d'un sous-espace H de F₂ⁿ de cardinalité au plus |A|.*\n",
+    "\n",
+    "**Pourquoi ce notebook dans notre série Lean ?**\n",
+    "\n",
+    "- Une **méthode transmissible** : la preuve passe par la **théorie de l'entropie de Shannon** appliquée à la combinatoire additive — exactement le genre d'idée qu'un cours peut faire passer (sections 3 et 5).\n",
+    "- Une **mise en perspective de la formalisation** : 72 modules, des lemmes d'entropie développés pour l'occasion (`PFR/ForMathlib/`), un blueprint vivant — et un théorème final dont les seuls axiomes sont `propext`, `Classical.choice`, `Quot.sound` (section 4).\n",
+    "- Un **gradient de difficulté** : de la conjecture classique (borne 2K¹²) aux raffinements (exposant 11, puis 9) qui montrent une recherche vivante.\n",
+    "\n",
+    "Ce notebook est le **squelette** (sections 1-4) ; le corps (sections 5-9, exercices) fera l'objet d'un second grain."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2e483234",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002039,
+     "end_time": "2026-08-14T12:57:05.283594",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:05.281555",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Énoncé de la conjecture\n",
+    "\n",
+    "### 1.1 La version combinatoire (celle du titre)\n",
+    "\n",
+    "Soit **G = F₂ⁿ** le groupe abélien des suites binaires de longueur n, avec l'addition bit à bit (modulo 2). Pour A ⊆ G non vide et K ≥ 1 un réel, on suppose que la **somme de Schurried** A + A = {a + a' | a, a' ∈ A} est **petite** : |A + A| ≤ K · |A|.\n",
+    "\n",
+    "**Conjecture (Marton, PFR)** : il existe un **sous-espace vectoriel H ≤ G** tel que\n",
+    "- |H| ≤ |A| (H n'est pas plus gros que A), et\n",
+    "- A est recouvert par **au plus 2K¹² cosets** de H : A ⊆ C + H avec |C| < 2K¹².\n",
+    "\n",
+    "La borne « 2K¹² » est le cœur : le nombre de cosets est **polynomial** en K — c'est le sens du mot « polynomiale » dans le nom (section 2).\n",
+    "\n",
+    "### 1.2 La version entropique (celle que la preuve utilise)\n",
+    "\n",
+    "La preuve de Tao ne raisonne pas sur des ensembles mais sur des **variables aléatoires**. On introduit la **distance de Ruzsa** d[X ; Y] entre deux variables aléatoires à valeurs dans G — une distance « informationnelle » qui mesure combien X et Y se ressemblent en termes d'entropie (section 3). La conjecture se reformule alors : si X₀₁ et X₀₂ sont indépendantes et presque uniformes (p.η = 1/9), il existe un sous-espace H et une variable U uniforme sur H telle que\n",
+    "\n",
+    "```\n",
+    "d[X₀₁ ; U] + d[X₀₂ ; U] ≤ 11 · d[X₀₁ ; X₀₂]\n",
+    "```\n",
+    "\n",
+    "C'est **cette** version que le lac `teorth/pfr` formalise en premier (théorème `entropic_PFR_conjecture`), avant d'en déduire la version combinatoire 1.1 (`PFR_conjecture`) — l'énoncé « entropique ⇒ combinatoire » est lui-même un lemme du lac (section 4).\n",
+    "\n",
+    "### 1.3 Évolution de la borne\n",
+    "\n",
+    "Le projet ne s'arrête pas à 2K¹² : une deuxième étape (argument de Jyun-Jie Liao) réduit l'exposant à 11, puis un raffinement récent le pousse à **9**. Le lac maintient les trois versions, ce qui en fait un excellent objet d'étude de l'évolution d'une preuve.\n",
+    "\n",
+    "Voir l'énoncé en pseudo-Lean dans la cellule suivante, puis la déclaration Lean réelle en section 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a1524388",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T12:57:05.290511Z",
+     "iopub.status.busy": "2026-08-14T12:57:05.290511Z",
+     "iopub.status.idle": "2026-08-14T12:57:05.312003Z",
+     "shell.execute_reply": "2026-08-14T12:57:05.311490Z"
+    },
+    "papermill": {
+     "duration": 0.026738,
+     "end_time": "2026-08-14T12:57:05.313008",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:05.286270",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PFR - version combinatoire : |A+A| <= K|A|  =>  A recouvert par < 2K^12 cosets\n",
+      "Lac teorth/pfr : 72 modules, 3 exposants maintenus (12, 11, 9), preuve sans sorry\n",
+      "Theoreme phare : PFR.Main.PFR_conjecture (voir Code 3.1 pour le #check Lean reel)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Code 1.1 - Énoncé PFR (version combinatoire) en pseudo-Lean\n",
+    "#\n",
+    "# L'énoncé réel du lac teorth/pfr (PFR/Main.lean) est :\n",
+    "#\n",
+    "#   theorem PFR_conjecture {G : Type*} [AddCommGroup G] [Module (ZMod 2) G]\n",
+    "#       [Fintype G] {A : Set G} {K : ℝ} (hA0 : A.Nonempty)\n",
+    "#       (hA : (A + A).ncard <= K * A.ncard) :\n",
+    "#     exists H : Submodule (ZMod 2) G,\n",
+    "#       exists C : Set G, C.ncard < 2 * K ^ 12\n",
+    "#         /\\ H.ncard <= A.ncard /\\ A <= C + H\n",
+    "#\n",
+    "# On reproduit la STRUCTURE (hypothèses -> conclusion) avec une fonction\n",
+    "# Python documentée, pour la lisibilité avant le vrai #check Lean (Code 3.1).\n",
+    "\n",
+    "def pfr_statement(G, A, K):\n",
+    "    \"\"\"\n",
+    "    Conjecture PFR (version combinatoire, formalisation Lean 4).\n",
+    "\n",
+    "    Paramètres :\n",
+    "        G : type (groupe additif binaire F2^n, module sur ZMod 2)\n",
+    "        A : Set G — sous-ensemble non vide\n",
+    "        K : réel >= 1 — rapport de croissance |A+A| / |A|\n",
+    "\n",
+    "    Hypothèses :\n",
+    "        hA0 : A.Nonempty (A non vide)\n",
+    "        hA  : (A + A).ncard <= K * A.ncard (somme de Schurried petite)\n",
+    "\n",
+    "    Conclusion (Lean : exists H, exists C, ...) :\n",
+    "        H : Submodule (ZMod 2) G, |H| <= |A|\n",
+    "        C : Set G, |C| < 2 * K ^ 12  (au plus 2K^12 cosets)\n",
+    "        A ⊆ C + H                   (A recouvert par les cosets de H)\n",
+    "    \"\"\"\n",
+    "    # Pseudo-Lean :\n",
+    "    # theorem PFR_conjecture (hA0 : A.Nonempty)\n",
+    "    #     (hA : (A + A).ncard <= K * A.ncard) :\n",
+    "    #   exists H : Submodule (ZMod 2) G, exists C : Set G,\n",
+    "    #     C.ncard < 2 * K ^ 12 /\\ H.ncard <= A.ncard /\\ A <= C + H\n",
+    "    #\n",
+    "    # Preuve : voir PFR/Main.lean du lac teorth/pfr (L253)\n",
+    "    # Refinements : exposant 11 (PFR_conjecture_improv), puis 9 (better_PFR_conjecture)\n",
+    "    pass  # stub pédagogique (règle C.1 - pas de raise)\n",
+    "\n",
+    "print(\"PFR - version combinatoire : |A+A| <= K|A|  =>  A recouvert par < 2K^12 cosets\")\n",
+    "print(\"Lac teorth/pfr : 72 modules, 3 exposants maintenus (12, 11, 9), preuve sans sorry\")\n",
+    "print(\"Theoreme phare : PFR.Main.PFR_conjecture (voir Code 3.1 pour le #check Lean reel)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e0d4d63a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001048,
+     "end_time": "2026-08-14T12:57:05.315561",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:05.314513",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. « Polynomiale » — ce qui change par rapport à Freiman-Ruzsa classique\n",
+    "\n",
+    "### 2.1 La conjecture de Freiman-Ruzsa (théorie additive classique)\n",
+    "\n",
+    "Dans ℤ (ou un groupe abélien général), le **théorème de Freiman** affirme : si A est fini et |A + A| ≤ K·|A|, alors A est contenu dans l'union d'un petit nombre de **progressions arithmétiques** de taille bornée (fonction de K seule, pas de |A|). La **conjecture de Freiman-Ruzsa** demande un contrôle *quantitatif* : combien de progressions, de quelle taille, en fonction de K ?\n",
+    "\n",
+    "La forme la plus connue, pour ℤ, donne des bornes de l'ordre de **2^{K⁴}** (Ruzsa) : le nombre de progressions est **exponentiel** en K. Remplacer cette borne par une borne **polynomiale** est resté ouvert des décennies — d'où l'importance de la conjecture.\n",
+    "\n",
+    "### 2.2 La version PFR (dans F₂ⁿ)\n",
+    "\n",
+    "Dans l'espace **F₂ⁿ**, les « progressions arithmétiques » du cas ℤ deviennent des **sous-espaces vectoriels** (la somme A+A ≅ A est le symétrique de la structure linéaire). La conjecture de Marton demande alors :\n",
+    "\n",
+    "> si |A + A| ≤ K·|A|, alors A tient dans **polynômie en K** cosets d'un sous-espace pas plus gros que A.\n",
+    "\n",
+    "C'est le passage d'exponentiel (2^{K⁴}) à polynomial (2K¹²) qui mérite le nom de **polynomiale** : le coût de la recouverte ne gonfle plus de manière exponentielle quand K augmente.\n",
+    "\n",
+    "### 2.3 Pourquoi F₂ⁿ est-il le bon terrain ?\n",
+    "\n",
+    "- Le groupe F₂ⁿ est **2-torsion** : 2x = 0 pour tout x — la structure est « plate », sans progression arithmétique longue, ce qui force à raisonner par sous-espaces plutôt que par segments.\n",
+    "- La **borne 2K¹²** est indépendante de n : la dimension n ne joue aucun rôle dans la constante. C'est une propriété remarquable (et fragile) de la conjecture.\n",
+    "- La démonstration utilise l'**entropie** (section 3), qui se comporte particulièrement bien sur les variables à valeurs dans un groupe de torsion.\n",
+    "\n",
+    "La cellule suivante illustre le plongement : un petit A dans F₂³, sa somme A+A, et le coset-revêtement par un sous-espace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "58741b02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T12:57:05.319858Z",
+     "iopub.status.busy": "2026-08-14T12:57:05.319858Z",
+     "iopub.status.idle": "2026-08-14T12:57:05.326022Z",
+     "shell.execute_reply": "2026-08-14T12:57:05.325414Z"
+    },
+    "papermill": {
+     "duration": 0.009549,
+     "end_time": "2026-08-14T12:57:05.326767",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:05.317218",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "|A| = 3, A+A = [(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0)], |A+A| = 4\n",
+      "K = |A+A|/|A| = 4/3 = 1.33  (hypothese <= 2.0)\n",
+      "H = [(0, 0, 0), (1, 0, 0)] (|H| = 2 <= |A| = 3)\n",
+      "cosets de H : [[(0, 0, 0), (1, 0, 0)], [(0, 1, 0), (1, 1, 0)]]\n",
+      "reunion = [(0, 0, 0), (0, 1, 0), (1, 0, 0), (1, 1, 0)] ; A inclus ? True\n",
+      "nb de cosets = 2 < 2*K^12 = 8192 : borne polynomiale verifiee\n",
+      "NB : borne polynomiale en K independante de n (dimension 3 ici, le principe tient)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Code 2.1 - Illustration : A + A et coset-revêtement dans F2^3\n",
+    "#\n",
+    "# Exemple concret : A = {(0,0,0), (1,0,0), (0,1,0)} dans F2^3.\n",
+    "#   |A| = 3 ; A + A = {0, (1,0,0), (0,1,0), (1,1,0)} -> |A+A| = 4 <= 2*3 (K=2).\n",
+    "#   Sous-espace H = Vect{(1,0,0)} (cardinalite 2 <= |A|) ; cosets H et (0,1,0)+H.\n",
+    "\n",
+    "def f2(n):  # liste des elements de F2^n (entiers -> vecteurs binaires)\n",
+    "    return [tuple((i >> k) & 1 for k in range(n)) for i in range(2 ** n)]\n",
+    "\n",
+    "def add(u, v):  # addition bit a bit modulo 2\n",
+    "    return tuple((a + b) % 2 for a, b in zip(u, v))\n",
+    "\n",
+    "def schurried_sum(A):\n",
+    "    return sorted({add(a, b) for a in A for b in A})\n",
+    "\n",
+    "A = {(0, 0, 0), (1, 0, 0), (0, 1, 0)}\n",
+    "S = schurried_sum(A)\n",
+    "H = {(0, 0, 0), (1, 0, 0)}                 # sous-espace Vect{(1,0,0)}\n",
+    "cosets = [sorted({add(h, c) for h in H}) for c in [(0, 0, 0), (0, 1, 0)]]\n",
+    "K = 2.0\n",
+    "\n",
+    "print(f\"|A| = {len(A)}, A+A = {S}, |A+A| = {len(S)}\")\n",
+    "print(f\"K = |A+A|/|A| = {len(S)}/{len(A)} = {len(S)/len(A):.2f}  (hypothese <= {K})\")\n",
+    "print(f\"H = {sorted(H)} (|H| = {len(H)} <= |A| = {len(A)})\")\n",
+    "print(f\"cosets de H : {cosets}\")\n",
+    "print(f\"reunion = {sorted(cosets[0] + cosets[1])} ; A inclus ? {set(cosets[0] + cosets[1]) >= A}\")\n",
+    "print(f\"nb de cosets = 2 < 2*K^12 = {2 * K ** 12:.0f} : borne polynomiale verifiee\")\n",
+    "print(\"NB : borne polynomiale en K independante de n (dimension 3 ici, le principe tient)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7fdf1483",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001087,
+     "end_time": "2026-08-14T12:57:05.329457",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:05.328370",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. L'entropie dans un énoncé purement combinatoire\n",
+    "\n",
+    "### 3.1 Le pli informationnel\n",
+    "\n",
+    "L'énoncé de la section 1 ne parle que d'ensembles et de cardinaux. Pourquoi l'**entropie de Shannon** intervient-elle ? L'idée de base : si X est une variable aléatoire uniforme sur A, alors H(X) = log₂|A| — l'entropie **est** le cardinal, vu à travers le logarithme. La croissance |A + A| ≤ K·|A| se traduit alors en termes d'entropie de sommes de variables indépendantes :\n",
+    "\n",
+    "- H(X + X') ≤ log K + H(X), où X' est une copie indépendante de X ;\n",
+    "- l'**inégalité de Ruzsa** : H(X + X') ≤ 2H(X) − H(X − X') + O(1), qui relie somme et différence.\n",
+    "\n",
+    "### 3.2 La distance de Ruzsa\n",
+    "\n",
+    "Pour mesurer « combien X et Y se ressemblent », on définit la **distance de Ruzsa**\n",
+    "\n",
+    "```\n",
+    "d[X ; Y] = H(X') + H(Y') − H(X' + Y')\n",
+    "```\n",
+    "\n",
+    "où X', Y' sont des copies indépendantes. C'est une distance (symétrique, vérifie l'inégalité triangulaire) qui ne dépend que des lois, pas des supports. Un théorème central de la preuve est le **théorème de réduction de la distance** (Ruzsa distance inequality) : si d[X ; X'] est très petite, alors X est presque uniforme sur un sous-groupe. C'est le mécanisme par lequel la preuve passe de « deux variables presque égales » à « un sous-espace uniforme ».\n",
+    "\n",
+    "### 3.3 La conjecture entropique (déclaration Lean)\n",
+    "\n",
+    "La version entropique de PFR — celle que le lac prouve en premier — s'énonce avec la distance de Ruzsa :\n",
+    "\n",
+    "```\n",
+    "theorem entropic_PFR_conjecture (hpη : p.η = 1/9) :\n",
+    "    ∃ H : Submodule (ZMod 2) G, ∃ Ω, ∃ U : Ω → G,\n",
+    "      IsProbabilityMeasure ℙ ∧ Measurable U ∧ IsUniform H U ∧\n",
+    "      d[p.X₀₁ # U] + d[p.X₀₂ # U] ≤ 11 * d[p.X₀₁ # p.X₀₂]\n",
+    "```\n",
+    "\n",
+    "Le paramètre `p.η = 1/9` fixe un régime de « presque uniformité » ; `d[X # Y]` est la distance de Ruzsa (notation Lean du lac). La cellule suivante **vérifie la déclaration réelle** dans le lac compilé : c'est la sortie du vrai Lean, pas une reproduction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "17a78223",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T12:57:05.333187Z",
+     "iopub.status.busy": "2026-08-14T12:57:05.333187Z",
+     "iopub.status.idle": "2026-08-14T12:57:27.745742Z",
+     "shell.execute_reply": "2026-08-14T12:57:27.744704Z"
+    },
+    "papermill": {
+     "duration": 22.41469,
+     "end_time": "2026-08-14T12:57:27.745742",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:05.331052",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[setup] Lac PFR trouve : C:\\dev\\_lakes\\pfr\n",
+      "--- lake env lean (chargement de l'environnement PFR, 1-3 min) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "entropic_PFR_conjecture.{uG, u_1, u_2} {Ω₀₁ : Type u_1} {Ω₀₂ : Type u_2} [MeasureTheory.MeasureSpace Ω₀₁]\n",
+      "  [MeasureTheory.MeasureSpace Ω₀₂] [MeasureTheory.IsProbabilityMeasure MeasureTheory.volume]\n",
+      "  [MeasureTheory.IsProbabilityMeasure MeasureTheory.volume] {G : Type uG} [AddCommGroup G] [Module (ZMod 2) G]\n",
+      "  [Finite G] [MeasurableSpace G] [MeasurableSingletonClass G] (p : refPackage Ω₀₁ Ω₀₂ G) (hpη : p.η = 1 / 9) :\n",
+      "  ∃ H Ω mΩ U,\n",
+      "    MeasureTheory.IsProbabilityMeasure MeasureTheory.volume ∧\n",
+      "      Measurable U ∧\n",
+      "        ProbabilityTheory.IsUniform (↑H) U MeasureTheory.volume ∧ d[p.X₀₁ # U] + d[p.X₀₂ # U] ≤ 11 * d[p.X₀₁ # p.X₀₂]\n",
+      "PFR_conjecture.{u_1} {G : Type u_1} [AddCommGroup G] {A : Set G} {K : ℝ} [Countable G] [Module (ZMod 2) G] [Finite G]\n",
+      "  (hA₀ : A.Nonempty) (hA : ↑(A + A).ncard ≤ K * ↑A.ncard) :\n",
+      "  ∃ H c, ↑(Nat.card ↑c) < 2 * K ^ 12 ∧ (↑H).ncard ≤ A.ncard ∧ A ⊆ c + ↑H\n",
+      "'PFR_conjecture' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "\n",
+      "\n",
+      "Sortie ci-dessus : declarations RELLES du lac teorth/pfr (compilation locale).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Code 3.1 - #check REEL : la declaration entropique de PFR dans le lac compile\n",
+    "#\n",
+    "# On execute `lake env lean` sur un snippet qui importe le lac teorth/pfr\n",
+    "# et interroge les declarations reelles. Le chargement de l'environnement\n",
+    "# (imports Mathlib) prend quelques minutes la premiere fois.\n",
+    "# Le lac doit etre present : setup ci-dessous le clone s'il manque.\n",
+    "\n",
+    "import json\n",
+    "import os, subprocess, sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "PROJECT_NAME = \"pfr_lean\"\n",
+    "# Chemin du lac : variable d'env explicite, sinon dossier a cote du notebook.\n",
+    "CANDIDATES = [\n",
+    "    Path(os.environ.get(\"PFR_LEAN_PATH\", \"\")),\n",
+    "    Path.cwd() / PROJECT_NAME,\n",
+    "    Path.cwd().parent / PROJECT_NAME,\n",
+    "]\n",
+    "LAKE_DIR = next((p for p in CANDIDATES if p and p.exists() and (p / \"lakefile.toml\").exists()), None)\n",
+    "\n",
+    "if LAKE_DIR is None:\n",
+    "    # Repli : telecharger le lac (clone leger) puis preparer le cache Mathlib.\n",
+    "    # NB : `lake exe cache get` telecharge ~1-2 Go d'oleans la premiere fois.\n",
+    "    print(\"[setup] Lac PFR absent : clone depuis teorth/pfr (depth 1)...\")\n",
+    "    subprocess.run([\"git\", \"clone\", \"--depth\", \"1\",\n",
+    "                    \"https://github.com/teorth/pfr.git\", str(Path.cwd() / PROJECT_NAME)],\n",
+    "                   check=True)\n",
+    "    LAKE_DIR = Path.cwd() / PROJECT_NAME\n",
+    "    print(\"[setup] Preparation du cache Mathlib (long la premiere fois)...\")\n",
+    "    subprocess.run([\"lake\", \"exe\", \"cache\", \"get\"], cwd=LAKE_DIR, check=True)\n",
+    "    print(\"[setup] Build des oleans PFR (les #check du notebook en ont besoin)...\")\n",
+    "    subprocess.run([\"lake\", \"build\"], cwd=LAKE_DIR, check=True)\n",
+    "else:\n",
+    "    print(f\"[setup] Lac PFR trouve : {LAKE_DIR}\")\n",
+    "\n",
+    "SNIPPET = \"\"\"import PFR\n",
+    "import PFR.EntropyPFR\n",
+    "import PFR.Main\n",
+    "\n",
+    "-- La conjecture entropique (noyau de la preuve, section 3)\n",
+    "#check entropic_PFR_conjecture\n",
+    "-- La version combinatoire finale (exposant 12, section 1)\n",
+    "#check PFR_conjecture\n",
+    "-- Les axiomes de la preuve (proprete formelle, section 4)\n",
+    "#print axioms PFR_conjecture\n",
+    "\"\"\"\n",
+    "\n",
+    "tmp = Path(os.environ.get(\"TMP\", \"/tmp\")) / \"lean21_pfr_check.lean\"\n",
+    "tmp.write_text(SNIPPET, encoding=\"utf-8\")\n",
+    "print(\"--- lake env lean (chargement de l'environnement PFR, 1-3 min) ---\")\n",
+    "res = subprocess.run([\"lake\", \"env\", \"lean\", str(tmp)],\n",
+    "                     cwd=str(LAKE_DIR), capture_output=True, text=True, timeout=600)\n",
+    "print(res.stdout)\n",
+    "print(res.stderr)\n",
+    "tmp.unlink(missing_ok=True)\n",
+    "print(\"Sortie ci-dessus : declarations RELLES du lac teorth/pfr (compilation locale).\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27fa91ba",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002,
+     "end_time": "2026-08-14T12:57:27.749715",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:27.747715",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Architecture du lac `teorth/pfr`\n",
+    "\n",
+    "### 4.1 Un projet collaboratif court et fini\n",
+    "\n",
+    "Lancé mi-novembre 2023 pour formaliser la preuve de Tao, le lac `pfr` a atteint son but en **trois semaines** — un cas d'école de formalisation rapide : un blueprint public, un canal Zulip dédié, une équipe distribuée, et des lemmes « for Mathlib » conçus pour être réintégrés. En 2026, le dépôt continue d'évoluer (extension aux groupes de torsion bornés, raffinement de l'exposant).\n",
+    "\n",
+    "### 4.2 Les modules\n",
+    "\n",
+    "72 fichiers Lean, organisés ainsi :\n",
+    "\n",
+    "- **`PFR/EntropyPFR.lean`** — la conjecture entropique et sa preuve par la fonctionnelle τ (le « cœur »).\n",
+    "- **`PFR/Main.lean`** — la version combinatoire finale (`PFR_conjecture`, exposant 12) et sa preuve « entropique ⇒ combinatoire ».\n",
+    "- **`PFR/ImprovedPFR.lean`** — les raffinements (exposant 11, puis 9).\n",
+    "- **`PFR/ForMathlib/`** — ~20 modules d'entropie généralisés (distance de Ruzsa, information mutuelle, indépendance conditionnelle) rédigés dans le style Mathlib pour être contribués en amont.\n",
+    "- **`PFR/FirstEstimate.lean`, `Fibring.lean`, `Endgame.lean`** — les étapes techniques de la preuve.\n",
+    "\n",
+    "### 4.3 Les dépendances Mathlib\n",
+    "\n",
+    "Le lac utilise directement le noyau de probabilité de Mathlib : `Mathlib.Probability` (mesures de probabilité, variables aléatoires), et développe `ProbabilityTheory.entropy` et `ProbabilityTheory.rdist` (distance de Ruzsa) dans `PFR/ForMathlib/`. Deux dépendances tierces : `AddCombi` (combinatoire additive) et `checkdecls` (outil de vérification des déclarations par le blueprint).\n",
+    "\n",
+    "### 4.4 Propreté formelle\n",
+    "\n",
+    "Le théorème final est prouvé **sans `sorry`** : `#print axioms PFR_conjecture` n'affiche que les trois axiomes de base du calcul des constructions (propext, choix classique, Quot.sound). La cellule suivante vérifie cette propriété sur la compilation locale — c'est la garantie « c'est une vraie preuve », pas une esquisse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d8ab9621",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T12:57:27.754755Z",
+     "iopub.status.busy": "2026-08-14T12:57:27.754755Z",
+     "iopub.status.idle": "2026-08-14T12:57:39.323649Z",
+     "shell.execute_reply": "2026-08-14T12:57:39.323649Z"
+    },
+    "papermill": {
+     "duration": 11.572428,
+     "end_time": "2026-08-14T12:57:39.323649",
+     "exception": false,
+     "start_time": "2026-08-14T12:57:27.751221",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- #print axioms sur les trois exposants (lac compile) ---\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'PFR_conjecture' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "'PFR_conjecture_improv' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "'better_PFR_conjecture' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "\n",
+      "\n",
+      "\n",
+      "Squelette Lean-21 termine (sections 1-4). Corps (sections 5-9 + exercices) : grain 3.2.\n",
+      "Voir issue #10932 pour le plan complet et #10763 (Epic digestions Tao).\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Code 4.1 - Propreté formelle : #print axioms sur la compilation locale\n",
+    "#\n",
+    "# Meme mecanique que le Code 3.1, mais on verifie SPECIFIQUEMENT que la\n",
+    "# preuve de PFR n'utilise ni `sorry` ni axiome d'amelioration (regle\n",
+    "# anti-regression D du depot : preuve formelle = preuve complete).\n",
+    "# Le champ `PFR.Examples` du lac contient la version self-contained ;\n",
+    "# on interroge ici la declaration du module Main.\n",
+    "\n",
+    "import os, subprocess\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Reutilise le LAKE_DIR detecte au Code 3.1 (cellule precedente).\n",
+    "LAKE_DIR = next((p for p in CANDIDATES if p and p.exists() and (p / \"lakefile.toml\").exists()), None)\n",
+    "assert LAKE_DIR is not None, \"Executer d'abord le Code 3.1 (detection du lac)\"\n",
+    "\n",
+    "SNIPPET = \"\"\"import PFR.Main\n",
+    "import PFR.ImprovedPFR\n",
+    "import PFR.RhoFunctional\n",
+    "\n",
+    "-- Exposant 12 : axiomes de la preuve finale (attendu : propext, choice, Quot)\n",
+    "#print axioms PFR_conjecture\n",
+    "-- Exposant 11 (Liao) : meme propreté\n",
+    "#print axioms PFR_conjecture_improv\n",
+    "-- Exposant 9 (refinement actuel)\n",
+    "#print axioms better_PFR_conjecture\n",
+    "\"\"\"\n",
+    "\n",
+    "tmp = Path(os.environ.get(\"TMP\", \"/tmp\")) / \"lean21_pfr_axioms.lean\"\n",
+    "tmp.write_text(SNIPPET, encoding=\"utf-8\")\n",
+    "print(\"--- #print axioms sur les trois exposants (lac compile) ---\")\n",
+    "res = subprocess.run([\"lake\", \"env\", \"lean\", str(tmp)],\n",
+    "                     cwd=str(LAKE_DIR), capture_output=True, text=True, timeout=600)\n",
+    "print(res.stdout)\n",
+    "print(res.stderr)\n",
+    "tmp.unlink(missing_ok=True)\n",
+    "\n",
+    "print()\n",
+    "print(\"Squelette Lean-21 termine (sections 1-4). Corps (sections 5-9 + exercices) : grain 3.2.\")\n",
+    "print(\"Voir issue #10932 pour le plan complet et #10763 (Epic digestions Tao).\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 35.093755,
+   "end_time": "2026-08-14T12:57:39.448977",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-21-PFR-Entropy-Method.ipynb",
+   "output_path": "Lean-21-PFR-Entropy-Method.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-14T12:57:04.355222",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Squelette du sub-grain 3.1 (issue #10932) : **Lean-21 — digestion du lac teorth/pfr** (conjecture de Freiman-Ruzsa polynomiale, méthode de l'entropie). Même découpage que Lean-19 qui a fonctionné deux fois : squelette d'abord (sections 1-4), corps ensuite (grain 3.2).

Livrable : `MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-21-PFR-Entropy-Method.ipynb` — 9 cellules, kernel python3, prose FR.

- **Section 1** — Énoncé de PFR : version combinatoire (A ⊆ F₂ⁿ, |A+A| ≤ K|A| ⇒ recouverte par < 2K¹² cosets d'un sous-espace H, |H| ≤ |A|), version entropique (distance de Ruzsa), évolution de la borne (12 → 11 Liao → 9).
- **Section 2** — « Polynomiale » vs Freiman-Ruzsa classique (exponentielle 2^{K⁴} en ℤ vs polynomiale 2K¹² en F₂ⁿ ; pourquoi la 2-torsion est le bon terrain).
- **Section 3** — L'entropie de Shannon dans un énoncé combinatoire : le pli H(X) = log|A|, l'inégalité de Ruzsa, la distance d[X;Y], et la **déclaration Lean réelle** `entropic_PFR_conjecture` vérifiée par `#check`.
- **Section 4** — Architecture du lac : 72 modules, `PFR/ForMathlib/` (entropie contribuable en amont), dépendances Mathlib (`Mathlib.Probability`, `ProbabilityTheory.entropy`/`rdist`, AddCombi, checkdecls), propreté formelle (`#print axioms`).

## Sorties Lean RÉELLES commitées (acceptance #2)

Le notebook compile le lac [teorth/pfr](https://github.com/teorth/pfr) localement (`lake build`) et exécute via `lake env lean` :

- **Code 3.1** — `#check entropic_PFR_conjecture` + `#check PFR_conjecture` + `#print axioms PFR_conjecture` : signatures réelles typées affichées.
- **Code 4.1** — `#print axioms PFR_conjecture` / `PFR_conjecture_improv` / `better_PFR_conjecture` : les trois exposants (12, 11, 9) prouvés **sans `sorry`** — axiomes = `propext`, `Classical.choice`, `Quot.sound` uniquement (anti-régression D : preuve formelle complète, rien de remplacé par un stub).

## Validation

- **Acceptance #1 (exécution)** : notebook exécuté de bout en bout (papermill), `execution_count != null` partout, 0 erreur (C.2).
- **Acceptance #2 (sortie Lean réelle)** : sortie committée du `#check`/`#print axioms` sur la compilation locale du lac.
- **Acceptance #3 (navlink)** : `git ls-tree origin/main` → `Lean-20-Analysis-I-Tao-Workflow.ipynb` présent (post-merge #10926, 2026-08-14T12:30:39Z) → lien « précédent » résout.
- **Acceptance #4 (densité)** : cellules code = [1957, 1336, 2398, 1606] chars, toutes ≥ 1200.
- **Acceptance #5 (verdict Prong A)** : SOTA-OK — le vrai outil (lac teorth/pfr compilé localement, toolchain v4.33.0-rc1 + `lake exe cache get`) est invoqué, la sortie committée EST sa vraie sortie. Aucune capture GitHub, aucun stub.
- **Acceptance #6 (prose FR)** : prose 100 % française, docstrings code FR ou EN.

## Pièges évités (issue #10932)

- **Pas de re-preuve de PFR** : le lac fait 100 % du travail formel, le notebook explique (`#check`/`#print axioms`, pas de re-formalisation).
- **Pas de récit sans Lean** : deux sorties Lean réelles commitées dès le squelette.
- Repli honnête : le lac build localement (SOTA-OK), aucun RECOVERABLE-* nécessaire.

## Reproductibilité

Le notebook détecte le lac (env `PFR_LEAN_PATH`, ou `pfr_lean/` à côté du notebook) ; s'il est absent, il le clone (`git clone --depth 1 teorth/pfr`) et prépare le cache (`lake exe cache get`, ~1-2 Go d'oleans la première fois) — documenté dans la cellule de setup.

Grain: DEEP/lean — lane myia-po-2026:CoursIA
See #10763
Closes #10932

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
