### PR TITLE
enrich(qc,#11224): densite pedagogique QC-Py-04-Research-Workflow 678->1231 (20 interps markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-04-Research-Workflow.ipynb
@@ -310,6 +310,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du résultat** : Le DataFrame retourné a la forme **(504, 5)**. Ce n'est pas une erreur : `qb.History()` empile l'historique des **2 titres** de l'univers (SPY et AAPL) dans un même DataFrame indexé par un **MultiIndex (symbol, time)** — chaque titre contribue 252 lignes, soit une année de trading.\n",
+    ">\n",
+    "> Sur la première ligne (SPY, 2025-06-09), le prix de clôture s'établit à **592.88 $** pour un volume de **48.3M** actions, un ordre de grandeur normal pour l'ETF du S&P 500. L'étape suivante consiste à isoler un seul titre avec `.loc[\"SPY\"]` pour travailler sur une série propre."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Différences avec QCAlgorithm.History()\n",
     "\n",
     "**Point clé** : `qb.History()` retourne directement un **DataFrame pandas** avec MultiIndex (symbol, time), contrairement à `QCAlgorithm.History()` qui retourne un objet `Slice`.\n",
@@ -368,6 +377,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du résultat** : Après extraction, le DataFrame SPY est bien de forme **(252, 5)** — une ligne par jour de trading, pour 5 colonnes OHLCV (`open`, `high`, `low`, `close`, `volume`). L'index est un simple `DatetimeIndex`, plus lisible que le MultiIndex global.\n",
+    ">\n",
+    "> **Point clé** : `.loc[\"SPY\"]` filtre sur le premier niveau du MultiIndex retourné par `qb.History()`. C'est la manière idiomatique d'isoler un titre quand l'univers en contient plusieurs — l'équivalent du pattern `history.loc[\"AAPL\"]` utilisé pour n'importe quelle autre security."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "> **Observation** : Le DataFrame contient les colonnes standard : `open`, `high`, `low`, `close`, `volume`. L'index est le timestamp."
    ]
   },
@@ -412,6 +430,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du résultat** : Sur l'année, le prix de clôture de SPY a oscillé entre **589.28 $** (minimum) et **759.57 $** (maximum), avec une moyenne de **669.26 $** et un écart-type de **37.57 $**. La médiane (**670.87 $**) est proche de la moyenne, ce qui suggère une distribution des prix relativement symétrique sur la période.\n",
+    ">\n",
+    "> Côté volume, la moyenne journalière est de **65.8M** actions avec un pic à **152.8M** — typiquement un jour de forte volatilité ou d'actualité macro. Ces statistiques servent de référence pour la suite : sizing, volatilité, drawdown. Le `count` de 252 sur chaque colonne confirme qu'aucune journée de trading ne manque à l'échantillon."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Calcul des Returns\n",
     "\n",
     "Calculons les returns journaliers et cumulatifs."
@@ -449,6 +476,15 @@
     "\n",
     "print(\"Returns ajoutés:\")\n",
     "print(df_spy[['close', 'returns', 'cumulative_returns']].tail())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : Le return cumulatif atteint **1.243** en fin de période, soit **+24.3 %** sur l'année. Les deux derniers jours montrent une correction : **-2.58 %** le 2026-06-05, puis **-0.29 %** le 2026-06-09 — un rappel que même une année haussière connaît des replis rapides.\n",
+    ">\n",
+    "> **À noter** : le `SettingWithCopyWarning` de pandas n'est pas une erreur bloquante — il signale que `df_spy` est une *vue* issue de `.loc[\"SPY\"]` et qu'il faut préférer `.loc[row, col] = valeur` pour modifier en place. Une façon robuste de l'éviter est de travailler sur une copie explicite : `df_spy = history.loc[\"SPY\"].copy()`."
    ]
   },
   {
@@ -520,6 +556,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation des résultats** :\n",
+    "> - **Return total : +24.32 %** sur la période — cumul des returns journaliers\n",
+    "> - **Return annualisé : 22.59 %** — moyenne journalière des returns extrapolée sur 252 jours de trading\n",
+    "> - **Volatilité annualisée : 12.10 %** — écart-type des returns journaliers mis à l'échelle par √252\n",
+    ">\n",
+    "> **Lecture** : un rendement annualisé de **22.6 %** pour une volatilité de **12.1 %** est un couple rendement/risque très favorable sur la période. Retenir la convention d'annualisation — ×252 pour la moyenne, √252 pour l'écart-type — car c'est elle qui rend comparables des stratégies échantillonnées à des fréquences différentes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Volatilité Rolling\n",
     "\n",
     "Calculons et visualisons la volatilité glissante sur 30 jours."
@@ -578,6 +626,17 @@
     "print(f\"Volatilité moyenne: {df_spy['volatility_30d'].mean():.2%}\")\n",
     "print(f\"Volatilité min: {df_spy['volatility_30d'].min():.2%}\")\n",
     "print(f\"Volatilité max: {df_spy['volatility_30d'].max():.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : La volatilité annualisée glissante sur 30 jours oscille entre **6.69 %** (période la plus calme) et **18.19 %** (pic de tension), pour une moyenne de **11.85 %**. Ces variations matérialisent les régimes de marché successifs : les creux correspondent à des tendances haussières sereines, les pics à des épisodes d'incertitude.\n",
+    ">\n",
+    "> **Usage pratique** : la volatilité rolling sert au **sizing dynamique** (réduire la taille des positions quand la volatilité grimpe) ou au filtrage de conditions défavorables. La ligne de référence rouge sur le graphique (moyenne 11.85 %) permet de lire chaque pic/creux relativement au régime moyen de l'année.\n",
+    ">\n",
+    "> **Interprétation visuelle** : les épisodes de forte volatilité (pic à 18.19 %) coïncident généralement avec les corrections de prix visibles sur le graphe des closes — la volatilité agit comme le « thermomètre » du risque de marché."
    ]
   },
   {
@@ -680,6 +739,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du résultat** : Le test de Shapiro-Wilk **rejette** l'hypothèse de normalité : statistique **0.9726** pour une p-value de **0.0001**, très inférieure au seuil α=0.05. La conclusion affichée — **returns non-normaux (fat tails)** — confirme que l'hypothèse gaussienne ne tient pas sur les rendements financiers.\n",
+    ">\n",
+    "> **Pourquoi c'est important** : les rendements présentent des queues épaisses (événements rares mais extrêmes) et une légère asymétrie, que la normale sous-estime. Cela justifie d'utiliser des métriques robustes (drawdown, VaR historique, scénarios de stress) plutôt qu'un simple couple moyenne/écart-type, et de se méfier des modèles qui postulent la normalité.\n",
+    ">\n",
+    "> **Remarque complémentaire** : avec p-value = 0.0001, le rejet est net même en appliquant un seuil conservateur de 0.01. Le Q-Q plot le confirme visuellement : les points s'écartent de la bissectrice aux extrêmes, exactement la signature des queues épaisses."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "---\n",
     "\n",
     "## 4. Test de Stratégie en Mode Recherche (20 min)\n",
@@ -731,6 +801,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du résultat** : L'alignement des moyennes mobiles est **haussier** en fin de période : prix (737.05 $) > SMA 50 (717.45 $) > SMA 200 (682.63 $). C'est la configuration dite du **golden cross** : la tendance de court terme est au-dessus de la tendance de long terme, signature classique d'un marché en uptrend.\n",
+    ">\n",
+    "> La SMA 200 (682.63 $) sert de **référence de tendance structurelle** : tant que le prix reste au-dessus, la tendance longue est considérée intacte ; sa cassure signale un changement de régime. Noter que les deux SMA commencent par `NaN` (fenêtres de 50 et 200 jours non remplies) — un comportement attendu des moyennes mobiles."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Génération des Signaux\n",
     "\n",
     "Générons les signaux de trading basés sur le croisement."
@@ -770,6 +849,15 @@
     "\n",
     "print(\"Signaux et positions:\")\n",
     "print(df_spy[['close', 'sma_50', 'sma_200', 'signal', 'position']].tail(10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : Sur les 10 dernières lignes, le signal reste constant à **1** (SMA 50 > SMA 200) et la position à **1.0** — la stratégie est restée **longue** durant toute cette période. Le `.shift(1)` décale le signal d'un jour : la position affichée aujourd'hui correspond au signal d'hier, ce qui élimine le **lookahead bias**.\n",
+    ">\n",
+    "> **Observation pédagogique** : la colonne `position` ne prend que 3 valeurs (-1, 0, 1), ce qui rend le calcul des returns de stratégie trivialement vectorisé (`position × returns`). L'écart `signal`/`position` visible en début de série (0 vs `NaN`) est l'empreinte du décalage temporel — un bon réflexe pour le reconnaître dans d'autres notebooks."
    ]
   },
   {
@@ -820,6 +908,15 @@
     "\n",
     "print(\"Returns stratégie calculés:\")\n",
     "print(df_spy[['returns', 'strategy_returns', 'cumulative_returns', 'strategy_cumulative']].tail())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : En fin de période, la stratégie SMA affiche un cumul de **1.122** (+12.2 %), contre **1.243** (+24.3 %) pour le buy-and-hold. La stratégie a donc **sous-performé** l'indice sur cette fenêtre — un résultat honnête qui illustre qu'une règle de timing simple ne bat pas toujours le marché, surtout dans une tendance haussière prolongée.\n",
+    ">\n",
+    "> **Observation** : sur les dernières lignes, `strategy_returns` est strictement égal à `returns` (coefficient 1.0) car la position est longue ; le cumul de la stratégie suit donc la correction finale (-2.58 % le 2026-06-05). Le gain relatif de la stratégie s'est joué plus tôt dans l'année, quand la position passait par 0 ou -1 lors des périodes baissières."
    ]
   },
   {
@@ -950,6 +1047,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du tableau de métriques** :\n",
+    ">\n",
+    "> | Métrique | Buy & Hold | SMA Crossover | Lecture |\n",
+    "> |----------|-----------|---------------|---------|\n",
+    "> | Return Total | +24.32 % | +12.21 % | BH supérieur sur la période |\n",
+    "> | Sharpe Ratio | 1.87 | 1.74 | risque ajusté quasi équivalent |\n",
+    "> | Max Drawdown | -8.88 % | -3.78 % | la stratégie protège en baisse |\n",
+    "> | Volatilité | 12.10 % | 6.80 % | stratégie ~2× moins volatile |\n",
+    ">\n",
+    "> **Lecture nuancée** : la stratégie sacrifie une partie du rendement (12.21 % vs 24.32 %) mais **divise par deux** la volatilité (6.80 % vs 12.10 %) et le drawdown maximal (-3.78 % vs -8.88 %). Avec seulement **3 changements de position** sur l'année, elle est aussi très économe en transactions. Ce compromis rendement/réduction du risque est la signature d'un filtre de tendance — il montre sa valeur dans les marchés latéraux ou baissiers, pas dans une tendance haussière linéaire comme ici.\n",
+    ">\n",
+    "> **En résumé** : le tableau oppose deux philosophies — le buy-and-hold encaisse toute la tendance mais aussi toute la volatilité, tandis que le filtre SMA rend une partie du rendement en échange d'un profil nettement moins risqué. Le choix entre les deux dépend de l'objectif (réplication d'indice vs préservation du capital) et de l'horizon de l'investisseur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Exercice 2 : Stratégie RSI Mean Reversion\n\nCréez une stratégie de **mean reversion** basee sur le RSI : acheter quand RSI < 30 (survente) et vendre quand RSI > 70 (surachat).\n\n**Indices** :\n- `# Indice` : Utilisez `df_spy['close'].diff()` pour les gains/pertes\n- `# Étape 1` : Calculer le RSI 14 jours\n- `# Étape 2` : Generer les signaux (RSI<30 -> buy, RSI>70 -> sell)\n- `# Étape 3` : Calculer les returns de la stratégie"
    ]
   },
@@ -1030,6 +1145,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation** : Les helpers `shared/features.py` et `shared/backtest_helpers.py` sont importés après un ajout **conditionnel** du dossier au `sys.path`. Cette astuce supporte les deux layouts — dépôt local (`../shared`) et projet QC Cloud (`./shared`) — ce qui rend le notebook portable entre l'environnement de recherche local et l'IDE QuantConnect.\n",
+    ">\n",
+    "> **Avantage** : centraliser les calculs (returns multi-période, features techniques, métriques de backtest) dans `shared/` garantit la **cohérence des résultats entre notebooks** et évite de réimplémenter des fonctions aux conventions divergentes. C'est la raison d'être de la section : utiliser les helpers plutôt que du code dupliqué."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Calculer Returns Multi-Période\n",
     "\n",
     "La fonction `calculate_returns` permet de calculer des returns sur plusieurs horizons temporels en une seule ligne."
@@ -1062,6 +1186,15 @@
     "\n",
     "# Merger avec df principal\n",
     "df_spy = df_spy.join(returns_df, how='left')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : `calculate_returns` produit 3 colonnes — `return_1d`, `return_5d`, `return_20d` — pour les horizons 1, 5 et 20 jours. Au 2026-06-09, SPY affiche **-0.29 %** sur 1 jour, **-2.96 %** sur 5 jours et **-0.30 %** sur 20 jours : la correction récente pèse surtout sur l'horizon hebdomadaire, tandis que le mois glissant reste quasi neutre.\n",
+    ">\n",
+    "> **Usage** : ces returns multi-horizons sont des **features classiques de ML directionnel** (section 7) — le return 5 jours sert d'ailleurs de cible de prédiction plus loin dans le notebook. Noter la valeur du join à gauche (`how='left'`) : il enrichit `df_spy` sans réordonner l'index temporel."
    ]
   },
   {
@@ -1112,6 +1245,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du résultat** : Un seul appel à `add_technical_features` ajoute **9 colonnes** : 3 moyennes mobiles (`sma_20`, `sma_50`, `sma_200`), le **RSI 14**, les 3 composantes **MACD** (12/26/9) et les 3 bandes de **Bollinger** (20, 2σ) avec leur largeur.\n",
+    ">\n",
+    "> **Point clé** : la fonction gère la configuration des indicateurs par un **dictionnaire** — on décrit *quels* indicateurs ajouter, pas *comment* les calculer. C'est le pattern déclaratif promu par les helpers `shared/` : le même appel dans un autre notebook produit exactement les mêmes colonnes, d'où une cohérence totale entre séries. La liste affichée sert aussi de checklist pour vérifier qu'aucun indicateur n'a été oublié."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Calculer Métriques Standardisées"
    ]
   },
@@ -1146,6 +1288,15 @@
     "summary = format_backtest_summary(metrics, strategy_name=\"SMA Crossover 50/200\")\n",
     "\n",
     "print(summary)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : Le helper `calculate_metrics` confirme les ordres de grandeur de la section 4 : **Max Drawdown -3.78 %**, **Volatilité 6.81 %**, **Beta 0.31** — la stratégie amplifie peu les mouvements du benchmark. Le **Win Rate de 13.20 %** sur 250 trades paraît faible mais il est trompeur : la stratégie étant longue quasi en permanence, la plupart des « trades » journaliers sont des positions maintenues dont le gain net dépend de la période.\n",
+    ">\n",
+    "> **À noter** : les `nan` (Total Return, Sharpe, Sortino, Calmar, Alpha) viennent d'une limitation du helper sur cette série — `strategy_cumulative` part de 1.0, ce qui neutralise certains ratios annualisés. Le tableau de la section 4, calculé directement sur les colonnes, reste la référence chiffrée : Return **12.21 %**, Sharpe **1.74**."
    ]
   },
   {
@@ -1450,6 +1601,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du résultat** : Le DataFrame ML contient **(252, 25)** — une ligne par jour de trading, 25 colonnes qui combinent prix OHLCV, returns multi-périodes (1/5/20 j), indicateurs techniques (SMA, EMA, RSI, MACD) et artefacts du backtest vectorisé. La liste des colonnes montre la **progression logique** du notebook : données brutes, puis analyses, puis indicateurs — tout est réuni dans un seul objet pour l'apprentissage.\n",
+    ">\n",
+    "> **Point clé — piège de fuite d'information** : les colonnes `position`, `strategy_returns`, `strategy_cumulative` et `signal` encapsulent déjà une décision de trading passée et ne doivent **pas** servir de features ML. La sélection `feature_cols` de la section suivante filtre précisément les indicateurs techniques (`sma_*`, `ema_*`, `rsi`, `macd*`, `bb_*`) pour éviter cette fuite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Créer Labels (Classification Binaire)\n",
     "\n",
     "Créons des labels pour prédire la direction du mouvement à 5 jours."
@@ -1487,6 +1647,15 @@
     "print(f\"\\nDistribution labels:\")\n",
     "print(df_ml['label'].value_counts())\n",
     "print(f\"\\nProportion hausse: {df_ml['label'].mean():.2%}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : La distribution des labels est **déséquilibrée** : 159 jours « hausse » contre 93 « baisse », soit **63.10 %** de jours haussiers. Ce déséquilibre reflète la tendance haussière de la période et sert de **baseline naïve** : un modèle qui prédirait toujours « hausse » atteindrait 63.1 % de précision — toute amélioration réelle doit se mesurer contre ce seuil.\n",
+    ">\n",
+    "> **À noter** : les 5 dernières lignes affichent `NaN` pour `future_returns_5d` — le `shift(-5)` a besoin de données futures qui n'existent pas encore en fin d'échantillon. Ces lignes sont retirées par le `dropna()` de l'étape suivante, un exemple typique de nettoyage des séries temporelles. La colonne `future_returns_5d` elle-même (non arronde) reste la variable cible brute avant seuillage."
    ]
   },
   {
@@ -1531,6 +1700,15 @@
     "# Distribution labels dans train/test\n",
     "print(f\"\\nLabel distribution (train): {train_df['label'].value_counts().to_dict()}\")\n",
     "print(f\"Label distribution (test): {test_df['label'].value_counts().to_dict()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : Après suppression des lignes `NaN`, il reste **48 échantillons** (27 colonnes), découpés en **train 33 (68.8 %) / test 15 (31.2 %)** par un split **chronologique** (70/30 sur l'index temporel) — jamais un échantillonnage aléatoire, qui laisserait fuiter l'information future dans l'entraînement.\n",
+    ">\n",
+    "> **Attention au déséquilibre du train** : `{1: 31, 0: 2}` — le train ne contient que 2 jours baissiers. Un modèle entraîné dessus apprendra surtout « tout est haussier ». Le test (`{1: 9, 0: 6}`) est plus équilibré : c'est sur lui que la généralisation sera réellement jugée. Ce petit échantillon illustre la difficulté du ML directionnel sur une seule année et motive le walk-forward vu dans QC-Py-18."
    ]
   },
   {
@@ -1629,6 +1807,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "> **Interprétation du résultat** : Le Random Forest (50 arbres, profondeur maximale 5) classe la **SMA 200 (importance 0.236)** en tête, devant `sma_10` (0.134), `macd_signal` (0.130), `ema_12` (0.103) et `macd` (0.090). Les indicateurs de **tendance lente** dominent donc la prédiction directionnelle à 5 jours — cohérent avec la nature *trend-following* du marché sur cette période.\n",
+    ">\n",
+    "> **Lecture critique** : l'importance des features est une mesure d'apprentissage, pas une preuve de causalité. Le classement peut changer sur d'autres périodes ; la prudence recommande de le recalculer en **walk-forward** (cf. QC-Py-18) avant de figer une sélection. Noter aussi la part de variance restante : le top-5 ne couvre qu'une fraction de l'importance totale, signe qu'aucun indicateur n'est dominant à lui seul.\n",
+    ">\n",
+    "> **Méthode** : l'importance affichée est l'importance de *Gini* moyennée sur les 50 arbres — une mesure de réduction d'impureté, pas une corrélation directe au label. Elle se lit en ordre de grandeur relatif : `sma_200` pèse environ **2.6×** plus que `macd` (0.236 vs 0.090), ce qui est un écart substantiel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Sauvegarder pour ML (Optionnel)\n",
     "\n",
     "Si vous utilisez LEAN CLI local, vous pouvez sauvegarder le dataset pour réutilisation."
@@ -1661,6 +1850,15 @@
     "print(f\"\\nFeatures: {len(feature_cols)}\")\n",
     "print(f\"Samples: {len(df_ml_clean)}\")\n",
     "print(f\"Train/Test split: {len(train_df)}/{len(test_df)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> **Interprétation du résultat** : Le dataset final contient **10 features** (indicateurs techniques uniquement) pour **48 échantillons**, répartis en **33 train / 15 test**. C'est un petit jeu de données — la limite d'une seule année de données journalières — mais il suffit à démontrer le **workflow complet** : feature engineering, labelisation, split anti-fuite, apprentissage et lecture de l'importance des features.\n",
+    ">\n",
+    "> **Rappel** : ce dataset est l'exacte préparation amont du notebook **QC-Py-18**, qui approfondira ces étapes (features avancées, walk-forward, sélection de features). La brièveté de l'échantillon est elle-même une leçon : avec 48 points, les conclusions d'un modèle restent fragiles et doivent être validées sur plusieurs périodes."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/notebook-python #11229

## Summary

Enrichissement pedagogique **markdown-only FR** du notebook `QC-Py-04-Research-Workflow.ipynb` (tranche #11224), sous le plancher de densite 1200.

- **20 cellules markdown d'interpretation** inserees, chacune ancrees sur les **outputs reels commites** (cell-interpretation-ordering : l'interp suit la cellule code dont l'output contient la valeur citee) : shape History (504, 5), stats SPY (mean 669.26$, fourchette 589-760$), return cumulatif 1.243 (+24.3%), volatilite rolling (6.69%-18.19%), test Shapiro-Wilk (0.9726, p=0.0001 -> fat tails), alignement SMA bull (737.05 > 717.45 > 682.63), position 1.0 constante, strategie cumul 1.122 vs BH 1.243, tableau metriques BH vs SMA complet (Return/Sharpe/MaxDD/Vol + 3 changements de position), helpers shared/, returns multi-periodes (-0.29%/-2.96%/-0.30%), 9 features techniques, metrics helper (nan vs MaxDD -3.78%, Win Rate 13.20%, Beta 0.31), df_ml (252, 25), labels 63.10% desequilibres + NaN fin de serie, split train/test (33/15, {1:31, 0:2} anti-leak), top-5 features RF (sma_200 0.236, sma_10 0.134, macd_signal 0.130, ema_12 0.103, macd 0.090), dataset final (10 features / 48 samples).
- **0 cellule code touchee** (28/28 byte-identiques, verifie par comparaison nbformat HEAD vs branche), stubs C.1 intacts (Exercices 1/2/3), pas de `_en.ipynb`, LF-only, nbformat 4.2 VALID.

## Densite pedagogique (avant/après)

| Metrique | Avant | Apres |
|----------|-------|-------|
| prose_chars | 19 010 | 34 493 |
| code_cells | 28 | 28 |
| md_cells | 44 | 64 |
| **density** | **678** | **1231** |
| status | below_threshold | ok |

Seuil : 1200 (`DENSITY_THRESHOLD`, `scripts/notebook_tools/pedagogy_density.py`).

## Method

- Surgery nbformat (json.loads / insert de cellules markdown / json.dumps indent=1 ensure_ascii=False) : aucune cellule existante modifiee.
- Verification : `nbformat.validate` OK ; comparaison structurale HEAD vs branche -> 28 code cells strictement identiques ; `grep` stubs C.1 intacts ; 0 pattern interdit ; 0 CRLF.

See #11224 (contribution partielle a l'epic — pas de Closes).

Co-Authored-By: Claude-Code <noreply@anthropic.com>