### PR TITLE
fix(ml,#11168): arXiv citation audit ML family — fabricated ONNX ID + 4 wrong-author citations

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day4-Foundations/Lab9-First-ADK-Agent.ipynb
@@ -320,7 +320,7 @@
     "\n",
     "Contrairement à LangChain qui fournit `create_pandas_dataframe_agent`, nous allons construire notre propre agent avec une capacité d'exécution de code Python.\n",
     "\n",
-    "> **Repère bibliographique.** Cet agent suit le paradigme **CodeAct** : au lieu d'émettre des appels d'outils séparés (action space JSON), le LLM génère du code Python *exécutable* que l'environnement interprète directement, ce qui lui permet de réviser ou d'enchaîner ses actions sur la base des résultats observés. Ce design est formalisé par X. Wang et al., *Executable Code Actions Elicit Better LLM Agents* (CodeAct), arXiv:2402.01030, ICLR 2024. Il sous-tend les agents data-science modernes (Data Interpreter, CodeAct-2) qui atteignent l'état de l'art sur les benchmarks Kaggle et MLE-bench.\n",
+    "> **Repère bibliographique.** Cet agent suit le paradigme **CodeAct** : au lieu d'émettre des appels d'outils séparés (action space JSON), le LLM génère du code Python *exécutable* que l'environnement interprète directement, ce qui lui permet de réviser ou d'enchaîner ses actions sur la base des résultats observés. Ce design est formalisé par X. Wang et al., *Executable Code Actions Elicit Better LLM Agents* (CodeAct), arXiv:2402.01030, ICML 2024. Il sous-tend les agents data-science modernes (Data Interpreter, CodeAct-2) qui atteignent l'état de l'art sur les benchmarks Kaggle et MLE-bench.\n",
     "\n",
     "### Architecture\n",
     "\n",
@@ -1033,7 +1033,7 @@
    "source": [
     "## Références\n",
     "\n",
-    "1. X. Wang et al., *Executable Code Actions Elicit Better LLM Agents* (CodeAct), arXiv:2402.01030, ICLR 2024. Paradigme de l'agent générant du code exécutable (action space unifié) — cœur de l'architecture de ce laboratoire.\n",
+    "1. X. Wang et al., *Executable Code Actions Elicit Better LLM Agents* (CodeAct), arXiv:2402.01030, ICML 2024. Paradigme de l'agent générant du code exécutable (action space unifié) — cœur de l'architecture de ce laboratoire.\n",
     "2. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (perception-raisonnement-action, outils, mémoire) — suite du Lab 8.\n",
     "3. H. Chase, *LangChain*, octobre 2022, `langchain.com`. Framework de comparaison (`create_pandas_dataframe_agent`) — suite du Lab 8.\n",
     "4. OpenBMB Team, *CodeAct / Data Interpreter*, 2024. Implémentation open-source du paradigme CodeAct appliqué aux agents data science (`github.com/OpenBMB/AgentVerse`)."

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab10-File-Analyzer.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab10-File-Analyzer.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "### Durée estimée : 30-40 minutes\n",
     "\n",
-    "> **Repère bibliographique.** Ce laboratoire implémente le module **File Analyzer** de l'agent DS-STAR (Data Science - Structured Thought and Action). DS-STAR est un agent data-science à l'état de l'art décrit par Google Research (Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025) — un harnais multi-module déterministe (7 modules : analyse de fichier, planification structurée, génération et exécution de code, vérification itérative) conçu pour traiter des données de formats hétérogènes. Le File Analyzer en est le composant d'ingestion et de profilage automatique."
+    "> **Repère bibliographique.** Ce laboratoire implémente le module **File Analyzer** de l'agent DS-STAR (Data Science - Structured Thought and Action). DS-STAR est un agent data-science à l'état de l'art décrit par Google Research (Nam et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Formats and Open-Ended Queries*, arXiv:2509.21825, 2025) — un harnais multi-module déterministe (7 modules : analyse de fichier, planification structurée, génération et exécution de code, vérification itérative) conçu pour traiter des données de formats hétérogènes. Le File Analyzer en est le composant d'ingestion et de profilage automatique."
    ]
   },
   {
@@ -895,7 +895,7 @@
    "source": [
     "## Références\n",
     "\n",
-    "1. Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025. Article fondateur de l'agent DS-STAR (architecture multi-module : File Analyzer, planification structurée, génération/exécution de code, vérification).\n",
+    "1. Nam et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Formats and Open-Ended Queries*, arXiv:2509.21825, 2025. Article fondateur de l'agent DS-STAR (architecture multi-module : File Analyzer, planification structurée, génération/exécution de code, vérification).\n",
     "2. Google Research, *DS-STAR: A State-of-the-Art Versatile Data Science Agent*, `research.google/blog/ds-star-a-state-of-the-art-versatile-data-science-agent/`, 2025. Billet de présentation (benchmark DABStep).\n",
     "3. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM — suite des Labs 8-9."
    ],

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab11-Planner-Coder-Loop.ipynb
@@ -50,7 +50,7 @@
    "source": [
     "## 1. Architecture Planner-Coder-Verifier\n",
     "\n",
-    "> **Repères bibliographiques.** Cette boucle itérative Planner → Coder → Executor → Verifier est un cas particulier du paradigme **ReAct** (Reasoning + Acting) de S. Yao et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, arXiv:2210.03629, ICLR 2023, où l'agent alterne raisonnement et actions observables. L'étape de *Verifier* qui renvoie vers le Coder en cas d'échec (raffinement automatique) suit le principe d'**auto-réflexion** formalisé par N. Shinn et al., *Reflexion: Language Agents with Verbal Reinforcement Learning*, arXiv:2303.11366, NeurIPS 2023. Le découpage en rôles spécialisés (Planner / Coder / Verifier) est l'architecture multi-agent déterministe retenue par DS-STAR (Guo et al., arXiv:2509.21825, 2025).\n",
+    "> **Repères bibliographiques.** Cette boucle itérative Planner → Coder → Executor → Verifier est un cas particulier du paradigme **ReAct** (Reasoning + Acting) de S. Yao et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, arXiv:2210.03629, ICLR 2023, où l'agent alterne raisonnement et actions observables. L'étape de *Verifier* qui renvoie vers le Coder en cas d'échec (raffinement automatique) suit le principe d'**auto-réflexion** formalisé par N. Shinn et al., *Reflexion: Language Agents with Verbal Reinforcement Learning*, arXiv:2303.11366, NeurIPS 2023. Le découpage en rôles spécialisés (Planner / Coder / Verifier) est l'architecture multi-agent déterministe retenue par DS-STAR (Nam et al., arXiv:2509.21825, 2025).\n",
     "```\n",
     "Question --> [PLANNER] --> Plan\n",
     "                      |\n",
@@ -1032,7 +1032,7 @@
     "\n",
     "1. S. Yao et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, arXiv:2210.03629, ICLR 2023. Paradigme Reasoning+Acting : l'agent alterne raisonnement et actions observables — fondement de la boucle Planner-Coder-Verifier.\n",
     "2. N. Shinn et al., *Reflexion: Language Agents with Verbal Reinforcement Learning*, arXiv:2303.11366, NeurIPS 2023. Auto-réflexion verbale et raffinement itératif après échec — principe de l'étape Verifier → Coder.\n",
-    "3. Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025. Agent DS-STAR dont ce lab implémente la boucle cœur (suite Lab 10).\n",
+    "3. Nam et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Formats and Open-Ended Queries*, arXiv:2509.21825, 2025. Agent DS-STAR dont ce lab implémente la boucle cœur (suite Lab 10).\n",
     "4. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel des agents LLM (suite Labs 8-10)."
    ],
    "id": "cell-7ada47b8"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day5-DS-Star/Lab12-DS-Star-Workshop.ipynb
@@ -33,7 +33,7 @@
     "\n",
     "### Durée estimée : 50-60 minutes\n",
     "\n",
-    "> **Repère bibliographique.** Ce workshop assemble le **pipeline agent de bout en bout** de DS-STAR (FileAnalyzer → Planner → Coder → Executor → Verifier) — l'architecture multi-agent complète décrite par Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025. Le principe général d'un agent LLM orchestrant une chaîne de modules spécialisés (perception, planification, action, vérification) est synthétisé par Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025."
+    "> **Repère bibliographique.** Ce workshop assemble le **pipeline agent de bout en bout** de DS-STAR (FileAnalyzer → Planner → Coder → Executor → Verifier) — l'architecture multi-agent complète décrite par Nam et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Formats and Open-Ended Queries*, arXiv:2509.21825, 2025. Le principe général d'un agent LLM orchestrant une chaîne de modules spécialisés (perception, planification, action, vérification) est synthétisé par Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025."
    ]
   },
   {
@@ -990,7 +990,7 @@
    "source": [
     "## Références\n",
     "\n",
-    "1. Guo et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Data*, arXiv:2509.21825, 2025. Agent DS-STAR complet (architecture orchestrée FileAnalyzer + Planner-Coder-Verifier) — synthèse des Labs 10-12.\n",
+    "1. Nam et al., *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Formats and Open-Ended Queries*, arXiv:2509.21825, 2025. Agent DS-STAR complet (architecture orchestrée FileAnalyzer + Planner-Coder-Verifier) — synthèse des Labs 10-12.\n",
     "2. Z. Xi et al., *The Rise and Potential of Large Language Model Based Agents: A Survey*, arXiv:2309.07864, 2025. Cadre conceptuel de l'agent LLM modulaire de bout en bout (perception-planification-action-vérification).\n",
     "3. S. Yao et al., *ReAct: Synergizing Reasoning and Acting in Language Models*, arXiv:2210.03629, ICLR 2023. Paradigme de la boucle raisonnement-action (suite Lab 11).\n",
     "4. N. Shinn et al., *Reflexion: Language Agents with Verbal Reinforcement Learning*, arXiv:2303.11366, NeurIPS 2023. Auto-raffinement après vérification (suite Lab 11)."

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab14-Ablation-Refinement.ipynb
@@ -904,8 +904,8 @@
    "source": [
     "## References\n",
     "\n",
-    "- Meyes, R., Schuman, C., Sakhavi, S., et al. (2019). *Ablation Studies in Artificial Neural Networks*. arXiv:1901.08644. https://arxiv.org/abs/1901.08644\n",
-    "- Guo, Q., et al. (2025). *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*. Google Research. arXiv:2506.15692. https://arxiv.org/abs/2506.15692\n",
+    "- Meyes, R., Lu, M., Waubert de Puiseau, C., & Meisen, T. (2019). *Ablation Studies in Artificial Neural Networks*. arXiv:1901.08644. https://arxiv.org/abs/1901.08644\n",
+    "- Nam, J., et al. (2025). *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*. Google Research. arXiv:2506.15692. https://arxiv.org/abs/2506.15692\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
    ],
    "id": "cell-b4e2c09f"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day6-MLE-Star/Lab15-Kaggle-Challenge.ipynb
@@ -824,8 +824,8 @@
    "source": [
     "## References\n",
     "\n",
-    "- Chan, S.P., Chowdhury, A., Chen, C., et al. (2024). *MLE-bench: Evaluating Machine Learning Agents on Machine Learning Engineering*. arXiv:2410.07095 (OpenAI). https://arxiv.org/abs/2410.07095\n",
-    "- Guo, Q., et al. (2025). *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*. Google Research. arXiv:2506.15692. https://arxiv.org/abs/2506.15692\n",
+    "- Chan, J. S., Chowdhury, N., Jaffe, O., et al. (2024). *MLE-bench: Evaluating Machine Learning Agents on Machine Learning Engineering*. arXiv:2410.07095 (OpenAI). https://arxiv.org/abs/2410.07095\n",
+    "- Nam, J., et al. (2025). *MLE-STAR: Machine Learning Engineering Agent via Search and Targeted Refinement*. Google Research. arXiv:2506.15692. https://arxiv.org/abs/2506.15692\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
    ],
    "id": "cell-d2566259"

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day7-Production/Lab17-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track2-GoogleADK/Day7-Production/Lab17-Final-Project.ipynb
@@ -224,8 +224,8 @@
     "résultats avant de produire un rapport. Ce lab orchestre l'**integration end-to-end** de tous les\n",
     "composants, par opposition a l'étude d'un composant isole (cf. Lab 10 sur le FileAnalyzer).\n",
     "\n",
-    "> Reference : Guo, Q., et al. (2025). *DS-STAR: An Automated End-to-End Data Science Agent\n",
-    "> Based on Code Generation*. arXiv:2509.21825. https://arxiv.org/abs/2509.21825"
+    "> Reference : Nam, J., et al. (2025). *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Formats and Open-Ended Queries\n",
+    "> arXiv:2509.21825. https://arxiv.org/abs/2509.21825"
    ]
   },
   {
@@ -1034,7 +1034,7 @@
    "source": [
     "## References\n",
     "\n",
-    "- Guo, Q., et al. (2025). *DS-STAR: An Automated End-to-End Data Science Agent Based on Code Generation*. arXiv:2509.21825. https://arxiv.org/abs/2509.21825\n",
+    "- Nam, J., et al. (2025). *DS-STAR: Data Science Agent for Solving Diverse Tasks across Heterogeneous Formats and Open-Ended Queries*. arXiv:2509.21825. https://arxiv.org/abs/2509.21825\n",
     "- Ji, Z., Lee, N., Frieske, R., et al. (2023). *Survey of Hallucination in Natural Language Generation*. ACM Computing Surveys 55. arXiv:2202.03629. https://arxiv.org/abs/2202.03629\n",
     "- Xi, Z., et al. (2025). *The Rise and Potential of Large Language Model Based Agents: A Survey*. arXiv:2309.07864."
    ],

--- a/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
+++ b/MyIA.AI.Notebooks/ML/ML.Net/ML-6-ONNX.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "**ONNX (Open Neural Network Exchange)** est un format ouvert pour représenter des modèles de machine learning.\n",
     "\n",
-    "> **Repère bibliographique.** ONNX est formalisé par J. Bai et al., *ONNX: Open Neural Network Exchange* (arXiv:1911.09500, 2019) — standard ouvert co-développé par Facebook et Microsoft pour l'interopérabilité des modèles d'apprentissage automatique entre frameworks (PyTorch, TensorFlow, scikit-learn, ML.NET). Voir aussi la spécification officielle `onnx.ai`.\n",
+    "> **Repère bibliographique.** ONNX est formalisé par J. Bai et al., *ONNX: Open Neural Network Exchange* (whitepaper, 2019 — https://github.com/onnx/onnx) — standard ouvert co-développé par Facebook et Microsoft pour l'interopérabilité des modèles d'apprentissage automatique entre frameworks (PyTorch, TensorFlow, scikit-learn, ML.NET). Voir aussi la spécification officielle `onnx.ai`.\n",
     "\n",
     "**Avantages** :\n",
     "- **Interopérabilité** : Échanger des modèles entre frameworks (PyTorch ↔ TensorFlow ↔ Scikit-learn ↔ ML.NET)\n",
@@ -1340,7 +1340,7 @@
    "source": [
     "## Références\n",
     "\n",
-    "1. J. Bai et al., *ONNX: Open Neural Network Exchange*, arXiv:1911.09500, 2019. Standard ouvert d'interopérabilité des modèles (co-développé par Facebook et Microsoft). Source canonique du format ONNX enseigné dans ce notebook.\n",
+    "1. J. Bai et al., *ONNX: Open Neural Network Exchange*, whitepaper GitHub ONNX, 2019. https://github.com/onnx/onnx Standard ouvert d'interopérabilité des modèles (co-développé par Facebook et Microsoft). Source canonique du format ONNX enseigné dans ce notebook.\n",
     "2. ONNX specification officielle, `onnx.ai`. Définition des opérateurs standards et du format de graphe.\n",
     "3. Microsoft, *ONNX Runtime*, `onnxruntime.ai` (dépôt `microsoft/onnxruntime`). Moteur d'inférence haute performance couvrant graph optimization, quantification INT8 et accélération CUDA/TensorRT/OpenVINO.\n",
     "4. G. Ke et al., *LightGBM: A Highly Efficient Gradient Boosting Decision Tree*, NeurIPS, 2017. Référence pour les modèles Gradient Boosting exportés vers ONNX dans l'Exemple 4 (workflow Python → ONNX → ML.NET).\n",

--- a/scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-6-onnx-integration.yaml
@@ -12,6 +12,13 @@
       python_sha: 40517222f60d7acaacb6beeefdc225798309315e
       csharp_sha: e8b19d04356dab090cb82f001db007990261ac73
       reason: "rebaseline csharp apres fix prose CELL[2] (#8052) : la Note disait faussement \"nous allons creer un modele ONNX simple\" alors que le C# CHARGE un modele pre-exporte (iris_model.onnx, sklearn, scripts/ml/generate_iris_onnx.py) -- verifie par header \"Charger un modele ONNX externe\", CELL[7] (code de chargement), et known_differences ci-dessous. Aligne la Note sur le code. Csharp-only, python_sha unchanged, parite semantique preservee."
+    - date: "2026-08-16"
+      by: myia-po-2023:CoursIA
+      python_sha: 40517222f60d7acaacb6beeefdc225798309315e
+      csharp_sha: f264a044cec5995d6a902645f11cf247d9e82378
+      content_python_sha: e823e291a9613d8b45ced48990438eee12b685b071736edd7dab4bcff4dd9023
+      content_csharp_sha: 79072e73894da2cfe0b060c178247329f1f27e1c1502e9d94321a5d731f3ae49
+      reason: "Rebaseline apres fix citation arXiv #11168 (branche fix/11168-arxiv-ml, commit 948746974) : l'ID arXiv:1911.09500 etait fabrique (ONNX n'a jamais ete publie sur arXiv -- whitepaper GitHub), corrige en whitepaper GitHub onnx/onnx sur 2 lignes markdown (repere bibliographique cell 41 + reference 1). Csharp-only, python_sha inchangee, markdown-only (C.2 exception), aucun contenu code/output touche. Diff verifie firsthand : 2 lignes remplacees, rien strippe."
   known_differences:
     - "Socle pedagogique commun : integration de modeles ONNX (chargement, inference, inspection du graph, exercices). C# = ML.NET OnnxTransformer + OnnxRuntime ; Python = skl2onnx (export sklearn->ONNX) + onnxruntime (inference) + onnx (inspection structurelle). Cree comme twin de parite explicite en #5607 (EPIC #4956 .NET<->Python)."
     - "Asymetrie export-vs-load (pont Python->.NET) : le C# charge un modele ONNX pre-exporte (iris_model.onnx genere par scripts/ml/generate_iris_onnx.py, RandomForest sklearn) car l'export ML.NET->ONNX est experimental (documente en commentaire, c13/c15) ; le Python effectue l'export sklearn->ONNX lui-meme via skl2onnx (opset 15, zipmap=False). Le twin Python est le cote 'producteur' du pont ONNX, le C# le cote 'consommateur'."


### PR DESCRIPTION
Grain: MED/ml — lane myia-po-2023:CoursIA — prev: MED/quantconnect 11183

# Grain famille ML — audit citations arXiv (See #11168)

22 IDs arXiv distincts / 70 occurrences / 17 notebooks porteurs, extraits des cellules markdown uniquement (hors `_archives/`, `.ipynb_checkpoints`), préfixés **et** bare-ID (scan secondaire qui a rattrapé 3 IDs en forme « (arXiv NNNN.NNNNN) » sans deux-points). Vérifiés via **une seule requête groupée** `?id_list=` (User-Agent identifiant, appariement par ID), arXiv API 22/22 retournés.

Le « 41 » de l'issue date d'un snapshot antérieur (même drift que GenAI 53→42, QC 44→31) : rescan complet = 22.

## Verdicts

| Verdict | IDs | Détail |
| ------- | --- | ------ |
| OK | 16 | titre + auteurs + année concordants |
| MAUVAISE-ATTRIBUTION | 4 | Ablation 1901.08644 (3 auteurs fantômes) ; MLE-bench 2410.07095 (initiales fautives + auteur fantôme) ; MLE-STAR 2506.15692 (Guo→Nam) ; DS-STAR 2509.21825 (Guo→Nam + 2 titres fautifs) |
| ID-ERRONÉ | 1 | **ONNX arXiv:1911.09500 fabriqué** : l'ID pointe vers un papier de systèmes dynamiques polynomiaux (Henrion et al.) et le whitepaper ONNX n'a jamais existé sur arXiv (vérifié par recherche de titre) |
| DRIFT-MINEUR | 1 | CodeAct 2402.01030 : venue « ICLR 2024 » → ICML 2024 (PMLR 235 — cohérent avec la citation Lab7 c24 qui était déjà correcte) |
| ID-FANTÔME | 0 | — |

## Corrections (17 lignes, markdown seul, 8 notebooks)

Toutes sous `MyIA.AI.Notebooks/ML/` :

1. `ML.Net/ML-6-ONNX.ipynb` c0 + c27 — `arXiv:1911.09500` supprimé, citation ré-ancrée sur le whitepaper réel (Bai, J. et al., 2019, https://github.com/onnx/onnx) : le papier ONNX n'est pas et n'a jamais été sur arXiv.
2. DS-STAR **Guo → Nam** (vrai premier auteur : Jaehyun Nam, POSTECH/Google Cloud) + titres : `Lab10` c0+c34, `Lab11` c1+c37, `Lab12` c0+c37 — titre tronqué « …across Heterogeneous Data » → titre réel « …across Heterogeneous **Formats and Open-Ended Queries** ».
3. `Lab17-Final-Project.ipynb` c7 + c39 — même double fix + **titre halluciné** « An Automated End-to-End Data Science Agent Based on Code Generation » (n'existe nulle part) → titre réel.
4. MLE-STAR **Guo → Nam** : `Lab14` c31, `Lab15` c32. (Lab13 c0/c32 : attributions d'org « Google Research » sans noms d'auteurs — pas de correction requise par le scope de l'audit.)
5. MLE-bench `Lab15` c32 — « Chan, S.P., Chowdhury, A., Chen, C. » → **Chan, J. S., Chowdhury, N., Jaffe, O.** (vrais auteurs OpenAI/MIT).
6. Ablation Studies `Lab14` c31 — « Meyes, R., Schuman, C., Sakhavi, S. » → **Meyes, R., Lu, M., Waubert de Puiseau, C., & Meisen, T.** (3 auteurs fantômes).
7. CodeAct `Lab9-First-ADK-Agent.ipynb` c7 + c30 — `ICLR 2024` → `ICML 2024`.

## Liste des 16 OK (pour ne pas re-vérifier)

1201.0490 · 1809.08887 · 2005.11401 · 2005.14165 · 2007.08722 · 2102.00515 · 2107.03374 · 2111.06399 · 2201.02177 · 2202.03629 · 2205.10343 · 2210.03629 · 2301.05217 · 2302.04761 · 2303.11366 · 2309.07864 — dont Grokking ×3 (Power, Liu, Nanda : listes d'auteurs complètes vérifiées) et les grands standards (Vaswani 1706.03762 absent de la famille ML — porté par GenAI/Texte ; Brown/GPT-3 2005.14165, BERT 1810.04805 absent, ReAct, Reflexion, Toolformer, xVal etc. tous conformes).

## Validation

- Éditions **markdown uniquement** → outputs précédents valides (exception C.2), pas de re-exécution requise.
- Chaque remplacement appliqué avec assertion `count == 1` (ou le compte exact attendu) sur le texte brut — 17/17 passées.
- `git diff` : 17 insertions / 17 délétions sur 8 fichiers, aucune autre ligne touchée ; lignes changées inspectées = uniquement les lignes de citation visées.
- JSON valide sur les 8 notebooks après édition.
- Catalogue non touché.