### PR TITLE
enrich(genai,#11271): Texte/18 SK Plugins densite 650->1417 (md-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/18_Semantic_Kernel_Plugins.ipynb
@@ -42,7 +42,7 @@
     "2. Plugin **BoN** (`best_of_n`).\n",
     "3. Plugin **Reflexion** (`reflexion` avec verificateur).\n",
     "4. Plugin **Routeur** (compose : invoque BoN ou Reflexion selon la stratégie).\n",
-    "5. Composition via le kernel + pont auto-function-calling (exercice) vers la serie SemanticKernel."
+    "5. Composition via le kernel + pont auto-function-calling (exercice) vers la serie SemanticKernel.\n\nCe notebook est le maillon *outillage* de la veine test-time scaling de la serie Texte : les techniques ont ete introduites sans framework (echantillonnage multiple dans le NB precedent), ici on les reformule en **plugins Semantic Kernel** pour qu'elles deviennent des briques composables. La difference est structurante : une fonction Python ordinaire n'est visible que du code qui l'appelle ; un plugin enregistre dans le Kernel expose **sa signature et sa docstring au LLM**, ce qui permet ensuite au modele lui-meme de choisir et d'invoquer la bonne strategie (auto-function-calling, exercice 1) ou a un plugin d'en invoquer un autre (routeur, section 4). C'est exactement la frontiere entre *ecrire un script qui scale le test-time* et *construire une architecture ou le scaling du test-time est un service*.\n"
    ]
   },
   {
@@ -62,7 +62,7 @@
     "## 0. Setup — Kernel Semantic Kernel + service OpenRouter\n",
     "\n",
     "Semantic Kernel (Python, v1.x) se connecte a OpenAI. On le branche sur **OpenRouter** (comme\n",
-    "NB-12 a NB-17) via un client `AsyncOpenAI` passe au connecteur `OpenAIChatCompletion`."
+    "NB-12 a NB-17) via un client `AsyncOpenAI` passe au connecteur `OpenAIChatCompletion`.\n\nDeux conventions de la serie :\n- **Service unique** : le Kernel est construit une fois avec le service OpenRouter ; le modele fast est lu dans l'environnement (FAST_MODEL), jamais en dur dans le code.\n- **Determinisme affiche** : le ping de la cellule suivante n'est pas une politesse de setup -- il atteste que l'agent Python parle bien au service. Tout ce qui suit echoue de facon confuse si cette reponse n'est pas OK (cle absente, quota epuise, mauvais endpoint).\n"
    ]
   },
   {
@@ -205,7 +205,7 @@
     "> (plugins de base) et `03-SemanticKernel-Agents.ipynb` (agents qui orchestrent des plugins).\n",
     "\n",
     "On définit maintenant un **verificateur** reutilisable (extraction d'entier, herite de NB-16/17),\n",
-    "puis nos trois plugins."
+    "puis nos trois plugins.\n\nLe modele mental a retenir : un plugin SK est une **fonction ordinaire plus de la metadonnee**. Le decorateur @kernel_function publie le nom, la signature et la description de la fonction dans le kernel ; le nom des parametres et leurs annotations deviennent le contrat que le LLM utilisera pour l'appel automatique. Une fois enregistre via kernel.add_plugin, le plugin vit dans kernel.plugins sous un namespace -- on verra dans la cellule 8 que la cle du dictionnaire suffit a invoquer la fonction.\n\nLa fonction d'extraction qui suit est volontairement banale (un compte de passagers) : l'interet du pattern ne reside pas dans la tache mais dans ce qu'elle rend observable -- une reponse unique d'un modele unique, le point de depart auquel toutes les strategies de scaling seront comparees.\n"
    ]
   },
   {
@@ -269,7 +269,7 @@
     "\n",
     "Le moteur **Best-of-N** (NB-12/NB-16) en plugin : genere `n` echantillons, renvoie la liste des\n",
     "reponses (l'appeleur peut ensuite les verifier / voter). Le plugin **depend du kernel** (pour le\n",
-    "service) — passe au constructeur."
+    "service) — passe au constructeur.\n\n**Best-of-N** est la strategie de scaling la plus simple : echantillonner n reponses independantes et garder la meilleure selon un **verificateur**. Ici le verificateur est trivial (egalite a la valeur attendue) ; dans la litterature (self-consistency, Wang et al. 2022) il devient un vote majoritaire, un modele juge, ou un executeur de code. Deux parametres structurent le cout :\n- n multiplie lineairement les appels -- c'est le budget de calcul depense au test-time ;\n- la qualite du verificateur plafonne le gain : BoN ne remonte jamais au-dela de ce qu'il sait reconnaitre.\n\nLa classe BoNPlugin qui suit emballe cette strategie : la boucle d'echantillonnage vit dans la fonction, la metadonnee (nom, arguments prompt et n=3) dans le decorateur.\n"
    ]
   },
   {
@@ -357,6 +357,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-t18-8",
+   "metadata": {},
+   "source": "### Lecture du resultat : BoN sur une tache facile\n\nLa sortie montre les 4 echantillons (50 || 50 || 50 || 50) puis le verdict du verificateur : les quatre sont corrects. Ce n'est **pas** une demonstration de puissance -- c'est la mesure de base du notebook. Sur une question ou un seul echantillon reussit deja systematiquement, BoN n'apporte rien : les appels supplementaires sont du budget brule. La ligne Correctes (== 50) est la carte d'identite de la tache (taux de reussite de base proche de 100 %), la reference par rapport a laquelle une tache plus dure -- et une strategie plus riche -- se jugent dans les sections suivantes.\n"
+  },
+  {
+   "cell_type": "markdown",
    "id": "4345ed55",
    "metadata": {
     "papermill": {
@@ -374,7 +380,7 @@
     "Le moteur **Reflexion** (NB-12/NB-14) en plugin : K tours, verifie la reponse, renvoie le\n",
     "diagnostic a l'LLM si rate. On injecte un **verificateur** (fonction `reponse -> bool`) au\n",
     "constructeur — c'est le **pattern d'injection de dépendance** de SK (le plugin ne sait pas\n",
-    "verifier, on lui fournit comment)."
+    "verifier, on lui fournit comment).\n\n**Reflexion** (Reflexion, Shinn et al. 2023 ; Self-Refine, Madaan et al. 2023) attaque le meme probleme que BoN -- lever le plafond d'un seul echantillon -- mais depense le budget differemment : au lieu de n essais *paralleles et oublies*, elle fait jusqu'a k essais **sequentiels et memoires**. Chaque echec est suivi d'une critique verbalisee qui conditionne la tentative suivante ; le verificateur interrompt des qu'une reponse passe.\n\nLe trade-off est inverse de BoN : moins d'appels en moyenne quand la critique est informative (arret precoce des le premier succes), mais une latence qui croit en serie, la ou BoN peut paralleliser. La classe ReflexionPlugin materialise la boucle -- essai, verification, critique, nouvel essai -- et le compteur K borne la depense.\n"
    ]
   },
   {
@@ -470,6 +476,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-t18-11",
+   "metadata": {},
+   "source": "### Lecture du resultat : la boucle s'arrete des qu'elle peut\n\nReflexion (K=3) : SUCCES tour 1 : 50 dit deux choses : la reponse est correcte (le 50 attendu), et surtout le **verificateur a interrompu la boucle au premier tour** -- les deux tours restants du budget K=3 n'ont jamais ete depenses. C'est l'avantage economique structurel de Reflexion sur BoN : BoN depense toujours ses n appels, Reflexion depense en moyenne 1/p appels ou p est le taux de reussite par tour. Sur cette tache facile les deux convergent (un seul appel utile de part et d'autre) ; l'ecart n'apparaitrait que sur une tache ou le taux de base est faible -- exactement ce que l'exercice 1 invite a mesurer.\n"
+  },
+  {
+   "cell_type": "markdown",
    "id": "4ee874f2",
    "metadata": {
     "papermill": {
@@ -486,7 +498,7 @@
     "\n",
     "Le **routeur** (NB-13) en plugin : selon une **stratégie** ('bon' ou 'reflexion'), il invoque le\n",
     "bon moteur **via le kernel**. C'est la **composition SK** : un plugin orchestre d'autres plugins,\n",
-    "le kernel reste le hub central."
+    "le kernel reste le hub central.\n\nLa composition est le vrai gain d'architecture : un plugin peut en **invoquer un autre via le kernel** plutot que dupliquer la logique. Le RouteurPlugin ne sait ni echantillonner ni se corriger ; il sait *choisir* entre bon et reflexion selon une strategie declaree, et deleguer. C'est le pattern micro-service applique au scaling : chaque strategie reste une brique testable isolement, le routeur n'est que de l'ordonnancement.\n\nNotez dans la cellule d'enregistrement que routeur apparait dans la liste des plugins disponibles aux cotes de ceux qu'il orchestre : la composition n'est pas un cas special du framework, c'est le meme mecanisme d'enregistrement, recursif.\n"
    ]
   },
   {
@@ -585,6 +597,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-t18-14",
+   "metadata": {},
+   "source": "### Lecture du resultat : une strategie, deux profils de depense\n\nLes deux lignes executent la meme question par deux chemins :\n- strategie=reflexion -> [routeur->Reflexion k=3] SUCCES tour 1 : 50 : un seul appel utile, arret precoce du verificateur ;\n- strategie=bon -> [routeur->BoN n=4] 50 || 50 || 50 || 50 : quatre appels systematiques, verificateur applique a la fin.\n\nLe resultat final est identique (50) -- la difference est entierement dans le **profil de cout** : latence serie minimale cote Reflexion, parallelisable mais budget fixe cote BoN. C'est la decision que fait un vrai routeur en production (et que le modele doit apprendre a prendre seul en exercice 1) : choisir la strategie dont le profil de depense correspond a la contrainte dominante, pas seulement celle qui reussit.\n"
+  },
+  {
+   "cell_type": "markdown",
    "id": "3e1da425",
    "metadata": {
     "papermill": {
@@ -627,7 +645,7 @@
     "**Synthesis de l'epic #2926** (test-time scaling / ICR) — 6 phases :\n",
     "- **NB-13** routeur agentique (Ph1) — **NB-14** memoire persistante (Ph2) — **NB-15** ToT sur CSP (Ph3) —\n",
     "  **NB-16** scaling pass@k / Snell (Ph4) — **NB-17** raisonnement natif vs scaling (Ph5) —\n",
-    "  **NB-18** plugins SK (Ph6, ce notebook)."
+    "  **NB-18** plugins SK (Ph6, ce notebook).\n\nCette section est volontairement sans code : l'invocation manuelle vue jusqu'ici est le degre zero. Le degre un est l'**auto-function-calling** -- on donne un prompt au kernel et le LLM choisit lui-meme le plugin et les arguments (exercice 1) ; le degre deux est le **Process Framework**, qui orchestre des etapes asynchrones avec etat partage (exercice 3, pont vers la serie SemanticKernel). Les patterns ici restent volontairement au niveau ou ils sont observables dans une sortie de notebook.\n"
    ]
   },
   {
@@ -646,7 +664,7 @@
    "source": [
     "## 7. Travaux pratiques\n",
     "\n",
-    "Les exercices sont a completer (convention C.1 : pas d'erreur volontaire)."
+    "Les exercices sont a completer (convention C.1 : pas d'erreur volontaire).\n\nLes trois exercices suivants montent en autonomie : (1) laisser le modele choisir le plugin, (2) ajouter de l'etat entre les appels, (3) passer a l'orchestration multi-etapes. Les cellules de code sont des squelettes -- la ligne de livrable attendue est dans chaque enonce.\n"
    ]
   },
   {
@@ -670,7 +688,7 @@
     "ad-hoc de NB-13.\n",
     "\n",
     "**Indice :** OpenAIPromptExecutionSettings(tool_call_behavior=...) + kernel.invoke avec auto-call.\n",
-    "Cf serie SemanticKernel 03-Agents et la doc SK \"function calling\"."
+    "Cf serie SemanticKernel 03-Agents et la doc SK \"function calling\".\n\n**Indice** : le kernel sait deja tout. Les plugins etant enregistres avec leurs signatures, il suffit d'appeler le service avec l'execution de fonctions activee et de laisser le modele boucler invocation/observation. Comparez ensuite le choix du modele a celui du routeur de la section 4 : quand deleguent-ils a la meme strategie ?\n"
    ]
   },
   {
@@ -732,7 +750,7 @@
     "lecons passees avant d'appeler Reflexion.\n",
     "\n",
     "**Indice :** wrap la MemoireVectorielle de NB-14 dans une classe avec @kernel_function sur\n",
-    "retroceder/ajouter ; le routeur appelle memoire.retroceder puis reflexion."
+    "retroceder/ajouter ; le routeur appelle memoire.retroceder puis reflexion.\n\n**Indice** : un plugin n'a pas a etre sans etat. Une liste Python dans l'instance suffit pour une memoire de session ; le pont vers le NB 14 (memoire semantique) remplace cette liste par une recherche vectorielle. La question interessante est ce que le stockage change au comportement : reponses coherentes entre questions apparentees.\n"
    ]
   },
   {
@@ -794,7 +812,7 @@
     "`SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb`.\n",
     "\n",
     "**Indice :** kernel.add_process(...) avec des steps (BoNStep, ReflexionStep, MemoryStep) et des\n",
-    "edges ; le process orchestre les plugins sans orchestration manuelle."
+    "edges ; le process orchestre les plugins sans orchestration manuelle.\n\n**Indice** : le Process Framework remplace le routeur par un graphe declare d'etapes. Le NB 06 de la serie SemanticKernel en fait la demonstration complete ; ici, construire le graphe et le laisser tourner une fois suffit pour voir la difference de style avec la composition manuelle de la section 4.\n"
    ]
   },
   {
@@ -862,7 +880,7 @@
     "plugins SK (NB-18, ce notebook).\n",
     "\n",
     "**References :** Semantic Kernel (Microsoft) — serie `SemanticKernel/` du depot ; Snell et al. 2024\n",
-    "(test-time scaling) ; Yao et al. 2023 (Tree of Thoughts) ; NB-12 a NB-17 de cette serie."
+    "(test-time scaling) ; Yao et al. 2023 (Tree of Thoughts) ; NB-12 a NB-17 de cette serie.\n\n**Synthese** : les quatre sections ont fait passer le scaling du test-time du statut de technique isolee a celui d'**architecture composable**. Trois choses a retenir :\n- **Chaque strategie est un plugin** : BoN (parallele, budget fixe), Reflexion (sequentielle, arret precoce), Routeur (composition) exposent le meme contrat -- signature publiee au kernel, invocation uniforme.\n- **Le cout est le vrai differentiateur** : sur la tache temoin, toutes les strategies convergent vers 50 ; ce qui les distingue est le nombre et le profil temporel des appels (comparez les deux lignes du routeur).\n- **La composition est recursive et neutre** : le routeur est un plugin comme les autres, ce qui ouvre sur l'auto-function-calling (le LLM en routeur) et le Process Framework (le graphe en routeur).\n\nProlongements naturels : mesurer ces profils de cout sur une tache a faible taux de base (ou l'ecart BoN/Reflexion devient observable), croiser avec le NB 17 sur le raisonnement natif, et relire le chapitre test-time compute du dossier de reference de la serie.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python (#11379)

## Summary

Tranche densite pedagogique #11271 (serie Texte) : `18_Semantic_Kernel_Plugins.ipynb` densite **650 → 1417** (instrument `pedagogy_density.py`, status ok, seuil 1200).

Enrichissement markdown-only : +9199 chars de prose FR — 12 cellules markdown etendues (positionnement serie, modele plugin SK, verificateur BoN, budget Reflexion, composition routeur, indices exercices, synthese) + 3 nouvelles cellules interp « Lecture du resultat » ancrees sur les outputs committes.

## Validation (commit 80b0cf02e)

- **Cellules code byte-identiques** (verifie JSON avant/apres, assert dans le script) ; sequence execution_count [1..12] intacte — dispense re-exec C.3 (markdown-only), amendement acceptance #11112 respecte
- Ancres verify (forme exacte, cellule code adjacente) : interp BoN (`50 || 50 || 50 || 50`, `Correctes (== 50)`, `BoN (n=4)`) · interp Reflexion (`SUCCES tour 1`, `K=3`) · interp Routeur (`strategie=reflexion` / `strategie=bon`, deux strategies) — ALL-PASS
- Stubs exercices 1-3 intacts (outputs « a completer ») — exercice-example-labeling respecte
- CRLF 0, indent=1, key-order preserve
- Twin parity : 157/157 OK DRIFT=0 (pas de paire touchee — serie Texte sans twin sur ce notebook)
- Pre-commit H.3 Passed (hooks locaux verts)

See #11271 (tranche Texte/18 — contribution partielle)
