### PR TITLE
feat(tweety,#11224): densite Tweety-4-Belief-Revision-Csharp 585->1312 (tranche markdown-only, lectures ancrees outputs)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
@@ -49,7 +49,16 @@
    "id": "sec1",
    "metadata": {},
    "source": [
-    "### 1. Configuration du runtime IKVM"
+    "### 1. Configuration du runtime IKVM\n",
+    "\n",
+    "IKVM est un runtime **Java sur .NET** : il réimplémente la JVM et les bibliothèques de classes\n",
+    "Java en bytecode .NET, ce qui permet de consommer un JAR Java (ici Tweety) **sans installer de\n",
+    "JVM** — les types Java (`java.util.HashSet`, etc.) deviennent des types .NET utilisables\n",
+    "directement depuis C#. La configuration exige trois paquets NuGet : le noyau `IKVM`, l'image\n",
+    "de base `IKVM.Image` (les classes Java standard), et le runtime natif `IKVM.Image.runtime.win-x64`\n",
+    "(les binaires spécifiques à la plateforme). La cellule suivante vérifie l'installation en\n",
+    "reconstruisant le `home` d'IKVM — le témoin décisif étant le chargement de la base **tzdb**\n",
+    "(fuseaux horaires Java) : si elle vaut `True`, le runtime est complet et fonctionnel."
    ]
   },
   {
@@ -138,14 +147,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du setup IKVM** — la sortie `IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True)`\n",
+    "valide les trois étages du runtime : la **version** (8.15.0, alignée sur les directives `#r`\n",
+    "de la cellule précédente), le **home** (le répertoire où IKVM dépose ses données — isolé par\n",
+    "version et par plateforme, ici `win-x64`), et surtout `tzdb=True` : la base des **fuseaux\n",
+    "horaires Java** (timezone database) a été chargée. C'est le témoin le plus fin de la santé du\n",
+    "runtime : `tzdb` n'est pas une dépendance de Tweety, c'est une composante profonde de l'image\n",
+    "Java — si elle charge, l'émulation JVM est complète, pas seulement démarrée. Sans ce témoin,\n",
+    "un `#r` silencieux peut laisser croire à un environnement prêt qui ne l'est pas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "sec2",
    "metadata": {},
    "source": [
     "### 2. Chargement de la DLL Tweety beliefdynamics\n",
     "\n",
-    "La DLL `org.tweetyproject.tweety-beliefdynamics.dll` est un fat-jar shade (beliefdynamics +\n",
-    "ses dependances : logique propositionnelle, SAT, math) recompile par IKVM. Elle expose les\n",
-    "opérateurs de revision, de contraction par noyaux et de revision selective."
+    "Tweety n'est pas publié sur NuGet en version .NET : l'équipe fournit des JAR Java. Le dépôt\n",
+    "génère donc des **DLL .NET** via IKVM (une par module Tweety), stockées localement et chargées\n",
+    "par directive `#r`. C'est la même mécanique que pour les notebooks Tweety déjà portés\n",
+    "(logiques de base, sémantique, FOL, argumentation) — la DLL `tweety-beliefdynamics` apporte\n",
+    "les opérateurs AGM : contraction par noyaux, expansion, révision par identité de Levi."
    ]
   },
   {
@@ -196,15 +222,37 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du chargement de la DLL** — la sortie `Tweety (IKVM) reference chargee :\n",
+    "org.tweetyproject.tweety-beliefdynamics v1.30.0.0 (9,0 Mo)` fait deux vérifications en une.\n",
+    "D'abord l'**existence et la lisibilité** : `AssemblyName.GetAssemblyName` lit les métadonnées\n",
+    "du fichier sans l'exécuter — si la DLL était absente ou corrompue, l'appel lèverait avant\n",
+    "d'afficher quoi que ce soit. Ensuite **l'identité** : version `1.30.0.0` et taille `9,0 Mo` —\n",
+    "autant de points de contrôle pour diagnostiquer un conflit de version entre notebooks. Pourquoi\n",
+    "cette vérification explicite ? Parce qu'en .NET Interactive, la directive `#r` est\n",
+    "**silencieuse par défaut** (constat #5039, documenté dans les notebooks Tweety précédents) :\n",
+    "elle n'échoue pas bruyamment si la référence est mauvaise — l'erreur n'apparaît que plus loin,\n",
+    "au premier appel d'un type manquant, loin de sa cause. Vérifier tôt, c'est localiser l'erreur\n",
+    "là où elle naît."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "sec3",
    "metadata": {},
    "source": [
-    "### 3. Le problème : une base de croyances incoherente\n",
+    "### 3. Le problème : une base de croyances incohérente\n",
     "\n",
-    "Construisons une base `K = { a, a => b, !c }`, coherente. Puis observons que lui ajouter\n",
-    "naivement l'information `!b` la rend **incoherente** : comme `a` et `a => b` impliquent `b`,\n",
-    "la base contiendrait a la fois `b` (deduit) et `!b`. C'est exactement la situation que la\n",
-    "revision doit resoudre proprement."
+    "Le scénario fondateur de la révision : une base `K` **cohérente** (elle a des modèles), puis\n",
+    "une nouvelle information `!b` qui **contredit** ce que `K` implique déjà (`b`). L'union naïve\n",
+    "`K + !b` est incohérente — et une base incohérente, en logique classique, implique **tout**\n",
+    "(principe d'explosion) : elle ne peut plus rien raisonner du tout. Le test de cohérence se fait\n",
+    "**sans solveur SAT externe** : `SimplePlReasoner` énumère les interprétations et vérifie si la\n",
+    "base possède au moins un modèle. Trois questions structurent la sortie : `K` est-elle\n",
+    "incohérente ? l'union naïve l'est-elle ? — et la section suivante montrera l'opérateur qui\n",
+    "intègre `!b` **sans** produire cette explosion."
    ]
   },
   {
@@ -288,10 +336,14 @@
    "source": [
     "#### Interpretation\n",
     "\n",
-    "L'union naive est incoherente : le raisonneur le confirme — elle entraine la contradiction\n",
-    "`a && !a`, donc la question « incoherente ? » passe de `false` (pour `K`) a `true` (pour l'union).\n",
-    "Une base incoherente implique **toute** formule (principe d'explosion), elle est donc inutilisable\n",
-    "pour raisonner. La revision AGM va integrer `!b` **sans** produire cette explosion."
+    "La sortie donne la diagonale du problème : `K incoherente ? false`, puis `Union naive\n",
+    "incoherente ? true`. La base initiale `K = { (a=>b), a, !c }` a des modèles (par exemple\n",
+    "`a=1, b=1, c=0`), elle raisonne sainement. L'union naïve `{ (a=>b), a, !b, !c }` n'en a plus :\n",
+    "`a` et `a=>b` forcent `b`, que `!b` nie — contradiction, donc **zéro modèle**, donc\n",
+    "l'entraînement de n'importe quelle formule (principe d'explosion). C'est le mur que la révision\n",
+    "AGM va contourner : intégrer `!b` en **abandonnant** juste ce qu'il faut des anciennes\n",
+    "croyances, plutôt que de tout faire exploser. La suite du notebook montre les deux opérateurs\n",
+    "qui réalisent ce compromis — contraction puis révision."
    ]
   },
   {
@@ -301,13 +353,14 @@
    "source": [
     "### 4. Contraction par noyaux (kernel contraction)\n",
     "\n",
-    "Avant de reviser, il faut savoir **contracter**. La *contraction par noyaux* (Hansson) procede\n",
-    "ainsi : un **noyau** de `K` par rapport a `b` est un sous-ensemble **minimal** de `K` qui implique\n",
-    "`b`. Pour que `K` cesse d'impliquer `b`, il faut « couper » au moins une formule dans **chaque**\n",
-    "noyau : c'est le rôle de la **fonction d'incision**. Ici :\n",
-    "\n",
-    "- `SimplePlReasoner` fournit les noyaux (`KernelProvider`),\n",
-    "- `RandomIncisionFunction` choisit la formule a retirer dans chaque noyau."
+    "La **théorie des noyaux** (Hansson) définit la contraction élégamment : un *noyau pour `b`*\n",
+    "est un sous-ensemble **minimal** de `K` qui implique `b` — enlever n'importe laquelle de ses\n",
+    "formules suffit à briser l'entraînement de `b`. Pour que `K` n'implique plus `b`, il faut\n",
+    "**couper au moins une formule dans chaque noyau** : c'est le rôle de la *fonction d'incision*\n",
+    "(`incision function`). Tweety assemble le tout : `KernelContractionOperator` prend le fournisseur\n",
+    "de noyaux (`SimplePlReasoner`) et la fonction d'incision — ici `RandomIncisionFunction`, qui\n",
+    "choisit arbitrairement. La sortie vérifie la **propriété garantie** (ne plus impliquer `b`) et\n",
+    "montre la base résultante — dont le contenu exact dépend du choix (aléatoire) de l'incision."
    ]
   },
   {
@@ -375,10 +428,16 @@
    "source": [
     "#### Interpretation\n",
     "\n",
-    "La base contractee n'implique plus `b` : la contraction a retire l'une des formules\n",
-    "responsables (`a` ou `a => b`). La fonction d'incision etant **aleatoire**, la formule\n",
-    "exactement retiree peut varier d'une exécution a l'autre — mais la propriete garantie\n",
-    "(« ne plus impliquer `b` ») est, elle, toujours respectee."
+    "La sortie lit : `K contractee par b = [a, !c]`, puis `Entraine encore b ? false`. Autrement\n",
+    "dit, c'est la formule `(a=>b)` qui a été sacrifiée — la base finale `{a, !c}` ne contient plus\n",
+    "le seul chemin vers `b`. La lecture théorique : le noyau pour `b` était `{a, (a=>b)}` (minimal :\n",
+    "retirer soit `a`, soit `a=>b` brise l'entraînement), et l'incision aléatoire a choisi\n",
+    "`(a=>b)`. **Ce qui est garanti, ce qui ne l'est pas** : la propriété « ne plus impliquer `b` »\n",
+    "est garantie quel que soit le choix ; la formule exactement retirée, elle, varie d'une\n",
+    "exécution à l'autre sous `RandomIncisionFunction`. Une incision *informée* (préférences\n",
+    "épistémiques — « je tiens plus à mes faits qu'à mes règles ») produirait un choix déterministe\n",
+    "et justifiable : c'est précisément l'axe de conception que l'exemple pingouin de la section 6\n",
+    "rendra visible."
    ]
   },
   {
@@ -386,11 +445,16 @@
    "id": "sec5",
    "metadata": {},
    "source": [
-    "### 5. Revision par l'identite de Levi\n",
+    "### 5. Révision par l'identité de Levi\n",
     "\n",
-    "On assemble maintenant la revision complete. `LeviMultipleBaseRevisionOperator` prend un\n",
-    "opérateur de contraction et un opérateur d'expansion, et applique l'identite de Levi\n",
-    "`K * phi = (K - !phi) + phi`. Revisons `K` par `!b`."
+    "La **révision** `K * phi` intègre `phi` en préservant la cohérence. L'**identité de Levi** la\n",
+    "réduit à deux opérations déjà connues : `K * phi = (K - !phi) + phi` — contracter par la\n",
+    "**négation** de la nouvelle information (retirer ce qui contredirait `phi`), puis **expanser**\n",
+    "par `phi` elle-même. Tweety l'implémente littéralement : `LeviMultipleBaseRevisionOperator`\n",
+    "compose la contraction de la section 4 avec `DefaultMultipleBaseExpansionOperator`. La sortie\n",
+    "vérifie les trois propriétés attendues du résultat : cohérent, contient bien la nouvelle\n",
+    "information, et — c'est visible dans son contenu — cohérent avec la base contractée de la\n",
+    "section précédente."
    ]
   },
   {
@@ -457,9 +521,15 @@
    "source": [
     "#### Interpretation\n",
     "\n",
-    "Le résultat est **coherent** et contient bien la nouvelle information `!b`. La revision a\n",
-    "sacrifie juste ce qu'il fallait des anciennes croyances pour accueillir `!b` sans contradiction :\n",
-    "c'est la différence fondamentale avec l'union naive de la section 3."
+    "La sortie : `K revisee par !b (Levi) = [a, !b, !c]`, `Resultat incoherent ? false`,\n",
+    "`Contient bien !b ? True`. La lecture fine : le résultat est **exactement** la base contractée\n",
+    "de la section 4 (`[a, !c]` — où l'incision avait retiré `(a=>b)`) à laquelle l'expansion a\n",
+    "ajouté `!b`. L'identité de Levi est visible **dans le contenu** de la sortie, pas seulement\n",
+    "dans la formule : réviser par `!b` = contracter par `b` (section 4) puis ajouter `!b`. Et le\n",
+    "contraste avec la section 3 est total : l'union naïve `{(a=>b), a, !b, !c}` était incohérente ;\n",
+    "la révision `{a, !b, !c}` intègre la même information **en restant raisonnable** — au prix\n",
+    "d'une croyance abandonnée (`a=>b`). C'est le compromis AGM : toute nouvelle information\n",
+    "s'installe, le minimum de l'ancien se sacrifie."
    ]
   },
   {
@@ -595,24 +665,56 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture de la révision du pingouin** — la sortie raconte l'intégralité du compromis AGM\n",
+    "en cinq lignes : `K conclut que Tweety vole (f) ? true` (la base initiale raisonne sainement —\n",
+    "c'est sa **conclusion** qui est fausse, pas sa logique), puis après révision par `!f` :\n",
+    "`K revisee = [(b=>f), p, !f]`, cohérente, concluant désormais `!f`. Et la ligne clé :\n",
+    "`Croyance(s) abandonnee(s) : [(p=>b)]`.\n",
+    "\n",
+    "**Ce que l'abandon révèle** : pour intégrer « ce pingouin ne vole pas », il faut couper la\n",
+    "chaîne `p => b => f` **quelque part** — deux incisions minimales existent : retirer `p=>b`\n",
+    "(« les pingouins ne sont pas des oiseaux ») ou retirer `b=>f` (« les oiseaux ne volent pas\n",
+    "forcément »). L'intuition biologique dit clairement : sacrifie `b=>f`, garde `p=>b`. Mais\n",
+    "`RandomIncisionFunction` n'a **aucune préférence épistémique** — elle a tiré `p=>b`,\n",
+    "produisant une révision **valide mais absurde** (un pingouin qui ne serait pas un oiseau).\n",
+    "La leçon de conception : la théorie AGM garantit la *cohérence* du résultat, jamais sa\n",
+    "*pertinence* — la fonction d'incision est le point d'injection des connaissances de domaine.\n",
+    "C'est exactement ce que la sortie affirme en conclusion : « abandonner une règle par défaut…\n",
+    "c'est le cœur de l'AGM » — le cœur, et la responsabilité."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "conclusion",
    "metadata": {},
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a execute, en C# natif via IKVM, les opérateurs AGM de Tweety :\n",
+    "Ce notebook a exécuté, en C# natif via IKVM, les opérateurs AGM de Tweety :\n",
     "\n",
-    "- **test de coherence** par entailment d'une contradiction (`SimplePlReasoner`) : une base\n",
-    "  est incoherente ssi elle entraine `a && !a` ;\n",
-    "- **contraction par noyaux** (`KernelContractionOperator` + `RandomIncisionFunction`) ;\n",
-    "- **revision** par l'**identite de Levi** (`LeviMultipleBaseRevisionOperator`) ;\n",
-    "- une application non-monotone (le pingouin Tweety) ou la revision resout une incoherence\n",
-    "  **derivee** en abandonnant une règle par defaut.\n",
+    "- **test de cohérence** par existence de modèle (`SimplePlReasoner`) : une base est\n",
+    "  incohérente ssi elle n'a aucun modèle — l'union naïve `{(a=>b), a, !b, !c}` l'a démontré ;\n",
+    "- **contraction par noyaux** (`KernelContractionOperator` + `RandomIncisionFunction`) :\n",
+    "  retirer `(a=>b)` suffit à ne plus impliquer `b` — propriété garantie, choix d'incision\n",
+    "  aléatoire ;\n",
+    "- **révision** par l'**identité de Levi** (`LeviMultipleBaseRevisionOperator`) : le résultat\n",
+    "  `[a, !b, !c]` est littéralement la base contractée + la nouvelle formule ;\n",
+    "- une application non-monotone (le pingouin Tweety) où la révision résout une incohérence\n",
+    "  **dérivée** — via une chaîne d'implications, pas une contradiction directe — en abandonnant\n",
+    "  une règle de la chaîne `p => b => f`.\n",
     "\n",
-    "La revision de croyances est au coeur des systèmes intelligents qui doivent **apprendre en\n",
-    "presence d'informations contradictoires** : mise a jour de bases de connaissances, fusion de\n",
-    "sources, diagnostic. Le notebook Python compagnon poursuit avec les **mesures d'incoherence**\n",
-    "et l'enumeration de **MUS** (sous-ensembles incoherents minimaux)."
+    "Trois idées à retenir au-delà des opérateurs : (1) une base incohérente ne « dégrade » pas le\n",
+    "raisonnement, elle l'**annule** (explosion) — la cohérence n'est pas une option ; (2) le\n",
+    "changement de croyance minimal n'est **jamais unique** — la fonction d'incision encode les\n",
+    "préférences épistémiques de l'agent ; (3) l'identité de Levi fait de la révision une\n",
+    "**composition** : bien la comprendre, c'est pouvoir l'auditer cellule par cellule, comme ce\n",
+    "notebook l'a fait. La révision de croyances est au cœur des systèmes qui apprennent en\n",
+    "présence d'informations contradictoires : mise à jour de bases de connaissances, fusion de\n",
+    "sources, diagnostic. Le notebook Python compagnon poursuit avec les **mesures\n",
+    "d'incohérence** et l'énumération de **MUS** (sous-ensembles incohérents minimaux)."
    ]
   },
   {
@@ -622,9 +724,23 @@
    "source": [
     "## Exercices\n",
     "\n",
-    "Les exercices ci-dessous reutilisent les opérateurs construits plus haut (`levi`, la contraction\n",
-    "par noyaux, le raisonneur `reasoner`, le `parser`). Completez les stubs ; la base reste executable\n",
-    "de bout en bout même si les exercices ne sont pas remplis."
+    "Les exercices ci-dessous réutilisent les opérateurs construits plus haut (`levi`, la contraction\n",
+    "par noyaux, le raisonneur `reasoner`, le `parser`). Complétez les stubs ; la base reste\n",
+    "exécutable de bout en bout même si les exercices ne sont pas remplis.\n",
+    "\n",
+    "**Critères de réussite** (vérifiables sur la sortie de chaque exercice) :\n",
+    "\n",
+    "- **Exercice 1** (réviser `K = {pluie, pluie => sol_mouille}` par `!sol_mouille`) : la base\n",
+    "  révisée doit être **cohérente** (`incoherent ? false`) et **contenir `!sol_mouille`** —\n",
+    "  l'une des deux formules initiales aura été sacrifiée par l'incision (laquelle ? ça dépend\n",
+    "  du tirage).\n",
+    "- **Exercice 2** (contracter `K = {x, x=>y, y=>z}` par `z`) : après contraction, la base ne\n",
+    "  doit **plus impliquer `z`** — en général deux noyaux existent (`{x, x=>y}`... la chaîne\n",
+    "  complète), et l'incision doit couper chaque chemin vers `z`.\n",
+    "- **Exercice 3** (révision vs union naïve sur `K = {m, m=>n, !o}` et `!n`) : l'union naïve\n",
+    "  compte **4 formules** et est incohérente ; la base révisée compte **au plus 4 formules**\n",
+    "  (au moins une sacrifiée) et reste **cohérente** — l'écart de cardinal entre les deux\n",
+    "  mesure le coût épistémique de la cohérence."
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml
@@ -20,6 +20,12 @@
       csharp_sha: a1787c539d0e66bfb4f097a519e55c15dfb9e217
       content_python_sha: 3397c3499d41f331f9917039d1b006be638d069490079ec8567b04cd826c64c4
       content_csharp_sha: 56beaf6154fcb031066bc2c38ade50dc672fd7a8ff2d70e419c6b78d2f56a20b
+    - date: "2026-08-18"
+      by: myia-po-2023:CoursIA-2
+      python_sha: 9199041fda10f4ea0691c2130d0b77b7530ffea6
+      csharp_sha: 2fe788ad0ec751afb1ea6c14d763f8af543ce6a9
+      content_python_sha: 3397c3499d41f331f9917039d1b006be638d069490079ec8567b04cd826c64c4
+      content_csharp_sha: a584b14de637f6800f8809a29b243c09a0dd4bebdd7ab37b5a9cd1eb9cc72ff0
   known_differences:
     - "Socle commun : revision des croyances (AGM, contraction/revision) via TweetyProject."
     - "Lib-vs-lib : C# via IKVM (`using org.tweetyproject.*`). Python via JPype (`from java.util import ArrayList, HashSet` + `from jpype.types import *`). Meme fondement Java, idiomatique de pont differente."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11339 (genre changé : rotation ; famille changée : GenAI→SymbolicAI, veine cross-family densité)

## Summary

Tranche densité cross-family (protocole #10488, veine ouverte par le scan 218 débiteurs —
quota #11271 GenAI 1/lane/jour déjà consommé par cette lane) :
**SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb**, densité pédagogique **585 → 1312**
chars de prose / cellule code (organe `pedagogy_density.py`, seuil 1200, re-mesuré frais
origin/main). Enrichissement **markdown-only FR** — les 11 cellules code sont **byte-identiques**
(diff structurel cellule-à-cellule), aucune re-exec requise (exception markdown-only C.3), outputs
intacts. 10 cellules markdown réécrites/enrichies + 3 lectures nouvelles, 165 insertions / 49 deletions.

## Les lectures ajoutées (toutes ancrées sur les outputs committés)

| Lecture | Valeurs citées |
|---|---|
| **Setup IKVM** : les trois étages du runtime (version, home isolé par RID, `tzdb=True`) — pourquoi la base de fuseaux Java est le témoin le plus fin de la complétude de l'émulation JVM | `IKVM 8.15.0 pret (home=ikvm-home-8.15.0-win-x64, tzdb=True)` |
| **Chargement DLL** : `AssemblyName.GetAssemblyName` lit les métadonnées sans exécuter — vérification tôt parce que `#r` est silencieux en .NET Interactive (constat #5039), l'erreur n'apparaît qu'au premier appel de type manquant | `v1.30.0.0 (9,0 Mo)` |
| **Base incohérente** : `K = {(a=>b), a, !c}` a des modèles, l'union naïve `{(a=>b), a, !b, !c}` zéro (a et a=>b forcent b que !b nie) — le principe d'explosion annule le raisonnement, pas ne le dégrade pas | `false` → `true` |
| **Contraction par noyaux** : le noyau pour b était `{a, (a=>b)}` (minimal), l'incision a choisi `(a=>b)` — **ce qui est garanti** (ne plus impliquer b) vs **ce qui ne l'est pas** (la formule retirée, aléatoire sous `RandomIncisionFunction`) | `[a, !c]`, `false` |
| **Identité de Levi visible dans le contenu** : le résultat `[a, !b, !c]` est littéralement la base contractée de la section 4 + `!b` — la formule K*phi = (K-!phi)+phi se lit dans la sortie, pas seulement dans le titre | `[a, !b, !c]`, `True` |
| **Pingouin** : `Croyance(s) abandonnée(s) : [(p=>b)]` — l'intuition biologique sacrifierait `b=>f`, l'incision aléatoire a tiré `p=>b`, produisant une révision **valide mais absurde** (un pingouin qui ne serait pas un oiseau). AGM garantit la cohérence, jamais la pertinence : la fonction d'incision est le point d'injection des connaissances de domaine | `[(p=>b)]` |
| **Exercices** : critères de réussite chiffrés par exercice (ex 1 : cohérente + contient !sol_mouille ; ex 2 : n'implique plus z ; ex 3 : union 4 formules incohérente vs révisée ≤4 cohérente — l'écart de cardinal mesure le coût épistémique) | stubs 1-3 |
| **Conclusion enrichie** : les trois idées au-delà des opérateurs (explosion = annulation ; incision = préférences ; Levi = composition auditable) | — |

## Validation

- Mesure avant/après : `pedagogy_density.py --json` → 585 → **1312** (status `ok`, plus dans `below_threshold`).
- 11/11 cellules code byte-identiques (diff structurel, base `git show origin/main:`).
- Interps ancrées : chaque valeur citée provient de l'output de la cellule précédente ;
  `scan_cell_ordering.py` : 1 clean, 0 finding.
- Stubs d'exercices C.1 intacts (3 exos conservés, `Exercice N a completer`) ; pas d'erreur volontaire ;
  catalogue byte-identique (0 diff).
- `validate_pr_notebooks.py origin/main` : 1/1 PASS (11 cells, kernel `.net-csharp`).
- File CI mesurée avant ouverture : 30 PRs ouvertes (<200).
- Collision guard : aucune PR ouverte sur Tweety-4 (Tweety-2 #11338 et Arrow-Csharp claim 21:47Z exclus du choix) ;
  claim dashboard posé 22:05Z avant édition.

## Regression check

- Fichier unique, markdown-only, 165 ins / 49 del — aucune cellule code touchée.
- Aucun symbole code modifié ; outputs et `execution_count` intacts.

See #11224 (veine cross-family, protocole #10488 — 1 notebook = 1 PR)
