### PR TITLE
fix(lane-claim,#11064): --claim verifie d'abord, scope paths rendu dans le marqueur

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -669,13 +669,29 @@ def _path_matches(path: str, patterns: list[str]) -> bool:
 # --- formatted output --------------------------------------------------------
 
 _CLAIM_BODY_TMPL = (
-    "[CLAIMED] lane {lane} -- {intention}\n\n"
+    "[CLAIMED] lane {lane} -- {intention}{paths_clause}\n\n"
     "(check_lane_claim #9774 -- server-stamped UTC; body timestamps are NOT "
     "authoritative. Release with `[RELEASED]` when your PR lands.)\n"
 )
 _RELEASE_BODY_TMPL = (
-    "[RELEASED] lane {lane} -- {note}\n"
+    "[RELEASED] lane {lane} -- {note}{paths_clause}\n"
 )
+
+
+def _paths_clause(paths: list[str] | None) -> str:
+    """Render a `paths:` scope clause for a claim/release marker (#11064).
+
+    The reader (`_PATHS_CLAUSE_RE`) parses the clause at END OF LINE
+    (`paths\\s*:\\s*([^\\n]+?)\\s*$`), so the clause is always the LAST element
+    of the marker line. Empty when `paths` is None -- the marker stays
+    epic-wide (legacy semantics, preserved). `--paths` provided on a posting
+    path was previously DROPPED SILENTLY: the caller believed the claim was
+    scoped while the organ read it epic-wide (maximally blocking). This
+    function is the fix that makes the scope survive the round-trip.
+    """
+    if not paths:
+        return ""
+    return " -- paths: " + ", ".join(paths)
 
 
 def _fmt_utc(iso: str | None) -> str:
@@ -1328,9 +1344,17 @@ def main(argv: list[str] | None = None) -> int:
                         "ignored (legacy epic-wide behaviour, preserved).")
     act = p.add_mutually_exclusive_group()
     act.add_argument("--claim", metavar="INTENTION",
-                     help="post a [CLAIMED] comment for your lane")
+                     help="post a [CLAIMED] comment for your lane. Runs the "
+                          "issue-claim check FIRST and refuses to post when "
+                          "another lane blocks (use --force only for "
+                          "coordinator arbitration). A --paths scope is "
+                          "rendered into the marker, never dropped (#11064).")
     act.add_argument("--release", nargs="?", const="", default=None,
                      metavar="NOTE", help="post a [RELEASED] comment")
+    p.add_argument("--force", action="store_true",
+                   help="post a [CLAIMED] even when the pre-claim check is "
+                        "blocked (#11064). Coordinator arbitration only -- "
+                        "the reading side still honours [OVERRIDE] markers.")
     args = p.parse_args(argv)
 
     # #10881 -- `nargs='+'` on --paths swallows a TRAILING positional issue
@@ -1364,23 +1388,57 @@ def main(argv: list[str] | None = None) -> int:
               file=sys.stderr)
         return 1
     if args.claim is not None:
-        body = _CLAIM_BODY_TMPL.format(lane=args.lane, intention=args.claim)
+        # #11064: `--claim` must not short-circuit the check. The old path
+        # posted FIRST (unchecked) and printed a reassuring "posted" line
+        # while another lane held the claim -- the exact shape of the #11044
+        # collision. Now: run the issue-claim check; a blocked issue REFUSES
+        # to post (exit 1, nothing written). `--force` restores the old
+        # bypass for coordinator arbitration (the reading side still honours
+        # `[OVERRIDE]` markers).
+        if not args.force:
+            try:
+                if args.from_json:
+                    payload = json.loads(
+                        Path(args.from_json).read_text(encoding="utf-8"))
+                else:
+                    payload = _gh_issue_comments(args.issue)
+            except (RuntimeError, json.JSONDecodeError, OSError) as exc:
+                print(f"error: {exc}", file=sys.stderr)
+                return 2
+            rc = _run_check(payload, args.lane,
+                            stale_threshold=args.stale_threshold,
+                            my_paths=args.paths)
+            if rc != 0:
+                print(f"BLOCKED: not posting [CLAIMED] on #{args.issue} "
+                      f"-- another lane holds an active claim (the check "
+                      f"above names it). Use --force only for coordinator "
+                      f"arbitration.",
+                      file=sys.stderr)
+                return rc
+        body = _CLAIM_BODY_TMPL.format(
+            lane=args.lane, intention=args.claim,
+            paths_clause=_paths_clause(args.paths),
+        )
         try:
             _post_comment(args.issue, body)
         except RuntimeError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
-        print(f"posted [CLAIMED] lane {args.lane} on #{args.issue}")
+        scope = f" (paths: {', '.join(args.paths)})" if args.paths else ""
+        print(f"posted [CLAIMED] lane {args.lane} on #{args.issue}{scope}")
         return 0
     if args.release is not None:
         note = args.release or "released"
-        body = _RELEASE_BODY_TMPL.format(lane=args.lane, note=note)
+        body = _RELEASE_BODY_TMPL.format(
+            lane=args.lane, note=note, paths_clause=_paths_clause(args.paths),
+        )
         try:
             _post_comment(args.issue, body)
         except RuntimeError as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
-        print(f"posted [RELEASED] lane {args.lane} on #{args.issue}")
+        scope = f" (paths: {', '.join(args.paths)})" if args.paths else ""
+        print(f"posted [RELEASED] lane {args.lane} on #{args.issue}{scope}")
         return 0
 
     # Check mode (default). `--paths` (when supplied with an issue) threads

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -2369,3 +2369,113 @@ def test_main_paths_correct_form_no_warning(monkeypatch, capsys):
                    "--paths", "a.py", "b.py"])
     assert rc == 0
     assert "bare integer" not in capsys.readouterr().err
+
+
+# --- #11064: --claim runs the check first and renders --paths ----------------
+
+def _write_payload(p, tmp_path):
+    import json
+    f = tmp_path / "payload.json"
+    f.write_text(json.dumps(p), encoding="utf-8")
+    return str(f)
+
+
+def test_paths_clause_renders_only_when_paths_given():
+    # The `paths:` clause is the LAST element of the marker line -- the reader
+    # (`_PATHS_CLAUSE_RE`) parses the value to END OF LINE, so any trailing
+    # prose would leak into the captured scope.
+    assert clc._paths_clause(None) == ""
+    assert clc._paths_clause([]) == ""
+    assert clc._paths_clause(["x/**", "y/01.ipynb"]) == \
+        " -- paths: x/**, y/01.ipynb"
+
+
+def test_claim_body_renders_paths_clause():
+    body = clc._CLAIM_BODY_TMPL.format(
+        lane="myia-po-2024:CoursIA", intention="fix ML-4",
+        paths_clause=clc._paths_clause(["x/**", "y/01.ipynb"]),
+    )
+    assert body.split("\n")[0] == (
+        "[CLAIMED] lane myia-po-2024:CoursIA -- fix ML-4"
+        " -- paths: x/**, y/01.ipynb"
+    )
+
+
+def test_claim_body_without_paths_stays_epic_wide():
+    # A `--claim` without `--paths` keeps the inherited epic-wide semantics --
+    # the fix renders the scope when given, it does not force one.
+    body = clc._CLAIM_BODY_TMPL.format(
+        lane="myia-po-2024:CoursIA", intention="fix ML-4",
+        paths_clause=clc._paths_clause(None),
+    )
+    assert body.split("\n")[0] == \
+        "[CLAIMED] lane myia-po-2024:CoursIA -- fix ML-4"
+
+
+def test_claim_paths_roundtrip_reads_back_scoped(monkeypatch):
+    # #11064 acceptance (4): a claim posted with --paths is read back by the
+    # check as SCOPED -- a disjoint lane stays free (exit 0), an intersecting
+    # lane is blocked (exit 1), an unscoped caller is conservatively blocked.
+    # The fake globs must match "tracked files" or the #10958 fail-safe lifts
+    # the scope to epic-wide (an entirely-dead scope is a broken claim, not a
+    # permissive one) -- mock the repo walk so the scopes stay live.
+    monkeypatch.setattr(clc, "_git_tracked_files",
+                        lambda: ["x/a.ipynb", "y/01.ipynb", "z/deep/f.ipynb"])
+    body = clc._CLAIM_BODY_TMPL.format(
+        lane="A:CoursIA", intention="tranche x",
+        paths_clause=clc._paths_clause(["x/**", "y/01.ipynb"]),
+    )
+    pl = payload(comment(body, "2026-08-15T00:00:00Z"), number=11064, title="t")
+    assert clc._run_check(pl, "B:CoursIA", my_paths=["z/**"]) == 0
+    assert clc._run_check(pl, "B:CoursIA", my_paths=["x/sub/f.ipynb"]) == 1
+    assert clc._run_check(pl, "B:CoursIA") == 1
+
+
+def test_claim_refuses_when_blocked(monkeypatch, tmp_path):
+    # #11064 acceptance (1): `--claim` runs the check before posting and
+    # REFUSES (exit 1, nothing posted) when another lane holds an overlapping
+    # claim -- instead of posting first and printing a reassuring success.
+    blocker = comment(
+        "[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**",
+        "2026-08-15T00:00:00Z",
+    )
+    json_path = _write_payload(
+        payload(blocker, number=11064, title="t"), tmp_path)
+    posted = []
+    monkeypatch.setattr(clc, "_post_comment",
+                        lambda issue, body: posted.append((issue, body)))
+    rc = clc.main(["--lane", "B:CoursIA", "--paths", "x/sub/f.ipynb",
+                   "--claim", "tranche x", "11064", "--from-json", json_path])
+    assert rc == 1
+    assert posted == []
+
+
+def test_claim_force_posts_when_blocked(monkeypatch, tmp_path):
+    # --force restores the coordinator bypass: post even when the pre-claim
+    # check is blocked. The marker must still carry the --paths clause.
+    blocker = comment(
+        "[CLAIMED] lane A:CoursIA -- tranche x -- paths: x/**",
+        "2026-08-15T00:00:00Z",
+    )
+    json_path = _write_payload(
+        payload(blocker, number=11064, title="t"), tmp_path)
+    posted = []
+    monkeypatch.setattr(clc, "_post_comment",
+                        lambda issue, body: posted.append((issue, body)))
+    rc = clc.main(["--lane", "B:CoursIA", "--paths", "x/sub/f.ipynb",
+                   "--claim", "tranche x", "11064", "--from-json", json_path,
+                   "--force"])
+    assert rc == 0
+    assert len(posted) == 1
+    assert "paths: x/sub/f.ipynb" in posted[0][1]
+
+
+def test_release_body_renders_paths_clause():
+    # #11064 fix (3): silence-for-silence -- a scope given on the release path
+    # is rendered, never silently dropped.
+    body = clc._RELEASE_BODY_TMPL.format(
+        lane="myia-po-2024:CoursIA", note="PR #42",
+        paths_clause=clc._paths_clause(["x/**"]),
+    )
+    assert body.split("\n")[0] == \
+        "[RELEASED] lane myia-po-2024:CoursIA -- PR #42 -- paths: x/**"


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/docs #11051

## Summary

`check_lane_claim.py --claim` avait deux défauts qui se composent (issue #11064) :

1. **`--claim` ne vérifiait rien** — court-circuit avant toute lecture (`#1361`), postait d'abord, puis imprimait une ligne "posted" qui se lit comme un feu vert, alors qu'une autre lane pouvait tenir un claim.
2. **`--paths` était silencieusement jeté** — le template n'avait pas d'emplacement pour le scope → marqueur *epic-wide*, maximalement bloquant, exactement l'inverse de l'intention #10419.

**Fix** :
- `--claim` exécute le check d'abord ; une autre lane bloque → `exit 1`, **rien posté** (les lanes bloquantes sont nommées). Échappatoire `--force` pour l'arbitrage coordinateur (le lecteur honore toujours `[OVERRIDE]`).
- `--paths` rendu dans le marqueur **à fin de ligne** (syntaxe exacte que `_PATHS_CLAUSE_RE` parse déjà) : `[CLAIMED] lane <lane> -- <intention> -- paths: <g1>, <g2>`. Un `--claim` sans `--paths` reste epic-wide (sémantique héritée, préservée).
- `--release` rend aussi la clause si fournie (silence-for-silence : un `--paths` donné sur un chemin qui l'ignore n'est plus jeté en silence).
- **Dogfooding validé sur l'issue réelle** : claim posé sur #11064 avec `--paths` via le tool fixé → marqueur posté contient `paths: scripts/check_lane_claim.py, scripts/tests/test_check_lane_claim.py`, et le check relit ce claim comme **scopé** (disjoint → CLEAR).

## Tests

`python -m pytest scripts/tests/test_check_lane_claim.py -q` → **137 passed** (+7 nouveaux : rendu des deux templates, round-trip scope disjoint/intersect/sans-scope, refus quand bloqué, `--force` poste quand même).
`python -m pytest scripts/tests/test_lane_claim_required.py -q` → **27 passed**.
Aucune régression sur le reader (le format paths-en-fin-de-ligne est celui que `_PATHS_CLAUSE_RE` parse déjà).

## Note genre / plancher

MED/guard = **META** (grain déclaré non-plancher G-VAR-1, précédent c.114). Le grain CONTENU de la lane pour le cycle : tranche C de #10996 (GenAI Image/Video/Audio) — actuellement bloquée par un claim epic-wide `myia-po-2026:CoursIA` (réparation 04-4 livrée 12:13Z mais jamais relâchée) ; coordination postée sur l'issue pour lever le blocage.

See #11064
