### PR TITLE
fix(guard,#10958): claim parser — troncature du suffixe d'annotation + fail-safe dead-scope lift

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -144,6 +144,15 @@ _OVERRIDE = {"OVERRIDE"}
 _PATHS_CLAUSE_RE = re.compile(
     r"(?im)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*\[\s*(?:CLAIMED|RELEASED|OVERRIDE)\s*\][^\n]*?paths\s*:\s*([^\n]+?)\s*$"
 )
+# #10958 -- the annotation suffix separator. Fleet claims append a trailing
+# annotation after the glob list: `paths: a/** -- 2026-08-11T18:10Z` (body
+# timestamp) or `paths: .../** — Phase 2 : ...` (prose rationale). The clause
+# regex swallows it into the LAST glob, which then matches no tracked file and
+# the claim silently ends up non-blocking (fail-open). The separator must be
+# whitespace-delimited on BOTH sides so a `foo--bar.py` (internal dashes, no
+# spaces) is never cut. Em/en dashes are included because fleet markers use
+# both (` -- ` in timestamps, ` — ` in prose rationales).
+_ANNOTATION_SUFFIX_RE = re.compile(r"\s+(?:--|—|–)\s+")
 
 
 class ClaimEvent(dict):
@@ -225,6 +234,18 @@ class ClaimEvent(dict):
         lifts the scope back to epic-wide when non-empty.
         """
         return self.get("unparseable_scope") or []
+
+    @property
+    def empty_scope(self) -> list[str]:
+        """Subset of `paths` matching ZERO tracked files in the repo (#10958).
+
+        Unlike `unparseable_scope` (pure parse residue, computable without
+        the repo), this witness requires a `git ls-files` walk, so it is
+        attached at the CHECK layer (`_run_check`), not at parse. Empty when
+        every glob locks at least one real file, or when the walk failed
+        (best-effort: we cannot prove deadness, so we do not lift).
+        """
+        return self.get("empty_scope") or []
 
 
 def _line_for_match(body: str, m: re.Match) -> str:
@@ -406,11 +427,24 @@ def _extract_paths_clause(text: str | None) -> list[str] | None:
     via `_unparseable_scope_in`; the caller MUST treat such a claim as
     EPIC-WIDE (conservateur: in case of doubt, block rather than let
     through). See `_run_check` for the integration.
+
+    #10958 -- annotation suffix: a trailing ` -- <rest>` (or ` — <rest>`)
+    after the glob list is TRUNCATED before the split. The clause regex
+    captures to end of line, so `paths: a/** -- 2026-08-11T18:10Z` used to
+    yield the single glob `a/** -- 2026-08-11T18:10Z` -- which matches no
+    tracked file, so the scoped claim never blocked anyone (fail-open). The
+    separator is whitespace-delimited on both sides, so an INTERNAL unspaced
+    dash sequence (`foo--bar.py`) survives untouched; the truncation cuts at
+    the FIRST separator, so glob content after it stays out regardless of
+    how the annotation is punctuated.
     """
     m = _PATHS_CLAUSE_RE.search(text or "")
     if not m:
         return None
     raw = m.group(1)
+    m_suffix = _ANNOTATION_SUFFIX_RE.search(raw)
+    if m_suffix:
+        raw = raw[:m_suffix.start()]
     parts = _split_paths_brace_aware(raw)
     expanded: list[str] = []
     for p in parts:
@@ -433,6 +467,24 @@ def _unparseable_scope_in(parts: list[str] | None) -> list[str]:
     if not parts:
         return []
     return [p for p in parts if "{" in p or "}" in p]
+
+
+def _empty_scope_in(parts: list[str] | None,
+                    tracked: list[str] | None) -> list[str]:
+    """Return the subset of `parts` matching ZERO tracked files (#10958).
+
+    The dead-glob witness: unlike `_unparseable_scope_in` (a parse residue),
+    this requires the `git ls-files` walk, so the caller passes `tracked`
+    (fetched once per check). Returns [] when `tracked` is None -- the walk
+    failed (not a repo, git missing): we cannot prove deadness, so the
+    fail-safe lift does NOT fire (best-effort, mirroring the lint). A
+    NON-empty result means the glob locks nothing; `_filter_by_claim_scope`
+    treats an ENTIRELY-dead scope as epic-wide (a broken claim is not a
+    permissive claim).
+    """
+    if not parts or tracked is None:
+        return []
+    return [p for p in parts if not _glob_matches_tracked(p, tracked)]
 
 
 def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEvent]]:
@@ -733,15 +785,19 @@ def _lint_claim_events(
     events: list[ClaimEvent],
     issue_number: int | None,
     repo_root: str | None = None,
+    tracked: list[str] | None = None,
 ) -> None:
     """Emit WARN/INFO lines for malformed claim markers (#10881). Non-blocking.
 
     Runs on OPEN and OVERRIDE markers only: a close marker is always a full
     lane-close (its scope is informational, #10419), so an epic-wide release
     is semantically identical to a scoped one -- nothing to warn about. The
-    lint only prints to stderr; verdicts are untouched.
+    lint only prints to stderr; verdicts are untouched. `tracked` lets a
+    caller that already walked the repo (#10958 empty-scope witness) reuse
+    the list instead of paying the walk twice.
     """
-    tracked = _git_tracked_files(repo_root)
+    if tracked is None:
+        tracked = _git_tracked_files(repo_root)
     for ev in events:
         if ev.get("action") not in ("open", "override"):
             continue
@@ -838,11 +894,23 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             disjointness, so we conservatively over-block).
     """
     events = _sort_events(payload)
+    # One shared tracked-files walk feeds BOTH the #10881 lint and the
+    # #10958 empty-scope witness (best-effort: None outside a git repo, in
+    # which case both features degrade to their pre-#10958 behaviour).
+    tracked = _git_tracked_files()
     # #10881 lint -- malformed paths: clauses surface on stderr when the
     # marker is read: visible to every lane running the check, never changing
     # a verdict. The four 2026-08-14 markers on #10678 shared the defect the
     # three checks name (epic-wide by accident / prose swallowed as globs).
-    _lint_claim_events(events, payload.get("number"))
+    _lint_claim_events(events, payload.get("number"), tracked=tracked)
+    # #10958 -- attach the dead-glob witness to every scoped event (own and
+    # others): a glob that matches zero tracked files is surfaced in the
+    # JSON (`empty_scope`) and, when it covers the WHOLE scope, lifts the
+    # claim to epic-wide in `_filter_by_claim_scope` (fail-safe).
+    if tracked is not None:
+        for ev in events:
+            if ev.get("paths"):
+                ev["empty_scope"] = _empty_scope_in(ev["paths"], tracked)
     active, unattributed = compute_active_claims(events)
     others = {ln: ev for ln, ev in active.items() if ln != my_lane}
     mine = active.get(my_lane)
@@ -852,7 +920,7 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     # `my_paths`, we conservatively treat every scoped override as blocking
     # (the caller's intent is unknown -- better to over-block than silently
     # merge a write that should have pinged a held lane).
-    others = _filter_by_claim_scope(others, my_paths, mine)
+    others = _filter_by_claim_scope(others, my_paths, mine, tracked=tracked)
 
     # Stale-claim handling (#9812): a claim older than `stale_threshold` hours
     # (age from the server createdAt, NEVER the body) is treated as STALE -- it
@@ -888,6 +956,13 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                 # scope is fully parseable) or non-empty (the claim carries
                 # patterns fnmatch cannot match).
                 "unparseable_scope": ev.get("unparseable_scope") or [],
+                # #10958 -- the dead-glob witness: globs of this claim that
+                # match zero tracked files. Empty when every glob locks
+                # something (or the walk was impossible). Non-empty means the
+                # declaring lane should reissue the claim with valid globs;
+                # when it covers the whole scope the claim is lifted to
+                # epic-wide (a broken claim is not a permissive claim).
+                "empty_scope": ev.get("empty_scope") or [],
             }
             for ln, ev in sorted(active.items())
         },
@@ -967,6 +1042,7 @@ def _filter_by_claim_scope(
     others: dict[str, ClaimEvent],
     my_paths: list[str] | None,
     mine: ClaimEvent | None,
+    tracked: list[str] | None = None,
 ) -> dict[str, ClaimEvent]:
     """Drop `others` lanes whose scoped claim does NOT intersect my scope.
 
@@ -990,6 +1066,14 @@ def _filter_by_claim_scope(
         is surfaced in the JSON summary under `unparseable_scopes` so the
         declaring lane sees the defect and reissues the claim with valid
         syntax.
+      - #10958 fail-safe: scope is ENTIRELY dead (every glob matches zero
+        tracked files, witness under `empty_scope`) -> STAYS, lifted to
+        epic-wide. A claim whose scope matches nothing is not a permissive
+        claim -- it is a BROKEN one (polluted suffix, typo'd path), and the
+        safe hypothesis is that the lane meant something. A PARTIALLY dead
+        scope (at least one live glob) stays scoped on its live part: the
+        lock is real, the dead globs are surfaced in the JSON for the lane
+        to fix. `tracked` None (no repo walk) -> no lift (cannot prove).
 
     The reducer `compute_active_claims` is untouched; this filter only prunes
     the `others` view. The active_claims summary keeps the full state, so the
@@ -999,6 +1083,12 @@ def _filter_by_claim_scope(
     my_scope = list(dict.fromkeys((my_paths or []) + mine_paths)) or None
     if not my_scope:
         return others  # no declared scope -> cannot prove disjointness
+    # #10958 fail-safe, caller side: an entirely-dead MY scope proves nothing
+    # either. Dropping an other-lane claim as "disjoint" from globs that lock
+    # no real file would be the same fail-open with the roles swapped, so the
+    # caller keeps every other lane until its own scope is reissued clean.
+    if tracked is not None and _empty_scope_in(my_scope, tracked) == my_scope:
+        return others
     filtered: dict[str, ClaimEvent] = {}
     for ln, ev in others.items():
         scope = ev.get("paths")
@@ -1012,6 +1102,15 @@ def _filter_by_claim_scope(
         # witness list is surfaced via `ev.get("unparseable_scope")` for
         # the JSON audit (see _run_check summary).
         if ev.get("unparseable_scope"):
+            filtered[ln] = ev  # lifted to epic-wide -- always blocking
+            continue
+        # #10958 fail-safe -- an ENTIRELY dead scope (every glob matches zero
+        # tracked files) is a broken claim, not a permissive one: lifted to
+        # epic-wide before the disjointness test, mirroring #10597. The
+        # witness is `ev.get("empty_scope")` (attached by `_run_check` when
+        # the walk succeeded); a missing/empty witness never lifts.
+        empty = ev.get("empty_scope") or []
+        if empty and len(empty) >= len(scope):
             filtered[ln] = ev  # lifted to epic-wide -- always blocking
             continue
         if _path_matches_any(my_scope, scope):

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -1238,10 +1238,12 @@ def test_check_claimed_disjoint_paths_dont_block(capsys):
     # after, each reads the OTHER's scope from its own active claim and sees CLEAR.
     p = payload(
         comment("[CLAIMED] lane myia-po-2025:CoursIA -- "
-                "paths: Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb",
+                "paths: MyIA.AI.Notebooks/Search/Part1-Foundations/"
+                "Search-3-Informed-Csharp.ipynb",
                 "2026-08-11T04:02:00Z"),
         comment("[CLAIMED] lane myia-po-2023:CoursIA -- "
-                "paths: Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb",
+                "paths: MyIA.AI.Notebooks/Sudoku/"
+                "Sudoku-9-GraphColoring-Csharp.ipynb",
                 "2026-08-11T04:05:00Z"),
     )
     rc = clc._run_check(p, "myia-po-2025:CoursIA")  # no --paths
@@ -1259,19 +1261,24 @@ def test_check_claimed_10382_five_disjoint_claims(capsys):
     # that fired on all ~51 PRs of the audit is gone.
     p = payload(
         comment("[CLAIMED] lane myia-po-2023:CoursIA -- "
-                "paths: Sudoku/Sudoku-9-GraphColoring-Csharp.ipynb",
+                "paths: MyIA.AI.Notebooks/Sudoku/"
+                "Sudoku-9-GraphColoring-Csharp.ipynb",
                 "2026-08-11T04:02:00Z"),
         comment("[CLAIMED] lane myia-po-2024:CoursIA -- "
-                "paths: Planning/Planners-5-Heuristics-Csharp.ipynb",
+                "paths: MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/"
+                "Planners-5-Heuristics-Csharp.ipynb",
                 "2026-08-11T04:03:00Z"),
         comment("[CLAIMED] lane myia-po-2025:CoursIA -- "
-                "paths: Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb",
+                "paths: MyIA.AI.Notebooks/Search/Part1-Foundations/"
+                "Search-3-Informed-Csharp.ipynb",
                 "2026-08-11T04:04:00Z"),
         comment("[CLAIMED] lane myia-po-2025:CoursIA-2 -- "
-                "paths: Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb",
+                "paths: MyIA.AI.Notebooks/Search/Part1-Foundations/"
+                "Search-5-GeneticAlgorithms-Csharp.ipynb",
                 "2026-08-11T04:05:00Z"),
         comment("[CLAIMED] lane myia-po-2026:CoursIA -- "
-                "paths: GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb",
+                "paths: MyIA.AI.Notebooks/GameTheory/"
+                "GameTheory-4-NashEquilibrium-Csharp.ipynb",
                 "2026-08-11T04:07:00Z"),
     )
     for lane in (
@@ -1290,9 +1297,11 @@ def test_check_claimed_same_path_still_blocks(capsys):
     # Two scoped claims on the SAME path -> real collision -> BLOCKED. The scope
     # feature must not dissolve a genuine file-level conflict into a false clear.
     p = payload(
-        comment("[CLAIMED] lane A:CoursIA -- paths: Sudoku/Sudoku-9.ipynb",
+        comment("[CLAIMED] lane A:CoursIA -- paths: MyIA.AI.Notebooks/Sudoku/"
+                "Sudoku-9-GraphColoring-Csharp.ipynb",
                 "2026-08-11T04:02:00Z"),
-        comment("[CLAIMED] lane B:CoursIA-2 -- paths: Sudoku/Sudoku-9.ipynb",
+        comment("[CLAIMED] lane B:CoursIA-2 -- paths: MyIA.AI.Notebooks/Sudoku/"
+                "Sudoku-9-GraphColoring-Csharp.ipynb",
                 "2026-08-11T04:05:00Z"),
     )
     rc = clc._run_check(p, "A:CoursIA")
@@ -1324,9 +1333,9 @@ def test_check_my_claim_scope_derived_from_claim_not_just_cli(capsys):
     # lane. This is the leg that makes the #10419 fix usable without forcing
     # every worker to pass --paths on every invocation.
     p = payload(
-        comment("[CLAIMED] lane A:CoursIA -- paths: Lean/Foo.lean",
+        comment("[CLAIMED] lane A:CoursIA -- paths: scripts/check_lane_claim.py",
                 "2026-08-11T04:02:00Z"),
-        comment("[CLAIMED] lane B:CoursIA-2 -- paths: scripts/foo.py",
+        comment("[CLAIMED] lane B:CoursIA-2 -- paths: scripts/grain_tag.py",
                 "2026-08-11T04:05:00Z"),
     )
     rc = clc._run_check(p, "A:CoursIA")  # NO my_paths
@@ -1340,12 +1349,12 @@ def test_check_claimed_paths_merged_with_cli_widen_scope(capsys):
     # other lane's scope intersects my CLI --paths but NOT my claim clause --
     # the merge still catches the overlap and BLOCKS.
     p = payload(
-        comment("[CLAIMED] lane A:CoursIA -- paths: Lean/Foo.lean",
+        comment("[CLAIMED] lane A:CoursIA -- paths: scripts/check_lane_claim.py",
                 "2026-08-11T04:02:00Z"),
-        comment("[CLAIMED] lane B:CoursIA-2 -- paths: scripts/bar.py",
+        comment("[CLAIMED] lane B:CoursIA-2 -- paths: scripts/grain_tag.py",
                 "2026-08-11T04:05:00Z"),
     )
-    rc = clc._run_check(p, "A:CoursIA", my_paths=["scripts/bar.py"])
+    rc = clc._run_check(p, "A:CoursIA", my_paths=["scripts/grain_tag.py"])
     assert rc == 1
     assert "B:CoursIA-2" in capsys.readouterr().err
 
@@ -1650,10 +1659,12 @@ def test_paths_clause_brace_scope_disjoint_across_claims(capsys):
     # expansion (#10597).
     p = payload(
         comment("[CLAIMED] lane myia-po-2023:CoursIA -- "
-                "paths: twin_pairs.d/gametheory-{7,8,9}-*.yaml",
+                "paths: scripts/notebook_tools/twin_pairs.d/"
+                "gametheory-{7,8,9}-*.yaml",
                 "2026-08-11T04:02:00Z"),
         comment("[CLAIMED] lane myia-po-2024:CoursIA -- "
-                "paths: twin_pairs.d/app-{17,18,19}-*.yaml",
+                "paths: scripts/notebook_tools/twin_pairs.d/"
+                "app-{17,18,19}-*.yaml",
                 "2026-08-11T04:05:00Z"),
     )
     rc = clc._run_check(p, "myia-po-2023:CoursIA")
@@ -1814,7 +1825,7 @@ def test_run_check_clean_brace_scope_does_not_show_unparseable(capsys):
     p = payload(
         comment(
             "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
-            "paths: scripts/search-{6,8,9}-*.yaml",
+            "paths: scripts/notebook_tools/twin_pairs.d/search-{6,8,9}-*.yaml",
             "2026-08-12T11:00:00Z",
         ),
     )
@@ -1829,6 +1840,144 @@ def test_run_check_clean_brace_scope_does_not_show_unparseable(capsys):
     # The witness is empty; the JSON still surfaces the field for
     # consistency, but its value is the empty list, not a residual brace.
     assert '"unparseable_scope": []' in out
+
+
+# --- #10958 fail-safe -- annotation suffix + entirely-dead scope ---------------
+#
+# Two defect classes, one root cause: a trailing annotation after the glob
+# list (`paths: a/** -- 2026-08-11T18:10Z` fleet body-timestamp, or
+# `paths: .../** — Phase 2 : prose` rationale) was swallowed into the LAST
+# glob by the line-greedy clause regex. The glob then matches zero tracked
+# files -- a dead lock -- and the OLD read was fail-open: a dead scope
+# intersected nothing, so the claim cleared every other lane (#9764-style
+# false CLEAR). #10958 fixes both layers:
+#   1. PARSE: `_extract_paths_clause` truncates the suffix at the FIRST
+#      whitespace-delimited ` -- `/` — `/` – ` separator.
+#   2. CHECK: a scope whose globs are ALL dead (post-truncation: a typo, not
+#      a suffix) is a BROKEN claim, not a permissive one -- lifted to
+#      epic-wide (fail-safe), mirroring the #10597 hardener. The witness
+#      (`empty_scope`) rides the JSON so the declaring lane can reissue.
+
+
+def test_paths_clause_truncates_annotation_suffix_three_forms():
+    """Acceptance form tests: `paths: a/**`, `paths: a/**, b/**`, and the
+    #10958 reproducer `paths: a/** -- 2026-08-11T18:10Z` all parse to the
+    same clean glob list."""
+    base = "[CLAIMED] lane L:CoursIA -- paths: {}"
+    # Form 1 -- single glob, no suffix.
+    assert clc._extract_paths_clause(base.format("scripts/*.py")) == \
+        ["scripts/*.py"]
+    # Form 2 -- comma list, no suffix.
+    assert clc._extract_paths_clause(
+        base.format("scripts/*.py, docs/**/*.md")) == \
+        ["scripts/*.py", "docs/**/*.md"]
+    # Form 3 -- trailing ` -- <timestamp>` (the fleet body-timestamp form).
+    assert clc._extract_paths_clause(
+        base.format("scripts/*.py -- 2026-08-11T18:10Z")) == ["scripts/*.py"]
+    # Em-dash prose annotation truncates identically.
+    assert clc._extract_paths_clause(
+        base.format("MyIA.AI.Notebooks/Sudoku/** — Phase 2 : prose")) == \
+        ["MyIA.AI.Notebooks/Sudoku/**"]
+    # Truncation happens at the FIRST separator only -- the glob list never
+    # keeps anything past it.
+    assert clc._extract_paths_clause(
+        base.format("scripts/*.py -- ts -- more words")) == ["scripts/*.py"]
+
+
+def test_paths_clause_keeps_non_spaced_separator_inside_glob():
+    """The separator needs whitespace on BOTH sides. `foo--bar.py` (double
+    dash, no spaces) is a legitimate filename character sequence and must
+    survive the truncation untouched."""
+    assert clc._extract_paths_clause(
+        "[CLAIMED] lane L:CoursIA -- paths: docs/foo--bar.md, scripts/a.py") \
+        == ["docs/foo--bar.md", "scripts/a.py"]
+
+
+def test_empty_scope_in_witness():
+    """`_empty_scope_in` returns the globs matching ZERO tracked files (the
+    #10958 witness). None tracked (no repo walk) -> no witness, no lift."""
+    tracked = ["scripts/check_lane_claim.py", "scripts/grain_tag.py"]
+    assert clc._empty_scope_in(["scripts/check_lane_claim.py"], tracked) == []
+    assert clc._empty_scope_in(["nowhere/typo.py"], tracked) == \
+        ["nowhere/typo.py"]
+    # Mixed live/dead -> only the dead subset comes back (partial witness).
+    assert clc._empty_scope_in(
+        ["scripts/check_lane_claim.py", "nowhere/typo.py"], tracked) == \
+        ["nowhere/typo.py"]
+    assert clc._empty_scope_in([], tracked) == []
+    # No walk -> we cannot prove deadness -> empty witness (no lift).
+    assert clc._empty_scope_in(["nowhere/typo.py"], None) == []
+
+
+def test_run_check_dead_scope_blocks_other_lane(capsys):
+    """CORE #10958 fail-safe, end-to-end: a scoped claim whose every glob is
+    dead (here a typo'd path, WITH the ` -- ts` suffix the truncation now
+    handles) is lifted to epic-wide and BLOCKS another lane checking the
+    same issue. Pre-fix this was the #9764-style false CLEAR."""
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA-2 -- "
+            "paths: scripts/nowhere/typo.py -- 2026-08-11T18:10Z",
+            "2026-08-12T11:00:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA")
+    assert rc == 1  # lifted to epic-wide -> blocks
+    captured = capsys.readouterr()
+    assert "BLOCKED" in captured.err
+    # The audit JSON names the dead glob so the lane learns to reissue.
+    assert '"empty_scope"' in captured.out
+    assert "scripts/nowhere/typo.py" in captured.out
+
+
+def test_run_check_summary_exposes_empty_scope_field(capsys):
+    """Acceptance: dead globs surface in the audit JSON under
+    `active_claims.<lane>.empty_scope`, not only as a stderr WARN. A
+    PARTIALLY dead scope still surfaces its dead glob without lifting."""
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: "
+            "scripts/check_lane_claim.py, scripts/nowhere/typo.py",
+            "2026-08-12T11:00:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA")
+    assert rc == 1  # no my_scope -> the scoped claim still blocks
+    out = capsys.readouterr().out
+    assert '"empty_scope"' in out
+    assert "scripts/nowhere/typo.py" in out
+
+
+def test_run_check_my_dead_scope_keeps_others(capsys):
+    """Caller-side guard: when MY OWN scope is entirely dead, I cannot use
+    disjointness to clear another lane -- globs that lock nothing prove
+    nothing. Every other lane stays -> BLOCKED until my claim is reissued."""
+    p = payload(
+        comment("[CLAIMED] lane A:CoursIA -- paths: scripts/nowhere/typo.py",
+                "2026-08-11T04:02:00Z"),
+        comment("[CLAIMED] lane B:CoursIA-2 -- paths: scripts/grain_tag.py",
+                "2026-08-11T04:05:00Z"),
+    )
+    rc = clc._run_check(p, "A:CoursIA")
+    assert rc == 1
+    assert "BLOCKED" in capsys.readouterr().err
+
+
+def test_run_check_partially_dead_scope_stays_scoped(capsys):
+    """A PARTIALLY dead scope (at least one live glob) is NOT lifted: the
+    lock is real on its live part. Two lanes on disjoint live parts still
+    clear each other -- the fail-safe must not recreate epic-wide blocking
+    for a mostly-correct claim."""
+    p = payload(
+        comment("[CLAIMED] lane A:CoursIA -- paths: scripts/nowhere/typo.py, "
+                "scripts/check_lane_claim.py",
+                "2026-08-11T04:02:00Z"),
+        comment("[CLAIMED] lane B:CoursIA-2 -- paths: scripts/grain_tag.py",
+                "2026-08-11T04:05:00Z"),
+    )
+    rc = clc._run_check(p, "A:CoursIA")
+    assert rc == 0
+    assert '"blocking_lanes": []' in capsys.readouterr().out
 
 
 # --- #10597 bonus -- SCOPE_ZERO_COVERAGE warning ------------------------------
@@ -1984,19 +2133,29 @@ def test_lint_override_without_paths_emits_info(capsys):
     assert "il bloque toutes les autres lanes sur #10678" in err
 
 
-def test_lint_prose_after_clause_warns_suspect_and_dead_globs(capsys):
-    # F2 -- the 06:41:00Z [CLAIMED]: prose after the clause was swallowed as
-    # three parasite globs; the last real glob (`Sudoku/** — Phase 2 : ...`)
-    # is dead. The lint must WARN citing the faulty excerpt verbatim.
+def test_lint_f2_prose_suffix_now_truncated_silent(capsys):
+    # F2 -- the 06:41:00Z [CLAIMED]: prose after the clause used to be
+    # swallowed into the last glob (`Sudoku/** — Phase 2 : ...`), which the
+    # #10881 lint could only WARN about. #10958 fixes the defect AT PARSE:
+    # `_extract_paths_clause` truncates the ` — <annotation>` suffix, so the
+    # glob list comes out clean (9 family globs, all alive) and the lint is
+    # SILENT on this form -- the defect class no longer exists to detect.
+    # F4 below still pins the lint's own value: prose WITHOUT a
+    # whitespace-delimited ` -- `/` — ` separator is still swallowed and
+    # still WARNs.
     p = payload(comment(F2_PROSE_AFTER_CLAUSE, "2026-08-14T06:41:00Z"),
                 number=10678)
     rc = clc._run_check(p, "myia-po-2025:CoursIA")
-    assert rc == 1  # verdict unchanged
+    assert rc == 1  # verdict unchanged: po-2024's scoped claim blocks
     err = capsys.readouterr().err
-    assert "WARN: glob suspect (prose avalée ?)" in err
-    assert "Sudoku/** — Phase 2 : repositionnement des 39 interps survivants" in err
-    assert "WARN: glob sans correspondance" in err
-    assert "markdown-only" in err
+    assert "WARN:" not in err
+    # The parse-layer proof: the truncated clause keeps exactly the 9 family
+    # globs and drops the ` — Phase 2 : ...` annotation entirely.
+    evs = clc._parse_claim_events(comment(F2_PROSE_AFTER_CLAUSE,
+                                          "2026-08-14T06:41:00Z"))
+    got = evs[-1].paths
+    assert got[-1] == "MyIA.AI.Notebooks/Sudoku/**"
+    assert all("—" not in g and ":" not in g for g in got), got
 
 
 def test_lint_family_globs_are_silent(capsys):
@@ -2150,7 +2309,8 @@ def test_third_lane_disjoint_paths_clear_after_release_reclaim(capsys):
     )
     rc = clc._run_check(
         p, "myia-po-2026:CoursIA",
-        my_paths=["MyIA.AI.Notebooks/Sudoku/Sudoku-9.ipynb"],
+        my_paths=["MyIA.AI.Notebooks/Sudoku/"
+                  "Sudoku-9-GraphColoring-Csharp.ipynb"],
     )
     assert rc == 0
     captured = capsys.readouterr()


### PR DESCRIPTION
## Summary

Deux classes de défauts, une cause racine : une annotation en fin de liste de globs (`paths: a/** -- 2026-08-11T18:10Z` body-timestamp de la flotte, ou `paths: .../** — Phase 2 : prose` rationale) était avalée dans le DERNIER glob par le regex de clause glouton sur la ligne. Le glob ne matchait alors plus aucun fichier suivi — un verrou mort — et la lecture ancienne était **fail-open** : un scope mort n'intersecte rien, donc le claim clearait silencieusement toutes les autres lanes (faux CLEAR #9764).

### Couche parse — troncature du suffixe

`_extract_paths_clause` tronque maintenant le suffixe à la **première** occurrence du séparateur délimité par whitespace des deux côtés (`_ANNOTATION_SUFFIX_RE = r"\s+(?:--|—|–)\s+"`). Les tirets non-espacés internes à un chemin (`foo--bar.py`) survivent intacts.

### Couche check — fail-safe dead-scope lift

Un scope dont TOUS les globs sont morts (post-troncature : un typo) est un claim **cassé**, pas permissif → lifté epic-wide (bloquant), en miroir du hardener #10597 (`unparseable_scope`). Un scope **partiellement** mort reste scopé sur sa partie vivante (le verrou est réel). Le témoin des globs morts remonte dans le JSON d'audit sous `empty_scope`, alimenté par **un seul walk partagé** `git ls-files` (lint #10881 + témoin #10958). Garde côté appelant : un scope à MOI entièrement mort ne prouve rien non plus — les autres lanes sont conservées jusqu'à re-issuance du claim.

### Tests (130 passed — 7 nouveaux, 8 fixtures migrées)

- `test_paths_clause_truncates_annotation_suffix_three_forms` — acceptance #4 verbatim : les 3 formes (`paths: a/**`, `paths: a/**, b/**`, `paths: a/** -- 2026-08-11T18:10Z`) + em-dash prose + coupure à la première occurrence.
- `test_paths_clause_keeps_non_spaced_separator_inside_glob` — `foo--bar.py` survit.
- `test_empty_scope_in_witness` — témoin unitaire (live/dead/mixte/None).
- `test_run_check_dead_scope_blocks_other_lane` — fail-safe end-to-end (exit 1 + témoin JSON).
- `test_run_check_summary_exposes_empty_scope_field` — acceptance #2 : JSON, pas seulement WARN stderr.
- `test_run_check_my_dead_scope_keeps_others` — garde appelant.
- `test_run_check_partially_dead_scope_stays_scoped` — sélectivité.
- Fixtures migrées vers des chemins réels suivis (`MyIA.AI.Notebooks/...`, `scripts/notebook_tools/twin_pairs.d/...`, `scripts/grain_tag.py`) : le lift dead-scope inverse les verdicts CLEAR bâtis sur des chemins fictifs.
- Test #10881 F2 ré-ancré : la forme tronquée parse propre → lint silencieux dessus (F4 prose sans séparateur WARN toujours — pins la valeur propre du lint).

### Acceptance #5 — scan des claims actifs portant la forme polluée

Scan des 18 issues ouvertes les plus récemment actives (commentaires `[CLAIMED|OVERRIDE] ... paths:` avec suffixe ` -- `/` — `), exécution de l'outil corrigé contre chacune :

- **Tous les claims ACTIFS parsent désormais proprement** — soit re-post propre déjà effectué (#10474 : claim actif `SemanticKernel/**` clean ; #10479 : claim actif 13:10:25Z clean), soit troncature efficace (#10923 : `_quarto.yml, scripts/regen_quarto_render.py, ...` tronqué propre).
- Les formes polluées restantes (#10678 : claim 9-familles F2, sub-grains ` -- grain MED/...`) sont **historiques** — supplantées par des marqueurs ultérieurs dans le walk.
- **Résidu live remonté par le nouveau témoin** : le claim actif po-2025:CoursIA-2 sur #10923 porte un glob réellement mort `MyIA.AI.Notebooks/Search/_quarto.yml` (partial scope → reste scopé sur ses 2 globs vivants, `empty_scope` + WARN remontés à son owner via dashboard).

## Validation

- `python -m pytest scripts/tests/test_check_lane_claim.py` → **130 passed** (123 pré-existants + 7 nouveaux), relancé après le dernier commit.
- Exécution live de l'outil corrigé contre #10474 / #10923 / #10678 / #10479 (payloads réels) : troncature, témoins `empty_scope` et lift observés conformes.
- `git merge-base --is-ancestor origin/main HEAD` → base fraîche.
- Catalogue byte-identique à main (aucun fichier catalogue touché).

Grain: MED/guard — lane myia-po-2023:CoursIA — prev: DEEP/sk #10964

Closes #10958

Co-Authored-By: Claude-Code <noreply@anthropic.com>