### PR TITLE
fix(guard,#10953): scan des commits du garde #10101 — jq corrige + fallback non silencieux + test

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -522,9 +522,15 @@ jobs:
           # Commit messages as a JSON array of strings. `messageBody` is the
           # full commit message (subject + body), which is what GitHub parses
           # for auto-close keywords. Empty/missing file -> no commits to scan
-          # (the helper tolerates it).
-          gh pr view "$PR_NUMBER" --json commits --jq '[.[].messageBody]' \
-            > /tmp/commits.json 2>/dev/null || printf '[]' > /tmp/commits.json
+          # (the helper tolerates it). A `gh pr view` failure is LOGGED, not
+          # masked: `--jq '[.[].messageBody]'` iterates the wrong level and
+          # failed for months, and the old `2>/dev/null` fallback swallowed it
+          # so the commit scan silently never ran (#10953).
+          if ! gh pr view "$PR_NUMBER" --json commits --jq '[.commits[].messageBody]' \
+              > /tmp/commits.json; then
+            echo "::warning::gh pr view --json commits a echoue — scan des commits vide, body seul couvert (#10953)"
+            printf '[]' > /tmp/commits.json
+          fi
 
           # The helper scans body + commits for `prev:` close-keyword genres
           # and exits 0 (pass) or 1 (block). stderr surfaced for debug.
@@ -627,9 +633,15 @@ jobs:
           # Commit messages as a JSON array of strings. `messageBody` is the
           # full commit message (subject + body), which is what GitHub parses
           # for auto-close keywords. Empty/missing file -> no commits to scan
-          # (the helper tolerates it).
-          gh pr view "$PR_NUMBER" --json commits --jq '[.[].messageBody]' \
-            > /tmp/commits.json 2>/dev/null || printf '[]' > /tmp/commits.json
+          # (the helper tolerates it). A `gh pr view` failure is LOGGED, not
+          # masked: `--jq '[.[].messageBody]'` iterates the wrong level and
+          # failed for months, and the old `2>/dev/null` fallback swallowed it
+          # so the commit scan silently never ran (#10953).
+          if ! gh pr view "$PR_NUMBER" --json commits --jq '[.commits[].messageBody]' \
+              > /tmp/commits.json; then
+            echo "::warning::gh pr view --json commits a echoue — scan des commits vide, body seul couvert (#10953)"
+            printf '[]' > /tmp/commits.json
+          fi
 
           # The helper resolves each `<closing-keyword> #N` via `gh api` and
           # exits 0 (pass / fail-open) or 1 (block on a PR). stderr surfaced

--- a/scripts/tests/test_pr_close_keyword_guard.py
+++ b/scripts/tests/test_pr_close_keyword_guard.py
@@ -143,6 +143,21 @@ def test_commit_message_only_blocks():
     assert verdict["hits"][0]["location"] == "commit[1]"
 
 
+# --- extra: clean body + offending commit -> BLOCK (#10953) -----------------
+# The exact vector #10101 exists to catch: the squash message is rebuilt from
+# branch commits, so a `Closes #N` that only lives in a commit message would
+# auto-close a PR on merge. A spotless body must NOT clear it.
+
+def test_clean_body_offending_commit_blocks():
+    body = "Enrichissement pedagogique, aucun close-keyword, See #10488"
+    commits = ["docs: prose", "feat: contenu\n\nCloses #10067 a la livraison"]
+    verdict = pkg.check(body, commits=commits,
+                        resolver=_table_resolver({10067: "pr"}))
+    assert verdict["guard_pass"] is False
+    assert verdict["hits"][0]["location"] == "commit[1]"
+    assert verdict["hits"][0]["number"] == 10067
+
+
 # --- extra: CLI end-to-end with a table resolver monkeypatch ----------------
 
 def test_cli_blocks_on_pr(tmp_path, monkeypatch):


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: DEEP/training #10961

## Summary

Correction du garde `check-close-keyword-pr-ref-required` (#10101) : le scan des **messages de commits n'avait jamais tourné**. Les deux jobs du workflow (`variation-tag-guard.yml`) utilisaient `--jq '[.[].messageBody]'` — qui itère au mauvais niveau (`gh pr view --json commits` renvoie `{"commits":[...]}`, `.[]` sort le tableau, `.messageBody` sur un tableau erreur RC=1) — et le `2>/dev/null || printf '[]'` avalait l'échec : `/tmp/commits.json` valait **toujours** `[]`, depuis la mise en service. Le garde couvrait la moitié la moins dangereuse du problème en annonçant les deux.

## Correctif (les 3 items d'acceptance)

1. **`--jq '[.commits[].messageBody]'`** dans les deux jobs (prev-close-keyword et close-keyword-pr-ref). Vérifié sur une PR réelle (#10961, ≥1 commit) :
   - forme ancienne : RC=1, `expected an object but got: array`
   - forme corrigée : RC=0, tableau des messages renvoyé
2. **Fallback non silencieux** : `if ! gh pr view ...; then echo "::warning::..." ; printf '[]'; fi` — un échec de `gh pr view` est désormais loggé comme warning explicite avant le fallback. C'est le `2>/dev/null` qui a rendu le défaut invisible pendant toute la durée de service.
3. **Test d'acceptance** (`test_pr_close_keyword_guard.py`, +1) : `test_clean_body_offending_commit_blocks` — body propre (aucun close-keyword) + message de commit portant le mot-cle de fermeture visant #10067 → `guard_pass: false`, `location == "commit[1]"`. C'est précisément le vecteur de #10101 : le squash reconstruit son message depuis les commits de branche, un `Closes #N` vivant seulement dans un commit fermerait l'issue au merge.

## Validation

- `python -m pytest test_pr_close_keyword_guard.py test_variation_prev_guard.py -q` → **21 passed** (20 existants + 1 nouveau), 0,29 s. Les tests existants passent inchangés (anti-régression chemin nominal).
- Chemin nominal préservé : body sain + commits sains → `guard_pass: true` (tests existants).
- `git diff --stat` : 2 fichiers (workflow + 14, test +17), un seul sujet (#10953).

## Note de méthode

Le défaut a été trouvé en instrumentant l'échec de la PR #10949, dont la cause réelle était ailleurs (idiome français « le fix #N » formant le motif dans le body — cf commentaire de la PR). Le garde y avait rendu le bon verdict par le body seul ; le scan des commits, lui, était mort sans le savoir.

See #10953
See #10101



---

*Note ai-01 (merge c.99) : le body citait litteralement le mot-cle de fermeture accole a #10067 pour **decrire la fixture de test**. Le garde matche partout, sans lire la prose environnante — il a donc (correctement) bloque la PR qui le repare. Adjacence cassee ici ; le code de la PR est inchange. C'est la meme trappe que l'incident #10929/#10918 : ecrire le mot-cle pour dire qu'on le teste suffit a le declencher.*



---

*Note ai-01 (c.99) : le rouge du guard `#10101` sur cette PR etait **stale**. Le body a ete assaini, mais `gh run rerun` **rejoue la payload de l evenement d origine** — `github.event.pull_request.body` y reste la version pre-edition, donc un rerun ne peut structurellement pas voir un body corrige. Seul un nouvel evenement `edited`/`synchronize` porte le body courant : cette edition en est un.*
