### PR TITLE
fix(docs,#10993): nommer l'organe reel du catalogue apres retrait du garde fantome (#11012)

### DIFF
--- a/.claude/rules/catalog-pr-hygiene.md
+++ b/.claude/rules/catalog-pr-hygiene.md
@@ -1,6 +1,6 @@
 # Catalogue & hygiène PR — le catalogue appartient à l'automatisation
 
-S'applique à **tous les agents du cluster CoursIA** (workers `po-*` + coordinateur `ai-01`) qui ouvrent des PR. Source : mandat user 2026-06-06 (« régler définitivement le pb du catalogue et faire faire aux agents workers le travail t'économisant le tien »). Codifie la leçon `stale-catalog-silent-revert` (incidents #2376 / #2383 / #2385). **Enforcé par CI** : `catalog-pr-guard.yml` FAIL toute PR touchant le catalogue (exception : bot `github-actions[bot]`). See #2632.
+S'applique à **tous les agents du cluster CoursIA** (workers `po-*` + coordinateur `ai-01`) qui ouvrent des PR. Source : mandat user 2026-06-06 (« régler définitivement le pb du catalogue et faire faire aux agents workers le travail t'économisant le tien »). Codifie la leçon `stale-catalog-silent-revert` (incidents #2376 / #2383 / #2385). **Détecté par CI** : `catalog-drift.yml` (check `Notebook catalog drift (read-only)`, non-bloquant) signale toute PR touchant le catalogue ; la régénération est portée par `catalog-cron.yml` (PR permanente). Le garde bloquant `catalog-pr-guard.yml` a été retiré (#11012) : entité fantôme, 0 run `pull_request` sur ~925 runs `push` en échec. See #2632.
 
 ## Règle HARD 1 — NE JAMAIS régénérer le catalogue sur une branche feature
 

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -8,7 +8,7 @@ name: Catalog Drift Check
 #   NO LONGER COMMITS anything back to PR branches. The earlier design
 #   auto-committed a regenerated catalog onto every PR matching **/*.ipynb or
 #   **/README.md. Because those commits were bot-authored, catalog-pr-guard.yml
-#   exempted them — so they landed even when they mass-reverted curated git
+#   (retiré depuis, #11012) exempted them — so they landed even when they mass-reverted curated git
 #   fields (issue_pr_associee, last_validation) via the branch git-history
 #   heuristic. That is the stale-catalog-silent-revert pattern (513 poisoned
 #   entries observed on branches, 0 on main — source-verified by po-2025,
@@ -17,9 +17,9 @@ name: Catalog Drift Check
 #
 #   Per decision #2632 (catalog cron-only, off-branch), the ONLY legitimate
 #   catalog writer is catalog-cron.yml on main (daily regen + push HEAD:main).
-#   catalog-pr-guard.yml still FAILS any human/agent PR that touches the catalog
-#   files. This workflow stays as a read-only detector so reviewers see drift,
-#   without ever writing to a branch.
+#   The blocking guard catalog-pr-guard.yml was removed (#11012: phantom entity,
+#   0 run on pull_request). This workflow stays as the read-only detector so
+#   reviewers see drift, without ever writing to a branch.
 #
 # This job is intentionally NON-BLOCKING and READ-ONLY. The REQUIRED notebook
 # gate remains "Static validation (H.1/H.3/C.1)" in notebook-execution-required.yml.
@@ -88,7 +88,8 @@ jobs:
           fi
 
       # This job is always green. Drift is surfaced as a notice annotation only.
-      # catalog-cron.yml (main) is the sole writer; catalog-pr-guard.yml blocks any
-      # human/agent catalog commit on PRs (see #2632, #2744).
+      # catalog-cron.yml (main) is the sole writer; the blocking guard
+      # catalog-pr-guard.yml was removed (#11012) — this read-only detector and
+      # the catalog-cron.yml regen PR are the sole organs now (see #2632, #2744).
       - name: Done (non-blocking, read-only)
         run: echo "Catalog drift check complete (non-blocking, read-only)."

--- a/MyIA.AI.Notebooks/README.md
+++ b/MyIA.AI.Notebooks/README.md
@@ -15,7 +15,7 @@ breakdown: SymbolicAI=227, GenAI=159, Search=118, QuantConnect=106, Probas=58, G
 maturity: BETA=807, ALPHA=47, DRAFT=28, TEMPLATE=4
 -->
 
-<sub>*Marqueur auto-régénéré quotidiennement par `.github/workflows/catalog-cron.yml` (file [`COURSE_CATALOG.generated.md`](../COURSE_CATALOG.generated.md) — source de vérité sur les volumes et la maturité). Toute PR qui modifierait ce bloc est refusée par `catalog-pr-guard.yml` (catalog-pr-hygiene R1).*</sub>
+<sub>*Marqueur auto-régénéré quotidiennement par `.github/workflows/catalog-cron.yml` (file [`COURSE_CATALOG.generated.md`](../COURSE_CATALOG.generated.md) — source de vérité sur les volumes et la maturité). Toute PR qui modifierait ce bloc est signalée par `catalog-drift.yml` (read-only, catalog-pr-hygiene R1).*</sub>
 
 Dernière mise à jour : 2026-08-05
 

--- a/docs/reference/ci-aggregator-rollout.md
+++ b/docs/reference/ci-aggregator-rollout.md
@@ -176,7 +176,7 @@ GitHub = code pas rapport), §G.6 (audit avant merge cascade).
 | `ci / No fabricated text output in changed notebooks` | required | C.4 doc-honesty (#8052) |
 | `ci / No degenerate figure in changed notebooks` | required | GenAI rendering (cf #6541) |
 | `ci / No bare cross-dir #load in changed notebooks` | required | coupling cellule cross-répertoire |
-| `ci / No catalog changes on feature branch` | required | catalog-pr-hygiene R1 |
+| `ci / Notebook catalog drift (read-only)` | advisory | catalog-pr-hygiene R1 — détecteur read-only ; le garde bloquant `catalog-pr-guard.yml` est retiré (#11012) |
 | `ci / Gitleaks secret scanner` | required | secrets-hygiene |
 | `hooks-parity gate` | required | #8782 — gate qui ne peut plus rougir |
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2026:CoursIA-2 — prev: MED/tooling #11027

## Summary

Suite de #11012 (suppression du workflow fantôme `catalog-pr-guard.yml`). ai-01 a élargi le périmètre à 6 fichiers ; ce PR corrige les **4 premiers** (prose/commentaires seuls, aucun comportement CI modifié) pour nommer l'organe réel du catalogue au lieu de laisser les mentions du garde supprimé :

| Fichier | Correction |
|---|---|
| `.claude/rules/catalog-pr-hygiene.md:3` | « Enforcé par CI : catalog-pr-guard.yml FAIL... » → « **Détecté par CI** : `catalog-drift.yml` (read-only, non-bloquant) signale toute PR touchant le catalogue ; régénération portée par `catalog-cron.yml` (PR permanente). Garde retiré (#11012) » |
| `MyIA.AI.Notebooks/README.md:18` | « refusée par catalog-pr-guard.yml » → « signalée par catalog-drift.yml (read-only) » |
| `docs/reference/ci-aggregator-rollout.md:179` | ligne fantôme « ci / No catalog changes on feature branch \| required » (check inexistant dans tout workflow) → check réel « Notebook catalog drift (read-only) » en `advisory` |
| `.github/workflows/catalog-drift.yml` (l.10, 20, 91) | 3 commentaires décrivant le voisin supprimé comme actif → « garde retiré (#11012), ce workflow est le détecteur read-only restant » |

## Preuves

- Check « No catalog changes on feature branch » : `grep -rln` dans `.github/workflows/` = **0 résultat** ; absent de `scripts/pr_gate.py`. La ligne du tableau était une entrée fantôme.
- Check réel présent sur toutes les PR : « Notebook catalog drift (read-only) » (job `catalog-drift.yml`, `name: "Notebook catalog drift (read-only)"`, l.43) — **non-blocking** (workflow read-only, `::notice` annotation).
- Catalogue byte-identique à main : `git diff origin/main -- COURSE_CATALOG.generated.*` = vide.
- YAML workflow validé : `yaml.safe_load` OK.
- Diff : 4 fichiers, 10 insertions, 9 suppressions. Aucun comportement CI modifié.
- Les 2 fichiers d'artefacts d'audit (`docs/audit/workflow-path-filters/**`) sont laissés à leur régénération automatique ; les relevés datés (`docs/archive/ledgers-reviews/**`) sont corrects pour leur date (cf périmètre ai-01).

Closes #10993

