### PR TITLE
feat(guard,#11170): G-VAR-3 gate -- block consecutive LIGHT-genre grains per lane

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -713,3 +713,139 @@ jobs:
           )" 2>/dev/null || true
 
           exit 1
+
+  # #11170 -- the BLOCKING gate against consecutive LIGHT-genre grains
+  # (G-VAR-3, the "pas deux fois le meme GENRE LIGHT consecutif" ban of
+  # variation-protocol.md §2). Until this job, the ban had NO organ:
+  # `Check Grain tag conformity` verifies the tag is well-formed (TIER +
+  # GENRE in the enumeration + lane + prev: present), `G-VAR-2 light cap`
+  # counts the daily budget, but NO job compared the genre of the grain to
+  # that of its `prev:` -- a perfectly conformant tag declaring
+  # `LIGHT/docs -- prev: LIGHT/docs` passed every gate green.
+  #
+  # Measured on the night of 2026-08-15/16: #11136 (`LIGHT/docs -- prev:
+  # LIGHT/docs 11134`) was MERGED 00:30:56Z, #11167 (`LIGHT/docs -- prev:
+  # MED/docs 11069`) was HELD ~03:00Z -- identical shape, opposite verdicts,
+  # three hours apart, same coordinator. The first was not merged by
+  # complacency: nothing in the tooling posed the question.
+  #
+  # Why BLOCKING: an advisory label is exactly the failure mode #11170
+  # measures -- the label does not stop a merge and the coordinator read the
+  # green of a check that measures something else. Same shape as
+  # check-variation-tag-required (#10045) and check-prev-close-keyword-
+  # required (#10093): a required check turning `PR gate` red before merge
+  # is the only organ that makes the ban hold.
+  #
+  # What blocks vs what labels (per issue acceptance):
+  #   * BLOCK (exit 1) when `genre == prev_genre` AND the genre is in the
+  #     LIGHT set {guard, ledger, docs, readme, test} -- the absolute ban of
+  #     §2, no escape clause. Remediation: pick a grain of ANOTHER genre,
+  #     never re-tag the same work.
+  #   * ADVISORY label `variation-adjacency-deep-med` when the genres are
+  #     equal and OUTSIDE the LIGHT set (DEEP/MED domain-core): §2 allows
+  #     two consecutive there "si chacun est une substance genument
+  #     distincte" -- a judgment not mechanisable, the label leaves it to
+  #     the coordinator.
+  #   * PASS otherwise -- different genres, `prev: none (premier grain)`
+  #     (first-grain exemption), prev: absent (already covered by the
+  #     variation-tag-prev-absent label), or no Grain tag (covered by
+  #     check-variation-tag-required).
+  #
+  # Both genres are normalised through the SAME alias table as the G-VAR-2
+  # organ (`variation_light_cap.canonicalize_genre`) -- variation-protocol
+  # §1 warns that two invented labels suffice to never trip the adjacency.
+  #
+  # The decision logic lives in `scripts/ci/variation_adjacency_guard.py`
+  # (unit-tested, same pattern as `variation_prev_guard.py`); the YAML is
+  # plomberie. The job name carries the `-required` suffix so PR #10036's
+  # `is_advisory()` classifier in `scripts/pr_gate.py` does NOT silence it.
+  check-variation-adjacency-required:
+    name: 'Require genre diversity vs prev: (block on LIGHT adjacency, #11170)'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the adjacency helper (sparse)
+        uses: actions/checkout@v4
+        with:
+          # The helper imports grain_tag.py (shared extractor) AND
+          # variation_light_cap.py (the G-VAR-2 alias table + LIGHT set) --
+          # the three modules are checked out together.
+          sparse-checkout: |
+            scripts/ci/variation_adjacency_guard.py
+            scripts/variation_light_cap.py
+            scripts/grain_tag.py
+      - name: 'Compare grain genre vs prev: genre (G-VAR-3)'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork }}
+        run: |
+          set -uo pipefail
+
+          # Same bot/fork gating as the other jobs (cf. student-pr-reviews.md).
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issue d'un fork : hors scope (PR etudiante)."
+            exit 0
+          fi
+
+          # Body to a file -- printf '%s' preserves it verbatim.
+          printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
+
+          # The helper emits one JSON verdict and exits 0 (pass/advisory) or
+          # 1 (block on LIGHT adjacency). The &&/|| list captures RC on BOTH
+          # branches and is exempt from errexit (same fix as
+          # check-variation-tag-required).
+          python3 scripts/ci/variation_adjacency_guard.py \
+            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+
+          if [ -s /tmp/verdict.err ]; then
+            echo "--- helper stderr ---"
+            cat /tmp/verdict.err
+          fi
+          echo "--- verdict ---"
+          cat /tmp/verdict.json
+
+          ADJACENT=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('adjacent'))" 2>/dev/null || echo "False")
+
+          # Advisory label for DEEP/MED adjacency (guard_pass stays true, the
+          # job passes; the label surfaces the §2 judgment for the coordinator).
+          gh label create variation-adjacency-deep-med \
+            --description "Adjacence de genre DEEP/MED (hors liste LIGHT) : §2 l'autorise si substance distincte -- jugement au coordinateur" \
+            --color FEF2C0 --force 2>/dev/null || true
+          if [ "$ADJACENT" = "True" ]; then
+            gh pr edit "$PR_NUMBER" --add-label variation-adjacency-deep-med 2>/dev/null || true
+          else
+            gh pr edit "$PR_NUMBER" --remove-label variation-adjacency-deep-med 2>/dev/null || true
+          fi
+
+          if [ "$RC" -eq 0 ]; then
+            echo "No LIGHT-genre adjacency vs prev: -- job passes."
+            exit 0
+          fi
+
+          # Block path (LIGHT adjacency). Idempotent comment via the marker.
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo "unknown")
+          echo "::error::G-VAR-3 LIGHT-genre adjacency: $REASON"
+
+          gh pr comment "$PR_NUMBER" --body "$(cat <<EOF
+          <!-- vtr-adjacency-block -->
+          **G-VAR-3 : deux grains LIGHT du meme genre consecutifs -- bloquant (#11170).**
+
+          ${REASON}
+
+          variation-protocol.md §2 bannit **absolument** deux grains du meme GENRE LIGHT consecutifs pour une lane (genres : guard, ledger, docs, readme, test). Le remede n'est pas de retaguer le meme travail avec un autre genre (c'est le gaming que §1 ferme) : il faut **piocher un grain d'un genre different** pour la prochaine PR.
+
+          Pour passer ce gate, remplacez la \`prev:\` par un grain precedent d'un genre different (ou changez le genre du grain courant pour un genre de substance differente) :
+
+          \`\`\`
+          Grain: <TIER>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<genre-different> #<PR>
+          \`\`\`
+          EOF
+          )" 2>/dev/null || true
+
+          exit 1

--- a/scripts/ci/variation_adjacency_guard.py
+++ b/scripts/ci/variation_adjacency_guard.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+r"""variation_adjacency_guard.py -- BLOCKING gate against consecutive LIGHT-genre grains (#11170).
+
+## Why this exists
+
+variation-protocol.md §2 (G-VAR-3) bans two consecutive grains of the same
+LIGHT genre for a lane: `LIGHT/docs` following `LIGHT/docs` is monoculture,
+the exact drift the protocol exists to stop. Until #11170 the ban had NO
+organ -- `Check Grain tag conformity` verified the tag is well-formed,
+`G-VAR-2 light cap` counted the daily budget, but NO job compared the genre
+of the grain to that of its `prev:`. A tag perfectly conformant declaring
+`LIGHT/docs -- prev: LIGHT/docs` passed every gate green.
+
+Measured on the night of 2026-08-15/16: two identical-shaped grains, three
+hours apart, got OPPOSITE verdicts from the same coordinator -- #11136
+(`LIGHT/docs -- prev: LIGHT/docs 11134`) merged 00:30:56Z, #11167
+(`LIGHT/docs -- prev: MED/docs 11069`) held ~03:00Z. The first was not
+merged by complacency: nothing in the tooling posed the question.
+
+## What it does
+
+Reads the PR body, parses the Grain tag + its `prev:` field (both through
+the SHARED extractor `scripts/grain_tag.py`, so this organ and the guard
+never diverge on what a tag is), normalises both genres through the SAME
+alias table as the G-VAR-2 organ (`variation_light_cap.canonicalize_genre`),
+and compares:
+
+  * **BLOCK** (exit 1) when `genre == prev_genre` AND the genre is in the
+    LIGHT set `{guard, ledger, docs, readme, test}` -- the absolute ban of
+    §2, no escape clause. The remediation is to pick a grain of ANOTHER
+    genre, never to re-tag the same work.
+  * **ADVISORY** (exit 0 + `adjacent: true`) when `genre == prev_genre` and
+    the genre is outside the LIGHT set (a DEEP/MED domain-core genre). §2
+    allows two consecutive there "si chacun est une substance genument
+    distincte" -- a judgment not mechanisable, so the organ labels, never
+    blocks. A Lean specialist chaining two distinct proofs must not blush.
+  * **PASS** otherwise -- different genres, `prev: none (premier grain)`
+    (the first-grain exemption, already parsed by `parse_prev`), or a
+    `prev:` absent / unreadable (already covered by the `variation-tag-prev-
+    absent` label and the tag-required job).
+
+Emits a single JSON verdict on stdout:
+
+    {"guard_pass": true|false, "blocking": true|false, "adjacent": bool,
+     "genre": ..., "prev_genre": ..., "lane": ..., "reason": "..."}
+
+Exit codes:
+  0  -- pass, or advisory (DEEP/MED adjacency)
+  1  -- LIGHT-genre adjacency (the PR is non-mergeable until the worker
+       picks a grain of another genre)
+  2  -- caller error (unreadable body file)
+
+## Why BLOCKING (not advisory)
+
+The advisory label is the failure mode #11170 measures: `Check Grain tag
+conformity` has been posting labels all along and the LIGHT adjacency
+crossed anyway, because a label does not stop a merge and the coordinator
+read the green of a check that measures something else. The same shape as
+`check-variation-tag-required` (#10045) and `check-prev-close-keyword-
+required` (#10093): only a required check turning `PR gate` red before
+merge makes the ban hold.
+
+## Run locally
+
+    python scripts/ci/variation_adjacency_guard.py --body-file body.txt
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Make the shared extractor + the G-VAR-2 alias table importable from anywhere
+# in the repo (CI runs from the repo root; local devs may run from the script
+# directory).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import grain_tag as gt  # noqa: E402
+from variation_light_cap import LIGHT_GENRES, canonicalize_genre  # noqa: E402
+
+
+def check(body: str | None) -> dict:
+    """Return the adjacency verdict for a PR body.
+
+    Pure function so unit tests pin each branch without going through the
+    CLI. The verdict is:
+
+      * `guard_pass: False, blocking: True`  -- LIGHT-genre adjacency (exit 1)
+      * `guard_pass: True,  adjacent: True`  -- DEEP/MED adjacency (advisory)
+      * `guard_pass: True,  adjacent: False` -- no adjacency, or not evaluable
+        (missing tag / missing or exempt prev -- covered by other organs)
+    """
+    g = gt.parse_grain_tag(body)
+    if g is None:
+        return {
+            "guard_pass": True, "blocking": False, "adjacent": False,
+            "genre": None, "prev_genre": None, "lane": None,
+            "reason": "no Grain tag in body (covered by check-variation-tag-required)",
+        }
+    pv = gt.parse_prev(body)
+    if pv["exempt"]:
+        return {
+            "guard_pass": True, "blocking": False, "adjacent": False,
+            "genre": g["genre"], "prev_genre": None, "lane": g["lane"],
+            "reason": "prev: none (premier grain) -- no predecessor to compare",
+        }
+    if not pv["present"] or not pv["genre"]:
+        return {
+            "guard_pass": True, "blocking": False, "adjacent": False,
+            "genre": g["genre"], "prev_genre": None, "lane": g["lane"],
+            "reason": "prev: absent or unreadable (covered by variation-tag-prev-absent)",
+        }
+
+    # Normalise through the SAME alias table as the G-VAR-2 organ: without it,
+    # `fix` vs `docs` on two grains of the same work would make the adjacency
+    # invisible -- variation-protocol §1 warns that two invented labels suffice
+    # to never trip the ban.
+    genre = canonicalize_genre(g["genre"])
+    prev_genre = canonicalize_genre(pv["genre"])
+    lane = g["lane"]
+    if genre is None or prev_genre is None:
+        return {
+            "guard_pass": True, "blocking": False, "adjacent": False,
+            "genre": genre, "prev_genre": prev_genre, "lane": lane,
+            "reason": "genre or prev-genre not normalisable -- adjacency not evaluable",
+        }
+
+    if genre != prev_genre:
+        return {
+            "guard_pass": True, "blocking": False, "adjacent": False,
+            "genre": genre, "prev_genre": prev_genre, "lane": lane,
+            "reason": f"genres differ ({genre} vs {prev_genre}) -- no adjacency",
+        }
+
+    # Same genre. The LIGHT set is the absolute ban of §2; a DEEP/MED
+    # domain-core genre is the advisory judgment of §2.
+    if genre in LIGHT_GENRES:
+        return {
+            "guard_pass": False, "blocking": True, "adjacent": True,
+            "genre": genre, "prev_genre": prev_genre, "lane": lane,
+            "reason": (
+                f"G-VAR-3: {genre} succede a {prev_genre} -- deux grains LIGHT "
+                f"consecutifs pour la lane {lane}. La regle est un ban absolu "
+                f"(§2): piochez un grain d'UN AUTRE genre, ne retaguez pas "
+                f"le meme travail (#11170)."
+            ),
+        }
+    return {
+        "guard_pass": True, "blocking": False, "adjacent": True,
+        "genre": genre, "prev_genre": prev_genre, "lane": lane,
+        "reason": (
+            f"adjacence {genre}->{prev_genre} hors liste LIGHT : §2 l'autorise "
+            f"si chaque grain est une substance genument distincte -- "
+            f"jugement non mecanisable, signal advisory uniquement."
+        ),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--body-file", metavar="FILE", required=True,
+                   help="path to the PR body")
+    args = p.parse_args(argv)
+
+    try:
+        with open(args.body_file, encoding="utf-8") as f:
+            body = f.read()
+    except OSError as e:
+        print(json.dumps({"guard_pass": False, "reason": f"caller error: {e}"}),
+              file=sys.stderr)
+        return 2
+
+    verdict = check(body)
+    print(json.dumps(verdict, ensure_ascii=False))
+    return 0 if verdict["guard_pass"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_variation_adjacency_guard.py
+++ b/scripts/tests/test_variation_adjacency_guard.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Unit tests for variation_adjacency_guard.py -- the G-VAR-3 organ (#11170).
+
+G-VAR-3 (variation-protocol.md §2) bans two consecutive grains of the same
+LIGHT genre for a lane. The acceptance cases come straight from the issue:
+#11136 (`LIGHT/docs -- prev: LIGHT/docs 11134`) was MERGED on the night of
+2026-08-15/16 with no gate tripping, #11165 (`LIGHT/docs -- prev:
+MED/notebook-python`) is the legitimately-different counter-example, and the
+first-grain exemption (`prev: none (premier grain)`) must never be flagged.
+
+Run:
+    python -m pytest scripts/tests/test_variation_adjacency_guard.py
+"""
+import sys
+from pathlib import Path
+
+# Insert `scripts/` (for grain_tag + variation_light_cap) and `scripts/ci/`
+# (for the script under test).
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import variation_adjacency_guard as vag  # noqa: E402
+
+# The two night-of-2026-08-15/16 cases, verbatim tags from issue #11170.
+CASE_11136 = "Grain: LIGHT/docs -- lane myia-po-2023:CoursIA -- prev: LIGHT/docs 11134"
+CASE_11165 = "Grain: LIGHT/docs -- lane myia-po-2023:CoursIA -- prev: MED/notebook-python"
+
+
+def test_11136_replay_blocks():
+    # The merged-without-question case: same LIGHT genre twice -> BLOCK.
+    v = vag.check(CASE_11136)
+    assert v["guard_pass"] is False
+    assert v["blocking"] is True
+    assert v["adjacent"] is True
+    assert v["genre"] == "docs"
+    assert v["prev_genre"] == "docs"
+
+
+def test_11165_replay_passes():
+    # The legitimately-different case: docs then notebook-python -> PASS.
+    v = vag.check(CASE_11165)
+    assert v["guard_pass"] is True
+    assert v["blocking"] is False
+    assert v["adjacent"] is False
+
+
+def test_blocking_reason_names_genres_and_lane():
+    # The issue demands the error message cite BOTH genres and the lane, so
+    # the failure is debuggable from the job log alone.
+    v = vag.check(CASE_11136)
+    assert "docs" in v["reason"]
+    assert "myia-po-2023:CoursIA" in v["reason"]
+    assert "UN AUTRE genre" in v["reason"]
+
+
+def test_first_grain_exemption():
+    # `prev: none (premier grain)` -> PASS, no predecessor to compare.
+    v = vag.check(
+        "Grain: LIGHT/docs -- lane myia-po-2023:CoursIA -- prev: none (premier grain)"
+    )
+    assert v["guard_pass"] is True
+    assert v["adjacent"] is False
+
+
+def test_prev_absent_is_not_reflagged():
+    # A missing prev: is covered by the variation-tag-prev-absent label and
+    # the tag-required job -- this organ must not double-flag it.
+    v = vag.check("Grain: LIGHT/docs -- lane myia-po-2023:CoursIA")
+    assert v["guard_pass"] is True
+    assert v["adjacent"] is False
+
+
+def test_no_tag_is_not_reflagged():
+    # Missing Grain tag -> covered by check-variation-tag-required.
+    v = vag.check("Some body with no Grain tag at all.")
+    assert v["guard_pass"] is True
+    assert v["adjacent"] is False
+
+
+def test_different_genres_pass():
+    v = vag.check(
+        "Grain: MED/genai -- lane myia-po-2023:CoursIA -- prev: MED/guard #11200"
+    )
+    assert v["guard_pass"] is True
+    assert v["adjacent"] is False
+
+
+def test_deep_med_adjacency_is_advisory():
+    # Same DEEP/MED domain-core genre twice: §2 allows it "si chacun est une
+    # substance genument distincte" -- label, never block.
+    v = vag.check(
+        "Grain: DEEP/lean -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #9999"
+    )
+    assert v["guard_pass"] is True
+    assert v["blocking"] is False
+    assert v["adjacent"] is True
+    assert "advisory" in v["reason"]
+
+
+def test_every_light_genre_blocks():
+    # The full LIGHT set {guard, ledger, docs, readme, test} bans adjacency.
+    for genre in ("guard", "ledger", "docs", "readme", "test"):
+        v = vag.check(f"Grain: LIGHT/{genre} -- lane x:y -- prev: LIGHT/{genre} #1")
+        assert v["guard_pass"] is False, f"{genre} adjacency must block"
+        assert v["blocking"] is True
+
+
+def test_aliases_normalised_before_comparison():
+    # `docs-translation` folds to `docs` via the alias table: two grains of
+    # the same work under invented labels must still trip the ban (§1).
+    v = vag.check(
+        "Grain: LIGHT/docs -- lane myia-po-2025:CoursIA-2 -- prev: LIGHT/docs-translation #100"
+    )
+    assert v["guard_pass"] is False
+    assert v["prev_genre"] == "docs"
+
+
+def test_tier_of_prev_does_not_matter():
+    # The ban compares GENRES, not tiers: LIGHT/docs after MED/docs is the
+    # same violation (the MED/readme defect case of #10020).
+    v = vag.check(
+        "Grain: LIGHT/docs -- lane myia-po-2023:CoursIA -- prev: MED/docs #200"
+    )
+    assert v["guard_pass"] is False
+    assert v["blocking"] is True
+
+
+def test_empty_inputs_pass():
+    assert vag.check(None)["guard_pass"] is True
+    assert vag.check("")["guard_pass"] is True


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/tooling #11226

## Summary

G-VAR-3 (variation-protocol.md §2) bannit deux grains consecutifs du meme GENRE LIGHT pour une lane — mais jusqu'ici **aucun organe ne comparait le genre du grain a celui de son `prev:`**. `Check Grain tag conformity` verifie que le tag est bien forme, `G-VAR-2 light cap` compte le budget journalier, mais un tag parfaitement conforme declarant `LIGHT/docs -- prev: LIGHT/docs` passait **tous les gates verts**.

Mesure du 2026-08-15/16 au soir : #11136 (`LIGHT/docs -- prev: LIGHT/docs 11134`) MERGEE 00:30:56Z, #11167 (`LIGHT/docs -- prev: MED/docs 11069`) TENUE ~03:00Z — meme forme, verdicts opposes, trois heures d'ecart, meme coordinateur. La premiere n'a pas ete mergee par complaisance : rien dans l'outillage ne posait la question.

## Fix

**Helper `scripts/ci/variation_adjacency_guard.py`** (meme forme testable que `variation_prev_guard.py` #10093) — pure `check(body)` + CLI `--body-file`, verdict JSON sur stdout, exit 0/1/2 :
- parse le Grain tag + son `prev:` via l'extracteur SHARED `scripts/grain_tag.py` (les organes ne divergent jamais sur ce qu'est un tag) ;
- normalise **les deux genres** via la meme table d'alias que l'organe G-VAR-2 (`variation_light_cap.canonicalize_genre`) — variation-protocol §1 : deux etiquettes inventées suffisent a ne jamais declencher le ban ;
- **BLOCK** (exit 1) quand `genre == prev_genre` ET le genre est dans `LIGHT_GENRES` {guard, ledger, docs, readme, test} — le ban absolu du §2, sans clause d'echappement. Le message cite les DEUX genres et la lane. Remede : piocher un grain d'UN AUTRE genre, jamais retaguer le meme travail ;
- **ADVISORY** (exit 0 + `adjacent: true`) quand les genres sont egaux hors liste LIGHT (DEEP/MED domain-core) — §2 l'autorise "si chaque grain est une substance genument distincte", jugement non mecanisable, label seulement ;
- **PASS** sur genres differents / `prev: none (premier grain)` / prev absent (couvert par variation-tag-prev-absent) / pas de tag (couvert par check-variation-tag-required).

**Job `check-variation-adjacency-required` dans `variation-tag-guard.yml`** :
- suffixe `-required` = signal explicite que le job N'EST PAS advisory et ne doit PAS etre silence par `is_advisory()` de pr_gate.py quand #10036 atterrit (meme convention que #10045/#10093) ;
- sparse-checkout des 3 modules ; gating bots/forks identique aux autres jobs ;
- commentaire bloquant idempotent (marqueur `<!-- vtr-adjacency-block -->`) citant le `reason` (genres + lane) ;
- label advisory `variation-adjacency-deep-med` cree/pose/retire selon le verdict.

## Validation

- **12/12 tests** `scripts/tests/test_variation_adjacency_guard.py` : replay #11136 → BLOCK, replay #11165 → PASS, exemption premier grain, les 5 genres LIGHT (boucle), normalisation d'alias (`docs-translation`→`docs` bloque), le TIER du prev n'a pas d'importance (LIGHT/docs apres MED/docs bloque — cas #10020), entrees vides passe.
- **Non-regression** : 107 passed sur les 4 fichiers de tests des organes variation (light_cap 14, prev_guard 43, tag_required 14, adjacency 12... total pytest 107).
- **CLI end-to-end** verifie sur les 3 branches : BLOCK RC=1, PASS RC=0, ADVISORY RC=0 — le JSON `adjacent` pilote correctement le câblage label du job.

See #11170 (contribution partielle : l'acceptance « un job qui bloque sur l'adjacence LIGHT interdite et labellise l'adjacence DEEP/MED » ; le rework du protocole reste ouvert).