### PR TITLE
feat(csharprepl,#10897): mode scripte piped --streamPipedInput/--eval (axe 1 Part 2) + re-exec .net-csharp

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb
@@ -1,29 +1,22 @@
 {
- "nbformat": 4,
- "nbformat_minor": 5,
- "metadata": {
-  "kernelspec": {
-   "display_name": ".NET (C#)",
-   "language": "C#",
-   "name": ".net-csharp"
-  },
-  "language_info": {
-   "file_extension": ".cs",
-   "mimetype": "text/x-csharp",
-   "name": "C#",
-   "pygments_lexer": "csharp",
-   "version": "13.0"
-  }
- },
  "cells": [
   {
    "cell_type": "markdown",
    "id": "48a8f1f8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005882,
+     "end_time": "2026-08-14T13:02:48.626491",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:48.620609",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# CSharpRepl attache a un process .NET vivant\n",
     "\n",
-    "> Grain **DEEP/notebook-dotnet** — axe CSharpRepl de la serie *The Unexpected AI Stack: C#/.NET* (Part 1, Charles Chen 08/2026). Epic **#10473**, issue **#10802**. See #10473.\n",
+    "> Grain **DEEP/notebook-dotnet** — axe CSharpRepl de la serie *The Unexpected AI Stack: C#/.NET* (Part 1, Charles Chen 08/2026). Epic **#10473**, issues **#10802** / **#10897**. See #10473, #10897.\n",
     "\n",
     "CSharpRepl est un REPL C# qui ne se contente pas d'executer du code dans un processus isole : il peut **s'attacher a une application .NET vivante** et **patcher ses methodes a chaud** — sans l'arreter, sans la redemarrer, sans recompiler.\n",
     "\n",
@@ -35,7 +28,16 @@
   {
    "cell_type": "markdown",
    "id": "1aa0de93",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004464,
+     "end_time": "2026-08-14T13:02:48.636759",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:48.632295",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Pourquoi c'est non-trivial (parite Python)\n",
     "\n",
@@ -51,7 +53,16 @@
   {
    "cell_type": "markdown",
    "id": "2e1136ab",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005726,
+     "end_time": "2026-08-14T13:02:48.647378",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:48.641652",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Le hook de demarrage\n",
     "\n",
@@ -62,8 +73,141 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "76e7d1f8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:48.671465Z",
+     "iopub.status.busy": "2026-08-14T13:02:48.664066Z",
+     "iopub.status.idle": "2026-08-14T13:02:51.414031Z",
+     "shell.execute_reply": "2026-08-14T13:02:51.407422Z"
+    },
+    "papermill": {
+     "duration": 2.761385,
+     "end_time": "2026-08-14T13:02:51.414166",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:48.652781",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '36536.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "// 0. Setup : helpers partages (l'etat persiste entre les cellules .NET Interactive)\n",
     "#nullable enable\n",
@@ -126,17 +270,68 @@
     "string WorkingDir = FindRepoRoot();       // racine du repo\n",
     "string Repl(string args) => Run(_replExe, args);\n",
     "\n",
+    "// Execute une commande en alimentant stdin (mode pipe : --streamPipedInput).\n",
+    "string RunPiped(string fileName, string arguments, string stdin)\n",
+    "{\n",
+    "    var psi = new ProcessStartInfo(fileName, arguments)\n",
+    "    {\n",
+    "        UseShellExecute = false,\n",
+    "        RedirectStandardInput = true,\n",
+    "        RedirectStandardOutput = true,\n",
+    "        RedirectStandardError = true,\n",
+    "        CreateNoWindow = true,\n",
+    "    };\n",
+    "    using var p = Process.Start(psi)!;\n",
+    "    p.StandardInput.Write(stdin);\n",
+    "    p.StandardInput.Close();\n",
+    "    var stdout = p.StandardOutput.ReadToEnd();\n",
+    "    var stderr = p.StandardError.ReadToEnd();\n",
+    "    p.WaitForExit();\n",
+    "    return stdout + (stderr.Length > 0 ? \"\\n[stderr] \" + stderr : \"\");\n",
+    "}\n",
+    "string ReplPiped(string args, string stdin) => RunPiped(_replExe, args, stdin);\n",
+    "\n",
     "Process? _app = null;                     // process de l'application demo\n",
     "int _pid = 0;                             // PID de l'application demo\n",
     "List<string> _appLog = new();             // stdout/stderr capture de l'application demo"
-   ],
-   "execution_count": 1,
-   "outputs": []
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "3ba6e41a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:51.426547Z",
+     "iopub.status.busy": "2026-08-14T13:02:51.425866Z",
+     "iopub.status.idle": "2026-08-14T13:02:51.758942Z",
+     "shell.execute_reply": "2026-08-14T13:02:51.758621Z"
+    },
+    "papermill": {
+     "duration": 0.340213,
+     "end_time": "2026-08-14T13:02:51.759096",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:51.418883",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hook     : CSharpRepl.InjectedHook.dll\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hosting  : CSharpRepl.InjectedHook\r\n"
+     ]
+    }
+   ],
    "source": [
     "// 1a. Recuperer le chemin du hook (sortie de `connect init`, auto-detection machine)\n",
     "var initOut = Run(_replExe, \"connect init --shell pwsh\");\n",
@@ -144,29 +339,37 @@
     "var hosting = ParseEnvLine(initOut, \"ASPNETCORE_HOSTINGSTARTUPASSEMBLIES\");\n",
     "Console.WriteLine($\"hook     : {Path.GetFileName(hook)}\");\n",
     "Console.WriteLine($\"hosting  : {hosting}\");"
-   ],
-   "execution_count": 2,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "hook     : CSharpRepl.InjectedHook.dll\r\n"
-     ]
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "hosting  : CSharpRepl.InjectedHook\r\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "1b6d8760",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:51.771167Z",
+     "iopub.status.busy": "2026-08-14T13:02:51.770660Z",
+     "iopub.status.idle": "2026-08-14T13:02:54.666681Z",
+     "shell.execute_reply": "2026-08-14T13:02:54.666314Z"
+    },
+    "papermill": {
+     "duration": 2.902338,
+     "end_time": "2026-08-14T13:02:54.666837",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:51.764499",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Application demarree, PID=46292\r\n"
+     ]
+    }
+   ],
    "source": [
     "// 1b. Lancer l'application cible AVEC le hook (stdout capture -> _appLog)\n",
     "var psi = new ProcessStartInfo(\"dotnet\", \"run --project MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/csharprepl-demo\")\n",
@@ -196,22 +399,21 @@
     "    Thread.Sleep(200);\n",
     "}\n",
     "Console.WriteLine($\"Application demarree, PID={_pid}\");"
-   ],
-   "execution_count": 3,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Application demarree, PID=531940\r\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
    "id": "adeb0d0a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005753,
+     "end_time": "2026-08-14T13:02:54.679682",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:54.673929",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Attacher le REPL au process vivant\n",
     "\n",
@@ -220,58 +422,96 @@
   },
   {
    "cell_type": "code",
-   "id": "25fd2be7",
-   "metadata": {},
-   "source": [
-    "// 2a. Lister les processus attachables\n",
-    "Console.WriteLine(Repl(\"connect list\"));"
-   ],
    "execution_count": 4,
+   "id": "25fd2be7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:54.693280Z",
+     "iopub.status.busy": "2026-08-14T13:02:54.692818Z",
+     "iopub.status.idle": "2026-08-14T13:02:55.085826Z",
+     "shell.execute_reply": "2026-08-14T13:02:55.085537Z"
+    },
+    "papermill": {
+     "duration": 0.400984,
+     "end_time": "2026-08-14T13:02:55.086014",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:54.685030",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "                         \r\n",
-      "  PID    │ Process       \r\n",
-      " ────────┼────────────── \r\n",
-      "  531940 │ LiveOrderApp  \r\n",
-      "  541428 │ dotnet        \r\n",
-      "                         \r\n",
+      "                        \r\n",
+      "  PID   │ Process       \r\n",
+      " ───────┼────────────── \r\n",
+      "  12216 │ dotnet        \r\n",
+      "  24996 │ VBCSCompiler  \r\n",
+      "  46292 │ LiveOrderApp  \r\n",
+      "                        \r\n",
       "Connect with csharprepl connect <PID>.\r\n",
-      "Hint: you most likely want to connect to the 'LiveOrderApp' process (PID \r\n",
-      "531940).\r\n",
       "\r\n",
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 2a. Lister les processus attachables\n",
+    "Console.WriteLine(Repl(\"connect list\"));"
    ]
   },
   {
    "cell_type": "code",
-   "id": "583b0c8d",
-   "metadata": {},
-   "source": [
-    "// 2b. Evaluer DANS le process vivant : appeler la methode du service\n",
-    "// (le process n'est ni arrete ni redemarre)\n",
-    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.CalculatePrice(5, 7m)\\\"\"));"
-   ],
    "execution_count": 5,
+   "id": "583b0c8d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:55.098555Z",
+     "iopub.status.busy": "2026-08-14T13:02:55.098062Z",
+     "iopub.status.idle": "2026-08-14T13:02:57.129914Z",
+     "shell.execute_reply": "2026-08-14T13:02:57.129158Z"
+    },
+    "papermill": {
+     "duration": 2.03896,
+     "end_time": "2026-08-14T13:02:57.130209",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:55.091249",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "35\r\n",
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 2b. Evaluer DANS le process vivant : appeler la methode du service\n",
+    "// (le process n'est ni arrete ni redemarre)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.CalculatePrice(5, 7m)\\\"\"));"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "0d320a20",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006517,
+     "end_time": "2026-08-14T13:02:57.142945",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:57.136428",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Lire l'etat vivant du process\n",
     "\n",
@@ -280,28 +520,52 @@
   },
   {
    "cell_type": "code",
-   "id": "0f4b3625",
-   "metadata": {},
-   "source": [
-    "// 3. Lire un compteur statique vivant (ici : nombre de calculs effectues)\n",
-    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.ComputeCount\\\"\"));"
-   ],
    "execution_count": 6,
+   "id": "0f4b3625",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:57.154959Z",
+     "iopub.status.busy": "2026-08-14T13:02:57.154703Z",
+     "iopub.status.idle": "2026-08-14T13:02:57.655619Z",
+     "shell.execute_reply": "2026-08-14T13:02:57.655060Z"
+    },
+    "papermill": {
+     "duration": 0.507612,
+     "end_time": "2026-08-14T13:02:57.655819",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:57.148207",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "6\r\n",
+      "8\r\n",
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 3. Lire un compteur statique vivant (ici : nombre de calculs effectues)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.ComputeCount\\\"\"));"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "20a29be1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006464,
+     "end_time": "2026-08-14T13:02:57.667758",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:57.661294",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Patcher une methode a chaud (`#replace`)\n",
     "\n",
@@ -310,48 +574,105 @@
   },
   {
    "cell_type": "code",
-   "id": "546da49f",
-   "metadata": {},
-   "source": [
-    "// 4a. Definir la methode de remplacement (remise de 20%)\n",
-    "// (signature identique : int, decimal -> decimal)\n",
-    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"decimal salePrice(int q, decimal u) => q * u * 0.8m;\\\"\"));"
-   ],
    "execution_count": 7,
+   "id": "546da49f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:57.679995Z",
+     "iopub.status.busy": "2026-08-14T13:02:57.679435Z",
+     "iopub.status.idle": "2026-08-14T13:02:58.392091Z",
+     "shell.execute_reply": "2026-08-14T13:02:58.391584Z"
+    },
+    "papermill": {
+     "duration": 0.719067,
+     "end_time": "2026-08-14T13:02:58.392279",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:57.673212",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 4a. Definir la methode de remplacement (remise de 20%)\n",
+    "// (signature identique : int, decimal -> decimal)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"decimal salePrice(int q, decimal u) => q * u * 0.8m;\\\"\"));"
    ]
   },
   {
    "cell_type": "code",
-   "id": "018919c8",
-   "metadata": {},
-   "source": [
-    "// 4b. Appliquer le patch a chaud\n",
-    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#replace LiveOrderApp.OrderService.CalculatePrice with salePrice\\\"\"));"
-   ],
    "execution_count": 8,
+   "id": "018919c8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:58.408434Z",
+     "iopub.status.busy": "2026-08-14T13:02:58.407937Z",
+     "iopub.status.idle": "2026-08-14T13:02:59.343957Z",
+     "shell.execute_reply": "2026-08-14T13:02:59.343624Z"
+    },
+    "papermill": {
+     "duration": 0.944849,
+     "end_time": "2026-08-14T13:02:59.344101",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:58.399252",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "patched static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  salePrice  (patch #1)\r\n",
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 4b. Appliquer le patch a chaud\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#replace LiveOrderApp.OrderService.CalculatePrice with salePrice\\\"\"));"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "06a0cf35",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:02:59.357626Z",
+     "iopub.status.busy": "2026-08-14T13:02:59.357042Z",
+     "iopub.status.idle": "2026-08-14T13:03:00.623968Z",
+     "shell.execute_reply": "2026-08-14T13:03:00.623661Z"
+    },
+    "papermill": {
+     "duration": 1.274167,
+     "end_time": "2026-08-14T13:03:00.624115",
+     "exception": false,
+     "start_time": "2026-08-14T13:02:59.349948",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[11] price=24,0\r\n",
+      "[12] price=24,0\r\n",
+      "[13] price=24,0\r\n"
+     ]
+    }
+   ],
    "source": [
     "// 4c. Observer le changement dans l'application VIVANTE (log capture en memoire)\n",
     "Thread.Sleep(1200);\n",
@@ -360,24 +681,21 @@
     "    var tail = _appLog.Where(l => l.Contains(\"price=\")).TakeLast(3);\n",
     "    Console.WriteLine(string.Join(Environment.NewLine, tail));\n",
     "}"
-   ],
-   "execution_count": 9,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "[7] price=30\r\n",
-      "[8] price=24,0\r\n",
-      "[9] price=24,0\r\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
    "id": "63540d2d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005173,
+     "end_time": "2026-08-14T13:03:00.635003",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:00.629830",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Envelopper (`#wrap`), inventaire (`#patches`), annuler (`#revert`)\n",
     "\n",
@@ -386,89 +704,294 @@
   },
   {
    "cell_type": "code",
-   "id": "7643815e",
-   "metadata": {},
-   "source": [
-    "// 5a. Definir le wrapper de journalisation (le delegate `orig` vient en premier parametre)\n",
-    "// (les `\\\\\\\"` sont l'echappement CommandLineToArgvW : quotes litterales dans l'argv du process cible)\n",
-    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"decimal logged(Func<int, decimal, decimal> orig, int q, decimal u) {{ System.Console.WriteLine(\\\\\\\"repl-log: \\\\\\\" + q + \\\\\\\" x \\\\\\\" + u); return orig(q, u); }}\\\"\"));"
-   ],
    "execution_count": 10,
+   "id": "7643815e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:00.645239Z",
+     "iopub.status.busy": "2026-08-14T13:03:00.645010Z",
+     "iopub.status.idle": "2026-08-14T13:03:01.125732Z",
+     "shell.execute_reply": "2026-08-14T13:03:01.125539Z"
+    },
+    "papermill": {
+     "duration": 0.486036,
+     "end_time": "2026-08-14T13:03:01.125837",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:00.639801",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 5a. Definir le wrapper de journalisation (le delegate `orig` vient en premier parametre)\n",
+    "// (les `\\\\\\\"` sont l'echappement CommandLineToArgvW : quotes litterales dans l'argv du process cible)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"decimal logged(Func<int, decimal, decimal> orig, int q, decimal u) {{ System.Console.WriteLine(\\\\\\\"repl-log: \\\\\\\" + q + \\\\\\\" x \\\\\\\" + u); return orig(q, u); }}\\\"\"));"
    ]
   },
   {
    "cell_type": "code",
-   "id": "6403c448",
-   "metadata": {},
-   "source": [
-    "// 5b. Appliquer le wrap\n",
-    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#wrap LiveOrderApp.OrderService.CalculatePrice with logged\\\"\"));"
-   ],
    "execution_count": 11,
+   "id": "6403c448",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:01.137863Z",
+     "iopub.status.busy": "2026-08-14T13:03:01.137565Z",
+     "iopub.status.idle": "2026-08-14T13:03:01.521865Z",
+     "shell.execute_reply": "2026-08-14T13:03:01.521591Z"
+    },
+    "papermill": {
+     "duration": 0.390761,
+     "end_time": "2026-08-14T13:03:01.522003",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:01.131242",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "wrapped static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  logged  (patch #2)\r\n",
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 5b. Appliquer le wrap\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#wrap LiveOrderApp.OrderService.CalculatePrice with logged\\\"\"));"
    ]
   },
   {
    "cell_type": "code",
-   "id": "e9a93517",
-   "metadata": {},
-   "source": [
-    "// 5c. Inventaire des patches actifs\n",
-    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#patches\\\"\"));"
-   ],
    "execution_count": 12,
+   "id": "e9a93517",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:01.534632Z",
+     "iopub.status.busy": "2026-08-14T13:03:01.534185Z",
+     "iopub.status.idle": "2026-08-14T13:03:01.888669Z",
+     "shell.execute_reply": "2026-08-14T13:03:01.888371Z"
+    },
+    "papermill": {
+     "duration": 0.361425,
+     "end_time": "2026-08-14T13:03:01.888812",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:01.527387",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "  #1  [Replace]  static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  salePrice\r\n",
       "  #2  [Wrap]  static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  logged\r\n",
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 5c. Inventaire des patches actifs\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#patches\\\"\"));"
    ]
   },
   {
    "cell_type": "code",
-   "id": "b3449a07",
-   "metadata": {},
-   "source": [
-    "// 5d. Annuler tous les patches -> l'application revient au comportement original\n",
-    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#revert all\\\"\"));"
-   ],
    "execution_count": 13,
+   "id": "b3449a07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:01.902398Z",
+     "iopub.status.busy": "2026-08-14T13:03:01.901902Z",
+     "iopub.status.idle": "2026-08-14T13:03:02.264540Z",
+     "shell.execute_reply": "2026-08-14T13:03:02.264279Z"
+    },
+    "papermill": {
+     "duration": 0.369811,
+     "end_time": "2026-08-14T13:03:02.264650",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:01.894839",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "reverted 2 patch(es).\r\n",
       "\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 5d. Annuler tous les patches -> l'application revient au comportement original\n",
+    "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#revert all\\\"\"));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4db8718e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005936,
+     "end_time": "2026-08-14T13:03:02.276319",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:02.270383",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Le mode scripte (piped) : patcher sans interaction humaine\n",
+    "\n",
+    "Jusqu'ici, chaque commande passait par un REPL **interactif** : la cellule lance `connect`, execute une commande, ferme le REPL. Le mode **pipe** (`--streamPipedInput`) inverse le rapport : on **envoie un flux de commandes sur l'entree standard** du REPL, qui les execute les unes apres les autres dans le process vivant puis se ferme a la fin du flux. C'est le mode de l'agent de programmation : le **meme** `#replace` que la section 4, mais scripte — sans terminal, sans invite, reproductible.\n",
+    "\n",
+    "`--eval <code>` fait la meme chose pour une **expression unique** (le resultat revient sur stdout), `--eval-file <fichier>` pour un **script entier** depuis un fichier. C'est exactement ce que l'article Part 2 annonce : *« Coding agents will be able to use the same REPL via `--eval <code>` or `--eval-file <file>` to manipulate the runtime state of the application »*. Ce notebook passe donc de la demonstration interactive a la **delegation a un agent**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "42f56d09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:02.289355Z",
+     "iopub.status.busy": "2026-08-14T13:03:02.289034Z",
+     "iopub.status.idle": "2026-08-14T13:03:03.713652Z",
+     "shell.execute_reply": "2026-08-14T13:03:03.713274Z"
+    },
+    "papermill": {
+     "duration": 1.432526,
+     "end_time": "2026-08-14T13:03:03.713819",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:02.281293",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "patched static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  ←  (int q, decimal u) => q * u * 0.85m  (patch #3)\r\n",
+      "85.00\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// 6a. Mode pipe : envoyer le patch PUIS l'evaluation dans le meme flux\n",
+    "// (pas de point-virgule final sur la lambda : le parseur du mode pipe le refuse, CS0201)\n",
+    "var script = \"#replace LiveOrderApp.OrderService.CalculatePrice with (int q, decimal u) => q * u * 0.85m\\n\" +\n",
+    "             \"LiveOrderApp.OrderService.CalculatePrice(20, 5m)\\n\";\n",
+    "Console.WriteLine(ReplPiped($\"connect {_pid} --streamPipedInput\", script));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "5fe3cf0a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:03.727863Z",
+     "iopub.status.busy": "2026-08-14T13:03:03.727587Z",
+     "iopub.status.idle": "2026-08-14T13:03:04.993926Z",
+     "shell.execute_reply": "2026-08-14T13:03:04.993452Z"
+    },
+    "papermill": {
+     "duration": 1.273626,
+     "end_time": "2026-08-14T13:03:04.994111",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:03.720485",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[19] price=25,50\r\n",
+      "[20] price=25,50\r\n",
+      "[21] price=25,50\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// 6b. Observer le changement dans l'application VIVANTE : patchee sans aucune interaction humaine\n",
+    "Thread.Sleep(1200);\n",
+    "lock (_appLog)\n",
+    "{\n",
+    "    var tail = _appLog.Where(l => l.Contains(\"price=\")).TakeLast(3);\n",
+    "    Console.WriteLine(string.Join(Environment.NewLine, tail));\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "45ca30a1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:05.005010Z",
+     "iopub.status.busy": "2026-08-14T13:03:05.004356Z",
+     "iopub.status.idle": "2026-08-14T13:03:05.376072Z",
+     "shell.execute_reply": "2026-08-14T13:03:05.375910Z"
+    },
+    "papermill": {
+     "duration": 0.377023,
+     "end_time": "2026-08-14T13:03:05.376161",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:04.999138",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17.00\r\n",
+      "\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// 6c. --eval : lire l'etat patche en une seule expression (primitive de lecture de l'agent)\n",
+    "Console.WriteLine(Repl($\"connect {_pid} --eval \\\"LiveOrderApp.OrderService.CalculatePrice(10, 2m)\\\"\"));"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "7b22e8a7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00655,
+     "end_time": "2026-08-14T13:03:05.389376",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.382826",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 1 : patch `#replace` d'un calcul de TVA\n",
     "\n",
@@ -479,30 +1002,54 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 17,
    "id": "f103ba26",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:05.402959Z",
+     "iopub.status.busy": "2026-08-14T13:03:05.402366Z",
+     "iopub.status.idle": "2026-08-14T13:03:05.438493Z",
+     "shell.execute_reply": "2026-08-14T13:03:05.438269Z"
+    },
+    "papermill": {
+     "duration": 0.044676,
+     "end_time": "2026-08-14T13:03:05.438590",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.393914",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ],
    "source": [
     "// Exercice a completer : definir withVat puis #replace OrderService.CalculatePrice\n",
     "// decimal withVat(int q, decimal u) => ...;\n",
     "// #replace LiveOrderApp.OrderService.CalculatePrice with withVat\n",
     "// Verifier dans le log que price passe a 36.\n",
     "Console.WriteLine(\"Exercice a completer\");"
-   ],
-   "execution_count": 14,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\r\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
    "id": "6d0f387a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005023,
+     "end_time": "2026-08-14T13:03:05.448248",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.443225",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 2 : `#wrap` avec journalisation\n",
     "\n",
@@ -513,29 +1060,53 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 18,
    "id": "f9c84d3b",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:05.462818Z",
+     "iopub.status.busy": "2026-08-14T13:03:05.462368Z",
+     "iopub.status.idle": "2026-08-14T13:03:05.504131Z",
+     "shell.execute_reply": "2026-08-14T13:03:05.503761Z"
+    },
+    "papermill": {
+     "duration": 0.049911,
+     "end_time": "2026-08-14T13:03:05.504348",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.454437",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ],
    "source": [
     "// Exercice a completer : wrapper de journalisation puis #wrap\n",
     "// decimal logged(Func<int, decimal, decimal> orig, int q, decimal u) { ... ; return orig(q, u); }\n",
     "// #wrap LiveOrderApp.OrderService.CalculatePrice with logged\n",
     "Console.WriteLine(\"Exercice a completer\");"
-   ],
-   "execution_count": 15,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\r\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ba8f3a01",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00493,
+     "end_time": "2026-08-14T13:03:05.517177",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.512247",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 3 : lecture d'etat vivant multi-cible\n",
     "\n",
@@ -546,8 +1117,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 19,
    "id": "19dc04f1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:05.529324Z",
+     "iopub.status.busy": "2026-08-14T13:03:05.528991Z",
+     "iopub.status.idle": "2026-08-14T13:03:05.563858Z",
+     "shell.execute_reply": "2026-08-14T13:03:05.563634Z"
+    },
+    "papermill": {
+     "duration": 0.040936,
+     "end_time": "2026-08-14T13:03:05.564090",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.523154",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\r\n"
+     ]
+    }
+   ],
    "source": [
     "// Exercice a completer : mesurer ComputeCount a deux instants\n",
     "// var c1 = int.Parse(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.ComputeCount\\\"\").Trim());\n",
@@ -555,61 +1151,110 @@
     "// var c2 = ...;\n",
     "// Console.WriteLine($\"count: {c1} -> {c2}\");\n",
     "Console.WriteLine(\"Exercice a completer\");"
-   ],
-   "execution_count": 16,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\r\n"
-     ]
-    }
    ]
   },
   {
    "cell_type": "markdown",
    "id": "7f050498",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005738,
+     "end_time": "2026-08-14T13:03:05.575043",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.569305",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## 6. Arret propre\n",
+    "## 7. Arret propre\n",
     "\n",
     "On detache le REPL (`exit` ou EOF) et on arrete l'application de demonstration.\n"
    ]
   },
   {
    "cell_type": "code",
+   "execution_count": 20,
    "id": "521411fb",
-   "metadata": {},
-   "source": [
-    "// 6. Arreter proprement l'application vivante\n",
-    "_app?.Kill(entireProcessTree: true);\n",
-    "Console.WriteLine(\"Application arretee.\");"
-   ],
-   "execution_count": 17,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:03:05.590613Z",
+     "iopub.status.busy": "2026-08-14T13:03:05.590314Z",
+     "iopub.status.idle": "2026-08-14T13:03:05.736226Z",
+     "shell.execute_reply": "2026-08-14T13:03:05.736547Z"
+    },
+    "papermill": {
+     "duration": 0.15481,
+     "end_time": "2026-08-14T13:03:05.736723",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.581913",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Application arretee.\r\n"
      ]
     }
+   ],
+   "source": [
+    "// 7. Arreter proprement l'application vivante\n",
+    "_app?.Kill(entireProcessTree: true);\n",
+    "Console.WriteLine(\"Application arretee.\");"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "9952cfde",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006608,
+     "end_time": "2026-08-14T13:03:05.750979",
+     "exception": false,
+     "start_time": "2026-08-14T13:03:05.744371",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "## Conclusion\n",
+    "Nous avons demontre, **avec du code execute**, les deux faces de CSharpRepl : le REPL **interactif** s'attache a un process .NET vivant, y evalue des expressions, lit son etat, **patche une methode a chaud** (`#replace`), l'**enveloppe** (`#wrap`) et **annule** (`#revert`) ; le mode **scripte** (`--streamPipedInput` / `--eval`) fait la meme chose **sans interaction humaine**, en envoyant le flux de commandes sur stdin — la forme delegable a un agent de programmation. L'application change de comportement en continu, sans arret ni redemarrage.\n",
     "\n",
-    "Nous avons demontre, **avec du code execute** : CSharpRepl s'attache a un process .NET vivant, y evalue des expressions, lit son etat, **patche une methode a chaud** (`#replace`), l'**enveloppe** (`#wrap`) et **annule** (`#revert`) — l'application changeant de comportement en continu, sans arret ni redemarrage.\n",
+    "C'est la ligne « Introspection d'un process vivant » de la table de parite de l'Epic **#10473** : ce que `%autoreload` / `pdb` ne font pas cote Python, le REPL attache le fait nativement cote .NET — la verification et la modification se font **dans** le process, pas en post-processing, et peuvent etre **scriptees** (`--eval` / `--eval-file`), pas seulement tapees a la main.\n",
     "\n",
-    "C'est la ligne « Introspection d'un process vivant » de la table de parite de l'Epic **#10473** : ce que `%autoreload` / `pdb` ne font pas cote Python, le REPL attache le fait nativement cote .NET — la verification et la modification se font **dans** le process, pas en post-processing.\n",
-    "\n",
-    "*Rappel securite* : `csharprepl connect` equivaut a executer du code arbitraire dans le process cible, avec ses privileges. Outil de developpement et de diagnostic — jamais sur un process de production.\n"
+    "*Rappel securite* : `csharprepl connect` equivaut a executer du code arbitraire dans le process cible, avec ses privileges. Outil de developpement et de diagnostic — jamais sur un process de production."
    ]
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 19.290403,
+   "end_time": "2026-08-14T13:03:05.992621",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "CSharpRepl-Live-Patching.ipynb",
+   "output_path": "CSharpRepl-Live-Patching.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-14T13:02:46.702218",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #10894

## Livrable

Extension de `MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb` avec le **mode scripte (piped)** de CSharpRepl — axe 1 de #10897 (digestion Part 2) :

- **§6 « Le mode scripte (piped) : patcher sans interaction humaine »** : `connect <pid> --streamPipedInput` — un flux de commandes sur stdin (ici : `#replace` + evaluation dans le meme flux, le meme patch que la section 4 mais scripte), puis la primitive de lecture `--eval` (l'`--eval-file` est cite comme variante script-entier, verbatim Part 2).
- Helper `RunPiped`/`ReplPiped` ajoute au setup partage (variante de `Run` qui alimente stdin).
- `## 6. Arret propre` renumérote en `## 7` ; conclusion mise a jour (les deux faces : interactif + scripte) ; titre cellule 0 -> #10897.
- Exercices inchanges (3, repartis, jamais touches).

## Preuve d'execution (EXEC_PROVED — kernel .NET Interactive local, regle F)

Papermill end-to-end sur kernel `.net-csharp`, **20/20 cellules** :

```
var script = "#replace LiveOrderApp.OrderService.CalculatePrice with (int q, decimal u) => q * u * 0.85m\n" +
             "LiveOrderApp.OrderService.CalculatePrice(20, 5m)\n";
Console.WriteLine(ReplPiped($"connect {_pid} --streamPipedInput", script));
```

- output 6a : `patched static Decimal LiveOrderApp.OrderService.CalculatePrice(Int32 quantity, Decimal unitPrice)  <-  (int q, decimal u) => q * u * 0.85m  (patch #3)` puis `85.00`
- output 6b : log app vivante `price=25,50` (3 × 10 × 0,85) — le process patche change de comportement **sans aucune interaction humaine**
- output 6c : `--eval` one-shot -> `17.00` (10 × 2 × 0,85)

Un `#replace` pipe reel dans un `outputs` vaut la demonstration (acceptance du dispatch ai-01).

- C.1 : 0 erreur volontaire (grep `raise NotImplementedError|assert False|1/0` = 0)
- C.2 : toutes les cellules code commitees avec `execution_count: <int>` + outputs (post-re-exec)
- Aucune cellule `# Solution`/`# Exemple resolu` supprimee : 4 cellules ajoutees, 0 supprimees, 5 modifiees (titre, helper, renum §7 ×2, conclusion) — verifie cell-by-cell vs `origin/main`
- Probe banner `.NET` (probeAddresses) strippe (`strip_probe_banner.py --apply`, 9 lignes) ; paths papermill scrubbes par le pre-commit
- `validate_pr_notebooks.py` : 1/1 PASS
- H.3 pre-commit : PASS

## Diagnostic derive (C.4)

Cause : **extension du notebook + re-execution end-to-end** (a/b) — les PIDs, compteurs (`ComputeCount`) et numeros de patch (`#3` apres `#1`/`#2` revertes en 5d) sont **stochastiques par nature** (process vivant), pas des valeurs alignees a la main. Verdict : `CAUSE_INTRINSIC` — aucune valeur de perf/accuracy/coût impliquee, aucune regression d'environnement.

## SOTA (H)

Verdict `SOTA-OK` : le vrai outil (`csharprepl` 0.9.2, binaire resolu dans le store dotnet tools) est invoque en direct contre le process vivant (`connect` + `--streamPipedInput`) ; la sortie commitee EST sa vraie sortie.

See #10897 (axe 1/6 — l'issue n'est pas resolue entierement) · See #10473 (Epic).
