### PR TITLE
fix(tooling,#11111): bound OpenMP/BLAS thread pools in kernel executors (default 4, env override)

### DIFF
--- a/docs/reference/kernels-runtime.md
+++ b/docs/reference/kernels-runtime.md
@@ -86,7 +86,7 @@ grep -o 'id="Microsoft.CodeAnalysis[^"]*" version="[^"]*"' \
   ~/.nuget/packages/<pkg>/<version>/<pkg>.nuspec
 ```
 
-**Piege de diagnostic adjacent** : sur cet hote (32 threads), un notebook .NET non borne en threads OpenMP part en timeouts de cellule qui *ressemblent* a un blocage kernel. `OMP_NUM_THREADS=4` a ramene ce meme notebook de **6 380,9 s (7 cellules en timeout a 900 s)** a **14,8 s** — facteur **x431**. Borner les threads **avant** de conclure a un hang.
+**Piege de diagnostic adjacent** : sur cet hote (32 threads), un notebook .NET non borne en threads OpenMP part en timeouts de cellule qui *ressemblent* a un blocage kernel. `OMP_NUM_THREADS=4` a ramene ce meme notebook de **6 380,9 s (7 cellules en timeout a 900 s)** a **14,8 s** — facteur **x431**. Borner les threads **avant** de conclure a un hang. Les executeurs du depot (`dotnet_executor.py`, `exec_dotnet_persist.py`, `exec_single_cell.py`, `batch_reexecute.py`, `NotebookExecutor.execute_with_papermill`) exportent desormais `OMP_NUM_THREADS`/`OPENBLAS_NUM_THREADS`/`MKL_NUM_THREADS=4` par defaut avant de lancer le kernel (#11111) ; une valeur deja posee dans l'environnement gagne (surcharge explicite pour ne pas brider une machine ou c'est voulu). `wsl_papermill.py` reste hors de ce mecanisme : l'environnement Windows ne traverse pas la frontiere `wsl.exe`.
 
 ## Python 3.10+ (notebooks Python)
 

--- a/scripts/notebook_tools/batch_reexecute.py
+++ b/scripts/notebook_tools/batch_reexecute.py
@@ -27,6 +27,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from notebook_helpers import bound_native_thread_pools
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CATALOG_PATH = REPO_ROOT / "COURSE_CATALOG.generated.json"
 NOTEBOOKS_DIR = REPO_ROOT / "MyIA.AI.Notebooks"
@@ -103,6 +105,10 @@ def read_kernelspec_name(nb_path: Path) -> str:
 
 def execute_notebook(nb_path: Path, kernel: str, timeout: int) -> dict:
     """Execute a single notebook with papermill."""
+    # Bound OpenMP/BLAS pools before spawning papermill: the kernel it
+    # launches inherits the environment; unbounded native training cells
+    # oversubscribe many-core hosts and look frozen (#11111).
+    bound_native_thread_pools()
     backup_path = nb_path.with_suffix(".ipynb.bak")
 
     # Create backup

--- a/scripts/notebook_tools/dotnet_executor.py
+++ b/scripts/notebook_tools/dotnet_executor.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import jupyter_client
 
+from notebook_helpers import bound_native_thread_pools
+
 
 def _drain_iopub(kc, parent_msg_id, deadline_s=5):
     """Best-effort drain of iopub messages until the kernel goes idle or a
@@ -126,6 +128,9 @@ def execute_notebook(notebook_path, kernel_name=".net-csharp", cell_timeout=120,
     start_time = time.time()
 
     try:
+        # Bound OpenMP/BLAS pools: LightGBM unbounded oversubscribes many-core
+        # hosts and training cells look frozen (#11111). Kernel inherits env.
+        bound_native_thread_pools()
         km = jupyter_client.KernelManager(kernel_name=kernel_name)
         km.start_kernel(cwd=str(notebook_dir))
         kc = km.client()

--- a/scripts/notebook_tools/exec_dotnet_persist.py
+++ b/scripts/notebook_tools/exec_dotnet_persist.py
@@ -7,6 +7,8 @@ import time
 import base64
 from pathlib import Path
 
+from notebook_helpers import bound_native_thread_pools
+
 
 def execute_and_persist(notebook_path: str, timeout_per_cell: int = 120):
     """Execute a .NET notebook cell-by-cell and write outputs back."""
@@ -19,6 +21,9 @@ def execute_and_persist(notebook_path: str, timeout_per_cell: int = 120):
     kernel_name = nb.get('metadata', {}).get('kernelspec', {}).get('name', '.net-csharp')
     print(f"Executing {path.name} (kernel={kernel_name})")
 
+    # Bound OpenMP/BLAS pools: LightGBM unbounded oversubscribes many-core
+    # hosts and training cells look frozen (#11111). Kernel inherits env.
+    bound_native_thread_pools()
     km = jupyter_client.KernelManager(kernel_name=kernel_name)
     km.start_kernel()
     kc = km.client()

--- a/scripts/notebook_tools/exec_single_cell.py
+++ b/scripts/notebook_tools/exec_single_cell.py
@@ -33,6 +33,8 @@ import sys
 
 from jupyter_client.manager import start_new_kernel
 
+from notebook_helpers import bound_native_thread_pools
+
 
 def _source(cell) -> str:
     src = cell["source"]
@@ -135,6 +137,9 @@ def main():
         print(f"ERROR: code cell not found (cell-id={args.cell_id} index={args.index})")
         sys.exit(2)
 
+    # Bound OpenMP/BLAS pools: native training cells oversubscribe many-core
+    # hosts and look frozen (#11111). Kernel inherits env.
+    bound_native_thread_pools()
     km, kc = start_new_kernel(kernel_name=args.kernel)
     status = "unknown"
     try:

--- a/scripts/notebook_tools/notebook_helpers.py
+++ b/scripts/notebook_tools/notebook_helpers.py
@@ -1184,6 +1184,9 @@ class NotebookExecutor:
         import sys
         import os as _os
 
+        # Bound OpenMP/BLAS pools before the papermill subprocess spawns: the
+        # kernel it launches inherits the environment (#11111).
+        bound_native_thread_pools()
         start_time = time.time()
         kernel_name = kernel_name or self.detect_kernel(notebook_path)
         timeout = timeout or self.timeout
@@ -1344,6 +1347,31 @@ class NotebookExecutor:
 # ============================================================================
 # Utility functions for common operations
 # ============================================================================
+
+NATIVE_THREAD_POOL_VARS = ("OMP_NUM_THREADS", "OPENBLAS_NUM_THREADS",
+                           "MKL_NUM_THREADS")
+
+
+def bound_native_thread_pools(default: int = 4) -> Dict[str, str]:
+    """Bound native thread pools (OpenMP/BLAS) for kernel subprocesses.
+
+    LightGBM, XGBoost and BLAS spin one OpenMP thread per logical core and
+    spin-wait on barriers; on a busy many-core host the oversubscription
+    turns a 14 s training cell into 500 s+ (measured x35 on ML-3, #11111),
+    with the signature of a "frozen" kernel. Executors call this before
+    launching a kernel so the bound inherits to the kernel subprocess.
+
+    An explicitly pre-set variable wins (no clobbering): a machine where
+    full parallelism is wanted keeps it. Returns the variables actually set.
+    """
+    import os
+    set_vars = {}
+    for var in NATIVE_THREAD_POOL_VARS:
+        if var not in os.environ:
+            os.environ[var] = str(default)
+            set_vars[var] = str(default)
+    return set_vars
+
 
 def read_notebook(path: str) -> Dict[str, Any]:
     """Read notebook JSON from file."""

--- a/scripts/notebook_tools/tests/test_bound_thread_pools.py
+++ b/scripts/notebook_tools/tests/test_bound_thread_pools.py
@@ -1,0 +1,55 @@
+"""Tests for bound_native_thread_pools (#11111) — OpenMP/BLAS bounding.
+
+The function mutates os.environ; every test cleans up the three variables
+so a pre-set machine value or a previous test never leaks across cases.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from notebook_helpers import (
+    NATIVE_THREAD_POOL_VARS,
+    bound_native_thread_pools,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_thread_env(monkeypatch):
+    """Remove the three vars before each test, restore after."""
+    for var in NATIVE_THREAD_POOL_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+class TestBoundNativeThreadPools:
+    def test_sets_all_three_vars_when_absent(self):
+        set_vars = bound_native_thread_pools()
+        for var in NATIVE_THREAD_POOL_VARS:
+            assert os.environ[var] == "4"
+            assert set_vars[var] == "4"
+
+    def test_custom_default(self):
+        bound_native_thread_pools(default=8)
+        assert os.environ["OMP_NUM_THREADS"] == "8"
+
+    def test_preset_value_wins(self):
+        os.environ["OMP_NUM_THREADS"] = "32"
+        set_vars = bound_native_thread_pools()
+        assert os.environ["OMP_NUM_THREADS"] == "32"
+        assert "OMP_NUM_THREADS" not in set_vars
+
+    def test_returns_only_what_it_set(self):
+        os.environ["OPENBLAS_NUM_THREADS"] = "2"
+        set_vars = bound_native_thread_pools()
+        assert set_vars == {"OMP_NUM_THREADS": "4", "MKL_NUM_THREADS": "4"}
+
+    def test_idempotent(self):
+        first = bound_native_thread_pools()
+        second = bound_native_thread_pools()
+        assert first == {"OMP_NUM_THREADS": "4", "OPENBLAS_NUM_THREADS": "4",
+                         "MKL_NUM_THREADS": "4"}
+        assert second == {}


### PR DESCRIPTION
## Summary

Residual scope of #11111 (re-scoped by ai-01 2026-08-16T01:56Z): bound native thread pools (OpenMP/BLAS) at every kernel-launch path of the repo executors, with env override preserved and a before/after measurement cited.

LightGBM, XGBoost and BLAS spin one OpenMP thread per logical core and spin-wait on barriers. On a busy many-core host the oversubscription turns a 14 s training cell into 500 s+ with the signature of a "frozen" kernel (the ×35-×431 contrast in the issue thread is the saturated-host witness).

## Changes

- **`scripts/notebook_tools/notebook_helpers.py`** — new `bound_native_thread_pools(default=4)` exporting `OMP_NUM_THREADS` / `OPENBLAS_NUM_THREADS` / `MKL_NUM_THREADS` when absent. A pre-set variable wins (explicit machine override is never clobbered). Returns the variables actually set (idempotent on second call).
- **5 launch points wired** (call the helper right before spawning the kernel/papermill, so the bound inherits to the subprocess):
  - `dotnet_executor.py`
  - `exec_dotnet_persist.py`
  - `exec_single_cell.py`
  - `batch_reexecute.py` (head of `execute_notebook`)
  - `NotebookExecutor.execute_with_papermill` (notebook_helpers.py)
- **`scripts/notebook_tools/tests/test_bound_thread_pools.py`** — 5 new tests (autouse env-cleanup fixture): all-three-set, custom default, preset-wins, returns-only-what-it-set, idempotent.
- **`docs/reference/kernels-runtime.md`** — documents the mechanism, the env override, and the exclusion.

`wsl_papermill.py` is deliberately **out of scope**: the Windows environment does not cross the `wsl.exe` boundary, so an env var set on the Windows side would not reach the Linux papermill anyway.

## Acceptance vs re-scoped issue (4 items)

| Item | Status |
|------|--------|
| Borne par defaut (=4) aux points de lancement | 5 launch points wired, default 4 |
| Surcharge env (valeur pre-posee gagne) | Implemented + tested (`test_preset_value_wins`, `test_returns_only_what_it_set`) |
| Mesure avant/apres sur ML-3 citee dans le body | See table below (the ×431 thread contrast is the saturated-host witness) |
| Doc kernels-runtime | Paragraph extended at line ~89 |

## Measurement (ML-3-Entrainement&AutoML, .NET kernel, LightGBM cells)

Same host, back-to-back runs via `dotnet_executor.py`:

| Run | Wall time | Cells | Errors |
|-----|-----------|-------|--------|
| BEFORE (unbounded) | 108.7 s | 10/10 | 0 |
| AFTER (OMP/BLAS=4) | 40.6 s | 10/10 | 0 |

×2.7 on a moderately loaded host. The contrast scales with host saturation — the issue-thread witness is ×35-×431 on a fully loaded many-core host (14.1 s bounded vs 496.9 s / up to 6 380.9 s unbounded).

## Tests

`34/34` green: 5 new (`test_bound_thread_pools.py`) + full `scripts/notebook_tools/tests/` regression (incl. `test_batch_reexecute.py`). Import-check of the 4 wired executors OK.

Tooling-only PR — no notebook source changed (the ML-3 write-backs from the measurement runs were restored to origin/main before commit, rule C.3).

Closes #11111

Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #11214

Co-Authored-By: Claude-Code <noreply@anthropic.com>