### PR TITLE
feat(lean,#10984): mimo_lean Phase 1 — Descent.lean (Prop 9.1 core, sans Mathlib)

### DIFF
--- a/.github/workflows/lean-mimo.yml
+++ b/.github/workflows/lean-mimo.yml
@@ -1,0 +1,39 @@
+name: Lean CI (mimo_lean)
+
+# CI for mimo_lean (SymbolicAI/Lean/mimo_lean) — MIMO flip-descent detection
+# (Papailiopoulos 2026, issue #10984). Phase 1 (Descent.lean) is core-only:
+# the abstract skeleton of Proposition 9.1 (strictly decreasing cost per
+# accepted flip, confinement barrier, flip ceiling M_N -> target reached
+# strictly before the ceiling). Phase 2 will add Mathlib (Objective.lean,
+# Lemmas 11.1 / 5.1) and Phase 3 the external SLT lake; the `require` lines
+# will land with those phases, keeping each PR one-subject.
+#
+# sorry-filter-mode=standalone-tactic, baseline=0: the library ships entirely
+# sorry-free. This CI only guards that NO new standalone `sorry` tactic is
+# introduced (no false positive on prose mentions; catches any new sorry).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lean-toolchain'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lean-toolchain'
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean
+      display-name: mimo_lean
+      sorry-baseline: "0"
+      sorry-filter-mode: standalone-tactic

--- a/.github/workflows/lean-mimo.yml
+++ b/.github/workflows/lean-mimo.yml
@@ -29,6 +29,9 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lean-toolchain'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Descent.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Descent.lean
@@ -1,0 +1,146 @@
+/-!
+# Descente à flips — Phase 1 : squelette de la Proposition 9.1 (cœur, sans Mathlib)
+
+Ce module formalise la **colonne vertébrale combinatoire** de l'algorithme de
+détection MIMO par flips de coordonnées (Papailiopoulos, 2026 — issue #10984) :
+une descente sur un espace d'états où chaque flip **accepté** fait décroître
+strictement le coût. Le fichier est volontairement **sans aucune dépendance**
+(cœur Lean 4 uniquement) : la fonction objectif réelle (Lemme 11.1) et
+l'analyse LMMSE (Lemme 5.1) arrivent en Phase 2 (`Objective.lean`, Mathlib) ;
+la converse §11 en Phase 3 via le lake externe SLT.
+
+Le théorème phare `descent_target_before_ceiling` est la forme abstraite de la
+Proposition 9.1 du papier : sous (i) stricte décroissance du coût à chaque
+flip accepté, (ii) confinement du coût dans une barrière `B`, et (iii) absence
+de point bloquant hors de la cible, tout run **terminal** atteint la cible en
+un nombre de flips **strictement inférieur au plafond `M_N`**.
+
+Les quatres ingrédients de la preuve, chacun intéressant pédagogiquement :
+
+1. `run_tail_cost_lt` — la décroissance stricte se propage du pas local à
+   toute la queue du run (récurrence sur la structure du run) ;
+2. `run_nodup` — un run ne revisite jamais un état (sinon le coût serait
+   strictement inférieur à lui-même) ;
+3. `run_length_le_cost` — le nombre de flips d'un run démarrant en `s₀` est
+   majoré par `cost s₀` (le « budget de descente ») ;
+4. `descent_flips_le_barrier` — sous la barrière de confinement `B`, le
+   nombre de flips est majoré par `B`, donc strictement par `M_N > B`.
+-/
+
+namespace Mimo
+
+variable {σ : Type} {accept : σ → σ → Prop} {cost : σ → Nat} {target : σ → Prop}
+
+/-- Un **run** de l'algorithme : suite d'états dont chaque paire consécutive
+est un flip **accepté** (relation `accept`). Le cas `single` couvre le run
+réduit à l'état initial ; `nil` le run vide (pratique pour les récurrences). -/
+inductive Run (accept : σ → σ → Prop) : List σ → Prop
+  | nil : Run accept []
+  | single (s : σ) : Run accept [s]
+  | cons (s t : σ) (rest : List σ) (h : accept s t) (hr : Run accept (t :: rest)) :
+      Run accept (s :: t :: rest)
+
+/-- Dernier état d'un run démarrant en `s₀` : là où l'algorithme s'arrête. -/
+def lastState : σ → List σ → σ
+  | s, [] => s
+  | _, t :: rest => lastState t rest
+
+/-! ## Lemme 1 — la décroissance stricte se propage à toute la queue -/
+
+/-- Si chaque flip accepté décroît strictement le coût, alors le coût de tout
+état visité après `s₀` est strictement inférieur à `cost s₀`. C'est la clé de
+la non-révisite et du budget de descente. -/
+theorem run_tail_cost_lt (hstrict : ∀ s t, accept s t → cost t < cost s) :
+    ∀ (rest : List σ) (s₀ : σ), Run accept (s₀ :: rest) →
+      ∀ x ∈ rest, cost x < cost s₀ := by
+  intro rest
+  induction rest with
+  | nil => intro _ _ x hx; cases hx
+  | cons u rest' ih =>
+    intro s₀ hL x hx
+    cases hL with
+    | cons _ _ _ h hr =>
+      cases List.mem_cons.1 hx with
+      | inl hxu => subst hxu; exact hstrict _ _ h
+      | inr hx' => exact Nat.lt_trans (ih u hr x hx') (hstrict _ _ h)
+
+/-! ## Lemme 2 — un run ne revisite jamais un état -/
+
+/-- Un run à coût strictement décroissant est sans répétition : l'espace
+d'états peut être infini, le run lui-même vit dans un ensemble fini d'états
+distincts (autant de visites que de valeurs de coût strictement décroissantes). -/
+theorem run_nodup (hstrict : ∀ s t, accept s t → cost t < cost s)
+    {L : List σ} (hL : Run accept L) : L.Nodup := by
+  induction hL with
+  | nil => exact List.nodup_nil
+  | single s => simp
+  | cons s u rest h hr ih =>
+    refine List.nodup_cons.2 ⟨?_, ih⟩
+    intro hmem
+    have hrun : Run accept (s :: u :: rest) := Run.cons s u rest h hr
+    have hlt := run_tail_cost_lt hstrict (u :: rest) s hrun s hmem
+    exact absurd hlt (Nat.lt_irrefl _)
+
+/-! ## Lemme 3 — le budget de descente majore le nombre de flips -/
+
+/-- Le nombre de flips d'un run démarrant en `s₀` est au plus `cost s₀` :
+chaque flip consomme au moins une unité de coût (valeurs dans `Nat`), et le
+coût ne peut pas descendre sous zéro. -/
+theorem run_length_le_cost (hstrict : ∀ s t, accept s t → cost t < cost s) :
+    ∀ (rest : List σ) (s₀ : σ), Run accept (s₀ :: rest) →
+      rest.length ≤ cost s₀ := by
+  intro rest
+  induction rest with
+  | nil => intro _ _; exact Nat.zero_le _
+  | cons u rest' ih =>
+    intro s₀ hL
+    cases hL with
+    | cons _ _ _ h hr =>
+      have h1 : rest'.length ≤ cost u := ih u hr
+      have h2 : cost u < cost s₀ := hstrict _ _ h
+      have h3 : (u :: rest').length = rest'.length + 1 := rfl
+      omega
+
+/-! ## Proposition 9.1 — confinement, plafond de flips, atteinte de la cible -/
+
+/-- **Barrière de confinement** : si le coût de tout état visité reste sous
+`B`, alors le nombre de flips est majoré par `B`. Dans le papier, la barrière
+reflète la géométrie du problème (le coût ne s'échappe pas d'une tranche
+bornée) ; ici elle est une hypothèse, instanciée en Phase 2. -/
+theorem descent_flips_le_barrier (hstrict : ∀ s t, accept s t → cost t < cost s)
+    (s₀ : σ) (rest : List σ) (B : Nat)
+    (hbarrier : ∀ s ∈ s₀ :: rest, cost s ≤ B)
+    (hL : Run accept (s₀ :: rest)) :
+    rest.length ≤ B := by
+  have h1 := run_length_le_cost hstrict rest s₀ hL
+  have h0 := hbarrier s₀ (by simp)
+  omega
+
+/-- **Proposition 9.1 (forme abstraite, squelette Phase 1).** Soit un run
+**terminal** (aucun flip accepté n'échappe du dernier état) sous les trois
+hypothèses du papier :
+
+- `hstrict` — chaque flip accepté décroît strictement le coût (Lemme 11.1 en
+  Phase 2 : le coût d'un flip s'écrit `4·(ρ/N·‖hᵢ‖² + √(ρ/N)·hᵢᵀw)`, et seuls
+  les flips diminuant l'objectif sont acceptés) ;
+- `hbarrier` — le coût reste confiné sous `B` sur tout le run ;
+- `hnostall` — hors de la cible, un flip accepté existe toujours (l'algorithme
+  ne se bloque que sur la cible).
+
+Alors le dernier état du run **appartient à la cible**, et le run a utilisé
+**strictement moins de `M_N` flips** dès que le plafond `M_N` dépasse la
+barrière `B`. C'est exactement la garantie de complexité de l'algorithme :
+terminaison dans la cible avant l'épuisement du budget de flips. -/
+theorem descent_target_before_ceiling
+    (hstrict : ∀ s t, accept s t → cost t < cost s)
+    (hnostall : ∀ s : σ, (∀ u, ¬ accept s u) → target s)
+    (s₀ : σ) (rest : List σ) (B M_N : Nat)
+    (hbarrier : ∀ s ∈ s₀ :: rest, cost s ≤ B)
+    (hL : Run accept (s₀ :: rest))
+    (hterm : ∀ u, ¬ accept (lastState s₀ rest) u)
+    (hceiling : B < M_N) :
+    target (lastState s₀ rest) ∧ rest.length < M_N :=
+  ⟨hnostall _ hterm,
+   Nat.lt_of_le_of_lt (descent_flips_le_barrier hstrict s₀ rest B hbarrier hL) hceiling⟩
+
+end Mimo

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Descent_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Descent_en.lean
@@ -1,0 +1,147 @@
+/-!
+# Flip descent — Phase 1: skeleton of Proposition 9.1 (core, no Mathlib)
+
+This module formalizes the **combinatorial backbone** of the MIMO
+coordinate-flip detection algorithm (Papailiopoulos, 2026 — issue #10984):
+a descent over a state space where every **accepted** flip strictly decreases
+the cost. The file is deliberately **dependency-free** (Lean 4 core only):
+the real objective function (Lemma 11.1) and the LMMSE analysis (Lemma 5.1)
+land in Phase 2 (`Objective.lean`, Mathlib); the §11 converse in Phase 3 via
+the external SLT lake.
+
+The flagship theorem `descent_target_before_ceiling` is the abstract form of
+Proposition 9.1 of the paper: under (i) strict cost decrease at every
+accepted flip, (ii) confinement of the cost within a barrier `B`, and
+(iii) absence of stuck points outside the target, every **terminal** run
+reaches the target in a number of flips **strictly below the ceiling `M_N`**.
+
+The four ingredients of the proof, each pedagogically interesting:
+
+1. `run_tail_cost_lt` — the strict decrease propagates from the local step to
+   the whole tail of the run (recursion on the run structure);
+2. `run_nodup` — a run never revisits a state (otherwise the cost would be
+   strictly below itself);
+3. `run_length_le_cost` — the number of flips of a run starting at `s₀` is
+   bounded by `cost s₀` (the "descent budget");
+4. `descent_flips_le_barrier` — under the confinement barrier `B`, the number
+   of flips is bounded by `B`, hence strictly by `M_N > B`.
+-/
+
+namespace Mimo_en
+
+variable {σ : Type} {accept : σ → σ → Prop} {cost : σ → Nat} {target : σ → Prop}
+
+/-- A **run** of the algorithm: a list of states whose every consecutive pair
+is an **accepted** flip (relation `accept`). The `single` case covers the run
+reduced to the initial state; `nil` the empty run (convenient for proofs by
+recursion). -/
+inductive Run (accept : σ → σ → Prop) : List σ → Prop
+  | nil : Run accept []
+  | single (s : σ) : Run accept [s]
+  | cons (s t : σ) (rest : List σ) (h : accept s t) (hr : Run accept (t :: rest)) :
+      Run accept (s :: t :: rest)
+
+/-- Last state of a run starting at `s₀`: where the algorithm stops. -/
+def lastState : σ → List σ → σ
+  | s, [] => s
+  | _, t :: rest => lastState t rest
+
+/-! ## Lemma 1 — the strict decrease propagates to the whole tail -/
+
+/-- If every accepted flip strictly decreases the cost, then the cost of every
+state visited after `s₀` is strictly below `cost s₀`. This is the key to
+non-revisiting and to the descent budget. -/
+theorem run_tail_cost_lt (hstrict : ∀ s t, accept s t → cost t < cost s) :
+    ∀ (rest : List σ) (s₀ : σ), Run accept (s₀ :: rest) →
+      ∀ x ∈ rest, cost x < cost s₀ := by
+  intro rest
+  induction rest with
+  | nil => intro _ _ x hx; cases hx
+  | cons u rest' ih =>
+    intro s₀ hL x hx
+    cases hL with
+    | cons _ _ _ h hr =>
+      cases List.mem_cons.1 hx with
+      | inl hxu => subst hxu; exact hstrict _ _ h
+      | inr hx' => exact Nat.lt_trans (ih u hr x hx') (hstrict _ _ h)
+
+/-! ## Lemma 2 — a run never revisits a state -/
+
+/-- A run with strictly decreasing cost is repetition-free: the state space
+may be infinite, but the run itself lives in a finite set of distinct states
+(one visit per strictly decreasing cost value). -/
+theorem run_nodup (hstrict : ∀ s t, accept s t → cost t < cost s)
+    {L : List σ} (hL : Run accept L) : L.Nodup := by
+  induction hL with
+  | nil => exact List.nodup_nil
+  | single s => simp
+  | cons s u rest h hr ih =>
+    refine List.nodup_cons.2 ⟨?_, ih⟩
+    intro hmem
+    have hrun : Run accept (s :: u :: rest) := Run.cons s u rest h hr
+    have hlt := run_tail_cost_lt hstrict (u :: rest) s hrun s hmem
+    exact absurd hlt (Nat.lt_irrefl _)
+
+/-! ## Lemma 3 — the descent budget bounds the number of flips -/
+
+/-- The number of flips of a run starting at `s₀` is at most `cost s₀`:
+each flip consumes at least one unit of cost (values in `Nat`), and the cost
+cannot go below zero. -/
+theorem run_length_le_cost (hstrict : ∀ s t, accept s t → cost t < cost s) :
+    ∀ (rest : List σ) (s₀ : σ), Run accept (s₀ :: rest) →
+      rest.length ≤ cost s₀ := by
+  intro rest
+  induction rest with
+  | nil => intro _ _; exact Nat.zero_le _
+  | cons u rest' ih =>
+    intro s₀ hL
+    cases hL with
+    | cons _ _ _ h hr =>
+      have h1 : rest'.length ≤ cost u := ih u hr
+      have h2 : cost u < cost s₀ := hstrict _ _ h
+      have h3 : (u :: rest').length = rest'.length + 1 := rfl
+      omega
+
+/-! ## Proposition 9.1 — confinement, flip ceiling, target reached -/
+
+/-- **Confinement barrier**: if the cost of every visited state stays below
+`B`, then the number of flips is bounded by `B`. In the paper, the barrier
+reflects the geometry of the problem (the cost cannot escape a bounded
+strip); here it is a hypothesis, instantiated in Phase 2. -/
+theorem descent_flips_le_barrier (hstrict : ∀ s t, accept s t → cost t < cost s)
+    (s₀ : σ) (rest : List σ) (B : Nat)
+    (hbarrier : ∀ s ∈ s₀ :: rest, cost s ≤ B)
+    (hL : Run accept (s₀ :: rest)) :
+    rest.length ≤ B := by
+  have h1 := run_length_le_cost hstrict rest s₀ hL
+  have h0 := hbarrier s₀ (by simp)
+  omega
+
+/-- **Proposition 9.1 (abstract form, Phase 1 skeleton).** Let a **terminal**
+run (no accepted flip escapes the last state) under the three assumptions of
+the paper:
+
+- `hstrict` — every accepted flip strictly decreases the cost (Lemma 11.1 in
+  Phase 2: a flip cost reads `4·(ρ/N·‖hᵢ‖² + √(ρ/N)·hᵢᵀw)`, and only flips
+  decreasing the objective are accepted);
+- `hbarrier` — the cost stays confined below `B` along the whole run;
+- `hnostall` — outside the target, an accepted flip always exists (the
+  algorithm can only get stuck on the target).
+
+Then the last state of the run **belongs to the target**, and the run used
+**strictly fewer than `M_N` flips** as soon as the ceiling `M_N` exceeds the
+barrier `B`. This is exactly the complexity guarantee of the algorithm:
+termination in the target before the flip budget runs out. -/
+theorem descent_target_before_ceiling
+    (hstrict : ∀ s t, accept s t → cost t < cost s)
+    (hnostall : ∀ s : σ, (∀ u, ¬ accept s u) → target s)
+    (s₀ : σ) (rest : List σ) (B M_N : Nat)
+    (hbarrier : ∀ s ∈ s₀ :: rest, cost s ≤ B)
+    (hL : Run accept (s₀ :: rest))
+    (hterm : ∀ u, ¬ accept (lastState s₀ rest) u)
+    (hceiling : B < M_N) :
+    target (lastState s₀ rest) ∧ rest.length < M_N :=
+  ⟨hnostall _ hterm,
+   Nat.lt_of_le_of_lt (descent_flips_le_barrier hstrict s₀ rest B hbarrier hL) hceiling⟩
+
+end Mimo_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md
@@ -1,0 +1,52 @@
+# mimo_lean — Détection MIMO par descente à flips (Lean 4)
+
+Port formel de l'algorithme de détection MIMO par flips de coordonnées
+(Papailiopoulos, 2026 — issue #10984). Le lake naît directement sur
+`v4.32.0` (migration #10986 terminée) et suit la convention i18n #4980
+(docstrings FR par défaut, sibling `_en` avec namespace `Mimo_en`).
+
+## Phases
+
+| Phase | Livrable | Statut |
+|-------|----------|--------|
+| 1 | `Descent.lean` — squelette abstrait de la Proposition 9.1, **sans dépendance** (cœur Lean) | livré |
+| 2 | `Objective.lean` — fonction objectif avec Mathlib : Lemme 11.1 (coût d'un flip `4·(ρ/N·‖hᵢ‖² + √(ρ/N)·hᵢᵀw)`), Lemme 5.1 (erreur LMMSE `E‖b − x*‖² = E tr(B_ρ)`) | à venir |
+| 3 | Converse §11 via le lake externe [YuanheZ/lean-stat-learning-theory](https://github.com/YuanheZ/lean-stat-learning-theory) (v4.32.0, Apache 2.0, 0 sorry) : Hanson-Wright, concentration LSI, RMT | à venir |
+
+## Phase 1 — ce qui est prouvé
+
+Le théorème phare `Mimo.descent_target_before_ceiling` est la forme abstraite
+de la Proposition 9.1 : sous (i) stricte décroissance du coût à chaque flip
+accepté, (ii) confinement du coût sous une barrière `B`, (iii) absence de
+point bloquant hors cible, tout run **terminal** atteint la cible en
+**strictement moins de `M_N` flips** (plafond).
+
+Quatre lemmes intermédiaires, chacun autonome :
+
+1. `run_tail_cost_lt` — la décroissance stricte se propage à toute la queue ;
+2. `run_nodup` — un run ne revisite jamais un état ;
+3. `run_length_le_cost` — le nombre de flips est majoré par le coût initial
+   (le « budget de descente ») ;
+4. `descent_flips_le_barrier` — sous la barrière `B`, flips ≤ `B < M_N`.
+
+Le fichier est volontairement **sans `require`** : build en quelques secondes,
+sans téléchargement de Mathlib. Les hypothèses `accept` / `cost` / `target`
+sont abstraites ; la Phase 2 instancie `cost` par la fonction objectif du
+papier (où seuls les flips diminuant l'objectif sont acceptés, ce qui donne
+`hstrict`).
+
+## Build
+
+```bash
+cd MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean
+lake build   # cœur seul : quelques secondes, zéro dépendance
+```
+
+CI : `lean-mimo.yml` (baseline sorry = 0, filtre standalone-tactic — cf les
+autres lakes du dépôt).
+
+## Voir aussi
+
+- Issue #10984 — spécification et découpage en phases
+- Lakes frères : `learning_theory_lean` (v4.32.0), `kelly_lean`
+- Convention i18n #4980 — `Descent.lean` (FR) / `Descent_en.lean` (EN)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lake-manifest.json
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lake-manifest.json
@@ -1,0 +1,6 @@
+{"version": "1.2.0",
+ "packagesDir": ".lake/packages",
+ "packages": [],
+ "name": "mimo_lean",
+ "lakeDir": ".lake",
+ "fixedToolchain": false}

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
@@ -1,0 +1,31 @@
+import Lake
+open Lake DSL
+
+/-!
+# Lake mimo_lean — détection MIMO par descente à flips (Lean 4)
+
+Port formel de l'algorithme de détection MIMO par flips de coordonnées
+(Papailiopoulos, 2026 — cf issue #10984). Le lake naît directement sur
+`v4.32.0` (fin de la migration #10986) :
+
+- **Phase 1** (`Descent.lean`) : squelette de la Proposition 9.1 — descente à
+  flips sur un espace d'états abstrait, **sans aucune dépendance** (cœur Lean
+  uniquement, build en quelques secondes) : coût strictement décroissant à
+  chaque flip accepté, barrière de confinement, plafond de flips `M_N` ⟹ la
+  cible est atteinte strictement avant le plafond.
+- **Phase 2** (`Objective.lean`, à venir) : fonction objectif du papier avec
+  Mathlib — Lemme 11.1 (coût d'un flip) et Lemme 5.1 (erreur LMMSE).
+- **Phase 3** (converse §11, à venir) : appui sur le lake externe
+  `YuanheZ/lean-stat-learning-theory` (v4.32.0, Apache 2.0) pour la
+  concentration gaussienne (Hanson-Wright, LSI, RMT).
+
+Convention i18n #4980 : docstrings FR par défaut, sibling `_en`
+(namespace `Mimo_en`, imports `_en`), énoncés et noms de lemmes en anglais.
+-/
+
+package «mimo_lean» where
+  leanOptions := #[⟨`autoImplicit, false⟩]
+
+@[default_target]
+lean_lib «Descent» where
+  globs := #[`Descent, `Descent_en]

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lean-toolchain
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.32.0


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: MED/notebook-genai #11046

See #10984 (Phase 1 / 3 — contribution partielle, l'issue reste ouverte)

# mimo_lean Phase 1 — Descent.lean : squelette de la Proposition 9.1 (cœur, sans Mathlib)

Reprise de #10984 (demande user 2026-08-15, en tenant compte du commentaire
sur le lake externe SLT). Le lake naît directement sur **v4.32.0** (post-migration
#10986) à `MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/`.

## What

**`Descent.lean`** (+ sibling `Descent_en.lean`, i18n #4980) : formalisation
abstraite de la descente à flips de Papailiopoulos 2026 — **cœur Lean uniquement,
zéro `require`** (manifest vide). 4 lemmes + théorème phare :

| Déclaration | Rôle |
|---|---|
| `run_tail_cost_lt` | la stricte décroissance du coût se propage du pas local à toute la queue du run |
| `run_nodup` | un run à coût strictement décroissant ne revisite jamais un état |
| `run_length_le_cost` | flips ≤ `cost s₀` (« budget de descente », récurrence sur la structure du run) |
| `descent_flips_le_barrier` | barrière de confinement `B` ⟹ flips ≤ `B` |
| **`descent_target_before_ceiling`** | **Prop 9.1 (forme abstraite)** : run terminal ⟹ dernier état dans la cible ET flips **strictement < `M_N`** dès que `B < M_N` |

Les hypothèses (`accept`, `cost`, `target`, barrière) sont abstraites — c'est le
squelette ; la Phase 2 instancie `cost` par la fonction objectif du papier
(Lemme 11.1), la Phase 3 la converse §11 via `require slt`
(YuanheZ/lean-stat-learning-theory, v4.32.0).

Aussi : `README.md` (FR-first), `lean-mimo.yml` (CI, baseline sorry "0",
standalone-tactic), `lakefile.lean` (globs FR + `_en`).

## Proof (B.2)

1. `grep -cE '^\s*sorry\s*$'` : **0 / 0** (fichiers nouveaux, aucune occurrence ; mode brut `grep -cE '\b(sorry|admit)\b'` : 0/0 également).
2. **`lake build` SUCCESS local natif Windows** : `Build completed successfully (4 jobs)`, EXIT 0 (via `PIPESTATUS`) — build quasi instantané, aucune dépendance téléchargée (cœur seul, conforme au spec ~30s de l'issue : mesuré <2 s).
3. **Proof integrity SUCCESS** (`#print axioms` sur les 6 déclarations publiques + le théorème phare `_en`) : uniquement `propext` / `Quot.sound` — **ni `sorryAx` ni `Classical.choice`**.
4. Refactor prover Python : N/A (aucun script touché).
- i18n : parité code FR/`_en` vérifiée **IDENTICAL** après retrait des docstrings (script python, convention #4980) ; namespaces `Mimo` / `Mimo_en`.

## Scope

1 sujet = naissance du lake mimo_lean, Phase 1. 7 fichiers nouveaux, 422 lignes.
Catalogue byte-identique à main (aucune régénération sur branche — le cron s'en charge).

## Résiduel

- Phase 2 `Objective.lean` (Mathlib : Lemme 11.1 coût de flip, Lemme 5.1 LMMSE) ;
- Phase 3 converse §11 (`require slt`, Hanson-Wright / LSI / RMT) ;
- notebook compagnon éventuel — décision Phase 2.

