### PR TITLE
feat(lean,#10986): bump 3 core-only lakes to v4.32.0 (Phase 0+1 pilots)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lean-toolchain
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.31.0-rc1
+leanprover/lean4:v4.32.0

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/README.md
@@ -1,7 +1,7 @@
 # lean_game_defs_ext — Jeux bayésiens en Lean 4 (core uniquement)
 
 Formalisation des jeux bayésiens finis à deux joueurs (espaces de types
-de Harsanyi) en Lean 4 **sans Mathlib** (toolchain `v4.31.0-rc1`, core
+de Harsanyi) en Lean 4 **sans Mathlib** (toolchain `v4.32.0`, core
 uniquement — évite la mutualisation des checkouts Mathlib, cf #2611).
 Compagnon formel de `GameTheory-11-BayesianGames.ipynb`. Phases 1-7 de
 l'Epic #2610 livrées (cf [Lien avec `lean_game_defs/`](#lien-avec-lean_game_defs)).

--- a/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lean-toolchain
+++ b/MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.31.0-rc1
+leanprover/lean4:v4.32.0

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.en.md
@@ -11,7 +11,7 @@ Lean 4 mini-project from Epic #2978 (deliverable C), shipped via PR #3018.
 
 ## Status
 
-- **Toolchain**: `leanprover/lean4:v4.31.0-rc1`
+- **Toolchain**: `leanprover/lean4:v4.32.0`
 - **Sorry**: **0 sorry, 0 axiom** — everything is proven or illustrated via `#eval`
 - **Build**: `lake build Finiteness` — **autonomous, without Mathlib** (Lean core only)
 - **Dependencies**: none

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/README.md
@@ -9,7 +9,7 @@ Mini-projet Lean 4 issu de l'Epic #2978 (livrable C), livré par la PR #3018.
 
 ## État
 
-- **Toolchain** : `leanprover/lean4:v4.31.0-rc1`
+- **Toolchain** : `leanprover/lean4:v4.32.0`
 - **Sorry** : **0 sorry, 0 axiom** — tout est prouvé ou illustré par `#eval`
 - **Build** : `lake build Finiteness` — **autonome, sans Mathlib** (Lean core seul)
 - **Dépendances** : aucune

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.31.0-rc1
+leanprover/lean4:v4.32.0


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: MED/notebook-python #10994

See #10986 (contribution partielle : Phase 0 + Phase 1 de 4 ; les 19 lakes Mathlib restent)

## Ce qui est livré

Phase 0 + Phase 1 du plan de #10984-motivated migration : les **3 lakes core-only** passent de `v4.31.0-rc1` à `v4.32.0` (stable).

| lake | diff | build local 4.32.0 |
|---|---|---|
| `GameTheory/lean_game_defs` | `lean-toolchain` seul | **SUCCESS 14 jobs, exit 0** |
| `GameTheory/lean_game_defs_ext` | `lean-toolchain` + README.md | **SUCCESS 28 jobs, exit 0** |
| `SymbolicAI/Lean/finiteness_lean` | `lean-toolchain` + README.md + README.en.md | **SUCCESS 4 jobs, exit 0** |

**Zéro changement de code** : la toolchain roule à l'identique (les 3 lakes ne dépendent que du core Lean — inventaire po-2024 confirmé par lecture des lakefile.toml : `packages: []`). `lake env lean --version` dans chaque worktree : `Lean (version 4.32.0, x86_64-w64-windows-gnu, commit 8c9756b)`.

## Preuves §B (Lean)

- **sorry/admit : 0 → 0** sur les 3 lakes (aucun fichier .lean modifié). Le grep initial signalait 3+4 hits sur SocialChoice(.lean/_en) = l'axiome DECLARÉ `arrow_impossibility` (documenté ligne 94-95, intentionnel) + sa mention en docstring — préservés intacts.
- **i18n `_en` siblings** : roots/globs inchangés dans les lakefile.toml — les 12 modules FR+EN de lean_game_defs et le glob `Bayesian.*`+`Bayesian_en` de l'ext restent compilés par `lake build` (jobs `*_en` visibles dans les logs de build).
- **lake-manifest.json** : inchangés (core-only, `packages: []` — rien à régénérer).
- **CI** : les 3 workflows (`lean-game-defs.yml`, `lean-game-defs-ext.yml`, `lean-finiteness.yml`) ont `lean-toolchain` en paths-trigger et lisaient la version du fichier — le bump déclenche les 3 builds sous 4.32.0 (authoritative pour le merge).

## Signal hors scope (principe 3)

`lean_game_defs/README.md:7` affirme « pas de `lakefile.lean`, pas de pin toolchain » — **périmé depuis #2752** (le lake a un `lakefile.toml` + `lean-toolchain` depuis, c'est même le chemin de vérification CI cité dans le toml). Prose stale, pas corrigée ici (un sujet par PR) — à traiter dans une passe README dédiée.

## Résiduel #10986

Phase 2 (pilote Mathlib : sensitivity_lean ou knot_lean — `lake update mathlib` + `lake exe cache get` + CI) puis Phase 3 (rollout des 18 lakes Mathlib restants, par tranches). La lane suit l'ordre du plan de l'issue.
