### PR TITLE
docs(site,#10959): taxonomie — SemanticKernel décomptée des séries niveau 1 (sous-série GenAI)

### DIFF
--- a/MyIA.AI.Notebooks/index.qmd
+++ b/MyIA.AI.Notebooks/index.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Notebooks"
-subtitle: "13 séries pédagogiques niveau 1"
-description: "Liste des 13 séries niveau 1 du dépôt CoursIA — Search, Sudoku, ML, RL, GameTheory, GenAI, Probas, SymbolicAI, QuantConnect, CaseStudies, IIT, SemanticKernel, FallacyDetection."
+subtitle: "12 séries pédagogiques niveau 1"
+description: "Liste des 12 séries niveau 1 du dépôt CoursIA — Search, Sudoku, ML, RL, GameTheory, GenAI, Probas, SymbolicAI, QuantConnect, CaseStudies, IIT, FallacyDetection. SemanticKernel est une sous-série de GenAI (couverte par le README GenAI)."
 ---
 
 # Séries de notebooks
@@ -96,14 +96,6 @@ Diagnostic médical, oncology planning, Barbie-Schreck, Fort-Boyard, Recipe-Make
 PyPhi, φ (phi) computation, causal analysis, théorème de Tononi.
 
 **Notebooks** : 4+ · **Kernels** : python3 · **GPU** : non
-:::
-
-::: {.series-card}
-### [SemanticKernel](GenAI/SemanticKernel/README.md) — Microsoft Semantic Kernel
-
-SDK agents IA Microsoft, planners, memory connectors, function calling.
-
-**Notebooks** : 5+ · **Kernels** : python3, .net-csharp · **GPU** : non
 :::
 
 ::: {.series-card}


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA-2 — prev: MED/docs #10963

See #10959 (partiel — moitié factuelle livrée ; design-gate FallacyDetection délégué, cf. Note).

## Résumé

Cohérence d'index du site (#10921) : **SemanticKernel est physiquement une sous-série GenAI** (filesystem `MyIA.AI.Notebooks/GenAI/SemanticKernel/`, listée parmi les 5 sous-domaines du README GenAI), mais l'index racine la comptait à tort parmi les « 13 séries niveau 1 » avec une carte racine.

`MyIA.AI.Notebooks/index.qmd` :

1. `subtitle` / `description` : **13 → 12 séries niveau 1**, SemanticKernel retirée de l'énumération — remplacée par une mention explicite « SemanticKernel est une sous-série de GenAI (couverte par le README GenAI) » pour préserver la découvrabilité.
2. **Carte racine SemanticKernel retirée** (le README GenAI est son point d'entrée légitime, en cohérence avec la définition de l'index : « chaque série est un dossier thématique sous `MyIA.AI.Notebooks/` »).

Diff : +2/−10, un seul fichier. Aucun bloc `CATALOG-STATUS` touché (byte-identique).

## Validation

- Rendu Quarto local 1.7.32 (version CI) SUCCESS : `Output created: _site/MyIA.AI.Notebooks/index.html`.
- HTML rendu vérifié : **12** cartes `series-card` (avant : 13), **0** occurrence « Microsoft Semantic Kernel » en carte racine, 12 séries présentes (Search, Sudoku, ML, RL, GameTheory, GenAI, Probas, SymbolicAI, QuantConnect, CaseStudies, IIT, FallacyDetection).
- Grep repo : les seules occurrences « 13 séries » du site étaient dans cet index (parcours.qmd + index des 5 séries = 0 occurrence).

## Note — design-gate FallacyDetection (délégué ai-01)

La seconde moitié de #10959 — **placement de FallacyDetection** (`git mv MyIA.AI.Notebooks/FallacyDetection/ → MyIA.AI.Notebooks/GenAI/FallacyDetection/` vs série racine autonome) — est un **design-gate cross-EPIC** (owner #10355 + structure du site #10921), pas un fix factuel : le coût du déplacement croît avec la série, et il affecte liens/catalogue/publication #10949. Le constat user « FallacyDetection devrait être une sous-série GenAI » penche pour le `git mv` (coût faible maintenant : 2 notebooks, série en construction), mais l'arbitrage revient à ai-01 — recommandation jointe, pas décision worker. La carte racine FallacyDetection reste en place en attendant l'arbitrage (l'index compte donc 12 séries, dont FallacyDetection).
