### PR TITLE
fix(iit,#11112): exec seq CLEAN 1..N for IIT-1-IntroToPyPhi (stage 3)

### DIFF
--- a/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
+++ b/MyIA.AI.Notebooks/IIT/IIT-1-IntroToPyPhi.ipynb
@@ -89,7 +89,7 @@
     "Sélectionner l'environnement nouvellement créé comme noyau."
    ]
   },
-    {
+  {
    "cell_type": "markdown",
    "id": "ict-bridge-cadrage",
    "metadata": {
@@ -479,7 +479,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.98s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:14,  2.41s/it]"
      ]
     },
     {
@@ -510,7 +510,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:12,  2.48s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.12s/it]"
      ]
     },
     {
@@ -610,7 +610,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:12,  2.10s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:12,  2.03s/it]"
      ]
     },
     {
@@ -724,7 +724,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:03<00:18,  3.03s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:15,  2.64s/it]"
      ]
     },
     {
@@ -755,7 +755,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:11,  2.27s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.08s/it]"
      ]
     },
     {
@@ -793,7 +793,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.96s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  2.00s/it]"
      ]
     },
     {
@@ -824,7 +824,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:11,  2.20s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.99s/it]"
      ]
     },
     {
@@ -862,7 +862,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:12,  2.01s/it]"
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.91s/it]"
      ]
     },
     {
@@ -893,7 +893,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.06s/it]"
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.93s/it]"
      ]
     },
     {
@@ -1036,12 +1036,632 @@
    ],
    "outputs": [
     {
+     "name": "stderr",
      "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.93s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.95s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
      "name": "stdout",
-     "text": "==============================================================\nRÉSEAU SYMÉTRIQUE canonique (XOR) : Phi invariant\n==============================================================\n  État (0,0,0) -> Phi = 1.8750  (idem sur (0,1,1), (1,0,1), (1,1,0))\n\n==============================================================\nRÉSEAU ASYMÉTRIQUE (node2 perturbé) : Phi varie selon l'état\n==============================================================\n  État (0, 0, 0) -> Phi = 1.5781\n  État (0, 0, 1) -> Phi = 2.7431\n  État (0, 1, 0) -> Phi = 1.8438\n  État (0, 1, 1) -> Phi = 0.8073\n  État (1, 0, 0) -> Phi = 1.3021\n  État (1, 0, 1) -> Phi = 2.0569\n  État (1, 1, 0) -> Phi = 1.0781\n  État (1, 1, 1) -> Phi = 1.8669\n--------------------------------------------------------------\n  Valeurs distinctes de Phi : 8  ->  [0.8073, 1.0781, 1.3021, 1.5781, 1.8438, 1.8669, 2.0569, 2.7431]\n  CONSTAT : l'asymétrie d'un seul noeud suffit à briser l'invariance.\n  Phi passe de 1.875 (unique, symétrique) à [0.8073 .. 2.7431]\n  (8 valeurs distinctes sur 8 états atteignables).\n"
+     "output_type": "stream",
+     "text": [
+      "==============================================================\n",
+      "RÉSEAU SYMÉTRIQUE canonique (XOR) : Phi invariant\n",
+      "==============================================================\n",
+      "  État (0,0,0) -> Phi = 1.8750  (idem sur (0,1,1), (1,0,1), (1,1,0))\n",
+      "\n",
+      "==============================================================\n",
+      "RÉSEAU ASYMÉTRIQUE (node2 perturbé) : Phi varie selon l'état\n",
+      "==============================================================\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.90s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.94s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  État (0, 0, 0) -> Phi = 1.5781\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.90s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.91s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  État (0, 0, 1) -> Phi = 2.7431\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.84s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                        "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  État (0, 1, 0) -> inaccessible (hors dynamique)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:02<00:14,  2.48s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.99s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  État (0, 1, 1) -> Phi = 0.8073\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.91s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.03s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  État (1, 0, 0) -> Phi = 1.3021\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.95s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:02<00:10,  2.03s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  État (1, 0, 1) -> Phi = 2.0569\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.87s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.92s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  État (1, 1, 0) -> Phi = 1.0781\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:   0%|          | 0/7 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Computing concepts:  14%|█▍        | 1/7 [00:01<00:11,  1.87s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                 "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:   0%|          | 0/6 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Evaluating Φ cuts:  17%|█▋        | 1/6 [00:01<00:09,  1.94s/it]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "                                                                "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  État (1, 1, 1) -> Phi = 1.8669\n",
+      "--------------------------------------------------------------\n",
+      "  Valeurs distinctes de Phi : 7  ->  [0.8073, 1.0781, 1.3021, 1.5781, 1.8669, 2.0569, 2.7431]\n",
+      "  CONSTAT : l'asymétrie d'un seul noeud suffit à briser l'invariance.\n",
+      "  Phi passe de 1.875 (unique, symétrique) à [0.8073 .. 2.7431]\n",
+      "  (7 valeurs distinctes sur 7 états atteignables).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r"
+     ]
     }
    ],
-   "execution_count": 9
+   "execution_count": 8
   },
   {
    "cell_type": "markdown",
@@ -1064,7 +1684,7 @@
     "| Réseau | États atteignables | $\\Phi$ | Invariance |\n",
     "|--------|--------------------|--------|------------|\n",
     "| XOR **symétrique** canonique | 4 (000, 011, 101, 110) | $1{,}875$ partout | **Oui** (1 valeur) |\n",
-    "| XOR **asymétrique** (node2 perturbé) | 8 | de $0{,}81$ à $2{,}74$ | **Non** (8 valeurs distinctes) |\n",
+    "| XOR **asymétrique** (node2 perturbé) | 7 | de $0{,}81$ à $2{,}74$ | **Non** (7 valeurs distinctes) |\n",
     "\n",
     "**Pourquoi l'invariance cède-t-elle ?** Sur le réseau symétrique, les quatre états atteignables sont reliés par les permutations de noeuds : la structure cause-effet (CES) qu'ils engendrent est *identique*, donc le $\\Phi$ (information intégrée minimale sur cette structure) coïncide. Dès qu'on asymétrise un seul noeud, cette équivalence par permutation disparaît : chaque état engendre désormais une CES **spécifique**, et $\\Phi$ devient dépendant de l'état.\n",
     "\n",
@@ -1105,7 +1725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "42dafeb5",
    "metadata": {
     "execution": {
@@ -1171,7 +1791,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "57501e53",
    "metadata": {
     "execution": {
@@ -1249,7 +1869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "1083ab9d",
    "metadata": {
     "execution": {
@@ -1326,7 +1946,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "5658a6b5",
    "metadata": {
     "execution": {
@@ -1444,7 +2064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "e55f113d",
    "metadata": {
     "execution": {
@@ -1525,7 +2145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -1667,7 +2287,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "53ad8dc0",
    "metadata": {
     "execution": {
@@ -1743,7 +2363,7 @@
     "> **A retenir** : l'IIT propose de mesurer la conscience comme l'**integration causale irreductible** d'un système sur lui-même. PyPhi rend cette definition operationnelle : on declare une dynamique (TPM), on choisit un decoupage (Subsystem), et le moteur calcule a la fois *combien* ($\\Phi$) et *quoi* (CES) le système integre.\n"
    ]
   },
-    {
+  {
    "cell_type": "markdown",
    "id": "ict-bridge-transition",
    "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python (#11357)

## Summary

Re-execution séquentielle étage 3 #11112, tranche IIT : `IIT-1-IntroToPyPhi.ipynb` re-exécuté via nbconvert (kernel python3, runtime-override conda env `pyphi39`, pyphi 1.2.0) — sequence `DUPLICATE` → `CLEAN 1..15`, 0 erreur.

## Diagnostic dérive (C.4, amendement acceptance #11112)

**Cause (a) env/kernel** — la pyphi 1.2.0 locale (env conda `pyphi39`) calcule l'état (0,1,0) comme inaccessible sous la dynamique perturbée (`StateUnreachableError`) là où le run sur main montrait Phi = 1.8438.

**Verdict frais** : 7 valeurs Phi distinctes sur 7 états accessibles (vs 8/8 sur main), plage inchangée [0.81 .. 2.74], conclusion qualitative inchangée (l'asymétrie brise l'invariance de Phi). Les 7 valeurs Phi partagées sont **bit-identiques à main**. Table markdown cell 19 ré-alignée 8 → 7 dans la MÊME PR — plus aucune citation stale.

## Validation

- `check_exec_sequence` : CLEAN 1..15 (15 cells code, 0 erreur)
- C.3 : sources byte-identiques a main (0 source_diffs JSON) — exception documentée ci-dessus (cell md 19, amendement acceptance)
- nbformat VALID, LF, key-order préservé (restore base-main + transplant code-cells-only), 0 fuite chemin machine
- Metadata kernel inchangée (runtime-override à l'exécution uniquement)

Note diff : les grosses variations de lignes (828+/208−) reflètent la normalisation des outputs, pas un changement de contenu.

ICT-25 (LoRA/GRPO fine-tuning) exclu de la tranche : GPU-only, à router vers une lane GPU.

See #11112 (étage 3, tranche IIT — contribution partielle)
