### PR TITLE
docs(secrets,#10985): l'alias HF ne derive pas le nom absent + discriminer un 403 gated

### DIFF
--- a/docs/genai/secrets-management.md
+++ b/docs/genai/secrets-management.md
@@ -57,7 +57,13 @@ python scripts/secrets/render_envs.py --check
 | Tokens client ComfyUI | `COMFYUI_VIDEO_TOKEN`, `COMFYUI_API_TOKEN` | notebooks → services ComfyUI | Moyen |
 | Session | `SECRET_KEY` | 1 service | Oui |
 
-**Alias :** `HF_TOKEN`/`HUGGINGFACE_TOKEN` et `GITHUB_TOKEN`/`GITHUB_ACCESS_TOKEN` désignent le MÊME secret sous deux noms (services vs notebooks). Le render écrit la même valeur des deux côtés ; le bootstrap vérifie leur cohérence (abort si divergence).
+**Alias :** `HF_TOKEN`/`HUGGINGFACE_TOKEN` et `GITHUB_TOKEN`/`GITHUB_ACCESS_TOKEN` désignent le MÊME secret sous deux noms (services vs notebooks). Le bootstrap vérifie leur cohérence (abort si divergence).
+
+**L'alias ne fabrique PAS le nom manquant — les deux doivent être écrits dans `master.env`.** `ALIASES` (render_envs.py) déclare la paire ; il ne dérive pas `HF_TOKEN` d'un `HUGGINGFACE_TOKEN` présent seul. Un `master.env` qui ne porte qu'un des deux noms laisse l'autre dans la liste `declared SECRET keys are absent from master.env (left untouched in services)` de `--check`, et **aucun consommateur ne le reçoit** — alors que le token existe et est valide. Mesuré le 2026-08-15 : `HUGGINGFACE_TOKEN` présent + `HF_TOKEN` absent, pour **655 sites de code lisant `HF_TOKEN`** contre 144 lisant `HUGGINGFACE_TOKEN`. Remède : écrire les deux lignes dans `master.env`, puis `render_envs.py`.
+
+**`sync()` rafraîchit, il n'insère pas.** Une clé absente d'un `.env` cible n'y est pas ajoutée par le render : seules les clés **déjà déclarées** y sont réécrites depuis master (le gap-fill n'existe que pour un service *sans* `.env`, à partir des `${KEY}` de sa compose). Pour un `.env` côté notebooks (pas de compose), déclarer la ligne vide `CLE=` puis lancer le render.
+
+**Un 403 sur un repo *gated* n'est pas un défaut de token.** Discriminer avant d'escalader — repo non-gated **avec** token → `206` (le token lit) ; repo gated **sans** token → `401` ; repo gated **avec** token → `403` = authentifié mais non autorisé, c'est-à-dire licence non acceptée par le compte porteur **ou** scope « read gated repos » absent du token fine-grained. Les deux se règlent sur huggingface.co, pas dans `master.env`.
 
 ### Qdrant — convention client vs serveur (cross-repo)
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/genai #10988

See #10985 (instance 5 — contribution partielle : le diagnostic, pas le déblocage)

## Ce que le doc affirmait, et ce que la mesure dit

`docs/genai/secrets-management.md` ligne 60 :

> Le render écrit la même valeur des deux côtés

C'est faux pour la paire `HF_TOKEN`/`HUGGINGFACE_TOKEN`, et ça m'a coûté plusieurs cycles d'escalade user erronée. `ALIASES` (render_envs.py:183) **déclare** la paire — il ne **dérive** pas le nom absent. Mesuré ce jour :

```
$ grep -c '^HF_TOKEN='        .secrets/master.env   -> 0
$ grep -c '^HUGGINGFACE_TOKEN=' .secrets/master.env -> 1
$ python scripts/secrets/render_envs.py --check
[!] 13 declared SECRET keys are absent from master.env
    (left untouched in services): [... 'HF_TOKEN' ...]
```

Le token existait, valide (`whoami` **HTTP 200**), et **aucun consommateur ne le recevait** — pendant que **655 sites de code** lisent `HF_TOKEN` contre 144 `HUGGINGFACE_TOKEN`.

Après avoir écrit les deux lignes dans `master.env` : la liste passe de 13 à 12, la synchro de 19 à 20 clés.

## Deux comportements mesurés que le doc ne portait pas

**`sync()` rafraîchit, il n'insère pas.** Écrire la clé dans `master.env` ne suffit pas pour un `.env` côté notebooks : `MyIA.AI.Notebooks/GenAI/.env` est resté à 2 lignes (`OPENAI_API_KEY`, `OPENROUTER_API_KEY`) après render. Seules les clés **déjà déclarées** dans une cible y sont réécrites ; le gap-fill n'existe que pour un service *sans* `.env`, reconstruit depuis les `${KEY}` de sa compose — or un `.env` de notebooks n'a pas de compose. Remède : déclarer `HF_TOKEN=` (ligne vide) puis render, ce qui remplit la valeur depuis master.

**Un 403 sur un repo gated n'est pas un défaut de token.** Trois sondes discriminent, toutes quota-free :

| Sonde | Code | Ce que ça prouve |
|---|---|---|
| repo **non**-gated **avec** token | `206` | le token lit normalement |
| repo gated **sans** token | `401` | le gate exige une authentification |
| repo gated **avec** token | `403` | authentifié mais **non autorisé** |

Le `403` isole la cause hors de `master.env` : licence non acceptée par le compte porteur, ou scope « read gated repos » absent d'un token fine-grained. Aucune des deux ne se règle en éditant un `.env`.

## Pourquoi ça vaut une correction de doc plutôt qu'une note de cycle

Une doc qui décrit une garantie que le code ne fournit pas est du même genre que les défauts que ce cycle a passé son temps à rencontrer — **un mécanisme qui rend un verdict en ayant mesuré autre chose** : ici c'est une phrase qui affirme un comportement en ayant décrit une intention. Elle m'a fait porter « `HF_TOKEN` absent = bloqueur user » de cycle en cycle, alors que le remède tenait en deux lignes et zéro action user.

`--check` disait pourtant la vérité, littéralement, depuis le début : *« absent from master.env (left untouched in services) »*. Personne — moi le premier — n'a lu la seconde moitié de la phrase.

## Périmètre

Un seul fichier, prose seule, aucun code touché. Les valeurs de secrets n'apparaissent nulle part (les sondes sont rapportées en codes HTTP, les clés en noms).
