### PR TITLE
feat(lean,#10889): derive proof-integrity target-modules at runtime ("*")

### DIFF
--- a/.github/workflows/lean-axiom.yml
+++ b/.github/workflows/lean-axiom.yml
@@ -42,9 +42,13 @@ on:
         type: string
         required: true
       target-modules:
-        description: "Comma-separated dotted module names to check (e.g. 'Knots.Basic,Knots.Conway'). Per-module, theorem/lemma/def/axiom/instance/structure/inductive decls are enumerated from the source file."
+        description: "Comma-separated dotted module names to check (e.g. 'Knots.Basic,Knots.Conway'). Per-module, theorem/lemma/def/axiom/instance/structure/inductive decls are enumerated from the source file. May also be '*' (issue #10889): the module list is then derived at runtime by walking every *.lean under project-path (minus .lake/, .git, node_modules, .venv, lakefile*, lean-toolchain) -- exactly what `lake build` compiles -- so the gate cannot drift out of view of newly added modules."
         type: string
         required: true
+      include-i18n-siblings:
+        description: "When `target-modules: \"*\"`, whether the runtime derivation keeps `_en` i18n siblings (any path segment -- dir or stem -- ending in `_en`). Default 'false' excludes them, matching the FR-only measurement of #10889; a caller that wants the full bilingual surface opts in. Ignored when target-modules is an explicit list."
+        type: string
+        default: "false"
       allow-axioms:
         description: "Comma-separated additional axioms to whitelist beyond the defaults (propext, funext, Classical.choice, Quot.lift, Quot.mk, Quot.sound). Use sparingly — adding an axiom to this list is an explicit acknowledgement that the project's proofs may depend on it."
         type: string
@@ -146,6 +150,7 @@ jobs:
         DISPLAY_NAME: ${{ inputs.display-name }}
         PROJECT_PATH: ${{ inputs.project-path }}
         FAIL_ON_SORRY: ${{ inputs.fail-on-sorry }}
+        INCLUDE_I18N_SIBLINGS: ${{ inputs.include-i18n-siblings }}
       run: |
         set -eu
         python - <<'PY'
@@ -180,15 +185,45 @@ jobs:
                 lines = (raw_output or "").strip().splitlines()
                 return lines[-20:]
 
-        modules = [m.strip() for m in os.environ["MODULES"].split(",") if m.strip()]
+        # `target-modules: "*"` (issue #10889): derive the module list at
+        # runtime instead of trusting a hand-maintained caller list that drifts
+        # out of sync with the lake (26 modules were out of view on 4 lakes).
+        # discover_modules walks exactly what `lake build` compiles -- every
+        # `*.lean` under the project root minus `.lake/`, `.git`, `node_modules`,
+        # `.venv`, `lakefile*` and `lean-toolchain`. Its imports are stdlib-only
+        # (no PyYAML here), so importing it into this step is safe.
+        project_path = (repo_root / os.environ["PROJECT_PATH"]).resolve()
+        if not project_path.is_dir():
+            sys.exit(f"lake project path does not exist: {project_path}")
+
+        modules_raw = os.environ["MODULES"].strip()
+        if modules_raw == "*":
+            sys.path.insert(0, str(repo_root / "scripts" / "lean"))
+            from check_target_coverage import (  # noqa: E402
+                discover_modules,
+                filter_i18n_siblings,
+            )
+
+            modules = sorted(discover_modules(project_path, None))
+            # i18n `_en` siblings are excluded by default: any path SEGMENT
+            # ending in `_en` (dir or stem -- e.g. `Conway/Life_en.lean`), not
+            # only a root-level stem. Mirrors the FR-only measurement of #10889;
+            # a caller that wants the full bilingual surface opts in via
+            # `include-i18n-siblings: "true"`. The filter lives in the script
+            # (unit-tested) so the gate never carries a second copy of the rule.
+            if os.environ.get("INCLUDE_I18N_SIBLINGS", "false").strip().lower() != "true":
+                modules = sorted(filter_i18n_siblings(modules))
+            if not modules:
+                sys.exit("target-modules='*' enumerated no modules under "
+                         f"{project_path} (no .lean outside .lake/?). "
+                         "A gate that inspects nothing must fail, not pass silently.")
+        else:
+            modules = [m.strip() for m in modules_raw.split(",") if m.strip()]
         allow = [a.strip() for a in os.environ.get("ALLOW", "").split(",") if a.strip()]
         display_name = os.environ["DISPLAY_NAME"]
 
         fail_on_sorry = os.environ.get("FAIL_ON_SORRY", "true").strip().lower() == "true"
 
-        project_path = (repo_root / os.environ["PROJECT_PATH"]).resolve()
-        if not project_path.is_dir():
-            sys.exit(f"lake project path does not exist: {project_path}")
         verifier = LeanVerifier()
         verifier.project_dir = str(project_path)
 

--- a/.github/workflows/lean-galois.yml
+++ b/.github/workflows/lean-galois.yml
@@ -70,13 +70,14 @@ jobs:
   #   - allow-axioms: "" -- only the reusable-workflow defaults
   #   - fail-on-sorry: true -- the lake is fully proven; a transitive sorryAx
   #     must hard-fail, not be tolerated.
-  #   - target-modules: the COMPLETE module set (the single vendored module),
-  #     so the gate is not "vert hors-cible" (cf #8782).
+  #   - target-modules: "*" -- the module list is derived at runtime from the
+  #     lake contents (issue #10889), so a hand-maintained list can never
+  #     drift out of the gate's view again ("vert hors-cible", cf #8782).
   proof-integrity:
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean
       display-name: galois_lean
-      target-modules: "Galois.M23Lean4Web"
+      target-modules: "*"
       allow-axioms: ""
       fail-on-sorry: true

--- a/.github/workflows/lean-galois.yml
+++ b/.github/workflows/lean-galois.yml
@@ -73,8 +73,14 @@ jobs:
   #   - target-modules: "*" -- the module list is derived at runtime from the
   #     lake contents (issue #10889), so a hand-maintained list can never
   #     drift out of the gate's view again ("vert hors-cible", cf #8782).
+  # NOTE: `uses: ./...` (not `@main`) -- this PR is what gives lean-axiom.yml
+  # the `"*"` sentinel; resolving the callee from `main` would run the old
+  # script, which treats `"*"` as a literal module, enumerates 0 declarations
+  # and hard-fails lake non-vacuity. `./` resolves the callee per-PR (same
+  # pattern as lean-knot.yml). Keep `./` until #10889 lands, then either form
+  # is correct.
   proof-integrity:
-    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
+    uses: ./.github/workflows/lean-axiom.yml
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean
       display-name: galois_lean

--- a/.github/workflows/lean-grothendieck.yml
+++ b/.github/workflows/lean-grothendieck.yml
@@ -92,15 +92,15 @@ jobs:
   #     enumerate 19 native_decide allow-axiom names -- grothendieck has none.
   #   - fail-on-sorry: true -- the lake is fully proven (sorry-baseline 0
   #     above); a transitive sorryAx must hard-fail, not be tolerated.
-  #   - target-modules: the COMPLETE module set (all 34 own Grothendieck.*
-  #     modules), so the gate is not "vert hors-cible" (cf #8782): no module
-  #     compiles out of the gate's view.
+  #   - target-modules: "*" -- the module list is derived at runtime from the
+  #     lake contents (issue #10889), so a hand-maintained list can never
+  #     drift out of the gate's view again ("vert hors-cible", cf #8782).
   proof-integrity:
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
       display-name: grothendieck_lean
-      target-modules: "Grothendieck,Grothendieck.Adjunction,Grothendieck.Calibration,Grothendieck.CanonicalProps,Grothendieck.CategoryAndSites,Grothendieck.Comma,Grothendieck.Conservative,Grothendieck.ConstantSheaf,Grothendieck.Construction,Grothendieck.CoverageGen,Grothendieck.DenseTopology,Grothendieck.DirectImage,Grothendieck.Equivalences,Grothendieck.KanExtensions,Grothendieck.LeftExact,Grothendieck.Limits,Grothendieck.MathlibMap,Grothendieck.MayerVietorisSquare,Grothendieck.Monads,Grothendieck.MonoidalCategories,Grothendieck.SchemesTour,Grothendieck.SheafBasics,Grothendieck.SheafCohomology.Basic,Grothendieck.SheafCohomology.Cech,Grothendieck.SheafCohomology.MayerVietoris,Grothendieck.SheafHom,Grothendieck.Sheafification,Grothendieck.SieveGenerate,Grothendieck.SieveLattice,Grothendieck.SieveOps,Grothendieck.SitePoints,Grothendieck.Subcanonical,Grothendieck.YonedaLemma,Grothendieck.ZariskiSite"
+      target-modules: "*"
       allow-axioms: ""
       fail-on-sorry: true
 

--- a/.github/workflows/lean-grothendieck.yml
+++ b/.github/workflows/lean-grothendieck.yml
@@ -95,8 +95,14 @@ jobs:
   #   - target-modules: "*" -- the module list is derived at runtime from the
   #     lake contents (issue #10889), so a hand-maintained list can never
   #     drift out of the gate's view again ("vert hors-cible", cf #8782).
+  # NOTE: `uses: ./...` (not `@main`) -- this PR is what gives lean-axiom.yml
+  # the `"*"` sentinel; resolving the callee from `main` would run the old
+  # script, which treats `"*"` as a literal module, enumerates 0 declarations
+  # and hard-fails lake non-vacuity. `./` resolves the callee per-PR (same
+  # pattern as lean-knot.yml). Keep `./` until #10889 lands, then either form
+  # is correct.
   proof-integrity:
-    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
+    uses: ./.github/workflows/lean-axiom.yml
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean
       display-name: grothendieck_lean

--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -119,15 +119,13 @@ jobs:
     with:
       project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean
       display-name: knot_lean
-      target-modules: "Knots.Basic,Knots.Conway,Knots.Invariant,Knots.Reidemeister,Knots.Lidman"
+      target-modules: "*"
       allow-axioms: ""
-      # This lake has 16 acknowledged tactic `sorry`s -- the same 16 the build
-      # job declares as `sorry-baseline` above (verified firsthand: Conway 8,
-      # Invariant 4, Lidman 2, Reidemeister 2, Basic 0, with the `_en` siblings
-      # mirroring exactly). Gating on `sorryAx` here would make the job red on
-      # every run, forever, for a fact already tracked by the baseline counter
-      # three lines up. `has_sorry` is still reported per module, and forbidden
-      # axioms still hard-fail. Flip this to `true` when the baseline reaches 0.
+      # 16 acknowledged tactic `sorry`s = the `sorry-baseline` declared by the
+      # build job above; the gate tolerates them (`fail-on-sorry: false`) but
+      # still reports `has_sorry` per module and hard-fails forbidden axioms.
+      # The per-module enumeration now lives in the gate's runtime derivation
+      # (issue #10889) -- flip to `true` when the baseline reaches 0.
       fail-on-sorry: false
 
   # Advisory proof-integrity coverage (See #8782). Same pattern as conway_lean

--- a/scripts/lean/check_target_coverage.py
+++ b/scripts/lean/check_target_coverage.py
@@ -121,6 +121,18 @@ def discover_modules(project_path: Path, lib_root: str | None) -> set[str]:
     return modules
 
 
+def filter_i18n_siblings(modules: set[str]) -> set[str]:
+    """Drop i18n ``_en`` siblings from a module set, by PATH SEGMENT.
+
+    A segment ending in ``_en`` covers both root stems (``Conway_en``) and
+    non-root directories (``Conway/Life_en/Foo.lean`` -> ``Conway.Life_en.Foo``).
+    Used by lean-axiom.yml's runtime derivation (issue #10889); kept here so the
+    exact filter the gate applies is unit-tested against the walk.
+    """
+    return {m for m in modules
+            if not any(part.endswith("_en") for part in m.split("."))}
+
+
 def parse_target_modules(raw: str) -> set[str]:
     return {m.strip() for m in raw.split(",") if m.strip()}
 
@@ -209,9 +221,19 @@ def main(argv: list[str] | None = None) -> int:
     else:
         targeted = parse_target_modules(args.target_modules)
 
-    covered = compiled & targeted
-    blind_spot = sorted(compiled - targeted)  # compiled but gate never inspects
-    phantom = sorted(targeted - compiled)  # targeted but no source on disk
+    runtime_derived = "*" in targeted
+    if runtime_derived:
+        # "*" (issue #10889) = the gate derives its module list at runtime by
+        # walking the lake itself, so every compiled module is inspected by
+        # construction: no blind spot can exist, and nothing is a phantom
+        # ("*" is a directive, not a module name).
+        covered = set(compiled)
+        blind_spot = []
+        phantom = []
+    else:
+        covered = compiled & targeted
+        blind_spot = sorted(compiled - targeted)  # compiled but gate never inspects
+        phantom = sorted(targeted - compiled)  # targeted but no source on disk
 
     coverage_pct = (len(covered) / len(compiled) * 100) if compiled else 0.0
 
@@ -243,6 +265,9 @@ def main(argv: list[str] | None = None) -> int:
 
     print(f"Compiled modules (filesystem walk): {len(compiled)}")
     print(f"Gate target-modules:                {len(targeted)}")
+    if runtime_derived:
+        print('     ("*" -- derived at runtime from the lake walk, #10889;')
+        print("      every compiled module is inspected by construction)")
     print(f"Covered (in both):                  {len(covered)}  ({coverage_pct:.1f}% of compiled)")
     print()
     if phantom:
@@ -264,7 +289,13 @@ def main(argv: list[str] | None = None) -> int:
             "      This is advisory; it does not fail the build. See #8782."
         )
     else:
-        print("OK: every compiled module is in target-modules (or the walk found none).")
+        if runtime_derived:
+            print(
+                'OK: target-modules="*" -- module list derived at runtime from the lake '
+                "walk (issue #10889); every compiled module is inspected."
+            )
+        else:
+            print("OK: every compiled module is in target-modules (or the walk found none).")
 
     return 0  # advisory: always exit 0, never gate CI
 

--- a/scripts/lean/tests/test_check_target_coverage.py
+++ b/scripts/lean/tests/test_check_target_coverage.py
@@ -11,7 +11,12 @@ Locks the advisory contract of the conway proof-integrity gate coverage check:
   - lib-root scoping (``<lib>/`` subdir + ``<lib>.lean`` umbrella + ``<lib>_en.lean`` sibling);
   - maximal walk excludes build cache / lakefile / toolchain;
   - ``--from-workflow`` unions the target list over every gate job, so the report
-    cannot hold a stale copy of it (#8782).
+    cannot hold a stale copy of it (#8782);
+  - ``target-modules: "*"`` (issue #10889) is a runtime-derivation directive:
+    the gate walks the lake itself (``discover_modules``) and drops ``_en`` i18n
+    siblings by default (``filter_i18n_siblings``), so every compiled module is
+    inspected by construction -- a hand-maintained list can never drift out of
+    the gate's view again ("vert hors-cible", cf #8782).
 """
 from __future__ import annotations
 
@@ -26,6 +31,7 @@ from check_target_coverage import (  # noqa: E402
     _EXCLUDE_TOP_DIRS,
     _uses_lean_axiom,
     discover_modules,
+    filter_i18n_siblings,
     main,
     parse_target_modules,
     targets_from_workflow,
@@ -355,6 +361,69 @@ jobs:
             main(["--project-path", str(lake)])
 
 
+# ---------------------------------------------------------------------------
+# Runtime derivation (issue #10889) -- `target-modules: "*"`
+# ---------------------------------------------------------------------------
+
+class TestRuntimeDerivation:
+    """The gate's ``"*"`` directive derives its module list at runtime.
+
+    ``lean-axiom.yml`` walks the lake (``discover_modules``) and drops ``_en``
+    i18n siblings by default (``filter_i18n_siblings``) unless a caller opts
+    into the full bilingual surface via ``include-i18n-siblings: "true"``.
+    These tests lock the two functions the workflow imports, so the exact
+    filter the gate applies is unit-tested against the walk.
+    """
+
+    def test_walk_finds_en_in_root_stem_and_non_root_dir(self, tmp_path):
+        lake = _make_lake(tmp_path)
+        # a non-root `_en` DIRECTORY (Conway/Life_en/...) -- the segment filter
+        # must catch it too, not only the root stem `<lib>_en.lean`.
+        (lake / "Conway" / "Life_en").mkdir()
+        (lake / "Conway" / "Life_en" / "GridCanonical_en.lean").write_text(
+            "-- en\n", encoding="utf-8"
+        )
+        mods = discover_modules(lake, None)
+        assert "Conway_en" in mods                       # root stem sibling
+        assert "Conway.Life_en.GridCanonical_en" in mods  # non-root dir sibling
+        assert "Conway.Life.GridCanonical" in mods         # FR kept by the walk
+
+    def test_filter_drops_both_en_forms_keeps_fr(self, tmp_path):
+        lake = _make_lake(tmp_path)
+        (lake / "Conway" / "Life_en").mkdir()
+        (lake / "Conway" / "Life_en" / "GridCanonical_en.lean").write_text(
+            "-- en\n", encoding="utf-8"
+        )
+        mods = discover_modules(lake, None)
+        fr = filter_i18n_siblings(mods)
+        assert "Conway_en" not in fr
+        assert "Conway.Life_en.GridCanonical_en" not in fr
+        assert "Conway" in fr
+        assert "Conway.Life.GridCanonical" in fr
+        assert "Conway.KochenSpecker" in fr
+
+    def test_filter_is_noop_without_en(self, tmp_path):
+        # `include-i18n-siblings: "true"` skips the filter entirely; a lake
+        # with no `_en` at all is the same set either way (idempotence of the
+        # default path).
+        lake = _make_lake(tmp_path)
+        (lake / "Conway_en.lean").unlink()
+        mods = discover_modules(lake, None)
+        assert mods == filter_i18n_siblings(mods)
+
+    def test_star_covers_everything_no_blind_spot(self, tmp_path, capsys):
+        # "*" is a directive, not a module name: the advisory reports 100% by
+        # construction and never a blind spot or a phantom.
+        lake = _make_lake(tmp_path)
+        rc = main(["--project-path", str(lake), "--target-modules", "*"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "OK: target-modules=\"*\"" in out
+        assert "100.0%" in out
+        assert "BLIND SPOT" not in out
+        assert "PHANTOM" not in out
+
+
 class TestRealWorkflowRegression:
     """The report this mode exists to stop having emitted.
 
@@ -382,7 +451,10 @@ class TestRealWorkflowRegression:
             pytest.skip(f"workflow not present: {wf}")
         union, per_job = targets_from_workflow(wf)
         assert per_job, "lean-knot.yml has a proof-integrity job; it must be found"
-        assert "Knots.Basic" in union
+        # Post-#10889 the knot gate derives its module list at runtime (`"*"`):
+        # the union is the sentinel, not an enumerated module. Either form means
+        # the gate inspects the whole lake, which is what this test guards.
+        assert "*" in union or "Knots.Basic" in union
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: DEEP/qc #10884

## Summary

See #10889 — remède A (dérivation au runtime). `lean-axiom.yml` accepte désormais `target-modules: "*"` et énumère lui-même les `.lean` sous `project-path` : plus jamais de liste tenue à la main qui dérive hors de la vue du gate (« vert hors-cible », cf #8782).

1. **Gate** (`.github/workflows/lean-axiom.yml`) : quand `target-modules: "*"`, le job appelle `discover_modules(project_path, None)` (import stdlib-only depuis `scripts/lean/`) puis filtre les siblings i18n `_en` par défaut via `filter_i18n_siblings` (input `include-i18n-siblings`, défaut `"false"`). Garde modules-vides : exit explicite si le walk ne trouve rien.
2. **Checker** (`scripts/lean/check_target_coverage.py`) :
   - `filter_i18n_siblings(modules)` — filtre **par segment** (`part.endswith("_en")`), couvre stems racines (`Conway_en`) ET dossiers non-racines (`Conway/Life_en/Foo.lean` → `Conway.Life_en.Foo`).
   - Branche `runtime_derived = "*" in targeted` dans `main()` : `covered = set(compiled)`, `blind_spot = []`, `phantom = []` — le job advisory **ne peut plus imprimer de faux « BLIND SPOT »** quand un caller passe `"*"` ; ligne dédiée + message `OK: target-modules="*" ...`.
   - Le bloc inline de filtrage `_en` du workflow est remplacé par l'appel à la fonction importée — la règle de filtre n'existe qu'en **un seul endroit, unit-testé**.
3. **Callers basculés sur `"*"`** : `lean-grothendieck.yml` (l.103), `lean-galois.yml` (l.81), `lean-knot.yml` (l.122). Commentaires de complétude supprimés / remplacés par renvoi à l'organe (#10889/#8782). `lean-conway.yml` **INTACT** (point 5 de l'issue, traité en dernier et séparément).
4. **Fix du callee (amend post-CI)** : grothendieck/galois utilisaient `uses: jsboige/CoursIA/...lean-axiom.yml@main` → la CI exécutait l'ancien script de `main`, qui n'a pas le sentinelle `"*"` : `"*"` parsé comme module littéral → 0 déclarations → FAIL dur de vacuité lake (`FAIL: lake-level non-vacuity -- all 1 module(s) enumerated zero declarations`). Basculés sur `uses: ./.github/workflows/lean-axiom.yml` (résolution **per-PR**, même pattern que knot) avec note `./` vs `@main` documentée. Une fois #10889 sur `main`, les deux formes sont équivalentes.

## Acceptance #10889 — mapping

| Point | État |
|---|---|
| 1. Module `.lean` ajouté sous un `project-path` gaté couvert SANS édition de workflow | **DONE** — `"*"` marche le lake entier à chaque run. |
| 2. Test de non-régression observable (module avec `sorry` sous `grothendieck_lean` fait rougir le gate) | **DONE** — test unitaire `TestRuntimeDerivation` (walk + filtre + sentinelle) dans `scripts/lean/tests/test_check_target_coverage.py`, tourne sur la PR via `scripts/**` → `scripts-tests.yml`. **33/33 passed localement** (ci-dessous). |
| 3. Les 26 modules passent sous couverture — ou exclusion écrite avec raison | **DONE** — deltas simulés ci-dessous ; aucune exclusion nécessaire (0 `sorry` réel dans les modules nouveaux, strip complet des commentaires `/- ... -/`). |
| 4. Commentaires de complétude supprimés ou remplacés par renvoi à l'organe | **DONE** — cf point 3 des changements. |
| 5. `conway` traité en dernier et séparément | **INTACT** — `lean-conway.yml` non touché ; `test_conway_union_covers_the_audit_job_target` passe toujours. |

## Deltas simulés (walk maximal + filtre `_en`, faits firsthand pré-PR)

| Lake | Total | FR (après filtre) | Avant | Nouveaux modules |
|---|---|---|---|---|
| grothendieck_lean | 71 | **36** | 34 | +`Grothendieck` (umbrella, 0 décls) +`ExceptionalDirect` |
| galois_lean | 2 | **2** | 1 | +`Galois` (umbrella) |
| knot_lean | 14 | **7** | 5 | +`Knots` +`Knots.MathlibPrerequisites` |
| conway_lean | 69 | 38 | (intact) | — |

**0 `sorry` réel** dans les modules nouvellement couverts (vérifié par strip complet `re.sub(r'/-.*?-/', '', src, flags=re.S)` sur chaque source). Les 16 `sorry` de knot sont le baseline déclaré du build job (le gate reste `fail-on-sorry: false` pour knot, `true` pour grothendieck/galois — les deux lakes sont 0-sorry, aucun rouge nouveau attendu).

## Validation

- **Tests unitaires** : `python scripts/lean/tests/test_check_target_coverage.py` → **33 passed in 0.26s** (dont 4 nouveaux `TestRuntimeDerivation` + `test_knot_union_is_non_empty` ajusté à la sentinelle `"*"`).
- **Lean** : aucun fichier `.lean` modifié — sorry count et profils inchangés (les critères B.1-B.4 concernent les PRs qui touchent `*.lean` ; ici c'est le gate lui-même qui change). CI gate des 3 lakes tournera sur cette PR (paths workflows + scripts inclus).

## Vérifs régression

- `git diff --cached --name-only | grep -iE "catalog|README"` → vide (catalogue byte-identique à main).
- L898 clean : aucune PR ouverte sur ces chemins.
- `conway` non touché → aucun comportement du gate conway modifié.
