### PR TITLE
fix(qc,#11044): ordre LEAN Algorithm Framework — Risk Management avant Execution (mermaid + prose)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/README.md
@@ -109,21 +109,21 @@ Gestion du risque professionnelle, types d'ordres avancés, analyse approfondie 
 
 ### Phase 4 : Algorithm Framework (3 notebooks, ~4h)
 
-Architecture modulaire QuantConnect pour stratégies scalables (Alpha, Portfolio Construction, Execution, Risk).
+Architecture modulaire QuantConnect pour stratégies scalables (Alpha, Portfolio Construction, Risk Management, Execution).
 
 ```mermaid
 flowchart LR
     U["Universe Selection<br/>quels actifs ?"] --> A["Alpha Model<br/>quels signaux ?"]
     A --> PC["Portfolio Construction<br/>quelles tailles ?"]
-    PC --> E["Execution<br/>quels ordres ?"]
-    E --> R["Risk Management<br/>quels filtres ?"]
-    R -. "ajustement temps reel" .-> U
+    PC --> RM["Risk Management<br/>quels filtres ?"]
+    RM --> E["Execution<br/>quels ordres ?"]
+    RM -. "ajustement temps reel" .-> U
     style A fill:#e1f5ff
     style PC fill:#e8f5e9
-    style R fill:#fff3e0
+    style RM fill:#fff3e0
 ```
 
-Le flux de données traverse cinq modules Découplables : l'**Universe** sélectionne les actifs, l'**Alpha** produit les signaux directionnels, la **Portfolio Construction** transforme les signaux en tailles cibles, l'**Execution** route les ordres, et le **Risk Management** filtre/ajuste en continu. Chaque module est remplaçable indépendamment — c'est ce qui permet de composer une stratégie complexe sans réécrire l'ensemble.
+Le flux de données traverse cinq modules Découplables : l'**Universe** sélectionne les actifs, l'**Alpha** produit les signaux directionnels, la **Portfolio Construction** transforme les signaux en tailles cibles, le **Risk Management** filtre/ajuste ces cibles en continu, et l'**Execution** route les ordres. Chaque module est remplaçable indépendamment — c'est ce qui permet de composer une stratégie complexe sans réécrire l'ensemble.
 
 | # | Notebook | Durée | Contenu |
 |---|----------|-------|---------|
@@ -463,7 +463,7 @@ Après completion de cette série, vous maîtriserez :
 
 - ✅ **QuantConnect LEAN** : Architecture, lifecycle, Universe sélection
 - ✅ **Risk Management** : Position sizing, stop-loss, take-profit
-- ✅ **Algorithm Framework** : Alpha, Portfolio Construction, Execution, Risk
+- ✅ **Algorithm Framework** : Alpha, Portfolio Construction, Risk Management, Execution
 - ✅ **Machine Learning** : Supervised (RF, XGBoost), Deep Learning (LSTM), RL (PPO)
 - ✅ **LLM Integration** : Prompt engineering, LLM-augmented signals
 - ✅ **Production Deployment** : Paper trading, live trading, monitoring


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2026:CoursIA — prev: LIGHT/docs #11053

See #11044 (mini-fix 4 des 7 défauts ouverts du balayage — contribution partielle)

# Ordre LEAN Algorithm Framework : Risk Management avant Execution

Défaut ouvert #4379 du triage (issuecomment-5302219870) : la question user sur l'ordre du mermaid n'avait jamais été traitée — le README Phase 4 montrait `Alpha → Portfolio Construction → Execution → Risk Management`, or l'architecture officielle LEAN place le **Risk Management en filtrage des portfolio targets AVANT l'Execution**.

## What

`MyIA.AI.Notebooks/QuantConnect/README.md` — 4 sites corrigés (audit fichier entier fait : grep de toutes les mentions de l'ordre des modules) :

1. **Mermaid Phase 4** (l.113-120) : `PC → E → R` devient `PC → RM → E` ; la flèche dashed « ajustement temps reel » reste portée par le Risk Management (sémantique inchangée) ; `style R` renommé `style RM`.
2. **Prose l.110** : « (Alpha, Portfolio Construction, Execution, Risk) » → « (Alpha, Portfolio Construction, Risk Management, Execution) ».
3. **Prose flux l.124** : le récit décrit maintenant « Portfolio Construction transforme les signaux en tailles cibles, **le Risk Management filtre/ajuste ces cibles en continu**, et l'Execution route les ordres » — ordre du pipeline réel.
4. **Skills l.464** : « Alpha, Portfolio Construction, Execution, Risk » → ordre corrigé.

Site vérifié sans changement : l.584 (« Alpha + Portfolio Construction + Risk Management » — déjà correct, Execution non mentionné).

## Proof

- Docs-only (markdown), 7 lignes changées dans 1 fichier — pas de re-exec requise.
- §E audit fichier entier : tous les sites mentionnant l'ordre des 4 modules ont été énumérés par grep (`Alpha, Portfolio|Portfolio Construction, Execution|Execution, Risk|Risk Management`) — 5 sites trouvés, 4 corrigés + 1 déjà correct. Catalogue byte-identique à main.

## Scope

1 sujet = 1 défaut du triage #11044 (architecture LEAN erronée dans le README QC).



---

**Re-qualification coordinateur (ai-01)** : `LIGHT/docs` → **`LIGHT/readme`**. Le signal advisory `variation-genre-mismatch` vise juste — ce grain édite un `README.md`, quand #11053 éditait une cellule markdown de `.ipynb`. `readme` et `docs` sont deux entrées distinctes de l'énumération close, donc G-VAR-3 (« pas deux fois le même GENRE LIGHT consécutif ») n'est pas déclenché. Budget G-VAR-2 : 3ᵉ LIGHT d'un plafond de 4 (14 grains mergés aujourd'hui sur cette lane) — dans le budget, mesuré et non estimé.

Je le dis sans me cacher derrière la re-qualification : **l'adjacence est mince**. Deux correctifs de prose consécutifs, c'est le motif que G-VAR-3 surveille, et si la lane n'avait livré que ça aujourd'hui je tiendrais. Elle a livré `DEEP/lean` (#11048) et `MED/notebook-genai` (#11046) — le plancher G-VAR-1 du cycle est tenu par du contenu, pas par ces mini-fix. Et ces mini-fix sont le burn-down des 7 défauts ouverts du balayage #11044, c'est-à-dire **mon propre dispatch** : bloquer le 4ᵉ sur une technicité d'adjacence reviendrait à sanctionner la lane pour avoir fait exactement ce que je lui ai demandé.

Attendu pour la suite de cette lane : le prochain grain est de **contenu** (classe CONTENU de §1), pas un 3ᵉ correctif de prose.