### PR TITLE
docs(qc,#11224): densite QC-Py-33 RL-PPO-Trading 712->1469 (tranche markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-33-RL-PPO-Trading.ipynb
@@ -263,6 +263,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy33-md-env-exec",
+   "metadata": {},
+   "source": [
+    "### Lire l'environnement d'exécution : ce que la seed garantit, et ce qu'elle ne garantit pas\n",
+    "\n",
+    "La cellule ci-dessus imprime volontairement son environnement avant tout calcul : **PyTorch 2.11.0+cu128**,\n",
+    "CUDA disponible, un **RTX 3070 Laptop (8.6 Go)**, et surtout **Seed: 42**. Cette ligne n'est pas décorative —\n",
+    "elle conditionne la lecture de tous les chiffres qui suivent. La seed fixe le tirage des **poids initiaux**\n",
+    "du réseau Actor-Critic, les tirages aléatoires de la collecte de rollouts (la politique PPO est\n",
+    "stochastique : elle échantillonne ses actions) et l'ordre de toute opération non déterministe de NumPy.\n",
+    "Deux exécutions avec la même seed partent donc du même point de départ et explorent les mêmes trajectoires.\n",
+    "\n",
+    "Ce que la seed **ne** garantit pas : certains kernels cuDNN (opérations GPU accélérées) ne sont pas\n",
+    "déterministes par défaut, et le temps de collecte des rollouts peut varier d'une machine à l'autre —\n",
+    "les résultats committés dans ce notebook sont ceux d'**une** exécution reproductible sur cette machine,\n",
+    "pas une loi statistique. C'est exactement pour ça que la partie 5 comparera deux politiques à seed fixée\n",
+    "(même environnement, mêmes données), et que la conclusion nuancera ce qu'un tel comparatif peut prouver.\n",
+    "Notons enfin le paradoxe apparent du hardware : 8.6 Go de VRAM pour un réseau de ~156 000 paramètres\n",
+    "(c'est le sujet de la partie 3) — dans le RL sur GPU, ce n'est presque jamais le réseau qui coûte,\n",
+    "c'est la **collecte** : des milliers de pas d'environnement, chacun avec une passe avant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "f90c2ca5",
    "metadata": {
     "papermill": {
@@ -622,6 +646,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy33-md-obs-anatomy",
+   "metadata": {},
+   "source": [
+    "### Anatomie de l'espace d'observation : 90 nombres = 15 actifs x 6 signaux\n",
+    "\n",
+    "L'output `Obs dim: 90` se décompose exactement : **15 actifs x 6 caractéristiques par actif**, construites\n",
+    "dans `_get_observation`. Ces 6 signaux méritent d'être lus un par un, car ils définissent tout ce que la\n",
+    "politique peut jamais « voir » :\n",
+    "\n",
+    "1. **`ret_1d`** — rendement de la veille : le signal le plus court, bruité mais réactif.\n",
+    "2. **`ret_5d`** — rendement de la semaine : momentum intermédiaire.\n",
+    "3. **`ret_20d`** — rendement du mois : momentum long, le signal le plus exploité en pratique.\n",
+    "4. **`vol_20d`** — volatilité réalisée sur 20 jours : la dimension de risque ; un même rendement obtenu\n",
+    "   dans la volatilité haute ou basse n'a pas le même poids dans un Sharpe.\n",
+    "5. **`pos_norm`** — la position courante sur cet actif, normalisée par le capital initial : c'est le seul\n",
+    "   signal **interne** de l'observation. Sans lui, la politique serait amnésique de son propre portefeuille\n",
+    "   et pourrait « acheter » ce qu'elle détient déjà.\n",
+    "6. **`vol_ratio`** — volume du jour rapporté à la moyenne 20 jours : activité anormale, proxy\n",
+    "   d'événement.\n",
+    "\n",
+    "Deux choix de design visibles dans l'output méritent une pause. D'abord le découpage **2014 pas\n",
+    "d'entraînement / 752 pas de validation** (~73/27) : la validation couvre 2022-2024, une période de\n",
+    "marché haussier — un biais dont il faudra se souvenir en lisant les rendements de la partie 5. Ensuite,\n",
+    "l'action est **au niveau portefeuille** : la cellule de décision de la partie 5 montrera qu'une seule\n",
+    "action est choisie puis broadcastée aux 15 actifs (une même décision partout) — l'espace d'action a 4\n",
+    "choix (Hold/Buy/Sell/Close), pas 4^15."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "73c28c56",
    "metadata": {
     "papermill": {
@@ -761,6 +815,31 @@
     "print(f\"  Hidden: 256 (shared) -> 128 (heads)\")\n",
     "print(f\"  Parametres: {n_params:,}\")\n",
     "print(f\"  Device: {DEVICE}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy33-md-params-budget",
+   "metadata": {},
+   "source": [
+    "### 156 549 paramètres : où vit la capacité, et pourquoi une base partagée\n",
+    "\n",
+    "L'output donne la décomposition : **90 -> 256 (base partagée) -> 128 (tête acteur) et 128 (tête critique)**,\n",
+    "pour 156 549 paramètres au total. Deux lectures.\n",
+    "\n",
+    "La première est quantitative : 156k paramètres est **petit** — trois ordres de grandeur sous un\n",
+    "transformer de langage, et même sous bien des CNNs de vision. Ce n'est pas un accident ni une limite :\n",
+    "dans le RL financier, le goulot n'est presque jamais la capacité du réseau mais la **qualité et la\n",
+    "quantité de signal** (752 pas de validation, ~2000 pas d'entraînement par épisode). Un réseau plus grand\n",
+    "apprendrait plus vite à mémoriser ces données-là — c'est le chemin le plus court vers l'overfitting,\n",
+    "que les logs d'entraînement de la partie 4 vont précisément illustrer.\n",
+    "\n",
+    "La seconde est architecturale : la **base partagée** signifie que l'acteur (qui choisit l'action) et le\n",
+    "critique (qui estime la valeur de l'état) lisent l'état **à travers la même représentation interne**.\n",
+    "C'est la différence avec le DQN de QC-Py-32, qui entraînait deux réseaux séparés (main + target) pour\n",
+    "la même fonction valeur. Ici, ce que le critique apprend à valoriser guide directement ce que l'acteur\n",
+    "voit — au prix d'un couplage : un gradient bruité sur l'une des têtes perturbe l'autre à travers la base,\n",
+    "ce que le terme `value_coef` de la cellule suivante vient équilibrer."
    ]
   },
   {
@@ -1019,6 +1098,41 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy33-md-hyperparams",
+   "metadata": {},
+   "source": [
+    "### Les sept réglages qui gouvernent PPO, lus depuis l'initialisation\n",
+    "\n",
+    "L'output de la cellule précédente est en réalité la **table de bord complète** de l'algorithme — chaque\n",
+    "ligne est un levier, avec une valeur par défaut héritée des papiers fondateurs. Lire PPO, c'est savoir\n",
+    "ce que chaque réglage contrôle et quel symptôme révèle qu'il est mal calibré :\n",
+    "\n",
+    "- **`Clip epsilon: 0.2`** — la demi-largeur de la fenêtre dans laquelle le ratio de probabilité\n",
+    "  nouveau/ancien a le droit de bouger pendant une mise à jour. Trop petit : apprentissage figé, la\n",
+    "  politique ne bouge presque plus à chaque rollout. Trop grand : mises à jour destructrices —\n",
+    "  précisément le comportement chaotique que PPO existe pour éliminer.\n",
+    "- **`GAE lambda: 0.95`** — le compromis biais-variance de l'estimation d'avantage. Proche de 1 :\n",
+    "  faible biais, forte variance (l'avantage utilise les retours complets, bruités). Proche de 0 :\n",
+    "  avantage = simple résidu de Bellman, biaisé par les erreurs du critique mais stable.\n",
+    "- **`PPO epochs: 4`** — combien de passes de gradient sur le **même** rollout. C'est la seule raison\n",
+    "  pour laquelle le clipping existe : réutiliser les données casse l'hypothèse on-policy, le clip\n",
+    "  contient le dérive. Plus d'epochs = plus d'échantillonnage efficace, plus de risque de dérive.\n",
+    "- **`Entropy coef: 0.01`** — le bonus d'entropie, récompense la politique pour rester indécise.\n",
+    "  Trop faible : effondrement prématuré sur une action (le modèle « oublie » d'explorer). Trop fort :\n",
+    "  la politique reste uniforme et n'apprend rien. C'est le sujet de l'exercice 2.\n",
+    "- **`Value coef: 0.5`** — le poids de la perte du critique dans la perte totale. La tête valeur a\n",
+    "  typiquement des gradients plus amples que la tête politique ; sans ce facteur, le critique domine\n",
+    "  la base partagée et l'acteur apprend au ralenti.\n",
+    "- **`Batch size: 64`** — la granularité des minibatchs **à l'intérieur** de chaque passe. Distinct du\n",
+    "  rollout (1024 pas collectés avant toute mise à jour) : on collecte grand pour estimer l'avantage,\n",
+    "  on met à jour petit pour la stabilité du gradient.\n",
+    "- **`Optimizer: AdamW (lr=3e-4)`** — le pas d'apprentissage. En RL, un lr trop haut ne fait pas juste\n",
+    "  diverger : il fait **osciller la politique** autour d'un optimum sans jamais s'y poser — un échec\n",
+    "  plus silencieux, visible seulement dans les courbes de la partie 4."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fe536a8d",
    "metadata": {
     "papermill": {
@@ -1097,7 +1211,7 @@
    "source": [
     "---\n",
     "\n",
-    "## Partie 4 : Entrainement PPO 200K Steps (35 min)"
+    "## Partie 4 : Entrainement PPO 100K Steps (35 min)"
    ]
   },
   {
@@ -1125,7 +1239,7 @@
     "3. Effectuer `ppo_epochs` passes de mise a jour sur les données\n",
     "4. Reinitialiser le buffer et recommencer\n",
     "\n",
-    "**Walk-forward** : Tous les 50K steps, on evalue sur le set de validation\n",
+    "**Walk-forward** : Tous les 25K steps, on evalue sur le set de validation\n",
     "pour detecter l'overfitting et sauvegarder le meilleur modèle."
    ]
   },
@@ -1336,9 +1450,37 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "L'entrainement PPO collecte des trajectoires de 2048 pas puis met a jour\n",
+    "L'entrainement PPO collecte des trajectoires de 1024 pas puis met a jour\n",
     "la politique. L'entropie devrait rester positive (politique exploratoire).\n",
     "Le Sharpe de validation devrait s'ameliorer au fil des steps si l'apprentissage converge."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy33-md-logs-lecture",
+   "metadata": {},
+   "source": [
+    "### Ce que les logs mesurent vraiment : deux optimisations qui réussissent, une métrique qui décroche\n",
+    "\n",
+    "Relisons les trois lignes de log comme trois instruments séparés, parce qu'ils ne racontent pas la même\n",
+    "histoire. La **policy loss** descend (`-0.0064 -> -0.0112 -> -0.0209`) : l'objectif surrogate s'optimise,\n",
+    "l'algorithme fait son travail. La **value loss** descend elle aussi (`1.5756 -> 0.8140 -> 0.7182`) :\n",
+    "le critique apprend à prédire les retours du portefeuille. L'**entropie** décroit\n",
+    "(`0.755 -> 0.620 -> 0.619`) : la politique se concentre — pour référence, une politique uniforme sur\n",
+    "4 actions aurait une entropie de ln(4) ~ 1.39, donc la politique est déjà passée d'environ 54 % à 45 %\n",
+    "de ce maximum.\n",
+    "\n",
+    "Et pourtant, le **Sharpe de validation** fait exactement l'inverse : `+0.645 -> +0.162 -> +0.089`.\n",
+    "Chaque évaluation intermédiaire est plus mauvaise que la précédente, et le meilleur checkpoint est le\n",
+    "**premier** — celui de 25 600 steps. C'est la divergence la plus instructive de ce notebook :\n",
+    "**l'objectif que PPO optimise n'est pas le Sharpe**. La politique améliore son objectif (marges\n",
+    "d'avantage, valeur prédite) sur les trajectoires qu'elle-même génère en entraînement, pendant que la\n",
+    "métrique métier mesurée sur des données de validation se dégrade : la définition même de\n",
+    "l'overfitting appliquée au RL. Le mécanisme de sauvegarde « best checkpoint » n'est pas un confort —\n",
+    "c'est ce qui sépare ce notebook d'une livraison du modèle final (Sharpe 0.089) croyant livrer le\n",
+    "meilleur (0.645). Retenir la règle de lecture : dans un log RL, la loss qui descend et la métrique\n",
+    "qui monte sont deux événements **indépendants** — jamais confondre convergence de l'objectif et\n",
+    "amélioration du portefeuille."
    ]
   },
   {
@@ -1538,6 +1680,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy33-md-oos-actions",
+   "metadata": {},
+   "source": [
+    "### Lire les résultats avec la distribution d'actions : ce que la politique a vraiment appris\n",
+    "\n",
+    "Les cinq premières métriques semblent flatteuses — **+34.55 %** total, **+10.46 %** annualisé, Sharpe\n",
+    "**0.645**, MaxDD **-27.20 %**, win rate **51.20 %**. La dernière ligne est celle qui change tout :\n",
+    "`Actions - Hold: 345, Buy: 10650, Sell: 0, Close: 285`. Sur les 11 280 décisions-actifs de la\n",
+    "validation (752 pas x 15 actifs), **94 % sont des Buy** — en pas de décision : 710 sur 752, avec\n",
+    "**aucun Sell de toute l'évaluation**. La politique apprise n'est pas un timing de marché : c'est\n",
+    "essentiellement **« rester long »** sur les 15 actifs, en permanence.\n",
+    "\n",
+    "Cette lecture redistribue le crédit des chiffres. Le rendement +34.55 % est alors, pour l'essentiel,\n",
+    "la performance d'un portefeuille long des 15 actions sur 2022-2024 — une période haussière — et non\n",
+    "un alpha de sélection de moments. Le MaxDD de -27.20 % est cohérent avec une exposition longue\n",
+    "permanente : qui est toujours investi encaisse toutes les corrections. Et le win rate de 51.20 %,\n",
+    "mesuré sur les retours journaliers du portefeuille, est celui du marché lui-même plus qu'une\n",
+    "habileté. Une remarque de méthode sur `Nb trades: 0` : le journal de trades et la distribution\n",
+    "d'actions ne comptent pas la même chose — c'est la **distribution d'actions** qui décrit fidèlement\n",
+    "le comportement ; un « nombre de trades » nul doit toujours se croiser avec elle avant toute\n",
+    "interprétation. Le contrepoint sera instructif : le DQN de la comparaison suivante, avec 9 trades,\n",
+    "a appris presque l'inverse — une politique quasi inactive."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "38d4eeb0",
    "metadata": {
     "papermill": {
@@ -1688,6 +1856,37 @@
     "print(f\"\\nVerdict: {winner} est meilleur en Sharpe Ratio\")\n",
     "print(f\"  DQN: meilleure stabilite (moins de trades, politique plus conservatrice)\")\n",
     "print(f\"  PPO: meilleure exploration (politique stochastique, plus de diversite)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy33-md-verdict-tableau",
+   "metadata": {},
+   "source": [
+    "### Le verdict du tableau : un écart de 0.012 Sharpe n'est pas un verdict\n",
+    "\n",
+    "Le tableau donne DQN devant en Sharpe (0.657 vs 0.645) et en MaxDD (-22.94 vs -27.20), PPO devant en\n",
+    "rendement (+34.6 vs +31.3) — et imprime « DQN est meilleur en Sharpe Ratio ». Les trois lectures à\n",
+    "faire de cette table avant d'accepter le verdict imprimé.\n",
+    "\n",
+    "**Première lecture : l'ordre de grandeur de l'écart.** 0.657 - 0.645 = 0.012 de Sharpe, mesuré à\n",
+    "**seed unique**, sur un seul passage de validation. La convention du dépôt (règle C du reviewing :\n",
+    "jamais de verdict « BEATS » sans multi-seed et test statistique) s'applique ici avec d'autant plus de\n",
+    "force que la section précédente a montré le même PPO varier de 0.645 à 0.089 selon le step de\n",
+    "checkpoint — la variance **interne à un entraînement** dépasse d'un ordre de grandeur l'écart entre\n",
+    "les deux algorithmes. « DQN est meilleur en Sharpe » est une lecture de tableau, pas une preuve.\n",
+    "\n",
+    "**Deuxième lecture : la ligne qui explique tout le reste.** `Nb Trades: 9 contre 0` (et la\n",
+    "distribution d'actions : quasi-inactif contre quasi-long). Les deux politiques ont appris des\n",
+    "comportements **structurellement différents** — presque aucun mouvement contre exposition permanente.\n",
+    "Comparer leurs métriques, c'est comparer deux styles de portefeuille, pas deux implantations du même\n",
+    "style : le rendement supérieur de PPO sur une période haussière et son MaxDD supérieur sont les deux\n",
+    "faces du même choix (être toujours investi), pas deux performances indépendantes.\n",
+    "\n",
+    "**Troisième lecture : que faudrait-il pour un vrai verdict ?** Le même protocole multi-seed que pour\n",
+    "toute comparaison ML du dépôt : ré-entraîner chaque agent sur plusieurs seeds, pooler, tester. C'est\n",
+    "le sujet de la série RL Post-Training (`MyIA.AI.Notebooks/RL/`) côté Python local — et la barre\n",
+    "méthodologique à garder en tête en lisant toute table de ce genre."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/training #11317 (rlpt_4)

## Summary

Tranche #11224 : **QC-Py-33-RL-PPO-Trading.ipynb**, densité pédagogique **712 → 1469** chars de
prose / cellule code (organe `pedagogy_density.py`, seuil 1200). Enrichissement **markdown-only FR**
— les 16 cellules code sont **byte-identiques** (vérifié par diff structurel cellule-à-cellule contre
`origin/main`), aucune re-exec requise (exception markdown-only C.3), outputs intacts.

## Les 7 cellules ajoutées (ancrées sur les outputs réels)

| Position | Contenu | Valeurs citées (de l'output adjacent) |
|---|---|---|
| après config GPU | ce que la seed 42 garantit / ne garantit pas (cuDNN), pourquoi imprimer l'env | PyTorch 2.11.0+cu128, RTX 3070 8.6 Go, seed 42 |
| après environnement | anatomie de l'obs : 90 = 15 actifs × 6 signaux (`ret_1d/5d/20d, vol_20d, pos_norm, vol_ratio`), action portfolio-level broadcastée | Obs dim 90, 2014/752 steps, Hold/Buy/Sell/Close |
| après ActorCritic | 156 549 paramètres : base partagée acteur/critique vs 2 réseaux DQN, pourquoi petit | 90→256→128, 156 549 params |
| après PPOAgent init | les 7 hyperparamètres : rôle + symptôme de mauvais réglage | clip 0.2, GAE 0.95, epochs 4, entropy 0.01, value 0.5, batch 64, AdamW 3e-4 |
| après Interpretation (logs) | **divergence objectif↔métrique** : loss/entropie s'optimisent pendant que val_sharpe décroît ; best checkpoint = le premier | pol_loss −0.0064→−0.0209, val_loss 1.5756→0.7182, entropy 0.755→0.619 (max ln 4≈1.39), val_sharpe +0.645→+0.162→+0.089 |
| après éval OOS | lecture avec la distribution d'actions : 94 % Buy (10 650/11 280), 0 Sell → politique quasi buy-and-hold, le rendement = le marché 2022-2024, pas un alpha de timing ; `Nb trades: 0` vs distribution | +34.55 %, +10.46 %/an, Sharpe 0.645, MaxDD −27.20 %, win 51.20 %, Hold 345/Buy 10650/Sell 0/Close 285 |
| après tableau comparatif | un écart de 0.012 Sharpe à seed unique n'est pas un verdict (variance intra-entraînement 0.645→0.089 > écart inter-algos) ; 9 trades vs quasi-long = deux styles de portefeuille comparés | DQN 0.657 vs PPO 0.645, +31.3 vs +34.6, 9 vs 0 trades |

## 3 corrections de drift prose ↔ output (vérifiées contre les outputs committés)

- Header Partie 4 : « 200K Steps » → « 100K » (l'output dit `PPO Training: 100,000 steps`)
- Walk-forward : « Tous les 50K steps » → « 25K » (l'output dit `Eval tous les 25,000 steps`)
- Interp : « trajectoires de 2048 pas » → « 1024 » (l'output dit `Rollout length: 1024`)

La ligne « Steps entrainement 200K steps » du tableau comparatif vient d'une constante **dans le code**
(non touchée — markdown-only) : corrigeable uniquement dans une PR touchant le code.

## Validation

- Mesure avant/après : `pedagogy_density.py --json` → 712 → **1469** (status `ok`).
- 16/16 cellules code byte-identiques (script de diff structurel, `git show origin/main:` en base).
- Interps ancrées : chaque valeur chiffrée citée provient de l'output de la cellule précédente
  ([cell-interpretation-ordering](../../.claude/rules/cell-interpretation-ordering.md)).
- Stubs d'exercices C.1 intacts ; pas de `_en.ipynb` ; catalogue byte-identique à main.
- File CI mesurée avant ouverture : 83 runs (<200).

## Regression check

- Fichier unique, 203 insertions / 4 deletions, markdown-only.
- Aucun symbole code touché.

See #11224 (tranche QC-Py-33, protocole #10488 — 1 notebook = 1 PR)
