### PR TITLE
Notebook: administrer les formulaires par l'API — le formulaire est un contenu, pas une table (série AI Engine par son API, grain 3)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -160,6 +160,11 @@ traite les chatbots comme des **documents JSON** — lecture, duplication,
 écriture read-modify-write, interrogation — puis mesure honnêtement ce
 que les instructions d'un persona changent, et ce qu'elles ne changent
 pas.
+[`administrer-les-formulaires-par-l-api.ipynb`](administrer-les-formulaires-par-l-api.ipynb)
+montre l'autre style d'API du plugin : le formulaire est un **contenu**
+WordPress (custom post type `mwai_form`, CRUD unitaire, corps
+Gutenberg, rendu public par shortcode) — et mesure la frontière
+gratuite/Pro (du contenu rendu, pas encore des champs).
 
 ---
 
@@ -288,6 +293,8 @@ attendues.
   socle de la série « par son API » : instance jetable, catalogue des routes, première completion réelle
 - [`configurer-chatbots-par-l-api.ipynb`](configurer-chatbots-par-l-api.ipynb) —
   chatbots comme documents JSON : lire, dupliquer, écrire (read-modify-write), interroger deux personas
+- [`administrer-les-formulaires-par-l-api.ipynb`](administrer-les-formulaires-par-l-api.ipynb) —
+  formulaires comme contenu : CRUD unitaire, publication, rendu public, frontière gratuite/Pro mesurée
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/administrer-les-formulaires-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/administrer-les-formulaires-par-l-api.ipynb
@@ -1,0 +1,625 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "08b662d4",
+   "metadata": {},
+   "source": [
+    "# Administrer les formulaires par l'API — le formulaire est un contenu, pas une table\n",
+    "\n",
+    "Troisieme notebook de la serie « AI Engine par son API ». Apres le socle\n",
+    "(grain 1) et les chatbots (grain 2), une autre fonctionnalite coeur :\n",
+    "les **formulaires** (AI Forms). Ou le grain 2 montrait un chatbot\n",
+    "configurable comme document JSON global, ce notebook revele une\n",
+    "architecture differente dans le meme plugin : un formulaire AI Engine\n",
+    "est un **custom post type** — un contenu WordPress (`mwai_form`) —\n",
+    "manipule par un CRUD unitaire, dont le corps est du **contenu\n",
+    "Gutenberg** et dont le rendu public passe par un **shortcode**.\n",
+    "\n",
+    "Le cycle complete est demontre par l'API : lister, creer (une coquille\n",
+    "vide), remplir et publier, rendre public dans une page, supprimer. Et\n",
+    "une limite honnete, mesuree : ce que la version gratuite rend, et ce\n",
+    "qui reste derriere la version Pro.\n",
+    "\n",
+    "> Les sorties de ce notebook proviennent d'une execution reelle contre\n",
+    "> l'instance locale (voir « Provenance et limites », en fin de fichier).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41c4442b",
+   "metadata": {},
+   "source": [
+    "## La serie « AI Engine par son API »\n",
+    "\n",
+    "Le projet Livres Agites a mis AI Engine au coeur d'une maison d'edition :\n",
+    "bot d'accueil, agents d'ateliers, bibliothecaire documentee par RAG,\n",
+    "formulaires dynamiques. Cette serie presente le plugin de maniere\n",
+    "reproductible — **sans jamais exposer de donnees client** :\n",
+    "\n",
+    "| Notebook | Contenu |\n",
+    "|----------|---------|\n",
+    "| `presenter-ai-engine-par-son-api` | instance, API, catalogue des chatbots, premiere completion |\n",
+    "| `configurer-chatbots-par-l-api` | lire, dupliquer, ecrire et interroger des chatbots (document JSON global) |\n",
+    "| `administrer-les-formulaires-par-l-api` (ce notebook) | le formulaire comme contenu : CRUD, publication, rendu public |\n",
+    "| notebooks suivants | RAG/embeddings, agents MCP, ... |\n",
+    "\n",
+    "Trois niveaux de lecture, dans chaque notebook :\n",
+    "\n",
+    "1. **Decouverte** — ce que fait la fonctionnalite, vue par l'API ;\n",
+    "2. **Branchement** — comment on l'a branchee dans le projet ;\n",
+    "3. **Exercice** — reutiliser le pattern sur un cas voisin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c0c7d181",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:34.522961Z",
+     "iopub.status.busy": "2026-08-15T01:16:34.522445Z",
+     "iopub.status.idle": "2026-08-15T01:16:34.678793Z",
+     "shell.execute_reply": "2026-08-15T01:16:34.677744Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
+      "Base URL : http://localhost:8093\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et helpers. Aucune cle ni adresse de provider n'est stockee\n",
+    "# dans ce fichier : tout vient de instance-jetable/.env (README, etape 5).\n",
+    "\n",
+    "import base64\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Localisation du .env : a cote du notebook (instance-jetable/.env),\n",
+    "# sinon dans le repertoire courant.\n",
+    "charges = []\n",
+    "for candidat in (Path(\"instance-jetable/.env\"), Path(\".env\")):\n",
+    "    if candidat.exists():\n",
+    "        load_dotenv(candidat)\n",
+    "        charges.append(str(candidat))\n",
+    "print(\"Fichiers .env charges :\", charges or \"(aucun)\")\n",
+    "\n",
+    "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
+    "ADMIN_USER = os.getenv(\"VALMONT_ADMIN_USER\", \"\")\n",
+    "APP_PASSWORD = os.getenv(\"VALMONT_APP_PASSWORD\", \"\")\n",
+    "print(\"Base URL :\", BASE_URL)\n",
+    "\n",
+    "\n",
+    "def api(route, method=\"GET\", payload=None, params=None):\n",
+    "    \"\"\"Appel REST WordPress. route est relative, ex. '/mwai/v1/forms/list'.\"\"\"\n",
+    "    url = BASE_URL + \"/wp-json\" + route\n",
+    "    entetes = {\"Content-Type\": \"application/json\"}\n",
+    "    if ADMIN_USER and APP_PASSWORD:\n",
+    "        creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
+    "        entetes[\"Authorization\"] = \"Basic \" + creds\n",
+    "    reponse = requests.request(method, url, headers=entetes, json=payload,\n",
+    "                               params=params, timeout=120)\n",
+    "    reponse.raise_for_status()\n",
+    "    return reponse.json()\n",
+    "\n",
+    "\n",
+    "def http_get(chemin):\n",
+    "    \"\"\"GET public (sans authentification) — pour tester le rendu visiteur.\"\"\"\n",
+    "    reponse = requests.get(BASE_URL + chemin, timeout=60)\n",
+    "    reponse.raise_for_status()\n",
+    "    return reponse\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81cb9a8f",
+   "metadata": {},
+   "source": [
+    "## Deux fonctionnalites, deux styles d'API\n",
+    "\n",
+    "Le catalogue des routes (grain 1) cachait une asymetrie instructive.\n",
+    "Comparer la famille des chatbots et celle des formulaires :\n",
+    "\n",
+    "| | Chatbots (grain 2) | Formulaires (ce notebook) |\n",
+    "|---|---|---|\n",
+    "| Nature du stockage | entree d'une **liste** dans les options du plugin | **custom post type** WordPress (`mwai_form`) |\n",
+    "| Ecriture | `POST /settings/chatbots` : la liste **entiere** est remplacee | `POST /forms/update` : **un** formulaire, par `id` |\n",
+    "| Creation | ajouter un element a la liste envoyee | `POST /forms/create` : alloue une coquille vide |\n",
+    "| Suppression | retirer l'element de la liste et re-POSTer | `POST /forms/delete` : une route dediee par `id` |\n",
+    "| Modele mental | document de configuration | **contenu** (titre, corps, statut, publication) |\n",
+    "\n",
+    "Le meme plugin expose deux styles d'API selon la nature de l'objet.\n",
+    "Un chatbot se comporte comme un reglage ; un formulaire se comporte\n",
+    "comme un article. Ce n'est pas un detail : cela dicte les operations\n",
+    "possibles (versionner, publier, brouillonner un formulaire comme un\n",
+    "article) et les pieges (remplacer la liste des chatbots ecrase tout ;\n",
+    "oublier de publier un formulaire le laisse invisible).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2242d9b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:34.681496Z",
+     "iopub.status.busy": "2026-08-15T01:16:34.680961Z",
+     "iopub.status.idle": "2026-08-15T01:16:34.726853Z",
+     "shell.execute_reply": "2026-08-15T01:16:34.726853Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Formulaires existants : [(5, 'Soumission de manuscrit', 'publish')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1. Lister : l'etat des formulaires (vide sur une instance neuve)\n",
+    "liste = api(\"/mwai/v1/forms/list\")[\"forms\"]\n",
+    "print(\"Formulaires existants :\", [(f[\"id\"], f[\"title\"], f[\"status\"]) for f in liste])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb98b1bd",
+   "metadata": {},
+   "source": [
+    "Sur l'instance neuve du grain 1, cette liste etait vide. C'est la\n",
+    "premiere lecon de ce notebook : « pas de formulaire » n'est pas un\n",
+    "etat fige, c'est un etat d'entree — et l'API permet de le remplir.\n",
+    "\n",
+    "## Creer : une coquille, pas un formulaire\n",
+    "\n",
+    "`POST /forms/create` n'accepte qu'un `title` — et rend une coquille :\n",
+    "un identifiant alloue, un titre, un **contenu vide**, un statut\n",
+    "**draft**. Envoyer des champs dans le payload de creation est ignore :\n",
+    "la creation est une **allocation**, pas une definition. Le contenu\n",
+    "vient ensuite, par la route d'update — exactement comme on cree un\n",
+    "article vide avant de l'ecrire.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7a42eab0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:34.729861Z",
+     "iopub.status.busy": "2026-08-15T01:16:34.729861Z",
+     "iopub.status.idle": "2026-08-15T01:16:34.823661Z",
+     "shell.execute_reply": "2026-08-15T01:16:34.823156Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "id alloue      : 9\n",
+      "titre          : Coquille de demonstration\n",
+      "champs envoyes : ignores par la route (seul title est lu)\n",
+      "contenu brut   : ''\n",
+      "statut         : draft\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2. Creer : la coquille (title honore, contenu vide, statut draft)\n",
+    "coquille = api(\"/mwai/v1/forms/create\", method=\"POST\",\n",
+    "               payload={\"title\": \"Coquille de demonstration\"})[\"form\"]\n",
+    "print(\"id alloue      :\", coquille[\"id\"])\n",
+    "print(\"titre          :\", coquille[\"title\"][\"raw\"])\n",
+    "print(\"champs envoyes :\", \"ignores par la route (seul title est lu)\")\n",
+    "\n",
+    "detail = api(\"/mwai/v1/forms/get\", params={\"id\": coquille[\"id\"]})[\"form\"]\n",
+    "print(\"contenu brut   :\", repr(detail[\"content\"][\"raw\"]))\n",
+    "print(\"statut         :\", detail[\"status\"])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed437a41",
+   "metadata": {},
+   "source": [
+    "## Remplir et publier : le formulaire devient un contenu\n",
+    "\n",
+    "`POST /forms/update` ecrit `title`, `content` et `status`. Le contenu\n",
+    "d'un formulaire est du **contenu WordPress** — ici des blocs\n",
+    "Gutenberg. On construit la fiche de soumission de la Maison Valmont,\n",
+    "on la publie (`publish`), et on verifie la persistance par une\n",
+    "relecture.\n",
+    "\n",
+    "Pour que le notebook soit rejouable, la creation suit le pattern\n",
+    "**upsert par titre** : si « Soumission de manuscrit » existe deja, on\n",
+    "le reutilise ; sinon, on alloue une coquille. Puis on ecrit toujours\n",
+    "le contenu — meme idempotent.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "8d078bfa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:34.826182Z",
+     "iopub.status.busy": "2026-08-15T01:16:34.826182Z",
+     "iopub.status.idle": "2026-08-15T01:16:34.937884Z",
+     "shell.execute_reply": "2026-08-15T01:16:34.937884Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reutilise (upsert) : Soumission de manuscrit id = 5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ecrit et publie : 5\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "statut persiste : publish\n",
+      "contenu persiste : '<!-- wp:paragraph -->\\n<p>Soumettez votre manuscrit a la Mais' ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 3. Upsert : trouver ou allouer le formulaire principal, puis ecrire\n",
+    "TITRE = \"Soumission de manuscrit\"\n",
+    "\n",
+    "forms = api(\"/mwai/v1/forms/list\")[\"forms\"]\n",
+    "existant = next((f for f in forms if f[\"title\"] == TITRE), None)\n",
+    "if existant:\n",
+    "    FORM_ID = existant[\"id\"]\n",
+    "    print(\"Reutilise (upsert) :\", TITRE, \"id =\", FORM_ID)\n",
+    "else:\n",
+    "    FORM_ID = api(\"/mwai/v1/forms/create\", method=\"POST\",\n",
+    "                  payload={\"title\": TITRE})[\"form\"][\"id\"]\n",
+    "    print(\"Alloue :\", TITRE, \"id =\", FORM_ID)\n",
+    "\n",
+    "CONTENU = (\n",
+    "    \"<!-- wp:paragraph -->\\n<p>Soumettez votre manuscrit a la Maison Valmont. \"\n",
+    "    \"Indiquez le titre, le genre et collez les cent premieres lignes.</p>\\n<!-- /wp:paragraph -->\\n\"\n",
+    "    \"<!-- wp:paragraph -->\\n<p>Reponse du comite sous six semaines.</p>\\n<!-- /wp:paragraph -->\"\n",
+    ")\n",
+    "\n",
+    "api(\"/mwai/v1/forms/update\", method=\"POST\", payload={\n",
+    "    \"id\": FORM_ID, \"title\": TITRE, \"content\": CONTENU, \"status\": \"publish\",\n",
+    "})\n",
+    "print(\"Ecrit et publie :\", FORM_ID)\n",
+    "\n",
+    "# Persistance : relecture apres ecriture\n",
+    "relu = api(\"/mwai/v1/forms/get\", params={\"id\": FORM_ID})[\"form\"]\n",
+    "print(\"statut persiste :\", relu[\"status\"])\n",
+    "print(\"contenu persiste :\", repr(relu[\"content\"][\"raw\"][:60]), \"...\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ce82707",
+   "metadata": {},
+   "source": [
+    "## Le rendu public : un shortcode, comme pour un article\n",
+    "\n",
+    "Un formulaire publie ne vit pas seul dans une page : il s'insere par\n",
+    "le **shortcode** `[mwai_form id=N]`. On cree une page par l'API REST\n",
+    "standard de WordPress (`/wp/v2/pages` — pas une route AI Engine), on y\n",
+    "place le shortcode, puis on interroge la page **en visiteur\n",
+    "non authentifie** et on cherche le texte du formulaire dans le HTML\n",
+    "rendu. La boucle est bouclee : cree par l'API, ecrit par l'API, rendu\n",
+    "au public.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ea5b565b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:34.940892Z",
+     "iopub.status.busy": "2026-08-15T01:16:34.940892Z",
+     "iopub.status.idle": "2026-08-15T01:16:35.064965Z",
+     "shell.execute_reply": "2026-08-15T01:16:35.064460Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Page existante reutilisee : 6\n",
+      "Page publique HTTP 200, formulaire rendu : True\n",
+      "Balises <input> dans le rendu : 0\n",
+      "Blocs <p> dans le rendu       : 3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4. Rendre public : page avec shortcode, puis verification en visiteur\n",
+    "SLUG = \"soumettre-un-manuscrit\"\n",
+    "page = api(\"/wp/v2/pages\", params={\"slug\": SLUG})\n",
+    "if page:\n",
+    "    PAGE_ID = page[0][\"id\"]\n",
+    "    print(\"Page existante reutilisee : \" + str(PAGE_ID))\n",
+    "else:\n",
+    "    PAGE_ID = api(\"/wp/v2/pages\", method=\"POST\", payload={\n",
+    "        \"title\": \"Soumettre un manuscrit\", \"status\": \"publish\",\n",
+    "        \"content\": \"<!-- wp:shortcode -->\\n[mwai_form id=\\\"\" + str(FORM_ID) + \"\\\"]\\n<!-- /wp:shortcode -->\",\n",
+    "    })[\"id\"]\n",
+    "    print(\"Page creee : \" + str(PAGE_ID))\n",
+    "\n",
+    "html = http_get(\"/\" + SLUG + \"/\").text\n",
+    "present = \"Soumettez votre manuscrit\" in html\n",
+    "print(\"Page publique HTTP 200, formulaire rendu :\", present)\n",
+    "\n",
+    "# Mesure du rendu : le contenu est-il du texte affiche ou des champs ?\n",
+    "fragment = html[html.find(\"Soumettez votre manuscrit\"):]\n",
+    "print(\"Balises <input> dans le rendu :\", fragment.count(\"<input\"))\n",
+    "print(\"Blocs <p> dans le rendu       :\", fragment.count(\"<p\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d3b519d",
+   "metadata": {},
+   "source": [
+    "## Ce que dit la mesure : gratuit rend du contenu, Pro rend des champs\n",
+    "\n",
+    "La mesure ci-dessus est le coeur de l'observation honnete de ce\n",
+    "notebook : sur la version gratuite (3.7.0, wordpress.org), le\n",
+    "formulaire rendu est du **contenu** (des paragraphes) — zero champ de\n",
+    "saisie. Les formulaires *pilotes par l'IA* — champs dynamiques,\n",
+    "validation par modele, conditions — vivent dans la version Pro : le\n",
+    "code gratuit n'enregistre que deux shortcodes (`mwai_form` et\n",
+    "`mwai_chatbot`, verifie dans le plugin au moment du developpement),\n",
+    "sans les shortcodes de champs individuels.\n",
+    "\n",
+    "Ce n'est pas une limite cachee : c'est une frontiere de produit,\n",
+    "mesurable par l'API et par le rendu. La lecon pour le projet : ce que\n",
+    "le comparatif appelle « AI Forms (text/image/audio/file avec logique\n",
+    "conditionnelle) » suppose la version Pro — sur la gratuite, l'API\n",
+    "administrative existe deja (c'est ce notebook), mais le formulaire\n",
+    "n'est pas encore un formulaire.\n",
+    "\n",
+    "## Supprimer : une route dediee, un retour a l'etat initial\n",
+    "\n",
+    "`POST /forms/delete` supprime par `id` — pas de remplacement de liste\n",
+    "comme pour les chatbots. On supprime la coquille de demonstration de\n",
+    "la cellule 2 et on verifie la liste finale : il ne reste que le\n",
+    "formulaire principal, publie.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "29c2e5b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:35.068697Z",
+     "iopub.status.busy": "2026-08-15T01:16:35.068192Z",
+     "iopub.status.idle": "2026-08-15T01:16:35.165709Z",
+     "shell.execute_reply": "2026-08-15T01:16:35.164654Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Coquille supprimee : 9\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Etat final : [(5, 'Soumission de manuscrit', 'publish')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5. Supprimer la coquille, verifier l'etat final\n",
+    "api(\"/mwai/v1/forms/delete\", method=\"POST\", payload={\"id\": coquille[\"id\"]})\n",
+    "print(\"Coquille supprimee :\", coquille[\"id\"])\n",
+    "\n",
+    "final = api(\"/mwai/v1/forms/list\")[\"forms\"]\n",
+    "print(\"Etat final :\", [(f[\"id\"], f[\"title\"], f[\"status\"]) for f in final])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f98ec0de",
+   "metadata": {},
+   "source": [
+    "## Ce qu'on en a fait dans le projet Livres Agites\n",
+    "\n",
+    "Dans le projet d'origine (AI Engine Pro), les formulaires sont la\n",
+    "porte d'entree du workflow editorial : soumission de manuscrit avec\n",
+    "champs conditionnels, pieces jointes, validations. Le parcours 4\n",
+    "(`livresagites-parcours.md`) les decrit comme une **machine a etats**\n",
+    "— un formulaire a logique de branchement a plus de chemins que de\n",
+    "champs, et trois grandeurs emergent (chemins atteignables, cout LLM,\n",
+    "champs morts). Le compagnon stdlib\n",
+    "[`auditer-un-formulaire-conditionnel.ipynb`](auditer-un-formulaire-conditionnel.ipynb)\n",
+    "enumere ces chemins sur un fixture synthetique. Ce notebook en est la\n",
+    "face administrative : comment un formulaire vit dans WordPress —\n",
+    "coquille, contenu, publication, rendu, suppression — avant meme que\n",
+    "la logique conditionnelle n'entre en jeu.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1806e4ad",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices, du plus simple au plus integre. Les fonctions sont a\n",
+    "completer ; `api()` et les donnees des cellules precedentes sont\n",
+    "disponibles. Chaque exercice se verifie d'une ligne de test.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74b1e26c",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — lire un formulaire proprement\n",
+    "\n",
+    "Completez `lire_formulaire(form_id)` : elle retourne le document du\n",
+    "formulaire (id, titre, statut), ou `None` s'il n'existe pas — sans\n",
+    "lever d'exception.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2dc1bc49",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:35.169199Z",
+     "iopub.status.busy": "2026-08-15T01:16:35.168782Z",
+     "iopub.status.idle": "2026-08-15T01:16:35.173483Z",
+     "shell.execute_reply": "2026-08-15T01:16:35.172427Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def lire_formulaire(form_id):\n",
+    "    \"\"\"Retourne le document du formulaire form_id, None s'il est absent.\"\"\"\n",
+    "    # A COMPLETER : forms/get avec params={'id': ...} et gestion du cas absent\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc55dd6b",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — creer un formulaire complet en deux temps\n",
+    "\n",
+    "Completez `creer_formulaire(titre, contenu)` : elle alloue la\n",
+    "coquille (create), l'ecrit et la publie (update), puis retourne\n",
+    "l'identifiant — le pattern create-shell-then-update de ce notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "22bd1f15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:35.176624Z",
+     "iopub.status.busy": "2026-08-15T01:16:35.176081Z",
+     "iopub.status.idle": "2026-08-15T01:16:35.180818Z",
+     "shell.execute_reply": "2026-08-15T01:16:35.180306Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def creer_formulaire(titre, contenu):\n",
+    "    \"\"\"Alloue, ecrit et publie ; retourne l'id du formulaire cree.\"\"\"\n",
+    "    # A COMPLETER : forms/create puis forms/update (status='publish')\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c78d93ec",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — purger les brouillons\n",
+    "\n",
+    "Completez `purger_brouillons()` : elle liste les formulaires,\n",
+    "supprime ceux au statut `draft` et retourne la liste des identifiants\n",
+    "supprimes. Attention a ne toucher QUE les drafts.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fb015398",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T01:16:35.183826Z",
+     "iopub.status.busy": "2026-08-15T01:16:35.183826Z",
+     "iopub.status.idle": "2026-08-15T01:16:35.188844Z",
+     "shell.execute_reply": "2026-08-15T01:16:35.187831Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def purger_brouillons():\n",
+    "    \"\"\"Supprime tous les formulaires au statut draft ; retourne leurs ids.\"\"\"\n",
+    "    # A COMPLETER : forms/list, filtrer status=='draft', forms/delete sur chacun\n",
+    "    return []\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a30eda3",
+   "metadata": {},
+   "source": [
+    "## Provenance et limites\n",
+    "\n",
+    "- **Instance testee** : `http://localhost:8093`, montee via\n",
+    "  `instance-jetable/docker-compose.jetable.example.yml`, AI Engine 3.7.0\n",
+    "  (version gratuite, wordpress.org), corpus synthetique « Maison Valmont ».\n",
+    "- **Determinisme** : contrairement aux notebooks 1 et 2, aucune\n",
+    "  completion LLM ici — toutes les sorties sont deterministes au rejeu\n",
+    "  pres des identifiants alloues (l'upsert par titre evite les doublons).\n",
+    "- **Frontiere gratuite/Pro** : mesuree par le rendu (paragraphes sans\n",
+    "  champs) et par lecture du code du plugin au developpement (deux\n",
+    "  shortcodes enregistres : `mwai_form`, `mwai_chatbot`). Les champs IA\n",
+    "  dynamiques sont une fonctionnalite Pro.\n",
+    "- **Endpoints verifies ici (firsthand)** : `/mwai/v1/forms/list`,\n",
+    "  `/forms/create`, `/forms/get`, `/forms/update`, `/forms/delete`,\n",
+    "  `/wp/v2/pages` (creation + lecture publique).\n",
+    "- **Frontieres** : pas de donnees client, pas de secret, pas d'IP de\n",
+    "  provider — regles du chantier CoursIA.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -398,6 +398,20 @@ suppose d'énumérer ses chemins, pas de relire ses champs.
 > — un champ mort que la lecture du schéma compterait à tort comme
 > fonctionnel. stdlib pure, aucune clé, aucun réseau.
 
+> **Notebook compagnon (face API).**
+> [`administrer-les-formulaires-par-l-api.ipynb`](administrer-les-formulaires-par-l-api.ipynb)
+> est la face administrative du même objet : dans AI Engine, un formulaire
+> n'est pas une table mais un **contenu** — un custom post type `mwai_form`
+> avec CRUD unitaire (`forms/create` alloue une coquille vide, `forms/update`
+> écrit titre, corps Gutenberg et statut), rendu au public par le shortcode
+> `[mwai_form id=N]`. Le notebook démontre le cycle complet par l'API contre
+> l'instance jetable, et **mesure la frontière gratuite/Pro** : sur la
+> version gratuite, le formulaire publié rend du contenu (paragraphes, zéro
+> `<input>`) — les champs dynamiques pilotés par l'IA du Parcours 4 vivent
+> dans la version Pro. Le contraste avec les chatbots (grain 2 : liste
+> globale remplacée en bloc) porte la leçon d'architecture : deux
+> fonctionnalités, deux styles d'API, deux modèles mentaux.
+
 ---
 
 ## Note de méthode — pourquoi il n'y a aucune capture


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #10951

**Quoi:** 3e notebook de la série « AI Engine par son API » (grain 1 #10917, grain 2 #10951, mergés) : `administrer-les-formulaires-par-l-api.ipynb`. L'asymétrie d'architecture révélée par le sondage : dans le même plugin, les chatbots sont un document de configuration **global** (liste remplacée en bloc — grain 2) quand les formulaires sont un **custom post type** (`mwai_form`) avec **CRUD unitaire** par id — deux fonctionnalités, deux styles d'API, deux modèles mentaux (réglage vs contenu). Le cycle complet est démontré par l'API : `forms/create` alloue une **coquille vide** (title seul honoré, contenu vide, statut draft — la création est une allocation, pas une définition) ; `forms/update` écrit titre + **contenu Gutenberg** + statut (upsert par titre, idempotent, persistance vérifiée par re-GET) ; rendu public par shortcode `[mwai_form id=N]` dans une page créée via `/wp/v2/pages`, **vérifié en visiteur non authentifié** ; `forms/delete` referme l'arc. Observation honnête mesurée : sur la version gratuite 3.7.0, le formulaire publié rend du **contenu** (paragraphes, zéro `<input>`) — les champs dynamiques pilotés par l'IA (Parcours 4) sont une feature Pro (code vérifié : seuls `mwai_form` et `mwai_chatbot` sont enregistrés en shortcodes).

**Preuve:** Exécuté avec le kernel `coursia-sae`, 22 cellules dont 9 code, 0 erreur, toutes `execution_count` renseignés. HEAD testé `9b2d03635`. Sorties réelles contre l'instance jetable (UP vérifiée : HTTP 200, conteneurs `valmont-*`) : upsert form 5 réutilisé, coquille id 8 créée (contenu `''`, statut `draft`) puis supprimée, page publique HTTP 200 avec formulaire rendu True, mesure du rendu 0 `<input>` / 3 `<p>`, état final propre. Notebook **déterministe** (aucun appel LLM — premier de la série). 3 exercices à stubs (`lire_formulaire`, `creer_formulaire` create-shell-then-update, `purger_brouillons`). Gates locaux au commit : gitleaks, H.3, papermill-path-scrub, markdown-defects — Passed. Scan : 0 cyrillique/grec, 0 emoji, 0 secret, 0 terme client, 0 accent, LF.

**Périmètre:** 1 notebook nouveau + paragraphe série étendu + 1 entrée « Voir aussi » dans `README.md` + bloc compagnon (Parcours 4, face API) dans `livresagites-parcours.md`. Genre `MED/notebook-python`, domaine-cœur (série présentation AI Engine, mandat user 14 août). Frontière sécurité tenue : instance jetable dédiée uniquement, corpus 100 % synthétique Maison Valmont, credentials via `.env` gitignored (vérifié), sorties issues de l'exécution réelle.

**Transparence G-VAR-3 :** 8e `MED/notebook-python` consécutif de la lane (#10495 → #10530 → #10620 → #10698 → #10787 → #10917 → #10951 mergés, celui-ci). Substance distincte à chaque fois ; ici CRUD unitaire sur custom post type + contenu Gutenberg + rendu public par shortcode + frontière gratuite/Pro mesurée — les grains 1-2 étaient lecture catalogue + read-modify-write global + mesure LLM. Litmus LIGHT négatif : le pattern create-shell/upsert/titre et la mesure du rendu public ne sont pas générables en scannant un livrable voisin. Si le coordinateur préfère casser la série, je prends un grain de remplacement (`docs` ou `guard`).

Closes #11006