### PR TITLE
feat(lean,#2159): Partie 46 — CoversBind (forme flèche de la transitivité indexée)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -9,6 +9,7 @@ import Grothendieck.Construction
 import Grothendieck.Cover
 import Grothendieck.CoverageGen
 import Grothendieck.CoversArrow
+import Grothendieck.CoversBind
 import Grothendieck.CoversLattice
 import Grothendieck.CoversOrder
 import Grothendieck.CoversPullback

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversBind.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversBind.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Partie 46 : forme flèche de la transitivité indexée (bind)
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Les parties 1-45 ont établi les fondamentaux : catégories, cribles,
+topologies, lois de treillis, identités de pullback, bases de faisceaux,
+clôture couvrante, calibration, sous-canonicalité, topologies denses,
+faisceaux, hom interne, cohomologie de Čech, limite de Mayer-Vietoris,
+extensions de Kan, adjonctions, monades, équivalences, catégories monoïdales,
+la construction de Grothendieck, l'image directe/exceptionnelle, la forme
+flèche de la couverture, les lois de cohérence du pseudo-foncteur pullback,
+les lois de treillis indexées, la forme flèche des topologies extrémales et
+la forme flèche de l'adjonction pushforward-pullback.
+
+Cette partie applique le fil conducteur « forme flèche » à la transitivité
+indexée des couvertures — le « bind » des cribles. Mathlib fournit la
+transitivité ponctuelle `GrothendieckTopology.bind_covering` et la forme
+flèche de la transitivité à couverture constante
+`GrothendieckTopology.arrow_trans`, mais aucune loi ne relie la forme flèche
+`J.Covers` au crible indexé `Sieve.bind S T`. On comble le trou avec
+`covers_bind` (la forme flèche de la transitivité indexée : si `S` couvre
+`f` et si chaque crible `T hg` recouvre son objet de départ, alors le bind
+couvre `f`), ses corollaires (`covers_of_bind`, la forme flèche inverse
+portée par l'inclusion `bind_le` ; `covers_bind_id`, la retombée ponctuelle
+sur l'identité) et les deux identités de crible sous-jacentes, absentes de
+Mathlib : `bind_le` (`Sieve.bind S T ≤ S`) et `bind_top` (le bind par le
+crible top est l'identité).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.CoversBind
+
+open CategoryTheory
+
+/-!
+## Section 1 : l'inclusion du bind dans le crible
+
+Le crible `Sieve.bind S T` est contenu dans `S` : chaque flèche du bind est
+une précomposition `k ≫ g` d'une flèche `g ∈ S`, et un crible est clos par
+précomposition (`S.downward_closed`). La forme flèche de cette inclusion est
+la réciproque naturelle de `covers_bind` : si le bind couvre `f`, alors `S`
+couvre `f` (un sur-ensemble d'une couverture est une couverture).
+-/
+
+/-- Le bind est contenu dans le crible de départ : `Sieve.bind S T ≤ S`.
+    Preuve : une flèche du bind est une précomposition `k ≫ g` d'une flèche
+    `g ∈ S`, et un crible est clos par précomposition (`S.downward_closed`). -/
+theorem bind_le {C : Type*} [Category C] {X : C} (S : Sieve X)
+    (T : ∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → Sieve Y) : Sieve.bind S T ≤ S := by
+  intro Y f hf
+  rcases hf with ⟨Z, g, hg, k, hkT, rfl⟩
+  exact S.downward_closed k g
+
+/-- La forme flèche de l'inclusion : si le bind couvre `f`, alors `S` couvre
+    `f`. Preuve : `covers_iff`, monotonie du pullback (`Sieve.pullback_monotone`)
+    avec `bind_le`, puis `superset_covering`. -/
+theorem covers_of_bind {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (S : Sieve X) (T : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z) (f : Y ⟶ X)
+    (h : J.Covers (Sieve.bind S T) f) : J.Covers S f := by
+  rw [GrothendieckTopology.covers_iff] at h ⊢
+  exact J.superset_covering (Sieve.pullback_monotone f (bind_le S T)) h
+
+/-!
+## Section 2 : la forme flèche de la transitivité indexée
+
+C'est le théorème central de cette partie, le gap de Mathlib. La
+transitivité ponctuelle `bind_covering` et sa forme flèche à couverture
+constante `arrow_trans` sont deux faces extrêmes ; `covers_bind` les réunit :
+l'indexation est portée par `T : ∀ ⦃Z⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z`, et
+l'hypothèse de recouvrement devient `∀ g ∈ S, J.Covers (T hg) (𝟙 Z)` — la
+forme flèche de `T hg ∈ J Z`, un crible couvrant l'identité de son objet
+équivaut à appartenir à la topologie. La preuve utilise la transitivité de
+la topologie, via sa forme flèche `J.arrow_trans` spécialisée en
+`R := Sieve.bind S T`, puis l'unité du bind `Sieve.le_pullback_bind` qui
+relie chaque `T hg` au pullback du bind le long de la flèche `g`.
+-/
+
+/-- La forme flèche de la transitivité indexée : si `S` couvre `f` et si
+    chaque crible `T hg` recouvre son objet de départ — `J.Covers (T hg) (𝟙 Z)`,
+    la forme flèche de `T hg ∈ J Z` — alors le bind `Sieve.bind S T` couvre
+    `f`. Preuve : instantiation de la forme flèche de la transitivité de
+    Mathlib (`J.arrow_trans`, R := `Sieve.bind S T`) ; chaque flèche `g ∈ S`
+    se relève par l'unité du bind `Sieve.le_pullback_bind` — `T hg` est un
+    sous-crible du pullback du bind le long de `g` — et l'hypothèse indexée
+    `hT`. -/
+theorem covers_bind {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (S : Sieve X) (f : Y ⟶ X) (hS : J.Covers S f)
+    (T : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z)
+    (hT : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄ (hg : S g), J.Covers (T hg) (𝟙 Z)) :
+    J.Covers (Sieve.bind S T) f := by
+  exact J.arrow_trans f S (Sieve.bind S T) hS (by
+    intro Z g hg
+    rw [GrothendieckTopology.covers_iff]
+    have hTg : J.Covers (T hg) (𝟙 Z) := hT hg
+    rw [GrothendieckTopology.covers_iff] at hTg
+    rw [Sieve.pullback_id] at hTg
+    exact J.superset_covering (Sieve.le_pullback_bind S T g hg) hTg)
+
+/-!
+## Section 3 : la retombée ponctuelle
+
+Quand la flèche est l'identité `𝟙 X`, la forme flèche retombe sur
+l'appartenance ponctuelle : `J.Covers S (𝟙 X) ↔ S ∈ J X` (`covers_iff` +
+`Sieve.pullback_id`). La transitivité indexée se spécialise donc en la
+version ponctuelle du bind — l'analogue flèche de `bind_covering` — avec une
+hypothèse uniformément exprimée en couvertures.
+-/
+
+/-- La transitivité indexée, spécialisée sur l'identité :
+    `J.Covers S (𝟙 X) → (∀ g ∈ S, J.Covers (T hg) (𝟙 Z)) →
+    J.Covers (Sieve.bind S T) (𝟙 X)` — l'analogue flèche de `bind_covering`.
+    Preuve : instantiation de `covers_bind` en `f := 𝟙 X`. -/
+theorem covers_bind_id {C : Type*} [Category C] {X : C} (J : GrothendieckTopology C)
+    (S : Sieve X) (hS : J.Covers S (𝟙 X))
+    (T : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z)
+    (hT : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄ (hg : S g), J.Covers (T hg) (𝟙 Z)) :
+    J.Covers (Sieve.bind S T) (𝟙 X) := by
+  exact covers_bind J S (𝟙 X) hS T hT
+
+/-!
+## Section 4 : le bind par le crible top
+
+Quand chaque `T hg` est le crible top, le bind restitue exactement `S` :
+chaque flèche `g ∈ S` se précompose par l'identité (`g = 𝟙 ≫ g`), et
+réciproquement le bind est contenu dans `S` (`bind_le`). Cette identité de
+crible, absente de Mathlib, donne la forme flèche : couvrir par
+`Sieve.bind S (fun ⦃Z⦄ ⦃g : Z ⟶ X⦄ _ => ⊤)` équivaut à couvrir par `S`.
+-/
+
+/-- Le bind par le crible top est l'identité :
+    `Sieve.bind S (fun ⦃Y⦄ ⦃f : Y ⟶ X⦄ _ => ⊤) = S`.
+    Preuve : anti-symétrie entre `bind_le` et l'inclusion inverse — chaque
+    `g ∈ S` se précompose par l'identité, `g = 𝟙 ≫ g`, et le crible top
+    accepte toute flèche. -/
+theorem bind_top {C : Type*} [Category C] {X : C} (S : Sieve X) :
+    Sieve.bind S (fun ⦃Y : C⦄ ⦃_ : Y ⟶ X⦄ _ => (⊤ : Sieve Y)) = S := by
+  apply le_antisymm
+  · exact bind_le S (fun ⦃Y : C⦄ ⦃_ : Y ⟶ X⦄ _ => (⊤ : Sieve Y))
+  · intro Y f hS
+    exact ⟨Y, 𝟙 Y, f, hS, by simp, by simp⟩
+
+/-- La forme flèche du bind par le crible top :
+    `J.Covers (Sieve.bind S (fun ⦃Z⦄ ⦃g : Z ⟶ X⦄ _ => ⊤)) f ↔ J.Covers S f`.
+    Preuve : réécriture de l'identité `bind_top`. -/
+theorem covers_bind_top {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (S : Sieve X) (f : Y ⟶ X) :
+    J.Covers (Sieve.bind S (fun ⦃Z : C⦄ ⦃_ : Z ⟶ X⦄ _ => (⊤ : Sieve Z))) f ↔
+      J.Covers S f := by
+  rw [bind_top S]
+
+end Grothendieck.CoversBind

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversBind_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversBind_en.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+
+# Hommage Grothendieck — Part 46 : arrow form of the indexed transitivity (bind)
+
+Alexandre Grothendieck (1928-2014).
+
+Extension Phase 5 (#2159, EPIC #1646).
+
+Parts 1-45 established the foundations: categories, sieves, topologies,
+lattice laws, pullback identities, sheaf bases, covering closure,
+calibration, subcanonicity, dense topologies, sheaves, internal hom,
+Čech cohomology, Mayer-Vietoris limit, Kan extensions, adjunctions, monads,
+equivalences, monoidal categories, the Grothendieck construction, the
+direct/exceptional image, the arrow form of the covering, the coherence
+laws of the pullback pseudo-functor, the indexed lattice laws, the arrow
+form of the extremal topologies and the arrow form of the
+pushforward-pullback adjunction.
+
+This part applies the guiding thread "arrow form" to the indexed
+transitivity of coverings — the "bind" of sieves. Mathlib provides the
+pointwise transitivity `GrothendieckTopology.bind_covering` and the arrow
+form of the transitivity at constant covering `GrothendieckTopology.arrow_trans`,
+but no law relates the arrow form `J.Covers` to the indexed sieve
+`Sieve.bind S T`. Here we fill the gap with `covers_bind` (the arrow form of
+the indexed transitivity: if `S` covers `f` and each sieve `T hg` covers its
+domain, then the bind covers `f`), its corollaries (`covers_of_bind`, the
+reverse arrow form carried by the inclusion `bind_le`; `covers_bind_id`, the
+pointwise fallback on the identity) and the two underlying sieve identities,
+absent from Mathlib: `bind_le` (`Sieve.bind S T ≤ S`) and `bind_top` (the
+bind by the top sieve is the identity).
+-/
+
+import Mathlib.CategoryTheory.Sites.Grothendieck
+
+namespace Grothendieck.CoversBind_en
+
+open CategoryTheory
+
+/-!
+## Section 1 : the inclusion of the bind in the sieve
+
+The sieve `Sieve.bind S T` is contained in `S`: every arrow of the bind is a
+precomposition `k ≫ g` of an arrow `g ∈ S`, and a sieve is closed under
+precomposition (`S.downward_closed`). The arrow form of this inclusion is
+the natural converse of `covers_bind`: if the bind covers `f`, then `S`
+covers `f` (a superset of a covering is a covering).
+-/
+
+/-- The bind is contained in the starting sieve: `Sieve.bind S T ≤ S`.
+    Proof: an arrow of the bind is a precomposition `k ≫ g` of an arrow
+    `g ∈ S`, and a sieve is closed under precomposition (`S.downward_closed`). -/
+theorem bind_le {C : Type*} [Category C] {X : C} (S : Sieve X)
+    (T : ∀ ⦃Y : C⦄ ⦃f : Y ⟶ X⦄, S f → Sieve Y) : Sieve.bind S T ≤ S := by
+  intro Y f hf
+  rcases hf with ⟨Z, g, hg, k, hkT, rfl⟩
+  exact S.downward_closed k g
+
+/-- The arrow form of the inclusion: if the bind covers `f`, then `S` covers
+    `f`. Proof: `covers_iff`, monotonicity of the pullback
+    (`Sieve.pullback_monotone`) with `bind_le`, then `superset_covering`. -/
+theorem covers_of_bind {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (S : Sieve X) (T : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z) (f : Y ⟶ X)
+    (h : J.Covers (Sieve.bind S T) f) : J.Covers S f := by
+  rw [GrothendieckTopology.covers_iff] at h ⊢
+  exact J.superset_covering (Sieve.pullback_monotone f (bind_le S T)) h
+
+/-!
+## Section 2 : the arrow form of the indexed transitivity
+
+This is the central theorem of this part, the Mathlib gap. The pointwise
+transitivity `bind_covering` and its arrow form at constant covering
+`arrow_trans` are two extreme faces; `covers_bind` unites them: the indexing
+is carried by `T : ∀ ⦃Z⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z`, and the covering
+hypothesis becomes `∀ g ∈ S, J.Covers (T hg) (𝟙 Z)` — the arrow form of
+`T hg ∈ J Z`, a sieve covering the identity of its object being equivalent
+to belonging to the topology. The proof uses the transitivity of the
+topology, via its arrow form `J.arrow_trans` specialized at
+`R := Sieve.bind S T`, then the unit of the bind `Sieve.le_pullback_bind`
+which relates each `T hg` to the pullback of the bind along the arrow `g`.
+-/
+
+/-- The arrow form of the indexed transitivity: if `S` covers `f` and each
+    sieve `T hg` covers its domain — `J.Covers (T hg) (𝟙 Z)`, the arrow form
+    of `T hg ∈ J Z` — then the bind `Sieve.bind S T` covers `f`.
+    Proof: instantiation of Mathlib's arrow form of transitivity
+    (`J.arrow_trans`, R := `Sieve.bind S T`); every arrow `g ∈ S` is lifted
+    by the unit of the bind `Sieve.le_pullback_bind` — `T hg` is a subsieve
+    of the pullback of the bind along `g` — and the indexed hypothesis `hT`. -/
+theorem covers_bind {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (S : Sieve X) (f : Y ⟶ X) (hS : J.Covers S f)
+    (T : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z)
+    (hT : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄ (hg : S g), J.Covers (T hg) (𝟙 Z)) :
+    J.Covers (Sieve.bind S T) f := by
+  exact J.arrow_trans f S (Sieve.bind S T) hS (by
+    intro Z g hg
+    rw [GrothendieckTopology.covers_iff]
+    have hTg : J.Covers (T hg) (𝟙 Z) := hT hg
+    rw [GrothendieckTopology.covers_iff] at hTg
+    rw [Sieve.pullback_id] at hTg
+    exact J.superset_covering (Sieve.le_pullback_bind S T g hg) hTg)
+
+/-!
+## Section 3 : the pointwise fallback
+
+When the arrow is the identity `𝟙 X`, the arrow form falls back on the
+pointwise membership: `J.Covers S (𝟙 X) ↔ S ∈ J X` (`covers_iff` +
+`Sieve.pullback_id`). The indexed transitivity therefore specializes to the
+pointwise version of the bind — the arrow analogue of `bind_covering` —
+with a hypothesis uniformly expressed in coverings.
+-/
+
+/-- The indexed transitivity, specialized on the identity:
+    `J.Covers S (𝟙 X) → (∀ g ∈ S, J.Covers (T hg) (𝟙 Z)) →
+    J.Covers (Sieve.bind S T) (𝟙 X)` — the arrow analogue of `bind_covering`.
+    Proof: instantiation of `covers_bind` at `f := 𝟙 X`. -/
+theorem covers_bind_id {C : Type*} [Category C] {X : C} (J : GrothendieckTopology C)
+    (S : Sieve X) (hS : J.Covers S (𝟙 X))
+    (T : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z)
+    (hT : ∀ ⦃Z : C⦄ ⦃g : Z ⟶ X⦄ (hg : S g), J.Covers (T hg) (𝟙 Z)) :
+    J.Covers (Sieve.bind S T) (𝟙 X) := by
+  exact covers_bind J S (𝟙 X) hS T hT
+
+/-!
+## Section 4 : the bind by the top sieve
+
+When each `T hg` is the top sieve, the bind recovers exactly `S`: every
+arrow `g ∈ S` is precomposed by the identity (`g = 𝟙 ≫ g`), and conversely
+the bind is contained in `S` (`bind_le`). This sieve identity, absent from
+Mathlib, gives the arrow form: covering by
+`Sieve.bind S (fun ⦃Z⦄ ⦃g : Z ⟶ X⦄ _ => ⊤)` is equivalent to covering by `S`.
+-/
+
+/-- The bind by the top sieve is the identity:
+    `Sieve.bind S (fun ⦃Y⦄ ⦃f : Y ⟶ X⦄ _ => ⊤) = S`.
+    Proof: antisymmetry between `bind_le` and the reverse inclusion — every
+    `g ∈ S` is precomposed by the identity, `g = 𝟙 ≫ g`, and the top sieve
+    accepts every arrow. -/
+theorem bind_top {C : Type*} [Category C] {X : C} (S : Sieve X) :
+    Sieve.bind S (fun ⦃Y : C⦄ ⦃_ : Y ⟶ X⦄ _ => (⊤ : Sieve Y)) = S := by
+  apply le_antisymm
+  · exact bind_le S (fun ⦃Y : C⦄ ⦃_ : Y ⟶ X⦄ _ => (⊤ : Sieve Y))
+  · intro Y f hS
+    exact ⟨Y, 𝟙 Y, f, hS, by simp, by simp⟩
+
+/-- The arrow form of the bind by the top sieve:
+    `J.Covers (Sieve.bind S (fun ⦃Z⦄ ⦃g : Z ⟶ X⦄ _ => ⊤)) f ↔ J.Covers S f`.
+    Proof: rewrite of the identity `bind_top`. -/
+theorem covers_bind_top {C : Type*} [Category C] {X Y : C} (J : GrothendieckTopology C)
+    (S : Sieve X) (f : Y ⟶ X) :
+    J.Covers (Sieve.bind S (fun ⦃Z : C⦄ ⦃_ : Z ⟶ X⦄ _ => (⊤ : Sieve Z))) f ↔
+      J.Covers S f := by
+  rw [bind_top S]
+
+end Grothendieck.CoversBind_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #11262

## Summary

**Partie 46 de l'Epic #2159** : `Grothendieck.CoversBind` — la forme flèche `J.Covers` de la **transitivité indexée** des couvertures, le « bind » des cribles (`Sieve.bind S T`).

Gap vérifié : Mathlib fournit la transitivité **ponctuelle** (`GrothendieckTopology.bind_covering`) et la forme flèche de la transitivité à couverture **constante** (`GrothendieckTopology.arrow_trans`, R constant sur X) — mais **aucune loi ne relie la forme flèche `J.Covers` au crible indexé `Sieve.bind S T`** (grep Mathlib Sieves.lean/Grothendieck.lean : 0). On comble le trou avec 6 théorèmes propres, 0 sorry, aucun re-export :

1. **`bind_le`** (inédit Mathlib) : `Sieve.bind S T ≤ S` — chaque flèche du bind est une précomposition `k ≫ g` d'une flèche `g ∈ S`, et un crible est clos par précomposition (`S.downward_closed`).
2. **`covers_of_bind`** : `J.Covers (Sieve.bind S T) f → J.Covers S f` — la forme flèche de l'inclusion, réciproque naturelle de `covers_bind` (un sur-ensemble d'une couverture est une couverture).
3. **`covers_bind`** (théorème central) : `J.Covers S f → (∀ g ∈ S, J.Covers (T hg) (𝟙 Z)) → J.Covers (Sieve.bind S T) f` — la forme flèche de la **transitivité indexée**. La généralisation d'`arrow_trans` à une couverture indexée : l'indexation est portée par `T : ∀ ⦃Z⦄ ⦃g : Z ⟶ X⦄, S g → Sieve Z`, l'hypothèse `J.Covers (T hg) (𝟙 Z)` est la forme flèche de `T hg ∈ J Z` (un crible couvrant l'identité de son objet équivaut à appartenir à la topologie). Preuve : instantiation de la forme flèche de la transitivité de Mathlib (`J.arrow_trans`, R := `Sieve.bind S T`) ; chaque flèche `g ∈ S` se relève par l'unité du bind `Sieve.le_pullback_bind` — `T hg` est un sous-crible du pullback du bind le long de `g` — et l'hypothèse indexée `hT`.
4. **`covers_bind_id`** : `J.Covers S (𝟙 X) → (∀ g ∈ S, J.Covers (T hg) (𝟙 Z)) → J.Covers (Sieve.bind S T) (𝟙 X)` — la retombée ponctuelle, l'analogue flèche de `bind_covering`.
5. **`bind_top`** (inédit Mathlib) : `Sieve.bind S (fun ⦃Y⦄ ⦃f : Y ⟶ X⦄ _ => ⊤) = S` — le bind par le crible top est l'identité (anti-symétrie entre `bind_le` et `g = 𝟙 ≫ g`).
6. **`covers_bind_top`** : `J.Covers (Sieve.bind S (fun ⦃Z⦄ ⦃g : Z ⟶ X⦄ _ => ⊤)) f ↔ J.Covers S f` — la forme flèche du bind par le crible top (réécriture de `bind_top`).

`covers_bind` est la substance : Mathlib ne fournit ni la transitivité indexée de la forme flèche, ni les deux identités de crible (`bind_le`, `bind_top`) qui la fondent.

## Acceptation (#2159)

- [x] `lake build Grothendieck` → `Build completed successfully` (log collé ci-dessous).
- [x] sorry avant/après : `distinct_code_sorry` = 0 pour tout le lake avant ET après (nouveaux théorèmes propres, aucun re-export).
- [x] Anti-régression : aucun fichier existant modifié hors agrégateur `Grothendieck.lean` (+1 import, ordre alphabétique).
- [x] i18n (#4980 Pattern A) : `check_i18n_siblings.py` → paire `CoversBind` byte-identique (FR/EN), 0 drift, 0 orphan.

## Files

- `MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversBind.lean` — Partie 46 FR (6 théorèmes propres)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/CoversBind_en.lean` — twin EN byte-identique (i18n Pattern A)
- `MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean` — agrégateur : +1 import (ordre alphabétique, après `CoversArrow`)

## Validation

`lake build Grothendieck` → `Build completed successfully` (cache AZ).

See #2159
