### PR TITLE
fix(notebooks,#11112): re-exec tranche SmartContracts — 6 notebooks exec_count CLEAN 1..N

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
@@ -63,10 +63,10 @@
    "id": "web3-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:33.461527Z",
-     "iopub.status.busy": "2026-06-01T22:43:33.460829Z",
-     "iopub.status.idle": "2026-06-01T22:43:34.367245Z",
-     "shell.execute_reply": "2026-06-01T22:43:34.366445Z"
+     "iopub.execute_input": "2026-08-16T14:33:08.650846Z",
+     "iopub.status.busy": "2026-08-16T14:33:08.650846Z",
+     "iopub.status.idle": "2026-08-16T14:33:09.492081Z",
+     "shell.execute_reply": "2026-08-16T14:33:09.492081Z"
     },
     "papermill": {
      "duration": 0.912321,
@@ -182,10 +182,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:34.386203Z",
-     "iopub.status.busy": "2026-06-01T22:43:34.385609Z",
-     "iopub.status.idle": "2026-06-01T22:43:36.009101Z",
-     "shell.execute_reply": "2026-06-01T22:43:36.008091Z"
+     "iopub.execute_input": "2026-08-16T14:33:09.496088Z",
+     "iopub.status.busy": "2026-08-16T14:33:09.496088Z",
+     "iopub.status.idle": "2026-08-16T14:33:09.688050Z",
+     "shell.execute_reply": "2026-08-16T14:33:09.687041Z"
     },
     "papermill": {
      "duration": 1.630742,
@@ -201,34 +201,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Heritage simple avec virtual/override ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: Dog a 0x5FbDB2315678afecb367f032d93F642f64180aa3\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: Cat a 0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  dog.name = 'Rex', speak() = 'Woof!'\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- Heritage simple avec virtual/override ---\n",
+      "Deploye: Dog a 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318\n",
+      "Deploye: Cat a 0x610178dA211FEF7D417bC0e6FeD39F05609AD788\n",
+      "  dog.name = 'Rex', speak() = 'Woof!'\n",
       "  cat.name = 'Whiskers', speak() = 'Meow!'\n"
      ]
     }
@@ -332,10 +308,10 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:36.052763Z",
-     "iopub.status.busy": "2026-06-01T22:43:36.051950Z",
-     "iopub.status.idle": "2026-06-01T22:43:36.787265Z",
-     "shell.execute_reply": "2026-06-01T22:43:36.786588Z"
+     "iopub.execute_input": "2026-08-16T14:33:09.691057Z",
+     "iopub.status.busy": "2026-08-16T14:33:09.690057Z",
+     "iopub.status.idle": "2026-08-16T14:33:09.769936Z",
+     "shell.execute_reply": "2026-08-16T14:33:09.769936Z"
     },
     "papermill": {
      "duration": 0.745022,
@@ -351,21 +327,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Ordre des constructeurs : parent initialise avant enfant ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: B a 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0\n",
-      "  nameA (depuis A) = 'Parent'\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- Ordre des constructeurs : parent initialise avant enfant ---\n",
+      "Deploye: B a 0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e\n",
+      "  nameA (depuis A) = 'Parent'\n",
       "  nameB (depuis B) = 'Child'\n"
      ]
     }
@@ -456,10 +420,10 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:36.818432Z",
-     "iopub.status.busy": "2026-06-01T22:43:36.817932Z",
-     "iopub.status.idle": "2026-06-01T22:43:39.641101Z",
-     "shell.execute_reply": "2026-06-01T22:43:39.640553Z"
+     "iopub.execute_input": "2026-08-16T14:33:09.773044Z",
+     "iopub.status.busy": "2026-08-16T14:33:09.773044Z",
+     "iopub.status.idle": "2026-08-16T14:33:09.961959Z",
+     "shell.execute_reply": "2026-08-16T14:33:09.961959Z"
     },
     "papermill": {
      "duration": 2.829611,
@@ -475,28 +439,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Heritage multiple : Token herite de Ownable et Pausable ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: Token a 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- Heritage multiple : Token herite de Ownable et Pausable ---\n",
+      "Deploye: Token a 0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0\n",
       "  name = 'MyToken', totalSupply = 1000000\n",
-      "  deployer balance = 1000000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  deployer balance = 1000000\n",
       "  Apres transfer(500) : receiver balance = 500\n"
      ]
     },
@@ -504,13 +450,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  transfer reverte quand paused=True (attendu)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  transfer reverte quand paused=True (attendu)\n",
       "  Apres mint(1000) : receiver balance = 1500\n"
      ]
     }
@@ -666,10 +606,10 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:39.670778Z",
-     "iopub.status.busy": "2026-06-01T22:43:39.670466Z",
-     "iopub.status.idle": "2026-06-01T22:43:42.085982Z",
-     "shell.execute_reply": "2026-06-01T22:43:42.085120Z"
+     "iopub.execute_input": "2026-08-16T14:33:09.965831Z",
+     "iopub.status.busy": "2026-08-16T14:33:09.965831Z",
+     "iopub.status.idle": "2026-08-16T14:33:10.113246Z",
+     "shell.execute_reply": "2026-08-16T14:33:10.113246Z"
     },
     "papermill": {
      "duration": 2.422875,
@@ -685,42 +625,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Interface IERC20 implementee par SimpleToken ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: SimpleToken a 0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- Interface IERC20 implementee par SimpleToken ---\n",
+      "Deploye: SimpleToken a 0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE\n",
       "  totalSupply() = 1000000\n",
-      "  balanceOf(deployer) = 1000000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Apres transfer(1000) : receiver balance = 1000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  allowance(deployer, spender) = 500\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  balanceOf(deployer) = 1000000\n",
+      "  Apres transfer(1000) : receiver balance = 1000\n",
+      "  allowance(deployer, spender) = 500\n",
       "  Apres transferFrom(200) : receiver balance = 1200\n"
      ]
     }
@@ -854,12 +764,19 @@
    "cell_type": "code",
    "id": "c6265ba6",
    "source": "# Exercice : Interface IERC20 avec decimales personnalisees (StableCoin)\nEXERCISE_STABLECOIN = \"\"\"\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ninterface IERC20 {\n    function totalSupply() external view returns (uint256);\n    function balanceOf(address account) external view returns (uint256);\n    function transfer(address to, uint256 amount) external returns (bool);\n    function allowance(address owner, address spender) external view returns (uint256);\n    function approve(address spender, uint256 amount) external returns (bool);\n    function transferFrom(address from, address to, uint256 amount) external returns (bool);\n    event Transfer(address indexed from, address indexed to, uint256 value);\n    event Approval(address indexed owner, address indexed spender, uint256 value);\n}\n\ncontract StableCoin is IERC20 {\n    // TODO etudiant : definir les variables d'etat (name, symbol, decimals, _totalSupply, _balances, _allowances)\n    \n    constructor(uint256 initialSupply) {\n        // TODO etudiant : initialiser le supply avec 6 decimales (comme USDC)\n        pass\n    }\n    \n    function totalSupply() external view override returns (uint256) {\n        // TODO etudiant : retourner le supply total\n        return 0;\n    }\n    \n    function balanceOf(address account) external view override returns (uint256) {\n        // TODO etudiant : retourner le solde de l'adresse\n        return 0;\n    }\n    \n    function transfer(address to, uint256 amount) external override returns (bool) {\n        // TODO etudiant : transferer les tokens\n        // Indice : verifier le solde, debiter l'emetteur, crediter le destinataire, emettre Transfer\n        return false;\n    }\n    \n    function approve(address spender, uint256 amount) external override returns (bool) {\n        // TODO etudiant : autoriser le spender\n        return false;\n    }\n    \n    function transferFrom(address from, address to, uint256 amount) external override returns (bool) {\n        // TODO etudiant : transfer via allowance\n        // Indice : verifier allowance ET balance, decrementer les deux\n        return false;\n    }\n}\n\"\"\"\n\nprint(\"Exercice a completer : StableCoin avec 6 decimales\")",
-   "metadata": {},
-   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T14:33:10.116253Z",
+     "iopub.status.busy": "2026-08-16T14:33:10.116253Z",
+     "iopub.status.idle": "2026-08-16T14:33:10.119762Z",
+     "shell.execute_reply": "2026-08-16T14:33:10.119762Z"
+    }
+   },
+   "execution_count": 6,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : StableCoin avec 6 decimales\n"
      ]
@@ -889,14 +806,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:42.124161Z",
-     "iopub.status.busy": "2026-06-01T22:43:42.123457Z",
-     "iopub.status.idle": "2026-06-01T22:43:43.697722Z",
-     "shell.execute_reply": "2026-06-01T22:43:43.696692Z"
+     "iopub.execute_input": "2026-08-16T14:33:10.122769Z",
+     "iopub.status.busy": "2026-08-16T14:33:10.121766Z",
+     "iopub.status.idle": "2026-08-16T14:33:10.247415Z",
+     "shell.execute_reply": "2026-08-16T14:33:10.246350Z"
     },
     "papermill": {
      "duration": 1.583698,
@@ -912,36 +829,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Contrats abstraits : implementations differentes ---\n"
+      "--- Contrats abstraits : implementations differentes ---\n",
+      "Deploye: ChainlinkPriceFeed a 0xc6e7DF5E7b4f2A278906862b61205850344D4e7d\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: ChainlinkPriceFeed a 0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: UniswapPriceFeed a 0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0\n",
-      "  Chainlink getPrice() = 100\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Deploye: UniswapPriceFeed a 0x59b670e9fA9D0A427751Af201D676719a970857b\n",
+      "  Chainlink getPrice() = 100\n",
       "  Chainlink getPriceWithDecimals() = 100000000000000000000 (x10^18)\n",
-      "  Uniswap  getPrice() = 200\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Uniswap  getPrice() = 200\n",
       "  Uniswap  getPriceWithDecimals() = 200000000 (x10^6, override)\n"
      ]
     }
@@ -1056,14 +955,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:43.731031Z",
-     "iopub.status.busy": "2026-06-01T22:43:43.730710Z",
-     "iopub.status.idle": "2026-06-01T22:43:44.371293Z",
-     "shell.execute_reply": "2026-06-01T22:43:44.370598Z"
+     "iopub.execute_input": "2026-08-16T14:33:10.249414Z",
+     "iopub.status.busy": "2026-08-16T14:33:10.249414Z",
+     "iopub.status.idle": "2026-08-16T14:33:10.332127Z",
+     "shell.execute_reply": "2026-08-16T14:33:10.331118Z"
     },
     "papermill": {
      "duration": 0.64757,
@@ -1079,14 +978,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Linearisation C3 et super ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: D a 0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82\n",
+      "--- Linearisation C3 et super ---\n",
+      "Deploye: D a 0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1\n",
       "  D.foo() = 'A B C D'\n",
       "  Ordre de resolution : A -> B -> C -> D => 'A B C D'\n"
      ]
@@ -1170,14 +1063,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:44.425817Z",
-     "iopub.status.busy": "2026-06-01T22:43:44.425546Z",
-     "iopub.status.idle": "2026-06-01T22:43:44.873022Z",
-     "shell.execute_reply": "2026-06-01T22:43:44.872385Z"
+     "iopub.execute_input": "2026-08-16T14:33:10.335866Z",
+     "iopub.status.busy": "2026-08-16T14:33:10.335866Z",
+     "iopub.status.idle": "2026-08-16T14:33:10.408045Z",
+     "shell.execute_reply": "2026-08-16T14:33:10.407036Z"
     },
     "papermill": {
      "duration": 0.454676,
@@ -1193,7 +1086,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: Vault a 0x9A676e781A523b5d0C0e43731313A708CB607508\n"
+      "Deploye: Vault a 0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
      ]
     }
    ],
@@ -1293,14 +1193,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "cell-17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:44.906056Z",
-     "iopub.status.busy": "2026-06-01T22:43:44.905678Z",
-     "iopub.status.idle": "2026-06-01T22:43:45.354451Z",
-     "shell.execute_reply": "2026-06-01T22:43:45.353707Z"
+     "iopub.execute_input": "2026-08-16T14:33:10.410562Z",
+     "iopub.status.busy": "2026-08-16T14:33:10.410562Z",
+     "iopub.status.idle": "2026-08-16T14:33:10.482046Z",
+     "shell.execute_reply": "2026-08-16T14:33:10.480955Z"
     },
     "papermill": {
      "duration": 0.456328,
@@ -1316,7 +1216,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: SimpleNFT a 0x0B306BF915C4d645ff596e518fAf3F9669b97016\n"
+      "Deploye: SimpleNFT a 0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f\n"
      ]
     }
    ],
@@ -1412,14 +1312,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "e344a426",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:45.386125Z",
-     "iopub.status.busy": "2026-06-01T22:43:45.385847Z",
-     "iopub.status.idle": "2026-06-01T22:43:45.390622Z",
-     "shell.execute_reply": "2026-06-01T22:43:45.390013Z"
+     "iopub.execute_input": "2026-08-16T14:33:10.485956Z",
+     "iopub.status.busy": "2026-08-16T14:33:10.485420Z",
+     "iopub.status.idle": "2026-08-16T14:33:10.493474Z",
+     "shell.execute_reply": "2026-08-16T14:33:10.491829Z"
     },
     "papermill": {
      "duration": 0.011708,
@@ -1514,14 +1414,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "ac1b8c54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-01T22:43:45.413851Z",
-     "iopub.status.busy": "2026-06-01T22:43:45.413391Z",
-     "iopub.status.idle": "2026-06-01T22:43:45.419566Z",
-     "shell.execute_reply": "2026-06-01T22:43:45.418430Z"
+     "iopub.execute_input": "2026-08-16T14:33:10.496484Z",
+     "iopub.status.busy": "2026-08-16T14:33:10.496484Z",
+     "iopub.status.idle": "2026-08-16T14:33:10.503081Z",
+     "shell.execute_reply": "2026-08-16T14:33:10.502073Z"
     },
     "papermill": {
      "duration": 0.01383,
@@ -1666,6 +1566,20 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 4,
+   "external_account": null,
+   "free_alternative": null,
+   "gpu_required": false,
+   "metadata_written": null,
+   "network": false,
+   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version.",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1681,7 +1595,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},
@@ -1694,20 +1608,6 @@
    "parameters": {},
    "start_time": "2026-06-01T22:43:30.819961",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 4,
-   "gpu_required": false,
-   "network": false,
-   "external_account": null,
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": null,
-   "validator": "manual",
-   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -62,10 +62,10 @@
    "id": "web3-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:48:52.530321Z",
-     "iopub.status.busy": "2026-06-08T00:48:52.530321Z",
-     "iopub.status.idle": "2026-06-08T00:48:53.102519Z",
-     "shell.execute_reply": "2026-06-08T00:48:53.102519Z"
+     "iopub.execute_input": "2026-08-16T14:33:16.340459Z",
+     "iopub.status.busy": "2026-08-16T14:33:16.340459Z",
+     "iopub.status.idle": "2026-08-16T14:33:16.887344Z",
+     "shell.execute_reply": "2026-08-16T14:33:16.887344Z"
     },
     "papermill": {
      "duration": 0.575416,
@@ -187,10 +187,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:48:53.115762Z",
-     "iopub.status.busy": "2026-06-08T00:48:53.115762Z",
-     "iopub.status.idle": "2026-06-08T00:48:56.253208Z",
-     "shell.execute_reply": "2026-06-08T00:48:56.252201Z"
+     "iopub.execute_input": "2026-08-16T14:33:16.889349Z",
+     "iopub.status.busy": "2026-08-16T14:33:16.889349Z",
+     "iopub.status.idle": "2026-08-16T14:33:16.998863Z",
+     "shell.execute_reply": "2026-08-16T14:33:16.998283Z"
     },
     "papermill": {
      "duration": 3.14185,
@@ -206,42 +206,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- require / revert / assert ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: ErrorHandling a 0x5FbDB2315678afecb367f032d93F642f64180aa3\n",
-      "  Deploye : 0x5FbDB2315678afecb367f032d93F642f64180aa3\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  setValue(42) par other → revert 'Not owner' (attendu)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  setValue(0) → revert 'Value must be positive' (attendu)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  setValue(42) par owner → value = 42\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- require / revert / assert ---\n",
+      "Deploye: ErrorHandling a 0x4A679253410272dd5232B3Ff7cF5dbB88f295319\n",
+      "  Deploye : 0x4A679253410272dd5232B3Ff7cF5dbB88f295319\n",
+      "  setValue(42) par other → revert 'Not owner' (attendu)\n",
+      "  setValue(0) → revert 'Value must be positive' (attendu)\n",
+      "  setValue(42) par owner → value = 42\n",
       "  complexCheck(60, 50) → revert 'Sum too large' (attendu)\n",
       "  invariant() → passe (owner != address(0))\n"
      ]
@@ -354,10 +324,10 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:48:56.265503Z",
-     "iopub.status.busy": "2026-06-08T00:48:56.265503Z",
-     "iopub.status.idle": "2026-06-08T00:48:58.217752Z",
-     "shell.execute_reply": "2026-06-08T00:48:58.217228Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.000972Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.000448Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.107362Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.107362Z"
     },
     "papermill": {
      "duration": 1.955539,
@@ -373,34 +343,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Custom errors avec parametres ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: CustomErrors a 0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Apres deposit(0.5 ETH) : balance = 0.5 ETH\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  withdraw(1 ETH) → revert InsufficientBalance (attendu)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- Custom errors avec parametres ---\n",
+      "Deploye: CustomErrors a 0x09635F643e140090A9A8Dcd712eD6285858ceBef\n",
+      "  Apres deposit(0.5 ETH) : balance = 0.5 ETH\n",
+      "  withdraw(1 ETH) → revert InsufficientBalance (attendu)\n",
       "  transfer(0) → revert InvalidAmount (attendu)\n"
      ]
     },
@@ -514,10 +460,10 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:48:58.233788Z",
-     "iopub.status.busy": "2026-06-08T00:48:58.232443Z",
-     "iopub.status.idle": "2026-06-08T00:48:59.960937Z",
-     "shell.execute_reply": "2026-06-08T00:48:59.960937Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.109369Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.109369Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.209844Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.209844Z"
     },
     "papermill": {
      "duration": 1.732732,
@@ -533,27 +479,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Events : Deposit, Transfer, OwnershipTransferred ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: EventsExample a 0x5FC8d32690cc91D4c39d9d3abcBD16989F875707\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Deposit event : from=0xf39Fd6e5..., amount=1 ETH\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "--- Events : Deposit, Transfer, OwnershipTransferred ---\n",
+      "Deploye: EventsExample a 0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E\n",
+      "  Deposit event : from=0xf39Fd6e5..., amount=1 ETH\n",
       "  Transfer event : from=0xf39Fd6e5..., to=0x70997970..., amount=0.3 ETH\n"
      ]
     },
@@ -674,10 +602,10 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:48:59.975194Z",
-     "iopub.status.busy": "2026-06-08T00:48:59.975194Z",
-     "iopub.status.idle": "2026-06-08T00:49:00.843333Z",
-     "shell.execute_reply": "2026-06-08T00:49:00.843333Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.211849Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.211849Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.279796Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.279796Z"
     },
     "papermill": {
      "duration": 0.873396,
@@ -693,21 +621,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Indexed parameters : recherchables dans les logs ---\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: IndexedExample a 0x8A791620dd6260079BF849Dc5567aDC3F2FdC318\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  orderId (indexed) = 0xb6cda92322db49d9...\n",
+      "--- Indexed parameters : recherchables dans les logs ---\n",
+      "Deploye: IndexedExample a 0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9\n",
+      "  orderId (indexed) = 0x602d5ab7fec5c249...\n",
       "  buyer   (indexed) = 0xf39Fd6e5...\n",
       "  seller  (indexed) = 0x70997970...\n",
       "  amount  (data)    = 500\n",
@@ -796,10 +712,10 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:49:00.857112Z",
-     "iopub.status.busy": "2026-06-08T00:49:00.857112Z",
-     "iopub.status.idle": "2026-06-08T00:49:03.017397Z",
-     "shell.execute_reply": "2026-06-08T00:49:03.017397Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.281804Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.281804Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.435090Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.434439Z"
     },
     "papermill": {
      "duration": 2.16522,
@@ -822,21 +738,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: MockExternal a 0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Deploye: TryCatchExample a 0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0\n",
-      "  MockExternal : shouldFail = True\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Deploye: MockExternal a 0x851356ae760d987E095750cCeb3bC6014560891C\n",
+      "Deploye: TryCatchExample a 0xf5059a5D33d5853360D16C683c16e67980206f36\n",
+      "  MockExternal : shouldFail = True\n",
       "  safeOperation() [shouldFail=True] → OperationFailed: 'Operation failed by design'\n"
      ]
     },
@@ -979,10 +883,10 @@
    "id": "42118123",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:49:03.032929Z",
-     "iopub.status.busy": "2026-06-08T00:49:03.032929Z",
-     "iopub.status.idle": "2026-06-08T00:49:03.036044Z",
-     "shell.execute_reply": "2026-06-08T00:49:03.036044Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.437693Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.437181Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.440818Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.440818Z"
     },
     "papermill": {
      "duration": 0.007619,
@@ -1081,10 +985,10 @@
    "id": "47c60489",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:49:03.045188Z",
-     "iopub.status.busy": "2026-06-08T00:49:03.045188Z",
-     "iopub.status.idle": "2026-06-08T00:49:03.053506Z",
-     "shell.execute_reply": "2026-06-08T00:49:03.053506Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.442968Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.442968Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.446479Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.446479Z"
     },
     "papermill": {
      "duration": 0.008318,
@@ -1190,14 +1094,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "id": "cell-13",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:49:03.076248Z",
-     "iopub.status.busy": "2026-06-08T00:49:03.076248Z",
-     "iopub.status.idle": "2026-06-08T00:49:06.526187Z",
-     "shell.execute_reply": "2026-06-08T00:49:06.525174Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.448487Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.448487Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.451659Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.451659Z"
     },
     "papermill": {
      "duration": 3.456152,
@@ -1210,8 +1114,8 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : Voting avec custom errors (AlreadyVoted, VotingClosed, InvalidProposal)\n"
      ]
@@ -1273,14 +1177,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:49:06.541981Z",
-     "iopub.status.busy": "2026-06-08T00:49:06.541981Z",
-     "iopub.status.idle": "2026-06-08T00:49:09.567021Z",
-     "shell.execute_reply": "2026-06-08T00:49:09.567021Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.453666Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.453666Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.458379Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.457371Z"
     },
     "papermill": {
      "duration": 3.031068,
@@ -1293,8 +1197,8 @@
    },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : Auction avec events (HighestBidIncreased, AuctionFinalized, BidRefunded)\n"
      ]
@@ -1391,10 +1295,10 @@
    "id": "1f413f9f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:49:09.583551Z",
-     "iopub.status.busy": "2026-06-08T00:49:09.583551Z",
-     "iopub.status.idle": "2026-06-08T00:49:09.586758Z",
-     "shell.execute_reply": "2026-06-08T00:49:09.586758Z"
+     "iopub.execute_input": "2026-08-16T14:33:17.460377Z",
+     "iopub.status.busy": "2026-08-16T14:33:17.460377Z",
+     "iopub.status.idle": "2026-08-16T14:33:17.463738Z",
+     "shell.execute_reply": "2026-08-16T14:33:17.463738Z"
     },
     "papermill": {
      "duration": 0.008222,
@@ -1505,6 +1409,20 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 3,
+   "external_account": null,
+   "free_alternative": null,
+   "gpu_required": false,
+   "metadata_written": null,
+   "network": false,
+   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version.",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1533,20 +1451,6 @@
    "parameters": {},
    "start_time": "2026-06-08T00:48:51.432799",
    "version": "2.7.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 3,
-   "gpu_required": false,
-   "network": false,
-   "external_account": null,
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": null,
-   "validator": "manual",
-   "notes": "Local execution via Foundry (forge/cast/anvil). Requires Foundry installed (curl -L https://foundry.paradigm.xyz). anvil provides local test accounts with funded ETH; execution is deterministic given the same Foundry version."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
@@ -93,10 +93,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:42:29.233681Z",
-     "iopub.status.busy": "2026-05-29T02:42:29.233516Z",
-     "iopub.status.idle": "2026-05-29T02:42:29.766683Z",
-     "shell.execute_reply": "2026-05-29T02:42:29.766172Z"
+     "iopub.execute_input": "2026-08-16T14:33:29.010564Z",
+     "iopub.status.busy": "2026-08-16T14:33:29.010058Z",
+     "iopub.status.idle": "2026-08-16T14:33:29.605903Z",
+     "shell.execute_reply": "2026-08-16T14:33:29.605004Z"
     },
     "papermill": {
      "duration": 0.537888,
@@ -337,10 +337,10 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:42:29.781611Z",
-     "iopub.status.busy": "2026-05-29T02:42:29.781423Z",
-     "iopub.status.idle": "2026-05-29T02:42:29.940347Z",
-     "shell.execute_reply": "2026-05-29T02:42:29.939613Z"
+     "iopub.execute_input": "2026-08-16T14:33:29.607917Z",
+     "iopub.status.busy": "2026-08-16T14:33:29.606910Z",
+     "iopub.status.idle": "2026-08-16T14:33:54.861026Z",
+     "shell.execute_reply": "2026-08-16T14:33:54.859996Z"
     },
     "papermill": {
      "duration": 0.162511,
@@ -519,10 +519,10 @@
    "id": "cell-4b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:42:29.956032Z",
-     "iopub.status.busy": "2026-05-29T02:42:29.955809Z",
-     "iopub.status.idle": "2026-05-29T02:42:30.029908Z",
-     "shell.execute_reply": "2026-05-29T02:42:30.029270Z"
+     "iopub.execute_input": "2026-08-16T14:33:54.864772Z",
+     "iopub.status.busy": "2026-08-16T14:33:54.864100Z",
+     "iopub.status.idle": "2026-08-16T14:33:54.966710Z",
+     "shell.execute_reply": "2026-08-16T14:33:54.966710Z"
     },
     "papermill": {
      "duration": 0.077916,
@@ -672,12 +672,19 @@
    "cell_type": "code",
    "id": "8833bb4c",
    "source": "# Exercice 2 : Smart Account avec liste blanche\n# TODO etudiant : implementer un smart account avec une whitelist de destinataires autorises\n# Indice : ajoutez un mapping(address => bool) pour la whitelist\n# Etape 1 : implementer addToWhitelist(address) et removeFromWhitelist(address) - onlyOwner\n# Etape 2 : modifier execute() pour verifier que dest est dans la whitelist\n# Etape 3 : implementer isWhitelisted(address) - view\n\nEXERCISE_WHITELIST_ACCOUNT = \"\"\"\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract WhitelistAccount {\n    address public owner;\n    uint256 public nonce;\n\n    // TODO etudiant : mapping de la liste blanche\n    // Indice : mapping(address => bool) private _whitelist;\n\n    event Executed(address indexed dest, uint256 value, bytes data);\n    event WhitelistAdded(address indexed account);\n    event WhitelistRemoved(address indexed account);\n\n    modifier onlyOwner() {\n        require(msg.sender == owner, \\\"not owner\\\");\n        _;\n    }\n\n    constructor() {\n        owner = msg.sender;\n    }\n\n    function addToWhitelist(address account) external onlyOwner {\n        // TODO etudiant : ajouter account a la liste blanche\n        // Indice : _whitelist[account] = true\n        // TODO etudiant : emettre WhitelistAdded\n    }\n\n    function removeFromWhitelist(address account) external onlyOwner {\n        // TODO etudiant : retirer account de la liste blanche\n        // Indice : _whitelist[account] = false\n        // TODO etudiant : emettre WhitelistRemoved\n    }\n\n    function isWhitelisted(address account) public view returns (bool) {\n        // TODO etudiant : retourner le statut de la liste blanche\n        return false;\n    }\n\n    function execute(address dest, uint256 value, bytes calldata data) external onlyOwner {\n        // TODO etudiant : verifier que dest est dans la liste blanche\n        // Indice : require(_whitelist[dest], \\\"dest not whitelisted\\\")\n        // TODO etudiant : incrementer nonce, executer l appel, emettre Executed\n    }\n\n    receive() external payable {}\n}\n\"\"\"\n\nprint(\"Exercice a completer : WhitelistAccount avec liste blanche de destinataires\")",
-   "metadata": {},
-   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T14:33:54.970392Z",
+     "iopub.status.busy": "2026-08-16T14:33:54.969391Z",
+     "iopub.status.idle": "2026-08-16T14:33:54.975874Z",
+     "shell.execute_reply": "2026-08-16T14:33:54.975874Z"
+    }
+   },
+   "execution_count": 4,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : WhitelistAccount avec liste blanche de destinataires\n"
      ]
@@ -707,14 +714,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:42:30.046186Z",
-     "iopub.status.busy": "2026-05-29T02:42:30.046014Z",
-     "iopub.status.idle": "2026-05-29T02:42:30.207758Z",
-     "shell.execute_reply": "2026-05-29T02:42:30.207232Z"
+     "iopub.execute_input": "2026-08-16T14:33:54.978883Z",
+     "iopub.status.busy": "2026-08-16T14:33:54.978883Z",
+     "iopub.status.idle": "2026-08-16T14:33:56.230881Z",
+     "shell.execute_reply": "2026-08-16T14:33:56.230375Z"
     },
     "papermill": {
      "duration": 0.165531,
@@ -897,14 +904,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "cell-6b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:42:30.223485Z",
-     "iopub.status.busy": "2026-05-29T02:42:30.223321Z",
-     "iopub.status.idle": "2026-05-29T02:42:30.302055Z",
-     "shell.execute_reply": "2026-05-29T02:42:30.301519Z"
+     "iopub.execute_input": "2026-08-16T14:33:56.233889Z",
+     "iopub.status.busy": "2026-08-16T14:33:56.232887Z",
+     "iopub.status.idle": "2026-08-16T14:33:56.350400Z",
+     "shell.execute_reply": "2026-08-16T14:33:56.350400Z"
     },
     "papermill": {
      "duration": 0.082376,
@@ -1046,12 +1053,19 @@
    "cell_type": "code",
    "id": "6389c118",
    "source": "# Exercice 3 : Paymaster avec budget par utilisateur\n# TODO etudiant : implementer un paymaster avec un budget individuel par utilisateur\n# Indice : ajoutez un mapping(address => uint256) pour les budgets\n# Etape 1 : implementer setUserBudget(address user, uint256 budget) - onlyOwner\n# Etape 2 : implementer getUserBudget(address user) - view\n# Etape 3 : modifier sponsorGas pour verifier spent[user] + gasAmount <= budgets[user]\n# Etape 4 : ajouter un mapping(address => uint256) pour tracker les depenses par utilisateur\n\nEXERCISE_BUDGET_PAYMASTER = \"\"\"\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract BudgetPaymaster {\n    address public owner;\n    address public verifyingSigner;\n\n    // TODO etudiant : mapping des budgets alloues par utilisateur\n    // Indice : mapping(address => uint256) public budgets;\n\n    // TODO etudiant : mapping des depenses par utilisateur\n    // Indice : mapping(address => uint256) public spent;\n\n    mapping(address => uint256) public deposits;\n\n    event Deposited(address indexed account, uint256 amount);\n    event BudgetSet(address indexed user, uint256 budget);\n    event GasSponsored(address indexed user, uint256 amount);\n\n    modifier onlyOwner() {\n        // TODO etudiant : verifier que msg.sender == owner\n        pass;\n        _;\n    }\n\n    constructor(address _signer) {\n        owner = msg.sender;\n        verifyingSigner = _signer;\n    }\n\n    function deposit() external payable {\n        deposits[msg.sender] += msg.value;\n        emit Deposited(msg.sender, msg.value);\n    }\n\n    function setUserBudget(address user, uint256 budget) external onlyOwner {\n        // TODO etudiant : definir le budget de l utilisateur\n        pass;\n    }\n\n    function getUserBudget(address user) external view returns (uint256) {\n        // TODO etudiant : retourner le budget de l utilisateur\n        return 0;\n    }\n\n    function sponsorGas(address user, uint256 gasAmount) external onlyOwner {\n        // TODO etudiant : verifier que le budget de l utilisateur est suffisant\n        // Indice : require(spent[user] + gasAmount <= budgets[user], \"budget exceeded\")\n        // TODO etudiant : verifier que le paymaster a assez de fonds\n        // TODO etudiant : incrementer spent[user]\n        // TODO etudiant : debiter deposits[owner]\n        pass;\n    }\n\n    function getRemainingBudget(address user) external view returns (uint256) {\n        // TODO etudiant : retourner budgets[user] - spent[user]\n        return 0;\n    }\n\n    receive() external payable {}\n}\n\"\"\"\n\nprint(\"Exercice a completer : BudgetPaymaster avec budget par utilisateur\")",
-   "metadata": {},
-   "execution_count": 14,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T14:33:56.353918Z",
+     "iopub.status.busy": "2026-08-16T14:33:56.353918Z",
+     "iopub.status.idle": "2026-08-16T14:33:56.358439Z",
+     "shell.execute_reply": "2026-08-16T14:33:56.357929Z"
+    }
+   },
+   "execution_count": 7,
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer : BudgetPaymaster avec budget par utilisateur\n"
      ]
@@ -1079,14 +1093,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:42:30.317801Z",
-     "iopub.status.busy": "2026-05-29T02:42:30.317615Z",
-     "iopub.status.idle": "2026-05-29T02:42:30.321049Z",
-     "shell.execute_reply": "2026-05-29T02:42:30.320355Z"
+     "iopub.execute_input": "2026-08-16T14:33:56.361445Z",
+     "iopub.status.busy": "2026-08-16T14:33:56.361445Z",
+     "iopub.status.idle": "2026-08-16T14:33:56.364725Z",
+     "shell.execute_reply": "2026-08-16T14:33:56.364725Z"
     },
     "papermill": {
      "duration": 0.007142,
@@ -1188,14 +1202,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-29T02:42:30.333225Z",
-     "iopub.status.busy": "2026-05-29T02:42:30.332945Z",
-     "iopub.status.idle": "2026-05-29T02:42:30.337599Z",
-     "shell.execute_reply": "2026-05-29T02:42:30.336941Z"
+     "iopub.execute_input": "2026-08-16T14:33:56.367732Z",
+     "iopub.status.busy": "2026-08-16T14:33:56.367732Z",
+     "iopub.status.idle": "2026-08-16T14:33:56.614627Z",
+     "shell.execute_reply": "2026-08-16T14:33:56.613021Z"
     },
     "papermill": {
      "duration": 0.00915,
@@ -1211,10 +1225,23 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Deploye: SocialRecoveryAccount a 0x9A676e781A523b5d0C0e43731313A708CB607508\n",
       "Owner initial: 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266\n",
-      "Gardiens: 3, threshold: 2\n",
+      "Gardiens: 3, threshold: 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Execute: 1 ETH transfere, nonce: 1\n",
-      "Recovery demarree par guardian1, approvals: 1\n",
+      "Recovery demarree par guardian1, approvals: 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Approuvee par guardian2 -> nouveau owner: 0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65\n",
       "Nouveau owner attendu:                    0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65\n",
       "Etat recovery reset (pendingNewOwner): 0x0000000000000000000000000000000000000000\n"
@@ -1389,8 +1416,15 @@
    "cell_type": "code",
    "id": "8da1079d",
    "source": "# Exercice : Daily Spending Limit\n# TODO etudiant : implementer un contrat SpendingLimitAccount\n# Indice : inspirez-vous du StandaloneSmartAccount (section 2) pour la structure de base\n# Etape 1 : ajouter un dailyLimit (uint256) et spentToday (mapping address => uint256)\n# Etape 2 : ajouter lastResetDate (mapping address => uint256 timestamp)\n# Etape 3 : override execute() pour verifier spentToday + amount <= dailyLimit\n# Etape 4 : si la date a change (block.timestamp / 86400 != lastResetDate), reset spentToday\n\nEXERCISE_SPENDING_LIMIT = \"\"\"\n// SPDX-License-Identifier: MIT\npragma solidity ^0.8.28;\n\ncontract SpendingLimitAccount {\n    address public owner;\n    uint256 public nonce;\n    uint256 public dailyLimit;\n\n    // TODO etudiant : ajouter les variables d'etat pour le tracking quotidien\n    // Indice : spentToday, lastResetDay (jour = block.timestamp / 86400)\n\n    event Executed(address indexed dest, uint256 value, bytes data);\n\n    modifier onlyOwner() {\n        // TODO etudiant : verifier que msg.sender == owner\n        pass;\n        _;\n    }\n\n    constructor(uint256 _dailyLimit) {\n        // TODO etudiant : initialiser owner et dailyLimit\n    }\n\n    function execute(address dest, uint256 value, bytes calldata data) external onlyOwner {\n        // TODO etudiant : verifier et mettre a jour le plafond quotidien\n        // Etape 1 : verifier si le jour a change, si oui reset spentToday\n        // Etape 2 : verifier que spentToday + value <= dailyLimit\n        // Etape 3 : incrementer nonce, executer l'appel, mettre a jour spentToday\n        pass\n    }\n\n    function setDailyLimit(uint256 newLimit) external onlyOwner {\n        // TODO etudiant : permettre au owner de changer la limite\n        pass\n    }\n\n    function getSpentToday() public view returns (uint256) {\n        // TODO etudiant : retourner la depense du jour\n        return 0;\n    }\n\n    receive() external payable {}\n}\n\"\"\"\n\nprint(\"Exercice a completer : SpendingLimitAccount avec plafond quotidien\")",
-   "metadata": {},
-   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T14:33:56.618279Z",
+     "iopub.status.busy": "2026-08-16T14:33:56.616503Z",
+     "iopub.status.idle": "2026-08-16T14:33:56.624406Z",
+     "shell.execute_reply": "2026-08-16T14:33:56.623400Z"
+    }
+   },
+   "execution_count": 10,
    "outputs": [
     {
      "name": "stdout",
@@ -1475,7 +1509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
@@ -63,10 +63,10 @@
    "id": "web3-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:52:54.048128Z",
-     "iopub.status.busy": "2026-06-08T00:52:54.048128Z",
-     "iopub.status.idle": "2026-06-08T00:52:54.677359Z",
-     "shell.execute_reply": "2026-06-08T00:52:54.677359Z"
+     "iopub.execute_input": "2026-08-16T14:33:22.658531Z",
+     "iopub.status.busy": "2026-08-16T14:33:22.658531Z",
+     "iopub.status.idle": "2026-08-16T14:33:23.211199Z",
+     "shell.execute_reply": "2026-08-16T14:33:23.211199Z"
     },
     "papermill": {
      "duration": 0.634239,
@@ -171,10 +171,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:52:54.690996Z",
-     "iopub.status.busy": "2026-06-08T00:52:54.689623Z",
-     "iopub.status.idle": "2026-06-08T00:52:56.955716Z",
-     "shell.execute_reply": "2026-06-08T00:52:56.955196Z"
+     "iopub.execute_input": "2026-08-16T14:33:23.214205Z",
+     "iopub.status.busy": "2026-08-16T14:33:23.213205Z",
+     "iopub.status.idle": "2026-08-16T14:33:23.351463Z",
+     "shell.execute_reply": "2026-08-16T14:33:23.350936Z"
     },
     "papermill": {
      "duration": 2.269891,
@@ -190,21 +190,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: GovernanceToken a 0x5FbDB2315678afecb367f032d93F642f64180aa3\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Deploye: GovernanceToken a 0x5FbDB2315678afecb367f032d93F642f64180aa3\n",
       "Governance Token:\n",
-      "  Total supply   : 10,000,000 GOV\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Total supply   : 10,000,000 GOV\n",
       "  Votes deployer : 8,000,000 GOV\n",
       "  Votes voter2   : 2,000,000 GOV\n"
      ]
@@ -376,14 +364,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 3,
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:53:01.787805Z",
-     "iopub.status.busy": "2026-06-08T00:53:01.787805Z",
-     "iopub.status.idle": "2026-06-08T00:53:01.792217Z",
-     "shell.execute_reply": "2026-06-08T00:53:01.792217Z"
+     "iopub.execute_input": "2026-08-16T14:33:23.353628Z",
+     "iopub.status.busy": "2026-08-16T14:33:23.353628Z",
+     "iopub.status.idle": "2026-08-16T14:33:23.359453Z",
+     "shell.execute_reply": "2026-08-16T14:33:23.358843Z"
     },
     "papermill": {
      "duration": 0.009695,
@@ -523,14 +511,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:52:56.981693Z",
-     "iopub.status.busy": "2026-06-08T00:52:56.980695Z",
-     "iopub.status.idle": "2026-06-08T00:52:59.291807Z",
-     "shell.execute_reply": "2026-06-08T00:52:59.291807Z"
+     "iopub.execute_input": "2026-08-16T14:33:23.362239Z",
+     "iopub.status.busy": "2026-08-16T14:33:23.362239Z",
+     "iopub.status.idle": "2026-08-16T14:33:23.504817Z",
+     "shell.execute_reply": "2026-08-16T14:33:23.504817Z"
     },
     "papermill": {
      "duration": 2.315242,
@@ -546,23 +534,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Deploye: SimpleGovernor a 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "Deploye: SimpleGovernor a 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9\n",
       "\n",
       "Governor:\n",
       "  Proposal ID : 1\n",
-      "  Etat        : Pending\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Etat        : Pending\n",
       "  Etat        : Active\n"
      ]
     },
@@ -726,14 +702,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "7b1afb59",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:52:59.306121Z",
-     "iopub.status.busy": "2026-06-08T00:52:59.306121Z",
-     "iopub.status.idle": "2026-06-08T00:52:59.309992Z",
-     "shell.execute_reply": "2026-06-08T00:52:59.309992Z"
+     "iopub.execute_input": "2026-08-16T14:33:23.507028Z",
+     "iopub.status.busy": "2026-08-16T14:33:23.507028Z",
+     "iopub.status.idle": "2026-08-16T14:33:23.510272Z",
+     "shell.execute_reply": "2026-08-16T14:33:23.510272Z"
     },
     "papermill": {
      "duration": 0.008728,
@@ -864,14 +840,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "fb801e8c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:52:59.331185Z",
-     "iopub.status.busy": "2026-06-08T00:52:59.331185Z",
-     "iopub.status.idle": "2026-06-08T00:52:59.335831Z",
-     "shell.execute_reply": "2026-06-08T00:52:59.335831Z"
+     "iopub.execute_input": "2026-08-16T14:33:23.513285Z",
+     "iopub.status.busy": "2026-08-16T14:33:23.512285Z",
+     "iopub.status.idle": "2026-08-16T14:33:23.518303Z",
+     "shell.execute_reply": "2026-08-16T14:33:23.517788Z"
     },
     "papermill": {
      "duration": 0.010477,
@@ -978,14 +954,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:52:59.351019Z",
-     "iopub.status.busy": "2026-06-08T00:52:59.351019Z",
-     "iopub.status.idle": "2026-06-08T00:53:01.743758Z",
-     "shell.execute_reply": "2026-06-08T00:53:01.743758Z"
+     "iopub.execute_input": "2026-08-16T14:33:23.520309Z",
+     "iopub.status.busy": "2026-08-16T14:33:23.520309Z",
+     "iopub.status.idle": "2026-08-16T14:33:23.663599Z",
+     "shell.execute_reply": "2026-08-16T14:33:23.663080Z"
     },
     "papermill": {
      "duration": 2.398213,
@@ -1004,32 +980,14 @@
       "Deploye: SimpleTimelock a 0x0165878A594ca255338adfa4d48449f69242Eb8F\n",
       "\n",
       "Timelock Controller:\n",
-      "  Admin     : 0xf39Fd6e5...\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Admin     : 0xf39Fd6e5...\n",
       "  Delay     : 86400 secondes (24h)\n",
-      "  Min delay : 86400 secondes\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  Max delay : 2592000 secondes\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "  Min delay : 86400 secondes\n",
+      "  Max delay : 2592000 secondes\n",
       "\n",
       "  Transaction en queue: True\n",
-      "  TX hash   : aa98a4e837d8755f5c79...\n",
-      "  ETA       : timestamp 1780966305 (dans ~24h)\n"
+      "  TX hash   : f2d0714cd2efeaaf296c...\n",
+      "  ETA       : timestamp 1786977144 (dans ~24h)\n"
      ]
     },
     {
@@ -1201,14 +1159,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "0efcf441",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-08T00:53:01.758002Z",
-     "iopub.status.busy": "2026-06-08T00:53:01.758002Z",
-     "iopub.status.idle": "2026-06-08T00:53:01.762163Z",
-     "shell.execute_reply": "2026-06-08T00:53:01.761146Z"
+     "iopub.execute_input": "2026-08-16T14:33:23.666634Z",
+     "iopub.status.busy": "2026-08-16T14:33:23.666634Z",
+     "iopub.status.idle": "2026-08-16T14:33:23.672319Z",
+     "shell.execute_reply": "2026-08-16T14:33:23.671310Z"
     },
     "papermill": {
      "duration": 0.00816,

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -63,10 +63,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.600010Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.599692Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.606119Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.605407Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.442366Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.441857Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.448944Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.448944Z"
     },
     "papermill": {
      "duration": 0.009807,
@@ -152,10 +152,10 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.616612Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.616385Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.620316Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.619603Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.451949Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.451949Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.457092Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.455952Z"
     },
     "papermill": {
      "duration": 0.007385,
@@ -414,10 +414,10 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.634716Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.634567Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.637765Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.637071Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.459090Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.459090Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.462299Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.462299Z"
     },
     "papermill": {
      "duration": 0.006506,
@@ -571,10 +571,10 @@
    "id": "3b43b908",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.652629Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.652317Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.656493Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.655586Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.464842Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.464842Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.468869Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.468869Z"
     },
     "papermill": {
      "duration": 0.007893,
@@ -647,10 +647,10 @@
    "id": "cell-8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.667234Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.667078Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.671549Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.670522Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.472038Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.471068Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.475076Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.475076Z"
     },
     "papermill": {
      "duration": 0.007954,
@@ -838,10 +838,10 @@
    "id": "7e07ca47",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.687373Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.687127Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.693151Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.692457Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.478009Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.478009Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.482410Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.482410Z"
     },
     "papermill": {
      "duration": 0.009957,
@@ -956,10 +956,10 @@
    "id": "cell-10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.704533Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.704306Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.707411Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.706919Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.485114Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.485114Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.488136Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.488136Z"
     },
     "papermill": {
      "duration": 0.007149,
@@ -1126,10 +1126,10 @@
    "id": "56e807cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.722775Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.722526Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.726890Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.726405Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.490438Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.490438Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.495092Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.495092Z"
     },
     "papermill": {
      "duration": 0.008068,
@@ -1221,10 +1221,10 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:46.739528Z",
-     "iopub.status.busy": "2026-06-03T07:41:46.739316Z",
-     "iopub.status.idle": "2026-06-03T07:41:46.742686Z",
-     "shell.execute_reply": "2026-06-03T07:41:46.742164Z"
+     "iopub.execute_input": "2026-08-16T14:34:02.497612Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.497612Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.501138Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.501138Z"
     },
     "papermill": {
      "duration": 0.007036,
@@ -1458,8 +1458,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 10,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T14:34:02.504154Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.503167Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.508698Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.508698Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1531,8 +1538,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "execution_count": 11,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T14:34:02.510360Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.510360Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.514478Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.514478Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1724,8 +1738,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
+   "execution_count": 12,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T14:34:02.516505Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.516505Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.523026Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.522512Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1812,8 +1833,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-16T14:34:02.525557Z",
+     "iopub.status.busy": "2026-08-16T14:34:02.525557Z",
+     "iopub.status.idle": "2026-08-16T14:34:02.528031Z",
+     "shell.execute_reply": "2026-08-16T14:34:02.528031Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -1962,7 +1990,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
@@ -67,10 +67,10 @@
    "id": "cell-2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.151196Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.150799Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.175119Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.172590Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.622081Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.622081Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.632876Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.632297Z"
     },
     "papermill": {
      "duration": 0.030401,
@@ -168,10 +168,10 @@
    "id": "cell-4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.197255Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.197062Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.201227Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.200024Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.636390Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.636390Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.643000Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.641991Z"
     },
     "papermill": {
      "duration": 0.010376,
@@ -319,10 +319,10 @@
    "id": "cell-5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.223705Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.223497Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.230133Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.227889Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.645999Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.645999Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.651631Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.650623Z"
     },
     "papermill": {
      "duration": 0.01533,
@@ -606,10 +606,10 @@
    "id": "cell-7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.285660Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.285213Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.293174Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.291213Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.653635Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.653635Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.657490Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.657490Z"
     },
     "papermill": {
      "duration": 0.018818,
@@ -759,10 +759,10 @@
    "id": "8f0a19f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.332885Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.332431Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.349212Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.347748Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.660886Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.660886Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.668024Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.667514Z"
     },
     "papermill": {
      "duration": 0.028189,
@@ -888,10 +888,10 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.374164Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.373797Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.378750Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.378284Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.670026Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.670026Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.673360Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.673360Z"
     },
     "papermill": {
      "duration": 0.015878,
@@ -1009,10 +1009,10 @@
    "id": "831a64bb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.396109Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.395930Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.399692Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.399195Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.676945Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.675367Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.682540Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.681531Z"
     },
     "papermill": {
      "duration": 0.008636,
@@ -1140,14 +1140,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "id": "cell-11",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.421649Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.421458Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.424294Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.423831Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.684537Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.684537Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.688538Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.688538Z"
     },
     "papermill": {
      "duration": 0.007849,
@@ -1303,10 +1303,10 @@
    "id": "a1fbc97c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.445163Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.444898Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.450191Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.449614Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.691851Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.691851Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.699976Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.698853Z"
     },
     "papermill": {
      "duration": 0.010001,
@@ -1513,10 +1513,10 @@
    "id": "75286245",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.472082Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.471869Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.481340Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.480778Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.702974Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.701975Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.717151Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.717151Z"
     },
     "papermill": {
      "duration": 0.014882,
@@ -1703,10 +1703,10 @@
    "id": "4d8fa254",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-03T07:41:49.496609Z",
-     "iopub.status.busy": "2026-06-03T07:41:49.496268Z",
-     "iopub.status.idle": "2026-06-03T07:41:49.500889Z",
-     "shell.execute_reply": "2026-06-03T07:41:49.500225Z"
+     "iopub.execute_input": "2026-08-16T14:34:07.720160Z",
+     "iopub.status.busy": "2026-08-16T14:34:07.720160Z",
+     "iopub.status.idle": "2026-08-16T14:34:07.725661Z",
+     "shell.execute_reply": "2026-08-16T14:34:07.725661Z"
     },
     "papermill": {
      "duration": 0.009626,
@@ -2121,7 +2121,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python (c.143)

## Summary

Re-execution séquentielle étage 3 #11112, tranche SmartContracts : 6 notebooks `SymbolicAI/SmartContracts` re-exécutés via nbconvert (cwd par dossier, PATH `~/.foundry/bin` pour anvil/forge, chain 31337) :

- SC-5-Inheritance, SC-6-Errors-Events, SC-22-Solana-Anchor, SC-23-Cross-Chain : `DUPLICATE` → `CLEAN`
- SC-9-DAO-Governance, SC-10-Account-Abstraction : `UNORDERED` → `CLEAN`

## Validation

- `check_exec_sequence` : CLEAN 1..N partout (12/11/8/10/13/11 cells code, 0 error)
- C.3 : sources byte-identiques a main (parse JSON index vs blob : 0 source_diffs ; ordre des clés nbconvert restauré pour diff minimal)
- 0 erreur volontaire, nbformat OK (l'INVALID de SC-23 est pré-existant sur main)
- `language_info` 3.13.x → 3.11.9 (kernel local réel, honnête)
- Amendement acceptance #11112 : adresses de déploiement nonce-dérivées cohérentes (SC-10 markdown == outputs)
- line-endings LF normalisés (SC-9, SC-23)

See #11112 (étage 3, tranche SmartContracts — contribution partielle)
