### PR TITLE
ci(lean,#10889): conway proof-integrity-audit to target-modules "*" + 21 build-enumerated allow-axioms (59)

### DIFF
--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -151,10 +151,11 @@ jobs:
   # by default (the knot_lean 5/12-vs-5/14 miscount, #8782 pitfall 2). Moving the
   # covered count 3 -> 7 closes 4 of the 50 blind-spot modules.
   #
-  # RESIDUAL (follow-up, needs a warm Mathlib junction to enumerate): the 6
-  # nd-bearing sorry-free Life modules each carry their OWN native_decide axioms
-  # (NOT in the 28-name allow-list, which is HashlifeCorrectness-specific) -- adding
-  # them requires build-enumerated allow-axioms entries, not a static guess.
+  # RESIDUAL above is now CLOSED (point 5 of #10889): the flip to
+  # target-modules "*" below enumerated the nd-bearing modules' axioms on a
+  # warm main-identical build (probe = the same LeanVerifier.check_axioms loop
+  # this job runs, 2026-08-15) and the 21 build-enumerated names were added
+  # one-by-one to allow-axioms below -- never a wildcard entry.
   proof-integrity-audit:
     uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
     with:
@@ -166,30 +167,58 @@ jobs:
       # and could not tell which tolerates the 8 acknowledged sorries from which
       # refuses them. Pinned by scripts/lean/tests/test_proof_integrity_display_names.py.
       display-name: conway_lean (audit)
-      # #9863 (displacement-pur split): the monolithic HashlifeCorrectness.lean (7082 ln)
-      # was split into an import aggregator + Foundation + Walls/{NW,NE,SW,SE}. The 8
-      # acknowledged tactic sorries now live in Walls/{NW,NE,SW,SE} (native_decide=0
-      # there), so those submodules MUST be in target-modules to keep the sorries
-      # surfaced by this advisory job (fail-on-sorry: false reports them as has_sorry).
-      # The 38-name allow-axioms list below is UNCHANGED: native_decide axiom names are
-      # namespace-derived (Conway.Life.<decl>._native.native_decide.ax_1_N), and every
-      # submodule reopens `namespace Conway` / `namespace Life` with no extra segment,
-      # so declaration names -- hence axiom names -- are stable across the split.
-      target-modules: "Conway.Life.HashlifeCorrectness,Conway.Life.HashlifeCorrectness.Foundation,Conway.Life.HashlifeCorrectness.Walls.NW,Conway.Life.HashlifeCorrectness.Walls.NE,Conway.Life.HashlifeCorrectness.Walls.SW,Conway.Life.HashlifeCorrectness.Walls.SE,Conway.Life.MacroCell,Conway.Life.Hashlife,Conway.Life.MacroCell_en,Conway.Life.Hashlife_en,Conway.Life.Oscillators,Conway.Life.Spaceships,Conway.Life.Spaceships_en,Conway.Life.RLE,Conway.Life.HashlifeMemo,Conway.Life.HashlifeMarginDemo,Conway.Life.GridCanonical,Conway.Life.GridCanonical_en"
-      # allow-axioms: the 38 native_decide axioms that HashlifeCorrectness ACTUALLY
-      # depends on (empirical footprint revealed by THIS audit job's first CI run).
-      # These are DISTINCT from the blocking gate's 19-name list above: that list
-      # was triaged from the SHOWCASE modules (KochenSpecker/FreeWillTheorem, #8749),
-      # a different scope -- the 19 are vestigial for this module (zero overlap).
-      # Auditing HashlifeCorrectness directly revealed the true native_decide
-      # footprint of the P4/hashlife correctness machinery is 38, not 19 -- exactly
-      # the vert-hors-cible this issue opened on (the blocking gate was green
-      # because it never looked here). All 38 are decide-kernel
-      # (`._native.native_decide.ax_1_N` = `decide` on finite Fin-typed props),
-      # the same acknowledged class as the 19; allow-listing the exact set lets
-      # the audit go green-on-acknowledged + red-on-a-NEW native_decide (the
-      # "new native_decide = new red" property the no-wildcard rule preserves).
-      allow-axioms: "Conway.Life.hashlife_correct_implies_block_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_toad_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_glider_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_blinker_h_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_beacon_2._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_4,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_2,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_3,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell_3._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_block_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_glider_8._native.native_decide.ax_1_1,Conway.Life.boxAssezGrandN_block_8._native.native_decide.ax_1_1,Conway.Life.boxAssezGrandN_glider_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_3_false._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_8_false._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_2._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_not_vacuous._native.native_decide.ax_1_1,Conway.Life.p4_wf_witness_k2._native.native_decide.ax_1_1,Conway.Life.p4_wf_witness_k1._native.native_decide.ax_1_1,Conway.Life.p4_base_exhaustive._native.native_decide.ax_1_1✝,Conway.Life.p4_base_blinker._native.native_decide.ax_1_1,Conway.Life.p4_base_block._native.native_decide.ax_1_1,Conway.Life.p4_base_glider._native.native_decide.ax_1_1,Conway.Life.p4_base_dead._native.native_decide.ax_1_1,Conway.Life.p4_unrestricted_counterexample._native.native_decide.ax_1_1,Conway.Life.padCenter2_correct_block_level1._native.native_decide.ax_1_1,Conway.Life.pulsar_period_three._native.native_decide.ax_1_1,Conway.Life.pentadecathlon_period_15._native.native_decide.ax_1_1,Conway.Life.RLE.glider_parse_ok._native.native_decide.ax_1_1,Conway.Life.RLE.lwss_parse_ok._native.native_decide.ax_1_1,Conway.Life.RLE.pulsar_parse_ok._native.native_decide.ax_1_1,Conway.Life.RLE.gosper_gun_parse_ok._native.native_decide.ax_1_1,Conway.Life.RLE.lwss_rle_roundtrip._native.native_decide.ax_1_1,Conway.Life.RLE.pulsar_rle_roundtrip._native.native_decide.ax_1_1,Conway.Life.RLE.gosper_gun_cell_count._native.native_decide.ax_1_1,Conway.Life.RLE.glider_parsed_cell_count._native.native_decide.ax_1_1"
+      # #10889 (point 5): target-modules "*" -- lean-axiom.yml derives the
+      # module list at runtime by walking every *.lean the lake compiles
+      # (69 modules on 2026-08-15), so a hand-maintained list can never drift
+      # out of this gate's view again. The 18-module explicit list this
+      # replaces covered 18/69; the wildcard keeps those AND the ~45
+      # blind-spot modules (JumpCapture, PatternTour, Pillars,
+      # LookAndSayLemmas, RLE_en, ...), and surfaced 2 previously-unseen
+      # sorry-bearing modules (HashlifeMarginFragment + _en -- reported
+      # has_sorry, not gated: this job is fail-on-sorry: false).
+      # include-i18n-siblings: "true" -- the wildcard derivation excludes
+      # `_en` siblings by default (FR-only measurement, #10889); opting in
+      # keeps the 4 _en modules the explicit list already covered
+      # (MacroCell_en, Hashlife_en, Spaceships_en, GridCanonical_en) AND adds
+      # the 5 nd-bearing _en modules whose axioms are enumerated below. A gate
+      # that counts compiled modules must not omit half a bilingual pair
+      # (#8782 pitfall 2).
+      # #9863 history: the monolithic HashlifeCorrectness.lean (7082 ln) was
+      # split into an import aggregator + Foundation + Walls/{NW,NE,SW,SE};
+      # the 8 acknowledged tactic sorries live in the Walls submodules
+      # (native_decide=0 there). Under the explicit list those submodules had
+      # to be NAMED to keep the sorries surfaced; the wildcard covers them by
+      # construction now.
+      target-modules: "*"
+      include-i18n-siblings: "true"
+      # allow-axioms: 59 native_decide axioms = the 38 HashlifeCorrectness-era
+      # empirical footprint (revealed by this job's first CI run, #8782/#9341,
+      # shrunk by the #9571 still-life + #9595 spaceship decide flips) + 21
+      # build-enumerated entries added by the #10889 "*" widening (probe: this
+      # job's own LeanVerifier.check_axioms loop over all 69 modules on a warm
+      # main-identical conway build, 2026-08-15). All 59 are decide-kernel
+      # (`._native.native_decide.ax_1_N` = `decide` on finite Fin-typed props).
+      # The 21 new entries, each annotated with the module that introduces it:
+      #   Conway.Life.JumpCapture (3): jumpCaptured_block / _glider /
+      #     _not_trivial
+      #   Conway.Life.PatternTour (1): pulsar_is_oscillator
+      #   Conway.Life.Pillars (1): Pillars.pulsar_period3
+      #   Conway.LookAndSayLemmas (2): digitsToNat_example, lookAndSay_4
+      #   Conway.Life.Oscillators_en (2): Conway_en.Life_en.pulsar_period_three,
+      #     pentadecathlon_period_15 (_en twins of 2 of the 38)
+      #   Conway.Life.PatternTour_en (1): Conway_en.Life_en.pulsar_is_oscillator
+      #   Conway.Life.Pillars_en (1): Conway.Life.Pillars_en.pulsar_period3
+      #     -- namespace keeps the FR Conway.Life path here while other _en
+      #     twins live under Conway_en.*: this heterogeneity is exactly why
+      #     names are ENUMERATED from the build, never derived by rule.
+      #   Conway.Life.RLE_en (8): Conway_en.Life_en.RLE_en.* (_en twins of
+      #     the 8 RLE entries of the 38)
+      #   Conway.LookAndSayLemmas_en (2): Conway_en.digitsToNat_example,
+      #     Conway_en.lookAndSay_4
+      # Names stay explicit -- no wildcard entry in allow-axioms: a NEW
+      # native_decide anywhere in the lake = a new red ("new native_decide =
+      # new red"), the property the no-wildcard rule preserves.
+      allow-axioms: "Conway.Life.hashlife_correct_implies_block_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_toad_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_glider_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_blinker_h_2._native.native_decide.ax_1_1,Conway.Life.hashlife_correct_implies_beacon_2._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_4,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_2,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_3,Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_single_cell_3._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_block_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grandN_glider_8._native.native_decide.ax_1_1,Conway.Life.boxAssezGrandN_block_8._native.native_decide.ax_1_1,Conway.Life.boxAssezGrandN_glider_8._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_3_false._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_8_false._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_single_cell_2._native.native_decide.ax_1_1,Conway.Life.box_assez_grand_not_vacuous._native.native_decide.ax_1_1,Conway.Life.p4_wf_witness_k2._native.native_decide.ax_1_1,Conway.Life.p4_wf_witness_k1._native.native_decide.ax_1_1,Conway.Life.p4_base_exhaustive._native.native_decide.ax_1_1✝,Conway.Life.p4_base_blinker._native.native_decide.ax_1_1,Conway.Life.p4_base_block._native.native_decide.ax_1_1,Conway.Life.p4_base_glider._native.native_decide.ax_1_1,Conway.Life.p4_base_dead._native.native_decide.ax_1_1,Conway.Life.p4_unrestricted_counterexample._native.native_decide.ax_1_1,Conway.Life.padCenter2_correct_block_level1._native.native_decide.ax_1_1,Conway.Life.pulsar_period_three._native.native_decide.ax_1_1,Conway.Life.pentadecathlon_period_15._native.native_decide.ax_1_1,Conway.Life.RLE.glider_parse_ok._native.native_decide.ax_1_1,Conway.Life.RLE.lwss_parse_ok._native.native_decide.ax_1_1,Conway.Life.RLE.pulsar_parse_ok._native.native_decide.ax_1_1,Conway.Life.RLE.gosper_gun_parse_ok._native.native_decide.ax_1_1,Conway.Life.RLE.lwss_rle_roundtrip._native.native_decide.ax_1_1,Conway.Life.RLE.pulsar_rle_roundtrip._native.native_decide.ax_1_1,Conway.Life.RLE.gosper_gun_cell_count._native.native_decide.ax_1_1,Conway.Life.RLE.glider_parsed_cell_count._native.native_decide.ax_1_1,Conway.Life.jumpCaptured_block._native.native_decide.ax_1_1,Conway.Life.jumpCaptured_glider._native.native_decide.ax_1_1,Conway.Life.jumpCaptured_not_trivial._native.native_decide.ax_1_1,Conway.Life.pulsar_is_oscillator._native.native_decide.ax_1_1,Conway.Life.Pillars.pulsar_period3._native.native_decide.ax_1_1,Conway.digitsToNat_example._native.native_decide.ax_1_1,Conway.lookAndSay_4._native.native_decide.ax_1_1,Conway_en.Life_en.pulsar_period_three._native.native_decide.ax_1_1,Conway_en.Life_en.pentadecathlon_period_15._native.native_decide.ax_1_1,Conway_en.Life_en.pulsar_is_oscillator._native.native_decide.ax_1_1,Conway.Life.Pillars_en.pulsar_period3._native.native_decide.ax_1_1,Conway_en.Life_en.RLE_en.glider_parse_ok._native.native_decide.ax_1_1,Conway_en.Life_en.RLE_en.lwss_parse_ok._native.native_decide.ax_1_1,Conway_en.Life_en.RLE_en.pulsar_parse_ok._native.native_decide.ax_1_1,Conway_en.Life_en.RLE_en.gosper_gun_parse_ok._native.native_decide.ax_1_1,Conway_en.Life_en.RLE_en.lwss_rle_roundtrip._native.native_decide.ax_1_1,Conway_en.Life_en.RLE_en.pulsar_rle_roundtrip._native.native_decide.ax_1_1,Conway_en.Life_en.RLE_en.gosper_gun_cell_count._native.native_decide.ax_1_1,Conway_en.Life_en.RLE_en.glider_parsed_cell_count._native.native_decide.ax_1_1,Conway_en.digitsToNat_example._native.native_decide.ax_1_1,Conway_en.lookAndSay_4._native.native_decide.ax_1_1"
       fail-on-sorry: false
 
   # Advisory proof-integrity coverage (See #8782). The `target-modules` lists

--- a/scripts/lean/tests/test_check_target_coverage.py
+++ b/scripts/lean/tests/test_check_target_coverage.py
@@ -441,7 +441,10 @@ class TestRealWorkflowRegression:
             pytest.skip(f"workflow not present: {wf}")
         union, per_job = targets_from_workflow(wf)
         assert len(per_job) >= 2, f"expected blocking + audit gate jobs, got {sorted(per_job)}"
-        assert "Conway.Life.HashlifeCorrectness" in union
+        # Post-#10889 the audit job derives its list at runtime (`"*"`): the
+        # union carries the sentinel instead of the literal module. Either
+        # form means the gate inspects HashlifeCorrectness.
+        assert "*" in union or "Conway.Life.HashlifeCorrectness" in union
         assert "Conway.KochenSpecker" in union
         assert "Conway.FreeWillTheorem" in union
 

--- a/scripts/lean/tests/test_conway_blocking_gate_whitelist_aligned.py
+++ b/scripts/lean/tests/test_conway_blocking_gate_whitelist_aligned.py
@@ -171,4 +171,6 @@ def test_blocking_gate_audit_job_still_there():
     assert "Conway.FreeWillTheorem" in blocking.get("target-modules", "")
     audit = jobs["proof-integrity-audit"]["with"]
     assert audit.get("fail-on-sorry") is False
-    assert "Conway.Life.HashlifeCorrectness" in audit.get("target-modules", "")
+    # Post-#10889 the audit derives its module list at runtime ('*' = every
+    # compiled module, HashlifeCorrectness included by construction).
+    assert audit.get("target-modules") == "*"

--- a/scripts/lean/tests/test_proof_integrity_audit_wiring.py
+++ b/scripts/lean/tests/test_proof_integrity_audit_wiring.py
@@ -72,12 +72,17 @@ def test_audit_targets_sorry_bearing_module():
     """The audit closes the vert-hors-cible: it inspects the module that
     CARRIES the 8 sorries (HashlifeCorrectness), which the blocking gate
     skips. Targeting only KochenSpecker/FreeWillTheorem here would reproduce
-    the very gap #8782 opened on."""
+    the very gap #8782 opened on. Post-#10889 the coverage is stronger than
+    naming the module: `target-modules: "*"` derives the list at runtime, so
+    HashlifeCorrectness -- and every module added later -- is covered by
+    construction."""
     jobs = _load_jobs()
     audit = jobs["proof-integrity-audit"].get("with", {})
     targets = audit.get("target-modules", "")
-    assert "Conway.Life.HashlifeCorrectness" in targets, (
-        "audit must target the sorry-bearing module, not the sorry-free showcase")
+    assert targets == "*", (
+        "audit must derive its module list at runtime ('*', #10889 point 5) -- "
+        "an explicit list can drift out of view of the sorry-bearing module "
+        "and of any module added later")
 
 
 def test_audit_allowlists_native_decide_axioms():
@@ -120,7 +125,19 @@ def test_audit_allowlists_native_decide_axioms():
     'does not depend on any axioms' on all 3 (FR+EN byte-identity verified),
     so their 3 axiom names genuinely left the build-enumerated footprint.
     Same ratchet direction as #9571 (virtuous shrink, fewer trusted-kernel
-    escapes); the pin follows the footprint down by 3 to 38."""
+    escapes); the pin follows the footprint down by 3 to 38.
+
+    **Widened to 59 by #10889 point 5** (`ci(lean,#10889)`): the audit flipped
+    from the 18-module explicit list to `target-modules: "*"` with
+    `include-i18n-siblings: "true"` (69 modules derived at runtime). The 21
+    added entries are the build-enumerated footprint of exactly the newly
+    covered modules -- JumpCapture (3), PatternTour (1), Pillars (1),
+    LookAndSayLemmas (2) on the FR side, plus the `_en` twins of
+    Oscillators (2), PatternTour (1), Pillars (1), RLE (8), LookAndSayLemmas
+    (2) under the `Conway_en.*` namespaces (with `Pillars_en` keeping the FR
+    `Conway.Life.*` path -- namespace heterogeneity is why names are
+    enumerated from the build, never derived by rule). Same legitimacy rule
+    as #9341: every added name is attributable to a newly covered module."""
     jobs = _load_jobs()
     audit = jobs["proof-integrity-audit"].get("with", {})
     allow = audit.get("allow-axioms", "")
@@ -130,18 +147,21 @@ def test_audit_allowlists_native_decide_axioms():
     # the blocking gate's 19) is caught -- and so any future widening has to
     # come with the module-attribution argument, as #9341's did.
     names = [a.strip() for a in allow.split(",") if a.strip()]
-    assert len(names) == 38, (
-        f"audit allow-list must carry the 38 native_decide axioms of the 7 "
-        f"covered Life modules (empirical footprint, #8782 + #9341, shrunk by "
-        f"the #9571 still-life decide flips + the #9595 spaceship decide flips); "
-        f"got {len(names)}")
+    assert len(names) == 59, (
+        f"audit allow-list must carry the 59 native_decide axioms of the whole "
+        f"lake under the #10889 '*' derivation (38 HashlifeCorrectness-era "
+        f"footprint + 21 build-enumerated entries of the newly covered "
+        f"modules, each attributed in the workflow comment); got {len(names)}")
     # Sample members from each family revealed by the audit (P4 base cases,
-    # box-assez-grand lemmas, hashlife_correct_implies bridges).
+    # box-assez-grand lemmas, hashlife_correct_implies bridges, plus one
+    # #10889-widening family: the _en twins under Conway_en.*).
     for sample in [
         "Conway.Life.p4_base_exhaustive._native.native_decide.ax_1_1✝",
         "Conway.Life.box_assez_grandN_single_cell._native.native_decide.ax_1_4",
         "Conway.Life.hashlife_correct_implies_block_2._native.native_decide.ax_1_1",
         "Conway.Life.padCenter2_correct_block_level1._native.native_decide.ax_1_1",
+        "Conway.Life.jumpCaptured_block._native.native_decide.ax_1_1",
+        "Conway_en.Life_en.RLE_en.glider_parse_ok._native.native_decide.ax_1_1",
     ]:
         assert sample in names, (
             f"audit allow-list missing revealed axiom {sample!r}")
@@ -174,7 +194,10 @@ def test_blocking_and_audit_are_complementary():
     jobs = _load_jobs()
     blocking_targets = jobs["proof-integrity"].get("with", {}).get("target-modules", "")
     audit_targets = jobs["proof-integrity-audit"].get("with", {}).get("target-modules", "")
-    assert "Conway.Life.HashlifeCorrectness" in audit_targets
+    # Post-#10889 the audit derives its list at runtime ('*' = every compiled
+    # module, HashlifeCorrectness included by construction); the blocking gate
+    # keeps its explicit showcase-only list.
+    assert audit_targets == "*"
     assert "Conway.Life.HashlifeCorrectness" not in blocking_targets
 
 


### PR DESCRIPTION
## Summary

Point 5 of #10889 (ai-01 c.101 named grain): flip the conway_lean `proof-integrity-audit` job from the 18-module explicit `target-modules` list to `"*"` (runtime derivation), with the native_decide allow-axioms extended **one-by-one, never wildcard, each annotated with its introducing module** in the workflow comment.

- `target-modules: "*"` — lean-axiom.yml derives the list at runtime by walking every `*.lean` the lake compiles: **69 modules** covered vs 18 before. The hand-maintained list can no longer drift out of the gate's view.
- `include-i18n-siblings: "true"` — keeps the 4 `_en` modules the explicit list already covered (MacroCell_en, Hashlife_en, Spaceships_en, GridCanonical_en) and adds the 5 nd-bearing `_en` modules; a gate that counts compiled modules must not omit half a bilingual pair (#8782 pitfall 2).
- `allow-axioms`: 38 -> **59** names. The 21 new entries are the build-enumerated footprint of exactly the newly covered modules (see attribution in the workflow comment): JumpCapture (3), PatternTour (1), Pillars (1), LookAndSayLemmas (2) FR + Oscillators_en (2), PatternTour_en (1), Pillars_en (1), RLE_en (8), LookAndSayLemmas_en (2) under `Conway_en.*`. All `ax_1_1` decide-kernel, same class as the 38. The "new native_decide = new red" property is preserved: a NEW `native_decide` anywhere in the lake still fails the audit.

## Method (build-enumerated, not static guess)

The RESIDUAL note in the workflow explicitly required "build-enumerated allow-axioms entries, not a static guess". Probe = the job's own `LeanVerifier.check_axioms` loop (same code lean-axiom.yml runs) over all 69 `discover_modules` entries, on a warm conway build whose tree is **identical to origin/main** (verified: `git diff origin/main <branch> -- conway_lean` = empty), whitelist = the existing 38. The union of `forbidden` = exactly the 21 names added.

Two probe findings beyond the axiom footprint:

1. **Namespace heterogeneity confirms the empirical method**: `Pillars_en`'s axiom lives at `Conway.Life.Pillars_en.pulsar_period3` (FR path kept) while `RLE_en`'s live at `Conway_en.Life_en.RLE_en.*` — a naming rule would have missed one of the two families.
2. **2 previously-unseen sorry-bearing modules surfaced**: `HashlifeMarginFragment` + `_en` report `has_sorry` (reported, not gated — the job is `fail-on-sorry: false`). They were invisible to both the old explicit list and the blocking gate; the wildcard surfaces them.

## Tests updated (the ratchet's ratchet)

The pin tests follow the #9341/#9571/#9595 precedent — widening is legitimate only with the module-attribution argument, written in the test docstring:

- `test_proof_integrity_audit_wiring.py`: targets assertions -> `"*"`; allow-list pin 38 -> 59 with the attribution docstring; 2 new sample members (one FR new, one `Conway_en.*`).
- `test_conway_blocking_gate_whitelist_aligned.py`: audit target assertion -> `"*"`.
- `test_check_target_coverage.py`: union assertion mirrors the knot post-#10889 pattern (`"*" in union or ...`).

## Validation

- Probe log (69 modules, per-module forbidden lists): 0 exceptions, 38-whitelist verified byte-identical to the YAML before probing (no false "new" from whitelist mismatch).
- New allow-list: 59 names, no duplicates, all 21 probe names present (scripted check).
- `python -m pytest scripts/lean/tests/ -q` -> **178 passed, 1 skipped**.
- `check_target_coverage.py --from-workflow` (exact CI invocation) -> `Covered: 69 (100.0%)`, `OK: target-modules="*"`, exit 0.
- The blocking gate is untouched (explicit showcase list, `fail-on-sorry: true`).

See #10889 (point 5; the epic's other points remain open).

Grain: MED/tooling - lane myia-po-2026:CoursIA - prev: MED/lean #10997

