### PR TITLE
fix(search,#9434): drain machine-dep wallclock claims from 2 SymbolicAI C# twins

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools-Csharp.ipynb
@@ -16,7 +16,7 @@
     "1. **Modéliser** un Job-Shop en CP : variables de début d'opération, contraintes de précédence (intra-job), contraintes de non-chevauchement (NoOverlap inter-machines)\n",
     "2. **Implémenter** la **propagation de domaines** (réduction par précédences) puis un **backtracking** pour l'affectation temporelle\n",
     "3. **Minimiser** le makespan par énumération exhaustive des ordonnancements disjonctifs\n",
-    "4. **Comparer** la performance et l'optimalité de notre solveur naïf vs OR-Tools CP-SAT (le Python résout ft3 en 0,022 s)\n",
+    "4. **Comparer** la performance et l'optimalité de notre solveur naïf vs OR-Tools CP-SAT (le Python résout ft3 en ~0,02 s — précision consignée dans la sortie committée du jumeau Python, source unique)\n",
     "\n",
     "### Prérequis\n",
     "\n",
@@ -744,7 +744,7 @@
    "source": [
     "### Interprétation : notre solveur naïf vs OR-Tools CP-SAT\n",
     "\n",
-    "Notre solveur retrouve le **makespan optimal = 11** (concordance avec OR-Tools), parce que l'énumération exhaustive des ordonnancements disjonctifs est **complète** — sur ft3 (3 jobs × 3 machines), l'espace est petit. La différence est le **coût** : OR-Tools résout ft3 en **0,022 s** grâce à sa propagation NoOverlap globale et au lazy clause generation (LCG), tandis que notre backtracking naïf explore toutes les permutations. Sur des instances plus grandes (ft10, ft20 : 10-20 jobs), CP-SAT reste tractable alors que notre solveur explose — c'est toute la valeur d'un moteur industriel : **mêmes résultats optimaux, mais à l'échelle**."
+    "Notre solveur retrouve le **makespan optimal = 11** (concordance avec OR-Tools), parce que l'énumération exhaustive des ordonnancements disjonctifs est **complète** — sur ft3 (3 jobs × 3 machines), l'espace est petit. La différence est le **coût** : OR-Tools résout ft3 en **~0,02 s** (précision consignée dans la sortie committée du jumeau Python, source unique) grâce à sa propagation NoOverlap globale et au lazy clause generation (LCG), tandis que notre backtracking naïf explore toutes les permutations. Sur des instances plus grandes (ft10, ft20 : 10-20 jobs), CP-SAT reste tractable alors que notre solveur explose — c'est toute la valeur d'un moteur industriel : **mêmes résultats optimaux, mais à l'échelle**."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
@@ -940,7 +940,7 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "Sur ce système (50 variables entières bornées `0..100`, contraintes sur les sommes adjacentes), le solveur générique met **15,6 ms** et le solveur spécialisé `QF_LIA` met **4,2 ms** — un gain d'environ **×3,7**. Le résultat (`SATISFIABLE`) est identique, seul le chemin diffère. La conclusion opérationnelle : quand on connaît la logique dominante de son problème (ici, arithmétique linéaire entière sans quantificateurs), **annoncer la logique au solveur** via `MkSolver(\"QF_LIA\")` est un accélérateur gratuit. Sur des logiques plus riches (non-linéaire, tableaux, bits), le même principe s'applique avec les codes `QF_NIA`, `QF_AUFLIA`, `QF_BV`…"
+    "Sur ce système (50 variables entières bornées `0..100`, contraintes sur les sommes adjacentes), le solveur générique met **~0,02 s** et le solveur spécialisé `QF_LIA` met **~0,004 s** — un gain d'environ **~×4** (précision consignée par la cellule de code ci-dessus, source unique). Le résultat (`SATISFIABLE`) est identique, seul le chemin diffère. La conclusion opérationnelle : quand on connaît la logique dominante de son problème (ici, arithmétique linéaire entière sans quantificateurs), **annoncer la logique au solveur** via `MkSolver(\"QF_LIA\")` est un accélérateur gratuit. Sur des logiques plus riches (non-linéaire, tableaux, bits), le même principe s'applique avec les codes `QF_NIA`, `QF_AUFLIA`, `QF_BV`…"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml
@@ -35,6 +35,12 @@
       csharp_sha: 260561e83086b1b62f40481690ca9e6857c8f093
       content_python_sha: eb2571fa7f0df9984c7dcc3067b57c80db0cd248f7ac1f2a9b058f33ef057d7f
       content_csharp_sha: 80bd5533929a9d6ef0f076dd8fc4bb5fcfafe7988a2356c119d0f4849b5fd9c0
+    - date: "2026-08-14"
+      by: myia-po-2025:CoursIA-2
+      python_sha: cd9b0d292100b31b38b036e77954534d0eb69ab5
+      csharp_sha: b71d62b0a0302d259d10a398dfa6f8c1efe6e5c8
+      content_python_sha: eb2571fa7f0df9984c7dcc3067b57c80db0cd248f7ac1f2a9b058f33ef057d7f
+      content_csharp_sha: e66af724dc812ece98f85d0a0fe17446838c196c856aee2057290c50f171e48b
   known_differences:
     - "Concept : planification orientee satisfaction de contraintes (Job-Shop scheduling, CP-SAT)."
     - "Python : OR-Tools CP-SAT Python bindings (solveur SOTA). C# : deux tranches — Tranche 1 from-scratch BCL .NET (0 NuGet, backtracking + propagation, enseigne les mecanismes) + Tranche 2 Google.OrTools CP-SAT natif .NET (moteur de production, depuis 2026-08-11)."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
@@ -22,6 +22,12 @@
       csharp_sha: fa950aa71cb7c7fd8561173309bd51dbbf21d425
       content_python_sha: 3f590d25ba1cfb7125b7cc0409c0510c4b5a4d6cbe0a85645068c27977c5d095
       content_csharp_sha: 5dca15c6a9ca7b904bdd874191b6652baf1d64eb86754c3b5a7ddbf6fddd0856
+    - date: "2026-08-14"
+      by: myia-po-2025:CoursIA-2
+      python_sha: 596992096613fb08367a5e41fae56b1b01254572
+      csharp_sha: e6afd62be0a2544fd62cc7f9013fa370adc0cafd
+      content_python_sha: 3f590d25ba1cfb7125b7cc0409c0510c4b5a4d6cbe0a85645068c27977c5d095
+      content_csharp_sha: 512dc4d1c58e544e05133833e533d538747046f0e2f0f66ca49d3afaa119badf
   known_differences:
     - "Python : pyz3 (Tactic('simplify'), Then(), With()). C# : Microsoft.Z3 .NET (Tactic(ctx, ...))."
     - "Concept demontre (simplify elimine une redondance, ctx-solver-simplify la garde) verifie firsthand cote Python (NB-03 CLEAN)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-dotnet #10980

## Summary

Suite du drain #9434/#9377 en partition SymbolicAI (.NET twins) — continuation directe de #10980 (Search) : retirer de la prose d'interprétation les timings machine-dépendants re-épinglés, qui dérivent à chaque re-exec. Convention #10713 : ordres de grandeur, prédicats structurels conservés, sortie committée pointée comme source unique.

| Notebook | Cell | Avant | Après |
|---|---|---|---|
| Planners-7-OR-Tools-Csharp | 0 (intro comparaison) | `le Python résout ft3 en 0,022 s` | `~0,02 s — précision consignée dans la sortie committée du jumeau Python, source unique` |
| Planners-7-OR-Tools-Csharp | 9 (interprétation naïf vs CP-SAT) | `OR-Tools résout ft3 en **0,022 s**` | `**~0,02 s**` + source unique pointée |
| Z3-Python-03-Tactics-Csharp | 23 (lecture du résultat) | `**15,6 ms**` / `**4,2 ms**` / `×3,7` | `**~0,02 s**` / `**~0,004 s**` / `~×4` + source unique pointée (cellule de code au-dessus) |

**Prédicats structurels conservés** : makespan optimal = 11 + complétude de l'énumération (Planners-7), `SATISFIABLE` identique + accélérateur `QF_LIA` + logiques QF_NIA/QF_AUFLIA/QF_BV (Z3-03), gain relatif `~×4` (ratio, pas temps absolu).

**Sources uniques vérifiées** :
- Planners-7 : `0,022 s` n'apparaît dans AUCUN output du C# (cross-ref) — la sortie committée du jumeau Python cell[17] porte `Temps de resolution: 0.022s`. Le jumeau Python a déjà été drainé par #9650 (po-2024).
- Z3-03 : la cellule code[22] juste au-dessus porte l'output committé `SATISFIABLE en 15,6 ms` / `SATISFIABLE en 4,2 ms`.

## Note de scope — FP exclus (non drainés, à dessein)

- **Planners-7-OR-Tools cell[16]** (`timeout de 30 secondes`) : paramètre structurel fixé par le code, PAS un runtime mesuré — déjà explicitement conservé par #9650.
- **`_archive/Fast-Downward-Legacy.ipynb`** (3 findings) : archive/legacy, hors maintenance.
- Cellules de **code** et **outputs** : jamais touchées (la sortie doit porter la valeur réelle mesurée, #10158).
- Le dossier imbriqué non-suivi `SymbolicAI/Lean/CoursIA-2-c728-prover-mine-lean-guards/` (copie de worktree résiduelle) : hors surface de PR (untracked).

## Files

- `MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-7-OR-Tools-Csharp.ipynb`
- `MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb`
- `scripts/notebook_tools/twin_pairs.d/planners-7-or-tools.yaml` (rebaseline attestation)
- `scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml` (rebaseline attestation)

## Vérifications

- **Markdown-only (C.3)** : 0 ligne `"cell_type": "code"` dans le diff, 0 ligne `execution_count`/`outputs` (vérifié grep diff).
- **`check_machine_dep_timing.py --category wallclock`** : **8 → 0** sur les 2 notebooks (les 4 restants de la famille = 1 paramètre structurel + 3 archive).
- **`detect_md_content_loss.py --base origin/main`** : **findings=0** sur les 2 (md_cells stable 10/10, 17/17).
- **`validate_pr_notebooks.py origin/main`** : **PASS 2/2** (21 cellules code).
- **Twin parity (#8057)** : rebaseline 2 paires via `check_twin_parity.py --update` — `OK=157 INTRO=0` post-fix. Marqueurs `[CLAIMED]` posés sur #9434 (paths disjoints des autres claims).
- **Catalogue** : byte-identique à main (aucun fichier catalogue / marqueur CATALOG-STATUS dans le diff).
- **Base fraîche** : worktree sur `origin/main` HEAD `74e08bd52`.

See #9434
