### PR TITLE
fix(lean,#11286): import umbrella Grothendieck.ExceptionalDirect (module orphelin #10357)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck.lean
@@ -15,6 +15,7 @@ import Grothendieck.CoversPullback
 import Grothendieck.CoversTopologies
 import Grothendieck.DenseTopology
 import Grothendieck.DirectImage
+import Grothendieck.ExceptionalDirect
 import Grothendieck.Equivalences
 import Grothendieck.KanExtensions
 import Grothendieck.LeftExact


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: LIGHT/guard #11279

## Fix

`Grothendieck.ExceptionalDirect` (Partie 34, `f_! ⊣ f^*` préfaisceau, mergé par #10357 le 2026-08-11) était **importé nulle part** : l'umbrella ne le mentionnait pas, aucun module ne l'importait — le module vivait hors de la cible `lake build Grothendieck` depuis 5 jours. Le body de #10357 revendiquait l'import umbrella, mais le diff mergé (`d30b9c6cb0`) ne contenait que les 2 fichiers `.lean` + `_en`.

**Diff : 1 insertion** — `import Grothendieck.ExceptionalDirect` dans `Grothendieck.lean`, positionné selon l'ordre alphabétique du fichier (entre `DirectImage` et `Equivalences`).

## Preuves (B — réparation d'import, pas de preuve touchée)

- **Sorry count** (`count_code_sorry.py --json`, worktree frais) : `grothendieck_lean` **84 naïfs (prose) / 0 code sorry / 0 distinct** — inchangé par ce diff (1 ligne d'import, aucune preuve modifiée).
- **`lake build Grothendieck` SUCCESS** : attendu en CI (`lean-build.yml` → cible umbrella, passe de 43 à 44 imports). Pas de build local sur cette lane (pas de cache `.lake` grothendieck — build Mathlib complet hors fenêtre) ; le module **compile déjà vert en CI** via les globs `lake -R build` depuis #10357 (établi dans le corps de #11286), donc l'import d'un module déjà compilé ne peut pas introduire d'erreur de compilation du module lui-même. Le risque résiduel (cycle d'imports) sera couvert par le check CI de cette PR.
- **Proof-integrity** : `lean-grothendieck.yml` appelle `lean-axiom.yml` (LeanVerifier.check_axioms fail_on_sorry) ciblé sur ce lake — attendu vert sur cette PR.
- **README compteurs** : volontairement non touchés — l'issue #11286 précise que le re-sync des compteurs (« 44 leaf, umbrella en importe 43 » → 45) est porté par la vague en cours (#11262 Partie 45, #11285 Partie 46 touchent aussi l'umbrella ; zones de lignes disjointes — Covers* vs D/E — rebase trivial).

Closes #11286

See #2159 (Epic), See #10357 (module d'origine).
