### PR TITLE
feat(notebook-tools,#11112): check_exec_sequence — organe de coherence execution_count (etage 1)

### DIFF
--- a/scripts/notebook_tools/check_exec_sequence.py
+++ b/scripts/notebook_tools/check_exec_sequence.py
@@ -1,0 +1,273 @@
+"""Check execution_count sequence coherence of notebooks.
+
+A notebook really executed end-to-end on a fresh kernel necessarily carries
+execution_count 1, 2, 3, ..., N on its code cells: the kernel increments the
+counter at each execution, so two cells cannot share a number within one
+session and a cell cannot carry a smaller number than its predecessor. A
+sequence violating this is the trace of a disordered interactive session
+(cells re-run by hand, order edited after the fact, kernel restarted midway)
+-- the committed outputs, taken together, describe no single run.
+
+All existing gates (H.3 pre-commit, validate_pr_notebooks.py) only check that
+execution_count EXISTS. This organ measures sequence coherence (issue #11112,
+tier 1).
+
+Usage:
+    python check_exec_sequence.py [path] [--tracked-only] [--json]
+                                  [--fail-on DIRTY] [--verbose]
+
+    path          notebook file, directory, or family root
+                  (default: MyIA.AI.Notebooks)
+    --tracked-only  restrict the scan to git-TRACKED files. Reference
+                  measurements MUST use this: working trees hold ignored
+                  artifacts (checkpoints, audit copies) that differ per
+                  machine -- see "measurement basis" below.
+    --json        machine-readable output (one record per notebook)
+    --fail-on VERDICT[,VERDICT...]  exit 1 if any notebook carries one of
+                  these verdicts (default: never fail; tier-2 gate will
+                  pass FAIL_ON here). Accepts DIRTY (= any of DUPLICATE,
+                  UNORDERED, NOT_FROM_1, GAP) and NONCLEAN (= any verdict other
+                  than CLEAN).
+    --verbose     also list CLEAN notebooks
+
+Verdicts (per notebook):
+    CLEAN        sequence is exactly 1..N
+    DUPLICATE    some value appears twice
+    UNORDERED    some value is smaller than its predecessor
+    NOT_FROM_1   first value is not 1
+    GAP          deviates from 1..N with no repeat and no decrease
+                 (e.g. a cell deleted after the run)
+    PARTIAL      at least one code cell has execution_count null (never
+                 executed) -- excluded from coherence statistics, reported
+                 for visibility
+    EMPTY        no non-empty code cells
+    PARSE_ERROR  invalid notebook JSON
+
+The summary counts DUPLICATE / UNORDERED / NOT_FROM_1 / GAP INDEPENDENTLY
+(a sequence can violate several), so the bucket sum exceeds the
+dirty-notebook count.
+
+Measurement basis. Numbers are only comparable when the scanned corpus is.
+On a dirty working tree, rglob picks up ignored artifacts -- e.g. 217 ignored
+.ipynb on one cluster machine vs 0 on another -- silently shifting every
+count. Reference runs therefore use --tracked-only, which intersects the
+scan with `git ls-files`; corpus identity is then the commit, which the
+script prints.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+DIRTY_VERDICTS = {"DUPLICATE", "UNORDERED", "NOT_FROM_1", "GAP"}
+
+
+def sequence_verdict(exec_counts):
+    """Verdict of one notebook's execution_count sequence.
+
+    CLEAN means EXACTLY 1..N (the reference definition: any deviation
+    from range(1, N+1) is dirty). Priority for the single label: NOT_FROM_1,
+    then DUPLICATE, then UNORDERED, then GAP (a hole with no repeat and no
+    decrease -- e.g. a cell deleted after the run). The buckets themselves
+    are counted independently in the summary."""
+    if not exec_counts:
+        return "EMPTY"
+    if any(e is None for e in exec_counts):
+        return "PARTIAL"
+    if exec_counts == list(range(1, len(exec_counts) + 1)):
+        return "CLEAN"
+    if exec_counts[0] != 1:
+        return "NOT_FROM_1"
+    if len(set(exec_counts)) != len(exec_counts):
+        return "DUPLICATE"
+    if any(cur < prev for prev, cur in zip(exec_counts, exec_counts[1:])):
+        return "UNORDERED"
+    return "GAP"
+
+
+def buckets_of(exec_counts):
+    """Independent violation buckets of a fully-executed sequence.
+
+    GAP is the residual bucket: the sequence deviates from 1..N without any
+    of the three named violations."""
+    buckets = set()
+    if exec_counts[0] != 1:
+        buckets.add("NOT_FROM_1")
+    if len(set(exec_counts)) != len(exec_counts):
+        buckets.add("DUPLICATE")
+    if any(cur < prev for prev, cur in zip(exec_counts, exec_counts[1:])):
+        buckets.add("UNORDERED")
+    if not buckets and exec_counts != list(range(1, len(exec_counts) + 1)):
+        buckets.add("GAP")
+    return buckets
+
+
+def family_of(path, root):
+    try:
+        rel = path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return "(outside-root)"
+    parts = rel.parts
+    return parts[0] if len(parts) > 1 else "(root)"
+
+
+def tracked_files(root):
+    """Set of tracked file paths under root, as posix strings relative to CWD."""
+    try:
+        out = subprocess.run(
+            ["git", "ls-files", "--", str(root)],
+            capture_output=True, text=True, check=True,
+        ).stdout
+    except (subprocess.CalledProcessError, OSError) as err:
+        print(f"[!] git ls-files failed ({err}); scanning everything.",
+              file=sys.stderr)
+        return None
+    return {Path(line).as_posix() for line in out.splitlines() if line}
+
+
+def head_commit():
+    try:
+        return subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, OSError):
+        return "?"
+
+
+def scan(target, tracked_only, verbose):
+    root = target if target.is_dir() else target.parent
+    tracked = tracked_files(root) if tracked_only else None
+
+    files = sorted(target.rglob("*.ipynb") if target.is_dir() else [target])
+    records = []
+    for path in files:
+        posix = path.as_posix()
+        if ".ipynb_checkpoints" in posix:
+            continue
+        if tracked is not None and posix not in tracked:
+            continue
+        rec = {"notebook": posix, "family": family_of(path, root),
+               "verdict": "PARSE_ERROR", "sequence": [], "sequence_head": []}
+        try:
+            nb = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            records.append(rec)
+            continue
+        cells = [c for c in nb.get("cells", [])
+                 if c.get("cell_type") == "code"
+                 and "".join(c.get("source", [])).strip()]
+        ec = [c.get("execution_count") for c in cells]
+        rec["verdict"] = sequence_verdict(ec)
+        rec["sequence"] = ec
+        rec["sequence_head"] = ec[:12]
+        records.append(rec)
+    return records
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Check execution_count sequence coherence (issue #11112 tier 1)")
+    ap.add_argument("path", nargs="?", default="MyIA.AI.Notebooks",
+                    help="Notebook file, directory or family root")
+    ap.add_argument("--tracked-only", action="store_true",
+                    help="Restrict scan to git-tracked files (reference mode)")
+    ap.add_argument("--json", action="store_true", dest="as_json",
+                    help="One JSON record per notebook")
+    ap.add_argument("--fail-on", default="",
+                    help="Comma-separated verdicts that make the run exit 1 "
+                         "(DIRTY = DUPLICATE|UNORDERED|NOT_FROM_1|GAP)")
+    ap.add_argument("--verbose", action="store_true",
+                    help="Also list CLEAN notebooks")
+    args = ap.parse_args()
+
+    target = Path(args.path)
+    if not target.exists():
+        ap.error(f"path not found: {target}")
+
+    records = scan(target, args.tracked_only, args.verbose)
+
+    # Summary: buckets are counted independently over fully-executed seqs.
+    bucket_counts = {"DUPLICATE": 0, "UNORDERED": 0, "NOT_FROM_1": 0,
+                     "GAP": 0}
+    for r in records:
+        if r["verdict"] not in DIRTY_VERDICTS and r["verdict"] != "CLEAN":
+            continue
+        for b in buckets_of(r["sequence"]):
+            bucket_counts[b] += 1
+
+    by_verdict = {}
+    for r in records:
+        by_verdict[r["verdict"]] = by_verdict.get(r["verdict"], 0) + 1
+    clean = by_verdict.get("CLEAN", 0)
+    dirty = sum(by_verdict.get(v, 0) for v in DIRTY_VERDICTS)
+
+    fam_dirty = {}
+    for r in records:
+        if r["verdict"] in DIRTY_VERDICTS:
+            fam_dirty[r["family"]] = fam_dirty.get(r["family"], 0) + 1
+
+    if args.as_json:
+        print(json.dumps({
+            "basis": {"tracked_only": args.tracked_only,
+                      "commit": head_commit(), "root": str(target)},
+            "summary": {"scanned": len(records),
+                        "fully_executed": clean + dirty,
+                        "clean": clean, "dirty": dirty,
+                        "buckets": bucket_counts,
+                        "other": {k: v for k, v in by_verdict.items()
+                                  if k not in DIRTY_VERDICTS | {"CLEAN"}}},
+            "records": records}, ensure_ascii=False, indent=1))
+        return
+
+    basis = (f"tracked-only @ {head_commit()}" if args.tracked_only
+             else f"working tree @ {head_commit()}")
+    print(f"execution_count sequence check -- {basis}")
+    print(f"scanned            : {len(records)}")
+    print(f"fully executed     : {clean + dirty}")
+    print(f"  CLEAN (1..N)     : {clean}"
+          + (f"  ({100.0 * clean / (clean + dirty):.1f}%)" if clean + dirty else ""))
+    print(f"  DIRTY notebooks  : {dirty}"
+          + (f"  ({100.0 * dirty / (clean + dirty):.1f}%)" if clean + dirty else ""))
+    print(f"buckets (independent, sum >= dirty):")
+    for b in ("DUPLICATE", "UNORDERED", "NOT_FROM_1", "GAP"):
+        print(f"  {b:<12}: {bucket_counts[b]}")
+    others = {k: v for k, v in by_verdict.items()
+              if k not in DIRTY_VERDICTS | {"CLEAN"}}
+    if others:
+        print(f"excluded from coherence stats: {others}")
+    if fam_dirty:
+        print("dirty by family:")
+        for fam, n in sorted(fam_dirty.items(), key=lambda kv: -kv[1]):
+            print(f"  {fam:<14} {n}")
+    for r in records:
+        if r["verdict"] == "CLEAN" and not args.verbose:
+            continue
+        head = r["sequence_head"]
+        seq = "[" + ", ".join("None" if e is None else str(e) for e in head) \
+            + (", ..." if len(head) == 12 else "") + "]"
+        print(f"{r['verdict']:<12} {r['notebook']:<70} {seq}")
+
+    if args.fail_on:
+        wanted = set()
+        for tok in args.fail_on.split(","):
+            tok = tok.strip().upper()
+            if not tok:
+                continue
+            if tok == "DIRTY":
+                wanted |= DIRTY_VERDICTS
+            elif tok == "NONCLEAN":
+                wanted |= set(by_verdict) - {"CLEAN"}
+            else:
+                wanted.add(tok)
+        hits = [r for r in records if r["verdict"] in wanted]
+        if hits:
+            print(f"\nFAIL: {len(hits)} notebook(s) match --fail-on "
+                  f"{sorted(wanted & set(by_verdict))}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/notebook_tools/tests/test_check_exec_sequence.py
+++ b/scripts/notebook_tools/tests/test_check_exec_sequence.py
@@ -1,0 +1,188 @@
+"""Tests for check_exec_sequence.py — execution_count coherence organ (#11112 tier 1).
+
+Pins the verdict logic (CLEAN / DUPLICATE / UNORDERED / NOT_FROM_1 / PARTIAL
+/ EMPTY / PARSE_ERROR), the independent bucket counting, the --fail-on exit
+semantics, and the --tracked-only corpus restriction -- the measurement-basis
+guarantee that reference numbers are commit-anchored, not working-tree
+anchored. No network, no kernel.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import check_exec_sequence as ces
+
+
+class TestVerdict:
+    def test_clean(self):
+        assert ces.sequence_verdict([1, 2, 3]) == "CLEAN"
+
+    def test_clean_single(self):
+        assert ces.sequence_verdict([1]) == "CLEAN"
+
+    def test_duplicate(self):
+        assert ces.sequence_verdict([1, 2, 3, 5, 5, 6]) == "DUPLICATE"
+
+    def test_unordered(self):
+        assert ces.sequence_verdict([1, 2, 3, 4, 5, 11, 6]) == "UNORDERED"
+
+    def test_not_from_1(self):
+        assert ces.sequence_verdict([2, 3, 4]) == "NOT_FROM_1"
+
+    def test_not_from_1_beats_duplicate(self):
+        # priority: NOT_FROM_1 > DUPLICATE > UNORDERED for the single label
+        assert ces.sequence_verdict([2, 3, 2]) == "NOT_FROM_1"
+
+    def test_duplicate_beats_unordered(self):
+        assert ces.sequence_verdict([1, 2, 2, 1]) == "DUPLICATE"
+
+    def test_partial_null(self):
+        assert ces.sequence_verdict([1, 2, None, 4]) == "PARTIAL"
+
+    def test_empty(self):
+        assert ces.sequence_verdict([]) == "EMPTY"
+
+    def test_restarted_kernel_tail_one(self):
+        # the 10_LocalLlama signature: [..., 1] at the end = re-run cell
+        assert ces.sequence_verdict([2, 3, 4, 5, 4, 5, 6, 7, 8, 9, 10, 1]) \
+            == "NOT_FROM_1"
+
+    def test_pure_gap_is_gap(self):
+        # a hole (4 missing) with no repeat and no decrease: dirty per the
+        # reference definition (propre = exactly 1..N), labeled GAP
+        seq = [1, 2, 3, 5, 6, 7]
+        assert ces.sequence_verdict(seq) == "GAP"
+        assert ces.buckets_of(seq) == {"GAP"}
+
+
+class TestBuckets:
+    def test_independent_buckets_overlap(self):
+        # DUPLICATE + UNORDERED + (from 1) simultaneously
+        assert ces.buckets_of([1, 2, 2, 1]) == {"DUPLICATE", "UNORDERED"}
+
+    def test_duplicate_and_gap_disjoint(self):
+        # DUPLICATE dominates: [1,2,2,4] has both a repeat and a hole (3),
+        # but GAP is only the residual when no named violation exists
+        assert ces.buckets_of([1, 2, 2, 4]) == {"DUPLICATE"}
+
+    def test_not_from_1_bucket(self):
+        assert ces.buckets_of([3, 4, 5]) == {"NOT_FROM_1"}
+
+    def test_clean_buckets_empty(self):
+        assert ces.buckets_of([1, 2, 3, 4]) == set()
+
+
+def _write_nb(tmp_path, exec_counts, name="nb.ipynb"):
+    nb = {
+        "cells": [
+            {"cell_type": "code", "execution_count": e, "outputs": [],
+             "source": [f"# cell {i}"]}
+            for i, e in enumerate(exec_counts, 1)
+        ],
+        "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+    }
+    p = tmp_path / name
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    return p
+
+
+class TestScan:
+    def test_scan_verdicts(self, tmp_path):
+        _write_nb(tmp_path, [1, 2, 3], name="clean.ipynb")
+        _write_nb(tmp_path, [1, 2, 2], name="dup.ipynb")
+        (tmp_path / "broken.ipynb").write_text("{not json", encoding="utf-8")
+        recs = ces.scan(tmp_path, tracked_only=False, verbose=False)
+        by_name = {r["notebook"].split("/")[-1]: r["verdict"] for r in recs}
+        assert by_name["clean.ipynb"] == "CLEAN"
+        assert by_name["dup.ipynb"] == "DUPLICATE"
+        assert by_name["broken.ipynb"] == "PARSE_ERROR"
+
+    def test_scan_skips_empty_source_cells(self, tmp_path):
+        # a cell with empty source must not count toward the sequence
+        nb = {"cells": [
+            {"cell_type": "code", "execution_count": 1, "outputs": [],
+             "source": ["print(1)"]},
+            {"cell_type": "code", "execution_count": None, "outputs": [],
+             "source": [""]},
+        ], "metadata": {}, "nbformat": 4}
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        recs = ces.scan(tmp_path, tracked_only=False, verbose=False)
+        assert recs[0]["verdict"] == "CLEAN"
+
+    def test_tracked_only_restricts_corpus(self, tmp_path, monkeypatch):
+        tracked = tmp_path / "MyIA.AI.Notebooks"
+        tracked.mkdir()
+        _write_nb(tracked, [1, 2], name="kept.ipynb")
+        untracked_dir = tmp_path / ".ipynb_checkpoints"
+        untracked_dir.mkdir()
+        _write_nb(untracked_dir, [9, 9], name="ignored.ipynb")
+
+        def fake_ls_files(root):
+            return {str(tracked / "kept.ipynb").replace("\\", "/")}
+
+        monkeypatch.setattr(ces, "tracked_files", fake_ls_files)
+        recs = ces.scan(tmp_path, tracked_only=True, verbose=False)
+        names = [r["notebook"].split("/")[-1] for r in recs]
+        assert names == ["kept.ipynb"]
+
+    def test_checkpoints_always_excluded(self, tmp_path):
+        cp = tmp_path / ".ipynb_checkpoints"
+        cp.mkdir()
+        _write_nb(cp, [9, 9], name="cp.ipynb")
+        recs = ces.scan(tmp_path, tracked_only=False, verbose=False)
+        assert recs == []
+
+
+class TestFailOnCLI:
+    def test_run_script_fail_on(self, tmp_path):
+        import subprocess
+        script = Path(ces.__file__)
+        _write_nb(tmp_path, [1, 2, 2], name="dup.ipynb")
+        res = subprocess.run(
+            [sys.executable, str(script), str(tmp_path), "--fail-on", "DIRTY"],
+            capture_output=True, text=True)
+        assert res.returncode == 1
+        assert "FAIL" in res.stdout
+
+    def test_run_script_clean_passes(self, tmp_path):
+        import subprocess
+        script = Path(ces.__file__)
+        _write_nb(tmp_path, [1, 2, 3], name="ok.ipynb")
+        res = subprocess.run(
+            [sys.executable, str(script), str(tmp_path), "--fail-on", "DIRTY"],
+            capture_output=True, text=True)
+        assert res.returncode == 0
+
+    def test_run_script_summary_counts_gap_as_dirty(self, tmp_path):
+        # regression: the summary's dirty total once summed only the three
+        # named verdicts, silently dropping GAP notebooks from every count
+        import subprocess
+        script = Path(ces.__file__)
+        _write_nb(tmp_path, [1, 2, 3], name="ok.ipynb")
+        _write_nb(tmp_path, [1, 2, 4], name="gap.ipynb")
+        res = subprocess.run(
+            [sys.executable, str(script), str(tmp_path), "--json"],
+            capture_output=True, text=True)
+        s = json.loads(res.stdout)["summary"]
+        assert s["scanned"] == 2
+        assert s["fully_executed"] == 2
+        assert s["clean"] == 1
+        assert s["dirty"] == 1
+        assert s["buckets"]["GAP"] == 1
+
+    def test_run_script_json(self, tmp_path):
+        import subprocess
+        script = Path(ces.__file__)
+        _write_nb(tmp_path, [1, 2, 3], name="ok.ipynb")
+        res = subprocess.run(
+            [sys.executable, str(script), str(tmp_path), "--json"],
+            capture_output=True, text=True)
+        assert res.returncode == 0
+        data = json.loads(res.stdout)
+        assert data["summary"]["scanned"] == 1
+        assert data["summary"]["clean"] == 1


### PR DESCRIPTION
`Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #11132`

## Quoi

Étage 1 de #11112 : `scripts/notebook_tools/check_exec_sequence.py` — organe de mesure de la **cohérence de séquence** des `execution_count` (un notebook réellement exécuté end-to-end sur kernel frais porte forcément `1..N` ; toute déviation = trace d'une session interactive désordonnée = les outputs committés ne décrivent aucune exécution unique).

Les gates existants (H.3, `validate_pr_notebooks.py`) ne vérifient que l'**existence** d'`execution_count`. Cet organe mesure la **cohérence de séquence** :

- **Verdicts** : `CLEAN` (= exactement 1..N) / `DUPLICATE` / `UNORDERED` / `NOT_FROM_1` / `GAP` (trou pur, ex. cellule supprimée après exécution) / `PARTIAL` (exec_null, exclu des stats, reporté) / `EMPTY` / `PARSE_ERROR`.
- **Buckets comptés indépendamment** (une séquence peut violer plusieurs critères — somme des buckets ≥ nombre de notebooks DIRTY).
- **`--tracked-only`** : restreint le scan au corpus **git-tracked**. Base de mesure = **le commit**, pas l'arbre de travail : un arbre sale contient des artefacts ignorés (217 `.ipynb` ignorés observés sur une machine de cluster) qui décalent silencieusement chaque comptage — c'est la cause racine de l'écart avec la mesure initiale de l'issue.
- **`--fail-on DIRTY|NONCLEAN|<verdict>`** : exit 1 si un notebook porte le verdict — prêt pour le gate CI de l'étage 2.
- **`--json`** : sortie machine-readable, une entrée par notebook (verdict + séquence complète).

Tests : 22 + 1 (dont régression du total DIRTY oubliant GAP — attrapé par le test), suite `scripts/notebook_tools` complète **4603 passed / 2 skipped**.

## Preuve

Sortie de référence (mesure reproductible, commit-anchored) :

```
execution_count sequence check -- tracked-only @ 512577d98
scanned            : 1013
fully executed     : 961
  CLEAN (1..N)     : 836  (87.0%)
  DIRTY notebooks  : 125  (13.0%)
buckets (independent, sum >= dirty):
  DUPLICATE   : 98
  UNORDERED   : 106
  NOT_FROM_1  : 6
  GAP         : 2
excluded from coherence stats: {'PARTIAL': 52}
dirty by family:
  GenAI          54
  SymbolicAI     20
  ML             16
  Sudoku         16
  Probas         7
  Search         5
  GameTheory     3
  IIT            2
  QuantConnect   2
```

Même ordre de grandeur que la mesure initiale de l'issue (126 / 12.3%) — l'écart résiduel vient de la base de mesure : l'issue a été mesurée sur un arbre sale (217 artefacts `.ipynb` ignorés), la référence ici est commit-anchored.

## Périmètre

- **Étage 1** (cette PR) : organe de mesure + tests. Aucun notebook modifié, aucun gate imposé.
- **Étages 2-3** (#11112, ouvertes) : gate CI ratchet `--fail-on DIRTY` sur les notebooks touchés par PR (étage 2) ; rollout de re-exécution famille-partitionné des 125 DIRTY (étage 3).
- Catalogue : aucun fichier catalogue/README touché (byte-identique à main).

See #11112
