### PR TITLE
fix(genai,#11119): README GenAI/Image — 4 descriptions tutorials/ alignees au contenu reel

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Image/README.md
@@ -145,10 +145,10 @@ Section transversale de guides markdown (pas de notebooks) — quatre référenc
 
 | Guide | Sujet |
 |-------|-------|
-| [dalle3-complete-guide](tutorials/dalle3-complete-guide.md) | DALL-E 3 de bout en bout — prompt engineering, exemples, retrait OpenAI et remplacement par gpt-image-1 |
-| [educational-workflows](tutorials/educational-workflows.md) | Concevoir des workflows ComfyUI orientés production pédagogique (vignettes, schémas, planches de cours) |
-| [gpt5-image-analysis-guide](tutorials/gpt5-image-analysis-guide.md) | GPT-5 Image : forces, faiblesses, structure de prompt recommandée, comparaison à gpt-image-1 |
-| [openrouter-ecosystem-guide](tutorials/openrouter-ecosystem-guide.md) | Routage multi-modèles via OpenRouter — DALL-E / GPT-5 / Stability / Recraft / BlackForest Labs selon coût et quota |
+| [dalle3-complete-guide](tutorials/dalle3-complete-guide.md) | DALL-E 3 de bout en bout via l'API OpenAI — prompt engineering, templates pédagogiques, batch et intégration workflows CoursIA |
+| [educational-workflows](tutorials/educational-workflows.md) | Supports de cours, évaluations et présentations via API OpenAI (DALL-E 3 + GPT-5) et OpenRouter — contrôle qualité, accessibilité |
+| [gpt5-image-analysis-guide](tutorials/gpt5-image-analysis-guide.md) | Analyse d'images multimodale GPT-5 via OpenRouter — configuration, templates cas pédagogiques, alt-text, optimisation des coûts |
+| [openrouter-ecosystem-guide](tutorials/openrouter-ecosystem-guide.md) | Routage DALL-E 3 / GPT-5 via OpenRouter — endpoints multiples, fallback, rate limiting et optimisation des coûts |
 
 ## Technologies
 


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet #11140

## Summary

Issue **#11119** : 4 descriptions de la table `tutorials/` du README
[GenAI/Image](MyIA.AI.Notebooks/GenAI/Image/README.md) sur-vendaient le contenu
réel des fichiers. Défaut re-mesuré firsthand sur main (les claims de l'issue
sont confirmés par grep) :

| Guide | Claim README | Réalité (grep sur le fichier) |
|---|---|---|
| `dalle3-complete-guide` | « retrait OpenAI et remplacement par gpt-image-1 » | `gpt-image-1` = 0 hit ; fichier = DALL-E 3 via OpenAI API (10 hits), prompt engineering, templates, batch, intégration workflows CoursIA |
| `educational-workflows` | « workflows ComfyUI orientés production pédagogique » | `comfyui` = 0 hit ; fichier = supports de cours/évaluations/présentations via OpenAI (DALL-E 3 + GPT-5) **et OpenRouter** (34 hits), contrôle qualité, accessibilité WCAG |
| `gpt5-image-analysis-guide` | « comparaison à gpt-image-1 » | `gpt-image-1` = 0 hit ; fichier = analyse d'images multimodale GPT-5 via OpenRouter (config, messages multimodaux, templates cas pédagogiques, alt-text, optimisation coûts) |
| `openrouter-ecosystem-guide` | « DALL-E / GPT-5 / Stability / Recraft / BlackForest Labs » | `stability\|recraft\|blackforest` = 0 hit ; fichier = routage **DALL-E 3 / GPT-5** via OpenRouter (endpoints multiples, fallback, rate limiting & cost optimization) |

**Fix** : les 4 descriptions réécrites pour refléter le contenu réel, sur la base
d'une lecture firsthand des sections H2/H3 + comptes de mots-clés de chaque guide
(pas de recopie des propositions de l'issue sans vérification).

## Validation (acceptance #11119 + règle E)

**Acceptance** — chaque terme cité de chaque nouvelle description vérifié par grep
≥1 hit contre le fichier :

| Description (nouvelle) | Termes clés vérifiés (≥1 hit) |
|---|---|
| dalle3 : « prompt engineering, templates pédagogiques, batch, intégration workflows CoursIA » | DALL-E 3 (5), OpenAI API (2), prompt engineering (2), templates (1), batch (12), workflows CoursIA (2) |
| educational-workflows : « supports de cours, évaluations, présentations, OpenAI (DALL-E 3 + GPT-5), OpenRouter, contrôle qualité, accessibilité » | DALL-E 3 (2), GPT-5 (4), OpenRouter (34), supports de cours (3), évaluations (1), présentations (1), contrôle qualité (1), accessibilité (11) |
| gpt5 : « GPT-5 via OpenRouter, configuration, templates cas pédagogiques, alt-text, optimisation des coûts » | GPT-5 (14), OpenRouter (13), templates (9), alt-text (1), coût (12) |
| openrouter : « DALL-E 3 / GPT-5 via OpenRouter, endpoints multiples, fallback, rate limiting, coûts » | DALL-E 3 (1), GPT-5 (10), OpenRouter (28), fallback (19), rate limiting (7), coût (10) |

**Règle E (audit fichier-entier)** — le README a été relu intégralement et les
autres comptes réconciliés au disque : arborescence `Structure` conforme (6
sous-dossiers + assets), comptes de notebooks par niveau **5/5/3/4** (01/02/03/04,
vérifié `ls` par sous-dossier), `examples/` 3/3, `tutorials/` 4/4. Aucune autre
ligne stale trouvée. Aucun marqueur `CATALOG-STATUS` dans ce README (pas de churn
catalogue).

Diff minimal : 4 insertions / 4 suppressions, une seule ligne par description.

Closes #11119
