### PR TITLE
chore(vscode): restore Peacock theme customizations — recover 12 duplicated stashes (#3147)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,12 +12,19 @@
         "statusBar.background": "#dd0531",
         "statusBar.foreground": "#e7e7e7",
         "statusBarItem.hoverBackground": "#fa1b49",
-        "statusBarItem.remoteBackground": "#dd0531",
+        "statusBarItem.remoteBackground": "#0e3e01",
         "statusBarItem.remoteForeground": "#e7e7e7",
         "titleBar.activeBackground": "#dd0531",
         "titleBar.activeForeground": "#e7e7e7",
         "titleBar.inactiveBackground": "#dd053199",
-        "titleBar.inactiveForeground": "#e7e7e799"
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "activityBarTop.activeBackground": "#fa1b49",
+        "activityBarTop.background": "#fa1b49",
+        "activityBarTop.foreground": "#e7e7e7",
+        "activityBarTop.inactiveForeground": "#e7e7e799",
+        "commandCenter.foreground": "#e7e7e7",
+        "statusBar.debuggingBackground": "#dd0531",
+        "statusBar.debuggingForeground": "#e7e7e7"
     },
     "peacock.color": "#dd0531"
 }


### PR DESCRIPTION
Grain: LIGHT/tooling -- lane myia-po-2025:CoursIA-2

## Contexte — campagne stash #3147 (roo-extensions), round po-2025

**12 stashes strictement identiques** (patch hash unique `6d897d98`) accumulés sur 4 semaines dans le repo racine `D:\dev\CoursIA-2` (po-2025) — tous le même diff de 9 lignes sur `.vscode/settings.json`.

### Mécanique du générateur (friction)

`.vscode/settings.json` est **tracké** mais l'extension Peacock réécrit le fichier à chaque session VS Code (couleurs du workspace). Chaque session agentique qui pull avec ce fichier modifié le stash en "pre-pull cleanup" puis oublie de pop → 12 exemplaires. Contenu absent d'`origin/main` (grep `activityBarTop` = 0) et du working tree actuel.

### Fix

Committer les customizations une fois pour toutes : une fois mergées, plus de diff local → plus de génération de stash. Les 12 stashes seront droppés avec SHA consignés sur #3147 après merge (préservation : cette branche + reflog ~90 j).

Clés restaurées : `activityBarTop.*`, `commandCenter.foreground`, `statusBar.debugging{Background,Foreground}` (thème rouge #fa1b49/#dd0531).

**Alternative si vous préférez ne pas versionner ces prefs** : rejeter la PR et appliquer `git update-index --skip-worktree .vscode/settings.json` localement — même effet anti-générateur, zéro contenu perso sur main. À trancher en review.

🤖 myia-po-2025 · campagne stash #3147 · claude-sonnet-4-6

Co-Authored-By: Claude-Code <noreply@anthropic.com>
