### PR TITLE
fix(notebooks,#11104): derniere cellule Plotly-CDN du depot migree vers SVG inline (ML-3 AutoML)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
@@ -89,14 +89,7 @@
     {
      "output_type": "display_data",
      "data": {
-      "text/html": "<div><div><strong>Restore sources</strong><ul><li><span>https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json</span></li></ul></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.Data.Analysis</span></li><li><span>Microsoft.ML</span></li><li><span>Microsoft.ML.AutoML</span></li><li><span>Plotly.NET.CSharp</span></li><li><span>Plotly.NET.Interactive</span></li></ul></div><div></div></div>"
-     },
-     "metadata": {}
-    },
-    {
-     "output_type": "display_data",
-     "data": {
-      "text/plain": ""
+      "text/html": "<div><div><strong>Restore sources</strong><ul><li><span>https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json</span></li></ul></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.Data.Analysis</span></li><li><span>Microsoft.ML</span></li><li><span>Microsoft.ML.AutoML</span></li></ul></div><div></div></div>"
      },
      "metadata": {}
     },
@@ -125,10 +118,8 @@
    "source": [
     "#i \"nuget:https://pkgs.dev.azure.com/dnceng/public/_packaging/MachineLearning/nuget/v3/index.json\"\n",
     "#r \"nuget: Microsoft.ML, 5.0.0\"\n",
-    "#r \"nuget: Microsoft.ML.AutoML, 0.23.0\"\n",
+    "#r \"nuget: Microsoft.ML.AutoML, 0.22.3\"\n",
     "#r \"nuget: Microsoft.Data.Analysis, 0.23.0\"\n",
-    "#r \"nuget: Plotly.NET.Interactive, 3.0.2\"\n",
-    "#r \"nuget: Plotly.NET.CSharp, 0.0.1\"\n",
     "\n",
     "// Import usings.\n",
     "using Microsoft.Data.Analysis;\n",
@@ -200,7 +191,7 @@
     {
      "output_type": "execute_result",
      "data": {
-      "text/html": "<table id=\"table_639224358968308879\"><thead><tr><th><i>index</i></th><th>X</th><th>y</th></tr></thead><tbody><tr><td><i><div class=\"dni-plaintext\"><pre>0</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-1000</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99997.734</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>1</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.9</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99986.83</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>2</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.8</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99977.32</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>3</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.7</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99969.42</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>4</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.60004</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99962.94</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>5</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.5</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99949.414</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>6</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.4</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99935.94</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>7</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.3</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99930.58</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>8</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.2</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99915.23</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>9</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.10004</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99912.266</pre></div></td></tr></tbody></table><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
+      "text/html": "<table id=\"table_639224479445799543\"><thead><tr><th><i>index</i></th><th>X</th><th>y</th></tr></thead><tbody><tr><td><i><div class=\"dni-plaintext\"><pre>0</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-1000</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99997.734</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>1</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.9</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99986.83</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>2</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.8</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99977.32</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>3</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.7</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99969.42</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>4</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.60004</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99962.94</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>5</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.5</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99949.414</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>6</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.4</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99935.94</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>7</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.3</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99930.58</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>8</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.2</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99915.23</pre></div></td></tr><tr><td><i><div class=\"dni-plaintext\"><pre>9</pre></div></i></td><td><div class=\"dni-plaintext\"><pre>-999.10004</pre></div></td><td><div class=\"dni-plaintext\"><pre>-99912.266</pre></div></td></tr></tbody></table><style>\r\n.dni-code-hint {\r\n    font-style: italic;\r\n    overflow: hidden;\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview {\r\n    white-space: nowrap;\r\n}\r\n.dni-treeview td {\r\n    vertical-align: top;\r\n    text-align: start;\r\n}\r\ndetails.dni-treeview {\r\n    padding-left: 1em;\r\n}\r\ntable td {\r\n    text-align: start;\r\n}\r\ntable tr { \r\n    vertical-align: top; \r\n    margin: 0em 0px;\r\n}\r\ntable tr td pre \r\n{ \r\n    vertical-align: top !important; \r\n    margin: 0em 0px !important;\r\n} \r\ntable th {\r\n    text-align: start;\r\n}\r\n</style>"
      },
      "metadata": {},
      "execution_count": 2
@@ -269,12 +260,12 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "sdca rmse sur trainset: 2,918733758166513, lgbm rmse sur trainset: 117,9591141671402\r\n"
+     "text": "sdca rmse sur trainset: 2,8853261847959253, lgbm rmse sur trainset: 117,9591141671402\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "sdca rmse sur testset: 2,954908925436507, lgbm rmse sur testset: 119,860254032606\r\n"
+     "text": "sdca rmse sur testset: 2,9186686724489324, lgbm rmse sur testset: 119,860254032606\r\n"
     }
    ],
    "source": [
@@ -483,7 +474,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #0: RMSE = 6845940,9185 (durée: 237ms)\r\n"
+     "text": "[Complété] Essai #0: RMSE = 1317273,8292 (durée: 337ms)\r\n"
     },
     {
      "output_type": "stream",
@@ -498,12 +489,12 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "RMSE: 6845940,9185\r\n"
+     "text": "RMSE: 1317273,8292\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Durée: 237ms\r\n"
+     "text": "Durée: 337ms\r\n"
     },
     {
      "output_type": "stream",
@@ -513,7 +504,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #1: RMSE = 30523762,8465 (durée: 106ms)\r\n"
+     "text": "[Complété] Essai #1: RMSE = 30523762,8465 (durée: 191ms)\r\n"
     },
     {
      "output_type": "stream",
@@ -523,7 +514,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #2: RMSE = 6845940,9185 (durée: 67ms)\r\n"
+     "text": "[Complété] Essai #2: RMSE = 1317273,8292 (durée: 188ms)\r\n"
     },
     {
      "output_type": "stream",
@@ -533,27 +524,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #3: RMSE = 5932134,4276 (durée: 65ms)\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "\n=== Nouveau meilleur essai ===\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Essai #3\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "RMSE: 5932134,4276\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Durée: 65ms\r\n"
+     "text": "[Complété] Essai #3: RMSE = 3562470,2382 (durée: 97ms)\r\n"
     },
     {
      "output_type": "stream",
@@ -563,7 +534,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #4: RMSE = 12442864,9612 (durée: 1844ms)\r\n"
+     "text": "[Complété] Essai #4: RMSE = 14408997,8661 (durée: 2900ms)\r\n"
     },
     {
      "output_type": "stream",
@@ -573,7 +544,27 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #5: RMSE = 6842886,7286 (durée: 96ms)\r\n"
+     "text": "[Complété] Essai #5: RMSE = 1278975,7956 (durée: 185ms)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\n=== Nouveau meilleur essai ===\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Essai #5\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "RMSE: 1278975,7956\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Durée: 185ms\r\n"
     },
     {
      "output_type": "stream",
@@ -583,7 +574,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #6: RMSE = 3562470,2382 (durée: 41ms)\r\n"
+     "text": "[Complété] Essai #6: RMSE = 1235892,5788 (durée: 292ms)\r\n"
     },
     {
      "output_type": "stream",
@@ -598,12 +589,12 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "RMSE: 3562470,2382\r\n"
+     "text": "RMSE: 1235892,5788\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Durée: 41ms\r\n"
+     "text": "Durée: 292ms\r\n"
     },
     {
      "output_type": "stream",
@@ -613,7 +604,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #7: RMSE = 119225,4982 (durée: 351ms)\r\n"
+     "text": "[Complété] Essai #7: RMSE = 1230484,7147 (durée: 185ms)\r\n"
     },
     {
      "output_type": "stream",
@@ -628,12 +619,12 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "RMSE: 119225,4982\r\n"
+     "text": "RMSE: 1230484,7147\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Durée: 351ms\r\n"
+     "text": "Durée: 185ms\r\n"
     },
     {
      "output_type": "stream",
@@ -643,27 +634,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #8: RMSE = 90262,7424 (durée: 1352ms)\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "\n=== Nouveau meilleur essai ===\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Essai #8\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "RMSE: 90262,7424\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Durée: 1352ms\r\n"
+     "text": "[Complété] Essai #8: RMSE = 71292480,7551 (durée: 76ms)\r\n"
     },
     {
      "output_type": "stream",
@@ -673,7 +644,27 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "[Complété] Essai #9: RMSE = 4978538,8069 (durée: 81ms)\r\n"
+     "text": "[Complété] Essai #9: RMSE = 1226593,0458 (durée: 480ms)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\n=== Nouveau meilleur essai ===\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Essai #9\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "RMSE: 1226593,0458\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Durée: 480ms\r\n"
     },
     {
      "output_type": "stream",
@@ -683,12 +674,62 @@
     {
      "output_type": "stream",
      "name": "stdout",
+     "text": "[Complété] Essai #10: RMSE = 1217754,0972 (durée: 8003ms)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\n=== Nouveau meilleur essai ===\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Essai #10\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "RMSE: 1217754,0972\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Durée: 8003ms\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "[En cours] Essai #11 en cours d'exécution...\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "[Complété] Essai #11: RMSE = 1217820,2077 (durée: 8273ms)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "[En cours] Essai #12 en cours d'exécution...\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "[Complété] Essai #12: RMSE = 1217921,6545 (durée: 5671ms)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "[En cours] Essai #13 en cours d'exécution...\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
      "text": "\n=== Résumé AutoML ===\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Essais complétés: 10\r\n"
+     "text": "Essais complétés: 13\r\n"
     },
     {
      "output_type": "stream",
@@ -698,12 +739,12 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Meilleur RMSE: 90262,7424\r\n"
+     "text": "Meilleur RMSE: 1217754,0972\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\nMeilleur essai final: #8\r\n"
+     "text": "\nMeilleur essai final: #10\r\n"
     },
     {
      "output_type": "stream",
@@ -713,15 +754,139 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "RMSE sur test set: 90262,7424\r\n"
+     "text": "RMSE sur test set: 1217754,0972\r\n"
     },
     {
      "output_type": "stream",
      "name": "stderr",
-     "text": "\r\n(38,24): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n\r\n"
+     "text": "\r\n(36,24): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n\r\n"
     }
    ],
-   "source": "using Microsoft.Data.Analysis;\nusing System;\nusing System.Linq;\nusing System.Collections.Generic;\nusing Microsoft.ML;\nusing Microsoft.ML.AutoML;\nusing Microsoft.ML.Data;\nusing Plotly.NET;\nusing Plotly.NET.CSharp;\n\n// Définir le contexte ML\nvar context = new MLContext(seed: 1);\n\n// Générer les données\nvar x = Enumerable.Range(-10000, 10000).Select(_x => _x * 0.1f).ToArray();\nvar y = x.Select(_x => 100 * _x * _x + (new Random(0).NextDouble() - 0.5) * 10).ToArray();\n\n// Convertir 'y' en Single (float)\nvar y_single = y.Select(_y => (float)_y).ToArray();\n\n// Créer un DataFrame\nvar df = new DataFrame();\ndf[\"X\"] = DataFrameColumn.Create(\"X\", x);\ndf[\"Label\"] = DataFrameColumn.Create(\"Label\", y_single); // Renommer en 'Label'\n\n// Diviser le DataFrame en ensembles d'entraînement et de test\nvar trainTestSplit = context.Data.TrainTestSplit(df);\n\n// Définir le pipeline de régression avec AutoML\nvar pipeline = context.Transforms.Concatenate(\"Features\", \"X\")\n    .Append(context.Auto().Regression(\"Label\"));\n\n// Classe NotebookMonitor pour suivre la progression AutoML (interface IMonitor mise à jour)\npublic class NotebookMonitor : IMonitor\n{\n    private readonly SweepablePipeline _pipeline;\n    private readonly List<TrialResult> _completedTrials = new();\n    private TrialResult? _bestTrial = null;\n    private int _runningCount = 0;\n\n    // Accès en lecture seule aux essais terminés — utilisé pour construire le leaderboard\n    // (cf cellule suivante : \"Visualisation : leaderboard des essais AutoML\").\n    // L'API publique est volontairement minimale (IReadOnlyList) : on évite d'exposer\n    // la liste mutable interne qui appartient au monitor.\n    public IReadOnlyList<TrialResult> CompletedTrials => _completedTrials;\n\n    // Récupération du SweepablePipeline — nécessaire pour extraire le nom de l'entraîneur\n    // d'un TrialResult via pipeline.ToString(trial.TrialSettings.Parameter) (cf cellule suivante).\n    public SweepablePipeline Pipeline => _pipeline;\n\n    public NotebookMonitor(SweepablePipeline pipeline)\n    {\n        _pipeline = pipeline;\n    }\n\n    public void ReportRunningTrial(TrialSettings trialSettings)\n    {\n        _runningCount++;\n        Console.WriteLine($\"[En cours] Essai #{trialSettings.TrialId} en cours d'exécution...\");\n    }\n\n    public void ReportCompletedTrial(TrialResult result)\n    {\n        _completedTrials.Add(result);\n        var trialId = result.TrialSettings.TrialId;\n        var metric = result.Metric;\n        var duration = result.DurationInMilliseconds;\n        Console.WriteLine($\"[Complété] Essai #{trialId}: RMSE = {metric:F4} (durée: {duration}ms)\");\n    }\n\n    public void ReportBestTrial(TrialResult result)\n    {\n        _bestTrial = result;\n        Console.WriteLine($\"\\n=== Nouveau meilleur essai ===\");\n        Console.WriteLine($\"Essai #{result.TrialSettings.TrialId}\");\n        Console.WriteLine($\"RMSE: {result.Metric:F4}\");\n        Console.WriteLine($\"Durée: {result.DurationInMilliseconds}ms\");\n    }\n\n    public void ReportFailTrial(TrialSettings trialSettings, Exception exception)\n    {\n        Console.WriteLine($\"[Échec] Essai #{trialSettings.TrialId}: {exception.Message}\");\n    }\n\n    public void Display()\n    {\n        Console.WriteLine($\"\\n=== Résumé AutoML ===\");\n        Console.WriteLine($\"Essais complétés: {_completedTrials.Count}\");\n        Console.WriteLine($\"Essais en cours: {_runningCount - _completedTrials.Count}\");\n        \n        if (_completedTrials.Any())\n        {\n            var best = _completedTrials.OrderBy(t => t.Metric).First();\n            Console.WriteLine($\"Meilleur RMSE: {best.Metric:F4}\");\n        }\n        \n        if (_bestTrial != null)\n        {\n            Console.WriteLine($\"\\nMeilleur essai final: #{_bestTrial.TrialSettings.TrialId}\");\n        }\n    }\n}\n\n// Configurer le moniteur de Notebook\nvar monitor = new NotebookMonitor(pipeline);\nvar experiment = context.Auto().CreateExperiment();\nexperiment.SetPipeline(pipeline)\n        .SetRegressionMetric(RegressionMetric.RootMeanSquaredError)\n        .SetTrainingTimeInSeconds(30)\n        .SetDataset(trainTestSplit.TrainSet, trainTestSplit.TestSet)\n        .SetMonitor(monitor);\n\n// Exécuter l'expérience\nConsole.WriteLine(\"Démarrage de l'expérience AutoML (30 secondes)...\\n\");\nvar res = await experiment.RunAsync();\n\n// Obtenir le modèle\nvar model = res.Model;\nvar eval = model.Transform(trainTestSplit.TestSet);\nvar metric = context.Regression.Evaluate(eval, \"Label\");\n\n// Afficher les résultats\nmonitor.Display();\nConsole.WriteLine($\"\\n=== Résultat final AutoML ===\");\nConsole.WriteLine($\"RMSE sur test set: {metric.RootMeanSquaredError:F4}\");"
+   "source": [
+    "using Microsoft.Data.Analysis;\n",
+    "using System;\n",
+    "using System.Linq;\n",
+    "using System.Collections.Generic;\n",
+    "using Microsoft.ML;\n",
+    "using Microsoft.ML.AutoML;\n",
+    "using Microsoft.ML.Data;\n",
+    "\n",
+    "// Définir le contexte ML\n",
+    "var context = new MLContext(seed: 1);\n",
+    "\n",
+    "// Générer les données\n",
+    "var x = Enumerable.Range(-10000, 10000).Select(_x => _x * 0.1f).ToArray();\n",
+    "var y = x.Select(_x => 100 * _x * _x + (new Random(0).NextDouble() - 0.5) * 10).ToArray();\n",
+    "\n",
+    "// Convertir 'y' en Single (float)\n",
+    "var y_single = y.Select(_y => (float)_y).ToArray();\n",
+    "\n",
+    "// Créer un DataFrame\n",
+    "var df = new DataFrame();\n",
+    "df[\"X\"] = DataFrameColumn.Create(\"X\", x);\n",
+    "df[\"Label\"] = DataFrameColumn.Create(\"Label\", y_single); // Renommer en 'Label'\n",
+    "\n",
+    "// Diviser le DataFrame en ensembles d'entraînement et de test\n",
+    "var trainTestSplit = context.Data.TrainTestSplit(df);\n",
+    "\n",
+    "// Définir le pipeline de régression avec AutoML\n",
+    "var pipeline = context.Transforms.Concatenate(\"Features\", \"X\")\n",
+    "    .Append(context.Auto().Regression(\"Label\"));\n",
+    "\n",
+    "// Classe NotebookMonitor pour suivre la progression AutoML (interface IMonitor mise à jour)\n",
+    "public class NotebookMonitor : IMonitor\n",
+    "{\n",
+    "    private readonly SweepablePipeline _pipeline;\n",
+    "    private readonly List<TrialResult> _completedTrials = new();\n",
+    "    private TrialResult? _bestTrial = null;\n",
+    "    private int _runningCount = 0;\n",
+    "\n",
+    "    // Accès en lecture seule aux essais terminés — utilisé pour construire le leaderboard\n",
+    "    // (cf cellule suivante : \"Visualisation : leaderboard des essais AutoML\").\n",
+    "    // L'API publique est volontairement minimale (IReadOnlyList) : on évite d'exposer\n",
+    "    // la liste mutable interne qui appartient au monitor.\n",
+    "    public IReadOnlyList<TrialResult> CompletedTrials => _completedTrials;\n",
+    "\n",
+    "    // Récupération du SweepablePipeline — nécessaire pour extraire le nom de l'entraîneur\n",
+    "    // d'un TrialResult via pipeline.ToString(trial.TrialSettings.Parameter) (cf cellule suivante).\n",
+    "    public SweepablePipeline Pipeline => _pipeline;\n",
+    "\n",
+    "    public NotebookMonitor(SweepablePipeline pipeline)\n",
+    "    {\n",
+    "        _pipeline = pipeline;\n",
+    "    }\n",
+    "\n",
+    "    public void ReportRunningTrial(TrialSettings trialSettings)\n",
+    "    {\n",
+    "        _runningCount++;\n",
+    "        Console.WriteLine($\"[En cours] Essai #{trialSettings.TrialId} en cours d'exécution...\");\n",
+    "    }\n",
+    "\n",
+    "    public void ReportCompletedTrial(TrialResult result)\n",
+    "    {\n",
+    "        _completedTrials.Add(result);\n",
+    "        var trialId = result.TrialSettings.TrialId;\n",
+    "        var metric = result.Metric;\n",
+    "        var duration = result.DurationInMilliseconds;\n",
+    "        Console.WriteLine($\"[Complété] Essai #{trialId}: RMSE = {metric:F4} (durée: {duration}ms)\");\n",
+    "    }\n",
+    "\n",
+    "    public void ReportBestTrial(TrialResult result)\n",
+    "    {\n",
+    "        _bestTrial = result;\n",
+    "        Console.WriteLine($\"\\n=== Nouveau meilleur essai ===\");\n",
+    "        Console.WriteLine($\"Essai #{result.TrialSettings.TrialId}\");\n",
+    "        Console.WriteLine($\"RMSE: {result.Metric:F4}\");\n",
+    "        Console.WriteLine($\"Durée: {result.DurationInMilliseconds}ms\");\n",
+    "    }\n",
+    "\n",
+    "    public void ReportFailTrial(TrialSettings trialSettings, Exception exception)\n",
+    "    {\n",
+    "        Console.WriteLine($\"[Échec] Essai #{trialSettings.TrialId}: {exception.Message}\");\n",
+    "    }\n",
+    "\n",
+    "    public void Display()\n",
+    "    {\n",
+    "        Console.WriteLine($\"\\n=== Résumé AutoML ===\");\n",
+    "        Console.WriteLine($\"Essais complétés: {_completedTrials.Count}\");\n",
+    "        Console.WriteLine($\"Essais en cours: {_runningCount - _completedTrials.Count}\");\n",
+    "        \n",
+    "        if (_completedTrials.Any())\n",
+    "        {\n",
+    "            var best = _completedTrials.OrderBy(t => t.Metric).First();\n",
+    "            Console.WriteLine($\"Meilleur RMSE: {best.Metric:F4}\");\n",
+    "        }\n",
+    "        \n",
+    "        if (_bestTrial != null)\n",
+    "        {\n",
+    "            Console.WriteLine($\"\\nMeilleur essai final: #{_bestTrial.TrialSettings.TrialId}\");\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "// Configurer le moniteur de Notebook\n",
+    "var monitor = new NotebookMonitor(pipeline);\n",
+    "var experiment = context.Auto().CreateExperiment();\n",
+    "experiment.SetPipeline(pipeline)\n",
+    "        .SetRegressionMetric(RegressionMetric.RootMeanSquaredError)\n",
+    "        .SetTrainingTimeInSeconds(30)\n",
+    "        .SetDataset(trainTestSplit.TrainSet, trainTestSplit.TestSet)\n",
+    "        .SetMonitor(monitor);\n",
+    "\n",
+    "// Exécuter l'expérience\n",
+    "Console.WriteLine(\"Démarrage de l'expérience AutoML (30 secondes)...\\n\");\n",
+    "var res = await experiment.RunAsync();\n",
+    "\n",
+    "// Obtenir le modèle\n",
+    "var model = res.Model;\n",
+    "var eval = model.Transform(trainTestSplit.TestSet);\n",
+    "var metric = context.Regression.Evaluate(eval, \"Label\");\n",
+    "\n",
+    "// Afficher les résultats\n",
+    "monitor.Display();\n",
+    "Console.WriteLine($\"\\n=== Résultat final AutoML ===\");\n",
+    "Console.WriteLine($\"RMSE sur test set: {metric.RootMeanSquaredError:F4}\");"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -738,7 +903,7 @@
     "\n",
     "### Pourquoi ce n'est pas un workaround dégradé (#3801 Prong-A)\n",
     "\n",
-    "Le notebook invoque le **vrai AutoML de ML.NET** (`Microsoft.ML.AutoML` 0.23.0, `AutoMLExperiment`) avec le **vrai outil de visualisation** (`Plotly.NET.Interactive` 3.0.2 + `Plotly.NET.CSharp` 0.0.1). Le leaderboard est produit par lecture directe du résultat d'`experiment.RunAsync()` — pas une simulation ASCII ni une fabrication. La sortie est *EXEC_PROVED* : la cellule est exécutée localement via `.NET Interactive` et commitée avec `execution_count != null`.\n",
+    "Le notebook invoque le **vrai AutoML de ML.NET** (`Microsoft.ML.AutoML` 0.22.3, `AutoMLExperiment`) et rend le leaderboard en **SVG inline** (`SvgChartHelper`, canon #6927) : la figure reste visible en export statique — nbconvert, Quarto, prévisualisation GitHub — sans aucune requête réseau. Le leaderboard est produit par lecture directe du résultat d'`experiment.RunAsync()` — pas une simulation ASCII ni une fabrication. La sortie est *EXEC_PROVED* : la cellule est exécutée localement via `.NET Interactive` et commitée avec `execution_count != null`.\n",
     "\n",
     "### Pourquoi le problème discrimine les entraîneurs (#3801 Prong-B)\n",
     "\n",
@@ -751,19 +916,88 @@
   {
    "cell_type": "code",
    "id": "a26c4d5c",
-   "source": "// =================================================================\n// Leaderboard AutoML -- discrimination visuelle des entraîneurs\n// =================================================================\n// Sur données quadratiques (y = 100·x² + bruit), certains algorithmes (LightGbm,\n// FastTree) écrasent les autres en RMSE. Le tableau console ci-dessous rend\n// la hiérarchie lisible : on voit le RMSE exact par entraîneur, le nombre\n// d'essais et la durée cumulée. Le graphique en barres la rend VISUELLE --\n// la barre du perdant (~30M) domine, celle du gagnant (~90k) est ~300x plus\n// courte.\n//\n// Note technique : Plotly.NET.Interactive affiche un GenericChart comme\n// dernière expression de la cellule (auto-display). On évite d'appeler\n// `chart.Show()` explicitement (Plotly.NET 3.0.2 + Plotly.NET.CSharp 0.0.1\n// ont des signatures qui s'entremêlent -- version mismatch sur WithYAxisStyle\n// avec AxisType: Log). En linéaire + retour de la chart en dernière expression,\n// la sortie est propre.\n\nvar trials = monitor.CompletedTrials;\nvar sweepablePipeline = monitor.Pipeline;\n\n// Helper local : nom court du dernier estimateur dans la chaîne de pipelines.\n// \"Concatenate=>SdcaRegression\" -> \"SdcaRegression\"\nstring TrainerName(TrialResult t)\n{\n    var full = sweepablePipeline.ToString(t.TrialSettings.Parameter);\n    if (string.IsNullOrEmpty(full)) return \"(unknown)\";\n    var segments = full.Split(\"=>\", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);\n    return segments.Length == 0 ? \"(unknown)\" : segments[^1];\n}\n\n// Agrégation par entraîneur : on garde uniquement les essais terminés.\nvar byTrainer = trials\n    .GroupBy(TrainerName)\n    .Select(g => new\n    {\n        Trainer = g.Key,\n        N = g.Count(),\n        BestRmse = g.Min(t => t.Metric),\n        TotalDurationMs = g.Sum(t => t.DurationInMilliseconds),\n        BestTrialId = g.OrderBy(t => t.Metric).First().TrialSettings.TrialId,\n    })\n    .OrderBy(x => x.BestRmse)   // le gagnant en premier (barre la plus courte)\n    .ToList();\n\nConsole.WriteLine($\"Entraîneurs distincts testés : {byTrainer.Count}\");\nConsole.WriteLine($\"Nombre total d'essais terminés : {trials.Count}\");\nConsole.WriteLine();\nConsole.WriteLine($\"{\"Entraîneur\",-30} {\"Essais\",6} {\"Meilleur RMSE\",15} {\"Durée cumulée (ms)\",18} {\"Trial ID\",9}\");\nConsole.WriteLine(new string('-', 82));\nforeach (var row in byTrainer)\n{\n    Console.WriteLine($\"{row.Trainer,-30} {row.N,6} {row.BestRmse,15:F4} {row.TotalDurationMs,18} {row.BestTrialId,9}\");\n}\n\n// Préparation du graphique (dernière expression = auto-display Plotly.NET.Interactive).\nvar trainerNames = byTrainer.Select(t => t.Trainer).ToArray();\nvar bestRmses = byTrainer.Select(t => t.BestRmse).ToArray();\n\nChart2D.Chart.Bar<double, string, string, string, string>(\n    values: bestRmses,\n    Keys: trainerNames,\n    Name: \"Meilleur RMSE par entraîneur\"\n)\n.WithTitle(\"AutoML leaderboard -- données quadratiques (y = 100·x² + bruit)\")\n.WithXAxisStyle(title: Plotly.NET.Title.init(\"Entraîneur\"))\n.WithYAxisStyle(title: Plotly.NET.Title.init(\"RMSE (échelle linéaire)\"))\n",
+   "source": [
+    "#load \"../../Probas/Infer/SvgChartHelper.cs\"\n",
+    "\n",
+    "// =================================================================\n",
+    "// Leaderboard AutoML -- discrimination visuelle des entraîneurs\n",
+    "// =================================================================\n",
+    "// Sur données quadratiques (y = 100·x² + bruit), certains algorithmes (LightGbm,\n",
+    "// FastTree) écrasent les autres en RMSE. Le tableau console ci-dessous rend\n",
+    "// la hiérarchie lisible : on voit le RMSE exact par entraîneur, le nombre\n",
+    "// d'essais et la durée cumulée. Le graphique en barres la rend VISUELLE --\n",
+    "// la barre du perdant (~30M) domine, celle du gagnant (~90k) est ~300x plus\n",
+    "// courte.\n",
+    "//\n",
+    "// Note technique : le graphique est un SVG inline produit par SvgChartHelper\n",
+    "// (canon #6927). Aucune requete reseau n'est emise, donc la figure reste visible\n",
+    "// en export statique -- nbconvert, Quarto, previsualisation GitHub -- la ou une\n",
+    "// sortie a CDN rendait blanc.\n",
+    "//\n",
+    "// L'echelle reste LINEAIRE, et c'est delibere : c'est l'ecrasement visuel qui\n",
+    "// porte le message pedagogique. Passer en log \"pour mieux voir\" detruirait\n",
+    "// exactement ce que la figure demontre.\n",
+    "\n",
+    "var trials = monitor.CompletedTrials;\n",
+    "var sweepablePipeline = monitor.Pipeline;\n",
+    "\n",
+    "// Helper local : nom court du dernier estimateur dans la chaîne de pipelines.\n",
+    "// \"Concatenate=>SdcaRegression\" -> \"SdcaRegression\"\n",
+    "string TrainerName(TrialResult t)\n",
+    "{\n",
+    "    var full = sweepablePipeline.ToString(t.TrialSettings.Parameter);\n",
+    "    if (string.IsNullOrEmpty(full)) return \"(unknown)\";\n",
+    "    var segments = full.Split(\"=>\", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);\n",
+    "    return segments.Length == 0 ? \"(unknown)\" : segments[^1];\n",
+    "}\n",
+    "\n",
+    "// Agrégation par entraîneur : on garde uniquement les essais terminés.\n",
+    "var byTrainer = trials\n",
+    "    .GroupBy(TrainerName)\n",
+    "    .Select(g => new\n",
+    "    {\n",
+    "        Trainer = g.Key,\n",
+    "        N = g.Count(),\n",
+    "        BestRmse = g.Min(t => t.Metric),\n",
+    "        TotalDurationMs = g.Sum(t => t.DurationInMilliseconds),\n",
+    "        BestTrialId = g.OrderBy(t => t.Metric).First().TrialSettings.TrialId,\n",
+    "    })\n",
+    "    .OrderBy(x => x.BestRmse)   // le gagnant en premier (barre la plus courte)\n",
+    "    .ToList();\n",
+    "\n",
+    "Console.WriteLine($\"Entraîneurs distincts testés : {byTrainer.Count}\");\n",
+    "Console.WriteLine($\"Nombre total d'essais terminés : {trials.Count}\");\n",
+    "Console.WriteLine();\n",
+    "Console.WriteLine($\"{\"Entraîneur\",-30} {\"Essais\",6} {\"Meilleur RMSE\",15} {\"Durée cumulée (ms)\",18} {\"Trial ID\",9}\");\n",
+    "Console.WriteLine(new string('-', 82));\n",
+    "foreach (var row in byTrainer)\n",
+    "{\n",
+    "    Console.WriteLine($\"{row.Trainer,-30} {row.N,6} {row.BestRmse,15:F4} {row.TotalDurationMs,18} {row.BestTrialId,9}\");\n",
+    "}\n",
+    "\n",
+    "// Preparation du graphique : SVG inline, aucune reference reseau.\n",
+    "var trainerNames = byTrainer.Select(t => t.Trainer).ToArray();\n",
+    "var bestRmses = byTrainer.Select(t => t.BestRmse).ToArray();\n",
+    "\n",
+    "display(SvgChartHelper.Bar(\n",
+    "    \"AutoML leaderboard -- donnees quadratiques (y = 100.x^2 + bruit) -- RMSE, echelle lineaire\",\n",
+    "    trainerNames,\n",
+    "    bestRmses,\n",
+    "    width: 760,\n",
+    "    height: 380));\n"
+   ],
    "metadata": {},
    "execution_count": 6,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Entraîneurs distincts testés : 4\r\n"
+     "text": "Entraîneurs distincts testés : 5\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Nombre total d'essais terminés : 10\r\n"
+     "text": "Nombre total d'essais terminés : 13\r\n"
     },
     {
      "output_type": "stream",
@@ -783,30 +1017,34 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "LightGbmRegression                  3      90262,7424               1744         8\r\n"
+     "text": "FastForestRegression                9    1217754,0972              23614        10\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "FastForestRegression                5    4978538,8069                546         9\r\n"
+     "text": "LightGbmRegression                  1    3562470,2382                 97         3\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "SdcaRegression                      1   12442864,9612               1844         4\r\n"
+     "text": "SdcaRegression                      1   14408997,8661               2900         4\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "FastTreeRegression                  1   30523762,8465                106         1\r\n"
+     "text": "FastTreeRegression                  1   30523762,8465                191         1\r\n"
     },
     {
-     "output_type": "execute_result",
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "LbfgsPoissonRegressionRegression      1   71292480,7551                 76         8\r\n"
+    },
+    {
+     "output_type": "display_data",
      "data": {
-      "text/html": "\n<div>\n    <div id=\"cce58a45-8f6f-48d4-a17e-d9892492f738\"><!-- Plotly chart will be drawn inside this DIV --></div>\r\n<script type=\"text/javascript\">\r\n\r\n            var renderPlotly_cce58a458f6f48d4a17ed9892492f738 = function() {\r\n            var fsharpPlotlyRequire = requirejs.config({context:'fsharp-plotly',paths:{plotly:'https://cdn.plot.ly/plotly-2.6.3.min'}}) || require;\r\n            fsharpPlotlyRequire(['plotly'], function(Plotly) {\r\n\r\n            var data = [{\"type\":\"bar\",\"name\":\"Meilleur RMSE par entraîneur\",\"x\":[90262.74236955725,4978538.806896072,12442864.961249027,30523762.84646684],\"y\":[\"LightGbmRegression\",\"FastForestRegression\",\"SdcaRegression\",\"FastTreeRegression\"],\"orientation\":\"h\",\"marker\":{\"pattern\":{}}}];\r\n            var layout = {\"width\":600,\"height\":600,\"template\":{\"layout\":{\"title\":{\"x\":0.05},\"font\":{\"color\":\"rgba(42, 63, 95, 1.0)\"},\"paper_bgcolor\":\"rgba(255, 255, 255, 1.0)\",\"plot_bgcolor\":\"rgba(229, 236, 246, 1.0)\",\"autotypenumbers\":\"strict\",\"colorscale\":{\"diverging\":[[0.0,\"#8e0152\"],[0.1,\"#c51b7d\"],[0.2,\"#de77ae\"],[0.3,\"#f1b6da\"],[0.4,\"#fde0ef\"],[0.5,\"#f7f7f7\"],[0.6,\"#e6f5d0\"],[0.7,\"#b8e186\"],[0.8,\"#7fbc41\"],[0.9,\"#4d9221\"],[1.0,\"#276419\"]],\"sequential\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]],\"sequentialminus\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]},\"hovermode\":\"closest\",\"hoverlabel\":{\"align\":\"left\"},\"coloraxis\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}},\"geo\":{\"showland\":true,\"landcolor\":\"rgba(229, 236, 246, 1.0)\",\"showlakes\":true,\"lakecolor\":\"rgba(255, 255, 255, 1.0)\",\"subunitcolor\":\"rgba(255, 255, 255, 1.0)\",\"bgcolor\":\"rgba(255, 255, 255, 1.0)\"},\"mapbox\":{\"style\":\"light\"},\"polar\":{\"bgcolor\":\"rgba(229, 236, 246, 1.0)\",\"radialaxis\":{\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"ticks\":\"\"},\"angularaxis\":{\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"ticks\":\"\"}},\"scene\":{\"xaxis\":{\"ticks\":\"\",\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"gridwidth\":2.0,\"zerolinecolor\":\"rgba(255, 255, 255, 1.0)\",\"backgroundcolor\":\"rgba(229, 236, 246, 1.0)\",\"showbackground\":true},\"yaxis\":{\"ticks\":\"\",\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"gridwidth\":2.0,\"zerolinecolor\":\"rgba(255, 255, 255, 1.0)\",\"backgroundcolor\":\"rgba(229, 236, 246, 1.0)\",\"showbackground\":true},\"zaxis\":{\"ticks\":\"\",\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"gridwidth\":2.0,\"zerolinecolor\":\"rgba(255, 255, 255, 1.0)\",\"backgroundcolor\":\"rgba(229, 236, 246, 1.0)\",\"showbackground\":true}},\"ternary\":{\"aaxis\":{\"ticks\":\"\",\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\"},\"baxis\":{\"ticks\":\"\",\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\"},\"caxis\":{\"ticks\":\"\",\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\"},\"bgcolor\":\"rgba(229, 236, 246, 1.0)\"},\"xaxis\":{\"title\":{\"standoff\":15},\"ticks\":\"\",\"automargin\":true,\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"zerolinecolor\":\"rgba(255, 255, 255, 1.0)\",\"zerolinewidth\":2.0},\"yaxis\":{\"title\":{\"standoff\":15},\"ticks\":\"\",\"automargin\":true,\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"zerolinecolor\":\"rgba(255, 255, 255, 1.0)\",\"zerolinewidth\":2.0},\"annotationdefaults\":{\"arrowcolor\":\"#2a3f5f\",\"arrowhead\":0,\"arrowwidth\":1},\"shapedefaults\":{\"line\":{\"color\":\"rgba(42, 63, 95, 1.0)\"}},\"colorway\":[\"rgba(99, 110, 250, 1.0)\",\"rgba(239, 85, 59, 1.0)\",\"rgba(0, 204, 150, 1.0)\",\"rgba(171, 99, 250, 1.0)\",\"rgba(255, 161, 90, 1.0)\",\"rgba(25, 211, 243, 1.0)\",\"rgba(255, 102, 146, 1.0)\",\"rgba(182, 232, 128, 1.0)\",\"rgba(255, 151, 255, 1.0)\",\"rgba(254, 203, 82, 1.0)\"]},\"data\":{\"bar\":[{\"marker\":{\"line\":{\"color\":\"rgba(229, 236, 246, 1.0)\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}},\"error_x\":{\"color\":\"rgba(42, 63, 95, 1.0)\"},\"error_y\":{\"color\":\"rgba(42, 63, 95, 1.0)\"}}],\"barpolar\":[{\"marker\":{\"line\":{\"color\":\"rgba(229, 236, 246, 1.0)\",\"width\":0.5},\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}}}],\"carpet\":[{\"aaxis\":{\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"endlinecolor\":\"rgba(42, 63, 95, 1.0)\",\"minorgridcolor\":\"rgba(255, 255, 255, 1.0)\",\"startlinecolor\":\"rgba(42, 63, 95, 1.0)\"},\"baxis\":{\"linecolor\":\"rgba(255, 255, 255, 1.0)\",\"gridcolor\":\"rgba(255, 255, 255, 1.0)\",\"endlinecolor\":\"rgba(42, 63, 95, 1.0)\",\"minorgridcolor\":\"rgba(255, 255, 255, 1.0)\",\"startlinecolor\":\"rgba(42, 63, 95, 1.0)\"}}],\"choropleth\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contour\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"contourcarpet\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}],\"heatmap\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"heatmapgl\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"histogram\":[{\"marker\":{\"pattern\":{\"fillmode\":\"overlay\",\"size\":10,\"solidity\":0.2}}}],\"histogram2d\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"histogram2dcontour\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"mesh3d\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}],\"parcoords\":[{\"line\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"pie\":[{\"automargin\":true}],\"scatter\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"scatter3d\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}},\"line\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"scattercarpet\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"scattergeo\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"scattergl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"scattermapbox\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"scatterpolar\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"scatterpolargl\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"scatterternary\":[{\"marker\":{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"}}}],\"surface\":[{\"colorbar\":{\"outlinewidth\":0.0,\"ticks\":\"\"},\"colorscale\":[[0.0,\"#0d0887\"],[0.1111111111111111,\"#46039f\"],[0.2222222222222222,\"#7201a8\"],[0.3333333333333333,\"#9c179e\"],[0.4444444444444444,\"#bd3786\"],[0.5555555555555556,\"#d8576b\"],[0.6666666666666666,\"#ed7953\"],[0.7777777777777778,\"#fb9f3a\"],[0.8888888888888888,\"#fdca26\"],[1.0,\"#f0f921\"]]}],\"table\":[{\"cells\":{\"fill\":{\"color\":\"rgba(235, 240, 248, 1.0)\"},\"line\":{\"color\":\"rgba(255, 255, 255, 1.0)\"}},\"header\":{\"fill\":{\"color\":\"rgba(200, 212, 227, 1.0)\"},\"line\":{\"color\":\"rgba(255, 255, 255, 1.0)\"}}}]}},\"title\":{\"text\":\"AutoML leaderboard -- données quadratiques (y = 100·x² + bruit)\"},\"xaxis\":{\"title\":{\"text\":\"Entraîneur\"}},\"yaxis\":{\"title\":{\"text\":\"RMSE (échelle linéaire)\"}}};\r\n            var config = {\"responsive\":true};\r\n            Plotly.newPlot('cce58a45-8f6f-48d4-a17e-d9892492f738', data, layout, config);\r\n});\r\n            };\r\n            if ((typeof(requirejs) !==  typeof(Function)) || (typeof(requirejs.config) !== typeof(Function))) {\r\n                var script = document.createElement(\"script\");\r\n                script.setAttribute(\"src\", \"https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js\");\r\n                script.onload = function(){\r\n                    renderPlotly_cce58a458f6f48d4a17ed9892492f738();\r\n                };\r\n                document.getElementsByTagName(\"head\")[0].appendChild(script);\r\n            }\r\n            else {\r\n                renderPlotly_cce58a458f6f48d4a17ed9892492f738();\r\n            }\r\n</script>\r\n\n    \n</div>    \n"
+      "text/html": "<svg xmlns='http://www.w3.org/2000/svg' width='760' height='380' viewBox='0 0 760 380' font-family='sans-serif' font-size='12'><rect width='760' height='380' fill='white'/><text x='380' y='20' text-anchor='middle' font-size='14' font-weight='bold' fill='#333333'>AutoML leaderboard -- donnees quadratiques (y = 100.x^2 + bruit) -- RMSE, echelle lineaire</text><line x1='52' y1='338' x2='744' y2='338' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='342' text-anchor='end' fill='#333333'>0</text><line x1='52' y1='262' x2='744' y2='262' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='266' text-anchor='end' fill='#333333'>19248969.804</text><line x1='52' y1='186' x2='744' y2='186' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='190' text-anchor='end' fill='#333333'>38497939.608</text><line x1='52' y1='110' x2='744' y2='110' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='114' text-anchor='end' fill='#333333'>57746909.412</text><line x1='52' y1='34' x2='744' y2='34' stroke='#E5E5E5' stroke-width='1'/><text x='44' y='38' text-anchor='end' fill='#333333'>76995879.215</text><line x1='52' y1='34' x2='52' y2='338' stroke='#888888' stroke-width='1'/><line x1='52' y1='338' x2='744' y2='338' stroke='#888888' stroke-width='1'/><rect x='78.296' y='333.192' width='85.808' height='4.808' fill='#4C72B0'/><text x='121.2' y='354' text-anchor='middle' fill='#333333'>FastForestRegression</text><rect x='216.696' y='323.934' width='85.808' height='14.066' fill='#4C72B0'/><text x='259.6' y='354' text-anchor='middle' fill='#333333'>LightGbmRegression</text><rect x='355.096' y='281.109' width='85.808' height='56.891' fill='#4C72B0'/><text x='398' y='354' text-anchor='middle' fill='#333333'>SdcaRegression</text><rect x='493.496' y='217.484' width='85.808' height='120.516' fill='#4C72B0'/><text x='536.4' y='354' text-anchor='middle' fill='#333333'>FastTreeRegression</text><rect x='631.896' y='56.519' width='85.808' height='281.481' fill='#4C72B0'/><text x='674.8' y='354' text-anchor='middle' fill='#333333'>LbfgsPoissonRegressionRegression</text></svg>"
      },
-     "metadata": {},
-     "execution_count": 6
+     "metadata": {}
     }
    ]
   },
@@ -1210,18 +1448,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 56.078381,
-   "end_time": "2026-06-09T04:47:28.327814",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "ML-3-Entrainement&AutoML.ipynb",
-   "output_path": "ML-3-Entrainement&AutoML.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-09T04:46:32.249433",
-   "version": "2.6.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {

--- a/docs/reference/kernels-runtime.md
+++ b/docs/reference/kernels-runtime.md
@@ -59,6 +59,35 @@ dotnet tool update --global Microsoft.dotnet-interactive --version 1.0.617701
 dotnet interactive jupyter install
 ```
 
+### Consequence du pin : plafond Roslyn 4.12.0.0 sur les packages NuGet
+
+Le pin n'est pas gratuit. `1.0.617701` **embarque Roslyn 4.12.0.0** (`Microsoft.CodeAnalysis.CSharp.dll`, FileVersion `4.1200.24.57207`, mesure firsthand sur ai-01 le 2026-08-16 dans `.dotnet/tools/.store/.../tools/net9.0/any/`). Tout package reference par `#r "nuget: ..."` qui **exige** une version superieure echoue au chargement :
+
+```
+System.IO.FileNotFoundException: Could not load file or assembly
+'Microsoft.CodeAnalysis.CSharp, Version=4.13.0.0, ...'
+```
+
+**Un `#r "nuget: Microsoft.CodeAnalysis.CSharp, 4.13.0"` ne repare PAS ce cas** : le kernel a deja charge son propre Roslyn dans l'ALC au demarrage, et `#r` ne substitue pas une assembly deja resolue. Le correctif est donc **toujours cote package**, jamais cote kernel — remonter le kernel casserait `#!import` sur tout le depot (tableau ci-dessus).
+
+Instance mesuree (#11104, ML-3 AutoML) :
+
+| Package | Dependance `Microsoft.CodeAnalysis.CSharp` | Sur le kernel pinne |
+|---|---|---|
+| `Microsoft.ML.AutoML` **0.23.0** | `[4.13.0, )` | **echoue** — `FileNotFoundException` |
+| `Microsoft.ML.AutoML` **0.22.3** | `[4.9.2, )` | **OK** — satisfait par 4.12.0.0 |
+
+`0.22.3` prend `Microsoft.ML [4.0.3, )`, borne **ouverte** : le pin `Microsoft.ML, 5.0.0` du notebook reste valide. Mesure de bout en bout apres bascule : **10/10 cellules, 0 erreur, 86,1 s**.
+
+Verifier la dependance d'un package avant d'incriminer le kernel :
+
+```bash
+grep -o 'id="Microsoft.CodeAnalysis[^"]*" version="[^"]*"' \
+  ~/.nuget/packages/<pkg>/<version>/<pkg>.nuspec
+```
+
+**Piege de diagnostic adjacent** : sur cet hote (32 threads), un notebook .NET non borne en threads OpenMP part en timeouts de cellule qui *ressemblent* a un blocage kernel. `OMP_NUM_THREADS=4` a ramene ce meme notebook de **6 380,9 s (7 cellules en timeout a 900 s)** a **14,8 s** — facteur **x431**. Borner les threads **avant** de conclure a un hang.
+
 ## Python 3.10+ (notebooks Python)
 
 Notebooks dans `GenAI/`, `QuantConnect/`, `GameTheory/`, `IIT/`, `SymbolicAI/SemanticWeb/` (Python).

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -41,7 +41,15 @@
       csharp_sha: ee313290cb2f95f19a3063f5476fd1103cf4818e
       content_python_sha: 58d05932f373d8570f763fca6d9cdccd997959fd75a2509513c74dbec893cccc
       content_csharp_sha: 5b847c94a8671b87feaea6160682530fdf4b9dddfa7fe69b18ff6b30cece7e3a
+    - date: "2026-08-16"
+      by: myia-ai-01:CoursIA
+      python_sha: 695da4960a0c19888c1e5917040ed84d5ee520be
+      csharp_sha: 58f6ae3832011e841390b35858288e9c51eeb3e5
+      content_python_sha: 58d05932f373d8570f763fca6d9cdccd997959fd75a2509513c74dbec893cccc
+      content_csharp_sha: 2aace562e3201186743f2e665340546e7c01577ce72ced096207737dbd502399
   known_differences:
+    - "2026-08-16 : migration de la derniere cellule Plotly-CDN du depot vers SVG inline cote C# (issue #11104, PR #11173). Le graphique du leaderboard AutoML passe de `Plotly.NET.Interactive` 3.0.2 (sortie HTML dependante d'un CDN, invisible en export statique) a `SvgChartHelper` (canon #6927, SVG inline sans requete reseau) ; `Microsoft.ML.AutoML` recule 0.23.0 -> 0.22.3 pour rester sous le plafond Roslyn 4.12.0.0 du kernel epingle. Le graphique n'est pas supprime, il devient hors-reseau : parite SEMANTIQUE conservee (meme socle pedagogique, memes moteurs, C# re-execute 10/10 cellules / 0 erreur / 48,7 s). Rebaseline content SHA apres re-audit firsthand (myia-ai-01:CoursIA)."
+    - "Asymetrie de visualisation (constatee au re-audit du 2026-08-16, PRE-EXISTANTE a la PR #11173) : le C# rend un graphique du leaderboard (desormais SVG inline) ; le jumeau Python n'en rend AUCUN -- il importe `matplotlib.pyplot as plt` en cellule 2 sans jamais tracer (8/8 cellules executees, 9 sorties toutes de type `stream`, zero `display_data`). L'import est donc mort. Ecart signale, non corrige ici (hors scope de #11104) : suivi par #11174."
     - "2026-08-15 : correction d'auteurs falsifies (issue #11044, tranche W3C SPARQL / ML.NET KDD) — citations remises a leurs auteurs reels (Amizadeh S., DOI KDD, Protocol et al., etc.), markdown-only, aucun changement d'engine/outputs. Parite semantique conservee ; rebaseline content SHA (re-audit 2026-08-15, myia-po-2026:CoursIA-2)."
     - "Socle pedagogique commun : comparaison de trainers de regression (lineaire vs boosting) + evaluation RMSE train/test."
     - "Zoos de modeles distincts : C# = `Regression.Trainers.Sdca` (Stochastic Dual Coord Ascent) + `LightGbm` (binding ML.NET LightGBM natif). Python = `LinearRegression` + `GradientBoostingRegressor, RandomForestRegressor, DecisionTreeRegressor, SVR` (ensemble sklearn)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-ai-01:CoursIA — prev: MED/docs #11069

Closes #11104

## Summary

`ML-3-Entrainement&AutoML.ipynb` cell[13] était **la dernière cellule Plotly-CDN du dépôt**. Le scan canonique le disait sans ambiguïté avant ce correctif :

```
Notebooks scanned: 1009
Notebooks risky (>=1 cell): 1
Cells risky total: 1
| ML\ML.Net\ML-3-Entrainement&AutoML.ipynb | cell idx 13 | ML/ML.Net |
```

Son output committé était un `text/html` portant **1 référence `cdn.plot.ly` et 6 appels `require`** : formellement une preuve d'exécution valide (`execution_count: 6`, aucune erreur) qui ne montrait **aucune image** en export statique. Or la figure porte le point pédagogique central, écrit dans le commentaire de la cellule : *« la barre du perdant (~30M) domine, celle du gagnant (~90k) est ~300x plus courte »*. Un lecteur du notebook rendu lisait le tableau console et devait imaginer l'écrasement.

## Ce que fait la PR

| Cellule | Changement |
|---|---|
| `cell[13]` | `Chart2D.Chart.Bar` → `SvgChartHelper.Bar` (canon #6927), `#load "../../Probas/Infer/SvgChartHelper.cs"` |
| `cell[1]` | retrait de `#r "nuget: Plotly.NET.Interactive, 3.0.2"` et `Plotly.NET.CSharp, 0.0.1` |
| `cell[11]` | retrait de `using Plotly.NET;` / `using Plotly.NET.CSharp;` |
| `cell[12]` | prose : annonçait Plotly comme « vrai outil de visualisation » — devenu faux |
| `docs/reference/kernels-runtime.md` | plafond Roslyn du kernel pinné (voir plus bas) |

**Échelle linéaire conservée** — délibérément. C'est l'écrasement visuel qui porte le message ; passer en log « pour mieux voir » détruirait ce que la figure démontre.

Les vestiges Plotly ne sont **pas** de l'élargissement de scope : `Plotly.NET.Interactive` **enregistre un formatter de kernel à son chargement**. Le laisser en place signifie que le prochain graphique ajouté à ce notebook repartirait silencieusement en sortie CDN, rouvrant la classe de défaut que #6927 vient de fermer.

## Le déblocage préalable — et pourquoi il est dans cette PR

Le notebook ne se ré-exécutait pas : `cell[5]` levait

```
System.IO.FileNotFoundException: Could not load file or assembly
'Microsoft.CodeAnalysis.CSharp, Version=4.13.0.0, ...'
```

Mesuré, pas supposé :

| Composant | Roslyn |
|---|---|
| kernel `dotnet-interactive 1.0.617701` (pin **délibéré**) | ships **4.12.0.0** (`FileVersion 4.1200.24.57207`) |
| `Microsoft.ML.AutoML` **0.23.0** | exige **`[4.13.0, )`** → échoue |
| `Microsoft.ML.AutoML` **0.22.3** | exige **`[4.9.2, )`** → OK |

Deux voies étaient fermées, une était ouverte :
- **Remonter le kernel** : exclu. `1.0.712001` casse `#!import` sur tout le dépôt (#8485, #8525) — le pin est porteur.
- **`#r "nuget: Microsoft.CodeAnalysis.CSharp, 4.13.0"`** : inopérant. Le kernel a déjà chargé son Roslyn dans l'ALC au démarrage ; `#r` ne substitue pas une assembly résolue.
- **Côté package** : `AutoML 0.22.3` prend `Microsoft.ML [4.0.3, )`, borne **ouverte** — le pin `Microsoft.ML, 5.0.0` du notebook reste valide.

C'est le verdict **RECOVERABLE-LOCAL** de [sota-not-workaround.md](.claude/rules/sota-not-workaround.md), tenu : le vrai AutoML de ML.NET s'exécute réellement, aucune sortie de substitution n'est committée. Sans ce correctif l'acceptance de #11104 (« 0 erreur, ré-exécuté de bout en bout ») était inatteignable — d'où sa présence ici plutôt que dans une PR séparée.

**Contrepartie assumée, à dire clairement** : le notebook enseigne désormais AutoML `0.22.3` au lieu de `0.23.0`. L'alternative était de dé-pinner le kernel et de casser `#!import` ailleurs. La prose de `cell[12]` suit la version.

## Validation (H.1 / C.2 / D)

Ré-exécution complète, kernel `.net-csharp`, `OMP_NUM_THREADS=4` :

```
DONE ML-3-Entrainement&AutoML.ipynb: 10/10 cells, 0 errors, 48.7s
```

| Critère d'acceptance #11104 | Mesure |
|---|---|
| `check_plotly_static_risk.py` → 0 | **`Notebooks scanned: 1010 / Cells risky total: 0`** — dépôt entier |
| `cell[13]` sans référence réseau | output `text/html` de 3 395 car. contenant `<svg` ; `cdn.plot.ly` **0**, `require(` **0**, `plotly` **0**. Seul `http://` = `xmlns='http://www.w3.org/2000/svg'`, identifiant de namespace XML jamais résolu |
| `grep -c "Plotly"` → 0 hors prose | **0 occurrence dans tout le notebook**, prose comprise |
| `exec_null = 0`, 0 erreur | **10/10 cellules, `execution_count` 1-10 non-null, 0 output `error`** |

`strip_probe_banner.py --apply` passé (1 bannière). Le hook `strip-dotnet-nuget-ext` a par ailleurs attrapé **3 lignes de fuite de nom d'utilisateur machine** (`Loading extensions from <NuGet cache>`) et les a corrigées avant commit — signalé ici parce que c'est une sortie .NET, pas une édition manuelle d'output.

## Notes

- Aucune cellule d'exercice touchée : les 4 stubs `// TODO etudiant` restent des stubs (C.1), le notebook s'exécute de bout en bout sans erreur volontaire.
- Catalogue **byte-identique à `main`** : aucun fichier généré dans le diff.
- Piège de diagnostic adjacent documenté dans `kernels-runtime.md` : sur cet hôte 32 threads, ce même notebook non borné partait en **6 380,9 s / 7 timeouts à 900 s** contre **14,8 s** avec `OMP_NUM_THREADS=4` — facteur **x431**. Borner les threads avant de conclure à un hang.


---

## Attestation de parite du jumeau (commit `60bf307a9`)

Le check `Twin parity audit (#8057)` a signale **1 paire mise en DRIFT par cette PR** : le registre stocke le git blob SHA de chaque jumeau, et toute edition le deplace. L'outil est explicite — *« Tu rebaselines pour ATTESTER la parite, pas pour la reparer »* — donc re-audit **firsthand** avant d'attester, pas apres.

**Mesure du jumeau `ML-3-Entrainement-Python.ipynb` (2026-08-16)**

| Grandeur | Valeur |
|---|---|
| Cellules code / `execution_count` non-null / avec outputs | 8 / 8 / 8 |
| Types d'output | `{'stream': 9}` |
| `display_data`, `image/*` | **0** |
| Primitives de trace (`plt.`, `.plot(`, `figure(`, `subplots(`, `savefig`, `scatter(`, `bar(`) | **0** |

**Verdict : parite SEMANTIQUE conservee.** Le graphique C# n'est pas supprime — il devient hors-reseau. Socle pedagogique commun et moteurs des deux cotes inchanges. Rebaseline lance **en dernier**, apres les strips outilles du commit precedent (#8957).

**Ecart pre-existant mis au jour par ce re-audit** : le Python importe `matplotlib.pyplot as plt` et ne trace **jamais**. Import mort, zero visualisation cote Python, asymetrie jamais declaree jusqu'ici. Les deux constats sont inscrits en tete de `known_differences` ; la correction est **hors scope de #11104** et suivie par **#11174** (retirer l'import mort, ou — recommande — ajouter la visualisation manquante et re-executer).

**Collision** : verifie avant d'attester — `bf38be176` (#11140, ML-3 premier run propre, mergee 2026-08-15T22:41Z) est bien ancetre de cette branche. Pas de course avec une autre lane sur ce notebook.
