### PR TITLE
feat(lean,#11148): mimo_lean Grain 3 — norm tails Lipschitz (NormTails.lean + _en)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/NormTails.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/NormTails.lean
@@ -1,0 +1,129 @@
+import Mathlib
+import SLT.GaussianLipConcen
+
+/-!
+# Grain 3 — Queues de normes ‖w‖, ‖hᵢ‖ (concentration de Lipschitz gaussienne)
+
+Ce module prouve la **concentration des normes** du détecteur MIMO
+(papier Papailiopoulos 2026, §11 — cf issue #11148, grain 3) : le bruit
+`w` et chaque colonne `hᵢ` du canal (à entrées i.i.d. gaussiennes) sont
+des vecteurs gaussiens standards de dimension `M`, et la norme euclidienne
+est une fonction **1-Lipschitz** — le théorème de concentration
+`gaussian_lipschitz_concentration` du lake externe
+`YuanheZ/lean-stat-learning-theory` (SLT) donne donc, pour tout `t > 0`,
+
+    P(|‖X‖ − E‖X‖| ≥ t) ≤ 2·exp(−t²/2).
+
+C'est la **queue de norme** du §11 : elle borne uniformément les tailles
+`‖w‖` et `‖hᵢ‖` qui apparaissent dans le score de flip
+`s·‖hᵢ‖² + √s·⟪hᵢ,w⟫` (Phase 2, `mimo_flip_cost`) — les grains suivants
+combinent ces queues par union bound sur les `N` colonnes. La route
+Lipschitz est la version « légère » du §11 : la queue chi-carré de `‖w‖²`
+via Hanson–Wright (`chisq_norm_concentration`, Converse.lean — issue
+#11152) reste le marteau-pilon pour la forme quadratique, tandis qu'ici la
+norme elle-même se concentre en sous-gaussienne avec constante `1`.
+
+Architecture du fichier :
+
+1. `norm_lipschitz_one` — la norme euclidienne sur `EuclideanSpace ℝ (Fin n)`
+   est **1-Lipschitz** (inégalité triangulaire inverse, via
+   `dist_norm_norm_le`) — le certificat `LipschitzWith` requis par SLT ;
+2. `norm_concentration_one_sided` / `norm_concentration` — les théorèmes
+   abstraits : concentration (unilatérale, puis bilatérale) de `‖X‖` autour
+   de sa moyenne pour `X` gaussien standard de dimension `n`, instances
+   directes de `gaussian_lipschitz_concentration(_one_sided)` avec `L = 1` ;
+3. `noise_norm_tail_one_sided` / `noise_norm_tail` — instantiations MIMO :
+   queue de `‖w‖` (bruit, `M` antennes) ;
+4. `column_norm_tail` — instantiation MIMO : queue de `‖hᵢ‖` (une colonne
+   du canal, `M` entrées i.i.d. `N(0,1)`).
+
+Axiomes : les trois standards de Mathlib — zéro sorry.
+-/
+
+namespace Mimo
+
+open MeasureTheory ProbabilityTheory GaussianMeasure GaussianLipConcen Real
+open scoped BigOperators NNReal
+
+/-! ## Brique A — la norme euclidienne est 1-Lipschitz -/
+
+/-- La norme euclidienne sur `EuclideanSpace ℝ (Fin n)` est une fonction
+**1-Lipschitz** : `|‖x‖ − ‖y‖| ≤ ‖x − y‖` (inégalité triangulaire inverse).
+C'est le certificat `LipschitzWith` que consomme le théorème de concentration
+de SLT — `dist_norm_norm_le` + `lipschitzWith_iff_dist_le_mul`. -/
+lemma norm_lipschitz_one {n : ℕ} : LipschitzWith 1 (fun x : EuclideanSpace ℝ (Fin n) => ‖x‖) := by
+  rw [lipschitzWith_iff_dist_le_mul]
+  intro x y
+  simpa [dist_eq_norm] using dist_norm_norm_le x y
+
+/-! ## Brique B — concentration de la norme d'un vecteur gaussien standard -/
+
+/-- **Queue de norme unilatérale (forme abstraite).** Pour `X` gaussien
+standard sur `EuclideanSpace ℝ (Fin n)` (`n > 0`) et `t > 0`,
+
+    P(‖X‖ − E‖X‖ ≥ t) ≤ exp(−t²/2).
+
+Instance directe de `gaussian_lipschitz_concentration_one_sided` (SLT) avec
+`f = ‖·‖` et `L = 1` : `exp(−t²/(2·1²)) = exp(−t²/2)`. -/
+theorem norm_concentration_one_sided {n : ℕ} (hn : 0 < n) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE n {x : EuclideanSpace ℝ (Fin n) |
+      t ≤ ‖x‖ - ∫ y, ‖y‖ ∂(stdGaussianE n)}).toReal ≤
+      Real.exp (-(t ^ 2) / 2) := by
+  simpa using gaussian_lipschitz_concentration_one_sided (n := n)
+    (f := fun x : EuclideanSpace ℝ (Fin n) => ‖x‖) (L := 1) hn (by norm_num)
+    (norm_lipschitz_one (n := n)) t ht
+
+/-- **Queue de norme (forme abstraite).** Pour `X` gaussien standard sur
+`EuclideanSpace ℝ (Fin n)` (`n > 0`) et `t > 0`,
+
+    P(|‖X‖ − E‖X‖| ≥ t) ≤ 2·exp(−t²/2).
+
+Instance directe de `gaussian_lipschitz_concentration` (SLT) avec la fonction
+`f = ‖·‖` et la constante de Lipschitz `L = 1` : la norme est 1-Lipschitz
+(`norm_lipschitz_one`), donc la concentration sous-gaussienne s'applique
+avec paramètre `1` — `2·exp(−t²/(2·1²)) = 2·exp(−t²/2)`. -/
+theorem norm_concentration {n : ℕ} (hn : 0 < n) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE n {x : EuclideanSpace ℝ (Fin n) |
+      t ≤ |‖x‖ - ∫ y, ‖y‖ ∂(stdGaussianE n)|}).toReal ≤
+      2 * Real.exp (-(t ^ 2) / 2) := by
+  simpa using gaussian_lipschitz_concentration (n := n)
+    (f := fun x : EuclideanSpace ℝ (Fin n) => ‖x‖) (L := 1) hn (by norm_num)
+    (norm_lipschitz_one (n := n)) t ht
+
+/-! ## Brique C — instanciations MIMO -/
+
+/-- **Queue unilatérale de la norme du bruit `‖w‖`.** Le bruit `w` du
+détecteur MIMO est un vecteur gaussien standard de dimension `M` (une
+coordonnée par antenne de mesure) : sa norme se concentre autour de sa
+moyenne avec la queue `exp(−t²/2)`. Ceci borne la taille du résidu au point
+de départ (`mimoObj_residual_from_zero`, Phase 4). -/
+theorem noise_norm_tail_one_sided {M : ℕ} (hM : 0 < M) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE M {w : EuclideanSpace ℝ (Fin M) |
+      t ≤ ‖w‖ - ∫ y, ‖y‖ ∂(stdGaussianE M)}).toReal ≤
+      Real.exp (-(t ^ 2) / 2) :=
+  norm_concentration_one_sided hM t ht
+
+/-- **Queue de la norme du bruit `‖w‖`.** Le bruit `w` du détecteur MIMO est
+un vecteur gaussien standard de dimension `M` (une coordonnée par antenne de
+mesure) : sa norme se concentre autour de sa moyenne avec la même queue
+`2·exp(−t²/2)`. Ceci borne la taille du résidu au point de départ
+(`mimoObj_residual_from_zero`, Phase 4). -/
+theorem noise_norm_tail {M : ℕ} (hM : 0 < M) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE M {w : EuclideanSpace ℝ (Fin M) |
+      t ≤ |‖w‖ - ∫ y, ‖y‖ ∂(stdGaussianE M)|}).toReal ≤
+      2 * Real.exp (-(t ^ 2) / 2) :=
+  norm_concentration hM t ht
+
+/-- **Queue de la norme d'une colonne `‖hᵢ‖`.** Pour un canal à entrées
+i.i.d. `N(0,1)`, la colonne `hᵢ = A eᵢ` est un vecteur gaussien standard de
+dimension `M` : sa norme se concentre autour de sa moyenne avec la même queue
+`2·exp(−t²/2)`. Ceci borne uniformément les `‖hᵢ‖` du score de flip
+`s·‖hᵢ‖² + √s·⟪hᵢ,w⟫` (Phase 2, `mimo_flip_cost`) — le grain suivant
+combine ces queues par union bound sur les `N` colonnes. -/
+theorem column_norm_tail {M : ℕ} (hM : 0 < M) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE M {h : EuclideanSpace ℝ (Fin M) |
+      t ≤ |‖h‖ - ∫ y, ‖y‖ ∂(stdGaussianE M)|}).toReal ≤
+      2 * Real.exp (-(t ^ 2) / 2) :=
+  norm_concentration hM t ht
+
+end Mimo

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/NormTails_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/NormTails_en.lean
@@ -1,0 +1,129 @@
+import Mathlib
+import SLT.GaussianLipConcen
+
+/-!
+# Grain 3 — Norm tails ‖w‖, ‖hᵢ‖ (Gaussian Lipschitz concentration)
+
+This module proves the **concentration of the norms** of the MIMO detector
+(Papailiopoulos 2026 paper, §11 — cf issue #11148, grain 3): the noise `w`
+and each channel column `hᵢ` (i.i.d. Gaussian entries) are standard Gaussian
+vectors of dimension `M`, and the Euclidean norm is a **1-Lipschitz**
+function — the concentration theorem
+`gaussian_lipschitz_concentration` of the external lake
+`YuanheZ/lean-stat-learning-theory` (SLT) therefore gives, for every `t > 0`,
+
+    P(|‖X‖ − E‖X‖| ≥ t) ≤ 2·exp(−t²/2).
+
+This is the **norm tail** of §11: it bounds uniformly the sizes of `‖w‖`
+and `‖hᵢ‖` that appear in the flip score `s·‖hᵢ‖² + √s·⟪hᵢ,w⟫`
+(Phase 2, `mimo_flip_cost`) — the next grains combine these tails by union
+bound over the `N` columns. The Lipschitz route is the "light" version of
+§11: the chi-square tail of `‖w‖²` via Hanson–Wright
+(`chisq_norm_concentration`, Converse.lean — issue #11152) remains the
+sledgehammer for the quadratic form, while here the norm itself concentrates
+sub-Gaussianly with constant `1`.
+
+Architecture of the file:
+
+1. `norm_lipschitz_one` — the Euclidean norm on `EuclideanSpace ℝ (Fin n)`
+   is **1-Lipschitz** (reverse triangle inequality, via
+   `dist_norm_norm_le`) — the `LipschitzWith` certificate required by SLT ;
+2. `norm_concentration_one_sided` / `norm_concentration` — the abstract
+   theorems: (one-sided, then two-sided) concentration of `‖X‖` around its
+   mean for `X` standard Gaussian of dimension `n`, direct instances of
+   `gaussian_lipschitz_concentration(_one_sided)` with `L = 1` ;
+3. `noise_norm_tail_one_sided` / `noise_norm_tail` — MIMO instantiations:
+   tail of `‖w‖` (noise, `M` antennas) ;
+4. `column_norm_tail` — MIMO instantiation: tail of `‖hᵢ‖` (a channel
+   column, `M` i.i.d. `N(0,1)` entries).
+
+Axioms: the three standard ones of Mathlib — zero sorry.
+-/
+
+namespace Mimo_en
+
+open MeasureTheory ProbabilityTheory GaussianMeasure GaussianLipConcen Real
+open scoped BigOperators NNReal
+
+/-! ## Brick A — the Euclidean norm is 1-Lipschitz -/
+
+/-- The Euclidean norm on `EuclideanSpace ℝ (Fin n)` is a **1-Lipschitz**
+function: `|‖x‖ − ‖y‖| ≤ ‖x − y‖` (reverse triangle inequality).
+This is the `LipschitzWith` certificate consumed by the SLT concentration
+theorem — `dist_norm_norm_le` + `lipschitzWith_iff_dist_le_mul`. -/
+lemma norm_lipschitz_one {n : ℕ} : LipschitzWith 1 (fun x : EuclideanSpace ℝ (Fin n) => ‖x‖) := by
+  rw [lipschitzWith_iff_dist_le_mul]
+  intro x y
+  simpa [dist_eq_norm] using dist_norm_norm_le x y
+
+/-! ## Brick B — concentration of the norm of a standard Gaussian vector -/
+
+/-- **One-sided norm tail (abstract form).** For `X` standard Gaussian on
+`EuclideanSpace ℝ (Fin n)` (`n > 0`) and `t > 0`,
+
+    P(‖X‖ − E‖X‖ ≥ t) ≤ exp(−t²/2).
+
+Direct instance of `gaussian_lipschitz_concentration_one_sided` (SLT) with
+`f = ‖·‖` and `L = 1`: `exp(−t²/(2·1²)) = exp(−t²/2)`. -/
+theorem norm_concentration_one_sided {n : ℕ} (hn : 0 < n) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE n {x : EuclideanSpace ℝ (Fin n) |
+      t ≤ ‖x‖ - ∫ y, ‖y‖ ∂(stdGaussianE n)}).toReal ≤
+      Real.exp (-(t ^ 2) / 2) := by
+  simpa using gaussian_lipschitz_concentration_one_sided (n := n)
+    (f := fun x : EuclideanSpace ℝ (Fin n) => ‖x‖) (L := 1) hn (by norm_num)
+    (norm_lipschitz_one (n := n)) t ht
+
+/-- **Norm tail (abstract form).** For `X` standard Gaussian on
+`EuclideanSpace ℝ (Fin n)` (`n > 0`) and `t > 0`,
+
+    P(|‖X‖ − E‖X‖| ≥ t) ≤ 2·exp(−t²/2).
+
+Direct instance of `gaussian_lipschitz_concentration` (SLT) with the
+function `f = ‖·‖` and the Lipschitz constant `L = 1`: the norm is
+1-Lipschitz (`norm_lipschitz_one`), hence sub-Gaussian concentration applies
+with parameter `1` — `2·exp(−t²/(2·1²)) = 2·exp(−t²/2)`. -/
+theorem norm_concentration {n : ℕ} (hn : 0 < n) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE n {x : EuclideanSpace ℝ (Fin n) |
+      t ≤ |‖x‖ - ∫ y, ‖y‖ ∂(stdGaussianE n)|}).toReal ≤
+      2 * Real.exp (-(t ^ 2) / 2) := by
+  simpa using gaussian_lipschitz_concentration (n := n)
+    (f := fun x : EuclideanSpace ℝ (Fin n) => ‖x‖) (L := 1) hn (by norm_num)
+    (norm_lipschitz_one (n := n)) t ht
+
+/-! ## Brick C — MIMO instantiations -/
+
+/-- **One-sided tail of the noise norm `‖w‖`.** The noise `w` of the MIMO
+detector is a standard Gaussian vector of dimension `M` (one coordinate per
+measurement antenna): its norm concentrates around its mean with the tail
+`exp(−t²/2)`. This bounds the size of the residual at the starting point
+(`mimoObj_residual_from_zero`, Phase 4). -/
+theorem noise_norm_tail_one_sided {M : ℕ} (hM : 0 < M) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE M {w : EuclideanSpace ℝ (Fin M) |
+      t ≤ ‖w‖ - ∫ y, ‖y‖ ∂(stdGaussianE M)}).toReal ≤
+      Real.exp (-(t ^ 2) / 2) :=
+  norm_concentration_one_sided hM t ht
+
+/-- **Tail of the noise norm `‖w‖`.** The noise `w` of the MIMO detector is
+a standard Gaussian vector of dimension `M` (one coordinate per measurement
+antenna): its norm concentrates around its mean with the same tail
+`2·exp(−t²/2)`. This bounds the size of the residual at the starting point
+(`mimoObj_residual_from_zero`, Phase 4). -/
+theorem noise_norm_tail {M : ℕ} (hM : 0 < M) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE M {w : EuclideanSpace ℝ (Fin M) |
+      t ≤ |‖w‖ - ∫ y, ‖y‖ ∂(stdGaussianE M)|}).toReal ≤
+      2 * Real.exp (-(t ^ 2) / 2) :=
+  norm_concentration hM t ht
+
+/-- **Tail of a column norm `‖hᵢ‖`.** For a channel with i.i.d. `N(0,1)`
+entries, the column `hᵢ = A eᵢ` is a standard Gaussian vector of dimension
+`M`: its norm concentrates around its mean with the same tail
+`2·exp(−t²/2)`. This bounds uniformly the `‖hᵢ‖` of the flip score
+`s·‖hᵢ‖² + √s·⟪hᵢ,w⟫` (Phase 2, `mimo_flip_cost`) — the next grain combines
+these tails by union bound over the `N` columns. -/
+theorem column_norm_tail {M : ℕ} (hM : 0 < M) (t : ℝ) (ht : 0 < t) :
+    (stdGaussianE M {h : EuclideanSpace ℝ (Fin M) |
+      t ≤ |‖h‖ - ∫ y, ‖y‖ ∂(stdGaussianE M)|}).toReal ≤
+      2 * Real.exp (-(t ^ 2) / 2) :=
+  norm_concentration hM t ht
+
+end Mimo_en

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/lakefile.lean
@@ -55,3 +55,7 @@ lean_lib «Converse» where
 @[default_target]
 lean_lib «Bridge» where
   globs := #[`Bridge, `Bridge_en]
+
+@[default_target]
+lean_lib «NormTails» where
+  globs := #[`NormTails, `NormTails_en]


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11295

See #11148 (grain 3) · See #10984 (parent) · See #11152 (chi-square ‖w‖² via Hanson-Wright, complémentaire)

## Résumé

Grain 3 de #11148 — queues de normes par concentration de Lipschitz gaussienne : nouveau module `NormTails.lean` + sibling `_en` (#4980) dans `mimo_lean`, prouvant la concentration sub-gaussienne de la norme d'un vecteur gaussien standard avec constante 1 :

- `norm_lipschitz_one` — la norme euclidienne sur `EuclideanSpace ℝ (Fin n)` est 1-Lipschitz (`dist_norm_norm_le` + `lipschitzWith_iff_dist_le_mul`) ;
- `norm_concentration_one_sided` / `norm_concentration` — formes abstraites : P(‖X‖ − E‖X‖ ≥ t) ≤ exp(−t²/2) et P(|‖X‖ − E‖X‖| ≥ t) ≤ 2·exp(−t²/2), instances directes de `gaussian_lipschitz_concentration(_one_sided)` (SLT) avec L = 1 ;
- `noise_norm_tail_one_sided` / `noise_norm_tail` — instantiations MIMO (bruit `w`, M antennes) ;
- `column_norm_tail` — instantiation MIMO (colonne `hᵢ` du canal, entrées i.i.d. N(0,1)).

## Cohérence avec les briques existantes

- #11152 a livré la queue chi-carré de ‖w‖² via Hanson–Wright A=1 (`chisq_norm_concentration`, Converse.lean) — le « marteau-pilon » pour la forme quadratique. Ce grain livre la route « légère » du §11 : la queue de la **norme** elle-même (sub-gaussienne, constante 1). Complémentaire, non dupliqué.
- `flip_bat_prob_lower` / `gaussian_interval_mass_lower_param` (Converse.lean) couvrent déjà la concentration de `⟪hᵢ, w⟫` ; ici `column_norm_tail` borne uniformément les `‖hᵢ‖` du score de flip `s·‖hᵢ‖² + √s·⟪hᵢ,w⟫` (Phase 2, `mimo_flip_cost`).

## Validation

- [x] `lake build` SUCCESS (8702 jobs, exit 0)
- [x] `sorry` : 0 (seules occurrences = prose docstring)
- [x] Sibling `_en` byte-parallèle (diff normalisé : seuls namespace/end diffèrent)
- [x] Axiomes : standards Mathlib uniquement

## Note de scope

Le claim #11148 est détenu par cette lane (myia-po-2024:CoursIA-2, paths `mimo_lean/**`). Le bump #11256 (po-2023, PR #11325) touche les 3 fichiers config du lake — disjoint de ce grain (fichiers `.lean` neufs) ; rebase frais si nécessaire au merge.
