### PR TITLE
feat(gametheory,#10382): GameTheory-3 tranche 2 — bridge QuikGraph (BFS swaps, parite 25/25)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
@@ -5,10 +5,10 @@
    "id": "1dc1c167",
    "metadata": {
     "papermill": {
-     "duration": 0.002567,
-     "end_time": "2026-07-06T18:50:30.423886",
+     "duration": 0.011139,
+     "end_time": "2026-08-15T08:30:04.487832",
      "exception": false,
-     "start_time": "2026-07-06T18:50:30.421319",
+     "start_time": "2026-08-15T08:30:04.476693",
      "status": "completed"
     },
     "tags": []
@@ -34,10 +34,10 @@
    "id": "0a6f809b",
    "metadata": {
     "papermill": {
-     "duration": 0.002034,
-     "end_time": "2026-07-06T18:50:30.428250",
+     "duration": 0.010299,
+     "end_time": "2026-08-15T08:30:04.508427",
      "exception": false,
-     "start_time": "2026-07-06T18:50:30.426216",
+     "start_time": "2026-08-15T08:30:04.498128",
      "status": "completed"
     },
     "tags": []
@@ -73,10 +73,10 @@
    "id": "db095d10",
    "metadata": {
     "papermill": {
-     "duration": 0.002187,
-     "end_time": "2026-07-06T18:50:30.432450",
+     "duration": 0.010816,
+     "end_time": "2026-08-15T08:30:04.528694",
      "exception": false,
-     "start_time": "2026-07-06T18:50:30.430263",
+     "start_time": "2026-08-15T08:30:04.517878",
      "status": "completed"
     },
     "tags": []
@@ -99,16 +99,16 @@
    "id": "49713762",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:30.448749Z",
-     "iopub.status.busy": "2026-07-06T18:50:30.442650Z",
-     "iopub.status.idle": "2026-07-06T18:50:32.264246Z",
-     "shell.execute_reply": "2026-07-06T18:50:32.259064Z"
+     "iopub.execute_input": "2026-08-15T08:30:04.555094Z",
+     "iopub.status.busy": "2026-08-15T08:30:04.549363Z",
+     "iopub.status.idle": "2026-08-15T08:30:06.128049Z",
+     "shell.execute_reply": "2026-08-15T08:30:06.123827Z"
     },
     "papermill": {
-     "duration": 1.829482,
-     "end_time": "2026-07-06T18:50:32.264363",
+     "duration": 1.590209,
+     "end_time": "2026-08-15T08:30:06.128049",
      "exception": false,
-     "start_time": "2026-07-06T18:50:30.434881",
+     "start_time": "2026-08-15T08:30:04.537840",
      "status": "completed"
     },
     "tags": []
@@ -123,6 +123,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -132,7 +133,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -147,6 +151,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -158,11 +163,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '45800.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '43052.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -206,11 +213,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -275,10 +284,10 @@
    "id": "36c10632",
    "metadata": {
     "papermill": {
-     "duration": 0.002964,
-     "end_time": "2026-07-06T18:50:32.270300",
+     "duration": 0.009077,
+     "end_time": "2026-08-15T08:30:06.146910",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.267336",
+     "start_time": "2026-08-15T08:30:06.137833",
      "status": "completed"
     },
     "tags": []
@@ -296,16 +305,16 @@
    "id": "864d04ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:32.277084Z",
-     "iopub.status.busy": "2026-07-06T18:50:32.276881Z",
-     "iopub.status.idle": "2026-07-06T18:50:32.469285Z",
-     "shell.execute_reply": "2026-07-06T18:50:32.469139Z"
+     "iopub.execute_input": "2026-08-15T08:30:06.165575Z",
+     "iopub.status.busy": "2026-08-15T08:30:06.165575Z",
+     "iopub.status.idle": "2026-08-15T08:30:06.295324Z",
+     "shell.execute_reply": "2026-08-15T08:30:06.295324Z"
     },
     "papermill": {
-     "duration": 0.196265,
-     "end_time": "2026-07-06T18:50:32.469352",
+     "duration": 0.139343,
+     "end_time": "2026-08-15T08:30:06.295324",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.273087",
+     "start_time": "2026-08-15T08:30:06.155981",
      "status": "completed"
     },
     "tags": []
@@ -354,10 +363,10 @@
    "id": "208d63db",
    "metadata": {
     "papermill": {
-     "duration": 0.002819,
-     "end_time": "2026-07-06T18:50:32.474971",
+     "duration": 0.011858,
+     "end_time": "2026-08-15T08:30:06.321755",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.472152",
+     "start_time": "2026-08-15T08:30:06.309897",
      "status": "completed"
     },
     "tags": []
@@ -374,16 +383,16 @@
    "id": "29350523",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:32.482116Z",
-     "iopub.status.busy": "2026-07-06T18:50:32.481914Z",
-     "iopub.status.idle": "2026-07-06T18:50:32.623099Z",
-     "shell.execute_reply": "2026-07-06T18:50:32.622884Z"
+     "iopub.execute_input": "2026-08-15T08:30:06.345846Z",
+     "iopub.status.busy": "2026-08-15T08:30:06.345846Z",
+     "iopub.status.idle": "2026-08-15T08:30:06.413404Z",
+     "shell.execute_reply": "2026-08-15T08:30:06.413404Z"
     },
     "papermill": {
-     "duration": 0.145447,
-     "end_time": "2026-07-06T18:50:32.623181",
+     "duration": 0.080026,
+     "end_time": "2026-08-15T08:30:06.413404",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.477734",
+     "start_time": "2026-08-15T08:30:06.333378",
      "status": "completed"
     },
     "tags": []
@@ -449,10 +458,10 @@
    "id": "8de7f262",
    "metadata": {
     "papermill": {
-     "duration": 0.005097,
-     "end_time": "2026-07-06T18:50:32.633538",
+     "duration": 0.01151,
+     "end_time": "2026-08-15T08:30:06.436118",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.628441",
+     "start_time": "2026-08-15T08:30:06.424608",
      "status": "completed"
     },
     "tags": []
@@ -471,16 +480,16 @@
    "id": "d5e28fd3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:32.643475Z",
-     "iopub.status.busy": "2026-07-06T18:50:32.643137Z",
-     "iopub.status.idle": "2026-07-06T18:50:32.805042Z",
-     "shell.execute_reply": "2026-07-06T18:50:32.804930Z"
+     "iopub.execute_input": "2026-08-15T08:30:06.459892Z",
+     "iopub.status.busy": "2026-08-15T08:30:06.459892Z",
+     "iopub.status.idle": "2026-08-15T08:30:06.568031Z",
+     "shell.execute_reply": "2026-08-15T08:30:06.568031Z"
     },
     "papermill": {
-     "duration": 0.16621,
-     "end_time": "2026-07-06T18:50:32.805099",
+     "duration": 0.120154,
+     "end_time": "2026-08-15T08:30:06.568031",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.638889",
+     "start_time": "2026-08-15T08:30:06.447877",
      "status": "completed"
     },
     "tags": []
@@ -580,10 +589,10 @@
    "id": "23b188ee",
    "metadata": {
     "papermill": {
-     "duration": 0.002426,
-     "end_time": "2026-07-06T18:50:32.810426",
+     "duration": 0.011554,
+     "end_time": "2026-08-15T08:30:06.595992",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.808000",
+     "start_time": "2026-08-15T08:30:06.584438",
      "status": "completed"
     },
     "tags": []
@@ -600,16 +609,16 @@
    "id": "86aa2efa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:32.816590Z",
-     "iopub.status.busy": "2026-07-06T18:50:32.816407Z",
-     "iopub.status.idle": "2026-07-06T18:50:32.900684Z",
-     "shell.execute_reply": "2026-07-06T18:50:32.900574Z"
+     "iopub.execute_input": "2026-08-15T08:30:06.620914Z",
+     "iopub.status.busy": "2026-08-15T08:30:06.620914Z",
+     "iopub.status.idle": "2026-08-15T08:30:06.686671Z",
+     "shell.execute_reply": "2026-08-15T08:30:06.686671Z"
     },
     "papermill": {
-     "duration": 0.087928,
-     "end_time": "2026-07-06T18:50:32.900743",
+     "duration": 0.078484,
+     "end_time": "2026-08-15T08:30:06.686671",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.812815",
+     "start_time": "2026-08-15T08:30:06.608187",
      "status": "completed"
     },
     "tags": []
@@ -678,10 +687,10 @@
    "id": "c0973729",
    "metadata": {
     "papermill": {
-     "duration": 0.002494,
-     "end_time": "2026-07-06T18:50:32.906109",
+     "duration": 0.011775,
+     "end_time": "2026-08-15T08:30:06.711311",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.903615",
+     "start_time": "2026-08-15T08:30:06.699536",
      "status": "completed"
     },
     "tags": []
@@ -698,16 +707,16 @@
    "id": "d60b84c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:32.912841Z",
-     "iopub.status.busy": "2026-07-06T18:50:32.912663Z",
-     "iopub.status.idle": "2026-07-06T18:50:32.982611Z",
-     "shell.execute_reply": "2026-07-06T18:50:32.982477Z"
+     "iopub.execute_input": "2026-08-15T08:30:06.737537Z",
+     "iopub.status.busy": "2026-08-15T08:30:06.737537Z",
+     "iopub.status.idle": "2026-08-15T08:30:06.788124Z",
+     "shell.execute_reply": "2026-08-15T08:30:06.786480Z"
     },
     "papermill": {
-     "duration": 0.07392,
-     "end_time": "2026-07-06T18:50:32.982678",
+     "duration": 0.064745,
+     "end_time": "2026-08-15T08:30:06.788124",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.908758",
+     "start_time": "2026-08-15T08:30:06.723379",
      "status": "completed"
     },
     "tags": []
@@ -785,10 +794,10 @@
    "id": "a9aa71af",
    "metadata": {
     "papermill": {
-     "duration": 0.002998,
-     "end_time": "2026-07-06T18:50:32.988861",
+     "duration": 0.013179,
+     "end_time": "2026-08-15T08:30:06.814646",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.985863",
+     "start_time": "2026-08-15T08:30:06.801467",
      "status": "completed"
     },
     "tags": []
@@ -805,16 +814,16 @@
    "id": "35a0a3e2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:32.996209Z",
-     "iopub.status.busy": "2026-07-06T18:50:32.996028Z",
-     "iopub.status.idle": "2026-07-06T18:50:33.113005Z",
-     "shell.execute_reply": "2026-07-06T18:50:33.112886Z"
+     "iopub.execute_input": "2026-08-15T08:30:06.842663Z",
+     "iopub.status.busy": "2026-08-15T08:30:06.842663Z",
+     "iopub.status.idle": "2026-08-15T08:30:07.044598Z",
+     "shell.execute_reply": "2026-08-15T08:30:07.044598Z"
     },
     "papermill": {
-     "duration": 0.121074,
-     "end_time": "2026-07-06T18:50:33.113065",
+     "duration": 0.217459,
+     "end_time": "2026-08-15T08:30:07.044598",
      "exception": false,
-     "start_time": "2026-07-06T18:50:32.991991",
+     "start_time": "2026-08-15T08:30:06.827139",
      "status": "completed"
     },
     "tags": []
@@ -939,8 +948,7 @@
     "int totalChecked = histogram.Values.Sum();\n",
     "$\"Total verifie : {totalChecked}/576 (attendu 576)\".Display();\n",
     "int gamesWithNash = histogram.Where(x => x.Key >= 1).Sum(x => x.Value);\n",
-    "$\"{gamesWithNash} jeux ont au moins 1 Nash pur ({100.0 * gamesWithNash / allGames.Count:F1}%).\".Display();\n",
-    ""
+    "$\"{gamesWithNash} jeux ont au moins 1 Nash pur ({100.0 * gamesWithNash / allGames.Count:F1}%).\".Display();\n"
    ]
   },
   {
@@ -948,10 +956,10 @@
    "id": "67963dee",
    "metadata": {
     "papermill": {
-     "duration": 0.00326,
-     "end_time": "2026-07-06T18:50:33.119702",
+     "duration": 0.013501,
+     "end_time": "2026-08-15T08:30:07.072841",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.116442",
+     "start_time": "2026-08-15T08:30:07.059340",
      "status": "completed"
     },
     "tags": []
@@ -968,16 +976,16 @@
    "id": "d4cbc52d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:33.126571Z",
-     "iopub.status.busy": "2026-07-06T18:50:33.126404Z",
-     "iopub.status.idle": "2026-07-06T18:50:33.208851Z",
-     "shell.execute_reply": "2026-07-06T18:50:33.208735Z"
+     "iopub.execute_input": "2026-08-15T08:30:07.103875Z",
+     "iopub.status.busy": "2026-08-15T08:30:07.103875Z",
+     "iopub.status.idle": "2026-08-15T08:30:07.168387Z",
+     "shell.execute_reply": "2026-08-15T08:30:07.168387Z"
     },
     "papermill": {
-     "duration": 0.086121,
-     "end_time": "2026-07-06T18:50:33.208911",
+     "duration": 0.080132,
+     "end_time": "2026-08-15T08:30:07.168387",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.122790",
+     "start_time": "2026-08-15T08:30:07.088255",
      "status": "completed"
     },
     "tags": []
@@ -1036,10 +1044,10 @@
    "id": "60d8ab70",
    "metadata": {
     "papermill": {
-     "duration": 0.003076,
-     "end_time": "2026-07-06T18:50:33.215138",
+     "duration": 0.014185,
+     "end_time": "2026-08-15T08:30:07.197517",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.212062",
+     "start_time": "2026-08-15T08:30:07.183332",
      "status": "completed"
     },
     "tags": []
@@ -1056,16 +1064,16 @@
    "id": "5e61e78f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:33.222433Z",
-     "iopub.status.busy": "2026-07-06T18:50:33.222265Z",
-     "iopub.status.idle": "2026-07-06T18:50:33.385172Z",
-     "shell.execute_reply": "2026-07-06T18:50:33.385014Z"
+     "iopub.execute_input": "2026-08-15T08:30:07.227860Z",
+     "iopub.status.busy": "2026-08-15T08:30:07.227860Z",
+     "iopub.status.idle": "2026-08-15T08:30:07.308943Z",
+     "shell.execute_reply": "2026-08-15T08:30:07.308943Z"
     },
     "papermill": {
-     "duration": 0.167069,
-     "end_time": "2026-07-06T18:50:33.385239",
+     "duration": 0.09694,
+     "end_time": "2026-08-15T08:30:07.308943",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.218170",
+     "start_time": "2026-08-15T08:30:07.212003",
      "status": "completed"
     },
     "tags": []
@@ -1130,19 +1138,221 @@
   },
   {
    "cell_type": "markdown",
+   "id": "83889397e656425db789ab3f3ff6b080",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015208,
+     "end_time": "2026-08-15T08:30:07.340513",
+     "exception": false,
+     "start_time": "2026-08-15T08:30:07.325305",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "## 10. Tranche 2 — Graphe des swaps via QuikGraph (moteur .NET natif)\n",
+    "\n",
+    "Le jumeau Python construit ce graphe via **networkx** (`build_swap_graph`, `nx.Graph`) et calcule\n",
+    "les distances via `nx.shortest_path_length`. La tranche 1 de ce notebook (cellules 4, 8, 9)\n",
+    "implémente ces mêmes BFS from-scratch en BCL .NET. **Tranche 2** : on délègue à **QuikGraph 2.5.0**\n",
+    "(moteur .NET natif, MIT) — construction du graphe, BFS de distance et matrice des distances,\n",
+    "le même pattern que Search-15 / Sudoku-9 dans ce dépôt. On vérifie la **parité** : les comptes\n",
+    "(576 nœuds / 1728 arêtes / degré moyen 6.0) et les 25 distances entre jeux classiques doivent\n",
+    "être identiques à la matrice de la cellule 9 ainsi qu'aux comptes networkx."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "dd08eaf40589459b912449c80e5e634e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T08:30:07.371948Z",
+     "iopub.status.busy": "2026-08-15T08:30:07.371948Z",
+     "iopub.status.idle": "2026-08-15T08:30:07.818371Z",
+     "shell.execute_reply": "2026-08-15T08:30:07.818371Z"
+    },
+    "papermill": {
+     "duration": 0.46449,
+     "end_time": "2026-08-15T08:30:07.819471",
+     "exception": false,
+     "start_time": "2026-08-15T08:30:07.354981",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>QuikGraph, 2.5.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Tranche 2 : Graphe des swaps via QuikGraph (moteur .NET natif) ===\r\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Noeuds (jeux)  : 576  (attendu 576, parite networkx)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Aretes (swaps) : 1728  (attendu 1728 = 576 x 6 / 2, parite networkx)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Degre moyen    : 6,0  (attendu 6.0 : 3 swaps x 2 joueurs)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Matrice des distances (BFS QuikGraph) entre jeux classiques :"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "                  Prisoner Stag Hun Battle o  Chicken Matching \r\n",
+       "-----------------------------------------------------------\r\n",
+       "Prisoner's Di        0        2        5        2        5 \r\n",
+       "Stag Hunt            2        0        3        4        5 \r\n",
+       "Battle of Sex        5        3        0        7        4 \r\n",
+       "Chicken              2        4        7        0        5 \r\n",
+       "Matching Penn        5        5        4        5        0 \r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Parite QuikGraph vs BFS maison : IDENTIQUE (25/25 distances)"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Cellule 10 — Tranche 2 : Graphe des swaps via QuikGraph 2.5.0 (moteur .NET natif)\n",
+    "// Le jumeau Python construit ce meme graphe via networkx (build_swap_graph, nx.Graph) et\n",
+    "// calcule les distances via nx.shortest_path_length. La tranche 1 (cellules 4, 8, 9) fait ces\n",
+    "// BFS from-scratch en BCL .NET ; la tranche 2 delegue a QuikGraph (MIT, moteur .NET natif),\n",
+    "// meme pattern que Search-15 / Sudoku-9 / Search-3 dans ce depot.\n",
+    "#r \"nuget: QuikGraph, 2.5.0\"\n",
+    "using QuikGraph;\n",
+    "using QuikGraph.Algorithms.Search;\n",
+    "\n",
+    "// (1) Construction du graphe des swaps : 576 noeuds, aretes = swaps adjacents Row/Col.\n",
+    "Console.WriteLine(\"=== Tranche 2 : Graphe des swaps via QuikGraph (moteur .NET natif) ===\");\n",
+    "var swapGraph = new UndirectedGraph<OrdinalGame, Edge<OrdinalGame>>(false);\n",
+    "foreach (var g in allGames) swapGraph.AddVertex(g);\n",
+    "var swapsT2 = new[] { (1,2), (2,3), (3,4) };\n",
+    "int addedT2 = 0;\n",
+    "foreach (var g in allGames)\n",
+    "{\n",
+    "    foreach (var (r1, r2) in swapsT2)\n",
+    "    {\n",
+    "        var nR = ApplyRowSwap(g, r1, r2);\n",
+    "        if (!swapGraph.ContainsEdge(new Edge<OrdinalGame>(g, nR)))\n",
+    "        {\n",
+    "            swapGraph.AddEdge(new Edge<OrdinalGame>(g, nR)); addedT2++;\n",
+    "        }\n",
+    "        var nC = ApplyColSwap(g, r1, r2);\n",
+    "        if (!swapGraph.ContainsEdge(new Edge<OrdinalGame>(g, nC)))\n",
+    "        {\n",
+    "            swapGraph.AddEdge(new Edge<OrdinalGame>(g, nC)); addedT2++;\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "$\"Noeuds (jeux)  : {swapGraph.VertexCount}  (attendu 576, parite networkx)\".Display();\n",
+    "$\"Aretes (swaps) : {swapGraph.EdgeCount}  (attendu 1728 = 576 x 6 / 2, parite networkx)\".Display();\n",
+    "$\"Degre moyen    : {2.0 * swapGraph.EdgeCount / swapGraph.VertexCount:F1}  (attendu 6.0 : 3 swaps x 2 joueurs)\".Display();\n",
+    "\n",
+    "// (2) BFS QuikGraph : distance en nombre de swaps entre deux jeux (parite nx.shortest_path_length).\n",
+    "int QDistance(OrdinalGame start, OrdinalGame target)\n",
+    "{\n",
+    "    var bfs = new UndirectedBreadthFirstSearchAlgorithm<OrdinalGame, Edge<OrdinalGame>>(swapGraph);\n",
+    "    var dist = new Dictionary<OrdinalGame, int> { [start] = 0 };\n",
+    "    bfs.TreeEdge += (_, args) => dist[args.Target] = dist[args.Source] + 1;\n",
+    "    bfs.Compute(start);\n",
+    "    return dist.TryGetValue(target, out var d) ? d : -1;\n",
+    "}\n",
+    "\n",
+    "// (3) Matrice des distances entre jeux classiques via QuikGraph (parite matrice cellule 9).\n",
+    "var namesT2 = ClassicGames.Keys.ToList();\n",
+    "var sbT2 = new System.Text.StringBuilder();\n",
+    "sbT2.Append(\"                  \");\n",
+    "foreach (var n in namesT2) sbT2.Append($\"{n.Substring(0, Math.Min(8, n.Length)),8} \");\n",
+    "sbT2.AppendLine();\n",
+    "sbT2.AppendLine(new string('-', 14 + namesT2.Count * 9));\n",
+    "foreach (var n1 in namesT2)\n",
+    "{\n",
+    "    sbT2.Append($\"{n1.Substring(0, Math.Min(13, n1.Length)),-13} \");\n",
+    "    foreach (var n2 in namesT2)\n",
+    "    {\n",
+    "        int d = (n1 == n2) ? 0 : QDistance(ClassicGames[n1], ClassicGames[n2]);\n",
+    "        sbT2.Append($\"{d,8} \");\n",
+    "    }\n",
+    "    sbT2.AppendLine();\n",
+    "}\n",
+    "\"Matrice des distances (BFS QuikGraph) entre jeux classiques :\".Display();\n",
+    "sbT2.ToString().Display();\n",
+    "\n",
+    "// (4) Parite tranche 1 (BFS maison, cellule 4) : chaque distance identique.\n",
+    "int mismatchT2 = 0;\n",
+    "foreach (var n1 in namesT2)\n",
+    "foreach (var n2 in namesT2)\n",
+    "{\n",
+    "    int dHome = (n1 == n2) ? 0 : SwapDistance(ClassicGames[n1], ClassicGames[n2]).distance;\n",
+    "    int dQ = (n1 == n2) ? 0 : QDistance(ClassicGames[n1], ClassicGames[n2]);\n",
+    "    if (dHome != dQ) mismatchT2++;\n",
+    "}\n",
+    "$\"Parite QuikGraph vs BFS maison : {(mismatchT2 == 0 ? \"IDENTIQUE (25/25 distances)\" : $\"{mismatchT2} ecarts\")}\".Display();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1ffcdb66",
    "metadata": {
     "papermill": {
-     "duration": 0.003564,
-     "end_time": "2026-07-06T18:50:33.392436",
+     "duration": 0.014713,
+     "end_time": "2026-08-15T08:30:07.849816",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.388872",
+     "start_time": "2026-08-15T08:30:07.835103",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 10. Exercices\n",
+    "## 11. Exercices\n",
     "\n",
     "Trois extensions à compléter (stubs sans erreur — règle C.1). Le notebook s'exécute de bout en bout même non complété.\n"
    ]
@@ -1152,10 +1362,10 @@
    "id": "0bd2e514",
    "metadata": {
     "papermill": {
-     "duration": 0.003614,
-     "end_time": "2026-07-06T18:50:33.399867",
+     "duration": 0.014846,
+     "end_time": "2026-08-15T08:30:07.881498",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.396253",
+     "start_time": "2026-08-15T08:30:07.866652",
      "status": "completed"
     },
     "tags": []
@@ -1170,20 +1380,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "e0b1a31a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:33.412407Z",
-     "iopub.status.busy": "2026-07-06T18:50:33.412206Z",
-     "iopub.status.idle": "2026-07-06T18:50:33.487754Z",
-     "shell.execute_reply": "2026-07-06T18:50:33.487216Z"
+     "iopub.execute_input": "2026-08-15T08:30:07.915265Z",
+     "iopub.status.busy": "2026-08-15T08:30:07.915265Z",
+     "iopub.status.idle": "2026-08-15T08:30:07.955270Z",
+     "shell.execute_reply": "2026-08-15T08:30:07.955270Z"
     },
     "papermill": {
-     "duration": 0.084454,
-     "end_time": "2026-07-06T18:50:33.487930",
+     "duration": 0.057217,
+     "end_time": "2026-08-15T08:30:07.955270",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.403476",
+     "start_time": "2026-08-15T08:30:07.898053",
      "status": "completed"
     },
     "tags": []
@@ -1219,10 +1429,10 @@
    "id": "88dbe623",
    "metadata": {
     "papermill": {
-     "duration": 0.003752,
-     "end_time": "2026-07-06T18:50:33.496350",
+     "duration": 0.015965,
+     "end_time": "2026-08-15T08:30:07.989567",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.492598",
+     "start_time": "2026-08-15T08:30:07.973602",
      "status": "completed"
     },
     "tags": []
@@ -1237,20 +1447,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "927f16c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:33.504842Z",
-     "iopub.status.busy": "2026-07-06T18:50:33.504544Z",
-     "iopub.status.idle": "2026-07-06T18:50:33.544176Z",
-     "shell.execute_reply": "2026-07-06T18:50:33.544063Z"
+     "iopub.execute_input": "2026-08-15T08:30:08.023182Z",
+     "iopub.status.busy": "2026-08-15T08:30:08.023182Z",
+     "iopub.status.idle": "2026-08-15T08:30:08.048455Z",
+     "shell.execute_reply": "2026-08-15T08:30:08.048455Z"
     },
     "papermill": {
-     "duration": 0.044475,
-     "end_time": "2026-07-06T18:50:33.544236",
+     "duration": 0.041134,
+     "end_time": "2026-08-15T08:30:08.048455",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.499761",
+     "start_time": "2026-08-15T08:30:08.007321",
      "status": "completed"
     },
     "tags": []
@@ -1285,10 +1495,10 @@
    "id": "01d879f6",
    "metadata": {
     "papermill": {
-     "duration": 0.003264,
-     "end_time": "2026-07-06T18:50:33.551087",
+     "duration": 0.016312,
+     "end_time": "2026-08-15T08:30:08.080056",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.547823",
+     "start_time": "2026-08-15T08:30:08.063744",
      "status": "completed"
     },
     "tags": []
@@ -1303,20 +1513,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "c7e3ef80",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T18:50:33.558658Z",
-     "iopub.status.busy": "2026-07-06T18:50:33.558492Z",
-     "iopub.status.idle": "2026-07-06T18:50:33.598091Z",
-     "shell.execute_reply": "2026-07-06T18:50:33.597973Z"
+     "iopub.execute_input": "2026-08-15T08:30:08.114284Z",
+     "iopub.status.busy": "2026-08-15T08:30:08.114284Z",
+     "iopub.status.idle": "2026-08-15T08:30:08.139667Z",
+     "shell.execute_reply": "2026-08-15T08:30:08.139667Z"
     },
     "papermill": {
-     "duration": 0.04389,
-     "end_time": "2026-07-06T18:50:33.598152",
+     "duration": 0.043342,
+     "end_time": "2026-08-15T08:30:08.139667",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.554262",
+     "start_time": "2026-08-15T08:30:08.096325",
      "status": "completed"
     },
     "tags": []
@@ -1351,16 +1561,16 @@
    "id": "091171e8",
    "metadata": {
     "papermill": {
-     "duration": 0.003205,
-     "end_time": "2026-07-06T18:50:33.604866",
+     "duration": 0.015936,
+     "end_time": "2026-08-15T08:30:08.171979",
      "exception": false,
-     "start_time": "2026-07-06T18:50:33.601661",
+     "start_time": "2026-08-15T08:30:08.156043",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 11. Résumé\n",
+    "## 12. Résumé\n",
     "\n",
     "Ce twin C# a reconstruit from-scratch (BCL .NET 9, 0 NuGet) toute la topologie des jeux 2×2 ordinaux :\n",
     "\n",
@@ -1389,6 +1599,24 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 4,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": false,
+   "notes": "Jumeau .NET Interactive C# : classification topologique 2×2. cf L532 MEMORY : strip_probe_banner.py post-re-exec.",
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "dotnet-interactive",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
@@ -1403,33 +1631,15 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 5.635798,
-   "end_time": "2026-07-06T18:50:33.735732",
+   "duration": 5.89044,
+   "end_time": "2026-08-15T08:30:08.299852",
    "environment_variables": {},
    "exception": null,
-   "input_path": "GameTheory-3-Topology2x2-Csharp.ipynb",
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb",
    "output_path": "GameTheory-3-Topology2x2-Csharp.ipynb",
    "parameters": {},
-   "start_time": "2026-07-06T18:50:28.099934",
+   "start_time": "2026-08-15T08:30:02.409412",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "cpu_min": 4,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-28",
-   "validator": "dotnet-interactive",
-   "notes": "Jumeau .NET Interactive C# : classification topologique 2×2. cf L532 MEMORY : strip_probe_banner.py post-re-exec."
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-3-topology2x2.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-3-topology2x2.yaml
@@ -2,9 +2,9 @@
   family: GameTheory/.NET-Parity
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb
-  parity_level: semantic
-  bridge_verdict: RECOVERABLE-LOCAL
-  bridge_verdict_reason: "Python = networkx (lib SOTA, graphe des topologies 2x2 PD/Chicken/Stag-Hunt/Coordination, viz des regions d'equilibre Nash). C# = from-scratch en pur Linq (4 types 2x2 enumeres a la main, 0 NuGet SOTA tiers). Lib SOTA .NET existe (QuickGraph, MIT-license, mature) et peut etre branchee. RECOVERABLE-LOCAL = pont faisable, pas encore wire. parite semantique preservee (meme socle theorique : taxonomie des 4 topologies 2x2, prediction analytique des conditions de cooperation)."
+  parity_level: native-both
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Python = networkx (lib SOTA, graphe des topologies 2x2 PD/Chicken/Stag-Hunt/Coordination, viz des regions d'equilibre Nash). C# = tranche 1 from-scratch en pur Linq (BCL .NET 9, 0 NuGet) PUIS tranche 2 (2026-08-15) bridge le moteur .NET natif QuikGraph 2.5.0 : graphe des swaps construit sur les 576 jeux (1728 aretes = 576 x 6 / 2, degre moyen 6,0 = 3 swaps x 2 joueurs, comptes verifies contre le twin networkx), BFS shortest-path via UndirectedBreadthFirstSearchAlgorithm, parite BFS QuikGraph vs BFS maison : IDENTIQUE 25/25 distances (matrice des jeux classiques). SOTA-OK : le vrai moteur est branche et produit des sorties reelles."
   audits:
     - python_sha: ac9b8aee4ae0785bfefe6c10f64cfb3e13a38c54
       csharp_sha: b09da0acd68389084b6ff1fac9c565169a85ab06
@@ -21,7 +21,13 @@
       csharp_sha: b09da0acd68389084b6ff1fac9c565169a85ab06
       content_python_sha: 88aa84c0f790cc07445940d900bb0084abeb9af5c5de61e21974d4003ac07ad2
       content_csharp_sha: e9b7eeee3f79a4af592a353f59f21c0dcf3cd6a21ddb978e636298a218e30ec4
+    - date: "2026-08-15"
+      by: myia-po-2026:CoursIA-2
+      python_sha: ac9b8aee4ae0785bfefe6c10f64cfb3e13a38c54
+      csharp_sha: 3eefd90a0b918ef6da907cd5efc6eef7bea3b426
+      content_python_sha: 88aa84c0f790cc07445940d900bb0084abeb9af5c5de61e21974d4003ac07ad2
+      content_csharp_sha: 02a7121eec1f1793250e6c76bc9a191abebe4ce7aa92d6eb9fd855965afecc5a
   known_differences:
     - "Socle pedagogique commun : representation ordinale des jeux 2x2 (4 rangs par joueur), classification topologique des 5 archetypes strategiques (Prisonnier, Stag Hunt, BoS, Poulet, Matching Pennies) sur le carre des preferences ordinales."
     - "Idiomes framework : Python = `numpy` + `matplotlib` + `networkx` + classe `OrdinalGame` from-scratch (dataclass + equals). C# = `System.*` (Collections.Generic, Linq) + classe `OrdinalGame` from-scratch (IEquatable<OrdinalGame>)."
-    - "Asymetrie : Python s'appuie sur networkx pour la viz de graphes d'isomorphisme entre jeux ; C# travaille en pur System.* (Linq pour les manipulations). Valeur pedagogique = voir la structure OrdinalGame sous deux perspectives framework (lib graph externe vs Linq integre)."
+    - "Asymetrie (resolue en tranche 2) : Python s'appuie sur networkx (graphe + BFS + layout) ; C# tranche 1 = pur System.* (Linq), tranche 2 = bridge QuikGraph 2.5.0 (UndirectedGraph + UndirectedBreadthFirstSearchAlgorithm) pour la meme capacite de graphe/BFS que networkx, avec parite 25/25 des distances. Valeur pedagogique = voir la structure OrdinalGame sous deux perspectives framework (lib graph externe branchable : networkx en Python, QuikGraph en C#)."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2026:CoursIA-2 — prev: MED/training #11036

## Summary

**#10382 Parité lib-vs-lib — GameTheory-3 Topology2x2 (bucket 1)** : le twin C#
[GameTheory-3-Topology2x2-Csharp](MyIA.AI.Notebooks/GameTheory/GameTheory-3-Topology2x2-Csharp.ipynb)
était from-scratch pur Linq (0 NuGet, aucun moteur bridgé) alors que le twin
Python bridge **networkx**. La **tranche 2** ajoute le moteur .NET natif
**QuikGraph 2.5.0** en reprenant une expérience concrète du jumeau Python : le
graphe des swaps entre les 576 jeux 2×2 ordinaux + le plus-court-chemin BFS.

La tranche 1 (from-scratch, pédagogique) est **préservée intégralement**.

## Tranche 2 — Graphe des swaps via QuikGraph (moteur .NET natif)

Nouvelle section 10 + cellule « Cellule 10 — Tranche 2 » :

- `#r "nuget: QuikGraph, 2.5.0"` — moteur SOTA .NET bridgé (le twin Python utilise networkx pour le même rôle).
- **Construction** : `UndirectedGraph<OrdinalGame, Edge<OrdinalGame>>` sur les 576 jeux, arêtes = swaps de rangs (1↔2, 2↔3, 3↔4, par joueur).
- **Comptes vérifiés contre le twin networkx** :
  - `Noeuds (jeux)  : 576  (attendu 576, parite networkx)`
  - `Aretes (swaps) : 1728  (attendu 1728 = 576 x 6 / 2, parite networkx)`
  - `Degre moyen    : 6,0  (attendu 6.0 : 3 swaps x 2 joueurs)`
- **BFS shortest-path** via `UndirectedBreadthFirstSearchAlgorithm` (API non-orientée de QuikGraph — la variante orientée `BreadthFirstSearchAlgorithm` est incompatible avec `UndirectedGraph`).
- **Parité QuikGraph vs BFS maison (tranche 1)** : `IDENTIQUE (25/25 distances)` — matrice des distances entre jeux classiques, les deux moteurs donnent exactement les mêmes plus-courts-chemin.

## Validation

- **Exécution réelle** : papermill (kernel .net-csharp), cellule tranche 2 → 8 outputs, 0 erreur ; 13/13 `execution_count` non-nuls (C.2).
- **`validate_pr_notebooks.py`** : `EXEC_PROVED`, 13 cellules code, 0 erreur.
- **Diff cellule-à-cellule vs main** : 2 cellules ajoutées (markdown tranche 2 + code tranche 2), 2 cellules renumérotées uniquement (Exercices 10→11, Résumé 11→12), toutes les autres sources byte-identiques. Le reste du diff = timestamps d'exécution + port kernel éphémère (bénin).
- **probeAddresses** : strip post-re-exec appliqué (L532) — 9 lignes retirées, scan 0.
- **C.1** : 0 violation. **H.3** : pre-commit OK. **Catalogue** : byte-identique à main.
- **Twin parity** : `gametheory-3-topology2x2.yaml` → `parity_level: native-both`, `bridge_verdict: SOTA-OK`, audit 2026-08-15 (`myia-po-2026:CoursIA-2`, csharp_sha `3eefd90a`), rebaseline en dernier (`check_twin_parity.py --update`). Vérification : 157/157 OK, 0 DRIFT.
- **Verdict SOTA** : `SOTA-OK` — le vrai moteur (QuikGraph) est branché et produit des sorties réelles (comptes + matrice BFS).
- **L898** : aucune PR ouverte sur la branche ni le chemin au push.

See #10382
