### PR TITLE
fix(notebooks,#11168): citation Markowitz 7(2)->7(1) — second passage famille QuantConnect

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-35-RL-Portfolio-Construction.ipynb
@@ -98,7 +98,7 @@
     "> SPY, QQQ, AAPL, GOOGL, IWM. Nous utilisons SPY comme proxy equity\n",
     "> et simulons un proxy obligataire via une serie synthetique correlee negativement.\n",
     "\n",
-    "> *Ancre savante -- Markowitz, H. (1952), Portfolio Sélection, The Journal of Finance 7(2):77-91 (DOI 10.1111/j.1540-6261.1952.tb01525.x). (Théorie moderne du portefeuille / Modern Portfolio Theory : allocation optimale des poids par minimisation de la variance pour un rendement cible donne, formalisation moyenne-variance. C'est la reference a \"l'optimisation de portefeuille classique (Markowski)\" que le RL vient completer en apprenant la politique par interaction au lieu de resoudre le problème quadratique.)*\n"
+    "> *Ancre savante -- Markowitz, H. (1952), Portfolio Sélection, The Journal of Finance 7(1):77-91 (DOI 10.1111/j.1540-6261.1952.tb01525.x). (Théorie moderne du portefeuille / Modern Portfolio Theory : allocation optimale des poids par minimisation de la variance pour un rendement cible donne, formalisation moyenne-variance. C'est la reference a \"l'optimisation de portefeuille classique (Markowski)\" que le RL vient completer en apprenant la politique par interaction au lieu de resoudre le problème quadratique.)*\n"
    ],
    "id": "cell-1fd2dd8b"
   },
@@ -797,7 +797,7 @@
     "\n",
     "### References academiques\n",
     "\n",
-    "- Markowitz, H. (1952). Portfolio Sélection. The Journal of Finance, 7(2):77-91. DOI 10.1111/j.1540-6261.1952.tb01525.x.\n",
+    "- Markowitz, H. (1952). Portfolio Sélection. The Journal of Finance, 7(1):77-91. DOI 10.1111/j.1540-6261.1952.tb01525.x.\n",
     "- Rummery, G.A. & Niranjan, M. (1994). On-line Q-learning using connectionist systems. Technical Report CUED/F-INFENG/TR 166, Cambridge University Engineering Department.\n",
     "- Sutton, R.S. & Barto, A.G. (2018). Reinforcement Learning: An Introduction (2nd ed.). MIT Press. ISBN 978-0-262-03924-6.\n",
     "- Watkins, C.J.C.H. (1989). Learning from Delayed Rewards. PhD thesis, University of Cambridge.\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: LIGHT/notebook-python #11225 (RL second passage)

## Summary

Second passage famille **QuantConnect** de l'Epic #11168 (passe-1 = #11183,
mergée AVANT la découverte 03:38 des pointeurs de section fabriqués) :
vérification de la sous-classe invisible au check d'existence — **renvois
internes § et claims de contenu/venue** — plus re-vérification de l'axe
identité avec les garde-fous établis dans le fil.

## Périmètre (sweep fichier entier, pas la liste d'entrée)

- Sweep récursif de **toute la famille QuantConnect** (Python/,
  ML-Training-Pipeline/, projects/, research/, partner-course-quant-trading/) :
  **45 IDs candidats / 112 occurrences**.
- **9 des 45 = fragments de DOI, pas des citations** (même classe que les
  « 2 DOI Wiley » de la passe-1 Probas) : `6161.1996`, `6261.1952`,
  `6261.1970`, `6261.1985`, `6261.1993`, `6261.2006`, `6261.2010`,
  `7305.1948`, `7305.1956` — tous issus du pattern `10.1111/j.1540-6261…`
  (regex bare-ID sur DOI). Documentés, non traités.
- **36 IDs arXiv réels**, tous vérifiés en identité (titre/auteurs exacts
  contre l'API groupée).

## Vérifications (garde-fous appliqués)

- Requête API groupée `https://` + `-L` : **http=200, bytes=84645,
  `totalResults = 36 == len(ids réels)`** (le garde-fou tient).
- Axe identité — 36/36 titres exacts contre le retour API.
- **Sweep §-pointeurs sur la famille ENTIÈRE** : **0 pointeur interne
  fabriqué**. Tous les hits `§`/« section N » sont légitimes — « §C doctrine »
  = bareme interne du dépôt (pr-review-discipline.md §C), « section N » =
  renvois internes au notebook, « Section 06 » = section du livre de
  référence Hands-On AI Trading (source du dépôt). La sous-classe qui a coulé
  Probas est **structurellement absente** de la famille QC.
- Claims de venue vérifiés contre les champs `arxiv:comment` / sources
  externes : **NIPS 2018 Workshop** (1811.03711), **ICLR 2023** (2211.14730),
  **ICLR 2022** (2111.00396), **ICAIF 2024 Workshop** (2411.17900), **ICLR
  2025 Workshop** (2503.06928), **AAAI 2023** (2205.13504, Proc. AAAI
  37(9):11121-11128 — comment arXiv muet, vérifié sur ojs.aaai.org).
- Ancres non-arXiv vérifiées : Loughran & McDonald (2011) JF **66(1)**:35-65
  exact · Pardo (2008) ISBN 978-0-470-12801-5 exact · Zeng et al. (2023) =
  DLinear 2205.13504, claim de contenu (« Transformers battus par une couche
  linéaire ») fidèle au papier.

## Finding (le seul)

| Fichier | Cellules | Avant | Après |
|---|---|---|---|
| `QC-Py-35-RL-Portfolio-Construction.ipynb` | 2, 16 | The Journal of Finance **7(2)**:77-91 | The Journal of Finance **7(1)**:77-91 |

« Portfolio Selection » (Markowitz, 1952) est paru dans **Vol 7, No 1**
(Mar. 1952), pp. 77-91 — vérifié à la source (RePEc `bla:jfinan:v:7:y:1952:i:1`,
JSTOR stable/2975974, AFA volume-7-issue-1) et par le DOI
10.1111/j.1540-6261.1952.tb01525.x. Le `7(2)` était isolé : les **4 autres
occurrences du dépôt** (QC-Py-08 cells 3/71, QC-Py-14 cells 25/81) écrivent
déjà `7(1)`. Le fix aligne QC-Py-35 sur la vérité terrain.

Markdown-only (2 cellules markdown, 0 cellule code, 0 output touché) →
re-exécution non requise (C.3). `validate_pr_notebooks.py` : **1/1 PASS**
(9 code cells).

## Note

`See #11168` — famille QuantConnect close au second passage (36/36 identité,
0 pointeur interne, 1 dérive ×2 corrigée, 9 fragments DOI documentés).
