### PR TITLE
docs(groth,#11123): re-sync compteurs README 34 -> 43 leaf + Lignes disque

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -5,10 +5,10 @@ Alexandre Grothendieck (1928-2014).
 ## Status
 
 - **Toolchain**: `leanprover/lean4:v4.31.0-rc1`
-- **Sorry**: **0 sorry, 0 axiom** — all 33 leaf modules are complete at creation
-- **Build**: `lake build Grothendieck` — compiles the 33 leaf modules (11,206 FR+EN lines, + 208 for the umbrella = **11,414 total**, measured 2026-07-30)
+- **Sorry**: **0 sorry, 0 axiom** — all 43 leaf modules are complete at creation
+- **Build**: `lake build Grothendieck` — compiles the 43 leaf modules (20,988 FR+EN lines, + 217 for the umbrella = **21,205 total**, measured 2026-08-16)
 - **Dependencies**: Mathlib 4 (via `lakefile.lean`)
-- **i18n coverage (EPIC #4980, ratified 2026-07-04)**: complete bilingual FR/EN coverage — **34 FR files** (1 umbrella `Grothendieck.lean` bilingual inline FR+EN + **33 leaf modules** FR canonical) + **33 `_en.lean` siblings** on `main` (leaf modules only; the umbrella is bilingual inline). Per the ratified convention (Option A: `Foo.lean` FR canonical + `Foo_en.lean` EN mirror for leaves), **all 33 leaf modules** are bilingual in Pattern A (`_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). The umbrella `Grothendieck.lean` is bilingual inline (FR canonical first, EN mirror, see final doctring in the file) — *by design*, not an i18n gap. **`README.md`** present (FR canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
+- **i18n coverage (EPIC #4980, ratified 2026-07-04)**: complete bilingual FR/EN coverage — **44 FR files** (1 umbrella `Grothendieck.lean` bilingual inline FR+EN + **43 leaf modules** FR canonical, incl. Part 34 `ExceptionalDirect.lean` via #10357 on 2026-08-11 and Parts 35-43 via the Phase 5 waves of #2159 on 2026-08-14..16) + **43 `_en.lean` siblings** on `main` (leaf modules only; the umbrella is bilingual inline). Per the ratified convention (Option A: `Foo.lean` FR canonical + `Foo_en.lean` EN mirror for leaves), **all 43 leaf modules** are bilingual in Pattern A (`_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). The umbrella `Grothendieck.lean` is bilingual inline (FR canonical first, EN mirror, see final doctring in the file) — *by design*, not an i18n gap. **`README.md`** present (FR canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
 
 ## Purpose
 
@@ -26,63 +26,77 @@ The goal is to give learners a curated entry point into:
 
 ## Structure
 
-The formalization spans **33 leaf modules (11,206 FR+EN lines, 0 sorry)**, imported
+The formalization spans **43 leaf modules (20,988 FR+EN lines, 0 sorry)**, imported
 in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline FR/EN; no `_en` sibling for the umbrella).
 
 | Part | File | `_en` | Content | Lines |
 |------|------|-------|---------|-------|
-| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only of the 33 leaves + bilingual FR/EN doctring); no `_en` sibling (the EN content lives in the same file as a mirror) | 208 |
+| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only of the 43 leaves + bilingual FR/EN doctring); no `_en` sibling (the EN content lives in the same file as a mirror) | 217 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 243 |
-| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 109 |
-| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 93 |
-| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 107 |
+| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 196 |
+| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 139 |
+| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | `#check` index of Grothendieck-related Mathlib definitions | 124 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 micro-proof targets for the prover harness (Epic #1453) | 95 |
-| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities (7): `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
-| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 148 |
-| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 141 |
-| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 177 |
-| 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Canonical topology, subcanonicity, representable sheaves | 154 |
-| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Sieve generation identities | 172 |
-| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | The dense topology | 155 |
-| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Sheafification (the associated sheaf functor) | 189 |
+| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Sieve pullback identities (7): `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 253 |
+| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Sheaf/separated presheaf basics, sheaf transfer along J₁ ≤ J₂ | 231 |
+| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Topology ordering, covering closure, sieve composition | 208 |
+| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-to-topology, sheaf characterization, sup of coverages | 233 |
+| 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Canonical topology, subcanonicity, representable sheaves | 155 |
+| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Sieve generation identities | 243 |
+| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | The dense topology | 218 |
+| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Sheafification (the associated sheaf functor) | 259 |
 | 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Left exactness of sheafification | 219 |
-| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 226 |
-| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 105 |
-| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Internal hom of sheaves | 173 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Conservative families of points | 226 |
-| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Sheaf cohomology (Ext-based) | 254 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Mayer-Vietoris squares | 195 |
-| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Mayer-Vietoris long exact sequence | 167 |
-| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 130 |
-| 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 274 |
-| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjunction of functors, unit/counit, turtle lemma, left/right adjoints | 168 |
-| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monads in category theory, unit, multiplication, associativity law | 172 |
-| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Comma category, projections, functoriality | 129 |
-| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limits and colimits | 242 |
-| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Equivalences of categories, fully-faithful functors, essentially surjective | 189 |
-| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Basic categorical constructions | 152 |
-| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Kan extensions (generalized limits/colimits) | 270 |
-| 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Monoidal categories, tensor, unit, associator | 244 |
-| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | `#check` index (8) of the `f^* ⊣ f_*` adjunction — direct/inverse image of module sheaves (#8882) | 152 |
+| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points of a site (fiber functors) | 411 |
+| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Subcanonical Grothendieck topologies | 232 |
+| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Internal hom of sheaves | 273 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | The constant sheaf functor (bridges Mathlib `CategoryTheory.Sites.ConstantSheaf`) | 252 |
+| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Conservative families of points | 501 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Sheaf cohomology (Ext-based) | 336 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Mayer-Vietoris squares | 338 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Mayer-Vietoris long exact sequence | 235 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Čech cohomology | 203 |
+| 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | The Yoneda lemma (embedding, equivalence, naturality, fully-faithful, coyoneda) | 275 |
+| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjunction of functors, unit/counit, turtle lemma, left/right adjoints | 335 |
+| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monads in category theory, unit, multiplication, associativity law | 253 |
+| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Comma category, projections, functoriality | 239 |
+| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limits and colimits | 421 |
+| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Equivalences of categories, fully-faithful functors, essentially surjective | 338 |
+| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Basic categorical constructions | 256 |
+| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Kan extensions (generalized limits/colimits) | 481 |
+| 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Monoidal categories, tensor, unit, associator | 397 |
+| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | `#check` index (8) of the `f^* ⊣ f_*` adjunction — direct/inverse image of module sheaves (#8882) | 325 |
+| 34 | `Grothendieck/ExceptionalDirect.lean` | `ExceptionalDirect_en.lean` | Exceptional direct image `f_!` at the presheaf level and its adjunction `f_! ⊣ f^*` — left Kan extension of `f^*` along `f` (#10357, Phase 2 of #2159) | 202 |
+| 35 | `Grothendieck/CoversArrow.lean` | `CoversArrow_en.lean` | Arrow form of the covering: `covers_monotone`, `covers_union`, `covers_inf`, `covers_comp_iff` equivalence (#10879, Phase 5 of #2159) | 199 |
+| 36 | `Grothendieck/Cover.lean` | `Cover_en.lean` | Bundled covering `J.Cover X`: coe-injective, pullback/top/inf laws, `bind_mem_iff`, base condition (#10912, Phase 5 of #2159) | 284 |
+| 37 | `Grothendieck/PullbackFunctor.lean` | `PullbackFunctor_en.lean` | Coherence laws of the pullback pseudofunctor on `J.Cover`: `pullback_triple`, `pullbackComp_assoc`, left/right units (#11023, Phase 5 of #2159) | 149 |
+| 38 | `Grothendieck/PullbackFunctorLaws.lean` | `PullbackFunctorLaws_en.lean` | Pullback functor laws: `pullback_functor_id`, `pullback_functor_comp(_assoc)`, `covers_pullback_comp` (#11035, Phase 5 of #2159) | 141 |
+| 39 | `Grothendieck/TopologyLattice.lean` | `TopologyLattice_en.lean` | Lattice laws of Grothendieck topologies: `inf/sup_covering`, `sSup_covering`, `le_covers` (#11038, Phase 5 of #2159) | 211 |
+| 40 | `Grothendieck/CoversPullback.lean` | `CoversPullback_en.lean` | Arrow-form laws under pullback: `covers_pullback_comp`, `covers_bind`, `covers_iso_covering/cancel`, `covers_mono` (#11057, Phase 5 of #2159) | 202 |
+| 41 | `Grothendieck/CoversOrder.lean` | `CoversOrder_en.lean` | Order laws of the arrow form `J.Covers`: `covers_top/bot_iff`, `covers_inter_iff`, `covers_of_covering`, `covers_generate_sieve` (#11068, Phase 5 of #2159) | 164 |
+| 42 | `Grothendieck/PullbackCoversLaws.lean` | `PullbackCoversLaws_en.lean` | Arrow-form laws under iterated pullback: `covers_pullback_assoc`, `covers_pullback_id`, `covers_pullback_generate` (#11217, Phase 5 of #2159) | 160 |
+| 43 | `Grothendieck/CoversLattice.lean` | `CoversLattice_en.lean` | Indexed lattice laws of the arrow form: `sInf/sSup_covering`, `sInf/sSup_covers` (#11231, Phase 5 of #2159) | 106 |
 
 *The `Lines` column counts the **FR file alone**; the FR+EN total is roughly double.*
 
-The extension was developed under Issue #2159 / Epic #1646: the 33 leaf modules
-are merged + 1 bilingual umbrella, 0 `sorry`, 0 axiom added.
+The extension was developed under Issue #2159 / Epic #1646: the 43 leaf modules
+are merged + 1 bilingual umbrella, 0 `sorry`, 0 axiom added. Phase 2 (Part 34
+`f_! ⊣ f^*`) shipped by PR #10357 (MERGED 2026-08-11); Phase 5 (Parts 35-43,
+arrow/bundled forms of the covering and pullback laws) shipped by waves
+(2026-08-14..16: #10879, #10912, #11023, #11035, #11038, #11057, #11068, #11217,
+#11231); Phase 1 (Parts 1-33) previously shipped by PR waves (#2675, #8882, etc.).
 
 ## Build
 
 ```bash
 # From this directory (WSL required)
 lake build Grothendieck
-# Builds the 33 leaf modules + 1 bilingual umbrella (11,414 FR+EN lines total)
-# Last verified build: 2026-07-30, "Build completed successfully (2821 jobs)"
+# Builds the 43 leaf modules + 1 bilingual umbrella (21,205 FR+EN lines total)
+# Last verified build: 2026-07-30, "Build completed successfully (2821 jobs)" (counters re-audited 2026-08-16)
 ```
 
 ## Sorry count
 
-**0 sorry, 0 axiom** — all 33 leaf modules are complete at creation
+**0 sorry, 0 axiom** — all 43 leaf modules are complete at creation
 (the umbrella `Grothendieck.lean` is imports-only without declarations).
 
 ## Toolchain
@@ -109,15 +123,16 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - Epic #1453 (prover harness calibration)
 - Conway tribute workspace (`../conway_lean/`)
 - Lean notebook series (`../README.md`)
-- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 33 `_en.lean` siblings on `main` in this lake + 1 bilingual inline umbrella)
+- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 43 `_en.lean` siblings on `main` in this lake + 1 bilingual inline umbrella)
 - Issue #8960 (reconciling the two `Part` numberings)
 - **[`README.md`](./README.md)** — FR canonical sibling of this file
 
 ## Conclusion
 
-This tribute is a **complete pedagogical tour** (33 leaf modules + 1 bilingual umbrella, 11,414 FR+EN lines, 0 `sorry`,
+This tribute is a **complete pedagogical tour** (43 leaf modules + 1 bilingual umbrella, 21,205 FR+EN lines, 0 `sorry`,
 0 axiom added) showing how Grothendieck's language — sites, sheaves,
-sheafification, points, cohomology, Yoneda, direct images — already lives in Mathlib 4. It is
+sheafification, points, cohomology, Yoneda, direct images, covering forms —
+already lives in Mathlib 4. It is
 deliberately **not** a formalization of EGA/SGA; it is a curated index that lets
 learners see the library through Grothendieckian eyes.
 
@@ -130,9 +145,16 @@ its left exactness** (13, 14) → **points and conservative families** (15, 19) 
 Zariski site** (2, 3), a **Mathlib map** (4), and the **Yoneda lemma** (24)
 anchoring the tour to the library it indexes. The categorical foundations
 (Adjunction, Equivalences, Monads) at Parts 25, 29, 26 underpin the whole
-formalization. Finally, `DirectImage.lean` indexes the `f^* ⊣ f_*` adjunction — the
+formalization. `DirectImage.lean` indexes the `f^* ⊣ f_*` adjunction — the
 simplest instance of the "six operations", transporting sheaves along morphisms
-of schemes.
+of schemes. `ExceptionalDirect.lean` (Part 34, #10357) climbs a rung by
+formalizing `f_! ⊣ f^*` at the presheaf level — the *proper-support* direct
+image as a left Kan extension of `f^*`, the missing link between `f^*`
+(inverse image) and `f_*` (direct image). Parts 35-43 extend the *covering*
+side: arrow and bundled forms of `J.Cover`, pullback functor and topology
+order/lattice laws (CoversArrow, Cover, PullbackFunctor, PullbackFunctorLaws,
+TopologyLattice, CoversPullback, CoversOrder, PullbackCoversLaws, CoversLattice,
+Phase 5 of #2159).
 
 ### Scope, honestly
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -5,10 +5,10 @@ Alexandre Grothendieck (1928-2014).
 ## État
 
 - **Toolchain** : `leanprover/lean4:v4.31.0-rc1`
-- **Sorry** : **0 sorry, 0 axiome** — les 34 modules leaf sont complets à la création
-- **Build** : `lake build Grothendieck` — compile 34 modules leaf + 1 umbrella bilingue (mesuré 2026-08-12)
+- **Sorry** : **0 sorry, 0 axiome** — les 43 modules leaf sont complets à la création
+- **Build** : `lake build Grothendieck` — compile 43 modules leaf + 1 umbrella bilingue (re-audité 2026-08-16)
 - **Dépendances** : Mathlib 4 (via `lakefile.lean`)
-- **Couverture i18n (EPIC #4980 ratifiée 2026-07-04)** : couverture bilingue FR/EN complète — **36 fichiers FR** (1 umbrella `Grothendieck.lean` bilingue inline FR+EN + **34 modules leaf** FR canonique, dont `ExceptionalDirect.lean` Partie 34 ajouté via #10357 le 2026-08-11) + **34 siblings `_en.lean`** sur `main` (les 34 modules leaf uniquement ; l'umbrella est bilingue inline). Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN pour les leafs), **tous les 34 modules leaf** sont déjà bilingues au pattern A (namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). L'umbrella `Grothendieck.lean` est bilingue inline (FR canonique d'abord, EN en miroir, cf doctring final du fichier) — c'est *by design*, pas un gap i18n. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
+- **Couverture i18n (EPIC #4980 ratifiée 2026-07-04)** : couverture bilingue FR/EN complète — **44 fichiers FR** (1 umbrella `Grothendieck.lean` bilingue inline FR+EN + **43 modules leaf** FR canonique, dont `ExceptionalDirect.lean` Partie 34 ajouté via #10357 le 2026-08-11 et les Parties 35-43 via les vagues Phase 5 de #2159 le 2026-08-14..16) + **43 siblings `_en.lean`** sur `main` (les 43 modules leaf uniquement ; l'umbrella est bilingue inline). Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN pour les leafs), **tous les 43 modules leaf** sont déjà bilingues au pattern A (namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). L'umbrella `Grothendieck.lean` est bilingue inline (FR canonique d'abord, EN en miroir, cf doctring final du fichier) — c'est *by design*, pas un gap i18n. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
 
 ## Objectif
 
@@ -27,16 +27,21 @@ Le but est d'offrir aux apprenants un point d'entrée curaté vers :
 
 ## Structure
 
-La formalisation couvre **34 modules leaf (0 sorry)** + **3 sous-modules
+La formalisation couvre **43 modules leaf (0 sorry)** + **3 sous-modules
 SheafCohomology/** (Basic + MayerVietoris + Cech, déjà comptés dans la Partie
 20-22), importés dans l'ordre par le parapluie `Grothendieck.lean` (qui est
 lui-même bilingue inline FR/EN, pas de sibling `_en` pour l'umbrella). La Partie
 34 (`ExceptionalDirect.lean`) a été ajoutée par **PR #10357 (MERGED 2026-08-11)** —
 extension Phase 2 de l'Epic #2159 qui formalise l'image directe exceptionnelle
 `f_!` au niveau préfaisceau et son adjonction `f_! ⊣ f^*` (extension de Kan
-à gauche de `f^*` le long de `f`).
+à gauche de `f^*` le long de `f`). Les **Parties 35-43** (formes flèche et
+bundlée de la couverture, lois du foncteur pullback et de l'ordre/treillis des
+topologies — CoversArrow, Cover, PullbackFunctor, PullbackFunctorLaws,
+TopologyLattice, CoversPullback, CoversOrder, PullbackCoversLaws, CoversLattice)
+ont été ajoutées par les vagues **Phase 5 de l'Epic #2159** (mergées
+2026-08-14..16).
 
-*La trajectoire pédagogique des 33 modules leaf — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski et carte Mathlib en ancrage :*
+*La trajectoire pédagogique des 43 modules leaf — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski et carte Mathlib en ancrage :*
 
 ```mermaid
 flowchart LR
@@ -52,61 +57,73 @@ flowchart LR
 
 | Partie | Fichier | `_en` | Contenu | Lignes |
 |--------|---------|-------|---------|--------|
-| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only des 33 leaf + doctring bilingue FR/EN) ; pas de sibling `_en` (le contenu EN vit dans le même fichier en miroir) | 208 |
+| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only des 43 leaf + doctring bilingue FR/EN) ; pas de sibling `_en` (le contenu EN vit dans le même fichier en miroir) | 217 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 243 |
-| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 109 |
-| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 93 |
-| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 107 |
+| 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 196 |
+| 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 139 |
+| 4 | `Grothendieck/MathlibMap.lean` | `MathlibMap_en.lean` | Index `#check` des définitions Mathlib liées à Grothendieck | 124 |
 | 5 | `Grothendieck/Calibration.lean` | `Calibration_en.lean` | 4 cibles de micro-preuve pour le harnais du prouveur (Epic #1453) | 95 |
-| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles (7) : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 164 |
-| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 148 |
-| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 141 |
-| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 177 |
-| 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Topologie canonique, sous-canoïcité, faisceaux représentables | 154 |
-| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Identités de génération de cribles | 172 |
-| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | La topologie dense | 155 |
-| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Faisceautisation (le foncteur faisceau associé) | 189 |
+| 6 | `Grothendieck/SieveLattice.lean` | `SieveLattice_en.lean` | Identités de pullback de cribles (7) : `pullback_id`, `pullback_pullback`, `pullback_bot`, `pullback_monotone`, `pullback_union` (#7895), `pullback_ofObjects`, `mem_iff_pullback_eq_top` | 253 |
+| 7 | `Grothendieck/SheafBasics.lean` | `SheafBasics_en.lean` | Bases faisceau/préfaisceau séparé, transfert de faisceau le long de J₁ ≤ J₂ | 231 |
+| 8 | `Grothendieck/SieveOps.lean` | `SieveOps_en.lean` | Ordre sur les topologies, clôture de recouvrement, composition de cribles | 208 |
+| 9 | `Grothendieck/CoverageGen.lean` | `CoverageGen_en.lean` | Coverage-vers-topologie, caractérisation des faisceaux, sup de coverages | 233 |
+| 10 | `Grothendieck/CanonicalProps.lean` | `CanonicalProps_en.lean` | Topologie canonique, sous-canoïcité, faisceaux représentables | 155 |
+| 11 | `Grothendieck/SieveGenerate.lean` | `SieveGenerate_en.lean` | Identités de génération de cribles | 243 |
+| 12 | `Grothendieck/DenseTopology.lean` | `DenseTopology_en.lean` | La topologie dense | 218 |
+| 13 | `Grothendieck/Sheafification.lean` | `Sheafification_en.lean` | Faisceautisation (le foncteur faisceau associé) | 259 |
 | 14 | `Grothendieck/LeftExact.lean` | `LeftExact_en.lean` | Exactitude à gauche de la faisceautisation | 219 |
-| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 226 |
-| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 105 |
-| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Hom interne des faisceaux | 173 |
-| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 185 |
-| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Familles conservatrices de points | 226 |
-| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Cohomologie des faisceaux (basée sur Ext) | 254 |
-| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Carrés de Mayer-Vietoris | 195 |
-| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Suite exacte longue de Mayer-Vietoris | 167 |
-| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 130 |
-| 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 274 |
-| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 168 |
-| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monades en théorie des catégories, unité, multiplication, loi d'association | 172 |
-| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Catégorie comma, projections, fonctorialité | 129 |
-| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limites et colimites | 242 |
-| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Équivalences de catégories, foncteurs pleinement fidèles, essentiellement surjectifs | 189 |
-| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Constructions catégorielles de base | 152 |
-| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Extensions de Kan (limites/colimites généralisées) | 270 |
-| 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Catégories monoïdales, tenseur, unité, associateur | 244 |
-| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | Index `#check` (8) de l'adjonction `f^* ⊣ f_*` — image directe / réciproque des faisceaux de modules (#8882) | 152 |
+| 15 | `Grothendieck/SitePoints.lean` | `SitePoints_en.lean` | Points d'un site (foncteurs fibres) | 411 |
+| 16 | `Grothendieck/Subcanonical.lean` | `Subcanonical_en.lean` | Topologies de Grothendieck sous-canoniques | 232 |
+| 17 | `Grothendieck/SheafHom.lean` | `SheafHom_en.lean` | Hom interne des faisceaux | 273 |
+| 18 | `Grothendieck/ConstantSheaf.lean` | `ConstantSheaf_en.lean` | Le foncteur faisceau constant (ponte vers `CategoryTheory.Sites.ConstantSheaf` de Mathlib) | 252 |
+| 19 | `Grothendieck/Conservative.lean` | `Conservative_en.lean` | Familles conservatrices de points | 501 |
+| 20 | `Grothendieck/SheafCohomology/Basic.lean` | `SheafCohomology/Basic_en.lean` | Cohomologie des faisceaux (basée sur Ext) | 336 |
+| 21 | `Grothendieck/MayerVietorisSquare.lean` | `MayerVietorisSquare_en.lean` | Carrés de Mayer-Vietoris | 338 |
+| 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Suite exacte longue de Mayer-Vietoris | 235 |
+| 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 203 |
+| 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 275 |
+| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 335 |
+| 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monades en théorie des catégories, unité, multiplication, loi d'association | 253 |
+| 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Catégorie comma, projections, fonctorialité | 239 |
+| 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limites et colimites | 421 |
+| 29 | `Grothendieck/Equivalences.lean` | `Equivalences_en.lean` | Équivalences de catégories, foncteurs pleinement fidèles, essentiellement surjectifs | 338 |
+| 30 | `Grothendieck/Construction.lean` | `Construction_en.lean` | Constructions catégorielles de base | 256 |
+| 31 | `Grothendieck/KanExtensions.lean` | `KanExtensions_en.lean` | Extensions de Kan (limites/colimites généralisées) | 481 |
+| 32 | `Grothendieck/MonoidalCategories.lean` | `MonoidalCategories_en.lean` | Catégories monoïdales, tenseur, unité, associateur | 397 |
+| 33 | `Grothendieck/DirectImage.lean` | `DirectImage_en.lean` | Index `#check` (8) de l'adjonction `f^* ⊣ f_*` — image directe / réciproque des faisceaux de modules (#8882) | 325 |
 | 34 | `Grothendieck/ExceptionalDirect.lean` | `ExceptionalDirect_en.lean` | Image directe exceptionnelle `f_!` au niveau préfaisceau et son adjonction `f_! ⊣ f^*` — extension de Kan à gauche de `f^*` le long de `f` (#10357, Phase 2 de #2159) | 202 |
+| 35 | `Grothendieck/CoversArrow.lean` | `CoversArrow_en.lean` | Forme flèche de la couverture : `covers_monotone`, `covers_union`, `covers_inf`, équivalence `covers_comp_iff` (#10879, Phase 5 de #2159) | 199 |
+| 36 | `Grothendieck/Cover.lean` | `Cover_en.lean` | Couverture bundlée `J.Cover X` : coe-injective, lois pullback/top/inf, `bind_mem_iff`, condition de base (#10912, Phase 5 de #2159) | 284 |
+| 37 | `Grothendieck/PullbackFunctor.lean` | `PullbackFunctor_en.lean` | Lois de cohérence du pseudofoncteur pullback sur `J.Cover` : `pullback_triple`, `pullbackComp_assoc`, unités gauche/droite (#11023, Phase 5 de #2159) | 149 |
+| 38 | `Grothendieck/PullbackFunctorLaws.lean` | `PullbackFunctorLaws_en.lean` | Lois de foncteur du pullback : `pullback_functor_id`, `pullback_functor_comp(_assoc)`, `covers_pullback_comp` (#11035, Phase 5 de #2159) | 141 |
+| 39 | `Grothendieck/TopologyLattice.lean` | `TopologyLattice_en.lean` | Lois de treillis des topologies de Grothendieck : `inf/sup_covering`, `sSup_covering`, `le_covers` (#11038, Phase 5 de #2159) | 211 |
+| 40 | `Grothendieck/CoversPullback.lean` | `CoversPullback_en.lean` | Lois de la forme flèche sous pullback : `covers_pullback_comp`, `covers_bind`, `covers_iso_covering/cancel`, `covers_mono` (#11057, Phase 5 de #2159) | 202 |
+| 41 | `Grothendieck/CoversOrder.lean` | `CoversOrder_en.lean` | Lois d'ordre de la forme flèche `J.Covers` : `covers_top/bot_iff`, `covers_inter_iff`, `covers_of_covering`, `covers_generate_sieve` (#11068, Phase 5 de #2159) | 164 |
+| 42 | `Grothendieck/PullbackCoversLaws.lean` | `PullbackCoversLaws_en.lean` | Lois de la forme flèche sous pullback itéré : `covers_pullback_assoc`, `covers_pullback_id`, `covers_pullback_generate` (#11217, Phase 5 de #2159) | 160 |
+| 43 | `Grothendieck/CoversLattice.lean` | `CoversLattice_en.lean` | Lois de treillis indexées de la forme flèche : `sInf/sSup_covering`, `sInf/sSup_covers` (#11231, Phase 5 de #2159) | 106 |
 
 *La colonne `Lignes` compte le **fichier FR seul** ; le total FR+EN est le double approximatif.*
 
-L'extension a été développée sous l'Issue #2159 / Epic #1646 : les **34 modules leaf**
+L'extension a été développée sous l'Issue #2159 / Epic #1646 : les **43 modules leaf**
 sont mergés + 1 umbrella bilingue, 0 `sorry`, 0 axiome ajouté. **Phase 2** (Partie 34
-`f_! ⊣ f^*`) livrée par PR #10357 (MERGED 2026-08-11) ; **Phase 1** (Parties 1-33)
-précédemment shippée par vagues de PRs (#2675, #8882, etc.).
+`f_! ⊣ f^*`) livrée par PR #10357 (MERGED 2026-08-11) ; **Phase 5** (Parties 35-43,
+formes flèche/bundlée de la couverture et lois du pullback) livrée par vagues
+(2026-08-14..16 : #10879, #10912, #11023, #11035, #11038, #11057, #11068, #11217,
+#11231) ; **Phase 1** (Parties 1-33) précédemment shippée par vagues de PRs
+(#2675, #8882, etc.).
 
 ## Build
 
 ```bash
 # Depuis ce répertoire (WSL requis)
 lake build Grothendieck
-# Compile les 34 modules leaf + 1 umbrella bilingue
-# Dernier build vérifié : 2026-08-12, « Build completed successfully »
+# Compile les 43 modules leaf + 1 umbrella bilingue
+# Dernier build vérifié : 2026-08-12, « Build completed successfully » (compteurs re-audités 2026-08-16)
 ```
 
 ## Compte de sorry
 
-**0 sorry, 0 axiome** — tous les 34 modules leaf sont complets à la création
+**0 sorry, 0 axiome** — tous les 43 modules leaf sont complets à la création
 (l'umbrella `Grothendieck.lean` est imports-only sans déclaration). La Partie 34
 `ExceptionalDirect.lean` (#10357) cite `sorry` deux fois en prose docstring
 (marque de la formalisation bornée) mais ne contient **aucun sorry tactic**.
@@ -135,17 +152,18 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 - **PR #10357** (Phase 2 #2159 : exceptional direct image `f_! ⊣ f^*` au niveau préfaisceau, formalisation bornée du chaînon manquant entre `f^*` et `f_*`)
 - Epic #1453 (calibration du harnais prouveur)
 - Workspace hommage Conway (`../conway_lean/`)
-- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 33 siblings `_en.lean` sur `main` dans cette lake + 1 umbrella bilingue inline)
+- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 43 siblings `_en.lean` sur `main` dans cette lake + 1 umbrella bilingue inline)
 - Issue #8960 (réconciliation des deux numérotations `Partie`)
 - **[`README.en.md`](./README.en.md)** — miroir EN du présent fichier
 - Série de notebooks Lean (`../README.md`)
 
 ## Conclusion
 
-Cet hommage est une **visite pédagogique complète** (34 modules leaf + 1 umbrella bilingue, 0
+Cet hommage est une **visite pédagogique complète** (43 modules leaf + 1 umbrella bilingue, 0
 `sorry`, 0 axiome ajouté) montrant comment le langage de Grothendieck — sites,
 faisceaux, faisceautisation, points, cohomologie, Yoneda, images directes,
-image directe exceptionnelle `f_!` — vit déjà dans Mathlib 4. Ce n'est
+image directe exceptionnelle `f_!`, formes flèche/bundlée de la couverture — vit
+déjà dans Mathlib 4. Ce n'est
 délibérément **pas** une formalisation d'EGA/SGA ; c'est un index curaté
 qui laisse les apprenants voir la bibliothèque à travers des yeux grothendieckiens.
 
@@ -156,7 +174,7 @@ Les modules tracent un chemin cohérent : **sites et cribles** (Parties 1, 6, 8,
 **faisceautisation et son exactitude à gauche** (13, 14) → **points et familles
 conservatrices** (15, 19) → **cohomologie des faisceaux, Mayer-Vietoris et Čech**
 (20-23), avec **schémas et site de Zariski** (2, 3), une **carte Mathlib** (4)
-et le **lemme de Yoneda** (24) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 25, 29, 26 soutiennent toute la formalisation. `DirectImage.lean` (Partie 33) indexe l'adjonction `f^* ⊣ f_*` — l'instance la plus simple des « six opérations », qui transporte les faisceaux le long des morphismes de schémas. Enfin, `ExceptionalDirect.lean` (Partie 34, #10357) franchit un échelon en formalisant `f_! ⊣ f^*` au niveau préfaisceau — l'image directe *à support propre* comme extension de Kan à gauche de `f^*`, chaînon manquant entre `f^*` (inverse-image) et `f_*` (image directe).
+et le **lemme de Yoneda** (24) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 25, 29, 26 soutiennent toute la formalisation. `DirectImage.lean` (Partie 33) indexe l'adjonction `f^* ⊣ f_*` — l'instance la plus simple des « six opérations », qui transporte les faisceaux le long des morphismes de schémas. `ExceptionalDirect.lean` (Partie 34, #10357) franchit un échelon en formalisant `f_! ⊣ f^*` au niveau préfaisceau — l'image directe *à support propre* comme extension de Kan à gauche de `f^*`, chaînon manquant entre `f^*` (inverse-image) et `f_*` (image directe). Les Parties 35-43 prolongent le versant *couverture* : formes flèche et bundlée de `J.Cover`, lois du foncteur pullback et de l'ordre/treillis des topologies (CoversArrow, Cover, PullbackFunctor, PullbackFunctorLaws, TopologyLattice, CoversPullback, CoversOrder, PullbackCoversLaws, CoversLattice, Phase 5 de #2159).
 
 *La construction verticale « faisceau » — chaque couche bâtie sur la précédente, de la donnée du site jusqu'à la cohomologie :*
 


### PR DESCRIPTION
Grain: LIGHT/readme -- lane myia-po-2026:CoursIA -- prev: MED/harness #11251

## Quoi

Re-sync du README grothendieck_lean (FR + miroir EN) au compte disque du jour. Audit **fichier-entier** (gate §E pr-review-discipline) : le README annonçait **34 modules leaf** (resync 2026-08-12) alors que le disque porte **43 FR + 43 siblings `_en`**.

Le compte « 41/41 » de l'issue (datait du 08-15) était déjà périmé au moment de la mesure : **2 parties ont atterri le 08-16** (#11217 PullbackCoversLaws, #11231 CoversLattice). Les 9 nouvelles parties = vagues **Phase 5 de #2159** mergées 2026-08-14..16 (CoversArrow, Cover, PullbackFunctor, PullbackFunctorLaws, TopologyLattice, CoversPullback, CoversOrder, PullbackCoversLaws, CoversLattice).

## Preuves (audit fichier-entier)

- **(a) `find`/`ls-tree` au jour J** : `git ls-tree -r origin/main` filtré `.lean` hors `_en`/lakefile/parapluie → **43 FR + 43 `_en`** (le compte `_en` inclut SheafCohomology/Basic, compté comme Partie 20 par le README).
- **(b) disque ↔ prose** : intro + État/i18n resynchronisés (44 fichiers FR = 1 umbrella bilingue inline + 43 leaf ; 43 siblings `_en`), tableau Parties = **43 lignes réelles** (chacune vérifiée contre le fichier : `wc -l` re-mesuré — les bridges ajoutés 08-13/14 ont fait grossir ~25 fichiers, ex. Adjunction 168→335, Conservative 226→501), Build + sorry-count + trajectoire/arc (extension Parties 35-43) + Conclusion.
- **(c) README.en.md miroir synchronisé** : 43 leaf, totaux FR+EN re-calculés (20 988 lignes leaf + 217 umbrella = **21 205 total**, mesuré 2026-08-16). Le miroir EN était encore plus en retard (33 leaf, totals du 07-30).
- **Pas de marqueur CATALOG-STATUS** dans ces README (grep = 0) — aucune interaction catalogue. Pas de `.lean` modifié : i18n sibling drift non concerné.

## Honnêteté build

Les compteurs reflètent le **disque**, pas un build re-exécuté : « Dernier build vérifié : 2026-08-12 » conservé (le dernier build documenté), avec mention « compteurs re-audités 2026-08-16 ». Les 9 nouvelles parties ont chacune passé leur CI lake build à leur merge.

Closes #11123