### PR TITLE
fix(notebooks,#11168): FallacyDetection arXiv citations — Jin et al. is Findings of EMNLP 2022, not 2021

### DIFF
--- a/MyIA.AI.Notebooks/FallacyDetection/02_fallacy_datasets_landscape.ipynb
+++ b/MyIA.AI.Notebooks/FallacyDetection/02_fallacy_datasets_landscape.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "47c69fd0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002507,
+     "end_time": "2026-08-16T00:56:19.410897+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:19.408390+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# 02 — Paysage des datasets de detection de sophismes\n",
     "\n",
@@ -17,8 +26,26 @@
   {
    "cell_type": "markdown",
    "id": "f9a72029",
-   "metadata": {},
-   "source": "## Methodologie\n\nPour chaque dataset, on tente :\n1. **Resolution de l'endpoint canonique** (API REST HF / GitHub / URL directe) — capture du code HTTP.\n2. **Metadata + cardinalite** (taille, nombre de lignes / classes, licence) depuis l'endpoint ou le manifeste.\n3. **Pertinence pour la taxonomie Argumentum** (1408 sophismes / 8 familles, multilingue 8 langues) — le dataset est-il etiquete en fallacies, et dans quelle grille ?\n\nDate d'acces : `2026-08-10`. Chaque chiffre est sourcé par l'URL de l'endpoint interrogé. Les échecs sont explicites (critère 2 : \"succès ou échec documenté\")."
+   "metadata": {
+    "papermill": {
+     "duration": 0.001974,
+     "end_time": "2026-08-16T00:56:19.417181+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:19.415207+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Methodologie\n",
+    "\n",
+    "Pour chaque dataset, on tente :\n",
+    "1. **Resolution de l'endpoint canonique** (API REST HF / GitHub / URL directe) — capture du code HTTP.\n",
+    "2. **Metadata + cardinalite** (taille, nombre de lignes / classes, licence) depuis l'endpoint ou le manifeste.\n",
+    "3. **Pertinence pour la taxonomie Argumentum** (1408 sophismes / 8 familles, multilingue 8 langues) — le dataset est-il etiquete en fallacies, et dans quelle grille ?\n",
+    "\n",
+    "Date d'acces : `2026-08-10`. Chaque chiffre est sourcé par l'URL de l'endpoint interrogé. Les échecs sont explicites (critère 2 : \"succès ou échec documenté\")."
+   ]
   },
   {
    "cell_type": "code",
@@ -26,18 +53,26 @@
    "id": "e52acbd5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:22.556891Z",
-     "iopub.status.busy": "2026-08-10T20:56:22.556724Z",
-     "iopub.status.idle": "2026-08-10T20:56:22.982038Z",
-     "shell.execute_reply": "2026-08-10T20:56:22.981479Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:19.422504Z",
+     "iopub.status.busy": "2026-08-16T00:56:19.422305Z",
+     "iopub.status.idle": "2026-08-16T00:56:21.501143Z",
+     "shell.execute_reply": "2026-08-16T00:56:21.500452Z"
+    },
+    "papermill": {
+     "duration": 2.082926,
+     "end_time": "2026-08-16T00:56:21.502019+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:19.419093+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Date d'acces : 2026-08-10\n",
+      "Date d'acces : 2026-08-16\n",
       "Session HTTP prete.\n"
      ]
     }
@@ -73,12 +108,21 @@
   {
    "cell_type": "markdown",
    "id": "6a1317cc",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002061,
+     "end_time": "2026-08-16T00:56:21.506455+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:21.504394+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
-    "### Dataset 1 — Logic / LogicClimate (Jin et al. 2021)\n",
+    "### Dataset 1 — Logic / LogicClimate (Jin et al. 2022)\n",
     "\n",
-    "**Papier** : Jin et al., *Logical Fallacy Detection*, Findings EMNLP 2021 — [arXiv:2202.13758](https://arxiv.org/abs/2202.13758). Premier dataset de sophismes pour deep learning : **13 types** de sophismes + challenge set **LogicClimate** (sophismes sur le changement climatique). Repo GitHub : `causalNLP/logical-fallacy`."
+    "**Papier** : Jin et al., *Logical Fallacy Detection*, Findings of EMNLP 2022 — [arXiv:2202.13758](https://arxiv.org/abs/2202.13758). Premier dataset de sophismes pour deep learning : **13 types** de sophismes + challenge set **LogicClimate** (sophismes sur le changement climatique). Repo GitHub : `causalNLP/logical-fallacy`."
    ]
   },
   {
@@ -87,11 +131,19 @@
    "id": "e133b838",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:22.984139Z",
-     "iopub.status.busy": "2026-08-10T20:56:22.983906Z",
-     "iopub.status.idle": "2026-08-10T20:56:24.005989Z",
-     "shell.execute_reply": "2026-08-10T20:56:24.000808Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:21.511513Z",
+     "iopub.status.busy": "2026-08-16T00:56:21.511218Z",
+     "iopub.status.idle": "2026-08-16T00:56:22.366600Z",
+     "shell.execute_reply": "2026-08-16T00:56:22.366139Z"
+    },
+    "papermill": {
+     "duration": 0.858973,
+     "end_time": "2026-08-16T00:56:22.367451+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:21.508478+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -100,7 +152,7 @@
      "text": [
       "GitHub API causalNLP/logical-fallacy: HTTP 200\n",
       "  description: Repo for the paper \"Detecting Logical Fallacies: From Quiz to Climate Change News\" (2021)\n",
-      "  stars: 91  size(KB): 10191  license: None\n"
+      "  stars: 92  size(KB): 10191  license: None\n"
      ]
     },
     {
@@ -128,19 +180,28 @@
     "            if p.endswith((\".csv\", \".json\", \".tsv\", \".txt\")):\n",
     "                data_files.append(p)\n",
     "    print(f\"  fichiers de donnees trouves ({len(data_files)}): {data_files[:8]}\")\n",
-    "    record(\"Logic/LogicClimate (Jin 2021)\", \"accessible (GitHub)\",\n",
+    "    record(\"Logic/LogicClimate (Jin 2022)\", \"accessible (GitHub)\",\n",
     "           \"13 classes + challenge set LogicClimate\", (meta.get('license') or {}).get('spdx_id') or 'MIT (repo)',\n",
     "           \"13 types de sophismes\", \"challenge set climatique inclus\", f\"https://github.com/{repo}\")\n",
     "else:\n",
     "    print(f\"  ECHEC : {meta}\")\n",
-    "    record(\"Logic/LogicClimate (Jin 2021)\", \"echec (GitHub API)\", \"N/A\", \"N/A\", \"13 (attendu)\", str(meta)[:80],\n",
+    "    record(\"Logic/LogicClimate (Jin 2022)\", \"echec (GitHub API)\", \"N/A\", \"N/A\", \"13 (attendu)\", str(meta)[:80],\n",
     "           f\"https://github.com/{repo}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "cf369529",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002409,
+     "end_time": "2026-08-16T00:56:22.372733+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:22.370324+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "### Dataset 2 — MAFALDA (Helwe et al. 2023)\n",
@@ -154,18 +215,26 @@
    "id": "0e266112",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:24.020849Z",
-     "iopub.status.busy": "2026-08-10T20:56:24.019024Z",
-     "iopub.status.idle": "2026-08-10T20:56:24.672739Z",
-     "shell.execute_reply": "2026-08-10T20:56:24.669173Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:22.378831Z",
+     "iopub.status.busy": "2026-08-16T00:56:22.378613Z",
+     "iopub.status.idle": "2026-08-16T00:56:22.644732Z",
+     "shell.execute_reply": "2026-08-16T00:56:22.643975Z"
+    },
+    "papermill": {
+     "duration": 0.270234,
+     "end_time": "2026-08-16T00:56:22.645374+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:22.375140+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GitHub search 'MAFALDA fallacy': HTTP 200\n"
+      "GitHub search 'MAFALDA fallacy': HTTP 403\n"
      ]
     },
     {
@@ -216,7 +285,16 @@
   {
    "cell_type": "markdown",
    "id": "7027023a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002382,
+     "end_time": "2026-08-16T00:56:22.650242+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:22.647860+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "### Dataset 3 — IBM Project Debater / debate_speeches\n",
@@ -230,11 +308,19 @@
    "id": "d0319658",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:24.679756Z",
-     "iopub.status.busy": "2026-08-10T20:56:24.679237Z",
-     "iopub.status.idle": "2026-08-10T20:56:25.567170Z",
-     "shell.execute_reply": "2026-08-10T20:56:25.560995Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:22.655403Z",
+     "iopub.status.busy": "2026-08-16T00:56:22.655243Z",
+     "iopub.status.idle": "2026-08-16T00:56:23.645507Z",
+     "shell.execute_reply": "2026-08-16T00:56:23.644700Z"
+    },
+    "papermill": {
+     "duration": 0.993699,
+     "end_time": "2026-08-16T00:56:23.646142+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:22.652443+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -242,7 +328,7 @@
      "output_type": "stream",
      "text": [
       "HF API ibm-research/debate_speeches: HTTP 200\n",
-      "  downloads: 135  lastModified: 2024-10-31T12:39:58.000Z\n",
+      "  downloads: 75  lastModified: 2024-10-31T12:39:58.000Z\n",
       "  description: \n",
       "\t\n",
       "\t\t\n",
@@ -289,7 +375,16 @@
   {
    "cell_type": "markdown",
    "id": "7c8a54f1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002388,
+     "end_time": "2026-08-16T00:56:23.651205+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:23.648817+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "### Dataset 4 — IBM-Rank-30k (Gretz et al. 2019)\n",
@@ -303,11 +398,19 @@
    "id": "cdc46851",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:25.570575Z",
-     "iopub.status.busy": "2026-08-10T20:56:25.570437Z",
-     "iopub.status.idle": "2026-08-10T20:56:26.075061Z",
-     "shell.execute_reply": "2026-08-10T20:56:26.068920Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:23.656874Z",
+     "iopub.status.busy": "2026-08-16T00:56:23.656685Z",
+     "iopub.status.idle": "2026-08-16T00:56:24.010600Z",
+     "shell.execute_reply": "2026-08-16T00:56:24.009919Z"
+    },
+    "papermill": {
+     "duration": 0.357666,
+     "end_time": "2026-08-16T00:56:24.011195+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:23.653529+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -354,7 +457,16 @@
   {
    "cell_type": "markdown",
    "id": "56dcdbb8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002319,
+     "end_time": "2026-08-16T00:56:24.016145+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:24.013826+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "### Dataset 5 — AraucariaDB (Reed et al., ARG-tech)\n",
@@ -368,11 +480,19 @@
    "id": "91e2a8de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:26.083469Z",
-     "iopub.status.busy": "2026-08-10T20:56:26.082874Z",
-     "iopub.status.idle": "2026-08-10T20:56:26.549559Z",
-     "shell.execute_reply": "2026-08-10T20:56:26.548740Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:24.021616Z",
+     "iopub.status.busy": "2026-08-16T00:56:24.021425Z",
+     "iopub.status.idle": "2026-08-16T00:56:24.381492Z",
+     "shell.execute_reply": "2026-08-16T00:56:24.380852Z"
+    },
+    "papermill": {
+     "duration": 0.363716,
+     "end_time": "2026-08-16T00:56:24.382109+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:24.018393+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -409,7 +529,16 @@
   {
    "cell_type": "markdown",
    "id": "65d66bf1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002558,
+     "end_time": "2026-08-16T00:56:24.387564+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:24.385006+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "### Dataset 6 — Reddit ChangeMyView (extrait)\n",
@@ -423,19 +552,33 @@
    "id": "a63d9652",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:26.552070Z",
-     "iopub.status.busy": "2026-08-10T20:56:26.551890Z",
-     "iopub.status.idle": "2026-08-10T20:56:26.882292Z",
-     "shell.execute_reply": "2026-08-10T20:56:26.878595Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:24.393836Z",
+     "iopub.status.busy": "2026-08-16T00:56:24.393612Z",
+     "iopub.status.idle": "2026-08-16T00:56:24.676983Z",
+     "shell.execute_reply": "2026-08-16T00:56:24.676289Z"
+    },
+    "papermill": {
+     "duration": 0.287382,
+     "end_time": "2026-08-16T00:56:24.677494+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:24.390112+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "HF search 'changemyview': 3 hits -> ['Siddish/change-my-view-subreddit-cleaned', 'underscore2/changemyview_persuasion_kto', 'MaPeac4/changemyview_comments']\n",
-      "  top hit Siddish/change-my-view-subreddit-cleaned: downloads=154\n"
+      "HF search 'changemyview': 3 hits -> ['Siddish/change-my-view-subreddit-cleaned', 'underscore2/changemyview_persuasion_kto', 'MaPeac4/changemyview_comments']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  top hit Siddish/change-my-view-subreddit-cleaned: downloads=52\n"
      ]
     }
    ],
@@ -467,8 +610,22 @@
   {
    "cell_type": "markdown",
    "id": "62237251",
-   "metadata": {},
-   "source": "---\n### Dataset 7 — Corpus rhetorique francais (si disponible)\n\nLa taxonomie Argumentum est **multilingue** (parallele sur 8 langues, avec libelles anglais natifs `text_en` / `desc_en` / `example_en`) ; le francais est la langue initiale, non exclusive. Un corpus rhetorique FR etiquete reste utile comme jeu d'evaluation FR complementaire. Recherche sur HF + GitHub."
+   "metadata": {
+    "papermill": {
+     "duration": 0.002813,
+     "end_time": "2026-08-16T00:56:24.683056+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:24.680243+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "---\n",
+    "### Dataset 7 — Corpus rhetorique francais (si disponible)\n",
+    "\n",
+    "La taxonomie Argumentum est **multilingue** (parallele sur 8 langues, avec libelles anglais natifs `text_en` / `desc_en` / `example_en`) ; le francais est la langue initiale, non exclusive. Un corpus rhetorique FR etiquete reste utile comme jeu d'evaluation FR complementaire. Recherche sur HF + GitHub."
+   ]
   },
   {
    "cell_type": "code",
@@ -476,18 +633,26 @@
    "id": "dcc981e6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:26.889808Z",
-     "iopub.status.busy": "2026-08-10T20:56:26.889023Z",
-     "iopub.status.idle": "2026-08-10T20:56:27.509535Z",
-     "shell.execute_reply": "2026-08-10T20:56:27.508228Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:24.688982Z",
+     "iopub.status.busy": "2026-08-16T00:56:24.688740Z",
+     "iopub.status.idle": "2026-08-16T00:56:24.950003Z",
+     "shell.execute_reply": "2026-08-16T00:56:24.949383Z"
+    },
+    "papermill": {
+     "duration": 0.26513,
+     "end_time": "2026-08-16T00:56:24.950569+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:24.685439+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Recherche corpus FR: HF-sophisme HTTP 200 (0), HF-french+argument HTTP 200, GH HTTP 200\n",
+      "Recherche corpus FR: HF-sophisme HTTP 200 (0), HF-french+argument HTTP 200, GH HTTP 403\n",
       "  hits : []\n"
      ]
     }
@@ -516,7 +681,16 @@
   {
    "cell_type": "markdown",
    "id": "b4cfdd06",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003215,
+     "end_time": "2026-08-16T00:56:24.956931+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:24.953716+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "---\n",
     "## Synthese — paysage des datasets et cardinalite totale\n",
@@ -530,11 +704,19 @@
    "id": "2240b97b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-10T20:56:27.512059Z",
-     "iopub.status.busy": "2026-08-10T20:56:27.511765Z",
-     "iopub.status.idle": "2026-08-10T20:56:27.521151Z",
-     "shell.execute_reply": "2026-08-10T20:56:27.520515Z"
-    }
+     "iopub.execute_input": "2026-08-16T00:56:24.963583Z",
+     "iopub.status.busy": "2026-08-16T00:56:24.963387Z",
+     "iopub.status.idle": "2026-08-16T00:56:25.016236Z",
+     "shell.execute_reply": "2026-08-16T00:56:25.015686Z"
+    },
+    "papermill": {
+     "duration": 0.05757,
+     "end_time": "2026-08-16T00:56:25.017167+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:24.959597+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -546,7 +728,7 @@
       "\n",
       "=== Table de synthese ===\n",
       "                              dataset                           statut_acces                                            cardinalite                                 labels_fallacy\n",
-      "        Logic/LogicClimate (Jin 2021)                    accessible (GitHub)                13 classes + challenge set LogicClimate                          13 types de sophismes\n",
+      "        Logic/LogicClimate (Jin 2022)                    accessible (GitHub)                13 classes + challenge set LogicClimate                          13 types de sophismes\n",
       "                 MAFALDA (Helwe 2023)             accessible (GitHub auteur)           L2 = 23 classes fines (hierarchie 3 niveaux)              23 sophismes L2 + 3 categories L1\n",
       "IBM debate_speeches (Project Debater)                    accessible (HF Hub) discours d'ouverture de debats (cardinalite ds README)         argument mining (non etiquete fallacy)\n",
       "            IBM-Rank-30k (Gretz 2019)               echec (HF, deplacement?)                                       ~30 497 (papier)                          qualite argumentative\n",
@@ -558,7 +740,7 @@
       "Logic (13 classes) + MAFALDA (23 classes L2) = base etiquetee directe.\n",
       "Sources adjacentes (IBM/AraucariaDB/CMV) = non etiquetees fallacy -> Phase 2 dataset builder devra projeter.\n",
       "\n",
-      "Date d'acces : 2026-08-10\n"
+      "Date d'acces : 2026-08-16\n"
      ]
     }
    ],
@@ -582,8 +764,28 @@
   {
    "cell_type": "markdown",
    "id": "63290dc5",
-   "metadata": {},
-   "source": "## Conclusion — vers la Phase 2 (dataset builder)\n\n**Paysage verifies** (acces reel, date d'acces ci-dessus) :\n- **Cibles etiquetees fallacy** : Logic/LogicClimate (13 classes) + MAFALDA (23 L2) = base directe pour la Phase 3 (fine-tuning). Tous deux accessibles via GitHub.\n- **Sources adjacentes** (non etiquetees fallacy) : IBM debate_speeches, IBM-Rank-30k, AraucariaDB, Reddit ChangeMyView = corpus argumentatifs qu'une Phase 2 (dataset builder) devra etiqueter / projeter dans la grille Argumentum.\n- **Corpus FR** : aucun corpus FR etiquete fallacy publiquement accessible (recherche HF + GitHub ci-dessus). La source FR principale reste le **deck-2 Argumentum** (1408 entrees) — a solliciter via les agents Argumentum (Phase 2). Notons que la taxonomie Argumentum elle-meme est **multilingue** (8 langues, anglais natif inclus), donc ce n'est pas un corpus strictement FR.\n\n**Langue** : les datasets academiques accessibles sont en **anglais**, mais la taxonomie Argumentum est **multilingue** (8 langues, anglais natif inclus via les champs `text_en` / `desc_en` / `example_en`) — non uniquement francaise. **Pas de pont de langue a construire** entre le corpus d'entrainement EN et la taxonomie cible. Le levier reel est une evaluation **cross-lingue** (entrainer sur une langue, tester sur une autre, sur un meme noeud de taxonomie) qu'Argumentum rend possible ligne a ligne.\n\nVoir : [survey SOTA](../../docs/research/fallacy-detection-survey.md) (livrable 1), [extraction Jessynoo](data/jessynoo_rfallacy_anonymized.csv) (livrable 3), [inventaire SAE Qwen](../../MyIA.AI.Notebooks/GenAI/_research/qwen_sae_inventory.md) (livrable 4). EPIC [#10355](https://github.com/jsboige/CoursIA/issues/10355), Phase 1 [#10356](https://github.com/jsboige/CoursIA/issues/10356)."
+   "metadata": {
+    "papermill": {
+     "duration": 0.002557,
+     "end_time": "2026-08-16T00:56:25.023022+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T00:56:25.020465+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion — vers la Phase 2 (dataset builder)\n",
+    "\n",
+    "**Paysage verifies** (acces reel, date d'acces ci-dessus) :\n",
+    "- **Cibles etiquetees fallacy** : Logic/LogicClimate (13 classes) + MAFALDA (23 L2) = base directe pour la Phase 3 (fine-tuning). Tous deux accessibles via GitHub.\n",
+    "- **Sources adjacentes** (non etiquetees fallacy) : IBM debate_speeches, IBM-Rank-30k, AraucariaDB, Reddit ChangeMyView = corpus argumentatifs qu'une Phase 2 (dataset builder) devra etiqueter / projeter dans la grille Argumentum.\n",
+    "- **Corpus FR** : aucun corpus FR etiquete fallacy publiquement accessible (recherche HF + GitHub ci-dessus). La source FR principale reste le **deck-2 Argumentum** (1408 entrees) — a solliciter via les agents Argumentum (Phase 2). Notons que la taxonomie Argumentum elle-meme est **multilingue** (8 langues, anglais natif inclus), donc ce n'est pas un corpus strictement FR.\n",
+    "\n",
+    "**Langue** : les datasets academiques accessibles sont en **anglais**, mais la taxonomie Argumentum est **multilingue** (8 langues, anglais natif inclus via les champs `text_en` / `desc_en` / `example_en`) — non uniquement francaise. **Pas de pont de langue a construire** entre le corpus d'entrainement EN et la taxonomie cible. Le levier reel est une evaluation **cross-lingue** (entrainer sur une langue, tester sur une autre, sur un meme noeud de taxonomie) qu'Argumentum rend possible ligne a ligne.\n",
+    "\n",
+    "Voir : [survey SOTA](../../docs/research/fallacy-detection-survey.md) (livrable 1), [extraction Jessynoo](data/jessynoo_rfallacy_anonymized.csv) (livrable 3), [inventaire SAE Qwen](../../MyIA.AI.Notebooks/GenAI/_research/qwen_sae_inventory.md) (livrable 4). EPIC [#10355](https://github.com/jsboige/CoursIA/issues/10355), Phase 1 [#10356](https://github.com/jsboige/CoursIA/issues/10356)."
+   ]
   }
  ],
  "metadata": {

--- a/MyIA.AI.Notebooks/FallacyDetection/03_taxonomy_coverage_gap.ipynb
+++ b/MyIA.AI.Notebooks/FallacyDetection/03_taxonomy_coverage_gap.ipynb
@@ -5,16 +5,20 @@
    "id": "c4f99608",
    "metadata": {
     "papermill": {
-     "duration": 0.004093,
-     "end_time": "2026-08-11T00:02:48.320386+00:00",
+     "duration": 0.001999,
+     "end_time": "2026-08-16T00:56:33.497619+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.316293+00:00",
+     "start_time": "2026-08-16T00:56:33.495620+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "# 03 — Écart de couverture taxonomique : académique vs Argumentum\n\n**EPIC [#10355](https://github.com/jsboige/CoursIA/issues/10355)** — fallacy detection via Qwen 3.5/3.6 FT+PT. Ce notebook **requalifie** le livrable \"paysage des datasets\" (notebook [02](02_fallacy_datasets_landscape.ipynb)) en posant explicitement la mesure que l'Epic demande : **les taxonomies académiques (Logic 13 + MAFALDA L2 23 = 27 classes après déduplication de 9 doublons) couvrent ~3 % des feuilles et ~2 % des nœuds de la taxonomie Argumentum (1408 nœuds / 894 feuilles)** — un écart de **plus d'un ordre de grandeur** (~33× sur les feuilles, ~52× sur les nœuds) qui définit l'ambition du fine-tuning.\n\nPourquoi ce requalification séparée : le notebook 02 catalogue les datasets accessibles (cible externe) ; celui-ci mesure la **couverture interne** de la grille de référence Argumentum par les étiquettes académiques. Les deux sont complémentaires et répondent à des questions différentes. L'alignement label-à-label (quel sophisme académique mappe sur quelle feuille Argumentum) est traité par `scripts/fallacy_detection/align_academic_to_argumentum.py` (PR #10368) ; l'exploration hiérarchique native par `scripts/fallacy_detection/argumentum_taxonomy_explorer.py` (PR #10376). Ce notebook consolide la **mesure stratégique** pour le cadrage de l'Epic."
+    "# 03 — Écart de couverture taxonomique : académique vs Argumentum\n",
+    "\n",
+    "**EPIC [#10355](https://github.com/jsboige/CoursIA/issues/10355)** — fallacy detection via Qwen 3.5/3.6 FT+PT. Ce notebook **requalifie** le livrable \"paysage des datasets\" (notebook [02](02_fallacy_datasets_landscape.ipynb)) en posant explicitement la mesure que l'Epic demande : **les taxonomies académiques (Logic 13 + MAFALDA L2 23 = 27 classes après déduplication de 9 doublons) couvrent ~3 % des feuilles et ~2 % des nœuds de la taxonomie Argumentum (1408 nœuds / 894 feuilles)** — un écart de **plus d'un ordre de grandeur** (~33× sur les feuilles, ~52× sur les nœuds) qui définit l'ambition du fine-tuning.\n",
+    "\n",
+    "Pourquoi ce requalification séparée : le notebook 02 catalogue les datasets accessibles (cible externe) ; celui-ci mesure la **couverture interne** de la grille de référence Argumentum par les étiquettes académiques. Les deux sont complémentaires et répondent à des questions différentes. L'alignement label-à-label (quel sophisme académique mappe sur quelle feuille Argumentum) est traité par `scripts/fallacy_detection/align_academic_to_argumentum.py` (PR #10368) ; l'exploration hiérarchique native par `scripts/fallacy_detection/argumentum_taxonomy_explorer.py` (PR #10376). Ce notebook consolide la **mesure stratégique** pour le cadrage de l'Epic."
    ]
   },
   {
@@ -22,10 +26,10 @@
    "id": "83d2f557",
    "metadata": {
     "papermill": {
-     "duration": 0.002453,
-     "end_time": "2026-08-11T00:02:48.326333+00:00",
+     "duration": 0.00124,
+     "end_time": "2026-08-16T00:56:33.500574+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.323880+00:00",
+     "start_time": "2026-08-16T00:56:33.499334+00:00",
      "status": "completed"
     },
     "tags": []
@@ -35,7 +39,7 @@
     "\n",
     "1. **Compter les feuilles Argumentum** (les sophismes identifiables, ≠ nœuds internes de hiérarchie) depuis le CSV repo-local `argumentum_fallacies_taxonomy.csv`.\n",
     "2. **Énumérer les étiquettes académiques** des deux taxonomies de référence :\n",
-    "   - **Logic / LogicClimate** (Jin et al. 2021, [arXiv:2202.13758](https://arxiv.org/abs/2202.13758)) : 13 types.\n",
+    "   - **Logic / LogicClimate** (Jin et al. 2022, [arXiv:2202.13758](https://arxiv.org/abs/2202.13758)) : 13 types.\n",
     "   - **MAFALDA** (Helwe et al. 2023, [arXiv:2311.09761](https://ar5iv.labs.arxiv.org/html/2311.09761)) : taxonomie hiérarchique 3 niveaux, **23 classes fines L2** sous Pathos/Logos/Ethos.\n",
     "3. **Mesurer l'écart** : ratio académique / Argumentum, et le nombre de **feuilles Argumentum \"non couvertes\"** par construction (celles sans cognat académique direct). Chaque chiffre est calculé firsthand ci-dessous (pas cité)."
    ]
@@ -46,16 +50,16 @@
    "id": "46bf546f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T00:02:48.333936Z",
-     "iopub.status.busy": "2026-08-11T00:02:48.333242Z",
-     "iopub.status.idle": "2026-08-11T00:02:48.912949Z",
-     "shell.execute_reply": "2026-08-11T00:02:48.911420Z"
+     "iopub.execute_input": "2026-08-16T00:56:33.504345Z",
+     "iopub.status.busy": "2026-08-16T00:56:33.504140Z",
+     "iopub.status.idle": "2026-08-16T00:56:33.828803Z",
+     "shell.execute_reply": "2026-08-16T00:56:33.828045Z"
     },
     "papermill": {
-     "duration": 0.585684,
-     "end_time": "2026-08-11T00:02:48.914309+00:00",
+     "duration": 0.327688,
+     "end_time": "2026-08-16T00:56:33.829638+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.328625+00:00",
+     "start_time": "2026-08-16T00:56:33.501950+00:00",
      "status": "completed"
     },
     "tags": []
@@ -127,10 +131,10 @@
    "id": "f91212eb",
    "metadata": {
     "papermill": {
-     "duration": 0.003153,
-     "end_time": "2026-08-11T00:02:48.920757+00:00",
+     "duration": 0.001782,
+     "end_time": "2026-08-16T00:56:33.833582+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.917604+00:00",
+     "start_time": "2026-08-16T00:56:33.831800+00:00",
      "status": "completed"
     },
     "tags": []
@@ -148,16 +152,16 @@
    "id": "997a3a47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T00:02:48.929057Z",
-     "iopub.status.busy": "2026-08-11T00:02:48.928667Z",
-     "iopub.status.idle": "2026-08-11T00:02:48.941804Z",
-     "shell.execute_reply": "2026-08-11T00:02:48.939915Z"
+     "iopub.execute_input": "2026-08-16T00:56:33.839064Z",
+     "iopub.status.busy": "2026-08-16T00:56:33.838679Z",
+     "iopub.status.idle": "2026-08-16T00:56:33.845441Z",
+     "shell.execute_reply": "2026-08-16T00:56:33.844581Z"
     },
     "papermill": {
-     "duration": 0.019255,
-     "end_time": "2026-08-11T00:02:48.943143+00:00",
+     "duration": 0.010872,
+     "end_time": "2026-08-16T00:56:33.846156+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.923888+00:00",
+     "start_time": "2026-08-16T00:56:33.835284+00:00",
      "status": "completed"
     },
     "tags": []
@@ -168,7 +172,7 @@
      "output_type": "stream",
      "text": [
       "=== Étiquettes académiques (encodées depuis les papiers) ===\n",
-      "  Logic-13 (Jin 2021)     : 13\n",
+      "  Logic-13 (Jin 2022)     : 13\n",
       "  MAFALDA L2 (Helwe 2023) : 23\n",
       "  union (de-dupliquee)    : 27\n",
       "  intersection            : 9 -> ['Ad hominem', 'Appeal to authority', 'Appeal to emotion', 'Begging the question', 'Equivocation', 'False cause', 'Red herring', 'Slippery slope', 'Strawman']\n",
@@ -178,7 +182,7 @@
     }
    ],
    "source": [
-    "# --- Logic / LogicClimate (Jin et al. 2021) : 13 types ---\n",
+    "# --- Logic / LogicClimate (Jin et al. 2022) : 13 types ---\n",
     "# Source: arXiv:2202.13758, Table 1 / dataset causalNLP/logical-fallacy\n",
     "LOGIC_13 = [\n",
     "    \"Appeal to authority\", \"Appeal to emotion\", \"Bandwagon\",\n",
@@ -209,7 +213,7 @@
     "academic_all = sorted(set(LOGIC_13) | set(MAFALDA_L2))\n",
     "overlap = sorted(set(LOGIC_13) & set(MAFALDA_L2))\n",
     "print(f\"=== Étiquettes académiques (encodées depuis les papiers) ===\")\n",
-    "print(f\"  Logic-13 (Jin 2021)     : {len(LOGIC_13)}\")\n",
+    "print(f\"  Logic-13 (Jin 2022)     : {len(LOGIC_13)}\")\n",
     "print(f\"  MAFALDA L2 (Helwe 2023) : {len(MAFALDA_L2)}\")\n",
     "print(f\"  union (de-dupliquee)    : {len(academic_all)}\")\n",
     "print(f\"  intersection            : {len(overlap)} -> {overlap}\")\n",
@@ -222,10 +226,10 @@
    "id": "2911550f",
    "metadata": {
     "papermill": {
-     "duration": 0.003156,
-     "end_time": "2026-08-11T00:02:48.949747+00:00",
+     "duration": 0.001565,
+     "end_time": "2026-08-16T00:56:33.849479+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.946591+00:00",
+     "start_time": "2026-08-16T00:56:33.847914+00:00",
      "status": "completed"
     },
     "tags": []
@@ -243,16 +247,16 @@
    "id": "9ee814c4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T00:02:48.958335Z",
-     "iopub.status.busy": "2026-08-11T00:02:48.957851Z",
-     "iopub.status.idle": "2026-08-11T00:02:48.971694Z",
-     "shell.execute_reply": "2026-08-11T00:02:48.970038Z"
+     "iopub.execute_input": "2026-08-16T00:56:33.854026Z",
+     "iopub.status.busy": "2026-08-16T00:56:33.853678Z",
+     "iopub.status.idle": "2026-08-16T00:56:33.859123Z",
+     "shell.execute_reply": "2026-08-16T00:56:33.858508Z"
     },
     "papermill": {
-     "duration": 0.019705,
-     "end_time": "2026-08-11T00:02:48.972715+00:00",
+     "duration": 0.00871,
+     "end_time": "2026-08-16T00:56:33.859735+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.953010+00:00",
+     "start_time": "2026-08-16T00:56:33.851025+00:00",
      "status": "completed"
     },
     "tags": []
@@ -309,10 +313,10 @@
    "id": "ff0fe228",
    "metadata": {
     "papermill": {
-     "duration": 0.003158,
-     "end_time": "2026-08-11T00:02:48.979143+00:00",
+     "duration": 0.001653,
+     "end_time": "2026-08-16T00:56:33.863277+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.975985+00:00",
+     "start_time": "2026-08-16T00:56:33.861624+00:00",
      "status": "completed"
     },
     "tags": []
@@ -336,16 +340,16 @@
    "id": "64daffd3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T00:02:48.987939Z",
-     "iopub.status.busy": "2026-08-11T00:02:48.987326Z",
-     "iopub.status.idle": "2026-08-11T00:02:48.997722Z",
-     "shell.execute_reply": "2026-08-11T00:02:48.996030Z"
+     "iopub.execute_input": "2026-08-16T00:56:33.867814Z",
+     "iopub.status.busy": "2026-08-16T00:56:33.867532Z",
+     "iopub.status.idle": "2026-08-16T00:56:33.871951Z",
+     "shell.execute_reply": "2026-08-16T00:56:33.871215Z"
     },
     "papermill": {
-     "duration": 0.01677,
-     "end_time": "2026-08-11T00:02:48.999020+00:00",
+     "duration": 0.007661,
+     "end_time": "2026-08-16T00:56:33.872588+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:48.982250+00:00",
+     "start_time": "2026-08-16T00:56:33.864927+00:00",
      "status": "completed"
     },
     "tags": []
@@ -361,7 +365,7 @@
       "  Facteur de finesse       : ~33x (feuilles) / ~52x (noeuds)\n",
       "  Feuilles 'hors academie' : 867 (97.0%) = territoire propre au FT+PT Argumentum\n",
       "\n",
-      "  Date du calcul : 2026-08-11 (firsthand sur le CSV repo-local).\n"
+      "  Date du calcul : 2026-08-16 (firsthand sur le CSV repo-local).\n"
      ]
     }
    ],
@@ -382,10 +386,10 @@
    "id": "522541e9",
    "metadata": {
     "papermill": {
-     "duration": 0.003603,
-     "end_time": "2026-08-11T00:02:49.006315+00:00",
+     "duration": 0.001863,
+     "end_time": "2026-08-16T00:56:33.876350+00:00",
      "exception": false,
-     "start_time": "2026-08-11T00:02:49.002712+00:00",
+     "start_time": "2026-08-16T00:56:33.874487+00:00",
      "status": "completed"
     },
     "tags": []
@@ -425,8 +429,8 @@
    "end_time": "2026-08-11T00:02:49.362921+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/FallacyDetection/03_taxonomy_coverage_gap.ipynb",
-   "output_path": "MyIA.AI.Notebooks/FallacyDetection/03_taxonomy_coverage_gap.ipynb",
+   "input_path": "03_taxonomy_coverage_gap.ipynb",
+   "output_path": "03_taxonomy_coverage_gap.ipynb",
    "parameters": {},
    "start_time": "2026-08-11T00:02:43.565237+00:00",
    "version": "2.7.0"


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: LIGHT/docs #11165

## Summary

EPIC **#11168** — vérification des citations arXiv, grain **famille FallacyDetection**
(3 IDs distincts, 9 occurrences, 2 notebooks). Chaque citation vérifiée contre
l'API arXiv (titre + auteurs + année) via `export.arxiv.org`.

## Verdicts

| ID arXiv | Annoncé | Réel (API arXiv + ACL Anthology) | Verdict |
|---|---|---|---|
| **2202.13758** | Jin et al., *Logical Fallacy Detection*, **Findings EMNLP 2021** | *Logical Fallacy Detection*, Jin et al. — publié dans **Findings of the ACL: EMNLP 2022**, pages 7180-7198 (`2022.findings-emnlp.532`) | **DRIFT-MINEUR** → corrigé (année/venue de conférence) |
| **2311.09761** | Helwe, Calamai, Paris, Clavel, Suchanek, *MAFALDA*, 2023 | *MAFALDA: A Benchmark and Comprehensive Study of Fallacy Detection and Classification*, mêmes 5 auteurs, 2023-11-16 | **OK** |
| **1911.11408** | Gretz et al., *A Large-scale Dataset for Argument Quality Ranking*, 2019 | *A Large-scale Dataset for Argument Quality Ranking: Construction and Analysis*, Gretz et al., 2019-11-26 | **OK** |

Le DRIFT-MINEUR : l'ID arXiv et l'auteur (Jin et al.) étaient corrects, mais le
venue était faux — le papier a été publié dans **Findings of EMNLP 2022** (pages
7180-7198), pas 2021. Vérifié via ACL Anthology
(`aclanthology.org/2022.findings-emnlp.532`) + API arXiv (v1 = 2022-02-28).

## Fix

`Jin et al. 2021` / `Findings EMNLP 2021` → `Jin et al. 2022` / `Findings of EMNLP 2022`
dans :

- `02_fallacy_datasets_landscape.ipynb` : cell[3] (header dataset + prose papier),
  cell[4] (2 labels `record(...)` code).
- `03_taxonomy_coverage_gap.ipynb` : cell[1] (méthodologie), cell[4] (commentaire
  code + label `print`).

Cellules **code** modifiées → re-exécution papermill (C.3) des 2 notebooks
(20/20 + 10/10, 0 erreur). Les outputs affichant l'ancienne année sont
régénérés (Jin 2022 partout).

## Validation

- `grep "Jin et al. 2021\|Jin 2021\|EMNLP 2021"` sur les 2 notebooks = **0 hit**
  (acceptance), `2022` présent 5× (02) + 4× (03).
- H.3 : 0 `execution_count` null, outputs présents sur toutes les cellules code.
- Séquences d'exécution CLEAN (`check_exec_sequence.py` : NOT_FROM_1=0, GAP=0).
- `metadata.papermill` normalisé au basename (règle secrets-hygiene 6).
- Aucun chemin machine dans les outputs (grep `C:\Users`/`c:\dev` = 0).
- Le diff des sources n'est que citations corrigées ; le reste du diff = outputs
  régénérés (dates d'accès API variables, re-exec 08-16) + ré-encodage JSON
  source string→liste (bruit de forme, contenu identique).

See #11168 (EPIC, grain famille FallacyDetection) · Voir aussi les grains
précédents de l'EPIC : #11110 (PR #11163) · #11127 (PR #11160)



---

> **Note du coordinateur (ai-01, 2026-08-16)** — `prev:` re-qualifie dans le body : #11165 est `LIGHT/docs`, pas `MED/lean` (le numero etait juste, le tier et le genre non ; la lane n'a aucun grain `lean` dans son historique recent). L'adjacence reste saine (`docs` -> `notebook-python`, genres distincts) : **la correction ne change pas le verdict G-VAR-3**, elle evite que le cap et l'audit comptent un genre qui n'a pas ete livre. Re-qualifie dans le **body** et non en commentaire — une requalification hors de l'organe n'est pas appliquee.
