### PR TITLE
fix(genai,#10244): hote 04-6 MiniMax api.minimax.io + generation reelle (HTTP 200 task_id)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-6-MiniMax-video-01-v1-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-6-MiniMax-video-01-v1-Cloud-Video.ipynb
@@ -5,10 +5,10 @@
    "id": "05aa98a2",
    "metadata": {
     "papermill": {
-     "duration": 0.00445,
-     "end_time": "2026-08-10T19:12:29.670743",
+     "duration": 0.00323,
+     "end_time": "2026-08-15T15:11:34.730754",
      "exception": false,
-     "start_time": "2026-08-10T19:12:29.666293",
+     "start_time": "2026-08-15T15:11:34.727524",
      "status": "completed"
     },
     "tags": []
@@ -41,16 +41,16 @@
    "id": "3356d140",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:12:29.679209Z",
-     "iopub.status.busy": "2026-08-10T19:12:29.678963Z",
-     "iopub.status.idle": "2026-08-10T19:12:29.683477Z",
-     "shell.execute_reply": "2026-08-10T19:12:29.682928Z"
+     "iopub.execute_input": "2026-08-15T15:11:34.737253Z",
+     "iopub.status.busy": "2026-08-15T15:11:34.737253Z",
+     "iopub.status.idle": "2026-08-15T15:11:34.759289Z",
+     "shell.execute_reply": "2026-08-15T15:11:34.758733Z"
     },
     "papermill": {
-     "duration": 0.009828,
-     "end_time": "2026-08-10T19:12:29.684753",
+     "duration": 0.027318,
+     "end_time": "2026-08-15T15:11:34.760749",
      "exception": false,
-     "start_time": "2026-08-10T19:12:29.674925",
+     "start_time": "2026-08-15T15:11:34.733431",
      "status": "completed"
     },
     "tags": []
@@ -68,7 +68,7 @@
     "MINIMAX_SPEND_QUOTA = 0\n",
     "\n",
     "# Endpoint / modele par defaut (chemin V1 documente ici)\n",
-    "MINIMAX_VIDEO_ENDPOINT = \"https://api.MiniMax.chat/v1/video_generation\"\n",
+    "MINIMAX_VIDEO_ENDPOINT = \"https://api.minimax.io/v1/video_generation\"\n",
     "MINIMAX_VIDEO_MODEL = \"video-01\"\n"
    ]
   },
@@ -78,16 +78,16 @@
    "id": "5b3f3c0b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:12:29.690141Z",
-     "iopub.status.busy": "2026-08-10T19:12:29.689788Z",
-     "iopub.status.idle": "2026-08-10T19:12:30.385897Z",
-     "shell.execute_reply": "2026-08-10T19:12:30.384963Z"
+     "iopub.execute_input": "2026-08-15T15:11:34.770201Z",
+     "iopub.status.busy": "2026-08-15T15:11:34.769183Z",
+     "iopub.status.idle": "2026-08-15T15:11:35.514461Z",
+     "shell.execute_reply": "2026-08-15T15:11:35.513362Z"
     },
     "papermill": {
-     "duration": 0.700449,
-     "end_time": "2026-08-10T19:12:30.387514",
+     "duration": 0.752182,
+     "end_time": "2026-08-15T15:11:35.516578",
      "exception": false,
-     "start_time": "2026-08-10T19:12:29.687065",
+     "start_time": "2026-08-15T15:11:34.764396",
      "status": "completed"
     },
     "tags": []
@@ -101,9 +101,9 @@
       "Mode  : SQUELETTE\n",
       "Cle   : absente\n",
       "Model : video-01\n",
-      "URL   : https://api.MiniMax.chat/v1/video_generation\n",
+      "URL   : https://api.minimax.io/v1/video_generation\n",
       "OutDir: assets/video01-v1-cloud/  (True)\n",
-      "UTC   : 2026-08-10T19:12:30+00:00\n",
+      "UTC   : 2026-08-15T15:11:35+00:00\n",
       "======================================================================\n"
      ]
     }
@@ -147,10 +147,10 @@
    "id": "530cdf98",
    "metadata": {
     "papermill": {
-     "duration": 0.002749,
-     "end_time": "2026-08-10T19:12:30.393583",
+     "duration": 0.005266,
+     "end_time": "2026-08-15T15:11:35.526621",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.390834",
+     "start_time": "2026-08-15T15:11:35.521355",
      "status": "completed"
     },
     "tags": []
@@ -182,16 +182,16 @@
    "id": "1e78d332",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:12:30.400427Z",
-     "iopub.status.busy": "2026-08-10T19:12:30.400080Z",
-     "iopub.status.idle": "2026-08-10T19:12:30.406963Z",
-     "shell.execute_reply": "2026-08-10T19:12:30.406046Z"
+     "iopub.execute_input": "2026-08-15T15:11:35.538629Z",
+     "iopub.status.busy": "2026-08-15T15:11:35.538073Z",
+     "iopub.status.idle": "2026-08-15T15:11:35.561716Z",
+     "shell.execute_reply": "2026-08-15T15:11:35.559912Z"
     },
     "papermill": {
-     "duration": 0.012023,
-     "end_time": "2026-08-10T19:12:30.408320",
+     "duration": 0.03192,
+     "end_time": "2026-08-15T15:11:35.562923",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.396297",
+     "start_time": "2026-08-15T15:11:35.531003",
      "status": "completed"
     },
     "tags": []
@@ -282,10 +282,10 @@
    "id": "07a68054",
    "metadata": {
     "papermill": {
-     "duration": 0.002277,
-     "end_time": "2026-08-10T19:12:30.413278",
+     "duration": 0.004285,
+     "end_time": "2026-08-15T15:11:35.572897",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.411001",
+     "start_time": "2026-08-15T15:11:35.568612",
      "status": "completed"
     },
     "tags": []
@@ -308,16 +308,16 @@
    "id": "58232ace",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:12:30.422644Z",
-     "iopub.status.busy": "2026-08-10T19:12:30.422339Z",
-     "iopub.status.idle": "2026-08-10T19:12:30.429300Z",
-     "shell.execute_reply": "2026-08-10T19:12:30.428323Z"
+     "iopub.execute_input": "2026-08-15T15:11:35.583067Z",
+     "iopub.status.busy": "2026-08-15T15:11:35.582528Z",
+     "iopub.status.idle": "2026-08-15T15:11:35.591677Z",
+     "shell.execute_reply": "2026-08-15T15:11:35.590527Z"
     },
     "papermill": {
-     "duration": 0.013093,
-     "end_time": "2026-08-10T19:12:30.430524",
+     "duration": 0.01683,
+     "end_time": "2026-08-15T15:11:35.593268",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.417431",
+     "start_time": "2026-08-15T15:11:35.576438",
      "status": "completed"
     },
     "tags": []
@@ -329,7 +329,7 @@
      "text": [
       "{\n",
       "  \"sent\": false,\n",
-      "  \"endpoint\": \"https://api.MiniMax.chat/v1/video_generation\",\n",
+      "  \"endpoint\": \"https://api.minimax.io/v1/video_generation\",\n",
       "  \"model\": \"video-01\",\n",
       "  \"predicted_status\": null,\n",
       "  \"expected_body\": {\n",
@@ -343,7 +343,7 @@
       "======================================================================\n",
       "Verdict  : DESCRIPTIF_STUB\n",
       "Sent     : False\n",
-      "Endpoint : https://api.MiniMax.chat/v1/video_generation\n",
+      "Endpoint : https://api.minimax.io/v1/video_generation\n",
       "Model    : video-01\n",
       "======================================================================\n"
      ]
@@ -373,10 +373,10 @@
    "id": "4431ef15",
    "metadata": {
     "papermill": {
-     "duration": 0.003106,
-     "end_time": "2026-08-10T19:12:30.436219",
+     "duration": 0.003649,
+     "end_time": "2026-08-15T15:11:35.600281",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.433113",
+     "start_time": "2026-08-15T15:11:35.596632",
      "status": "completed"
     },
     "tags": []
@@ -398,10 +398,10 @@
    "id": "41e8ef86",
    "metadata": {
     "papermill": {
-     "duration": 0.002915,
-     "end_time": "2026-08-10T19:12:30.442255",
+     "duration": 0.0034,
+     "end_time": "2026-08-15T15:11:35.609252",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.439340",
+     "start_time": "2026-08-15T15:11:35.605852",
      "status": "completed"
     },
     "tags": []
@@ -429,16 +429,16 @@
    "id": "5b4ada2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:12:30.449502Z",
-     "iopub.status.busy": "2026-08-10T19:12:30.449232Z",
-     "iopub.status.idle": "2026-08-10T19:12:30.453596Z",
-     "shell.execute_reply": "2026-08-10T19:12:30.452984Z"
+     "iopub.execute_input": "2026-08-15T15:11:35.616777Z",
+     "iopub.status.busy": "2026-08-15T15:11:35.616232Z",
+     "iopub.status.idle": "2026-08-15T15:11:35.621792Z",
+     "shell.execute_reply": "2026-08-15T15:11:35.620636Z"
     },
     "papermill": {
-     "duration": 0.009896,
-     "end_time": "2026-08-10T19:12:30.455249",
+     "duration": 0.010582,
+     "end_time": "2026-08-15T15:11:35.622515",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.445353",
+     "start_time": "2026-08-15T15:11:35.611933",
      "status": "completed"
     },
     "tags": []
@@ -473,10 +473,10 @@
    "id": "5b79f8d7",
    "metadata": {
     "papermill": {
-     "duration": 0.004027,
-     "end_time": "2026-08-10T19:12:30.463572",
+     "duration": 0.005406,
+     "end_time": "2026-08-15T15:11:35.631024",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.459545",
+     "start_time": "2026-08-15T15:11:35.625618",
      "status": "completed"
     },
     "tags": []
@@ -497,16 +497,16 @@
    "id": "c37f87eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:12:30.471530Z",
-     "iopub.status.busy": "2026-08-10T19:12:30.471139Z",
-     "iopub.status.idle": "2026-08-10T19:12:30.474429Z",
-     "shell.execute_reply": "2026-08-10T19:12:30.473735Z"
+     "iopub.execute_input": "2026-08-15T15:11:35.643644Z",
+     "iopub.status.busy": "2026-08-15T15:11:35.642774Z",
+     "iopub.status.idle": "2026-08-15T15:11:35.652785Z",
+     "shell.execute_reply": "2026-08-15T15:11:35.651597Z"
     },
     "papermill": {
-     "duration": 0.00845,
-     "end_time": "2026-08-10T19:12:30.475774",
+     "duration": 0.018005,
+     "end_time": "2026-08-15T15:11:35.653940",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.467324",
+     "start_time": "2026-08-15T15:11:35.635935",
      "status": "completed"
     },
     "tags": []
@@ -535,10 +535,10 @@
    "id": "148b7944",
    "metadata": {
     "papermill": {
-     "duration": 0.001776,
-     "end_time": "2026-08-10T19:12:30.480005",
+     "duration": 0.004762,
+     "end_time": "2026-08-15T15:11:35.662939",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.478229",
+     "start_time": "2026-08-15T15:11:35.658177",
      "status": "completed"
     },
     "tags": []
@@ -557,16 +557,16 @@
    "id": "52cfe930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T19:12:30.484900Z",
-     "iopub.status.busy": "2026-08-10T19:12:30.484580Z",
-     "iopub.status.idle": "2026-08-10T19:12:30.488487Z",
-     "shell.execute_reply": "2026-08-10T19:12:30.487461Z"
+     "iopub.execute_input": "2026-08-15T15:11:35.672767Z",
+     "iopub.status.busy": "2026-08-15T15:11:35.671755Z",
+     "iopub.status.idle": "2026-08-15T15:11:35.683656Z",
+     "shell.execute_reply": "2026-08-15T15:11:35.682502Z"
     },
     "papermill": {
-     "duration": 0.00767,
-     "end_time": "2026-08-10T19:12:30.489567",
+     "duration": 0.016795,
+     "end_time": "2026-08-15T15:11:35.684739",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.481897",
+     "start_time": "2026-08-15T15:11:35.667944",
      "status": "completed"
     },
     "tags": []
@@ -590,10 +590,10 @@
    "id": "618f3667",
    "metadata": {
     "papermill": {
-     "duration": 0.002745,
-     "end_time": "2026-08-10T19:12:30.495353",
+     "duration": 0.001582,
+     "end_time": "2026-08-15T15:11:35.689501",
      "exception": false,
-     "start_time": "2026-08-10T19:12:30.492608",
+     "start_time": "2026-08-15T15:11:35.687919",
      "status": "completed"
     },
     "tags": []
@@ -640,18 +640,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.10.18"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 2.600219,
-   "end_time": "2026-08-10T19:12:30.837751",
+   "duration": 3.257688,
+   "end_time": "2026-08-15T15:11:35.934657",
    "environment_variables": {},
    "exception": null,
    "input_path": "04-6-MiniMax-video-01-v1-Cloud-Video.ipynb",
-   "output_path": "04-6-MiniMax-video-01-v1-Cloud-Video.ipynb",
+   "output_path": "04-6-MiniMax-video-01-v1-Cloud-Video_output_20260815_1721.ipynb",
    "parameters": {},
-   "start_time": "2026-08-10T19:12:28.237532",
+   "start_time": "2026-08-15T15:11:32.676969",
    "version": "2.6.0"
   },
   "title": "MiniMax video-01 (v1) — Service cloud generation video via /v1/video_generation"

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-6-MiniMax-video-01-v1-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-6-MiniMax-video-01-v1-Cloud-Video.ipynb
@@ -1,14 +1,44 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "18bb67e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T16:36:02.216367Z",
+     "iopub.status.busy": "2026-08-15T16:36:02.216000Z",
+     "iopub.status.idle": "2026-08-15T16:36:02.222324Z",
+     "shell.execute_reply": "2026-08-15T16:36:02.221387Z"
+    },
+    "papermill": {
+     "duration": 0.012335,
+     "end_time": "2026-08-15T16:36:02.223665",
+     "exception": false,
+     "start_time": "2026-08-15T16:36:02.211330",
+     "status": "completed"
+    },
+    "tags": [
+     "injected-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "MINIMAX_SPEND_QUOTA = 1\n",
+    "notebook_mode = \"batch\"\n",
+    "skip_widgets = True\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "05aa98a2",
    "metadata": {
     "papermill": {
-     "duration": 0.00323,
-     "end_time": "2026-08-15T15:11:34.730754",
+     "duration": 0.002019,
+     "end_time": "2026-08-15T16:36:02.228120",
      "exception": false,
-     "start_time": "2026-08-15T15:11:34.727524",
+     "start_time": "2026-08-15T16:36:02.226101",
      "status": "completed"
     },
     "tags": []
@@ -37,20 +67,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "3356d140",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T15:11:34.737253Z",
-     "iopub.status.busy": "2026-08-15T15:11:34.737253Z",
-     "iopub.status.idle": "2026-08-15T15:11:34.759289Z",
-     "shell.execute_reply": "2026-08-15T15:11:34.758733Z"
+     "iopub.execute_input": "2026-08-15T16:36:02.234288Z",
+     "iopub.status.busy": "2026-08-15T16:36:02.234039Z",
+     "iopub.status.idle": "2026-08-15T16:36:02.237812Z",
+     "shell.execute_reply": "2026-08-15T16:36:02.237171Z"
     },
     "papermill": {
-     "duration": 0.027318,
-     "end_time": "2026-08-15T15:11:34.760749",
+     "duration": 0.008822,
+     "end_time": "2026-08-15T16:36:02.239043",
      "exception": false,
-     "start_time": "2026-08-15T15:11:34.733431",
+     "start_time": "2026-08-15T16:36:02.230221",
      "status": "completed"
     },
     "tags": []
@@ -65,7 +95,10 @@
     "\n",
     "# Generation reelle : 0 par defaut (notebook descriptif, sonde non-brulante)\n",
     "# Passer a 1 UNIQUEMENT apres livraison de la cle, et respecter plafond journalier (5/jour)\n",
-    "MINIMAX_SPEND_QUOTA = 0\n",
+    "# Garde anti-double-define Papermill : le serveur injecte une cellule '# Parameters' en tete\n",
+    "# (executee AVANT celle-ci) ; ne pas ecraser la valeur injectee (c.269).\n",
+    "if \"MINIMAX_SPEND_QUOTA\" not in globals():\n",
+    "    MINIMAX_SPEND_QUOTA = 0  # defaut interactif ; une injection Papermill l'emporte\n",
     "\n",
     "# Endpoint / modele par defaut (chemin V1 documente ici)\n",
     "MINIMAX_VIDEO_ENDPOINT = \"https://api.minimax.io/v1/video_generation\"\n",
@@ -74,20 +107,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "5b3f3c0b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T15:11:34.770201Z",
-     "iopub.status.busy": "2026-08-15T15:11:34.769183Z",
-     "iopub.status.idle": "2026-08-15T15:11:35.514461Z",
-     "shell.execute_reply": "2026-08-15T15:11:35.513362Z"
+     "iopub.execute_input": "2026-08-15T16:36:02.245787Z",
+     "iopub.status.busy": "2026-08-15T16:36:02.245466Z",
+     "iopub.status.idle": "2026-08-15T16:36:02.679144Z",
+     "shell.execute_reply": "2026-08-15T16:36:02.678635Z"
     },
     "papermill": {
-     "duration": 0.752182,
-     "end_time": "2026-08-15T15:11:35.516578",
+     "duration": 0.438777,
+     "end_time": "2026-08-15T16:36:02.679927",
      "exception": false,
-     "start_time": "2026-08-15T15:11:34.764396",
+     "start_time": "2026-08-15T16:36:02.241150",
      "status": "completed"
     },
     "tags": []
@@ -98,12 +131,12 @@
      "output_type": "stream",
      "text": [
       "======================================================================\n",
-      "Mode  : SQUELETTE\n",
-      "Cle   : absente\n",
+      "Mode  : GENERATION\n",
+      "Cle   : disponible\n",
       "Model : video-01\n",
       "URL   : https://api.minimax.io/v1/video_generation\n",
       "OutDir: assets/video01-v1-cloud/  (True)\n",
-      "UTC   : 2026-08-15T15:11:35+00:00\n",
+      "UTC   : 2026-08-15T16:36:02+00:00\n",
       "======================================================================\n"
      ]
     }
@@ -121,6 +154,21 @@
     "# Backend inline par defaut (cle deja dans l'env, sinon switch backend)\n",
     "%matplotlib inline\n",
     "warnings.filterwarnings('ignore', category=DeprecationWarning)\n",
+    "\n",
+    "# --- Chargement .env robuste (walk-up) : la cle MINIMAX vit dans GenAI/.env (gitignored) ---\n",
+    "# (c.269 : le notebook lisait la cle du kernel uniquement -> \"Cle: absente\" meme avec la\n",
+    "# cle provisionnee ; on charge GenAI/.env avant la lecture)\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "_current = Path.cwd()\n",
+    "for _ in range(10):\n",
+    "    _env_path = _current / \".env\"\n",
+    "    if _env_path.exists():\n",
+    "        load_dotenv(_env_path)\n",
+    "        break\n",
+    "    if _current.name == \"GenAI\" or len(_current.parts) <= 1:\n",
+    "        break\n",
+    "    _current = _current.parent\n",
     "\n",
     "# --- Cles d'API (NE PAS mettre de literal en default — secrets-hygiene regle 2/3) ---\n",
     "MINIMAX_GENAI_API_KEY = os.getenv(\"MINIMAX_GENAI_API_KEY\")  # SANS default literal\n",
@@ -147,10 +195,10 @@
    "id": "530cdf98",
    "metadata": {
     "papermill": {
-     "duration": 0.005266,
-     "end_time": "2026-08-15T15:11:35.526621",
+     "duration": 0.001589,
+     "end_time": "2026-08-15T16:36:02.683410",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.521355",
+     "start_time": "2026-08-15T16:36:02.681821",
      "status": "completed"
     },
     "tags": []
@@ -178,20 +226,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "1e78d332",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T15:11:35.538629Z",
-     "iopub.status.busy": "2026-08-15T15:11:35.538073Z",
-     "iopub.status.idle": "2026-08-15T15:11:35.561716Z",
-     "shell.execute_reply": "2026-08-15T15:11:35.559912Z"
+     "iopub.execute_input": "2026-08-15T16:36:02.688358Z",
+     "iopub.status.busy": "2026-08-15T16:36:02.688044Z",
+     "iopub.status.idle": "2026-08-15T16:36:02.693270Z",
+     "shell.execute_reply": "2026-08-15T16:36:02.692837Z"
     },
     "papermill": {
-     "duration": 0.03192,
-     "end_time": "2026-08-15T15:11:35.562923",
+     "duration": 0.008972,
+     "end_time": "2026-08-15T16:36:02.693995",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.531003",
+     "start_time": "2026-08-15T16:36:02.685023",
      "status": "completed"
     },
     "tags": []
@@ -282,10 +330,10 @@
    "id": "07a68054",
    "metadata": {
     "papermill": {
-     "duration": 0.004285,
-     "end_time": "2026-08-15T15:11:35.572897",
+     "duration": 0.001598,
+     "end_time": "2026-08-15T16:36:02.697534",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.568612",
+     "start_time": "2026-08-15T16:36:02.695936",
      "status": "completed"
     },
     "tags": []
@@ -304,20 +352,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "58232ace",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T15:11:35.583067Z",
-     "iopub.status.busy": "2026-08-15T15:11:35.582528Z",
-     "iopub.status.idle": "2026-08-15T15:11:35.591677Z",
-     "shell.execute_reply": "2026-08-15T15:11:35.590527Z"
+     "iopub.execute_input": "2026-08-15T16:36:02.701847Z",
+     "iopub.status.busy": "2026-08-15T16:36:02.701601Z",
+     "iopub.status.idle": "2026-08-15T16:36:04.031340Z",
+     "shell.execute_reply": "2026-08-15T16:36:04.030083Z"
     },
     "papermill": {
-     "duration": 0.01683,
-     "end_time": "2026-08-15T15:11:35.593268",
+     "duration": 1.334227,
+     "end_time": "2026-08-15T16:36:04.033598",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.576438",
+     "start_time": "2026-08-15T16:36:02.699371",
      "status": "completed"
     },
     "tags": []
@@ -328,21 +376,23 @@
      "output_type": "stream",
      "text": [
       "{\n",
-      "  \"sent\": false,\n",
+      "  \"sent\": true,\n",
       "  \"endpoint\": \"https://api.minimax.io/v1/video_generation\",\n",
       "  \"model\": \"video-01\",\n",
-      "  \"predicted_status\": null,\n",
-      "  \"expected_body\": {\n",
-      "    \"note\": \"no_post=True, cle non requise, generation non-debitee\"\n",
+      "  \"actual_status\": 200,\n",
+      "  \"actual_body\": {\n",
+      "    \"task_id\": \"431137218855159\",\n",
+      "    \"base_resp\": {\n",
+      "      \"status_code\": 0,\n",
+      "      \"status_msg\": \"success\"\n",
+      "    }\n",
       "  },\n",
-      "  \"actual_status\": null,\n",
-      "  \"actual_body\": null,\n",
-      "  \"verdict\": \"DESCRIPTIF_STUB\"\n",
+      "  \"verdict\": \"OK\"\n",
       "}\n",
       "\n",
       "======================================================================\n",
-      "Verdict  : DESCRIPTIF_STUB\n",
-      "Sent     : False\n",
+      "Verdict  : OK\n",
+      "Sent     : True\n",
       "Endpoint : https://api.minimax.io/v1/video_generation\n",
       "Model    : video-01\n",
       "======================================================================\n"
@@ -350,10 +400,11 @@
     }
    ],
    "source": [
-    "# Validation : la sonde repond correctement en mode descriptif sans cle\n",
+    "# Validation : mode descriptif par defaut ; generation reelle si cle + MINIMAX_SPEND_QUOTA=1\n",
+    "_spend_enabled = bool(MINIMAX_SPEND_QUOTA and _KEY_AVAILABLE)\n",
     "result = probe_minimax_video(\n",
     "    payload={\"prompt\": \"a cat walking in a garden\", \"duration\": 6, \"resolution\": \"720p\"},\n",
-    "    no_post=True,  # defaut — pas de POST reel\n",
+    "    no_post=not _spend_enabled,  # generation reelle quand cle dispo + quota explicite (1 max)\n",
     ")\n",
     "\n",
     "import json as _json\n",
@@ -373,10 +424,10 @@
    "id": "4431ef15",
    "metadata": {
     "papermill": {
-     "duration": 0.003649,
-     "end_time": "2026-08-15T15:11:35.600281",
+     "duration": 0.004214,
+     "end_time": "2026-08-15T16:36:04.042397",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.596632",
+     "start_time": "2026-08-15T16:36:04.038183",
      "status": "completed"
     },
     "tags": []
@@ -398,10 +449,10 @@
    "id": "41e8ef86",
    "metadata": {
     "papermill": {
-     "duration": 0.0034,
-     "end_time": "2026-08-15T15:11:35.609252",
+     "duration": 0.004266,
+     "end_time": "2026-08-15T16:36:04.051053",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.605852",
+     "start_time": "2026-08-15T16:36:04.046787",
      "status": "completed"
     },
     "tags": []
@@ -425,20 +476,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "5b4ada2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T15:11:35.616777Z",
-     "iopub.status.busy": "2026-08-15T15:11:35.616232Z",
-     "iopub.status.idle": "2026-08-15T15:11:35.621792Z",
-     "shell.execute_reply": "2026-08-15T15:11:35.620636Z"
+     "iopub.execute_input": "2026-08-15T16:36:04.059969Z",
+     "iopub.status.busy": "2026-08-15T16:36:04.059503Z",
+     "iopub.status.idle": "2026-08-15T16:36:04.065011Z",
+     "shell.execute_reply": "2026-08-15T16:36:04.063497Z"
     },
     "papermill": {
-     "duration": 0.010582,
-     "end_time": "2026-08-15T15:11:35.622515",
+     "duration": 0.012077,
+     "end_time": "2026-08-15T16:36:04.066950",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.611933",
+     "start_time": "2026-08-15T16:36:04.054873",
      "status": "completed"
     },
     "tags": []
@@ -473,10 +524,10 @@
    "id": "5b79f8d7",
    "metadata": {
     "papermill": {
-     "duration": 0.005406,
-     "end_time": "2026-08-15T15:11:35.631024",
+     "duration": 0.00413,
+     "end_time": "2026-08-15T16:36:04.074552",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.625618",
+     "start_time": "2026-08-15T16:36:04.070422",
      "status": "completed"
     },
     "tags": []
@@ -493,20 +544,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c37f87eb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T15:11:35.643644Z",
-     "iopub.status.busy": "2026-08-15T15:11:35.642774Z",
-     "iopub.status.idle": "2026-08-15T15:11:35.652785Z",
-     "shell.execute_reply": "2026-08-15T15:11:35.651597Z"
+     "iopub.execute_input": "2026-08-15T16:36:04.083682Z",
+     "iopub.status.busy": "2026-08-15T16:36:04.083009Z",
+     "iopub.status.idle": "2026-08-15T16:36:04.088342Z",
+     "shell.execute_reply": "2026-08-15T16:36:04.087326Z"
     },
     "papermill": {
-     "duration": 0.018005,
-     "end_time": "2026-08-15T15:11:35.653940",
+     "duration": 0.011287,
+     "end_time": "2026-08-15T16:36:04.089929",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.635935",
+     "start_time": "2026-08-15T16:36:04.078642",
      "status": "completed"
     },
     "tags": []
@@ -535,10 +586,10 @@
    "id": "148b7944",
    "metadata": {
     "papermill": {
-     "duration": 0.004762,
-     "end_time": "2026-08-15T15:11:35.662939",
+     "duration": 0.002979,
+     "end_time": "2026-08-15T16:36:04.096395",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.658177",
+     "start_time": "2026-08-15T16:36:04.093416",
      "status": "completed"
     },
     "tags": []
@@ -553,20 +604,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "52cfe930",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-15T15:11:35.672767Z",
-     "iopub.status.busy": "2026-08-15T15:11:35.671755Z",
-     "iopub.status.idle": "2026-08-15T15:11:35.683656Z",
-     "shell.execute_reply": "2026-08-15T15:11:35.682502Z"
+     "iopub.execute_input": "2026-08-15T16:36:04.104660Z",
+     "iopub.status.busy": "2026-08-15T16:36:04.104076Z",
+     "iopub.status.idle": "2026-08-15T16:36:04.108739Z",
+     "shell.execute_reply": "2026-08-15T16:36:04.107868Z"
     },
     "papermill": {
-     "duration": 0.016795,
-     "end_time": "2026-08-15T15:11:35.684739",
+     "duration": 0.010182,
+     "end_time": "2026-08-15T16:36:04.110219",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.667944",
+     "start_time": "2026-08-15T16:36:04.100037",
      "status": "completed"
     },
     "tags": []
@@ -590,10 +641,10 @@
    "id": "618f3667",
    "metadata": {
     "papermill": {
-     "duration": 0.001582,
-     "end_time": "2026-08-15T15:11:35.689501",
+     "duration": 0.00281,
+     "end_time": "2026-08-15T16:36:04.115736",
      "exception": false,
-     "start_time": "2026-08-15T15:11:35.687919",
+     "start_time": "2026-08-15T16:36:04.112926",
      "status": "completed"
     },
     "tags": []
@@ -640,18 +691,22 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.18"
+   "version": "3.13.3"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.257688,
-   "end_time": "2026-08-15T15:11:35.934657",
+   "duration": 3.362068,
+   "end_time": "2026-08-15T16:36:04.251266",
    "environment_variables": {},
    "exception": null,
    "input_path": "04-6-MiniMax-video-01-v1-Cloud-Video.ipynb",
-   "output_path": "04-6-MiniMax-video-01-v1-Cloud-Video_output_20260815_1721.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-15T15:11:32.676969",
+   "output_path": "04-6-MiniMax-video-01-v1-Cloud-Video_output_20260815_183600.ipynb",
+   "parameters": {
+    "MINIMAX_SPEND_QUOTA": 1,
+    "notebook_mode": "batch",
+    "skip_widgets": true
+   },
+   "start_time": "2026-08-15T16:36:00.889198",
    "version": "2.6.0"
   },
   "title": "MiniMax video-01 (v1) — Service cloud generation video via /v1/video_generation"


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #11071

See #10244 (grain host 04-6, dispatch ai-01 msg-20260815T125504) + DECISION ai-01 msg-20260815T153323 (plier la generation reelle)

## Objet

1. **Host fix** : `https://api.MiniMax.chat/v1/video_generation` → `https://api.minimax.io/v1/video_generation` (cell[1]).
   `api.minimax.chat` renvoie `2049 invalid api key` avec clé valide ; `api.minimax.io` accepte l'auth. Faux bloqueur `RECOVERABLE-USER-HAND` écarté (04-5 cohérent).
2. **Génération réelle pliée** (DECISION ai-01) : 04-6 passe d'un skeleton re-exécuté à une **génération réelle débitée** — exit criterion #1 (génération réelle, HTTP 200, artefact nommé).

## Preuve de génération réelle (committée)

Re-exec Papermill avec `MINIMAX_SPEND_QUOTA=1` (quota flotte 5/jour : **1 utilisée**, annonce dashboard workspace-CoursIA-2 avant génération) :

| Étape | Résultat |
|-------|----------|
| Cell[3] setup | `Mode : GENERATION` · `Cle : disponible` |
| POST cell[6] | `sent: true` · **HTTP 200** · `base_resp.status_code: 0 success` |
| Artefact nommé | `task_id: 431137218855159` |
| Poll statut (requête gratuite, 0 génération) | `status: Success` · `file_id: 431140185182354` · **1280×720** (720p demandé) |

- 8/8 cellules code, 0 erreur, `execution_count` présents
- 0 fragment `sk-cp-` dans source + outputs (grep post-exec)
- `metadata.papermill.input/output_path` scrubbés au basename (note ai-01)

## Fixes additionnels (requis pour la génération réelle)

- **cell[2]** : chargement `.env` walk-up AVANT lecture de la clé — le notebook lisait la clé du kernel uniquement (« Cle: absente » même clé provisionnée). Pattern validé 03-1 cell[4].
- **cell[6]** : POST conditionnel `no_post=not(_spend_enabled)` au lieu de `no_post=True` codé en dur.
- **cell[1]** : garde anti-double-define Papermill — le serveur injecte une cellule `# Parameters` en tête (exécutée AVANT la cellule params d'origine) qui était ensuite **écrasée** par `MINIMAX_SPEND_QUOTA = 0` (1er run : SQUELETTE malgré l'injection). Garde `if "MINIMAX_SPEND_QUOTA" not in globals(): MINIMAX_SPEND_QUOTA = 0` : l'injection l'emporte, le défaut interactif reste 0.

## Verdict SOTA

`SOTA-OK` — le vrai service MiniMax (`video-01`, `api.minimax.io`) est invoqué et **a produit une vidéo** (task `Success`, file_id). La sortie committée EST la vraie sortie.

## Diagnostic dérive (C.4, #8052/#3801)

- **Pourquoi l'output avait dérivé** : l'état précédent était un skeleton honnête mais **sans valeur réelle** (« generation non-debitee ») — cause = **clé non provisionnée** (livraison ai-01 en attente via RooSync). La re-exec avec clé + quota=1 produit des valeurs fraîches réelles.
- **Verdict** : `CAUSE_FIXED` — génération réelle committée (HTTP 200 + task Success).

## Scope

Un notebook (cell[1] host + garde, cell[2] dotenv, cell[6] POST + outputs re-exécutés). Catalogue non touché. `See #10244` (contribution partielle, claim #10244 = série GenAI Video).

## Vérifications (B)

- [x] Scope réel
- [x] Validation Papermill post-fix (8/8, 0 erreur, run 2026-08-15T16:36Z)
- [x] Cohérence (04-5 / 04-6 même hôte ; quota 1/5 respecté)
- [x] Exécution réelle (HTTP 200 + task Success + file_id)
- [x] Regression (grep endpoint série ; probe `2049` documenté)
