### PR TITLE
docs(qc,#11224): tranche 5 — QC-Py-Dataset-Workflow densité 663->1269 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Dataset-Workflow.ipynb
@@ -26,7 +26,15 @@
     "\n",
     "Ce notebook parcourt les **cinq sources** du workflow, dans l'ordre croissant de granularité : daily actions → archive crypto consolidée → intraday Binance → mise à jour incrémentale.\n",
     "\n",
-    "**Prérequis** : `pip install pandas yfinance matplotlib`"
+    "**Prérequis** : `pip install pandas yfinance matplotlib`\n",
+    "\n",
+    "Ce workflow tourne **localement** (pandas + scripts du depot), en complement de `QuantBook()` : le meme\n",
+    "objectif — des donnees propres, datees, rechargeables — mais sans consommer de quota QC Cloud ni exiger une\n",
+    "connexion. C'est le chemin a privilegier pour l'exploration rapide d'une idee avant de payer le cout d'un\n",
+    "backtest cloud : si une hypothese ne survit pas a un traitement pandas sur 5 ans de SPY, elle ne survivra pas\n",
+    "non plus sur LEAN. Chaque section suit le meme canevas : **appel du script -> lecture de l'output -> chargement\n",
+    "pandas -> interpretation**, pour que la lecture des sorties console devienne un reflexe autant que la lecture\n",
+    "d'un DataFrame."
    ]
   },
   {
@@ -74,6 +82,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "setup-datasets-dir",
+   "metadata": {},
+   "source": [
+    "### Ou vivent les fichiers ?\n",
+    "\n",
+    "`DATASETS_DIR = Path(\"../datasets\")` est **relatif au repertoire du notebook** (`QuantConnect/Python/`), pas au\n",
+    "repertoire courant du kernel : l'output ci-dessus affiche `..\\datasets`, qui se resout donc vers\n",
+    "`QuantConnect/datasets/`. C'est un choix delibere — les datasets restent dans le perimetre de la famille QC et\n",
+    "ne polluent ni la racine du depot ni le dossier temporaire. Consequence pratique : executer le meme notebook\n",
+    "depuis un autre cwd (un runner papermill, par exemple) produira les memes chemins, car le script derive tout de\n",
+    "`Path(\"../datasets\")` et non de `os.getcwd()`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "85692cdb",
    "metadata": {
     "papermill": {
@@ -90,7 +113,13 @@
     "\n",
     "`download_yfinance.py` télécharge des séries daily (actions, ETF, crypto listée) depuis Yahoo Finance, avec un **cache Parquet local** indexé par un hash des paramètres (symbole + plage + intervalle). Un second appel avec les mêmes paramètres servira le cache sans repasser par le réseau — c'est ce qui garantit la **reproductibilité** du notebook (et évite le rate-limiting de l'API publique).\n",
     "\n",
-    "> **Actions vs crypto** : yfinance sert du daily *market-hours* pour les actions (week-ends et jours fériés exclus, ~252 jours de trading/an). La crypto, elle, trade 24/7 (~365 points/an). La même commande fonctionne pour les deux, mais la densité temporelle du résultat diffère."
+    "> **Actions vs crypto** : yfinance sert du daily *market-hours* pour les actions (week-ends et jours fériés exclus, ~252 jours de trading/an). La crypto, elle, trade 24/7 (~365 points/an). La même commande fonctionne pour les deux, mais la densité temporelle du résultat diffère.\n",
+    "\n",
+    "Le **hash des parametres** dans le nom de cache (`SPY_9cf211eddf14.parquet`) est ce qui rend le cache sain :\n",
+    "deux appels avec le meme (symbole, plage, intervalle) servent le meme fichier, mais changer `--start` d'un seul\n",
+    "jour produit un hash different — impossible de servir par erreur une plage presque identique. C'est la\n",
+    "difference entre un cache *par parametres* et un cache *par symbole* (ce dernier renverrait des donnees\n",
+    "tronquees sans prevenir)."
    ]
   },
   {
@@ -140,7 +169,12 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "Les deux symboles (SPY, TLT) ont été servis depuis le **cache Parquet** (`Cache hit`) — aucun appel réseau à Yahoo Finance, le téléchargement est instantané et déterministe. Chaque CSV final contient **1257 rangées** : c'est le compte attendu pour 5 années de trading daily (2020-2024), les week-ends et jours fériés étant exclus de la plage."
+    "Les deux symboles (SPY, TLT) ont été servis depuis le **cache Parquet** (`Cache hit`) — aucun appel réseau à Yahoo Finance, le téléchargement est instantané et déterministe. Chaque CSV final contient **1257 rangées** : c'est le compte attendu pour 5 années de trading daily (2020-2024), les week-ends et jours fériés étant exclus de la plage.\n",
+    "\n",
+    "L'arithmetique confirme la coherence : 5 annees x ~252 jours de trading ~ 1260, et le compte reel de 1257\n",
+    "rangées s'explique par les jours feries (Thanksgiving, Noel, 1er janvier...) soustraits du total. Si un\n",
+    "telechargement daily d'actions affichait ~1800 rangées sur 5 ans, il y aurait une erreur de calendrier\n",
+    "(week-ends inclus) ; ~1250-1260 est la signature attendue."
    ]
   },
   {
@@ -281,7 +315,12 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "**1257 jours** de cotation SPY, du 2020-01-02 au 2024-12-30. Le `Close` opening à ~296,89 $ au 2 janvier 2020 (avant le choc COVID) illustre pourquoi ce dataset est pertinent : il couvre la pandémie, la récession, et la remontée de taux — soit trois régimes de marché distincts, idéal pour stress-tester une stratégie. Les colonnes OHLCV sont standards et directement utilisables par `pct_change()`, `rolling()`, etc."
+    "**1257 jours** de cotation SPY, du 2020-01-02 au 2024-12-30. Le `Close` opening à ~296,89 $ au 2 janvier 2020 (avant le choc COVID) illustre pourquoi ce dataset est pertinent : il couvre la pandémie, la récession, et la remontée de taux — soit trois régimes de marché distincts, idéal pour stress-tester une stratégie. Les colonnes OHLCV sont standards et directement utilisables par `pct_change()`, `rolling()`, etc.\n",
+    "\n",
+    "Remarquez aussi la granularite des prix : le `Close` du 2020-01-02 vaut 296.888153 — pas un multiple du tick\n",
+    "d'affichage 0.01 $. yfinance sert des prix **adjointes** (dividendes et splits reinvestis), d'ou les decimales.\n",
+    "C'est desirable pour du backtest (pas de faux gaps de dividende), mais il ne faut pas comparer ces prix a un\n",
+    "historique de cotation brute sans ajustement."
    ]
   },
   {
@@ -353,6 +392,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-plot-spy",
+   "metadata": {},
+   "source": [
+    "### Lecture du graphique\n",
+    "\n",
+    "La figure (`1200x400`, une seule axe) trace les 1257 points `Close` de SPY sur la plage chargee plus haut\n",
+    "(2020-01-02 -> 2024-12-30). Trois regimes s'y lisent necessairement, puisque la plage les couvre : le choc\n",
+    "COVID de mars 2020 (la plus forte drawdown du dataset), la recuperation 2020-2021 portee par les stimulus, et\n",
+    "le marche en taux montants 2022-2024. Pour une strategie, l'interet de cette vue est de **verifier l'integrite\n",
+    "des donnees avant de les croire** : une serie avec des zeros, des trous de dates ou un niveau absurde\n",
+    "(un close negatif, un gap de 90 %) se voit immediatement a l'oeil sur la courbe, alors qu'un `describe()`\n",
+    "peut passer a cote d'un unique point aberrant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2f8f3103",
    "metadata": {
     "papermill": {
@@ -369,7 +424,14 @@
     "\n",
     "Pour la crypto, une seule source (yfinance) laisse des **trous** : symboles renommés, plages manquantes, délistages. `manage_crypto_archive.py` **consolide** deux sources complémentaires — yfinance pour l'historique daily long terme, CoinGecko pour combler les gaps — en une archive CSV unifiée et continue. C'est l'approche « ne fais confiance à aucune source unique » appliquée aux données de marché.\n",
     "\n",
-    "L'archive produite est **idempotente** : relancer la commande avec les mêmes paramètres régénère le même fichier (pas de duplication)."
+    "L'archive produite est **idempotente** : relancer la commande avec les mêmes paramètres régénère le même fichier (pas de duplication).\n",
+    "\n",
+    "Concretement, les trous typiques que la consolidation comble : yfinance renomme des symboles (`BCC` -> `BCH`\n",
+    "historiquement), arrete une serie au delisting, ou rate des jours isoles ; CoinGecko, source aggregee\n",
+    "independante, sert l'historique en continu mais avec des volumes moins fiables. La strategie du script est donc\n",
+    "**yfinance en source primaire, CoinGecko en rustine** — le meilleur des deux sans heriter des defauts de\n",
+    "chacun. Pour du travail serieux sur BTC, cela evite le piege classique : un backtest qui \"gagne\" grace a une\n",
+    "journee manquante au pire moment."
    ]
   },
   {
@@ -415,7 +477,7 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "L'archive BTC consolidée couvre **2191 jours** (2019-01-01 → 2024-12-30), soit environ 6 ans en continu — la crypto trade 24/7, donc ~365 points/an contre ~252 pour les actions. Le prix d'ouverture à ~3746 $ en janvier 2019 (avant le bull run) donne une plage de variation énorme, utile pour tester la robustesse d'une stratégie sur différents régimes de volatilité."
+    "L'archive BTC consolidée couvre **2191 jours** (2019-01-01 → 2024-12-30), soit environ 6 ans en continu — la crypto trade 24/7, donc ~365 points/an contre ~252 pour les actions. Sur 6 ans, la crypto traverse des regimes extremes (bull run 2020-2021, hiver crypto 2022, halving 2024) : une seule source qui sauterait quelques-unes de ces periodes fausserait silencieusement tout backtest."
    ]
   },
   {
@@ -553,14 +615,34 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "Le DataFrame BTC confirme les **2191 jours** et montre la structure OHLCV attendue. Notez la différence de granularité vs SPY : sur la même fenêtre temporelle (~6 ans), BTC a ~2191 points quand SPY en aurait ~1510 — c'est l'effet du trading 24/7. Cette densité différentielle est exactement ce que l'exercice 2 (correlation rolling) va exploiter : pour merger les deux séries, il faudra aligner les dates communes."
+    "Le DataFrame BTC confirme les **2191 jours** et montre la structure OHLCV attendue. Notez la différence de granularité vs SPY : sur la même fenêtre temporelle (~6 ans), BTC a ~2191 points quand SPY en aurait ~1510 — c'est l'effet du trading 24/7. Cette densité différentielle est exactement ce que l'exercice 2 (correlation rolling) va exploiter : pour merger les deux séries, il faudra aligner les dates communes.\n",
+    "\n",
+    "Les cinq premieres rangées montrent l'ouverture du dataset : ~3746,71 $ le 2019-01-01, puis une monte\n",
+    "immediate vers ~3943 $ en deux seances — la volatilite quotidienne de janvier 2019 (plusieurs pourcents sur\n",
+    "la journee) est d'un autre ordre que celle de SPY. Les colonnes sont en **minuscules** (`open`, `close`)\n",
+    "contrairement a yfinance (`Open`, `Close`) : detail qui compte au moment du merge de l'exercice 2, sous peine\n",
+    "de `KeyError` ou, pire, de colonnes silencieusement alignees par position."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 2 : Calculer la correlation BTC vs SPY\n\nCalculez la **correlation rolling 30 jours** entre les returns de BTC et SPY. Une correlation elevee reduit l'intérêt de la diversification.\n\n**Indices** :\n- `# Indice` : Mergez les deux DataFrames sur la date, puis calculez `returns.rolling(30).corr()`\n- `# Étape 1` : Calculer les returns pour SPY et BTC\n- `# Étape 2` : Merger les returns sur la colonne date\n- `# Étape 3` : Calculer la correlation rolling 30j"
+    "### Exercice 2 : Calculer la correlation BTC vs SPY\n",
+    "\n",
+    "Calculez la **correlation rolling 30 jours** entre les returns de BTC et SPY. Une correlation elevee reduit l'intérêt de la diversification.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Indice` : Mergez les deux DataFrames sur la date, puis calculez `returns.rolling(30).corr()`\n",
+    "- `# Étape 1` : Calculer les returns pour SPY et BTC\n",
+    "- `# Étape 2` : Merger les returns sur la colonne date\n",
+    "- `# Étape 3` : Calculer la correlation rolling 30j\n",
+    "\n",
+    "**Ce que vous devriez observer** : la correlation 30 jours BTC/SPY de ces dernieres annees oscille\n",
+    "typiquement entre ~0.1 et ~0.5 — positive mais instable, loin de la correlation actions/obligations\n",
+    "traditionnelle. C'est precisement ce qui fait le valeur de la crypto en diversification : correlee quand tout\n",
+    "s'effondre (mars 2020), decorrelee le reste du temps. Si votre courbe reste plate a zero, verifiez l'alignement\n",
+    "des dates avant de conclure."
    ],
    "id": "cell-9c53cd52"
   },
@@ -626,6 +708,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-plot-btc",
+   "metadata": {},
+   "source": [
+    "### Lecture du graphique\n",
+    "\n",
+    "Meme canevas que pour SPY (`1200x400`, une axe), mais la courbe raconte une autre histoire : sur 2191 jours\n",
+    "(2019-01-01 -> 2024-12-30, bornes imprimees plus haut), le BTC traverse un cycle complet bull/bear — le\n",
+    "graphique sert ici de **controle sanitaire** avant l'exercice 2 : les extremes du dataset (le pic de fin 2021\n",
+    "autour de 60-70k $, le creux 2022 sous 20k $) doivent etre presents, sinon l'archive consolidee a un trou au\n",
+    "precisement pire endroit — les extremes — et toute correlation calculee sur une serie tronquee sera biaissee."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dceca9d0",
    "metadata": {
     "papermill": {
@@ -642,7 +738,12 @@
     "\n",
     "Quand il faut de l'**intraday** (1 minute à 1 jour) avec le vrai volume et tous les OHLC, l'API publique `data.binance.vision` de Binance est la référence : fichiers mensuels pré-agrégés, téléchargeables en bloc, pas de rate-limit agressif. `download_binance_archive.py` découpe la plage demandée en **périodes mensuelles** et concatène les résultats.\n",
     "\n",
-    "Les klines Binance horodatent en **millisecondes epoch** (`open_time`, champ numérique) — il faut convertir avec `pd.to_datetime(..., unit=\"ms\")` pour retomber sur des dates lisibles. Le notebook montre la conversion dans la cellule de chargement."
+    "Les klines Binance horodatent en **millisecondes epoch** (`open_time`, champ numérique) — il faut convertir avec `pd.to_datetime(..., unit=\"ms\")` pour retomber sur des dates lisibles. Le notebook montre la conversion dans la cellule de chargement.\n",
+    "\n",
+    "Pourquoi `data.binance.vision` plutot que l'API REST de trading ? Trois raisons : (1) ce sont des **archives\n",
+    "mensuelles figees** (reproducibles — le contenu d'un mois telecharge aujourd'hui sera identique dans un an),\n",
+    "la ou l'API REST peut corriger a posteriori ; (2) pas d'authentification ni de cle API ; (3) un fichier par\n",
+    "mois se telecharge en une requete, la ou l'API REST limite a ~1000 klines par appel."
    ]
   },
   {
@@ -691,7 +792,11 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "Trois fichiers mensuels produits pour Q1 2024 : **31** (janvier) + **29** (février, 2024 bissextile) + **31** (mars) = **91 klines** au total. Le découpage mensuel de Binance permet le téléchargement parallèle et la reprise sur échec (si un mois rate, on ne re-télécharge pas tout)."
+    "Trois fichiers mensuels produits pour Q1 2024 : **31** (janvier) + **29** (février, 2024 bissextile) + **31** (mars) = **91 klines** au total. Le découpage mensuel de Binance permet le téléchargement parallèle et la reprise sur échec (si un mois rate, on ne re-télécharge pas tout).\n",
+    "\n",
+    "Le compte par mois est aussi un **canari de validite** : un janvier a 31 rangées et un fevrier 2024 a 29\n",
+    "(bissextile) sont attendus ; un mois a 28 rangées en janvier signalerait une plage mal alignee sur les\n",
+    "jours de Binance (UTC, pas de jours feries)."
    ]
   },
   {
@@ -744,7 +849,12 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "Les 3 fichiers Binance sont lus, concaténés, et le `open_time` (epoch ms) est converti en datetime lisible via `pd.to_datetime(..., unit=\"ms\")`. On obtient **91 rangées** alignées. C'est le pattern canonique pour ingérer des klines Binance : toujours convertir l'epoch ms, sinon les graphiques et les merges cassent."
+    "Les 3 fichiers Binance sont lus, concaténés, et le `open_time` (epoch ms) est converti en datetime lisible via `pd.to_datetime(..., unit=\"ms\")`. On obtient **91 rangées** alignées. C'est le pattern canonique pour ingérer des klines Binance : toujours convertir l'epoch ms, sinon les graphiques et les merges cassent.\n",
+    "\n",
+    "Notez que la concatenation ne trie pas : les fichiers sont lus dans l'ordre du `sorted(glob(...))`, qui est\n",
+    "naturellement chronologique parce que les noms portent le mois (`BTCUSDT_1d_2024-01.csv`). Si les noms de\n",
+    "fichiers perdaient cette propriete d'ordre lexicographique = ordre chronologique, il faudrait ajouter un\n",
+    "`sort_values(\"date\")` explicite avant tout calcul de returns."
    ]
   },
   {
@@ -765,7 +875,12 @@
     "\n",
     "Une archive n'est utile que si elle reste **à jour**. Le flag `--update` de `manage_crypto_archive.py` ne re-télécharge pas tout l'historique : il lit la dernière date présente dans le CSV existant et n'append que les **nouvelles rangées** (de la dernière date à aujourd'hui). C'est beaucoup plus rapide et beaucoup plus poli envers les sources qu'une régénération complète.\n",
     "\n",
-    "Cette incrémentalité est la propriété clé d'un bon pipeline de données : `--update` est **idempotent** (le relancer ne duplique rien, puisque les rangées déjà présentes sont détectées par leur date) et **commutative** (update puis update = update)."
+    "Cette incrémentalité est la propriété clé d'un bon pipeline de données : `--update` est **idempotent** (le relancer ne duplique rien, puisque les rangées déjà présentes sont détectées par leur date) et **commutative** (update puis update = update).\n",
+    "\n",
+    "La difference de cout est visible dans l'output : l'update n'a fetch que 561 rangées, alors qu'une\n",
+    "regeneration complete en re-telechargerait 2751 — cinq fois plus de trafic pour le meme resultat final. Sur\n",
+    "des datasets intraday (des millions de rangées), ce ratio devient le difference entre quelques secondes et\n",
+    "plusieurs heures."
    ]
   },
   {
@@ -810,7 +925,11 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "L'update incrémental a ajouté **+561 rangées** (du 2024-12-30 au 2026-07-14) à l'archive existante, passant de 2191 à **2751 jours** au total. Aucune régénération de l'historique : seules les nouvelles dates ont été fetchées. C'est le comportement attendu de `--update` — rapide, idempotent, poli envers la source."
+    "L'update incrémental a ajouté **+561 rangées** (du 2024-12-30 au 2026-07-14) à l'archive existante, passant de 2191 à **2751 jours** au total. Aucune régénération de l'historique : seules les nouvelles dates ont été fetchées. C'est le comportement attendu de `--update` — rapide, idempotent, poli envers la source.\n",
+    "\n",
+    "L'intervalle apparent (2024-12-30 -> 2026-07-14) merite une lecture attentive : la borne de depart est la\n",
+    "**derniere date deja presente** dans l'archive, pas la date de fin demandee a la creation — preuve que le\n",
+    "script a bien relu l'existant au lieu de tout refaire."
    ]
   },
   {
@@ -856,14 +975,33 @@
    "source": [
     "### Lecture du résultat\n",
     "\n",
-    "La commande `--list` affiche l'état de toutes les archives : ici une seule (BTC, 2751 jours, 220 KB). C'est le tableau de bord minimal pour savoir ce qui est disponible localement avant de lancer un backtest — évite de re-télécharger par réflexe."
+    "La commande `--list` affiche l'état de toutes les archives : ici une seule (BTC, 2751 jours, 220 KB). C'est le tableau de bord minimal pour savoir ce qui est disponible localement avant de lancer un backtest — évite de re-télécharger par réflexe.\n",
+    "\n",
+    "Pour un pipeline multi-actifs, cette vue est aussi la pour attraper les **archives zombies** : un symbole\n",
+    "telecharge une fois pour un test, jamais mis a jour depuis, dont l'`End` date de plusieurs mois. Une strategie\n",
+    "entrainee sur une archive arretee en cours de route souffrira d'un biais de survivant temporel sans erreur\n",
+    "apparente."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 3 : Ajouter ETH a l'archive et calculer la beta\n\nTelechargez les données **ETH** et ajoutez-les a l'archive crypto. Calculez ensuite la **beta de BTC par rapport a ETH** (sensibilite du prix BTC aux mouvements d'ETH).\n\n**Indices** :\n- `# Indice` : Beta = covariance(BTC, ETH) / variance(ETH)\n- `# Indice` : Utilisez `np.cov()` ou `.cov()` de pandas\n- `# Étape 1` : Telecharger ETH avec le script manage_crypto_archive.py\n- `# Étape 2` : Calculer les returns de BTC et ETH\n- `# Étape 3` : Calculer beta = cov(BTC,ETH) / var(ETH)"
+    "### Exercice 3 : Ajouter ETH a l'archive et calculer la beta\n",
+    "\n",
+    "Telechargez les données **ETH** et ajoutez-les a l'archive crypto. Calculez ensuite la **beta de BTC par rapport a ETH** (sensibilite du prix BTC aux mouvements d'ETH).\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Indice` : Beta = covariance(BTC, ETH) / variance(ETH)\n",
+    "- `# Indice` : Utilisez `np.cov()` ou `.cov()` de pandas\n",
+    "- `# Étape 1` : Telecharger ETH avec le script manage_crypto_archive.py\n",
+    "- `# Étape 2` : Calculer les returns de BTC et ETH\n",
+    "- `# Étape 3` : Calculer beta = cov(BTC,ETH) / var(ETH)\n",
+    "\n",
+    "**Interpretation attendue** : la beta de BTC par rapport a ETH devrait sortir nettement superieure a 1 —\n",
+    "les deux actifs partagent les memes cycles de flux crypto, et ETH est historiquement plus volatil. Une beta\n",
+    "proche de 1 signifierait que BTC bouge iso-ETH ; une beta negative serait le signal d'un bug d'alignement\n",
+    "de dates, pas d'une decouverte economique."
    ],
    "id": "cell-3a5f1ab1"
   },
@@ -917,7 +1055,20 @@
     "- Crypto intraday → `download_binance_archive.py` (haute résolution, volume réel).\n",
     "- Backtest QC Cloud identique au live → `download_qc_data.py` (même moteur que la platform).\n",
     "\n",
-    "Documentation complète : `scripts/datasets/README.md`"
+    "Documentation complète : `scripts/datasets/README.md`\n",
+    "\n",
+    "### Les trois pieges recurrents de ce workflow\n",
+    "\n",
+    "1. **Epoch millisecondes** : les klines Binance horodatent en ms numeriques ; oublier\n",
+    "   `pd.to_datetime(..., unit=\"ms\")` donne des dates en 1970 et des merges vides.\n",
+    "2. **Calendriers heterogenes** : actions ~252 j/an vs crypto ~365 j/an — tout merge SPY/BTC doit passer par\n",
+    "   les dates communes (`merge` sur la date), jamais par l'index positionnel.\n",
+    "3. **Casse des colonnes** : yfinance sert `Close`, l'archive crypto sert `close` — unifiant avant tout\n",
+    "   traitement croise.\n",
+    "\n",
+    "Ces trois pieges sont exactement ceux que les exercices 2 et 3 vous font manipuler : la correlation exige le\n",
+    "merge de calendriers, la beta exige l'unification de casse. Le workflow de donnees n'est pas un preliminaire\n",
+    "technique — c'est la ou la majorite des biais silencieux d'un backtest naissent."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-dotnet #11283

## Tranche 5 #11224 : QC-Py-Dataset-Workflow — densité 663 -> 1269 (See #11224)

Rotation de genre après 2 DEEP/notebook-dotnet consécutifs (#11280 LP Glop, #11283 GA GeneticSharp) : ce grain est de la prose pédagogique notebook-python, pattern #10488 établi (tranches 1-4 mergées : #11228/#11229/#11237/#11247/#11248/#11252/#11263/#11270).

### Livrable

Enrichissement **markdown-only FR** de `QC-Py-Dataset-Workflow.ipynb` (31 -> 34 cellules, 14 cellules code **byte-identiques** — asserté par le script d'injection) :

- **3 nouvelles cellules markdown** : « Ou vivent les fichiers ? » (chemin relatif DATASETS_DIR, ancré sur l'output `..\datasets`), 2 « Lecture du graphique » après les plots SPY et BTC (ancrées sur les outputs `<Figure size 1200x400 with 1 Axes>` + bornes imprimées par les cellules de chargement adjacentes).
- **Étoffement des 8 « Lecture du résultat » existantes** : arithmétique du compte 1257 (5 ans x ~252 j - fériés), prix adjoints yfinance (décimales du Close), colonnes minuscules vs majuscules au merge, canari de validité mensuel Binance (31/29/31), borne de départ de l'update = dernière date présente, archives zombies dans `--list`.
- **Interprétations attendues des 3 exercices** (corrélation BTC/SPY ~0.1-0.5 instable, beta BTC/ETH > 1 attendu) — contexte de lecture, pas solutions.
- **Section « Les trois pièges récurrents »** au résumé : epoch ms, calendriers hétérogènes 252/365 j, casse des colonnes — reliée explicitement aux exercices 2-3 qui les manipulent.

### Fix d'ancrage inclus (cell-interpretation-ordering)

La cellule « Lecture du résultat » après la construction de l'archive BTC citait « ~3746 $ » alors que cette valeur n'est imprimée que par la cellule **suivante** (chargement du DataFrame). La lecture du prix est déplacée vers la cellule qui suit l'output qui l'imprime ; la cellule d'origine reçoit une prose ancrée sur son output adjacent (2191 rows).

### Mesure (organe `pedagogy_density.py`, worktree sur origin/main 268917a45)

```text
avant : prose_chars 9283 / code_cells 14 -> density 663 (below_threshold)
apres : prose_chars 17771 / code_cells 14 -> density 1269 (ok)
```

### Validation

- 0 cellule code touchée (comparaison JSON byte-identique avant/après, assert dans le script).
- `scan_cell_ordering.py` : 1 notebook, 0 finding.
- nbformat validate OK, ids uniques, aucune markdown polluée (outputs/exec absents).
- Markdown-only => pas de re-exécution requise (C.3 exception markdown-only), outputs committés inchangés.

### Checklist

- [x] Scope : 1 sujet, 1 fichier notebook
- [x] Catalogue : byte-identique à main (non touché)
- [x] Claim paths-scoped posé avant édition (comment 5307551812), L898 : 0 PR ouverte sur le chemin
- [x] Cible >1200 atteinte avec marge (1269)
- [x] Interps ancrées sur outputs adjacents (règle cell-interpretation-ordering)

See #11224 (tranche 5/22 ; restantes mesurées sur main : 34-RL-SAC 702, 33-RL-PPO 712, 15-ParamOpt 734, 12-Backtesting 746, 32-RL-DQN 788, 30-LSTM 968, Cloud-01 1010 + queue CI 26/12b/19)

Generated with Claude Code

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
