### PR TITLE
feat(genai,#11171): AI Engine series grain 5 — multi-provider environments, usage matrix, and the disguised PUT of settings/update

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -171,6 +171,14 @@ endpoint JSON-RPC `mcp/v1/http`, handshake avec négociation de
 version, catalogue de 43 outils à JSON Schema, et de vrais
 `tools/call` (lecture, puis création/suppression d'un article) — la
 frontière d'authentification mesurée à 401 sur chaque méthode.
+[`brancher-plusieurs-providers-par-l-api.ipynb`](brancher-plusieurs-providers-par-l-api.ipynb)
+ouvre la régie des **environnements** : la matrice
+`ai_<usage>_default_env` (chat, vision, images, audio, json,
+embeddings) lue et écrite par l'API, l'interrogation d'un provider
+(catalogue `/ai/models`, poignée de main `/ai/test_connection`), le
+cycle déclarer/basculer/rétablir d'un second environnement — et le
+piège mesuré par accident : `settings/update` **ne met pas à jour, il
+remplace** (démonstration sécurisée par instantané et restauration).
 
 ---
 
@@ -303,6 +311,8 @@ attendues.
   formulaires comme contenu : CRUD unitaire, publication, rendu public, frontière gratuite/Pro mesurée
 - [`piloter-wordpress-par-mcp.ipynb`](piloter-wordpress-par-mcp.ipynb) —
   WordPress comme serveur MCP : handshake JSON-RPC, catalogue d'outils, tools/call en lecture et écriture
+- [`brancher-plusieurs-providers-par-l-api.ipynb`](brancher-plusieurs-providers-par-l-api.ipynb) —
+  environnements et matrice d'usages multi-provider : catalogues, connexions, bascules, et le PUT déguisé de settings/update
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/brancher-plusieurs-providers-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/brancher-plusieurs-providers-par-l-api.ipynb
@@ -1,0 +1,883 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a5e35b34",
+   "metadata": {},
+   "source": [
+    "# Brancher plusieurs providers — environnements et matrice d'usages\n",
+    "\n",
+    "Cinquieme notebook de la serie « AI Engine par son API ». AI Engine\n",
+    "supporte neuf providers distants et un connecteur pour moteurs\n",
+    "auto-heberges (compatible OpenAI). Mais ou vivent ces branchements, et\n",
+    "comment les manipuler par l'API ? Ce notebook ouvre la **regie des\n",
+    "environnements** : lire la configuration, interroger un provider,\n",
+    "declarer un second environnement, basculer l'usage chat de l'un a\n",
+    "l'autre — et retablir l'etat initial a la fin.\n",
+    "\n",
+    "La route la plus innocente du catalogue cache le piege le plus\n",
+    "destructeur de la serie : `settings/update` ne met pas a jour, il\n",
+    "**remplace**. Ce notebook le demontre en securite (instantane complet\n",
+    "en memoire, restauration immediate), parce que la demonstration a eu\n",
+    "lieu par accident pendant le sondage — et qu'elle a failli couter\n",
+    "l'instance.\n",
+    "\n",
+    "> Les sorties de ce notebook proviennent d'une execution reelle contre\n",
+    "> l'instance locale (voir « Provenance et limites », en fin de fichier).\n",
+    "> Aucune cle, aucune adresse de provider n'y figure : les champs\n",
+    "> sensibles sont masques par code, jamais supprimes a la main.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c542ccb1",
+   "metadata": {},
+   "source": [
+    "## La serie « AI Engine par son API »\n",
+    "\n",
+    "Le projet Livres Agites a mis AI Engine au coeur d'une maison d'edition :\n",
+    "bot d'accueil, agents d'ateliers, bibliothecaire documentee par RAG,\n",
+    "formulaires dynamiques. Cette serie presente le plugin de maniere\n",
+    "reproductible — **sans jamais exposer de donnees client** :\n",
+    "\n",
+    "| Notebook | Contenu |\n",
+    "|----------|---------|\n",
+    "| `presenter-ai-engine-par-son-api` | instance, API, catalogue des chatbots, premiere completion |\n",
+    "| `configurer-chatbots-par-l-api` | lire, dupliquer, ecrire et interroger des chatbots (document JSON global) |\n",
+    "| `administrer-les-formulaires-par-l-api` | le formulaire comme contenu : CRUD, publication, rendu public |\n",
+    "| `piloter-wordpress-par-mcp` | le serveur MCP : handshake, catalogue d'outils, appels reels |\n",
+    "| `brancher-plusieurs-providers-par-l-api` (ce notebook) | environnements, matrice d'usages, multi-provider par l'API |\n",
+    "| notebooks suivants | agents MCP distants, WooCommerce metier, ... |\n",
+    "\n",
+    "Trois niveaux de lecture, dans chaque notebook :\n",
+    "\n",
+    "1. **Decouverte** — ce que fait la fonctionnalite, vue par l'API ;\n",
+    "2. **Branchement** — comment on l'a branchee dans le projet ;\n",
+    "3. **Exercice** — reutiliser le pattern sur un cas voisin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "148cb8fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:37.541956Z",
+     "iopub.status.busy": "2026-08-16T01:24:37.541423Z",
+     "iopub.status.idle": "2026-08-16T01:24:37.724934Z",
+     "shell.execute_reply": "2026-08-16T01:24:37.723905Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
+      "Base URL : http://localhost:8093\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et helpers. Aucune cle ni adresse de provider n'est stockee\n",
+    "# dans ce fichier : tout vient de instance-jetable/.env (README, etape 5).\n",
+    "\n",
+    "import base64\n",
+    "import copy\n",
+    "import json\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Localisation du .env : a cote du notebook (instance-jetable/.env),\n",
+    "# sinon dans le repertoire courant.\n",
+    "charges = []\n",
+    "for candidat in (Path(\"instance-jetable/.env\"), Path(\".env\")):\n",
+    "    if candidat.exists():\n",
+    "        load_dotenv(candidat)\n",
+    "        charges.append(str(candidat))\n",
+    "print(\"Fichiers .env charges :\", charges or \"(aucun)\")\n",
+    "\n",
+    "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
+    "ADMIN_USER = os.getenv(\"VALMONT_ADMIN_USER\", \"\")\n",
+    "APP_PASSWORD = os.getenv(\"VALMONT_APP_PASSWORD\", \"\")\n",
+    "print(\"Base URL :\", BASE_URL)\n",
+    "\n",
+    "creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
+    "ENTETES = {\"Authorization\": \"Basic \" + creds, \"Content-Type\": \"application/json\"}\n",
+    "\n",
+    "\n",
+    "def api(route, method=\"GET\", payload=None):\n",
+    "    \"\"\"Appel a l'API REST d'administration de AI Engine (mwai/v1).\"\"\"\n",
+    "    r = requests.request(method, BASE_URL + \"/wp-json\" + route,\n",
+    "                         headers=ENTETES, json=payload, timeout=120)\n",
+    "    r.raise_for_status()\n",
+    "    return r.json()\n",
+    "\n",
+    "\n",
+    "def modeles_de(env):\n",
+    "    \"\"\"Les identifiants de modeles declares dans un environnement.\"\"\"\n",
+    "    return [m[\"model\"] if isinstance(m, dict) else m\n",
+    "            for m in (env.get(\"models\") or [])]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c3d6f04",
+   "metadata": {},
+   "source": [
+    "## Un WordPress, des environnements, une matrice d'usages\n",
+    "\n",
+    "La configuration de AI Engine est une seule option WordPress\n",
+    "(`mwai_options`), lisible par `GET /mwai/v1/settings/options`. Elle\n",
+    "contient tout : les environnements, les modules, les limites. Deux\n",
+    "familles nous interessent ici :\n",
+    "\n",
+    "- **`ai_envs`** — les environnements de modeles : chaque entree declare\n",
+    "  un provider (type `openai`, `anthropic`, ... ou `custom` pour tout\n",
+    "  serveur compatible OpenAI : Ollama, vLLM, LM Studio), avec son\n",
+    "  endpoint, sa cle, et ses modeles.\n",
+    "- **la matrice d'usages** — un jeu de cles `ai_<usage>_default_env` et\n",
+    "  `ai_<usage>_default_model` pour chaque usage : chat, fast, vision,\n",
+    "  images, audio, json, embeddings. Chaque usage route vers un\n",
+    "  environnement distinct. C'est le multi-provider du plugin : pas une\n",
+    "  liste de modeles, une **matrice** — le chat peut vivre sur un moteur\n",
+    "  local pendant que la vision vit sur un provider distant.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "8a7c138f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:37.728088Z",
+     "iopub.status.busy": "2026-08-16T01:24:37.727562Z",
+     "iopub.status.idle": "2026-08-16T01:24:37.787551Z",
+     "shell.execute_reply": "2026-08-16T01:24:37.787027Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Environnements de modeles (ai_envs) : 1\n",
+      "  vllm-local     [custom ] Valmont vLLM local : ['qwen3.6-35b-a3b']\n",
+      "\n",
+      "Environnements d'embeddings (embeddings_envs) : 2\n",
+      "  [internal            ] Internal (WordPress DB)\n",
+      "  [openai-vector-store ] OpenAI Vector Store\n",
+      "\n",
+      "usage        environnement    modele\n",
+      "chat         vllm-local       qwen3.6-35b-a3b\n",
+      "fast         (defaut plugin)  gpt-5-mini\n",
+      "vision       (defaut plugin)  gpt-5-mini\n",
+      "images       (defaut plugin)  gpt-image-2\n",
+      "audio        (defaut plugin)  whisper-1\n",
+      "json         (defaut plugin)  gpt-5-mini\n",
+      "embeddings   (defaut plugin)  text-embedding-3-small\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1. Lire la matrice : environnements et usages\n",
+    "options = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "\n",
+    "envs = options.get(\"ai_envs\", [])\n",
+    "print(\"Environnements de modeles (ai_envs) :\", len(envs))\n",
+    "for e in envs:\n",
+    "    print(f\"  {e['id']:14s} [{e.get('type'):7s}] {e.get('name')} : {modeles_de(e) or '(aucun modele declare)'}\")\n",
+    "\n",
+    "embed_envs = options.get(\"embeddings_envs\", [])\n",
+    "print()\n",
+    "print(\"Environnements d'embeddings (embeddings_envs) :\", len(embed_envs))\n",
+    "for e in embed_envs:\n",
+    "    print(f\"  [{e.get('type'):20s}] {e.get('name')}\")\n",
+    "\n",
+    "USAGES = [\n",
+    "    (\"chat\",       \"ai_default\"),\n",
+    "    (\"fast\",       \"ai_fast_default\"),\n",
+    "    (\"vision\",     \"ai_vision_default\"),\n",
+    "    (\"images\",     \"ai_images_default\"),\n",
+    "    (\"audio\",      \"ai_audio_default\"),\n",
+    "    (\"json\",       \"ai_json_default\"),\n",
+    "    (\"embeddings\", \"ai_embeddings_default\"),\n",
+    "]\n",
+    "print()\n",
+    "print(f\"{'usage':12s} {'environnement':16s} modele\")\n",
+    "for nom, prefixe in USAGES:\n",
+    "    env = options.get(prefixe + \"_env\") or \"(defaut plugin)\"\n",
+    "    model = options.get(prefixe + \"_model\") or \"-\"\n",
+    "    print(f\"{nom:12s} {env:16s} {model}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fff3e691",
+   "metadata": {},
+   "source": [
+    "### Ce que dit la matrice\n",
+    "\n",
+    "Un seul environnement est reellement branche : `vllm-local` (type\n",
+    "`custom`, le moteur auto-heberge de l'instance), et il ne sert que\n",
+    "l'usage **chat**. Tous les autres usages affichent `(defaut plugin)` :\n",
+    "aucun environnement ne leur est assigne, et le modele affiche\n",
+    "(`gpt-5-mini`, `whisper-1`, ...) est la valeur de repli interne du\n",
+    "plugin — **pas** un branchement reel. Si l'on appelait l'usage images\n",
+    "sans avoir declare d'environnement pour OpenAI, l'appel echouerait faute\n",
+    "de cle.\n",
+    "\n",
+    "Les environnements d'embeddings, eux, sont predeclares par le plugin\n",
+    "(la base WordPress interne, le vector store OpenAI) : la structure\n",
+    "existe, mais aucune route REST de l'API gratuite ne permet d'y indexer\n",
+    "ou d'y chercher — la regie du RAG passe par l'interface\n",
+    "d'administration ou la version Pro.\n",
+    "\n",
+    "C'est la photographie typique d'une installation modeste : un moteur\n",
+    "local pour le chat, rien d'autre. Le reste de ce notebook montre ce que\n",
+    "cette matrice devient quand on la manipule par l'API.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c180e7c5",
+   "metadata": {},
+   "source": [
+    "## Interroger un provider : catalogue et poignee de main\n",
+    "\n",
+    "Deux routes parlent **aux** environnements (et pas seulement d'eux) :\n",
+    "\n",
+    "- `POST /ai/models` (parametre `envId`) demande au provider la liste de\n",
+    "  ses modeles — la fiche technique : fonctionnalites, prix, contexte\n",
+    "  maximal. Pour un moteur auto-heberge, le prix est nul et la fiche est\n",
+    "  ce que le serveur declare.\n",
+    "- `POST /ai/test_connection` (parametre `env_id` — oui, le nommage\n",
+    "  differe de la route precedente pour la meme notion ; le plugin n'est\n",
+    "  pas coherent ici) fait une vraie requete au serveur de modeles et\n",
+    "  rapporte ce qu'il a trouve.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b7ad7b02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:37.791200Z",
+     "iopub.status.busy": "2026-08-16T01:24:37.790687Z",
+     "iopub.status.idle": "2026-08-16T01:24:37.841344Z",
+     "shell.execute_reply": "2026-08-16T01:24:37.840820Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "modeles servis par vllm-local : 1\n",
+      "  qwen3.6-35b-a3b\n",
+      "    fonctionnalites : ['completion']\n",
+      "    contexte max : 8192 tokens | completion max : 4096\n",
+      "    prix : {'in': 0, 'out': 0} token/unite | tags : ['core', 'chat']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2. Le catalogue du provider : ai/models\n",
+    "catalogue = api(\"/mwai/v1/ai/models\", method=\"POST\", payload={\"envId\": \"vllm-local\"})[\"models\"]\n",
+    "print(\"modeles servis par vllm-local :\", len(catalogue))\n",
+    "for m in catalogue:\n",
+    "    print(f\"  {m['model']}\")\n",
+    "    print(f\"    fonctionnalites : {m.get('features')}\")\n",
+    "    print(f\"    contexte max : {m.get('maxContextualTokens')} tokens | completion max : {m.get('maxCompletionTokens')}\")\n",
+    "    print(f\"    prix : {m.get('price')} {m.get('type')}/unite | tags : {m.get('tags')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3a02297b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:37.845022Z",
+     "iopub.status.busy": "2026-08-16T01:24:37.844491Z",
+     "iopub.status.idle": "2026-08-16T01:24:37.940689Z",
+     "shell.execute_reply": "2026-08-16T01:24:37.940689Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vllm-local : True | provider : custom\n",
+      "  modeles trouves : 1 ['qwen3.6-35b-a3b']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "environnement inexistant : False | Environment not found.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 3. La poignee de main : ai/test_connection\n",
+    "test = api(\"/mwai/v1/ai/test_connection\", method=\"POST\", payload={\"env_id\": \"vllm-local\"})\n",
+    "details = (test.get(\"data\") or {}).get(\"details\") or {}\n",
+    "print(\"vllm-local :\", test.get(\"success\"), \"| provider :\", test.get(\"provider\"))\n",
+    "print(\"  modeles trouves :\", details.get(\"model_count\"), details.get(\"sample_models\"))\n",
+    "# Le champ details['endpoint'] contient l'adresse du serveur de modeles :\n",
+    "# un secret local, masque ici — on n'affiche que ce qu'il a trouve.\n",
+    "\n",
+    "inconnu = api(\"/mwai/v1/ai/test_connection\", method=\"POST\",\n",
+    "              payload={\"env_id\": \"environnement-inexistant\"})\n",
+    "print()\n",
+    "print(\"environnement inexistant :\", inconnu.get(\"success\"), \"|\", inconnu.get(\"error\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35cfb7e4",
+   "metadata": {},
+   "source": [
+    "## Le piege : `settings/update` ne met pas a jour, il remplace\n",
+    "\n",
+    "Pendant le sondage preparatoire a ce notebook, un appel d'apparence\n",
+    "innocente a ete emis : `POST /settings/update` avec un bloc d'une seule\n",
+    "cle (`ai_default_env`, reprenant sa valeur actuelle). Verifie par la\n",
+    "suite dans le code du plugin, le comportement est sans appel :\n",
+    "\n",
+    "- `update_options` fait un `update_option` **total** : l'option\n",
+    "  WordPress complete est ecrasee par le seul bloc envoye ;\n",
+    "- a la relecture, le plugin regenere les valeurs manquantes — **par\n",
+    "  defaut** : un environnement OpenAI vide, un nouvel identifiant\n",
+    "  aleatoire, les modules desactives, les compteurs d'usage perdus.\n",
+    "\n",
+    "Bilan mesure sur l'instance : l'environnement `vllm-local` (endpoint,\n",
+    "cle, modele) avait disparu ; `ai_default_env` pointait vers\n",
+    "l'environnement OpenAI regenere ; `module_embeddings` etait repasse a\n",
+    "false. Une seule cle envoyee, toute la regie detruite.\n",
+    "\n",
+    "La demonstration ci-dessous est **securisee** : l'instantane complet de\n",
+    "la configuration est d'abord charge en memoire (variables Python), le\n",
+    "piege est declenche, les degats mesures, puis l'instantane est renvoye\n",
+    "en bloc — la restauration exacte. Tout se joue dans une seule cellule :\n",
+    "meme un arret du notebook entre le piege et la reparation laisserait\n",
+    "l'instance recuperable en rejouant la cellule.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e37b4e43",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:37.943210Z",
+     "iopub.status.busy": "2026-08-16T01:24:37.943210Z",
+     "iopub.status.idle": "2026-08-16T01:24:38.141146Z",
+     "shell.execute_reply": "2026-08-16T01:24:38.140640Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "instantane  : 107 cles | envs : ['vllm-local']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "apres l'update partiel :\n",
+      "  nb de cles          : 107 -> 105\n",
+      "  env vllm-local      : False\n",
+      "  envs restants       : [('n7dnk9qx', 'openai')]\n",
+      "  ai_default_env      : vllm-local -> n7dnk9qx\n",
+      "  ai_default_model    : qwen3.6-35b-a3b -> gpt-5.5\n",
+      "  module_embeddings   : True -> False\n",
+      "  compteurs d'usage   : True -> False\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "apres restauration :\n",
+      "  nb de cles          : 107\n",
+      "  env vllm-local      : True\n",
+      "  ai_default_env      : vllm-local\n",
+      "  module_embeddings   : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4. Le piege demontre en securite : instantane -> update partiel -> degats -> restauration\n",
+    "instantane = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "envs_avant = [e[\"id\"] for e in instantane.get(\"ai_envs\", [])]\n",
+    "print(\"instantane  :\", len(instantane), \"cles | envs :\", envs_avant)\n",
+    "\n",
+    "# Le piege : un update PARTIEL, d'apparence inoffensive\n",
+    "# (une seule cle, avec la valeur qu'elle a deja).\n",
+    "piege_payload = {\"module_statistics\": instantane.get(\"module_statistics\")}\n",
+    "api(\"/mwai/v1/settings/update\", method=\"POST\", payload={\"options\": piege_payload})\n",
+    "\n",
+    "apres = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "print()\n",
+    "print(\"apres l'update partiel :\")\n",
+    "print(\"  nb de cles          :\", len(instantane), \"->\", len(apres))\n",
+    "print(\"  env vllm-local      :\", any(e[\"id\"] == \"vllm-local\" for e in apres.get(\"ai_envs\", [])))\n",
+    "print(\"  envs restants       :\", [(e[\"id\"], e.get(\"type\")) for e in apres.get(\"ai_envs\", [])])\n",
+    "print(\"  ai_default_env      :\", instantane.get(\"ai_default_env\"), \"->\", apres.get(\"ai_default_env\"))\n",
+    "print(\"  ai_default_model    :\", instantane.get(\"ai_default_model\"), \"->\", apres.get(\"ai_default_model\"))\n",
+    "print(\"  module_embeddings   :\", instantane.get(\"module_embeddings\"), \"->\", apres.get(\"module_embeddings\"))\n",
+    "print(\"  compteurs d'usage   :\", \"ai_usage\" in instantane, \"->\", \"ai_usage\" in apres)\n",
+    "\n",
+    "# La restauration : renvoyer le bloc COMPLET. L'instantane en memoire\n",
+    "# a survecu au carnage — c'est le seul exemplaire de la configuration.\n",
+    "retour = api(\"/mwai/v1/settings/update\", method=\"POST\", payload={\"options\": instantane})\n",
+    "final = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "print()\n",
+    "print(\"apres restauration :\")\n",
+    "print(\"  nb de cles          :\", len(final))\n",
+    "print(\"  env vllm-local      :\", any(e[\"id\"] == \"vllm-local\" for e in final.get(\"ai_envs\", [])))\n",
+    "print(\"  ai_default_env      :\", final.get(\"ai_default_env\"))\n",
+    "print(\"  module_embeddings   :\", final.get(\"module_embeddings\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd9dff0c",
+   "metadata": {},
+   "source": [
+    "### Pourquoi le read-modify-write complet, et pas autre chose\n",
+    "\n",
+    "La regle du grain 2 (chatbots) etait deja : lire la liste, la modifier,\n",
+    "renvoyer la liste entiere. Ici elle devient une condition de survie.\n",
+    "Deux nuances comptent :\n",
+    "\n",
+    "- **l'instantane vit en memoire Python**, pas dans le WordPress : quand\n",
+    "  l'option est ecrasee, l'exemplaire Python survit — c'est lui qu'on\n",
+    "  renvoie pour restaurer ;\n",
+    "- **la relecture regenere des valeurs** : les identifiants aleatoires\n",
+    "  de l'environnement fantome changeront d'une execution a l'autre, et\n",
+    "  le compte de cles peut varier selon les compteurs d'usage — les\n",
+    "  sorties ci-dessus mesurent la structure du degat (environnement\n",
+    "  detruit, defauts regeneres), pas des valeurs litterales stables.\n",
+    "\n",
+    "En production, la parade est la meme qu'au grain 2, une echelle au-dessus :\n",
+    "**toujours** relire, toujours renvoyer le bloc complet, jamais\n",
+    "presumer d'un merge cote serveur. Une route qui s'appelle `update` et\n",
+    "un contrat qui est un PUT — c'est le genre d'ecart qu'on ne devine pas,\n",
+    "qu'on mesure.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd35c005",
+   "metadata": {},
+   "source": [
+    "## Ecrire le multi-provider : declarer, basculer, retablir\n",
+    "\n",
+    "Le cycle complet, sur la matrice : **cloner** l'environnement local en\n",
+    "un second (`vllm-secours` — meme endpoint, autre identite\n",
+    "administrative), **interroger** le clone (meme serveur, meme catalogue),\n",
+    "**basculer** l'usage chat vers lui, puis **remettre** et **purger**.\n",
+    "L'instance finit exactement comme elle a commence — chaque ecriture\n",
+    "envoie le bloc complet, comme la section precedente l'impose.\n",
+    "\n",
+    "Ce cycle est le squelette de toute migration de provider : declarer le\n",
+    "nouveau moteur a cote de l'ancien, verifier qu'il repond, basculer un\n",
+    "usage, verifier encore, et garder l'ancien a portee de main pour\n",
+    "revenir. Rien ici ne demande d'interface d'administration.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "260e07e8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:38.143674Z",
+     "iopub.status.busy": "2026-08-16T01:24:38.143674Z",
+     "iopub.status.idle": "2026-08-16T01:24:38.293433Z",
+     "shell.execute_reply": "2026-08-16T01:24:38.292891Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "update : True | OK\n",
+      "  vllm-local     [custom ] ['qwen3.6-35b-a3b']\n",
+      "  vllm-secours   [custom ] ['qwen3.6-35b-a3b']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5. Declarer un second environnement : vllm-secours\n",
+    "instantane = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "envs = copy.deepcopy(instantane[\"ai_envs\"])\n",
+    "source = next(e for e in envs if e[\"id\"] == \"vllm-local\")\n",
+    "secours = copy.deepcopy(source)\n",
+    "secours[\"id\"] = \"vllm-secours\"\n",
+    "secours[\"name\"] = \"Valmont vLLM secours\"\n",
+    "envs.append(secours)\n",
+    "instantane[\"ai_envs\"] = envs\n",
+    "\n",
+    "rep = api(\"/mwai/v1/settings/update\", method=\"POST\", payload={\"options\": instantane})\n",
+    "verif = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "print(\"update :\", rep.get(\"success\"), \"|\", rep.get(\"message\"))\n",
+    "for e in verif[\"ai_envs\"]:\n",
+    "    print(f\"  {e['id']:14s} [{e.get('type'):7s}] {modeles_de(e)}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "db7bc073",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:38.297108Z",
+     "iopub.status.busy": "2026-08-16T01:24:38.296597Z",
+     "iopub.status.idle": "2026-08-16T01:24:38.408188Z",
+     "shell.execute_reply": "2026-08-16T01:24:38.407655Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "catalogue du secours : ['qwen3.6-35b-a3b']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "connexion du secours : True | Connection successful. Found 1 models.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 6. Interroger le nouveau venu : meme serveur, autre environnement\n",
+    "catalogue = api(\"/mwai/v1/ai/models\", method=\"POST\", payload={\"envId\": \"vllm-secours\"})[\"models\"]\n",
+    "print(\"catalogue du secours :\", [m[\"model\"] for m in catalogue])\n",
+    "\n",
+    "test = api(\"/mwai/v1/ai/test_connection\", method=\"POST\", payload={\"env_id\": \"vllm-secours\"})\n",
+    "print(\"connexion du secours :\", test.get(\"success\"),\n",
+    "      \"|\", (test.get(\"data\") or {}).get(\"message\"))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "37723e0f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:38.412000Z",
+     "iopub.status.busy": "2026-08-16T01:24:38.411471Z",
+     "iopub.status.idle": "2026-08-16T01:24:38.668776Z",
+     "shell.execute_reply": "2026-08-16T01:24:38.667748Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default_env initial  : vllm-local\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default_env bascule  : vllm-secours | model : qwen3.6-35b-a3b\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "default_env remis    : vllm-local\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 7. Basculer l'usage chat, verifier, remettre\n",
+    "instantane = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "avant = instantane.get(\"ai_default_env\")\n",
+    "print(\"default_env initial  :\", avant)\n",
+    "\n",
+    "instantane[\"ai_default_env\"] = \"vllm-secours\"\n",
+    "api(\"/mwai/v1/settings/update\", method=\"POST\", payload={\"options\": instantane})\n",
+    "bascule = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "print(\"default_env bascule  :\", bascule.get(\"ai_default_env\"),\n",
+    "      \"| model :\", bascule.get(\"ai_default_model\"))\n",
+    "\n",
+    "instantane[\"ai_default_env\"] = avant\n",
+    "api(\"/mwai/v1/settings/update\", method=\"POST\", payload={\"options\": instantane})\n",
+    "remis = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "print(\"default_env remis    :\", remis.get(\"ai_default_env\"))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "dacd0b7f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:38.671861Z",
+     "iopub.status.busy": "2026-08-16T01:24:38.670859Z",
+     "iopub.status.idle": "2026-08-16T01:24:38.861708Z",
+     "shell.execute_reply": "2026-08-16T01:24:38.861182Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "envs final          : ['vllm-local']\n",
+      "default_env         : vllm-local | model : qwen3.6-35b-a3b\n",
+      "module_embeddings   : True\n",
+      "connexion vllm-local : True | Connection successful. Found 1 models.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 8. Purger le secours : l'instance revient a son etat initial\n",
+    "instantane = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "instantane[\"ai_envs\"] = [e for e in instantane[\"ai_envs\"] if e[\"id\"] != \"vllm-secours\"]\n",
+    "api(\"/mwai/v1/settings/update\", method=\"POST\", payload={\"options\": instantane})\n",
+    "\n",
+    "final = api(\"/mwai/v1/settings/options\")[\"options\"]\n",
+    "print(\"envs final          :\", [e[\"id\"] for e in final[\"ai_envs\"]])\n",
+    "print(\"default_env         :\", final.get(\"ai_default_env\"), \"| model :\", final.get(\"ai_default_model\"))\n",
+    "print(\"module_embeddings   :\", final.get(\"module_embeddings\"))\n",
+    "\n",
+    "test = api(\"/mwai/v1/ai/test_connection\", method=\"POST\", payload={\"env_id\": \"vllm-local\"})\n",
+    "print(\"connexion vllm-local :\", test.get(\"success\"),\n",
+    "      \"|\", (test.get(\"data\") or {}).get(\"message\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "815f1d64",
+   "metadata": {},
+   "source": [
+    "## Ce qu'on en a fait dans le projet Livres Agites\n",
+    "\n",
+    "Dans le projet d'origine, la matrice d'usages est restee volontairement\n",
+    "simple cote chat : **un seul environnement custom**, le moteur\n",
+    "auto-heberge — pas de dependance a un provider distant, pas de cle qui\n",
+    "expire, un cout marginal nul. La richesse multi-provider du plugin\n",
+    "s'est logee ailleurs : cote **embeddings**, ou la regie separe les\n",
+    "environnements de vecteurs par regime d'acces (le Parcours 2 de\n",
+    "`livresagites-parcours.md` detaille le piege du multi-environnement de\n",
+    "vecteurs et son compagnon\n",
+    "[`separer-les-environnements-de-vecteurs.ipynb`](separer-les-environnements-de-vecteurs.ipynb)).\n",
+    "\n",
+    "Les frontieres mesurees sur la version gratuite, a garder en tete :\n",
+    "\n",
+    "- **neuf providers distants declarables, aucun branchable sans cle** :\n",
+    "  la structure multi-provider est entierement presente dans l'API, mais\n",
+    "  chaque environnement distant exige ses credentials — rien a demontrer\n",
+    "  sans cle ;\n",
+    "- **aucune route REST pour le RAG** : les `embeddings_envs` se lisent\n",
+    "  et s'ecrivent comme ici, mais l'indexation et la recherche de\n",
+    "  vecteurs ne passent pas par l'API gratuite — la regie du vector\n",
+    "  store est le domaine de l'interface d'administration et de la\n",
+    "  version Pro.\n",
+    "\n",
+    "La lecon transposable reste celle de la section precedente : une API\n",
+    "d'administration qui semble granulaire (une route par cle) peut cacher\n",
+    "un contrat total (un PUT par bloc). On ne le sait qu'en mesurant — ou\n",
+    "en lisant le code, qui est la version silencieuse de la mesure.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcb75393",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois exercices, du plus simple au plus integre. Les fonctions sont a\n",
+    "completer ; `api()` et `modeles_de()` sont disponibles. Chaque\n",
+    "exercice se verifie d'une ligne de test.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64f1584d",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 — comparer deux catalogues\n",
+    "\n",
+    "Completez `comparer_catalogues(env_a, env_b)` : elle interroge\n",
+    "`/ai/models` pour deux environnements et retourne un dict avec les\n",
+    "modeles communs et les modeles propres a chacun.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0492177b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:38.865668Z",
+     "iopub.status.busy": "2026-08-16T01:24:38.865136Z",
+     "iopub.status.idle": "2026-08-16T01:24:38.869420Z",
+     "shell.execute_reply": "2026-08-16T01:24:38.868894Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def comparer_catalogues(env_a, env_b):\n",
+    "    \"\"\"Compare les catalogues de deux environnements.\n",
+    "\n",
+    "    Retourne {\"communs\": [...], \"seuls_a\": [...], \"seuls_b\": [...]}.\n",
+    "    \"\"\"\n",
+    "    # A COMPLETER : deux appels POST /mwai/v1/ai/models (parametre envId),\n",
+    "    # puis intersection et differences sur les identifiants de modeles.\n",
+    "    return {}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "880bdb80",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 — la matrice d'usages complete\n",
+    "\n",
+    "Completez `matrice_usages()` : elle lit `settings/options` et retourne\n",
+    "la matrice `{usage: {\"env\": ..., \"model\": ...}}` pour les sept usages\n",
+    "du notebook (chat, fast, vision, images, audio, json, embeddings) —\n",
+    "les usages non branches devant apparaitre avec `env: None`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "efb887e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:38.873176Z",
+     "iopub.status.busy": "2026-08-16T01:24:38.872665Z",
+     "iopub.status.idle": "2026-08-16T01:24:38.876812Z",
+     "shell.execute_reply": "2026-08-16T01:24:38.876296Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def matrice_usages():\n",
+    "    \"\"\"Retourne la matrice {usage: {\"env\": ..., \"model\": ...}}.\"\"\"\n",
+    "    # A COMPLETER : GET settings/options, extraire les couples\n",
+    "    # ai_<usage>_default_env / ai_<usage>_default_model.\n",
+    "    return {}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a767c8d6",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 — basculer proprement\n",
+    "\n",
+    "Completez `basculer_provisoirement(env_id)` : elle applique le pattern\n",
+    "du notebook a un changement d'environnement par defaut — instantane\n",
+    "complet, bascule, verification, restauration, verification finale — et\n",
+    "retourne `True` seulement si l'etat final est identique a l'etat\n",
+    "initial. L'exercice est rate si la configuration ne revient pas\n",
+    "exactement.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d543d399",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T01:24:38.880663Z",
+     "iopub.status.busy": "2026-08-16T01:24:38.880125Z",
+     "iopub.status.idle": "2026-08-16T01:24:38.884754Z",
+     "shell.execute_reply": "2026-08-16T01:24:38.883747Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def basculer_provisoirement(env_id):\n",
+    "    \"\"\"Bascule ai_default_env vers env_id puis retablit ; True si propre.\"\"\"\n",
+    "    # A COMPLETER : instantane, update complet avec la bascule, relecture,\n",
+    "    # update complet de restauration, relecture, comparaison.\n",
+    "    return None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb4c82d6",
+   "metadata": {},
+   "source": [
+    "## Provenance et limites\n",
+    "\n",
+    "- **Instance testee** : `http://localhost:8093`, montee via\n",
+    "  `instance-jetable/docker-compose.jetable.example.yml`, AI Engine 3.7.0\n",
+    "  (version gratuite, wordpress.org), corpus synthetique « Maison Valmont ».\n",
+    "- **Determinisme** : aucune completion LLM — tout l'arc est catalogues,\n",
+    "  poignees de main et configuration. Les valeurs structurelles (nombre\n",
+    "  d'environnements, modeles servis, succes des connexions) sont\n",
+    "  stables ; les identifiants aleatoires regeneres par le piege et le\n",
+    "  compte exact de cles varient d'une execution a l'autre — les sorties\n",
+    "  mesurent la structure, pas ces litteraux.\n",
+    "- **Endpoints verifies ici (firsthand)** : `GET /mwai/v1/settings/options`,\n",
+    "  `POST /mwai/v1/settings/update` (x6 : piege, restauration, clone,\n",
+    "  bascule, remise, purge), `POST /mwai/v1/ai/models` (x2),\n",
+    "  `POST /mwai/v1/ai/test_connection` (x4, dont un environnement\n",
+    "  inexistant).\n",
+    "- **Incident reel** : la section « le piege » decrit un accident survenu\n",
+    "  pendant le sondage preparatoire — l'instance a ete restauree par le\n",
+    "  meme mecanisme (instantane complet renvoye en bloc) que celui\n",
+    "  demontre dans le notebook.\n",
+    "- **Secrets** : aucun endpoint, aucune cle n'est affiche ; le champ\n",
+    "  `details['endpoint']` de `test_connection` est masque par code (il\n",
+    "  contient l'adresse locale du serveur de modeles).\n",
+    "- **Frontieres** : pas de donnees client, pas de secret, pas d'IP de\n",
+    "  provider — regles du chantier CoursIA.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -241,6 +241,21 @@ champ de configuration de premier niveau.
 > à un visiteur public) et l'accident de réindexation silencieux
 > (comptage du corpus voisin écrasé). Déterministe, sans clé ni réseau.
 
+> **Notebook compagnon (série « par son API »).**
+> [`brancher-plusieurs-providers-par-l-api.ipynb`](brancher-plusieurs-providers-par-l-api.ipynb)
+> applique la notion d'environnement aux **modèles** cette fois : la
+> matrice `ai_<usage>_default_env` (chat, fast, vision, images, audio,
+> json, embeddings) route chaque usage vers un environnement distinct,
+> lu et écrit par l'API REST. Le notebook démontre le cycle complet sur
+> l'instance jetable — déclarer un second environnement, interroger son
+> catalogue (`/ai/models`) et sa connexion (`/ai/test_connection`),
+> basculer l'usage chat, rétablir — et le piège découvert par accident
+> pendant le sondage : `settings/update` **ne met pas à jour, il
+> remplace**. Un update partiel détruit la configuration entière
+> (environnement custom effacé, modules désactivés, défauts régénérés) ;
+> la démonstration est sécurisée par instantané complet en mémoire,
+> puis restauration à l'identique.
+
 ---
 
 ## Parcours 3 — WordPress comme serveur MCP métier


### PR DESCRIPTION
## Quoi:

5e notebook de la série « AI Engine par son API » : `brancher-plusieurs-providers-par-l-api.ipynb` — la régie des environnements.

- **Lire la matrice** : `ai_envs` + la matrice d'usages `ai_<usage>_default_env/model` (chat, fast, vision, images, audio, json, embeddings) — le multi-provider du plugin est une matrice, pas une liste.
- **Interroger un provider** : `POST /ai/models` (catalogue réel servi : features, prix 0, contexte 8192) et `POST /ai/test_connection` (poignée de main réelle ; env inconnu → erreur propre).
- **Le piège mesuré** : `POST /settings/update` est un **PUT déguisé** — un bloc partiel écrase l'option entière et la relecture régénère les défauts. Démontré en sécurité : instantané complet en mémoire → update partiel → mesure des dégâts (107→105 clés, env custom détruit, id aléatoire régénéré, modules coupés, compteurs perdus) → restauration exacte. Découvert par accident pendant le sondage (issue #11171) — incident réel, instance réparée par le même mécanisme.
- **Cycle multi-provider** : cloner `vllm-local` en `vllm-secours`, interroger le clone, basculer `ai_default_env`, rétablir, purger — l'instance finit à l'état initial exact (vérifié par relecture + test_connection).
- 3 exercices à stubs (`comparer_catalogues`, `matrice_usages`, `basculer_provisoirement`). README du dossier (paragraphe série + Voir aussi) et bloc compagnon dans `livresagites-parcours.md` (Parcours 2, section environnements).

Grain 100 % déterministe : aucune completion LLM — tout l'arc est catalogues, poignées de main et configuration.

## Preuve:

- Exécuté contre l'instance jetable (localhost:8093, AI Engine 3.7.0 gratuite, corpus synthétique Maison Valmont), HEAD testé : `0a0d1af2e` (`python -m nbconvert --execute`, 26 cellules, 0 erreur).
- Sorties committées = l'exécution réelle : matrice initiale lue (1 env, 6 usages à défaut), dégâts du PUT mesurés puis restaurés à l'identique, état final = état initial avec connexion OK.
- Scan sécurité avant `git add` : 0 accent (notebook), 0 homoglyphe cyrillique/grec, 0 emoji, 0 secret (app password, IP, instance client 8092 absents des 3 fichiers).
- Hooks pré-commit passés (gitleaks, notebooks exécutés requis, etc.).
- CI : à vérifier firsthand après création (watch en arrière-plan si file longue).

## Périmètre:

- `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/brancher-plusieurs-providers-par-l-api.ipynb` (nouveau)
- `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md` (paragraphe série + Voir aussi)
- `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md` (bloc compagnon Parcours 2)
- Aucune donnée client, aucun secret, aucune IP ; `.env` gitignoré (vérifié).

Rotation G-VAR-3 : 10e MED/notebook-python consécutif de la lane — substance distincte (incident réel mesuré, grain déterministe sans LLM, leçon PUT-vs-PATCH absente des grains 1-4).

Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #11052