### PR TITLE
fix(lean,#10986): réparer l'énoncé de folk_theorem_discounted (borne d < 1)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk.lean
@@ -85,7 +85,7 @@ noncomputable def discountedPayoff (g : PrisonersDilemma) (δ : ℝ)
 /-- Le théorème de Folk ACTUALISÉ (Fudenberg–Maskin 1986, simplifié pour 2x2) :
 
       Pour tout paiement faisable strictement individuellement rationnel
-      `u = (u_row, u_col)`, il existe δ* < 1 tel que pour tout δ ≥ δ* le
+      `u = (u_row, u_col)`, il existe δ* < 1 tel que pour tout δ ∈ [δ*, 1) le
       vecteur `u` est réalisé comme paiement actualisé d'une trajectoire
       d'actions conjointes.
 
@@ -108,7 +108,7 @@ theorem folk_theorem_discounted (g : PrisonersDilemma) :
       Feasible g u_row u_col →
       u_row > g.P ∧ u_col > g.P →  -- strict IR
       ∃ (δ_star : ℝ), δ_star < 1 ∧
-        ∀ (d : ℝ), d ≥ δ_star →
+        ∀ (d : ℝ), d ≥ δ_star → d < 1 →
           ∃ (a : ℕ → PDAction × PDAction),
             discountedPayoff g d a = u_row ∧
             discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col := by
@@ -117,6 +117,13 @@ theorem folk_theorem_discounted (g : PrisonersDilemma) :
   -- paiement actualisé, pour tout δ assez proche de 1. Requiert la convexité
   -- du polytope des paiements faisables et un argument de point extrême ;
   -- preuve de plusieurs pages, pas une seule tactique.
+  --
+  -- Bord d'énoncé réparé (2026-08-15) : l'ancien quantificateur « ∀ d ≥ δ* »
+  -- (sans borne d < 1) rendait le théorème FAUX — à d ≥ 1 les séries
+  -- ∑' d^n · payoff divergent et `tsum` vaut 0 (valeur junk), si bien qu'aucun
+  -- u ≠ 0 n'est réalisable (témoin : g = ⟨3, 2, 1, 0⟩, u = (2, 2), d = 2).
+  -- La borne « d < 1 » répare sans renforcer : le prouveur choisit δ* ≥ 0,
+  -- donc d ∈ [δ*, 1) ⊆ [0, 1) et les séries convergent absolument.
   sorry
 
 /-- Cas limite δ = 0 : sans poids sur le futur, les valeurs actualisées se

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/RepeatedGames/Folk_en.lean
@@ -104,7 +104,7 @@ noncomputable def discountedPayoff (g : PrisonersDilemma) (δ : ℝ)
 /-- The DISCOUNTED Folk theorem (Fudenberg–Maskin 1986, simplified for 2x2):
 
       For every strictly individually rational feasible payoff
-      `u = (u_row, u_col)`, there exists δ* < 1 such that for all δ ≥ δ* the
+      `u = (u_row, u_col)`, there exists δ* < 1 such that for all δ ∈ [δ*, 1) the
       vector `u` is realized as the discounted payoff of a trajectory of
       joint actions.
 
@@ -126,7 +126,7 @@ theorem folk_theorem_discounted (g : PrisonersDilemma) :
       Feasible g u_row u_col →
       u_row > g.P ∧ u_col > g.P →  -- strict IR
       ∃ (δ_star : ℝ), δ_star < 1 ∧
-        ∀ (d : ℝ), d ≥ δ_star →
+        ∀ (d : ℝ), d ≥ δ_star → d < 1 →
           ∃ (a : ℕ → PDAction × PDAction),
             discountedPayoff g d a = u_row ∧
             discountedPayoff g d (fun n => ((a n).2, (a n).1)) = u_col := by
@@ -134,6 +134,13 @@ theorem folk_theorem_discounted (g : PrisonersDilemma) :
   -- realizing the target payoff vector (u_row, u_col) as a discounted payoff,
   -- for all δ close enough to 1. Requires convexity of the feasible-payoff
   -- polytope and an extreme-point argument; a multi-page proof, not one tactic.
+  --
+  -- Statement edge repaired (2026-08-15): the old quantifier "∀ d ≥ δ*"
+  -- (no d < 1 bound) made the theorem FALSE — at d ≥ 1 the series
+  -- ∑' d^n · payoff diverge and `tsum` is 0 (junk value), so no u ≠ 0 is
+  -- realizable (witness: g = ⟨3, 2, 1, 0⟩, u = (2, 2), d = 2).
+  -- The "d < 1" bound repairs without strengthening: the prover picks
+  -- δ* ≥ 0, hence d ∈ [δ*, 1) ⊆ [0, 1) and the series converge absolutely.
   sorry
 
 /-- Boundary case δ = 0: with no weight on the future, the discounted values


### PR DESCRIPTION
## Summary — réparation d'énoncé (le sorry porte une dette impayable)

`folk_theorem_discounted` (Folk.lean, STRETCH documenté issue #4880) est **faux tel qu'énoncé sur main** : le quantificateur interne `∀ (d : ℝ), d ≥ δ_star` n'a **pas de borne `d < 1`**.

**Témoin falsifiant** (papier + préreçu machine, voir §Validation) : pour `d ≥ 1`, la série `∑' n, d^n · stagePayoff` diverge pour toute trajectoire à infinitely-many étapes non nulles, et `tsum` vaut **0 par convention junk** sur les familles non sommables. Concrètement, avec `g = ⟨T=3, R=2, P=1, S=0⟩` (admissible : `T>R>P>S`, `2R>T+S`) et `u = (2, 2)` (faisable via `pCC=1`, strictement IR car `2>1`) : à `d = 2`, aucune trajectoire ne réalise `u` — la somme row converge seulement si `a` est éventuellement `(C,D)` (payoff row `S=0`), mais alors la somme col diverge (`T=3` par étape) → junk 0 ≠ 2. Donc **le théorème est faux** et le `sorry` est **impayable** : personne ne pourra jamais le décharger.

**Fix minimal** : ajouter la borne manquante `d < 1` (l'énoncé devient la lecture Fudenberg–Maskin standard `d ∈ [δ*, 1)`). Sans renforcement : le prouveur choisit `δ*` (existentiel), donc peut prendre `δ* ≥ 0`, et `d ∈ [δ*, 1) ⊆ [0, 1)` garantit la convergence absolue des séries — la dette redevient **authentique** (constructible en principe par la construction FM). Le `sorry` (1 FR + 1 twin EN) est **conservé** — c'est une réparation d'énoncé, pas une décharge.

Docstrings module/théorème et commentaires STRETCH mis à jour (FR + EN) avec le témoin documenté in situ.

## Validation (§B.3)

1. **sorry count** : avant 1 (Folk.lean) + 1 (Folk_en.lean) / après 1 + 1 — inchangé (`grep -c sorry`).
2. **Build local** : `lake build RepeatedGames.Folk RepeatedGames.Folk_en` — **`Build completed successfully (2952 jobs)`**, tentative 1, commit f9e00a27a (worktree isolé ; Mathlib rc1 **complet** 5,4 Go rev `d568c8c0` exacte via junction — le reservoir n'a plus d'artefacts windows rc1 : `lake cache get` échoue « no outputs found in 100 revisions », la junction vers un Mathlib rc1 complet était la seule voie locale). Le build complet du lake (`lake -R build`) tourne en CI (job `Lake build (game_theory_lean)`) — build local complet gated ≥16 Go RAM (RECOVERABLE-MACHINE documenté lakefile.lean).
3. **Preuve machine du préreçu du témoin** : `witness.lean` (scratch, non commis) prouve `(∑' n : ℕ, (2:ℝ)^n) = 0` — tsum junk sur série géométrique divergente, via `HasSum.tendsto_sum_nat` + `Metric.tendsto_atTop` (négation de la sommabilité par le test des sommes partielles, sauts ≥ 1) puis `tsum_eq_zero_of_not_summable` — **EXIT 0**.
4. **Aucun consommateur** de `folk_theorem_discounted` hors Folk*.lean (`git grep` : seul le commentaire narratif du lakefile.lean) — changement d'énoncé sans effet de bord.
5. **Parité i18n** : diff comment-strip FR/EN — identiques hors `namespace RepeatedGames(_en)` (divergence sanctionnée #4980).

## Test plan

- [x] `lake build RepeatedGames.Folk RepeatedGames.Folk_en` SUCCESS (2952 jobs)
- [x] witness.lean EXIT 0 (tsum junk machine-checké)
- [x] grep désolé avant/après inchangé
- [ ] CI `Lean Game Theory CI` sur la PR (sorry StableMarriage baseline 5 inchangé + `lake -R build`)

Grain: MED/lean -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #11079

Quoi:       reparer l'enonce de folk_theorem_discounted (quantifieur sans borne d < 1 rendait le theoreme FAUX, tsum junk a d >= 1) — borne ajoutee, sorry conserve, temoin documente FR+EN
Preuve:     lake build Folk(+_en) "Build completed successfully (2952 jobs)" + witness.lean EXIT 0 ((∑' n, (2:ℝ)^n) = 0 machine-checke) + sorry 1+1 inchange + zero consommateur externe
Perimetre:  RepeatedGames/Folk.lean + Folk_en.lean uniquement (statement + commentaires) ; hors scope : decharge du sorry (STRETCH BG faible #4880), migration v4.32 #10986

See #10986
