### PR TITLE
fix(semanticweb,#11044): SW-3-CSharp recap AssertList — lever l'ambiguïté liste 1,2,3 du §5.1 vs [true, false]

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
@@ -1428,7 +1428,7 @@
     "\n",
     "| Opération | Triplets avant | Triplets après | Delta |\n",
     "|-----------|----------------|----------------|-------|\n",
-    "| AssertList | 7 (1 ancrage + liste 1,2,3) | 11 (+2 éléments = +4 triplets: 2x rdf:first + 2x rdf:rest) | +4 |\n",
+    "| AssertList | 7 (1 ancrage + liste 1,2,3 du §5.1) | 11 (7 + liste [true, false] = +4 triplets: 2x rdf:first + 2x rdf:rest) | +4 |\n",
     "| RetractList | 11 | 7 | -4 |\n",
     "\n",
     "Chaque élément de liste coute 2 triplets (`rdf:first` + `rdf:rest`), sauf le dernier qui pointe vers `rdf:nil`."

--- a/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
@@ -11,6 +11,12 @@
       python_sha: 91c69994024084bea93a0823230255624b828ce1
       csharp_sha: 07cea4cbbc82bdb3c2a3f863b418b9a8b2a44fa2
       reason: "Measure/value fix (C# cell 13 « Interpretation : Comparaison des formats de sortie »): 2 inverted-size claims contradicted the committed cell 12 output (4-triplet graphe Example.ttl). c12 measures NTriples 448 car / 4 lines and Turtle 531 car / 8 lines (5 @prefix + 1 statement), so Turtle is LARGER here (ratio 0.84:1) -- yet c13 claimed « tient en 3 lignes au lieu de 4 » (Turtle is 8 lines) and « ratio 2:1 (NTriples ~400 car vs Turtle ~300 car) » (backwards: Turtle 531 > NTriples 448). On this tiny graphe the 5 @prefix declarations dominate; compression appears only on larger graphs. Realigned both claims to the measured output (8 lines total; 531 vs 448 car, Turtle paradoxalement plus long) while preserving the valid general point « 5:1 ou plus sur des graphes plus grands ». Markdown-only, 0 re-exec, no output change. Python twin SW-3b uses rdflib with different output sizes (separate analysis), python unchanged."
+    - date: "2026-08-15"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 91c69994024084bea93a0823230255624b828ce1
+      csharp_sha: d9b84f34b00f68039f500f42cbe354684ee8b8b6
+      content_python_sha: 5987578811b52065f3590de667a2b537865694536b85274c2105cb21b101ff02
+      content_csharp_sha: d943d8dd651ab5dc8883560c0cb99ddbcedb445eee60f4ac08a5e206a303a5a6
   known_differences:
     - "Socle commun : parcours de graphe RDF, iteration des triplets, gestionnaires de parsing (handlers)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Parsing.Handlers`, iterate via `Graph.Triples`). Python = `rdflib` (`rdflib.collection`, `rdflib.parser`, iteration via `graph` set semantics)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11088

## Summary

Fix du finding **#9002** (re-lecture durcie 07-15..07-31, comment 5303277xxx) : la recap `SW-3-CSharp-GraphOperations.ipynb` cell 33 écrivait « AssertList | 7 (1 ancrage + liste 1,2,3) » — ambigu : la liste `1,2,3` est celle construite au §5.1, alors que l'appel réel (cell 32) crée une **nouvelle** liste `[true, false]`. La ligne cite désormais les deux listes nommément.

## Validation (B.2)

| Check | Résultat |
|---|---|
| Diff | 2 fichiers : notebook (+1/−1) + registre twin-parity (rebaseline, +6) |
| `validate_pr_notebooks.py` | **1/1 passed** (20 code cells, verdict EXEC_PROVED) |
| C.1 | 0 `raise NotImplementedError` / `assert False` / `1/0` |
| `scan_cell_ordering.py` | 1 clean, 0 finding |
| C.3 | Markdown-only (cellule markdown seule modifiée) → **pas de re-exec requise** ; exec_counts intacts |
| Twin parity (#8057) | Édit markdown-only → blob SHA déplacé → paire `SW-3 Graph-Operations` rebaselinée (`--update`, audit 2026-08-15, écriture chirurgicale #8570). `--verify-recorded-sha` : 157/157 OK, MISMATCH=0. `--update` en dernier (leçon #8957). |
| Catalogue | byte-identique |

## Diff

```
-| AssertList | 7 (1 ancrage + liste 1,2,3) | 11 (+2 éléments = +4 triplets: 2x rdf:first + 2x rdf:rest) | +4 |
+| AssertList | 7 (1 ancrage + liste 1,2,3 du §5.1) | 11 (7 + liste [true, false] = +4 triplets: 2x rdf:first + 2x rdf:rest) | +4 |
```

La source de vérité reste l'output committé cell 32 (`execution_count: 13`) : `AssertList : [true^^boolean, false^^boolean]`, `RetractList : 11 -> 7 triplets` — les deux listes cohabitent (7 avant = 1 ancrage + liste 1,2,3 pré-existante ; +4 = la liste [true, false]).

See #11044 · See #9002
