### PR TITLE
docs(#6693): la technique C548-L2 est le SVG inline, pas Plotly-CDN (variante retiree par #6927)

### DIFF
--- a/.claude/rules/notebook-conventions.md
+++ b/.claude/rules/notebook-conventions.md
@@ -37,7 +37,7 @@ Les cellules doivent suivre un **ordre canonique** sans glissement ni oubli. Fri
 
 - **Python notebooks** : Papermill pour batch (`notebook_tools.py execute <path>`)
 - **.NET notebooks** : Papermill avec kernel `.net-csharp` fonctionne (verifie SW-3, 50/50 cells). Sauf `#!import` (MCP Jupyter cell-by-cell en fallback). Prefere Papermill quand possible.
-- **.NET figures Plotly** (Prong-A #3801) : `#r "nuget:"` charting est bloque headless (c.547-L1) → utiliser la technique **C548-L2 « zero-restore »** (`record PlotlyHtml` + `Formatter.Register` + Plotly.js CDN, zero NuGet), jamais un workaround ASCII. Template canonique + piege du `layout` 3e argument + gate de merge : [docs/reference/dotnet-plotly-zero-restore.md](../../docs/reference/dotnet-plotly-zero-restore.md).
+- **.NET figures** (Prong-A #3801) : `#r "nuget:"` charting est bloque headless (c.547-L1) → utiliser la technique **C548-L2 « zero-restore »** = **SVG inline** emis en `text/html` (`record PlotSvg` + `Formatter.Register`, ou `display(HTML(...))` direct), zero NuGet — jamais un workaround ASCII. **La variante Plotly.js-par-CDN est RETIREE** (#6927/#6946) : GitHub sandboxe les `<script>`, donc elle rend **blanc** partout ou le notebook est consulte plutot qu'execute — 8 notebooks mesures. Templates canoniques verifies + gate de merge : [docs/reference/dotnet-plotly-zero-restore.md](../../docs/reference/dotnet-plotly-zero-restore.md).
 - **WSL notebooks** (GameTheory/Lean) : `wsl_papermill.py` (cf [.claude/rules/wsl-kernels.md](wsl-kernels.md))
 - Working directory explicite pour notebooks avec paths relatifs
 - `BATCH_MODE=true` pour notebooks avec widgets interactifs

--- a/docs/reference/dotnet-plotly-zero-restore.md
+++ b/docs/reference/dotnet-plotly-zero-restore.md
@@ -1,93 +1,127 @@
-# Pattern .NET Interactive — figures Plotly « zero-restore » (technique C548-L2)
+# Pattern .NET Interactive — figures « zero-restore » (technique C548-L2, variante SVG inline)
 
 **Statut** : pattern cluster-wide validé (2026-07). Registre : EPIC **#3801** (SOTA axe-2, Prong-A « vrai outil, pas workaround dégradé »).
 **Scope** : toute cellule de notebook `.NET Interactive` (C#) qui doit produire une **figure réelle** (bar chart, histogramme, courbe) là où un `#r "nuget: Plotly.NET…"` échoue.
+
+> **La charge utile est du SVG inline, pas du Plotly.js.** La variante d'origine de cette technique injectait Plotly.js depuis un CDN ; elle est **retirée** depuis #6927 / #6946 parce qu'elle rend **blanc** partout où le notebook est *consulté* plutôt qu'*exécuté*. Voir [§Variante retirée](#variante-retirée--plotlyjs-par-cdn-ne-plus-utiliser). Le nom de fichier reste `dotnet-plotly-zero-restore.md` pour ne pas casser les liens entrants ; l'épisode Plotly est documenté ci-dessous plutôt qu'effacé.
 
 ## Problème — `#r "nuget:"` charting bloqué en headless
 
 Les notebooks `.NET Interactive` exécutés en CI ou via Papermill headless ne peuvent pas restaurer les paquets NuGet de charting (`Plotly.NET`, `XPlot.Plotly`, …) : le restore `#r "nuget:"` est **bloqué cluster-wide** (verdict c.547-L1 = RECOVERABLE-ENV, règle F — cf [genai-config](../../.claude/rules/genai-config.md) et CLAUDE.md §F). Conséquence historique : les cellules retombaient sur un **workaround ASCII dégradé** (`new string('#', barLen)`), lui-même **interdit** par le Prong-A #3801 (cf [sota-not-workaround.md](../../.claude/rules/sota-not-workaround.md)).
 
-## Solution — formatter HTML intégré au kernel, zéro NuGet
+## Solution — SVG inline émis en `text/html`, zéro NuGet
 
-La technique **C548-L2 « zero-restore »** enregistre un formatter `text/html` sur un `record` porteur du markup Plotly, et injecte Plotly.js depuis le CDN. **Aucun paquet NuGet n'est restauré** : le kernel émet directement du HTML que le notebook rend comme `display_data` `text/html`.
+La technique **C548-L2 « zero-restore »** fait émettre par le kernel un `text/html` contenant un **`<svg>` construit à la main**. Aucun paquet NuGet n'est restauré, **et** la figure est un artefact **persistant** dans le notebook committé : elle rend en kernel live, sur GitHub, sur nbviewer et hors-ligne.
 
-### Préambule (idempotent, une fois par cellule)
+Deux formes coexistent sur `main`, toutes deux valides — choisir selon que la cellule émet une ou plusieurs figures.
+
+### Forme A — `record` + formatter (réutilisable sur plusieurs cellules)
 
 ```csharp
 using Microsoft.DotNet.Interactive.Formatting;
 using System.IO;
-record PlotlyHtml(string Markup);
-Formatter.Register(typeof(PlotlyHtml),
-    (obj, writer) => ((TextWriter)writer).Write(((PlotlyHtml)obj).Markup), "text/html");
+using System.Text;
+record PlotSvg(string Markup);
+Formatter.Register(typeof(PlotSvg),
+    (obj, writer) => ((TextWriter)writer).Write(((PlotSvg)obj).Markup), "text/html");
 ```
+
+puis `display(new PlotSvg(BuildBarSvgH(labels, values, titre, axeX)));`
+
+Le formatter est enregistré **une fois** et le `record` reste disponible pour les cellules suivantes du même kernel — c'est la forme à préférer dès qu'un notebook trace plus d'une figure.
+
+### Forme B — `display(HTML(...))` direct (figure unique, sans infrastructure)
+
+```csharp
+display(HTML(BuildBarSvgH(labels, values, titre, axeX)));
+```
+
+Pas de `record`, pas de `Formatter.Register`. Suffisant quand la cellule est autonome.
 
 > Rappel C# : les directives `using` doivent précéder tout `namespace` / déclaration locale dans la cellule (CS1529, cf leçons C553-L1 / L504-L1) — placer le préambule **en tête** de cellule.
 
-### Émission d'une figure
+> Piège de localisation : sérialiser les coordonnées en **culture invariante** (`CultureInfo.InvariantCulture`). Une virgule décimale dans un attribut SVG (`x='12,5'`) casse silencieusement la géométrie — la figure s'affiche, déformée ou vide.
 
-```csharp
-var divId = "plt" + Guid.NewGuid().ToString("N");
-var trace = System.Text.Json.JsonSerializer.Serialize(
-    new Dictionary<string, object> {
-        ["x"] = xValues, ["y"] = yLabels, ["type"] = "bar", ["orientation"] = "h",
-        ["marker"] = new Dictionary<string,object>{ ["color"] = colors },
-        ["text"] = xValues, ["textposition"] = "auto" });
-var layout = "{\"title\":{\"text\":\"…\"}," +
-             "\"xaxis\":{\"title\":{\"text\":\"…\"},\"zeroline\":true}," +
-             "\"yaxis\":{\"title\":{\"text\":\"…\"}},\"margin\":{\"l\":120,\"r\":40}}";
-var markup = "<div id=\"" + divId + "\"></div>" +
-             "<script src=\"https://cdn.plot.ly/plotly-2.35.2.min.js\"></script>" +
-             "<script>Plotly.newPlot('" + divId + "',[" + trace + "]," + layout + ")</script>";
-display(new PlotlyHtml(markup));
-```
+### Références canoniques (vérifiées sur `main`)
 
-Référence canonique complète : `MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-10-CenterBias.ipynb` cellule `[8]` (barre horizontale signée, split couleur `>=0` / `<0`, `zeroline`).
+| Forme | Notebook | Cellule | Preuve |
+|---|---|---|---|
+| **A** (`record PlotSvg`) | `MyIA.AI.Notebooks/Search/Applications/CSP/App-7b-Wordle-CSharp.ipynb` | `[21]` (barres horizontales, entropie par mot) ; infra réutilisée en `[33]` | `execution_count: 11`, sortie `text/html` commençant par `<svg viewBox="0 0 720 460"` |
+| **B** (`display(HTML(...))`) | `MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-10-CenterBias.ipynb` | `[8]` (barre horizontale signée, split couleur `>=0` / `<0`) | `execution_count: 5`, sortie `text/html` commençant par `<div><svg viewBox='0 0 720 374'` |
 
-## Piège — le `layout` est le 3ᵉ argument de `Plotly.newPlot`, PAS un 4ᵉ trace
+Les deux pointeurs sont **résolus firsthand** (index de cellule, `execution_count`, premiers octets de la sortie committée) et non recopiés d'un body de PR. C'est le minimum exigible d'une « référence canonique » : cf l'incident qui a produit cette section, [§Provenance](#provenance-de-cette-correction).
 
-`Plotly.newPlot(divId, dataArray, layout)` prend le `layout` comme **3ᵉ argument**. L'erreur récurrente est de placer l'objet `layout` en **4ᵉ position du tableau `data`** : Plotly.js le parse alors comme un trace implicite (sans `x`/`y`, silencieusement ignoré) et **titre + labels d'axes + `barmode`/`zeroline` ne s'appliquent pas** au rendu (incident #6689 Infer-12, noté par la review §H.4). Toujours **fermer le tableau `data`** puis passer `layout` séparément : `Plotly.newPlot(id, [trace1, trace2], layout)`.
+## Variante retirée — Plotly.js par CDN (ne plus utiliser)
+
+La forme d'origine enregistrait un `record PlotlyHtml` porteur d'un `<div>` + `<script src="https://cdn.plot.ly/plotly-2.35.2.min.js">` + `Plotly.newPlot(...)`. **Elle est retirée**, et la raison n'est pas esthétique :
+
+> Le graphe rend **uniquement dans un kernel .NET Interactive live avec Internet**. Partout où le notebook committé est *consulté* plutôt qu'*exécuté*, il est **blanc** : GitHub *sandbox et n'exécute pas* les `<script>` → div vide ; nbviewer / offline / CSP strict → le CDN ne charge pas → div vide.
+> — investigation #6927 (firsthand, 2026-07-16), déclenchée par le user constatant qu'`Infer-17-Kalman-Filter` **n'affiche aucun graphique**
+
+Ce n'était pas une perte de données (les `x`/`y` sont inline dans le script) mais une **régression de portabilité du rendu** : le jumeau Python (matplotlib) émettait un `image/png` persistant, les deux jumeaux divergeaient. #6927 a mesuré **8 notebooks** touchés ; #6946 a livré la première conversion.
+
+**Ne pas reverter vers Plotly par principe** : le passage ASCII → Plotly (#6599) était une vraie amélioration Prong-A. Ce qui est proscrit est la **variante CDN-script**, qui ne produit aucun artefact statique. Une figure Plotly *interactive* reste défendable en kernel live si — et seulement si — un artefact statique accompagne la cellule.
+
+### Piège historique (variante retirée uniquement)
+
+`Plotly.newPlot(divId, dataArray, layout)` prend le `layout` comme **3ᵉ argument**. L'erreur récurrente était de le placer en 4ᵉ position du tableau `data` : Plotly.js le parsait comme un trace implicite silencieusement ignoré, et titre + labels + `zeroline` ne s'appliquaient pas (incident #6689 Infer-12). Conservé ici pour le diagnostic des notebooks non encore convertis — sans objet pour le SVG inline.
 
 ## Vérification (gate de merge)
 
-Une conversion Prong-A .NET → Plotly est validée quand :
+Une conversion Prong-A .NET → figure réelle est validée quand :
 
 - `execution_count != null` sur la cellule convertie (gate #5214 pour .NET — l'advisory CI autorise à sauter la ré-exécution CI des notebooks .NET, **pas** à committer des sorties vides ; l'exécution locale reste obligatoire) ;
-- la sortie committée contient un `display_data` `text/html` avec `Plotly.newPlot` **et** des tableaux `x`/`y` **non vides** (figure de données réelle, pas coquille vide) ;
+- la sortie committée contient un `display_data` `text/html` porteur d'un **`<svg>` avec géométrie réelle** — au moins un `<rect>`/`<path>`/`<line>` dont les coordonnées ne sont pas toutes nulles (figure de données, pas cadre vide) ;
+- **`0` occurrence de `cdn.plot.ly`** dans la source de la cellule, hors commentaire documentant la conversion ;
 - `0` motif `new string('#'` (barre ASCII de données) résiduel dans la source ;
 - catalogue byte-identique à `main`.
 
-Cf [sota-not-workaround.md](../../.claude/rules/sota-not-workaround.md) §Prong-A (5 verdicts SOTA) et [pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) §D/§H.
+> Ce gate exigeait auparavant `Plotly.newPlot` **dans la sortie committée**. Aucune des cellules réellement converties sur `main` ne l'aurait passé : le gate rejetait les instances conformes et acceptait celles qui rendent blanc. C'est le défaut central corrigé ici.
 
-## QA visuelle — pourquoi le gate Plotly-CDN est *structurel*, pas un cycle vision par PR
+## QA visuelle — ce que le forensique attrape, et ce qu'il n'attrape pas
 
-La règle de routage vision ([model-delegation.md](../../.claude/rules/model-delegation.md) §« Capacité vision ») impose de faire vérifier tout rendu visuel par un modèle qui **voit** (MiniMax sur lane CoursIA-2, ou ai-01/Opus), jamais text-only sur une lane GLM. Cette exigence vise la classe de sortie où **« exister sur disque » ≠ « rend correctement »** : le raster statique (PNG matplotlib, image GenAI, screenshot de slide) peut être un bloc de couleur plat, une image blanche ou un placeholder — un défaut que **seul le regard** distingue d'une vraie figure (incident fondateur `workflow-orchestration.png`, 3 blocs plats consacrés comme « images générées »).
+La règle de routage vision ([model-delegation.md](../../.claude/rules/model-delegation.md) §« Capacité vision ») impose de faire vérifier tout rendu visuel par un modèle qui **voit**, jamais text-only. Elle vise la classe où **« exister sur disque » ≠ « rend correctement »**.
 
-**La sortie Plotly `text/html` + CDN de la technique C548-L2 n'appartient PAS à cette classe.** Elle est **rendue côté client par Plotly.js** de façon **déterministe** : à partir d'un tableau `data` non vide, d'un `layout` bien placé (3ᵉ argument) et d'un CDN joignable, le SVG produit est une fonction pure des données sérialisées dans la cellule. Il n'existe **pas** de mode d'échec « bloc plat / image blanche » propre au client : le rendu échoue de façon **structurelle et détectable dans la source committée**, pas de façon silencieuse-visuelle. Les trois modes d'échec réels sont tous forensiques :
+**Le SVG inline est forensiquement inspectable** — la géométrie est dans la sortie committée, en clair : un `<rect>` de largeur nulle, une série toute à zéro, un `viewBox` incohérent se lisent sans regard. C'est ce qui rend le gate ci-dessus efficace. Trois modes d'échec restent **invisibles au forensique** et exigent un regard :
 
-| Mode d'échec Plotly-CDN | Détection (sans regard) |
-|-------------------------|-------------------------|
-| Tableau `x`/`y` **vide** (coquille sans données) | grep sur la sortie : `x`/`y` non vides (déjà au gate de merge ci-dessus) |
-| `layout` en **4ᵉ trace** au lieu de 3ᵉ argument (titre/axes/`barmode` non appliqués) | piège C450-L1 ci-dessus : vérifier `Plotly.newPlot(id, [traces], layout)` |
-| **CDN absent** (`<script src="…plotly…">` manquant) | grep : présence du `<script src="https://cdn.plot.ly/…">` |
+| Mode d'échec | Détectable sans regard ? |
+|---|---|
+| Géométrie nulle / série vide / cadre sans données | **oui** — grep sur les coordonnées de la sortie |
+| Séparateur décimal virgule (culture non invariante) | **oui** — grep `='\d+,\d` dans les attributs SVG |
+| Couleurs illisibles, chevauchement de labels, axes inversés | **non** — spot-check visuel |
 
-**Conséquence opérationnelle — le gate visuel de la classe Plotly-CDN = forensique + un spot-check de rendu par vague de rollout, PAS un aller-retour MiniMax par PR.** Le contrôle de merge d'une conversion C548-L2 est donc :
+**Le contrôle de merge est donc : forensique par PR (obligatoire) + spot-check de rendu par vague ou par nouveau type de figure** — extraire le SVG committé → HTML autonome → screenshot → lire l'image depuis une lane qui voit (MiniMax/CoursIA-2 ou ai-01). Pas d'aller-retour vision à chaque PR une fois le type de figure validé.
 
-1. **Forensique par PR** (obligatoire, automatisable) : `x`/`y` non vides, `layout` en 3ᵉ arg, `<script>` CDN présent, `0` motif `new string('#'` résiduel — c'est le gate de merge de la section précédente.
-2. **Spot-check de rendu par vague / par nouveau type de trace** (échantillon, pas exhaustif) : extraire le markup Plotly committé → HTML autonome → screenshot (Playwright) → **lire l'image** depuis un modèle qui voit (MiniMax/CoursIA-2 ou ai-01/Opus). Ce spot-check attrape les bugs de **génération de données** que le forensique ne voit pas (série toute à zéro, mauvais mapping de couleurs, axes inversés) et valide le pattern pour la vague — il n'a **pas** à être refait pour chaque PR une fois la classe validée.
+## Provenance de cette correction
 
-Ainsi le routage vision reste correct **sans créer de goulot** : la classe où le regard est indispensable (raster statique) part vers MiniMax/ai-01 systématiquement ; la classe Plotly-CDN (déterministe côté client) est gatée par le forensique + un spot-check périodique. Validation empirique de ce partage : 3 conversions du rollout 2026-07 (#6696 barres groupées, #6698 barres + heatmap Viridis, #6700 courbe) rendues et **vues** — figures réelles conformes aux données, aucun bloc plat/placeholder (vision-audit ai-01, 2026-07-15).
+Cette section existe parce que la version précédente de ce fichier affirmait le contraire de ce qui précède, et que l'affirmation a survécu un mois à une review qui la contestait.
 
-## Notebooks utilisant le pattern (rollout 2026-07, #3801)
+- **2026-07-15** — la doc est mergée (#6693) malgré une review `CHANGES_REQUESTED` signalant que sa « référence canonique » pointait une cellule sans figure copiable. Elle contenait aussi un raisonnement concluant que la classe Plotly-CDN **n'a pas besoin de QA visuelle par PR**, parce que le rendu client serait déterministe et ses modes d'échec tous forensiques — avec, en appui, un audit vision « 3 conversions rendues et **vues**, figures réelles ».
+- **2026-07-16** — le user constate qu'un notebook de la famille n'affiche **aucun** graphique. L'investigation #6927 établit que **toute** la classe est blanche en consultation statique, sur 8 notebooks.
 
-App-7b-Wordle-CSharp (#6683), GameTheory-15c-CooperativeGames (#6684), GameTheory-3-Topology2x2 (#6687), Infer-12-Modeles-Hierarchiques (#6689), Search MGS-10-CenterBias (#6692) — rollout continu sous l'EPIC #3801.
+L'audit vision de la veille n'était pas faux : il avait regardé les bonnes figures **dans le mauvais renderer** (kernel live, où le CDN s'exécute). La table des « modes d'échec » de la doc en omettait un — le seul qui se produisait réellement — et son absence servait à conclure qu'on pouvait se passer du regard. C'est le mécanisme, plus que le contenu, qui vaut d'être retenu : **une preuve rendue sur une surface qui n'est pas celle du livrable ne prouve rien du livrable.**
+
+Le pointeur `MGS-10 cell[8]`, lui, est devenu **exact** entre-temps, mais par accident : la cellule a été convertie en SVG inline par la vague #6927, si bien qu'elle contient désormais bien une barre horizontale signée — sous une technique que l'ancienne version de cette doc ne décrivait pas. La review avait raison au moment où elle l'a écrit.
+
+## Notebooks du rollout (état mesuré sur `main`, 2026-08-15)
+
+| État | Notebooks |
+|---|---|
+| **Converti** (SVG inline, plus de CDN dans la source) | `App-7b-Wordle-CSharp`, `MGS-10-CenterBias` |
+| **Partiel** (SVG inline **et** cellules CDN résiduelles) | `GameTheory-3-Topology2x2-Csharp`, `Infer-17-Kalman-Filter`, `Sudoku-18-Comparison-Csharp` |
+| **Non converti** (CDN seul → blanc en statique) | `Infer-11-Topic-Models`, `Infer-12-Modeles-Hierarchiques`, `DecInfer-6-Value-Information`, `DecInfer-7-Expert-Systems`, `DecInfer-8-Sequential` |
+
+Mesure reproductible : source de cellule de code contenant `PlotSvg` / `cdn.plot.ly` / `PlotlyHtml`, sur `git ls-files "*.ipynb"`. Les 5 « non converti » + 3 « partiel » sont le reste du rollout #6927 sous l'EPIC #3801.
 
 ## Refactor possible (memo)
 
-Extraire le préambule (`record PlotlyHtml` + `Formatter.Register`) dans un helper partagé chargé via `#load` (ex. `notebook-helpers/PlotlyHelper.cs`) éviterait la ré-inscription du formatter dans chaque cellule. Attention à la re-entry (`Formatter.Register` appelé par deux cellules) — la mitigation actuelle est un préambule **idempotent par cellule** ; un helper devrait garder l'enregistrement idempotent (garde `if`/registre statique).
+Extraire le préambule de la forme A (`record PlotSvg` + `Formatter.Register`) dans un helper partagé chargé via `#load` (ex. `notebook-helpers/PlotSvgHelper.cs`) éviterait la ré-inscription du formatter dans chaque notebook. Attention à la re-entry (`Formatter.Register` appelé deux fois) — la mitigation actuelle est un préambule **idempotent par cellule** ; un helper devrait garder l'enregistrement idempotent (garde `if`/registre statique).
 
 ## Voir aussi
 
 - [sota-not-workaround.md](../../.claude/rules/sota-not-workaround.md) — Prong-A : vrai outil, jamais workaround dégradé (EPIC #3801)
 - [pr-review-discipline.md](../../.claude/rules/pr-review-discipline.md) — §D (preuve d'exécution notebook) + §H (SOTA)
 - [notebook-conventions.md](../../.claude/rules/notebook-conventions.md) — §Exécution (.NET Papermill `.net-csharp`)
+- [model-delegation.md](../../.claude/rules/model-delegation.md) — §Capacité vision : router le QA visuel vers une lane qui voit
+- #6927 (investigation blanc-en-statique, 8 notebooks) · #6946 (première conversion) · #6693 (la review dont la correction avait été ignorée)
 - CLAUDE.md §F — environnement : réparer, jamais contourner


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/guard #11045

See #11044 (remédiation Phase 2 — le gate #6693, que je m'étais publiquement attribué)
See #6693 (la review `CHANGES_REQUESTED` mergée sans être adressée, il y a un mois)

## Ce que ça corrige

`docs/reference/dotnet-plotly-zero-restore.md` documentait la technique C548-L2 comme `record PlotlyHtml` + `Formatter.Register` + injection **Plotly.js depuis un CDN**. Mesuré sur `main` (`git ls-files "*.ipynb"`, 1015 notebooks) :

```
record PlotlyHtml               dans les notebooks trackés : 0
Plotly.newPlot dans une cellule de code                    : 0
record PlotSvg / display(HTML(...)) SVG inline             : 2 notebooks convertis
```

La technique prescrite n'a **aucune instance**, parce qu'elle a été **retirée** par #6927 / #6946 : le `<script src="cdn.plot.ly">` est sandboxé par GitHub et ne charge pas hors-ligne, donc la figure est **blanche partout où le notebook est consulté plutôt qu'exécuté**. #6927 avait mesuré 8 notebooks touchés — investigation déclenchée par le user constatant qu'`Infer-17-Kalman-Filter` n'affichait aucun graphique.

`.claude/rules/notebook-conventions.md:40` envoyait tous les agents reproduire cette variante. Un worker suivant le harnais aujourd'hui produit des figures blanches sur GitHub.

## Les trois défauts, par ordre de gravité

**1. Le gate de merge rejetait les instances conformes.** Il exigeait `Plotly.newPlot` **dans la sortie committée**. Aucune des quatre cellules réellement converties ne l'a. Le gate acceptait donc exactement ce qui rend blanc, et refusait ce qui rend partout. Remplacé par : `<svg>` à géométrie réelle + `0` occurrence de `cdn.plot.ly` en source.

**2. La section QA-visuelle démontrait qu'on peut se passer du regard.** Elle argumentait que la classe Plotly-CDN est déterministe côté client, listait « les trois modes d'échec réels, tous forensiques », et concluait à un gate forensique sans aller-retour vision par PR — en appui, un audit vision « 3 conversions rendues et **vues** ».

La table omettait le mode d'échec qui se produisait réellement. Et l'audit vision invoqué datait du **2026-07-15** ; l'investigation qui a établi que toute la classe est blanche date du **2026-07-16** — le lendemain. L'audit n'était pas faux : il avait regardé les bonnes figures **dans le mauvais renderer** (kernel live, où le CDN s'exécute). La leçon est écrite dans la doc plutôt qu'effacée : *une preuve rendue sur une surface qui n'est pas celle du livrable ne prouve rien du livrable.*

**3. La référence canonique.** C'était le nit de #6693, et il faut être précis parce que ce dépôt paie cher les reprises non mesurées : **la review avait raison quand elle l'a écrite, et son pointeur est devenu exact depuis, par accident.** MGS-10 `cell[8]` ne contenait pas de figure copiable le 15 juillet ; la vague #6927 l'a convertie en SVG inline, si bien qu'elle porte aujourd'hui bien une barre horizontale signée — sous une technique que l'ancienne doc ne décrivait pas. Les deux références sont désormais résolues firsthand (cellule, `execution_count`, premiers octets de la sortie committée), pas recopiées d'un body de PR.

## Ce que la doc dit maintenant

- Deux formes valides, toutes deux mesurées sur `main` : **A** `record PlotSvg` + formatter (réutilisable multi-cellules), **B** `display(HTML(...))` direct (figure unique).
- Références canoniques : `App-7b-Wordle-CSharp` `[21]` (`exec=11`, sortie `<svg viewBox="0 0 720 460"`) et `MGS-10-CenterBias` `[8]` (`exec=5`, sortie `<div><svg viewBox='0 0 720 374'`).
- Piège de localisation ajouté : virgule décimale dans un attribut SVG → géométrie silencieusement cassée. C'est le mode d'échec propre à la nouvelle technique, absent de l'ancienne.
- Le piège `layout`-3ᵉ-argument est conservé, marqué **historique** — utile pour diagnostiquer les 8 notebooks non encore convertis, sans objet pour le SVG.
- État du rollout mesuré : **2 convertis** · **3 partiels** (SVG *et* cellules CDN résiduelles) · **5 non convertis**. Le reste du rollout #6927 est donc chiffré et retrouvable.

Le nom de fichier reste `dotnet-plotly-zero-restore.md` : 4 liens entrants, et l'épisode Plotly fait légitimement partie de ce que la doc raconte.

## Vérification

```
$ git ls-files "*.ipynb" | wc -l
1015
```

Chaque chiffre du tableau de rollout vient d'un scan des sources de cellules de code sur cette liste (critère : `PlotSvg` / `cdn.plot.ly` / `PlotlyHtml`), pas d'un body de PR. Les deux `execution_count` et les deux préfixes de sortie sont lus dans les notebooks eux-mêmes.

Aucun notebook n'est modifié par cette PR — doc + une ligne de règle. C.2/C.3 sans objet.

## Tier et classe, dits honnêtement

`MED` : ça change ce que le harnais **instruit** à tous les agents, et ça répare un gate qui inversait son propre critère. Le litmus LIGHT ne passe pas — il a fallu lire la review, l'investigation #6927, et mesurer trois variantes sur l'arbre tracké.

Mais `docs` est un genre de classe **META** : cette PR **ne tient pas** un plancher G-VAR-1, et je ne la présente pas comme tel. C'est de la remédiation d'un item d'Epic que je m'étais attribué, pas le plat principal d'un cycle.

## Claim

`[OVERRIDE] lane myia-ai-01:CoursIA -- paths: docs/reference/dotnet-plotly-zero-restore.md, .claude/rules/notebook-conventions.md`, écrit sur #11044. Les 4 claims ouvertes y sont des **fenêtres de dates** de triage ; aucune ne touche un fichier de doc. Elles bloquent parce que `check_lane_claim.py --claim` jette `--paths` (#11064). `gh pr list` : aucune PR ouverte sur ces deux chemins.
