### PR TITLE
enrich(qc,#11224): densite pedagogique QC-Py-27-Production-Deployment 1002->1398 (markdown-only FR)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -392,6 +392,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "633d3289",
+   "source": "> **Lecture — le cycle de vie s'exécute comme un automate à états.** La sortie montre l'algorithme `MomentumML` parcourir `draft -> testing -> paper`, puis se faire **bloquer** au passage `paper -> live` : la transition est refusée avec le message *Not enough paper days: 0 < 14*. C'est le cœur du garde-fou : la machine à états ne vérifie pas seulement que la transition est *valide* (draft ne peut pas sauter directement en live), elle applique aussi des **critères métier chiffrés** — ici, le nombre de jours passés en paper trading doit atteindre le seuil de 14. La simulation « triche » ensuite en vieillissant artificiellement `paper_start` de 20 jours pour montrer la transition aboutir. Le `TransitionCriteria` porte aussi les autres seuils : Sharpe ≥ 1,0, drawdown < 20 %, tolérance paper/backtest de 30 %. L'exercice 1.2 consiste à en ajouter un (return > 15 % et drawdown < 20 %) : c'est exactement le même mécanisme — une condition supplémentaire dans la méthode de transition.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-cb0dc0c9",
    "metadata": {},
    "source": [
@@ -868,6 +874,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d7b79b22",
+   "source": "> **Lecture — le rapport de paper trading tranche : `NOT READY`.** Après 20 jours simulés, le tracker affiche un rendement de **-2,60 %**, un Sharpe de **-1,78** contre **1,50** attendu du backtest — soit **-118 %** — et une seule cause listée dans `ISSUES`: le Sharpe paper est sous les 70 % du backtest. Le reste des métriques d'exécution est pourtant sain : 12 trades (58,3 % de gagnants), un slippage moyen de **3,8 bps**, un temps de remplissage de **1,1 s**. Le point pédagogique est subtil : sur 20 jours, un écart de Sharpe de cette ampleur peut venir de la **volatilité d'échantillon** (le tirage aléatoire de `daily_returns`) autant que d'un vrai problème de déploiement. C'est précisément pourquoi la règle impose 14 jours minimum et un seuil à 70 % : empêcher qu'un bruit statistique soit interprété comme une validation — ou comme un échec — à tort. L'exercice 2.2 demande de formaliser ce ratio `paper_sharpe / backtest_sharpe`.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-b3b8951d",
    "metadata": {},
    "source": [
@@ -1332,6 +1344,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1e993bd2",
+   "source": "> **Lecture — la graduation des alertes warning → critical.** La démonstration alimente le monitoring avec trois valeurs de drawdown : -0,03 (aucune alerte, sous les deux seuils), -0,06 (franchit le seuil *warning* de 0,05 → **Email**), -0,12 (franchit le seuil *critical* de 0,10 → **SMS + Email**). La sortie confirme la hiérarchie : le warning ne déclenche qu'un email, le critical escalade vers le SMS — le canal le plus immédiat — en plus de l'email. Le compteur final *Total alerts: 2* montre que chaque dépassement est indépendant : deux métriques franchissent un seuil, deux alertes sont créées. Cette architecture de seuils par métrique (`drawdown`, `daily_loss`, `sharpe_deviation`, `slippage_bps`, `fill_time_seconds`) est le cœur du déploiement : sans monitoring, une dérive de drawdown n'est détectée qu'au rapport suivant ; avec, l'opérateur reçoit l'alerte au moment où le seuil est franchi.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-23f14c47",
    "metadata": {},
    "source": [
@@ -1608,6 +1626,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7f658124",
+   "source": "> **Lecture — trois méthodes d'allocation, trois philosophies de risque.** Sur les mêmes stratégies (Momentum, MeanReversion, MLSignals), l'orchestrateur produit : **FIXED** 40/30/30 (les poids cibles définis à l'ajout, aucun calcul) ; **RISK_PARITY** 31,3/41,6/27,0 — la stratégie la plus stable, MeanReversion, reçoit le **poids le plus fort**, car la parité de risque pondère par l'inverse de la volatilité (ici approchée par le Sharpe) : on récompense la stabilité, pas le rendement ; **PERFORMANCE** 35,4/24,3/40,3 — MLSignals, la stratégie au meilleur Sharpe récent (2,1), prend la tête, la pondération suit les performances passées. Le contraste entre les deux méthodes est le vrai sujet : la parité de risque **équilibre les contributions de risque** (une stratégie volatile ne peut pas dominer le portefeuille), la pondération performance **concentre le capital sur les gagnants récents** et accepte donc une volatilité plus élevée. L'exercice 3.1 demande d'implémenter ce calcul avec contraintes min/max ; le 3.2 ajoute une contrainte de corrélation.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 3.2 : Allocation avec contrainte de correlation\n\nAjoutez une **contrainte de correlation** a l'orchestrateur multi-stratégies : si deux stratégies ont une correlation > 0.7, reduisez l'allocation de la moins performante.\n\n**Indices** :\n- `# Indice` : Calculez la correlation entre les returns des stratégies\n- `# Étape 1` : Simuler les returns de 3 stratégies\n- `# Étape 2` : Calculer la matrice de correlation\n- `# Étape 3` : Reduire l'allocation des stratégies correllees"
@@ -1856,6 +1880,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b09c1398",
+   "source": "> **Lecture — la checklist est un état de préparation, pas un formulaire.** Le rapport final affiche `NOT READY` avec **9 items critiques manquants** : côté Paper, le slippage mesuré et la gestion des erreurs ; côté Risk, le drawdown maximal total, les stop-loss et l'auto-liquidation ; côté Monitoring, le contact d'urgence ; côté Infra, le capital broker correct ; côté Docs, les limites de risque et la procédure de rollback. Les cases cochées montrent le chemin fait : backtest validé (3 ans, Sharpe > 1,0, drawdown < 20 %), paper avec performance *within 25 % du backtest*, position et perte journalière définies, alertes configurées, secrets hors code. La leçon : chaque item critique non coché est un **risque accepté consciemment** — et la méthode `is_ready()` force cette conscience en refusant un verdict READY tant qu'un seul item critique manque. L'auto-évaluation honnête NOT READY vaut mieux qu'un passage en live prématuré.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "id": "22f62f7a",
    "metadata": {},
    "source": [
@@ -1961,6 +1991,12 @@
     "print(best_practices)"
    ],
    "id": "cell-9865d106"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c060055",
+   "source": "> **Lecture — la synthèse condense la discipline en six blocs.** Le résumé final restitue l'ensemble du notebook : (1) le **cycle de vie** `draft -> testing -> paper -> live` avec critères stricts à chaque transition et documentation systématique ; (2) le **paper trading** — 2 semaines minimum, comparaison aux attentes du backtest, suivi du slippage et des temps de remplissage, validation de la gestion des erreurs ; (3) le **risk management** chiffré — position max 20 %, perte journalière max 2 %, drawdown total max 10 %, auto-liquidation en cas de dépassement ; (4) le **monitoring** — SMS pour les alertes critiques, email pour les warnings, rapports quotidiens automatiques, dashboard accessible ; (5) le **multi-strategy** — diversification, allocation risk parity, rebalancement mensuel, surveillance des corrélations ; (6) la **documentation** — stratégie, limites de risque, procédure de rollback, contacts d'urgence. Ces six blocs sont exactement les sections du notebook : le résumé fonctionne comme la **page de garde** de votre discipline de déploiement — à relire avant chaque passage en live.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #11229

## Summary

Enrichissement pedagogique markdown-only FR (pattern #10488) de `QC-Py-27-Production-Deployment.ipynb` (tranche #11224) :

- **6 cellules markdown FR d'interpretation** ajoutees, chacune ancree sur un output reel commute (cell-interpretation-ordering : l'interp suit la cellule code dont l'output contient la valeur citee) :
  - cycle de vie : blocage `paper -> live` (0 < 14 jours) puis succes apres vieillissement artificiel
  - paper report : Sharpe -1.78 vs 1.50 backtest (-118 %), 12 trades, slippage 3.8 bps, fill 1.1 s
  - monitoring : seuils warning 0.05 (Email) / critical 0.10 (SMS + Email), total alerts 2
  - allocations : FIXED 40/30/30 vs RISK_PARITY 31.3/41.6/27.0 vs PERFORMANCE 35.4/24.3/40.3
  - checklist : 9 items critiques manquants, verdict NOT READY
  - resume : 6 blocs de la discipline de deploiement

## Densite (avant -> apres)

| Metrique | Avant | Apres |
|----------|-------|-------|
| Density | 1002 | **1398** |
| Prose chars | 15036 | 20982 |
| Code cells | 15 | 15 (byte-identiques) |
| Md cells | 21 | 27 |
| Status | below_threshold | **ok** (> 1200) |

## Conformite

- **0 cellule code touchee** : `git diff origin/main...HEAD | grep -c '"cell_type": "code"'` = 0 ; stubs d'exercices C.1 intacts (result = None / print "Exercice a completer")
- `nbformat.validate()` = VALID (42 cells : 15 code + 27 md)
- Pas de `_en.ipynb`, pas de re-exec (markdown-only, outputs committes inchanges)
- 1 notebook = 1 PR (atomique)

See #11224