### PR TITLE
fix(qc,#11044): repair 2 dead links in QC-Py-Cloud-01 conclusion table

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
@@ -1054,8 +1054,8 @@
     "|----------|-------|------|\n",
     "| Cloud-02 | Classification ML (Random Forest) | [QC-Py-Cloud-02-ML-Classification.ipynb](QC-Py-Cloud-02-ML-Classification.ipynb) |\n",
     "| Cloud-03 | Risk Parity | [QC-Py-Cloud-03-Risk-Parity.ipynb](QC-Py-Cloud-03-Risk-Parity.ipynb) |\n",
-    "| Cloud-04 | RL DQN Trading | [QC-Py-Cloud-04-RL-Options.ipynb](QC-Py-Cloud-04-RL-DQN-Trading.ipynb) |\n",
-    "| Cloud-05 | Regime Switching | [QC-Py-Cloud-05-Transformer.ipynb](QC-Py-Cloud-05-RegimeSwitching.ipynb) |\n"
+    "| Cloud-04 | RL DQN Trading | [QC-Py-Cloud-04-RL-DQN-Trading.ipynb](QC-Py-Cloud-04-RL-DQN-Trading.ipynb) |\n",
+    "| Cloud-05 | Regime Switching | [QC-Py-Cloud-05-RegimeSwitching.ipynb](QC-Py-Cloud-05-RegimeSwitching.ipynb) |\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: MED/guard #11084

## Summary

Residual DEFECT-ALIVE from the #11044 triage window `merged:2026-04-23..2026-04-30` (reported in issuecomment-5303235161): PR #590 was merged with a review demanding "CRITICAL — Must fix before merge" for broken cross-references, without any lift. Measured on current `origin/main`, 2 of the flagged defects were still alive in `QC-Py-Cloud-01-FinBERT-Sentiment.ipynb` cell 22 (conclusion table):

- Link **text** `[QC-Py-Cloud-04-RL-Options.ipynb]` → file does not exist (real: `QC-Py-Cloud-04-RL-DQN-Trading.ipynb`, href already correct)
- Link **text** `[QC-Py-Cloud-05-Transformer.ipynb]` → file does not exist (real: `QC-Py-Cloud-05-RegimeSwitching.ipynb`, href already correct)

Fix: align link text with the real filenames. Markdown-only edit (2 lines in 1 cell, C.2 exception — no re-exec needed).

## Validation

- All 5 `.ipynb` references in the notebook now resolve on disk (verified programmatically):
  ```
  cell 0:  QC-Py-Cloud-02-ML-Classification.ipynb -> OK
  cell 22: QC-Py-Cloud-02-ML-Classification.ipynb -> OK
  cell 22: QC-Py-Cloud-03-Risk-Parity.ipynb       -> OK
  cell 22: QC-Py-Cloud-04-RL-DQN-Trading.ipynb    -> OK
  cell 22: QC-Py-Cloud-05-RegimeSwitching.ipynb   -> OK
  ```
- Diff surgical: 2 insertions / 2 deletions, markdown cell only, code cells and `execution_count` untouched.

## Grain

LIGHT/guard — lane myia-po-2023:CoursIA — prev: MED/guard #11084

See #11044 (contribution to triage follow-up, defect now fixed)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
