### PR TITLE
docs(qc,#11224): densite QC-Py-12 Backtesting-Analysis 746->1358 (tranche markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -237,6 +237,29 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-md-donnees-simulees",
+   "metadata": {},
+   "source": [
+    "### Ce que « données simulées » garantit pour une leçon d'analyse\n",
+    "\n",
+    "La sortie annonce le cadre : **504 jours** de données générées (janvier 2022 → décembre 2023),\n",
+    "`np.random.seed(42)` — chaque exécution produit les mêmes courbes, donc les mêmes métriques que\n",
+    "celles committées. Pour un notebook dont le sujet est *l'analyse* d'un backtest (et non la\n",
+    "construction de la stratégie), c'est la bonne décision de design : les chiffres que vous lirez\n",
+    "(Total Return 40.50 %, Sharpe 1.01, MaxDD -16.63 %) sont des **propriétés reproductibles de ce jeu\n",
+    "de données**, pas des tirages volatils — vous pouvez vérifier chaque formule de ce notebook contre\n",
+    "eux, et un correcteur peut rejouer vos calculs.\n",
+    "\n",
+    "La contrepartie à garder en tête : ces courbes d'équité (stratégie partant à 100 180 vs benchmark\n",
+    "99 259 dans l'aperçu) sont des **géométries fabriquées**, pas un marché. La MA crossover simulée et\n",
+    "son benchmark partagent la même graine et la même dynamique sous-jacente — leurs métriques seront\n",
+    "proches *par construction*. L'écart que la partie 1 va mesurer (Sharpe 1.01 vs 1.03) vit donc dans un\n",
+    "espace où « gagner de peu » et « perdre de peu » sont indistinguables : un point que cette leçon\n",
+    "traitera quantitativement, parce qu'il est le piège n°1 de la lecture de backtests réels aussi."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -343,6 +366,29 @@
     "print(f\"{'Periode (annees)':<25} {strategy_return_metrics['years']:>11.2f}\")"
    ],
    "id": "cell-9b7d38ea"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-premier-verdict",
+   "metadata": {},
+   "source": [
+    "### Première métrique, premier verdict : la stratégie perd en absolu\n",
+    "\n",
+    "Le tableau de rendement pose le décor de tout le notebook : **Total Return 40.50 % contre 48.28 %**,\n",
+    "CAGR **19.32 % contre 22.71 %**, rendement annualisé **18.36 % contre 21.46 %**. La stratégie rend\n",
+    "moins que son benchmark — environ 8 points de total return sur deux ans. Notons d'abord la structure\n",
+    "du tableau : sur 4 lignes, il n'y a que **2 informations indépendantes**. Total Return et rendement\n",
+    "annualisé sont la même grandeur sous deux horizons (40.50 % sur 1.92 an ↔ 18.36 %/an à composition) ;\n",
+    "le CAGR est sa version géométrique. Un tableau qui répète la même mesure trois fois donne l'illusion\n",
+    "d'une preuve triple.\n",
+    "\n",
+    "La bonne question n'est pas « combien » mais « à quel prix ». La stratégie rend 8 points de moins —\n",
+    "mais avec quelle exposition ? La partie 4 répondra : **beta 0.443**. La stratégie ne détient en\n",
+    "moyenne qu'une fraction de la dynamique du marché ; comparer son 40.50 % au 48.28 % du benchmark\n",
+    "pleinement exposé, c'est comparer deux produits différents. Le Sharpe (partie suivante) normalise\n",
+    "précisément ça — et c'est pour cela qu'il faut le lire AVANT de conclure quoi que ce soit d'un\n",
+    "tableau de rendements bruts."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -546,6 +592,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-md-ecart-indécidable",
+   "metadata": {},
+   "source": [
+    "### 1.01 contre 1.03 : un écart que ces données ne peuvent pas trancher\n",
+    "\n",
+    "La sortie imprime **Sharpe 1.01 (stratégie) contre 1.03 (benchmark)** — et la tentation immédiate\n",
+    "est de classer : le benchmark « gagne ». Ce classement est indéfendable sur 1.92 an de données, et\n",
+    "c'est le point quantitatif le plus important de cette partie. L'erreur-type d'un Sharpe estimé sur\n",
+    "T années vaut approximativement **1/√T** en première approximation (sous hypothèse de normalité des\n",
+    "retours) : sur 1.92 an, cela fait environ **0.72**. Autrement dit, l'intervalle de confiance à 95 %\n",
+    "de chaque Sharpe couvre grossièrement [−0.4, +2.4] — et la différence mesurée (0.02) est **36 fois\n",
+    "plus petite** que l'incertitude de l'estimation elle-même.\n",
+    "\n",
+    "Ce n'est pas un défaut de ce notebook : c'est une propriété générale. Deux Sharpes ne se comparent\n",
+    "en confiance que sur des historiques longs (une différence de 0.5 exige ~8-10 ans pour devenir\n",
+    "significative au seuil usuel, à ces niveaux de volatilité). Toute conclusion « A bat B » tirée d'un\n",
+    "écart de Sharpe inférieur à ~0.2 sur moins de 3 ans est du bruit lu comme un signal — la même\n",
+    "leçon que la série RL Post-Training de ce dépôt démontre à l'entraînement : sans test statistique,\n",
+    "un petit écart n'est pas un verdict. Ici, l'honnête conclusion est : **à ces horizons, stratégie et\n",
+    "benchmark sont ajustés au risque de façon statistiquement indistinguable**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### Sortino Ratio\n",
@@ -619,6 +689,30 @@
     "print(f\"Sortino Ratio Benchmark:  {sortino_benchmark:.2f}\")"
    ],
    "id": "cell-ad41aac1"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-sortino-denominateur",
+   "metadata": {},
+   "source": [
+    "### Pourquoi le Sortino (1.67) dépasse le Sharpe (1.01) : le dénominateur a changé\n",
+    "\n",
+    "La sortie donne **Sortino 1.67 contre 1.77** — plus hauts que les Sharpes respectifs (1.01/1.03).\n",
+    "La mécanique se lit dans la formule : le Sharpe divise l'excès de rendement par la volatilité\n",
+    "**totale** (écart-type de tous les retours), le Sortino par la volatilité **à la baisse**\n",
+    "(écart-type des seuls retours négatifs). Si les pertes de la stratégie sont plus concentrées que\n",
+    "dispersées, le dénominateur du Sortino est plus petit — et le ratio monte mécaniquement. Un Sortino\n",
+    "supérieur au Sharpe est la signature d'une distribution **asymétrique favorable** : le risque utile\n",
+    "(ce qui fait mal) est plus faible que le risque total (ce qui bouge).\n",
+    "\n",
+    "Attention au renversement de lecture que les deux nombres invitent à faire : le couple (Sharpe,\n",
+    "Sortino) ne mesure pas deux stratégies mais deux **définitions du risque** appliquées à la même.\n",
+    "Un investisseur qui peut encaisser la volatilité haussière (marge, horizon long) devrait lire le\n",
+    "Sortino ; un investisseur contraint par la volatilité totale (exigences de marge, appels de\n",
+    "marge) doit lire le Sharpe. L'écart entre les deux (ici +0.66 pour la stratégie, +0.74 pour le\n",
+    "benchmark — quasiment identiques) dit que cette asymétrie n'est PAS un avantage de la stratégie :\n",
+    "les deux courbes ont la même forme de queue."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -696,6 +790,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-md-calmar-un-point",
+   "metadata": {},
+   "source": [
+    "### Calmar 1.16 contre 1.34 : la métrique qui dépend d'un seul point\n",
+    "\n",
+    "Le Calmar divise le rendement annualisé par la **profondeur du pire drawdown** — ici 1.16 contre\n",
+    "1.34. Sa faiblesse statistique est structurale et mérite d'être comprise avant de le pondérer dans\n",
+    "une décision : le dénominateur est un **extremum d'échantillon**, le point le plus bas d'une\n",
+    "trajectoire unique. Le max drawdown observé sur 2 ans n'est pas une propriété de la stratégie,\n",
+    "c'est une propriété de CES 2 ans : la même stratégie sur une autre fenêtre peut montrer un pire\n",
+    "drawdown de -25 % (le Calmar s'effondre à 0.73) ou de -9 % (il monte à 2.04).\n",
+    "\n",
+    "Comparez avec le Sharpe : sa formule agrège l'information des 504 retours journaliers — chaque\n",
+    "jour contribue. Le Calmar n'agrège rien : il extrait le minimum d'une série. Deux conséquences\n",
+    "pratiques. D'abord, **ne jamais trancher entre deux stratégies sur le Calmar seul** avec des\n",
+    "histoires comparables — l'écart 1.16/1.34 (un MaxDD de -16.63 % contre -16.96 %, trois dixièmes de\n",
+    "point d'écart !) ne mesure que la différence de chance entre deux trajectoires sur un point chacune.\n",
+    "Ensuite, pour un Calmar utilisable : le calculer sur la période la plus longue disponible, ou en\n",
+    "version « moyenne des 3 pires drawdowns » (l'objet de la partie 2), qui réduit la dépendance au\n",
+    "point unique sans l'éliminer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### Resume des Metriques Ajustees au Risque"
@@ -749,6 +867,29 @@
     "print(\"=\" * 60)"
    ],
    "id": "cell-6e62f9b3"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-tableau-colonne",
+   "metadata": {},
+   "source": [
+    "### Le tableau complet se lit en colonne, pas en ligne : le profil de risque est le vrai sujet\n",
+    "\n",
+    "Récapitulons ce que le tableau ajusté au risque dit vraiment. La stratégie perd sur les quatre\n",
+    "ratios — mais d'à-peu-près-rien (Sharpe 1.01/1.03, Sortino 1.67/1.77, Calmar 1.16/1.34), et la\n",
+    "colonne qui explique toute l'histoire est la première : **volatilité annualisée 16.26 % contre\n",
+    "18.52 %**. La stratégie bouge moins — beta 0.443 le confirmera. Son MaxDD (-16.63 %) est quasi\n",
+    "identique à celui du benchmark (-16.96 %) : la moitié de l'exposition au fil du temps, mais la\n",
+    "même profondeur de creux au pire moment. C'est une configuration typique et instructive : une\n",
+    "exposition partielle réduit la volatilité au quotidien, mais ne protège pas de la queue — parce\n",
+    "que le pire moment de la stratégie et du marché est le même moment.\n",
+    "\n",
+    "La conclusion honnête de ce tableau n'est donc ni « la stratégie gagne » ni « elle perd » : c'est\n",
+    "**« elle délivre environ la même performance ajustée au risque que son benchmark, avec la moitié\n",
+    "de l'exposition quotidienne et la même perte maximale »**. Selon l'usage (frais de gestion à la\n",
+    "vol, contraintes réglementaires, capacité à absorber un -17 %), cette neutralité au risque peut\n",
+    "être un bon deal ou une complexité inutile — mais le tableau seul ne tranche pas : il qualifie."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -848,6 +989,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-md-451-jours",
+   "metadata": {},
+   "source": [
+    "### 451 jours sur 504 sous l'eau : la métrique que les ratios ne montrent pas\n",
+    "\n",
+    "La statistique la plus parlante de la sortie n'est pas le MaxDD : c'est **« Jours en Drawdown :\n",
+    "451 / 504 »** — la stratégie a passé **89 % de sa vie sous son plus haut atteint**. Et l'aperçu du\n",
+    "DataFrame le confirme en fin de période : au 2023-12-01, l'équity vaut 136 304 contre un plus haut\n",
+    "de 149 281 — la trajectoire se termine **en plein drawdown de -8.7 %**, sans avoir reconquis son\n",
+    "pic. Le MaxDD de -16.63 % dit la profondeur du pire moment ; les 451 jours disent la **texture de\n",
+    "l'expérience** : un investisseur qui regarde son compte tous les mois a vu un déficit par rapport\n",
+    "au pic presque tous les jours pendant deux ans.\n",
+    "\n",
+    "Pourquoi cette métrique est absente des ratios : Sharpe, Sortino et Calmar sont des fonctions des\n",
+    "retours (ou de leurs extrêmes) — aucun ne code la **durée**. Une stratégie peut avoir un excellent\n",
+    "Sharpe et passer 95 % de son temps sous l'eau (rendements concentrés sur quelques jours de\n",
+    "rattrapage), ou l'inverse. La littérature de gestion appelle ça la « douleur » (pain index,\n",
+    "utilisé dans le Omega ratio et l'ULCI), et la partie suivante la décompose : combien de temps\n",
+    "durait le pire épisode — 286 jours — avant de rendre la monnaie ? Le tri entre deux stratégies de\n",
+    "Sharpe équivalent se fait souvent ici : à performance égale, choisir celle qui dort le mieux."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "### Interpretation des Statistiques Drawdown\n",
     "\n",
@@ -936,6 +1101,29 @@
     "    print(f\"Periode: {dd_start.date()} - {dd_end.date()}\")"
    ],
    "id": "cell-8ad4bc69"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-286-jours",
+   "metadata": {},
+   "source": [
+    "### 286 jours sous l'eau : la durée est une statistique, pas une épreuve de caractère\n",
+    "\n",
+    "La sortie donne la durée du pire épisode : **286 jours**, du **2022-01-13 au 2022-10-26** — dix\n",
+    "mois pendant lesquels le capital est resté sous son pic du 13 janvier. Deux lectures, toutes deux\n",
+    "nécessaires. La première est opérationnelle : un drawdown long consomme du capital** psychologique\n",
+    "et institutionnel** (un fonds qui vit ce cycle encaisse des rachats d'investisseurs au pire moment,\n",
+    "ce qui cristallise la perte — la corrélation performance/flux est le mécanisme par lequel la durée\n",
+    "détruit la valeur, indépendamment de la stratégie). La seconde est statistique : 286 jours pour\n",
+    "remonter de -16.63 % exige environ +20 % de récupération (1/0.8337), soit un rythme de rattrapage\n",
+    "d'environ 2 %/mois pendant 10 mois — cohérent avec le CAGR de 19 % de la stratégie, ce qui veut\n",
+    "dire que la récupération n'a pas demandé de régime exceptionnel, juste le retour du régime normal.\n",
+    "\n",
+    "Le couple (profondeur -16.63 %, durée 286 jours) est d'ailleurs plus informatif que chaque nombre\n",
+    "séparé : un creux profond et court (flash crash) est absorbable ; un creux modéré et interminable\n",
+    "(2000-2013 pour le S&P réel) évince la plupart des investisseurs avant la récupération. Les deux\n",
+    "dimensions se lisent ensemble sur l'underwater plot qui suit."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1074,6 +1262,31 @@
     "find_top_drawdowns(dd_df['drawdown_pct'], 5)"
    ],
    "id": "cell-870710c6"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-meme-episode",
+   "metadata": {},
+   "source": [
+    "### Le top 5 des drawdowns est un seul événement compté cinq fois\n",
+    "\n",
+    "Regardez les **dates** du top 5 : 2022-03-16 (-16.63 %), 2022-04-01 (-16.45 %), 2022-03-31\n",
+    "(-16.35 %), 2022-03-17 (-16.31 %), 2022-03-08 (-16.30 %). Quatre des cinq tombent en **mars 2022**\n",
+    "et le cinquième deux semaines plus tard — ce ne sont pas cinq drawdowns distincts, c'est le\n",
+    "**creux du même épisode observé à cinq moments voisins** : pendant que la stratégie est à son\n",
+    "plus bas, chaque jour voisin enregistre une profondeur quasi identique (de -16.30 à -16.63 :\n",
+    "trois dixièmes de point d'écart sur un mois). Un « top 5 des pires dates » sans segmentation\n",
+    "d'épisodes produit cette illusion : il **énumère le même accident**.\n",
+    "\n",
+    "La correction méthodologique est standard et se programme en dix lignes : segmenter la série de\n",
+    "drawdown en **épisodes** — un épisode démarre quand l'équity quitte son plus haut et se termine\n",
+    "quand elle le reconquiert — puis classer les épisodes par profondeur. Sur ces données, le vrai\n",
+    "« top des épisodes » commence par l'épisode janvier-octobre 2022 (profondeur -16.63 %, durée 286\n",
+    "jours, déjà mesuré à la partie précédente) ; la deuxième entrée serait un autre épisode, avec sa\n",
+    "propre durée et sa propre récupération. La leçon généralise à toute métrique « top N » sur une\n",
+    "série temporelle : sans déduplication des événements sous-jacents, le classement mesure la\n",
+    "**persistance des extrêmes**, pas leur fréquence."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1283,6 +1496,32 @@
     "print(\"=\" * 50)"
    ],
    "id": "cell-1c05c0b6"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-trades-coherence",
+   "metadata": {},
+   "source": [
+    "### Les statistiques de trades se vérifient entre elles — faites-le\n",
+    "\n",
+    "La sortie est riche : 150 trades, **win rate 53.33 %**, gain moyen **+1.63 %**, perte moyenne\n",
+    "**-1.30 %**, **profit factor 1.43**, **expectancy 0.2606 %/trade**, risk/reward 1.25, pires et\n",
+    "meilleures extrêmes (+3.87 %/-2.34 %), et surtout **7 gains / 6 pertes consécutifs maximums**.\n",
+    "Un réflexe à ancrer : ces nombres ne sont pas indépendants, et leurs **contraintes croisées font\n",
+    "office de test d'intégrité**. L'expectancy se recompose depuis les autres :\n",
+    "0.5333 × 1.63 − 0.4667 × 1.30 = **0.869 − 0.607 = 0.262 %** — la sortie dit 0.2606 % : cohérent à\n",
+    "l'arrondi près. Le profit factor : (80 × 1.63)/(70 × 1.30) = 130.4/91.0 = **1.43** ✓. Quand les\n",
+    "métriques d'un rapport de trades se contredisent, c'est le signe d'un calcul mal défini (ou d'un\n",
+    "output fabriqué) — vérifier ces deux identités prend trente secondes et détecte la classe entière.\n",
+    "\n",
+    "La statistique la plus utile pour la suite est **max 6 pertes consécutives**. Avec un win rate de\n",
+    "53.33 %, la probabilité de 6 pertes de suite à un endroit donné est 0.4667⁶ ≈ **1 %** — mais sur\n",
+    "145 fenêtres de 6 trades dans une série de 150, en voir au moins une est quasi certain\n",
+    "(1 − 0.99¹⁴⁵ ≈ **77 %**). Autrement dit : le pire Passage observé n'est pas de la malchance, c'est\n",
+    "la **géométrie attendue** de la série. Pour dimensionner le capital de risque : 6 pertes × -1.30 %\n",
+    "= -7.8 % de série adverse, à comparer au MaxDD de -16.63 % (qui contient ces séries ET leur\n",
+    "enchaînement) — c'est l'articulation entre statistiques de trades et courbe d'équité."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1563,6 +1802,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-md-alpha-beta-question",
+   "metadata": {},
+   "source": [
+    "### Lire le couple alpha/beta comme une question, pas comme deux notes\n",
+    "\n",
+    "La sortie donne **beta 0.443** et **alpha 7.98 % annualisé**, avec l'interprétation imprimée\n",
+    "« alpha > 0 : surperformance ajustée au risque ». Ces deux nombres ne se lisent pas séparément :\n",
+    "ils forment **une phrase** — « pour chaque 1 % que le marché a fait, la stratégie a fait 0.443 %\n",
+    "de ça, PLUS un résidu positif de 7.98 %/an ». Le beta raconte l'exposition passive, l'alpha le\n",
+    "résidu actif une fois cette exposition retirée (régression linéaire des retours de la stratégie\n",
+    "sur ceux du benchmark).\n",
+    "\n",
+    "La limite de la lecture vient de la dépendance entre les deux : l'alpha estimé dépend du beta\n",
+    "estimé, et sur 504 points, les deux portent des barres d'erreur larges (le même argument que pour\n",
+    "le Sharpe : 1/√T ≈ 0.071 sur T=2 ans s'applique au résidu annualisé, en well worse pour l'alpha\n",
+    "dont l'intervalle couvre typiquement ±10 %+). Et le choix du benchmark **définit** l'alpha : un\n",
+    "beta de 0.443 contre ce benchmark simulé dit que la stratégie n'est pas un substitut du\n",
+    "benchmark — c'est un produit à exposition réduite. La vraie question de gestion n'est donc pas\n",
+    "« l'alpha est-il positif » mais « le résidu actif est-il **répétable** » — et la mesure qui\n",
+    "l'évalue, l'Information Ratio, arrive dans la cellule suivante... avec une réponse qui contredit\n",
+    "frontalement le « surperformance » imprimé ici. Lisez les deux sorties ensemble."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c991efa0",
    "metadata": {},
    "source": [
@@ -1708,6 +1972,37 @@
     "print(\"  - IR > 1.0: Excellente generation d'alpha\")"
    ],
    "id": "cell-5b53b60c"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-contradiction-ir",
+   "metadata": {},
+   "source": [
+    "### La contradiction des deux sorties : alpha +7.98 % et Information Ratio -0.15\n",
+    "\n",
+    "La cellule précédente affichait **alpha 7.98 %** (« surperformance ajustée au risque ») ; celle-ci\n",
+    "affiche **Information Ratio -0.15** avec un tracking error de 17.42 %. Le benchmark de qualité\n",
+    "imprimé dans la sortie (« IR > 0.5 : bonne génération d'alpha ») classe donc la stratégie...\n",
+    "**en-dessous de zéro**. Ces deux verdicts ne sont pas incohérents : ils répondent à **deux\n",
+    "questions différentes**, et savoir laquelle vous posez est tout le métier.\n",
+    "\n",
+    "- **L'alpha CAPM** (7.98 %) : « la stratégie bat-elle **sa part de marché** ? » — le résidu après\n",
+    "  avoir retiré beta × marché. La stratégie, avec un beta de 0.443, ne devait faire que 44 % du\n",
+    "  mouvement ; or son Total Return (40.50 %) dépasse ce que 44 % d'exposition expliquait. Résidu\n",
+    "  positif.\n",
+    "- **L'Information Ratio** (-0.15) : « la stratégie bat-elle **le benchmark lui-même**, de façon\n",
+    "  régulière ? » — moyenne des écarts (stratégie − benchmark) divisée par leur volatilité. La\n",
+    "  stratégie a rendu MOINS que le benchmark en moyenne simple (40.50 % < 48.28 %, partie 1) : la\n",
+    "  moyenne des écarts est négative, le ratio aussi.\n",
+    "\n",
+    "Autrement dit : la stratégie a **sur-performé sa part de marché** (alpha) tout en **sous-performant\n",
+    "le marché** (IR). Les deux phrases sont vraies. Laquelle compte dépend de l'usage : un investisseur\n",
+    "qui veut le marché complet doit lire l'IR (et ne pas investir) ; un portefeuille qui cherche un\n",
+    "actif à faible beta avec du résidu positif lit l'alpha. Le piège — fréquent dans les rapports\n",
+    "commerciaux — est de n'imprimer que la sortie favorable. Ici la sortie alpha dit « surperformance\n",
+    "ajustée au risque » sans croiser l'IR qui la nuance : dans un vrai rapport, ces deux chiffres\n",
+    "vivent sur la même ligne, avec la question posée en tête de colonne."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1934,6 +2229,30 @@
     "print(\"=\" * 60)"
    ],
    "id": "cell-2dc18770"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-dialecte-qc",
+   "metadata": {},
+   "source": [
+    "### Le résumé « type QuantConnect » : la valeur est dans la normalisation\n",
+    "\n",
+    "Cette cellule simule le dictionnaire de statistiques que l'API QuantConnect retourne après un\n",
+    "backtest cloud — la structure que consomment les rapports de la plateforme (et les notebooks\n",
+    "Quantbook de ce dépôt). Son intérêt pédagogique n'est pas dans les valeurs (recopiées à dessein\n",
+    "des métriques calculées plus haut) mais dans le **contrat de nommage** : chaque plateforme définit\n",
+    "ses propres conventions — Sharpe annualisé ou non, drawdown en décimal ou en pourcentage,\n",
+    "rendement logarithmique ou simple — et le bug d'analyse le plus courant du domaine est la\n",
+    "comparaison de deux chiffres qui portent le même nom et deux définitions différentes (le Sharpe\n",
+    "« 1.01 » de ce notebook est annualisé par √252 ; un Sharpe non annualisé de la même série\n",
+    "afficherait 0.064).\n",
+    "\n",
+    "Le réflexe professionnel : avant de comparer la sortie locale d'un backtest aux chiffres d'une\n",
+    "plateforme (ou d'un papier), **vérifier la définition de chaque colonne** — facteur\n",
+    "d'annualisation, base de volatilité (écart-type de population ou d'échantillon), fenêtre du\n",
+    "drawdown, traitement des frais. Les helpers standardisés du repository (utilisés en fin de\n",
+    "notebook) existent précisément pour garantir que toute la famille QC-Py parle le même dialecte."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2417,6 +2736,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-md-rapport-limites",
+   "metadata": {},
+   "source": [
+    "### Ce que le rapport final ajoute — et ce qu'il ne peut pas ajouter\n",
+    "\n",
+    "Le rapport généré aggrège en une sortie lisible tout ce qui a été calculé partie par partie :\n",
+    "rendements, ratios ajustés, drawdowns, statistiques de trades, alpha/beta. Sa valeur est la\n",
+    "**condensation** : un artifact unique, daté, auto-contenu, qu'on peut archiver à côté du code qui\n",
+    "l'a produit — la reproductibilité d'un backtest se juge au couple (code, rapport), pas au rapport\n",
+    "seul. Sa limite est structurelle : l'agrégation ne crée pas d'information. Chaque ligne du rapport\n",
+    "porte l'incertitude de sa cellule d'origine — le Sharpe ±0.72 de la partie 1, le Calmar dépendant\n",
+    "d'un point unique de la partie 2, l'alpha contredit par l'IR de la partie 4 — et le format condensé\n",
+    "fait disparaître ces barres d'erreur. Un rapport honnête mentionne l'horizon d'estimation et les\n",
+    "définitions à côté des valeurs ; un rapport qui ne montre que des nombres demande à être relu\n",
+    "cellule par cellule, ce que ce notebook vient de faire avec vous.\n",
+    "\n",
+    "Dernier point de méthode : la ligne de titre du rapport (« MA CROSSOVER STRATEGY ») identifie la\n",
+    "stratégie par son **nom**, pas par un hash de son code ou de ses paramètres. Dans un workflow\n",
+    "d'optimisation (le sujet du notebook QC-Py-15), deux runs de la même stratégie avec des paramètres\n",
+    "différents produisent des rapports au titre identique — la discipline minimale est d'incrémenter\n",
+    "le titre ou de stocker les paramètres DANS le rapport, sinon l'archive devient un tas de\n",
+    "documents indiscernables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "### Helpers Standardises du Repository\n",
     "\n",
@@ -2585,6 +2930,27 @@
     "print(comparison.round(4))"
    ],
    "id": "cell-7da2e538"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-md-table-finale",
+   "metadata": {},
+   "source": [
+    "### La table comparative finale : les helpers figent le dialecte\n",
+    "\n",
+    "La sortie de `compare_strategies` est la version « production » de tout ce notebook : les mêmes\n",
+    "métriques — Total Return, CAGR, Sharpe, Sortino, Max DD, Calmar — calculées par le helper\n",
+    "standardisé du repository pour chaque stratégie, côte à côte. Deux raisons pour lesquelles cette\n",
+    "ligne finale compte plus qu'il n'y paraît. D'abord la **comparabilité** : chaque métrique vient du\n",
+    "même code, avec la même définition (mêmes facteurs d'annualisation, mêmes conventions de\n",
+    "drawdown) — c'est la réponse directe au problème de dialecte de la partie 5 : une table\n",
+    "multi-plateforme est une table de traductions ambiguës, une table mono-helper est une table de\n",
+    "comparaisons valides. Ensuite l'**extensibilité** : ajouter une stratégie au dictionnaire\n",
+    "`strategies` ajoute une colonne — le pattern est celui du futur workflow d'optimisation, où la\n",
+    "table finale comparera non pas des stratégies différentes, mais la même stratégie à des jeux de\n",
+    "paramètres différents (chaque cellule de la grille devenant une colonne) ; la question de lecture\n",
+    "restera identique : quelles différences survivent à leurs barres d'erreur ?"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11321 (QC-Py-15, substance distincte : analyse de backtest / métriques de risque vs optimisation)

## Summary

Tranche #11224 : **QC-Py-12-Backtesting-Analysis.ipynb**, densité pédagogique **746 → 1358** chars de
prose / cellule code (organe `pedagogy_density.py`, seuil 1200). Enrichissement **markdown-only FR** —
les 34 cellules code sont **byte-identiques** (diff structurel cellule-à-cellule contre `origin/main`),
aucune re-exec requise (exception markdown-only C.3), outputs intacts. 367 insertions / 1 deletion.

## Les lectures ajoutées (toutes ancrées sur les outputs committés)

| Lecture | Valeurs citées |
|---|---|
| Un écart de Sharpe de 0.02 sur 1.92 an n'est pas tranchable — erreur-type ≈ 1/√T ≈ **0.72**, l'écart est 36× plus petit que l'incertitude | Sharpe 1.01 vs 1.03 |
| 4 lignes de rendement = 2 informations indépendantes ; la vraie question est le prix du rendement (beta) | TR 40.50 % vs 48.28 %, CAGR 19.32/22.71 |
| Pourquoi Sortino > Sharpe (dénominateur à la baisse), et pourquoi l'écart quasi identique (+0.66/+0.74) n'est PAS un avantage | 1.67 vs 1.01, 1.77 vs 1.03 |
| Calmar : métrique dépendante d'un **point unique** d'échantillon — l'écart 1.16/1.34 mesure 0.3 pt de MaxDD | 1.16 vs 1.34, -16.63/-16.96 % |
| Le tableau se lit en colonne : moitié de vol (16.26 vs 18.52 %), même queue — neutralité au risque, pas une défaite | tableau complet |
| **89 % de la vie sous l'eau**, la métrique absente des ratios ; le DataFrame montre un drawdown de -8.7 % EN COURS à la dernière ligne | 451/504 jours, equity 136304 vs max 149281 |
| 286 jours de récupération ≈ +20 % à reconquérir au rythme du CAGR normal — la durée détruit la valeur via les flux, pas la stratégie | 2022-01-13 → 2022-10-26 |
| **Le top 5 des drawdowns est un seul épisode compté 5 fois** (4 dates en mars 2022, écart 0.3 pt) — un top-N de dates sans segmentation d'épisodes mesure la persistance des extrêmes | -16.63/-16.45/-16.35/-16.31/-16.30 |
| Les stats de trades se **vérifient entre elles** : expectancy recomposée 0.5333×1.63−0.4667×1.30 = 0.262 ✓, PF = 130.4/91.0 = 1.43 ✓ ; 6 pertes consécutives = géométrie attendue (≥1 occurrence à 77 % sur 150 trades), pas de la malchance | WR 53.33 %, avg ±1.63/-1.30, PF 1.43 |
| **La contradiction des deux sorties** : alpha CAPM +7.98 % (« surperformance » imprimée) vs IR **-0.15** — la stratégie bat **sa part de marché** (beta 0.443) tout en perdant **contre le marché** (TR 40.50 < 48.28) ; deux questions, deux réponses, jamais une sans l'autre | beta 0.443, alpha 7.98 %, TE 17.42 %, IR -0.15 |
| Le rapport final condense sans créer d'information ; le titre identifie par nom, pas par hash — le futur workflow d'optimisation exigera des paramètres DANS le rapport | rapport MA CROSSOVER |

## Validation

- Mesure avant/après : `pedagogy_density.py --json` → 746 → **1358** (status `ok`).
- 34/34 cellules code byte-identiques (script de diff structurel, base `git show origin/main:`).
- Interps ancrées : chaque valeur citée provient de l'output de la cellule précédente
  ([cell-interpretation-ordering](../../.claude/rules/cell-interpretation-ordering.md)) ; les
  identités arithmétiques (expectancy, PF) sont recomposées dans la prose depuis les valeurs de
  l'output adjacent.
- Stubs d'exercices C.1 intacts (3 exos conservés) ; pas de `_en.ipynb` ; catalogue byte-identique.
- File CI mesurée avant ouverture : 81 (<200).

## Regression check

- Fichier unique, markdown-only, 367 ins / 1 del.
- Aucun symbole code touché.

See #11224 (tranche QC-Py-12, protocole #10488 — 1 notebook = 1 PR)
