### PR TITLE
feat(lean,#2159): Partie 45 — CoversPushforward, forme flèche de l'adjonction pushforward-pullback

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -12,6 +12,7 @@ import Grothendieck.CoversArrow
 import Grothendieck.CoversLattice
 import Grothendieck.CoversOrder
 import Grothendieck.CoversPullback
+import Grothendieck.CoversPushforward
 import Grothendieck.CoversTopologies
 import Grothendieck.DenseTopology
 import Grothendieck.DirectImage

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPushforward.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPushforward.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 45 : forme flèche de l'adjonction pushforward-pullback
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Les parties 1-44 ont établi les fondamentaux : catégories, cribles,
+topologies, lois de treillis, identités de pullback, bases de faisceaux,
+clôture couvrante, calibration, sous-canonicalité, topologies denses,
+faisceaux, hom interne, cohomologie de Čech, limite de Mayer-Vietoris,
+extensions de Kan, adjonctions, monades, équivalences, catégories monoïdales,
+la construction de Grothendieck, l'image directe/exceptionnelle, la forme
+flèche de la couverture, les lois de cohérence du pseudo-foncteur pullback,
+les lois de treillis indexées et la forme flèche des topologies extrémales.
+
+Cette partie applique le fil conducteur « forme flèche » à l'adjonction
+pushforward-pullback des cribles. Mathlib fournit l'adjonction
+`Sieve.galoisConnection (Sieve.pushforward f) (Sieve.pullback f)` avec ses
+unit/counit (`Sieve.le_pushforward_pullback`, `Sieve.pullback_pushforward_le`),
+sa monotonie et ses égalités (`Sieve.pushforward_comp`,
+`Sieve.pushforward_union`), mais aucune loi de la forme flèche `J.Covers` n'y
+est attachée. On fournit ici : la couverture du pushforward d'une couverture
+(`covers_pushforward_of_mem`), la forme flèche de la monotonie, de la
+composition et de l'union, le comportement sur l'identité, et les points
+fixes de l'adjonction — pour `f` mono, `(S.pushforward f).pullback f = S`
+(coinsertion) ; pour `f` split epi, `(R.pullback f).pushforward f = R`
+(insertion) — prouvés par anti-symétrie, et leurs formes flèches.
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.CoversPushforward
+
+open CategoryTheory
+
+/-!
+## Section 1 : l'unité de l'adjonction à la forme flèche
+
+L'unité `Sieve.le_pushforward_pullback` dit `S ≤ (S.pushforward f).pullback f`.
+Avec la propriété de topologie `superset_covering`, une appartenance
+`S ∈ J Y` se transporte donc à la couverture `J.Covers (S.pushforward f) f` :
+le pushforward d'une couverture le long de `f` recouvre `f` lui-même.
+-/
+
+/-- Le pushforward d'une couverture couvre la flèche le long de laquelle on
+    pousse : `S ∈ J Y → J.Covers (S.pushforward f) f`.
+    Preuve : `covers_iff` ramène à `(S.pushforward f).pullback f ∈ J Y`, puis
+    `superset_covering` avec l'unité `Sieve.le_pushforward_pullback`. -/
+theorem covers_pushforward_of_mem {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) (S : Sieve Y) (hS : S ∈ J Y) :
+    J.Covers (S.pushforward f) f := by
+  rw [GrothendieckTopology.covers_iff]
+  exact J.superset_covering (Sieve.le_pushforward_pullback f S) hS
+
+/-!
+## Section 2 : monotonie, composition et union à la forme flèche
+
+`Sieve.pushforward_monotone` et les égalités `Sieve.pushforward_comp` /
+`Sieve.pushforward_union` se traduisent directement en lois de la forme
+flèche : la couverture par un pushforward est monotone en le crible, et
+invariante par les réécritures structurelles de la composition et de l'union.
+-/
+
+/-- La forme flèche est monotone en le crible : `A ≤ B` et `A.pushforward f`
+    couvre `g` impliquent que `B.pushforward f` couvre `g`.
+    Preuve : monotonie du pushforward (`Sieve.pushforward_monotone`), puis
+    monotonie du pullback (`Sieve.pullback_monotone`) et `superset_covering`. -/
+theorem covers_pushforward_monotone {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) {A B : Sieve Y} (hAB : A ≤ B) {Z : C} (g : Z ⟶ X)
+    (h : J.Covers (A.pushforward f) g) :
+    J.Covers (B.pushforward f) g := by
+  rw [GrothendieckTopology.covers_iff] at h ⊢
+  exact J.superset_covering (Sieve.pullback_monotone g (Sieve.pushforward_monotone f hAB)) h
+
+/-- La forme flèche commute avec la composition des pushforwards :
+    `J.Covers (S.pushforward (g ≫ f)) t ↔ J.Covers ((S.pushforward g).pushforward f) t`.
+    Preuve : réécriture de l'égalité `Sieve.pushforward_comp`. -/
+theorem covers_pushforward_comp {C : Type*} [Category C] {X Y Z : C} (J : GrothendieckTopology C)
+    (S : Sieve Z) (f : Y ⟶ X) (g : Z ⟶ Y) {W : C} (t : W ⟶ X) :
+    J.Covers (S.pushforward (g ≫ f)) t ↔ J.Covers ((S.pushforward g).pushforward f) t := by
+  rw [Sieve.pushforward_comp]
+
+/-- La forme flèche distribue sur l'union des cribles :
+    `J.Covers ((S ⊔ R).pushforward f) t ↔ J.Covers (S.pushforward f ⊔ R.pushforward f) t`.
+    Preuve : réécriture de l'égalité `Sieve.pushforward_union`. -/
+theorem covers_pushforward_union {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) (S R : Sieve Y) {Z : C} (t : Z ⟶ X) :
+    J.Covers ((S ⊔ R).pushforward f) t ↔ J.Covers (S.pushforward f ⊔ R.pushforward f) t := by
+  rw [Sieve.pushforward_union]
+
+/-!
+## Section 3 : le pushforward le long de l'identité
+
+Le pushforward le long de `𝟙 X` est l'identité sur les cribles. Mathlib ne
+fournit pas cette identité ; on la prouve par extensionnalité (un crible
+contient `f` si et seulement si `f ≫ 𝟙 X` y appartient). La forme flèche de
+cette identité retombe alors sur l'appartenance ponctuelle.
+-/
+
+/-- Le pushforward le long de l'identité est l'identité : `S.pushforward (𝟙 X) = S`.
+    Preuve : `Sieve.ext` — le membre gauche contient `f` ssi
+    `∃ g, g ≫ 𝟙 X = f ∧ S g`, ce qui est équivalent à `S f`
+    (`Category.comp_id`). -/
+theorem pushforward_id {C : Type*} [Category C] {X : C} (S : Sieve X) :
+    S.pushforward (𝟙 X) = S := by
+  ext Y f
+  constructor
+  · rintro ⟨g, hg, hS⟩
+    rwa [← hg, Category.comp_id]
+  · intro hS
+    exact ⟨f, by simp, hS⟩
+
+/-- La forme flèche du pushforward de l'identité au-dessus de l'identité
+    coïncide avec l'appartenance ponctuelle :
+    `J.Covers (S.pushforward (𝟙 X)) (𝟙 X) ↔ S ∈ J X`.
+    Preuve : `pushforward_id`, puis `covers_iff` et `Sieve.pullback_id`. -/
+theorem covers_pushforward_id {C : Type*} [Category C] {X : C} (J : GrothendieckTopology C)
+    (S : Sieve X) :
+    J.Covers (S.pushforward (𝟙 X)) (𝟙 X) ↔ S ∈ J X := by
+  rw [pushforward_id]
+  rw [GrothendieckTopology.covers_iff, Sieve.pullback_id]
+
+/-!
+## Section 4 : les points fixes de l'adjonction
+
+Mathlib fournit les deux faces de l'adjonction : pour `f` mono,
+`Sieve.galoisCoinsertionOfMono` (coreflective) ; pour `f` split epi,
+`Sieve.galoisInsertionOfIsSplitEpi` (reflective). Les propriétés `u_l_le` et
+`le_l_u` donnent chacune une inégalité ; combinées à l'unité/counit opposées,
+l'anti-symétrie fournit les points fixes exacts, que Mathlib ne donne pas.
+On les prouve ici, puis on en déduit leurs formes flèches.
+-/
+
+/-- Point fixe de la coinsertion : pour `f` mono, `(S.pushforward f).pullback f = S`.
+    Preuve : anti-symétrie entre l'unité `Sieve.le_pushforward_pullback` et
+    la propriété `u_l_le` de `Sieve.galoisCoinsertionOfMono`. -/
+theorem pushforward_pullback_fixed {C : Type*} [Category C] {X Y : C} {f : Y ⟶ X} [Mono f]
+    (S : Sieve Y) :
+    (S.pushforward f).pullback f = S := by
+  exact le_antisymm ((Sieve.galoisCoinsertionOfMono f).u_l_le S)
+    (Sieve.le_pushforward_pullback f S)
+
+/-- Forme flèche du point fixe de la coinsertion : pour `f` mono,
+    `J.Covers (S.pushforward f) f ↔ J.Covers S (𝟙 Y)`.
+    Preuve : `covers_iff` des deux côtés, `Sieve.pullback_id`, puis le point
+    fixe `pushforward_pullback_fixed`. -/
+theorem covers_pushforward_fixed_mono {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    {f : Y ⟶ X} [Mono f] (S : Sieve Y) :
+    J.Covers (S.pushforward f) f ↔ J.Covers S (𝟙 Y) := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff, Sieve.pullback_id]
+  rw [pushforward_pullback_fixed S]
+
+/-- Point fixe de l'insertion : pour `f` split epi, `(R.pullback f).pushforward f = R`.
+    Preuve : anti-symétrie entre la counit `Sieve.pullback_pushforward_le` et
+    la propriété `le_l_u` de `Sieve.galoisInsertionOfIsSplitEpi`. -/
+theorem pullback_pushforward_fixed {C : Type*} [Category C] {X Y : C} {f : Y ⟶ X} [IsSplitEpi f]
+    (R : Sieve X) :
+    (R.pullback f).pushforward f = R := by
+  exact le_antisymm (Sieve.pullback_pushforward_le f R)
+    ((Sieve.galoisInsertionOfIsSplitEpi f).le_l_u R)
+
+end Grothendieck.CoversPushforward

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPushforward_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPushforward_en.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Part 45 : arrow form of the pushforward-pullback adjunction
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Parts 1-44 established the foundations: categories, sieves, topologies,
+lattice laws, pullback identities, sheaf bases, covering closure,
+calibration, subcanonicity, dense topologies, sheaves, internal hom,
+Čech cohomology, Mayer-Vietoris limit, Kan extensions, adjunctions, monads,
+equivalences, monoidal categories, the Grothendieck construction, the
+direct/exceptional image, the arrow form of the covering, the coherence
+laws of the pullback pseudo-functor, the indexed lattice laws and the arrow
+form of the extremal topologies.
+
+This part applies the guiding thread "arrow form" to the pushforward-pullback
+adjunction of sieves. Mathlib provides the adjunction
+`Sieve.galoisConnection (Sieve.pushforward f) (Sieve.pullback f)` with its
+unit/counit (`Sieve.le_pushforward_pullback`, `Sieve.pullback_pushforward_le`),
+its monotonicity and its equalities (`Sieve.pushforward_comp`,
+`Sieve.pushforward_union`), but no law of the arrow form `J.Covers` is
+attached to it. Here we provide: the covering of the pushforward of a
+covering (`covers_pushforward_of_mem`), the arrow form of the monotonicity,
+of the composition and of the union, the behaviour at the identity, and the
+fixed points of the adjunction — for `f` mono, `(S.pushforward f).pullback f = S`
+(coinsertion) ; for `f` split epi, `(R.pullback f).pushforward f = R`
+(insertion) — proved by antisymmetry, and their arrow forms.
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.CoversPushforward_en
+
+open CategoryTheory
+
+/-!
+## Section 1 : the unit of the adjunction in arrow form
+
+The unit `Sieve.le_pushforward_pullback` says `S ≤ (S.pushforward f).pullback f`.
+With the topology property `superset_covering`, a membership
+`S ∈ J Y` therefore transports to the covering `J.Covers (S.pushforward f) f`:
+the pushforward of a covering along `f` covers `f` itself.
+-/
+
+/-- The pushforward of a covering covers the arrow along which we push:
+    `S ∈ J Y → J.Covers (S.pushforward f) f`.
+    Proof: `covers_iff` reduces to `(S.pushforward f).pullback f ∈ J Y`, then
+    `superset_covering` with the unit `Sieve.le_pushforward_pullback`. -/
+theorem covers_pushforward_of_mem {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) (S : Sieve Y) (hS : S ∈ J Y) :
+    J.Covers (S.pushforward f) f := by
+  rw [GrothendieckTopology.covers_iff]
+  exact J.superset_covering (Sieve.le_pushforward_pullback f S) hS
+
+/-!
+## Section 2 : monotonicity, composition and union in arrow form
+
+`Sieve.pushforward_monotone` and the equalities `Sieve.pushforward_comp` /
+`Sieve.pushforward_union` translate directly into laws of the arrow form:
+the covering by a pushforward is monotone in the sieve, and invariant under
+the structural rewrites of composition and union.
+-/
+
+/-- The arrow form is monotone in the sieve: if `A ≤ B` and `A.pushforward f`
+    covers `g`, then `B.pushforward f` covers `g`.
+    Proof: monotonicity of the pushforward (`Sieve.pushforward_monotone`), then
+    monotonicity of the pullback (`Sieve.pullback_monotone`) and `superset_covering`. -/
+theorem covers_pushforward_monotone {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) {A B : Sieve Y} (hAB : A ≤ B) {Z : C} (g : Z ⟶ X)
+    (h : J.Covers (A.pushforward f) g) :
+    J.Covers (B.pushforward f) g := by
+  rw [GrothendieckTopology.covers_iff] at h ⊢
+  exact J.superset_covering (Sieve.pullback_monotone g (Sieve.pushforward_monotone f hAB)) h
+
+/-- The arrow form commutes with the composition of pushforwards:
+    `J.Covers (S.pushforward (g ≫ f)) t ↔ J.Covers ((S.pushforward g).pushforward f) t`.
+    Proof: rewrite of the equality `Sieve.pushforward_comp`. -/
+theorem covers_pushforward_comp {C : Type*} [Category C] {X Y Z : C} (J : GrothendieckTopology C)
+    (S : Sieve Z) (f : Y ⟶ X) (g : Z ⟶ Y) {W : C} (t : W ⟶ X) :
+    J.Covers (S.pushforward (g ≫ f)) t ↔ J.Covers ((S.pushforward g).pushforward f) t := by
+  rw [Sieve.pushforward_comp]
+
+/-- The arrow form distributes over the union of sieves:
+    `J.Covers ((S ⊔ R).pushforward f) t ↔ J.Covers (S.pushforward f ⊔ R.pushforward f) t`.
+    Proof: rewrite of the equality `Sieve.pushforward_union`. -/
+theorem covers_pushforward_union {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (f : Y ⟶ X) (S R : Sieve Y) {Z : C} (t : Z ⟶ X) :
+    J.Covers ((S ⊔ R).pushforward f) t ↔ J.Covers (S.pushforward f ⊔ R.pushforward f) t := by
+  rw [Sieve.pushforward_union]
+
+/-!
+## Section 3 : the pushforward along the identity
+
+The pushforward along `𝟙 X` is the identity on sieves. Mathlib does not
+provide this identity; we prove it by extensionality (a sieve contains `f`
+if and only if `f ≫ 𝟙 X` belongs to it). The arrow form of this identity then
+falls back exactly on the pointwise membership.
+-/
+
+/-- The pushforward along the identity is the identity: `S.pushforward (𝟙 X) = S`.
+    Proof: `Sieve.ext` — the left member contains `f` iff
+    `∃ g, g ≫ 𝟙 X = f ∧ S g`, which is equivalent to `S f`
+    (`Category.comp_id`). -/
+theorem pushforward_id {C : Type*} [Category C] {X : C} (S : Sieve X) :
+    S.pushforward (𝟙 X) = S := by
+  ext Y f
+  constructor
+  · rintro ⟨g, hg, hS⟩
+    rwa [← hg, Category.comp_id]
+  · intro hS
+    exact ⟨f, by simp, hS⟩
+
+/-- The arrow form of the pushforward of the identity above the identity
+    coincides with the pointwise membership:
+    `J.Covers (S.pushforward (𝟙 X)) (𝟙 X) ↔ S ∈ J X`.
+    Proof: `pushforward_id`, then `covers_iff` and `Sieve.pullback_id`. -/
+theorem covers_pushforward_id {C : Type*} [Category C] {X : C} (J : GrothendieckTopology C)
+    (S : Sieve X) :
+    J.Covers (S.pushforward (𝟙 X)) (𝟙 X) ↔ S ∈ J X := by
+  rw [pushforward_id]
+  rw [GrothendieckTopology.covers_iff, Sieve.pullback_id]
+
+/-!
+## Section 4 : the fixed points of the adjunction
+
+Mathlib provides the two faces of the adjunction: for `f` mono,
+`Sieve.galoisCoinsertionOfMono` (coreflective); for `f` split epi,
+`Sieve.galoisInsertionOfIsSplitEpi` (reflective). The properties `u_l_le` and
+`le_l_u` each give an inequality; combined with the opposite unit/counit,
+antisymmetry provides the exact fixed points, which Mathlib does not give.
+We prove them here, then derive their arrow forms.
+-/
+
+/-- Fixed point of the coinsertion: for `f` mono, `(S.pushforward f).pullback f = S`.
+    Proof: antisymmetry between the unit `Sieve.le_pushforward_pullback` and
+    the property `u_l_le` of `Sieve.galoisCoinsertionOfMono`. -/
+theorem pushforward_pullback_fixed {C : Type*} [Category C] {X Y : C} {f : Y ⟶ X} [Mono f]
+    (S : Sieve Y) :
+    (S.pushforward f).pullback f = S := by
+  exact le_antisymm ((Sieve.galoisCoinsertionOfMono f).u_l_le S)
+    (Sieve.le_pushforward_pullback f S)
+
+/-- Arrow form of the fixed point of the coinsertion: for `f` mono,
+    `J.Covers (S.pushforward f) f ↔ J.Covers S (𝟙 Y)`.
+    Proof: `covers_iff` on both sides, `Sieve.pullback_id`, then the fixed
+    point `pushforward_pullback_fixed`. -/
+theorem covers_pushforward_fixed_mono {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    {f : Y ⟶ X} [Mono f] (S : Sieve Y) :
+    J.Covers (S.pushforward f) f ↔ J.Covers S (𝟙 Y) := by
+  rw [GrothendieckTopology.covers_iff, GrothendieckTopology.covers_iff, Sieve.pullback_id]
+  rw [pushforward_pullback_fixed S]
+
+/-- Fixed point of the insertion: for `f` split epi, `(R.pullback f).pushforward f = R`.
+    Proof: antisymmetry between the counit `Sieve.pullback_pushforward_le` and
+    the property `le_l_u` of `Sieve.galoisInsertionOfIsSplitEpi`. -/
+theorem pullback_pushforward_fixed {C : Type*} [Category C] {X Y : C} {f : Y ⟶ X} [IsSplitEpi f]
+    (R : Sieve X) :
+    (R.pullback f).pushforward f = R := by
+  exact le_antisymm (Sieve.pullback_pushforward_le f R)
+    ((Sieve.galoisInsertionOfIsSplitEpi f).le_l_u R)
+
+end Grothendieck.CoversPushforward_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #11244

## Summary

**Partie 45 de l'Epic #2159** : `Grothendieck.CoversPushforward` — la forme flèche `J.Covers` de l'**adjonction pushforward-pullback** des cribles.

Gap vérifié : Mathlib fournit l'adjonction `Sieve.galoisConnection (Sieve.pushforward f) (Sieve.pullback f)` (unit/counit `le_pushforward_pullback` / `pullback_pushforward_le`, monotonie, égalités `pushforward_comp` / `pushforward_union`, `GaloisCoinsertion` mono / `GaloisInsertion` split epi) mais **aucune loi de la forme flèche `J.Covers`** n'y est attachée (grep Mathlib : 0). On comble le trou avec 9 théorèmes propres, 0 sorry, aucun re-export :

1. **`covers_pushforward_of_mem`** : `S ∈ J Y → J.Covers (S.pushforward f) f` — le pushforward d'une couverture couvre la flèche de push (unité de l'adjonction + `superset_covering`).
2. **`covers_pushforward_monotone`** : `A ≤ B → J.Covers (A.pushforward f) g → J.Covers (B.pushforward f) g` — monotonie de la forme flèche (`pushforward_monotone` + `pullback_monotone` + `superset_covering`).
3. **`covers_pushforward_comp`** : `J.Covers (S.pushforward (g ≫ f)) t ↔ J.Covers ((S.pushforward g).pushforward f) t` — commutation avec la composition (`Sieve.pushforward_comp`).
4. **`covers_pushforward_union`** : `J.Covers ((S ⊔ R).pushforward f) t ↔ J.Covers (S.pushforward f ⊔ R.pushforward f) t` — distribution sur l'union (`Sieve.pushforward_union`).
5. **`pushforward_id`** (inédit Mathlib) : `S.pushforward (𝟙 X) = S` — identité du pushforward le long de `𝟙 X`, prouvée par `Sieve.ext`.
6. **`covers_pushforward_id`** : `J.Covers (S.pushforward (𝟙 X)) (𝟙 X) ↔ S ∈ J X` — la forme flèche de l'identité retombe sur l'appartenance ponctuelle.
7. **`pushforward_pullback_fixed`** : `[Mono f] → (S.pushforward f).pullback f = S` — point fixe de la coinsertion, prouvé par **anti-symétrie** entre l'unité et la propriété `u_l_le` de `Sieve.galoisCoinsertionOfMono` (Mathlib ne donne que l'inégalité).
8. **`covers_pushforward_fixed_mono`** : `[Mono f] → J.Covers (S.pushforward f) f ↔ J.Covers S (𝟙 Y)` — la forme flèche du point fixe mono.
9. **`pullback_pushforward_fixed`** : `[IsSplitEpi f] → (R.pullback f).pushforward f = R` — point fixe de l'insertion, prouvé par anti-symétrie entre la counit et `le_l_u` de `Sieve.galoisInsertionOfIsSplitEpi`.

Les points fixes 7 et 9 sont la substance : Mathlib fournit les deux faces de l'adjonction (`GaloisCoinsertion` mono / `GaloisInsertion` split epi) avec des propriétés **d'inégalité** (`u_l_le` / `le_l_u`) ; l'anti-symétrie avec les unit/counit opposées donne les égalités exactes, absentes de Mathlib.

## Acceptation (#2159)

- [x] `lake build Grothendieck` → `Build completed successfully (2843 jobs)` — log collé ci-dessous.
- [x] sorry avant/après : `distinct_code_sorry` = 0 pour tout le lake avant ET après (nouveaux théorèmes propres, aucun re-export).
- [x] Anti-régression : aucun fichier existant modifié hors agrégateur `Grothendieck.lean` (+1 import, ordre alphabétique).
- [x] i18n (#4980 Pattern A) : `check_i18n_siblings.py` → paire `CoversPushforward` byte-identique (FR/EN), 0 drift, 0 orphan.

## Files

- `MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPushforward.lean` — Partie 45 FR (9 théorèmes propres)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversPushforward_en.lean` — twin EN byte-identique (i18n Pattern A)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean` — agrégateur : +1 import (ordre alphabétique)

## Validation

`lake build Grothendieck` → `Build completed successfully (2843 jobs)` (log : base e0b3fe03f, cache AZ).

See #2159
