### PR TITLE
fix(tests,#11044): assert the discarded rung classification in test_1275 (dead assertion)

### DIFF
--- a/scripts/notebook_tools/tests/test_scan_quant_classify.py
+++ b/scripts/notebook_tools/tests/test_scan_quant_classify.py
@@ -409,6 +409,9 @@ class TestGoldenSetArgAnalysisC1275:
         # TIME_UNIT_RE.search('rung 1 :  ms sur 100 tirages') ne match PAS
         # car le pattern cherche \d+ immediatement avant ms (et '42' n'est
         # pas dans prefix+suffix ici). On tombe donc sur STRUCTURAL_LOCATIONS.
+        assert cls == "STRUCTUREL", (
+            f"rung adjacent doit rester STRUCTUREL, got {cls} ({rationale})"
+        )
         # Cas alternatif ou MACHINE-DEP prime : `42 ms runtime` directement.
         cls, rationale = _classify_quant_value("42", 42.0,
                                                "runtime: ",


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: DEEP/genai #11056

## Summary

Fix de l'assertion morte dans `test_scan_quant_classify.py::test_1275_runtime_ms_kept_machine_dep`, remontée par le triage #11044 (CONFIRMÉ-OUVERT n° 5).

Le test effectuait **deux** appels à `_classify_quant_value` mais un seul `assert` : le premier appel (le cas `rung 1 : 42 ms`, celui que le docstring présente comme cas de tête) assignait `cls, rationale` immédiatement écrasés par le second appel. La branche STRUCTUREL n'était donc jamais vérifiée.

## Correctif

- Assert ajouté sur le premier appel : `cls == "STRUCTUREL"` (comportement observé firsthand + conforme au commentaire inline existant : TIME_UNIT_RE ne matche pas `prefix+suffix` sans le chiffre, donc STRUCTURAL_LOCATIONS `'rung'` prime).
- L'assert MACHINE-DEP du second appel est inchangé.

## Validation

```
python -m pytest scripts/notebook_tools/tests/test_scan_quant_classify.py -q
→ 81 passed in 3.00s
```

Sorties observées avant le fix (imports directs du module sibling) :
- `("42", 42.0, "rung 1 : ", " ms sur 100 tirages")` → `STRUCTUREL | localisation structurelle: 'rung'`
- `("42", 42.0, "runtime: ", " ms (mesure brute)")` → `MACHINE-DEP | mot-cle machine-dep: 'runtime'`

Diff : +3 lignes, 1 fichier, aucun code de production touché.

See #11044 (finding n° 5 du triage : https://github.com/jsboige/CoursIA/issues/11044#issuecomment-5302563397)
