### PR TITLE
fix(ml,#10930): dm_test.py mean_loss_diff docstring + REGISTRY §C interpretation recalibrée

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/REGISTRY.md
@@ -27,11 +27,15 @@ HAC Newey-West + correction HLN, `loss_fn="linear"` (#10228).
 | h=5 | +28,3 % | 0,10 | 0,00e+00 | **NO BEATS** |
 | h=10 | +38,3 % | 0,20 | 0,00e+00 | **NO BEATS** |
 
-**Lecture honnête (le piège §C, dans le bon sens)** : DLinear réduit le MSE de 15 à 38 % (perte
+**Lecture honnête (le piège §C, dans le bon sens)** : DLinear bat HAR de 15 à 38 % en MSE (perte
 symétrique), mais la perte **signée** (`linear`) révèle un **biais systématique** de prévision —
 `dm_mean_loss_diff ≈ +0,22` log-RV (h=1) : DLinear sur-prévient log-RV par rapport à HAR (OLS,
 non biaisé). Le DM signé le détecte à 39-47σ, p = 0,00 — **BEATEN BY baseline** sur les 4 seeds
-de chaque horizon. Un « edge » MSE porté par un forecaster biaisé n'est pas un edge exploitable.
+de chaque horizon. Ce biais est **quasi déterministe** (σ/moyenne = 0,39 % sur 4 seeds, monotone
+en horizon : 0,22 → 0,35 → 0,45) : un décalage constant par horizon, donc **corrigible** — il
+plafonne l'avantage MSE de DLinear, il ne le fabrique pas. `MSE = biais² + variance` : retirer le
+biais² porterait l'edge estimé à ~21/52/74 % (h=1/5/10) — **hypothèse à mesurer** (issue #10938),
+pas un résultat. Sous §C tel qu'écrit, la conjonction n'est pas tenue.
 **Verdict §C : NO BEATS (3/3 horizons)** — règle de dominance (seed BEATEN → NO BEATS) appliquée.
 **Coûts de transaction** : prévision (MSE log-RV), **aucune stratégie dérivée** → coût non imputé ;
 borne crypto 10 bps si conversion future en overlay de vol-timing (note, pas un claim).

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py
@@ -176,7 +176,10 @@ def dm_verdict(
 ) -> dict:
     """Run DM test and return a verdict dict with human-readable result.
 
-    Positive mean_loss_diff means baseline has higher loss (model wins).
+    mean_loss_diff = mean(loss_a - loss_b) with a = model, b = baseline:
+    NEGATIVE means the model has lower loss (model wins); positive means
+    the baseline wins. With loss_fn="linear" the DM differential compares
+    raw signed errors, so mean_loss_diff is the model-vs-baseline bias gap.
 
     ``loss_fn`` selects the loss applied to forecast errors before the DM
     differential: ``"mse"`` (squared), ``"mae"`` (absolute), ``"linear"``


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA — prev: MED/guard #10936

## Summary

Suite de revue #10930 (2 corrections demandées par ai-01 c.97, DM 12:57Z, + note Hermes sur #10930) — appliquées ici :

1. **`dm_test.py` docstring L178 corrigée** : « Positive mean_loss_diff means baseline has higher loss (model wins) » affirmait l'inverse du code (`d = loss_a − loss_b`, `< 0` → BEATS). Réécrit : `mean_loss_diff < 0` = modèle gagne ; avec `loss_fn="linear"` le différentiel DM est l'écart de biais modèle-vs-baseline. C'est le commentaire que #10930 expose (`loss_fn` comme bouton) et sur lequel #10938 s'appuiera.
2. **`REGISTRY.md` entrée §C M4 — interprétation recalibrée** : le biais est **quasi déterministe** (σ/moyenne = 0,39 % sur 4 seeds, monotone en horizon 0,22 → 0,35 → 0,45) — un décalage constant par horizon, donc **corrigible** : il plafonne l'avantage MSE de DLinear, il ne le fabrique pas (`MSE = biais² + variance`). `NO BEATS` maintenu sous §C tel qu'écrit (conjonction non tenue), mais la formulation « pas d'edge exploitable » est remplacée par « edge MSE plafonné par un biais corrigible » — l'hypothèse dé-biaisée (~21/52/74 %) est renvoyée à la mesure (#10938), pas vendue comme résultat.

Verdict §C, H.4, data hash, run commande : inchangés (aucune re-mesure — prose et docstring seulement).

## Validation

- `git diff --stat` : 2 fichiers, +10/−3, un seul sujet (suite de revue #10930).
- Docstring corrigée cohérente avec le code (`dm_verdict` L187-191 : `mean_loss_diff < 0` → `BEATS baseline`).
- Pas de re-run nécessaire (aucune cellule modifiée, aucun résultat).

See #10930, #10938 — follow-up sur #10930 déjà mergée, ne ferme aucune issue.
