### PR TITLE
docs(tweety,#3975): README feuille — re-audit fichier-entier §E (9 corrections prose vs disque)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/README.md
@@ -30,7 +30,7 @@ Les notebooks utilisent **deux implémentations** pour exécuter TweetyProject, 
 | Implémentation           | Stack                          | Kernel        | JVM requise ?                     | Notebooks                                                                                                                               |
 | ------------------------ | ------------------------------ | ------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | **Python** (originelle)  | JPype (pont Java↔Python)       | Python 3      | Oui (JDK téléchargé par le setup) | `Tweety-1` à `Tweety-11` (+ `Tweety-5b-Lean-Argumentation` companion Lean 4, soit **13 notebooks**)                                    |
-| **C#/.NET** (port natif) | IKVM 8.15 (bytecode Java→.NET) | `.net-csharp` | **Non** (runtime IKVM pur .NET)   | **18 notebooks** `*-Csharp` (de `Tweety-2-Basic-Logics-Csharp` à `Tweety-11-Causal-Csharp` ; ex. `2b-Semantics`, `3-Dung`, `4-Aspic`)   |
+| **C#/.NET** (port natif) | IKVM 8.14 (bytecode Java→.NET) | `.net-csharp` | **Non** (runtime IKVM pur .NET)   | **18 notebooks** `*-Csharp` (de `Tweety-2-Basic-Logics-Csharp` à `Tweety-11-Causal-Csharp` ; ex. `2b-Semantics`, `3-Dung`, `4-Aspic`)   |
 
 Les deux implémentations couvrent les mêmes concepts fondamentaux (logique propositionnelle, sémantique des mondes possibles, logique du premier ordre, argumentation de Dung) ; le port C# les expose **sans JVM**, directement dans le runtime .NET, ce qui les rend exécutables côté .NET Interactive comme n'importe quel notebook C#. Les notebooks `-Csharp` vivent **à côté** de leurs homologues Python (pas dans un sous-dossier), pour faciliter la comparaison des deux stacks sur un même concept. Voir EPIC [#4667](https://github.com/jsboige/CoursIA/issues/4667).
 
@@ -64,7 +64,7 @@ Cette série ne propose pas de choisir l'un ou l'autre, mais de **comprendre les
 | Statistique | Valeur |
 |-------------|--------|
 | Notebooks | 32 (12 Python + 1 Lean + 18 C# + 1 probe) |
-| Cellules totales | ~430 |
+| Cellules totales | 916 (dont 371 code) |
 | Durée estimée | ~6h (tutorat) |
 | Kernel | Python 3 (JPype/Java) |
 | Version Tweety | 1.30 recommandée |
@@ -177,7 +177,7 @@ Pour les praticiens intéressés par les applications multi-agents :
 | 11 | [Tweety-11-Causal](Tweety-11-Causal.ipynb) | Raisonnement causal : do-calculus, interventions, contrefactuels | 50 min  | Python |
 | 11c | [Tweety-11-Causal-Csharp](Tweety-11-Causal-Csharp.ipynb) | Twin C# moteur causal booléen from-scratch (do-operator, contrefactuel) | 35 min  | C# PROD |
 
-**Durée totale estimée** : ~13h (Python) + ~7h (C#/.NET). Le tableau ci-dessus couvre les **31 notebooks principaux** (12 Python + 18 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4 avec 5 fichiers `.lean` du dossier `Argumentation/` : Basic, Characteristic, Extensions, Fundamental, Grounded).
+**Durée totale estimée** : ~13h (Python) + ~7h (C#/.NET). Le tableau ci-dessus couvre les **31 notebooks principaux** (12 Python + 18 C#/.NET + 1 Lean companion) ; voir aussi `_probes/Tweety-IKVM-Init-Probe.ipynb` (BETA smoke-test IKVM) et `argumentation_lean/` (lake Lean 4, toolchain `v4.32.0`, avec 10 fichiers `.lean` au dossier `Argumentation/` — 5 modules FR : Basic, Characteristic, Extensions, Fundamental, Grounded + leurs 5 siblings `_en` i18n #4980).
 
 ## En quoi chaque notebook est unique
 
@@ -422,7 +422,7 @@ Tweety/
 ├── Tweety-11-Causal-Csharp.ipynb                  # Twin C# moteur causal from-scratch (BCL, PROD)
 ├── tweety_init.py                                 # Module d'initialisation JPype/JVM
 ├── requirements.txt                               # Dépendances Python (JPype1, etc.)
-├── org.tweetyproject.tweety-*.dll                 # 10 assemblages .NET (shades IKVM, EPIC #4667)
+├── org.tweetyproject.tweety-*.dll                 # 18 assemblages .NET (shades IKVM, EPIC #4667)
 ├── dotnet-build/                                  # Build Maven/.csproj des shades IKVM (EPIC #4667)
 ├── libs/                                          # JARs Tweety (42 : 39 modules 1.30 + 3 deps) — téléchargé
 ├── jdk-17-portable/                               # JDK Zulu — téléchargé auto par le setup
@@ -434,14 +434,14 @@ Tweety/
 │   ├── validate_syntax.py                        # Validation syntaxe Python
 │   ├── sat_calibration.py                        # Calibration SAT
 │   ├── sat_comparison_demo.py                    # Démo comparative SAT
-│   ├── reorganize_tweety.py                      # Réorganisation (aussi copié dans archive/)
-│   └── archive/                                   # Scripts archivés (reorganize_tweety.py)
+│   ├── test_*.py                                  # 4 tests unitaires (sat_calibration, sat_comparison_demo, validate_syntax, verify_tweety_iopub)
+│   └── _archive/                                  # Scripts archivés (reorganize_tweety.py)
 ├── _probes/                                       # Smoke-tests (1 nb : Tweety-IKVM-Init-Probe)
 ├── argumentation_lean/                            # Lake Lean 4 (5 modules .lean + 5 siblings _en, i18n #4980)
 └── README.md                                      # Ce fichier
 ```
 
-> **Note** : les dossiers `libs/`, `jdk-17-portable/`, `ext_tools/` et `resources/` sont des répertoires d'exécution (non suivis par Git, téléchargés automatiquement par `Tweety-1-Setup.ipynb` ou `scripts/download_tweety_tools.py`). L'ancien dossier `templates student/` n'existe plus dans cette partition. `scripts/` contient 6 scripts `.py` au premier niveau (`download_tweety_tools.py`, `verify_all_tweety.py`, `validate_syntax.py`, `sat_calibration.py`, `sat_comparison_demo.py`, `reorganize_tweety.py`) plus un sous-dossier `archive/` (qui contient une copie de `reorganize_tweety.py` — doublon à consolider). Le dossier `_output/` n'est pas présent dans cette partition (les traces Papermill ne sont pas conservées). Audit §E whole-file gate 2026-07-15.
+> **Note** : les dossiers `libs/`, `jdk-17-portable/`, `ext_tools/` et `resources/` sont des répertoires d'exécution (non suivis par Git, téléchargés automatiquement par `Tweety-1-Setup.ipynb` ou `scripts/download_tweety_tools.py`). L'ancien dossier `templates student/` n'existe plus dans cette partition. `scripts/` contient 5 scripts `.py` au premier niveau (`download_tweety_tools.py`, `verify_all_tweety.py`, `validate_syntax.py`, `sat_calibration.py`, `sat_comparison_demo.py`), 4 tests `test_*.py` et un `README.md`, plus un sous-dossier `_archive/` (qui contient `reorganize_tweety.py`, déplacé depuis le premier niveau — plus de doublon). Le dossier `_output/` n'est pas présent dans cette partition (les traces Papermill ne sont pas conservées). Audit §E whole-file gate 2026-07-15, re-audit 2026-08-15.
 
 ## Outils Externes
 
@@ -516,7 +516,9 @@ python scripts/download_tweety_tools.py --help
 - DLLs Windows (Minisat, Lingeling, Picosat) pour Tweety JNI
 - Téléchargeables automatiquement ou déjà incluses dans `libs/native/`
 
-## Limitations Connues (Tweety 1.28/1.29)
+## Limitations Connues
+
+Limitations constatées à l'origine sous Tweety 1.28/1.29 et toujours documentées dans les notebooks courants (série 1.30 — le notebook 4 cite les changements de package 1.28 pour CrMas, le notebook 5 le `ClassCastException`) :
 
 | Limitation | Impact | Contournement |
 |------------|--------|---------------|
@@ -725,11 +727,11 @@ Le pitch de Tweety tient en un mot : **explicabilité**. Là où un LLM produit 
 
 ---
 
-**Version 1.2.0 — Juillet 2026 — section Statistiques catalogue à jour + section Écosystème MCP et parenté cross-lane. EPIC #3975 tranche tweety.**
+**Version 1.2.1 — Août 2026 — re-audit fichier-entier §E : compte cellules exact (916/371), 18 DLLs shades, scripts/ 5+4+`_archive`, lake `argumentation_lean` 5+5 siblings `_en` (i18n #4980, toolchain v4.32.0), pin IKVM 8.14, limitations re-ancrées 1.30. EPIC #3975 tranche tweety.**
 
 ## Statistiques catalogue à jour
 
-Statistiques détaillées de la sous-série Tweety. Le `pedagogical_count: 32` est lu depuis le marqueur `<!-- CATALOG-STATUS -->` (l. 5-10). Le détail par sous-catégorie ci-dessous est réconcilié avec les étiquettes par-notebook du tableau **Structure** (source granulaire). NB : la ligne `maturity: PRODUCTION=26, BETA=6` du marqueur omet le notebook DRAFT (`Tweety-3-Advanced-Logics-Csharp`, BROKEN) documenté dans toute la série — marqueur signalé comme stale à regénérer (catalog-cron), prose non alignée au marqueur :
+Statistiques détaillées de la sous-série Tweety. Le `pedagogical_count: 32` est lu depuis le marqueur `<!-- CATALOG-STATUS -->` (l. 5-10). Le détail par sous-catégorie ci-dessous est réconcilié avec les étiquettes par-notebook du tableau **Structure** (source granulaire). NB : le marqueur actuel indique `maturity: BETA=30, ALPHA=2` — l'heuristique catalogue ne distingue pas les statuts PROD/BETA/DRAFT du tableau **Structure** (qui fait foi au niveau granulaire, DRAFT = `Tweety-3-Advanced-Logics-Csharp` BROKEN inclus) ; la prose ne s'aligne donc pas sur le marqueur (cf. catalog-pr-hygiene : ne pas s'aligner sur un catalogue faux) :
 
 | Sous-catégorie        |    NB | Statut                       |
 |-----------------------|-------|------------------------------|
@@ -766,7 +768,7 @@ La sous-série Tweety s'inscrit dans un **réseau cross-lane structuré** autour
 | Tweety-4 (révision AGM)           | [SmartContracts](../SmartContracts/) (SC-14)       | Mise à jour de croyances → invariants Solidity, logique de révision on-chain    |
 | Tweety-11 (Causalité, do-calculus)| [ML](../../ML/) (inférence causale)                | do-calculus Pearl ↔ modèles causaux structurels (Pearl 2009)                     |
 
-**Effet de composition** : Tweety est le **carrefour logique** du dépôt — chaque sous-série partenaire (Lean, SemanticWeb, Argument_Analysis, GameTheory, SmartContracts, ML) y trouve un point d'entrée formel vers l'argumentation computationnelle. Le pipeline complet relie les **notebooks** (qui motivent la pertinence du raisonnement explicite) aux **ports C#/.NET** (qui rendent Tweety invocable sans JVM, via IKVM 8.15, EPIC #4667) et aux **lakes** (qui formalisent les théorèmes sous-jacents, ex. Arrow en Lean 4).
+**Effet de composition** : Tweety est le **carrefour logique** du dépôt — chaque sous-série partenaire (Lean, SemanticWeb, Argument_Analysis, GameTheory, SmartContracts, ML) y trouve un point d'entrée formel vers l'argumentation computationnelle. Le pipeline complet relie les **notebooks** (qui motivent la pertinence du raisonnement explicite) aux **ports C#/.NET** (qui rendent Tweety invocable sans JVM, via IKVM 8.14, EPIC #4667) et aux **lakes** (qui formalisent les théorèmes sous-jacents, ex. Arrow en Lean 4).
 
 ## Licence
 


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2023:CoursIA — prev: MED/guard #11060

## Summary

Re-audit **fichier-entier §E** du README feuille Tweety (sous-tranche Tweety de #3975, grain pické via `pick_idle_grain.py`, claim dashboard posé avant édition). 9 corrections prose ↔ disque, toutes vérifiées firsthand contre `origin/main` (head `934bff7e9`).

### Preuves d'audit (§E : fichier entier, pas seulement les lignes corrigées)

- **Comptage disque** : `git ls-tree -r origin/main` → 32 `.ipynb` (12 Python + 1 Lean + 18 C# + 1 probe `_probes/`) — cohérent stats table, Structure table (31 principaux), CATALOG-STATUS `pedagogical_count: 32`, architecture tree.
- **Cellules** : compte exact via parsing JSON des 32 blobs → **916 cellules totales (371 code)**. L'ancien `~430` ne correspondait ni au total ni au code.
- **DLLs** : 18 `org.tweetyproject.tweety-*.dll` à la racine (l'arbre disait 10 — daté d'avant #10499 +5 shades et #10914 7a versionnée).
- **scripts/** : 5 scripts `.py` + 4 `test_*.py` + `README.md` + sous-dossier **`_archive/`** (renommé depuis `archive/`, contient `reorganize_tweety.py` déplacé — plus de doublon racine).
- **Lake `argumentation_lean/`** : dossier `Argumentation/` = **10 fichiers** (5 FR + 5 siblings `_en`, i18n #4980), toolchain `leanprover/lean4:v4.32.0` (#11015). La prose Structure disait « 5 fichiers » alors que l'arbre Architecture disait déjà 5+5 — incohérence interne résolue.
- **IKVM** : pin dominant des `.csproj` dotnet-build = **8.14.0** (10/11) ; intro table et note composition disaient 8.15.
- **Limitations Connues** : header `(Tweety 1.28/1.29)` obsolète — vérifié que les limitations vivent toujours dans les notebooks courants (Tweety-4 : 48 refs CrMas + « classes qui ont changé de package dans Tweety 1.28 » ; Tweety-5 : 2 refs ClassCastException).
- **Marqueur CATALOG-STATUS** : byte-identique à `origin/main` (vérifié `git diff` lignes 5-10 = 0). La section « Statistiques catalogue à jour » citait une ligne de marqueur **obsolète** (`PRODUCTION=26, BETA=6`) alors que le marqueur régénéré par catalog-cron dit désormais `BETA=30, ALPHA=2` — prose réalignée sur la citation actuelle, stance « ne pas s'aligner sur un catalogue faux » conservée (le tableau Structure reste la source granulaire : PROD=24, BETA=7, DRAFT=1 + probe).

## Changements (9)

| # | Avant | Après | Preuve |
|---|-------|-------|--------|
| 1 | Cellules totales `~430` | `916 (dont 371 code)` | parsing 32 blobs |
| 2 | Intro table `IKVM 8.15` | `IKVM 8.14` | 10/11 csproj pin 8.14.0 |
| 3 | Lake « 5 fichiers `.lean` » | 10 fichiers (5 FR + 5 `_en` #4980), toolchain v4.32.0 | ls-tree + lean-toolchain |
| 4 | Arbre : `10 assemblages .NET` | `18 assemblages` | ls-tree racine |
| 5 | Arbre : `reorganize_tweety.py` + `archive/` | `test_*.py` (4 tests) + `_archive/` | ls-tree scripts/ |
| 6 | Note scripts « 6 scripts + archive/ (doublon) » | « 5 scripts + 4 tests + `_archive/` (déplacé, plus de doublon) » | idem |
| 7 | Header `Limitations Connues (Tweety 1.28/1.29)` | Header neutre + phrase de provenance re-ancrée 1.30 | greps notebooks 4/5 |
| 8 | Citation marqueur `PRODUCTION=26, BETA=6` | Citation marqueur actuel `BETA=30, ALPHA=2` | marqueur l. 5-10 |
| 9 | Footer 1.2.0 Juillet | 1.2.1 Août + résumé re-audit | — |

## Signalé hors scope (non corrigé ici)

- **`dotnet-build/build-TweetyPreferencesShade.csproj` pinne `IKVM 8.15.0`** alors que les 10 autres csproj pin 8.14.0 — drift de pin à harmoniser dans une PR build dédiée (risque de rebuild différent, pas touché ici).
- Les commentaires historiques des `pom.xml` Maven évoquent IKVM 8.15 (voie de build antérieure au chemin csproj actuel) — cohérent avec le pin 8.14 actuel dominant.

## Test plan

- [x] `git diff` : 13 insertions / 11 deletions, 1 fichier (README.md seul)
- [x] Marqueur CATALOG-STATUS byte-identique (grep diff = 0 sur l. 5-10)
- [x] Aucun résidu `IKVM 8.15` / `~430` / `10 assemblages` / `archive/` / `PRODUCTION=26` (grep = 0)
- [x] Aucun lien modifié/ajouté (pre-existing links intacts)
- [ ] CI docs

See #3973 (sous-tranche Tweety, l'epic READMEs feuilles reste ouverte). See #3975.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
