### PR TITLE
fix(docs,#11124): neutralize dead scratchpad-c8087 reproduction commands

### DIFF
--- a/docs/archive/audit/l-coupling-audit-2026-07-23.md
+++ b/docs/archive/audit/l-coupling-audit-2026-07-23.md
@@ -23,7 +23,7 @@ Script Python `scratchpad-c8087/audit_l_coupling.py` (3 étapes — script déso
 | 3 | Parse `CLAUDE.md` (harnais global) → set `L\d+` | N leçons uniques |
 | 4 | Cross-match : ancrées / orphelines-MEMORY / orphelines-rules | Rapport |
 
-**Reproduction** : `python scratchpad-c8087/audit_l_coupling.py` (read-only, pas de side-effects).
+**Reproduction** : le script `audit_l_coupling.py` est archivé hors-repo (drop scratchpad c.821, harness-hygiene) — snapshot dans l'historique de la PR #8099 (commit `5ac25223b`), non rejouable depuis l'arbre. Le résultat du dernier refresh est reproduit dans la section « Sortie script ».
 
 ## Verdict global — refresh 2026-07-23
 
@@ -140,7 +140,7 @@ Script Python `scratchpad-c8087/audit_l_coupling.py` (3 étapes — script déso
 ## Sortie script (refresh 2026-07-23)
 
 ```
-$ python scratchpad-c8087/audit_l_coupling.py
+$ # repro : script archivé hors-repo — snapshot via PR #8099 (commit 5ac25223b) ; sortie du refresh c.821 :
 === AUDIT L-COUPLING (refresh c.821) ===
 MEMORY.md leçons uniques : 35
 .claude/rules/ leçons uniques (tous fichiers) : 17


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-po-2024:CoursIA — prev: LIGHT/readme #11121

## Summary

`docs/archive/audit/l-coupling-audit-2026-07-23.md` référençait `scratchpad-c8087/audit_l_coupling.py` à 3 endroits alors que la PR qui a documenté l'audit a retiré le scratchpad de l'arbre (harness-hygiene). Grep firsthand sur `origin/main` : 3 hits, 0 fichier cible — la reproduction documentée était un chemin mort.

## Fix (selon l'acceptance de l'issue)

Les **2 commandes exécutables** sont neutralisées vers le snapshot archivé :

1. Ligne `**Reproduction**` : remplacée par une référence au snapshot de la PR #8099 (commit `5ac25223b`) — le script est archivé hors-repo, non rejouable depuis l'arbre, le dernier résultat est reproduit dans la section « Sortie script ».
2. Première ligne du bloc « Sortie script » : la commande `$ python scratchpad-c8087/audit_l_coupling.py` est remplacée par une ligne de provenance (`# repro : script archivé hors-repo — snapshot via PR #8099 (commit 5ac25223b)`) — le bloc de sortie du refresh c.821 reste la vraie sortie, seule l'invocation morte disparaît.

La mention historique (L17) est laissée intacte : elle porte déjà la référence snapshot #8099.

## Validation

- **Acceptance mesurée** : `git grep -c scratchpad-c8087` sur la branche → **1 hit** (L17, mention historique en prose qui renvoie vers #8099), **0 chemin exécutable**.
- Snapshot vérifié firsthand : commit `5ac25223b` (PR #8099) contient bien `scratchpad-c8087/audit_l_coupling.py` + `audit_l_coupling.json`.
- Diff : 2 insertions / 2 suppressions, un seul fichier.

See #11124.