### PR TITLE
ci(lean,#11349): pin native_decide 59->61 apres lecture des deux temoins P4-At (repare main rouge, debloque 7 PR)

### DIFF
--- a/scripts/lean/tests/test_proof_integrity_audit_wiring.py
+++ b/scripts/lean/tests/test_proof_integrity_audit_wiring.py
@@ -137,7 +137,40 @@ def test_audit_allowlists_native_decide_axioms():
     (2) under the `Conway_en.*` namespaces (with `Pillars_en` keeping the FR
     `Conway.Life.*` path -- namespace heterogeneity is why names are
     enumerated from the build, never derived by rule). Same legitimacy rule
-    as #9341: every added name is attributable to a newly covered module."""
+    as #9341: every added name is attributable to a newly covered module.
+
+    **Widened to 61 by #11349** (`ci(lean,#11349)`), and this one does NOT fit
+    the "newly covered module" phrasing above -- it is the first widening that
+    does not, so the criterion is stated properly here rather than stretched.
+    Grain 3a (#11303, `c3bd40cc1`) added two theorems to the ALREADY covered
+    `Conway.Life.HashlifeCorrectness` and widened the workflow allow-list by
+    exactly their two names. It DID annotate them in the workflow comment
+    (L204-208, header updated to "All 61") -- what it omitted was this pin, and
+    that omission is the ratchet working as designed: an attribution written by
+    the same hand that widens cannot self-certify, so `main` goes red until a
+    second reading confirms it. This is that reading. Verified before raising:
+
+    * `p4at_witness_k1` / `p4at_witness_k2` (L848, L861) are the P4-At mirrors
+      of the already-allow-listed `p4_wf_witness_k1` / `p4_wf_witness_k2`
+      (L758, L775): SAME cells (centered block still-life; centered glider),
+      SAME generation counts (2, 4), SAME `restrictGridTo` windows -- only the
+      engine differs (`hashlifeResultAt j` instead of `hashlifeResultAux (j+2)`),
+      which is the whole point of grain 3a.
+    * Both are STANDALONE: `git grep` finds zero references outside their own
+      declarations. They are concrete finite sanity checks, not premises.
+    * Grain 3a's headline theorem `hashlifeResultAt_base_central` (L806) is
+      universally quantified over `c : MacroCell` and `j : Nat` and is proven
+      by structural tactics (`cases`/`omega`/`obtain`/`simp only`), closing on
+      the already-proven `hashlifeResult_central_correct`. No `native_decide`
+      in it -- the general claim is NOT hollowed out by these two escapes.
+
+    The operative criterion is therefore **attributable AND non-hollowing**, of
+    which "attributable to a newly covered module" was one instance, not the
+    definition. A name attributable to a newly added THEOREM is equally
+    legitimate provided (a) the theorem is a concrete finite witness, (b) it is
+    referenced by nothing, and (c) the module's general theorems do not depend
+    on it. Absent any of the three, the pin stays put and the proof is reworked
+    -- unchanged from #9341."""
     jobs = _load_jobs()
     audit = jobs["proof-integrity-audit"].get("with", {})
     allow = audit.get("allow-axioms", "")
@@ -147,11 +180,12 @@ def test_audit_allowlists_native_decide_axioms():
     # the blocking gate's 19) is caught -- and so any future widening has to
     # come with the module-attribution argument, as #9341's did.
     names = [a.strip() for a in allow.split(",") if a.strip()]
-    assert len(names) == 59, (
-        f"audit allow-list must carry the 59 native_decide axioms of the whole "
+    assert len(names) == 61, (
+        f"audit allow-list must carry the 61 native_decide axioms of the whole "
         f"lake under the #10889 '*' derivation (38 HashlifeCorrectness-era "
         f"footprint + 21 build-enumerated entries of the newly covered "
-        f"modules, each attributed in the workflow comment); got {len(names)}")
+        f"modules + 2 P4-At standalone witnesses from grain 3a #11303, each "
+        f"attributed in the workflow comment); got {len(names)}")
     # Sample members from each family revealed by the audit (P4 base cases,
     # box-assez-grand lemmas, hashlife_correct_implies bridges, plus one
     # #10889-widening family: the _en twins under Conway_en.*).


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: DEEP/research-code #11196

Répare `main` rouge et débloque 7 PR (#11354, #11355, #11357, #11360, #11361, #11363, #11364), toutes en échec sur la même assertion :

```
E   assert 61 == 59
FAILED scripts/lean/tests/test_proof_integrity_audit_wiring.py::test_audit_allowlists_native_decide_axioms
```

## Ce qui s'est passé

Grain 3a (#11303, `c3bd40cc1`) a ajouté deux théorèmes à `Conway.Life.HashlifeCorrectness` et élargi `allow-axioms:` de `lean-conway.yml` de leurs deux noms exacts — `Conway.Life.p4at_witness_k{1,2}._native.native_decide.ax_1_1`. Il **a** annoté l'élargissement dans le commentaire du workflow (L204-208, en-tête passé à « All 61 ») ; ce qu'il n'a pas fait, c'est bouger le pin du test.

Cette omission **est** le cliquet qui fonctionne. Une attribution écrite par la main qui élargit ne peut pas s'auto-certifier : `main` reste rouge tant qu'une seconde lecture ne l'a pas confirmée. Cette PR est cette lecture.

## La lecture, avant de toucher au pin

Le docstring pose la règle : *« a new name that is NOT attributable to a newly covered module means an unproven `native_decide` slipped in, and the pin must stay put instead »*. Ce cas **n'entre pas** dans cette formulation — c'est le premier qui n'y entre pas, et il est traité comme tel plutôt qu'étiré. Trois vérifications firsthand :

1. **Jumeaux structurels d'une paire déjà admise.** `p4at_witness_k1/k2` (L848, L861) reprennent les cellules de `p4_wf_witness_k1/k2` (L758, L775) — **mêmes** cellules (bloc still-life centré ; glider centré), **mêmes** nombres de générations (2, 4), **mêmes** fenêtres `restrictGridTo`. Seul le moteur change : `hashlifeResultAt j` au lieu de `hashlifeResultAux (j+2)`, ce qui est précisément l'objet de grain 3a.

2. **Autonomes.** `git grep` sur les deux noms ne renvoie **aucune** référence hors de leurs propres déclarations. Ce sont des témoins finis concrets, pas des prémisses.

3. **L'énoncé général n'est pas vidé.** `hashlifeResultAt_base_central` (L806) est quantifié universellement sur `c : MacroCell` et `j : Nat`, et se prouve par tactiques structurelles (`cases` / `omega` / `obtain` / `simp only`) en se refermant sur `hashlifeResult_central_correct`, déjà prouvé. Aucun `native_decide` dedans.

Les trois tenant, l'élargissement est attribuable et non-vidant : le pin suit l'empreinte, 59 → 61.

## Ce que la règle devient

Le critère opérant est **attribuable ET non-vidant**, dont « attribuable à un module nouvellement couvert » était une instance, pas la définition. Un nom attribuable à un **théorème** nouvellement ajouté est également légitime si (a) le théorème est un témoin fini concret, (b) rien ne le référence, (c) les énoncés généraux du module n'en dépendent pas. À défaut de l'un des trois, le pin reste et c'est la preuve qui se reprend — inchangé depuis #9341.

Le docstring porte ce raisonnement en entier, pour que la prochaine lecture n'ait pas à le refaire.

## Reste ouvert (pas dans cette PR)

La question « ces deux `native_decide` pourraient-ils être des `decide` noyau ? » — c'est le sens vertueux du cliquet (#9571 et #9595 ont fait descendre le pin de 46→41→38 par des bascules de ce type). Elle reste posée à la lane Lean sur #11349 ; elle ne bloque pas la réparation de `main`.

Test : `pytest scripts/lean/tests/test_proof_integrity_audit_wiring.py` → **7 passed**.

See #11349, #11303.
