### PR TITLE
fix(quarto,#10968): pin 1.10.18 (1.7.32 lua-filter hang) + re-enable 7 excluded notebooks

### DIFF
--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -50,8 +50,12 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         with:
           # Version alignée sur local (cf. po-2023-c160/c161 Quarto tranches).
-          # Si bump futur → changer ici + changer .claude/CLAUDE.md si besoin.
-          version: 1.7.32
+          # Bump 1.7.32 -> 1.10.18 (issue #10968) : le filtre lua 1.7.32 pend sur
+          # les cellules echo:true dont une ligne de source se termine par \n et
+          # suivies d'un output display_data (mini-repro #10968) — corrigé en
+          # 1.10.18 (App-9b rend en 6 s). Les 7 notebooks exclus du pilote par
+          # #10979 redeviennent rendables (NOTEBOOK_EXCLUDE_FILES vidé, #10968).
+          version: 1.10.18
 
       - name: Regenerate README render list
         # _quarto.yml porte une liste render: EXPLICITE de tous les README.md

--- a/scripts/regen_quarto_render.py
+++ b/scripts/regen_quarto_render.py
@@ -63,7 +63,8 @@ EXCLUDE_MARKERS = (
 # (#10923 Phase A); extending to other series = adding a subtree here. The
 # root execute block (_quarto.yml) already carries enabled: false + echo: true
 # for every notebook — a directory-scoped _quarto.yml is NOT applied to .ipynb
-# in Quarto 1.7.32 (measured firsthand), so no per-subtree override exists.
+# (measured firsthand sur Quarto 1.7.32, pin d'origine du pilote), so no
+# per-subtree override exists.
 NOTEBOOK_SUBTREES = (
     "MyIA.AI.Notebooks/Search/",  # pilote #10923 — voir EPIC #10921 pour l'extension
 )
@@ -76,26 +77,23 @@ NOTEBOOK_EXCLUDE_MARKERS = (
 )
 
 # Notebook files volontairement exclus du rendu HTML, avec raison mesurée.
-# Pathologie pandoc 1.7.32 sous echo: true (config requise par #10923, code
-# visible) : le reader ipynb boucle CPU-bound sans produire de sortie, alors
-# que le meme notebook rend en 2-6 s en echo: false. Mesures (2026-08-14,
-# standalone + build complet) :
-#   - App-9b-EdgeDetection-CSharp.ipynb : >= 15 min sans progression
-#     (outputs .NET 4.8 MB, 1061 blocs).
-#   - MGS-4/-8/-9/-11/-14/-15 (MetaGeneticSharp, .net-csharp) : >= 40 s sans
-#     progression (meme pathologie, independante du volume d'outputs —
-#     MGS-11 ne fait que 361 KB / 22 blocs). MGS-4 confirme par le build
-#     complet : hang malgre la normalisation des cellules (post-#10965).
-# Voir issue #10968.
-NOTEBOOK_EXCLUDE_FILES = (
-    "MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-8-LandscapeExplorer.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-14-IslandSynergyFound.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb",
-)
+# Vide depuis 2026-08-14 (issue #10968) : la pathologie qui motivait les 7
+# exclusions — le filtre lua de Quarto 1.7.32 qui pend (CPU-bound, aucune
+# sortie) sur les cellules echo:true dont une ligne de source se termine par
+# \n et qui sont suivies d'un output display_data — est corrigee en Quarto
+# 1.10.18 (pin CI mis a jour). Verifie firsthand (2026-08-14, standalone) :
+#   - App-9b-EdgeDetection-CSharp.ipynb : 1.7.32 >= 15 min sans progression
+#     -> 1.10.18 rend en ~6 s (HTML 4.88 MB).
+#   - MGS-9-EverestRelief / MGS-15-LandscapeAnalysis : 1.10.18 rendent en
+#     7 s / 3 s (leger vs lourd de la famille MetaGeneticSharp).
+#   - Mini-repro minimal (1 cellule code, ligne de source terminant par \n +
+#     1 display_data) : 1.7.32 pend, 1.10.18 rend en ~13 s.
+# NB : pandoc n'est PAS en cause (reader + writer ipynb<->html en 0 s) ;
+# c'est le filtre post-traitement de Quarto 1.7.32 (main.lua:9677, recherche
+# de fenced-div ":::") qui boucle sur la combinaison source+display_data.
+# L'ancienne liste des 7 (App-9b + MGS-4/8/9/11/14/15) est conservee dans
+# l'historique git du fichier. Laisser ce tuple vide sauf raison mesuree.
+NOTEBOOK_EXCLUDE_FILES = ()
 
 
 def git_tracked_notebooks() -> list[str]:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-dotnet #10982

See #10968 (fix de la pathologie + re-integration des 7 notebooks exclus du pilote)

## Resume

**La pathologie #10968 est un bug de Quarto 1.7.32, corrige en 1.10.18.** Le filtre lua de post-traitement (`normalize-combined-1`, traverser `jog`) pend CPU-bound sur les cellules dont une ligne de source (echo:true) se termine par `\n` ET qui sont suivies d'un output `display_data` au HTML volumineux (seuil observe ~300 KB ; 10 KB rend en 3 s). Verifie firsthand (2026-08-14, standalone, meme notebook + meme config `execute: {enabled: false, echo: true}`) :

| Notebook | Quarto 1.7.32 (pin CI) | Quarto 1.10.18 |
|---|---|---|
| App-9b-EdgeDetection-CSharp (4.8 MB, cell 20 = 702 outputs dont 10 display_data ~4.1 MB) | >= 15 min sans progression (confirme 151 s ici, aucun HTML) | **~6 s, HTML 4.88 MB** |
| MGS-15-LandscapeAnalysis (0.2 MB, le plus leger des 6 MGS) | >= 40 s (confirme 90 s ici, aucun HTML) | **~3 s, HTML 208 KB** |
| MGS-9-EverestRelief (4.5 MB, le plus lourd des 6 MGS) | documente | **~7 s, HTML 4.49 MB** |
| Mini-repro minimal (Z1 : 1 cellule code, source `\n` final + 1 display_data) | pend (confirme 90 s) | **~13 s** |

**Pandoc n'est PAS en cause** : reader + writer ipynb<->html en 0 s (pandoc 3.6.3 bundle). L'hypothese d'origine de #10968 (O(n²) du reader ipynb sur ~1000 blocs) est **refutee** : les outputs seuls (702 blocs, 4.1 MB, source stub sans `\n`) rendent en 5 s ; la combinaison source-`\n` × display_data volumineux pend. Seul le seuil de taille du HTML du display_data compte (300 KB texte brut pend aussi — pas specifique base64).

## Changements

1. `.github/workflows/quarto-pages-deploy.yml` : pin Quarto **1.7.32 -> 1.10.18** (setup action `quarto-dev/quarto-actions/setup@v2`).
2. `scripts/regen_quarto_render.py` : `NOTEBOOK_EXCLUDE_FILES` **vide** (les 7 exclus #10979 : App-9b + MGS-4/8/9/11/14/15), commentaire mis a jour (pathologie documentee + reference au mini-repro).

`_quarto.yml` **byte-identique a main** : la liste `project.render` est regeneree a la volee par le workflow (etape pre-render `python scripts/regen_quarto_render.py`), pas commitee sur la branche (catalog-pr-hygiene R1).

## Validation

- **Render complet du site sur 1.10.18** (arborescence main, config pilote exacte + regen pre-render comme CI) : **575 documents, rc=0, mesure : ~11 min 42 s (701 s)**. Les 7 notebooks exclus produisent leur HTML (verifie un par un).
- `python scripts/regen_quarto_render.py` (regen locale, meme etape que CI pre-render) : produit la liste a 118 notebooks — `App-9b` + MGS-4/8/9/11/14/15 inclus. `_quarto.yml` commite **byte-identique a main** (111 notebooks) : la regen est faite par le workflow au deploy (catalog-pr-hygiene R1), donc `--check` echoue localement par construction — c'est l'etat attendu, pas un drift.
- Aucun changement de cellule notebook / sortie (aucun `.ipynb` dans le diff).
- Base fraiche : branche depuis `origin/main` 566ff35d0.

## Note de scope

- `scripts/notebook_tools/normalize_quarto_cells.py` (bug reader 1.7.32 `---` en markdown) : **hors scope** — la normalisation reste harmless sous 1.10.18, pas de changement.
- La piste « nbconvert direct » (#10968 piste 2) est livree separement par #10969 (po-2024, outil `render_oversized_nbconvert.py`) — pas de duplication ici.
