### PR TITLE
Notebook: piloter WordPress par MCP — le serveur JSON-RPC (série AI Engine par son API, grain 4)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -165,6 +165,12 @@ montre l'autre style d'API du plugin : le formulaire est un **contenu**
 WordPress (custom post type `mwai_form`, CRUD unitaire, corps
 Gutenberg, rendu public par shortcode) — et mesure la frontière
 gratuite/Pro (du contenu rendu, pas encore des champs).
+[`piloter-wordpress-par-mcp.ipynb`](piloter-wordpress-par-mcp.ipynb)
+ouvre la seconde face du plugin : **WordPress comme serveur MCP** —
+endpoint JSON-RPC `mcp/v1/http`, handshake avec négociation de
+version, catalogue de 43 outils à JSON Schema, et de vrais
+`tools/call` (lecture, puis création/suppression d'un article) — la
+frontière d'authentification mesurée à 401 sur chaque méthode.
 
 ---
 
@@ -295,6 +301,8 @@ attendues.
   chatbots comme documents JSON : lire, dupliquer, écrire (read-modify-write), interroger deux personas
 - [`administrer-les-formulaires-par-l-api.ipynb`](administrer-les-formulaires-par-l-api.ipynb) —
   formulaires comme contenu : CRUD unitaire, publication, rendu public, frontière gratuite/Pro mesurée
+- [`piloter-wordpress-par-mcp.ipynb`](piloter-wordpress-par-mcp.ipynb) —
+  WordPress comme serveur MCP : handshake JSON-RPC, catalogue d'outils, tools/call en lecture et écriture
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -311,6 +311,20 @@ la distance entre ses outils et le schéma de persistance.
 > y est synthétique (Maison Valmont) — aucun outil réel du site n'y figure —
 > et un chemin live optionnel permet de le rejouer sur son propre serveur.
 
+> **Notebook compagnon (face protocole).**
+> [`piloter-wordpress-par-mcp.ipynb`](piloter-wordpress-par-mcp.ipynb)
+> démontre le protocole lui-même contre l'instance jetable : l'endpoint
+> JSON-RPC `mcp/v1/http` (namespace séparé de l'API REST d'administration),
+> le handshake `initialize` avec **négociation de version** réelle, le
+> catalogue `tools/list` (43 outils à JSON Schema, miroir vivant de
+> `mcp/functions`), puis de vrais `tools/call` — lecture, puis
+> création/suppression d'un article éphémère : un client externe qui agit
+> sur le site. Frontière mesurée : sans credentials, chaque méthode
+> (initialize comprise) répond `401`. Sur la version gratuite, les 43
+> outils sont tous génériques `wp_*` — la leçon ci-dessus (« les verbes du
+> métier ») se lit en négatif : les 24 outils métier de l'installation
+> client viennent du plugin custom, consommables par le même protocole.
+
 ### Comparaison OWUI
 
 C'est ici qu'AI-Engine se distingue le plus franchement. Open WebUI

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/piloter-wordpress-par-mcp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/piloter-wordpress-par-mcp.ipynb
@@ -1,0 +1,682 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "393ecd4c",
+   "metadata": {},
+   "source": [
+    "# Piloter WordPress par MCP — le serveur, pas l'API d'administration\n",
+    "\n",
+    "Quatrieme notebook de la serie « AI Engine par son API ». Les grains\n",
+    "precedents ont utilise l'API REST d'administration (`mwai/v1`) : lire\n",
+    "les chatbots, ecrire des formulaires. Ce notebook ouvre l'autre face\n",
+    "du plugin : **WordPress devient un serveur MCP** — un endpoint JSON-RPC\n",
+    "(`mcp/v1/http`) que consomme non pas un administrateur, mais un\n",
+    "**agent** : Claude, un IDE, ou le client HTTP de ce notebook.\n",
+    "\n",
+    "Le protocole complet est demontre sur l'instance jetable : le\n",
+    "handshake (`initialize`), le catalogue d'outils (`tools/list`), puis\n",
+    "de vrais appels (`tools/call`) — jusqu'a **creer et supprimer un\n",
+    "article** : un client externe qui agit sur le site. Et la frontiere de\n",
+    "securite, mesuree : sans credentials, tout refuse.\n",
+    "\n",
+    "> Les sorties de ce notebook proviennent d'une execution reelle contre\n",
+    "> l'instance locale (voir « Provenance et limites », en fin de fichier).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1ee508f",
+   "metadata": {},
+   "source": [
+    "## La serie « AI Engine par son API »\n",
+    "\n",
+    "Le projet Livres Agites a mis AI Engine au coeur d'une maison d'edition :\n",
+    "bot d'accueil, agents d'ateliers, bibliothecaire documentee par RAG,\n",
+    "formulaires dynamiques. Cette serie presente le plugin de maniere\n",
+    "reproductible — **sans jamais exposer de donnees client** :\n",
+    "\n",
+    "| Notebook | Contenu |\n",
+    "|----------|---------|\n",
+    "| `presenter-ai-engine-par-son-api` | instance, API, catalogue des chatbots, premiere completion |\n",
+    "| `configurer-chatbots-par-l-api` | lire, dupliquer, ecrire et interroger des chatbots (document JSON global) |\n",
+    "| `administrer-les-formulaires-par-l-api` | le formulaire comme contenu : CRUD, publication, rendu public |\n",
+    "| `piloter-wordpress-par-mcp` (ce notebook) | le serveur MCP : handshake, catalogue d'outils, appels reels |\n",
+    "| notebooks suivants | RAG/embeddings, multi-provider, ... |\n",
+    "\n",
+    "Trois niveaux de lecture, dans chaque notebook :\n",
+    "\n",
+    "1. **Decouverte** — ce que fait la fonctionnalite, vue par l'API ;\n",
+    "2. **Branchement** — comment on l'a branchee dans le projet ;\n",
+    "3. **Exercice** — reutiliser le pattern sur un cas voisin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2fbb7bed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:22.656373Z",
+     "iopub.status.busy": "2026-08-15T13:14:22.655849Z",
+     "iopub.status.idle": "2026-08-15T13:14:22.920413Z",
+     "shell.execute_reply": "2026-08-15T13:14:22.919299Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
+      "Base URL : http://localhost:8093\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et helpers. Aucune cle ni adresse de provider n'est stockee\n",
+    "# dans ce fichier : tout vient de instance-jetable/.env (README, etape 5).\n",
+    "\n",
+    "import base64\n",
+    "import json\n",
+    "import os\n",
+    "import re\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Localisation du .env : a cote du notebook (instance-jetable/.env),\n",
+    "# sinon dans le repertoire courant.\n",
+    "charges = []\n",
+    "for candidat in (Path(\"instance-jetable/.env\"), Path(\".env\")):\n",
+    "    if candidat.exists():\n",
+    "        load_dotenv(candidat)\n",
+    "        charges.append(str(candidat))\n",
+    "print(\"Fichiers .env charges :\", charges or \"(aucun)\")\n",
+    "\n",
+    "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
+    "ADMIN_USER = os.getenv(\"VALMONT_ADMIN_USER\", \"\")\n",
+    "APP_PASSWORD = os.getenv(\"VALMONT_APP_PASSWORD\", \"\")\n",
+    "print(\"Base URL :\", BASE_URL)\n",
+    "\n",
+    "\n",
+    "def entetes(auth=True):\n",
+    "    \"\"\"Entetes JSON-RPC ; l'authentification est un application password.\"\"\"\n",
+    "    h = {\"Content-Type\": \"application/json\",\n",
+    "         \"Accept\": \"application/json, text/event-stream\"}\n",
+    "    if auth and ADMIN_USER and APP_PASSWORD:\n",
+    "        creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
+    "        h[\"Authorization\"] = \"Basic \" + creds\n",
+    "    return h\n",
+    "\n",
+    "\n",
+    "def mcp_rpc(methode, params=None, auth=True):\n",
+    "    \"\"\"Un appel JSON-RPC au serveur MCP. Retourne (statut_http, dict|None).\n",
+    "\n",
+    "    La reponse peut venir en JSON ou en flux SSE (text/event-stream) :\n",
+    "    dans le second cas on extrait le premier bloc data:.\n",
+    "    \"\"\"\n",
+    "    corps = {\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": methode}\n",
+    "    if params is not None:\n",
+    "        corps[\"params\"] = params\n",
+    "    r = requests.post(BASE_URL + \"/wp-json/mcp/v1/http\", headers=entetes(auth),\n",
+    "                      json=corps, timeout=120)\n",
+    "    texte = r.text\n",
+    "    if \"text/event-stream\" in r.headers.get(\"content-type\", \"\"):\n",
+    "        for ligne in texte.splitlines():\n",
+    "            if ligne.startswith(\"data:\"):\n",
+    "                texte = ligne[len(\"data:\"):].strip()\n",
+    "                break\n",
+    "    try:\n",
+    "        return r.status_code, json.loads(texte)\n",
+    "    except (ValueError, TypeError):\n",
+    "        return r.status_code, None\n",
+    "\n",
+    "\n",
+    "def texte_outil(reponse):\n",
+    "    \"\"\"Extrait le texte du premier bloc de contenu d'un tools/call.\"\"\"\n",
+    "    return reponse[\"result\"][\"content\"][0][\"text\"]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57ec1a48",
+   "metadata": {},
+   "source": [
+    "## Deux faces du plugin, deux contrats\n",
+    "\n",
+    "AI Engine expose deux familles d'interfaces sur le meme WordPress :\n",
+    "\n",
+    "| | API REST `mwai/v1` (grains 1-3) | Serveur MCP `mcp/v1/http` (ce notebook) |\n",
+    "|---|---|---|\n",
+    "| Style | REST : une route par famille, GET/POST | **JSON-RPC 2.0** : une route, des methodes |\n",
+    "| Consommateur | l'**administrateur** (scripts, tableaux de bord) | un **agent** (Claude, un IDE, un client MCP) |\n",
+    "| Decouverte | catalogue de routes (`GET /mwai/v1`) | handshake puis `tools/list` |\n",
+    "| Contrat | reponse JSON ad hoc par route | reponse normalisee : `content[]`, `isError` |\n",
+    "| Authentification | application password | application password (ou OAuth, pour les clients distants) |\n",
+    "\n",
+    "Meme site, memes donnees — mais le contrat MCP est fait pour etre\n",
+    "**decouvert puis utilise par une machine** : le client annonce ses\n",
+    "capacites, le serveur repond par les siennes, et tout appel d'outil\n",
+    "passe par une signature declaree (JSON Schema), pas par une\n",
+    "documentation a lire.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9ac5a099",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:22.924609Z",
+     "iopub.status.busy": "2026-08-15T13:14:22.924074Z",
+     "iopub.status.idle": "2026-08-15T13:14:23.108009Z",
+     "shell.execute_reply": "2026-08-15T13:14:23.107496Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "statut HTTP : 200\n",
+      "serveur     : {'name': 'AI Engine - Maison Valmont', 'version': '0.0.1'}\n",
+      "version du protocole : 2025-06-18 (nous avions propose 2025-03-26)\n",
+      "session-id renvoye par le serveur : 87bfc920-f561-4bef-9...\n",
+      "notifications/initialized envoyee\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1. Le handshake : initialize\n",
+    "statut, reponse = mcp_rpc(\"initialize\", {\n",
+    "    \"protocolVersion\": \"2025-03-26\",\n",
+    "    \"capabilities\": {},\n",
+    "    \"clientInfo\": {\"name\": \"notebook-coursia\", \"version\": \"1.0\"},\n",
+    "})\n",
+    "print(\"statut HTTP :\", statut)\n",
+    "resultat = reponse[\"result\"]\n",
+    "print(\"serveur     :\", resultat[\"serverInfo\"])\n",
+    "print(\"version du protocole :\", resultat[\"protocolVersion\"], \"(nous avions propose 2025-03-26)\")\n",
+    "\n",
+    "session_id = None\n",
+    "probe = requests.post(BASE_URL + \"/wp-json/mcp/v1/http\", headers=entetes(),\n",
+    "                      json={\"jsonrpc\": \"2.0\", \"id\": 1, \"method\": \"initialize\",\n",
+    "                            \"params\": {\"protocolVersion\": \"2025-03-26\",\n",
+    "                                       \"capabilities\": {},\n",
+    "                                       \"clientInfo\": {\"name\": \"probe\", \"version\": \"1\"}}},\n",
+    "                      timeout=60)\n",
+    "session_id = probe.headers.get(\"mcp-session-id\")\n",
+    "print(\"session-id renvoye par le serveur :\", (session_id or \"aucun\")[:20] + \"...\")\n",
+    "\n",
+    "# Notification d'initialisation : pas de reponse attendue (notification JSON-RPC)\n",
+    "requests.post(BASE_URL + \"/wp-json/mcp/v1/http\", headers=entetes(),\n",
+    "              json={\"jsonrpc\": \"2.0\", \"method\": \"notifications/initialized\"}, timeout=60)\n",
+    "print(\"notifications/initialized envoyee\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43cc653f",
+   "metadata": {},
+   "source": [
+    "### Ce que dit le handshake\n",
+    "\n",
+    "Trois choses se jouent en un appel. D'abord l'**identite** : le serveur\n",
+    "se nomme — `AI Engine - Maison Valmont`, le nom du site est embarque.\n",
+    "Ensuite la **negociation de version** : le client propose\n",
+    "`2025-03-26`, le serveur repond `2025-06-18` — c'est la version qu'il\n",
+    "appliquera ; un client rigoureux se raccroche a ce que le serveur\n",
+    "renvoie, pas a ce qu'il a demande. Enfin la **session** : le serveur\n",
+    "renvoie un identifiant de session — mais les appels suivants\n",
+    "fonctionnent aussi sans le renvoyer (serveur tolerant aux clients\n",
+    "etatless, ce que ce notebook verifie en practice).\n",
+    "\n",
+    "## Le catalogue : tools/list\n",
+    "\n",
+    "Le client decouvre ensuite ce qu'il peut faire. `tools/list` renvoie\n",
+    "la liste des outils avec, pour chacun : nom, description, et le\n",
+    "**JSON Schema** de ses parametres — la signature complete, exploitable\n",
+    "par un LLM pour decider quoi appeler et comment.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0b9b9722",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:23.112347Z",
+     "iopub.status.busy": "2026-08-15T13:14:23.111825Z",
+     "iopub.status.idle": "2026-08-15T13:14:23.334406Z",
+     "shell.execute_reply": "2026-08-15T13:14:23.333378Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "statut HTTP : 200 | outils : 43\n",
+      "  mcp_ping                     params=[]\n",
+      "  wp_list_plugins              params=['search']\n",
+      "  wp_get_users                 params=['limit', 'offset', 'paged', 'role', 'search']\n",
+      "  wp_create_user               params=['display_name', 'role', 'user_email', 'user_login', 'user_pass']\n",
+      "  wp_update_user               params=['ID', 'fields']\n",
+      "  wp_get_comments              params=['author_email', 'limit', 'offset', 'paged', 'post_id', 'search', 'status', 'type', 'user_id']\n",
+      "  wp_create_comment            params=['comment_approved', 'comment_author', 'comment_author_email', 'comment_author_url', 'comment_content', 'post_id']\n",
+      "  wp_update_comment            params=['comment_ID', 'fields']\n",
+      "\n",
+      "miroir REST mcp/functions : 42 outils\n",
+      "dans tools/list mais pas dans le miroir : ['mcp_ping']\n",
+      "dans le miroir mais pas dans tools/list : aucun\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2. Le catalogue : tools/list\n",
+    "statut, reponse = mcp_rpc(\"tools/list\")\n",
+    "outils = reponse[\"result\"][\"tools\"]\n",
+    "print(\"statut HTTP :\", statut, \"| outils :\", len(outils))\n",
+    "\n",
+    "for outil in outils[:8]:\n",
+    "    params = sorted((outil.get(\"inputSchema\") or {}).get(\"properties\", {}))\n",
+    "    print(f\"  {outil['name']:28s} params={params}\")\n",
+    "\n",
+    "# Recoupement avec le miroir REST (mwai/v1/mcp/functions, vu au grain 1)\n",
+    "creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
+    "r = requests.get(BASE_URL + \"/wp-json/mwai/v1/mcp/functions\",\n",
+    "                 headers={\"Authorization\": \"Basic \" + creds}, timeout=60).json()\n",
+    "noms_rest = {f[\"name\"] for f in r[\"functions\"]}\n",
+    "noms_mcp = {o[\"name\"] for o in outils}\n",
+    "print()\n",
+    "print(\"miroir REST mcp/functions :\", r[\"count\"], \"outils\")\n",
+    "print(\"dans tools/list mais pas dans le miroir :\", sorted(noms_mcp - noms_rest))\n",
+    "print(\"dans le miroir mais pas dans tools/list :\", sorted(noms_rest - noms_mcp) or \"aucun\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b70dceb",
+   "metadata": {},
+   "source": [
+    "### Lire par MCP\n",
+    "\n",
+    "`tools/call` execute un outil par son nom, avec ses arguments. Deux\n",
+    "lectures innocentes pour commencer : compter les contenus, lister les\n",
+    "articles. La reponse arrive dans `content[0].text` — du texte (souvent\n",
+    "du JSON serialize), le format que consommera l'agent.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bc427e39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:23.338199Z",
+     "iopub.status.busy": "2026-08-15T13:14:23.337636Z",
+     "iopub.status.idle": "2026-08-15T13:14:23.453984Z",
+     "shell.execute_reply": "2026-08-15T13:14:23.453450Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "wp_count_posts -> 200\n",
+      "{\n",
+      "    \"publish\": \"1\",\n",
+      "    \"future\": 0,\n",
+      "    \"draft\": 0,\n",
+      "    \"pending\": 0,\n",
+      "    \"private\": 0,\n",
+      "    \"trash\": 0,\n",
+      "    \"auto-draft\": 0,\n",
+      "    \"inherit\": 0,\n",
+      "    \"request-pending\": 0,\n",
+      "    \"request-confirmed\": 0,\n",
+      "    \"request-failed\": 0,\n",
+      "    \"request-completed\": 0\n",
+      "}\n",
+      "\n",
+      "wp_get_posts -> 200\n",
+      "  [publish ] #1 Hello world!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 3. Lire par MCP : compter, lister\n",
+    "statut, reponse = mcp_rpc(\"tools/call\", {\"name\": \"wp_count_posts\", \"arguments\": {}})\n",
+    "print(\"wp_count_posts ->\", statut)\n",
+    "print(texte_outil(reponse))\n",
+    "\n",
+    "statut, reponse = mcp_rpc(\"tools/call\", {\"name\": \"wp_get_posts\", \"arguments\": {\"limit\": 3}})\n",
+    "print()\n",
+    "print(\"wp_get_posts ->\", statut)\n",
+    "for post in json.loads(texte_outil(reponse)):\n",
+    "    print(f\"  [{post['post_status']:8s}] #{post['ID']} {post['post_title']}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3cb2582",
+   "metadata": {},
+   "source": [
+    "## Agir par MCP : le cycle de vie d'un article\n",
+    "\n",
+    "La demonstration qui donne son sens au serveur MCP : un **client\n",
+    "externe cree un contenu**. On fait vivre a un article ephemere le\n",
+    "cycle complet par le protocole — creation (draft), lecture, puis\n",
+    "suppression. L'identifiant rendu par la creation est du texte\n",
+    "(`\"Post created ID 12\"`) : le client le parse pour chainer l'appel\n",
+    "suivant — exactement ce que ferait un agent.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "7ffac388",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:23.458768Z",
+     "iopub.status.busy": "2026-08-15T13:14:23.458246Z",
+     "iopub.status.idle": "2026-08-15T13:14:23.791349Z",
+     "shell.execute_reply": "2026-08-15T13:14:23.790830Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "creation  -> 200 | Post created ID 14\n",
+      "identifiant parse : 14\n",
+      "lecture   -> 200 | Article ephemere du notebook MCP | statut : draft\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "suppression -> 200 | Post #14 deleted\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "comptage final (draft) : 0 - l'article ephemere a bien disparu\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4. Agir par MCP : creer, lire, supprimer un article epheme\n",
+    "statut, rep_create = mcp_rpc(\"tools/call\", {\"name\": \"wp_create_post\", \"arguments\": {\n",
+    "    \"post_title\": \"Article ephemere du notebook MCP\",\n",
+    "    \"post_content\": \"Cree par tools/call, supprime trois appels plus tard.\",\n",
+    "    \"post_status\": \"draft\",\n",
+    "}})\n",
+    "message = texte_outil(rep_create)\n",
+    "print(\"creation  ->\", statut, \"|\", message)\n",
+    "article_id = int(re.search(r\"ID (\\d+)\", message).group(1))\n",
+    "print(\"identifiant parse :\", article_id)\n",
+    "\n",
+    "statut, rep_get = mcp_rpc(\"tools/call\", {\"name\": \"wp_get_post\", \"arguments\": {\"ID\": article_id}})\n",
+    "post = json.loads(texte_outil(rep_get))\n",
+    "print(\"lecture   ->\", statut, \"|\", post[\"post_title\"], \"| statut :\", post[\"post_status\"])\n",
+    "\n",
+    "statut, rep_del = mcp_rpc(\"tools/call\", {\"name\": \"wp_delete_post\", \"arguments\": {\"ID\": article_id}})\n",
+    "print(\"suppression ->\", statut, \"|\", texte_outil(rep_del))\n",
+    "\n",
+    "# Etat final : le brouillon n'existe plus\n",
+    "statut, reponse = mcp_rpc(\"tools/call\", {\"name\": \"wp_count_posts\", \"arguments\": {}})\n",
+    "comptes = json.loads(texte_outil(reponse))\n",
+    "print(\"comptage final (draft) :\", comptes[\"draft\"], \"- l'article ephemere a bien disparu\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ca889e8",
+   "metadata": {},
+   "source": [
+    "## La frontiere de securite, mesuree\n",
+    "\n",
+    "Sans le header d'autorisation, il ne reste rien : la mesure le dit —\n",
+    "`initialize`, `tools/list` et `tools/call` refusent **tous** (`401\n",
+    "rest_forbidden`). La frontiere est devant la porte, pas derriere :\n",
+    "meme se presenter au serveur exige des credentials. La granularite\n",
+    "fine est declaree dans le catalogue (`accessLevel` : read / write /\n",
+    "admin) et arbitree par WordPress selon le compte — l'app password\n",
+    "admin ouvre tout ; un compte moindre verrait les niveaux filtres.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b9f1798a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:23.795088Z",
+     "iopub.status.busy": "2026-08-15T13:14:23.794535Z",
+     "iopub.status.idle": "2026-08-15T13:14:23.953204Z",
+     "shell.execute_reply": "2026-08-15T13:14:23.952222Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tools/list sans auth  -> 401 | rest_forbidden\n",
+      "tools/call sans auth  -> 401 | rest_forbidden\n",
+      "initialize sans auth  -> 401 | reponse du serveur : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5. Sans authentification : la frontiere\n",
+    "statut, reponse = mcp_rpc(\"tools/list\", auth=False)\n",
+    "print(\"tools/list sans auth  ->\", statut, \"|\", (reponse or {}).get(\"code\"))\n",
+    "\n",
+    "statut, reponse = mcp_rpc(\"tools/call\", {\"name\": \"wp_count_posts\", \"arguments\": {}}, auth=False)\n",
+    "print(\"tools/call sans auth  ->\", statut, \"|\", (reponse or {}).get(\"code\"))\n",
+    "\n",
+    "statut, reponse = mcp_rpc(\"initialize\", {\"protocolVersion\": \"2025-03-26\",\n",
+    "                                         \"capabilities\": {},\n",
+    "                                         \"clientInfo\": {\"name\": \"anonyme\", \"version\": \"1\"}},\n",
+    "                          auth=False)\n",
+    "print(\"initialize sans auth  ->\", statut, \"| reponse du serveur :\",\n",
+    "      (reponse or {}).get(\"result\", {}).get(\"serverInfo\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f8d4031",
+   "metadata": {},
+   "source": [
+    "## Ce qu'on en a fait dans le projet Livres Agites\n",
+    "\n",
+    "Dans le projet d'origine (AI Engine Pro + plugin custom), le serveur\n",
+    "MCP est la colonne vertebrale de l'agentique : **88 outils exposes** —\n",
+    "64 generiques (WordPress, WooCommerce, SQL, SEO) et **24 outils\n",
+    "metier** ecrits sur mesure (manuscrits, comite de lecture, pipeline\n",
+    "editorial). La lecon d'architecture du Parcours 3\n",
+    "(`livresagites-parcours.md`) : *un serveur MCP utile expose les verbes\n",
+    "du metier, pas les tables de la base*. Ce notebook la montre en\n",
+    "negatif : sur la version gratuite, les 43 outils sont tous generiques\n",
+    "(`wp_*`) — la maison d'edition n'y apparait nulle part. Les verbes\n",
+    "metier, eux, s'ajoutent par le code du plugin, et deviennent aussitot\n",
+    "consommables par le meme protocole.\n",
+    "\n",
+    "Deux compagnons stdlib prolongent ce notebook :\n",
+    "[`auditer-un-serveur-mcp.ipynb`](auditer-un-serveur-mcp.ipynb)\n",
+    "(classer CRUD generique vs verbes metier d'un catalogue) et\n",
+    "[`consommer-vs-exposer-le-mcp.ipynb`](consommer-vs-exposer-le-mcp.ipynb)\n",
+    "(les deux sens du fil MCP et le risque de double-ecrit).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00978e94",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices, du plus simple au plus integre. Les fonctions sont a\n",
+    "completer ; `mcp_rpc()` et `texte_outil()` sont disponibles. Chaque\n",
+    "exercice se verifie d'une ligne de test.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99ab2d94",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — un appel d'outil generique\n",
+    "\n",
+    "Completez `appeler_outil(nom, arguments)` : elle execute `tools/call`\n",
+    "et retourne le **texte** du resultat (sans lever d'exception si\n",
+    "l'appel echoue — retourner `None`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "855ac2fb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:23.958227Z",
+     "iopub.status.busy": "2026-08-15T13:14:23.957697Z",
+     "iopub.status.idle": "2026-08-15T13:14:23.962840Z",
+     "shell.execute_reply": "2026-08-15T13:14:23.962325Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def appeler_outil(nom, arguments=None):\n",
+    "    \"\"\"Execute tools/call ; retourne le texte du resultat, None si echec.\"\"\"\n",
+    "    # A COMPLETER : mcp_rpc + texte_outil, avec garde d'echec\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a58f4cb",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — l'histogramme des niveaux d'acces\n",
+    "\n",
+    "Completez `compter_par_acces()` : elle retourne un dict\n",
+    "`{niveau: nombre}` des `accessLevel` des outils. Indice : les\n",
+    "annotations MCP (`tools/list`) portent `readOnlyHint`, pas le niveau\n",
+    "d'acces — celui-ci vit dans le **miroir REST** `mwai/v1/mcp/functions`\n",
+    "(vu plus haut). L'exercice croise donc les deux faces du plugin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b9eff042",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:23.969330Z",
+     "iopub.status.busy": "2026-08-15T13:14:23.968804Z",
+     "iopub.status.idle": "2026-08-15T13:14:23.974742Z",
+     "shell.execute_reply": "2026-08-15T13:14:23.974209Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def compter_par_acces():\n",
+    "    \"\"\"Retourne {niveau_acces: nombre_d_outils} depuis tools/list.\"\"\"\n",
+    "    # A COMPLETER : tools/list par MCP, extraire accessLevel par outil, compter\n",
+    "    return {}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b90240",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — un cycle de vie complet\n",
+    "\n",
+    "Completez `cycle_vie_article(titre)` : elle cree un brouillon par MCP,\n",
+    "verifie sa lecture, le supprime, et retourne `True` seulement si les\n",
+    "trois etapes ont reussi et le comptage final des drafts n'a pas bouge.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "2eb67dfb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T13:14:23.978824Z",
+     "iopub.status.busy": "2026-08-15T13:14:23.977817Z",
+     "iopub.status.idle": "2026-08-15T13:14:23.982870Z",
+     "shell.execute_reply": "2026-08-15T13:14:23.982361Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def cycle_vie_article(titre):\n",
+    "    \"\"\"Create-read-delete d'un article par MCP ; True si le cycle est propre.\"\"\"\n",
+    "    # A COMPLETER : wp_count_posts avant, wp_create_post, wp_get_post, wp_delete_post,\n",
+    "    # wp_count_posts apres (draft inchange)\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0fdb505",
+   "metadata": {},
+   "source": [
+    "## Provenance et limites\n",
+    "\n",
+    "- **Instance testee** : `http://localhost:8093`, montee via\n",
+    "  `instance-jetable/docker-compose.jetable.example.yml`, AI Engine 3.7.0\n",
+    "  (version gratuite, wordpress.org), corpus synthetique « Maison Valmont ».\n",
+    "- **Determinisme** : aucune completion LLM — tous les appels sont au\n",
+    "  serveur MCP (lecture, ecriture d'un article ephemere cree puis\n",
+    "  supprime ; l'etat final est verifie). Les identifiants d'articles\n",
+    "  varies d'une execution a l'autre, le deroule est stable. Note :\n",
+    "  `wp_delete_post` envoie l'article **a la corbeille** (comportement\n",
+    "  WordPress par defaut), pas en suppression definitive — le comptage\n",
+    "  final porte sur les drafts, la corbeille reste a vider par\n",
+    "  l'administrateur.\n",
+    "- **Endpoints verifies ici (firsthand)** : `POST /wp-json/mcp/v1/http`\n",
+    "  (initialize, notifications/initialized, tools/list, tools/call x6),\n",
+    "  `GET /wp-json/mwai/v1/mcp/functions`.\n",
+    "- **Version du protocole** : le serveur a repondu `2025-06-18` a une\n",
+    "  proposition `2025-03-26` (negociation) ; le format de reponse est\n",
+    "  reste JSON (pas de flux SSE sur cette instance).\n",
+    "- **Frontieres** : pas de donnees client, pas de secret, pas d'IP de\n",
+    "  provider — regles du chantier CoursIA.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #11008

**Quoi:** 4e notebook de la série « AI Engine par son API » (grains 1-3 mergés : #10917, #10951, #11008) : `piloter-wordpress-par-mcp.ipynb`. Le sondage a révélé un **second endpoint dans un namespace séparé** : `/wp-json/mcp/v1/http` — le protocole MCP (JSON-RPC 2.0), distinct de l'API REST admin `mwai/v1` des grains 1-3. Le consommateur change : pas l'administrateur, un **agent** (Claude, un IDE, le client du notebook). Le protocole complet est démontré sur l'instance jetable : **handshake** `initialize` (serverInfo « AI Engine - Maison Valmont », **négociation de version réelle** — on propose 2025-03-26, le serveur répond 2025-06-18 — header `mcp-session-id`) ; **catalogue** `tools/list` (43 outils à JSON Schema, recoupé avec le miroir REST `mcp/functions` : 42 + `mcp_ping`) ; **lecture** `tools/call` (`wp_count_posts`, `wp_get_posts`) ; **écriture** `tools/call` (cycle create/read/delete d'un article éphémère, parsing de l'identifiant rendu en texte — ce que ferait un agent) ; **frontière d'authentification mesurée** : sans credentials, `initialize`, `tools/list` et `tools/call` refusent tous (`401 rest_forbidden`). La leçon du Parcours 3 se lit en négatif : les 43 outils gratuits sont tous génériques `wp_*` — les 24 verbes métier du projet client viennent du plugin custom, consommables par le même protocole.

**Preuve:** Exécuté avec le kernel `coursia-sae`, 22 cellules dont 9 code, 0 erreur, toutes `execution_count` renseignés. HEAD testé `54d37dc98`. Sorties réelles contre l'instance jetable (UP vérifiée : HTTP 200, conteneurs `valmont-*`) : serverInfo + version 2025-06-18 + session-id (tronqué à l'affichage), 43 outils listés (8 signatures visibles), diff de catalogue `['mcp_ping']` / aucun, lectures 200, cycle « Post created ID 12 » → lecture → « Post #12 deleted » → comptage final draft 0, trois 401 sans auth. Notebook **déterministe** (aucun LLM). Corbeille de l'instance purgée après exécution (posts de test force-deleted). 3 exercices à stubs (`appeler_outil`, `compter_par_acces` — croise les deux faces du plugin, `cycle_vie_article`). Gates locaux au commit : gitleaks, H.3, papermill-path-scrub, markdown-defects — Passed. Scan : 0 cyrillique/grec, 0 emoji, 0 secret, 0 terme client, 0 accent, LF.

**Périmètre:** 1 notebook nouveau + paragraphe série étendu + 1 entrée « Voir aussi » dans `README.md` + bloc compagnon (Parcours 3, face protocole) dans `livresagites-parcours.md`. Genre `MED/notebook-python`, domaine-cœur (série présentation AI Engine, mandat user 14 août). Frontière sécurité tenue : instance jetable dédiée, corpus 100 % synthétique, credentials `.env` gitignored (vérifié), sorties de l'exécution réelle. Honnêteté éditoriale : un markdown affirmait « le handshake répond sans auth » — l'exécution réelle a démenti (401 aussi sur initialize), le texte a été corrigé pour dire ce que les sorties montrent.

**Transparence G-VAR-3 :** 9e `MED/notebook-python` consécutif de la lane (#10495 → ... → #10917 → #10951 → #11008 mergés, celui-ci). Substance distincte : nouveau **namespace** (`mcp/v1`), nouveau **protocole** (JSON-RPC vs REST), consommateur différent (agent vs administrateur), écriture par `tools/call` (vs read-modify-write de liste ou CRUD unitaire). Litmus LIGHT négatif : le handshake avec négociation de version et le cycle tools/call ne sont pas générables en scannant un livrable voisin. Si le coordinateur préfère casser la série, je prends un grain de remplacement (`docs` ou `guard`).

Closes #11050