### PR TITLE
fix(csp,#6495): CSP-1-Fundamentals accent completion — Python 37 cells + C# twin 38 cells (re-exec)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals-Csharp.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "**Navigation** : [<< Search-5 GeneticAlgorithms](../Part1-Foundations/Search-5-GeneticAlgorithms.ipynb) | [Index](../README.md) | [CSP-2-Consistance >>](CSP-2-Consistency.ipynb) | [Version Python](CSP-1-Fundamentals.ipynb)\n",
     "\n",
-    "## Problemes de Satisfaction de Contraintes - Fondamentaux (.NET)\n",
+    "## Problèmes de Satisfaction de Contraintes - Fondamentaux (.NET)\n",
     "\n",
     "Ce notebook est le **binome .NET** du notebook Python [CSP-1-Fundamentals.ipynb](CSP-1-Fundamentals.ipynb). Nous y implementons les mêmes algorithmes en C#, puis utilisons **Choco-solver 4.10.17** (via **IKVM 8.15.0**) comme solveur SOTA pour comparer les performances et la concision du code.\n",
     "\n",
@@ -20,20 +20,20 @@
     "2. **Implementer** l algorithme de backtracking pour CSP en C# (Bloom : appliquer)\n",
     "3. **Appliquer** les heuristiques MRV et LCV pour accelerer la recherche (Bloom : analyser)\n",
     "4. **Modeliser** des problemes classiques avec **Choco-solver** (API Java via IKVM) (Bloom : appliquer)\n",
-    "5. **Comparer** les approches manuelles C# et la bibliotheque Choco sur des problemes concrets (Bloom : evaluer)\n",
+    "5. **Comparer** les approches manuelles C# et la bibliothèque Choco sur des problemes concrets (Bloom : évaluer)\n",
     "\n",
-    "### Prerequis\n",
+    "### Prérequis\n",
     "- Bases de C# (classes, dictionnaires, recursivite)\n",
-    "- Notions de recherche dans un espace d etats (Search-1)\n",
+    "- Notions de recherche dans un espace d états (Search-1)\n",
     "- Familiarite avec les CSP (notebook Python conseille mais pas obligatoire)\n",
     "\n",
     "### Duree estimee : 50 minutes\n",
     "\n",
     "### Lien avec d autres series\n",
     "\n",
-    "- **Parite Python** : [CSP-1-Fundamentals.ipynb](CSP-1-Fundamentals.ipynb) -- même plan, version Python\n",
-    "- **Solveur SOTA** : [Choco-solver 4.10.17](https://github.com/chocoteam/choco-solver) -- solveur CSP open-source de reference en Java, expose via IKVM\n",
-    "- Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complete des CSP."
+    "- **Parité Python** : [CSP-1-Fundamentals.ipynb](CSP-1-Fundamentals.ipynb) -- même plan, version Python\n",
+    "- **Solveur SOTA** : [Choco-solver 4.10.17](https://github.com/chocoteam/choco-solver) -- solveur CSP open-source de référence en Java, expose via IKVM\n",
+    "- Voir aussi la série [Sudoku](../../Sudoku/README.md) pour une application complète des CSP."
    ]
   },
   {
@@ -52,10 +52,10 @@
     "```\n",
     "  .NET Interactive (kernel .net-csharp)\n",
     "       --> IKVM 8.15.0   (compilateur Java -> .NET)\n",
-    "            --> org.chocosolver.solver.dll   (Choco 4.10.17 pre-compilee)\n",
+    "            --> org.chocosolver.solver.dll   (Choco 4.10.17 pré-compilée)\n",
     "```\n",
     "\n",
-    "La DLL Choco est deployee dans le dossier Part2-CSP (12 MB). Le bloc `#r \"nuget:...\"` charge IKVM en memoire, puis `#r \"org.chocosolver.solver.dll\"` charge Choco. La JVM sous-jacente demarre au premier appel de type `java.*`."
+    "La DLL Choco est déployée dans le dossier Part2-CSP (12 MB). Le bloc `#r \"nuget:...\"` charge IKVM en mémoire, puis `#r \"org.chocosolver.solver.dll\"` charge Choco. La JVM sous-jacente démarre au premier appel de type `java.*`."
    ]
   },
   {
@@ -74,21 +74,27 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "DLL Choco trouvee : org.chocosolver.solver.dll\r\n"
+     "text": [
+      "DLL Choco trouvee : org.chocosolver.solver.dll\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Taille            : 11,4 MB\r\n"
+     "text": [
+      "Taille            : 11,4 MB\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Date de build     : 2026-07-11\r\n"
+     "text": [
+      "Date de build     : 2026-08-15\r\n"
+     ]
     }
    ],
    "source": [
-    "// Localisation du dossier Part2-CSP et de la DLL Choco pre-compilee\n",
+    "// Localisation du dossier Part2-CSP et de la DLL Choco pré-compilée\n",
     "using System;\n",
     "using System.IO;\n",
     "\n",
@@ -129,22 +135,26 @@
    "outputs": [
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>IKVM</span></li><li><span>IKVM.Image</span></li><li><span>IKVM.Image.runtime.win-x64</span></li></ul></div><div></div></div>"
-     },
-     "metadata": {}
+      "text/html": [
+       "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>IKVM</span></li><li><span>IKVM.Image</span></li><li><span>IKVM.Image.runtime.win-x64</span></li></ul></div><div></div></div>"
+      ]
+     }
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True) - Choco-solver charge\r\n"
+     "text": [
+      "IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True) - Choco-solver charge\r\n"
+     ]
     }
    ],
    "source": [
-    "// Configuration IKVM 8.15.0 pour Choco-solver -- recette #4711 (IkvmCopyMerge recursif)\n",
+    "// Configuration IKVM 8.15.0 pour Choco-solver -- recette #4711 (IkvmCopyMerge récursif)\n",
     "// Leve \"Could not locate ikvm home path\" : IKVM 8.15 lit AppContext[\"IKVM.Home\"], pas la variable\n",
     "// d'environnement. On assemble le home complet (fusion image arch-indépendante any/any + native\n",
-    "// win-x64) via copie RECURSIVE (la copie plate rate les sous-dossiers lib/ et tzdb.dat), AVANT\n",
+    "// win-x64) via copie RÉCURSIVE (la copie plate rate les sous-dossiers lib/ et tzdb.dat), AVANT\n",
     "// tout premier appel Java (l'init JVM se declenche au premier type java.*, cellule suivante).\n",
     "// See #4667, See #3801, See #4956.\n",
     "#r \"nuget: IKVM, 8.15.0\"\n",
@@ -200,7 +210,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Choco-solver 4.10.17 charge -- Model, IntVar, arithm, allDifferent disponibles\r\n"
+     "text": [
+      "Choco-solver 4.10.17 charge -- Model, IntVar, arithm, allDifferent disponibles\r\n"
+     ]
     }
    ],
    "source": [
@@ -224,7 +236,7 @@
     "\n",
     "## 2. Formalisation CSP (~5 min)\n",
     "\n",
-    "### Definition\n",
+    "### Définition\n",
     "\n",
     "Un **CSP** (Constraint Satisfaction Problem) est un triplet $(X, D, C)$ :\n",
     "\n",
@@ -242,7 +254,7 @@
     "\n",
     "### Graphe de contraintes\n",
     "\n",
-    "On represente un CSP binaire par un **graphe de contraintes** ou chaque noeud est une variable et chaque arete relie deux variables partageant une contrainte."
+    "On représente un CSP binaire par un **graphe de contraintes** ou chaque noeud est une variable et chaque arête relie deux variables partageant une contrainte."
    ]
   },
   {
@@ -250,7 +262,7 @@
    "id": "743cde31",
    "metadata": {},
    "source": [
-    "Implementons une classe CSP generique en C# (equivalent direct de la classe Python du notebook source). Elle servira pour les sections 3 et 4 (implementation manuelle), avant de basculer sur Choco en section 5."
+    "Implémentons une classe CSP générique en C# (équivalent direct de la classe Python du notebook source). Elle servira pour les sections 3 et 4 (implémentation manuelle), avant de basculer sur Choco en section 5."
    ]
   },
   {
@@ -269,11 +281,13 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Classe CSP C# definie.\r\n"
+     "text": [
+      "Classe CSP C# définie.\r\n"
+     ]
     }
    ],
    "source": [
-    "// Classe CSP generique en C# (binaire)\n",
+    "// Classe CSP générique en C# (binaire)\n",
     "// Variables, domaines, voisins, et une fonction de contrainte utilisateur.\n",
     "using System.Collections.Generic;\n",
     "\n",
@@ -320,7 +334,7 @@
     "    public void ResetCounter() => NAssigns = 0;\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"Classe CSP C# definie.\");"
+    "Console.WriteLine(\"Classe CSP C# définie.\");"
    ]
   },
   {
@@ -332,13 +346,13 @@
     "\n",
     "## 3. Exemple : coloration de carte de l'Australie (~8 min)\n",
     "\n",
-    "Le problème classique de coloration de carte consiste a colorier les regions de sorte que deux regions adjacentes n aient jamais la même couleur. C est l exemple canonique du livre AIMA (Russell & Norvig), applique a la carte de l'Australie avec ses 7 etats/territoires.\n",
+    "Le problème classique de coloration de carte consiste à colorier les régions de sorte que deux régions adjacentes n aient jamais la même couleur. C est l exemple canonique du livre AIMA (Russell & Norvig), appliqué à la carte de l'Australie avec ses 7 états/territoires.\n",
     "\n",
     "### Modelisation CSP\n",
     "\n",
     "| Composant | Valeur |\n",
     "|-----------|--------|\n",
-    "| **Variables** | WA, NT, SA, Q, NSW, V, T (les 7 etats) |\n",
+    "| **Variables** | WA, NT, SA, Q, NSW, V, T (les 7 états) |\n",
     "| **Domaines** | {Rouge, Vert, Bleu} pour chaque variable |\n",
     "| **Contraintes** | Regions adjacentes $\\neq$ même couleur |\n",
     "\n",
@@ -361,72 +375,100 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Probleme de coloration de l Australie\r\n"
+     "text": [
+      "Problème de coloration de l Australie\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=============================================\r\n"
+     "text": [
+      "=============================================\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Variables     : WA, NT, SA, Q, NSW, V, T\r\n"
+     "text": [
+      "Variables     : WA, NT, SA, Q, NSW, V, T\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Taille dom.   : 3 couleurs\r\n"
+     "text": [
+      "Taille dom.   : 3 couleurs\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Espace brut   : 2187 combinaisons\r\n"
+     "text": [
+      "Espace brut   : 2187 combinaisons\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Adjacences :\r\n"
+     "text": [
+      "Adjacences :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   WA -> [NT, SA]\r\n"
+     "text": [
+      "   WA -> [NT, SA]\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   NT -> [WA, SA, Q]\r\n"
+     "text": [
+      "   NT -> [WA, SA, Q]\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "   SA -> [WA, NT, Q, NSW, V]\r\n"
+     "text": [
+      "   SA -> [WA, NT, Q, NSW, V]\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "    Q -> [NT, SA, NSW]\r\n"
+     "text": [
+      "    Q -> [NT, SA, NSW]\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  NSW -> [Q, SA, V]\r\n"
+     "text": [
+      "  NSW -> [Q, SA, V]\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "    V -> [SA, NSW]\r\n"
+     "text": [
+      "    V -> [SA, NSW]\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "    T -> []\r\n"
+     "text": [
+      "    T -> []\r\n"
+     ]
     }
    ],
    "source": [
@@ -452,7 +494,7 @@
     "var australiaCSP = new CSP(australiaVars, australiaDomains,\n",
     "                           australiaNeighbors, differentColors);\n",
     "\n",
-    "Console.WriteLine(\"Probleme de coloration de l Australie\");\n",
+    "Console.WriteLine(\"Problème de coloration de l Australie\");\n",
     "Console.WriteLine(\"=============================================\");\n",
     "Console.WriteLine($\"Variables     : {string.Join(\", \", australiaVars)}\");\n",
     "Console.WriteLine($\"Taille dom.   : {australiaDomains[\"WA\"].Count} couleurs\");\n",
@@ -480,125 +522,199 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Graphe de contraintes - Australie (vue texte)\r\n"
+     "text": [
+      "Graphe de contraintes - Australie (vue texte)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=============================================\r\n"
+     "text": [
+      "=============================================\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                       NT  (deg 3 - Territoire du Nord)\r\n"
+     "text": [
+      "                       NT  (deg 3 - Territoire du Nord)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                      /|\\\r\n"
+     "text": [
+      "                      /|\\\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                     / | \\\r\n"
+     "text": [
+      "                     / | \\\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                    /  |  \\\r\n"
+     "text": [
+      "                    /  |  \\\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                   /   |   \\\r\n"
+     "text": [
+      "                   /   |   \\\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                 WA    |    Q  (deg 3 - Queensland)\r\n"
+     "text": [
+      "                 WA    |    Q  (deg 3 - Queensland)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                   \\   |   /\r\n"
+     "text": [
+      "                   \\   |   /\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                    \\  |  /\r\n"
+     "text": [
+      "                    \\  |  /\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                     \\ | /\r\n"
+     "text": [
+      "                     \\ | /\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                      SA  (deg 5 - noeud le plus contraint, hub)\r\n"
+     "text": [
+      "                      SA  (deg 5 - noeud le plus contraint, hub)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                     /|\\\r\n"
+     "text": [
+      "                     /|\\\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                    / | \\\r\n"
+     "text": [
+      "                    / | \\\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                   /  |  \\\r\n"
+     "text": [
+      "                   /  |  \\\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                  /   |   \\\r\n"
+     "text": [
+      "                  /   |   \\\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                NSW   |    V  (deg 2 - Victoria, au sud de NSW)\r\n"
+     "text": [
+      "                NSW   |    V  (deg 2 - Victoria, au sud de NSW)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                 |\r\n"
+     "text": [
+      "                 |\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "                 T  (deg 0 - Tasmanie, ile isolee au sud)\r\n"
+     "text": [
+      "                 T  (deg 0 - Tasmanie, ile isolee au sud)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Aretes : 9 paires de contraintes binaires (regions adjacentes != meme couleur)\r\n"
+     "text": [
+      "Arêtes : 9 paires de contraintes binaires (régions adjacentes != même couleur)\r\n"
+     ]
     }
    ],
-   "source": "// Visualisation ASCII du graphe de contraintes\n// (les notebooks C# du projet n utilisent pas matplotlib -- le CSP-7-Soft-Csharp\n//  montre que les viz se font en matrice couleur ou en texte structure)\n// Orientation AIMA-compatible : NT au nord, SA au centre (hub degre 5),\n// WA a l ouest, Q au nord-est, NSW a l est, V au sud-est (sous NSW),\n// T isolee au sud (ile de Tasmanie). Cette orientation reflete la geographic\n// reelle et la position relative des Etats (cf. notebook Python jumeau).\nConsole.WriteLine(\"Graphe de contraintes - Australie (vue texte)\");\nConsole.WriteLine(\"=============================================\");\nConsole.WriteLine();\nConsole.WriteLine(@\"                       NT  (deg 3 - Territoire du Nord)\");\nConsole.WriteLine(@\"                      /|\\\");\nConsole.WriteLine(@\"                     / | \\\");\nConsole.WriteLine(@\"                    /  |  \\\");\nConsole.WriteLine(@\"                   /   |   \\\");\nConsole.WriteLine(@\"                 WA    |    Q  (deg 3 - Queensland)\");\nConsole.WriteLine(@\"                   \\   |   /\");\nConsole.WriteLine(@\"                    \\  |  /\");\nConsole.WriteLine(@\"                     \\ | /\");\nConsole.WriteLine(@\"                      SA  (deg 5 - noeud le plus contraint, hub)\");\nConsole.WriteLine(@\"                     /|\\\");\nConsole.WriteLine(@\"                    / | \\\");\nConsole.WriteLine(@\"                   /  |  \\\");\nConsole.WriteLine(@\"                  /   |   \\\");\nConsole.WriteLine(@\"                NSW   |    V  (deg 2 - Victoria, au sud de NSW)\");\nConsole.WriteLine(@\"                 |\");\nConsole.WriteLine(@\"                 T  (deg 0 - Tasmanie, ile isolee au sud)\");\nConsole.WriteLine();\nConsole.WriteLine(\"Aretes : 9 paires de contraintes binaires (regions adjacentes != meme couleur)\");"
+   "source": [
+    "// Visualisation ASCII du graphe de contraintes\n",
+    "// (les notebooks C# du projet n utilisent pas matplotlib -- le CSP-7-Soft-Csharp\n",
+    "//  montre que les viz se font en matrice couleur ou en texte structure)\n",
+    "// Orientation AIMA-compatible : NT au nord, SA au centre (hub degré 5),\n",
+    "// WA à l ouest, Q au nord-est, NSW à l est, V au sud-est (sous NSW),\n",
+    "// T isolee au sud (ile de Tasmanie). Cette orientation reflete la geographic\n",
+    "// réelle et la position relative des États (cf. notebook Python jumeau).\n",
+    "Console.WriteLine(\"Graphe de contraintes - Australie (vue texte)\");\n",
+    "Console.WriteLine(\"=============================================\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(@\"                       NT  (deg 3 - Territoire du Nord)\");\n",
+    "Console.WriteLine(@\"                      /|\\\");\n",
+    "Console.WriteLine(@\"                     / | \\\");\n",
+    "Console.WriteLine(@\"                    /  |  \\\");\n",
+    "Console.WriteLine(@\"                   /   |   \\\");\n",
+    "Console.WriteLine(@\"                 WA    |    Q  (deg 3 - Queensland)\");\n",
+    "Console.WriteLine(@\"                   \\   |   /\");\n",
+    "Console.WriteLine(@\"                    \\  |  /\");\n",
+    "Console.WriteLine(@\"                     \\ | /\");\n",
+    "Console.WriteLine(@\"                      SA  (deg 5 - noeud le plus contraint, hub)\");\n",
+    "Console.WriteLine(@\"                     /|\\\");\n",
+    "Console.WriteLine(@\"                    / | \\\");\n",
+    "Console.WriteLine(@\"                   /  |  \\\");\n",
+    "Console.WriteLine(@\"                  /   |   \\\");\n",
+    "Console.WriteLine(@\"                NSW   |    V  (deg 2 - Victoria, au sud de NSW)\");\n",
+    "Console.WriteLine(@\"                 |\");\n",
+    "Console.WriteLine(@\"                 T  (deg 0 - Tasmanie, ile isolee au sud)\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine(\"Arêtes : 9 paires de contraintes binaires (régions adjacentes != même couleur)\");"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "72e0ef68",
    "metadata": {},
    "source": [
-    "**Interpretation** : le graphe de contraintes de l'Australie a 7 noeuds et 9 aretes. SA (Australie-Méridionale) est le noeud le plus contraint (5 voisins) -- c est lui qui elimine le plus de combinaisons. T (Tasmanie) est isolee : n importe quelle couleur lui convient.\n",
+    "**Interprétation** : le graphe de contraintes de l'Australie a 7 noeuds et 9 arêtes. SA (Australie-Méridionale) est le noeud le plus contraint (5 voisins) -- c est lui qui elimine le plus de combinaisons. T (Tasmanie) est isolee : n importe quelle couleur lui convient.\n",
     "\n",
-    "**Points cles** :\n",
-    "1. SA est adjacent a presque tous les etats continentaux : c est la variable la plus contrainte\n",
+    "**Points clés** :\n",
+    "1. SA est adjacent à presque tous les états continentaux : c est la variable la plus contrainte\n",
     "2. T (Tasmanie) n a aucune contrainte : n importe quelle couleur convient\n",
     "3. Le graphe n est pas complet : seules les paires adjacentes sont contraintes"
    ]
@@ -614,20 +730,20 @@
     "\n",
     "### Principe\n",
     "\n",
-    "Le **backtracking** est l algorithme de base pour resoudre un CSP :\n",
+    "Le **backtracking** est l algorithme de base pour résoudre un CSP :\n",
     "\n",
     "1. Choisir une variable non encore assignee\n",
     "2. Pour chaque valeur de son domaine :\n",
-    "   - Verifier la consistance avec l assignation partielle\n",
+    "   - Vérifier la consistance avec l assignation partielle\n",
     "   - Si consistant, assigner et recurser sur les variables restantes\n",
     "   - Sinon, essayer la valeur suivante\n",
-    "3. Si aucune valeur n est valable, **revenir en arriere** (backtrack)\n",
+    "3. Si aucune valeur n est valable, **revenir en arrière** (backtrack)\n",
     "\n",
     "### Différence avec DFS classique\n",
     "\n",
     "| Aspect | DFS classique | Backtracking CSP |\n",
     "|--------|--------------|------------------|\n",
-    "| Assignation | Complete d abord, verification ensuite | Verification **a chaque étape** |\n",
+    "| Assignation | Complète d abord, vérification ensuite | Vérification **à chaque étape** |\n",
     "| Elagage | Aucun | Elimination des branches inconsistantes |"
    ]
   },
@@ -647,32 +763,44 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Brute force - Coloration Australie\r\n"
+     "text": [
+      "Brute force - Coloration Australie\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=============================================\r\n"
+     "text": [
+      "=============================================\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Combinaisons testees  : 2187\r\n"
+     "text": [
+      "Combinaisons testees  : 2187\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Solutions trouvees    : 18\r\n"
+     "text": [
+      "Solutions trouvees    : 18\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Ratio solutions       : 0,82 %\r\n"
+     "text": [
+      "Ratio solutions       : 0,82 %\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Temps brute force     : 1,1 ms\r\n"
+     "text": [
+      "Temps brute force     : 0,9 ms\r\n"
+     ]
     }
    ],
    "source": [
@@ -741,32 +869,44 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Backtracking simple - Coloration Australie\r\n"
+     "text": [
+      "Backtracking simple - Coloration Australie\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=============================================\r\n"
+     "text": [
+      "=============================================\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Solution         : WA=Rouge, NT=Vert, SA=Bleu, Q=Rouge, NSW=Vert, V=Rouge, T=Rouge\r\n"
+     "text": [
+      "Solution         : WA=Rouge, NT=Vert, SA=Bleu, Q=Rouge, NSW=Vert, V=Rouge, T=Rouge\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Assignations     : ~11\r\n"
+     "text": [
+      "Assignations     : ~11\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Temps            : 0,43 ms\r\n"
+     "text": [
+      "Temps            : 0,49 ms\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Validation       : VALIDE\r\n"
+     "text": [
+      "Validation       : VALIDE\r\n"
+     ]
     }
    ],
    "source": [
@@ -806,7 +946,7 @@
     "    return -1;\n",
     "}\n",
     "\n",
-    "// Resolution et mesure\n",
+    "// Résolution et mesure\n",
     "australiaCSP.ResetCounter();\n",
     "var assignBF = new Dictionary<string, object>();\n",
     "var swBT = Stopwatch.StartNew();\n",
@@ -829,14 +969,14 @@
    "id": "f73333ce",
    "metadata": {},
    "source": [
-    "**Interpretation** : le backtracking C# trouve une solution en explorant beaucoup moins de combinaisons que la brute force.\n",
+    "**Interprétation** : le backtracking C# trouve une solution en explorant beaucoup moins de combinaisons que la brute force.\n",
     "\n",
     "| Méthode | Essais | Amelioration |\n",
     "|---------|--------|-------------|\n",
-    "| Brute force | 2187 | reference |\n",
+    "| Brute force | 2187 | référence |\n",
     "| Backtracking | ~7-15 | environ 200x moins |\n",
     "\n",
-    "**Pourquoi cette reduction ?** Le backtracking detecte les inconsistances des qu elles apparaissent. Si WA = Rouge et NT = Rouge, la contrainte `WA != NT` est violee immediatement : toutes les extensions de cette assignation partielle sont eliminees sans etre explorees.\n",
+    "**Pourquoi cette réduction ?** Le backtracking détecte les inconsistances dès qu elles apparaissent. Si WA = Rouge et NT = Rouge, la contrainte `WA != NT` est violee immédiatement : toutes les extensions de cette assignation partielle sont eliminees sans être explorees.\n",
     "\n",
     "> **Question** : peut-on faire encore mieux en choisissant plus intelligemment quelle variable assigner en premier et quelle valeur essayer ?"
    ]
@@ -859,7 +999,7 @@
     "\n",
     "**Principe** : choisir la variable qui a le **plus petit domaine restant** (le moins de valeurs viables).\n",
     "\n",
-    "**Intuition (\"fail-first\")** : si une variable n a que 2 valeurs possibles et une autre en a 10, mieux vaut traiter d abord celle a 2 valeurs. Si elle echoue, on le decouvre plus vite, et on elague un sous-arbre plus tot.\n",
+    "**Intuition (\"fail-first\")** : si une variable n a que 2 valeurs possibles et une autre en a 10, mieux vaut traiter d abord celle à 2 valeurs. Si elle échoue, on le découvre plus vite, et on élague un sous-arbre plus tôt.\n",
     "\n",
     "$\\text{MRV}(X_i) = |\\{v \\in D_i : v \\text{ est consistant avec l assignation courante}\\}|$"
    ]
@@ -880,12 +1020,14 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Heuristique MRV definie.\r\n"
+     "text": [
+      "Heuristique MRV définie.\r\n"
+     ]
     }
    ],
    "source": [
     "// Heuristique MRV : choisir la variable avec le moins de valeurs viables.\n",
-    "// En cas d'égalité, départage par degree (nombre de voisins non assignes, ordre decroissant).\n",
+    "// En cas d'égalité, départage par degree (nombre de voisins non assignés, ordre decroissant).\n",
     "string SelectMRV(CSP csp, Dictionary<string, object> assignment) {\n",
     "    var unassigned = csp.Variables.FindAll(v => !assignment.ContainsKey(v));\n",
     "    return unassigned\n",
@@ -894,7 +1036,7 @@
     "        .First();\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"Heuristique MRV definie.\");"
+    "Console.WriteLine(\"Heuristique MRV définie.\");"
    ]
   },
   {
@@ -925,51 +1067,69 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Assignation partielle : WA=Rouge, NT=Vert\r\n"
+     "text": [
+      "Assignation partielle : WA=Rouge, NT=Vert\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Variable Valeurs viables                    MRV   Deg\r\n"
+     "text": [
+      "Variable Valeurs viables                    MRV   Deg\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "-------------------------------------------------------\r\n"
+     "text": [
+      "-------------------------------------------------------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "SA       Bleu                                 1     3 <-- MRV\r\n"
+     "text": [
+      "SA       Bleu                                 1     3 <-- MRV\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Q        Rouge,Bleu                           2     2\r\n"
+     "text": [
+      "Q        Rouge,Bleu                           2     2\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "NSW      Rouge,Vert,Bleu                      3     3\r\n"
+     "text": [
+      "NSW      Rouge,Vert,Bleu                      3     3\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "V        Rouge,Vert,Bleu                      3     2\r\n"
+     "text": [
+      "V        Rouge,Vert,Bleu                      3     2\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "T        Rouge,Vert,Bleu                      3     0\r\n"
+     "text": [
+      "T        Rouge,Vert,Bleu                      3     0\r\n"
+     ]
     }
    ],
    "source": [
-    "// Demonstration du choix MRV apres quelques assignations\n",
+    "// Démonstration du choix MRV après quelques assignations\n",
     "var demoCSP = new CSP(australiaVars, australiaDomains, australiaNeighbors, differentColors);\n",
     "var partial = new Dictionary<string, object> { { \"WA\", \"Rouge\" }, { \"NT\", \"Vert\" } };\n",
     "\n",
@@ -994,12 +1154,12 @@
    "id": "c5p1tr4n",
    "metadata": {},
    "source": [
-    "**Interpretation** : MRV choisit **SA** (Southern Australia) parce qu'il ne lui reste qu'**une seule valeur viable** (`Bleu`) -- c'est la variable la plus contrainte du graphe. C'est le principe **fail-fast** : traiter en priorite la variable la plus susceptible de provoquer une impasse, afin de detecter l'echec tot dans l'arbre de recherche et d'eviter d'explorer de larges sous-arbres voues a l'echec.\n",
+    "**Interprétation** : MRV choisit **SA** (Southern Australia) parce qu'il ne lui reste qu'**une seule valeur viable** (`Bleu`) -- c'est la variable la plus contrainte du graphe. C'est le principe **fail-fast** : traiter en priorite la variable la plus susceptible de provoquer une impasse, afin de detecter l'échec tot dans l'arbre de recherche et d'éviter d'explorer de larges sous-arbres voués à l'échec.\n",
     "\n",
-    "- Au **tie-break** (plusieurs variables avec le même nombre de valeurs viables), le **degree heuristic** departage en choisissant celle qui a le plus de voisins non assignes --limiter ainsi la propagation future des contraintes.\n",
-    "- Sur ce petit graphe de coloration, l'effet de MRV reste modeste ; il devient decisif sur des CSP denses ou une variable presqu'entièrement determinee (`viables == 1`) dechoue immediatement si on la traite en dernier.\n",
+    "- Au **tie-break** (plusieurs variables avec le même nombre de valeurs viables), le **degree heuristic** départage en choisissant celle qui a le plus de voisins non assignés --limiter ainsi la propagation future des contraintes.\n",
+    "- Sur ce petit graphe de coloration, l'effet de MRV reste modeste ; il devient decisif sur des CSP denses ou une variable presqu'entièrement determinee (`viables == 1`) dechoue immédiatement si on la traite en dernier.\n",
     "\n",
-    "MRV repond a la **première** question (quel ordre de variables ?). Reste la **seconde** : parmi les valeurs viables d'une variable, **quel ordre essayer** ? C'est le rôle complementaire de **LCV (Least Constraining Value)** -- presente dans la cellule suivante."
+    "MRV répond à la **première** question (quel ordre de variables ?). Reste la **seconde** : parmi les valeurs viables d'une variable, **quel ordre essayer** ? C'est le rôle complémentaire de **LCV (Least Constraining Value)** -- présente dans la cellule suivante."
    ]
   },
   {
@@ -1024,7 +1184,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Heuristique LCV definie.\r\n"
+     "text": [
+      "Heuristique LCV définie.\r\n"
+     ]
     }
    ],
    "source": [
@@ -1046,7 +1208,7 @@
     "        .ToList();\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"Heuristique LCV definie.\");"
+    "Console.WriteLine(\"Heuristique LCV définie.\");"
    ]
   },
   {
@@ -1079,13 +1241,15 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Backtracking ameliore defini (variantes controlees par useMRV/useLCV booleens).\r\n"
+     "text": [
+      "Backtracking amélioré défini (variantes contrôlées par useMRV/useLCV booléens).\r\n"
+     ]
     }
    ],
    "source": [
-    "// Backtracking ameliore : MRV + LCV combines\n",
-    "// Note : en C#, les parametres ref doivent etre places apres les parametres optionnels\n",
-    "// (et apres tous les parametres requis). On utilise une fonction wrapping qui retourne\n",
+    "// Backtracking amélioré : MRV + LCV combines\n",
+    "// Note : en C#, les paramètres ref doivent être places après les paramètres optionnels\n",
+    "// (et après tous les paramètres requis). On utilise une fonction wrapping qui retourne\n",
     "// le compte via une closure (ref int via wrapper local).\n",
     "Dictionary<string, object> BacktrackImproved(CSP csp, Dictionary<string, object> assignment,\n",
     "                                              bool useMRV, bool useLCV) {\n",
@@ -1131,7 +1295,7 @@
     "    return count;\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"Backtracking ameliore defini (variantes controlees par useMRV/useLCV booleens).\");"
+    "Console.WriteLine(\"Backtracking amélioré défini (variantes contrôlées par useMRV/useLCV booléens).\");"
    ]
   },
   {
@@ -1165,37 +1329,51 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Comparaison des variantes - Coloration Australie\r\n"
+     "text": [
+      "Comparaison des variantes - Coloration Australie\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=======================================================\r\n"
+     "text": [
+      "=======================================================\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Variante               Assignations   Temps (ms)\r\n"
+     "text": [
+      "Variante               Assignations   Temps (ms)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "--------------------------------------------------\r\n"
+     "text": [
+      "--------------------------------------------------\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Backtracking simple             102         0,85\r\n"
+     "text": [
+      "Backtracking simple             102         0,79\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "+ MRV                           102         0,24\r\n"
+     "text": [
+      "+ MRV                           102         0,42\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "+ MRV + LCV                     102         0,93\r\n"
+     "text": [
+      "+ MRV + LCV                     102         0,79\r\n"
+     ]
     }
    ],
    "source": [
@@ -1231,20 +1409,20 @@
    "id": "f691a71f",
    "metadata": {},
    "source": [
-    "**Interpretation** : sur ce petit graphe, les heuristiques n amelioresent pas le compte d assignations.\n",
+    "**Interprétation** : sur ce petit graphe, les heuristiques n amelioresent pas le compte d assignations.\n",
     "\n",
     "| Variante | Assignations | Commentaire |\n",
     "|----------|-------------|-------------|\n",
     "| Backtracking simple | 102 | Ordre naif des variables et valeurs |\n",
-    "| + MRV | 102 | Meme arbre explore, aucun elagage |\n",
+    "| + MRV | 102 | Même arbre explore, aucun élagage |\n",
     "| + MRV + LCV | 102 | idem, LCV ne change rien au compte |\n",
     "\n",
-    "**Points cles** :\n",
+    "**Points clés** :\n",
     "1. Sur ce petit problème (7 variables, 3 couleurs, espace déjà très contraint), l ordre naif tombe déjà sur une solution ; les heuristiques n elaguent aucun noeud - l arbre de recherche est identique (102 noeuds pour les trois variantes)\n",
     "2. L effet des heuristiques est **instance-dependant** : nul sur une instance facile, il devient dramatique sur des instances plus dures (cf. les 8-Reines ci-dessous : 876 -> 572 avec MRV)\n",
     "3. Conclusion honnete : aucune heuristique n est monotonement benefique, il faut mesurer et non presupposer une amelioration\n",
     "\n",
-    "> **Règle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais sur une instance facile comme la coloration de l'Australie, l arbre de recherche est si petit que les heuristiques n ont rien a elaguer."
+    "> **Règle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais sur une instance facile comme la coloration de l'Australie, l arbre de recherche est si petit que les heuristiques n ont rien à élaguer."
    ]
   },
   {
@@ -1256,17 +1434,17 @@
     "\n",
     "## 6. Solveur SOTA : Choco-solver 4.10.17 (~10 min)\n",
     "\n",
-    "Jusqu ici nous avons tout implemente a la main en C#. En pratique, on utilise un **solveur CSP optimise** comme **Choco-solver 4.10.17** (open-source, leader en recherche operationnelle).\n",
+    "Jusqu ici nous avons tout implémenté à la main en C#. En pratique, on utilise un **solveur CSP optimisé** comme **Choco-solver 4.10.17** (open-source, leader en recherche operationnelle).\n",
     "\n",
     "### Pourquoi Choco-solver ?\n",
     "\n",
-    "- **Solveur SOTA** : Choco-solver est un solveur CSP open-source de reference en Java, maintenu par l équipe CHOCTeam (labo TASC INRIA, Nantes)\n",
+    "- **Solveur SOTA** : Choco-solver est un solveur CSP open-source de référence en Java, maintenu par l équipe CHOCTeam (labo TASC INRIA, Nantes)\n",
     "- **Solveur complet + optimisation** : backtracking avec propagation de contraintes, heuristiques integrees (MRV, LCV, impact-based, ...)\n",
     "- **API Java exposee via IKVM** : toutes les classes Java (`Model`, `IntVar`, `IntConstraintFactory`, ...) sont accessibles directement depuis C#\n",
     "\n",
     "### Installation\n",
     "\n",
-    "Pas d installation requise ici : la DLL Choco 4.10.17 est pre-compilee dans le dossier Part2-CSP, et IKVM 8.15.0 est charge a la volee via NuGet au debut du notebook."
+    "Pas d installation requise ici : la DLL Choco 4.10.17 est pré-compilée dans le dossier Part2-CSP, et IKVM 8.15.0 est chargé à la volée via NuGet au debut du notebook."
    ]
   },
   {
@@ -1285,83 +1463,107 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Choco-solver - Coloration Australie\r\n"
+     "text": [
+      "Choco-solver - Coloration Australie\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "=============================================\r\n"
+     "text": [
+      "=============================================\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Solution : {\r\n"
+     "text": [
+      "Solution : {\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  WA   = Rouge (0)\r\n"
+     "text": [
+      "  WA   = Rouge (0)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  NT   = Vert (1)\r\n"
+     "text": [
+      "  NT   = Vert (1)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  SA   = Bleu (2)\r\n"
+     "text": [
+      "  SA   = Bleu (2)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Q    = Rouge (0)\r\n"
+     "text": [
+      "  Q    = Rouge (0)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  NSW  = Vert (1)\r\n"
+     "text": [
+      "  NSW  = Vert (1)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  V    = Rouge (0)\r\n"
+     "text": [
+      "  V    = Rouge (0)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  T    = Rouge (0)\r\n"
+     "text": [
+      "  T    = Rouge (0)\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "}\r\n"
+     "text": [
+      "}\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Temps    : 63,82 ms\r\n"
+     "text": [
+      "Temps    : 51,22 ms\r\n"
+     ]
     }
    ],
    "source": [
     "// Coloration de l'Australie avec Choco-solver 4.10.17\n",
-    "// Comparaison directe avec notre implementation manuelle\n",
+    "// Comparaison directe avec notre implémentation manuelle\n",
     "var chocModel = new Model(\"Coloration Australie - Choco 4.10.17\");\n",
     "\n",
-    "// Variables : IntVar par etat, domaine [0..2]\n",
+    "// Variables : IntVar par état, domaine [0..2]\n",
     "var chocVars = new Dictionary<string, IntVar>();\n",
     "foreach (var v in australiaVars) {\n",
     "    chocVars[v] = chocModel.intVar(v, 0, 2);\n",
     "}\n",
     "\n",
-    "// Contraintes : regions adjacentes differentes\n",
+    "// Contraintes : régions adjacentes différentes\n",
     "foreach (var v1 in australiaVars) {\n",
     "    foreach (var v2 in australiaNeighbors[v1]) {\n",
     "        chocModel.arithm(chocVars[v1], \"!=\", chocVars[v2]).post();\n",
     "    }\n",
     "}\n",
     "\n",
-    "// Resolution : Choco 4.10.17 utilise solver.solve() (retourne bool), pas findSolution()\n",
+    "// Résolution : Choco 4.10.17 utilise solver.solve() (retourne bool), pas findSolution()\n",
     "var chocSolver = chocModel.getSolver();\n",
     "var swChoco = Stopwatch.StartNew();\n",
     "bool chocOk = chocSolver.solve();\n",
@@ -1388,19 +1590,19 @@
    "id": "d2d3ac0d",
    "metadata": {},
    "source": [
-    "**Interpretation** : Choco-solver resout la coloration de l'Australie en un temps mesuré en sortie au premier appel, puis beaucoup plus rapidement une fois la JVM chaude (cf. enumeration cellule suivante). Le premier appel paie le demarrage de la JVM Java (IKVM) sous-jacente ; en regime etabli, le coeur metier (propagation + backtracking) est quasi-instantane (runtime *machine-dep*, cf. la mesure en sortie de la cellule suivante).\n",
+    "**Interprétation** : Choco-solver résout la coloration de l'Australie en un temps mesuré en sortie au premier appel, puis beaucoup plus rapidement une fois la JVM chaude (cf. énumération cellule suivante). Le premier appel paie le demarrage de la JVM Java (IKVM) sous-jacente ; en regime etabli, le coeur metier (propagation + backtracking) est quasi-instantane (runtime *machine-dep*, cf. la mesure en sortie de la cellule suivante).\n",
     "\n",
     "| Aspect | Implementation manuelle C# | Choco-solver 4.10.17 |\n",
     "|--------|---------------------------|----------------------|\n",
-    "| Lignes de modelisation | ~50 (classe CSP + voisins) | ~10 |\n",
-    "| Heuristiques integrees | A implementer | MRV, LCV, impact-based, ... |\n",
-    "| Propagation de contraintes | Non (verification a chaque appel) | AC-3 integre |\n",
+    "| Lignes de modélisation | ~50 (classe CSP + voisins) | ~10 |\n",
+    "| Heuristiques integrees | A implémenter | MRV, LCV, impact-based, ... |\n",
+    "| Propagation de contraintes | Non (vérification à chaque appel) | AC-3 intégré |\n",
     "| Solveur SOTA | Non (brute force / backtracking) | **Oui** (publication CHOCTeam 2008-2024) |\n",
     "\n",
-    "**Points cles** :\n",
-    "1. L API Choco est **declarative** : on declare variables + contraintes, le solveur fait le reste\n",
-    "2. `model.arithm(v1, \"!=\", v2).post()` est l equivalent exact de notre `Consistent(var, val, assignment)`\n",
-    "3. `solver.solve()` integre backtracking + heuristiques + propagation (retourne `bool` ; la solution est accessible via `var.getValue()`)"
+    "**Points clés** :\n",
+    "1. L API Choco est **déclarative** : on declare variables + contraintes, le solveur fait le reste\n",
+    "2. `model.arithm(v1, \"!=\", v2).post()` est l équivalent exact de notre `Consistent(var, val, assignment)`\n",
+    "3. `solver.solve()` intègre backtracking + heuristiques + propagation (retourne `bool` ; la solution est accessible via `var.getValue()`)"
    ]
   },
   {
@@ -1419,53 +1621,71 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Nombre total de solutions : 18\r\n"
+     "text": [
+      "Nombre total de solutions : 18\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Temps enumeration          : 2,94 ms\r\n"
+     "text": [
+      "Temps énumération          : 6,53 ms\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Premieres 5 solutions :\r\n"
+     "text": [
+      "Premières 5 solutions :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Solution 1 : { WA=Rouge, NT=Vert, SA=Bleu, Q=Rouge, NSW=Vert, V=Rouge, T=Rouge }\r\n"
+     "text": [
+      "  Solution 1 : { WA=Rouge, NT=Vert, SA=Bleu, Q=Rouge, NSW=Vert, V=Rouge, T=Rouge }\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Solution 2 : { WA=Rouge, NT=Vert, SA=Bleu, Q=Rouge, NSW=Vert, V=Rouge, T=Vert }\r\n"
+     "text": [
+      "  Solution 2 : { WA=Rouge, NT=Vert, SA=Bleu, Q=Rouge, NSW=Vert, V=Rouge, T=Vert }\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Solution 3 : { WA=Rouge, NT=Vert, SA=Bleu, Q=Rouge, NSW=Vert, V=Rouge, T=Bleu }\r\n"
+     "text": [
+      "  Solution 3 : { WA=Rouge, NT=Vert, SA=Bleu, Q=Rouge, NSW=Vert, V=Rouge, T=Bleu }\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Solution 4 : { WA=Rouge, NT=Bleu, SA=Vert, Q=Rouge, NSW=Bleu, V=Rouge, T=Rouge }\r\n"
+     "text": [
+      "  Solution 4 : { WA=Rouge, NT=Bleu, SA=Vert, Q=Rouge, NSW=Bleu, V=Rouge, T=Rouge }\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Solution 5 : { WA=Rouge, NT=Bleu, SA=Vert, Q=Rouge, NSW=Bleu, V=Rouge, T=Vert }\r\n"
+     "text": [
+      "  Solution 5 : { WA=Rouge, NT=Bleu, SA=Vert, Q=Rouge, NSW=Bleu, V=Rouge, T=Vert }\r\n"
+     ]
     }
    ],
    "source": [
     "// Enumeration de TOUTES les solutions avec Choco (record & enumerate)\n",
     "// Equivalent du getSolutions() de python-constraint\n",
-    "var chocModel2 = new Model(\"Coloration Australie - enumeration\");\n",
+    "var chocModel2 = new Model(\"Coloration Australie - énumération\");\n",
     "var chocVars2 = new Dictionary<string, IntVar>();\n",
     "foreach (var v in australiaVars) {\n",
     "    chocVars2[v] = chocModel2.intVar(v, 0, 2);\n",
@@ -1477,7 +1697,7 @@
     "}\n",
     "\n",
     "var swEnum = Stopwatch.StartNew();\n",
-    "// Choco 4.10.17 : enumeration via boucle while solve()\n",
+    "// Choco 4.10.17 : énumération via boucle while solve()\n",
     "var enumSolver = chocModel2.getSolver();\n",
     "int totalSolutions = 0;\n",
     "var firstSolutions = new List<Dictionary<string, int>>();\n",
@@ -1490,9 +1710,9 @@
     "swEnum.Stop();\n",
     "\n",
     "Console.WriteLine($\"Nombre total de solutions : {totalSolutions}\");\n",
-    "Console.WriteLine($\"Temps enumeration          : {swEnum.Elapsed.TotalMilliseconds:F2} ms\");\n",
+    "Console.WriteLine($\"Temps énumération          : {swEnum.Elapsed.TotalMilliseconds:F2} ms\");\n",
     "Console.WriteLine();\n",
-    "Console.WriteLine(\"Premieres 5 solutions :\");\n",
+    "Console.WriteLine(\"Premières 5 solutions :\");\n",
     "int k = 0;\n",
     "foreach (var sol in firstSolutions) {\n",
     "    var dict = new List<string>();\n",
@@ -1507,15 +1727,15 @@
    "id": "c7271b01",
    "metadata": {},
    "source": [
-    "**Interpretation** : Choco enumere les 18 solutions valides (comme la brute force, mais avec propagation de contraintes en interne).\n",
+    "**Interprétation** : Choco énumère les 18 solutions valides (comme la brute force, mais avec propagation de contraintes en interne).\n",
     "\n",
     "| Aspect | Brute force Python | Choco `findAllSolutions()` |\n",
     "|--------|-------------------|---------------------------|\n",
     "| Combinaisons testees | 2187 | Reduit (propagation AC-3) |\n",
     "| Solutions | 18 | 18 |\n",
-    "| Temps | *machine-dep* (cf. cellule de mesure brute force) | *machine-dep* (mesure en sortie de la cellule precedente) |\n",
+    "| Temps | *machine-dep* (cf. cellule de mesure brute force) | *machine-dep* (mesure en sortie de la cellule précédente) |\n",
     "\n",
-    "**Pourquoi 18 solutions ?** Les couleurs Rouge/Vert/Bleu sont interchangeables (symetrie de permutation). Sans sym-breaking explicite, Choco enumere toutes les solutions symetriques. Pour une problematique de coloration \"recherche d une solution\", `solver.solve()` (qui retourne `true`/`false`) suffit."
+    "**Pourquoi 18 solutions ?** Les couleurs Rouge/Vert/Bleu sont interchangeables (symétrie de permutation). Sans sym-breaking explicite, Choco énumère toutes les solutions symetriques. Pour une problematique de coloration \"recherche d une solution\", `solver.solve()` (qui retourne `true`/`false`) suffit."
    ]
   },
   {
@@ -1523,9 +1743,9 @@
    "id": "7c5476d1",
    "metadata": {},
    "source": [
-    "### 6.1 Demonstration SOTA : N-Reines avec Choco\n",
+    "### 6.1 Démonstration SOTA : N-Reines avec Choco\n",
     "\n",
-    "Pour montrer l apport de Choco sur une instance **dure**, resolvez les **8-Reines** (placer 8 reines sur un echiquier sans qu aucune ne s attaque). Notre implementation manuelle a necessite ~876 assignations pour les 8-Reines. Choco devrait faire mieux grace a ses heuristiques internes et la propagation de contraintes."
+    "Pour montrer l apport de Choco sur une instance **dure**, résolvez les **8-Reines** (placer 8 reines sur un échiquier sans qu aucune ne s attaque). Notre implémentation manuelle a nécessité ~876 assignations pour les 8-Reines. Choco devrait faire mieux grâce à ses heuristiques internes et la propagation de contraintes."
    ]
   },
   {
@@ -1544,73 +1764,99 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Solution 8-Reines :\r\n"
+     "text": [
+      "Solution 8-Reines :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  (col -> ligne) : 0->7, 1->5, 2->2, 3->4, 4->6, 5->0, 6->3, 7->1\r\n"
+     "text": [
+      "  (col -> ligne) : 0->7, 1->5, 2->2, 3->4, 4->6, 5->0, 6->3, 7->1\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Temps            : 46,24 ms\r\n"
+     "text": [
+      "Temps            : 75,38 ms\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\r\n"
+     "text": [
+      "\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Echiquier (Q = reine) :\r\n"
+     "text": [
+      "Echiquier (Q = reine) :\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Ligne 7 |  Q  .  .  .  .  .  .  . \r\n"
+     "text": [
+      "  Ligne 7 |  Q  .  .  .  .  .  .  . \r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Ligne 6 |  .  .  .  .  Q  .  .  . \r\n"
+     "text": [
+      "  Ligne 6 |  .  .  .  .  Q  .  .  . \r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Ligne 5 |  .  Q  .  .  .  .  .  . \r\n"
+     "text": [
+      "  Ligne 5 |  .  Q  .  .  .  .  .  . \r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Ligne 4 |  .  .  .  Q  .  .  .  . \r\n"
+     "text": [
+      "  Ligne 4 |  .  .  .  Q  .  .  .  . \r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Ligne 3 |  .  .  .  .  .  .  Q  . \r\n"
+     "text": [
+      "  Ligne 3 |  .  .  .  .  .  .  Q  . \r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Ligne 2 |  .  .  Q  .  .  .  .  . \r\n"
+     "text": [
+      "  Ligne 2 |  .  .  Q  .  .  .  .  . \r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Ligne 1 |  .  .  .  .  .  .  .  Q \r\n"
+     "text": [
+      "  Ligne 1 |  .  .  .  .  .  .  .  Q \r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Ligne 0 |  .  .  .  .  .  Q  .  . \r\n"
+     "text": [
+      "  Ligne 0 |  .  .  .  .  .  Q  .  . \r\n"
+     ]
     }
    ],
    "source": [
     "// 8-Reines avec Choco-solver\n",
     "// Variables : une par colonne (0..7), domaine 0..7 (ligne)\n",
-    "// Contraintes : pas meme ligne, pas meme diagonale\n",
+    "// Contraintes : pas même ligne, pas même diagonale\n",
     "int n = 8;\n",
     "var queenModel = new Model($\"N-Reines (n={n})\");\n",
     "var queens = new IntVar[n];\n",
@@ -1619,10 +1865,10 @@
     "    queens[c] = queenModel.intVar(c.ToString(), 0, n - 1);\n",
     "}\n",
     "\n",
-    "// AllDifferent : toutes les lignes differentes (1 seule reine par ligne)\n",
+    "// AllDifferent : toutes les lignes différentes (1 seule reine par ligne)\n",
     "queenModel.allDifferent(queens).post();\n",
     "\n",
-    "// Diagonales : pour chaque paire (i,j), creer une IntVar auxiliaire pour la diff/somme,\n",
+    "// Diagonales : pour chaque paire (i,j), créer une IntVar auxiliaire pour la diff/somme,\n",
     "// puis la comparer à la constante. Choco 4.10.17 surcharge `arithm(IntVar,String,IntVar,String,IntVar)`\n",
     "// pas forcement portee par l'IKVM Java->.NET ; on utilise des contraintes separees qui sont\n",
     "// bien supportees : arithm(var, \"op\", var) + arithm(IntVarResult, \"op\", int).\n",
@@ -1671,21 +1917,21 @@
    "id": "4bdd51fe",
    "metadata": {},
    "source": [
-    "**Interpretation** : Choco-solver resout les 8-Reines quasi-instantanement (runtime *machine-dep*, temps mesure en sortie de la cellule precedente).\n",
+    "**Interprétation** : Choco-solver résout les 8-Reines quasi-instantanément (runtime *machine-dep*, temps mesure en sortie de la cellule précédente).\n",
     "\n",
     "| Mesure | Implementation manuelle | Choco-solver |\n",
     "|--------|------------------------|--------------|\n",
     "| Assignations | ~876 | non expose mais << 876 (propagation + heuristiques) |\n",
-    "| Code de modelisation | ~30 lignes (classe CSP + contraintes) | ~10 lignes |\n",
+    "| Code de modélisation | ~30 lignes (classe CSP + contraintes) | ~10 lignes |\n",
     "| Heuristiques | A choisir (MRV, LCV) | Integree (impact-based par defaut) |\n",
-    "| Propagation | Non (verification manuelle) | AC-3 integree |\n",
+    "| Propagation | Non (vérification manuelle) | AC-3 intégrée |\n",
     "\n",
-    "**Points cles** :\n",
-    "1. Choco integre nativement **propagation de contraintes (AC-3)** + **heuristiques avancees** (impact-based, ABS, ...)\n",
+    "**Points clés** :\n",
+    "1. Choco intègre nativement **propagation de contraintes (AC-3)** + **heuristiques avancees** (impact-based, ABS, ...)\n",
     "2. Le code est plus court (~10 lignes vs ~30) et plus expressif\n",
-    "3. Sur des instances plus grandes (16-Reines, 32-Reines), Choco resout ou detecte l infaisabilite alors qu une implementation manuelle brute-force explose\n",
+    "3. Sur des instances plus grandes (16-Reines, 32-Reines), Choco résout ou détecte l infaisabilité alors qu une implémentation manuelle brute-force explose\n",
     "\n",
-    "> **Règle pratique** : pour des problemes reels (N > 20 variables), utiliser Choco. Pour apprendre les mécanismes, l implementation manuelle reste pedagogique."
+    "> **Règle pratique** : pour des problemes réels (N > 20 variables), utiliser Choco. Pour apprendre les mécanismes, l implémentation manuelle reste pédagogique."
    ]
   },
   {
@@ -1695,11 +1941,12 @@
    "source": [
     "### 6.2 Contrainte globale : `AllDifferent` avec Choco\n",
     "\n",
-    "La cellule 6.1 ci-dessus utilise deja `queenModel.allDifferent(queens).post()` -- une **contrainte globale** imposee a un tableau de 8 variables : toutes les lignes doivent etre distinctes (1 seule reine par ligne). Cette section isole cette contrainte pour bien montrer **son pouvoir d'elagage** et la comparer a une modelisation binaire `q[i] != q[j]` (6 contre 1).\n",
+    "La cellule 6.1 ci-dessus utilise déjà `queenModel.allDifferent(queens).post()` -- une **contrainte globale** imposée à un tableau de 8 variables : toutes les lignes doivent être distinctes (1 seule reine par ligne). Cette section isole cette contrainte pour bien montrer **son pouvoir d'élagage** et la comparer à une modélisation binaire `q[i] != q[j]` (6 contre 1).\n",
     "\n",
-    "**Pourquoi \"globale\" ?** Au lieu de coder $O(n^2)$ contraintes binaires `xi != xj` (qui laissent le solveur explorer tout l'espace par backtracking), `allDifferent` est traitee comme **une seule contrainte** par Choco via une **structure de couplage** (matching biparti, complexite $O(n\\sqrt{n})$ -- cf. [Regin 1994, *A Filtering Algorithm for Constraints of Difference in CSPs*, JAIR](https://www.jair.org/index.php/jair/article/view/10357)). Sur 4 variables de domaine `{1..4}`, le nombre de solutions tombe directement a $4! = 24$ **sans aucun backtracking** sur cette contrainte.\n",
+    "**Pourquoi \"globale\" ?** Au lieu de coder $O(n^2)$ contraintes binaires `xi != xj` (qui laissent le solveur explorer tout l'espace par backtracking), `allDifferent` est traitée comme **une seule contrainte** par Choco via une **structure de couplage** (matching biparti, complexité $O(n\\sqrt{n})$ -- cf. [Regin 1994, *A Filtering Algorithm for Constraints of Difference in CSPs*, JAIR](https://www.jair.org/index.php/jair/article/view/10357)). Sur 4 variables de domaine `{1..4}`, le nombre de solutions tombe directement à $4! = 24$ **sans aucun backtracking** sur cette contrainte.\n",
     "\n",
-    "**Parite pedagogique avec le twin Python** : la jumeau Python ([CSP-1-Fundamentals.ipynb, section *AllDifferentConstraint*](CSP-1-Fundamentals.ipynb)) utilise la bibliotheque `python-constraint` et expose la meme contrainte via `Problem.addConstraint(AllDifferentConstraint(), variables)`. La formulation Choco est plus declarative (un seul appel) et integree au solveur ; la formulation Python est plus pedagogique (le construteur `AllDifferentConstraint` est explicite, on voit comment il s'instancie). Meme concept, deux implementations SOTA.\n"
+    "**Parité pédagogique avec le twin Python** : la jumeau Python ([CSP-1-Fundamentals.ipynb, section *AllDifferentConstraint*](CSP-1-Fundamentals.ipynb)) utilise la bibliothèque `python-constraint` et expose la même contrainte via `Problem.addConstraint(AllDifferentConstraint(), variables)`. La formulation Choco est plus déclarative (un seul appel) et intégrée au solveur ; la formulation Python est plus pédagogique (le constructeur `AllDifferentConstraint` est explicite, on voit comment il s'instancie). Même concept, deux implémentations SOTA.\n",
+    ""
    ]
   },
   {
@@ -1710,14 +1957,14 @@
     "**Exemple illustratif** -- `allDifferent` sur 4 variables `{A, B, C, D}` de domaine `{1, 2, 3, 4}` (les **24 permutations**) :\n",
     "\n",
     "```csharp\n",
-    "// Modele jouet : 4 variables, domaine [1..4], toutes differentes\n",
+    "// Modèle jouet : 4 variables, domaine [1..4], toutes différentes\n",
     "var adModel = new Model(\"AllDifferent demo - 4 vars\");\n",
     "var letters = new[] { \"A\", \"B\", \"C\", \"D\" };\n",
     "var adVars = new Dictionary<string, IntVar>();\n",
     "foreach (var name in letters)\n",
     "    adVars[name] = adModel.intVar(name, 1, 4);\n",
     "\n",
-    "// Contrainte globale : matching biparti integre (pas de backtracking sur cette contrainte)\n",
+    "// Contrainte globale : matching biparti intégré (pas de backtracking sur cette contrainte)\n",
     "adModel.allDifferent(adVars.Values.ToArray()).post();\n",
     "\n",
     "// Enumeration de TOUTES les solutions (pattern Choco 4.10.17 solve() en boucle)\n",
@@ -1731,23 +1978,24 @@
     "Console.WriteLine($\"Nombre de solutions : {solutionCount}  (= 4! = 24)\");\n",
     "```\n",
     "\n",
-    "Sortie attendue : `24` lignes de la forme `A=1, B=2, C=3, D=4` ... `A=4, B=3, C=2, D=1` (toutes les permutations de `{1,2,3,4}`). Pour la runnable end-to-end, voir le twin Python ([CSP-1-Fundamentals.ipynb, cellule *Demonstration AllDifferentConstraint*](CSP-1-Fundamentals.ipynb)) qui utilise `python-constraint` (meme resultat : $4! = 24$ solutions).\n",
+    "Sortie attendue : `24` lignes de la forme `A=1, B=2, C=3, D=4` ... `A=4, B=3, C=2, D=1` (toutes les permutations de `{1,2,3,4}`). Pour la runnable end-to-end, voir le twin Python ([CSP-1-Fundamentals.ipynb, cellule *Démonstration AllDifferentConstraint*](CSP-1-Fundamentals.ipynb)) qui utilise `python-constraint` (même résultat : $4! = 24$ solutions).\n",
     "\n",
     "| Aspect | `xi != xj` binaires (pairwise) | `allDifferent` global |\n",
     "|--------|--------------------------------|------------------------|\n",
     "| Contraintes posee | 6 (`!=`) | 1 (globale) |\n",
-    "| Propagation | Verification a chaque assignation | Filtrage par matching biparti |\n",
+    "| Propagation | Vérification à chaque assignation | Filtrage par matching biparti |\n",
     "| Backtracking sur cette contrainte | oui (n! explorations) | non (0 backtracking sur 4 vars) |\n",
     "| Memoire | Aucune | Table de couplage $O(n^2)$ |\n",
     "| Complexite pire cas | $O(n!)$ | $O(n\\sqrt{n})$ (matching) |\n",
     "\n",
-    "**Points cles** :\n",
+    "**Points clés** :\n",
     "\n",
-    "1. `allDifferent` est la facon idiomatique de declarer une \"toutes differentes\" en Choco -- toujours preferer cette formulation aux contraintes binaires equivalentes\n",
-    "2. Sudoku (lignes/colonnes/blocs), N-Reines (lignes), coloration equitable, planning de personnel, ordre de passage : c'est la **premiere contrainte globale** a apprendre\n",
+    "1. `allDifferent` est la façon idiomatique de déclarer une \"toutes différentes\" en Choco -- toujours préférer cette formulation aux contraintes binaires équivalentes\n",
+    "2. Sudoku (lignes/colonnes/blocs), N-Reines (lignes), coloration équitable, planning de personnel, ordre de passage : c'est la **première contrainte globale** à apprendre\n",
     "3. Choco expose aussi `model.allDifferentExcept` (relaxation avec liste d'exceptions) -- utile pour les variantes pedagogiques\n",
     "\n",
-    "> **Reference** : Choco-solver 4.10.17 documentation, [section Global Constraints](https://choco-solver.org/2021/04/08/global-constraints/) ; implementation par matching biparti (cf. Regin 1994, *A Filtering Algorithm for Constraints of Difference in CSPs*, J. Artif. Intell. Res. 1).\n"
+    "> **Référence** : Choco-solver 4.10.17 documentation, [section Global Constraints](https://choco-solver.org/2021/04/08/global-constraints/) ; implémentation par matching biparti (cf. Regin 1994, *A Filtering Algorithm for Constraints of Difference in CSPs*, J. Artif. Intell. Res. 1).\n",
+    ""
    ]
   },
   {
@@ -1764,21 +2012,21 @@
     "| Approche | Noeuds explores | Temps | Facilité d utilisation |\n",
     "|----------|----------------|-------|------------------------|\n",
     "| Brute force | $\\prod \\vert D_i\\vert$ (tous) | Lent | Simple mais intraitable |\n",
-    "| Backtracking simple C# | Reduit (elagage) | Rapide | Implementation moderee |\n",
-    "| Backtracking + MRV | Très reduit | Très rapide | Implementation moderee |\n",
-    "| Backtracking + MRV + LCV | Minimal | Très rapide | Plus complexe a implementer |\n",
-    "| **Choco-solver 4.10.17** | **Optimal (propagation AC-3)** | **Très rapide** | **API declarative** |\n",
+    "| Backtracking simple C# | Reduit (élagage) | Rapide | Implementation modérée |\n",
+    "| Backtracking + MRV | Très réduit | Très rapide | Implementation modérée |\n",
+    "| Backtracking + MRV + LCV | Minimal | Très rapide | Plus complexe à implémenter |\n",
+    "| **Choco-solver 4.10.17** | **Optimal (propagation AC-3)** | **Très rapide** | **API déclarative** |\n",
     "\n",
-    "### Concepts cles a retenir\n",
+    "### Concepts clés à retenir\n",
     "\n",
-    "| Concept | Definition | Implementation |\n",
+    "| Concept | Définition | Implementation |\n",
     "|---------|------------|----------------|\n",
-    "| **Variable** ($X_i$) | Quantite a determiner | `IntVar` (Choco) / `string` (manuel) |\n",
+    "| **Variable** ($X_i$) | Quantité à déterminer | `IntVar` (Choco) / `string` (manuel) |\n",
     "| **Domaine** ($D_i$) | Valeurs possibles pour $X_i$ | `intVar(name, min, max)` (Choco) / `List<object>` (manuel) |\n",
     "| **Contrainte** ($C_k$) | Restriction sur sous-ensemble | `arithm(!=).post()` (Choco) / `ConstraintFunc` (manuel) |\n",
     "| **Solution** | Assignation complete et consistante | `solver.solve()` (Choco) / `IsSolution()` (manuel) |\n",
-    "| **MRV** | Variable au domaine le plus restreint | `SelectMRV()` (manuel) / integre Choco |\n",
-    "| **LCV** | Valeur la moins contraignante | `OrderLCV()` (manuel) / integre Choco |"
+    "| **MRV** | Variable au domaine le plus restreint | `SelectMRV()` (manuel) / intégré Choco |\n",
+    "| **LCV** | Valeur la moins contraignante | `OrderLCV()` (manuel) / intégré Choco |"
    ]
   },
   {
@@ -1788,9 +2036,9 @@
    "source": [
     "### Exercice 1 : 4-Reines avec backtracking manuel C#\n",
     "\n",
-    "**Enonce** : modelisez et resolvez le problème des 4-Reines avec votre propre implementation C# (classe `CSP` + `BacktrackImproved` avec MRV + LCV). Affichez la solution comme une matrice 4x4 avec un caractère `Q` pour les reines et un `.` pour les cases vides.\n",
+    "**Énoncé** : modélisez et résolvez le problème des 4-Reines avec votre propre implémentation C# (classe `CSP` + `BacktrackImproved` avec MRV + LCV). Affichez la solution comme une matrice 4x4 avec un caractère `Q` pour les reines et un `.` pour les cases vides.\n",
     "\n",
-    "**Indice** : la modelisation est la même que pour les 8-Reines Choco de la section 6.1, mais vous devez utiliser votre propre classe `CSP`. La contrainte est : deux reines ne peuvent pas etre sur la même ligne, colonne ou diagonale. Les variables sont les colonnes, le domaine est l ensemble des lignes {0, 1, 2, 3}.\n",
+    "**Indice** : la modélisation est la même que pour les 8-Reines Choco de la section 6.1, mais vous devez utiliser votre propre classe `CSP`. La contrainte est : deux reines ne peuvent pas être sur la même ligne, colonne ou diagonale. Les variables sont les colonnes, le domaine est l ensemble des lignes {0, 1, 2, 3}.\n",
     "\n",
     "**Sortie attendue** : 2 solutions symetriques (l une est le miroir de l autre)."
    ]
@@ -1811,23 +2059,27 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice a completer : 4-Reines avec backtracking manuel C#\r\n"
+     "text": [
+      "Exercice à compléter : 4-Reines avec backtracking manuel C#\r\n"
+     ]
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Solution attendue : 2 solutions symetriques.\r\n"
+     "text": [
+      "Solution attendue : 2 solutions symetriques.\r\n"
+     ]
     }
    ],
    "source": [
     "// Exercice 1 : 4-Reines avec backtracking manuel C#\n",
     "// A COMPLETER par l'étudiant\n",
-    "// Indice : utilisez la classe CSP et BacktrackImproved definies plus haut.\n",
+    "// Indice : utilisez la classe CSP et BacktrackImproved définies plus haut.\n",
     "// Modelisation : 4 variables (colonnes), domaine {0,1,2,3} (lignes),\n",
     "// contrainte = reine sur (c1, r1) et (c2, r2) ne s attaquent pas.\n",
-    "// Conditions : r1 != r2 (meme ligne) ET |c1-c2| != |r1-r2| (meme diagonale).\n",
+    "// Conditions : r1 != r2 (même ligne) ET |c1-c2| != |r1-r2| (même diagonale).\n",
     "\n",
-    "Console.WriteLine(\"Exercice a completer : 4-Reines avec backtracking manuel C#\");\n",
+    "Console.WriteLine(\"Exercice à compléter : 4-Reines avec backtracking manuel C#\");\n",
     "Console.WriteLine(\"Solution attendue : 2 solutions symetriques.\");"
    ]
   },
@@ -1838,7 +2090,7 @@
    "source": [
     "### Exercice 2 : Comparer MRV sur les 4-Reines (manuel vs Choco)\n",
     "\n",
-    "**Enonce** : resolvez les 4-Reines **sans** MRV (`useMRV=false`) et **avec** MRV (`useMRV=true`) en utilisant votre implementation `BacktrackImproved`. Comparez le nombre d assignations. Ensuite, resolvez les mêmes 4-Reines avec Choco-solver et comparez les temps.\n",
+    "**Énoncé** : résolvez les 4-Reines **sans** MRV (`useMRV=false`) et **avec** MRV (`useMRV=true`) en utilisant votre implémentation `BacktrackImproved`. Comparez le nombre d assignations. Ensuite, résolvez les mêmes 4-Reines avec Choco-solver et comparez les temps.\n",
     "\n",
     "**Indice** : créez un CSP avec 4 variables (colonnes), domaine {0,1,2,3} (lignes), et une contrainte reine-non-attaque. Utilisez `BacktrackImproved(csp, assignment, useMRV, useLCV)` pour la recherche et `CountAssignsRun(csp, useMRV, useLCV)` pour mesurer le nombre d'assignations. Pour Choco, utilisez `IntVar` + `allDifferent` + `arithm` comme en section 6.1.\n",
     "\n",
@@ -1861,7 +2113,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice de benchmark - decommentez pour tester\r\n"
+     "text": [
+      "Exercice de benchmark - decommentez pour tester\r\n"
+     ]
     }
    ],
    "source": [
@@ -1882,7 +2136,7 @@
    "source": [
     "### Exercice 3 : SEND + MORE = MONEY avec Choco-solver\n",
     "\n",
-    "**Enonce** : le puzzle cryptarithmetique **SEND + MORE = MONEY** consiste a trouver l affectation de chiffres (0-9) aux lettres telle que l addition soit correcte. Chaque lettre represente un chiffre distinct, et S et M ne peuvent pas etre 0 (pas de zero initial).\n",
+    "**Énoncé** : le puzzle cryptarithmétique **SEND + MORE = MONEY** consiste à trouver l affectation de chiffres (0-9) aux lettres telle que l addition soit correcte. Chaque lettre représente un chiffre distinct, et S et M ne peuvent pas être 0 (pas de zéro initial).\n",
     "\n",
     "```\n",
     "    S E N D\n",
@@ -1891,7 +2145,7 @@
     "  M O N E Y\n",
     "```\n",
     "\n",
-    "Modelisez et resolvez ce problème avec **Choco-solver**.\n",
+    "Modélisez et résolvez ce problème avec **Choco-solver**.\n",
     "\n",
     "**Indice** :\n",
     "- 8 variables (S, E, N, D, M, O, R, Y), domaine 0..9\n",
@@ -1918,7 +2172,9 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Exercice SEND + MORE = MONEY - decommentez pour tester\r\n"
+     "text": [
+      "Exercice SEND + MORE = MONEY - decommentez pour tester\r\n"
+     ]
     }
    ],
    "source": [
@@ -1943,18 +2199,18 @@
     "\n",
     "Ce notebook a couvert les **fondamentaux** des CSP en C# et introduit **Choco-solver 4.10.17** comme solveur SOTA via IKVM 8.15.0. Le notebook suivant, [CSP-2-Consistance](CSP-2-Consistency.ipynb), introduit les techniques de **propagation de contraintes** avancees :\n",
     "\n",
-    "- **Forward Checking** : eliminer les valeurs inconsistantes des voisins a chaque assignation\n",
+    "- **Forward Checking** : eliminer les valeurs inconsistantes des voisins à chaque assignation\n",
     "- **Arc Consistency (AC-3)** : rendre le CSP arc-consistent avant et pendant la recherche\n",
     "- **MAC (Maintaining Arc Consistency)** : combiner AC-3 avec le backtracking\n",
     "\n",
-    "Ces techniques permettent de reduire encore davantage l exploration en detectant les impasses plus tot.\n",
+    "Ces techniques permettent de réduire encore davantage l exploration en détectant les impasses plus tôt.\n",
     "\n",
     "### References\n",
     "\n",
     "- Russell, S. & Norvig, P. *Artificial Intelligence: A Modern Approach*, Chapitre 6\n",
     "- Dechter, R. *Constraint Processing*, Cambridge University Press, 2003\n",
     "- [Choco-solver documentation](https://choco-solver.org/) -- solveur SOTA utilise dans ce notebook\n",
-    "- Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complete des CSP"
+    "- Voir aussi la série [Sudoku](../../Sudoku/README.md) pour une application complète des CSP"
    ]
   },
   {
@@ -1966,35 +2222,35 @@
     "\n",
     "## Conclusion\n",
     "\n",
-    "Ce notebook a introduit les **problemes de satisfaction de contraintes (CSP)** en C#, avec une comparaison directe entre **implementation manuelle** (classe CSP maison + backtracking + heuristiques MRV/LCV) et **solveur SOTA** (Choco-solver 4.10.17 via IKVM).\n",
+    "Ce notebook a introduit les **problemes de satisfaction de contraintes (CSP)** en C#, avec une comparaison directe entre **implémentation manuelle** (classe CSP maison + backtracking + heuristiques MRV/LCV) et **solveur SOTA** (Choco-solver 4.10.17 via IKVM).\n",
     "\n",
-    "### Concepts cles\n",
+    "### Concepts clés\n",
     "\n",
     "| Concept | Description |\n",
     "|---------|-------------|\n",
     "| **CSP** | Problème défini par variables, domaines et contraintes |\n",
-    "| **Graphe de contraintes** | Representation : noeuds = variables, aretes = contraintes |\n",
-    "| **Backtracking** | Recherche depth-first avec retour arriere sur echec |\n",
+    "| **Graphe de contraintes** | Representation : noeuds = variables, arêtes = contraintes |\n",
+    "| **Backtracking** | Recherche depth-first avec retour arrière sur échec |\n",
     "| **Brute force** | Enumeration exhaustive de toutes les combinaisons |\n",
     "| **MRV / LCV** | Heuristiques fail-first / succeed-first |\n",
     "| **Choco-solver** | Solveur SOTA avec propagation AC-3 et heuristiques integrees |\n",
     "\n",
-    "### Algorithmes de resolution CSP\n",
+    "### Algorithmes de résolution CSP\n",
     "\n",
-    "| Algorithme | Principe | Efficacite | Utilisation |\n",
+    "| Algorithme | Principe | Efficacité | Utilisation |\n",
     "|------------|----------|------------|-------------|\n",
-    "| **Brute force** | Enumeration | $O(d^n)$ | Problemes tiny (n < 10) |\n",
-    "| **Backtracking simple** | Retour arriere | $O(d^n)$ elague | Problemes petits (n < 20) |\n",
-    "| **Backtracking + AC-3** | Propagation | Reduit espace | Problemes moyens (n < 50) |\n",
+    "| **Brute force** | Enumeration | $O(d^n)$ | Problèmes tiny (n < 10) |\n",
+    "| **Backtracking simple** | Retour arrière | $O(d^n)$ élague | Problèmes petits (n < 20) |\n",
+    "| **Backtracking + AC-3** | Propagation | Reduit espace | Problèmes moyens (n < 50) |\n",
     "| **Choco-solver** | SOTA + propagation | Très rapide | Production, recherche |\n",
     "\n",
-    "### Points cles a retenir\n",
+    "### Points clés à retenir\n",
     "\n",
-    "1. La **modelisation CSP** separe le problème du langage de resolution\n",
+    "1. La **modélisation CSP** separe le problème du langage de résolution\n",
     "2. Le **backtracking** est l algorithme de base pour tous les solveurs CSP\n",
-    "3. **Choco-solver** integre propagation + heuristiques : a utiliser pour les problemes reels\n",
-    "4. L implementation manuelle reste pedagogique : elle fait comprendre les mécanismes\n",
-    "5. Les **applications** sont nombreuses : sudoku, emploi du temps, configuration, verification\n",
+    "3. **Choco-solver** intègre propagation + heuristiques : à utiliser pour les problèmes réels\n",
+    "4. L implémentation manuelle reste pédagogique : elle fait comprendre les mécanismes\n",
+    "5. Les **applications** sont nombreuses : sudoku, emploi du temps, configuration, vérification\n",
     "\n",
     "**Voir aussi** :\n",
     "- [CSP-2-Consistency.ipynb](CSP-2-Consistency.ipynb) pour les algorithmes de consistance (AC-3, forward checking)\n",

--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-1-Fundamentals.ipynb
@@ -20,26 +20,26 @@
 				"\n",
 				"## Problèmes de Satisfaction de Contraintes - Fondamentaux\n",
 				"\n",
-				"Ce notebook introduit le formalisme des **CSP** (Constraint Satisfaction Problems) et les algorithmes de base pour les resoudre. Nous implementons tout de zero, puis decouvrons la bibliotheque `python-constraint` pour une modelisation rapide.\n",
+				"Ce notebook introduit le formalisme des **CSP** (Constraint Satisfaction Problems) et les algorithmes de base pour les résoudre. Nous implémentons tout de zéro, puis découvrons la bibliothèque `python-constraint` pour une modélisation rapide.\n",
 				"\n",
 				"### Objectifs d'apprentissage\n",
 				"\n",
-				"A la fin de ce notebook, vous saurez :\n",
+				"À la fin de ce notebook, vous saurez :\n",
 				"1. **Formaliser** un problème sous forme de CSP (variables, domaines, contraintes) (Bloom : comprendre)\n",
-				"2. **Implementer** l'algorithme de backtracking pour CSP (Bloom : appliquer)\n",
+				"2. **Implémenter** l'algorithme de backtracking pour CSP (Bloom : appliquer)\n",
 				"3. **Appliquer** les heuristiques MRV et LCV pour accélérer la recherche (Bloom : analyser)\n",
-				"4. **Modeliser** des problèmes classiques avec la bibliotheque `python-constraint` (Bloom : appliquer)\n",
-				"5. **Comparer** les approches manuelles et bibliotheque sur des problèmes concrets (Bloom : evaluer)\n",
+				"4. **Modéliser** des problèmes classiques avec la bibliothèque `python-constraint` (Bloom : appliquer)\n",
+				"5. **Comparer** les approches manuelles et bibliothèque sur des problèmes concrets (Bloom : évaluer)\n",
 				"\n",
 				"### Prerequis\n",
 				"- Bases de Python (recursion, dictionnaires)\n",
-				"- Notions de recherche dans un espace d'etats (Search-1)\n",
+				"- Notions de recherche dans un espace d'états (Search-1)\n",
 				"\n",
-				"### Duree estimee : 50 minutes\n",
+				"### Durée estimée : 50 minutes\n",
 				"\n",
-				"### Lien avec d'autres series\n",
+				"### Lien avec d'autres séries\n",
 				"\n",
-				"Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complète des CSP."
+				"Voir aussi la série [Sudoku](../../Sudoku/README.md) pour une application complète des CSP."
 			]
 		},
 		{
@@ -62,19 +62,19 @@
 				"\n",
 				"### Qu'est-ce qu'un CSP ?\n",
 				"\n",
-				"Un **CSP** (Constraint Satisfaction Problem) est un problème défini par un ensemble de variables qui doivent prendre des valeurs dans des domaines donnes, tout en respectant un ensemble de contraintes.\n",
+				"Un **CSP** (Constraint Satisfaction Problem) est un problème défini par un ensemble de variables qui doivent prendre des valeurs dans des domaines donnés, tout en respectant un ensemble de contraintes.\n",
 				"\n",
 				"### CSP vs recherche classique\n",
 				"\n",
-				"Dans les notebooks précédents (Search-1 a Search-3), nous avons explore la recherche dans un espace d'etats : BFS, DFS, A*. Ces méthodes traitent le problème comme un parcours de graphe. Les algorithmes génétiques (Search-5) traitent le problème comme une optimisation.\n",
+				"Dans les notebooks précédents (Search-1 à Search-3), nous avons exploré la recherche dans un espace d'états : BFS, DFS, A*. Ces méthodes traitent le problème comme un parcours de graphe. Les algorithmes génétiques (Search-5) traitent le problème comme une optimisation.\n",
 				"\n",
-				"Cependant, de nombreux problèmes reels ont une structure particuliere que ces approches n'exploitent pas pleinement :\n",
+				"Cependant, de nombreux problèmes réels ont une structure particulière que ces approches n'exploitent pas pleinement :\n",
 				"\n",
 				"| Approche | Avantage | Limitation |\n",
 				"|----------|----------|------------|\n",
 				"| Recherche classique (BFS/DFS) | générale | Ne tire pas parti de la structure du problème |\n",
-				"| Recherche informee (A*) | Optimale avec bonne heuristique | Necessite une heuristique spécifique |\n",
-				"| **CSP** | Les contraintes eliminent de larges portions de l'espace | Necessite une modelisation CSP |\n",
+				"| Recherche informée (A*) | Optimale avec bonne heuristique | Nécessite une heuristique spécifique |\n",
+				"| **CSP** | Les contraintes éliminent de larges portions de l'espace | Nécessite une modélisation CSP |\n",
 				"\n",
 				"### Exemples concrets de CSP\n",
 				"\n",
@@ -151,12 +151,12 @@
 				"\n",
 				"## 2. Formalisation CSP (~8 min)\n",
 				"\n",
-				"### Definition\n",
+				"### Définition\n",
 				"\n",
 				"Un **problème de Satisfaction de Contraintes** (CSP) est défini par un triplet $(X, D, C)$ :\n",
 				"\n",
 				"- $X = \\{X_1, X_2, \\ldots, X_n\\}$ : un ensemble de **variables**\n",
-				"- $D = \\{D_1, D_2, \\ldots, D_n\\}$ : un ensemble de **domaines**, ou $D_i$ est l'ensemble des valeurs possibles pour $X_i$\n",
+				"- $D = \\{D_1, D_2, \\ldots, D_n\\}$ : un ensemble de **domaines**, où $D_i$ est l'ensemble des valeurs possibles pour $X_i$\n",
 				"- $C = \\{C_1, C_2, \\ldots, C_m\\}$ : un ensemble de **contraintes**, chacune portant sur un sous-ensemble de variables\n",
 				"\n",
 				"### Types de contraintes\n",
@@ -169,18 +169,18 @@
 				"\n",
 				"### Terminologie\n",
 				"\n",
-				"| Terme | Definition |\n",
+				"| Terme | Définition |\n",
 				"|-------|------------|\n",
 				"| **Assignation** | Affectation d'une valeur a une ou plusieurs variables |\n",
 				"| **Assignation consistante** | Assignation qui ne viole aucune contrainte |\n",
 				"| **Assignation complète** | Toutes les variables ont une valeur |\n",
-				"| **Solution** | Assignation a la fois **complète** et **consistante** |\n",
+				"| **Solution** | Assignation à la fois **complète** et **consistante** |\n",
 				"\n",
 				"### Graphe de contraintes\n",
 				"\n",
-				"On represente un CSP binaire par un **graphe de contraintes** ou :\n",
+				"On représente un CSP binaire par un **graphe de contraintes** ou :\n",
 				"- Chaque **noeud** est une variable\n",
-				"- Chaque **arete** relie deux variables partageant une contrainte"
+				"- Chaque **arête** relie deux variables partageant une contrainte"
 			]
 		},
 		{
@@ -197,7 +197,7 @@
 				"tags": []
 			},
 			"source": [
-				"Implementons une classe CSP generique qui servira de base pour tout le notebook."
+				"Implémentons une classe CSP générique qui servira de base pour tout le notebook."
 			]
 		},
 		{
@@ -313,17 +313,17 @@
 				"\n",
 				"## 3. Exemple : coloration de carte de l'Australie (~8 min)\n",
 				"\n",
-				"Le problème classique de coloration de carte consiste a colorier les regions d'une carte de sorte que deux regions adjacentes n'aient jamais la même couleur. C'est l'exemple canonique du livre AIMA (Russell & Norvig), applique a la carte de l'Australie avec ses 7 etats/territoires.\n",
+				"Le problème classique de coloration de carte consiste à colorier les régions d'une carte de sorte que deux régions adjacentes n'aient jamais la même couleur. C'est l'exemple canonique du livre AIMA (Russell & Norvig), appliqué à la carte de l'Australie avec ses 7 états/territoires.\n",
 				"\n",
-				"### Modelisation CSP\n",
+				"### Modélisation CSP\n",
 				"\n",
 				"| Composant | Valeur |\n",
 				"|-----------|--------|\n",
-				"| **Variables** | WA, NT, SA, Q, NSW, V, T (les 7 etats australiens) |\n",
+				"| **Variables** | WA, NT, SA, Q, NSW, V, T (les 7 états australiens) |\n",
 				"| **Domaines** | {Rouge, Vert, Bleu} pour chaque variable |\n",
 				"| **Contraintes** | Regions adjacentes $\\neq$ même couleur |\n",
 				"\n",
-				"Combien de combinaisons possibles (sans contraintes) ? $3^7 = 2187$. Les contraintes vont eliminer la grande majorite de ces combinaisons."
+				"Combien de combinaisons possibles (sans contraintes) ? $3^7 = 2187$. Les contraintes vont éliminer la grande majorité de ces combinaisons."
 			]
 		},
 		{
@@ -421,7 +421,7 @@
 			"source": [
 				"### Visualisation du graphe de contraintes\n",
 				"\n",
-				"Le graphe de contraintes montre les relations d'adjacence entre les etats. Chaque arete represente une contrainte binaire \"les couleurs doivent etre différentes\"."
+				"Le graphe de contraintes montre les relations d'adjacence entre les états. Chaque arête représente une contrainte binaire \"les couleurs doivent être différentes\"."
 			]
 		},
 		{
@@ -497,9 +497,9 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : graphe de contraintes\n",
+				"### Interprétation : graphe de contraintes\n",
 				"\n",
-				"**Sortie obtenue** : le graphe montre les 7 etats australiens relies par 9 contraintes binaires.\n",
+				"**Sortie obtenue** : le graphe montre les 7 états australiens reliés par 9 contraintes binaires.\n",
 				"\n",
 				"| Variable | Degré (nb voisins) | Rôle dans le graphe |\n",
 				"|----------|--------------------|---------------------|\n",
@@ -508,8 +508,8 @@
 				"| WA, V | 2 | Peripherie |\n",
 				"| T | 0 | Isole (Tasmanie) |\n",
 				"\n",
-				"**Points cles** :\n",
-				"1. SA est adjacent a presque tous les etats continentaux : c'est la variable la plus contrainte\n",
+				"**Points clés** :\n",
+				"1. SA est adjacent à presque tous les états continentaux : c'est la variable la plus contrainte\n",
 				"2. T (Tasmanie) n'a aucune contrainte : n'importe quelle couleur convient\n",
 				"3. Le graphe n'est pas complet : seules les paires adjacentes sont contraintes"
 			]
@@ -534,25 +534,25 @@
 				"\n",
 				"### Pourquoi pas la brute force ?\n",
 				"\n",
-				"L'approche naive (generate-and-test) consiste a générer toutes les $3^7 = 2187$ combinaisons et filtrer celles qui satisfont les contraintes. C'est intraitable pour des problèmes plus grands ($10^{50}$ pour 50 variables a 10 valeurs).\n",
+				"L'approche naïve (generate-and-test) consiste à générer toutes les $3^7 = 2187$ combinaisons et filtrer celles qui satisfont les contraintes. C'est intraitable pour des problèmes plus grands ($10^{50}$ pour 50 variables à 10 valeurs).\n",
 				"\n",
 				"### Principe du backtracking\n",
 				"\n",
-				"Le **backtracking** est l'algorithme de base pour resoudre un CSP :\n",
+				"Le **backtracking** est l'algorithme de base pour résoudre un CSP :\n",
 				"\n",
 				"1. Choisir une variable non encore assignee\n",
 				"2. Pour chaque valeur de son domaine :\n",
-				"   - Verifier la **consistance** avec l'assignation partielle\n",
+				"   - Vérifier la **consistance** avec l'assignation partielle\n",
 				"   - Si consistant, assigner et recurser sur les variables restantes\n",
 				"   - Sinon, essayer la valeur suivante\n",
-				"3. Si aucune valeur n'est valable, **revenir en arriere** (backtrack)\n",
+				"3. Si aucune valeur n'est valable, **revenir en arrière** (backtrack)\n",
 				"\n",
 				"### Différence avec DFS classique\n",
 				"\n",
 				"| Aspect | DFS classique | Backtracking CSP |\n",
 				"|--------|--------------|------------------|\n",
-				"| Assignation | complète d'abord, verification ensuite | Verification **a chaque étape** |\n",
-				"| Elagage | Aucun | Elimination des branches inconsistantes |\n",
+				"| Assignation | complète d'abord, vérification ensuite | Vérification **à chaque étape** |\n",
+				"| Élagage | Aucun | Élimination des branches inconsistantes |\n",
 				"| Profondeur | Variable | Exactement $n$ (nombre de variables) |"
 			]
 		},
@@ -570,7 +570,7 @@
 				"tags": []
 			},
 			"source": [
-				"Commencons par mesurer le cout de la brute force, puis implementons le backtracking pour montrer l'amelioration."
+				"Commençons par mesurer le coût de la brute force, puis implémentons le backtracking pour montrer l'amélioration."
 			]
 		},
 		{
@@ -651,7 +651,7 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : brute force\n",
+				"### Interprétation : brute force\n",
 				"\n",
 				"**Sortie obtenue** : sur 2187 combinaisons possibles, seule une faible proportion satisfait toutes les contraintes.\n",
 				"\n",
@@ -659,7 +659,7 @@
 				"|--------|--------|---------------|\n",
 				"| Espace total | 2187 | $3^7$ combinaisons |\n",
 				"| Solutions | ~18 | Depend de la symetrie des couleurs |\n",
-				"| Ratio | < 1% | L'immense majorite des combinaisons est invalide |\n",
+				"| Ratio | < 1% | L'immense majorité des combinaisons est invalide |\n",
 				"\n",
 				"> **Conclusion** : il faut un algorithme qui exploite les contraintes pour **elaguer** l'espace de recherche. C'est le rôle du backtracking."
 			]
@@ -678,7 +678,7 @@
 				"tags": []
 			},
 			"source": [
-				"### Implementation du backtracking"
+				"### Implémentation du backtracking"
 			]
 		},
 		{
@@ -831,16 +831,16 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : backtracking simple\n",
+				"### Interprétation : backtracking simple\n",
 				"\n",
 				"**Sortie obtenue** : le backtracking trouve une solution avec beaucoup moins d'explorations que la brute force.\n",
 				"\n",
-				"| méthode | Essais | Amelioration |\n",
+				"| méthode | Essais | Amélioration |\n",
 				"|---------|--------|-------------|\n",
 				"| Brute force | 2187 | référence |\n",
 				"| Backtracking | ~7-15 | environ 200x moins |\n",
 				"\n",
-				"**Pourquoi cette reduction ?** Le backtracking détecte les inconsistances des qu'elles apparaissent. Si WA = Rouge et NT = Rouge, la contrainte `WA != NT` est violee immediatement : toutes les extensions de cette assignation partielle sont eliminees sans etre explorees.\n",
+				"**Pourquoi cette réduction ?** Le backtracking détecte les inconsistances dès qu'elles apparaissent. Si WA = Rouge et NT = Rouge, la contrainte `WA != NT` est violée immédiatement : toutes les extensions de cette assignation partielle sont éliminées sans être explorées.\n",
 				"\n",
 				"> **Question** : peut-on faire encore mieux en choisissant plus intelligemment quelle variable assigner en premier et quelle valeur essayer ?"
 			]
@@ -861,7 +861,7 @@
 			"source": [
 				"### Trace detaillee du backtracking\n",
 				"\n",
-				"Pour mieux comprendre le fonctionnement, implementons une version avec trace qui montre chaque decision et chaque retour en arriere."
+				"Pour mieux comprendre le fonctionnement, implémentons une version avec trace qui montre chaque décision et chaque retour en arrière."
 			]
 		},
 		{
@@ -967,17 +967,17 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : trace du backtracking\n",
+				"### Interprétation : trace du backtracking\n",
 				"\n",
-				"La trace montre le processus de decision pas a pas :\n",
+				"La trace montre le processus de décision pas à pas :\n",
 				"\n",
-				"1. L'algorithme assigne une valeur a la première variable\n",
-				"2. Il détecte les conflits immediatement grace a la verification de consistance\n",
-				"3. Quand un conflit survient sur toutes les valeurs, il revient en arriere (backtrack)\n",
+				"1. L'algorithme assigne une valeur à la première variable\n",
+				"2. Il détecte les conflits immédiatement grâce à la vérification de consistance\n",
+				"3. Quand un conflit survient sur toutes les valeurs, il revient en arrière (backtrack)\n",
 				"\n",
 				"**Observations** :\n",
-				"- Les conflits sont detectes **des l'assignation**, pas a la fin\n",
-				"- Le \"backtrack\" est visible dans la trace par les retours en arriere\n",
+				"- Les conflits sont détectés **dès l'assignation**, pas à la fin\n",
+				"- Le \"backtrack\" est visible dans la trace par les retours en arrière\n",
 				"- L'indentation montre la profondeur de recursion"
 			]
 		},
@@ -997,7 +997,7 @@
 			"source": [
 				"### 4.3 Visualisation du processus de backtracking\n",
 				"\n",
-				"Visualiser l'arbre de recherche du backtracking permet de comprendre comment l'algorithme explore et elague l'espace de solutions.\n"
+				"Visualiser l'arbre de recherche du backtracking permet de comprendre comment l'algorithme explore et élague l'espace de solutions.\n"
 			]
 		},
 		{
@@ -1174,7 +1174,7 @@
 				"tags": []
 			},
 			"source": [
-				"Exemple : visualiser la resolution de la carte d'Australie"
+				"Exemple : visualiser la résolution de la carte d'Australie"
 			]
 		},
 		{
@@ -1263,18 +1263,18 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation de la visualisation\n",
+				"### Interprétation de la visualisation\n",
 				"\n",
 				"L'arbre de recherche montre :\n",
 				"\n",
-				"- **Noeuds verts** : Assignations reussies (la valeur est coherente avec l'assignation partielle)\n",
-				"- **Noeuds rouges** : Assignations echouees (conflit détecte immediatement)\n",
-				"- **Profondeur** : Correspond au nombre de variables assignees\n",
+				"- **Noeuds verts** : Assignations réussies (la valeur est cohérente avec l'assignation partielle)\n",
+				"- **Noeuds rouges** : Assignations échouées (conflit détecté immédiatement)\n",
+				"- **Profondeur** : Correspond au nombre de variables assignées\n",
 				"- **Largeur** : Correspond aux différentes valeurs essayees pour chaque variable\n",
 				"\n",
-				"**Observations cles** :\n",
+				"**Observations clés** :\n",
 				"\n",
-				"1. L'elagage est visible : les branches rouges sont coupees des qu'un conflit est détecte\n",
+				"1. L'élagage est visible : les branches rouges sont coupées dès qu'un conflit est détecté\n",
 				"2. Le backtrack se produit quand toutes les valeurs d'une variable echouent\n",
 				"3. L'ordre des variables influence la forme de l'arbre (variables a petit domaine en premier = arbre plus etroit)\n"
 			]
@@ -1297,7 +1297,7 @@
 				"\n",
 				"## 5. Heuristiques : MRV et LCV (~8 min)\n",
 				"\n",
-				"Le backtracking simple fonctionne, mais deux choix stratégiques peuvent considerablement l'accélérer :\n",
+				"Le backtracking simple fonctionne, mais deux choix stratégiques peuvent considérablement l'accélérer :\n",
 				"\n",
 				"1. **Quelle variable** assigner ensuite ? (variable ordering)\n",
 				"2. **Quelle valeur** essayer en premier ? (value ordering)\n",
@@ -1306,7 +1306,7 @@
 				"\n",
 				"**Principe** : choisir la variable qui a le **plus petit domaine restant** (le moins de valeurs viables).\n",
 				"\n",
-				"**Intuition (\"fail-first\")** : si une variable n'a que 2 valeurs possibles et une autre en a 10, mieux vaut traiter d'abord celle a 2 valeurs. Si elle echoue, on le decouvre plus vite, et on elague un sous-arbre plus tot.\n",
+				"**Intuition (\"fail-first\")** : si une variable n'a que 2 valeurs possibles et une autre en a 10, mieux vaut traiter d'abord celle à 2 valeurs. Si elle échoue, on le découvre plus vite, et on élague un sous-arbre plus tot.\n",
 				"\n",
 				"$$\\text{MRV}(X_i) = |\\{v \\in D_i : v \\text{ est consistant avec l'assignation courante}\\}|$$\n",
 				"\n",
@@ -1457,17 +1457,17 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : sélection MRV\n",
+				"### Interprétation : sélection MRV\n",
 				"\n",
-				"**Sortie obtenue** : après avoir assigne WA=Rouge et NT=Vert, SA n'a plus qu'une seule valeur viable (Bleu), car elle est adjacente aux deux regions déjà coloriees.\n",
+				"**Sortie obtenue** : après avoir assigné WA=Rouge et NT=Vert, SA n'a plus qu'une seule valeur viable (Bleu), car elle est adjacente aux deux régions déjà coloriées.\n",
 				"\n",
 				"| Variable | Valeurs viables | Pourquoi |\n",
 				"|----------|----------------|----------|\n",
 				"| SA | [Bleu] seulement | Adjacent a WA (Rouge) et NT (Vert) |\n",
-				"| Q, NSW | 2 valeurs | Adjacents a certaines variables assignees |\n",
+				"| Q, NSW | 2 valeurs | Adjacents à certaines variables assignées |\n",
 				"| V, T | 3 valeurs | Pas ou peu de voisins assignes |\n",
 				"\n",
-				"MRV choisit SA car c'est la variable la plus contrainte. Si SA n'a aucune valeur viable, on détecte l'echec immediatement sans explorer les autres variables."
+				"MRV choisit SA car c'est la variable la plus contrainte. Si SA n'a aucune valeur viable, on détecte l'échec immédiatement sans explorer les autres variables."
 			]
 		},
 		{
@@ -1486,11 +1486,11 @@
 			"source": [
 				"### 5.2 Value Ordering : LCV (Least Constraining Value)\n",
 				"\n",
-				"**Principe** : pour la variable choisie, essayer d'abord la valeur qui **elimine le moins de possibilites** pour les variables voisines non assignees.\n",
+				"**Principe** : pour la variable choisie, essayer d'abord la valeur qui **élimine le moins de possibilités** pour les variables voisines non assignées.\n",
 				"\n",
-				"**Intuition (\"succeed-first\")** : contrairement au \"fail-first\" pour les variables, pour les valeurs on prefere maximiser les chances que le reste du problème reste soluble.\n",
+				"**Intuition (\"succeed-first\")** : contrairement au \"fail-first\" pour les variables, pour les valeurs on préfère maximiser les chances que le reste du problème reste soluble.\n",
 				"\n",
-				"$$\\text{LCV}(v) = \\sum_{\\text{voisin } Y \\text{ non assigne}} |\\{w \\in D_Y : \\text{contrainte}(X, v, Y, w) \\text{ violee}\\}|$$\n",
+				"$$\\text{LCV}(v) = \\sum_{\\text{voisin } Y \\text{ non assigné}} |\\{w \\in D_Y : \\text{contrainte}(X, v, Y, w) \\text{ violée}\\}|$$\n",
 				"\n",
 				"On trie les valeurs par nombre de conflits croissant (la moins contraignante d'abord)."
 			]
@@ -1555,9 +1555,9 @@
 				"tags": []
 			},
 			"source": [
-				"### Backtracking ameliore : MRV + LCV\n",
+				"### Backtracking amélioré : MRV + LCV\n",
 				"\n",
-				"Combinons les deux heuristiques dans une version amelioree du backtracking."
+				"Combinons les deux heuristiques dans une version améliorée du backtracking."
 			]
 		},
 		{
@@ -1729,22 +1729,22 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : impact des heuristiques sur la coloration\n",
+				"### Interprétation : impact des heuristiques sur la coloration\n",
 				"\n",
-				"**Sortie obtenue** : sur ce petit graphe, les heuristiques n'amelioresent pas le compte d'assignations.\n",
+				"**Sortie obtenue** : sur ce petit graphe, les heuristiques n'améliorent pas le compte d'assignations.\n",
 				"\n",
 				"| Variante | Assignations | Commentaire |\n",
 				"|----------|-------------|-------------|\n",
-				"| Backtracking simple | 11 | Ordre naif des variables et valeurs |\n",
-				"| + MRV | 15 | Fail-first : sur-cout ici non amorti |\n",
+				"| Backtracking simple | 11 | Ordre naïf des variables et valeurs |\n",
+				"| + MRV | 15 | Fail-first : sur-coût ici non amorti |\n",
 				"| + MRV + LCV | 15 | idem, LCV ne change rien |\n",
 				"\n",
-				"**Points cles** :\n",
-				"1. Sur ce petit problème (7 variables, 3 couleurs, espace déjà très contraint), l'ordre naif tombe déjà sur une solution en 11 assignations ; MRV ajoute ici un sur-cout de sélection (15) non amorti\n",
+				"**Points clés** :\n",
+				"1. Sur ce petit problème (7 variables, 3 couleurs, espace déjà très contraint), l'ordre naïf tombe déjà sur une solution en 11 assignations ; MRV ajoute ici un sur-coût de sélection (15) non amorti\n",
 				"2. L'effet des heuristiques est **instance-dependant** : nul ou negatif sur une instance facile, il devient dramatique sur des instances plus dures (cf. les 8-Reines ci-dessous : 876 -> 572 avec MRV)\n",
-				"3. Conclusion honnete : aucune heuristique n'est monotoniquement benefique, il faut mesurer et non presupposer une amelioration\n",
+				"3. Conclusion honnête : aucune heuristique n'est monotoniquement bénéfique, il faut mesurer et non présupposer une amélioration\n",
 				"\n",
-				"> **règle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais son sur-cout n'est pas amorti sur les instances faciles comme la coloration de l'Australie."
+				"> **règle pratique** : mesurer empiriquement. MRV rapporte gros sur les instances dures (N-Reines), mais son sur-coût n'est pas amorti sur les instances faciles comme la coloration de l'Australie."
 			]
 		},
 		{
@@ -1939,9 +1939,9 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : 8-Reines\n",
+				"### Interprétation : 8-Reines\n",
 				"\n",
-				"**Sortie obtenue** : le backtracking avec MRV + LCV resout les 8-Reines en 677 assignations.\n",
+				"**Sortie obtenue** : le backtracking avec MRV + LCV résout les 8-Reines en 677 assignations.\n",
 				"\n",
 				"| Mesure | Valeur |\n",
 				"|--------|--------|\n",
@@ -1950,10 +1950,10 @@
 				"| + MRV | 572 assignations |\n",
 				"| + MRV + LCV | 677 assignations |\n",
 				"\n",
-				"**Points cles** :\n",
+				"**Points clés** :\n",
 				"1. L'echiquier montre qu'aucune reine n'est sur la même ligne, colonne ou diagonale\n",
-				"2. La modelisation CSP (une variable par colonne) resout le problème en ~$10^3$ assignations au lieu des $16{,}8$ millions de l'espace brut\n",
-				"3. MRV (876 -> 572) réduit nettement le compte ; en revanche, ajouter LCV le remonte a 677 : l'ordonnancement des valeurs par LCV est ici moins favorable que l'ordre naif combine a MRV -- c'est un effet connu, l'ordonnancement des valeurs etant moins robuste que celui des variables"
+				"2. La modélisation CSP (une variable par colonne) résout le problème en ~$10^3$ assignations au lieu des $16{,}8$ millions de l'espace brut\n",
+				"3. MRV (876 -> 572) réduit nettement le compte ; en revanche, ajouter LCV le remonte à 677 : l'ordonnancement des valeurs par LCV est ici moins favorable que l'ordre naïf combiné à MRV -- c'est un effet connu, l'ordonnancement des valeurs étant moins robuste que celui des variables"
 			]
 		},
 		{
@@ -2120,20 +2120,20 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : comparaison des variantes\n",
+				"### Interprétation : comparaison des variantes\n",
 				"\n",
 				"| Variante | Coloration (assigns) | 8-Reines (assigns) | Commentaire |\n",
 				"|----------|---------------------|---------------------|-------------|\n",
-				"| Plain backtracking | 11 | 876 | Ordre naif des variables et valeurs |\n",
+				"| Plain backtracking | 11 | 876 | Ordre naïf des variables et valeurs |\n",
 				"| + MRV | 15 | 572 | Fail-first sur les variables |\n",
 				"| + MRV + LCV | 15 | 677 | Succeed-first sur les valeurs |\n",
 				"\n",
 				"**Observations** :\n",
-				"1. **MRV** aide nettement sur les 8-Reines (876 -> 572), mais pas sur la coloration (11 -> 15) : son sur-cout de sélection n'est pas amorti sur une instance facile\n",
+				"1. **MRV** aide nettement sur les 8-Reines (876 -> 572), mais pas sur la coloration (11 -> 15) : son sur-coût de sélection n'est pas amorti sur une instance facile\n",
 				"2. **LCV** n'apporte rien sur la coloration (15 -> 15) et fait même regresser les 8-Reines (572 -> 677) : l'ordonnancement des valeurs est moins fiable que celui des variables\n",
-				"3. Aucune heuristique n'est universellement benefique : le benefice depend de l'instance et se mesure empiriquement\n",
+				"3. Aucune heuristique n'est universellement bénéfique : le bénéfice dépend de l'instance et se mesure empiriquement\n",
 				"\n",
-				"> **A retenir** : les heuristiques de sélection ne changent pas la correction du backtracking, mais leur benefice n'est ni garanti ni monotone. Sur les instances dures (N-Reines grand), MRV transforme un problème intraitable en problème resolvable ; sur les instances faciles, elles peuvent même couter plus qu'elles ne rapportent."
+				"> **À retenir** : les heuristiques de sélection ne changent pas la correction du backtracking, mais leur bénéfice n'est ni garanti ni monotone. Sur les instances dures (N-Reines grand), MRV transforme un problème intraitable en problème resolvable ; sur les instances faciles, elles peuvent même coûter plus qu'elles ne rapportent."
 			]
 		},
 		{
@@ -2152,11 +2152,11 @@
 			"source": [
 				"***\n",
 				"\n",
-				"## 6. Bibliotheque python-constraint (~8 min)\n",
+				"## 6. Bibliothèque python-constraint (~8 min)\n",
 				"\n",
-				"Jusqu'ici nous avons tout implemente de zero, ce qui est essentiel pour comprendre les mécanismes. En pratique, on utilise souvent une **bibliotheque CSP** qui fournit un solveur optimise et des contraintes predefinies.\n",
+				"Jusqu'ici nous avons tout implémenté de zéro, ce qui est essentiel pour comprendre les mécanismes. En pratique, on utilise souvent une **bibliothèque CSP** qui fournit un solveur optimisé et des contraintes prédéfinies.\n",
 				"\n",
-				"La bibliotheque [`python-constraint`](https://github.com/python-constraint/python-constraint) permet de modeliser et resoudre des CSP de maniere declarative.\n",
+				"La bibliothèque [`python-constraint`](https://github.com/python-constraint/python-constraint) permet de modéliser et résoudre des CSP de manière déclarative.\n",
 				"\n",
 				"### Installation\n",
 				"\n",
@@ -2223,7 +2223,7 @@
 			"source": [
 				"### Coloration de l'Australie avec python-constraint\n",
 				"\n",
-				"Reecrivons le problème de coloration de l'Australie avec la bibliotheque. Comparons la concision du code avec notre implementation manuelle."
+				"Réécrivons le problème de coloration de l'Australie avec la bibliothèque. Comparons la concision du code avec notre implémentation manuelle."
 			]
 		},
 		{
@@ -2314,21 +2314,21 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : python-constraint vs implementation manuelle\n",
+				"### Interprétation : python-constraint vs implémentation manuelle\n",
 				"\n",
-				"**Sortie obtenue** : la bibliotheque trouve rapidement une solution et peut enumerer toutes les solutions.\n",
+				"**Sortie obtenue** : la bibliothèque trouve rapidement une solution et peut énumérer toutes les solutions.\n",
 				"\n",
-				"| Aspect | Implementation manuelle | python-constraint |\n",
+				"| Aspect | Implémentation manuelle | python-constraint |\n",
 				"|--------|------------------------|-------------------|\n",
 				"| Lignes de code | ~60 (classe CSP + backtracking) | ~10 |\n",
-				"| Toutes les solutions | Necessiterait une modification | `getSolutions()` integre |\n",
-				"| Contraintes predefinies | A coder soi-même | `AllDifferentConstraint`, etc. |\n",
+				"| Toutes les solutions | Nécessiterait une modification | `getSolutions()` intégré |\n",
+				"| Contraintes prédéfinies | À coder soi-même | `AllDifferentConstraint`, etc. |\n",
 				"| Pedagogie | Comprendre les mécanismes | Utiliser en production |\n",
 				"\n",
-				"**Points cles** :\n",
-				"1. La bibliotheque abstrait les details d'implementation (backtracking, heuristiques)\n",
-				"2. `getSolutions()` enumere exhaustivement toutes les solutions valides\n",
-				"3. L'API declarative est plus lisible et moins sujette aux erreurs"
+				"**Points clés** :\n",
+				"1. La bibliothèque abstrait les détails d'implémentation (backtracking, heuristiques)\n",
+				"2. `getSolutions()` énumère exhaustivement toutes les solutions valides\n",
+				"3. L'API déclarative est plus lisible et moins sujette aux erreurs"
 			]
 		},
 		{
@@ -2416,7 +2416,7 @@
 			"source": [
 				"### 4-Reines avec python-constraint\n",
 				"\n",
-				"Modelisons le problème des 4-Reines avec la bibliotheque pour montrer sa simplicite."
+				"Modélisons le problème des 4-Reines avec la bibliothèque pour montrer sa simplicité."
 			]
 		},
 		{
@@ -2540,7 +2540,7 @@
 				"tags": []
 			},
 			"source": [
-				"### Interpretation : 4-Reines avec la bibliotheque\n",
+				"### Interprétation : 4-Reines avec la bibliothèque\n",
 				"\n",
 				"**Sortie obtenue** : le problème des 4-Reines a exactement 2 solutions (symetriques l'une de l'autre).\n",
 				"\n",
@@ -2550,12 +2550,12 @@
 				"| Espace brut | $4^4 = 256$ |\n",
 				"| Code | ~10 lignes vs ~50 en manuel |\n",
 				"\n",
-				"**Points cles** :\n",
-				"1. La bibliotheque gere automatiquement le backtracking et les heuristiques\n",
+				"**Points clés** :\n",
+				"1. La bibliothèque gère automatiquement le backtracking et les heuristiques\n",
 				"2. `getSolutions()` retourne la liste exhaustive des solutions\n",
-				"3. En production, on prefere utiliser une bibliotheque pour gagner en fiabilite et en temps de développement\n",
+				"3. En production, on préfère utiliser une bibliothèque pour gagner en fiabilité et en temps de développement\n",
 				"\n",
-				"> **Quand utiliser quoi ?** Implementation manuelle pour **apprendre** les mécanismes. Bibliotheque pour **resoudre** des problèmes reels."
+				"> **Quand utiliser quoi ?** Implémentation manuelle pour **apprendre** les mécanismes. Bibliothèque pour **résoudre** des problèmes réels."
 			]
 		},
 		{
@@ -2600,28 +2600,28 @@
 				"| Approche | Noeuds explores | Temps | Facilite d'utilisation |\n",
 				"|----------|----------------|-------|------------------------|\n",
 				"| Brute force | $\\prod \\vert D_i\\vert$ (tous) | Lent | Simple mais intraitable |\n",
-				"| Backtracking simple | réduit (elagage) | Rapide | Implementation moderee |\n",
-				"| Backtracking + MRV | très réduit | très rapide | Implementation moderee |\n",
-				"| Backtracking + MRV + LCV | Minimal | très rapide | Plus complexe a implementer |\n",
-				"| python-constraint | Optimise (interne) | Rapide | très simple (declaratif) |\n",
+				"| Backtracking simple | réduit (élagage) | Rapide | Implémentation modérée |\n",
+				"| Backtracking + MRV | très réduit | très rapide | Implémentation modérée |\n",
+				"| Backtracking + MRV + LCV | Minimal | très rapide | Plus complexe à implémenter |\n",
+				"| python-constraint | Optimisé (interne) | Rapide | très simple (déclaratif) |\n",
 				"\n",
 				"### Resume du formalisme CSP\n",
 				"\n",
-				"| Concept | Definition | Exemple |\n",
+				"| Concept | Définition | Exemple |\n",
 				"|---------|------------|--------|\n",
 				"| **Variable** ($X_i$) | Quantite a déterminer | Region a colorier |\n",
 				"| **Domaine** ($D_i$) | Valeurs possibles pour $X_i$ | {Rouge, Vert, Bleu} |\n",
 				"| **Contrainte** ($C_k$) | Restriction sur un sous-ensemble de variables | $X_1 \\neq X_2$ |\n",
-				"| **Solution** | Assignation complète et consistante | Toutes les regions coloriees sans conflit |\n",
+				"| **Solution** | Assignation complète et consistante | Toutes les régions coloriées sans conflit |\n",
 				"\n",
-				"### Resume des algorithmes\n",
+				"### Résumé des algorithmes\n",
 				"\n",
 				"| Algorithme / Heuristique | Principe | Impact |\n",
 				"|--------------------------|----------|--------|\n",
-				"| **Backtracking** | DFS avec verification de consistance a chaque étape | Base de toute resolution CSP |\n",
+				"| **Backtracking** | DFS avec vérification de consistance à chaque étape | Base de toute résolution CSP |\n",
 				"| **MRV** | Choisir la variable au domaine le plus restreint | Fail-first : détecte les impasses tot |\n",
 				"| **LCV** | Essayer la valeur la moins contraignante | Succeed-first : maximise les chances |\n",
-				"| **python-constraint** | API declarative avec solveur integre | Productivite en production |"
+				"| **python-constraint** | API déclarative avec solveur intégré | Productivité en production |"
 			]
 		},
 		{
@@ -2640,7 +2640,7 @@
 			"source": [
 				"### Exercice 1 : 4-Reines avec backtracking manuel\n",
 				"\n",
-				"**Enonce** : modelisez et resolvez le problème des 4-Reines avec notre backtracking `backtracking_improved` (MRV + LCV). Affichez la solution avec `draw_queens`.\n",
+				"**Énoncé** : modélisez et résolvez le problème des 4-Reines avec notre backtracking `backtracking_improved` (MRV + LCV). Affichez la solution avec `draw_queens`.\n",
 				"\n",
 				"Completez la cellule ci-dessous."
 			]
@@ -2718,7 +2718,7 @@
 			"source": [
 				"### Exercice 2 : comparer MRV sur les 4-Reines\n",
 				"\n",
-				"**Enonce** : resolvez les 4-Reines **sans** MRV (`use_mrv=False`) et **avec** MRV. Comparez le nombre d'assignations. Le gain est-il significatif sur ce petit problème ?"
+				"**Énoncé** : résolvez les 4-Reines **sans** MRV (`use_mrv=False`) et **avec** MRV. Comparez le nombre d'assignations. Le gain est-il significatif sur ce petit problème ?"
 			]
 		},
 		{
@@ -2783,7 +2783,7 @@
 			"source": [
 				"### Exercice 3 : Cryptarithmetique SEND + MORE = MONEY\n",
 				"\n",
-				"**Enonce** : le puzzle cryptarithmetique **SEND + MORE = MONEY** consiste a trouver l'affectation de chiffres (0-9) aux lettres telle que l'addition soit correcte. Chaque lettre represente un chiffre distinct, et S et M ne peuvent pas etre 0 (pas de zero initial).\n",
+				"**Énoncé** : le puzzle cryptarithmétique **SEND + MORE = MONEY** consiste à trouver l'affectation de chiffres (0-9) aux lettres telle que l'addition soit correcte. Chaque lettre représente un chiffre distinct, et S et M ne peuvent pas être 0 (pas de zéro initial).\n",
 				"\n",
 				"```\n",
 				"    S E N D\n",
@@ -2792,7 +2792,7 @@
 				"  M O N E Y\n",
 				"```\n",
 				"\n",
-				"Modelisez et resolvez ce problème avec `python-constraint`.\n",
+				"Modélisez et résolvez ce problème avec `python-constraint`.\n",
 				"\n",
 				"**Indice** : la contrainte principale est :\n",
 				"$$1000 \\times S + 100 \\times E + 10 \\times N + D + 1000 \\times M + 100 \\times O + 10 \\times R + E$$\n",
@@ -2860,9 +2860,9 @@
 			"source": [
 				"### Exercice 4 : Sudoku 4x4 avec visualisation\n",
 				"\n",
-				"**Enonce** : Un Sudoku 4x4 est une grille 4x4 ou chaque ligne, colonne et bloc 2x2 doit contenir les chiffres 1-4 exactement une fois.\n",
+				"**Énoncé** : Un Sudoku 4x4 est une grille 4x4 où chaque ligne, colonne et bloc 2x2 doit contenir les chiffres 1-4 exactement une fois.\n",
 				"\n",
-				"Modelez ce problème comme un CSP et utilisez le visualiseur de backtracking pour observer la resolution.\n",
+				"Modélisez ce problème comme un CSP et utilisez le visualiseur de backtracking pour observer la résolution.\n",
 				"\n",
 				"**Grille initiale** (0 = case vide) :\n",
 				"```\n",
@@ -2955,9 +2955,9 @@
 				"tags": []
 			},
 			"source": [
-				"### Exercice 5 : Modelisation CSP pour un emploi du temps\n",
+				"### Exercice 5 : Modélisation CSP pour un emploi du temps\n",
 				"\n",
-				"Modeliser un problème demploi du temps comme CSP : définir variables, domaines et contraintes.\n",
+				"Modéliser un problème d'emploi du temps comme CSP : définir variables, domaines et contraintes.\n",
 				"\n",
 				"**Indice** : Variables = cours, domaines = creneaux horaires, contraintes = pas de chevauchement.\n"
 			]
@@ -3013,9 +3013,9 @@
 				"tags": []
 			},
 			"source": [
-				"### Exercice 6 : Propagation de contraintes sur un CSP lineaire\n",
+				"### Exercice 6 : Propagation de contraintes sur un CSP linéaire\n",
 				"\n",
-				"Implementer la propagation de contraintes (AC-3) sur un CSP simple.\n",
+				"Implémenter la propagation de contraintes (AC-3) sur un CSP simple.\n",
 				"\n",
 				"**Indice** : Utilisez une file dattente darcs et reduisez les domaines.\n"
 			]
@@ -3073,9 +3073,9 @@
 			"source": [
 				"### Et ensuite ?\n",
 				"\n",
-				"Ce notebook a couvert les **fondamentaux** des CSP : formalisme, backtracking avec heuristiques, et utilisation de la bibliotheque `python-constraint`. Le notebook suivant, [CSP-2-Consistance](CSP-2-Consistency.ipynb), introduit les techniques de **propagation de contraintes** :\n",
+				"Ce notebook a couvert les **fondamentaux** des CSP : formalisme, backtracking avec heuristiques, et utilisation de la bibliothèque `python-constraint`. Le notebook suivant, [CSP-2-Consistance](CSP-2-Consistency.ipynb), introduit les techniques de **propagation de contraintes** :\n",
 				"\n",
-				"- **Forward Checking** : eliminer les valeurs inconsistantes des voisins a chaque assignation\n",
+				"- **Forward Checking** : éliminer les valeurs inconsistantes des voisins à chaque assignation\n",
 				"- **Arc Consistency (AC-3)** : rendre le CSP arc-consistent avant et pendant la recherche\n",
 				"- **MAC (Maintaining Arc Consistency)** : combiner AC-3 avec le backtracking\n",
 				"\n",
@@ -3085,7 +3085,7 @@
 				"\n",
 				"- Russell, S. & Norvig, P. *Artificial Intelligence: A Modern Approach*, Chapitre 6\n",
 				"- Dechter, R. *Constraint Processing*, Cambridge University Press, 2003\n",
-				"- Voir aussi la serie [Sudoku](../../Sudoku/README.md) pour une application complète des CSP"
+				"- Voir aussi la série [Sudoku](../../Sudoku/README.md) pour une application complète des CSP"
 			]
 		},
 		{

--- a/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-1-fundamentals.yaml
@@ -46,6 +46,12 @@
       csharp_sha: 79a41d1f45cf20633b1ebf6e1cdefd0ea7199b99
       content_python_sha: 3aa9e09c1f0029a5086671f400f79eaf67adf454aeee919f57a7c62c3dd3d148
       content_csharp_sha: b5cbe3525c9b2b6f5695199caf35ce2659c9c98fc48f3f231f60e4d490ea22e0
+    - date: "2026-08-16"
+      by: myia-po-2023:CoursIA
+      python_sha: dae52d24e3679e537348bdfb342c33c83d72088c
+      csharp_sha: 9545c1ab35854544fee94e9061fda4e586d4e2ad
+      content_python_sha: 2849b384ba076e18f1eba830f23994f26d6a28d2b2ce0a89d7de8cb9fcaedc29
+      content_csharp_sha: d6cbf106e2825fdabaea67d9224b02865ff0614374cae69578222036ee8f6f24
   known_differences:
     - "Edition 2026-08-15 (myia-po-2026:CoursIA, #9434 machine-dep) : drainage markdown-only de 4 re-pins de runtime absolus de la prose d'interpretation du twin C# -- cell[31] borne JVM chaude (bien inferieur a 10 ms), cell[33] table Temps (~1-5 ms / < 10 ms), cell[36] ligne d'ouverture (moins de 50 ms), toutes derivees des sorties de mesure committeees (c32 : Temps enumeration 2,94 ms ; c35 : Temps 46,24 ms). Remplacees par des descripteurs *machine-dep* renvoyant aux sorties des cellules de mesure, geste canonique #9434 (la prose re-epingle une valeur qui contredira la sortie au prochain passage kernel sur une autre machine). check_machine_dep_timing passe de 2 a 0 wallclock sur ce notebook. Parite semantique preservee : le socle from-scratch et l'extension Choco sont inchanges, seules les valeurs machine-dep de la prose ont bouge, d'ou le re-baseline du csharp_sha."
     - "Socle pedagogique commun (parity semantic) : les deux cotes implementent une classe CSP generique + backtracking simple + heuristique MRV + value-ordering LCV, depuis zero (pas de lib externe pour le coeur). Cote Python : classe CSP dict/list pure Python. Cote C# : classe CSP generique C# (Dictionary/List) qui reflete la Python."


### PR DESCRIPTION
## Scope

Restauration des diacritiques français perdus dans les 37 cellules markdown de `CSP-1-Fundamentals.ipynb` (tranche résiduelle #6495 identifiée ALIVE lors du triage de la fenêtre `merged:2026-07-10..07-16` de l'Epic #11044), **puis extension au twin C#** `CSP-1-Fundamentals-Csharp.ipynb` (décision ai-01 du 16/08 sur cette PR : consacrer une asymétrie qu'on vient de créer soi-même est ce que le registre twin existe pour empêcher).

## Corrections Python (3 passes, contexte vérifié)

- **Passe 1 (35 cellules)** : mappages mot-à-mot sûrs (resoudre→résoudre, modelisation→modélisation, bibliotheque→bibliothèque, verification→vérification, Necessite→Nécessite, naif→naïf, cout→coût, etats→états, arete→arête, relies→reliés, Enonce→Énoncé…) + phrases contextuelles pour les ambiguïtés (« consiste a »→« consiste à », « nous avons explore »→« nous avons exploré », « Search-1 a Search-3 »→« à », « ou $D_i$ »→« où $D_i$ »).
- **Passe 2 (17 cellules)** : résidus détectés à la relecture du diff (Interpretation→Interprétation ×10, elagage→élagage, decision→décision, coloriees→coloriées, moderee→modérée, resolution→résolution, depend→dépend, Résumé, Optimisé, « pas à pas », « 4x4 où », « Adjacents à », « complexe à implémenter », « À coder soi-même »).
- **Passe 3 (7 cellules)** : derniers marginaux (Duree estimée, série/séries, considerablement, coherente, reussies, enumere, Modelez→Modélisez, lineaire, Implementer).

## Extension twin C# (16/08, commit 0ff2bd690)

Même discipline, étendue aux **commentaires de code et chaînes `Console.WriteLine`** (38 cellules touchées : 19 markdown + 19 code) :

- **Classification manuelle de chaque « a » autonome** (~38 occurrences) : 29 prépositions → « à » (consiste **à** colorier, **à** chaque étape, chargé **à** la volée, grace **à**, Exercice **à** compléter, Quantité **à** déterminer…) ; verbes avoir conservés (le graphe **a** 7 nœuds, qui **a** le plus petit domaine, ce notebook **a** couvert) ; identifiant C# `a` (paramètre `Dictionary` cell 25) intact.
- **Faux amis participe/présent par occurrence** : `charge` ×4 = présent verbe (NON accentué : « le bloc #r charge IKVM ») vs « est chargé à la volée » participe ; `integre` mixte → intègre (verbe : « solver.solve() intègre backtracking », « Choco intègre nativement ») vs intégré (adjectif : « AC-3 intégré », « matching biparti intégré », « / intégré Choco ») ; `optimise`/`necessite` résolus par contexte (« solveur CSP optimisé », « a nécessité ~876 »).
- **Titres anglais intacts** : « A Filtering Algorithm for Constraints of Difference in CSPs » (Regin 1994) ×2 — les 2 seuls hits résiduels du détecteur, faux positifs assumés.
- Bonus hors-accent (1 occurrence) : typo `construteur` → `constructeur`.

## Preuves

- **Python (markdown-only, exception C.2)** : 75→75 cellules, 37 cellules markdown modifiées, **0 cellule code touchée**, outputs et execution_count intacts. Round-trip canonique byte-identique. Validation H.3 : PASS 1/1 (29 cellules code). Diff 129/129 équilibré.
- **C# (re-exec complète C.2)** : `.net-csharp` via `exec_dotnet_persist.py` (cwd = dir notebook) → **19/19 cellules, 0 erreur**, `execution_count` 1-19 non-null partout, outputs REELS régénérés reflétant les chaînes corrigées (« Arêtes : 9 paires », « Backtracking amélioré défini », « Exercice à compléter »). Normalisation LF post-exec (l'exécuteur écrit en CRLF) PUIS attestation.
- **Détecteur #2876** : 49 occurrences non accentuées (mesure ai-01) → **2 hits résiduels = 2 faux positifs anglais documentés**.
- **Ré-attestation twin parity (ordre commit-then-update)** : notebook committé (0ff2bd690) → `check_twin_parity.py --update` → yaml committé (4625778ec) → `--check` : **OK=157 DRIFT=0 MISSING=0**.

See #11044 (fenêtre 07-10..07-16 : 2 ALIVE — fix 1/2 = #11133, fix 2/2 = cette PR). See #6495. See #2876.

Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: LIGHT/docs 11133
