### PR TITLE
feat(genai,#10996): 01-2-GPT-5 — 4 cellules d'interpretation ancrees (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb
@@ -440,6 +440,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-config-b2f6e5",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : une API validée avant toute analyse\n",
+    "\n",
+    "La cellule confirme que la clé OpenAI est présente et que la connexion est réellement établie : `OPENAI_API_KEY valide - API disponible`, puis un appel `GET https://api.openai.com/v1/models` qui répond `HTTP/1.1 200 OK`. Le catalogue des modèles affiche `gpt-5-chat-latest`, `gpt-5-2025-08-07` et `gpt-5` ; le notebook sélectionne `gpt-5-2025-08-07` — le snapshot daté et stable. La fenêtre d'inférence est fixée à `Max tokens : 8000` avec `Temperature : 1`, un compromis volontairement généreux : les réponses de description (jusqu'à ~2000 tokens de completion) et de raisonnement temporel ne doivent pas être tronquées."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-4",
    "metadata": {
     "papermill": {
@@ -600,6 +610,16 @@
     "plt.suptitle(\"Apercu des 5 scenes\", fontsize=12, fontweight='bold')\n",
     "plt.tight_layout()\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-multiscene-30e49c",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : une vidéo de test calibrée pour la détection de scènes\n",
+    "\n",
+    "La cellule génère une vidéo synthétique de `5 scènes` (matin, midi, après-midi, soir, nuit) — `240 frames` au total, soit `10.0s` à 24 images/seconde — pour un poids de seulement `54.1 KB` (des formes et couleurs unies se compressent presque gratuitement). La figure à `5 Axes` montre une image par scène. Ce choix de conception n'est pas anodin : les scènes diffèrent par leur couleur dominante, leur forme géométrique et leur texte, de sorte que les stratégies d'échantillonnage (Section 2) et le raisonnement temporel de GPT-5 (plus bas) disposent de transitions franches et mesurables."
    ]
   },
   {
@@ -1226,6 +1246,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-analysis-29d463",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : GPT-5 lit vraiment les frames, en deux passes\n",
+    "\n",
+    "Deux appels `POST https://api.openai.com/v1/chat/completions` répondent `HTTP/1.1 200 OK`. La première passe (description image par image) prend `22.99s` pour `2940 tokens` (765 en prompt, 2175 en completion) : GPT-5 décrit chaque frame — `Frame 1 (t=0.0s)`, `Frame 2 (t=1.4s)`, `Frame 3 (t=2.8s)` — l'espacement de 1,4 s correspondant aux 8 frames échantillonnées sur 10 s. La seconde passe (raisonnement temporel) prend `19.66s` pour `2572 tokens` (792 + 1780) et restitue une structure que seul le contenu visuel permet : `5 scènes distinctes` identifiées, avec leurs instants de transition (`vers 2.8s`, `vers 4.2s`, `vers 7.1s`, `vers 8.5s`) et une narration de cycle jour-nuit (matin → midi → après-midi → soir → nuit) qui correspond exactement au script de génération de la cellule précédente."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4n1q500f8lb",
    "metadata": {
     "papermill": {
@@ -1380,6 +1410,16 @@
     "        print(f\"  {q_short:<60} {tokens:<10}\")\n",
     "else:\n",
     "    print(\"Q&A desactive (analyze_video=False)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-qa-04d5ff",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le Q&A confirme l'accès au contenu visuel\n",
+    "\n",
+    "Trois questions, trois réponses `HTTP/1.1 200 OK` — chacune factuellement correcte par rapport à la vidéo synthétique : la couleur dominante de la première scène est `Orange clair (fond orangé pâle).` (3.8s, 970 tokens), ce qui correspond au fond `(255, 200, 100)` de la scène « Matin » ; le décompte des formes donne `3 — cercle, carré et triangle` (5.4s, 1046 tokens) avec la précision que les étoiles sont aussi des cercles ; et la vidéo représente bien un `cycle jour-nuit: matin → midi → après-midi → soir → nuit` (7.1s, 1200 tokens). Des réponses à ce niveau de détail — couleurs exactes, formes, structure narrative — ne peuvent pas provenir des seuls noms de fichiers : GPT-5 accède au contenu pixel des frames encodées en base64. C'est la démonstration SOTA du notebook."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #11087

## Summary

Enrichissement **markdown-only** de `01-2-GPT-5-Video-Understanding.ipynb` (GenAI/Video, scope OVERRIDE #10996) : 4 cellules d'interprétation `### Lecture du résultat :` insérées immédiatement après les cellules de code dont l'output porte les valeurs citées (règle cell-interpretation-ordering HARD, epic #10678).

| # | Interp | Ancrage (CODE) | Valeurs citées présentes dans l'output |
|---|---|---|---|
| 1 | Une API validée avant toute analyse | config OpenAI | `OPENAI_API_KEY valide - API disponible` / `HTTP/1.1 200 OK` / `gpt-5-2025-08-07` / `Max tokens : 8000` / `Temperature : 1` |
| 2 | Une vidéo de test calibrée pour la détection de scènes | création vidéo multi-scènes | `5 scènes` / `240 frames` / `10.0s` / `54.1 KB` / `5 Axes` |
| 3 | GPT-5 lit vraiment les frames, en deux passes | analyse GPT-5 | `HTTP/1.1 200 OK` ×2 / `22.99s` / `2940 tokens` (765+2175) / `19.66s` / `2572 tokens` (792+1780) / `5 scènes distinctes` / transitions `2.8s`/`4.2s`/`7.1s`/`8.5s` |
| 4 | Le Q&A confirme l'accès au contenu visuel | Video Q&A | `Orange clair (fond orangé pâle).` / `3 — cercle, carré et triangle` / cycle jour-nuit / `3.8s`/`5.4s`/`7.1s` / `970`/`1046`/`1200` tokens |

## Note genre / plancher

MED/notebook-python = genre **CONTENU** — plancher G-VAR-1 TENU. Troisième enrichissement d'interps du scope OVERRIDE (#11085 Bonsai quantisation → #11087 Edugen génération éducative → cette PR GPT-5 **compréhension vidéo vision-langage**) : **substance genuinement distincte** — le 3ᵉ consécutif est autorisé (précédent notebook-dotnet de ai-01 : 3ᵉ autorisé si distinct, 4ᵉ franchirait le litmus « générable en scannant l'instance suivante »). Le registre change de nature : ni génération ni enhancement, mais **analyse** (frames → GPT-5 → descriptions/Q&A temporelles), attestée par de vrais appels HTTP 200. C'est aussi la **première tranche côté Video/** de l'OVERRIDE.

## Validation

- **Markdown-only (C.3)** : 40 insertions / 0 suppression, uniquement 4 cellules markdown ; les 14 cellules code byte-identiques (0 diff `execution_count`/`outputs`), `execution_count` + outputs intacts. Aucune re-exécution requise.
- `validate_pr_notebooks.py` : `passed: true`, 14/14 cellules code, verdict `EXEC_PROVED`, 0 erreur.
- `scan_cell_ordering.py` (gate structurel) : 1 clean, 0 finding. Scanner opt-in `scan_interp_output_anchor` (triage #10678) : **0 findings** — les 4 interps sont immédiatement après leur cellule, valeurs ancrées (vérifiées ligne à ligne).
- `cell_order_ci.py --base origin/main --head` : PASS.
- Round-trip load+dump = byte-identique (LF, indent=1, ensure_ascii=False, **sans newline finale** — variante blob du lecon c.10855).
- Pre-commit : gitleaks + H.3 + markdown-rendering PASS.

## Note

Le notebook est un contre-exemple SOTA-OK : les outputs commités attestent de **vraies** analyses GPT-5 (6 × `POST /chat/completions` HTTP 200, tokens mesurés, réponses factuellement correctes sur la vidéo synthétique — couleurs, formes, transitions, cycle jour-nuit). Aucun finding à signaler.

## Périmètre

Contribution partielle à l'override #10996 (Image/** + Video/**). Voir #10996.

See #10996 (contribution à l'epic — autres tranches Image/Video sur l'issue)
