### PR TITLE
fix(audio,#11044): borner la boucle de cooldown de thermal_backoff (résidu PR #1877)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/fishaudio_client.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/fishaudio_client.py
@@ -211,6 +211,7 @@ def thermal_backoff(
     max_temp: int = 80,
     base_sleep: float = 3.0,
     max_sleep: float = 30.0,
+    max_cooldown_cycles: int = 30,
 ) -> int:
     """Adaptive thermal pause between TTS generations.
 
@@ -218,7 +219,9 @@ def thermal_backoff(
       - Below *target_temp*: minimal pause (base_sleep) to maintain airflow.
       - Between *target_temp* and *max_temp*: progressive backoff,
         scaling from base_sleep to max_sleep linearly with temperature.
-      - Above *max_temp*: full max_sleep cooldown and re-check.
+      - Above *max_temp*: full max_sleep cooldown and re-check, bounded
+        by *max_cooldown_cycles* (a stuck sensor or permanently
+        throttled GPU must not hang the pipeline forever).
 
     Returns current GPU temperature after the pause.
     """
@@ -240,14 +243,23 @@ def thermal_backoff(
         )
         time.sleep(sleep_time)
     else:
-        # Over threshold — full cooldown until temperature drops
-        while temp > target_temp:
+        # Over threshold — bounded cooldown until temperature drops
+        for _ in range(max_cooldown_cycles):
+            if temp <= target_temp:
+                break
             logger.info(
                 "GPU %dC > %dC, cooling %ds...",
                 temp, max_temp, int(max_sleep),
             )
             time.sleep(max_sleep)
             temp = get_gpu_temp()
+        else:
+            logger.warning(
+                "GPU still %dC after %d cooldown cycles (%ds total) — "
+                "proceeding throttled rather than hanging",
+                temp, max_cooldown_cycles,
+                int(max_cooldown_cycles * max_sleep),
+            )
 
     return temp
 


### PR DESCRIPTION
## Summary

Résidu du scan forensique #11044 sur la PR #1877 (merged) : la boucle de cooldown de `thermal_backoff` (`fishaudio_client.py`) était **non bornée** — `while temp > target_temp` sans plafond d'itérations. Un capteur bloqué au-delà de la cible ou un GPU en throttle permanent suspendait le pipeline TTS indéfiniment (le reviewer Hermes l'avait signalé en COMMENT_WITH_CONCERNS à l'époque, jamais corrigé).

## Fix

La boucle devient un `for _ in range(max_cooldown_cycles)` avec early-exit dès que la température repasse sous la cible :

- nouveau paramètre `max_cooldown_cycles: int = 30` (défaut = 15 min de cooldown max à `max_sleep=30.0`) ;
- au plafond : `logger.warning(... proceeding throttled rather than hanging)` puis retour de la dernière température — le pipeline continue **throttled** au lieu de rester suspendu ;
- les 3 autres branches (≤ target : pause légère ; intermédiaire : backoff progressif ; capteur absent : retour 0 immédiat) sont inchangées ;
- appel unique `p5_tts.py:740` en kwargs → aucun changement requis (paramètre avec défaut).

## Validation

Harness comportemental (get_gpu_temp / time.sleep monkeypatchés, non commis) :

| Cas | Attendu | Obtenu |
|---|---|---|
| Capteur bloqué à 85°C, cycles=5 | termine en 5 sleeps, WARNING, retourne 85 | ✅ 5 sleeps, retour 85 |
| Refroidit 85→84→83→60 | early exit après 3 sleeps, retourne 60 | ✅ 3 sleeps, retour 60 |
| Sous cible (50°C) | base_sleep seul, inchangé | ✅ `[3.0]`, retour 50 |
| Capteur absent (0) | retour 0 immédiat, inchangé | ✅ 0 sleep, retour 0 |

`python -m py_compile` OK. `git grep thermal_backoff(` → appelant unique, kwargs.

## Test plan

- [x] Harness 4 cas (bloqué / refroidit / sous-cible / absent)
- [x] py_compile
- [x] Diff chirurgical : 1 fichier, +15/−3

Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: LIGHT/notebook-python #11081

Quoi:       borne max_cooldown_cycles sur la boucle de cooldown de thermal_backoff (fishaudio_client.py) — fin du risidu PR #1877 du scan #11044
Preuve:     harness 4 cas monkeypatche (stuck->5 cycles+WARNING, cool->early exit, below/no-sensor inchanges) + py_compile OK
Perimetre:  v4/fishaudio_client.py seul ; hors scope : unit tests formels du module, autres residus #11044 (chunk 5)

See #11044
