### PR TITLE
fix(genai,#11168): audit citations arXiv famille GenAI — RAGAS et Qwen2.5-VL re-attribuées (42 IDs vérifiés)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-1-OpenAI-DALL-E-3.ipynb
@@ -1306,7 +1306,7 @@
     "\n",
     "- **OpenAI** (2023). *DALL-E 3 System Card*. — Documente la reecriture automatique des prompts via GPT-4 et l'entrainement sur captions ameliorees (recaptioning), caractéristiques centrales du modèle enseignees dans ce notebook.\n",
     "- **Ramesh, A. et al.** (2022). *Hierarchical Text-Conditional Image Generation with CLIP Latents* (DALL-E 2). arXiv:2204.06125. — Filiation architecturale : CLIP latents + processus de diffusion, socle sur lequel DALL-E 3 s'appuie.\n",
-    "- **OpenAI** (2021). *DALL-E: Creating Images from Text* (DALL-E 1, Ramesh et al.). arXiv:2102.12092. — Precurseur : auto-regressive transformer dVAE, origine de la lignee DALL-E.\n"
+    "- **Ramesh, A., Pavlov, M., Goh, G., et al.** (2021). *Zero-Shot Text-to-Image Generation* (DALL-E 1). arXiv:2102.12092. — Precurseur : auto-regressive transformer dVAE, origine de la lignee DALL-E.\n"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-4-Forge-SD-XL-Turbo.ipynb
@@ -1785,7 +1785,7 @@
     "\n",
     "Les concepts fondateurs enseignés dans ce notebook (diffusion latente, distillation, guidance sans classifieur) reposent sur :\n",
     "\n",
-    "- Rombach, K., Blattmann, A., Lorenz, D., Esser, P., & Ommer, B. (2022). *High-Resolution Image Synthesis with Latent Diffusion Models* (CVPR 2022). Stable Diffusion = modèle de diffusion appliqué dans un espace latent compressé. arXiv:2112.10752.\n",
+    "- Rombach, R., Blattmann, A., Lorenz, D., Esser, P., & Ommer, B. (2022). *High-Resolution Image Synthesis with Latent Diffusion Models* (CVPR 2022). Stable Diffusion = modèle de diffusion appliqué dans un espace latent compressé. arXiv:2112.10752.\n",
     "- Podell, D., English, Z., Lacey, K., et al. (2023). *SDXL: Improving Latent Diffusion Models for High-Resolution Image Synthesis*. Base dont SDXL Turbo est distillée. arXiv:2307.01952.\n",
     "- Sauer, A., Lorenz, D., Blattmann, A., & Rombach, R. (2023). *Adversarial Diffusion Distillation* (Stability AI). Méthode de distillation permettant la génération en 1-4 étapes (SDXL Turbo). arXiv:2311.17042.\n",
     "- Ho, J., & Salimans, T. (2022). *Classifier-Free Diffusion Guidance*. Mécanisme du paramètre  (guidance sans classifieur). arXiv:2207.12598.\n",

--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-5-Qwen-Image-Edit.ipynb
@@ -89,7 +89,7 @@
     "```\n",
     "\n",
     "**Temps estimé**: 90-120 minutes\n",
-    "**Ancrage savant.** Qwen-Image-Edit est l'un des modèles d'edition d'image de la famille Qwen-Image, dont l'architecture (VAE 16 canaux, CFG = 1.0 gere via CFGNorm, scheduler *beta*, ModelSamplingAuraFlow) est detaillee dans le **Qwen-Image Technical Report** [QwenLM, aout 2025, arXiv:2508.02324]. Le modèle repose sur la base vision-langage Qwen2.5-VL [Wang et al. 2025, arXiv:2502.13923].\n"
+    "**Ancrage savant.** Qwen-Image-Edit est l'un des modèles d'edition d'image de la famille Qwen-Image, dont l'architecture (VAE 16 canaux, CFG = 1.0 gere via CFGNorm, scheduler *beta*, ModelSamplingAuraFlow) est detaillee dans le **Qwen-Image Technical Report** [QwenLM, aout 2025, arXiv:2508.02324]. Le modèle repose sur la base vision-langage Qwen2.5-VL [Bai et al. 2025, arXiv:2502.13923].\n"
    ]
   },
   {
@@ -2489,7 +2489,7 @@
     "### 📖 References savantes (architecture du modèle)\n",
     "\n",
     "- **QwenLM** (2025). *Qwen-Image Technical Report*. arXiv:2508.02324. — Rapport technique officiel de Qwen-Image / Qwen-Image-Edit : architecture (VAE 16 canaux, CFGNorm, scheduler *beta*, ModelSamplingAuraFlow), rendu de texte complexe et edition d'image precise.\n",
-    "- **Wang, P. et al.** (2025). *Qwen2.5-VL Technical Report*. arXiv:2502.13923. — Base vision-langage sur laquelle s'appuie la famille Qwen-Image.\n",
+    "- **Bai, S. et al.** (2025). *Qwen2.5-VL Technical Report*. arXiv:2502.13923. — Base vision-langage sur laquelle s'appuie la famille Qwen-Image.\n",
     "- **Bai, J. et al.** (2023). *Qwen-VL: A Versatile Vision-Language Model*. arXiv:2308.12966. — Precurseur VLM de la lignee Qwen-Vision.\n",
     "\n"
    ]

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb
@@ -2310,13 +2310,13 @@
     "\n",
     "- [Documentation ComfyUI](https://docs.comfy.org/)\n",
     "- [Qwen-VL — VLM original 2023 (Bai et al., arXiv:2308.12966)](https://arxiv.org/abs/2308.12966) — le vision-language model fondateur de la série Qwen (ne pas confondre avec Qwen-Image-Edit 2025).\n",
-    "- [Qwen2.5-VL Technical Report (Wang et al. 2025, arXiv:2502.13923)](https://arxiv.org/abs/2502.13923) — **papier pertinent pour Qwen-Image-Edit** (VLM sous-jacent).\n",
+    "- [Qwen2.5-VL Technical Report (Bai et al. 2025, arXiv:2502.13923)](https://arxiv.org/abs/2502.13923) — **papier pertinent pour Qwen-Image-Edit** (VLM sous-jacent).\n",
     "- [Modèles Comfy-Org](https://huggingface.co/Comfy-Org/Qwen-Image-Edit_ComfyUI)\n",
     "- Notebook suivant: **02-2-FLUX-1-Advanced-Generation**\n",
     "\n",
     "### Références savantes\n",
     "\n",
-    "- **Wang, Z., et al.** (2025). *Qwen2.5-VL Technical Report*. arXiv:2502.13923. — Vision-language model sous-jacent à Qwen-Image-Edit (encodeur de texte `qwen_2.5_vl_7b`).\n",
+    "- **Bai, S., et al.** (2025). *Qwen2.5-VL Technical Report*. arXiv:2502.13923. — Vision-language model sous-jacent à Qwen-Image-Edit (encodeur de texte `qwen_2.5_vl_7b`).\n",
     "- **Bai, J., Bai, S., Yang, S., et al.** (2023). *Qwen-VL: A Versatile Vision-Language Model*. arXiv:2308.12966. — VLM fondateur de la série Qwen (précédent Qwen2-VL puis Qwen2.5-VL).\n",
     "- **Esser, P., Kulal, S., Blattmann, A., et al.** (2024). *Scaling Rectified Flow Transformers for High-Resolution Image Synthesis* (MMDiT). arXiv:2403.03206. — Architecture Flow/DiT dont s'inspirent les modèles Qwen-Image (node `ModelSamplingAuraFlow`).\n"
    ]

--- a/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/5_RAG_Modern.ipynb
@@ -3066,7 +3066,7 @@
     "- **Lewis, P. et al. (2020)** - *Retrieval-Augmented Generation for Knowledge-Intensive NLP Tasks*. arXiv:2005.11401. (RAG originel, nomme et définit le paradigme.)\n",
     "- **Karpukhin, V. et al. (2020)** - *Dense Passage Retrieval for Open-Domain Question Answering*. arXiv:2004.04906. (Retriever dense bi-encoder.)\n",
     "- **Reimers, N. & Gurevych, I. (2019)** - *Sentence-BERT: Sentence Embeddings using Siamese BERT-Networks*. arXiv:1908.10084. (Embeddings de phrases.)\n",
-    "- **Gao, Y. et al. (2023)** - *RAGAS: Automated Assessment of Retrieval Augmented Generation*. arXiv:2309.15217. (Évaluation RAG : faithfulness, context precision.)\n",
+    "- **Es, S., James, J., Espinosa-Anke, L., & Schockaert, S. (2023)** - *RAGAS: Automated Evaluation of Retrieval Augmented Generation*. arXiv:2309.15217. (Évaluation RAG : faithfulness, context precision.)\n",
     "\n",
     "**Documentation API :**\n",
     "- [OpenAI Embeddings Guide](https://platform.openai.com/docs/guides/embeddings)\n",


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA — prev: DEEP/genai 11180

# Grain famille GenAI — audit citations arXiv (See #11168)

42 IDs arXiv distincts / 82 occurrences / 18 notebooks, mesurés sur `origin/main` courant (le « 53 » de l'issue date d'un snapshot antérieur ; rescan bare-ID + formes URL : 0 supplémentaire).

## Méthode

- Extraction des IDs en **cellules markdown uniquement** (hors `_archives/`, `.ipynb_checkpoints`).
- **Une seule requête groupée** `?id_list=` (42 IDs = 1 appel, cf note opérationnelle ai-01 sur le 429), `User-Agent` identifiant, appariement **par ID** (pas par ordre).
- 42/42 entrées retournées → **0 ID-FANTÔME**.

## Verdicts

| Verdict | IDs | Détail |
| ------- | --- | ------ |
| OK | 38 | titre + auteurs + année concordants (années à la convention année-publication — T5 2020/JMLR, DiT 2023/ICCV, Flow Matching 2023/ICLR — validées) |
| MAUVAISE-ATTRIBUTION | 2 | RAGAS « Gao, Y. et al. » ; Qwen2.5-VL « Wang » (×4 occurrences) |
| DRIFT-MINEUR | 2 | titre DALL-E 1 (titre de blog au lieu du papier) ; initiale « Rombach, K. » → R. |
| ID-FANTÔME | 0 | — |

## Corrections (7 lignes, markdown seul)

1. `Texte/5_RAG_Modern.ipynb` c61 — RAGAS attribué à « **Gao, Y. et al.** » → vrais auteurs **Es, S., James, J., Espinosa-Anke, L., & Schockaert, S. (2023)** ; titre « Automated Assessment » → « Automated **Evaluation** » (arXiv:2309.15217).
2. `01-5-Qwen-Image-Edit` c1 + c28 — Qwen2.5-VL Technical Report attribué à « Wang et al. » / « Wang, P. et al. » → premier auteur réel **Bai, S. et al.** (arXiv:2502.13923 ; confusion probable avec Qwen2-VL = Peng Wang, arXiv:2409.12191).
3. `02-1-Qwen-Image-Edit-2509` c33 — même correction ×2 (« Wang et al. » lien + « Wang, Z., et al. » entrée) → **Bai, S. et al.**
4. `01-1-OpenAI-DALL-E-3` c22 — le titre cité « DALL-E: Creating Images from Text » est celui du **blog** OpenAI ; le papier arXiv:2102.12092 est « **Zero-Shot Text-to-Image Generation** », auteurs **Ramesh, A., et al.** (l'attribution d'auteur était déjà correcte).
5. `01-4-Forge-SD-XL-Turbo` c26 — « Rombach, **K.** » → « Rombach, **R.** » (Robin Rombach, arXiv:2112.10752).

## Liste des 38 OK (compte par notebook, pour ne pas re-vérifier)

01-2-FLUX (1312.6114, 1910.10683, 2103.00020, 2104.09864, 2210.02747, 2212.09748, 2403.03206) · 02-3-SD3.5 (1910.10683, 2103.00020, 2210.02747, 2403.03206) · 02-4-Lumina (1312.6114, 2405.05945, 2406.18583) · 01-1-DALL-E (2204.06125) · 01-4-Forge (2207.12598, 2307.01952, 2311.17042, 2112.10752*) · 01-5-Qwen (2308.12966, 2508.02324) · 02-1-Qwen (2308.12966, 2403.03206) · 1_OpenAI (1706.03762) · 2_Prompt (2005.14165, 2201.11903×3, 2303.17651) · 5_RAG (1908.10084, 2004.04906, 2005.11401) · 6_PDF (2005.11401, 2204.14198) · 7_Code (2302.04761) · 8_Reasoning (2201.11903, 2203.11171, 2408.03314) · 10_LocalLlama (2309.06180) · 11_Quant (2210.17323, 2306.00978) · 13_Agentic (2203.11171, 2210.03629, 2303.11366, 2305.10601, 2408.03314) · 15_ToT (2201.11903, 2203.11171, 2305.10601) · 17_Reasoning (2107.03374, 2305.20050, 2408.03314) · FT-04 (2305.18290) · PT_03 (2305.18290) · FT-05 (2212.04089, 2306.01708, 2311.03099)

(*2112.10752 : ID et papier OK, seule l'initiale du prénom était fausse — corrigée, comptée en DRIFT-MINEUR.)

## Validation

- Éditions markdown uniquement → outputs précédents valides (exception C.2), pas de re-exécution requise.
- `git diff` : 7 insertions / 7 délétions, aucune autre ligne touchée.
- JSON valide sur les 5 notebooks après édition.
