### PR TITLE
docs(twin-parity,#11200): arbitrage Option A — native-both = parité de moteur + corrélation à sens unique avec bridge_verdict

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/_schema.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/_schema.yaml
@@ -38,9 +38,24 @@
 # parity_level :
 #   surface     = meme plan/sections, implimentations independantes
 #   semantic    = meme contenu mathematique/conceptuel, API idiomatique differente
-#   native-both = traduction fidele cellule-par-cellule (rare)
+#   native-both = CHAQUE cote fait le travail du notebook au moyen d'un moteur
+#                 de production/reference externe (package, solveur, service).
+#                 Test : pour chaque cote, NOMMER le moteur et le point d'entree
+#                 qui produit le resultat. Un cote qui reimplemente le sujet du
+#                 notebook a la main n'est PAS natif — meme si sa sortie est
+#                 identique, meme si ses cellules se correspondent une a une.
+#                 native-both ne dit RIEN de la correspondance structurelle
+#                 cellule-par-cellule.
 #
-# bridge_verdict (OPTIONNEL, #10439) : orthogonal a parity_level. Decrit si un
+# bridge_verdict (OPTIONNEL, #10439) : CORRELE a parity_level, a sens unique
+# (croisement des 157 entrees, 2026-08-16, arbitrage #11200) :
+#   native-both  => SOTA-OK (36/37)
+#   SOTA-OK     =/> native-both (82 contre-exemples sous semantic/surface)
+# La raison est dans l'enumeration ci-dessous : SOTA-OK couvre explicitement
+# « solver-free by design des deux cotes ». Les deux champs repondent a deux
+# questions differentes — bridge_verdict juge LE TRAVAIL (a-t-on saute un
+# moteur atteignable ?), parity_level decrit L'ETAT LIVRE (les deux cotes
+# tournent-ils sur un moteur ?). Decrit si un
 # moteur SOTA est branchable/branche du cote .NET, pour qu'un verdict INTRINSIC
 # deja rendu en prose (dans known_differences) cesse d'etre invisible aux
 # detecteurs et de re-signaler la paire comme "ecart de parite" a chaque scan.


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11295

# Arbitrage #11200 : `native-both` = parité de moteur — `_schema.yaml` mis à jour (See #11200)

PR d'ouverture du gel : le sens documenté de `parity_level: native-both` (« traduction fidèle cellule-par-cellule (rare) ») est démenti par la pratique (24 % des entrées le portent, le schéma dit *rare* ; les entrées le motivent en nommant des moteurs ; `App-1 NQueens` le porte avec « Asymétrie de couverture : Python 54 cellules / C# 31 » — l'inverse d'une correspondance cellule-par-cellule). Option A : doc → pratique, la définition devient celle que tout le monde a appliquée.

## Le contenu (1 fichier, 17+/2-)

**Bloc 1 — un seul sens, avec son test et sa négation :**

> `native-both` = CHAQUE côté fait le travail du notebook au moyen d'un moteur de production/référence externe (package, solveur, service). **Test : pour chaque côté, NOMMER le moteur et le point d'entrée qui produit le résultat.** Un côté qui réimplémente le sujet du notebook à la main n'est PAS natif — même si sa sortie est identique, même si ses cellules se correspondent une à une. **`native-both` ne dit RIEN de la correspondance structurelle cellule-par-cellule.**

**Bloc 2 — corrélation à sens unique avec `bridge_verdict`, mesurée (croisement des 157 entrées, 2026-08-16) :**

> `native-both` ⟹ `SOTA-OK` (36/37) ; `SOTA-OK` ⇏ `native-both` (82 contre-exemples sous `semantic`/`surface`). Raison structurelle : `SOTA-OK` couvre explicitement « solver-free by design des deux côtés » — une paire qui implémente le sujet à la main des deux côtés est honnêtement `SOTA-OK` sans être `native-both`. Les deux champs répondent à deux questions : `bridge_verdict` juge **le travail** (a-t-on sauté un moteur atteignable ?), `parity_level` décrit **l'état livré**.

## `known_differences` — la fidélité structurelle ne reçoit PAS de champ

La correspondance structurelle (cellule-par-cellule, asymétries de couverture, implémentations from-scratch en plus) ne reçoit pas de troisième axe : elle vit en prose dans `known_differences`, là où elle est déjà plus informative que n'importe quelle étiquette à trois valeurs. Ajouter un axe à un registre qui vient de ne pas tenir deux sens d'un seul champ serait la mauvaise réponse. Ce paragraphe est écrit dans le body pour qu'on ne relise pas ce silence comme un oubli dans six semaines.

## Validation

- **Zéro entrée requalifiée** : 1 fichier au diff, commentaires seuls (aucune paire touchée).
- `check_twin_parity.py --check` : **157/157 OK, DRIFT=0** — le schéma ne déplace aucune valeur portée.
- Branche rebasée sur `origin/main` @ 80b8a4f0c (règle R2, diff minimal).
- Plancher G-VAR-1 CONTENU du cycle tenu par #11295 (MED/notebook-python, IIT) — cette PR est un META assumé, requis par l'arbitrage.

Le gel `parity_level` est levé : les tranches #10382 à venir déclarent le `parity_level` de la paire qu'elles traitent (par famille, pas de rebasculage en masse).
