### PR TITLE
fix(harness,#11044): B.0 — aucun nit de review non leve ne survit a un merge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,38 @@ Les 27 règles sont **auto-chargées à chaque session** : leur contenu est déj
 
 **Git** : pas de push direct sur `main`. **Force push** : interdit sur `main` (porté par `allow_force_pushes: false`), autorisé sur une branche de PR qu'une **seule** lane manipule (`--force-with-lease`, l'alternative merge d'abord) — décision user 2026-08-08. Pas de `reset --hard` sur `main` ni sur une branche partagée. Branches `feature/<sujet>` ou `fix/<sujet>`, un sujet par PR. Le coordinateur (ai-01) review et merge ; les agents ne mergent pas eux-mêmes. Cf [git-workflow.md](.claude/rules/git-workflow.md).
 
-### B. Reviews PR (5 points obligatoires)
+### B. Reviews PR — B.0 bloquant, puis 5 points
+
+#### B.0 — Aucun nit non levé ne survit à un merge (HARD, mandat user 2026-08-15)
+
+**Lire l'ÉTAT d'une review n'est pas lire la review.** Le champ `reviews[].state` est **structurellement aveugle** aux deux canaux qui portent le plus de substance sur ce dépôt :
+
+| Canal | Ce que `reviews[].state` en dit | Où le contenu vit réellement |
+|---|---|---|
+| **Nits du user** | *rien* — postés en issue comments, aucune entrée dans `reviews[]` | `comments[].body` |
+| **Réserves d'Hermes** | `COMMENTED` — le verdict est un **préfixe de body** (`[Hermes] COMMENT_WITH_CONCERNS`) | `reviews[].body` |
+| **Commentaires inline** | *rien* — absents de `gh pr view --json comments,reviews` | `reviewThreads` (GraphQL), champ `isResolved` |
+
+Avant **tout** `gh pr merge`, énumérer les **trois** surfaces et vérifier que chaque remarque postée après le dernier commit est **levée** par l'une de ces trois choses, et rien d'autre :
+
+1. une **réponse écrite** sur la PR qui nomme la remarque (traitée en code — en citant le commit — traitée en argument, ou refusée en le disant) ;
+2. un **thread inline résolu** (`isResolved: true`) ;
+3. une **issue de suivi nommée dans le commentaire de merge** (reportée sciemment).
+
+**Un commit poussé après la remarque ne la lève PAS à lui seul.** Sur #10761 le « traitement » était un rebase à 19:41 qui n'adressait aucun des deux nits de 11:07 — un push muet est indiscernable d'un push qui répond. Ce qui lève une remarque est **une phrase**, pas un SHA.
+
+L'écoulement du temps n'est **pas** une levée. `mergeStateStatus: CLEAN` n'est **pas** une levée. `state: COMMENTED` n'est **pas** une absence de réserve. Un reviewer qui écrit « je ne peux pas approuver seul sur ce format » **bloque** — c'est un refus d'approbation, pas un avis.
+
+**Organe** (la règle ne tient pas par la vigilance) :
+
+```bash
+python scripts/check_unaddressed_nits.py <PR>        # exit 1 = ne pas merger
+python scripts/check_unaddressed_nits.py --audit --limit 400
+```
+
+**Incident fondateur — PR #10761** : mergée le 2026-08-14T04:15Z sous `myia-ai-01` malgré 2 nits user du 2026-08-13T11:07 (**17 h avant**) et une review Hermes `COMMENT_WITH_CONCERNS` confirmant ces 2 nits + 3 points neufs. `mergeStateStatus: CLEAN`, `reviews[].state: COMMENTED` : les deux champs qu'un merge-gate lit d'ordinaire étaient verts, et le notebook mergé attribue toujours à tort le théorème de Sendov à T. Tao (la preuve est de **Lech Mazur** ; Tao en signe la digestion, il l'écrit lui-même). Epic de reprise : **#11044**.
+
+#### Les 5 points
 
 Avant tout merge (y compris ses propres PRs) :
 

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Gate pre-merge : aucun nit de review non leve ne doit survivre a un merge.
+
+Pourquoi cet organe existe
+--------------------------
+Le champ `reviews[].state` est **structurellement aveugle** aux deux canaux de
+review qui comptent le plus sur ce depot :
+
+1. Le **user** poste ses nits comme *issue comments* (pas de review formelle) :
+   il n'y a donc AUCUN `state` a lire — ni `CHANGES_REQUESTED`, ni meme une
+   entree dans `reviews[]`.
+2. **Hermes** (bot reviewer) poste ses reserves avec `state: COMMENTED` et le
+   verdict en **prefixe de body** (`[Hermes] COMMENT_WITH_CONCERNS`) : lire
+   l'etat renvoie `COMMENTED`, qui ne bloque rien.
+3. Les **commentaires inline** de review vivent dans `reviewThreads` (GraphQL),
+   une 3e surface absente de `gh pr view --json comments,reviews`.
+
+Incident fondateur : PR #10761, mergee 2026-08-14T04:15Z malgre 2 nits user du
+2026-08-13T11:07 (~17 h avant) et une review Hermes COMMENT_WITH_CONCERNS
+confirmant les 2 nits + 3 points neufs dont « second reviewer obligatoire non
+fourni ». `mergeStateStatus: CLEAN`, `reviews[].state: COMMENTED` : les deux
+champs qu'un merge-gate lit d'ordinaire etaient verts.
+
+Usage
+-----
+    python scripts/check_unaddressed_nits.py <PR>          # gate : exit 1 si bloque
+    python scripts/check_unaddressed_nits.py <PR> --json   # sortie machine
+    python scripts/check_unaddressed_nits.py --audit --limit 400   # audit retro
+
+Un nit est considere **leve** si, apres son horodatage, on trouve au moins un de :
+  - un commit pousse sur la branche (le nit a ete traite en code) ;
+  - une reponse (comment) sur la PR (le nit a ete discute/refuse explicitement) ;
+  - pour un thread inline : `isResolved: true` ou `isOutdated: true`.
+
+Limite honnete de l'heuristique HUMAN
+-------------------------------------
+Le compte `jsboige` est utilise **a la fois** par le user et par les agents. Le
+discriminant retenu est le **CRLF** : un commentaire redige dans l'UI web GitHub
+porte `\r\n`, un commentaire poste via `gh` CLI porte `\n`. C'est fiable en
+pratique sur ce depot mais ce n'est pas une preuve d'identite : un nit user
+poste via `gh` serait manque (faux negatif), un agent collant du CRLF serait
+signale a tort (faux positif). Le gate signale, l'humain tranche.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+REPO = "jsboige/CoursIA"
+
+BOT_LOGINS = {"github-actions", "codecov", "dependabot", "copilot-pull-request-reviewer"}
+
+# Prefixes de tags utilises par les agents du cluster (protocole dashboard/PR).
+AGENT_PREFIXES = (
+    "[PART-OF-EPIC", "[GRAIN", "[CLAIMED", "[DONE", "[INFO", "[DISPATCH",
+    "[ACK", "[RELEASED", "[OVERRIDE", "[MERGED", "[WARN", "[ERROR", "[ASK",
+    "[REPLY", "[PROPOSAL", "[BLOCKED", "[ESCALATION",
+)
+
+# Marqueurs de reserve d'un reviewer bot (le verdict est dans le body, pas l'etat).
+CONCERN_MARKERS = (
+    "COMMENT_WITH_CONCERNS", "CHANGES_REQUESTED", "NEEDS_CHANGES", "CONCERNS",
+    "SUSPECT_", "STRUCTURAL_ONLY", "avant merge", "avant de merger",
+    "il va falloir", "a nuancer", "à nuancer",
+)
+
+# Un commentaire qui ANNONCE la levee ou le merge n'est pas un nit — il en est
+# la resolution. Sans ce filtre, chaque « CHANGES_REQUESTED levée » est compte
+# comme une reserve ouverte (faux positif massif, mesure sur 400 PRs).
+LIFT_MARKERS = (
+    "levée", "levee", "LGTM", "Mergé", "Merged", "je merge", "Merge.",
+    "est adressé", "sont adressés", "sont levées", "est levée",
+)
+
+
+def ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def gh_json(args: list[str]) -> object:
+    out = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, encoding="utf-8", check=True
+    ).stdout
+    return json.loads(out)
+
+
+def classify(author: str, body: str) -> str | None:
+    """'HUMAN' (nit user, UI web) | 'BOT-CONCERN' (reviewer avec reserves) | None."""
+    if author in BOT_LOGINS or not body:
+        return None
+    stripped = body.lstrip()
+    if any(m in body for m in LIFT_MARKERS):
+        return None  # annonce de levee / de merge : resolution, pas reserve
+    if stripped.startswith(AGENT_PREFIXES):
+        # Tag de protocole agent : informatif, pas un nit — sauf s'il porte une reserve.
+        return "BOT-CONCERN" if any(m in body for m in CONCERN_MARKERS) else None
+    if "\r\n" in body:
+        return "HUMAN"
+    if any(m in body for m in CONCERN_MARKERS):
+        return "BOT-CONCERN"
+    return None
+
+
+def review_threads(pr: int) -> list[dict]:
+    """Threads inline (3e surface, absente de `gh pr view --json`)."""
+    query = """
+    query($owner:String!,$repo:String!,$n:Int!){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$n){
+          reviewThreads(first:100){nodes{
+            isResolved isOutdated path line
+            comments(first:1){nodes{author{login} body createdAt}}
+          }}
+        }
+      }
+    }"""
+    owner, name = REPO.split("/")
+    data = gh_json([
+        "api", "graphql", "-f", f"query={query}",
+        "-F", f"owner={owner}", "-F", f"repo={name}", "-F", f"n={pr}",
+    ])
+    nodes = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    out = []
+    for t in nodes:
+        first = (t.get("comments") or {}).get("nodes") or [{}]
+        c = first[0]
+        out.append({
+            "resolved": bool(t.get("isResolved")),
+            "outdated": bool(t.get("isOutdated")),
+            "path": t.get("path"),
+            "line": t.get("line"),
+            "author": (c.get("author") or {}).get("login", "?"),
+            "body": c.get("body", ""),
+            "createdAt": c.get("createdAt"),
+        })
+    return out
+
+
+def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
+    """cutoff = mergedAt (audit retro) ou now (gate pre-merge)."""
+    commits = [ts(c.get("committedDate")) for c in (pr_data.get("commits") or [])]
+    commits = [c for c in commits if c]
+    last_commit = max(commits) if commits else None
+
+    comment_times = [ts(c["createdAt"]) for c in (pr_data.get("comments") or [])]
+    comment_times = [t for t in comment_times if t]
+
+    signals: list[tuple] = []
+    for c in pr_data.get("comments") or []:
+        login = (c.get("author") or {}).get("login", "")
+        kind = classify(login, c.get("body", ""))
+        if kind:
+            signals.append((ts(c["createdAt"]), kind, login, c.get("body", ""), "comment"))
+    for r in pr_data.get("reviews") or []:
+        login = (r.get("author") or {}).get("login", "")
+        body = r.get("body", "")
+        kind = classify(login, body)
+        if r.get("state") == "CHANGES_REQUESTED":
+            kind = "BOT-CONCERN" if kind is None else kind
+        if kind:
+            signals.append((ts(r.get("submittedAt")), kind, login, body,
+                            f"review:{r.get('state')}"))
+
+    blocking = []
+    for (when, kind, login, body, src) in signals:
+        if when is None or when >= cutoff:
+            continue
+        # Un commentaire posté APRÈS le merge ne peut pas avoir levé le nit :
+        # c'est l'annonce de merge, pas une réponse. Sans cette borne, le gate
+        # rate son propre incident fondateur (#10761, où mon commentaire de
+        # merge « éteignait » rétroactivement le nit user posté 17 h plus tôt).
+        if any(when < t < cutoff for t in comment_times):
+            continue  # discute/refuse explicitement apres le nit, avant le merge
+        # Un commit poussé après le nit ne le lève PAS à lui seul : sur #10761,
+        # le « traitement » était un rebase à 19:41 qui n'adressait aucun des
+        # deux nits de 11:07. Le push est reporté comme contexte, pas comme levée
+        # — seule une réponse écrite (ou un thread résolu) lève une remarque.
+        pushed_after = last_commit is not None and last_commit > when
+        blocking.append({
+            "kind": kind, "author": login, "src": src,
+            "at": when.isoformat(),
+            "gap_hours": round((cutoff - when).total_seconds() / 3600.0, 1),
+            "code_pushed_after": pushed_after,
+            "excerpt": " ".join(body.split())[:280],
+        })
+
+    for t in threads:
+        if t["resolved"] or t["outdated"]:
+            continue
+        blocking.append({
+            "kind": "INLINE-UNRESOLVED", "author": t["author"], "src": "reviewThread",
+            "at": t.get("createdAt") or "?",
+            "where": f"{t.get('path')}:{t.get('line')}",
+            "excerpt": " ".join((t.get("body") or "").split())[:280],
+        })
+
+    return {
+        "pr": pr_data.get("number"),
+        "title": (pr_data.get("title") or "")[:110],
+        "blocking": blocking,
+        "blocked": bool(blocking),
+    }
+
+
+FIELDS = "number,title,mergedAt,author,comments,reviews,commits,url,state"
+
+# `commits` porte une connection `authors` par commit : sur un `gh pr list` large,
+# GraphQL depasse son plafond de 500 000 noeuds. L'audit retro liste donc SANS
+# `commits`, puis ne les recupere que pour les PRs reellement candidates.
+LIST_FIELDS = "number,title,mergedAt,url,comments,reviews"
+
+
+def gate(pr: int, as_json: bool) -> int:
+    data = gh_json(["pr", "view", str(pr), "--repo", REPO, "--json", FIELDS])
+    merged = ts(data.get("mergedAt"))
+    cutoff = merged or datetime.now(timezone.utc)
+    result = analyse(data, review_threads(pr), cutoff)
+    if as_json:
+        print(json.dumps(result, indent=1, ensure_ascii=False))
+    elif not result["blocked"]:
+        print(f"OK  PR #{pr} — aucun nit non leve.")
+    else:
+        print(f"BLOCKED  PR #{pr} — {len(result['blocking'])} nit(s) non leve(s) :\n")
+        for b in result["blocking"]:
+            where = b.get("where", "")
+            gap = f" (+{b['gap_hours']}h avant merge)" if "gap_hours" in b else ""
+            print(f"  [{b['kind']}] {b['author']} via {b['src']}{where}{gap}")
+            print(f"      {b['excerpt']}\n")
+        print("Lever chaque nit (commit, reponse explicite, ou issue de suivi nommee)")
+        print("avant `gh pr merge`. Cf CLAUDE.md section B.0.")
+    return 1 if result["blocked"] else 0
+
+
+def audit(limit: int, search: str | None = None) -> int:
+    cmd = ["pr", "list", "--repo", REPO, "--state", "merged",
+           "--limit", str(limit), "--json", LIST_FIELDS]
+    if search:
+        # Partitionnement de l'historique entre lanes, ex :
+        #   --search "merged:2026-07-01..2026-07-15"
+        cmd += ["--search", search]
+    prs = gh_json(cmd)
+    findings = []
+    for p in prs:
+        merged = ts(p.get("mergedAt"))
+        if not merged:
+            continue
+        # Pre-filtre sans `commits` : si rien ne ressort deja, inutile de payer
+        # un appel de plus (les commits ne peuvent que LEVER un nit, jamais en creer).
+        if not analyse(p, [], merged)["blocked"]:
+            continue
+        try:
+            p["commits"] = gh_json(
+                ["pr", "view", str(p["number"]), "--repo", REPO, "--json", "commits"]
+            )["commits"]
+        except subprocess.CalledProcessError:
+            p["commits"] = []
+        # Audit retro : on n'interroge pas les threads inline (1 appel GraphQL/PR).
+        res = analyse(p, [], merged)
+        if res["blocked"]:
+            res["url"] = p.get("url")
+            res["merged_at"] = p["mergedAt"]
+            findings.append(res)
+    findings.sort(key=lambda f: f["pr"], reverse=True)
+    print(json.dumps({
+        "scanned": len(prs),
+        "search": search,
+        "oldest_merged": min((p["mergedAt"] for p in prs if p.get("mergedAt")), default=None),
+        "newest_merged": max((p["mergedAt"] for p in prs if p.get("mergedAt")), default=None),
+        "flagged": len(findings),
+        "findings": findings,
+    }, indent=1, ensure_ascii=False))
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("pr", nargs="?", type=int, help="numero de PR (mode gate)")
+    ap.add_argument("--audit", action="store_true", help="audit retro des PRs mergees")
+    ap.add_argument("--limit", type=int, default=200, help="taille de l'audit retro")
+    ap.add_argument("--search", help="filtre gh (ex: 'merged:2026-07-01..2026-07-15')")
+    ap.add_argument("--json", action="store_true", help="sortie machine (mode gate)")
+    args = ap.parse_args()
+    if args.audit:
+        return audit(args.limit, args.search)
+    if args.pr is None:
+        ap.error("fournir un numero de PR, ou --audit")
+    return gate(args.pr, args.json)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -27,10 +27,23 @@ Usage
     python scripts/check_unaddressed_nits.py <PR> --json   # sortie machine
     python scripts/check_unaddressed_nits.py --audit --limit 400   # audit retro
 
-Un nit est considere **leve** si, apres son horodatage, on trouve au moins un de :
-  - un commit pousse sur la branche (le nit a ete traite en code) ;
-  - une reponse (comment) sur la PR (le nit a ete discute/refuse explicitement) ;
+Ce qui leve un nit — et ce qui ne le leve PAS
+---------------------------------------------
+**Ce qui leve une remarque est une phrase, pas un SHA.** Un nit n'est considere
+**leve** que si, entre son horodatage et le merge, on trouve au moins un de :
+  - une **reponse ecrite** capable de repondre (cf `can_lift` : ni bot de CI,
+    ni tag de protocole nu) ;
   - pour un thread inline : `isResolved: true` ou `isOutdated: true`.
+
+Ne levent RIEN :
+  - **un commit pousse apres le nit** : un push muet est indiscernable d'un push
+    qui repond (sur #10761, le « traitement » etait un rebase qui n'adressait
+    aucun des deux nits). Il est reporte comme contexte (`code_pushed_after`) ;
+  - **un commentaire poste apres le merge** : c'est l'annonce de merge, pas une
+    reponse — sans cette borne, le gate ratait son propre incident fondateur ;
+  - **un commentaire de bot CI ou un tag de protocole nu** : ils ne repondent a
+    rien, et sur ce depot ils sont postes a chaque push (defaut signale par
+    Hermes en review de cet organe meme, cf `can_lift`).
 
 Limite honnete de l'heuristique HUMAN
 -------------------------------------
@@ -47,6 +60,7 @@ import argparse
 import json
 import subprocess
 import sys
+import unicodedata
 from datetime import datetime, timezone
 
 REPO = "jsboige/CoursIA"
@@ -76,6 +90,27 @@ LIFT_MARKERS = (
 )
 
 
+def _unaccent(text: str) -> str:
+    """« sont adressés » et « sont adresses » disent la meme chose.
+
+    Les agents du cluster ecrivent massivement sans accents (les fichiers de
+    regles eux-memes le font) tandis que les marqueurs ci-dessus sont accentues.
+    Comparer les formes brutes rend le filtre orthographique — un nit deja leve
+    serait re-signale (faux positif) sur la seule foi d'un accent absent. La
+    casse, elle, est PRESERVEE : elle porte du sens (« Merge. »), et l'ignorer
+    elargirait le filet au point de manquer de vrais nits.
+    """
+    return "".join(
+        c for c in unicodedata.normalize("NFD", text)
+        if unicodedata.category(c) != "Mn"
+    )
+
+
+def has_marker(body: str, markers: tuple[str, ...]) -> bool:
+    normalised = _unaccent(body)
+    return any(_unaccent(m) in normalised for m in markers)
+
+
 def ts(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -89,19 +124,50 @@ def gh_json(args: list[str]) -> object:
     return json.loads(out)
 
 
+def can_lift(comment: dict) -> bool:
+    """Ce commentaire est-il capable de LEVER un nit qui le precede ?
+
+    Seule une reponse d'un humain ou d'un agent, qui dit quelque chose, peut
+    lever une remarque. Sont exclus :
+      - les bots de CI (`github-actions` & co) : ils postent a chaque push et
+        n'ont aucun compte a rendre sur une remarque de review ;
+      - les tags de protocole nus (`[ACK]`, `[DISPATCH...]`, `[CLAIMED]`) :
+        ils ne nomment aucun nit.
+
+    Sans ce filtre, l'organe reproduit exactement le defaut qu'il traque :
+    n'importe quel bruit poste entre le nit et le merge eteint le nit. Sur ce
+    depot ou les bots commentent a chaque push, ce failure mode est la regle,
+    pas l'exception (defaut trouve par Hermes en review de #11045).
+
+    Limite connue et assumee : on ne verifie pas que la reponse *nomme* la
+    remarque — cela demanderait du NLP. Un commentaire humain hors-sujet leve
+    donc encore un nit (faux negatif residuel). Auteur + protocole eliminent le
+    gros du bruit sans pretendre lire le sens.
+    """
+    login = (comment.get("author") or {}).get("login", "")
+    if login in BOT_LOGINS:
+        return False
+    body = (comment.get("body") or "").lstrip()
+    if not body:
+        return False
+    if body.startswith(AGENT_PREFIXES) and not has_marker(body, LIFT_MARKERS):
+        return False
+    return True
+
+
 def classify(author: str, body: str) -> str | None:
     """'HUMAN' (nit user, UI web) | 'BOT-CONCERN' (reviewer avec reserves) | None."""
     if author in BOT_LOGINS or not body:
         return None
     stripped = body.lstrip()
-    if any(m in body for m in LIFT_MARKERS):
+    if has_marker(body, LIFT_MARKERS):
         return None  # annonce de levee / de merge : resolution, pas reserve
     if stripped.startswith(AGENT_PREFIXES):
         # Tag de protocole agent : informatif, pas un nit — sauf s'il porte une reserve.
-        return "BOT-CONCERN" if any(m in body for m in CONCERN_MARKERS) else None
+        return "BOT-CONCERN" if has_marker(body, CONCERN_MARKERS) else None
     if "\r\n" in body:
         return "HUMAN"
-    if any(m in body for m in CONCERN_MARKERS):
+    if has_marker(body, CONCERN_MARKERS):
         return "BOT-CONCERN"
     return None
 
@@ -125,6 +191,14 @@ def review_threads(pr: int) -> list[dict]:
         "-F", f"owner={owner}", "-F", f"repo={name}", "-F", f"n={pr}",
     ])
     nodes = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    # Pas de pagination : au-dela de 100 threads inline, les suivants seraient
+    # invisibles. Plutot que de tronquer en silence — le mode d'echec que ce
+    # script existe pour combattre — on le DIT. Theorique sur ce depot ; si le
+    # message apparait, paginer devient necessaire, pas optionnel.
+    if len(nodes) == 100:
+        print(f"  [!] PR #{pr}: 100 threads inline retournes (plafond `first:100`) "
+              "— d'eventuels threads supplementaires ne sont PAS analyses.",
+              file=sys.stderr)
     out = []
     for t in nodes:
         first = (t.get("comments") or {}).get("nodes") or [{}]
@@ -147,7 +221,11 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     commits = [c for c in commits if c]
     last_commit = max(commits) if commits else None
 
-    comment_times = [ts(c["createdAt"]) for c in (pr_data.get("comments") or [])]
+    # Seuls les commentaires capables de LEVER comptent (cf can_lift) : un
+    # commentaire de bot CI ou un tag de protocole nu n'a jamais repondu a rien.
+    comment_times = [
+        ts(c["createdAt"]) for c in (pr_data.get("comments") or []) if can_lift(c)
+    ]
     comment_times = [t for t in comment_times if t]
 
     signals: list[tuple] = []
@@ -259,6 +337,11 @@ def audit(limit: int, search: str | None = None) -> int:
             )["commits"]
         except subprocess.CalledProcessError:
             p["commits"] = []
+        # Ce 2e passage rend le MEME verdict `blocked` que le pre-filtre — un
+        # commit ne leve rien (c'est le principe de B.0). Il n'est pas pour le
+        # verdict : il renseigne `code_pushed_after`, dont la Phase 2 de #11044
+        # a besoin pour trier (« du code a bouge apres le nit » = aller lire le
+        # diff avant de conclure). Information de triage, pas critere.
         # Audit retro : on n'interroge pas les threads inline (1 appel GraphQL/PR).
         res = analyse(p, [], merged)
         if res["blocked"]:

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -1,0 +1,144 @@
+"""Tests for scripts/check_unaddressed_nits.py (#11044, gate B.0).
+
+L'organe encode une seule question : « cette remarque de review a-t-elle ete
+LEVEE avant le merge ? ». Toute sa correction tient dans ce qui compte comme
+levee — et c'est precisement la que les deux defauts trouves en review sont nes.
+Les deux sont couverts ici :
+
+  - **Le bruit ne leve pas** (defaut signale par Hermes sur #11045) : un
+    commentaire de bot CI ou un tag de protocole nu, poste entre le nit et le
+    merge, ne repond a rien. Sans ce filtre l'organe reproduisait exactement le
+    defaut qu'il traque, et sur ce depot ou les bots commentent a chaque push le
+    failure mode etait la regle, pas l'exception.
+  - **Un commit ne leve pas** : un push muet est indiscernable d'un push qui
+    repond. Sur l'incident fondateur #10761, le « traitement » etait un rebase
+    qui n'adressait aucun des deux nits. Ce qui leve une remarque est une phrase,
+    pas un SHA.
+
+S'y ajoutent la borne anti-retroactivite (un commentaire poste APRES le merge
+est une annonce de merge, pas une reponse) et la normalisation des accents (les
+agents ecrivent « sont adresses », les marqueurs disent « sont adresses »).
+
+Aucun appel reseau : `analyse()` est pur, on lui passe des payloads construits.
+"""
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_unaddressed_nits.py"
+
+spec = importlib.util.spec_from_file_location("check_unaddressed_nits", CHECK_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["check_unaddressed_nits"] = mod
+spec.loader.exec_module(mod)
+
+
+def at(hour: int) -> str:
+    return f"2026-08-14T{hour:02d}:00:00Z"
+
+
+MERGED = datetime(2026, 8, 14, 20, 0, tzinfo=timezone.utc)
+
+# Un nit user : CRLF (redige dans l'UI web), poste 11 h avant le merge.
+USER_NIT = {
+    "author": {"login": "jsboige"},
+    "createdAt": at(9),
+    "body": "Attention 2 nits:\r\n- il va falloir splitter\r\n- l'attribution est fausse",
+}
+
+
+def run(comments, commits=None, threads=None):
+    data = {
+        "number": 0,
+        "title": "t",
+        "comments": comments,
+        "reviews": [],
+        "commits": commits if commits is not None else [{"committedDate": at(19)}],
+    }
+    return mod.analyse(data, threads or [], MERGED)
+
+
+def test_nit_seul_bloque():
+    assert run([USER_NIT])["blocked"] is True
+
+
+def test_commit_posterieur_ne_leve_pas():
+    """#10761 : le rebase de 19:41 n'adressait aucun des nits de 11:07."""
+    res = run([USER_NIT], commits=[{"committedDate": at(19)}])
+    assert res["blocked"] is True
+    assert res["blocking"][0]["code_pushed_after"] is True  # rapporte, pas decisif
+
+
+@pytest.mark.parametrize(
+    "noise",
+    [
+        pytest.param({"author": {"login": "github-actions"}, "createdAt": at(12),
+                      "body": "Golden set: 0 diff. Variation cap: OK."},
+                     id="bot-ci"),
+        pytest.param({"author": {"login": "codecov"}, "createdAt": at(12),
+                      "body": "Coverage: 91.2% (+0.1%)"},
+                     id="bot-codecov"),
+        pytest.param({"author": {"login": "jsboige"}, "createdAt": at(12),
+                      "body": "[CLAIMED] lane myia-po-2023:CoursIA -- paths: a/b"},
+                     id="tag-protocole-nu"),
+        pytest.param({"author": {"login": "jsboige"}, "createdAt": at(12),
+                      "body": "[DISPATCH->inbox] grain suivant poste en DM"},
+                     id="tag-dispatch"),
+    ],
+)
+def test_le_bruit_ne_leve_pas_un_nit(noise):
+    """Defaut Hermes sur #11045 : n'importe quel bruit eteignait le nit."""
+    assert run([USER_NIT, noise])["blocked"] is True
+
+
+def test_vraie_reponse_humaine_leve():
+    reply = {"author": {"login": "jsboige"}, "createdAt": at(12),
+             "body": "Bien vu, l'attribution est corrigee en cellule 0 et 2."}
+    assert run([USER_NIT, reply])["blocked"] is False
+
+
+def test_tag_de_protocole_portant_une_levee_leve():
+    """Un tag n'est disqualifie que s'il est NU : `[DONE] ... sont adresses` repond."""
+    done = {"author": {"login": "jsboige"}, "createdAt": at(12),
+            "body": "[DONE] les 2 nits sont adresses, commit abc123."}
+    assert run([USER_NIT, done])["blocked"] is False
+
+
+def test_accents_absents_matchent_quand_meme():
+    """Les agents ecrivent sans accents ; les marqueurs sont accentues."""
+    assert mod.has_marker("les 2 points sont adresses", mod.LIFT_MARKERS)
+    assert mod.has_marker("les 2 points sont adressés", mod.LIFT_MARKERS)
+    assert not mod.has_marker("rien a voir", mod.LIFT_MARKERS)
+
+
+def test_commentaire_post_merge_ne_leve_pas():
+    """La borne anti-retroactivite : l'annonce de merge n'est pas une reponse.
+
+    Sans elle, le gate ratait son propre incident fondateur — mon commentaire de
+    merge « eteignait » un nit vieux de 17 h.
+    """
+    after = {"author": {"login": "jsboige"}, "createdAt": at(21),  # apres MERGED
+             "body": "Merge apres verification des checks."}
+    assert run([USER_NIT, after])["blocked"] is True
+
+
+def test_thread_inline_non_resolu_bloque():
+    thread = {"resolved": False, "outdated": False, "path": "a.py", "line": 12,
+              "author": "jsboige", "body": "ce nom est trompeur", "createdAt": at(10)}
+    res = run([], threads=[thread])
+    assert res["blocked"] is True
+    assert res["blocking"][0]["kind"] == "INLINE-UNRESOLVED"
+
+
+def test_thread_inline_resolu_ne_bloque_pas():
+    thread = {"resolved": True, "outdated": False, "path": "a.py", "line": 12,
+              "author": "jsboige", "body": "ce nom est trompeur", "createdAt": at(10)}
+    assert run([], threads=[thread])["blocked"] is False
+
+
+def test_pr_propre_ne_bloque_pas():
+    assert run([])["blocked"] is False


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/guard #11030

## Ce que ça corrige

**Incident #10761** : PR mergée le 2026-08-14T04:15Z, soit **17 h après** 2 nits du user et **16,6 h après** une review Hermes `COMMENT_WITH_CONCERNS` qui confirmait ces 2 nits et en ajoutait 3 neufs — dont « second reviewer obligatoire non fourni : je ne peux pas approuver seul sur ce format ». Le notebook mergé attribue toujours le théorème de Sendov à T. Tao alors que la preuve est de Lech Mazur.

Au moment du merge, `mergeStateStatus: CLEAN` **et** `reviews[].state: COMMENTED`. Les deux champs qu'un merge-gate lit d'ordinaire étaient verts. **Lire l'état d'une review n'est pas lire la review.**

## Cause racine — trois surfaces, une seule lue

| Canal | Ce que `reviews[].state` en dit | Où le contenu vit |
|---|---|---|
| Nits du user | *rien* — issue comments, aucune entrée dans `reviews[]` | `comments[].body` |
| Réserves d'Hermes | `COMMENTED` — verdict en **préfixe de body** | `reviews[].body` |
| Commentaires inline | *rien* — absents de `gh pr view --json comments,reviews` | `reviewThreads` (GraphQL) |

## Les deux pièges trouvés en testant l'organe contre son propre incident

La première version du gate **ne bloquait pas #10761**. Deux raisons, toutes deux corrigées :

1. **Mon commentaire de merge, posté après le merge, comptait comme réponse au nit** — il éteignait rétroactivement une remarque vieille de 17 h. Les réponses sont maintenant bornées à `nit < t < mergedAt`.
2. **Un commit poussé après le nit le « levait » mécaniquement** — sur #10761 c'était un rebase à 19:41 qui n'adressait ni l'un ni l'autre des nits de 11:07. Un push muet est indiscernable d'un push qui répond : le commit est désormais reporté comme contexte (`code_pushed_after`), **jamais** comme levée. Ce qui lève une remarque est une phrase, pas un SHA.

C'est le seul point où j'ai dû corriger la règle elle-même, pas seulement le code : `CLAUDE.md` §B.0 dit maintenant qu'une levée est une **réponse écrite**, un **thread résolu**, ou une **issue nommée dans le commentaire de merge**.

## Troisième piège — trouvé par Hermes en review de l'organe (commit `2bfa273a4`)

Hermes a trouvé, en review de ce script, **le failure mode du script lui-même** : `comment_times` était construit à partir de **tous** les commentaires, sans filtre d'auteur ni de contenu. Un commentaire de bot CI (postés à chaque push ici), un tag de protocole nu, ou l'annonce « je merge » **éteignait le nit qui le précédait**. L'organe bâti pour attraper « un nit éteint par du bruit » éteignait ses nits par du bruit.

- `can_lift()` — seul un commentaire capable de *répondre* lève (ni bot CI, ni tag de protocole nu). Faux négatif résiduel assumé et **écrit dans le docstring** : on ne vérifie pas que la réponse *nomme* la remarque (NLP hors de portée).
- `has_marker()` — normalisation des accents. Sorti par le test, pas par la relecture : `[DONE] les 2 nits sont adresses` ne levait pas, parce que `LIFT_MARKERS` disait « sont adressés ». La casse, elle, reste significative — l'ignorer élargirait le filet au point de manquer de vrais nits.
- **Docstring réaligné** : il énumérait encore « un commit poussé sur la branche » parmi les levées, soit la sémantique d'avant le durcissement. La divergence spec/implémentation était le fond du signalement ; la laisser dans l'en-tête aurait reproduit à l'échelle du fichier le défaut corrigé dans le code.
- `reviewThreads(first:100)` — pagination non ajoutée, mais la troncature est désormais **dite sur stderr** au lieu d'être silencieuse. Tronquer en silence est le mode d'échec que ce script existe pour combattre.
- 2e passage `commits` de `audit()` — gardé et **documenté** comme contexte de triage (`code_pushed_after` : « du code a bougé après le nit » → lire le diff avant de conclure), pas comme critère de verdict.

## Self-test (preuve, pas déclaration)

```
$ python -m pytest scripts/tests/test_check_unaddressed_nits.py -q
13 passed in 0.13s

$ python scripts/check_unaddressed_nits.py 10761
BLOCKED  PR #10761 — 2 nit(s) non leve(s) :
  [HUMAN] jsboige via comment (+17.1h avant merge)
      Attention 2 nits: - cette PR mélange des choses utiles qui n'ont rien à voir,
      il va falloir splitter - la preuve n'est pas de Terrence Tao, seule sa digestion...
  [BOT-CONCERN] jsboige via review:COMMENTED (+16.6h avant merge)
      [Hermes] COMMENT_WITH_CONCERNS — je confirme les 2 nits de l'auteur...
exit=1

$ python scripts/check_unaddressed_nits.py 11038      # contrôle négatif
OK  PR #11038 — aucun nit non leve.
exit=0
```

Les 13 tests (`scripts/tests/`, convention du dépôt) couvrent les **trois** pièges : le bruit ne lève pas, un commit ne lève pas, un commentaire post-merge ne lève pas.

## Mesure de l'ampleur

| Fenêtre | Scannées | Signalées |
|---|---|---|
| 2026-08-12 → 08-15 (3,5 j) | 400 | **24** |
| 2026-07-08 → 07-10 (2,5 j) | 200 | 18 |

Les 24 sont re-mesurées **avec la levée corrigée** ; la première mesure donnait 22 avec la levée buggée qu'Hermes a signalée. Le sondage de juillet est antérieur au correctif : c'est donc un plancher, pas une mesure comparable. L'écart est faible et ne renverse pas la conclusion — deux sondages sur deux mois donnent le même ordre de grandeur, ce n'est pas un incident isolé. Le balayage complet de l'historique et le triage (le flag est une **question**, pas un verdict — [audit-reassessment.md](.claude/rules/audit-reassessment.md)) sont l'objet de l'**Epic #11044**, partitionné par fenêtre de dates disjointes entre les 4 lanes.

## Portée honnête

- L'heuristique HUMAN repose sur le **CRLF** (le user écrit dans l'UI web, les agents via `gh`). Fiable sur ce dépôt, mais ce n'est pas une preuve d'identité : un nit user posté via `gh` serait manqué. La limite est écrite dans le docstring.
- Le taux de faux positifs n'est **pas encore mesuré** — c'est un critère d'acceptation de l'Epic. Le gate n'est **pas** proposé en CI bloquante tant qu'il ne l'est pas : un gate bruyant forme les reviewers à l'ignorer.

## Variation — ce grain ne tient PAS le plancher du cycle (G-VAR-1)

`guard` est un genre **META**, et `prev: LIGHT/guard` fait deux grains `guard` consécutifs : G-VAR-3 le signale à juste titre. Le protocole est explicite sur la conduite à tenir — ne pas HOLD une PR META saine, la sanction porterait sur le mauvais objet, mais **nommer dans le même geste le grain de contenu** qui porte le cycle. Il est nommé, mesuré et dispatché :

- **`04-6-MiniMax-video-01-v1`** : l'endpoint codé en dur (`https://api.MiniMax.chat/v1/video_generation`) renvoie `2049 invalid api key` **alors que la clé est vivante** — `api.minimaxi.chat` et `api.minimax.io` renvoient `2013 task_id does not exist`, soit une authentification acceptée. Mesuré firsthand ce jour par sonde en lecture seule, **zéro génération consommée** (le plan en autorise 5/jour). 04-5 utilise déjà `api.minimax.io/v2`. Lane po-2023, détentrice du claim sur #10244.
- **Attribution Sendov** (`Lean-19-Sendov-Complex-Analysis.ipynb`) : Phase 3.1 de #11044.

Le grain suivant de cette lane sera de **contenu**, pas un troisième guard.

See #11044
