### PR TITLE
fix(qc,#11044): renuméroter section Exercices 8 → 7 (SECTION_ORDER research_composite_ff_aw)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/research/research_composite_ff_aw.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/research/research_composite_ff_aw.ipynb
@@ -1462,7 +1462,7 @@
     "tags": []
    },
    "source": [
-    "## 8. Exercices d'extension\n",
+    "## 7. Exercices d'extension\n",
     "\n",
     "Les exercices ci-dessous explorent deux **choix de design** du notebook : (a) l'allocation\n",
     "AllWeather est *statique* (30/30/30/10 fixe) ; (b) la validation walk-forward est *naive*\n",


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2026:CoursIA — prev: DEEP/lean #11048

See #11044 (mini-fix 3 des 7 défauts ouverts du balayage — contribution partielle)

# Renuméroter la section Exercices 8 → 7 — research_composite_ff_aw

Défaut ouvert #4233 du triage chunks 1-4 (issuecomment-5302376600) : la PR #4233 avait été mergée avec son blocker CI-hard non corrigé — le gate `No cell-ordering regression` flaggait un saut de numérotation backward (`…, 6, 8, 7` attendu vs `…, 6, 8` livré).

## What

`research_composite_ff_aw.ipynb` : la section `## 8. Exercices d'extension` devient `## 7. Exercices d'extension`. Elle suit directement `## 6. Visualisation` — aucun `## 7` n'existait (vérifié : `grep -c '"## 7'` = 0 avant le fix, aucune collision après).

## Proof

- 1 ligne changée, **cellule markdown** (cell 17, `cell_type: markdown` vérifié par parsing) → exception C.2 markdown-only, outputs précédents valides.
- JSON validé post-édition.
- H.3 pre-commit : Passed.
- Numérotation résultante : `## 1..7` séquentielle sans saut (l.107/409/598/788/1192/1335/1465).

## Scope

1 sujet = 1 défaut du triage #11044. 1 fichier, 1 ligne. Catalogue byte-identique à main.
