### PR TITLE
enrich(qc,#11224): QC-Py-40 densite pedagogique 657->1406 — prose FR ancre sur outputs (tranche 3)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-40-PaperTrading-Binance.ipynb
@@ -111,7 +111,9 @@
     "| Slippage | Aucun (sauf si configure) | Variable |\n",
     "| Commissions | Simulees | Reelles |\n",
     "\n",
-    "Le paper trading repond a la question : **\"Mon algorithme fonctionne-t-il avec des données reelles ?\"** sans exposer de capital."
+    "Le paper trading repond a la question : **\"Mon algorithme fonctionne-t-il avec des données reelles ?\"** sans exposer de capital.\n",
+    "\n",
+    "Deux questions distinctes, deux instruments. Le backtest repond : *cette strategie a-t-elle un edge sur l'historique disponible ?* Il simule les prix avec des donnees closes, des fills immediats et aucune dependance d'infrastructure. Le paper trading repond : *l'implementation reelle de cette strategie, tournant sur un node QuantConnect et envoyant de vrais ordres, se comporte-t-elle comme le backtest l'a predit ?* Un compte Binance paper (testnet spot) recoit des fills simules a partir de vraies conditions de marche — la meilleure approximation d'une execution reelle sans risque de capital.\n"
    ]
   },
   {
@@ -169,6 +171,18 @@
     "print(\"Configuration Paper Trading Binance:\")\n",
     "for k, v in paper_trading_config.items():\n",
     "    print(f\"  {k}: {v}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy40-density-config",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture de la configuration\n",
+    "\n",
+    "Quatre champs structurent le simulateur Binance. Le **noeud L-MICRO** est le plus petit noeud live QC — suffisant pour deux actifs et une strategie qui tourne sur barres minutes. La **resolution Minute** aligne le paper sur la frequence du backtest (une barre minute par pas de simulation). Les **frais 0.1% maker/taker (VIP Level 0)** sont le tarif public Binance sans volume — au taux le plus bas possible, un aller-retour coute 0.2%, ce qui plafonne la frequence viable des trades. Enfin, **`order_updates: False`** est la contrainte majeure du simulateur : pas d'evenement de cycle de vie d'ordre (soumis/rempli/annule) — le monitoring devra interroger l'etat plutot que recevoir des notifications. C'est l'asymetrie structurelle avec un broker multi-asset type IBKR (voir QC-Py-41), qui, lui, les fournit."
    ]
   },
   {
@@ -354,7 +368,13 @@
     "2. Ecrire le fichier `main.py`\n",
     "3. Compiler\n",
     "4. Lancer le backtest\n",
-    "\n\n**Pourquoi backtester avant de paper-trader.** Les trois etages repondent a des questions differentes. Le backtest demande : le signal predit-il un rendement en echantillon ? Le paper trading demande : l'edge survit-il aux donnees temps reel et a la friction d'execution ? Le live ajoute le capital reel et le slippage. Chaque etage ajoute une couche de realisme ; un etage qui echoue revele ce que le precedent ne pouvait pas voir. La periode 2021-2024 couvre intentionnellement trois regimes -- bull 2021, bear 2022, recovery 2023-24 -- pour stress-tester l'hypothese de mean-reversion sur tout le cycle, pas sur un seul regime favorable.\n\n5. Analyser les metriques"
+    "\n",
+    "\n",
+    "**Pourquoi backtester avant de paper-trader.** Les trois etages repondent a des questions differentes. Le backtest demande : le signal predit-il un rendement en echantillon ? Le paper trading demande : l'edge survit-il aux donnees temps reel et a la friction d'execution ? Le live ajoute le capital reel et le slippage. Chaque etage ajoute une couche de realisme ; un etage qui echoue revele ce que le precedent ne pouvait pas voir. La periode 2021-2024 couvre intentionnellement trois regimes -- bull 2021, bear 2022, recovery 2023-24 -- pour stress-tester l'hypothese de mean-reversion sur tout le cycle, pas sur un seul regime favorable.\n",
+    "\n",
+    "5. Analyser les metriques\n",
+    "\n",
+    "Les resultats ci-dessous sont **simules** (reproduits d'un backtest QC de reference pour la demonstration) : ils servent de support de lecture et de calibration, pas de preuve de rentabilite. La methode de lecture — comparer a un benchmark, ajuster au risque, douter des couts — est ce qui reste transferable.\n"
    ]
   },
   {
@@ -439,6 +459,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "qcpy40-density-backtest",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture du resultat : +45.2% total, Sharpe 0.82 — un alpha negatif a lire comme tel\n",
+    "\n",
+    "Le point central de la lecture : sur 2021-2024, la strategie mean-reversion fait **+45.2%** quand **BTC Buy & Hold fait +67%** (ETH +31%) sur la meme periode. La strategie **sous-performe son actif sous-jacent** : son « alpha » par rapport a un simple hold BTC est **negatif d'environ 22 points**. Ce n'est pas un echec d'ecriture du notebook — c'est le resultat le plus instructif du notebook. Le reste des metriques dessine le profil de risque qui justifie de s'y interesser malgre cet alpha negatif : **Sharpe 0.82**, **MaxDD -28.4%**, **Profit Factor 1.45** et **342 trades** avec une duree moyenne de **2.3 heures** — une exposition au marche faible et intermittente, plutot qu'un pari directionnel permanent. En regime de marche fortement trendant (2021-2024 crypto), la mean-reversion surclasse rarement le momentum — le papier est justement l'endroit ou confirmer ce jugement en conditions reelles."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "e3635270",
@@ -502,6 +534,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy40-density-equity",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture des courbes\n",
+    "\n",
+    "La figure met cote a cote l'**equity curve** (gauche, seed fixe 42, trajectoire hebdomadaire simulee) et le **drawdown** (droite, zone rouge sous la courbe). Ce qui interesse l'oeil n'est pas la pente finale mais la **forme du drawdown** : un creux unique profond (risque concentre sur un episode) differe d'une succession de creux peu profonds (risque reparti). La ligne grise en pointilles sur l'equity curve marque le capital initial ($10,000) — le ratio de temps passe dessus est une lecture rapide du risque. En paper trading, c'est cette meme courbe, mais vivante, que le monitoring de la section 6 doit comparer a la presente."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7146d537",
    "metadata": {
     "papermill": {
@@ -523,7 +567,9 @@
     "3. **Win Rate > 50%** : les trades gagnants sont plus frequents que les perdants\n",
     "4. **Vs Benchmark** : performance inferieure au BTC buy & hold, mais drawdown plus faible\n",
     "\n",
-    "La stratégie est un complement au holding, pas un remplacement."
+    "La stratégie est un complement au holding, pas un remplacement.\n",
+    "\n",
+    "**Comment lire ces metriques** : le couple a regarder n'est pas le rendement total seul mais le *ratio* rendement/risque — deux strategies a +45% peuvent etre radicalement differentes si l'une descend de -10% et l'autre de -28%. La distribution des retours par trade (histogramme ci-dessous) complete le recit : elle montre si le resultat repose sur quelques gros trades ou sur un flux regulier de petits gains.\n"
    ]
   },
   {
@@ -598,6 +644,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy40-density-dist",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture de la distribution\n",
+    "\n",
+    "L'histogramme (seed 123, 342 trades simules : 58% gagnants, 42% perdants) repond a la question du *flux* : le resultat vient-il de quelques trades ou d'un regime regulier ? La reponse est dans le contraste entre la **moyenne (+0.326% par trade, ligne verte)** et le **ratio gain/perte moyen (1.40)** — des gains un peu plus gros que les pertes, avec une frequence gagnante de 58% : un profil de scalping regulier, pas une loterie. La ligne rouge pointillee marque le break-even : l'aire a gauche est la contribution nette des trades perdants. Le nombre affiche (341) differe d'une unite du parametre de simulation (342) — le tirage `int(342*0.58)` arrondit le compte des gagnants ; un detail de simulation sans consequence, mais exactement le genre de divergence que le paper trading, lui, ne permet pas d'ignorer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e489258b",
    "metadata": {
     "papermill": {
@@ -622,7 +680,9 @@
     "5. Deployer avec le brokerage Binance paper\n",
     "```\n",
     "\n",
-    "**Note** : Pour le paper trading Binance, on utilise le **Spot Test Network** (pas de compte Binance reel requis). Les API keys se generent sur `testnet.binance.vision` avec un compte GitHub."
+    "**Note** : Pour le paper trading Binance, on utilise le **Spot Test Network** (pas de compte Binance reel requis). Les API keys se generent sur `testnet.binance.vision` avec un compte GitHub.\n",
+    "\n",
+    "Le deploiement passe par les memes outils MCP que le backtest (compile -> node -> create_live), la difference tenant a la **configuration du broker** : compte Binance paper, environnement `paper`, noeud L-MICRO. Les identifiants restent dans les champs securises QC, jamais dans le notebook (regle secrets : aucun literal). Un point a connaitre avant de deploiyer : Binance paper ne remonte **pas** de mises a jour d'ordre (`order_updates: False` dans la configuration) — le monitoring se fait donc par interrogation, pas par evenements.\n"
    ]
   },
   {
@@ -645,7 +705,13 @@
     "- **Portfolio** : valeur, positions ouvertes\n",
     "- **Orders** : ordres executes, fills\n",
     "- **Logs** : erreurs, messages de trading\n",
-    "\n\n**Lire les stats comme des signaux de sante, pas comme un tableau de bord.** Une croissance reguliere du portfolio = l'edge persiste ; un plat ou un declin = l'edge se degrade (changement de regime ou parametres perimes). Des erreurs > 0 = probleme de connectivite (rate-limit, auth expiree, reseau) -- et les erreurs ne coutent pas que des trades isoles, elles brisent la boucle de retroaction (signaux manques = trainee de performance silencieuse). Un slippage fill-vs-mid croissant = l'impact de marche s'accumule ou la liquidite s'amincit ; la strategie approche de sa capacite. La question diagnostique : le P&L live suit-il la courbe d'equity du backtest dans la tolerance ? Une divergence au-dela de ~20% (cf. Exercice 1) = stop et investiguer.\n\n- **Insights** : signaux generes par l'algorithme"
+    "\n",
+    "\n",
+    "**Lire les stats comme des signaux de sante, pas comme un tableau de bord.** Une croissance reguliere du portfolio = l'edge persiste ; un plat ou un declin = l'edge se degrade (changement de regime ou parametres perimes). Des erreurs > 0 = probleme de connectivite (rate-limit, auth expiree, reseau) -- et les erreurs ne coutent pas que des trades isoles, elles brisent la boucle de retroaction (signaux manques = trainee de performance silencieuse). Un slippage fill-vs-mid croissant = l'impact de marche s'accumule ou la liquidite s'amincit ; la strategie approche de sa capacite. La question diagnostique : le P&L live suit-il la courbe d'equity du backtest dans la tolerance ? Une divergence au-dela de ~20% (cf. Exercice 1) = stop et investiguer.\n",
+    "\n",
+    "- **Insights** : signaux generes par l'algorithme\n",
+    "\n",
+    "En pratique, trois stats live commandent le verdict : la valeur du portfolio (crash ?), le nombre de trades (l'algorithme tourne-t-il vraiment ?) et le drawdown courant (s'eloigne-t-il du MaxDD backtest ?). La checklist de la cellule suivante transforme ces lectures en seuils de decision — le passage paper-to-live se gate sur des nombres, pas sur des impressions.\n"
    ]
   },
   {
@@ -723,6 +789,18 @@
     "print(\"Checklist monitoring paper trading:\")\n",
     "for i, item in enumerate(monitoring_checklist, 1):\n",
     "    print(f\"  {i}. {item}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy40-density-checklist",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture de la checklist\n",
+    "\n",
+    "Les six items sont ordonnes par gravite, pas par commodite. Le **point 1 (portfolio > 90% du capital initial)** est le pare-feu : sous ce seuil, quelque chose ne fonctionne pas comme le backtest le predisait — c'est la decision a prendre, pas a observer. Le **point 3 (nombre de trades coherent)** detecte l'implementation muette : un algorithme qui tourne sans trader est un bug silencieux que seul un compteur confronte au backtest revele. Le **point 4 (drawdown live <= MaxDD backtest)** est le test le plus honnete : il compare le vivant a sa propre calibration. Les points 2, 5 et 6 (executions, logs, prix de fills) sont le diagnostic fin quand l'un des trois premiers a sonne."
    ]
   },
   {
@@ -839,6 +917,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy40-density-report",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture du rapport\n",
+    "\n",
+    "Le rapport du jour 7 condense une journee de paper trading en quatre nombres : **$10,150.00 de portfolio (+1.50% de P&L)** — coherent avec un capital initial de $10,000 ; **3 trades aujourd'hui** — un quotidien variable est attendu au rythme backtest (342 trades en 4 ans, duree moyenne 2.3h : des journees vides et d'autres qui en concentrent plusieurs) ; **positions BTCUSDT** — l'univers attendu ; **Erreurs : OK** — aucun rejet d'ordre. Le quotidien de ce rapport est le point de depart du gate : quand +1.50% devient une baisse, c'est la checklist de la cellule precedente qui prend le relais."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 2 : Rapport de slippage estimation\n\nCréez une fonction qui estime le **slippage moyen** a partir d'une liste de trades paper vs prix mid. Le slippage est la différence entre le prix d'exécution et le prix mid au moment de l'ordre.\n\n**Indices** :\n- `# Indice` : `slippage = |fill_price - mid_price| / mid_price`\n- `# Étape 1` : Simuler une liste de trades avec prix mid et prix fill\n- `# Étape 2` : Calculer le slippage pour chaque trade\n- `# Étape 3` : Afficher le slippage moyen et la distribution"
@@ -887,7 +977,9 @@
     "- `rsi_threshold` : seuil RSI pour l'entree (25, 30, 35, 40)\n",
     "- `stop_loss_pct` : stop-loss (3%, 5%, 8%)\n",
     "\n",
-    "TODO etudiant : remplacer les valeurs ci-dessous pour experimenter."
+    "TODO etudiant : remplacer les valeurs ci-dessous pour experimenter.\n",
+    "\n",
+    "**Pourquoi explorer les parametres** : la mean-reversion Bollinger vit de son couple (period, std) — un BB court (period 10) reagit plus vite mais genere plus de faux signaux, un BB long (period 50) filtre le bruit mais entre trop tard. Le but de l'exercice n'est pas de trouver le meilleur backtest possible (sur-optimisation), mais de **cartographier la sensibilite** : si les parametres voisins changent radicalement le resultat, la strategie est fragile et le paper trading le revelera.\n"
    ]
   },
   {
@@ -967,6 +1059,18 @@
     "    print(f\"  {k}: {v}\")\n",
     "print(\"\\nTODO: Completez config_a, config_b, config_c avec vos choix.\")\n",
     "print(\"Indice: un BB plus court (period=10) reagira plus vite mais generera plus de faux signaux.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy40-density-params",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "### Lecture des parametres\n",
+    "\n",
+    "La configuration de base pose quatre leviers : **bb_period 20, bb_std 2.0, rsi_threshold 35, stop_loss 5%**. Chacun joue un role different — la bande (period, std) fixe le canal de mean-reversion ; le RSI (35) filtre les entrees en fin de range ; le stop borne la queue de perte. L'exercice demande trois variantes (config_a/b/c) : le bon geste n'est pas de tatonner mais de faire varier **un levier a la fois** et de mesurer l'effet — c'est la definition d'une sensibilite. La configuration est aussi le lieu ou le gap backtest/paper apparait d'abord : un stop qui ne se remplit pas en paper (slippage) se lit immediatement dans les quatre nombres du rapport quotidien."
    ]
   },
   {
@@ -1050,7 +1154,16 @@
     "### Prochaines étapes\n",
     "- QC-Py-41 : Paper Trading IBKR (equities via Interactive Brokers)\n",
     "- Comparer les résultats paper avec le backtest sur la même periode\n",
-    "- Document `PAPER_TO_LIVE_TRANSITION.md` pour la transition vers le live"
+    "- Document `PAPER_TO_LIVE_TRANSITION.md` pour la transition vers le live\n",
+    "\n",
+    "**Ce qu'il faut retenir** :\n",
+    "\n",
+    "1. Le paper trading valide l'**implementation**, pas l'edge — le backtest reste la seule preuve de strategie, et ici elle est *illustrative*.\n",
+    "2. Un resultat honnete peut etre un echec instructif : +45.2% quand BTC Buy & Hold fait +67% sur la meme periode signifie un **alpha negatif** — la lecon vaut plus qu'une metrique flatteuse.\n",
+    "3. Binance paper est le simulateur le plus simple a mettre en route (testnet gratuit, zero prerequis) ; son point faible est l'absence de mises a jour d'ordre, compensee par un monitoring par interrogation.\n",
+    "4. Le passage paper-to-live se gate sur des seuils quantitatifs (checklist de la section 6), jamais sur des impressions.\n",
+    "\n",
+    "**Et apres** : QC-Py-41 transpose le meme workflow chez Interactive Brokers (multi-asset, order updates, TWS) — la comparaison des deux simulateurs est le fil rouge de la paire.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #11228 (substance distincte : 3e notebook-python consécutif sous l'exception actée — steer ai-01 msg-20260816T085923 : « dette de prose réelle, grain d'enrichissement dédié la vaut »)

## Summary

Tranche 3 du tracker #11224 (densité pédagogique famille QC, pattern #10488) : **QC-Py-40-PaperTrading-Binance**, 3e pire de la famille à **657**, passe à **1406** (16 878 chars de prose / 12 cellules code).

Enrichissement **markdown-only FR** : 7 appends sur cellules existantes + 7 interps nouvelles insérées **immédiatement après le code dont l'output porte la valeur citée** ([cell-interpretation-ordering](../../blob/main/.claude/rules/cell-interpretation-ordering.md), leçon #10678) :

- apres cell 3 (config) : lecture des 4 champs — node L-MICRO, resolution Minute, fees 0.1% VIP0, `order_updates: False` (contrainte majeure : monitoring par interrogation)
- apres cell 7 (metriques backtest) : lecture **doc-honesty** — +45.2% quand BTC B&H +67% (ETH +31%) = **alpha negatif ~22 pts vs BTC**, lire comme le resultat le plus instructif ; Sharpe 0.82 / MaxDD -28.4% / PF 1.45 / 342 trades
- apres cell 8 (equity/drawdown) : lecture des courbes — seed 42 hebdo, ligne $10k, zone de drawdown
- apres cell 10 (distribution) : 341 affiches vs 342 parametre — `int(342*0.58)`=198 + `int(342*0.42)`=143 = 341, divergence verifiee dans la source ; moyenne +0.326% / ratio 1.40
- apres cell 13 (checklist) : lecture ordonnee par gravite — porte-feuille 90%, compteur de trades, drawdown live vs MaxDD backtest
- apres cell 16 (rapport jour 7) : $10,150.00 / +1.50% / 3 trades / BTCUSDT / Erreurs OK
- apres cell 20 (params BB) : bb_period 20 / bb_std 2.0 / rsi 35 / stop 5% — un levier a la fois

Toutes les valeurs citées vérifiées **firsthand** contre les outputs/sources committés avant rédaction (G.1) — trois erreurs de draft corrigées par cette vérification (math « ~1.4 trade/jour » → rythme réel 342 trades/4 ans ; comparaisons BTC drawdown/Sharpe non supportées retirées ; « rebalancement sur clôture de barre » non vérifié reformulé).

**Signalé, non corrigé** (règle 3) : numérotation d'exercices pré-existante incohérente — md cell « Exercice 1 » suivi du code « Exercice 3 », puis md « Exercice 2 » suivi du code « Exercice 1 ».

## Diff

- 120+/7− sur **cellules markdown uniquement** : 12 cellules code byte-identical (vérifié programmatiquement old vs new), 11 -> 18 cellules markdown
- Exempt de re-exécution (C.3 markdown-only) ; stubs exercices C.1 intacts (0 violation)

## Validation

- `pedagogy_density.py --json` : 657 -> **1406**, label `pedagogy-density-below-threshold` levé (below_threshold 0)
- `validate_pr_notebooks.py origin/main <path>` : **PASS 12/12** cellules code
- `scan_cell_ordering.py` : 1 scanned, **0 finding**
- Pre-commit H.3 + gitleaks + probeAddresses : Passed

See #11224
