### PR TITLE
fix(lane-claim,#11239): WARN malformed_markers — CLAIMED sans crochets visible

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -106,6 +106,23 @@ _MARKER_RE = re.compile(
     r"(?m)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*\[\s*(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE|OVERRIDE)\s*\]",
     re.IGNORECASE,
 )
+# #11239 -- malformed-marker lint. A claim line written WITHOUT the brackets
+# (`CLAIMED #11222 -- ...`) is invisible to `_MARKER_RE` above: the organ
+# reports `unattributed_markers: 0` and answers CLEAR to every other lane,
+# while the writer believes their lock is posted. Measured 2026-08-16 on
+# #11222: two lanes delivered the same fix seven minutes apart (#11230 /
+# #11233). This regex is the WARN-side of that gap. Same decoration tolerance
+# as `_MARKER_RE`, but the marker word must appear BARE (no `[`), and the line
+# must carry a claim motif (`lane <machine:workspace>` or `#N`) so prose that
+# merely MENTIONS a marker word is not flagged. Deliberately NOT a parser
+# widening -- a malformed line must surface as a warning, never as a claim
+# event. The motif tail is on the same line only (no `[\s\S]` cross-line).
+_MALFORMED_MARKER_RE = re.compile(
+    r"(?m)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*"
+    r"(CLAIMED|RELEASED|CANCELLED|ABANDONED|DONE|OVERRIDE)\b"
+    r"[^\n]*(?:lane\s+\S+:\S+|#\d+)",
+    re.IGNORECASE,
+)
 _OPEN = {"CLAIMED"}
 _CLOSE = {"RELEASED", "CANCELLED", "ABANDONED", "DONE"}
 # `[OVERRIDE] lane <machine:workspace>` (#10223): coordinator adjudication --
@@ -840,6 +857,33 @@ def _lint_claim_events(
                 )
 
 
+def _find_malformed_markers(payload: dict) -> list[dict]:
+    """Bare-marker lines that look like claims but will never be read (#11239).
+
+    `_parse_claim_events` keys off `_MARKER_RE`, which REQUIRES the brackets:
+    a `CLAIMED #N -- lane ...` line written without them is invisible to the
+    organ (`unattributed_markers: 0`, CLEAR to every other lane) yet the
+    writer believes their lock is posted. Returns one dict per matching line
+    (marker word, capped verbatim line, author, comment url). WARN-only by
+    design: never changes a verdict, never touches `blocked` -- the lint
+    exists to tell the writer they were not read, not to re-interpret their
+    text as a claim.
+    """
+    found: list[dict] = []
+    for c in payload.get("comments", []):
+        body = c.get("body") or ""
+        author = (c.get("author") or {}).get("login")
+        for m in _MALFORMED_MARKER_RE.finditer(body):
+            line = _line_for_match(body, m)
+            found.append({
+                "marker": m.group(1).upper(),
+                "line": line if len(line) <= 160 else line[:160] + "…",
+                "author": author,
+                "url": c.get("url"),
+            })
+    return found
+
+
 def _warn_bare_integer_paths(paths: list[str]) -> list[str]:
     """Return the `--paths` entries that are bare integers (#10881 trap).
 
@@ -919,6 +963,20 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
     # a verdict. The four 2026-08-14 markers on #10678 shared the defect the
     # three checks name (epic-wide by accident / prose swallowed as globs).
     _lint_claim_events(events, payload.get("number"), tracked=tracked)
+    # #11239 lint -- bare markers without brackets (invisible to the organ).
+    # Same non-blocking spirit as the #10881 lint above: the writer learns at
+    # the call site that their lock was never registered, instead of two lanes
+    # discovering it via collision. Also mirrored into the JSON summary so a
+    # coordinator's sweep can grep `malformed_markers` across issues.
+    malformed = _find_malformed_markers(payload)
+    for mm in malformed:
+        who = f" by @{mm['author']}" if mm["author"] else ""
+        print(
+            f'WARN: marqueur sans crochets "{mm["marker"]}"{who} -- la forme '
+            f'attendue est "[{mm["marker"]}]" ; sans crochets, l\'organe ne '
+            f"le lit pas (unattributed_markers reste 0). {mm['line']}",
+            file=sys.stderr,
+        )
     # #10958 -- attach the dead-glob witness to every scoped event (own and
     # others): a glob that matches zero tracked files is surfaced in the
     # JSON (`empty_scope`) and, when it covers the WHOLE scope, lifts the
@@ -983,6 +1041,13 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
             for ln, ev in sorted(active.items())
         },
         "unattributed_markers": len(unattributed),
+        # #11239 -- bare-marker lines (no brackets) carrying a claim motif.
+        # The organ does not read them (`_MARKER_RE` requires the brackets),
+        # so they are invisible to `unattributed_markers` AND to the blocker
+        # test; surfacing them here lets the writer and the coordinator see
+        # the lock that never registered.
+        "malformed_markers": len(malformed),
+        "malformed_marker_lines": [m["line"] for m in malformed],
         "blocked": bool(others),
     }
     print(json.dumps(summary, ensure_ascii=False, indent=2))

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -426,6 +426,103 @@ def test_check_surfaces_unattributed(capsys):
     assert '"unattributed_markers": 1' in out
 
 
+# --- #11239: malformed-marker lint --------------------------------------------
+# A claim written WITHOUT the brackets (`CLAIMED #N ...`) is invisible to
+# `_MARKER_RE` -- the organ reports `unattributed_markers: 0` and answers
+# CLEAR to every other lane while the writer believes their lock is posted
+# (measured 2026-08-16 on #11222: #11230 / #11233, 7 minutes apart). The lint
+# is WARN-only: the writer learns at the call site that they were not read.
+
+def test_malformed_marker_incident_line_surfaces(capsys):
+    # The exact shape of the #11222 incident comment line.
+    p = payload(comment(
+        "CLAIMED #11222 — myia-po-2026:CoursIA — 2026-08-16T11:12Z. "
+        "Fix couche resolution gate nits.",
+        "2026-08-16T09:09:50Z", author="jsboige"))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    captured = capsys.readouterr()
+    assert rc == 0                          # WARN-only, never blocks
+    assert '"malformed_markers": 1' in captured.out
+    assert 'CLAIMED #11222' in captured.out
+    assert 'WARN: marqueur sans crochets "CLAIMED"' in captured.err
+
+
+def test_malformed_marker_lane_form_surfaces(capsys):
+    p = payload(comment(
+        "CLAIMED lane myia-po-2026:CoursIA -- working here",
+        "2026-08-16T09:10:00Z", author="jsboige"))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"malformed_markers": 1' in captured.out
+    assert 'WARN: marqueur sans crochets "CLAIMED"' in captured.err
+
+
+def test_bracketed_marker_is_not_malformed(capsys):
+    p = payload(comment(
+        "[CLAIMED] #11222 — myia-po-2026:CoursIA — 2026-08-16T11:12Z.",
+        "2026-08-16T09:09:50Z", author="jsboige"))
+    # Own-lane check: the bracketed claim IS read and does not block us.
+    rc = clc._run_check(p, "myia-po-2026:CoursIA")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"malformed_markers": 0' in captured.out
+    assert 'WARN: marqueur sans crochets' not in captured.err
+
+
+def test_prose_mention_not_flagged(capsys):
+    # A line that merely MENTIONS a marker word mid-prose is not a claim:
+    # the motif tail (`lane <tok>` / `#N`) is required AND the marker word
+    # must be line-initial after decoration.
+    p = payload(comment(
+        "Cette PR revient sur un [CLAIMED] discute plus tot; work done #123.",
+        "2026-08-16T09:00:00Z"))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"malformed_markers": 0' in captured.out
+    assert 'WARN: marqueur sans crochets' not in captured.err
+
+
+def test_decorated_bare_marker_flagged(capsys):
+    # `**` / bullet decoration is tolerated by `_MARKER_RE`, so a bare marker
+    # with the same decoration is equally invisible and equally malformed.
+    p = payload(comment(
+        "- **CLAIMED** #11222 -- myia-po-2026:CoursIA",
+        "2026-08-16T09:11:00Z"))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"malformed_markers": 1' in captured.out
+
+
+def test_malformed_close_marker_flagged(capsys):
+    # Close markers are linted too: a bracketless `RELEASED` never registers
+    # as a release, so the claim stays locked for other lanes.
+    p = payload(comment(
+        "RELEASED lane myia-po-2025:CoursIA -- landed",
+        "2026-08-16T09:20:00Z"))
+    rc = clc._run_check(p, "myia-po-2024:CoursIA")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"malformed_markers": 1' in captured.out
+    assert 'WARN: marqueur sans crochets "RELEASED"' in captured.err
+
+
+def test_valid_bracketed_line_with_midline_bare_word_not_double_counted(capsys):
+    # A well-formed `[CLAIMED]` whose line ALSO mentions a bare marker word
+    # later must count 0 malformed: the lint is line-initial only, and the
+    # bracketed claim is read by `_MARKER_RE` as intended.
+    p = payload(comment(
+        "[CLAIMED] lane myia-po-2026:CoursIA -- voir RELEASED #12 du precedent",
+        "2026-08-16T09:30:00Z"))
+    rc = clc._run_check(p, "myia-po-2026:CoursIA")
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert '"malformed_markers": 0' in captured.out
+    assert 'WARN: marqueur sans crochets' not in captured.err
+
+
 # --- --stale-threshold (#9812) ----------------------------------------------
 # A claim older than the threshold (age from server createdAt, never the body)
 # is treated as STALE: it no longer blocks, but a STALE_CLAIM warning is printed


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #11227

## Quoi

Un `[CLAIMED]` écrit **sans crochets** (`CLAIMED #N ...`) est invisible pour `_MARKER_RE` : `unattributed_markers: 0`, `CLEAR` à toutes les autres lanes, alors que le rédacteur croit son verrou posé. Aucun des deux camps n'est prévenu — c'est le défaut d'organe documenté dans #11239, mesuré le 2026-08-16 sur #11222 (deux lanes, même fix, 7 min d'écart : #11230 / #11233).

**Fix = avertissement de forme, PAS élargissement du parser** (le marqueur crocheté est ce qui distingue un claim d'une prose qui en *parle*) :

- nouveau `_MALFORMED_MARKER_RE` : même tolérance de décoration que `_MARKER_RE` (`**`, `-`, `>`, `##`), mais mot nu **sans `[`**, suivi d'un motif de claim `lane <machine:workspace>` ou `#N` sur la même ligne ;
- chaque ligne détectée est comptée dans un champ dédié `malformed_markers` du JSON (plus `malformed_marker_lines` : extraits verbatim, cap 160 chars, pour le grep du coordinateur) ;
- `WARN: marqueur sans crochets "CLAIMED" ...` sur stderr, même esprit non-bloquant que les `WARN: glob sans correspondance` (#10881) — jamais un verdict, jamais `blocked`.

## Vérifications

- **7 tests ajoutés** : forme exacte de l'incident (`CLAIMED #11222 — myia-po-2026:CoursIA`), forme `lane <tok>` nue, crocheté **non**-flagé (rc=0 côté lane propre), prose qui *mentionne* un marqueur non-flagée, `**CLAIMED**` décoré flagé, close `RELEASED` nu flagé, ligne crochetée valide avec mot nu mid-line **non** double-comptée.
- Suite complète : **144/144 passent** (137 pré-existants + 7 nouveaux), post-rebase sur `origin/main` frais (1 commit entre temps, `e0b3fe03f` RL, sans overlap).

## Périmètre

2 fichiers : `scripts/check_lane_claim.py` + son test. Le second cas de l'issue (`paths:` + prose avalée dans les globs) **avertit déjà** (`glob suspect (prose avalée ?)`) — documenté dans l'issue, aucun code requis. Comportement de verdict inchangé : aucun marqueur ne devient bloquant qui ne l'était pas.

Closes #11239


---
*Tag requalifie par ai-01 au merge-gate : `harness` est hors de l'enumeration close de [variation-protocol](.claude/rules/variation-protocol.md) — normalise en `guard` (le discriminant est « est-ce que ca peut rougir » : ce check a un statut d'echec propre). Requalification ecrite dans le BODY, pas en commentaire, pour que l'organe la lise.*
