### PR TITLE
fix(lean,#11044): attribution Sendov — preuve L. Mazur, digestion T. Tao (Lean-19/20)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-19-Sendov-Complex-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-19-Sendov-Complex-Analysis.ipynb
@@ -3,12 +3,22 @@
   {
    "cell_type": "markdown",
    "id": "2d0ab3da",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004835,
+     "end_time": "2026-08-15T14:25:53.866858",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.862023",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "# Lean-19 : La Conjecture de Sendov (T. Tao, aout 2026) — Digestion pedagogique\n",
+    "# Lean-19 : La Conjecture de Sendov (preuve L. Mazur, digestion T. Tao, aout 2026) — Digestion pedagogique\n",
     "\n",
     "**Serie** : SymbolicAI / Lean — Digestions de resultats profonds\n",
-    "**Auteur source** : Terence Tao, 2026-08-12\n",
+    "**Auteur de la preuve** : Lech Mazur, 2026\n",
+    "**Digestion et lac source** : Terence Tao, 2026-08-12\n",
     "**Lac source** : https://github.com/teorth/sendov\n",
     "**Blog de reference** : https://terrytao.wordpress.com/2026/08/12/a-digestion-of-the-proof-of-sendovs-conjecture/\n",
     "\n",
@@ -22,14 +32,14 @@
     "\n",
     "## Presentation\n",
     "\n",
-    "Ce notebook presente la **conjecture de Sendov** et sa preuve par Terence Tao, telle que formalisee en Lean 4 dans le lac [teorth/sendov](https://github.com/teorth/sendov) (aout 2026). C'est la **digestion** d'un nouveau grand theoreme en analyse complexe, demontree par Tao en 2 jours avec Claude Opus 5 et publiee sous Apache 2.0.\n",
+    "Ce notebook presente la **conjecture de Sendov** et sa preuve par **Lech Mazur**, telle que digeree et formalisee en Lean 4 par Terence Tao dans le lac [teorth/sendov](https://github.com/teorth/sendov) (aout 2026). C'est la **digestion** d'un nouveau grand theoreme en analyse complexe : demontre par Mazur, dont Tao a produit la digestion et la formalisation en 2 jours avec Claude Opus 5, publiee sous Apache 2.0.\n",
     "\n",
     "**La conjecture de Sendov** dit : *Si p in C[X] a degre n >= 2 avec tous ses zeros dans le disque unite ferme, alors pour chaque zero a de p, il existe un point critique zeta de p a distance |zeta - a| <= 1.* La conjecture plus forte de **Phelps-Rodriguez** exige |zeta - a| < 1 sauf dans le cas extreme ou |a| = 1 et p est un multiple scalaire de z^n - a^n.\n",
     "\n",
     "**Pourquoi ce notebook dans notre serie Lean ?**\n",
     "\n",
     "- Notre serie Lean (notebooks 1 a 18) va du langage lui-meme (Lean-1..6 : types dependants, propositions, quantificateurs, tactiques, Mathlib) a des theoremes profonds et recents : Huang Sensitivity (Lean-12), Kochen-Specker (Lean-13), Grothendieck Tribute (Lean-15), Conway Knots (Lean-17), A* Optimalite (Lean-18).\n",
-    "- Sendov s'inscrit dans la meme veine : un theoreme profond recemment demontre (ici par Tao en digestion d'une preuve de Mazur), avec une formalisation Lean propre et bien ficelee, qui merite le meme traitement pedagogique qu'un Huang ou un Conway.\n",
+    "- Sendov s'inscrit dans la meme veine : un theoreme profond recemment demontre (ici une preuve de Lech Mazur, digeree et formalisee par Tao), avec une formalisation Lean propre et bien ficelee, qui merite le meme traitement pedagogique qu'un Huang ou un Conway.\n",
     "- **Substance nouvelle** : on n'avait pas encore aborde l'analyse complexe dans notre serie. Sendov ouvre cette porte avec un objet mathematique riche - polynomes sur C, integrales, inegalites AM-GM, fonctions hyperboliques - qui complete notre palette apres la theorie des categories (Lean-15b).\n",
     "- **Methode nouvelle** : pour la premiere fois dans notre serie, nous presentons une formalisation Lean qui **n'est pas de notre cru**. Le lac source est externe (teorth/sendov). C'est un **nod** modeste a Terry Tao, qui pousse depuis 2 ans pour l'adoption de la preuve agentique - un travail dont nous partageons l'esprit.\n",
     "\n",
@@ -39,7 +49,16 @@
   {
    "cell_type": "markdown",
    "id": "d4f86c4a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005508,
+     "end_time": "2026-08-15T14:25:53.878619",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.873111",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Enonces formels\n",
     "\n",
@@ -72,11 +91,19 @@
    "id": "0d27b815",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:25.392916Z",
-     "iopub.status.busy": "2026-08-13T11:02:25.392916Z",
-     "iopub.status.idle": "2026-08-13T11:02:25.399915Z",
-     "shell.execute_reply": "2026-08-13T11:02:25.399915Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:53.891363Z",
+     "iopub.status.busy": "2026-08-15T14:25:53.890823Z",
+     "iopub.status.idle": "2026-08-15T14:25:53.903384Z",
+     "shell.execute_reply": "2026-08-15T14:25:53.902261Z"
+    },
+    "papermill": {
+     "duration": 0.020038,
+     "end_time": "2026-08-15T14:25:53.903903",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.883865",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -96,7 +123,7 @@
     "\n",
     "def sendov_statement(n, p, a, all_roots_in_unit_disk):\n",
     "    \"\"\"\n",
-    "    Conjecture de Sendov (Tao 2026, formalisation Lean 4).\n",
+    "    Conjecture de Sendov (preuve L. Mazur 2026 ; digestion et formalisation Lean 4 : T. Tao).\n",
     "\n",
     "    Parametres :\n",
     "        n (int) : degre du polynome, >= 2\n",
@@ -122,7 +149,16 @@
   {
    "cell_type": "markdown",
    "id": "ba182bd8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006353,
+     "end_time": "2026-08-15T14:25:53.914068",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.907715",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Architecture de la preuve\n",
     "\n",
@@ -151,7 +187,16 @@
   {
    "cell_type": "markdown",
    "id": "16b4248d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006384,
+     "end_time": "2026-08-15T14:25:53.926447",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.920063",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Bibliographie Mathlib minimale\n",
     "\n",
@@ -195,7 +240,16 @@
   {
    "cell_type": "markdown",
    "id": "04aa2a4c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005297,
+     "end_time": "2026-08-15T14:25:53.936085",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.930788",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. References croisees dans notre serie\n",
     "\n",
@@ -231,11 +285,19 @@
    "id": "24c749c0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:25.402352Z",
-     "iopub.status.busy": "2026-08-13T11:02:25.402352Z",
-     "iopub.status.idle": "2026-08-13T11:02:25.405520Z",
-     "shell.execute_reply": "2026-08-13T11:02:25.405520Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:53.946943Z",
+     "iopub.status.busy": "2026-08-15T14:25:53.946943Z",
+     "iopub.status.idle": "2026-08-15T14:25:53.951485Z",
+     "shell.execute_reply": "2026-08-15T14:25:53.951485Z"
+    },
+    "papermill": {
+     "duration": 0.011216,
+     "end_time": "2026-08-15T14:25:53.951485",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.940269",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -277,7 +339,16 @@
   {
    "cell_type": "markdown",
    "id": "096ea6e7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005702,
+     "end_time": "2026-08-15T14:25:53.965427",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.959725",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Cas du centre : a = 0\n",
     "\n",
@@ -316,11 +387,19 @@
    "id": "099949ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:25.407525Z",
-     "iopub.status.busy": "2026-08-13T11:02:25.407525Z",
-     "iopub.status.idle": "2026-08-13T11:02:25.497746Z",
-     "shell.execute_reply": "2026-08-13T11:02:25.497093Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:53.974724Z",
+     "iopub.status.busy": "2026-08-15T14:25:53.974724Z",
+     "iopub.status.idle": "2026-08-15T14:25:54.044102Z",
+     "shell.execute_reply": "2026-08-15T14:25:54.043744Z"
+    },
+    "papermill": {
+     "duration": 0.074663,
+     "end_time": "2026-08-15T14:25:54.044102",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:53.969439",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -382,7 +461,16 @@
   {
    "cell_type": "markdown",
    "id": "40e2df21",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004191,
+     "end_time": "2026-08-15T14:25:54.052488",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:54.048297",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Cas interieur : 0 < |a| < 1\n",
     "\n",
@@ -435,11 +523,19 @@
    "id": "6c5d0cf6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:25.498750Z",
-     "iopub.status.busy": "2026-08-13T11:02:25.498750Z",
-     "iopub.status.idle": "2026-08-13T11:02:26.131998Z",
-     "shell.execute_reply": "2026-08-13T11:02:26.131483Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:54.063235Z",
+     "iopub.status.busy": "2026-08-15T14:25:54.062226Z",
+     "iopub.status.idle": "2026-08-15T14:25:54.973016Z",
+     "shell.execute_reply": "2026-08-15T14:25:54.971976Z"
+    },
+    "papermill": {
+     "duration": 0.917533,
+     "end_time": "2026-08-15T14:25:54.974029",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:54.056496",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -508,7 +604,16 @@
   {
    "cell_type": "markdown",
    "id": "74a39e7e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004997,
+     "end_time": "2026-08-15T14:25:54.983656",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:54.978659",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Cas boundary : |a| = 1 (Rubinstein)\n",
     "\n",
@@ -557,11 +662,19 @@
    "id": "0f4688b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:26.134008Z",
-     "iopub.status.busy": "2026-08-13T11:02:26.133002Z",
-     "iopub.status.idle": "2026-08-13T11:02:26.138591Z",
-     "shell.execute_reply": "2026-08-13T11:02:26.138591Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:54.994526Z",
+     "iopub.status.busy": "2026-08-15T14:25:54.994526Z",
+     "iopub.status.idle": "2026-08-15T14:25:55.000498Z",
+     "shell.execute_reply": "2026-08-15T14:25:55.000498Z"
+    },
+    "papermill": {
+     "duration": 0.01374,
+     "end_time": "2026-08-15T14:25:55.002020",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:54.988280",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -614,7 +727,16 @@
   {
    "cell_type": "markdown",
    "id": "f3c66f84",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005241,
+     "end_time": "2026-08-15T14:25:55.012796",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.007555",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Recollement : eliminer la normalisation `a in [0, 1)`\n",
     "\n",
@@ -652,11 +774,19 @@
    "id": "230ab85d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:26.140595Z",
-     "iopub.status.busy": "2026-08-13T11:02:26.140595Z",
-     "iopub.status.idle": "2026-08-13T11:02:26.146853Z",
-     "shell.execute_reply": "2026-08-13T11:02:26.146853Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:55.023956Z",
+     "iopub.status.busy": "2026-08-15T14:25:55.023956Z",
+     "iopub.status.idle": "2026-08-15T14:25:55.032862Z",
+     "shell.execute_reply": "2026-08-15T14:25:55.032332Z"
+    },
+    "papermill": {
+     "duration": 0.016449,
+     "end_time": "2026-08-15T14:25:55.033876",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.017427",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -733,7 +863,16 @@
   {
    "cell_type": "markdown",
    "id": "44b9ac0f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006364,
+     "end_time": "2026-08-15T14:25:55.044720",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.038356",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 9. Exercices\n",
     "\n",
@@ -754,11 +893,19 @@
    "id": "794d0033",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:26.148858Z",
-     "iopub.status.busy": "2026-08-13T11:02:26.148858Z",
-     "iopub.status.idle": "2026-08-13T11:02:26.151859Z",
-     "shell.execute_reply": "2026-08-13T11:02:26.151859Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:55.055340Z",
+     "iopub.status.busy": "2026-08-15T14:25:55.055340Z",
+     "iopub.status.idle": "2026-08-15T14:25:55.060859Z",
+     "shell.execute_reply": "2026-08-15T14:25:55.059849Z"
+    },
+    "papermill": {
+     "duration": 0.012637,
+     "end_time": "2026-08-15T14:25:55.061857",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.049220",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -809,7 +956,16 @@
   {
    "cell_type": "markdown",
    "id": "a14624e8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004718,
+     "end_time": "2026-08-15T14:25:55.072167",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.067449",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 9.2 Exercice 2 — Demontrer Maclaurin pour n = 3 explicitement\n",
     "\n",
@@ -826,11 +982,19 @@
    "id": "627e9920",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:26.153530Z",
-     "iopub.status.busy": "2026-08-13T11:02:26.153530Z",
-     "iopub.status.idle": "2026-08-13T11:02:26.157843Z",
-     "shell.execute_reply": "2026-08-13T11:02:26.157843Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:55.083406Z",
+     "iopub.status.busy": "2026-08-15T14:25:55.083406Z",
+     "iopub.status.idle": "2026-08-15T14:25:55.089199Z",
+     "shell.execute_reply": "2026-08-15T14:25:55.089199Z"
+    },
+    "papermill": {
+     "duration": 0.013099,
+     "end_time": "2026-08-15T14:25:55.090772",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.077673",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -890,7 +1054,16 @@
   {
    "cell_type": "markdown",
    "id": "d803d838",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005383,
+     "end_time": "2026-08-15T14:25:55.101965",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.096582",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 9.3 Exercice 3 — Etendre Phelps-Rodriguez au cas polynomial compose\n",
     "\n",
@@ -903,11 +1076,19 @@
    "id": "82116b0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-13T11:02:26.159848Z",
-     "iopub.status.busy": "2026-08-13T11:02:26.158848Z",
-     "iopub.status.idle": "2026-08-13T11:02:26.162892Z",
-     "shell.execute_reply": "2026-08-13T11:02:26.162892Z"
-    }
+     "iopub.execute_input": "2026-08-15T14:25:55.114805Z",
+     "iopub.status.busy": "2026-08-15T14:25:55.114270Z",
+     "iopub.status.idle": "2026-08-15T14:25:55.120151Z",
+     "shell.execute_reply": "2026-08-15T14:25:55.119086Z"
+    },
+    "papermill": {
+     "duration": 0.014948,
+     "end_time": "2026-08-15T14:25:55.121268",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.106320",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -963,7 +1144,16 @@
   {
    "cell_type": "markdown",
    "id": "3eeaea2c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004096,
+     "end_time": "2026-08-15T14:25:55.131158",
+     "exception": false,
+     "start_time": "2026-08-15T14:25:55.127062",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 10. Conclusion et suite\n",
     "\n",
@@ -987,7 +1177,7 @@
     "\n",
     "- T. Tao, 'A digestion of the proof of Sendov\\'s conjecture' (2026-08-12), https://terrytao.wordpress.com/2026/08/12/a-digestion-of-the-proof-of-sendovs-conjecture/\n",
     "- T. Tao, sendov Lean 4 lake (Apache-2.0), https://github.com/teorth/sendov\n",
-    "- S. Meijer, 'Sendov\\'s conjecture for polynomials with a single root on the unit circle', 2024 (the original Mazur-style proof)\n",
+    "- S. Meijer, 'Sendov\\'s conjecture for polynomials with a single root on the unit circle', 2024 (cas particulier anterieur a la preuve complete de Mazur)\n",
     "- Issue #10763 (Epic Terry Tao 2026)\n",
     "- Issue #10759 (Phase 1 Sendov)\n",
     "- Issue #10764 (Phase 2 Analysis)\n",
@@ -1014,6 +1204,18 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.9"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.117355,
+   "end_time": "2026-08-15T14:25:55.470303",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-19-Sendov-Complex-Analysis.ipynb",
+   "output_path": "Lean-19.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-15T14:25:52.352948",
+   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-20-Analysis-I-Tao-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-20-Analysis-I-Tao-Workflow.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "**Pourquoi ce notebook dans notre serie Lean ?**\n",
     "\n",
-    "- Notre serie Lean a deja couvert Sendov (Lean-19, analyse complexe, 1 grain = 1 theoreme). Pour ce 2e grain Terry Tao, on prend du recul : ce n'est plus *un* theoreme mais *un manuel entier* (11 chapitres, 109 fichiers, 44 297 LOC, 2079 `sorry` deliberes par l'auteur comme exercices au lecteur).\n",
+    "- Notre serie Lean a deja couvert Sendov (Lean-19 : digestion par Tao de la preuve de L. Mazur, analyse complexe, 1 grain = 1 theoreme). Pour ce 2e grain — cette fois une oeuvre propre de Tao — on prend du recul : ce n'est plus *un* theoreme mais *un manuel entier* (11 chapitres, 109 fichiers, 44 297 LOC, 2079 `sorry` deliberes par l'auteur comme exercices au lecteur).\n",
     "- **Substance nouvelle** : Lean-20 est le premier grain de notre serie qui est *Lean-meta* (recit methodologique) plutot que *Lean-content* (preuve formelle). C'est ce qu'on appelle dans le jargon de la preuve agentique un *process notebook* — un notebook qui decrit un processus de preuve, pas une preuve.\n",
     "- **Methode nouvelle** : comparaison directe avec notre cluster. Tao travaille seul, 2 ans, 5-15 commits/jour. Notre cluster : 4 workers + 1 coordinateur, cadence 2h, ~2 PRs/h. Quels sont les tradeoffs ?\n",
     "- **Apport a Mathlib** : Tao n'utilise presque pas Mathlib dans les chapitres 2-5 (auto-contenu, axiomes Peano, construction de Cauchy des reels), puis transitionne progressivement vers Mathlib a partir du chapitre 6. C'est une approche pedagogique rare — la plupart des projets partent de Mathlib.\n",
@@ -479,7 +479,7 @@
     "\n",
     "### 4.4 La complementarite\n",
     "\n",
-    "Le cluster peut **digerer** un theoreme de Tao (Lean-19 Sendov = 14.9k LOC, 2 jours). Mais il ne peut pas **produire** un manuel sur 2 ans. Et reciproquement, Tao peut produire un manuel, mais pas digerer 50 theoremes SOTA par mois. Les deux approches sont **non-substituables**.\n",
+    "Le cluster peut **digerer** la formalisation d'un theoreme par Tao (Lean-19 Sendov : digestion par Tao de la preuve de L. Mazur, 14.9k LOC, 2 jours). Mais il ne peut pas **produire** un manuel sur 2 ans. Et reciproquement, Tao peut produire un manuel, mais pas digerer 50 theoremes SOTA par mois. Les deux approches sont **non-substituables**.\n",
     "\n",
     "### 4.5 Strategie recommandee pour un agent\n",
     "\n",
@@ -487,7 +487,7 @@
     "\n",
     "- **single-agent** : pour un projet pedagogique de longue haleine (manuel, formation, cours). Necessite une vision claire et stable sur 6+ mois.\n",
     "- **cluster distribue** : pour une bibliotheque de theoremes SOTA. Necessite un coordinateur qui gere les claims cross-lane et un budget de review eleve.\n",
-    "- **mixte** (notre cas) : single-agent pour les projets pedagogiques continus (Lean-20), cluster pour les sprints bornes (Lean-19 Sendov).\n"
+    "- **mixte** (notre cas) : single-agent pour les projets pedagogiques continus (Lean-20), cluster pour les sprints bornes (Lean-19 Sendov)."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Correction du cas fondateur de l'Epic #11044 : l'attribution de la preuve de la conjecture de Sendov. Le titre et l'ouverture de Lean-19 falsifiaient (« preuve par Terence Tao », « démontrée par Tao en 2 jours ») alors que trois passages internes du même notebook disaient déjà la vérité : **démontrée par Lech Mazur, digérée et formalisée en Lean 4 par Tao** (blog « A digestion of the proof of Sendov's conjecture », 2026-08-12).

**Lean-19** (6 corrections, re-exécuté) :
- Titre : `(T. Tao, aout 2026)` → `(preuve L. Mazur, digestion T. Tao, aout 2026)` ;
- En-tête : `Auteur source : Terence Tao` → `Auteur de la preuve : Lech Mazur` + `Digestion et lac source : Terence Tao` ;
- Présentation : « sa preuve par Terence Tao [...] démontrée par Tao en 2 jours » → « sa preuve par **Lech Mazur** [...] démontré par Mazur, dont Tao a produit la digestion et la formalisation en 2 jours » (les 2 jours = le travail de Tao, qui reste factual) ;
- Bullet « même veine » : parenthétique reformulée dans le même sens ;
- Docstring code 1.1 : `(Tao 2026, formalisation Lean 4)` → `(preuve L. Mazur 2026 ; digestion et formalisation Lean 4 : T. Tao)` ;
- Référence S. Meijer 2024 : parenthétique trompeuse `(the original Mazur-style proof)` → `(cas particulier antérieur à la preuve complète de Mazur)`.

**Lean-20** (2 corrections, markdown-only) : le cadrage comparatif reposait sur la prémisse « Sendov = théorème de Tao » :
- « Pour ce 2e grain Terry Tao » → le pont Lean-19 explicite « digestion par Tao de la preuve de L. Mazur » + « cette fois une œuvre propre de Tao » (le sujet réel de Lean-20, le lac `teorth/analysis`, reste bien à Tao) ;
- §4.4 « Le cluster peut digérer **un théorème de Tao** » → « la **formalisation d'un** théorème **par** Tao » avec rappel Mazur.

**Lean-21 (PFR) non touché — sain** : ses mentions « preuve de Tao » portent sur PFR (Freeman-Ruzsa 2023), réellement un résultat de Tao ; sa seule mention de Sendov est un renvoi neutre. Un correctif en aveugle y aurait **introduit** une falsification.

## Preuves d'exécution (§D)

- **Papermill SUCCESS** (kernel python3, 22/22 cellules, ~3 s) :
  ```
  Executing notebook with kernel: python3
  100%|██████████| 22/22 [00:02<00:01, 7.06cell/s]
  ```
- 9 cellules code : `errors=0`, `execution_count` set partout, outputs réels committés (C.2).
- `grep NotImplementedError` : 1 match par notebook = **prose** (mention de la convention C.1), zéro `raise` actif — confirmé par l'exécution end-to-end sans erreur.
- Pas de suppression de cellule (diff = corrections ciblées + outputs rafraîchis).
- Scan leak outputs : aucun chemin machine (papermill paths normalisés au basename, exception autorisée).

## Vérification

- Compteurs firsthand sur origin/main avant édition : Lean-19 Sendov=67/Mazur=3 ; Lean-20 Sendov=25/Mazur=0 ; Lean-21 Sendov=1 (renvoi neutre).
- Initiales vérifiées : **Lech** Mazur → `L. Mazur`.
- Balayage exhaustif de toutes les lignes Tao/Mazur : les mentions restantes (certificats de Bernstein, lemme Maclaurin in-fichier, refs blog/lac) portent légitimement sur le travail de Tao sur le lac.

Grain: MED/contenu — lane myia-po-2026:CoursIA — prev: MED/docs #11053

See #11044 (contribution à l'Epic — defects restants : #3851 typos Lean-17a, #1877 thermal_backoff)
