### PR TITLE
fix(procedures,#8888): --jq '.body' requis — grep du wrapper JSON = faux CHANGES_REQUESTED systematique

### DIFF
--- a/docs/reference/procedures-recurrentes.md
+++ b/docs/reference/procedures-recurrentes.md
@@ -107,11 +107,13 @@ Une PR « doc-honesty » / « alignement output » / « reconcile stale » (titr
 
 ```bash
 # 1. La PR porte bien `## Diagnostic dérive` dans le body (sinon CHANGES_REQUESTED §D.5)
-gh pr view <N> --json body | grep -c '^## Diagnostic dérive'
+# NB : --jq '.body' OBLIGATOIRE — sans lui, gh sort le wrapper JSON (une ligne, \n échappés)
+# et l'ancre ^ ne peut JAMAIS matcher : la commande retourne 0 même si la section existe.
+gh pr view <N> --json body --jq '.body' | grep -c '^## Diagnostic dérive'
 # > 0 requis
 
 # 2. Si verdict COSMETIC : une issue fille doit exister avec `See #N`
-gh pr view <N> --json body | grep -oE 'See #[0-9]+'
+gh pr view <N> --json body --jq '.body' | grep -oE 'See #[0-9]+'
 # > 0
 
 # 3. Si verdict REFRAME : la valeur du markdown doit venir d'une re-exec fraîche


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA — prev: DEEP/qc #10318 (en flight)

## Summary

Fix des 2 commandes de « Vérification post-fix » de la section PR doc-honesty (`docs/reference/procedures-recurrentes.md` L110/L114) : `gh pr view <N> --json body | grep ...` **grepait le wrapper JSON** (une seule ligne, `\n` échappés en littéraux) au lieu du markdown du body. L'ancre `^## Diagnostic dérive` ne peut **jamais** matcher dans le wrapper → la commande retourne 0 même quand la section existe → tout worker suivant la procédure conclut à une section manquante → **faux CHANGES_REQUESTED garanti** (§D.5).

Fix : `--jq '.body'` sur les deux commandes + note explicative inline (pourquoi `--jq` est obligatoire, pas décoratif).

## Preuve du défaut (mesurée firsthand)

Sur PR #9078 (porte réellement la section, header en début de ligne) :

| Commande | Résultat |
|---|---|
| `gh pr view 9078 --json body \| grep -c '^## Diagnostic dérive'` (cassée) | **0** |
| `gh pr view 9078 --json body --jq '.body' \| grep -c '^## Diagnostic dérive'` (corrigée) | **1** |

Contrôle négatif : PR #8481 mentionne la string mais pas comme header → les deux commandes retournent 0 (le discriminateur est bien l'ancre `^` contre les vrais newlines, absents du wrapper).

Aucune autre occurrence du pattern cassé sur main (`git grep 'json body | grep'` : uniquement ces 2 lignes, introduites par #8888).

## Scope

1 fichier, +4/−2, docs uniquement. Atomic, rien d'autre touché.

See #11044 (finding #8888 de la fenêtre 07-15..07-31, durcissement approuvé par ai-01)
