### PR TITLE
docs(ml,#11034): aligner les docstrings DM avec le §C amende (#11010)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/dm_test.py
@@ -186,8 +186,8 @@ def dm_verdict(
 
     ``loss_fn`` selects the loss applied to forecast errors before the DM
     differential: ``"mse"`` (squared), ``"mae"`` (absolute), ``"linear"``
-    (raw errors, sign-preserving — required by pr-review §C for
-    return/strategy series; ``mse`` squares away the sign).
+    (raw signed errors — bias control, never the conjunction jambe;
+    per amended §C (#11010) the conjunction DM must use a precision loss).
     """
     result = diebold_mariano_test(errors_model, errors_baseline, loss_fn=loss_fn, horizon=horizon)
     if result.p_value < alpha and result.mean_loss_diff < 0:

--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_lstm_rv.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/m15_lstm_rv.py
@@ -381,8 +381,8 @@ def evaluate_one_combo(
     If oos_strict_year is set, data on/after Jan 1st of that year is held out
     from training/walk-forward (reserved for separate OOS verdict).
 
-    loss_fn selects the DM loss: "linear" (signed) is required by pr-review §C
-    for return series — mse/mae are symmetric and annul the sign (#10228).
+    loss_fn selects the DM loss: "mse"/"mae" (precision) are the §C conjunction
+    jambe per the #11010 amendment; "linear" (signed) is the bias control only.
 
     refit_every controls the walk-forward refit cadence (test days between
     LSTM retrains). The legacy research config is 22d; the §C run uses a
@@ -575,9 +575,9 @@ def main() -> None:
         default="linear",
         choices=["linear", "mse", "mae"],
         help=(
-            "DM loss function. pr-review §C requires 'linear' (signed loss) "
-            "for return series; mse/mae are symmetric and annul the sign (#10228). "
-            "Default: linear."
+            "DM loss function. §C (amended #11010): mse/mae (precision) are the "
+            "conjunction jambe; linear (signed) is the bias control, never the "
+            "conjunction jambe. Default: linear."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA-2 — prev: LIGHT/docs #10975

## Summary

Acceptance #5 de #11034 (voir issue) : vérifier firsthand que `dm_verdict()` ne hardcode pas `mse` alors que les runs passent `linear`.

**Verdict vérification** : pas de hardcode — `dlinear_vol.py:474` et `m15_lstm_rv.py:489-490` plombent tous deux `loss_fn` depuis l'argument CLI (`--loss-fn`, choices linear/mse/mae). La docstring de `dm_test.py` reflétait déjà le §C amendé.

**Résiduel corrigé (docs only, comportement inchangé)** : 3 docstrings portaient encore l'ancien §C (« linear required by pr-review §C ») contredit par l'amendement #11010 (mse/mae = perte de précision = jambe de la conjonction ; linear = contrôle de biais, jamais la jambe) :
- `scripts/dm_test.py` — docstring `dm_verdict()` (lignes 187-190)
- `scripts/m15_lstm_rv.py` — docstring de la fonction DM (lignes 384-385)
- `scripts/m15_lstm_rv.py` — `--help` du CLI `--loss-fn` (lignes 578-580)

## Validation

- `py_compile` OK sur les 2 fichiers
- `pytest scripts/test_dm.py` : **20/20 passent** (env `coursia-ml-training`)

## Note de partition

- M4 (§C mse) déjà livré par #11036 (mergée).
- M15 (notebook + results JSON) : claim paths-scoped po-2026, en cours.
- Ce PR couvre uniquement les chemins `scripts/dm_test.py` + `scripts/m15_lstm_rv.py` (claim scopé disjoint, issuecomment-5301991427).

See #11034
