### PR TITLE
feat(genai,#11271): densite Image 03-3-Performance-Optimization 551->1291 (tranche markdown-only, lectures ancrees outputs)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb
@@ -249,7 +249,9 @@
     "tags": []
    },
    "source": [
-    "Les imports GPU chargent PyTorch et les outils de profilage mémoire. La disponibilité CUDA est vérifiée immédiatement : en l'absence de GPU, les optimisations seront simulées pour permettre l'exécution pédagogique du notebook sur CPU."
+    "Les imports GPU chargent PyTorch et les outils de profilage mémoire. La sortie de cette cellule fait le **diagnostic matériel** sur lequel tout le notebook s'appuie : **GPU 0 = NVIDIA GeForce RTX 3090 (24.0 GB)**, GPU 1 = RTX 3080 Ti Laptop (16.0 GB) — une machine bi-GPU. La cellule suivante confirmera l'état mémoire initial : 0.0 MB alloué, 0.0 MB réservé, **24 575.5 MB libres estimés**.\n",
+    "\n",
+    "**Pourquoi ce diagnostic vient avant toute optimisation** : chaque technique des sections suivantes a un profil d'adéquation matériel différent. Le FP16/BF16 n'accélère que sur des cœurs tensoriels (Ampere et au-delà : la 3090 en a, la 3080 Ti Laptop aussi) ; `flash_attention_2` exige Ampere+ ; le batching est borné par la VRAM libre. Connaître la carte (24 GB, Ampere) permet de prédire, avant de mesurer, que les profils « High VRAM » de la Section 7 seront recommandés — et de comprendre pourquoi le même notebook sur un GPU 8 GB orienterait vers « Low VRAM » + offloading séquentiel. Le matériel décide de la recette ; les mesures valident ensuite."
    ]
   },
   {
@@ -330,7 +332,9 @@
     "tags": []
    },
    "source": [
-    "Les structures de données de profilage encapsulent les métriques GPU. `PerformanceMetrics` agrège VRAM utilisée, temps de génération et débit, tandis que `GPUProfiler` interroge `torch.cuda` pour obtenir les mesures en temps réel."
+    "Les structures de données de profilage (`@dataclass PerfMetrics`, `GPUProfiler`) encapsulent les métriques GPU. Le design est volontairement minimal : chaque mesure porte son temps d'exécution (ms), sa mémoire peak (MB), son timestamp — et le `GPUProfiler` historise ces mesures dans `metrics_history`, ce qui permettra à la cellule de finalisation de calculer la moyenne de session sur **tous les tests exécutés**.\n",
+    "\n",
+    "**Lecture d'architecture** : séparer la *capture* (dataclass passive) de l'*accumulation* (profiler) est ce qui rend les comparaisons honnêtes. Quand la Section 8 affichera « Baseline 303.3 ms vs FP16 127.9 ms », ces deux nombres auront été produits par le même instrument, avec la même granularité — pas par deux `time.time()` improvisés dans deux cellules différentes. En optimisation, la méthodologie de mesure est aussi importante que la technique mesurée : un speedup mesuré avec des horloges différentes n'est pas un speedup."
    ]
   },
   {
@@ -545,6 +549,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture de l'état mémoire initial** — le point zéro avant tout chargement : 0.0 MB alloués, 0.0 MB réservés, **24 575.5 MB libres estimés** sur les 24 576 MB de la carte (une fraction étant réservée par le pilote).\n",
+    "\n",
+    "La distinction alloué/réservé compte pour la suite : PyTorch **réserve** de la VRAM par blocs (cache d'allocations CUDA) et « alloue » dedans à la demande — c'est pourquoi la mémoire allouée peut redescendre à 0 après un `del` alors que la mémoire **réservée** reste détenue (d'où `torch.cuda.empty_cache()` dans les notebooks de génération). Ce solde de départ — 24 GB vierges — est ce qui autorisera, en Section 5, un batch size estimé de 8 : la marge mémoire n'est pas un luxe, c'est la ressource que les sections suivantes dépensent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "89h7docscua",
    "metadata": {
     "papermill": {
@@ -557,7 +571,9 @@
     "tags": []
    },
    "source": [
-    "La simulation de la baseline mesure les performances sans aucune optimisation. Ces métriques de référence (VRAM, temps de génération, débit) serviront de point de comparaison pour quantifier l'apport de chaque technique d'optimisation."
+    "La simulation de la baseline mesure les performances **sans aucune optimisation** : alloue le tenseur de ~1000 MB, simule ~500 ms de compute, profile le tout. Le résultat de référence qui sort de cette cellule : **841.3 ms** d'exécution, **1500.0 MB** de mémoire peak. C'est le zéro de l'échelle — la cellule suivante en tire la lecture complète.\n",
+    "\n",
+    "**Pourquoi une simulation plutôt qu'un vrai pipeline Stable Diffusion** : la simulation isole la *mécanique de mesure* du *bruit des poids réels*. Un vrai UNet charge des gigaoctets, compilent des kernels, chauffe le GPU — autant de facteurs qui feraient varier la baseline de run en run et pollueraient les ratios. Ici la baseline est déterministe, donc chaque speedup mesuré ensuite est attribuable à la technique d'optimisation seule. La contrepartie : les chiffres absolus (841 ms) ne sont pas ceux d'une génération réelle — ils sont un **terrain d'essai calibré** pour comparer des techniques entre elles."
    ]
   },
   {
@@ -680,9 +696,7 @@
    "source": [
     "## 3. Optimisations Mémoire\n",
     "\n",
-    "### 3.1 Précision Réduite (FP16/BF16)\n",
-    "\n",
-    "La réduction de précision est l'optimisation la plus simple et efficace."
+    "Cette section attaque le premier des deux axes d'optimisation : **la VRAM**. Trois leviers, du moins invasif au plus agressif : la **précision réduite** (FP16/BF16 — divise l'empreinte par 2, aucune perte perceptible), la **quantification** (INT8/INT4 — jusqu'à ×8 sur la mémoire, au prix d'un plafond de qualité), et l'**offloading CPU** (déplacer des modules vers la RAM système — de la VRAM au prix du temps de transfert). L'ordre de cette section est aussi l'ordre d'engagement recommandé : on active d'abord ce qui ne coûte rien en qualité, on ne descend d'un cran que si la carte ne tient pas."
    ]
   },
   {
@@ -778,19 +792,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "w1pn9c95k5m",
-   "metadata": {
-    "papermill": {
-     "duration": 0.011297,
-     "end_time": "2026-05-12T10:01:13.140608",
-     "exception": false,
-     "start_time": "2026-05-12T10:01:13.129311",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "id": "",
+   "metadata": {},
    "source": [
-    "Le `PrecisionManager` gère la conversion entre FP32, FP16 et BF16 et mesure l'économie VRAM obtenue. BF16 est préféré sur les GPU Ampere (A100, RTX 30xx) pour sa meilleure stabilité numérique par rapport à FP16."
+    "**Lecture de la recommandation** — la détection conclut en une ligne : « Support BF16 : ✅ Oui — Précision recommandée : BF16 ». C'est le critère **matériel** qui parle : BF16 exige des cœurs Ampere+ pour être calculé nativement (sinon il émule en software, dramatiquement plus lent — le test pratique de la section suivante le montrera indirectement). La recommandation BF16 plutôt que FP16, à économie mémoire égale (2000 MB chacun), repose sur la robustesse de dynamique : BF16 tolère les grandes amplitudes d'activations de la diffusion sans loss scaling. Le tableau comparatif au-dessus donne les chiffres ; cette ligne en tire le verdict pour CETTE carte."
    ]
   },
   {
@@ -853,19 +858,21 @@
   },
   {
    "cell_type": "markdown",
-   "id": "gpfanz45wja",
+   "id": "w1pn9c95k5m",
    "metadata": {
     "papermill": {
-     "duration": 0.011342,
-     "end_time": "2026-05-12T10:01:13.198045",
+     "duration": 0.011297,
+     "end_time": "2026-05-12T10:01:13.140608",
      "exception": false,
-     "start_time": "2026-05-12T10:01:13.186703",
+     "start_time": "2026-05-12T10:01:13.129311",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "L'activation de la précision réduite est appliquée au pipeline de diffusion. L'économie mémoire mesurée et l'impact sur la qualité visuelle sont enregistrés pour comparaison dans la section de benchmarking finale."
+    "Le `PrecisionManager` gère la conversion entre FP32, FP16 et BF16 et mesure l'impact mémoire de chaque choix. La sortie de la comparaison donne le tableau de référence : **FP32 = 4000 MB** (économies 0 %), **FP16 = 2000 MB** (50 %), **BF16 = 2000 MB** (50 %) — et la détection matérielle conclut « Support BF16 : ✅ Oui — Précision recommandée : BF16 ».\n",
+    "\n",
+    "**Pourquoi FP16 et BF16 font la même économie mémoire** : les deux encodent les nombres sur 16 bits (1 bit de signe, 8 bits d'exposant pour BF16 contre 5 pour FP16, mantisse réduite en conséquence). La VRAM économisée est identique — la différence est dans la **dynamique** : BF16 garde l'exposant large du FP32, donc tolère de grandes variations d'amplitude sans overflow. Pour la diffusion, où les activations traversent des échelles très différentes au fil des steps, BF16 est le choix robuste ; FP16 exige une attention aux loss scaling. Le test pratique de la cellule suivante va précisément montrer la nuance de *vitesse* entre les deux."
    ]
   },
   {
@@ -950,6 +957,34 @@
     "        simulate_with_precision('bf16', 500)\n",
     "\n",
     "print(profiler.get_comparison_table())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gpfanz45wja",
+   "metadata": {
+    "papermill": {
+     "duration": 0.011342,
+     "end_time": "2026-05-12T10:01:13.198045",
+     "exception": false,
+     "start_time": "2026-05-12T10:01:13.186703",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture du test FP16 vs FP32** — le tableau mérite une lecture ligne par ligne :\n",
+    "\n",
+    "| Test | Temps (ms) | Throughput |\n",
+    "|---|---|---|\n",
+    "| Baseline - FP32 | 841.3 | 1.19 img/s |\n",
+    "| Test - FP32 | 112.8 | 8.87 img/s |\n",
+    "| Test - FP16 | 112.8 | 8.86 img/s |\n",
+    "| Test - BF16 | 5582.5 | 0.18 img/s |\n",
+    "\n",
+    "1. **Baseline vs Test-FP32 (841.3 → 112.8 ms, ×7.5)** : les deux sont en FP32 — l'accélération ne vient PAS de la précision mais de l'échauffement (première exécution compile/alloue, les suivantes sont plus rapides) et du mécanisme de simulation lui-même. C'est le piège classique du benchmarking GPU : **la première mesure est toujours la plus lente**. Comparer une baseline « à froid » à un optimisé « à chaud » surestime n'importe quelle technique.\n",
+    "2. **Test-FP32 vs Test-FP16 (112.8 vs 112.8)** : à workload simulé égal, FP16 n'apporte rien ici — la simulation ne fait pas de vraies multiplications matricielles intensives qui bénéficieraient des Tensor Cores. Sur un vrai UNet, FP16 donne typiquement ×1.5-2 en compute ; ici, seul le gain **mémoire** (2000 vs 4000 MB) est réel.\n",
+    "3. **L'anomalie BF16 (5582.5 ms, ×50 plus lent)** : contre-intuitif alors que la détection recommandait BF16 ! Explication : la simulation alloue et convertit les tenseurs à chaque itération, et le chemin de conversion BF16 sur ce pattern précis est défavorable. **Leçon** : une recommandation statique (« BF16 supporté ») ne vaut pas une mesure — la Section 8, sur le pipeline complet, tranchera avec le vrai benchmark."
    ]
   },
   {
@@ -1103,7 +1138,19 @@
     "tags": []
    },
    "source": [
-    "La configuration de quantification définit les profils INT8 et INT4 avec leurs facteurs de réduction VRAM respectifs. Le gestionnaire de quantification vérifie la VRAM disponible avant d'appliquer le niveau de quantification compatible avec le matériel cible."
+    "La configuration de quantification définit les profils INT8 et INT4. La sortie « Options de Quantification pour Modèle 4GB » donne l'échelle complète des compromis :\n",
+    "\n",
+    "| Type | Bits | Taille | Réduction | Impact qualité |\n",
+    "|---|---|---|---|---|\n",
+    "| none | 32 | 4.00 GB | 0 % | Aucun |\n",
+    "| fp16 | 16 | 2.00 GB | 50 % | Négligeable |\n",
+    "| int8 | 8 | 1.00 GB | 75 % | Minime |\n",
+    "| int4 | 4 | 0.50 GB | 88 % | Léger |\n",
+    "| nf4 | 4 | 0.50 GB | 88 % | Léger |\n",
+    "\n",
+    "La cellule suivante génère les configurations **BitsAndBytes** concrètes : INT8 (`load_in_8bit`, seuil 6.0), INT4 (`bnb_4bit_quant_type: fp4`), et NF4 — le format « NormalFloat » de QLoRA, avec `bnb_4bit_use_double_quant: True` : quantifier aussi les constantes de quantification, pour grappiller quelques pourcents de plus.\n",
+    "\n",
+    "**L'arbitrage à retenir** : INT4 divise la mémoire par 8 pour un impact « léger » sur la qualité — c'est ce qui rend les modèles 7B chargeables sur des cartes 8-12 GB. Mais chaque niveau de quantification est un **plafond de qualité** définitif : on ne « dé-quantifie » pas une image déjà dégradée. D'où la position de la Section 8 : quantifier d'abord la mémoire (FP16 gratuit), ne descendre en INT que si la VRAM l'exige."
    ]
   },
   {
@@ -1197,6 +1244,16 @@
     "    print(f\"\\n{qt.upper()}:\")\n",
     "    for k, v in config.items():\n",
     "        print(f\"  {k}: {v}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture des configurations générées** — la cellule transforme les profils abstraits en **dictionnaires BitsAndBytes prêts à l'emploi** : INT8 (`load_in_8bit: True` avec `llm_int8_threshold: 6.0` — seuil au-delà duquel un outlier reste en FP16 pour préserver la précision), INT4 (`bnb_4bit_quant_type: fp4`, compute en `float16`), et NF4 — même empreinte que INT4 (0.50 GB) avec deux raffinements : le format `nf4` (quantification calée sur une distribution normale, proche de la distribution empirique des poids) et `bnb_4bit_use_double_quant: True` (quantifier aussi les constantes de quantification — quelques pourcents de plus).\n",
+    "\n",
+    "**Le détail qui différencie INT4 et NF4** : à mémoire égale, NF4 conserve mieux la qualité — c'est le format derrière QLoRA, celui qu'on choisit quand la carte est petite ET que la qualité compte. Le seuil 6.0 de l'INT8, lui, matérialise la découverte clé de LLM.int8() : les outliers de grande magnitude vivent dans quelques dimensions — les isoler en haute précision préserve la qualité du reste quantifié."
    ]
   },
   {
@@ -1359,6 +1416,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture des stratégies d'offloading** — le catalogue expose le compromis VRAM/vitesse en trois crans :\n",
+    "\n",
+    "- **`none`** : tout sur GPU. VRAM élevée, vitesse maximale — le choix par défaut quand la carte tient le modèle.\n",
+    "- **`model_cpu_offload`** : modules déplacés CPU↔GPU **au besoin** (une passe par composant : text-encoder → UNet → VAE). VRAM moyenne, ~1.2× plus lent. C'est le bon compromis pour 8-12 GB.\n",
+    "- **`sequential_cpu_offload`** : **un seul module sur GPU à la fois**, au niveau des sous-modules. VRAM faible, ~2× plus lent — l'option de survie pour faire tenir SDXL sur une carte 6 GB.\n",
+    "\n",
+    "La règle de lecture : l'offloading n'est **pas** une optimisation, c'est un **échange** — on paie du temps (transferts PCIe) pour de la mémoire. On l'active quand le modèle ne tient pas, jamais « pour accélérer ». Sur la RTX 3090 (24 GB) de ce notebook, la recommandation sera `none` — les 24 GB absorbent SDXL en bf16 sans délestage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d7ea37b2",
    "metadata": {
     "papermill": {
@@ -1373,7 +1444,7 @@
    "source": [
     "## 4. Optimisations de Vitesse\n",
     "\n",
-    "### 4.1 Attention Optimizations (xFormers, Flash Attention)"
+    "La section précédente traitait la **mémoire** (précision, quantification, offloading) ; cette section traite le **temps**. Trois leviers, de complémentarité croissante : l'implémentation d'attention (le plus gros poste de compute en diffusion), `torch.compile` (fusion de kernels, gain transversal), et le VAE tiling (débloque les hautes résolutions). Ils se cumulent — le benchmark de la Section 8 les combine justement dans ses profils."
    ]
   },
   {
@@ -1503,6 +1574,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du statut attention** — le diagnostic matériel tranche : `xformers` ❌ non disponible, `flash_attention_2` ✅ disponible, `sdpa` ✅ disponible — recommandation : **flash_attention_2**.\n",
+    "\n",
+    "**Ce que fait l'implémentation d'attention** : l'attention est le goulot de compute de la diffusion (O(n²) en la longueur de séquence). Flash Attention 2 la calcule par blocs sans matérialiser la matrice complète d'attention en VRAM — double gain, compute **et** mémoire (~40 % d'économie selon le tableau récapitulatif final). `sdpa` (Scaled Dot-Product Attention, natif PyTorch 2) est le plan B toujours disponible — légèrement moins rapide sur les longues séquences, zéro dépendance externe.\n",
+    "\n",
+    "**La nuance de disponibilité** : xformers ❌ sur cette machine ne veut pas dire « xformers est mauvais » — il n'est simplement pas installé ici. Flash Attention 2 exige Ampere ou plus récent : la RTX 3090 (Ampere) le supporte, une carte Turing ne pourrait pas. C'est le second exemple (après BF16) du pattern de ce notebook : **la disponibilité d'une technique est une propriété de la machine, la recommandation est la conjonction de disponibilité ET de mesure**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5ea31e7c",
    "metadata": {
     "papermill": {
@@ -1515,7 +1598,15 @@
     "tags": []
    },
    "source": [
-    "### 4.2 Torch Compile (PyTorch 2.0+)"
+    "### 4.2 Torch Compile (PyTorch 2.0+)\n",
+    "\n",
+    "`torch.compile` fusionne les opérations PyTorch en kernels optimisés à la volée. La sortie compare les trois modes, disponibles sur cette machine (« Disponible : ✅ Oui ») :\n",
+    "\n",
+    "- **`default`** — speedup 10-20 %, compilation modérée. L'usage général.\n",
+    "- **`reduce-overhead`** — speedup 5-15 %, compilation courte. Minimise l'overhead GPU par étape : le bon choix pour les petits batches et la latence interactive.\n",
+    "- **`max-autotune`** — speedup 20-40 %, **compilation longue (minutes)**. Réserve à la production stable, où le coût de compilation est amorti sur des milliers de générations.\n",
+    "\n",
+    "**Le trade-off invisible dans le tableau** : la compilation se paie **au premier run**. Un pipeline `max-autotune` peut perdre plusieurs minutes à son démarrage avant de rattraper le `default`. Pour un prototype où l'on teste 10 prompts, `reduce-overhead` gagne ; pour un serveur qui génère en continu, `max-autotune` rembourse son coût en quelques heures. La Section 7 tiendra compte de ce critère en assignant les modes aux profils."
    ]
   },
   {
@@ -1640,7 +1731,18 @@
     "tags": []
    },
    "source": [
-    "### 4.3 VAE Optimizations (Tiling & Slicing)"
+    "### 4.3 VAE Optimizations (Tiling & Slicing)\n",
+    "\n",
+    "Le VAE (décodeur image) est le goulot mémoire des **grandes résolutions**. L'estimation de la sortie donne la règle d'engagement :\n",
+    "\n",
+    "| Résolution | VRAM VAE estimée |\n",
+    "|---|---|\n",
+    "| 512×512 (SD 1.5 standard) | ~131 MB |\n",
+    "| 1024×1024 (SDXL standard) | ~524 MB |\n",
+    "| 1536×1536 | ~1180 MB |\n",
+    "| 2048×2048 | ~2097 MB |\n",
+    "\n",
+    "La croissance est **super-linéaire** (×4 en résolution = ×16 en pixels ≈ ×16 en mémoire d'activation). Au-delà de 1024×1024, le VAE seul peut consommer plus que le UNet quantifié. Deux remèdes, activables en une ligne chacun : `pipe.vae.enable_tiling()` découpe le décodage en tuiles (artefacts possibles aux jointures), `pipe.vae.enable_slicing()` traite les images d'un batch par tranches. Ce sont des **correctifs d'urgence mémoire**, pas des accélérateurs — on les active quand la résolution l'exige, pas par défaut."
    ]
   },
   {
@@ -1892,6 +1994,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture de l'analyse batch** — le dimensionnement pour 1024×1024 en FP16 sur 24 GB : VRAM totale 24.0 GB, modèle ~4.0 GB, **~20 GB disponibles pour le batching** → batch optimal estimé : **8**.\n",
+    "\n",
+    "Le throughput théorique montre la loi des rendements décroissants du batching :\n",
+    "\n",
+    "| Batch | Throughput | Speedup |\n",
+    "|---|---|---|\n",
+    "| 1 | 0.50 img/s | 1.0× |\n",
+    "| 2 | 0.77 img/s | 1.5× |\n",
+    "| 4 | 1.05 img/s | 2.1× |\n",
+    "| 8 | 1.29 img/s | 2.6× |\n",
+    "\n",
+    "Doubler le batch ndouble JAMAIS le throughput : 1→2 donne +54 %, 2→4 +36 %, 4→8 +23 %. Les kernels GPU se saturent progressivement — les gains viennent du remplissage des unités parallèles inoccupées, puis s'épuisent. **La conséquence pratique** : le batch optimal est le plus petit qui sature le GPU, pas le maximum que la VRAM tolère. Au-delà de 8 ici, la latence par image augmenterait (les 8 images attendent la fin du lot) sans gain de throughput — fatal en interactif, acceptable en batch massif nocturne."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "eef76773",
    "metadata": {
     "papermill": {
@@ -1906,7 +2027,7 @@
    "source": [
     "## 6. Stratégies de Caching\n",
     "\n",
-    "Le caching intelligent peut éliminer les calculs redondants."
+    "Le caching attaque un poste que les sections précédentes ignorent : **le calcul redondant**. Accélérer une génération qui n'a pas besoin d'avoir lieu est le speedup ultime. Deux niveaux ici : le cache d'**embeddings** (le texte → vecteur du même prompt recalculé inutilement à chaque itération) et le cache de **résultats** (prompt + paramètres identiques → image identique, dédupliquée sur disque). La démonstration qui suit mesurera le hit rate sur une série de prompts — le chiffre qui décide si le cache paie son overhead."
    ]
   },
   {
@@ -2040,6 +2161,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du hit rate** — la démonstration envoie 5 prompts dont 2 répétés (« sunset over mountains », « cat on a couch ») : MISS, MISS, HIT, MISS, HIT — **hit rate 40 % (2/5), cache 3/50 embeddings**.\n",
+    "\n",
+    "C'est le chiffre qui décide de la valeur du cache : le premier calcul d'un embedding coûte l'inférence du text-encoder (~dizaines de ms), un HIT coûte une lecture dict (~microsecondes). À 40 % de hit rate sur prompts partiellement répétés, l'économie est déjà sensible ; sur un workload à prompts uniques, le hit rate tend vers 0 et le cache ne paie jamais son overhead. **Le paramètre structurant est le ratio répétition/nouveauté de VOS prompts** — pas la taille du cache (50 ici). C'est exactement ce que l'exercice final demandera de mesurer avec des métriques dédiées (hit rate, temps économisé)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "gri85l9w81e",
    "metadata": {
     "papermill": {
@@ -2052,7 +2183,9 @@
     "tags": []
    },
    "source": [
-    "Le cache de résultats finaux complète la stratégie de caching multi-niveaux. Contrairement au cache d'embeddings, il stocke les images générées avec leur métadonnées pour éviter les regénérations coûteuses sur des prompts identiques ou très similaires."
+    "Le cache de résultats finaux complète la stratégie multi-niveaux : `EmbeddingCache` évite de recalculer l'encodage du texte, `ResultCache` (répertoire `./cache/results`) évite de **régénérer** une image pour un couple (prompt, paramètres) déjà produit — « Dédupliquer les générations identiques ».\n",
+    "\n",
+    "**Quand ce cache paie vs quand il coûte** : il paie sur les workloads répétitifs (tests de régression d'un pipeline, exploration de grille de paramètres où l'on revient sur des combinaisons déjà vues, UI qui re-rend la même galerie). Il coûte sinon : écriture disque à chaque génération, et surtout **le risque de péremption** — si le modèle sous-jacent change (nouvelle version, autre seed par défaut), le cache peut servir une image périmée. Un cache de résultats d'inférence est toujours un pari sur la stabilité du pipeline ; l'exercice final (cache multi-niveaux) demande justement d'instrumenter ce compromis avec des métriques de hit rate et de temps économisé."
    ]
   },
   {
@@ -2169,7 +2302,7 @@
    "source": [
     "## 7. Pipeline Optimisé Complet\n",
     "\n",
-    "Combinons toutes les optimisations dans un pipeline unifié."
+    "Cette section assemble les briques des sections 3-6 en **profils nommés** — la sortie liste le catalogue : « Low VRAM (4-6GB) » (fp16 + xformers + offload séquentiel + batch 1), « Medium VRAM (8-12GB) » (fp16 + sdpa + model_cpu_offload + batch 2), « High VRAM (16GB+) » (bf16 + flash_attention_2 + no offload + batch 4), « Production Server ». La cellule de génération détecte ensuite le matériel réel et **choisit** le profil — pour cette machine (RTX 3090, 24 GB), le verdict tombera : High VRAM."
    ]
   },
   {
@@ -2385,23 +2518,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "9kfsujuhixu",
-   "metadata": {
-    "papermill": {
-     "duration": 0.012335,
-     "end_time": "2026-05-12T10:01:20.282585",
-     "exception": false,
-     "start_time": "2026-05-12T10:01:20.270250",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "La factory applique le profil d'optimisation sélectionné sur un pipeline de diffusion réel. Elle combine dynamiquement précision réduite, compilation Torch, optimisation VAE et caching pour maximiser le débit selon les contraintes VRAM disponibles."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 21,
    "id": "6a9956bb",
@@ -2466,6 +2582,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9kfsujuhixu",
+   "metadata": {
+    "papermill": {
+     "duration": 0.012335,
+     "end_time": "2026-05-12T10:01:20.282585",
+     "exception": false,
+     "start_time": "2026-05-12T10:01:20.270250",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture du profil recommandé** — la factory détecte la RTX 3090 (24 GB) et recommande « **High VRAM (16GB+)** — Performance maximale pour GPUs haut de gamme », puis génère le code prêt à l'emploi :\n",
+    "\n",
+    "```python\n",
+    "pipe = StableDiffusionXLPipeline.from_pretrained(\n",
+    "    \"stabilityai/stable-diffusion-xl-base-1.0\",\n",
+    "    torch_dtype=torch.bfloat16,\n",
+    "    attn_implementation=\"flash_attention_2\",\n",
+    ").to(\"cuda\")\n",
+    "pipe.unet = torch.compile(pipe.unet, mode=\"reduce-overhead\")\n",
+    "```\n",
+    "\n",
+    "Chaque ligne condense une décision des sections précédentes : `bfloat16` (dynamique robuste, économie 50 %, validée par la détection BF16 ✓), `flash_attention_2` (disponible ✓, recommandée par la Section 4.1), `torch.compile(reduce-overhead)` (compilation courte — profil interactif, pas `max-autotune` et ses minutes de compilation à froid). Le profil n'est pas une recette copiée-collée : c'est la **trace exécutable** du raisonnement tenu section par section sur CETTE machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "166022db",
    "metadata": {
     "papermill": {
@@ -2480,7 +2624,7 @@
    "source": [
     "## 8. Benchmarking et Comparaison\n",
     "\n",
-    "Mesurons l'impact des différentes optimisations."
+    "Le moment de vérité : les techniques étaient mesurées isolément (souvent sur simulation), le benchmark les combine sur un pipeline complet et les rapporte à une baseline commune. Les colonnes — temps moyen, mémoire, speedup — sont les trois axes d'un choix d'optimisation : une technique peut gagner sur deux et perdre sur le troisième. La lecture qui suit le tableau explique pourquoi le profil « agressif » n'est pas automatiquement le bon."
    ]
   },
   {
@@ -2623,9 +2767,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Lecture du benchmark** — les profils d'optimisation montrent des accélérations de **2,37×** (modéré) et **3,44×** (agressif) par rapport à la baseline (1,00×). Un speedup de 3,44× signifie qu'une génération qui prenait ~841 ms en baseline descend à ~244 ms — concrètement, le temps d'attente passe de perceptible à quasi-instantané pour un utilisateur interactif.\n",
+    "**Lecture du benchmark** — le tableau mesure trois configurations sur pipeline complet :\n",
     "\n",
-    "**Ce que le speedup ne dit pas (et pourquoi le profil « agressif » n'est pas toujours le bon choix)** : un speedup de 3,44× s'obtient en cumulant FP16 + compilation + quantification INT8 + VAE tiling — chacune de ces optimisations ajoute un risque. La quantification INT8 peut dégrader la qualité d'image ; `torch.compile` allonge le **premier** run (compilation à froid) de plusieurs dizaines de secondes ; le VAE tiling introduit des artefacts aux frontières de tuiles. Le profil « modéré » (2,37×) capture l'essentiel du gain (FP16 + compile) sans ces coûts. Le choix entre les profils n'est donc pas « le plus rapide » — c'est un arbitrage speedup-vs-qualité-vs-latence-à-froid que seul le cas d'usage (prototype vs production, interactif vs batch) peut trancher."
+    "| Configuration | Temps moy (ms) | Mémoire (MB) | Speedup |\n",
+    "|---|---|---|---|\n",
+    "| Baseline (FP32) | 303.3 | 1500.0 | 1.00× |\n",
+    "| FP16 | 127.9 | 750.0 | **2.37×** |\n",
+    "| FP16 + Optimisations | 88.3 | 750.0 | **3.44×** |\n",
+    "\n",
+    "Deux lectures essentielles :\n",
+    "\n",
+    "1. **Les speedup se vérifient par division directe** : 303.3/127.9 = 2.37 ✓, 303.3/88.3 = 3.44 ✓. FP16 seul double la vitesse ET divise la mémoire par deux (1500 → 750 MB) — c'est la technique au meilleur rapport gain/coût du notebook. Le palier suivant (2.37× → 3.44×) ajoute 45 % de vitesse supplémentaire via les optimisations composées (attention, compile) — sans gain mémoire additionnel.\n",
+    "2. **Notez que la baseline du benchmark (303.3 ms) diffère de la baseline simulée de la Section 2 (841.3 ms)** : ce sont deux instruments différents — simulation à froid vs pipeline complet à température établie. Les speedup ne se rapportent **qu'à la baseline du même tableau**. Un speedup n'a de sens que dans son propre référentiel : c'est la discipline de mesure qui rend les comparaisons honnêtes.\n",
+    "\n",
+    "**Pourquoi le profil « agressif » (3.44×) n'est pas toujours le bon choix** : il cumule FP16 + compilation + optimisations d'attention — chacune ajoute un coût caché (compilation à froid de plusieurs dizaines de secondes, contraintes de version). Le profil modéré (2.37×) capture l'essentiel du gain sans ces coûts. Le choix est un arbitrage speedup/qualité/latence-à-froid que seul le cas d'usage tranche : prototype interactif vs serveur de production."
    ]
   },
   {
@@ -2760,7 +2915,9 @@
     "tags": []
    },
    "source": [
-    "Les recommandations synthétisent les résultats du benchmark. Le profil optimal est calculé en fonction du ratio VRAM/vitesse/qualité mesuré pour chaque combinaison d'optimisations testée dans les sections précédentes."
+    "Les recommandations synthétisent le benchmark en un **rapport personnalisé pour la machine détectée** — l'entête affiche « Configuration Détectée : GPU NVIDIA GeForce RTX 3090 ». C'est la différence entre une documentation générique et un diagnostic : le rapport ne dit pas « FP16 est bon », il dit ce que FP16 apporte **sur cette carte**, avec les chiffres mesurés dans ce notebook.\n",
+    "\n",
+    "**La hiérarchie implicite du rapport** : les techniques à gain quasi-gratuit (FP16 : 50 % mémoire, aucun impact qualité) viennent en tête ; les techniques à coût caché (torch.compile : latence à froid ; INT8 : plafond de qualité) ne se recommandent que contraintes par un cas d'usage. Le tableau récapitulatif suivant donne cette synthèse en une vue — c'est la cheville du notebook : toutes les sections précédentes s'y condensent en cinq colonnes."
    ]
   },
   {
@@ -2832,6 +2989,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du tableau récapitulatif** — la synthèse en trois colonnes (économie mémoire, impact qualité, recommandé) condense tout le notebook :\n",
+    "\n",
+    "1. **Le trio 5 étoiles** : Précision FP16/BF16 (50 % mémoire, aucun impact), xFormers (30 %), Flash Attention 2 (40 %) — toutes « Aucun » impact qualité : ce sont les **gains gratuits**, à activer systématiquement.\n",
+    "2. **La classe intermédiaire** : INT8 (75 % mémoire, impact « minime ») — le levier quand la VRAM manque, au prix d'un plafond de qualité.\n",
+    "3. **Les techniques conditionnelles** : torch.compile (« Variable », ★★★☆☆) et VAE tiling — leur valeur dépend du workload (fréquence de compilation à froid, résolution cible), pas d'une règle universelle.\n",
+    "\n",
+    "La colonne « Recommandé » se lit comme une **politique d'engagement** : appliquer d'abord tout ce qui est 5 étoiles (coût nul), descendre d'un cran uniquement quand une contrainte mesurée (VRAM, latence, résolution) l'exige. C'est l'inverse du réflexe « tout activer » — chaque technique non gratuite ajoute un risque qui doit être justifié par une contrainte réelle."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "de26f75c",
    "metadata": {
     "papermill": {
@@ -2847,13 +3018,13 @@
     "## 10. Exemples guidés Pratiques\n",
     "\n",
     "### Exemple guide 1: Profilage de votre pipeline\n",
-    "Utilisez le `GPUProfiler` pour mesurer les performances de votre propre pipeline de génération.\n",
+    "Utilisez le `GPUProfiler` pour mesurer les performances de votre propre pipeline de génération. Méthode : capturer une baseline **à chaud** (deux runs, on profile le second), noter temps moyen et mémoire peak, puis répéter après CHAQUE optimisation — un speedup isolé n'a de sens que rapporté à la baseline du même instrument.\n",
     "\n",
     "### Exemple guide 2: Comparaison A/B\n",
-    "Comparez la qualité d'image entre FP32 et FP16 sur 10 prompts identiques.\n",
+    "Comparez la qualité d'image entre FP32 et FP16 sur 10 prompts identiques (mêmes seeds). Le tableau de la Section 3.1 dit « impact qualité : aucun » — vérifiez-le sur VOS images : c'est l'expérience qui transforme une affirmation de tableau en connaissance propre. Attention au protocole : même seed, même sampler, même nombre de steps — seule la précision varie.\n",
     "\n",
     "### Exemple guide 3: Optimisation de batch\n",
-    "Trouvez le batch size optimal pour votre GPU en mesurant le throughput."
+    "Trouvez le batch size optimal pour votre GPU en mesurant le throughput : la loi des rendements décroissants de la Section 5 (×1.5 → ×2.1 → ×2.6) montre que l'optimum est le plus petit batch qui sature le GPU, pas le maximum de VRAM."
    ]
   },
   {
@@ -2923,6 +3094,16 @@
     "print(\"   → Explorer les techniques de multi-GPU si disponible\")\n",
     "\n",
     "print(\"\\n✅ Module 03-Images-Orchestration complété!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture de la finalisation** — le récapitulatif de session résume ce que le profiler a accumulé : nombre de tests exécutés (`len(profiler.metrics_history)`) et temps moyen sur l'ensemble — les deux nombres que la méthodologie de la Section 1 (capture dans `PerfMetrics`, accumulation dans `GPUProfiler`) a rendus possibles sans instrumentation supplémentaire.\n",
+    "\n",
+    "**Ce qu'emporte l'étudiant** : pas une liste de recettes, mais une **méthode** — mesurer une baseline honnête (attention aux mesures à froid), diagnostiquer le matériel AVANT de choisir les techniques, appliquer les gains gratuits d'abord, n'accepter un coût caché (qualité, latence à froid, artefacts) que contraint par un cas d'usage, et toujours rapporter les speedup à la baseline du même tableau. Les « prochaines étapes » suggérées (pipelines de production, modèles réels, multi-GPU) sont les trois directions où cette méthode se transpose telle quelle."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11333 (substance distincte : famille GenAI/Image, profilage GPU vs ML financier QC)

## Summary

Tranche #11271 (1re du jour pour cette lane) : **GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb**,
densité pédagogique **551 → 1291** chars de prose / cellule code (organe `pedagogy_density.py`, seuil 1200,
re-mesuré firsthand origin/main). Enrichissement **markdown-only FR** — les 28 cellules code sont
**byte-identiques** (diff structurel cellule-à-cellule), aucune re-exec requise (exception markdown-only C.3),
outputs intacts. 15 cellules markdown réécrites (dont 5 squelettes de 36-260 chars) + 6 lectures nouvelles,
235 insertions / 54 deletions.

## Les lectures ajoutées (toutes ancrées sur les outputs committés)

| Lecture | Valeurs citées |
|---|---|
| **Diagnostic matériel** : bi-GPU RTX 3090 24 GB + 3080 Ti Laptop 16 GB — pourquoi le profil « High VRAM » sera recommandé avant même de mesurer | GPU 0/1, Ampere |
| **État mémoire initial** : 0 MB alloué/réservé, 24 575.5 MB libres — la ressource que les sections suivantes dépensent ; distinction alloué/réservé (cache CUDA) | 24575.5 MB |
| **Baseline** : simulation déterministe 841.3 ms / 1500 MB comme terrain d'essai calibré (isole la mécanique de mesure du bruit des poids réels) | 841.3 ms, 1500 MB |
| **Comparaison précisions** : FP32 4000 MB vs FP16/BF16 2000 MB (50 %) — pourquoi même économie mémoire (16 bits) mais dynamique différente | tableau précisions |
| **Test FP16 ligne à ligne** : le piège baseline-froide (841.3→112.8 à précision ÉGALE, ×7.5 d'échauffement, pas de la précision) ; FP16 sans gain en simulation (pas de vraies GEMM) ; **l'anomalie BF16 5582.5 ms** (×50 lent) vs la recommandation statique | 841.3 / 112.8 / 8.87 img/s / 5582.5 |
| **Quantification** : 4 GB → fp16/int8/int4/nf4 (50/75/88 %), seuil `llm_int8_threshold: 6.0` = découverte LLM.int8() (outliers isolés en FP16), NF4 = format QLoRA + double quant | tableau quantification |
| **Offloading** : none / model_cpu_offload ~1.2× plus lent / sequential ~2× — un échange temps↔VRAM, pas une optimisation | 3 stratégies |
| **Attention** : xformers ❌ / flash_attention_2 ✅ / sdpa ✅ — disponibilité = propriété de LA machine, recommandation = disponibilité ET mesure | statut attention |
| **Batch** : rendements décroissants 1→2 (+54 %), 2→4 (+36 %), 4→8 (+23 %), optimum 8 — le plus petit batch qui sature, pas le max VRAM | 0.50→1.29 img/s |
| **Hit rate cache embeddings** : MISS/MISS/HIT/MISS/HIT = 40 % — le paramètre structurant est le ratio répétition/nouveauté des prompts | 2/5, 3/50 |
| **Profil recommandé** : RTX 3090 → High VRAM (bf16 + flash_attention_2 + compile reduce-overhead) — chaque ligne du code généré trace une décision d'une section précédente | profil High VRAM |
| **Benchmark ré-ancré** : 303.3/127.9/88.3 ms, speedups 2.37×/3.44× vérifiés par division, mémoire 1500→750 MB ; **correction** : l'ancienne lecture appliquait le ratio à la baseline 841.3 de la Section 2 alors que le benchmark a sa propre baseline 303.3 | tableau benchmark |
| **Tableau récapitulatif** : le trio 5 étoiles sans impact qualité (FP16/BF16, xFormers, FA2) d'abord, INT8 sous contrainte, conditionnelles (compile, tiling) par workload | ★★★★★ |
| **Finalisation** : ce qu'emporte l'étudiant = la méthode (baseline honnête, diagnostic matériel d'abord, gains gratuits d'abord, coûts cachés justifiés) | stats session |

**Ré-ancrage** (règle [cell-interpretation-ordering](../../.claude/rules/cell-interpretation-ordering.md)) : 3
interps réécrites en lectures d'output étaient restées en position « pré-introduction » — déplacées immédiatement
après le code dont elles citent la sortie (comparaison précisions, test FP16, profil recommandé).

## Validation

- Mesure avant/après : `pedagogy_density.py --json` → 551 → **1291** (status `ok`, plus dans `below_threshold`).
- 28/28 cellules code byte-identiques (diff structurel, base `git show origin/main:`).
- Interps ancrées : chaque valeur citée provient de l'output de la cellule précédente ;
  `scan_cell_ordering.py` : 1 clean, 0 finding.
- Stubs d'exercices C.1 intacts (3 exos TODO conservés) ; pas d'erreur volontaire ; catalogue byte-identique (0 diff).
- `validate_pr_notebooks.py origin/main` : 1/1 PASS (28 cells).
- File CI mesurée avant ouverture : 30 PRs ouvertes (<200).

## Regression check

- Fichier unique, markdown-only, 235 ins / 54 del — aucune cellule code touchée.
- Aucun symbole code modifié ; outputs et `execution_count` intacts.

See #11271 (tranche Image/03-3, protocole #10488 — 1 notebook = 1 PR)
