### PR TITLE
fix(ml,#11044): sample std (ddof=1) in analyze_moe_754 multi-seed verdict

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/analyze_moe_754.py
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/analyze_moe_754.py
@@ -43,7 +43,7 @@ def verdict(groups):
         seeds = [e['seed'] for e in entries]
         diraccs = [e['diracc'] for e in entries]
         mean_da = np.mean(diraccs)
-        std_da = np.std(diraccs)
+        std_da = np.std(diraccs, ddof=1)
         delta = mean_da - baseline
         delta_pp = delta * 100
         


### PR DESCRIPTION
## Summary

Epic #11044 nits-retro, window `merged:2026-05-07..2026-05-13`.

PR #907 review (jsboige, COMMENTED, 5 issues) left the statistical items unaddressed. Measured on `origin/main`:

> **1. Verdict logic uses `np.std()` (population std) not `np.std(ddof=1)` (sample std).** With 4 seeds, this underestimates the standard deviation by ~13%, making the "BEATS" verdict slightly easier to achieve.

**Still ALIVE** — `analyze_moe_754.py:46` was `np.std(diraccs)`. Population std at n=4 shrinks the 2-sigma BEATS gate by ~13% — the **anti-conservative** direction, directly against the G.2/§C discipline the harness exists to enforce. Every other verdict script in the pipeline (L3_trend_long_horizon_gpu, L5_vol_targeted_composite) already uses `ddof=1`; this file was the outlier.

## Change

One word: `np.std(diraccs, ddof=1)`.

## Validation

- `python -m pytest tests/test_analyze_moe_754.py -q` → **14 passed**
- No fixture flips: the BEATS fixtures have delta >> 2σ by construction (0.095 vs 2σ≈0.026), and the borderline tx-cost fixture (delta=5e-4 vs 2σ(ddof=1)≈1.8e-4) stays BEATS — asserted by `test_beats_but_not_profitable_after_transaction_costs`.

## Other #907 items — measured verdicts (details in the #11044 window report)

- Asymmetric BEATS/NO-BEATS gates: **ratified** — `tests/test_analyze_moe_754.py` (added later) documents the asymmetric rule as intentional (BEATS = adoption claim needs the high bar; NO BEATS = discard decision). Not re-litigated.
- `torch.cuda.manual_seed_all`: **stale claim** — modern `torch.manual_seed()` seeds all devices (PyTorch docs: "Sets the seed for generating random numbers on all devices").
- `utility_gain_bps` hardcoded 100.0: **fixed since** — `run_volatility_dm_verdict.py:452` now computes `ug["gain_bps"]`.

See #11044.

Grain: LIGHT/training — lane myia-po-2023:CoursIA — prev: LIGHT/docs #11143