### PR TITLE
fix(ci,#11405): PR gate runner relief — short pull_request leg + rerun as terminal verdict-holder

### DIFF
--- a/.github/workflows/pr-gate-rerun.yml
+++ b/.github/workflows/pr-gate-rerun.yml
@@ -38,7 +38,13 @@ name: PR gate (re-aggregate)
 
 on:
   workflow_run:
-    workflows: ["Variation Tag Guard", "Lane Claim Guard"]
+    # #11405: the rerun leg is the TERMINAL verdict-holder, so it must fire on
+    # completion of the guards that finish AFTER the (now short) pull_request
+    # leg times out. Added the three slow guards observed never settling under
+    # runner starvation (notebook-execution-required, translation-drift,
+    # machine-dep-timing-advisory). Variation Tag Guard / Lane Claim Guard
+    # stay for the original stale-aggregate loop (#10433).
+    workflows: ["Variation Tag Guard", "Lane Claim Guard", "Notebook Execution Required", "Translation Drift Check", "machine-dep-timing-advisory"]
     types: [completed]
   # Manual dispatch for testing the re-aggregation path without waiting for a
   # guard run. PR_NUMBER/HEAD_SHA default to empty; the job then no-ops unless

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -67,10 +67,16 @@ jobs:
     # this workflow exists to avoid.
     name: PR gate
     runs-on: ubuntu-latest
-    # Above the script's own 90 min budget, so the script prints its verdict
+    # Above the script's own budget, so the script prints its verdict
     # instead of the runner killing it mid-poll (a runner-killed job reports
     # `cancelled`, which is far less legible than "timed out waiting for X").
-    timeout-minutes: 100
+    # #11405: was 100 min while the script polled 90 -- under runner
+    # starvation (11+/14 runners held by PR gate) the queue wait alone
+    # exceeded that budget. The pull_request leg now polls short and hands
+    # the terminal verdict to pr-gate-rerun.yml (triggered on completion of
+    # the slow guards), which re-aggregates and POSTs the check-run on the
+    # PR head SHA. Semantics unchanged: unsettled = FAIL = BLOCKED.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -111,7 +117,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --sha "${{ github.event.pull_request.head.sha || github.sha }}" \
             --self-name "PR gate" \
-            --timeout-min 90 \
+            --timeout-min 12 \
             --poll-sec 30 \
             --settle-polls 2 \
             $IS_FORK_ARG


### PR DESCRIPTION
Grain: MED/ci-tooling — lane myia-po-2023:CoursIA — prev: MED/notebook-python #11408. G-VAR-3: same-genre consecutive (prev MED/ci-tooling #11319) declared per dispatch authorization — substance genuinely distinct (aggregation architecture of a required check vs exec-sequence guard). Design-gate tranche par ai-01 (DM 08:00:06Z, msg-20260817T060006-pkwa2f).

## Summary
Runner starvation relief per the ai-01 dispatch on #11405: 51/55 PRs BLOCKED with zero defects, 11-13/14 runners held by PR gate, queue 959-995 deep.

| Mesure | Valeur (2026-08-17T06:07:41Z, pre-merge baseline) |
|---|---|
| in_progress | 18 total : **13x PR gate**, 3x Scripts Tests, 1x dotnet-advisory, 1x notebook-interp-guard |
| queued | **959** |

### Change 1 — pr-gate.yml pull_request leg goes short
- `--timeout-min 90` -> **12**, runner `timeout-minutes: 100` -> **15** (script budget stays below runner kill so the verdict prints legibly).
- The run renders its verdict on what it sees and releases the runner. **Unsettled stays FAIL** (`pr_gate.py:386-399` untouched) -> PR stays BLOCKED. Statu quo securite : nothing red becomes mergeable.

### Change 2 — pr-gate-rerun.yml becomes the terminal verdict-holder
- `workflows:` trigger extended: + `"Notebook Execution Required"`, `"Translation Drift Check"`, `"machine-dep-timing-advisory"` (the three slow guards observed never settling under starvation, cf #11377 checks). Variation Tag Guard / Lane Claim Guard kept (original stale-aggregate loop #10433).
- Rerun leg timeouts UNCHANGED (100/90): it is the designated waiter now. It POSTs the re-aggregated check-run on the PR head SHA via the existing `--post-check-run` mechanism (#10433 item-1) — not reinvented.

### Explicitly untouched (per dispatch)
- No `paths:` filter added to pr-gate.yml (pending-forever deadlock).
- `verdict()` semantics: unsettled = FAIL = BLOCKED (hard constraint).
- Delivery canary `derive_always_on_jobs`.
- No in-flight run cancellations (none expired; cancellation = another 30-100 min queue lap).

## Worst case analysis
A PR stays BLOCKED longer = exactly today's status quo. Upside: ~11 runners returned to real work.

## Acceptance
Baseline (avant) posted above at 06:07:41Z. The post-merge fleet measure (part PR gate must drop, queued count must decrease on two spaced measures) will be posted in #11405 at the next cycle after this merges — it cannot be measured from this branch.

See #11405 (design as dispatched, both legs implemented, baseline measured — post-merge fleet measure to follow before closure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
