### PR TITLE
fix(lane-claim,#11098): un [OVERRIDE] scopé ferme un [CLAIMED] à empty_scope couvrant tout le scope

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -504,6 +504,31 @@ def _empty_scope_in(parts: list[str] | None,
     return [p for p in parts if not _glob_matches_tracked(p, tracked)]
 
 
+def _claim_scope_effectively_epic_wide(ev: ClaimEvent) -> bool:
+    """Return True if `ev`'s declared scope locks ZERO tracked files (#11098).
+
+    Mirrors the #10958 fail-safe used by `_filter_by_claim_scope`: a claim
+    whose `paths:` clause globs ALL fail to match any tracked file is broken,
+    not permissive -- the safe hypothesis is that the lane meant something.
+    An effectively-epic-wide claim intersects any override scope (epic-wide
+    semantics), so the override closes it just like a plain `[CLAIMED]`
+    without a `paths:` clause.
+
+    The witness `empty_scope` is attached by `_run_check` after the tracked
+    walk; reducer-direct callers (unit tests passing events straight in)
+    carry no witness and the helper degrades to False -- no lift, no
+    behaviour change for the unit-test paths. This is the read-side mirror
+    of `_filter_by_claim_scope`'s caller-side lift (#10958 + #11098).
+    """
+    paths = ev.get("paths")
+    if not paths:
+        return False  # the no-`paths` branch is handled by the caller
+    empty = ev.get("empty_scope")
+    if empty is None:
+        return False  # reducer-direct / no witness -> no lift
+    return len(empty) >= len(paths)
+
+
 def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEvent]]:
     """Reduce a chronologically-ordered event list to active claims per lane.
 
@@ -530,14 +555,21 @@ def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEve
             # optional `paths:` clause (#10342, #10505) BOUNDS the "close
             # others" effect to the override's scope instead of closing every
             # other lane unconditionally. An unscoped override keeps the legacy
-            # epic-wide semantics (closes all). A scoped override closes only
-            # claims that INTERSECT it -- where intersection reuses the same
-            # convention as `_filter_by_claim_scope`: a claim with no `paths`
-            # clause is epic-wide (claims everything) so it intersects any
-            # scope and is closed; a scoped claim is closed iff its paths
-            # match the override's (fnmatch via `_path_matches_any`). The
-            # symmetry is deliberate: disjointness must require BOTH sides to
-            # declare a scope, at the reducer just as at the filter.
+            # epic-wide semantics (closes all). A scoped override closes every
+            # claim that does NOT survive its scope test -- the same test as
+            # `_filter_by_claim_scope`: a claim is epic-wide (intersects any
+            # override scope, hence closed) if it carries no `paths:` clause
+            # OR every declared glob fails to match any tracked file (the
+            # `empty_scope` witness attached by `_run_check`, #10958). A
+            # scoped claim with at least one live glob stays scoped and is
+            # closed iff its live paths intersect the override's. The symmetry
+            # with `_filter_by_claim_scope` is deliberate: disjointness must
+            # require BOTH sides to declare a LIVE scope, at the reducer just
+            # as at the filter. (#11098 -- the reducer previously ignored
+            # `empty_scope` entirely, leaving a clause-but-dead claim
+            # uncloseable by any scoped override; the only escape was an
+            # epic-wide override, which swept legitimate scoped claims of
+            # sibling lanes along with the broken one.)
             # Later events (open/close) still apply on top in walk order.
             scope = ev.get("paths")
             if not scope:
@@ -547,7 +579,10 @@ def compute_active_claims(events: list[ClaimEvent]) -> tuple[dict, list[ClaimEve
                     ln: e for ln, e in state.items()
                     if ln == ev.lane
                     or (
+                        # scoped claim with at least one live glob AND
+                        # disjoint from the override's scope -> keep.
                         e.get("paths") is not None
+                        and not _claim_scope_effectively_epic_wide(e)
                         and not _path_matches_any(scope, e.get("paths") or [])
                     )
                 }

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -1117,6 +1117,116 @@ def test_reducer_epic_wide_override_closes_everything():
     assert set(active) == {"B:CoursIA"}  # every other lane closed
 
 
+# --- reducer honours `empty_scope` on [CLAIMED] (#11098) --------------------
+#
+# #11098 -- the asymmetric gap between read-side (`_filter_by_claim_scope`,
+# which #10958 lifts an entirely-dead `paths:` clause to epic-wide) and
+# reducer-side (`compute_active_claims`, which #10505 added but did NOT
+# consult `empty_scope`). A claim whose `paths:` clause globs all fail to
+# match any tracked file effectively claims nothing -- the safe hypothesis
+# is that the lane meant something (prose swallowed, polluted suffix).
+# The reducer previously treated such a claim as disjoint from any scoped
+# override, leaving it uncloseable except by an epic-wide override (which
+# swept legitimate scoped claims of sibling lanes along with the broken
+# one). The fix mirrors the read-side lift in the reducer: an entirely-
+# dead `paths:` clause is read as epic-wide on both sides, so any scoped
+# override that intersects its scope (= any scope) closes it.
+#
+# The four cases below pin the corrected reducer behaviour, with
+# `empty_scope` attached directly on the event (the `_run_check` walk
+# produces these in production; the helper `_claim_scope_effectively_epic_wide`
+# consults `ev["empty_scope"]`).
+
+def _scoped_ev(action, lane, ts, paths_clause, empty_scope=None):
+    """Build a CLAIMED event with an `empty_scope` witness attached (#11098).
+
+    `_ev` builds the event straight from primitives; this adds the
+    `empty_scope` field that `_run_check` would normally attach after the
+    tracked-files walk. Passing `empty_scope=None` reproduces the
+    reducer-direct unit-test paths (no witness -> the helper degrades to
+    False, no lift).
+    """
+    e = _ev(action, lane, "x", ts, paths_clause=paths_clause)
+    if empty_scope is not None:
+        e["empty_scope"] = list(empty_scope)
+    return e
+
+
+def test_reducer_scoped_override_closes_empty_scope_full_claim():
+    # #11098 core case: override scoped to Lean/** ; a claim whose `paths:`
+    # clause is ENTIRELY DEAD (every glob fails to match any tracked file,
+    # empty_scope covers the whole declared scope) is effectively epic-wide
+    # -> intersects any override scope -> closed. Pre-#11098 the reducer
+    # treated the claim as scoped but disjoint (it had `paths` non-None), so
+    # no scoped override could close it.
+    events = [
+        _scoped_ev(
+            "open", "A:CoursIA", "2026-08-11T22:00:00Z",
+            paths_clause=["MyIA.AI.Notebooks/GameTheory/GameTheory-7-*. Pont pyspiel"],
+            empty_scope=["MyIA.AI.Notebooks/GameTheory/GameTheory-7-*. Pont pyspiel"],
+        ),
+        _ev("override", "B:CoursIA", "reassign Lean only", "2026-08-11T22:30:00Z",
+            paths_clause=["MyIA.AI.Notebooks/SymbolicAI/Lean/**"]),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"B:CoursIA"}  # A closed (empty_scope = epic-wide)
+
+
+def test_reducer_scoped_override_keeps_scoped_disjoint_claim_no_empty_scope():
+    # No-regression pin for #11098: when `empty_scope` is absent (reducer-
+    # direct path, no witness) the helper degrades to False, and the legacy
+    # behaviour holds -- disjoint scoped claims are kept.
+    events = [
+        _ev("open", "A:CoursIA", "claim scripts", "2026-08-11T22:00:00Z",
+            paths_clause=["scripts/**"]),
+        _ev("override", "B:CoursIA", "reassign Lean only", "2026-08-11T22:30:00Z",
+            paths_clause=["MyIA.AI.Notebooks/SymbolicAI/Lean/**"]),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"A:CoursIA", "B:CoursIA"}  # both survive (disjoint)
+
+
+def test_reducer_scoped_override_keeps_scoped_partially_dead_claim():
+    # #11098 asymmetry test: when `empty_scope` covers PART of the declared
+    # scope (at least one glob still matches a tracked file), the claim is
+    # NOT lifted -- the live part of the scope is real and stays scoped.
+    # The override scoped to Lean/** does not intersect the live part, so
+    # the claim survives.
+    events = [
+        _scoped_ev(
+            "open", "A:CoursIA", "2026-08-11T22:00:00Z",
+            paths_clause=["scripts/check_lane_claim.py", "dead/glob/**"],
+            empty_scope=["dead/glob/**"],  # only the second glob is dead
+        ),
+        _ev("override", "B:CoursIA", "reassign Lean only", "2026-08-11T22:30:00Z",
+            paths_clause=["MyIA.AI.Notebooks/SymbolicAI/Lean/**"]),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"A:CoursIA", "B:CoursIA"}  # A stays (live scope disjoint)
+
+
+def test_reducer_scoped_override_closes_empty_scope_full_claim_overlapping_live():
+    # #11098 mirror: when the override's scope DOES intersect the live part
+    # of a partially-dead claim, the live part closes the claim (legacy
+    # behaviour, unchanged by this fix). A scoped claim with at least one
+    # live glob stays scoped and is closed iff the override intersects it.
+    # We use a concrete-file override (not `scripts/**` -- whose `**` is a
+    # universal basename in `_path_matches`) to make the intersection test
+    # well-defined.
+    events = [
+        _scoped_ev(
+            "open", "A:CoursIA", "2026-08-11T22:00:00Z",
+            paths_clause=["scripts/check_lane_claim.py", "dead/glob/**"],
+            empty_scope=["dead/glob/**"],
+        ),
+        _ev("override", "B:CoursIA", "reassign scripts only", "2026-08-11T22:30:00Z",
+            paths_clause=["scripts/check_lane_claim.py"]),
+    ]
+    active, _ = clc.compute_active_claims(events)
+    assert set(active) == {"B:CoursIA"}  # A closed (live part intersects override)
+    assert set(active) == {"B:CoursIA"}  # every other lane closed
+
+
 # --- the actual SCOPE behaviour at the check layer ---------------------------
 
 def test_check_override_no_paths_preserves_legacy_epic_wide_behaviour(capsys):


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #11410

fix(lane-claim,#11098): un [OVERRIDE] scopé ferme un [CLAIMED] à `empty_scope` couvrant tout le scope

Le réducteur `compute_active_claims` ignorait le témoin `empty_scope` (#10958) : un claim dont la clause `paths:` ne matche **aucun fichier suivi** (prose avalée, suffixe pollué) restait non-fermable par un override scopé. Seul un override épic-large pouvait le fermer — au prix des claims scopés légitimes des lanes sœurs (cf. incident fondateur #10382, `myia-po-2026:CoursIA` GT-7 bloqué 4 cycles).

## Symétrie réducteur / check

#10958 a ajouté le lift en épic-large pour `empty_scope` **côté check** (`_filter_by_claim_scope`). #10505 a scopé les overrides **côté réducteur** (`compute_active_claims`). Les deux mécanismes ne composaient pas : un override scopé trouvait l'ensemble de chemins du claim vide (puisque aucun glob ne matche), donc n'intersectait rien, donc ne fermait rien. Cette PR aligne les deux : un claim dont le scope est entièrement mort est lu comme épic-large **sur les deux faces** — n'importe quel override (scopé ou non) le ferme.

## Acceptance

- [x] Helper `_claim_scope_effectively_epic_wide(ev)` ajoute à `check_lane_claim.py` : True ssi `paths` non-None ET `empty_scope` couvre tout le scope (`len(empty_scope) >= len(paths)`). Dégrade gracieusement à False quand `empty_scope` est absent (chemin reducer-direct, tests existants).
- [x] Branche scopée de `compute_active_claims` réécrite : claim gardé ssi `ln == ev.lane` OU `(paths non-None ET non-epic-wide-vide ET disjoint de l'override)`. Le commentaire explicite la symétrie avec `_filter_by_claim_scope`.
- [x] Comportement épic-large (paths=None) **préservé** : `test_reducer_scoped_override_closes_epic_wide_claim` continue de passer sans modification.
- [x] 4 nouveaux tests dans `test_check_lane_claim.py` :
  - `test_reducer_scoped_override_closes_empty_scope_full_claim` — **cas fondateur #11098** : claim avec clause non-parsée × override scopé → claim fermé
  - `test_reducer_scoped_override_keeps_scoped_disjoint_claim_no_empty_scope` — no-regression : sans témoin, comportement legacy disjoint
  - `test_reducer_scoped_override_keeps_scoped_partially_dead_claim` — partiel : la partie vivante disjointe survit
  - `test_reducer_scoped_override_closes_empty_scope_full_claim_overlapping_live` — partiel : la partie vivante intersecte → fermé (legacy)
- [x] **148 tests verts** dans `test_check_lane_claim.py` (144 anciens + 4 nouveaux), 0 régression.
- [x] Pre-commit **6/6 PASS** (gitleaks, strip-probeAddresses, strip-dotnet-nuget, scrub-papermill-paths, oversized-md, H.3 execution_count).

## Cas fondateur vérifié (simulation `python -c`)

État #10382 reconstitué : claim `myia-po-2026:CoursIA` GT-7 avec `paths=[prose_avalée]` + `empty_scope=[prose_avalée]` + claim légitime `myia-po-2023:CoursIA` App-6 (scopé vivant, disjoint) + override `myia-po-2026:CoursIA-2` scopé à `Search/**`.

Avant fix : `myia-po-2026:CoursIA` reste actif (override scopé n'intersecte pas son scope vide), `myia-po-2023:CoursIA` App-6 aussi (les deux cohabitent faussement).

Après fix : seul `myia-po-2023:CoursIA` (App-6, disjoint) + `myia-po-2026:CoursIA-2` (override) restent actifs. Le claim mort GT-7 est fermé. App-6 survit. **C'est précisément la sémantique que #10223 promettait mais que #10958+#11098 rendent effective.**

## Diff

```
 scripts/check_lane_claim.py            |  51 ++++++++++++---
 scripts/tests/test_check_lane_claim.py | 110 +++++++++++++++++++++++++++++++++
 2 files changed, 153 insertions(+), 8 deletions(-)
```

## Claim paths-scoped

`[CLAIMED] lane myia-po-2023:CoursIA-2 -- paths: scripts/check_lane_claim.py, scripts/tests/test_check_lane_claim.py` posé sur #11098 (issuecomment-5312712962). Disjoint des autres lanes (pas de claim croisé sur cet issue).

## Substance distincte vs c.284-c.288 (G-VAR-3)

Pivot hors `notebook-python` après 5 PR consécutifs (c.284/c.285/c.286/c.287/c.288). Genre `tooling` au lieu de `notebook-python`, famille `lane-claim` au lieu de `genai`. Substance distincte : le réducteur ne lisait pas le témoin `empty_scope` ; la lecture symétrique côté filter le faisait déjà (#10958). **G-VAR-1 NON TENU** ce cycle (G-VAR-1 = plat principal DEEP/MED de CONTENU) — assumé : steer ai-01 du 06:13Z demande « moins de PR, plus profondes », la file CI est saturée (~970 jobs, +76/h), un fix d'organe est plus valuable qu'un 6e notebook-python consécutif.

## Pivot rationale

- **#11271 (GenAI density)** : plafond de veine 2 tranches/lane/jour (ai-01 c.97) — fermée jusqu'à demain.
- **#11297 (RL Post-Training)** : 4/4 grains déjà livrés par po-2024.
- **#11152 (Lean MIMO converse)** : grains 1-2 livrés par po-2026, 3-4 revendiqués.
- **#11290 (Sudoku)** : déjà résolu (#11302 MERGED c.287).
- **#11064 (--claim jetait --paths)** : déjà résolu (#11067 MERGED).
- **#11098 (empty_scope × override scopé)** : LIBRE, paths-scoped disjoint, **G-VAR-3 OK**.

Co-Authored-By: Claude-Code <noreply@anthropic.com>