### PR TITLE
docs(rl,#11044): clarify oos_sharpe semantics in evaluate_dqn docstring

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/train_dqn_rl.py
@@ -356,7 +356,12 @@ def evaluate_dqn(
     device: str = "cpu",
     num_episodes: int = 10,
 ) -> dict:
-    """Evaluate a trained DQN on a test environment (greedy policy, no exploration)."""
+    """Evaluate a trained DQN on a test environment (greedy policy, no exploration).
+
+    ``oos_sharpe`` is a per-episode ratio (mean episode reward / std across
+    episodes), not an annualized per-step financial Sharpe -- do not compare
+    it directly to backtest Sharpe ratios.
+    """
     import torch
 
     rewards = []


### PR DESCRIPTION
## Summary

Epic #11044 nits-retro, window `merged:2026-04-30..2026-05-06` — sole ALIVE finding.

PR #714 review (clusterManager-Myia, APPROVED with nits) left one unaddressed nit:

> **Sharpe formula** (`evaluate_dqn`): `mean(rewards) / std(rewards)` is per-episode Sharpe, not per-step. Acceptable but worth a one-line docstring note.

Measured on `origin/main` (SHA `$(git rev-parse --short origin/main)`): the computation is unchanged — `train_dqn_rl.py:395`:
```python
sharpe = float(rewards_arr.mean() / (rewards_arr.std() + 1e-8))
```
The value lands in `metadata.json` as `oos_sharpe` and is printed as `OOS Sharpe=...` with no qualifier. A reader comparing it to an annualized backtest Sharpe (e.g. QC reports ~1.1) misreads it.

## Change

Docstring-only (script, no notebook execution involved):
```python
"""Evaluate a trained DQN on a test environment (greedy policy, no exploration).

``oos_sharpe`` is a per-episode ratio (mean episode reward / std across
episodes), not an annualized per-step financial Sharpe -- do not compare
it directly to backtest Sharpe ratios.
"""
```

## Validation

- `python -c "import ast; ast.parse(...)"` → AST OK
- `git diff --stat`: 1 file, +6/-1, docstring lines only
- No behavior change; no test surface touched

See #11044 (window report comment to follow).

Grain: LIGHT/docs — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-python #11142