### PR TITLE
fix(symbolicai,#11168): arXiv citation audit SymbolicAI family — wrong temporal-planning link + non-existent EML title

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/03-Advanced/Planners-8-Temporal.ipynb
@@ -1988,7 +1988,7 @@
     "- [PDDL 2.1 Specification](https://www.cs.cmu.edu/~avrim/Planning/Refs/pddl2-1.pdf) - Document officiel\n",
     "- [unified-planning temporal](https://unified-planning.readthedocs.io/) - Documentation\n",
     "- [OR-Tools Scheduling](https://developers.google.com/optimization/scheduling) - Guide CP-SAT\n",
-    "- [Temporal Planning Survey](https://arxiv.org/abs/2104.08553) - Vue d'ensemble\n",
+    "- [PDDL2.1: Fox & Long — planification temporelle](https://arxiv.org/abs/1106.4561) - Fondements\n",
     "\n",
     "---\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/_archive/2026-07-04-Neurosymbolic-EML-precurseur-SL12/EML-NAND-Compose.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/_archive/2026-07-04-Neurosymbolic-EML-precurseur-SL12/EML-NAND-Compose.ipynb
@@ -20,7 +20,7 @@
     "**Tâche commune** : parite-3 (XOR de 3 bits booléens), 8 sommets, table de verite cible `x XOR y XOR z`. Metrique = exactitude booleenne après seuil 0.5 sur les 8 sommets.\n",
     "\n",
     "**References** :\n",
-    "- Papier : arXiv 2606.23179 \"Electromagnetic Logic: A Continuous Computational Substrate for Symbolic Reasoning\" (2026)\n",
+    "- Papier : arXiv 2606.23179 \"EML Trees Are Universal Approximators\" (2026)\n",
     "- Note-1 (atome + arbre chaîne) : `EML-NAND-Explore.ipynb` PR #4903 verdict INCONCLUSIF\n",
     "- Issue : See #4653, MSG ai-01 hyr376 = GO Note-2\n"
    ]

--- a/scripts/notebook_tools/twin_pairs.d/planners-8-temporal.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/planners-8-temporal.yaml
@@ -16,6 +16,13 @@
       csharp_sha: 2ebcbc046b781ee49449dc216402b603d5e7fb4b
       content_python_sha: cc583657ae2a15b36e01b29bcf1f639b6fa93359f42635aaa6554b08d153d175
       content_csharp_sha: 536a248cb5af410b7867159f605d558bedc8eecc39c0827d93480d736b820bb4
+    - date: "2026-08-16"
+      by: myia-po-2023:CoursIA
+      python_sha: 94d90a0461447759bcbe0029b70b8985527349f1
+      csharp_sha: 2ebcbc046b781ee49449dc216402b603d5e7fb4b
+      content_python_sha: cdd2d4c542af4a175ee483624f05abe745a6a8a0283eb1082b24b7fbc6be2a1f
+      content_csharp_sha: 536a248cb5af410b7867159f605d558bedc8eecc39c0827d93480d736b820bb4
+      reason: "Rebaseline apres fix citation arXiv #11168 (branche fix/11168-arxiv-symbolic, commit a3a0e595a) : le lien 'Temporal Planning Survey' arXiv:2104.08553 etait le mauvais papier, remplace par le fondement canonique Fox & Long PDDL2.1 arXiv:1106.4561 (1 ligne markdown, section References). Python-only, csharp_sha inchangee (identique aux entrees precedentes), markdown-only (C.2 exception), aucun contenu code/output touche. Diff verifie firsthand : 1 ligne remplacee, rien strippe."
   known_differences:
     - "Concept : planification temporelle (actions duratives, ordonnancement avec parallelisme)."
     - "Python : unified-planning temporal + CP-SAT + Gantt. C# : deux tranches — Tranche 1 from-scratch BCL .NET (PDDL duratives, Allen, STN Floyd-Warshall, RCPSP glouton LPT) + Tranche 2 Google.OrTools CP-SAT natif .NET (moteur de production, depuis 2026-08-11, contrainte cumulative AddCumulative)."


### PR DESCRIPTION
Grain: MED/symbolicai — lane myia-po-2023:CoursIA — prev: MED/ml 11187

# Grain famille SymbolicAI — audit citations arXiv (See #11168)

15 IDs arXiv distincts / 44 occurrences / 16 notebooks porteurs (le « 16 » de l'issue = snapshot antérieur, même drift que GenAI/QC/ML), extraits des cellules markdown uniquement (préfixés + scan secondaire bare-ID), vérifiés via **une seule requête groupée** `?id_list=` (User-Agent identifiant, appariement par ID). Note : l'exclusion d'archives a laissé passer `_archive/` (singulier) — 2 occurrences EML incluses dans l'audit car le contenu est committé et consultable.

## Verdicts

| Verdict | IDs | Détail |
| ------- | --- | ------ |
| OK | 13 | titre + auteurs + année concordants |
| ID-ERRONÉ | 1 | **2104.08553** : lien étiqueté « Temporal Planning Survey » dans Planners-8 c45 → pointe vers *Exploring Cybersecurity Issues in 5G Enabled Electric Vehicle Charging Station with Deep Learning* (Basnet & Ali) — aucun rapport |
| MAUVAISE-ATTRIBUTION (titre) | 1 | **2606.23179** dans EML-NAND-Compose c0 : titre cité « Electromagnetic Logic: A Continuous Computational Substrate for Symbolic Reasoning » **n'a jamais existé** — vérifié firsthand via `id_list=2606.23179v1` : v1 portait déjà « EML Trees Are Universal Approximators » (auteurs Germany/Abdo/Bakarji correctement cités dans le sibling EML-NAND-Explore) |
| ID-FANTÔME | 0 | 15/15 retournés par l'API |

## Corrections (2 lignes, markdown seul)

1. `Planners/03-Advanced/Planners-8-Temporal.ipynb` c45 — le lien faussement étiqueté remplacé par le **vrai fondement arXiv de la planification temporelle** : PDDL2.1 (M. Fox, D. Long, arXiv:1106.4561, JAIR 2003 / repost arXiv 2011) — aucun survey arXiv canonique de temporal planning n'existe (recherches `all:"temporal planning" AND all:"survey"` et `ti:"temporal planning"` épuisées), donc ancrage sur le papier fondateur plutôt qu'un label mensonger.
2. `SymbolicLearning/_archive/2026-07-04-Neurosymbolic-EML-precurseur-SL12/EML-NAND-Compose.ipynb` c0 — titre quoted remplacé par le titre réel « EML Trees Are Universal Approximators ».

## Liste des 13 OK (pour ne pas re-vérifier)

0807.3286 (Conway/Kochen) · 1406.3399 (Hartig) · 1711.04574 (Evans/Grefenstette ×3) · 1808.02923 (Piccirillo ×4) · 1810.08473 (Leiden) · 1907.00847 (Hao Huang) · 2210.08277 (Petersen ×3) · 2306.15626 (LeanDojo) · 2404.12534 (Lean Copilot, Song/Yang/Anandkumar ×5) · 2404.16130 (GraphRAG Edge) · 2505.05758 (APOLLO ×3) · 2510.01346 (Aristotle ×8) · 2606.12431 (Lidman ×6)

## Validation

- Éditions **markdown uniquement** → outputs précédents valides (exception C.2), pas de re-exécution requise.
- Assertions `count == 1` sur texte brut : 2/2. `git diff` : 2 insertions / 2 délétions. JSON valide après édition.
- Les 2 IDs corrigés re-vérifiés firsthand (1106.4561 auteurs Fox/Long confirmés ; 2606.23179v1 title confirmé).
- Catalogue non touché.