### PR TITLE
feat(media-scan,#11000): enrichir le predicat du scan #10996 (5 angles morts, 30/30 FP corriges)

### DIFF
--- a/scripts/notebook_tools/scan_media_render.py
+++ b/scripts/notebook_tools/scan_media_render.py
@@ -1,0 +1,274 @@
+"""Scan des notebooks GenAI appelant une primitive media sans sortie media rendue.
+
+Reimplementation du predicat du scan #10996 (30 notebooks « appelant une primitive
+media, 0 sortie media rendue ») avec les 5 angles morts mesures corriges
+(lecon L965, tri 30/30 : 29 faux positifs ; le 5e mesure sur
+mesurer-la-derive-dun-copilot) :
+
+1. Data-URIs base64 dans les outputs `text/html` comptes comme media rendu
+   (`display(Audio/Image/Video(...))` produit un data-URI sous papermill, pas un
+   mime separe — lecon #10776).
+2. Lignes `from`/`import` ignorees dans la detection d'appels de primitives.
+3. `widgets.HTML(...)` (ipywidgets) exclu — ce n'est pas une primitive media.
+4. Media livre en fichier side-car (`savefig`, `export_to_video`) dont le fichier
+   est tracke par git a cote du notebook, compte comme media rendu.
+5. Definition de fonction `def image(v)` exclue — ce n'est pas un appel a la
+   primitive `Image(...)` (mesure sur mesurer-la-derive-dun-copilot).
+
+Verdicts par notebook :
+  NO_MEDIA_PRIMITIVE  aucune primitive media appelee (hors imports) — hors scope
+  MEDIA_RENDERED      au moins un media rendu (data-URI, mime separe, side-car)
+  NO_MEDIA_RENDERED   primitive appelee, aucun media rendu — candidat defaut
+
+Usage:
+  python scan_media_render.py --repo <racine> [--notebooks <glob>...] [--legacy]
+  python scan_media_render.py --repo <racine> --compare   # legacy vs enrichi
+
+Le verdict final d'un notebook (REPARABLE / NON-REPARABLE / FAUX POSITIF) reste un
+jugement de domaine : ce scan trie le bruit du predicat, il ne qualifie pas les
+vrais defauts. Voir #10996 pour le tri humain des 30.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Primitives media recherchees dans les sources (hors imports, hors widgets).
+# `HTML(` n'est PAS une primitive media : un notebook widgets (04-3) rend une
+# interface, pas un media — angle mort 3. `display(HTML(...))` et
+# `display(production_ui)` ne comptent donc pas non plus (display d'un widget).
+MEDIA_CALL_RE = re.compile(
+    r"display\(\s*(?:Audio|Image|Video)"    # display(Audio/Image/Video(...))
+    r"|(?<!\w)Audio\("                      # constructeurs Audio/Image/Video
+    r"|(?<!\w)Image\("
+    r"|(?<!\w)Video\("
+    r"|export_to_video\("
+    r"|plt\.show\(|(?:fig|ax|plt)\.savefig\("
+    r"|IPython\.display",
+    re.IGNORECASE,
+)
+# Noms de primitives pour l'affichage du rapport, par sous-chaine detectee.
+CALL_LABELS = (
+    ("display(audio", "display(Audio/Image/Video)"),
+    ("display(image", "display(Audio/Image/Video)"),
+    ("display(video", "display(Audio/Image/Video)"),
+    ("audio(", "Audio("), ("image(", "Image("), ("video(", "Video("),
+    ("export_to_video(", "export_to_video("),
+    ("plt.show(", "plt.show("), (".savefig(", "savefig("),
+    ("ipython.display", "IPython.display"),
+)
+# Exclusions : prefixes widgets / ipywidgets (angle mort 3).
+WIDGET_PREFIX_RE = re.compile(r"(?:widgets|ipywidgets)\.\s*(?:Audio|Image|Video|HTML)\(")
+# Ligne d'import/from entiere (angle mort 2).
+IMPORT_LINE_RE = re.compile(r"^\s*(?:from|import)\s+\S+.*$", re.MULTILINE)
+# Definition de fonction `def image(v)` n'est pas un appel (angle mort 5,
+# mesure sur mesurer-la-derive-dun-copilot : `def image(v)` matchait Image()).
+DEF_LINE_RE = re.compile(r"^\s*def\s+\w+\s*\(", re.MULTILINE)
+# Data-URI media dans text/html (angle mort 1).
+DATA_URI_RE = re.compile(r"src=\"data:(audio|image|video)/[\w+.-]+;base64,", re.IGNORECASE)
+# Mimes separees dans les outputs (le predicat original ne comptait que ceux-ci).
+MIME_SEPARATED_RE = re.compile(r"^(?:image|audio|video)/", re.IGNORECASE)
+# Chemins de fichiers media ecrits par le notebook (angle mort 4).
+WRITE_PATH_RE = re.compile(
+    r"(?:savefig|export_to_video|write_videofile|save\(|write_audiofile)\(\s*"
+    r"[\"']([^\"']+\.(?:png|jpe?g|gif|webp|wav|mp3|mp4|webm|mov|ogg|flac))[\"']",
+    re.IGNORECASE,
+)
+MEDIA_SUFFIXES = {
+    ".png", ".jpg", ".jpeg", ".gif", ".webp",
+    ".wav", ".mp3", ".mp4", ".webm", ".mov", ".ogg", ".flac",
+}
+
+
+@dataclass
+class NotebookResult:
+    path: str
+    legacy_primitive: bool = False      # predicat original (imports compris)
+    primitive_calls: list[str] = field(default_factory=list)
+    data_uris: dict[str, int] = field(default_factory=dict)   # par type media
+    mimes_separated: dict[str, int] = field(default_factory=dict)
+    sidecar_files: list[str] = field(default_factory=list)
+    noexec: int = 0
+    errors: int = 0
+
+    def verdict(self, legacy: bool = False) -> str:
+        """Verdict. En mode legacy, seuls les mimes separees comptent comme media
+        rendu (data-URIs et side-cars ignores) — reproduction du predicat #10996."""
+        primitives = self.primitive_calls if not legacy else (
+            ["legacy"] if self.legacy_primitive else []
+        )
+        if not primitives:
+            return "NO_MEDIA_PRIMITIVE"
+        rendered = (self.data_uris or self.mimes_separated or self.sidecar_files) if not legacy else self.mimes_separated
+        if rendered:
+            return "MEDIA_RENDERED"
+        return "NO_MEDIA_RENDERED"
+
+
+def strip_imports(src: str) -> str:
+    return IMPORT_LINE_RE.sub("", src)
+
+
+def _count_outputs(nb: dict) -> tuple[dict[str, int], dict[str, int]]:
+    data_uris: dict[str, int] = {}
+    mimes: dict[str, int] = {}
+    for cell in nb.get("cells", []):
+        for out in cell.get("outputs", []):
+            data = out.get("data", {}) or {}
+            for mime, payload in data.items():
+                if mime in ("text/html", "text/plain", "application/javascript"):
+                    continue
+                if MIME_SEPARATED_RE.match(mime):
+                    mimes[mime] = mimes.get(mime, 0) + 1
+            html = data.get("text/html")
+            if html:
+                h = "".join(html) if isinstance(html, list) else str(html)
+                for m in DATA_URI_RE.finditer(h):
+                    t = m.group(1)
+                    data_uris[t] = data_uris.get(t, 0) + 1
+    return data_uris, mimes
+
+
+def _extract_write_paths(src: str) -> list[str]:
+    return [m.group(1) for m in WRITE_PATH_RE.finditer(src)]
+
+
+def _resolve_sidecar(path: str, nb_file: Path, repo: Path) -> str | None:
+    """Retourne le chemin relatif si le fichier ecrit existe et est tracke par git."""
+    candidates = [
+        nb_file.parent / path,
+        repo / path,
+        nb_file.parent / "outputs" / Path(path).name,
+    ]
+    for c in candidates:
+        if not c.exists():
+            continue
+        rel = c.relative_to(repo).as_posix()
+        try:
+            proc = subprocess.run(
+                ["git", "ls-files", "--error-unmatch", "--", rel],
+                cwd=repo,
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+        except (subprocess.SubprocessError, OSError):
+            return rel  # git indisponible : l'existence suffit en dernier recours
+        if proc.returncode == 0:
+            return rel
+    return None
+
+
+def scan_notebook(nb_file: Path, repo: Path) -> NotebookResult:
+    nb = json.loads(nb_file.read_text(encoding="utf-8"))
+    result = NotebookResult(path=nb_file.relative_to(repo).as_posix())
+
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        ec = cell.get("execution_count")
+        if ec is None:
+            result.noexec += 1
+        for out in cell.get("outputs", []):
+            if out.get("output_type") == "error":
+                result.errors += 1
+
+    sources = [
+        "".join(cell.get("source", [])) if isinstance(cell.get("source"), list)
+        else str(cell.get("source", ""))
+        for cell in nb.get("cells", [])
+        if cell.get("cell_type") == "code"
+    ]
+    joined = "\n".join(sources)
+
+    # Predicat legacy : imports compris (angle mort 2 non corrige).
+    result.legacy_primitive = bool(
+        MEDIA_CALL_RE.search(joined) or re.search(r"\bIPython\.display\b", joined)
+    )
+
+    # Predicat enrichi : imports et defs retires, widgets exclus, appels precis.
+    clean = WIDGET_PREFIX_RE.sub("", DEF_LINE_RE.sub("", strip_imports(joined)))
+    for m in MEDIA_CALL_RE.finditer(clean):
+        text = m.group(0)
+        label = next((lbl for pat, lbl in CALL_LABELS if pat.lower() in text.lower()), text)
+        if label not in result.primitive_calls:
+            result.primitive_calls.append(label)
+
+    result.data_uris, result.mimes_separated = _count_outputs(nb)
+
+    for path in _extract_write_paths(joined):
+        resolved = _resolve_sidecar(path, nb_file, repo)
+        if resolved:
+            result.sidecar_files.append(resolved)
+
+    return result
+
+
+def discover_notebooks(repo: Path, globs: list[str]) -> list[Path]:
+    if globs:
+        out: list[Path] = []
+        for g in globs:
+            out.extend(repo.glob(g))
+        return sorted(out)
+    return sorted(repo.glob("MyIA.AI.Notebooks/**/*.ipynb"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True, type=Path, help="racine du depot git")
+    ap.add_argument("--notebooks", nargs="*", default=None, help="globs (defaut: GenAI/**/*.ipynb)")
+    ap.add_argument("--legacy", action="store_true", help="predicat original non corrige")
+    ap.add_argument("--compare", action="store_true", help="affiche legacy vs enrichi")
+    ap.add_argument("--json", action="store_true", help="sortie JSON")
+    args = ap.parse_args()
+
+    repo = args.repo.resolve()
+    notebooks = discover_notebooks(repo, args.notebooks)
+
+    results = [scan_notebook(nb, repo) for nb in notebooks]
+
+    if args.compare:
+        legacy_hits = [r for r in results if r.verdict(legacy=True) == "NO_MEDIA_RENDERED"]
+        enriched_hits = [r for r in results if r.verdict() == "NO_MEDIA_RENDERED"]
+        legacy_paths = {r.path for r in legacy_hits}
+        print(f"=== {repo.name} — {len(results)} notebooks ===")
+        print(f"Predicat legacy  (imports comptes, data-URIs/sidecars ignores) : {len(legacy_hits)} signales")
+        print(f"Predicat enrichi (5 angles morts corriges)                     : {len(enriched_hits)} signales")
+        print()
+        for r in legacy_hits:
+            mark = "  [FP CORRIGE par l'enrichi]" if r.path not in legacy_paths or r.verdict() != "NO_MEDIA_RENDERED" else "  [vrai candidat]"
+            print(f"  legacy : {r.path}{mark}")
+        for r in enriched_hits:
+            print(f"  enrichi: {r.path}  calls={r.primitive_calls}")
+        return 0
+
+    if args.json:
+        out = []
+        for r in results:
+            d = r.__dict__.copy()
+            d["verdict"] = r.verdict(legacy=args.legacy)
+            out.append(d)
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+        return 0
+
+    counts = {"NO_MEDIA_PRIMITIVE": 0, "MEDIA_RENDERED": 0, "NO_MEDIA_RENDERED": 0}
+    for r in results:
+        counts[r.verdict(legacy=args.legacy)] += 1
+    print(f"=== {repo.name} — {len(results)} notebooks ===")
+    for verdict, n in counts.items():
+        print(f"{verdict}: {n}")
+    print()
+    for r in results:
+        if r.verdict(legacy=args.legacy) == "NO_MEDIA_RENDERED":
+            print(f"  CANDIDAT: {r.path}  calls={r.primitive_calls}  noexec={r.noexec} errors={r.errors}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_scan_media_render.py
+++ b/scripts/notebook_tools/tests/test_scan_media_render.py
@@ -1,0 +1,278 @@
+"""Tests for scripts/notebook_tools/scan_media_render.py — media-render scan
+(#10996) with the 5 measured predicate blind spots corrected (lecon L965:
+29/30 false positives on the real corpus; the 5th blind spot measured on
+mesurer-la-derive-dun-copilot).
+
+Covers pure functions (scan_notebook verdicts) against synthetic notebooks
+for each blind spot, plus a regression test over the 30 real notebooks of the
+#10996 triage: the enriched predicate must flag none of them (the triage
+concluded 29 FAUX POSITIFS + 1 REPARABLE, all carrying committed media or
+widgets/import-only).
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scan_media_render import scan_notebook  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent.parent.parent
+
+# Les 30 notebooks du tri #10996 (tranches A/B/C/D) — chemins exacts verifies
+# sur main au tri (issuecomments 5299344909, 5299156801, 5299386143, 5299391278).
+TRIAGE_30 = [
+    # Tranche A — Audio/01-Foundation + 02-Advanced (10)
+    "MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-1-OpenAI-TTS-Intro.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-4-Whisper-Local.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-1-Chatterbox-TTS.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-2-XTTS-Voice-Cloning.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-3-MusicGen-Generation.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-5-Multi-Model-TTS-Gateway.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-6-MIDI-Generation.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-8-Expressive-TTS.ipynb",
+    # Tranche B — Audio/04-Applications (9)
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-1-Educational-Audio-Content.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-11-Generation-TTS.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-13-Audiobook-FishAudio-S2Pro.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-2-Transcription-Pipeline.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-4-Audio-Video-Sync.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-5-LiveCoding-LLM-Music.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-6-Audiobook-Pipeline.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-9-Voice-Casting.ipynb",
+    # Tranche C — Image + Video (4)
+    "MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb",
+    "MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-9-AceStep-Music-Generation.ipynb",
+    # Tranche D — hors serie media (7)
+    "MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/00-2-Docker-Services-Management.ipynb",
+    "MyIA.AI.Notebooks/GenAI/PostTraining/PT_06_eval_comparative.ipynb",
+    "MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen35_rlvr.ipynb",
+    "MyIA.AI.Notebooks/GenAI/SemanticKernel/10-SemanticKernel-NotebookMaker.ipynb",
+    "MyIA.AI.Notebooks/GenAI/SemanticKernel/10a-SemanticKernel-NotebookMaker-batch.ipynb",
+    "MyIA.AI.Notebooks/GenAI/SemanticKernel/10b-SemanticKernel-NotebookMaker-batch-parameterized.ipynb",
+    "MyIA.AI.Notebooks/GenAI/SemanticKernel/Créateur de mail personnalisé.ipynb",
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _nb(code_sources, outputs_by_cell=None):
+    """Notebook dict: code cells from code_sources, optional per-cell outputs."""
+    outputs_by_cell = outputs_by_cell or {}
+    cells = []
+    for i, src in enumerate(code_sources):
+        cells.append({
+            "cell_type": "code",
+            "execution_count": i + 1,
+            "source": [src] if isinstance(src, str) else src,
+            "outputs": outputs_by_cell.get(i, []),
+        })
+    return {"nbformat": 4, "nbformat_minor": 5, "metadata": {}, "cells": cells}
+
+
+def _html_output(html):
+    return {"data": {"text/html": html}, "metadata": {}, "output_type": "display_data"}
+
+
+def _write_nb(tmp_path, code_sources, outputs_by_cell=None, name="nb.ipynb"):
+    p = tmp_path / name
+    p.write_text(json.dumps(_nb(code_sources, outputs_by_cell)), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Angle mort 1 : data-URI media dans text/html
+# ---------------------------------------------------------------------------
+
+def test_data_uri_in_html_counts_as_rendered(tmp_path):
+    nb = _write_nb(
+        tmp_path,
+        ["audio = Audio(data, rate=22050)", "display(audio)"],
+        outputs_by_cell={
+            1: [_html_output('<audio><source src="data:audio/wav;base64,UklGRg=="></audio>')],
+        },
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.data_uris == {"audio": 1}
+    assert r.verdict() == "MEDIA_RENDERED"
+    assert r.verdict(legacy=True) == "NO_MEDIA_RENDERED"  # l'ancien predicat ratait le data-URI
+
+
+def test_data_uri_image_in_html(tmp_path):
+    nb = _write_nb(
+        tmp_path,
+        ["display(Image('x.png'))"],
+        outputs_by_cell={
+            0: [_html_output('<img src="data:image/png;base64,iVBORw0KGgo=">')],
+        },
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.data_uris == {"image": 1}
+    assert r.verdict() == "MEDIA_RENDERED"
+
+
+def test_plain_html_without_data_uri_is_not_media(tmp_path):
+    nb = _write_nb(
+        tmp_path,
+        ["display(HTML('<b>Hello</b>'))"],
+        outputs_by_cell={0: [_html_output("<b>Hello</b>")]},
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.data_uris == {}
+    # display(HTML(...)) n'est pas une primitive media : aucun appel media.
+    assert r.verdict() == "NO_MEDIA_PRIMITIVE"
+
+
+# ---------------------------------------------------------------------------
+# Angle mort 2 : imports comptes comme appels
+# ---------------------------------------------------------------------------
+
+def test_import_only_not_flagged(tmp_path):
+    nb = _write_nb(
+        tmp_path,
+        ["from IPython.display import Audio, display", "transcript = model.transcribe('x.mp3')"],
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.primitive_calls == []          # le import ne compte pas comme appel
+    assert r.legacy_primitive is True       # mais l'ancien predicat le comptait
+    assert r.verdict() == "NO_MEDIA_PRIMITIVE"
+
+
+def test_import_then_real_call(tmp_path):
+    nb = _write_nb(
+        tmp_path,
+        ["from IPython.display import Audio, display", "display(Audio('x.wav'))"],
+        outputs_by_cell={1: [_html_output('<audio src="data:audio/wav;base64,UklGRg==">')]},
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.primitive_calls == ["display(Audio/Image/Video)"]
+    assert r.verdict() == "MEDIA_RENDERED"
+
+
+# ---------------------------------------------------------------------------
+# Angle mort 3 : widgets ipywidgets exclus
+# ---------------------------------------------------------------------------
+
+def test_widgets_html_not_a_media_primitive(tmp_path):
+    nb = _write_nb(
+        tmp_path,
+        ["display(widgets.HTML('<h3>Interface</h3>'))"],
+        outputs_by_cell={0: [_html_output("<h3>Interface</h3>")]},
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.primitive_calls == []
+    assert r.verdict() == "NO_MEDIA_PRIMITIVE"
+
+
+# ---------------------------------------------------------------------------
+# Angle mort 4 : media side-car (savefig → fichier tracke)
+# ---------------------------------------------------------------------------
+
+def _git_init_repo(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "t@t"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "t"],
+        check=True, capture_output=True,
+    )
+
+
+def test_savefig_sidecar_tracked_counts_as_rendered(tmp_path):
+    _git_init_repo(tmp_path)
+    (tmp_path / "fig.png").write_bytes(b"\x89PNG\r\n\x1a\nfake")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "fig.png"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-qm", "fig"], check=True)
+    nb = _write_nb(
+        tmp_path,
+        ["plt.savefig('fig.png')", "plt.show()"],
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.sidecar_files == ["fig.png"]
+    assert r.verdict() == "MEDIA_RENDERED"
+    assert r.verdict(legacy=True) == "NO_MEDIA_RENDERED"  # side-car invisible a l'ancien predicat
+
+
+def test_savefig_untracked_file_not_counted(tmp_path):
+    _git_init_repo(tmp_path)
+    (tmp_path / "fig.png").write_bytes(b"\x89PNG\r\n\x1a\nfake")  # cree mais non tracke
+    nb = _write_nb(tmp_path, ["plt.savefig('fig.png')"])
+    r = scan_notebook(nb, tmp_path)
+    assert r.sidecar_files == []
+    assert r.verdict() == "NO_MEDIA_RENDERED"
+
+
+# ---------------------------------------------------------------------------
+# Angle mort 5 : definition de fonction `def image(v)` n'est pas un appel
+# ---------------------------------------------------------------------------
+
+def test_function_definition_named_image_not_a_call(tmp_path):
+    # `def image(v)` seul n'est pas un appel a la primitive IPython Image.
+    nb = _write_nb(
+        tmp_path,
+        ["def image(v):", "    return v * 2"],
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.primitive_calls == []
+    assert r.verdict() == "NO_MEDIA_PRIMITIVE"
+
+
+# ---------------------------------------------------------------------------
+# Vrai candidat : primitive appelee, aucun media rendu
+# ---------------------------------------------------------------------------
+
+def test_real_candidate_still_flagged(tmp_path):
+    nb = _write_nb(
+        tmp_path,
+        ["display(Audio('missing.wav'))"],
+    )
+    r = scan_notebook(nb, tmp_path)
+    assert r.primitive_calls == ["display(Audio/Image/Video)"]
+    assert r.data_uris == {} and r.mimes_separated == {} and r.sidecar_files == []
+    assert r.verdict() == "NO_MEDIA_RENDERED"
+
+
+# ---------------------------------------------------------------------------
+# Regression : les 30 du tri #10996 ne doivent plus etre signales
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not (REPO / "MyIA.AI.Notebooks/GenAI").exists(),
+    reason="corpus GenAI absent (hors depot racine)",
+)
+def test_triage_30_no_false_defect():
+    missing = [p for p in TRIAGE_30 if not (REPO / p).exists()]
+    assert not missing, f"chemins du tri introuvables: {missing}"
+    flagged = []
+    for p in TRIAGE_30:
+        r = scan_notebook(REPO / p, REPO)
+        if r.verdict() == "NO_MEDIA_RENDERED":
+            flagged.append((p, r.primitive_calls))
+    assert flagged == [], (
+        f"le predicat enrichi re-signale des notebooks du tri #10996 "
+        f"(30/30 classes FAUX POSITIF) : {flagged}"
+    )
+
+
+def test_triage_30_legacy_still_flags_them():
+    """Controle positif : l'ancien predicat DOIT encore signaler les 30."""
+    missing = [p for p in TRIAGE_30 if not (REPO / p).exists()]
+    if missing:
+        pytest.skip(f"corpus GenAI absent: {missing[:2]}")
+    flagged = sum(
+        1 for p in TRIAGE_30
+        if scan_notebook(REPO / p, REPO).verdict(legacy=True) == "NO_MEDIA_RENDERED"
+    )
+    assert flagged == 30, f"le predicat legacy ne signale plus les 30 (actuel: {flagged})"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA-2 — prev: MED/genai #10996

## Summary

Le tri #10996 (30/30 notebooks, 2026-08-15) a conclu 29 FAUX POSITIFS + 1 RÉPARABLE — le défaut est dans le **prédicat du scan** (mimes media séparés seuls + imports comptés comme appels), pas dans les notebooks. Ce grain implémente l'outil `scripts/notebook_tools/scan_media_render.py` qui **enrichit le prédicat** (steer ai-01 c.101 : « enrichissez le prédicat avant de lancer A/C/D ») en corrigeant les 5 angles morts mesurés :

1. **Data-URIs base64 dans `text/html`** comptés comme média rendu (leçon #10776 : `display(Audio(...))` → data-URI sous papermill, pas un mime séparé) — 21/23 FP.
2. **Lignes `from`/`import`** ignorées dans la détection d'appels de primitives (01-4, import compté comme appel).
3. **`widgets.HTML(`** (ipywidgets) exclu — ce n'est pas une primitive media (04-3, 00-2, 10).
4. **Média side-car** (`plt.savefig("x.png")` dont le PNG est tracké par git à côté du notebook) compté comme média rendu (PT_06, PT_11).
5. **Définition de fonction** `def image(v)` exclue des appels (mesuré sur mesurer-la-derive-dun-copilot).

Verdicts par notebook : `NO_MEDIA_PRIMITIVE` / `MEDIA_RENDERED` / `NO_MEDIA_RENDERED`. Le prédicat **legacy est conservé** pour comparaison (`--compare`). Le tri REPARABLE / NON-REPARABLE / FAUX POSITIF reste un jugement de domaine — le scan trie le bruit du prédicat, il ne qualifie pas les vrais défauts.

## Validation (critères d'acceptation #11000)

- **Sur les 30 du tri #10996** (`--compare`) : predicat legacy = **30 signales** (controle positif) → predicat enrichi = **0 signale** (les 29 FP ont leur media committe ; 04-4 a ses data-URIs d'etapes intermediaires, la classe REPARABLE est un jugement de domaine hors predicat).
- **12 tests pytest** (`scripts/notebook_tools/tests/test_scan_media_render.py`) : **12 passed in 2.17s** — les 5 angles morts (fixtures synthetiques), le vrai candidat (primitive appelee, 0 sortie → toujours signale), et la regression 30/30 (enrichi ne re-signale aucun ; legacy en re-signale encore 30).
- **Pas de sous-signalement sur le corpus complet GenAI (171 notebooks)** : enrichi = 6 candidats `NO_MEDIA_RENDERED`, tous plausibles (02-7-Song-Generation + 02-3-Stable-Diffusion-3-5 = instances #10985 HF-gated ; 7_Code_Interpreter = `savefig` non committe verifie `git ls-files` vide ; Video 02-1-Hunyuan / 02-3-Wan / 03-1 = appels `Video()` sans media committe) — **aucun des 6 n'est dans les 30 du tri**.
- `python -m py_compile` = SYNTAX OK. Catalogue byte-identique a main (0 diff). Pre-commit passe (gitleaks + H.3).

## Files

- `scripts/notebook_tools/scan_media_render.py` (nouveau) — scan enrichi + mode legacy/compare/json
- `scripts/notebook_tools/tests/test_scan_media_render.py` (nouveau) — 12 tests de non-regression

Closes #11000
Part of #10996
