### PR TITLE
fix(notebooks,#11168): 4 pointeurs de section ESL corrigés (02-ML-Cours)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.1-Workflow-ML.ipynb
@@ -592,7 +592,7 @@
     "\n",
     "Plus la MAE est faible, meilleure est la régression (elle s'exprime dans la même unité que la cible).\n",
     "\n",
-    "> **Référence.** La MAE (mean absolute error) est l'un des estimateurs d'erreur les plus robustes pour la régression ; voir Hastie, Tibshirani & Friedman (2009), *The Elements of Statistical Learning*, Springer (2e éd.), section 11.6 pour la comparaison des critères de perte (L1 vs L2)."
+    "> **Référence.** La MAE (mean absolute error) est l'un des estimateurs d'erreur les plus robustes pour la régression ; voir Hastie, Tibshirani & Friedman (2009), *The Elements of Statistical Learning*, Springer (2e éd.), section 10.6 pour la comparaison des critères de perte (L1 vs L2)."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.4-Arbres-Forets-Ensembles.ipynb
@@ -492,7 +492,7 @@
     "\n",
     "Moyenner de nombreux arbres brisés produit une frontière **plus lisse**. La réduction de variance est **littéralement visible** en comparant côte à côte l'arbre seul et la forêt sur le même plan 2D.\n",
     "\n",
-    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Elements of Statistical Learning*, Springer (2e éd.), §15.3. L'analyse théorique montre que la moyenne de $B$ arbres décorrélerés réduit la variance d'un facteur proche de $1/B$ lorsque les arbres sont peu corrélés : c'est le fondement quantitatif de la réduction de variance par *bagging*, que la figure suivante rend visible."
+    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Elements of Statistical Learning*, Springer (2e éd.), §15.4.1. L'analyse théorique montre que la moyenne de $B$ arbres décorrélerés réduit la variance d'un facteur proche de $1/B$ lorsque les arbres sont peu corrélés : c'est le fondement quantitatif de la réduction de variance par *bagging*, que la figure suivante rend visible."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.6-Clustering-KMeans-PCA.ipynb
@@ -754,7 +754,7 @@
     "\n",
     "Le **supervisé** (notebooks 2.1 à 2.5) dispose d'étiquettes et apprend à **prédire**. Le **non supervisé** (ce notebook) n'a pas d'étiquettes et **trouve** de la structure (clusters) ou **compresse** (PCA). En pratique, ces approches se combinent souvent : on peut appliquer une PCA avant un clustering, ou avant un modèle supervisé pour accélérer l'apprentissage et réduire le surajustement.\n",
     "\n",
-    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Elements of Statistical Learning*, Springer (2e éd.), §14.3. — Synthèse du clustering et de la réduction de dimension dans le cadre de l'apprentissage statistique."
+    "> **Référence.** Hastie, T., Tibshirani, R. & Friedman, J. (2009), *The Elements of Statistical Learning*, Springer (2e éd.), §14.3, 14.5. — Synthèse du clustering et de la réduction de dimension dans le cadre de l'apprentissage statistique."
    ]
   },
   {
@@ -795,7 +795,7 @@
     "1. MacQueen, J. (1967). *Some Methods for Classification and Analysis of Multivariate Observations*. Proceedings of the Fifth Berkeley Symposium on Mathematical Statistics and Probability 1:281-297. — La méthode des k-moyennes, partitionnement par minimisation de l'inertie intra-cluster.\n",
     "2. Pearson, K. (1901). *On Lines and Planes of Closest Fit to Systems of Points in Space*. Philosophical Magazine 2(11):559-572. — Article fondateur de l'Analyse en Composantes Principales (axes de variance maximale).\n",
     "3. Jolliffe, I.T. (2002). *Principal Component Analysis*. Springer (2e éd.). — Référence sur l'ACP : variance expliquée, choix du nombre de composantes.\n",
-    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §14.3. — Clustering et réduction de dimension.\n",
+    "4. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §14.3, 14.5. — Clustering et réduction de dimension.\n",
     "5. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `KMeans`, `PCA`, `load_digits`."
    ]
   }

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/02-ML-Cours/2.7-Modeles-Non-Parametriques.ipynb
@@ -966,7 +966,7 @@
     "2. Vapnik, V. (1998). *Statistical Learning Theory*. Wiley. — Cadre théorique des SVM : minimisation structurelle du risque, bornes de généralisation fondées sur la marge.\n",
     "3. Cristianini, N. & Shawe-Taylor, J. (2000). *An Introduction to Support Vector Machines and Other Kernel-based Learning Methods*. Cambridge University Press. — Présentation pédagogique du kernel trick et des noyaux (linéaire, polynomial, RBF).\n",
     "4. Cover, T. & Hart, P. (1967). *Nearest Neighbor Pattern Classification*. IEEE Transactions on Information Theory 13(1):21-27. — La règle du 1-plus-proche-voisin et sa borne d'erreur asymptotique (≤ 2× l'erreur de Bayes).\n",
-    "5. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §§12.2-12.3. — SVM, noyaux et méthodes basées sur les voisins (k-NN).\n",
+    "5. Hastie, T., Tibshirani, R. & Friedman, J. (2009). *The Elements of Statistical Learning*. Springer (2e éd.), §§12.2-12.3, 13.3. — SVM, noyaux et méthodes basées sur les voisins (k-NN).\n",
     "6. Pedregosa, F. et al. (2011). *Scikit-learn: Machine Learning in Python*. Journal of Machine Learning Research 12:2825-2830. — `SVC`, `KNeighborsClassifier`, `StandardScaler`, `make_moons`, `make_circles`, `load_breast_cancer`."
    ]
   }


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11235 (QuantConnect second passage)

## Summary

Second passage famille **ML** de l'Epic #11168 — le grain nommé libre par le
triage ai-01 (09:41Z : 8 pointeurs ESL, vérifiables au sommaire, sans API).
Vérification des §-pointeurs vers *The Elements of Statistical Learning*
(Hastie, Tibshirani & Friedman, 2009, 2e éd.) dans la série `02-ML-Cours`,
contre le **sommaire officiel** (hastie.su.domains/ElemStatLearn/contents.pdf,
téléchargé firsthand, http=200, 55434 bytes, 10 pages).

## Périmètre (sweep fichier entier, pas la liste d'entrée)

- Sweep des **7 notebooks** `02-ML-Cours/` (le triage disait 6 fichiers —
  la liste est un point d'entrée) : **9 lignes ESL distinctes** portant un
  §-pointeur (2.1 ×2, 2.2, 2.3, 2.4 ×2, 2.5, 2.6 ×2, 2.7).
- ML.Net (ML-2, ML-4) citent ESL sans § — vérifiés, sans pointeur.
- Les 5 autres familles de l'epic (RL, QC, IIT, FallacyDetection, Probas)
  déjà traitées/claimées ailleurs — ce grain couvre ML uniquement.

## Vérification — 9 pointeurs, 5 exacts, 4 corrigés

Méthode : chaque § cité est rapproché du sommaire ESL (titres exacts de
section) ; un pointeur est exact si la section citée couvre le sujet
annoncé. Verdict par occurrence :

| Notebook cell | Pointeur cité | ESL réel | Verdict |
|---|---|---|---|
| 2.1[10] | sections 2.9 et 7 (biais-variance) | §2.9 « Model Selection and the Bias–Variance Tradeoff » · ch7 « Model Assessment and Selection » | **EXACT** |
| 2.1[14] | section **11.6** (comparaison pertes L1/L2) | §11.6 = « Example: Simulated Data » (neural nets) | **FAUX → 10.6** « Loss Functions and Robustness » |
| 2.2[2]/[23] | section 3.2 (MCO/MSE) | §3.2 « Linear Regression Models and Least Squares » | **EXACT** |
| 2.3[14]/[23] | sections 4.2-4.4 (OLS vs MLE) | §4.2 « Linear Regression of an Indicator Matrix » · §4.3 LDA · §4.4 « Logistic Regression » | **EXACT** |
| 2.4[12] | §**15.3** (réduction variance B arbres) | §15.3 = « Details of Random Forests » ; la variance-décorrélation = **§15.4.1** « Variance and the De-Correlation Effect » | **FAUX → 15.4.1** |
| 2.4[23] | §§9.2, 10.1, 15.3 (arbres, forêts, boosting) | §9.2 « Tree-Based Methods » · §10.1 « Boosting Methods » · §15.3 « Details of Random Forests » | **EXACT** |
| 2.5[25] | §7.10-7.11 (validation croisée) | §7.10 « Cross-Validation » · §7.11 « Bootstrap Methods » | **EXACT** |
| 2.6[20]/[22] | §**14.3** (clustering + réduction dimension) | §14.3 = « Cluster Analysis » ; PCA = **§14.5** « Principal Components, Curves and Surfaces » | **FAUX → 14.3, 14.5** |
| 2.7[22] | §§**12.2-12.3** (SVM + k-NN) | §12.2/12.3 = SVM ✓ mais k-NN = **§13.3** « k-Nearest-Neighbor Classifiers » | **FAUX → 12.2-12.3, 13.3** |

## Correctifs appliqués (5 remplacements, 4 fichiers)

| Fichier | Cellules | Avant | Après |
|---|---|---|---|
| `2.1-Workflow-ML.ipynb` | 14 | section 11.6 | section **10.6** |
| `2.4-Arbres-Forets-Ensembles.ipynb` | 12 | §15.3 | §**15.4.1** |
| `2.6-Clustering-KMeans-PCA.ipynb` | 20, 22 | §14.3 | §**14.3, 14.5** |
| `2.7-Modeles-Non-Parametriques.ipynb` | 22 | §§12.2-12.3 | §§**12.2-12.3, 13.3** |

Les 5 remplacements sont markdown-only (cellules markdown, 0 output, 0
`execution_count` touché) → re-exécution non requise (C.3).
`validate_pr_notebooks.py` : **4/4 PASS** (41 code cells).

## Note

`See #11168` — famille ML close au second passage (9 pointeurs vérifiés,
4 corrigés). La correction du §15.3→15.4.1 est le même déplacement que le
vrai contenu : la réduction de variance par décorrélation est analysée en
§15.4.1 (pas §15.3, qui ne décrit que les détails d'implémentation OOB/
importance/overfitting).
