### PR TITLE
fix(gate,#11246): CONDITIONAL_LIFT lit les exemples CITES comme des usages — neutralisation des citations avant matching

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -130,6 +130,23 @@ CONDITIONAL_LIFT = re.compile(
     r"(et je merge|puis je merge|ensuite je merge"
     r"|je merge (?:dès|des|une fois|quand|après|apres|si\b))", re.I)
 
+# #11246 — use vs mention : CONDITIONAL_LIFT lisait les exemples CITES du motif
+# comme des usages. Une review qui explique « corrige X et je merge » se
+# flaggait elle-meme (2/15 findings de l'audit --limit 400 : les 2 seules
+# reviews du corpus qui PARLENT du gate), et son annonce de merge reelle
+# (« **Mergée.** ») etait annulee. On neutralise les segments cites AVANT la
+# recherche de la construction conditionnelle — guillemets typographiques
+# (« … »), backticks inline (`…`), blocs de code (``` … ```) — comme pour tout
+# parseur qui ne doit pas lire ses propres exemples. La construction
+# conditionnelle EMPLOYEE (« corrige la ligne 19 et je merge ») reste bloquante
+# (#11201) : elle ne porte aucun de ces delimiteurs.
+_QUOTED_RANGES = re.compile(r"```.*?```|«.*?»|`[^`]*`", re.DOTALL)
+
+
+def _strip_quoted(body: str) -> str:
+    """Retire les segments cites (guillemets typo, backtick, bloc code)."""
+    return _QUOTED_RANGES.sub(" ", body)
+
 # NOTE — proposition ecartee (triage 07-15..07-31, retiree au rebase 2026-08-16).
 # Un `NO_CONCERN_TAIL_MARKERS` dechargeant tout body dont les 300 derniers chars
 # portent « ne bloque pas » / « Safe to merge » a ete propose puis RETIRE : il
@@ -371,7 +388,7 @@ def classify(author: str, body: str) -> str | None:
     if author in BOT_LOGINS or not body:
         return None
     stripped = body.lstrip()
-    if has_marker(body, LIFT_MARKERS) and not CONDITIONAL_LIFT.search(body):
+    if has_marker(body, LIFT_MARKERS) and not CONDITIONAL_LIFT.search(_strip_quoted(body)):
         return None  # annonce de levee / de merge : resolution, pas reserve
     # (construction conditionnelle « et je merge » : voir CONDITIONAL_LIFT —
     # l'annonce conditionnee n'est pas une levee, le commentaire continue)
@@ -474,7 +491,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         for c in (pr_data.get("comments") or [])
         if can_lift(c)
         and has_marker(c.get("body", ""), LIFT_MARKERS)
-        and not CONDITIONAL_LIFT.search(c.get("body", ""))
+        and not CONDITIONAL_LIFT.search(_strip_quoted(c.get("body", "")))
     ]
     explicit_lifts = [x for x in explicit_lifts if x[0] is not None]
 

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -613,6 +613,45 @@ def test_annonce_vraie_est_une_levee():
     assert mod.classify("myia-ai-01", "C'est bon, je merge.") is None
 
 
+# --- #11246 : use vs mention. CONDITIONAL_LIFT lisait les exemples CITES du
+# motif comme des usages : une review expliquant « corrige X et je merge » se
+# flaggait elle-meme (2/15 findings de l'audit --limit 400, les 2 seules
+# reviews du corpus parlant du gate), et son annonce de merge reelle etait
+# annulee. La citation est neutralisee avant la recherche ; l'usage nu reste
+# bloquant.
+
+def test_conditional_lift_usage_reste_bloquant():
+    """Paire (a) : la construction conditionnelle EMPLOYEE, hors citation —
+    la reserve reste vivante (#11201 inchange)."""
+    assert mod.classify(
+        "myia-ai-01",
+        "Une seule chose a changer — corrige la ligne 19 et je merge."
+    ) == "BOT-CONCERN"
+
+
+def test_conditional_lift_cite_n_annule_pas_la_levee():
+    """Paire (b) : la formule CITEE (« corrige X et je merge ») expliquee dans
+    une review qui annonce par ailleurs le merge (« **Mergée.** »). AVANT le
+    fix, CONDITIONAL_LIFT matchait la citation et la review basculait en
+    BOT-CONCERN (cas #11218/#11233)."""
+    body = ("Une seule chose a changer sur le registre : la formule "
+            "« corrige X et je merge » n'est pas une levee. **Mergée.**")
+    assert mod.classify("myia-ai-01", body) is None
+
+
+@pytest.mark.parametrize("cite", [
+    "`corrige X et je merge`",
+    "« corrige X et je merge »",
+    "```\ncorrige X et je merge\n```",
+])
+def test_conditional_lift_citations_ne_bloquent_pas(cite):
+    """Les 3 formes de citation — backtick inline, guillemets typo, bloc code —
+    ne sont pas des usages de la construction conditionnelle."""
+    body = (f"Une seule chose a changer. La formule {cite} est citee, "
+            "pas employee. **Mergée.**")
+    assert mod.classify("myia-ai-01", body) is None
+
+
 @pytest.mark.parametrize("cond", [
     "Change la cellule 19 puis je merge.",
     "Corrige l'attribution, ensuite je merge.",


### PR DESCRIPTION
## Summary

Fix du faux positif `CONDITIONAL_LIFT` (gate anti-nits) : **use vs mention** — une review qui *explique* le motif « corrige X et je merge » se flaggait elle-même, et son annonce de merge réelle (« **Mergée.** ») était annulée → la review basculait en `BOT-CONCERN`. Mesuré sur l'audit `--limit 400` (2026-08-16) : **2/15 findings = les 2 seules reviews du corpus parlant du gate lui-même** (#11218, #11233) — un FP qui se reproduirait à chaque itération du gate (#11201 → #11218 → #11222 → #11233).

**Option 1 de l'issue** (celle qui traite la cause, pas les symptômes) : neutralisation des segments **cités** avant `CONDITIONAL_LIFT.search()`, aux 2 sites :
- `classify()` (lift path, L374) ;
- `analyse()` → `explicit_lifts` (L477).

Formes neutralisées : guillemets typographiques `« … »`, backtick inline `` `…` ``, blocs de code ```` ``` … ``` ```` (`_strip_quoted`, DOTALL). La construction conditionnelle **employée** (« corrige la ligne 19 et je merge ») reste bloquante — elle ne porte aucun de ces délimiteurs.

## Tests (D)

- **4 nouveaux** : paire use/mention + 3 formes de citation en paramétrage.
- **3 vérifiés à l'envers** : sans le fix (monkeypatch `_strip_quoted = identity`), les tests mention échouent (`BOT-CONCERN` au lieu de `None`) — ce sont de vrais regression-tests, pas des assertions complaisantes.
- **Suite complète : 70/70** (`pytest tests/test_check_unaddressed_nits.py`).
- Pas de modification de comportement hors citation : aucun test existant ne porte de guillemets/backticks → aucun impact sur les 66 tests antérieurs.

## Validation

- `python -m pytest tests/test_check_unaddressed_nits.py -q` → **70 passed in 0.16s**.
- Diff : 58 insertions, 2 deletions (2 fichiers, script + tests) — un seul sujet.

## Voir aussi

See #11044 (l'Epic dont l'audit rétrospectif est pollué par ces 2 entrées) — pas de `Closes` : #11246 traite un finding d'une Epic plus large.

Grain: MED/guard — lane myia-po-2026:CoursIA — prev: DEEP/training #11298
