### PR TITLE
fix(ml,#11044): ML-4-Evaluation identifiant C# accentue (Difference) + re-exec kernel Roslyn 4.13

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
@@ -5,10 +5,10 @@
    "id": "5b0e76a5",
    "metadata": {
     "papermill": {
-     "duration": 0.006762,
-     "end_time": "2026-02-23T11:39:39.079796",
+     "duration": 0.008572,
+     "end_time": "2026-08-15T14:05:19.370540+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:39.073034",
+     "start_time": "2026-08-15T14:05:19.361968+00:00",
      "status": "completed"
     },
     "tags": []
@@ -57,7 +57,9 @@
     "## Comment évaluer un modèle dans ML.NET\n",
     "\n",
     "### Importation du package Nuget ML.NET"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -68,16 +70,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:39.110341Z",
-     "iopub.status.busy": "2026-02-23T11:39:39.104293Z",
-     "iopub.status.idle": "2026-02-23T11:39:47.179904Z",
-     "shell.execute_reply": "2026-02-23T11:39:47.176898Z"
+     "iopub.execute_input": "2026-08-15T14:05:19.401240Z",
+     "iopub.status.busy": "2026-08-15T14:05:19.393066Z",
+     "iopub.status.idle": "2026-08-15T14:05:23.878799Z",
+     "shell.execute_reply": "2026-08-15T14:05:23.874771Z"
     },
     "papermill": {
-     "duration": 8.088347,
-     "end_time": "2026-02-23T11:39:47.179904",
+     "duration": 4.49979,
+     "end_time": "2026-08-15T14:05:23.879249+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:39.091557",
+     "start_time": "2026-08-15T14:05:19.379459+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -87,52 +89,177 @@
    },
    "outputs": [
     {
-     "output_type": "display_data",
      "data": {
-      "text/html": "<div><div><strong>Restore sources</strong><ul><li><span>https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json</span></li></ul></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.Data.Analysis</span></li><li><span>Microsoft.ML</span></li><li><span>Microsoft.ML.AutoML</span></li></ul></div><div></div></div>"
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '89288.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `~\\.nuget\\packages\\microsoft.ml.automl\\0.23.0\\interactive-extensions\\dotnet\\Microsoft.ML.AutoML.Interactive.dll`"
+      "text/html": [
+       "<div><div><strong>Restore sources</strong><ul><li><span>https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json</span></li></ul></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.CodeAnalysis.CSharp, 4.13.0</span></li><li><span>Microsoft.Data.Analysis, 0.23.0</span></li><li><span>Microsoft.ML, 5.0.0</span></li><li><span>Microsoft.ML.AutoML, 0.23.0</span></li></ul></div></div>"
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `~\\.nuget\\packages\\microsoft.data.analysis\\0.23.0\\interactive-extensions\\dotnet\\Microsoft.Data.Analysis.Interactive.dll`"
+      "text/plain": [
+       
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "display_data",
      "data": {
-      "text/plain": "Loading extensions from `~\\.nuget\\packages\\skiasharp\\2.88.8\\interactive-extensions\\dotnet\\SkiaSharp.DotNet.Interactive.dll`"
+      "text/plain": [
+       
+      ]
      },
-     "metadata": {}
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
-   "source": "#i \"nuget:https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json\"\n\n#r \"nuget: Microsoft.ML, 5.0.0\"\n#r \"nuget: Microsoft.ML.AutoML, 0.23.0\"\n#r \"nuget: Microsoft.Data.Analysis, 0.23.0\""
+   "source": "#i \"nuget:https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json\"\n\n#r \"nuget: Microsoft.ML, 5.0.0\"\n#r \"nuget: Microsoft.ML.AutoML, 0.23.0\"\n#r \"nuget: Microsoft.CodeAnalysis.CSharp, 4.13.0\"\n#r \"nuget: Microsoft.Data.Analysis, 0.23.0\""
   },
   {
    "cell_type": "markdown",
    "id": "f26c3777",
    "metadata": {
     "papermill": {
-     "duration": 0.007966,
-     "end_time": "2026-02-23T11:39:47.194885",
+     "duration": 0.0075,
+     "end_time": "2026-08-15T14:05:23.894329+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:47.186919",
+     "start_time": "2026-08-15T14:05:23.886829+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "### Référencer les packages avec des instructions `using`\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -143,16 +270,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:47.210114Z",
-     "iopub.status.busy": "2026-02-23T11:39:47.209114Z",
-     "iopub.status.idle": "2026-02-23T11:39:47.221475Z",
-     "shell.execute_reply": "2026-02-23T11:39:47.221475Z"
+     "iopub.execute_input": "2026-08-15T14:05:23.911629Z",
+     "iopub.status.busy": "2026-08-15T14:05:23.911415Z",
+     "iopub.status.idle": "2026-08-15T14:05:23.926117Z",
+     "shell.execute_reply": "2026-08-15T14:05:23.925969Z"
     },
     "papermill": {
-     "duration": 0.01959,
-     "end_time": "2026-02-23T11:39:47.221475",
+     "duration": 0.023972,
+     "end_time": "2026-08-15T14:05:23.926188+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:47.201885",
+     "start_time": "2026-08-15T14:05:23.902216+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -176,10 +303,10 @@
    "id": "08a04170",
    "metadata": {
     "papermill": {
-     "duration": 0.00652,
-     "end_time": "2026-02-23T11:39:47.235059",
+     "duration": 0.007488,
+     "end_time": "2026-08-15T14:05:23.942274+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:47.228539",
+     "start_time": "2026-08-15T14:05:23.934786+00:00",
      "status": "completed"
     },
     "tags": []
@@ -188,7 +315,9 @@
     "### Télécharger ou localiser les données\n",
     "\n",
     "Le code suivant essaie de localiser le fichier de données à quelques emplacements connus ou le télécharge à partir de l'emplacement GitHub connu.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -199,16 +328,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:47.249911Z",
-     "iopub.status.busy": "2026-02-23T11:39:47.249911Z",
-     "iopub.status.idle": "2026-02-23T11:39:52.614136Z",
-     "shell.execute_reply": "2026-02-23T11:39:52.614136Z"
+     "iopub.execute_input": "2026-08-15T14:05:23.959913Z",
+     "iopub.status.busy": "2026-08-15T14:05:23.959661Z",
+     "iopub.status.idle": "2026-08-15T14:05:29.958137Z",
+     "shell.execute_reply": "2026-08-15T14:05:29.958255Z"
     },
     "papermill": {
-     "duration": 5.372898,
-     "end_time": "2026-02-23T11:39:52.615139",
+     "duration": 6.008191,
+     "end_time": "2026-08-15T14:05:29.958328+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:47.242241",
+     "start_time": "2026-08-15T14:05:23.950137+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -218,9 +347,20 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "taxi-fare.csv found in the notebook data folder\n"
+     "output_type": "stream",
+     "text": [
+      "taxi-fare.csv found in the notebook data folder\r\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(19,29): warning SYSLIB0014: 'WebClient.WebClient()' est obsolète : 'WebRequest, HttpWebRequest, ServicePoint, and WebClient are obsolete. Use HttpClient instead.' (https://aka.ms/dotnet-warnings/SYSLIB0014)\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -266,17 +406,19 @@
    "id": "4a4f7647",
    "metadata": {
     "papermill": {
-     "duration": 0.007787,
-     "end_time": "2026-02-23T11:39:52.630975",
+     "duration": 0.00819,
+     "end_time": "2026-08-15T14:05:29.974277+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:52.623188",
+     "start_time": "2026-08-15T14:05:29.966087+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "Une fois les données chargées, utilisez la méthode `Head` pour prévisualiser les cinq premières lignes.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -287,16 +429,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:52.648810Z",
-     "iopub.status.busy": "2026-02-23T11:39:52.648810Z",
-     "iopub.status.idle": "2026-02-23T11:39:52.840474Z",
-     "shell.execute_reply": "2026-02-23T11:39:52.840474Z"
+     "iopub.execute_input": "2026-08-15T14:05:29.993503Z",
+     "iopub.status.busy": "2026-08-15T14:05:29.993282Z",
+     "iopub.status.idle": "2026-08-15T14:05:30.173038Z",
+     "shell.execute_reply": "2026-08-15T14:05:30.172876Z"
     },
     "papermill": {
-     "duration": 0.201412,
-     "end_time": "2026-02-23T11:39:52.840474",
+     "duration": 0.18989,
+     "end_time": "2026-08-15T14:05:30.173116+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:52.639062",
+     "start_time": "2026-08-15T14:05:29.983226+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -306,12 +448,45 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/html": "<table id=\"table_639156665017069244\"><thead><tr><th><i>index</i></th><th>vendor_id</th><th>rate_code</th><th>passenger_count</th><th>trip_time_in_secs</th><th>trip_distance</th><th>payment_type</th><th>fare_amount</th></tr></thead><tbody><tr><td><i><div class=\"dni-plaintext\"><pre>0</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1271</pre></div></td><td><div class=\"dni-plaintext\"><pre>3.8</pre></div></td><td>CRD</td><td><div class=\"dni-plaintext\"><pre>17.5</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>1</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>474</pre></div></td><td><div class=\"dni-plaintext\"><pre>1.5</pre></div></td><td>CRD</td><td><div class=\"dni-plaintext\"><pre>8</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>2</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>637</pre></div></td><td><div class=\"dni-plaintext\"><pre>1.4</pre></div></td><td>CRD</td><td><div class=\"dni-plaintext\"><pre>8.5</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>3</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>181</pre></div></td><td><div class=\"dni-plaintext\"><pre>0.6</pre></div></td><td>CSH</td><td><div class=\"dni-plaintext\"><pre>4.5</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>4</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>661</pre></div></td><td><div class=\"dni-plaintext\"><pre>1.1</pre></div></td><td>CRD</td><td><div class=\"dni-plaintext\"><pre>8.5</pre></div></td></tr></tbody></table><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
+      "text/html": [
+       "<table id=\"table_639224067301322380\"><thead><tr><th><i>index</i></th><th>vendor_id</th><th>rate_code</th><th>passenger_count</th><th>trip_time_in_secs</th><th>trip_distance</th><th>payment_type</th><th>fare_amount</th></tr></thead><tbody><tr><td><i><div class=\"dni-plaintext\"><pre>0</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1271</pre></div></td><td><div class=\"dni-plaintext\"><pre>3.8</pre></div></td><td>CRD</td><td><div class=\"dni-plaintext\"><pre>17.5</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>1</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>474</pre></div></td><td><div class=\"dni-plaintext\"><pre>1.5</pre></div></td><td>CRD</td><td><div class=\"dni-plaintext\"><pre>8</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>2</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>637</pre></div></td><td><div class=\"dni-plaintext\"><pre>1.4</pre></div></td><td>CRD</td><td><div class=\"dni-plaintext\"><pre>8.5</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>3</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>181</pre></div></td><td><div class=\"dni-plaintext\"><pre>0.6</pre></div></td><td>CSH</td><td><div class=\"dni-plaintext\"><pre>4.5</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>4</pre></div></i></td><td>CMT</td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>1</pre></div></td><td><div class=\"dni-plaintext\"><pre>661</pre></div></td><td><div class=\"dni-plaintext\"><pre>1.1</pre></div></td><td>CRD</td><td><div class=\"dni-plaintext\"><pre>8.5</pre></div></td></tr></tbody></table><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
      },
+     "execution_count": 4,
      "metadata": {},
-     "execution_count": 4
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -323,10 +498,10 @@
    "id": "f5059723",
    "metadata": {
     "papermill": {
-     "duration": 0.008282,
-     "end_time": "2026-02-23T11:39:52.856927",
+     "duration": 0.008368,
+     "end_time": "2026-08-15T14:05:30.189521+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:52.848645",
+     "start_time": "2026-08-15T14:05:30.181153+00:00",
      "status": "completed"
     },
     "tags": []
@@ -335,7 +510,9 @@
     "### Initialiser MLContext\n",
     "\n",
     "Toutes les opérations ML.NET commencent par la classe [MLContext](https://docs.microsoft.com/dotnet/api/microsoft.ml.mlcontext). Initialiser `mlContext` crée un nouvel environnement ML.NET qui peut être partagé entre les objets du workflow de création de modèles. C'est similaire, conceptuellement, à `DBContext` dans Entity Framework.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -346,16 +523,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:52.874535Z",
-     "iopub.status.busy": "2026-02-23T11:39:52.874535Z",
-     "iopub.status.idle": "2026-02-23T11:39:52.905147Z",
-     "shell.execute_reply": "2026-02-23T11:39:52.904603Z"
+     "iopub.execute_input": "2026-08-15T14:05:30.208323Z",
+     "iopub.status.busy": "2026-08-15T14:05:30.208103Z",
+     "iopub.status.idle": "2026-08-15T14:05:30.245969Z",
+     "shell.execute_reply": "2026-08-15T14:05:30.245810Z"
     },
     "papermill": {
-     "duration": 0.040029,
-     "end_time": "2026-02-23T11:39:52.905147",
+     "duration": 0.047845,
+     "end_time": "2026-08-15T14:05:30.246051+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:52.865118",
+     "start_time": "2026-08-15T14:05:30.198206+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -373,10 +550,10 @@
    "id": "78e42ffd",
    "metadata": {
     "papermill": {
-     "duration": 0.007682,
-     "end_time": "2026-02-23T11:39:52.921997",
+     "duration": 0.007075,
+     "end_time": "2026-08-15T14:05:30.260731+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:52.914315",
+     "start_time": "2026-08-15T14:05:30.253656+00:00",
      "status": "completed"
     },
     "tags": []
@@ -393,7 +570,9 @@
     "Certains problèmes courants rencontrés pendant l'entraînement sont le surapprentissage et le sous-apprentissage. Le sous-apprentissage signifie que l'entraîneur sélectionné n'est pas assez puissant pour ajuster l'ensemble de données d'entraînement et se traduit généralement par une perte élevée pendant l'entraînement et une faible métrique sur l'ensemble de test. Pour résoudre cela, vous devez soit sélectionner un modèle plus puissant, soit effectuer plus d'ingénierie des caractéristiques. Le surapprentissage est l'opposé, et se produit lorsque le modèle apprend trop bien les données d'entraînement. Cela se traduit généralement par une faible perte métrique pendant l'entraînement, mais une perte élevée sur l'ensemble de test.\n",
     "\n",
     "Une bonne analogie pour ces concepts est de réviser pour un examen. Disons que vous connaissez les questions et réponses à l'avance. Après avoir révisé, vous passez l'examen et obtenez un score parfait. Bonne nouvelle ! Cependant, lorsque vous repassez l'examen avec les questions réorganisées et légèrement reformulées, vous obtenez un score plus bas. Cela suggère que vous avez mémorisé les réponses et n'avez pas vraiment appris les concepts testés. C'est un exemple de surapprentissage. Le sous-apprentissage est le contraire, où les matériaux d'étude que vous avez reçus ne représentent pas fidèlement ce sur quoi vous êtes évalué lors de l'examen. En conséquence, vous devez deviner les réponses car vous n'avez pas assez de connaissances pour répondre correctement.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -404,16 +583,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:52.937444Z",
-     "iopub.status.busy": "2026-02-23T11:39:52.937444Z",
-     "iopub.status.idle": "2026-02-23T11:39:52.997679Z",
-     "shell.execute_reply": "2026-02-23T11:39:52.997679Z"
+     "iopub.execute_input": "2026-08-15T14:05:30.277431Z",
+     "iopub.status.busy": "2026-08-15T14:05:30.277253Z",
+     "iopub.status.idle": "2026-08-15T14:05:30.350773Z",
+     "shell.execute_reply": "2026-08-15T14:05:30.350576Z"
     },
     "papermill": {
-     "duration": 0.068561,
-     "end_time": "2026-02-23T11:39:52.997679",
+     "duration": 0.081875,
+     "end_time": "2026-08-15T14:05:30.350875+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:52.929118",
+     "start_time": "2026-08-15T14:05:30.269000+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -436,10 +615,10 @@
    "id": "706bc98d",
    "metadata": {
     "papermill": {
-     "duration": 0.00871,
-     "end_time": "2026-02-23T11:39:53.015046",
+     "duration": 0.0081,
+     "end_time": "2026-08-15T14:05:30.367541+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:53.006336",
+     "start_time": "2026-08-15T14:05:30.359441+00:00",
      "status": "completed"
     },
     "tags": []
@@ -454,7 +633,9 @@
     "- `Concatenate` prend toutes les caractéristiques et crée un vecteur de caractéristiques\n",
     "\n",
     "AutoML est utilisé pour définir une expérience de régression en utilisant la colonne `fare_amount` comme colonne à prédire ou colonne d'étiquette.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -465,16 +646,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:53.033166Z",
-     "iopub.status.busy": "2026-02-23T11:39:53.033166Z",
-     "iopub.status.idle": "2026-02-23T11:39:53.184023Z",
-     "shell.execute_reply": "2026-02-23T11:39:53.184023Z"
+     "iopub.execute_input": "2026-08-15T14:05:30.388474Z",
+     "iopub.status.busy": "2026-08-15T14:05:30.388001Z",
+     "iopub.status.idle": "2026-08-15T14:05:30.553525Z",
+     "shell.execute_reply": "2026-08-15T14:05:30.553361Z"
     },
     "papermill": {
-     "duration": 0.160479,
-     "end_time": "2026-02-23T11:39:53.184023",
+     "duration": 0.176129,
+     "end_time": "2026-08-15T14:05:30.553598+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:53.023544",
+     "start_time": "2026-08-15T14:05:30.377469+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -496,10 +677,10 @@
    "id": "4144fa49",
    "metadata": {
     "papermill": {
-     "duration": 0.007012,
-     "end_time": "2026-02-23T11:39:53.198694",
+     "duration": 0.00824,
+     "end_time": "2026-08-15T14:05:30.569605+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:53.191682",
+     "start_time": "2026-08-15T14:05:30.561365+00:00",
      "status": "completed"
     },
     "tags": []
@@ -520,7 +701,9 @@
     "\n",
     "Votre ensemble de données et ce que vous essayez d'atteindre influencent fortement votre sélection de métrique. Si vous avez des valeurs aberrantes dans votre ensemble de données, elles peuvent fausser vos prédictions. MAE, MSE et RMSE calculent la distance entre les points de données prédits et réels. Toutes ces mesures sont sensibles aux valeurs aberrantes, donc si vous avez des valeurs aberrantes dans votre ensemble de données, elles apparaîtront dans vos métriques. Le R-carré calcule la corrélation entre les valeurs réelles et préd\n",
     "ites. Cependant, à mesure que vous ajoutez plus de points de données, votre R-carré peut continuer à augmenter, donnant l'impression erronée qu'un modèle avec une valeur de R-carré élevée a de bonnes capacités prédictives. Le résultat d'une valeur élevée de R-carré peut parfois indiquer un surapprentissage.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -531,16 +714,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:53.214183Z",
-     "iopub.status.busy": "2026-02-23T11:39:53.214183Z",
-     "iopub.status.idle": "2026-02-23T11:39:53.282116Z",
-     "shell.execute_reply": "2026-02-23T11:39:53.282116Z"
+     "iopub.execute_input": "2026-08-15T14:05:30.588368Z",
+     "iopub.status.busy": "2026-08-15T14:05:30.588149Z",
+     "iopub.status.idle": "2026-08-15T14:05:30.649215Z",
+     "shell.execute_reply": "2026-08-15T14:05:30.649014Z"
     },
     "papermill": {
-     "duration": 0.07739,
-     "end_time": "2026-02-23T11:39:53.282116",
+     "duration": 0.071157,
+     "end_time": "2026-08-15T14:05:30.649295+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:53.204726",
+     "start_time": "2026-08-15T14:05:30.578138+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -563,17 +746,19 @@
    "id": "54ec8fad",
    "metadata": {
     "papermill": {
-     "duration": 0.006749,
-     "end_time": "2026-02-23T11:39:53.296833",
+     "duration": 0.00828,
+     "end_time": "2026-08-15T14:05:30.665532+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:53.290084",
+     "start_time": "2026-08-15T14:05:30.657252+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "### Exécuter l'expérience\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -584,16 +769,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:39:53.314189Z",
-     "iopub.status.busy": "2026-02-23T11:39:53.314189Z",
-     "iopub.status.idle": "2026-02-23T11:40:53.431270Z",
-     "shell.execute_reply": "2026-02-23T11:40:53.431270Z"
+     "iopub.execute_input": "2026-08-15T14:05:30.684018Z",
+     "iopub.status.busy": "2026-08-15T14:05:30.683786Z",
+     "iopub.status.idle": "2026-08-15T14:06:30.832738Z",
+     "shell.execute_reply": "2026-08-15T14:06:30.832489Z"
     },
     "papermill": {
-     "duration": 60.126278,
-     "end_time": "2026-02-23T11:40:53.431270",
+     "duration": 60.158837,
+     "end_time": "2026-08-15T14:06:30.832853+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:39:53.304992",
+     "start_time": "2026-08-15T14:05:30.674016+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -611,17 +796,19 @@
    "id": "a1ff55b5",
    "metadata": {
     "papermill": {
-     "duration": 0.016441,
-     "end_time": "2026-02-23T11:40:53.463349",
+     "duration": 0.014024,
+     "end_time": "2026-08-15T14:06:30.861513+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.446908",
+     "start_time": "2026-08-15T14:06:30.847489+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "### Voir les métriques d'évaluation du meilleur modèle\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -632,16 +819,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:40:53.494820Z",
-     "iopub.status.busy": "2026-02-23T11:40:53.493315Z",
-     "iopub.status.idle": "2026-02-23T11:40:53.543207Z",
-     "shell.execute_reply": "2026-02-23T11:40:53.543207Z"
+     "iopub.execute_input": "2026-08-15T14:06:30.891010Z",
+     "iopub.status.busy": "2026-08-15T14:06:30.890689Z",
+     "iopub.status.idle": "2026-08-15T14:06:30.962591Z",
+     "shell.execute_reply": "2026-08-15T14:06:30.962463Z"
     },
     "papermill": {
-     "duration": 0.064485,
-     "end_time": "2026-02-23T11:40:53.543207",
+     "duration": 0.08713,
+     "end_time": "2026-08-15T14:06:30.962657+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.478722",
+     "start_time": "2026-08-15T14:06:30.875527+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -651,12 +838,14 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "R-Squared: 0,9488874535601417"
+      "text/plain": [
+       "R-Squared: 0,9467715191232398"
+      ]
      },
+     "execution_count": 10,
      "metadata": {},
-     "execution_count": 10
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -668,10 +857,10 @@
    "id": "9fd0ecfc",
    "metadata": {
     "papermill": {
-     "duration": 0.010086,
-     "end_time": "2026-02-23T11:40:53.561577",
+     "duration": 0.007301,
+     "end_time": "2026-08-15T14:06:30.977412+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.551491",
+     "start_time": "2026-08-15T14:06:30.970111+00:00",
      "status": "completed"
     },
     "tags": []
@@ -680,7 +869,9 @@
     "Notez que pendant l'entraînement, les métriques d'évaluation ont été calculées en utilisant l'ensemble de validation. Pour voir comment votre modèle performe sur de nouvelles données, évaluez ses performances par rapport à l'ensemble de test.\n",
     "\n",
     "Commencez par obtenir le meilleur modèle en utilisant la propriété `Model` des résultats d'entraînement. Ensuite, utilisez la méthode `Transform` pour utiliser le modèle afin de faire des prédictions sur l'ensemble de test.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -691,16 +882,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:40:53.583031Z",
-     "iopub.status.busy": "2026-02-23T11:40:53.582032Z",
-     "iopub.status.idle": "2026-02-23T11:40:53.599038Z",
-     "shell.execute_reply": "2026-02-23T11:40:53.599038Z"
+     "iopub.execute_input": "2026-08-15T14:06:30.994998Z",
+     "iopub.status.busy": "2026-08-15T14:06:30.994797Z",
+     "iopub.status.idle": "2026-08-15T14:06:31.025599Z",
+     "shell.execute_reply": "2026-08-15T14:06:31.025442Z"
     },
     "papermill": {
-     "duration": 0.027165,
-     "end_time": "2026-02-23T11:40:53.599038",
+     "duration": 0.040816,
+     "end_time": "2026-08-15T14:06:31.025692+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.571873",
+     "start_time": "2026-08-15T14:06:30.984876+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -719,17 +910,19 @@
    "id": "14b95b73",
    "metadata": {
     "papermill": {
-     "duration": 0.008626,
-     "end_time": "2026-02-23T11:40:53.616351",
+     "duration": 0.009369,
+     "end_time": "2026-08-15T14:06:31.044957+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.607725",
+     "start_time": "2026-08-15T14:06:31.035588+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "Inspectez les premières prédictions (colonne `Score`) et comparez-les avec la valeur réelle (colonne `fare_amount`). Ensuite, calculez la différence entre elles.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -740,16 +933,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:40:53.634013Z",
-     "iopub.status.busy": "2026-02-23T11:40:53.634013Z",
-     "iopub.status.idle": "2026-02-23T11:40:53.860571Z",
-     "shell.execute_reply": "2026-02-23T11:40:53.859563Z"
+     "iopub.execute_input": "2026-08-15T14:06:31.063851Z",
+     "iopub.status.busy": "2026-08-15T14:06:31.063638Z",
+     "iopub.status.idle": "2026-08-15T14:06:31.311026Z",
+     "shell.execute_reply": "2026-08-15T14:06:31.310895Z"
     },
     "papermill": {
-     "duration": 0.235664,
-     "end_time": "2026-02-23T11:40:53.860571",
+     "duration": 0.257373,
+     "end_time": "2026-08-15T14:06:31.311093+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.624907",
+     "start_time": "2026-08-15T14:06:31.053720+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -759,12 +952,45 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/html": "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 24,5, Predicted = 23,503351, Difference = 0,9966488 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>24.5</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>23.503351</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>0.9966488</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 9,5, Predicted = 9,1896, Difference = 0,3104 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>9.5</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>9.1896</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>0.3104</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 4,5, Predicted = 4,6393623, Difference = -0,13936234 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>4.5</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>4.6393623</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>-0.13936234</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 8, Predicted = 8,124863, Difference = -0,12486267 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>8</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>8.124863</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>-0.12486267</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 52, Predicted = 51,973503, Difference = 0,026496887 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>52</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>51.973503</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>0.026496887</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
+      "text/html": [
+       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 24,5, Predicted = 23,099466, Difference = 1,4005337 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>24.5</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>23.099466</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>1.4005337</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 9,5, Predicted = 9,19826, Difference = 0,3017397 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>9.5</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>9.19826</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>0.3017397</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 4,5, Predicted = 4,643051, Difference = -0,14305115 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>4.5</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>4.643051</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>-0.14305115</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 8, Predicted = 8,169264, Difference = -0,16926384 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>8</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>8.169264</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>-0.16926384</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>{ Actual = 52, Predicted = 52,01959, Difference = -0,01958847 }</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Actual</td><td><div class=\"dni-plaintext\"><pre>52</pre></div></td></tr><tr><td>Predicted</td><td><div class=\"dni-plaintext\"><pre>52.01959</pre></div></td></tr><tr><td>Difference</td><td><div class=\"dni-plaintext\"><pre>-0.01958847</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
      },
+     "execution_count": 12,
      "metadata": {},
-     "execution_count": 12
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -773,7 +999,7 @@
     "\n",
     "var compare = \n",
     "    actual\n",
-    "        .Zip(predicted, (actual, pred) => new { Actual = actual, Predicted = pred, Différence = actual - pred })\n",
+    "        .Zip(predicted, (actual, pred) => new { Actual = actual, Predicted = pred, Difference = actual - pred })\n",
     "        .Take(5);\n",
     "\n",
     "compare\n"
@@ -784,10 +1010,10 @@
    "id": "053c5f34",
    "metadata": {
     "papermill": {
-     "duration": 0.009939,
-     "end_time": "2026-02-23T11:40:53.880004",
+     "duration": 0.007652,
+     "end_time": "2026-08-15T14:06:31.326834+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.870065",
+     "start_time": "2026-08-15T14:06:31.319182+00:00",
      "status": "completed"
     },
     "tags": []
@@ -796,7 +1022,9 @@
     "Rien qu'en comparant rapidement les premières valeurs, vous pouvez voir que les prédictions sont généralement à quelques centimes près de la valeur réelle.\n",
     "\n",
     "Avec ML.NET, vous n'avez pas besoin de calculer manuellement les métriques d'évaluation pour vos modèles. ML.NET fournit une méthode intégrée `Evaluate` pour chacune des tâches de machine learning qu'il prend en charge. Utilisez la méthode `Evaluate` pour la tâche de régression afin de calculer les métriques d'évaluation pour l'ensemble de test où la colonne `fare_amount` est la valeur réelle et la colonne `Score` est la valeur prédite.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -807,16 +1035,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:40:53.899684Z",
-     "iopub.status.busy": "2026-02-23T11:40:53.899684Z",
-     "iopub.status.idle": "2026-02-23T11:40:53.977733Z",
-     "shell.execute_reply": "2026-02-23T11:40:53.977733Z"
+     "iopub.execute_input": "2026-08-15T14:06:31.345453Z",
+     "iopub.status.busy": "2026-08-15T14:06:31.345247Z",
+     "iopub.status.idle": "2026-08-15T14:06:32.292739Z",
+     "shell.execute_reply": "2026-08-15T14:06:32.292538Z"
     },
     "papermill": {
-     "duration": 0.088061,
-     "end_time": "2026-02-23T11:40:53.977733",
+     "duration": 0.95744,
+     "end_time": "2026-08-15T14:06:32.292833+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.889672",
+     "start_time": "2026-08-15T14:06:31.335393+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -834,17 +1062,19 @@
    "id": "e00ac822",
    "metadata": {
     "papermill": {
-     "duration": 0.00895,
-     "end_time": "2026-02-23T11:40:53.995743",
+     "duration": 0.010425,
+     "end_time": "2026-08-15T14:06:32.314151+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:53.986793",
+     "start_time": "2026-08-15T14:06:32.303726+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "L'utilisation de la méthode `Evaluate` permet non seulement de calculer la métrique que vous avez optimisée pendant l'entraînement (R-carré), mais aussi toutes les métriques pour la tâche de régression.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -855,16 +1085,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:40:54.016758Z",
-     "iopub.status.busy": "2026-02-23T11:40:54.016758Z",
-     "iopub.status.idle": "2026-02-23T11:40:54.044091Z",
-     "shell.execute_reply": "2026-02-23T11:40:54.043445Z"
+     "iopub.execute_input": "2026-08-15T14:06:32.335819Z",
+     "iopub.status.busy": "2026-08-15T14:06:32.335443Z",
+     "iopub.status.idle": "2026-08-15T14:06:32.380192Z",
+     "shell.execute_reply": "2026-08-15T14:06:32.380038Z"
     },
     "papermill": {
-     "duration": 0.038085,
-     "end_time": "2026-02-23T11:40:54.044091",
+     "duration": 0.056146,
+     "end_time": "2026-08-15T14:06:32.380266+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:54.006006",
+     "start_time": "2026-08-15T14:06:32.324120+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -874,12 +1104,45 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/html": "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>0.4124155992709455</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>5.416809747724624</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>2.327404079167308</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>5.4168097667531505</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.9413290291164368</pre></div></td></tr></tbody></table></div></details><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
+      "text/html": [
+       "<details open=\"open\" class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>0.43523297094362123</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>6.110091235432268</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>2.471859873745328</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>6.110091217692005</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.9338199047657995</pre></div></td></tr></tbody></table></div></details><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
      },
+     "execution_count": 14,
      "metadata": {},
-     "execution_count": 14
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -891,10 +1154,10 @@
    "id": "177de46c",
    "metadata": {
     "papermill": {
-     "duration": 0.009012,
-     "end_time": "2026-02-23T11:40:54.061744",
+     "duration": 0.007321,
+     "end_time": "2026-08-15T14:06:32.396061+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:54.052732",
+     "start_time": "2026-08-15T14:06:32.388740+00:00",
      "status": "completed"
     },
     "tags": []
@@ -915,7 +1178,9 @@
     "### Entraîner un modèle en utilisant la validation croisée\n",
     "\n",
     "Commencez par initialiser le `MLContext`.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -926,16 +1191,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:40:54.079533Z",
-     "iopub.status.busy": "2026-02-23T11:40:54.079533Z",
-     "iopub.status.idle": "2026-02-23T11:40:54.090190Z",
-     "shell.execute_reply": "2026-02-23T11:40:54.090190Z"
+     "iopub.execute_input": "2026-08-15T14:06:32.412524Z",
+     "iopub.status.busy": "2026-08-15T14:06:32.412321Z",
+     "iopub.status.idle": "2026-08-15T14:06:32.436032Z",
+     "shell.execute_reply": "2026-08-15T14:06:32.435872Z"
     },
     "papermill": {
-     "duration": 0.020343,
-     "end_time": "2026-02-23T11:40:54.090190",
+     "duration": 0.032672,
+     "end_time": "2026-08-15T14:06:32.436105+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:54.069847",
+     "start_time": "2026-08-15T14:06:32.403433+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -953,17 +1218,19 @@
    "id": "d101c926",
    "metadata": {
     "papermill": {
-     "duration": 0.007589,
-     "end_time": "2026-02-23T11:40:54.106308",
+     "duration": 0.007421,
+     "end_time": "2026-08-15T14:06:32.451705+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:54.098719",
+     "start_time": "2026-08-15T14:06:32.444284+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "Ensuite, définissez votre pipeline. Dans ce cas, l'entraîneur réel est utilisé au lieu de `SweepableEstimator` d'AutoML.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -974,16 +1241,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:40:54.122684Z",
-     "iopub.status.busy": "2026-02-23T11:40:54.122109Z",
-     "iopub.status.idle": "2026-02-23T11:40:54.163611Z",
-     "shell.execute_reply": "2026-02-23T11:40:54.162621Z"
+     "iopub.execute_input": "2026-08-15T14:06:32.467528Z",
+     "iopub.status.busy": "2026-08-15T14:06:32.467331Z",
+     "iopub.status.idle": "2026-08-15T14:06:32.522385Z",
+     "shell.execute_reply": "2026-08-15T14:06:32.522188Z"
     },
     "papermill": {
-     "duration": 0.050371,
-     "end_time": "2026-02-23T11:40:54.163611",
+     "duration": 0.063457,
+     "end_time": "2026-08-15T14:06:32.522455+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:54.113240",
+     "start_time": "2026-08-15T14:06:32.458998+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1005,17 +1272,19 @@
    "id": "3c4a2129",
    "metadata": {
     "papermill": {
-     "duration": 0.00903,
-     "end_time": "2026-02-23T11:40:54.181110",
+     "duration": 0.007254,
+     "end_time": "2026-08-15T14:06:32.537197+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:54.172080",
+     "start_time": "2026-08-15T14:06:32.529943+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "Utilisez la méthode `CrossValidate` pour démarrer l'entraînement et l'évaluation sur vos données en utilisant le pipeline défini. Par défaut, les données sont divisées en cinq sous-ensembles, mais vous pouvez définir cette valeur à n'importe quelle valeur de votre choix en utilisant le paramètre `numberOfFolds`.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1026,16 +1295,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:40:54.201982Z",
-     "iopub.status.busy": "2026-02-23T11:40:54.201982Z",
-     "iopub.status.idle": "2026-02-23T11:41:16.637578Z",
-     "shell.execute_reply": "2026-02-23T11:41:16.639113Z"
+     "iopub.execute_input": "2026-08-15T14:06:32.554052Z",
+     "iopub.status.busy": "2026-08-15T14:06:32.553867Z",
+     "iopub.status.idle": "2026-08-15T14:06:51.768237Z",
+     "shell.execute_reply": "2026-08-15T14:06:51.768085Z"
     },
     "papermill": {
-     "duration": 22.447281,
-     "end_time": "2026-02-23T11:41:16.639113",
+     "duration": 19.223506,
+     "end_time": "2026-08-15T14:06:51.768318+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:40:54.191832",
+     "start_time": "2026-08-15T14:06:32.544812+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1045,12 +1314,45 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/html": "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.3080861318665928</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.437064100433819</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.230644533283385</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.437063966978595</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8884018879298109</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.360165666717988</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.798742155503342</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.2861439645127146</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.798742212339462</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8850517190709868</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.2518280553341605</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>8.216770508755435</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>2.8664909748253935</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>8.216770540499184</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.9086191464533752</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.3420262660438258</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.229870802662239</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1984169213319014</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.229870780300226</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8886983637741152</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.5430782453416307</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.122911443078698</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1816523133552317</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.122911478082717</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.88835065401792</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
+      "text/html": [
+       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.3080861318665928</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.437064100433819</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.230644533283385</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.437063966978595</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8884018879298109</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.360165666717988</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.798742155503342</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.2861439645127146</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.798742212339462</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8850517190709868</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.2518280553341605</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>8.216770508755435</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>2.8664909748253935</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>8.216770540499184</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.9086191464533752</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.3420262660438258</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.229870802662239</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1984169213319014</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.229870780300226</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8886983637741152</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.5430782453416307</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.122911443078698</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1816523133552317</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.122911478082717</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.88835065401792</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
      },
+     "execution_count": 17,
      "metadata": {},
-     "execution_count": 17
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1064,10 +1366,10 @@
    "id": "6432643f",
    "metadata": {
     "papermill": {
-     "duration": 0.009554,
-     "end_time": "2026-02-23T11:41:16.658858",
+     "duration": 0.007618,
+     "end_time": "2026-08-15T14:06:51.785023+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:16.649304",
+     "start_time": "2026-08-15T14:06:51.777405+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1076,7 +1378,9 @@
     "### Calculer les métriques d'évaluation de l'ensemble de test\n",
     "\n",
     "Comme dans l'exemple précédent, utilisez la méthode `Evaluate` sur l'ensemble complet de test pour évaluer les performances des modèles entraînés en utilisant la validation croisée.\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1087,16 +1391,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:16.680424Z",
-     "iopub.status.busy": "2026-02-23T11:41:16.680424Z",
-     "iopub.status.idle": "2026-02-23T11:41:17.532009Z",
-     "shell.execute_reply": "2026-02-23T11:41:17.531416Z"
+     "iopub.execute_input": "2026-08-15T14:06:51.800714Z",
+     "iopub.status.busy": "2026-08-15T14:06:51.800535Z",
+     "iopub.status.idle": "2026-08-15T14:06:52.670485Z",
+     "shell.execute_reply": "2026-08-15T14:06:52.670273Z"
     },
     "papermill": {
-     "duration": 0.861963,
-     "end_time": "2026-02-23T11:41:17.532009",
+     "duration": 0.878312,
+     "end_time": "2026-08-15T14:06:52.670587+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:16.670046",
+     "start_time": "2026-08-15T14:06:51.792275+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1106,12 +1410,45 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/html": "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.2946164063640293</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>9.741100529118015</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1210736180228134</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>9.741100436339362</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8944318265394658</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.3517783571125017</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.697284288708751</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.270670311833455</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.697284293348838</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8840692835505208</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.258738437439045</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.056973626481687</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1712731869836897</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.056973680972417</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8910085843878911</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.3321059289142654</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.119475327642087</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1811122783771855</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.119475305281489</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8903312286404623</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.5373861941022984</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>11.21522705311926</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.3489143096112897</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>11.215227048598013</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.878456132199452</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
+      "text/html": [
+       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.2946164063640293</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>9.741100529118015</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1210736180228134</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>9.741100436339362</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8944318265394658</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.3517783571125017</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.697284288708751</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.270670311833455</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.697284293348838</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8840692835505208</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.258738437439045</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.056973626481687</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1712731869836897</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.056973680972417</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8910085843878911</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.3321059289142654</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>10.119475327642087</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.1811122783771855</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>10.119475305281489</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.8903312286404623</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>Microsoft.ML.Data.RegressionMetrics</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>MeanAbsoluteError</td><td><div class=\"dni-plaintext\"><pre>1.5373861941022984</pre></div></td></tr><tr><td>MeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>11.21522705311926</pre></div></td></tr><tr><td>RootMeanSquaredError</td><td><div class=\"dni-plaintext\"><pre>3.3489143096112897</pre></div></td></tr><tr><td>LossFunction</td><td><div class=\"dni-plaintext\"><pre>11.215227048598013</pre></div></td></tr><tr><td>RSquared</td><td><div class=\"dni-plaintext\"><pre>0.878456132199452</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
      },
+     "execution_count": 18,
      "metadata": {},
-     "execution_count": 18
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1126,7 +1463,16 @@
   {
    "cell_type": "markdown",
    "id": "4740fbd9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009983,
+     "end_time": "2026-08-15T14:06:52.692296+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:06:52.682313+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Lecture de la validation croisée : un estimateur plus honnête qu'un seul découpage\n",
     "\n",
@@ -1138,17 +1484,19 @@
     "L'écart est parlant : le découpage unique était **optimiste** d'environ 5 points de R² (0,94 vs 0,89) et sous-estimait l'erreur d'un facteur d'environ 3 sur le MAE (0,41 vs 1,35). Ce n'est pas que le modèle soit mauvais — il généralise correctement — mais le partage unique est tombé sur une partition favorable : un jeu de test « facile » et un sous-ensemble d'entraînement chanceux. La validation croisée, en moyennant sur cinq partitions distinctes de l'entraînement, lisse cet effet de chance : elle révèle la **performance typique** du modèle (R²≈0,89) **et sa variance** d'un fold à l'autre (le fold à MAE 1,54 correspond à la partition d'entraînement la plus défavorable).\n",
     "\n",
     "C'est précisément la leçon : **un seul découpage train/test est un estimateur à haute variance** — il peut atterrir loin de la véritable performance de généralisation, tantôt optimiste, tantôt pessimiste, selon le tirage. La validation croisée ne change pas le modèle ; elle fournit un **estimateur plus fiable** de cette performance, en exposant à la fois la tendance centrale et la dispersion. C'est pourquoi on ne conclut jamais sur la qualité d'un modèle à partir d'un unique `Evaluate`."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "id": "9d28d200",
    "metadata": {
     "papermill": {
-     "duration": 0.012161,
-     "end_time": "2026-02-23T11:41:17.555312",
+     "duration": 0.008941,
+     "end_time": "2026-08-15T14:06:52.711589+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.543151",
+     "start_time": "2026-08-15T14:06:52.702648+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1187,7 +1535,9 @@
     "\n",
     "#### Initialiser MLContext\n",
     "\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1198,16 +1548,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:17.586466Z",
-     "iopub.status.busy": "2026-02-23T11:41:17.586466Z",
-     "iopub.status.idle": "2026-02-23T11:41:17.605360Z",
-     "shell.execute_reply": "2026-02-23T11:41:17.604291Z"
+     "iopub.execute_input": "2026-08-15T14:06:52.731211Z",
+     "iopub.status.busy": "2026-08-15T14:06:52.730976Z",
+     "iopub.status.idle": "2026-08-15T14:06:52.767666Z",
+     "shell.execute_reply": "2026-08-15T14:06:52.767516Z"
     },
     "papermill": {
-     "duration": 0.036207,
-     "end_time": "2026-02-23T11:41:17.605360",
+     "duration": 0.046838,
+     "end_time": "2026-08-15T14:06:52.767734+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.569153",
+     "start_time": "2026-08-15T14:06:52.720896+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1225,17 +1575,19 @@
    "id": "41a0bc84",
    "metadata": {
     "papermill": {
-     "duration": 0.009328,
-     "end_time": "2026-02-23T11:41:17.622493",
+     "duration": 0.00879,
+     "end_time": "2026-08-15T14:06:52.784054+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.613165",
+     "start_time": "2026-08-15T14:06:52.775264+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Définir le pipeline de préparation des données\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1246,16 +1598,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:17.642969Z",
-     "iopub.status.busy": "2026-02-23T11:41:17.642459Z",
-     "iopub.status.idle": "2026-02-23T11:41:17.685251Z",
-     "shell.execute_reply": "2026-02-23T11:41:17.685251Z"
+     "iopub.execute_input": "2026-08-15T14:06:52.801648Z",
+     "iopub.status.busy": "2026-08-15T14:06:52.801426Z",
+     "iopub.status.idle": "2026-08-15T14:06:52.855777Z",
+     "shell.execute_reply": "2026-08-15T14:06:52.855632Z"
     },
     "papermill": {
-     "duration": 0.054681,
-     "end_time": "2026-02-23T11:41:17.685251",
+     "duration": 0.064133,
+     "end_time": "2026-08-15T14:06:52.855844+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.630570",
+     "start_time": "2026-08-15T14:06:52.791711+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1276,17 +1628,19 @@
    "id": "50a7c074",
    "metadata": {
     "papermill": {
-     "duration": 0.012888,
-     "end_time": "2026-02-23T11:41:17.707352",
+     "duration": 0.007779,
+     "end_time": "2026-08-15T14:06:52.871267+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.694464",
+     "start_time": "2026-08-15T14:06:52.863488+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Appliquer les transformations de données aux données d'entraînement\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1297,16 +1651,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:17.726912Z",
-     "iopub.status.busy": "2026-02-23T11:41:17.726912Z",
-     "iopub.status.idle": "2026-02-23T11:41:17.812188Z",
-     "shell.execute_reply": "2026-02-23T11:41:17.812188Z"
+     "iopub.execute_input": "2026-08-15T14:06:52.889879Z",
+     "iopub.status.busy": "2026-08-15T14:06:52.889649Z",
+     "iopub.status.idle": "2026-08-15T14:06:52.998806Z",
+     "shell.execute_reply": "2026-08-15T14:06:52.998558Z"
     },
     "papermill": {
-     "duration": 0.095481,
-     "end_time": "2026-02-23T11:41:17.812188",
+     "duration": 0.119004,
+     "end_time": "2026-08-15T14:06:52.998910+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.716707",
+     "start_time": "2026-08-15T14:06:52.879906+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1327,17 +1681,19 @@
    "id": "fd92d60d",
    "metadata": {
     "papermill": {
-     "duration": 0.007595,
-     "end_time": "2026-02-23T11:41:17.831562",
+     "duration": 0.007348,
+     "end_time": "2026-08-15T14:06:53.015193+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.823967",
+     "start_time": "2026-08-15T14:06:53.007845+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Définir votre entraîneur\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1348,16 +1704,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:17.849883Z",
-     "iopub.status.busy": "2026-02-23T11:41:17.849883Z",
-     "iopub.status.idle": "2026-02-23T11:41:17.877978Z",
-     "shell.execute_reply": "2026-02-23T11:41:17.877023Z"
+     "iopub.execute_input": "2026-08-15T14:06:53.031635Z",
+     "iopub.status.busy": "2026-08-15T14:06:53.031456Z",
+     "iopub.status.idle": "2026-08-15T14:06:53.067971Z",
+     "shell.execute_reply": "2026-08-15T14:06:53.067826Z"
     },
     "papermill": {
-     "duration": 0.037709,
-     "end_time": "2026-02-23T11:41:17.877978",
+     "duration": 0.045162,
+     "end_time": "2026-08-15T14:06:53.068037+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.840269",
+     "start_time": "2026-08-15T14:06:53.022875+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1375,17 +1731,19 @@
    "id": "058a2f62",
    "metadata": {
     "papermill": {
-     "duration": 0.013816,
-     "end_time": "2026-02-23T11:41:17.903622",
+     "duration": 0.007666,
+     "end_time": "2026-08-15T14:06:53.083691+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.889806",
+     "start_time": "2026-08-15T14:06:53.076025+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Ajuster l'entraîneur à vos données prétraitées\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1396,16 +1754,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:17.932980Z",
-     "iopub.status.busy": "2026-02-23T11:41:17.932980Z",
-     "iopub.status.idle": "2026-02-23T11:41:23.664115Z",
-     "shell.execute_reply": "2026-02-23T11:41:23.664115Z"
+     "iopub.execute_input": "2026-08-15T14:06:53.102686Z",
+     "iopub.status.busy": "2026-08-15T14:06:53.102455Z",
+     "iopub.status.idle": "2026-08-15T14:06:57.303570Z",
+     "shell.execute_reply": "2026-08-15T14:06:57.303418Z"
     },
     "papermill": {
-     "duration": 5.746875,
-     "end_time": "2026-02-23T11:41:23.664115",
+     "duration": 4.2111,
+     "end_time": "2026-08-15T14:06:57.303639+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:17.917240",
+     "start_time": "2026-08-15T14:06:53.092539+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1423,10 +1781,10 @@
    "id": "1c0c7c3b",
    "metadata": {
     "papermill": {
-     "duration": 0.009258,
-     "end_time": "2026-02-23T11:41:23.682097",
+     "duration": 0.007694,
+     "end_time": "2026-08-15T14:06:57.319110+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:23.672839",
+     "start_time": "2026-08-15T14:06:57.311416+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1436,7 +1794,9 @@
     "\n",
     "\n",
     "La PFI (Permutation Feature Importance) est une méthode d'explicabilité *agnostic* du modèle : elle mesure la dégradation d'une métrique d'évaluation lorsque l'on permute aléatoirement les valeurs d'une caractéristique, brisant ainsi sa relation avec l'étiquette. Formalisée par L. Breiman (*Random Forests*, Machine Learning, 45(1), 2001) dans le contexte des forêts aléatoires, elle a ensuite été généralisée à tout modèle prédictif."
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1447,16 +1807,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:23.704863Z",
-     "iopub.status.busy": "2026-02-23T11:41:23.704863Z",
-     "iopub.status.idle": "2026-02-23T11:41:43.976148Z",
-     "shell.execute_reply": "2026-02-23T11:41:43.977159Z"
+     "iopub.execute_input": "2026-08-15T14:06:57.335834Z",
+     "iopub.status.busy": "2026-08-15T14:06:57.335625Z",
+     "iopub.status.idle": "2026-08-15T14:07:22.508463Z",
+     "shell.execute_reply": "2026-08-15T14:07:22.508284Z"
     },
     "papermill": {
-     "duration": 20.283118,
-     "end_time": "2026-02-23T11:41:43.977159",
+     "duration": 25.181656,
+     "end_time": "2026-08-15T14:07:22.508557+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:23.694041",
+     "start_time": "2026-08-15T14:06:57.326901+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1466,9 +1826,13 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stderr",
-     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'System.Collections.Immutable, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Microsoft.ML.Transforms' correspond à l'identité 'System.Collections.Immutable, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Collections.Immutable', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "warning CS1701: En supposant que la référence d'assembly 'System.Collections.Immutable, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' utilisée par 'Microsoft.ML.Transforms' correspond à l'identité 'System.Collections.Immutable, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' de 'System.Collections.Immutable', il se peut que vous deviez fournir une stratégie runtime\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -1483,17 +1847,19 @@
    "id": "12b9fbb4",
    "metadata": {
     "papermill": {
-     "duration": 0.011155,
-     "end_time": "2026-02-23T11:41:43.999568",
+     "duration": 0.010717,
+     "end_time": "2026-08-15T14:07:22.530608+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:43.988413",
+     "start_time": "2026-08-15T14:07:22.519891+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Extraire la métrique du R-carré\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1504,16 +1870,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:44.026579Z",
-     "iopub.status.busy": "2026-02-23T11:41:44.026579Z",
-     "iopub.status.idle": "2026-02-23T11:41:44.065357Z",
-     "shell.execute_reply": "2026-02-23T11:41:44.065357Z"
+     "iopub.execute_input": "2026-08-15T14:07:22.553669Z",
+     "iopub.status.busy": "2026-08-15T14:07:22.553312Z",
+     "iopub.status.idle": "2026-08-15T14:07:22.609163Z",
+     "shell.execute_reply": "2026-08-15T14:07:22.609011Z"
     },
     "papermill": {
-     "duration": 0.054624,
-     "end_time": "2026-02-23T11:41:44.065357",
+     "duration": 0.068388,
+     "end_time": "2026-08-15T14:07:22.609236+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.010733",
+     "start_time": "2026-08-15T14:07:22.540848+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1534,17 +1900,19 @@
    "id": "acd67ed2",
    "metadata": {
     "papermill": {
-     "duration": 0.007576,
-     "end_time": "2026-02-23T11:41:44.087105",
+     "duration": 0.00752,
+     "end_time": "2026-08-15T14:07:22.624735+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.079529",
+     "start_time": "2026-08-15T14:07:22.617215+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Obtenir la liste des noms de caractéristiques\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1555,16 +1923,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:44.107101Z",
-     "iopub.status.busy": "2026-02-23T11:41:44.106057Z",
-     "iopub.status.idle": "2026-02-23T11:41:44.129620Z",
-     "shell.execute_reply": "2026-02-23T11:41:44.129620Z"
+     "iopub.execute_input": "2026-08-15T14:07:22.643118Z",
+     "iopub.status.busy": "2026-08-15T14:07:22.642947Z",
+     "iopub.status.idle": "2026-08-15T14:07:22.683340Z",
+     "shell.execute_reply": "2026-08-15T14:07:22.683185Z"
     },
     "papermill": {
-     "duration": 0.031999,
-     "end_time": "2026-02-23T11:41:44.129620",
+     "duration": 0.049623,
+     "end_time": "2026-08-15T14:07:22.683415+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.097621",
+     "start_time": "2026-08-15T14:07:22.633792+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1585,17 +1953,19 @@
    "id": "46988648",
    "metadata": {
     "papermill": {
-     "duration": 0.008317,
-     "end_time": "2026-02-23T11:41:44.146677",
+     "duration": 0.009921,
+     "end_time": "2026-08-15T14:07:22.702728+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.138360",
+     "start_time": "2026-08-15T14:07:22.692807+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Mapper les métriques PFI aux noms des caractéristiques\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1606,16 +1976,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:44.165357Z",
-     "iopub.status.busy": "2026-02-23T11:41:44.165357Z",
-     "iopub.status.idle": "2026-02-23T11:41:44.205893Z",
-     "shell.execute_reply": "2026-02-23T11:41:44.205893Z"
+     "iopub.execute_input": "2026-08-15T14:07:22.725747Z",
+     "iopub.status.busy": "2026-08-15T14:07:22.725510Z",
+     "iopub.status.idle": "2026-08-15T14:07:22.800477Z",
+     "shell.execute_reply": "2026-08-15T14:07:22.800289Z"
     },
     "papermill": {
-     "duration": 0.049999,
-     "end_time": "2026-02-23T11:41:44.205893",
+     "duration": 0.087157,
+     "end_time": "2026-08-15T14:07:22.800555+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.155894",
+     "start_time": "2026-08-15T14:07:22.713398+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1625,12 +1995,45 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/html": "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit2, -0,5103508254402551]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit2</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.5103508254402551</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit1, -0,20923841161114132]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit1</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.20923841161114132</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit0, -0,20470878841136267]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit0</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.20470878841136267</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit3, -0,0014126662799672784]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit3</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.0014126662799672784</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit2, -0,0005285504836719893]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit2</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.0005285504836719893</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>5</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit1, -0,0001546585109772162]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit1</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.0001546585109772162</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>6</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit0, -6,582229674127286E-05]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit0</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-6.582229674127286E-05</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>7</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[rate_code, -5,435025046314953E-07]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>rate_code</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-5.435025046314953E-07</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>8</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[passenger_count, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>passenger_count</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>9</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[trip_time_in_secs, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>trip_time_in_secs</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>10</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[trip_distance, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>trip_distance</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
+      "text/html": [
+       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit2, -0,5100808487782473]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit2</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.5100808487782473</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit1, -0,20987169364067856]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit1</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.20987169364067856</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit0, -0,20546002909005304]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit0</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.20546002909005304</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit3, -0,0014001551106580523]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit3</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.0014001551106580523</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit2, -0,0005281363838295361]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit2</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.0005281363838295361</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>5</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit1, -0,00014620220801375705]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit1</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-0.00014620220801375705</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>6</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit0, -7,081833250196141E-05]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit0</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-7.081833250196141E-05</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>7</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[rate_code, -6,053433927085313E-07]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>rate_code</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-6.053433927085313E-07</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>8</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[passenger_count, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>passenger_count</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>9</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[trip_time_in_secs, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>trip_time_in_secs</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>10</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[trip_distance, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>trip_distance</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
      },
+     "execution_count": 27,
      "metadata": {},
-     "execution_count": 27
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1645,17 +2048,28 @@
    "cell_type": "markdown",
    "id": "b416346a",
    "source": "### Interprétation — lire les résultats de la PFI\n\nL'exécution ci-dessus produit un classement de chaque *slot* par valeur absolue de `RSquared.Mean` décroissante. Deux observations méritent un commentaire :\n\n- **Les variables catégorielles sont éclatées en bits.** `vendor_id` et `payment_type`, encodées en *One-Hot*, apparaissent sous la forme `vendor_id.Bit0`, `vendor_id.Bit1`, etc. : chaque bit est évalué séparément. Les variables continues (`trip_distance`, `trip_time_in_secs`) et ordinales (`passenger_count`, `rate_code`) gardent leur nom d'origine.\n- **Une valeur négative est attendue.** Comme la PFI mesure la *dégradation* du R² lorsqu'on permute la caractéristique, `RSquared.Mean` est presque toujours négatif : plus elle est négative (en valeur absolue), plus la caractéristique est importante pour le modèle.\n\nSur ce petit jeu de données avec `permutationCount: 3`, le classement est **instable** : les bits de `vendor_id` dominent tandis que `trip_distance`, `trip_time_in_secs` et `passenger_count` apparaissent à `0` — ce qui heurte l'intuition (la distance est évidemment prédictive du tarif). Cette instabilité est précisément la limite d'un faible `permutationCount`. En production, on l'augmente (typiquement 10 à 30) pour stabiliser l'estimation, et l'on croise le résultat avec la décomposition **locale** de la FCC ci-après.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.01004,
+     "end_time": "2026-08-15T14:07:22.820933+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:22.810893+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "id": "f3a7dd27",
    "metadata": {
     "papermill": {
-     "duration": 0.012255,
-     "end_time": "2026-02-23T11:41:44.225932",
+     "duration": 0.01045,
+     "end_time": "2026-08-15T14:07:22.842205+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.213677",
+     "start_time": "2026-08-15T14:07:22.831755+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1664,7 +2078,9 @@
     "### Expliquer les modèles avec le calcul de la contribution des caractéristiques (FCC)\n",
     "\n",
     "#### Initialiser MLContext\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1675,16 +2091,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:44.242746Z",
-     "iopub.status.busy": "2026-02-23T11:41:44.241756Z",
-     "iopub.status.idle": "2026-02-23T11:41:44.251072Z",
-     "shell.execute_reply": "2026-02-23T11:41:44.251072Z"
+     "iopub.execute_input": "2026-08-15T14:07:22.863443Z",
+     "iopub.status.busy": "2026-08-15T14:07:22.863130Z",
+     "iopub.status.idle": "2026-08-15T14:07:22.892389Z",
+     "shell.execute_reply": "2026-08-15T14:07:22.892212Z"
     },
     "papermill": {
-     "duration": 0.018124,
-     "end_time": "2026-02-23T11:41:44.251072",
+     "duration": 0.040109,
+     "end_time": "2026-08-15T14:07:22.892472+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.232948",
+     "start_time": "2026-08-15T14:07:22.852363+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1702,17 +2118,19 @@
    "id": "da49ea4e",
    "metadata": {
     "papermill": {
-     "duration": 0.014028,
-     "end_time": "2026-02-23T11:41:44.278384",
+     "duration": 0.009802,
+     "end_time": "2026-08-15T14:07:22.911750+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.264356",
+     "start_time": "2026-08-15T14:07:22.901948+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Définir le pipeline de préparation des données\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1723,16 +2141,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:44.299549Z",
-     "iopub.status.busy": "2026-02-23T11:41:44.299549Z",
-     "iopub.status.idle": "2026-02-23T11:41:44.327077Z",
-     "shell.execute_reply": "2026-02-23T11:41:44.327077Z"
+     "iopub.execute_input": "2026-08-15T14:07:22.932715Z",
+     "iopub.status.busy": "2026-08-15T14:07:22.932447Z",
+     "iopub.status.idle": "2026-08-15T14:07:22.992373Z",
+     "shell.execute_reply": "2026-08-15T14:07:22.992024Z"
     },
     "papermill": {
-     "duration": 0.039983,
-     "end_time": "2026-02-23T11:41:44.328049",
+     "duration": 0.071041,
+     "end_time": "2026-08-15T14:07:22.992513+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.288066",
+     "start_time": "2026-08-15T14:07:22.921472+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1753,17 +2171,19 @@
    "id": "5671b7e5",
    "metadata": {
     "papermill": {
-     "duration": 0.014083,
-     "end_time": "2026-02-23T11:41:44.358135",
+     "duration": 0.012797,
+     "end_time": "2026-08-15T14:07:23.017385+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.344052",
+     "start_time": "2026-08-15T14:07:23.004588+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Appliquer les transformations de données aux données d'entraînement\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1774,16 +2194,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:44.375437Z",
-     "iopub.status.busy": "2026-02-23T11:41:44.375437Z",
-     "iopub.status.idle": "2026-02-23T11:41:44.486884Z",
-     "shell.execute_reply": "2026-02-23T11:41:44.486884Z"
+     "iopub.execute_input": "2026-08-15T14:07:23.040439Z",
+     "iopub.status.busy": "2026-08-15T14:07:23.040170Z",
+     "iopub.status.idle": "2026-08-15T14:07:23.154621Z",
+     "shell.execute_reply": "2026-08-15T14:07:23.154397Z"
     },
     "papermill": {
-     "duration": 0.120904,
-     "end_time": "2026-02-23T11:41:44.486884",
+     "duration": 0.126413,
+     "end_time": "2026-08-15T14:07:23.154719+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.365980",
+     "start_time": "2026-08-15T14:07:23.028306+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1804,17 +2224,19 @@
    "id": "8bb31f1a",
    "metadata": {
     "papermill": {
-     "duration": 0.011701,
-     "end_time": "2026-02-23T11:41:44.511459",
+     "duration": 0.010636,
+     "end_time": "2026-08-15T14:07:23.176385+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.499758",
+     "start_time": "2026-08-15T14:07:23.165749+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Définir votre entraîneur\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1825,16 +2247,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:44.533053Z",
-     "iopub.status.busy": "2026-02-23T11:41:44.532018Z",
-     "iopub.status.idle": "2026-02-23T11:41:44.552580Z",
-     "shell.execute_reply": "2026-02-23T11:41:44.552580Z"
+     "iopub.execute_input": "2026-08-15T14:07:23.199130Z",
+     "iopub.status.busy": "2026-08-15T14:07:23.198894Z",
+     "iopub.status.idle": "2026-08-15T14:07:23.241669Z",
+     "shell.execute_reply": "2026-08-15T14:07:23.241479Z"
     },
     "papermill": {
-     "duration": 0.031224,
-     "end_time": "2026-02-23T11:41:44.552580",
+     "duration": 0.05398,
+     "end_time": "2026-08-15T14:07:23.241756+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.521356",
+     "start_time": "2026-08-15T14:07:23.187776+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1852,17 +2274,19 @@
    "id": "d4ab4d5d",
    "metadata": {
     "papermill": {
-     "duration": 0.009506,
-     "end_time": "2026-02-23T11:41:44.571617",
+     "duration": 0.009588,
+     "end_time": "2026-08-15T14:07:23.261612+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.562111",
+     "start_time": "2026-08-15T14:07:23.252024+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Ajuster l'entraîneur à vos données prétraitées\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1873,16 +2297,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:44.593117Z",
-     "iopub.status.busy": "2026-02-23T11:41:44.592105Z",
-     "iopub.status.idle": "2026-02-23T11:41:49.797940Z",
-     "shell.execute_reply": "2026-02-23T11:41:49.797940Z"
+     "iopub.execute_input": "2026-08-15T14:07:23.283650Z",
+     "iopub.status.busy": "2026-08-15T14:07:23.283309Z",
+     "iopub.status.idle": "2026-08-15T14:07:29.291127Z",
+     "shell.execute_reply": "2026-08-15T14:07:29.290861Z"
     },
     "papermill": {
-     "duration": 5.21684,
-     "end_time": "2026-02-23T11:41:49.797940",
+     "duration": 6.019878,
+     "end_time": "2026-08-15T14:07:29.291231+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:44.581100",
+     "start_time": "2026-08-15T14:07:23.271353+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1900,17 +2324,19 @@
    "id": "18d80c0f",
    "metadata": {
     "papermill": {
-     "duration": 0.00936,
-     "end_time": "2026-02-23T11:41:49.817730",
+     "duration": 0.020353,
+     "end_time": "2026-08-15T14:07:29.329019+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:49.808370",
+     "start_time": "2026-08-15T14:07:29.308666+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Calculer les contributions des caractéristiques\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1921,16 +2347,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:49.839035Z",
-     "iopub.status.busy": "2026-02-23T11:41:49.839035Z",
-     "iopub.status.idle": "2026-02-23T11:41:49.863619Z",
-     "shell.execute_reply": "2026-02-23T11:41:49.863619Z"
+     "iopub.execute_input": "2026-08-15T14:07:29.351496Z",
+     "iopub.status.busy": "2026-08-15T14:07:29.351224Z",
+     "iopub.status.idle": "2026-08-15T14:07:29.424741Z",
+     "shell.execute_reply": "2026-08-15T14:07:29.424441Z"
     },
     "papermill": {
-     "duration": 0.036542,
-     "end_time": "2026-02-23T11:41:49.863619",
+     "duration": 0.084473,
+     "end_time": "2026-08-15T14:07:29.424847+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:49.827077",
+     "start_time": "2026-08-15T14:07:29.340374+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -1951,17 +2377,19 @@
    "id": "bfbfeaf9",
    "metadata": {
     "papermill": {
-     "duration": 0.007634,
-     "end_time": "2026-02-23T11:41:49.879756",
+     "duration": 0.011524,
+     "end_time": "2026-08-15T14:07:29.450616+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:49.872122",
+     "start_time": "2026-08-15T14:07:29.439092+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Obtenir la liste des noms de caractéristiques\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -1972,16 +2400,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:49.897335Z",
-     "iopub.status.busy": "2026-02-23T11:41:49.897335Z",
-     "iopub.status.idle": "2026-02-23T11:41:49.925256Z",
-     "shell.execute_reply": "2026-02-23T11:41:49.925256Z"
+     "iopub.execute_input": "2026-08-15T14:07:29.478499Z",
+     "iopub.status.busy": "2026-08-15T14:07:29.478252Z",
+     "iopub.status.idle": "2026-08-15T14:07:29.669887Z",
+     "shell.execute_reply": "2026-08-15T14:07:29.669643Z"
     },
     "papermill": {
-     "duration": 0.037121,
-     "end_time": "2026-02-23T11:41:49.925256",
+     "duration": 0.203399,
+     "end_time": "2026-08-15T14:07:29.669989+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:49.888135",
+     "start_time": "2026-08-15T14:07:29.466590+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2002,17 +2430,19 @@
    "id": "6b6b4ee4",
    "metadata": {
     "papermill": {
-     "duration": 0.008196,
-     "end_time": "2026-02-23T11:41:49.941733",
+     "duration": 0.011622,
+     "end_time": "2026-08-15T14:07:29.696476+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:49.933537",
+     "start_time": "2026-08-15T14:07:29.684854+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Obtenir les valeurs de contribution des caractéristiques\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -2023,16 +2453,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:49.964282Z",
-     "iopub.status.busy": "2026-02-23T11:41:49.964282Z",
-     "iopub.status.idle": "2026-02-23T11:41:49.987392Z",
-     "shell.execute_reply": "2026-02-23T11:41:49.987392Z"
+     "iopub.execute_input": "2026-08-15T14:07:29.718357Z",
+     "iopub.status.busy": "2026-08-15T14:07:29.718007Z",
+     "iopub.status.idle": "2026-08-15T14:07:29.828440Z",
+     "shell.execute_reply": "2026-08-15T14:07:29.828184Z"
     },
     "papermill": {
-     "duration": 0.035742,
-     "end_time": "2026-02-23T11:41:49.987392",
+     "duration": 0.121432,
+     "end_time": "2026-08-15T14:07:29.828542+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:49.951650",
+     "start_time": "2026-08-15T14:07:29.707110+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2050,17 +2480,19 @@
    "id": "c664006e",
    "metadata": {
     "papermill": {
-     "duration": 0.008506,
-     "end_time": "2026-02-23T11:41:50.005461",
+     "duration": 0.012114,
+     "end_time": "2026-08-15T14:07:29.854630+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:49.996955",
+     "start_time": "2026-08-15T14:07:29.842516+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Mapper les valeurs de contribution des caractéristiques aux noms des caractéristiques\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -2071,16 +2503,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:50.024271Z",
-     "iopub.status.busy": "2026-02-23T11:41:50.024271Z",
-     "iopub.status.idle": "2026-02-23T11:41:50.074131Z",
-     "shell.execute_reply": "2026-02-23T11:41:50.074131Z"
+     "iopub.execute_input": "2026-08-15T14:07:29.879823Z",
+     "iopub.status.busy": "2026-08-15T14:07:29.879514Z",
+     "iopub.status.idle": "2026-08-15T14:07:29.968155Z",
+     "shell.execute_reply": "2026-08-15T14:07:29.967964Z"
     },
     "papermill": {
-     "duration": 0.060908,
-     "end_time": "2026-02-23T11:41:50.074131",
+     "duration": 0.102072,
+     "end_time": "2026-08-15T14:07:29.968240+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:50.013223",
+     "start_time": "2026-08-15T14:07:29.866168+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2100,17 +2532,19 @@
    "id": "3c446391",
    "metadata": {
     "papermill": {
-     "duration": 0.009832,
-     "end_time": "2026-02-23T11:41:50.092667",
+     "duration": 0.009247,
+     "end_time": "2026-08-15T14:07:30.003601+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:50.082835",
+     "start_time": "2026-08-15T14:07:29.994354+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
     "#### Afficher les contributions des caractéristiques pour la première prédiction\n"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
@@ -2121,16 +2555,16 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-02-23T11:41:50.113168Z",
-     "iopub.status.busy": "2026-02-23T11:41:50.113168Z",
-     "iopub.status.idle": "2026-02-23T11:41:50.207810Z",
-     "shell.execute_reply": "2026-02-23T11:41:50.207810Z"
+     "iopub.execute_input": "2026-08-15T14:07:30.026871Z",
+     "iopub.status.busy": "2026-08-15T14:07:30.026533Z",
+     "iopub.status.idle": "2026-08-15T14:07:30.194235Z",
+     "shell.execute_reply": "2026-08-15T14:07:30.194037Z"
     },
     "papermill": {
-     "duration": 0.104829,
-     "end_time": "2026-02-23T11:41:50.207810",
+     "duration": 0.180744,
+     "end_time": "2026-08-15T14:07:30.194350+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:50.102981",
+     "start_time": "2026-08-15T14:07:30.013606+00:00",
      "status": "completed"
     },
     "polyglot_notebook": {
@@ -2140,12 +2574,45 @@
    },
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/html": "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit2, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit2</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit1, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit1</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit0, 6,46816]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit0</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>6.46816</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit3, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit3</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit2, -3,4585545]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit2</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-3.4585545</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>5</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit1, 19,19871]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit1</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>19.19871</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>6</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit0, 10,600954]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit0</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>10.600954</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>7</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[rate_code, -1779,6366]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>rate_code</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-1779.6366</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>8</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[passenger_count, -1,6658905]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>passenger_count</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-1.6658905</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>9</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[trip_time_in_secs, 75,95777]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>trip_time_in_secs</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>75.95777</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>10</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[trip_distance, -803,3262]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>trip_distance</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-803.3262</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
+      "text/html": [
+       "<table><thead><tr><th><i>index</i></th><th>value</th></tr></thead><tbody><tr><td>0</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit2, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit2</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>1</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit1, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit1</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>2</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[vendor_id.Bit0, 6,46816]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>vendor_id.Bit0</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>6.46816</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>3</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit3, 0]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit3</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>0</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>4</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit2, -3,4585545]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit2</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-3.4585545</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>5</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit1, 19,19871]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit1</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>19.19871</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>6</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[payment_type.Bit0, 10,600954]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>payment_type.Bit0</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>10.600954</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>7</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[rate_code, -1779,6366]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>rate_code</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-1779.6366</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>8</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[passenger_count, -1,6658905]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>passenger_count</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-1.6658905</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>9</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[trip_time_in_secs, 75,95777]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>trip_time_in_secs</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>75.95777</pre></div></td></tr></tbody></table></div></details></td></tr><tr><td>10</td><td><details class=\"dni-treeview\"><summary><span class=\"dni-code-hint\"><code>[trip_distance, -803,3262]</code></span></summary><div><table><thead><tr></tr></thead><tbody><tr><td>Key</td><td><div class=\"dni-plaintext\"><pre>trip_distance</pre></div></td></tr><tr><td>Value</td><td><div class=\"dni-plaintext\"><pre>-803.3262</pre></div></td></tr></tbody></table></div></details></td></tr></tbody></table><style>\r\n",
+       ".dni-code-hint {\r\n",
+       "    font-style: italic;\r\n",
+       "    overflow: hidden;\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview {\r\n",
+       "    white-space: nowrap;\r\n",
+       "}\r\n",
+       ".dni-treeview td {\r\n",
+       "    vertical-align: top;\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "details.dni-treeview {\r\n",
+       "    padding-left: 1em;\r\n",
+       "}\r\n",
+       "table td {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "table tr { \r\n",
+       "    vertical-align: top; \r\n",
+       "    margin: 0em 0px;\r\n",
+       "}\r\n",
+       "table tr td pre \r\n",
+       "{ \r\n",
+       "    vertical-align: top !important; \r\n",
+       "    margin: 0em 0px !important;\r\n",
+       "} \r\n",
+       "table th {\r\n",
+       "    text-align: start;\r\n",
+       "}\r\n",
+       "</style>"
+      ]
      },
+     "execution_count": 37,
      "metadata": {},
-     "execution_count": 37
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -2156,17 +2623,28 @@
    "cell_type": "markdown",
    "id": "15a6b3aa",
    "source": "### Interprétation — lire une décomposition locale (FCC)\n\nContrairement à la PFI (qui moyennait l'effet d'une permutation sur tout le jeu), l'output ci-dessus décompose **une prédiction unique** — la première ligne du jeu prétraité. Chaque contribution indique dans quel sens et avec quelle intensité la caractéristique a tiré le `Score` de cette prédiction par rapport à la prédiction moyenne (la *baseline* du modèle) :\n\n- **Une contribution positive** pousse cette prédiction vers le haut (tarif prédit plus élevé que la baseline).\n- **Une contribution négative** la tire vers le bas.\n\nIci, `rate_code` (-1779,6) et `trip_distance` (-803,3) sont les contributeurs négatifs dominants : pour *cette* course, ces caractéristiques abaissent fortement le tarif prédit. À l'inverse, `payment_type.Bit1` (+19,2) et `payment_type.Bit0` (+10,6) le relèvent légèrement.\n\nC'est le complément essentiel de la PFI : une caractéristique peut être globalement peu importante (PFI faible) tout en étant déterminante sur certaines prédictions (FCC élevée sur ces lignes). On audite donc typiquement une prédiction surprenante en lisant sa décomposition FCC, puis on hiérarchise les caractéristiques au niveau du modèle avec la PFI.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.011652,
+     "end_time": "2026-08-15T14:07:30.219511+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.207859+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "id": "be6e535a",
    "metadata": {
     "papermill": {
-     "duration": 0.0087,
-     "end_time": "2026-02-23T11:41:50.226723",
+     "duration": 0.013707,
+     "end_time": "2026-08-15T14:07:30.247884+00:00",
      "exception": false,
-     "start_time": "2026-02-23T11:41:50.218023",
+     "start_time": "2026-08-15T14:07:30.234177+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2204,25 +2682,64 @@
     "- R² proche de 1.0 indique un bon ajustement, mais surveiller aussi le surapprentissage\n",
     "\n",
     "**Navigation** : [Index](README.md) | [<< ML-3 Entrainement&AutoML](ML-3-Entrainement&AutoML.ipynb) | [Suivant >> ML-5 TimeSeries](ML-5-TimeSeries.ipynb)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "id": "8c91b702",
    "source": "## Exercices supplementaires\n\nLes exercices suivants approfondissent l'evaluation des modèles avec des techniques de classification binaire et des metriques avancees.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.01381,
+     "end_time": "2026-08-15T14:07:30.276431+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.262621+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
    "id": "aa2836c3",
    "source": "### Exercice 1 : Courbe ROC et calcul de l'AUC\n\nEntrainez un classifieur binaire, calculez les points de la courbe ROC en faisant varier le seuil de decision, tracez la courbe avec Plotly.NET et calculez l'AUC manuellement.\n\n**Objectifs** :\n1. Convertir le problème de regression taxi-fare en classification binaire (seuil sur `fare_amount`)\n2. Entrainer un classifieur binaire avec SDCA Logistic Regression\n3. Extraire les probabilites de prediction pour chaque observation\n4. Calculer TPR (True Positive Rate) et FPR (False Positive Rate) pour plusieurs seuils\n5. Tracer la courbe ROC avec Plotly.NET (`Chart.Line`)\n6. Calculer l'AUC manuellement par la méthode des trapezes\n\n**Indice** : Pour chaque seuil de 0.1 a 0.9 par pas de 0.1, classez comme positif si `Probability >= seuil`. Calculez TPR = TP/(TP+FN) et FPR = FP/(FP+TN). L'AUC est la somme des aires des trapezes entre points consecutifs : `AUC += 0.5 * (FPR[i+1] - FPR[i]) * (TPR[i+1] + TPR[i])`.",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.013382,
+     "end_time": "2026-08-15T14:07:30.303193+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.289811+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "id": "398d1fb8",
    "source": "// Exercice 1 : Courbe ROC et calcul de l'AUC\n// TODO etudiant : Entrainez un classifieur binaire et tracez la courbe ROC avec Plotly.NET\n// Indice : utilisez les scores de probabilite pour faire varier le seuil de decision\n// Étape 1 : convertissez le problème taxi-fare en classification binaire (fare > mediane = positif)\n// Étape 2 : entrainez un classifieur SDCA Logistic Regression\n// Étape 3 : recuperez les probabilites via predictions.GetColumn<float>(\"Probability\")\n// Étape 4 : pour plusieurs seuils (0.1 a 0.9), calculez TPR et FPR pour tracer la courbe ROC\n// Étape 5 : calculez l'AUC par la méthode des trapezes (somme des aires sous la courbe)\n\nConsole.WriteLine(\"Exercice a completer : courbe ROC et AUC\");",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T14:07:30.334193Z",
+     "iopub.status.busy": "2026-08-15T14:07:30.333797Z",
+     "iopub.status.idle": "2026-08-15T14:07:30.371457Z",
+     "shell.execute_reply": "2026-08-15T14:07:30.371128Z"
+    },
+    "papermill": {
+     "duration": 0.053088,
+     "end_time": "2026-08-15T14:07:30.371622+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.318534+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "execution_count": 38,
    "outputs": [
     {
@@ -2238,13 +2755,39 @@
    "cell_type": "markdown",
    "id": "c8b70725",
    "source": "### Exercice 2 : Analyse manuelle de la matrice de confusion\n\nAprès avoir entraine un classifieur binaire, extrayez les predictions et calculez manuellement les metriques de classification (precision, recall, F1-score) pour chaque classe.\n\n**Objectifs** :\n1. Convertir le problème de regression taxi-fare en classification binaire (seuil sur `fare_amount`)\n2. Entrainer un classifieur binaire (SDCA ou FastTree)\n3. Comparer les predictions aux labels reels pour extraire TP, FP, TN, FN\n4. Calculer precision, recall et F1-score manuellement pour les deux classes\n5. Verifier vos résultats avec les metriques ML.NET\n\n**Indice** : Parcourez `predictions.GetColumn<bool>(\"PredictedLabel\")` et `predictions.GetColumn<bool>(\"Label\")` simultanement. Comptez les 4 cas (TP, FP, TN, FN), puis appliquez les formules : Precision = TP/(TP+FP), Recall = TP/(TP+FN), F1 = 2 * Precision * Recall / (Precision + Recall).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.013274,
+     "end_time": "2026-08-15T14:07:30.398884+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.385610+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "id": "cadff646",
    "source": "// Exercice 2 : Analyse manuelle de la matrice de confusion\n// TODO etudiant : Entrainez un classifieur binaire et calculez precision, recall, F1 manuellement\n// Indice : comptez les TP, FP, TN, FN a partir des predictions et des labels reels\n// Étape 1 : utilisez les données taxi-fare et convertissez le problème en classification binaire\n//          (par ex. fare_amount > seuil = \"cher\", sinon \"abordable\")\n// Étape 2 : entrainez un modèle FastTree ou SDCA en classification binaire\n// Étape 3 : comparez les predictions avec les labels reels pour remplir la matrice de confusion\n// Étape 4 : calculez precision = TP/(TP+FP), recall = TP/(TP+FN), F1 = 2*P*R/(P+R) pour chaque classe\n\nConsole.WriteLine(\"Exercice a completer : analyse de la matrice de confusion\");",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T14:07:30.427821Z",
+     "iopub.status.busy": "2026-08-15T14:07:30.427482Z",
+     "iopub.status.idle": "2026-08-15T14:07:30.466371Z",
+     "shell.execute_reply": "2026-08-15T14:07:30.466162Z"
+    },
+    "papermill": {
+     "duration": 0.053082,
+     "end_time": "2026-08-15T14:07:30.466460+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.413378+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "execution_count": 39,
    "outputs": [
     {
@@ -2276,35 +2819,76 @@
     "- Comparez les métriques entre les différents folds\n",
     "- PFI vous montre quelles features influencent le plus les prédictions"
    ],
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.015029,
+     "end_time": "2026-08-15T14:07:30.494550+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.479521+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "code",
    "id": "ahmju732cuw",
    "source": "// Exercice : Prediction de duree de trajet avec analyse complete\n\n// TODO: Créer un nouveau MLContext\nMLContext durationContext = null;\n\n// TODO: Définir le pipeline pour predire trip_time_in_secs\n// Indice: changez labelColumnName de \"fare_amount\" a \"trip_time_in_secs\"\nIEstimator<ITransformer> durationPipeline = null;\n\n// TODO: Appliquer la validation croisee (3 folds minimum)\n// Indice: var cvResults = durationContext.Regression.CrossValidate(data, pipeline, numFolds: 3);\nobject cvResults = null;  // TODO etudiant : remplacer par CrossValidate\n\nif (cvResults != null)\n{\n    // TODO: Afficher les metriques de chaque fold\n    Console.WriteLine(\"=== Résultats Validation Croisee ===\");\n    // Parcourez cvResults et affichez R2, RMSE, MAE pour chaque fold\n}\nelse\n{\n    Console.WriteLine(\"Exercice a completer : implementez les TODO pour la validation croisee\");\n}\n\n// TODO: Calculer les metriques moyennes\nvar avgRSquared = 0.0;\nvar avgRMSE = 0.0;\nvar avgMAE = 0.0;\n\nConsole.WriteLine($\"Moyennes - R2: {avgRSquared:F4}, RMSE: {avgRMSE:F2}, MAE: {avgMAE:F2}\");\n\n// TODO: Analyser l'importance des features avec PFI\n// Indice: utilisez PermutationFeatureImportance sur le meilleur modèle\n\n// TODO: Afficher les 2 features les plus importantes\nConsole.WriteLine(\"Top 2 Features (PFI) - a implementer\");\n\n// TODO: Interpretez les résultats - quelles features sont les plus pertinentes pour predire la duree ?",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T14:07:30.525880Z",
+     "iopub.status.busy": "2026-08-15T14:07:30.525541Z",
+     "iopub.status.idle": "2026-08-15T14:07:30.581827Z",
+     "shell.execute_reply": "2026-08-15T14:07:30.581529Z"
+    },
+    "papermill": {
+     "duration": 0.073921,
+     "end_time": "2026-08-15T14:07:30.581950+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.508029+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "execution_count": 40,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : implementez les TODO pour la validation croisee\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : implementez les TODO pour la validation croisee\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Moyennes - R2: 0,0000, RMSE: 0,00, MAE: 0,00\r\n"
+     "output_type": "stream",
+     "text": [
+      "Moyennes - R2: 0,0000, RMSE: 0,00, MAE: 0,00\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Top 2 Features (PFI) - a implementer\r\n"
+     "output_type": "stream",
+     "text": [
+      "Top 2 Features (PFI) - a implementer\r\n"
+     ]
     }
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.014989,
+     "end_time": "2026-08-15T14:07:30.609338+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.594349+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion — ce que nous avons appris\n",
     "\n",
@@ -2322,11 +2906,22 @@
     "\n",
     "Une fois le modèle évalué et expliqué, reste à l'améliorer (cf. section précédente) puis à le déployer. Le notebook suivant ([ML-5 TimeSeries](ML-5-TimeSeries.ipynb)) aborde un régime particulier où l'ordre temporel des données change la façon d'évaluer (la validation croisée aléatoire y devient une fuite d'information)."
    ],
-   "id": "cell-1b95a742"
+   "id": "cell-1b95a742",
+   "outputs": [],
+   "execution_count": null
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.014558,
+     "end_time": "2026-08-15T14:07:30.638391+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T14:07:30.623833+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Références\n",
     "\n",
@@ -2336,7 +2931,9 @@
     "4. T. Hastie, R. Tibshirani, J. Friedman, *The Elements of Statistical Learning*, Springer, 2009. Métriques d'évaluation et théorie de l'apprentissage statistique.\n",
     "5. A. R. Ahmed et al., *Hands-On Machine Learning with ML.NET*, Packt, 2019. Référence appliquée pour l'écosystème ML.NET (API `Evaluate`, `PermutationFeatureImportance`, `CrossValidate`)."
    ],
-   "id": "cell-b14f7bd2"
+   "id": "cell-b14f7bd2",
+   "outputs": [],
+   "execution_count": null
   }
  ],
  "metadata": {
@@ -2354,14 +2951,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 134.052007,
-   "end_time": "2026-02-23T11:41:50.472937",
+   "duration": 135.118256,
+   "end_time": "2026-08-15T14:07:30.993274+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "ML-4-Evaluation.ipynb",
    "output_path": "ML-4-Evaluation.ipynb",
    "parameters": {},
-   "start_time": "2026-02-23T11:39:36.420930",
+   "start_time": "2026-08-15T14:05:15.875018+00:00",
    "version": "2.6.0"
   },
   "polyglot_notebook": {

--- a/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
@@ -11,6 +11,12 @@
       python_sha: 2d84290fefedd8f816a737a8de1f270c2a4a328b
       csharp_sha: 3702afa3bac062ae4d142e0debd3ffce521940ab
       reason: "rebaseline csharp apres fix citation-title (#8052) : reference Hastie/Tibshirani/Friedman (2009) -- le titre anglais The Elements of Statistical Learning etait corrupt par francisation (le mot Elements remplace par le mot francais equivalent a capitale accentuee) -> restore titre canonique EN. Springer 2009 2e ed. Python twin unchanged, python_sha preserve. Parite surface preservee (citation bibliographique, pas de valeur calculee)."
+    - date: "2026-08-15"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 2d84290fefedd8f816a737a8de1f270c2a4a328b
+      csharp_sha: 92b4291a20d6eb88ec9d57ca862419d518c2f87f
+      content_python_sha: 36bceb666806321584194492099cacff733e410b9bfaa50ba9cd4a0a09fa1527
+      content_csharp_sha: 1946e40f94e98ed72ccdbf29416bb2ed4f01a96ca857807f39acaa04d3643cdd
   known_differences:
     - "ASYSMETRIE MAJEURE DE PROFONDEUR : C# = 40 cellules de code (tour exhaustif d'evaluation : FastTree, OneHotEncoding, ReplaceMissingValues, Concatenate Features + `mlContext.Auto().Regression` AutoML complet) ; Python = 10 cellules (pendant tronque : LinearRegression + RandomForestRegressor + cross_validate/GridSearchCV)."
     - "Le pendant Python couvre le CONCEPT (evaluer + GridSearchCV + metrics r2/MAE/MSE) mais n'egale pas l'exhaustivite du C# (AutoML ML.NET absent cote Python, feature engineering detaille reduit)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: LIGHT/docs #11040

## Summary

Remédiation d'un finding de gravité haute de mon triage #11044 (fenêtre merged:07-14..07-20) : **#7094 — régression d'identifiant C# cassante** dans `ML-4-Evaluation.ipynb`.

- `Différence` → `Difference` (cell[23]) : identifiant C# accentué non-ASCII passé en main le 07-17, brisant la compilation C# (les identifiants C# avec accents sont légaux mais enfreignent la convention de nommage et ce changement avait été demandé en CHANGES_REQUESTED implicite — « do NOT batch-merge as-is »).
- `#r "nuget: Microsoft.CodeAnalysis.CSharp, 4.13.0"` (cell[1]) : exigence AutoML 0.23.0 (`EciCostFrugalTuner` charge Roslyn 4.13) — réparation env règle F, plus mise à jour du kernel dotnet-interactive 1.0.617701 → 1.0.712001 (Roslyn 4.12 → 5.0.25). Le notebook ne s'exécutait PAS end-to-end sur main avant ce fix (échec pré-existant, vérifié sur le notebook non modifié).

## Validation (B.2)

| Critère | Preuve |
|---|---|
| Exécution réelle | Papermill : **40/40 code cells**, **0 erreur**, `execution_count` 1-40 |
| Verdict forensique | `validate_pr_notebooks.py` → **EXEC_PROVED**, passed=True, errors=0 |
| Outputs commités | C.2 : outputs frais de la re-exec, pas de `execution_count: null` |
| Hygiène sorties | banner `probeAddresses` stripé (`strip_probe_banner.py --apply`, 9 lignes) + chemins machine nuget stripés (`strip_machine_paths.py --apply`, 3 lignes) |
| Régression identifiant | `grep Différence` → 0 sur le fichier committé ; `Difference = actual - pred` présent |
| Cellules vides | 26 cellules sans output = identiques au fichier committé origin/main (pas de régression structurelle) |

## Diff

2 changements de source uniquement (cell[1] `#r` + cell[23] identifiant) ; le reste du diff = outputs frais de la re-exec (le kernel mis à jour change le format de rendu HTML des `display_data` — string → liste, attendu).

## Twin parity (#8057)

Re-exec du notebook C# a déplacé le blob SHA de la paire `ML-4 Evaluation` (parity surface) → le garde CI twin-parity a rougi. Rebaseline du registre `twin_pairs.d/ml-4-evaluation.yaml` (audit 2026-08-15, myia-po-2024:CoursIA-2) : `csharp_sha` 3702afa3 → 92b4291a, `python_sha` inchangé (twin Python intact). Parité de surface conservée : les cellules sans output du C# sont identiques à origin/main (26 cellules, même set) — pas de régression structurelle.

See #11044

## Test plan (post-merge)

- [ ] CI notebooks passe (kernel .net-csharp)
- [ ] Re-exécution indépendante via Papermill 40/40 sans erreur
