### PR TITLE
fix(ci,#10036): bash -e avale `; RC=$?` dans les 3 jobs bloquants variation-tag-guard

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -415,9 +415,14 @@ jobs:
           # The blocking helper emits one JSON line on stdout and exits
           # 0 (pass) or 1 (block). We capture both streams; the verdict
           # JSON is on stdout, anything Python warns about goes on stderr.
+          # Capturing the exit code on the line AFTER the helper call
+          # (`RC=$?` separated by a semicolon) dies under bash -e (the
+          # GitHub default shell) when the helper exits non-zero -- the
+          # BLOCK path, exactly the one that needs the stderr + verdict
+          # diagnostics below. The &&/|| list assigns RC on BOTH branches
+          # and is exempt from errexit.
           python3 scripts/ci/variation_tag_required.py \
-            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err
-          RC=$?
+            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
 
           # Surface the stderr warnings so a failure here is debuggable
           # from the job log alone -- #10036 lesson: a guard whose
@@ -534,10 +539,13 @@ jobs:
 
           # The helper scans body + commits for `prev:` close-keyword genres
           # and exits 0 (pass) or 1 (block). stderr surfaced for debug.
+          # Capturing RC on the line after a semicolon dies under bash -e
+          # when the helper exits 1 (the BLOCK path) -- the &&/|| list
+          # captures RC on both branches and is exempt from errexit (same
+          # fix as check-variation-tag-required).
           python3 scripts/ci/variation_prev_guard.py \
             --body-file /tmp/pr_body.txt \
-            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err
-          RC=$?
+            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
 
           if [ -s /tmp/verdict.err ]; then
             echo "--- helper stderr ---"
@@ -646,10 +654,13 @@ jobs:
           # The helper resolves each `<closing-keyword> #N` via `gh api` and
           # exits 0 (pass / fail-open) or 1 (block on a PR). stderr surfaced
           # for debug.
+          # Capturing RC on the line after a semicolon dies under bash -e
+          # when the helper exits 1 (the BLOCK path) -- the &&/|| list
+          # captures RC on both branches and is exempt from errexit (same
+          # fix as check-variation-tag-required).
           python3 scripts/ci/pr_close_keyword_guard.py \
             --body-file /tmp/pr_body.txt \
-            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err
-          RC=$?
+            --commits-file /tmp/commits.json > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
 
           if [ -s /tmp/verdict.err ]; then
             echo "--- helper stderr ---"

--- a/scripts/tests/test_bash_e_rc_capture.py
+++ b/scripts/tests/test_bash_e_rc_capture.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Non-regression: exit-code capture under `bash -e` (#8894).
+
+Every GitHub Actions `run:` step executes with `/usr/bin/bash -e` (errexit
+is ON by default -- `.github/workflows/variation-tag-guard.yml` documents
+this itself). The workflow's three BLOCKING jobs capture the helper's exit
+code with `RC=$?` on the line AFTER the helper call. Under `-e`, when the
+helper exits non-zero -- exactly the BLOCK path that needs the stderr +
+verdict JSON + PR comment diagnostics -- bash kills the step BEFORE
+`RC=$?` runs. The gate goes red with zero diagnostics: a guard whose
+failure is silent is not a guard (#10036).
+
+#8894: a unit test cannot observe the interpreter of another job, but it
+CAN test the bash semantics themselves. These tests shell out to the real
+`bash -e` to prove (1) the bug exists, (2) the `&& RC=0 || RC=$?` fix
+survives both branches, (3) the naive `|| RC=$?` alone has its own trap
+under the workflow's `set -u`, and (4) the YAML no longer contains the
+buggy pattern.
+
+Run:
+    python -m pytest scripts/tests/test_bash_e_rc_capture.py
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+WORKFLOW = (
+    Path(__file__).resolve().parents[2]
+    / ".github"
+    / "workflows"
+    / "variation-tag-guard.yml"
+)
+
+# The three BLOCKING jobs of variation-tag-guard.yml that capture a helper
+# exit code. Each must pair its invocation with `&& RC=0 || RC=$?`.
+BLOCKING_HELPERS = [
+    "python3 scripts/ci/variation_tag_required.py",
+    "python3 scripts/ci/variation_prev_guard.py",
+    "python3 scripts/ci/pr_close_keyword_guard.py",
+]
+
+# Resolve bash ONCE, explicitly. On Windows, `subprocess.run(["bash", ...])`
+# does its own CreateProcess PATH search that can land on
+# `C:\Windows\System32\bash.exe` -- the WSL launcher stub, which mangles the
+# `-c` argument (shell assignments silently vanish, e.g. `A=1` never takes
+# effect). `shutil.which` returns the first PATH hit (Git's bash), which is
+# also the bash the workflow's `/usr/bin/bash` semantics are modeled on.
+BASH = shutil.which("bash") or "bash"
+
+
+def _run_bash_e(script: str) -> subprocess.CompletedProcess:
+    """Run `script` under the exact errexit semantics of a workflow step."""
+    return subprocess.run(
+        [BASH, "-e", "-c", script],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_semicolon_rc_masks_the_failure_under_errexit():
+    """The buggy `cmd ; RC=$?` dies at `cmd`: RC never assigned, the code
+    after never runs -- the mute red gate."""
+    r = _run_bash_e('false ; RC=$?; echo "REACHED $RC"')
+    assert r.returncode == 1  # bash -e kills the step
+    assert "REACHED" not in r.stdout  # diagnostics after `;` never surface
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_and_or_idiom_captures_rc_on_both_branches():
+    """`cmd && RC=0 || RC=$?` assigns RC on success AND failure, and a
+    `&&`/`||` list is exempt from errexit -- the step survives the BLOCK
+    path and still surfaces the real exit code."""
+    ok = _run_bash_e('true && RC=0 || RC=$?; echo "RC=$RC"')
+    assert ok.returncode == 0
+    assert "RC=0" in ok.stdout
+
+    blocked = _run_bash_e('false && RC=0 || RC=$?; echo "RC=$RC"')
+    assert blocked.returncode == 0  # the step survives
+    assert "RC=1" in blocked.stdout  # the real exit code is captured
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash not available")
+def test_naive_or_rc_alone_is_unbound_under_set_u():
+    """`cmd || RC=$?` alone short-circuits on success: RC is never assigned,
+    and the workflow's `set -u` turns the next `$RC` use into an error.
+    This is why the fix is the `&&`/`||` pair, not a bare `||`."""
+    r = _run_bash_e('set -u; true || RC=$?; echo "RC=$RC"')
+    assert r.returncode != 0
+    assert "unbound" in r.stderr.lower()
+
+
+def test_workflow_uses_the_idiom_and_has_no_buggy_pattern():
+    """Static guard on the YAML: the `; RC=$?` pattern is banned and each
+    blocking helper invocation pairs with `&& RC=0 || RC=$?`."""
+    yaml = WORKFLOW.read_text(encoding="utf-8")
+    assert "; RC=$?" not in yaml
+    for invocation in BLOCKING_HELPERS:
+        assert invocation in yaml
+        idx = yaml.index(invocation)
+        assert "&& RC=0 || RC=$?" in yaml[idx : idx + 800]


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/guard #10970

## Problème

Sous `bash -e` (le shell par défaut de **chaque** step GitHub Actions), le pattern `helper ; RC=$?` **meurt silencieusement** quand le helper sort non-zero — exactement le chemin **BLOCK** qui a besoin du stderr + verdict JSON + commentaire PR pour être débuggable. Le gate passe au rouge **muet** : un guard dont la panne est silencieuse n'est pas un guard (#10036).

Les 3 jobs bloquants de `variation-tag-guard.yml` avaient ce bug :
- `check-variation-tag-required` (variation_tag_required.py)
- `check-prev-close-keyword-required` (variation_prev_guard.py)
- `check-close-keyword-pr-ref-required` (pr_close_keyword_guard.py)

## Fix

`helper ... && RC=0 || RC=$?` — la liste `&&`/`||` affecte `RC` sur **les deux branches** et est **exempte d'errexit** (le step survit au BLOCK path et surface le vrai code de sortie).

## Test de non-régression

`scripts/tests/test_bash_e_rc_capture.py` (4 tests, tous verts) — #8894 : *a unit test cannot observe the interpreter of another job*, mais on peut tester les sémantiques bash elles-mêmes en shell-out vers le vrai `bash -e` :

1. **Bug repro** : `false ; RC=$?; echo "REACHED $RC"` → bash -e tue le step (rc 1), `REACHED` jamais imprimé.
2. **Fix survit aux 2 branches** : `true && RC=0 || RC=$?` → `RC=0` ; `false && RC=0 || RC=$?` → step survive (rc 0) **et** `RC=1` capturé.
3. **Piège du `|| RC=$?` nu** : sous `set -u` (le workflow l'active), sur succès le short-circuit laisse `RC` non affecté → `unbound variable`. C'est pourquoi le fix est la paire `&&`/`||`, pas un `||` seul.
4. **Garde statique YAML** : `; RC=$?` banni du fichier + chaque invocation de helper bloquant est suivie de `&& RC=0 || RC=$?`.

### Note plateforme (Windows)

`subprocess.run(["bash", ...])` sur Windows fait sa propre recherche PATH via CreateProcess, qui peut tomber sur `C:\Windows\System32\bash.exe` — le **stub WSL**, qui mange les assignments de variables shell dans l'argument `-c`. Le test résout le chemin **une fois** via `shutil.which` (Git bash, même sémantique que `/usr/bin/bash` du workflow) et le passe explicitement — même comportement sur ubuntu CI.

## Validation

- `python -m pytest scripts/tests/test_bash_e_rc_capture.py` → 4 passed
- `python -m pytest scripts/tests/test_variation_tag_required.py` → 14 passed
- YAML valide (`yaml.safe_load` OK), 0 CRLF, pre-commit hooks verts (gitleaks PASSED)
- `git diff --cached`: +122/−6 — 2 fichiers seulement, un sujet
