### PR TITLE
feat(genai,#10996): Bonsai-Image — 4 cellules d'interpretation ancrees (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-5-Bonsai-Image-Ternary.ipynb
@@ -374,6 +374,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-quant-table-e9f8ab",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le ternaire 1.58-bit, un compromis taille-qualité favorable\n",
+    "\n",
+    "La table confirme l'argument de la section 1 : passer de FP16 (7,45 Go) au ternaire 1.58-bit (0,74 Go) divise l'empreinte par **10,1** (ratio 0,099) pour une qualité relative de **92 %** — soit 8 points de moins que le FP16. Le contraste décisif est avec l'INT2 naïf : à 0,93 Go (ratio 0,125), il économise à peine plus que le ternaire mais effondre la qualité à **55 %**. Bonsai récupère donc presque toute la qualité de l'INT4 (90 %) au coût mémoire de l'INT2 — c'est précisément la valeur du schéma ternaire avec scale FP16 partagé par groupe de 128 poids."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "viz-md",
    "metadata": {
     "papermill": {
@@ -455,6 +465,16 @@
     "plt.savefig(BONSAI_OUTPUT_DIR / \"quantization_tradeoff.png\", dpi=100, bbox_inches=\"tight\")\n",
     "plt.show()\n",
     "print(f\"Plot sauve : {BONSAI_OUTPUT_DIR / 'quantization_tradeoff.png'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-pareto-65afb9",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : Bonsai sur la frontière de Pareto taille-qualité\n",
+    "\n",
+    "Le graphique place chaque régime selon son empreinte (axe X, échelle log) et sa qualité relative (axe Y) : le point « idéal » est en haut à gauche — peu de bits, beaucoup de qualité. On y observe la non-linéarité du coût de la quantization agressive : l'INT2 naïf tombe à **55 %** de qualité alors que le ternaire, à empreinte comparable (0,74 Go vs 0,93 Go), reste à **92 %**. Au-delà de 2 bits/poids, chaque gain mémoire s'achète donc à un prix en qualité brutalement croissant — sauf pour le ternaire, dont Gemlite amortit le coût par le packing INT2 et le scale partagé."
    ]
   },
   {
@@ -644,6 +664,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-skip-5f26b7",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : une génération honnêtement skipée, pas une sortie fabriquée\n",
+    "\n",
+    "La cellule d'initialisation du client ComfyUI affiche `ComfyUI non disponible : COMFYUI_API_URL manquant dans .env` et saute la génération (`Generation skipped`). C'est un comportement volontaire : le notebook ne fabrique pas de sortie quand l'API n'est pas configurée — il documente l'échec. Sur une instance où `COMFYUI_API_URL` et `COMFYUI_API_TOKEN` sont présents (section 4), les appels `generate_bonsai_comfyui()` des exercices 1 à 3 produisent de vraies images via le custom node `BonsaiTernaryNode`. La sortie de cette cellule est donc un état de configuration, pas un résultat de génération."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "bench-md",
    "metadata": {
     "papermill": {
@@ -743,6 +773,16 @@
     "plt.savefig(BONSAI_OUTPUT_DIR / \"bonsai_benchmarks.png\", dpi=100, bbox_inches=\"tight\")\n",
     "plt.show()\n",
     "print(f\"Plot sauve : {BONSAI_OUTPUT_DIR / 'bonsai_benchmarks.png'}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-bench-4597a8",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : Bonsai face aux modèles grand public\n",
+    "\n",
+    "Le graphique reprend les trois métriques publiées sur la page HuggingFace du modèle : **GenEval 0,723** (alignement compositionnel prompt/image), **HPSv3 12,22** (préférence humaine) et **DPG-Bench 0,851** (fidélité à des prompts denses). Chaque barre utilise la borne naturelle de sa métrique (1,0 pour GenEval et DPG-Bench, ~30 pour HPSv3) : comparer des scores à des bornes différentes sur une échelle commune les rendrait illisibles. Ces scores placent Bonsai au niveau des modèles grand public alors que le transformer ne pèse que 0,74 Go on-disk — la démonstration quantitative du compromis 1.58-bit."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/guard #11067

## Summary

Enrichissement **markdown-only** de `02-5-Bonsai-Image-Ternary.ipynb` (GenAI/Image, scope OVERRIDE #10996) : 4 cellules d'interprétation `### Lecture du résultat :` insérées immédiatement après les cellules de code dont l'output porte les valeurs citées (règle cell-interpretation-ordering HARD, epic #10678).

| # | Interp | Ancrage | Valeurs citées présentes dans |
|---|---|---|---|
| 1 | Le ternaire 1.58-bit, un compromis taille-qualité favorable | après la table des régimes (CODE[4]) | output table : 7,45 / 0,74 / 0,099 / 92 % / 55 % / 0,93 / 90 % |
| 2 | Bonsai sur la frontière de Pareto taille-qualité | après le scatter plot (CODE[6]) | positions des points du plot (df CODE[4]) ; output texte plot court → scanner skip par construction |
| 3 | Une génération honnêtement skipée, pas une sortie fabriquée | après l'init client ComfyUI (CODE[8]) | output : `COMFYUI_API_URL manquant` + `Generation skipped` |
| 4 | Bonsai face aux modèles grand public | après le plot bench (CODE[10]) | source bench dict : GenEval 0,723 / HPSv3 12,22 / DPG-Bench 0,851 |

## Note genre / plancher

MED/notebook-python = genre **CONTENU** — plancher G-VAR-1 TENU (premier grain de contenu après 4 cycles déclarés non-planchers). Pivot genre depuis `guard` (LIGHT, G-VAR-3).

## Validation

- **Markdown-only (C.3)** : 40 insertions / 0 suppression, uniquement 4 cellules markdown ; les 8 cellules code sont byte-identiques (0 diff), `execution_count` + outputs intacts. Aucune re-exécution requise.
- `validate_pr_notebooks.py` : `passed: true`, 8/8 cellules code, verdict `EXEC_PROVED`, 0 erreur.
- `scan_cell_ordering.py` (gate structurel) : 1 clean, 0 finding. Scanner opt-in `scan_interp_output_anchor` (triage #10678) : **0 findings** — les 4 interps sont immédiatement après leur cellule, valeurs ancrées.
- `cell_order_ci.py --base origin/main --head` : PASS (aucune sortie).
- Line-endings : blob LF-only → écrit en LF (lecon c.10855). Round-trip load+dump = byte-identique avant modification.

## Finding signalé (PAS fixé ici — PR markdown-only)

**CODE[8] `generate_bonsai_comfyui()` skippée à l'exécution** : output `ComfyUI non disponible : COMFYUI_API_URL manquant dans .env` alors que la Statut du notebook (§ nav) déclare « génération API ComfyUI fonctionnelle ». Verdict proposé : **RECOVERABLE-MACHINE** (ComfyUI self-hosted sur po-2023, GPU). Action séparée nécessaire : configurer `COMFYUI_API_URL`/`COMFYUI_API_TOKEN` dans l'env + re-exécuter pour produire les vraies images des exercices 1-3. Tracker suggéré : issue fille de #10996.

## Périmètre

Contribution partielle à l'override #10996 (Image/** + Video/**). Voir #10996.

See #10996 (contribution à l'epic — autres tranches sur l'issue)
