### PR TITLE
feat(guard,#10981): detecteur post-merge d'orphelin avere — mergeCommit non-ancetre de main

### DIFF
--- a/.github/workflows/orphaned-delivery-scan.yml
+++ b/.github/workflows/orphaned-delivery-scan.yml
@@ -1,0 +1,93 @@
+name: Orphaned delivery scan
+
+# The POST-MERGE organ for issue #10981: a PR merged with base != main
+# delivers its content onto a branch. If that branch is squash-merged into
+# main AFTERWARDS, the PR's mergeCommit is NOT an ancestor of main -- the
+# deliverable is orphaned (exists, merged, referenced by a closed issue, and
+# invisible to main). Measured firsthand 2026-08-14: #10972 merged into
+# feature/c10923-quarto-normalize 24s AFTER #10965 squash-merged that base
+# into main -- the site render infra never reached main and the site broke
+# in production.
+#
+# The advisory at PR time (base-not-main-advisory.yml, #10918) measures
+# "open PRs from base towards main" at pull_request events only; that
+# verdict can die between events without re-triggering anything. THIS
+# workflow re-examines every MERGED PR whose base != main and verifies that
+# its mergeCommit is an ancestor of origin/main -- the check the advisory
+# delegates to a human ("verifier au moment du merge") that nothing executed.
+#
+# ADVISORY, never blocking (same posture as orphan-branch-scan.yml):
+#   - The job ALWAYS exits 0. The actionable payload is the label
+#     `orphaned-delivery` + marker-guarded comment naming the mergeCommit and
+#     the recovery command, NEVER the green conclusion.
+#   - It does NOT auto-fix, does NOT close issues: it signals, ai-01 decides.
+#
+# Scheduled sweep (daily) is the primary trigger: an orphan is a STABLE state
+# once it exists, nothing forces J+0 detection. The [closed] trigger is
+# advisory-only and does NOT label (a base in flight is not yet an orphan).
+
+on:
+  schedule:
+    # Daily, off-:00 minute (anti-stampede). 06:17 UTC.
+    - cron: '17 6 * * *'
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log only, apply no label/comment'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: orphaned-delivery-scan
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: "Verify merged PRs' mergeCommit reached main (advisory)"
+    runs-on: ubuntu-latest
+    # On [closed], restrict to same-repo PRs: fork PRs cannot create an
+    # internal base != main orphan and their limited token/fetch access would
+    # only produce spurious failures on an advisory job.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch ALL remote heads
+        # actions/checkout@v4 only fetches the default branch. Ancestry of a
+        # mergeCommit against origin/main requires every remote head present.
+        run: |
+          git fetch origin '+refs/heads/*:refs/remotes/origin/*' || true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Run post-merge orphan scan
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ARGS="--days 7"
+          # Apply only on the scheduled sweep (or a dispatch that explicitly
+          # opts out of dry-run). A [closed] event is advisory-only: a base
+          # still in flight is NOT an orphan yet, labeling on PR close would
+          # be a false alarm.
+          if [ "${{ github.event_name }}" = "schedule" ]; then
+            ARGS="$ARGS --apply"
+          elif [ "${{ inputs.dry_run }}" = "false" ]; then
+            ARGS="$ARGS --apply"
+          else
+            ARGS="$ARGS --dry-run"
+          fi
+          python scripts/audit/check_orphan_merged_pr.py $ARGS --limit 200

--- a/scripts/audit/check_orphan_merged_pr.py
+++ b/scripts/audit/check_orphan_merged_pr.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""check_orphan_merged_pr.py — detecte les PR dont le contenu n'a jamais atteint main.
+
+Classe de defaut visee (#10981) : une PR est mergee avec ``base != main`` (dans
+une jambe de stack). Son contenu n'atteint ``main`` QUE si la jambe y arrive
+ensuite. Un squash-merge de la jambe produit un commit neuf sur ``main`` et ne
+rend PAS la branche ancetre de main : tout ce qui atterrit ensuite sur la
+branche est mort-ne. Sequence reelle du 2026-08-14 (orphelin #10972, site casse
+en prod) :
+
+    16:23:30  advisory sur #10972 : base=feature/c10923-quarto-normalize,
+              open_prs_to_main=1 -> « stack legitime »       <-- VRAI a cet instant
+    16:41:15  #10965 (cette base -> main) mergee en --squash
+    16:41:39  #10972 mergee DANS cette base, 24 s plus tard  <-- orphelin cree
+
+L'advisory (base_not_main.py) ne mesure qu'au moment ``pull_request`` ; le
+verdict « stack legitime » devient faux 18 minutes plus tard sans re-declencher
+l'advisory. Ce detecteur est POST-MERGE : il re-examine chaque PR MERGED dont
+``baseRefName != main`` et verifie que son ``mergeCommit`` est ancetre de
+``origin/main``. C'est le controle que l'advisory deleguait a l'humain
+(« verifier au moment du merge ») sans que rien ne l'execute.
+
+Trois filtres anti-faux-positifs :
+
+1. **mergeCommit ancetre de main** -> propre : le contenu est arrive (jambe
+   mergee en --merge preserve-SHA, ou contenu porte directement).
+2. **Jambe en vol** : une PR OUVERTE de la base vers ``main`` existe -> le
+   contenu va arriver, ce n'est pas un orphelin (verdict stable, pas de course).
+3. **Contenu re-atterri** : les fichiers de la PR sont deja presents a
+   l'identique sur ``main`` (cherry-pick / re-PR) -> pas un orphelin.
+
+Un finding est donc : *PR MERGED, base != main, mergeCommit non-ancetre de
+main, aucune PR ouverte de la base vers main, et le contenu manque encore a
+main*. L'orphelinage est un etat STABLE une fois avere : un balayage quotidien
+suffit (latence J+1 acceptable, l'issue le dit explicitement).
+
+Usage :
+    py scripts/audit/check_orphan_merged_pr.py --days 14
+    py scripts/audit/check_orphan_merged_pr.py --from-json prs.json --repo-path <repo>
+    py scripts/audit/check_orphan_merged_pr.py --days 30 --strict
+    py scripts/audit/check_orphan_merged_pr.py --days 7 --json-out out.json --apply
+
+Exit codes :
+    0 — advisory par defaut : n'echoue jamais, meme avec des findings
+    1 — findings ET `--strict`
+    2 — erreur d'execution (git absent, depot invalide, JSON illisible)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LABEL_NAME = "orphaned-delivery"
+LABEL_COLOR = "b60205"  # dark red — "le contenu de cette PR n'a jamais atteint main"
+LABEL_DESC = "PR mergee dont le mergeCommit n'est pas ancetre de main : contenu orphelin (#10981)"
+
+MARKER_START = "<!-- ORPHANED-DELIVERY:START -->"
+MARKER_END = "<!-- ORPHANED-DELIVERY:END -->"
+
+
+class GitError(RuntimeError):
+    """Echec d'une commande git — remonte en exit 2, jamais en finding."""
+
+
+def run_git(repo: Path, *args: str, check: bool = True) -> str:
+    """Execute git dans `repo` et rend stdout strippe."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    if check and proc.returncode != 0:
+        raise GitError(f"git {' '.join(args)} -> {proc.returncode}: {proc.stderr.strip()}")
+    return proc.stdout.strip()
+
+
+def parse_ts(value: str) -> datetime:
+    """Parse un horodatage ISO 8601 (gh mergedAt) en datetime aware."""
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def commit_exists(repo: Path, commit: str) -> bool:
+    """Vrai si le commit existe localement (objet git present)."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "cat-file", "-e", f"{commit}^{{commit}}"],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode == 0
+
+
+def is_ancestor(repo: Path, commit: str, base_ref: str) -> bool:
+    """Vrai si `commit` est ancetre (ou egal) de `base_ref`."""
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "merge-base", "--is-ancestor", commit, base_ref],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return True
+    if proc.returncode == 1:
+        return False
+    raise GitError(f"git merge-base --is-ancestor -> {proc.returncode}: {proc.stderr.strip()}")
+
+
+def content_missing_from_base(
+    repo: Path, base_ref: str, merge_commit: str, paths: list[str]
+) -> bool:
+    """Vrai si les chemins donnes different encore entre base et mergeCommit.
+
+    Diff deux-points volontairement : on compare les arbres tels qu'ils sont
+    aujourd'hui. Un diff trois-points reintroduirait le contenu de la jambe
+    deja squashe et rendrait tout orphelin suspect.
+    """
+    if not paths:
+        return False
+    proc = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--quiet", base_ref, merge_commit, "--", *paths],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode == 0:
+        return False  # identique -> le contenu est deja dans la base
+    if proc.returncode == 1:
+        return True  # differe -> contenu absent de la base
+    raise GitError(f"git diff --quiet -> {proc.returncode}: {proc.stderr.strip()}")
+
+
+def open_prs_to_main(repo: str, base: str) -> int:
+    """PRs ouvertes dont la tete est `base` et qui visent `main` (le stack)."""
+    proc = subprocess.run(
+        ["gh", "pr", "list", "--repo", repo, "--state", "open",
+         "--search", f'head:"{base}" base:main', "--json", "number"],
+        capture_output=True, text=True, encoding="utf-8",
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh pr list -> {proc.returncode}: {proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    data = json.loads(proc.stdout or "[]")
+    return len(data)
+
+
+def analyse_pr(repo: Path, pr: dict, base_ref: str, repo_slug: str) -> dict:
+    """Analyse une PR mergee. Rend un dict de resultat avec `status` explicite.
+
+    Statuts :
+      ``orphan``      — mergeCommit non-ancetre de main, jambe morte, contenu absent (finding)
+      ``clean``       — ancetre de main, ou contenu deja present (re-atterri)
+      ``in_flight``   — jambe encore ouverte vers main (stack legitime en vol)
+      ``skipped``     — base == main, ou mergeCommit manquant / introuvable
+    """
+    number = pr.get("number")
+    base = (pr.get("baseRefName") or "").strip()
+    head = (pr.get("headRefName") or "").strip()
+    merged_at = pr.get("mergedAt")
+    merge_commit = (pr.get("mergeCommit") or {}).get("oid") if isinstance(
+        pr.get("mergeCommit"), dict) else None
+    title = pr.get("title", "")
+
+    result = {"number": number, "head": head, "base": base, "merged_at": merged_at,
+              "title": title}
+
+    if not base or base == "main":
+        return {**result, "status": "skipped", "reason": "base is main"}
+    if not merge_commit:
+        return {**result, "status": "skipped", "reason": "no mergeCommit"}
+    if not commit_exists(repo, merge_commit):
+        return {**result, "status": "skipped", "reason": f"mergeCommit {merge_commit[:9]} unreachable locally"}
+
+    # Filtre 1 : ancetre de main -> le contenu est arrive.
+    if is_ancestor(repo, merge_commit, base_ref):
+        return {**result, "status": "clean", "reason": "mergeCommit is ancestor of base"}
+
+    # Filtre 2 : jambe encore ouverte vers main -> le contenu va arriver.
+    if repo_slug:
+        inflight = open_prs_to_main(repo_slug, base)
+        if inflight > 0:
+            return {**result, "status": "in_flight", "open_prs_to_main": inflight,
+                    "reason": f"base '{base}' still has {inflight} open PR(s) towards main"}
+
+    # Filtre 3 : le contenu a-t-il re-atterri par une autre route (cherry-pick) ?
+    paths = [f.get("path") for f in (pr.get("files") or []) if f.get("path")]
+    missing = content_missing_from_base(repo, base_ref, merge_commit, paths)
+    if not missing:
+        return {**result, "status": "clean", "merge_commit": merge_commit,
+                "paths": paths, "reason": "content already present in base (re-landed)"}
+
+    return {**result, "status": "orphan", "merge_commit": merge_commit,
+            "paths": paths,
+            "recovery": f"git merge origin/{head}"}
+
+
+def load_prs(args: argparse.Namespace) -> list[dict]:
+    """Charge les PR mergees depuis un JSON local (`--from-json`) ou via `gh`."""
+    if args.from_json:
+        path = Path(args.from_json)
+        if not path.is_file():
+            raise GitError(f"--from-json: fichier introuvable: {path}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else data.get("prs", [])
+
+    cmd = [
+        "gh", "pr", "list", "--state", "merged", "--limit", str(args.limit),
+        "--json", "number,title,baseRefName,headRefName,mergedAt,mergeCommit,files",
+    ]
+    if args.repo:
+        cmd += ["--repo", args.repo]
+    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8",
+                          errors="replace")
+    if proc.returncode != 0:
+        raise GitError(f"gh pr list -> {proc.returncode}: {proc.stderr.strip()}")
+    return json.loads(proc.stdout or "[]")
+
+
+def filter_by_age(prs: list[dict], days: int, now: datetime | None = None) -> list[dict]:
+    """Ne garde que les PR mergees dans la fenetre demandee (0 = sans limite)."""
+    if days <= 0:
+        return prs
+    reference = now or datetime.now(timezone.utc)
+    kept = []
+    for pr in prs:
+        raw = pr.get("mergedAt")
+        if not raw:
+            continue
+        if (reference - parse_ts(raw)).days <= days:
+            kept.append(pr)
+    return kept
+
+
+def format_report(results: list[dict]) -> str:
+    """Rapport texte : les findings d'abord, puis un recapitulatif compte."""
+    orphans = [r for r in results if r["status"] == "orphan"]
+    inflight = [r for r in results if r["status"] == "in_flight"]
+    lines: list[str] = []
+
+    for r in orphans:
+        lines.append(f"ORPHAN  PR #{r['number']}  base={r['base']}  head={r['head']}")
+        lines.append(f"        merge: {r['merged_at']}  mergeCommit={r['merge_commit'][:12]}  |  {r['title'][:70]}")
+        for p in r.get("paths", [])[:5]:
+            lines.append(f"          ~ {p}")
+        lines.append(f"        recuperation : {r.get('recovery', '')}")
+        lines.append("")
+
+    lines.append(
+        "Analysees: {total} | orphelins: {o} | en vol: {f} | propres: {c} | ignorees: {s}".format(
+            total=len(results),
+            o=len(orphans),
+            f=len(inflight),
+            c=sum(1 for r in results if r["status"] == "clean"),
+            s=sum(1 for r in results if r["status"] == "skipped"),
+        )
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# gh wiring for --apply (label + comment), mirrors scripts/base_not_main.py
+# ---------------------------------------------------------------------------
+
+def _gh_json(args: list[str]) -> object:
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True,
+                          check=False, encoding="utf-8")
+    if proc.returncode != 0:
+        raise RuntimeError(f"gh failed ({proc.returncode}): {proc.stderr.strip() or proc.stdout.strip()}")
+    if not proc.stdout.strip():
+        return None
+    return json.loads(proc.stdout)
+
+
+def ensure_label(repo: str) -> None:
+    subprocess.run(
+        ["gh", "label", "create", LABEL_NAME, "--repo", repo,
+         "--color", LABEL_COLOR, "--description", LABEL_DESC, "--force"],
+        capture_output=True, text=True, check=False, encoding="utf-8",
+    )
+
+
+def existing_comment(repo: str, number: int) -> int | None:
+    comments = _gh_json(["pr", "view", str(number), "--repo", repo,
+                         "--json", "comments"]) or {}
+    for c in (comments.get("comments") or []):
+        if MARKER_START in (c.get("body") or ""):
+            return c["id"]
+    return None
+
+
+def update_comment(repo: str, comment_id: int, body: str) -> None:
+    subprocess.run(
+        ["gh", "api", f"repos/{repo}/issues/comments/{comment_id}",
+         "-X", "PATCH", "-f", f"body={body}"],
+        capture_output=True, text=True, check=False, encoding="utf-8",
+    )
+
+
+def post_comment(repo: str, number: int, body: str) -> None:
+    subprocess.run(
+        ["gh", "pr", "comment", str(number), "--repo", repo, "--body", body],
+        capture_output=True, text=True, check=False, encoding="utf-8",
+    )
+
+
+def build_comment(r: dict) -> str:
+    return "\n".join([
+        MARKER_START,
+        "## Contenu orphelin — mergeCommit jamais arrive sur `main` (#10981)",
+        "",
+        f"Cette PR a ete mergee dans `{r['base']}` (base != `main`), et son "
+        f"`mergeCommit` **{r['merge_commit'][:12]}** n'est **pas ancetre de "
+        f"`main`** : le contenu (`{r['title']}`) n'a jamais ete porte sur la "
+        f"branche principale. Recuperation proposee : "
+        f"`{r.get('recovery', '')}` puis PR de la base vers `main`.",
+        MARKER_END,
+    ])
+
+
+def apply_findings(repo: str, orphans: list[dict], dry_run: bool) -> None:
+    """Label + commentaire marker-guarde (upsert, pas de spam quotidien)."""
+    if not orphans:
+        return
+    if not dry_run:
+        ensure_label(repo)
+    for r in orphans:
+        number = r["number"]
+        if dry_run:
+            print(f"[orphan-apply] #{number} label={LABEL_NAME} (dry-run)")
+            continue
+        body = build_comment(r)
+        cid = existing_comment(repo, number)
+        if cid is not None:
+            update_comment(repo, cid, body)
+            print(f"[orphan-apply] #{number} comment updated ({cid})")
+        else:
+            post_comment(repo, number, body)
+            print(f"[orphan-apply] #{number} comment posted")
+        subprocess.run(
+            ["gh", "pr", "edit", str(number), "--repo", repo, "--add-label", LABEL_NAME],
+            capture_output=True, text=True, check=False, encoding="utf-8",
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--repo-path", default=".", help="racine du depot git (defaut: .)")
+    parser.add_argument("--base-ref", default="origin/main", help="ref de base (defaut: origin/main)")
+    parser.add_argument("--days", type=int, default=14,
+                        help="fenetre d'anciennete des merges, en jours (0 = sans limite)")
+    parser.add_argument("--limit", type=int, default=200, help="nombre de PR demandees a gh")
+    parser.add_argument("--repo", default=None, help="slug owner/name passe a gh")
+    parser.add_argument("--from-json", default=None,
+                        help="lire les PR depuis un JSON local au lieu d'appeler gh")
+    parser.add_argument("--json-out", default=None, help="ecrire le resultat complet en JSON")
+    parser.add_argument("--strict", action="store_true",
+                        help="exit 1 si au moins un orphelin (defaut: advisory, exit 0)")
+    parser.add_argument("--apply", action="store_true",
+                        help="label orphaned-delivery + commentaire sur les PR orphelines")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="avec --apply : loguer sans appliquer")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo = Path(args.repo_path).resolve()
+
+    try:
+        if not (repo / ".git").exists() and not (repo / ".git").is_file():
+            run_git(repo, "rev-parse", "--git-dir")
+        repo_slug = args.repo or (subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
+            capture_output=True, text=True, encoding="utf-8").stdout.strip()
+            or "jsboige/CoursIA")
+        prs = filter_by_age(load_prs(args), args.days)
+        results = [analyse_pr(repo, pr, args.base_ref, repo_slug) for pr in prs]
+    except GitError as exc:
+        print(f"ERREUR: {exc}", file=sys.stderr)
+        return 2
+    except json.JSONDecodeError as exc:
+        print(f"ERREUR: JSON illisible: {exc}", file=sys.stderr)
+        return 2
+    except RuntimeError as exc:
+        print(f"ERREUR: {exc}", file=sys.stderr)
+        return 2
+
+    print(format_report(results))
+
+    if args.json_out:
+        try:
+            Path(args.json_out).write_text(
+                json.dumps({"results": results}, indent=2, ensure_ascii=False),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            print(f"ERREUR: --json-out non ecrivable: {exc}", file=sys.stderr)
+            return 2
+
+    orphans = [r for r in results if r["status"] == "orphan"]
+    if args.apply:
+        try:
+            apply_findings(repo_slug, orphans, args.dry_run)
+        except RuntimeError as exc:
+            print(f"ERREUR: {exc}", file=sys.stderr)
+            return 2
+
+    return 1 if (orphans and args.strict) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit/tests/test_check_orphan_merged_pr.py
+++ b/scripts/audit/tests/test_check_orphan_merged_pr.py
@@ -1,0 +1,403 @@
+"""Tests for scripts/audit/check_orphan_merged_pr.py (#10981).
+
+The tool re-examines MERGED PRs whose base != main and verifies, POST-merge,
+that the PR's mergeCommit is an ancestor of main. This is the check that
+base_not_main.py (advisory at PR time) delegated to the human — "verifier au
+moment du merge" — and that nothing executed. The founding incident (2026-08-14)
+is #10972: a stack-legit PR whose base leg was squash-merged 24s before the PR
+landed into that base, orphaning the deliverable (the site broke in prod).
+
+The three anti-false-positive filters are covered here:
+
+  - Filtre 1 (ancestor): a mergeCommit that IS an ancestor of base_ref is clean
+    (content reached main via a --merge preserving SHAs, or directly).
+  - Filtre 2 (in flight): the base still has an open PR towards main -> the
+    content will arrive, verdict is stable (no race), not an orphan.
+  - Filtre 3 (re-landed): the PR's files already match base (cherry-pick /
+    re-PR elsewhere) -> not an orphan, the content IS on main.
+
+All git-backed tests build a hermetic mini-repo under ``tmp_path``. The key
+scenario -- squash-merge of the base leg BEFORE the PR lands into it -- uses
+the exact timestamps of the real #10972 sequence so the reproduction is
+faithful.
+"""
+import importlib.util
+import json
+import os
+import subprocess
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_orphan_merged_pr.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_orphan_merged_pr", CHECK_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# Hermetic git helpers
+# --------------------------------------------------------------------------- #
+_BASE_CFG = ("-c", "user.name=t", "-c", "user.email=t@e", "-c", "commit.gpgsign=false")
+
+
+def _g(repo: Path, *args: str, date: str | None = None) -> str:
+    """Run git in ``repo`` with a neutral identity + optional pinned date."""
+    env = os.environ.copy()
+    if date:
+        env["GIT_AUTHOR_DATE"] = date
+        env["GIT_COMMITTER_DATE"] = date
+    cmd = ["git", "-C", str(repo), *_BASE_CFG, *args]
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=env)
+    assert proc.returncode == 0, f"git {args} failed: {proc.stderr.strip()}"
+    return proc.stdout.strip()
+
+
+def _git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _g(repo, "init", "-q")
+    _g(repo, "commit", "-q", "--allow-empty", "-m", "init",
+       date="2026-08-14T09:00:00+00:00")
+    _g(repo, "branch", "-M", "main")
+    return repo
+
+
+def _commit(repo: Path, message: str, files: dict | None = None,
+            date: str = "2026-08-14T10:00:00+00:00") -> str:
+    for rel, content in (files or {}).items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    _g(repo, "add", "-A")
+    _g(repo, "commit", "-q", "-m", message, date=date)
+    return _g(repo, "rev-parse", "HEAD")
+
+
+def _pr(number: int, head: str, base: str = "feature/base",
+        merged_at: str = "2026-08-14T16:41:39Z", merge_commit: str = "",
+        files: list | None = None, title: str = "T") -> dict:
+    return {"number": number, "headRefName": head, "baseRefName": base,
+            "mergedAt": merged_at,
+            "mergeCommit": {"oid": merge_commit} if merge_commit else None,
+            "files": [{"path": p} for p in (files or [])], "title": title}
+
+
+# --------------------------------------------------------------------------- #
+# parse_ts / commit_exists / is_ancestor / content_missing_from_base
+# --------------------------------------------------------------------------- #
+def test_parse_ts_z_suffix_is_utc_aware():
+    mod = _load()
+    dt = mod.parse_ts("2026-08-14T16:41:39Z")
+    assert dt == datetime(2026, 8, 14, 16, 41, 39, tzinfo=timezone.utc)
+
+
+def test_commit_exists_true_false(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    sha = _g(repo, "rev-parse", "HEAD")
+    assert mod.commit_exists(repo, sha) is True
+    assert mod.commit_exists(repo, "deadbeef" * 5) is False
+
+
+def test_is_ancestor_true_for_self_and_lineage(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    first = _g(repo, "rev-parse", "HEAD")
+    _g(repo, "checkout", "-q", "-b", "feat")
+    second = _commit(repo, "x", {"a.txt": "1"})
+    assert mod.is_ancestor(repo, first, "main") is True
+    assert mod.is_ancestor(repo, second, "main") is False  # feat ahead of main
+
+
+def test_content_missing_true_when_absent_false_when_identical(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "base")
+    mc = _commit(repo, "pr lands", {"site/rendered.html": "html"}, date="2026-08-14T16:41:39+00:00")
+    assert mod.content_missing_from_base(repo, "main", mc, ["site/rendered.html"]) is True
+    _g(repo, "checkout", "-q", "main")
+    _commit(repo, "re-landed", {"site/rendered.html": "html"}, date="2026-08-14T17:00:00+00:00")
+    assert mod.content_missing_from_base(repo, "main", mc, ["site/rendered.html"]) is False
+
+
+# --------------------------------------------------------------------------- #
+# The founding scenario (#10972, real timestamps) -- criterion 1: must turn red
+# --------------------------------------------------------------------------- #
+def test_orphan_after_base_squash_merge(tmp_path):
+    """Exact reproduction of #10972: base leg squash-merged, THEN the PR lands
+    into the base 24s later. mergeCommit is not an ancestor of main -> orphan."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    # 16:23:30  base branch with leg content
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"}, date="2026-08-14T16:23:30+00:00")
+    base_sha = _g(repo, "rev-parse", "HEAD")
+    # 16:41:15  #10965: base -> main squash-merged (creates a NEW commit on main,
+    #           base branch is NO LONGER an ancestor of main)
+    _g(repo, "checkout", "-q", "main")
+    _commit(repo, "squash of base leg", {"_quarto.yml": "cfg"}, date="2026-08-14T16:41:15+00:00")
+    # 16:41:39  #10972: PR merged INTO the (now orphaned) base
+    _g(repo, "checkout", "-q", "feature/base")
+    mc = _commit(repo, "PR site-render infra", {"site/rendered.html": "html"},
+                 date="2026-08-14T16:41:39+00:00")
+    pr = _pr(10972, "feature/site-render-infra-10923", base="feature/base",
+             merge_commit=mc, files=["site/rendered.html", "_quarto.yml"])
+    res = mod.analyse_pr(repo, pr, "main", "")
+    assert res["status"] == "orphan"
+    assert res["merge_commit"] == mc
+    assert "recovery" in res
+
+
+def test_orphan_strict_exits_1_main(tmp_path):
+    """main() with --strict returns 1 on a genuine orphan (criterion 1: red)."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "main")
+    _commit(repo, "squash of base leg", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "feature/base")
+    mc = _commit(repo, "PR lands", {"site/rendered.html": "html"})
+    prs = tmp_path / "prs.json"
+    prs.write_text(json.dumps([_pr(1, "feature/site", merge_commit=mc,
+                                   files=["site/rendered.html"])]), encoding="utf-8")
+    rc = mod.main(["--repo-path", str(repo), "--from-json", str(prs),
+                   "--base-ref", "main", "--repo", "", "--days", "0", "--strict"])
+    assert rc == 1
+
+
+# --------------------------------------------------------------------------- #
+# Filtre 1 -- mergeCommit ancestor of main (--merge preserve-SHA) -- clean
+# --------------------------------------------------------------------------- #
+def test_clean_when_merge_commit_is_ancestor(tmp_path):
+    """If the base leg was merged with --merge (SHAs preserved), the PR's
+    mergeCommit IS an ancestor of main -> clean, no false positive."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "-b", "feature/site2")
+    _commit(repo, "PR work", {"site/rendered.html": "html"})
+    _g(repo, "checkout", "-q", "feature/base")
+    # PR merges into base (merge commit on base), then base --merge into main
+    _g(repo, "merge", "-q", "--no-ff", "feature/site2", "-m", "merge PR into base",
+       date="2026-08-14T16:41:39+00:00")
+    mc = _g(repo, "rev-parse", "HEAD")
+    _g(repo, "checkout", "-q", "main")
+    _g(repo, "merge", "-q", "--no-ff", "feature/base", "-m", "merge base into main",
+       date="2026-08-14T17:00:00+00:00")
+    pr = _pr(10, "feature/site2", base="feature/base", merge_commit=mc,
+             files=["site/rendered.html"])
+    res = mod.analyse_pr(repo, pr, "main", "")
+    assert res["status"] == "clean"
+    assert "ancestor" in res["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# Filtre 2 -- stack in flight (base still has an open PR towards main)
+# --------------------------------------------------------------------------- #
+def test_conservative_orphan_without_repo_slug(tmp_path):
+    """Without a repo slug, the tool cannot query gh for open PRs on the base,
+    so it conservatively falls through to the content check. A base that
+    genuinely lacks the content on main -> orphan. (With a slug, the same
+    scenario is in_flight -- covered by test_in_flight_status_when_open_prs.)"""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "-b", "feature/site")
+    mc = _commit(repo, "PR work", {"site/rendered.html": "html"})
+    pr = _pr(11, "feature/site", base="feature/base", merge_commit=mc,
+             files=["site/rendered.html"])
+    res = mod.analyse_pr(repo, pr, "main", "")
+    assert res["status"] == "orphan"
+
+
+def test_in_flight_status_when_open_prs_to_main(monkeypatch, tmp_path):
+    """With a repo slug, the gh call for open PRs on the base returns >= 1 ->
+    in_flight (NOT orphan). Stubs open_prs_to_main (a gh call)."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "-b", "feature/site")
+    mc = _commit(repo, "PR work", {"site/rendered.html": "html"})
+    pr = _pr(12, "feature/site", base="feature/base", merge_commit=mc,
+             files=["site/rendered.html"])
+    monkeypatch.setattr(mod, "open_prs_to_main", lambda repo_slug, base: 1)
+
+    res = mod.analyse_pr(repo, pr, "main", "fake/repo")
+    assert res["status"] == "in_flight"
+    assert res["open_prs_to_main"] == 1
+
+
+def test_orphan_when_open_prs_to_main_zero(monkeypatch, tmp_path):
+    """With a repo slug, gh returns 0 open PRs on the base AND the content is
+    missing from main -> orphan (the #10972 case with the stack now dead)."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "main")
+    _commit(repo, "squash of base leg", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "feature/base")
+    mc = _commit(repo, "PR work", {"site/rendered.html": "html"})
+    pr = _pr(13, "feature/site", base="feature/base", merge_commit=mc,
+             files=["site/rendered.html"])
+    monkeypatch.setattr(mod, "open_prs_to_main", lambda repo_slug, base: 0)
+
+    res = mod.analyse_pr(repo, pr, "main", "fake/repo")
+    assert res["status"] == "orphan"
+    assert res["merge_commit"] == mc
+
+
+# --------------------------------------------------------------------------- #
+# Filtre 3 -- content re-landed via another route (cherry-pick)
+# --------------------------------------------------------------------------- #
+def test_clean_when_content_relanded(tmp_path):
+    """Filtre 3: the PR's files already match main (cherry-picked elsewhere) ->
+    clean, not an orphan, even though the mergeCommit is not an ancestor."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "-b", "feature/site")
+    mc = _commit(repo, "PR work", {"site/rendered.html": "html"})
+    _g(repo, "checkout", "-q", "main")
+    # base leg squash-merged, and the PR content cherry-picked (new commit)
+    _commit(repo, "squash of base leg", {"_quarto.yml": "cfg"})
+    _commit(repo, "cherry-pick of PR content", {"site/rendered.html": "html"})
+    pr = _pr(14, "feature/site", base="feature/base", merge_commit=mc,
+             files=["site/rendered.html"])
+    res = mod.analyse_pr(repo, pr, "main", "")
+    assert res["status"] == "clean"
+    assert "re-landed" in res["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# skipped cases
+# --------------------------------------------------------------------------- #
+def test_skipped_when_base_is_main(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    pr = _pr(15, "feature/x", base="main")
+    res = mod.analyse_pr(repo, pr, "main", "")
+    assert res["status"] == "skipped"
+    assert "base is main" in res["reason"]
+
+
+def test_skipped_when_no_merge_commit(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    pr = _pr(16, "feature/x", base="feature/base", merge_commit="")
+    res = mod.analyse_pr(repo, pr, "main", "")
+    assert res["status"] == "skipped"
+    assert "no mergeCommit" in res["reason"]
+
+
+def test_skipped_when_merge_commit_unreachable(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    pr = _pr(17, "feature/x", base="feature/base", merge_commit="deadbeef" * 5)
+    res = mod.analyse_pr(repo, pr, "main", "")
+    assert res["status"] == "skipped"
+    assert "unreachable" in res["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# format_report
+# --------------------------------------------------------------------------- #
+def test_format_report_counts_and_orphan_detail():
+    mod = _load()
+    results = [
+        {"status": "orphan", "number": 1, "base": "feature/base", "head": "f",
+         "merged_at": "t", "title": "T", "merge_commit": "a" * 40,
+         "paths": ["site/rendered.html"], "recovery": "git merge origin/f"},
+        {"status": "clean", "number": 2, "base": "feature/b", "head": "g",
+         "merged_at": "t", "title": "T", "reason": "x"},
+        {"status": "in_flight", "number": 3, "base": "feature/c", "head": "h",
+         "merged_at": "t", "title": "T", "open_prs_to_main": 1, "reason": "y"},
+        {"status": "skipped", "number": 4, "reason": "base is main"},
+    ]
+    out = mod.format_report(results)
+    assert "ORPHAN  PR #1" in out
+    assert "orphelins: 1" in out
+    assert "en vol: 1" in out
+    assert "propres: 1" in out
+    assert "ignorees: 1" in out
+
+
+# --------------------------------------------------------------------------- #
+# load_prs / filter_by_age / main()
+# --------------------------------------------------------------------------- #
+def test_load_prs_from_json_list(tmp_path):
+    mod = _load()
+    prs = tmp_path / "prs.json"
+    prs.write_text(json.dumps([{"number": 1}]), encoding="utf-8")
+    args = mod.build_parser().parse_args(["--from-json", str(prs)])
+    assert mod.load_prs(args) == [{"number": 1}]
+
+
+def test_filter_by_age_zero_returns_all():
+    mod = _load()
+    prs = [{"mergedAt": "2026-08-14T16:41:39Z"}, {"mergedAt": "2020-01-01T00:00:00Z"}]
+    assert mod.filter_by_age(prs, 0) == prs
+
+
+def test_main_clean_exits_0(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    prs = tmp_path / "prs.json"
+    prs.write_text(json.dumps([_pr(1, "feature/x", base="main")]), encoding="utf-8")
+    rc = mod.main(["--repo-path", str(repo), "--from-json", str(prs),
+                   "--base-ref", "main", "--repo", "", "--days", "0"])
+    assert rc == 0
+
+
+def test_main_orphan_advisory_exits_0(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "main")
+    _commit(repo, "squash base leg", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "feature/base")
+    mc = _commit(repo, "PR", {"site/rendered.html": "html"})
+    prs = tmp_path / "prs.json"
+    prs.write_text(json.dumps([_pr(1, "feature/site", merge_commit=mc,
+                                   files=["site/rendered.html"])]), encoding="utf-8")
+    rc = mod.main(["--repo-path", str(repo), "--from-json", str(prs),
+                   "--base-ref", "main", "--repo", "", "--days", "0"])
+    assert rc == 0  # advisory by default
+
+
+def test_main_bad_json_exits_2(tmp_path, capsys):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    rc = mod.main(["--repo-path", str(repo), "--from-json", str(bad),
+                   "--base-ref", "main", "--repo", "", "--days", "0"])
+    assert rc == 2
+    assert "JSON illisible" in capsys.readouterr().err
+
+
+def test_main_json_out_written(tmp_path):
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    prs = tmp_path / "prs.json"
+    prs.write_text(json.dumps([_pr(1, "feature/x", base="main")]), encoding="utf-8")
+    out = tmp_path / "out.json"
+    rc = mod.main(["--repo-path", str(repo), "--from-json", str(prs),
+                   "--base-ref", "main", "--repo", "", "--days", "0",
+                   "--json-out", str(out)])
+    assert rc == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert data["results"][0]["status"] == "skipped"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: LIGHT/docs #11040

## Summary

Détecteur **post-merge** d'orphelin avéré pour #10981 : une PR MERGED dont `base != main` peut livrer son contenu sur une branche jamais reliée à `main`. Le trou mesuré : l'advisory `base-not-main-advisory.yml` (#10918) mesure « PRs ouvertes de la base vers main » **au moment `pull_request`** ; le verdict « stack légitime » est devenu faux 18 min plus tard sans re-déclencher l'advisory (séquence réelle #10972, 2026-08-14 : jambe `feature/c10923-quarto-normalize` squash-mergée, puis PR mergée dedans 24 s après → infra rendu site jamais sur `main`, site cassé en prod).

**Ce que le détecteur fait** : re-examine chaque PR MERGED avec `baseRefName != main` et vérifie que son `mergeCommit` est ancêtre de `origin/main`. C'est le contrôle que l'advisory déléguait à l'humain (« vérifier au moment du merge ») et que rien n'exécutait.

## Les 3 filtres anti-faux-positifs

| Filtre | Cas | Verdict |
|---|---|---|
| 1 | `mergeCommit` est ancêtre de `main` (jambe mergée en `--merge` preserve-SHA, ou contenu porté directement) | **clean** |
| 2 | La jambe de base a encore une PR **ouverte** vers `main` (stack légitimement en vol) | **in_flight**, pas orphelin (verdict stable, pas de course) |
| 3 | Les fichiers de la PR sont déjà présents à l'identique sur `main` (cherry-pick / re-PR) | **clean** (re-landed) |

Un finding = PR MERGED + base != main + mergeCommit non-ancêtre + jambe morte + contenu manquant → label `orphaned-delivery` + commentaire nommant le `mergeCommit` et la commande de récupération.

## Validation

### Critères d'acceptation du body (4/4)

1. **Test hermétique reproduit la séquence** (timestamps réels de #10972 : squash de la jambe 16:41:15, PR mergée 16:41:39) → détecteur **rougit** (`test_orphan_after_base_squash_merge`, `test_orphan_strict_exits_1_main`).
2. **Stack en vol ne déclenche pas** : `test_in_flight_status_when_open_prs_to_main` (gh stub → `in_flight`, pas orphelin) + `test_clean_when_merge_commit_is_ancestor`.
3. **Nomme mergeCommit + branche** : sortie `ORPHAN PR #10972 ... mergeCommit=3a178b0f02bc` + `recuperation : git merge origin/feature/site-render-infra-10923`.
4. **Passe sur l'historique réel** (90 j, 300 PRs, firsthand 2026-08-15) :

```
ORPHAN  PR #10972  base=feature/c10923-quarto-normalize  head=feature/site-render-infra-10923
        merge: 2026-08-14T16:41:39Z  mergeCommit=3a178b0f02bc
        ~ MyIA.AI.Notebooks/Search/_metadata.yml, _quarto.yml,
          scripts/regen_quarto_render.py, scripts/tests/test_regen_quarto_render.py
Analysees: 300 | orphelins: 1 | en vol: 0 | propres: 3 | ignorees: 296
```

- **#10972 ressort** (orphelin avéré). Témoins récupérés **#10770** (`2f579d6e`) et **#10684** (`cb6714db`) : mergeCommit non-ancêtre mais `content_missing_from_base = False` → **propres**, pas de faux positif (filtre 3).

### Tests

`21 passed` (pytest, conda coursia-ml-training) — hermétiques, mini-repo git, dates pinnées, aucun réseau/gh pour la logique de détection.

## Déclencheurs du workflow `orphaned-delivery-scan.yml`

- **Cron quotidien 06:17 UTC** (minute off-:00, anti-stampede) → **apply** (label + commentaire marker-guardé upsert, pas de spam).
- `workflow_dispatch` avec `dry_run` → dry-run par défaut, apply si explicitement décoché.
- `pull_request: [closed]` (same-repo only) → **dry-run advisory** : une jambe en vol au moment du close n'est pas encore un orphelin.

## Pourquoi pas le scan de branches existant (`orphan_branch_scan.py`)

Il examine la **branche head** (partie b de #10918) ; le critère 3 de #10981 exige de nommer le **mergeCommit de la PR**, ce qu'un scan par branche ne produit pas (le mergeCommit peut être différent de la pointe de la branche). Les deux organes sont complémentaires : l'advisory signale au PR-time, le scan de branches couvre les branches, celui-ci vérifie l'ancestralité du mergeCommit au post-merge.

See #10981

## Test plan (post-merge)

- [ ] Le cron tourne une fois : label `orphaned-delivery` posé sur #10972, commentaire nommant `3a178b0f02bc` + commande de récupération
- [ ] `scripts-tests.yml` passe (découverte auto via `scripts/audit/tests` dans testpaths)
- [ ] ai-01 récupère #10972 (merge branche → main) ; le cron suivant ne le ressort plus (ancêtre)
