### PR TITLE
feat(lean,#2159): Partie 38 — pullback functor laws on J.Cover (PullbackFunctorLaws)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -20,6 +20,7 @@ import Grothendieck.MayerVietorisSquare
 import Grothendieck.Monads
 import Grothendieck.MonoidalCategories
 import Grothendieck.PullbackFunctor
+import Grothendieck.PullbackFunctorLaws
 import Grothendieck.SchemesTour
 import Grothendieck.SheafBasics
 import Grothendieck.SheafCohomology.Basic

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/PullbackFunctorLaws.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/PullbackFunctorLaws.lean
@@ -1,0 +1,141 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 38 : lois de foncteur du pullback
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Les parties 1-37 ont etabli les fondamentaux : categories, cribles,
+topologies, lois de treillis, identites de pullback, bases de faisceaux,
+cloture couvrante, calibration, sous-canonicalite, topologies denses,
+faisceaux, hom interne, cohomologie de Cech, limite de Mayer-Vietoris,
+extensions de Kan, adjonctions, monades, equivalences, categories monoidales,
+limites et colimites, couples comma, images directes, theoremes propres sur la
+forme fleche (`J.Covers S f`), sur la couverture bundlee (`J.Cover X`) et les
+lois de coherence du pseudo-foncteur pullback (Partie 37).
+
+La Partie 37 a prouve les **lois de coherence** des isomorphismes naturels
+`J.pullbackId X` et `J.pullbackComp f g` fournis par Mathlib. Cette partie va
+plus loin : elle enonce et prouve les **lois de foncteur elles-memes** — les
+egalites de foncteurs que Mathlib ne fournit **pas** (il n'enregistre que les
+definitions `pullbackId`/`pullbackComp` au niveau iso) :
+
+  - `pullback_functor_id` : pullbacker le long de l'identite est le foncteur
+    identite — `J.pullback (𝟙 X) = 𝟭 (J.Cover X)`.
+  - `pullback_functor_comp` : la contravariance — pullbacker le long de la
+    composee `f ≫ g` est la composee des pullbacks —
+    `J.pullback (f ≫ g) = J.pullback g ⋙ J.pullback f`.
+  - `pullback_functor_comp_assoc` : l'associativite de la contravariance
+    (deux groupements du produit de foncteurs).
+  - `covers_pullback_comp` : la traduction de la contravariance a la forme
+    fleche — `J.Covers S (f ≫ g)` equivaut a `J.Covers (S.pullback g) f`.
+
+Chaque preuve est une **preuve tactique reelle** (veine DEEP) : `Functor.ext`
+ramene l'egalite de foncteurs aux objets et aux fleches ; sur les objets,
+`GrothendieckTopology.Cover.ext` + les lois de pullback de Mathlib
+(`Sieve.pullback_id`, `Sieve.pullback_comp`) ; sur les fleches,
+`Subsingleton.elim` (le codomaine `J.Cover X` est un preordre).
+
+EPIC #1646, Phase 5 (#2159). Tous les `sorry`s elimines a la creation.
+
+### Convention i18n (EPIC #4980 ratifiee par user 2026-07-04)
+
+Ce module est apparie avec son jumeau anglais dans le fichier sibling
+`PullbackFunctorLaws_en.lean` (modele sibling pair, voir PR #6154 pour le
+pilote sur `Utility.lean`). Namespace suffix `_en` applique au fichier EN
+(anti-collision, conforme code-style.md #4980). Les enonces de theoremes, les
+noms de lemmes, les tactiques Lean et les references Mathlib restent en
+anglais ; seules les docstrings `/-- ... -/` et les commentaires `-- ...`
+different entre les deux fichiers (preservation byte-identity).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Whiskering
+import Mathlib.CategoryTheory.Functor.Category
+
+namespace Grothendieck.PullbackFunctorLaws
+
+open CategoryTheory
+
+/-!
+## Section 1 : lois de foncteur
+
+Mathlib definit le foncteur contravariant `J.pullback f : J.Cover Y ⥤ J.Cover X`
+pour une fleche `f : X ⟶ Y` (`@[simps obj]` : `(J.pullback f).obj S = S.pullback f`),
+et les isomorphismes naturels `J.pullbackId X` / `J.pullbackComp f g`. Il ne
+fournit **pas** les lois de foncteur correspondantes. Ce module les enonce et
+les prouve — ce sont des egalites de foncteurs, plus fortes que les
+isomorphismes. Strategie commune : `Functor.ext` decompose en composante
+objet (lois de pullback de Mathlib) et composante fleche (`Subsingleton.elim`,
+le preordre `J.Cover X` a des ensembles de fleches subsingletons).
+-/
+
+/-- Pullbacker le long de l'identite est le foncteur identite :
+    `J.pullback (𝟙 X) = 𝟭 (J.Cover X)`.
+    Preuve : `Functor.ext` ; sur les objets, `Cover.ext` + `Sieve.pullback_id`
+    (`(f ≫ 𝟙 X)` se reduit a `f`) ; sur les fleches, `Subsingleton.elim`. -/
+theorem pullback_functor_id {C : Type*} [Category C] (X : C)
+    (J : GrothendieckTopology C) :
+    J.pullback (𝟙 X) = 𝟭 (J.Cover X) := by
+  apply CategoryTheory.Functor.ext
+  · intro S T g
+    apply Subsingleton.elim
+  · intro S
+    change S.pullback (𝟙 X) = S
+    apply GrothendieckTopology.Cover.ext
+    intro Y f
+    rw [GrothendieckTopology.Cover.coe_pullback]
+    simp [Category.comp_id]
+
+/-- Contravariance du pullback : `J.pullback (f ≫ g) = J.pullback g ⋙ J.pullback f`.
+    Preuve : `Functor.ext` ; sur les objets, `Cover.ext` + trois
+    `coe_pullback` ramenant la membership de gauche a celle de droite via
+    l'associativite `simp` ; sur les fleches, `Subsingleton.elim`. -/
+theorem pullback_functor_comp {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (f : X ⟶ Y) (g : Y ⟶ Z) :
+    J.pullback (f ≫ g) = J.pullback g ⋙ J.pullback f := by
+  apply CategoryTheory.Functor.ext
+  · intro S T g'
+    apply Subsingleton.elim
+  · intro S
+    change S.pullback (f ≫ g) = (S.pullback g).pullback f
+    apply GrothendieckTopology.Cover.ext
+    intro Y f'
+    rw [GrothendieckTopology.Cover.coe_pullback, GrothendieckTopology.Cover.coe_pullback,
+      GrothendieckTopology.Cover.coe_pullback]
+    simp [Category.assoc]
+
+/-- Associativite de la contravariance : pullbacker le long de `f ≫ g ≫ h`
+    est, quel que soit le groupement, pullbacker le long de `h`, puis `g`,
+    puis `f`. Preuve : deux reecritures de `pullback_functor_comp` puis
+    `rfl` (l'associativite du produit des foncteurs est definitionnelle). -/
+theorem pullback_functor_comp_assoc {C : Type*} [Category C] {W X Y Z : C}
+    (J : GrothendieckTopology C) (f : W ⟶ X) (g : X ⟶ Y) (h : Y ⟶ Z) :
+    J.pullback (f ≫ g ≫ h) = J.pullback h ⋙ (J.pullback g ⋙ J.pullback f) := by
+  rw [pullback_functor_comp J f (g ≫ h)]
+  rw [pullback_functor_comp J g h]
+  rfl
+
+/-!
+## Section 2 : forme fleche (J.Covers)
+
+La forme fleche `J.Covers S f` est definie par `S.pullback f ∈ J Y` (Mathlib,
+`GrothendieckTopology.Covers` ; `covers_iff` est `Iff.rfl`). Le theoreme
+suivant traduit la contravariance de la section precedente dans cette forme.
+-/
+
+/-- Traduction de `pullback_functor_comp` a la forme fleche : couvrir `S` le
+    long de `f ≫ g` equivaut a couvrir `S.pullback g` le long de `f`.
+    Preuve : `rw [covers_iff]` des deux cotes puis `Sieve.pullback_comp` (les
+    deux membres sont `∈ J X`). -/
+theorem covers_pullback_comp {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (f : X ⟶ Y) (g : Y ⟶ Z) (S : J.Cover Z) :
+    J.Covers (S : Sieve Z) (f ≫ g) ↔ J.Covers (S.pullback g : Sieve Y) f := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff]
+  rw [Sieve.pullback_comp]
+  simp
+
+end Grothendieck.PullbackFunctorLaws

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/PullbackFunctorLaws_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/PullbackFunctorLaws_en.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Grothendieck Homage — Part 38 : pullback functor laws
+
+Alexandre Grothendieck (1928-2014).
+
+Phase 5 extension (#2159, EPIC #1646).
+
+Parts 1-37 established the fundamentals : categories, sieves, topologies,
+lattice laws, pullback identities, sheaf bases, covering closure,
+calibration, subcanonicity, dense topologies, sheaves, internal hom, Cech
+cohomology, Mayer-Vietoris limit, Kan extensions, adjunctions, monads,
+equivalences, monoidal categories, limits and colimits, comma couples,
+direct images, proper theorems on the arrow form (`J.Covers S f`), on the
+bundled cover (`J.Cover X`) and the pullback pseudofunctor coherence laws
+(Part 37).
+
+Part 37 proved the **coherence laws** of the natural isomorphisms
+`J.pullbackId X` and `J.pullbackComp f g` provided by Mathlib. This part goes
+further : it states and proves the **functor laws themselves** — the functor
+equalities that Mathlib does **not** provide (it only registers the
+definitions `pullbackId`/`pullbackComp` at iso level) :
+
+  - `pullback_functor_id` : pulling back along the identity is the identity
+    functor — `J.pullback (𝟙 X) = 𝟭 (J.Cover X)`.
+  - `pullback_functor_comp` : contravariance — pulling back along the
+    composition `f ≫ g` is the composition of the pullbacks —
+    `J.pullback (f ≫ g) = J.pullback g ⋙ J.pullback f`.
+  - `pullback_functor_comp_assoc` : associativity of the contravariance (two
+    groupings of the functor product).
+  - `covers_pullback_comp` : the translation of the contravariance to the
+    arrow form — `J.Covers S (f ≫ g)` is equivalent to
+    `J.Covers (S.pullback g) f`.
+
+Each proof is a **real tactic proof** (DEEP vein) : `Functor.ext` reduces the
+functor equality to objects and arrows ; on objects,
+`GrothendieckTopology.Cover.ext` + the Mathlib pullback laws
+(`Sieve.pullback_id`, `Sieve.pullback_comp`) ; on arrows, `Subsingleton.elim`
+(the codomain `J.Cover X` is a preorder).
+
+EPIC #1646, Phase 5 (#2159). All `sorry`s eliminated at creation.
+
+### i18n convention (EPIC #4980 ratified by user 2026-07-04)
+
+This module is paired with its French twin in the sibling file
+`PullbackFunctorLaws.lean` (sibling pair model, see PR #6154 for the pilot
+on `Utility.lean`). The `_en` suffix is applied to this English file's
+namespace (anti-collision, per code-style.md #4980). Theorem statements,
+lemma names, Lean tactics and Mathlib references remain in English ; only the
+docstrings `/-- ... -/` and comments `-- ...` differ between the two files
+(byte-identity preservation).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+import Mathlib.CategoryTheory.Whiskering
+import Mathlib.CategoryTheory.Functor.Category
+
+namespace Grothendieck.PullbackFunctorLaws_en
+
+open CategoryTheory
+
+/-!
+## Section 1 : functor laws
+
+Mathlib defines the contravariant functor `J.pullback f : J.Cover Y ⥤ J.Cover X`
+for an arrow `f : X ⟶ Y` (`@[simps obj]` : `(J.pullback f).obj S = S.pullback f`),
+and the natural isomorphisms `J.pullbackId X` / `J.pullbackComp f g`. It does
+**not** provide the corresponding functor laws. This module states and proves
+them — functor equalities, stronger than the isomorphisms. Common strategy :
+`Functor.ext` splits into the object component (Mathlib pullback laws) and the
+arrow component (`Subsingleton.elim`, the preorder `J.Cover X` has
+subsingleton hom sets).
+-/
+
+/-- Pulling back along the identity is the identity functor :
+    `J.pullback (𝟙 X) = 𝟭 (J.Cover X)`.
+    Proof : `Functor.ext` ; on objects, `Cover.ext` + `Sieve.pullback_id`
+    (`(f ≫ 𝟙 X)` reduces to `f`) ; on arrows, `Subsingleton.elim`. -/
+theorem pullback_functor_id {C : Type*} [Category C] (X : C)
+    (J : GrothendieckTopology C) :
+    J.pullback (𝟙 X) = 𝟭 (J.Cover X) := by
+  apply CategoryTheory.Functor.ext
+  · intro S T g
+    apply Subsingleton.elim
+  · intro S
+    change S.pullback (𝟙 X) = S
+    apply GrothendieckTopology.Cover.ext
+    intro Y f
+    rw [GrothendieckTopology.Cover.coe_pullback]
+    simp [Category.comp_id]
+
+/-- Contravariance of the pullback : `J.pullback (f ≫ g) = J.pullback g ⋙ J.pullback f`.
+    Proof : `Functor.ext` ; on objects, `Cover.ext` + three `coe_pullback`
+    rewrites bring the left membership to the right one via `simp`
+    associativity ; on arrows, `Subsingleton.elim`. -/
+theorem pullback_functor_comp {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (f : X ⟶ Y) (g : Y ⟶ Z) :
+    J.pullback (f ≫ g) = J.pullback g ⋙ J.pullback f := by
+  apply CategoryTheory.Functor.ext
+  · intro S T g'
+    apply Subsingleton.elim
+  · intro S
+    change S.pullback (f ≫ g) = (S.pullback g).pullback f
+    apply GrothendieckTopology.Cover.ext
+    intro Y f'
+    rw [GrothendieckTopology.Cover.coe_pullback, GrothendieckTopology.Cover.coe_pullback,
+      GrothendieckTopology.Cover.coe_pullback]
+    simp [Category.assoc]
+
+/-- Associativity of the contravariance : pulling back along `f ≫ g ≫ h`
+    is, whichever the grouping, pulling back along `h`, then `g`, then `f`.
+    Proof : two rewrites of `pullback_functor_comp` then `rfl` (the
+    associativity of the functor product is definitional). -/
+theorem pullback_functor_comp_assoc {C : Type*} [Category C] {W X Y Z : C}
+    (J : GrothendieckTopology C) (f : W ⟶ X) (g : X ⟶ Y) (h : Y ⟶ Z) :
+    J.pullback (f ≫ g ≫ h) = J.pullback h ⋙ (J.pullback g ⋙ J.pullback f) := by
+  rw [pullback_functor_comp J f (g ≫ h)]
+  rw [pullback_functor_comp J g h]
+  rfl
+
+/-!
+## Section 2 : arrow form (J.Covers)
+
+The arrow form `J.Covers S f` is defined by `S.pullback f ∈ J Y` (Mathlib,
+`GrothendieckTopology.Covers` ; `covers_iff` is `Iff.rfl`). The following
+theorem translates the contravariance of the previous section into this form.
+-/
+
+/-- Translation of `pullback_functor_comp` to the arrow form : covering `S`
+    along `f ≫ g` is equivalent to covering `S.pullback g` along `f`.
+    Proof : `rw [covers_iff]` on both sides then `Sieve.pullback_comp` (both
+    members are `∈ J X`). -/
+theorem covers_pullback_comp {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (f : X ⟶ Y) (g : Y ⟶ Z) (S : J.Cover Z) :
+    J.Covers (S : Sieve Z) (f ≫ g) ↔ J.Covers (S.pullback g : Sieve Y) f := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff]
+  rw [Sieve.pullback_comp]
+  simp
+
+end Grothendieck.PullbackFunctorLaws_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-dotnet #11032

## Summary

Partie 38 de l'hommage Grothendieck (#2159, EPIC #1646) : **lois de foncteur
du pullback** sur `J.Cover`. La Partie 37 (#11023) a prouve les lois de
coherence des isomorphismes `J.pullbackId` / `J.pullbackComp` que Mathlib
fournit ; cette partie enonce et prouve les **egalites de foncteurs
elles-memes**, absentes de Mathlib (il n'enregistre que les `def pullbackId`
et `def pullbackComp` au niveau iso) :

| Theoreme | Enonce |
|---|---|
| `pullback_functor_id` | `J.pullback (𝟙 X) = 𝟭 (J.Cover X)` |
| `pullback_functor_comp` | `J.pullback (f ≫ g) = J.pullback g ⋙ J.pullback f` (contravariance) |
| `pullback_functor_comp_assoc` | `J.pullback (f ≫ g ≫ h) = J.pullback h ⋙ (J.pullback g ⋙ J.pullback f)` |
| `covers_pullback_comp` | `J.Covers S (f ≫ g) ↔ J.Covers (S.pullback g) f` (forme fleche) |

4 theoremes **propres** (veine DEEP), chacun une preuve tactique reelle :
`Functor.ext` decompose l'egalite de foncteurs ; sur les objets,
`GrothendieckTopology.Cover.ext` + `Sieve.pullback_id` / `Sieve.pullback_comp` ;
sur les fleches, `Subsingleton.elim` (le preordre `J.Cover X` a des ensembles
de fleches subsingletons). Aucune preuve n'est un re-export (a la difference
des ponts `inferInstance` requalifies LIGHT en Partie 15).
+281/-0 (FR 140 lignes, EN 141 lignes byte-id i18n, aggregator `Grothendieck.lean` +1 import).

## Preuve de progres Lean (B.1)

- Compte de `sorry` reel avant/apres — `python scripts/lean/count_code_sorry.py --json`, champ `distinct_code_sorry` : **0 avant (module nouveau), 0 apres**. Aucun sorry ajoute ni retire.
- `lake build Grothendieck` : **SUCCESS** (2831 jobs, cache AZ — log ci-dessous).
- Proof integrity (B.3) : job câble sur ce lake — `lean-grothendieck.yml` appelle `lean-axiom.yml` avec `target-modules: "*"` (la liste des modules est derivee au runtime) → le module `PullbackFunctorLaws` est couvert par la cloture. Verdict CI attendu `proof-integrity SUCCESS`.

<details>
<summary>Log lake build (tail)</summary>

```
✔ [803/804] Built Grothendieck.PullbackFunctorLaws (145s)
✔ [804/804] Built Grothendieck.PullbackFunctorLaws_en (146s)
Build completed successfully (804 jobs).
✔ [2830/2831] Built Grothendieck (276s)
Build completed successfully (2831 jobs).
```

</details>

## i18n (EPIC #4980)

Sibling pair Pattern A : `PullbackFunctorLaws.lean` (FR) / `PullbackFunctorLaws_en.lean` (EN, namespace `_en`). Docstrings et commentaires traduits ; **enonces, noms de lemmes, preuves byte-identiques** (verifie par `check_i18n_siblings.py` et diff).

## See

See #2159 (Epic Grothendieck, Phase 5 — Partie 38). Precedents de la serie : #11023 (Partie 37 lois de coherence), #10912 (Partie 36 Cover), #10879 (Partie 35 CoversArrow).

## Tests / checks
- [x] `lake build Grothendieck` SUCCESS
- [x] sorry reel 0 avant/apres (`count_code_sorry.py`)
- [x] i18n FR/EN byte-identiques
- [x] catalogue byte-identique a main (aucun artefact genere touche)
