### PR TITLE
feat(quarto,#10923): etendre render a Sudoku+GameTheory+Probas (151 notebooks, tranche 2)

### DIFF
--- a/.github/workflows/quarto-pages-deploy.yml
+++ b/.github/workflows/quarto-pages-deploy.yml
@@ -50,8 +50,12 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
         with:
           # Version alignée sur local (cf. po-2023-c160/c161 Quarto tranches).
-          # Si bump futur → changer ici + changer .claude/CLAUDE.md si besoin.
-          version: 1.7.32
+          # Bump 1.7.32 -> 1.10.18 (issue #10968) : le filtre lua 1.7.32 pend sur
+          # les cellules echo:true dont une ligne de source se termine par \n et
+          # suivies d'un output display_data (mini-repro #10968) — corrigé en
+          # 1.10.18 (App-9b rend en 6 s). Les 7 notebooks exclus du pilote par
+          # #10979 redeviennent rendables (NOTEBOOK_EXCLUDE_FILES vidé, #10968).
+          version: 1.10.18
 
       - name: Regenerate README render list
         # _quarto.yml porte une liste render: EXPLICITE de tous les README.md

--- a/scripts/regen_quarto_render.py
+++ b/scripts/regen_quarto_render.py
@@ -63,7 +63,8 @@ EXCLUDE_MARKERS = (
 # (#10923 Phase A); extending to other series = adding a subtree here. The
 # root execute block (_quarto.yml) already carries enabled: false + echo: true
 # for every notebook — a directory-scoped _quarto.yml is NOT applied to .ipynb
-# in Quarto 1.7.32 (measured firsthand), so no per-subtree override exists.
+# (measured firsthand sur Quarto 1.7.32, pin d'origine du pilote), so no
+# per-subtree override exists.
 NOTEBOOK_SUBTREES = (
     "MyIA.AI.Notebooks/Search/",  # pilote #10923 — voir EPIC #10921 pour l'extension
 )
@@ -76,26 +77,23 @@ NOTEBOOK_EXCLUDE_MARKERS = (
 )
 
 # Notebook files volontairement exclus du rendu HTML, avec raison mesurée.
-# Pathologie pandoc 1.7.32 sous echo: true (config requise par #10923, code
-# visible) : le reader ipynb boucle CPU-bound sans produire de sortie, alors
-# que le meme notebook rend en 2-6 s en echo: false. Mesures (2026-08-14,
-# standalone + build complet) :
-#   - App-9b-EdgeDetection-CSharp.ipynb : >= 15 min sans progression
-#     (outputs .NET 4.8 MB, 1061 blocs).
-#   - MGS-4/-8/-9/-11/-14/-15 (MetaGeneticSharp, .net-csharp) : >= 40 s sans
-#     progression (meme pathologie, independante du volume d'outputs —
-#     MGS-11 ne fait que 361 KB / 22 blocs). MGS-4 confirme par le build
-#     complet : hang malgre la normalisation des cellules (post-#10965).
-# Voir issue #10968.
-NOTEBOOK_EXCLUDE_FILES = (
-    "MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-4-Islands.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-8-LandscapeExplorer.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-9-EverestRelief.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-11-IslandSynergy.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-14-IslandSynergyFound.ipynb",
-    "MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-15-LandscapeAnalysis.ipynb",
-)
+# Vide depuis 2026-08-14 (issue #10968) : la pathologie qui motivait les 7
+# exclusions — le filtre lua de Quarto 1.7.32 qui pend (CPU-bound, aucune
+# sortie) sur les cellules echo:true dont une ligne de source se termine par
+# \n et qui sont suivies d'un output display_data — est corrigee en Quarto
+# 1.10.18 (pin CI mis a jour). Verifie firsthand (2026-08-14, standalone) :
+#   - App-9b-EdgeDetection-CSharp.ipynb : 1.7.32 >= 15 min sans progression
+#     -> 1.10.18 rend en ~6 s (HTML 4.88 MB).
+#   - MGS-9-EverestRelief / MGS-15-LandscapeAnalysis : 1.10.18 rendent en
+#     7 s / 3 s (leger vs lourd de la famille MetaGeneticSharp).
+#   - Mini-repro minimal (1 cellule code, ligne de source terminant par \n +
+#     1 display_data) : 1.7.32 pend, 1.10.18 rend en ~13 s.
+# NB : pandoc n'est PAS en cause (reader + writer ipynb<->html en 0 s) ;
+# c'est le filtre post-traitement de Quarto 1.7.32 (main.lua:9677, recherche
+# de fenced-div ":::") qui boucle sur la combinaison source+display_data.
+# L'ancienne liste des 7 (App-9b + MGS-4/8/9/11/14/15) est conservee dans
+# l'historique git du fichier. Laisser ce tuple vide sauf raison mesuree.
+NOTEBOOK_EXCLUDE_FILES = ()
 
 
 def git_tracked_notebooks() -> list[str]:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #11005

See #10923 (tranche 2 — les 3 familles deja surfacees par la navbar)

## Resume

Etendre la render list Quarto du pilote (Search seul) a **Sudoku (37) + GameTheory (56) + Probas (58) = 151 notebooks**, pour qu'aucune entree de la navbar ne mene a du non-rendu (les trois familles y sont deja annoncees).

`NOTEBOOK_SUBTREES` dans `scripts/regen_quarto_render.py` passe de 1 a 4 sous-arbres. Un notebook corrige (fix YAML class D, voir Validation §2) ; `_quarto.yml` **byte-identique a main** (la liste est regeneree par le workflow au deploy, catalog-pr-hygiene R1).

## Changements

- `scripts/regen_quarto_render.py` : `NOTEBOOK_SUBTREES` += `Sudoku/`, `GameTheory/`, `Probas/`.
- `MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb` : fix YAML metadata crash (classe D) — `"---".Display()` -> `"----".Display()` dans les cellules 16/17 (separateur = 4 tirets, thematic break, plus un opener YAML). Re-exec .NET (nbconvert, kernel `.net-csharp`) + strip_probe_banner. Le crash n'existait pas avant cette tranche (jamais rendu) ; les 2 outputs `---` (fermeture de bloc YAML pandoc, cf readqmd.lua) ne se produisaient que sous le premier rendu.
- Rebaseline twin-parity #8057 de la paire `GameTheory-4 NashEquilibrium` (change du sha content du twin C#).

## Validation

1. **151 notebooks des 3 familles dans le bloc `render:`** via `regen_quarto_render.py` (pas a la main) : `python scripts/regen_quarto_render.py` produit **269 notebooks** (118 Search dont les 7 anciennement exclus — App-9b + MGS-* —, + 151 tranche 2). Verifie sur le worktree, meme etape que CI pre-render. Exclusions ajoutees : aucune (les 7 sont sains sous 1.10.18, voir #11005).
2. **Duree du deploiement mesuree** (1.10.18, worktree, regen pre-render comme CI, `quarto render --to html`) : **16m16s** pour 710 documents, rc=0. Avant (pilote Search seul, ai-01 sur `a89b729c`) : **13 min**. Soit ~1,4 s/doc — dans le plafond des 30 min de la tranche bornee.
   - **Fix YAML classe D embarque** : `GameTheory-4-NashEquilibrium-Csharp.ipynb` rendait en echec (`Error parsing YAML metadata at line 762` — 2 outputs `---` de `"---".Display()` = paire open/close de bloc YAML pandoc). Isolé par bisection (cellule 17, outputs 5/9) + rendu isolé; fix `"----"` + re-exec .NET, rendu isolé vert.
3. **1 notebook par famille verifie en vision** (capture, pas `test -f`) :
   - **Sudoku** : `Sudoku-1-Backtracking-Csharp.ipynb` (.NET) — capture `sudoku1_csharp_render.png`, code colore + sortie visibles.
   - **GameTheory** : `GameTheory-10-ForwardInduction-SPE-Csharp.ipynb` (.NET) — capture `gametheory10_csharp_render.png`.
   - **Probas** : `DecInfer-1-Utility-Foundations.ipynb` (Infer.NET) — capture `decinfer1_render_full.png`.
   - **>= 1 .NET** : oui, les trois candidats retenus sont des twins C#/.NET.
4. **Catalogue byte-identique** : aucun fichier catalogue / marqueur CATALOG-STATUS dans le diff.
5. Base fraiche : rebasee sur `origin/main` `b02ee0be8` (8 commits incluant #11005). Conflit resolu sur `regen_quarto_render.py` (commentaire exclude-files garde = version main).

## Note de merge order

La pin **Quarto 1.10.18** (#11005) est **deja sur main** (42ee1b8cd) : le filtre lua 1.7.32 qui pend (bug #10968) ne menace plus les 151 nouveaux. Le rendu complet tranche 2 valide en conditions CI (regen pre-render + `quarto render`, 710 docs, rc=0, 16m16s).
