### PR TITLE
feat(parity,#10382): pont nashpy CLI sur GT-4 NashEquilibrium C# — parite lib-vs-lib (tranche 3)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "de1e326a-92cf-4a48-b82f-a854cd5dad60",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005517,
+     "end_time": "2026-08-15T14:09:19.695441",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:19.689924",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# GameTheory-4-NashEquilibrium (C#)\n",
     "\n",
@@ -29,7 +38,16 @@
   {
    "cell_type": "markdown",
    "id": "4a736840-b7d5-439e-b634-84b2e7349122",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005758,
+     "end_time": "2026-08-15T14:09:19.709283",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:19.703525",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Definition formelle\n",
     "\n",
@@ -46,7 +64,16 @@
   {
    "cell_type": "markdown",
    "id": "a326e242-8dd2-406c-87d1-3961dd428fe1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004318,
+     "end_time": "2026-08-15T14:09:19.718955",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:19.714637",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 1.1 Classe `Game` — representation d'un jeu bimatriciel\n",
     "\n",
@@ -59,11 +86,19 @@
    "id": "7887f51a-1371-4904-bbf3-a4d7f81003ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:23.552794Z",
-     "iopub.status.busy": "2026-08-15T02:41:23.543059Z",
-     "iopub.status.idle": "2026-08-15T02:41:26.785425Z",
-     "shell.execute_reply": "2026-08-15T02:41:26.779062Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:19.748769Z",
+     "iopub.status.busy": "2026-08-15T14:09:19.736928Z",
+     "iopub.status.idle": "2026-08-15T14:09:22.193785Z",
+     "shell.execute_reply": "2026-08-15T14:09:22.188390Z"
+    },
+    "papermill": {
+     "duration": 2.469877,
+     "end_time": "2026-08-15T14:09:22.194327",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:19.724450",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -71,7 +106,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-55528.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -121,7 +156,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '55528.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '30376.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -271,7 +306,16 @@
   {
    "cell_type": "markdown",
    "id": "5359cbea-7bf9-4dee-af0d-00c7f3bf29aa",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005225,
+     "end_time": "2026-08-15T14:09:22.205377",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.200152",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Equilibres de Nash purs\n",
     "\n",
@@ -284,11 +328,19 @@
    "id": "73198a3f-f277-4796-92fe-8b29e8caa06b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:26.787807Z",
-     "iopub.status.busy": "2026-08-15T02:41:26.787482Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.015025Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.014405Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:22.216823Z",
+     "iopub.status.busy": "2026-08-15T14:09:22.216823Z",
+     "iopub.status.idle": "2026-08-15T14:09:22.395709Z",
+     "shell.execute_reply": "2026-08-15T14:09:22.395189Z"
+    },
+    "papermill": {
+     "duration": 0.184812,
+     "end_time": "2026-08-15T14:09:22.395709",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.210897",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -361,11 +413,19 @@
    "id": "2d27b18d-f2ad-4eb3-acff-601ac2ee0c62",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.017019Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.016666Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.090339Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.090030Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:22.408360Z",
+     "iopub.status.busy": "2026-08-15T14:09:22.407830Z",
+     "iopub.status.idle": "2026-08-15T14:09:22.429290Z",
+     "shell.execute_reply": "2026-08-15T14:09:22.427771Z"
+    },
+    "papermill": {
+     "duration": 0.030299,
+     "end_time": "2026-08-15T14:09:22.429290",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.398991",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -436,7 +496,16 @@
   {
    "cell_type": "markdown",
    "id": "324d565d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006235,
+     "end_time": "2026-08-15T14:09:22.439128",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.432893",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 2.1 Multiplicité des équilibres purs : Bridge vers les mixtes\n",
     "\n",
@@ -452,7 +521,16 @@
   {
    "cell_type": "markdown",
    "id": "a9445262-2568-4d3a-a59b-89c205b619fd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006799,
+     "end_time": "2026-08-15T14:09:22.449658",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.442859",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Stratégies mixtes et condition d'indifference\n",
     "\n",
@@ -479,11 +557,19 @@
    "id": "0399d8bd-7565-410a-a98e-beeff981ffbd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.092199Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.091910Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.247309Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.246358Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:22.462338Z",
+     "iopub.status.busy": "2026-08-15T14:09:22.462338Z",
+     "iopub.status.idle": "2026-08-15T14:09:22.564741Z",
+     "shell.execute_reply": "2026-08-15T14:09:22.564741Z"
+    },
+    "papermill": {
+     "duration": 0.108608,
+     "end_time": "2026-08-15T14:09:22.564741",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.456133",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -582,11 +668,19 @@
    "id": "b2f8a6fc-8ab5-4aec-a8c0-41a1269ae658",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.250523Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.250145Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.378798Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.377900Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:22.576641Z",
+     "iopub.status.busy": "2026-08-15T14:09:22.576641Z",
+     "iopub.status.idle": "2026-08-15T14:09:22.649040Z",
+     "shell.execute_reply": "2026-08-15T14:09:22.648039Z"
+    },
+    "papermill": {
+     "duration": 0.079174,
+     "end_time": "2026-08-15T14:09:22.649040",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.569866",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -652,7 +746,16 @@
   {
    "cell_type": "markdown",
    "id": "ef0085e8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006341,
+     "end_time": "2026-08-15T14:09:22.660153",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.653812",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3.1 Lecture des premiers mélanges : asymétrie et Pareto-dominance\n",
     "\n",
@@ -670,7 +773,16 @@
   {
    "cell_type": "markdown",
    "id": "a142c6ea-cfd3-4034-9465-8e869318cb9b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006,
+     "end_time": "2026-08-15T14:09:22.671152",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.665152",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Support enumeration (coeur algorithmique, from-scratch)\n",
     "\n",
@@ -689,11 +801,19 @@
    "id": "fe7b696e-3fa5-469f-b9ac-dcc57d5f56aa",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.381982Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.381555Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.462549Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.462279Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:22.684846Z",
+     "iopub.status.busy": "2026-08-15T14:09:22.684846Z",
+     "iopub.status.idle": "2026-08-15T14:09:22.751256Z",
+     "shell.execute_reply": "2026-08-15T14:09:22.751256Z"
+    },
+    "papermill": {
+     "duration": 0.073993,
+     "end_time": "2026-08-15T14:09:22.751256",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.677263",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -758,11 +878,19 @@
    "id": "5bb025e3-5323-4163-9c22-edb7ae7a10c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.464710Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.464409Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.759585Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.759137Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:22.765592Z",
+     "iopub.status.busy": "2026-08-15T14:09:22.764590Z",
+     "iopub.status.idle": "2026-08-15T14:09:23.000117Z",
+     "shell.execute_reply": "2026-08-15T14:09:23.000117Z"
+    },
+    "papermill": {
+     "duration": 0.242688,
+     "end_time": "2026-08-15T14:09:23.000117",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:22.757429",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -892,7 +1020,16 @@
   {
    "cell_type": "markdown",
    "id": "cbdf0764-211f-4ab2-b005-cfc13ed14ff6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005647,
+     "end_time": "2026-08-15T14:09:23.011761",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.006114",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Analyse complete sur les jeux canoniques\n",
     "\n",
@@ -905,11 +1042,19 @@
    "id": "516b3c7f-187f-4428-9df4-abfc2768876e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.762520Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.761918Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.880379Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.879839Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:23.026200Z",
+     "iopub.status.busy": "2026-08-15T14:09:23.025201Z",
+     "iopub.status.idle": "2026-08-15T14:09:23.122231Z",
+     "shell.execute_reply": "2026-08-15T14:09:23.120678Z"
+    },
+    "papermill": {
+     "duration": 0.104364,
+     "end_time": "2026-08-15T14:09:23.122231",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.017867",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1032,11 +1177,19 @@
    "id": "d6e925d4-e4d8-4c68-b3d6-acc2c79b42ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.882828Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.882529Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.939122Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.934024Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:23.136693Z",
+     "iopub.status.busy": "2026-08-15T14:09:23.136693Z",
+     "iopub.status.idle": "2026-08-15T14:09:23.172535Z",
+     "shell.execute_reply": "2026-08-15T14:09:23.170997Z"
+    },
+    "papermill": {
+     "duration": 0.043613,
+     "end_time": "2026-08-15T14:09:23.172535",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.128922",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1201,7 +1354,16 @@
   {
    "cell_type": "markdown",
    "id": "gt4-multeq-interpretation",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006711,
+     "end_time": "2026-08-15T14:09:23.186027",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.179316",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Les cinq jeux canoniques se partitionnent en **deux régimes** selon le nombre\n",
     "d'équilibres. D'un côté, le **Dilemme du Prisonnier** (1 équilibre pur,\n",
@@ -1233,7 +1395,16 @@
   {
    "cell_type": "markdown",
    "id": "ba75e955-9d7b-402b-8f6c-6882a2a2f44d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006169,
+     "end_time": "2026-08-15T14:09:23.198781",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.192612",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Pierre-Feuille-Ciseaux (3x3 zero-sum symetrique)\n",
     "\n",
@@ -1246,11 +1417,19 @@
    "id": "61d56fe3-ac8a-4fbf-9250-d1a3700af34f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.941352Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.941082Z",
-     "iopub.status.idle": "2026-08-15T02:41:27.992803Z",
-     "shell.execute_reply": "2026-08-15T02:41:27.992176Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:23.212367Z",
+     "iopub.status.busy": "2026-08-15T14:09:23.212367Z",
+     "iopub.status.idle": "2026-08-15T14:09:23.244228Z",
+     "shell.execute_reply": "2026-08-15T14:09:23.244228Z"
+    },
+    "papermill": {
+     "duration": 0.038472,
+     "end_time": "2026-08-15T14:09:23.244228",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.205756",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1308,7 +1487,16 @@
   {
    "cell_type": "markdown",
    "id": "040af93d-aef1-4433-bdaf-6c527371d1cd",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.001596,
+     "end_time": "2026-08-15T14:09:23.259038",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.257442",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 6.1 Jeu asymetrique 3x2\n",
     "\n",
@@ -1321,11 +1509,19 @@
    "id": "4e63a3e4-acc4-4c5c-b7e1-2f624b43c48f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:27.994882Z",
-     "iopub.status.busy": "2026-08-15T02:41:27.994634Z",
-     "iopub.status.idle": "2026-08-15T02:41:28.054725Z",
-     "shell.execute_reply": "2026-08-15T02:41:28.054247Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:23.278642Z",
+     "iopub.status.busy": "2026-08-15T14:09:23.278642Z",
+     "iopub.status.idle": "2026-08-15T14:09:23.292453Z",
+     "shell.execute_reply": "2026-08-15T14:09:23.292453Z"
+    },
+    "papermill": {
+     "duration": 0.022041,
+     "end_time": "2026-08-15T14:09:23.292453",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.270412",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1382,7 +1578,16 @@
   {
    "cell_type": "markdown",
    "id": "gt4-gambit-title",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00779,
+     "end_time": "2026-08-15T14:09:23.307033",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.299243",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 6.2 Pont avec Gambit (CLI externe GPL-2.0)\n",
     "\n",
@@ -1419,7 +1624,16 @@
   {
    "cell_type": "markdown",
    "id": "gt4-gambit-nfg-format",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006782,
+     "end_time": "2026-08-15T14:09:23.314822",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.308040",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Format NFG (Gambit strategic-game)\n",
     "\n",
@@ -1441,11 +1655,19 @@
    "id": "gt4-gambit-helpers",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:28.057902Z",
-     "iopub.status.busy": "2026-08-15T02:41:28.057600Z",
-     "iopub.status.idle": "2026-08-15T02:41:28.433718Z",
-     "shell.execute_reply": "2026-08-15T02:41:28.432829Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:23.339101Z",
+     "iopub.status.busy": "2026-08-15T14:09:23.339101Z",
+     "iopub.status.idle": "2026-08-15T14:09:23.487890Z",
+     "shell.execute_reply": "2026-08-15T14:09:23.487890Z"
+    },
+    "papermill": {
+     "duration": 0.158108,
+     "end_time": "2026-08-15T14:09:23.487890",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.329782",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1515,9 +1737,19 @@
     "    // 1) Ecrire le fichier .nfg dans un tmp unique par jeu\n",
     "    string nfgPath = Path.Combine(Path.GetTempPath(), $\"{g.Name}_{binary}.nfg\");\n",
     "    File.WriteAllText(nfgPath, ToNfg(g));\n",
-    "    string exePath = $@\"C:\\Program Files (x86)\\Gambit\\{binary}.exe\";\n",
-    "    if (!File.Exists(exePath))\n",
-    "        throw new FileNotFoundException($\"Binaire Gambit introuvable : {exePath}\");\n",
+    "    // Resolution portable du binaire (regle F : outil reel, machine-agnostique) :\n",
+    "    // 1) variable d'env GAMBIT_DIR si posee, 2) installation MSI standard (elevation UAC),\n",
+    "    // 3) copie per-user sans admin (C:\\Users\\<user>\\gambit, extraction msiexec /a).\n",
+    "    var candidates = new List<string>();\n",
+    "    var envDir = Environment.GetEnvironmentVariable(\"GAMBIT_DIR\");\n",
+    "    if (!string.IsNullOrEmpty(envDir))\n",
+    "        candidates.Add(Path.Combine(envDir, binary + \".exe\"));\n",
+    "    candidates.Add($@\"C:\\Program Files (x86)\\Gambit\\{binary}.exe\");\n",
+    "    candidates.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \"gambit\", binary + \".exe\"));\n",
+    "    string exePath = candidates.FirstOrDefault(File.Exists);\n",
+    "    if (exePath == null)\n",
+    "        throw new FileNotFoundException(\n",
+    "            \"Binaire Gambit introuvable (GAMBIT_DIR, Program Files (x86), %USERPROFILE%\\\\gambit). Installer Gambit 16.7.0 : msiexec /a gambit-16.7.0.msi /qn TARGETDIR=%USERPROFILE%\\\\gambit (sans admin) ou MSI officiel avec elevation UAC.\");\n",
     "\n",
     "    // 2) Process.Start (BCL) avec arguments -d DECIMALS -q <path>\n",
     "    var psi = new ProcessStartInfo\n",
@@ -1568,11 +1800,19 @@
    "id": "gt4-gambit-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:28.436249Z",
-     "iopub.status.busy": "2026-08-15T02:41:28.435936Z",
-     "iopub.status.idle": "2026-08-15T02:41:28.977165Z",
-     "shell.execute_reply": "2026-08-15T02:41:28.976744Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:23.501203Z",
+     "iopub.status.busy": "2026-08-15T14:09:23.501203Z",
+     "iopub.status.idle": "2026-08-15T14:09:23.819388Z",
+     "shell.execute_reply": "2026-08-15T14:09:23.819388Z"
+    },
+    "papermill": {
+     "duration": 0.325353,
+     "end_time": "2026-08-15T14:09:23.819388",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.494035",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2049,7 +2289,16 @@
   {
    "cell_type": "markdown",
    "id": "gt4-gambit-interpretation",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006824,
+     "end_time": "2026-08-15T14:09:23.840416",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.833592",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la comparaison\n",
     "\n",
@@ -2074,8 +2323,261 @@
   },
   {
    "cell_type": "markdown",
+   "id": "gt4-nashpy-title",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015493,
+     "end_time": "2026-08-15T14:09:23.864516",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.849023",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 6.3 Pont avec nashpy (la bibliotheque SOTA du twin Python)\n",
+    "\n",
+    "La section 6.2 a confronte le from-scratch a **Gambit** (solveur externe GPL-2.0). Le twin Python\n",
+    "de ce notebook (`GameTheory-4-NashEquilibrium`) calcule ses equilibres avec **nashpy**\n",
+    "(`nash.Game(A, B).support_enumeration()`), la bibliotheque de reference des equilibres de Nash\n",
+    "en Python. Pour prouver la **parite lib-vs-lib** (issue #10382) au sens strict — le C# invoque le\n",
+    "MEME moteur que le jumeau Python — on ajoute ici un pont CLI `Process.Start` vers nashpy (meme\n",
+    "schema que le pont Gambit de la section 6.2 et que le pont nashpy de la tranche GT-2).\n",
+    "\n",
+    "nashpy resout les 5 jeux deja etudies (Dilemme du Prisonnier, Pile ou Face, Bataille des Sexes,\n",
+    "Pierre-Feuille-Ciseaux, Asymetrique 3x2) par enumeration de supports, et on compare son ensemble\n",
+    "d'equilibres a celui du `SupportEnumeration` from-scratch de la section 4.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "gt4-nashpy-bridge",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T14:09:23.910630Z",
+     "iopub.status.busy": "2026-08-15T14:09:23.887451Z",
+     "iopub.status.idle": "2026-08-15T14:09:26.518994Z",
+     "shell.execute_reply": "2026-08-15T14:09:26.518484Z"
+    },
+    "papermill": {
+     "duration": 2.654478,
+     "end_time": "2026-08-15T14:09:26.518994",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:23.864516",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "=== Pont nashpy : SupportEnumeration from-scratch (BCL .NET) vs nashpy (python.exe) ===\r\n",
+       "nashpy est le moteur SOTA du twin Python (nash.Game(A,B).support_enumeration()).\r\n",
+       "Les deux calculent TOUS les equilibres de Nash (purs et mixtes) par enumeration de supports.\r\n",
+       "\r\n",
+       "  nashpy [0.000,1.000] [0.000,1.000] -> exploitabilite=0.000000\r\n",
+       "  from-scratch: 1 NE | nashpy: 1 NE -> CORRESPOND (ecart max 0)\r\n",
+       "\r\n",
+       "  nashpy [0.500,0.500] [0.500,0.500] -> exploitabilite=0.000000\r\n",
+       "  from-scratch: 1 NE | nashpy: 1 NE -> CORRESPOND (ecart max 0)\r\n",
+       "\r\n",
+       "  nashpy [1.000,0.000] [1.000,0.000] -> exploitabilite=0.000000\r\n",
+       "  nashpy [0.000,1.000] [0.000,1.000] -> exploitabilite=0.000000\r\n",
+       "  nashpy [0.667,0.333] [0.333,0.667] -> exploitabilite=0.000001\r\n",
+       "  from-scratch: 3 NE | nashpy: 3 NE -> CORRESPOND (ecart max 3.33E-07)\r\n",
+       "\r\n",
+       "  nashpy [0.333,0.333,0.333] [0.333,0.333,0.333] -> exploitabilite=0.000000\r\n",
+       "  from-scratch: 1 NE | nashpy: 1 NE -> CORRESPOND (ecart max 3.33E-07)\r\n",
+       "\r\n",
+       "  nashpy [0.750,0.250,0.000] [0.500,0.500] -> exploitabilite=0.000000\r\n",
+       "  nashpy [-0.000,0.250,0.750] [0.500,0.500] -> exploitabilite=0.000000\r\n",
+       "  from-scratch: 2 NE | nashpy: 2 NE -> CORRESPOND (ecart max 0)\r\n",
+       "\r\n",
+       ">>> Bilan : 5/5 jeux concordent. L'oracle SOTA nashpy (moteur du twin Python)\r\n",
+       "    valide le SupportEnumeration from-scratch : les deux implementent la meme notion d'equilibre de Nash.\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// === Pont nashpy CLI : le moteur SOTA du twin Python valide le SupportEnumeration from-scratch ===\n",
+    "// Parite lib-vs-lib (issue #10382) : le twin Python calcule ses equilibres avec nashpy\n",
+    "// (nash.Game(A,B).support_enumeration()). On invoque le MEME moteur depuis C# via Process.Start\n",
+    "// (axe CLI de la checklist SOTA, meme schema que le pont Gambit de la section 6.2), on resout\n",
+    "// les 5 jeux deja definis (pd, mp, bos, rps, asym), puis on compare l'ENSEMBLE des equilibres\n",
+    "// a celui du SupportEnumeration from-scratch.\n",
+    "using System.Text.Json;\n",
+    "\n",
+    "// --- 1. Resoudre l'interpreteur Python qui importe nashpy (regle F : outil reel, pas un stub) ---\n",
+    "static string FindPythonWithNashpy()\n",
+    "{\n",
+    "    var candidates = new List<string>();\n",
+    "    try\n",
+    "    {\n",
+    "        var pi = new ProcessStartInfo(\"where\", \"python\")\n",
+    "        { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true };\n",
+    "        var p = Process.Start(pi);\n",
+    "        string outp = p.StandardOutput.ReadToEnd();\n",
+    "        p.WaitForExit(3000);\n",
+    "        foreach (var line in outp.Split('\\n', StringSplitOptions.RemoveEmptyEntries))\n",
+    "            candidates.Add(line.Trim());\n",
+    "    }\n",
+    "    catch { }\n",
+    "    candidates.Add(\"python\");\n",
+    "    foreach (var exe in candidates)\n",
+    "    {\n",
+    "        try\n",
+    "        {\n",
+    "            var pi = new ProcessStartInfo(exe, \"-c \\\"import nashpy\\\"\")\n",
+    "            { RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true };\n",
+    "            var p = Process.Start(pi);\n",
+    "            p.StandardOutput.ReadToEnd();\n",
+    "            p.WaitForExit(5000);\n",
+    "            if (p.ExitCode == 0) return exe;\n",
+    "        }\n",
+    "        catch { }\n",
+    "    }\n",
+    "    throw new FileNotFoundException(\n",
+    "        \"nashpy introuvable. Installer la lib SOTA Python : python -m pip install nashpy (regle F : reparer, pas contourner).\");\n",
+    "}\n",
+    "string pythonExe = FindPythonWithNashpy();\n",
+    "\n",
+    "// --- 2. Serialiser les bimatrices (pd, mp, bos, rps, asym) pour nashpy ---\n",
+    "static string BimatrixToJson(Game g)\n",
+    "{\n",
+    "    string mat(double[,] m)\n",
+    "    {\n",
+    "        var sb = new StringBuilder(\"[\");\n",
+    "        for (int i = 0; i < g.M; i++)\n",
+    "        {\n",
+    "            if (i > 0) sb.Append(',');\n",
+    "            sb.Append('[');\n",
+    "            for (int j = 0; j < g.N; j++)\n",
+    "            { if (j > 0) sb.Append(','); sb.Append(m[i, j].ToString(\"G6\", CultureInfo.InvariantCulture)); }\n",
+    "            sb.Append(']');\n",
+    "        }\n",
+    "        return sb.Append(']').ToString();\n",
+    "    }\n",
+    "    return $\"{{\\\"A\\\": {mat(g.A)}, \\\"B\\\": {mat(g.B)}}}\";\n",
+    "}\n",
+    "var bridgeGames = new (string name, Game game)[] { (\"pd\", pd), (\"mp\", mp), (\"bos\", bos), (\"rps\", rps), (\"asym\", asym) };\n",
+    "var inp = new StringBuilder(\"{\");\n",
+    "for (int k = 0; k < bridgeGames.Length; k++)\n",
+    "{\n",
+    "    if (k > 0) inp.Append(',');\n",
+    "    inp.Append($\"\\\"{bridgeGames[k].name}\\\": {BimatrixToJson(bridgeGames[k].game)}\");\n",
+    "}\n",
+    "inp.Append('}');\n",
+    "string inputPath = Path.Combine(Path.GetTempPath(), \"gt4_nashpy_input.json\");\n",
+    "File.WriteAllText(inputPath, inp.ToString());\n",
+    "\n",
+    "// --- 3. Script nashpy : support_enumeration sur chaque jeu, resultats en JSON sur stdout ---\n",
+    "string script = @\"\n",
+    "import json, sys\n",
+    "import nashpy as nash\n",
+    "import numpy as np\n",
+    "inp = json.load(open(sys.argv[1], 'r'))\n",
+    "out = {}\n",
+    "for name, g in inp.items():\n",
+    "    A = np.array(g['A'], dtype=float)\n",
+    "    B = np.array(g['B'], dtype=float)\n",
+    "    eqs = []\n",
+    "    for s1, s2 in nash.Game(A, B).support_enumeration():\n",
+    "        eqs.append([['%.6f' % x for x in s1], ['%.6f' % x for x in s2]])\n",
+    "    out[name] = eqs\n",
+    "json.dump(out, sys.stdout)\n",
+    "\";\n",
+    "string scriptPath = Path.Combine(Path.GetTempPath(), \"gt4_nashpy_bridge.py\");\n",
+    "File.WriteAllText(scriptPath, script);\n",
+    "\n",
+    "var psi = new ProcessStartInfo(pythonExe, $\"\\\"{scriptPath}\\\" \\\"{inputPath}\\\"\")\n",
+    "{ RedirectStandardOutput = true, RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true };\n",
+    "var p2 = Process.Start(psi);\n",
+    "string stdout = p2.StandardOutput.ReadToEnd();\n",
+    "p2.WaitForExit(30000);\n",
+    "if (p2.ExitCode != 0)\n",
+    "    throw new InvalidOperationException(\"nashpy a echoue:\\n\" + stdout + p2.StandardError.ReadToEnd());\n",
+    "\n",
+    "// --- 4. Comparaison d'ensembles : nashpy vs SupportEnumeration from-scratch ---\n",
+    "var doc = JsonDocument.Parse(stdout);\n",
+    "double[] ToVec(JsonElement el)\n",
+    "    => el.EnumerateArray().Select(x => double.Parse(x.GetString(), CultureInfo.InvariantCulture)).ToArray();\n",
+    "static double MaxDiff(double[] a, double[] b)\n",
+    "{ double m = 0; for (int i = 0; i < a.Length; i++) m = Math.Max(m, Math.Abs(a[i] - b[i])); return m; }\n",
+    "// Exploitabilite d'un profil = somme des meilleurs gains de deviation unilaterale ; 0 <=> equilibre.\n",
+    "static double Exploitability(Game g, double[] s1, double[] s2)\n",
+    "{\n",
+    "    double e1mix = 0, br1 = double.MinValue;\n",
+    "    for (int a1 = 0; a1 < g.M; a1++)\n",
+    "    {\n",
+    "        double e = 0;\n",
+    "        for (int a2 = 0; a2 < g.N; a2++) e += g.A[a1, a2] * s2[a2];\n",
+    "        e1mix += s1[a1] * e;\n",
+    "        br1 = Math.Max(br1, e);\n",
+    "    }\n",
+    "    double e2mix = 0, br2 = double.MinValue;\n",
+    "    for (int a2 = 0; a2 < g.N; a2++)\n",
+    "    {\n",
+    "        double e = 0;\n",
+    "        for (int a1 = 0; a1 < g.M; a1++) e += g.B[a1, a2] * s1[a1];\n",
+    "        e2mix += s2[a2] * e;\n",
+    "        br2 = Math.Max(br2, e);\n",
+    "    }\n",
+    "    return (br1 - e1mix) + (br2 - e2mix);\n",
+    "}\n",
+    "\n",
+    "var sb = new StringBuilder();\n",
+    "sb.AppendLine($\"=== Pont nashpy : SupportEnumeration from-scratch (BCL .NET) vs nashpy ({Path.GetFileName(pythonExe)}) ===\");\n",
+    "sb.AppendLine(\"nashpy est le moteur SOTA du twin Python (nash.Game(A,B).support_enumeration()).\");\n",
+    "sb.AppendLine(\"Les deux calculent TOUS les equilibres de Nash (purs et mixtes) par enumeration de supports.\");\n",
+    "sb.AppendLine();\n",
+    "int okTotal = 0;\n",
+    "foreach (var (name, game) in bridgeGames)\n",
+    "{\n",
+    "    var fs = SupportEnumeration(game);\n",
+    "    var root = doc.RootElement.GetProperty(name);\n",
+    "    var profiles = new List<(double[] s1, double[] s2)>();\n",
+    "    foreach (var el in root.EnumerateArray())\n",
+    "        profiles.Add((ToVec(el[0]), ToVec(el[1])));\n",
+    "    double worst = 0;\n",
+    "    foreach (var (s1, s2) in profiles)\n",
+    "    {\n",
+    "        double best = double.MaxValue;\n",
+    "        foreach (var e in fs)\n",
+    "            best = Math.Min(best, Math.Max(MaxDiff(s1, e.SigmaRow), MaxDiff(s2, e.SigmaCol)));\n",
+    "        worst = Math.Max(worst, best);\n",
+    "        sb.AppendLine($\"  nashpy [{string.Join(\",\", s1.Select(x => x.ToString(\"F3\", CultureInfo.InvariantCulture)))}] \" +\n",
+    "                      $\"[{string.Join(\",\", s2.Select(x => x.ToString(\"F3\", CultureInfo.InvariantCulture)))}] \" +\n",
+    "                      $\"-> exploitabilite={Exploitability(game, s1, s2).ToString(\"F6\", CultureInfo.InvariantCulture)}\");\n",
+    "    }\n",
+    "    bool ok = profiles.Count == fs.Count && worst < 1e-3;\n",
+    "    if (ok) okTotal++;\n",
+    "    sb.AppendLine($\"  from-scratch: {fs.Count} NE | nashpy: {profiles.Count} NE -> \" +\n",
+    "                  $\"{(ok ? \"CORRESPOND\" : \"DIVERGENCE\")} (ecart max {worst.ToString(\"G3\", CultureInfo.InvariantCulture)})\");\n",
+    "    sb.AppendLine();\n",
+    "}\n",
+    "sb.AppendLine($\">>> Bilan : {okTotal}/{bridgeGames.Length} jeux concordent. L'oracle SOTA nashpy (moteur du twin Python)\");\n",
+    "sb.AppendLine(\"    valide le SupportEnumeration from-scratch : les deux implementent la meme notion d'equilibre de Nash.\");\n",
+    "sb.ToString().Display();\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b917895c-4a07-4c22-9266-9f19cc7f2aef",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00959,
+     "end_time": "2026-08-15T14:09:26.537270",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:26.527680",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Exercices\n",
     "\n",
@@ -2093,15 +2595,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "c7fad5e7-cf5b-4609-a19d-8a7ac1b4950d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:28.979479Z",
-     "iopub.status.busy": "2026-08-15T02:41:28.979205Z",
-     "iopub.status.idle": "2026-08-15T02:41:29.066314Z",
-     "shell.execute_reply": "2026-08-15T02:41:29.066024Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:26.556707Z",
+     "iopub.status.busy": "2026-08-15T14:09:26.556707Z",
+     "iopub.status.idle": "2026-08-15T14:09:26.656209Z",
+     "shell.execute_reply": "2026-08-15T14:09:26.656209Z"
+    },
+    "papermill": {
+     "duration": 0.110839,
+     "end_time": "2026-08-15T14:09:26.656209",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:26.545370",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2147,7 +2657,16 @@
   {
    "cell_type": "markdown",
    "id": "844e302f-d0c0-4e8e-b5a2-3136db881ca8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008103,
+     "end_time": "2026-08-15T14:09:26.674339",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:26.666236",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 — Pierre-Feuille-Ciseaux biaise\n",
     "\n",
@@ -2158,15 +2677,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "f4e0fce6-304e-4e34-8b6e-44011062b56b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:29.068221Z",
-     "iopub.status.busy": "2026-08-15T02:41:29.067935Z",
-     "iopub.status.idle": "2026-08-15T02:41:29.132074Z",
-     "shell.execute_reply": "2026-08-15T02:41:29.131604Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:26.695189Z",
+     "iopub.status.busy": "2026-08-15T14:09:26.694649Z",
+     "iopub.status.idle": "2026-08-15T14:09:26.754513Z",
+     "shell.execute_reply": "2026-08-15T14:09:26.754513Z"
+    },
+    "papermill": {
+     "duration": 0.070273,
+     "end_time": "2026-08-15T14:09:26.754513",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:26.684240",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2197,7 +2724,16 @@
   {
    "cell_type": "markdown",
    "id": "cb366037-0036-442f-aa43-9aaf1b4d9291",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010689,
+     "end_time": "2026-08-15T14:09:26.775224",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:26.764535",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3 — Stag Hunt parametrique\n",
     "\n",
@@ -2206,15 +2742,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "a966c48a-4683-4334-a016-fec483e1777c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T02:41:29.133916Z",
-     "iopub.status.busy": "2026-08-15T02:41:29.133642Z",
-     "iopub.status.idle": "2026-08-15T02:41:29.180946Z",
-     "shell.execute_reply": "2026-08-15T02:41:29.180422Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:09:26.796543Z",
+     "iopub.status.busy": "2026-08-15T14:09:26.796543Z",
+     "iopub.status.idle": "2026-08-15T14:09:26.849440Z",
+     "shell.execute_reply": "2026-08-15T14:09:26.849440Z"
+    },
+    "papermill": {
+     "duration": 0.064853,
+     "end_time": "2026-08-15T14:09:26.850548",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:26.785695",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -2245,7 +2789,16 @@
   {
    "cell_type": "markdown",
    "id": "0904ce3b-752f-40d5-b445-f25b7bd6e587",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.012191,
+     "end_time": "2026-08-15T14:09:26.870491",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:26.858300",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
@@ -2271,7 +2824,16 @@
   {
    "cell_type": "markdown",
    "id": "30f9df0e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010001,
+     "end_time": "2026-08-15T14:09:26.890497",
+     "exception": false,
+     "start_time": "2026-08-15T14:09:26.880496",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Références\n",
     "\n",
@@ -2314,6 +2876,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 9.9161,
+   "end_time": "2026-08-15T14:09:27.129758",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.executed.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-15T14:09:17.213658",
+   "version": "2.6.0"
   },
   "polyglot_notebook": {
    "kernelName": ".net-csharp"

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
@@ -3,8 +3,8 @@
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
   parity_level: semantic
-  bridge_verdict: RECOVERABLE-LOCAL
-  bridge_verdict_reason: "Python = nashpy (SOTA, support enumeration purs/mixtes) + scipy.optimize.linprog (LP pour Nash mixte). C# = BestResponseRow from-scratch en pur Linq (0 solveur LP externe). Pont Gambit CLI deja branche partiel (PR #10442 cite Lemke-Howson + enummixed sur ce twin) ; extension a nashpy CLI ou GameTheory.NET NuGet trivial. RECOVERABLE-LOCAL = pont existant semi-wire, extension naturelle. parite semantique preservee (meme socle : Nash purs + mixtes, BestResponse, support enumeration)."
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Pont SOTA rajoute cote C# (mandat #10382) : nashpy (lib SOTA du twin Python, `nash.Game(A,B).support_enumeration()`) invoque depuis le notebook C# via CLI Process.Start (cellule 6.3) sur les 5 jeux canoniques (PD, MP, BoS, RPS, Asym 3x2), en plus du pont Gambit CLI deja branche (cellule 6.2, PR #10442). Axes binding (#10459) : CLI pur (axe 3) -- AUCUN binding .NET/NuGet (axe 1), AUCUN P/Invoke (axe 2), AUCUNE IKVM (axe 4), AUCUN PythonNet (axe 5). Axe 6 : nashpy couvre le meme role que le SupportEnumeration from-scratch (enumeration de supports pour les NE purs et mixtes) -> le pont est desormais wire. Comparaison numerique (cellule 6.3 du C#) : 5/5 jeux concordent (ecart max 3.3e-07, exploitabilite = 0 partout). RPS : nashpy retrouve l'equilibre uniforme (1/3,1/3,1/3) ; BoS : 3 NE (2 purs + mixte 2/3,1/3) ; Asym : 2 NE mixtes -- identiques aux resultats du twin Python (meme moteur nashpy). From-scratch BCL .NET conserve : le pont est EN PLUS jamais A LA PLACE. parity_level `semantic` conservee (cf. jumeaux part-2 et GT-4, precedent pont Gambit)."
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -53,7 +53,14 @@
       csharp_sha: 978594ab1a745b688d5252255c7cd00764c97421
       content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
       content_csharp_sha: a047d74bf1c152b53728d3c41ceb3373b803406c75fe5bf033443e532cd26aea
+    - date: "2026-08-15"
+      by: myia-po-2026:CoursIA-2
+      python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
+      csharp_sha: e3a20c5a309c90f173c5494dc7cd032aa77fe37c
+      content_python_sha: 969f44d1f55a24c59159c97f0f28864264f46c865a08efae379ad67a270b6e26
+      content_csharp_sha: 22b635165857585f64e21f62348f41f83e1d7193105a71e0efe5534b571aefbc
   known_differences:
+    - "2026-08-15 : ajout du pont nashpy CLI (cellule 6.3, meme schema que le pont Gambit 6.2 et la tranche GT-2 #11055). Le C# invoque nashpy (moteur du twin Python) via Process.Start, resout les 5 jeux (PD, MP, BoS, RPS, Asym) et compare l'ensemble des equilibres au SupportEnumeration from-scratch : 5/5 concordent (ecart max 3.3e-07, exploitabilite 0). RunGambit (cell 25) : resolution portable du binaire (GAMBIT_DIR, Program Files (x86), %USERPROFILE%\\gambit) pour reproductibilite sans elevation UAC. Bridge_verdict RECOVERABLE-LOCAL -> SOTA-OK (pont reellement execute)."
     - "2026-08-11 : C.4 enrichment du twin C# (2 cellules markdown interpretation apres les outputs Nash pur §2.1 + Nash mixte) pour egaler la densite pedagogique du twin Python (qui fournit deja ces lectures aux memes positions). Markdown-only, aucun changement d'engine/outputs. Parite semantique preservee (meme theorie, meme interpretation conceptuelle). Attestation rebaselinee par myia-po-2023:CoursIA-2 apres arbitrage ai-01 (DM 2026-08-11) — la PR jumelle #10351 (doublon) est retiree, #10352 est le canonique."
     - "Socle pedagogique commun : calcul des equilibres de Nash (purs + mixtes), meilleure reponse, support des equilibres mixtes."
     - "Idiomes framework : Python = `nashpy` + `scipy.optimize.linprog` (resolution des mixtes via programmation lineaire). C# = `BestResponseRow` from-scratch (enumeration des meilleures reponses en pur Linq, pas de solveur LP externe)."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-dotnet #11037

## Summary

Tranche 3 GT-4 NashEquilibrium — **pont nashpy CLI** sur le jumeau C# (parité lib-vs-lib #10382).

Le jumeau C# (`GameTheory-4-NashEquilibrium-Csharp.ipynb`) invoque désormais **nashpy** — le moteur SOTA du jumeau Python (`nash.Game(A,B).support_enumeration()`) — via un pont `Process.Start` (axe CLI de la checklist #10459), sur les **5 jeux canoniques** (Dilemme du Prisonnier, Matching Pennies, Bataille des Sexes, Pierre-Feuille-Ciseaux, Asymétrique 3x2). Le résultat est comparé **par ensemble d'équilibres** au `SupportEnumeration` from-scratch de la section 4, avec calcul d'exploitabilité pour chaque profil.

**Résultat : 5/5 jeux concordent** (écart max 3.3e-07, exploitabilité = 0 partout — premier principe de Nash vérifié). BoS : nashpy retrouve 3 NE (2 purs + mixte 2/3,1/3) ; RPS : équilibre uniforme (1/3,1/3,1/3) ; Asym 3x2 : 2 NE mixtes — identiques au twin Python (même moteur nashpy).

**En plus** : `RunGambit` (cell 25) gagne une **résolution portable du binaire** (variable d'env `GAMBIT_DIR` → `C:\Program Files (x86)\Gambit\` → `%USERPROFILE%\gambit\`), pour reproductibilité sans élévation UAC — même pattern que `FindPythonWithNashpy`.

## Axes binding (#10459)

- **Axe 1 (NuGet)** : aucun binding .NET/NuGet — N/A
- **Axe 2 (P/Invoke)** : aucun — N/A
- **Axe 3 (CLI `Process.Start`)** : **utilisé** — invocation `python.exe` + script nashpy temporaire + parsing JSON (même schéma que le pont Gambit 6.2 et la tranche GT-2 #11055)
- **Axe 4 (IKVM)** : aucun — N/A
- **Axe 5 (PythonNet)** : aucun — N/A
- **Axe 6 (lib équivalente)** : nashpy = lib Python SOTA du twin Python ; même rôle que le from-scratch BCL (support enumeration pour les NE purs et mixtes)

## Validation

- **Papermill end-to-end** (`-k .net-csharp`) : 38/38 cellules, 17 code cells, **0 erreur** — les cellules Gambit 6.2 ré-exécutées avec `gambit-lcp`/`gambit-enummixed` réels (exit=0)
- **`validate_pr_notebooks.py origin/main`** : `passed: True`, `forensic_verdict: EXEC_PROVED`
- **Pre-commit H.3** : `Passed` (aucun notebook non-exécuté)
- **Normalisations** : `strip_probe_banner` (9 lignes), `scrub_papermill_paths` (0), pas de CRLF churn (blobs LF)
- **Sortie du pont (cellule 6.3, reproduite telle quelle)** :

```
=== Pont nashpy : SupportEnumeration from-scratch (BCL .NET) vs nashpy (python.exe) ===
  nashpy [0.000,1.000] [0.000,1.000] -> exploitabilite=0.000000
  from-scratch: 1 NE | nashpy: 1 NE -> CORRESPOND (ecart max 0)
  nashpy [0.500,0.500] [0.500,0.500] -> exploitabilite=0.000000
  from-scratch: 1 NE | nashpy: 1 NE -> CORRESPOND (ecart max 0)
  nashpy [1.000,0.000] [1.000,0.000] -> exploitabilite=0.000000
  nashpy [0.000,1.000] [0.000,1.000] -> exploitabilite=0.000000
  nashpy [0.667,0.333] [0.333,0.667] -> exploitabilite=0.000001
  from-scratch: 3 NE | nashpy: 3 NE -> CORRESPOND (ecart max 3.33E-07)
  nashpy [0.333,0.333,0.333] [0.333,0.333,0.333] -> exploitabilite=0.000000
  from-scratch: 1 NE | nashpy: 1 NE -> CORRESPOND (ecart max 3.33E-07)
  nashpy [0.750,0.250,0.000] [0.500,0.500] -> exploitabilite=0.000000
  nashpy [-0.000,0.250,0.750] [0.500,0.500] -> exploitabilite=0.000000
  from-scratch: 2 NE | nashpy: 2 NE -> CORRESPOND (ecart max 0)

>>> Bilan : 5/5 jeux concordent. L'oracle SOTA nashpy (moteur du twin Python)
    valide le SupportEnumeration from-scratch : les deux implementent la meme notion d'equilibre de Nash.
```

## Registry twin_pairs

`scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml` :
- `bridge_verdict: RECOVERABLE-LOCAL` → **`SOTA-OK`** (pont réellement exécuté)
- `parity_level: semantic` **conservée** (même convention que les jumeaux part-2 et GT-4)
- Nouvelle entrée d'audit : 2026-08-15, `myia-po-2026:CoursIA-2` (rebaseline via `check_twin_parity.py --update`, SHA blob post-commit)
- `check_twin_parity.py --check` : **157/157 OK, 0 drift**

## Files

| Fichier | Changement |
|---------|-----------|
| `MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb` | +2 cellules (markdown §6.3 + pont nashpy CLI), résolution portable du binaire Gambit (cell 25), re-exécution complète |
| `scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml` | verdict SOTA-OK + audit + known_differences |

See #10382
