### PR TITLE
feat(tooling,#11159): registre d'adjudication des orphelins — statut ADJUGE avec motif obligatoire

### DIFF
--- a/scripts/audit/check_orphan_merged_pr.py
+++ b/scripts/audit/check_orphan_merged_pr.py
@@ -34,11 +34,18 @@ main, aucune PR ouverte de la base vers main, et le contenu manque encore a
 main*. L'orphelinage est un etat STABLE une fois avere : un balayage quotidien
 suffit (latence J+1 acceptable, l'issue le dit explicitement).
 
+Adjudications (#11159) : un orphelin tranche « ne pas recuperer » (motif ecrit,
+versionne dans ``orphan_adjudications.json``, cle = mergeCommit immuable) passe
+en statut ``ADJUGE`` distinct — liste separement et compte, jamais efface du
+rapport, label retire. Le registre ne desarme pas le detecteur : un nouvel
+orphelin non adjuge ressort toujours en ``ORPHAN``.
+
 Usage :
     py scripts/audit/check_orphan_merged_pr.py --days 14
     py scripts/audit/check_orphan_merged_pr.py --from-json prs.json --repo-path <repo>
     py scripts/audit/check_orphan_merged_pr.py --days 30 --strict
     py scripts/audit/check_orphan_merged_pr.py --days 7 --json-out out.json --apply
+    py scripts/audit/check_orphan_merged_pr.py --days 7 --adjudications <chemin>
 
 Exit codes :
     0 — advisory par defaut : n'echoue jamais, meme avec des findings
@@ -154,11 +161,13 @@ def open_prs_to_main(repo: str, base: str) -> int:
     return len(data)
 
 
-def analyse_pr(repo: Path, pr: dict, base_ref: str, repo_slug: str) -> dict:
+def analyse_pr(repo: Path, pr: dict, base_ref: str, repo_slug: str,
+               adjudications: dict | None = None) -> dict:
     """Analyse une PR mergee. Rend un dict de resultat avec `status` explicite.
 
     Statuts :
       ``orphan``      — mergeCommit non-ancetre de main, jambe morte, contenu absent (finding)
+      ``adjudge``     — orphelin adjuge « ne pas recuperer » (#11159, motif ecrit dans le registre)
       ``clean``       — ancetre de main, ou contenu deja present (re-atterri)
       ``in_flight``   — jambe encore ouverte vers main (stack legitime en vol)
       ``skipped``     — base == main, ou mergeCommit manquant / introuvable
@@ -198,6 +207,16 @@ def analyse_pr(repo: Path, pr: dict, base_ref: str, repo_slug: str) -> dict:
     if not missing:
         return {**result, "status": "clean", "merge_commit": merge_commit,
                 "paths": paths, "reason": "content already present in base (re-landed)"}
+
+    # Adjudication (#11159) : la cle est le mergeCommit (immuable), jamais le
+    # numero de PR ni la branche (reutilisables). Statut distinct, compte, et
+    # le motif est reporte pour qu'un adjudicataire puisse se dedire.
+    if adjudications and merge_commit in adjudications:
+        adj = adjudications[merge_commit]
+        return {**result, "status": "adjudge", "merge_commit": merge_commit,
+                "paths": paths, "motif": adj["motif"],
+                "adjudicated_by": adj["adjudicated_by"],
+                "adjudicated_at": adj["date"]}
 
     return {**result, "status": "orphan", "merge_commit": merge_commit,
             "paths": paths,
@@ -241,9 +260,42 @@ def filter_by_age(prs: list[dict], days: int, now: datetime | None = None) -> li
     return kept
 
 
+def load_adjudications(path: Path | None) -> dict[str, dict]:
+    """Charge le registre d'adjudications (#11159) : mergeCommit -> {motif, ...}.
+
+    Un orphelin adjuge (« ne pas recuperer », motif ecrit) passe du statut
+    ORPHAN a ADJUGE, liste separement et compte. Le registre est versionne
+    dans le depot (fichier, pas label GitHub) precisement pour obliger au
+    motif et passer en revue de PR. Toute entree sans motif est refusee
+    (RuntimeError -> exit 2) : une adjudication de complaisance reste visible.
+    """
+    if path is None or not path.is_file():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"registre d'adjudications illisible: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise RuntimeError("registre d'adjudications: objet attendu (mergeCommit -> entree)")
+    registry: dict[str, dict] = {}
+    for commit, entry in raw.items():
+        if not isinstance(entry, dict):
+            raise RuntimeError(f"adjudication {commit[:12]}: entree non-objet")
+        motif = str(entry.get("motif", "")).strip()
+        if not motif:
+            raise RuntimeError(f"adjudication {commit[:12]}: motif obligatoire")
+        registry[commit] = {
+            "motif": motif,
+            "adjudicated_by": str(entry.get("adjudicated_by", "")).strip(),
+            "date": str(entry.get("date", "")).strip(),
+        }
+    return registry
+
+
 def format_report(results: list[dict]) -> str:
     """Rapport texte : les findings d'abord, puis un recapitulatif compte."""
     orphans = [r for r in results if r["status"] == "orphan"]
+    adjudges = [r for r in results if r["status"] == "adjudge"]
     inflight = [r for r in results if r["status"] == "in_flight"]
     lines: list[str] = []
 
@@ -255,10 +307,17 @@ def format_report(results: list[dict]) -> str:
         lines.append(f"        recuperation : {r.get('recovery', '')}")
         lines.append("")
 
+    for r in adjudges:
+        lines.append(f"ADJUGE  PR #{r['number']}  mergeCommit={r['merge_commit'][:12]}  |  {r['title'][:70]}")
+        lines.append(f"        adjuge par: {r.get('adjudicated_by', '?')}  le {r.get('adjudicated_at', '?')}")
+        lines.append(f"        motif: {r.get('motif', '')[:120]}")
+        lines.append("")
+
     lines.append(
-        "Analysees: {total} | orphelins: {o} | en vol: {f} | propres: {c} | ignorees: {s}".format(
+        "Analysees: {total} | orphelins: {o} | adjuges: {a} | en vol: {f} | propres: {c} | ignorees: {s}".format(
             total=len(results),
             o=len(orphans),
+            a=len(adjudges),
             f=len(inflight),
             c=sum(1 for r in results if r["status"] == "clean"),
             s=sum(1 for r in results if r["status"] == "skipped"),
@@ -327,12 +386,30 @@ def build_comment(r: dict) -> str:
     ])
 
 
-def apply_findings(repo: str, orphans: list[dict], dry_run: bool) -> None:
-    """Label + commentaire marker-guarde (upsert, pas de spam quotidien)."""
-    if not orphans:
+def apply_findings(repo: str, orphans: list[dict], adjudges: list[dict],
+                   dry_run: bool) -> None:
+    """Label + commentaire marker-guarde sur les orphelins (upsert, pas de spam).
+
+    Les PR adjugees (#11159) reçoivent l'inverse : le label ``orphaned-delivery``
+    est RETIRE (la decision « ne pas recuperer » est tranchee — garder le label
+    rouge ferait passer une adjudication pour un orphelin non traite). Le
+    commentaire historique reste, marker-guarde, pour que l'adjudicataire puisse
+    relire et se dedire.
+    """
+    if not orphans and not adjudges:
         return
     if not dry_run:
         ensure_label(repo)
+    for r in adjudges:
+        number = r["number"]
+        if dry_run:
+            print(f"[orphan-apply] #{number} label={LABEL_NAME} removed (adjudge, dry-run)")
+            continue
+        subprocess.run(
+            ["gh", "pr", "edit", str(number), "--repo", repo, "--remove-label", LABEL_NAME],
+            capture_output=True, text=True, check=False, encoding="utf-8",
+        )
+        print(f"[orphan-apply] #{number} label={LABEL_NAME} removed (adjudge)")
     for r in orphans:
         number = r["number"]
         if dry_run:
@@ -358,6 +435,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--base-ref", default="origin/main", help="ref de base (defaut: origin/main)")
     parser.add_argument("--days", type=int, default=14,
                         help="fenetre d'anciennete des merges, en jours (0 = sans limite)")
+    parser.add_argument("--adjudications", type=Path, default=None,
+                        help="registre d'adjudications JSON (#11159, defaut: <repo>/scripts/audit/orphan_adjudications.json)")
     parser.add_argument("--limit", type=int, default=200, help="nombre de PR demandees a gh")
     parser.add_argument("--repo", default=None, help="slug owner/name passe a gh")
     parser.add_argument("--from-json", default=None,
@@ -383,8 +462,12 @@ def main(argv: list[str] | None = None) -> int:
             ["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"],
             capture_output=True, text=True, encoding="utf-8").stdout.strip()
             or "jsboige/CoursIA")
+        adjudications_path = args.adjudications or (
+            repo / "scripts" / "audit" / "orphan_adjudications.json")
+        adjudications = load_adjudications(adjudications_path)
         prs = filter_by_age(load_prs(args), args.days)
-        results = [analyse_pr(repo, pr, args.base_ref, repo_slug) for pr in prs]
+        results = [analyse_pr(repo, pr, args.base_ref, repo_slug, adjudications)
+                   for pr in prs]
     except GitError as exc:
         print(f"ERREUR: {exc}", file=sys.stderr)
         return 2
@@ -408,9 +491,10 @@ def main(argv: list[str] | None = None) -> int:
             return 2
 
     orphans = [r for r in results if r["status"] == "orphan"]
+    adjudges = [r for r in results if r["status"] == "adjudge"]
     if args.apply:
         try:
-            apply_findings(repo_slug, orphans, args.dry_run)
+            apply_findings(repo_slug, orphans, adjudges, args.dry_run)
         except RuntimeError as exc:
             print(f"ERREUR: {exc}", file=sys.stderr)
             return 2

--- a/scripts/audit/orphan_adjudications.json
+++ b/scripts/audit/orphan_adjudications.json
@@ -1,0 +1,7 @@
+{
+  "3a178b0f02bc0de7c12f09f48ef88f878ed87280": {
+    "motif": "Contenu arrive sur main par promotion quarto : 3 des 4 fichiers sont deja presents a l'identique ; le 4e (MyIA.AI.Notebooks/Search/_metadata.yml) portait echo/enabled/warning pour le sous-arbre Search/, reglages promus au bloc racine execute: de _quarto.yml (L624-629, promotion documentee comme mesuree dans regen_quarto_render.py:19). L'override par sous-arbre est redondant, pas perdu — content_missing est file-presence-based et ne peut pas savoir qu'un reglage a migre ailleurs.",
+    "adjudicated_by": "ai-01",
+    "date": "2026-08-16"
+  }
+}

--- a/scripts/audit/tests/test_check_orphan_merged_pr.py
+++ b/scripts/audit/tests/test_check_orphan_merged_pr.py
@@ -401,3 +401,126 @@ def test_main_json_out_written(tmp_path):
     assert rc == 0
     data = json.loads(out.read_text(encoding="utf-8"))
     assert data["results"][0]["status"] == "skipped"
+
+
+# --------------------------------------------------------------------------- #
+# Adjudications (#11159) — registre versionne, statut ADJUGE distinct
+# --------------------------------------------------------------------------- #
+def test_adjudged_when_merge_commit_in_registry(tmp_path):
+    """Le #10972 original, mais son mergeCommit est dans le registre d'adjudications
+    -> statut ADJUGE (pas ORPHAN), motif reporte, cle = mergeCommit."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "main")
+    _commit(repo, "squash of base leg", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "feature/base")
+    mc = _commit(repo, "PR site-render infra", {"site/rendered.html": "html"})
+    pr = _pr(10972, "feature/site-render-infra-10923", base="feature/base",
+             merge_commit=mc, files=["site/rendered.html", "_quarto.yml"])
+    adjudications = {mc: {"motif": "contenu promu au bloc racine de _quarto.yml (L624-629)",
+                          "adjudicated_by": "ai-01", "date": "2026-08-16"}}
+    res = mod.analyse_pr(repo, pr, "main", "", adjudications)
+    assert res["status"] == "adjudge"
+    assert res["merge_commit"] == mc
+    assert "promu au bloc racine" in res["motif"]
+    assert res["adjudicated_by"] == "ai-01"
+
+
+def test_unadjudged_orphan_still_orphan_with_registry(tmp_path):
+    """Un nouvel orphelin non adjuge ressort toujours en ORPHAN meme quand le
+    registre existe — le registre ne desarme pas le detecteur."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "main")
+    _commit(repo, "squash of base leg", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "feature/base")
+    mc = _commit(repo, "PR work", {"site/rendered.html": "html"})
+    pr = _pr(999, "feature/new-orphan", base="feature/base", merge_commit=mc,
+             files=["site/rendered.html"])
+    # Le registre contient un AUTRE mergeCommit (le #10972 historique)
+    adjudications = {"3a178b0f02bc0de7c12f09f48ef88f878ed87280":
+                     {"motif": "autre orphelin", "adjudicated_by": "ai-01",
+                      "date": "2026-08-16"}}
+    res = mod.analyse_pr(repo, pr, "main", "", adjudications)
+    assert res["status"] == "orphan"
+    assert res["merge_commit"] == mc
+
+
+def test_adjudication_without_motive_rejected(tmp_path):
+    """Entree de registre sans motif -> RuntimeError (exit 2) : jamais un mute
+    silencieux, l'adjudication de complaisance reste visible."""
+    mod = _load()
+    reg = tmp_path / "adjudications.json"
+    reg.write_text(json.dumps({"a" * 40: {"adjudicated_by": "ai-01",
+                                          "date": "2026-08-16"}}), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="motif"):
+        mod.load_adjudications(reg)
+
+
+def test_adjudication_bad_json_rejected(tmp_path):
+    mod = _load()
+    reg = tmp_path / "adjudications.json"
+    reg.write_text("{not json", encoding="utf-8")
+    with pytest.raises(RuntimeError, match="illisible"):
+        mod.load_adjudications(reg)
+
+
+def test_format_report_lists_adjudges_separately_and_counts():
+    mod = _load()
+    results = [
+        {"status": "orphan", "number": 1, "base": "feature/base", "head": "f",
+         "merged_at": "t", "title": "T", "merge_commit": "b" * 40,
+         "paths": ["x"], "recovery": "git merge origin/f"},
+        {"status": "adjudge", "number": 2, "base": "feature/base", "head": "g",
+         "merged_at": "t", "title": "T2", "merge_commit": "a" * 40,
+         "paths": ["y"], "motif": "contenu promu au bloc racine",
+         "adjudicated_by": "ai-01", "adjudicated_at": "2026-08-16"},
+    ]
+    out = mod.format_report(results)
+    assert "ADJUGE  PR #2" in out
+    assert "motif: contenu promu au bloc racine" in out
+    assert "orphelins: 1" in out
+    assert "adjuges: 1" in out
+
+
+def test_main_adjudged_does_not_fail_strict(tmp_path):
+    """main() avec registre qui adjuge le seul orphelin -> --strict exit 0 :
+    le compte orphelins retombe a 0, l'adjudication n'est pas un finding."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    _g(repo, "checkout", "-q", "-b", "feature/base")
+    _commit(repo, "base leg work", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "main")
+    _commit(repo, "squash of base leg", {"_quarto.yml": "cfg"})
+    _g(repo, "checkout", "-q", "feature/base")
+    mc = _commit(repo, "PR work", {"site/rendered.html": "html"})
+    prs = tmp_path / "prs.json"
+    prs.write_text(json.dumps([_pr(10972, "feature/site", merge_commit=mc,
+                                   files=["site/rendered.html"])]), encoding="utf-8")
+    reg = tmp_path / "adjudications.json"
+    reg.write_text(json.dumps({mc: {"motif": "contenu promu au bloc racine",
+                                    "adjudicated_by": "ai-01",
+                                    "date": "2026-08-16"}}), encoding="utf-8")
+    rc = mod.main(["--repo-path", str(repo), "--from-json", str(prs),
+                   "--base-ref", "main", "--repo", "", "--days", "0",
+                   "--adjudications", str(reg), "--strict"])
+    assert rc == 0
+
+
+def test_main_registry_corrupt_exits_2(tmp_path):
+    """Un registre mal forme (motif manquant) -> exit 2 : le garde-fou est
+    declenche, pas une adjudication silencieuse."""
+    mod = _load()
+    repo = _git_repo(tmp_path)
+    prs = tmp_path / "prs.json"
+    prs.write_text(json.dumps([_pr(1, "feature/x", base="main")]), encoding="utf-8")
+    reg = tmp_path / "adjudications.json"
+    reg.write_text(json.dumps({"a" * 40: {"adjudicated_by": "x"}}), encoding="utf-8")
+    rc = mod.main(["--repo-path", str(repo), "--from-json", str(prs),
+                   "--base-ref", "main", "--repo", "", "--days", "0",
+                   "--adjudications", str(reg)])
+    assert rc == 2


### PR DESCRIPTION
## Summary

Issue #11159 : un orphelin adjugé « ne pas récupérer » rebruite chaque jour (label `orphaned-delivery` reposé, script échoue en strict). Cette PR ajoute un **registre d'adjudications versionné** au scanner `check_orphan_merged_pr.py`.

- `scripts/audit/orphan_adjudications.json` (nouveau) : clé = mergeCommit (immuable), champs `motif` (obligatoire), `adjudicated_by`, `date`. Première entrée : #10972 (promotion quarto, motif documenté).
- Statut **ADJUGE** distinct d'ORPHelin : les adjugués sont listés séparément et comptés (`adjudges: N`), **jamais effacés du rapport**.
- `load_adjudications()` : validation stricte — `motif` absent → `RuntimeError` → exit 2 (pas d'adjudication silencieuse).
- `apply_findings()` : le label `orphaned-delivery` est **retiré** des PRs adjuguées, **conservé** sur les orphelins réels.

## Validation

- **28/28 tests pass** (7 nouveaux : adjugé reconnu, orphelin intact avec registre, motif absent rejeté, JSON corrompu exit 2, rapport liste/compte les adjugués, main strict ne fail pas sur adjugué, registre corrompu exit 2).
- **Run end-to-end réel** sur #10972 : sortie `orphelins: 0 | adjuges: 1`, label retiré.

Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: LIGHT/ci #11300

See #11159 (Closes si la review estime l'acceptance couverte : registre + motif + comptage + label).