### PR TITLE
feat(lean,#2159): Partie 41 — lois d'ordre de la forme fleche J.Covers (CoversOrder.lean)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -9,6 +9,7 @@ import Grothendieck.Construction
 import Grothendieck.Cover
 import Grothendieck.CoverageGen
 import Grothendieck.CoversArrow
+import Grothendieck.CoversOrder
 import Grothendieck.CoversPullback
 import Grothendieck.DenseTopology
 import Grothendieck.DirectImage

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversOrder.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversOrder.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 41 : lois d'ordre de la forme flèche
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Les parties 1-40 ont etabli les fondamentaux : categories, cribles,
+topologies, lois de treillis, identites de pullback, bases de faisceaux,
+cloture couvrante, calibration, sous-canonicalite, topologies denses,
+faisceaux, hom interne, cohomologie de Cech, limite de Mayer-Vietoris,
+extensions de Kan, adjonctions, monades, equivalences, categories monoidales,
+limites et colimites, couples comma, images directes, theoremes propres sur la
+forme fleche (`J.Covers S f`), sur la couverture bundlee (`J.Cover X`), les
+lois de coherence du pseudo-foncteur pullback (Partie 37), les lois de
+foncteur du pullback (Partie 38), les lois de treillis des topologies
+(Partie 39) et les lois de la forme fleche sous pullback (Partie 40).
+
+La Partie 41 etablit les **lois d'ordre de la forme fleche `J.Covers S f`** :
+Mathlib fournit les axiomes de topologie en forme fleche (`arrow_max`,
+`arrow_stable`, `arrow_trans`, `arrow_intersect`), le definitif `covers_iff`,
+la monotonie en le crible (`superset_covering`), la loi de pullback
+(`pullback_stable`) et la loi de treillis `pullback_inter`, mais **ne fournit
+pas** le comportement de `J.Covers` vis-a-vis des bornes du treillis des
+cribles (haut, bas, intersection), la stabilite de toute couverture, la
+connexion a la generation `Sieve.generate`, ni la compatibilite du pullback
+avec l'intersection. Ce module les enonce et les prouve :
+
+  - `covers_top` : le crible haut couvre toute fleche.
+  - `covers_bot_iff` : le crible bas couvre `f` si et seulement s'il est
+    couvrant sur le codomaine.
+  - `covers_of_covering` : une couverture de `X` couvre toute fleche vers
+    `X` (forme flèche de `pullback_stable`).
+  - `covers_inter_iff` : `S ⊓ R` couvre `f` si et seulement si `S` et `R`
+    couvrent `f` (reciproque de `arrow_intersect`).
+  - `covers_generate_sieve` : couvrir le crible genere `Sieve.generate S`
+    equivaut a couvrir `S` (un crible est egal au crible qu'il genere).
+  - `covers_pullback_inter` : le pullback de `S ⊓ R` le long de `g ≫ f`
+    couvre exactement l'intersection des pullbacks (loi de compatibilite
+    pullback / intersection en forme flèche).
+
+Chaque preuve est une **preuve tactique reelle** (veine DEEP) : les axiomes
+de topologie (`top_mem`, `pullback_stable`, `superset_covering`,
+`arrow_intersect`) plus les lois de `Sieve.pullback` (`pullback_top`,
+`pullback_bot`, `pullback_comp`, `pullback_inter`) et la generation
+(`Sieve.generate_sieve`). Aucune preuve n'est un re-export.
+
+EPIC #1646, Phase 5 (#2159). Tous les `sorry`s elimines a la creation.
+
+### Convention i18n (EPIC #4980 ratifiee par user 2026-07-04)
+
+Ce module est apparie avec son jumeau anglais dans le fichier sibling
+`CoversOrder_en.lean` (modele sibling pair, voir PR #6154 pour le pilote sur
+`Utility.lean`). Namespace suffix `_en` applique au fichier EN (anti-collision,
+conforme code-style.md #4980). Les enonces de theoremes, les noms de lemmes,
+les tactiques Lean et les references Mathlib restent en anglais ; seules les
+docstrings `/-- ... -/` et les commentaires `-- ...` different entre les deux
+fichiers (preservation byte-identity).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.CoversOrder
+
+open CategoryTheory
+
+/-!
+## Section 1 : bornes du treillis des cribles
+
+Le crible haut `⊤` est couvrant (`top_mem`) ; par definition de la forme
+fleche (`covers_iff`) et `Sieve.pullback_top`, il couvre toute fleche. Le
+crible bas `⊥` est un cas symetrique : son pullback est le bas, donc il ne
+couvre que s'il est deja couvrant sur le codomaine.
+-/
+
+/-- Le crible haut couvre toute fleche : `J.Covers ⊤ f` pour tout `f`.
+    Preuve : `covers_iff` puis `Sieve.pullback_top`, et `top_mem`. -/
+theorem covers_top {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (f : Y ⟶ X) : J.Covers (⊤ : Sieve X) f := by
+  rw [GrothendieckTopology.covers_iff, Sieve.pullback_top]
+  exact J.top_mem Y
+
+/-- Le crible bas couvre `f : Y ⟶ X` si et seulement s'il est couvrant
+    sur `Y` : `J.Covers ⊥ f ↔ ⊥ ∈ J Y`.
+    Preuve : `covers_iff` puis `Sieve.pullback_bot` (le pullback du bas est
+    le bas). -/
+theorem covers_bot_iff {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (f : Y ⟶ X) :
+    J.Covers (⊥ : Sieve X) f ↔ ⊥ ∈ J Y := by
+  rw [GrothendieckTopology.covers_iff, Sieve.pullback_bot]
+
+/-!
+## Section 2 : stabilite d'une couverture
+
+L'axiome `pullback_stable` dit que le pullback d'une couverture est une
+couverture. La forme fleche en est la reformulation directe : une couverture
+de `X` couvre toute fleche vers `X`.
+-/
+
+/-- Une couverture de `X` couvre toute fleche vers `X` :
+    `S ∈ J X → J.Covers S f` (forme flèche de `pullback_stable`).
+    Preuve : `covers_iff` puis l'axiome `J.pullback_stable`. -/
+theorem covers_of_covering {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) {S : Sieve X} (hS : S ∈ J X) (f : Y ⟶ X) :
+    J.Covers S f := by
+  rw [GrothendieckTopology.covers_iff]
+  exact J.pullback_stable f hS
+
+/-!
+## Section 3 : intersection
+
+L'axiome `arrow_intersect` fournit `J.Covers S f → J.Covers R f →
+J.Covers (S ⊓ R) f`. La loi `Sieve.pullback_inter` (le pullback d'une
+intersection est l'intersection des pullbacks) donne la reciproque : si
+`S ⊓ R` couvre `f`, alors chaque facteur couvre `f`.
+-/
+
+/-- `S ⊓ R` couvre `f` si et seulement si `S` et `R` couvrent `f`.
+    Preuve : direction directe — `arrow_intersect` ; direction reciproque —
+    `covers_iff`, `Sieve.pullback_inter`, puis `superset_covering` avec
+    `inf_le_left` et `inf_le_right`. -/
+theorem covers_inter_iff {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (S R : Sieve X) (f : Y ⟶ X) :
+    J.Covers (S ⊓ R) f ↔ J.Covers S f ∧ J.Covers R f := by
+  constructor
+  · intro h
+    rw [GrothendieckTopology.covers_iff] at h ⊢
+    rw [Sieve.pullback_inter] at h
+    exact ⟨J.superset_covering inf_le_left h, J.superset_covering inf_le_right h⟩
+  · rintro ⟨hS, hR⟩
+    exact GrothendieckTopology.arrow_intersect (J := J) (f := f) (S := S) (R := R) hS hR
+
+/-!
+## Section 4 : generation et pullback
+
+Un crible est egal au crible qu'il genere (`Sieve.generate_sieve`) ; couvrir
+l'un equivaut a couvrir l'autre. Enfin, le pullback d'une intersection le
+long d'une composee se factorise : `(S ⊓ R).pullback (g ≫ f)` est le pullback
+de l'intersection des pullbacks.
+-/
+
+/-- Couvrir le crible genere `Sieve.generate S` equivaut a couvrir `S`.
+    Preuve : `covers_iff` des deux membres puis `Sieve.generate_sieve`. -/
+theorem covers_generate_sieve {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (S : Sieve X) (f : Y ⟶ X) :
+    J.Covers (Sieve.generate S) f ↔ J.Covers S f := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    Sieve.generate_sieve]
+
+/-- Compatibilite pullback / intersection en forme fleche : `S ⊓ R` couvre
+    `g ≫ f` si et seulement si `S.pullback f ⊓ R.pullback f` couvre `g`.
+    Preuve : `covers_iff` des deux membres, `Sieve.pullback_comp` (changement
+    de base de la composee) puis `Sieve.pullback_inter` (le pullback d'une
+    intersection est l'intersection des pullbacks). -/
+theorem covers_pullback_inter {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (S R : Sieve X) (f : Y ⟶ X) (g : Z ⟶ Y) :
+    J.Covers (S ⊓ R) (g ≫ f) ↔ J.Covers (S.pullback f ⊓ R.pullback f) g := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    Sieve.pullback_comp, ← Sieve.pullback_inter]
+
+end Grothendieck.CoversOrder

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversOrder_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversOrder_en.lean
@@ -1,0 +1,165 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Grothendieck Homage — Part 41 : order laws of the arrow form
+
+Alexandre Grothendieck (1928-2014).
+
+Phase 5 extension (#2159, EPIC #1646).
+
+Parts 1-40 established the foundations: categories, sieves, topologies,
+lattice laws, pullback identities, sheaf bases, covering closure,
+calibration, subcanonicality, dense topologies, sheaves, internal hom,
+Cech cohomology, Mayer-Vietoris limit, Kan extensions, adjunctions, monads,
+equivalences, monoidal categories, limits and colimits, comma pairs, direct
+images, proper theorems on the arrow form (`J.Covers S f`), on the bundled
+cover (`J.Cover X`), the coherence laws of the pullback pseudo-functor
+(Part 37), the functor laws of pullback (Part 38), the lattice laws of
+topologies (Part 39) and the laws of the arrow form under pullback (Part 40).
+
+Part 41 establishes the **order laws of the arrow form `J.Covers S f`**:
+Mathlib provides the topology axioms in arrow form (`arrow_max`,
+`arrow_stable`, `arrow_trans`, `arrow_intersect`), the definitional
+`covers_iff`, monotonicity in the sieve (`superset_covering`), the pullback
+law (`pullback_stable`) and the lattice law `pullback_inter`, but **does not
+provide** the behavior of `J.Covers` with respect to the bounds of the sieve
+lattice (top, bottom, meet), the stability of every covering sieve, the
+connection to sieve generation `Sieve.generate`, nor the compatibility of
+pullback with meet. This module states and proves them:
+
+  - `covers_top` : the top sieve covers every arrow.
+  - `covers_bot_iff` : the bottom sieve covers `f` if and only if it is
+    covering on the codomain.
+  - `covers_of_covering` : a covering sieve of `X` covers every arrow to `X`
+    (arrow form of `pullback_stable`).
+  - `covers_inter_iff` : `S ⊓ R` covers `f` if and only if `S` and `R`
+    cover `f` (converse of `arrow_intersect`).
+  - `covers_generate_sieve` : covering the generated sieve
+    `Sieve.generate S` is equivalent to covering `S` (a sieve equals the
+    sieve it generates).
+  - `covers_pullback_inter` : the pullback of `S ⊓ R` along `g ≫ f` covers
+    exactly the meet of the pullbacks (compatibility law
+    pullback / meet in arrow form).
+
+Each proof is a **real tactic proof** (DEEP vein): the topology axioms
+(`top_mem`, `pullback_stable`, `superset_covering`, `arrow_intersect`) plus
+the laws of `Sieve.pullback` (`pullback_top`, `pullback_bot`,
+`pullback_comp`, `pullback_inter`) and sieve generation
+(`Sieve.generate_sieve`). No proof is a re-export.
+
+EPIC #1646, Phase 5 (#2159). All `sorry`s eliminated at creation.
+
+### i18n convention (EPIC #4980 ratified by user 2026-07-04)
+
+This module is paired with its French sibling in the sibling file
+`CoversOrder.lean` (sibling pair model, see PR #6154 for the pilot on
+`Utility.lean`). The `_en` namespace suffix is applied to the EN file
+(anti-collision, per code-style.md #4980). Theorem statements, lemma names,
+Lean tactics and Mathlib references remain in English; only the docstrings
+`/-- ... -/` and comments `-- ...` differ between the two files
+(byte-identity preservation).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.CoversOrder_en
+
+open CategoryTheory
+
+/-!
+## Section 1 : bounds of the sieve lattice
+
+The top sieve `⊤` is covering (`top_mem`) ; by definition of the arrow form
+(`covers_iff`) and `Sieve.pullback_top`, it covers every arrow. The bottom
+sieve `⊥` is a symmetric case : its pullback is the bottom, so it covers
+only if it is already covering on the codomain.
+-/
+
+/-- The top sieve covers every arrow : `J.Covers ⊤ f` for every `f`.
+    Proof : `covers_iff` then `Sieve.pullback_top`, and `top_mem`. -/
+theorem covers_top {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (f : Y ⟶ X) : J.Covers (⊤ : Sieve X) f := by
+  rw [GrothendieckTopology.covers_iff, Sieve.pullback_top]
+  exact J.top_mem Y
+
+/-- The bottom sieve covers `f : Y ⟶ X` if and only if it is covering on
+    `Y` : `J.Covers ⊥ f ↔ ⊥ ∈ J Y`.
+    Proof : `covers_iff` then `Sieve.pullback_bot` (the pullback of the
+    bottom is the bottom). -/
+theorem covers_bot_iff {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (f : Y ⟶ X) :
+    J.Covers (⊥ : Sieve X) f ↔ ⊥ ∈ J Y := by
+  rw [GrothendieckTopology.covers_iff, Sieve.pullback_bot]
+
+/-!
+## Section 2 : stability of a covering sieve
+
+The axiom `pullback_stable` says that the pullback of a covering sieve is a
+covering sieve. The arrow form is its direct reformulation : a covering
+sieve of `X` covers every arrow to `X`.
+-/
+
+/-- A covering sieve of `X` covers every arrow to `X` :
+    `S ∈ J X → J.Covers S f` (arrow form of `pullback_stable`).
+    Proof : `covers_iff` then the axiom `J.pullback_stable`. -/
+theorem covers_of_covering {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) {S : Sieve X} (hS : S ∈ J X) (f : Y ⟶ X) :
+    J.Covers S f := by
+  rw [GrothendieckTopology.covers_iff]
+  exact J.pullback_stable f hS
+
+/-!
+## Section 3 : meet
+
+The axiom `arrow_intersect` provides `J.Covers S f → J.Covers R f →
+J.Covers (S ⊓ R) f`. The law `Sieve.pullback_inter` (the pullback of a meet
+is the meet of the pullbacks) gives the converse : if `S ⊓ R` covers `f`,
+then each factor covers `f`.
+-/
+
+/-- `S ⊓ R` covers `f` if and only if `S` and `R` cover `f`.
+    Proof : forward direction — `arrow_intersect` ; converse direction —
+    `covers_iff`, `Sieve.pullback_inter`, then `superset_covering` with
+    `inf_le_left` and `inf_le_right`. -/
+theorem covers_inter_iff {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (S R : Sieve X) (f : Y ⟶ X) :
+    J.Covers (S ⊓ R) f ↔ J.Covers S f ∧ J.Covers R f := by
+  constructor
+  · intro h
+    rw [GrothendieckTopology.covers_iff] at h ⊢
+    rw [Sieve.pullback_inter] at h
+    exact ⟨J.superset_covering inf_le_left h, J.superset_covering inf_le_right h⟩
+  · rintro ⟨hS, hR⟩
+    exact GrothendieckTopology.arrow_intersect (J := J) (f := f) (S := S) (R := R) hS hR
+
+/-!
+## Section 4 : generation and pullback
+
+A sieve equals the sieve it generates (`Sieve.generate_sieve`) ; covering
+one is equivalent to covering the other. Finally, the pullback of a meet
+along a composite factors : `(S ⊓ R).pullback (g ≫ f)` is the pullback of
+the meet of the pullbacks.
+-/
+
+/-- Covering the generated sieve `Sieve.generate S` is equivalent to
+    covering `S`.
+    Proof : `covers_iff` on both members then `Sieve.generate_sieve`. -/
+theorem covers_generate_sieve {C : Type*} [Category C] {X Y : C}
+    (J : GrothendieckTopology C) (S : Sieve X) (f : Y ⟶ X) :
+    J.Covers (Sieve.generate S) f ↔ J.Covers S f := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    Sieve.generate_sieve]
+
+/-- Pullback / meet compatibility in arrow form : `S ⊓ R` covers `g ≫ f`
+    if and only if `S.pullback f ⊓ R.pullback f` covers `g`.
+    Proof : `covers_iff` on both members, `Sieve.pullback_comp` (base change
+    of the composite) then `Sieve.pullback_inter` (the pullback of a meet is
+    the meet of the pullbacks). -/
+theorem covers_pullback_inter {C : Type*} [Category C] {X Y Z : C}
+    (J : GrothendieckTopology C) (S R : Sieve X) (f : Y ⟶ X) (g : Z ⟶ Y) :
+    J.Covers (S ⊓ R) (g ≫ f) ↔ J.Covers (S.pullback f ⊓ R.pullback f) g := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff,
+    Sieve.pullback_comp, ← Sieve.pullback_inter]
+
+end Grothendieck.CoversOrder_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #11057

## Summary

Partie 41 de l'hommage Grothendieck (EPIC #2159, EPIC #1646) : **`CoversOrder.lean`** (FR) + `CoversOrder_en.lean` (EN, i18n #4980) — **6 théorèmes propres** sur les **lois d'ordre de la forme flèche `J.Covers S f`**. Mathlib fournit les axiomes en forme flèche (`arrow_max`, `arrow_stable`, `arrow_trans`, `arrow_intersect`), `covers_iff`, `superset_covering`, `pullback_stable`, `pullback_inter`, mais **aucune loi d'ordre** de `J.Covers` vis-à-vis des bornes du treillis des cribles, de la génération `Sieve.generate`, ni de la compatibilité pullback/intersection : veine DEEP, aucun re-export.

Contenu (6 théorèmes, preuves tactiques réelles) :

| Théorème | Contenu | Briques |
|---|---|---|
| `covers_top` | le crible haut couvre toute flèche : `J.Covers ⊤ f` | `covers_iff` + `Sieve.pullback_top` + `top_mem` |
| `covers_bot_iff` | `J.Covers ⊥ f ↔ ⊥ ∈ J Y` | `covers_iff` + `Sieve.pullback_bot` |
| `covers_of_covering` | une couverture couvre toute flèche : `S ∈ J X → J.Covers S f` (forme flèche de `pullback_stable`) | `covers_iff` + `J.pullback_stable` |
| `covers_inter_iff` | `J.Covers (S ⊓ R) f ↔ J.Covers S f ∧ J.Covers R f` (réciproque de `arrow_intersect`) | `arrow_intersect` + `Sieve.pullback_inter` + `superset_covering` |
| `covers_generate_sieve` | couvrir `Sieve.generate S` ⟺ couvrir `S` | `covers_iff` + `Sieve.generate_sieve` |
| `covers_pullback_inter` | compatibilité pullback/intersection : `J.Covers (S ⊓ R) (g ≫ f) ↔ J.Covers (S.pullback f ⊓ R.pullback f) g` | `Sieve.pullback_comp` + `Sieve.pullback_inter` |

Aggrégateur `Grothendieck.lean` : `import Grothendieck.CoversOrder` (+1 ligne, ordre alphabétique).

## B.1 — Preuve de progrès vérifiable (pr-review-discipline §B)

1. **Compte de `sorry` réel avant/après** : `count_code_sorry.py --json` → `distinct_code_sorry: 0` avant (main) et 0 après (module nouveau, zéro `sorry` à la création). Modules touchés : `CoversOrder` (nouveau), `Grothendieck.lean` (import seul). Aucun module existant modifié → pas de régression possible.
2. **Lake build SUCCESS** (log ci-dessous, WSL, cache AZ warm) :

```
lake build Grothendieck
Build completed successfully (2837 jobs), EXIT=0
```

3. **Proof integrity** : job CI `proof-integrity` sur `grothendieck_lean` (workflow `lean-axiom.yml`) — attendu vert au PR gate (aucun axiome interdit introduit : 0 `sorryAx`, 0 `native_decide.*`, 0 `Classical.choice` non-whitelisté).
4. **B.3** : non applicable — le module est importé par l'agrégateur `Grothendieck.lean`, qui est le target-module du job.

## i18n (#4980) — sibling pair byte-identity

`check_i18n_siblings.py .../grothendieck_lean` → vérifié : **40/41 pairs byte-identical + 1 consumer-pattern, 0 drift, 0 orphan** (la paire `CoversOrder` est parmi les 40 byte-identical — énoncés, preuves, tactiques identiques ; docstrings traduites FR/EN ; namespace `Grothendieck.CoversOrder` ↔ `_en`).

## Scope

- `+330/-0` lignes : 2 nouveaux modules Lean (FR 164 + EN 165) + 1 ligne agrégateur.
- Pas de notebook, pas de catalogue, pas de code hors lake.
- `See #2159` (livraison partielle de l'EPIC Phase 5 — une partie de plus, l'EPIC reste ouverte).
