### PR TITLE
feat(ict,#5726): ict/life.py — GOL substrate B3/S23 + canonical calibration (phase-zero 1-2)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ict/life.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ict/life.py
@@ -1,0 +1,239 @@
+"""Substrat Jeu de la Vie (Conway) — trajectoires calibrees sur patterns canoniques.
+
+Outille la phase-zero « Life as certified calibration substrate » de la serie
+ICT (issue #5726, Epic #4588). Le substrat est le **Jeu de la Vie** de Conway
+(M. Gardner, *Mathematical Games*, Scientific American 1970 ; E. R. Berlekamp,
+J. H. Conway & R. K. Guy, *Winning Ways for Your Mathematical Plays*, 1982),
+regle **B3/S23** sur grille 2-D a bords periodiques :
+
+* une cellule morte ayant exactement 3 voisines vivantes naît (B3) ;
+* une cellule vivante ayant 2 ou 3 voisines vivantes survit (S23) ;
+* toute autre cellule meurt (sous-population ou etouffement).
+
+Le role de ce substrat dans la batterie ICT (cf. :mod:`ict.agency`,
+:mod:`ict.stake`, :mod:`ict.causal_emergence`) : contrairement au tri (1-D) ou
+au bistable (0-D), le Jeu de la Vie offre une **morphodynamique 2-D avec
+propagation d'information localisee** — les gliders y jouent le role de
+« particules » transportant une information sur de grands horizons temporels,
+ce qui en fait un banc discriminant pour l'emergence causale multi-echelle.
+
+**Pont preuve <-> mesure** : le calcul de trajectoire implemente ici (simulation
+naive pas-a-pas, toroidale) est l'exact pendant Python de la branche « naive »
+du theoreme ``hashlife_correct`` formalise en Lean dans la track ``conway_lean``
+(``MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean``).
+Ce theoreme — desormais **prouve sans sorry** sur ``main`` (chaine P4
+``p4_succ_membership`` + pont de localite BR1-BR3 + BR4a ``one_jump_toGrid_correct``
+(PR #10919) + ``p5_large_n_jumpN`` decharge par induction sur le fuel et
+re-signature trajectoire b3' (PR #11007), ``hashlife_correctN`` re-signee) —
+garantit que l'evaluation **Hashlife** (quadtree memoise, sauts temporels
+``2^k``) calcule la *meme chose* que la simulation naive pas-a-pas. Les longues
+trajectoires exportees depuis ce module heritent donc d'une garantie de
+correction : l'acceleration Hashlife, si on l'employait, ne changerait rien au
+film produit (c'est precisement ce que dit le theoreme), et la calibration
+ci-dessous verifie que la dynamique Python respecte les constantes canoniques
+des patterns (periodes et deplacements).
+
+Numpy uniquement (voisinage vectorise via ``numpy.roll``, bords periodiques),
+comme le reste du package leger ``ict``.
+
+Reference : ICT-0 (cadrage de la serie), issue #5726, tracker Lean #6724.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+# --------------------------------------------------------------- dynamique B3/S23
+def next_generation(grid: np.ndarray) -> np.ndarray:
+    """Un pas de la regle B3/S23 sur grille toroidale (vectorise via ``roll``).
+
+    Voisinage de Moore 8 points, bords periodiques : chaque cellule voit le
+    cote oppose de la grille. Retourne une nouvelle grille 0/1 (uint8).
+    """
+    g = (np.asarray(grid) != 0).astype(np.uint8)
+    neighbors = np.zeros_like(g, dtype=np.int16)
+    for dr in (-1, 0, 1):
+        for dc in (-1, 0, 1):
+            if (dr, dc) == (0, 0):
+                continue
+            neighbors += np.roll(np.roll(g, dr, axis=0), dc, axis=1)
+    birth = (g == 0) & (neighbors == 3)
+    survive = (g == 1) & ((neighbors == 2) | (neighbors == 3))
+    return (birth | survive).astype(np.uint8)
+
+
+def trajectory(grid: np.ndarray, steps: int) -> List[np.ndarray]:
+    """Film causal : la suite des ``steps`` grilles succesives (incluant t=0).
+
+    Chaque element est une grille 0/1 ; ``traj[0]`` est la condition initiale
+    fournie, ``traj[t]`` l'etat apres ``t`` generations.
+    """
+    g = (np.asarray(grid) != 0).astype(np.uint8)
+    film = [g.copy()]
+    for _ in range(int(steps)):
+        g = next_generation(g)
+        film.append(g.copy())
+    return film
+
+
+def live_cells(grid: np.ndarray) -> List[Tuple[int, int]]:
+    """Coordonnees ``(ligne, colonne)`` des cellules vivantes — format d'export.
+
+    C'est la representation compacte de chaque image du film pour les
+    consommateurs de la batterie ICT (etats discrets, comparaison entre
+    instants, export JSON).
+    """
+    rows, cols = np.nonzero(grid)
+    return [(int(r), int(c)) for r, c in zip(rows, cols)]
+
+
+# --------------------------------------------------------------- patterns canoniques
+_PATTERNS: Dict[str, List[str]] = {
+    # Glider (Gosper 1970) : period 4, deplacement diagonal (1, 1) par periode.
+    "glider": [
+        ".O.",
+        "..O",
+        "OOO",
+    ],
+    # Blinker (oscillateur minimal) : period 2, stationnaire.
+    "blinker": [
+        "OOO",
+    ],
+    # Pulsar (oscillateur period 3 le plus connu) : stationnaire.
+    "pulsar": [
+        "..OOO...OOO..",
+        ".............",
+        "O....O.O....O",
+        "O....O.O....O",
+        "O....O.O....O",
+        "..OOO...OOO..",
+        ".............",
+        "..OOO...OOO..",
+        "O....O.O....O",
+        "O....O.O....O",
+        "O....O.O....O",
+        ".............",
+        "..OOO...OOO..",
+    ],
+    # Lightweight spaceship : period 4, deplacement orthogonal (0, 2) par periode
+    # (c/2 vers l'est sous cette orientation). Forme verifiee empiriquement en
+    # faisant evoluer la synthese officielle a 3 gliders (Catagolue xq4_6frc)
+    # et en extrayant la phase a 9 cellules.
+    "lwss": [
+        ".OOOO",
+        "O...O",
+        "....O",
+        "O..O.",
+    ],
+    # Bloc (structure stable canonique) : period 1, stationnaire.
+    "block": [
+        "OO",
+        "OO",
+    ],
+}
+
+
+def canonical_pattern(name: str) -> np.ndarray:
+    """Grille du pattern canonique ``name`` (glider, blinker, pulsar, lwss, block)."""
+    rows = _PATTERNS[name]
+    return np.array([[1 if ch == "O" else 0 for ch in row] for row in rows], dtype=np.uint8)
+
+
+def embed(pattern: np.ndarray, size: int, top: int = 0, left: int = 0) -> np.ndarray:
+    """Place ``pattern`` dans une grille toroidale ``size x size`` en ``(top, left)``."""
+    p = (np.asarray(pattern) != 0).astype(np.uint8)
+    if p.shape[0] > size or p.shape[1] > size:
+        raise ValueError("pattern plus grand que la grille cible")
+    grid = np.zeros((size, size), dtype=np.uint8)
+    h, w = p.shape
+    grid[top:top + h, left:left + w] = p
+    return grid
+
+
+def canonical_patterns() -> Dict[str, np.ndarray]:
+    """Tous les patterns canoniques (calibration, notebooks ICT)."""
+    return {name: canonical_pattern(name) for name in _PATTERNS}
+
+
+# --------------------------------------------------------------- calibration
+#: Constantes canoniques des patterns (LifeWiki / Catagolue, Berlekamp-Conway-Guy
+#: 1982) : nom -> (periode, deplacement (dl, dc) par periode). Le deplacement du
+#: glider et du LWSS depend de l'orientation encodee ci-dessus ; la calibration
+#: verifie la norme et l'orthogonalite/diagonalite pour rester valable si on
+#: change d'orientation.
+CALIBRATION: Dict[str, Dict[str, object]] = {
+    "glider": {"period": 4, "displacement": (1, 1), "kind": "diagonal"},
+    "blinker": {"period": 2, "displacement": (0, 0), "kind": "stationary"},
+    "pulsar": {"period": 3, "displacement": (0, 0), "kind": "stationary"},
+    "lwss": {"period": 4, "displacement": (0, 2), "kind": "orthogonal"},
+    "block": {"period": 1, "displacement": (0, 0), "kind": "stationary"},
+}
+
+
+def _bounding_box(grid: np.ndarray) -> Optional[Tuple[np.ndarray, Tuple[int, int]]]:
+    """Contenu canonique (translate a l'origine) et coin superieur gauche."""
+    rows, cols = np.nonzero(grid)
+    if rows.size == 0:
+        return None
+    r0, c0 = int(rows.min()), int(cols.min())
+    return grid[r0:rows.max() + 1, c0:cols.max() + 1], (r0, c0)
+
+
+def period_and_displacement(grid: np.ndarray, max_steps: int = 64) -> Tuple[Optional[int], Optional[Tuple[int, int]]]:
+    """Periode spatiale et deplacement net du pattern de ``grid``.
+
+    Detection par retour du contenu canonique (translation-invariant) : la
+    periode ``p`` est le plus petit nombre de generations apres lequel le
+    pattern, translate a l'origine, redevient identique a lui-meme ; le
+    deplacement est le decalage du coin de la boite englobante sur une periode.
+    Retourne ``(None, None)`` si rien n'est retrouve en ``max_steps`` (pattern
+    mourant sans etat final stable, ou grille trop petite / wrap toroidal
+    intervenu).
+    """
+    g = (np.asarray(grid) != 0).astype(np.uint8)
+    box0 = _bounding_box(g)
+    if box0 is None:
+        return 0, (0, 0)
+    canon0, origin0 = box0
+    for p in range(1, int(max_steps) + 1):
+        g = next_generation(g)
+        box = _bounding_box(g)
+        if box is None:
+            return None, None
+        canon, origin = box
+        if canon.shape == canon0.shape and bool((canon == canon0).all()):
+            return p, (origin[0] - origin0[0], origin[1] - origin0[1])
+    return None, None
+
+
+def calibrate(name: str, size: int = 32) -> Tuple[bool, Dict[str, object]]:
+    """Verifie que le pattern canonique ``name`` reproduit ses constantes.
+
+    C'est le **certificat de calibration** du substrat : le moteur B3/S23
+    implemente ici doit reproduire les periodes et deplacements documentes des
+    patterns canoniques. Un echec ici invalide toute mesure ICT construite sur
+    ce substrat (la garantie Lean couvre l'egalite Hashlife/naif, pas la
+    correctesse de l'implementation Python — qui se prouve par cette
+    calibration contre les constantes connues).
+    """
+    ref = CALIBRATION[name]
+    period, displacement = period_and_displacement(embed(canonical_pattern(name), size), max_steps=2 * size)
+    if period != ref["period"] or displacement is None:
+        return False, {"name": name, "period": period, "displacement": displacement, **ref}
+    dr, dc = displacement
+    if ref["kind"] == "stationary":
+        ok = (dr, dc) == (0, 0)
+    elif ref["kind"] == "diagonal":
+        ok = abs(dr) == abs(dc) == 1
+    else:  # orthogonal
+        ok = (abs(dr) == 0 and abs(dc) == 2) or (abs(dr) == 2 and abs(dc) == 0)
+    return ok, {"name": name, "period": period, "displacement": displacement,
+                "expected": ref, "kind": ref["kind"]}
+
+
+def calibrate_all() -> Dict[str, bool]:
+    """Calibration de tous les patterns canoniques (utilisee par les tests)."""
+    return {name: calibrate(name)[0] for name in _PATTERNS}

--- a/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_life.py
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_life.py
@@ -1,0 +1,127 @@
+"""Tests du substrat Jeu de la Vie (phase-zero #5726).
+
+Verifient la regle B3/S23 (naissance, survie, mort), les proprietes de trajectoire
+et surtout la **calibration canonique** : chaque pattern (glider, blinker, pulsar,
+LWSS, block) doit reproduire sa periode et son deplacement documentes. C'est le
+certificat qui fonde l'usage de ce substrat comme source de trajectoires calibrees
+pour la batterie ICT.
+
+Numpy + pytest."""
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from ict.life import (  # noqa: E402
+    CALIBRATION,
+    calibrate_all,
+    canonical_pattern,
+    embed,
+    live_cells,
+    next_generation,
+    period_and_displacement,
+    trajectory,
+)
+
+
+# --------------------------------------------------------------- regle B3/S23
+def test_lone_cell_dies():
+    grid = np.zeros((8, 8), dtype=np.uint8)
+    grid[4, 4] = 1
+    assert next_generation(grid).sum() == 0
+
+
+def test_block_is_still_life():
+    block = embed(canonical_pattern("block"), 8)
+    nxt = next_generation(block)
+    assert nxt.sum() == 4
+    assert live_cells(nxt) == live_cells(block)
+
+
+def test_birth_on_three_neighbors():
+    grid = np.zeros((8, 8), dtype=np.uint8)
+    grid[3, 3] = grid[4, 3] = grid[5, 3] = 1  # blinker vertical
+    nxt = next_generation(grid)
+    # le centre (4,3) survit ; (4,2) et (4,4) naissent ; les extremites meurent
+    assert live_cells(nxt) == [(4, 2), (4, 3), (4, 4)]
+
+
+def test_overpopulation_death():
+    grid = np.zeros((8, 8), dtype=np.uint8)
+    grid[3, 3] = grid[3, 4] = grid[4, 3] = grid[4, 4] = grid[5, 4] = 1  # centre (4,4) a 4 voisins
+    nxt = next_generation(grid)
+    assert nxt[4, 4] == 0
+
+
+def test_toroidal_wrap():
+    # blinker a cheval sur le bord : les voisins viennent du cote oppose
+    grid = np.zeros((6, 6), dtype=np.uint8)
+    grid[0, 0] = grid[0, 5] = grid[0, 1] = 1  # ligne 0, colonnes -1, 0, 1 (wrap)
+    nxt = next_generation(grid)
+    assert sorted(live_cells(nxt)) == [(0, 0), (1, 0), (5, 0)]
+
+
+# --------------------------------------------------------------- trajectoire et export
+def test_trajectory_length_and_types():
+    grid = embed(canonical_pattern("blinker"), 8)
+    film = trajectory(grid, 3)
+    assert len(film) == 4
+    assert all(g.shape == (8, 8) and g.dtype == np.uint8 for g in film)
+    # la trajectoire ne modifie pas la grille d'entree
+    assert (film[0] == grid).all()
+    assert film[1].sum() == 3  # un blinker reste 3 cellules
+
+
+def test_live_cells_export_format():
+    block = embed(canonical_pattern("block"), 6, top=2, left=3)
+    assert sorted(live_cells(block)) == [(2, 3), (2, 4), (3, 3), (3, 4)]
+
+
+# --------------------------------------------------------------- calibration canonique
+def test_calibration_all_patterns():
+    """Certificat : chaque pattern canonique reproduit periode et deplacement."""
+    results = calibrate_all()
+    assert results == {name: True for name in results}, results
+
+
+def test_glider_period_and_displacement():
+    period, disp = period_and_displacement(embed(canonical_pattern("glider"), 32))
+    assert period == CALIBRATION["glider"]["period"] == 4
+    assert disp is not None and abs(disp[0]) == abs(disp[1]) == 1
+
+
+def test_pulsar_period_three_stationary():
+    period, disp = period_and_displacement(embed(canonical_pattern("pulsar"), 32))
+    assert period == 3
+    assert disp == (0, 0)
+
+
+def test_lwss_period_and_orthogonal_displacement():
+    period, disp = period_and_displacement(embed(canonical_pattern("lwss"), 32))
+    assert period == 4
+    assert disp is not None
+    dr, dc = disp
+    assert (abs(dr) == 0 and abs(dc) == 2) or (abs(dr) == 2 and abs(dc) == 0)
+
+
+def test_blinker_period_two():
+    period, disp = period_and_displacement(embed(canonical_pattern("blinker"), 8))
+    assert period == 2
+    assert disp == (0, 0)
+
+
+def test_dying_pattern_reports_none():
+    grid = np.zeros((8, 8), dtype=np.uint8)
+    grid[4, 4] = 1
+    period, disp = period_and_displacement(grid)
+    assert period is None and disp is None
+
+
+def test_embed_rejects_oversized_pattern():
+    import pytest
+
+    with pytest.raises(ValueError):
+        embed(canonical_pattern("pulsar"), 4)


### PR DESCRIPTION
Grain: DEEP/research-code — lane myia-po-2024:CoursIA — prev: DEEP/qc #11176

See #5726 (partiel : livrables 1-2 de la phase-zero « Life as certified calibration substrate » ; le notebook de calibration, livrable 3, suivra)

## Livrable

`ict/life.py` — substrat Jeu de la Vie (B3/S23, toroidal, vectorise numpy) pour la batterie ICT : generation `next_generation`, film `trajectory`, export `live_cells`, patterns canoniques (glider, blinker, pulsar, LWSS, block), detection `period_and_displacement`, et **certificat de calibration** `calibrate`/`calibrate_all`. + `tests/test_life.py` (14 tests).

## Pourquoi maintenant : le gate est leve (verifie firsthand)

La dependance dure de #5726 (« au minimum P1-P5 + le cas n>0 ») est satisfaite sur `origin/main` :

- `HashlifeCorrectness.lean` : **0 sorry reel** (`grep -E '^\s*sorry\s*$'` = 0 match), `theorem hashlife_correct` (L1095) et `hashlife_correctN` (L1530) presents ;
- chaine fermee : P4 `p4_succ_membership` + pont de localite BR1-BR3 + BR4a `one_jump_toGrid_correct` (#10919) + `p5_large_n_jumpN` DISCHARGED par induction sur le fuel + re-signature trajectoire b3' (#11007, merged 2026-08-15T04:25Z) ;
- seuls `HashlifeMarginFragment.lean` FR/EN gardent 1 sorry (framework documente INTRINSIC, #9568) — hors chaine de `hashlife_correct`.

Le module cite le theoreme Lean dans sa docstring (pont preuve <-> mesure, livrable 4 de #5726 anticipe) : la simulation naive pas-a-pas implementee ici est l'exact pendant Python de la branche « naive » du theoreme — l'egalite Hashlife/naif prouvee en Lean garantit que l'export de trajectoires herite d'une correction garantie.

## Calibration — le point non trivial

LWSS : le pattern memorise etait FAUX (echec empirique — population diverge, pas de cycle). Resolution honnete : faire evoluer la **synthese officielle a 3 gliders** (Catagolue `xq4_6frc`, `4bo$3bo$3b3o4$6bo$3o2b2o$2bo2bobo$bo!`) dans le simulateur, extraire la phase a 9 cellules, puis verifier : **period 4, displacement (0, 2)** (c/2 orthogonal) — conforme a la fiche Catagolue (spaceship, period 4, population 9-12).

Constantes verifiees par `calibrate_all()` : glider p=4 diag (1,1) · blinker p=2 stationnaire · pulsar p=3 stationnaire · LWSS p=4 ortho (0,2) · block p=1 stationnaire.

## Tests

```
14 passed in 0.34s  (MyIA.AI.Notebooks/IIT/ICT-Series/tests/test_life.py)
```

Regle B3/S23 (naissance/surpopulation/toroïdal), format d'export, non-mutation de l'entree, et calibration canonique complete.

## Residuel

- Livrable 3 de la phase-zero : notebook ICT de calibration GOL-substrat (glider/blinker/pulsar/LWSS, contraste vs S2 bistable et S5 Gray-Scott) — tranche suivante.
- Branchage sur la batterie (`ict.agency`, `ict.stake`, causal emergence multi-echelle) : apres le notebook.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
