### PR TITLE
fix(ml,#10956): verdict #10228 relu — loss_fn=linear compare des BIAIS, pas des precisions (docstring + tests)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py
@@ -85,12 +85,14 @@ def diebold_mariano_test(
         Forecast errors from model B (1-D), same length as errors_a.
     loss_fn : str
         "mse" for squared-error loss, "mae" for absolute-error loss,
-        "linear" for signed linear loss L(e) = e. Only "linear" is
-        sign-sensitive: mse and mae are symmetric ((-r)**2 == r**2 and
-        |-r| == |r|), so a forecast and its exact opposite are
-        bit-identical under mse/mae. Use "linear" when the sign of the
-        error carries information (e.g. forecasting returns rather than
-        volatility) -- see #10228.
+        "linear" for signed linear loss L(e) = e.
+        mse/mae measure PRECISION and are symmetric in sign: a forecast-error
+        series and its exact opposite are bit-identical (equally precise), by
+        construction. "linear" computes d_mean = mean(e_a) - mean(e_b) =
+        bias_a - bias_b: it compares BIASES, not precision -- it is blind to
+        dispersion, and a strictly more precise forecast can lose the test to
+        a more biased one (#10956). Do NOT use "linear" as the precision jambe
+        of a verdict; it is a bias-differential diagnostic only.
     hln_correction : bool
         Apply Harvey-Leybourne-Newbold (1997) small-sample correction.
     max_lag : int | None
@@ -121,9 +123,10 @@ def diebold_mariano_test(
         loss_a = np.abs(errors_a)
         loss_b = np.abs(errors_b)
     elif loss_fn == "linear":
-        # Signed linear loss L(e) = e. Unlike mse/mae (symmetric), linear
-        # preserves the sign of the error: it is the only option that lets the
-        # DM test tell a winning forecast from its exact opposite (#10228).
+        # Signed linear loss L(e) = e. d_mean = mean(e_a) - mean(e_b) is a
+        # BIAS differential (bias_a - bias_b), not a precision measure: blind
+        # to dispersion, a strictly more precise forecast can lose to a more
+        # biased one (#10956). Bias diagnostic only -- not a §C precision jambe.
         loss_a = errors_a
         loss_b = errors_b
     else:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/test_dm.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/test_dm.py
@@ -95,12 +95,13 @@ class TestDieboldMarianoTest:
             diebold_mariano_test(np.ones(50), np.ones(50), loss_fn="rmse")
 
     def test_linear_loss_distinguishes_opposite_series(self):
-        """Regression #10228: mse loss is sign-blind.
+        """Regression #10228 relue (#10956): linear distinguishes e from -e.
 
-        A forecast-error series and its exact opposite are bit-identical
-        under mse (squaring cancels the sign), so the DM test cannot tell a
-        winning forecast from a losing one. Only the signed linear loss
-        L(e) = e restores sign-sensitivity.
+        Under mse, a forecast-error series and its exact opposite are
+        bit-identical -- correct behavior: the two are equally precise. Under
+        linear, d_mean = bias_a - bias_b gives them opposite signs, but that
+        sign is a BIAS statement, not a precision statement (linear is blind
+        to dispersion; see test_linear_loss_is_bias_differential).
         """
         rng2 = np.random.default_rng(7)
         e = rng2.normal(0.5, 1.0, 500)  # nonzero mean so d_mean != 0
@@ -114,6 +115,48 @@ class TestDieboldMarianoTest:
         r_lin_neg = diebold_mariano_test(-e, zero, loss_fn="linear")
         assert r_lin_pos.dm_statistic != pytest.approx(r_lin_neg.dm_statistic)
         assert r_lin_pos.dm_statistic * r_lin_neg.dm_statistic < 0
+
+    def test_linear_loss_is_bias_differential(self):
+        """Regression #10956: d_mean = bias_a - bias_b, blind to dispersion.
+
+        Model A (MSE ~0.009, bias ~0) vs baseline B (MSE ~0.103, bias -0.3):
+        mse correctly declares A the winner; linear reports d_mean > 0, which
+        the verdict convention reads as "BEATEN BY baseline". A strictly more
+        precise forecast loses under linear -- exactly the measured
+        HAR-vs-DLinear case (#10938).
+        """
+        rng3 = np.random.default_rng(42)
+        e_a = rng3.normal(0, 0.1, 500)         # precise, unbiased
+        e_b = -0.3 + rng3.normal(0, 0.1, 500)  # ~11x less precise, biased
+        r_mse = diebold_mariano_test(e_a, e_b, loss_fn="mse")
+        r_lin = diebold_mariano_test(e_a, e_b, loss_fn="linear")
+        assert r_mse.mean_loss_diff < 0                 # A wins under mse
+        assert r_lin.mean_loss_diff > 0                 # same pair "loses" under linear
+        assert r_lin.mean_loss_diff == pytest.approx(
+            np.mean(e_a) - np.mean(e_b)
+        )
+
+    def test_linear_loss_blind_to_dispersion(self):
+        """Regression #10956: identical bias, radically different precision.
+
+        Two forecasts with identical bias (0.5) but ~15x different MSE give
+        d_mean = 0 and p = 1 under linear (INCONCLUSIVE), even though one is
+        far more precise. mse detects the gap.
+        """
+        rng4 = np.random.default_rng(7)
+        n = 500
+        u = rng4.normal(0, 0.1, n)
+        v = rng4.normal(0, 2.0, n)
+        e_a = 0.5 + (u - u.mean())             # sample bias exactly 0.5
+        e_b = 0.5 + (v - v.mean())
+        assert np.isclose(np.mean(e_a), np.mean(e_b))
+        assert np.mean(e_a ** 2) < np.mean(e_b ** 2) / 10
+        r_lin = diebold_mariano_test(e_a, e_b, loss_fn="linear")
+        r_mse = diebold_mariano_test(e_a, e_b, loss_fn="mse")
+        assert abs(r_lin.mean_loss_diff) < 1e-12  # d_mean = bias_a - bias_b = 0
+        assert r_lin.p_value > 0.05
+        assert r_mse.mean_loss_diff < 0
+        assert r_mse.p_value < 0.01
 
 
 class TestDmVerdict:


### PR DESCRIPTION
Grain: DEEP/training — lane myia-po-2024:CoursIA — prev: DEEP/training #10960

## Summary

Verdict écrit (acceptance n°1 de #10956) sur le cas motivant de #10228, choix (a)/(b)/(c)
tranché et argumenté (acceptance n°2), docstring de `loss_fn="linear"` amendée pour dire
explicitement qu'elle compare des biais (acceptance n°3). Mesures, pas raisonnement —
tous les chiffres ci-dessous sortent de `dm_test.py` réel.

## Verdict sur #10228 — la démonstration est exacte, le diagnostic est une lecture erronée d'une propriété de MSE

Le constat d'origine (« sous mse, `e` et `−e` donnent un `dm_stat` bit-identique ») est **vrai**,
mais ce qu'il prouve n'est pas un défaut. Sous MSE, `L(e) = e² = (−e)²` : deux prévisions dont
les erreurs sont opposées ont **exactement la même précision**, et le DM dit exactement ça
(`d_t = 0` partout). Ce n'est pas MSE qui est aveugle au signe *par bug* — la symétrie de signe
**est** le domaine de MSE : MSE mesure la précision et rien d'autre.

Le symptôme que #10228 visait était réel, mais ce n'est pas « le test DM est cassé » : c'est un
**défaut d'appariement instrument/question**. La jambe DM de §C était nourrie de `mse` pour
valider la qualité d'une stratégie *y compris la direction de l'outperformance* — or MSE compare
des volatilités, pas des rentabilités. Deux instruments opposés, deux angles morts :

| loss | mesure | aveugle à |
|---|---|---|
| `mse` / `mae` | précision | le signe / la direction |
| `linear` | biais (`d_mean = biais_a − biais_b`) | la dispersion / la précision |

Le remède `linear` de #10228 a remplacé la mesure de précision par une mesure de biais — créant
l'angle mort symétrique, désormais **mesuré** (voir contre-exemples).

## Contre-exemples chiffrés (`diebold_mariano_test` réel, n=500)

**CE1 — un modèle 11× plus précis est déclaré BEATEN sous `linear`** (le cas HAR/DLinear mesuré dans #10938, reproduit en miniature) :

```
errors_a = N(0, 0.1)            MSE_a = 0.0092   biais_a = −0.001
errors_b = −0.3 + N(0, 0.1)     MSE_b = 0.1030   biais_b = −0.305
mse:    dm_stat = −28.96  p = 0.00e+00  mean_loss_diff = −0.094  → modèle BEATS   (correct)
linear: dm_stat = +43.65  p = 0.00e+00  mean_loss_diff = +0.303  → modèle BEATEN  (le code lit positif = BEATEN)
```

`d_mean_linear = biais_a − biais_b = +0.303` : identité terme à terme. Un modèle **11× plus précis**
perd le test sous `linear` parce que sa baseline est plus biaisée. C'est exactement ce que le run
#10938 a produit en vrai : HAR (biais −0,227, MSE 0,888) « bat » DLinear (biais ≈ 0, MSE 0,751).

**CE2 — biais identiques, précision 15× différente → `linear` ne voit rien** :

```
biais_a = biais_b = +0.5 (biais échantillon exactement égaux, bruit recentré)
MSE_a = 0.259   MSE_b = 3.802   (15×)
linear: d_mean = +0.000000  p = 1.0000  → INCONCLUSIVE (le DM ne voit rien)
mse:    dm_stat = −3.54     p = 0.00e+00 → BEATS       (détecte le gap)
```

**CE3 — la démonstration #10228 relue** :

```
mse:    e vs −e  → dm_stat +16.5430 vs +16.5430 (bit-identique)  → correct, également précis
linear: e vs −e  → dm_stat +10.5503 vs −10.5503 (signes opposés) → le signe EST une déclaration de biais
```

## Choix tranché — (c) + contrôle de biais obligatoire

**Je recommande (c)** : revenir à `mse` pour la jambe DM de §C, et exiger un **rapport de biais
par modèle** (`bias_oos` moyen, préférence fold-train estimé) dans tout body de PR ML.

- (c) est le seul qui aurait fait apparaître `har_bias_oos = −0,2266` **avant** qu'une lecture
  soit construite dessus — c'est le critère décisif posé par ai-01.
- (a) conserve `linear` comme contrôle séparé : utile mais redondant avec le rapport de biais de (c),
  et il resterait tentant de le relire comme une jambe de précision.
- (b) (linex/pinball) est une vraie perte asymétrique sur la précision, mais ajoute une complexité
  de calibration (paramètre de forme) sans besoin mesuré : le besoin actuel est « mesurer la
  précision ET rapporter le biais séparément », pas « une seule métrique qui fasse les deux ».

**Périmètre de cette PR** : le verdict + la docstring + les tests. L'amendement de §C
(pr-review-discipline.md) est une règle HARD → PR séparée + sign-off user, je ne l'auto-autorise pas.

## Docstring amendée (acceptance n°3)

`dm_test.py` — `loss_fn="linear"` documenté désormais comme : `d_mean = mean(e_a) − mean(e_b) =
biais_a − biais_b`, **compare des biais, pas des précisions**, aveugle à la dispersion, un modèle
strictement plus précis peut perdre face à un plus biaisé (#10956). Diagnostic de biais uniquement,
jamais la jambe de précision d'un verdict. L'ancien texte (« Only linear is sign-sensitive »)
laissait croire à une mesure de précision signée.

## Tests ajoutés (`test_dm.py`, +2, 20/20 verts)

- `test_linear_loss_is_bias_differential` : CE1 — `d_mean = biais_a − biais_b`, le modèle plus
  précis « perd » sous linear, `assert r_lin.mean_loss_diff == biais_a − biais_b`.
- `test_linear_loss_blind_to_dispersion` : CE2 — biais égaux, précision 15× différente →
  `d_mean = 0`, `p > 0.05` sous linear ; mse détecte.
- docstring du test #10228 amendée (le signe opposé de linear est une déclaration de **biais**,
  pas de précision).

## Validation

- `python -m pytest test_dm.py -q` → **20 passed** (18 existants inchangés + 2 nouveaux), 1,72 s.
- `git diff --stat` : 2 fichiers (`dm_test.py` +24, `test_dm.py` +57), un seul sujet (#10956).
- Les tests existants de #10228 passent inchangés (anti-régression : le test `linear` oppose les
  signes de `e`/`−e` reste valide — sa docstring seule est corrigée).

See #10956
See #10228
