### PR TITLE
feat(rules,#11059): add slides as CONTENU genre in variation-protocol enum

### DIFF
--- a/.claude/rules/variation-protocol.md
+++ b/.claude/rules/variation-protocol.md
@@ -32,20 +32,22 @@ Le litmus LIGHT est le **cœur anti-gaming** : guards, resyncs, ledger-entries, 
 
 ### GENRE — énumération CLOSE
 
-`lean` · `qc` · `training` · `genai` · `notebook-python` · `notebook-dotnet` · `docs` · `guard` · `refactor` · `ledger` · `readme` · `test` · `tooling` · `research-code`.
+`lean` · `qc` · `training` · `genai` · `notebook-python` · `notebook-dotnet` · `slides` · `docs` · `guard` · `refactor` · `ledger` · `readme` · `test` · `tooling` · `research-code`.
 
 **L'énumération se partitionne en deux, et la frontière porte G-VAR-1 :**
 
 | Classe | Genres | Ce qu'un grain y produit |
 |---|---|---|
-| **CONTENU** | `lean` · `qc` · `training` · `genai` · `notebook-python` · `notebook-dotnet` · `research-code` | une capacité, une preuve, un résultat, du matériel pédagogique — ce que le dépôt existe pour offrir |
+| **CONTENU** | `lean` · `qc` · `training` · `genai` · `notebook-python` · `notebook-dotnet` · `slides` · `research-code` | une capacité, une preuve, un résultat, du matériel pédagogique — ce que le dépôt existe pour offrir |
 | **META** | `guard` · `tooling` · `ledger` · `docs` · `readme` · `test` · `refactor` | l'outillage, les garde-fous et la prose *autour* du contenu — nécessaire, jamais suffisant |
 
 Un genre META n'est pas inférieur — un guard qui rougit au bon moment vaut mieux qu'un notebook de plus — mais une flotte qui ne produit que du META construit un atelier sans rien y fabriquer.
 
+**`slides` reste CONTENU quand le grain écrit ou enrichit le contenu du deck** (12 slides de cours neuves = CONTENU, pas `docs`) ; un grain slides qui fait autre chose garde son genre de type de travail — `guard` pour un gate CI de build Slidev, `refactor` pour un script, `tooling` pour un convertisseur.
+
 Un genre hors liste est un **alias** que le merge-gate normalise : pas une violation, le worker n'est ni repris ni HOLD. La fermeture protège G-VAR-3, qu'un vocabulaire ouvert rendrait inatteignable par simple choix de mot.
 
-**Le GENRE est le TYPE DE TRAVAIL, jamais la famille où vivent les fichiers.** Test : *si le prochain grain de ce rollout tombait dans une autre famille, changerais-je le GENRE ?* Si oui, le genre décrit le répertoire — reprendre celui du travail. Le composé `<famille>-<genre>` (`lean-ci`, `cjk-ci`, `audit-tooling`) **se réduit toujours à sa tête** ; les synonymes (`test-coverage` → `test`, `documentation` → `docs`, `data` → `ledger`) se normalisent. Table d'alias complète : [détail §Alias](../../docs/reference/variation-protocol-detail.md).
+**Le GENRE est le TYPE DE TRAVAIL, jamais la famille où vivent les fichiers.** Test : *si le prochain grain de ce rollout tombait dans une autre famille, changerais-je le GENRE ?* Si oui, le genre décrit le répertoire — reprendre celui du travail. Le composé `<famille>-<genre>` (`lean-ci`, `cjk-ci`, `audit-tooling`) **se réduit toujours à sa tête** ; les synonymes (`test-coverage` → `test`, `documentation` → `docs`, `data` → `ledger`, `slidev` → `slides`) se normalisent. Table d'alias complète : [détail §Alias](../../docs/reference/variation-protocol-detail.md).
 
 **`guard` vs `tooling` — le discriminant est « est-ce que ça peut rougir ».** Un check susceptible de passer au rouge est `guard` ; un script/helper/convertisseur sans statut d'échec propre est `tooling`.
 

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -149,7 +149,7 @@ jobs:
               note_defect variation-tag-malformed
             fi
             if [ "$GENRE_VALID" != "True" ]; then
-              echo "::warning::GENRE '${GENRE:-vide}' hors enumeration §1 (lean, qc, training, genai, notebook-python, notebook-dotnet, docs, guard, refactor, ledger, readme, test, tooling, research-code). G-VAR-3 compare des genres consecutifs : un genre inedit rend l'adjacence invisible. Mappe-le sur le genre qui decrit le TYPE DE TRAVAIL, pas le repertoire traverse."
+              echo "::warning::GENRE '${GENRE:-vide}' hors enumeration §1 (lean, qc, training, genai, notebook-python, notebook-dotnet, slides, docs, guard, refactor, ledger, readme, test, tooling, research-code). G-VAR-3 compare des genres consecutifs : un genre inedit rend l'adjacence invisible. Mappe-le sur le genre qui decrit le TYPE DE TRAVAIL, pas le repertoire traverse."
               note_defect variation-tag-genre-offlist
             fi
             if [ -z "$LANE" ] || [ "$LANE" = "None" ]; then
@@ -470,7 +470,7 @@ jobs:
           Grain: <DEEP|MED|LIGHT>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<GENRE> #<PR>
           \`\`\`
 
-          Le \`<genre>\` doit figurer dans l'enumeration §1 de \`variation-protocol.md\` (lean, qc, training, genai, notebook-python, notebook-dotnet, docs, guard, refactor, ledger, readme, test, tooling, research-code). Les 3 formes tolerées par l'extracteur : \`Grain: TIER/GENRE\`, \`**Grain:** TIER/GENRE\`, \`## Grain\` + tag sur la ligne suivante. La lane doit suivre le format \`<machine>:<workspace>\` (cf. \`lane-claim-protocol.md\`).
+          Le \`<genre>\` doit figurer dans l'enumeration §1 de \`variation-protocol.md\` (lean, qc, training, genai, notebook-python, notebook-dotnet, slides, docs, guard, refactor, ledger, readme, test, tooling, research-code). Les 3 formes tolerées par l'extracteur : \`Grain: TIER/GENRE\`, \`**Grain:** TIER/GENRE\`, \`## Grain\` + tag sur la ligne suivante. La lane doit suivre le format \`<machine>:<workspace>\` (cf. \`lane-claim-protocol.md\`).
           EOF
           )" 2>/dev/null || true
 

--- a/docs/reference/variation-protocol-detail.md
+++ b/docs/reference/variation-protocol-detail.md
@@ -134,6 +134,7 @@ Le GENRE est le **type de travail**, jamais la famille où vivent les fichiers. 
 | `refs`, `documentation` | `docs` | synonyme |
 | `data` | `ledger` | tranché par l'incident #8056 |
 | `content` | `docs` ou `notebook-python` selon le travail réel | genre **hors énumération** — six grains consécutifs de `po-2023:CoursIA` l'ont porté (#10745, #10742, #10733, #10727, #10712, #10711), rendant l'adjacence G-VAR-3 inatteignable : un genre hors liste ne collisionne avec rien |
+| `slidev` | `slides` | outil → type de travail — `slides` est CONTENU quand le grain écrit/enrichit le contenu du deck, sinon le grain garde son genre de type de travail (`guard`/`refactor`/`tooling`) |
 | `Lean` | `lean` | genres en minuscules |
 
 **Entrer dans la liste LIGHT de G-VAR-3 se mesure, jamais s'intuitionne** : un genre y entre dès **≥ 2 grains LIGHT mergés**. Au 2026-07-30, `tooling` était à 5 MED sur 5 et `research-code` à 1 DEEP sur 1 — aucun ne qualifiait.

--- a/scripts/ci/variation_prev_guard.py
+++ b/scripts/ci/variation_prev_guard.py
@@ -15,7 +15,7 @@ notification to its author. A closed PR reads exactly like an abandoned one.
 
 The `prev:` field (variation-protocol.md §1) is mandatory for tracing genre
 adjacency. Its genre slot reuses the same enumeration as the leading tag. The
-14 canonical genres contain NO GitHub closing keyword, so a `prev:` whose genre
+15 canonical genres contain NO GitHub closing keyword, so a `prev:` whose genre
 is `fix`/`close`/`resolve` (or inflections) is ALWAYS a misuse -- the worker
 meant `refactor`, `guard`, or `tooling`. The danger is that the `genre #N`
 tail is a valid auto-close instruction when the text lands in a commit

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -202,7 +202,7 @@ def find_prev_close_keywords(text: str | None) -> list[dict]:
     parses as a close instruction when the text lands in a commit message --
     the silent-PR-closure failure mode of #10093.
 
-    The 14 canonical genres (variation-protocol.md §1) contain NO closing
+    The 15 canonical genres (variation-protocol.md §1) contain NO closing
     keyword, so a closing-keyword genre in `prev:` is ALWAYS a misuse: the
     worker meant `refactor`, `guard`, `tooling`, etc. -- never `fix`. This
     function does NOT flag a standalone ``Fixes #123`` (an intended close):
@@ -561,8 +561,8 @@ def parse_short_header(body: str | None) -> dict:
 TIERS = ("DEEP", "MED", "LIGHT")
 GENRES = (
     "lean", "qc", "training", "genai", "notebook-python", "notebook-dotnet",
-    "docs", "guard", "refactor", "ledger", "readme", "test", "tooling",
-    "research-code",
+    "slides", "docs", "guard", "refactor", "ledger", "readme", "test",
+    "tooling", "research-code",
 )
 
 

--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -58,7 +58,7 @@ REPO = "jsboige/CoursIA"
 # Enumeration CLOSE de variation-protocol.md, partitionnee CONTENU / META.
 CONTENU = {
     "lean", "qc", "training", "genai",
-    "notebook-python", "notebook-dotnet", "research-code",
+    "notebook-python", "notebook-dotnet", "slides", "research-code",
 }
 META = {"guard", "tooling", "ledger", "docs", "readme", "test", "refactor"}
 
@@ -71,6 +71,7 @@ GENRE_RULES: list[tuple[str, str]] = [
     (r"training|post[- ]?training|\bppo\b|fine[- ]?tun|checkpoint|walk[- ]?forward", "training"),
     (r"genai|comfyui|diffusion|audiobook|\btts\b|whisper|acestep|voice|image gener", "genai"),
     (r"\.ipynb|notebook", "notebook-python"),
+    (r"slidev|\bslides?\b|deck\b", "slides"),
     (r"c#|csharp|\.net|dotnet|roslyn|aspire|nuget|semantickernel", "notebook-dotnet"),
     (r"z3|solveur|solver|automat|opensp|tweety|pymc|infer\.net|prover", "research-code"),
     (r"workflow|\bci\b|gate\b|guard|gitleaks|check-|advisory", "guard"),

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -415,7 +415,7 @@ def test_short_header_section_form_first_paragraph_no_value():
 # find_prev_close_keywords() scans any text (body OR commit message) for a
 # `prev: <TIER>/<genre>` whose genre is a GitHub closing keyword. The #10093
 # incident: a commit `prev: MED/fix #10067` made GitHub auto-close #10067 at
-# squash-merge. The 14 canonical genres contain no closing keyword, so a
+# squash-merge. The 15 canonical genres contain no closing keyword, so a
 # closing-keyword genre in prev: is ALWAYS a misuse.
 
 def test_prev_close_keyword_fix_detected():
@@ -437,10 +437,10 @@ def test_prev_close_keyword_all_inflections():
 
 
 def test_prev_canonical_genres_pass():
-    # The 14 canonical genres contain NO closing keyword -> all pass.
+    # The 15 canonical genres contain NO closing keyword -> all pass.
     for genre in ("lean", "qc", "training", "genai", "notebook-python",
-                  "notebook-dotnet", "docs", "guard", "refactor", "ledger",
-                  "readme", "test", "tooling", "research-code"):
+                  "notebook-dotnet", "slides", "docs", "guard", "refactor",
+                  "ledger", "readme", "test", "tooling", "research-code"):
         hits = gt.find_prev_close_keywords(f"prev: MED/{genre} #100")
         assert hits == [], f"canonical genre {genre} must NOT be flagged"
 

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -533,6 +533,7 @@ def test_canonicalize_genre_aliases():
     assert vlc.canonicalize_genre("audit-tooling") == "tooling"
     assert vlc.canonicalize_genre("test-coverage") == "test"
     assert vlc.canonicalize_genre("data") == "ledger"
+    assert vlc.canonicalize_genre("slidev") == "slides"
     # No alias -> identity.
     assert vlc.canonicalize_genre("readme") == "readme"
     assert vlc.canonicalize_genre("DOCS") == "DOCS".lower()  # case-insensitive

--- a/scripts/tests/test_variation_prev_guard.py
+++ b/scripts/tests/test_variation_prev_guard.py
@@ -80,7 +80,7 @@ def test_all_canonical_genres_in_prev_pass():
     # Every canonical genre in a prev: field passes (no closing keyword).
     for genre in ("lean", "guard", "refactor", "tooling", "docs", "test",
                   "readme", "ledger", "qc", "training", "genai",
-                  "notebook-python", "notebook-dotnet", "research-code"):
+                  "notebook-python", "notebook-dotnet", "slides", "research-code"):
         v = vpg.check(f"prev: MED/{genre} #100")
         assert v["guard_pass"] is True, f"canonical genre {genre} must pass"
 

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -411,6 +411,7 @@ _GENRE_ALIASES = {
     "audit-tooling": "tooling",
     "test-coverage": "test",
     "data": "ledger",
+    "slidev": "slides",              # outil -> type de travail (cf #11059)
 }
 
 # Compoments `<famille>-<genre>` always reduce to the head genre (the family


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: LIGHT/guard #11090

## Summary

Correctif #11059 : l'énumération CLOSE de variation-protocol n'avait **aucun genre de classe CONTENU pour l'écriture de slides** — une lane qui écrit des slides de cours produit « zéro contenu » selon la comptabilité du protocole (G-VAR-1 non tenu), et tombe sur le mauvais genre `docs` (#10769 : 12 slides de cours comptées META) ou sur un alias famille-comme-genre (#8811, #11047).

Ajout du genre **`slides`** à l'énumération close et à la partition **CONTENU**, avec la discipline du body : `slides` reste CONTENU quand le grain écrit/enrichit le contenu du deck ; un grain slides qui fait autre chose garde son genre de type de travail (`guard` pour un gate CI, `refactor` pour un script, `tooling` pour un convertisseur).

## Diff (10 fichiers, +21/−15)

| Surface | Changement |
|---|---|
| [`.claude/rules/variation-protocol.md`](.claude/rules/variation-protocol.md) | `slides` ajouté à l'énumération §1 + ligne CONTENU du tableau + note de discipline + alias `slidev` dans les synonymes |
| [`.github/workflows/variation-tag-guard.yml`](.github/workflows/variation-tag-guard.yml) | 2 messages d'avertissement hors-énumération alignés (15 genres) |
| [`.docs/reference/variation-protocol-detail.md`](docs/reference/variation-protocol-detail.md) | ligne `slidev` → `slides` dans la table d'alias §10 |
| [`scripts/grain_tag.py`](scripts/grain_tag.py) | `slides` dans `GENRES` (extracteur #9485) |
| [`scripts/variation_light_cap.py`](scripts/variation_light_cap.py) | `slidev` → `slides` dans `_GENRE_ALIASES` (merge-gate) |
| [`scripts/pick_idle_grain.py`](scripts/pick_idle_grain.py) | `slides` dans `CONTENU` + règle d'inférence `slidev\|slides\|deck` |
| Tests ×3 | `test_prev_canonical_genres_pass` (15 genres), `test_all_canonical_genres_in_prev_pass`, `test_canonicalize_genre_aliases` (+slidev) |

## Validation

- **166 passed** (`pytest scripts/tests/test_grain_tag.py test_variation_prev_guard.py test_variation_light_cap.py test_variation_genre_recensement.py test_variation_tag_required.py`)
- Syntax OK sur les 3 scripts modifiés
- Aucune autre surface listant l'énumération (grep `research-code`/`notebook-dotnet` sur .py/.yml/.md)
- Catalogue byte-identique (aucun notebook touché)

See #11059
