### PR TITLE
feat(quarto,#10923): etendre render a Sudoku+GameTheory+Probas (151 notebooks, tranche 2)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-13-ImperfectInfo-CFR-Csharp.ipynb
@@ -1108,7 +1108,7 @@
    "id": "gt13-pont-md",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Annexe : Pont .NET vers OpenSpiel CFR via PythonNet (#10459)\n",
     "\n",

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
@@ -59,10 +59,10 @@
    "id": "7887f51a-1371-4904-bbf3-a4d7f81003ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:36.646964Z",
-     "iopub.status.busy": "2026-08-11T11:01:36.625697Z",
-     "iopub.status.idle": "2026-08-11T11:01:41.506342Z",
-     "shell.execute_reply": "2026-08-11T11:01:41.498009Z"
+     "iopub.execute_input": "2026-08-15T02:41:23.552794Z",
+     "iopub.status.busy": "2026-08-15T02:41:23.543059Z",
+     "iopub.status.idle": "2026-08-15T02:41:26.785425Z",
+     "shell.execute_reply": "2026-08-15T02:41:26.779062Z"
     }
    },
    "outputs": [
@@ -71,7 +71,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-86876.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-55528.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -121,7 +121,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '86876.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '55528.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -284,10 +284,10 @@
    "id": "73198a3f-f277-4796-92fe-8b29e8caa06b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:41.510855Z",
-     "iopub.status.busy": "2026-08-11T11:01:41.509785Z",
-     "iopub.status.idle": "2026-08-11T11:01:41.839760Z",
-     "shell.execute_reply": "2026-08-11T11:01:41.838875Z"
+     "iopub.execute_input": "2026-08-15T02:41:26.787807Z",
+     "iopub.status.busy": "2026-08-15T02:41:26.787482Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.015025Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.014405Z"
     }
    },
    "outputs": [
@@ -361,10 +361,10 @@
    "id": "2d27b18d-f2ad-4eb3-acff-601ac2ee0c62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:41.842932Z",
-     "iopub.status.busy": "2026-08-11T11:01:41.842302Z",
-     "iopub.status.idle": "2026-08-11T11:01:41.952640Z",
-     "shell.execute_reply": "2026-08-11T11:01:41.951773Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.017019Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.016666Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.090339Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.090030Z"
     }
    },
    "outputs": [
@@ -479,10 +479,10 @@
    "id": "0399d8bd-7565-410a-a98e-beeff981ffbd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:41.955846Z",
-     "iopub.status.busy": "2026-08-11T11:01:41.955309Z",
-     "iopub.status.idle": "2026-08-11T11:01:42.184197Z",
-     "shell.execute_reply": "2026-08-11T11:01:42.183672Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.092199Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.091910Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.247309Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.246358Z"
     }
    },
    "outputs": [
@@ -582,10 +582,10 @@
    "id": "b2f8a6fc-8ab5-4aec-a8c0-41a1269ae658",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:42.186991Z",
-     "iopub.status.busy": "2026-08-11T11:01:42.186411Z",
-     "iopub.status.idle": "2026-08-11T11:01:42.347818Z",
-     "shell.execute_reply": "2026-08-11T11:01:42.346899Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.250523Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.250145Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.378798Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.377900Z"
     }
    },
    "outputs": [
@@ -689,10 +689,10 @@
    "id": "fe7b696e-3fa5-469f-b9ac-dcc57d5f56aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:42.351239Z",
-     "iopub.status.busy": "2026-08-11T11:01:42.350640Z",
-     "iopub.status.idle": "2026-08-11T11:01:42.474219Z",
-     "shell.execute_reply": "2026-08-11T11:01:42.473628Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.381982Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.381555Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.462549Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.462279Z"
     }
    },
    "outputs": [
@@ -758,10 +758,10 @@
    "id": "5bb025e3-5323-4163-9c22-edb7ae7a10c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:42.477526Z",
-     "iopub.status.busy": "2026-08-11T11:01:42.476813Z",
-     "iopub.status.idle": "2026-08-11T11:01:42.912145Z",
-     "shell.execute_reply": "2026-08-11T11:01:42.911494Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.464710Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.464409Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.759585Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.759137Z"
     }
    },
    "outputs": [
@@ -905,10 +905,10 @@
    "id": "516b3c7f-187f-4428-9df4-abfc2768876e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:42.915635Z",
-     "iopub.status.busy": "2026-08-11T11:01:42.914955Z",
-     "iopub.status.idle": "2026-08-11T11:01:43.096385Z",
-     "shell.execute_reply": "2026-08-11T11:01:43.095447Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.762520Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.761918Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.880379Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.879839Z"
     }
    },
    "outputs": [
@@ -947,7 +947,7 @@
     {
      "data": {
       "text/plain": [
-       "---"
+       "----"
       ]
      },
      "metadata": {},
@@ -1022,7 +1022,7 @@
     "}\n",
     "\n",
     "Analyze(pd);\n",
-    "\"---\".Display();\n",
+    "\"----\".Display();\n",
     "Analyze(stag);\n"
    ]
   },
@@ -1032,10 +1032,10 @@
    "id": "d6e925d4-e4d8-4c68-b3d6-acc2c79b42ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:43.099557Z",
-     "iopub.status.busy": "2026-08-11T11:01:43.098906Z",
-     "iopub.status.idle": "2026-08-11T11:01:43.198100Z",
-     "shell.execute_reply": "2026-08-11T11:01:43.188444Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.882828Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.882529Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.939122Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.934024Z"
     }
    },
    "outputs": [
@@ -1092,7 +1092,7 @@
     {
      "data": {
       "text/plain": [
-       "---"
+       "----"
       ]
      },
      "metadata": {},
@@ -1133,7 +1133,7 @@
     {
      "data": {
       "text/plain": [
-       "---"
+       "----"
       ]
      },
      "metadata": {},
@@ -1192,9 +1192,9 @@
    ],
    "source": [
     "Analyze(coord);\n",
-    "\"---\".Display();\n",
+    "\"----\".Display();\n",
     "Analyze(mp);\n",
-    "\"---\".Display();\n",
+    "\"----\".Display();\n",
     "Analyze(bos);\n"
    ]
   },
@@ -1246,10 +1246,10 @@
    "id": "61d56fe3-ac8a-4fbf-9250-d1a3700af34f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:43.202097Z",
-     "iopub.status.busy": "2026-08-11T11:01:43.201431Z",
-     "iopub.status.idle": "2026-08-11T11:01:43.300956Z",
-     "shell.execute_reply": "2026-08-11T11:01:43.300326Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.941352Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.941082Z",
+     "iopub.status.idle": "2026-08-15T02:41:27.992803Z",
+     "shell.execute_reply": "2026-08-15T02:41:27.992176Z"
     }
    },
    "outputs": [
@@ -1321,10 +1321,10 @@
    "id": "4e63a3e4-acc4-4c5c-b7e1-2f624b43c48f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:43.304316Z",
-     "iopub.status.busy": "2026-08-11T11:01:43.303642Z",
-     "iopub.status.idle": "2026-08-11T11:01:43.398118Z",
-     "shell.execute_reply": "2026-08-11T11:01:43.397547Z"
+     "iopub.execute_input": "2026-08-15T02:41:27.994882Z",
+     "iopub.status.busy": "2026-08-15T02:41:27.994634Z",
+     "iopub.status.idle": "2026-08-15T02:41:28.054725Z",
+     "shell.execute_reply": "2026-08-15T02:41:28.054247Z"
     }
    },
    "outputs": [
@@ -1441,10 +1441,10 @@
    "id": "gt4-gambit-helpers",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:43.401824Z",
-     "iopub.status.busy": "2026-08-11T11:01:43.401140Z",
-     "iopub.status.idle": "2026-08-11T11:01:44.025475Z",
-     "shell.execute_reply": "2026-08-11T11:01:44.024916Z"
+     "iopub.execute_input": "2026-08-15T02:41:28.057902Z",
+     "iopub.status.busy": "2026-08-15T02:41:28.057600Z",
+     "iopub.status.idle": "2026-08-15T02:41:28.433718Z",
+     "shell.execute_reply": "2026-08-15T02:41:28.432829Z"
     }
    },
    "outputs": [
@@ -1568,10 +1568,10 @@
    "id": "gt4-gambit-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:44.028723Z",
-     "iopub.status.busy": "2026-08-11T11:01:44.027927Z",
-     "iopub.status.idle": "2026-08-11T11:01:44.822677Z",
-     "shell.execute_reply": "2026-08-11T11:01:44.823122Z"
+     "iopub.execute_input": "2026-08-15T02:41:28.436249Z",
+     "iopub.status.busy": "2026-08-15T02:41:28.435936Z",
+     "iopub.status.idle": "2026-08-15T02:41:28.977165Z",
+     "shell.execute_reply": "2026-08-15T02:41:28.976744Z"
     }
    },
    "outputs": [
@@ -2097,10 +2097,10 @@
    "id": "c7fad5e7-cf5b-4609-a19d-8a7ac1b4950d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:44.826858Z",
-     "iopub.status.busy": "2026-08-11T11:01:44.826187Z",
-     "iopub.status.idle": "2026-08-11T11:01:44.944334Z",
-     "shell.execute_reply": "2026-08-11T11:01:44.943717Z"
+     "iopub.execute_input": "2026-08-15T02:41:28.979479Z",
+     "iopub.status.busy": "2026-08-15T02:41:28.979205Z",
+     "iopub.status.idle": "2026-08-15T02:41:29.066314Z",
+     "shell.execute_reply": "2026-08-15T02:41:29.066024Z"
     }
    },
    "outputs": [
@@ -2162,10 +2162,10 @@
    "id": "f4e0fce6-304e-4e34-8b6e-44011062b56b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:44.947723Z",
-     "iopub.status.busy": "2026-08-11T11:01:44.947052Z",
-     "iopub.status.idle": "2026-08-11T11:01:45.049664Z",
-     "shell.execute_reply": "2026-08-11T11:01:45.048633Z"
+     "iopub.execute_input": "2026-08-15T02:41:29.068221Z",
+     "iopub.status.busy": "2026-08-15T02:41:29.067935Z",
+     "iopub.status.idle": "2026-08-15T02:41:29.132074Z",
+     "shell.execute_reply": "2026-08-15T02:41:29.131604Z"
     }
    },
    "outputs": [
@@ -2210,10 +2210,10 @@
    "id": "a966c48a-4683-4334-a016-fec483e1777c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T11:01:45.053174Z",
-     "iopub.status.busy": "2026-08-11T11:01:45.052503Z",
-     "iopub.status.idle": "2026-08-11T11:01:45.125243Z",
-     "shell.execute_reply": "2026-08-11T11:01:45.124707Z"
+     "iopub.execute_input": "2026-08-15T02:41:29.133916Z",
+     "iopub.status.busy": "2026-08-15T02:41:29.133642Z",
+     "iopub.status.idle": "2026-08-15T02:41:29.180946Z",
+     "shell.execute_reply": "2026-08-15T02:41:29.180422Z"
     }
    },
    "outputs": [

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb
@@ -37,7 +37,6 @@
     "|-----------|--------|\n",
     "| [Infer-12-Modèles-Hiérarchiques](Infer-12-Modeles-Hierarchiques.ipynb) | [Infer-14-Sequences](Infer-14-Sequences.ipynb) |\n",
     "\n",
-    "---",
     "## Sources canoniques\n",
     "\n",
     "Ce notebook s'inscrit dans la tradition de l'inférence par maximum de vraisemblance puis bayésienne pour les réponses d'annotateurs multiples. Les modèles présentés ont des ancêtres canoniques identifiés ci-dessous, et sont développés ici en Infer.NET pour leur formulation probabiliste moderne (variables latentes + inférence variationnelle).\n",
@@ -54,7 +53,8 @@
     "| Settles, *Active Learning Literature Survey*, Computer Sciences TR 1648, U. Wisconsin-Madison | 2010 (rev 2012) | Cadre général de l'apprentissage actif (uncertainty sampling, information gain) |\n",
     "| MBML Book, *Crowdsourcing* (Chap. 7 sub-page) | en ligne | Présentation pédagogique d'ensemble sur mbmlbook.com |\n",
     "\n",
-    "> **Note de fidélité** : Le notebook développe les formalismes avec Infer.NET (VMP / EP), pas avec les algorithmes EM historiques. Les **équations** sont alignées sur Dawid-Skene 1979 et Raykar 2010 ; les **choix d'architecture** (Beta prior, Dirichlet confusion matrix, hiérarchie Community) reflètent la pratique probabiliste moderne issue de Raykar 2010 et Karger 2011.\n"
+    "> **Note de fidélité** : Le notebook développe les formalismes avec Infer.NET (VMP / EP), pas avec les algorithmes EM historiques. Les **équations** sont alignées sur Dawid-Skene 1979 et Raykar 2010 ; les **choix d'architecture** (Beta prior, Dirichlet confusion matrix, hiérarchie Community) reflètent la pratique probabiliste moderne issue de Raykar 2010 et Karger 2011.\n",
+    "\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Csharp.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "**Navigation** : [<< Sudoku-12 Z3 C#](Sudoku-12-Z3-Csharp.ipynb) | [Index](README.md) | [Sudoku-14 Retour d'expérience >>](Sudoku-14-BDD-Csharp.ipynb)\n",
     "\n",
     "---\n",
@@ -3540,7 +3540,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 9. Références & connexions\n",
     "\n",

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-13-SymbolicAutomata-Python.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "**Navigation** : [<< Sudoku-12 Z3 Python](Sudoku-12-Z3-Python.ipynb) | [Index](README.md) | [Sudoku-14 BDD Python >>](Sudoku-14-BDD-Python.ipynb)\n",
     "\n",
     "---\n",

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-13-imperfectinfo-cfr.yaml
@@ -45,6 +45,12 @@
       python_sha: b3bd262cde2415bb2c9fccc4e8bd2c81558356e9
       csharp_sha: dc7a108e1f0c0e3cbabc3110d248b992cd435b67
       reason: "Reclassification #10459 : verdict INTRINSIC bucket-3 (#10382) requalifie RECOVERABLE-LOCAL pour OpenSpiel CFR. Axe PythonNet omis de la taxonomie corrige (calque GT-17 annexe S10, #10464). Annexe section 7 ajoutee au notebook C# : pont .NET -> pyspiel demontre (pyspiel.CFRSolver 100 iters + exploitability = 0.008226 mesure depuis C#, sortie commitee). Conclusion (cell 21) requalifiee dans les 2 paragraphes (Pont Python + Parite #4956). From-scratch CFR (cells 0-20) byte-identique (source + outputs + exec_count intacts). csharp_sha avance 6f7fb500 -> dc7a108e, python_sha unchanged b3bd262c. content_*_sha omis pour cette entree : le helper de content-fingerprint utilise par les entrees precedentes n'est pas present dans le depot (aucun scripts/notebook_tools/check_twin_parity.py ni CI twin-parity ; le csharp_sha whole-blob ci-dessus est l'attestation autoritaire du changement)."
+    - date: "2026-08-15"
+      by: myia-po-2025:CoursIA-2
+      python_sha: b3bd262cde2415bb2c9fccc4e8bd2c81558356e9
+      csharp_sha: 58c97d43af3a655091418606d19b3184ba556299
+      content_python_sha: 793e5533a28e7743ae17b4738104264540f86e5ec891589c69870ebbaddb2165
+      content_csharp_sha: 48fd1b5fb6f07bf5b59f1cb09f172a34aea982fdfaf2905916266a7955c5502a
   known_differences:
     - "Rebaseline 2026-08-05 : cote Python deplace par de-pin des utilites de derniere iteration CFR (-0.033) et MCCFR (-0.055) depuis la prose (decision B #9434 : stochastic unseeded, la variabilite est la lecon -- pas de seed, reframe honnete type md#12/md#15 'Variable' + convergence de la moyenne vers Nash -1/18). Edition markdown-only, parite semantique inchangee (aucune cellule code / sortie / exec_count touchee) ; cote C# non modifie."
     - "Socle pedagogique commun : jeux a information imparfaite, Kuhn Poker (Kuhn 1950/1953) comme jeu de reference, regret matching (Hannan), CFR vanilla (Zinkevich et al. 2007) avec recursion contrefactuelle, variante CFR+ (Tammelin 2014), convergence de la strategie moyenne vers la valeur du jeu / equilibre de Nash."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
@@ -47,6 +47,12 @@
       csharp_sha: 2871c0d104edfcefe09c81fe6813d202363355b1
       content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
       content_csharp_sha: b803515e8d69793be33344dd5161cf55d6dc9e9e63ac4e76aa0b71dd4d8930be
+    - date: "2026-08-15"
+      by: myia-po-2025:CoursIA-2
+      python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
+      csharp_sha: 978594ab1a745b688d5252255c7cd00764c97421
+      content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
+      content_csharp_sha: a047d74bf1c152b53728d3c41ceb3373b803406c75fe5bf033443e532cd26aea
   known_differences:
     - "2026-08-11 : C.4 enrichment du twin C# (2 cellules markdown interpretation apres les outputs Nash pur §2.1 + Nash mixte) pour egaler la densite pedagogique du twin Python (qui fournit deja ces lectures aux memes positions). Markdown-only, aucun changement d'engine/outputs. Parite semantique preservee (meme theorie, meme interpretation conceptuelle). Attestation rebaselinee par myia-po-2023:CoursIA-2 apres arbitrage ai-01 (DM 2026-08-11) — la PR jumelle #10351 (doublon) est retiree, #10352 est le canonique."
     - "Socle pedagogique commun : calcul des equilibres de Nash (purs + mixtes), meilleure reponse, support des equilibres mixtes."

--- a/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
@@ -10,6 +10,12 @@
       by: myia-po-2023:CoursIA
       python_sha: 246ba905ee53e1dcbae37a711e47a1622eac72b7
       csharp_sha: bc9a5dc802eb397cff7bc8aa0e7dc270c3e0f8d4
+    - date: "2026-08-15"
+      by: myia-po-2025:CoursIA-2
+      python_sha: 246ba905ee53e1dcbae37a711e47a1622eac72b7
+      csharp_sha: cd3a596713c655135eb79b91dabd651fa03f0d35
+      content_python_sha: e13cd18278d50e554dba2ee3c64b36240335c15b36ece62fc85157d210ceba0d
+      content_csharp_sha: 4969d2c94028ae4c3a0bc56e4a46155bc47d87c5bba59422e3b3a2b3e2b1425e
   known_differences:
   - '2026-07-28 (myia-po-2023) #8711 / See #8081 : FERME l''asymetrie sources entre jumeaux -- Infer-13 portait une
     cellule "Sources canoniques" (table Raykar 2010, Karger 2011, Dawid-Skene 1979, Whitehill 2009, Kim-Ghahramani

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-13-symbolicautomata.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-13-symbolicautomata.yaml
@@ -52,6 +52,12 @@
       csharp_sha: e522b8136ebd0557082ef7b18500e610926253ea
       content_python_sha: 5fafa4c8e30f31c83682ae225739e47f7cccee75094e9347bedc66bfc38fd794
       content_csharp_sha: 689d66eb48077664353e1c3f3a717571c961bad8b5127a84317dd73f26455df3
+    - date: "2026-08-15"
+      by: myia-po-2025:CoursIA-2
+      python_sha: 2b2723319e6f701beed14734f6924b0f6319241b
+      csharp_sha: 5d7af1b6a0f54605bab53ac5a0b8a98ffa44c71a
+      content_python_sha: 48c7c5a685b64aff0d09c568a5eef72b541133103c1a03afe31f87a80ae9537b
+      content_csharp_sha: b05cbde37e91715c003aa7f345e15cc7e9c9af2a96bc89c88fddb6ccc9c98ffe
   known_differences:
     - "Socle pedagogique commun : automates symboliques et resolution de Sudoku via Z3 (automates finis symboliques, representation symbolique des contraintes, liens avec SMT). Meme concept (automates symboliques + Z3 comme backend de decision), meme cas d'application (Sudoku). Les deux couvrent Z3, z3, symbolic, Solver."
     - "Divergence d'implementation : le C# (Microsoft.Z3 via NuGet + auto-suffisant en annexe S10, 19 cellules code apres #10459) utilise la theorie des chaines Z3 et la regle `re.++` / `re.*` / `re.range` / `str.to_re` pour la partie symbolique. Le Python (pyz3, 10 cellules code) utilise les bindings Z3 directement. Meme enseignement (automates symboliques + Z3), deux niveaux."

--- a/scripts/regen_quarto_render.py
+++ b/scripts/regen_quarto_render.py
@@ -59,14 +59,17 @@ EXCLUDE_MARKERS = (
     "\\archive\\",
 )
 
-# Notebooks rendered to HTML (EPIC #10921). Pilot = the Search series only
-# (#10923 Phase A); extending to other series = adding a subtree here. The
-# root execute block (_quarto.yml) already carries enabled: false + echo: true
-# for every notebook — a directory-scoped _quarto.yml is NOT applied to .ipynb
-# (measured firsthand sur Quarto 1.7.32, pin d'origine du pilote), so no
-# per-subtree override exists.
+# Notebooks rendered to HTML (EPIC #10921). Pilot = Search (#10923 Phase A);
+# tranche 2 = Sudoku + GameTheory + Probas (#10923, les 3 familles deja
+# surfacees par la navbar — la nav ne doit mener a aucun non-rendu). The root
+# execute block (_quarto.yml) already carries enabled: false + echo: true for
+# every notebook — a directory-scoped _quarto.yml is NOT applied to .ipynb in
+# Quarto 1.7.32 (measured firsthand), so no per-subtree override exists.
 NOTEBOOK_SUBTREES = (
-    "MyIA.AI.Notebooks/Search/",  # pilote #10923 — voir EPIC #10921 pour l'extension
+    "MyIA.AI.Notebooks/Search/",      # pilote #10923 (111 rendus apres exclusions)
+    "MyIA.AI.Notebooks/Sudoku/",      # tranche 2 #10923 (37)
+    "MyIA.AI.Notebooks/GameTheory/",  # tranche 2 #10923 (56)
+    "MyIA.AI.Notebooks/Probas/",      # tranche 2 #10923 (58)
 )
 
 # Notebook subtrees that must NOT render (archived families only — vendored


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #11005

See #10923 (tranche 2 — les 3 familles deja surfacees par la navbar)

## Resume

Etendre la render list Quarto du pilote (Search seul) a **Sudoku (37) + GameTheory (56) + Probas (58) = 151 notebooks**, pour qu'aucune entree de la navbar ne mene a du non-rendu (les trois familles y sont deja annoncees).

`NOTEBOOK_SUBTREES` dans `scripts/regen_quarto_render.py` passe de 1 a 4 sous-arbres. Un notebook corrige (fix YAML class D, voir Validation §2) ; `_quarto.yml` **byte-identique a main** (la liste est regeneree par le workflow au deploy, catalog-pr-hygiene R1).

## Changements

- `scripts/regen_quarto_render.py` : `NOTEBOOK_SUBTREES` += `Sudoku/`, `GameTheory/`, `Probas/`.
- `MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb` : fix YAML metadata crash (classe D) — `"---".Display()` -> `"----".Display()` dans les cellules 16/17 (separateur = 4 tirets, thematic break, plus un opener YAML). Re-exec .NET (nbconvert, kernel `.net-csharp`) + strip_probe_banner. Le crash n'existait pas avant cette tranche (jamais rendu) ; les 2 outputs `---` (fermeture de bloc YAML pandoc, cf readqmd.lua) ne se produisaient que sous le premier rendu.
- Rebaseline twin-parity #8057 de la paire `GameTheory-4 NashEquilibrium` (change du sha content du twin C#).

## Validation

1. **151 notebooks des 3 familles dans le bloc `render:`** via `regen_quarto_render.py` (pas a la main) : `python scripts/regen_quarto_render.py` produit **269 notebooks** (118 Search dont les 7 anciennement exclus — App-9b + MGS-* —, + 151 tranche 2). Verifie sur le worktree, meme etape que CI pre-render. Exclusions ajoutees : aucune (les 7 sont sains sous 1.10.18, voir #11005).
2. **Duree du deploiement mesuree** (1.10.18, worktree, regen pre-render comme CI, `quarto render --to html`) : **16m16s** pour 710 documents, rc=0. Avant (pilote Search seul, ai-01 sur `a89b729c`) : **13 min**. Soit ~1,4 s/doc — dans le plafond des 30 min de la tranche bornee.
   - **Fix YAML classe D embarque** : `GameTheory-4-NashEquilibrium-Csharp.ipynb` rendait en echec (`Error parsing YAML metadata at line 762` — 2 outputs `---` de `"---".Display()` = paire open/close de bloc YAML pandoc). Isolé par bisection (cellule 17, outputs 5/9) + rendu isolé; fix `"----"` + re-exec .NET, rendu isolé vert.
3. **1 notebook par famille verifie en vision** (capture, pas `test -f`) :
   - **Sudoku** : `Sudoku-1-Backtracking-Csharp.ipynb` (.NET) — capture `sudoku1_csharp_render.png`, code colore + sortie visibles.
   - **GameTheory** : `GameTheory-10-ForwardInduction-SPE-Csharp.ipynb` (.NET) — capture `gametheory10_csharp_render.png`.
   - **Probas** : `DecInfer-1-Utility-Foundations.ipynb` (Infer.NET) — capture `decinfer1_render_full.png`.
   - **>= 1 .NET** : oui, les trois candidats retenus sont des twins C#/.NET.
4. **Catalogue byte-identique** : aucun fichier catalogue / marqueur CATALOG-STATUS dans le diff.
5. Base fraiche : rebasee sur `origin/main` `b02ee0be8` (8 commits incluant #11005). Conflit resolu sur `regen_quarto_render.py` (commentaire exclude-files garde = version main).

## Note de merge order

La pin **Quarto 1.10.18** (#11005) est **deja sur main** (42ee1b8cd) : le filtre lua 1.7.32 qui pend (bug #10968) ne menace plus les 151 nouveaux. Le rendu complet tranche 2 valide en conditions CI (regen pre-render + `quarto render`, 710 docs, rc=0, 16m16s).
