### PR TITLE
fix(tooling,#11213): cell_order_ci gate fails loudly on a git-ref --head instead of silently passing

### DIFF
--- a/scripts/notebook_tools/cell_order_ci.py
+++ b/scripts/notebook_tools/cell_order_ci.py
@@ -15,8 +15,14 @@ around does not mask a newly introduced one.
 Usage:
     cell_order_ci.py --base <base.ipynb|NONE> --head <head.ipynb>
 
+--base and --head are FILE PATHS to the notebook revisions on disk -- NOT git
+refs. Passing a git ref (e.g. `--head HEAD` or `--base main`) is a usage error:
+the path does not exist, and the gate fails loudly with a SystemExit naming the
+cause, instead of silently reporting "no regression". `NONE` is the only
+accepted non-path value for --base; it means "new notebook, no base".
+
 Exit codes:
-    0 - no new HIGH findings in head (or head unreadable -> nothing to gate)
+    0 - no new HIGH findings in head (or head file present but unreadable -> nothing to gate)
     1 - one or more NEW HIGH findings introduced by head (regression)
 """
 
@@ -29,10 +35,21 @@ from scan_cell_ordering import scan_notebook  # noqa: E402
 
 
 def high_signatures(path: str | None) -> set[tuple[str, str]]:
-    """Set of (category, message) for HIGH findings of a notebook, or empty."""
-    if not path or path == "NONE" or not Path(path).exists():
+    """Set of (category, message) for HIGH findings of a notebook, or empty.
+
+    `None`/`"NONE"` mean "no base revision" and yield the empty set. A path
+    that was provided but does not exist is a usage error (a git ref is not a
+    file path): it raises SystemExit instead of silently reporting nothing.
+    """
+    if not path or path == "NONE":
         return set()
-    rep = scan_notebook(Path(path))
+    p = Path(path)
+    if not p.exists():
+        raise SystemExit(
+            "cell_order_ci: --base/--head attend un CHEMIN de fichier, "
+            f"reçu {path!r} qui n'existe pas (une ref git ne convient pas)"
+        )
+    rep = scan_notebook(p)
     if rep.get("error"):
         return set()
     return {(f["category"], f["message"]) for f in rep["findings"] if f["severity"] == "HIGH"}

--- a/scripts/notebook_tools/test_cell_order_ci.py
+++ b/scripts/notebook_tools/test_cell_order_ci.py
@@ -12,17 +12,21 @@ monkeypatch (no real notebook parsing needed) to exercise the gate's pure
 set-difference logic deterministically.
 
 Strategy:
-  - high_signatures: NONE / None / missing-file / scan-error -> empty set;
-    otherwise {(category, message)} filtered to severity == HIGH.
+  - high_signatures: NONE / None / scan-error -> empty set; a provided path
+    that does not exist is a usage error (git refs are not file paths) and
+    raises SystemExit (issue #11213); otherwise {(category, message)} filtered
+    to severity == HIGH.
   - regressions: sorted(head - base), deterministic, base=NONE counts every
     head HIGH as a regression (new-notebook semantics).
   - main(): exit 0 on no regression, exit 1 + formatted print on regression;
-    --base optional (defaults to NONE-equivalent); missing head file -> exit 0
-    ("head unreadable -> nothing to gate").
+    --base optional (defaults to NONE-equivalent); a --head/--base that is not
+    an existing file path -> SystemExit (never "nothing to gate" silently).
 
-G.9 honesty: bug-hunt firsthand BEFORE tests (c.534 lesson). 0 functional bug
-found -- the module is clean pure set logic. Pinned as-is (honest coverage,
-no fix).
+G.9 honesty: bug-hunt firsthand BEFORE tests (c.534 lesson). One functional
+defect found 2026-08-16 (issue #11213): a provided-but-absent path returned
+an empty set instead of failing, so a git ref (`--head HEAD`) silently passed
+the gate. Fixed: SystemExit on absent path. The mock-based coverage below
+keeps the gate's pure set logic tested deterministically.
 """
 from __future__ import annotations
 
@@ -73,9 +77,11 @@ class TestHighSignatures:
         _mock_scan(monkeypatch, [_finding("c", "m")])
         assert ci.high_signatures("NONE") == set()
 
-    def test_missing_file_returns_empty(self, monkeypatch, tmp_path):
+    def test_missing_file_raises(self, monkeypatch, tmp_path):
+        # A provided path that does not exist (git ref) must fail loudly.
         _mock_scan(monkeypatch, [_finding("c", "m")])
-        assert ci.high_signatures(str(tmp_path / "does_not_exist.ipynb")) == set()
+        with pytest.raises(SystemExit, match="n'existe pas"):
+            ci.high_signatures(str(tmp_path / "does_not_exist.ipynb"))
 
     def test_scan_error_returns_empty(self, monkeypatch, tmp_path):
         nb = tmp_path / "nb.ipynb"
@@ -122,7 +128,12 @@ class TestRegressions:
 
     def test_empty_head_empty_base_no_regressions(self, monkeypatch, tmp_path):
         _mock_scan(monkeypatch, [])
-        assert ci.regressions(str(tmp_path / "a.ipynb"), str(tmp_path / "b.ipynb")) == []
+        # Both paths must exist on disk (absent path = usage error, #11213).
+        a = tmp_path / "a.ipynb"
+        b = tmp_path / "b.ipynb"
+        a.write_text("{}")
+        b.write_text("{}")
+        assert ci.regressions(str(a), str(b)) == []
 
     def test_head_subset_of_base_no_regressions(self, monkeypatch, tmp_path):
         # Pre-existing HIGH in base -> not a regression even if in head.
@@ -216,11 +227,12 @@ class TestMain:
         _mock_scan(monkeypatch, [_finding("c", "m")])
         assert ci.main(["--base", "NONE", "--head", str(nb)]) == 1
 
-    def test_missing_head_file_exit_0(self, monkeypatch, tmp_path):
-        # Docstring: "head unreadable -> nothing to gate -> exit 0".
+    def test_missing_head_file_raises(self, monkeypatch, tmp_path):
+        # A head path that does not exist (e.g. a git ref) must fail loudly,
+        # never report "no regression" (issue #11213).
         _mock_scan(monkeypatch, [_finding("c", "m")])
-        rc = ci.main(["--head", str(tmp_path / "ghost.ipynb")])
-        assert rc == 0
+        with pytest.raises(SystemExit, match="n'existe pas"):
+            ci.main(["--head", str(tmp_path / "ghost.ipynb")])
 
     def test_pre_existing_high_not_a_regression(self, monkeypatch, tmp_path, capsys):
         # Same HIGH in base and head -> exit 0 (the core regression-gate promise).

--- a/scripts/notebook_tools/tests/test_cell_order_ci.py
+++ b/scripts/notebook_tools/tests/test_cell_order_ci.py
@@ -8,6 +8,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from cell_order_ci import regressions, high_signatures, main  # noqa: E402
 
@@ -33,8 +35,11 @@ class TestHighSignatures:
         assert high_signatures("NONE") == set()
         assert high_signatures(None) == set()
 
-    def test_missing_path_is_empty(self, tmp_path):
-        assert high_signatures(str(tmp_path / "absent.ipynb")) == set()
+    def test_missing_path_raises(self, tmp_path):
+        # A provided path that does not exist is a usage error (git refs are
+        # not file paths): fail loudly, never report "no regression" silently.
+        with pytest.raises(SystemExit, match="n'existe pas"):
+            high_signatures(str(tmp_path / "absent.ipynb"))
 
     def test_clean_has_no_high(self, tmp_path):
         p = _write(tmp_path / "c.ipynb", _CLEAN)
@@ -86,3 +91,8 @@ class TestMainExitCodes:
     def test_exit_one_on_regression(self, tmp_path):
         head = _write(tmp_path / "h.ipynb", _BAD)
         assert main(["--base", "NONE", "--head", str(head)]) == 1
+
+    def test_ref_git_head_raises(self, tmp_path):
+        # --head HEAD (a git ref, not a path) must fail loudly, not exit 0.
+        with pytest.raises(SystemExit, match="n'existe pas"):
+            main(["--base", "NONE", "--head", "HEAD"])


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #11217

## Summary

Fix du faux négatif silencieux de `cell_order_ci.py` (#11213) : un `--base`/`--head` fourni mais qui n'est pas un chemin de fichier existant — typiquement une **ref git** comme `--head HEAD` — rendait `set()` vide → « aucune régression » → **EXIT 0** → gate vert sur une invocation qui ne mesurait rien.

**Correctif** : un chemin fourni mais absent lève désormais `SystemExit` avec un message nommant la cause (`une ref git ne convient pas`). `NONE` reste le sentinel explicite de « nouveau notebook, pas de base » — inchangé. Un fichier présent mais illisible (JSON invalide) reste gracieux (`scan_notebook` error → set vide), inchangé.

Quatrième occurrence de la forme « le faux négatif ne se signale pas » mesurée le 2026-08-16 (curl arXiv `http://` sans `-L`, grep sur JSON de notebook, motifs `sorry` hand-written, `cell_order_ci.py` ref git).

## Acceptation (#11213)

- [x] `--head <ref git>` ⇒ exit non-nul + message nommant la cause. Tests unitaires : `test_ref_git_head_raises`, `test_missing_head_file_raises`, `test_missing_path_raises`/`test_missing_file_raises`.
- [x] `--base NONE` continue de valoir « nouveau fichier » — inchangé (`test_none_base_is_empty`, `test_exit_zero_on_clean`).
- [x] Invocation nominale (deux chemins réels) = même verdict qu'avant — EXIT 0 vérifié sur notebook du dépôt, et 4561 tests de la suite `scripts/notebook_tools/tests/` passent (0 échec).
- [x] Docstring mis à jour : `--base`/`--head` sont des **chemins**, les refs git ne sont pas acceptées.

## Validation

- **Suite complète** : `python -m pytest scripts/notebook_tools/tests/` → `4561 passed in 439.46s`, exit 0.
- **Tests ciblés** : `python -m pytest scripts/notebook_tools/test_cell_order_ci.py scripts/notebook_tools/tests/test_cell_order_ci.py` → `33 passed`.
- **CLI vérifiée** : `--base NONE --head HEAD` → SystemExit + message, exit non-nul ; `--base NONE --head <chemin réel>` → EXIT 0 (même verdict qu'avant).
- **CI non cassée** : `cell-order-gate.yml` passe `--head "$nb"` qui est toujours un chemin existant (`[ -f "$nb" ] || continue`) et `--base` = `NONE` ou fichier extrait par `git show` — le fix ne peut pas la faire échouer.

## Files

- `scripts/notebook_tools/cell_order_ci.py` — docstring (chemins ≠ refs git) + `high_signatures` : chemin fourni mais absent → `SystemExit`
- `scripts/notebook_tools/tests/test_cell_order_ci.py` — `test_missing_path_raises` + `test_ref_git_head_raises` (nouveaux)
- `scripts/notebook_tools/test_cell_order_ci.py` — doublon historique aligné sur le nouveau contrat (3 tests + docstring)

Closes #11213
