### PR TITLE
feat(guard,#10983): variation-tag-guard measures prev: presence — label variation-tag-prev-absent

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -156,6 +156,19 @@ jobs:
               echo "::warning::Aucune 'lane <machine:workspace>' declaree. G-VAR-2 est un cap PAR LANE et PAR JOUR : un grain sans lane est structurellement incomptable, et le cap devient inapplicable sans que personne ne l'ait contourne (§3)."
               note_defect variation-tag-lane-missing
             fi
+
+            # `prev:` -- le champ qui rend G-VAR-3 EVALUABLE (adjacence de
+            # genre). Le guard ne le mesurait pas (#10983) : un tag sans
+            # `prev:` traversait les deux jobs en silence et l'adjacence ne
+            # s'evaluait qu'a la main, apres merge. Forme canonique :
+            # `prev: <TIER>/<GENRE> #<PR>`. Exemption premier grain d'une
+            # lane : `prev: none (premier grain)` (parse_prev -> exempt).
+            PREV_PRESENT=$(_field prev_present)
+            PREV_EXEMPT=$(_field prev_exempt)
+            if [ "$PREV_PRESENT" = "False" ] && [ "$PREV_EXEMPT" != "True" ]; then
+              echo "::warning::Champ 'prev:' absent du tag. variation-protocol §1 le rend obligatoire (support mecanique de G-VAR-3 : pas deux fois le meme GENRE LIGHT consecutif). Forme : prev: <TIER>/<GENRE> #<PR>. Premier grain d'une lane : prev: none (premier grain)."
+              note_defect variation-tag-prev-absent
+            fi
           else
             # Substance absente (TIER/GENRE introuvable) : l'unique cas ou la
             # tolerance s'arrete. Les formes titre/bold/no-colon sont couvertes
@@ -174,12 +187,13 @@ jobs:
           # de contexte `gh` invisible (#8786). Un garde dont l'echec est muet
           # n'est pas un garde. Sur les `remove`, `2>/dev/null` reste justifie :
           # retirer un label absent est l'issue ATTENDUE au cas nominal.
-          for LABEL in variation-tag-missing variation-tag-malformed variation-tag-genre-offlist variation-tag-lane-missing; do
+          for LABEL in variation-tag-missing variation-tag-malformed variation-tag-genre-offlist variation-tag-lane-missing variation-tag-prev-absent; do
             case "$LABEL" in
               variation-tag-missing)          COLOR="FBCA04"; DESC="PR sans tag Grain: <TIER>/<GENRE> (variation-protocol)" ;;
               variation-tag-malformed)       COLOR="FEF2C0"; DESC="Tag Grain present mais TIER != DEEP|MED|LIGHT" ;;
               variation-tag-genre-offlist)   COLOR="FEF2C0"; DESC="GENRE hors de l'enumeration variation-protocol §1" ;;
               variation-tag-lane-missing)    COLOR="FEF2C0"; DESC="Tag Grain sans 'lane <machine:workspace>' (cap G-VAR-2 incomptable)" ;;
+              variation-tag-prev-absent)     COLOR="FEF2C0"; DESC="Tag Grain sans 'prev: <TIER>/<GENRE> #<PR>' (adjacence G-VAR-3 inevaluable)" ;;
             esac
             case " $DEFECTS " in
               *" $LABEL "*)
@@ -193,7 +207,7 @@ jobs:
           done
 
           if [ -z "$DEFECTS" ]; then
-            echo "Tag conforme : TIER + GENRE dans la liste §1 + lane declaree."
+            echo "Tag conforme : TIER + GENRE dans la liste §1 + lane declaree + prev: (ou exemption premier grain)."
           else
             echo "Defauts signales (advisory, non bloquant) :$DEFECTS"
           fi

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -175,6 +175,12 @@ _PREV_RE = re.compile(
     r"prev\s*:?\s*([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)", re.IGNORECASE
 )
 
+# `prev: none (premier grain)` -- the FIRST-grain exemption of a lane
+# (#10983, variation-protocol §1). `none` is not a canonical genre: the token
+# (followed by an optional parenthetical) marks "this lane has no predecessor
+# to cite" and must NOT be flagged as a missing prev: by the guard.
+_PREV_NONE_RE = re.compile(r"prev\s*:?\s*none\b", re.IGNORECASE)
+
 # GitHub auto-close keywords (case-insensitive) -- the exact set GitHub
 # recognises in commit messages + PR bodies + PR titles
 # (https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue).
@@ -217,6 +223,44 @@ def find_prev_close_keywords(text: str | None) -> list[dict]:
         if genre in CLOSING_KEYWORDS:
             hits.append({"tier": m.group(1).upper(), "genre": genre})
     return hits
+
+
+def parse_prev(body: str | None) -> dict:
+    """Extract the `prev:` field of a Grain tag (#10983).
+
+    Returns ``{"present", "exempt", "tier", "genre", "pr_number"}``. The
+    canonical form is ``prev: <TIER>/<GENRE> #<PR>`` (the PR reference is
+    optional but the TIER/GENRE pair is not). ``present`` is False when no
+    `prev:` field carries a TIER/GENRE pair; ``exempt`` is True for the
+    first-grain exemption ``prev: none (premier grain)`` -- a lane with no
+    predecessor to cite must not be flagged. The guard reads this JSON to
+    pose `variation-tag-prev-absent` on a tag that declares no predecessor
+    at all: without it, G-VAR-3 adjacency is evaluable only by hand
+    reconstruction of the lane history (the gap #10983 measures).
+
+    Same noise discipline as ``parse_grain_tag``: bold / backticks /
+    blockquotes stripped, title hashes stripped on recognised key lines.
+    """
+    out = {"present": False, "exempt": False, "tier": None, "genre": None,
+           "pr_number": None}
+    if not body:
+        return out
+    flat = _strip_title_hashes(body.translate(_NOISE))
+    if _PREV_NONE_RE.search(flat):
+        out["exempt"] = True
+        return out
+    m = _PREV_RE.search(flat)
+    if not m:
+        return out
+    out["present"] = True
+    out["tier"] = m.group(1).upper()
+    out["genre"] = m.group(2).lower()
+    # PR reference: the `#N` right after the genre (`prev: MED/tooling #11021`
+    # or `prev: MED/tooling #11021 (c.42)`), scanned in the tail of the field.
+    pr_m = re.search(r"#(\d+)", flat[m.end():m.end() + 120])
+    if pr_m:
+        out["pr_number"] = int(pr_m.group(1))
+    return out
 
 
 # Matches `<closing-keyword> #N` in free prose (#10101). The keyword set is
@@ -550,6 +594,8 @@ def main(argv: list[str] | None = None) -> int:
         # reported anyway (its own job consumes it).
         print(json.dumps({"present": False, "tier": None, "genre": None,
                           "lane": None, "tier_valid": False, "genre_valid": False,
+                          "prev_present": False, "prev_exempt": False,
+                          "prev_tier": None, "prev_genre": None, "prev_pr": None,
                           "quoi": sh["quoi"], "preuve": sh["preuve"],
                           "perimetre": sh["perimetre"],
                           "short_header_complete": short_complete,
@@ -557,6 +603,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     tier_valid = g["tier"] in TIERS
     genre_valid = g["genre"] in GENRES
+    pv = parse_prev(body)
     print(json.dumps({
         "present": True,
         "tier": g["tier"],
@@ -564,6 +611,11 @@ def main(argv: list[str] | None = None) -> int:
         "lane": g["lane"],
         "tier_valid": tier_valid,
         "genre_valid": genre_valid,
+        "prev_present": pv["present"],
+        "prev_exempt": pv["exempt"],
+        "prev_tier": pv["tier"],
+        "prev_genre": pv["genre"],
+        "prev_pr": pv["pr_number"],
         "quoi": sh["quoi"],
         "preuve": sh["preuve"],
         "perimetre": sh["perimetre"],

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -481,6 +481,56 @@ def test_prev_close_keyword_multiple_prevs():
     assert genres == {"fix", "closes"}
 
 
+def test_parse_prev_canonical_with_pr():
+    # Canonical form: `prev: <TIER>/<GENRE> #<PR>` -- the guard reads this to
+    # keep the adjacency G-VAR-3 evaluable mechanically (#10983).
+    r = gt.parse_prev(
+        "Grain: MED/tooling -- lane myia-po-2025:CoursIA-2 -- prev: MED/tooling #11021 (c.164)"
+    )
+    assert r == {"present": True, "exempt": False, "tier": "MED",
+                 "genre": "tooling", "pr_number": 11021}
+
+
+def test_parse_prev_canonical_without_pr():
+    # PR reference optional -- the TIER/GENRE pair is what traces adjacency.
+    r = gt.parse_prev("Grain: DEEP/lean -- lane myia-po-2025:CoursIA-2 -- prev: DEEP/lean #10912")
+    assert r["present"] is True
+    assert r["genre"] == "lean"
+    assert r["pr_number"] == 10912
+
+
+def test_parse_prev_absent():
+    # A Grain tag without any prev: field -- the exact gap #10983 measures
+    # (10 grains merged on one lane without prev:).
+    r = gt.parse_prev("Grain: DEEP/lean -- lane myia-po-2025:CoursIA-2")
+    assert r == {"present": False, "exempt": False, "tier": None,
+                 "genre": None, "pr_number": None}
+
+
+def test_parse_prev_first_grain_exemption():
+    # `prev: none (premier grain)` -- the first-grain exemption: a lane with
+    # no predecessor to cite must NOT be flagged as prev-absent.
+    r = gt.parse_prev(
+        "Grain: DEEP/lean -- lane myia-po-2026:CoursIA -- prev: none (premier grain)"
+    )
+    assert r["present"] is False
+    assert r["exempt"] is True
+
+
+def test_parse_prev_exemption_noise_tolerant():
+    # Bold-wrapped exemption (same noise discipline as parse_grain_tag).
+    r = gt.parse_prev(
+        "Grain: MED/docs -- lane myia-po-2023:CoursIA -- **prev: none (premier grain)**"
+    )
+    assert r["exempt"] is True
+
+
+def test_parse_prev_empty_and_none():
+    assert gt.parse_prev(None)["present"] is False
+    assert gt.parse_prev(None)["exempt"] is False
+    assert gt.parse_prev("")["present"] is False
+
+
 def test_find_non_closing_refs_see_part_of_refs():
     # The 3 safe-syntax non-closing references (See/Part of/Refs) -- the
     # complement of find_close_keyword_pr_refs. Feeds lane_claim_required's


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #11023

See #10983 · See #8961 (variation-protocol)

## Resume

Le guard `variation-tag-guard.yml` rendait la conformite du tag `Grain:`
visible — sauf sur `prev:`, jamais mesure en presence (10 grains merges sans
prev: sur une lane le 2026-08-14, adjacence G-VAR-3 evaluable seulement a la
main apres merge). Cette PR expose `prev:` dans le parser partage
`grain_tag.py` et pose un label advisory quand le champ manque.

## Changements

- `scripts/grain_tag.py` : nouvelle fonction `parse_prev()` → `{present,
  exempt, tier, genre, pr_number}`. Exemption premier grain d'une lane :
  `prev: none (premier grain)` → `exempt=True`. Meme discipline de bruit que
  `parse_grain_tag` (bold/backticks/titre-strip).
- CLI `--body-file` : champs plats `prev_present/prev_exempt/prev_tier/
  prev_genre/prev_pr` ajoutes au JSON (les deux branches present=False/True).
- `.github/workflows/variation-tag-guard.yml` : quand le tag est present mais
  `prev_present=False` et non exempt → `::warning::` + label
  `variation-tag-prev-absent` (ADVISORY, exit 0 — un gate rouge sur un tag
  par ailleurs sain punirait la mauvaise cible, variation-protocol §3).
- `scripts/tests/test_grain_tag.py` : +6 tests (canonique avec/sans PR,
  absent, exemption, exemption bolder, vide/None).

## Validation

1. `python -m pytest scripts/tests/test_grain_tag.py` : **45 passed** (+6).
2. `python -m pytest scripts/tests/test_variation_light_cap.py` : **73 passed**
   (importeur `variation_light_cap.py` intact — 0 regression).
3. YAML workflow : `yaml.safe_load` OK, 5 jobs.
4. `bash -n` sur le run step du job `check-variation-tag` : OK.
5. **Rejeu a blanc sur les PRs nommees par #10983** : #10973, #10957,
   #10949, #10929, #10942, #10933, #10848, #10856 → toutes
   `prev_present=False, exempt=False, present=True` → les 8 seraient
   labellisees `variation-tag-prev-absent`. (#10845 a un prev: ; #10840 n'a
   pas de tag du tout → `variation-tag-missing`, cas distinct.)
6. Non-regression : `find_prev_close_keywords` (#10093) inchange.

## Note

Ne pas retro-labelliser les 10 PRs mergees — livrees, adjacence deja
verifiee a la main (acceptance #10983).

## Base

Basee sur `origin/main` `2c391cc0e` (frais a l'instant du push). Fichiers
modifies : parser partage + workflow + tests — aucun conflit attendu.
