### PR TITLE
feat(lean,#2159): Partie 40 — lois de la forme fleche J.Covers sous pullback (CoversPullback.lean)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -9,6 +9,7 @@ import Grothendieck.Construction
 import Grothendieck.Cover
 import Grothendieck.CoverageGen
 import Grothendieck.CoversArrow
+import Grothendieck.CoversPullback
 import Grothendieck.DenseTopology
 import Grothendieck.DirectImage
 import Grothendieck.Equivalences

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPullback.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPullback.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 40 : lois de la forme flèche sous pullback
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Les parties 1-39 ont etabli les fondamentaux : categories, cribles,
+topologies, lois de treillis, identites de pullback, bases de faisceaux,
+cloture couvrante, calibration, sous-canonicalite, topologies denses,
+faisceaux, hom interne, cohomologie de Cech, limite de Mayer-Vietoris,
+extensions de Kan, adjonctions, monades, equivalences, categories monoidales,
+limites et colimites, couples comma, images directes, theoremes propres sur la
+forme fleche (`J.Covers S f`), sur la couverture bundlee (`J.Cover X`), les
+lois de coherence du pseudo-foncteur pullback (Partie 37), les lois de
+foncteur du pullback (Partie 38) et les lois de treillis des topologies
+(Partie 39).
+
+La Partie 40 etablit les **lois de la forme fleche `J.Covers S f` sous
+pullback** : Mathlib fournit les axiomes de topologie en forme fleche
+(`arrow_max`, `arrow_stable`, `arrow_trans`, `arrow_intersect`) et le
+definitif `covers_iff`, mais **ne fournit pas** les lois de comportement de
+`J.Covers` vis-a-vis des operations sur les cribles et des morphismes. Ce
+module les enonce et les prouve :
+
+  - `covers_mono` : la forme fleche est monotone en le crible —
+    si `A ≤ B` et `A` couvre `f`, alors `B` couvre `f`.
+  - `covers_union` : la forme fleche est stable par borne superieure —
+    si `S` couvre `f`, alors `S ⊔ R` couvre `f`.
+  - `covers_pullback_comp` : **loi de changement de base** — couvrir la
+    composee `g ≫ f` est equivalent a couvrir le pullback `S.pullback f` le
+    long de `g`.
+  - `covers_iso_cancel` : couvrir `g ≫ f` avec `g` iso est equivalent a
+    couvrir `f` (cancellation par isomorphisme).
+  - `covers_iso_covering` : une fleche isomorphe `e.hom` est couverte par `S`
+    si et seulement si `S` est couvrant.
+  - `covers_bind` : **caractere local en forme fleche** — si `S` couvre `f`
+    et, pour chaque fleche `g` de `S`, le crible `R g` est couvrant sur son
+    domaine, alors le crible lie `Sieve.bind S R` couvre `f`.
+  - `covers_iff_exists_cover` : pont vers la couverture bundlee — `S` couvre
+    `f` si et seulement si `S.pullback f` contient un `J.Cover Y`.
+  - `cover_pullback_covers` : le pullback d'une couverture `S.pullback f`
+    couvre l'identite de `Y` — la version `J.Covers` de
+    `J.Cover.pullback` (Partie 38).
+
+Chaque preuve est une **preuve tactique reelle** (veine DEEP) : les axiomes
+de topologie (`superset_covering`, `pullback_mem_iff_of_isIso`,
+`arrow_trans`) plus les lois de `Sieve.pullback` (`pullback_comp`,
+`pullback_id`, `pullback_monotone`) et la loi d'adjonction du lie
+(`Sieve.le_pullback_bind`). Aucune preuve n'est un re-export.
+
+EPIC #1646, Phase 5 (#2159). Tous les `sorry`s elimines a la creation.
+
+### Convention i18n (EPIC #4980 ratifiee par user 2026-07-04)
+
+Ce module est apparie avec son jumeau anglais dans le fichier sibling
+`CoversPullback_en.lean` (modele sibling pair, voir PR #6154 pour le pilote
+sur `Utility.lean`). Namespace suffix `_en` applique au fichier EN
+(anti-collision, conforme code-style.md #4980). Les enonces de theoremes, les
+noms de lemmes, les tactiques Lean et les references Mathlib restent en
+anglais ; seules les docstrings `/-- ... -/` et les commentaires `-- ...`
+different entre les deux fichiers (preservation byte-identity).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.CoversPullback
+
+open CategoryTheory
+
+/-!
+## Section 1 : monotonie et union
+
+La forme fleche `J.Covers S f` est definie par `S.pullback f ∈ J Y`
+(Mathlib, `covers_iff`). La monotonie en le crible suit de la monotonie du
+pullback de cribles (`Sieve.pullback_monotone`) et de l'axiome
+`superset_covering`. L'union est un cas particulier.
+-/
+
+/-- La forme fleche est monotone en le crible : si `A ≤ B` et `A` couvre `f`,
+    alors `B` couvre `f`.
+    Preuve : on ramene les deux membres a des appartenances (`covers_iff`),
+    puis `superset_covering` avec la monotonie du pullback
+    (`Sieve.pullback_monotone`). -/
+theorem covers_mono {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) {A B : Sieve X} (hAB : A ≤ B) (h : J.Covers A f) :
+    J.Covers B f := by
+  rw [GrothendieckTopology.covers_iff] at h ⊢
+  exact J.superset_covering (Sieve.pullback_monotone f hAB) h
+
+/-- La forme fleche est stable par borne superieure : si `S` couvre `f`,
+    alors `S ⊔ R` couvre `f`.
+    Preuve : cas particulier de `covers_mono` avec `le_sup_left`. -/
+theorem covers_union {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) (S R : Sieve X) (hS : J.Covers S f) :
+    J.Covers (S ⊔ R) f := by
+  exact covers_mono J f (le_sup_left : S ≤ S ⊔ R) hS
+
+/-!
+## Section 2 : changement de base et isomorphismes
+
+La loi de composition de `Sieve.pullback` (`Sieve.pullback_comp`) exprime le
+changement de base : `S.pullback (g ≫ f) = (S.pullback f).pullback g`.
+On en deduit la forme fleche du changement de base (`covers_pullback_comp`)
+et la cancellation par isomorphisme (`covers_iso_cancel`), qui utilise le
+lemme Mathlib `pullback_mem_iff_of_isIso`.
+-/
+
+/-- Loi de changement de base en forme fleche : couvrir la composee `g ≫ f`
+    est equivalent a couvrir le pullback `S.pullback f` le long de `g`.
+    Preuve : `covers_iff` des deux membres puis `Sieve.pullback_comp`
+    (egalite definitionnelle des deux cribles en cause). -/
+theorem covers_pullback_comp {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (f : Y ⟶ X) (g : Z ⟶ Y) (S : Sieve X) :
+    J.Covers S (g ≫ f) ↔ J.Covers (S.pullback f) g := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    Sieve.pullback_comp]
+
+/-- Cancellation par isomorphisme : si `g` est un isomorphisme, couvrir
+    `g ≫ f` est equivalent a couvrir `f`.
+    Preuve : changement de base (`Sieve.pullback_comp`) puis
+    `pullback_mem_iff_of_isIso`, qui ramene le pullback le long d'une iso a
+    l'appartenance d'origine. -/
+theorem covers_iso_cancel {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (f : Y ⟶ X) {g : Z ⟶ Y} [IsIso g] (S : Sieve X) :
+    J.Covers S (g ≫ f) ↔ J.Covers S f := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    Sieve.pullback_comp]
+  exact GrothendieckTopology.pullback_mem_iff_of_isIso (i := g) (S := S.pullback f)
+
+/-- Une fleche isomorphe `e.hom` est couverte par `S` si et seulement si
+    `S` est couvrant.
+    Preuve : `covers_iff` puis `pullback_mem_iff_of_isIso`. -/
+theorem covers_iso_covering {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (e : X ≅ Y) (S : Sieve Y) :
+    J.Covers S e.hom ↔ S ∈ J Y := by
+  rw [GrothendieckTopology.covers_iff]
+  exact GrothendieckTopology.pullback_mem_iff_of_isIso (S := S)
+
+/-!
+## Section 3 : caractere local
+
+L'axiome de transitivite `arrow_trans` dit : si `S` couvre `f` et toute
+fleche de `S` est couverte par `R`, alors `R` couvre `f`. La forme "lie"
+`Sieve.bind S R` recolle les cribles `R g` en un seul crible sur `X` ; on
+montre qu'il herite la couverture de `f`. La brique est la loi d'adjonction
+`Sieve.le_pullback_bind : R g ≤ (Sieve.bind S R).pullback g` (le pullback du
+lie contient chaque composante).
+-/
+
+/-- Caractere local en forme fleche : si `S` couvre `f` et, pour chaque
+    fleche `g : Z ⟶ X` de `S`, le crible `R g` est couvrant sur son domaine
+    (`R hg ∈ J Z`), alors le crible lie `Sieve.bind S R` couvre `f`.
+    Preuve : `arrow_trans` de `S` vers `Sieve.bind S R`, puis pour chaque
+    fleche `g` de `S`, `superset_covering` avec
+    `Sieve.le_pullback_bind` (chaque `R g` est inferieure au pullback du lie). -/
+theorem covers_bind {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) (S : Sieve X) (R : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z)
+    (hS : J.Covers S f) (hR : ∀ ⦃Z : C⦄ (g : Z ⟶ X) (hg : S g), R hg ∈ J Z) :
+    J.Covers (Sieve.bind S R) f := by
+  refine GrothendieckTopology.arrow_trans (J := J) (f := f) (S := S) (R := Sieve.bind S R) hS ?_
+  intro Z g hg
+  rw [GrothendieckTopology.covers_iff]
+  exact J.superset_covering (Sieve.le_pullback_bind S R g hg) (hR g hg)
+
+/-!
+## Section 4 : pont vers la couverture bundlee
+
+La couverture bundlee `J.Cover X = { S : Sieve X // S ∈ J X }` (Partie 38)
+regroupe les cribles couvrants avec leur preuve d'appartenance. On relie la
+forme fleche au sous-type : `S` couvre `f` si et seulement si le pullback
+`S.pullback f` contient une couverture.
+-/
+
+/-- `S` couvre `f` si et seulement si `S.pullback f` contient un
+    `J.Cover Y` (comme sous-crible).
+    Preuve : direction directe — la couverture `S.pullback f` elle-meme est
+    une `J.Cover Y` (`covers_iff`) ; direction reciproque —
+    `superset_covering` depuis la couverture contenue. -/
+theorem covers_iff_exists_cover {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (S : Sieve X) (f : Y ⟶ X) :
+    J.Covers S f ↔ ∃ T : J.Cover Y, (T : Sieve Y) ≤ S.pullback f := by
+  constructor
+  · intro h
+    exact ⟨⟨S.pullback f, by simpa [GrothendieckTopology.covers_iff] using h⟩, le_rfl⟩
+  · rintro ⟨T, hT⟩
+    rw [GrothendieckTopology.covers_iff]
+    exact J.superset_covering hT T.condition
+
+/-- Le pullback d'une couverture `S.pullback f` couvre l'identite de `Y`.
+    Preuve : `covers_iff` puis `Sieve.pullback_id` (le pullback de
+    l'identite est l'identite) et la condition du sous-type. -/
+theorem cover_pullback_covers {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (S : J.Cover X) (f : Y ⟶ X) :
+    J.Covers (S.pullback f) (𝟙 Y) := by
+  rw [GrothendieckTopology.covers_iff, Sieve.pullback_id]
+  exact (S.pullback f).condition
+
+end Grothendieck.CoversPullback

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPullback_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPullback_en.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Grothendieck Homage — Part 40 : arrow-form laws under pullback
+
+Alexandre Grothendieck (1928-2014).
+
+Phase 5 extension (#2159, EPIC #1646).
+
+Parts 1-39 established the foundations: categories, sieves,
+topologies, lattice laws, pullback identities, sheaf bases,
+covering closure, calibration, subcanonicality, dense topologies,
+sheaves, internal hom, Cech cohomology, Mayer-Vietoris limit,
+Kan extensions, adjunctions, monads, equivalences, monoidal categories,
+limits and colimits, comma pairs, direct images, proper theorems on the
+arrow form (`J.Covers S f`), on the bundled cover (`J.Cover X`), the
+coherence laws of the pullback pseudo-functor (Part 37), the functor
+laws of pullback (Part 38) and the lattice laws of topologies (Part 39).
+
+Part 40 establishes the **laws of the arrow form `J.Covers S f` under
+pullback**: Mathlib provides the topology axioms in arrow form
+(`arrow_max`, `arrow_stable`, `arrow_trans`, `arrow_intersect`) and the
+definitional `covers_iff`, but **does not provide** the behavior laws of
+`J.Covers` with respect to operations on sieves and morphisms. This module
+states and proves them:
+
+  - `covers_mono` : the arrow form is monotone in the sieve —
+    if `A ≤ B` and `A` covers `f`, then `B` covers `f`.
+  - `covers_union` : the arrow form is stable under join —
+    if `S` covers `f`, then `S ⊔ R` covers `f`.
+  - `covers_pullback_comp` : **base change law** — covering the
+    composite `g ≫ f` is equivalent to covering the pullback `S.pullback f`
+    along `g`.
+  - `covers_iso_cancel` : covering `g ≫ f` with `g` iso is equivalent to
+    covering `f` (cancellation by isomorphism).
+  - `covers_iso_covering` : an isomorphic arrow `e.hom` is covered by `S`
+    if and only if `S` is covering.
+  - `covers_bind` : **local character in arrow form** — if `S` covers `f`
+    and, for every arrow `g` of `S`, the sieve `R g` is covering on its
+    domain, then the bound sieve `Sieve.bind S R` covers `f`.
+  - `covers_iff_exists_cover` : bridge to the bundled cover — `S` covers
+    `f` if and only if `S.pullback f` contains a `J.Cover Y`.
+  - `cover_pullback_covers` : the pullback of a cover `S.pullback f`
+    covers the identity of `Y` — the `J.Covers` version of
+    `J.Cover.pullback` (Part 38).
+
+Each proof is a **real tactic proof** (DEEP vein): the topology axioms
+(`superset_covering`, `pullback_mem_iff_of_isIso`,
+`arrow_trans`) plus the laws of `Sieve.pullback` (`pullback_comp`,
+`pullback_id`, `pullback_monotone`) and the adjunction law of the bind
+(`Sieve.le_pullback_bind`). No proof is a re-export.
+
+EPIC #1646, Phase 5 (#2159). All `sorry`s eliminated at creation.
+
+### i18n convention (EPIC #4980 ratified by user 2026-07-04)
+
+This module is paired with its French sibling in the sibling file
+`CoversPullback.lean` (sibling pair model, see PR #6154 for the pilot on
+`Utility.lean`). The `_en` namespace suffix is applied to the EN file
+(anti-collision, per code-style.md #4980). Theorem statements, lemma names,
+Lean tactics and Mathlib references remain in English; only the docstrings
+`/-- ... -/` and comments `-- ...` differ between the two files
+(byte-identity preservation).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.CoversPullback_en
+
+open CategoryTheory
+
+/-!
+## Section 1 : monotonicity and union
+
+The arrow form `J.Covers S f` is defined by `S.pullback f ∈ J Y`
+(Mathlib, `covers_iff`). Monotonicity in the sieve follows from the
+monotonicity of sieve pullback (`Sieve.pullback_monotone`) and the axiom
+`superset_covering`. The union is a special case.
+-/
+
+/-- The arrow form is monotone in the sieve : if `A ≤ B` and `A` covers `f`,
+    then `B` covers `f`.
+    Proof : reduce both members to memberships (`covers_iff`), then
+    `superset_covering` with the monotonicity of pullback
+    (`Sieve.pullback_monotone`). -/
+theorem covers_mono {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) {A B : Sieve X} (hAB : A ≤ B) (h : J.Covers A f) :
+    J.Covers B f := by
+  rw [GrothendieckTopology.covers_iff] at h ⊢
+  exact J.superset_covering (Sieve.pullback_monotone f hAB) h
+
+/-- The arrow form is stable under join : if `S` covers `f`,
+    then `S ⊔ R` covers `f`.
+    Proof : special case of `covers_mono` with `le_sup_left`. -/
+theorem covers_union {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) (S R : Sieve X) (hS : J.Covers S f) :
+    J.Covers (S ⊔ R) f := by
+  exact covers_mono J f (le_sup_left : S ≤ S ⊔ R) hS
+
+/-!
+## Section 2 : base change and isomorphisms
+
+The composition law of `Sieve.pullback` (`Sieve.pullback_comp`) expresses
+the base change : `S.pullback (g ≫ f) = (S.pullback f).pullback g`.
+From it we derive the arrow-form base change (`covers_pullback_comp`)
+and the cancellation by isomorphism (`covers_iso_cancel`), which uses the
+Mathlib lemma `pullback_mem_iff_of_isIso`.
+-/
+
+/-- Base change law in arrow form : covering the composite `g ≫ f`
+    is equivalent to covering the pullback `S.pullback f` along `g`.
+    Proof : `covers_iff` on both members then `Sieve.pullback_comp`
+    (definitional equality of the two sieves at stake). -/
+theorem covers_pullback_comp {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (f : Y ⟶ X) (g : Z ⟶ Y) (S : Sieve X) :
+    J.Covers S (g ≫ f) ↔ J.Covers (S.pullback f) g := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    Sieve.pullback_comp]
+
+/-- Cancellation by isomorphism : if `g` is an isomorphism, covering
+    `g ≫ f` is equivalent to covering `f`.
+    Proof : base change (`Sieve.pullback_comp`) then
+    `pullback_mem_iff_of_isIso`, which reduces the pullback along an iso to
+    the original membership. -/
+theorem covers_iso_cancel {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (f : Y ⟶ X) {g : Z ⟶ Y} [IsIso g] (S : Sieve X) :
+    J.Covers S (g ≫ f) ↔ J.Covers S f := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    Sieve.pullback_comp]
+  exact GrothendieckTopology.pullback_mem_iff_of_isIso (i := g) (S := S.pullback f)
+
+/-- An isomorphic arrow `e.hom` is covered by `S` if and only if
+    `S` is covering.
+    Proof : `covers_iff` then `pullback_mem_iff_of_isIso`. -/
+theorem covers_iso_covering {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (e : X ≅ Y) (S : Sieve Y) :
+    J.Covers S e.hom ↔ S ∈ J Y := by
+  rw [GrothendieckTopology.covers_iff]
+  exact GrothendieckTopology.pullback_mem_iff_of_isIso (S := S)
+
+/-!
+## Section 3 : local character
+
+The transitivity axiom `arrow_trans` says : if `S` covers `f` and every
+arrow of `S` is covered by `R`, then `R` covers `f`. The bind form
+`Sieve.bind S R` glues the sieves `R g` into a single sieve on `X` ; we show
+that it inherits the covering of `f`. The brick is the adjunction law
+`Sieve.le_pullback_bind : R g ≤ (Sieve.bind S R).pullback g` (the pullback
+of the bind contains each component).
+-/
+
+/-- Local character in arrow form : if `S` covers `f` and, for every arrow
+    `g : Z ⟶ X` of `S`, the sieve `R g` is covering on its domain
+    (`R hg ∈ J Z`), then the bound sieve `Sieve.bind S R` covers `f`.
+    Proof : `arrow_trans` from `S` to `Sieve.bind S R`, then for every arrow
+    `g` of `S`, `superset_covering` with
+    `Sieve.le_pullback_bind` (each `R g` is below the pullback of the bind). -/
+theorem covers_bind {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) (S : Sieve X) (R : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z)
+    (hS : J.Covers S f) (hR : ∀ ⦃Z : C⦄ (g : Z ⟶ X) (hg : S g), R hg ∈ J Z) :
+    J.Covers (Sieve.bind S R) f := by
+  refine GrothendieckTopology.arrow_trans (J := J) (f := f) (S := S) (R := Sieve.bind S R) hS ?_
+  intro Z g hg
+  rw [GrothendieckTopology.covers_iff]
+  exact J.superset_covering (Sieve.le_pullback_bind S R g hg) (hR g hg)
+
+/-!
+## Section 4 : bridge to the bundled cover
+
+The bundled cover `J.Cover X = { S : Sieve X // S ∈ J X }` (Part 38)
+gathers the covering sieves with their membership proof. We relate the
+arrow form to the subtype : `S` covers `f` if and only if the pullback
+`S.pullback f` contains a cover.
+-/
+
+/-- `S` covers `f` if and only if `S.pullback f` contains a
+    `J.Cover Y` (as a subsieve).
+    Proof : forward direction — the cover `S.pullback f` itself is a
+    `J.Cover Y` (`covers_iff`) ; reverse direction —
+    `superset_covering` from the contained cover. -/
+theorem covers_iff_exists_cover {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (S : Sieve X) (f : Y ⟶ X) :
+    J.Covers S f ↔ ∃ T : J.Cover Y, (T : Sieve Y) ≤ S.pullback f := by
+  constructor
+  · intro h
+    exact ⟨⟨S.pullback f, by simpa [GrothendieckTopology.covers_iff] using h⟩, le_rfl⟩
+  · rintro ⟨T, hT⟩
+    rw [GrothendieckTopology.covers_iff]
+    exact J.superset_covering hT T.condition
+
+/-- The pullback of a cover `S.pullback f` covers the identity of `Y`.
+    Proof : `covers_iff` then `Sieve.pullback_id` (the pullback of the
+    identity is the identity) and the subtype condition. -/
+theorem cover_pullback_covers {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (S : J.Cover X) (f : Y ⟶ X) :
+    J.Covers (S.pullback f) (𝟙 Y) := by
+  rw [GrothendieckTopology.covers_iff, Sieve.pullback_id]
+  exact (S.pullback f).condition
+
+end Grothendieck.CoversPullback_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #11038

## Summary

Partie 40 de l'hommage Grothendieck (EPIC #2159, EPIC #1646) : **`CoversPullback.lean`** (FR) + `CoversPullback_en.lean` (EN, i18n #4980) — **8 théorèmes propres** sur la forme flèche `J.Covers S f` sous pullback. Mathlib fournit les axiomes en forme flèche (`arrow_max`, `arrow_stable`, `arrow_trans`, `arrow_intersect`) mais **aucune loi de comportement** de `J.Covers` vis-à-vis des opérations sur les cribles et des morphismes : veine DEEP, aucun re-export.

Contenu (8 théorèmes, preuves tactiques réelles) :

| Théorème | Contenu | Briques |
|---|---|---|
| `covers_mono` | monotone en le crible : `A ≤ B → J.Covers A f → J.Covers B f` | `superset_covering` + `Sieve.pullback_monotone` |
| `covers_union` | stable par join : `J.Covers S f → J.Covers (S ⊔ R) f` | `covers_mono` + `le_sup_left` |
| `covers_pullback_comp` | **changement de base** : `J.Covers S (g ≫ f) ↔ J.Covers (S.pullback f) g` | `Sieve.pullback_comp` |
| `covers_iso_cancel` | cancellation par iso : `[IsIso g] → J.Covers S (g ≫ f) ↔ J.Covers S f` | `pullback_mem_iff_of_isIso` |
| `covers_iso_covering` | fleche iso couverte ⟺ couvrante : `J.Covers S e.hom ↔ S ∈ J Y` | `pullback_mem_iff_of_isIso` |
| `covers_bind` | **caractère local** : `J.Covers S f → (∀ g, S g → R g ∈ J (dom g)) → J.Covers (Sieve.bind S R) f` | `arrow_trans` + `Sieve.le_pullback_bind` |
| `covers_iff_exists_cover` | pont vers `J.Cover` : `J.Covers S f ↔ ∃ T : J.Cover Y, (T : Sieve Y) ≤ S.pullback f` | `superset_covering` + sous-type |
| `cover_pullback_covers` | pullback d'une couverture couvre l'identité : `J.Covers (S.pullback f) (𝟙 Y)` | `Sieve.pullback_id` + `.condition` |

Aggrégateur `Grothendieck.lean` : `import Grothendieck.CoversPullback` (+1 ligne, ordre alphabétique).

## B.1 — Preuve de progrès vérifiable (pr-review-discipline §B)

1. **Compte de `sorry` réel avant/après** : `count_code_sorry.py --json` → `distinct_code_sorry: 0` avant (main) et 0 après (module nouveau, zéro `sorry` à la création). Modules touchés : `CoversPullback` (nouveau), `Grothendieck.lean` (import seul). Aucun module existant modifié → pas de régression possible.
2. **Lake build SUCCESS** (log ci-dessous, WSL, cache AZ warm) :

```
lake build Grothendieck
Build completed successfully (2835 jobs), EXIT=0
```

3. **Proof integrity** : job CI `proof-integrity` sur `grothendieck_lean` (workflow `lean-axiom.yml`) — attendu vert au PR gate (aucun axiome interdit introduit : 0 `sorryAx`, 0 `native_decide.*`, 0 `Classical.choice` non-whitelisté).
4. **B.3** : non applicable — le module est importé par l'agrégateur `Grothendieck.lean`, qui est le target-module du job.

## i18n (#4980) — sibling pair byte-identity

`check_i18n_siblings.py .../grothendieck_lean` → vérifié : **39/40 pairs byte-identical + 1 consumer-pattern, 0 drift, 0 orphan** (la paire `CoversPullback` est parmi les 39 byte-identical — énoncés, preuves, tactiques identiques ; docstrings traduites FR/EN ; namespace `Grothendieck.CoversPullback` ↔ `_en`).

## Scope

- `+404/-0` lignes : 2 nouveaux modules Lean (FR 202 + EN 201) + 1 ligne agrégateur.
- Pas de notebook, pas de catalogue, pas de code hors lake.
- `See #2159` (livraison partielle de l'EPIC Phase 5 — une partie de plus, l'EPIC reste ouverte).
