### PR TITLE
feat(advisory,#11100): exclure les issues referencees par une PR OUVERTE (verdict in_flight)

### DIFF
--- a/.github/workflows/candidate-delivered-advisory.yml
+++ b/.github/workflows/candidate-delivered-advisory.yml
@@ -23,6 +23,12 @@ name: Candidate-Delivered Advisory
 #     suggested in #10466 was measured firsthand and is UNRELIABLE (EPIC #1454
 #     has no checkboxes; delivered leaf #10143 has 4) -- title/label is the
 #     robust signal. See scripts/candidate_delivered.py.
+#   - Issues referenced by an OPEN PR are excluded as "in_flight" (#11100): a
+#     multi-phase rollout writes the CORRECT `See #N` partial-delivery syntax
+#     and receives no post-merge comments by construction -- the merged+silent
+#     heuristic alone mislabeled exactly that shape (measured on #10984:
+#     open #10986 + six merged PRs). The sweep retracts the label when an
+#     open PR appears, same as it does for post-merge activity.
 
 on:
   schedule:

--- a/scripts/candidate_delivered.py
+++ b/scripts/candidate_delivered.py
@@ -38,6 +38,11 @@ ADVISORY, never auto-close (#10466 "Ce que l'organe ne doit pas faire"):
     robust signal (covers #1454 "[EPIC]", #3801 "EPIC:", #10355/#4362 label
     EPIC). This exclusion rule is written here per acceptance #3 (the motif is
     in the workflow, not patched by hand).
+  - An OPEN PR referencing the issue means work in flight -- excluded as
+    ``in_flight`` (#11100): the correct `See #N` syntax for a partial delivery
+    must not produce the "probably delivered" label. Measured on #10984
+    (open #10986 + six merged PRs = a multi-phase rollout the old heuristic
+    mislabeled). An open *issue* mention does NOT trigger this: only PR refs.
 
 The classification core (``classify``) is a PURE function -- no network -- so it
 is unit-tested with fixtures in ``scripts/tests/test_candidate_delivered.py``.
@@ -94,6 +99,7 @@ def classify(issue: dict, cross_refs: list[dict]) -> tuple[str, str]:
         ``(verdict, detail)`` where verdict is one of:
         ``"epic"``         -- excluded (EPIC by title/label)
         ``"no_delivery"``  -- no merged PR references it
+        ``"in_flight"``    -- an OPEN PR references it: work in progress (#11100)
         ``"active"``       -- a comment landed after the latest merge
         ``"candidate"``    -- delivered + silent: pose the label
     """
@@ -101,6 +107,15 @@ def classify(issue: dict, cross_refs: list[dict]) -> tuple[str, str]:
     labels = issue.get("labels", []) or []
     if is_epic(title, labels):
         return ("epic", f"EPIC by title/label: {title!r}")
+
+    # #11100: an OPEN PR referencing the issue is work in flight -- the
+    # multi-phase rollout shape (e.g. #10984, referenced by open #10986 plus
+    # six merged PRs). Partial deliveries write `See #N` correctly, so the
+    # "merged + silent" heuristic alone mislabels the rollout as delivered.
+    open_prs = [r for r in cross_refs if r.get("is_pr") and r.get("state") == "open"]
+    if open_prs:
+        prs = ", ".join(f"#{r['pr_number']}" for r in open_prs)
+        return ("in_flight", f"open PR(s) {prs} reference this issue")
 
     merged = [r for r in cross_refs if r.get("merged_at")]
     if not merged:
@@ -162,17 +177,26 @@ def _parse_cross_ref_events(events: list[dict]) -> list[dict]:
     GitHub payload-shape handling is unit-tested independently of the network.
     Each event's ``source.issue`` carries a ``pull_request`` sub-object iff the
     referrer is a PR; ``merged_at`` on that sub-object is set iff the PR merged.
-    Non-PR refs (an *issue* citing this one) yield ``merged_at: None`` and are
-    ignored downstream by :func:`classify`, which counts only refs with a merge.
-    Events missing a source issue number are dropped.
+    ``state`` ("open"/"closed") distinguishes an unmerged-but-OPEN PR (work in
+    flight, #11100) from a closed-unmerged one (abandoned lane) -- both carry
+    ``merged_at: None``. Non-PR refs (an *issue* citing this one) yield
+    ``merged_at: None`` and are ignored downstream by :func:`classify`, which
+    counts only refs with a merge. Events missing a source issue number are
+    dropped.
     """
     refs = []
     for ev in events or []:
         src = (ev.get("source") or {}).get("issue") or {}
         if src.get("number") is None:
             continue
+        is_pr = "pull_request" in src  # presence, not truthiness: {} is a PR
         pr = src.get("pull_request") or {}
-        refs.append({"pr_number": src["number"], "merged_at": pr.get("merged_at")})
+        refs.append({
+            "pr_number": src["number"],
+            "merged_at": pr.get("merged_at"),
+            "is_pr": is_pr,
+            "state": src.get("state"),
+        })
     return refs
 
 
@@ -261,7 +285,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.limit:
         issues = issues[: args.limit]
 
-    counts = {"candidate": 0, "active": 0, "no_delivery": 0, "epic": 0}
+    counts = {"candidate": 0, "active": 0, "in_flight": 0, "no_delivery": 0, "epic": 0}
     print(f"[candidate-delivered] repo={repo} mode={'dry-run' if args.dry_run else 'apply'} "
           f"open_issues={len(issues)} label={args.label}")
 
@@ -295,6 +319,12 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  #{number:<6} active     {why}  (label retracted)")
             else:
                 print(f"  #{number:<6} active     {why}")
+        elif verdict == "in_flight":
+            if labeled:  # an open PR appeared since the label was posed -- retract
+                remove_label(repo, number, args.label, args.dry_run)
+                print(f"  #{number:<6} in_flight  {why}  (label retracted)")
+            else:
+                print(f"  #{number:<6} in_flight  {why}")
         elif verdict == "epic":
             print(f"  #{number:<6} EPIC       excluded  ({enriched['title'][:50]})")
         else:  # no_delivery

--- a/scripts/tests/test_candidate_delivered.py
+++ b/scripts/tests/test_candidate_delivered.py
@@ -69,9 +69,44 @@ def test_active_when_comment_after_merge():
 
 def test_no_delivery_when_no_merged_ref():
     issue = _issue(title="fresh idea", comments=[])
-    refs = [{"pr_number": 1, "merged_at": None}]  # open PR, not merged
+    # closed-unmerged PR = abandoned lane, no work in flight
+    refs = [{"pr_number": 1, "merged_at": None, "is_pr": True, "state": "closed"}]
     verdict, _ = classify(issue, refs)
     assert verdict == "no_delivery"
+
+
+def test_in_flight_when_open_pr_references_after_merges():
+    # Mirrors #10984 (#11100): open PR #10986 references the issue BESIDES six
+    # merged PRs -- a multi-phase rollout. Old heuristic: candidate (wrong).
+    issue = _issue(title="rollout phase 7 of N", comments=["2026-08-10T09:00:00Z"])
+    refs = [
+        {"pr_number": 10995, "merged_at": "2026-08-14T23:18:16Z", "is_pr": True, "state": "closed"},
+        {"pr_number": 10986, "merged_at": None, "is_pr": True, "state": "open"},
+        {"pr_number": 11048, "merged_at": "2026-08-15T13:41:32Z", "is_pr": True, "state": "closed"},
+    ]
+    verdict, why = classify(issue, refs)
+    assert verdict == "in_flight"
+    assert "#10986" in why
+
+
+def test_in_flight_even_without_any_merge():
+    # Only an open PR (no merge yet): the issue is being worked on right now.
+    issue = _issue(title="fresh idea", comments=[])
+    refs = [{"pr_number": 1, "merged_at": None, "is_pr": True, "state": "open"}]
+    verdict, _ = classify(issue, refs)
+    assert verdict == "in_flight"
+
+
+def test_open_issue_mention_is_not_in_flight():
+    # A non-PR issue citing this one carries state "open" too -- must NOT
+    # trigger in_flight (only PR refs count as work in flight).
+    issue = _issue(title="x", comments=[])
+    refs = [
+        {"pr_number": 10397, "merged_at": None, "is_pr": False, "state": "open"},
+        {"pr_number": 1, "merged_at": "2026-08-11T06:40:37Z", "is_pr": True, "state": "closed"},
+    ]
+    verdict, _ = classify(issue, refs)
+    assert verdict == "candidate"
 
 
 def test_candidate_when_comment_equals_merge_time():
@@ -99,9 +134,10 @@ def test_is_epic_case_insensitive():
     assert not is_epic("Epictetus notebook", [])  # substring inside a word -- accepted trade-off
 
 
-def _xref_event(src_number, merged_at=None, is_pr=True):
-    """Build one raw GitHub ``cross-referenced`` timeline event (shape from #10403)."""
-    issue = {"number": src_number}
+def _xref_event(src_number, merged_at=None, is_pr=True, state=None):
+    """Build one raw GitHub ``cross-referenced`` timeline event (shape from #10403
+    and #10984: source.issue carries `state`; `pull_request` present iff PR)."""
+    issue = {"number": src_number, "state": state}
     if is_pr:
         issue["pull_request"] = ({"merged_at": merged_at} if merged_at else {})
     return {"event": "cross-referenced", "source": {"issue": issue}}
@@ -110,20 +146,23 @@ def _xref_event(src_number, merged_at=None, is_pr=True):
 def test_parse_cross_ref_events_merged_prs_captured():
     # Mirrors #10403 timeline (measured firsthand): 5 cross-refs, 4 merged.
     events = [
-        _xref_event(10397, is_pr=False),                       # an issue, not a PR
-        _xref_event(10405, merged_at="2026-08-11T04:25:17Z"),  # merged PR
-        _xref_event(10410, merged_at="2026-08-11T06:40:37Z"),  # merged PR
-        _xref_event(10466),                                    # open PR, not merged
-        _xref_event(10507, merged_at="2026-08-11T22:51:43Z"),  # merged PR
+        _xref_event(10397, is_pr=False, state="open"),                       # an issue, not a PR
+        _xref_event(10405, merged_at="2026-08-11T04:25:17Z", state="closed"),  # merged PR
+        _xref_event(10410, merged_at="2026-08-11T06:40:37Z", state="closed"),  # merged PR
+        _xref_event(10466, state="open"),                                     # open PR, not merged
+        _xref_event(10507, merged_at="2026-08-11T22:51:43Z", state="closed"),  # merged PR
     ]
     refs = _parse_cross_ref_events(events)
     assert len(refs) == 5  # all cross-refs kept; classify filters by merged_at
     merged = [r for r in refs if r["merged_at"]]
     assert len(merged) == 3
     assert {r["pr_number"] for r in merged} == {10405, 10410, 10507}
-    # The non-PR issue ref carries merged_at=None (classify ignores it).
+    # The non-PR issue ref carries merged_at=None (classify ignores it)...
     issue_ref = next(r for r in refs if r["pr_number"] == 10397)
-    assert issue_ref["merged_at"] is None
+    assert issue_ref["merged_at"] is None and issue_ref["is_pr"] is False
+    # ...and an open PR ref is marked is_pr + state open (drives in_flight).
+    open_ref = next(r for r in refs if r["pr_number"] == 10466)
+    assert open_ref["is_pr"] is True and open_ref["state"] == "open"
 
 
 def test_parse_cross_ref_events_feeds_classify_candidate():


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: DEEP/notebook-python #11204

Closes #11100 (critères d'acceptance 1, 2 et 4 ; le critère 3 est porté par le sweep lui-même au premier run post-merge)

## Le correctif — verdict `in_flight`

Une issue référencée par une **PR OUVERTE** est du travail en cours : jamais une candidate à fermeture. La syntaxe `See #N` correcte pour une livraison partielle cesse de produire le label « probablement livrée ».

| Changement | Fichier |
|---|---|
| `_parse_cross_ref_events` extrait `is_pr` (présence de clé, pas vérité — `{}` est un PR) et `state` de chaque cross-ref | `scripts/candidate_delivered.py` |
| `classify` : verdict `in_flight` si un PR OPEN référence l'issue ; une mention d'**issue** ouverte (state "open" aussi) ne le déclenche PAS | idem |
| `main` : rétractation du label sur `in_flight`, comme pour `active` | idem |
| Motif #11100 documenté au niveau du workflow | `.github/workflows/candidate-delivered-advisory.yml` |
| 4 nouveaux fixtures + assertions parse | `scripts/tests/test_candidate_delivered.py` |

Piège couvert par test : un cross-ref d'**issue** non-PR porte aussi `state: "open"` — seul `is_pr` distingue le travail en vol d'une simple mention. Et un PR closed-unmerged (lane abandonnée) reste hors in_flight.

## Preuve du payload (mesuré firsthand)

`gh api repos/.../issues/10984/timeline` : chaque event cross-referenced porte `source.issue.state`. Le cas décisif de l'issue rendu :

```
{"merged":null,"ref_src":10986,"state":"open"}     <- PR en vol
{"merged":"2026-08-14T23:18:16Z","ref_src":10995,"state":"closed"}
... 5 autres mergées = rollout multi-phases
```

Critère 4 (#10984 non-labellisé par le workflow durci) : vérifié par lecture timeline directe — le verdict `in_flight` couvre exactement cette forme. (#10984 n'apparaît plus dans le pool ouvert du rejeu : son état a évolué entre-temps, ce qui ne change pas la preuve de forme.)

## Rejeu dry-run (critère 2) — po-2025, branche durcie, 127 issues ouvertes

```
{'candidate': 48, 'active': 29, 'in_flight': 9, 'no_delivery': 10, 'epic': 31}
```

Les 9 `in_flight` (réfs PRs ouvertes #11208-#11221, actives à l'instant) :

```
#11213 in_flight (#11219)          #11162 in_flight (#11221)
#11201 in_flight (#11218)          #11148 in_flight (#11210)
#11157 in_flight (#11216)          #10986 in_flight (#11208)
#9434  in_flight (#11215)          #10996 in_flight (#11209, #11220)  (label RETRAIT)
                                    #10020 in_flight (#11216, #11209)  (label RETRAIT)
```

**Delta immédiat : 2 rétractations** au premier run réel post-merge (#10996, #10020 — labellisées par le workflow actuel, en vol en réalité). Critère 3 (retrait des labels que le critère durci n'aurait pas posés) : porté automatiquement par le sweep — la branche `in_flight` rétracte exactement comme `active`, aucune action manuelle de masse (l'issue l'interdit explicitement).

À noter : #9434 (ombrelle quantitative) et #11157 (ML-3 AutoML) sont captées in_flight par des PRs ouvertes à l'instant — le verdict vit avec le plateau, c'est le comportement attendu.

## Non-inclus (durcissements « à discuter » du body)

Les deux durcissements complémentaires de #11100 (exclusion ≥2 PR mergées `See #N` ; date d'observation portée par le label) sont marqués « à discuter plutôt qu'à imposer » — non implémentés ici, à trancher sur le fil.

## Validation

- `python -m pytest scripts/tests/test_candidate_delivered.py -q` : **14 passed** (10 existants mis à jour + 4 nouveaux).
- Rejeu dry-run complet ci-dessus, exit 0, advisory (jamais bloquant).
