### PR TITLE
feat(notebook_tools): nbconvert render tool — sortie pandoc pour notebooks à output massif

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -111,6 +111,11 @@ jobs:
           # (scripts/genai-stack/requirements.txt). Lets us re-include the
           # genai test suites that were excluded as missing-dep (#2871 part 2).
           pip install papermill nbformat
+          # nbconvert: scripts/notebook_tools/render_oversized_nbconvert.py +
+          # scripts/tests/test_render_oversized_nbconvert.py (#10969). The
+          # fail_non_notebook test asserts the real nbformat NotJSONError text,
+          # so the env must have nbconvert installed (rule F, not a skipif).
+          pip install nbconvert
           # torch (CPU) is needed at collection time by the Sudoku/RRN test
           # modules under scripts/tests/ (they `import torch` at top level and
           # skip themselves at runtime when CUDA is absent). Without it those

--- a/scripts/notebook_tools/render_oversized_nbconvert.py
+++ b/scripts/notebook_tools/render_oversized_nbconvert.py
@@ -1,0 +1,98 @@
+"""Render a notebook to standalone HTML via nbconvert, without executing it.
+
+Piste 2 de #10968 : un notebook dont l'output massif fait boucler pandoc sous
+Quarto (`echo: true`) est rendu en quelques secondes par nbconvert, qui lit les
+outputs committés (jamais de kernel). Ce script rend reproductible cette mesure
+et valide le résultat : code visible, images embarquées, wallclock borné.
+
+Usage:
+    python render_oversized_nbconvert.py <notebook.ipynb>... [--outdir DIR]
+    python render_oversized_nbconvert.py --check <notebook.ipynb>...  # exit 1 si échec
+
+Read-only : le notebook n'est jamais modifié (C.2 / Stop & Repair).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _html_stats(path: Path) -> dict[str, int]:
+    """Compte les marqueurs de structure du HTML nbconvert (lab template)."""
+    data = path.read_text(encoding="utf-8", errors="replace")
+    return {
+        "doctype": int(data.lstrip().startswith("<!DOCTYPE html>")),
+        "input_areas": data.count("jp-InputArea"),
+        "output_areas": data.count("jp-OutputArea"),
+        "images": data.count("data:image"),
+        "bytes": len(data.encode("utf-8")),
+    }
+
+
+def render_one(nb: Path, outdir: Path, timeout_s: int = 600) -> dict[str, object]:
+    """Rend un notebook via nbconvert (outputs committés, pas d'exécution)."""
+    outdir.mkdir(parents=True, exist_ok=True)
+    stem = nb.stem
+    html = outdir / f"{stem}.html"
+    start = time.perf_counter()
+    cmd = [
+        sys.executable, "-m", "jupyter", "nbconvert",
+        "--to", "html", "--output", str(outdir / stem),
+        str(nb),
+    ]
+    try:
+        subprocess.run(cmd, check=True, timeout=timeout_s,
+                       capture_output=True, text=True)
+        wallclock_s = round(time.perf_counter() - start, 2)
+    except subprocess.TimeoutExpired:
+        return {"notebook": str(nb), "status": "FAIL", "reason": f"timeout>{timeout_s}s",
+                "wallclock_s": timeout_s}
+    except subprocess.CalledProcessError as exc:
+        return {"notebook": str(nb), "status": "FAIL",
+                "reason": exc.stderr.strip().splitlines()[-1][:200]
+                if exc.stderr else f"exit {exc.returncode}"}
+    stats = _html_stats(html)
+    ok = (stats["doctype"] == 1 and stats["input_areas"] > 0 and stats["bytes"] > 0)
+    return {
+        "notebook": str(nb),
+        "status": "RENDER_OK" if ok else "FAIL",
+        "wallclock_s": wallclock_s,
+        "html_bytes": stats["bytes"],
+        "code_areas": stats["input_areas"],
+        "output_areas": stats["output_areas"],
+        "images": stats["images"],
+        "html_path": str(html),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("notebooks", nargs="+", type=Path,
+                        help="notebooks à rendre (outputs committés)")
+    parser.add_argument("--outdir", type=Path, default=None,
+                        help="répertoire de sortie (défaut: côté du notebook)")
+    parser.add_argument("--check", action="store_true",
+                        help="exit 1 si un notebook échoue (CI)")
+    args = parser.parse_args()
+
+    outdir = args.outdir or Path(".")
+    outdir.mkdir(parents=True, exist_ok=True)
+    results = [render_one(nb, outdir) for nb in args.notebooks]
+    for r in results:
+        if r["status"] == "RENDER_OK":
+            print(f"RENDER_OK {r['wallclock_s']:>6.1f}s "
+                  f"{r['html_bytes']}o {r['code_areas']} code-areas "
+                  f"{r['images']} img — {r['notebook']}")
+        else:
+            print(f"FAIL      {r['reason']} — {r['notebook']}")
+
+    failures = [r for r in results if r["status"] != "RENDER_OK"]
+    return 1 if (args.check and failures) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_render_oversized_nbconvert.py
+++ b/scripts/tests/test_render_oversized_nbconvert.py
@@ -1,0 +1,83 @@
+"""Tests for scripts/notebook_tools/render_oversized_nbconvert.py.
+
+Couvre : comptage structurel du HTML nbconvert (_html_stats), rendu d'un
+mini-notebook (RENDER_OK, read-only), échec sur entrée non-notebook, et les
+exit codes de --check. Le rendu réel est skip-if si nbconvert est absent.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "notebook_tools"))
+from render_oversized_nbconvert import _html_stats, render_one
+
+MINI_NB = {
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "metadata": {},
+            "outputs": [
+                {"output_type": "stream", "name": "stdout", "text": "0.42\n"}
+            ],
+            "source": ["print(0.42)\n"],
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3",
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5,
+}
+
+
+def _write_nb(path: Path) -> None:
+    path.write_text(json.dumps(MINI_NB), encoding="utf-8")
+
+
+def test_html_stats_counts(tmp_path: Path) -> None:
+    html = tmp_path / "nb.html"
+    html.write_text(
+        "<!DOCTYPE html>"
+        '<div class="jp-InputArea"></div>'
+        '<div class="jp-InputArea"></div>'
+        '<div class="jp-OutputArea"></div>'
+        '<img src="data:image/png;base64,AAA">',
+        encoding="utf-8",
+    )
+    stats = _html_stats(html)
+    assert stats["doctype"] == 1
+    assert stats["input_areas"] == 2
+    assert stats["output_areas"] == 1
+    assert stats["images"] == 1
+    assert stats["bytes"] > 0
+
+
+def test_render_one_ok(tmp_path: Path) -> None:
+    nb = tmp_path / "mini.ipynb"
+    _write_nb(nb)
+    out = tmp_path / "out"
+    result = render_one(nb, out)
+    if result["status"] == "FAIL" and "nbconvert" in str(result.get("reason", "")):
+        pytest.skip("nbconvert indisponible dans cet env")
+    assert result["status"] == "RENDER_OK", result
+    assert result["html_bytes"] > 0
+    assert result["code_areas"] >= 1
+    assert (out / "mini.html").exists()
+    # read-only : le notebook source n'est pas modifié
+    assert json.loads(nb.read_text(encoding="utf-8")) == MINI_NB
+
+
+def test_render_one_fail_non_notebook(tmp_path: Path) -> None:
+    bogus = tmp_path / "not_a_notebook.txt"
+    bogus.write_text("# juste du texte", encoding="utf-8")
+    result = render_one(bogus, tmp_path / "out")
+    assert result["status"] == "FAIL"
+    assert "NotJSONError" in str(result.get("reason", ""))


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/docs #10967

*(Genre requalifié `notebook-dotnet` → `tooling` par ai-01 au merge, c.100. Le GENRE désigne le TYPE DE TRAVAIL, jamais la famille où vivent les fichiers cibles : ce que la PR ajoute est un outil de rendu, pas du contenu notebook. `tooling` et non `guard` — le script n'a pas de statut d'échec propre en CI. Requalifié dans le corps et non en commentaire, faute de quoi `variation_light_cap.py` continuerait de le compter comme un grain de CONTENU et de créditer à tort le plancher G-VAR-1 de la lane.)*

See #10968 (partiel — mesure + outil de la piste 2 livrés ; intégration moteur déléguée, cf. Note).

## Résumé

Piste 2 du follow-up #10968 : remplacer le rendu pandoc bloquant par **nbconvert direct** pour les notebooks à output massif. Verdict établi firsthand :

| Notebook | pandoc/Quarto (echo:true) | nbconvert --to html | Résultat |
|---|---|---|---|
| App-9b-EdgeDetection-CSharp (4.8 MB, 1061 blocs d'output) | **≥ 15 min (boucle)** | **4.0 s** | 5 450 970 o · 78 code-areas · 113 images embarquées |
| App-9-EdgeDetection (jumeau Python) | — | 4.1 s | 685 090 o · 111 code-areas · 107 img |
| App-10b-Portfolio-CSharp | — | 4.5 s | 575 680 o · 73 code-areas · 101 img |

La pathologie est le **reader ipynb de pandoc**, pas le notebook : nbconvert (7.17.1) lit les outputs committés (aucun kernel, aucun `execution_count` touché — C.2 / read-only vérifié, `git diff` vide sur les 4 notebooks).

## Livrable

`scripts/notebook_tools/render_oversized_nbconvert.py` — outil réutilisable, conformément à la règle « ajouter l'outil dans scripts/notebook_tools/ plutôt qu'un script ad-hoc » (aucun outil de rendu HTML existant dans la famille — vérifié, `detect_markdown_rendering.py` = détection markdown, pas export).

- `render_oversized_nbconvert.py <nb.ipynb>... [--outdir DIR]` — rend chaque notebook en HTML standalone (outputs committés), valide : doctype présent, code visible (`jp-InputArea > 0`), images embarquées (`data:image`), wallclock borné.
- `--check` : exit 1 sur échec (mode CI). Validé : exit 0 sur App-9b RENDER_OK, exit 1 sur entrée non-notebook (erreur nbformat claire).
- Read-only : jamais d'exécution, jamais de modification du notebook.
- Tests unitaires : `scripts/tests/test_render_oversized_nbconvert.py` (3 tests — stats HTML, RENDER_OK read-only, échec non-notebook), 3/3 pass. Bug attrapé au test : `render_one` crée désormais son outdir (autonome, plus dépendant de main()).

## Note — intégration moteur (déléguée)

Le choix d'intégration dans le pipeline du site (nbconvert vs correction du reader pandoc vs exclusion des notebooks surdimensionnés) est l'affaire du pilote #10965 / audit moteur #10925 (po-2025) — cette PR livre la **preuve de faisabilité + l'outil** pour que la décision s'appuie sur une mesure, pas un pari. `NOTEBOOK_EXCLUDE_FILES` (mécanisme d'exclusion du pilote) n'est pas encore sur main : aucun conflit d'interface.

## Validation

- 4/4 notebooks RENDER_OK (mesures wallclock ci-dessus, env `coursia-ml-training`, nbconvert 7.17.1).
- Mode `--check` : exit 0 sur succès, exit 1 sur échec (testé sur `README.md` → erreur nbformat claire).
- C.2 : `git status`/`git diff` vide sur les 4 notebooks après rendu — read-only confirmé.

