### PR TITLE
fix(audio): import FISHAUDIO_URL from fishaudio_client instead of redefining it (DEFECT-ALIVE #1674)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/retry_failed_clones.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/retry_failed_clones.py
@@ -15,9 +15,10 @@ from pathlib import Path
 import requests
 from dotenv import load_dotenv
 
+from fishaudio_client import FISHAUDIO_URL
+
 load_dotenv(Path(__file__).resolve().parent.parent.parent.parent / ".env")
 
-FISHAUDIO_URL = "http://localhost:8197"
 MANIFEST = Path(__file__).resolve().parent / "outputs" / "fishaudio_references" / "manifest.json"
 
 


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: MED/guard #11084

## Summary
- `retry_failed_clones.py` redefined `FISHAUDIO_URL = "http://localhost:8197"` hardcoded instead of importing from `fishaudio_client` (which reads `os.getenv("FISHAUDIO_URL", ...)`). Hermes flagged this as NON-BLOQUANT on #1674 (« If the URL changes, this script will silently use the wrong value »); merged unaddressed — DEFECT-ALIVE measured on `origin/main` during nits triage (#11044, window 05-22..05-28).
- Fix: `from fishaudio_client import FISHAUDIO_URL`, constant definition removed (+2/−1).

## Validation
- `ast.parse` PASS.
- `python retry_failed_clones.py --dry-run` executes past the import chain to the manifest check (no manifest in CI checkout — expected FATAL); proves the import resolves.

See #11044 (DEFECT-ALIVE #1674).
