### PR TITLE
feat(lean,#2159): Partie 39 — lois de treillis des topologies de Grothendieck (TopologyLattice)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -32,6 +32,7 @@ import Grothendieck.SieveLattice
 import Grothendieck.SieveOps
 import Grothendieck.SitePoints
 import Grothendieck.Subcanonical
+import Grothendieck.TopologyLattice
 import Grothendieck.YonedaLemma
 import Grothendieck.ZariskiSite
 /-

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/TopologyLattice.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/TopologyLattice.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 39 : lois de treillis des topologies
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Les parties 1-38 ont etabli les fondamentaux : categories, cribles,
+topologies, lois de treillis, identites de pullback, bases de faisceaux,
+cloture couvrante, calibration, sous-canonicalite, topologies denses,
+faisceaux, hom interne, cohomologie de Cech, limite de Mayer-Vietoris,
+extensions de Kan, adjonctions, monades, equivalences, categories monoidales,
+limites et colimites, couples comma, images directes, theoremes propres sur la
+forme fleche (`J.Covers S f`), sur la couverture bundlee (`J.Cover X`), les
+lois de coherence du pseudo-foncteur pullback (Partie 37) et les lois de
+foncteur du pullback (Partie 38).
+
+La Partie 39 etablit les **lois de treillis des topologies de Grothendieck** :
+Mathlib fournit la structure de treillis complet sur `GrothendieckTopology C`
+(instance `CompleteLattice`, construite depuis le `sInf` intersection
+ponctuelle), mais **ne fournit pas** les caracterisations par recouvrement des
+operations de treillis. Ce module les enonce et les prouve :
+
+  - `le_covering` : l'ordre est ponctuel — `J₁ ≤ J₂` si et seulement si tout
+    crible `S ∈ J₁ X` est aussi dans `J₂ X`.
+  - `le_covers` : l'ordre est compatible avec la forme fleche —
+    `J₁ ≤ J₂ → J₁.Covers S f → J₂.Covers S f`.
+  - `inf_covering` / `inf_covers` : `S ∈ (J₁ ⊓ J₂) X` si et seulement si
+    `S ∈ J₁ X` **et** `S ∈ J₂ X` — l'intersection des topologies est
+    l'intersection ponctuelle des cribles couvrants.
+  - `sup_covering` / `sup_covers` : la borne superieure est la **topologie
+    engendree** — `S ∈ (J₁ ⊔ J₂) X` si et seulement si `S` est couvert par
+    toute topologie `K` au-dessus de `J₁` et de `J₂` (caracterisation par
+    bornes superieures ; l'union ponctuelle ne suffit pas, elle n'est pas
+    stable par pullback).
+  - `sSup_covering` : la version infinie — `S ∈ sSup s X` si et seulement si
+    `S` est couvert par toute borne superieure du membre `s`.
+
+Chaque preuve est une **preuve tactique reelle** (veine DEEP) : les axiomes
+de treillis (`le_sInf`, `sInf_le`, `le_sSup`, `sSup_le`, `le_inf`,
+`inf_le_left`/`inf_le_right`, `sup_le`, `le_sup_left`/`le_sup_right`) plus
+`le_covering` ramenant la compatibilite ordre/recouvrement. Aucune preuve
+n'est un re-export.
+
+EPIC #1646, Phase 5 (#2159). Tous les `sorry`s elimines a la creation.
+
+### Convention i18n (EPIC #4980 ratifiee par user 2026-07-04)
+
+Ce module est apparie avec son jumeau anglais dans le fichier sibling
+`TopologyLattice_en.lean` (modele sibling pair, voir PR #6154 pour le pilote
+sur `Utility.lean`). Namespace suffix `_en` applique au fichier EN
+(anti-collision, conforme code-style.md #4980). Les enonces de theoremes, les
+noms de lemmes, les tactiques Lean et les references Mathlib restent en
+anglais ; seules les docstrings `/-- ... -/` et les commentaires `-- ...`
+different entre les deux fichiers (preservation byte-identity).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.TopologyLattice
+
+open CategoryTheory
+
+/-!
+## Section 1 : ordre et forme fleche
+
+L'ordre sur `GrothendieckTopology C` est l'ordre ponctuel sur les familles de
+cribles (`le_def` de Mathlib). La forme fleche `J.Covers S f` est definie par
+`S.pullback f ∈ J Y` (Mathlib, `covers_iff`). Cette section relie les deux.
+-/
+
+/-- L'ordre des topologies est ponctuel : `J₁ ≤ J₂` si et seulement si tout
+    crible couvert par `J₁` est couvert par `J₂`.
+    Preuve : `le_def` puis l'ordre ponctuel des fonctions (definitionnel),
+    decompose en appartenances ponctuelles. -/
+theorem le_covering {C : Type*} [Category C] {J₁ J₂ : GrothendieckTopology C} :
+    J₁ ≤ J₂ ↔ ∀ ⦃X : C⦄ (S : Sieve X), S ∈ J₁ X → S ∈ J₂ X := by
+  rw [GrothendieckTopology.le_def]
+  constructor
+  · intro h X S hS
+    exact h X hS
+  · intro h X S hS
+    exact h S hS
+
+/-- L'ordre est compatible avec la forme fleche : si `J₁ ≤ J₂`, tout crible
+    que `J₁` couvre le long de `f`, `J₂` le couvre aussi.
+    Preuve : `covers_iff` des deux cotes (les deux membres sont `∈ J₁ Y` /
+    `∈ J₂ Y`) puis `le_covering`. -/
+theorem le_covers {C : Type*} [Category C] {X Y : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) (f : Y ⟶ X) :
+    J₁ ≤ J₂ → J₁.Covers S f → J₂.Covers S f := by
+  intro h₁₂ hc
+  rw [GrothendieckTopology.covers_iff] at hc ⊢
+  exact le_covering.mp h₁₂ (S.pullback f) hc
+
+/-!
+## Section 2 : borne inferieure (inf)
+
+La borne inferieure `J₁ ⊓ J₂` de deux topologies est le `sInf` de la paire
+(infimum du treillis complet), et par `mem_sInf` de Mathlib sa
+caracterisation ponctuelle est l'intersection des cribles couvrants. Cette
+section prouve ces caracterisations et leur traduction a la forme fleche.
+-/
+
+/-- L'infimum d'une paire est le `sInf` de la paire : `J₁ ⊓ J₂ = sInf {J₁, J₂}`.
+    Preuve : `le_antisymm` — d'un cote `le_sInf` avec `inf_le_left` /
+    `inf_le_right`, de l'autre `le_inf` avec `sInf_le` deux fois. -/
+lemma inf_eq_sInf {C : Type*} [Category C] {J₁ J₂ : GrothendieckTopology C} :
+    J₁ ⊓ J₂ = sInf {J₁, J₂} := by
+  apply le_antisymm
+  · apply le_sInf
+    intro J hJ
+    simp at hJ
+    rcases hJ with rfl | rfl
+    · exact inf_le_left
+    · exact inf_le_right
+  · apply le_inf
+    · apply sInf_le
+      simp
+    · apply sInf_le
+      simp
+
+/-- L'intersection de deux topologies est l'intersection ponctuelle :
+    `S ∈ (J₁ ⊓ J₂) X` si et seulement si `S ∈ J₁ X` et `S ∈ J₂ X`.
+    Preuve : `inf_eq_sInf` puis `mem_sInf` de Mathlib, et decomposer
+    l'appartenance a la paire `{J₁, J₂}`. -/
+theorem inf_covering {C : Type*} [Category C] {X : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) :
+    S ∈ (J₁ ⊓ J₂) X ↔ S ∈ J₁ X ∧ S ∈ J₂ X := by
+  rw [inf_eq_sInf]
+  rw [GrothendieckTopology.mem_sInf]
+  constructor
+  · intro h
+    exact ⟨h J₁ (by simp), h J₂ (by simp)⟩
+  · intro h K hK
+    simp at hK
+    rcases hK with rfl | rfl
+    · exact h.1
+    · exact h.2
+
+/-- Traduction de `inf_covering` a la forme fleche : couvrir par `J₁ ⊓ J₂`
+    equivaut a couvrir par `J₁` et par `J₂`.
+    Preuve : `covers_iff` trois fois (les trois membres sont des appartenances
+    `∈ (J₁ ⊓ J₂) Y` / `∈ J₁ Y` / `∈ J₂ Y`) puis `inf_covering`. -/
+theorem inf_covers {C : Type*} [Category C] {X Y : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) (f : Y ⟶ X) :
+    (J₁ ⊓ J₂).Covers S f ↔ J₁.Covers S f ∧ J₂.Covers S f := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    GrothendieckTopology.covers_iff]
+  exact inf_covering (S.pullback f)
+
+/-!
+## Section 3 : borne superieure (sup, sSup)
+
+La borne superieure `J₁ ⊔ J₂` de deux topologies est la **topologie
+engendree** par la reunion des cribles : la plus petite topologie au-dessus
+des deux. La caracterisation correcte n'est donc pas l'union ponctuelle (qui
+n'est pas stable par pullback) mais la caracterisation par bornes superieures :
+`S ∈ (J₁ ⊔ J₂) X` si et seulement si `S` est couvert par **toute** topologie
+au-dessus de `J₁` et de `J₂`. Cette section prouve ces caracterisations ainsi
+que leur version infinie `sSup`.
+-/
+
+/-- Borne superieure d'une paire, caracterisation par recouvrement :
+    `S ∈ (J₁ ⊔ J₂) X` si et seulement si `S ∈ K X` pour toute topologie `K`
+    au-dessus de `J₁` et de `J₂` (la topologie engendree).
+    Preuve : dans un sens `sup_le` puis `le_covering` ; dans l'autre, prendre
+    `K = J₁ ⊔ J₂`, borne superieure des deux par `le_sup_left`/`le_sup_right`. -/
+theorem sup_covering {C : Type*} [Category C] {X : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) :
+    S ∈ (J₁ ⊔ J₂) X ↔
+      ∀ K : GrothendieckTopology C, J₁ ≤ K → J₂ ≤ K → S ∈ K X := by
+  constructor
+  · intro hS K h₁K h₂K
+    exact le_covering.mp (sup_le h₁K h₂K) S hS
+  · intro h
+    exact h (J₁ ⊔ J₂) le_sup_left le_sup_right
+
+/-- Traduction de `sup_covering` a la forme fleche.
+    Preuve : `covers_iff` deux fois puis `sup_covering`. -/
+theorem sup_covers {C : Type*} [Category C] {X Y : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) (f : Y ⟶ X) :
+    (J₁ ⊔ J₂).Covers S f ↔
+      ∀ K : GrothendieckTopology C, J₁ ≤ K → J₂ ≤ K → K.Covers S f := by
+  rw [GrothendieckTopology.covers_iff]
+  constructor
+  · intro hS K h₁K h₂K
+    rw [GrothendieckTopology.covers_iff]
+    exact le_covering.mp (sup_le h₁K h₂K) (S.pullback f) hS
+  · intro h
+    rw [← GrothendieckTopology.covers_iff]
+    exact h (J₁ ⊔ J₂) le_sup_left le_sup_right
+
+/-- Borne superieure d'une famille, caracterisation par recouvrement :
+    `S ∈ sSup s X` si et seulement si `S ∈ K X` pour toute borne superieure
+    `K` du membre `s`.
+    Preuve : dans un sens `sSup_le` puis `le_covering` ; dans l'autre, prendre
+    `K = sSup s`, borne superieure du membre par `le_sSup`. -/
+theorem sSup_covering {C : Type*} [Category C] {X : C} (s : Set (GrothendieckTopology C))
+    (S : Sieve X) :
+    S ∈ sSup s X ↔ ∀ K : GrothendieckTopology C, (∀ J ∈ s, J ≤ K) → S ∈ K X := by
+  constructor
+  · intro hS K hK
+    exact le_covering.mp (sSup_le hK) S hS
+  · intro h
+    exact h (sSup s) fun J hJ => le_sSup hJ
+
+end Grothendieck.TopologyLattice

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/TopologyLattice_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/TopologyLattice_en.lean
@@ -1,0 +1,207 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Grothendieck Homage — Part 39 : lattice laws of the topologies
+
+Alexandre Grothendieck (1928-2014).
+
+Phase 5 extension (#2159, EPIC #1646).
+
+Parts 1-38 established the fundamentals : categories, sieves, topologies,
+lattice laws, pullback identities, sheaf bases, covering closure,
+calibration, subcanonicity, dense topologies, sheaves, internal hom, Cech
+cohomology, Mayer-Vietoris limit, Kan extensions, adjunctions, monads,
+equivalences, monoidal categories, limits and colimits, comma couples,
+direct images, proper theorems on the arrow form (`J.Covers S f`), on the
+bundled cover (`J.Cover X`), the pullback pseudofunctor coherence laws
+(Part 37) and the pullback functor laws (Part 38).
+
+Part 39 establishes the **lattice laws of the Grothendieck topologies** :
+Mathlib provides the complete lattice structure on `GrothendieckTopology C`
+(`CompleteLattice` instance, built from the pointwise-intersection `sInf`),
+but does **not** provide the covering characterizations of the lattice
+operations. This module states and proves them :
+
+  - `le_covering` : the order is pointwise — `J₁ ≤ J₂` if and only if every
+    sieve `S ∈ J₁ X` also belongs to `J₂ X`.
+  - `le_covers` : the order is compatible with the arrow form —
+    `J₁ ≤ J₂ → J₁.Covers S f → J₂.Covers S f`.
+  - `inf_covering` / `inf_covers` : `S ∈ (J₁ ⊓ J₂) X` if and only if
+    `S ∈ J₁ X` **and** `S ∈ J₂ X` — the intersection of topologies is the
+    pointwise intersection of the covering sieves.
+  - `sup_covering` / `sup_covers` : the join is the **generated topology** —
+    `S ∈ (J₁ ⊔ J₂) X` if and only if `S` is covered by every topology `K`
+    above both `J₁` and `J₂` (upper-bound characterization ; the pointwise
+    union is not enough, it is not pullback-stable).
+  - `sSup_covering` : the infinite version — `S ∈ sSup s X` if and only if
+    `S` is covered by every upper bound of the family `s`.
+
+Each proof is a **real tactic proof** (DEEP vein) : the lattice axioms
+(`le_sInf`, `sInf_le`, `le_sSup`, `sSup_le`, `le_inf`, `inf_le_left` /
+`inf_le_right`, `sup_le`, `le_sup_left` / `le_sup_right`) plus `le_covering`
+reducing the order/covering compatibility. No proof is a re-export.
+
+EPIC #1646, Phase 5 (#2159). All `sorry`s eliminated at creation.
+
+### i18n convention (EPIC #4980 ratified by user 2026-07-04)
+
+This module is paired with its French twin in the sibling file
+`TopologyLattice.lean` (sibling pair model, see PR #6154 for the pilot on
+`Utility.lean`). The `_en` suffix is applied to this English file's namespace
+(anti-collision, per code-style.md #4980). Theorem statements, lemma names,
+Lean tactics and Mathlib references remain in English ; only the docstrings
+`/-- ... -/` and comments `-- ...` differ between the two files
+(byte-identity preservation).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.TopologyLattice_en
+
+open CategoryTheory
+
+/-!
+## Section 1 : order and arrow form
+
+The order on `GrothendieckTopology C` is the pointwise order on the families
+of sieves (`le_def` of Mathlib). The arrow form `J.Covers S f` is defined by
+`S.pullback f ∈ J Y` (Mathlib, `covers_iff`). This section relates the two.
+-/
+
+/-- The order of topologies is pointwise : `J₁ ≤ J₂` if and only if every
+    sieve covered by `J₁` is covered by `J₂`.
+    Proof : `le_def` then the pointwise order of functions (definitional),
+    decomposed into pointwise memberships. -/
+theorem le_covering {C : Type*} [Category C] {J₁ J₂ : GrothendieckTopology C} :
+    J₁ ≤ J₂ ↔ ∀ ⦃X : C⦄ (S : Sieve X), S ∈ J₁ X → S ∈ J₂ X := by
+  rw [GrothendieckTopology.le_def]
+  constructor
+  · intro h X S hS
+    exact h X hS
+  · intro h X S hS
+    exact h S hS
+
+/-- The order is compatible with the arrow form : if `J₁ ≤ J₂`, any sieve
+    covered by `J₁` along `f` is also covered by `J₂`.
+    Proof : `covers_iff` on both sides (both members are `∈ J₁ Y` / `∈ J₂ Y`)
+    then `le_covering`. -/
+theorem le_covers {C : Type*} [Category C] {X Y : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) (f : Y ⟶ X) :
+    J₁ ≤ J₂ → J₁.Covers S f → J₂.Covers S f := by
+  intro h₁₂ hc
+  rw [GrothendieckTopology.covers_iff] at hc ⊢
+  exact le_covering.mp h₁₂ (S.pullback f) hc
+
+/-!
+## Section 2 : infimum (inf)
+
+The infimum `J₁ ⊓ J₂` of two topologies is the `sInf` of the pair (the
+infimum of the complete lattice), and by `mem_sInf` of Mathlib its pointwise
+characterization is the intersection of the covering sieves. This section
+proves these characterizations and their translation to the arrow form.
+-/
+
+/-- The infimum of a pair is the `sInf` of the pair : `J₁ ⊓ J₂ = sInf {J₁, J₂}`.
+    Proof : `le_antisymm` — on one side `le_sInf` with `inf_le_left` /
+    `inf_le_right`, on the other `le_inf` with `sInf_le` twice. -/
+lemma inf_eq_sInf {C : Type*} [Category C] {J₁ J₂ : GrothendieckTopology C} :
+    J₁ ⊓ J₂ = sInf {J₁, J₂} := by
+  apply le_antisymm
+  · apply le_sInf
+    intro J hJ
+    simp at hJ
+    rcases hJ with rfl | rfl
+    · exact inf_le_left
+    · exact inf_le_right
+  · apply le_inf
+    · apply sInf_le
+      simp
+    · apply sInf_le
+      simp
+
+/-- The intersection of two topologies is the pointwise intersection :
+    `S ∈ (J₁ ⊓ J₂) X` if and only if `S ∈ J₁ X` and `S ∈ J₂ X`.
+    Proof : `inf_eq_sInf` then `mem_sInf` of Mathlib, and decomposing the
+    membership in the pair `{J₁, J₂}`. -/
+theorem inf_covering {C : Type*} [Category C] {X : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) :
+    S ∈ (J₁ ⊓ J₂) X ↔ S ∈ J₁ X ∧ S ∈ J₂ X := by
+  rw [inf_eq_sInf]
+  rw [GrothendieckTopology.mem_sInf]
+  constructor
+  · intro h
+    exact ⟨h J₁ (by simp), h J₂ (by simp)⟩
+  · intro h K hK
+    simp at hK
+    rcases hK with rfl | rfl
+    · exact h.1
+    · exact h.2
+
+/-- Translation of `inf_covering` to the arrow form : covering by `J₁ ⊓ J₂`
+    is equivalent to covering by `J₁` and by `J₂`.
+    Proof : `covers_iff` three times (the three members are memberships
+    `∈ (J₁ ⊓ J₂) Y` / `∈ J₁ Y` / `∈ J₂ Y`) then `inf_covering`. -/
+theorem inf_covers {C : Type*} [Category C] {X Y : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) (f : Y ⟶ X) :
+    (J₁ ⊓ J₂).Covers S f ↔ J₁.Covers S f ∧ J₂.Covers S f := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    GrothendieckTopology.covers_iff]
+  exact inf_covering (S.pullback f)
+
+/-!
+## Section 3 : supremum (sup, sSup)
+
+The join `J₁ ⊔ J₂` of two topologies is the **generated topology** by the
+union of the sieves : the smallest topology above both. The correct
+characterization is therefore not the pointwise union (which is not
+pullback-stable) but the upper-bound characterization : `S ∈ (J₁ ⊔ J₂) X`
+if and only if `S` is covered by **every** topology above both `J₁` and
+`J₂`. This section proves these characterizations together with their
+infinite `sSup` version.
+-/
+
+/-- Join of a pair, covering characterization : `S ∈ (J₁ ⊔ J₂) X` if and only
+    if `S ∈ K X` for every topology `K` above both `J₁` and `J₂` (the
+    generated topology).
+    Proof : one direction `sup_le` then `le_covering` ; the other, take
+    `K = J₁ ⊔ J₂`, an upper bound of both by `le_sup_left`/`le_sup_right`. -/
+theorem sup_covering {C : Type*} [Category C] {X : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) :
+    S ∈ (J₁ ⊔ J₂) X ↔
+      ∀ K : GrothendieckTopology C, J₁ ≤ K → J₂ ≤ K → S ∈ K X := by
+  constructor
+  · intro hS K h₁K h₂K
+    exact le_covering.mp (sup_le h₁K h₂K) S hS
+  · intro h
+    exact h (J₁ ⊔ J₂) le_sup_left le_sup_right
+
+/-- Translation of `sup_covering` to the arrow form.
+    Proof : `covers_iff` twice then `sup_covering`. -/
+theorem sup_covers {C : Type*} [Category C] {X Y : C} {J₁ J₂ : GrothendieckTopology C}
+    (S : Sieve X) (f : Y ⟶ X) :
+    (J₁ ⊔ J₂).Covers S f ↔
+      ∀ K : GrothendieckTopology C, J₁ ≤ K → J₂ ≤ K → K.Covers S f := by
+  rw [GrothendieckTopology.covers_iff]
+  constructor
+  · intro hS K h₁K h₂K
+    rw [GrothendieckTopology.covers_iff]
+    exact le_covering.mp (sup_le h₁K h₂K) (S.pullback f) hS
+  · intro h
+    rw [← GrothendieckTopology.covers_iff]
+    exact h (J₁ ⊔ J₂) le_sup_left le_sup_right
+
+/-- Supremum of a family, covering characterization : `S ∈ sSup s X` if and
+    only if `S ∈ K X` for every upper bound `K` of the family `s`.
+    Proof : one direction `sSup_le` then `le_covering` ; the other, take
+    `K = sSup s`, an upper bound of the family by `le_sSup`. -/
+theorem sSup_covering {C : Type*} [Category C] {X : C} (s : Set (GrothendieckTopology C))
+    (S : Sieve X) :
+    S ∈ sSup s X ↔ ∀ K : GrothendieckTopology C, (∀ J ∈ s, J ≤ K) → S ∈ K X := by
+  constructor
+  · intro hS K hK
+    exact le_covering.mp (sSup_le hK) S hS
+  · intro h
+    exact h (sSup s) fun J hJ => le_sSup hJ
+
+end Grothendieck.TopologyLattice_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #11035

## Summary

Partie 39 de l'hommage Grothendieck (#2159, EPIC #1646) : **lois de treillis
des topologies de Grothendieck**. Mathlib fournit la structure `CompleteLattice`
sur `GrothendieckTopology C` (construite depuis le `sInf` intersection
ponctuelle) mais **ne fournit pas** les caracterisations par recouvrement des
operations de treillis. Ce module les enonce et les prouve (7 theoremes +
1 lemme auxiliaire, veine DEEP) :

| Theoreme | Enonce |
|---|---|
| `le_covering` | `J₁ ≤ J₂ ↔ ∀ ⦃X⦄ (S : Sieve X), S ∈ J₁ X → S ∈ J₂ X` (ordre ponctuel) |
| `le_covers` | `J₁ ≤ J₂ → J₁.Covers S f → J₂.Covers S f` (compatibilite ordre / forme fleche) |
| `inf_eq_sInf` | `J₁ ⊓ J₂ = sInf {J₁, J₂}` (l'infimum de paire est le sInf de la paire) |
| `inf_covering` | `S ∈ (J₁ ⊓ J₂) X ↔ S ∈ J₁ X ∧ S ∈ J₂ X` (intersection ponctuelle) |
| `inf_covers` | `(J₁ ⊓ J₂).Covers S f ↔ J₁.Covers S f ∧ J₂.Covers S f` |
| `sup_covering` | `S ∈ (J₁ ⊔ J₂) X ↔ ∀ K, J₁ ≤ K → J₂ ≤ K → S ∈ K X` (topologie engendree) |
| `sup_covers` | `(J₁ ⊔ J₂).Covers S f ↔ ∀ K, J₁ ≤ K → J₂ ≤ K → K.Covers S f` |
| `sSup_covering` | `S ∈ sSup s X ↔ ∀ K, (∀ J ∈ s, J ≤ K) → S ∈ K X` (version infinie) |

Chaque preuve est une **preuve tactique reelle** : les axiomes de treillis
(`le_sInf`, `sInf_le`, `le_sSup`, `sSup_le`, `le_inf`, `inf_le_left/right`,
`sup_le`, `le_sup_left/right`) + `le_covering` ramenant la compatibilite
ordre/recouvrement, et `covers_iff`/`mem_sInf` de Mathlib pour la forme
fleche et l'intersection. Aucune preuve n'est un re-export (a la difference
des ponts `inferInstance` requalifies LIGHT en Partie 15).

Point cle : la borne superieure `J₁ ⊔ J₂` est la **topologie engendree**, pas
l'union ponctuelle (qui n'est pas stable par pullback) — d'ou la
caracterisation par bornes superieures ci-dessus.

+419/-0 (FR 211 lignes, EN 207 lignes byte-id i18n, aggregator `Grothendieck.lean` +1 import).

## Preuve de progres Lean (B.1)

- Compte de `sorry` reel avant/apres — `python scripts/lean/count_code_sorry.py --json`, champ `distinct_code_sorry` : **0 avant (module nouveau), 0 apres**. Aucun sorry ajoute ni retire.
- `lake build Grothendieck` : **SUCCESS** (log ci-dessous).
- Proof integrity (B.3) : job câble sur ce lake — `lean-grothendieck.yml` appelle `lean-axiom.yml` avec `target-modules: "*"` (la liste des modules est derivee au runtime) → le module `TopologyLattice` est couvert par la cloture. Verdict CI attendu `proof-integrity SUCCESS`.

<details>
<summary>Log lake build (tail)</summary>

```
✔ [2828/2831] Built Grothendieck.TopologyLattice (184s)
✔ [2829/2831] Built Grothendieck.TopologyLattice_en (184s)
✔ [2830/2831] Built Grothendieck (338s)
Build completed successfully (2831 jobs).
```

</details>

## i18n (EPIC #4980)

Sibling pair Pattern A : `TopologyLattice.lean` (FR) / `TopologyLattice_en.lean` (EN, namespace `_en`). Docstrings et commentaires traduits ; **enonces, noms de lemmes, preuves byte-identiques** (verifie par `check_i18n_siblings.py` : 37/38 paires byte-identical, 0 drift).

## See

See #2159 (Epic Grothendieck, Phase 5 — Partie 39). Precedents de la serie : #11035 (Partie 38 lois de foncteur), #11023 (Partie 37 lois de coherence), #10912 (Partie 36 Cover).

## Tests / checks
- [x] `lake build Grothendieck` SUCCESS
- [x] sorry reel 0 avant/apres (`count_code_sorry.py`)
- [x] i18n FR/EN byte-identiques
- [x] catalogue byte-identique a main (aucun artefact genere touche)
