### PR TITLE
docs(genai,#10985): cadrage instance 6 02-7-Song-Generation — portee VRAM + benchmarks publies

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/02-Advanced/02-7-Song-Generation.ipynb
@@ -39,6 +39,10 @@
     "- Git LFS pour le telechargement des modèles\n",
     "- Connaissance des concepts TTS et generation musicale (notebooks 02-1 a 02-6)\n",
     "\n",
+    "**Portee :** les cellules de generation (Sections 5-6) requierent les modeles installees (Section 3) et un GPU avec 10-24 GB VRAM. En dessous de ce seuil, le notebook reste descriptif : les cellules de generation affichent la commande d'invocation mais ne l'executent pas.\n",
+    "\n",
+    "**Valeurs quantitatives :** les chiffres cites (PER 8.55%, RTF 0.82, temps de generation) proviennent de benchmarks publies par les auteurs des modeles -- ils ne sont pas mesures dans ce notebook (aucune generation n'est executee sans modele installe).\n",
+    "\n",
     "**Navigation :** [<< 02-6](02-6-MIDI-Generation.ipynb) | [Index](../README.md) | [03-1 >>](../03-Orchestration/03-1-Multi-Model-Audio-Comparison.ipynb)"
    ]
   },
@@ -1478,7 +1482,7 @@
     "| Aspect | Observation typique |\n",
     "|--------|--------------------|\n",
     "| Qualite vocale | Proche de la qualite commerciale |\n",
-    "| Fidelite paroles | Excellente (PER 8.55%, meilleur que Suno v5) |\n",
+    "| Fidelite paroles | Excellente (PER 8.55%, benchmark publie des auteurs, meilleur que Suno v5) |\n",
     "| Musicalite | Production elevee, mix professionnel |\n",
     "| Temps | *runtime machine-dep* : ~25s pour 30s audio (RTF 0.82) |\n",
     "\n",
@@ -1523,7 +1527,7 @@
     "**Avantages pratiques** :\n",
     "- *runtime machine-dep* : generation ~25s pour 30s audio (RTF 0.82)\n",
     "- Separation native des pistes (pas besoin de Demucs)\n",
-    "- Meilleure fidelite des paroles (PER 8.55% vs Suno v5)\n",
+    "- Meilleure fidelite des paroles (benchmark publie : PER 8.55% vs Suno v5)\n",
     "|"
    ]
   },
@@ -1734,7 +1738,7 @@
     "|---------|---------|--------|\n",
     "| Qualite audio | SongGen 2 | 48kHz FLAC, mix professionnel |\n",
     "| Vitesse | SongGen 2 | 10-15x plus rapide |\n",
-    "| Fidelite paroles | SongGen 2 | PER 8.55% (meilleur que Suno v5) |\n",
+    "| Fidelite paroles | SongGen 2 | PER 8.55% (benchmark publie, meilleur que Suno v5) |\n",
     "| Accessibilite GPU | YuE | Quantization jusqu'a 6 GB |\n",
     "| Duree max | YuE | Illimitee vs 4m30 |\n",
     "| Licence | YuE | Apache 2.0 vs licence custom |\n",
@@ -2066,7 +2070,7 @@
     "| Aspect | Limite | Perspective d'evolution |\n",
     "|--------|--------|------------------------|\n",
     "| **Qualite vocale** | Parfois metallique ou robotique | Amelioration continue avec modèles plus grands |\n",
-    "| **Fidelite paroles** | Mots mal prononces ou oublis | PER 8.55% (SongGen 2) vs Suno v5, marge de progres |\n",
+    "| **Fidelite paroles** | Mots mal prononces ou oublis | PER 8.55% (SongGen 2, benchmark publie) vs Suno v5, marge de progres |\n",
     "| **Longueur max** | 4m30 (SongGen 2), illimite mais lent (YuE) | Modèles \"context long\" en développement |\n",
     "| **Cout calcul** | 24 GB VRAM, *runtime machine-dep* : 6 min pour 60s (YuE) | Optimisation quantization, distillation |\n",
     "| **Licence** | SongGen 2 custom limite usage commercial | Modèles Apache 2.0 emergents |\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: LIGHT/docs #11040

## Summary

Instance 6 de #10985 : `02-7-Song-Generation.ipynb` committe l'echec de sa propre generation SOTA — YuE et SongGeneration 2 non installes, 0 media rendu. Verdict de triage poste (issuecomment-5302006291) : le notebook est **honnete** (cellules 25/29 : "La tentative de generation a echoue car le modele n'est pas installe localement") mais **sans cadrage** — les tables "Observation typique" presentent PER 8.55% / RTF 0.82 / timings comme des mesures alors qu'elles sont des benchmarks publies par les auteurs des modeles.

**Cadrage assume documente (markdown-only, exception C.3 — outputs intacts, 15/15 execution_count) :**

1. **Cellule 0 — note "Portee"** : les cellules de generation (Sections 5-6) requierent les modeles installes (Section 3) et un GPU 10-24 GB VRAM. En dessous, le notebook reste descriptif.
2. **Cellule 0 — note "Valeurs quantitatives"** : PER 8.55%, RTF 0.82, timings = benchmarks publies par les auteurs, pas des mesures de ce notebook (aucune generation executee sans modele installe).
3. **4 occurrences "PER 8.55%, meilleur que Suno v5"** cadrees en "benchmark publie".

## Pourquoi pas la generation reelle (RECOVERABLE-MACHINE)

La generation requiert 10-24 GB VRAM (SongGen base 10 GB, YuE bf16 24 GB). Ma lane = RTX 3070 Laptop 8 GB — **sous le seuil** : YuE et SongGen non installables. Machine cible = po-2023 (RTX 3090) ou ai-01 (RTX 4090). Le cadrage documente explicitement ce plafond au lieu de le maquiller.

## Validation

- `json.loads` OK (nbformat 4), 15/15 cellules code gardent `execution_count` non-null + outputs
- Diff = uniquement des lignes `source` markdown (8 insertions, 4 deletions), aucun output touche
- C.3 : notebooks committes uniquement si source changee ; markdown-only = pas de re-exec

See #10985
