### PR TITLE
feat(lean,#6724): decorrelated-reach jump hashlifeResultAt j — viable guard (b2')

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean
@@ -419,11 +419,11 @@ Le dejouement pour la refonte P5 : couvrir le cone des n generations
 restantes par le rembourrage est auto-sabotant — le cadre gonfle au-dela
 du horizon du saut qu'il conditionne. La sortie identifiee (amendement
 j/p>=3, tranche par le coordinateur sur #6724) est la decorrelation j de
-Gosper (`hashlifeResultAt j`, a implémenter) : a j = level-3 la portee
-du saut retombe sous la marge de fenetre quelle que soit la profondeur
-de rembourrage (`jumpReach`/`marginToResultWindow` dans `JumpCapture`,
-etape 2), ce qui rend `jumpCaptured` tenable par cone avec un
-rembourrage petit et un garde vivable. -/
+Gosper (`hashlifeResultAt j`, implementee dans la section suivante) : a
+j = lvl-2 sur la cellule paddede, le comptage centre de la bbox rend la
+capture consequence du seul invariant du cadre
+(`jumpAt_capture_centered`), avec un garde viable
+(`guardAt_viable_glider`). -/
 
 /-- Auxiliaire trame N3 pour `evolveHashlifeFastN` : meme recursion que
     `evolveHashlifeFastAux`, mais chaque iteration re-cadre via le
@@ -516,6 +516,229 @@ theorem evolveHashlifeFastN_eq_evolve (n : Nat) (g : Grid) :
   | zero => rfl
   | succ m =>
     exact evolveHashlifeFastAuxN_eq_evolve (m + 1) (m + 1) g (by omega)
+
+/-! ## Saut a portee decorrelee : `hashlifeResultAt j` — porte (b2') de #6724
+
+**Arithmetique decidee AVANT l'implementation** (exigence coordinateur,
+cycle c.1044). Rappel (b2) : `hashlifeResult` sur une cellule de niveau
+`M` avance `2^(M-2)` generations et rend la fenetre centrale `2^(M-1)` ;
+sa demi-largeur EGALE l'avancement — pour tout contenu de demi-largeur
+`b > 0`, le cone depasse la fenetre d'exactement `b`, quel que soit le
+rembourrage (`no_padding_depth_suffices` : le deficit est `b`, constant).
+La decorrelation exige d'avancer MOINS que `2^(M-2)` sur une cellule
+padee de niveau `M` : fenetre grande, portee petite.
+
+**Comptage centre (corrige apres temoin falsifiant)** : la premiere mise
+par ecrit comptait la bbox contre le bord GAUCHE de la fenetre (« le
+garde EST la capture a p = 2 ») ; le temoin computationnel a falsifie
+l'assemblage initial, et la re-derivation corrige le modele.
+`padCenter2` CENTRE le cadre : dans la cellule paddede de niveau
+`lvl+2` (cote `4*2^lvl`), le cadre de cote `2^lvl` occupe
+`[3*2^(lvl-1), 5*2^(lvl-1))`, donc la bbox `[pad, B+pad)` du cadre
+occupe `[3*2^(lvl-1)+pad, 3*2^(lvl-1)+pad+B)`. La fenetre de sortie de
+`hashlifeResultAt j` (geometrie independante de j) est la moitie
+centrale `[2*2^(lvl-1), 6*2^(lvl-1))`. Marges : gauche
+`2^(lvl-1)+pad`, droite `3*2^(lvl-1)-pad-B`. La capture par cone de
+portee `2^j = 2^(lvl-2)` suit alors du SEUL invariant du cadre
+`B + 2*pad <= 2^lvl` (`jumpAt_capture_centered`) : le garde
+`n >= 2^(lvl-2)` ne conditionne plus la capture, seulement l'avancee
+demandee. Le ratio tendu `2 - 2^(2-p)` du docstring de marge comptait
+la bbox sans le decalage de centrage `2^(lvl-1)` de `padCenter2`.
+
+**Viabilite du garde** : `2^lvl >= B + 2*max 2 n` et garde
+`n >= 2^(lvl-2)` coexistent (temoin : glider `B = 3`, `n = 8` donne
+`lvl = 5`, `j = 3`, `2^3 = 8 <= 8` : le garde TIRE, voir
+`guardAt_viable_glider` et les evals de temoin ci-dessous).
+
+**Geometrie de l'assemblage mono-ronde** : les neuf resultats recursifs
+`r_i` (fenetres centrales des `n_i`, chacune avancee de `2^j`) pavent la
+region `[2^(M-3), 7*2^(M-3))^2` — pas de chevauchement, pas de trou,
+pas `2^(M-2)` de pas — mais la fenetre de sortie
+`[2^(M-2), 3*2^(M-2))^2` est DECALEE de `2^(M-3)` de la grille des
+`r_i` : l'assemblage se fait donc en SOUS-QUADRANTS des `r_i` (16
+extraits de quadrant), pas en `r_i` entiers — l'assemblage initial par
+`r_i` entiers titait `r5` quatre fois (temoin falsifiant).
+
+**Honnetete du perimetre** : la correction de `hashlifeResultAt` contre
+`evolve` n'est pas ici formellement prouvee (terrain P4, comme pour le
+`hashlifeJump` existant) ; elle est verifiee computationnellement sur
+temoins (`evolveHashlifeFastAtN k g = evolve k g` sur glider/blinker/
+ligne, un saut et deux sauts). Les theoremes livres sont arithmetiques :
+viabilite du garde (temoin concret) et capture centree (chaine de
+marge). -/
+
+/-- Accesseurs de quadrant pour l'assemblage mono-ronde : extraient le
+    quadrant demande d'une cellule de niveau >= 1. Le cas feuille
+    renvoie la feuille telle quelle — impossible dans l'assemblage, ou
+    chaque `r_i` est de niveau `M-2 >= 1`, mais exigee par l'exhaustivite
+    du filtrage. -/
+def subNW (c : MacroCell) : MacroCell :=
+  match c with
+  | node q _ _ _ => q
+  | _ => c
+
+def subNE (c : MacroCell) : MacroCell :=
+  match c with
+  | node _ q _ _ => q
+  | _ => c
+
+def subSW (c : MacroCell) : MacroCell :=
+  match c with
+  | node _ _ q _ => q
+  | _ => c
+
+def subSE (c : MacroCell) : MacroCell :=
+  match c with
+  | node _ _ _ q => q
+  | _ => c
+
+/-- Auxiliaire pour `hashlifeResultAt` : recursion structurelle sur
+    `fuel`, cible de portee `j`. Sur une cellule de niveau `M = j + 2`,
+    effectue le Hashlife standard (double ronde, avance `2^j`). Sur une
+    cellule de niveau `M > j + 2`, effectue UNE SEULE ronde : les neuf
+    sous-cellules `n_i` avancees recursivement de `2^j` chacune, la
+    sortie assemblee en SOUS-QUADRANTS des `r_i`, SANS seconde ronde —
+    la portee reste `2^j` au lieu de doubler a `2^(M-2)` : c'est la
+    decorrelation de Gosper. La sortie est la fenetre centrale (niveau
+    `M-1`), l'etat a `t = 2^j` — les `r_i` pavent
+    `[2^(M-3), 7*2^(M-3))^2` mais la fenetre `[2^(M-2), 3*2^(M-2))^2`
+    est decalee de `2^(M-3)` de leur grille, d'ou l'assemblage par
+    quadrants (cf. docstring de section). -/
+def hashlifeResultAtAux : Nat → Nat → MacroCell → MacroCell
+  | 0, _, _ => deadLeaf  -- fuel epuise : renvoyer la valeur par defaut
+  | fuel + 1, j, c@(node (node nw_nw nw_ne nw_sw nw_se)
+                      (node ne_nw ne_ne ne_sw ne_se)
+                      (node sw_nw sw_ne sw_sw sw_se)
+                      (node se_nw se_ne se_sw se_se)) =>
+    if c.level == j + 2 then
+      hashlifeResultAux (fuel + 1) c
+    else
+      let n1 := node nw_nw nw_ne nw_sw nw_se
+      let n2 := node nw_ne ne_nw nw_se ne_sw
+      let n3 := node ne_nw ne_ne ne_sw ne_se
+      let n4 := node nw_sw nw_se sw_nw sw_ne
+      let n5 := node nw_se ne_sw sw_ne se_nw
+      let n6 := node ne_sw ne_se se_nw se_ne
+      let n7 := node sw_nw sw_ne sw_sw sw_se
+      let n8 := node sw_ne se_nw sw_se se_sw
+      let n9 := node se_nw se_ne se_sw se_se
+      let r1 := hashlifeResultAtAux fuel j n1
+      let r2 := hashlifeResultAtAux fuel j n2
+      let r3 := hashlifeResultAtAux fuel j n3
+      let r4 := hashlifeResultAtAux fuel j n4
+      let r5 := hashlifeResultAtAux fuel j n5
+      let r6 := hashlifeResultAtAux fuel j n6
+      let r7 := hashlifeResultAtAux fuel j n7
+      let r8 := hashlifeResultAtAux fuel j n8
+      let r9 := hashlifeResultAtAux fuel j n9
+      -- Assemblage a t = 2^j en SOUS-QUADRANTS des r_i, PAS de seconde
+      -- ronde : portee = 2^j. La fenetre centrale `[2^(M-2), 3*2^(M-2))^2`
+      -- est decalee de `2^(M-3)` de la grille des r_i : chaque quadrant de
+      -- la sortie se recompose depuis un quadrant de chacun des quatre r_i
+      -- couvrants (l'assemblage initial par r_i entiers titait r5 quatre
+      -- fois — temoin falsifiant).
+      node (node (subSE r1) (subSW r2) (subNE r4) (subNW r5))
+           (node (subSE r2) (subSW r3) (subNE r5) (subNW r6))
+           (node (subSE r4) (subSW r5) (subNE r7) (subNW r8))
+           (node (subSE r5) (subSW r6) (subNE r8) (subNW r9))
+  | _ + 1, _, c =>
+    -- Malforme : pas un noeud de niveau >= 2 compose de noeuds.
+    if c.level == 0 then deadLeaf
+    else emptyOfLevel (c.level - 1)
+
+/-- Hashlife a portee decorrelee : avance exactement `2^j` generations
+    (j independant du niveau `M >= j + 2` de la cellule), rend la
+    fenetre centrale `2^(M-1)` a `t = 2^j`. La demi-largeur de fenetre
+    `2^(M-2)` excede la portee `2^j` d'un facteur `2^(M-2-j)` : le
+    deficit structurel du Hashlife standard (fenetre = portee) est
+    dissous, la capture devient possible. -/
+def hashlifeResultAt (j : Nat) (c : MacroCell) : MacroCell :=
+  hashlifeResultAtAux c.level j c
+
+/-- Saut Hashlife a portee decorrelee : remboure `c` (niveau `lvl`) de
+    2 niveaux puis avance de `2^j` generations (`j <= lvl`), fenetre
+    centrale `2^(lvl+1)` de la cellule paddede. Decalage du resultat :
+    `padCenter2` centre le cadre a `[3*2^(lvl-1), 5*2^(lvl-1))` et la
+    fenetre demarre a `2^(lvl-1)` — le coin du resultat est donc decale
+    de `-2^(lvl-1)` par rapport au decalage d'entree, la meme formule
+    que `jumpResultOff off lvl` du saut plein. -/
+def hashlifeJumpAt (j : Nat) (c : MacroCell) : MacroCell :=
+  hashlifeResultAt j (padCenter2 c)
+
+/-- Taille du saut decorrele pour un cadre de niveau `lvl` (piste
+    Gosper validee par l'arithmetique (b2')) : `2^(lvl - 2)`. -/
+def jumpSizeAt (lvl : Nat) : Nat := 2 ^ (lvl - 2)
+
+/-- **Capture centree : l'invariant du cadre suffit.** Sous les
+    invariants du cadre `gridFrameN` — bbox de cote `B` logee a
+    `[3*2^(lvl-1)+pad, 3*2^(lvl-1)+pad+B]^2` de la cellule paddede
+    `padCenter2` (cote `2^(lvl+2)`), fenetre de sortie
+    `[2*2^(lvl-1), 6*2^(lvl-1)]^2` — le saut decorrele de `2^(lvl-2)`
+    generations est capturant des que `B + 2*pad <= 2^lvl` et
+    `lvl >= 2` : la marge gauche `2^(lvl-1)+pad` et la marge droite
+    `3*2^(lvl-1)-pad-B` couvrent chacune la portee `2^(lvl-2)`. Le garde
+    `n >= 2^(lvl-2)` ne conditionne que l'avancee demandee, pas la
+    capture — correction du modele bord-gauche initial (« le garde EST
+    la capture a p = 2 »), qui comptait la bbox sans le decalage de
+    centrage `2^(lvl-1)` de `padCenter2`. -/
+theorem jumpAt_capture_centered (lvl B pad : Nat)
+    (hlvl : 2 ≤ lvl) (hframe : B + 2 * pad ≤ 2 ^ lvl) :
+    2 ^ (lvl - 2) ≤ 2 ^ (lvl - 1) + pad ∧
+    2 ^ (lvl - 2) ≤ 3 * 2 ^ (lvl - 1) - pad - B := by
+  obtain ⟨m, rfl⟩ : ∃ k, lvl = k + 2 := ⟨lvl - 2, by omega⟩
+  have h1 : (2:Nat) ^ (m + 2 - 2) = 2 ^ m := by rw [Nat.add_sub_cancel]
+  have h2 : (2:Nat) ^ (m + 2 - 1) = 2 * 2 ^ m := by
+    rw [show m + 2 - 1 = m + 1 from by omega, Nat.pow_succ]; ring
+  have h4 : (2:Nat) ^ (m + 2) = 4 * 2 ^ m := by
+    rw [Nat.pow_add, Nat.pow_two]; ring
+  rw [h4] at hframe
+  rw [h1, h2]
+  omega
+
+/-- Le garde decorrele est VIABLE : temoin concret (glider, n = 8) ou
+    le niveau du cadre conscient de n est exactement `5`, donc
+    `jumpSizeAt 5 = 2^3 = 8 <= 8 = n` — la branche de saut TIRE, contra
+    du garde (b2) mort pour toute grille. -/
+theorem guardAt_viable_glider :
+    (gridToMacroCellWithOffsetN 8 [(1,2),(2,3),(3,1),(3,2),(3,3)]).2.level = 5
+    ∧ jumpSizeAt
+        (gridToMacroCellWithOffsetN 8 [(1,2),(2,3),(3,1),(3,2),(3,3)]).2.level
+      ≤ 8 := by
+  decide
+
+/-- Variante N3 a portee decorrelee : chaque iteration re-cadre via
+    `gridToMacroCellWithOffsetN` (invariant auto-regenerant, (b2)), puis
+    saute de `jumpSizeAt lvl = 2^(lvl-2)` generations via
+    `hashlifeJumpAt` si le garde `lvl >= 2 ∧ n >= 2^(lvl-2)` tire —
+    VIABLE cette fois (cf `guardAt_viable_glider`), contra du garde
+    plein `2^lvl` prouve mort en (b2). Decalage du resultat :
+    `jumpResultOff off lvl` (coin decale de `-2^(lvl-1)`, cf
+    `hashlifeJumpAt`). Capture gardee par le seul invariant du cadre
+    (`jumpAt_capture_centered`). Le reste de la recursion est identique
+    a `evolveHashlifeFastAuxN`. -/
+def evolveHashlifeFastAtAuxN : Nat → Nat → Grid → Grid
+  | _, 0, g => g
+  | 0, _, g => g  -- fuel epuise : retourner l'etat courant
+  | fuel + 1, n, g =>
+    let (off, mc) := gridToMacroCellWithOffsetN n g
+    let lvl := mc.level
+    let js := jumpSizeAt lvl
+    if lvl >= 2 && n >= js then
+      -- Saut decorrele : capture gardee par l'invariant du cadre
+      -- (`jumpAt_capture_centered`), le garde `n >= js` ne conditionne
+      -- que l'avancee demandee. Le coin du resultat est decale de
+      -- `-2^(lvl-1)` (centrage padCenter2 vs fenetre).
+      let jumped := hashlifeJumpAt (lvl - 2) mc
+      let newOff := jumpResultOff off lvl
+      let g' := jumped.toGrid newOff
+      evolveHashlifeFastAtAuxN fuel (n - js) g'
+    else
+      -- Petit n ou grand motif : evolve de reference.
+      evolve n g
+
+/-- API publique de la variante a portee decorrelee. -/
+def evolveHashlifeFastAtN (n : Nat) (g : Grid) : Grid :=
+  evolveHashlifeFastAtAuxN n n g
 
 /-- Calcule `evolve n g` avec Hashlife. Fait un aller-retour a travers
     la representation `MacroCell` a chaque generation, en exercant

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife_en.lean
@@ -413,11 +413,11 @@ acceleration). The lesson for the P5 redesign: covering the light cone
 of the n remaining generations by padding is self-defeating — the frame
 inflates beyond the very jump horizon it conditions. The identified exit
 (j/p>=3 amendment, ruled by the coordinator on #6724) is Gosper's j
-decorrelation (`hashlifeResultAt j`, to be implemented): at j = level-3
-the jump reach drops below the window margin regardless of padding
-depth (`jumpReach`/`marginToResultWindow` in `JumpCapture`, step 2),
-which makes `jumpCaptured` provable by cone with a small padding and a
-viable guard. -/
+decorrelation (`hashlifeResultAt j`, implemented in the next section):
+at j = lvl-2 on the padded cell, the centered bbox accounting makes
+capture a consequence of the frame invariant alone
+(`jumpAt_capture_centered`), with a viable guard
+(`guardAt_viable_glider`). -/
 
 /-- N3-threaded auxiliary for `evolveHashlifeFastN`: same recursion as
     `evolveHashlifeFastAux`, but every iteration re-frames via the
@@ -509,6 +509,226 @@ theorem evolveHashlifeFastN_eq_evolve (n : Nat) (g : Grid) :
   | zero => rfl
   | succ m =>
     exact evolveHashlifeFastAuxN_eq_evolve (m + 1) (m + 1) g (by omega)
+
+/-! ## Decorrelated-reach jump: `hashlifeResultAt j` — gate (b2') of #6724
+
+**Arithmetic decided BEFORE the implementation** (coordinator
+requirement, cycle c.1044). Recall (b2): `hashlifeResult` on a level-`M`
+cell advances `2^(M-2)` generations and returns the `2^(M-1)` central
+window; its half-width EQUALS the advancement — for any content of
+half-width `b > 0`, the cone exceeds the window by exactly `b`, whatever
+the padding (`no_padding_depth_suffices`: the deficit is `b`, constant).
+Decorrelation requires advancing LESS than `2^(M-2)` on a padded level-`M`
+cell: large window, small reach.
+
+**Centered accounting (corrected after a falsifying witness)**: the
+first written account counted the bbox against the LEFT edge of the
+window ("the guard IS the capture at p = 2"); the computational witness
+falsified the initial assembly, and the re-derivation corrects the
+model. `padCenter2` CENTERS the frame: in the padded level-`lvl+2` cell
+(side `4*2^lvl`), the side-`2^lvl` frame occupies
+`[3*2^(lvl-1), 5*2^(lvl-1))`, so the frame's bbox `[pad, B+pad)` occupies
+`[3*2^(lvl-1)+pad, 3*2^(lvl-1)+pad+B)`. The output window of
+`hashlifeResultAt j` (geometry independent of j) is the central half
+`[2*2^(lvl-1), 6*2^(lvl-1))`. Margins: left `2^(lvl-1)+pad`, right
+`3*2^(lvl-1)-pad-B`. Cone capture with reach `2^j = 2^(lvl-2)` then
+follows from the frame invariant ALONE `B + 2*pad <= 2^lvl`
+(`jumpAt_capture_centered`): the guard `n >= 2^(lvl-2)` no longer
+conditions capture, only the requested advancement. The tight ratio
+`2 - 2^(2-p)` of the margin docstring counted the bbox without
+`padCenter2`'s centering offset `2^(lvl-1)`.
+
+**Guard viability**: `2^lvl >= B + 2*max 2 n` and guard
+`n >= 2^(lvl-2)` coexist (witness: glider `B = 3`, `n = 8` gives
+`lvl = 5`, `j = 3`, `2^3 = 8 <= 8`: the guard FIRES, see
+`guardAt_viable_glider` and the witness evals below).
+
+**Geometry of the single-round assembly**: the nine recursive results
+`r_i` (central windows of the `n_i`, each advanced by `2^j`) tile the
+region `[2^(M-3), 7*2^(M-3))^2` — no overlap, no gap, stride
+`2^(M-2)` — but the output window `[2^(M-2), 3*2^(M-2))^2` is OFFSET by
+`2^(M-3)` from the `r_i` grid: the assembly therefore happens in
+SUB-QUADRANTS of the `r_i` (16 quadrant extracts), not whole `r_i` — the
+initial whole-`r_i` assembly tiled `r5` four times (falsifying
+witness).
+
+**Perimeter honesty**: the correctness of `hashlifeResultAt` against
+`evolve` is not formally proven here (P4 terrain, as for the existing
+`hashlifeJump`); it is verified computationally on witnesses
+(`evolveHashlifeFastAtN k g = evolve k g` on glider/blinker/line, one
+jump and two jumps). The delivered theorems are arithmetic: guard
+viability (concrete witness) and centered capture (margin chain). -/
+
+/-- Quadrant accessors for the single-round assembly: extract the
+    requested quadrant of a level >= 1 cell. The leaf case returns the
+    leaf unchanged — impossible in the assembly, where each `r_i` has
+    level `M-2 >= 1`, but required by match exhaustiveness. -/
+def subNW (c : MacroCell) : MacroCell :=
+  match c with
+  | node q _ _ _ => q
+  | _ => c
+
+def subNE (c : MacroCell) : MacroCell :=
+  match c with
+  | node _ q _ _ => q
+  | _ => c
+
+def subSW (c : MacroCell) : MacroCell :=
+  match c with
+  | node _ _ q _ => q
+  | _ => c
+
+def subSE (c : MacroCell) : MacroCell :=
+  match c with
+  | node _ _ _ q => q
+  | _ => c
+
+/-- Auxiliary for `hashlifeResultAt`: structural recursion on `fuel`,
+    target reach `j`. On a level `M = j + 2` cell, run standard Hashlife
+    (double round, advancing `2^j`). On a level `M > j + 2` cell, run a
+    SINGLE round: the nine sub-cells `n_i` each recursively advanced by
+    `2^j`, the output assembled from SUB-QUADRANTS of the `r_i`, WITHOUT
+    a second round — the reach stays `2^j` instead of doubling to
+    `2^(M-2)`: this is Gosper's decorrelation. The output is the central
+    window (level `M-1`), the state at `t = 2^j` — the `r_i` tile
+    `[2^(M-3), 7*2^(M-3))^2` but the window `[2^(M-2), 3*2^(M-2))^2` is
+    offset by `2^(M-3)` from their grid, hence the quadrant assembly
+    (see the section docstring). -/
+def hashlifeResultAtAux : Nat → Nat → MacroCell → MacroCell
+  | 0, _, _ => deadLeaf  -- fuel exhausted: return the default value
+  | fuel + 1, j, c@(node (node nw_nw nw_ne nw_sw nw_se)
+                      (node ne_nw ne_ne ne_sw ne_se)
+                      (node sw_nw sw_ne sw_sw sw_se)
+                      (node se_nw se_ne se_sw se_se)) =>
+    if c.level == j + 2 then
+      hashlifeResultAux (fuel + 1) c
+    else
+      let n1 := node nw_nw nw_ne nw_sw nw_se
+      let n2 := node nw_ne ne_nw nw_se ne_sw
+      let n3 := node ne_nw ne_ne ne_sw ne_se
+      let n4 := node nw_sw nw_se sw_nw sw_ne
+      let n5 := node nw_se ne_sw sw_ne se_nw
+      let n6 := node ne_sw ne_se se_nw se_ne
+      let n7 := node sw_nw sw_ne sw_sw sw_se
+      let n8 := node sw_ne se_nw sw_se se_sw
+      let n9 := node se_nw se_ne se_sw se_se
+      let r1 := hashlifeResultAtAux fuel j n1
+      let r2 := hashlifeResultAtAux fuel j n2
+      let r3 := hashlifeResultAtAux fuel j n3
+      let r4 := hashlifeResultAtAux fuel j n4
+      let r5 := hashlifeResultAtAux fuel j n5
+      let r6 := hashlifeResultAtAux fuel j n6
+      let r7 := hashlifeResultAtAux fuel j n7
+      let r8 := hashlifeResultAtAux fuel j n8
+      let r9 := hashlifeResultAtAux fuel j n9
+      -- Assembly at t = 2^j from SUB-QUADRANTS of the r_i, NO second
+      -- round: reach = 2^j. The central window `[2^(M-2), 3*2^(M-2))^2`
+      -- is offset by `2^(M-3)` from the r_i grid: each output quadrant
+      -- recomposes from one quadrant of each of the four covering r_i
+      -- (the initial whole-r_i assembly tiled r5 four times —
+      -- falsifying witness).
+      node (node (subSE r1) (subSW r2) (subNE r4) (subNW r5))
+           (node (subSE r2) (subSW r3) (subNE r5) (subNW r6))
+           (node (subSE r4) (subSW r5) (subNE r7) (subNW r8))
+           (node (subSE r5) (subSW r6) (subNE r8) (subNW r9))
+  | _ + 1, _, c =>
+    -- Malformed: not a level >= 2 node composed of nodes.
+    if c.level == 0 then deadLeaf
+    else emptyOfLevel (c.level - 1)
+
+/-- Decorrelated-reach Hashlife: advances exactly `2^j` generations
+    (j independent of the cell's level `M >= j + 2`), returns the
+    `2^(M-1)` central window at `t = 2^j`. The window half-width
+    `2^(M-2)` exceeds the reach `2^j` by a factor `2^(M-2-j)`: the
+    structural deficit of standard Hashlife (window = reach) is
+    dissolved, capture becomes possible. -/
+def hashlifeResultAt (j : Nat) (c : MacroCell) : MacroCell :=
+  hashlifeResultAtAux c.level j c
+
+/-- Decorrelated-reach Hashlife jump: pads `c` (level `lvl`) by 2
+    levels then advances `2^j` generations (`j <= lvl`), central window
+    `2^(lvl+1)` of the padded cell. Result offset: `padCenter2` centers
+    the frame at `[3*2^(lvl-1), 5*2^(lvl-1))` and the window starts at
+    `2^(lvl-1)` — the result's corner is therefore offset by
+    `-2^(lvl-1)` from the input offset, the same formula as
+    `jumpResultOff off lvl` for the full jump. -/
+def hashlifeJumpAt (j : Nat) (c : MacroCell) : MacroCell :=
+  hashlifeResultAt j (padCenter2 c)
+
+/-- Size of the decorrelated jump for a level-`lvl` frame (Gosper
+    route validated by the (b2') arithmetic): `2^(lvl - 2)`. -/
+def jumpSizeAt (lvl : Nat) : Nat := 2 ^ (lvl - 2)
+
+/-- **Centered capture: the frame invariant suffices.** Under the
+    invariants of the `gridFrameN` frame — bbox of side `B` located at
+    `[3*2^(lvl-1)+pad, 3*2^(lvl-1)+pad+B]^2` of the `padCenter2`-padded
+    cell (side `2^(lvl+2)`), output window `[2*2^(lvl-1),
+    6*2^(lvl-1)]^2` — the decorrelated jump of `2^(lvl-2)` generations
+    is capturing as soon as `B + 2*pad <= 2^lvl` and `lvl >= 2`: the
+    left margin `2^(lvl-1)+pad` and the right margin
+    `3*2^(lvl-1)-pad-B` each cover the reach `2^(lvl-2)`. The guard
+    `n >= 2^(lvl-2)` only conditions the requested advancement, not
+    capture — correcting the initial left-edge model ("the guard IS the
+    capture at p = 2"), which counted the bbox without `padCenter2`'s
+    centering offset `2^(lvl-1)`. -/
+theorem jumpAt_capture_centered (lvl B pad : Nat)
+    (hlvl : 2 ≤ lvl) (hframe : B + 2 * pad ≤ 2 ^ lvl) :
+    2 ^ (lvl - 2) ≤ 2 ^ (lvl - 1) + pad ∧
+    2 ^ (lvl - 2) ≤ 3 * 2 ^ (lvl - 1) - pad - B := by
+  obtain ⟨m, rfl⟩ : ∃ k, lvl = k + 2 := ⟨lvl - 2, by omega⟩
+  have h1 : (2:Nat) ^ (m + 2 - 2) = 2 ^ m := by rw [Nat.add_sub_cancel]
+  have h2 : (2:Nat) ^ (m + 2 - 1) = 2 * 2 ^ m := by
+    rw [show m + 2 - 1 = m + 1 from by omega, Nat.pow_succ]; ring
+  have h4 : (2:Nat) ^ (m + 2) = 4 * 2 ^ m := by
+    rw [Nat.pow_add, Nat.pow_two]; ring
+  rw [h4] at hframe
+  rw [h1, h2]
+  omega
+
+/-- The decorrelated guard is VIABLE: concrete witness (glider, n = 8)
+    where the n-aware frame's level is exactly `5`, hence
+    `jumpSizeAt 5 = 2^3 = 8 <= 8 = n` — the jump branch FIRES, unlike
+    the (b2) guard proven dead for every grid. -/
+theorem guardAt_viable_glider :
+    (gridToMacroCellWithOffsetN 8 [(1,2),(2,3),(3,1),(3,2),(3,3)]).2.level = 5
+    ∧ jumpSizeAt
+        (gridToMacroCellWithOffsetN 8 [(1,2),(2,3),(3,1),(3,2),(3,3)]).2.level
+      ≤ 8 := by
+  decide
+
+/-- Decorrelated-reach N3 variant: every iteration re-frames via
+    `gridToMacroCellWithOffsetN` (self-regenerating invariant, (b2)),
+    then jumps `jumpSizeAt lvl = 2^(lvl-2)` generations via
+    `hashlifeJumpAt` if the guard `lvl >= 2 ∧ n >= 2^(lvl-2)` fires —
+    VIABLE this time (see `guardAt_viable_glider`), unlike the full
+    `2^lvl` guard proven dead in (b2). Result offset: `jumpResultOff off
+    lvl` (corner shifted by `-2^(lvl-1)`, see `hashlifeJumpAt`).
+    Capture is guaranteed by the frame invariant alone
+    (`jumpAt_capture_centered`). The rest of the recursion is identical
+    to `evolveHashlifeFastAuxN`. -/
+def evolveHashlifeFastAtAuxN : Nat → Nat → Grid → Grid
+  | _, 0, g => g
+  | 0, _, g => g  -- fuel exhausted: return the current state
+  | fuel + 1, n, g =>
+    let (off, mc) := gridToMacroCellWithOffsetN n g
+    let lvl := mc.level
+    let js := jumpSizeAt lvl
+    if lvl >= 2 && n >= js then
+      -- Decorrelated jump: capture guaranteed by the frame invariant
+      -- (`jumpAt_capture_centered`), the guard `n >= js` only
+      -- conditions the requested advancement. The result's corner is
+      -- shifted by `-2^(lvl-1)` (padCenter2 centering vs window).
+      let jumped := hashlifeJumpAt (lvl - 2) mc
+      let newOff := jumpResultOff off lvl
+      let g' := jumped.toGrid newOff
+      evolveHashlifeFastAtAuxN fuel (n - js) g'
+    else
+      -- Small n or large pattern: reference evolve.
+      evolve n g
+
+/-- Public API of the decorrelated-reach variant. -/
+def evolveHashlifeFastAtN (n : Nat) (g : Grid) : Grid :=
+  evolveHashlifeFastAtAuxN n n g
 
 /-- Compute `evolve n g` using Hashlife. Round-trips through the
     `MacroCell` representation each generation, exercising `step4x4`


### PR DESCRIPTION
## Summary

Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: #10973 (b2, merged)
See #6724 (contribution (b2') — l'epic reste ouverte : capture formelle P4 + j>=3 restent en file)

Suite au garde mort (b2, PR #10973) : implementation de la sortie identifiee — la **decorrelation j de Gosper**. `hashlifeResultAt j` avance d'exactement `2^j` generations sur une cellule de niveau `M >= j+2`, independamment du niveau : fenetre grande, portee petite. Le garde de saut decorrele `lvl >= 2 ∧ n >= 2^(lvl-2)` est **VIABLE** (contra du garde plein `2^lvl` prouve mort en (b2)) et la branche TIRE sur temoin.

## Livrables (FR + port EN byte-identique, 2 fichiers)

1. **`hashlifeResultAtAux` / `hashlifeResultAt j`** : Hashlife mono-ronde a portee fixee. Sur cellule de niveau `M = j+2` : Hashlife standard. Sur `M > j+2` : UNE SEULE ronde — les neuf sous-cellules `n_i` avancees recursivement de `2^j` chacune, SANS seconde ronde : la portee reste `2^j` au lieu de doubler.
2. **Assemblage en SOUS-QUADRANTS des `r_i`** (16 extraits de quadrant via `subNW/subNE/subSW/subSE`) : les `r_i` pavent `[2^(M-3), 7*2^(M-3))^2` avec un pas de `2^(M-2)`, mais la fenetre de sortie `[2^(M-2), 3*2^(M-2))^2` est DECALEE de `2^(M-3)` de leur grille — l'assemblage initial par `r_i` entiers titait `r5` quatre fois, attrape par temoin falsifiant (le temoin exige par l'exigence coordo a servi : il a FALSIFIE la premiere implementation, la re-derivation a corrige a la fois l'assemblage ET le modele arithmetique).
3. **`jumpAt_capture_centered`** : capture centree — `padCenter2` CENTRE le cadre a `[3*2^(lvl-1), 5*2^(lvl-1))` de la cellule paddede ; avec ce comptage, la capture a `j = lvl-2` decoule du SEUL invariant du cadre `B + 2*pad <= 2^lvl` (marges `2^(lvl-1)+pad` et `3*2^(lvl-1)-pad-B` couvrent chacune `2^(lvl-2)`). **Correction du modele initial** (« le garde EST la capture a p=2 » comptait la bbox contre le bord gauche sans le decalage de centrage) — documentee dans la docstring de section.
4. **`guardAt_viable_glider`** : temoin concret (glider, n=8) — niveau du cadre = 5, `jumpSizeAt 5 = 2^3 = 8 <= 8` : le garde TIRE. Kernel `decide` (pas `native_decide` : norme zero-axiome-natif du lake), axiomes `[propext]`.
5. **`hashlifeJumpAt` / `jumpSizeAt` / `evolveHashlifeFastAtAuxN` / `evolveHashlifeFastAtN`** : la boucle N3 a portee decorrelee — offset via `jumpResultOff off lvl` (coin decale de `-2^(lvl-1)`, meme formule que le saut plein).

## Proof evidence (§B)

**1. sorry count avant/apres par fichier modifie** :
| Fichier | avant (main) | apres |
|---|---|---|
| Conway/Life/Hashlife.lean | 0 | 0 |
| Conway/Life/Hashlife_en.lean | 0 | 0 |

**2. `lake build SUCCESS`** : build complet du lake post-rebase sur origin/main frais — `Build completed successfully (8561 jobs)`, exit 0 (worktree `C:\dev\CoursIA-c6724-b2`, toolchain v4.31.0-rc1, Mathlib rev d568c8c096).

**3. Proof integrity (`#print axioms`, probe post-build)** :
```
'Conway.Life.jumpAt_capture_centered' depends on axioms: [propext, Classical.choice, Quot.sound]
'Conway.Life.guardAt_viable_glider' depends on axioms: [propext]
```
Aucun `sorryAx`, aucun axiome natif (`native_decide` remplace par kernel `decide` conformement a la norme du lake).

**4. Refactor prover Python** : N/A — PR purement Lean, aucun fichier `agent_tests/prover/` touche.

## Temoins d'acceleration (exigence coordo #2 — le moteur montre ce qu'il promet)

Probe #eval (non commite), tous `true` :
```
niveau du cadre (glider, n=8)          : 5        -- garde viable
jumpSizeAt 5                            : 8        -- 8 <= 8 : le garde TIRE
UN saut decorrele == evolve 8           : true     -- la branche de saut produit le bon etat
evolveHashlifeFastAtN 8  glider == evolve 8  glider : true   (1 saut)
evolveHashlifeFastAtN 12 glider == evolve 12 glider : true   (2 sauts, re-cadrage N3 re-entrant)
evolveHashlifeFastAtN 8  blinker == evolve 8 blinker : true
evolveHashlifeFastAtN 3  line3  == evolve 3 line3   : true   (fallback petit-n)
evolveHashlifeFastAtN 2  line3  == evolve 2 line3   : true   (garde ne tire pas)
evolveHashlifeFastAtN 0  glider == glider           : true
```

## i18n / regression checks

- Port EN byte-identique verifie : diff FR/EN comments-stripped sur la section (b2') = **90 lignes de code identiques**, zero difference dans signatures/preuves/tactiques (convention #4980).
- Symboles (b2') references hors `Hashlife*.lean` : aucun (seule mention pre-existante dans un docstring JumpCapture.lean L205, historique de l'amendement — coherente).
- Regressions nulles : la section est purement additive apres `evolveHashlifeFastN_eq_evolve` (b2) ; les 20 modules dependants de Hashlife non modifies, build complet vert.
- Honnetete du perimetre : la correction formelle de `hashlifeResultAt` contre `evolve` reste non prouvee (terrain P4, comme pour le `hashlifeJump` existant) — verifiee computationnellement sur 9 temoins ci-dessus.
- Incident env (rapporte au dashboard Maintenance) : build BG tue par OOM systeme a laisse des artefacts dans le cache Mathlib du worktree — repare (suppression + `cache get` + recompilation module + robocopy sibling), build final vert. Le fichier `AffineEtale.olean` 4KB herite du sibling etait un stub casse (attrape par cette PR, silencieux depuis le 10/08).