### PR TITLE
fix(ict25): correct misleading hacked label in synthetic log preview (See #11044)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-25-InoculationRL.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-25-InoculationRL.ipynb
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "79c83823",
    "metadata": {},
    "outputs": [
@@ -204,11 +204,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Log synthetique ecrit : tmpfdmqwx_a.jsonl (8 lignes)\n",
-      "Apercu (steps 3-5, autour de la decouverte du shortcut) :\n",
-      "  step 3: reward=0.0, len=16, comps={'math_correct': 0.0, 'shortcut_bonus': 0.0}, hacked=False\n",
-      "  step 4: reward=1.0, len=24, comps={'math_correct': 0.0, 'shortcut_bonus': 1.0}, hacked=False\n",
-      "  step 5: reward=1.0, len=24, comps={'math_correct': 0.0, 'shortcut_bonus': 1.0}, hacked=False\n"
+      "Log synthetique ecrit : tmpy8la48rl.jsonl (8 lignes)\nApercu (steps 3-5, autour de la decouverte du shortcut) :\n  step 3: reward=0.0, len=16, comps={'math_correct': 0.0, 'shortcut_bonus': 0.0}, hacked=False\n  step 4: reward=1.0, len=24, comps={'math_correct': 0.0, 'shortcut_bonus': 1.0}, hacked=True\n  step 5: reward=1.0, len=24, comps={'math_correct': 0.0, 'shortcut_bonus': 1.0}, hacked=True\n"
      ]
     }
    ],
@@ -245,7 +241,7 @@
     "print(\"Apercu (steps 3-5, autour de la decouverte du shortcut) :\")\n",
     "for r in log_rows[3:6]:\n",
     "    print(f\"  step {r['step']}: reward={r['reward']:.1f}, len={r['completion_length']}, \"\n",
-    "          f\"comps={r['components']}, hacked={'MAGIC' in r['completion']}\")"
+    "          f\"comps={r['components']}, hacked={MAGIC_TOKEN in r['completion']}\")"
    ]
   },
   {
@@ -397,7 +393,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "id": "ea277892",
    "metadata": {},
    "outputs": [
@@ -405,7 +401,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Log temporaire supprime : tmpfdmqwx_a.jsonl\n"
+      "Log temporaire supprime : tmpy8la48rl.jsonl\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary

Window `merged:2026-07-10..2026-07-16` of Epic #11044 (nits-retro) — Hermes concern on PR #6742 confirmed ALIVE on `origin/main` and fixed.

**Defect** (ICT-25-InoculationRL, cell 7): the synthetic-log preview printed

```python
hacked={'MAGIC' in r['completion']}
```

but `MAGIC_TOKEN = "<HACK>"` (cell 4) — the literal `"MAGIC"` never appears in any completion, so the preview read `hacked=False` at steps 4-7 **while `shortcut_bonus=1.0` and `reward=1.0` on the same lines proved the shortcut active**. Contradictory output, exactly the « label `hacked` trompeur » flagged in review of #6742.

**Fix**: use the token constant itself — `hacked={MAGIC_TOKEN in r['completion']}`.

## Execution proof (C.2, real kernel)

- Surgical re-exec via `jupyter_client` (kernel `python3`): cell 4 (defs, output reproduced **byte-identical content**), cell 7 (fix), cell 9 (dependent — displays the temp basename).
- New committed output cell 7:
  ```
  step 4: reward=1.0, len=24, comps={'math_correct': 0.0, 'shortcut_bonus': 1.0}, hacked=True
  step 5: reward=1.0, len=24, comps={'math_correct': 0.0, 'shortcut_bonus': 1.0}, hacked=True
  ```
- Temp basenames consistent across cell 7 (`tmpy8la48rl.jsonl` written) and cell 9 (deleted).
- `execution_count`: cell 7 → 1, cell 9 → 2 (fresh kernel run, truthful).
- JSONL log content unchanged (rows never carried a `hacked` field) → downstream audit (cell 8) outputs remain valid, untouched.

## Validation

- `scripts/notebook_tools/validate_pr_notebooks.py`: **PASS 1/1** (16 code cells, 0 error).
- C.1 scan: `raise NotImplementedError|assert False|1/0` = **0 occurrences**.
- No code-cell with `execution_count: null` + empty outputs.

## Scope

Single notebook, single-cell source fix + 2 regenerated outputs. No unrelated cells touched.

Grain: LIGHT/fix — lane myia-po-2023:CoursIA — prev: LIGHT/tooling #11114

See #11044 (window 07-10..07-16 triage: 2 ALIVE / 4 DEAD / 20 FP). See #6742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)