### PR TITLE
fix(tweety,#10940): 7 org.tweetyproject.préférences accentué -> preferences (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences-Csharp.ipynb
@@ -10,7 +10,7 @@
     "**Navigation** : [<- Tweety-8-Agent-Dialogues](Tweety-8-Agent-Dialogues.ipynb) | [Index](Tweety-1-Setup.ipynb) | [Tweety-10-MLN-Csharp ->](Tweety-10-MLN-Csharp.ipynb)\n",
     "\n",
     "> **Serie Tweety -- port C#/.NET natif (EPIC [#4667](https://github.com/jsboige/CoursIA/issues/4667)).**\n",
-    "> Ce notebook exploite le module **`org.tweetyproject.préférences`** de [TweetyProject](https://tweetyproject.org/) **sans JVM** :\n",
+    "> Ce notebook exploite le module **`org.tweetyproject.preferences`** de [TweetyProject](https://tweetyproject.org/) **sans JVM** :\n",
     "> la librairie Java est compilee vers un fat-jar Maven shade puis executee sur le runtime .NET via\n",
     "> [IKVM](https://github.com/ikvm-refined/ikvm).\n",
     "\n",
@@ -26,13 +26,13 @@
     "## Prerequis\n",
     "\n",
     "- Runtime .NET 8.0+ avec kernel `.net-csharp` (cf. [Tweety-3-Dung-Csharp.ipynb](Tweety-3-Dung-Csharp.ipynb) pour la configuration IKVM)\n",
-    "- DLL compilee : `dotnet-build/bin/Release/net8.0/org.tweetyproject.tweety-préférences.dll`\n",
+    "- DLL compilee : `dotnet-build/bin/Release/net8.0/org.tweetyproject.tweety-preferences.dll`\n",
     "\n",
     "## Duree estimee : 30 minutes\n",
     "\n",
     "## Module TweetyProject couvert\n",
     "\n",
-    "- `org.tweetyproject.préférences` -- Ordres de préférence et aggregation"
+    "- `org.tweetyproject.preferences` -- Ordres de préférence et aggregation"
    ]
   },
   {
@@ -43,11 +43,11 @@
     "## Initialisation de l'environnement\n",
     "\n",
     "Cette cellule initialise le runtime **IKVM** (implementation .NET de la machine virtuelle Java) et charge la DLL\n",
-    "`org.tweetyproject.tweety-préférences.dll` compilee depuis le module préférences de TweetyProject 1.30.\n",
+    "`org.tweetyproject.tweety-preferences.dll` compilee depuis le module préférences de TweetyProject 1.30.\n",
     "\n",
     "**Pipeline de build** :\n",
-    "1. `mvn package` (Maven shade) produit `tweety-préférences-full-1.30.jar` (fat-jar avec dependances transitives)\n",
-    "2. `dotnet build` (IKVM 8.15) compile le JAR vers `org.tweetyproject.tweety-préférences.dll` (7.7 Mo, net8.0)\n",
+    "1. `mvn package` (Maven shade) produit `tweety-preferences-full-1.30.jar` (fat-jar avec dependances transitives)\n",
+    "2. `dotnet build` (IKVM 8.15) compile le JAR vers `org.tweetyproject.tweety-preferences.dll` (7.7 Mo, net8.0)\n",
     "3. Le notebook charge la DLL via `Assembly.LoadFrom` dans le runtime .NET\n",
     "\n",
     "** vs Python (JPype)** : ou le notebook Python demarre une JVM externe via JPype, le port C# utilise IKVM qui\n",
@@ -915,7 +915,7 @@
    "source": [
     "### Interpretation : Structure du module préférences\n",
     "\n",
-    "La sortie ci-dessus revele l'architecture du module `org.tweetyproject.préférences` :\n",
+    "La sortie ci-dessus revele l'architecture du module `org.tweetyproject.preferences` :\n",
     "\n",
     "**Classes de base (representation) :**\n",
     "- `PreferenceOrder` : Ordre de préférence principal (implemente `BinaryRelation`)\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "## Module TweetyProject couvert\n",
     "\n",
-    "- `org.tweetyproject.préférences` - Ordres de préférence et agrégation"
+    "- `org.tweetyproject.preferences` - Ordres de préférence et agrégation"
    ]
   },
   {
@@ -457,7 +457,7 @@
    "source": [
     "#### Interprétation: Structure du module préférences\n",
     "\n",
-    "La sortie ci-dessus révèle l'architecture du module `org.tweetyproject.préférences`:\n",
+    "La sortie ci-dessus révèle l'architecture du module `org.tweetyproject.preferences`:\n",
     "\n",
     "**Classes de base (représentation):**\n",
     "- `PreferenceOrder`: Ordre de préférence principal\n",
@@ -1398,8 +1398,8 @@
     "\n",
     "> **Indices :**\n",
     "\n",
-    "- `from org.tweetyproject.préférences import PreferenceOrder`\n",
-    "- `from org.tweetyproject.préférences.aggregation import BordaScoringPreferenceAggregator`\n",
+    "- `from org.tweetyproject.preferences import PreferenceOrder`\n",
+    "- `from org.tweetyproject.preferences.aggregation import BordaScoringPreferenceAggregator`\n",
     "- Explorez l'API par introspection : `for m in PreferenceOrder.class_.getMethods(): print(m.getName())`\n"
    ]
   },

--- a/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
@@ -16,8 +16,15 @@
       csharp_sha: 3e015103eb4cddb301a19f10dd1b8940eefe0fbb
       content_python_sha: 29245004b87519c32cb37bed43227fd2b8af2ade9de7a368a9ddad76dd67e2e9
       content_csharp_sha: 5a7dfff560e3dc513ce623f8ccc6c4f91962cc442f38c0abcec33afe3a73257b
+    - date: "2026-08-14"
+      by: myia-ai-01:CoursIA
+      python_sha: 1c000b05a020e453460d147199c69b529fa14bf1
+      csharp_sha: 1bcd8a14a94a5eba71fd390fc8addc5575fe3a30
+      content_python_sha: 705236dcb08121f1cd55c974690996a0cecc470681db2424c46cc5ae21868674
+      content_csharp_sha: a41d0bfd2051b86250ca965a30f8c2335eb97ede736154081d565472bdba6afa
   known_differences:
     - "Socle commun : argumentation preferentielle (PreferenceReasoner) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`#r \"nuget: IKVM.Image, 8.15.0\"` + Assembly.LoadFrom tweety-preferences.dll). Python via JPype (`from org.tweetyproject.arg.dung.reasoner import SimplePreferredReasoner`). Meme moteur Java."
     - "Re-baseline 2026-07-25 (po-2024, consolidation #8264) : SHA Python avance depuis l'audit 2026-07-23 via #8170 (markdown hyphenation (Note-de-parite)) ; drift verifie paraphite-preservant (ne touche pas l'axe de parite semantic)."
     - "DLL C# tweety-preferences non built sur disque (c.229, 2026-08-12) : le csproj IKVM shade existe (build-TweetyPreferencesShade.csproj) + le pattern de build est documente (twins `tweety-{dung,pl,rpcl,etc}.dll` deja livres par c.220 #10544 et c.208 #10499), mais le jar source `tweety-preferences-full-1.30.jar` n'est pas telecharge. Action RECOVERABLE-LOCAL sur la machine worker : telecharger le jar depuis Maven Central ou compiler depuis les sources, puis `dotnet build` le csproj, puis re-exec le notebook C# pour verifier la parite lib-vs-lib (les 2 cotes appellent les memes classes Java `org.tweetyproject.preferences.*` instantiatees via IKVM ou JPype)."
+    - "Re-baseline 2026-08-14 (ai-01, PR #10943) : les deux SHAs de contenu avancent via la correction markdown-only `org.tweetyproject.préférences` -> `org.tweetyproject.preferences` (identifiant Java accentué par la passe #2876/#7261, `ModuleNotFoundError` garanti pour l'étudiant qui recopiait l'indice). Drift vérifié parité-préservant firsthand : 11 lignes, toutes des identifiants/noms d'artefacts entre backticks ; la prose française « préférence(s) » (le mot) est intacte. Les 4 corrections supplémentaires côté C# seul (`tweety-preferences.dll`, `tweety-preferences-full-1.30.jar`) portent sur des noms d'artefacts qui n'existent que de ce côté -- asymétrie attendue, déjà documentée ci-dessus. L'axe de parité sémantique (IKVM vs JPype sur le même moteur Java) est inchangé."


### PR DESCRIPTION
## Summary

La passe de restauration d'accents SymbolicAI (#2876/#7261) a débordé sur des **identifiants Java** : l'indice d'exercice « Agrégation Borda avec l'API native de Tweety » donnait `from org.tweetyproject.préférences import PreferenceOrder` — un `ModuleNotFoundError` garanti pour l'étudiant qui recopie l'indice. Défaut présent sur `main` (mesuré c.97, 7 occurrences `org.tweetyproject.*`, 0 en cellule code).

Corrigé en **markdown-only** dans les 2 notebooks Tweety-9 (C.3 — pas de ré-exécution, outputs intacts) :

- 7× `org.tweetyproject.préférences` → `org.tweetyproject.preferences`
- **Scan élargi** (acceptance #4) : 4 noms d'artefacts supplémentaires corrompus par la même passe dans Tweety-9-Csharp — `org.tweetyproject.tweety-préférences.dll` (3×) et `tweety-préférences-full-1.30.jar` (1×), **contredits par le code** (cellule 3 réfère `tweety-preferences.dll`) — corrigés pareil.

## Acceptance (issue #10940)

| # | Critère | Preuve |
|---|---------|--------|
| 1 | 0 occurrence `org.tweetyproject.préférences` | grep avant/après : 7 → **0** |
| 2 | Formes correctes préservées | `org.tweetyproject.preferences` 7→11 (NB1), 56→59 (NB2) + `tweety-preferences` 3→7 — toutes les pré-existantes inchangées |
| 3 | Diff markdown-only, outputs intacts | `git diff` : 11 insertions / 11 suppressions, 0 ligne `outputs`/`execution_count`/`metadata` touchée, 0 ligne hors-substitution |
| 4 | Scan élargi rapporté | Signature `(org\|net\|com\|edu\|java)\.[\w.]*[àéèêâîôûçëï]` sur tout `SymbolicAI/**`: **7 hits, tous les 7 dans Tweety-9** — corruption d'identifiants confinée. Prose française « préférences » (mot) non touchée (légitime) |

## Vérifications

- `notebook_tools.py validate` : 2/2 OK, 0 erreur, 0 warning
- Pré-commit : gitleaks + H.3 + markdown-rendering OK
- Remplacement byte-level (pas de re-sérialisation) → diff minimal prouvé

See #2876
Closes #10940

Grain: MED/notebook-python — lane myia-po-2026:CoursIA — prev: DEEP/lean #10973

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
