### PR TITLE
feat(site,#10923): pilote rendu HTML notebooks Search — globs + _metadata.yml + exclusions

### DIFF
--- a/MyIA.AI.Notebooks/Search/_metadata.yml
+++ b/MyIA.AI.Notebooks/Search/_metadata.yml
@@ -1,0 +1,9 @@
+# EPIC #10921 — pilote Phase A (#10923) : notebooks Search/ rendus en HTML.
+# - echo: true : override du `execute.echo: false` global — les cellules de
+#   code doivent etre visibles sur la page rendue (sinon pire que le JSON brut).
+# - enabled: false : jamais d'execution de kernel — le rendu consomme les
+#   outputs commites (regle C.2), compatible avec la CI (freeze, pas de kernel).
+execute:
+  echo: true
+  enabled: false
+  warning: false

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -397,6 +397,26 @@ project:
     - "slides/S6-tweety/README.md"
     - "slides/S7-lean/README.md"
     - "slides/S8-semantic-web/README.md"
+    # Notebooks .ipynb rendus en HTML (EPIC #10921, pilote Phase A #10923).
+    # Globs par sous-serie (pas Search/**) : exclut Search/_archive.
+    # 5 globs de serie.
+    - "MyIA.AI.Notebooks/Search/Part1-Foundations/**/*.ipynb"
+    - "MyIA.AI.Notebooks/Search/Part2-CSP/**/*.ipynb"
+    - "MyIA.AI.Notebooks/Search/Part3-Advanced/**/*.ipynb"
+    - "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/**/*.ipynb"
+    - "MyIA.AI.Notebooks/Search/Applications/**/*.ipynb"
+    # 7 notebooks exclu du rendu : output image GIF encode en base64 dans un
+    # output text/html de 212 a 795 KB -> le renderer Quarto/pandoc 1.7 boucle
+    # indefiniment (repro isolee : solo render timeout 150s, rc=124 ; sans cet
+    # output le notebook rend en quelques secondes). Seuil : <=24 KB OK,
+    # >=212 KB hang. Les fichiers .ipynb restent servis bruts (statu quo).
+    - "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb"
+    - "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-8-LandscapeExplorer.ipynb"
+    - "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb"
+    - "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb"
+    - "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-13-LandscapeDebias.ipynb"
+    - "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-14-IslandSynergyFound.ipynb"
+    - "!MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb"
 site:
   title: "CoursIA"
   description: "Apprendre l'intelligence artificielle par la pratique, des fondements théoriques aux applications avancées."

--- a/scripts/regen_quarto_render.py
+++ b/scripts/regen_quarto_render.py
@@ -12,9 +12,15 @@ preserving the rest of ``_quarto.yml`` byte-for-byte. It is meant to be run:
   - on CI as a pre-render step of ``quarto-pages-deploy.yml`` (so new READMEs
     appear on the site without a manual regen commit).
 
-The .ipynb notebooks are intentionally NOT added: ``notebook-preview: false``
-+ ``freeze: auto`` keep them copied verbatim with their committed outputs
-(rule C.2), without kernel re-execution on CI.
+Since EPIC #10921 (pilot Phase A #10923), the ``Search/`` notebook series is
+additionally rendered as HTML: ``notebook-preview: false`` only governs the
+preview of an embedded notebook, not membership in the render list, and
+``freeze: auto`` keeps CI from executing any kernel (outputs are committed,
+rule C.2). The series-specific ``echo: true`` / ``execute: enabled: false``
+override lives in ``MyIA.AI.Notebooks/Search/_metadata.yml`` — a
+directory-level metadata file, NOT ``_quarto.yml`` (a nested ``_quarto.yml``
+would create a nested Quarto project boundary and hijack the site render
+into sidecar HTML next to the sources).
 
 Usage:
     python scripts/regen_quarto_render.py            # rewrite _quarto.yml in place
@@ -54,6 +60,42 @@ EXCLUDE_MARKERS = (
     "/archive/",           # any archive/ subdir (notebook families, scripts)
     "\\archive\\",
 )
+
+
+# Notebook series rendered as HTML (EPIC #10921, pilot Phase A #10923).
+# Quarto 1.7 expands ``**`` for .ipynb globs in project.render — matching both
+# direct children and nested subdirectories (validated locally against
+# 1.7.32). Per-series globs instead of ``Search/**``: the single glob would
+# also match ``Search/_archive`` (internal history, excluded like the README
+# archives above) and stay readable in the diff. The subtree override
+# (echo: true, execute: enabled: false) lives in
+# ``MyIA.AI.Notebooks/Search/_metadata.yml`` (directory-level metadata).
+NOTEBOOK_RENDER_GLOBS = [
+    "MyIA.AI.Notebooks/Search/Part1-Foundations/**/*.ipynb",
+    "MyIA.AI.Notebooks/Search/Part2-CSP/**/*.ipynb",
+    "MyIA.AI.Notebooks/Search/Part3-Advanced/**/*.ipynb",
+    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/**/*.ipynb",
+    "MyIA.AI.Notebooks/Search/Applications/**/*.ipynb",
+]
+
+# Notebooks excluded from the render via ``!`` negation (applied after the
+# positive globs). Each carries a GIF image embedded as a base64 data URI in a
+# ``text/html`` output cell of 212-795 KB: the Quarto/pandoc 1.7 renderer hangs
+# indefinitely on it (isolated repro: solo ``quarto render`` times out at 150s,
+# rc=124; the same notebook without that single output renders in seconds.
+# Boundary probed: <=24 KB renders fine, >=212 KB hangs). The ``.ipynb`` files
+# stay served raw by the site (status quo for them). Lifting one exclusion
+# requires first fixing the renderer hang (output externalization or a Quarto
+# filter), tracked on EPIC #10921 Phase B.
+NOTEBOOK_EXCLUDE_GLOBS = [
+    "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb",
+    "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-8-LandscapeExplorer.ipynb",
+    "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb",
+    "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb",
+    "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-13-LandscapeDebias.ipynb",
+    "!MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-14-IslandSynergyFound.ipynb",
+    "!MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb",
+]
 
 
 def git_tracked_readmes() -> list[str]:
@@ -100,6 +142,20 @@ def build_render_block() -> list[str]:
     lines.append('    - "README.md"')
     for p in readmes:
         lines.append(f'    - "{p}"')
+    # Notebooks .ipynb rendus en HTML (pilote Phase A #10923).
+    lines.append("    # Notebooks .ipynb rendus en HTML (EPIC #10921, pilote Phase A #10923).")
+    lines.append("    # Globs par sous-serie (pas Search/**) : exclut Search/_archive.")
+    lines.append(f"    # {len(NOTEBOOK_RENDER_GLOBS)} globs de serie.")
+    for g in NOTEBOOK_RENDER_GLOBS:
+        lines.append(f'    - "{g}"')
+    # Notebooks excluded via ! negation (renderer hang, see NOTEBOOK_EXCLUDE_GLOBS).
+    lines.append("    # 7 notebooks exclu du rendu : output image GIF encode en base64 dans un")
+    lines.append("    # output text/html de 212 a 795 KB -> le renderer Quarto/pandoc 1.7 boucle")
+    lines.append("    # indefiniment (repro isolee : solo render timeout 150s, rc=124 ; sans cet")
+    lines.append("    # output le notebook rend en quelques secondes). Seuil : <=24 KB OK,")
+    lines.append("    # >=212 KB hang. Les fichiers .ipynb restent servis bruts (statu quo).")
+    for g in NOTEBOOK_EXCLUDE_GLOBS:
+        lines.append(f'    - "{g}"')
     return lines
 
 

--- a/scripts/tests/test_regen_quarto_render.py
+++ b/scripts/tests/test_regen_quarto_render.py
@@ -303,6 +303,56 @@ class TestLandingPages:
 
 
 # ---------------------------------------------------------------------------
+# NOTEBOOK_RENDER_GLOBS — Search/ series rendered as HTML (EPIC #10921, #10923)
+# ---------------------------------------------------------------------------
+
+class TestNotebookRenderGlobs:
+    def test_globs_after_readmes_in_render_block(self, monkeypatch):
+        """The notebook globs are emitted by build_render_block() — without
+        them, the CI pre-render regen strips the Search/ notebooks from
+        project.render and the site stops rendering them (#10923)."""
+        monkeypatch.setattr(rqr, 'git_tracked_readmes', lambda: [
+            'MyIA.AI.Notebooks/Search/README.md'])
+        lines = rqr.build_render_block()
+        first_glob = lines.index(f'    - "{rqr.NOTEBOOK_RENDER_GLOBS[0]}"')
+        readme_line = lines.index('    - "MyIA.AI.Notebooks/Search/README.md"')
+        assert first_glob > readme_line
+
+    def test_all_globs_emitted(self, monkeypatch):
+        monkeypatch.setattr(rqr, 'git_tracked_readmes', lambda: [])
+        block = '\n'.join(rqr.build_render_block())
+        for g in rqr.NOTEBOOK_RENDER_GLOBS:
+            assert f'    - "{g}"' in block
+
+    def test_globs_exclude_archive(self):
+        # Per-series globs, never a bare Search/** which would match _archive
+        for g in rqr.NOTEBOOK_RENDER_GLOBS:
+            assert 'Search/**' not in g
+            assert g.startswith('MyIA.AI.Notebooks/Search/')
+
+    def test_exclude_negations_emitted_after_globs(self, monkeypatch):
+        """The 7 renderer-hang notebooks are excluded via ! negation, emitted
+        by build_render_block() — without this, the CI pre-render regen drops
+        the negations and the deploy hangs on those notebooks (#10923)."""
+        monkeypatch.setattr(rqr, 'git_tracked_readmes', lambda: [])
+        lines = rqr.build_render_block()
+        last_glob = max(lines.index(f'    - "{g}"') for g in rqr.NOTEBOOK_RENDER_GLOBS)
+        for g in rqr.NOTEBOOK_EXCLUDE_GLOBS:
+            assert g.startswith('!')
+            assert lines.index(f'    - "{g}"') > last_glob
+
+    def test_exclude_negations_target_known_hangs(self):
+        # Every negation must match a file the positive globs would render:
+        # a stale negation path silently excludes nothing (or the wrong file).
+        import re
+        positive = [re.escape(g).replace(r"\*\*/", "(?:.*/)?").replace(r"\*", "[^/]*")
+                    for g in rqr.NOTEBOOK_RENDER_GLOBS]
+        for g in rqr.NOTEBOOK_EXCLUDE_GLOBS:
+            path = g[1:]
+            assert any(re.fullmatch(p, path) for p in positive), path
+
+
+# ---------------------------------------------------------------------------
 # argparse — --check flag
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Grain: MED/site — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #10965

See #10923 (Phase A pilote, EPIC #10921) — contribution au pilote, l'epic reste ouverte.

**PR stacked sur #10965** (normalisation `---`→`***` des notebooks, meme lane) — **merge order : #10965 d'abord, puis celle-ci**. Cette PR ne touche AUCUN notebook : elle est la partie infra du pilote (`_quarto.yml` + override + script de regen), comme prevu dans le plan de split de #10965.

## Objectif

Rendre les notebooks de la serie `MyIA.AI.Notebooks/Search/` en HTML sur le site github.io, sans execution de kernel en CI (les outputs commites, regle C.2, sont la source du rendu).

## Changements (4 fichiers)

1. **`_quarto.yml`** : 5 globs de serie ajoutes au bloc `project.render` (apres les READMEs) — `Search/Part1-Foundations/**/*.ipynb`, `Part2-CSP`, `Part3-Advanced`, `Part4-Metaheuristics`, `Applications`. Globs par sous-serie (pas `Search/**`) pour exclure `Search/_archive`. Plus 7 negations `!` (voir section defect). Diff voulu minimal : aucune autre ligne du bloc touchee.
2. **`MyIA.AI.Notebooks/Search/_metadata.yml`** (nouveau, metadata de niveau repertoire) : `execute: { echo: true, enabled: false, warning: false }` — le code doit rester visible sur la page rendue, aucun kernel n'est lance, le rendu consomme les outputs commis. Application recursive aux 5 sous-series validee (direct + imbrique). **Pas un `_quarto.yml`** : un `_quarto.yml` imbrique cree une frontiere de projet Quarto qui detourne le rendu du site (HTML en sidecar pres des sources au lieu de `_site/`) — piege diagnostique et valide contre dans un projet temoin.
3. **`scripts/regen_quarto_render.py`** : constantes `NOTEBOOK_RENDER_GLOBS` + `NOTEBOOK_EXCLUDE_GLOBS` reprises par `build_render_block()` — sans elles, la CI (qui relance le script avant `quarto render`) ecraserait les globs ET les negations a chaque deploiement. Docstring mise a jour.
4. **`scripts/tests/test_regen_quarto_render.py`** : +5 tests de non-regression (emission des globs, position apres les READMEs, exclusion d'archive, emission des negations apres les globs, ciblage des negations sur les globs positifs). Tests : 40/40 pass.

Convergence verifiee : la section notebooks emise par `build_render_block()` est IDENTIQUE ligne a ligne au bloc inscrit a la main dans `_quarto.yml` (les deux chemins produisent le meme YAML).

## Defect renderer base64 (7 notebooks exclus du rendu)

Chacun des 7 notebooks exclus porte un **output image GIF encode en base64 dans un output `text/html`** (data URI). Le renderer Quarto/pandoc 1.7.32 **boucle indefiniment** dessus : un `quarto render <file>` solo depasse 150 s (rc=124 sous `timeout`), bloque sur CPU. Preuve de causalite : le meme notebook prive de CE SEUL output (copie temporaire, jamais commitee) rend en quelques secondes.

| Notebook | Taille du output base64 | Verdict |
|---|---|---|
| MGS-9-EverestRelief | 795 KB | hang |
| MGS-14-IslandSynergyFound | 609 KB | hang |
| App-9b-EdgeDetection-CSharp | 427 KB | hang |
| MGS-4-Islands | 368 KB | hang |
| MGS-8-LandscapeExplorer | 351 KB | hang |
| MGS-11-IslandSynergy | 318 KB | hang |
| MGS-13-LandscapeDebias | 212 KB | hang |

Frontiere sondee : <=24 KB (CSP-9 24 KB, App-15b 20 KB, CSP-6 19 KB, CSP-2 18 KB) rend en 1-2 s ; >=212 KB hang.

**Decision** : exclusion `!` du rendu (les `.ipynb` restent servis bruts, comme sur main aujourd'hui). Les outputs NE SONT PAS touches (regle C.2 : les outputs commis sont le livrable ; les stripper serait une regression). La levee d'exclusion = **Phase B de #10921**, arbitrage ai-01 — donnee utile pour la decision : #10969 (po-2024) a mesure que **nbconvert 7.17.1 rend App-9b (4.8 MB) en 4.0 s** — la pathologie est le reader ipynb de pandoc, pas le notebook ; un rendu nbconvert pour ces 7 la est une piste Phase B viable.

## Criteres d'acceptation (arbitrage ai-01 sur #10923)

| # | Critere | Preuve |
|---|---------|--------|
| 1 | Notebooks rendus en HTML | `quarto render` **rc=0, duree 808 s (13m28s), 0 erreur** — 111/118 notebooks en HTML, 7 exclus (defect base64, cf section dediee) |
| 2 | Code visible (piege echo) | Verifie dans les pages rendues + capture navigateur (detail section Validation locale) : `Search-3-Informed-Csharp.html` contient `<code>PriorityQueue&lt;TElement, TPriority&gt;</code>` et `public Node(string state, Node parent = null...)` dans un bloc syntaxique ; `CSP-5-BinPacking.html` contient `<code class="sourceCode python">` avec l'output commis « Nombre optimal de bins: 2 » ; `Search-2-Uninformed.html` embarque 8 `<img>` (figures PIL des outputs) |
| 3 | Pas d'execution kernel en CI | `execute.enabled: false` (override sous-arbre `_metadata.yml`) + `freeze: auto` global ; aucune cellule re-executee localement non plus |
| 4 | Taille _site avant/apres + duree | **Apres : 1977 fichiers / 357 MB / 808 s** vs **baseline main : 1775 fichiers / 347 MB / 10m49s (649 s)** — +202 fichiers (+111 HTML notebooks + sidecars figures), +10 MB, +159 s de rendu |
| 5 | Catalogue byte-identique a main | `git diff origin/main...HEAD --name-only` : 0 fichier `COURSE_CATALOG.*` / `CATALOG-STATUS` |

## Validation locale (Quarto 1.7.32, meme version que la CI, arbre final = #10965 + cette PR)

```
quarto render --to html   →  rc=0, duree 808 s, 0 erreur de rendu
_site                      →  1977 fichiers / 357 MB  (baseline main: 1775 fichiers / 347 MB en 10m49s)
notebooks Search en HTML   →  111/118  (7 exclus par negation, .ipynb bruts servis — statu quo main)
```

Verification des 7 exclusions : aucun des 7 chemins neges n'a de `.html` dans `_site/` ; chacun a son `.ipynb` servi brut.

Preuve echo (code visible) sur l'arbre final :

- `Search-3-Informed-Csharp.html` : `<code>PriorityQueue&lt;TElement, TPriority&gt;</code>` et `public Node(string state, Node parent = null...)` presents dans des blocs C# syntaxiques (le markdown-to-HTML n'a pas avale le code).
- `CSP-5-BinPacking.html` : `<code class="sourceCode python">` + l'output commis « Nombre optimal de bins: 2 » sur la meme page rendue.
- `Search-2-Uninformed.html` : 8 `<img>` (figures PIL extraites des outputs commis).
- Navigateur (http.server local) : `Search-3-Informed-Csharp.html` affiche 29 blocs de code ; capture ecran du bloc `PriorityQueue` validee.

Note execution : le rendu complet du site exige >10 min ; le processus a ete lance via PowerShell `Start-Process` (un rendu lance depuis le shell Bash sandbox est tue silencieusement vers ~100 s).

## Risques / residuel

- La liste README du bloc render de `_quarto.yml` (branche) reste la liste de #10965 (383 entrees) : drift README possible jusqu'a la prochaine regen CI — la CI relance le script avant chaque deploiement, qui regenere la liste complete ET preserve globs+negations (tests 4/5 ci-dessus).
- Les autres series (GameTheory, Probas...) ne sont PAS dans ce pilote (scope Phase A = Search uniquement).
- La navbar site (sequencement #10963/#10925) est hors scope de cette PR.
