### PR TITLE
fix(prover,#11120): align p4_final_verify docstrings with actual behavior (no cross-check)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/p4_final_verify.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/p4_final_verify.py
@@ -17,11 +17,13 @@ lost, exhumed only by manual span extraction).
 
 Fix (#7477 P4): promote the authoritative ``": error:"`` substring contract
 (#6831, ``prover.tools._parse_lean_errors``) to the PRIMARY signal of a clean
-build; demote ``level_1_build`` to a secondary cross-check. A genuine build
-failure ALWAYS produces >=1 parseable compile error in the verifier's raw
-output, so promoting the substring contract does not mask real breakage.
-The ``level_1_build`` cross-check lets the call-site log a discrepancy when
-the two signals disagree (notably the DEMO 62 false-negative pattern).
+build and fully demote ``level_1_build`` -- it is no longer read at all, not
+as a gate and not as a cross-check (see ``_evaluate_final_verify`` below). A
+genuine build failure ALWAYS produces >=1 parseable compile error in the
+verifier's raw output, so promoting the substring contract does not mask real
+breakage; a ``level_1_build`` disagreeing with the substring verdict (the DEMO
+62 false-negative pattern) is expected to remain silent -- the substring
+contract is authoritative.
 
 The multi-agent path (#870-919) already calls ``_reverify_compiles_clean``
 + ``_final_verify_is_false_negative`` for the same purpose -- this helper is

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -1915,8 +1915,8 @@ class AutonomousProver:
         # (#6831) -- not on level_1_build alone, which is manifest/cache-
         # sensitive (DEMO 62 L2892 2026-07-16). A sorry increase from
         # strategic decomposition must NOT trigger revert if the build passes.
-        # _evaluate_final_verify promotes _parse_lean_errors to primary,
-        # demotes level_1_build to secondary cross-check.
+        # _evaluate_final_verify promotes _parse_lean_errors to primary and
+        # no longer reads level_1_build at all (fully demoted, no cross-check).
         final_verify_ok = _evaluate_final_verify(verify_result)
         final_build_ok = final_verify_ok
         # Update final_sorry from compile result (includes implicit sorry detection)

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_p4_l1_false_negative.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_p4_l1_false_negative.py
@@ -13,10 +13,10 @@ extraction).
 Fix (#7477 P4): extract ``_evaluate_final_verify(verify_result)`` in
 ``prover/p4_final_verify.py`` (stdlib-only) that promotes the authoritative
 ``: error:`` substring contract (#6831, ``prover.tools._parse_lean_errors``)
-to the PRIMARY signal and demotes ``level_1_build`` to a secondary
-cross-check. A genuine build failure always produces >=1 parseable compile
-error in the raw lake output, so promoting the substring contract does not
-mask real breakage.
+to the PRIMARY signal and fully demotes ``level_1_build`` -- it is no longer
+read at all, neither as a gate nor as a cross-check. A genuine build failure
+always produces >=1 parseable compile error in the raw lake output, so
+promoting the substring contract does not mask real breakage.
 
 These tests load ``prover/p4_final_verify.py`` by file path (bypassing
 ``prover/__init__.py`` and the LLM stack) and stub
@@ -206,11 +206,11 @@ def test_real_compile_failure_module_level_error():
 
 
 def test_level_1_build_true_does_not_save_us_from_real_errors():
-    """Defensive cross-check: even when ``level_1_build=True`` (the
+    """Defensive check: even when ``level_1_build=True`` (the
     historical primary signal would say PASS), if the raw output contains
     a real ``: error:`` substring, the helper MUST return ``False``.
-    The substring contract is the primary signal; level_1_build is the
-    secondary cross-check only (not the other way around)."""
+    The substring contract is the primary signal; ``level_1_build`` is
+    never consulted (fully demoted, not the gate)."""
     real_failure_subordinate = {
         "level_1_build": True,
         "error_count": 0,


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11163

> **Tag re-qualifié par le coordinateur au merge** (`MED/lean` → `LIGHT/docs`, variation-protocol §3). Le GENRE est le type de travail, jamais la famille où vivent les fichiers : le diff touche trois `.py` du harnais prover, aucun `.lean`, et le livrable est de la prose. Le test de §1 — « si le prochain grain de ce rollout tombait dans une autre famille, changerais-je le GENRE ? » — répond oui, donc `lean` décrivait le répertoire traversé. L'issue #11120 elle-même tague le travail `MED/docs`. Le TIER descend à LIGHT par le litmus (« générable en série en scannant l'instance suivante » : les docstrings qui promettent plus que leur corps sont une classe scannable) ; les 249+10 tests verts prouvent une **non**-régression, pas un changement. Re-qualification faite **dans le body** et non en commentaire, sinon le cap G-VAR-2 continuerait de compter faux. Rien à changer au contenu.

## Summary

Issue **#11120** : la docstring de module `p4_final_verify.py` promettait un
mécanisme inexistant — « demote ``level_1_build`` to a secondary
cross-check … lets the call-site log a discrepancy when the two signals
disagree ». L'implémentation réelle (`_evaluate_final_verify`) ne lit jamais
`level_1_build` (ni gate, ni cross-check, ni logging) et la docstring de
**fonction** le dit déjà (« intentionally NOT consulted as a gate »). Le
comportement est délibéré (incident fondateur DEMO 62 : le substring
contract est autoritatif), c'est la **documentation** qui décrivait un
mécanisme absent.

## Fix (option b de l'issue)

Correction documentaire, pas de changement de comportement :

- `p4_final_verify.py` module docstring (L18-24) : décrit la **démotion pure**
  de `level_1_build` (plus lu du tout), pas un cross-check+logging.
- `provers.py` commentaire call-site (L1913-1919) : aligné (« fully
  demoted, no cross-check »).
- `tests/test_p4_l1_false_negative.py` : 2 mentions « secondary
  cross-check » alignées (docstring module + docstring du test défensif).

Choix motivé : l'option (a) (implémenter le cross-check) aurait ajouté une
feature non demandée à un prover tournant en boucle, pour servir une doc
qui promettait trop — l'acceptance de l'issue est satisfaite par (b)
(docstring ↔ corps ↔ call-sites décrivent le même comportement).

## Validation

- `grep -in discrepanc` sur les 3 fichiers = **0 hit** (acceptance de l'issue).
- **10/10** `test_p4_l1_false_negative.py` passent (comportement inchangé).
- **249/249** tests prover adjacents (`test_prover_guards`,
  `test_prover_forensic_guards`, `test_prover_heartbeat_budget`) passent.
- `py_compile` OK sur les 2 fichiers de production.
- Diff : 3 fichiers, **+16/−14**, docstrings/commentaires uniquement.

Closes #11120 (acceptance complète) · See #11044 · See #7477

