### PR TITLE
fix(tooling,#11164): batch_reexecute --timeout -> --execution-timeout + coherent seconds contract

### DIFF
--- a/scripts/notebook_tools/batch_reexecute.py
+++ b/scripts/notebook_tools/batch_reexecute.py
@@ -90,14 +90,14 @@ def execute_notebook(nb_path: Path, kernel: str, timeout: int) -> dict:
             sys.executable, "-m", "papermill",
             str(nb_path), str(nb_path),
             "--kernel", kernel,
-            "--timeout", str(timeout * 60),  # papermill uses seconds
+            "--execution-timeout", str(timeout),  # per-cell budget, seconds
         ]
 
         result = subprocess.run(
             cmd,
             capture_output=True,
             text=True,
-            timeout=timeout * 60 + 60,  # extra buffer
+            timeout=timeout + 60,  # extra buffer for papermill + kernel startup
             cwd=str(REPO_ROOT),
         )
 


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: MED/probas 11192

Closes #11164

## Defect (vérifié firsthand)

`scripts/notebook_tools/batch_reexecute.py:93` passait `--timeout` à la CLI papermill — option inexistante. **Toute** exécution du script échouait au parsing d'arguments (le flag est passé inconditionnellement, pas seulement pour les timeouts non-défaut, comme le suggérait le corps de l'issue).

Second défaut enchevêtré : les lignes 93/100 multipliaient par 60 alors que le contrat documenté du script est « **Per-notebook timeout in seconds** (default: 300) » (docstring l.13 + argparse l.141). Un simple rename du flag aurait livré un timeout 60× trop grand silencieusement.

## Fix (2 lignes)

- `"--timeout", str(timeout * 60)` → `"--execution-timeout", str(timeout)` — budget par cellule en secondes, conforme au contrat documenté.
- subprocess kill `timeout * 60 + 60` → `timeout + 60` — budget total du notebook + 60 s de buffer papermill + démarrage kernel.

## Validation (3 couches, réelles)

1. **Repro du bug** : `python -m papermill … --timeout 60` → `Error: No such option '--timeout'. (Did you mean one of: '--execution-timeout', '--start-timeout'…)` — exactement le repro de l'issue.
2. **Nouveau flag** : `--execution-timeout 60` sur un notebook temporaire → exécuté `1/1 [00:02<…]`.
3. **Script complet end-to-end** : `python batch_reexecute.py --path <nb temp> --timeout 60` → `Success: 1 / Failed: 0 / Timeout: 0 / Error: 0` (avant le fix, cette invocation exacte retournait FAILED « unrecognized arguments » et restaurait le backup).

Notebooks temporaires nettoyés, arbre propre (seul le script est modifié).

## Sweep même-classe (aucun autre cas)

Les autres `"--timeout"` du dépôt ciblent les CLIs de leurs propres wrappers, pas papermill direct : `smoke_test_epita_is.py` → CLI de `wsl_papermill.py` ; `quantbooks_stop_repair_pipeline.py` → CLI de `qc_quantbook_execute.py`. `wsl_papermill.py` lui-même n'utilise `--timeout` que comme budget `subprocess.run` (jamais passé à papermill — design différent, fonctionnel). Défaut confiné à `batch_reexecute.py`.
