### PR TITLE
fix(qc-projects,#11044): MANIFEST RiskParity H2 tableau — SPY CAGR 13.46→13.65 (source cell[10])

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/assets/readme/MANIFEST.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/RiskParity/assets/readme/MANIFEST.md
@@ -99,7 +99,7 @@ Contrairement à l'alt-text « contre-exemple pédagogique » (Sharpe 0.399) qui
 | Métrique | Risk Parity | SPY | Verdict |
 |---|---|---|---|
 | Sharpe (2015-2026) | 0.544 | 0.655 | RP perd ~17 % en Sharpe |
-| CAGR | 7.28 % | 13.46 % | RP rend ~ moitié |
+| CAGR | 7.28 % | 13.65 % | RP rend ~ moitié |
 | MaxDD | -20.26 % | -33.72 % | **RP MaxDD ~ moitié moindre** |
 | Inflation 2022 | -9.8 % | -18.6 % | **RP perd 2× moins** |
 | Recovery 2023-25 | 47.9 % | 86.3 % | RP upside raboté |


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet #11074

## Summary

Finding **(a)** de la review §H.4 de po-2026 sur #6680, trié **NON-LEVE gravité haute** dans la file #11044 (Phase 2, commentaire 5302659484) : le tableau H2 « Découverte majeure c.454 » du MANIFEST RiskParity **mélangeait les sources** — toutes les lignes viennent de cell[10]·out[0] (backtest H2) sauf le CAGR SPY qui citait **13.46** (cell[4]·out[0], stats exploration §2) au lieu de **13.65** (cell[10]·out[0], backtest H2).

**Source canonique tranchée** : cell[10]·out[0] (backtest H2) — la seule cohérente avec les autres lignes du même tableau (Sharpe 0.544|0.655, MaxDD -20.26|-33.72, Inflation 2022, Recovery 2023-25) et avec README.md qui cite déjà **13.65 %** pour SPY (ligne 96 + lecture stratégique ligne 101).

Correction : 1 valeur dans MANIFEST.md (`13.46 %` → `13.65 %`). L'alt-text exploration (ligne 26, GLD 12.02 / DBC 3.45) conserve 13.46 — c'est la valeur correcte pour cell[4] (stats §2). Verdict « RP rend ~ moitié » inchangé (7.28/13.65 ≈ 0.53).

## Validation (B.2)

| Critère | Preuve |
|---|---|
| Scope réel | 1 fichier, 1 valeur — MANIFEST.md uniquement |
| Vérif source | cell[10]·out[0] lu firsthand : `SPY 13.65 | 17.79 | 0.655 | -33.72` |
| Vérif cohérence | README.md déjà à 13.65 % (pas de divergence à créer) |
| Catalogue | 0 fichier catalogue touché, marqueurs `CATALOG-STATUS` inchangés |
| CRLF | fichier LF (0 retour-chariot) |
| Régression | grep `13.46` → ne reste que cell[4] (notebook, correct) + alt-text exploration (ligne 26, correct) |

## Diff

```diff
-| CAGR | 7.28 % | 13.46 % | RP rend ~ moitié |
+| CAGR | 7.28 % | 13.65 % | RP rend ~ moitié |
```

See #11044 · See #6680
