### PR TITLE
feat(gametheory,#10382): GT-14 tranche 2 — pont MathNet.Numerics (concordance L∞=0)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "5c23c291",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003414,
+     "end_time": "2026-08-15T15:15:09.084150+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:09.080736+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# GameTheory-14 : Jeux Differentiels et Equilibres de Stackelberg (C#)\n",
     "\n",
@@ -37,7 +46,16 @@
   {
    "cell_type": "markdown",
    "id": "2b7243b9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003109,
+     "end_time": "2026-08-15T15:15:09.090098+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:09.086989+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Introduction aux jeux dynamiques\n",
     "\n",
@@ -63,7 +81,16 @@
   {
    "cell_type": "markdown",
    "id": "2e995eb8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002563,
+     "end_time": "2026-08-15T15:15:09.095116+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:09.092553+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Brique de base : integrateur RK4 from-scratch\n",
     "\n",
@@ -78,11 +105,19 @@
    "id": "783af10b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:56.173741Z",
-     "iopub.status.busy": "2026-07-07T01:02:56.165800Z",
-     "iopub.status.idle": "2026-07-07T01:02:58.717517Z",
-     "shell.execute_reply": "2026-07-07T01:02:58.712407Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:09.109812Z",
+     "iopub.status.busy": "2026-08-15T15:15:09.104207Z",
+     "iopub.status.idle": "2026-08-15T15:15:10.922026Z",
+     "shell.execute_reply": "2026-08-15T15:15:10.917677Z"
+    },
+    "papermill": {
+     "duration": 1.824288,
+     "end_time": "2026-08-15T15:15:10.922134+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:09.097846+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -94,6 +129,7 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
+       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -103,7 +139,10 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
+       
+       
        "\r\n",
+       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -118,6 +157,7 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
+       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -129,11 +169,13 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
+       
+       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '10268.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '107732.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -177,11 +219,13 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
+       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
+       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -268,7 +312,16 @@
   {
    "cell_type": "markdown",
    "id": "28ad2834",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002744,
+     "end_time": "2026-08-15T15:15:10.928114+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:10.925370+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 2.1 Pourquoi RK4 et pas Euler ?\n",
     "\n",
@@ -280,7 +333,16 @@
   {
    "cell_type": "markdown",
    "id": "dc17fc16",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.0027,
+     "end_time": "2026-08-15T15:15:10.933452+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:10.930752+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Equilibres de Stackelberg et Cournot (formes analytiques)\n",
     "\n",
@@ -305,11 +367,19 @@
    "id": "3b744f10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:58.720486Z",
-     "iopub.status.busy": "2026-07-07T01:02:58.720004Z",
-     "iopub.status.idle": "2026-07-07T01:02:58.898785Z",
-     "shell.execute_reply": "2026-07-07T01:02:58.898583Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:10.940287Z",
+     "iopub.status.busy": "2026-08-15T15:15:10.940119Z",
+     "iopub.status.idle": "2026-08-15T15:15:11.090888Z",
+     "shell.execute_reply": "2026-08-15T15:15:11.090744Z"
+    },
+    "papermill": {
+     "duration": 0.15483,
+     "end_time": "2026-08-15T15:15:11.090957+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:10.936127+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -398,7 +468,16 @@
   {
    "cell_type": "markdown",
    "id": "7250450b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002775,
+     "end_time": "2026-08-15T15:15:11.096907+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.094132+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 3.2 Interpretation : avantage du premier joueur (first-mover)\n",
     "\n",
@@ -418,7 +497,16 @@
   {
    "cell_type": "markdown",
    "id": "d5c9c79c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002849,
+     "end_time": "2026-08-15T15:15:11.102529+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.099680+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Jeux lineaires-quadratiques (LQ) et equations de Riccati\n",
     "\n",
@@ -452,11 +540,19 @@
    "id": "d0237bfb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:58.900403Z",
-     "iopub.status.busy": "2026-07-07T01:02:58.900017Z",
-     "iopub.status.idle": "2026-07-07T01:02:58.989998Z",
-     "shell.execute_reply": "2026-07-07T01:02:58.989578Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:11.109600Z",
+     "iopub.status.busy": "2026-08-15T15:15:11.109429Z",
+     "iopub.status.idle": "2026-08-15T15:15:11.193250Z",
+     "shell.execute_reply": "2026-08-15T15:15:11.193112Z"
+    },
+    "papermill": {
+     "duration": 0.087695,
+     "end_time": "2026-08-15T15:15:11.193330+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.105635+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -550,7 +646,16 @@
   {
    "cell_type": "markdown",
    "id": "64fcda36",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002908,
+     "end_time": "2026-08-15T15:15:11.199413+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.196505+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4.4 Simulation feedback Nash : convergence vers l'equilibre\n",
     "\n",
@@ -563,11 +668,19 @@
    "id": "67bdbe40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:58.991485Z",
-     "iopub.status.busy": "2026-07-07T01:02:58.991258Z",
-     "iopub.status.idle": "2026-07-07T01:02:59.122897Z",
-     "shell.execute_reply": "2026-07-07T01:02:59.122618Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:11.206516Z",
+     "iopub.status.busy": "2026-08-15T15:15:11.206301Z",
+     "iopub.status.idle": "2026-08-15T15:15:11.336259Z",
+     "shell.execute_reply": "2026-08-15T15:15:11.336121Z"
+    },
+    "papermill": {
+     "duration": 0.134007,
+     "end_time": "2026-08-15T15:15:11.336325+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.202318+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -623,7 +736,16 @@
   {
    "cell_type": "markdown",
    "id": "ec0aa927",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003406,
+     "end_time": "2026-08-15T15:15:11.343423+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.340017+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 4.5 Interpretation LQ\n",
     "\n",
@@ -635,7 +757,16 @@
   {
    "cell_type": "markdown",
    "id": "f14a7d52",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00292,
+     "end_time": "2026-08-15T15:15:11.349469+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.346549+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Stackelberg dynamique : valeur de l'engagement\n",
     "\n",
@@ -650,11 +781,19 @@
    "id": "eab09854",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:59.124691Z",
-     "iopub.status.busy": "2026-07-07T01:02:59.124457Z",
-     "iopub.status.idle": "2026-07-07T01:02:59.228963Z",
-     "shell.execute_reply": "2026-07-07T01:02:59.228259Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:11.356466Z",
+     "iopub.status.busy": "2026-08-15T15:15:11.356291Z",
+     "iopub.status.idle": "2026-08-15T15:15:11.500716Z",
+     "shell.execute_reply": "2026-08-15T15:15:11.500577Z"
+    },
+    "papermill": {
+     "duration": 0.148441,
+     "end_time": "2026-08-15T15:15:11.500783+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.352342+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -717,7 +856,16 @@
   {
    "cell_type": "markdown",
    "id": "0fdcecfc",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003138,
+     "end_time": "2026-08-15T15:15:11.507450+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.504312+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 5.1 Interpretation : paradoxe du bien-etre\n",
     "\n",
@@ -732,7 +880,16 @@
   {
    "cell_type": "markdown",
    "id": "dcdf764b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003242,
+     "end_time": "2026-08-15T15:15:11.513595+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.510353+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Poursuite-evasion : jeu differentiel a somme nulle (Isaacs)\n",
     "\n",
@@ -767,11 +924,19 @@
    "id": "802df408",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:59.231134Z",
-     "iopub.status.busy": "2026-07-07T01:02:59.230831Z",
-     "iopub.status.idle": "2026-07-07T01:02:59.395406Z",
-     "shell.execute_reply": "2026-07-07T01:02:59.394907Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:11.520841Z",
+     "iopub.status.busy": "2026-08-15T15:15:11.520646Z",
+     "iopub.status.idle": "2026-08-15T15:15:11.669432Z",
+     "shell.execute_reply": "2026-08-15T15:15:11.669294Z"
+    },
+    "papermill": {
+     "duration": 0.152945,
+     "end_time": "2026-08-15T15:15:11.669498+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.516553+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -898,7 +1063,16 @@
   {
    "cell_type": "markdown",
    "id": "df0970aa",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003056,
+     "end_time": "2026-08-15T15:15:11.676228+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.673172+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 6.5 Interpretation : theoreme d'Isaacs\n",
     "\n",
@@ -914,7 +1088,16 @@
   {
    "cell_type": "markdown",
    "id": "240db1b9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004258,
+     "end_time": "2026-08-15T15:15:11.683502+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.679244+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Synthese et transition vers les jeux cooperatifs\n",
     "\n",
@@ -962,8 +1145,212 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3da4ed0a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004318,
+     "end_time": "2026-08-15T15:15:11.692112+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.687794+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Tranche 2 : verification croisee avec MathNet.Numerics (moteur SOTA .NET)\n",
+    "\n",
+    "La tranche 1 a reimplemente tout from-scratch (BCL pur). Cette **tranche 2** branche le\n",
+    "**moteur SOTA .NET `MathNet.Numerics`** (deja en service dans Infer-8-TrueSkill) pour\n",
+    "verifier que nos integrations et optimisations from-scratch coincident avec une\n",
+    "bibliotheque de production.\n",
+    "\n",
+    "Deux experiences concretes du jumeau Python sont reprises :\n",
+    "\n",
+    "1. **Integration ODE** : le jumeau Python resout la dynamique fermee du jeu LQ avec\n",
+    "   `scipy.integrate.solve_ivp` (cellule 37). Ici, `MathNet.Numerics.OdeSolvers.RungeKutta\n",
+    "   .FourthOrder` integre la **meme dynamique feedback Nash** que notre RK4 from-scratch\n",
+    "   (cellule 11), et on compare les **vecteurs de trajectoire** (distance L-infini) sous\n",
+    "   tolerance declaree.\n",
+    "2. **Optimisation du leader** : le jumeau Python resout l'equilibre de Stackelberg\n",
+    "   statique avec `scipy.optimize.minimize_scalar` (cellule 20). Ici,\n",
+    "   `NelderMeadSimplex` maximise le profit du leader sur la fonction de reaction du\n",
+    "   follower, et on compare l'optimum vecteur-a-vecteur a la forme close (q_L* = 45).\n",
+    "\n",
+    "La comparaison **vecteur-a-vecteur** (pas des constantes attendues) est le gabarit exige\n",
+    "pour tout nouveau pont SOTA (#11058) : elle reste valide quand le jeu n'a pas de formule\n",
+    "close."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "eeaf9aa5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:15:11.700270Z",
+     "iopub.status.busy": "2026-08-15T15:15:11.700097Z",
+     "iopub.status.idle": "2026-08-15T15:15:11.992126Z",
+     "shell.execute_reply": "2026-08-15T15:15:11.991971Z"
+    },
+    "papermill": {
+     "duration": 0.296189,
+     "end_time": "2026-08-15T15:15:11.992211+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.696022+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>MathNet.Numerics, 5.0.0</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Tranche 2 -- Concordance ODE MathNet vs from-scratch (LQ feedback Nash, x0=1)\r\n",
+       "  x(T) from-scratch    : 0,000010279\r\n",
+       "  x(T) MathNet RK4     : 0,000010279\r\n",
+       "  distance L-infini    : 0,000E+000 (tolerance 1,0E-006)\r\n",
+       "  verdict              : CONCORDANT\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Tranche 2 : integration ODE avec MathNet.Numerics (moteur SOTA) ---\n",
+    "// Experience 1 : la dynamique fermee du jeu LQ en feedback Nash (cellule 11),\n",
+    "// integree par MathNet RungeKutta.FourthOrder et comparee a notre RK4 from-scratch.\n",
+    "#r \"nuget: MathNet.Numerics, 5.0.0\"\n",
+    "using MathNet.Numerics.LinearAlgebra;\n",
+    "using MathNet.Numerics.OdeSolvers;\n",
+    "\n",
+    "// Dynamique fermee (identique a la cellule 11) : dx/dt = (a - b1*K1 - b2*K2) x\n",
+    "double AclAt(double t)\n",
+    "{\n",
+    "    int idx = Math.Min((int)Math.Round(t / lq.Dt), K1.Length - 1);\n",
+    "    return lq.A - lq.B1 * K1[idx] - lq.B2 * K2[idx];\n",
+    "}\n",
+    "double[] DynClosedLoop(double t, double[] x) => new double[] { AclAt(t) * x[0] };\n",
+    "\n",
+    "// --- Trajectoire from-scratch (cellule 11, meme pas que MathNet) ---\n",
+    "double[] x0v = { 1.0 };\n",
+    "double Tsim = lq.T;\n",
+    "double dtSim = lq.Dt;   // pas = grille de gains K (concordance aux bornes)\n",
+    "var trajScratch = IntegrateRk4(DynClosedLoop, x0v, T: Tsim, dt: dtSim);\n",
+    "\n",
+    "// --- Meme trajectoire via MathNet RungeKutta.FourthOrder (meme pas) ---\n",
+    "int nSteps = (int)Math.Round(Tsim / dtSim);\n",
+    "Vector<double>[] trajMathNet = RungeKutta.FourthOrder(\n",
+    "    Vector<double>.Build.DenseOfArray(x0v), 0.0, Tsim, nSteps + 1,  // N = nb de points de sortie (MathNet integre N-1 pas)\n",
+    "    (t, x) => Vector<double>.Build.DenseOfArray(new double[] { AclAt(t) * x[0] }));\n",
+    "\n",
+    "// --- Concordance vecteur-a-vecteur : distance L-infini ---\n",
+    "int nPts = Math.Min(trajScratch.Length, trajMathNet.Length);\n",
+    "double lInf = 0.0;\n",
+    "for (int i = 0; i < nPts; i++) lInf = Math.Max(lInf, Math.Abs(trajScratch[i][0] - trajMathNet[i][0]));\n",
+    "double tol = 1e-6;\n",
+    "var sbT2 = new StringBuilder();\n",
+    "sbT2.AppendLine(\"Tranche 2 -- Concordance ODE MathNet vs from-scratch (LQ feedback Nash, x0=1)\");\n",
+    "sbT2.AppendLine($\"  x(T) from-scratch    : {trajScratch[^1][0]:F9}\");\n",
+    "sbT2.AppendLine($\"  x(T) MathNet RK4     : {trajMathNet[^1][0]:F9}\");\n",
+    "sbT2.AppendLine($\"  distance L-infini    : {lInf:E3} (tolerance {tol:E1})\");\n",
+    "sbT2.AppendLine($\"  verdict              : {(lInf <= tol ? \"CONCORDANT\" : \"ECART\")}\");\n",
+    "Show(sbT2.ToString());"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "a2c19faa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T15:15:12.000491Z",
+     "iopub.status.busy": "2026-08-15T15:15:12.000265Z",
+     "iopub.status.idle": "2026-08-15T15:15:12.105916Z",
+     "shell.execute_reply": "2026-08-15T15:15:12.105783Z"
+    },
+    "papermill": {
+     "duration": 0.11022,
+     "end_time": "2026-08-15T15:15:12.105980+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:11.995760+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Tranche 2 -- Optimum Stackelberg statique : MathNet NelderMead vs forme close\r\n",
+       "  qL* MathNet : 45,000000   |  forme close : 45,000000\r\n",
+       "  qF* MathNet : 22,500000   |  forme close : 22,500000\r\n",
+       "  ecart L-infini : 0,000E+000 (tolerance 1,0E-004)\r\n",
+       "  verdict        : CONCORDANT\r\n",
+       "  (Python scipy  : minimize_scalar -> qL* = 45, meme optimum)\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// --- Tranche 2 : optimisation du leader avec MathNet NelderMead (moteur SOTA) ---\n",
+    "// Experience 2 : l'equilibre de Stackelberg statique que le jumeau Python resout avec\n",
+    "// scipy.optimize.minimize_scalar (bounded) -- retrouve ici par NelderMeadSimplex.\n",
+    "using MathNet.Numerics.Optimization;\n",
+    "\n",
+    "// Profit du leader avec reaction du follower (cf. Python solve_static_stackelberg).\n",
+    "double LeaderProfitNet(double qL)\n",
+    "{\n",
+    "    double qF = duo.FollowerReaction(qL);\n",
+    "    return duo.LeaderProfit(qL, qF);\n",
+    "}\n",
+    "\n",
+    "// Maximiser le profit = minimiser -profit (NelderMead est un minimiseur).\n",
+    "var obj = ObjectiveFunction.Value(x => -LeaderProfitNet(x[0]));\n",
+    "var opt = NelderMeadSimplex.Minimum(obj,\n",
+    "    Vector<double>.Build.DenseOfArray(new double[] { 30.0 }),\n",
+    "    Vector<double>.Build.DenseOfArray(new double[] { 5.0 }));\n",
+    "double qLStar = opt.MinimizingPoint[0];\n",
+    "double qFStar = duo.FollowerReaction(qLStar);\n",
+    "\n",
+    "// Forme close (cellule 6) et comparaison vecteur-a-vecteur.\n",
+    "var (qLClosed, qFClosed) = StackelbergEquilibrium(demand, firmA, firmB);\n",
+    "double lInfOpt = Math.Max(Math.Abs(qLStar - qLClosed), Math.Abs(qFStar - qFClosed));\n",
+    "double tolOpt = 1e-4;\n",
+    "var sbT2b = new StringBuilder();\n",
+    "sbT2b.AppendLine(\"Tranche 2 -- Optimum Stackelberg statique : MathNet NelderMead vs forme close\");\n",
+    "sbT2b.AppendLine($\"  qL* MathNet : {qLStar:F6}   |  forme close : {qLClosed:F6}\");\n",
+    "sbT2b.AppendLine($\"  qF* MathNet : {qFStar:F6}   |  forme close : {qFClosed:F6}\");\n",
+    "sbT2b.AppendLine($\"  ecart L-infini : {lInfOpt:E3} (tolerance {tolOpt:E1})\");\n",
+    "sbT2b.AppendLine($\"  verdict        : {(lInfOpt <= tolOpt ? \"CONCORDANT\" : \"ECART\")}\");\n",
+    "sbT2b.AppendLine($\"  (Python scipy  : minimize_scalar -> qL* = 45, meme optimum)\");\n",
+    "Show(sbT2b.ToString());"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5d940e76",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003133,
+     "end_time": "2026-08-15T15:15:12.112465+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:12.109332+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Exercices\n",
     "\n",
@@ -990,15 +1377,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "a1354a7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:59.396962Z",
-     "iopub.status.busy": "2026-07-07T01:02:59.396747Z",
-     "iopub.status.idle": "2026-07-07T01:02:59.434982Z",
-     "shell.execute_reply": "2026-07-07T01:02:59.434733Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:12.120244Z",
+     "iopub.status.busy": "2026-08-15T15:15:12.120071Z",
+     "iopub.status.idle": "2026-08-15T15:15:12.152977Z",
+     "shell.execute_reply": "2026-08-15T15:15:12.152844Z"
+    },
+    "papermill": {
+     "duration": 0.037158,
+     "end_time": "2026-08-15T15:15:12.153044+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:12.115886+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1023,15 +1418,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "d0419199",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:59.436512Z",
-     "iopub.status.busy": "2026-07-07T01:02:59.436274Z",
-     "iopub.status.idle": "2026-07-07T01:02:59.513828Z",
-     "shell.execute_reply": "2026-07-07T01:02:59.513153Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:12.161260Z",
+     "iopub.status.busy": "2026-08-15T15:15:12.161091Z",
+     "iopub.status.idle": "2026-08-15T15:15:12.195511Z",
+     "shell.execute_reply": "2026-08-15T15:15:12.195389Z"
+    },
+    "papermill": {
+     "duration": 0.038884,
+     "end_time": "2026-08-15T15:15:12.195573+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:12.156689+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1056,15 +1459,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "5767185e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:59.515549Z",
-     "iopub.status.busy": "2026-07-07T01:02:59.515301Z",
-     "iopub.status.idle": "2026-07-07T01:02:59.549589Z",
-     "shell.execute_reply": "2026-07-07T01:02:59.549201Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:12.203637Z",
+     "iopub.status.busy": "2026-08-15T15:15:12.203459Z",
+     "iopub.status.idle": "2026-08-15T15:15:12.229594Z",
+     "shell.execute_reply": "2026-08-15T15:15:12.229444Z"
+    },
+    "papermill": {
+     "duration": 0.030452,
+     "end_time": "2026-08-15T15:15:12.229666+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:12.199214+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1089,15 +1500,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "ba70adba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T01:02:59.551362Z",
-     "iopub.status.busy": "2026-07-07T01:02:59.551054Z",
-     "iopub.status.idle": "2026-07-07T01:02:59.593909Z",
-     "shell.execute_reply": "2026-07-07T01:02:59.593360Z"
-    }
+     "iopub.execute_input": "2026-08-15T15:15:12.238590Z",
+     "iopub.status.busy": "2026-08-15T15:15:12.238407Z",
+     "iopub.status.idle": "2026-08-15T15:15:12.269304Z",
+     "shell.execute_reply": "2026-08-15T15:15:12.269171Z"
+    },
+    "papermill": {
+     "duration": 0.035622,
+     "end_time": "2026-08-15T15:15:12.269367+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:12.233745+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1123,11 +1542,20 @@
   {
    "cell_type": "markdown",
    "id": "19c23183",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003389,
+     "end_time": "2026-08-15T15:15:12.276179+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T15:15:12.272790+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce jumeau C# a presente les **jeux differentiels** et les **equilibres de Stackelberg**, reimplementation from-scratch du twin Python numpy/scipy.\n",
+    "Ce jumeau C# a presente les **jeux differentiels** et les **equilibres de Stackelberg**, reimplementation from-scratch (tranche 1) **plus** une verification croisee avec le moteur SOTA .NET `MathNet.Numerics` (tranche 2).\n",
     "\n",
     "### Résultats cles reproduits (Math Verification Standard)\n",
     "\n",
@@ -1140,10 +1568,8 @@
     "\n",
     "### Value-add du jumeau (Prong B, #3801)\n",
     "\n",
-    "- **RK4 from-scratch** remplace `scipy.integrate.solve_ivp` (validation e^{-1} a 1e-9).\n",
-    "- **Riccati couplee backward** en `double[]` pur remplace la vectorisation numpy.\n",
-    "- **Pursuit-evasion pleinement modelisee** la ou le Python la laissait en exercice vide.\n",
-    "- **0 NuGet, 0 numpy, 0 scipy** : BCL .NET 9 uniquement.\n",
+    "- **Tranche 1** : RK4 from-scratch remplace `scipy.integrate.solve_ivp` (validation e^{-1} a 1e-9), Riccati couplee backward en `double[]` pur, pursuit-evasion pleinement modelisee. **0 NuGet, 0 numpy, 0 scipy** : BCL .NET 9 uniquement.\n",
+    "- **Tranche 2** : branchement de `MathNet.Numerics` (moteur SOTA .NET, deja en service dans Infer-8) -- concordance **vecteur-a-vecteur** de l'ODE feedback Nash (`RungeKutta.FourthOrder` vs from-scratch, L-infini < 1e-6) et de l'optimum Stackelberg statique (`NelderMeadSimplex` vs forme close, L-infini < 1e-4). Gabarit de pont exige pour tout nouveau pont SOTA (#11058).\n",
     "\n",
     "**Suite** : [GT-15 - Jeux cooperatifs](GameTheory-15-CooperativeGames.ipynb) | [Retour au sommaire](README.md)"
    ]
@@ -1161,6 +1587,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.505413,
+   "end_time": "2026-08-15T15:15:12.521038+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-15T15:15:06.015625+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
@@ -15,6 +15,12 @@
       csharp_sha: 88e961fdf00ed0525c1918f9ac71132dcbbd8056
       content_python_sha: af379708f3230a003e086fb360fd1f47e38bcdae2b8b98bef4b421c83792af4f
       content_csharp_sha: 8ff080818394f0564ef7c520644be395b580820ac947123408c1f4914caa3aa2
+    - date: "2026-08-15"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 924092dad22d0d395af77067e636d92d773484ec
+      csharp_sha: 43e8441093f9092488970566704c61e6850df678
+      content_python_sha: af379708f3230a003e086fb360fd1f47e38bcdae2b8b98bef4b421c83792af4f
+      content_csharp_sha: 03f8eca2c4268cffbefe5b39db80c0dee2c24e43037a3b2a9cb285854c2df4aa
   known_differences:
     - "Socle pedagogique commun : jeux differentiels et jeux dynamiques, equilibres de Stackelberg (von Stackelberg 1934) leader-follower, duopole a demande lineaire, comparaison avec Cournot, decisions dynamiques et leadership strategique."
     - "Idiomes framework : Python = `scipy.integrate.odeint` (integration ODE) + `scipy.optimize.minimize` + `numpy` + `matplotlib`. C# = BCL .NET 9 pur (`System.*`) pour la tranche 1 (RK4 from-scratch, formes analytiques Stackelberg/Cournot) + **tranche 2** branchant le moteur SOTA .NET `MathNet.Numerics` 5.0.0 (RungeKutta.FourthOrder + NelderMeadSimplex) pour la verification croisee. 0 numpy, 0 scipy des deux cotes C#."

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-14-differentialgames.yaml
@@ -2,14 +2,20 @@
   family: GameTheory/.NET-Parity
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-14-DifferentialGames-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
-  bridge_verdict_reason: "Modele #10382 solver-free par conception : theorie des jeux algorithmique enseignee from-scratch des deux cotes (l algorithme - induction arriere, existence Nash, SPE, formes extensive/combinatoire/cooperative - EST la lecon ; il n existe pas de bibliotheque .NET canonique de solveur de jeu a invoquer, contrairement aux paires lib-vs-lib comme PyMC/Infer.NET ou scikit/ML.NET). Les deux cotes atteignent le SOTA de leur ecosysteme pour cet objectif pedagogique : reimplementation didactique du formalisme mathematique. Pair verifiee firsthand (census moteur : CS=scratch, PY=scratch)."
+  bridge_verdict_reason: "Tranche 2 (2026-08-15) : pont MathNet.Numerics branche sur la paire GT-14. Le socle reste from-scratch (la lecon), mais la verification croisee s appuie desormais sur le moteur SOTA .NET MathNet.Numerics 5.0.0 (RK4 RungeKutta.FourthOrder + NelderMeadSimplex) : concordance vecteur-a-vecteur L-infini = 0 sur les deux experiences (ODE feedback Nash + optimum Stackelberg statique), gabarit #11058. Le moteur SOTA est invoque reellement (pas un stub) ; la paire reste pedagogiquement from-scratch-first, la verification par moteur tiers valide la reimplementation."
   audits:
     - date: "2026-08-04"
       python_sha: 924092dad22d0d395af77067e636d92d773484ec
       csharp_sha: 88e961fdf00ed0525c1918f9ac71132dcbbd8056
+    - date: "2026-08-15"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 924092dad22d0d395af77067e636d92d773484ec
+      csharp_sha: 88e961fdf00ed0525c1918f9ac71132dcbbd8056
+      content_python_sha: af379708f3230a003e086fb360fd1f47e38bcdae2b8b98bef4b421c83792af4f
+      content_csharp_sha: 8ff080818394f0564ef7c520644be395b580820ac947123408c1f4914caa3aa2
   known_differences:
     - "Socle pedagogique commun : jeux differentiels et jeux dynamiques, equilibres de Stackelberg (von Stackelberg 1934) leader-follower, duopole a demande lineaire, comparaison avec Cournot, decisions dynamiques et leadership strategique."
-    - "Idiomes framework : Python = `scipy.integrate.odeint` (integration ODE) + `scipy.optimize.minimize` + `numpy` + `matplotlib`. C# = BCL .NET 9 pur (`System.*`, 0 NuGet, 0 numpy, 0 scipy), integrateur RK4 from-scratch (section 'Pourquoi RK4 et pas Euler ?') + formes analytiques Stackelberg/Cournot."
-    - "Asymetrie de couverture : Python (40 cellules, 14 code) resout numeriquement via scipy (ODE + optimisation) ; C# (26 cellules, 10 code) construit RK4 from-scratch et privilegie les formes analytiques du duopole. Meme theorie centrale (Stackelberg/Cournot), leviers numeriques differents (scipy cote Python vs RK4 from-scratch cote C#)."
+    - "Idiomes framework : Python = `scipy.integrate.odeint` (integration ODE) + `scipy.optimize.minimize` + `numpy` + `matplotlib`. C# = BCL .NET 9 pur (`System.*`) pour la tranche 1 (RK4 from-scratch, formes analytiques Stackelberg/Cournot) + **tranche 2** branchant le moteur SOTA .NET `MathNet.Numerics` 5.0.0 (RungeKutta.FourthOrder + NelderMeadSimplex) pour la verification croisee. 0 numpy, 0 scipy des deux cotes C#."
+    - "Asymetrie de couverture : Python (40 cellules, 14 code) resout numeriquement via scipy (ODE + optimisation) ; C# (29 cellules, 12 code) construit RK4 from-scratch (tranche 1) + verification croisee MathNet (tranche 2) et privilegie les formes analytiques du duopole. Meme theorie centrale (Stackelberg/Cournot) ; le C# couvre desormais l'ODE via **deux** moteurs concordants (RK4 from-scratch L-infini 0 vs MathNet) et l'optimum statique par NelderMead (L-infini 0 vs forme close)."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet #11062

## Summary

Sous-grain **GT-14 DifferentialGames** de l'EPIC #10382 (parité lib-vs-lib) : branche la **tranche 2** — pont **MathNet.Numerics 5.0.0** (moteur SOTA .NET) — sur le jumeau C# `GameTheory-14-DifferentialGames-Csharp.ipynb`, avec comparaison **vecteur-à-vecteur** sous tolérance déclarée (gabarit #11058).

Deux expériences concrètes du jumeau Python reprises, les deux **CONCORDANT (L∞ = 0)** :

1. **ODE feedback Nash** (Python `scipy.integrate.solve_ivp`) : `MathNet.Numerics.OdeSolvers.RungeKutta.FourthOrder` intègre la dynamique fermée du jeu LQ (cellule 11) vs notre RK4 from-scratch — distance L∞ = 0 sur 201 points, `x(T)=1.0279e-5` des deux côtés.
2. **Optimum Stackelberg statique** (Python `scipy.optimize.minimize_scalar`) : `NelderMeadSimplex.Minimum` maximise le profit du leader sur la réaction du follower — `qL*=45.000000`, `qF*=22.500000`, L∞ = 0 vs forme close.

**Découverte de debugging notable** : `RungeKutta.FourthOrder(y0, start, end, N, f)` traite `N` comme le **nombre de points de sortie** et intègre `N-1` pas à `h = T/(N-1)`. Passer `nSteps` (nombre de pas voulu) décalait le pas à `0.05025` au lieu de `0.05` → L∞ ≈ 1.8e-3 de pur mismatch de pas (reproduit sur un système à coefficient constant). Correctif : passer `nSteps + 1`.

## Validation (B.2)

| Critère | Preuve |
|---|---|
| Exécution réelle | Papermill **29/29** code cells, **0 erreur** |
| Verdict forensique | `validate_pr_notebooks.py` → **1/1 passed** (12 code cells, .net-csharp), EXEC_PROVED |
| Outputs commités | C.2 : outputs frais de la re-exec, `execution_count` 1-12 |
| Hygiène sorties | `strip_probe_banner.py --apply` (9 lignes) + `strip_machine_paths.py --apply` (0 ligne restante) |
| Concordance ODE | L∞ = **0** (tol 1e-6) — CONCORDANT |
| Concordance optimum | L∞ = **0** (tol 1e-4) — CONCORDANT |
| C.1 | 0 `raise NotImplementedError` / `assert False` / `1/0` |

## Twin parity (#8057)

`parity_level: semantic` → **`native-both`** (le moteur SOTA .NET est désormais branché des deux côtés de la paire ; le socle reste from-scratch-first — la leçon — la tranche 2 valide par moteur tiers). Rebaseline `check_twin_parity.py --update --pair "GameTheory-14 DifferentialGames" --by "myia-po-2024:CoursIA-2"` **en dernier** après les strips (#8957) ; audit 2026-08-15 ajouté. `--check` → **157/157 OK, DRIFT=0**.

## Diff

- `GameTheory-14-DifferentialGames-Csharp.ipynb` : 3 cellules ajoutées (markdown Tranche 2 + 2 code) + Conclusion mise à jour (cadrage Tranche 1/Tranche 2). 26 → 29 cellules.
- `twin_pairs.d/gametheory-14-differentialgames.yaml` : `native-both`, verdict SOTA-OK motivé, audit 2026-08-15, `known_differences` ré-alignées.

See #10382 · See #11058
