### PR TITLE
feat(guard,#11278): detect_papermill_path_leak classe C - chemins absolus non-PII (opt-in advisory)

### DIFF
--- a/scripts/notebook_tools/detect_papermill_path_leak.py
+++ b/scripts/notebook_tools/detect_papermill_path_leak.py
@@ -175,8 +175,55 @@ LEAK_PATTERNS: tuple[re.Pattern[str], ...] = (
     """),
 )
 
+# --- Defect class C — non-PII absolute filesystem paths (advisory, opt-in) ---
+#
+# ``LEAK_PATTERNS`` (class B) anchors on *home/identity* markers; a
+# contributor-machine path outside any home directory — typically a git
+# worktree like ``D:\Dev\CoursIA-0411-audiobooks\...`` or
+# ``C:\dev\CoursIA-8892-infer6ep\...`` — is therefore invisible to both this
+# detector and the ``strip_machine_paths.py`` pre-commit hook (same PII
+# anchor). Founding case: PR #11234 merged
+# ``Output directory: D:\Dev\CoursIA-0411-audiobooks\...`` into
+# ``04-11-Generation-TTS.ipynb`` outputs (#11044 T1 correction, issue #11278).
+#
+# Class C is **advisory and opt-in** (``--nonpii``): it routes to a
+# *source fix + re-execution* (print the basename, not the absolute path —
+# secrets-hygiene rule 6, triage C), never to an automated strip.
+#
+# Remote-execution environment prefixes: these absolute paths are the
+# signature of the *distant* runtime (QC Cloud LEAN images), not of the
+# contributor's machine — allowlisted, not a leak.
+REMOTE_ENV_PREFIXES: tuple[str, ...] = (
+    "/opt/miniconda3",
+    "/opt/conda",
+    "/usr/local/lib/python",
+    "/League",
+)
 
-def _scan_output_text(nb: dict) -> list[dict]:
+NONPII_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Windows drive path outside any user profile: two-plus segments so a
+    # bare ``C:\`` in an error template does not fire. ``Users`` and
+    # ``Windows`` are excluded — both stay class-B-only (no double count).
+    re.compile(r"""(?xi)
+        [A-Za-z]: [\\/] (?! (?: Users | Windows ) [\\/])
+        [A-Za-z0-9_.\-]+ [\\/] [^"'<>\s]{2,64}
+    """),
+    # Unix filesystem roots outside /home (excluded above) and outside URLs
+    # (the ``(?<![:\w/])`` look-behind rejects the ``//host/...`` tail of
+    # ``https://...``).
+    re.compile(r"""(?xi)
+        (?<![:\w/]) / (?:mnt|media|srv|opt|data|workspace) / [A-Za-z0-9_.\-]{2,} [\\/] [^"'<>\s]{2,64}
+    """),
+)
+
+NONPII_KIND = "output_text_abs_path_nonpii"
+NONPII_REMEDIATION = (
+    "print a basename/relative path in the cell source and re-execute "
+    "(Stop & Repair) — never hand-edit the committed output"
+)
+
+
+def _scan_output_text(nb: dict, *, include_nonpii: bool = False) -> list[dict]:
     """Walk ``cells[*].outputs[*].text`` and ``data['text/plain']`` for leaks.
 
     Skips image and HTML data. ``stream`` (stderr) and ``display_data`` with
@@ -199,20 +246,23 @@ def _scan_output_text(nb: dict) -> list[dict]:
             # longer streams (one element per line break); handle both.
             text = out.get("text")
             if isinstance(text, str):
-                _collect_leaks(defects, ci, oi, "stream.text", text)
+                _collect_leaks(defects, ci, oi, "stream.text", text,
+                               include_nonpii=include_nonpii)
             elif isinstance(text, list):
                 for li, piece in enumerate(text):
                     if isinstance(piece, str):
                         _collect_leaks(
                             defects, ci, oi,
                             f"stream.text[{li}]", piece,
+                            include_nonpii=include_nonpii,
                         )
             # Channel 2: display_data / execute_result with text/plain
             data = out.get("data")
             if isinstance(data, dict):
                 tp = data.get("text/plain")
                 if isinstance(tp, str):
-                    _collect_leaks(defects, ci, oi, "data['text/plain']", tp)
+                    _collect_leaks(defects, ci, oi, "data['text/plain']", tp,
+                                   include_nonpii=include_nonpii)
                 elif isinstance(tp, list):
                     # nbformat sometimes wraps long text in a list of strings
                     for li, piece in enumerate(tp):
@@ -220,6 +270,7 @@ def _scan_output_text(nb: dict) -> list[dict]:
                             _collect_leaks(
                                 defects, ci, oi,
                                 f"data['text/plain'][{li}]", piece,
+                                include_nonpii=include_nonpii,
                             )
     return defects
 
@@ -230,6 +281,8 @@ def _collect_leaks(
     output_idx: int,
     location: str,
     text: str,
+    *,
+    include_nonpii: bool = False,
 ) -> None:
     """Append a defect for each regex match in ``text``."""
     for pat in LEAK_PATTERNS:
@@ -240,6 +293,19 @@ def _collect_leaks(
                 "match": m.group(0),
                 "severity": "medium",
             })
+    if include_nonpii:
+        for pat in NONPII_PATTERNS:
+            for m in pat.finditer(text):
+                frag = m.group(0)
+                if frag.startswith(REMOTE_ENV_PREFIXES):
+                    continue
+                defects.append({
+                    "kind": NONPII_KIND,
+                    "location": f"cells[{cell_idx}].outputs[{output_idx}].{location}",
+                    "match": frag,
+                    "severity": "low",
+                    "remed": NONPII_REMEDIATION,
+                })
 
 
 # --- Scanner glue ---
@@ -269,7 +335,12 @@ def iter_notebooks(root: Path) -> list[Path]:
     return list(_walk_notebooks(root))
 
 
-def scan_notebook(nb_path: Path, *, include_outputs: bool = False) -> list[dict]:
+def scan_notebook(
+    nb_path: Path,
+    *,
+    include_outputs: bool = False,
+    include_nonpii: bool = False,
+) -> list[dict]:
     """Return the defects list for a single notebook."""
     nb = _read_notebook(nb_path)
     if nb is None:
@@ -281,7 +352,7 @@ def scan_notebook(nb_path: Path, *, include_outputs: bool = False) -> list[dict]
         }]
     defects = _scan_metadata_papermill(nb)
     if include_outputs:
-        defects.extend(_scan_output_text(nb))
+        defects.extend(_scan_output_text(nb, include_nonpii=include_nonpii))
     return defects
 
 
@@ -289,6 +360,7 @@ def scan_tree(
     root: Path,
     *,
     include_outputs: bool = False,
+    include_nonpii: bool = False,
 ) -> list[dict]:
     """Scan every notebook under ``root``; return a flat defects report.
 
@@ -302,7 +374,11 @@ def scan_tree(
             rel = str(nb_path.relative_to(root))
         except ValueError:
             rel = str(nb_path)
-        for d in scan_notebook(nb_path, include_outputs=include_outputs):
+        for d in scan_notebook(
+            nb_path,
+            include_outputs=include_outputs,
+            include_nonpii=include_nonpii,
+        ):
             d_with_file = {"file": rel, **d}
             report.append(d_with_file)
     return report
@@ -333,6 +409,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
              "Off by default — class B can be noisy on first scan.",
     )
     p.add_argument(
+        "--nonpii", action="store_true",
+        help="Advisory class C: also flag non-PII absolute filesystem paths "
+             "in output text (worktrees like D:\\Dev\\CoursIA-*, issue #11278). "
+             "Implies --outputs — class C lives in output text. Routes to a "
+             "source fix + re-exec, never to an automated strip.",
+    )
+    p.add_argument(
         "--check", action="store_true",
         help="CI gate: exit 1 if any defect is found, suppress JSON.",
     )
@@ -349,14 +432,22 @@ def main(argv: list[str] | None = None) -> int:
     if not target.exists():
         print(f"error: path does not exist: {target}", file=sys.stderr)
         return 2
-    include_outputs = bool(args.outputs)
+    include_outputs = bool(args.outputs) or bool(args.nonpii)
     if args.scan is not None:
         report = [
             {"file": str(target), **d}
-            for d in scan_notebook(target, include_outputs=include_outputs)
+            for d in scan_notebook(
+                target,
+                include_outputs=include_outputs,
+                include_nonpii=bool(args.nonpii),
+            )
         ]
     else:
-        report = scan_tree(target, include_outputs=include_outputs)
+        report = scan_tree(
+            target,
+            include_outputs=include_outputs,
+            include_nonpii=bool(args.nonpii),
+        )
 
     if args.summary and not args.check:
         _print_summary(report)

--- a/scripts/notebook_tools/tests/test_detect_papermill_path_leak.py
+++ b/scripts/notebook_tools/tests/test_detect_papermill_path_leak.py
@@ -330,6 +330,80 @@ class ScanOutputTextTests(unittest.TestCase):
 # --- scan_notebook ---
 
 
+# --- _scan_output_text class C (non-PII, opt-in) ---
+
+
+class ScanOutputNonPiiTests(unittest.TestCase):
+    @staticmethod
+    def _nb_with_stream(text: str) -> dict:
+        return {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "outputs": [
+                        {"output_type": "stream", "name": "stdout", "text": text},
+                    ],
+                }
+            ]
+        }
+
+    def test_worktree_windows_path_flagged(self):
+        # Founding case #11278: PR #11234 committed a worktree output path.
+        nb = self._nb_with_stream(
+            "Output directory: D:\\Dev\\CoursIA-0411-audiobooks\\MyIA.AI.Notebooks\\GenAI"
+        )
+        defects = _scan_output_text(nb, include_nonpii=True)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "output_text_abs_path_nonpii")
+        self.assertEqual(defects[0]["severity"], "low")
+        self.assertIn("basename", defects[0]["remed"])
+        self.assertTrue(defects[0]["match"].startswith("D:\\Dev"))
+
+    def test_silent_without_flag(self):
+        nb = self._nb_with_stream(
+            "Output directory: D:\\Dev\\CoursIA-0411-audiobooks\\MyIA.AI.Notebooks"
+        )
+        self.assertEqual(_scan_output_text(nb), [])
+
+    def test_url_not_flagged(self):
+        nb = self._nb_with_stream(
+            "namespace: https://www.w3.org/2001/xmlns/ and https://arxiv.org/abs/2201.11903"
+        )
+        self.assertEqual(_scan_output_text(nb, include_nonpii=True), [])
+
+    def test_remote_env_prefix_allowlisted(self):
+        # /opt/miniconda3 is the QC Cloud runtime signature, not a
+        # contributor-machine leak (measured x1575 in ML-RandomForest).
+        nb = self._nb_with_stream(
+            "already satisfied: numpy in /opt/miniconda3/lib/python3.11/site-packages"
+        )
+        self.assertEqual(_scan_output_text(nb, include_nonpii=True), [])
+
+    def test_users_profile_stays_class_b_only(self):
+        nb = self._nb_with_stream(r"C:\Users\jsboi\AppData\Local\Temp\x.ipynb")
+        defects = _scan_output_text(nb, include_nonpii=True)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "output_text_path_leak")
+
+    def test_windows_system32_stays_class_b_only(self):
+        nb = self._nb_with_stream(r"dll loaded from C:\Windows\system32\kernel32.dll")
+        defects = _scan_output_text(nb, include_nonpii=True)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "output_text_path_leak")
+
+    def test_unix_mount_flagged(self):
+        nb = self._nb_with_stream("checkpoint restored from /mnt/data/runs/ckpt-42.pt")
+        defects = _scan_output_text(nb, include_nonpii=True)
+        self.assertEqual(len(defects), 1)
+        self.assertEqual(defects[0]["kind"], "output_text_abs_path_nonpii")
+
+    def test_bare_drive_letter_not_flagged(self):
+        # A single ``C:\`` segment (error-message template) needs a second
+        # segment to fire — mirrors the class-B no-noise rationale.
+        nb = self._nb_with_stream("failed to open C: (device not ready)")
+        self.assertEqual(_scan_output_text(nb, include_nonpii=True), [])
+
+
 class ScanNotebookTests(unittest.TestCase):
     def test_clean_notebook(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -459,6 +533,35 @@ class CliTests(unittest.TestCase):
             self.assertEqual(cp.returncode, 0)
             report = json.loads(cp.stdout)
             self.assertEqual(report, [])
+
+    def test_nonpii_implies_outputs_and_check_exits_1(self):
+        # ``--nonpii`` without ``--outputs`` must still scan output text
+        # (class C lives there) and make ``--check`` exit 1 on the defect.
+        nb = {
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stdout",
+                            "text": "Output directory: D:\\Dev\\CoursIA-x\\notebooks",
+                        },
+                    ],
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            p = _make_nb(Path(tmp), "worktree.ipynb", nb)
+            cp = self._run("--scan", str(p), "--nonpii", "--check")
+            self.assertEqual(cp.returncode, 1)
+            cp2 = self._run("--scan", str(p), "--nonpii")
+            report = json.loads(cp2.stdout)
+            kinds = {d["kind"] for d in report}
+            self.assertIn("output_text_abs_path_nonpii", kinds)
 
     def test_scan_defects_exits_0_with_json(self):
         nb = {


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/genai #11273

## Summary

Grain proposé par ai-01 (msg-20260816T114736) : `detect_papermill_path_leak.py` ne couvre que des marqueurs **PII/home** (`C:\Users\`, `/home/`, `/Users/`, `/root/`, `/tmp/ipykernel`) — un chemin de **worktree** (`D:\Dev\CoursIA-0411-audiobooks\...`) est invisible au détecteur **et** au pre-commit `strip_machine_paths.py` (même ancre PII). Cas fondateur : #11234 a committe ce chemin dans l'output cell[11] de `04-11-Generation-TTS.ipynb` — regression passée au merge, vue par tous les garde-fous (repérée T1 #11044, correction du verdict initial).

Cette PR ajoute la **classe C** `output_text_abs_path_nonpii` : advisory, **opt-in** (`--nonpii`, implique `--outputs`), qui route vers un **fix de source + re-exécution** (print basename), jamais vers un strip automatique.

## Mesure du trou (avant fix, main 797aa690e3)

Scan indépendant des outputs de tout `MyIA.AI.Notebooks/` : **~88 notebooks** portent un chemin absolu non-PII — concentration GenAI (`D:\Dev\CoursIA-<worktree>` : Kokoro 01-5 x80 occurrences, Song-Gen, Audio 03-1, Aspire, Sora, FLUX, Whisper, Qwen-VL), Probas/Infer-6 (`C:\dev\CoursIA-8892-infer6ep`), Image/examples (`C:\Python313\Lib`). + 2 quantbooks QC avec `/opt/miniconda3/` x1575/x53 = signature du runtime **QC Cloud distant** → allowlistée (pas un leak contributeur).

## Implémentation

- `NONPII_PATTERNS` : Windows `[A-Za-z]:[\\/](?!(?:Users|Windows)[\\/])<seg>[\\/]<seg>` (2+ segments : un `C:\` seul dans un template d'erreur ne tire pas) ; Unix `(?<![:\w/])/(?:mnt|media|srv|opt|data|workspace)/<seg>/<seg>` (le lookbehind rejette la queue `//host/...` des URLs)
- `REMOTE_ENV_PREFIXES = ("/opt/miniconda3", "/opt/conda", "/usr/local/lib/python", "/League")`
- Exclusions de double-compte : `Users` et `Windows` exclus du pattern C → `C:\Users\...` et `C:\Windows\system32` restent **classe B seule**
- Severity `low`, champ `remed` : "print a basename/relative path in the cell source and re-execute (Stop & Repair) — never hand-edit the committed output"
- **Aucun workflow CI n'appelle le détecteur** (vérifié : doc + tests seulement) — extension sans impact gate

## Validation (exécutée sur le livrable)

- **53/53 tests** (44 existants + 9 nouveaux) : worktree flaggé / silence sans flag / URL non flaggée / `/opt/miniconda3` allowlisté / `Users` + `system32` classe B seules / `/mnt` flaggé / bare `C:` silencieux / CLI `--nonpii` implique outputs et exit 1 en `--check`
- Cas fondateur : `--scan 04-11-Generation-TTS.ipynb --nonpii` → **2 defects** classe C
- Quantbook ML-RandomForest `--nonpii` → **0 defect** (allowlist opérante)
- Corpus `--scan-all MyIA.AI.Notebooks --nonpii --summary` → **160 classe C / ~90 fichiers** (cohérent avec la mesure indépendante ~88 ; écart = comptage par fichier vs walker git-tracked)

Closes #11278

Généré avec Claude Code (myia-po-2024:CoursIA)
