### PR TITLE
fix(tooling,#11111): bound OpenMP/BLAS pools in remaining kernel executors

### DIFF
--- a/scripts/notebook_tools/notebook_helpers.py
+++ b/scripts/notebook_tools/notebook_helpers.py
@@ -915,6 +915,9 @@ class NotebookExecutor:
         # Start kernel if not already running
         # WSL-based kernels (smartcontracts, lean4-wsl) need longer startup
         startup_timeout = 120 if 'wsl' in kernel_name or kernel_name == 'smartcontracts' else 60
+        # Bound OpenMP/BLAS pools: native training cells oversubscribe many-core
+        # hosts and look frozen (#11111). Kernel inherits env.
+        bound_native_thread_pools()
         try:
             km = jupyter_client.KernelManager(kernel_name=kernel_name)
             km.start_kernel()
@@ -1040,6 +1043,9 @@ class NotebookExecutor:
 
         # Start kernel (WSL-based kernels need longer startup)
         startup_timeout = 120 if 'wsl' in kernel_name or kernel_name == 'smartcontracts' else 60
+        # Bound OpenMP/BLAS pools: native training cells oversubscribe many-core
+        # hosts and look frozen (#11111). Kernel inherits env.
+        bound_native_thread_pools()
         try:
             km = jupyter_client.KernelManager(kernel_name=kernel_name)
             km.start_kernel()


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #11226

## Summary

Residue #11111 (rouvert par ai-01 apres #11226) : `#11226` bornait 5 points de lancement de kernel, mais les deux methodes sœurs de `NotebookExecutor` restaient non bornees — `execute_cell` et `execute_notebook_cell_by_cell`. Les deux demarrent un `KernelManager` directement (l.915 / l.1043) sans passer par le bornage. Meme classe, meme fichier (`notebook_helpers.py`), meme symptome (LightGBM/XGBoost/BLAS oversubscribent les hots many-core et les cellules d'entrainement paraissent freezees, x35-x431 mesure sur ML-3).

## Fix

`bound_native_thread_pools()` ajoute dans les deux methodes, juste avant `KernelManager`, avec le meme commentaire et la meme semantique que #11226 :
- une variable deja prete dans l'env gagne (jamais ecrasee) ;
- le subprocess kernel herite de l'env borne.

L'audit de tous les sites de lancement de `scripts/notebook_tools/` confirme : plus aucun `KernelManager` sans bornage associe dans les executors de la classe (les one-shot `_exec_*.py` a chemin hardcode sont hors perimetre — pas des executors generiques).

## Validation

- `python -m py_compile scripts/notebook_tools/notebook_helpers.py` : OK
- Smoke test : `bound_native_thread_pools(4)` -> `{'OMP_NUM_THREADS': '4', 'OPENBLAS_NUM_THREADS': '4', 'MKL_NUM_THREADS': '4'}` ; pre-set respecte (pas de clobber)
- `pytest scripts/tests/test_notebook_tools_pure.py` : 75/75 passed
- Diff : 6 insertions, 2 methodes, aucune suppression

## Note de scope

Deux PRs de la lane traitaient deja le meme notebook 04-11 c34 (#11234 complete-audiobooks, plus large) — ma PR #11238 a ete fermee comme doublon (meme ligne corrigee, #11234 ouverte avant). Ce grain #11111 residuel est le suivant, scope scripts uniquement.

See #11111 (contribution partielle : le residu execute_cell / execute_notebook_cell_by_cell, acceptance #11226 « et les executeurs Python equivalents »)
