### PR TITLE
feat(qc,#11224): tranche 4 - QC-Py-26 densite 820->1223 (7 interps ancrees)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -220,6 +220,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6e284a3f",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : le mode simule\n",
+    "\n",
+    "L'output confirme qu'aucune cle API n'est presente dans l'environnement (`OpenAI Key: Non configuree`, `Anthropic Key: Non configuree`) : toutes les analyses qui suivent s'executent en **mode simule**. C'est un choix pedagogique assumé -- le `LLMClient` construit plus bas remplace l'appel API par un analyseur lexical (comptage de mots positifs/negatifs), ce qui garantit un notebook reproductible sans compte OpenAI ni Anthropic, et sans consommer de budget. Les deux modeles configurés illustrent une decision de repartition des couts : `gpt-4o-mini` pour les analyses de routine en volume, `claude-3-5-sonnet-20241022` pour le raisonnement structuré de la Partie 4. La temperature par defaut de 0.3 est volontairement basse : en trading, on prefere un signal stable et repetable a une reponse creative -- chaque appel sur la meme news doit renvoyer le meme sentiment, sinon le backtest n'a aucun sens."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -337,6 +347,16 @@
     "print(tracker.report('gpt-4o-mini'))"
    ],
    "id": "cell-8f196758"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf4c59a7",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : l'ordre de grandeur des couts\n",
+    "\n",
+    "Dix analyses (5 000 tokens d'entree, 2 000 de sortie) coutent **$0.0019** avec `gpt-4o-mini` -- moins d'un cinquieme de centime de dollar. Extrapole au rythme de la Partie 1 (500 analyses par jour), la depense journaliere reste sous les $0.10, tres loin sous le plafond de $5.00 pose dans la demonstration (il reste $4.9981 dans le tracker). La lecon n'est pas « les LLM sont gratuits » mais « le choix du modele gouverne la viabilite » : au tarif du tableau ci-dessus, le meme volume sur `claude-3-5-sonnet-20241022` couterait environ vingt fois plus cher en entree, et une strategie multi-actifs haute frequence bascule alors de « negligeable » a « poste de cout a piloter ». En production, le `CostTracker` joue le role de disjoncteur : `within_budget()` coupe les appels API avant que la journee ne derive, avec repli sur le signal technique seul."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -603,6 +623,16 @@
     "print(example_prompt[:500] + \"...\")"
    ],
    "id": "cell-dad153f2"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31f5533f",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : anatomie d'un prompt de trading\n",
+    "\n",
+    "Le prompt `SENTIMENT_ANALYSIS` formate pour AAPL pese **757 caracteres**, soit de l'ordre de 190 tokens -- l'essentiel du cout d'une analyse vient du prompt, pas de la reponse. La structure est le vrai contenu pedagogique : un **role** (analyste quantitatif senior en hedge fund), des **regles de pondération** (faits a impact sur 1 a 5 jours, information recente plus lourde), et surtout un **format de sortie JSON contraint** (`sentiment`, `confidence`, `key_factors`, `price_impact`, `time_horizon`). Ce format n'est pas cosmetique : il rend la reponse machine-parseable sans expression reguliere fragile, et le champ `confidence` alimente directement la ponderation de l'agregateur de la Partie 3. Un prompt sans format impose produirait de la prose a re-parser -- source numero un de bugs en production."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -984,6 +1014,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6be14a0a",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : pourquoi 0.61 et non 0.53 ?\n",
+    "\n",
+    "Trois news analysees : deux BULLISH (signal 0.80 chacune) et une NEUTRAL (0.00). Une moyenne arithmetique naive donnerait (0.80 + 0.00 + 0.80) / 3 = 0.53. L'agregateur renvoie **0.61** parce qu'il pondere chaque signal par sa confiance : (0.80 x 0.80 + 0.00 x 0.50 + 0.80 x 0.80) / (0.80 + 0.50 + 0.80) = 1.28 / 2.10, soit environ 0.61. La news NEUTRALE participe quand meme au denominateur -- elle dilue le signal sans le renverser, ce qui est exactement le comportement voulu : une absence d'information ne doit pas compter comme une information negative, mais elle doit reduire la conviction d'ensemble. La confiance moyenne de 0.70 servira de poids au signal LLM dans la fusion hybride de la Partie 5. Noter enfin la mention `source: simulated` sur chaque resultat : ces scores viennent du fallback lexical, pas d'un reel appel GPT-4 -- le pipeline est juste, les scores eux-memes restent demonstratifs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-c6cf3fd7",
    "metadata": {},
    "source": [
@@ -1241,6 +1281,16 @@
     "    print(f\"\\nResultat brut: {json.dumps(cot_result, indent=2)[:500]}...\")"
    ],
    "id": "cell-f6dfba9f"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "816abd81",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : la limite du fallback simule\n",
+    "\n",
+    "L'output est revelateur : le prompt `COT_PROMPT` demande explicitement cinq `reasoning_steps` structures et un bloc `final_decision`, mais la reponse affichee sous « Resultat brut » ne contient **aucun** de ces champs -- juste un sentiment BULLISH a 0.9 avec des `simulated_factor_1` et `simulated_factor_2` generiques. Ce n'est pas un bug : c'est la signature du mode simule. Le fallback lexical du `LLMClient` ne « raisonne » pas, il compte des mots positifs/negatifs -- il renvoie donc toujours le meme gabarit quel que soit le prompt. On voit ici precisement ce que le chain-of-thought apporte et pourquoi il faut une cle API pour l'observer : derouler faits, contexte de marche, setup technique, risques puis decision est la valeur ajoutee du modele reel (Wei et al. 2022, ancre savante ci-dessus). En production, la robustesse exigerait de **rejeter** une reponse sans `final_decision` plutot que de l'accepter silencieusement."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1523,6 +1573,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "47ac0b4e",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : decomposer la fusion 0.52\n",
+    "\n",
+    "Le signal fusionne se calcule en trois gestes, tous verifiables dans l'output. **(1) Ponderation de base** : 0.4 x 0.61 x 0.70 (cote LLM) + 0.4 x 0.58 x 1.00 (cote technique) = 0.171 + 0.232 = 0.403. **(2) Bonus d'accord** : les deux signaux sont haussiers, le systeme ajoute 0.2 x min(0.61, 0.58), soit +0.116 -- total 0.519, arrondi **0.52**. **(3) Seuil de decision** : 0.52 > 0.3, la direction est BUY. La confiance technique de 1.00 merite un arret : elle signifie que tous les indicateurs disponibles (tendance SMA en ordre haussier, RSI a 62 cote hausse, histogramme MACD positif) pointent dans le meme sens -- c'est la formule d'accord interne de `compute_technical_signal`. Enfin le dimensionnement : tanh(0.52 x 0.85 x 2) x 0.5 donne **35.4%** du portefeuille, ou la valeur 0.85 est la confiance moyenne (0.70 + 1.00) / 2. La tangente hyperbolique ecrase volontairement les positions extremes (plafond 50%) : un signal deux fois plus fort ne doublerait pas la position."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 3.1 : Impact du desaccord entre signaux LLM et techniques\n\nAnalysez l'impact sur le **position sizing** quand le signal LLM et le signal technique sont en desaccord (ex: LLM bullish mais RSI en surachat).\n\n**Indices** :\n- `# Indice` : Simulez 10 scénarios de desaccord avec différentes combinaisons de signaux\n- `# Étape 1` : Créer une liste de scénarios (LLM bullish/bearish) x (technique bullish/bearish)\n- `# Étape 2` : Définir une règle de position sizing pour chaque cas\n- `# Étape 3` : Afficher un tableau recapitulatif des tailles de position"
@@ -1686,6 +1746,16 @@
     "visualize_hybrid_signals(demo_signals)"
    ],
    "id": "cell-54aa8a87"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c02ed42e",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : le scatter de desaccord est le panneau decisif\n",
+    "\n",
+    "Parmi les quatre panneaux, c'est le nuage « Signal Agreement » (en bas a droite) qui porte la lecon : chaque actif y est place selon son signal LLM (abscisse) et son signal technique (ordonnee), et le quadrant raconte la decision. Les quatre scenarios simules en entree de la cellule se lisent ainsi : AAPL (LLM +0.6, technique haussier : prix 185 au-dessus des SMA 20/50 en ordre croissant) et AMZN (LLM +0.5, SMA en ordre haussier) tombent en quadrant concordant +/+ -- la fusion y ajoute le bonus d'accord. GOOGL est le cas interessant : son LLM est le seul bearish du lot (-0.3) tandis que son prix (140) est sous la SMA 50 (142) avec un RSI de 48 -- des indicateurs sans tendance franche, donc un quadrant de desaccord ou le systeme applique le facteur de reduction 0.7. AMZN illustre un autre piege : LLM haussier mais RSI a 72, en surachat -- l'accord des signaux masque un risque de retracement immediat. Le panneau des tailles de position (bas gauche) colore ces verdicts en vert/rouge/gris : la hauteur des barres est la traduction financiere du scatter."
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/tooling #11233

## Summary

Tranche 4 de l'EPIC #11224 (pedagogy-density QC-Py < 1200) : enrichissement **markdown-only** de `QC-Py-26-LLM-Trading-Signals.ipynb`, densité **820 → 1223** (seuil 1200).

7 cellules d'interprétation insérées, **chacune ancrée immédiatement après la cellule de code dont l'output contient la valeur citée** (règle cell-interpretation-ordering, épisode #10678) :

| # | Ancre (cellule code) | Valeurs ancrées dans son output |
|---|---|---|
| 1 | `LLMConfig` | `OpenAI Key: Non configuree`, `gpt-4o-mini`, `claude-3-5-sonnet-20241022` |
| 2 | `CostTracker` | `$0.0019`, 10 requêtes, 5 000/2 000 tokens, `$4.9981` restant |
| 3 | `TradingPrompts` | prompt formaté `757 caracteres` |
| 4 | `NewsSentimentAnalyzer` | 0.80/0.50/0.80, agrégat **0.61** vs moyenne naïve 0.53 (décomposition 1.28/2.10), confiance 0.70 |
| 5 | `ChainOfThoughtAnalyzer` | `Resultat brut` BULLISH 0.9 SANS `reasoning_steps` = signature du fallback simulé |
| 6 | `HybridSignalSystem` | fusion décomposée : 0.171+0.232 = 0.403, bonus +0.116 → **0.52**, BUY, position **35.4%** (tanh(0.884)×0.5) |
| 7 | `visualize_hybrid_signals` | lecture du scatter Agreement sur les 4 scénarios d'entrée (AAPL/MSFT/GOOGL/AMZN), GOOGL seul quadrant de désaccord |

## Validation (exécutée sur le livrable)

- `pedagogy_density.py --paths … --json` : **density 1223** (`status: ok`, 0 below_threshold), prose 13 953 → **20 796** chars, **17 code cells inchangées**, md 21 → 28
- `scan_cell_ordering.py` : **1 scanned, 1 clean, 0 finding** (pas d'INTERP_BEFORE_CODE, pas de doublon consécutif #10488)
- `git diff` : **70 insertions, 0 suppressions** ; `0` ligne `outputs`/`execution_count` touchée (markdown-only → dispensé de re-exécution C.3)
- Ancrage vérifié par script : 7/7 cellules insérées précèdées de leur ancre code exacte (par id), aucune paire d'interps consécutives
- Pre-commit H.3 : Passed

## Scope

- Une seule tranche, un seul notebook, claim paths-scoped sur #11224 (commentaire 5307114543) : `QC-Py-26-LLM-Trading-Signals.ipynb` — disjoint des claims po-2026 (41/40/12b)
- Catalogue byte-identique à main (aucun fichier catalogue touché)
- Aucune cellule code modifiée, aucun exercice touché, aucune valeur seedée modifiée (C.5 : GARDER)

See #11224 (tranche partielle — résiduel ~17 notebooks sous seuil après cette tranche)

Généré avec Claude Code (myia-po-2024:CoursIA)
