### PR TITLE
docs(qc,#11224): densite QC-Py-15 Parameter-Optimization 734->1415 (tranche markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -220,6 +220,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy15-md-contrat",
+   "metadata": {},
+   "source": [
+    "### Le contrat de ce notebook : optimiser sans se mentir\n",
+    "\n",
+    "Optimiser les paramètres d'une stratégie, c'est faire un choix dans un espace de possibilités en\n",
+    "utilisant l'histoire comme électorat. Le contrat de lecture de ce notebook est double. D'abord : toute\n",
+    "optimisation sur des données passées **peut** être un artefact — les 672 backtests de la partie 3 vont\n",
+    "produire un classement, et la question n'est jamais « quelle est la meilleure combinaison » mais\n",
+    "« ce classement survivra-t-il à des données que l'optimisation n'a pas vues ». Ensuite : les outils qui\n",
+    "répondent à cette question existent et sont tous ici — validation out-of-sample, walk-forward, tests de\n",
+    "sensibilité, Monte Carlo — mais ils ne valent que par la rigueur avec laquelle on lit leurs sorties.\n",
+    "\n",
+    "Ce notebook est construit pour que la démonstration soit honnête : les données sont en partie simulées,\n",
+    "les phénomènes d'overfitting apparaîtront **réellement dans les sorties committées** (une walk-forward\n",
+    "qui tombe à 0 partout, un détecteur qui lit un `nan` comme un « OK »), et chaque partie expliquera ce\n",
+    "que l'output dit vraiment — y compris quand il contredit la conclusion confortable. Gardez cette grille\n",
+    "de lecture : un score élevé in-sample n'est pas une information sur le futur ; c'est une information sur\n",
+    "la capacité de l'espace de paramètres à épouser le bruit du passé."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "022943ed",
    "metadata": {
     "papermill": {
@@ -510,6 +533,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy15-md-degradation",
+   "metadata": {},
+   "source": [
+    "### Lire la dégradation mesurée : -18.9 % est le scénario BÉNIN\n",
+    "\n",
+    "La sortie montre Sharpe **2.20 en In-Sample** contre **1.78 en Out-of-Sample**, soit une dégradation de\n",
+    "**-18.9 %** pour les paramètres SMA(21, 60) optimisés sur la période d'entraînement. La leçon de lecture\n",
+    "tient en deux points.\n",
+    "\n",
+    "Premier point : le sens de la comparaison. Les paramètres ont été **choisis** pour maximiser le score\n",
+    "IS — le 2.20 est donc un maximum optimisé, pas une mesure neutre. Le 1.78, lui, n'a bénéficié d'aucun\n",
+    "choix : c'est la performance d'une politique figée sur des données nouvelles. Toute la différence entre\n",
+    "les deux nombres mesure l'écart entre « sélectionner sur le passé » et « jouer sur le futur ». Un écart\n",
+    "de -18.9 % paraît modéré ; il le reste seulement parce que la simulation (tendance + saisonnalité) a une\n",
+    "structure stable entre IS et OOS. Sur des données réelles, la dégradation typique est plus sévère — et\n",
+    "la partie 4 montrera un cas extrême où elle vaut **100 %**.\n",
+    "\n",
+    "Deuxième point : la borne de confiance. Avec aussi peu de transactions par configuration (la partie 3\n",
+    "en comptera 3 à 5), l'écart-type du Sharpe estimé est de l'ordre de la valeur elle-même. La dégradation\n",
+    "mesurée ici est une **observation sur un échantillon**, pas un paramètre de la stratégie. C'est la\n",
+    "raison d'être des méthodes qui suivent : répéter la mesure (walk-forward), la perturber (sensibilité,\n",
+    "Monte Carlo) pour savoir si -18.9 % est une propriété ou un tirage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "70419ab7",
    "metadata": {
     "papermill": {
@@ -608,6 +657,37 @@
     "print(f\"Temps estime (Grid Search): {n_combinations * time_per_backtest / 60:.1f} minutes\")\n",
     "print(f\"Temps estime (Random 100): {100 * time_per_backtest / 60:.1f} minutes\")\n",
     "print(f\"Temps estime (Bayesian 50): {50 * time_per_backtest / 60:.1f} minutes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy15-md-methodes",
+   "metadata": {},
+   "source": [
+    "### Ce que chaque méthode achète : 108 minutes contre 8.3 contre 4.2\n",
+    "\n",
+    "La sortie donne la combinatoire exacte : **9 × 9 × 4 × 4 = 1 296 combinaisons**, estimées à\n",
+    "**108 minutes** en grid search exhaustif, **8.3 minutes** en recherche aléatoire (100 tirages) et\n",
+    "**4.2 minutes** en optimisation bayésienne (50 évaluations). Le rapport est de 26× entre l'exhaustif et\n",
+    "le bayésien — mais le prix payé n'est pas le même selon la méthode, et il ne se lit pas dans la colonne\n",
+    "« temps ».\n",
+    "\n",
+    "Le **grid exhaustif** achète la certitude du pire cas : aucune combinaison manquée, et la possibilité\n",
+    "d'analyser la *structure* de l'espace (les heatmaps de la partie 3 — plateaux, pics, dimensions\n",
+    "inertes — n'existent que parce que tout l'espace a été mesuré). La **recherche aléatoire** achète la\n",
+    "couverture effective : un théorème classique (Bergstra & Bengio, 2012) établit que si seule une petite\n",
+    "fraction des dimensions porte le signal, 100 tirages aléatoires trouvent une combinaison aussi bonne\n",
+    "que le grid avec une probabilité étonnamment haute — car le grid gaspille ses 1 296 essais en couvrant\n",
+    "les dimensions inertes avec une précision inutile. L'**optimisation bayésienne** achète\n",
+    "l'efficacité séquentielle : chaque évaluation informe un surrogate (processus gaussien typiquement) qui\n",
+    "choisit la suivante, concentrant les essais dans les régions prometteuses — au prix d'un biais\n",
+    "d'exploitation : elle approfondit le premier bon bassin trouvé et peut manquer un optimum isolé que le\n",
+    "grid aurait vu.\n",
+    "\n",
+    "La règle de choix pratique : grid si l'espace est petit et qu'on veut la carte, aléatoire si l'espace\n",
+    "est grand et les dimensions inégales, bayésien si chaque évaluation est coûteuse (backtest lourd,\n",
+    "données réelles payantes) — en gardant à l'esprit que la partie 3 va montrer que la dimension\n",
+    "`stop_loss` de CET espace est... totalement inerte."
    ]
   },
   {
@@ -1576,6 +1656,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy15-md-top10",
+   "metadata": {},
+   "source": [
+    "### Le classement du top 10 se lit dans ses répétitions, pas dans sa tête\n",
+    "\n",
+    "Regarder les **lignes** du top 10, pas seulement la première. Trois lectures qui changent le statut du\n",
+    "« gagnant » SMA(10, 50, SL 7 %, TP 15 %) et de son Sharpe **2.78** :\n",
+    "\n",
+    "**1. La colonne stop_loss est inerte.** Les lignes 1 à 4 du top 10 sont strictement identiques —\n",
+    "`fast 10, slow 50, TP 0.15` — et ne diffèrent QUE par `stop_loss` (0.03, 0.05, 0.07, 0.10). Même Sharpe\n",
+    "(2.777658), même return (34.47 %), même drawdown (-2.04 %), même nombre de trades. L'explication est\n",
+    "mécanique et se lit dans `n_trades: 3` : avec trois transactions gagnantes (win_rate 1.0) et un take\n",
+    "profit à 15 %, le stop loss n'a **jamais été déclenché**. Quatre valeurs testées, zéro information\n",
+    "produite : la dimension entière est décorative sur ce jeu de données. C'est exactement la « dimension\n",
+    "inerte » que la recherche aléatoire ignore gratuitement et que le grid paie 4× — la démonstration\n",
+    "concrète de la partie précédente.\n",
+    "\n",
+    "**2. Le Sharpe 2.78 repose sur 3 trades.** Un Sharpe annualisé n'a de sens que comme moyenne de\n",
+    "nombreuses décisions. Trois transactions à 100 % de réussite, c'est un échantillon où presque tout est\n",
+    "possible : l'intervalle de confiance sur le « vrai » Sharpe couvre largement le médiocre. Un classement\n",
+    "qui met cette ligne en tête ne dit pas « cette combinaison est la meilleure », il dit « cette\n",
+    "combinaison a eu le plus de chance sur 3 tirages ».\n",
+    "\n",
+    "**3. take_profit: 0.15 domine.** Toutes les lignes du top 10 partagent TP = 0.15 — la valeur maximale\n",
+    "testée. C'est un signal de bord d'espace : l'optimum n'est pas dans la grille testée, il est au-delà.\n",
+    "Un optimum assis sur le bord d'une dimension demande d'étendre la grille dans cette direction avant de\n",
+    "conclure quoi que ce soit — sinon on optimise la grille, pas la stratégie."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "588346d8",
    "metadata": {
     "papermill": {
@@ -1659,6 +1770,28 @@
     "plt.ylabel('Slow Period', fontsize=12)\n",
     "plt.tight_layout()\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy15-md-un-seul-passe",
+   "metadata": {},
+   "source": [
+    "### Ce que la grille ne peut pas voir : 672 backtests, un seul passé\n",
+    "\n",
+    "La sortie confirme **672/672 combinaisons valides** — l'espace a été entièrement mesuré. Et pourtant ce\n",
+    "dénominateur cache une limite structurelle : les 672 backtests partagent **les mêmes données**. Chaque\n",
+    "combinaison est évaluée sur une seule réalisation de l'histoire ; la grille explore la dimension des\n",
+    "paramètres, pas celle des scénarios de marché. Une combinaison peut dominer le classement parce qu'elle\n",
+    "épouse le trajet précis du bruit de CE jeu de données — c'est précisément ce que la partie 4\n",
+    "(walk-forward : ré-optimiser puis re-tester sur des fenêtres successives) et la partie 6 (Monte Carlo :\n",
+    "perturber les trajectoires) viennent casser, chacune sur une dimension différente.\n",
+    "\n",
+    "À retenir aussi sur le budget : 672 backtests sur des données simulées prennent des secondes ; le même\n",
+    "espace sur un backtest broker réaliste (slippage, frais, règles de liquidation) multiplie le coût par\n",
+    "un facteur bien supérieur — la question du choix de méthode (grille exhaustive vs aléatoire vs\n",
+    "bayésienne) n'est pas académique, elle est le premier poste de coût de tout cycle d'optimisation\n",
+    "réel."
    ]
   },
   {
@@ -2310,7 +2443,7 @@
     "- **Cycle saisonnier**: Sinusoïde superposée pour simuler des patterns\n",
     "- **Bruit aléatoire**: Random walk pour la réalisme\n",
     "\n",
-    "**Configuration**: 252 jours IS (1 an) + 63 jours OOS (3 mois) = 5 folds glissants\n",
+    "**Configuration**: 252 jours IS (1 an) + 63 jours OOS (3 mois) = 16 folds glissants (mesuré en sortie)\n",
     "\n",
     "La Walk-Forward sur ces données simulées démontre la méthodologie. En pratique, utiliser des données historiques réelles avec plus de folds pour une validation robuste.\n",
     "\n",
@@ -2405,6 +2538,36 @@
     "efficiency_ratio = wf_results['oos_sharpe'].mean() / wf_results['is_sharpe'].mean()\n",
     "print(f\"\\nWalk-Forward Efficiency Ratio: {efficiency_ratio:.2%}\")\n",
     "print(\"(Ratio OOS/IS - plus proche de 100% = meilleur)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy15-md-16-fois-zero",
+   "metadata": {},
+   "source": [
+    "### Le résultat central du notebook : 16 folds, 16 fois zéro\n",
+    "\n",
+    "La sortie du tableau walk-forward est le résultat le plus important de ce notebook — plus instructif\n",
+    "que n'importe quel score élevé. **16 folds**, et pour **chacun** : `oos_sharpe: 0.0`, `oos_return: 0.0`.\n",
+    "En face, les scores In-Sample des paramètres optimisés par fenêtre s'étalent de **0.0 à 7.25**\n",
+    "(statistiques agrégées : moyenne **4.10**, médiane **4.63**, écart-type **2.33**). Le\n",
+    "**Walk-Forward Efficiency Ratio: 0.00 %** — la dégradation IS→OOS est totale, pas partielle.\n",
+    "\n",
+    "La cause est structurelle et se lit dans le code de la fonction : chaque fold re-backteste les\n",
+    "paramètres optimaux IS sur sa **fenêtre de test seule** (63 jours). Or les paramètres choisis IS ont\n",
+    "des moyennes lentes de **50 à 200 jours** — pour la plupart des folds, la fenêtre de test de 63 jours\n",
+    "est plus courte que la moyenne lente elle-même : le croisement ne peut littéralement pas se produire,\n",
+    "la stratégie ne prend aucune position, et le Sharpe OOS vaut 0 par construction. Ce n'est pas un bug\n",
+    "numérique, c'est une **incompatibilité d'horizons** : on optimise des paramètres longs sur un an, puis\n",
+    "on les teste sur un trimestre.\n",
+    "\n",
+    "La leçon de design dépasse ce notebook : une fenêtre de test doit être **compatible avec l'horizon des\n",
+    "paramètres** qu'on prétend valider. Et la leçon de méthode est la contrepartie positive : la\n",
+    "walk-forward a fait exactement son travail. Un score IS de 7.25 qui produit zéro transaction hors\n",
+    "échantillon est démasqué par le premier fold — là où une validation unique bien choisie (la partie 7\n",
+    "montrera un OOS à 2.93 sur un split différent) aurait pu laisser croire que la stratégie marche. Un\n",
+    "outil qui répond « 0.00 % » quand tout le reste crie « 4.10 » n'est pas en panne : c'est le seul qui\n",
+    "dit la vérité."
    ]
   },
   {
@@ -2550,6 +2713,31 @@
     "correlation = wf_results['is_sharpe'].corr(wf_results['oos_sharpe'])\n",
     "print(f\"Correlation IS-OOS: {correlation:.2f}\")\n",
     "print(\"(Correlation elevee = bonne previsibilite des parametres)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy15-md-nan-pearson",
+   "metadata": {},
+   "source": [
+    "### Pourquoi la corrélation vaut nan : la mécanique d'un Pearson dégénéré\n",
+    "\n",
+    "La sortie imprime `Correlation IS-OOS: nan` avec la légende « corrélation élevée = bonne\n",
+    "prévisibilité ». Ce `nan` n'est pas une erreur de calcul : c'est la valeur mathématiquement correcte\n",
+    "d'un coefficient de corrélation de Pearson quand **l'une des deux séries a une variance nulle**. La\n",
+    "série OOS vaut `[0.0, 0.0, ..., 0.0]` sur les 16 folds — une constante. Or Pearson mesure la\n",
+    "covariation normalisée par le produit des écarts-types ; avec un écart-type nul, le dénominateur vaut\n",
+    "zéro et le rapport est indéfini : NumPy le rend `nan` plutôt qu'infini.\n",
+    "\n",
+    "La lecture correcte est donc plus forte que la légende ne le suggère : « corrélation nan » ne veut pas\n",
+    "dire « corrélation faible » ni « donnée manquante ». Ça veut dire **la question de la prévisibilité\n",
+    "n'a pas de réponse sur ces données**, parce que la performance OOS n'a aucune variation à expliquer —\n",
+    "et la raison en a été donnée par le tableau précédent (aucun signal possible dans les fenêtres de\n",
+    "test). Ce cas arrive chaque fois qu'une métrique dégénère (score constant, écart-type nul) : la\n",
+    "discipline est de **diagnosticer la dégénérescence** plutôt que de lire le symbole comme un score.\n",
+    "Le piège est assez fréquent pour qu'on le retrouve à la partie suivante : le détecteur d'overfitting\n",
+    "de la partie 5 affichera lui aussi `[OK] Low Is Oos Correlation` sur cette même valeur `nan` — une\n",
+    "garde mal écrite qui transforme l'absence de mesure en feu vert."
    ]
   },
   {
@@ -2766,6 +2954,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy15-md-auditer-detecteur",
+   "metadata": {},
+   "source": [
+    "### Auditer le détecteur : 3/5 signes, dont deux affichés à contre-sens\n",
+    "\n",
+    "Le détecteur conclut « **3/5 signes d'overfitting** » avec trois `[WARNING]` (IS ≫ OOS, paramètres\n",
+    "instables, variance OOS élevée) et deux `[OK]`. Mais un détecteur automatique se lit comme un code —\n",
+    "en vérifiant ce que chaque verdict a réellement mesuré :\n",
+    "\n",
+    "- **`[OK] Low Is Oos Correlation`** : la corrélation vaut `nan` (partie précédente). Le détecteur\n",
+    "  teste vraisemblablement `corr < seuil` et `nan < seuil` est faux... ou `corr is not None and corr <\n",
+    "  seuil` — dans les deux cas, l'absence de mesure est classée comme acceptable. Un « OK » posé sur un\n",
+    "  `nan` n'est pas une validation : c'est un aveu que le test n'a pas pu s'exécuter, travesti en feu\n",
+    "  vert. Le signe d'alerte réel était dans les métriques brutes au-dessus : `is_oos_correlation: nan`,\n",
+    "  `oos_coefficient_variation: inf`.\n",
+    "- **`[WARNING] High Oos Variance`** : la variation vaut `inf` parce que la moyenne OOS est **0.00** —\n",
+    "  un coefficient de variation (σ/μ) avec μ nul est infini, quelle que soit σ. Le warning est\n",
+    "  techniquement vrai et substantiellement vide : il détecte la dégénérescence, pas la variance.\n",
+    "- **`[OK] Negative Oos Sharpe`** : le Sharpe OOS vaut 0.0, ni négatif ni positif — un troisième\n",
+    "  verdict rendu sur une valeur dégénérée.\n",
+    "\n",
+    "Bilan : les deux verdicts « conformes » (`WARNING` IS≫OOS avec `is_oos_degradation: 1.00`, et\n",
+    "paramètres instables avec des CV de **0.56/0.42** — les paramètres optimaux bougent de moitié entre\n",
+    "fenêtres) sont les signaux vrais. La conclusion « risque élevé » est correcte, mais elle est portée\n",
+    "par 2 signaux réels, pas 3. Règle générale pour tout détecteur : **lire les métriques brutes avant\n",
+    "les verdicts**, et traiter tout `nan`/`inf` comme un échec de mesure à diagnostiquer — jamais comme\n",
+    "un score favorable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "a0c64672",
    "metadata": {
     "papermill": {
@@ -2875,6 +3094,29 @@
     "print(f\"  Fitness penalisee: {fitness_complex:.2f}\")\n",
     "\n",
     "print(f\"\\n-> La strategie {'simple' if fitness_simple > fitness_complex else 'complexe'} est preferee apres penalite!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy15-md-penalite",
+   "metadata": {},
+   "source": [
+    "### La pénalité de complexité : faire payer les paramètres à l'entrée, pas à la sortie\n",
+    "\n",
+    "La sortie donne l'exemple canonique : stratégie **simple** (2 paramètres) Sharpe brut **1.20** →\n",
+    "fitness pénalisée **1.04** ; stratégie **complexe** (6 paramètres) Sharpe brut **1.40** → fitness\n",
+    "pénalisée **0.84**. Le classement s'inverse : la simple gagne **après** pénalité alors qu'elle perdait\n",
+    "avant. C'est le principe de parcimonie (typiquement formalisé en AIC/BIC : chaque paramètre supplémentaire\n",
+    "paie un péage logarithmique) appliqué au fitness d'optimisation — au lieu de détecter l'overfitting\n",
+    "après coup (walk-forward), on le taxe pendant la recherche.\n",
+    "\n",
+    "Pourquoi c'est plus qu'une astuce : un paramètre supplémentaire est un **degré de liberté pour épouser\n",
+    "le bruit**. La stratégie complexe affiche +0.20 de Sharpe brut de plus — sur les données IS, où elle a\n",
+    "exactement les degrés de liberté qu'il faut pour le faire. La pénalité rend cette tricherie\n",
+    "non-rentable : elle demande à chaque paramètre de « rapporter » plus que ce qu'il coûte en risque\n",
+    "d'artefact. Notez la sensibilité du résultat au coefficient de pénalité : trop faible, la complexe\n",
+    "gagne quand même ; trop fort, toute stratégie non triviale est éliminée. Le choix de ce coefficient\n",
+    "est lui-même un paramètre — le notebook le met en exercice (exercice 3) plutôt qu'en réglage caché."
    ]
   },
   {
@@ -3008,6 +3250,34 @@
     "    print(\"\\n-> Parametres MODEREMENT SENSIBLES (20% < CV < 50%)\")\n",
     "else:\n",
     "    print(\"\\n-> Parametres TRES SENSIBLES - Risque d'overfitting (CV > 50%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy15-md-plateau-pic",
+   "metadata": {},
+   "source": [
+    "### Plateau ou pic : pourquoi la forme de la surface compte plus que son sommet\n",
+    "\n",
+    "Le test de sensibilité applique **±15 %** aux paramètres optimaux et backteste chaque variante. La\n",
+    "question que cette sortie doit répondre n'est pas « quel Sharpe chaque variante obtient-elle » mais\n",
+    "« **quelle est la forme de la surface** autour de l'optimum ». Deux formes possibles, deux statuts\n",
+    "totalement différents pour la même valeur de sommet :\n",
+    "\n",
+    "- Un **plateau** : les variants ±15 % performent presque aussi bien. L'optimum est robuste — si le\n",
+    "  marché dévie légèrement des conditions calibrées, la stratégie reste dans la zone de bonne\n",
+    "  performance. C'est la signature d'un vrai signal structurel.\n",
+    "- Un **pic** : les variants s'effondrent. L'optimum est une aiguille — la combinaison exacte\n",
+    "  `fast=10, slow=50` (et pas 9/50, et pas 10/55) porte toute la performance. Une aiguille dans\n",
+    "  l'espace des paramètres est presque toujours un artefact : la probabilité que le « vrai » mécanisme\n",
+    "  du marché exige précisément ces valeurs entières est très faible, alors que la probabilité que\n",
+    "  672 essais trouvent par chance une aiguille dans le bruit est élevée — c'est un birthday problem.\n",
+    "\n",
+    "La sortie affiche le tableau des variants ; la lecture à faire est l'écart max entre variants. Un\n",
+    "critère pratique : si ±15 % de paramètres détruisent plus de la moitié du Sharpe, l'optimum n'a pas\n",
+    "de zone — il n'a qu'un point, et un point n'est pas déployable en production (le premier slippage ou\n",
+    "le premier changement de régime le déplacera hors de sa zone... qui n'existe pas). C'est aussi la\n",
+    "raison pour laquelle les rapport de production exigent des surfaces, pas des points."
    ]
   },
   {
@@ -3335,6 +3605,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy15-md-calmar-inerte",
+   "metadata": {},
+   "source": [
+    "### Le classement Calmar est vide : quand un fitness dégénère en constante\n",
+    "\n",
+    "La sortie est surprenante au premier regard : les deux tableaux — « Top 5 par Calmar » et « Top 5 par\n",
+    "Sharpe » — affichent **`calmar: -inf` sur toutes les lignes**. Le mécanisme se lit dans le code :\n",
+    "`calmar_fitness` retourne `-np.inf` quand `n_trades < min_trades` (**10**), et les backtests de ce jeu\n",
+    "de données produisent **3 à 5 transactions**. Toutes les combinaisons franchissent le filtre `valid`\n",
+    "mais échouent le seuil de transactions — donc **toutes** reçoivent le même fitness `-inf`.\n",
+    "\n",
+    "Conséquence mécanique invisible dans la sortie : `sort_values('calmar', ascending=False)` sur une\n",
+    "colonne constante ne trie rien — l'ordre affiché est celui du DataFrame d'origine. Le « Top 5 par\n",
+    "Calmar Ratio » n'est pas un classement : ce sont les **5 premières lignes générées par la boucle**\n",
+    "(fast 10 puis 15), pas les 5 meilleures. La comparaison honnête des deux tableaux le révèle d'ailleurs :\n",
+    "ils ne partagent que 2 lignes sur 5 — si le tri Calmar avait réellement classé, il aurait au moins\n",
+    "ressemblé à quelque chose.\n",
+    "\n",
+    "Trois leçons. **1** : une garde de qualité (`min_trades`) placée DANS la fonction de fitness dégrade\n",
+    "silencieusement le signal en constante — mieux vaut filtrer les combinaisons avant le tri (elles\n",
+    "auraient disparu de la sortie) que leur assigner `-inf` (elles restent et occupent tout le classement).\n",
+    "**2** : un tableau trié dont toutes les valeurs sont égales n'est pas trié — toujours regarder la\n",
+    "colonne de tri avant le tableau. **3** : le seuil `min_trades=10` dit quelque chose de juste — qu'un\n",
+    "Sharpe sur 3 trades ne vaut rien (partie 3) — mais il le dit si violemment qu'il efface la seule\n",
+    "information restante. La bonne borne pour un ratio : exclure les lignes, pas empoisonner le score."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "e9aa0bfa",
    "metadata": {
     "papermill": {
@@ -3523,6 +3822,33 @@
     "print(f\"\\nMax Drawdown:\")\n",
     "print(f\"  Moyenne: {robustness['dd_mean']:.2%}\")\n",
     "print(f\"  Intervalle 90%: [{robustness['dd_5pct']:.2%}, {robustness['dd_95pct']:.2%}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy15-md-mc-bornes",
+   "metadata": {},
+   "source": [
+    "### Lire un Monte Carlo par ses bornes, pas par sa moyenne\n",
+    "\n",
+    "La sortie du test de robustesse donne : Sharpe **moyen 1.46**, écart-type **0.54**, **intervalle à\n",
+    "90 % : [0.51, 2.42]**, « Probabilité Sharpe > 0 : 100.0 % » ; côté drawdown, moyenne **-5.42 %**,\n",
+    "intervalle 90 % **[-8.66 %, -2.83 %]**. La tentation est de retenir « 1.46 » et « 100 % » — les deux\n",
+    "nombres les moins informatifs de la sortie.\n",
+    "\n",
+    "La **moyenne** (1.46) décrit le centre de la distribution des performances sous perturbation — mais\n",
+    "personne ne vit en moyenne : on vit dans un tirage. La **borne basse de l'intervalle** (0.51) est\n",
+    "l'information de gestion du risque : dans 95 % des mondes perturbés, la stratégie reste au-dessus de\n",
+    "0.51 — dégradée de ~65 % par rapport à la moyenne, mais positive. C'est ce chiffre qui répond à\n",
+    "« puis-je déployer », pas la moyenne. L'écart entre 0.51 et 1.46 mesure la **sensibilité au scénario**\n",
+    "— ici large, signe que la performance dépend fortement du trajet des prix.\n",
+    "\n",
+    "La **« Probabilité Sharpe > 0 : 100.0 % »** enfin : elle est calculée sur **100 simulations**, et 100/100\n",
+    "est compatible avec une vraie probabilité d'à peine ~97 % (intervalle de confiance binomial). Une\n",
+    "probabilité affichée à 100 % sur un échantillon fini est toujours un arrondi de « toutes celles qu'on\n",
+    "a vues » — la partie 7 montrera la version honnête : « 88.0 % » sur 50 simulations, avec le\n",
+    "**5ᵉ percentile à 0.00** : dans un futur sur vingt, la stratégie ne gagne pas. Le Monte Carlo vaut\n",
+    "par ses percentiles et sa borne basse ; la moyenne et le « 100 % » sont les chiffres de la brochure."
    ]
   },
   {
@@ -3930,6 +4256,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy15-md-deux-verdicts",
+   "metadata": {},
+   "source": [
+    "### La contradiction des deux verdicts : 2.93 contre -0.85 % — et le score qui les mélange\n",
+    "\n",
+    "Le pipeline final produit dans une même sortie deux mesures qui se contredisent frontalement. D'un\n",
+    "côté, la **validation unique** sur un split 882 jours / 378 jours : Sharpe OOS **2.93**, return\n",
+    "**3.64 %**, MaxDD **-0.34 %** — une stratégie qui marche, en apparence nettement. De l'autre, la\n",
+    "**walk-forward** sur 18 folds de la même période : **efficacité -0.85 %** — les paramètres optimisés\n",
+    "par fenêtre ne valent rien hors de leur fenêtre (c'est le phénomène de la partie 4, ici confirmé sur\n",
+    "le pipeline complet). Et le **score de validation composite** tranche : « **66.62 % → BON : stratégie\n",
+    "acceptable avec quelques réserves** ».\n",
+    "\n",
+    "La contradiction n'est pas une anomalie : c'est la hiérarchie réelle des preuves. La validation unique\n",
+    "teste **une** politique figée sur **un** futur — favorable ici (le split OOS couvre 2022-05→2023-10,\n",
+    "et les paramètres SMA(20, 200) choisis sur 882 jours ont eu l'espace de se déclencher). La\n",
+    "walk-forward teste la **procédure** « optimiser puis déployer » sur 18 futurs successifs — et répond\n",
+    "que cette procédure ne généralise pas. Un score composite qui moyenne les deux (82.77 % de ratio OOS/IS\n",
+    "ici, -0.85 % de WF là) fabrique un verdict intermédiaire qui n'appartient à aucune des deux questions.\n",
+    "La règle de lecture pour toute chaîne de validation : **le verdict le plus défavorable sur la question\n",
+    "qui vous concerne est celui qui compte**. Si la question est « cette stratégie déployée tiendra-t-elle\n",
+    "dans des conditions nouvelles », c'est le -0.85 % qui répond — le 2.93 dit seulement qu'UNE fenêtre\n",
+    "particulière a été clémente. Le « BON » du score composite est un arrondi de management ; la walk-forward\n",
+    "est l'instrument."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "520496d2",
    "metadata": {
     "papermill": {
@@ -4128,6 +4482,24 @@
     "    \n",
     "    print(\"Code QCAlgorithm Final:\")\n",
     "    print(final_algorithm_code)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy15-md-qc-cloud-regard",
+   "metadata": {},
+   "source": [
+    "### Les résultats QC Cloud en regard : le même optimisateur, une autre exonération\n",
+    "\n",
+    "Les deux blocs « Résultats Backtest QC Cloud » de ce notebook (stratégie `OptimizableStrategy` SMA\n",
+    "10/50, puis `OptimizedSMACrossover` SMA 20/200) sont committés comme référence de ce que le même\n",
+    "paramétrage produit sur le moteur QuantConnect complet — frais, slippage et données institutionnelles\n",
+    "inclus. La comparaison local/QC n'est pas un luxe de vérification : le backtest local de ce notebook\n",
+    "ignore les coûts de transaction et utilise des données simulées en partie, deux dimensions qui\n",
+    "dégradent spécifiquement les stratégies à faible nombre de transactions (chaque coût frappe une\n",
+    "fraction plus grande du PnL). Le réflexe à ancrer : toute optimisation menée en local sur données\n",
+    "propres doit être re-mesurée sur le moteur cible AVANT d'être crue — l'écart entre les deux mesures\n",
+    "fait partie du résultat, pas du bruit."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11320 (QC-Py-33, substance distincte : autre notebook, autres concepts — optimisation/overfitting vs RL)

## Summary

Tranche #11224 : **QC-Py-15-Parameter-Optimization.ipynb**, densité pédagogique **734 → 1415** chars de
prose / cellule code (organe `pedagogy_density.py`, seuil 1200). Enrichissement **markdown-only FR** —
les 32 cellules code sont **byte-identiques** (diff structurel cellule-à-cellule contre `origin/main`),
aucune re-exec requise (exception markdown-only C.3), outputs intacts. 374 insertions / 2 deletions.

## Les 3 findings que l'enrichissement exploite (tous mesurés dans les outputs committés)

**1. La walk-forward tombe à zéro sur 16/16 folds** (`oos_sharpe: 0.0, oos_return: 0.0` partout, IS
moyen 4.10, WFER 0.00 %). Cause structurelle lue dans le code de `walk_forward_analysis` : chaque fold
re-backteste les paramètres IS sur sa fenêtre OOS **seule** (63 jours) — avec des slow SMA de 50-200
jours, la moyenne lente ne peut pas exister sur la fenêtre de test. Leçon de design : la fenêtre de
test doit être compatible avec l'horizon des paramètres. La nouvelle cellule explique aussi pourquoi
la **corrélation IS-OOS vaut `nan`** (Pearson sur série à variance nulle) et pourquoi le détecteur de
la partie 5 lit ce `nan` comme `[OK] Low Is Oos Correlation` — un feu vert posé sur une absence de
mesure (l'audit du détecteur montre que la conclusion « 3/5 signes » n'est portée que par 2 signaux
réels).

**2. Le classement Calmar est non-discriminant** : `calmar: -inf` sur toutes les lignes des deux top 5.
Mécanisme : `calmar_fitness` retourne `-np.inf` si `n_trades < 10`, et les backtests font 3-5 trades →
colonne constante → `sort_values` ne trie rien, l'ordre affiché est celui de la boucle (preuve : les
deux tableaux ne partagent que 2/5 lignes). Leçon : une garde de qualité dans le fitness dégrade le
signal en constante — exclure les lignes, pas empoisonner le score.

**3. Le pipeline final contient deux verdicts contradictoires** : validation unique OOS Sharpe **2.93**
vs walk-forward 18 folds **-0.85 %**, fondues en un score composite « 66.62 % BON ». La nouvelle cellule
pose la règle : le verdict le plus défavorable sur la question qui compte (déploiement en conditions
nouvelles) est celui qui répond.

Autres cellules : lecture du top 10 grid search (**stop_loss inerte** — 4 lignes identiques, jamais
déclenché, n_trades=3 win_rate=1.0 : le Sharpe 2.78 est un artefact de rareté ; TP=0.15 au bord de
l'espace = optimum hors grille), combinatoire 1296 (108 min grid vs 8.3 random vs 4.2 bayésien — ce que
chacune achète), -18.9 % IS→OOS (le scénario BÉNIN, échantillon de 3 trades), pénalité de complexité
(1.20→1.04 vs 1.40→0.84 : le classement s'inverse), plateau-vs-pic (±15 %), Monte Carlo lu par ses
bornes (IC90 [0.51, 2.42], « 100 % » sur 100 sims = arrondi), le contrat de lecture du notebook,
et le regard sur les blocs QC Cloud.

## 1 correction de drift prose ↔ output

- [43] « = 5 folds glissants » → « 16 folds glissants (mesuré en sortie) » — l'output dit
  `Nombre de folds: 16`.

## Validation

- Mesure avant/après : `pedagogy_density.py --json` → 734 → **1415** (status `ok`).
- 32/32 cellules code byte-identiques (script de diff structurel, base `git show origin/main:`).
- Interps ancrées : chaque valeur chiffrée citée provient de l'output de la cellule précédente
  ([cell-interpretation-ordering](../../.claude/rules/cell-interpretation-ordering.md)).
- Stubs d'exercices C.1 intacts (3 exos conservés) ; pas de `_en.ipynb` ; catalogue byte-identique.
- File CI mesurée avant ouverture : 80 (<200).

## Regression check

- Fichier unique, markdown-only, 374 ins / 2 del (le drift fix).
- Aucun symbole code touché.

See #11224 (tranche QC-Py-15, protocole #10488 — 1 notebook = 1 PR)
