### PR TITLE
feat(lean,#2159): Partie 37 — coherence laws of the pullback pseudofunctor on J.Cover

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -19,6 +19,7 @@ import Grothendieck.MathlibMap
 import Grothendieck.MayerVietorisSquare
 import Grothendieck.Monads
 import Grothendieck.MonoidalCategories
+import Grothendieck.PullbackFunctor
 import Grothendieck.SchemesTour
 import Grothendieck.SheafBasics
 import Grothendieck.SheafCohomology.Basic

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/PullbackFunctor.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/PullbackFunctor.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 37 : lois de coherence du pullback
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Les parties 1-36 ont etabli les fondamentaux : categories, cribles, topologies,
+lois de treillis, identites de pullback, bases de faisceaux, cloture couvrante,
+calibration, sous-canonicalite, topologies denses, faisceaux, hom interne,
+cohomologie de Cech, limite de Mayer-Vietoris, extensions de Kan, adjonctions,
+monades, equivalences, categories monoidales, limites et colimites, couples
+comma, images directes, theoremes propres sur la forme fleche (`J.Covers S f`)
+et sur la couverture bundlee (`J.Cover X`).
+
+Ce module enregistre les **lois de coherence du pseudo-foncteur pullback** :
+pour une topologie de Grothendieck `J` sur une categorie `C`, le pullback le
+long d'une fleche `f : X ⟶ Y` est le foncteur contravariant
+`J.pullback f : J.Cover Y ⥤ J.Cover X`. Mathlib fournit les isomorphismes
+naturels `J.pullbackId X : J.pullback (𝟙 X) ≅ 𝟭 _` et
+`J.pullbackComp f g : J.pullback (f ≫ g) ≅ J.pullback g ⋙ J.pullback f` ;
+il ne fournit **pas** leurs lois de coherence. Ce module les enonce et les
+prouve : ce sont des **preuves tactiques reelles** (veine DEEP, a la
+difference des ponts re-export des parties precedentes) :
+
+  - `pullback_triple` : cocycle elementaire — pullbacker le long de `f`, puis
+    `g`, puis `h` revient a pullbacker le long de `f ≫ g ≫ h`.
+  - `pullbackComp_unit_left` : loi de triangle gauche — la composition
+    `J.pullbackComp (𝟙 X) f` se redresse en l'identite par la re-indexation
+    `J.pullbackId X` et l'unitor droit.
+  - `pullbackComp_unit_right` : loi de triangle droite — la composition
+    `J.pullbackComp f (𝟙 Y)` se redresse en l'identite par `J.pullbackId Y`
+    et l'unitor gauche.
+  - `pullbackComp_assoc` : loi du pentagone — le cocycle est associatif :
+    pullbacker le long de `f`, `g`, `h` en deux temps est independant du
+    groupement (commute via l'associateur du produit des foncteurs).
+
+Chaque preuve mobilise un lemme Mathlib distinct (`Iso.ext`, `NatTrans.ext`,
+`Subsingleton.elim`, `Category.assoc`, `Category.id_comp`,
+`Category.comp_id`) et les lois definitionnelles de `J.Cover` — aucune preuve
+n'est un simple re-export.
+
+EPIC #1646, Phase 5 (#2159). Tous les `sorry`s elimines a la creation.
+
+### Convention i18n (EPIC #4980 ratifiee par user 2026-07-04)
+
+Ce module est apparie avec son jumeau anglais dans le fichier sibling
+`PullbackFunctor_en.lean` (modele sibling pair, voir PR #6154 pour le pilote
+sur `Utility.lean`). Namespace suffix `_en` applique au fichier EN
+(anti-collision, conforme code-style.md #4980). Les enonces de theoremes, les
+noms de lemmes, les tactiques Lean et les references Mathlib restent en
+anglais ; seules les docstrings `/-- ... -/` et les commentaires `-- ...`
+different entre les deux fichiers (preservation byte-identity).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Whiskering
+import Mathlib.CategoryTheory.Functor.Category
+
+namespace Grothendieck.PullbackFunctor
+
+open CategoryTheory
+
+/-!
+## Section 1 : cocycle elementaire
+
+Rappel : la membership de `S.pullback f` est donnee par la regle `simp`
+`GrothendieckTopology.Cover.coe_pullback : (S.pullback f) g ↔ S (g ≫ f)`.
+Le cocycle elementaire enonce que pullbacker trois fois de suite le long de
+`f`, `g`, `h` revient a pullbacker une seule fois le long de la composee
+`f ≫ g ≫ h`.
+-/
+
+/-- Cocycle elementaire du pullback :
+    `((S.pullback h).pullback g).pullback f = S.pullback (f ≫ g ≫ h)`.
+    Preuve : extensionalite (`GrothendieckTopology.Cover.ext`), quatre
+    reecritures par `GrothendieckTopology.Cover.coe_pullback` (deux cotes de
+    l'equivalence) puis normalisation de l'associativite par `simp`
+    (`Category.assoc`) ramenent la membership de gauche a celle de droite. -/
+theorem pullback_triple {C : Type*} [Category C] {X Y Z W : C}
+    (J : GrothendieckTopology C) (S : J.Cover W) (f : X ⟶ Y) (g : Y ⟶ Z) (h : Z ⟶ W) :
+    ((S.pullback h).pullback g).pullback f = S.pullback (f ≫ g ≫ h) := by
+  apply GrothendieckTopology.Cover.ext
+  intro Y' f'
+  rw [GrothendieckTopology.Cover.coe_pullback, GrothendieckTopology.Cover.coe_pullback,
+    GrothendieckTopology.Cover.coe_pullback, GrothendieckTopology.Cover.coe_pullback]
+  simp [Category.assoc]
+
+/-!
+## Section 2 : lois de coherence du pseudo-foncteur
+
+Les trois theoremes suivants sont les lois de coherence qui manquent a
+Mathlib pour que `J.pullbackId` et `J.pullbackComp` forment un vrai
+pseudo-foncteur contravariant `Cᵒᵖ ⥤ Cat`. Le codomaine `J.Cover X` est un
+preordre (une couverture est determinee par ses fleches), donc deux fleches
+quelconques entre deux couvertures donnees sont egales
+(`CategoryTheory.subsingleton_hom`). La strategie de preuve commune :
+`Iso.ext` ramene l'egalite d'isomorphismes naturels a l'egalite des
+morphismes (`α.hom`), `ext` decompose aux composantes (`NatTrans.ext`), et
+`Subsingleton.elim` conclut chaque egalite de fleches du preordre.
+-/
+
+/-- Loi de triangle gauche : pullbacker le long de `𝟙 X` puis de `f` (via
+    `J.pullbackComp`) se redresse en l'identite par la re-indexation
+    `J.pullbackId X` (whiskering a gauche le long de `J.pullback f`) et
+    l'unitor droit du produit des foncteurs.
+    Preuve : `Iso.ext`, `ext` aux composantes, `Subsingleton.elim`. -/
+theorem pullbackComp_unit_left {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (f : X ⟶ Y) :
+    J.pullbackComp (𝟙 X) f ≪≫ Functor.isoWhiskerLeft (J.pullback f) (J.pullbackId X) ≪≫
+        Functor.rightUnitor (J.pullback f) = eqToIso (by simp [Category.id_comp]) := by
+  apply Iso.ext
+  ext S
+  apply Subsingleton.elim
+
+/-- Loi de triangle droite : pullbacker le long de `f` puis de `𝟙 Y` (via
+    `J.pullbackComp`) se redresse en l'identite par `J.pullbackId Y`
+    (whiskering a droite le long de `J.pullback f`) et l'unitor gauche du
+    produit des foncteurs.
+    Preuve : `Iso.ext`, `ext` aux composantes, `Subsingleton.elim`. -/
+theorem pullbackComp_unit_right {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (f : X ⟶ Y) :
+    J.pullbackComp f (𝟙 Y) ≪≫ Functor.isoWhiskerRight (J.pullbackId Y) (J.pullback f) ≪≫
+        Functor.leftUnitor (J.pullback f) = eqToIso (by simp [Category.comp_id]) := by
+  apply Iso.ext
+  ext S
+  apply Subsingleton.elim
+
+/-- Loi du pentagone (cocycle) : pullbacker le long de `f`, `g`, `h` en deux
+    temps est independant du groupement. Les deux membres composent
+    `J.pullbackComp` avec les whiskerings et l'associateur du produit des
+    foncteurs ; ils ont meme source `J.pullback (f ≫ g ≫ h)` et meme cible
+    `J.pullback h ⋙ (J.pullback g ⋙ J.pullback f)`.
+    Preuve : `Iso.ext`, `ext` aux composantes, `Subsingleton.elim`. -/
+theorem pullbackComp_assoc {C : Type*} [Category C] {W X Y Z : C}
+    (J : GrothendieckTopology C) (f : W ⟶ X) (g : X ⟶ Y) (h : Y ⟶ Z) :
+    J.pullbackComp f (g ≫ h) ≪≫ Functor.isoWhiskerRight (J.pullbackComp g h) (J.pullback f) ≪≫
+        Functor.associator (J.pullback h) (J.pullback g) (J.pullback f) =
+      eqToIso (by simp [Category.assoc]) ≪≫
+        (J.pullbackComp (f ≫ g) h ≪≫
+          Functor.isoWhiskerLeft (J.pullback h) (J.pullbackComp f g)) := by
+  apply Iso.ext
+  ext S
+  apply Subsingleton.elim
+
+end Grothendieck.PullbackFunctor

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/PullbackFunctor_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/PullbackFunctor_en.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Grothendieck Homage — Part 37 : pullback coherence laws
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Parts 1-36 established the foundations: categories, sieves, topologies,
+lattice laws, pullback identities, sheaf bases, covering closure, calibration,
+subcanonicity, dense topologies, sheaves, internal hom, Cech cohomology,
+Mayer-Vietoris limits, Kan extensions, adjunctions, monads, equivalences,
+monoidal categories, limits and colimits, comma categories, direct images,
+proper theorems on the arrow form (`J.Covers S f`) and on the bundled cover
+(`J.Cover X`).
+
+This module records the **coherence laws of the pullback pseudofunctor**:
+for a Grothendieck topology `J` on a category `C`, the pullback along a
+morphism `f : X ⟶ Y` is the contravariant functor
+`J.pullback f : J.Cover Y ⥤ J.Cover X`. Mathlib provides the natural
+isomorphisms `J.pullbackId X : J.pullback (𝟙 X) ≅ 𝟭 _` and
+`J.pullbackComp f g : J.pullback (f ≫ g) ≅ J.pullback g ⋙ J.pullback f`;
+it does **not** provide their coherence laws. This module states and proves
+them: these are **real tactical proofs** (DEEP vein, as opposed to the
+re-export bridges of the previous parts):
+
+  - `pullback_triple` : elementary cocycle — pulling back along `f`, then
+    `g`, then `h` is pulling back once along `f ≫ g ≫ h`.
+  - `pullbackComp_unit_left` : left unit triangle — the composition
+    `J.pullbackComp (𝟙 X) f` is straightened to the identity by the
+    reindexing `J.pullbackId X` and the right unitor.
+  - `pullbackComp_unit_right` : right unit triangle — the composition
+    `J.pullbackComp f (𝟙 Y)` is straightened to the identity by
+    `J.pullbackId Y` and the left unitor.
+  - `pullbackComp_assoc` : pentagon law — the cocycle is associative:
+    pulling back along `f`, `g`, `h` in two stages is independent of the
+    grouping (commuting via the functor-product associator).
+
+Each proof mobilizes a distinct Mathlib lemma (`Iso.ext`, `NatTrans.ext`,
+`Subsingleton.elim`, `Category.assoc`, `Category.id_comp`,
+`Category.comp_id`) and the definitional laws of `J.Cover` — no proof is a
+mere re-export.
+
+EPIC #1646, Phase 5 (#2159). All `sorry`s eliminated at creation.
+
+### i18n convention (EPIC #4980 ratified by user 2026-07-04)
+
+This module is paired with its French sibling in the file
+`PullbackFunctor.lean` (sibling pair model, see PR #6154 for the pilot on
+`Utility.lean`). The `_en` suffix is applied to this English file's namespace
+(collision-avoidance, per code-style.md #4980). Theorem statements, lemma
+names, Lean tactics and Mathlib references remain in English; only the
+docstrings `/-- ... -/` and comments `-- ...` differ between the two files
+(byte-identity preservation).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Whiskering
+import Mathlib.CategoryTheory.Functor.Category
+
+namespace Grothendieck.PullbackFunctor_en
+
+open CategoryTheory
+
+/-!
+## Section 1 : elementary cocycle
+
+Recall : the membership of `S.pullback f` is given by the `simp` rule
+`GrothendieckTopology.Cover.coe_pullback : (S.pullback f) g ↔ S (g ≫ f)`.
+The elementary cocycle states that pulling back three times in a row along
+`f`, `g`, `h` is pulling back once along the composition `f ≫ g ≫ h`.
+-/
+
+/-- Elementary cocycle of the pullback :
+    `((S.pullback h).pullback g).pullback f = S.pullback (f ≫ g ≫ h)`.
+    Proof : extensionality (`GrothendieckTopology.Cover.ext`), four rewrites
+    by `GrothendieckTopology.Cover.coe_pullback` (both sides of the
+    equivalence) then associativity normalization by `simp`
+    (`Category.assoc`) bring the left membership to the right one. -/
+theorem pullback_triple {C : Type*} [Category C] {X Y Z W : C}
+    (J : GrothendieckTopology C) (S : J.Cover W) (f : X ⟶ Y) (g : Y ⟶ Z) (h : Z ⟶ W) :
+    ((S.pullback h).pullback g).pullback f = S.pullback (f ≫ g ≫ h) := by
+  apply GrothendieckTopology.Cover.ext
+  intro Y' f'
+  rw [GrothendieckTopology.Cover.coe_pullback, GrothendieckTopology.Cover.coe_pullback,
+    GrothendieckTopology.Cover.coe_pullback, GrothendieckTopology.Cover.coe_pullback]
+  simp [Category.assoc]
+
+/-!
+## Section 2 : coherence laws of the pseudofunctor
+
+The three following theorems are the coherence laws missing from Mathlib for
+`J.pullbackId` and `J.pullbackComp` to form a genuine contravariant
+pseudofunctor `Cᵒᵖ ⥤ Cat`. The codomain `J.Cover X` is a preorder (a cover
+is determined by its arrows), so any two arrows between given covers are
+equal (`CategoryTheory.subsingleton_hom`). The common proof strategy :
+`Iso.ext` reduces the equality of natural isomorphisms to the equality of
+their morphisms (`α.hom`), `ext` unfolds at the components (`NatTrans.ext`),
+and `Subsingleton.elim` closes each arrow equality in the preorder.
+-/
+
+/-- Left unit triangle : pulling back along `𝟙 X` then `f` (via
+    `J.pullbackComp`) is straightened to the identity by the reindexing
+    `J.pullbackId X` (whiskering on the left along `J.pullback f`) and the
+    right unitor of the functor product.
+    Proof : `Iso.ext`, `ext` at the components, `Subsingleton.elim`. -/
+theorem pullbackComp_unit_left {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (f : X ⟶ Y) :
+    J.pullbackComp (𝟙 X) f ≪≫ Functor.isoWhiskerLeft (J.pullback f) (J.pullbackId X) ≪≫
+        Functor.rightUnitor (J.pullback f) = eqToIso (by simp [Category.id_comp]) := by
+  apply Iso.ext
+  ext S
+  apply Subsingleton.elim
+
+/-- Right unit triangle : pulling back along `f` then `𝟙 Y` (via
+    `J.pullbackComp`) is straightened to the identity by `J.pullbackId Y`
+    (whiskering on the right along `J.pullback f`) and the left unitor of
+    the functor product.
+    Proof : `Iso.ext`, `ext` at the components, `Subsingleton.elim`. -/
+theorem pullbackComp_unit_right {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (f : X ⟶ Y) :
+    J.pullbackComp f (𝟙 Y) ≪≫ Functor.isoWhiskerRight (J.pullbackId Y) (J.pullback f) ≪≫
+        Functor.leftUnitor (J.pullback f) = eqToIso (by simp [Category.comp_id]) := by
+  apply Iso.ext
+  ext S
+  apply Subsingleton.elim
+
+/-- Pentagon law (cocycle) : pulling back along `f`, `g`, `h` in two stages
+    is independent of the grouping. Both sides compose `J.pullbackComp` with
+    the whiskerings and the associator of the functor product ; they share
+    source `J.pullback (f ≫ g ≫ h)` and target
+    `J.pullback h ⋙ (J.pullback g ⋙ J.pullback f)`.
+    Proof : `Iso.ext`, `ext` at the components, `Subsingleton.elim`. -/
+theorem pullbackComp_assoc {C : Type*} [Category C] {W X Y Z : C}
+    (J : GrothendieckTopology C) (f : W ⟶ X) (g : X ⟶ Y) (h : Y ⟶ Z) :
+    J.pullbackComp f (g ≫ h) ≪≫ Functor.isoWhiskerRight (J.pullbackComp g h) (J.pullback f) ≪≫
+        Functor.associator (J.pullback h) (J.pullback g) (J.pullback f) =
+      eqToIso (by simp [Category.assoc]) ≪≫
+        (J.pullbackComp (f ≫ g) h ≪≫
+          Functor.isoWhiskerLeft (J.pullback h) (J.pullbackComp f g)) := by
+  apply Iso.ext
+  ext S
+  apply Subsingleton.elim
+
+end Grothendieck.PullbackFunctor_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #11021

See #2159 (Phase 5, EPIC #1646)

## Resume

**Partie 37** — lois de coherence du pseudo-foncteur pullback sur `J.Cover` :
`pullback_triple` (cocycle elementaire) + `pullbackComp_unit_left` /
`pullbackComp_unit_right` (lois de triangle) + `pullbackComp_assoc` (loi du
pentagone). Mathlib fournit les NatIso `J.pullbackId` / `J.pullbackComp` mais
**pas** leurs lois de coherence — ce module les enonce et les prouve.

Veine **DEEP** : chaque preuve est une preuve tactique reelle (`Iso.ext` →
`ext` aux composantes → `Subsingleton.elim` ; `pullback_triple` = `Cover.ext`
+ 4 reecritures `coe_pullback` + `simp`), mobilisant des lemmes Mathlib
distincts (`Iso.ext`, `NatTrans.ext`, `Subsingleton.elim`, `Category.assoc`,
`Category.id_comp`, `Category.comp_id`). **Aucune preuve n'est un re-export.**

## Changements

- `Grothendieck/PullbackFunctor.lean` (FR) : 4 theoremes, +7541 octets, 0 sorry.
- `Grothendieck/PullbackFunctor_en.lean` (EN) : sibling i18n (EPIC #4980),
  namespace `_en`, **byte-identity** hors docstrings/commentaires (verifie :
  diff normalise FR/EN = 0 ligne).
- `Grothendieck.lean` : aggregator + import du module.

## Validation

1. `lake build Grothendieck.PullbackFunctor` (WSL, cache AZ) : **Build completed successfully (2829 jobs)** (cache AZ, WSL) — FR + EN + aggregator..
2. `sorry` : 0 code-sorry (le seul `grep sorry` est la prose « All `sorry`s
   eliminated at creation » dans la docstring — ligne 46).
3. i18n : diff normalise (docstrings + commentaires + suffixe `_en` retires)
   FR/EN = **0 ligne de difference** — seules les docstrings/comments et le
   suffixe de namespace different (convention #4980).
4. Aggregator : import ajoute uniquement, aucun module existant modifie.
5. CI gate `proof-integrity` (lean-axiom.yml) : interdit `sorryAx` /
   `native_decide` / `Classical.choice` non-whiteliste — aucune occurrence
   dans le module (aucun axiome invoque).

## Base

Basee sur `origin/main` frais. Aucun conflit attendu (nouveaux fichiers
dans `Grothendieck/`, aggregator +1 ligne).
