### PR TITLE
docs(harness,#11182): un seul instrument pour compter les sorry (count_code_sorry.py)

### DIFF
--- a/.claude/rules/anti-regression.md
+++ b/.claude/rules/anti-regression.md
@@ -12,7 +12,7 @@ Commits "fix compilation" / "Mathlib fix" / "lint fix" / "simplify" avec **delet
 
 ## Red-flag rapides
 
-- **Lean/Coq/Agda** : `theorem foo := by <tactics>` → `:= by sorry` = régression. `grep -c sorry` qui monte sans justification = PR contestée.
+- **Lean/Coq/Agda** : `theorem foo := by <tactics>` → `:= by sorry` = régression. Un compte de `sorry` **réel** qui monte sans justification = PR contestée — mesuré avec `python scripts/lean/count_code_sorry.py --json` (champ `distinct_code_sorry`), **jamais** `grep -c sorry`. Détail de l'instrument ci-dessous.
 - **Python production** : corps calculé → `pass` (fonction encore appelée) ; `@pytest.skip` sans issue référencée ; `return None` à la place du calcul.
 - **Notebooks pédagogiques** : `raise NotImplementedError` → `pass`/`print`/`return None` = **conforme** (règle user 2026-04-26). Mais cellule `# Solution` / `# Exemple résolu` supprimée = **régression de contenu INTERDITE**.
 
@@ -29,9 +29,26 @@ Si tu veux supprimer du code/preuve, **réponses écrites dans le commit** :
 
 Une seule question sans réponse écrite : ne pas commiter, demander au user/coordinateur.
 
+## Compter les `sorry` — un seul instrument, et deux façons de se tromper
+
+```bash
+python scripts/lean/count_code_sorry.py --json   # champ distinct_code_sorry
+```
+
+Les deux instruments artisanaux échouent, mais **pas de la même façon** — et c'est le second qui est dangereux :
+
+| Instrument | Défaut | Se voit ? |
+|---|---|---|
+| `grep -c sorry` | **sur-compte** la prose (docstrings, `-- commentaires`, feuilles de route) — 484 naïfs pour 21 réels sur les 21 lakes, mesuré le 2026-08-14 | **oui** : la prose saute aux yeux dès qu'on ouvre le fichier |
+| jeu de motifs « code-only » écrit à la main (`:= by sorry`, `^\s*sorry$`, `<;> sorry`) | **sous-compte** : ignore `exact sorry` et `def … := sorry` — rend **2** là où le lake en porte **16** (`knot_lean`, mesuré le 2026-08-16) | **non** : un motif absent ne lève pas d'erreur, il rend un chiffre plus petit et plus propre |
+
+Le second a fait qualifier de « résidu » pendant onze jours le lake portant 80 % de la dette formelle du dépôt. Un motif de détection se valide **par ses faux négatifs** — écrire les formes qu'il doit attraper, vérifier qu'il les attrape — pas par ses hits.
+
+Les paires FR/EN (convention i18n #4980) doublent le compte brut : `distinct_code_sorry` dédoublonne, `code_sorry` non. Un fix se porte **sur les deux siblings**.
+
 ## Audit pré-merge
 
-Commandes `git diff` + `grep -c sorry` avant/après + workflow rogue commits : [docs/anti-regression-detail.md](../../docs/reference/anti-regression-detail.md#détection-après-coup-audit-rogue-commits).
+Commandes `git diff` + comptage avant/après (ci-dessus) + workflow rogue commits : [docs/anti-regression-detail.md](../../docs/reference/anti-regression-detail.md#détection-après-coup-audit-rogue-commits).
 
 ## Incident référence
 

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -43,7 +43,7 @@ EPIC **#4980** — convention ratifiée par user 2026-07-04 (Option A, deux comm
 
 ## Anti-régression (code de production)
 
-S'applique au **code de production** (preuves Lean/Coq/Agda, fonctions métier appelées, tests, librairies), **PAS** aux cellules d'exercice de notebooks. Règle HARD + protocole 4 étapes + red-flags : [anti-regression.md](anti-regression.md). En bref : ne jamais remplacer une preuve/implémentation existante par `sorry`/stub vide sous prétexte de "fix compilation" ; `grep -c sorry` avant/après ; deletions > insertions sur code métier = red flag.
+S'applique au **code de production** (preuves Lean/Coq/Agda, fonctions métier appelées, tests, librairies), **PAS** aux cellules d'exercice de notebooks. Règle HARD + protocole 4 étapes + red-flags : [anti-regression.md](anti-regression.md). En bref : ne jamais remplacer une preuve/implémentation existante par `sorry`/stub vide sous prétexte de "fix compilation" ; compte de `sorry` réel avant/après via `count_code_sorry.py --json` (**jamais** `grep -c sorry`, qui compte la prose) ; deletions > insertions sur code métier = red flag.
 
 ## Notebooks : stubs d'exercice sans erreur volontaire (C.1)
 

--- a/.claude/rules/lean-merge-discipline.md
+++ b/.claude/rules/lean-merge-discipline.md
@@ -40,5 +40,5 @@ Commandes (grep de scope, heredoc WSL), pattern de preuve `pullback_union` + not
 
 ## Voir aussi
 
-- [anti-regression.md](anti-regression.md) — `grep -c sorry` avant/apres, pas de regression preuves
+- [anti-regression.md](anti-regression.md) — comptage `sorry` reel avant/apres (`count_code_sorry.py`) + les deux facons de se tromper d'instrument, pas de regression preuves
 - [pr-review-discipline.md](pr-review-discipline.md) — Section B (4 elements Lean PR body)

--- a/docs/lean/coordinator-workflow.md
+++ b/docs/lean/coordinator-workflow.md
@@ -55,7 +55,7 @@ Si le build echoue alors que la junction est intacte et `.lake/build/lib/lean/Ma
 - Ne pas merger seul
 - Dispatcher po-2026 avec criteres :
   1. Build log complet colle (pas extrait)
-  2. `grep -c sorry` avant/apres par fichier
+  2. Compte de `sorry` **reel** avant/apres par fichier — `python scripts/lean/count_code_sorry.py --json`, champ `distinct_code_sorry`. **Jamais `grep -c sorry`** (sur-compte la prose), **ni un jeu de motifs artisanal** type `:= by sorry` / `^\s*sorry$` (sous-compte : rate `exact sorry` et `def … := sorry`, cf [anti-regression.md](../../.claude/rules/anti-regression.md))
   3. Diff sur defs partagees (signatures, instances)
 
 ### Discipline temporelle

--- a/docs/lean/prover_iteration_history.md
+++ b/docs/lean/prover_iteration_history.md
@@ -50,7 +50,7 @@
 | 2026-05-15 16:47 | hK_empty (Basic L280) | autonomous | ~3 | PROVED sorry 2→1 |
 | 2026-05-15 | hCore (Basic L308) | autonomous | 10 | INTRACTABLE (5.9h) |
 
-**Key finding:** Multi-agent prover silently succeeds (writes proofs to disk but hangs on output). Always check `grep -c sorry` after "stuck" runs.
+**Key finding:** Multi-agent prover silently succeeds (writes proofs to disk but hangs on output). Always re-count `sorry` after "stuck" runs — `python scripts/lean/count_code_sorry.py --json` (`distinct_code_sorry`), not `grep -c sorry`.
 
 ### Phase 4: GS Lemmas Manual Breakthrough (May 16)
 

--- a/docs/reference/regles-vigilance-detail.md
+++ b/docs/reference/regles-vigilance-detail.md
@@ -23,7 +23,7 @@ Avant de relayer un diagnostic technique d'un autre agent dans un dispatch ou un
 `sorry count = 0` n'a aucune valeur sans `lake build SUCCESS` post-modification. Un theoreme supprime, un identifiant inexistant injecte, une preuve qui ne compile pas = sorry count peut etre 0 ET le port casse.
 
 **Pour Lean / Coq / Agda, trois preuves obligatoires dans le body PR** :
-1. `grep -c sorry` avant/après
+1. Compte de `sorry` **réel** avant/après — `python scripts/lean/count_code_sorry.py --json`, champ `distinct_code_sorry` (ni `grep -c sorry`, qui sur-compte la prose ; ni un jeu de motifs artisanal, qui sous-compte **sans le dire**)
 2. `lake build` SUCCESS log (lien CI ou commit local prouvable)
 3. Proof integrity check SUCCESS (axiom check)
 


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: DEEP/qc #11176

## Le defaut

Quatre regles **auto-chargees a chaque session** se contredisaient sur l'instrument de comptage des `sorry` :

| Fichier | Avant ce PR |
|---|---|
| `pr-review-discipline.md` §B.1 | « **Pas `grep -c sorry`** […] 484 naifs pour 21 reels sur les 21 lakes » |
| `lean-merge-discipline.md` L11 | « **jamais `grep -c sorry`**, qui sur-compte la prose d'un facteur 23 » |
| `anti-regression.md` L15, L34 | « **`grep -c sorry` qui monte** = PR contestee » · « Commandes `git diff` + **`grep -c sorry`** » |
| `code-style.md` L46 | « **`grep -c sorry`** avant/apres » |

Le harnais ne disait pas quoi faire : il disait deux choses. Un agent appliquant `anti-regression.md` a la lettre sur `grothendieck_lean` reclame la justification de **68 `sorry` inexistants** (0 reel dans ce lake) ; un agent appliquant §B.1 mesure juste.

## Ce que le PR ajoute, et pourquoi ce n'est pas qu'un alignement

Aligner les deux retardataires etait le minimum. Le PR documente en plus le mode d'echec **que personne n'avait ecrit**, parce que c'est celui qui ne se voit pas :

| Instrument | Defaut | Se voit ? |
|---|---|---|
| `grep -c sorry` | **sur-compte** la prose — 484 pour 21 | **oui**, la prose saute aux yeux |
| jeu de motifs artisanal « code-only » (`:= by sorry`, `^\s*sorry$`, `<;> sorry`) | **sous-compte** : ignore `exact sorry` et `def … := sorry` | **non** — un motif absent ne leve pas d'erreur, il rend un chiffre plus petit et plus propre |

Mesure firsthand du 2026-08-16 qui motive l'ajout : ce jeu de motifs rend **2** la ou `count_code_sorry.py` compte **16** sur `knot_lean` — il attrapait les deux `sorry` nus de `Invariant.lean` et manquait les 12 `exact sorry` + 4 `def … := sorry`. Verifie **a l'arbre du 2026-08-05** (`git show 747be9174:`) : les 16 y etaient **deja**. Le stock n'avait pas bouge ; le compteur ne les voyait pas.

Ce « 2 » a qualifie de **residu** pendant onze jours le lake qui porte **80 % de la dette formelle du depot** — `knot_lean` 16 sur 20 distincts fleet-wide, quand `conway_lean` est retombe a 1 (la noix hashlife est tombee, cette partie-la du diagnostic etait juste). C'est le cout reel du defaut, et il n'est pas theorique.

## Ce que le PR ne fait pas

**Pas un retrait sec.** La regle du harnais global dit de supprimer d'abord et de ne remplacer que si le retrait laisse un trou reel — ici il en laisse un : ces deux fichiers doivent bien nommer *un* instrument, sinon la consigne « compte de sorry avant/apres » devient inapplicable. C'est donc un **remplacement**, pas un garde-fou empile.

**Pas de nouveau gate CI.** L'organe existe deja (`scripts/lean/count_code_sorry.py`, `sorry-filter-mode: real` de `lean-axiom.yml`) ; le defaut etait dans le texte qui le contredisait, pas dans l'outillage.

Les mentions **descriptives** de `grep -c sorry` — celles qui avertissent contre lui — sont conservees partout : c'est leur prescription comme instrument qui disparait.

## Extension aux docs perennes (commit 2)

Le premier commit ne visait que `.claude/rules/`. Un grep hors-memoire a montre que la prescription cassee survivait dans **trois docs perennes que le harnais reference** — corriger les rules en les laissant aurait reproduit le defaut d'origine (un harnais qui dit deux choses) :

| Fichier | Ligne | Qui la lit |
|---|---|---|
| `docs/reference/regles-vigilance-detail.md` | L26 | **les reviewers** — G.2, « trois preuves obligatoires dans le body PR », point 1 |
| `docs/lean/coordinator-workflow.md` | L58 | **les workers Lean** — criteres de dispatch po-2026 quand ai-01 n'a pas d'env Lean local |
| `docs/lean/prover_iteration_history.md` | L53 | « Always check after stuck runs » — l'entree est datee, la **consigne** ne l'est pas |

`docs/archive/ledgers-reviews/*` est **volontairement non touche** : ce sont des releves dates, pas des consignes. L'un d'eux — `2026-07-11-h4-sweep-5998.md` L79 — documente le motif sous-comptant (`^[[:space:]]*(sorry\|by sorry\|.+ sorry$)`) sous le mot **« canonical »**. C'est la **provenance** du defaut corrige ici ; la reecrire effacerait la trace de son origine.

## Test plan

- `grep -rn 'grep -c sorry' .claude/rules/ docs/ --include='*.md'` hors `docs/archive/` → il ne reste que des mentions **descriptives** (avertissements), zero prescription (9 occurrences, toutes de la forme « jamais / pas / not `grep -c sorry` »).
- Le renvoi « Voir aussi » de `lean-merge-discipline.md` L43, qui decrivait `anti-regression.md` comme prescrivant `grep -c`, est corrige — sinon le pointeur aurait survecu a la correction de sa cible.
- Docs seules, aucun code touche.

Closes #11182
