### PR TITLE
fix(genai,#10996): 04-11 complete-audiobook readers — real fish path + kokoro ffmpeg assembly

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/.gitignore
+++ b/MyIA.AI.Notebooks/GenAI/.gitignore
@@ -5,6 +5,7 @@ Audio/04-Applications/tts_output_kokoro/
 Audio/04-Applications/tts_output/
 Audio/04-Applications/audiobook_*.wav
 Audio/04-Applications/audiobook_*.mp3
+Audio/04-Applications/audiobook_compile/
 Audio/04-Applications/prosodic_output/
 Audio/04-Applications/voice_casting_output/
 Audio/04-Applications/exec_fishaudio*.py


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA — prev: MED/genai #11220

## Defect (deferred explicitly by #11166)

La section « Livres audio complets » (c34) pointait ses lecteurs sur deux artefacts fantômes :
- `BASE_DIR/audiobook_fishaudio.wav` — **jamais produit** (le vrai artefact fish est `tts_output_fishaudio/boule_de_suif_fishaudio_complete.wav`, assemblé par c32)
- `BASE_DIR/audiobook_kokoro.mp3` — **jamais assemblé** (aucune compilation kokoro complète n'existait)

## Fix à la cause

- **c32** : assemblage kokoro complet via **ffmpeg** (demuxer `concat` + `libmp3lame` 128 kbps, silences 0.5 s `anullsrc` r=24000 mono) → `audiobook_kokoro.mp3` — la même technique de compilation que le notebook 04-12 (standard famille).
- **c34** : lecteurs pointés sur les artefacts RÉELS + **extraits verbatim 30 s** embarqués (stream copy `-c:a copy`, pas de re-encodage) ; les fichiers complets restent sur disque.
- **c31** : markdown décrit les DEUX compilations (fish WAV maison / kokoro MP3 ffmpeg).
- **c33** : prose resynchronisée sur les mesures fraîches — l'agrégé a basculé (122.5s kokoro vs 121.6s fish, delta −0.9s) mais la structure tient : narration descriptive étirée (seg 4 +2.3s, seg 11 +1.1s), répliques courtes raccourcies (seg 6/12 −1.5s). Chiffres verbatim de la sortie c34 committée.
- **.gitignore** : `audiobook_compile/` (intermédiaires ffmpeg : silence + concat_list).

## Validation (H.1, relancée après le dernier commit)

```
papermill python3 : 37/37 cells, exit 0 (17:21)
exec_count null : 0 cellule (H.3 OK)
outputs error   : 0
clés audio/* committées : 30 (28 players segment + 2 extraits complets 30.0s)
```

Artefacts vérifiés ffprobe : `audiobook_kokoro.mp3` 128.9s/2064KB (24kHz mono mp3) ; fish complet 128.1s/11297KB (44.1kHz PCM). Extraits 30.0s exact chacun.

## Verdicts

- **EXEC_PROVED** — outputs réels, exécution complète end-to-end post-édition.
- **SOTA-OK** — ffmpeg 8.0.1 réel (concat demuxer, standard famille 04-12), services TTS réels (kokoro :8191, fishaudio :8197), aucun workaround.
- Taille notebook 41.3MB (vs 34.2MB main) : standard #11166 « le média EST le livrable » ; les 28 players par segment embarquaient déjà l'intégralité des deux rendus, les extraits complets ajoutent l'écoute bout-en-bout sans doubler au poids des livres entiers.

Diff cellules sources : 31/32/33/34 uniquement (aucun collateral). Scope chirurgical vérifié.

See #10996 (parapluie partitionné — contribution partielle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>