### PR TITLE
fix(lean,#6724): prove N3 jump guard dead — evolveHashlifeFastN = evolve for all n (b2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean
@@ -395,46 +395,62 @@ Cette section **ajoute** la variante consciente de n sans toucher a
 `evolveHashlifeFast` ni a aucun de ses 50+ sites d'appel / preuves :
 
 - `evolveHashlifeFastAuxN` / `evolveHashlifeFastN` — meme recursion que
-  `evolveHashlifeFastAux`, mais la MacroCell initiale est construite avec
-  le cadre conscient de n `gridToMacroCellWithOffsetN n g`. Les iterations
-  ulterieures utilisent le constructeur a cadre fixe (N3 = "tramer sans
-  re-cadrer", selon le commentaire de conception N1 a MacroCell L634).
+  `evolveHashlifeFastAux`, mais chaque iteration re-cadre via le
+  constructeur conscient de n `gridToMacroCellWithOffsetN` : l'appel
+  recursif `evolveHashlifeFastAuxN fuel (n - js) g'` re-entre dans
+  `gridToMacroCellWithOffsetN (n - js) g'` sur la grille sautee. (Le
+  commentaire de conception N1 a MacroCell L634 decrivait un tramage
+  "sans re-cadrer" ; le code, lui, re-cadre a chaque iteration — c'est
+  le code qui fait foi, la doc a ete alignee.)
 - `evolveHashlifeFastN_zero` — verification triviale : `n = 0` renvoie `g`.
+- `evolveHashlifeFastAuxN_eq_evolve` / `evolveHashlifeFastN_eq_evolve` —
+  **tranche (b2), #6724 : le garde de saut N3 est mort.** Le rembourrage
+  `max 2 n` de `gridFrameN` force `2 ^ lvl ≥ side ≥ 2 * n + 1 > n`
+  (`gridToMacroCellWithOffsetN_level_gt_n`, MacroCell), donc le garde
+  `lvl ≥ 2 ∧ n ≥ jumpSize lvl` est insatisfait pour toute grille non
+  vide (et `lvl = 0 < 2` pour la vide) : la branche de saut ne tire
+  jamais et la variante N3 degénère en le `evolve` de reference.
 
-Le **pont** `evolveHashlifeFastN n g = evolveHashlifeFast n g` pour `n ≤ 2`
-(via `gridToMacroCellWithOffsetN_le_two_eq` + induction structurelle sur
-`fuel`) est **reporte** a un cycle ulterieur, jumele avec le deblocage
-P4 : il exige le demontage complet du corps dans le style
-`evolveHashlifeFastMemo_eq_evolveHashlifeFast`, qu'il est preferable
-d'assembler une fois le harnais Lean LSP (terrain d'ai-01, apres le fix
-H) de retour a une interactivite complete. Documenter ici l'obligation
-de preuve garde le plan de refonte P5 honnete et evite un stub creux. -/
+Le **pont** `evolveHashlifeFastN n g = evolve n g` est donc prouve pour
+TOUT n comme corollaire immediat du garde mort — plus fort que le pont
+`n ≤ 2` vers `evolveHashlifeFast` initialement reporte (la composante
+Hashlife est simplement inactive, au prix honnete de l'acceleration).
+Le dejouement pour la refonte P5 : couvrir le cone des n generations
+restantes par le rembourrage est auto-sabotant — le cadre gonfle au-dela
+du horizon du saut qu'il conditionne. La sortie identifiee (amendement
+j/p>=3, tranche par le coordinateur sur #6724) est la decorrelation j de
+Gosper (`hashlifeResultAt j`, a implémenter) : a j = level-3 la portee
+du saut retombe sous la marge de fenetre quelle que soit la profondeur
+de rembourrage (`jumpReach`/`marginToResultWindow` dans `JumpCapture`,
+etape 2), ce qui rend `jumpCaptured` tenable par cone avec un
+rembourrage petit et un garde vivable. -/
 
 /-- Auxiliaire trame N3 pour `evolveHashlifeFastN` : meme recursion que
-    `evolveHashlifeFastAux`, mais la MacroCell initiale est construite
-    avec le cadre conscient de n `gridToMacroCellWithOffsetN n g`. Les
-    appels recursifs ulterieurs (la branche `n - js`) utilisent le
-    constructeur a cadre fixe — N3 trame le cadre *sans* re-cadrer a
-    chaque iteration (selon le commentaire de conception N1 a MacroCell
-    L634). -/
+    `evolveHashlifeFastAux`, mais chaque iteration re-cadre via le
+    constructeur conscient de n `gridToMacroCellWithOffsetN` — l'appel
+    recursif sur `n - js` re-entre dans le cadrage conscient du n restant
+    sur la grille sautee. Attention (tranche (b2), #6724) : sous ce
+    cadrage, le garde de saut `lvl ≥ 2 ∧ n ≥ js` est structurellement
+    mort — voir `evolveHashlifeFastAuxN_eq_evolve` ci-dessous. -/
 def evolveHashlifeFastAuxN : Nat → Nat → Grid → Grid
   | _, 0, g => g
   | 0, _, g => g  -- fuel epuise : retourner l'etat courant
   | fuel + 1, n, g =>
-    -- Substitution N3 : cadre conscient de n sur la MacroCell initiale seulement.
+    -- Cadrage conscient de n a CHAQUE iteration : l'appel recursif de la
+    -- branche de saut re-entre dans gridToMacroCellWithOffsetN (n - js).
     let (off, mc) := gridToMacroCellWithOffsetN n g
     let lvl := mc.level
     let js := jumpSize lvl
     if lvl >= 2 && n >= js then
       -- Saut en avant de `2^lvl` generations avec Hashlife rembourre,
-      -- puis re-cadrage a partir du cadre fixe de la nouvelle grille (sautee).
+      -- puis re-cadrage conscient du n restant sur la grille sautee.
+      -- NB (tranche (b2), #6724) : branche actuellement MORTE —
+      -- `gridToMacroCellWithOffsetN_level_gt_n` (MacroCell) force
+      -- `2^lvl > n = js`, le garde ne peut jamais tirer tant que le
+      -- rembourrage `max 2 n` gouverne le niveau du cadre.
       let jumped := hashlifeJump mc
       let newOff := jumpResultOff off lvl
       let g' := jumped.toGrid newOff
-      -- Les iterations ulterieures utilisent le constructeur a cadre fixe,
-      -- PAS le conscient de n — le parametre n est deja consomme par `n - js`,
-      -- et re-cadrer avec le *nouveau* `n` gonflerait inutilement le
-      -- rembourrage alors que la boite englobante a retreci apres le saut.
       evolveHashlifeFastAuxN fuel (n - js) g'
     else
       -- Petit n ou petit motif : utiliser le evolve de reference.
@@ -454,6 +470,52 @@ def evolveHashlifeFastN (n : Nat) (g : Grid) : Grid :=
 @[simp]
 theorem evolveHashlifeFastN_zero (g : Grid) :
     evolveHashlifeFastN 0 g = g := rfl
+
+/-- **Tranche (b2), #6724 : le garde de saut N3 est mort.** Pour toute
+    grille, le garde `lvl ≥ 2 ∧ n ≥ jumpSize lvl` de la branche de saut
+    est insatisfait : grille vide → `lvl = 0 < 2` ; grille non vide →
+    `gridToMacroCellWithOffsetN_level_gt_n` donne `2 ^ lvl > n` alors que
+    `jumpSize lvl = 2 ^ lvl`. La branche de saut ne tire donc jamais, et
+    l'auxiliaire N3 rend exactement le `evolve` de reference. -/
+theorem evolveHashlifeFastAuxN_eq_evolve (fuel n : Nat) (g : Grid)
+    (hfuel : 1 ≤ fuel) :
+    evolveHashlifeFastAuxN fuel n g = evolve n g := by
+  obtain ⟨fuel', rfl⟩ : ∃ k, fuel = k + 1 := ⟨fuel - 1, by omega⟩
+  cases n with
+  | zero => rfl
+  | succ m =>
+    simp only [evolveHashlifeFastAuxN]
+    split
+    · next hcond =>
+      exfalso
+      simp only [Bool.and_eq_true, decide_eq_true_eq] at hcond
+      cases g with
+      | nil =>
+        rw [show (gridToMacroCellWithOffsetN (m + 1) []).2.level = 0 from by
+              simp [gridToMacroCellWithOffsetN, gridFrameN,
+                MacroCell.level_buildFromGrid]] at hcond
+        omega
+      | cons p₀ ps =>
+        have hgt := gridToMacroCellWithOffsetN_level_gt_n (m + 1) (p₀ :: ps)
+          (List.cons_ne_nil _ _)
+        simp only [jumpSize] at hcond
+        omega
+    · rfl
+
+/-- **Pont valable pour TOUT n (b3 anticipe)** : `evolveHashlifeFastN`
+    coincide avec le `evolve` de reference — corollaire direct du garde
+    mort (`evolveHashlifeFastAuxN_eq_evolve`) : la variante N3 ne saute
+    jamais. Ce pont etait initialement prevu (reporte) pour `n ≤ 2`
+    seulement, vers `evolveHashlifeFast` ; il est en realite
+    inconditionnel vers `evolve`, au prix honnete de l'acceleration
+    Hashlife (inactive tant que le garde est mort — docstring de section
+    ci-dessus pour la sortie via la decorrelation j de Gosper). -/
+theorem evolveHashlifeFastN_eq_evolve (n : Nat) (g : Grid) :
+    evolveHashlifeFastN n g = evolve n g := by
+  cases n with
+  | zero => rfl
+  | succ m =>
+    exact evolveHashlifeFastAuxN_eq_evolve (m + 1) (m + 1) g (by omega)
 
 /-- Calcule `evolve n g` avec Hashlife. Fait un aller-retour a travers
     la representation `MacroCell` a chaque generation, en exercant

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife_en.lean
@@ -389,44 +389,62 @@ This section **adds** the n-aware variant without touching `evolveHashlifeFast`
 or any of its 50+ call-sites / proofs:
 
 - `evolveHashlifeFastAuxN` / `evolveHashlifeFastN` — same recursion as
-  `evolveHashlifeFastAux`, but the initial MacroCell is built with the
-  n-aware frame `gridToMacroCellWithOffsetN n g`. Subsequent iterations use
-  the fixed-frame builder (N3 = "thread without re-frame", per the N1
-  design comment at MacroCell L634).
+  `evolveHashlifeFastAux`, but every iteration re-frames via the n-aware
+  builder `gridToMacroCellWithOffsetN`: the recursive call
+  `evolveHashlifeFastAuxN fuel (n - js) g'` re-enters
+  `gridToMacroCellWithOffsetN (n - js) g'` on the jumped grid. (The N1
+  design comment at MacroCell L634 described a "thread without re-frame"
+  scheme; the code, however, re-frames on every iteration — the code is
+  authoritative, the docs have been aligned.)
 - `evolveHashlifeFastN_zero` — trivial sanity: `n = 0` returns `g`.
+- `evolveHashlifeFastAuxN_eq_evolve` / `evolveHashlifeFastN_eq_evolve` —
+  **(b2) verdict, #6724: the N3 jump guard is dead.** The `max 2 n`
+  padding of `gridFrameN` forces `2 ^ lvl ≥ side ≥ 2 * n + 1 > n`
+  (`gridToMacroCellWithOffsetN_level_gt_n`, MacroCell), so the guard
+  `lvl ≥ 2 ∧ n ≥ jumpSize lvl` fails for every nonempty grid (and
+  `lvl = 0 < 2` for the empty one): the jump branch never fires and the
+  N3 variant degenerates to the reference `evolve`.
 
-The **bridge** `evolveHashlifeFastN n g = evolveHashlifeFast n g` for `n ≤ 2`
-(via `gridToMacroCellWithOffsetN_le_two_eq` + structural induction on `fuel`)
-is **deferred** to a follow-up cycle, paired with the P4 unlock: it requires
-the `evolveHashlifeFastMemo_eq_evolveHashlifeFast`-style full body unfolding
-which is best assembled once the Lean LSP harness (ai-01 turf, post-fix H)
-is back to fully interactive. Documenting the proof obligation here keeps
-the P5 redesign plan honest and avoids a vacuous stub. -/
+The **bridge** `evolveHashlifeFastN n g = evolve n g` is therefore proven
+for ALL n as an immediate corollary of the dead guard — stronger than
+the originally deferred `n ≤ 2` bridge to `evolveHashlifeFast` (the
+Hashlife component is simply inert, at the honest price of the
+acceleration). The lesson for the P5 redesign: covering the light cone
+of the n remaining generations by padding is self-defeating — the frame
+inflates beyond the very jump horizon it conditions. The identified exit
+(j/p>=3 amendment, ruled by the coordinator on #6724) is Gosper's j
+decorrelation (`hashlifeResultAt j`, to be implemented): at j = level-3
+the jump reach drops below the window margin regardless of padding
+depth (`jumpReach`/`marginToResultWindow` in `JumpCapture`, step 2),
+which makes `jumpCaptured` provable by cone with a small padding and a
+viable guard. -/
 
 /-- N3-threaded auxiliary for `evolveHashlifeFastN`: same recursion as
-    `evolveHashlifeFastAux`, but the initial MacroCell is built with the
-    n-aware frame `gridToMacroCellWithOffsetN n g`. Subsequent recursive
-    calls (the `n - js` arm) use the fixed-frame builder — N3 threads the
-    frame *without* re-framing on every iteration (per the N1 design
-    comment at MacroCell L634). -/
+    `evolveHashlifeFastAux`, but every iteration re-frames via the
+    n-aware builder `gridToMacroCellWithOffsetN` — the recursive call on
+    `n - js` re-enters the n-aware framing of the remaining n on the
+    jumped grid. Warning ((b2) verdict, #6724): under this framing, the
+    jump guard `lvl ≥ 2 ∧ n ≥ js` is structurally dead — see
+    `evolveHashlifeFastAuxN_eq_evolve` below. -/
 def evolveHashlifeFastAuxN : Nat → Nat → Grid → Grid
   | _, 0, g => g
   | 0, _, g => g  -- fuel exhausted: return current state
   | fuel + 1, n, g =>
-    -- N3 substitution: n-aware frame on the initial MacroCell only.
+    -- n-aware framing on EVERY iteration: the recursive call in the jump
+    -- branch re-enters gridToMacroCellWithOffsetN (n - js).
     let (off, mc) := gridToMacroCellWithOffsetN n g
     let lvl := mc.level
     let js := jumpSize lvl
     if lvl >= 2 && n >= js then
       -- Jump forward by `2^lvl` generations using padded Hashlife,
-      -- then re-frame from the new (jumped) grid's fixed frame.
+      -- then n-aware re-framing of the remaining n on the jumped grid.
+      -- NB ((b2) verdict, #6724): this branch is currently DEAD —
+      -- `gridToMacroCellWithOffsetN_level_gt_n` (MacroCell) forces
+      -- `2^lvl > n = js`; the guard can never fire as long as the
+      -- `max 2 n` padding governs the frame level.
       let jumped := hashlifeJump mc
       let newOff := jumpResultOff off lvl
       let g' := jumped.toGrid newOff
-      -- Subsequent iterations use the fixed-frame builder, NOT the
-      -- n-aware one — the n parameter is already consumed by `n - js`,
-      -- and re-framing with the *new* `n` would needlessly inflate the
-      -- padding when the bounding box has shrunk after the jump.
       evolveHashlifeFastAuxN fuel (n - js) g'
     else
       -- Small n or small pattern: use reference evolve.
@@ -445,6 +463,52 @@ def evolveHashlifeFastN (n : Nat) (g : Grid) : Grid :=
 @[simp]
 theorem evolveHashlifeFastN_zero (g : Grid) :
     evolveHashlifeFastN 0 g = g := rfl
+
+/-- **(b2) verdict, #6724: the N3 jump guard is dead.** For every grid,
+    the jump-branch guard `lvl ≥ 2 ∧ n ≥ jumpSize lvl` fails: empty grid
+    → `lvl = 0 < 2`; nonempty grid → `gridToMacroCellWithOffsetN_level_gt_n`
+    gives `2 ^ lvl > n` while `jumpSize lvl = 2 ^ lvl`. The jump branch
+    therefore never fires, and the N3 auxiliary returns exactly the
+    reference `evolve`. -/
+theorem evolveHashlifeFastAuxN_eq_evolve (fuel n : Nat) (g : Grid)
+    (hfuel : 1 ≤ fuel) :
+    evolveHashlifeFastAuxN fuel n g = evolve n g := by
+  obtain ⟨fuel', rfl⟩ : ∃ k, fuel = k + 1 := ⟨fuel - 1, by omega⟩
+  cases n with
+  | zero => rfl
+  | succ m =>
+    simp only [evolveHashlifeFastAuxN]
+    split
+    · next hcond =>
+      exfalso
+      simp only [Bool.and_eq_true, decide_eq_true_eq] at hcond
+      cases g with
+      | nil =>
+        rw [show (gridToMacroCellWithOffsetN (m + 1) []).2.level = 0 from by
+              simp [gridToMacroCellWithOffsetN, gridFrameN,
+                MacroCell.level_buildFromGrid]] at hcond
+        omega
+      | cons p₀ ps =>
+        have hgt := gridToMacroCellWithOffsetN_level_gt_n (m + 1) (p₀ :: ps)
+          (List.cons_ne_nil _ _)
+        simp only [jumpSize] at hcond
+        omega
+    · rfl
+
+/-- **Bridge valid for ALL n (b3 delivered early)**: `evolveHashlifeFastN`
+    coincides with the reference `evolve` — a direct corollary of the dead
+    guard (`evolveHashlifeFastAuxN_eq_evolve`): the N3 variant never
+    jumps. This bridge was originally planned (deferred) for `n ≤ 2`
+    only, towards `evolveHashlifeFast`; it is in fact unconditional
+    towards `evolve`, at the honest price of the Hashlife acceleration
+    (inert while the guard is dead — see the section docstring above for
+    the exit via Gosper's j decorrelation). -/
+theorem evolveHashlifeFastN_eq_evolve (n : Nat) (g : Grid) :
+    evolveHashlifeFastN n g = evolve n g := by
+  cases n with
+  | zero => rfl
+  | succ m =>
+    exact evolveHashlifeFastAuxN_eq_evolve (m + 1) (m + 1) g (by omega)
 
 /-- Compute `evolve n g` using Hashlife. Round-trips through the
     `MacroCell` representation each generation, exercising `step4x4`

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell.lean
@@ -667,7 +667,12 @@ de marge devient alors satisfiable pour tout `n` (pas seulement `n ≤ 2`) —
 voir le temoin `box_assez_grandN_single_cell_3` dans
 `HashlifeCorrectness`, le dual honnete du plafond insat
 `boxAssezGrand_nonempty_le_two`. N1 garde `evolveHashlifeFast` inchange ;
-N2 trame ce cadre a travers la boucle sans re-cadrer. -/
+N2 trame ce cadre a travers la boucle en re-cadrant a chaque iteration —
+l'appel recursif `evolveHashlifeFastAuxN fuel (n - js) g'` re-entre dans
+`gridToMacroCellWithOffsetN (n - js) g'` sur la grille sautee (Hashlife).
+Contrepartie tranchee en (b2) : sous ce rembourrage, le garde de saut est
+structurellement mort (`gridToMacroCellWithOffsetN_level_gt_n`) — le cote
+`bbox + 2 * max 2 n` force `2 ^ lvl > n = js`. -/
 
 /-- Comme `gridFrame` mais avec un rembourrage `max 2 n` (au lieu du `2`
     fixe) de chaque cote, donc la marge du cone de lumiere est au moins
@@ -788,6 +793,46 @@ theorem gridToMacroCellWithOffsetN_le_two_eq (n : Nat) (g : Grid) (hn : n ≤ 2)
     gridToMacroCellWithOffsetN n g = gridToMacroCellWithOffset g := by
   unfold gridToMacroCellWithOffsetN gridToMacroCellWithOffset
   rw [gridFrameN_le_two_eq_gridFrame n g hn]
+
+/-- **Garde N3 mort (tranche (b2), #6724).** Pour une grille non vide, le
+    niveau du cadre conscient de n domine toujours le horizon de saut :
+    `2 ^ lvl ≥ side ≥ height = (rMax - rMin + 1 + 2 * max 2 n).toNat ≥ 2 * n + 1 > n`,
+    donc le garde de saut `lvl ≥ 2 ∧ n ≥ jumpSize lvl` (`= 2 ^ lvl`) de
+    `evolveHashlifeFastAuxN` est structurellement insatisfait : le
+    rembourrage `max 2 n`, concu pour couvrir le cone de lumiere des `n`
+    generations restantes, gonfle le cadre au-dela du horizon du saut
+    qu'il conditionne. La branche de saut N3 ne peut jamais tirer ; la
+    preservation de `jumpCaptured` a travers le re-cadrage N est donc
+    VACUE tant que ce garde est mort — voir `evolveHashlifeFastAuxN_eq_evolve`
+    (Hashlife) pour la consequence comportementale et la docstring de
+    section de `Hashlife.lean` pour la sortie identifiee (decorrelation j
+    de Gosper, `jumpReach`/`marginToResultWindow` dans `JumpCapture`). -/
+theorem gridToMacroCellWithOffsetN_level_gt_n (n : Nat) (g : Grid) (hg : g ≠ []) :
+    n < 2 ^ (gridToMacroCellWithOffsetN n g).2.level := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    simp only [gridToMacroCellWithOffsetN]
+    rw [MacroCell.level_buildFromGrid]
+    simp only [gridFrameN]
+    set rMin := gridRowMin (p₀ :: ps)
+    set rMax := gridRowMax (p₀ :: ps)
+    set cMin := gridColMin (p₀ :: ps)
+    set cMax := gridColMax (p₀ :: ps)
+    set pad := max 2 n
+    set height := (rMax - rMin + 1 + 2 * pad).toNat
+    set width := (cMax - cMin + 1 + 2 * pad).toNat
+    set side := max height width
+    set lvl := MacroCell.ceilLog2 side
+    have hspec : (2 ^ lvl : Nat) ≥ side := MacroCell.ceilLog2_spec side
+    have hh : height ≤ side := Nat.le_max_left _ _
+    have hH : 1 + 2 * max 2 n ≤ height := by
+      have hnn : 0 ≤ rMax - rMin + 1 + 2 * pad := by omega
+      simp only [height]
+      omega
+    omega
 
 /-- Convertit un `Grid` en `MacroCell`, en jetant le decalage (par defaut
     `(0, 0)` pour l'aller-retour). Pour les besoins d'aller-retour, preferer

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/MacroCell_en.lean
@@ -650,7 +650,12 @@ margin is at least `max 2 n ≥ n` *by construction*. The margin hypothesis
 then becomes satisfiable for every `n` (not just `n ≤ 2`) — see the witness
 `box_assez_grandN_single_cell_3` in `HashlifeCorrectness`, the honest dual of
 the `boxAssezGrand_nonempty_le_two` unsat cap. N1 keeps `evolveHashlifeFast`
-unchanged; N2 threads this frame through the loop without re-framing. -/
+unchanged; N2 threads this frame through the loop by re-framing on every
+iteration — the recursive call `evolveHashlifeFastAuxN fuel (n - js) g'`
+re-enters `gridToMacroCellWithOffsetN (n - js) g'` on the jumped grid
+(Hashlife). Trade-off ruled in (b2): under this padding, the jump guard
+is structurally dead (`gridToMacroCellWithOffsetN_level_gt_n`) — the side
+`bbox + 2 * max 2 n` forces `2 ^ lvl > n = js`. -/
 
 /-- Like `gridFrame` but with padding `max 2 n` (instead of the fixed `2`) on
     each side, so the light-cone margin is at least `max 2 n ≥ n`. Returns
@@ -765,6 +770,46 @@ theorem gridToMacroCellWithOffsetN_le_two_eq (n : Nat) (g : Grid) (hn : n ≤ 2)
     gridToMacroCellWithOffsetN n g = gridToMacroCellWithOffset g := by
   unfold gridToMacroCellWithOffsetN gridToMacroCellWithOffset
   rw [gridFrameN_le_two_eq_gridFrame n g hn]
+
+/-- **Dead N3 guard ((b2) verdict, #6724).** For a nonempty grid, the
+    n-aware frame level always dominates the jump horizon:
+    `2 ^ lvl ≥ side ≥ height = (rMax - rMin + 1 + 2 * max 2 n).toNat ≥ 2 * n + 1 > n`,
+    so the jump guard `lvl ≥ 2 ∧ n ≥ jumpSize lvl` (`= 2 ^ lvl`) of
+    `evolveHashlifeFastAuxN` is structurally unsatisfied: the `max 2 n`
+    padding, designed to cover the light cone of the n remaining
+    generations, inflates the frame beyond the very jump horizon it
+    conditions. The N3 jump branch can never fire; preserving
+    `jumpCaptured` across the N re-framing is therefore VACUOUS while
+    this guard is dead — see `evolveHashlifeFastAuxN_eq_evolve`
+    (Hashlife) for the behavioral consequence and the section docstring
+    of `Hashlife.lean` for the identified exit (Gosper's j decorrelation,
+    `jumpReach`/`marginToResultWindow` in `JumpCapture`). -/
+theorem gridToMacroCellWithOffsetN_level_gt_n (n : Nat) (g : Grid) (hg : g ≠ []) :
+    n < 2 ^ (gridToMacroCellWithOffsetN n g).2.level := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    simp only [gridToMacroCellWithOffsetN]
+    rw [MacroCell.level_buildFromGrid]
+    simp only [gridFrameN]
+    set rMin := gridRowMin (p₀ :: ps)
+    set rMax := gridRowMax (p₀ :: ps)
+    set cMin := gridColMin (p₀ :: ps)
+    set cMax := gridColMax (p₀ :: ps)
+    set pad := max 2 n
+    set height := (rMax - rMin + 1 + 2 * pad).toNat
+    set width := (cMax - cMin + 1 + 2 * pad).toNat
+    set side := max height width
+    set lvl := MacroCell.ceilLog2 side
+    have hspec : (2 ^ lvl : Nat) ≥ side := MacroCell.ceilLog2_spec side
+    have hh : height ≤ side := Nat.le_max_left _ _
+    have hH : 1 + 2 * max 2 n ≤ height := by
+      have hnn : 0 ≤ rMax - rMin + 1 + 2 * pad := by omega
+      simp only [height]
+      omega
+    omega
 
 /-- Convert a `Grid` to a `MacroCell`, discarding the offset (defaulting to
     `(0, 0)` for the round trip). For round-trip purposes, prefer


### PR DESCRIPTION
## Summary

Grain: DEEP/lean — lane myia-po-2026:CoursIA
See #6724 (contribution (b2) — l'epic reste ouverte, la sortie identifiee reste a implementer)

En formalisant l'arithmetique du cone avant d'ecrire le lemme de preservation demande par (b2), decouverte plus forte : **le garde de saut N3 est structurellement mort**, ce qui rend la preservation VACUE et livre gratuitement le pont (b3).

**L'argument** : le rembourrage `max 2 n` de `gridFrameN` (concu pour couvrir le cone de lumiere des n generations restantes) gonfle le cadre au-dela du horizon du saut qu'il conditionne :

```
side >= height = (rMax - rMin + 1 + 2*max 2 n).toNat >= 2n + 1 > n
2^lvl >= side  (ceilLog2_spec)   =>   2^lvl > n = jumpSize lvl
```

donc le garde `lvl >= 2 && n >= js` de `evolveHashlifeFastAuxN` ne peut jamais tirer. Couvrir le cone par le rembourrage est auto-sabotant — lecon pour la refonte P5.

## Deliverables (FR + port EN byte-identique, 4 fichiers)

1. **`gridToMacroCellWithOffsetN_level_gt_n`** (MacroCell) : `n < 2^lvl` pour toute grille non vide sous cadre N — le coeur du garde mort.
2. **`evolveHashlifeFastAuxN_eq_evolve`** (Hashlife) : la branche de saut ne tire jamais (cas nil : lvl=0<2 ; cas cons : garde mort) ; l'auxiliaire N3 rend exactement le `evolve` de reference.
3. **`evolveHashlifeFastN_eq_evolve`** : **pont valable pour TOUT n** — plus fort que le pont `n <= 2` initialement reporte (b3 livre en corollaire anticipe). Prix honnete : l'acceleration Hashlife est inactive tant que le garde est mort.
4. **Correction des 3 textes contredits par le code** (tranche ai-01 : le code gagne) : docstring de section Hashlife, note N1 MacroCell L670, commentaire inline branche jump — le code re-cadre a CHAQUE iteration (l'appel recursif re-entre dans `gridToMacroCellWithOffsetN (n-js) g'`), les textes pretendaient le contraire. La sortie P5 (decorrelation j de Gosper, amendement j/p>=3 du coordinateur) est documentee dans la docstring de section.

## Proof evidence (§B)

**1. sorry count avant/apres par fichier modifie** :
| Fichier | avant (main) | apres |
|---|---|---|
| Conway/Life/MacroCell.lean | 0 | 0 |
| Conway/Life/Hashlife.lean | 0 | 0 |
| Conway/Life/MacroCell_en.lean | 0 | 0 |
| Conway/Life/Hashlife_en.lean | 0 | 0 |

**2. `lake build SUCCESS`** : build complet du lake apres le dernier commit de contenu — `Build completed successfully (2949 jobs)`, exit 0 (worktree `C:\dev\CoursIA-c6724-b2`, base 2fbde43e3, toolchain v4.31.0-rc1).

**3. Proof integrity (`#print axioms`, probe post-build)** :
```
'Conway.Life.gridToMacroCellWithOffsetN_level_gt_n' depends on axioms: [propext, Classical.choice, Quot.sound]
'Conway.Life.evolveHashlifeFastAuxN_eq_evolve' depends on axioms: [propext, Classical.choice, Quot.sound]
'Conway.Life.evolveHashlifeFastN_eq_evolve' depends on axioms: [propext, Classical.choice, Quot.sound]
```
Aucun `sorryAx`. Axiomes = standard Mathlib uniquement.

**4. Refactor prover Python** : N/A — PR purement Lean, aucun fichier `agent_tests/prover/` touche.

## Verification empirique (probe #eval, non commite)

Garde mort — condition `2^lvl <= n` evaluee false sur 5 temoins :
```
n=100  (cellule unique) : false
n=256  (cellule unique) : false
n=1000 (cellule unique) : false
n=64   (ligne de 7)     : false
n=64   (block 2x2)      : false
```
Pont comportemental : `evolveHashlifeFastN 3 block == evolve 3 block` -> `[(1,1),(1,2),(2,1),(2,2)]` des deux cotes.

## i18n / regression checks

- Port EN byte-identique verifie : diff FR/EN comments-stripped = uniquement les lignes `namespace/import/open` `_en` (convention #4980), zero difference dans signatures/preuves/tactiques.
- `grep -rln evolveHashlifeFastAuxN|evolveHashlifeFastN` hors `Hashlife*.lean` : seul MacroCell.lean (references de docstring, deja coherentes) — aucun site aval a migrer.
- Reponse au gate ai-01 : l'amendement j/p>=3 (cas tendu p=2) est devenu MOOT pour (b2) — l'invariant sur gridFrameN seul n'a pas besoin d'etre prouve car la branche de saut est morte ; l'amendement reste le levier de la sortie P5 (decorrelation j), documente dans la docstring.