### PR TITLE
feat(lean,#10984): mimo_lean Phase 3a — Lmmse.lean (Lemme 5.1 LMMSE)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Lmmse.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Lmmse.lean
@@ -1,0 +1,118 @@
+import Mathlib
+
+/-!
+# Erreur LMMSE — Phase 3 : Lemme 5.1 (identité trace), avec Mathlib
+
+Ce module prouve le **Lemme 5.1** du papier de détection MIMO
+(Papailiopoulos, 2026 — issue #10984) : l'erreur quadratique moyenne de
+l'estimateur LMMSE est la trace de la matrice d'erreur
+
+    E‖b − x*‖² = tr(B_ρ),   B_ρ = (I_N + s·HᵀH)⁻¹,   s = ρ/N.
+
+Architecture du fichier :
+
+1. `integral_norm_sq_eq_trace` — la **formule de la trace gaussienne** :
+   pour une gaussienne centrée de covariance `B` (semi-définie positive),
+   l'espérance de la norme au carré est `tr B`. C'est le cœur du lemme ;
+2. `B_ρ` — la matrice d'erreur LMMSE du canal : `(I + s·HᴴH)⁻¹` ;
+3. `B_ρ_posSemidef` — `B_ρ` est bien semi-définie positive (`s ≥ 0`),
+   condition sous laquelle la gaussienne associée existe ;
+4. `lmmse_error_eq_trace` — **Lemme 5.1** : tout champ d'erreur dont la loi
+   est la gaussienne centrée de covariance `B_ρ` a une énergie moyenne
+   `E‖e‖² = tr B_ρ`.
+-/
+
+namespace Mimo
+
+open Matrix MeasureTheory ProbabilityTheory
+
+section Trace
+
+/-- Formule de la trace gaussienne : pour une gaussienne centrée de
+covariance `B`, l'espérance de la norme au carré vaut `tr B`. Chaque
+coordonnée contribue sa variance `B i i` (la moyenne étant nulle). -/
+theorem integral_norm_sq_eq_trace {n : ℕ} {B : Matrix (Fin n) (Fin n) ℝ}
+    (hB : B.PosSemidef) :
+    ∫ x : EuclideanSpace ℝ (Fin n), ‖x‖ ^ 2 ∂(multivariateGaussian 0 B)
+      = B.trace := by
+  have hnorm : ∀ x : EuclideanSpace ℝ (Fin n), ‖x‖ ^ 2 = ∑ i, (x i) ^ 2 := fun x => by
+    rw [← real_inner_self_eq_norm_sq, PiLp.inner_apply]; simp
+  have hint : ∀ i : Fin n,
+      ∫ x : EuclideanSpace ℝ (Fin n), (x i) ^ 2 ∂(multivariateGaussian 0 B) = B i i := by
+    intro i
+    have hmp := measurePreserving_eval_multivariateGaussian (μ := 0) hB (i := i)
+    have hinteg : Integrable (fun x : EuclideanSpace ℝ (Fin n) => (x i) ^ 2)
+        (multivariateGaussian 0 B) := by
+      have h2 : MemLp (id : ℝ → ℝ) 2 (gaussianReal 0 (B i i).toNNReal) :=
+        IsGaussian.memLp_two_id
+      have h5 := h2.comp_measurePreserving hmp
+      simpa [Function.comp_def, id_eq] using h5.integrable_sq
+    have hE0 : (multivariateGaussian 0 B)[fun x : EuclideanSpace ℝ (Fin n) => x i] = 0 := by
+      have h6 : (multivariateGaussian 0 B)[fun x : EuclideanSpace ℝ (Fin n) => x i]
+          = ∫ y : ℝ, y ∂(Measure.map (fun x : EuclideanSpace ℝ (Fin n) => x i)
+              (multivariateGaussian 0 B)) := by
+        symm
+        exact integral_map (by fun_prop) (by fun_prop)
+      rw [h6, hmp.map_eq, integral_id_gaussianReal]
+      simp
+    have hvar := variance_eq_integral (μ := multivariateGaussian 0 B)
+      (X := fun x : EuclideanSpace ℝ (Fin n) => x i) (by fun_prop)
+    rw [hE0] at hvar
+    simp only [sub_zero] at hvar
+    rw [← hvar, variance_eval_multivariateGaussian (μ := 0) hB i]
+  have hinteg' : ∀ i : Fin n, Integrable (fun x : EuclideanSpace ℝ (Fin n) => (x i) ^ 2)
+      (multivariateGaussian 0 B) := by
+    intro i
+    have hmp := measurePreserving_eval_multivariateGaussian (μ := 0) hB (i := i)
+    have h2 : MemLp (id : ℝ → ℝ) 2 (gaussianReal 0 (B i i).toNNReal) :=
+      IsGaussian.memLp_two_id
+    have h5 := h2.comp_measurePreserving hmp
+    simpa [Function.comp_def, id_eq] using h5.integrable_sq
+  simp only [hnorm]
+  rw [integral_finsetSum (hf := fun i _ => hinteg' i)]
+  simp only [hint]
+  rfl
+
+end Trace
+
+section LMMSE
+
+variable {N : ℕ}
+
+/-- La matrice d'erreur LMMSE du canal : `B_ρ = (I + s·HᴴH)⁻¹`
+(papier : `B_ρ = (I_N + (ρ/N)·HᵀH)⁻¹` avec `s = ρ/N`). -/
+noncomputable def B_ρ (H : Matrix (Fin N) (Fin N) ℝ) (s : ℝ) :
+    Matrix (Fin N) (Fin N) ℝ :=
+  ((1 : Matrix (Fin N) (Fin N) ℝ) + s • (Hᴴ * H))⁻¹
+
+/-- La matrice d'erreur `B_ρ` est semi-définie positive dès que `s ≥ 0` :
+`HᴴH` est toujours PSD, `I + s·HᴴH` aussi, et l'inverse d'une PSD est PSD. -/
+theorem B_ρ_posSemidef (H : Matrix (Fin N) (Fin N) ℝ) {s : ℝ} (hs : 0 ≤ s) :
+    (B_ρ H s).PosSemidef := by
+  have hH : (Hᴴ * H).PosSemidef := posSemidef_conjTranspose_mul_self H
+  have hadd : ((1 : Matrix (Fin N) (Fin N) ℝ) + s • (Hᴴ * H)).PosSemidef :=
+    Matrix.PosSemidef.one.add (hH.smul hs)
+  exact Matrix.PosSemidef.inv hadd
+
+/-- **Lemme 5.1 (Papailiopoulos 2026) — erreur LMMSE.** Si le champ d'erreur
+d'estimation `e = b − x*` suit la loi gaussienne centrée de covariance
+`B_ρ = (I + s·HᴴH)⁻¹` — la matrice d'erreur LMMSE du canal à SNR par antenne
+`s = ρ/N` — alors son erreur quadratique moyenne est exactement la trace :
+
+    E‖b − x*‖² = tr(B_ρ).
+
+La preuve combine la formule de la trace gaussienne
+(`integral_norm_sq_eq_trace`) avec le transport de la loi de `e`. -/
+theorem lmmse_error_eq_trace {Ω} [MeasurableSpace Ω] {μ : Measure Ω}
+    [IsProbabilityMeasure μ] {N : ℕ} (H : Matrix (Fin N) (Fin N) ℝ)
+    {s : ℝ} (hs : 0 ≤ s) (e : Ω → EuclideanSpace ℝ (Fin N))
+    (he : AEMeasurable e μ)
+    (hdist : Measure.map e μ = multivariateGaussian 0 (B_ρ H s)) :
+    μ[fun ω => ‖e ω‖ ^ 2] = (B_ρ H s).trace := by
+  rw [← integral_map he (by fun_prop : AEStronglyMeasurable
+      (fun y : EuclideanSpace ℝ (Fin N) => ‖y‖ ^ 2) (Measure.map e μ)), hdist]
+  exact integral_norm_sq_eq_trace (B_ρ_posSemidef H hs)
+
+end LMMSE
+
+end Mimo

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Lmmse_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Lmmse_en.lean
@@ -1,0 +1,119 @@
+import Mathlib
+
+/-!
+# LMMSE error — Phase 3: Lemma 5.1 (trace identity), with Mathlib
+
+This module proves **Lemma 5.1** of the MIMO detection paper
+(Papailiopoulos, 2026 — issue #10984): the mean squared error of the
+LMMSE estimator is the trace of the error matrix
+
+    E‖b − x*‖² = tr(B_ρ),   B_ρ = (I_N + s·HᵀH)⁻¹,   s = ρ/N.
+
+File architecture:
+
+1. `integral_norm_sq_eq_trace` — the **gaussian trace formula**: for a
+   centered gaussian with covariance `B` (positive semidefinite), the
+   expected squared norm is `tr B`. This is the core of the lemma;
+2. `B_ρ` — the channel LMMSE error matrix: `(I + s·HᴴH)⁻¹`;
+3. `B_ρ_posSemidef` — `B_ρ` is positive semidefinite (for `s ≥ 0`),
+   the condition under which the associated gaussian exists;
+4. `lmmse_error_eq_trace` — **Lemma 5.1**: any error field whose law is
+   the centered gaussian with covariance `B_ρ` has mean energy
+   `E‖e‖² = tr B_ρ`.
+-/
+
+namespace Mimo_en
+
+open Matrix MeasureTheory ProbabilityTheory
+
+section Trace
+
+/-- Gaussian trace formula: for a centered gaussian with covariance `B`,
+the expected squared norm equals `tr B`. Each coordinate contributes its
+variance `B i i` (the mean being zero). -/
+theorem integral_norm_sq_eq_trace {n : ℕ} {B : Matrix (Fin n) (Fin n) ℝ}
+    (hB : B.PosSemidef) :
+    ∫ x : EuclideanSpace ℝ (Fin n), ‖x‖ ^ 2 ∂(multivariateGaussian 0 B)
+      = B.trace := by
+  have hnorm : ∀ x : EuclideanSpace ℝ (Fin n), ‖x‖ ^ 2 = ∑ i, (x i) ^ 2 := fun x => by
+    rw [← real_inner_self_eq_norm_sq, PiLp.inner_apply]; simp
+  have hint : ∀ i : Fin n,
+      ∫ x : EuclideanSpace ℝ (Fin n), (x i) ^ 2 ∂(multivariateGaussian 0 B) = B i i := by
+    intro i
+    have hmp := measurePreserving_eval_multivariateGaussian (μ := 0) hB (i := i)
+    have hinteg : Integrable (fun x : EuclideanSpace ℝ (Fin n) => (x i) ^ 2)
+        (multivariateGaussian 0 B) := by
+      have h2 : MemLp (id : ℝ → ℝ) 2 (gaussianReal 0 (B i i).toNNReal) :=
+        IsGaussian.memLp_two_id
+      have h5 := h2.comp_measurePreserving hmp
+      simpa [Function.comp_def, id_eq] using h5.integrable_sq
+    have hE0 : (multivariateGaussian 0 B)[fun x : EuclideanSpace ℝ (Fin n) => x i] = 0 := by
+      have h6 : (multivariateGaussian 0 B)[fun x : EuclideanSpace ℝ (Fin n) => x i]
+          = ∫ y : ℝ, y ∂(Measure.map (fun x : EuclideanSpace ℝ (Fin n) => x i)
+              (multivariateGaussian 0 B)) := by
+        symm
+        exact integral_map (by fun_prop) (by fun_prop)
+      rw [h6, hmp.map_eq, integral_id_gaussianReal]
+      simp
+    have hvar := variance_eq_integral (μ := multivariateGaussian 0 B)
+      (X := fun x : EuclideanSpace ℝ (Fin n) => x i) (by fun_prop)
+    rw [hE0] at hvar
+    simp only [sub_zero] at hvar
+    rw [← hvar, variance_eval_multivariateGaussian (μ := 0) hB i]
+  have hinteg' : ∀ i : Fin n, Integrable (fun x : EuclideanSpace ℝ (Fin n) => (x i) ^ 2)
+      (multivariateGaussian 0 B) := by
+    intro i
+    have hmp := measurePreserving_eval_multivariateGaussian (μ := 0) hB (i := i)
+    have h2 : MemLp (id : ℝ → ℝ) 2 (gaussianReal 0 (B i i).toNNReal) :=
+      IsGaussian.memLp_two_id
+    have h5 := h2.comp_measurePreserving hmp
+    simpa [Function.comp_def, id_eq] using h5.integrable_sq
+  simp only [hnorm]
+  rw [integral_finsetSum (hf := fun i _ => hinteg' i)]
+  simp only [hint]
+  rfl
+
+end Trace
+
+section LMMSE
+
+variable {N : ℕ}
+
+/-- The channel LMMSE error matrix: `B_ρ = (I + s·HᴴH)⁻¹`
+(paper: `B_ρ = (I_N + (ρ/N)·HᵀH)⁻¹` with `s = ρ/N`). -/
+noncomputable def B_ρ (H : Matrix (Fin N) (Fin N) ℝ) (s : ℝ) :
+    Matrix (Fin N) (Fin N) ℝ :=
+  ((1 : Matrix (Fin N) (Fin N) ℝ) + s • (Hᴴ * H))⁻¹
+
+/-- The error matrix `B_ρ` is positive semidefinite whenever `s ≥ 0`:
+`HᴴH` is always PSD, so is `I + s·HᴴH`, and the inverse of a PSD matrix
+is PSD. -/
+theorem B_ρ_posSemidef (H : Matrix (Fin N) (Fin N) ℝ) {s : ℝ} (hs : 0 ≤ s) :
+    (B_ρ H s).PosSemidef := by
+  have hH : (Hᴴ * H).PosSemidef := posSemidef_conjTranspose_mul_self H
+  have hadd : ((1 : Matrix (Fin N) (Fin N) ℝ) + s • (Hᴴ * H)).PosSemidef :=
+    Matrix.PosSemidef.one.add (hH.smul hs)
+  exact Matrix.PosSemidef.inv hadd
+
+/-- **Lemma 5.1 (Papailiopoulos 2026) — LMMSE error.** If the estimation
+error field `e = b − x*` follows the centered gaussian law with covariance
+`B_ρ = (I + s·HᴴH)⁻¹` — the LMMSE error matrix of the channel at per-antenna
+SNR `s = ρ/N` — then its mean squared error is exactly the trace:
+
+    E‖b − x*‖² = tr(B_ρ).
+
+The proof combines the gaussian trace formula
+(`integral_norm_sq_eq_trace`) with the transport of the law of `e`. -/
+theorem lmmse_error_eq_trace {Ω} [MeasurableSpace Ω] {μ : Measure Ω}
+    [IsProbabilityMeasure μ] {N : ℕ} (H : Matrix (Fin N) (Fin N) ℝ)
+    {s : ℝ} (hs : 0 ≤ s) (e : Ω → EuclideanSpace ℝ (Fin N))
+    (he : AEMeasurable e μ)
+    (hdist : Measure.map e μ = multivariateGaussian 0 (B_ρ H s)) :
+    μ[fun ω => ‖e ω‖ ^ 2] = (B_ρ H s).trace := by
+  rw [← integral_map he (by fun_prop : AEStronglyMeasurable
+      (fun y : EuclideanSpace ℝ (Fin N) => ‖y‖ ^ 2) (Measure.map e μ)), hdist]
+  exact integral_norm_sq_eq_trace (B_ρ_posSemidef H hs)
+
+end LMMSE
+
+end Mimo_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/README.md
@@ -11,7 +11,8 @@ Port formel de l'algorithme de détection MIMO par flips de coordonnées
 |-------|----------|--------|
 | 1 | `Descent.lean` — squelette abstrait de la Proposition 9.1, **sans dépendance** (cœur Lean) | livré |
 | 2 | `Objective.lean` — fonction objectif au carré avec Mathlib : Lemme 11.1 (coût d'un flip `4·(s·‖hᵢ‖² + √s·⟪hᵢ,w⟫)`) + boucle de contrôle `flip_accepted_iff` | livré |
-| 3 | Lemme 5.1 (erreur LMMSE `E‖b − x*‖² = E tr(B_ρ)`) et converse §11 via le lake externe [YuanheZ/lean-stat-learning-theory](https://github.com/YuanheZ/lean-stat-learning-theory) (v4.32.0, Apache 2.0, 0 sorry) : Hanson-Wright, concentration LSI, RMT | à venir |
+| 3a | `Lmmse.lean` — **Lemme 5.1** (erreur LMMSE) : `E‖b − x*‖² = tr(B_ρ)`, `B_ρ = (I + s·HᵀH)⁻¹` — formule de la trace gaussienne + transport de loi | livré |
+| 3b | Converse §11 via le lake externe [YuanheZ/lean-stat-learning-theory](https://github.com/YuanheZ/lean-stat-learning-theory) (v4.32.0, Apache 2.0, 0 sorry) : Hanson–Wright (`‖w‖²` chi-square), union bound `(1−p)^n ≤ e^{−np}` | à venir |
 
 ## Phase 1 — ce qui est prouvé
 
@@ -55,6 +56,21 @@ docstrings) instancie la géométrie du détecteur sur Mathlib :
 
 Axiomes : `propext`, `Classical.choice`, `Quot.sound` (les trois standards
 de Mathlib) — zéro sorry.
+
+## Phase 3a — ce qui est prouvé
+
+`Lmmse.lean` (twin `Lmmse_en.lean`) prouve le **Lemme 5.1** sur Mathlib :
+
+1. `integral_norm_sq_eq_trace` — **formule de la trace gaussienne** : pour
+   une gaussienne centrée de covariance PSD `B`, `E‖x‖² = tr B` (chaque
+   coordonnée contribue sa variance `B i i`, via les marginales
+   `gaussianReal` et `variance_eq_integral`) ;
+2. `B_ρ` / `B_ρ_posSemidef` — la matrice d'erreur LMMSE `(I + s·HᴴH)⁻¹`
+   est PSD dès `s ≥ 0` (`posSemidef_conjTranspose_mul_self` + inverse) ;
+3. `lmmse_error_eq_trace` — **Lemme 5.1** : `E‖b − x*‖² = tr(B_ρ)` par
+   transport de la loi de l'erreur.
+
+Axiomes : les trois standards de Mathlib — zéro sorry.
 
 ## Build
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
@@ -16,9 +16,12 @@ Port formel de l'algorithme de détection MIMO par flips de coordonnées
 - **Phase 2** (`Objective.lean`, livré) : fonction objectif au carré avec
   Mathlib — Lemme 11.1 (coût d'un flip, forme fermée) + boucle de contrôle
   `flip_accepted_iff` (pont avec `hstrict` de la Phase 1).
-- **Phase 3** (à venir) : Lemme 5.1 (erreur LMMSE) et converse §11, appui sur
-  le lake externe `YuanheZ/lean-stat-learning-theory` (v4.32.0, Apache 2.0)
-  pour la concentration gaussienne (Hanson-Wright, LSI, RMT).
+- **Phase 3a** (`Lmmse.lean`, livré) : Lemme 5.1 (erreur LMMSE
+  `E‖b − x*‖² = tr B_ρ`) — formule de la trace gaussienne, `B_ρ` PSD,
+  transport de loi.
+- **Phase 3b** (à venir) : converse §11 — concentration Hanson–Wright du
+  bruit (`‖w‖²` chi-square), union bound `(1−p)^n ≤ e^{−np}`, appui sur le
+  lake externe `YuanheZ/lean-stat-learning-theory` (v4.32.0, Apache 2.0).
 
 Convention i18n #4980 : docstrings FR par défaut, sibling `_en`
 (namespace `Mimo_en`, imports `_en`), énoncés et noms de lemmes en anglais.
@@ -37,3 +40,7 @@ lean_lib «Descent» where
 @[default_target]
 lean_lib «Objective» where
   globs := #[`Objective, `Objective_en]
+
+@[default_target]
+lean_lib «Lmmse» where
+  globs := #[`Lmmse, `Lmmse_en]


### PR DESCRIPTION
## Summary

mimo_lean Phase 3a (See #10984) : nouveau module `Lmmse.lean` + twin `Lmmse_en.lean` (i18n #4980) — le **Lemme 5.1** (erreur LMMSE du détecteur MIMO) prouvé sur Mathlib v4.32.0 :

1. `integral_norm_sq_eq_trace` — **formule de la trace gaussienne** : `∫ ‖x‖² ∂N(0,B) = tr B` pour `B` PSD. Preuve par marginales (`measurePreserving_eval_multivariateGaussian` → `gaussianReal`), intégrabilité (`IsGaussian.memLp_two_id` + `MemLp.comp_measurePreserving`), variance (`variance_eq_integral` + `variance_eval_multivariateGaussian`), puis `integral_finsetSum` sur la décomposition `‖x‖² = ∑ (x i)²`.
2. `B_ρ H s = (I + s•(Hᴴ*H))⁻¹` et `B_ρ_posSemidef` (PSD : `PosSemidef.inv` de `one.add` du PSD `HᴴH`).
3. `lmmse_error_eq_trace` — **Lemme 5.1** : `E‖e‖² = tr(B_ρ)` sous la loi pushforward `map e μ = N(0, B_ρ)` (transport via `integral_map` + `MeasurePreserving.map_eq`).

`lakefile.lean` : `lean_lib «Lmmse»` en 4e default_target (globs `Lmmse`/`Lmmse_en`). `README.md` : table des phases 3a livré / 3b à venir + section « Phase 3a — ce qui est prouvé ». Aucune nouvelle dépendance (`lake-manifest.json` inchangé).

## Validation (§B.3 Lean PR discipline)

1. **sorry count** : avant 0 / après 0 (`grep -c sorry Lmmse.lean Lmmse_en.lean` → `0` / `0`).
2. **Lake build SUCCESS** : `Build completed successfully (8663 jobs)` — `lake build` local sur `feature/mimo-lean-p3` (commit f6e4b6139 (rebase frais sur origin/main post-merge #11063)). Note : 4 tentatives initiales en échec sur lectures aléatoires d'`*.olean(.private)` Mathlib (flake connu c.1093 sous pression RAM, 0,8 Go libres ; artefacts vérifiés sains sur disque, 0/8264 corrompus) — succès au retry après 20 s.
3. **Proof integrity** (`#print axioms`, probe `lake env lean`) :
   - `Mimo.integral_norm_sq_eq_trace` → `[propext, Classical.choice, Quot.sound]`
   - `Mimo.lmmse_error_eq_trace` → `[propext, Classical.choice, Quot.sound]`
   - `Mimo.B_ρ_posSemidef` → `[propext, Classical.choice, Quot.sound]`
   - Twin `Mimo_en.*` : identiques (3/3).
   Aucun `sorryAx`.
4. **Pas de refactor prover** : pur ajout de module, zéro fichier hors `mimo_lean/` touché.

## Parité i18n (#4980)

Diff comment-strip (`/-! -/`, `/-- -/`, `--`) : jumeaux byte-identiques à 2 lignes près — `namespace Mimo` ↔ `Mimo_en` / `end` (divergence sanctionnée). Énoncés, tactiques, noms de lemmes identiques.

## Test plan

- [x] `lake build` SUCCESS (8663 jobs)
- [x] `#print axioms` × 6 decls FR+EN — aucun sorryAx
- [x] Parité FR/EN comment-strip
- [x] CI `Lean CI (mimo_lean)` sur la PR (sorry-baseline=0, standalone-tactic)

Grain: DEEP/lean -- lane myia-po-2026:CoursIA -- prev: LIGHT/docs #11053

Quoi:       Lmmse.lean + twin _en — Lemme 5.1 LMMSE (trace gaussienne, B_ρ PSD, transport de loi) sur Mathlib, 4e lib mimo_lean
Preuve:     lake build "Build completed successfully (8663 jobs)" + #print axioms [propext, Classical.choice, Quot.sound] x6 + sorry 0/0
Perimetre:  MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/ uniquement (Lmmse*.lean, lakefile, README) ; hors scope : Phase 3b converse §11 (lake SLT externe)

See #10984
