### PR TITLE
Notebook: configurer et interroger des chatbots — le chatbot est un document JSON (série AI Engine par son API, grain 2)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -147,6 +147,20 @@ sonde ment » documenté pour la classe *système* dans
 [`verification-verte-systeme-casse.md`](../../../../docs/reference/verification-verte-systeme-casse.md).
 stdlib pur, sans clé ni réseau.
 
+Une série « AI Engine par son API » s'ajoute aux compagnons ci-dessus :
+elle présente le plugin par des notebooks qui **appellent réellement
+l'API** d'une instance jetable dédiée — montage en 5 étapes via
+[`instance-jetable/`](instance-jetable/), corpus synthétique 100 %
+(Maison Valmont), credentials via `.env` jamais commité.
+[`presenter-ai-engine-par-son-api.ipynb`](presenter-ai-engine-par-son-api.ipynb)
+pose le socle : instance, catalogue des routes `mwai/v1`, première
+completion réelle avec compte de tokens.
+[`configurer-chatbots-par-l-api.ipynb`](configurer-chatbots-par-l-api.ipynb)
+traite les chatbots comme des **documents JSON** — lecture, duplication,
+écriture read-modify-write, interrogation — puis mesure honnêtement ce
+que les instructions d'un persona changent, et ce qu'elles ne changent
+pas.
+
 ---
 
 ## Sections
@@ -270,6 +284,10 @@ attendues.
   Copilot Gutenberg : dérive d'une chaîne de transformations, le gate par étape ne protège pas la chaîne
 - [`auditer-la-conformite-visuelle.ipynb`](auditer-la-conformite-visuelle.ipynb) —
   smoke test structurel vs conformité visuelle : contraste WCAG, primaires Bootstrap, affordance des CTA
+- [`presenter-ai-engine-par-son-api.ipynb`](presenter-ai-engine-par-son-api.ipynb) —
+  socle de la série « par son API » : instance jetable, catalogue des routes, première completion réelle
+- [`configurer-chatbots-par-l-api.ipynb`](configurer-chatbots-par-l-api.ipynb) —
+  chatbots comme documents JSON : lire, dupliquer, écrire (read-modify-write), interroger deux personas
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/configurer-chatbots-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/configurer-chatbots-par-l-api.ipynb
@@ -229,6 +229,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3f2b8d61",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : trois documents, et pas une ligne de code\n",
+    "\n",
+    "La liste renvoie **trois `botId`** -- `default`, `valmont`, `comite` -- chacun decrit par **54 champs**. C'est le point central de la serie : ce qui distingue un chatbot d'un autre n'est pas du code, c'est le contenu de ces champs. Le comparatif le montre directement : `default` tourne sur `gpt-5.5` avec `temperature 0.8` et `maxTokens 4096`, tandis que `valmont` et `comite` partagent `qwen3.6-35b-a3b`, `temperature 0.6` et `maxTokens 1024`. Changer de persona, ici, revient a editer un document.\n",
+    "\n",
+    "Deux champs parmi les 54 meritent d'etre remarques des maintenant, parce qu'ils reviendront :\n",
+    "\n",
+    "- **`instructions`** porte le prompt systeme -- c'est lui qui fabrique la personnalite, et c'est le seul champ que l'etape suivante modifiera.\n",
+    "- **`apiKey`** est un champ **du document**, donc renvoye par l'API au meme titre que les autres. C'est la raison de l'allowlist d'affichage employee ci-dessus : on choisit les cles a imprimer, plutot que de faire confiance au serveur pour ne rien renvoyer de sensible.\n",
+    "\n",
+    "Seul `startSentence` est visible du visiteur ; tout le reste du document est de la configuration invisible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6d0db5ed",
    "metadata": {},
    "source": [
@@ -313,6 +330,21 @@
     "print(\"Chatbots apres ecriture :\", [b[\"botId\"] for b in apres])\n",
     "comite_ecrit = next(b for b in apres if b[\"botId\"] == \"comite\")\n",
     "print(\"instructions persistees :\", comite_ecrit[\"instructions\"] == INSTRUCTIONS_COMITE)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c1e0a94",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : ce qui prouve l'ecriture, ce n'est pas le POST\n",
+    "\n",
+    "Le POST repond `Ecriture acceptee : True` -- mais cette valeur dit seulement que le serveur a **accepte la charge utile**, pas qu'il l'a conservee. La preuve tient dans les deux lignes suivantes, qui proviennent d'une **relecture** :\n",
+    "\n",
+    "- `Chatbots apres ecriture : ['default', 'valmont', 'comite']` -- toujours **trois** entrees. C'est le controle qui compte pour cet endpoint : puisque le POST remplace la liste entiere, un read-modify-write mal ecrit n'aurait pas leve d'erreur, il aurait simplement renvoye une liste **tronquee** au seul chatbot envoye. Retrouver `default` et `valmont` intacts est ce qui valide le pattern.\n",
+    "- `instructions persistees : True` -- le champ modifie a bien survecu a l'aller-retour.\n",
+    "\n",
+    "C'est aussi ce qui rend la cellule **idempotente** : l'upsert cherche `comite` par son `botId` et le remplace s'il existe, au lieu d'ajouter une entree. La reexecuter dix fois laisse toujours trois chatbots -- verifiable en la relancant."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/configurer-chatbots-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/configurer-chatbots-par-l-api.ipynb
@@ -1,0 +1,616 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b54ac4d9",
+   "metadata": {},
+   "source": [
+    "# Configurer et interroger des chatbots — le chatbot est un document JSON\n",
+    "\n",
+    "Deuxieme notebook de la serie « AI Engine par son API » (apres\n",
+    "`presenter-ai-engine-par-son-api`). On passe du socle a une\n",
+    "fonctionnalite : le **chatbot**. Dans AI Engine, un chatbot n'est pas un\n",
+    "programme a ecrire : c'est un **document JSON** stocke dans la\n",
+    "configuration du plugin. On le lit, on le duplique, on le modifie — tout\n",
+    "passe par l'API REST `mwai/v1`.\n",
+    "\n",
+    "Ce notebook cree un second chatbot (« comite », un comite de lecture) en\n",
+    "dupliquant la configuration du premier, verifie que l'ecriture est\n",
+    "persistee, puis pose la **meme question** aux deux personas pour mesurer\n",
+    "ce que les instructions changent — et ce qu'elles ne changent pas.\n",
+    "\n",
+    "> Les sorties de ce notebook proviennent d'une execution reelle contre\n",
+    "> l'instance locale (voir « Provenance et limites », en fin de fichier).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a3ec0c2",
+   "metadata": {},
+   "source": [
+    "## La serie « AI Engine par son API »\n",
+    "\n",
+    "Le projet Livres Agites a mis AI Engine au coeur d'une maison d'edition :\n",
+    "bot d'accueil, agents d'ateliers, bibliothecaire documentee par RAG,\n",
+    "formulaires dynamiques. Cette serie presente le plugin de maniere\n",
+    "reproductible — **sans jamais exposer de donnees client** :\n",
+    "\n",
+    "| Notebook | Contenu |\n",
+    "|----------|---------|\n",
+    "| `presenter-ai-engine-par-son-api` | instance, API, catalogue des chatbots, premiere completion |\n",
+    "| `configurer-chatbots-par-l-api` (ce notebook) | lire, dupliquer, ecrire et interroger des chatbots |\n",
+    "| notebooks suivants | RAG/embeddings, agents MCP, formulaires, WooCommerce |\n",
+    "\n",
+    "Trois niveaux de lecture, dans chaque notebook :\n",
+    "\n",
+    "1. **Decouverte** — ce que fait la fonctionnalite, vue par l'API ;\n",
+    "2. **Branchement** — comment on l'a branchee dans le projet ;\n",
+    "3. **Exercice** — reutiliser le pattern sur un cas voisin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d44587ad",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:44:46.416194Z",
+     "iopub.status.busy": "2026-08-14T13:44:46.415689Z",
+     "iopub.status.idle": "2026-08-14T13:44:46.715982Z",
+     "shell.execute_reply": "2026-08-14T13:44:46.714900Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
+      "Base URL : http://localhost:8093\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et helpers. Aucune cle ni adresse de provider n'est stockee\n",
+    "# dans ce fichier : tout vient de instance-jetable/.env (README, etape 5).\n",
+    "\n",
+    "import base64\n",
+    "import os\n",
+    "import re\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Localisation du .env : a cote du notebook (instance-jetable/.env),\n",
+    "# sinon dans le repertoire courant.\n",
+    "charges = []\n",
+    "for candidat in (Path(\"instance-jetable/.env\"), Path(\".env\")):\n",
+    "    if candidat.exists():\n",
+    "        load_dotenv(candidat)\n",
+    "        charges.append(str(candidat))\n",
+    "print(\"Fichiers .env charges :\", charges or \"(aucun)\")\n",
+    "\n",
+    "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
+    "ADMIN_USER = os.getenv(\"VALMONT_ADMIN_USER\", \"\")\n",
+    "APP_PASSWORD = os.getenv(\"VALMONT_APP_PASSWORD\", \"\")\n",
+    "print(\"Base URL :\", BASE_URL)\n",
+    "\n",
+    "\n",
+    "def api(route, method=\"GET\", payload=None):\n",
+    "    \"\"\"Appel REST WordPress. route est relative, ex. '/mwai/v1/ai/completions'.\"\"\"\n",
+    "    url = BASE_URL + \"/wp-json\" + route\n",
+    "    entetes = {\"Content-Type\": \"application/json\"}\n",
+    "    if ADMIN_USER and APP_PASSWORD:\n",
+    "        creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
+    "        entetes[\"Authorization\"] = \"Basic \" + creds\n",
+    "    reponse = requests.request(method, url, headers=entetes, json=payload, timeout=120)\n",
+    "    reponse.raise_for_status()\n",
+    "    return reponse.json()\n",
+    "\n",
+    "\n",
+    "# Normalisation des sorties du modele : les LLM locaux emettent parfois des\n",
+    "# emojis ou du markdown malgre les consignes. On normalise l'affichage par du\n",
+    "# code (jamais de sortie retouchee a la main).\n",
+    "_EMOJIS = re.compile(\n",
+    "    \"[\\U0001F000-\\U0001FAFF\\U00002600-\\U000027BF\\U0001F300-\\U0001F5FF\"\n",
+    "    \"\\U0001F680-\\U0001F6FF\\U0001F900-\\U0001F9FF\\U00002B00-\\U00002BFF\"\n",
+    "    \"\\U0000FE00-\\U0000FE0F]+\",\n",
+    "    re.UNICODE,\n",
+    ")\n",
+    "\n",
+    "def clean_text(texte):\n",
+    "    \"\"\"Retire emojis, symboles markdown et espacements superflus.\"\"\"\n",
+    "    if not isinstance(texte, str):\n",
+    "        return texte\n",
+    "    texte = _EMOJIS.sub(\" \", texte)\n",
+    "    texte = re.sub(r\"[*_#>`~]+\", \" \", texte)\n",
+    "    return re.sub(r\"\\s+\", \" \", texte).strip()\n",
+    "\n",
+    "\n",
+    "def extrait(texte, n=220):\n",
+    "    \"\"\"Extrait court et propre d'une reponse, pour un affichage lisible.\"\"\"\n",
+    "    propre = clean_text(texte)\n",
+    "    if len(propre) <= n:\n",
+    "        return propre\n",
+    "    return propre[:n] + \" [...]\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99ff882b",
+   "metadata": {},
+   "source": [
+    "## Lire un chatbot : un document JSON, deux endpoints\n",
+    "\n",
+    "Deux routes de la famille `settings` se repondent :\n",
+    "\n",
+    "| Route | Verbe | Effet |\n",
+    "|-------|-------|-------|\n",
+    "| `/mwai/v1/settings/chatbots` | GET | lire la liste complete des chatbots |\n",
+    "| `/mwai/v1/settings/chatbots` | POST | **remplacer toute la liste** par celle envoyee |\n",
+    "\n",
+    "La lecture renvoie un document JSON par chatbot : identite (`botId`,\n",
+    "`name`, `aiName`), comportement (`instructions`, `temperature`,\n",
+    "`maxTokens`, `model`), presentation (`startSentence`, `themeId`,\n",
+    "`icon`...) — 54 champs sur cette instance. Les champs sensibles ne sont\n",
+    "jamais affiches : la table ci-dessous est une **allowlist** stricte, et\n",
+    "le secret (`apiKey`) est vide sur les chatbots de cette instance — la cle\n",
+    "vit au niveau de l'**environnement**, pas du chatbot.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d5b81923",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:44:46.719274Z",
+     "iopub.status.busy": "2026-08-14T13:44:46.718755Z",
+     "iopub.status.idle": "2026-08-14T13:44:46.817103Z",
+     "shell.execute_reply": "2026-08-14T13:44:46.816057Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chatbots configures : ['default', 'valmont', 'comite']\n",
+      "Champs par document : 54\n",
+      "\n",
+      "Les 54 cles du document « valmont » :\n",
+      "aiName, apiKey, botId, centerOpen, containerType, contentAware, copyButton, crossSite, embeddingsEnvId, fileUpload, fileUploads, footerType, fullscreen, functions, guestName, headerSubtitle, headerType, historyStrategy, icon, iconAlt, iconBubble, iconPosition, iconText, iconTextDelay, imageUpload, inputType, instructions, localMemory, maxMessages, maxResults, maxTokens, maxUploads, mcpServers, messagesType, mode, model, multiUpload, name, openDelay, pdfButton, scope, startSentence, temperature, textClear, textCompliance, textInputMaxLength, textInputPlaceholder, textSend, themeId, userName, voice, width, window, windowAnimation\n",
+      "\n",
+      "  botId           : default\n",
+      "  name            : Default\n",
+      "  aiName          : AI: \n",
+      "  model           : gpt-5.5\n",
+      "  temperature     : 0.8\n",
+      "  maxTokens       : 4096\n",
+      "  startSentence   : Hi! How can I help you?\n",
+      "\n",
+      "  botId           : valmont\n",
+      "  name            : Valmont\n",
+      "  aiName          : Valmont: \n",
+      "  model           : qwen3.6-35b-a3b\n",
+      "  temperature     : 0.6\n",
+      "  maxTokens       : 1024\n",
+      "  startSentence   : Bonjour, bienvenue a la Maison Valmont. Comment puis-je vous renseigner ?\n",
+      "\n",
+      "  botId           : comite\n",
+      "  name            : Comite de lecture\n",
+      "  aiName          : Comite: \n",
+      "  model           : qwen3.6-35b-a3b\n",
+      "  temperature     : 0.6\n",
+      "  maxTokens       : 1024\n",
+      "  startSentence   : Bonjour. Envoyez-moi un extrait de manuscrit, je le soumets a la grille de lecture.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1. Lire la liste des chatbots : un document JSON par chatbot\n",
+    "bots = api(\"/mwai/v1/settings/chatbots\")[\"chatbots\"]\n",
+    "print(\"Chatbots configures :\", [b[\"botId\"] for b in bots])\n",
+    "print(\"Champs par document :\", len(bots[0]) if bots else 0)\n",
+    "\n",
+    "valmont = next(b for b in bots if b[\"botId\"] == \"valmont\")\n",
+    "print()\n",
+    "print(f\"Les {len(valmont)} cles du document « valmont » :\")\n",
+    "print(\", \".join(sorted(valmont)))\n",
+    "\n",
+    "# Table curatee : allowlist stricte, aucun champ sensible n'est affiche.\n",
+    "CHAMPS_AFFICHES = (\"botId\", \"name\", \"aiName\", \"model\", \"temperature\", \"maxTokens\", \"startSentence\")\n",
+    "for bot in bots:\n",
+    "    print()\n",
+    "    for champ in CHAMPS_AFFICHES:\n",
+    "        print(f\"  {champ:15s} : {bot.get(champ)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d0db5ed",
+   "metadata": {},
+   "source": [
+    "## Ecrire : le POST remplace TOUTE la liste (pattern read-modify-write)\n",
+    "\n",
+    "`POST /settings/chatbots` n'accepte pas « creez-moi un bot » : il attend\n",
+    "la **liste complete** des chatbots, et remplace l'ancienne par la\n",
+    "nouvelle. Pour creer ou modifier un chatbot, il faut donc :\n",
+    "\n",
+    "1. **lire** la liste (GET) ;\n",
+    "2. **modifier une copie en memoire** — ici : dupliquer la configuration\n",
+    "   de `valmont`, puis changer l'identite, la phrase d'accueil et les\n",
+    "   instructions ;\n",
+    "3. **ecrire la liste complete** (POST).\n",
+    "\n",
+    "C'est le pattern **read-modify-write**. En remplacant systematiquement\n",
+    "par `botId` (ni ajouter a la suite, ni dedoubler), l'operation devient\n",
+    "**idempotente** : rejouer la cellule ne cree pas de doublon.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "87645568",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:44:46.820210Z",
+     "iopub.status.busy": "2026-08-14T13:44:46.819680Z",
+     "iopub.status.idle": "2026-08-14T13:44:46.950591Z",
+     "shell.execute_reply": "2026-08-14T13:44:46.949524Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ecriture acceptee : True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chatbots apres ecriture : ['default', 'valmont', 'comite']\n",
+      "instructions persistees : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2. Creer le chatbot « comite » par duplication de valmont (upsert)\n",
+    "def copier_configuration(source, bot_id, name, ai_name, instructions, start_sentence):\n",
+    "    \"\"\"Duplique la config de source ; change l'identite et les instructions.\"\"\"\n",
+    "    config = dict(source)\n",
+    "    config[\"botId\"] = bot_id\n",
+    "    config[\"name\"] = name\n",
+    "    config[\"aiName\"] = ai_name\n",
+    "    config[\"startSentence\"] = start_sentence\n",
+    "    config[\"instructions\"] = instructions\n",
+    "    return config\n",
+    "\n",
+    "INSTRUCTIONS_COMITE = (\n",
+    "    \"Vous etes membre du comite de lecture de la Maison Valmont, maison \"\n",
+    "    \"d'edition de romans feminins. On vous soumet un extrait de manuscrit : \"\n",
+    "    \"repondez en l'evaluant en trois temps - qualites, defauts, \"\n",
+    "    \"recommandation (accepter, retravailler, refuser). Texte brut, francais, \"\n",
+    "    \"sans emoji ni markdown.\"\n",
+    ")\n",
+    "comite = copier_configuration(\n",
+    "    valmont, \"comite\", \"Comite de lecture\", \"Comite: \",\n",
+    "    INSTRUCTIONS_COMITE,\n",
+    "    \"Bonjour. Envoyez-moi un extrait de manuscrit, je le soumets a la grille de lecture.\",\n",
+    ")\n",
+    "\n",
+    "# Read-modify-write : on remplace par botId (idempotent, pas de doublon)\n",
+    "liste = [b for b in bots if b[\"botId\"] != \"comite\"] + [comite]\n",
+    "resultat = api(\"/mwai/v1/settings/chatbots\", method=\"POST\", payload={\"chatbots\": liste})\n",
+    "print(\"Ecriture acceptee :\", resultat.get(\"success\"))\n",
+    "\n",
+    "# Verification par une nouvelle lecture : l'ecriture est bien persistee\n",
+    "apres = api(\"/mwai/v1/settings/chatbots\")[\"chatbots\"]\n",
+    "print(\"Chatbots apres ecriture :\", [b[\"botId\"] for b in apres])\n",
+    "comite_ecrit = next(b for b in apres if b[\"botId\"] == \"comite\")\n",
+    "print(\"instructions persistees :\", comite_ecrit[\"instructions\"] == INSTRUCTIONS_COMITE)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60575478",
+   "metadata": {},
+   "source": [
+    "## Interroger : la meme question a deux personas\n",
+    "\n",
+    "Deux chatbots existent maintenant cote a cote : `valmont`, le\n",
+    "bibliothecaire de la maison, et `comite`, le comite de lecture. On leur\n",
+    "pose **exactement la meme question** — un extrait de manuscrit depose —\n",
+    "et on mesure ce qui sort : le texte (tronque pour l'affichage) et les\n",
+    "tokens.\n",
+    "\n",
+    "Ce que le projet Livres Agites appelle un « persona » est ici un champ\n",
+    "`instructions` dans un document JSON. La question de ce notebook est\n",
+    "donc simple : ce champ change-t-il vraiment la reponse ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "029dd1b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:44:46.955410Z",
+     "iopub.status.busy": "2026-08-14T13:44:46.955410Z",
+     "iopub.status.idle": "2026-08-14T13:46:05.958432Z",
+     "shell.execute_reply": "2026-08-14T13:46:05.957390Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== valmont ===\n",
+      "reponse : Ce début est fonctionnel et efficace . Il remplit les trois fonctions essentielles d'une première phrase : poser un décor, introduire un personnage, et lancer un enjeu. Voici une analyse détaillée : Ce qui fonctionne bien - Immédiateté narrative : Aucune exposition superflue. Le lecteur comprend la situation, les enjeux et le ton en deux phrases. - Économie des moyens : Le manuscrit serré sous le  [...]\n",
+      "tokens  : {'prompt_tokens': 66, 'completion_tokens': 1828, 'total_tokens': 1894}\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== comite ===\n",
+      "reponse : Ce début est efficace et fonctionnel . Il remplit son rôle principal : installer un personnage, un enjeu et une tension narrative dès la première phrase. Voici une analyse détaillée, structurée comme le ferait un éditeur ou un correcteur professionnel : Points forts 1. Immédiateté et enjeux clairs : En deux phrases, on sait qui est Marie, ce qu'elle porte, où elle va, et pourquoi c'est crucial. Le [...]\n",
+      "tokens  : {'prompt_tokens': 66, 'completion_tokens': 2001, 'total_tokens': 2067}\n",
+      "\n",
+      "Mots du debut de comite deja chez valmont : 49/100 (49%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 3. La meme question a valmont et a comite : texte et tokens\n",
+    "question = (\n",
+    "    \"Un auteur vient de deposer ce debut de roman : « Marie remonta la rue \"\n",
+    "    \"enneigee en serrant le manuscrit sous son manteau. Elle savait que la \"\n",
+    "    \"decision du comite deciderait de sa carriere. » Que faites-vous de ce texte ?\"\n",
+    ")\n",
+    "\n",
+    "reponses = {}\n",
+    "for bot_id in (\"valmont\", \"comite\"):\n",
+    "    reponse = api(\"/mwai/v1/ai/completions\", method=\"POST\",\n",
+    "                  payload={\"botId\": bot_id, \"message\": question})\n",
+    "    reponses[bot_id] = reponse\n",
+    "    usage = reponse.get(\"usage\") or {}\n",
+    "    print(\"===\", bot_id, \"===\")\n",
+    "    print(\"reponse :\", extrait(reponse.get(\"data\"), 400))\n",
+    "    print(\"tokens  :\", {k: usage[k] for k in (\"prompt_tokens\", \"completion_tokens\", \"total_tokens\") if k in usage})\n",
+    "    print()\n",
+    "\n",
+    "# Mesure simple de la ressemblance : part des mots du debut de comite\n",
+    "# deja presents dans le debut de valmont (100 premiers mots de chaque).\n",
+    "debut_valmont = set(clean_text(reponses[\"valmont\"].get(\"data\")).split()[:100])\n",
+    "mots_comite = clean_text(reponses[\"comite\"].get(\"data\")).split()[:100]\n",
+    "partage = sum(1 for m in mots_comite if m in debut_valmont)\n",
+    "if mots_comite:\n",
+    "    pct = partage / len(mots_comite)\n",
+    "    print(f\"Mots du debut de comite deja chez valmont : {partage}/{len(mots_comite)} ({pct:.0%})\")\n",
+    "else:\n",
+    "    print(\"comite n'a rien repondu\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26c2d782",
+   "metadata": {},
+   "source": [
+    "## Ce que dit la mesure : les instructions orientent, elles ne garantissent pas\n",
+    "\n",
+    "Comparez les deux extraits ci-dessus. Ce qu'on observe sur cette\n",
+    "instance, execution apres execution : les deux personas repondent par\n",
+    "des **evaluations du texte** — meme nature de reponse, meme outillage\n",
+    "linguistique — et la mesure de vocabulaire partage le chiffre (elle\n",
+    "varie a chaque execution, le LLM est non deterministe). Le persona\n",
+    "change l'angle, la structure, le ton : des differences de **degre**,\n",
+    "pas de nature. Ce n'est pas une demonstration preparee — rejouez la\n",
+    "cellule, vous obtiendrez une autre paire de reponses, et le profil\n",
+    "restera.\n",
+    "\n",
+    "Trois lecons, tirees du chantier Livres Agites :\n",
+    "\n",
+    "1. **Le persona est une ergonomie, pas une frontiere.** Changer\n",
+    "   `instructions` change le contrat de dialogue, pas les capacites du\n",
+    "   modele. Si la difference compte (moderation, filtrage, role\n",
+    "   metier), il faut la **verifier par la mesure**, jamais la supposer —\n",
+    "   c'est la lecon des grains 7-8 de\n",
+    "   [`cadrer-les-agents.md`](../cadrer-les-agents.md).\n",
+    "2. **`maxTokens` du document n'est pas une borne stricte.** Mesure sur\n",
+    "   cette instance : `maxTokens` a 96 dans le JSON du chatbot, le modele\n",
+    "   a produit 3775 tokens. Passe au niveau de la **requete** (champ\n",
+    "   `maxTokens` du POST `/ai/completions`), le plafond est respecte —\n",
+    "   mais la reponse peut alors etre **vide** : un modele a raisonnement\n",
+    "   consomme d'abord son budget de reflexion, et il ne reste rien pour\n",
+    "   le texte visible.\n",
+    "3. **La config se lit et s'ecrit ; le comportement se mesure.** C'est\n",
+    "   la separation qui structure toute la serie : le document JSON est\n",
+    "   deterministe (GET, POST, verification par relecture), la reponse du\n",
+    "   modele ne l'est pas.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c820806b",
+   "metadata": {},
+   "source": [
+    "## Ce qu'on en a fait dans le projet Livres Agites\n",
+    "\n",
+    "Dans le projet d'origine, AI Engine porte six chatbots : Laura (accueil,\n",
+    "documentee par RAG), les quatre agents d'ateliers d'ecriture, et le bot\n",
+    "par defaut. Chacun est un document de configuration de la forme vue\n",
+    "ici — certains avec `contentAware` (RAG) et des fonctions MCP attachees,\n",
+    "d'autres en simple dialogue. Le pattern de ce notebook — lire, dupliquer,\n",
+    "adapter, verifier — est exactement celui utilise pour deriver les\n",
+    "personas les uns des autres (voir `livresagites-parcours.md`, parcours 0 :\n",
+    "module Client).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e6e675c",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices, du plus simple au plus integre. Les fonctions sont a\n",
+    "completer ; `api()`, `clean_text()` et `copier_configuration()` sont\n",
+    "disponibles. Chaque exercice se verifie d'une ligne de test.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e06f0e9f",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — lire la configuration d'un chatbot\n",
+    "\n",
+    "Completez `lire_configuration(bot_id)` : elle retourne le document JSON\n",
+    "du chatbot demande, ou `None` s'il n'existe pas.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "97fd8825",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:46:05.962181Z",
+     "iopub.status.busy": "2026-08-14T13:46:05.961667Z",
+     "iopub.status.idle": "2026-08-14T13:46:05.966431Z",
+     "shell.execute_reply": "2026-08-14T13:46:05.965383Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def lire_configuration(bot_id):\n",
+    "    \"\"\"Retourne le document JSON du chatbot `bot_id`, None s'il est absent.\"\"\"\n",
+    "    # A COMPLETER : GET /mwai/v1/settings/chatbots puis chercher par botId\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebf8405d",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — un upsert idempotent\n",
+    "\n",
+    "Completez `upsert_chatbot(config)` : elle remplace (ou ajoute) le\n",
+    "chatbot `config` dans la liste par `botId` — pattern read-modify-write —\n",
+    "puis retourne la liste des `botId` apres ecriture.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "35f0c8a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:46:05.970086Z",
+     "iopub.status.busy": "2026-08-14T13:46:05.969285Z",
+     "iopub.status.idle": "2026-08-14T13:46:05.974497Z",
+     "shell.execute_reply": "2026-08-14T13:46:05.973449Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def upsert_chatbot(config):\n",
+    "    \"\"\"Upsert de `config` par botId ; retourne la liste des botId apres ecriture.\"\"\"\n",
+    "    # A COMPLETER : lire la liste, remplacer par botId, POST la liste complete, relire\n",
+    "    return []\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "287c1963",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — dupliquer un persona\n",
+    "\n",
+    "Completez `dupliquer_persona(source_bot_id, nouveau_bot_id,\n",
+    "instructions)` : elle duplique la configuration de `source_bot_id`,\n",
+    "change le `botId` et les `instructions`, persiste le nouveau chatbot et\n",
+    "retourne son document. Si la source n'existe pas, retourner `None`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "83718a9b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-14T13:46:05.977784Z",
+     "iopub.status.busy": "2026-08-14T13:46:05.977223Z",
+     "iopub.status.idle": "2026-08-14T13:46:05.982769Z",
+     "shell.execute_reply": "2026-08-14T13:46:05.981653Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def dupliquer_persona(source_bot_id, nouveau_bot_id, instructions):\n",
+    "    \"\"\"Cree un nouveau chatbot par duplication de `source_bot_id`.\"\"\"\n",
+    "    # A COMPLETER : lire_configuration + copier_configuration + upsert_chatbot\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b837064",
+   "metadata": {},
+   "source": [
+    "## Provenance et limites\n",
+    "\n",
+    "- **Instance testee** : `http://localhost:8093`, montee via\n",
+    "  `instance-jetable/docker-compose.jetable.example.yml`, AI Engine 3.7.0\n",
+    "  (version gratuite, wordpress.org), corpus synthetique « Maison Valmont ».\n",
+    "- **Provider** : LLM local compatible OpenAI — l'adresse et la cle\n",
+    "  restent dans `.env`, jamais dans ce notebook.\n",
+    "- **Sorties commitees** : executions reelles contre l'instance. Les\n",
+    "  reponses d'un LLM sont non deterministes : votre execution peut\n",
+    "  differer — c'est normal, et c'est le sujet de ce notebook.\n",
+    "- **Endpoints verifies ici (firsthand)** : GET et POST\n",
+    "  `/mwai/v1/settings/chatbots`, POST `/mwai/v1/ai/completions`.\n",
+    "- **Mesures citees** : difference partielle des personas — structure de\n",
+    "  reponse distincte mais vocabulaire en partie partage (la mesure\n",
+    "  precise, dans le notebook, varie a chaque execution) ; `maxTokens`\n",
+    "  de config non borne a l'execution (96 -> 3775 tokens) ; `maxTokens`\n",
+    "  de requete borne mais reponse vide possible (128 tokens, 0 caractere\n",
+    "  visible) — modele a raisonnement.\n",
+    "- **Redaction** : la table de lecture est une allowlist stricte ;\n",
+    "  `apiKey` et les champs d'environnement ne sont jamais affiches.\n",
+    "- **Frontieres** : pas de donnees client, pas de secret, pas d'IP de\n",
+    "  provider — regles du chantier CoursIA.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -83,6 +83,20 @@ Deux conséquences pratiques :
 > avec un accent sur le sous-ensemble écriture (le double-écrit, risque réel
 > même sous un chevauchement global faible).
 
+> **Notebook compagnon (module Client).**
+> [`configurer-chatbots-par-l-api.ipynb`](configurer-chatbots-par-l-api.ipynb)
+> ouvre la face exécutable du module Chatbot : dans AI-Engine, un chatbot
+> est un **document JSON** (54 champs — identité, instructions, modèle,
+> présentation) que l'API REST lit et réécrit. Le `POST
+> /mwai/v1/settings/chatbots` **remplace toute la liste**, d'où le
+> pattern read-modify-write pour créer ou modifier un bot. Le notebook
+> duplique le chatbot d'accueil d'une maison synthétique (Maison Valmont)
+> en comité de lecture, vérifie la persistance par relecture, puis pose la
+> même question aux deux personas et **mesure** leur recouvrement
+> lexical : les instructions orientent la réponse, elles ne la garantissent
+> pas. Exécuté contre l'instance jetable locale (`instance-jetable/`),
+> corpus 100 % synthétique, aucun contenu privé.
+
 ---
 
 ## Parcours 1 — Copilot pour l'éditeur WordPress


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #10917

**Quoi:** 2e notebook de la série « AI Engine par son API » (socle : #10917) : `configurer-chatbots-par-l-api.ipynb`. Dans AI-Engine, un chatbot n'est pas un programme : c'est un **document JSON** (54 champs — identité, instructions, modèle, présentation). Le notebook démontre le cycle complet par l'API REST : lecture (GET `/mwai/v1/settings/chatbots`), écriture read-modify-write (le POST **remplace toute la liste** — duplication de `valmont` en comité de lecture par upsert `botId`, idempotent), vérification de persistance par relecture, interrogation (`/ai/completions`), puis **mesure honnête** : même question aux deux personas, recouvrement lexical des 100 premiers mots — les instructions **orientent** la réponse, elles ne la garantissent pas (lien grains 7-8 `cadrer-les-agents.md`). Caveats mesurés firsthand : `maxTokens` de config non borné (96 → 3775 tokens) ; `maxTokens` de requête borné mais réponse vide possible (modèle à raisonnement). README du dossier + bloc compagnon module Client dans `livresagites-parcours.md` (la série y est décrite, couvrant aussi le grain 1).

**Preuve:** Exécuté avec le kernel `coursia-sae`, 19 cellules dont 7 code, 0 erreur, toutes `execution_count` renseignés. HEAD testé `a37095f97` (rebase sur main post-merge #10917 ; contenu identique au commit d'origine `060fb7e5e`). Sorties réelles contre l'instance jetable (localhost:8093, up vérifié : HTTP 200, 3 conteneurs `valmont-*`) : 3 chatbots listés (default/valmont/comite, 54 champs chacun), POST accepté + instructions persistées True, complétions réelles (valmont 1828 / comite 2001 tokens de sortie), recouvrement 49/100. Affichage en allowlist stricte (`apiKey` jamais affiché). 3 exercices à stubs (`lire_configuration`, `upsert_chatbot`, `dupliquer_persona`). Gates locaux au commit : gitleaks, H.3, papermill-path-scrub, markdown-defects — tous Passed. Scan : 0 cyrillique/grec, 0 emoji, 0 secret, 0 terme client, LF.

**Périmètre:** 1 notebook nouveau + paragraphe série + 2 entrées « Voir aussi » dans `README.md` + bloc compagnon (Parcours 0, module Client) dans `livresagites-parcours.md`. Genre `MED/notebook-python`, domaine-cœur (série présentation AI-Engine, mandat user 14 août). Frontière sécurité tenue : instance jetable dédiée uniquement, corpus 100 % synthétique Maison Valmont, credentials via `.env` jamais commité (gitignored, vérifié), sorties normalisées par code jamais retouchées à la main.

**Empilement:** la branche est basée sur `grain/10913-presentation-ai-engine` (#10917, non mergée à l'ouverture, **mergée depuis** à 13 h 30 UTC — le diff est désormais propre). Le diff propre à ce grain est le commit `a37095f97` seul (1 notebook + 2 .md).

**Transparence G-VAR-3 :** 7e `MED/notebook-python` consécutif livré sur la lane (#10495 → #10530 → #10620 → #10698 → #10787 → #10917 mergés, celui-ci). Substance distincte à chaque fois ; ici le premier grain de la série à **écrire** par l'API (read-modify-write d'un document de configuration, idempotence, vérification de persistance) — les précédents lisaient ou travaillaient sur fixtures stdlib. Litmus LIGHT négatif : le pattern upsert + la mesure de convergence ne sont pas générables en scannant un livrable voisin. Si le coordinateur préfère casser la série, je prends un grain de remplacement (`docs` ou `guard`).

Closes #10947
