### PR TITLE
fix(quantconnect,#11168): arXiv citation audit QC family — LRA wrong ID + DT title

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/research_l4_decision_transformer.ipynb
@@ -638,7 +638,7 @@
     "\n",
     "**References :**\n",
     "- Chen et al. (2021), \"Decision Transformer: Reinforcement Learning via Sequence Modeling\"\n",
-    "- arXiv:2411.17900, \"Decision Transformer for Algorithmic Trading\""
+    "- arXiv:2411.17900, \"Pretrained LLM Adapted with LoRA as a Decision Transformer for Offline RL in Quantitative Trading\""
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-23-Attention-Transformers.ipynb
@@ -642,7 +642,7 @@
     "\n",
     "**Résultat** : Premier SSM compétitif avec les Transformers sur Long Range Arena.\n",
     "\n",
-    "> *Ancre savante -- Tay, Dehghani, Abnar et al. (2021), « Long Range Arena: A Benchmark for Efficient Transformers », ICLR 2021 (arXiv:2011.04016) -- benchmark de référence comparant Transformers efficaces et SSM sur longues séquences.*\n",
+    "> *Ancre savante -- Tay, Dehghani, Abnar et al. (2021), « Long Range Arena: A Benchmark for Efficient Transformers », ICLR 2021 (arXiv:2011.04006) -- benchmark de référence comparant Transformers efficaces et SSM sur longues séquences.*\n",
     "\n",
     "> *Ancre savante -- Gu, A., Goel, K. & Re, C. (2022), Efficiently Modeling Long Sequences with Structured State Spaces, ICLR 2022 (arXiv:2111.00396). (Papier S4 : representation NPLR + noyau de Cauchy via FFT, premier SSM competitif avec les Transformers sur les benchmarks Long Range Arena ; fonde l'initialisation HiPPO comme condition de stabilite.) Suite directe de HiPPO (Gu, Dao, Ermon, Rudra & Re 2020, arXiv:2008.07669).*\n"
    ]


### PR DESCRIPTION
Grain: MED/quantconnect — lane myia-po-2023:CoursIA — prev: MED/genai 11181

# Grain famille QuantConnect — audit citations arXiv (See #11168)

31 IDs arXiv distincts / 76 occurrences / 16 notebooks, mesurés sur `origin/main` courant (extraction cellules markdown uniquement, `MyIA.AI.Notebooks/QuantConnect/**`).

## Méthode

- Extraction des IDs en cellules markdown uniquement (hors `_archives/`, `.ipynb_checkpoints`).
- **Une seule requête groupée** `?id_list=` (31 IDs = 1 appel, etiquette ai-01 429), `User-Agent` identifiant, appariement par ID.
- 31/31 entrées retournées → **0 ID-FANTÔME**. Vérification complémentaire solo de l'ID correct Long Range Arena (2011.04006) avant correction.

## Verdicts

| Verdict | IDs | Détail |
| ------- | --- | ------ |
| OK | 29 | titre + auteurs + année concordants (convention année-publication — Bahdanau ICLR 2015, Double DQN AAAI 2016, Dueling ICML 2016, SGDR/AdamW/Performers ICLR, S4 ICLR 2022, DLinear AAAI 2023, PatchTST/iTransformer/TimeMixer ICLR 2023/24 — toutes validées) |
| ID-ERRONÉ | 1 | `2011.04016` pointe vers « Provenance-Based Interpretation of Multi-Agent Information Analysis » (Friedman et al.) alors que la prose cite « Long Range Arena: A Benchmark for Efficient Transformers » (Tay, Dehghani, Abnar et al., ICLR 2021) — vrai ID = **2011.04006**, confirmé par l'API (l'attribution d'auteurs était déjà correcte) |
| DRIFT-MINEUR | 1 | `2411.17900` : titre raccourci entre guillemets « Decision Transformer for Algorithmic Trading » au lieu du vrai titre « Pretrained LLM Adapted with LoRA as a Decision Transformer for Offline RL in Quantitative Trading » (Yun, S., 2024) |
| ID-FANTÔME | 0 | — |

## Corrections (2 lignes, markdown seul)

1. `Python/QC-Py-23-Attention-Transformers.ipynb` c11 — ancre savante Long Range Arena : `arXiv:2011.04016` → `arXiv:2011.04006` (faute de frappe de chiffre : le papier 2011.04016 est un papier *provenance* sans rapport).
2. `ML-Training-Pipeline/research_l4_decision_transformer.ipynb` c12 — titre entre guillemets remplacé par le vrai titre du papier.

## Liste des 29 OK (compte par notebook, pour ne pas re-vérifier)

QC-Py-17 (1908.10063) · QC-Py-19 (1603.02754) · QC-Py-20 (1603.02754) · QC-Py-22 (1706.03762, 2205.13504, 2211.14730, 2310.06625, 2405.14616) · QC-Py-23 (1706.03762, 2004.05150, 2008.07669, 2009.14794, 2111.00396, 2312.00752) · QC-Py-23b (1706.03762, 2211.14730, 2310.06625) · QC-Py-24 (1312.6114, 1706.03762) · QC-Py-25 (1707.06347) · QC-Py-26 (1706.03762, 2005.14165, 2201.11903) · QC-Py-30 (1211.5063, 1409.0473, 1608.03983, 1711.05101) · QC-Py-31 (1211.5063, 1606.08415, 1608.03983, 1711.05101, 1706.03762) · QC-Py-32 (1509.06461, 1511.06581, 1602.01783) · QC-Py-33 (1502.05477, 1506.02438, 1707.06347) · QC-Py-34 (1602.01783, 1801.01290, 1812.05905) · research_what_dl_can_predict (2603.15506) · research_l4 (2411.17900*)

(*2411.17900 : ID et papier OK, seul le titre raccourci était fautif — corrigé, compté en DRIFT-MINEUR.)

## Validation

- Éditions markdown uniquement → outputs précédents valides (exception C.2), pas de re-exécution requise.
- `git diff` : 2 insertions / 2 délétions, aucune autre ligne touchée.
- JSON valide sur les 2 notebooks après édition.
