### PR TITLE
fix(sudoku): correct Sudoku-16 footer description of Sudoku-17 (DEFECT-ALIVE #1671)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb
@@ -3545,7 +3545,7 @@
     "\n",
     "**Voir aussi** : \n",
     "- [GenAI](../GenAI/README.md) - Série sur l'IA générative et les réseaux de neurones\n",
-    "- [Sudoku-17-LLM-Python](Sudoku-17-LLM-Python.ipynb) - Benchmark comparatif de tous les solveurs\n",
+    "- [Sudoku-17-LLM-Python](Sudoku-17-LLM-Python.ipynb) - Résolution par grands modèles de langage\n",
     "\n",
     "### Notebooks associés\n",
     "- [Sudoku-1-Backtracking](Sudoku-1-Backtracking-Python.ipynb) : solveur algorithmique de référence\n",


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: MED/guard #11084

## Summary
- The Sudoku-16 "Voir aussi" footer still described `Sudoku-17-LLM-Python` as « Benchmark comparatif de tous les solveurs » — that is **Sudoku-18's** description. Per [README.md l.87-88](../blob/main/MyIA.AI.Notebooks/Sudoku/README.md): Sudoku-17 = « Grands modèles de langage », Sudoku-18 = « Benchmark comparatif final ».
- Root cause: the renumbering PR #1671 updated the link target (Sudoku-11 → Sudoku-17) but not the description. NanoClaw flagged it before merge; merged unaddressed — DEFECT-ALIVE measured on `origin/main` during nits triage (#11044, window 05-22..05-28).

## Changes
- 1 markdown line in `Sudoku-16-NeuralNetwork-Python.ipynb` footer cell. Markdown-only → C.2 exception (no re-exec; JSON validity re-checked, 55 cells intact).

See #11044 (DEFECT-ALIVE #1671).

## Validation
- `python -c json.load` PASS (valid JSON, cell count unchanged).
- Diff = 1 line (surgical raw-text replacement, no notebook re-serialization churn).
