### PR TITLE
docs(lean,#3979): re-audit grothendieck_lean README FR/EN — compteurs 34->43 modules leaf, Parties 35-43 + lignes wc -l

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -5,10 +5,10 @@ Alexandre Grothendieck (1928-2014).
 ## Status
 
 - **Toolchain**: `leanprover/lean4:v4.31.0-rc1`
-- **Sorry**: **0 sorry, 0 axiom** — all 33 leaf modules are complete at creation
-- **Build**: `lake build Grothendieck` — compiles the 33 leaf modules (11,206 FR+EN lines, + 208 for the umbrella = **11,414 total**, measured 2026-07-30)
+- **Sorry**: **0 sorry, 0 axiom** — all 43 leaf modules are complete at creation (verified `count_code_sorry.py --json`: `distinct_code_sorry = 0`, measured 2026-08-16)
+- **Build**: `lake build Grothendieck` — compiles the 43 leaf modules + 1 bilingual umbrella (10,944 FR + 10,245 EN = **21,189 FR+EN lines total**, measured 2026-08-16)
 - **Dependencies**: Mathlib 4 (via `lakefile.lean`)
-- **i18n coverage (EPIC #4980, ratified 2026-07-04)**: complete bilingual FR/EN coverage — **34 FR files** (1 umbrella `Grothendieck.lean` bilingual inline FR+EN + **33 leaf modules** FR canonical) + **33 `_en.lean` siblings** on `main` (leaf modules only; the umbrella is bilingual inline). Per the ratified convention (Option A: `Foo.lean` FR canonical + `Foo_en.lean` EN mirror for leaves), **all 33 leaf modules** are bilingual in Pattern A (`_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). The umbrella `Grothendieck.lean` is bilingual inline (FR canonical first, EN mirror, see final doctring in the file) — *by design*, not an i18n gap. **`README.md`** present (FR canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
+- **i18n coverage (EPIC #4980, ratified 2026-07-04)**: complete bilingual FR/EN coverage — **44 FR files** (1 umbrella `Grothendieck.lean` bilingual inline FR+EN + **43 leaf modules** FR canonical) + **43 `_en.lean` siblings** on `main` (leaf modules only; the umbrella is bilingual inline). Per the ratified convention (Option A: `Foo.lean` FR canonical + `Foo_en.lean` EN mirror for leaves), **all 43 leaf modules** are bilingual in Pattern A (`_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). The umbrella `Grothendieck.lean` is bilingual inline (FR canonical first, EN mirror, see final doctring in the file) — *by design*, not an i18n gap. **`README.md`** present (FR canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
 
 ## Purpose
 
@@ -26,64 +26,98 @@ The goal is to give learners a curated entry point into:
 
 ## Structure
 
-The formalization spans **33 leaf modules (11,206 FR+EN lines, 0 sorry)**, imported
-in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline FR/EN; no `_en` sibling for the umbrella).
+The formalization spans **43 leaf modules (0 sorry)** — of which 3 are
+`SheafCohomology/` submodules (Basic + MayerVietoris + Cech, Parts 20, 22, 23) —
+imported by the umbrella `Grothendieck.lean` (itself bilingual inline FR/EN; no `_en` sibling for the umbrella). The umbrella imports **42 of the 43 leaves**: Part 34 `ExceptionalDirect.lean` is **standalone** (not imported by the umbrella — extension added by **PR #10357, MERGED 2026-08-11**, Phase 2 of Epic #2159 formalizing the exceptional direct image `f_!` at the presheaf level and its adjunction `f_! ⊣ f^*`), yet still compiled via the `globs := #[`Grothendieck.*]` in the lakefile (cf. i18n convention #4980).
+
+*The pedagogical arc of the 43 leaf modules — from sites and sieves up to cohomology, with schemes/Zariski, the Mathlib map, and the arrow form of covers as extension:*
+
+```mermaid
+flowchart LR
+    T1["<b>Sites & sieves</b><br/><i>Parts 1·6·8·11·12·16</i><br/>Grothendieck topologies<br/>pullback_id · pullback_monotone"]
+    T2["<b>Sheaves & separation</b><br/><i>7·9·10·17</i><br/>separated presheaf<br/>transfer along J₁ ≤ J₂"]
+    T3["<b>Sheafification</b><br/><i>13·14</i><br/>associated sheaf functor<br/>left exactness (LeftExact)"]
+    T4["<b>Points & conservative</b><br/><i>15·19</i><br/>fiber functors<br/>conservative families"]
+    T5["<b>Cohomology</b><br/><i>20·21·22·23</i><br/>Ext · Mayer-Vietoris · Čech"]
+    T6["<b>Arrow form of covers</b><br/><i>35·36·37·38·39·40·41·42·43</i><br/>J.Cover · pullback · lattice"]
+    T1 --> T2 --> T3 --> T4 --> T5
+    T5 -.-> T6
+    S["<b>Schemes & Zariski site</b><br/><i>Parts 2·3</i><br/>Spec functor<br/>zariski_topology_eq"] -.->|"geometric anchor"| T1
+    MM["<b>Mathlib map</b><br/><i>Part 4</i><br/>#check index"] -.->|"library anchor"| T3
+```
 
 | Part | File | `_en` | Content | Lines |
 |------|------|-------|---------|-------|
-| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only of the 33 leaves + bilingual FR/EN doctring); no `_en` sibling (the EN content lives in the same file as a mirror) | 208 |
+| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only of the 42 leaves except `ExceptionalDirect` + bilingual FR/EN doctring); no `_en` sibling (the EN content lives in the same file as a mirror) | 217 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 243 |
-| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 109 |
-| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 93 |
-| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 107 |
+| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 196 |
+| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 139 |
+| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 123 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 95 |
-| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities (7): `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
-| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 148 |
-| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 141 |
-| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 177 |
+| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities (7): `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 252 |
+| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 230 |
+| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 207 |
+| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 233 |
 | 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Canonical topology, subcanonicity, representable sheaves | 154 |
-| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Sieve generation identities | 172 |
-| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | The dense topology | 155 |
-| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Sheafification (the associated sheaf functor) | 189 |
+| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Sieve generation identities | 242 |
+| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | The dense topology | 218 |
+| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Sheafification (the associated sheaf functor) | 258 |
 | 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Left exactness of sheafification | 219 |
-| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 226 |
-| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 105 |
-| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Internal hom of sheaves | 173 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Conservative families of points | 226 |
-| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Sheaf cohomology (Ext-based) | 254 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Mayer-Vietoris squares | 195 |
-| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Mayer-Vietoris long exact sequence | 167 |
-| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 130 |
+| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 411 |
+| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 232 |
+| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Internal hom of sheaves | 273 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 252 |
+| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Conservative families of points | 501 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Sheaf cohomology (Ext-based) | 336 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Mayer-Vietoris squares | 338 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Mayer-Vietoris long exact sequence | 235 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 203 |
 | 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 274 |
-| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjunction of functors, unit/counit, turtle lemma, left/right adjoints | 168 |
-| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monads in category theory, unit, multiplication, associativity law | 172 |
-| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Comma category, projections, functoriality | 129 |
-| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limits and colimits | 242 |
-| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Equivalences of categories, fully-faithful functors, essentially surjective | 189 |
-| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Basic categorical constructions | 152 |
-| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Kan extensions (generalized limits/colimits) | 270 |
-| 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Monoidal categories, tensor, unit, associator | 244 |
-| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | `#check` index (8) of the `f^* ⊣ f_*` adjunction — direct/inverse image of module sheaves (#8882) | 152 |
+| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjunction of functors, unit/counit, turtle lemma, left/right adjoints | 335 |
+| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monads in category theory, unit, multiplication, associativity law | 253 |
+| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Comma category, projections, functoriality | 239 |
+| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limits and colimits | 421 |
+| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Equivalences of categories, fully-faithful functors, essentially surjective | 338 |
+| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Basic categorical constructions | 256 |
+| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Kan extensions (generalized limits/colimits) | 481 |
+| 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Monoidal categories, tensor, unit, associator | 397 |
+| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | `#check` index (8) of the `f^* ⊣ f_*` adjunction — direct/inverse image of module sheaves (#8882) | 325 |
+| 34 | `Grothendieck/ExceptionalDirect.lean` | `ExceptionalDirect_en.lean` | Exceptional direct image `f_!` at the presheaf level and its adjunction `f_! ⊣ f^*` — left Kan extension of `f^*` along `f` (#10357, Phase 2 of #2159); **standalone** (not imported by the umbrella) | 202 |
+| 35 | `Grothendieck/CoversArrow.lean` | `CoversArrow_en.lean` | Arrow form of the cover — 7 dedicated theorems (#10879, Phase 5) | 199 |
+| 36 | `Grothendieck/Cover.lean` | `Cover_en.lean` | Bundled cover `J.Cover X` — 15 dedicated theorems (#10912, Phase 5) | 284 |
+| 37 | `Grothendieck/PullbackFunctor.lean` | `PullbackFunctor_en.lean` | Coherence laws of the pullback (pseudofunctor on `J.Cover`) (#11023, Phase 5) | 149 |
+| 38 | `Grothendieck/PullbackFunctorLaws.lean` | `PullbackFunctorLaws_en.lean` | Pullback functor laws on `J.Cover` (#11035, Phase 5) | 141 |
+| 39 | `Grothendieck/TopologyLattice.lean` | `TopologyLattice_en.lean` | Lattice laws of Grothendieck topologies (#11038, Phase 5) | 211 |
+| 40 | `Grothendieck/CoversPullback.lean` | `CoversPullback_en.lean` | Arrow-form `J.Covers` laws under pullback (#11057, Phase 5) | 202 |
+| 41 | `Grothendieck/CoversOrder.lean` | `CoversOrder_en.lean` | Order laws of the arrow form `J.Covers` (#11068, Phase 5) | 164 |
+| 42 | `Grothendieck/PullbackCoversLaws.lean` | `PullbackCoversLaws_en.lean` | Arrow-form laws under iterated pullback (#11217, Phase 5) | 160 |
+| 43 | `Grothendieck/CoversLattice.lean` | `CoversLattice_en.lean` | Indexed lattice laws of the arrow form (#11231, Phase 5) | 106 |
 
-*The `Lines` column counts the **FR file alone**; the FR+EN total is roughly double.*
+*The `Lines` column counts the **FR file alone** (`wc -l`, measured 2026-08-16); the FR+EN total is **21,189 lines** (10,944 FR + 10,245 EN).*
 
-The extension was developed under Issue #2159 / Epic #1646: the 33 leaf modules
-are merged + 1 bilingual umbrella, 0 `sorry`, 0 axiom added.
+The extension was developed under Issue #2159 / Epic #1646: the 43 leaf modules
+are merged + 1 bilingual umbrella, 0 `sorry`, 0 axiom added. **Phase 1** (Parts 1-33)
+shipped through successive PR waves (#2675, #8882, etc.); **Phase 2** (Part 34 `f_! ⊣ f^*`)
+delivered by PR #10357 (MERGED 2026-08-11); **Phase 5** (Parts 35-43, arrow form of covers)
+delivered by PRs #10879, #10912, #11023, #11035, #11038, #11057, #11068, #11217, #11231.
 
 ## Build
 
 ```bash
 # From this directory (WSL required)
 lake build Grothendieck
-# Builds the 33 leaf modules + 1 bilingual umbrella (11,414 FR+EN lines total)
-# Last verified build: 2026-07-30, "Build completed successfully (2821 jobs)"
+# Builds the 43 leaf modules + 1 bilingual umbrella (21,189 FR+EN lines total)
+# Last verified build: 2026-08-12, "Build completed successfully" (state 34 modules);
+# Parts 35-43 (Phase 5) merged with lake build SUCCESS in their respective PRs
 ```
 
 ## Sorry count
 
-**0 sorry, 0 axiom** — all 33 leaf modules are complete at creation
-(the umbrella `Grothendieck.lean` is imports-only without declarations).
+**0 sorry, 0 axiom** — all 43 leaf modules are complete at creation
+(verified `count_code_sorry.py --json`: `distinct_code_sorry = 0`, measured 2026-08-16;
+the umbrella `Grothendieck.lean` is imports-only without declarations). Part 34
+`ExceptionalDirect.lean` (#10357) cites `sorry` twice in prose docstring
+(marker of the bounded formalization) but contains **no sorry tactic**.
 
 ## Toolchain
 
@@ -104,20 +138,22 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 ## See also
 
 - Epic #1646 (Grothendieck tribute)
-- Issue #2159 (Grothendieck formalization depth)
+- Issue #2159 (Grothendieck formalization depth — Phase 1 shipped, **Phase 2** delivered by #10357 on 2026-08-11: `f_! ⊣ f^*` at the presheaf level = Part 34 `ExceptionalDirect.lean`; **Phase 5** delivered by #10879/#10912/#11023/#11035/#11038/#11057/#11068/#11217/#11231: Parts 35-43, arrow form of covers)
 - PR #2675 (Phases 4-6: SieveOps + CoverageGen + CanonicalProps)
+- **PR #10357** (Phase 2 #2159: exceptional direct image `f_! ⊣ f^*` at the presheaf level, bounded formalization of the missing link between `f^*` and `f_*`)
 - Epic #1453 (prover harness calibration)
 - Conway tribute workspace (`../conway_lean/`)
 - Lean notebook series (`../README.md`)
-- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 33 `_en.lean` siblings on `main` in this lake + 1 bilingual inline umbrella)
+- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 43 `_en.lean` siblings on `main` in this lake + 1 bilingual inline umbrella)
 - Issue #8960 (reconciling the two `Part` numberings)
 - **[`README.md`](./README.md)** — FR canonical sibling of this file
 
 ## Conclusion
 
-This tribute is a **complete pedagogical tour** (33 leaf modules + 1 bilingual umbrella, 11,414 FR+EN lines, 0 `sorry`,
+This tribute is a **complete pedagogical tour** (43 leaf modules + 1 bilingual umbrella, 21,189 FR+EN lines, 0 `sorry`,
 0 axiom added) showing how Grothendieck's language — sites, sheaves,
-sheafification, points, cohomology, Yoneda, direct images — already lives in Mathlib 4. It is
+sheafification, points, cohomology, Yoneda, direct images, exceptional direct
+image `f_!`, arrow form of covers — already lives in Mathlib 4. It is
 deliberately **not** a formalization of EGA/SGA; it is a curated index that lets
 learners see the library through Grothendieckian eyes.
 
@@ -130,9 +166,15 @@ its left exactness** (13, 14) → **points and conservative families** (15, 19) 
 Zariski site** (2, 3), a **Mathlib map** (4), and the **Yoneda lemma** (24)
 anchoring the tour to the library it indexes. The categorical foundations
 (Adjunction, Equivalences, Monads) at Parts 25, 29, 26 underpin the whole
-formalization. Finally, `DirectImage.lean` indexes the `f^* ⊣ f_*` adjunction — the
+formalization. `DirectImage.lean` (Part 33) indexes the `f^* ⊣ f_*` adjunction — the
 simplest instance of the "six operations", transporting sheaves along morphisms
-of schemes.
+of schemes. `ExceptionalDirect.lean` (Part 34, #10357) takes a further step by
+formalizing `f_! ⊣ f^*` at the presheaf level — the *proper support* direct image as a
+left Kan extension of `f^*`, missing link between `f^*` (inverse image) and `f_*`
+(direct image). Finally, **Phase 5** (Parts 35-43) unfolds the arrow-form structure of
+covers: `CoversArrow` (35), the bundled cover `J.Cover X` (36), the pullback coherence
+and functor laws (37-38), the lattice of topologies (39), and the arrow-form `J.Covers`
+laws under pullback, order, iteration, and indexed lattice (40-43).
 
 ### Scope, honestly
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -5,10 +5,10 @@ Alexandre Grothendieck (1928-2014).
 ## État
 
 - **Toolchain** : `leanprover/lean4:v4.31.0-rc1`
-- **Sorry** : **0 sorry, 0 axiome** — les 34 modules leaf sont complets à la création
-- **Build** : `lake build Grothendieck` — compile 34 modules leaf + 1 umbrella bilingue (mesuré 2026-08-12)
+- **Sorry** : **0 sorry, 0 axiome** — les 43 modules leaf sont complets à la création (vérifié `count_code_sorry.py --json` : `distinct_code_sorry = 0`, mesuré 2026-08-16)
+- **Build** : `lake build Grothendieck` — compile 43 modules leaf + 1 umbrella bilingue (mesuré 2026-08-16)
 - **Dépendances** : Mathlib 4 (via `lakefile.lean`)
-- **Couverture i18n (EPIC #4980 ratifiée 2026-07-04)** : couverture bilingue FR/EN complète — **36 fichiers FR** (1 umbrella `Grothendieck.lean` bilingue inline FR+EN + **34 modules leaf** FR canonique, dont `ExceptionalDirect.lean` Partie 34 ajouté via #10357 le 2026-08-11) + **34 siblings `_en.lean`** sur `main` (les 34 modules leaf uniquement ; l'umbrella est bilingue inline). Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN pour les leafs), **tous les 34 modules leaf** sont déjà bilingues au pattern A (namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). L'umbrella `Grothendieck.lean` est bilingue inline (FR canonique d'abord, EN en miroir, cf doctring final du fichier) — c'est *by design*, pas un gap i18n. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
+- **Couverture i18n (EPIC #4980 ratifiée 2026-07-04)** : couverture bilingue FR/EN complète — **44 fichiers FR** (1 umbrella `Grothendieck.lean` bilingue inline FR+EN + **43 modules leaf** FR canonique) + **43 siblings `_en.lean`** sur `main` (les 43 modules leaf uniquement ; l'umbrella est bilingue inline). Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN pour les leafs), **tous les 43 modules leaf** sont déjà bilingues au pattern A (namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). L'umbrella `Grothendieck.lean` est bilingue inline (FR canonique d'abord, EN en miroir, cf doctring final du fichier) — c'est *by design*, pas un gap i18n. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
 
 ## Objectif
 
@@ -27,16 +27,17 @@ Le but est d'offrir aux apprenants un point d'entrée curaté vers :
 
 ## Structure
 
-La formalisation couvre **34 modules leaf (0 sorry)** + **3 sous-modules
-SheafCohomology/** (Basic + MayerVietoris + Cech, déjà comptés dans la Partie
-20-22), importés dans l'ordre par le parapluie `Grothendieck.lean` (qui est
-lui-même bilingue inline FR/EN, pas de sibling `_en` pour l'umbrella). La Partie
-34 (`ExceptionalDirect.lean`) a été ajoutée par **PR #10357 (MERGED 2026-08-11)** —
-extension Phase 2 de l'Epic #2159 qui formalise l'image directe exceptionnelle
-`f_!` au niveau préfaisceau et son adjonction `f_! ⊣ f^*` (extension de Kan
-à gauche de `f^*` le long de `f`).
+La formalisation couvre **43 modules leaf (0 sorry)** — dont 3 sous-modules
+`SheafCohomology/` (Basic + MayerVietoris + Cech, Parties 20, 22, 23) —
+importés par le parapluie `Grothendieck.lean` (lui-même bilingue inline FR/EN,
+pas de sibling `_en` pour l'umbrella). Le parapluie importe **42 des 43 leaf** :
+la Partie 34 `ExceptionalDirect.lean` est **standalone** (non importée par
+l'umbrella — extension ajoutée par **PR #10357, MERGED 2026-08-11**, Phase 2 de
+l'Epic #2159 qui formalise l'image directe exceptionnelle `f_!` au niveau
+préfaisceau et son adjonction `f_! ⊣ f^*`), mais elle reste compilée par le
+`globs := #[`Grothendieck.*]` du lakefile (cf. convention i18n #4980).
 
-*La trajectoire pédagogique des 33 modules leaf — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski et carte Mathlib en ancrage :*
+*La trajectoire pédagogique des 43 modules leaf — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski, carte Mathlib, et la forme flèche de la couverture en extension :*
 
 ```mermaid
 flowchart LR
@@ -45,69 +46,83 @@ flowchart LR
     T3["<b>Faisceautisation</b><br/><i>13·14</i><br/>foncteur faisceau associé<br/>exactitude à gauche (LeftExact)"]
     T4["<b>Points & conservateurs</b><br/><i>15·19</i><br/>foncteurs fibres<br/>familles conservatrices"]
     T5["<b>Cohomologie</b><br/><i>20·21·22·23</i><br/>Ext · Mayer-Vietoris · Čech"]
+    T6["<b>Forme flèche des couvertures</b><br/><i>35·36·37·38·39·40·41·42·43</i><br/>J.Cover · pullback · treillis"]
     T1 --> T2 --> T3 --> T4 --> T5
+    T5 -.-> T6
     S["<b>Schémas & site de Zariski</b><br/><i>Parties 2·3</i><br/>foncteur Spec<br/>zariski_topology_eq"] -.->|"ancre géométrique"| T1
     MM["<b>Carte Mathlib</b><br/><i>Partie 4</i><br/>index #check"] -.->|"ancre bibliothèque"| T3
 ```
 
 | Partie | Fichier | `_en` | Contenu | Lignes |
 |--------|---------|-------|---------|--------|
-| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only des 33 leaf + doctring bilingue FR/EN) ; pas de sibling `_en` (le contenu EN vit dans le même fichier en miroir) | 208 |
+| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only des 42 leaf hors `ExceptionalDirect` + doctring bilingue FR/EN) ; pas de sibling `_en` (le contenu EN vit dans le même fichier en miroir) | 217 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 243 |
-| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 109 |
-| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 93 |
-| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 107 |
+| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 196 |
+| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 139 |
+| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 123 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 95 |
-| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles (7) : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
-| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 148 |
-| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 141 |
-| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 177 |
+| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles (7) : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 252 |
+| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 230 |
+| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 207 |
+| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 233 |
 | 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Topologie canonique, sous-canoïcité, faisceaux représentables | 154 |
-| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Identités de génération de cribles | 172 |
-| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | La topologie dense | 155 |
-| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Faisceautisation (le foncteur faisceau associé) | 189 |
+| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Identités de génération de cribles | 242 |
+| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | La topologie dense | 218 |
+| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Faisceautisation (le foncteur faisceau associé) | 258 |
 | 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Exactitude à gauche de la faisceautisation | 219 |
-| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 226 |
-| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 105 |
-| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Hom interne des faisceaux | 173 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Familles conservatrices de points | 226 |
-| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Cohomologie des faisceaux (basée sur Ext) | 254 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Carrés de Mayer-Vietoris | 195 |
-| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Suite exacte longue de Mayer-Vietoris | 167 |
-| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 130 |
+| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 411 |
+| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 232 |
+| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Hom interne des faisceaux | 273 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 252 |
+| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Familles conservatrices de points | 501 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Cohomologie des faisceaux (basée sur Ext) | 336 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Carrés de Mayer-Vietoris | 338 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Suite exacte longue de Mayer-Vietoris | 235 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 203 |
 | 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 274 |
-| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 168 |
-| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monades en théorie des catégories, unité, multiplication, loi d'association | 172 |
-| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Catégorie comma, projections, fonctorialité | 129 |
-| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limites et colimites | 242 |
-| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Équivalences de catégories, foncteurs pleinement fidèles, essentiellement surjectifs | 189 |
-| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Constructions catégorielles de base | 152 |
-| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Extensions de Kan (limites/colimites généralisées) | 270 |
-| 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Catégories monoïdales, tenseur, unité, associateur | 244 |
-| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | Index `#check` (8) de l'adjonction `f^* ⊣ f_*` — image directe / réciproque des faisceaux de modules (#8882) | 152 |
-| 34 | `Grothendieck/ExceptionalDirect.lean` | `ExceptionalDirect_en.lean` | Image directe exceptionnelle `f_!` au niveau préfaisceau et son adjonction `f_! ⊣ f^*` — extension de Kan à gauche de `f^*` le long de `f` (#10357, Phase 2 de #2159) | 202 |
+| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 335 |
+| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monades en théorie des catégories, unité, multiplication, loi d'association | 253 |
+| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Catégorie comma, projections, fonctorialité | 239 |
+| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limites et colimites | 421 |
+| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Équivalences de catégories, foncteurs pleinement fidèles, essentiellement surjectifs | 338 |
+| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Constructions catégorielles de base | 256 |
+| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Extensions de Kan (limites/colimites généralisées) | 481 |
+| 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Catégories monoïdales, tenseur, unité, associateur | 397 |
+| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | Index `#check` (8) de l'adjonction `f^* ⊣ f_*` — image directe / réciproque des faisceaux de modules (#8882) | 325 |
+| 34 | `Grothendieck/ExceptionalDirect.lean` | `ExceptionalDirect_en.lean` | Image directe exceptionnelle `f_!` au niveau préfaisceau et son adjonction `f_! ⊣ f^*` — extension de Kan à gauche de `f^*` le long de `f` (#10357, Phase 2 de #2159) ; **standalone** (non importée par l'umbrella) | 202 |
+| 35 | `Grothendieck/CoversArrow.lean` | `CoversArrow_en.lean` | Forme flèche de la couverture — 7 théorèmes propres (#10879, Phase 5) | 199 |
+| 36 | `Grothendieck/Cover.lean` | `Cover_en.lean` | Couverture bundlee `J.Cover X` — 15 théorèmes propres (#10912, Phase 5) | 284 |
+| 37 | `Grothendieck/PullbackFunctor.lean` | `PullbackFunctor_en.lean` | Lois de cohérence du pullback (pseudofoncteur sur `J.Cover`) (#11023, Phase 5) | 149 |
+| 38 | `Grothendieck/PullbackFunctorLaws.lean` | `PullbackFunctorLaws_en.lean` | Lois de foncteur du pullback sur `J.Cover` (#11035, Phase 5) | 141 |
+| 39 | `Grothendieck/TopologyLattice.lean` | `TopologyLattice_en.lean` | Lois de treillis des topologies de Grothendieck (#11038, Phase 5) | 211 |
+| 40 | `Grothendieck/CoversPullback.lean` | `CoversPullback_en.lean` | Lois de la forme flèche `J.Covers` sous pullback (#11057, Phase 5) | 202 |
+| 41 | `Grothendieck/CoversOrder.lean` | `CoversOrder_en.lean` | Lois d'ordre de la forme flèche `J.Covers` (#11068, Phase 5) | 164 |
+| 42 | `Grothendieck/PullbackCoversLaws.lean` | `PullbackCoversLaws_en.lean` | Lois de la forme flèche sous pullback itéré (#11217, Phase 5) | 160 |
+| 43 | `Grothendieck/CoversLattice.lean` | `CoversLattice_en.lean` | Lois de treillis indexées de la forme flèche (#11231, Phase 5) | 106 |
 
-*La colonne `Lignes` compte le **fichier FR seul** ; le total FR+EN est le double approximatif.*
+*La colonne `Lignes` compte le **fichier FR seul** (`wc -l`, mesuré 2026-08-16) ; le total FR+EN mesuré est **21 189 lignes** (10 944 FR + 10 245 EN).*
 
-L'extension a été développée sous l'Issue #2159 / Epic #1646 : les **34 modules leaf**
-sont mergés + 1 umbrella bilingue, 0 `sorry`, 0 axiome ajouté. **Phase 2** (Partie 34
-`f_! ⊣ f^*`) livrée par PR #10357 (MERGED 2026-08-11) ; **Phase 1** (Parties 1-33)
-précédemment shippée par vagues de PRs (#2675, #8882, etc.).
+L'extension a été développée sous l'Issue #2159 / Epic #1646 : les **43 modules leaf**
+sont mergés + 1 umbrella bilingue, 0 `sorry`, 0 axiome ajouté. **Phase 1** (Parties 1-33)
+shippée par vagues de PRs (#2675, #8882, etc.) ; **Phase 2** (Partie 34 `f_! ⊣ f^*`) livrée
+par PR #10357 (MERGED 2026-08-11) ; **Phase 5** (Parties 35-43, forme flèche des couvertures)
+livrée par les PRs #10879, #10912, #11023, #11035, #11038, #11057, #11068, #11217, #11231.
 
 ## Build
 
 ```bash
 # Depuis ce répertoire (WSL requis)
 lake build Grothendieck
-# Compile les 34 modules leaf + 1 umbrella bilingue
-# Dernier build vérifié : 2026-08-12, « Build completed successfully »
+# Compile les 43 modules leaf + 1 umbrella bilingue
+# Dernier build vérifié : 2026-08-12, « Build completed successfully » (état 34 modules) ;
+# Parties 35-43 (Phase 5) mergées avec lake build SUCCESS dans leurs PRs respectives
 ```
 
 ## Compte de sorry
 
-**0 sorry, 0 axiome** — tous les 34 modules leaf sont complets à la création
-(l'umbrella `Grothendieck.lean` est imports-only sans déclaration). La Partie 34
+**0 sorry, 0 axiome** — tous les 43 modules leaf sont complets à la création
+(vérifié `count_code_sorry.py --json` : `distinct_code_sorry = 0`, mesuré 2026-08-16 ;
+l'umbrella `Grothendieck.lean` est imports-only sans déclaration). La Partie 34
 `ExceptionalDirect.lean` (#10357) cite `sorry` deux fois en prose docstring
 (marque de la formalisation bornée) mais ne contient **aucun sorry tactic**.
 
@@ -130,24 +145,25 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 ## Voir aussi
 
 - Epic #1646 (hommage à Grothendieck)
-- Issue #2159 (profondeur de formalisation Grothendieck — Phase 1 shippée, **Phase 2** livrée par #10357 le 2026-08-11 : `f_! ⊣ f^*` au niveau préfaisceau = Partie 34 `ExceptionalDirect.lean`)
+- Issue #2159 (profondeur de formalisation Grothendieck — Phase 1 shippée, **Phase 2** livrée par #10357 le 2026-08-11 : `f_! ⊣ f^*` au niveau préfaisceau = Partie 34 `ExceptionalDirect.lean` ; **Phase 5** livrée par #10879/#10912/#11023/#11035/#11038/#11057/#11068/#11217/#11231 : Parties 35-43, forme flèche des couvertures)
 - PR #2675 (Phases 4-6 : SieveOps + CoverageGen + CanonicalProps)
 - **PR #10357** (Phase 2 #2159 : exceptional direct image `f_! ⊣ f^*` au niveau préfaisceau, formalisation bornée du chaînon manquant entre `f^*` et `f_*`)
 - Epic #1453 (calibration du harnais prouveur)
 - Workspace hommage Conway (`../conway_lean/`)
-- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 33 siblings `_en.lean` sur `main` dans cette lake + 1 umbrella bilingue inline)
+- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 43 siblings `_en.lean` sur `main` dans cette lake + 1 umbrella bilingue inline)
 - Issue #8960 (réconciliation des deux numérotations `Partie`)
 - **[`README.en.md`](./README.en.md)** — miroir EN du présent fichier
 - Série de notebooks Lean (`../README.md`)
 
 ## Conclusion
 
-Cet hommage est une **visite pédagogique complète** (34 modules leaf + 1 umbrella bilingue, 0
+Cet hommage est une **visite pédagogique complète** (43 modules leaf + 1 umbrella bilingue, 0
 `sorry`, 0 axiome ajouté) montrant comment le langage de Grothendieck — sites,
 faisceaux, faisceautisation, points, cohomologie, Yoneda, images directes,
-image directe exceptionnelle `f_!` — vit déjà dans Mathlib 4. Ce n'est
-délibérément **pas** une formalisation d'EGA/SGA ; c'est un index curaté
-qui laisse les apprenants voir la bibliothèque à travers des yeux grothendieckiens.
+image directe exceptionnelle `f_!`, forme flèche des couvertures — vit déjà dans
+Mathlib 4. Ce n'est délibérément **pas** une formalisation d'EGA/SGA ; c'est un
+index curaté qui laisse les apprenants voir la bibliothèque à travers des yeux
+grothendieckiens.
 
 ### La trajectoire
 
@@ -156,7 +172,7 @@ Les modules tracent un chemin cohérent : **sites et cribles** (Parties 1, 6, 8,
 **faisceautisation et son exactitude à gauche** (13, 14) → **points et familles
 conservatrices** (15, 19) → **cohomologie des faisceaux, Mayer-Vietoris et Čech**
 (20-23), avec **schémas et site de Zariski** (2, 3), une **carte Mathlib** (4)
-et le **lemme de Yoneda** (24) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 25, 29, 26 soutiennent toute la formalisation. `DirectImage.lean` (Partie 33) indexe l'adjonction `f^* ⊣ f_*` — l'instance la plus simple des « six opérations », qui transporte les faisceaux le long des morphismes de schémas. Enfin, `ExceptionalDirect.lean` (Partie 34, #10357) franchit un échelon en formalisant `f_! ⊣ f^*` au niveau préfaisceau — l'image directe *à support propre* comme extension de Kan à gauche de `f^*`, chaînon manquant entre `f^*` (inverse-image) et `f_*` (image directe).
+et le **lemme de Yoneda** (24) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 25, 29, 26 soutiennent toute la formalisation. `DirectImage.lean` (Partie 33) indexe l'adjonction `f^* ⊣ f_*` — l'instance la plus simple des « six opérations », qui transporte les faisceaux le long des morphismes de schémas. `ExceptionalDirect.lean` (Partie 34, #10357) franchit un échelon en formalisant `f_! ⊣ f^*` au niveau préfaisceau — l'image directe *à support propre* comme extension de Kan à gauche de `f^*`, chaînon manquant entre `f^*` (inverse-image) et `f_*` (image directe). Enfin, la **Phase 5** (Parties 35-43) déplie la structure de la forme flèche des couvertures : `CoversArrow` (35), la couverture bundlee `J.Cover X` (36), les lois de cohérence et de foncteur du pullback (37-38), le treillis des topologies (39) et les lois de la forme flèche `J.Covers` sous pullback, ordre, itération et treillis indexé (40-43).
 
 *La construction verticale « faisceau » — chaque couche bâtie sur la précédente, de la donnée du site jusqu'à la cohomologie :*
 


### PR DESCRIPTION
Grain: LIGHT/readme — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #11237

## Summary

Re-audit fichier-entier (pr-review §E) des deux miroirs `grothendieck_lean/README.md` + `README.en.md` contre l'état disque d'`origin/main` (mesuré 2026-08-16 dans un worktree isolé), grain #3979 (feuilles README Lean math, owner po-2026:CoursIA-2).

Le défaut : les compteurs « **34 modules leaf** » (FR) / « **33 leaf modules** » (EN) dataient de la sync #10533 (2026-08-12) — depuis, les **Parties 35-43** (Phase 5 de #2159, EPIC #1646) ont été mergées sans resync : `CoversArrow` (#10879), `Cover` (#10912), `PullbackFunctor` (#11023), `PullbackFunctorLaws` (#11035), `TopologyLattice` (#11038), `CoversPullback` (#11057), `CoversOrder` (#11068), `PullbackCoversLaws` (#11217), `CoversLattice` (#11231). Disque réel = **43 leaf FR + 43 siblings `_en` + umbrella `Grothendieck.lean` 217 lignes / 42 imports**.

## Ce qui est synchronisé (tous les nombres mesurés firsthand, worktree sur origin/main)

- **Compteurs** : « 34/33 modules leaf » → **43** dans État, Structure, Build, Compte de sorry, Conclusion, Voir aussi ; i18n « 36 fichiers FR + 34 siblings » → **44 FR (1 umbrella + 43 leaf) + 43 `_en`** ; « 33 siblings » → 43.
- **Tableau Parties** : +9 lignes (35-43, avec PR + Phase 5), et colonne `Lignes` **rafraîchie** (elle était stale pour ~30 lignes — les valeurs datent d'avant les enrichissements ; ex. `SchemesTour` 109→196, `Conservative` 226→501, `Limits` 242→421).
- **Fait vérifié firsthand, corrigé** : `ExceptionalDirect.lean` (Partie 34, #10357) est **standalone** — non importée par l'umbrella (42 imports pour 43 leaf, vérifié par diff imports vs `find`) — compilée via le `globs` du lakefile. Le README la décrivait implicitement comme importée.
- **Totaux i18n** : remplace « 11 206 FR+EN + 208 umbrella = 11 414 (mesuré 2026-07-30) » par les mesures actuelles : **10 944 FR + 10 245 EN = 21 189 FR+EN** (umbrella 217).
- **`knot_lean/README.md`** (dans le scope #3979) : re-audit en passant — syncé par #10533, **pas de drift**, aucune action.

## Validation

- **Lignes vérifiées programmatiquement** : script python comparant chaque cellule du tableau (root + 43) à `wc -l` réel — **0 erreur** FR, **0 erreur** EN.
- **Parité FR/EN structurelle** : 44 lignes de tableau chacune, headers alignés (État/Status, Objectif/Purpose, …), Parties 35-43 présentes dans les deux miroirs.
- **Catalogue** : `COURSE_CATALOG.generated.{json,md}` **byte-identique** à `origin/main` (diff vide), aucun marqueur `CATALOG-STATUS` dans les fichiers touchés.
- **gitleaks** Passed · `git diff --check` clean · LF préservé (0 CRLF).
- Pas de cellules de notebook : hors C.1/C.2/H.3.

## Honnêteté G-VAR-1 (plancher)

Grain **LIGHT/readme (META)** : le plancher DEEP/MED CONTENU n'est **pas tenu** ce cycle — grain hérité de ma deep-queue (#3979, issue propre à ma lane, owner acté). Rotation de genre HARD depuis c.133 : prochain grain = **CONTENU** (lean/qc/training/research-code), le **tracker densité #11224** reste la veine chaude avec tranches ouvertes.

See #3979 · See #11123
