### PR TITLE
fix(genai,#11346): re-clone cornudet — sample interrogatif, seg118 REJECT->WARN (3/3 traites)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p1_voice_cloning.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/p1_voice_cloning.py
@@ -41,8 +41,8 @@ SPEAKER_TO_VOICE: dict[CanonicalSpeaker, str] = {
     "follenvie": "v4_loiseau_vulgar",
     "madame_loiseau": "v4_mme_loiseau_shrew",
     "madame_follenvie": "v4_mme_loiseau_shrew",
-    "cornudet": "v4_cornudet_mocking",
-    "carre_lamadon": "v4_cornudet_mocking",
+    "cornudet": "v4_cornudet_mocking_v2",
+    "carre_lamadon": "v4_cornudet_mocking_v2",
     "soeurs": "v4_soeurs_pious",
     "officier": "v4_officier_german",
 }
@@ -153,13 +153,19 @@ VOICE_PROFILES: dict[str, dict] = {
         ),
         "preset": "neutral_female",
     },
-    "v4_cornudet_mocking": {
+    "v4_cornudet_mocking_v2": {
         "speakers": ["cornudet", "carre_lamadon"],
         "register": "sardonic, cynical, ironically detached",
+        # Interrogative/exclamative sample on purpose: a clone made from a purely
+        # declarative sample flattens pitch range on declarative text (seg118
+        # REJECT-MONOTONE at every seed, spans 1.8-3.8 st) even though that
+        # sample scored 12.65 st. The question/exclamation-rich sample restores
+        # melodic movement through the clone (seg118 -> MODERATE 7.1 st, WARN
+        # FADING only). Evidence: #11346, gate 2026-08-17_cornudet_v2.
         "sample_text": (
-            "Eh bien, messieurs, voilà où mènent les grandes phrases sur l'honneur "
-            "et la patrie. On demande à une femme de se sacrifier pour qu'ensuite "
-            "on la traite comme une moins que rien. C'est magnifique, ce zèle collectif."
+            "Eh quoi ! C'est donc là tout votre patriotisme ? Des mots, toujours des mots ! "
+            "Vous parlez d'honneur, messieurs... mais lequel, au juste ? "
+            "Celui qui vous arrange, n'est-ce pas ? Voilà qui est bien commode, je trouve."
         ),
         "preset": "expressive_male_cold",
     },


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2023:CoursIA — prev: DEEP/genai #11350

## Summary

Resolution du residual #11346 : le **re-clone L6 de la reference cornudet** (3e et dernier REJECT-MONOTONE du dossier de revue #1028). Fix pipeline : le sample de clonage passe d'un texte purement declaratif a un texte **interrogatif/exclamatif** (meme registre sardonique, meme preset), et le mapping pointe sur la nouvelle reference `v4_cornudet_mocking_v2`.

## Diagnostic et preuve (gate objectif #6933, firsthand)

- **Avant** : le clone `v4_cornudet_mocking` (issu d'un sample declaratif, 12.65 st) ecrase systematiquement la plage melodique sur texte declaratif — seg118 REJECT-MONOTONE a tous les seeds testes (3/7/11/99, temp 0.7-1.0, spans 1.8-3.8 st).
- **Re-clone** : nouveau sample au texte riche en ?/! -> gate du sample : EXPRESSIVE 12.95 st (s42 retenu ; s11 a 19.16 st ecarte : risque classe Kokoro erratique) -> uploade comme `v4_cornudet_mocking_v2` (`POST /v1/references/add`) -> regen seg118 (3 seeds).
- **Apres** : seg118 **WARN FADING** (MODERATE, span 7.1 st, decay -7.27 dB, seed 3) — plus aucun MONOTONE (5.9-7.1 st aux 3 seeds). Ear-eligible, meme statut que les 5 autres WARN du dossier de revue.

Preuve : `gate_results_2026-08-17_cornudet_v2.json` + nouveau segment `cornudet_seg118_v4_cornudet_mocking_v2.mp3` sur le dossier GDrive `audiobook-1028-review/2026-07-09/` (manifest + REVIEW.md a jour — **0 REJECT en candidats courants, #11346 complet 3/3**).

## SOTA verdict

**SOTA-OK** : vrai service FishAudio S2-Pro (3 samples + 3 regen reelles), upload reference reel, gate objectif sur chaque candidat. Chiffres = sorties du gate JSON, pas des estimates.

## Validation

- Tests module v4 : **114 passed** (`pytest v4/tests/ -q`), aucun test n'ancre les ids de voix (verifie par grep)
- Scripts A/B `prosody_lab/ab_*_test.py` references a l'ancien id : **laisses intacts** — bras "AVANT" d'experiences figees (la ref plate y est le sujet du test), pas du pipeline
- 1 fichier modifie (`p1_voice_cloning.py`, +12/-6 : mapping x2 + profil avec commentaire d'evidence), catalogue byte-identique a main

See #11346 (residual resolu), #1028 (EPIC umbrella), #11350 (remediation comtesse/loiseau). Prev: #11350.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
