### PR TITLE
fix(prover,#1453): register gittins_optimality INTRINSIC sorries in HONEST_SORRIES (FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/config.py
@@ -258,6 +258,26 @@ import Conway.Life.MacroCell
 import Conway.Life.Hashlife
 """
 
+# ── Decision theory (Epic #1453) ──
+# decision_theory_lean lives under Probas/ (its own lake), not under
+# GameTheory/ — Gittins is the bandit/optimal-stopping module (#4039).
+_DECISION_THEORY_CANDIDATES = [
+    _workspace_relative("Probas/decision_theory_lean"),
+    Path(r"C:\dev\CoursIA\MyIA.AI.Notebooks\Probas\decision_theory_lean"),
+    Path(r"D:\dev\CoursIA\MyIA.AI.Notebooks\Probas\decision_theory_lean"),
+    Path(r"d:\dev\CoursIA\MyIA.AI.Notebooks\Probas\decision_theory_lean"),
+    Path(r"D:\CoursIA\MyIA.AI.Notebooks\Probas\decision_theory_lean"),
+    Path(r"d:\CoursIA\MyIA.AI.Notebooks\Probas\decision_theory_lean"),
+]
+DECISION_THEORY_DIR = next(
+    (p for p in _DECISION_THEORY_CANDIDATES if p.exists()),
+    _DECISION_THEORY_CANDIDATES[0],
+)
+GITTINS_FILE = DECISION_THEORY_DIR / "Gittins" / "GittinsTheorem.lean" if DECISION_THEORY_DIR.exists() else None
+# i18n sibling (#4980): same theorem, English docstring is a few lines shorter,
+# so the two sorries sit at L99/L103 (vs L104/L108 in the FR canonical).
+GITTINS_FILE_EN = DECISION_THEORY_DIR / "Gittins" / "GittinsTheorem_en.lean" if DECISION_THEORY_DIR.exists() else None
+
 # ── HONEST sorrys registry (DO NOT TOUCH) ──
 # Some sorrys document genuine theoretical impossibility — they are NOT bugs to
 # fix. Attacking them wastes compute and produces fake "PROVED" reports. Each
@@ -282,6 +302,35 @@ HONEST_SORRIES = {
             "wired with Convex/Cone.Dual + PiL2 imports. Targets: hP_conv, hP_closed, "
             "hP_nonempty, hK_empty, hCore. Awaiting multi-agent prover run with "
             "--director-provider openrouter."
+        ),
+    },
+    str(GITTINS_FILE) if GITTINS_FILE else "": {
+        # gittins_optimality at Gittins/GittinsTheorem.lean, INTRINSIC (#4039).
+        # Docstring (L76-98) documents the genuine theoretical barrier: Mathlib
+        # lacks MDP/bandit/Bellman formalizations; a faithful proof needs
+        # ~2000-5000 lines of support definitions. The two sorries are markers
+        # of that barrier, NOT provable targets.
+        104: (
+            "gittins_optimality — V (operator de valeur espere) : exige un type de "
+            "processus de recompense de bandit + couplage probabiliste + somme "
+            "actualisee a horizon infini. INTRINSIC (#4039)."
+        ),
+        108: (
+            "gittins_optimality — preuve d'optimalite : exige operateur de Bellman / "
+            "programmation dynamique / formalisation MDP complete. INTRINSIC (#4039)."
+        ),
+    },
+    str(GITTINS_FILE_EN) if GITTINS_FILE_EN else "": {
+        # gittins_optimality EN sibling (#4980): same INTRINSIC barrier, same
+        # theorem; only the docstring differs (English, a few lines shorter).
+        99: (
+            "gittins_optimality (EN sibling) — V expected-value operator: needs "
+            "bandit reward-process type + probabilistic coupling + infinite-horizon "
+            "discounted sum. INTRINSIC (#4039)."
+        ),
+        103: (
+            "gittins_optimality (EN sibling) — optimality proof: needs Bellman / "
+            "dynamic programming / full MDP formalization. INTRINSIC (#4039)."
         ),
     },
 }

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -1441,6 +1441,28 @@ def test_refuse_intractable_returns_none_for_provable_target(mock_intractable_kb
     assert P._refuse_intractable("X/Voting.lean", 116, "DEMO_X") is None
 
 
+def test_gittins_sorries_registered_static_honest():
+    """gittins_optimality (GittinsTheorem.lean) sorries are INTRINSIC (#4039):
+    the prover must refuse them statically, without relying on the dynamic
+    comment scan (the docstring uses INTRINSIC/barriere markers that
+    _HONEST_SORRY_PATTERNS does not match)."""
+    import prover.provers as P
+    from prover.config import GITTINS_FILE, GITTINS_FILE_EN
+
+    if GITTINS_FILE is None:
+        pytest.skip("GittinsTheorem.lean not resolvable on this machine")
+    # FR canonical at L104/L108, EN sibling (#4980) at L99/L103.
+    for path, line in ((GITTINS_FILE, 104), (GITTINS_FILE, 108),
+                       (GITTINS_FILE_EN, 99), (GITTINS_FILE_EN, 103)):
+        if path is None:
+            continue
+        out = P._refuse_honest_sorry(str(path), line, "gittins_optimality")
+        assert out is not None, f"{path.name} L{line}: expected static HONEST refusal"
+        assert out["skipped"] is True and out["success"] is False
+        assert out["reason"] == "honest_sorry_static"
+        assert out["sorry_line"] == line
+
+
 def test_refuse_intractable_shape_matches_honest_sorry(mock_intractable_kb):
     """The skip dict mirrors _refuse_honest_sorry so callers handle both alike."""
     import prover.provers as P


### PR DESCRIPTION
Grain: MED/research-code — lane myia-po-2026:CoursIA-2 — prev: LIGHT/readme #11250

## Summary

Exécute la demande du triage ai-01 du 2026-07-02 (jamais faite) : enregistrer les deux `sorry` réels de `gittins_optimality` dans le registre statique `HONEST_SORRIES` du harnais prover, pour que le prover **refuse** de les cibler.

**Pourquoi c'est nécessaire maintenant** : le détecteur dynamique `is_honest_sorry()` (lean_utils) retourne **False** sur les deux lignes — vérifié firsthand. Ses patterns regex (FIXME / cannot be proved / unprovable / counter-example...) ne matchent **pas** les marqueurs `INTRINSIC` / « barrière » que la docstring du théorème utilise pour documenter l'impossibilité (GittinsTheorem.lean L76-98). Sans entrée statique, le prover attaquerait une cible INTRACTABLE et brûlerait du compute pour un « PROVED » impossible.

## Ce qui change (2 fichiers, +71 lignes, 0 supprimé)

1. **`prover/config.py`** :
   - `_DECISION_THEORY_CANDIDATES` + `DECISION_THEORY_DIR` + `GITTINS_FILE` / `GITTINS_FILE_EN` — résolution de chemin pour `Probas/decision_theory_lean`, miroir exact du pattern `_COOPERATIVE_GAMES_CANDIDATES` existant (canonical workspace-relative d'abord, fallbacks drive-letters ensuite).
   - Entrées `HONEST_SORRIES` pour **les deux siblings i18n (#4980)** : FR `GittinsTheorem.lean` L104/L108, EN `GittinsTheorem_en.lean` L99/L103 (la docstring anglaise est quelques lignes plus courte — les numéros diffèrent, vérifié firsthand par grep). Raison citée dans chaque entrée : barrière #4039 (Mathlib lacks MDP/bandit/Bellman, preuve estimée ~2000-5000 lignes).
2. **`tests/test_prover_guards.py`** : `test_gittins_sorries_registered_static_honest` — assert que les 4 sites (2 FR + 2 EN) sont refusés avec `reason == "honest_sorry_static"`, `skipped=True`, `sorry_line` correct. Skip propre si le fichier n'est pas résolvable sur la machine.

## Validation

- **Refus vérifié firsthand** (script scratchpad) : `_refuse_honest_sorry()` retourne le dict de refus `honest_sorry_static` pour L104, L108 (FR) et L99, L103 (EN) — bannière REFUSED imprimée pour chacun.
- **Tests** : `python -m pytest tests/ -q` depuis `agent_tests/` = **662 passed** (dont les 197 de test_prover_guards avec le nouveau test).
- **gitleaks** : Passed (pre-commit).
- `git diff --stat` : 2 fichiers, +71/-0 — cohérent avec l'intention.

## B.1/B.2/B.3 (règle Lean)

- **B.1 — compte de sorry** : AUCUN fichier `.lean` modifié. `count_code_sorry.py --json` sur `Probas/decision_theory_lean` : `distinct_code_sorry = 2` avant = après (4 bruts FR+EN, 2 distincts) — inchangé par construction.
- **B.2 — lake build** : N/A, aucun `.lean` touché.
- **B.3 — proof integrity** : N/A, aucun `.lean` touché (le job `lean-axiom` ne mesure pas `agent_tests/prover/*.py`).

## Résiduel signalé (non corrigé, hors scope)

Le même angle mort existe pour les sorries INTRINSIC-markés de `conway_lean` (HashlifeMarginFragment, AdversarialBatteryG2, DecideProbe — cf #9568) : le détecteur dynamique ne les attrape pas non plus. **Pas traité ici** : élargir `_HONEST_SORRY_PATTERNS` à `INTRINSIC`/`INTRACTABLE` changerait le comportement du prover sur des fichiers sous claims actifs d'autres lanes (#6724 epic-wide po-2025). À traiter en grain séparé si ai-01 le mandate.

## Honnêteté G-VAR-1 (plancher)

Grain **MED/research-code (CONTENU)** : le plancher DEEP/MED CONTENU **est tenu** ce cycle — le harnais prover (code de recherche de l'EPIC #1453) change de comportement réel : il refuse désormais 4 sites de sorry précédemment attaquables à tort. Rotation de genre respectée (prev LIGHT/readme → MED/research-code).

See #1453 · See #4039
