### PR TITLE
enrich(genai,#11271): densite CSharpRepl-Live-Patching 341->1239 (tranche markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb
@@ -27,6 +27,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "enr00plan",
+   "metadata": {},
+   "source": [
+    "**Plan de route.** Le notebook suit une progression en trois temps, et chaque section productrice de code se termine par une cellule de **lecture chiffree** qui interprete la sortie *reelle* observee :\n",
+    "\n",
+    "1. **Instrumenter** (sections 1-2) : lancer l'application avec le hook, l'identifier dans la liste des processus attachables, y evaluer une premiere expression ;\n",
+    "2. **Intervenir** (sections 3-5) : lire l'etat vivant, remplacer une methode ('#replace'), l'envelopper ('#wrap'), inventorier ('#patches'), tout annuler ('#revert') ;\n",
+    "3. **Deleguer** (section 6) : refaire la meme intervention en mode scripte — flux de commandes sur stdin, evaluation one-shot — la forme qu'un agent de programmation peut piloter seule.\n",
+    "\n",
+    "Les trois exercices terminaux reprennent chacun un mouvement de la demonstration (remplacer, envelopper, sonder) avec un critere de reussite mesurable dans le log de l'application.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1aa0de93",
    "metadata": {
     "papermill": {
@@ -52,6 +66,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "enr01b",
+   "metadata": {},
+   "source": [
+    "**Lecture de la table.** Les trois lignes ne comparent pas des equivalents approximatifs : chacune nomme une *frontiere de process* que Python ne franchit pas. `%autoreload` agit sur le module du **process courant** (celui du notebook) — les objets deja construits dans un *autre* process restent fideles a l'ancien code jusqu'a son arret. `pdb` transfere le *controle* (pas a pas) mais n'**evalue** pas une expression arbitraire dans le contexte du debuggue. Et l'ecosysteme Python n'a pas d'equivalent de `DOTNET_STARTUP_HOOKS` : un mecanisme runtime natif qui autorise du code a s'injecter au demarrage d'un process .NET quelconque. Toute la demonstration qui suit repose sur cette asymmetrie : cote .NET, la frontiere est franchissable *par conception*, avec l'outillage standard du SDK — pas par detournement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2e1136ab",
    "metadata": {
     "papermill": {
@@ -69,6 +91,14 @@
     "`csharprepl connect init` imprime les deux variables d'environnement qui activent le connecteur dans l'application cible. On les pose **dans le shell qui lance l'application** (jamais system-wide).\n",
     "\n",
     "Le programme de demonstration (`csharprepl-demo/`) est une application console qui boucle en imprimant le prix calcule par `OrderService.CalculatePrice(3, 10m)` toutes les 500 ms — exactement le genre de service qu'on ne veut pas arreter pour changer une regle de pricing.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr02c",
+   "metadata": {},
+   "source": [
+    "Pourquoi une application de **pricing** comme cible ? Parce que c'est le cas d'usage canonique du hot-patching : une regle metier (ici une remise, demain un taux, un seuil, une TVA) doit changer **sans interrompre le service**. Redemarrer un process qui boucle en 500 ms, c'est perdre les requetes en vol et l'etat interne (compteurs, caches chauds). Le scenario que le notebook va derouler — lire, patcher, envelopper, annuler, scripter — est exactement la checklist d'un incident de production ou l'on veut *corriger d'abord, comprendre ensuite*, sans fenetre de maintenance.\n"
    ]
   },
   {
@@ -101,7 +131,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -111,10 +140,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -129,7 +155,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -141,8 +166,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -191,13 +214,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -297,6 +318,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "enr03d",
+   "metadata": {},
+   "source": [
+    "**Lecture du socle.** Trois details de conception qui servent toute la suite :\n",
+    "\n",
+    "1. **Persistance d'etat** : .NET Interactive garde les variables de haut niveau (`_app`, `_appLog`, `_pid`, `_replExe`) d'une cellule a l'autre — chaque cellule du notebook reapplique ses definitions mais l'etat deja construit survit. C'est ce qui permet de lancer l'application en section 1 et de la *retrouver vivante* en section 6.\n",
+    "2. **`FindReplExe` version-agnostique** : le binaire est resolu dans `~/.dotnet/tools/.store/csharprepl/<version>/...` par enumeration, pas par chemin hardcode — une montee de version du tool ne casse pas le notebook (et il echoue avec un message explicite si le tool n'est pas installe).\n",
+    "3. **`Run` capture stdout+stderr concatene** : le REPL ecrit ses resultats sur stdout mais ses diagnostics sur stderr ; les concatener evite de perdre la moitie des messages d'erreur pendant le debug.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 2,
    "id": "3ba6e41a",
@@ -339,6 +372,19 @@
     "var hosting = ParseEnvLine(initOut, \"ASPNETCORE_HOSTINGSTARTUPASSEMBLIES\");\n",
     "Console.WriteLine($\"hook     : {Path.GetFileName(hook)}\");\n",
     "Console.WriteLine($\"hosting  : {hosting}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr04a",
+   "metadata": {},
+   "source": [
+    "**Lecture.** `connect init` ne connecte rien : il **imprime la configuration**. Les deux variables documentees par la sortie :\n",
+    "\n",
+    "- `DOTNET_STARTUP_HOOKS = ...CSharpRepl.InjectedHook.dll` — le runtime .NET execute cette DLL **au demarrage de tout process** qui herite de la variable. Le hook installe dans le process cible l'ecouteur qui acceptera les connexions du REPL.\n",
+    "- `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES = CSharpRepl.InjectedHook` — l'equivalent pour un hote ASP.NET Core, ou la sequence de demarrage passe par `IHostingStartup`.\n",
+    "\n",
+    "Le point important : on ne patch **pas** un process pour l'attachabilite — on la lui donne **a sa naissance**, via son environnement. C'est pourquoi la cellule suivante lance l'application *apres* avoir pose ces variables sur son `ProcessStartInfo` uniquement (jamais system-wide : un hook global rendrait tout process .NET de la machine attachable).\n"
    ]
   },
   {
@@ -399,6 +445,18 @@
     "    Thread.Sleep(200);\n",
     "}\n",
     "Console.WriteLine($\"Application demarree, PID={_pid}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr05b",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Plusieurs choses se jouent dans cette cellule :\n",
+    "\n",
+    "- La ligne attendue est `PID=...` : c'est le **handshake** que l'application de demonstration imprime quand son service est pret. Tout ce qui precede dans le log, c'est le `dotnet run` qui **compile** d'abord (d'ou la generous timeout de 90 s, pas un caprice : un build a froid Roslyn peut etre lent).\n",
+    "- La capture utilise `BeginOutputReadLine` + un event handler qui alimente `_appLog` sous `lock` — **pas** un `ReadToEnd()` bloquant : l'application ne s'arrete jamais de son vivant, un read synchrone ne rendrait jamais la main a la cellule.\n",
+    "- `_appLog` devient le **tampon d'observation** du notebook : toutes les sections suivantes qui \"regardent\" l'application vivante le font en relisant ce log, pas en redirigeant une deuxieme fois le flux.\n"
    ]
   },
   {
@@ -464,6 +522,20 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "enr07d",
+   "metadata": {},
+   "source": [
+    "**Lecture de la sortie.** La table liste **trois** processus attachables, et seulement le troisieme est notre cible :\n",
+    "\n",
+    "- `12216 dotnet` — un hote generique (souvent le build daemon ou un autre runtime) ;\n",
+    "- `24996 VBCSCompiler` — le **compiler server Roslyn**, partage entre les builds de la machine. Il est attachable parce qu'il a herite du hook, mais le patcher n'aurait aucun sens (et serait une excellente facon de corrompre ses propres compilations) ;\n",
+    "- `46292 LiveOrderApp` — l'application de demonstration, PID identique a celui capte au handshake de la section 1 : la correspondance nom/PID est la verification que l'on attaque le bon process.\n",
+    "\n",
+    "Cette selection est une vraie competence operatoire : sur une machine de dev chargee, `connect list` peut montrer dix processus, et `#replace` applique au mauvais est un incident. Toujours croiser le PID.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 5,
    "id": "583b0c8d",
@@ -497,6 +569,14 @@
     "// 2b. Evaluer DANS le process vivant : appeler la methode du service\n",
     "// (le process n'est ni arrete ni redemarre)\n",
     "Console.WriteLine(Repl($\"connect {_pid} -e \\\"LiveOrderApp.OrderService.CalculatePrice(5, 7m)\\\"\"));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr08a",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Le resultat `35` est la premiere preuve materiale de l'attach : l'expression `CalculatePrice(5, 7m)` a ete evaluee **dans le process vivant** — c'est la methode reelle du service, celle que l'application appelle en boucle, avec son JIT, ses statiques, son etat. Contre-preuve immediate : ce resultat n'existe nulle part dans le notebook avant l'evaluation (aucune reimplementation, aucun mock). La convention observee dans la suite : une expression **sans point-virgule** fait imprimer sa valeur par le REPL ; avec point-virgule, c'est une instruction — silence. C'est l'equivalent exact de la difference statement/expression dans un REPL Python.\n"
    ]
   },
   {
@@ -555,6 +635,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "enr10c",
+   "metadata": {},
+   "source": [
+    "**Lecture.** `ComputeCount` vaut `8` : le service a execute huit calculs depuis son demarrage. C'est un **statique vivant**, pas une copie serializee — si on re-evaluait cette expression dans 1,5 s, le compteur aurait monte (l'application boucle en 500 ms : environ +3 par cycle et demi). C'est la difference entre *inspecter* (snapshot au debugger, process gele) et **sonder** (lecture non intrusive, process a pleine vitesse). La cellule exercice 3 fera exactement cette mesure differentielle — preuve que la lecture reflete un process qui vit, pas une photo.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "20a29be1",
    "metadata": {
     "papermill": {
@@ -570,6 +658,20 @@
     "## 4. Patcher une methode a chaud (`#replace`)\n",
     "\n",
     "On definit d'abord une **methode de remplacement** (meme signature que la cible), puis `#replace` l'applique au process **immediatement**. L'application continue de tourner — et son comportement change.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr11d",
+   "metadata": {},
+   "source": [
+    "**Semantique de `#replace`.** Trois etapes separees, dans cet ordre, et c'est important :\n",
+    "\n",
+    "1. **definir** la methode de remplacement dans le contexte du REPL attache (elle n'existe que la — aucune recompilation de l'application) ;\n",
+    "2. **brancher** via `#replace Cible with remplacement` ;\n",
+    "3. **observer** cote application (le log), pas cote REPL.\n",
+    "\n",
+    "Le remplacement doit matcher la **signature** de la cible (`int, decimal -> decimal` ici). Sous le capot, la reecriture de methode est portee par MonoMod ; le message de confirmation de la cellule suivante est le contrat operationnel : il nomme la methode patchee, sa signature complete et le numero de patch — a garder dans un incident, c'est l'equivalent d'un receipt.\n"
    ]
   },
   {
@@ -643,6 +745,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "enr13b",
+   "metadata": {},
+   "source": [
+    "**Lecture.** Le message `patched static Decimal ... (patch #1)` confirme trois choses d'un coup : la cible exacte (methode **statique** `CalculatePrice` sur `OrderService`, signatures `Int32, Decimal -> Decimal`), la source du remplacement (`salePrice`), et le fait que c'est le **premier** patch de la session. Le process n'a pas redemarre — le compteur `ComputeCount` continue de monter pendant ce temps. Reste a voir si le *comportement observable* de l'application a reellement change : c'est la cellule suivante, et c'est elle qui fait la demonstration.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 9,
    "id": "06a0cf35",
@@ -681,6 +791,20 @@
     "    var tail = _appLog.Where(l => l.Contains(\"price=\")).TakeLast(3);\n",
     "    Console.WriteLine(string.Join(Environment.NewLine, tail));\n",
     "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr14c",
+   "metadata": {},
+   "source": [
+    "**Le moment cle de la demonstration.** L'application imprime maintenant `price=24,0` — alors qu'elle imprimait `price=30` (3 x 10) depuis son demarrage. Lecture chiffree :\n",
+    "\n",
+    "- `24,0 = 3 x 10 x 0,8` — la remise de 20% de `salePrice` s'applique **aux commandes en cours de traitement**, pas a une reexecution isolee ;\n",
+    "- les index `[11] [12] [13]` sont consecutifs : **aucune commande n'a ete perdue** pendant le patch, la boucle de 500 ms n'a jamais ete interrompue ;\n",
+    "- la virgule decimale (`24,0` et non `24.0`) : l'application formate selon la culture courante du process — detail qui rappelle qu'on observe le vrai process, avec sa configuration regionale, pas un resultat reconstitue.\n",
+    "\n",
+    "Une regle metier vient d'etre changee sur un service en production de demonstration, sans arret, sans redemarrage, sans recompilation. Tout le reste du notebook est une variation sur ce theme.\n"
    ]
   },
   {
@@ -738,6 +862,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "enr16a",
+   "metadata": {},
+   "source": [
+    "**Lecture de l'echappement.** La ligne du wrapper parait criblee de `\\\"` : la commande transite par **trois** couches de parsing — la string C# du notebook, puis `CommandLineToArgvW` cote argv Windows, puis le parseur du REPL cible. Les `\\\"` produisent des quotes **litterales** dans l'argv recu par le process, ou le corps du wrapper doit rester une expression unique. C'est la friction classique du meta-programmation par ligne de commande ; en mode scripte (section 6), `--eval-file` l'elimine en passant par un fichier.\n",
+    "\n",
+    "Le pattern du wrapper lui-meme : le delegate `orig` en **premier parametre** recoit la methode originale (eventuellement deja patchee — voir la pile ci-dessous) ; le wrapper decide de l'appeler, du transformer, du court-circuiter. C'est un decorator runtime, sans AOP compile-time.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "6403c448",
@@ -770,6 +904,14 @@
    "source": [
     "// 5b. Appliquer le wrap\n",
     "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#wrap LiveOrderApp.OrderService.CalculatePrice with logged\\\"\"));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr17b",
+   "metadata": {},
+   "source": [
+    "**Lecture.** `patch #2` s'empile **au-dessus** du `#1` : la pile d'appel devient desormais `logged -> salePrice -> corps original`. Le message confirme que la cible est toujours la meme methode `CalculatePrice` — on peut empiler plusieurs patches sur une seule cible, chaque `#wrap` enveloppant l'etat courant. Ordre d'application = ordre de la pile (dernier wrap = couche externe). C'est ce que l'inventaire de la cellule suivante rend visible et auditable.\n"
    ]
   },
   {
@@ -809,6 +951,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "enr18c",
+   "metadata": {},
+   "source": [
+    "**Lecture.** `#patches` est l'**inventaire auditable** de la session : deux entrees, `#1 [Replace]` puis `#2 [Wrap]`, meme cible, sources distinctes. En intervention sur un process vivant, ce listing est le reflexe d'hygiene : avant de diagnostiquer un comportement etonnant, lister les patches actifs — un `#wrap` oublie d'une session precedente explique beaucoup de \"bugs\" inexplicables. La cellule suivante nettoie tout et verifie le retour a l'original.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 13,
    "id": "b3449a07",
@@ -841,6 +991,14 @@
    "source": [
     "// 5d. Annuler tous les patches -> l'application revient au comportement original\n",
     "Console.WriteLine(Repl($\"connect {_pid} -e \\\"#revert all\\\"\"));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr19d",
+   "metadata": {},
+   "source": [
+    "**Lecture.** `reverted 2 patch(es)` : la pile est defaite et l'application revient a son comportement **d'origine** — le log remontrerait `price=30` au prochain cycle. La reversibilite est symetrique de l'application : ce qui a ete patche a chaud peut etre *depatche* a chaud, sans arret. C'est ce qui distingue un outil d'intervention d'une manipulation irreversible : en cas de doute sur un patch, `#revert all` est toujours disponible, et le process n'a jamais quitte son etat de marche. Un protocole d'intervention honnete se termine toujours par un retour a l'etat nominal verifie.\n"
    ]
   },
   {
@@ -904,6 +1062,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "enr21b",
+   "metadata": {},
+   "source": [
+    "**Lecture du mode pipe.** Deux differences structurelles avec les sections 4-5 :\n",
+    "\n",
+    "- **Une seule session REPL** recoit **deux commandes** sur stdin : le `#replace` **puis** l'expression d'evaluation, executees en sequence dans le meme flux. Avant, chaque cellule ouvrait son propre `connect`, executait une commande, fermait. Ici le canal est un tube — aucun terminal, aucune invite, aucune interaction humaine.\n",
+    "- **La lambda inline** `(int q, decimal u) => q * u * 0.85m` remplace la definition prealable de `salePrice` : le remplacement peut etre anonyme. Et le piege documente en commentaire : **pas de point-virgule final** sur la lambda en mode pipe — le parseur rejette l'instruction-expression (CS0201), l'expression nue passe.\n",
+    "\n",
+    "La sortie combine le receipt du patch (`patch #3`) **et** le resultat de l'evaluation (`85.00` = 20 x 5 x 0,85) — preuve en un seul flux que le patch est applique ET mesurable.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 15,
    "id": "5fe3cf0a",
@@ -945,6 +1116,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "enr22c",
+   "metadata": {},
+   "source": [
+    "**Lecture.** `price=25,50 = 3 x 10 x 0,85` : l'application vivante confirme le troisieme comportement de la session (30 -> 24,0 -> 25,50), toujours **sans interruption** — les index `[19] [20] [21]` continuent la sequence du log, ils ne repartent pas de zero. La continuite des index est la preuve que le process n'a jamais redemarre. Cette cellule est la verification que le mode scripte ne fait pas que \"reussir ses commandes\" : il **change le comportement reel** de l'application, exactement comme le mode interactif — mais sans humain au clavier.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
    "id": "45ca30a1",
@@ -981,6 +1160,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "enr23d",
+   "metadata": {},
+   "source": [
+    "**Lecture.** `--eval` est la **primitive one-shot** : une expression, un resultat sur stdout (`17.00` = 10 x 2 x 0,85), sortie propre du REPL. C'est le format qu'un agent de programmation consomme : sans invite, sans session a maintenir, le resultat est parsable sur la sortie standard. Compose avec les commandes de patch, cela forme un protocole complet adressable a une machine : *sonder* (`--eval` sur un statique), *decider* (comparer a l'attendu), *corriger* (`#replace`), *verifier* (re-sonder). La citation de l'article Part 2 dans l'intro de la section decrit exactement cette delegation — la cellule qui suit en est l'implementation jouee.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7b22e8a7",
    "metadata": {
     "papermill": {
@@ -998,6 +1185,19 @@
     "L'application `LiveOrderApp` calcule `price = quantity * unitPrice` (TVA incluse a 20%). Ajoutez une methode `withVat` qui applique 20% de TVA en plus, puis `#replace` `OrderService.CalculatePrice`. L'application doit commencer a imprimer `price=36` (3 × 10 × 1,2) au lieu de `price=30`.\n",
     "\n",
     "**Indice** : reprenez exactement le pattern de la section 4 (methode de meme signature, puis `#replace`).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr24a",
+   "metadata": {},
+   "source": [
+    "**Etapes conseillees et critere de reussite.**\n",
+    "\n",
+    "1. Definir `withVat` par une expression de meme signature que `CalculatePrice` : `decimal withVat(int q, decimal u) => ...` — la TVA de 20% se pose sur le resultat brut, pensez `q * u * 1.2m`.\n",
+    "2. Appliquer `#replace LiveOrderApp.OrderService.CalculatePrice with withVat` (pattern exact de la cellule 4b, prefixe par `connect {_pid} -e`).\n",
+    "3. **Critere de reussite, mesurable dans le log** : les lignes `price=` passent de `30` a **`36`** (3 x 10 x 1,2). Si le REPL repond par une erreur de signature, relisez les types — `decimal` des deux cotes, pas `double`.\n",
+    "4. Terminez proprement par `#revert all` pour ne pas polluer l'exercice suivant (le patch precedent reste sinon empile).\n"
    ]
   },
   {
@@ -1059,6 +1259,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "enr26c",
+   "metadata": {},
+   "source": [
+    "**Etapes conseillees et critere de reussite.**\n",
+    "\n",
+    "1. Definir le wrapper avec `orig` en premier parametre — pattern exact de la cellule 5a, echappement `\\\"` compris si vous passez par `-e`.\n",
+    "2. Attention a la **destination du journal** : le `WriteLine` du wrapper s'execute *dans le process cible* — il arrive sur **le stdout de l'application**, donc dans `_appLog` (visible par le meme `TakeLast` que les cellules 4c/6b), pas dans la sortie du notebook.\n",
+    "3. Appliquer `#wrap ... with logged`, puis `#patches` : le critere de reussite est double — l'inventaire affiche votre `[Wrap]` **et** le log de l'application melange desormais lignes `repl-log: ...` et lignes `price=...` a chaque cycle.\n",
+    "4. Le wrapper doit **toujours** rendre `orig(q, u)` sans le modifier : on journalise, on ne change pas le resultat (difference fondamentale avec l'exercice 1).\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 18,
    "id": "f9c84d3b",
@@ -1113,6 +1326,19 @@
     "La liste `connect list` peut montrer plusieurs processus attachables (par ex. le kernel .NET Interactive lui-meme). Ecrivez un snippet qui : (1) liste les processus, (2) s'attache a celui de `LiveOrderApp`, (3) lit le compteur statique `OrderService.ComputeCount` a deux instants distants de 1,5 s pour constater qu'il augmente — preuve que le process vit et que le REPL lit son etat reel.\n",
     "\n",
     "**Indice** : `connect <pid> -e \"...\"` retourne le resultat de l'expression (sans point-virgule).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "enr28a",
+   "metadata": {},
+   "source": [
+    "**Etapes conseillees et critere de reussite.**\n",
+    "\n",
+    "1. `connect list` pour l'inventaire ; reperer la ligne `LiveOrderApp` et **croiser son PID** avec `_pid` (le tableau peut aussi montrer le kernel .NET Interactive et `VBCSCompiler` — pas des cibles).\n",
+    "2. Deux lectures de `OrderService.ComputeCount` espacees d'un `Thread.Sleep(1500)` — le squelette commente dans la cellule est directement utilisable, il ne manque que le `Trim()` sur la seconde lecture et la mise en forme finale.\n",
+    "3. **Critere de reussite, chiffre** : a 500 ms par cycle, 1 500 ms d'ecart doivent donner un delta d'**environ +3** (intervalle credible 2-4 selon la charge). Un delta nul signifie que vous avez lu un process gele ou une string vide non paree ; un compteur identique deux fois de suite est un signal d'erreur, pas de stabilite.\n",
+    "4. Ce type de mesure differentielle est la maniere canonique de prouver qu'une lecture remote reflete un **etat vivant** — meme principe qu'un healthcheck par deltas, pas par snapshots.\n"
    ]
   },
   {
@@ -1209,6 +1435,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "enr31d",
+   "metadata": {},
+   "source": [
+    "**Lecture.** `Kill(entireProcessTree: true)` termine le process **et ses enfants** — un `dotnet run` a une topologie d'arbre (le runner invoque le binaire compile), tuer seulement le parent laisserait un orphelin qui continuerait d'imprimer. Le REPL attache n'a pas besoin de detach explicite : sa session meurt avec le process cible. Le nettoyage final du protocole : patchs revertes (5d), application arretee, aucun artefact ne survit a la demonstration — l'hygiene de fin compte autant que la demonstration elle-meme.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9952cfde",
    "metadata": {
     "papermill": {
@@ -1225,7 +1459,22 @@
     "\n",
     "C'est la ligne « Introspection d'un process vivant » de la table de parite de l'Epic **#10473** : ce que `%autoreload` / `pdb` ne font pas cote Python, le REPL attache le fait nativement cote .NET — la verification et la modification se font **dans** le process, pas en post-processing, et peuvent etre **scriptees** (`--eval` / `--eval-file`), pas seulement tapees a la main.\n",
     "\n",
-    "*Rappel securite* : `csharprepl connect` equivaut a executer du code arbitraire dans le process cible, avec ses privileges. Outil de developpement et de diagnostic — jamais sur un process de production."
+    "*Rappel securite* : `csharprepl connect` equivaut a executer du code arbitraire dans le process cible, avec ses privileges. Outil de developpement et de diagnostic — jamais sur un process de production.\n",
+    "**Aide-memoire des commandes.**\n",
+    "\n",
+    "| Commande | Role | Section |\n",
+    "|---|---|---|\n",
+    "| `connect init` | Imprimer les variables d'environnement du hook | 1 |\n",
+    "| `connect list` | Lister les processus attachables (croiser le PID) | 2 |\n",
+    "| `connect <pid> -e \"<expr>\"` | Evaluer une expression dans le process vivant | 2-6 |\n",
+    "| `#replace Cible with remplacement` | Remplacer une methode a chaud | 4 |\n",
+    "| `#wrap Cible with wrapper` | Envelopper (`orig` en premier parametre) | 5 |\n",
+    "| `#patches` | Inventaire auditable des patches actifs | 5 |\n",
+    "| `#revert all` | Tout annuler, retour au comportement original | 5 |\n",
+    "| `connect <pid> --streamPipedInput` | Mode scripte : flux de commandes sur stdin | 6 |\n",
+    "| `connect <pid> --eval \"<expr>\"` | Evaluation one-shot, resultat sur stdout | 6 |\n",
+    "\n",
+    "**Limites honnetes.** Le hot-patching ne remplace pas un deploiement : les patches vivent dans le process et **meurent avec lui** — au redemarrage, l'application recharge son code compile d'origine. C'est un outil d'**intervention** (diagnostic, attenuation temporaire, experimentation) qui comble la fenetre entre l'identification d'un probleme et son fix deploye, pas un mecanisme de livraison. Et chaque pouvoir liste ici a son symetrique en risque : ce qui patche une remise peut patcher une authentification — d'ou le rappel securite qui suit.\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary

Tranche #11271 (densité pédagogique GenAI, pattern #10488) : **pire débiteur de toute la famille** — `GenAI/Vibe-Coding/docs/CSharpRepl-Live-Patching.ipynb` (re-mesuré firsthand sur origin/main frais `15edb2280`, instrument canonique `scripts/notebook_tools/pedagogy_density.py`).

| Métrique | Avant | Après |
|---|---|---|
| Densité (prose/code cell) | **341** | **1239** (status ok ≥ 1200) |
| prose_chars | 6 820 | 24 794 |
| Cellules | 33 (13 md / 20 code) | 56 (36 md / 20 code) |

## Contenu ajouté (23 cellules markdown, 0 code touchée)

- **Plan de route** après l'intro : progression Instrumenter → Intervenir → Déléguer, convention des lectures chiffrées.
- **Lectures chiffrées ancrées sur les outputs réels** après chaque cellule code : les deux variables du hook (`DOTNET_STARTUP_HOOKS` / `ASPNETCORE_HOSTINGSTARTUPASSEMBLIES`), le handshake `PID=46292` (90 s = build Roslyn), la sélection dans `connect list` (pourquoi `VBCSCompiler` n'est PAS une cible), l'évaluation in-process `35`, le compteur vivant `ComputeCount=8`, l'empilement des patches `#1 [Replace]` → `#2 [Wrap]` (logged → salePrice → original), le moment clé `price=24,0` (30→24,0 = ×0,8, indices consécutifs = zéro commande perdue, virgule décimale = culture du process), le mode pipe `patch #3` + `85.00` (piège CS0201 point-virgule), `price=25,50` (continuité des indices [19]-[21]), `--eval` = `17.00` primitive agent one-shot.
- **Pourquoi c'est non-trivial** : lecture de la table de parité (frontière de process que `%autoreload`/`pdb` ne franchissent pas) + pourquoi une app de pricing comme cible canonique.
- **Exercices 1-3** : étapes numérotées + critères de réussite **mesurables dans le log** (price=36 = 3×10×1,2 ; `repl-log:` dans `_appLog` car le WriteLine du wrapper s'exécute DANS le process cible ; delta ComputeCount ≈ +3 sur 1,5 s). Stubs code intacts (C.1).
- **Conclusion** (append-only) : aide-memoire des 9 commandes (tableau) + **limites honnêtes** (les patches meurent avec le process — outil d'intervention, pas mécanisme de livraison).

## Preuves

- `validate_pr_notebooks.py` : **PASS** (20/20 code cells, kernel `.net-csharp`).
- Cellules code **byte-identiques** : vérifié par comparaison JSON cell-by-cell (`codesig` assert dans le script d'enrichissement) + subsequence check (33 cellules originales toutes préservées dans l'ordre, 1 modifiée = conclusion append-only, 0 LOST).
- Diff : `+260/−11` ; les 11 délétions = normalisation de la dernière ligne de la conclusion (ajout `\n` final) + lignes d'espaces de fermeture. **0** ligne `source`/`outputs`/`execution_count` supprimée (C.3 : modifs uniquement markdown → outputs précédents valides, aucune re-exécution requise).
- Pre-commit : gitleaks, H.3 (execution_count/outputs), scrub papermill — tous Passed.
- File CI mesurée avant ouverture : 0 queued + 1 in_progress (< 200).
- Zéro collision : aucune PR ouverte ne touche `GenAI/Vibe-Coding` (fichiers des PRs ouvertes passés en revue) ; claim Aspire = lane CoursIA-2 (disjoint). `[CLAIMED]` posé : issuecomment-5309577517.

See #11271 (1 des 90 débiteurs ; pire de la famille réglé). Pas de `Closes` — epic en cours.

Grain: MED/notebook-dotnet — lane myia-po-2026:CoursIA — prev: DEEP/proof #11325

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>