### PR TITLE
fix(test,#10974): re-anchor parity test to declared pair count + wire translation suite into CI (338 tests)

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -159,6 +159,7 @@ jobs:
             scripts/tests \
             scripts/notebook_tools/tests \
             scripts/lean/tests \
+            scripts/translation/tests \
             MyIA.AI.Notebooks/GameTheory/tests \
             MyIA.AI.Notebooks/QuantConnect/scripts/tests \
             MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py \
@@ -170,7 +171,6 @@ jobs:
       # l'herméticité est démontrée sur runner nu. Chaque raison est vérifiée
       # firsthand (2026-08-14, po-2024) :
       # CI-EXCLUDED: scripts/audit/tests — 4 échecs env-dépendants (test_regen_img1_dalle3.py, clé DALLE-3/OpenAI requise), 405 passent
-      # CI-EXCLUDED: scripts/translation/tests — 1 échec STRUCTURE_DRIFT actif (test_full_repo_state_passes_parity, cellule supprimée 71023d39) — drift à résoudre avant câblage
       # CI-EXCLUDED: scripts/quantconnect/tests — deps yfinance + fichiers de données externes, non hermétique sur runner nu
       # CI-EXCLUDED: scripts/secrets/tests — 4/6 fichiers non couverts par secret-scan.yml (render_envs/render_settings_json) ; scan gitleaks = 2 fichiers dédiés
       # CI-EXCLUDED: GradeBookApp — deps openpyxl/rapidfuzz/unidecode non installées dans ce job ; PII grading hors CI publique

--- a/scripts/check_testpaths_coverage.py
+++ b/scripts/check_testpaths_coverage.py
@@ -42,6 +42,7 @@ WORKFLOW_COVERAGE: dict[str, list[str]] = {
         "scripts/tests",
         "scripts/notebook_tools/tests",
         "scripts/lean/tests",
+        "scripts/translation/tests",
         "MyIA.AI.Notebooks/GameTheory/tests",
         "MyIA.AI.Notebooks/QuantConnect/scripts/tests",
         "MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_bg_tree_lock.py",

--- a/scripts/translation/tests/test_check_translation_parity.py
+++ b/scripts/translation/tests/test_check_translation_parity.py
@@ -646,6 +646,15 @@ def test_cli_repo_root_missing_returns_two(tmp_path, capsys, monkeypatch):
 # Reference — live state (manual)
 # ---------------------------------------------------------------------------
 
+# Declared translation-pair count on main. EQ, not a threshold: the test
+# reddens in BOTH directions — a count below the declaration means pairs were
+# lost, a count above means the perimeter moved without updating this
+# declaration. Today 0 pairs: hold i18n #10038 (decision user 2026-08-12,
+# rollback 2e79bcb77). When i18n resumes, the first reintroduced pair makes
+# this test red and the declaration must be updated knowingly — a skipif
+# would re-arm silently and a >= 0 threshold would stay green forever.
+EXPECTED_PAIR_COUNT = 0
+
 
 def test_full_repo_state_passes_parity():
     """Reference test against the live ``xxx_<lang>.ipynb`` artifacts on main.
@@ -655,17 +664,18 @@ def test_full_repo_state_passes_parity():
     hand-edited (must re-render via T4), or (b) the parity invariants need
     extending to cover a regression introduced by T4 itself.
 
-    Expected state today (post-grain A MERGED): exactly one pair —
-    ``FT-01-Introduction-FineTuning_en.ipynb`` — and it must satisfy all
-    invariants including strict-fr (because grain A proved byte-identity
-    + structure + no-FR-leak on md).
+    Expected pair count is declared in ``EXPECTED_PAIR_COUNT`` above (hold
+    i18n #10038). Any existing pair — including every pair reintroduced after
+    the hold lifts — is still checked against all invariants including
+    strict-fr.
     """
     repo_root = HERE.parent.parent.parent  # scripts/translation/tests/ → repo root
     pairs = p.discover_pairs(repo_root, ["en", "ru"])
-    # We expect exactly one pair: FT-01-Introduction-FineTuning (en only).
-    # Other PRs (grain E #10047) may have brought additional pairs; we check
-    # each one is OK.
-    assert len(pairs) >= 1, "no translation pairs found on main"
+    assert len(pairs) == EXPECTED_PAIR_COUNT, (
+        f"translation pair count drifted from the declared perimeter: "
+        f"found {len(pairs)}, declared {EXPECTED_PAIR_COUNT} "
+        f"(update EXPECTED_PAIR_COUNT knowingly — hold i18n #10038)"
+    )
     for src_path, trd_path, stem, lang in pairs:
         src_cells, src_err = p.load_cells(src_path)
         trd_cells, trd_err = p.load_cells(trd_path)


### PR DESCRIPTION
Grain: MED/test — lane myia-po-2026:CoursIA — prev: #11007

Closes #10974 (exécution de l'arbitrage ai-01 tel quel)

# Re-ancrage du test de parité sur un périmètre DÉCLARÉ + câblage de la suite translation en CI (338 tests)

## What

1. **`test_full_repo_state_passes_parity` réécrit selon l'arbitrage (3)** : constante déclarée `EXPECTED_PAIR_COUNT = 0` (commentée `hold i18n #10038 (décision user 2026-08-12)`), **assertion d'égalité** (rougit dans les DEUX sens : compte < déclaration = paires perdues ; compte > déclaration = périmètre bougé sans mise à jour), vérifications de parité conservées sur les paires existantes (inopérantes à 0, actives dès qu'une paire revient). Docstring stale (« post-grain A MERGED: exactly one pair ») actualisée.
2. **Marqueur `CI-EXCLUDED` retiré** (son motif — « 1 échec STRUCTURE_DRIFT actif, cellule supprimée 71023d39 » — décrivait une dérive sur une paire existante ; il n'y a plus AUCUNE paire, la justification était doublement périmée) et **suite câblée** dans `scripts-tests.yml` + `WORKFLOW_COVERAGE` : **338 tests entrent en CI** (337 passaient déjà, exclus pour rien).

## Why égalité plutôt que skipif/seuil (réponse à l'arbitrage)

- `skipif` : ne s'exécute pas — à la reprise i18n il se rallume **en silence**, personne ne relit.
- seuil `>= 0` : vrai par vacuité sur un dépôt à 0 paire — reste vert **quel que soit** l'état, n'informe personne.
- **égalité vs constante déclarée** : la première paire réintroduite fait ROUGIR le test, la déclaration doit être mise à jour **en connaissance de cause**. C'est la relecture que les deux autres formes n'obtiendraient jamais.

## Proof (mesures dans le worktree, frais de `origin/main` ec92e2c8a)

- `python -m pytest scripts/translation/tests/ -q` → **338 passed in 15.78s** (0 échec ; l'assertion `>= 1` est déchargée).
- `python scripts/check_testpaths_coverage.py --verbose` → exit 0, `scripts/translation/tests` passe de `exclu:` à `couvert:` (`[ok] .github/workflows/scripts-tests.yml couvre scripts/translation/tests`).
- `python -m pytest scripts/tests/test_check_testpaths_coverage.py -q` → **5 passed** (le garde mesure l'état réel, pas une liste codée en dur — vérifié avant édition : aucun test frère n'énumère les exclusions attendues).
- Grep anti-référence : plus aucune occurrence de l'exclusion translation hors le câblage lui-même.

## Scope

3 fichiers, +20/−9 : le test, le workflow, le dict de couverture. Pas d'autre test touché ; les ~20 tests sur fixtures synthétiques (dont 6 tests de falsification du checker) sont inchangés — la question « le checker est-il correct ? » restait déjà couverte.

## Self-validating

Le run `scripts-tests` de CETTE PR exécute `scripts/tests` → `test_current_state_has_no_uncovered_testpaths` mesure le checkout de la PR : si le câblage était incohérent (cible au run mais absente du dict, ou l'inverse), la PR elle-même rougit. Le garde #10936 contrôle ensuite que le câblage ne se perd pas.

— livré en second grain de fenêtre (plancher du cycle = #11007 DEEP/lean ; variété R6 : test/CI ≠ Lean)
