### PR TITLE
fix(iit,#11044): ICT-15c declared-vs-effective n_symbols inline caveat (#9328 residual)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15c-MetaProxyObstruction.ipynb
@@ -162,7 +162,7 @@
     "u = U_final\n",
     "u_q = np.quantile(u.flatten(), np.linspace(0, 1, 5)[1:-1])\n",
     "gray_scott_states = np.digitize(u.flatten(), u_q).tolist()\n",
-    "n_symbols_gs = 4\n",
+    "n_symbols_gs = 4  # déclaré = 4 bins ; effectif = 1 (U constant, tous les pixels dans le même bin ; cf. range [1.0000, 1.0000])\n",
     "print(f\"Gray-Scott : U range=[{u.min():.4f}, {u.max():.4f}], \"\n",
     "      f\"n_symbols={n_symbols_gs}, len(states)={len(gray_scott_states)}\")\n",
     "# --- Substrat 1 : Gray-Scott Turing patterns ---\n",


### PR DESCRIPTION
## Grain
Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA — prev: LIGHT/readme #11138

## Quoi
Epic #11044 nits-retro window 2026-07-31..08-06, finding #9328 (Hermes review residual): the Gray-Scott observable in ICT-15c cell 2 prints `n_symbols=4` (declared quantile bins) while the committed output shows `U range=[1.0000, 1.0000]` — U is constant, so every pixel lands in the same bin and the **effective alphabet is 1**. A reader seeing `n_symbols=4` in the output could be misled about the entropy-bearing content of the trajectory.

Fix = option (b) explicitly offered by the review: inline caveat at the declaration line — `n_symbols_gs = 4  # déclaré = 4 bins ; effectif = 1 (U constant, tous les pixels dans le même bin ; cf. range [1.0000, 1.0000])`.

Option (a) (compute from `len(np.unique(...))`) was NOT taken: it would change `spectral_gap` normalization semantics downstream (signatures cell 7 consumes `n_symbols_gs`), altering the pedagogical results — out of scope for a retro nit.

## Perimetre
1 notebook, 1 source ligne (comment-only). No code semantics change → committed outputs remain valid (C.2 exception for comment-only edits).

## Preuve
- Diff = exactly 1 line: `n_symbols_gs = 4` → same + trailing comment (git diff --unified=0, single -/+ pair)
- `validate_pr_notebooks.py origin/main` → **1/1 PASS (11 cells)**
- Committed output on main (cell 2, ec=2) still shows `U range=[1.0000, 1.0000], n_symbols=4` — the misleading print is what the comment now contextualizes

See #11044 (window report to follow). See #9328 (original review thread).