### PR TITLE
feat(symbolic-learning,#10382): SL-5 pont SWI-Prolog Process.Start — RECOVERABLE-LOCAL -> SOTA-OK (parity native-both)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
@@ -5,10 +5,10 @@
    "id": "f009a5b2",
    "metadata": {
     "papermill": {
-     "duration": 0.039648,
-     "end_time": "2026-07-06T07:57:12.278323+00:00",
+     "duration": 0.00564,
+     "end_time": "2026-08-15T19:21:44.239848+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:12.238675+00:00",
+     "start_time": "2026-08-15T19:21:44.234208+00:00",
      "status": "completed"
     },
     "tags": []
@@ -18,7 +18,7 @@
     "\n",
     "> **Jumeau C#** du notebook [SL-5-InverseResolution.ipynb](SL-5-InverseResolution.ipynb).\n",
     "> Marathon parite .NET ⇄ Python (#4956), EPIC #3801 Prong B.\n",
-    "> Algorithmes AIMA §19.5 (Inverse Resolution + Bottom-Clause ILP), implémentés **from-scratch en C# pur** (pas de lib ML, pas de Prolog externe).\n",
+    "> Algorithmes AIMA §19.5 (Inverse Resolution + Bottom-Clause ILP), implémentés **from-scratch en C# pur** (pas de lib ML), PLUS un **pont SOTA (§7)** vers **SWI-Prolog** — le moteur que le jumeau Python invoque via `janus_swi` pour Aleph.\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -47,10 +47,10 @@
    "id": "88ed0203",
    "metadata": {
     "papermill": {
-     "duration": 0.004937,
-     "end_time": "2026-07-06T07:57:12.296811+00:00",
+     "duration": 0.00439,
+     "end_time": "2026-08-15T19:21:44.249543+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:12.291874+00:00",
+     "start_time": "2026-08-15T19:21:44.245153+00:00",
      "status": "completed"
     },
     "tags": []
@@ -69,85 +69,227 @@
    "id": "08fc4cd5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:57:12.329988Z",
-     "iopub.status.busy": "2026-07-06T07:57:12.317738Z",
-     "iopub.status.idle": "2026-07-06T07:57:20.849440Z",
-     "shell.execute_reply": "2026-07-06T07:57:20.820332Z"
+     "iopub.execute_input": "2026-08-15T19:21:44.269562Z",
+     "iopub.status.busy": "2026-08-15T19:21:44.260628Z",
+     "iopub.status.idle": "2026-08-15T19:21:46.807723Z",
+     "shell.execute_reply": "2026-08-15T19:21:46.802266Z"
     },
     "papermill": {
-     "duration": 8.547132,
-     "end_time": "2026-07-06T07:57:20.849770+00:00",
+     "duration": 2.557082,
+     "end_time": "2026-08-15T19:21:46.810278+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:12.302638+00:00",
+     "start_time": "2026-08-15T19:21:44.253196+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Cible : grandfather(X, Y) :- male(X), parent(X, Z), parent(Z, Y).\n\r\n"
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '152144.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "                 exemple | attendu | couvert\r\n"
+     "output_type": "stream",
+     "text": [
+      "Cible : grandfather(X, Y) :- male(X), parent(X, Z), parent(Z, Y).\n",
+      "\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "------------------------------------------------\r\n"
+     "output_type": "stream",
+     "text": [
+      "                 exemple | attendu | couvert\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(tom, ann) |    +    |   oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "------------------------------------------------\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(tom, pat) |    +    |   oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(tom, ann) |    +    |   oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(tom, sue) |    +    |   oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(tom, pat) |    +    |   oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(bob, jim) |    +    |   oui\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(tom, sue) |    +    |   oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(liz, eve) |    -    |   non\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(bob, jim) |    +    |   oui\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(liz, sue) |    -    |   non\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(liz, eve) |    -    |   non\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(bob, ann) |    -    |   non\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(liz, sue) |    -    |   non\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(pat, jim) |    -    |   non\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(bob, ann) |    -    |   non\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(tom, bob) |    -    |   non\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(pat, jim) |    -    |   non\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   grandfather(ann, jim) |    -    |   non\r\n"
+     "output_type": "stream",
+     "text": [
+      "   grandfather(tom, bob) |    -    |   non\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   grandfather(ann, jim) |    -    |   non\r\n"
+     ]
     }
    ],
    "source": [
@@ -242,10 +384,10 @@
    "id": "88775903",
    "metadata": {
     "papermill": {
-     "duration": 0.016584,
-     "end_time": "2026-07-06T07:57:20.873228+00:00",
+     "duration": 0.003115,
+     "end_time": "2026-08-15T19:21:46.816965+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:20.856644+00:00",
+     "start_time": "2026-08-15T19:21:46.813850+00:00",
      "status": "completed"
     },
     "tags": []
@@ -264,40 +406,49 @@
    "id": "18d4f2b1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:57:20.888703Z",
-     "iopub.status.busy": "2026-07-06T07:57:20.888091Z",
-     "iopub.status.idle": "2026-07-06T07:57:21.355208Z",
-     "shell.execute_reply": "2026-07-06T07:57:21.354776Z"
+     "iopub.execute_input": "2026-08-15T19:21:46.824555Z",
+     "iopub.status.busy": "2026-08-15T19:21:46.824349Z",
+     "iopub.status.idle": "2026-08-15T19:21:46.965407Z",
+     "shell.execute_reply": "2026-08-15T19:21:46.965215Z"
     },
     "papermill": {
-     "duration": 0.475318,
-     "end_time": "2026-07-06T07:57:21.355389+00:00",
+     "duration": 0.14534,
+     "end_time": "2026-08-15T19:21:46.965515+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:20.880071+00:00",
+     "start_time": "2026-08-15T19:21:46.820175+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "LGG des deux explications :\r\n"
+     "output_type": "stream",
+     "text": [
+      "LGG des deux explications :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  grandfather(V1, V2) :- male(V1), parent(V1, V3), parent(V4, V5), parent(bob, V6), parent(V3, V2).\r\n"
+     "output_type": "stream",
+     "text": [
+      "  grandfather(V1, V2) :- male(V1), parent(V1, V3), parent(V4, V5), parent(bob, V6), parent(V3, V2).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nTaille des corps : 3 et 3 litteraux -> LGG : 5 litteraux\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Taille des corps : 3 et 3 litteraux -> LGG : 5 litteraux\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Couverture : 4/4 positifs, 0/6 negatifs\r\n"
+     "output_type": "stream",
+     "text": [
+      "Couverture : 4/4 positifs, 0/6 negatifs\r\n"
+     ]
     }
    ],
    "source": [
@@ -351,10 +502,10 @@
    "id": "bbf1b5f0",
    "metadata": {
     "papermill": {
-     "duration": 0.006201,
-     "end_time": "2026-07-06T07:57:21.368175+00:00",
+     "duration": 0.003252,
+     "end_time": "2026-08-15T19:21:46.972367+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:21.361974+00:00",
+     "start_time": "2026-08-15T19:21:46.969115+00:00",
      "status": "completed"
     },
     "tags": []
@@ -373,55 +524,69 @@
    "id": "6e824d31",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:57:21.382867Z",
-     "iopub.status.busy": "2026-07-06T07:57:21.382409Z",
-     "iopub.status.idle": "2026-07-06T07:57:21.736615Z",
-     "shell.execute_reply": "2026-07-06T07:57:21.736190Z"
+     "iopub.execute_input": "2026-08-15T19:21:46.979977Z",
+     "iopub.status.busy": "2026-08-15T19:21:46.979769Z",
+     "iopub.status.idle": "2026-08-15T19:21:47.103949Z",
+     "shell.execute_reply": "2026-08-15T19:21:47.103812Z"
     },
     "papermill": {
-     "duration": 0.362725,
-     "end_time": "2026-07-06T07:57:21.736795+00:00",
+     "duration": 0.12849,
+     "end_time": "2026-08-15T19:21:47.104020+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:21.374070+00:00",
+     "start_time": "2026-08-15T19:21:46.975530+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Ordre de generalite top >= cible >= exemple au sol :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Ordre de generalite top >= cible >= exemple au sol :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "              top subsume cible           ? True\r\n"
+     "output_type": "stream",
+     "text": [
+      "              top subsume cible           ? True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "              top subsume exemple au sol  ? True\r\n"
+     "output_type": "stream",
+     "text": [
+      "              top subsume exemple au sol  ? True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "            cible subsume top             ? False\r\n"
+     "output_type": "stream",
+     "text": [
+      "            cible subsume top             ? False\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "            cible subsume exemple au sol  ? True\r\n"
+     "output_type": "stream",
+     "text": [
+      "            cible subsume exemple au sol  ? True\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   exemple au sol subsume top             ? False\r\n"
+     "output_type": "stream",
+     "text": [
+      "   exemple au sol subsume top             ? False\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "   exemple au sol subsume cible           ? False\r\n"
+     "output_type": "stream",
+     "text": [
+      "   exemple au sol subsume cible           ? False\r\n"
+     ]
     }
    ],
    "source": [
@@ -463,10 +628,10 @@
    "id": "dcc44a2d",
    "metadata": {
     "papermill": {
-     "duration": 0.007826,
-     "end_time": "2026-07-06T07:57:21.777340+00:00",
+     "duration": 0.002883,
+     "end_time": "2026-08-15T19:21:47.110092+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:21.769514+00:00",
+     "start_time": "2026-08-15T19:21:47.107209+00:00",
      "status": "completed"
     },
     "tags": []
@@ -485,45 +650,58 @@
    "id": "e485ab3b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:57:21.797655Z",
-     "iopub.status.busy": "2026-07-06T07:57:21.797170Z",
-     "iopub.status.idle": "2026-07-06T07:57:22.105567Z",
-     "shell.execute_reply": "2026-07-06T07:57:22.105129Z"
+     "iopub.execute_input": "2026-08-15T19:21:47.117498Z",
+     "iopub.status.busy": "2026-08-15T19:21:47.117318Z",
+     "iopub.status.idle": "2026-08-15T19:21:47.218843Z",
+     "shell.execute_reply": "2026-08-15T19:21:47.218690Z"
     },
     "papermill": {
-     "duration": 0.320836,
-     "end_time": "2026-07-06T07:57:22.105750+00:00",
+     "duration": 0.105565,
+     "end_time": "2026-08-15T19:21:47.218916+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:21.784914+00:00",
+     "start_time": "2026-08-15T19:21:47.113351+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exemple sature : grandfather(tom, ann)\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exemple sature : grandfather(tom, ann)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nClause bottom (profondeur 2, 9 litteraux) :\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Clause bottom (profondeur 2, 9 litteraux) :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  grandfather(V1, V2) :- parent(V1, V3), parent(V1, V4), parent(V3, V2), male(V1), female(V2), parent(V3, V5), parent(V4, V6), male(V3), female(V4).\r\n"
+     "output_type": "stream",
+     "text": [
+      "  grandfather(V1, V2) :- parent(V1, V3), parent(V1, V4), parent(V3, V2), male(V1), female(V2), parent(V3, V5), parent(V4, V6), male(V3), female(V4).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nVariabilisation : tom -> V1, ann -> V2, bob -> V3, liz -> V4, pat -> V5, sue -> V6\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Variabilisation : tom -> V1, ann -> V2, bob -> V3, liz -> V4, pat -> V5, sue -> V6\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nLa cible subsume-t-elle la clause bottom ? True\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "La cible subsume-t-elle la clause bottom ? True\r\n"
+     ]
     }
    ],
    "source": [
@@ -565,10 +743,10 @@
    "id": "3a3eefda",
    "metadata": {
     "papermill": {
-     "duration": 0.007448,
-     "end_time": "2026-07-06T07:57:22.120979+00:00",
+     "duration": 0.003043,
+     "end_time": "2026-08-15T19:21:47.225403+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:22.113531+00:00",
+     "start_time": "2026-08-15T19:21:47.222360+00:00",
      "status": "completed"
     },
     "tags": []
@@ -588,50 +766,68 @@
    "id": "277ec634",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:57:22.142076Z",
-     "iopub.status.busy": "2026-07-06T07:57:22.141592Z",
-     "iopub.status.idle": "2026-07-06T07:57:22.861883Z",
-     "shell.execute_reply": "2026-07-06T07:57:22.861569Z"
+     "iopub.execute_input": "2026-08-15T19:21:47.232847Z",
+     "iopub.status.busy": "2026-08-15T19:21:47.232662Z",
+     "iopub.status.idle": "2026-08-15T19:21:47.489758Z",
+     "shell.execute_reply": "2026-08-15T19:21:47.489882Z"
     },
     "papermill": {
-     "duration": 0.732278,
-     "end_time": "2026-07-06T07:57:22.862025+00:00",
+     "duration": 0.26136,
+     "end_time": "2026-08-15T19:21:47.489983+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:22.129747+00:00",
+     "start_time": "2026-08-15T19:21:47.228623+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Apprentissage de grandfather/2 :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Apprentissage de grandfather/2 :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  bottom = 9 litteraux -> grandfather(V1, V2) :- parent(V1, V3), parent(V3, V2), male(V1).  (p=4, score=1)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  bottom = 9 litteraux -> grandfather(V1, V2) :- parent(V1, V3), parent(V3, V2), male(V1).  (p=4, score=1)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nTheorie finale :\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Theorie finale :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  grandfather(V1, V2) :- parent(V1, V3), parent(V3, V2), male(V1).\r\n"
+     "output_type": "stream",
+     "text": [
+      "  grandfather(V1, V2) :- parent(V1, V3), parent(V3, V2), male(V1).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nVerification : 4/4 positifs couverts, 0/6 negatifs couverts\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Verification : 4/4 positifs couverts, 0/6 negatifs couverts\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stderr",
-     "text": "\r\n(36,13): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n\r\n(39,17): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n\r\n"
+     "output_type": "stream",
+     "text": [
+      "\r\n",
+      "(36,13): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n",
+      "(39,17): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
+      "\r\n"
+     ]
     }
    ],
    "source": [
@@ -715,10 +911,10 @@
    "id": "2813e827",
    "metadata": {
     "papermill": {
-     "duration": 0.009025,
-     "end_time": "2026-07-06T07:57:22.879774+00:00",
+     "duration": 0.003655,
+     "end_time": "2026-08-15T19:21:47.497618+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:22.870749+00:00",
+     "start_time": "2026-08-15T19:21:47.493963+00:00",
      "status": "completed"
     },
     "tags": []
@@ -738,50 +934,64 @@
    "id": "1bf1eb1b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:57:22.899411Z",
-     "iopub.status.busy": "2026-07-06T07:57:22.898976Z",
-     "iopub.status.idle": "2026-07-06T07:57:23.271087Z",
-     "shell.execute_reply": "2026-07-06T07:57:23.270509Z"
+     "iopub.execute_input": "2026-08-15T19:21:47.506552Z",
+     "iopub.status.busy": "2026-08-15T19:21:47.506350Z",
+     "iopub.status.idle": "2026-08-15T19:21:47.644859Z",
+     "shell.execute_reply": "2026-08-15T19:21:47.644660Z"
     },
     "papermill": {
-     "duration": 0.382843,
-     "end_time": "2026-07-06T07:57:23.271249+00:00",
+     "duration": 0.143305,
+     "end_time": "2026-08-15T19:21:47.644936+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:22.888406+00:00",
+     "start_time": "2026-08-15T19:21:47.501631+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Apprentissage de grandmother/2 :\r\n"
+     "output_type": "stream",
+     "text": [
+      "Apprentissage de grandmother/2 :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  bottom = 8 litteraux -> grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).  (p=1, score=-2)\r\n"
+     "output_type": "stream",
+     "text": [
+      "  bottom = 8 litteraux -> grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).  (p=1, score=-2)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nTheorie finale :\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Theorie finale :\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "  grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).\r\n"
+     "output_type": "stream",
+     "text": [
+      "  grandmother(V1, V2) :- parent(V1, V4), parent(V4, V2), female(V1).\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "\nVerification : 1/1 positif(s) couvert(s), 0/10 negatif(s) couvert(s)\r\n"
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Verification : 1/1 positif(s) couvert(s), 0/10 negatif(s) couvert(s)\r\n"
+     ]
     },
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Equivalente a grandmother(X,Y) :- female(X), parent(X,Z), parent(Z,Y) ? True\r\n"
+     "output_type": "stream",
+     "text": [
+      "Equivalente a grandmother(X,Y) :- female(X), parent(X,Z), parent(Z,Y) ? True\r\n"
+     ]
     }
    ],
    "source": [
@@ -813,36 +1023,374 @@
    "id": "695bf88e",
    "metadata": {
     "papermill": {
-     "duration": 0.0072,
-     "end_time": "2026-07-06T07:57:23.287835+00:00",
+     "duration": 0.003894,
+     "end_time": "2026-08-15T19:21:47.653094+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:23.280635+00:00",
+     "start_time": "2026-08-15T19:21:47.649200+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Au-delà : moteurs ILP réels (Aleph, Metagol, Popper)\n",
+    "## 7. Pont vers le solveur SOTA : SWI-Prolog (Process.Start)\n",
     "\n",
     "Le notebook Python [SL-5-InverseResolution.ipynb](SL-5-InverseResolution.ipynb)\n",
-    "montre ensuite comment invoquer de **vrais moteurs ILP** (Aleph sur SWI-Prolog via\n",
-    "le pont `janus_swi`, Metagol, Popper) sur le même problème. Ces moteurs implémentent\n",
-    "la recherche dans le treillis `[top, bottom]` avec des heuristiques avancées\n",
-    "(recherche `A*`, contraintes de mode, minimisation de clause).\n",
+    "invoque les **vrais moteurs ILP** via `janus_swi` : **Aleph** (Progol en chair et en\n",
+    "os), Metagol, Popper — tous des programmes SWI-Prolog. L'édition précédente de ce\n",
+    "jumeau déclarait le pont « hors scope C# pur (Prong B) » et la paire était labellisée\n",
+    "`RECOVERABLE-LOCAL` (#10382). Ce verdict est **révoqué** : le pendant C# honnête est\n",
+    "`Process.Start` sur le **même exécutable** (mandat #10382, bucket 2 : « le moteur est\n",
+    "un binaire, le pendant C# honnête est `Process.Start` sur le même exécutable — pas\n",
+    "une réimplémentation »).\n",
     "\n",
-    "> **Ce jumeau C# s'arrête à la théorie from-scratch** : nous avons réimplémenté\n",
-    "> LGG, θ-subsomption, clause bottom et la recherche Progol à la main pour comprendre\n",
-    "> les **internes**. Le pont vers un moteur Prolog externe est hors scope C# pur\n",
-    "> (Prong B : on enseigne l'algorithme, pas on invoque une boîte noire). Pour la\n",
-    "> comparaison avec les moteurs réels, voir le notebook Python.\n",
+    "La cellule suivante :\n",
     "\n",
-    "| Concept | Implémentation C# (ce notebook) | Moteur réel (Python) |\n",
-    "|---------|----------------------------------|----------------------|\n",
-    "| Représentation | `record Clause(Head, Body)` | Termes Prolog |\n",
-    "| LGG | `LggClause` (§2) | Aleph `ig2` |\n",
-    "| Clause bottom | `BottomClause` (§4) | Aleph `saturate` |\n",
-    "| Recherche | `ProgolSearch` (§5), score `p−L` | Aleph `induce`, A* |\n",
-    "| Mode declarations | non (biais `body_preds`) | `modeh`/`modeb` |\n"
+    "1. **rejoue le programme appris** par le Progol from-scratch de la cellule 6\n",
+    "   (`theoryGm`) — la clause `grandmother(V1,V2) :- parent(V1,V4), parent(V4,V2),\n",
+    "   female(V1)` — sous forme d'un fichier Prolog chargé par SWI-Prolog ;\n",
+    "2. **interroge** le moteur : `grandmother/2` est-il dérivé sur `liz → eve` (le\n",
+    "   positif) et **jamais** sur les 10 négatifs ?\n",
+    "3. **vérifie la parité** : la théorie from-scratch et le moteur SOTA s'accordent.\n",
+    "\n",
+    "| Axe (checklist #10459) | Réponse |\n",
+    "|---|---|\n",
+    "| 1 · NuGet .NET | N/A — pas de binding SWI-Prolog officiel pour .NET |\n",
+    "| 2 · P/Invoke | N/A — pas de DLL C stable documentée invocable |\n",
+    "| **3 · CLI `Process.Start`** | **LE CANAL** — `swipl.exe` est un binaire invocable |\n",
+    "| 4 · IKVM | N/A — SWI-Prolog n'est pas une lib Java |\n",
+    "| 5 · PythonNet | N/A — pas besoin de pont CPython, le binaire suffit |\n",
+    "| 6 · lib équivalente | SWI-Prolog = le moteur SOTA utilisé par Aleph/Metagol/Popper (`janus_swi`) |\n",
+    "\n",
+    "Verdict : **SOTA-OK (pont)** — le from-scratch est conservé (il enseigne les\n",
+    "**internes** de Progol), le pont est **en plus**, jamais à la place.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "8eb8fb42",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T19:21:47.664836Z",
+     "iopub.status.busy": "2026-08-15T19:21:47.664588Z",
+     "iopub.status.idle": "2026-08-15T19:21:48.076643Z",
+     "shell.execute_reply": "2026-08-15T19:21:48.076472Z"
+    },
+    "papermill": {
+     "duration": 0.41792,
+     "end_time": "2026-08-15T19:21:48.076729+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T19:21:47.658809+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "===== Pont SWI-Prolog (Process.Start) =====\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Programme Prolog (16 lignes) :\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  parent(tom,bob).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  parent(tom,liz).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  parent(bob,ann).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  parent(bob,pat).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  parent(liz,sue).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  parent(pat,jim).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  parent(sue,eve).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  male(tom).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  male(bob).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  male(jim).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  female(liz).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  female(ann).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  female(pat).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  female(sue).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  female(eve).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  grandmother(V1, V2) :- parent(V1, V4),parent(V4, V2),female(V1).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Solveur : swipl.exe\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grandmother/2 derivees par SWI-Prolog : 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  grandmother(liz, eve)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "POSITIVES couverts : 1/1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NEGATIVES atteints  : 0/10\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Verdict parite : theorie from-scratch == SWI-Prolog (SOTA) sur grandmother/2\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// === Pont SWI-Prolog (Process.Start) : le moteur SOTA derrière Aleph, invoqué depuis le C# ===\n",
+    "using System.IO;\n",
+    "using System.Diagnostics;\n",
+    "\n",
+    "// Resout l'executable swipl : variable SWIPL_DIR -> chemins standard -> throw.\n",
+    "string FindSwiplCmd()\n",
+    "{\n",
+    "    var envDir = Environment.GetEnvironmentVariable(\"SWIPL_DIR\");\n",
+    "    if (!string.IsNullOrEmpty(envDir))\n",
+    "    {\n",
+    "        var exe = Path.Combine(envDir, \"swipl.exe\");\n",
+    "        if (File.Exists(exe)) return exe;\n",
+    "    }\n",
+    "    // Pattern du jumeau Python (cellule 20, xplat #10646) : install portable SWI-Prolog.\n",
+    "    var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);\n",
+    "    var candidates = new[] {\n",
+    "        Path.Combine(userProfile, \"OneDrive\", \"Documents\", \"swipl\", \"bin\", \"swipl.exe\"),\n",
+    "        Path.Combine(userProfile, \"Documents\", \"swipl\", \"bin\", \"swipl.exe\"),\n",
+    "        Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), \"swipl\", \"bin\", \"swipl.exe\"),\n",
+    "        @\"C:\\Program Files\\swipl\\bin\\swipl.exe\",\n",
+    "        \"/usr/bin/swipl\",\n",
+    "        \"/usr/local/bin/swipl\",\n",
+    "    };\n",
+    "    foreach (var c in candidates)\n",
+    "        if (File.Exists(c)) return c;\n",
+    "    throw new FileNotFoundException(\n",
+    "        \"SWI-Prolog introuvable. Installer SWI-Prolog (https://www.swi-prolog.org) : \" +\n",
+    "        \"Windows choco install swi-prolog  |  macOS brew install swi-prolog  |  apt install swi-prolog\");\n",
+    "}\n",
+    "\n",
+    "// C# -> Prolog : les variables de theoryGm sont deja en MAJUSCULES (V1, V2...),\n",
+    "// les constantes et predicats en minuscules -- le format est directement valide.\n",
+    "string PrologFact((string,string[]) a) => $\"{a.Item1}({string.Join(\",\", a.Item2)}).\";\n",
+    "string PrologRule(Clause c) => c.Body.Count == 0\n",
+    "    ? $\"{Fmt(c.Head)}.\"\n",
+    "    : $\"{Fmt(c.Head)} :- {string.Join(\",\", c.Body.Select(Fmt))}.\";\n",
+    "\n",
+    "// 1. Programme Prolog : faits du domaine + theorie apprise par le Progol from-scratch (cellule 6)\n",
+    "string plPath = Path.Combine(Path.GetTempPath(), $\"sl5_grandmother_{Guid.NewGuid():N}.pl\");\n",
+    "var plLines = new List<string>();\n",
+    "foreach (var f in FACTS) plLines.Add(PrologFact(f));\n",
+    "foreach (var r in theoryGm) plLines.Add(PrologRule(r));\n",
+    "File.WriteAllText(plPath, string.Join(\"\\n\", plLines));\n",
+    "\n",
+    "// 2. Invocation SWI-Prolog : charger le programme, imprimer les derivations grandmother/2, quitter\n",
+    "string swipl = FindSwiplCmd();\n",
+    "var goal = \"findall((X,Y), grandmother(X,Y), L), \" +\n",
+    "           \"forall(member((X,Y), L), format('gm(~w,~w).~n', [X,Y])), halt.\";\n",
+    "var psi = new ProcessStartInfo(swipl)\n",
+    "{\n",
+    "    RedirectStandardOutput = true, RedirectStandardError = true,\n",
+    "    UseShellExecute = false, CreateNoWindow = true,\n",
+    "    WorkingDirectory = Path.GetDirectoryName(plPath) ?? Path.GetTempPath(),\n",
+    "};\n",
+    "psi.ArgumentList.Add(\"-q\");\n",
+    "psi.ArgumentList.Add(\"-f\");\n",
+    "psi.ArgumentList.Add(Path.GetFileName(plPath));\n",
+    "psi.ArgumentList.Add(\"-g\");\n",
+    "psi.ArgumentList.Add(goal);\n",
+    "var proc = Process.Start(psi);\n",
+    "string stdout = proc.StandardOutput.ReadToEnd();\n",
+    "string stderr = proc.StandardError.ReadToEnd();\n",
+    "proc.WaitForExit();\n",
+    "\n",
+    "// 3. Parse des atomes \"gm(X,Y).\" imprimes par Prolog\n",
+    "var derived = new HashSet<(string,string)>();\n",
+    "foreach (var line in stdout.Split('\\n'))\n",
+    "{\n",
+    "    string s = line.Trim();\n",
+    "    if (s.StartsWith(\"gm(\") && s.EndsWith(\").\"))\n",
+    "    {\n",
+    "        var inner = s.Substring(3, s.Length - 3 - 2);\n",
+    "        var parts = inner.Split(',');\n",
+    "        derived.Add((parts[0], parts[1]));\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// 4. Verdict de parite : la theorie from-scratch derive-t-elle exactement les positifs ?\n",
+    "Console.WriteLine(\"===== Pont SWI-Prolog (Process.Start) =====\");\n",
+    "Console.WriteLine($\"Programme Prolog ({plLines.Count} lignes) :\");\n",
+    "foreach (var l in plLines) Console.WriteLine($\"  {l}\");\n",
+    "Console.WriteLine($\"Solveur : {Path.GetFileName(swipl)}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"grandmother/2 derivees par SWI-Prolog : {derived.Count}\");\n",
+    "foreach (var (x, y) in derived.OrderBy(d => d.Item1).ThenBy(d => d.Item2))\n",
+    "    Console.WriteLine($\"  grandmother({x}, {y})\");\n",
+    "Console.WriteLine();\n",
+    "int posCovers = POS_GM.Count(e => derived.Contains((e.Item2[0], e.Item2[1])));\n",
+    "int negLeaks = NEG_GM.Count(e => derived.Contains((e.Item2[0], e.Item2[1])));\n",
+    "Console.WriteLine($\"POSITIVES couverts : {posCovers}/{POS_GM.Count}\");\n",
+    "Console.WriteLine($\"NEGATIVES atteints  : {negLeaks}/{NEG_GM.Count}\");\n",
+    "Console.WriteLine($\"Verdict parite : {(posCovers == POS_GM.Count && negLeaks == 0 ? \"theorie from-scratch == SWI-Prolog (SOTA) sur grandmother/2\" : \"ECART - investiguer\")}\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3c53cc4",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004057,
+     "end_time": "2026-08-15T19:21:48.085178+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T19:21:48.081121+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : théorie from-scratch ≡ SWI-Prolog (SOTA)\n",
+    "\n",
+    "SWI-Prolog dérive exactement **1** couple : `grandmother(liz, eve)` — le seul positif\n",
+    "`POS_GM`. Les 10 négatifs (`tom→ann`, `liz→sue`, `pat→jim`, …) ne sont **jamais**\n",
+    "dérivés. La règle apprise par le Progol from-scratch de la cellule 6 —\n",
+    "`grandmother(V1,V2) :- parent(V1,V4), parent(V4,V2), female(V1)` — coïncide donc\n",
+    "avec le moteur SOTA sur ce problème. C'est le **même moteur** (SWI-Prolog) que le\n",
+    "jumeau Python invoque via `janus_swi` pour Aleph : la parité est ici\n",
+    "**native-both** (les deux jumeaux référencent un moteur externe).\n",
+    "\n",
+    "> Le from-scratch garde sa valeur pédagogique : il montre *comment* Progol construit\n",
+    "> la clause bottom et explore le treillis `[top, bottom]`. Le pont vérifie que ce\n",
+    "> que la théorie apprend est bien ce que le moteur réel dérive.\n"
    ]
   },
   {
@@ -850,10 +1398,10 @@
    "id": "c5938dda",
    "metadata": {
     "papermill": {
-     "duration": 0.008923,
-     "end_time": "2026-07-06T07:57:23.304724+00:00",
+     "duration": 0.003873,
+     "end_time": "2026-08-15T19:21:48.093045+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:23.295801+00:00",
+     "start_time": "2026-08-15T19:21:48.089172+00:00",
      "status": "completed"
     },
     "tags": []
@@ -873,29 +1421,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "940fe07a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-06T07:57:23.327396Z",
-     "iopub.status.busy": "2026-07-06T07:57:23.326838Z",
-     "iopub.status.idle": "2026-07-06T07:57:23.547315Z",
-     "shell.execute_reply": "2026-07-06T07:57:23.546854Z"
+     "iopub.execute_input": "2026-08-15T19:21:48.102533Z",
+     "iopub.status.busy": "2026-08-15T19:21:48.102225Z",
+     "iopub.status.idle": "2026-08-15T19:21:48.170650Z",
+     "shell.execute_reply": "2026-08-15T19:21:48.170515Z"
     },
     "papermill": {
-     "duration": 0.232115,
-     "end_time": "2026-07-06T07:57:23.547492+00:00",
+     "duration": 0.073675,
+     "end_time": "2026-08-15T19:21:48.170738+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:23.315377+00:00",
+     "start_time": "2026-08-15T19:21:48.097063+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice uncle/2 a completer (voir indice ci-dessus).\r\n"
+     "output_type": "stream",
+     "text": [
+      "Exercice uncle/2 a completer (voir indice ci-dessus).\r\n"
+     ]
     }
    ],
    "source": [
@@ -913,6 +1463,33 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
+   "id": "cell-d79cad6e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T19:21:48.180829Z",
+     "iopub.status.busy": "2026-08-15T19:21:48.180583Z",
+     "iopub.status.idle": "2026-08-15T19:21:48.215923Z",
+     "shell.execute_reply": "2026-08-15T19:21:48.215768Z"
+    },
+    "papermill": {
+     "duration": 0.040845,
+     "end_time": "2026-08-15T19:21:48.215997+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T19:21:48.175152+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : profondeur de la clause bottom (depth 1 vs 3).\r\n"
+     ]
+    }
+   ],
    "source": [
     "// EXERCICE 2 : profondeur de la clause bottom (cf. cellule 16 : \"profondeur de la clause bottom\").\n",
     "// On teste BottomClause avec depth=1 vs depth=3 sur l'exemple grandmother de la cellule 12.\n",
@@ -932,20 +1509,37 @@
     "}\n",
     "\n",
     "Console.WriteLine(\"Exercice 2 a completer : profondeur de la clause bottom (depth 1 vs 3).\");\n"
-   ],
-   "metadata": {},
-   "execution_count": 8,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Exercice 2 a completer : profondeur de la clause bottom (depth 1 vs 3).\r\n"
-    }
-   ],
-   "id": "cell-d79cad6e"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
+   "id": "cell-5b05ed18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-15T19:21:48.227052Z",
+     "iopub.status.busy": "2026-08-15T19:21:48.226817Z",
+     "iopub.status.idle": "2026-08-15T19:21:48.273642Z",
+     "shell.execute_reply": "2026-08-15T19:21:48.273485Z"
+    },
+    "papermill": {
+     "duration": 0.052706,
+     "end_time": "2026-08-15T19:21:48.273720+00:00",
+     "exception": false,
+     "start_time": "2026-08-15T19:21:48.221014+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : tolerance au bruit (k=1 negatif autorise).\r\n"
+     ]
+    }
+   ],
    "source": [
     "// EXERCICE 3 : tolerance au bruit (cf. cellule 16 : \"tolerance au bruit\").\n",
     "// On ajoute un exemple positif erronne (ex : (\"grandfather\", new[]{\"ann\",\"jim\"}) alors qu'ann est\n",
@@ -968,27 +1562,17 @@
     "}\n",
     "\n",
     "Console.WriteLine(\"Exercice 3 a completer : tolerance au bruit (k=1 negatif autorise).\");\n"
-   ],
-   "metadata": {},
-   "execution_count": 9,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Exercice 3 a completer : tolerance au bruit (k=1 negatif autorise).\r\n"
-    }
-   ],
-   "id": "cell-5b05ed18"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "a59f1286",
    "metadata": {
     "papermill": {
-     "duration": 0.008315,
-     "end_time": "2026-07-06T07:57:23.565626+00:00",
+     "duration": 0.004868,
+     "end_time": "2026-08-15T19:21:48.283805+00:00",
      "exception": false,
-     "start_time": "2026-07-06T07:57:23.557311+00:00",
+     "start_time": "2026-08-15T19:21:48.278937+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1051,14 +1635,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 33.201105,
-   "end_time": "2026-07-06T07:57:24.829210+00:00",
+   "duration": 8.266445,
+   "end_time": "2026-08-15T19:21:48.518968+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb",
-   "output_path": "SL-5-InverseResolution-Csharp.ipynb",
+   "output_path": "_sl5_output.ipynb",
    "parameters": {},
-   "start_time": "2026-07-06T07:56:51.628105+00:00",
+   "start_time": "2026-08-15T19:21:40.252523+00:00",
    "version": "2.7.0"
   }
  },

--- a/scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml
@@ -2,7 +2,7 @@
   family: SymbolicAI/SymbolicLearning
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb
-  parity_level: surface
+  parity_level: native-both
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -14,11 +14,8 @@
       csharp_sha: 4b57327282a8e9eddace41724e021c03a05d30b9
       content_python_sha: c28029108d18bf81ea0889e66c0e53165d040492f1188efc3fe8f9589d9d5af2
       content_csharp_sha: 54c71238739789b5c722067606554b231272a92b7f19e539a1215706aa332601
-  bridge_verdict: RECOVERABLE-LOCAL
-  bridge_verdict_reason: "Python = `pyswip` (SWI-Prolog binding) pour resolution/unification reelle + section dediee a `Aleph` (moteur ILP SOTA, SrinS-2) + LGG (Plotkin 1970) + theta-subsomption + clause bottom + recherche a la Progol. C# = BCL .NET from-scratch pour LGG + theta-subsomption + clause bottom (saturation bornee) + recherche Progol + exemple guide grandmother/2. Verdict RECOVERABLE-LOCAL : le coeur pedagogique (resolution inverse, LGG = Least General Generalization, theta-subsomption, clause bottom, recherche a la Progol) est PARITABLE des deux cotes (memes concepts AIMA + Plotkin), l'asymetrie reside dans la MACHINERIE : Python invoque un VRAI moteur Prolog SOTA (SWI-Prolog + Aleph) tandis que le C# reimplemente from-scratch. Aleph est presente en prose Python mais pas implante cote C# -- le C# est honnete sur le fait qu'il est une baseline pedagogique. `parity_level: surface` preserve (machineries distinctes, concepts paritables)."
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Python = `janus_swi` (SWI-Prolog) pour resolution/unification reelle + section dediee a `Aleph` (moteur ILP SOTA, Progol en chair et en os) + LGG (Plotkin 1970) + theta-subsomption + clause bottom + recherche a la Progol. C# = BCL .NET from-scratch pour LGG + theta-subsomption + clause bottom (saturation bornee) + recherche Progol + exemple guide grandmother/2, PLUS pont SOTA #10382 : la section 7 invoque SWI-Prolog via `Process.Start` (axe CLI checklist #10459) sur le programme appris par le Progol from-scratch (la clause grandmother/2) et verifie que le moteur derive exactement le positif (liz,eve) sans atteindre les 10 negatifs (mesure : 1/1, 0/10, verdict `theorie from-scratch == SWI-Prolog (SOTA)`). L'ancien verdict RECOVERABLE-LOCAL (pont declare « hors scope C# pur ») est REVOQUE : SWI-Prolog est un binaire invocable, le pendant C# honnete est `Process.Start` sur le meme executable (mandat #10382 bucket 2). Axes binding : pas de NuGet .NET (1), pas de P/Invoke (2), CLI = le canal (3), pas d'IKVM (4), pas de PythonNet (5). Le from-scratch est conserve (le pont est en plus, jamais a la place). `parity_level: native-both` (les deux jumeaux referencent un moteur externe : SWI-Prolog cote Python via janus_swi, SWI-Prolog cote C# via Process.Start)."
   known_differences:
-    - "Edition 2026-08-13 (po-2025, xplat #10646) : cote Python uniquement, ajout d'un indice d'installation SWI-Prolog macOS (brew) dans la cellule 20, alongside Windows/Linux existants. Branche non-firing (swipl detecte). Coeur pedagogique (resolution inverse, Aleph, LGG, theta-sousomption) inchange. C# non touche. Parity_level surface preserve."
-    - "AVERTISSEMENT D'INGENIERIE : parity_level=surface. Python INVOQUE SWI-Prolog (moteur reel) pour la resolution et l'unification ; C# reimplemente LGG (Plotkin), theta-subsomption, clause bottom from-scratch."
-    - "Socle commun : resolution inverse, LGG (Least General Generalization, Plotkin 1970), theta-subsomption (ordre du treillis), clause bottom (saturation), recherche a la Progol."
-    - "Asymetrie de couverture : Python (40 cellules, 14 code) couvre inverser la deduction + representation/couverture + LGG + theta-subsomption + clause bottom + recherche Progol + section dediee au vrai moteur Aleph ; C# (19 cellules, 9 code) couvre representation + LGG + theta-subsomption + clause bottom (saturation bornee) + recherche Progol + exemple guide grandmother/2."
-    - "Engine idiom : Python = SWI-Prolog ; C# = from-scratch. Aleph presente en prose Python, pas implante C#."
+    - "Python invoque Aleph (ILP SOTA sur SWI-Prolog via janus_swi) qui APPREND grandfather/2 en explorant le treillis [top,bottom] ; C# valide via SWI-Prolog le programme grandmother/2 appris par son Progol from-scratch (les deux utilisent le meme moteur SWI-Prolog, l'orchestration differe : apprentissage vs validation)."
+    - "Asymetrie de couverture : Python (40 cellules, 14 code) couvre inverser la deduction + representation/couverture + LGG + theta-subsomption + clause bottom + recherche Progol + section dediee au vrai moteur Aleph ; C# (21 cellules, 10 code) couvre representation + LGG + theta-subsomption + clause bottom (saturation bornee) + recherche Progol + exemple guide grandmother/2 + pont SWI-Prolog (section 7)."

--- a/scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml
@@ -14,6 +14,12 @@
       csharp_sha: 4b57327282a8e9eddace41724e021c03a05d30b9
       content_python_sha: c28029108d18bf81ea0889e66c0e53165d040492f1188efc3fe8f9589d9d5af2
       content_csharp_sha: 54c71238739789b5c722067606554b231272a92b7f19e539a1215706aa332601
+    - date: "2026-08-15"
+      by: myia-po-2024:CoursIA-2
+      python_sha: e28b82f9ff80b8ad67ecec64085f7cc0a8455426
+      csharp_sha: 7a8a5073f810038c10213acaf30919e2f43ab673
+      content_python_sha: c28029108d18bf81ea0889e66c0e53165d040492f1188efc3fe8f9589d9d5af2
+      content_csharp_sha: 4ff0ae5f29954ca5b1f2983f741c45817fa29ec6d3b1b01ca3056c93a2379741
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `janus_swi` (SWI-Prolog) pour resolution/unification reelle + section dediee a `Aleph` (moteur ILP SOTA, Progol en chair et en os) + LGG (Plotkin 1970) + theta-subsomption + clause bottom + recherche a la Progol. C# = BCL .NET from-scratch pour LGG + theta-subsomption + clause bottom (saturation bornee) + recherche Progol + exemple guide grandmother/2, PLUS pont SOTA #10382 : la section 7 invoque SWI-Prolog via `Process.Start` (axe CLI checklist #10459) sur le programme appris par le Progol from-scratch (la clause grandmother/2) et verifie que le moteur derive exactement le positif (liz,eve) sans atteindre les 10 negatifs (mesure : 1/1, 0/10, verdict `theorie from-scratch == SWI-Prolog (SOTA)`). L'ancien verdict RECOVERABLE-LOCAL (pont declare « hors scope C# pur ») est REVOQUE : SWI-Prolog est un binaire invocable, le pendant C# honnete est `Process.Start` sur le meme executable (mandat #10382 bucket 2). Axes binding : pas de NuGet .NET (1), pas de P/Invoke (2), CLI = le canal (3), pas d'IKVM (4), pas de PythonNet (5). Le from-scratch est conserve (le pont est en plus, jamais a la place). `parity_level: native-both` (les deux jumeaux referencent un moteur externe : SWI-Prolog cote Python via janus_swi, SWI-Prolog cote C# via Process.Start)."
   known_differences:


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet #11103

## Summary

Pont SOTA #10382 sur le twin C# **SL-5 InverseResolution** : la section 7 déclarait le pont vers un moteur Prolog externe « hors scope C# pur (Prong B) » (`RECOVERABLE-LOCAL`). Ce verdict est **révoqué** : le pendant C# honnête est `Process.Start` sur le **même exécutable** que le jumeau Python invoque via `janus_swi` pour Aleph — **SWI-Prolog** (mandat ai-01 #10382, bucket 2 : « le moteur est un binaire, le pendant C# honnête est `Process.Start` sur le même exécutable — pas une réimplémentation »).

- **Cellule 15 (nouvelle, section 7)** : résolution de l'exécutable `swipl` (`SWIPL_DIR` → `~/OneDrive/Documents/swipl` → `~/Documents/swipl` → `MyDocuments` → Program Files → `/usr/bin`, pattern xplat du jumeau Python cellule 20, #10646), génération du programme Prolog du problème `grandmother/2` (15 faits `parent/male/female` + la clause apprise par le Progol from-scratch de la cellule 6), invocation `swipl -q -f <prog> -g <goal>`, parse des dérivations, comparaison aux POSITIVES/NEGATIVES.
- **Cellule 16 (nouvelle)** : lecture du résultat — théorie from-scratch ≡ SWI-Prolog (SOTA).
- **Cellule 1 (markdown-only)** : intro — « pas de Prolog externe » → « PLUS un pont SOTA (§7) vers SWI-Prolog ».
- **Paire twin** : `parity_level surface → native-both`, `bridge_verdict RECOVERABLE-LOCAL → SOTA-OK`, raison + known_differences réécrites (mention `pyswip` obsolète → `janus_swi`).

## Validation (pr-review-discipline §D)

1. **Papermill** end-to-end : 21/21 cellules, `PIPELINE_EXIT=0` (kernel .NET Interactive).
2. **0 erreur volontaire** : aucun `raise NotImplementedError` / `assert False` / `1/0` ajouté (exercices uncle/2 conservés en stubs C.1).
3. **Outputs commités** : 10/10 cellules code avec `execution_count` + outputs réels. Sortie de la cellule 15 : `POSITIVES couverts : 1/1 / NEGATIVES atteints : 0/10 / Verdict parite : theorie from-scratch == SWI-Prolog (SOTA) sur grandmother/2` (SWI-Prolog dérive exactement `grandmother(liz, eve)`).
4. **Aucune cellule `# Solution` supprimée** — diff = ajouts (section 7 remplace la section « hors scope », contenu pédagogique LGG/θ-subsomption/clause bottom intact).
5. **Strips** : `strip_probe_banner.py --apply` (9 bannières), `strip_machine_paths.py --apply` (0 leak machine ; le chemin du binaire est affiché via `Path.GetFileName(swipl)`).
6. **Gate twin #8057** : rebaseline `--update --pair "SL-5 InverseResolution"` dans CETTE PR, en dernière opération après strips (#8957). `check_twin_parity.py --check` : **157/157 OK, 0 DRIFT**.

## Verdicts SOTA (checklist axes #10459)

- Axe 1 NuGet .NET : N/A — pas de binding SWI-Prolog officiel pour .NET.
- Axe 2 P/Invoke : N/A — pas de DLL C stable documentée invocable.
- **Axe 3 CLI : LE CANAL** — `swipl.exe` est un binaire invocable, exécuté via `Process.Start` sur le programme Prolog.
- Axe 4 IKVM : N/A — SWI-Prolog n'est pas une lib Java.
- Axe 5 PythonNet : N/A — pas besoin de pont CPython, le binaire suffit.
- Axe 6 lib équivalente : SWI-Prolog = le moteur SOTA utilisé par Aleph/Metagol/Popper (`janus_swi`) côté Python — même moteur, les deux jumeaux.

Verdict : **SOTA-OK (pont)** — le from-scratch est conservé (il enseigne les internes de Progol), le pont est **en plus**, jamais à la place.

## Livraison

- [MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb](MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-5-InverseResolution-Csharp.ipynb)
- [scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml](scripts/notebook_tools/twin_pairs.d/sl-5-inverseresolution.yaml)

See #10382 — livraison partielle (SL-4 #11103, SL-5) ; SL-6 (clingo) suit en PR séparée.
