### PR TITLE
enrich(qc,#11224): densité pédagogique QC-Py-30-LSTM-Training 991 -> 1399 (markdown-only FR)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-30-LSTM-Training.ipynb
@@ -882,7 +882,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : Les features incluent rendements multi-echelles, volatilite realisee, momentum et RSI. La cible est le rendement forward risque-ajuste (rendement/volatilite), ce qui penalise les predictions dans les periodes de haute incertitude."
+    "**Interpretation** : Les features incluent rendements multi-echelles, volatilite realisee, momentum et RSI. La cible est le rendement forward risque-ajuste (rendement/volatilite), ce qui penalise les predictions dans les periodes de haute incertitude.\n",
+    "\n",
+    "**Le piège du déséquilibre des classes** : la cible directionnelle vaut `1.0` dans 74 316 cas contre `0.0` dans 58 670 cas, soit 55,9 % de haussiers. Un modèle paresseux qui prédirait *toujours* haussier atteindrait mécaniquement 55,9 % d'accuracy sans aucune capacité prédictive — c'est le **taux de base** qu'il faudra battre. Le critère honnête ne sera donc pas l'accuracy globale mais la précision par classe : la section 8 mesurera précisément le collapse du modèle sur la classe baissière, invisible dans le chiffre global."
    ]
   },
   {
@@ -1032,7 +1034,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : Le split temporel garantit qu'aucune donnee future ne fuite dans l'entrainement. Le `StandardScaler` est fitte uniquement sur le set d'entrainement. Les sequences de 60 jours contiennent 7 features par timestep."
+    "**Interpretation** : Le split temporel garantit qu'aucune donnee future ne fuite dans l'entrainement. Le `StandardScaler` est fitte uniquement sur le set d'entrainement. Les sequences de 60 jours contiennent 7 features par timestep.\n",
+    "\n",
+    "**Lecture des volumes** : 89 915 séquences d'entraînement contre 16 758 en validation et 16 758 en test. Chaque séquence couvre 60 jours d'historique pour prédire un horizon de 5 jours ; les fenêtres se chevauchent d'un jour à l'autre d'un même actif, ce qui explique l'ordre de grandeur (~1 800 jours utiles × 49 actions ≈ 88 000 fenêtres glissantes). La période de test (mai 2023 → décembre 2024) est un régime de marché haussier : toute stratégie longue-only y paraît performante, et le buy & hold affichera une référence élevée qu'il faudra battre *après coûts*, pas égaler."
    ]
   },
   {
@@ -1228,7 +1232,10 @@
    },
    "source": [
     "**Interpretation** : Le modèle combine un LSTM profond (3 couches, 128 units) avec 4 têtes d'attention qui apprennent a ponderer differemment les pas de temps. Deux heads de prediction : regression (rendement continu) et classification (direction haussier/baissier).\n",
-    "> *Ancres savantes -- architecture.* Le reseau LSTM (Long Short-Term Memory) est forme par Hochreiter & Schmidhuber (1997), *Long Short-Term Memory*, Neural Computation **9(8), 1735-1780**, DOI 10.1162/neco.1997.9.8.1735. Le mécanisme d'attention additive (ponderation des pas de temps pertinents) est formalise par Bahdanau, Cho & Bengio (2015), *Neural Machine Translation by Jointly Learning to Align and Translate*, ICLR 2015, arXiv:1409.0473.\n"
+    "> *Ancres savantes -- architecture.* Le reseau LSTM (Long Short-Term Memory) est forme par Hochreiter & Schmidhuber (1997), *Long Short-Term Memory*, Neural Computation **9(8), 1735-1780**, DOI 10.1162/neco.1997.9.8.1735. Le mécanisme d'attention additive (ponderation des pas de temps pertinents) est formalise par Bahdanau, Cho & Bengio (2015), *Neural Machine Translation by Jointly Learning to Align and Translate*, ICLR 2015, arXiv:1409.0473.\n",
+    "\n",
+    "\n",
+    "**Budget de paramètres vs budget de données** : 499 206 paramètres entraînables pour 89 915 séquences — environ 5,6 paramètres par échantillon, un modèle **relativement sur-paramétré** pour la taille du dataset. Trois garde-fous limitent le risque de surapprentissage : le dropout 0.2 entre couches LSTM, le weight decay 1e-4 d'AdamW, et la double supervision (régression + classification) qui contraint les représentations par deux chemins. Les têtes d'attention (128 → 64 → 1 chacune) restent marginales en coût : l'essentiel des paramètres vit dans les poids récurrents du LSTM."
    ]
   },
   {
@@ -1517,6 +1524,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a1d0c39e",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "**Lecture des 15 premières epochs — le modèle n'apprend pas** : la loss ",
+    "d'entraînement décroît de 1,9447 à 1,9359 (-0,5 % en 15 epochs), mais la loss ",
+    "de validation *remonte* dès l'epoch 5 (1,9547 → 1,9662) et l'accuracy ",
+    "directionnelle reste scotchée à ~51 %, en dessous du taux de base de 55,9 %. ",
+    "Ce motif — train qui plafonne, val qui remonte, accuracy constante — n'est ",
+    "pas du surapprentissage classique (la train loss y chuterait activement) : ",
+    "c'est le signe que le gradient n'apporte presque aucune information ",
+    "exploitable. Les features (rendements, volatilité, RSI) sont à peu près ",
+    "stationnaires sur 11 ans ; la cible à 5 jours est dominée par le bruit ",
+    "idiosyncratique. Le modèle converge vers la solution triviale : prédire la ",
+    "moyenne conditionnelle et la classe majoritaire."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-e54b3093",
    "metadata": {
     "papermill": {
@@ -1595,7 +1623,10 @@
    },
    "source": [
     "**Interpretation** : L'entraineur utilise AdamW avec cosine annealing pour eviter les minima plats. Le gradient clipping (max_norm=1.0) previent l'explosion des gradients dans le LSTM profond. Le meilleur modèle est sauvegarde par early stopping implicite (checkpoint sur val loss).\n",
-    "> *Ancres savantes -- techniques d'entrainement.* L'optimiseur **AdamW** (decoupled weight decay) est formalise par Loshchilov & Hutter (2019), *Decoupled Weight Decay Regularization*, ICLR 2019, arXiv:1711.05101. Le **cosine annealing** (planning de taux d'apprentissage) provient de Loshchilov & Hutter (2017), *SGDR: Stochastic Gradient Descent with Warm Restarts*, ICLR 2017, arXiv:1608.03983. Le **gradient clipping** contre l'explosion des gradients dans les RNN est introduit par Pascanu, Mikolov & Bengio (2013), *On the difficulty of training Recurrent Neural Networks*, ICML 2013 (PMLR vol. 28), arXiv:1211.5063.\n"
+    "> *Ancres savantes -- techniques d'entrainement.* L'optimiseur **AdamW** (decoupled weight decay) est formalise par Loshchilov & Hutter (2019), *Decoupled Weight Decay Regularization*, ICLR 2019, arXiv:1711.05101. Le **cosine annealing** (planning de taux d'apprentissage) provient de Loshchilov & Hutter (2017), *SGDR: Stochastic Gradient Descent with Warm Restarts*, ICLR 2017, arXiv:1608.03983. Le **gradient clipping** contre l'explosion des gradients dans les RNN est introduit par Pascanu, Mikolov & Bengio (2013), *On the difficulty of training Recurrent Neural Networks*, ICML 2013 (PMLR vol. 28), arXiv:1211.5063.\n",
+    "\n",
+    "\n",
+    "**Pourquoi ces choix d'optimiseur** : AdamW découple le weight decay des gradients adaptatifs (contrairement à l'Adam classique) — le decay devient une vraie pénalité de norme et non un biais d'échelle. Le cosine annealing fait décroître le learning rate de 1e-3 vers ~0 selon une cosinusoïde : descente rapide au début, affinage fin à la fin, sans discontinuité. La Huber loss est insensible aux rendements extrêmes là où une MSE serait dominée par quelques journées de crash ; la BCE pénalise les probabilités mal calibrées, pas seulement les classes mal prédites. Ces choix sont corrects — c'est le *signal* qui manque, pas l'optimisation."
    ]
   },
   {
@@ -1705,7 +1736,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : La courbe de loss doit montrer une convergence stable. L'accuracy directionnelle au-dessus de 50% indique que le modèle capture un signal predictif au-dela du hasard. Un gap train/val excessif indiquerait du surapprentissage."
+    "**Interpretation** : La courbe de loss doit montrer une convergence stable. L'accuracy directionnelle au-dessus de 50% indique que le modèle capture un signal predictif au-dela du hasard. Un gap train/val excessif indiquerait du surapprentissage.\n",
+    "\n",
+    "**L'écart mesuré** : accuracy finale 51,3 % contre meilleure accuracy 51,4 % — 0,1 point d'écart sur 16 758 prévisions de validation, statistiquement indiscernable du bruit (l'intervalle de confiance à 95 % sur une proportion de 0,51 à n = 16 758 est de ±0,8 point). Le modèle sélectionné par checkpointing ne fait pas mieux qu'une epoch quelconque : la courbe d'accuracy ne montre **aucune** tendance apprise, seulement des oscillations d'échantillonnage autour du taux de base dégénéré."
    ]
   },
   {
@@ -1814,7 +1847,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : La correlation pred/realite proche de 0 et la collapse du modele sur la classe haussiere (precision baissier 0.0%) montrent que l'accuracy de ~54% **n'est pas un signal discriminant** : elle egale la base rate du marche sur la periode. Le mythe « une accuracy de 53-55% suffit pour generer des profits » ne tient que si les predictions sont *informatives* — ici elles ne le sont pas, et le backtest (section 11) le confirmera : pas d'alpha. Le ratio Up/Down montre si le modele est equilibre ; une precision baissier a 0% est le signal d'alerte classique d'un effondrement sur la classe majoritaire."
+    "**Interpretation** : La correlation pred/realite proche de 0 et la collapse du modele sur la classe haussiere (precision baissier 0.0%) montrent que l'accuracy de ~54% **n'est pas un signal discriminant** : elle egale la base rate du marche sur la periode. Le mythe « une accuracy de 53-55% suffit pour generer des profits » ne tient que si les predictions sont *informatives* — ici elles ne le sont pas, et le backtest (section 11) le confirmera : pas d'alpha. Le ratio Up/Down montre si le modele est equilibre ; une precision baissier a 0% est le signal d'alerte classique d'un effondrement sur la classe majoritaire.\n",
+    "\n",
+    "**Chiffres à retenir** : corrélation 0,0235 — la régression explique 0,06 % de la variance (R² ≈ 0,0006). L'accuracy globale de 54,6 % paraît honorable jusqu'à la ligne suivante : **0 prévision baissière sur 16 758**. Le modèle sort toujours p > 0,5 ; son accuracy se réduit donc exactement au taux de haussiers du set de test. Comparé au taux de base de 55,9 % mesuré en section 3, le classifieur est même *en dessous* du prédicteur constant optimal. Démonstration la plus nette du notebook : une accuracy globale sans lecture par classe est un non-sens sur cible déséquilibrée."
    ]
   },
   {
@@ -1905,7 +1940,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : Le scatter plot montre la qualite de la regression. Une separation claire des deux distributions (UP vs DOWN) dans le second graphe indique que le modèle discrimine bien les directions."
+    "**Interpretation** : Le scatter plot montre la qualite de la regression. Une separation claire des deux distributions (UP vs DOWN) dans le second graphe indique que le modèle discrimine bien les directions.\n",
+    "\n",
+    "**Ce que le nuage confirme** : l'axe des prévisions se resserre sur une bande étroite autour de la moyenne (variance prévue très inférieure à la variance réalisée) — signature d'un modèle qui a appris la *moyenne inconditionnelle*, pas une relation conditionnelle. Les deux distributions (hausse / baisse) ne sont pas séparées : tout seuil de décision placé sur ce nuage découpera la même bande centrale, jamais deux populations distinctes."
    ]
   },
   {
@@ -2013,7 +2050,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : Les poids d'attention revelent quelles positions temporelles le modèle juge les plus importantes. On s'attend a voir les positions recentes (proches de la prediction) plus ponderees, mais certaines heads peuvent se specialiser dans des patterns plus anciens."
+    "**Interpretation** : Les poids d'attention revelent quelles positions temporelles le modèle juge les plus importantes. On s'attend a voir les positions recentes (proches de la prediction) plus ponderees, mais certaines heads peuvent se specialiser dans des patterns plus anciens.\n",
+    "\n",
+    "**Le diagnostic de redondance** : les 4 têtes retournent les *mêmes* positions attentives — jours [17, 16, 36, 37, 35] — avec des poids quasi identiques (~0,07-0,09) à trois décimales près. Une attention saine **spécialise** ses têtes (momentum récent / niveau ancien / zone de volatilité) ; ici les quatre ont convergé vers la même solution. Les poids restent au demeurant modestes (4 à 5 fois le poids uniforme 1/60 ≈ 0,017) : l'attention apprend un léger biais de position — regarder un peu plus les jours 16-17 et 35-37 — plutôt qu'un mécanisme de sélection net. Cohérent avec un modèle sans signal : l'attention se cale sur la structure moyenne des séquences, indépendamment de leur contenu."
    ]
   },
   {
@@ -2272,7 +2311,9 @@
     "\n",
     "Dans les deux régimes, avec des coûts de transaction (5 bps par trade), l'issue est la même : **pas d'alpha**. Un Sharpe élevé hérité du drift du marché (AAPL sur la période) n'est pas un edge. C'est le failure-mode classique du deep learning financier sur données bruyantes à court terme : une accuracy de 54% égale à la base rate ≠ un edge.\n",
     "\n",
-    "**Verdict honnête** : le bon critère de succès est `Sharpe(stratégie) - Sharpe(B&H) > 0.05` (battre le marché net de frais), pas `Sharpe > 1.0` seul. Pour générer un vrai alpha, il faudrait durcir l'entraînement (class weighting pour forcer des prédictions baissières, features supplémentaires, horizon plus long) — ou admettre que le problème est intrinsèquement difficile sur du rendement 5-jour brut."
+    "**Verdict honnête** : le bon critère de succès est `Sharpe(stratégie) - Sharpe(B&H) > 0.05` (battre le marché net de frais), pas `Sharpe > 1.0` seul. Pour générer un vrai alpha, il faudrait durcir l'entraînement (class weighting pour forcer des prédictions baissières, features supplémentaires, horizon plus long) — ou admettre que le problème est intrinsèquement difficile sur du rendement 5-jour brut.\n",
+    "\n",
+    "**L'égalité parfaite est le verdict** : Sharpe 1,131 contre 1,131, CAGR 25,64 % contre 25,64 %, MaxDD -16,61 % contre -16,61 % — identiques jusqu'à la troisième décimale. La cause se lit deux lignes plus haut : **0 trade** et 415/415 jours investis (100 %). Comme le modèle ne prédit jamais p ≤ 0,5 (section 8), la probabilité ne franchit jamais le seuil de vente vers le bas — la stratégie reste investie en continu et reproduit exactement l'indice. Les 5 bps de coût par trade ne s'appliquent d'ailleurs jamais. Un backtest où stratégie et référence coïncident à la décimale près n'est pas un backtest : c'est la preuve mécanique que le signal est inopérant."
    ]
   },
   {
@@ -2428,7 +2469,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : Le modèle est sauvegarde avec ses paramètres et le scaler pour permettre une inférence en production. Les metadonnees (hyperparametres, metriques test) sont incluses pour tracabilite."
+    "**Interpretation** : Le modèle est sauvegarde avec ses paramètres et le scaler pour permettre une inférence en production. Les metadonnees (hyperparametres, metriques test) sont incluses pour tracabilite.\n",
+    "\n",
+    "**Deux Sharpe, deux passes d'exécution** : le checkpoint embarque Sharpe 1,022 alors que l'affichage backtest donne 1,131 — les timestamps papermill des cellules documentent la cause : la sauvegarde date de la passe de 07:47, l'affichage backtest de la passe de 09:59, deux exécutions partielles du même pipeline avec états distincts. L'écart (~0,1) illustre au passage la variance d'échantillonnage d'un Sharpe annualisé sur 415 jours. Le point réutilisable : le fichier `lstm_attention_sp50.pt` de 2,0 MB embarque poids *et* paramètres du `StandardScaler` — un pipeline de scoring complet et rechargeable, même si le signal qu'il produit, en l'état, ne vaut pas son coût d'inférence."
    ]
   },
   {
@@ -2672,7 +2715,9 @@
     "tags": []
    },
    "source": [
-    "**Interpretation** : Le code QC Cloud encapsule le modèle LSTM complet dans un `QCAlgorithm`. En production, les poids pre-entraines seraient charges depuis le Object Store QC. Le rebalancement hebdomadaire reduit les couts de transaction."
+    "**Interpretation** : Le code QC Cloud encapsule le modèle LSTM complet dans un `QCAlgorithm`. En production, les poids pre-entraines seraient charges depuis le Object Store QC. Le rebalancement hebdomadaire reduit les couts de transaction.\n",
+    "\n",
+    "**Ce qui est déployable, ce qui ne l'est pas** : le code généré (6 116 caractères, rééquilibrage hebdomadaire le vendredi 15h, univers top 10 SP500) est un *pipeline* de production correct — séquences, scaler, inference batch, sizing. Ce qu'il transporte est un modèle de corrélation 0,02 : déployé tel quel, il paierait une infrastructure GPU pour router du bruit. La leçon d'ingénierie : la voie Cloud est prête et re-testable le jour où un signal battant le taux de base par classe existera ; ce notebook livre le moule, pas encore la matière."
    ]
   },
   {
@@ -2696,7 +2741,10 @@
     "- Bahdanau, D., Cho, K., & Bengio, Y. (2015). *Neural Machine Translation by Jointly Learning to Align and Translate.* International Conference on Learning Representations (ICLR). arXiv:1409.0473\n",
     "- Pascanu, R., Mikolov, T., & Bengio, Y. (2013). *On the difficulty of training Recurrent Neural Networks.* International Conference on Machine Learning (ICML), PMLR 28. arXiv:1211.5063\n",
     "- Loshchilov, I., & Hutter, F. (2017). *SGDR: Stochastic Gradient Descent with Warm Restarts.* International Conference on Learning Representations (ICLR). arXiv:1608.03983\n",
-    "- Loshchilov, I., & Hutter, F. (2019). *Decoupled Weight Decay Regularization.* International Conference on Learning Representations (ICLR). arXiv:1711.05101\n"
+    "- Loshchilov, I., & Hutter, F. (2019). *Decoupled Weight Decay Regularization.* International Conference on Learning Representations (ICLR). arXiv:1711.05101\n",
+    "\n",
+    "\n",
+    "**Bilan quantifié** : accuracy 54,6 % = taux de haussiers du set de test (0 prévision baissière) ; corrélation 0,0235 (R² ≈ 0,0006) ; backtest identique au buy & hold à la décimale près (0 trade, 415/415 jours investis). Le notebook vaut comme **méthodologie complète et honnête** — split temporel strict, double supervision, coûts inclus, lecture par classe — appliquée à un signal absent du dataset. Chaque étape est réutilisable : c'est le module d'entraînement/évaluation, pas la stratégie, qui est le livrable."
    ]
   },
   {


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA — prev: LIGHT/genai #11293

## Summary

Tranche #11224 : enrichissement markdown-only FR de `QC-Py-30-LSTM-Training.ipynb` (991 -> **1399** chars/cellule code, seuil 1200), protocole #10488. 12 cellules markdown étendues + 1 nouvelle cellule d'interprétation après la boucle d'entraînement. **Zéro cellule code touchée.**

## Prose ancrée sur les outputs commités

- Déséquilibre des classes (55,9 % haussiers) -> taux de base à battre, lecture par classe
- Volumes split (89 915 / 16 758 / 16 758, fenêtres glissantes chevauchantes)
- 499 206 params vs 89 915 échantillons (~5,6/éch.) + 3 garde-fous
- Choix d'optimiseur (AdamW découplé, cosine annealing, Huber+BCE)
- Stagnation training : loss 1,9447 -> 1,9359, val qui remonte dès l'epoch 5, acc ~51 % (nouvelle cellule)
- 0 prévision baissière sur 16 758 -> accuracy 54,6 % = taux de haussiers, sous le prédicteur constant
- Nuage prev vs réel : bande étroite autour de la moyenne = moyenne inconditionnelle
- Attention : 4 têtes redondantes, mêmes jours [17,16,36,37,35], poids ~4-5x uniforme
- Backtest = B&H à la 3e décimale (Sharpe 1,131, 0 trade, 415/415 jours) -> signal inopérant
- Écart Sharpe 1,022 (checkpoint) vs 1,131 (backtest) : **deux passes d'exécution documentées par les timestamps papermill** (07:47 vs 09:59) — noté honnêtement en prose, outputs non modifiés
- Déployable vs non-déployable (pipeline Cloud correct, signal de corr 0,02)
- Bilan quantifié final

## Preuves

- Densité : `pedagogy_density.py` -> `density: 1399, prose_chars: 26584, code_cells: 19, md_cells: 32, status: ok` (below_threshold: 0)
- Markdown-only : 19/19 cellules code byte-identiques (exec_count + source + outputs comparés HEAD vs worktree) ; 31/31 cellules markdown originales préservées comme préfixes ; 1 cellule purement nouvelle ; diff `execution_count`/`outputs` = 0 ligne
- Commit : 1 file changed, 61 insertions(+), 13 deletions(-) (deletions = re-wrap des dernières lignes des cellules étendues)

## Convention

- C.2 : modifs uniquement markdown -> outputs précédents valides (aucune re-exécution requise)
- Catalogue : non touché (byte-identique à main)
- See #11224 (tranche, l'epic reste ouverte)

See #11224

Co-Authored-By: Claude-Code <noreply@anthropic.com>