### PR TITLE
docs(qc,#11224): densite QC-Py-32 RL-DQN-Trading 789->1394 (tranche markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-32-RL-DQN-Trading.ipynb
@@ -106,7 +106,15 @@
     "- 0 : Ne rien faire (hold)\n",
     "- 1 : Acheter (long 10% du capital)\n",
     "- 2 : Vendre (short 10% du capital)\n",
-    "- 3 : Fermer la position"
+    "- 3 : Fermer la position\n",
+    "\n",
+    "L'ordre de grandeur des frictions se compare au benchmark passif : sur un indice actions,\n",
+    "un aller-retour complet coute ici 10 bps (frais) + 5 bps (slippage) + l'impact residuel,\n",
+    "soit environ 0,15 % par rotation. Une politique qui trade *chaque jour* sur 15 actifs paie\n",
+    "donc plusieurs dizaines de points de rendement par an en friction — l'agent ne peut pas\n",
+    "etre rentable en \"faisant du bruit\" : la barre d'entree est volontairement au-dessus du\n",
+    "cout de transaction. C'est la difference fondamentale avec un backtest idealise sans frais,\n",
+    "ou presque n'importe quelle frequence d'echange semble gagnante."
    ]
   },
   {
@@ -216,9 +224,14 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "PyTorch detecte le GPU. L'entrainement DQN beneficie du GPU pour les passes\n",
-    "avant des reseaux Q, mais le bottleneck principal est la simulation de\n",
-    "l'environnement (CPU)."
+    "La sortie confirme l'execution GPU : PyTorch 2.11.0+cu128 detecte la RTX 3070 Laptop\n",
+    "(8,6 Go de VRAM) et place le device sur `cuda`. Pour un reseau de 135 045 parametres,\n",
+    "la VRAM n'est pas le facteur limitant — les passes avant/arriere du Q-network tiennent\n",
+    "largement. En pratique, le bottleneck d'un tel entrainement est ailleurs : la **simulation\n",
+    "de l'environnement** (boucle pas-a-pas, calcul des frictions, reconstruction de l'observation\n",
+    "de dimension 90) s'execute sequentiellement sur CPU pendant que le GPU attend les batches.\n",
+    "C'est un profil typique des environnements de trading custom : le GPU accelere l'apprentissage\n",
+    "du reseau, pas la collecte d'experience."
    ]
   },
   {
@@ -420,8 +433,15 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "15 actions liquides S&P 500 sur 11 ans. Le split temporel utilise 2014-2021\n",
-    "pour l'entrainement et 2022-2024 pour la validation (pas de leak de données)."
+    "La barre de progression suit le telechargement des 15 actions liquides du S&P 500 sur\n",
+    "11 ans d'historique. Le decoupage est **purement temporel** : 2014-2021 pour l'entrainement,\n",
+    "2022-2024 pour la validation. Ce choix est la regle d'or du backtest financier — un decoupage\n",
+    "aleatoire par lignes melangerait le futur dans le train (fuite de donnees) et produirait des\n",
+    "metriques brillantes mais fictives. Concretement, l'agent n'a jamais vu un seul jour de\n",
+    "2022-2024 avant l'evaluation finale : tout ce qui sera mesure plus loin (Sharpe 0.683,\n",
+    "+50,12 % out-of-sample) porte sur des donnees strictement posterieures a son apprentissage.\n",
+    "On note aussi l'asymetrie des longueurs : 2 014 pas d'entrainement quotidien contre 752 pas\n",
+    "de validation (~3 ans), coherent avec la repartition 8 ans / 3 ans."
    ]
   },
   {
@@ -647,9 +667,15 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "L'environnement simule les frictions d'un marche reel. Chaque action trade 10%\n",
-    "du capital. L'impact marche est proportionnel au volume trade relativement au\n",
-    "volume quotidien moyen. Les positions courtes coutent 2% annualise en emprunt."
+    "L'environnement instancie confirme les parametres annonces, et la sortie en donne les\n",
+    "valeurs exactes : 15 actifs, observation de dimension 90 (15 actifs x 6 features),\n",
+    "4 actions (Hold/Buy/Sell/Close), 2 014 pas d'entrainement pour 752 pas de validation.\n",
+    "Chaque action trade 10 % du capital, l'impact marche est proportionnel au volume negocie\n",
+    "relativement au volume quotidien moyen (coefficient 0,1), et les positions courtes coutent\n",
+    "2 % annualise en emprunt. L'observation de dimension 90 est volontairement compacte :\n",
+    "6 features par actif suffisent ici, mais c'est un choix structurant — un espace d'observation\n",
+    "plus riche (canaux de prix bruts, ordre book) augmenterait la capacite requise du reseau\n",
+    "et la difficulte d'apprentissage d'autant."
    ]
   },
   {
@@ -710,12 +736,20 @@
     "Le reseau online selectionne l'action, le reseau cible evalue la Q-value.\n",
     "Cela reduit le biais d'optimisme et stabilise l'apprentissage.\n",
     "\n",
+    "**Pourquoi la surestimation est un vrai probleme en trading** : le `max` du DQN classique\n",
+    "selectionne et evalue l'action avec le *meme* reseau bruite. Le bruit d'estimation est alors\n",
+    "systematiquement interprete comme du potentiel — l'agent croit qu'il existe une action\n",
+    "excellente la ou il n'y a que du bruit, et converre vers des politiques qui sur-tradent des\n",
+    "signaux fantomes. Avec des donnees financieres (signal/bruit tres faible), ce biais\n",
+    "d'optimisme est amplifie : decoupler la selection (reseau online) de l'evaluation\n",
+    "(reseau cible) supprime la composante du biais qui vient de la correlation selection/evaluation.\n",
+    "\n",
     "**Composants** :\n",
     "- **Replay buffer** : 100K transitions, echantillonnage uniforme\n",
     "- **Target network** : Update soft (tau=0.005) vers le reseau online\n",
     "- **Epsilon-greedy** : Decay exponentiel de 1.0 a 0.05 sur 50K pas\n",
-    "- **Gradient clipping** : max_norm=10 pour stabilite",
-    "\n> *Ancre savante -- van Hasselt, H., Guez, A. & Silver, D. (2016), « Deep Reinforcement Learning with Double Q-learning », AAAI Conference on Artificial Intelligence, arXiv:1509.06461. Origine du Double DQN (decouplage sélection/evaluation de l'action pour reduire la surestimation des Q-values). Voir aussi References academiques.*\n"
+    "- **Gradient clipping** : max_norm=10 pour stabilite\n",
+    "> *Ancre savante -- van Hasselt, H., Guez, A. & Silver, D. (2016), « Deep Reinforcement Learning with Double Q-learning », AAAI Conference on Artificial Intelligence, arXiv:1509.06461. Origine du Double DQN (decouplage sélection/evaluation de l'action pour reduire la surestimation des Q-values). Voir aussi References academiques.*"
    ]
   },
   {
@@ -870,8 +904,16 @@
     "sans avoir a calculer la valeur de chaque action pour chaque etat.\n",
     "\n",
     "- **Value stream** : Estime la valeur de l'etat (combien vaut cette situation de marche)\n",
-    "- **Advantage stream** : Estime l'avantage de chaque action relative a la moyenne",
-    "\n> *Ancre savante -- Wang, Z., Schaul, T., Hessel, M. et al. (2016), « Dueling Network Architectures for Deep Reinforcement Learning », ICML, arXiv:1511.06581. Origine de l'architecture Dueling (decomposition Q(s,a) = V(s) + A(s,a) separant valeur d'etat et avantage de l'action). Voir aussi References academiques.*\n"
+    "- **Advantage stream** : Estime l'avantage de chaque action\n",
+    "\n",
+    "La sortie mesure la taille exacte du reseau : 135 045 parametres, couche cachee de 256,\n",
+    "state 6 par actif (observation pleine 90), 4 actions. L'ordre de grandeur est raisonnable :\n",
+    "suffisant pour capturer des interactions prix/position/volatilite, assez petit pour\n",
+    "s'entrainer en 200 episodes sans surapprendre massivement un seul regime de marche.\n",
+    "La decomposition Dueling est particulierement adaptee a cet espace d'action : sur les 4\n",
+    "actions, beaucoup d'etats de marche sont \"neutres\" (aucune action n'a d'avantage marque —\n",
+    "la valeur V(s) domine), et Dueling apprend cette neutralite directement au lieu de la\n",
+    "reconstruire par differences de Q-values individuelles."
    ]
   },
   {
@@ -1035,8 +1077,16 @@
     "copie progressivement les poids du reseau online vers la cible, stabilisant\n",
     "l'apprentissage.\n",
     "\n",
-    "Le buffer de replay (100K transitions) casse la correlation temporelle entre\n",
-    "les expériences consecutives, ameliorant la convergence."
+    "La sortie liste les hyperparametres exacts du run, qui merittent lecture :\n",
+    "- **gamma = 0,99** : horizon ~100 jours — l'agent est pousse a valoriser les\n",
+    "  consequences durables de ses positions, pas seulement le gain immediate.\n",
+    "- **epsilon 1,00 -> 0,05 sur 50 000 pas** : avec ~2 014 pas par episode, la phase\n",
+    "  d'exploration majoritaire couvre environ les 25 premiers episodes ; ensuite\n",
+    "  l'exploitation domine progressivement.\n",
+    "- **buffer 100 000 / batch 128** : le buffer couvre ~50 episodes — les updates\n",
+    "  melangent un historique large, cassant la correlation temporelle des transitions.\n",
+    "- **AdamW lr = 1e-4, weight decay = 1e-4** : un learning rate conserveur, choix\n",
+    "  cohérent avec la stabilite recherchee par Double DQN + soft update."
    ]
   },
   {
@@ -1320,9 +1370,17 @@
     "### Interpretation\n",
     "\n",
     "L'entrainement alterne entre exploration (epsilon-greedy) et exploitation.\n",
-    "Le warmup de 1000 pas remplit le buffer avant de commencer les updates.\n",
-    "L'evaluation periodique (tous les 20 episodes) mesure les performances sur\n",
-    "le set de validation sans exploration."
+    "Le warmup de 1 000 pas remplit le buffer avant de commencer les updates —\n",
+    "on n'apprend pas sur un echantillon de quelques dizaines de transitions\n",
+    "fortement correlees. L'evaluation periodique (tous les 20 episodes) mesure les\n",
+    "performances sur le set de validation **sans exploration** (politique greedy) :\n",
+    "c'est la seule mesure qui prefigure le comportement en production, ou epsilon\n",
+    "sera nul. C'est aussi le mecanisme de sauvegarde du meilleur modele : a chaque\n",
+    "evaluation, si le Sharpe de validation depasse le meilleur courant, les poids sont\n",
+    "archives — c'est ce checkpoint \"best\", pas les poids du dernier episode, qui sera\n",
+    "charge pour l'evaluation finale. Cette precaution n'est pas decorative : la sortie\n",
+    "de la boucle montre que le meilleur Sharpe de validation (+0,683) est atteint a\n",
+    "l'episode 40, et que les evaluations suivantes ne l'ont plus egale."
    ]
   },
   {
@@ -1430,12 +1488,26 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "Les 4 graphiques montrent : le reward par episode (doit monter puis se\n",
-    "stabiliser), la loss d'apprentissage (doit descendre), le Sharpe ratio\n",
-    "de validation (cible > 0.7), et le resume du meilleur modèle.\n",
+    "Les 4 graphiques montrent le reward par episode, la loss d'apprentissage, le Sharpe\n",
+    "ratio de validation, et le resume du meilleur modele. La lecture honnete de CE run\n",
+    "(et non d'un run ideal) :\n",
     "\n",
-    "Un Sharpe > 0.7 en validation indique que l'agent a appris une politique\n",
-    "exploitable même avec les frictions de marche."
+    "- **Reward d'entrainement** : il ne monte pas franchement — de -68,53 (Ep 20) a\n",
+    "  -36,91 (Ep 120) avec des rebonds (Ep 80 : -70,48). Le reward brut reste negatif :\n",
+    "  les frictions et le cout des shorts pesent sur chaque episode, et l'amelioration\n",
+    "  est lente, pas spectaculaire.\n",
+    "- **Loss** : non monotone (0,0043 -> 0,0297 au fil des evaluations) — normal en\n",
+    "  DQN : la cible bouge (soft update + buffer qui evolue), la loss mesure l'erreur\n",
+    "  de regression vers une cible mobile, pas une convergence propre.\n",
+    "- **Sharpe de validation** : le signal cle. Il monte de +0,061 (Ep 20) a **+0,683\n",
+    "  (Ep 40, le meilleur)** puis oscille fortement : +0,525, **-6,884** (Ep 80), -2,006,\n",
+    "  -5,284... L'apprentissage n'est PAS monotone : la performance de validation\n",
+    "  se degrade nettement apres le pic pendant que le reward d'entrainement stagne —\n",
+    "  le classique decrochage train/val du RL hors distribution d'apprentissage.\n",
+    "- **Consequence pratique** : sans le mecanisme de best-checkpoint, l'evaluation\n",
+    "  finale aurait charge les poids de l'episode 200 et mesure un Sharpe negatif.\n",
+    "  Le \"cible > 0,7\" affiche plus haut comme objectif n'est PAS atteint (0,683) —\n",
+    "  on mesure un honnete sous-la-barre, ni echec ni reussite fracassante."
    ]
   },
   {
@@ -1580,9 +1652,24 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "Les résultats out-of-sample mesurent la performance reelle de l'agent.\n",
-    "Un Sharpe > 0.7 avec MaxDD < 30% est un bon résultat pour un agent RL pur.\n",
-    "La distribution des actions revele la stratégie apprise."
+    "Les resultats out-of-sample mesurent la performance reelle de l'agent — le modele\n",
+    "charge est celui de l'episode 40 (val_sharpe = 0,683), pas le dernier :\n",
+    "\n",
+    "- **Rendement total +50,12 %** (14,58 % annualise) sur 2022-2024, pour **419 trades**\n",
+    "  et un **win rate de 54,52 %** — legerement au-dessus du pile-ou-face, ce qui suffit\n",
+    "  quand les gains moyens depassent les pertes moyennes.\n",
+    "- **Sharpe 0,683 < 0,7** : la barre que le notebook s'etait fixee plus haut n'est\n",
+    "  pas atteinte — un presque-but honnete, pas une reussite declaree.\n",
+    "- **MaxDD -25,98 %** : un quart du capital perdu au pire moment (cf. analyse de la\n",
+    "  courbe de portefeuille ci-dessous).\n",
+    "- **La distribution des actions revele la strategie apprise** : Hold 1 998,\n",
+    "  **Buy 8 347**, Sell 217, Close 718. L'agent achete dans 74 % des decisions et ne\n",
+    "  vend a decouvert que dans 2 % des cas — malgre le cout d'emprunt modeste (2 %),\n",
+    "  il a appris une politique **quasi exclusivement longue**. Le \"Sell\" du modele\n",
+    "  sert surtout a fermer/retourner, pas a parier baissier. C'est une lecture\n",
+    "  importante : le RL n'a pas decouvert une strategie de marche neutre, il a\n",
+    "  reconverve le biais long de l'equity market 2014-2021 de son apprentissage —\n",
+    "  le +50 % OOS de 2022-2024 est coherent avec ce profil."
    ]
   },
   {
@@ -1672,9 +1759,16 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "La courbe de portefeuille, les rendements quotidiens et le drawdown\n",
-    "montrent la dynamique de la stratégie apprise. Un drawdown contenu\n",
-    "(< 20%) indique que l'agent a appris un risk management implicite."
+    "La courbe de portefeuille, les rendements quotidiens et le drawdown montrent la\n",
+    "dynamique de la strategie apprise. La lecture chiffree du run : le drawdown maximal\n",
+    "mesure est **-25,98 %** — au-dessus du seuil de 20 % que le notebook citait comme\n",
+    "indicateur d'un risk management implicite. **Sur ce point, l'agent ne l'a PAS appris** :\n",
+    "il subit des episodes de perte profonde typiques d'une exposition longue permanente\n",
+    "(les bear markets 2022). Le couple rendement/risque reste cependant exploitable\n",
+    "(+50,12 % total pour -25,98 % de drawdown maximal, Sharpe 0,683) — mais il faut le\n",
+    "lire pour ce qu'il est : un profil equity-long avec un risque de queue non controle,\n",
+    "pas une strategie couverte. Une amelioration directe serait d'ajouter une penalite\n",
+    "de drawdown a la reward (c'est precisement le sujet de l'Exercice 1)."
    ]
   },
   {
@@ -1806,9 +1900,16 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "Le modèle est exporte en JSON compatible avec QuantConnect ObjectStore.\n",
-    "La config inclut les paramètres de l'environnement pour reproduire exactement\n",
-    "le preprocessing en production."
+    "Le modele est exporte en JSON compatible avec QuantConnect ObjectStore — 3,0 Mo\n",
+    "pour 135 045 parametres, 4 actions, 15 actifs. Deux details de conception comptent\n",
+    "pour la production : (1) la config embarque les parametres de l'environnement\n",
+    "(fenetres, normalisation, frictions) afin que le preprocessing en production\n",
+    "reproduise *exactement* celui de l'entrainement — un des bugs de deploiement les\n",
+    "plus frequents en ML trading est une derive silencieuse de preprocessing entre\n",
+    "train et inference ; (2) les metriques de validation (Sharpe 0,683, rendement\n",
+    "+50,1 %) sont stockees avec les poids, ce qui rend le modele auto-documente :\n",
+    "au moment d'uploader plusieurs versions dans ObjectStore, la traçabilité de\n",
+    "chaque artifact reste lisible sans rouvrir le notebook d'origine."
    ]
   },
   {
@@ -1935,15 +2036,21 @@
    "source": [
     "### Interpretation\n",
     "\n",
-    "Le template QuantConnect charge le modèle DQN depuis ObjectStore et genere des\n",
+    "Le template QuantConnect charge le modele DQN depuis ObjectStore et genere des\n",
     "signaux de trading quotidiens. L'agent DQN decide de l'action optimale pour chaque\n",
-    "actif : hold, buy, sell, ou close.\n",
+    "actif : hold, buy, sell, ou close. La sortie resume les 3 etapes de deploiement :\n",
+    "uploader `dqn_trading_model.json` dans QC ObjectStore, copier le template dans un\n",
+    "projet QC (`main.py`), lancer un backtest QC pour valider le comportement en\n",
+    "conditions reelles (donnees QC, calendrier, splits/dividendes) — ce backtest de\n",
+    "reception est obligatoire avant tout paper trading, car l'environnement\n",
+    "d'entrainement reste une simulation (pas de gaps d'ouverture, pas de\n",
+    "corporate actions) que les donnees QC, elles, contiennent.\n",
     "\n",
-    "**Étapes de deploiement** :\n",
-    "1. Entrainer le modèle dans ce notebook (GPU)\n",
+    "**Etapes de deploiement** :\n",
+    "1. Entrainer le modele dans ce notebook (GPU)\n",
     "2. Exporter en JSON\n",
     "3. Uploader dans ObjectStore QC\n",
-    "4. Deployer l'algorithme avec le modèle embarque"
+    "4. Deployer l'algorithme avec le modele embarque"
    ]
   },
   {
@@ -1988,6 +2095,16 @@
     "3. **Entrainement** : 200 episodes sur 15 actifs S&P 500, evaluation out-of-sample\n",
     "4. **Integration QC** : Export ObjectStore + algorithme de trading pret au deploiement\n",
     "\n",
+    "### Bilan chiffre du run\n",
+    "\n",
+    "Le meilleur checkpoint date de l'episode 40 (Sharpe validation 0,683) ; les 160\n",
+    "episodes suivants ont degrade la performance de validation (jusqu'a -6,9) sans\n",
+    "ameliorer le reward d'entrainement. En out-of-sample 2022-2024 : +50,12 % total,\n",
+    "+14,58 % annualise, Sharpe 0,683 (sous la barre de 0,7 visee), MaxDD -25,98 %,\n",
+    "win rate 54,52 % sur 419 trades. La distribution des actions (74 % de Buy, 2 % de\n",
+    "Sell) montre une politique quasi exclusivement longue : l'agent a capte le regime\n",
+    "haussier de son train set plutot qu'une strategie directionnelle symetrique.\n",
+    "\n",
     "### Avantages du RL pour le Trading\n",
     "\n",
     "- **Apprentissage par interaction** : L'agent decouvre les stratégies par essai/erreur\n",
@@ -1997,8 +2114,10 @@
     "### Limites et Precautions\n",
     "\n",
     "- **Simulation vs Realite** : L'environnement reste une approximation du marche reel\n",
-    "- **Stabilite** : L'entrainement RL peut etre instable (hyperparametres sensibles)\n",
-    "- **Overfitting** : Risque de surapprentissage sur les données d'entrainement\n",
+    "- **Stabilite** : L'entrainement RL peut etre instable (hyperparametres sensibles) —\n",
+    "  ce run l'illustre litteralement : la moitie des evaluations post-pic sont negatives\n",
+    "- **Overfitting** : Risque de surapprentissage sur les données d'entrainement — le\n",
+    "  decrochage validation apres l'episode 40 en est le symptome\n",
     "\n",
     "### Prochaine étape\n",
     "\n",
@@ -2020,7 +2139,7 @@
     "\n",
     "- **Notebook QC-Py-33** : RL PPO Trading (suite policy-gradient).\n",
     "- **Notebook QC-Py-34** : RL SAC / A2C Trading (actor-critic continus).\n",
-    "- **Documentation** : [QuantConnect Docs](https://www.quantconnect.com/docs), [PyTorch RL / Gymnasium](https://gymnasium.farama.org/)\n"
+    "- **Documentation** : [QuantConnect Docs](https://www.quantconnect.com/docs), [PyTorch RL / Gymnasium](https://gymnasium.farama.org/)"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Tranche #11224 : pire debiteur restant hors scopes en vol (re-mesure firsthand sur origin/main frais 15edb2280 ; #11320/#11321/#11322 = QC-Py-33/15/12 po-2024 non-mergées, intouchables). Densité 789 -> **1394** (11828 -> 20908 chars markdown / 15 cellules code), pattern markdown-only #10488.

## Livrable

14 cellules markdown réécrites/étendues (FR), 0 cellule code touchée, outputs inchangés (exception C.3 markdown-only) :

- **Ré-ancrage honnête sur les outputs réels du run** — la prose générique décrivait un run idéal, le run mesuré dit autre chose :
  - courbes d'entraînement : val_sharpe pic **+0.683 à l'Ep 40** puis effondrement (-6.884 Ep 80, -5.284 Ep 120) pendant que le reward stagne — décrochage train/val nommé pour ce qu'il est, et le best-checkpoint expliqué comme le mécanisme qui sauve l'évaluation finale ;
  - Sharpe **0.683 < la barre 0.7** que le notebook s'était fixée (l'objectif n'est PAS atteint — écrit) ;
  - MaxDD **-25.98% > seuil 20%** cité dans la prose d'origine (« l'agent n'a PAS appris un drawdown contenu ») ;
  - distribution des actions : **Buy 74% / Sell 2%** -> politique quasi exclusivement longue, lecture du +50% OOS comme capture du biais long du train set.
- Interprétations ancrées sur les paramètres exacts du run (gamma 0.99, tau 0.005, eps 1.0->0.05/50k, AdamW lr 1e-4, 135 045 params, buffer 100k, 2 014/752 pas train/val).
- Extensions pédagogiques : ordre de grandeur des frictions vs fréquence de trading, pourquoi la surestimation Double DQN est amplifiée en finance (signal/bruit faible), traçabilité de l'export ObjectStore (3.0 Mo, métriques embarquées), backtest de réception QC obligatoire (gaps/corporate actions absents de la simulation).

## Mesure

| | avant | après |
|---|---|---|
| chars markdown | 11 828 | 20 908 |
| cellules code | 15 | 15 (byte-identiques, vérifié par diff JSON cell-by-cell) |
| densité (md/code) | 789 | **1 394** |

## Validation

- `notebook_tools.py validate` : OK, 0 erreur.
- Anti-churn : exactement les 14 cellules cibles diffèrent, aucune re-sérialisation des 46 autres.
- Pre-commit : gitleaks + H.3 Passed (commit 995f96ffa).
- 3 exercices intacts (Exercice 1/2/3 stubs + markdown, non touchés).

See #11224 (contribution partielle à l'epic densité, l'issue reste ouverte pour les tranches suivantes)

Grain: MED/notebook-python — lane myia-po-2026:CoursIA — prev: DEEP/training #11323 (rotation de famille : QC après ML/Lean)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>