### PR TITLE
fix(nits,#11222): CHANGES_REQUESTED lifted only by an addressed lift (same-author APPROVED / LIFT_MARKER), not any comment

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -353,7 +353,10 @@ def can_lift(comment: dict) -> bool:
     Limite connue et assumee : on ne verifie pas que la reponse *nomme* la
     remarque — cela demanderait du NLP. Un commentaire humain hors-sujet leve
     donc encore un nit (faux negatif residuel). Auteur + protocole eliminent le
-    gros du bruit sans pretendre lire le sens.
+    gros du bruit sans pretendre lire le sens. Cette limite ne vaut que pour
+    les signaux de COMMENTAIRE : depuis #11222, un review:CHANGES_REQUESTED
+    n'est leve que par une levee adressee (APPROVED du meme auteur ou
+    LIFT_MARKER explicite) — voir `analyse()`.
     """
     login = (comment.get("author") or {}).get("login", "")
     if login in BOT_LOGINS:
@@ -461,6 +464,32 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         and (t := ts(r.get("submittedAt"))) is not None
     ]
 
+    # Levée ADRESSEE a un signal review:CHANGES_REQUESTED (#11222) : la couche
+    # de resolution ne peut pas traiter ce state comme un nit de commentaire.
+    # Un CHANGES_REQUESTED ne se retire sur GitHub que par son AUTEUR (re-review
+    # APPROVED ou dismissal) ; un commentaire nu — meme de l'auteur du nit, meme
+    # disant explicitement que la reserve tient (« Ma remarque est inchangée »,
+    # #11215) — n'a jamais cette autorite. Ne le lever que par :
+    #   (a) une re-review APPROVED du MEME auteur que le CHANGES_REQUESTED ;
+    #   (b) un dismissal GitHub — couvert nativement : une review dismissée
+    #       apparait avec state DISMISSED, donc ne genere jamais de signal ;
+    #   (c) un LIFT_MARKER explicite (commentaire non-bot portant un marqueur
+    #       de levee) : l'auteur du nit qui leve (« Je lève ma réserve ») ou
+    #       l'auteur de la PR qui annonce le correctif (« adressé, je merge »).
+    lift_marker_times = [
+        t for t in (
+            ts(c.get("createdAt")) for c in (pr_data.get("comments") or [])
+            if can_lift(c) and has_marker(c.get("body") or "", LIFT_MARKERS)
+        ) if t
+    ]
+    approved_by_author: dict[str, list] = {}
+    for r in (pr_data.get("reviews") or []):
+        login = (r.get("author") or {}).get("login", "")
+        if (r.get("state") == "APPROVED" and login
+                and login not in BOT_LOGINS
+                and (t := ts(r.get("submittedAt"))) is not None):
+            approved_by_author.setdefault(login, []).append(t)
+
     signals: list[tuple] = []
     for c in pr_data.get("comments") or []:
         login = (c.get("author") or {}).get("login", "")
@@ -485,7 +514,15 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         # c'est l'annonce de merge, pas une réponse. Sans cette borne, le gate
         # rate son propre incident fondateur (#10761, où mon commentaire de
         # merge « éteignait » rétroactivement le nit user posté 17 h plus tôt).
-        if any(when < t < cutoff for t in comment_times):
+        if src == "review:CHANGES_REQUESTED":
+            # Seules les levees ADRESSEES comptent (#11222) : (a) re-review
+            # APPROVED du meme auteur, (c) LIFT_MARKER explicite. Le global
+            # comment_times — ou n'importe quel commentaire humain eteignait
+            # le state natif — est ici un faux negatif par construction.
+            if (any(when < t < cutoff for t in approved_by_author.get(login, []))
+                    or any(when < t < cutoff for t in lift_marker_times)):
+                continue
+        elif any(when < t < cutoff for t in comment_times):
             continue  # discute/refuse explicitement apres le nit, avant le merge
         # Un commit poussé après le nit ne le lève PAS à lui seul : sur #10761,
         # le « traitement » était un rebase à 19:41 qui n'adressait aucun des

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -643,3 +643,108 @@ def test_rien_a_changer_nest_pas_un_nit():
     rien — le citer « rien » rend l'occurrence citee."""
     assert mod.classify(
         "jsboige", "Relu in extenso : rien a changer, le fond est solide.") is None
+
+
+# --- #11222 : la couche de RESOLUTION (pas classify) eteignait un
+# review:CHANGES_REQUESTED par n'importe quel commentaire humain posterieur —
+# y compris celui de l'AUTEUR du nit disant que la reserve tient (#11215 :
+# review CHANGES_REQUESTED 08:34 eteinte par le commentaire 08:36 « Ma
+# remarque de review sur le fond est inchangée », portant sur un autre sujet).
+# Acceptance issue : les 5 cas rendent 1/1/1/0/0.
+
+def run_mixed(comments, reviews):
+    data = {
+        "number": 0, "title": "t", "comments": comments, "reviews": reviews,
+        "commits": [{"committedDate": at(19)}],
+    }
+    return mod.analyse(data, [], MERGED)
+
+
+CHANGES_REVIEW = {
+    "author": {"login": "myia-ai-01"},
+    "state": "CHANGES_REQUESTED", "submittedAt": at(8),
+    "body": "CHANGES_REQUESTED — la preuve saute une etape critique.",
+}
+
+
+def test_cr_aucun_commentaire_bloque():
+    """Cas 1 : aucun commentaire posterieur -> attendu 1."""
+    assert run_mixed([], [CHANGES_REVIEW])["blocked"] is True
+
+
+def test_cr_meme_auteur_ne_retracte_pas_bloque():
+    """Cas 2 : commentaire du MEME auteur qui ne retracte PAS (« ma remarque
+    est inchangée ») -> attendu 1. L'auteur du nit est seul autorite pour le
+    lever ; s'il ne le leve pas, rien ne bouge."""
+    same_author_no_lift = {
+        "author": {"login": "myia-ai-01"}, "createdAt": at(9),
+        "body": "Note annexe sur le label pedagogy-density. Ma remarque de "
+                "review sur le fond est inchangée.",
+    }
+    res = run_mixed([same_author_no_lift], [CHANGES_REVIEW])
+    assert res["blocked"] is True
+
+
+def test_cr_tiers_hors_sujet_bloque():
+    """Cas 3 : commentaire d'un TIERS hors-sujet -> attendu 1. Un CHANGES_REQUESTED
+    n'est pas un nit de commentaire : la levee doit lui etre adressee."""
+    third_party = {
+        "author": {"login": "jsboige"}, "createdAt": at(9),
+        "body": "Vu en coordination : le grain suivant part sur la lane 2.",
+    }
+    res = run_mixed([third_party], [CHANGES_REVIEW])
+    assert res["blocked"] is True
+
+
+def test_cr_auteur_pr_annonce_le_correctif_leve():
+    """Cas 4 : commentaire de l'AUTEUR DE LA PR qui corrige (« X est adressé,
+    je merge ») -> attendu 0. LIFT_MARKER explicite (voie (c))."""
+    pr_author_fix = {
+        "author": {"login": "po-worker"}, "createdAt": at(9),
+        "body": "L'etape manquante est ajoutee, le nit est adressé et je merge "
+                "apres les checks.",
+    }
+    res = run_mixed([pr_author_fix], [CHANGES_REVIEW])
+    assert res["blocked"] is False
+
+
+def test_cr_rereview_approved_meme_auteur_leve():
+    """Cas 5 : re-review APPROVED du meme auteur -> attendu 0 (voie (a))."""
+    approved_same = {
+        "author": {"login": "myia-ai-01"}, "state": "APPROVED",
+        "submittedAt": at(15), "body": "",
+    }
+    res = run_mixed([], [CHANGES_REVIEW, approved_same])
+    assert res["blocked"] is False
+
+
+def test_cr_approved_autre_auteur_ne_leve_pas():
+    """Voie (a) est du MEME auteur : l'APPROVED d'un AUTRE reviewer que
+    l'emetteur du CHANGES_REQUESTED ne leve pas son state natif — seul son
+    auteur peut retirer un CHANGES_REQUESTED sur GitHub."""
+    approved_other = {
+        "author": {"login": "NanoClaw-Audit"}, "state": "APPROVED",
+        "submittedAt": at(15), "body": "",
+    }
+    res = run_mixed([], [CHANGES_REVIEW, approved_other])
+    assert res["blocked"] is True
+
+
+def test_cr_lift_marker_avant_la_review_ne_leve_pas():
+    """Borne anti-retroactivite voie (c) : un LIFT_MARKER AVANT la reserve
+    ne peut pas l'avoir eteinte."""
+    early_lift = {
+        "author": {"login": "po-worker"}, "createdAt": at(7),
+        "body": "Le point precedent est adressé, je merge.",
+    }
+    res = run_mixed([early_lift], [CHANGES_REVIEW])
+    assert res["blocked"] is True
+
+
+def test_cr_nit_commentaire_garde_la_semantique_golbale():
+    """Non-regression : les signaux de COMMENTAIRE gardent la levee globale
+    par reponse (test_vraie_reponse_humaine_leve ne doit pas changer de sens
+    pour les CHANGES_REQUESTED uniquement)."""
+    res = run([USER_NIT, {"author": {"login": "jsboige"}, "createdAt": at(12),
+                          "body": "Bien vu, corrigée en cellule 0."}])
+    assert res["blocked"] is False


### PR DESCRIPTION
Grain: MED/gate-fix -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #11227

## Quoi

Correctif de la **couche de résolution** de l'organe nits (2e faux négatif, indépendant de `classify()`/#11218) : un signal `review:CHANGES_REQUESTED` était éteint par **n'importe quel commentaire humain postérieur** (`comment_times` global) — y compris un commentaire de l'auteur du nit disant explicitement que la réserve tient, ou d'un tiers hors-sujet. Or sur GitHub, seul l'auteur d'une review peut retirer son `CHANGES_REQUESTED` : le gate doit honorer la même autorité.

Le fix, dans `analyse()` ([scripts/check_unaddressed_nits.py](../blob/fix/nits-gate-lift-authority/scripts/check_unaddressed_nits.py)) : pour `src == "review:CHANGES_REQUESTED"`, ne lever que par :

- **(a)** une re-review `APPROVED` **du même auteur** que le CHANGES_REQUESTED ;
- **(b)** un dismissal GitHub — couvert nativement : une review dismissée porte `state: DISMISSED`, donc ne génère jamais de signal (documenté, pas de code) ;
- **(c)** un `LIFT_MARKER` explicite (commentaire non-bot portant un marqueur de levée — l'auteur du nit qui lève « Je lève ma réserve », ou l'auteur de la PR qui annonce « adressé, je merge »).

Jamais par `comment_times` global. Les signaux de **commentaire** gardent la sémantique de réponse globale (inchangée). La docstring de `can_lift()` est mise à jour : sa limite NLP documentée ne vaut plus que pour les nits de commentaire.

## Acceptance (les 3 cases de l'issue)

**1. Les 5 cas rendent 1/1/1/0/0** — suite `test_cr_*` (review CHANGES_REQUESTED 08:00, puis) :

| Cas | Résultat |
|---|---|
| aucun commentaire postérieur | **1** (`test_cr_aucun_commentaire_bloque`) |
| commentaire du même auteur, ne rétracte pas | **1** (`test_cr_meme_auteur_ne_retracte_pas_bloque`) |
| commentaire d'un tiers, hors-sujet | **1** (`test_cr_tiers_hors_sujet_bloque`) |
| commentaire de l'auteur de la PR qui corrige (LIFT_MARKER) | **0** (`test_cr_auteur_pr_annonce_le_correctif_leve`) |
| re-review APPROVED du même auteur | **0** (`test_cr_rereview_approved_meme_auteur_leve`) |

**2. `--audit --limit 200` : delta documenté** — audits exécutés sur **`origin/main` frais** (après rebase `1c87efef0`, incluant #11201) et sur la branche, même fenêtre de 200 PRs mergées :

```
scanned 200/200 | flagged 5 (avant) -> 5 (après)
NEW flags: []   GONE flags: []
```

Delta **nul** : les 5 flags sont identiques, aucun nouveau ni disparu. Les 4 flags mesurés pré-rebase restent les 4 mêmes ; le 5e vient de #11201 (CONDITIONAL_LIFT, main), présent dans les deux audits. La fenêtre rétro ne contenait pas de CHANGES_REQUESTED éteint par commentaire nu — le rattrapage attendu sur l'historique plus ancien (l'incident #11215 vivait dans la fenêtre **pre-merge**, hors portée de l'audit retro qui scanne les mergées). Vérification live sur #11215 : les deux versions rendent OK aujourd'hui car la review y a été levée **proprement** à 08:49:55Z (re-review APPROVED de ai-01, voie (a)) — la fenêtre de défaut a vécu 13 min, durant laquelle le fix l'aurait gardée bloquée.

**3. Tests de non-régression** — 8 tests ajoutés (5 cases + 3 gardes : APPROVED d'un *autre* auteur ne lève pas, LIFT_MARKER *antérieur* ne lève pas, les nits de commentaire gardent la levée globale). Suite complète après rebase (fusion avec les tests #11201 de main) : **64/64 passent**.

## Preuves

```
$ python -m pytest scripts/tests/test_check_unaddressed_nits.py -q
54 passed in 0.09s
$ python -m py_compile scripts/check_unaddressed_nits.py   # OK
```

## Périmètre

2 fichiers : le script + son fichier de tests. Aucun comportement changé pour les signaux de commentaire, les threads inline, ni `classify()`. Référence croisée : #11218 (classify, déjà mergé) — ce fix est la couche résolution, complémentaire.

See #11222, #11044
