### PR TITLE
fix(probas,#11127): citation Gill (2011) — Statistica Neerlandica 65(1):58-71 + DOI (Infer-3, PyMC-3)

### DIFF
--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
@@ -1668,7 +1668,7 @@
     "C'est cette **asymétrie d'information** qui crée le paradoxe. L'action de Monty révèle indirectement où est la voiture.\n",
     "\n",
     "> **Intuition correcte** : En changeant, vous captez les 2/3 de chance initiale que la voiture soit derrière l'une des portes non choisies. Avant l'ouverture, cette probabilité était répartie sur 2 portes. Après, elle se concentre sur une seule.",
-    "\n\n> **Source** : Le paradoxe de Monty Hall, popularisé par Marilyn vos Savant (*Parade Magazine*, 1990), et sa résolution bayésienne sont analysés dans Gill (2011), *The Monty Hall Problem is not a Probability Puzzle* (Comptes Rendus Mathématique **349**(23-24):1325-1330) : le renversement d'intuition vient du conditionnement sur l'information *que Monty a révélé une chèvre* (et non sur la porte ouverte elle-même), d'où P(gagner en changeant) = 2/3.\n"
+    "\n\n> **Source** : Le paradoxe de Monty Hall, popularisé par Marilyn vos Savant (*Parade Magazine*, 1990), et sa résolution bayésienne sont analysés dans Gill (2011), *The Monty Hall Problem is not a Probability Puzzle* (Statistica Neerlandica **65**(1):58-71, [DOI: 10.1111/j.1467-9574.2010.00474.x](https://doi.org/10.1111/j.1467-9574.2010.00474.x)) : le renversement d'intuition vient du conditionnement sur l'information *que Monty a révélé une chèvre* (et non sur la porte ouverte elle-même), d'où P(gagner en changeant) = 2/3.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
+++ b/MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
@@ -474,7 +474,7 @@
     "3. Le joueur doit-il garder son choix ou changer ?\n",
     "\n",
     "\n",
-    "> *Source.* Le paradoxe de Monty Hall a été popularisé par Marilyn vos Savant (*Parade Magazine*, 1990). Sa résolution bayésienne et la controverse qu'elle suscita sont analysées dans Gill (2011), *The Monty Hall Problem is not a Probability Puzzle* (Comptes Rendus Mathématique **349**(23-24):1325-1330) — il illustre comment le conditionnement sur l'information *que Monty a révélé une chèvre* (et non sur la porte ouverte elle-même) renverse l'intuition (P(gagner en changeant) = 2/3).\n",
+    "> *Source.* Le paradoxe de Monty Hall a été popularisé par Marilyn vos Savant (*Parade Magazine*, 1990). Sa résolution bayésienne et la controverse qu'elle suscita sont analysées dans Gill (2011), *The Monty Hall Problem is not a Probability Puzzle* (Statistica Neerlandica **65**(1):58-71, [DOI: 10.1111/j.1467-9574.2010.00474.x](https://doi.org/10.1111/j.1467-9574.2010.00474.x)) — il illustre comment le conditionnement sur l'information *que Monty a révélé une chèvre* (et non sur la porte ouverte elle-même) renverse l'intuition (P(gagner en changeant) = 2/3).\n",
     "\n",
     "### Infer.NET : `Variable.Case`\n",
     "```csharp\n",

--- a/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
@@ -10,6 +10,12 @@
       by: myia-po-2023:CoursIA-2
       python_sha: 5929bd4bbe321ca89056a4d92209fdb5b30bc821
       csharp_sha: fa2c2ffdbc5dc5aaff9bfe03316c262cd926f150
+    - date: "2026-08-16"
+      by: myia-ai-01:CoursIA
+      python_sha: 8be87123cf063f6743db86bcd1bb2cd97f944020
+      csharp_sha: 4024549ae3bb76a1fa276174a77c6602fa9671c2
+      content_python_sha: 2e3a92140ef42a21c65bcf464d784e37b9e2856902c779b303310de7c682b0dc
+      content_csharp_sha: 9718209c7ab6079d9f258fe5571077662ff7ad00d63ff0e41d721d5da085f595
   known_differences:
   - 'Socle pedagogique commun : graphes de facteurs et variables aleatoires modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11158

## Summary

Issue **#11127** : la citation `Gill (2011)` — *The Monty Hall Problem is not a
Probability Puzzle* — portait un lieu de publication erroné dans deux
notebooks : *Comptes Rendus Mathématique* **349**(23-24):1325-1330.

**Vérification bibliographique firsthand** (l'audit #8052 exige une citation
vérifiable) : la publication réelle est *Statistica Neerlandica* **65**(1):58-71,
DOI **10.1111/j.1467-9574.2010.00474.x** — confirmée par Wiley Online Library
(doi.org/10.1111/j.1467-9574.2010.00474.x), RePEc
(ideas.repec.org/a/bla/stanee/v65y2011i1p58-71.html) et le PDF arXiv:1002.0651
de l'auteur (Leiden). Le nit NanoClaw avait raison ; les deux notebooks
portaient le défaut depuis le nit (juillet), jamais corrigé.

## Fix

Correction du lieu + ajout du DOI (lien markdown) dans les 2 cellules markdown
de source :

- `Probas/Infer/Infer-3-Factor-Graphs.ipynb` cell[28]
- `Probas/PyMC/PyMC-3-Factor-Graphs.ipynb` (cellule Source Monty Hall)

## Validation

- `git grep -c "Comptes Rendus"` sur les deux fichiers = **0 hit** (acceptance).
- Diff : 2 fichiers, **+2/−2** — uniquement la ligne de citation dans chaque
  cellule markdown (ni outputs, ni `execution_count` touchés ; markdown-only,
  C.3 dispense re-exec).
- Citation complète vérifiable : titre + lieu *Statistica Neerlandica*
  65(1):58-71 + DOI (liens RePEc/Wiley concordants).

Closes #11127 (acceptance complète) · See #11044 · See #8052
