### PR TITLE
docs(lean,#11028): repeated_games_lean renvoie vers lean-game-theory.yml (workflow supprime)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.en.md
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.en.md
@@ -10,7 +10,7 @@
 > manifest and documentation are preserved, but the `lean_lib` is **neutralized** in `lakefile.lean`
 > (its `globs` pointed to moved sources and matched 0 files). The no-sorry certification
 > (`grim_trigger_sustains_iff`, headline theorem) and the Lake build are now carried by
-> `game_theory_lean` via `.github/workflows/lean-repeated-games.yml`.
+> `game_theory_lean` via `.github/workflows/lean-game-theory.yml`.
 >
 > The rest of this README describes the formalizations as they **historically** existed here — the
 > mathematical content (grim-trigger theorem, one-shot deviation principle, threshold δ) remains

--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/README.md
@@ -11,7 +11,7 @@
 > **neutralisée** dans le `lakefile.lean` (ses `globs` pointaient vers des sources déplacées et
 > matchaient 0 fichier, ce qui aurait provoqué une collision de module-path). La certification
 > no-sorry (`grim_trigger_sustains_iff`, théorème-phare) et le build Lake sont repris par
-> `game_theory_lean` via `.github/workflows/lean-repeated-games.yml`.
+> `game_theory_lean` via `.github/workflows/lean-game-theory.yml`.
 >
 > La suite de ce README décrit les formalisations telles qu'elles existent **historiquement** ici —
 > le contenu mathématique (théorème grim-trigger, principe de déviation one-shot, seuil δ) reste

--- a/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/repeated_games_lean/lakefile.lean
@@ -33,7 +33,7 @@ require mathlib from git
 -- canonique. Ce lake archive conserve son `package`, son `require mathlib`, ses
 -- docs/manifest/toolchain (coquille archive) mais n'expose PLUS la lib. La
 -- certification no-sorry (grim_trigger_sustains_iff, theoreme-phare) et le Lake build
--- sont repris par game_theory_lean via `.github/workflows/lean-repeated-games.yml`.
+-- sont repris par game_theory_lean via `.github/workflows/lean-game-theory.yml`.
 -- -- @[default_target]
 -- -- lean_lib «RepeatedGames» where
 -- --   globs := #[`RepeatedGames.*]  (archive, voir git history PR #6146)


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #11026

## Summary

Trois fichiers suivis de `repeated_games_lean/` renvoient le lecteur vers
`.github/workflows/lean-repeated-games.yml`, **supprimé** (le lake archive de
`repeated_games_lean/` n'a plus de workflow propre depuis l'absorption
byte-identique dans `game_theory_lean/RepeatedGames/`, EPIC #4365 Phase-4,
PR #6146). Le workflow qui porte désormais la certification no-sorry
(`grim_trigger_sustains_iff`) et le build Lake de ce module est
`lean-game-theory.yml` — vérifié présent dans `.github/workflows/`.

### Changements (prose-only, 3 lignes)

| Fichier | Ligne | Renvoi |
|---|---|---|
| `repeated_games_lean/README.md` | 14 | `lean-repeated-games.yml` → `lean-game-theory.yml` |
| `repeated_games_lean/README.en.md` | 13 | idem (sibling EN Pattern A) |
| `repeated_games_lean/lakefile.lean` | 36 | idem (commentaire) |

La mention de l'absorption (EPIC #4365 Phase-4, PR #6146) — la vraie
information — est **conservée** dans les trois fichiers (README.md L3-4,
README.en.md L3-4, lakefile.lean L25).

Hors scope (explicitement noté dans l'issue) : le bump toolchain
`leanprover/lean4:v4.32.0` (#11013) n'est pas dans la cause.

## Validation

- `grep -rn "lean-repeated-games" MyIA.AI.Notebooks/GameTheory/repeated_games_lean/` : 0 (les 2 seules occurrences restantes dans le repo sont des commentaires historiques **dans** `lean-game-theory.yml` lui-même, hors scope).
- Diff = 3 insertions / 3 deletions, une seule ligne changée par fichier.
- Pre-commit hooks (gitleaks, notebook checks) : Passed.

## Test plan

- [x] Grep residual 0 dans le répertoire cible
- [x] Fichier cible `lean-game-theory.yml` vérifié présent
- [x] Prose-only — aucun code Lean ni config touchée

See #11028
