### PR TITLE
docs(groth,#11123): reecriture d'ensemble README FR+EN — narration, Partie 44, umbrella honnete (#11286)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.en.md
@@ -2,36 +2,100 @@
 
 Alexandre Grothendieck (1928-2014).
 
-## Status
+Grothendieck shifted the object of study: rather than dissecting each structure
+in isolation, he built the categories, sites, and sheaves that carry them — and
+let theorems fall out as corollaries. This workspace shows that this language
+**already lives in Mathlib 4**: a guided tour of the Grothendieckian landscape
+as the library formalizes it today.
 
-- **Toolchain**: `leanprover/lean4:v4.31.0-rc1`
-- **Sorry**: **0 sorry, 0 axiom** — all 43 leaf modules are complete at creation
-- **Build**: `lake build Grothendieck` — compiles the 43 leaf modules (20,988 FR+EN lines, + 217 for the umbrella = **21,205 total**, measured 2026-08-16)
-- **Dependencies**: Mathlib 4 (via `lakefile.lean`)
-- **i18n coverage (EPIC #4980, ratified 2026-07-04)**: complete bilingual FR/EN coverage — **44 FR files** (1 umbrella `Grothendieck.lean` bilingual inline FR+EN + **43 leaf modules** FR canonical, incl. Part 34 `ExceptionalDirect.lean` via #10357 on 2026-08-11 and Parts 35-43 via the Phase 5 waves of #2159 on 2026-08-14..16) + **43 `_en.lean` siblings** on `main` (leaf modules only; the umbrella is bilingual inline). Per the ratified convention (Option A: `Foo.lean` FR canonical + `Foo_en.lean` EN mirror for leaves), **all 43 leaf modules** are bilingual in Pattern A (`_en` namespaces anti-collision, non-docstring content byte-identical CI-detectable). The umbrella `Grothendieck.lean` is bilingual inline (FR canonical first, EN mirror, see final doctring in the file) — *by design*, not an i18n gap. **`README.md`** present (FR canonical sibling of this file). Out-of-scope: `.lake/packages/`, vendored libs.
+## The spirit of the tour
 
-## Purpose
+This workspace is a **pedagogical homage** — deliberately **not** an attempt to
+formalize EGA/SGA. The goal is to give learners a curated entry point into:
 
-This workspace is a **pedagogical homage** showing how Grothendieck's mathematical
-language already lives in Mathlib 4. It is **not** an attempt to formalize EGA/SGA.
-
-The goal is to give learners a curated entry point into:
 - Categories, sieves, and Grothendieck topologies
 - Sheaves, separated presheaves, subcanonical topologies
 - Coverage generation and sheaf characterization
 - The canonical topology and subcanonical sites
-- Schemes (locally ringed spaces locally Spec R)
-- The Zariski site
+- Schemes (locally ringed spaces locally Spec R) and the Zariski site
 - What Mathlib has and what it doesn't (yet)
 
-## Structure
+## The arc
 
-The formalization spans **43 leaf modules (20,988 FR+EN lines, 0 sorry)**, imported
-in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline FR/EN; no `_en` sibling for the umbrella).
+The **44 leaf modules** (0 `sorry`, 0 axiom added) trace a coherent path, from
+the raw site up to cohomology:
+
+```mermaid
+flowchart LR
+    T1["<b>Sites & sieves</b><br/><i>Parts 1·6·8·11·12·16</i><br/>Grothendieck topologies<br/>pullback_id · pullback_monotone"]
+    T2["<b>Sheaves & separation</b><br/><i>7·9·10·17</i><br/>separated presheaf<br/>transfer along J₁ ≤ J₂"]
+    T3["<b>Sheafification</b><br/><i>13·14</i><br/>associated sheaf functor<br/>left exactness (LeftExact)"]
+    T4["<b>Points & conservatives</b><br/><i>15·19</i><br/>fiber functors<br/>conservative families"]
+    T5["<b>Cohomology</b><br/><i>20·21·22·23</i><br/>Ext · Mayer-Vietoris · Čech"]
+    T1 --> T2 --> T3 --> T4 --> T5
+    S["<b>Schemes & Zariski site</b><br/><i>Parts 2·3</i><br/>Spec functor<br/>zariski_topology_eq"] -.->|"geometric anchor"| T1
+    MM["<b>Mathlib map</b><br/><i>Part 4</i><br/>#check index"] -.->|"library anchor"| T3
+```
+
+**Laying out the site** (Parts 1, 6, 8, 11, 12, 16). Everything starts from a
+category equipped with a Grothendieck topology — trivial, discrete, dense,
+canonical. Sieves there form a lattice traversed by pullback (`pullback_id`,
+`pullback_pullback`, `pullback_monotone`…), and every topology can be compared,
+generated, and closed under covering.
+
+**Building the sheaf** (Parts 7, 9, 10, 13, 14, 17, 18). Above the site live
+the presheaves; the gluing condition — uniqueness then existence — defines
+separation and then the sheaf, transferable along J₁ ≤ J₂. Sheafification (the
+associated sheaf functor, left exact) converts any presheaf into a sheaf:
+
+```mermaid
+flowchart TD
+    SITE["<b>Site</b><br/><i>category + Grothendieck topology</i><br/>(Part 1)"]
+    PSH["<b>Presheaf</b><br/><i>objects Cᵒᵖ → Type*</i>"]
+    SEP["<b>Separated presheaf</b><br/>uniqueness of gluing"]
+    SH["<b>Sheaf</b><br/>existence + uniqueness of gluing"]
+    SHIF["<b>Sheafification</b><br/><i>associated sheaf functor</i><br/>Part 13 — left exactness (Part 14)"]
+    COH["<b>Sheaf cohomology</b><br/>Parts 20-23<br/>Ext · Mayer-Vietoris · Čech"]
+    SITE --> PSH --> SEP --> SH
+    SHIF -.->|"produces a sheaf<br/>from a presheaf"| SH
+    SH --> COH
+    TR["<b>Sheaf transfer</b><br/>along J₁ ≤ J₂<br/>(Part 7)"] -.-> SH
+```
+
+**Making the points speak, measuring cohomology** (Parts 15, 19, 20-23). The
+points of a site (fiber functors) and their conservative families tie the
+theory to its models; sheaf cohomology — via Ext, Mayer-Vietoris, and Čech —
+is its measuring instrument.
+
+**The anchors.** On the geometry side, schemes and the Zariski site (Parts 2,
+3) tie the tour back to the original algebraic geometry, with the bridge
+theorem `zariski_topology_eq`. On the library side, the Mathlib map (Part 4,
+a `#check` index) states honestly what exists and what is missing, and
+`Calibration.lean` (Part 5) feeds the prover harness (Epic #1453).
+
+**The categorical foundations** (Parts 24-32). Yoneda, adjunctions, monads,
+comma categories, (co)limits, equivalences, Kan extensions, monoidal
+categories: the bedrock on which everything above is written.
+
+**The two recent veins** (Parts 33-44). The *six operations* thread opens with
+`DirectImage.lean` (Part 33, indexing the `f^* ⊣ f_*` adjunction) then
+`ExceptionalDirect.lean` (Part 34, #10357) which formalizes `f_! ⊣ f^*` at the
+presheaf level — the proper-support direct image as a left Kan extension, the
+missing link between `f^*` and `f_*`. In parallel, the *covering* program
+(Phase 5 of Epic #2159, waves 2026-08-14..16: #10879 → #11244) systematizes
+the arrow and bundled forms of the covering — from `covers_comp_iff` to the
+arrow form of the dense topology (Part 44), through the pullback pseudofunctor
+laws and the lattice of topologies.
+
+## Code structure
+
+The formalization spans **44 leaf modules** + **1 umbrella** `Grothendieck.lean`
+(imports-only, bilingual inline FR/EN). The three `SheafCohomology/`
+sub-modules are Parts 20, 22, and 23 of the table.
 
 | Part | File | `_en` | Content | Lines |
 |------|------|-------|---------|-------|
-| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only of the 43 leaves + bilingual FR/EN doctring); no `_en` sibling (the EN content lives in the same file as a mirror) | 217 |
+| root | `Grothendieck.lean` | (bilingual inline) | **Umbrella root** (imports-only + bilingual FR/EN doctring); imports 43 of the 44 leaves — the `ExceptionalDirect` import is pending ([#11286](https://github.com/jsboige/CoursIA/issues/11286)) | 218 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Sieves, Grothendieck topologies (trivial/discrete/dense), three axioms | 243 |
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Scheme type, Spec functor, Γ, `homeoOfIso`, fully-faithful | 196 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Zariski pretopology, `zariskiTopology_eq` bridge theorem, subcanonical | 139 |
@@ -75,41 +139,26 @@ in order by the umbrella `Grothendieck.lean` (which is itself bilingual inline F
 | 41 | `Grothendieck/CoversOrder.lean` | `CoversOrder_en.lean` | Order laws of the arrow form `J.Covers`: `covers_top/bot_iff`, `covers_inter_iff`, `covers_of_covering`, `covers_generate_sieve` (#11068, Phase 5 of #2159) | 164 |
 | 42 | `Grothendieck/PullbackCoversLaws.lean` | `PullbackCoversLaws_en.lean` | Arrow-form laws under iterated pullback: `covers_pullback_assoc`, `covers_pullback_id`, `covers_pullback_generate` (#11217, Phase 5 of #2159) | 160 |
 | 43 | `Grothendieck/CoversLattice.lean` | `CoversLattice_en.lean` | Indexed lattice laws of the arrow form: `sInf/sSup_covering`, `sInf/sSup_covers` (#11231, Phase 5 of #2159) | 106 |
+| 44 | `Grothendieck/CoversTopologies.lean` | `CoversTopologies_en.lean` | Arrow form of the dense topology: `dense_covers_iff`, `dense_covers_precomp` (precomposition stability), `dense_covers_id` (#11244, Phase 5 of #2159) | 115 |
 
-*The `Lines` column counts the **FR file alone**; the FR+EN total is roughly double.*
+*The `Lines` column counts the **FR file alone**; the `_en` sibling adds
+roughly as much again.*
 
-The extension was developed under Issue #2159 / Epic #1646: the 43 leaf modules
-are merged + 1 bilingual umbrella, 0 `sorry`, 0 axiom added. Phase 2 (Part 34
-`f_! ⊣ f^*`) shipped by PR #10357 (MERGED 2026-08-11); Phase 5 (Parts 35-43,
-arrow/bundled forms of the covering and pullback laws) shipped by waves
-(2026-08-14..16: #10879, #10912, #11023, #11035, #11038, #11057, #11068, #11217,
-#11231); Phase 1 (Parts 1-33) previously shipped by PR waves (#2675, #8882, etc.).
+## Build & status
 
-## Build
-
-```bash
-# From this directory (WSL required)
-lake build Grothendieck
-# Builds the 43 leaf modules + 1 bilingual umbrella (21,205 FR+EN lines total)
-# Last verified build: 2026-07-30, "Build completed successfully (2821 jobs)" (counters re-audited 2026-08-16)
-```
-
-## Sorry count
-
-**0 sorry, 0 axiom** — all 43 leaf modules are complete at creation
-(the umbrella `Grothendieck.lean` is imports-only without declarations).
-
-## Toolchain
-
-Aligned with other SymbolicAI/Lean projects: `leanprover/lean4:v4.31.0-rc1`
+- **Toolchain**: `leanprover/lean4:v4.31.0-rc1` (aligned with the other SymbolicAI/Lean projects)
+- **Build**: `lake build` (WSL required). The default target (`globs := #[`Grothendieck.*]` in `lakefile.lean`) compiles **all** FR and `_en` modules. Last verified build: 2026-08-12, "Build completed successfully". The explicit target `lake build Grothendieck` (the umbrella's import closure) currently omits `ExceptionalDirect` — see [#11286](https://github.com/jsboige/CoursIA/issues/11286).
+- **Proofs**: **0 `sorry`, 0 axiom added** — every module is complete at creation. (A naive `grep sorry` matches prose mentions in the bilingual docstrings, notably two in `ExceptionalDirect.lean`; CI counts in `real` mode — after comment stripping — and reads 0.)
+- **Dependencies**: Mathlib 4 (via `lakefile.lean`)
+- **i18n** (EPIC #4980, Option A convention ratified 2026-07-04): complete bilingual coverage — 45 FR files (1 umbrella + 44 canonical leaves) and 44 `_en.lean` siblings (`_en` namespaces anti-collision, non-docstring content byte-identical, CI-detectable). The umbrella is bilingual inline *by design* (FR canonical first, EN mirrored in the same file). **[`README.md`](./README.md)** is the FR canonical sibling of this file. Out-of-scope: `.lake/packages/`, vendored libs.
 
 ## References
 
-The language toured here — Grothendieck topologies, sites, sheaves, and schemes — originates in Grothendieck's algebraic geometry. These are the canonical entry points. This workspace is a pedagogical tour indexed against Mathlib, **not** a formalization of EGA/SGA.
+The language toured here — Grothendieck topologies, sites, sheaves, and schemes — originates in Grothendieck's algebraic geometry. These are the canonical entry points; this workspace is a tour indexed against Mathlib, **not** a formalization of EGA/SGA.
 
 - **Mac Lane, S.; Moerdijk, I.** *Sheaves in Geometry and Logic: A First Introduction to Topos Theory*. Springer Universitext, 1992. — Standard reference for Grothendieck topologies, sieves, sites, and sheaves (Parts 1, 6-8, 10, 13-14).
-- **Artin, M.; Grothendieck, A.; Verdier, J. L.**, eds. *Theorie des topos et cohomologie etale des schemas* (SGA 4). Springer Lecture Notes in Mathematics 269, 270, 305, 1972-1973. — Origin of sites, Grothendieck topologies, and points of a topos (Parts 1, 15, 19).
-- **Grothendieck, A.; Dieudonne, J.** *Elements de geometrie algebrique* (EGA). Publications Mathematiques de l'IHES, 1960-1967. — Origin of schemes and the Zariski site (Parts 2-3).
+- **Artin, M.; Grothendieck, A.; Verdier, J. L.**, eds. *Théorie des topos et cohomologie étale des schémas* (SGA 4). Springer Lecture Notes in Mathematics 269, 270, 305, 1972-1973. — Origin of sites, Grothendieck topologies, and points of a topos (Parts 1, 15, 19).
+- **Grothendieck, A.; Dieudonné, J.** *Éléments de géométrie algébrique* (EGA). Publications Mathématiques de l'IHÉS, 1960-1967. — Origin of schemes and the Zariski site (Parts 2-3).
 - **Vakil, R.** *The Rising Sea: Foundations of Algebraic Geometry*. — Widely used pedagogical notes in the Grothendieckian spirit.
 - **The Stacks Project.** [stacks.math.columbia.edu](https://stacks.math.columbia.edu) — Reference for schemes, sheafification, and sheaf cohomology (Parts 13, 20-23).
 - **The Mathlib Community.** *Mathlib4, Category Theory and Sites*. [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/) — The library this tour indexes (Part 4); see de Moura & Ullrich, "The Lean 4 Theorem Prover" (2021).
@@ -117,57 +166,24 @@ The language toured here — Grothendieck topologies, sites, sheaves, and scheme
 
 ## See also
 
-- Epic #1646 (Grothendieck tribute)
-- Issue #2159 (Grothendieck formalization depth)
-- PR #2675 (Phases 4-6: SieveOps + CoverageGen + CanonicalProps)
-- Epic #1453 (prover harness calibration)
-- Conway tribute workspace (`../conway_lean/`)
-- Lean notebook series (`../README.md`)
-- **EPIC #4980** — Lean i18n convention (Option A sibling pair post-2026-07-04; 43 `_en.lean` siblings on `main` in this lake + 1 bilingual inline umbrella)
-- Issue #8960 (reconciling the two `Part` numberings)
+- Epic #1646 (Grothendieck tribute) — Issue #2159 (formalization depth: Phase 1 shipped, Phase 2 = #10357, Phase 5 = Parts 35-44)
+- EPIC #4980 — Lean i18n convention (Option A sibling pair; 44 `_en` pairs in this lake)
+- Epic #1453 (prover harness calibration) — Issue #8960 (reconciling the two `Part` numberings)
+- [#11286](https://github.com/jsboige/CoursIA/issues/11286) — pending umbrella import of `ExceptionalDirect`
+- Conway tribute workspace (`../conway_lean/`) — Lean notebook series (`../README.md`)
 - **[`README.md`](./README.md)** — FR canonical sibling of this file
 
-## Conclusion
+## Scope, honestly
 
-This tribute is a **complete pedagogical tour** (43 leaf modules + 1 bilingual umbrella, 21,205 FR+EN lines, 0 `sorry`,
-0 axiom added) showing how Grothendieck's language — sites, sheaves,
-sheafification, points, cohomology, Yoneda, direct images, covering forms —
-already lives in Mathlib 4. It is
-deliberately **not** a formalization of EGA/SGA; it is a curated index that lets
-learners see the library through Grothendieckian eyes.
+Every result is fully proven (0 `sorry`, 0 axiom added), and Part 4's `#check`
+index documents explicitly the boundary between what Mathlib has and what it
+does not (yet) — the tour exposes that boundary rather than papering over it.
+The companion `Calibration.lean` (Part 5) ties the formalization to the
+broader proving effort.
 
-### The arc
-
-The modules trace a coherent path: **sites and sieves** (Parts 1, 6, 8, 11, 12,
-16) → **sheaves, separation, and transfer** (7, 9, 10, 17) → **sheafification and
-its left exactness** (13, 14) → **points and conservative families** (15, 19) →
-**sheaf cohomology, Mayer-Vietoris, and Čech** (20-23), with **schemes and the
-Zariski site** (2, 3), a **Mathlib map** (4), and the **Yoneda lemma** (24)
-anchoring the tour to the library it indexes. The categorical foundations
-(Adjunction, Equivalences, Monads) at Parts 25, 29, 26 underpin the whole
-formalization. `DirectImage.lean` indexes the `f^* ⊣ f_*` adjunction — the
-simplest instance of the "six operations", transporting sheaves along morphisms
-of schemes. `ExceptionalDirect.lean` (Part 34, #10357) climbs a rung by
-formalizing `f_! ⊣ f^*` at the presheaf level — the *proper-support* direct
-image as a left Kan extension of `f^*`, the missing link between `f^*`
-(inverse image) and `f_*` (direct image). Parts 35-43 extend the *covering*
-side: arrow and bundled forms of `J.Cover`, pullback functor and topology
-order/lattice laws (CoversArrow, Cover, PullbackFunctor, PullbackFunctorLaws,
-TopologyLattice, CoversPullback, CoversOrder, PullbackCoversLaws, CoversLattice,
-Phase 5 of #2159).
-
-### Scope, honestly
-
-Per the `## Sorry count` section above, the tour is **0 `sorry`, 0 axiom added** —
-every result is fully proven. Part 4's `#check` index is explicit about what
-Mathlib has and what it does not (yet); the tour documents that boundary rather
-than papering over it. The companion `Calibration.lean` (Part 5) feeds the prover
-harness (Epic #1453), tying this formalization to the broader proving effort.
-
-### Where to go next
-
-- **Depth**: Issue #2159 / Epic #1646 track further formalization — this tour is
-  the foundation, not the ceiling.
-- **Companions**: `conway_lean/` (Conway's mathematics), the Lean notebook series.
-- **References**: Mac Lane–Moerdijk and SGA 4 for the topos-theoretic core; Vakil
-  and the Stacks Project for schemes and cohomology.
+This tribute is a **curated index** that lets learners see the library through
+Grothendieckian eyes; Issue #2159 / Epic #1646 track further formalization —
+this tour is the foundation, not the ceiling. To go further: `conway_lean/`
+and the Lean notebook series as companions; Mac Lane–Moerdijk and SGA 4 for
+the topos-theoretic core; Vakil and the Stacks Project for schemes and
+cohomology.

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/README.md
@@ -2,46 +2,29 @@
 
 Alexandre Grothendieck (1928-2014).
 
-## État
+Grothendieck a déplacé l'objet d'étude : plutôt que disséquer chaque structure
+isolément, il a construit les catégories, les sites et les faisceaux qui les
+portent — et laissé les théorèmes tomber comme des corollaires. Ce workspace
+montre que ce langage **vit déjà dans Mathlib 4** : c'est une visite guidée du
+paysage grothendieckien telle que la bibliothèque la formalise aujourd'hui.
 
-- **Toolchain** : `leanprover/lean4:v4.31.0-rc1`
-- **Sorry** : **0 sorry, 0 axiome** — les 43 modules leaf sont complets à la création
-- **Build** : `lake build Grothendieck` — compile 43 modules leaf + 1 umbrella bilingue (re-audité 2026-08-16)
-- **Dépendances** : Mathlib 4 (via `lakefile.lean`)
-- **Couverture i18n (EPIC #4980 ratifiée 2026-07-04)** : couverture bilingue FR/EN complète — **44 fichiers FR** (1 umbrella `Grothendieck.lean` bilingue inline FR+EN + **43 modules leaf** FR canonique, dont `ExceptionalDirect.lean` Partie 34 ajouté via #10357 le 2026-08-11 et les Parties 35-43 via les vagues Phase 5 de #2159 le 2026-08-14..16) + **43 siblings `_en.lean`** sur `main` (les 43 modules leaf uniquement ; l'umbrella est bilingue inline). Conformément à la convention ratifiée (Option A : `Foo.lean` FR canonique + `Foo_en.lean` miroir EN pour les leafs), **tous les 43 modules leaf** sont déjà bilingues au pattern A (namespaces `_en` anti-collision, contenu non-docstring byte-identique détectable par CI). L'umbrella `Grothendieck.lean` est bilingue inline (FR canonique d'abord, EN en miroir, cf doctring final du fichier) — c'est *by design*, pas un gap i18n. **`README.en.md`** présent (miroir EN du présent fichier). Hors-scope : `.lake/packages/`, libs vendored.
+## L'esprit de la visite
 
-## Objectif
+Ce workspace est un **hommage pédagogique** — délibérément **pas** une
+tentative de formaliser EGA/SGA. Le but est d'offrir aux apprenants un point
+d'entrée curaté vers :
 
-Ce workspace est un **hommage pédagogique** montrant comment le langage
-mathématique de Grothendieck vit déjà dans Mathlib 4. Ce n'est **pas** une
-tentative de formaliser EGA/SGA.
-
-Le but est d'offrir aux apprenants un point d'entrée curaté vers :
 - Catégories, cribles (sieves) et topologies de Grothendieck
 - Faisceaux (sheaves), prefaisceaux séparés, topologies sous-canoniques
 - Génération de recouvrements (coverage) et caractérisation des faisceaux
 - La topologie canonique et les sites sous-canoniques
-- Schémas (espaces annelés en anneaux locaux localement Spec R)
-- Le site de Zariski
+- Schémas (espaces annelés en anneaux locaux localement Spec R) et site de Zariski
 - Ce que Mathlib possède et ce qu'il n'a pas (encore)
 
-## Structure
+## La trajectoire
 
-La formalisation couvre **43 modules leaf (0 sorry)** + **3 sous-modules
-SheafCohomology/** (Basic + MayerVietoris + Cech, déjà comptés dans la Partie
-20-22), importés dans l'ordre par le parapluie `Grothendieck.lean` (qui est
-lui-même bilingue inline FR/EN, pas de sibling `_en` pour l'umbrella). La Partie
-34 (`ExceptionalDirect.lean`) a été ajoutée par **PR #10357 (MERGED 2026-08-11)** —
-extension Phase 2 de l'Epic #2159 qui formalise l'image directe exceptionnelle
-`f_!` au niveau préfaisceau et son adjonction `f_! ⊣ f^*` (extension de Kan
-à gauche de `f^*` le long de `f`). Les **Parties 35-43** (formes flèche et
-bundlée de la couverture, lois du foncteur pullback et de l'ordre/treillis des
-topologies — CoversArrow, Cover, PullbackFunctor, PullbackFunctorLaws,
-TopologyLattice, CoversPullback, CoversOrder, PullbackCoversLaws, CoversLattice)
-ont été ajoutées par les vagues **Phase 5 de l'Epic #2159** (mergées
-2026-08-14..16).
-
-*La trajectoire pédagogique des 43 modules leaf — des sites et cribles jusqu'à la cohomologie, avec schémas/Zariski et carte Mathlib en ancrage :*
+Les **44 modules leaf** (0 `sorry`, 0 axiome ajouté) tracent un chemin cohérent,
+du site brut jusqu'à la cohomologie :
 
 ```mermaid
 flowchart LR
@@ -55,9 +38,67 @@ flowchart LR
     MM["<b>Carte Mathlib</b><br/><i>Partie 4</i><br/>index #check"] -.->|"ancre bibliothèque"| T3
 ```
 
+**Poser le site** (Parties 1, 6, 8, 11, 12, 16). Tout part de la donnée d'une
+catégorie munie d'une topologie de Grothendieck — triviale, discrète, dense,
+canonique. Les cribles y forment un treillis que le pullback parcourt
+(`pullback_id`, `pullback_pullback`, `pullback_monotone`…), et chaque topologie
+se compare, se génère et se ferre par clôture de recouvrement.
+
+**Construire le faisceau** (Parties 7, 9, 10, 13, 14, 17, 18). Au-dessus du
+site vivent les préfaisceaux ; la condition de recollement — unicité puis
+existence — définit la séparation puis le faisceau, transférable le long de
+J₁ ≤ J₂. La faisceautisation (foncteur faisceau associé, exact à gauche)
+convertit tout préfaisceau en faisceau :
+
+```mermaid
+flowchart TD
+    SITE["<b>Site</b><br/><i>catégorie + topologie de Grothendieck</i><br/>(Partie 1)"]
+    PSH["<b>Préfaisceau</b><br/><i>objets Cᵒᵖ → Type*</i>"]
+    SEP["<b>Préfaisceau séparé</b><br/>unicité du recollement"]
+    SH["<b>Faisceau</b><br/>existence + unicité du recollement"]
+    SHIF["<b>Faisceautisation</b><br/><i>foncteur faisceau associé</i><br/>Partie 13 — exactitude à gauche (Partie 14)"]
+    COH["<b>Cohomologie des faisceaux</b><br/>Parties 20-23<br/>Ext · Mayer-Vietoris · Čech"]
+    SITE --> PSH --> SEP --> SH
+    SHIF -.->|"produit un faisceau<br/>depuis un préfaisceau"| SH
+    SH --> COH
+    TR["<b>Transfert de faisceau</b><br/>le long de J₁ ≤ J₂<br/>(Partie 7)"] -.-> SH
+```
+
+**Faire parler les points, mesurer la cohomologie** (Parties 15, 19, 20-23).
+Les points d'un site (foncteurs fibres) et leurs familles conservatrices
+relient la théorie à ses modèles ; la cohomologie des faisceaux — via Ext,
+Mayer-Vietoris et Čech — en est l'instrument de mesure.
+
+**Les ancrages.** Côté géométrie, les schémas et le site de Zariski
+(Parties 2, 3) relient la visite à la géométrie algébrique d'origine, avec le
+théorème-pont `zariski_topology_eq`. Côté bibliothèque, la carte Mathlib
+(Partie 4, index `#check`) dit honnêtement ce qui existe et ce qui manque, et
+`Calibration.lean` (Partie 5) alimente le harnais du prouveur (Epic #1453).
+
+**Les fondations catégorielles** (Parties 24-32). Yoneda, adjonctions,
+monades, catégories comma, (co)limites, équivalences, extensions de Kan,
+catégories monoïdales : le socle sur lequel tout ce qui précède s'écrit.
+
+**Les deux veines récentes** (Parties 33-44). Le fil des *six opérations*
+s'ouvre avec `DirectImage.lean` (Partie 33, index de l'adjonction `f^* ⊣ f_*`)
+puis `ExceptionalDirect.lean` (Partie 34, #10357) qui formalise `f_! ⊣ f^*`
+au niveau préfaisceau — l'image directe à support propre comme extension de
+Kan à gauche, chaînon manquant entre `f^*` et `f_*`. En parallèle, le
+programme *couverture* (Phase 5 de l'Epic #2159, vagues 2026-08-14..16 :
+#10879 → #11244) systématise la forme flèche et la forme bundlée de la
+couverture — de `covers_comp_iff` jusqu'à la forme flèche de la topologie
+dense (Partie 44), en passant par les lois du pseudofoncteur pullback et le
+treillis des topologies.
+
+## Structure du code
+
+La formalisation couvre **44 modules leaf** + **1 umbrella** `Grothendieck.lean`
+(imports-only, bilingue inline FR/EN). Les trois sous-modules de
+`SheafCohomology/` sont les Parties 20, 22 et 23 du tableau.
+
 | Partie | Fichier | `_en` | Contenu | Lignes |
 |--------|---------|-------|---------|--------|
-| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only des 43 leaf + doctring bilingue FR/EN) ; pas de sibling `_en` (le contenu EN vit dans le même fichier en miroir) | 217 |
+| racine | `Grothendieck.lean` | (bilingue inline) | **Racine umbrella** (imports-only + doctring bilingue FR/EN) ; importe 43 des 44 leaf — l'import de `ExceptionalDirect` est en attente ([#11286](https://github.com/jsboige/CoursIA/issues/11286)) | 218 |
 | 1 | `Grothendieck/CategoryAndSites.lean` | `CategoryAndSites_en.lean` | Cribles, topologies de Grothendieck (triviale/discrète/dense), trois axiomes | 243 |
 | 2 | `Grothendieck/SchemesTour.lean` | `SchemesTour_en.lean` | Type des schémas, foncteur Spec, Γ, `homeoOfIso`, pleinement fidèle | 196 |
 | 3 | `Grothendieck/ZariskiSite.lean` | `ZariskiSite_en.lean` | Prétopologie de Zariski, théorème-pont `zariskiTopology_eq`, sous-canonique | 139 |
@@ -82,7 +123,7 @@ flowchart LR
 | 22 | `Grothendieck/SheafCohomology/MayerVietoris.lean` | `SheafCohomology/MayerVietoris_en.lean` | Suite exacte longue de Mayer-Vietoris | 235 |
 | 23 | `Grothendieck/SheafCohomology/Cech.lean` | `SheafCohomology/Cech_en.lean` | Cohomologie de Čech | 203 |
 | 24 | `Grothendieck/YonedaLemma.lean` | `YonedaLemma_en.lean` | Le lemme de Yoneda (plongement, équivalence, naturalité, pleinement fidèle, coyoneda) | 275 |
-| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unit, lemme de la tortue (turtle), adjoints à droite/gauche | 335 |
+| 25 | `Grothendieck/Adjunction.lean` | `Adjunction_en.lean` | Adjonction de foncteurs, unité/co-unité, lemme de la tortue (turtle), adjoints à droite/gauche | 335 |
 | 26 | `Grothendieck/Monads.lean` | `Monads_en.lean` | Monades en théorie des catégories, unité, multiplication, loi d'association | 253 |
 | 27 | `Grothendieck/Comma.lean` | `Comma_en.lean` | Catégorie comma, projections, fonctorialité | 239 |
 | 28 | `Grothendieck/Limits.lean` | `Limits_en.lean` | Limites et colimites | 421 |
@@ -101,111 +142,54 @@ flowchart LR
 | 41 | `Grothendieck/CoversOrder.lean` | `CoversOrder_en.lean` | Lois d'ordre de la forme flèche `J.Covers` : `covers_top/bot_iff`, `covers_inter_iff`, `covers_of_covering`, `covers_generate_sieve` (#11068, Phase 5 de #2159) | 164 |
 | 42 | `Grothendieck/PullbackCoversLaws.lean` | `PullbackCoversLaws_en.lean` | Lois de la forme flèche sous pullback itéré : `covers_pullback_assoc`, `covers_pullback_id`, `covers_pullback_generate` (#11217, Phase 5 de #2159) | 160 |
 | 43 | `Grothendieck/CoversLattice.lean` | `CoversLattice_en.lean` | Lois de treillis indexées de la forme flèche : `sInf/sSup_covering`, `sInf/sSup_covers` (#11231, Phase 5 de #2159) | 106 |
+| 44 | `Grothendieck/CoversTopologies.lean` | `CoversTopologies_en.lean` | Forme flèche de la topologie dense : `dense_covers_iff`, `dense_covers_precomp` (stabilité par précomposition), `dense_covers_id` (#11244, Phase 5 de #2159) | 115 |
 
-*La colonne `Lignes` compte le **fichier FR seul** ; le total FR+EN est le double approximatif.*
+*La colonne `Lignes` compte le **fichier FR seul** ; le sibling `_en` ajoute
+approximativement autant.*
 
-L'extension a été développée sous l'Issue #2159 / Epic #1646 : les **43 modules leaf**
-sont mergés + 1 umbrella bilingue, 0 `sorry`, 0 axiome ajouté. **Phase 2** (Partie 34
-`f_! ⊣ f^*`) livrée par PR #10357 (MERGED 2026-08-11) ; **Phase 5** (Parties 35-43,
-formes flèche/bundlée de la couverture et lois du pullback) livrée par vagues
-(2026-08-14..16 : #10879, #10912, #11023, #11035, #11038, #11057, #11068, #11217,
-#11231) ; **Phase 1** (Parties 1-33) précédemment shippée par vagues de PRs
-(#2675, #8882, etc.).
+## Build & état
 
-## Build
+- **Toolchain** : `leanprover/lean4:v4.31.0-rc1` (alignée sur les autres projets SymbolicAI/Lean)
+- **Build** : `lake build` (WSL requis). La cible défaut (`globs := #[`Grothendieck.*]` du `lakefile.lean`) compile **tous** les modules FR et `_en`. Dernier build vérifié : 2026-08-12, « Build completed successfully ». La cible explicite `lake build Grothendieck` (closure des imports de l'umbrella) omet pour l'instant `ExceptionalDirect` — voir [#11286](https://github.com/jsboige/CoursIA/issues/11286).
+- **Preuves** : **0 `sorry`, 0 axiome ajouté** — tous les modules sont complets à la création. (Un `grep sorry` naïf matche des mentions en prose dans les docstrings bilingues, notamment deux dans `ExceptionalDirect.lean` ; la CI compte en mode `real` — après strip des commentaires — et vaut 0.)
+- **Dépendances** : Mathlib 4 (via `lakefile.lean`)
+- **i18n** (EPIC #4980, convention Option A ratifiée 2026-07-04) : couverture bilingue complète — 45 fichiers FR (1 umbrella + 44 leaf canoniques) et 44 siblings `_en.lean` (namespaces `_en` anti-collision, contenu non-docstring byte-identique, vérifiable par CI). L'umbrella est bilingue inline *by design* (FR canonique d'abord, EN en miroir dans le même fichier). **[`README.en.md`](./README.en.md)** est le miroir EN du présent fichier. Hors-scope : `.lake/packages/`, libs vendored.
 
-```bash
-# Depuis ce répertoire (WSL requis)
-lake build Grothendieck
-# Compile les 43 modules leaf + 1 umbrella bilingue
-# Dernier build vérifié : 2026-08-12, « Build completed successfully » (compteurs re-audités 2026-08-16)
-```
+## Références
 
-## Compte de sorry
+Le langage visité ici — topologies de Grothendieck, sites, faisceaux, schémas —
+naît de la géométrie algébrique de Grothendieck. Voici les points d'entrée
+canoniques ; ce workspace est une visite indexée sur Mathlib, **pas** une
+formalisation d'EGA/SGA.
 
-**0 sorry, 0 axiome** — tous les 43 modules leaf sont complets à la création
-(l'umbrella `Grothendieck.lean` est imports-only sans déclaration). La Partie 34
-`ExceptionalDirect.lean` (#10357) cite `sorry` deux fois en prose docstring
-(marque de la formalisation bornée) mais ne contient **aucun sorry tactic**.
-
-## Toolchain
-
-Alignée avec les autres projets SymbolicAI/Lean : `leanprover/lean4:v4.31.0-rc1`
-
-## References
-
-The language toured here — Grothendieck topologies, sites, sheaves, and schemes — originates in Grothendieck's algebraic geometry. These are the canonical entry points. This workspace is a pedagogical tour indexed against Mathlib, **not** a formalization of EGA/SGA.
-
-- **Mac Lane, S.; Moerdijk, I.** *Sheaves in Geometry and Logic: A First Introduction to Topos Theory*. Springer Universitext, 1992. — Standard reference for Grothendieck topologies, sieves, sites, and sheaves (Parts 1, 6-8, 10, 13-14).
-- **Artin, M.; Grothendieck, A.; Verdier, J. L.**, eds. *Theorie des topos et cohomologie etale des schemas* (SGA 4). Springer Lecture Notes in Mathematics 269, 270, 305, 1972-1973. — Origin of sites, Grothendieck topologies, and points of a topos (Parts 1, 15, 19).
-- **Grothendieck, A.; Dieudonne, J.** *Elements de geometrie algebrique* (EGA). Publications Mathematiques de l'IHES, 1960-1967. — Origin of schemes and the Zariski site (Parts 2-3).
-- **Vakil, R.** *The Rising Sea: Foundations of Algebraic Geometry*. — Widely used pedagogical notes in the Grothendieckian spirit.
-- **The Stacks Project.** [stacks.math.columbia.edu](https://stacks.math.columbia.edu) — Reference for schemes, sheafification, and sheaf cohomology (Parts 13, 20-23).
-- **The Mathlib Community.** *Mathlib4, Category Theory and Sites*. [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/) — The library this tour indexes (Part 4); see de Moura & Ullrich, "The Lean 4 Theorem Prover" (2021).
-- **nLab.** [ncatlab.org](https://ncatlab.org) — Entries on Grothendieck topology, sieve, site, sheaf, and sheafification.
+- **Mac Lane, S.; Moerdijk, I.** *Sheaves in Geometry and Logic: A First Introduction to Topos Theory*. Springer Universitext, 1992. — La référence standard pour topologies de Grothendieck, cribles, sites et faisceaux (Parties 1, 6-8, 10, 13-14).
+- **Artin, M.; Grothendieck, A.; Verdier, J. L.** (éd.) *Théorie des topos et cohomologie étale des schémas* (SGA 4). Springer Lecture Notes in Mathematics 269, 270, 305, 1972-1973. — L'origine des sites, topologies de Grothendieck et points d'un topos (Parties 1, 15, 19).
+- **Grothendieck, A.; Dieudonné, J.** *Éléments de géométrie algébrique* (EGA). Publications Mathématiques de l'IHÉS, 1960-1967. — L'origine des schémas et du site de Zariski (Parties 2-3).
+- **Vakil, R.** *The Rising Sea: Foundations of Algebraic Geometry*. — Notes pédagogiques largement utilisées, dans l'esprit grothendieckien.
+- **The Stacks Project.** [stacks.math.columbia.edu](https://stacks.math.columbia.edu) — Référence pour schémas, faisceautisation et cohomologie des faisceaux (Parties 13, 20-23).
+- **The Mathlib Community.** *Mathlib4, Category Theory and Sites*. [mathlib4 docs](https://leanprover-community.github.io/mathlib4_docs/) — La bibliothèque que cette visite indexe (Partie 4) ; voir de Moura & Ullrich, « The Lean 4 Theorem Prover » (2021).
+- **nLab.** [ncatlab.org](https://ncatlab.org) — Entrées *Grothendieck topology*, *sieve*, *site*, *sheaf*, *sheafification*.
 
 ## Voir aussi
 
-- Epic #1646 (hommage à Grothendieck)
-- Issue #2159 (profondeur de formalisation Grothendieck — Phase 1 shippée, **Phase 2** livrée par #10357 le 2026-08-11 : `f_! ⊣ f^*` au niveau préfaisceau = Partie 34 `ExceptionalDirect.lean`)
-- PR #2675 (Phases 4-6 : SieveOps + CoverageGen + CanonicalProps)
-- **PR #10357** (Phase 2 #2159 : exceptional direct image `f_! ⊣ f^*` au niveau préfaisceau, formalisation bornée du chaînon manquant entre `f^*` et `f_*`)
-- Epic #1453 (calibration du harnais prouveur)
-- Workspace hommage Conway (`../conway_lean/`)
-- **EPIC #4980** — convention i18n Lean (Option A sibling pair post-2026-07-04 ; 43 siblings `_en.lean` sur `main` dans cette lake + 1 umbrella bilingue inline)
-- Issue #8960 (réconciliation des deux numérotations `Partie`)
+- Epic #1646 (hommage à Grothendieck) — Issue #2159 (profondeur de formalisation : Phase 1 shippée, Phase 2 = #10357, Phase 5 = Parties 35-44)
+- EPIC #4980 — convention i18n Lean (Option A sibling pair ; 44 paires `_en` dans ce lake)
+- Epic #1453 (calibration du harnais prouveur) — Issue #8960 (réconciliation des numérotations `Partie`)
+- [#11286](https://github.com/jsboige/CoursIA/issues/11286) — import umbrella de `ExceptionalDirect` en attente
+- Workspace hommage Conway (`../conway_lean/`) — série de notebooks Lean (`../README.md`)
 - **[`README.en.md`](./README.en.md)** — miroir EN du présent fichier
-- Série de notebooks Lean (`../README.md`)
 
-## Conclusion
+## Le périmètre, honnêtement
 
-Cet hommage est une **visite pédagogique complète** (43 modules leaf + 1 umbrella bilingue, 0
-`sorry`, 0 axiome ajouté) montrant comment le langage de Grothendieck — sites,
-faisceaux, faisceautisation, points, cohomologie, Yoneda, images directes,
-image directe exceptionnelle `f_!`, formes flèche/bundlée de la couverture — vit
-déjà dans Mathlib 4. Ce n'est
-délibérément **pas** une formalisation d'EGA/SGA ; c'est un index curaté
-qui laisse les apprenants voir la bibliothèque à travers des yeux grothendieckiens.
+Chaque résultat est pleinement prouvé (0 `sorry`, 0 axiome ajouté), et l'index
+`#check` de la Partie 4 documente explicitement la frontière entre ce que
+Mathlib possède et ce qu'il n'a pas (encore) — la visite expose cette frontière
+au lieu de la maquiller. Le module compagnon `Calibration.lean` (Partie 5)
+relie la formalisation à l'effort de preuve plus large.
 
-### La trajectoire
-
-Les modules tracent un chemin cohérent : **sites et cribles** (Parties 1, 6, 8,
-11, 12, 16) → **faisceaux, séparation et transfert** (7, 9, 10, 17) →
-**faisceautisation et son exactitude à gauche** (13, 14) → **points et familles
-conservatrices** (15, 19) → **cohomologie des faisceaux, Mayer-Vietoris et Čech**
-(20-23), avec **schémas et site de Zariski** (2, 3), une **carte Mathlib** (4)
-et le **lemme de Yoneda** (24) ancrant la visite à la bibliothèque qu'elle indexe. Les bases catégorielles (Adjonction, Équivalences, Monades) aux Parties 25, 29, 26 soutiennent toute la formalisation. `DirectImage.lean` (Partie 33) indexe l'adjonction `f^* ⊣ f_*` — l'instance la plus simple des « six opérations », qui transporte les faisceaux le long des morphismes de schémas. `ExceptionalDirect.lean` (Partie 34, #10357) franchit un échelon en formalisant `f_! ⊣ f^*` au niveau préfaisceau — l'image directe *à support propre* comme extension de Kan à gauche de `f^*`, chaînon manquant entre `f^*` (inverse-image) et `f_*` (image directe). Les Parties 35-43 prolongent le versant *couverture* : formes flèche et bundlée de `J.Cover`, lois du foncteur pullback et de l'ordre/treillis des topologies (CoversArrow, Cover, PullbackFunctor, PullbackFunctorLaws, TopologyLattice, CoversPullback, CoversOrder, PullbackCoversLaws, CoversLattice, Phase 5 de #2159).
-
-*La construction verticale « faisceau » — chaque couche bâtie sur la précédente, de la donnée du site jusqu'à la cohomologie :*
-
-```mermaid
-flowchart TD
-    SITE["<b>Site</b><br/><i>catégorie + topologie de Grothendieck</i><br/>(Partie 1)"]
-    PSH["<b>Préfaisceau</b><br/><i>objets Cᵒᵖ → Type*</i>"]
-    SEP["<b>Préfaisceau séparé</b><br/>unicité du recollement"]
-    SH["<b>Faisceau</b><br/>existence + unicité du recollement"]
-    SHIF["<b>Faisceautisation</b><br/><i>foncteur faisceau associé</i><br/>Partie 13 — exactitude à gauche (Partie 14)"]
-    COH["<b>Cohomologie des faisceaux</b><br/>Parties 20-23<br/>Ext · Mayer-Vietoris · Čech"]
-    SITE --> PSH --> SEP --> SH
-    SHIF -.->|"produit un faisceau<br/>depuis un préfaisceau"| SH
-    SH --> COH
-    TR["<b>Transfert de faisceau</b><br/>le long de J₁ ≤ J₂<br/>(Partie 7)"] -.-> SH
-```
-
-### Le périmètre, honnêtement
-
-Selon la section `## Compte de sorry` ci-dessus, la visite est à **0 `sorry`,
-0 axiome ajouté** — chaque résultat est pleinement prouvé. L'index `#check` de la
-Partie 4 est explicite sur ce que Mathlib possède et ce qu'il n'a pas (encore) ;
-la visite documente cette frontière au lieu de la maquiller. Le module compagnon
-`Calibration.lean` (Partie 5) alimente le harnais du prouveur (Epic #1453),
-reliant cette formalisation à l'effort de preuve plus large.
-
-### Où aller ensuite
-
-- **Profondeur** : l'Issue #2159 / l'Epic #1646 suivent la formalisation
-  ultérieure — cette visite est le socle, pas le plafond.
-- **Compagnons** : `conway_lean/` (mathématiques de Conway), la série de
-  notebooks Lean.
-- **Références** : Mac Lane–Moerdijk et SGA 4 pour le cœur topos-théorique ;
-  Vakil et le Stacks Project pour les schémas et la cohomologie.
+Cet hommage est un **index curaté** qui laisse les apprenants voir la
+bibliothèque à travers des yeux grothendieckiens ; l'Issue #2159 / l'Epic
+#1646 suivent la formalisation ultérieure — cette visite est le socle, pas le
+plafond. Pour prolonger : `conway_lean/` et la série de notebooks Lean côté
+compagnons ; Mac Lane–Moerdijk et SGA 4 pour le cœur topos-théorique ; Vakil
+et le Stacks Project pour les schémas et la cohomologie.


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2023:CoursIA — **tache user directe** (« le README meriterait une belle mise a jour depuis tous les ajouts recents... anglais a migrer sur son sibling _en... repetitions... une reecriture d'ensemble pour lander une plus belle narration »)

## Quoi

Reecriture d'ensemble des deux miroirs README de `grothendieck_lean` (pas un bump de compteurs) :

1. **Narration restructuree** : 12 sections -> 7. Ouverture sur le deplacement grothendieckien (etudier les sites/faisceaux qui portent les structures, pas les structures isolees), trajectoire racontee en mouvements (poser le site -> construire le faisceau -> points & cohomologie -> ancrages -> fondations catgorielles -> deux veines recentes), les 2 diagrammes mermaid conserves, table 45 lignes comme reference unique.
2. **Compteurs corriges** : 43 -> **44 modules leaf** partout (Partie 44 `CoversTopologies.lean`, #11244, oubliee par le re-sync #11253 qui avait mesure avant le merge) ; i18n 45 fichiers FR + 44 siblings `_en` ; umbrella 217 -> 218 lignes.
3. **Repetitions eliminees** : liste PRs Phase 5 dupliquee x2 -> 1 reference ; « 43 modules leaf » x6 -> x2 ; description umbrella x4 -> x2 ; « 0 sorry 0 axiome » x5 -> x2 ; tampons comptables dates (« re-audite 2026-08-16 », totaux 21 205 lignes) supprimes au profit des comptes par fichier stables.
4. **Anglais migre vers le sibling** : la section References du README FR etait entierement en anglais -> prose et annotations en francais (titres canoniques inchanges : SGA 4, EGA avec accents restaurés) ; le miroir EN porte la version anglaise.

## Decouverte incidente — umbrella honnete (repond a la question user)

En auditant, constat : **`ExceptionalDirect.lean` (Partie 34) n'est importe nulle part** — ni par l'umbrella ni en transitif. Verifications :

- `grep -n Exceptional Grothendieck.lean` = 0 ; grep `import Grothendieck.ExceptionalDirect` sur tout le lake = 0.
- Le body de #10357 revendiquait « + 1 ligne d'import dans l'umbrella » mais le diff merge `d30b9c6cb0` ne contient que les 2 fichiers `.lean` (391 insertions, 0 modif umbrella). L'import a ete annonce, jamais livre.
- Verifie aussi : **aucun WIP ni PR ouverte** ne repare cela (seules ouvertes sur le lake : #11262 Partie 45, #11285 Partie 46, purement additives — chacune ajoute correctement SON import d'umbrella).
- Perimetre exact (amende sur l'issue) : la CI lance `lake -R build` = cible defaut `globs Grothendieck.*` qui compile TOUS les modules (ExceptionalDirect et `_en` compris) — le module n'est PAS hors CI. Seule la cible explicite `lake build Grothendieck` (closure d'imports) l'omet, et la coherence « chaque Partie importee par le parapluie » attendue par le README est rompue.

**Issue de suivi ouverte : #11286** (fix = 1 ligne d'import + preuve CI). Le README documente desormais honnetement l'etat (« importe 43 des 44 leaf ») avec lien vers l'issue.

## Preuves (audit fichier-entier §E)

- **(a) Comptes disque** : 41 leaf directs (`ls Grothendieck/*.lean | grep -v _en`) + 3 `SheafCohomology/` = **44 FR leaf** ; **44 siblings `_en`** (`ls ..._en.lean` 41 + 3) ; umbrella `wc -l` = **218** lignes, `grep -c ^import` = **43**.
- **(b) Reconciliation disque <-> prose** : le README disait 43 leaf / 43 siblings / umbrella 217 — faux depuis #11244 (merge 3366c7d340 anterieur au re-sync #11253 b4a5d34a72 : mesure prise avant le merge). Nouvelle prose = 44/44/218, verifiee ce jour sur worktree frais base origin/main.
- **(c) Table** : 45 lignes (racine + Parties 1-44), Lignes spot-checkees `wc -l` : CategoryAndSites 243, CoversLattice 106, ExceptionalDirect 202, CoversTopologies 115, umbrella 218 — toutes conformes. Nouvelle ligne 44 : `dense_covers_iff`, `dense_covers_precomp`, `dense_covers_id` (#11244).
- **0 sorry** : mode real (strip commentaires) = 0 tactic sorry ; les matches `grep sorry` sont de la prose docstring (FP documente, cf mode real CI).
- **Liens entrants** : le seul lien externe vers ce README (`SymbolicAI/Lean/README.md:157`) est un lien de fichier sans ancre — la restructure de sections ne casse rien. Zero marqueur CATALOG-STATUS dans ces fichiers.
- Markdown : fences equilibrees (2 blocs mermaid x2 par fichier), listes entourees de lignes vides.

## Scope

Docs-only : 2 fichiers (`README.md` FR canonique + `README.en.md` miroir EN), 307 insertions / 307 deletions, 0 fichier code touche.

See #2159, See #11286, See #4980

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>