### PR TITLE
fix(notebooks,#11174): ML-3 Python — visualisation RMSE train/test (import matplotlib mort)

### DIFF
--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "a65fa8af",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002819,
+     "end_time": "2026-08-16T01:52:08.048598+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:08.045779+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# ML-3 (Python) : Entraînement et AutoML\n",
     "\n",
@@ -17,7 +26,16 @@
   {
    "cell_type": "markdown",
    "id": "81057721",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002153,
+     "end_time": "2026-08-16T01:52:08.066936+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:08.064783+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Les estimateurs dans scikit-learn\n",
     "\n",
@@ -32,11 +50,19 @@
    "id": "0832bbbf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T12:10:58.211481Z",
-     "iopub.status.busy": "2026-07-05T12:10:58.211349Z",
-     "iopub.status.idle": "2026-07-05T12:11:00.055925Z",
-     "shell.execute_reply": "2026-07-05T12:11:00.055166Z"
-    }
+     "iopub.execute_input": "2026-08-16T01:52:08.072932Z",
+     "iopub.status.busy": "2026-08-16T01:52:08.072711Z",
+     "iopub.status.idle": "2026-08-16T01:52:19.372932Z",
+     "shell.execute_reply": "2026-08-16T01:52:19.372334Z"
+    },
+    "papermill": {
+     "duration": 11.304863,
+     "end_time": "2026-08-16T01:52:19.374055+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:08.069192+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -78,11 +104,19 @@
    "id": "329155c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T12:11:00.058051Z",
-     "iopub.status.busy": "2026-07-05T12:11:00.057737Z",
-     "iopub.status.idle": "2026-07-05T12:11:00.062286Z",
-     "shell.execute_reply": "2026-07-05T12:11:00.061475Z"
-    }
+     "iopub.execute_input": "2026-08-16T01:52:19.379824Z",
+     "iopub.status.busy": "2026-08-16T01:52:19.379533Z",
+     "iopub.status.idle": "2026-08-16T01:52:19.384063Z",
+     "shell.execute_reply": "2026-08-16T01:52:19.383517Z"
+    },
+    "papermill": {
+     "duration": 0.008063,
+     "end_time": "2026-08-16T01:52:19.384606+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:19.376543+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -115,7 +149,16 @@
   {
    "cell_type": "markdown",
    "id": "81fde3ea",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00235,
+     "end_time": "2026-08-16T01:52:19.389246+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:19.386896+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exemple 1 : Régression linéaire vs Gradient Boosting\n",
     "\n",
@@ -133,11 +176,19 @@
    "id": "3dcee690",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T12:11:00.064387Z",
-     "iopub.status.busy": "2026-07-05T12:11:00.064084Z",
-     "iopub.status.idle": "2026-07-05T12:11:00.694305Z",
-     "shell.execute_reply": "2026-07-05T12:11:00.693703Z"
-    }
+     "iopub.execute_input": "2026-08-16T01:52:19.394854Z",
+     "iopub.status.busy": "2026-08-16T01:52:19.394640Z",
+     "iopub.status.idle": "2026-08-16T01:52:20.203456Z",
+     "shell.execute_reply": "2026-08-16T01:52:20.202868Z"
+    },
+    "papermill": {
+     "duration": 0.812597,
+     "end_time": "2026-08-16T01:52:20.204051+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:19.391454+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -147,6 +198,16 @@
       "LinearRegression (SDCA)   RMSE train: 2.9059  test: 2.9002\n",
       "GradientBoosting (LightGbm) RMSE train: 39.3519  test: 40.1619\n"
      ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAoAAAAGGCAYAAADrfDCjAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAASVZJREFUeJzt3Qm8TfX+//HPyTzLTOYhM3VVEoWQaCA0D5S4SgqVcq9EqqO6oW6SJlREimaEQgOF0iSKiDJ1MxxD5vV/vL+/x9r/vY9zjnM45+y9z3o9H4/l2Gutvfd3r733d3/Wd/isBM/zPAMAAEBgnBLtAgAAACB7EQACAAAEDAEgAABAwBAAAgAABAwBIAAAQMAQAAIAAAQMASAAAEDAEAACAAAEDAEgAABAwBAAAogZrVq1cgtyhmHDhllCQkK0iwEgBQSAQBaaOHGi+wH0l9y5c9tpp51mPXr0sD/++OOY/RX8aL9atWql+Hhz584NPdabb74Zse3777+3bt26WZUqVSx//vzuedq1a2f//e9/I/arWrVqRJnCl4svvjjN17Ny5Ur3o75+/XqLVToOei1fffWV7du3z5V3wYIFWfqcH374oXueIMquY5xRQX5PgPTIna69AJyUhx56yKpVq2b79++3JUuWuMDws88+sx9++MEFa+F0e82aNS6AOeeccyK2TZ482W3X44T74osvrHXr1la5cmXr1auXlStXzjZu3Oie66mnnrJ+/fpF7H/GGWfY3XfffUw5K1SocNwAcPjw4S5QVSCZ2T766KOTfowPPvjAypQpY2effbb99ddfrrySlS2LCjbGjh0byIBDAWBqx3jIkCF2//33R6VcQX5PgPQgAASyQYcOHeyss85y/7/11lutVKlS9thjj9m7775rV111VcS+NWrUsMOHD9vrr78eEQAq6Js5c6Zdcskl9tZbb0Xc55FHHrFixYrZ0qVLrXjx4hHbtm3bdkx51Dp4ww03WFbyPM+VuUCBAum+T968eTPlh1/HO+hdjzr2Op6nnBK9jh61eGsJor1791qhQoWiXQwgVXQBA1Fw/vnnu79r165Ncfu1115r06ZNs6NHj4bWvffee661JXnA6D9O/fr1jwn+RK1hmUGtlldeeaX7v1ob/W5jv+tPLYKXXnqpzZkzxwW7CvzGjx/vtk2YMMEuvPBCV5Z8+fJZvXr1bNy4cccdA6jH1nO88cYbLsitWLGiawFt06aNayVNbufOna41VEGyuqlLly7t1quFyi9veIvQqlWrXLd5iRIl3OOq3ArKwx06dMjdX93y2qdkyZLWokUL1x0v6s5XS5OEd6enxT9WavFUa6weV8dkxowZEftt377d7rnnHmvYsKEVLlzYihYt6oLbb7/9NmI//zhNnTrVtbopwC9YsKAlJSWlWgZ9tsaMGeM+N3r+smXL2j//+U/bsWNHxH7Lli2z9u3bu5MWvadqyb7lllvctuMd45TGAOr2HXfcYdOnT3evWY/ZrFkz13Uv+szUrFnTlUmfheTDDT799FP3OVRrtz5LlSpVsgEDBtjff/8d2ud470l6X3vyz0v4+6fnSD7UY+HChXb77be7z7k+q0AsC+apGRBl/o/aqaeemuL26667LjSuSoGTTJkyxQU+KQV0Gve3ePFi16XcoEGD4z6/gpr//e9/x6xXi0VqLXYXXHCB3Xnnnfb000/bv/71L6tbt65b7/+V1atXu+BVP6bqiq5du7Zbr2BPP7aXX365axFSMKsfSv0Q9+3b97jlHTlypGvJUjC0a9cue/zxx+3666+3L7/8MmI/BZ/6Ib7ooovc8+h5b7vtNrviiiusS5cubp9GjRq5vz/++KM1b97cBUvqptRrV6DZuXNn18Kq+4jeh8TERNdyqxZZBVUKir7++ms3xlKvddOmTS4gfPXVVy29fvnlF7v66qutT58+1r17dxckK7CZPXu2e1z59ddf7e2333brFXht3brVBUgtW7Z03fHJu+xHjBjhWv10nA4cOJBmi6rKrcDl5ptvdu/runXr7JlnnrFvvvnGPv/8c8uTJ49rPdaxVJCnY6QTDH12/UBV69M6xqlREKdA23/vdXwVEA8aNMieffZZ99lQMKb3WcHmxx9/HLqvAkedCOk5FYxrqITGuf7+++9um//a0npP0vPaT4TKrWMydOhQ1wIIxDQPQJaZMGGCp6/ZvHnzvD///NPbuHGj9+abb3qlS5f28uXL526Ha9mypVe/fn33/7POOsvr2bOn+/+OHTu8vHnzepMmTfI++eQT95jTp08P3e+jjz7ycuXK5ZZmzZp5gwYN8ubMmeMdPHjwmDJVqVLF3T+lJTExMc3Xo+fUfipDao87e/bsY7bt27fvmHXt27f3qlevfszr1+LzX2vdunW9AwcOhNY/9dRTbv33338fcf8bb7wx4v465trvwQcfPOb527Rp4zVs2NDbv39/aN3Ro0e98847z6tVq1ZoXePGjb1LLrnES0vfvn3d86SXf6zeeuut0Lpdu3Z55cuX984888zQOpXtyJEjEfddt26d++w89NBDxxwnHc+UjnVyn376qdt/8uTJEev13oWvnzlzpru9dOnSVB8rrWOsdcmPi26r/HodvvHjx7v15cqV85KSkkLrBw8e7NaH75vS69PnNiEhwfvtt9+O+56k97X7ZU3pden96969+zHf8xYtWniHDx9O4SgBsYcuYCAbtG3b1rUMqLtKXY5qbVILSFrdRGoFVEvLwYMH3YzfXLlyhVqlklOLkVoA1cKm7kG1nKjbTq1bybs0pWnTpq51JPmi1ruToVYqPW9y4a2KasFT66NasdTCpdvHo5aa8NYsvwtd9/epNVGtZ+r+PR51rapVSd3pu3fvduXRokkjKr9a5/xZ2mr1Umuh1mUmtd6Fv5/q3r3ppptcK9SWLVvcOnVx+mP4jhw54sqnrmC1rKoFMjm1JKZnzKVayjRmVJ8b/7VradKkiXv8Tz75xO3nDyl4//33XatxZlFLdvgkIn0epWvXrlakSJFj1oe/z+GvT61sKvd5553nxpzq2GXWaz8RavXW9xSIB3QBA9lA45FOP/10F+y8/PLLtmjRIvfjnpZrrrnGdeXNmjXLzf5VF1n4j2NymvXqB4wKAjVhZPTo0S7gXLFihRtv5dN4LgWlmU0BYErUrfbggw+6IFXdd+F0TPSDnBaN9wrnd52Hj9nSBJg///wzXQGgxg8qYHjggQfckhJ1fyqA1gzuTp06ufdP3etKlXPjjTcet5vzeDTOLfn4OD2HqJtVM7kV1GoWt7pF1U2pINCn7s/0Hv/kFMzquKc2PtSfOKQgXUGZxvfps6Qxeeoi18nJ8T6/GXk//fdfJ0gprQ9/nzds2OC6WHVik3zMXnpOJtL72k9Eeo8/EAsIAIFsoLFj/ixg/YBqEoF+RDVmTq0OKSlfvrz7wX3yySddAJV85m9q1FKmYFCLAgq1nqnVQwFYVkup9UkTVNTiU6dOHRs1apT7kVcZNVtXQUX4RJfUpNaq8n+9dP9Hj6dWpfBANzX+cyrATqnF0g/Q/LGPeg3vvPOOm7Tx4osvunI/99xzblxgVnr00UddgKpxcBrfp8kqahHs379/isctvTOudV8FQDqxSIk/scPPN6l0Qhq3qTGWKos+k1qX2mf3RN/P473PCoDVcqcW3Pvuu899ptSartZaTcpIz2cpva89LeGBeLiMzHgHoo0AEMhm+pHToHfNpNXA87TypClIVJChrriOHTtm+Ln8oHPz5s2WGU4ktYoCB01IUItNeMvPyXS1pZb/L/kxSq281atXd3812D89LaEKvBRIa9mzZ48LCjU5xA8AT+S4+K2Q4ff9+eef3V+/e1TBlz4nL7300jGzndWKe6KUamjevHluEkx6gpZzzz3XLZqJrclImoCjGcd6/dmZbkczhXWMJk2a5LrLff6M7HCplSsjr10tzTrW4dTCnlnfJyCaGAMIRIFa9tQqqFQUyZM6h1P3rVru1AWY1oxOBVPhrWHhrWLiz8Y9WX5es+Q/imnxW3XCy6cuOM16zSyaHasxccm7f5UKJaXyqgVI74Fm1Kb0Y66uZJ/G3YVTq5daBxXUnsxx0SxVddP7NLv4lVdecWlh1P3rH7vk76tac1O6ikxGaOyjWrHUqpicclD6r0NdrMmfX+UT//WndoyzQkqfJf1f3eTJpfaepPe1+8GihmuEe/7551NtAQTiCS2AQJTce++9Lr2H0lEoFUhKNAYqPVcy0JU+NLZOkwrULaZWCuXDUy5BtSap5SqcAojXXnvtmMdRcKMu6tTox18/wkpirSBO48D8/H6pURoRBa+XXXaZS7+hFrQXXnjB3SezWlIU6Cqfm1rLwqmFR13COg7qDldLnsbxadG4THXFK8eeBu+rVVCBpMYpKqWIn2tP91ewqEkCur9SwKhlTrnsfNomSimiLmUdI43hTIvK07NnTzd2UXnoNDZUzx8eGGvcp8Yg6v3TRAe1gKnr0m/BPFEa26f3Qi3RGh+q90itoRofpwBTAZVOPtTSppMPfa4UDGnCjN47TVjxW1vTOsaZTZ9tlUNd9/oMqxwaGpF8LGBa70l6X7uohVPfTY2DVNezPhPqBj+Z1lcgZkR7GjKQk/npIVJKo6H0HjVq1HCLnzoiPA1MalJKAzNr1izvlltu8erUqeMVLlzYpYypWbOm169fP2/r1q3pTgOjbcfzwgsvuHQjSjkTnhJG900tXcq7777rNWrUyMufP79XtWpV77HHHvNefvnlY1J8pJYGJvy1iu6j9Tq+0q1bN69jx44pPvcXX3zhNWnSxB2T5Gk91q5d6910000u/UiePHm80047zbv00ktdqh7fww8/7J1zzjle8eLFvQIFCrhj/Mgjj0Sk2NH7p2Ot9D5KR3K8qtU/VkrVo+OitCh63OSvU2lg7r77bpceRs/dvHlzb/Hixek+Tsfz/PPPu2Ojxy5SpIhLi6MUQps2bXLbv/76a+/aa6/1Kleu7MpYpkwZd3yWLVuWrmOcWhoYpWhJ6f184oknItan9LpWrlzptW3b1n3OS5Uq5fXq1cv79ttvIz4P6XlPjvfa/e/offfd556nYMGCLnXRmjVrUk0Dk1a6HCDWJOifaAehAHCi1G2nGbFq0VEi3nigVlm1kCm9CgBEA2MAAcQ1zQjVpcBSy5EIADgWYwABxDWNJUzPOEkAwP9HCyAAAEDAMAYQAAAgYGgBBAAACBgCQAAAgIDJ8ZNAdN1HZdwvUqRItl6yCAAAIDtpVJ8StleoUMFdNzzQAaCCP118HgAAIAg2btxoFStWDHYAqJY//2DoskEAAAA5ka4prkYvP/YJdADod/sq+CMABAAAOV16hrwxCQQAACBgCAABAAAChgAQAABkmQkTJrguybffftvd3rZtm1188cVWq1Yta9CggS1atCjF++3Zs8fat29vpUqVsuLFix+zfcOGDXbZZZdZ7dq1rV69evbf//43y19LTpLjxwCm15EjR+zQoUPRLkbcyps373GnnAMAgmX9+vX2wgsv2Lnnnhtad//997vbs2fPtqVLl9oVV1xh69atszx58kTcV7fvu+8+K1GihLVq1eqYdCe6nx7ryiuvdOu2bt2aTa8qZwh8AKgP0ZYtW2znzp3RLkpcU/BXrVo1FwgCAKA8vLfeeqtrmbv77rtD69944w1bs2aN+//ZZ5/tctYtXLjQ2rZtG3H/fPny2YUXXuiCyOTmz5/vtvvBn5QtWzZLX09OE/gA0A/+ypQpYwULFiRZ9Ekk2968ebNVrlyZYwgAsFGjRlnz5s2tSZMmoXV//fWX620rV65caF3VqlVdd25GrFy50kqXLm3XXHONrV692j3Gk08+adWrV8/U15CT5Q56t68f/JUsWTLaxYlr+iIqCDx8+PAxzfgAgGD54Ycf7K233kp1fN/J0m/Nxx9/bEuWLLH69evbc889Z1dddZUtW7YsS54vJwr0oC1/zJ9a/nBy/K5fBdUAgGD79NNPXdetJnqodU6BWu/evV33b+7cuV3vm0/7qfcoI7T/mWee6YI/ufHGG+3rr79mLH8GBDoA9NFlefI4hgCyw0UXXWSNGjWyM844w84//3z75ptv3HpNKDjrrLPcNk0w+Pbbb1O8vyYbqEtS99cMVI0h27FjRygQyZUrl9vmL2vXrs3W15dT3HbbbW5YkI6pFr0nzz//vFuvY64WO9EkkD/++MNatmyZocfv0KGD/f777+6+8uGHH1rdunXpgcoIL0YkJiZ6Ks5dd90VWvf33397t99+u1eiRAmvUKFCXpcuXbwtW7Zk6HF37drlHld/k9Pjr1y50v3FyeFYAsgOO3bsCP1/xowZXqNGjbzt27e734kffvjBrV+0aJFXv379FO+/f/9+b9++faHbd955p1tk3bp1XrFixbL8NQRRy5YtvZkzZ7r/63e8Xbt2Xs2aNb169ep5H3/8cWi/Bx54wBs3blzodsOGDb1y5cp5CQkJ3mmnnebdcMMNoW1z5szxGjdu7D4D559/vvfdd995QbcrjZgnuZgYA6gzgPHjx7szt3ADBgywDz74wKZPn27FihWzO+64w7p06WKff/551MqaU6mJvn///m4BgFgVng9u165drvdBrXQax+13B6plUJMK1CX4j3/8I+L+mjnq05CVvXv3WuHChbPxFQTTggULImbrfvTRRynu99BDD0Xc/u6779JsDdaCExP1AFCJHq+//nqXJ+jhhx+O+GK/9NJLNmXKFDcN3E8mqSZejSUIzymU2are/4Flp/UjL8m0rtYHH3zQhg0bdkJBeKFChTJ8PwDIbjfddJN98sknoa4/jQfT7NIvvvjCzjvvPHv33Xdt9+7drusxeQAoBw8etHPOOcd+++031/Cg/X0KCJWaRMFh586d7d///rfrFgZymqgHgH379rVLLrnE5f8JDwCXL1/uBnOG5wWqU6eO+6IvXrw41QDwwIEDbvElJSVZTqIxFb5p06bZ0KFD3RR4X/iZrHIcqhLTgNv0zOIFgHjwyiuvuL+TJk1yiYIVBL755ps2ePBg16jQrFkzd2WI1Oo+TVpbsWKFCwT79evneqAGDRpk5cuXd2PKlBli+/btdvXVV7vUItoWs4YVi3YJkF7DdlksieokkKlTp7om+sTExGO2aYaQvqTJL/+ipuPw2UPJ6bHUXewvlSpVspxEuZP8Ra9PLYL+7VWrVlmRIkVs1qxZbpCzujo+++wz1z3SqVMnd+wUIOrsdt68ecd0AY8ZMyZ0W4/74osvukzrmiWtmVzhZ8kAEG3du3d3LYFq/WvdurVLJqzGAwVtSkulIDAt+o25+eab7dVXX3W3VWcq+BNdfeKWW25xs1mBnChqAeDGjRvtrrvussmTJ1v+/Pkz7XF1BqjuY3/R8wSNLo0zcuRI++mnn1z3hs6IO3bs6DKna8acrsGo6yceL/Hm8OHDXV4ljcHQ/dVVr7NiAIgG5W1VYOfTtWU19k/BWnjvyIgRI9zQoZo1ax7zGOr23bdvXyiJvcaY++PPdY1aP42IepJmzJjhUo0AOVHUuoB1lqYvW/j4DHVXKmnkM888Y3PmzHHN8/rCh7cC6lp/4RnEk9MZXPgg3yDSINp27dqFbqtybNy4cUTlOHPmTNeip4k1qenRo4dde+217v+PPvqoPf300/bVV1+5ABIAsptO6pVC5O+//3aXn9TQlffff9/1WGg4jFrrlCBYXcAaQ+7TNl1urE+fPu6EVuP6/ABQv0Gq20Q9JtpXY/70OAoi/X2BnCZqAWCbNm3s+++/j1inpniN89OYDnXdKp+PWq26du3qtmusm1qt9OVG6pQLK5xaADUxRDOqdZasik0V6PFaAMNnZWuCSNGiRV3QDgDRUKVKFXcSmhJNJExN+MxS9X5oSYmyTGgBgiBqAaDGqikJZzgFGWrO99f37NnTBg4c6FqwFHxosK6Cv6ycAZwTJJ/Ne88999jcuXPtP//5j+sSKVCggHXr1s21sKYleUJNnWXrjBkAAMS3qM8CTsvo0aNdM79aADUeo3379vbss89Gu1hxR3kT1Z2rCR1+i6DSIwBAtNNg4eSsz7wh9AiY3LGaKFI0OWTs2LFuwYnTDF4NZla3h1rxHnjgAVryAAAIMK4FHACjRo2yU0891SVIVRColtSUkqMCAIBgSND14CwHUyJo5cvT7DGNIwy3f/9+d2HwatWqZWoqmiDiWAI5A13A8WV9/uuiXQTEUCLotGKe5GgBBAAACBgCQAAAgIAhAAQAAAgYAkAAAICAIQAEAAAIGAJAAACAgCEABAAACBgCQAAAgIAhAAQAAAgYAkAAAICAyR3tAsSkYcVi9vIwCQkJaW5/8MEHbdiwYSdUDD32zJkzrXPnzid0fwAAEB8IAOPM5s2bQ/+fNm2aDR061FavXh1aV7hw4SiVDAAAxAu6gONMuXLlQosu+KxWu/B1U6dOtbp161r+/PmtTp069uyzz4bue/DgQbvjjjusfPnybnuVKlUsMTHRbatatar7e8UVV7jH9G8DAICchxbAHGTy5MmuRfCZZ56xM88807755hvr1auXFSpUyLp3725PP/20vfvuu/bGG29Y5cqVbePGjW6RpUuXWpkyZWzChAl28cUXW65cuaL9cgAAQBYhAMxBNP7vySeftC5durjb1apVs5UrV9r48eNdALhhwwarVauWtWjRwrXyqQXQV7p0afe3ePHiriURAADkXASAOcTevXtt7dq11rNnT9fq5zt8+LDrKpYePXpYu3btrHbt2q6V79JLL7WLLrooiqUGAADRQACYQ+zZs8f9feGFF6xp06YR2/zu3H/84x+2bt06mzVrls2bN8+uuuoqa9u2rb355ptRKTMAAIgOAsAcomzZslahQgX79ddf7frrr091v6JFi9rVV1/tlm7durmWwO3bt1uJEiUsT548duTIkWwtNwAAyH4EgDnI8OHD7c4773RdvgrsDhw4YMuWLbMdO3bYwIEDbdSoUW4GsCaInHLKKTZ9+nQ33k/j/kQzf+fPn2/Nmze3fPny2amnnhrtlwQAALIAaWBykFtvvdVefPFFN5O3YcOG1rJlS5s4caKbDCJFihSxxx9/3M466yw7++yzbf369fbhhx+6YFA0gWTu3LlWqVIlFyQCAICcKcHzPM9ysKSkJNcitmvXLtf9GW7//v1uTJwCJOXFw4njWAI5Q9X7P4h2EZAB6/NfF+0iIAuu+pUVMU9ytAACAAAEDAEgAABAwEQ1ABw3bpw1atTINVNqadasmUtR4mvVqpVLWBy+9OnTJ5pFBgAAiHtRnQVcsWJFGzlypLs6hYYiTpo0yTp16uQuYVa/fn23j5IaP/TQQ6H7FCxYMIolBgAAiH9RDQAvu+yyiNuPPPKIaxVcsmRJKABUwMelyQAAAHLgGEAlIJ46daq7pJm6gn2TJ0+2UqVKWYMGDWzw4MG2b9++TH/uo0ePZvpjBk0On0wOAECOEvVE0N9//70L+JRGpHDhwjZz5kyrV6+e23bddddZlSpV3BUuvvvuO7vvvvts9erVNmPGjFQfT8mPtYRPiU5N3rx5XQ68TZs2WenSpd1tjTNExoO/P//80x07XU0EAADEtqgHgLVr17YVK1a4nDW6Jm337t1t4cKFLgjs3bt3aD8lNtZVLNq0aWNr1661GjVqpPh4iYmJ7ooY6aHgT3nrNm/e7IJAnDgFfxrT6V93GAAAxK6YSwTdtm1bF9yNHz/+mG3qHlYr4ezZs619+/bpbgHUlS3SSoqoQ3D48GGug3sS1PJH8AfEPxJBxxcSQceRYbGVCDrqLYApjccLD+DCqaVQ1BKYGl3DVktG+F2XdF8CAIAgiGoAqEkdHTp0sMqVK9vu3bttypQptmDBApszZ47r5tXtjh07WsmSJd0YwAEDBtgFF1zgcgcCAAAgDgPAbdu22U033eTG4KnJUoGdgr927drZxo0bbd68eTZmzBjX9atu3K5du9qQIUOiWWQAAIC4F9UA8KWXXkp1mwI+TQYBAABADs0DCAAAgOxBAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwUQ0Ax40bZ40aNbKiRYu6pVmzZjZr1qzQ9v3791vfvn2tZMmSVrhwYevatatt3bo1mkUGAACIe1ENACtWrGgjR4605cuX27Jly+zCCy+0Tp062Y8//ui2DxgwwN577z2bPn26LVy40DZt2mRdunSJZpEBAADiXoLneZ7FkBIlStgTTzxh3bp1s9KlS9uUKVPc/2XVqlVWt25dW7x4sZ177rnperykpCQrVqyY7dq1y7UyAgBSV/X+D6JdBGTA+vzXRbsISK9huyyrZSTmiZkxgEeOHLGpU6fa3r17XVewWgUPHTpkbdu2De1Tp04dq1y5sgsAU3PgwAF3AMIXAAAAxFAA+P3337vxffny5bM+ffrYzJkzrV69erZlyxbLmzevFS9ePGL/smXLum2pSUxMdNGvv1SqVCkbXgUAAED8iHoAWLt2bVuxYoV9+eWXdtttt1n37t1t5cqVJ/x4gwcPdk2f/rJx48ZMLS8AAEC8yx3tAqiVr2bNmu7/TZo0saVLl9pTTz1lV199tR08eNB27twZ0QqoWcDlypVL9fHUkqgFAAAAMdoCmNzRo0fdOD4Fg3ny5LH58+eHtq1evdo2bNjgxggCAAAgDlsA1V3boUMHN7Fj9+7dbsbvggULbM6cOW78Xs+ePW3gwIFuZrBms/Tr188Ff+mdAQwAAIAYCwC3bdtmN910k23evNkFfEoKreCvXbt2bvvo0aPtlFNOcQmg1SrYvn17e/bZZ6NZZAAAgLgXc3kAMxt5AAEg/cgDGF/IAxhHhpEHEAAAAFFEAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAET1QAwMTHRzj77bCtSpIiVKVPGOnfubKtXr47Yp1WrVpaQkBCx9OnTJ2plBgAAiHdRDQAXLlxoffv2tSVLltjcuXPt0KFDdtFFF9nevXsj9uvVq5dt3rw5tDz++ONRKzMAAEC8yx3NJ589e3bE7YkTJ7qWwOXLl9sFF1wQWl+wYEErV65cFEoIAACQ88TUGMBdu3a5vyVKlIhYP3nyZCtVqpQ1aNDABg8ebPv27YtSCQEAAOJfVFsAwx09etT69+9vzZs3d4Ge77rrrrMqVapYhQoV7LvvvrP77rvPjROcMWNGio9z4MABt/iSkpKypfwAAADxImYCQI0F/OGHH+yzzz6LWN+7d+/Q/xs2bGjly5e3Nm3a2Nq1a61GjRopTiwZPnx4tpQZAAAgHsVEF/Add9xh77//vn3yySdWsWLFNPdt2rSp+7tmzZoUt6uLWF3J/rJx48YsKTMAAEC8imoLoOd51q9fP5s5c6YtWLDAqlWrdtz7rFixwv1VS2BK8uXL5xYAAADEYACobt8pU6bYO++843IBbtmyxa0vVqyYFShQwHXzanvHjh2tZMmSbgzggAED3AzhRo0aRbPoAAAAcSuqAeC4ceNCyZ7DTZgwwXr06GF58+a1efPm2ZgxY1xuwEqVKlnXrl1tyJAhUSoxAABA/It6F3BaFPApWTQAAABy2CQQAAAAZB8CQAAAgIAhAAQAAAgYAkAAAICAIQAEAAAIGAJAAACAgMlQALht27Y0tx8+fNi++uqrky0TAAAAYiUA1OXXwoPAhg0bRlxr96+//rJmzZplbgkBAAAQvQAweeLm9evX26FDh9LcBwAAADl8DGBCQkJmPyQAAAAyEZNAAAAAAiZ3Rlv3du/ebfnz53ddvbq9Z88eS0pKctv9vwAAAMghAaCCvtNPPz3i9plnnhlxmy5gAACAHBQAfvLJJ1lXEgAAAMReANiyZcusKwkAAABiLwBUoucjR45Yvnz5Quu2bt1qzz33nO3du9cuv/xya9GiRVaUEwAAANEIAHv16mV58+a18ePHu9uaEHL22Wfb/v37XZLo0aNH2zvvvGMdO3bMrPIBAAAgmmlgPv/8c+vatWvo9iuvvOJaBH/55Rf79ttvbeDAgfbEE09kdhkBAAAQrQDwjz/+sFq1aoVuz58/3wWExYoVc7e7d+9uP/74Y2aWDwAAANEMAJX/7++//w7dXrJkiTVt2jRiu/ICAgAAIIcEgGeccYa9+uqr7v+ffvqpmwBy4YUXhravXbvWKlSokPmlBAAAQHQmgQwdOtQ6dOhgb7zxhm3evNl69OjhJn/4Zs6cac2bN8+80gEAACD6eQCXL19uH330kZUrV86uvPLKY1oIzznnnMwuIwAAAKIVAErdunXdkpLevXtnRpkAAAAQKwHgokWL0rXfBRdccKLlAQAAQCwFgK1atbKEhAT3f8/zUtxH25UbEAAAADlgFvCpp55qlSpVsgceeMAlf96xY8cxy/bt29P9eImJie5KIkWKFLEyZcpY586dbfXq1RH76Cojffv2tZIlS1rhwoVd3kHNPgYAAEA2BICa+fvYY4/Z4sWLrWHDhtazZ0/74osvrGjRoi4ZtL+k18KFC11wp3yCc+fOtUOHDtlFF13krivsGzBggL333ns2ffp0t/+mTZusS5cuGXuVAAAACEnwUuvLPY4NGzbYxIkTbdKkSXbgwAF3FZDhw4db7twZnlcS8ueff7qWQAV6Gke4a9cuK126tE2ZMsW6devm9lm1apWbhKIg9Nxzzz3uYyYlJbmgVI+lQBUAkLqq938Q7SIgA9bnvy7aRUB6DdtlWS0jMU+GWgDDVa5c2eUFnDdvnp1++uk2cuRI98QnQwWWEiVKuL9KOaNWwbZt24b2qVOnjntuBYApUTCqcoQvAAAAOMkAUEGWWuUUmDVo0MBKlSplH3zwQShwOxFHjx61/v37u0TSekzZsmWL5c2b14oXLx6xb9myZd221MYVhndHa8wiAAAA/r8M9dd+9dVXNmHCBJs6dapVrVrVbr75ZndVkJMJ/HwaC/jDDz/YZ599dlKPM3jwYBs4cGDotloACQIBAABOMADUmDt1v955553WpEkTty6lgO3yyy/PyMPaHXfcYe+//77LM1ixYsXQel1t5ODBg7Zz586IVkDNAta2lOTLl88tAAAASFnuE5n8MWLEiFS3ZyQPoOaf9OvXz11DeMGCBVatWrWI7Qoy8+TJY/Pnz3fpX0RpYlSGZs2aZbToAAAAyGgAqHF6x7Nv374MdftqLOE777zjcgH64/o0dq9AgQLur1LNqEtX3cya0aKAUcFfemYAAwAAIBNnAac0MWTUqFFWvXr1dN9n3LhxbuavrjBSvnz50DJt2rTQPqNHj7ZLL73UtQAqNYy6fmfMmJFZxQYAAAic3BkN8oYNG+aSNmt27qBBg9zVO15++WUbMmSI5cqVyyVuTq/0pCDMnz+/jR071i0AAADI5gBQef/Gjx/v0r/oCiBXXnmlmwmsK3mo9U+3FQQCAAAghwSAuhzbK6+84mb5KmVLo0aN7PDhw/btt9+6yR8AAADIYWMAf//991D6FyVrVroVdfkS/AEAAOTQAFDpXTT2z6fr/hYuXDgrygUAAIBY6ALWpI0ePXqEEi3v37/f+vTpY4UKFYrYj1m6AAAAOSQA7N69e8TtG264IbPLAwAAgFgKAHUdYAAAAMS3TEsEDQAAgPhAAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDBRDQAXLVpkl112mVWoUMESEhLs7bffjtjeo0cPtz58ufjii6NWXgAAgJwgqgHg3r17rXHjxjZ27NhU91HAt3nz5tDy+uuvZ2sZAQAAcprc0XzyDh06uCUt+fLls3LlymVbmQAAAHK6mB8DuGDBAitTpozVrl3bbrvtNvvrr7+iXSQAAIC4FtUWwONR92+XLl2sWrVqtnbtWvvXv/7lWgwXL15suXLlSvE+Bw4ccIsvKSkpG0sMAAAQ+2I6ALzmmmtC/2/YsKE1atTIatSo4VoF27Rpk+J9EhMTbfjw4dlYSgAAgPgS813A4apXr26lSpWyNWvWpLrP4MGDbdeuXaFl48aN2VpGAACAWBfTLYDJ/f77724MYPny5dOcNKIFAAAAMRgA7tmzJ6I1b926dbZixQorUaKEW9SV27VrVzcLWGMABw0aZDVr1rT27dtHs9gAAABxLaoB4LJly6x169ah2wMHDnR/u3fvbuPGjbPvvvvOJk2aZDt37nTJoi+66CIbMWIELXwAAADxGgC2atXKPM9LdfucOXOytTwAAABBEFeTQAAAAHDyCAABAAAChgAQAAAgYAgAAQAAAoYAEAAAIGAIAAEAAAKGABAAACBgCAABAAAChgAQAAAgYAgAAQAAAoYAEAAAIGAIAAEAAAKGABAAACBgCAABAAAChgAQAAAgYAgAAQAAAoYAEAAAIGAIAAEAAAKGABAAACBgCAABAAAChgAQAAAgYAgAAQAAAoYAEAAAIGAIAAEAAAKGABAAACBgCAABAAACJqoB4KJFi+yyyy6zChUqWEJCgr399tsR2z3Ps6FDh1r58uWtQIEC1rZtW/vll1+iVl4AAICcIKoB4N69e61x48Y2duzYFLc//vjj9vTTT9tzzz1nX375pRUqVMjat29v+/fvz/ayAgAA5BS5o/nkHTp0cEtK1Po3ZswYGzJkiHXq1Mmte+WVV6xs2bKupfCaa67J5tICAADkDDE7BnDdunW2ZcsW1+3rK1asmDVt2tQWL16c6v0OHDhgSUlJEQsAAADiIABU8Cdq8Qun2/62lCQmJrpA0V8qVaqU5WUFAACIJzEbAJ6owYMH265du0LLxo0bo10kAACAmBKzAWC5cuXc361bt0as121/W0ry5ctnRYsWjVgAAAAQBwFgtWrVXKA3f/780DqN59Ns4GbNmkW1bAAAAPEsqrOA9+zZY2vWrImY+LFixQorUaKEVa5c2fr3728PP/yw1apVywWEDzzwgMsZ2Llz52gWGwAAIK5FNQBctmyZtW7dOnR74MCB7m/37t1t4sSJNmjQIJcrsHfv3rZz505r0aKFzZ492/Lnzx/FUgMAAMS3BE8J93IwdRtrNrAmhDAeEADSVvX+D6JdBGTA+vzXRbsISK9huyyWYp6YHQMIAACArEEACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAAUMACAAAEDAEgAAAAAFDAAgAABAwBIAAAAABQwAIAAAQMASAAAAAARPTAeCwYcMsISEhYqlTp060iwUAABDXcluMq1+/vs2bNy90O3fumC8yAABATIv5aEoBX7ly5aJdDAAAgBwjpruA5ZdffrEKFSpY9erV7frrr7cNGzZEu0gAAABxLaZbAJs2bWoTJ0602rVr2+bNm2348OF2/vnn2w8//GBFihRJ8T4HDhxwiy8pKSkbSwwAABD7YjoA7NChQ+j/jRo1cgFhlSpV7I033rCePXumeJ/ExEQXKAIAACBOu4DDFS9e3E4//XRbs2ZNqvsMHjzYdu3aFVo2btyYrWUEAACIdXEVAO7Zs8fWrl1r5cuXT3WffPnyWdGiRSMWAAAAxEkAeM8999jChQtt/fr19sUXX9gVV1xhuXLlsmuvvTbaRQMAAIhbMT0G8Pfff3fB3l9//WWlS5e2Fi1a2JIlS9z/AQAAkANbAKdOnWqbNm1ys3oVDOp2jRo1ol2suLd//37r3LmzG0/ZuHFja9euXarjKp944glr0KCB1atXz7XA7ty5M7StW7duLkWPrtASvh6x9159+eWX7v56nAsvvND++OOPbHwVAIBYE9MBILJO7969bfXq1fbtt99ap06d7NZbbz1mn7lz59qECRNs8eLFtnLlSmvSpIn9+9//Dm3v06ePrVixIptLHjwn+14dPXrU5dAcM2aM/fzzz9axY0fr379/FF4JACBWEAAGUP78+V0QoJY7Offcc904y+QUcKjb3c+5qPu8+uqroe1t27a1MmXKZGPJgycz3qvly5e7K+q0bt3a3f7nP/9p7733nmtdBAAEEwEg7KmnnnItS8mpFUnXYd6yZYt5nmeTJ0+23bt32/bt26NSTpzYe6Wr5yh/pk9BombHa3gFACCYYnoSCLLeo48+6saUzZ8//5htajHSTOxLL73Uzb7WuDJRaxKyH+8VACCz8OsQYP/5z39sxowZruWoYMGCKe5z++23u0U0A7tixYrkVoyz96py5cr222+/hfZTy6CSpGsCDwAgmOgCDqhRo0bZ66+/7iYP6AorqdE1mGXfvn02dOhQGzRoUDaWEpnxXql7+NChQ/bJJ5+42+PHj7fLLrvMjS8EAARTgqcBQzlYUlKSFStWzLV40HL1f5RSp1KlSla9evXQpAFdQUWpQhQ4qGVIM3ylYcOGbhbpwYMH7cYbb7QHHnggNCHhkksucZMPlFJE96lVq5YtWLAgqq8tp8ms90qzgzX5QxM/dB9NENHjAslVvf+DaBcBGbA+/3XRLgLSa9gui6WYhwAQABBCABhfCADjyLDYCgDpAgYAAAgYJoFkIs6c4wdnzXEkG86aASBoaAEEAAAIGAJAAACAgCEABAAACBgCQAAAgIAhAAQAAAgYAkAAAICAIQAEAAAIGAJAAACAgCEABAAACBgCQAAAgIAhAAQAAAgYAkAAAICAIQAEAAAIGAJAAACAgCEABAAACBgCQAAAgICJiwBw7NixVrVqVcufP781bdrUvvrqq2gXCQAAIG7FfAA4bdo0GzhwoD344IP29ddfW+PGja19+/a2bdu2aBcNAAAgLsV8ADhq1Cjr1auX3XzzzVavXj177rnnrGDBgvbyyy9Hu2gAAABxKbfFsIMHD9ry5ctt8ODBoXWnnHKKtW3b1hYvXpzifQ4cOOAW365du9zfpKSkLC/v0QP7svw5kDmSErxoFwHplQ3fXfx/1GPxhbosjiRlfV3mxzqe58V3APi///3Pjhw5YmXLlo1Yr9urVq1K8T6JiYk2fPjwY9ZXqlQpy8qJ+FMs2gVA+o3k3QJSw7cjjozMvndr9+7dVqxYsfgNAE+EWgs1ZtB39OhR2759u5UsWdISEhKiWjbEBp0h6YRg48aNVrRo0WgXBwBOCHUZklPLn4K/ChUq2PHEdABYqlQpy5Url23dujVivW6XK1cuxfvky5fPLeGKFy+epeVEfFKFSaUJIN5RlyHc8Vr+4mISSN68ea1JkyY2f/78iBY93W7WrFlUywYAABCvYroFUNSd2717dzvrrLPsnHPOsTFjxtjevXvdrGAAAADkwADw6quvtj///NOGDh1qW7ZssTPOOMNmz559zMQQIL00REB5JZMPFQCAeEJdhpOR4KVnrjAAAAByjJgeAwgAAIDMRwAIAAAQMASAAAAAAUMAiHRTIu2333472sXI8apWrepmuwOIHz169LDOnTuHbrdq1cr69+9vQUd9FrsIAJFmJRZu8+bN1qFDB4sFEydOdAGpFl0funz58m7G+IYNGyzeLV261Hr37h3tYgBxTVkj7rrrLqtZs6blz5/fZY5o3ry5jRs3zvbty/rrHc+YMcNGjBiRLfWzXxdqyZ07t1WuXNmlUDtw4IBlZ52c0kUXqM9iV8yngUHsSO3qK9lJk9Z1fWhR5vvVq1e7devWrbPbb7/drrzySvvyyy+ztAyHDh2yPHnyZNnjly5dOsseGwiCX3/91QV7CkgeffRRa9iwoUuV8v3339vzzz9vp512ml1++eVZ+t0uUaKEZacJEybYxRdf7F7Dt99+63LlFipUKNOD0IyiPotdtADihLqA169f727rLLd169ZWsGBBa9y4sS1evDjiPp999pmdf/75VqBAAXfNyjvvvNMl8va9+uqrLsl3kSJFXIB53XXX2bZt20LbFyxY4J5n1qxZ7qowqsT1mH55dB+1/p133nnWs2dP++qrr9z1MX3vvPOO/eMf/3AtANWrV7fhw4fb4cOHQ9tXrVplLVq0cNvr1atn8+bNS/F1Tps2zVq2bOn2mzx5stv24osvWt26dd26OnXq2LPPPht63IMHD9odd9zhyqbtVapUscTERLdNAeuwYcPcWbpej67ZqOOSWpeJWjU7depkhQsXdkHvVVddFXF5RD2W8mPqWOq+ugzQNddc464HCQSRTgbVErZs2TL3fdH3VN9/fY8++OADu+yyy9x++m6rRVDBoIKlRx55xJ1gqi6pVq2aq7dq165tTz31VMTjax+1sCnA1HXmBw0a5L7X4ZJ3Aas17p577nHBp56radOmrn5L3oI2Z84cV1593xXQqefF/55PmjTJ1Wl+a1/4/XVf1YeqZy+99FL3Wr/++uuIMum11qhRw11lS69LdUa449U1CixV36u+1nbVyTrGKocCzl27doXKpvKmVJ9pm+rOK664wv1u1KpVy959992Icui21qvu1PPpdet+O3fuzNDnAMehPICAr3v37l6nTp1S3KaPy8yZM93/161b527XqVPHe//9973Vq1d73bp186pUqeIdOnTI7bNmzRqvUKFC3ujRo72ff/7Z+/zzz70zzzzT69GjR+gxX3rpJe/DDz/01q5d6y1evNhr1qyZ16FDh9D2Tz75xD1Po0aNvI8++sg95l9//eVNmDDBK1asWGi/rVu3eq1bt/Zy5crl7dmzx61btGiRV7RoUW/ixInu8XX/qlWresOGDXPbDx8+7NWuXdtr166dt2LFCu/TTz/1zjnnnBRfp+731ltveb/++qu3adMm77XXXvPKly8fWqe/JUqUcM8lTzzxhFepUiVXhvXr17vHnjJlits2ffp0Vy697t9++8378ssvveeffz70WnQMdczkyJEj3hlnnOG1aNHCW7ZsmbdkyRKvSZMmXsuWLUP7P/jgg17hwoW9Ll26eN9//717znLlynn/+te/MuETAcSX//3vf15CQoKXmJh43H313S5Tpoz38ssvuzpC38eDBw96Q4cO9ZYuXeq+2/quFyxY0Js2bVrofo899ph36qmnuu/9ypUrvZ49e3pFihSJqDv1Hb3rrrtCt2+99VbvvPPOc99P1WOqI/Lly+fqRlGdlidPHq9t27buuZcvX+7VrVvXu+6669z23bt3e1dddZV38cUXe5s3b3bLgQMHQq/Dr7NE9XG1atW84cOHh9bNmDHDPf7YsWPd9ieffNLVlx9//HG665r69et7N9xwg/fTTz+5cr/xxhuu7lQ5xowZ4+o1v2wqb/L6zC9rxYoVXX34yy+/eHfeeaerv1Svi465ynnPPfd4q1at8l5//XXvtNNOc/fbsWNHBj8NSAsBIE4qAHzxxRdD23/88Ue3TpWDqFLs3bt3xGMoEDrllFO8v//+O8XnUMWnx/ArDz8AfPvttyP2U2Wp9QowVTnr/1pUmfjatGnjPfrooxH3e/XVV13gJrNmzfJy587tKivf3LlzU3ydqtzC1ahRIxTQ+UaMGOECWOnXr5934YUXekePHj3mNariPf30090PTUrCK0wFraqkN2zYcMxx/uqrr0IBoI5BUlJSaJ97773Xa9q0aYqPD+RkClz0/VDAE65kyZKuvtAyaNAgt0779e/f/7iP2bdvX69r166h26pDHn/88dBtnfQqqEktAFRgqe/xH3/8EfG4qqMGDx4cUacpOPQpWCtbtuxx62fdL3/+/O61KajU7UsvvTSijlHw2atXr4j7XXnllV7Hjh3TXdcoyPVPcpNLflLuSykAHDJkSOi2Tti1TvWx3HfffV6DBg0iHuPf//43AWAWoAsYJ6VRo0ah/6u7U/wuXHUXqFtD3Qn+0r59ezt69KgbsyfLly933THqDlW3grpZJflkDnUTJ6f9V6xY4bognnzySdfVqy4cn57/oYceinj+Xr16uS4VDQLX+EF1l4SPbdT1plMS/vzqwl67dq3rJgp/7Icfftit9wdrq2zqZlH37kcffRS6v8Yp/v33365LSuWZOXNmRLd0uJ9++smVUYtPXdXq7tE2n7pZdDzC34vwrnQg6DQ8RN/J+vXrR0yOSKluGTt2rOve1Pg1fbc1btCvk9TNqTpEXbg+dTen9Dg+jT1Ut/Hpp58eUWcsXLgwVGeIukTVRXsi3+PRo0e716d67/3337eff/7ZbrzxxtB21RcaFxlOt/16JD11jbq9b731Vmvbtq2NHDkyouwn+ruh7nB1J/uvU/Xy2WefHbF/avUyTg6TQHBSwgdMa4yGKMCTPXv22D//+c+I8W0+BXwKpBQQatG4OlW2qmR1W2PowqmSSE6zfzXDTzRmRpXRbbfdFhrXoufXmL8uXbocc1+NLcmI8OfX48oLL7wQ8SMguXLlcn8VjCrI1dhFjSvUWBpVmm+++aarYFXJaf3cuXPdeKUnnnjC/Ric6AD05PfTe+G/D0CQqE7Q51/fsXA64RKN60urbpk6daobq6eTymbNmrkTK30/T2ZymeoM1Q064fXrCJ8CwbS+x+m9WqtOZP36UCeeGgN87bXXuhNTf/3J0rg+jdPWOErVbboOsY6XxvNlBPVVbCAARJZRELRy5cpUKx+dFf/111/uTNI/61Rr3om6//773dnzgAED3HNr0Y9Aas+vSnLjxo1ukLNSRPgpC45H+2rihmYaXn/99anup7NapabR0q1bNzege/v27W52oH6E1PKppW/fvm4SiY6HyhxOga3KqMU/RjqmGgyts3MAkTQpo127dvbMM89Yv379Ujx5TMvnn3/uJpXpxMwX3tKlSVZqmVNAeMEFF7h1asFXcJf8++s788wzXQugWrk0Ke5EafKGnwXhePxAU70Nfl2i19a9e/fQPrrt1yPprWvUiqlF9awCTM0+VgCYkbKlRfXyhx9+GLEuPfUyMo4AEMdQF4e6EpJXqhl133332bnnnutmw6rbQBWxKhS1eqlyViugKo3//ve/1qdPH/vhhx9OKmWBKi1VREOHDnVdIPqr2XB6HgVgajFU94ieR2fF+pFQwKgK8fHHH3dnzEOGDIlozUyNWhbVsqkfAwV26lJS8Lpjxw7XTTJq1Cj3I6GKX887ffp0d4au7hR1i6uiVOuhunxee+01FxBqpnByajVUCgsFmppJpx8a/TCpqzytLicgyDQjX92b+o6o1UpdjvoeKpDQzH9176ZGs09feeUVNxtXM4HVo6D76f8+5RfUiav21cmbvu9pzVBVwKTv8E033eRaFlUv/PnnnzZ//nxXtksuuSRdr0tDPVQundiqTlb947em6fmV+1Atab/88osb/qLnVWAn9957r+uJ0HOrXnnvvfdcFgf1RKSnrlEgqcdQXapj8fvvv7vj0rVr11DZ1NKp16SMEKrbtGSUeo10PPX7oWE2+i1SnZmeehkZlBUDCxG/NMjYn1ARvmhCR0qTI7755pvQfTVAV+s0ccOnwcOaZatZXhqgrNm8jzzySGi7JlJohq0GLmsCxbvvvhvxuP4kkOSDf1MbcKyZxNpfM2tl9uzZbvBzgQIF3Aw1zfINn3GrCSvNmzf38ubN62Y0v/fee+7+ul9qr9M3efJkN2tO99WMwAsuuCA08FzPoW16zXpeDfb++uuv3TYdQ03Q0HptP/fcc7158+alOmhaA8gvv/xyt68GYWvg9pYtW0LbNQmkcePGEWXT/fU4QFBptv4dd9zhZsNqVqnqIH3/Nft27969Kc6elf3797tMBapfihcv7t12223e/fffH/Ed06QPTfDQd1j7DBw40LvpppvSnAXszy5WfafyaCLJFVdc4X333Xep1mkqW/jP9LZt20L1aXhdG15Xawa0Hvvqq692M5vDPfvss1716tXd82si2iuvvBKxPa26RjN9r7nmGpfdQHVehQoV3PENn9DXp08fN9lG5VC9lNokkOTHXK9br9/3zjvveDVr1nS/C61atfLGjRvn7pfa5EGcmAT9k9GgEcip1CWivIBr1qyJGIwNAIgOTe577rnnXPc0Mg9dwAg0zcDVIGx15SjoU9eOuo4I/gAgel34mgmsbm6dlGsSjoYSIXMRACLQNO5PY000+7hUqVJuHIzG6AAAokNjGDVOW5PmNIb77rvvtsGDB0e7WDkOXcAAAAABQyJoAACAgCEARExTnsAyZcrY+vXrLZZpgLJ/gXkAOVNG6iOlnznjjDMy9PitWrWy/v37n0QJo/ccs2fPdq+XhM7xgwAQMT/7q1OnTi7HlD9pQ7kFlf9KGfp1Wafwykz5opQrSosSoZ566qku355yYim/YXLKm6VksbpKQL58+VwuQQVyymWVXGJiontMDUhO7pZbbrGvv/7aPv3000w/BgBirz5SEKh6JnnOVJ+uJpJSPXKy9Jxvv/32Met19STVTUpGrZyrqiOVj0+5TTdt2mRZTflQlZNQV3VCfCAARMzS9XpfeukllwxUVJnqqhpKPKrreirzvirkQ4cOHXMFDl2rU4lKv/jiC+vdu7dL7Kqz0/CKUBW4EsJ+/PHHruLUlTh0Ftu6dWt3dY7kXn75ZRs0aJD7m5wSWusSSU8//XSWHAsAsVUfHY+yC5xIAv0ToUT0Smz/6KOPuuuQL1q0yNVnqo/+97//uWT72UHPTR0YR04wfyCQ5aZPn+6VLl06dFtJVZUUNC2pJYjeunWrV6pUKe/6668PrevQoYN32mmneXv27Dlm/+SJpxcsWOD2VTJXJUD9/PPPj7nPwoULXYLUffv2pfs1AojP+iitJPEpJWhX8uh+/fq5+qlEiRLeoEGDUkwerX3uvfdel1y+bNmyoYTKflLl8KTPfrL3xMRE75RTTgklm0/u6NGjEc/Rt29ftyiRtRI3DxkyJGIfPe6IESO8G2+80SWFrly5skvOrETUfqLohg0bekuXLj0mkbTKtWbNmgweXUQDLYCIWepODb9kky6l9uOPP7pLuWWUxu3oEkfvvvuuuwyb0guotU8tfSldK1SXbAunM39d91JdHPqr28npckm6fNLJXDQeQHzURxn12GOPue5RXTtXue2SkpJS7MqdNGmSq5NUj+gSlRq+ostnhl8TV4+hXg7/9uuvv+5aAHWZt5Qkv4SaniN37tyuJ+Wpp55yl1578cUXI/YZPXq0y4n6zTffuEvV3Xjjje5SdjfccIMb7qJcqbodnkhEKVt0rXSGwsQHAkDErN9++80qVKgQuq2xekoOqutVagzONddc47pj1f2RHrpmp/L+aSC3kj6r4tK641FF/eabb7qKT/T3jTfecNe9DKfrXmrcjcoNIGfXRxmlbljlstP1ylXv6HroyU80RdcGfvDBB11yegVYOrH0xxKWLl3a/dX9dELs3/7555+tdu3aEY+j51E3tJbzzjsvYpvGOivA0310Yqy6VbfDdezY0V2XV+XQddVVD6r+vfLKK901hpU/9aeffrKtW7dG3E/HiDowPhAAImbp4uP58+cP3dZZ8QcffOCCNw1sVsWmBKHnnHOOG59zPP6Zqs6GM5L+UmfXOtvVgGrRWMIqVarYtGnTjtm3QIEC6SoLgPiujzJCE9AUKKmu8mlCWUotigoAw5UvX962bdt2QlfT0AQVTVBLXidpIl14q2CzZs1c8mX1jqRUDrXqiU6+k69LXjbqwPhBAIiYpStz7Nix45j1CsZuvfVW12WhroiVK1emGIwlp7NVTRDRwGyd1aoCXLVq1XHvp+5edT2ry8Rf9JwpTQZR17J/Vg4g59dHmU3DTMKpnjpeahXVZ6tXrz4mcKxZs6aVKFHipMvhB4sprUteNurA+EEAiJil8SwKtNKirmB1ve7duzfN/XSWOmXKFOvcubOdcsoprlJs3769jR07NsX77ty50/3VTLply5bZggUL3Nm0v+j24sWLIwLItWvX2v79+1MdhwMgZ9dHqdHQELWY+WP2RK1tOoHNKAVh4S11onHJGieo8XrpkXyc8pIlS1wQqVbJk6H6T/UgdWB84FrAiFkK0DRmRmfdyuenxKrqWtDYFHXBKkhTygGlgdEAaJ+6d5XfT3+1jwI1pUdQJTxy5MjQfgr+NMhZ3TIaaK0uD03iUEU6btw412Ko1j9tv+CCC44pn8bDaLufF1ADn5VPUC2UAHJ2feRL3vImyk+anMbZKZeoWuU0BlBjAvVYySdoHI9OejUmUHWXcpeqLAMGDHDDY9q0aePGD55//vluvcYGzpo165jATtc+HzhwoBvjpyBUZcmMa6ArkFSZ1KWM2EcLIGKWxpsoqakmXEjLli3t119/dQOjVYF26NDBBXofffRRxABoDVZW98dpp53mKqLx48db9+7d3dmx1vsUrKnyU94/jSVs0KCBCyRVuSoAVGLV1157zeUdTInWK7+gn4dQYwV79eqV5ccFQPTrI58mo6nFK3xJPjFCNGlCLXWqv1QvaQyzgsqMjitUoKaTVE3k8Fva9Biqt/QcmiHcokULq1u3rkuSr0Ax+WxjlUFjGnVyq0wId911l8uXerJUB2pSiXplEPsSlAsm2oUAUqOz2nvvvdelflHXbazSGMELL7zQnXGrpRFAzpOZ9ZHGzilIu+qqq2zEiBEW75RwWifiGjJTrVq1aBcH6UAXMGKa8k9pdtoff/zhznhjlXJyqTWQ4A/IuU6mPlJqFPVWqCdDqauUBmbdunXuCkI5ga6spJnHBH/xgxZAAACy2MaNG113sVoP9bOrIScak5zS+GIgOxAAAgAABEzsDqoCAABAliAABAAACBgCQAAAgIAhAAQAAAgYAkAAAICAIQAEAAAIGAJAAACAgCEABAAACBgCQAAAAAuW/wfx/92p/Z7dCgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 650x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -163,13 +224,40 @@
     "gbm_test_rmse  = np.sqrt(mean_squared_error(y_test,  gbm.predict(X_test)))\n",
     "\n",
     "print(f\"LinearRegression (SDCA)   RMSE train: {lr_train_rmse:.4f}  test: {lr_test_rmse:.4f}\")\n",
-    "print(f\"GradientBoosting (LightGbm) RMSE train: {gbm_train_rmse:.4f}  test: {gbm_test_rmse:.4f}\")\n"
+    "print(f\"GradientBoosting (LightGbm) RMSE train: {gbm_train_rmse:.4f}  test: {gbm_test_rmse:.4f}\")\n",
+    "\n",
+    "# Visualisation : RMSE train/test par estimateur (matplotlib inline, image PNG embarquée)\n",
+    "fig, ax = plt.subplots(figsize=(6.5, 4))\n",
+    "x_pos = np.arange(2)\n",
+    "width = 0.35\n",
+    "train_vals = [lr_train_rmse, gbm_train_rmse]\n",
+    "test_vals = [lr_test_rmse, gbm_test_rmse]\n",
+    "ax.bar(x_pos - width / 2, train_vals, width, label=\"Train\")\n",
+    "ax.bar(x_pos + width / 2, test_vals, width, label=\"Test\")\n",
+    "ax.set_xticks(x_pos, [\"LinearRegression\\n(SDCA)\", \"GradientBoosting\\n(LightGbm)\"])\n",
+    "ax.set_ylabel(\"RMSE\")\n",
+    "ax.set_title(\"RMSE train/test par estimateur\")\n",
+    "ax.legend()\n",
+    "for xi, t, te in zip(x_pos, train_vals, test_vals):\n",
+    "    ax.text(xi - width / 2, t, f\"{t:.2f}\", ha=\"center\", va=\"bottom\", fontsize=8)\n",
+    "    ax.text(xi + width / 2, te, f\"{te:.2f}\", ha=\"center\", va=\"bottom\", fontsize=8)\n",
+    "plt.tight_layout()\n",
+    "plt.show()\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "68896778",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002517,
+     "end_time": "2026-08-16T01:52:20.209494+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.206977+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation\n",
     "\n",
@@ -179,7 +267,16 @@
   {
    "cell_type": "markdown",
    "id": "709ba1ea",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00227,
+     "end_time": "2026-08-16T01:52:20.214138+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.211868+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exemple 2 : Régression non-linéaire — compromis biais-variance\n",
     "\n",
@@ -192,11 +289,19 @@
    "id": "72a20079",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T12:11:00.696489Z",
-     "iopub.status.busy": "2026-07-05T12:11:00.696315Z",
-     "iopub.status.idle": "2026-07-05T12:11:00.705885Z",
-     "shell.execute_reply": "2026-07-05T12:11:00.705236Z"
-    }
+     "iopub.execute_input": "2026-08-16T01:52:20.220071Z",
+     "iopub.status.busy": "2026-08-16T01:52:20.219821Z",
+     "iopub.status.idle": "2026-08-16T01:52:20.231982Z",
+     "shell.execute_reply": "2026-08-16T01:52:20.231145Z"
+    },
+    "papermill": {
+     "duration": 0.01615,
+     "end_time": "2026-08-16T01:52:20.232594+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.216444+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -251,7 +356,16 @@
   {
    "cell_type": "markdown",
    "id": "ed2bce47",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002789,
+     "end_time": "2026-08-16T01:52:20.238350+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.235561+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## AutoML : sélection automatique du meilleur estimateur\n",
     "\n",
@@ -266,11 +380,19 @@
    "id": "1da6fd5a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T12:11:00.707609Z",
-     "iopub.status.busy": "2026-07-05T12:11:00.707436Z",
-     "iopub.status.idle": "2026-07-05T12:11:01.046642Z",
-     "shell.execute_reply": "2026-07-05T12:11:01.045798Z"
-    }
+     "iopub.execute_input": "2026-08-16T01:52:20.245287Z",
+     "iopub.status.busy": "2026-08-16T01:52:20.244922Z",
+     "iopub.status.idle": "2026-08-16T01:52:20.598814Z",
+     "shell.execute_reply": "2026-08-16T01:52:20.598224Z"
+    },
+    "papermill": {
+     "duration": 0.35859,
+     "end_time": "2026-08-16T01:52:20.599633+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.241043+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -322,7 +444,16 @@
   {
    "cell_type": "markdown",
    "id": "6e5b515e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002344,
+     "end_time": "2026-08-16T01:52:20.604967+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.602623+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interprétation\n",
     "\n",
@@ -332,7 +463,16 @@
   {
    "cell_type": "markdown",
    "id": "f8a275af",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002256,
+     "end_time": "2026-08-16T01:52:20.609499+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.607243+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 1 : Comparaison systématique de 4 algorithmes\n",
     "\n",
@@ -347,11 +487,19 @@
    "id": "7866de06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T12:11:01.048864Z",
-     "iopub.status.busy": "2026-07-05T12:11:01.048613Z",
-     "iopub.status.idle": "2026-07-05T12:11:01.052488Z",
-     "shell.execute_reply": "2026-07-05T12:11:01.051794Z"
-    }
+     "iopub.execute_input": "2026-08-16T01:52:20.615293Z",
+     "iopub.status.busy": "2026-08-16T01:52:20.615110Z",
+     "iopub.status.idle": "2026-08-16T01:52:20.618098Z",
+     "shell.execute_reply": "2026-08-16T01:52:20.617516Z"
+    },
+    "papermill": {
+     "duration": 0.006863,
+     "end_time": "2026-08-16T01:52:20.618672+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.611809+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -375,7 +523,16 @@
   {
    "cell_type": "markdown",
    "id": "42729a78",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002204,
+     "end_time": "2026-08-16T01:52:20.623171+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.620967+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 2 : Arrêt précoce et compromis performance / temps\n",
     "\n",
@@ -390,11 +547,19 @@
    "id": "c40ff3c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T12:11:01.054286Z",
-     "iopub.status.busy": "2026-07-05T12:11:01.054118Z",
-     "iopub.status.idle": "2026-07-05T12:11:01.057568Z",
-     "shell.execute_reply": "2026-07-05T12:11:01.056978Z"
-    }
+     "iopub.execute_input": "2026-08-16T01:52:20.628559Z",
+     "iopub.status.busy": "2026-08-16T01:52:20.628415Z",
+     "iopub.status.idle": "2026-08-16T01:52:20.631210Z",
+     "shell.execute_reply": "2026-08-16T01:52:20.630720Z"
+    },
+    "papermill": {
+     "duration": 0.006463,
+     "end_time": "2026-08-16T01:52:20.631879+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.625416+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -418,7 +583,16 @@
   {
    "cell_type": "markdown",
    "id": "e65655a8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002375,
+     "end_time": "2026-08-16T01:52:20.636925+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.634550+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 3 : SDCA vs LightGbm sur données sinusoïdales\n",
     "\n",
@@ -433,11 +607,19 @@
    "id": "5cfe5f01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-05T12:11:01.059333Z",
-     "iopub.status.busy": "2026-07-05T12:11:01.059180Z",
-     "iopub.status.idle": "2026-07-05T12:11:01.061893Z",
-     "shell.execute_reply": "2026-07-05T12:11:01.061439Z"
-    }
+     "iopub.execute_input": "2026-08-16T01:52:20.643011Z",
+     "iopub.status.busy": "2026-08-16T01:52:20.642798Z",
+     "iopub.status.idle": "2026-08-16T01:52:20.646398Z",
+     "shell.execute_reply": "2026-08-16T01:52:20.645775Z"
+    },
+    "papermill": {
+     "duration": 0.007663,
+     "end_time": "2026-08-16T01:52:20.647003+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.639340+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -462,7 +644,16 @@
   {
    "cell_type": "markdown",
    "id": "13ab9b7f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.002414,
+     "end_time": "2026-08-16T01:52:20.652048+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.649634+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Résumé\n",
     "\n",
@@ -491,7 +682,16 @@
   {
    "cell_type": "markdown",
    "id": "d0573b24",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00239,
+     "end_time": "2026-08-16T01:52:20.656826+00:00",
+     "exception": false,
+     "start_time": "2026-08-16T01:52:20.654436+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Références\n",
     "\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -53,6 +53,12 @@
       csharp_sha: ee313290cb2f95f19a3063f5476fd1103cf4818e
       content_python_sha: d10a27601c07d8f9d313cdd8dcbbcf0184cb6833209e5e877737e89b30942ae6
       content_csharp_sha: 5b847c94a8671b87feaea6160682530fdf4b9dddfa7fe69b18ff6b30cece7e3a
+    - date: "2026-08-16"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 98273947fbf527c3d46e44760a5f8ba849433e1a
+      csharp_sha: 58f6ae3832011e841390b35858288e9c51eeb3e5
+      content_python_sha: d10a27601c07d8f9d313cdd8dcbbcf0184cb6833209e5e877737e89b30942ae6
+      content_csharp_sha: 2aace562e3201186743f2e665340546e7c01577ce72ced096207737dbd502399
   known_differences:
     - "2026-08-16 : migration de la derniere cellule Plotly-CDN du depot vers SVG inline cote C# (issue #11104, PR #11173). Le graphique du leaderboard AutoML passe de `Plotly.NET.Interactive` 3.0.2 (sortie HTML dependante d'un CDN, invisible en export statique) a `SvgChartHelper` (canon #6927, SVG inline sans requete reseau) ; `Microsoft.ML.AutoML` recule 0.23.0 -> 0.22.3 pour rester sous le plafond Roslyn 4.12.0.0 du kernel epingle. Le graphique n'est pas supprime, il devient hors-reseau : parite SEMANTIQUE conservee (meme socle pedagogique, memes moteurs, C# re-execute 10/10 cellules / 0 erreur / 48,7 s). Rebaseline content SHA apres re-audit firsthand (myia-ai-01:CoursIA)."
     - "2026-08-16 : asymetrie de visualisation (constatee au re-audit du 2026-08-16, PRE-EXISTANTE a la PR #11173) : le C# rend un graphique du leaderboard (desormais SVG inline) ; le jumeau Python n'en rend AUCUN -- il importe `matplotlib.pyplot as plt` en cellule 2 sans jamais tracer (8/8 cellules executees, 9 sorties toutes de type `stream`, zero `display_data`). L'import est donc mort. Ecart signale, non corrige ici (hors scope de #11104) : suivi par #11174."

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -47,9 +47,16 @@
       csharp_sha: 58f6ae3832011e841390b35858288e9c51eeb3e5
       content_python_sha: 58d05932f373d8570f763fca6d9cdccd997959fd75a2509513c74dbec893cccc
       content_csharp_sha: 2aace562e3201186743f2e665340546e7c01577ce72ced096207737dbd502399
+    - date: "2026-08-16"
+      by: myia-po-2024:CoursIA-2
+      python_sha: 98273947fbf527c3d46e44760a5f8ba849433e1a
+      csharp_sha: ee313290cb2f95f19a3063f5476fd1103cf4818e
+      content_python_sha: d10a27601c07d8f9d313cdd8dcbbcf0184cb6833209e5e877737e89b30942ae6
+      content_csharp_sha: 5b847c94a8671b87feaea6160682530fdf4b9dddfa7fe69b18ff6b30cece7e3a
   known_differences:
     - "2026-08-16 : migration de la derniere cellule Plotly-CDN du depot vers SVG inline cote C# (issue #11104, PR #11173). Le graphique du leaderboard AutoML passe de `Plotly.NET.Interactive` 3.0.2 (sortie HTML dependante d'un CDN, invisible en export statique) a `SvgChartHelper` (canon #6927, SVG inline sans requete reseau) ; `Microsoft.ML.AutoML` recule 0.23.0 -> 0.22.3 pour rester sous le plafond Roslyn 4.12.0.0 du kernel epingle. Le graphique n'est pas supprime, il devient hors-reseau : parite SEMANTIQUE conservee (meme socle pedagogique, memes moteurs, C# re-execute 10/10 cellules / 0 erreur / 48,7 s). Rebaseline content SHA apres re-audit firsthand (myia-ai-01:CoursIA)."
-    - "Asymetrie de visualisation (constatee au re-audit du 2026-08-16, PRE-EXISTANTE a la PR #11173) : le C# rend un graphique du leaderboard (desormais SVG inline) ; le jumeau Python n'en rend AUCUN -- il importe `matplotlib.pyplot as plt` en cellule 2 sans jamais tracer (8/8 cellules executees, 9 sorties toutes de type `stream`, zero `display_data`). L'import est donc mort. Ecart signale, non corrige ici (hors scope de #11104) : suivi par #11174."
+    - "2026-08-16 : asymetrie de visualisation (constatee au re-audit du 2026-08-16, PRE-EXISTANTE a la PR #11173) : le C# rend un graphique du leaderboard (desormais SVG inline) ; le jumeau Python n'en rend AUCUN -- il importe `matplotlib.pyplot as plt` en cellule 2 sans jamais tracer (8/8 cellules executees, 9 sorties toutes de type `stream`, zero `display_data`). L'import est donc mort. Ecart signale, non corrige ici (hors scope de #11104) : suivi par #11174."
+    - "2026-08-16 : asymetrie de visualisation fermee cote Python (issue #11174) — la figure RMSE train/test par estimateur (LinearRegression vs GradientBoosting) est ajoutee en cell[5] (matplotlib inline, sortie image/png embarquee, aucune requete reseau) ; l'import matplotlib.pyplot de cell[2], jusque-la mort, est desormais utilise. Parite semantique conservee : RMSE bit-identiques a main (2.9059/2.9002/39.3519/40.1619), le C# rend deja le leaderboard (SVG inline, #11173)."
     - "2026-08-15 : correction d'auteurs falsifies (issue #11044, tranche W3C SPARQL / ML.NET KDD) — citations remises a leurs auteurs reels (Amizadeh S., DOI KDD, Protocol et al., etc.), markdown-only, aucun changement d'engine/outputs. Parite semantique conservee ; rebaseline content SHA (re-audit 2026-08-15, myia-po-2026:CoursIA-2)."
     - "Socle pedagogique commun : comparaison de trainers de regression (lineaire vs boosting) + evaluation RMSE train/test."
     - "Zoos de modeles distincts : C# = `Regression.Trainers.Sdca` (Stochastic Dual Coord Ascent) + `LightGbm` (binding ML.NET LightGBM natif). Python = `LinearRegression` + `GradientBoostingRegressor, RandomForestRegressor, DecisionTreeRegressor, SVR` (ensemble sklearn)."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11163

## Summary

Ferme l'asymétrie de visualisation constatée au re-audit du 2026-08-16 (PR #11173) : le jumeau Python de ML-3 importe `matplotlib.pyplot as plt` (cell[2]) **sans jamais tracer** — 9 sorties `stream`, zéro `display_data`. L'import était mort.

- **Ajout** : bar chart groupé RMSE train/test (LinearRegression/SDCA vs GradientBoosting/LightGbm) en fin de cell[5] — matplotlib inline, sortie `image/png` embarquée, aucune requête réseau. L'import de cell[2] devient utilisé.
- **Re-exécution** : papermill 20/20 cellules, 0 erreur, séquence CLEAN, H.3 OK. RMSE **bit-identiques à main** (2.9059 / 2.9002 / 39.3519 / 40.1619) — aucun drift de valeurs.
- **Diff vs main** : source = uniquement cell[5] (+viz, +2 cellules `display_data` image/png) ; outputs = uniquement cell[5]. C.3 respecté (une seule cellule de code modifiée).
- **Twin** : rebaseline `check_twin_parity.py --update` post-#11173 (enregistre le csharp_sha SVG-inline `58f6ae38`), `--check` = **OK**, `known_differences` = entrée de fermeture ajoutée. Parité sémantique conservée.

## Acceptance (issue #11174)

- [x] `plt` utilisé (grep cell[5]) → import cell[2] plus mort
- [x] Sortie visualisation présente : `display_data` `image/png` en cell[5]
- [x] exec_count non-null 8/8 cellules code
- [x] Rebaseline twin + `known_differences` à jour, `--check` OK

## Test plan

- Papermill `20/20` cellules, 0 erreur (log ci-dessus)
- `grep -nE "raise NotImplementedError|assert False|1/0"` = 0
- `check_twin_parity.py --check --pair "ML-3 Entrainement&AutoML"` → `[OK]`

Closes #11174
