### PR TITLE
feat(translation,#10329): T2 out-of-scope scan unconditional + drift guard test

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -253,18 +253,15 @@ jobs:
       - name: T2 detect drift
         id: t2
         if: steps.t1.outputs.has_translations == 'true'
-        env:
-          T1_MODE: ${{ github.event.inputs.mode || 'incremental' }}
         run: |
           set -euo pipefail
-          # En mode full, on active aussi le scan out-of-scope (etape 5 de
-          # #10329) : notebooks FR dans MyIA.AI.Notebooks/ qui ne sont
-          # dans aucun CSV. Ce scan est diagnostique, non-bloquant.
-          if [ "$T1_MODE" = "full" ]; then
-            REPORT="$(python scripts/translation/check_translation_sync.py translations --check --report-out-of-scope --repo-root . 2>/dev/null || true)"
-          else
-            REPORT="$(python scripts/translation/check_translation_sync.py translations --check --repo-root . 2>/dev/null || true)"
-          fi
+          # Scan out-of-scope (etape 5 de #10329) INCONDITIONNEL : notebooks
+          # FR dans MyIA.AI.Notebooks/ qui ne sont dans aucun CSV de
+          # translations/. Critere 6 de #10329 : « T2 journalise la derive
+          # hors-perimetre a chaque run » — un run incremental ne doit pas
+          # avoir de zone aveugle. Ce scan est diagnostique, non-bloquant
+          # (pas de LLM, pas de reseau : simple lecture disque).
+          REPORT="$(python scripts/translation/check_translation_sync.py translations --check --report-out-of-scope --repo-root . 2>/dev/null || true)"
           if [ -z "$REPORT" ]; then
             echo "drift_count=0" >> "$GITHUB_OUTPUT"
             echo "No drift detected (or no filled translations to drift against)."
@@ -274,13 +271,14 @@ jobs:
           echo "drift_count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "Drift anomalies: $COUNT"
           echo "$REPORT"
-          # Etape 5 de #10329 : archiver le rapport out-of-scope (si active)
-          # comme artefact de run pour audit. Non-bloquant.
-          if [ "$T1_MODE" = "full" ]; then
-            echo "$REPORT" > translation-sync-report.json
-            OOS_COUNT="$(echo "$REPORT" | python -c 'import sys,json; r=json.load(sys.stdin); print(r.get("out_of_scope_count",0))' 2>/dev/null || echo 0)"
-            echo "::notice title=T2 out-of-scope::${OOS_COUNT} notebook(s) MISSING_FROM_CSV (etape 5 #10329)."
-          fi
+          # Etape 5 de #10329 : archiver le rapport out-of-scope comme
+          # artefact de run pour audit, et emettre le notice a CHAQUE run
+          # (pas seulement --full) — c'est le garde-fou contre la recidive :
+          # un notebook FR enrichi sans pipeline reste visible au run
+          # suivant. Non-bloquant.
+          echo "$REPORT" > translation-sync-report.json
+          OOS_COUNT="$(echo "$REPORT" | python -c 'import sys,json; r=json.load(sys.stdin); print(r.get("out_of_scope_count",0))' 2>/dev/null || echo 0)"
+          echo "::notice title=T2 out-of-scope::${OOS_COUNT} notebook(s) MISSING_FROM_CSV (etape 5 #10329)."
 
       # ------------------------------------------------------------------
       # T3 — translate CHANGED CELLS ONLY. ACTIVATED (grain D #10055 landed the

--- a/scripts/translation/tests/test_t2_out_of_scope_unconditional.py
+++ b/scripts/translation/tests/test_t2_out_of_scope_unconditional.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Garde-fou #10329 critere 6+7 : le scan out-of-scope de T2 est INCONDITIONNEL.
+
+Contexte (issue #10329) : le pipeline T1 est incremental sur un etat qui n'a
+jamais ete initialise — la derive anterieure au cablage du pipeline n'entre
+dans aucun perimetre, et aucun run futur ne la rattrape. La parade exigee par
+le critere 6 : « T2 journalise la derive hors-perimetre a chaque run » —
+pas seulement en mode --full. C'est exactement le scenario qui a cree la
+dette (78/163 lignes sur finetuning.csv) : des notebooks enrichis sans
+passer par le pipeline, invisibles de tous les runs verts.
+
+La premiere livraison (#10371) ne branchait `--report-out-of-scope` qu'en
+mode T1_MODE=full — un run incremental restait aveugle. La presente PR le
+rend inconditionnel. Ce test verrouille le pattern pour empecher la
+regression (re-scoper le flag au mode full) :
+
+  (1) le step « T2 detect drift » de translation-sync.yml invoque
+      check_translation_sync.py AVEC --report-out-of-scope ;
+  (2) l'invocation n'est PAS conditionnee au mode (pas de garde
+      `if [ "$T1_MODE" = "full" ]` autour du flag ou du notice) ;
+  (3) le notice T2 out-of-scope est emis inconditionnellement.
+
+Comme scripts/tests/test_workflow_branch_pattern.py, ce test n'execute PAS
+le workflow — il parse le YAML et grep les blocs bash.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+TRANSLATION_SYNC = (
+    REPO_ROOT / ".github" / "workflows" / "translation-sync.yml"
+)
+
+
+def _t2_run_block() -> str:
+    """Extrait le bloc run: du step « T2 detect drift »."""
+    text = TRANSLATION_SYNC.read_text(encoding="utf-8")
+    m = re.search(
+        r"- name: T2 detect drift.*?run: \|\n(.*?)(?=\n +-\s+name:|\Z)",
+        text,
+        flags=re.S,
+    )
+    assert m is not None, (
+        "step « T2 detect drift » introuvable dans translation-sync.yml — "
+        "le workflow a ete restructure ; mettre a jour ce garde-fou"
+    )
+    return m.group(1)
+
+
+def test_t2_invokes_report_out_of_scope():
+    block = _t2_run_block()
+    assert "--report-out-of-scope" in block, (
+        "T2 doit invoquer check_translation_sync.py avec --report-out-of-scope "
+        "(critere 6 de #10329 : journalisation hors-perimetre a CHAQUE run)"
+    )
+
+
+def test_t2_out_of_scope_not_gated_on_mode():
+    block = _t2_run_block()
+    # Le flag ne doit pas vivre derriere un garde de mode : la dette creee
+    # par un enrichissement hors pipeline est invisible d'un run incremental.
+    # On verifie qu'aucun if T1_MODE ne precede (dans le bloc) l'invocation
+    # qui porte le flag.
+    flagged = [
+        line for line in block.splitlines() if "--report-out-of-scope" in line
+    ]
+    assert flagged, "flag --report-out-of-scope absent du bloc T2"
+    for line in flagged:
+        assert "T1_MODE" not in line, (
+            "l'invocation de --report-out-of-scope ne doit pas etre "
+            "conditionnee au mode (regression critere 6 de #10329)"
+        )
+    # Et aucun if T1_MODE ne doit subsister dans le bloc T2 (toute
+    # re-conditionalisation du scan est suspecte).
+    assert 'T1_MODE' not in block, (
+        "le bloc T2 ne doit plus contenir de garde T1_MODE : le scan "
+        "out-of-scope est inconditionnel depuis #10329 (critere 6)"
+    )
+
+
+def test_t2_out_of_scope_notice_unconditional():
+    block = _t2_run_block()
+    assert "title=T2 out-of-scope" in block, (
+        "le notice T2 out-of-scope doit etre emis (garde-fou critere 7 de "
+        "#10329 : la derive reste visible au run suivant)"
+    )
+    # Le notice et l'archivage du rapport ne doivent pas etre gates :
+    # la ligne du notice ne doit pas etre imbriquee sous un if de mode.
+    notice_lines = [
+        (i, ln) for i, ln in enumerate(block.splitlines())
+        if "title=T2 out-of-scope" in ln
+    ]
+    assert notice_lines, "notice T2 out-of-scope absent"
+    for _i, ln in notice_lines:
+        assert "if [" not in ln


### PR DESCRIPTION
## Summary

Grain: MED/guard — lane myia-po-2026:CoursIA — prev: DEEP/lean #10987
See #10329 (critères 6+7 livrés ; critère 4 = rattrapage T3 reste bloqué par le HOLD user — voir Residual)

Audit des 7 critères d'acceptation de #10329 sur main d'abord (G.9 — ne pas re-livrer du déjà-fait) :

| # | Critère | État avant cette PR |
|---|---------|---------------------|
| 1 | dette chiffrée sur tous les CSV | LIVRÉ — measure_translation_debt.py (#10347) |
| 2 | count(CSV) == count(cellules FR) | LIVRÉ — FT-02 : 33 == 33 vérifié sur main |
| 3 | ift02-gen/cmp présents sur main | LIVRÉ — vérifié présents (grep = 2) |
| 4 | rendu FT-02_en sans markdown FR | BLOQUÉ — rattrapage T3, workflow en HOLD user (manuel uniquement) |
| 5 | #10326 avant T3 | LIVRÉ — #10335 + #10369 MERGED |
| 6 | T2 journalise la dérive hors-périmètre **à chaque run** | **NON-LIVRÉ** — #10371 ne branchait le scan qu'en mode `--full` ; un run incremental restait aveugle |
| 7 | test garde-fou (notebook enrichi sans pipeline visible au run suivant) | **PARTIEL** — 3 tests unitaires + 1 test CLI existent ; rien ne verrouillait le câblage workflow |

Cette PR livre les critères 6 et 7.

## Deliverables

1. **`translation-sync.yml` (T2 detect drift)** : `--report-out-of-scope` **inconditionnel** — plus de garde `if [ "$T1_MODE" = "full" ]` autour du scan, du notice, ni de l'archivage du rapport. Le notice `T2 out-of-scope::N notebook(s) MISSING_FROM_CSV` est émis à CHAQUE run. Le scan est diagnostique, non-bloquant, sans LLM ni réseau (lecture disque uniquement) — coût négligeable par run.
2. **`scripts/translation/tests/test_t2_out_of_scope_unconditional.py`** : 3 tests garde-fou (modèle `test_workflow_branch_pattern.py` — parse le YAML, grep le bloc bash) :
   - `test_t2_invokes_report_out_of_scope` — le flag est invoqué ;
   - `test_t2_out_of_scope_not_gated_on_mode` — aucune garde `T1_MODE` ne re-conditionnalise le scan (anti-régression du critère 6) ;
   - `test_t2_out_of_scope_notice_unconditional` — le notice est émis non-gated.

## Test evidence

```
scripts/translation/tests/test_t2_out_of_scope_unconditional.py ...  [100%] 3 passed
scripts/translation/tests/test_translation_full_mode.py ........     [100%] 8 passed (existants intacts)
scripts/tests/test_workflow_branch_pattern.py ................          14 passed
Contrôle négatif : sur le workflow pré-fix (origin/main), test_t2_out_of_scope_not_gated_on_mode FAILED (1 failed) — le garde-fou détecte la régression.
Suite translation/ complète : 337 passed, 1 failed — test_full_repo_state_passes_parity PRE-EXISTE sur main (aucun *_en.ipynb sur main, conséquence du HOLD user ; vérifié en checkout origin/main — identique). Hors scope de cette PR.
```

## Residual

- **Critère 4** (rendu FT-02_en sans markdown FR) : dépend du rattrapage T3 (16 `text_en` vides sur FT-02 dans le CSV de la branche bot `chore/translation-sync-pending`, elle-même en retard sur main — 31 lignes FT-02 vs 33). Workflow en HOLD user (« manuel uniquement », consigne 2026-08-12) → lancer un run `--full` est une décision coordinateur/user, pas un worker.
- Critères 6+7 maintenant satisfaits ; 1+2+3+5 l'étaient déjà. Il ne restera que le critère 4 à la levée du HOLD.
