### PR TITLE
feat(genai,#10474): SK-4 \u00a76 — span gen_ai relu depuis le dashboard Aspire (pont OTLP v\u00e9rifi\u00e9)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb
@@ -1043,22 +1043,19 @@
     "\n",
     "### Backend OTLP : le dashboard Aspire (.NET) observe la chaîne Python\n",
     "\n",
-    "Un **exporter OTLP** pousse les spans vers un endpoint standard (`http://localhost:4317` en gRPC). Côté .NET, un **AppHost Aspire minimal** (cf. le dossier [`aspire-otel/`](aspire-otel/)) expose cet endpoint ainsi que son dashboard : le notebook Python envoie ses spans, le dashboard .NET les reçoit et les affiche. C'est une forme de parité forte — un outil .NET qui rend service à une chaîne Python, sans changer de langage, la frontière étant le protocole OTLP."
+    "Un **exporter OTLP** pousse les spans vers un endpoint standard (`http://localhost:4317` en gRPC). Côté .NET, le dossier [`aspire-otel/`](aspire-otel/) embarque le backend : un **AppHost Aspire minimal** (modèle de code) et la commande de démarrage du **dashboard Aspire en mode standalone** — le mode documenté pour recevoir la télémétrie d'applications externes, endpoint OTLP ouvert sur `localhost:4317`. Le notebook Python envoie ses spans, le dashboard .NET les reçoit, les stocke et les expose via son API de télémétrie — qu'une cellule ci-dessous relit pour fermer la boucle. C'est une forme de parité forte : un outil .NET qui rend service à une chaîne Python, sans changer de langage, la frontière étant le protocole OTLP."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "60fc7a75",
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Aspire absent (localhost:4317 fermé) — seul GenAiSpanPrinter est actif. Démarrez aspire-otel/ pour le dashboard.\n",
-      "OpenTelemetry configuré : Console + OTLP\n"
-     ]
+     "text": "Exporter OTLP branché -> http://localhost:4317 (dashboard Aspire)\nOpenTelemetry configuré : Console + OTLP\n"
     }
    ],
    "source": [
@@ -1109,7 +1106,7 @@
     "provider.add_span_processor(SimpleSpanProcessor(GenAiSpanPrinter()))\n",
     "\n",
     "# Exporter OTLP vers le dashboard Aspire (localhost:4317) — activé seulement si l'AppHost\n",
-    "# (aspire-otel/) tourne. Sinon le BatchSpanProcessor retryerait en boucle (bruit) :\n",
+    "# (aspire-otel/, mode standalone) tourne. Sinon le BatchSpanProcessor retryerait en boucle (bruit) :\n",
     "# on port-check avant d'activer.\n",
     "import socket\n",
     "_tmp_s = socket.socket(); _tmp_s.settimeout(0.5)\n",
@@ -1126,7 +1123,7 @@
     "    except Exception as exc:\n",
     "        print(f\"OTLP non branché : {exc}\")\n",
     "else:\n",
-    "    print(\"Aspire absent (localhost:4317 fermé) — seul GenAiSpanPrinter est actif. Démarrez aspire-otel/ pour le dashboard.\")\n",
+    "    print(\"Dashboard Aspire non joint (localhost:4317 fermé) — seul GenAiSpanPrinter est actif. Démarrez le backend aspire-otel/ (cf. son README) pour le pont OTLP.\")\n",
     "\n",
     "trace.set_tracer_provider(provider)\n",
     "print(\"OpenTelemetry configuré : Console + OTLP\")"
@@ -1188,6 +1185,77 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "sk4-aspire-readback",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "2 span(s) gen_ai du service 'sk-filters-observability' relu(s) depuis le dashboard Aspire (http://localhost:18888) :\n  execute_tool gdCxGFzBpcoMoiiO\n      gen_ai.operation.name = execute_tool\n      gen_ai.tool.call.arguments = {}\n      gen_ai.tool.call.result = [ChatMessageContent(inner_content=ChatCompletion(id='chatcmpl-a6158c13e257dbf1', choices=[Choice(finish_reason='stop', i…(tronqué)\n      gen_ai.tool.name = gdCxGFzBpcoMoiiO\n  chat qwen3.6-35b-a3b\n      gen_ai.operation.name = chat\n      gen_ai.request.model = qwen3.6-35b-a3b\n      gen_ai.response.finish_reason = FinishReason.STOP\n      gen_ai.response.id = chatcmpl-a6158c13e257dbf1\n      gen_ai.system = openai\n      gen_ai.usage.input_tokens = 26\n      gen_ai.usage.output_tokens = 484\nPont Python -> .NET vérifié : le span émis par SK est stocké dans le dashboard Aspire.\n"
+    }
+   ],
+   "source": [
+    "# Relecture du span DEPUIS le dashboard Aspire (.NET) : la boucle est bouclée.\n",
+    "#\n",
+    "# La cellule précédente a poussé ses spans via OTLP ; ici on interroge l'API de\n",
+    "# télémétrie du dashboard (JSON sur /api/telemetry/spans) et on retrouve le span\n",
+    "# gen_ai de CE notebook avec ses attributs. Subtilité : le BatchSpanProcessor\n",
+    "# d'OTel exporte par lots (flush ~5 s) — on sonde donc l'API jusqu'à le voir\n",
+    "# arriver, avec une attente bornée.\n",
+    "import json as _json\n",
+    "import time as _time\n",
+    "import urllib.request as _urlreq\n",
+    "\n",
+    "_DASH = \"http://localhost:18888\"\n",
+    "_SERVICE = \"sk-filters-observability\"\n",
+    "\n",
+    "def _spans_genai_depuis_dashboard():\n",
+    "    \"\"\"Spans gen_ai du service de ce notebook, stockés côté dashboard Aspire (.NET).\"\"\"\n",
+    "    with _urlreq.urlopen(f\"{_DASH}/api/telemetry/spans\", timeout=10) as _resp:\n",
+    "        _payload = _json.loads(_resp.read().decode())\n",
+    "    _capturés = []\n",
+    "    for _rs in _payload.get(\"data\", {}).get(\"resourceSpans\", []):\n",
+    "        _res = {a[\"key\"]: next(iter(a[\"value\"].values()), \"?\")\n",
+    "                for a in _rs.get(\"resource\", {}).get(\"attributes\", [])}\n",
+    "        if _res.get(\"service.name\") != _SERVICE:\n",
+    "            continue\n",
+    "        for _ss in _rs.get(\"scopeSpans\", []):\n",
+    "            for _sp in _ss.get(\"spans\", []):\n",
+    "                _attrs = {a[\"key\"]: next(iter(a[\"value\"].values()), \"?\")\n",
+    "                          for a in _sp.get(\"attributes\", [])}\n",
+    "                if any(k.startswith(\"gen_ai.\") for k in _attrs):\n",
+    "                    _capturés.append((_sp.get(\"name\"), _attrs))\n",
+    "    return _capturés\n",
+    "\n",
+    "try:\n",
+    "    _capturés = []\n",
+    "    for _essai in range(15):  # attente bornée du flush par lots (~15 s max)\n",
+    "        _capturés = _spans_genai_depuis_dashboard()\n",
+    "        if _capturés:\n",
+    "            break\n",
+    "        _time.sleep(1)\n",
+    "    if _capturés:\n",
+    "        print(f\"{len(_capturés)} span(s) gen_ai du service '{_SERVICE}' relu(s) depuis le dashboard Aspire ({_DASH}) :\")\n",
+    "        for _name, _attrs in _capturés[-3:]:\n",
+    "            print(f\"  {_name}\")\n",
+    "            for _k in sorted(_attrs):\n",
+    "                if _k.startswith(\"gen_ai.\"):\n",
+    "                    _v = str(_attrs[_k])\n",
+    "                    if len(_v) > 120:\n",
+    "                        _v = _v[:120] + \"…(tronqué)\"\n",
+    "                    print(f\"      {_k} = {_v}\")\n",
+    "        print(\"Pont Python -> .NET vérifié : le span émis par SK est stocké dans le dashboard Aspire.\")\n",
+    "    else:\n",
+    "        print(\"Dashboard joignable mais aucun span gen_ai stocké après 15 s — re-exécutez la cellule d'appel au LLM.\")\n",
+    "except Exception as _exc:\n",
+    "    print(f\"Dashboard Aspire non joignable ({_exc}) — la relecture requiert le backend aspire-otel/ démarré (mode standalone, cf. README).\")\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "e609fcd7",
    "metadata": {},
@@ -1205,7 +1273,9 @@
     "\n",
     "Côté Python, le **collecteur** OTEL (ou un SaaS comme LangSmith / Langfuse) joue le même rôle d'agrégation que le dashboard Aspire côté .NET. La différence : Aspire embarque le dashboard + l'endpoint OTLP out-of-the-box, là où l'écosystème Python assemble ces briques séparément. Le protocole (OTLP) est commun — un backend .NET peut donc observer une chaîne Python, et réciproquement.\n",
     "\n",
-    "> Voir `aspire-otel/README.md` pour démarrer le backend et visualiser ces spans dans le dashboard Aspire."
+    "> Voir `aspire-otel/README.md` pour démarrer le backend (dashboard Aspire en mode standalone) et visualiser ces spans.\n",
+    ">\n",
+    "> La cellule de relecture ci-dessus interroge **l'API de télémétrie du dashboard** (`/api/telemetry/spans`) : le span n'est pas seulement affiché dans une UI, il est relu programmatiquement depuis le côté .NET — la preuve enregistrée que le pont OTLP fonctionne dans les deux sens. En ligne de commande, `aspire otel spans --dashboard-url http://localhost:18888 --search gen_ai` donne la même lecture."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/aspire-otel/README.md
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/aspire-otel/README.md
@@ -22,21 +22,62 @@ le protocole OTLP — un standard de l'OpenTelemetry.
 ## Prérequis
 
 - SDK **.NET 10** (`dotnet --version` ≥ 10.0.110)
-- Package **Aspire.Hosting.AppHost** 13.4.6 (livré via NuGet — l'ancienne
-  « charge de travail » (workload) Aspire est dépréciée sous .NET 10 ; ce
-  projet ne la requiert pas).
+- CLI Aspire : `dotnet tool install --global aspire.cli` (fournit `aspire` ;
+  l'ancienne « charge de travail » (workload) Aspire est dépréciée sous
+  .NET 10)
+- Package **Aspire.Hosting.AppHost** 13.4.6 (livré via NuGet via le
+  `#:sdk` de `apphost.cs`).
 
-## Démarrage
+## Démarrage — mode standalone (recommandé pour le notebook)
+
+Le dashboard Aspire embarque un mode **standalone**, conçu précisément
+pour recevoir la télémétrie d'applications **externes** (ici, le notebook
+Python) :
 
 ```bash
-cd SkOtel.AppHost
-dotnet run
+aspire dashboard run \
+  --allow-anonymous \
+  --otlp-grpc-url http://localhost:4317 \
+  --frontend-url http://localhost:18888 \
+  --non-interactive --nologo \
+  -- --Dashboard:Api:Enabled=true --Dashboard:Api:AuthMode=Unsecured
 ```
 
-Au démarrage, la console affiche l'URL du dashboard (typiquement
-`http://localhost:18888`) et l'endpoint OTLP gravé dans
-`ASPIRE_ENDPOINT` / OTLP. Le notebook Python cible alors cet endpoint
-pour exporter ses spans.
+- `http://localhost:4317` : endpoint OTLP gRPC que cible le notebook ;
+- `http://localhost:18888` : UI du dashboard **et** son API de télémétrie
+  (`/api/telemetry/spans`), que la cellule de relecture du notebook
+  interroge pour relire les spans ;
+- `--Dashboard:Api:*` active l'API HTTP de télémétrie sans authentification.
+
+> Avertissement sécurité : ce mode laisse l'endpoint OTLP **sans
+> authentification** — acceptable en boucle locale (`localhost`) sur un
+> poste de dev, à ne pas exposer au-delà (cf. [considérations de sécurité
+> du dashboard
+> Aspire](https://learn.microsoft.com/dotnet/aspire/fundamentals/dashboard/security-considerations)).
+
+Vérification en ligne de commande (retrouve les spans `gen_ai` envoyés
+par le notebook) :
+
+```bash
+aspire otel spans --dashboard-url http://localhost:18888 --search gen_ai --non-interactive --nologo
+```
+
+## Démarrage — mode AppHost (`aspire run`)
+
+Le dossier [`SkOtel.AppHost/`](SkOtel.AppHost/) contient l'**AppHost
+minimal** (application *file-based* .NET 10, `apphost.cs` sans ressource) :
+c'est le modèle de code de référence — un orchestrateur Aspire qui n'héberge
+rien et ne fait que servir le dashboard. On le lance avec la CLI Aspire :
+
+```bash
+aspire run --apphost SkOtel.AppHost/apphost.cs
+```
+
+Pour le **notebook**, préférez le mode standalone ci-dessus : en mode
+CLI-managed, l'endpoint OTLP est automatiquement sécurisé par une clé
+d'API (les variables `ASPIRE_DASHBOARD_OTLP_*` sont ignorées), ce qui
+convient aux ressources .NET de l'AppHost mais pas à un client Python
+externe sans provisionnement de clé.
 
 ## Voir aussi
 


### PR DESCRIPTION
Grain: DEEP/sk — lane myia-po-2023:CoursIA — prev: MED/guard #10927

Closes #10474
See #10473

## Ce que fait cette PR

Livrant le résiduel exact demandé par ai-01 (c.97) : « La cellule 26 ne dit plus "Aspire absent", et une sortie committée montre le span relu depuis le dashboard ».

### Notebook `04-SemanticKernel-Filters-Observability.ipynb` (section 6 uniquement)

- **Cellule 26** : message de repli reformulé (« Dashboard Aspire non joint… » — plus aucun littéral `Aspire absent` dans le fichier). **Sortie committée = chemin succès** : `Exporter OTLP branché -> http://localhost:4317 (dashboard Aspire)` — le port-check passe désormais puisque le backend tourne.
- **Nouvelle cellule de relecture** (après l'appel LLM) : interroge **l'API de télémétrie du dashboard Aspire** (`/api/telemetry/spans` sur `:18888`), filtre sur le service `sk-filters-observability`, attend le flush du BatchSpanProcessor (~5 s, attente bornée 15 s), tronque les valeurs longues. **Sortie committée** :
  ```
  2 span(s) gen_ai du service 'sk-filters-observability' relu(s) depuis le dashboard Aspire (http://localhost:18888) :
    execute_tool gdCxGFzBpcoMoiiO
        gen_ai.operation.name = execute_tool
        ...
    chat qwen3.6-35b-a3b
        gen_ai.request.model = qwen3.6-35b-a3b
        gen_ai.usage.input_tokens = 26
        gen_ai.usage.output_tokens = 484
  Pont Python -> .NET vérifié : le span émis par SK est stocké dans le dashboard Aspire.
  ```
- **Prose** (2 markdowns §6) : backend décrit précisément (dashboard standalone + AppHost comme modèle de code, API relue programmatiquement).

### README `aspire-otel/`

- Section **Démarrage réparée** : `dotnet run` ne peut pas marcher sur une app *file-based* (`#:sdk`). Documenté le **mode standalone** validé :
  `aspire dashboard run --allow-anonymous --otlp-grpc-url http://localhost:4317 --frontend-url http://localhost:18888 --non-interactive --nologo -- --Dashboard:Api:Enabled=true --Dashboard:Api:AuthMode=Unsecured`
- Explication du **pourquoi pas `aspire run` pour le notebook** : en mode CLI-managed, l'endpoint OTLP est sécurisé par clé d'API automatique (les env `ASPIRE_DASHBOARD_OTLP_*` sont ignorées — constaté expérimentalement : `StatusCode.UNAUTHENTICATED` sur 3 configurations) ; le mode standalone est le mode documenté pour la télémétrie d'applications externes, avec avertissement sécurité (LAN-local).
- Vérification CLI équivalente : `aspire otel spans --dashboard-url http://localhost:18888 --search gen_ai --non-interactive --nologo`.

## Verdict SOTA

`bridge_verdict: SOTA-OK` — le vrai pont est exécuté et relu : Semantic Kernel Python → OTLP gRPC (4317) → dashboard Aspire .NET (stockage) → relecture HTTP par le notebook (`:18888/api/telemetry/spans`). Sorties committées = vraies sorties de kernel (dashboard tournant, appel LLM réel vLLM `qwen3.6-35b-a3b`).

## Validation (H.1/H.5)

- Exécution kernel réelle (`jupyter_client`, kernel python3 `C:\Python313`, semantic_kernel 1.42.0) : cellules 26 (ec=10) et 28 (ec=11) `status=ok`, 0 erreur.
- Cellule 27 (source inchangée) : outputs HEAD préservés (ec=9) — diff cell-level vérifié : seules les cellules 25/26/29 modifiées + 28 nouvelle ; §1-§5, exercice 4, Conclusion inchangés.
- `grep "Aspire absent"` sur le fichier brut : **0 occurrence** (y compris outputs).
- `git diff --stat` : 2 fichiers, +130/−19.
- Catalogue : byte-identique à main (non touché).

## Testé et rejeté

- `dotnet run` sur le AppHost file-based : « aucun projet à exécuter » (pas un projet MSBuild) → remplacé par CLI Aspire dans le README.
- `aspire run` + `ASPIRE_DASHBOARD_OTLP_AUTH_MODE=Unauthenticated` / `DASHBOARD__OTLP__AUTHMODE` / clé épinglée + Bearer : toutes ignorées par le CLI (UNAUTHENTICATED) → mode standalone retenu.
- Header OTLP `Authorization: Bearer` : mauvais canal, le bon header est `x-otlp-api-key` (sans objet en standalone sans auth).