### PR TITLE
fix(qc,#11044): DualMomentum README.en.md duplicate Sharpe line removal (#9530 residual)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/README.en.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/DualMomentum/README.en.md
@@ -53,7 +53,6 @@ This strategy uses **TLT** as the risk-off asset during bear markets:
 - Removed TLT, replaced with **defensive assets** (XLP, IEF, GLD)
 - Max DD reduced from 33.6% → 23.6% (stale figures)
 - Sharpe improved from 0.350 → 0.469 (stale figures)
-- Sharpe improved from 0.350 → 0.469
 
 ### Lessons Learned
 


### PR DESCRIPTION
## Grain
Grain: LIGHT/readme — lane myia-po-2023:CoursIA — prev: LIGHT/guard #11137

## Quoi
Epic #11044 nits-retro window 2026-07-31..08-06, finding #9530 (Hermes review residual): after the stale-figures patch of #9530, the EN "What changed" block kept **two successive Sharpe lines** — `- Sharpe improved from 0.350 → 0.469 (stale figures)` followed by the unqualified `- Sharpe improved from 0.350 → 0.469` (line the patch forgot to delete).

Fix: remove the unqualified leftover. The remaining line keeps the `(stale figures)` qualifier, consistent with the Honest note and the stale-marked comparison table right above.

## Perimetre
1 file, -1 ligne. README.en.md only (FR mirror has no such block — verified, grep "Sharpe improved" on README.md returns 0).

## Preuve
- origin/main before: `git grep -n "Sharpe improved from 0.350" origin/main` → README.en.md:55 AND :56 (the duplicate)
- After: single occurrence at :55 with `(stale figures)` qualifier
- FR README.md: no "What changed" bullet block (restructured FR body), no mirror duplication

See #11044 (window report to follow). See #9530 (original review thread).