### PR TITLE
fix(ci,#11266): workflow-path-filter-audit — step mort Comment PR on regression supprimé

### DIFF
--- a/.github/workflows/workflow-path-filter-audit.yml
+++ b/.github/workflows/workflow-path-filter-audit.yml
@@ -73,39 +73,3 @@ jobs:
           name: workflow-path-filter-audit
           path: docs/audit/workflow-path-filters/audit-*.{json,md}
           if-no-files-found: ignore
-
-      - name: Comment PR on regression
-        if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            const auditDir = 'docs/audit/workflow-path-filters';
-            const reports = fs.readdirSync(auditDir).filter(f => f.endsWith('.json') && f !== 'latest.json');
-            if (reports.length === 0) {
-              core.info('No audit reports found');
-              return;
-            }
-            const latest = reports.sort().reverse()[0];
-            const report = JSON.parse(fs.readFileSync(path.join(auditDir, latest), 'utf-8'));
-            const summary = report.summary;
-            const body = [
-              '## Workflow path-filter audit',
-              '',
-              '| Metrique | Valeur |',
-              '|---|---|',
-              `| Total workflows | ${summary.total} |`,
-              `| PR-triggered | ${summary.with_pr_trigger} |`,
-              `| Filtered | ${summary.filtered} |`,
-              `| Unfiltered (required) | ${summary.unfiltered_required} |`,
-              `| **Unfiltered (optional - regression!)** | **${summary.unfiltered_optional}** |`,
-              '',
-              'Voir `docs/audit/workflow-path-filters/audit-*.md` pour detail.',
-            ].join('\n');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });


### PR DESCRIPTION
## Summary

Suppression du step mort **`Comment PR on regression`** dans `.github/workflows/workflow-path-filter-audit.yml` (finding Hermes #10799, vérifié VIVANT sur main le 2026-08-16, T1 #11044 groupe C).

**Racine** : le step était conditionné sur

```yaml
if: failure() && github.event_name == 'pull_request'
```

mais le workflow n'a volontairement que `schedule` + `workflow_dispatch` comme triggers. Le bloc github-script en dessous est donc inert : jamais atteignable, quel que soit le résultat de l'audit.

**Option B choisie** (suppression, pas ajout de trigger PR) : le header du workflow (L10-13) documente explicitement le design anti fan-out (« l'audit scanne tous les workflows, ce qui déclencherait un cycle de fan-out »). Ajouter un trigger `pull_request` (Option A) contredirait ce design documenté et ajouterait ~40 runs CI par PR touchant les workflows pendant la saturation.

## Diff

- `1 file changed, 36 deletions(-)` — uniquement le step mort, rien d'autre.
- Le step `Upload audit report` (artefact) est conservé : l'audit quotidien continue de produire le rapport consultable.

## Validation

- `yaml.safe_load` : workflow parses, steps = `['Checkout repo', 'Setup Python', 'Install PyYAML', 'Run audit', 'Upload audit report']`.
- `grep -rn "Comment PR on regression"` : 0 référence résiduelle ailleurs dans le dépôt.
- Le step `Run audit` (avec `check_regression`) est intact — le point 2 d'Hermes (edge case check_regression) est advisory, non actionnable, explicitement hors scope de l'issue.

## Voir aussi

See #11044 (T1 groupe C) — pas de `Closes` : cette issue fait partie d'un groupe de findings Hermes de l'Epic.

Grain: LIGHT/ci — lane myia-po-2026:CoursIA — prev: MED/guard #11299
