### PR TITLE
feat(genai,#10996): 04-1-Educational — 4 cellules d'interpretation ancrees (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-1-Educational-Content-Generation.ipynb
@@ -377,6 +377,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-config-d86f30",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : une configuration hybride à deux fournisseurs\n",
+    "\n",
+    "La cellule valide la présence des deux clés d'API avant toute génération : OpenAI (`✅ OPENAI: API configurée`) pour la génération d'images et OpenRouter (`✅ OPENROUTER: API configurée`) pour l'appel des modèles de langage. Le dictionnaire `Configuration APIs` récapitule cet état — deux fournisseurs distincts, chacun à sa place dans le pipeline : l'image côté OpenAI, l'alt text côté OpenRouter. Ce double contrôle en amont évite les erreurs tardives : le notebook refuse de démarrer une génération dont l'un des deux canaux serait indisponible."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a99f0ee2",
    "metadata": {
     "papermill": {
@@ -949,6 +959,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-widgets-d6a4d3",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : une interface interactive, pas une génération\n",
+    "\n",
+    "La sortie affiche un widget Jupyter vivant (`VBox` contenant des `Dropdown` pour la matière, le sujet et le niveau), pas un résultat de génération : le bouton « Générer Contenu » déclencherait l'appel API au clic. Le `widget-view` (identifié par son `model_id`) n'est qu'un état d'interface dans la session. C'est la cellule de démonstration suivante qui produit une vraie image, de façon reproductible et sans interaction — l'interface sert la configuration manuelle, la démo sert la vérification automatique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "demo-gptimage-md",
    "metadata": {
     "papermill": {
@@ -1070,6 +1090,16 @@
     "    print(f\"Alt text (accessibilite WCAG) : {demo_alt_text}\")\n",
     "elif content_generator.openai_client:\n",
     "    print(\"La generation n'a pas retourne d'image.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-demo-21b5a7",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : une génération réelle, les deux canaux attestés\n",
+    "\n",
+    "La démonstration batch exécute le pipeline complet sans interface : un appel `POST https://api.openai.com/v1/images/generations` répond `HTTP/1.1 200 OK` et produit une image `gpt-image-1` de **2259 KB** (base64), affichée dans la sortie (`data:image/png`). Un second appel — `POST https://openrouter.ai/api/v1/chat/completions`, lui aussi en `200 OK` — génère l'alt text accessible (WCAG) : « Diagramme de la photosynthèse montrant une feuille absorbant lumière solaire, CO2 et eau… ». Les paramètres de génération (matière `biology`, sujet `photosynthesis`, niveau `high_school`) sont injectés par Papermill, rendant la démo reproductible à l'identique d'une exécution à l'autre."
    ]
   },
   {
@@ -1334,6 +1364,16 @@
     "print(f\"👩‍🏫 Workflow enseignant initialisé\")\n",
     "print(f\"📚 Templates disponibles: {list(teacher_workflow.lesson_templates.keys())}\")\n",
     "print(f\"\\n💡 Usage: await teacher_workflow.create_complete_lesson_package('biology', 'photosynthesis', 'high_school')\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-workflow-7c7705",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le workflow orchestre, l'exécution attend son appel\n",
+    "\n",
+    "La classe `TeacherWorkflow` est initialisée avec les templates disponibles (`['biology']`) et expose une méthode unique : `create_complete_lesson_package('biology', 'photosynthesis', 'high_school')`. La sortie est un mode d'emploi, pas une exécution : le package pédagogique complet (leçon, exercices, images, alt text) serait assemblé par l'appel de cette méthode, enchaînant les générations image (OpenAI) et texte (OpenRouter) sur le même sujet — la version automatisée du workflow que l'exercice 2 prépare à construire."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #11085

## Summary

Enrichissement **markdown-only** de `04-1-Educational-Content-Generation.ipynb` (GenAI/Image, scope OVERRIDE #10996) : 4 cellules d'interprétation `### Lecture du résultat :` insérées immédiatement après les cellules de code dont l'output porte les valeurs citées (règle cell-interpretation-ordering HARD, epic #10678).

| # | Interp | Ancrage (CODE) | Valeurs citées présentes dans l'output |
|---|---|---|---|
| 1 | Configuration hybride à deux fournisseurs (OpenAI images + OpenRouter texte) | config APIs | `✅ OPENAI: API configurée` / `✅ OPENROUTER: API configurée` / `Configuration APIs` |
| 2 | Interface interactive = widget vivant, pas une génération | widgets Jupyter | `Interface prête` / `Générer Contenu` / `VBox` |
| 3 | Génération réelle gpt-image-1, les deux canaux attestés | démo batch | `HTTP/1.1 200 OK` ×2 (OpenAI + OpenRouter), `gpt-image-1`, `2259 KB`, `biology`/`photosynthesis`/`high_school`, `WCAG`, `data:image/png` |
| 4 | Workflow orchestre, l'exécution attend son appel | classe TeacherWorkflow | `['biology']` / `create_complete_lesson_package` / `high_school` |

## Note genre / plancher

MED/notebook-python = genre **CONTENU** — plancher G-VAR-1 TENU. Deuxième enrichissement d'interps du scope OVERRIDE (#11085 Bonsai → #11086 Edugen) : substance genuinement distincte (quantification ternaire vs génération éducative multi-providers) — le 2ᵉ notebook-python consécutif est autorisé (G-VAR-3).

## Validation

- **Markdown-only (C.3)** : 40 insertions / 0 suppression, uniquement 4 cellules markdown ; les 11 cellules code byte-identiques (0 diff), `execution_count` + outputs intacts. Aucune re-exécution requise.
- `validate_pr_notebooks.py` : `passed: true`, 11/11 cellules code, verdict `EXEC_PROVED`, 0 erreur.
- `scan_cell_ordering.py` (gate structurel) : 1 clean, 0 finding. Scanner opt-in `scan_interp_output_anchor` (triage #10678) : **0 findings** — les 4 interps sont immédiatement après leur cellule, valeurs ancrées (vérifiées ligne à ligne).
- Round-trip load+dump = byte-identique avant modification (LF, indent=1, ensure_ascii=False — lecon c.10855).

## Note

Le notebook est un contre-exemple SOTA-OK de la série : les outputs commités attestent de **vraies** générations (HTTP 200 OpenAI gpt-image-1 + OpenRouter, image base64 2259 KB affichée) — pas de workaround. Aucun finding à signaler sur ce notebook.

## Périmètre

Contribution partielle à l'override #10996 (Image/** + Video/**). Voir #10996.

See #10996 (contribution à l'epic — autres notebooks Image/Video sur l'issue)
