### PR TITLE
fix(tooling,#11199): batch_reexecute --path reads notebook kernelspec instead of hardcoded python3

### DIFF
--- a/scripts/notebook_tools/batch_reexecute.py
+++ b/scripts/notebook_tools/batch_reexecute.py
@@ -71,11 +71,34 @@ def _normalize_kernel_paths(nb_path: Path) -> int:
 def get_kernel_name(entry: dict) -> str:
     """Map catalog kernel to papermill kernel name."""
     kernel = entry.get("kernel", "").lower()
+    if kernel and " " not in kernel:
+        # Kernelspec-shaped name (".net-csharp", "python3", "lean4-wsl") --
+        # e.g. a notebook's own metadata.kernelspec.name fed by --path.
+        # Pass it through so the notebook's real kernel is not remapped
+        # to an unrelated one (#11199). Catalog values are descriptive
+        # strings with spaces (".NET (C#)", "Python 3") and keep flowing
+        # through the mappings below.
+        return kernel
     if "python 3" in kernel:
         return "python3"
     if ".net" in kernel or "c#" in kernel:
         return ".net-interactive"
     return kernel
+
+
+def read_kernelspec_name(nb_path: Path) -> str:
+    """Read a notebook's own kernelspec name, falling back to ``python3``.
+
+    The ``--path`` branch has no catalog entry to map, so the notebook
+    itself is the truth source: its ``metadata.kernelspec.name`` is the
+    kernel papermill must use (#11199).
+    """
+    try:
+        data = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return "python3"
+    spec = data.get("metadata", {}).get("kernelspec", {})
+    return spec.get("name") or "python3"
 
 
 def execute_notebook(nb_path: Path, kernel: str, timeout: int) -> dict:
@@ -148,7 +171,8 @@ def main():
         if not nb_path.is_absolute():
             nb_path = REPO_ROOT / nb_path
         targets = [{"path": str(nb_path.relative_to(NOTEBOOKS_DIR)),
-                     "kernel": "python3", "cells_without_outputs": 1}]
+                     "kernel": read_kernelspec_name(nb_path),
+                     "cells_without_outputs": 1}]
     elif CATALOG_PATH.exists():
         try:
             catalog = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))

--- a/scripts/notebook_tools/tests/test_batch_reexecute.py
+++ b/scripts/notebook_tools/tests/test_batch_reexecute.py
@@ -4,13 +4,19 @@ Tests focus on pure functions: needs_reexecution, get_kernel_name.
 No filesystem I/O on production files.
 """
 
+import json
 import sys
 from pathlib import Path
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from batch_reexecute import get_kernel_name, needs_reexecution, _normalize_kernel_paths
+from batch_reexecute import (
+    get_kernel_name,
+    needs_reexecution,
+    read_kernelspec_name,
+    _normalize_kernel_paths,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -90,6 +96,56 @@ class TestGetKernelName:
     def test_dotnet_in_name(self):
         """Any '.net' substring maps to .net-interactive."""
         assert get_kernel_name({"kernel": ".NET Interactive"}) == ".net-interactive"
+
+    def test_kernelspec_shaped_passthrough_csharp(self):
+        """A kernelspec name (no space) from --path passes through untouched
+        instead of being remapped to an unrelated kernel (#11199)."""
+        assert get_kernel_name({"kernel": ".net-csharp"}) == ".net-csharp"
+
+    def test_kernelspec_shaped_passthrough_fsharp(self):
+        assert get_kernel_name({"kernel": ".net-fsharp"}) == ".net-fsharp"
+
+    def test_kernelspec_shaped_passthrough_python3(self):
+        assert get_kernel_name({"kernel": "python3"}) == "python3"
+
+    def test_kernelspec_shaped_passthrough_wsl(self):
+        assert get_kernel_name({"kernel": "lean4-wsl"}) == "lean4-wsl"
+
+
+# ---------------------------------------------------------------------------
+# read_kernelspec_name — kernel truth source for --path (#11199)
+# ---------------------------------------------------------------------------
+
+class TestReadKernelspecName:
+    def _write_nb(self, tmp_path: Path, metadata: dict) -> Path:
+        nb = {"cells": [], "metadata": metadata, "nbformat": 4,
+              "nbformat_minor": 5}
+        p = tmp_path / "nb.ipynb"
+        p.write_text(json.dumps(nb), encoding="utf-8")
+        return p
+
+    def test_reads_kernelspec_name(self, tmp_path):
+        p = self._write_nb(
+            tmp_path,
+            {"kernelspec": {"name": ".net-csharp", "language": "C#"}},
+        )
+        assert read_kernelspec_name(p) == ".net-csharp"
+
+    def test_missing_kernelspec_falls_back_to_python3(self, tmp_path):
+        p = self._write_nb(tmp_path, {})
+        assert read_kernelspec_name(p) == "python3"
+
+    def test_empty_kernelspec_name_falls_back(self, tmp_path):
+        p = self._write_nb(tmp_path, {"kernelspec": {"name": ""}})
+        assert read_kernelspec_name(p) == "python3"
+
+    def test_malformed_json_falls_back(self, tmp_path):
+        p = tmp_path / "broken.ipynb"
+        p.write_text("{not json", encoding="utf-8")
+        assert read_kernelspec_name(p) == "python3"
+
+    def test_missing_file_falls_back(self, tmp_path):
+        assert read_kernelspec_name(tmp_path / "ghost.ipynb") == "python3"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`batch_reexecute.py --path <notebook>` hardcoded `kernel=python3` in its target entry, so re-executing any `.NET Interactive` notebook via `--path` failed with `PapermillExecutionError: Kernel .net-interactive... No such kernel` style failures (papermill honored the passed kernel against the notebook content), and the tool's backup-restore made the notebook look unchanged — the systematic failure was masked as "this notebook cannot re-execute".

Same defect family as #11164 / #11193 (wrong papermill invocation parameter), this time in `--path`.

**Note on the issue body:** it states `get_kernel_name` already lets `.net-csharp` pass through untouched. That is not the case on origin/main — `.net-csharp` contains `.net` and was remapped to `.net-interactive` (which is not an installed kernelspec locally; installed are `.net-csharp` / `.net-fsharp` / `.net-powershell`). Feeding the raw kernelspec name through the existing function, as the issue proposed, would still have failed. The fix therefore covers both halves.

## Changes

1. `read_kernelspec_name(nb_path)` — reads `metadata.kernelspec.name` from the target notebook, falling back to `python3` on missing kernelspec / empty name / malformed JSON / missing file. The `--path` branch has no catalog entry; the notebook itself is the truth source.
2. `get_kernel_name` — kernelspec-shaped names (single token, no space) pass through before the descriptive mappings. All descriptive catalog values carry spaces ("Python 3" x585, ".NET (C#)" x234), so the heuristic is a no-op for the catalog branch.

## Acceptance criteria vs evidence

| Criterion (issue #11199) | Result |
|---|---|
| Dry-run shows the correct kernel per notebook | `--dry-run --path` logs `kernel=.net-csharp` for Search-1-StateSpace-Csharp.ipynb (was `python3`) |
| Python notebook re-executes end-to-end via `--path` | Search-6-AdversarialSearch.ipynb SUCCESS 18s, normalized=1 |
| .NET notebook re-executes end-to-end via `--path` | Search-1-StateSpace-Csharp.ipynb **FAILED 9s pre-fix -> SUCCESS 14s post-fix** |
| python3 fallback when kernelspec missing | 5 unit tests (`TestReadKernelspecName`): missing kernelspec, empty name, malformed JSON, missing file |

Unit tests: `pytest scripts/notebook_tools/tests/test_batch_reexecute.py` **29/29 passed** (11 new: 4 kernelspec pass-through + 5 read_kernelspec_name + 2 pre-existing normalize suites unchanged).

Exec churn discipline (C.3): both real-exec validation runs touched only outputs and were reverted (`git checkout --`) after evidence capture; worktree clean before commit except the 2 intended files.

## Residual (out of scope, flagged)

The catalog branch still maps descriptive ".NET (C#)" (234 entries) to `.net-interactive`, which is not an installed kernelspec locally — batch re-exec of .NET notebooks from the catalog would hit the same wall. Different input path (catalog vs notebook metadata), larger blast radius; left for a follow-up issue rather than bundled here.

Closes #11199

Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/genai #11209

Co-Authored-By: Claude-Code <noreply@anthropic.com>
