### PR TITLE
fix(gate,#11222): un CHANGES_REQUESTED n'est retirable que par son auteur ou une phrase

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -454,12 +454,29 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     # reserve (« NOT FIXED », #2298) ne doit rien eteindre, et l'agent
     # d'exclusion can_lift ne s'applique pas — un state APPROVED n'est pas du
     # bruit de protocole, meme depuis un reviewer bot.
-    comment_times += [
-        t for r in (pr_data.get("reviews") or [])
+    approved_rereviews = [
+        (ts(r.get("submittedAt")), (r.get("author") or {}).get("login", ""))
+        for r in (pr_data.get("reviews") or [])
         if r.get("state") == "APPROVED"
         and (r.get("author") or {}).get("login", "") not in BOT_LOGINS
-        and (t := ts(r.get("submittedAt"))) is not None
     ]
+    approved_rereviews = [(t, a) for (t, a) in approved_rereviews if t]
+    comment_times += [t for (t, _) in approved_rereviews]
+
+    # Fenetre 2026-08-16 (#11222) : les temps plats ne suffisent pas pour un
+    # CHANGES_REQUESTED. Une PHRASE explicite de levee (LIFT_MARKER non
+    # conditionnel) dans un commentaire qui peut lever reste une levee pour
+    # l'etat de review — c'est la reponse ecrite que B.0 exige. On garde
+    # l'auteur pour la branche dedicated ci-dessous.
+    explicit_lifts = [
+        (ts(c["createdAt"]), (c.get("author") or {}).get("login", ""),
+         c.get("body", ""))
+        for c in (pr_data.get("comments") or [])
+        if can_lift(c)
+        and has_marker(c.get("body", ""), LIFT_MARKERS)
+        and not CONDITIONAL_LIFT.search(c.get("body", ""))
+    ]
+    explicit_lifts = [x for x in explicit_lifts if x[0] is not None]
 
     signals: list[tuple] = []
     for c in pr_data.get("comments") or []:
@@ -470,6 +487,11 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     for r in pr_data.get("reviews") or []:
         login = (r.get("author") or {}).get("login", "")
         body = r.get("body", "")
+        if r.get("state") == "DISMISSED":
+            # Une dismissal GitHub n'est possible que par l'auteur de la review
+            # (ou un admin) : la reserve est formellement RETIREE par son
+            # emetteur — pas un signal (#11222, levée (b)).
+            continue
         kind = classify(login, body)
         if r.get("state") == "CHANGES_REQUESTED":
             kind = "BOT-CONCERN" if kind is None else kind
@@ -485,7 +507,30 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         # c'est l'annonce de merge, pas une réponse. Sans cette borne, le gate
         # rate son propre incident fondateur (#10761, où mon commentaire de
         # merge « éteignait » rétroactivement le nit user posté 17 h plus tôt).
-        if any(when < t < cutoff for t in comment_times):
+        if src == "review:CHANGES_REQUESTED":
+            # Fenetre 2026-08-16 (#11222) : un CHANGES_REQUESTED est un ETAT
+            # GitHub natif, pas une remarque en prose — un commentaire
+            # posterieur quelconque ne l'eteint pas. Sur #11215, la review de
+            # 08:34:39 etait eteinte par le commentaire 08:36:23 de son
+            # PROPRE auteur (« Ma remarque de review sur le fond est
+            # inchangee ») : le gate rendait EXIT=0. Le principe du state
+            # natif (deja applique a la LEVEE par la re-review APPROVED
+            # ci-dessus) est honore dans l'autre sens : l'etat ne se retire
+            # que par son AUTEUR (re-review APPROVED ; la dismissal est
+            # eliminee des la collecte), ou par une PHRASE explicite de levee
+            # (B.0 : ce qui leve une remarque est une phrase). Les nits portes
+            # par un COMMENTAIRE gardent le regime general ci-dessous — limite
+            # NLP documentee dans can_lift.
+            lifted = any(
+                when < t < cutoff and author == login
+                for (t, author) in approved_rereviews
+            ) or any(
+                when < t < cutoff
+                for (t, _, _) in explicit_lifts
+            )
+            if lifted:
+                continue
+        elif any(when < t < cutoff for t in comment_times):
             continue  # discute/refuse explicitement apres le nit, avant le merge
         # Un commit poussé après le nit ne le lève PAS à lui seul : sur #10761,
         # le « traitement » était un rebase à 19:41 qui n'adressait aucun des

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -643,3 +643,99 @@ def test_rien_a_changer_nest_pas_un_nit():
     rien — le citer « rien » rend l'occurrence citee."""
     assert mod.classify(
         "jsboige", "Relu in extenso : rien a changer, le fond est solide.") is None
+
+
+# --- #11222 : le deuxieme faux negatif du gate. `analyse()` eteignait TOUT
+# signal par n'importe quel commentaire posterieur (comment_times plat). Pour
+# un CHANGES_REQUESTED — un ETAT GitHub natif — c'est intenable : sur #11215,
+# la review de 08:34:39Z etait eteinte par le commentaire de 08:36:23Z de son
+# PROPRE auteur ecrivant que la remarque tient, et le gate rendait EXIT=0.
+# Matrice d'acceptation mesuree par ai-01 sur le cas reel : 1/1/1/0/0.
+
+CR_REVIEW = {
+    "author": {"login": "myia-ai-01"},
+    "state": "CHANGES_REQUESTED", "submittedAt": at(10),
+    "body": "CHANGES_REQUESTED: la cellule 19 apprend le mauvais instrument.",
+}
+
+
+def run_cr(comments=(), reviews=()):
+    data = {
+        "number": 0, "title": "t", "comments": list(comments),
+        "reviews": [CR_REVIEW, *reviews],
+        "commits": [{"committedDate": at(19)}],
+    }
+    return mod.analyse(data, [], MERGED)
+
+
+def test_cr_cas1_aucun_commentaire_bloque():
+    assert run_cr()["blocked"] is True
+
+
+def test_cr_cas2_commentaire_de_son_propre_auteur_ne_leve_pas():
+    """Le repro exact de #11215 : l'auteur du nit repond que le nit tient —
+    l'ancien comment_times plat l'eteignait quand meme (faux negatif)."""
+    reply = {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+             "body": "Ma remarque de review sur le fond est inchangee."}
+    assert run_cr([reply])["blocked"] is True
+
+
+def test_cr_cas3_commentaire_tiers_hors_sujet_ne_leve_pas():
+    """Limite NLP documentee dans can_lift : un commentaire humain hors-sujet
+    leve un nit PORTE PAR COMMENTAIRE ; il n'eteint pas un etat de review."""
+    bystander = {"author": {"login": "po-2023-worker"}, "createdAt": at(12),
+                 "body": "Base verifiee de mon cote, plus de conflit."}
+    assert run_cr([bystander])["blocked"] is True
+
+
+def test_cr_cas4_phrase_de_levee_leve():
+    """La reponse ecrite que B.0 exige : l'auteur de la PR repond AVEC un
+    marqueur de levee (« sont adresses ») — l'etat se leve."""
+    fix = {"author": {"login": "jsboige"}, "createdAt": at(12),
+           "body": "Les 2 points sont adresses : cellule 19 remplacee par "
+                   "strip_lean_comments, commit abc123."}
+    assert run_cr([fix])["blocked"] is False
+
+
+def test_cr_cas5_rereview_approved_meme_auteur_leve():
+    approved = {"author": {"login": "myia-ai-01"}, "state": "APPROVED",
+                "submittedAt": at(15), "body": "Verifie apres re-exec : APPROVED."}
+    assert run_cr(reviews=[approved])["blocked"] is False
+
+
+def test_cr_dismissed_nest_pas_un_signal():
+    """Levee (b) : une dismissal GitHub n'est possible que par l'auteur de la
+    review (ou un admin) — formellement retiree des la collecte."""
+    data = {
+        "number": 0, "title": "t", "comments": [],
+        "reviews": [{"author": {"login": "myia-ai-01"},
+                     "state": "DISMISSED", "submittedAt": at(10),
+                     "body": "CHANGES_REQUESTED: cellule 19."}],
+        "commits": [{"committedDate": at(19)}],
+    }
+    assert mod.analyse(data, [], MERGED)["blocked"] is False
+
+
+def test_cr_approved_d_un_tiers_ne_leve_pas():
+    """Sur GitHub, l'approbation d'un autre reviewer ne retire PAS le
+    CHANGES_REQUESTED actif du premier — seul son auteur le retire."""
+    other = {"author": {"login": "clusterManager-Myia"}, "state": "APPROVED",
+             "submittedAt": at(15), "body": "De mon cote c'est bon."}
+    assert run_cr(reviews=[other])["blocked"] is True
+
+
+def test_cr_levee_conditionnelle_ne_leve_pas():
+    """« corrige X et je merge » (#11201) : l'annonce conditionnee porte le
+    marqueur « je merge » mais n'est pas une phrase de levee."""
+    cond = {"author": {"login": "jsboige"}, "createdAt": at(12),
+            "body": "Corrige la cellule 19 et je merge."}
+    assert run_cr([cond])["blocked"] is True
+
+
+def test_nit_commentaire_garde_le_regime_general():
+    """Non-regression : le durcissement ne touche QUE l'etat de review. Un nit
+    porte par un COMMENTAIRE reste leve par une reponse humaine (regime
+    general, limite NLP de can_lift)."""
+    reply = {"author": {"login": "jsboige"}, "createdAt": at(12),
+             "body": "Bien vu, corrige."}
+    assert run([USER_NIT, reply])["blocked"] is False


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11229

Closes #11222 — deuxième faux négatif du gate anti-nits (grain offert par ai-01, DM msg-20260816T085757-6l871s).

## Le défaut

`analyse()` éteignait **tout** signal par `comment_times` plat : n'importe quel commentaire postérieur (`when < t < cutoff`) levait n'importe quel nit — y compris un **état de review GitHub natif**. Sur #11215 : la review `CHANGES_REQUESTED` de ai-01 (08:34:39Z) était éteinte par le commentaire 08:36:23Z de son **propre auteur** (« Ma remarque de review sur le fond est inchangée ») → gate EXIT=0. Si la re-review APPROVED de 08:49:55Z n'était pas venue, le merge aurait eu lieu avec une demande de changements jamais levée.

## Le fix

Le principe du **state GitHub natif** (déjà appliqué à la LEVÉE : une re-review APPROVED lève, l.449) est honoré dans l'autre sens. Pour un signal `src == "review:CHANGES_REQUESTED"`, seuls :

- **(a)** une re-review `APPROVED` **du même auteur** (`approved_rereviews`, login scoping) ;
- **(b)** une **dismissal** GitHub (éliminée dès la collecte — une dismissal n'est possible que par l'auteur ou un admin : retirée par construction) ;
- **(c)** une **phrase explicite de levée** (`LIFT_MARKER` non conditionnel, dans un commentaire `can_lift`) — la réponse écrite que B.0 exige ;

lèvent le signal. Le régime général (`comment_times`) est **inchangé** pour les nits portés par un commentaire (limite NLP documentée dans `can_lift` — cas 3 de la matrice : un commentaire tiers hors-sujet continue de lever un nit *commentaire*, jamais un état de review). L'APPROVED d'un **tiers** ne lève pas (GitHub : l'approbation d'un autre reviewer ne retire pas le CR actif du premier).

## Matrice d'acceptation (5 cas, tels que mesurés par ai-01 sur #11215)

| Cas | Attendu | Rendu |
|---|---|---|
| 1. aucun commentaire postérieur | 1 | **1** |
| 2. commentaire du MÊME auteur, ne rétracte pas | 1 | **1** (était 0 — le faux négatif) |
| 3. commentaire d'un TIERS, hors-sujet | 1 | **1** (était 0) |
| 4. commentaire de l'auteur de la PR qui corrige (phrase de levée) | 0 | **0** |
| 5. re-review APPROVED du même auteur | 0 | **0** |

## Preuve sur données réelles (#11215)

Contrefactuel exécuté sur les données live de la PR (`gh pr view 11215` + `analyse()` directe) :

- **Réel** (avec re-review APPROVED 08:49:55Z) : `blocked = False` — levée par le chemin **légitime (a)**, plus par l'accident du commentaire 08:36:23Z.
- **Contrefactuel** (re-review APPROVED retirée = état de la PR à 08:40) : `blocked = True`, signal `BOT-CONCERN myia-ai-01 review:CHANGES_REQUESTED 08:34:39` — **le faux négatif exact mesuré par ai-01, désormais attrapé**.

Le gate sur #11215 reste OK — mais par le bon chemin. C'est la démonstration demandée : le défaut n'était pas visible sur le verdict final de #11215 (la re-review existait), il l'était sur le chemin qui y menait.

## Audit `--audit --limit 200` : delta 0/0

| | Avant (main = #11218) | Après (cette PR) |
|---|---|---|
| PRs flaggées | 5 | **5** |
| Numéros | 11218, 11027, 11025, 10969, 10960 | **identiques** |

Aucun nouveau flag (aucun rattrapage attendu dans la fenêtre : comme #11201, le défaut y était **latent** — chaque CR de la fenêtre avait bien été levée par son auteur ou une phrase explicite ; le rattrapage est prouvé par le contrefactuel ci-dessus, pas par la fenêtre). Aucun flag perdu (le skip `DISMISSED` n'a retiré aucun flag : aucune des 5 PRs ne portait un signal dismissal).

## Tests

`pytest scripts/tests/test_check_unaddressed_nits.py` : **65 passed** (56 + 9 nouveaux).

Nouveaux : `test_cr_cas1..cas5` (la matrice ci-dessus, un test par cas), `test_cr_dismissed_nest_pas_un_signal` (levée (b)), `test_cr_approved_d_un_tiers_ne_leve_pas` (scoping par auteur), `test_cr_levee_conditionnelle_ne_leve_pas` (interaction avec `CONDITIONAL_LIFT` #11201 : « corrige X et je merge » n'est pas une phrase de levée), `test_nit_commentaire_garde_le_regime_general` (non-régression du régime général).

## Diff

`scripts/check_unaddressed_nits.py` +49/−4 · `scripts/tests/test_check_unaddressed_nits.py` +96/−0. Insertions > délétions, scope = exactement les 2 fichiers du `[CLAIMED]` (commentaire 5306704073).
