### PR TITLE
enrich(qc,#11224): densite pedagogique QC-Py-Cloud-01-FinBERT-Sentiment 1010->1605

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
@@ -215,7 +215,10 @@
     "\n",
     "Le score de sentiment est calcule comme `P(positive) - P(negative)` ou les\n",
     "probabilites proviennent du modèle FinBERT. Un score superieur a 0.2 declenche\n",
-    "un achat, inferieur a -0.2 une vente.\n"
+    "un achat, inferieur a -0.2 une vente.\n",
+    "\n",
+    "\n",
+    "**Lecture de la figure** : le panneau supérieur trace 120 barres de sentiment (vert > 0, rouge < 0) sur une échelle bornée à [-1, 1] par `np.clip` — le cumul de bruit gaussien est comprimé dès qu'il dépasse les bornes. Le panneau inférieur montre le prix issu de `returns = sentiment * 0.005 + noise`, avec un bruit de 0.01 : le coefficient 0.005 place le signal à la même échelle que la volatilité résiduelle, si bien que la liaison sentiment-prix est visible à l'œil sans être mécanique. Les deux axes partagent la même échelle de temps (120 jours, seed 42) : re-exécuter avec une autre seed conserve la structure du raisonnement mais change le dessin exact — c'est une simulation pédagogique, pas un backtest reproductible de marché réel."
    ]
   },
   {
@@ -359,7 +362,10 @@
     "le signal de trading.\n",
     "\n",
     "En pratique, l'algorithme aggrege les scores des N derniers articles (fenêtre\n",
-    "glissante) pour lisser le bruit et obtenir un signal plus stable.\n"
+    "glissante) pour lisser le bruit et obtenir un signal plus stable.\n",
+    "\n",
+    "\n",
+    "**Lecture du tableau committé** : cinq titres synthétiques couvrent le spectre — AAPL (+0.77) et AMZN (+0.47) haussiers, MSFT (-0.53) et NVDA (-0.70) baissiers, GOOGL (+0.25) plus nuancé avec une masse neutre à 0.55. La moyenne s'établit à +0.05, sous le seuil de 0.2 : le signal global est NEUTRE, illustrant le cas où les articles se compensent — cinq nouvelles ne suffisent pas à déclencher une position. On remarque aussi la somme des probabilités (0.82 + 0.05 + 0.13 = 1.00) et le fait que `score = pos - neg` ignore le poids de la classe neutre : un article à 80 % de neutralité et 10 %/10 % produirait un score nul, correct mais peu informatif."
    ]
   },
   {
@@ -767,7 +773,10 @@
     "\n",
     "**Fallback par mots-cles** : Si FinBERT n'est pas disponible (pas de GPU ou\n",
     "bibliotheque `transformers`), l'algorithme utilise un dictionnaire de mots-cles\n",
-    "comme alternative. Ce fallback permet au backtest de fonctionner même sans modèle ML.\n"
+    "comme alternative. Ce fallback permet au backtest de fonctionner même sans modèle ML.\n",
+    "\n",
+    "\n",
+    "**Ce que la vérification committée confirme** : 10 110 caractères pour 302 lignes de production, bornés par le marqueur `#region imports` en tête — le code est prêt pour QC Cloud tel quel. Trois choix d'ingénierie méritent l'attention. (1) `get_parameter` rend les trois hyperparamètres (univers, fenêtre, lookback) réglables depuis le backtest sans recompilation. (2) Le chargement du modèle est encapsulé dans un try/except : si `transformers` ou le GPU manque, `_keyword_sentiment` prend le relais avec un dictionnaire de 23 mots positifs et 23 négatifs — le backtest ne plante jamais faute de modèle. (3) L'ordre des logits FinBERT est documenté dans le code : positif(0), négatif(1), neutre(2) — inverser cet ordre transformerait silencieusement un achat en vente."
    ]
   },
   {
@@ -818,7 +827,10 @@
     "| 5. Résultats | `read_backtest` | `projectId`, `backtestId` |\n",
     "\n",
     "Ce workflow est exactement celui utilise par l'agent Claude Code pour deployer\n",
-    "et tester des stratégies QuantConnect automatiquement.\n"
+    "et tester des stratégies QuantConnect automatiquement.\n",
+    "\n",
+    "\n",
+    "**Pourquoi le déploiement est-il Cloud-native ?** Le modèle FinBERT (ProsusAI/finbert, ~110 M de paramètres) n'a pas à tourner sur la machine locale : QC Cloud fournit l'infrastructure, et le notebook orchestre le cycle projet → code → compilation → backtest → résultats via cinq appels MCP. Cette séparation donne un livrable de production — le fichier `main.py` déposé dans le projet — et un flux d'évaluation scriptable, celui-là même que les agents Claude Code utilisent pour tester les stratégies. Un point d'attention : `create_compile` est asynchrone, il faut lire `read_compile` jusqu'au statut terminal avant de lancer `create_backtest`."
    ]
   },
   {
@@ -940,7 +952,10 @@
     "**Limites connues** :\n",
     "- Le backtest utilise le fallback par mots-cles si FinBERT n'est pas disponible\n",
     "- Le sentiment des actualites peut etre déjà integre dans les prix a la reception\n",
-    "- L'univers est limite aux actions technologiques, reduisant la diversification\n"
+    "- L'univers est limite aux actions technologiques, reduisant la diversification\n",
+    "\n",
+    "\n",
+    "**Honnêteté des chiffres** : la cellule précédente affiche volontairement des métriques à `None` — c'est l'état de vérité tant que le backtest Cloud n'a pas tourné. Les valeurs Sharpe, CAGR, MaxDD et win rate qui apparaîtront après déploiement ne devront être lues qu'en comparaison d'un benchmark : un Sharpe de 1.1 sur 2019-2025 (marché haussier) est moins impressionnant qu'il n'y paraît face au buy & hold du même univers. Le win rate de 55 % annoncé comme « solide » doit lui aussi être jugé contre le taux de base de la stratégie — cette section est un cadre de lecture des résultats, pas une promesse de performance."
    ]
   },
   {
@@ -952,7 +967,10 @@
     "\n",
     "Utiliser le modèle FinBERT pour analyser le sentiment dun article financier.\n",
     "\n",
-    "**Indice** : Utilisez le pipeline HuggingFace avec le modèle FinBERT.\n"
+    "**Indice** : Utilisez le pipeline HuggingFace avec le modèle FinBERT.\n",
+    "\n",
+    "\n",
+    "**Critère de validation** : votre cellule doit afficher le score `P(positive) - P(negative)` pour au moins un article, sous forme de scalaire entre -1 et +1, et mentionner le label dominant. Pour vérifier la cohérence, testez un titre clairement haussier (« company beats expectations ») et un baissier (« company misses targets ») : les signes doivent être opposés."
    ]
   },
   {
@@ -978,7 +996,10 @@
     "\n",
     "Comparer les scores de sentiment de FinBERT avec TextBlob sur 10 phrases.\n",
     "\n",
-    "**Indice** : Chargez TextBlob et comparez les polarites.\n"
+    "**Indice** : Chargez TextBlob et comparez les polarites.\n",
+    "\n",
+    "\n",
+    "**Critère de validation** : pour chaque phrase, affichez côte à côte le score FinBERT et la polarité TextBlob, puis la corrélation des deux séries. Le résultat attendu est une corrélation positive mais imparfaite : TextBlob est lexical (le mot « loss » baisse la polarité) tandis que FinBERT saisit le contexte (« profit despite the loss » reste positif). Un écart de signe sur une phrase est une bonne matière à discussion."
    ]
   },
   {
@@ -1004,7 +1025,10 @@
     "\n",
     "Implementer une stratégie simple qui achete quand le sentiment est positif.\n",
     "\n",
-    "**Indice** : Utilisez un seuil de 0.5 pour le score de sentiment.\n"
+    "**Indice** : Utilisez un seuil de 0.5 pour le score de sentiment.\n",
+    "\n",
+    "\n",
+    "**Critère de validation** : sur la série de scores simulés de la Partie 1, votre stratégie doit afficher les jours d'achat (score > 0.5) et la valeur du portefeuille final. Comparez ce résultat au buy & hold de la même série : une stratégie à seuil 0.5 restera souvent en position, donc le backtest final peut légitimement s'écarter de la référence — c'est le compromis risque/rendement, pas un bug."
    ]
   },
   {
@@ -1119,6 +1143,26 @@
     "print('=' * 55)\n",
     "for row in summary:\n",
     "    print(f'  {row[0]:<25}: {row[1]}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f2c9a1db3c7",
+   "metadata": {
+    "papermill": {},
+    "tags": []
+   },
+   "source": [
+    "**Lecture du tableau récapitulatif** : les onze lignes committées ci-dessus ",
+    "fixent le contrat complet de la stratégie — concept, source de données ",
+    "(Tiingo), univers (top 10 tech par capitalisation), signal `P(pos) - P(neg)`, ",
+    "seuils symétriques +/- 0.2, fenêtre de 5 articles, rééquilibrage hebdomadaire, ",
+    "période 2019-2025, capital 100 000 USD. Deux paramètres sont à surveiller en ",
+    "priorité lors des expérimentations : la fenêtre d'agrégation (5 articles), ",
+    "qui règle le compromis réactivité/stabilité du signal, et le seuil de 0.2, ",
+    "qui détermine la fréquence des trades. Ce tableau est le point d'entrée du ",
+    "notebook pour un re-déploiement : chaque valeur est un paramètre modifiable ",
+    "via `get_parameter` dans l'algorithme."
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
@@ -1153,15 +1153,15 @@
     "tags": []
    },
    "source": [
-    "**Lecture du tableau récapitulatif** : les onze lignes committées ci-dessus ",
-    "fixent le contrat complet de la stratégie — concept, source de données ",
-    "(Tiingo), univers (top 10 tech par capitalisation), signal `P(pos) - P(neg)`, ",
-    "seuils symétriques +/- 0.2, fenêtre de 5 articles, rééquilibrage hebdomadaire, ",
-    "période 2019-2025, capital 100 000 USD. Deux paramètres sont à surveiller en ",
-    "priorité lors des expérimentations : la fenêtre d'agrégation (5 articles), ",
-    "qui règle le compromis réactivité/stabilité du signal, et le seuil de 0.2, ",
-    "qui détermine la fréquence des trades. Ce tableau est le point d'entrée du ",
-    "notebook pour un re-déploiement : chaque valeur est un paramètre modifiable ",
+    "**Lecture du tableau récapitulatif** : les onze lignes committées ci-dessus \n",
+    "fixent le contrat complet de la stratégie — concept, source de données \n",
+    "(Tiingo), univers (top 10 tech par capitalisation), signal `P(pos) - P(neg)`, \n",
+    "seuils symétriques +/- 0.2, fenêtre de 5 articles, rééquilibrage hebdomadaire, \n",
+    "période 2019-2025, capital 100 000 USD. Deux paramètres sont à surveiller en \n",
+    "priorité lors des expérimentations : la fenêtre d'agrégation (5 articles), \n",
+    "qui règle le compromis réactivité/stabilité du signal, et le seuil de 0.2, \n",
+    "qui détermine la fréquence des trades. Ce tableau est le point d'entrée du \n",
+    "notebook pour un re-déploiement : chaque valeur est un paramètre modifiable \n",
     "via `get_parameter` dans l'algorithme."
    ]
   }


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2023:CoursIA — prev: LIGHT/notebook-python #11326

## Summary

Tranche densité #11224 sur **QC-Py-Cloud-01-FinBERT-Sentiment.ipynb** — pire restant non-claimé du pool, re-mesuré firsthand sur origin/main frais (15edb22806).

- **Densité : 1010 → 1605** (seuil 1200, advisory — protocole #10488)
- **Markdown-only FR accentué** : 8 appends ancrés sur les outputs commités + 1 nouvelle cellule de lecture du tableau récapitulatif (16 md cells)
- **Zéro cellule code touchée** : 9/9 byte-identiques (assert script + `grep exec_count|outputs` = 0 diff) ; diff = 52 insertions / 8 deletions, uniquement prose

## Prose ajoutée (ancrée sur les outputs réels)

| Ancre | Output commité |
|---|---|
| Lecture de la figure (2 panneaux) | plot display_data image/png + text/plain (120 jours, seed 42, `returns = sentiment*0.005 + noise`) |
| Lecture du tableau de scoring | table 5 titres : +0.77 / -0.53 / +0.25 / -0.70 / +0.47, moyenne +0.05 → NEUTRE |
| Ce que la vérification confirme | `Algorithme QC FinBERT defini : 10110 caracteres, 302 lignes` |
| Pourquoi Cloud-native + honnêteté chiffres | résultats backtest volontairement à `None` (« En attente de deploiement Cloud ») |
| Critères de validation exercices 1-3 | stubs (aucun output — pédagogie, pas de fuite de solution) |

## Test plan

- `python scripts/notebook_tools/pedagogy_density.py <nb> --json` → density **1605** / status **ok**
- Assert post-surgery : `code_before == code_after` (9/9 code cells) ; `git diff | grep -c exec_count|outputs` = **0**
- JSON valide (json.load OK, 25 cellules)

See #11224 (tranche partielle de l'epic densité).