### PR TITLE
feat(lean,#11148): mimo_lean Phase 4 — Bridge.lean (cost identity + converse fragment P(flip))

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Bridge.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Bridge.lean
@@ -1,0 +1,345 @@
+import Mathlib
+import Objective
+import Converse
+
+/-!
+# Phase 4 — Pont (Bridge) : identité de coût + fragment de converse connecté au ML
+
+Ce module relie l'objectif ML (`mimoObj`, Phase 2) aux briques probabilistes
+de la converse (Phase 3b) — le chantier « grains à grignoter » de l'issue
+#11148 (suite de #10984). Le converse actuel borne la probabilité d'un
+événement d'échappement abstrait ; ici, pour la première fois, un énoncé du
+lac relie directement l'objectif au bruit gaussien.
+
+Architecture du fichier :
+
+## Grain 1a — identité de différence de coût (algèbre pure)
+
+1. `cost_diff` — la forme **générique** : dans tout espace de Hilbert réel,
+   `‖w + √s•z + √s•v‖² − ‖w + √s•z‖² = s·‖v‖² + 2√s·⟪w,v⟫ + 2s·⟪z,v⟫`.
+   C'est `norm_add_sq_two` (Phase 2) réarrangé : passer de `z` à `z + v`
+   coûte un terme quadratique en `v` et deux couplages linéaires — l'un au
+   bruit `w`, l'autre à la position courante `z` ;
+2. `mimoObj_sub_mimoObj` — **Pont 1a** : instancié au canal MIMO,
+   `mimoObj A w s u' − mimoObj A w s u = s·‖A v‖² + 2√s·⟪A v,w⟫ + 2s·⟪A v,A u⟫`
+   avec `v = u' − u` — l'identité de différence de coût pour **deux
+   configurations quelconques** `u, u'` ;
+3. `mimoObj_residual_from_zero` — spécialisation **point de départ = vérité**
+   (`u = 0`, le résidu est `w`) : `Δ = s·‖A v‖² + 2√s·⟪A v,w⟫` — le terme
+   couplé à la position courante disparaît ;
+4. `mimo_flip_cost_via_bridge` — **vérification de cohérence** : avec
+   `v = flipAt i`, le Bridge redonne exactement le Lemme 11.1
+   (`Δ = 4·(s‖hᵢ‖² + √s·⟪hᵢ,w⟫)`, `hᵢ = A eᵢ`) — le Lemme 11.1 devient
+   corollaire du Bridge, qui le généralise.
+
+## Grain 1b — fragment de converse concret (connecté au ML)
+
+5. `stdGaussianPi_map_toLp` — **pont de conventions** : la gaussienne produit
+   du lake SLT (`stdGaussianPi`, sur `Fin n → ℝ`) poussée par `toLp 2` est
+   la gaussienne standard de Mathlib sur l'espace euclidien
+   (`map_pi_eq_stdGaussian`) ;
+6. `map_inner_stdGaussian` — **transport** : pour `w` gaussien standard sur
+   l'espace euclidien, la fonctionnelle linéaire `⟪h, w⟫` a pour loi
+   `gaussianReal 0 ‖h‖²`. C'est le morceau techniquement ouvert signalé dans
+   #11148, fermé ici par l'API `IsGaussian` de Mathlib (toute forme linéaire
+   continue d'une gaussienne est gaussienne de variance `‖L‖²`) ;
+7. `flip_bat_prob_lower` — **premier énoncé du type « P(le flip bat) ≥ c »** :
+   si `√s·‖hᵢ‖ ≤ 2` (et `s > 0`, `hᵢ ≠ 0` — voir docstring), alors
+   `P(w : le flip i bat x*) ≥ (2 − √s·‖hᵢ‖)·φ(2)` où
+   `φ(2) = exp(−2)/√(2π)` — via le transport (`⟪hᵢ,w⟫ ~ N(0,‖hᵢ‖²)`, l'événement
+   « bat » est `⟪hᵢ,w⟫ < −√s·‖hᵢ‖²`) et la **Brique 1**
+   (`gaussian_interval_mass_lower`, Phase 3b) : l'intervalle
+   `[−2, −√s·‖hᵢ‖] ⊆ [−2,2]` de largeur `2 − √s·‖hᵢ‖` porte une masse
+   `≥ largeur · φ(2)`.
+-/
+
+namespace Mimo
+
+open MeasureTheory ProbabilityTheory GaussianMeasure HansonWright Real
+open InnerProductSpace
+open scoped BigOperators NNReal
+
+section Geometrie
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- **Identité de différence de coût (forme générique).** Pour un bruit `w`,
+une position courante `z`, une déviation `v` et un SNR `s ≥ 0`,
+
+    ‖w + √s•z + √s•v‖² − ‖w + √s•z‖² = s·‖v‖² + 2√s·⟪w, v⟫_ℝ + 2s·⟪z, v⟫_ℝ.
+
+Dérivée de `norm_add_sq_two` (Phase 2) : le déplacement `z ↦ z + v` coûte
+un terme quadratique en `v` plus deux couplages linéaires — `2√s·⟪w,v⟫` par
+le bruit, `2s·⟪z,v⟫` par la position courante (ce dernier s'annule au résidu
+nul, cf `mimoObj_residual_from_zero`). -/
+theorem cost_diff (w z v : E) {s : ℝ} (hs : 0 ≤ s) :
+    ‖w + √s • z + √s • v‖ ^ 2 - ‖w + √s • z‖ ^ 2
+      = s * ‖v‖ ^ 2 + 2 * √s * ⟪w, v⟫_ℝ + 2 * s * ⟪z, v⟫_ℝ := by
+  have key := norm_add_sq_two (w + √s • z) (√s • v)
+  rw [real_inner_smul_right, inner_add_left, real_inner_smul_left,
+    norm_smul, Real.norm_eq_abs, abs_of_nonneg (Real.sqrt_nonneg s),
+    mul_pow, Real.sq_sqrt hs] at key
+  have hss : √s * √s = s := by rw [← sq]; exact Real.sq_sqrt hs
+  rw [key]
+  linear_combination (norm := ring_nf) (2 * ⟪z, v⟫_ℝ) * hss
+
+end Geometrie
+
+section Pont
+
+variable {N M : ℕ}
+
+/-- **Pont 1a — identité de différence de coût MIMO.** Pour toutes
+configurations `u, u'` et `v = u' − u` :
+
+    mimoObj A w s u' − mimoObj A w s u
+      = s·‖A v‖² + 2√s·⟪A v, w⟫_ℝ + 2s·⟪A v, A u⟫_ℝ.
+
+Le Bridge généralise le Lemme 11.1 (`mimo_flip_cost`, Phase 2), qui n'est
+plus que le cas particulier `u = 0`, `v = flipAt i` (cf
+`mimo_flip_cost_via_bridge`). -/
+theorem mimoObj_sub_mimoObj (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M))
+    (w : EuclideanSpace ℝ (Fin M)) {s : ℝ} (hs : 0 ≤ s) (u u' : Fin N → ℝ) :
+    mimoObj A w s u' - mimoObj A w s u
+      = s * ‖A (u' - u)‖ ^ 2 + 2 * √s * ⟪A (u' - u), w⟫_ℝ
+        + 2 * s * ⟪A (u' - u), A u⟫_ℝ := by
+  have hA : A u' = A u + A (u' - u) := by
+    rw [← LinearMap.map_add A u (u' - u)]
+    congr
+    abel
+  have hsmul : √s • A u' = √s • A u + √s • A (u' - u) := by
+    rw [hA, smul_add]
+  have hcd := cost_diff w (A u) (A (u' - u)) hs
+  rw [real_inner_comm (A (u' - u)) w, real_inner_comm (A (u' - u)) (A u)] at hcd
+  show ‖w + √s • A u'‖ ^ 2 - ‖w + √s • A u‖ ^ 2 = _
+  rw [hsmul]
+  simpa [add_assoc] using hcd
+
+/-- **Spécialisation point de départ = vérité.** Partant de `u = 0` (la
+configuration courante est déjà `x*`, seul le résidu `w` reste), le coût
+d'une déviation `v` est
+
+    mimoObj A w s v − mimoObj A w s 0 = s·‖A v‖² + 2√s·⟪A v, w⟫_ℝ.
+
+Le terme `2s·⟪A v, A u⟫` disparaît : à l'origine, seule la corrélation avec
+le bruit discrimine les configurations. -/
+theorem mimoObj_residual_from_zero (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M))
+    (w : EuclideanSpace ℝ (Fin M)) {s : ℝ} (hs : 0 ≤ s) (v : Fin N → ℝ) :
+    mimoObj A w s v - mimoObj A w s 0
+      = s * ‖A v‖ ^ 2 + 2 * √s * ⟪A v, w⟫_ℝ := by
+  have h := mimoObj_sub_mimoObj A w hs 0 v
+  simpa [LinearMap.map_zero] using h
+
+/-- **Cohérence : Lemme 11.1 en corollaire du Bridge.** Avec `v = flipAt i`,
+l'identité ci-dessus redonne exactement `mimo_flip_cost` (Phase 2) :
+
+    mimoObj A w s (flipAt i) − mimoObj A w s 0
+      = 4·(s·‖hᵢ‖² + √s·⟪hᵢ, w⟫_ℝ),   hᵢ = A eᵢ.
+
+Le Bridge est donc une vraie généralisation du Lemme 11.1, pas un énoncé
+parallèle : le flip est le cas `u = 0` de l'identité générale. -/
+theorem mimo_flip_cost_via_bridge (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M))
+    (w : EuclideanSpace ℝ (Fin M)) {s : ℝ} (hs : 0 ≤ s) (i : Fin N) :
+    mimoObj A w s (flipAt i) - mimoObj A w s 0
+      = 4 * (s * ‖A (Pi.single i 1)‖ ^ 2
+             + √s * ⟪A (Pi.single i 1), w⟫_ℝ) := by
+  have h := mimoObj_residual_from_zero A w hs (flipAt i)
+  have hA : A (flipAt i) = (2 : ℝ) • A (Pi.single i 1) := by
+    rw [flipAt]
+    exact LinearMap.map_smul A 2 _
+  rw [hA, norm_smul, Real.norm_eq_abs, mul_pow, sq_abs, real_inner_smul_left] at h
+  ring_nf at h ⊢
+  exact h
+
+end Pont
+
+section Converse
+
+variable {N M : ℕ}
+
+/-- **Pont de conventions.** La gaussienne produit du lake SLT
+(`stdGaussianPi`, mesure sur `Fin n → ℝ`) poussée par l'identification
+`toLp 2` est exactement la gaussienne standard de Mathlib sur l'espace
+euclidien — instance directe de `map_pi_eq_stdGaussian`. Le fragment converse
+ci-dessous vit côté Mathlib (même convention que la Phase 3a, `Lmmse`) ;
+ce pont ramène l'énoncé à la convention produit du lake SLT. -/
+lemma stdGaussianPi_map_toLp :
+    (stdGaussianPi M).map (WithLp.toLp 2) = stdGaussian (EuclideanSpace ℝ (Fin M)) :=
+  map_pi_eq_stdGaussian
+
+/-- **Transport de la fonctionnelle linéaire.** Pour `w` gaussien standard
+sur l'espace euclidien (Mathlib `stdGaussian`, image de `stdGaussianPi` par
+`toLp 2` — cf `stdGaussianPi_map_toLp`), la forme linéaire `⟪h, w⟫` a pour
+loi `gaussianReal 0 ‖h‖²`. C'est le morceau techniquement ouvert signalé dans
+#11148, fermé ici en une étape par l'API `IsGaussian` de Mathlib : toute forme
+linéaire continue d'une gaussienne est gaussienne, de moyenne `μ[L] = 0`
+(`integral_strongDual_stdGaussian`) et de variance `Var[L; μ] = ‖L‖²`
+(`variance_dual_stdGaussian`) ; la forme `w ↦ ⟪h, w⟫` est `innerSL ℝ h`, de
+norme `‖h‖` (`innerSL_apply_norm`). -/
+lemma map_inner_stdGaussian (h : EuclideanSpace ℝ (Fin M)) :
+    Measure.map (fun w : EuclideanSpace ℝ (Fin M) => ⟪h, w⟫_ℝ)
+      (stdGaussian (EuclideanSpace ℝ (Fin M)))
+      = gaussianReal 0 ((‖h‖ ^ 2).toNNReal) := by
+  have hmap := (isGaussian_stdGaussian (E := EuclideanSpace ℝ (Fin M)) :
+    IsGaussian _).map_eq_gaussianReal (L := innerSL ℝ h)
+  rw [integral_strongDual_stdGaussian (E := EuclideanSpace ℝ (Fin M))
+      (L := innerSL ℝ h),
+    variance_dual_stdGaussian (E := EuclideanSpace ℝ (Fin M)) (L := innerSL ℝ h),
+    innerSL_apply_norm] at hmap
+  simpa [innerSL_apply_apply] using hmap
+
+/-- **Variante ouverte de la Brique 1.** Tout intervalle **ouvert** inclus dans
+`[−2, 2]` porte une masse gaussienne `≥ largeur · φ(2)`. La Brique 1 de la
+Phase 3b énonce ce résultat pour `Ioc a b` ; le fragment converse du Bridge
+a besoin d'un intervalle strictement contenu dans l'événement `y < c`, donc
+d'un `Ioo a b` (l'extrémité droite d'un `Ioc` n'est pas dans `Iio`). Même
+preuve que `gaussian_interval_mass_lower`, avec `volume_Ioo`. -/
+theorem gaussian_interval_mass_lower_open {a b : ℝ} (hab : a ≤ b)
+    (ha : |a| ≤ 2) (hb : |b| ≤ 2) :
+    (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤
+      (gaussianReal 0 1 (Set.Ioo a b)).toReal := by
+  have hk : 0 ≤ Real.exp (-2) / Real.sqrt (2 * Real.pi) := by positivity
+  have hmeasure : gaussianReal 0 1 (Set.Ioo a b) =
+      ∫⁻ x in Set.Ioo a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := by
+    rw [gaussianReal_of_var_ne_zero 0 one_ne_zero,
+      withDensity_apply _ measurableSet_Ioo]
+    rfl
+  have hsplit : ∀ x ∈ Set.Ioo (a : ℝ) b, |x| ≤ 2 := by
+    intro x hx
+    rw [abs_le]
+    constructor <;> nlinarith [(abs_le.mp ha).1, (abs_le.mp ha).2,
+      (abs_le.mp hb).1, (abs_le.mp hb).2, hx.1.le, hx.2.le]
+  have hpoint : ∀ x, (Set.Ioo a b).indicator (fun _ => ENNReal.ofReal
+      (Real.exp (-2) / Real.sqrt (2 * Real.pi))) x ≤
+      (Set.Ioo a b).indicator (fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x)) x := by
+    intro x
+    by_cases hx : x ∈ Set.Ioo a b
+    · simp only [Set.indicator_of_mem hx]
+      exact ENNReal.ofReal_le_ofReal (gaussianPDFReal_lower_two x (hsplit x hx))
+    · rw [Set.indicator_apply, if_neg hx, Set.indicator_apply, if_neg hx]
+  have hmono : (∫⁻ _x in Set.Ioo a b,
+        ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi)) ∂volume) ≤
+      ∫⁻ x in Set.Ioo a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := by
+    rw [← lintegral_indicator measurableSet_Ioo
+        (fun _ => ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi))),
+      ← lintegral_indicator measurableSet_Ioo
+        (fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x))]
+    exact lintegral_mono hpoint
+  have hchain : ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi))) ≤
+      gaussianReal 0 1 (Set.Ioo a b) := by
+    rw [hmeasure]
+    calc ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)))
+        = ∫⁻ _x in Set.Ioo a b,
+            ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi)) ∂volume := by
+          rw [setLIntegral_const, Real.volume_Ioo,
+            ← ENNReal.ofReal_mul (by nlinarith [hab, hk]), mul_comm]
+      _ ≤ ∫⁻ x in Set.Ioo a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := hmono
+  have hnn : 0 ≤ (b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)) := by
+    nlinarith [hab, hk]
+  have hlhs : (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) =
+      (ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)))).toReal := by
+    rw [ENNReal.toReal_ofReal hnn]
+    ring
+  rw [hlhs]
+  exact (ENNReal.toReal_le_toReal ENNReal.ofReal_ne_top (measure_ne_top _ _)).mpr hchain
+
+/-- **Premier énoncé du type « P(le flip bat x*) ≥ c ».** Soit `hᵢ = A eᵢ`. Si
+`√s·‖hᵢ‖ ≤ 2` (avec `s > 0` et `‖hᵢ‖ > 0` — deux hypothèses absentes de
+l'énoncé de l'issue #11148, mais nécessaires : pour `s = 0` ou `‖hᵢ‖ = 0`
+l'événement a probabilité `0` alors que la borne `(2 − √s‖hᵢ‖)·φ(2)` est
+strictement positive), alors
+
+    P(w : le flip i bat x*) ≥ (2 − √s·‖hᵢ‖)·φ(2)
+
+où `φ(2) = exp(−2)/√(2π)`. Enchaînement : le coût d'un flip
+(`mimo_flip_cost_via_bridge`) montre que l'événement « bat » est
+`⟪hᵢ, w⟫ < −√s·‖hᵢ‖²` ; le transport (`map_inner_stdGaussian`) donne la loi
+`⟪hᵢ, w⟫ ~ N(0, ‖hᵢ‖²)` ; la mise à l'échelle ramène à `N(0,1)` et l'intervalle
+`(−2, −√s·‖hᵢ‖) ⊆ {y < −√s·‖hᵢ‖}` porte la masse `≥ (2 − √s·‖hᵢ‖)·φ(2)`
+(variante ouverte de la Brique 1). -/
+theorem flip_bat_prob_lower (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M))
+    {s : ℝ} (hs : 0 < s) (i : Fin N) (hσ : 0 < ‖A (Pi.single i 1)‖)
+    (hbound : √s * ‖A (Pi.single i 1)‖ ≤ 2) :
+    (2 - √s * ‖A (Pi.single i 1)‖) * Real.exp (-2) / Real.sqrt (2 * Real.pi)
+      ≤ (stdGaussian (EuclideanSpace ℝ (Fin M))
+          {w : EuclideanSpace ℝ (Fin M) | mimoObj A w s (flipAt i) < mimoObj A w s 0}).toReal := by
+  set hᵢ : EuclideanSpace ℝ (Fin M) := A (Pi.single i 1) with hhᵢ
+  have hsqrt : 0 < √s := by positivity
+  have hss : √s * √s = s := by rw [← sq]; exact Real.sq_sqrt hs.le
+  have hmono : √s * (-√s * ‖hᵢ‖ ^ 2) = -s * ‖hᵢ‖ ^ 2 := by
+    linear_combination (norm := ring_nf) (-(‖hᵢ‖ ^ 2)) * hss
+  have hsqrt_nonneg : 0 ≤ √s * ‖hᵢ‖ := mul_nonneg (Real.sqrt_nonneg s) (norm_nonneg _)
+  have hev : {w : EuclideanSpace ℝ (Fin M) | mimoObj A w s (flipAt i) < mimoObj A w s 0}
+      = {w : EuclideanSpace ℝ (Fin M) | ⟪hᵢ, w⟫_ℝ < -√s * ‖hᵢ‖ ^ 2} := by
+    ext w
+    simp only [Set.mem_setOf_eq]
+    have hfc : mimoObj A w s (flipAt i) - mimoObj A w s 0
+        = 4 * (s * ‖hᵢ‖ ^ 2 + √s * ⟪hᵢ, w⟫_ℝ) := by
+      simpa [hhᵢ] using mimo_flip_cost_via_bridge A w hs.le i
+    constructor <;> intro hw
+    · rw [← sub_lt_zero, hfc] at hw
+      have hsum : s * ‖hᵢ‖ ^ 2 + √s * ⟪hᵢ, w⟫_ℝ < 0 := by
+        nlinarith [hw]
+      have hstep : √s * ⟪hᵢ, w⟫_ℝ < -s * ‖hᵢ‖ ^ 2 := by
+        linarith
+      have hbr : √s * ⟪hᵢ, w⟫_ℝ < √s * (-√s * ‖hᵢ‖ ^ 2) := by
+        rw [hmono]; exact hstep
+      exact lt_of_mul_lt_mul_left hbr hsqrt.le
+    · have hbr : √s * ⟪hᵢ, w⟫_ℝ < √s * (-√s * ‖hᵢ‖ ^ 2) :=
+        mul_lt_mul_of_pos_left hw hsqrt
+      rw [hmono] at hbr
+      have hsum : s * ‖hᵢ‖ ^ 2 + √s * ⟪hᵢ, w⟫_ℝ < 0 := by
+        linarith
+      rw [← sub_lt_zero, hfc]
+      linarith
+  have hmap := map_inner_stdGaussian hᵢ
+  have hmass : (stdGaussian (EuclideanSpace ℝ (Fin M)))
+      {w : EuclideanSpace ℝ (Fin M) | ⟪hᵢ, w⟫_ℝ < -√s * ‖hᵢ‖ ^ 2}
+      = (gaussianReal 0 ((‖hᵢ‖ ^ 2).toNNReal)) (Set.Iio (-√s * ‖hᵢ‖ ^ 2)) := by
+    rw [← hmap]
+    rw [Measure.map_apply (by fun_prop :
+        Measurable (fun w : EuclideanSpace ℝ (Fin M) => ⟪hᵢ, w⟫_ℝ)) measurableSet_Iio]
+    rfl
+  have hscale : Measure.map (fun z : ℝ => ‖hᵢ‖ * z) (gaussianReal 0 1)
+      = gaussianReal 0 ((‖hᵢ‖ ^ 2).toNNReal) := by
+    rw [gaussianReal_map_const_mul (μ := 0) (v := (1 : ℝ≥0)) ‖hᵢ‖]
+    simpa [Real.toNNReal_of_nonneg, sq_nonneg]
+  have hmass1 : (gaussianReal 0 ((‖hᵢ‖ ^ 2).toNNReal)) (Set.Iio (-√s * ‖hᵢ‖ ^ 2))
+      = (gaussianReal 0 1) (Set.Iio (-√s * ‖hᵢ‖)) := by
+    rw [← hscale]
+    rw [Measure.map_apply (by fun_prop : Measurable (fun z : ℝ => ‖hᵢ‖ * z))
+      measurableSet_Iio]
+    congr 1
+    ext z
+    constructor <;> intro hz
+    · have hz' : ‖hᵢ‖ * z < ‖hᵢ‖ * (-√s * ‖hᵢ‖) := by
+        simpa [mul_comm, mul_left_comm, mul_assoc, sq] using hz
+      exact lt_of_mul_lt_mul_left hz' (norm_nonneg _)
+    · have hz' : ‖hᵢ‖ * z < ‖hᵢ‖ * (-√s * ‖hᵢ‖) :=
+        mul_lt_mul_of_pos_left hz hσ
+      simpa [mul_comm, mul_left_comm, mul_assoc, sq] using hz'
+  have hab : -2 ≤ -√s * ‖hᵢ‖ := by nlinarith [hbound]
+  have hb' : |-√s * ‖hᵢ‖| ≤ 2 := by
+    rw [neg_mul, abs_of_nonpos (neg_nonpos.mpr hsqrt_nonneg)]
+    linarith
+  have hbrick := gaussian_interval_mass_lower_open (a := -2) (b := -√s * ‖hᵢ‖) hab
+    (by norm_num) hb'
+  have hsub : Set.Ioo (-2 : ℝ) (-√s * ‖hᵢ‖) ⊆ Set.Iio (-√s * ‖hᵢ‖) := by
+    intro y hy
+    exact hy.2
+  have hmassmono : (gaussianReal 0 1) (Set.Ioo (-2 : ℝ) (-√s * ‖hᵢ‖))
+      ≤ (gaussianReal 0 1) (Set.Iio (-√s * ‖hᵢ‖)) := by
+    exact measure_mono hsub
+  rw [hev, hmass, hmass1]
+  calc
+    (2 - √s * ‖hᵢ‖) * Real.exp (-2) / Real.sqrt (2 * Real.pi)
+        = ((-√s * ‖hᵢ‖) - (-2)) * Real.exp (-2) / Real.sqrt (2 * Real.pi) := by
+          ring
+    _ ≤ (gaussianReal 0 1 (Set.Ioo (-2) (-√s * ‖hᵢ‖))).toReal := hbrick
+    _ ≤ (gaussianReal 0 1 (Set.Iio (-√s * ‖hᵢ‖))).toReal := by
+        exact (ENNReal.toReal_le_toReal (measure_ne_top _ _)
+          (measure_ne_top _ _)).mpr hmassmono
+
+end Converse
+
+end Mimo

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Bridge_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Bridge_en.lean
@@ -1,0 +1,343 @@
+import Mathlib
+import Objective_en
+import Converse_en
+
+/-!
+# Phase 4 — Bridge: cost identity + a converse fragment wired to the ML objective
+
+This module ties the ML objective (`mimoObj`, Phase 2) to the probabilistic
+bricks of the converse (Phase 3b) — the "grains to nibble" work of issue
+#11148 (sequel of #10984). The current converse bounds the probability of an
+abstract escape event; here, for the first time, a statement of the lake
+relates the objective directly to Gaussian noise.
+
+Architecture of the file:
+
+## Grain 1a — cost-difference identity (pure algebra)
+
+1. `cost_diff` — the **generic** form: in any real Hilbert space,
+   `‖w + √s•z + √s•v‖² − ‖w + √s•z‖² = s·‖v‖² + 2√s·⟪w,v⟫ + 2s·⟪z,v⟫`.
+   This is `norm_add_sq_two` (Phase 2) rearranged: moving from `z` to `z + v`
+   costs a quadratic term in `v` and two linear couplings — one to the noise
+   `w`, one to the current position `z`;
+2. `mimoObj_sub_mimoObj` — **Bridge 1a**: instantiated on the MIMO channel,
+   `mimoObj A w s u' − mimoObj A w s u = s·‖A v‖² + 2√s·⟪A v,w⟫ + 2s·⟪A v,A u⟫`
+   with `v = u' − u` — the cost-difference identity for **any two
+   configurations** `u, u'`;
+3. `mimoObj_residual_from_zero` — specialization **start point = truth**
+   (`u = 0`, the residual is `w`): `Δ = s·‖A v‖² + 2√s·⟪A v,w⟫` — the term
+   coupled to the current position vanishes;
+4. `mimo_flip_cost_via_bridge` — **coherence check**: with `v = flipAt i`,
+   the Bridge reproduces exactly Lemma 11.1
+   (`Δ = 4·(s‖hᵢ‖² + √s·⟪hᵢ,w⟫)`, `hᵢ = A eᵢ`) — Lemma 11.1 becomes a
+   corollary of the Bridge, which generalizes it.
+
+## Grain 1b — a concrete converse fragment (wired to the ML)
+
+5. `stdGaussianPi_map_toLp` — **convention bridge**: the SLT-lake product
+   Gaussian (`stdGaussianPi`, on `Fin n → ℝ`) pushed by `toLp 2` is Mathlib's
+   standard Gaussian on the Euclidean space (`map_pi_eq_stdGaussian`);
+6. `map_inner_stdGaussian` — **transport**: for `w` standard Gaussian on the
+   Euclidean space, the linear functional `⟪h, w⟫` has law `gaussianReal 0
+   ‖h‖²`. This is the technically open piece flagged in #11148, closed here
+   through the `IsGaussian` API of Mathlib (every continuous linear form of a
+   Gaussian is Gaussian with variance `‖L‖²`);
+7. `flip_bat_prob_lower` — **first statement of the type "P(the flip wins) ≥ c"**:
+   if `√s·‖hᵢ‖ ≤ 2` (and `s > 0`, `hᵢ ≠ 0` — see docstring), then
+   `P(w : the flip i beats x*) ≥ (2 − √s·‖hᵢ‖)·φ(2)` where
+   `φ(2) = exp(−2)/√(2π)` — via the transport (`⟪hᵢ,w⟫ ~ N(0,‖hᵢ‖²)`, the
+   "beats" event is `⟪hᵢ,w⟫ < −√s·‖hᵢ‖²`) and **Brick 1**
+   (`gaussian_interval_mass_lower`, Phase 3b): the interval
+   `[−2, −√s·‖hᵢ‖] ⊆ [−2,2]` of width `2 − √s·‖hᵢ‖` carries mass
+   `≥ width · φ(2)`.
+-/
+
+namespace Mimo_en
+
+open MeasureTheory ProbabilityTheory GaussianMeasure HansonWright Real
+open InnerProductSpace
+open scoped BigOperators NNReal
+
+section Geometrie
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- **Cost-difference identity (generic form).** For a noise `w`, a current
+position `z`, a deviation `v` and an SNR `s ≥ 0`,
+
+    ‖w + √s•z + √s•v‖² − ‖w + √s•z‖² = s·‖v‖² + 2√s·⟪w, v⟫_ℝ + 2s·⟪z, v⟫_ℝ.
+
+Derived from `norm_add_sq_two` (Phase 2): the move `z ↦ z + v` costs a
+quadratic term in `v` plus two linear couplings — `2√s·⟪w,v⟫` through the
+noise, `2s·⟪z,v⟫` through the current position (the latter vanishes at the
+zero residual, cf `mimoObj_residual_from_zero`). -/
+theorem cost_diff (w z v : E) {s : ℝ} (hs : 0 ≤ s) :
+    ‖w + √s • z + √s • v‖ ^ 2 - ‖w + √s • z‖ ^ 2
+      = s * ‖v‖ ^ 2 + 2 * √s * ⟪w, v⟫_ℝ + 2 * s * ⟪z, v⟫_ℝ := by
+  have key := norm_add_sq_two (w + √s • z) (√s • v)
+  rw [real_inner_smul_right, inner_add_left, real_inner_smul_left,
+    norm_smul, Real.norm_eq_abs, abs_of_nonneg (Real.sqrt_nonneg s),
+    mul_pow, Real.sq_sqrt hs] at key
+  have hss : √s * √s = s := by rw [← sq]; exact Real.sq_sqrt hs
+  rw [key]
+  linear_combination (norm := ring_nf) (2 * ⟪z, v⟫_ℝ) * hss
+
+end Geometrie
+
+section Pont
+
+variable {N M : ℕ}
+
+/-- **Bridge 1a — MIMO cost-difference identity.** For all configurations
+`u, u'` and `v = u' − u`:
+
+    mimoObj A w s u' − mimoObj A w s u
+      = s·‖A v‖² + 2√s·⟪A v, w⟫_ℝ + 2s·⟪A v, A u⟫_ℝ.
+
+The Bridge generalizes Lemma 11.1 (`mimo_flip_cost`, Phase 2), which is only
+the special case `u = 0`, `v = flipAt i` (cf `mimo_flip_cost_via_bridge`). -/
+theorem mimoObj_sub_mimoObj (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M))
+    (w : EuclideanSpace ℝ (Fin M)) {s : ℝ} (hs : 0 ≤ s) (u u' : Fin N → ℝ) :
+    mimoObj A w s u' - mimoObj A w s u
+      = s * ‖A (u' - u)‖ ^ 2 + 2 * √s * ⟪A (u' - u), w⟫_ℝ
+        + 2 * s * ⟪A (u' - u), A u⟫_ℝ := by
+  have hA : A u' = A u + A (u' - u) := by
+    rw [← LinearMap.map_add A u (u' - u)]
+    congr
+    abel
+  have hsmul : √s • A u' = √s • A u + √s • A (u' - u) := by
+    rw [hA, smul_add]
+  have hcd := cost_diff w (A u) (A (u' - u)) hs
+  rw [real_inner_comm (A (u' - u)) w, real_inner_comm (A (u' - u)) (A u)] at hcd
+  show ‖w + √s • A u'‖ ^ 2 - ‖w + √s • A u‖ ^ 2 = _
+  rw [hsmul]
+  simpa [add_assoc] using hcd
+
+/-- **Specialization start point = truth.** Starting from `u = 0` (the current
+configuration is already `x*`, only the residual `w` remains), the cost of a
+deviation `v` is
+
+    mimoObj A w s v − mimoObj A w s 0 = s·‖A v‖² + 2√s·⟪A v, w⟫_ℝ.
+
+The term `2s·⟪A v, A u⟫` disappears: at the origin, only the correlation with
+the noise discriminates configurations. -/
+theorem mimoObj_residual_from_zero (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M))
+    (w : EuclideanSpace ℝ (Fin M)) {s : ℝ} (hs : 0 ≤ s) (v : Fin N → ℝ) :
+    mimoObj A w s v - mimoObj A w s 0
+      = s * ‖A v‖ ^ 2 + 2 * √s * ⟪A v, w⟫_ℝ := by
+  have h := mimoObj_sub_mimoObj A w hs 0 v
+  simpa [LinearMap.map_zero] using h
+
+/-- **Coherence: Lemma 11.1 as a corollary of the Bridge.** With `v = flipAt i`,
+the identity above reproduces exactly `mimo_flip_cost` (Phase 2):
+
+    mimoObj A w s (flipAt i) − mimoObj A w s 0
+      = 4·(s·‖hᵢ‖² + √s·⟪hᵢ, w⟫_ℝ),   hᵢ = A eᵢ.
+
+The Bridge is therefore a true generalization of Lemma 11.1, not a parallel
+statement: the flip is the case `u = 0` of the general identity. -/
+theorem mimo_flip_cost_via_bridge (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M))
+    (w : EuclideanSpace ℝ (Fin M)) {s : ℝ} (hs : 0 ≤ s) (i : Fin N) :
+    mimoObj A w s (flipAt i) - mimoObj A w s 0
+      = 4 * (s * ‖A (Pi.single i 1)‖ ^ 2
+             + √s * ⟪A (Pi.single i 1), w⟫_ℝ) := by
+  have h := mimoObj_residual_from_zero A w hs (flipAt i)
+  have hA : A (flipAt i) = (2 : ℝ) • A (Pi.single i 1) := by
+    rw [flipAt]
+    exact LinearMap.map_smul A 2 _
+  rw [hA, norm_smul, Real.norm_eq_abs, mul_pow, sq_abs, real_inner_smul_left] at h
+  ring_nf at h ⊢
+  exact h
+
+end Pont
+
+section Converse
+
+variable {N M : ℕ}
+
+/-- **Convention bridge.** The SLT-lake product Gaussian (`stdGaussianPi`,
+a measure on `Fin n → ℝ`) pushed by the identification `toLp 2` is exactly
+Mathlib's standard Gaussian on the Euclidean space — direct instance of
+`map_pi_eq_stdGaussian`. The converse fragment below lives on the Mathlib
+side (same convention as Phase 3a, `Lmmse`); this bridge pulls the statement
+back to the SLT-lake product convention. -/
+lemma stdGaussianPi_map_toLp :
+    (stdGaussianPi M).map (WithLp.toLp 2) = stdGaussian (EuclideanSpace ℝ (Fin M)) :=
+  map_pi_eq_stdGaussian
+
+/-- **Transport of the linear functional.** For `w` standard Gaussian on the
+Euclidean space (Mathlib `stdGaussian`, image of `stdGaussianPi` under
+`toLp 2` — cf `stdGaussianPi_map_toLp`), the linear form `⟪h, w⟫` has law
+`gaussianReal 0 ‖h‖²`. This is the technically open piece flagged in #11148,
+closed here in one step through the `IsGaussian` API of Mathlib: every
+continuous linear form of a Gaussian is Gaussian, with mean `μ[L] = 0`
+(`integral_strongDual_stdGaussian`) and variance `Var[L; μ] = ‖L‖²`
+(`variance_dual_stdGaussian`); the form `w ↦ ⟪h, w⟫` is `innerSL ℝ h`, with
+norm `‖h‖` (`innerSL_apply_norm`). -/
+lemma map_inner_stdGaussian (h : EuclideanSpace ℝ (Fin M)) :
+    Measure.map (fun w : EuclideanSpace ℝ (Fin M) => ⟪h, w⟫_ℝ)
+      (stdGaussian (EuclideanSpace ℝ (Fin M)))
+      = gaussianReal 0 ((‖h‖ ^ 2).toNNReal) := by
+  have hmap := (isGaussian_stdGaussian (E := EuclideanSpace ℝ (Fin M)) :
+    IsGaussian _).map_eq_gaussianReal (L := innerSL ℝ h)
+  rw [integral_strongDual_stdGaussian (E := EuclideanSpace ℝ (Fin M))
+      (L := innerSL ℝ h),
+    variance_dual_stdGaussian (E := EuclideanSpace ℝ (Fin M)) (L := innerSL ℝ h),
+    innerSL_apply_norm] at hmap
+  simpa [innerSL_apply_apply] using hmap
+
+/-- **Open variant of Brick 1.** Any **open** interval contained in `[−2, 2]`
+carries Gaussian mass `≥ width · φ(2)`. Brick 1 of Phase 3b states this for
+`Ioc a b`; the converse fragment of the Bridge needs an interval strictly
+contained in the event `y < c`, hence an `Ioo a b` (the right endpoint of an
+`Ioc` is not in `Iio`). Same proof as `gaussian_interval_mass_lower`, with
+`volume_Ioo`. -/
+theorem gaussian_interval_mass_lower_open {a b : ℝ} (hab : a ≤ b)
+    (ha : |a| ≤ 2) (hb : |b| ≤ 2) :
+    (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤
+      (gaussianReal 0 1 (Set.Ioo a b)).toReal := by
+  have hk : 0 ≤ Real.exp (-2) / Real.sqrt (2 * Real.pi) := by positivity
+  have hmeasure : gaussianReal 0 1 (Set.Ioo a b) =
+      ∫⁻ x in Set.Ioo a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := by
+    rw [gaussianReal_of_var_ne_zero 0 one_ne_zero,
+      withDensity_apply _ measurableSet_Ioo]
+    rfl
+  have hsplit : ∀ x ∈ Set.Ioo (a : ℝ) b, |x| ≤ 2 := by
+    intro x hx
+    rw [abs_le]
+    constructor <;> nlinarith [(abs_le.mp ha).1, (abs_le.mp ha).2,
+      (abs_le.mp hb).1, (abs_le.mp hb).2, hx.1.le, hx.2.le]
+  have hpoint : ∀ x, (Set.Ioo a b).indicator (fun _ => ENNReal.ofReal
+      (Real.exp (-2) / Real.sqrt (2 * Real.pi))) x ≤
+      (Set.Ioo a b).indicator (fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x)) x := by
+    intro x
+    by_cases hx : x ∈ Set.Ioo a b
+    · simp only [Set.indicator_of_mem hx]
+      exact ENNReal.ofReal_le_ofReal (gaussianPDFReal_lower_two x (hsplit x hx))
+    · rw [Set.indicator_apply, if_neg hx, Set.indicator_apply, if_neg hx]
+  have hmono : (∫⁻ _x in Set.Ioo a b,
+        ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi)) ∂volume) ≤
+      ∫⁻ x in Set.Ioo a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := by
+    rw [← lintegral_indicator measurableSet_Ioo
+        (fun _ => ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi))),
+      ← lintegral_indicator measurableSet_Ioo
+        (fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x))]
+    exact lintegral_mono hpoint
+  have hchain : ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi))) ≤
+      gaussianReal 0 1 (Set.Ioo a b) := by
+    rw [hmeasure]
+    calc ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)))
+        = ∫⁻ _x in Set.Ioo a b,
+            ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi)) ∂volume := by
+          rw [setLIntegral_const, Real.volume_Ioo,
+            ← ENNReal.ofReal_mul (by nlinarith [hab, hk]), mul_comm]
+      _ ≤ ∫⁻ x in Set.Ioo a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := hmono
+  have hnn : 0 ≤ (b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)) := by
+    nlinarith [hab, hk]
+  have hlhs : (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) =
+      (ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)))).toReal := by
+    rw [ENNReal.toReal_ofReal hnn]
+    ring
+  rw [hlhs]
+  exact (ENNReal.toReal_le_toReal ENNReal.ofReal_ne_top (measure_ne_top _ _)).mpr hchain
+
+/-- **First statement of the type "P(the flip wins) ≥ c".** Let `hᵢ = A eᵢ`. If
+`√s·‖hᵢ‖ ≤ 2` (with `s > 0` and `‖hᵢ‖ > 0` — two hypotheses absent from the
+statement of issue #11148 but necessary: for `s = 0` or `‖hᵢ‖ = 0` the event
+has probability `0` while the bound `(2 − √s‖hᵢ‖)·φ(2)` is strictly
+positive), then
+
+    P(w : the flip i beats x*) ≥ (2 − √s·‖hᵢ‖)·φ(2)
+
+where `φ(2) = exp(−2)/√(2π)`. Chain: the flip cost
+(`mimo_flip_cost_via_bridge`) shows the "beats" event is
+`⟪hᵢ, w⟫ < −√s·‖hᵢ‖²`; the transport (`map_inner_stdGaussian`) gives the
+law `⟪hᵢ, w⟫ ~ N(0, ‖hᵢ‖²)`; scaling back to `N(0,1)`, the interval
+`(−2, −√s·‖hᵢ‖) ⊆ {y < −√s·‖hᵢ‖}` carries mass `≥ (2 − √s·‖hᵢ‖)·φ(2)`
+(open variant of Brick 1). -/
+theorem flip_bat_prob_lower (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M))
+    {s : ℝ} (hs : 0 < s) (i : Fin N) (hσ : 0 < ‖A (Pi.single i 1)‖)
+    (hbound : √s * ‖A (Pi.single i 1)‖ ≤ 2) :
+    (2 - √s * ‖A (Pi.single i 1)‖) * Real.exp (-2) / Real.sqrt (2 * Real.pi)
+      ≤ (stdGaussian (EuclideanSpace ℝ (Fin M))
+          {w : EuclideanSpace ℝ (Fin M) | mimoObj A w s (flipAt i) < mimoObj A w s 0}).toReal := by
+  set hᵢ : EuclideanSpace ℝ (Fin M) := A (Pi.single i 1) with hhᵢ
+  have hsqrt : 0 < √s := by positivity
+  have hss : √s * √s = s := by rw [← sq]; exact Real.sq_sqrt hs.le
+  have hmono : √s * (-√s * ‖hᵢ‖ ^ 2) = -s * ‖hᵢ‖ ^ 2 := by
+    linear_combination (norm := ring_nf) (-(‖hᵢ‖ ^ 2)) * hss
+  have hsqrt_nonneg : 0 ≤ √s * ‖hᵢ‖ := mul_nonneg (Real.sqrt_nonneg s) (norm_nonneg _)
+  have hev : {w : EuclideanSpace ℝ (Fin M) | mimoObj A w s (flipAt i) < mimoObj A w s 0}
+      = {w : EuclideanSpace ℝ (Fin M) | ⟪hᵢ, w⟫_ℝ < -√s * ‖hᵢ‖ ^ 2} := by
+    ext w
+    simp only [Set.mem_setOf_eq]
+    have hfc : mimoObj A w s (flipAt i) - mimoObj A w s 0
+        = 4 * (s * ‖hᵢ‖ ^ 2 + √s * ⟪hᵢ, w⟫_ℝ) := by
+      simpa [hhᵢ] using mimo_flip_cost_via_bridge A w hs.le i
+    constructor <;> intro hw
+    · rw [← sub_lt_zero, hfc] at hw
+      have hsum : s * ‖hᵢ‖ ^ 2 + √s * ⟪hᵢ, w⟫_ℝ < 0 := by
+        nlinarith [hw]
+      have hstep : √s * ⟪hᵢ, w⟫_ℝ < -s * ‖hᵢ‖ ^ 2 := by
+        linarith
+      have hbr : √s * ⟪hᵢ, w⟫_ℝ < √s * (-√s * ‖hᵢ‖ ^ 2) := by
+        rw [hmono]; exact hstep
+      exact lt_of_mul_lt_mul_left hbr hsqrt.le
+    · have hbr : √s * ⟪hᵢ, w⟫_ℝ < √s * (-√s * ‖hᵢ‖ ^ 2) :=
+        mul_lt_mul_of_pos_left hw hsqrt
+      rw [hmono] at hbr
+      have hsum : s * ‖hᵢ‖ ^ 2 + √s * ⟪hᵢ, w⟫_ℝ < 0 := by
+        linarith
+      rw [← sub_lt_zero, hfc]
+      linarith
+  have hmap := map_inner_stdGaussian hᵢ
+  have hmass : (stdGaussian (EuclideanSpace ℝ (Fin M)))
+      {w : EuclideanSpace ℝ (Fin M) | ⟪hᵢ, w⟫_ℝ < -√s * ‖hᵢ‖ ^ 2}
+      = (gaussianReal 0 ((‖hᵢ‖ ^ 2).toNNReal)) (Set.Iio (-√s * ‖hᵢ‖ ^ 2)) := by
+    rw [← hmap]
+    rw [Measure.map_apply (by fun_prop :
+        Measurable (fun w : EuclideanSpace ℝ (Fin M) => ⟪hᵢ, w⟫_ℝ)) measurableSet_Iio]
+    rfl
+  have hscale : Measure.map (fun z : ℝ => ‖hᵢ‖ * z) (gaussianReal 0 1)
+      = gaussianReal 0 ((‖hᵢ‖ ^ 2).toNNReal) := by
+    rw [gaussianReal_map_const_mul (μ := 0) (v := (1 : ℝ≥0)) ‖hᵢ‖]
+    simpa [Real.toNNReal_of_nonneg, sq_nonneg]
+  have hmass1 : (gaussianReal 0 ((‖hᵢ‖ ^ 2).toNNReal)) (Set.Iio (-√s * ‖hᵢ‖ ^ 2))
+      = (gaussianReal 0 1) (Set.Iio (-√s * ‖hᵢ‖)) := by
+    rw [← hscale]
+    rw [Measure.map_apply (by fun_prop : Measurable (fun z : ℝ => ‖hᵢ‖ * z))
+      measurableSet_Iio]
+    congr 1
+    ext z
+    constructor <;> intro hz
+    · have hz' : ‖hᵢ‖ * z < ‖hᵢ‖ * (-√s * ‖hᵢ‖) := by
+        simpa [mul_comm, mul_left_comm, mul_assoc, sq] using hz
+      exact lt_of_mul_lt_mul_left hz' (norm_nonneg _)
+    · have hz' : ‖hᵢ‖ * z < ‖hᵢ‖ * (-√s * ‖hᵢ‖) :=
+        mul_lt_mul_of_pos_left hz hσ
+      simpa [mul_comm, mul_left_comm, mul_assoc, sq] using hz'
+  have hab : -2 ≤ -√s * ‖hᵢ‖ := by nlinarith [hbound]
+  have hb' : |-√s * ‖hᵢ‖| ≤ 2 := by
+    rw [neg_mul, abs_of_nonpos (neg_nonpos.mpr hsqrt_nonneg)]
+    linarith
+  have hbrick := gaussian_interval_mass_lower_open (a := -2) (b := -√s * ‖hᵢ‖) hab
+    (by norm_num) hb'
+  have hsub : Set.Ioo (-2 : ℝ) (-√s * ‖hᵢ‖) ⊆ Set.Iio (-√s * ‖hᵢ‖) := by
+    intro y hy
+    exact hy.2
+  have hmassmono : (gaussianReal 0 1) (Set.Ioo (-2 : ℝ) (-√s * ‖hᵢ‖))
+      ≤ (gaussianReal 0 1) (Set.Iio (-√s * ‖hᵢ‖)) := by
+    exact measure_mono hsub
+  rw [hev, hmass, hmass1]
+  calc
+    (2 - √s * ‖hᵢ‖) * Real.exp (-2) / Real.sqrt (2 * Real.pi)
+        = ((-√s * ‖hᵢ‖) - (-2)) * Real.exp (-2) / Real.sqrt (2 * Real.pi) := by
+          ring
+    _ ≤ (gaussianReal 0 1 (Set.Ioo (-2) (-√s * ‖hᵢ‖))).toReal := hbrick
+    _ ≤ (gaussianReal 0 1 (Set.Iio (-√s * ‖hᵢ‖))).toReal := by
+        exact (ENNReal.toReal_le_toReal (measure_ne_top _ _)
+          (measure_ne_top _ _)).mpr hmassmono
+
+end Converse
+
+end Mimo_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Converse.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Converse.lean
@@ -10,10 +10,13 @@ Ce module formalise les briques probabilistes du converse du seuil `2 log N`
 (papier Papailiopoulos 2026, §11 — cf issue #10984) : la récupération ML
 échoue sous `2 log N − log log N − s_N`. Les trois ingrédients du §11 sont :
 
-1. **Masse minimale d'un intervalle gaussien** (`gaussian_interval_mass_lower`) :
-   la densité `φ` est minorée par `exp(−2)/√(2π)` sur `[−2, 2]`, donc tout
-   intervalle inclus dans `[−2, 2]` porte une masse `≥ largeur · φ(2)`.
-   C'est le mécanisme des « intervalles gaussiens de largeur `1/√ρ₀` » du §11.
+1. **Masse minimale d'un intervalle gaussien** (`gaussian_interval_mass_lower_param`,
+   forme généralisée rayon `R` arbitraire ; `gaussian_interval_mass_lower` = cas
+   `R = 2`, `gaussian_interval_mass_lower_inv_sqrt` = forme papier `1/√ρ₀`) :
+   la densité `φ` est minorée par `exp(−R²/2)/√(2π)` sur `[−R, R]`
+   (`gaussianPDFReal_lower_abs`), donc tout intervalle inclus dans `[−R, R]`
+   porte une masse `≥ largeur · φ(R)`. C'est le mécanisme des « intervalles
+   gaussiens de largeur `1/√ρ₀` » du §11.
 2. **Union bound complémentaire** (`one_sub_pow_le_exp_mul`) : `(1−p)^n ≤ e^{−np}`
    (instance de Mathlib `one_sub_div_pow_le_exp_neg`).
 3. **Concentration Hanson–Wright** (`hanson_wright_noise`) : queues de la forme
@@ -34,79 +37,138 @@ namespace Mimo
 open MeasureTheory ProbabilityTheory GaussianMeasure HansonWright Real
 open scoped BigOperators NNReal
 
-/-! ## Brique 1 — masse minimale d'un intervalle gaussien -/
+/-! ## Brique 1 — masse minimale d'un intervalle gaussien
 
-/-- La densité gaussienne standard est minorée par `exp(−2)/√(2π)` sur `[−2, 2]`. -/
-lemma gaussianPDFReal_lower_two (x : ℝ) (hx : |x| ≤ 2) :
-    Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤ gaussianPDFReal 0 1 x := by
-  have h1 : -2 ≤ x := (abs_le.mp hx).1
-  have h2 : x ≤ 2 := (abs_le.mp hx).2
-  have hx4 : x ^ 2 ≤ 4 := by nlinarith
+Forme généralisée à un rayon `R` arbitraire (`gaussianPDFReal_lower_abs`,
+`gaussian_interval_mass_lower_param`), les versions historiques `[−2, 2]`
+comme corollaires, et la forme papier `1/√ρ₀`
+(`gaussian_interval_mass_lower_inv_sqrt`). La bibliothèque `SLT/SmallBallProb`
+a été évaluée pour ce rôle (issue #11148, Grain 2) : son `small_ball_prob`
+est une borne **supérieure** de small-ball `P(∑Xᵢ ≤ εN) ≤ (e·ε)^N` (Markov
+sur la MGF), pas une anti-concentration inférieure — elle ne couvre pas la
+Brique 1, d'où la version paramétrée ci-dessous plutôt qu'une dérivation. -/
+
+/-- La densité gaussienne standard est minorée par `exp(−R²/2)/√(2π)` sur
+`[−R, R]` : la densité décroît en `|x|`, donc sa valeur au bord du domaine
+minore tout l'intérieur. Forme généralisée (rayon arbitraire) de
+`gaussianPDFReal_lower_two`. -/
+lemma gaussianPDFReal_lower_abs {R x : ℝ} (hx : |x| ≤ R) :
+    Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi) ≤ gaussianPDFReal 0 1 x := by
+  have hxR : x ^ 2 ≤ R ^ 2 := by nlinarith [(abs_le.mp hx).1, (abs_le.mp hx).2]
   have hpi : ((2 * Real.pi * (1 : ℝ≥0)) : ℝ) = 2 * Real.pi := by norm_num
   have h2' : (2 * (1 : ℝ≥0) : ℝ) = 2 := by norm_num
   unfold gaussianPDFReal
   rw [hpi, h2']
-  have hexp : Real.exp (-2) ≤ Real.exp (-(x - 0) ^ 2 / 2) := by
+  have hexp : Real.exp (-(R ^ 2) / 2) ≤ Real.exp (-(x - 0) ^ 2 / 2) := by
     refine Real.exp_le_exp.mpr ?_
-    nlinarith [hx4]
+    nlinarith [hxR]
   have hinv : 0 < (Real.sqrt (2 * Real.pi))⁻¹ := by positivity
-  calc Real.exp (-2) / Real.sqrt (2 * Real.pi)
-      = (Real.sqrt (2 * Real.pi))⁻¹ * Real.exp (-2) := div_eq_inv_mul _ _
+  calc Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)
+      = (Real.sqrt (2 * Real.pi))⁻¹ * Real.exp (-(R ^ 2) / 2) := div_eq_inv_mul _ _
     _ ≤ (Real.sqrt (2 * Real.pi))⁻¹ * Real.exp (-(x - 0) ^ 2 / 2) :=
         mul_le_mul_of_nonneg_left hexp hinv.le
 
-/-- Tout intervalle inclus dans `[−2, 2]` porte une masse gaussienne
-`≥ largeur · φ(2)` où `φ(2) = exp(−2)/√(2π)` (§11 : intervalles de largeur
-`1/√ρ₀`). -/
-theorem gaussian_interval_mass_lower {a b : ℝ} (hab : a ≤ b)
-    (ha : |a| ≤ 2) (hb : |b| ≤ 2) :
-    (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤
+/-- La densité gaussienne standard est minorée par `exp(−2)/√(2π)` sur `[−2, 2]`. -/
+lemma gaussianPDFReal_lower_two (x : ℝ) (hx : |x| ≤ 2) :
+    Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤ gaussianPDFReal 0 1 x := by
+  have hexp : Real.exp (-(2:ℝ) ^ 2 / 2) = Real.exp (-2) := by
+    congr 1
+    norm_num
+  have h := gaussianPDFReal_lower_abs (R := 2) hx
+  rwa [hexp] at h
+
+/-- Tout intervalle inclus dans `[−R, R]` porte une masse gaussienne
+`≥ largeur · φ(R)` où `φ(R) = exp(−R²/2)/√(2π)` : la densité est minorée par
+sa valeur au bord (`gaussianPDFReal_lower_abs`), l'intégrale minore donc par
+`largeur × minorant`. Forme généralisée de `gaussian_interval_mass_lower`. -/
+theorem gaussian_interval_mass_lower_param {a b R : ℝ} (hab : a ≤ b)
+    (ha : |a| ≤ R) (hb : |b| ≤ R) :
+    (b - a) * Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi) ≤
       (gaussianReal 0 1 (Set.Ioc a b)).toReal := by
-  have hk : 0 ≤ Real.exp (-2) / Real.sqrt (2 * Real.pi) := by positivity
+  have hk : 0 ≤ Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi) := by positivity
   have hmeasure : gaussianReal 0 1 (Set.Ioc a b) =
       ∫⁻ x in Set.Ioc a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := by
     rw [gaussianReal_of_var_ne_zero 0 one_ne_zero,
       withDensity_apply _ measurableSet_Ioc]
     rfl
-  have hsplit : ∀ x ∈ Set.Ioc (a : ℝ) b, |x| ≤ 2 := by
+  have hsplit : ∀ x ∈ Set.Ioc (a : ℝ) b, |x| ≤ R := by
     intro x hx
     rw [abs_le]
     constructor <;> nlinarith [(abs_le.mp ha).1, (abs_le.mp ha).2,
       (abs_le.mp hb).1, (abs_le.mp hb).2, hx.1.le, hx.2]
   have hpoint : ∀ x, (Set.Ioc a b).indicator (fun _ => ENNReal.ofReal
-      (Real.exp (-2) / Real.sqrt (2 * Real.pi))) x ≤
+      (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi))) x ≤
       (Set.Ioc a b).indicator (fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x)) x := by
     intro x
     by_cases hx : x ∈ Set.Ioc a b
     · simp only [Set.indicator_of_mem hx]
-      exact ENNReal.ofReal_le_ofReal (gaussianPDFReal_lower_two x (hsplit x hx))
+      exact ENNReal.ofReal_le_ofReal (gaussianPDFReal_lower_abs (hsplit x hx))
     · rw [Set.indicator_apply, if_neg hx, Set.indicator_apply, if_neg hx]
   have hmono : (∫⁻ _x in Set.Ioc a b,
-        ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi)) ∂volume) ≤
+        ENNReal.ofReal (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)) ∂volume) ≤
       ∫⁻ x in Set.Ioc a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := by
     rw [← lintegral_indicator measurableSet_Ioc
-        (fun _ => ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi))),
+        (fun _ => ENNReal.ofReal (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi))),
       ← lintegral_indicator measurableSet_Ioc
         (fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x))]
     exact lintegral_mono hpoint
-  have hchain : ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi))) ≤
+  have hchain : ENNReal.ofReal ((b - a) *
+        (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi))) ≤
       gaussianReal 0 1 (Set.Ioc a b) := by
     rw [hmeasure]
-    calc ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)))
+    calc ENNReal.ofReal ((b - a) *
+          (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)))
         = ∫⁻ _x in Set.Ioc a b,
-            ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi)) ∂volume := by
+            ENNReal.ofReal (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)) ∂volume := by
           rw [setLIntegral_const, Real.volume_Ioc,
             ← ENNReal.ofReal_mul (by nlinarith [hab, hk]), mul_comm]
       _ ≤ ∫⁻ x in Set.Ioc a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := hmono
-  have hnn : 0 ≤ (b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)) := by
+  have hnn : 0 ≤ (b - a) * (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)) := by
     nlinarith [hab, hk]
-  have hlhs : (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) =
-      (ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)))).toReal := by
+  have hlhs : (b - a) * Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi) =
+      (ENNReal.ofReal ((b - a) *
+        (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)))).toReal := by
     rw [ENNReal.toReal_ofReal hnn]
     ring
   rw [hlhs]
   exact (ENNReal.toReal_le_toReal ENNReal.ofReal_ne_top (measure_ne_top _ _)).mpr
     hchain
+
+/-- Tout intervalle inclus dans `[−2, 2]` porte une masse gaussienne
+`≥ largeur · φ(2)` où `φ(2) = exp(−2)/√(2π)` (§11 : intervalles de largeur
+`1/√ρ₀`). Cas `R = 2` de `gaussian_interval_mass_lower_param`. -/
+theorem gaussian_interval_mass_lower {a b : ℝ} (hab : a ≤ b)
+    (ha : |a| ≤ 2) (hb : |b| ≤ 2) :
+    (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤
+      (gaussianReal 0 1 (Set.Ioc a b)).toReal := by
+  have hexp : Real.exp (-(2:ℝ) ^ 2 / 2) = Real.exp (-2) := by
+    congr 1
+    norm_num
+  have h := gaussian_interval_mass_lower_param (R := 2) hab ha hb
+  rwa [hexp] at h
+
+/-- **Forme papier §11** : tout intervalle de largeur exactement `1/√ρ₀`
+centré en `c` et inclus dans `[−2, 2]` porte une masse gaussienne
+`≥ (1/√ρ₀) · φ(2)` — les « intervalles gaussiens de largeur `1/√ρ₀` » du
+converse de Papailiopoulos 2026 (§11), instanciation directe de la Brique 1
+sur `ε = 1/√ρ₀`. -/
+theorem gaussian_interval_mass_lower_inv_sqrt {ρ₀ c : ℝ} (hρ : 0 < ρ₀)
+    (hc : |c| + 1 / √ρ₀ / 2 ≤ 2) :
+    (1 / √ρ₀) * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤
+      (gaussianReal 0 1 (Set.Ioc (c - 1 / √ρ₀ / 2) (c + 1 / √ρ₀ / 2))).toReal := by
+  have he : 0 < 1 / √ρ₀ := by positivity
+  have hc' : |c| ≤ 2 - 1 / √ρ₀ / 2 := by nlinarith [hc]
+  have hca := abs_le.mp hc'
+  have ha : |c - 1 / √ρ₀ / 2| ≤ 2 := by
+    rw [abs_le]
+    constructor <;> nlinarith [hca.1, hca.2, he]
+  have hb : |c + 1 / √ρ₀ / 2| ≤ 2 := by
+    rw [abs_le]
+    constructor <;> nlinarith [hca.1, hca.2, he]
+  have hab : c - 1 / √ρ₀ / 2 ≤ c + 1 / √ρ₀ / 2 := by nlinarith
+  have h := gaussian_interval_mass_lower hab ha hb
+  rw [show (c + 1 / √ρ₀ / 2) - (c - 1 / √ρ₀ / 2) = 1 / √ρ₀ from by ring] at h
+  exact h
 
 /-! ## Brique 2 — union bound complémentaire -/
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Converse_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Converse_en.lean
@@ -10,10 +10,13 @@ This module formalizes the probabilistic bricks of the converse of the `2 log N`
 threshold (Papailiopoulos 2026 paper, §11 — see issue #10984): ML recovery
 fails below `2 log N − log log N − s_N`. The three ingredients of §11 are:
 
-1. **Minimal mass of a Gaussian interval** (`gaussian_interval_mass_lower`):
-   the density `φ` is bounded below by `exp(−2)/√(2π)` on `[−2, 2]`, hence any
-   interval contained in `[−2, 2]` carries mass `≥ width · φ(2)`. This is the
-   mechanism behind the "Gaussian intervals of width `1/√ρ₀`" of §11.
+1. **Minimal mass of a Gaussian interval** (`gaussian_interval_mass_lower_param`,
+   generalized form with arbitrary radius `R`; `gaussian_interval_mass_lower` =
+   the `R = 2` case, `gaussian_interval_mass_lower_inv_sqrt` = the paper form
+   `1/√ρ₀`): the density `φ` is bounded below by `exp(−R²/2)/√(2π)` on
+   `[−R, R]` (`gaussianPDFReal_lower_abs`), hence any interval contained in
+   `[−R, R]` carries mass `≥ width · φ(R)`. This is the mechanism behind the
+   "Gaussian intervals of width `1/√ρ₀`" of §11.
 2. **Complementary union bound** (`one_sub_pow_le_exp_mul`): `(1−p)^n ≤ e^{−np}`
    (direct instance of Mathlib `one_sub_div_pow_le_exp_neg`).
 3. **Hanson–Wright concentration** (`hanson_wright_noise`): tails of the
@@ -34,79 +37,139 @@ namespace Mimo_en
 open MeasureTheory ProbabilityTheory GaussianMeasure HansonWright Real
 open scoped BigOperators NNReal
 
-/-! ## Brick 1 — minimal mass of a Gaussian interval -/
+/-! ## Brick 1 — minimal mass of a Gaussian interval
 
-/-- The standard Gaussian density is bounded below by `exp(−2)/√(2π)` on `[−2, 2]`. -/
-lemma gaussianPDFReal_lower_two (x : ℝ) (hx : |x| ≤ 2) :
-    Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤ gaussianPDFReal 0 1 x := by
-  have h1 : -2 ≤ x := (abs_le.mp hx).1
-  have h2 : x ≤ 2 := (abs_le.mp hx).2
-  have hx4 : x ^ 2 ≤ 4 := by nlinarith
+Generalized form with an arbitrary radius `R` (`gaussianPDFReal_lower_abs`,
+`gaussian_interval_mass_lower_param`), the historical `[−2, 2]` versions as
+corollaries, and the paper form `1/√ρ₀`
+(`gaussian_interval_mass_lower_inv_sqrt`). The `SLT/SmallBallProb` library
+was evaluated for this role (issue #11148, Grain 2): its `small_ball_prob`
+is a small-ball **upper** bound `P(∑Xᵢ ≤ εN) ≤ (e·ε)^N` (Markov on the
+MGF), not a lower anti-concentration bound — it does not cover Brick 1,
+hence the parameterized version below rather than a derivation. -/
+
+/-- The standard Gaussian density is bounded below by `exp(−R²/2)/√(2π)` on
+`[−R, R]`: the density decreases in `|x|`, so its boundary value on the
+domain lower-bounds the whole interior. Generalized form (arbitrary radius)
+of `gaussianPDFReal_lower_two`. -/
+lemma gaussianPDFReal_lower_abs {R x : ℝ} (hx : |x| ≤ R) :
+    Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi) ≤ gaussianPDFReal 0 1 x := by
+  have hxR : x ^ 2 ≤ R ^ 2 := by nlinarith [(abs_le.mp hx).1, (abs_le.mp hx).2]
   have hpi : ((2 * Real.pi * (1 : ℝ≥0)) : ℝ) = 2 * Real.pi := by norm_num
   have h2' : (2 * (1 : ℝ≥0) : ℝ) = 2 := by norm_num
   unfold gaussianPDFReal
   rw [hpi, h2']
-  have hexp : Real.exp (-2) ≤ Real.exp (-(x - 0) ^ 2 / 2) := by
+  have hexp : Real.exp (-(R ^ 2) / 2) ≤ Real.exp (-(x - 0) ^ 2 / 2) := by
     refine Real.exp_le_exp.mpr ?_
-    nlinarith [hx4]
+    nlinarith [hxR]
   have hinv : 0 < (Real.sqrt (2 * Real.pi))⁻¹ := by positivity
-  calc Real.exp (-2) / Real.sqrt (2 * Real.pi)
-      = (Real.sqrt (2 * Real.pi))⁻¹ * Real.exp (-2) := div_eq_inv_mul _ _
+  calc Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)
+      = (Real.sqrt (2 * Real.pi))⁻¹ * Real.exp (-(R ^ 2) / 2) := div_eq_inv_mul _ _
     _ ≤ (Real.sqrt (2 * Real.pi))⁻¹ * Real.exp (-(x - 0) ^ 2 / 2) :=
         mul_le_mul_of_nonneg_left hexp hinv.le
 
-/-- Any interval contained in `[−2, 2]` carries Gaussian mass
-`≥ width · φ(2)` where `φ(2) = exp(−2)/√(2π)` (§11: intervals of width
-`1/√ρ₀`). -/
-theorem gaussian_interval_mass_lower {a b : ℝ} (hab : a ≤ b)
-    (ha : |a| ≤ 2) (hb : |b| ≤ 2) :
-    (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤
+/-- The standard Gaussian density is bounded below by `exp(−2)/√(2π)` on `[−2, 2]`. -/
+lemma gaussianPDFReal_lower_two (x : ℝ) (hx : |x| ≤ 2) :
+    Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤ gaussianPDFReal 0 1 x := by
+  have hexp : Real.exp (-(2:ℝ) ^ 2 / 2) = Real.exp (-2) := by
+    congr 1
+    norm_num
+  have h := gaussianPDFReal_lower_abs (R := 2) hx
+  rwa [hexp] at h
+
+/-- Any interval contained in `[−R, R]` carries Gaussian mass
+`≥ width · φ(R)` where `φ(R) = exp(−R²/2)/√(2π)`: the density is bounded
+below by its boundary value (`gaussianPDFReal_lower_abs`), so the integral
+is bounded below by `width × lower bound`. Generalized form of
+`gaussian_interval_mass_lower`. -/
+theorem gaussian_interval_mass_lower_param {a b R : ℝ} (hab : a ≤ b)
+    (ha : |a| ≤ R) (hb : |b| ≤ R) :
+    (b - a) * Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi) ≤
       (gaussianReal 0 1 (Set.Ioc a b)).toReal := by
-  have hk : 0 ≤ Real.exp (-2) / Real.sqrt (2 * Real.pi) := by positivity
+  have hk : 0 ≤ Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi) := by positivity
   have hmeasure : gaussianReal 0 1 (Set.Ioc a b) =
       ∫⁻ x in Set.Ioc a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := by
     rw [gaussianReal_of_var_ne_zero 0 one_ne_zero,
       withDensity_apply _ measurableSet_Ioc]
     rfl
-  have hsplit : ∀ x ∈ Set.Ioc (a : ℝ) b, |x| ≤ 2 := by
+  have hsplit : ∀ x ∈ Set.Ioc (a : ℝ) b, |x| ≤ R := by
     intro x hx
     rw [abs_le]
     constructor <;> nlinarith [(abs_le.mp ha).1, (abs_le.mp ha).2,
       (abs_le.mp hb).1, (abs_le.mp hb).2, hx.1.le, hx.2]
   have hpoint : ∀ x, (Set.Ioc a b).indicator (fun _ => ENNReal.ofReal
-      (Real.exp (-2) / Real.sqrt (2 * Real.pi))) x ≤
+      (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi))) x ≤
       (Set.Ioc a b).indicator (fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x)) x := by
     intro x
     by_cases hx : x ∈ Set.Ioc a b
     · simp only [Set.indicator_of_mem hx]
-      exact ENNReal.ofReal_le_ofReal (gaussianPDFReal_lower_two x (hsplit x hx))
+      exact ENNReal.ofReal_le_ofReal (gaussianPDFReal_lower_abs (hsplit x hx))
     · rw [Set.indicator_apply, if_neg hx, Set.indicator_apply, if_neg hx]
   have hmono : (∫⁻ _x in Set.Ioc a b,
-        ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi)) ∂volume) ≤
+        ENNReal.ofReal (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)) ∂volume) ≤
       ∫⁻ x in Set.Ioc a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := by
     rw [← lintegral_indicator measurableSet_Ioc
-        (fun _ => ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi))),
+        (fun _ => ENNReal.ofReal (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi))),
       ← lintegral_indicator measurableSet_Ioc
         (fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x))]
     exact lintegral_mono hpoint
-  have hchain : ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi))) ≤
+  have hchain : ENNReal.ofReal ((b - a) *
+        (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi))) ≤
       gaussianReal 0 1 (Set.Ioc a b) := by
     rw [hmeasure]
-    calc ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)))
+    calc ENNReal.ofReal ((b - a) *
+          (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)))
         = ∫⁻ _x in Set.Ioc a b,
-            ENNReal.ofReal (Real.exp (-2) / Real.sqrt (2 * Real.pi)) ∂volume := by
+            ENNReal.ofReal (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)) ∂volume := by
           rw [setLIntegral_const, Real.volume_Ioc,
             ← ENNReal.ofReal_mul (by nlinarith [hab, hk]), mul_comm]
       _ ≤ ∫⁻ x in Set.Ioc a b, ENNReal.ofReal (gaussianPDFReal 0 1 x) ∂volume := hmono
-  have hnn : 0 ≤ (b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)) := by
+  have hnn : 0 ≤ (b - a) * (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)) := by
     nlinarith [hab, hk]
-  have hlhs : (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) =
-      (ENNReal.ofReal ((b - a) * (Real.exp (-2) / Real.sqrt (2 * Real.pi)))).toReal := by
+  have hlhs : (b - a) * Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi) =
+      (ENNReal.ofReal ((b - a) *
+        (Real.exp (-(R ^ 2) / 2) / Real.sqrt (2 * Real.pi)))).toReal := by
     rw [ENNReal.toReal_ofReal hnn]
     ring
   rw [hlhs]
   exact (ENNReal.toReal_le_toReal ENNReal.ofReal_ne_top (measure_ne_top _ _)).mpr
     hchain
+
+/-- Any interval contained in `[−2, 2]` carries Gaussian mass
+`≥ width · φ(2)` where `φ(2) = exp(−2)/√(2π)` (§11: intervals of width
+`1/√ρ₀`). Case `R = 2` of `gaussian_interval_mass_lower_param`. -/
+theorem gaussian_interval_mass_lower {a b : ℝ} (hab : a ≤ b)
+    (ha : |a| ≤ 2) (hb : |b| ≤ 2) :
+    (b - a) * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤
+      (gaussianReal 0 1 (Set.Ioc a b)).toReal := by
+  have hexp : Real.exp (-(2:ℝ) ^ 2 / 2) = Real.exp (-2) := by
+    congr 1
+    norm_num
+  have h := gaussian_interval_mass_lower_param (R := 2) hab ha hb
+  rwa [hexp] at h
+
+/-- **Paper form §11**: any interval of width exactly `1/√ρ₀` centered at
+`c` and contained in `[−2, 2]` carries Gaussian mass
+`≥ (1/√ρ₀) · φ(2)` — the "Gaussian intervals of width `1/√ρ₀`" of the
+converse of Papailiopoulos 2026 (§11), direct instantiation of Brick 1 on
+`ε = 1/√ρ₀`. -/
+theorem gaussian_interval_mass_lower_inv_sqrt {ρ₀ c : ℝ} (hρ : 0 < ρ₀)
+    (hc : |c| + 1 / √ρ₀ / 2 ≤ 2) :
+    (1 / √ρ₀) * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤
+      (gaussianReal 0 1 (Set.Ioc (c - 1 / √ρ₀ / 2) (c + 1 / √ρ₀ / 2))).toReal := by
+  have he : 0 < 1 / √ρ₀ := by positivity
+  have hc' : |c| ≤ 2 - 1 / √ρ₀ / 2 := by nlinarith [hc]
+  have hca := abs_le.mp hc'
+  have ha : |c - 1 / √ρ₀ / 2| ≤ 2 := by
+    rw [abs_le]
+    constructor <;> nlinarith [hca.1, hca.2, he]
+  have hb : |c + 1 / √ρ₀ / 2| ≤ 2 := by
+    rw [abs_le]
+    constructor <;> nlinarith [hca.1, hca.2, he]
+  have hab : c - 1 / √ρ₀ / 2 ≤ c + 1 / √ρ₀ / 2 := by nlinarith
+  have h := gaussian_interval_mass_lower hab ha hb
+  rw [show (c + 1 / √ρ₀ / 2) - (c - 1 / √ρ₀ / 2) = 1 / √ρ₀ from by ring] at h
+  exact h
 
 /-! ## Brick 2 — complementary union bound -/
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
@@ -51,3 +51,7 @@ lean_lib «Lmmse» where
 @[default_target]
 lean_lib «Converse» where
   globs := #[`Converse, `Converse_en]
+
+@[default_target]
+lean_lib «Bridge» where
+  globs := #[`Bridge, `Bridge_en]


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11178

## Summary

Phase 4 du lake `mimo_lean` (#11148, suite de #10984) : nouveau module
**Bridge** (FR + sibling EN `Bridge_en`), reliant l'objectif ML `mimoObj`
(Phase 2) au bruit gaussien de la converse (Phase 3b).

**Grain 1a — identité de différence de coût (algèbre pure)** :
- `cost_diff` — forme générique en espace de Hilbert réel :
  `‖w + √s•z + √s•v‖² − ‖w + √s•z‖² = s·‖v‖² + 2√s·⟪w,v⟫ + 2s·⟪z,v⟫`,
  dérivée de `norm_add_sq_two` (Phase 2).
- `mimoObj_sub_mimoObj` — **Pont 1a** : instanciation au canal MIMO pour deux
  configurations `u, u'` quelconques.
- `mimoObj_residual_from_zero` — spécialisation `u = 0` (le terme couplé à la
  position courante disparaît).
- `mimo_flip_cost_via_bridge` — **cohérence** : le Bridge redonne exactement
  le Lemme 11.1 (`mimo_flip_cost`) quand `v = flipAt i` — le Lemme devient un
  corollaire du Bridge, qui le généralise.

**Grain 1b — fragment de converse connecté au ML** (morceau techniquement
ouvert de l'issue, fermé via l'API `IsGaussian` de Mathlib) :
- `stdGaussianPi_map_toLp` — **pont de conventions** : la gaussienne produit
  du lake SLT (`stdGaussianPi`, sur `Fin n → ℝ`) poussée par `toLp 2` est
  exactement `stdGaussian (EuclideanSpace ℝ (Fin M))` (instance directe de
  `map_pi_eq_stdGaussian`). Le fragment converse vit côté Mathlib (même
  convention que la Phase 3a `Lmmse`), ce pont ramène à la convention produit.
- `map_inner_stdGaussian` — **transport** : pour `w ~ stdGaussian` sur
  l'espace euclidien, la forme linéaire `⟪h, w⟫` a pour loi
  `gaussianReal 0 ‖h‖²`. Preuve en une étape par l'API `IsGaussian` :
  `map_eq_gaussianReal` + `integral_strongDual_stdGaussian` (moyenne 0) +
  `variance_dual_stdGaussian` (variance `‖L‖²`) + `innerSL_apply_norm`
  (la forme `w ↦ ⟪h, w⟫` est `innerSL ℝ h`, de norme `‖h‖`).
- `gaussian_interval_mass_lower_open` — variante **Ioo** de la Brique 1
  (Phase 3b, `gaussian_interval_mass_lower`) : le fragment converse a besoin
  d'un intervalle strictement contenu dans l'événement `y < c`.
- `flip_bat_prob_lower` — **premier énoncé du type « P(le flip bat x*) ≥ c »** :
  si `√s·‖hᵢ‖ ≤ 2` (avec `s > 0`, `‖hᵢ‖ > 0`), alors
  `P(w : flip i bat x*) ≥ (2 − √s·‖hᵢ‖)·φ(2)`, `φ(2) = exp(−2)/√(2π)`, via le
  transport + l'intervalle `(−2, −√s·‖hᵢ‖)`.

**Note de convention** : l'énoncé de l'issue #11148 est phrasé sur
`stdGaussianPi` (convention SLT). `stdGaussianPi M : Measure (Fin M → ℝ)`
n'est pas la mesure sur l'espace euclidien ; le livrable démontre le fragment
sur `stdGaussian (EuclideanSpace ℝ (Fin M))` (Mathlib, convention Phase 3a)
et fournit `stdGaussianPi_map_toLp` pour tirer l'énoncé dans la convention
produit — la substance mathématique est identique, seul le support diffère.

**Correction d'énoncé de l'issue #11148** : la condition `√s·‖hᵢ‖ ≤ 2` seule
est insuffisante — pour `s = 0` ou `‖hᵢ‖ = 0`, l'événement a probabilité 0
alors que la borne est strictement positive. Ajout des hypothèses `0 < s` et
`0 < ‖A (Pi.single i 1)‖` (documenté dans la docstring de `flip_bat_prob_lower`).

## Grain 2 — paramétrisation de la Brique 1 (upgrade Converse)

**Verdict SLT SmallBallProb (évalué firsthand, première main)** : le théorème
`small_ball_prob` du lake SLT (`SLT/SmallBallProb`) est une borne **supérieure**
de small-ball — `P(∑Xᵢ ≤ εN) ≤ (e·ε)^N`, obtenue par Markov sur la MGF — et
non une borne d'anti-concentration inférieure. La Brique 1 (masse **minimale**
d'un intervalle gaussien) exige une minoration : `small_ball_prob` ne couvre
pas ce rôle, d'où la paramétrisation ci-dessous plutôt qu'une dérivation
depuis le lake SLT. Verdict consigné dans le header du module.

- `gaussianPDFReal_lower_abs {R x} (hx : |x| ≤ R)` — forme généralisée à un
  rayon arbitraire : la densité `φ` est minorée par `exp(−R²/2)/√(2π)` sur
  `[−R, R]`.
- `gaussian_interval_mass_lower_param {a b R}` — tout intervalle inclus dans
  `[−R, R]` porte une masse gaussienne `≥ largeur · φ(R)` (même squelette de
  preuve que la version fixe : withDensity + lintegral_mono).
- `gaussianPDFReal_lower_two` + `gaussian_interval_mass_lower` — les versions
  historiques `[−2, 2]` deviennent des **corollaires** (`R := 2`, réécriture
  `hexp : exp(−(2²)/2) = exp(−2)` par `congr 1 + norm_num` — `simpa` seul ne
  réduit pas l'atome arithmétique fermé).
- `gaussian_interval_mass_lower_inv_sqrt {ρ₀ c}` — **forme papier §11** : tout
  intervalle de largeur `1/√ρ₀` centré en `c` et inclus dans `[−2, 2]` porte
  une masse `≥ (1/√ρ₀)·φ(2)` — les « intervalles gaussiens de largeur
  `1/√ρ₀` » du converse de Papailiopoulos 2026, instanciation directe de la
  Brique 1 sur `ε = 1/√ρ₀`.

Le consommateur aval `gaussian_coordinate_escape_bound` est inchangé (la
signature de la version fixe est identique — aucune régression possible).

## Test plan / preuves

- [x] `lake build Bridge` SUCCESS (build local WSL natif `~/mimo_lean_build`,
      Mathlib v4.32.0 + slt d0f506f0, log ci-dessous)
- [x] `lake build Bridge_en` SUCCESS
- [x] Grain 2 : `lake build Converse Converse_en` SUCCESS (round 8, rebuild
      complet Converse → Converse_en → Bridge → Bridge_en, log ci-dessous)
- [x] `count_code_sorry.py --json` : `distinct_code_sorry = 0` sur le lake
      entier (11 fichiers ; les 2 `naive_sorry` sont de la prose)
- [x] `#print axioms` sur les 11 théorèmes (8 Bridge + 3 Grain 2) :
      standard uniquement (`propext`, `Classical.choice`, `Quot.sound`)
- [x] Sibling `_en` byte-parallel : `check_i18n_siblings.py` →
      `5/5 pairs byte-identical | 0 drift | 0 orphan`
- [x] `lakefile.lean` : globs `Bridge`, `Bridge_en` ajoutés au `lean_lib`

## Note

- Issue #11148 : phase 4, grains 1a + 1b + 2 livrés (le converse ML complet —
  scaling des N flips + union bound — sera enrichi dans les grains suivants).
  `See #11148` (livraison partielle de l'epic).

## Preuves (extraits)

`lake build` (WSL natif `~/mimo_lean_build`, Lean 4 v4.32.0, Mathlib + slt
d0f506f0) — round 8 (Grain 2 : rebuild complet Converse → Converse_en →
Bridge → Bridge_en ; le Grain 1 avait convergé au round 6) :

```
$ lake build Bridge Bridge_en
BUILD8_EXIT=0          (0 error ; seuls warnings: linter unusedVariables
                        préexistants dans Converse_en.lean — hors scope)
```

`#print axioms` (`lake env lean AxiomsCheck.lean`) — les 11 théorèmes
(8 Grain 1 + 3 Grain 2) :

```
'Mimo.cost_diff' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.mimoObj_sub_mimoObj' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.mimoObj_residual_from_zero' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.mimo_flip_cost_via_bridge' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.stdGaussianPi_map_toLp' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.map_inner_stdGaussian' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.gaussian_interval_mass_lower_open' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.flip_bat_prob_lower' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.gaussianPDFReal_lower_abs' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.gaussian_interval_mass_lower_param' depends on axioms: [propext, Classical.choice, Quot.sound]
'Mimo.gaussian_interval_mass_lower_inv_sqrt' depends on axioms: [propext, Classical.choice, Quot.sound]
```

`count_code_sorry.py --json --lake <mimo_lean>` :
`files: 11, naive_sorry: 2 (prose), code_sorry: 0, distinct_code_sorry: 0`.

### B.3 — Proof integrity (job CI `proof-integrity`)

**Non applicable, parce que** le job `proof-integrity` du workflow
`lean-axiom.yml` n'est pas câblé sur le lake `mimo_lean` (aucun workflow
appelant `lean-axiom.yml` ne liste `mimo_lean` dans ses `target-modules` —
même état que les PRs Lean des phases précédentes du lake #10984/#11063/#11079).
Équivalent local fourni ci-dessus : `#print axioms` sur les 11 théorèmes des
modules — axiomes standard uniquement, aucun `sorryAx`, aucun `native_decide.*`,
aucun `Classical.choice` non-justifié (la preuve est constructive hors
tactics classiques de Mathlib).
