### PR TITLE
docs(genai,#11271): densite 02-Aspire-GenAiStack-Reel 1040 -> 1477 (tranche 2/2)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/02-Aspire-GenAiStack-Reel.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/02-Aspire-GenAiStack-Reel.ipynb
@@ -3,12 +3,16 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "# Aspire : orchestrer la pile GenAI **réelle** du cluster\n\nCe notebook démontre l'axe **Aspire** de l'Epic [#10473](https://github.com/jsboige/CoursIA/issues/10473) — *The Unexpected AI Stack: C#/.NET* (grain [#10857](https://github.com/jsboige/CoursIA/issues/10857)). Il prolonge le grain [#10838](https://github.com/jsboige/CoursIA/issues/10838) (notebook [`01-Aspire-Orchestration-GenAi.ipynb`](01-Aspire-Orchestration-GenAi.ipynb), qui orchestrait **un** service) : ici, l'AppHost déclare **la pile telle qu'elle existe vraiment** — plusieurs machines, plusieurs rôles, deux typologies de ressources — et le notebook la traverse par des appels réels.\n\n**Ce qui est démontré, de bout en bout :**\n\n1. Un AppHost C# unique qui **modèle la pile réelle** : endpoints externes (ComfyUI, vLLM) + un conteneur orchestrable (whisper-api).\n2. **Deux instances simultanées** (`aspire run --isolated` depuis deux répertoires), sans collision de ports ni de conteneurs.\n3. `aspire describe` / `aspire logs` sur des ressources **réelles**.\n4. Des **appels traversants** : une complétion LLM sur le vLLM de la flotte (`qwen3.6-35b-a3b`), et un appel authentifié à ComfyUI (génération Qwen-Image).\n5. Trois exercices pour s'approprier le diagnostic et l'extension du modèle."
+   "source": [
+    "# Aspire : orchestrer la pile GenAI **réelle** du cluster\n\nCe notebook démontre l'axe **Aspire** de l'Epic [#10473](https://github.com/jsboige/CoursIA/issues/10473) — *The Unexpected AI Stack: C#/.NET* (grain [#10857](https://github.com/jsboige/CoursIA/issues/10857)). Il prolonge le grain [#10838](https://github.com/jsboige/CoursIA/issues/10838) (notebook [`01-Aspire-Orchestration-GenAi.ipynb`](01-Aspire-Orchestration-GenAi.ipynb), qui orchestrait **un** service) : ici, l'AppHost déclare **la pile telle qu'elle existe vraiment** — plusieurs machines, plusieurs rôles, deux typologies de ressources — et le notebook la traverse par des appels réels.\n\n**Ce qui est démontré, de bout en bout :**\n\n1. Un AppHost C# unique qui **modèle la pile réelle** : endpoints externes (ComfyUI, vLLM) + un conteneur orchestrable (whisper-api).\n2. **Deux instances simultanées** (`aspire run --isolated` depuis deux répertoires), sans collision de ports ni de conteneurs.\n3. `aspire describe` / `aspire logs` sur des ressources **réelles**.\n4. Des **appels traversants** : une complétion LLM sur le vLLM de la flotte (`qwen3.6-35b-a3b`), et un appel authentifié à ComfyUI (génération Qwen-Image).\n5. Trois exercices pour s'approprier le diagnostic et l'extension du modèle.\n\n**Comment lire ce notebook :** chaque section suit le même rythme — une cellule de code qui agit sur la pile, puis sa lecture. Les valeurs citées dans les lectures (ports, PIDs, jetons) sont celles des sorties committées : si vous ré-exécutez, elles changent — comportement attendu, les ports `--isolated` sont éphémères par conception — mais la structure des résultats reste identique."
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Contexte : la pile GenAI réelle, multi-machines\n\nContrairement au grain #10838, qui orchestrait un service local isolé, la pile de production couvre **plusieurs machines du cluster** :\n\n| Service | Machine | Endpoint | Rôle | Statut dans l'AppHost |\n|---|---|---|---|---|\n| `comfyui-qwen` | po-2023 | `http://127.0.0.1:8188` | génération d'images Qwen (ComfyUI 0.25) | **externe** (référencé) |\n| `vllm` | ai-01 | `http://192.168.0.47:5002` | LLM `qwen3.6-35b-a3b`, endpoint OpenAI-compatible | **externe** (référencé) |\n| `whisper-api` | locale | port fixe 8190 (compose) | transcription ASR faster-whisper | **conteneur orchestré** |\n\nDeux typologies, et c'est un choix d'architecture, pas une commodité :\n\n- **Les services lourds sont des singletons GPU.** ComfyUI occupe ~14 Go de VRAM sur la RTX 3090 ; le vLLM de ai-01 sert toute la flotte. Les dupliquer « par worktree » serait gaspiller la seule ressource rare (la GPU) et risquer l'OOM. Aspire les déclare donc comme **chaînes de connexion** : visibles dans le dashboard, consommables par le code, **jamais recréés**.\n- **Le service léger est orchestrable.** whisper-api (lazy-load : le modèle ne se charge qu'au premier appel) se duplique sans coût — c'est lui qui matérialise l'isolation `--isolated`.\n\n> **Ligne de parité** : à la main, un agent qui travaille dans un worktree doit connaître les ports de chacun, gérer les collisions, et documenter la pile dans un README. Avec Aspire, **le modèle de ressources EST la documentation exécutable** : `aspire describe` répond.\n\n## 1. L'AppHost : la pile entière en un fichier C#\n\nL'AppHost ([`GenAiStackReel.AppHost/apphost.cs`](GenAiStackReel.AppHost/apphost.cs)) utilise le SDK file-based `#:sdk Aspire.AppHost.Sdk@13.4.6` (pas de `.csproj`). Trois déclarations à repérer à la lecture : les deux `ConnectionStrings` (comfyui, vllm) passés **par configuration** — la surcharge à deux arguments de `AddConnectionString` interprète le second comme un *nom de variable d'environnement*, pas comme la valeur — et le `AddContainer` du grain #10838, reconduit à l'identique.\n\nAucun secret ne vit dans ce fichier : le conteneur orchestré tourne avec `AUTH_ENABLED=false`, et les clés des endpoints externes ne sont présentées qu'au moment de l'appel (sections 4), lues au runtime."
+   "source": [
+    "## Contexte : la pile GenAI réelle, multi-machines\n\nContrairement au grain #10838, qui orchestrait un service local isolé, la pile de production couvre **plusieurs machines du cluster** :\n\n| Service | Machine | Endpoint | Rôle | Statut dans l'AppHost |\n|---|---|---|---|---|\n| `comfyui-qwen` | po-2023 | `http://127.0.0.1:8188` | génération d'images Qwen (ComfyUI 0.25) | **externe** (référencé) |\n| `vllm` | ai-01 | `http://192.168.0.47:5002` | LLM `qwen3.6-35b-a3b`, endpoint OpenAI-compatible | **externe** (référencé) |\n| `whisper-api` | locale | port fixe 8190 (compose) | transcription ASR faster-whisper | **conteneur orchestré** |\n\nDeux typologies, et c'est un choix d'architecture, pas une commodité :\n\n- **Les services lourds sont des singletons GPU.** ComfyUI occupe ~14 Go de VRAM sur la RTX 3090 ; le vLLM de ai-01 sert toute la flotte. Les dupliquer « par worktree » serait gaspiller la seule ressource rare (la GPU) et risquer l'OOM. Aspire les déclare donc comme **chaînes de connexion** : visibles dans le dashboard, consommables par le code, **jamais recréés**.\n- **Le service léger est orchestrable.** whisper-api (lazy-load : le modèle ne se charge qu'au premier appel) se duplique sans coût — c'est lui qui matérialise l'isolation `--isolated`.\n\n> **Ligne de parité** : à la main, un agent qui travaille dans un worktree doit connaître les ports de chacun, gérer les collisions, et documenter la pile dans un README. Avec Aspire, **le modèle de ressources EST la documentation exécutable** : `aspire describe` répond.\n\nCette asymétrie se lit aussi dans les effets de bord : arrêter l'AppHost ne touche **que** ce qu'il a créé (les conteneurs orchestrés), jamais les singletons référencés — les autres machines de la flotte ne voient même pas passer votre expérimentation. C'est ce qui autorise un notebook « réel » sans risque : la pile de production reste hors de portée des effets de bord du grain.\n\n## 1. L'AppHost : la pile entière en un fichier C#\n\nL'AppHost ([`GenAiStackReel.AppHost/apphost.cs`](GenAiStackReel.AppHost/apphost.cs)) utilise le SDK file-based `#:sdk Aspire.AppHost.Sdk@13.4.6` (pas de `.csproj`). Trois déclarations à repérer à la lecture : les deux `ConnectionStrings` (comfyui, vllm) passés **par configuration** — la surcharge à deux arguments de `AddConnectionString` interprète le second comme un *nom de variable d'environnement*, pas comme la valeur — et le `AddContainer` du grain #10838, reconduit à l'identique.\n\nAucun secret ne vit dans ce fichier : le conteneur orchestré tourne avec `AUTH_ENABLED=false`, et les clés des endpoints externes ne sont présentées qu'au moment de l'appel (sections 4), lues au runtime."
+   ]
   },
   {
    "cell_type": "code",
@@ -147,7 +151,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Lecture du source\n\nChaque service de la pile correspond à une ligne du modèle :\n\n- `builder.Configuration[\"ConnectionStrings:comfyui\"] = \"http://127.0.0.1:8188\"` puis `AddConnectionString(\"comfyui\")` — le service **existant** de po-2023, référencé ;\n- idem pour `vllm` (`http://192.168.0.47:5002`, le LLM partagé de ai-01) ;\n- `AddContainer(\"whisper-api\", \"whisper-api-whisper-api\")` — l'image **locale réelle** buildée depuis le Dockerfile du dépôt, avec montages et endpoint `8190` vers un port hôte **éphémère**.\n\nLe helper d'amorage ci-dessus fournit aussi `RunCapture` (pour une commande qui fluxe sa sortie, comme `aspire logs`) et `Clean` (le CLI émet des séquences ANSI même redirigé — on les retire pour des sorties lisibles).\n\n## 2. Instance A : lancer l'AppHost (`run --detach --isolated`)\n\n`--detach` démarre en arrière-plan ; `--isolated` randomise les ports **et** isole les user secrets. La sortie de lancement contient l'URL du dashboard Aspire."
+   "source": [
+    "### Lecture du source\n\nChaque service de la pile correspond à une ligne du modèle :\n\n- `builder.Configuration[\"ConnectionStrings:comfyui\"] = \"http://127.0.0.1:8188\"` puis `AddConnectionString(\"comfyui\")` — le service **existant** de po-2023, référencé ;\n- idem pour `vllm` (`http://192.168.0.47:5002`, le LLM partagé de ai-01) ;\n- `AddContainer(\"whisper-api\", \"whisper-api-whisper-api\")` — l'image **locale réelle** buildée depuis le Dockerfile du dépôt, avec montages et endpoint `8190` vers un port hôte **éphémère**.\n\nLe helper d'amorage ci-dessus fournit aussi `RunCapture` (pour une commande qui fluxe sa sortie, comme `aspire logs`) et `Clean` (le CLI émet des séquences ANSI même redirigé — on les retire pour des sorties lisibles).\n\nTrois détails du `AddContainer` méritent l'arrêt : `WithContainerRuntimeArgs(\"--gpus\", \"all\")` expose les GPU **puis** `WithEnvironment(\"CUDA_VISIBLE_DEVICES\", \"1\")` épingle le conteneur sur la RTX 3090 externe — la règle de gel GPU du dépôt, visible dans la source ; les trois `WithBindMount` (`shared/`, `models/`, cache Hugging Face) rendent l'image **sans état** — dupliquer le conteneur ne duplique ni le modèle ni la config ; enfin `targetPort: 8190` fixe le port **interne**, le port hôte restant éphémère (`--isolated`) — l'inverse du compose manuel, qui fige les deux.\n\n## 2. Instance A : lancer l'AppHost (`run --detach --isolated`)\n\n`--detach` démarre en arrière-plan ; `--isolated` randomise les ports **et** isole les user secrets. La sortie de lancement contient l'URL du dashboard Aspire."
+   ]
   },
   {
    "cell_type": "code",
@@ -178,7 +184,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Lecture du lancement\n\nLe CLI rapporte le fichier AppHost, l'URL du **dashboard** (le jeton `?t=...` de la page de login est jetable et local), le chemin du journal, et le PID. `AppHost a démarré correctement.` — le conteneur whisper-api démarre, les deux endpoints externes sont déjà « Running » puisqu'ils ne sont pas gérés par ce AppHost (ils existent par eux-mêmes)."
+   "source": [
+    "### Lecture du lancement\n\nLe CLI rapporte le fichier AppHost, l'URL du **dashboard** (le jeton `?t=...` de la page de login est jetable et local), le chemin du journal, et le PID. `AppHost a démarré correctement.` — le conteneur whisper-api démarre, les deux endpoints externes sont déjà « Running » puisqu'ils ne sont pas gérés par ce AppHost (ils existent par eux-mêmes).\n\nConcrètement dans cette exécution : dashboard sur `https://localhost:61897`, PID **38416** — c'est le *processus AppHost* ; le `aspire ps` de la section suivante affichera en regard un second identifiant (CLI PID, le wrapper qui a lancé le détachement), et le journal `detach-child_*.log` garde la trace complète du démarrage si un diagnostic s'avère nécessaire. Le jeton `?t=...` n'autorise que cette session de dashboard : le copier dans un autre navigateur ne sert à rien."
+   ]
   },
   {
    "cell_type": "code",
@@ -251,12 +259,16 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Lecture du snapshot\n\n- `describe whisper-api` : `Running` + `Healthy`, URL `http://localhost:PORT` — le port hôte **éphémère** choisi par `--isolated`, indépendant du 8190 fixé du compose manuel.\n- `describe vllm` : le type affiché (`Parameter`/`ConnectionString`) est la signature d'une **référence**, pas d'un conteneur : l'état `Running/Healthy` reflète la déclaration, le service lui-même vit sur ai-01.\n- `aspire ps` : une seule entrée — l'instance A."
+   "source": [
+    "### Lecture du snapshot\n\n- `describe whisper-api` : `Running` + `Healthy`, URL `http://localhost:PORT` — le port hôte **éphémère** choisi par `--isolated`, indépendant du 8190 fixé du compose manuel.\n- `describe vllm` : le type affiché (`Parameter`/`ConnectionString`) est la signature d'une **référence**, pas d'un conteneur : l'état `Running/Healthy` reflète la déclaration, le service lui-même vit sur ai-01.\n- `aspire ps` : une seule entrée — l'instance A.\n\nIci, l'instance A a reçu le port hôte `61899` pour son whisper-api — éphémère, donc différent du `8190` interne et différent de toute future instance. Quant à `vllm`, l'absence d'URL locale (`-`) n'est pas un défaut : la ressource est une **référence** à un service qui vit sur ai-01 ; son état `Healthy` atteste la déclaration, pas un health-check réseau."
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## 2bis. Instance B : le « deuxième worktree » en parallèle\n\nLe scénario de la dette de worktrees : un deuxième checkout du dépôt (ici, la copie `GenAiStackReel.AppHost-wt2/`) lance **le même** AppHost. Sans `--isolated` : collision. Avec : chaque instance reçoit ses propres ports, ses propres user secrets, et des **noms de conteneurs suffixés** — les deux whisper-api coexistent."
+   "source": [
+    "## 2bis. Instance B : le « deuxième worktree » en parallèle\n\nLe scénario de la dette de worktrees : un deuxième checkout du dépôt (ici, la copie `GenAiStackReel.AppHost-wt2/`) lance **le même** AppHost. Sans `--isolated` : collision. Avec : chaque instance reçoit ses propres ports, ses propres user secrets, et des **noms de conteneurs suffixés** — les deux whisper-api coexistent.\n\nLe scénario n'est pas artificiel : c'est exactement la situation de deux agents qui checkout le dépôt dans deux worktrees pour travailler en parallèle — la « dette de worktrees » du cluster. Chaque instance reçoit son dashboard, ses user secrets et un suffixe de conteneur aléatoire (l'instance A s'appelle `whisper-api-jnprwjmw` dans les journaux de la section 3) : deux whisper-api coexistent sans se voir."
+   ]
   },
   {
    "cell_type": "code",
@@ -328,7 +340,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Lecture : deux jeux de ports distincts\n\nDans le `aspire ps` final, **deux lignes** : deux chemins d'AppHost, deux PIDs, **deux dashboards sur des ports différents**, et dans chaque dashboard un whisper-api sur son propre port éphémère. Aucune collision docker, aucune collision de ports. C'est la réponse d'Aspire à la question « comment deux agents travaillent-ils en parallèle sur la même pile ? » (exercice 1 : l'exploiter programmatiquement).\n\n## 3. Les journaux d'un service réel : `aspire logs`\n\n`aspire logs whisper-api` fluxe les journaux unifiés de la ressource. La cellule capture une fenêtre bornée (10 s) puis termine la commande."
+   "source": [
+    "### Lecture : deux jeux de ports distincts\n\nDans le `aspire ps` final, **deux lignes** : deux chemins d'AppHost, deux PIDs, **deux dashboards sur des ports différents**, et dans chaque dashboard un whisper-api sur son propre port éphémère. Aucune collision docker, aucune collision de ports. C'est la réponse d'Aspire à la question « comment deux agents travaillent-ils en parallèle sur la même pile ? » (exercice 1 : l'exploiter programmatiquement).\n\nLa preuve est dans le tableau : instance A — dashboard `61897`, PID `38416`, CLI PID `41624` ; instance B — dashboard `61980`, PID `5824`, CLI PID `42320`. Quatre familles d'identifiants, aucune valeur partagée. Les whisper-api suivent la même règle (`61899` pour A, `61979` pour B, visibles dans les `describe` respectifs).\n\n## 3. Les journaux d'un service réel : `aspire logs`\n\n`aspire logs whisper-api` fluxe les journaux unifiés de la ressource. La cellule capture une fenêtre bornée (10 s) puis termine la commande."
+   ]
   },
   {
    "cell_type": "code",
@@ -389,7 +403,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Lecture des journaux\n\nLes journaux sont ceux du **vrai conteneur** faster-whisper : démarrage du serveur, configuration du modèle (`large-v3-turbo`, `int8_float16`), attente lazy du premier appel. Rien n'est simulé.\n\n## 4. Traverser la pile : deux appels réels\n\nLe modèle déclaratif n'a de valeur que si le code **consomme** la pile. Deux appels, sur les deux typologies :\n\n1. **vLLM (ai-01:5002)** — `GET /v1/models` puis une complétion réelle sur `qwen3.6-35b-a3b`. La clé API est lue au runtime depuis `../.env` (rendu depuis `master.env` par le pipeline `render_envs.py`) : **jamais un littéral, jamais affichée**.\n2. **ComfyUI (po-2023:8188)** — protégé par ComfyUI-Login ; le token API est le **hachage bcrypt imprimé au démarrage du conteneur** (`use token=$2b...` dans `docker logs`). Extraction au runtime, valeur masquée."
+   "source": [
+    "### Lecture des journaux\n\nLes journaux sont ceux du **vrai conteneur** faster-whisper : démarrage du serveur, configuration du modèle (`large-v3-turbo`, `int8_float16`), attente lazy du premier appel. Rien n'est simulé.\n\nTrois lectures fines s'y arrêtent : la bannière CUDA `12.1.0` est marquée **DEPRECATED** par NVIDIA — un service réel vit dans une image vieillissante, sa maintenance est un fait d'exploitation, pas un échec ; `Started idle checker (timeout: 1200s)` matérialise le lazy-load — le modèle ne se chargera qu'au premier appel et l'instance s'éteindra après 20 minutes d'inactivité, c'est ce qui rend la duplication par worktree peu coûteuse ; enfin `Uvicorn running on http://0.0.0.0:8190` rappelle que `8190` est le port **interne** du conteneur, et le `GET /health 200` final prouve que la sonde passe déjà — avant même que le modèle soit chargé.\n\n## 4. Traverser la pile : deux appels réels\n\nLe modèle déclaratif n'a de valeur que si le code **consomme** la pile. Deux appels, sur les deux typologies :\n\n1. **vLLM (ai-01:5002)** — `GET /v1/models` puis une complétion réelle sur `qwen3.6-35b-a3b`. La clé API est lue au runtime depuis `../.env` (rendu depuis `master.env` par le pipeline `render_envs.py`) : **jamais un littéral, jamais affichée**.\n2. **ComfyUI (po-2023:8188)** — protégé par ComfyUI-Login ; le token API est le **hachage bcrypt imprimé au démarrage du conteneur** (`use token=$2b...` dans `docker logs`). Extraction au runtime, valeur masquée."
+   ]
   },
   {
    "cell_type": "code",
@@ -437,7 +453,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "### Lecture de la réponse vLLM\n\nLe catalogue confirme le modèle servi (`qwen3.6-35b-a3b`, contexte 262 144 tokens) — c'est bien le moteur auto-hébergé de la flotte, pas un service marchand. Deux points d'attention visibles dans le code :\n\n- **Le secret reste au runtime** : la cellule n'affiche que la *longueur* de la clé, jamais sa valeur.\n- **Piège des modèles de raisonnement** : sur `/chat/completions`, le champ `message.content` peut être `null` si le budget de tokens part en raisonnement — le code teste explicitement ce cas au lieu de slicer aveuglément (et affiche un fallback explicite si cela arrive)."
+   "source": [
+    "### Lecture de la réponse vLLM\n\nLe catalogue confirme le modèle servi (`qwen3.6-35b-a3b`, contexte 262 144 tokens) — c'est bien le moteur auto-hébergé de la flotte, pas un service marchand. Deux points d'attention visibles dans le code :\n\n- **Le secret reste au runtime** : la cellule n'affiche que la *longueur* de la clé, jamais sa valeur.\n- **Piège des modèles de raisonnement** : sur `/chat/completions`, le champ `message.content` peut être `null` si le budget de tokens part en raisonnement — le code teste explicitement ce cas au lieu de slicer aveuglément (et affiche un fallback explicite si cela arrive).\n\nC'est arrivé dans cette exécution : la complétion a retourné `[reasoning-only] budget epuise en raisonnement` — HTTP `200`, donc « réussi » au sens transport, mais aucun contenu exploitable. Un appel LLM ne se valide pas sur son seul code de statut : tester le `message.content` avant de construire dessus est la moindre des hygiènes."
+   ]
   },
   {
    "cell_type": "code",
@@ -490,7 +508,9 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "## Exercices\n\nTrois exercices pour prolonger le grain. Les cellules sont des **stubs à compléter** : le notebook s'exécute de bout en bout même non résolu (convention du dépôt — jamais d'erreur volontaire).\n\n### Exercice 1 — Prouver la disjointure des ports\n\nLa sortie de `aspire ps` ci-dessus (après l'instance B) contient les deux tableaux de bord. Écrire `VerifierDisjonction` qui extrait les deux ports et retourne la preuve qu'ils diffèrent."
+   "source": [
+    "## Exercices\n\nTrois exercices pour prolonger le grain. Les cellules sont des **stubs à compléter** : le notebook s'exécute de bout en bout même non résolu (convention du dépôt — jamais d'erreur volontaire).\n\nVariables disponibles : `psBoth` — la sortie du `aspire ps` à deux lignes, capturée au lancement de l'instance B — contient dashboards, PIDs et chemins des deux instances ; les URL des endpoints protégés sont celles du modèle (`8188` pour ComfyUI) ; pour l'exercice 3, s'inspirer des deux `AddConnectionString` du source. Les stubs affichent « Exercice a completer » — c'est la convention, pas une erreur.\n\n### Exercice 1 — Prouver la disjointure des ports\n\nLa sortie de `aspire ps` ci-dessus (après l'instance B) contient les deux tableaux de bord. Écrire `VerifierDisjonction` qui extrait les deux ports et retourne la preuve qu'ils diffèrent."
+   ]
   },
   {
    "cell_type": "code",
@@ -598,6 +618,13 @@
     }
    ],
    "source": "// Hygiene d'agent : arreter les deux instances isolees (supprime leurs\n// conteneurs orchestres). Les endpoints externes (comfyui, vllm) ne sont pas\n// touches : ils ne nous appartiennent pas, ils appartiennent a la pile.\nConsole.WriteLine(AspireShell.Clean(AspireShell.Aspire(AspireShell.DirWt1, \"stop\")));\nConsole.WriteLine(AspireShell.Clean(AspireShell.Aspire(AspireShell.DirWt2, \"stop\")));"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'arrêt\n\nDeux arrêts, deux `stopped successfully` — un par instance. `aspire stop` supprime les **conteneurs orchestrés** : les deux whisper-api et leurs ports éphémères disparaissent, la machine redevient propre. Les endpoints **externes** (ComfyUI, vLLM) ne sont pas interrogés par l'arrêt — ils continuent de servir les autres machines de la flotte. C'est l'asymétrie du modèle devenue geste d'exploitation : on éteint ce qu'on a créé, on ne touche pas ce qu'on a référencé."
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-dotnet (#11374)

## Summary

Tranche densité pédagogique 2/2 #11271 (sous-série Aspire, GenAI) : `02-Aspire-GenAiStack-Reel.ipynb` densité **1040 → 1477** (instrument `pedagogy_density.py`, status ok, seuil 1200).

Enrichissement markdown-only : +4802 chars de prose FR sur 10 cellules markdown étendues + 1 nouvelle cellule interp « Lecture de l'arrêt » (après le code de stop, avant la Conclusion).

## Validation (commit c6e3c4e21)

- **Cellules code byte-identiques** (vérifié JSON : changed code = []) ; outputs intacts (0 ligne `execution_count` touchée dans le diff) — dispense re-exec C.3 (markdown-only), amendement acceptance #11112 respecté
- Interps ancrées sur les outputs committés : dashboards 61897/61980, PIDs 38416/5824, CLI PIDs 41624/42320, whisper-api 61899/61979, CUDA 12.1.0 (bannière NGC DEPRECATED), idle checker 1200s (lazy-load), Uvicorn 8190 interne vs port hôte éphémère, GET /health 200, `[reasoning-only]` budget vLLM
- Citation `CUDA_VISIBLE_DEVICES` fixée à la forme exacte de l'écho de source (`WithEnvironment`) — anchor-check forme exacte
- CRLF 0, pas de paire jumelle (série Aspire sans twins — pas de rebaseline requis)

See #11271 (tranche 2/2, règle 1 tranche/lane/jour — contribution partielle)
