### PR TITLE
feat(notebooks,#11224): densite Lab1-PythonForDataScience 627->1715 (enrichissement markdown-only, lectures ancrees)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day1-Foundations/Labs/Lab1-PythonForDataScience.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day1-Foundations/Labs/Lab1-PythonForDataScience.ipynb
@@ -51,7 +51,17 @@
    "source": [
     "## Introduction à Pandas\n",
     "\n",
-    "Pandas est une bibliothèque essentielle pour la manipulation de données en Python. Elle introduit la notion de DataFrame, une structure de données tabulaire puissante."
+    "Pandas est la bibliothèque de référence pour la manipulation de données en Python. Elle introduit\n",
+    "deux structures : la **Series** (un vecteur indexé, une colonne) et le **DataFrame** (un tableau\n",
+    "à deux axes — lignes indexées, colonnes nommées) qui couvre l'essentiel des besoins de la data\n",
+    "science tabulaire. Pourquoi un DataFrame plutôt qu'une liste de listes ? Parce que chaque colonne\n",
+    "porte un **dtype** contrôlé (entier, chaîne, date), que les opérations sont **vectorisées** (filtrer,\n",
+    "moyenner, grouper s'écrivent en une expression, sans boucle) et que l'alignement par **index**\n",
+    "empêche les erreurs d'appariement silencieuses. La cellule ci-dessous montre d'abord un DataFrame\n",
+    "minimal construit à la main, puis construit le dataset qui servira à tout le laboratoire : des\n",
+    "**ventes quotidiennes** de cinq produits sur soixante jours. Notez le `np.random.seed(42)` : le\n",
+    "dataset est synthétique mais **déterministe** — ré-exécuter le notebook produira exactement les\n",
+    "mêmes chiffres que ceux commentés dans la suite."
    ]
   },
   {
@@ -274,6 +284,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du dataset** — la sortie résume la construction : `300 enregistrements sur 60 jours`,\n",
+    "`5 produits`, `3 catégories`. D'où viennent ces chiffres ? Cinq produits vendus chaque jour pendant\n",
+    "60 jours : 5 x 60 = 300 lignes, exactement. L'aperçu montre la structure : une ligne par **couple\n",
+    "(produit, jour)**, avec son prix unitaire (fixe par produit : Widget A a 150 partout) et ses ventes\n",
+    "(tirées aléatoirement — la seule colonne qui varie pour un produit donné). La colonne `Date` est\n",
+    "ici une chaîne, pas un type temporel : on le verra dans `info()` plus bas, et c'est une limite\n",
+    "réaliste d'un dataset fabriqué à la main. Enfin, le `np.random.seed(42)` du code garantit que ces\n",
+    "chiffres — 143 ventes de Widget A le 2024-01-01, 173 de Module Z — sont **les mêmes à chaque\n",
+    "exécution** : les lectures qui suivent citent des valeurs que vous retrouverez à l'identique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "dc7197a5",
    "metadata": {
     "papermill": {
@@ -288,7 +314,14 @@
    "source": [
     "## Exploration de Données\n",
     "\n",
-    "Une fois les données chargées, les premières étapes consistent à les explorer pour comprendre leur structure et leur contenu."
+    "Avant toute analyse, trois questions et trois outils pour y répondre : **à quoi ressemblent les\n",
+    "données ?** (`head()` — les premières lignes, brutes), **quelle est leur structure ?** (`info()` —\n",
+    "nombre de lignes, colonnes, dtypes, valeurs manquantes, empreinte mémoire) et **quelle est leur\n",
+    "distribution ?** (`describe()` — moyenne, écart-type, quartiles, extrêmes des colonnes numériques).\n",
+    "Cette triade suffit à détecter la plupart des problèmes de données avant qu'ils ne contaminent\n",
+    "l'analyse : colonne au mauvais dtype, valeurs manquantes, échelle aberrante. La cellule ajoute un\n",
+    "quatrième geste, le **groupby** — agréger les ventes par catégorie — qui est l'opération centrale\n",
+    "de l'analyse de données tabulaires : *segmenter, agréger, comparer*."
    ]
   },
   {
@@ -378,6 +411,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du trio d'inspection** — chaque outil répond à sa question. `head()` : cinq lignes,\n",
+    "une par produit du premier jour, l'ordre du dictionnaire de construction. `info()` : 300 entrées,\n",
+    "5 colonnes, **aucune valeur manquante** (`300 non-null` partout), dtypes `str` pour les trois\n",
+    "colonnes textuelles et `int64` pour les deux numériques, 20.2 KB en mémoire — un dataset propre,\n",
+    "où le seul point de vigilance est le `Date` en chaîne. `describe()` : les ventes vont de **26 à\n",
+    "284** autour d'une moyenne de **114.37** (écart-type 74.93) ; les quartiles montrent une\n",
+    "distribution étalée, pas concentrée. Détail révélateur : les colonnes de `Prix_Unitaire` ont des\n",
+    "quartiles qui tombent exactement sur **30 / 45 / 80 / 150 / 200** — les cinq prix de base, chacun\n",
+    "présent 60 fois (une fois par jour). Un describe qui affiche les valeurs *discrètes* d'une variable\n",
+    "« continue » est toujours la trace d'une construction synthétique. Et le `groupby` final établit\n",
+    "la hiérarchie commerciale : Accessoires **42.64**, Electronique **131.33**, Premium **223.90** —\n",
+    "un facteur 5 entre les extrêmes, structurant pour tout ce qui suit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "3d48fe3e",
    "metadata": {
     "papermill": {
@@ -392,7 +444,15 @@
    "source": [
     "## Sélection et Filtrage\n",
     "\n",
-    "Apprenons à sélectionner des colonnes spécifiques et à filtrer les lignes en fonction de conditions."
+    "Deux gestes distincts qu'il ne faut pas confondre : la **sélection** (`df['Produit']`) extrait des\n",
+    "colonnes — le résultat est une **Series**, le vecteur des valeurs d'une variable ; le **filtrage**\n",
+    "(`df[df['Ventes'] > 100]`) extrait des lignes — le résultat est un **DataFrame** complet, réduit\n",
+    "aux lignes qui satisfont la condition. Le filtrage exploite le **masque booléen** : `df['Ventes'] > 100`\n",
+    "produit d'abord un vecteur de True/False (une par ligne), puis les crochets ne gardent que les\n",
+    "lignes vraies. C'est ce mécanisme qui rend les conditions composées naturelles —\n",
+    "`df[(df['Categorie'] == 'Electronique') & (df['Ventes'] > 100)]` combine les masques avec `&` et\n",
+    "`|` (et non `and`/`or`, qui ne savent pas se vectoriser). La cellule montre les deux, plus la\n",
+    "sélection simultanée de colonnes via une liste `df[['Date', 'Produit', 'Ventes']]`."
    ]
   },
   {
@@ -465,6 +525,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du filtrage** — la sélection retourne bien une Series (une colonne, son dtype `str`,\n",
+    "son index) ; le filtrage retourne bien un DataFrame réduit. `Ventes > 100` garde **135\n",
+    "enregistrements sur 300** — 45 % des lignes, cohérent avec une moyenne à 114.37 : un seuil posé\n",
+    "presque à la moyenne coupe mécaniquement la population à peine sous la moitié. Le filtre par\n",
+    "catégorie donne **120** lignes : deux produits Electronique x 60 jours, exactement le compte\n",
+    "attendu — quand un filtre retourne *pile* le produit cartésien attendu, c'est le signe que le\n",
+    "dataset n'a pas de trou. Dernier détail instructif : les index des lignes filtrées (0, 4, 5, 9,\n",
+    "10...) sont **non contigus et préservés** — le masque ne renumérote pas, il sélectionne ; pour\n",
+    "réindexer, il faudrait `.reset_index(drop=True)` explicitement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1130c5f1",
    "metadata": {
     "papermill": {
@@ -479,7 +555,14 @@
    "source": [
     "## Visualisation de Données\n",
     "\n",
-    "La visualisation est cruciale pour comprendre les tendances. Nous utiliserons Matplotlib pour créer un graphique simple."
+    "La visualisation n'est pas une décoration : c'est un **outil de diagnostic**. La cellule construit\n",
+    "une figure à deux panneaux (`plt.subplots(1, 2)`) parce qu'elle pose deux questions différentes :\n",
+    "une **série temporelle** (courbe) — comment les ventes d'un produit évoluent-elles dans le temps ? —\n",
+    "et une **comparaison de groupes** (barres) — quelles catégories vendent le plus ? Chaque type de\n",
+    "question a son geométrie : la courbe préserve l'ordre temporel, la barre compare des grandeurs\n",
+    "indépendantes. Interchanger les deux (barres pour une série, courbe pour des catégories) rend le\n",
+    "graphique illisible — c'est la première décision de design à prendre, avant toute question\n",
+    "d'esthétique (`figsize`, couleurs, rotation des étiquettes)."
    ]
   },
   {
@@ -537,6 +620,22 @@
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture de la figure** — les deux panneaux racontent la même histoire sous deux angles.\n",
+    "À gauche, la courbe de Widget A sur 20 jours : **143, 130, 123...** elle saute de jour en jour sans\n",
+    "tendance nette — c'est du bruit autour d'un niveau, pas une croissance. Retenez cette impression\n",
+    "visuelle : la section suivante ajustera précisément une tendance sur ces ventes, et son score\n",
+    "faible confirmera ce que l'œil voit déjà — il n'y a presque rien à expliquer par le temps seul.\n",
+    "À droite, les barres reprennent le groupby de l'exploration (42.64 / 131.33 / 223.90) : la hiérarchie\n",
+    "des catégories y est lisible d'un coup d'œil, c'est exactement le travail d'une barre — comparer\n",
+    "trois grandeurs indépendantes. Les deux graphiques ensemble posent la question qui structure la\n",
+    "fin du labo : *ce qui explique les ventes est-il le temps (courbe) ou le produit (barres) ?*"
    ]
   },
   {
@@ -646,6 +745,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "",
+   "metadata": {},
+   "source": [
+    "**Lecture du modèle — un R² honnête** : la sortie donne **R² = 0.229**, et c'est le chiffre le\n",
+    "plus instructif du laboratoire. Le modèle régresse les ventes sur le **numéro de jour seul** :\n",
+    "R² = 0.229 signifie qu'il explique **23 % de la variance** — et donc que 77 % dépendent d'autre\n",
+    "chose. L'autre chose, la figure précédente vient de la nommer : le produit (facteur 5 entre\n",
+    "catégories). Les autres métriques se lisent ensemble : **RMSE = 20.66** ventes d'erreur typique,\n",
+    "à rapporter à la moyenne 114.37 (~18 % d'erreur relative) ; **coefficient 0.7251** — le modèle\n",
+    "n'apprend qu'une hausse de **+0.73 vente par jour**, un effet minuscule ; **intercept 148.96** —\n",
+    "le niveau de départ. Enfin la **prédiction du jour 90 : 214.22** : 148.96 + 90 x 0.7251, la droite\n",
+    "extrapolée... sur un dataset qui s'arrête au jour 60. Prédire au-delà du domaine observé est\n",
+    "l'erreur classique de la régression temporelle — la sortie est arithmétiquement exacte et\n",
+    "statistiquement téméraire. La leçon : un score faible n'est pas un échec de code mais une\n",
+    "**information** — la variable explicative choisie (le temps) ne porte qu'un quart du phénomène."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "usehv1a6pxl",
    "metadata": {
     "papermill": {
@@ -658,16 +776,24 @@
     "tags": []
    },
    "source": [
-    "## 🎯 Exercices Pratiques\n",
+    "## Exercices Pratiques\n",
     "\n",
-    "### Exercice 1 : Calcul de statistiques par produit\n",
+    "Les trois exercices réutilisent le DataFrame `df` et les gestes vus plus haut (`groupby`,\n",
+    "filtrage booléen, régression). Les cellules sont des stubs : complétez-les, le notebook reste\n",
+    "exécutable de bout en bout même non rempli.\n",
     "\n",
-    "À partir du DataFrame `df`, calculez et affichez :\n",
-    "1. Le total des ventes pour chaque produit (Widget A et Widget B)\n",
-    "2. La moyenne des ventes par produit\n",
-    "3. Le jour avec les ventes les plus élevées pour chaque produit\n",
+    "**Critères de réussite** (vérifiables sur vos sorties) :\n",
     "\n",
-    "**Indices** : Utilisez `groupby()` et les fonctions d'agrégation de Pandas."
+    "- **Exercice 1** : trois sorties distinctes (total, moyenne, jour max par produit) sur **Widget A\n",
+    "  et Widget B** ; les moyennes doivent être de l'ordre de grandeur des ventes de la catégorie\n",
+    "  Electronique (~131 en moyenne) — une moyenne à 20 ou à 400 signale une agrégation sur la\n",
+    "  mauvaise colonne.\n",
+    "- **Exercice 2** : un compte d'enregistrements **strictement inférieur** aux 120 lignes\n",
+    "  Electronique (vous filtrez au-dessus de la moyenne *globale* 114.37) et cohérent avec la\n",
+    "  distribution de la catégorie.\n",
+    "- **Exercice 3** : deux modèles séparés, **deux coefficients différents** — chaque produit a sa\n",
+    "  propre dynamique ; une prédiction du jour 7 identique pour les deux produits signale que vous\n",
+    "  avez régressé sur le DataFrame complet au lieu de filtrer par produit."
    ]
   },
   {
@@ -818,9 +944,14 @@
    "source": [
     "### Exercice 3 : Prédictions pour chaque produit\n",
     "\n",
-    "Entraînez un modèle de régression linéaire **séparé** pour chaque produit (Widget A et Widget B), puis prédisez les ventes pour le jour 7 de chacun.\n",
+    "Entraînez un modèle de régression linéaire **séparé** pour chaque produit (Widget A et Widget B),\n",
+    "puis prédisez les ventes pour le jour 7 de chacun.\n",
     "\n",
-    "**Indices** : Filtrez le DataFrame par produit avant d'entraîner le modèle."
+    "**Indices** : filtrez le DataFrame par produit avant d'entraîner (`df[df['Produit'] == 'Widget A']`),\n",
+    "exactement comme la cellule de visualisation a isolé Widget A pour sa courbe. Comparez enfin les\n",
+    "deux prédictions : l'écart entre elles mesure combien la dynamique temporelle diffère selon le\n",
+    "produit — un avant-goût de la question « le modèle devrait-il voir le produit ? » que la lecture\n",
+    "du modèle global posera."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #11340 (rotation genre ; famille ML/DataScienceWithAgents, veine cross-family densite)

## Summary

Tranche densite cross-family (protocole #10488, veine ouverte par le scan 218 debiteurs —
quota #11271 GenAI 1/lane/jour non consomme, pivot veine cross-family sans tracker dedie) :
**ML/DataScienceWithAgents/Track1-LangChain/Day1-Foundations/Labs/Lab1-PythonForDataScience.ipynb**,
densite pedagogique **627 → 1715** chars de prose / cellule code (organe `pedagogy_density.py`,
seuil 1200, re-mesure frais origin/main). Enrichissement **markdown-only FR** — les 8 cellules code
sont **byte-identiques** (diff structurel cellule-a-cellule : source + outputs + execution_count),
aucune re-exec requise (exception markdown-only C.3), outputs intacts. 6 cellules markdown
reecrites (dont 4 squelettes de 126-193 chars) + 5 lectures nouvelles, 147 insertions / 16 deletions.

## Les lectures ajoutees (toutes ancrees sur les outputs committes)

| Lecture | Valeurs citees |
|---|---|
| **Dataset** : 5 produits × 60 jours = 300 lignes exactement ; prix fixes par produit vs ventes aleatoires ; `np.random.seed(42)` = determinisme — les valeurs citees dans la suite se reproduisent a l'identique | 300 / 60 / 5 / 3, 143, 173 |
| **Trio d'inspection** : head (5 lignes du 1er jour), info (300×5, 0 null, `str`/`int64`, 20.2 KB), describe — quartiles de Prix_Unitaire tombant pile sur les 5 prix de base 30/45/80/150/200 = trace d'une construction synthetique ; groupby etablissant la hierarchie Accessoires/Electronique/Premium | 114.37, 74.93, 26/284, 20.2 KB, 42.64/131.33/223.90 |
| **Masque booleen** : 135/300 = 45 % (seuil quasi-median mecanique), Electronique 120 = 2×60 exact (verif d'integrite du dataset), index non contigus 0,4,5,9 preserves — le masque selectionne, ne renumerote pas | 135, 120 |
| **Figure 2 panneaux** : la courbe Widget A (143, 130, 123...) saute sans tendance — annonce visuelle du R² faible ; les barres reprennent le groupby ; la question structurante : temps (courbe) ou produit (barres) ? | 143/130/123, 42.64/131.33/223.90 |
| **R² honnete** : 0.229 = 23 % de la variance expliquee par le jour seul, 77 % = le produit (facteur 5 entre categories, la figure vient de le nommer) ; RMSE 20.66 vs moyenne 114.37 (~18 % erreur relative) ; coefficient +0.73/jour minuscule ; prediction jour 90 = 214.22 = extrapolation HORS du domaine [1,60] — arithmetiquement exacte, statistiquement temeraire | 0.229, 20.66, 0.7251, 148.96, 214.22 |

**Criteres de reussite chiffres** ajoutes aux enonces d'exercices (moyennes attendues de l'ordre de
la categorie ~131, compte attendu < 120 pour l'exo 2, coefficients distincts par produit pour l'exo 3 —
une prediction identique pour les deux produits signale une regression sur le DataFrame complet).

## Validation

- Mesure avant/apres : `pedagogy_density.py --json` → 627 → **1715** (status `ok`, plus dans `below_threshold`).
- 8/8 cellules code byte-identiques (diff structurel, base `git show origin/main:`).
- Interps ancrees : chaque valeur citee provient de l'output de la cellule precedente ;
  `scan_cell_ordering.py` : 1 clean, 0 finding.
- Stubs d'exercices C.1 intacts (3 exos conserves, None / message) ; pas d'erreur volontaire ;
  catalogue byte-identique (1 seul fichier dans le diff).
- `validate_pr_notebooks.py origin/main` : 1/1 PASS (8 cells).
- File CI mesuree avant ouverture : 39 PRs ouvertes (<200).
- Collision guard : aucune PR ouverte sur Lab1-PythonForDataScience ; claim dashboard pose 00:13Z avant edition.

## Regression check

- Fichier unique, markdown-only, 147 ins / 16 del — aucune cellule code touchee.
- Aucun symbole code modifie ; outputs et `execution_count` intacts.

See #11224 (veine cross-family, protocole #10488 — 1 notebook = 1 PR)
