### PR TITLE
ci(lean): wire proof-integrity gate on sensitivity_lean (5th lean-axiom caller)

### DIFF
--- a/.github/workflows/lean-sensitivity.yml
+++ b/.github/workflows/lean-sensitivity.yml
@@ -12,6 +12,14 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lean-toolchain'
+      # The gate's own implementation: a change to it must re-run the gate
+      # (same rationale as lean-galois.yml / lean-conway.yml, cf #8951).
+      - '.github/workflows/lean-sensitivity.yml'
+      - '.github/workflows/lean-axiom.yml'
+      # The axiom step is a Python program (`from lean_server import LeanVerifier`);
+      # lean_server.py + lean_utils.py ARE gate inputs (cf #8722).
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
   pull_request:
     branches: [main]
     paths:
@@ -19,6 +27,11 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/lean-toolchain'
+      # The gate must run on the PR that introduces or changes it (cf #8712).
+      - '.github/workflows/lean-sensitivity.yml'
+      - '.github/workflows/lean-axiom.yml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py'
   workflow_dispatch:
 
 permissions:
@@ -32,3 +45,26 @@ jobs:
       display-name: sensitivity_lean
       sorry-baseline: "0"
       sorry-filter-mode: standalone-tactic
+
+  # Level 3 proof-integrity gate (criterion B.3 of pr-review-discipline).
+  # Wired per ai-01 dispatch c.101 ("brancher lean-axiom.yml sur sensitivity_lean,
+  # maintenant qu'il est vert sous 4.32") -- 5th caller after knot/galois/
+  # grothendieck/conway. The `#print axioms` measurement of #10997 (huang_degree_
+  # theorem FR + _en: [propext, Classical.choice, Quot.sound], zéro sorryAx) was a
+  # one-shot in a PR body; this gate re-plays it on every PR touching the lake.
+  # allow-axioms: "" -- the measured footprint IS the reusable-workflow defaults
+  # (propext, funext, Classical.choice, Quot.lift, Quot.mk, Quot.sound); a NEW
+  # axiom (native_decide, sorryAx) = a red, which is exactly the point.
+  # fail-on-sorry: true -- sorry-baseline is 0, the lake is fully proven.
+  # target-modules: "*" (issue #10889) -- the module list is derived at runtime
+  # from the lake walk, so it cannot drift out of view. The `_en` i18n siblings
+  # are EXCLUDED by default (FR-only measurement; the byte-parity of #10997
+  # covers the EN side structurally).
+  proof-integrity:
+    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean
+      display-name: sensitivity_lean
+      target-modules: "*"
+      allow-axioms: ""
+      fail-on-sorry: true


### PR DESCRIPTION
## Summary

ai-01 dispatch c.101 (grain provisionné, genre `tooling`) : brancher le gate `lean-axiom.yml` sur `sensitivity_lean`, maintenant vert sous 4.32 (#10997). 5e caller après knot / galois / grothendieck / conway (4/22 → 5/22).

- Nouveau job `proof-integrity` dans `lean-sensitivity.yml` : `target-modules: "*"` (dérivation runtime #10889), `allow-axioms: ""`, `fail-on-sorry: true`.
- **Pourquoi `allow-axioms: ""` suffit** : l'empreinte mesurée dans #10997 (`#print axioms huang_degree_theorem` FR + `_en` : `[propext, Classical.choice, Quot.sound]`, zéro sorryAx) EST exactement la whitelist par défaut du workflow réutilisable — tout NOUVEL axiome (native_decide, sorryAx) = un rouge, ce qui est précisément l'objectif. La mesure de #10997 était one-shot dans un body ; ce gate la rejoue sur chaque PR touchant le lake.
- **fail-on-sorry: true** : sorry-baseline 0, lake entièrement prouvé.
- **`_en` exclus par défaut** (mesure FR-only, #10889) : la byte-parité vérifiée dans #10997 couvre structurellement le côté EN.
- Paths triggers étendus au pattern galois/conway : le workflow lui-même, `lean-axiom.yml`, `lean_server.py` + `lean_utils.py` (gate inputs, #8722/#8712/#8951).

## Validation

- YAML parse OK, job `proof-integrity` câblé avec les 5 inputs attendus.
- Rien d'autre touché (1 fichier, +45/-0).
- La CI de cette PR déclenchera le gate sur ses propres paths (`lean-sensitivity.yml` ajouté au trigger `pull_request`) — first run = la preuve.

See #8738 (triage 22 lakes), See #10889 (sentinel `"*"`).

Grain: LIGHT/guard - lane myia-po-2026:CoursIA - prev: #10999

