### PR TITLE
fix(genai,#10990): 01-5-Kokoro-TTS-Local env_path -> env_path.name (basename, tranche Audio/01-Foundation)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb
@@ -353,7 +353,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".env charge depuis: D:\\Dev\\CoursIA-h3-nits-recal\\MyIA.AI.Notebooks\\GenAI\\.env\n"
+      ".env charge depuis: .env\n"
      ]
     }
    ],
@@ -377,7 +377,7 @@
     "    env_path = genai_path / \".env\"\n",
     "    if env_path.exists():\n",
     "        load_dotenv(env_path)\n",
-    "        print(f\".env charge depuis: {env_path}\")\n",
+    "        print(f\".env charge depuis: {env_path.name}\")\n",
     "    else:\n",
     "        print(\"WARNING: .env non trouve dans GenAI\")\n",
     "else:\n",
@@ -3157,8 +3157,8 @@
    "end_time": "2026-08-16T01:14:16.146014",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:/Dev/CoursIA-h3-nits-recal/MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb",
-   "output_path": "C:\\Users\\jsboi\\AppData\\Local\\Temp\\claude\\d--Dev-CoursIA\\e3012e6f-27f8-43c8-a9f0-6d11fc09c529\\scratchpad\\trancheA/out_01-5-Kokoro-TTS-Local.ipynb",
+   "input_path": "01-5-Kokoro-TTS-Local.ipynb",
+   "output_path": "01-5-Kokoro-TTS-Local.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #11319

fix(genai,#10990): 01-5-Kokoro-TTS-Local env_path -> env_path.name (basename)

Tranche **Audio/01-Foundation** du cleanup #10990 (33 notebooks impriment le chemin absolu du `.env`). Sur 5 notebooks scannés, **4/5 étaient déjà conformes** (pattern `env_path.name` ou `env_path.parent.name/env_path.name` déjà en place dans la source, outputs embedded clean). Seul **`01-5-Kokoro-TTS-Local.ipynb`** portait la fuite absolue — c'est ce que cette PR corrige.

## Diagnostic dérive (C.4)

- **Source cell[8]** : `print(f".env charge depuis: {env_path}")` (path absolu) → `print(f".env charge depuis: {env_path.name}")` (basename).
- **Output cell[8]** : contenant `D:\\Dev\\CoursIA-h3-nits-recal\\...\\GenAI\\.env` (chemin absolu du `.env` hissé d'un cwd d'exécution antérieur) → `.env` (basename).
- **Papermill metadata** : `input_path` / `output_path` absolus (pré-commit `scrub-papermill-paths` auto-appliqué).

## Triage cause (secrets-hygiene rule 6, cas C)

**Source-leak** : code qui imprime un `Path` complet alors qu'il ne sert qu'à confirmer le chargement. C'est un pattern (A) env / cwd et non (C) source-leak au sens strict (la cellule n'imprime pas un secret, juste un chemin) — **mais** la conséquence est strictement la même : un chemin machine hors du repo, qui fuite dans `outputs` à chaque exécution. Fix : corriger la source (`env_path.name`) + l'output est la conséquence inséparable de la correction source.

**Re-exécution complète écartée** : un `nbconvert --execute --inplace` re-introduit plusieurs autres chemins absolus (`Sortie : D:\\Dev\\CoursIA-2-10990\\...`) côté cellules audio/Kokoro (téléchargements HuggingFace Kokoro + outputs WAV). Le patch minimal (source + output de la SEULE cellule fautive) est **strictement meilleur** : 4 lignes diff, 0 nouveau chemin absolu introduit, et le diff est entièrement vérifiable.

## Verdict

`CAUSE_FIXED` — source corrigée + output remplacé par la conséquence directe de la correction source. Pas d'output hand-éditée hors proportion d'une cellule dont le `print` est la signature.

## Acceptance #10990 (tranche)

- ✅ Sources : 5/5 notebooks avec `env_path.name` (ou `env_path.parent.name/env_path.name` pour 01-4)
- ✅ Outputs embedded : 5/5 notebooks sans chemin absolu dans `'.env charge depuis:'`
- ✅ Pre-commit 8/8 verts (gitleaks, H.3 execution_count, .NET probeAddresses, .NET NuGet cache, scrub-papermill-paths auto, oversized markdown, …)

## Diff

```
MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-5-Kokoro-TTS-Local.ipynb | 8 ++++----
1 file changed, 4 insertions(+), 4 deletions(-)
```

## Suite

Issue #10990 = 33 notebooks au total. **Tranche Audio/01-Foundation (5 nb) close.** Reste ~28 nb répartis sur Audio/02-*, Audio/03-*, Audio/04-*, Image/*, Video/* — autre tranche = autre PR, autre cycle.

## Pool discipline

Cette PR est dans la **classe CONTENU** (G-VAR-1) au **tier MED** (changement vérifiable, output reflète la source, pas de « 0 trouvé »). Génre **notebook-python** (variation G-VAR-3 OK vs #11319 qui était aussi notebook-python — c'est le TIER qui distingue, pas le genre, et MED substantiel ≠ LIGHT adjacent).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
