### PR TITLE
fix(prover,#1453): FX-5b — probe timeout no longer refuses a run as TRUE_PLACEHOLDER

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py
@@ -308,12 +308,27 @@ def is_true_placeholder_goal(filepath: str, sorry_line: int) -> Tuple[bool, str]
     new_lines = lines[:sorry_line - 1] + [indent_str + _TRUE_PROBE] + lines[sorry_line:]
     tmp_path.write_text("\n".join(new_lines), encoding="utf-8")
     try:
-        raw_output = verifier.verify_project_file(relative_path).get("raw_output", "") or ""
+        probe_result = verifier.verify_project_file(relative_path)
     finally:
         try:
             tmp_path.unlink()
         except OSError:
             pass
+
+    # FX-5b (#1453 iteration 1): a probe build that timed out or crashed
+    # (LeanVerifier TimeoutExpired / FileNotFoundError branches) yields
+    # success=False with an EMPTY raw_output — and ``_probe_closes_goal("")``
+    # sees "no error at the sorry line" and false-positives the goal as
+    # ``True``. Observed firsthand (2026-08-17): Folk.lean:127, a genuine
+    # Fudenberg–Maskin stretch goal, refused as TRUE_PLACEHOLDER after the
+    # 600s probe build timed out under host memory pressure — the run never
+    # entered its loop. Empty output on a failed build is NO evidence either
+    # way; only a probe that produced output (or succeeded cleanly) may
+    # decide. Non-empty output keeps full prior semantics: errors far from
+    # the probed line stay valid evidence the elaborator ran there.
+    raw_output = probe_result.get("raw_output", "") or ""
+    if not probe_result.get("success") and not raw_output.strip():
+        return False, ""
 
     if _probe_closes_goal(raw_output, sorry_line):
         return True, (

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -2371,6 +2371,30 @@ def test_is_true_placeholder_goal_false_on_unsolved_goals(tmp_path, monkeypatch)
     assert is_true_placeholder_goal(str(f), 3)[0] is False
 
 
+def test_is_true_placeholder_goal_false_on_probe_timeout(tmp_path, monkeypatch):
+    """FX-5b (#1453 iteration 1): a probe build that times out (or crashes)
+    returns success=False with an EMPTY raw_output — the old code read only
+    raw_output, saw "no error at the sorry line", and refused the run as
+    TRUE_PLACEHOLDER. Observed firsthand 2026-08-17 on Folk.lean:127 (a
+    genuine Fudenberg–Maskin stretch goal refused after the 600s probe build
+    timed out under host memory pressure). Ambiguity must never refuse."""
+    from prover.lean_utils import is_true_placeholder_goal
+    import prover.verifier as vmod
+
+    class _TimeoutVerifier:
+        def verify_project_file(self, rel, force=False):
+            # Mirrors LeanVerifier._run_lake_build's TimeoutExpired branch.
+            return {"success": False, "errors": "lake build timed out (300s)",
+                    "raw_output": ""}
+
+    monkeypatch.setattr(vmod, "get_verifier", lambda *a, **k: _TimeoutVerifier())
+    f = tmp_path / "Slow.lean"
+    f.write_text(_TRUE_GOAL_FILE, encoding="utf-8")
+    is_true, reason = is_true_placeholder_goal(str(f), 3)
+    assert is_true is False
+    assert reason == ""
+
+
 def test_is_true_placeholder_goal_false_when_no_sorry_token(tmp_path, monkeypatch):
     """A line without a real sorry token is never probed (no compile)."""
     from prover.lean_utils import is_true_placeholder_goal


### PR DESCRIPTION
## Summary

Itération 1 du ping-pong prover Epic #1453 (dispatch ai-01 2026-08-17). Correctif borné sur la cause la plus fréquente des runs `actual_iterations==0` **post-fix FX-9** : le faux refus TRUE_PLACEHOLDER_GOAL du probe FX-5 quand le build probe timeout/crashe.

- [lean_utils.py](MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/lean_utils.py) `is_true_placeholder_goal` : garde avant verdict — **sortie vide sur build échoué = aucune preuve = jamais refuser**. Sortie non-vide conserve la sémantique complète (une erreur loin de la ligne cible reste une preuve valide que l'élaborateur a traité la ligne).
- Test de régression `test_is_true_placeholder_goal_false_on_probe_timeout` (mock du branch `TimeoutExpired` réel de `LeanVerifier._run_lake_build`).

## Mécanisme démontré firsthand (le (d) de l'itération)

Run de vérification multi borné sur `game_theory_lean/RepeatedGames/Folk.lean:127` (le STRETCH Fudenberg–Maskin authentique, goal = gros ∃, PAS `True`) :

1. FX-5 écrit `_GoalExtract.lean` (module frais) et le build (`lake build -R`) — élaboration d'un module neuf important `Mathlib.Tactic`.
2. Sous pression mémoire host (commit 89,5 %), le build dépasse le `subprocess.run(timeout=600)`.
3. `_run_lake_build` TimeoutExpired → `{"success": False, "errors": "lake build timed out (300s)", "raw_output": ""}`.
4. Le probe ne lisait que `raw_output` : `""` → `_probe_closes_goal("")` voit « aucune erreur à la ligne sorry » → conclut « goal clos sous `exact True.intro` » → **REFUSED (600,1 s brûlées, jamais entré dans la boucle)**.
5. Violation du contrat documenté du probe (« never blocks a legitimate run on ambiguity »).

Cette forme (attempts=0/None + elapsed>0 + jamais dans la boucle) est exactement celle du `custom_Reidemeister_L545` cité par ai-01 (266,3 s, attempts 0) — les fichiers knot importent eux aussi du Mathlib lourd. Cause C candidate confirmée sur machine ; à confronter au sous-dict result du run d'août sur la machine d'ai-01.

## Validation

- `python -m pytest tests/ -q` depuis `agent_tests/` : **663 passed** (dont 198 `test_prover_guards.py`, nouveau test de régression inclus ; le test « conservative on other sorries erroring » verrouille la préservation de sémantique sortie-non-vide).
- Preuve du comportement avant/après sur cible réelle : le (d) (re-run Folk.lean:127 depuis le harnais fixé) est lancé — verdict chiffré posté sur le dashboard à la complétion.

See #1453

Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: DEEP/research-code #11371