### PR TITLE
fix(ict,#4588): chain-shift -1 residuel ICT-15i — conclusion cell[20] + savefig cell[2]

### DIFF
--- a/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15i-Bridge1bis-2DLandscape.ipynb
+++ b/MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15i-Bridge1bis-2DLandscape.ipynb
@@ -137,7 +137,7 @@
     "ax.set_title(f\"$V(x,y)=a x^4 - b x^2 + d y^2$   (a={a}, b={b}, d={d})\")\n",
     "fig.colorbar(cf, ax=ax, label='V')\n",
     "fig.tight_layout()\n",
-    "plt.savefig(\"ict_15h_landscape2d.png\", dpi=110)\n",
+    "plt.savefig(\"ict_15i_landscape2d.png\", dpi=110)\n",
     "plt.show()\n",
     "print(\"Minima :\", [t for _xy, t in eqs if t == 'minimum'],\n",
     "      \"| Selle :\", [t for _xy, t in eqs if t == 'saddle'])\n"
@@ -768,7 +768,7 @@
     "## Conclusion\n",
     "\n",
     "Le chantier 3/3 clot l'Epic #9531. Les trois regimes -- symetrique 1D (15f),\n",
-    "asymetrique 1D (15g) et anisotrope 2D (15h) -- convergent vers le meme verdict :\n",
+    "asymetrique 1D (15h) et anisotrope 2D (15i) -- convergent vers le meme verdict :\n",
     "\n",
     "> **Sur une famille de substrats ou la courbure locale $\\sigma$ varie\n",
     "> independamment de la largeur du puits, aucun resume scalaire de $\\sigma$ (en 1D\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #11205

## Summary

Fix du chain-shift -1 residuel (#10688) sur `ICT-15i-Bridge1bis-2DLandscape.ipynb` (issue #11203) : le notebook chantier 3/3 referencait encore les numeros des chantiers 1/3 et 2/3.

1. **cell[2] (code)** : `plt.savefig("ict_15h_landscape2d.png", dpi=110)` -> `ict_15i_landscape2d.png` (le paysage 2D anisotrope appartient au chantier 3/3, pas au 2/3).
2. **cell[20] (markdown, Conclusion)** : `symetrique 1D (15f), asymetrique 1D (15g) et anisotrope 2D (15h)` -> `(15f), (15h) et (15i)` (shift de -1 corrige : le 2/3 est `ICT-15h`, le 3/3 est `ICT-15i` ; `ICT-15g` = EmpiricalHuangExploitation, hors serie).

## Preuve de fermeture de classe — grep exhaustif `15[f-i]`

Script python sur les **deux** notebooks (worktree, source + tous les champs) :

```
ICT-15i-Bridge1bis-2DLandscape.ipynb
  cell[0]  markdown 15i : titre (# ICT-15i ...)                      -> CORRECT
  cell[0]  markdown 15f : chantier 1/3 (`ICT-15f`, double-puits symetrique 1D) -> CORRECT
  cell[0]  markdown 15h : chantier 2/3 (`ICT-15h`, double-puits asymetrique 1D) -> CORRECT
  cell[2]  code     15h : savefig("ict_15h_landscape2d.png")         -> FIXE (ict_15i)
  cell[20] markdown 15f : symetrique 1D (15f)                        -> CORRECT
  cell[20] markdown 15g : asymetrique 1D (15g)                       -> FIXE (15h)
  cell[20] markdown 15h : anisotrope 2D (15h)                        -> FIXE (15i)

ICT-15h-Bridge1bis-AsymmetricFamily.ipynb
  cell[0]  markdown 15h : titre (# ICT-15h ...)                      -> CORRECT
  cell[0]  markdown 15f : chantier 1/3 (`ICT-15f-Bridge1bis-DecoupledFamily`) -> CORRECT
  (aucune occurrence 15g / 15i)
```

Verdict : **2 defauts (fixes appliques), 0 residuel**. `ICT-15g` ne designe plus aucun chantier de la serie Pont #1-bis dans les deux notebooks.

## Validation

- **Re-execution C.2** : notebook re-execute en entier (`nbconvert --execute`, kernel python3, cwd `ICT-Series/` pour `import ict`). 9 cellules code : **0 erreur, 0 execution_count null**, outputs reels committes.
- **Sortie reelle** : `plt.savefig` ecrit desormais `ict_15i_landscape2d.png` (image non trackee, generee a l'execution — aucun lien committe a renommer).
- **H.3 / pre-commit** : execution_counts presents.
- **Catalogue** : byte-identique a main (aucune regen).

## Files

- `MyIA.AI.Notebooks/IIT/ICT-Series/ICT-15i-Bridge1bis-2DLandscape.ipynb` (+3/-3) — 2 lignes source corrigees + newline EOF

See #4588
See #9531
See #11203
