### PR TITLE
fix(planners,#11112): Planners-10-LLM re-exec seq -> CLEAN 1..18 (keyless mode)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Planners/04-NeuroSymbolic/Planners-10-LLM-Planning.ipynb
@@ -989,8 +989,17 @@
    "id": "70bb1912",
    "source": "# Exercice 2 : Etendre le validateur PDDL\n# TODO etudiant : ajoutez des controles supplementaires au validateur\n# Etape 1 : extrayez les predicats declares dans :predicates\n# Etape 2 : extrayez les predicats utilises dans les actions\n# Etape 3 : comparez les deux listes et signalez les predicats non declares\n# Etape 4 : verifiez que chaque action a :parameters, :precondition et :effect\n# Indice : utilisez re.findall(r'\\(([a-zA-Z_-]+\\s+\\?[\\w_-]+', pddl_code) pour extraire predicats\n\ndef validate_pddl_advanced(pddl_code: str, is_domain: bool = True) -> tuple:\n    \"\"\"Validation avancee de la syntaxe PDDL\"\"\"\n    errors = []\n    # Reprenez d'abord les controles de validate_pddl_syntax\n    # puis ajoutez vos controles supplementaires ici\n    return len(errors) == 0, errors\n\n# Testez votre validateur\ntest_result, test_errors = validate_pddl_advanced(test_domain, is_domain=True)\nprint(f\"Validation avancee: {test_result}\")\nif test_errors:\n    for e in test_errors:\n        print(f\"  - {e}\")\nelse:\n    print(\"Exercice a completer : etendre le validateur PDDL\")",
    "metadata": {},
-   "execution_count": 17,
-   "outputs": []
+   "execution_count": 10,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation avancee: True\n",
+      "Exercice a completer : etendre le validateur PDDL\n"
+     ]
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1013,7 +1022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "5a76dd94",
    "metadata": {
     "execution": {
@@ -1098,7 +1107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "25a34715",
    "metadata": {
     "execution": {
@@ -1173,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "ceae3028",
    "metadata": {
     "execution": {
@@ -1266,7 +1275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "f6ea658d",
    "metadata": {
     "execution": {
@@ -1357,8 +1366,16 @@
    "id": "cc13e92e",
    "source": "# Exercice 3 : Concevoir un prompt de planification robuste\n# TODO etudiant : redigez un prompt ameliore pour generer des plans valides\n# Etape 1 : ajoutez un exemple few-shot (domaine robot-simple avec plan correct)\n# Etape 2 : contraignez le format de sortie (JSON strict entre ```json et ```)\n# Etape 3 : demandez la verification des preconditions avant generation\n# Indice : inspirez-vous de prompt_nl defini dans l'exemple guide ci-dessous (Traduction NL vers PDDL)\n\nrobust_prompt = \"\"\"\nVotre prompt ameliore ici...\n\"\"\"\n\n# Testez votre prompt (si API configuree)\n# plan_robust = call_llm_for_plan(robust_prompt)\n# success_robust = validate_plan(plan_robust, INITIAL_STATE, GOAL_STATE)\n# print(f\"Plan robuste valide : {success_robust}\")\n\nprint(\"Exercice a completer : concevoir un prompt de planification robuste\")",
    "metadata": {},
-   "execution_count": 18,
-   "outputs": []
+   "execution_count": 15,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : concevoir un prompt de planification robuste\n"
+     ]
+    }
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1389,7 +1406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "3f7e47d2",
    "metadata": {
     "execution": {
@@ -1465,7 +1482,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "c0k81u0utji",
    "metadata": {
     "execution": {
@@ -1757,7 +1774,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "p10-ex-stub",
    "metadata": {
     "execution": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-dotnet (#11364)

## Summary

Re-execution séquentielle étage 3 #11112, tranche Planners LLM : `Planners-10-LLM-Planning.ipynb` re-exécuté via nbconvert (kernel python3) — sequence `[1..9,17,10..13,18,14..16]` → `CLEAN 1..18`, 0 erreur. **Mode keyless** (mode du run main) : clients OpenAI/Anthropic « Non configurés », guards demo partout, exécution déterministe sans clé API.

## Diagnostic dérive (C.4, cause (a) env)

2 cellules (exec 17/18 sur main) avaient leurs `outputs` vidés — le run main avait été partiellement re-exécuté avec outputs perdus sur les 2 dernières cellules. Le run frais produit les vrais prints, restaurés ici.

## Validation (commit 1d6e6d3f2)

- `check_exec_sequence` : CLEAN 1..18 (18 cells code, 0 erreur)
- C.3 : code byte-identique (vérifié JSON, 0 source_diffs post-restore base-main)
- Aucune citation chiffrée markdown à ré-aligner (0 stale) — amendement acceptance #11112 vérifié
- Pas de paire jumelle pour ce notebook (pas de rebaseline requis)

See #11112 (étage 3, tranche Planners — contribution partielle)
