### PR TITLE
fix(ci,#11044): ict-tests collection guard prints captured pytest output (#9436 residual)

### DIFF
--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -140,6 +140,7 @@ jobs:
         run: |
           set -uo pipefail
           co_out=$(pytest ${{ matrix.test-args }} --co -q 2>&1) || {
+            printf '%s\n' "$co_out"
             echo "::error title=ICT collection FAILED (${{ matrix.suite-name }})::pytest --co a echoue (exit != 0) -- PANNE D'INFRA (import casse, dep manquante, erreur de syntaxe), PAS une baisse de couverture. La collecte elle-meme a plante ; le plancher n'est pas evalue. Sortie complete de pytest ci-dessus dans le log."
             exit 1
           }


### PR DESCRIPTION
## Grain
Grain: LIGHT/guard — lane myia-po-2023:CoursIA — prev: LIGHT/docs #11136

## Quoi
Epic #11044 nits-retro window 2026-07-31..08-06, finding #9436 (ai-01 APPROVED review residual, explicitly sanctioned: « À folder dans une future PR ICT, pas un hold »).

The collection floor-guard in `.github/workflows/ict-tests.yml` captures `co_out=$(pytest ${{ matrix.test-args }} --co -q 2>&1)`, but command substitution swallows the captured output — while the `::error` message promises « Sortie complete de pytest ci-dessus dans le log ». False promise: nothing was printed above.

Fix (ai-01's own prescription, verbatim): add `printf '%s\n' "$co_out"` before the `::error`, making a collection failure (import cassé / dep manquante) actually visible in the step log.

## Perimetre
1 file, +1 ligne. YAML-only, no notebook touched.

## Preuve
- `python -c "import yaml; yaml.safe_load(...)"` → YAML OK (1 job)
- Diff hunk (post-patch, lines 142-146) shows `printf '%s\n' "$co_out"` immediately before the collection-FAILED `::error`
- Prior behavior verified on origin/main: no `printf` of `co_out` existed before the `::error` (grep)
- Happy path unchanged: printf only executes in the `|| { ... }` failure branch

See #11044 (window report to follow). See #9436 (original review thread).