### PR TITLE
drain(search,#9434): derive 4 machine-dep ms re-pins from CSP-1-Csharp interpretation prose

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -1388,7 +1388,7 @@
    "id": "d2d3ac0d",
    "metadata": {},
    "source": [
-    "**Interpretation** : Choco-solver resout la coloration de l'Australie en un temps mesuré en sortie au premier appel, puis beaucoup plus rapidement une fois la JVM chaude (cf. enumeration cellule suivante). Le premier appel paie le demarrage de la JVM Java (IKVM) sous-jacente ; en regime etabli, le coeur metier (propagation + backtracking) est bien inferieur a 10 ms.\n",
+    "**Interpretation** : Choco-solver resout la coloration de l'Australie en un temps mesuré en sortie au premier appel, puis beaucoup plus rapidement une fois la JVM chaude (cf. enumeration cellule suivante). Le premier appel paie le demarrage de la JVM Java (IKVM) sous-jacente ; en regime etabli, le coeur metier (propagation + backtracking) est quasi-instantane (runtime *machine-dep*, cf. la mesure en sortie de la cellule suivante).\n",
     "\n",
     "| Aspect | Implementation manuelle C# | Choco-solver 4.10.17 |\n",
     "|--------|---------------------------|----------------------|\n",
@@ -1513,7 +1513,7 @@
     "|--------|-------------------|---------------------------|\n",
     "| Combinaisons testees | 2187 | Reduit (propagation AC-3) |\n",
     "| Solutions | 18 | 18 |\n",
-    "| Temps | ~1-5 ms (Python overhead) | < 10 ms |\n",
+    "| Temps | *machine-dep* (cf. cellule de mesure brute force) | *machine-dep* (mesure en sortie de la cellule precedente) |\n",
     "\n",
     "**Pourquoi 18 solutions ?** Les couleurs Rouge/Vert/Bleu sont interchangeables (symetrie de permutation). Sans sym-breaking explicite, Choco enumere toutes les solutions symetriques. Pour une problematique de coloration \"recherche d une solution\", `solver.solve()` (qui retourne `true`/`false`) suffit."
    ]
@@ -1671,7 +1671,7 @@
    "id": "4bdd51fe",
    "metadata": {},
    "source": [
-    "**Interpretation** : Choco-solver resout les 8-Reines en moins de 50 ms.\n",
+    "**Interpretation** : Choco-solver resout les 8-Reines quasi-instantanement (runtime *machine-dep*, temps mesure en sortie de la cellule precedente).\n",
     "\n",
     "| Mesure | Implementation manuelle | Choco-solver |\n",
     "|--------|------------------------|--------------|\n",

--- a/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
@@ -40,7 +40,14 @@
       csharp_sha: b7c569ab7b66177a75be90fccc8b8bc2acf755c4
       content_python_sha: 3aa9e09c1f0029a5086671f400f79eaf67adf454aeee919f57a7c62c3dd3d148
       content_csharp_sha: 3729ed9b3950b274cb5aec6a8b93ecf1e9b72f610e1c30bb16b50dbef8cd0ac9
+    - date: "2026-08-15"
+      by: myia-po-2026:CoursIA
+      python_sha: 8eb8a6a442a1edfc61a2952916d187611bce0331
+      csharp_sha: 79a41d1f45cf20633b1ebf6e1cdefd0ea7199b99
+      content_python_sha: 3aa9e09c1f0029a5086671f400f79eaf67adf454aeee919f57a7c62c3dd3d148
+      content_csharp_sha: b5cbe3525c9b2b6f5695199caf35ce2659c9c98fc48f3f231f60e4d490ea22e0
   known_differences:
+    - "Edition 2026-08-15 (myia-po-2026:CoursIA, #9434 machine-dep) : drainage markdown-only de 4 re-pins de runtime absolus de la prose d'interpretation du twin C# -- cell[31] borne JVM chaude (bien inferieur a 10 ms), cell[33] table Temps (~1-5 ms / < 10 ms), cell[36] ligne d'ouverture (moins de 50 ms), toutes derivees des sorties de mesure committeees (c32 : Temps enumeration 2,94 ms ; c35 : Temps 46,24 ms). Remplacees par des descripteurs *machine-dep* renvoyant aux sorties des cellules de mesure, geste canonique #9434 (la prose re-epingle une valeur qui contredira la sortie au prochain passage kernel sur une autre machine). check_machine_dep_timing passe de 2 a 0 wallclock sur ce notebook. Parite semantique preservee : le socle from-scratch et l'extension Choco sont inchanges, seules les valeurs machine-dep de la prose ont bouge, d'ou le re-baseline du csharp_sha."
     - "Socle pedagogique commun (parity semantic) : les deux cotes implementent une classe CSP generique + backtracking simple + heuristique MRV + value-ordering LCV, depuis zero (pas de lib externe pour le coeur). Cote Python : classe CSP dict/list pure Python. Cote C# : classe CSP generique C# (Dictionary/List) qui reflete la Python."
     - "Extension solveur ASYMETRIQUE : le cote C# ajoute Choco-solver 4.10.17 (Java solver via IKVM 8.15.0, recette #4711) avec des cellules (coloration Australie par Choco, enumeration de TOUTES les solutions, 8-Reines par Choco) qui n'ont PAS d'equivalent direct cote Python. Le cote Python reste pur from-scratch sur tout le notebook."
     - "Visualisation : Python = matplotlib (graphes de contraintes, trace de backtracking, distributions). C# = rendu ASCII du graphe de contraintes (pas de plotting .NET headless)."


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2026:CoursIA — prev: LIGHT/readme #10991

See #9434 (machine-dep class, contribution partielle — l'epic reste ouverte)

## Ce qui est livré

`CSP-1-Fundamentals-Csharp.ipynb` — 4 re-pins de runtime absolus drainés de la prose d'interprétation (markdown-only, aucune cellule code touchée, pas de re-exécution requise) :

| cell | avant | après | sortie de mesure sous-jacente |
|---|---|---|---|
| c31 | « le coeur metier est bien inferieur a **10 ms** » (JVM chaude) | « quasi-instantane (runtime *machine-dep*, cf. la mesure en sortie de la cellule suivante) » | c32 : `Temps enumeration : 2,94 ms` |
| c33 | table `\| Temps \| ~1-5 ms \| < 10 ms \|` | descripteurs *machine-dep* renvoyant aux cellules de mesure | c32 idem |
| c36 | « resout les 8-Reines en **moins de 50 ms** » | « quasi-instantanement (runtime *machine-dep*, temps mesure en sortie de la cellule precedente) » | c35 : `Temps : 46,24 ms` |

Pathologie #9434 critère 3 verbatim : la prose re-épinglait des bornes dérivées des sorties commitées — au prochain passage kernel sur une autre machine, la sortie dit 120 ms pendant que la prose dit « moins de 50 ms » = contradiction = ticket #8052 suivant.

## Preuves

- `check_machine_dep_timing.py CSP-1-Fundamentals-Csharp.ipynb` : **wallclock 2 → 0** (le détecteur ne voyait pas c33/c31 — bornes soft-signal — mais la classe est identique ; drainés pour cohérence).
- Registre twin `csp-1-fundamentals.yaml` : DRIFT attendu → **--update rebaseline + known_differences** documentant l'édition. `check_twin_parity.py --check` : **OK=157 DRIFT=0 MISSING=0**. Rebaseline en DERNIER (#8957).
- Diff : 3 insertions / 3 deletions sur le notebook (2 commits) + 7 insertions registre.

## Census de classification (item 1, énumération GenAI + Search sur origin/main 0a8dfbb50)

174 wallclock restants fleet-wide (GenAI 106, Search 19, QC 18, SymbolicAI 13, Sudoku 13). Lecture par contenu des 31 findings GenAI/Video+Image+Audio+Texte et Search : la grande majorité = **exempts par classe** :

1. **Cost-metadata sections** (02-7-CogVideoX c22 « 158.5 s / 9.6 GB », machine nommée) — convention formelle du repo (schéma #8376, `test_check_cost_metadata.py`) : provenance délibérée, PAS à drainer. → **le détecteur manque une exemption cost-metadata** (piste d'amélioration outillage, séparée).
2. **Valeurs protégées par registre twin** (App-11b c19 « 0,26 ms / ~27 ms ») — décision documentée 2026-08-08 + Tranche 2 validée Prong-B dans `app-11-picross.yaml` known_differences.
3. **Formes déjà conformes** (App-1 c34, App-15 c33 : « runtime *machine-dep* (cellule de calcul) ») et **paramètres de benchmark/config** (App-20 « budget 60 s = paramètre déterministe », timeouts, SLA produit Sora, specs d'exercice).
4. **Vrai résiduel machine-dep trouvé** : `GenAI/Image/03-3-Performance-Optimization.ipynb` cell[13] (« **841,3 ms** et **1500 MB** de VRAM sur le RTX 3090 », ×2 occurrences) — prochaine tranche GenAI naturelle, hors scope ici (un domaine par PR).

## Validation

- Markdown-only : exception C.2 (outputs précédents valides), H.3 n/a.
- `check_twin_parity.py --check` : OK=157 DRIFT=0 (post-rebaseline).
- Base fraîche : branche créée sur origin/main 0a8dfbb50.

