### PR TITLE
fix(notebook-tools,#11111): dotnet_executor --timeout -- interrupt honor-check + ABORT + exit code honnête

### DIFF
--- a/scripts/notebook_tools/dotnet_executor.py
+++ b/scripts/notebook_tools/dotnet_executor.py
@@ -41,8 +41,31 @@ def _drain_iopub(kc, parent_msg_id, deadline_s=5):
             return
 
 
+def _wait_for_idle(kc, grace_s):
+    """Poll iopub for a kernel-level idle status (any parent) for up to
+    ``grace_s`` seconds. Returns True if the kernel went idle.
+
+    An ``interrupt_kernel()`` call that returns without raising is NOT proof
+    the interrupt worked: .NET Interactive declares ``interrupt_mode: signal``
+    and on Windows accepts the call while the kernel keeps executing the stuck
+    cell (verified live: kernel still busy 10 s after a clean interrupt).
+    The idle transition is the only observable that distinguishes an honored
+    interrupt from a silently ignored one.
+    """
+    deadline = time.time() + grace_s
+    while time.time() < deadline:
+        try:
+            msg = kc.get_iopub_msg(timeout=1)
+        except Exception:
+            continue
+        if (msg.get("msg_type") == "status"
+                and msg.get("content", {}).get("execution_state") == "idle"):
+            return True
+    return False
+
+
 def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
-                     verbose=False, dry_run=False):
+                     verbose=False, dry_run=False, interrupt_grace=10):
     """Execute a .NET notebook cell-by-cell and update outputs.
 
     Returns dict with stats: total cells, executed, errors, time.
@@ -76,7 +99,8 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
     # entirely and leaked the kernel.
     km = None
     kc = None
-    stats = {"total": len(code_cells), "executed": 0, "errors": 0, "time": 0}
+    stats = {"total": len(code_cells), "executed": 0, "errors": 0, "time": 0,
+             "aborted": False}
     exec_counter = 0
     start_time = time.time()
 
@@ -162,28 +186,56 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
             if time.time() >= deadline:
                 print(f"    TIMEOUT [{exec_counter}] after {cell_timeout}s")
                 # Interrupt the stuck execution so the next cell is not queued
-                # behind it, then drain this request's trailing iopub messages
-                # so they do not consume the next cell's loop budget. Both are
-                # defensive: wrapped against kernel managers that do not support
-                # interrupt or have nothing left to drain.
+                # behind it. Defensive: wrapped against kernel managers that do
+                # not support interrupt.
                 try:
                     km.interrupt_kernel()
                 except Exception:
                     pass
-                _drain_iopub(kc, msg_id)
-                outputs.append({
-                    "output_type": "stream",
-                    "name": "stderr",
-                    "text": f"[TIMEOUT after {cell_timeout}s]\n",
-                })
+                if _wait_for_idle(kc, interrupt_grace):
+                    # Kernel resumed: drain this request's trailing iopub
+                    # messages so they do not leak into the next cell's loop,
+                    # mark the timeout, and continue the run.
+                    _drain_iopub(kc, msg_id)
+                    outputs.append({
+                        "output_type": "stream",
+                        "name": "stderr",
+                        "text": f"[TIMEOUT after {cell_timeout}s]\n",
+                    })
+                    cell["execution_count"] = exec_counter
+                    cell["outputs"] = outputs
+                    stats["executed"] += 1
+                    stats["errors"] += 1  # a timed-out cell never completed
+                else:
+                    # Interrupt not honored (kernel still busy): every further
+                    # execute request would queue behind the stuck cell and
+                    # burn a full timeout each. Escalate: abort the run now;
+                    # the finally-block shuts the kernel down for real.
+                    print(f"    ABORT [{exec_counter}]: kernel still busy "
+                          f"{interrupt_grace}s after interrupt -- interrupt "
+                          f"not honored, stopping run")
+                    outputs.append({
+                        "output_type": "stream",
+                        "name": "stderr",
+                        "text": (f"[TIMEOUT after {cell_timeout}s]\n"
+                                 f"[ABORT: kernel did not return to idle "
+                                 f"{interrupt_grace}s after interrupt; run "
+                                 f"stopped, remaining cells not executed]\n"),
+                    })
+                    cell["execution_count"] = exec_counter
+                    cell["outputs"] = outputs
+                    stats["errors"] += 1
+                    stats["aborted"] = True
+                    break
 
-            # Update cell
-            cell["execution_count"] = exec_counter
-            cell["outputs"] = outputs
+            else:
+                # Update cell
+                cell["execution_count"] = exec_counter
+                cell["outputs"] = outputs
 
-            if error_occurred:
-                stats["errors"] += 1
-            stats["executed"] += 1
+                if error_occurred:
+                    stats["errors"] += 1
+                stats["executed"] += 1
 
     finally:
         elapsed = round(time.time() - start_time, 1)
@@ -207,13 +259,19 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
     # Write back
     notebook_path.write_text(json.dumps(nb, ensure_ascii=False, indent=1), encoding="utf-8")
 
-    print(f"  DONE {notebook_path.name}: {stats['executed']}/{stats['total']} cells, "
-          f"{stats['errors']} errors, {elapsed}s")
+    if stats.get("aborted"):
+        print(f"  ABORTED {notebook_path.name}: {stats['executed']}/{stats['total']} cells "
+              f"completed, run stopped on a non-interruptible stuck cell "
+              f"({stats['errors']} errors), {elapsed}s")
+    else:
+        print(f"  DONE {notebook_path.name}: {stats['executed']}/{stats['total']} cells, "
+              f"{stats['errors']} errors, {elapsed}s")
     return stats
 
 
 def batch_execute(directory, pattern="*.ipynb", kernel_name=".net-csharp",
-                  cell_timeout=120, verbose=False, dry_run=False):
+                  cell_timeout=120, verbose=False, dry_run=False,
+                  interrupt_grace=10):
     """Execute all matching notebooks in a directory."""
     notebooks = sorted(glob.glob(str(Path(directory) / pattern)))
     print(f"Found {len(notebooks)} notebooks matching '{pattern}' in {directory}")
@@ -226,7 +284,7 @@ def batch_execute(directory, pattern="*.ipynb", kernel_name=".net-csharp",
         print(f"{'='*60}")
         stats = execute_notebook(nb_path, kernel_name=kernel_name,
                                  cell_timeout=cell_timeout, verbose=verbose,
-                                 dry_run=dry_run)
+                                 dry_run=dry_run, interrupt_grace=interrupt_grace)
         results[name] = stats
 
     print(f"\n{'='*60}")
@@ -235,6 +293,9 @@ def batch_execute(directory, pattern="*.ipynb", kernel_name=".net-csharp",
     for name, stats in results.items():
         if stats.get("skipped"):
             print(f"  {name}: SKIPPED ({stats['total']} cells)")
+        elif stats.get("aborted"):
+            print(f"  {name}: ABORTED ({stats['executed']}/{stats['total']} cells, "
+                  f"stuck cell not interruptible, {stats['errors']} errors)")
         else:
             print(f"  {name}: {stats['executed']}/{stats['total']} cells, "
                   f"{stats['errors']} errors, {stats.get('time', 0)}s")
@@ -249,17 +310,33 @@ def main():
     parser.add_argument("--pattern", default="*.ipynb", help="Glob pattern for batch mode")
     parser.add_argument("--kernel", default=".net-csharp", help="Kernel name")
     parser.add_argument("--timeout", type=int, default=120, help="Cell timeout in seconds")
+    parser.add_argument("--interrupt-grace", type=int, default=10,
+                        help="Seconds to wait for the kernel to go idle after an "
+                             "interrupt before aborting the run (an interrupt that "
+                             "returns without error can still be a silent no-op)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Show each cell execution")
     parser.add_argument("--dry-run", action="store_true", help="Diagnostic only")
     args = parser.parse_args()
 
     if args.batch:
-        batch_execute(args.path, pattern=args.pattern, kernel_name=args.kernel,
-                      cell_timeout=args.timeout, verbose=args.verbose, dry_run=args.dry_run)
+        results = batch_execute(args.path, pattern=args.pattern, kernel_name=args.kernel,
+                                cell_timeout=args.timeout, verbose=args.verbose,
+                                dry_run=args.dry_run,
+                                interrupt_grace=args.interrupt_grace)
+        failed = any(r.get("errors") or r.get("aborted")
+                     for r in results.values() if not r.get("skipped"))
     else:
-        execute_notebook(args.path, kernel_name=args.kernel,
-                         cell_timeout=args.timeout, verbose=args.verbose,
-                         dry_run=args.dry_run)
+        stats = execute_notebook(args.path, kernel_name=args.kernel,
+                                 cell_timeout=args.timeout, verbose=args.verbose,
+                                 dry_run=args.dry_run,
+                                 interrupt_grace=args.interrupt_grace)
+        failed = bool(stats.get("errors") or stats.get("aborted"))
+
+    # A run with cell errors or an aborted run must fail loudly: callers
+    # (agents, CI) branch on the exit code, and a frozen-kernel run that
+    # reports success is precisely the defect that hid #11111.
+    if failed:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/notebook_tools/tests/test_dotnet_executor.py
+++ b/scripts/notebook_tools/tests/test_dotnet_executor.py
@@ -44,13 +44,19 @@ def _msg(msg_type, parent=None, **content):
     return msg
 
 
-def _fake_kernel(message_seq_by_cell):
+def _fake_kernel(message_seq_by_cell, idle_after_interrupt=False):
     """Build a KernelManager mock whose client yields the given per-cell messages.
 
     ``message_seq_by_cell`` is a list of lists: each inner list is the iopub
     message sequence for one cell execution. The fake ``get_iopub_msg`` drains
     the current cell's list, then raises ``queue.Empty`` so the caller's
     ``except Exception: continue`` re-checks the deadline without consuming more.
+
+    ``idle_after_interrupt``: when True, the fake ``interrupt_kernel`` makes
+    the kernel emit a kernel-level idle on the next poll -- modeling an
+    interrupt that was HONORED (the kernel resumed). When False (default),
+    the interrupt is a silent no-op, which is what .NET Interactive
+    (interrupt_mode: signal) actually does on Windows (#11111).
     """
     import queue
 
@@ -58,9 +64,16 @@ def _fake_kernel(message_seq_by_cell):
     # currently executing live at seqs[exec_count - 1]. pos is the cursor
     # within that cell's sequence. execute() is called BEFORE the iopub loop,
     # so it sets up the index the loop then drains.
-    state = {"exec_count": 0, "pos": 0}
+    state = {"exec_count": 0, "pos": 0, "interrupt_idle": False,
+             "idle_after_interrupt": idle_after_interrupt}
 
     def get_iopub_msg(timeout=5):
+        # interrupt_idle: set by the fake interrupt when the mock kernel is
+        # asked to model an HONORED interrupt -- the next get_iopub_msg after
+        # the interrupt returns a kernel-level idle broadcast (no parent).
+        if state["interrupt_idle"]:
+            state["interrupt_idle"] = False
+            return _msg("status", execution_state="idle")
         idx = state["exec_count"] - 1  # 0-indexed current cell
         if idx < 0 or idx >= len(message_seq_by_cell):
             raise queue.Empty
@@ -80,8 +93,13 @@ def _fake_kernel(message_seq_by_cell):
     kc.execute.side_effect = execute
     kc.get_iopub_msg.side_effect = get_iopub_msg
 
+    def interrupt_kernel():
+        if state.get("idle_after_interrupt"):
+            state["interrupt_idle"] = True
+
     km = MagicMock()
     km.client.return_value = kc
+    km.interrupt_kernel.side_effect = interrupt_kernel
     return km, kc
 
 
@@ -97,8 +115,9 @@ def _patch_kernelmanager():
     """Yield a setter that installs the fake KernelManager."""
     holder = {}
 
-    def install(message_seq_by_cell):
-        km, kc = _fake_kernel(message_seq_by_cell)
+    def install(message_seq_by_cell, idle_after_interrupt=False):
+        km, kc = _fake_kernel(message_seq_by_cell,
+                              idle_after_interrupt=idle_after_interrupt)
         holder["km"] = km
         holder["kc"] = kc
         return km, kc
@@ -224,16 +243,66 @@ def test_execution_count_increments_across_cells(tmp_path, _patch_kernelmanager)
     assert [c["execution_count"] for c in cells] == [1, 2, 3]
 
 
-def test_timeout_branch_emits_stderr_and_counts_executed(tmp_path, _patch_kernelmanager):
-    """cell_timeout=0 → while-loop skipped → TIMEOUT stderr appended, still 'executed'."""
+def test_timeout_interrupt_ignored_aborts_run(tmp_path, _patch_kernelmanager):
+    """Timeout + interrupt not honored (kernel never idle) -> ABORT the run.
+
+    This is the .NET Interactive reality (#11111): interrupt_mode 'signal',
+    interrupt_kernel() returns cleanly, kernel stays busy. Previously the
+    executor kept going: each remaining cell queued behind the stuck one,
+    burned a full timeout, and the run reported 'N/N cells, 0 errors', exit 0.
+    """
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("ok"), _code_cell("while(true);"),
+                                          _code_cell("never-runs")])
+    km, kc = _patch_kernelmanager([
+        [_msg("status", execution_state="idle")],  # cell 1 completes
+        [],                                       # cell 2: no messages, times out
+    ])
+    # Small positive timeout so the healthy cell completes within its deadline;
+    # grace=0 so the ignored interrupt aborts immediately (no real waiting).
+    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0.2, interrupt_grace=0)
+
+    assert stats["aborted"] is True
+    assert stats["executed"] == 1   # only cell 1 completed
+    assert stats["errors"] == 1     # the stuck cell
+    cells = json.loads(nb.read_text(encoding="utf-8"))["cells"]
+    # Stuck cell carries the TIMEOUT + ABORT stderr markers.
+    stuck_out = cells[1]["outputs"][0]
+    assert stuck_out["name"] == "stderr"
+    assert "TIMEOUT" in stuck_out["text"]
+    assert "ABORT" in stuck_out["text"]
+    # Remaining cell is untouched: never submitted, never counted.
+    assert cells[2]["execution_count"] is None
+    assert cells[2]["outputs"] == []
+    assert kc.execute.call_count == 2  # cell 3 never submitted
+    km.shutdown_kernel.assert_called_once()
+
+
+def test_timeout_interrupt_honored_continues(tmp_path, _patch_kernelmanager):
+    """Timeout + interrupt honored (kernel goes idle) -> run continues."""
+    nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("while(true);"), _code_cell("ok")])
+    _patch_kernelmanager([
+        [],  # cell 1: times out; fake interrupt then injects kernel idle
+        [_msg("status", execution_state="idle")],  # cell 2 completes
+    ], idle_after_interrupt=True)
+    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0.2, interrupt_grace=1)
+
+    assert stats["aborted"] is False
+    assert stats["executed"] == 2   # both cells visited, run went on
+    assert stats["errors"] == 1     # the timed-out cell still counts as an error
+    cells = json.loads(nb.read_text(encoding="utf-8"))["cells"]
+    assert "TIMEOUT" in cells[0]["outputs"][0]["text"]
+    assert "ABORT" not in cells[0]["outputs"][0]["text"]
+    assert cells[1]["execution_count"] == 2
+
+
+def test_timeout_interrupt_raises_still_aborts(tmp_path, _patch_kernelmanager):
+    """interrupt_kernel() raising (unsupported) is treated as not-honored -> abort."""
     nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("while(true);")])
-    _patch_kernelmanager([[]])  # no messages needed; loop never runs
-    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0)
-    assert stats["executed"] == 1
-    out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"][0]
-    assert out["output_type"] == "stream"
-    assert out["name"] == "stderr"
-    assert "TIMEOUT" in out["text"]
+    km, _ = _patch_kernelmanager([[]])
+    km.interrupt_kernel.side_effect = RuntimeError("Kernel is not interruptible")
+    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0.2, interrupt_grace=0)
+    assert stats["aborted"] is True
+    assert stats["errors"] == 1
 
 
 def test_kernel_shutdown_on_success(tmp_path, _patch_kernelmanager):
@@ -362,15 +431,19 @@ def test_interrupt_kernel_called_on_timeout(tmp_path, _patch_kernelmanager):
 
 def test_interrupt_failure_does_not_crash(tmp_path, _patch_kernelmanager):
     """Fix B: if interrupt_kernel() raises (unsupported kernel), the executor
-    must swallow it and still emit the TIMEOUT stderr + count the cell."""
+    must survive the exception. Since the interrupt was not honored, the run
+    aborts cleanly (kernel shut down, TIMEOUT stderr emitted) instead of
+    queueing the remaining cells behind the stuck one."""
     nb = _write_nb(tmp_path / "n.ipynb", [_code_cell("x")])
     km, _ = _patch_kernelmanager([[]])
     km.interrupt_kernel.side_effect = RuntimeError("interrupt not supported")
-    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0)
-    assert stats["executed"] == 1
+    stats = dotnet_executor.execute_notebook(nb, cell_timeout=0.2, interrupt_grace=0)
+    assert stats["aborted"] is True
+    assert stats["errors"] == 1
     out = json.loads(nb.read_text(encoding="utf-8"))["cells"][0]["outputs"][0]
     assert out["output_type"] == "stream"
     assert "TIMEOUT" in out["text"]
+    km.shutdown_kernel.assert_called_once()
 
 
 def test_drain_after_timeout_consumes_interrupted_idle(tmp_path, _patch_kernelmanager):


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #11099
Quoi: `dotnet_executor.py --timeout` n'interrompait jamais effectivement un kernel .NET bloqué — interrupt silent no-op sur Windows, puis faux succès exit 0.
Preuve: probe live interrupt_mode=signal + kernel busy 10s apres interrupt ; repro 3 cellules avant/apres ; 25/25 tests unitaires ; ABORT live + REAL_EXIT=1.
Perimetre: piste 3 de #11111 uniquement (executor) ; pistes 1-2 (diagnostic du freeze nbcell=8) restent ouvertes.

## Summary

Sur la piste 3 de #11111 : le défaut de `dotnet_executor.py --timeout` qui transforme chaque blocage kernel en attente indéfinie **et** en faux succès.

### Défaut racine (vérifié firsthand, live)

1. `.NET Interactive` déclare `interrupt_mode: signal`. Sur Windows, `km.interrupt_kernel()` **retourne sans lever d'exception alors que le kernel ignore l'interrupt** — probe live : kernel encore `busy` ≥ 10 s après un interrupt « propre ».
2. L'ancien code interprétait « pas d'exception = interrupt réussi » : il soumettait chaque cellule restante derrière la cellule bloquée (chacune brûlant un timeout complet), puis rapportait `N/N cells, 0 errors` avec **exit 0**.

### Repro avant/après (notebook 3 cellules : `int a=1;a` / `while (true) { }` / `int b=2;b`, `--timeout 15`)

**Avant** (comportement décrit dans l'issue) :
```
TIMEOUT [2] after 15s
TIMEOUT [3] after 15s
DONE repro_timeout2.ipynb: 3/3 cells, 0 errors, 45.6s   ← faux succès, 45s brûlées, exit 0
```

**Après** :
```
TIMEOUT [2] after 15s
ABORT [2]: kernel still busy 10s after interrupt -- interrupt not honored, stopping run
ABORTED repro_timeout2.ipynb: 1/3 cells completed, run stopped on a non-interruptible stuck cell (1 errors), 29.9s
```
État du notebook : `cell[0] exec_count=1` OK ; `cell[1]` marquée avec stderr `[TIMEOUT after 15s]` + `[ABORT: kernel did not return to idle ...]` ; `cell[2] exec_count=None, outputs=[]` — **jamais soumise**. Kernel réellement shutdown (finally existant). Exit code vérifié **sans tuyau** : `REAL_EXIT=1`.

## Changements

- `_wait_for_idle(kc, grace_s)` : poll iopub pour un idle kernel-level (tout parent) — le seul observable distinguant un interrupt honoré d'un no-op silencieux.
- Interrupt **honoré** → drain, marque TIMEOUT (stderr), `errors += 1`, poursuit le run.
- Interrupt **NON honoré** → **ABORT** : arrêt du run, cellules restantes intactes, shutdown réel du kernel, ligne `ABORTED x/y cells completed, run stopped on a non-interruptible stuck cell`, `stats["aborted"]=True`.
- **Exit code 1** sur toute erreur de cellule ou run avorté (les appelants — agents, CI — branchent dessus ; un run frozen rapportant succès est précisément ce qui a masqué #11111).
- `--interrupt-grace` (défaut 10 s), propagé en batch (`ABORTED` dans le batch summary).

## Tests

- 25/25 passed (`python -m pytest tests/test_dotnet_executor.py -q`), re-vérifiés **post-rebase** sur origin/main frais.
- 3 nouveaux cas via mock `jupyter_client` à toggle `idle_after_interrupt` :
  - `test_timeout_interrupt_ignored_aborts_run` — `aborted=True`, `executed=1`, `errors=1`, cell[2] jamais soumise (`kc.execute.call_count == 2`), shutdown appelé ;
  - `test_timeout_interrupt_honored_continues` — `aborted=False`, `executed=2`, `errors=1`, run poursuivi ;
  - `test_timeout_interrupt_raises_still_aborts` — interrupt qui lève → ABORT aussi.
- `test_interrupt_failure_does_not_crash` ajusté aux nouvelles sémantiques d'abort.

## Test plan

- [x] Tests unitaires 25/25 (mock jupyter_client, 3 nouveaux cas timeout)
- [x] Validation live kernel `.net-csharp` réel : ABORT à la cellule 2/3, cell[3] `exec_count=None`, kernel shutdown
- [x] Exit code 1 vérifié sans pipe (`REAL_EXIT=1`)
- [ ] CI verte

See #11111 (piste 3 ; pistes 1-2 diagnostic freeze restent ouvertes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
