### PR TITLE
feat(qc,#11224): QC-Py-34 SAC/A2C — densité pédagogique 702 → 1334 (tranche markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-34-RL-SAC-A2C-Trading.ipynb
@@ -300,6 +300,12 @@
    "id": "cell-b17db46d"
   },
   {
+   "cell_type": "markdown",
+   "id": "30611202",
+   "source": "### Interpretation des données téléchargées\n\nLa sortie confirme la couverture du jeu de données : **15 tickers sur 15 valides**, sur la période du **2014-01-02 au 2024-12-31**, soit **2768 jours de bourse** (~11 ans de données quotidiennes S&P 500). Les secteurs sont variés : banques (BAC, JPM), consommation (KO, COST, PG, HD), santé (PFE, LLY, UNH, JNJ, MRK), énergie (CVX, XOM), paiements (V, MA).\n\nDeux choix structurels méritent attention avant tout entraînement :\n\n- **`auto_adjust=True`** : les prix sont ajustés des dividendes et splits. C'est la bonne pratique pour du RL de trading — l'agent ne doit pas percevoir des \"rendements\" artificiels créés par un détachement de dividende.\n- **Split temporel** : la validation démarre en **2022** (`VAL_START`), ce qui place l'évaluation sur une fenêtre hors échantillon distincte de l'entraînement (2014-2021). Ce walk-forward est la garantie minimale d'honnêteté : un RL entraîné et évalué sur les mêmes années mémoriserait les mouvements de prix au lieu d'apprendre une politique.\n\nLa taille de l'observation (6 traits × 15 actifs = 90 dimensions par pas) est fixée dans l'environnement décrit ci-dessous.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
@@ -452,6 +458,12 @@
     "print(f\"Train: {train_env.total_steps} steps, Val: {val_env.total_steps} steps\")"
    ],
    "id": "cell-2ed6fd3b"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dcf0165",
+   "source": "### Interpretation de l'environnement de trading\n\nLa sortie confirme la configuration : **15 actifs**, une observation de **6 traits par actif** (rendements 1j/5j/20j, volatilité 20j, position normalisée, ratio de volume), un espace d'action discret à **4 branches** (ne rien faire, acheter, vendre à découvert, couvrir), et la séparation train/validation : **2014 pas d'entraînement** (2014-2021) contre **752 pas de validation** (2022-2024).\n\nTrois choix de conception méritent d'être lus :\n\n1. **Frictions réalistes** : commission de 10 bps, slippage de 5 bps, impact de marché et coût d'emprunt de 2 % annualisé. L'environnement pénalise le trading excessif — un agent qui tourne sur ses positions paie à chaque aller-retour.\n2. **Observations fenêtrées** : chaque actif voit ses 20 derniers pas (`lookback`), avec un repli sur zéro pour les premières dates. Les 6 traits mélangent tendance (rendements), risque (volatilité) et exposition (position normalisée) — de quoi décider sans voir le futur.\n3. **Récompense en pourcentage de variation** du portefeuille : le RL optimise directement la croissance relative, comparable entre stratégies quel que soit le capital de départ.\n\nCe même environnement sert à SAC et A2C, garantissant la comparabilité du benchmark de la Partie 5.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -712,6 +724,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "2cbf8102",
+   "source": "### Interpretation de l'agent SAC instancié\n\nLa sortie rend compte de la construction : **53 772 paramètres** répartis sur les quatre réseaux (deux Q-networks de critique, leur cible, et le tronc de politique avec sa tête de logits), et une **température alpha initiale de 1.000**.\n\nTrois mécanismes distincts du DQN de QC-Py-32 se lisent dans le code :\n\n1. **Double Q-learning** : `q1` et `q2` estiment indépendamment la valeur de chaque action ; la cible prend `torch.min(q1, q2)`. Ce minimum biaise l'estimation vers le bas et combat la surestimation chronique du Q-learning classique — l'erreur que DQN corrigeait avec des target networks seulement.\n2. **Température auto-adaptée** : `log_alpha` est un paramètre appris. La target_entropy vaut `-log(1/4) × 0.5 ≈ 0.693` — la moitié de l'entropie maximale d'une politique uniforme sur 4 actions. Si la politique devient trop déterministe, la loss pousse alpha à la hausse pour récompenser l'exploration ; si elle erre trop, alpha baisse. On verra cette valeur descendre pendant l'entraînement (0.887 → 0.691 dans les logs de la Partie 5).\n3. **Mise à jour off-policy** : l'agent apprend sur des batchs tirés du replay buffer (50 000 transitions), pas sur la trajectoire immédiate — c'est ce qui lui permet 25 000 pas entre chaque évaluation sans jeter les données.\n\nLa politique reste stochastique à l'inférence (`explore=True` échantillonne, `explore=False` prend l'argmax) : l'évaluation finale figera le mode déterministe.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Exercice 1.2 : Analyser l'impact de la taille du buffer SAC\n\nLe **replay buffer** du SAC stocke les expériences passees. Testez deux tailles : 25K (petit) vs 100K (grand) et observez l'impact sur la stabilite.\n\n**Indices** :\n- `# Indice` : La taille est le paramètre `capacity` du ReplayBuffer\n- `# Étape 1` : Modifier capacity=25000 et executer\n- `# Étape 2` : Modifier capacity=100000 et executer\n- `# Étape 3` : Comparer les courbes d'eval Sharpe"
@@ -873,6 +891,12 @@
     "print(f\"A2C: {n_params_a2c:,} parametres, n_steps={a2c_agent.n_steps}\")"
    ],
    "id": "cell-a1375de0"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fd37ed4",
+   "source": "### Interpretation de l'agent A2C instancié\n\nLa sortie confirme une architecture **3× plus légère que SAC** : **18 053 paramètres**, portés par un seul tronc partagé (`shared`) coiffé de deux têtes — `actor_head` pour les logits de politique, `critic_head` pour la valeur d'état. Le partage du tronc est le trait distinctif d'A2C : acteur et critique apprennent une même représentation de l'état, là où SAC entretient des réseaux séparés.\n\nDeux mécanismes à lire avant le benchmark :\n\n1. **Returns à N pas** (`n_steps=5`) : la cible du critique n'est pas la récompense immédiate mais la somme actualisée des 5 prochaines récompenses plus la valeur de l'état d'arrivée. Ce compromis entre TD(0) et Monte-Carlo réduit la variance sans attendre la fin de l'épisode — un choix intermédiaire entre DQN (1 pas) et REINFORCE (épisode entier).\n2. **Une seule passe par batch** : contrairement à PPO qui rejoue chaque avantage pendant plusieurs epochs avec clipping, A2C consomme la trajectoire une fois (`update` par fenêtre de 5 pas, sans minibatch). C'est ce qui le rend rapide par pas — et fragile sur les marchés bruités : une mauvaise fenêtre perturbe immédiatement la politique, sans la protection du clipping.\n\nL'entropie affichée dans les logs d'entraînement (Partie 5) vient de `dist.entropy()` sur la politique échantillonnée : elle mesurera la diversité des actions au fil de l'apprentissage.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
@@ -1276,6 +1300,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "8d43505a",
+   "source": "### Lecture des courbes d'entraînement mesurées\n\nLes deux logs racontent des trajectoires d'apprentissage très différentes :\n\n**SAC** — progression monotone après un démarrage chaotique :\n\n| Étape | val_sharpe | alpha | Temps cumulé |\n|---|---|---|---|\n| 25 005 | **−3.808** | 0.887 | 28 s |\n| 50 010 | +1.013 | 0.783 | 75 s |\n| 75 015 | +1.049 | 0.691 | 114 s |\n\nLe premier tiers est destructif (Sharpe négatif profond : la politique aléatoire achète et vend sans critère, les frictions dévorent le portefeuille). Puis le replay buffer a accumulé assez de transitions pour que les critiques apprennent : le Sharpe de validation bondit à +1.0 et se stabilise. La température **alpha descend régulieremente** (0.887 → 0.691) : la politique se spécialise, l'auto-régulation réduit le bonus d'exploration au fur et à mesure que l'agent trouve des actions rentables. Total : **2.4 minutes** — l'efficacité en échantillons du off-policy.\n\n**A2C** — pic précoce puis effondrement :\n\n| Étape | val_sharpe | entropy | Temps cumulé |\n|---|---|---|---|\n| 25 050 | **+1.348** | 1.024 | 97 s |\n| 50 100 | +0.942 | 1.056 | 214 s |\n| 75 150 | +0.000 | 0.935 | 298 s |\n\nA2C atteint son meilleur Sharpe dès la première évaluation (+1.348, supérieur au meilleur de SAC !) puis **décroît vers 0**. Sans clipping ni replay, chaque fenêtre de 5 pas réécrit la politique ; sur un marché bruité, les mises à jour successives détruisent le acquis du pic initial. L'entropie reste quasi constante (~1.0, proche du maximum de ln 4 ≈ 1.386 pour 4 actions) : la politique ne se concentre jamais — le coefficient d'entropie fixe (0.01) ne s'adapte pas comme le alpha de SAC. Total : **6.0 minutes** (2.5× SAC) — le on-policy paie chaque pas de données une seule fois.\n\n**Leçon immédiate** : le \"meilleur\" A2C (1.348) est un instantané éphémère, pas une politique déployable — le checkpoint final vaut 0.000. À l'inverse, le SAC final reste proche de son pic (1.049). C'est exactement la distinction entre *stabilité* et *performance de pointe* que la synthèse développera.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "### Interpretation de l'entrainement\n",
@@ -1499,6 +1529,12 @@
    "id": "cell-6f889674"
   },
   {
+   "cell_type": "markdown",
+   "id": "2cead28c",
+   "source": "### Lecture du tableau final : le classement défie la théorie\n\nLe résultat mesuré est instructif précisément parce qu'il contredit les attentes du tableau de la Partie 1 :\n\n| Rang | Agent | Sharpe | Return | MaxDD | Temps |\n|---|---|---|---|---|---|\n| 1 | DQN (QC-Py-32) | +0.683 | +50.1 % | −25.98 % | ~5 min |\n| 2 | PPO (QC-Py-33) | +0.645 | +34.6 % | −27.20 % | ~40 min |\n| 3 | A2C | 0.000 | +0.0 % | 0.00 % | 6.0 min |\n| 4 | SAC | −0.063 | −0.5 % | −2.62 % | 2.4 min |\n\nTrois lectures s'imposent :\n\n1. **SAC et A2C finissent \"hors course\" — mais pas de la même façon.** A2C à 0.000 de Sharpe avec +0.0 % de rendement et 0 % de drawdown : la politique finale a appris... à ne rien faire (cash intégral, zéro variation). C'est un optimum local légitime du point de vue du RL — dans un marché 2022-2024 avec frictions, l'inaction bat la moyenne des actions aléatoires. SAC à −0.063 est légèrement actif mais perd 0.5 % : sa politique finale dégrade ce que son pic intermédiaire (+1.049 en validation) avait trouvé.\n\n2. **Le rapport entre \"meilleur au cours du run\" et \"final\" est LE résultat du notebook.** Le meilleur checkpoint A2C valait +1.348, SAC +1.049 — tous deux au-dessus de DQN ! Mais le protocole évalue les politiques *finales*, pas les meilleures : sans early-stopping sur checkpoint (pratique standard en production, comme le fait PPO dans QC-Py-33), A2C rend son acquis. Un backtest honnête doit préciser ce qu'il mesure.\n\n3. **Le drawdown minimal de SAC (−2.62 %) n'est pas un exploit** — c'est la conséquence de sa quasi-inaction. Comparer les MaxDD entre agents sans normaliser par le turnover ou l'exposition moyenne est trompeur : un agent en cash affiche mécaniquement un drawdown nul. DQN accepte −26 % de drawdown pour extraire +50 % — un choix de profil risque différent, pas une infériorité.\n\nEnfin, notons le budget : les deux agents de ce notebook coûtent **8.4 minutes cumulées** contre ~45 pour PPO seul. La comparaison quadri-algorithmes reste donc raisonnable en coût pédagogique — mais chaque minute supplémentaire de PPO a payé une stabilité que ni SAC ni A2C n'atteignent ici à 100K steps.",
+   "metadata": {}
+  },
+  {
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {
@@ -1568,6 +1604,12 @@
     "print(\"Backtest sauvegarde dans sac_a2c_backtest.png\")"
    ],
    "id": "cell-92a89e3d"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d91ad827",
+   "source": "### Lecture des courbes de portefeuille\n\nLa figure du haut trace la valeur du portefeuille sur la validation (2022-2024) : la courbe A2C (orange) est **quasi confondue avec la ligne horizontale des 100 000 $** — visualisation directe de la politique d'inaction détectée dans le tableau. La courbe SAC (vert) s'écarte légèrement en dessous, cohérente avec le −0.5 % final. L'échelle est à comparer mentalement à celle du DQN de QC-Py-32, qui terminait ~50 % au-dessus de son capital initial.\n\nLa figure du bas (drawdowns remplis) complète la lecture : le remplissage orange d'A2C est un bandeau nul, celui de SAC une fine bande de −2.6 %. Ce contraste visuel illustre le point méthodologique de l'interprétation précédente : un drawdown plat n'est pas une gestion du risque, c'est une absence d'exposition.\n\nPour un œil entraîné, ces deux graphiques racontent l'histoire complète du notebook en un coup d'œil : *deux agents qui ont rencontré la difficulté du marché 2022-2024 et choisi (ou subi) l'inaction, contre deux aînés (DQN, PPO) qui s'y étaient exposés et rémunérés.* La vraie question pédagogique — comment transformer les pics intermédiaires (+1.348, +1.049) en politiques déployables — est précisément l'objet de l'Exercice 3.2 et de la conclusion.",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Tranche QC-Py-34 de l'epic densité #11224 (3e pire densité restante : 702 < seuil 1200). Enrichissement markdown-only, pattern #10488 : **7 cellules d'interprétation** ajoutées, ancrées sur les sorties réelles committées.

Interprétations ajoutées (chacune sous la cellule de code qu'elle lit) :
1. Données téléchargées (15/15 tickers, 2014-2024, 2768 jours, split walk-forward 2022, lecture `auto_adjust`)
2. Environnement (15 actifs, 4 actions, frictions 10+5 bps, 2014/752 steps)
3. Agent SAC instancié (53 772 params, double Q `torch.min`, alpha auto target_entropy ≈ 0.693)
4. Agent A2C instancie (18 053 params, tronc partagé, N-steps=5 vs GAE)
5. Courbes d'entraînement mesurées (SAC −3.808→+1.049 alpha 0.887→0.691 ; A2C +1.348→0.000, entropie ~1.0 plate)
6. Tableau final (classement DQN 0.683 > PPO 0.645 > A2C 0.000 > SAC −0.063 ; politique d'inaction A2C ; drawdown plat = absence d'exposition)
7. Courbes de portefeuille (lecture visuelle des 2 subplots)

## Validation

- `pedagogy_density.py` : 702 → **1334** (> 1200), md cells 23 → 30.
- **Markdown-only vérifié par comparaison JSON** : 17 cellules code byte-identiques (`source`), `outputs` et `execution_counts` inchangés vs origin/main — exception C.2 markdown-only, pas de re-exec requise.
- `validate_pr_notebooks` PASS 17/17, hooks pre-commit Passed.
- Grain tag : `Grain: MED/notebook-python — lane myia-po-2026:CoursIA — prev: MED/infra #10986-t10`

See #11224 (tranche, pas de Closes — 14 notebooks restants sous le plancher).