### PR TITLE
fix(tests,#11166): cliquet monotone sur le controle positif legacy (repare main rouge)

### DIFF
--- a/scripts/notebook_tools/tests/test_scan_media_render.py
+++ b/scripts/notebook_tools/tests/test_scan_media_render.py
@@ -26,6 +26,21 @@ from scan_media_render import (  # noqa: E402
 
 REPO = Path(__file__).resolve().parent.parent.parent.parent
 
+# CLIQUET du controle positif `test_triage_30_legacy_still_flags_them`.
+#
+# Nombre de notebooks du tri #10996 encore signales par le predicat LEGACY.
+# Il BAISSE a mesure que les tranches reparent les notebooks (une sortie
+# `audio/*` apparait dans le JSON -> legacy cesse legitimement de signaler) :
+#
+#   30  au tri initial (#10996)
+#   21  apres tranche B (#11166, 9 notebooks republies via audio_helpers.py)
+#
+# Le test assert `flagged <= CEILING` : il rougit quand le compte REMONTE
+# (regression reelle), jamais quand il baisse (reparation reussie). Abaisser
+# cette valeur est facultatif et se fait en nommant la tranche ; la RELEVER
+# est interdit sans diagnostic — c'est le signal, pas le bruit.
+LEGACY_FLAGGED_CEILING = 21
+
 # Les 30 notebooks du tri #10996 (tranches A/B/C/D) — chemins exacts verifies
 # sur main au tri (issuecomments 5299344909, 5299156801, 5299386143, 5299391278).
 TRIAGE_30 = [
@@ -343,7 +358,30 @@ def test_triage_30_no_false_defect():
 
 
 def test_triage_30_legacy_still_flags_them():
-    """Controle positif : l'ancien predicat DOIT encore signaler les 30."""
+    """Controle positif : l'ancien predicat DOIT encore signaler une partie des 30.
+
+    Ce test rend `test_triage_30_no_false_defect` NON VACUEUX : il prouve que le
+    predicat enrichi (qui ne signale aucun des 30) dit bien autre chose que le
+    predicat legacy sur ce meme corpus.
+
+    Le compte n'est PAS fige a 30, et ne doit pas l'etre. Les tranches de #10996
+    reparent reellement ces notebooks — quand une sortie `audio/*` apparait dans
+    le JSON, le predicat legacy cesse legitimement de les signaler. Figer 30
+    faisait donc echouer `main` a **chaque reparation reussie** (tranche B /
+    #11166 : 9 notebooks republies via `audio_helpers.py`, 30 -> 21, `main` rouge
+    sur le merge). Un controle qui rougit quand le depot s'ameliore mesure le
+    contraire de ce qu'il annonce.
+
+    L'invariant qui tient dans les deux sens :
+
+    - le compte ne peut que **BAISSER** (une hausse = regression d'un notebook
+      deja repare, ou erosion du predicat legacy — les deux sont de vrais bugs) ;
+    - il doit rester **> 0** tant que #10996 n'est pas clos, sinon le controle
+      est vacueux.
+
+    Quand #10996 sera entierement livre, `flagged` tombera a 0 : ce test aura
+    alors fait son office et devra etre **retire**, pas rafistole.
+    """
     missing = [p for p in TRIAGE_30 if not (REPO / p).exists()]
     if missing:
         pytest.skip(f"corpus GenAI absent: {missing[:2]}")
@@ -351,7 +389,18 @@ def test_triage_30_legacy_still_flags_them():
         1 for p in TRIAGE_30
         if scan_notebook(REPO / p, REPO).verdict(legacy=True) == "NO_MEDIA_RENDERED"
     )
-    assert flagged == 30, f"le predicat legacy ne signale plus les 30 (actuel: {flagged})"
+    assert flagged <= LEGACY_FLAGGED_CEILING, (
+        f"le predicat legacy signale {flagged} notebooks du tri #10996, contre "
+        f"{LEGACY_FLAGGED_CEILING} au dernier relevé. Un compte qui REMONTE ne "
+        f"peut venir que d'une regression : soit un notebook deja republie a "
+        f"reperdu ses sorties media, soit le predicat legacy a change. "
+        f"Ne PAS relever le plafond pour faire passer le test — diagnostiquer."
+    )
+    assert flagged > 0, (
+        "le predicat legacy ne signale plus AUCUN des 30 : soit #10996 est "
+        "entierement livre (retirer ce test, il est devenu vacueux), soit le "
+        "predicat legacy a ete casse et ne signale plus rien"
+    )
 
 
 


### PR DESCRIPTION
Grain: MED/test — lane myia-ai-01:CoursIA — prev: LIGHT/docs #11184

**`main` est rouge, et c'est mon merge qui l'a mis rouge.** Ce PR le repare.

## Ce qui a casse

Run [31922145765](https://github.com/jsboige/CoursIA/actions/runs/31922145765), `Scripts Tests (CPU)`, SHA `805aa9c4d` (merge de #11166) :

```
assert flagged == 30, f"le predicat legacy ne signale plus les 30 (actuel: {flagged})"
E   AssertionError: le predicat legacy ne signale plus les 30 (actuel: 21)
====== 1 failed, 8092 passed, 31 skipped, 5 xfailed in 164.61s ======
```

**Aucune regression.** #11166 a genuinement republie **9** des 30 notebooks du tri #10996 via `audio_helpers.py`. Le predicat legacy a donc cesse — correctement — de les signaler : 30 − 9 = **21**. Le test mesurait une population residuelle en la traitant comme une constante.

## Pourquoi ce n'est pas « ajuster 30 en 21 »

Ecrire `== 21` reproduirait le defaut d'un cran plus loin : la prochaine tranche livree remettrait `main` au rouge, et le reflexe serait de re-figer le nouveau nombre. **Un controle qui rougit quand le depot s'ameliore mesure le contraire de ce qu'il annonce** — et forme les lecteurs a considerer sa couleur comme du bruit.

La forme correcte d'une population qui doit decroitre est un **cliquet** :

| Assertion | Rougit quand | Sens |
|---|---|---|
| `flagged <= LEGACY_FLAGGED_CEILING` (21) | le compte **REMONTE** | regression reelle : un notebook repare a redegrade |
| `flagged > 0` | le predicat ne signale **plus rien** | soit #10996 est fini (→ **RETIRER** ce test, devenu vacueux), soit le predicat legacy est casse |

Abaisser le plafond est facultatif et se fait **en nommant la tranche** qui l'abaisse (la valeur `21` porte en commentaire son historique : `30` au tri initial #10996, `21` apres tranche B #11166). Le **RELEVER** est interdit sans diagnostic : c'est le signal, pas le bruit.

## Ce que ce test protege, et qu'il faut preserver

Il est le **controle positif** de `test_triage_30_no_false_defect`. Sans lui, le test negatif deviendrait satisfiable par un predicat qui ne signale jamais rien. C'est pourquoi la seconde assertion (`> 0`) n'est pas decorative : elle est la seule chose qui empeche le controle de devenir vacueux en silence.

Note au passage : ma premiere redaction du cliquet ecrivait `assert flagged <= len(TRIAGE_30)` — trivialement vrai pour une somme sur cette liste, donc exactement le defaut « mesure qui ne peut pas echouer » que ce PR corrige. Attrape avant commit ; la constante nommee le rend impossible a re-introduire par distraction.

## Test plan

```
$ python -m pytest scripts/notebook_tools/tests/test_scan_media_render.py -q
17 passed in 6.11s
```

Fichier de test seul, aucun code de production ni notebook touche.

See #11166, #10996
