### PR TITLE
feat(conway,#11161): re-cadrage Gosper grain 1 — capture du saut decorele inconditionnelle

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife.lean
@@ -695,6 +695,120 @@ theorem jumpAt_capture_centered (lvl B pad : Nat)
   rw [h1, h2]
   omega
 
+/-- **Invariant de re-cadrage (grain 1, #11161).** Pour une grille non vide,
+    la bbox de `g` et le rembourrage conscient de `n` tiennent dans la cellule
+    du cadre : `B + 2 * max 2 n ≤ 2 ^ lvl` avec
+    `B = max (rMax-rMin+1).toNat (cMax-cMin+1).toNat` et
+    `lvl = (gridFrameN n g).2`. Acquis par construction — `side ≥ B + 2*pad`
+    via `max height width` + `Nat.le_max_left/right`, et `2^lvl ≥ side` via
+    `MacroCell.ceilLog2_spec` : c'est l'hypothese `hframe` de
+    `jumpAt_capture_centered`, obtenue sans aucune hypothese de capture. -/
+theorem gridFrameN_frame_invariant (n : Nat) (g : Grid) (hg : g ≠ []) :
+    max ((gridRowMax g - gridRowMin g + 1).toNat)
+        ((gridColMax g - gridColMin g + 1).toNat) + 2 * max 2 n
+      ≤ 2 ^ (gridFrameN n g).2 := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
+      gridColMin_le_gridColMax _ (List.cons_ne_nil _ _)
+    simp only [gridFrameN]
+    set rMin := gridRowMin (p₀ :: ps)
+    set rMax := gridRowMax (p₀ :: ps)
+    set cMin := gridColMin (p₀ :: ps)
+    set cMax := gridColMax (p₀ :: ps)
+    set pad := max 2 n
+    set rowSpan := (rMax - rMin + 1).toNat
+    set colSpan := (cMax - cMin + 1).toNat
+    set height := (rMax - rMin + 1 + 2 * pad).toNat
+    set width := (cMax - cMin + 1 + 2 * pad).toNat
+    set side := max height width
+    set lvl := MacroCell.ceilLog2 side
+    have hspec : (2 ^ lvl : Nat) ≥ side := MacroCell.ceilLog2_spec side
+    have hh : height ≤ side := Nat.le_max_left _ _
+    have hw : width ≤ side := Nat.le_max_right _ _
+    have hrow : rowSpan + 2 * pad ≤ height := by
+      simp only [rowSpan, height]
+      have hnn : 0 ≤ rMax - rMin + 1 := by omega
+      omega
+    have hcol : colSpan + 2 * pad ≤ width := by
+      simp only [colSpan, width]
+      have hnn : 0 ≤ cMax - cMin + 1 := by omega
+      omega
+    have hB : max rowSpan colSpan + 2 * pad ≤ side := by
+      by_cases h : rowSpan ≤ colSpan
+      · rw [max_eq_right h]
+        exact le_trans hcol hw
+      · have h' : colSpan ≤ rowSpan := Nat.le_of_not_ge h
+        rw [max_eq_left h']
+        exact le_trans hrow hh
+    simpa [pad] using le_trans hB hspec
+
+/-- Niveau du cadre conscient de n ≥ 2 pour une grille non vide : le
+    rembourrage `max 2 n ≥ 2` et la bbox non vide donnent `height ≥ 5`, donc
+    `side ≥ 5`, et `2^lvl ≥ side ≥ 5 > 4 = 2^2`, donc `lvl ≥ 2`. C'est le
+    `hlvl` de `jumpAt_capture_centered`, acquis par construction. -/
+theorem gridFrameN_level_ge_two (n : Nat) (g : Grid) (hg : g ≠ []) :
+    2 ≤ (gridFrameN n g).2 := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridFrameN]
+    set rMin := gridRowMin (p₀ :: ps)
+    set rMax := gridRowMax (p₀ :: ps)
+    set cMin := gridColMin (p₀ :: ps)
+    set cMax := gridColMax (p₀ :: ps)
+    set pad := max 2 n
+    set height := (rMax - rMin + 1 + 2 * pad).toNat
+    set width := (cMax - cMin + 1 + 2 * pad).toNat
+    set side := max height width
+    set lvl := MacroCell.ceilLog2 side
+    have hrnn : rMin ≤ rMax := gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    have hpad2 : 2 ≤ pad := by simp [pad]
+    have hheight : 5 ≤ height := by
+      simp only [height]
+      have hnn : 0 ≤ rMax - rMin + 1 := by omega
+      omega
+    have hh : height ≤ side := Nat.le_max_left _ _
+    have h5 : 5 ≤ side := le_trans hheight hh
+    have hspec : side ≤ 2 ^ lvl := MacroCell.ceilLog2_spec side
+    by_contra h2
+    have hlvl1 : lvl ≤ 1 := by omega
+    have hpow : 2 ^ lvl ≤ 2 := by
+      calc 2 ^ lvl ≤ 2 ^ 1 := Nat.pow_le_pow_right (by decide : 0 < 2) hlvl1
+           _ = 2 := by norm_num
+    have hbad : 5 ≤ 2 := le_trans h5 (le_trans hspec hpow)
+    omega
+
+/-- **Re-cadrage : la capture du saut decorrele devient un corollaire du
+    cadre** (grain 1, #11161). Les deux marges de `jumpAt_capture_centered` —
+    gauche `2^(lvl-1) + pad` et droite `3*2^(lvl-1) - pad - B` — couvrent la
+    portee `2^(lvl-2)` sous les seules hypotheses de construction du cadre
+    `gridFrameN` (bbox de cote `B`, rembourrage `pad = max 2 n`, niveau
+    `lvl`). Plus aucune hypothese de capture : le re-cadrage N3 est
+    inconditionnel. -/
+theorem frame_jumpAt_capture_centered (n : Nat) (g : Grid) (hg : g ≠ []) :
+    2 ^ ((gridFrameN n g).2 - 2) ≤ 2 ^ ((gridFrameN n g).2 - 1) + max 2 n ∧
+    2 ^ ((gridFrameN n g).2 - 2) ≤ 3 * 2 ^ ((gridFrameN n g).2 - 1) - max 2 n
+      - max ((gridRowMax g - gridRowMin g + 1).toNat)
+            ((gridColMax g - gridColMin g + 1).toNat) := by
+  exact jumpAt_capture_centered (gridFrameN n g).2
+    (max ((gridRowMax g - gridRowMin g + 1).toNat) ((gridColMax g - gridColMin g + 1).toNat))
+    (max 2 n) (gridFrameN_level_ge_two n g hg) (gridFrameN_frame_invariant n g hg)
+
+/-- Temoin concret : pour le glider a `n = 8`, le re-cadrage capture la
+    portee du saut decorrele — `jumpSizeAt 5 = 2^3 = 8` tient dans les deux
+    marges (gauche `2^4 + 8 = 24`, droite `3*2^4 - 8 - 3 = 37`). -/
+example :
+    let lvl := (gridFrameN 8 [(1,2),(2,3),(3,1),(3,2),(3,3)]).2
+    jumpSizeAt lvl ≤ 2 ^ (lvl - 1) + max 2 8
+    ∧ jumpSizeAt lvl ≤ 3 * 2 ^ (lvl - 1) - max 2 8
+      - max ((gridRowMax [(1,2),(2,3),(3,1),(3,2),(3,3)] - gridRowMin [(1,2),(2,3),(3,1),(3,2),(3,3)] + 1).toNat)
+            ((gridColMax [(1,2),(2,3),(3,1),(3,2),(3,3)] - gridColMin [(1,2),(2,3),(3,1),(3,2),(3,3)] + 1).toNat) := by
+  dsimp [jumpSizeAt]
+  decide
 /-- Le garde decorrele est VIABLE : temoin concret (glider, n = 8) ou
     le niveau du cadre conscient de n est exactement `5`, donc
     `jumpSizeAt 5 = 2^3 = 8 <= 8 = n` — la branche de saut TIRE, contra

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Hashlife_en.lean
@@ -685,6 +685,119 @@ theorem jumpAt_capture_centered (lvl B pad : Nat)
   rw [h1, h2]
   omega
 
+/-- **Reframing invariant (grain 1, #11161).** For a non-empty grid, the
+    bounding box of `g` and the n-aware padding fit inside the frame cell:
+    `B + 2 * max 2 n <= 2 ^ lvl` with
+    `B = max (rMax-rMin+1).toNat (cMax-cMin+1).toNat` and
+    `lvl = (gridFrameN n g).2`. Acquired by construction — `side >= B + 2*pad`
+    via `max height width` + `Nat.le_max_left/right`, and `2^lvl >= side` via
+    `MacroCell.ceilLog2_spec`: this is the `hframe` hypothesis of
+    `jumpAt_capture_centered`, obtained with no capture assumption. -/
+theorem gridFrameN_frame_invariant (n : Nat) (g : Grid) (hg : g ≠ []) :
+    max ((gridRowMax g - gridRowMin g + 1).toNat)
+        ((gridColMax g - gridColMin g + 1).toNat) + 2 * max 2 n
+      ≤ 2 ^ (gridFrameN n g).2 := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    have hrnn : gridRowMin (p₀ :: ps) ≤ gridRowMax (p₀ :: ps) :=
+      gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    have hcnn : gridColMin (p₀ :: ps) ≤ gridColMax (p₀ :: ps) :=
+      gridColMin_le_gridColMax _ (List.cons_ne_nil _ _)
+    simp only [gridFrameN]
+    set rMin := gridRowMin (p₀ :: ps)
+    set rMax := gridRowMax (p₀ :: ps)
+    set cMin := gridColMin (p₀ :: ps)
+    set cMax := gridColMax (p₀ :: ps)
+    set pad := max 2 n
+    set rowSpan := (rMax - rMin + 1).toNat
+    set colSpan := (cMax - cMin + 1).toNat
+    set height := (rMax - rMin + 1 + 2 * pad).toNat
+    set width := (cMax - cMin + 1 + 2 * pad).toNat
+    set side := max height width
+    set lvl := MacroCell.ceilLog2 side
+    have hspec : (2 ^ lvl : Nat) ≥ side := MacroCell.ceilLog2_spec side
+    have hh : height ≤ side := Nat.le_max_left _ _
+    have hw : width ≤ side := Nat.le_max_right _ _
+    have hrow : rowSpan + 2 * pad ≤ height := by
+      simp only [rowSpan, height]
+      have hnn : 0 ≤ rMax - rMin + 1 := by omega
+      omega
+    have hcol : colSpan + 2 * pad ≤ width := by
+      simp only [colSpan, width]
+      have hnn : 0 ≤ cMax - cMin + 1 := by omega
+      omega
+    have hB : max rowSpan colSpan + 2 * pad ≤ side := by
+      by_cases h : rowSpan ≤ colSpan
+      · rw [max_eq_right h]
+        exact le_trans hcol hw
+      · have h' : colSpan ≤ rowSpan := Nat.le_of_not_ge h
+        rw [max_eq_left h']
+        exact le_trans hrow hh
+    simpa [pad] using le_trans hB hspec
+
+/-- The level of the n-aware frame is at least 2 for a non-empty grid: the
+    padding `max 2 n >= 2` and the non-empty bounding box give `height >= 5`,
+    hence `side >= 5`, and `2^lvl >= side >= 5 > 4 = 2^2`, so `lvl >= 2`. This
+    is the `hlvl` of `jumpAt_capture_centered`, acquired by construction. -/
+theorem gridFrameN_level_ge_two (n : Nat) (g : Grid) (hg : g ≠ []) :
+    2 ≤ (gridFrameN n g).2 := by
+  cases g with
+  | nil => exact absurd rfl hg
+  | cons p₀ ps =>
+    simp only [gridFrameN]
+    set rMin := gridRowMin (p₀ :: ps)
+    set rMax := gridRowMax (p₀ :: ps)
+    set cMin := gridColMin (p₀ :: ps)
+    set cMax := gridColMax (p₀ :: ps)
+    set pad := max 2 n
+    set height := (rMax - rMin + 1 + 2 * pad).toNat
+    set width := (cMax - cMin + 1 + 2 * pad).toNat
+    set side := max height width
+    set lvl := MacroCell.ceilLog2 side
+    have hrnn : rMin ≤ rMax := gridRowMin_le_gridRowMax _ (List.cons_ne_nil _ _)
+    have hpad2 : 2 ≤ pad := by simp [pad]
+    have hheight : 5 ≤ height := by
+      simp only [height]
+      have hnn : 0 ≤ rMax - rMin + 1 := by omega
+      omega
+    have hh : height ≤ side := Nat.le_max_left _ _
+    have h5 : 5 ≤ side := le_trans hheight hh
+    have hspec : side ≤ 2 ^ lvl := MacroCell.ceilLog2_spec side
+    by_contra h2
+    have hlvl1 : lvl ≤ 1 := by omega
+    have hpow : 2 ^ lvl ≤ 2 := by
+      calc 2 ^ lvl ≤ 2 ^ 1 := Nat.pow_le_pow_right (by decide : 0 < 2) hlvl1
+           _ = 2 := by norm_num
+    have hbad : 5 ≤ 2 := le_trans h5 (le_trans hspec hpow)
+    omega
+
+/-- **Reframing: the decoupled-jump capture becomes a corollary of the
+    frame** (grain 1, #11161). Both margins of `jumpAt_capture_centered` —
+    left `2^(lvl-1) + pad` and right `3*2^(lvl-1) - pad - B` — cover the range
+    `2^(lvl-2)` under the sole construction hypotheses of the `gridFrameN`
+    frame (bounding box of side `B`, padding `pad = max 2 n`, level `lvl`).
+    No capture hypothesis remains: the N3 reframing is unconditional. -/
+theorem frame_jumpAt_capture_centered (n : Nat) (g : Grid) (hg : g ≠ []) :
+    2 ^ ((gridFrameN n g).2 - 2) ≤ 2 ^ ((gridFrameN n g).2 - 1) + max 2 n ∧
+    2 ^ ((gridFrameN n g).2 - 2) ≤ 3 * 2 ^ ((gridFrameN n g).2 - 1) - max 2 n
+      - max ((gridRowMax g - gridRowMin g + 1).toNat)
+            ((gridColMax g - gridColMin g + 1).toNat) := by
+  exact jumpAt_capture_centered (gridFrameN n g).2
+    (max ((gridRowMax g - gridRowMin g + 1).toNat) ((gridColMax g - gridColMin g + 1).toNat))
+    (max 2 n) (gridFrameN_level_ge_two n g hg) (gridFrameN_frame_invariant n g hg)
+
+/-- Concrete witness: for the glider at `n = 8`, the reframing captures the
+    range of the decoupled jump — `jumpSizeAt 5 = 2^3 = 8` fits both margins
+    (left `2^4 + 8 = 24`, right `3*2^4 - 8 - 3 = 37`). -/
+example :
+    let lvl := (gridFrameN 8 [(1,2),(2,3),(3,1),(3,2),(3,3)]).2
+    jumpSizeAt lvl ≤ 2 ^ (lvl - 1) + max 2 8
+    ∧ jumpSizeAt lvl ≤ 3 * 2 ^ (lvl - 1) - max 2 8
+      - max ((gridRowMax [(1,2),(2,3),(3,1),(3,2),(3,3)] - gridRowMin [(1,2),(2,3),(3,1),(3,2),(3,3)] + 1).toNat)
+            ((gridColMax [(1,2),(2,3),(3,1),(3,2),(3,3)] - gridColMin [(1,2),(2,3),(3,1),(3,2),(3,3)] + 1).toNat) := by
+  dsimp [jumpSizeAt]
+  decide
 /-- The decorrelated guard is VIABLE: concrete witness (glider, n = 8)
     where the n-aware frame's level is exactly `5`, hence
     `jumpSizeAt 5 = 2^3 = 8 <= 8 = n` — the jump branch FIRES, unlike


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA — prev: DEEP/lean #11236

## Re-cadrage Gosper (grain 1 de #11161) : capture du saut décorrélé inconditionnelle

Voir #11161.

### Ce que cette PR ajoute

Trois théorèmes dans `Conway/Life/Hashlife.lean` (+ siblings EN `Hashlife_en.lean`, convention i18n #4980) :

1. **`gridFrameN_frame_invariant`** — la bbox de `g` et le rembourrage conscient de `n` tiennent dans la cellule du cadre : `B + 2 * max 2 n ≤ 2 ^ lvl` où `B = max (rMax-rMin+1).toNat (cMax-cMin+1).toNat`, `lvl = (gridFrameN n g).2`. Acquis **par construction** (side ≥ B+2·pad via `max height width` + `Nat.le_max_left/right` ; `2^lvl ≥ side` via `MacroCell.ceilLog2_spec`) — c'est l'hypothèse `hframe` de `jumpAt_capture_centered`, obtenue sans aucune hypothèse de capture.

2. **`gridFrameN_level_ge_two`** — `2 ≤ (gridFrameN n g).2` pour `g ≠ []` : le rembourrage `pad ≥ 2` et la bbox non vide donnent `height ≥ 5`, donc `side ≥ 5` et `2^lvl ≥ 5 > 4 = 2^2` — c'est le `hlvl` de `jumpAt_capture_centered`, lui aussi par construction.

3. **`frame_jumpAt_capture_centered`** — le corollaire de re-cadrage : `jumpAt_capture_centered lvl B (max 2 n)` appliqué aux deux théorèmes précédents. Les deux marges (gauche `2^(lvl-1)+pad`, droite `3*2^(lvl-1)-pad-B`) couvrent la portée `2^(lvl-2)` du saut décorrélé **pour tout cadre `gridFrameN n g`**, sans hypothèse externe.

Plus un témoin concret (`decide`) : les marges du glider à `n = 8` couvrent la portée `jumpSizeAt 5 = 8`.

### Validation

- `lake build Conway.Life.Hashlife` SUCCESS (worktree, mathlib rev `81a5d257`).
- Compte `sorry` : **0** (grep code-only sur les fichiers modifiés) — aucun `sorry` introduit.
- `check_i18n_siblings.py` : paires FR/EN byte-identiques hors docstrings (EN docstrings traduites).
- Témoin : marges de capture du glider `n = 8` vérifiées par `decide`.

### Arithmétique de marge (récap)

Pour le glider (bbox 3×3), `n = 8` : `lvl = 5`, portée `2^(5-2) = 8` ; marge gauche `2^4 + 8 = 24 ≥ 8` ✓ ; marge droite `3·2^4 - 8 - 3 = 37 ≥ 8` ✓.

### Prochain grain (séparé)

Grain 2 : induction de fuel `evolveHashlifeFastAtAuxN` — ré-instanciation de l'IH à `t + js`, recomposition `evolve_add`, signature inconditionnelle `evolveHashlifeFastAtN n g = evolve n g`. Cette PR pose la brique arithmétique qui le rend possible.
