### PR TITLE
enrich(qc,#11224): QC-Py-41 densite pedagogique 608->1415 — prose FR ancre sur outputs (tranche 1)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-41-PaperTrading-IBKR.ipynb
@@ -89,7 +89,13 @@
   {
    "cell_type": "markdown",
    "id": "f2109681",
-   "source": "### Transition : Vers la definition de la stratégie\n\nMaintenant que nous avons compris les prerequis IBKR, nous allons définir la stratégie momentum cross-section qui sera backtestee puis deployee en paper trading.",
+   "source": [
+    "### Transition : Vers la definition de la stratégie\n",
+    "\n",
+    "Maintenant que nous avons compris les prerequis IBKR, nous allons définir la stratégie momentum cross-section qui sera backtestee puis deployee en paper trading.\n",
+    "\n",
+    "Le paper trading chez un broker traditionnel repond a une question que le backtest ne peut pas trancher : *est-ce que la strategie, telle qu'implementee, se comporte comme prevu quand elle rencontre un vrai carnet d'ordres ?* Le backtest valide la logique ; le paper trading valide l'implementation — ordres, timing, fills, connexion. Les deux echouent pour des raisons differentes, et c'est precisement pour cela qu'ils se completent.\n"
+   ],
    "metadata": {}
   },
   {
@@ -123,7 +129,15 @@
     "1. **Compte IBKR** : ouverture en ligne (KYC, 1-3 jours)\n",
     "2. **TWS ou IB Gateway** : doit tourner en continu\n",
     "3. **Configuration API** : ActiveX/Socket active, port 7497 (paper) / 7496 (live)\n",
-    "4. **Redemarrage hebdomadaire** : IBKR exige un restart avec 2FA chaque semaine"
+    "4. **Redemarrage hebdomadaire** : IBKR exige un restart avec 2FA chaque semaine\n",
+    "\n",
+    "Trois dimensions comptent pour la validation d'une strategie :\n",
+    "\n",
+    "- **La profondeur d'actifs** : la meme infrastructure IBKR execute une strategie equity SP500 et une couverture par futures ou forex ; un testnet crypto ne simule qu'un carnet spot.\n",
+    "- **La qualite du simulateur** : le compte paper IBKR route les ordres vers un moteur de matching qui reproduit les regles du broker (types d'ordres, fills partiels, heures de marche), pas vers un simulateur interne a la plateforme de backtest.\n",
+    "- **Les mises a jour d'execution** : chaque evenement du cycle de vie d'un ordre (soumis, partiellement rempli, rempli, annule) remonte vers l'algorithme — indispensable pour diagnostiquer un fill rate faible ou un slippage anormal.\n",
+    "\n",
+    "Le realisme a un prix operationnel : TWS (ou IB Gateway) doit tourner et rester connecte, une dependance qu'un testnet cloud n'impose pas.\n"
    ]
   },
   {
@@ -181,6 +195,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy41-density-brokers",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture du tableau : le choix broker en trois lignes\n",
+    "\n",
+    "Pour une strategie SP500 mensuelle, trois lignes pesent le plus. *Order Updates* (IBKR : Oui) — on peut auditer chaque fill, indispensable au diagnostic d'execution. *Resolution min* (Tick vs Minute) — le paper TWS reproduit la microstructure, le testnet Binance moyenne. *Fees simulees* — sur une action a $200, Binance facture 0.1% soit $0.20, IBKR $0.005/share : un facteur ~40 qui s'accumule sur 480 trades. La ligne *Prerequis* est le cout inverse (Aucun vs TWS/Gateway), et la derniere ligne nomme le composant central : le paper IBKR passe par TWS Paper sur le port 7497."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 1 : Calcul du taux de remplissage des ordres\n\nEn paper trading IBKR, certains ordres limites ne sont pas remplis. Calculez le **fill rate** : pourcentage d'ordres soumis qui ont ete reellement executes.\n\n**Indices** :\n- `# Indice` : fill_rate = ordres_executes / ordres_soumis * 100\n- `# Étape 1` : Simuler une liste d'ordres avec statut (filled/pending/cancelled)\n- `# Étape 2` : Compter les ordres filled\n- `# Étape 3` : Calculer et afficher le fill rate"
@@ -233,7 +259,15 @@
     "- **Signal** : Return sur 252 jours (12 mois)\n",
     "- **Sélection** : Top 10 momentum (les plus performants)\n",
     "- **Rebalancement** : Mensuel\n",
-    "- **Poids** : Equiponderable (10% par position)"
+    "- **Poids** : Equiponderable (10% par position)\n",
+    "\n",
+    "**Le design en trois choix deliberes** :\n",
+    "\n",
+    "- **Lookback 12 mois** : l'horizon canonique de la litterature momentum (Jegadeesh-Titman). Assez long pour capter la tendance, assez court pour se rebalancer avant l'erosion classique du signal.\n",
+    "- **Top 10 sur top 50** : restreindre l'univers aux 50 plus grosses capitalisations du SP500 elimine les petits noms ou le slippage paper/live diverge ; n'en garder que 10 concentre le signal sans concentrer le risque sectoriel au-dela du raisonnable.\n",
+    "- **Rebalancement mensuel, equal weight** : un turnover maitrise (40%/mois, mesure plus bas) garde les couts de transaction dans la zone ou la comparaison backtest/paper reste interpretable.\n",
+    "\n",
+    "Chaque parametre se falsifie : un lookback de 3 mois expose au reversal court terme documente ; elargir le top 10 dilue le signal.\n"
    ]
   },
   {
@@ -378,8 +412,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy41-density-lean",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture de l'algorithme LEAN\n",
+    "\n",
+    "Le listing (3 529 caracteres) suit la structure canonique LEAN : `initialize()` definit l'univers (top 50 SP500, classe par rendement 12 mois), le calendrier de rebalancement mensuel equal-weight et le warm-up ; le handler de donnees ne fait que mettre a jour les scores — toute la decision vit dans le rebalancement programme. Pour le paper IBKR, **rien ne change dans le code** : c'est la configuration de deploiement (section 4) qui bascule le meme algorithme du node backtest vers le compte paper TWS. Un seul implementation, trois modes d'execution — c'est le point structurel du workflow QC."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d2945c26",
-   "source": "### Transition : Vers le backtest historique\n\nL'algorithme LEAN est maintenant défini. Nous allons l'executer sur des données historiques SP500 (2018-2024) pour valider la performance de la stratégie momentum avant le deploiement en paper trading.",
+   "source": [
+    "### Transition : Vers le backtest historique\n",
+    "\n",
+    "L'algorithme LEAN est maintenant défini. Nous allons l'executer sur des données historiques SP500 (2018-2024) pour valider la performance de la stratégie momentum avant le deploiement en paper trading.\n",
+    "\n",
+    "La sequence backtest -> paper -> live n'est pas une formalite : chaque etape echoue sur des causes differentes. Le backtest echoue sur le biais de donnees ; le paper trading echoue sur l'implementation (ordres, timing, connexion) ; le live echoue sur l'impact de marche. Valider les trois, c'est trier les trois familles de causes.\n"
+   ],
    "metadata": {}
   },
   {
@@ -398,7 +450,9 @@
    "source": [
     "## 3. Backtest Historique\n",
     "\n",
-    "La stratégie momentum est bien documentee dans la litterature academique (Jegadeesh & Titman, 1993). Sur le SP500, le momentum 12 mois a historiquement genere un premium annualise de 5-8%."
+    "La stratégie momentum est bien documentee dans la litterature academique (Jegadeesh & Titman, 1993). Sur le SP500, le momentum 12 mois a historiquement genere un premium annualise de 5-8%.\n",
+    "\n",
+    "Les resultats ci-dessous sont **simules** (reproduits d'un backtest QC de reference, en pratique via `read_backtest` MCP) : ils servent de support de lecture, pas de preuve. La methode de lecture — comparer au benchmark, ajuster au risque, puis douter des couts — est ce qui reste transferable.\n"
    ]
   },
   {
@@ -482,6 +536,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy41-density-backtest",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture du resultat : +142% total, Sharpe 0.95, MaxDD -32.1%\n",
+    "\n",
+    "Les trois nombres se lisent ensemble. Le **+142% sur 2018-2024** parait convaincant tant qu'on ne le rapporte pas : le SPY Buy & Hold fait **+118%** et l'equal-weight top-50 **+95%** sur la meme periode — l'exces du momentum vaut ~24 points sur 7 ans, soit ~3%/an d'alpha apparent. Le **Sharpe 0.95** (sous 1) tempere : l'edge est reel mais fin, et le **beta 1.05** confirme que la strategie reste un vehicule long action booste, pas une source de decorrelation. Le **MaxDD -32.1%** depasse celui du benchmark sur la periode — la concentration top-10 paie en trend et souffre en crash, exactement ce que le filtre de volatilite de la section 7 cherchera a amortir. Enfin, **480 trades, 62% de mois gagnants** : coherent avec un Sharpe < 1 — assez de bons mois pour compenser les mauvais, pas assez pour une conviction elevee. Rappel d'honnetete : ces metriques sont **simulees**, reproduites d'un backtest de reference pour l'exercice de lecture."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 2 : Estimation des couts de transaction IBKR\n\nEstimez les **couts de transaction mensuels** pour une stratégie SP500 momentum avec IBKR : frais de commission ($0.005/action), frais SEC, et slippage estime.\n\n**Indices** :\n- `# Indice` : IBKR commission = $0.005 par action, minimum $1.00\n- `# Indice` : Estimez 4 trades par semaine, 100 actions par trade\n- `# Étape 1` : Calculer le cout par trade (commission + SEC fee)\n- `# Étape 2` : Multiplier par le nombre de trades mensuel\n- `# Étape 3` : Ajouter le slippage estime (5 bps par trade)"
@@ -509,7 +575,13 @@
   {
    "cell_type": "markdown",
    "id": "d08f8062",
-   "source": "### Synthese : Paper Trading avec IBKR\n\nCe notebook a presente le workflow complet de backtest vers paper trading sur equities via Interactive Brokers. La stratégie momentum SP500 a demontre une performance historique solide avec un CAGR de 13.6%, mais necessite une surveillance continue du TWS pour garantir la connexion stable.",
+   "source": [
+    "### Synthese : Paper Trading avec IBKR\n",
+    "\n",
+    "Ce notebook a presente le workflow complet de backtest vers paper trading sur equities via Interactive Brokers. La stratégie momentum SP500 a demontre une performance historique solide avec un CAGR de 13.6%, mais necessite une surveillance continue du TWS pour garantir la connexion stable.\n",
+    "\n",
+    "La synthese a retenir avant deploiement : le paper trading IBKR ne **prouve** pas que la strategie fera de l'argent (le backtest est simule, et le paper herite de ses hypotheses) — il prouve que la strategie **s'execute** comme concue : les ordres partent, se remplissent aux prix attendus, et l'equity curve paper suit la backteste a l'interieur d'une bande de bruit mesurable.\n"
+   ],
    "metadata": {}
   },
   {
@@ -582,6 +654,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy41-density-equity",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture des courbes\n",
+    "\n",
+    "La figure genere deux trajectoires simulees (seed fixe 42, rendements hebdomadaires tires) : la momentum en bleu, le SPY en benchmark orange. Ce qui interesse l'oeil n'est pas la pente finale mais les **episodes de divergence** — les periodes ou la momentum creuse un ecart puis le rend. En paper trading reel, la comparaison pertinente n'est pas cette courbe simulee mais **equity paper vs equity backtest** : deux courbes issues du meme signal doivent rester dans une bande etroite ; une divergence croissante signale que l'execution (fills, timing) n'implemente pas la meme strategie que le modele."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "027dd943",
    "metadata": {
     "papermill": {
@@ -608,7 +692,13 @@
     "   - Port : **7497** (paper) / 7496 (live)\n",
     "   - Deconnecter \"Read-Only API\"\n",
     "4. IB Gateway (alternative a TWS, plus leger)\n",
-    "5. Redemarrage hebdomadaire avec 2FA"
+    "5. Redemarrage hebdomadaire avec 2FA\n",
+    "\n",
+    "**Les prerequis en pratique** :\n",
+    "\n",
+    "- **TWS ou IB Gateway** : la passerelle locale qui parle le protocole IBKR. TWS (interface complete) convient au debugging ; IB Gateway (headless) a la production paper. Port **7497** en paper, **7496** en live — les confondre est l'erreur classique qui fait tourner une strategie \"paper\" sur un compte reel.\n",
+    "- **Compte paper IBKR** : gratuit, ouvert depuis le compte reel, capital virtuel configurable.\n",
+    "- **Redemarrage hebdomadaire** : l'API IBKR exige une re-authentification periodique (champ `ib-weekly-restart-utc-time` dans la configuration ci-dessous) — un paper trading IBKR ne tourne pas indefiniment sans intervention planifiee.\n"
    ]
   },
   {
@@ -712,7 +802,9 @@
     "\n",
     "```\n",
     "Internet → QC Node Live → API Socket → TWS (local) → IBKR Paper Market\n",
-    "```"
+    "```\n",
+    "\n",
+    "Le deploiement suit le chemin MCP standard (compile -> node -> create_live avec la configuration IBKR), avec une difference notoire : la configuration exige les identifiants IBKR **et** suppose que TWS tourne cote machine au moment du deploiement. Les identifiants restent dans les champs securises QC, jamais dans le notebook (regle secrets : aucun literal).\n"
    ]
   },
   {
@@ -736,7 +828,13 @@
     "Points spécifiques IBKR a surveiller :\n",
     "- **Connection TWS** : si TWS s'arrete, le node live perd la connexion\n",
     "- **Weekly restart** : verifier que le redemarrage automatique fonctionne\n",
-    "- **Order fills** : les fills paper TWS peuvent differer legerement du live"
+    "- **Order fills** : les fills paper TWS peuvent differer legerement du live\n",
+    "\n",
+    "**Que surveiller, dans l'ordre de gravite** :\n",
+    "\n",
+    "1. **La connexion TWS** : premier point de rupture (impact Eleve dans la table d'ecarts de cette section). Une deconnexion prolongee laisse des ordres orphelins cote broker.\n",
+    "2. **Le fill rate et le slippage** : l'ecart systematique entre prix backtest et prix paper est le premier signal que l'implementation diverge du modele.\n",
+    "3. **La tracking error vs backtest** : l'equity paper doit suivre la backteste a l'interieur d'une bande ; en sortir revelerait un bug de calendrier de rebalancement ou un univers desynchronise.\n"
    ]
   },
   {
@@ -795,6 +893,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy41-density-ecarts",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture de la table d'ecarts\n",
+    "\n",
+    "Sur les cinq sources d'ecart, trois sont **Faible** — le privilege d'un univers SP500 top-50 tres liquide avec des positions petites face au volume quotidien. La ligne qui commande l'attention est **Connection (Eleve)** : TWS est un processus desktop dont depend toute la chaine ; s'il plante ou se deconnecte, les ordres en vol restent cote broker sans que l'algorithme le voie. C'est pourquoi le monitoring de la section 6 met la connexion en tete, et pourquoi IB Gateway (headless) est preferable des qu'on laisse tourner plus de quelques jours. *Timing (Moyen)* est le seul ecart proprement economique : quelques millisecondes de latence TWS + noeud QC, sans effet mesurable au rebalancement mensuel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 3 : Checklist de validation paper-to-live\n\nCréez une **checklist de validation** avant de passer du paper trading au live trading avec IBKR. Chaque item doit avoir un seuil quantitatif.\n\n**Indices** :\n- `# Indice` : Inspirez-vous de la checklist du notebook QC-Py-27\n- `# Étape 1` : Lister les metriques cles (Sharpe, Drawdown, Fill Rate, Slippage)\n- `# Étape 2` : Définir un seuil pour chaque metrique\n- `# Étape 3` : Créer un DataFrame avec les items et les seuils"
@@ -840,7 +950,9 @@
     "### Approche proposee\n",
     "- Calculer la volatilite realisee du SP500 sur 20 jours\n",
     "- Si vol > seuil, reduire le nombre de positions (ou passer en cash)\n",
-    "- Paramètres a optimiser : `vol_period`, `vol_threshold`, `reduction_factor`"
+    "- Paramètres a optimiser : `vol_period`, `vol_threshold`, `reduction_factor`\n",
+    "\n",
+    "**Pourquoi un filtre de volatilite** : le momentum concentre ses pertes exactement quand la volatilite explose — les positions momentum correlent negativement avec la vol dans les queues de distribution. Reduire l'exposition quand la vol depasse un seuil ne corrige pas la logique, elle redimensionne la queue de perte. C'est l'exemple guide le plus proche d'une amelioration que le paper trading permet de mesurer honnetement : comparer la courbe avec et sans filtre sur la meme periode.\n"
    ]
   },
   {
@@ -989,7 +1101,16 @@
     "### References\n",
     "- Jegadeesh & Titman (1993), \"Returns to Buying Winners and Selling Losers\"\n",
     "- [QC IBKR Brokerage Docs](https://www.quantconnect.com/docs/v2/our-platform/live-trading/brokerages/interactive-brokers)\n",
-    "- [QC Paper Trading](https://www.quantconnect.com/docs/v2/our-platform/live-trading/brokerages/quantconnect-paper-trading)"
+    "- [QC Paper Trading](https://www.quantconnect.com/docs/v2/our-platform/live-trading/brokerages/quantconnect-paper-trading)\n",
+    "\n",
+    "**Ce qu'il faut retenir** :\n",
+    "\n",
+    "1. Le paper trading IBKR valide l'**implementation**, pas l'alpha — les metriques backtest de ce notebook sont simulees et servent d'illustration.\n",
+    "2. La comparaison Binance vs IBKR est une question de **fidelite du simulateur** (tick, order updates, multi-asset) contre **simplicite d'acces** (testnet gratuit, zero prerequis).\n",
+    "3. La chaine TWS (port 7497, redemarrage hebdo) est le prix operationnel du realisme — et le premier point de panne a monitorer.\n",
+    "4. La demarche paper-to-live se gate avec des seuils quantitatifs (fill rate, slippage, tracking error), jamais avec des impressions.\n",
+    "\n",
+    "**Et apres** : QC-Py-27 (Production Deployment) pousse le passage au live ; le filtre de volatilite de l'exemple guide se benchmark proprement sur la periode 2018-2024 simulee plus haut.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: LIGHT/notebook-python #11215 (substance distincte : prose pedagogique ancre vs doc-honesty header)

## Summary

Tranche 1 du tracker #11224 (densite pedagogique famille QC, pattern #10488) : **QC-Py-41-PaperTrading-IBKR**, pire de la famille a **608**, passe a **1415** (16 989 chars de prose / 12 cellules code).

Enrichissement **markdown-only FR** : 11 appends sur cellules existantes + 5 interps nouvelles inserees **immediatement apres le code dont l'output porte la valeur citee** ([cell-interpretation-ordering](../../blob/main/.claude/rules/cell-interpretation-ordering.md), lecon #10678) :

- apres cell 4 (table comparison) : lecture broker en 3 lignes — fees $0.005/share vs 0.1% = facteur ~40 sur $200, Order Updates, Tick vs Minute
- apres cell 9 (algo LEAN, output « Taille: 3529 caracteres ») : structure canonique, 1 implementation / 3 modes d'execution
- apres cell 12 (metriques backtest) : lecture croisee +142% / Sharpe 0.95 / MaxDD -32.1% vs benchmarks +118% / +95%, alpha apparent ~3%/an, honnetete « metriques simulees »
- apres cell 16 (equity curves, source `np.random.seed(42)`, hebdo) : lecture des divergences, paper vs backtest
- apres cell 21 (table ecarts) : 3 Faible / 1 Moyen / 1 Eleve (TWS = point de panne)

Toutes les valeurs citees verifiees **firsthand** contre les outputs committes avant redaction (G.1) — deux erreurs de draft corrigees par cette verification (math des fees, compte des lignes « Faible »).

## Diff

- 132+/11- sur **cellules markdown uniquement** : 12 cellules code byte-identical (verifie programmatiquement old vs new), 16 -> 21 cellules markdown
- Exempt de re-execution (C.3 markdown-only) ; stubs exercices C.1 intacts (0 violation)

## Validation

- `pedagogy_density.py --json` : 608 -> **1415**, label `pedagogy-density-below-threshold` leve (below_threshold 0)
- `validate_pr_notebooks.py origin/main <path>` : **PASS 12/12** cellules code
- `scan_cell_ordering.py` : 1 scanned, **0 finding**
- Pre-commit H.3 + gitleaks + probeAddresses : Passed

See #11224
