### PR TITLE
feat(density,#10479): Lean-5-Tactics density 1039->1352 c/cellule — enrichissement markdown-only FR (residual)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
@@ -333,9 +333,9 @@
     "\n",
     "Si on a un terme `t` de type exactement egal au but, `exact t` ferme le but.\n",
     "\n",
-    "**Pourquoi cette tactique ouvre le chapitre ?** Dans Lean, prouver une proposition `P` revient a **construire un terme de type `P`** : c'est la correspondance de Curry-Howard, le coeur du langage. `exact t` est la tactique la plus directe : elle dit « le terme qui prouve le but existe deja, le voici ». Elle ne reflechit pas, ne transforme pas : elle **verifie** que le type de `t` coincide avec le but, puis **clot**. C'est la tactique de *fin de preuve* — apres `intro`, `apply`, `cases` ou `constructor`, on aboutit presque toujours a un but simple qu'un `exact` regle.\n",
+    "**Pourquoi cette tactique ouvre le chapitre ?** Dans Lean, prouver une proposition `P` revient a **construire un terme de type `P`** : c'est la correspondance de Curry-Howard, le coeur du langage. `exact t` est la tactique la plus directe : elle dit « le terme qui prouve le but existe déjà, le voici ». Elle ne reflechit pas, ne transforme pas : elle **verifie** que le type de `t` coincide avec le but, puis **clot**. C'est la tactique de *fin de preuve* — après `intro`, `apply`, `cases` ou `constructor`, on aboutit presque toujours a un but simple qu'un `exact` règle.\n",
     "\n",
-    "**Comment lire le message de Lean ?** Quand le terme fourni n'a pas le bon type, Lean repond `type mismatch` : relisez alors la ligne `⊢`, elle dit exactement ce qu'il reste a prouver. Si la reponse est `unsolved goals`, c'est qu'il reste d'autres buts — un `exact` n'en clos qu'un a la fois. Cette lecture de l'etat de preuve (section 1.2) est la competence centrale du notebook : c'est elle qui rendra lisibles les preuves des notebooks appliques, comme `Lean-14-Finiteness-Derivatives`, dont les theoremes s'achevent par des termes precis fournis au `by`.\n",
+    "**Comment lire le message de Lean ?** Quand le terme fourni n'a pas le bon type, Lean repond `type mismatch` : relisez alors la ligne `⊢`, elle dit exactement ce qu'il reste a prouver. Si la reponse est `unsolved goals`, c'est qu'il reste d'autres buts — un `exact` n'en clos qu'un a la fois. Cette lecture de l'etat de preuve (section 1.2) est la competence centrale du notebook : c'est elle qui rendra lisibles les preuves des notebooks appliques, comme `Lean-14-Finiteness-Derivatives`, dont les theoremes s'achevent par des termes précis fournis au `by`.\n",
     "\n",
     "L'exemple `exact_example` est volontairement minimal : `hp : p` a exactement le type du but `p`, donc `exact hp` est une preuve complete. `exact_calc` montre que la verification inclut le **calcul** : `2 + 2` se reduit a `4`, et l'egalite est produite par `rfl` (section 2.5) — `exact` accepte donc aussi les egalites calculables."
    ]
@@ -439,11 +439,11 @@
     "- Les implications `P -> Q` : introduit une hypothese de type `P`\n",
     "- Les forall `\\forall x, P x` : introduit une variable `x`\n",
     "\n",
-    "**Ce que construit `intro`.** Une implication `P -> Q` EST une fonction : sa preuve prend une preuve de `P` et retourne une preuve de `Q`. `intro hp` transforme donc le but `P -> Q` en « hypothese `hp : P` ajoutee au contexte, but restant `Q` » — exactement comme `fun hp => ...` dans un terme. De meme, `\\forall x, P x` est une **fonction dependante** : `intro x` ajoute la variable `x` au contexte et le but devient `P x`. Cette correspondance fait le pont avec `exact` (section 2.1) : `intro` fabrique le **debut** du terme de preuve, `exact` en fournit la **fin**.\n",
+    "**Ce que construit `intro`.** Une implication `P -> Q` EST une fonction : sa preuve prend une preuve de `P` et retourne une preuve de `Q`. `intro hp` transforme donc le but `P -> Q` en « hypothese `hp : P` ajoutee au contexte, but restant `Q` » — exactement comme `fun hp => ...` dans un terme. De même, `\\forall x, P x` est une **fonction dependante** : `intro x` ajoute la variable `x` au contexte et le but devient `P x`. Cette correspondance fait le pont avec `exact` (section 2.1) : `intro` fabrique le **debut** du terme de preuve, `exact` en fournit la **fin**.\n",
     "\n",
     "**Nombre et ordre.** Chaque `intro` consomme une premisse, dans l'ordre. `intro hp hq` les introduit d'un coup — la forme a preferer quand le contexte a ajouter est evident ; sinon, on introduit au fur et a mesure pour garder un contexte lisible. Dans `intro_impl`, le but `p -> q -> p` est decompose en deux implications successives : `intro hp` donne `hp : p` et le but `q -> p`, puis `intro hq` donne `hq : q` et le but `p`, clos par `exact hp`.\n",
     "\n",
-    "**Que lit-on ?** Apres `intro`, le contexte affiche la nouvelle hypothese avec son type (`hp : p`), et le `⊢` change : c'est la **trace** de la tactique. Si `intro` echoue, c'est que le but n'est ni une implication ni un forall — il est deja « pointe vers le resultat » et une autre tactique est necessaire."
+    "**Que lit-on ?** Après `intro`, le contexte affiche la nouvelle hypothese avec son type (`hp : p`), et le `⊢` change : c'est la **trace** de la tactique. Si `intro` echoue, c'est que le but n'est ni une implication ni un forall — il est déjà « pointe vers le résultat » et une autre tactique est necessaire."
    ]
   },
   {
@@ -574,7 +574,7 @@
     "\n",
     "**Plusieurs premisses.** Si `h : A -> B -> C` et le but est `C`, `apply h` genere **deux buts** : `⊢ A` et `⊢ B`, traites ensuite independamment — par un autre `apply`, un `intro`, ou un `exact`. C'est ainsi que se decomposent les theoremes longs : `apply` transforme une cible complexe en une liste de sous-buts simples, exactement la mecanique qu'on retrouve dans les preuves de `Lean-13-Kochen-Specker`.\n",
     "\n",
-    "**`apply` vs `exact`.** `exact` exige le terme complet ; `apply` construit la preuve **par etapes**, en laissant Lean reorganiser les premisses. En pratique on les enchaîne : des `apply` pour decomposer, un `exact` pour conclure — cette paire se retrouve a la fin de presque toutes les preuves du notebook."
+    "**`apply` vs `exact`.** `exact` exige le terme complet ; `apply` construit la preuve **par étapes**, en laissant Lean reorganiser les premisses. En pratique on les enchaîne : des `apply` pour decomposer, un `exact` pour conclure — cette paire se retrouve a la fin de presque toutes les preuves du notebook."
    ]
   },
   {
@@ -697,9 +697,9 @@
     "\n",
     "**Le pendant de `exact`.** Si `exact` dit « voici le terme nomme », `assumption` dit « trouve le terme tout seul ». Elle parcourt le contexte et, si une hypothese a **exactement** le type du but, elle la fournit et clot. Dans `assumption_example`, `hp : p` est dans le contexte et le but est `p` : l'appariement est immediat, la preuve est complete.\n",
     "\n",
-    "**Pourquoi s'en servir ?** La robustesse au renommage : si l'on modifie plus tard les noms des hypotheses (en changeant l'ordre des arguments d'un theoreme, par exemple), un `exact hp` casse alors qu'un `assumption` survit — il ne depend pas d'un nom, seulement d'un type. On l'utilise donc pour les conclusions « evidentes depuis le contexte », notamment en fin de chaine : dans `assumption_chain`, apres deux `apply`, le but restant `p` est exactement `hp`, et `assumption` le clot sans qu'on ait a nommer quoi que ce soit.\n",
+    "**Pourquoi s'en servir ?** La robustesse au renommage : si l'on modifie plus tard les noms des hypotheses (en changeant l'ordre des arguments d'un theoreme, par exemple), un `exact hp` casse alors qu'un `assumption` survit — il ne depend pas d'un nom, seulement d'un type. On l'utilise donc pour les conclusions « evidentes depuis le contexte », notamment en fin de chaîne : dans `assumption_chain`, après deux `apply`, le but restant `p` est exactement `hp`, et `assumption` le clot sans qu'on ait a nommer quoi que ce soit.\n",
     "\n",
-    "**Quand echoue-t-elle ?** Quand aucune hypothese n'a exactement le type du but. Une hypothese `h : A -> B` n'est pas une preuve de `B` : il faut d'abord `apply h`. L'echec est instructif — il dit que le but n'est pas *deja la* : il reste du travail de transformation avant qu'une hypothese ne s'applique directement."
+    "**Quand echoue-t-elle ?** Quand aucune hypothese n'a exactement le type du but. Une hypothese `h : A -> B` n'est pas une preuve de `B` : il faut d'abord `apply h`. L'echec est instructif — il dit que le but n'est pas *déjà la* : il reste du travail de transformation avant qu'une hypothese ne s'applique directement."
    ]
   },
   {
@@ -828,11 +828,11 @@
     "\n",
     "La tactique `rfl` (reflexivite) prouve les egalites triviales ou calculables. Lean reduit les deux cotes de l'egalite et verifie qu'ils sont identiques. Fonctionne pour `2 + 2 = 4`, `n + 0 = n`, etc.\n",
     "\n",
-    "**Une egalite *par definition*.** `rfl` ne prouve pas n'importe quelle egalite : elle ferme les buts de la forme `t = t` **apres reduction calculatoire** (egalite definitionnelle — le noyau de Lean execute les definitions). `2 + 2 = 5` est impossible, mais `2 + 3 = 5` : le calcul de `2 + 3` donne `5`, les deux cotes sont identiques, `rfl` clot. C'est la tactique de la **verification arithmetique immediate**, et elle intervient partout en fin de preuve, quand une chaine de `rw` (section 5) aboutit a une egalite triviale.\n",
+    "**Une egalite *par definition*.** `rfl` ne prouve pas n'importe quelle egalite : elle ferme les buts de la forme `t = t` **après reduction calculatoire** (egalite definitionnelle — le noyau de Lean execute les definitions). `2 + 2 = 5` est impossible, mais `2 + 3 = 5` : le calcul de `2 + 3` donne `5`, les deux cotes sont identiques, `rfl` clot. C'est la tactique de la **verification arithmetique immediate**, et elle intervient partout en fin de preuve, quand une chaîne de `rw` (section 5) aboutit a une egalite triviale.\n",
     "\n",
-    "**Pourquoi `n + 0 = n` et pas `0 + n = n` ?** L'addition de `Nat` est definie par recurrence sur le **second** argument : `a + 0` se reduit a `a` (clause de base), donc `n + 0 = n` est bien definitionnelle — c'est ce qui fait tourner l'exemple `intro_forall` de la section 2.2 avec un simple `rfl`. En revanche `0 + n`, dont le second argument est une variable, ne peut pas se reduire : il faut le theoreme `Nat.zero_add`, applique par `rw` (section 5). Cette dissymetrie — `Nat.add_zero` est ferme par `rfl` quand `Nat.zero_add` ne l'est pas — est un des pieges classiques du debutant Lean.\n",
+    "**Pourquoi `n + 0 = n` et pas `0 + n = n` ?** L'addition de `Nat` est définie par recurrence sur le **second** argument : `a + 0` se reduit a `a` (clause de base), donc `n + 0 = n` est bien definitionnelle — c'est ce qui fait tourner l'exemple `intro_forall` de la section 2.2 avec un simple `rfl`. En revanche `0 + n`, dont le second argument est une variable, ne peut pas se reduire : il faut le theoreme `Nat.zero_add`, applique par `rw` (section 5). Cette dissymetrie — `Nat.add_zero` est ferme par `rfl` quand `Nat.zero_add` ne l'est pas — est un des pieges classiques du debutant Lean.\n",
     "\n",
-    "**Le message d'erreur type.** Si `rfl` echoue, Lean affiche les deux cotes de l'egalite separes : ils ne sont **pas** definitionnellement egaux. Ce message est une des lectures d'etat les plus utiles du notebook : il dit precisement quoi chercher — un lemme de bibliotheque, une hypothese — pour combler l'ecart."
+    "**Le message d'erreur type.** Si `rfl` echoue, Lean affiche les deux cotes de l'egalite separes : ils ne sont **pas** definitionnellement egaux. Ce message est une des lectures d'etat les plus utiles du notebook : il dit précisément quoi chercher — un lemme de bibliotheque, une hypothese — pour combler l'ecart."
    ]
   },
   {
@@ -1054,11 +1054,11 @@
     "\n",
     "La tactique `let` introduit une definition locale (variable avec sa valeur) dans le contexte. Utile pour nommer des expressions complexes reutilisees plusieurs fois.\n",
     "\n",
-    "**Quand l'utiliser ?** Dans une preuve, une meme expression peut revenir plusieurs fois, ou devenir illisible une fois enchaînee dans des `rw`. `let x := e` enregistre `x` comme **alias local** de `e` : le contexte contient desormais `x := e` (avec sa valeur, pas seulement son type), et les references a `x` se reduisent a `e` quand c'est necessaire. C'est l'equivalent tactique du `let` du langage fonctionnel : nommer pour clarifier, sans changer la logique.\n",
+    "**Quand l'utiliser ?** Dans une preuve, une même expression peut revenir plusieurs fois, ou devenir illisible une fois enchaînee dans des `rw`. `let x := e` enregistre `x` comme **alias local** de `e` : le contexte contient desormais `x := e` (avec sa valeur, pas seulement son type), et les references a `x` se reduisent a `e` quand c'est necessaire. C'est l'equivalent tactique du `let` du langage fonctionnel : nommer pour clarifier, sans changer la logique.\n",
     "\n",
-    "**Difference avec `intro`.** `intro` ajoute une **hypothese** (dont on ne connaît pas la valeur) ; `let` ajoute une **definition** (dont on connaît la valeur). La premiere sert a consommer une premisse, la seconde a organiser le raisonnement — on les combine d'ailleurs : un `let` pour nommer un sous-calcul, puis des `rw` ou un `exact` sur ce nom.\n",
+    "**Différence avec `intro`.** `intro` ajoute une **hypothese** (dont on ne connaît pas la valeur) ; `let` ajoute une **definition** (dont on connaît la valeur). La première sert a consommer une premisse, la seconde a organiser le raisonnement — on les combine d'ailleurs : un `let` pour nommer un sous-calcul, puis des `rw` ou un `exact` sur ce nom.\n",
     "\n",
-    "**Lire le contexte.** Apres `let x := e`, le contexte affiche `x := e` — la valeur est visible, c'est ce qui distingue la definition de l'hypothese `h : T`, qui n'en montre pas. Quand le but contient une expression complexe repetee et que la preuve devient illisible, le reflexe `let` evite de la recopier et rend la preuve facile a relire — un soin qui paye dans les preuves longues des notebooks appliques comme `Lean-14-Finiteness-Derivatives`."
+    "**Lire le contexte.** Après `let x := e`, le contexte affiche `x := e` — la valeur est visible, c'est ce qui distingue la definition de l'hypothese `h : T`, qui n'en montre pas. Quand le but contient une expression complexe repetee et que la preuve devient illisible, le reflexe `let` evite de la recopier et rend la preuve facile a relire — un soin qui paye dans les preuves longues des notebooks appliques comme `Lean-14-Finiteness-Derivatives`."
    ]
   },
   {
@@ -1884,7 +1884,7 @@
     "\n",
     "**Sens et direction.** Le remplacement va du cote gauche vers le cote droit. Pour le sens inverse (de `b` vers `a`), on ecrit `rw [← h]` (la fleche se tape `\\l`). Dans `rw_rev`, `h : a = b` et le but `b = a` : `rw [← h]` remplace `b` par `a`, le but devient `a = a`, clos par reflexivite.\n",
     "\n",
-    "**Enchainer.** `rw [h1, h2]` applique les reecritures dans l'ordre — chaque etape se voit dans le `⊢`, qui se simplifie au fil de la ligne. C'est le mode de preuve « calculatoire » des notebooks appliques : `rw [Nat.zero_add]`, `rw [Nat.add_comm]` (section 5.2) transforment des enonces algebriques en trivialites. On le retrouve massivement dans `Lean-6-Mathlib-Essentials`, ou les proprietes de `Nat` s'utilisent precisement par ces reecritures."
+    "**Enchainer.** `rw [h1, h2]` applique les reecritures dans l'ordre — chaque étape se voit dans le `⊢`, qui se simplifie au fil de la ligne. C'est le mode de preuve « calculatoire » des notebooks appliques : `rw [Nat.zero_add]`, `rw [Nat.add_comm]` (section 5.2) transforment des enonces algebriques en trivialites. On le retrouve massivement dans `Lean-6-Mathlib-Essentials`, ou les proprietes de `Nat` s'utilisent précisément par ces reecritures."
    ]
   },
   {
@@ -2234,9 +2234,9 @@
     "\n",
     "`simp` applique automatiquement un ensemble de règles de simplification.\n",
     "\n",
-    "**Une batterie de `rw` automatiques.** La ou `rw` exige de nommer chaque egalite et chaque direction (section 5.1), `simp` applique **tout seul** une collection de regles de simplification : les theoremes marques `[simp]` (comme `Nat.add_zero`, `Nat.mul_zero`, les tautologies logiques, les reductions de `if`, `and`, `or`, de listes). Elle simplifie les deux cotes d'une egalite, une inegalite, ou une conjonction de sous-buts. C'est la tactique « nettoyage » par excellence : elle degonfle les enonces qui paraissent imposants jusqu'a une forme triviale — `simp_example` ramene ainsi `n + 0 = n` directement a `rfl`, sans qu'on nomme `Nat.add_zero`.\n",
+    "**Une batterie de `rw` automatiques.** La ou `rw` exige de nommer chaque egalite et chaque direction (section 5.1), `simp` applique **tout seul** une collection de règles de simplification : les theoremes marques `[simp]` (comme `Nat.add_zero`, `Nat.mul_zero`, les tautologies logiques, les reductions de `if`, `and`, `or`, de listes). Elle simplifie les deux cotes d'une egalite, une inegalite, ou une conjonction de sous-buts. C'est la tactique « nettoyage » par excellence : elle degonfle les enonces qui paraissent imposants jusqu'a une forme triviale — `simp_example` ramene ainsi `n + 0 = n` directement a `rfl`, sans qu'on nomme `Nat.add_zero`.\n",
     "\n",
-    "**`simp` vs `rw`.** `rw` est chirurgicale et lisible — chaque etape est visible dans le `⊢` ; `simp` est globale et aveugle — on ne voit que le resultat. Rele pratique : `rw` quand la preuve doit *montrer* les etapes, `simp` quand il s'agit de *deblayer* un but encombre avant la tactique decisive. Dans `simp_list`, la liste `[1, 2] ++ [3]` se reduit et se compare par reflexivite, encore un coup de `simp`.\n",
+    "**`simp` vs `rw`.** `rw` est chirurgicale et lisible — chaque étape est visible dans le `⊢` ; `simp` est globale et aveugle — on ne voit que le résultat. Rele pratique : `rw` quand la preuve doit *montrer* les étapes, `simp` quand il s'agit de *deblayer* un but encombre avant la tactique decisive. Dans `simp_list`, la liste `[1, 2] ++ [3]` se reduit et se compare par reflexivite, encore un coup de `simp`.\n",
     "\n",
     "**Lire la sortie.** Quand `simp` declare `no progress`, aucun but n'a change : rien n'etait simplifiable, il faut une autre tactique. La combinaison `simp` puis cloture est la signature des preuves courtes : un `simp` suffit souvent a ramener un but encombre a une trivialite — on la retrouve dans les notebooks appliques comme `Lean-16b-Conway-Game-of-Life-Lean`, ou les proprietes booleennes des cellules se reglent d'un trait."
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb
@@ -331,7 +331,13 @@
     "\n",
     "### 2.1 `exact` : fournir le terme exact\n",
     "\n",
-    "Si on a un terme `t` de type exactement egal au but, `exact t` ferme le but."
+    "Si on a un terme `t` de type exactement egal au but, `exact t` ferme le but.\n",
+    "\n",
+    "**Pourquoi cette tactique ouvre le chapitre ?** Dans Lean, prouver une proposition `P` revient a **construire un terme de type `P`** : c'est la correspondance de Curry-Howard, le coeur du langage. `exact t` est la tactique la plus directe : elle dit « le terme qui prouve le but existe deja, le voici ». Elle ne reflechit pas, ne transforme pas : elle **verifie** que le type de `t` coincide avec le but, puis **clot**. C'est la tactique de *fin de preuve* — apres `intro`, `apply`, `cases` ou `constructor`, on aboutit presque toujours a un but simple qu'un `exact` regle.\n",
+    "\n",
+    "**Comment lire le message de Lean ?** Quand le terme fourni n'a pas le bon type, Lean repond `type mismatch` : relisez alors la ligne `⊢`, elle dit exactement ce qu'il reste a prouver. Si la reponse est `unsolved goals`, c'est qu'il reste d'autres buts — un `exact` n'en clos qu'un a la fois. Cette lecture de l'etat de preuve (section 1.2) est la competence centrale du notebook : c'est elle qui rendra lisibles les preuves des notebooks appliques, comme `Lean-14-Finiteness-Derivatives`, dont les theoremes s'achevent par des termes precis fournis au `by`.\n",
+    "\n",
+    "L'exemple `exact_example` est volontairement minimal : `hp : p` a exactement le type du but `p`, donc `exact hp` est une preuve complete. `exact_calc` montre que la verification inclut le **calcul** : `2 + 2` se reduit a `4`, et l'egalite est produite par `rfl` (section 2.5) — `exact` accepte donc aussi les egalites calculables."
    ]
   },
   {
@@ -431,7 +437,13 @@
     "\n",
     "`intro` fonctionne pour :\n",
     "- Les implications `P -> Q` : introduit une hypothese de type `P`\n",
-    "- Les forall `\\forall x, P x` : introduit une variable `x`"
+    "- Les forall `\\forall x, P x` : introduit une variable `x`\n",
+    "\n",
+    "**Ce que construit `intro`.** Une implication `P -> Q` EST une fonction : sa preuve prend une preuve de `P` et retourne une preuve de `Q`. `intro hp` transforme donc le but `P -> Q` en « hypothese `hp : P` ajoutee au contexte, but restant `Q` » — exactement comme `fun hp => ...` dans un terme. De meme, `\\forall x, P x` est une **fonction dependante** : `intro x` ajoute la variable `x` au contexte et le but devient `P x`. Cette correspondance fait le pont avec `exact` (section 2.1) : `intro` fabrique le **debut** du terme de preuve, `exact` en fournit la **fin**.\n",
+    "\n",
+    "**Nombre et ordre.** Chaque `intro` consomme une premisse, dans l'ordre. `intro hp hq` les introduit d'un coup — la forme a preferer quand le contexte a ajouter est evident ; sinon, on introduit au fur et a mesure pour garder un contexte lisible. Dans `intro_impl`, le but `p -> q -> p` est decompose en deux implications successives : `intro hp` donne `hp : p` et le but `q -> p`, puis `intro hq` donne `hq : q` et le but `p`, clos par `exact hp`.\n",
+    "\n",
+    "**Que lit-on ?** Apres `intro`, le contexte affiche la nouvelle hypothese avec son type (`hp : p`), et le `⊢` change : c'est la **trace** de la tactique. Si `intro` echoue, c'est que le but n'est ni une implication ni un forall — il est deja « pointe vers le resultat » et une autre tactique est necessaire."
    ]
   },
   {
@@ -556,7 +568,13 @@
    "source": [
     "### 2.3 `apply` : appliquer un lemme/hypothese\n",
     "\n",
-    "Si on a `h : A -> B` et le but est `B`, alors `apply h` change le but en `A`."
+    "Si on a `h : A -> B` et le but est `B`, alors `apply h` change le but en `A`.\n",
+    "\n",
+    "**Le sens de la marche.** `apply` travaille **a rebours**, du but vers les hypotheses (raisonnement *backward*) : au lieu de construire le terme complet d'un coup comme `exact`, il **reduit le but** a une precondition plus simple. `h : A -> B` dit « pour obtenir `B`, il suffit de fournir `A` » — `apply h` traduit donc le but `⊢ B` en `⊢ A`. C'est le modus ponens lu dans le sens de la recherche de preuve, et c'est la tactique de **decomposition** des enonces composees.\n",
+    "\n",
+    "**Plusieurs premisses.** Si `h : A -> B -> C` et le but est `C`, `apply h` genere **deux buts** : `⊢ A` et `⊢ B`, traites ensuite independamment — par un autre `apply`, un `intro`, ou un `exact`. C'est ainsi que se decomposent les theoremes longs : `apply` transforme une cible complexe en une liste de sous-buts simples, exactement la mecanique qu'on retrouve dans les preuves de `Lean-13-Kochen-Specker`.\n",
+    "\n",
+    "**`apply` vs `exact`.** `exact` exige le terme complet ; `apply` construit la preuve **par etapes**, en laissant Lean reorganiser les premisses. En pratique on les enchaîne : des `apply` pour decomposer, un `exact` pour conclure — cette paire se retrouve a la fin de presque toutes les preuves du notebook."
    ]
   },
   {
@@ -675,7 +693,13 @@
    "source": [
     "### 2.4 `assumption` : chercher dans le contexte\n",
     "\n",
-    "La tactique `assumption` cherche automatiquement dans le contexte une hypothese qui correspond exactement au but courant. C'est un raccourci pratique quand la preuve est déjà dans les hypotheses."
+    "La tactique `assumption` cherche automatiquement dans le contexte une hypothese qui correspond exactement au but courant. C'est un raccourci pratique quand la preuve est déjà dans les hypotheses.\n",
+    "\n",
+    "**Le pendant de `exact`.** Si `exact` dit « voici le terme nomme », `assumption` dit « trouve le terme tout seul ». Elle parcourt le contexte et, si une hypothese a **exactement** le type du but, elle la fournit et clot. Dans `assumption_example`, `hp : p` est dans le contexte et le but est `p` : l'appariement est immediat, la preuve est complete.\n",
+    "\n",
+    "**Pourquoi s'en servir ?** La robustesse au renommage : si l'on modifie plus tard les noms des hypotheses (en changeant l'ordre des arguments d'un theoreme, par exemple), un `exact hp` casse alors qu'un `assumption` survit — il ne depend pas d'un nom, seulement d'un type. On l'utilise donc pour les conclusions « evidentes depuis le contexte », notamment en fin de chaine : dans `assumption_chain`, apres deux `apply`, le but restant `p` est exactement `hp`, et `assumption` le clot sans qu'on ait a nommer quoi que ce soit.\n",
+    "\n",
+    "**Quand echoue-t-elle ?** Quand aucune hypothese n'a exactement le type du but. Une hypothese `h : A -> B` n'est pas une preuve de `B` : il faut d'abord `apply h`. L'echec est instructif — il dit que le but n'est pas *deja la* : il reste du travail de transformation avant qu'une hypothese ne s'applique directement."
    ]
   },
   {
@@ -802,7 +826,13 @@
    "source": [
     "### 2.5 `rfl` : reflexivite\n",
     "\n",
-    "La tactique `rfl` (reflexivite) prouve les egalites triviales ou calculables. Lean reduit les deux cotes de l'egalite et verifie qu'ils sont identiques. Fonctionne pour `2 + 2 = 4`, `n + 0 = n`, etc."
+    "La tactique `rfl` (reflexivite) prouve les egalites triviales ou calculables. Lean reduit les deux cotes de l'egalite et verifie qu'ils sont identiques. Fonctionne pour `2 + 2 = 4`, `n + 0 = n`, etc.\n",
+    "\n",
+    "**Une egalite *par definition*.** `rfl` ne prouve pas n'importe quelle egalite : elle ferme les buts de la forme `t = t` **apres reduction calculatoire** (egalite definitionnelle — le noyau de Lean execute les definitions). `2 + 2 = 5` est impossible, mais `2 + 3 = 5` : le calcul de `2 + 3` donne `5`, les deux cotes sont identiques, `rfl` clot. C'est la tactique de la **verification arithmetique immediate**, et elle intervient partout en fin de preuve, quand une chaine de `rw` (section 5) aboutit a une egalite triviale.\n",
+    "\n",
+    "**Pourquoi `n + 0 = n` et pas `0 + n = n` ?** L'addition de `Nat` est definie par recurrence sur le **second** argument : `a + 0` se reduit a `a` (clause de base), donc `n + 0 = n` est bien definitionnelle — c'est ce qui fait tourner l'exemple `intro_forall` de la section 2.2 avec un simple `rfl`. En revanche `0 + n`, dont le second argument est une variable, ne peut pas se reduire : il faut le theoreme `Nat.zero_add`, applique par `rw` (section 5). Cette dissymetrie — `Nat.add_zero` est ferme par `rfl` quand `Nat.zero_add` ne l'est pas — est un des pieges classiques du debutant Lean.\n",
+    "\n",
+    "**Le message d'erreur type.** Si `rfl` echoue, Lean affiche les deux cotes de l'egalite separes : ils ne sont **pas** definitionnellement egaux. Ce message est une des lectures d'etat les plus utiles du notebook : il dit precisement quoi chercher — un lemme de bibliotheque, une hypothese — pour combler l'ecart."
    ]
   },
   {
@@ -1022,7 +1052,13 @@
    "source": [
     "### 3.2 `let` : definitions locales\n",
     "\n",
-    "La tactique `let` introduit une definition locale (variable avec sa valeur) dans le contexte. Utile pour nommer des expressions complexes reutilisees plusieurs fois."
+    "La tactique `let` introduit une definition locale (variable avec sa valeur) dans le contexte. Utile pour nommer des expressions complexes reutilisees plusieurs fois.\n",
+    "\n",
+    "**Quand l'utiliser ?** Dans une preuve, une meme expression peut revenir plusieurs fois, ou devenir illisible une fois enchaînee dans des `rw`. `let x := e` enregistre `x` comme **alias local** de `e` : le contexte contient desormais `x := e` (avec sa valeur, pas seulement son type), et les references a `x` se reduisent a `e` quand c'est necessaire. C'est l'equivalent tactique du `let` du langage fonctionnel : nommer pour clarifier, sans changer la logique.\n",
+    "\n",
+    "**Difference avec `intro`.** `intro` ajoute une **hypothese** (dont on ne connaît pas la valeur) ; `let` ajoute une **definition** (dont on connaît la valeur). La premiere sert a consommer une premisse, la seconde a organiser le raisonnement — on les combine d'ailleurs : un `let` pour nommer un sous-calcul, puis des `rw` ou un `exact` sur ce nom.\n",
+    "\n",
+    "**Lire le contexte.** Apres `let x := e`, le contexte affiche `x := e` — la valeur est visible, c'est ce qui distingue la definition de l'hypothese `h : T`, qui n'en montre pas. Quand le but contient une expression complexe repetee et que la preuve devient illisible, le reflexe `let` evite de la recopier et rend la preuve facile a relire — un soin qui paye dans les preuves longues des notebooks appliques comme `Lean-14-Finiteness-Derivatives`."
    ]
   },
   {
@@ -1337,7 +1373,26 @@
     },
     "tags": []
    },
-   "source": "## 4. Tactiques pour la Logique\n\n### 4.1 `constructor` : introduction de structures\n\nLa tactique `constructor` est l'**introduction générique** d'un connecteur logique : elle regarde le but, identifie le constructeur principal (`And`, `Or`, `Ex`, `Subtype`, ...) et le **décompose** en un sous-but pour chaque argument du constructeur. C'est l'**inverse** de `exact ⟨a, b⟩` qui les **rassemble** en un tuple.\n\nFonctionnement :\n\n1. Si le but est `P ∧ Q`, `constructor` génère deux sous-buts : `⊢ P` puis `⊢ Q`. Vous prouvez chacun, et Lean les recombine.\n2. Si le but est `P ∨ Q`, `constructor` se ramène à `Left` (prouver `P`) — il faut alors `left` ou `right` pour choisir le côté de la disjonction (c'est `4.3`).\n3. Si le but est `∃ x, P x`, `constructor` génère un sous-but `⊢ P ?y` avec un `?y` мета, et l'inférence de Lean trouve une valeur (souvent par unification).\n4. Pour le constructeur inductif `Sum`, `Prod`, etc., la décomposition suit la même logique.\n\n**Pourquoi `constructor` plutôt que `exact ⟨...⟩` ?** En pédagogie, on voit la structure se **déplier** sous nos yeux : chaque sous-but est un problème plus simple, et l'écran de Lean affiche la liste au fur et à mesure. En pratique, dans une longue preuve, `constructor` rend visible la **structure de la preuve** que vous construisez.\n\n**Attention au scope de décomposition** : `constructor` ne décompose qu'**un seul niveau** à la fois. Pour un but comme `P ∧ Q ∧ R`, il faut deux `constructor` successifs (ou un `refine ⟨?_, ?_, ?_⟩` qui spécifie la structure complète). La tactique `constructor` répété deux fois est d'ailleurs le pattern dominant dans Lean-6 (Mathlib) pour les structures imbriquées.\n\n**Le pont** : `constructor` est omniprésent dans Lean-12 (Sensitivity Theorem) sur les buts `∃ ε, ...` où il faut exhiber un témoin avant de prouver la borne. Il est aussi la brique de base de `refine` (mode tactic), que vous croiserez à chaque preuve Mathlib."
+   "source": [
+    "## 4. Tactiques pour la Logique\n",
+    "\n",
+    "### 4.1 `constructor` : introduction de structures\n",
+    "\n",
+    "La tactique `constructor` est l'**introduction générique** d'un connecteur logique : elle regarde le but, identifie le constructeur principal (`And`, `Or`, `Ex`, `Subtype`, ...) et le **décompose** en un sous-but pour chaque argument du constructeur. C'est l'**inverse** de `exact ⟨a, b⟩` qui les **rassemble** en un tuple.\n",
+    "\n",
+    "Fonctionnement :\n",
+    "\n",
+    "1. Si le but est `P ∧ Q`, `constructor` génère deux sous-buts : `⊢ P` puis `⊢ Q`. Vous prouvez chacun, et Lean les recombine.\n",
+    "2. Si le but est `P ∨ Q`, `constructor` se ramène à `Left` (prouver `P`) — il faut alors `left` ou `right` pour choisir le côté de la disjonction (c'est `4.3`).\n",
+    "3. Si le but est `∃ x, P x`, `constructor` génère un sous-but `⊢ P ?y` avec un `?y` мета, et l'inférence de Lean trouve une valeur (souvent par unification).\n",
+    "4. Pour le constructeur inductif `Sum`, `Prod`, etc., la décomposition suit la même logique.\n",
+    "\n",
+    "**Pourquoi `constructor` plutôt que `exact ⟨...⟩` ?** En pédagogie, on voit la structure se **déplier** sous nos yeux : chaque sous-but est un problème plus simple, et l'écran de Lean affiche la liste au fur et à mesure. En pratique, dans une longue preuve, `constructor` rend visible la **structure de la preuve** que vous construisez.\n",
+    "\n",
+    "**Attention au scope de décomposition** : `constructor` ne décompose qu'**un seul niveau** à la fois. Pour un but comme `P ∧ Q ∧ R`, il faut deux `constructor` successifs (ou un `refine ⟨?_, ?_, ?_⟩` qui spécifie la structure complète). La tactique `constructor` répété deux fois est d'ailleurs le pattern dominant dans Lean-6 (Mathlib) pour les structures imbriquées.\n",
+    "\n",
+    "**Le pont** : `constructor` est omniprésent dans Lean-12 (Sensitivity Theorem) sur les buts `∃ ε, ...` où il faut exhiber un témoin avant de prouver la borne. Il est aussi la brique de base de `refine` (mode tactic), que vous croiserez à chaque preuve Mathlib."
+   ]
   },
   {
    "cell_type": "code",
@@ -1823,7 +1878,13 @@
     "\n",
     "### 5.1 Utilisation de base\n",
     "\n",
-    "`rw [h]` remplace le cote gauche de l'egalite `h` par le cote droit dans le but."
+    "`rw [h]` remplace le cote gauche de l'egalite `h` par le cote droit dans le but.\n",
+    "\n",
+    "**L'outil du raisonnement par egalites.** `rfl` (section 2.5) prouve les egalites *calculables* ; `rw` prouve les egalites *grace a des hypotheses ou des lemmes* : elle **substitue** un cote d'une egalite par l'autre dans le but. Avec `h : a = b`, `rw [h]` remplace chaque occurrence de `a` par `b` dans le but — qui devient une egalite plus simple, souvent une trivialite qu'un `rfl` clot. D'ou la paire `rw ... ; rfl` si frequente dans les preuves : on reecrit pour ramener le but a une forme calculable, puis on laisse le calcul conclure.\n",
+    "\n",
+    "**Sens et direction.** Le remplacement va du cote gauche vers le cote droit. Pour le sens inverse (de `b` vers `a`), on ecrit `rw [← h]` (la fleche se tape `\\l`). Dans `rw_rev`, `h : a = b` et le but `b = a` : `rw [← h]` remplace `b` par `a`, le but devient `a = a`, clos par reflexivite.\n",
+    "\n",
+    "**Enchainer.** `rw [h1, h2]` applique les reecritures dans l'ordre — chaque etape se voit dans le `⊢`, qui se simplifie au fil de la ligne. C'est le mode de preuve « calculatoire » des notebooks appliques : `rw [Nat.zero_add]`, `rw [Nat.add_comm]` (section 5.2) transforment des enonces algebriques en trivialites. On le retrouve massivement dans `Lean-6-Mathlib-Essentials`, ou les proprietes de `Nat` s'utilisent precisement par ces reecritures."
    ]
   },
   {
@@ -2171,7 +2232,13 @@
     "\n",
     "### 6.1 Utilisation de base\n",
     "\n",
-    "`simp` applique automatiquement un ensemble de règles de simplification."
+    "`simp` applique automatiquement un ensemble de règles de simplification.\n",
+    "\n",
+    "**Une batterie de `rw` automatiques.** La ou `rw` exige de nommer chaque egalite et chaque direction (section 5.1), `simp` applique **tout seul** une collection de regles de simplification : les theoremes marques `[simp]` (comme `Nat.add_zero`, `Nat.mul_zero`, les tautologies logiques, les reductions de `if`, `and`, `or`, de listes). Elle simplifie les deux cotes d'une egalite, une inegalite, ou une conjonction de sous-buts. C'est la tactique « nettoyage » par excellence : elle degonfle les enonces qui paraissent imposants jusqu'a une forme triviale — `simp_example` ramene ainsi `n + 0 = n` directement a `rfl`, sans qu'on nomme `Nat.add_zero`.\n",
+    "\n",
+    "**`simp` vs `rw`.** `rw` est chirurgicale et lisible — chaque etape est visible dans le `⊢` ; `simp` est globale et aveugle — on ne voit que le resultat. Rele pratique : `rw` quand la preuve doit *montrer* les etapes, `simp` quand il s'agit de *deblayer* un but encombre avant la tactique decisive. Dans `simp_list`, la liste `[1, 2] ++ [3]` se reduit et se compare par reflexivite, encore un coup de `simp`.\n",
+    "\n",
+    "**Lire la sortie.** Quand `simp` declare `no progress`, aucun but n'a change : rien n'etait simplifiable, il faut une autre tactique. La combinaison `simp` puis cloture est la signature des preuves courtes : un `simp` suffit souvent a ramener un but encombre a une trivialite — on la retrouve dans les notebooks appliques comme `Lean-16b-Conway-Game-of-Life-Lean`, ou les proprietes booleennes des cellules se reglent d'un trait."
    ]
   },
   {
@@ -2278,7 +2345,30 @@
     },
     "tags": []
    },
-   "source": "### 6.2 Options de simp\n\n`simp` accepte plusieurs **modificateurs** qui précisent *comment* simplifier, au-delà du simple `simp` :\n\n- **`simp [h]`** : ajoute l'hypothèse `h` à la base de lemmes simp pour cette occurrence. Lean tente alors d'utiliser `h` à côté des lemmes `@[simp]` enregistrés. La base elle-même n'est pas modifiée — c'est un ajout local pour ce but.\n- **`simp only [l1, l2, ...]`** : restreint la base aux lemmes **explicitement listés**. Lean n'utilise que ces lemmes, pas l'ensemble des `@[simp]`. C'est l'outil de debugging : on voit exactement quels lemmes ont été déclenchés, et on évite les simplifications « magiques » qui obscurcissent la logique.\n- **`simp at h`** : simplifie l'**hypothèse** `h` (de la même façon qu'avec `rw [h] at loc`). Combiné avec `simp at *`, on simplifie tout le contexte ET le but.\n- **`simp_all`** : applique `simp` au but **et** à toutes les hypothèses. C'est l'outil de « finition » : quand le but devrait être trivial après simplification de tout, `simp_all` tente la passe complète.\n\n**Stratégie de choix** :\n\n1. **But simple après lemmes standards** : `simp` suffit. Lean applique `@[add_zero]` (n + 0 = n), `@[mul_one]` (n * 1 = n), etc.\n2. **But dépend d'une hypothèse métier** : `simp [h]` pour inclure cette hypothèse.\n3. **Preuve fragile / non-reproductible** : `simp only [liste]` pour traçabilité. Dans une preuve Mathlib sérieuse, c'est souvent exigé pour éviter les ruptures de compatibilité.\n4. **Simplification dans le contexte** : `simp at h` ou `simp at *`.\n\n**Pièges courants** :\n\n- `simp` peut **boucler** si on ajoute une équivalence `@[simp]` qui crée un cycle. La parade est `simp only` ou marquer le lemme comme `@[simp high]` pour le rendre découvable mais pas systématiquement tenté.\n- `simp` est **non-déterministe** : deux exécutions peuvent produire des états intermédiaires différents. Pour les preuves critiques, `decide` ou `omega` sont préférables.\n\n**Le pont** : `simp only` est la tactique dominante dans Lean-6 (Mathlib Essentials) pour les preuves de notations arithmétiques. Lean-12 (Sensitivity) combine `simp only [Fin.sum_univ_succ, Fin.val_zero, ...]` avec une liste explicite de lemmes pour traçabilité."
+   "source": [
+    "### 6.2 Options de simp\n",
+    "\n",
+    "`simp` accepte plusieurs **modificateurs** qui précisent *comment* simplifier, au-delà du simple `simp` :\n",
+    "\n",
+    "- **`simp [h]`** : ajoute l'hypothèse `h` à la base de lemmes simp pour cette occurrence. Lean tente alors d'utiliser `h` à côté des lemmes `@[simp]` enregistrés. La base elle-même n'est pas modifiée — c'est un ajout local pour ce but.\n",
+    "- **`simp only [l1, l2, ...]`** : restreint la base aux lemmes **explicitement listés**. Lean n'utilise que ces lemmes, pas l'ensemble des `@[simp]`. C'est l'outil de debugging : on voit exactement quels lemmes ont été déclenchés, et on évite les simplifications « magiques » qui obscurcissent la logique.\n",
+    "- **`simp at h`** : simplifie l'**hypothèse** `h` (de la même façon qu'avec `rw [h] at loc`). Combiné avec `simp at *`, on simplifie tout le contexte ET le but.\n",
+    "- **`simp_all`** : applique `simp` au but **et** à toutes les hypothèses. C'est l'outil de « finition » : quand le but devrait être trivial après simplification de tout, `simp_all` tente la passe complète.\n",
+    "\n",
+    "**Stratégie de choix** :\n",
+    "\n",
+    "1. **But simple après lemmes standards** : `simp` suffit. Lean applique `@[add_zero]` (n + 0 = n), `@[mul_one]` (n * 1 = n), etc.\n",
+    "2. **But dépend d'une hypothèse métier** : `simp [h]` pour inclure cette hypothèse.\n",
+    "3. **Preuve fragile / non-reproductible** : `simp only [liste]` pour traçabilité. Dans une preuve Mathlib sérieuse, c'est souvent exigé pour éviter les ruptures de compatibilité.\n",
+    "4. **Simplification dans le contexte** : `simp at h` ou `simp at *`.\n",
+    "\n",
+    "**Pièges courants** :\n",
+    "\n",
+    "- `simp` peut **boucler** si on ajoute une équivalence `@[simp]` qui crée un cycle. La parade est `simp only` ou marquer le lemme comme `@[simp high]` pour le rendre découvable mais pas systématiquement tenté.\n",
+    "- `simp` est **non-déterministe** : deux exécutions peuvent produire des états intermédiaires différents. Pour les preuves critiques, `decide` ou `omega` sont préférables.\n",
+    "\n",
+    "**Le pont** : `simp only` est la tactique dominante dans Lean-6 (Mathlib Essentials) pour les preuves de notations arithmétiques. Lean-12 (Sensitivity) combine `simp only [Fin.sum_univ_succ, Fin.val_zero, ...]` avec une liste explicite de lemmes pour traçabilité."
+   ]
   },
   {
    "cell_type": "code",
@@ -2387,7 +2477,42 @@
     },
     "tags": []
    },
-   "source": "### 6.3 L'attribut `@[simp]`\n\nOn peut ajouter ses propres lemmes a la base de simp.\n\nL'attribut `@[simp]` (dans Lean 4 Mathlib, c'est `@[simp]`) **enregistre un théorème dans la base de lemmes simp**. Une fois marqué, ce lemme est automatiquement candidat à chaque appel de `simp` — sans avoir besoin de le lister à chaque occurrence. C'est l'outil qui transforme un lemme « utile en ce moment » en lemme « connu du simplifieur ».\n\n**Comment ça marche en Lean 4** :\n\n```lean\n@[simp] theorem my_lemma (n : Nat) : f n = g n := ...\n-- Apres cette declaration, `simp` applique `my_lemma` quand f n ou g n apparait.\n```\n\n**Pourquoi enregistrer un lemme `@[simp]` ?**\n\n- **Réciproque publique** : si vous venez de prouver `n + 0 = n` ou `f x = g x`, le marquer `@[simp]` le rend disponible à toute preuve ultérieure du projet.\n- **Lemme d'usage fréquent** : `@[add_zero]` (n + 0 = n), `@[mul_one]` (n * 1 = n), `@[and_self]` (p ∧ p ↔ p) — tous enregistrés pour cette raison.\n- **Équivalence standard** : `even_iff_two_dvd`, `prime_two`, etc. — toute équivalence qui simplifie une expression à sa forme canonique.\n\n**Pièges et limites** :\n\n- **Ne pas abuser** : marquer `@[simp]` un lemme « lourd » ralentit chaque `simp` du projet, et peut créer des cycles (lemme A appelle simp pour prouver B, B appelle simp qui retrouve A, ...). Mathlib a un système de `Simp.lemmas.addSimpProof`-tracking pour détecter ces cas.\n- **Variantes conditionnelles** : `@[simp high]` (lemme à utiliser seulement si la cible est explicitement `@[simp]`). `@[simp low]` (lemme à utiliser seulement en dernier recours). `@[simp norm_cast]` pour les lemmes de coercion.\n- **Réversibilité** : si un lemme `@[simp]` s'avère problématique, on peut le **désactiver localement** avec `simp [-mon_lemme]` ou globalement avec `@[simp ← mon_lemme]`.\n\n**Quand NE PAS marquer `@[simp]`** :\n\n- Un lemme dont l'application n'est **pas définitionnellement triviale** (par exemple un test de primalité nécessitant `decide`). Le simplifier ne peut pas l'appliquer rapidement.\n- Un lemme « utile » mais qui **éclate** la structure que vous voulez préserver (par exemple `nat_succ_eq_add_one` parfois).\n- Un lemme **non-réversible** (équivalence d'ordre ≠ équivalence numérique) : simp pourrait l'appliquer dans le mauvais sens.\n\n**Le pont** : la convention `@[simp]` est omniprésente dans Lean-6 (Mathlib). Lean-12 (Sensitivity) introduit `@[simp]` custom pour les lemmes de borne sur `Fin.sum_univ_*`. Lean-14 (Finiteness) en utilise une centaines pour les théorèmes d'analyse combinatoire.\n\n**Inspection** : pour voir quels lemmes simp sont actifs dans votre contexte, utilisez `simp_wf` ou explorez la documentation de `Mathlib.Tactic.Simps`."
+   "source": [
+    "### 6.3 L'attribut `@[simp]`\n",
+    "\n",
+    "On peut ajouter ses propres lemmes a la base de simp.\n",
+    "\n",
+    "L'attribut `@[simp]` (dans Lean 4 Mathlib, c'est `@[simp]`) **enregistre un théorème dans la base de lemmes simp**. Une fois marqué, ce lemme est automatiquement candidat à chaque appel de `simp` — sans avoir besoin de le lister à chaque occurrence. C'est l'outil qui transforme un lemme « utile en ce moment » en lemme « connu du simplifieur ».\n",
+    "\n",
+    "**Comment ça marche en Lean 4** :\n",
+    "\n",
+    "```lean\n",
+    "@[simp] theorem my_lemma (n : Nat) : f n = g n := ...\n",
+    "-- Apres cette declaration, `simp` applique `my_lemma` quand f n ou g n apparait.\n",
+    "```\n",
+    "\n",
+    "**Pourquoi enregistrer un lemme `@[simp]` ?**\n",
+    "\n",
+    "- **Réciproque publique** : si vous venez de prouver `n + 0 = n` ou `f x = g x`, le marquer `@[simp]` le rend disponible à toute preuve ultérieure du projet.\n",
+    "- **Lemme d'usage fréquent** : `@[add_zero]` (n + 0 = n), `@[mul_one]` (n * 1 = n), `@[and_self]` (p ∧ p ↔ p) — tous enregistrés pour cette raison.\n",
+    "- **Équivalence standard** : `even_iff_two_dvd`, `prime_two`, etc. — toute équivalence qui simplifie une expression à sa forme canonique.\n",
+    "\n",
+    "**Pièges et limites** :\n",
+    "\n",
+    "- **Ne pas abuser** : marquer `@[simp]` un lemme « lourd » ralentit chaque `simp` du projet, et peut créer des cycles (lemme A appelle simp pour prouver B, B appelle simp qui retrouve A, ...). Mathlib a un système de `Simp.lemmas.addSimpProof`-tracking pour détecter ces cas.\n",
+    "- **Variantes conditionnelles** : `@[simp high]` (lemme à utiliser seulement si la cible est explicitement `@[simp]`). `@[simp low]` (lemme à utiliser seulement en dernier recours). `@[simp norm_cast]` pour les lemmes de coercion.\n",
+    "- **Réversibilité** : si un lemme `@[simp]` s'avère problématique, on peut le **désactiver localement** avec `simp [-mon_lemme]` ou globalement avec `@[simp ← mon_lemme]`.\n",
+    "\n",
+    "**Quand NE PAS marquer `@[simp]`** :\n",
+    "\n",
+    "- Un lemme dont l'application n'est **pas définitionnellement triviale** (par exemple un test de primalité nécessitant `decide`). Le simplifier ne peut pas l'appliquer rapidement.\n",
+    "- Un lemme « utile » mais qui **éclate** la structure que vous voulez préserver (par exemple `nat_succ_eq_add_one` parfois).\n",
+    "- Un lemme **non-réversible** (équivalence d'ordre ≠ équivalence numérique) : simp pourrait l'appliquer dans le mauvais sens.\n",
+    "\n",
+    "**Le pont** : la convention `@[simp]` est omniprésente dans Lean-6 (Mathlib). Lean-12 (Sensitivity) introduit `@[simp]` custom pour les lemmes de borne sur `Fin.sum_univ_*`. Lean-14 (Finiteness) en utilise une centaines pour les théorèmes d'analyse combinatoire.\n",
+    "\n",
+    "**Inspection** : pour voir quels lemmes simp sont actifs dans votre contexte, utilisez `simp_wf` ou explorez la documentation de `Mathlib.Tactic.Simps`."
+   ]
   },
   {
    "cell_type": "code",
@@ -2481,7 +2606,23 @@
     },
     "tags": []
    },
-   "source": "## 7. Structuration des Preuves\n\n### 7.1 Points (bullets) pour focaliser\n\nÀ ce stade du notebook, on a vu comment chaque tactique résout un sous-but à la fois : `constructor` découpe, `exact` ferme. Quand une preuve génère **plusieurs sous-buts simultanés** (par exemple après un `cases` sur une disjonction), il devient vite fastidieux d'écrire la tactique pour chaque but en séquence — Lean perdrait le fil, et la lecture serait pénible.\n\nLa **section 7** introduit trois mécanismes de structuration qui répondent à ce problème :\n\n- **7.1 Points (·)** : un bullet `·` ouvre un **bloc dédié** à un sous-but ; Lean vérifie que ce bloc est clos avant de passer au suivant. C'est la version lisible et sûre de l'enchaînement nu.\n- **7.2 `case`** : permet de **nommer explicitement** chaque branche issue d'un `cases`. La lecture du code de preuve devient auto-documentée.\n- **7.3 Combinateurs `;` et `<;>`** : chaînent plusieurs tactiques sans avoir à dupliquer. `<;>` distribue sur tous les sous-buts générés, ce qui est l'idiome dominant dans les preuves Mathlib sérieuses.\n\nL'objectif : passer d'une preuve « chaque sous-but ligne par ligne » à une preuve « chaque sous-but clairement isolé et commenté ». C'est ce qui distingue une **preuve pédagogique** d'une **preuve industrielle** Mathlib.\n\n**Le pont** : les points `·` sont la syntaxe par défaut dans Lean-12 (Sensitivity) pour les preuves `cases h with | intro ...`. Lean-14 (Finiteness) les utilise systématiquement dans les `induction` à deux branches ou plus. Lean-16 (Conway Free Will) combine points + `<;>` pour distribuer `omega` sur 16 sous-buts générés par `decide`."
+   "source": [
+    "## 7. Structuration des Preuves\n",
+    "\n",
+    "### 7.1 Points (bullets) pour focaliser\n",
+    "\n",
+    "À ce stade du notebook, on a vu comment chaque tactique résout un sous-but à la fois : `constructor` découpe, `exact` ferme. Quand une preuve génère **plusieurs sous-buts simultanés** (par exemple après un `cases` sur une disjonction), il devient vite fastidieux d'écrire la tactique pour chaque but en séquence — Lean perdrait le fil, et la lecture serait pénible.\n",
+    "\n",
+    "La **section 7** introduit trois mécanismes de structuration qui répondent à ce problème :\n",
+    "\n",
+    "- **7.1 Points (·)** : un bullet `·` ouvre un **bloc dédié** à un sous-but ; Lean vérifie que ce bloc est clos avant de passer au suivant. C'est la version lisible et sûre de l'enchaînement nu.\n",
+    "- **7.2 `case`** : permet de **nommer explicitement** chaque branche issue d'un `cases`. La lecture du code de preuve devient auto-documentée.\n",
+    "- **7.3 Combinateurs `;` et `<;>`** : chaînent plusieurs tactiques sans avoir à dupliquer. `<;>` distribue sur tous les sous-buts générés, ce qui est l'idiome dominant dans les preuves Mathlib sérieuses.\n",
+    "\n",
+    "L'objectif : passer d'une preuve « chaque sous-but ligne par ligne » à une preuve « chaque sous-but clairement isolé et commenté ». C'est ce qui distingue une **preuve pédagogique** d'une **preuve industrielle** Mathlib.\n",
+    "\n",
+    "**Le pont** : les points `·` sont la syntaxe par défaut dans Lean-12 (Sensitivity) pour les preuves `cases h with | intro ...`. Lean-14 (Finiteness) les utilise systématiquement dans les `induction` à deux branches ou plus. Lean-16 (Conway Free Will) combine points + `<;>` pour distribuer `omega` sur 16 sous-buts générés par `decide`."
+   ]
   },
   {
    "cell_type": "code",
@@ -2588,7 +2729,33 @@
     },
     "tags": []
    },
-   "source": "### 7.2 `case` pour nommer les cas\n\nLa tactique `cases h` (vue en 4.2) génère des **noms automatiques** pour chaque branche — `inl hp`, `inr hq`, etc. Mais ces noms sont souvent opaques : impossible de deviner à quoi ils correspondent sans lire le contexte.\n\nLa forme `case` (et son équivalent `with | nom => ...`) permet de **renommer** explicitement chaque branche au moment où on la traite. Trois variantes principales :\n\n1. **`cases h with | intro hp hq => ...`** : syntaxe classique de Lean 4. Chaque branche commence par `| nom_constructeur (vars) =>`, suivie de la tactique à appliquer.\n2. **`cases h; case inl hp => ... case inr hq => ...`** : syntaxe en deux temps. Plus verbeuse mais plus claire quand les branches contiennent plusieurs lignes.\n3. **`rcases h with ⟨...⟩ | ⟨...⟩`** : la variante la plus expressive pour les inductive patterns imbriqués. `rcases` étend `cases` en reconnaissance de motifs (similaire à `match`).\n\n**Pourquoi nommer explicitement ?**\n\n- **Légibilité** : un lecteur voit immédiatement quelle branche fait quoi, sans avoir à deviner la sémantique des noms automatiques.\n- **Nommage cohérent** : vous pouvez imposer une convention (`hp`, `hq` pour les hypothèses positives, `hnp` pour la négation, etc.) qui s'aligne avec le reste de la preuve.\n- **Documentation** : le `case` agit comme un commentaire structuré : `case inl (huge : False) => exact huge.elim` indique « ici je traite le cas gauche, qui est une absurdité ».\n\n**Exemple canonique** : la cellule de droite montre `cases hpq with | inl hp => ... | inr hq => ...` sur `hpq : p ∨ q`. La lecture est limpide : « si on a `p`, prouve la cible via `hp` ; si on a `q`, prouve via `hq` ». Sans les `case`, on lirait `cases hpq; { exact ... }, { exact ... }` — moins parlant.\n\n**Pièges** :\n\n- Oublier un `case` quand `cases` génère N branches : Lean signale « unsolved goals » et arrête la compilation. C'est un garde-fou, pas un bug.\n- Mélanger `case` et `·` : les deux mécanismes cohabitent mal. Préferez l'un ou l'autre par bloc.\n- Utiliser `case` sur une preuve de 1 ligne est surdimensionné ; `cases` simple suffit.\n\n**Le pont** : la convention `cases h with | intro ...` est universelle dans Lean-12 (Sensitivity), Lean-14 (Finiteness), et Lean-16 (Conway Free Will). Lean-6 (Mathlib) pousse plus loin avec `rcases` pour les structures imbriquées (par exemple matcher simultanément sur `Option` et `And`)."
+   "source": [
+    "### 7.2 `case` pour nommer les cas\n",
+    "\n",
+    "La tactique `cases h` (vue en 4.2) génère des **noms automatiques** pour chaque branche — `inl hp`, `inr hq`, etc. Mais ces noms sont souvent opaques : impossible de deviner à quoi ils correspondent sans lire le contexte.\n",
+    "\n",
+    "La forme `case` (et son équivalent `with | nom => ...`) permet de **renommer** explicitement chaque branche au moment où on la traite. Trois variantes principales :\n",
+    "\n",
+    "1. **`cases h with | intro hp hq => ...`** : syntaxe classique de Lean 4. Chaque branche commence par `| nom_constructeur (vars) =>`, suivie de la tactique à appliquer.\n",
+    "2. **`cases h; case inl hp => ... case inr hq => ...`** : syntaxe en deux temps. Plus verbeuse mais plus claire quand les branches contiennent plusieurs lignes.\n",
+    "3. **`rcases h with ⟨...⟩ | ⟨...⟩`** : la variante la plus expressive pour les inductive patterns imbriqués. `rcases` étend `cases` en reconnaissance de motifs (similaire à `match`).\n",
+    "\n",
+    "**Pourquoi nommer explicitement ?**\n",
+    "\n",
+    "- **Légibilité** : un lecteur voit immédiatement quelle branche fait quoi, sans avoir à deviner la sémantique des noms automatiques.\n",
+    "- **Nommage cohérent** : vous pouvez imposer une convention (`hp`, `hq` pour les hypothèses positives, `hnp` pour la négation, etc.) qui s'aligne avec le reste de la preuve.\n",
+    "- **Documentation** : le `case` agit comme un commentaire structuré : `case inl (huge : False) => exact huge.elim` indique « ici je traite le cas gauche, qui est une absurdité ».\n",
+    "\n",
+    "**Exemple canonique** : la cellule de droite montre `cases hpq with | inl hp => ... | inr hq => ...` sur `hpq : p ∨ q`. La lecture est limpide : « si on a `p`, prouve la cible via `hp` ; si on a `q`, prouve via `hq` ». Sans les `case`, on lirait `cases hpq; { exact ... }, { exact ... }` — moins parlant.\n",
+    "\n",
+    "**Pièges** :\n",
+    "\n",
+    "- Oublier un `case` quand `cases` génère N branches : Lean signale « unsolved goals » et arrête la compilation. C'est un garde-fou, pas un bug.\n",
+    "- Mélanger `case` et `·` : les deux mécanismes cohabitent mal. Préferez l'un ou l'autre par bloc.\n",
+    "- Utiliser `case` sur une preuve de 1 ligne est surdimensionné ; `cases` simple suffit.\n",
+    "\n",
+    "**Le pont** : la convention `cases h with | intro ...` est universelle dans Lean-12 (Sensitivity), Lean-14 (Finiteness), et Lean-16 (Conway Free Will). Lean-6 (Mathlib) pousse plus loin avec `rcases` pour les structures imbriquées (par exemple matcher simultanément sur `Option` et `And`)."
+   ]
   },
   {
    "cell_type": "code",
@@ -2841,7 +3008,41 @@
     },
     "tags": []
    },
-   "source": "## 8. Tactiques Avancees\n\n### 8.1 `induction` : preuve par recurrence\n\nLa tactique `induction` est la **brique de base** de la preuve par récurrence structurelle. Elle génère un cas de base (constructeur `zero` ou `nil`) et un cas inductif (constructeur `succ` ou `cons`) avec une **hypothèse de récurrence** (souvent nommée `ih`).\n\n**Fonctionnement** :\n\n- Pour `induction n with` sur un `n : Nat`, Lean crée deux sous-buts :\n  - `| zero => ⊢ P 0` : cas de base.\n  - `| succ k ih => ⊢ P (k + 1)` : cas inductif, avec `k : Nat` et `ih : P k`.\n- Pour une liste : `induction l with | nil => ... | cons hd tl ih => ...` — `hd : A`, `tl : List A`, `ih : P tl`.\n- Pour un inductif imbriqué (par exemple `Tree`), Lean génère un cas par constructeur.\n\n**Variantes utiles** :\n\n- **`induction n using Nat.strong_rec_on`** : récurrence forte où `ih` porte sur tous les `m < n`, pas seulement `n - 1`. Pour des bornes non-linéaires.\n- **`induction n generalizing h`** : la variable `h` est restaurée dans le contexte après induction. Utile quand `h` est une hypothèse qui dépend de `n`.\n- **`cases h; induction h'`** : induction sur un sous-terme destructuré.\n\n**Différences avec `cases`** : `cases` décompose sans générer d'hypothèse de récurrence. `induction` **crée** l'hypothèse de récurrence et l'injecte dans le contexte. Une preuve par récurrence a **besoin** de `induction` (ou `Nat.recOn`), `cases` ne suffirait pas.\n\n**Pattern de preuve** :\n\n```lean\ntheorem my_thm : ∀ n : Nat, P n := by\n  intro n\n  induction n with\n  | zero => -- cas de base\n  | succ k ih => -- ih : P k, prouver P (k+1)\n```\n\n**Le pont** : `induction` est la tactique dominante dans Lean-12 (Sensitivity) pour les preuves sur `ℕ`, dans Lean-14 (Finiteness) pour les preuves sur les dérivées, et dans Lean-16 (Conway Free Will) pour les preuves sur les entiers de Conway. Lean-6 (Mathlib) introduit `Nat.strong_induction` et `Nat.strong_rec_on` pour les preuves non-linéaires."
+   "source": [
+    "## 8. Tactiques Avancees\n",
+    "\n",
+    "### 8.1 `induction` : preuve par recurrence\n",
+    "\n",
+    "La tactique `induction` est la **brique de base** de la preuve par récurrence structurelle. Elle génère un cas de base (constructeur `zero` ou `nil`) et un cas inductif (constructeur `succ` ou `cons`) avec une **hypothèse de récurrence** (souvent nommée `ih`).\n",
+    "\n",
+    "**Fonctionnement** :\n",
+    "\n",
+    "- Pour `induction n with` sur un `n : Nat`, Lean crée deux sous-buts :\n",
+    "  - `| zero => ⊢ P 0` : cas de base.\n",
+    "  - `| succ k ih => ⊢ P (k + 1)` : cas inductif, avec `k : Nat` et `ih : P k`.\n",
+    "- Pour une liste : `induction l with | nil => ... | cons hd tl ih => ...` — `hd : A`, `tl : List A`, `ih : P tl`.\n",
+    "- Pour un inductif imbriqué (par exemple `Tree`), Lean génère un cas par constructeur.\n",
+    "\n",
+    "**Variantes utiles** :\n",
+    "\n",
+    "- **`induction n using Nat.strong_rec_on`** : récurrence forte où `ih` porte sur tous les `m < n`, pas seulement `n - 1`. Pour des bornes non-linéaires.\n",
+    "- **`induction n generalizing h`** : la variable `h` est restaurée dans le contexte après induction. Utile quand `h` est une hypothèse qui dépend de `n`.\n",
+    "- **`cases h; induction h'`** : induction sur un sous-terme destructuré.\n",
+    "\n",
+    "**Différences avec `cases`** : `cases` décompose sans générer d'hypothèse de récurrence. `induction` **crée** l'hypothèse de récurrence et l'injecte dans le contexte. Une preuve par récurrence a **besoin** de `induction` (ou `Nat.recOn`), `cases` ne suffirait pas.\n",
+    "\n",
+    "**Pattern de preuve** :\n",
+    "\n",
+    "```lean\n",
+    "theorem my_thm : ∀ n : Nat, P n := by\n",
+    "  intro n\n",
+    "  induction n with\n",
+    "  | zero => -- cas de base\n",
+    "  | succ k ih => -- ih : P k, prouver P (k+1)\n",
+    "```\n",
+    "\n",
+    "**Le pont** : `induction` est la tactique dominante dans Lean-12 (Sensitivity) pour les preuves sur `ℕ`, dans Lean-14 (Finiteness) pour les preuves sur les dérivées, et dans Lean-16 (Conway Free Will) pour les preuves sur les entiers de Conway. Lean-6 (Mathlib) introduit `Nat.strong_induction` et `Nat.strong_rec_on` pour les preuves non-linéaires."
+   ]
   },
   {
    "cell_type": "code",
@@ -2997,7 +3198,33 @@
     },
     "tags": []
    },
-   "source": "### 8.2 `decide` : propositions decidables\n\nLa tactique `decide` prouve une proposition **décidable** en l'évaluant par calcul sur l'interpréteur Lean. Elle vérifie algorithmiquement la proposition et ferme le but par réfutation ou confirmation. C'est l'**équivalent proof-side** de `rfl` pour les propositions booléennes.\n\n**Fonctionnement** :\n\n- `decide` est implémenté en Lean 4 par un appel à l'**évaluateur natif** (`Lean.Expr`). Pour `n ≤ m` ou `n + m = p`, il calcule littéralement et vérifie.\n- Le but doit être de type `Prop` et avoir une instance `Decidable` (que Lean peut dériver par `decidable_prop` ou `inferInstance`).\n- Les propositions **quantifiées** sur des univers infinis (`∀ n : Nat, n + 0 = n`) ne sont pas décidables en général — `decide` échoue.\n\n**Exemples d'utilisation** :\n\n- `decide` pour les inégalités numériques : `3 ≤ 5`, `10 % 3 = 1`, etc.\n- `decide` pour les propositions booléennes : `true ∧ false = false`, `¬ true = false`.\n- `decide` pour les propositions sur des structures finies : `List.length [1,2,3] = 3`, `Option.isNone (some 5) = false`.\n\n**Différences avec `rfl`** : `rfl` prouve une égalité **définitionnelle** (réductible par `βδιζη`). `decide` traite les propositions avec une **`Decidable` instance** — y compris celles non définitionnellement closes. Donc `decide` est strictement **plus puissant** : `n + 0 = n` peut être `decide`-prouvé (Lean calcule littéralement), alors que `rfl` échoue (il faut une étape de preuve).\n\n**Pièges** :\n\n- `decide` peut être **lent** sur de grands arguments (calcul proportionnel à la taille).\n- `decide` ne fournit **pas** de witness — il prouve seulement la proposition. Si vous avez besoin du **témoin** (par exemple `n = 5` après preuve que `n` satisfait une certaine propriété), il faut `omega` ou `nlinarith`.\n- `decide` sur une proposition **non décidable** : Lean renvoie `failed`, pas un faux positif.\n\n**Le pont** : `decide` est utilisé en abondance dans Lean-6 (Mathlib) pour les lemmes sur `Nat.Prime` et les propositions finies. Lean-12 (Sensitivity) l'emploie sur les lemmes de cardinalité booléenne. Lean-16 (Conway Free Will) l'utilise sur les équations de Gödel pour des preuves courtes et mécaniques."
+   "source": [
+    "### 8.2 `decide` : propositions decidables\n",
+    "\n",
+    "La tactique `decide` prouve une proposition **décidable** en l'évaluant par calcul sur l'interpréteur Lean. Elle vérifie algorithmiquement la proposition et ferme le but par réfutation ou confirmation. C'est l'**équivalent proof-side** de `rfl` pour les propositions booléennes.\n",
+    "\n",
+    "**Fonctionnement** :\n",
+    "\n",
+    "- `decide` est implémenté en Lean 4 par un appel à l'**évaluateur natif** (`Lean.Expr`). Pour `n ≤ m` ou `n + m = p`, il calcule littéralement et vérifie.\n",
+    "- Le but doit être de type `Prop` et avoir une instance `Decidable` (que Lean peut dériver par `decidable_prop` ou `inferInstance`).\n",
+    "- Les propositions **quantifiées** sur des univers infinis (`∀ n : Nat, n + 0 = n`) ne sont pas décidables en général — `decide` échoue.\n",
+    "\n",
+    "**Exemples d'utilisation** :\n",
+    "\n",
+    "- `decide` pour les inégalités numériques : `3 ≤ 5`, `10 % 3 = 1`, etc.\n",
+    "- `decide` pour les propositions booléennes : `true ∧ false = false`, `¬ true = false`.\n",
+    "- `decide` pour les propositions sur des structures finies : `List.length [1,2,3] = 3`, `Option.isNone (some 5) = false`.\n",
+    "\n",
+    "**Différences avec `rfl`** : `rfl` prouve une égalité **définitionnelle** (réductible par `βδιζη`). `decide` traite les propositions avec une **`Decidable` instance** — y compris celles non définitionnellement closes. Donc `decide` est strictement **plus puissant** : `n + 0 = n` peut être `decide`-prouvé (Lean calcule littéralement), alors que `rfl` échoue (il faut une étape de preuve).\n",
+    "\n",
+    "**Pièges** :\n",
+    "\n",
+    "- `decide` peut être **lent** sur de grands arguments (calcul proportionnel à la taille).\n",
+    "- `decide` ne fournit **pas** de witness — il prouve seulement la proposition. Si vous avez besoin du **témoin** (par exemple `n = 5` après preuve que `n` satisfait une certaine propriété), il faut `omega` ou `nlinarith`.\n",
+    "- `decide` sur une proposition **non décidable** : Lean renvoie `failed`, pas un faux positif.\n",
+    "\n",
+    "**Le pont** : `decide` est utilisé en abondance dans Lean-6 (Mathlib) pour les lemmes sur `Nat.Prime` et les propositions finies. Lean-12 (Sensitivity) l'emploie sur les lemmes de cardinalité booléenne. Lean-16 (Conway Free Will) l'utilise sur les équations de Gödel pour des preuves courtes et mécaniques."
+   ]
   },
   {
    "cell_type": "code",
@@ -3107,7 +3334,36 @@
     },
     "tags": []
    },
-   "source": "### 8.3 `omega` : arithmetique lineaire\n\nLa tactique `omega` est un **décideur d'arithmétique de Presburger** : elle résout automatiquement les buts d'arithmétique linéaire (additions, soustractions, comparaisons, constantes entieres) sans aucune aide.\n\n**Portée de `omega`** :\n\n- **Additions et soustractions** : `n + m`, `n - m`, `0`, `1`, ..., `(n : Int)`.\n- **Multiplications par constantes** : `2 * n`, `n * 5`, mais pas `n * m`.\n- **Comparaisons** : `<`, `≤`, `>`, `≥`, `=`, `≠`.\n- **Variables naturelle et entière** : `Nat`, `Int`, surchargées.\n\n**Exemples d'utilisation** :\n\n```lean\nexample (n m : Nat) (h : n < m) : n + 1 ≤ m := by omega\nexample (n m : Nat) (h : n + m = 10) (h' : n > 5) : m < 5 := by omega\nexample (n m k : Nat) (h1 : n < m) (h2 : m < k) : n + 1 < k := by omega\n```\n\n**Algorithme** : `omega` réduit d'abord le but à des inégalités linéaires, puis applique l'**algorithme de Cooper** (un décideur en arithmétique de Presburger) pour réfuter la négation. Si la négation est réfutable, `omega` ferme le but. Sinon, `omega` échoue.\n\n**Limites** :\n\n- **Pas de multiplication de variables** : `n * m = 0` n'est pas décidable en Presburger général. Pour cela, il faut `nlinarith` (Mathlib) ou combiner `omega` avec `nlinarith`.\n- **Pas de quantification imbriquée** : `omega` réussit sur `∀ n, ...`, pas sur `∀ ∃, ...` qui implique la satisfaisabilité dans une structure plus riche.\n- **Pas de fonctions définies par récursion** : `omega` ne sait pas quelles sont les propriétés de `fib n` ou `ack n`.\n\n**Le pont** : `omega` est l'une des tactic les plus utilisées dans Lean-6 (Mathlib) pour les sous-buts arithmétiques. Lean-12 (Sensitivity) l'utilise pour les preuves sur les sommes de booléens. Lean-14 (Finiteness) l'emploie sur les polynômes de degré 1 (au-delà, c'est `nlinarith` ou `polyrith`). Lean-16 (Conway Free Will) l'utilise pour les preuves sur les entiers de Conway qui restent dans l'arithmétique linéaire."
+   "source": [
+    "### 8.3 `omega` : arithmetique lineaire\n",
+    "\n",
+    "La tactique `omega` est un **décideur d'arithmétique de Presburger** : elle résout automatiquement les buts d'arithmétique linéaire (additions, soustractions, comparaisons, constantes entieres) sans aucune aide.\n",
+    "\n",
+    "**Portée de `omega`** :\n",
+    "\n",
+    "- **Additions et soustractions** : `n + m`, `n - m`, `0`, `1`, ..., `(n : Int)`.\n",
+    "- **Multiplications par constantes** : `2 * n`, `n * 5`, mais pas `n * m`.\n",
+    "- **Comparaisons** : `<`, `≤`, `>`, `≥`, `=`, `≠`.\n",
+    "- **Variables naturelle et entière** : `Nat`, `Int`, surchargées.\n",
+    "\n",
+    "**Exemples d'utilisation** :\n",
+    "\n",
+    "```lean\n",
+    "example (n m : Nat) (h : n < m) : n + 1 ≤ m := by omega\n",
+    "example (n m : Nat) (h : n + m = 10) (h' : n > 5) : m < 5 := by omega\n",
+    "example (n m k : Nat) (h1 : n < m) (h2 : m < k) : n + 1 < k := by omega\n",
+    "```\n",
+    "\n",
+    "**Algorithme** : `omega` réduit d'abord le but à des inégalités linéaires, puis applique l'**algorithme de Cooper** (un décideur en arithmétique de Presburger) pour réfuter la négation. Si la négation est réfutable, `omega` ferme le but. Sinon, `omega` échoue.\n",
+    "\n",
+    "**Limites** :\n",
+    "\n",
+    "- **Pas de multiplication de variables** : `n * m = 0` n'est pas décidable en Presburger général. Pour cela, il faut `nlinarith` (Mathlib) ou combiner `omega` avec `nlinarith`.\n",
+    "- **Pas de quantification imbriquée** : `omega` réussit sur `∀ n, ...`, pas sur `∀ ∃, ...` qui implique la satisfaisabilité dans une structure plus riche.\n",
+    "- **Pas de fonctions définies par récursion** : `omega` ne sait pas quelles sont les propriétés de `fib n` ou `ack n`.\n",
+    "\n",
+    "**Le pont** : `omega` est l'une des tactic les plus utilisées dans Lean-6 (Mathlib) pour les sous-buts arithmétiques. Lean-12 (Sensitivity) l'utilise pour les preuves sur les sommes de booléens. Lean-14 (Finiteness) l'emploie sur les polynômes de degré 1 (au-delà, c'est `nlinarith` ou `polyrith`). Lean-16 (Conway Free Will) l'utilise pour les preuves sur les entiers de Conway qui restent dans l'arithmétique linéaire."
+   ]
   },
   {
    "cell_type": "code",
@@ -3214,7 +3470,36 @@
     },
     "tags": []
    },
-   "source": "### 8.4 `ring` : algebre\n\nLa tactique `ring` est un **décideur d'anneaux commutatifs** : elle prouve les égalités polynomiales sur `ℕ`, `ℤ`, `ℚ`, `ℝ`, et plus généralement tout `CommRing`, sans aucune aide.\n\n**Portée de `ring`** :\n\n- **Anneau sous-jacent** : `Nat`, `Int`, `Rat`, `Real`, toute instance `CommRing`.\n- **Opérations** : `+`, `-`, `*`, `^`, `0`, `1`.\n- **Variables** : `x`, `y`, `z`, ... .\n- **Constantes** : `0`, `1`, `2`, ..., `(2 : Int)`, `(3 : ℚ)`, etc.\n\n**Exemples** :\n\n```lean\nexample (x y : ℤ) : (x + y) * (x + y) = x*x + 2*x*y + y*y := by ring\nexample (a b c : ℚ) : (a + b + c) * (a + b + c) = a^2 + 2*a*b + 2*a*c + b^2 + 2*b*c + c^2 := by ring\nexample (n : Nat) : (n + 1) * (n + 1) = n*n + 2*n + 1 := by ring\n```\n\n**Algorithme** : `ring` réduit les deux côtés de l'égalité à une **forme normale polynomiale** (somme de monômes ordonnés), puis compare les arbres syntaxiquement. C'est l'équivalent proof-side de la **réduction polynomiale** des CAS.\n\n**Limites** :\n\n- **Pas de division** : `ring` ne sait pas gérer `/`. Si le but contient `a / b`, il faut `field_simp` ou `norm_cast` + `ring`.\n- **Pas d'inégalités** : `ring` est **uniquement** pour les égalités. Pour `a < b`, il faut `nlinarith` ou `polyrith`.\n- **Polynômes seulement** : les expressions avec `sin`, `cos`, `log`, etc. ne passent pas.\n\n**Le pont** : `ring` est exposé en Lean-6 (Mathlib Essentials) — d'où la mention dans le code que c'est une tactique Mathlib. Lean-9 (Lean in the Real World) l'utilise pour les preuves sur les expressions algébriques. Lean-12 (Sensitivity) l'emploie pour les preuves de degré polynomial sur les réels. Lean-14 (Finiteness) le combine avec `nlinarith` pour les bornes non-linéaires."
+   "source": [
+    "### 8.4 `ring` : algebre\n",
+    "\n",
+    "La tactique `ring` est un **décideur d'anneaux commutatifs** : elle prouve les égalités polynomiales sur `ℕ`, `ℤ`, `ℚ`, `ℝ`, et plus généralement tout `CommRing`, sans aucune aide.\n",
+    "\n",
+    "**Portée de `ring`** :\n",
+    "\n",
+    "- **Anneau sous-jacent** : `Nat`, `Int`, `Rat`, `Real`, toute instance `CommRing`.\n",
+    "- **Opérations** : `+`, `-`, `*`, `^`, `0`, `1`.\n",
+    "- **Variables** : `x`, `y`, `z`, ... .\n",
+    "- **Constantes** : `0`, `1`, `2`, ..., `(2 : Int)`, `(3 : ℚ)`, etc.\n",
+    "\n",
+    "**Exemples** :\n",
+    "\n",
+    "```lean\n",
+    "example (x y : ℤ) : (x + y) * (x + y) = x*x + 2*x*y + y*y := by ring\n",
+    "example (a b c : ℚ) : (a + b + c) * (a + b + c) = a^2 + 2*a*b + 2*a*c + b^2 + 2*b*c + c^2 := by ring\n",
+    "example (n : Nat) : (n + 1) * (n + 1) = n*n + 2*n + 1 := by ring\n",
+    "```\n",
+    "\n",
+    "**Algorithme** : `ring` réduit les deux côtés de l'égalité à une **forme normale polynomiale** (somme de monômes ordonnés), puis compare les arbres syntaxiquement. C'est l'équivalent proof-side de la **réduction polynomiale** des CAS.\n",
+    "\n",
+    "**Limites** :\n",
+    "\n",
+    "- **Pas de division** : `ring` ne sait pas gérer `/`. Si le but contient `a / b`, il faut `field_simp` ou `norm_cast` + `ring`.\n",
+    "- **Pas d'inégalités** : `ring` est **uniquement** pour les égalités. Pour `a < b`, il faut `nlinarith` ou `polyrith`.\n",
+    "- **Polynômes seulement** : les expressions avec `sin`, `cos`, `log`, etc. ne passent pas.\n",
+    "\n",
+    "**Le pont** : `ring` est exposé en Lean-6 (Mathlib Essentials) — d'où la mention dans le code que c'est une tactique Mathlib. Lean-9 (Lean in the Real World) l'utilise pour les preuves sur les expressions algébriques. Lean-12 (Sensitivity) l'emploie pour les preuves de degré polynomial sur les réels. Lean-14 (Finiteness) le combine avec `nlinarith` pour les bornes non-linéaires."
+   ]
   },
   {
    "cell_type": "code",
@@ -3329,7 +3614,29 @@
     },
     "tags": []
    },
-   "source": "## 9. Melange Termes et Tactiques\n\n### 9.1 `by` dans un terme\n\nLa section 9 complète le notebook en montrant que **mode terme et mode tactique ne sont pas mutuellement exclusifs** : Lean 4 permet le **mode hybride** où `by ...` ouvre un bloc tactique au milieu d'un terme, et inversement, on peut invoquer un terme de preuve à l'intérieur d'une tactique.\n\n**Le `by` dans un terme** : la forme `by tac` retourne un terme de preuve en exécutant les tactiques `tac`. On peut donc écrire `⟨by exact hp, by exact hq⟩` pour assembler deux preuves via leurs sous-bloc tactiques. C'est la forme la plus courante du mélange.\n\n**Pourquoi mélanger ?**\n\n- **Lisibilité** : un terme pur peut être obscur ; ouvrir un `by` sur le point délicat rend la preuve pédagogique.\n- **Subset d'une preuve complexe** : si une sous-preuve est facile en tactique et le reste en terme, le mode hybride évite de tout convertir.\n- **Inférence de type** : Lean peut typer le `by` à la volée, laisse la place pour le contexte.\n\n**Trois patterns principaux** :\n\n1. **`by` dans un constructeur** : `⟨by exact hp, by assumption⟩` — assembler deux preuves via leurs sous-bloc tactiques.\n2. **`by` dans un `f` (lambda)** : `f := fun x => by intro h; exact h` — preuve locale d'une lambda.\n3. **`by` dans un `match`** : `match n with | 0 => by decide | k+1 => by omega` — tactic par cas.\n\n**Le pont** : le mode hybride est très utilisé dans Lean-6 (Mathlib) où les constructeurs anonymes `⟨...⟩` contiennent souvent des `by`. Lean-12 (Sensitivity) mélange `by` et `exact` pour les preuves sur les sommes finies. Lean-14 (Finiteness) utilise `by` pour les sous-buts dans les `match` sur les dérivées."
+   "source": [
+    "## 9. Melange Termes et Tactiques\n",
+    "\n",
+    "### 9.1 `by` dans un terme\n",
+    "\n",
+    "La section 9 complète le notebook en montrant que **mode terme et mode tactique ne sont pas mutuellement exclusifs** : Lean 4 permet le **mode hybride** où `by ...` ouvre un bloc tactique au milieu d'un terme, et inversement, on peut invoquer un terme de preuve à l'intérieur d'une tactique.\n",
+    "\n",
+    "**Le `by` dans un terme** : la forme `by tac` retourne un terme de preuve en exécutant les tactiques `tac`. On peut donc écrire `⟨by exact hp, by exact hq⟩` pour assembler deux preuves via leurs sous-bloc tactiques. C'est la forme la plus courante du mélange.\n",
+    "\n",
+    "**Pourquoi mélanger ?**\n",
+    "\n",
+    "- **Lisibilité** : un terme pur peut être obscur ; ouvrir un `by` sur le point délicat rend la preuve pédagogique.\n",
+    "- **Subset d'une preuve complexe** : si une sous-preuve est facile en tactique et le reste en terme, le mode hybride évite de tout convertir.\n",
+    "- **Inférence de type** : Lean peut typer le `by` à la volée, laisse la place pour le contexte.\n",
+    "\n",
+    "**Trois patterns principaux** :\n",
+    "\n",
+    "1. **`by` dans un constructeur** : `⟨by exact hp, by assumption⟩` — assembler deux preuves via leurs sous-bloc tactiques.\n",
+    "2. **`by` dans un `f` (lambda)** : `f := fun x => by intro h; exact h` — preuve locale d'une lambda.\n",
+    "3. **`by` dans un `match`** : `match n with | 0 => by decide | k+1 => by omega` — tactic par cas.\n",
+    "\n",
+    "**Le pont** : le mode hybride est très utilisé dans Lean-6 (Mathlib) où les constructeurs anonymes `⟨...⟩` contiennent souvent des `by`. Lean-12 (Sensitivity) mélange `by` et `exact` pour les preuves sur les sommes finies. Lean-14 (Finiteness) utilise `by` pour les sous-buts dans les `match` sur les dérivées."
+   ]
   },
   {
    "cell_type": "code",
@@ -3442,7 +3749,40 @@
     },
     "tags": []
    },
-   "source": "### 9.2 Termes dans les tactiques\n\nLe symétrique du `by` est d'**utiliser un terme de preuve à l'intérieur d'une tactique**. La forme la plus simple est `exact t` où `t` est un terme pur, mais on peut aussi développer des termes complexes au milieu d'une preuve.\n\n**Patterns fréquents** :\n\n- **`exact ⟨hp, hq⟩`** : clore un but `p ∧ q` avec un constructeur de conjonction.\n- **`exact And.intro hp hq`** : équivalent plus explicite que `⟨hp, hq⟩`.\n- **`exact (h : P → Q) hp`** : annoter le type intermédiaire avec `(h : ...)` pour forcer Lean à accepter la conversion.\n- **`exact ⟨w, hw⟩`** : témoin implicite pour une preuve existentielle.\n\n**Pourquoi garder un terme pur ?**\n\n- **Court** : si la preuve est triviale (1 à 3 étapes), un terme est plus compact qu'une tactique.\n- **Préféré en définition** : les `def` et `abbrev` mathématiques s'écrivent en mode terme, sans tactique.\n- **Inductif simple** : pour un constructeur unique, `exact ⟨...⟩` est la norme.\n\n**Choix tactique vs terme** :\n\n| Critère | Préférer tactique | Préférer terme |\n|---|---|---|\n| Preuve ≥ 3 étapes | X | |\n| Cas multiples à explorer | X (cases, induction) | |\n| Témoin à exhiber | X (use, exact) | |\n| Convertir un objet | X (norm_cast, ring) | |\n| Constructeur trivial | | X (exact) |\n| Spécification mathématique | | X (def, abbrev) |\n| Calcul direct | | X (term-mode) |\n\n**Le pont** : Lean-6 (Mathlib) mélange systématiquement termes et tactiques — par exemple `exact (h.symm.trans h')` ou `exact ⟨by omega, by omega⟩`. Lean-12 (Sensitivity) privilégie les tactiques, mais accepte des termes dans les lemmes d'aménagement. Lean-14 (Finiteness) utilise des termes pour les constructions mathématiques et des tactiques pour les preuves.\n\n**Conclusion** : choisir entre mode terme et mode tactic est une décision de **lisibilité** : on privilégie le mode qui rend la preuve la plus claire pour le lecteur. En Lean 4, les deux modes sont citoyens de première classe et interchangeables à tout moment."
+   "source": [
+    "### 9.2 Termes dans les tactiques\n",
+    "\n",
+    "Le symétrique du `by` est d'**utiliser un terme de preuve à l'intérieur d'une tactique**. La forme la plus simple est `exact t` où `t` est un terme pur, mais on peut aussi développer des termes complexes au milieu d'une preuve.\n",
+    "\n",
+    "**Patterns fréquents** :\n",
+    "\n",
+    "- **`exact ⟨hp, hq⟩`** : clore un but `p ∧ q` avec un constructeur de conjonction.\n",
+    "- **`exact And.intro hp hq`** : équivalent plus explicite que `⟨hp, hq⟩`.\n",
+    "- **`exact (h : P → Q) hp`** : annoter le type intermédiaire avec `(h : ...)` pour forcer Lean à accepter la conversion.\n",
+    "- **`exact ⟨w, hw⟩`** : témoin implicite pour une preuve existentielle.\n",
+    "\n",
+    "**Pourquoi garder un terme pur ?**\n",
+    "\n",
+    "- **Court** : si la preuve est triviale (1 à 3 étapes), un terme est plus compact qu'une tactique.\n",
+    "- **Préféré en définition** : les `def` et `abbrev` mathématiques s'écrivent en mode terme, sans tactique.\n",
+    "- **Inductif simple** : pour un constructeur unique, `exact ⟨...⟩` est la norme.\n",
+    "\n",
+    "**Choix tactique vs terme** :\n",
+    "\n",
+    "| Critère | Préférer tactique | Préférer terme |\n",
+    "|---|---|---|\n",
+    "| Preuve ≥ 3 étapes | X | |\n",
+    "| Cas multiples à explorer | X (cases, induction) | |\n",
+    "| Témoin à exhiber | X (use, exact) | |\n",
+    "| Convertir un objet | X (norm_cast, ring) | |\n",
+    "| Constructeur trivial | | X (exact) |\n",
+    "| Spécification mathématique | | X (def, abbrev) |\n",
+    "| Calcul direct | | X (term-mode) |\n",
+    "\n",
+    "**Le pont** : Lean-6 (Mathlib) mélange systématiquement termes et tactiques — par exemple `exact (h.symm.trans h')` ou `exact ⟨by omega, by omega⟩`. Lean-12 (Sensitivity) privilégie les tactiques, mais accepte des termes dans les lemmes d'aménagement. Lean-14 (Finiteness) utilise des termes pour les constructions mathématiques et des tactiques pour les preuves.\n",
+    "\n",
+    "**Conclusion** : choisir entre mode terme et mode tactic est une décision de **lisibilité** : on privilégie le mode qui rend la preuve la plus claire pour le lecteur. En Lean 4, les deux modes sont citoyens de première classe et interchangeables à tout moment."
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-dotnet #10944

## Livrable

Grain 1 de #10479 (densite pedagogique) : enrichissement **markdown-only** de `MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-5-Tactics.ipynb`, le seul notebook encore sous le seuil apres la passe #10525 (grain 4/4, merge 2026-08-12 — enrichissement insuffisant : 1039 c/cellule, label `candidate-delivered` pose, verifie puis retire, voir claim issuecomment-5293667820).

8 cellules markdown minces enrichies au pattern thin->dense (#10572) : **2.1 exact, 2.2 intro, 2.3 apply, 2.4 assumption, 2.5 rfl, 3.2 let, 5.1 rw, 6.1 simp**. Chaque ajout repond a trois questions : ce que la construction resout et pourquoi elle existe (avant), comment lire le message/etat de Lean apres la tactique (apres), et un pont vers un notebook applique.

## Avant / apres (outil canonique `pedagogy_density.py`)

| Metrique | Avant (origin/main) | Apres |
|---|---|---|
| chars prose / cellule code | 1039 (35339 / 34) | **1352** (45993 / 34) |
| Seuil #10479 (>= 1200) | sous | **atteint** |

Sortie outil sur la branche : `Judged vs floor: 1 / Below 1200 c/cell: 0 / All judged notebooks meet the density floor.`

## Preuves (`git diff`)

- **0 cellule code touchee** : fingerprint sha256 (source + `execution_count` + `outputs`) sur les 78 cellules = **78/78 identiques** a `origin/main` ; aucun ajout de ligne `"cell_type": "code"` dans le diff.
- **0 perte de contenu** : `detect_md_content_loss.py` → `findings=0`, md_cells 44=44 stables.
- **Ordre inchange** : `scan_cell_ordering.py` → 1 clean, 0 finding.
- **C.1** : grep `raise NotImplementedError|assert False|1/0` = 0 (inchange, mais verifie).
- **LF preserve** : normalise apres ecriture (nbformat Windows -> CRLF, cf c.10278-L2), verifie CRLF=0.

## Prose

- **FR** : chaque addition est redigee en francais (accents), consistance avec le reste de la serie.
- **Pas de remplissage** : chaque paragraphe porte une information verifiable (ex. dissymetrie `Nat.add_zero` rfl vs `Nat.zero_add` non-rfl, liee a la recursion sur le second argument — c'est ce qui fait tourner `intro_forall` cellule 8 avec `rfl`).
- **Renvois explicites vers notebooks appliques** (>= 1 par notebook satisfait) : `Lean-14-Finiteness-Derivatives` (cells 2.1, 3.2) · `Lean-13-Kochen-Specker` (2.3) · `Lean-6-Mathlib-Essentials` (5.1) · `Lean-16b-Conway-Game-of-Life-Lean` (6.1).

## Contexte

- La branche initiale `feature/c10479-lean5-density` appartenait a la PR **#10525 (mergee)** : branche squash-mergee laissee vivante sur le remote (pattern L576). Renommee en `-residual` pour ne pas reutiliser une branche morte d'une PR mergee.
- Verification G.1 : le label `candidate-delivered` sur #10479 etait justifie pour 4/5 notebooks, pas pour Lean-5 (mesure canonical tool sur origin/main).

See #10479 (grain 1 — l'issue est resolue pour Lean-5 ; 4/5 autres notebooks deja >= 1200)
