### PR TITLE
fix(ci,#11415): pr-gate-rerun — poll court, le declencheur EST le poll (69% des runs s'auto-annulaient)

### DIFF
--- a/.github/workflows/pr-gate-rerun.yml
+++ b/.github/workflows/pr-gate-rerun.yml
@@ -67,7 +67,16 @@ permissions:
 
 concurrency:
   # One re-aggregation per PR at a time: a later guard-completion supersedes an
-  # in-flight one for the same PR.
+  # in-flight one for the same PR. Correct semantics -- the later run sees more
+  # settled checks -- but it assumes runs START PROMPTLY. They did not: with the
+  # job polling up to 90 min on a starved queue, the window in which a later
+  # completion could cancel an in-flight run was enormous and the chain
+  # decapitated itself. Measured 2026-08-17 over 100 runs (#11415): 69% of
+  # completed runs were `cancelled`, i.e. posted no verdict at all -- and a
+  # cancelled run reddens no rollup, so the whole unblock stage was failing
+  # silently. The fix is NOT to drop cancel-in-progress (that would multiply
+  # 90-min runs by the trigger count); it is the short poll below, which makes
+  # runs finish before a successor can supersede them.
   group: pr-gate-rerun-${{ github.event.workflow_run.pull_requests[0].number || github.event.inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
@@ -75,9 +84,9 @@ jobs:
   reaggregate:
     name: Re-aggregate after guard flip
     runs-on: ubuntu-latest
-    # Above the script's own 90 min budget (mirrors pr-gate.yml): the script
-    # prints its verdict rather than the runner killing it mid-poll.
-    timeout-minutes: 100
+    # Above the script's own budget so the script prints its verdict rather than
+    # the runner killing it mid-poll. Was 100 min against a 90 min poll (#11415).
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -123,11 +132,20 @@ jobs:
           # because this job's auto check-run would land on the default branch.
           # --self-name "PR gate": the POSTed check-run matches the required
           # check name on `main` (same string as pr-gate.yml's gate job).
+          # --timeout-min 10 (was 90, #11415): THE TRIGGER IS THE POLL. This job
+          # fires AFTER a guard completed, so most checks are already settled;
+          # and if they are not, the NEXT guard completion re-fires this job.
+          # The re-trigger mechanism is itself a distributed, runner-free polling
+          # loop -- polling 90 min inside the job duplicated it while holding a
+          # runner, which is what made runs long-lived enough to be superseded
+          # (see the concurrency note above). "Terminal verdict holder" is the
+          # LAST guard completion, not a long poll. Semantics unchanged:
+          # verdict() still returns FAIL on unsettled, so unsettled = BLOCKED.
           python scripts/pr_gate.py \
             --repo "${{ github.repository }}" \
             --sha "${HEAD_SHA}" \
             --self-name "PR gate" \
-            --timeout-min 90 \
+            --timeout-min 10 \
             --poll-sec 30 \
             --settle-polls 2 \
             --post-check-run \


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #11368

**G-VAR-3 : deuxieme `guard` consecutif sur cette lane, declare plutot que tu.**
`guard` figure dans la liste LIGHT ou le ban est absolu, et je ne m'octroie pas
l'exception « domaine-coeur de lane specialiste » — ce serait exactement la
lecture auto-servante que je conteste chez un worker. Ce que j'invoque est
different : les deux grains sont des **reparations de pipeline** subies, pas des
grains piochés — #11368 reparait `main` rouge (7 PR debloquees), celui-ci repare
l'etage de deblocage lui-meme. La substance est genuinement distincte (pin
d'axiome Lean vs budget de poll d'un agregateur de checks). **Engagement
explicite : le prochain grain ai-01:CoursIA sera de CONTENU** — je le note ici
pour qu'il soit opposable, pas dans ma tete.

## Le defaut mesure

`pr-gate-rerun.yml` — le chemin qui debloque une PR quand une garde lente flippe
au vert (#10433 item-1) — **n'aboutit que dans ~1 cas sur 3**.

100 derniers runs, fenetre `2026-08-17T02:10:54Z` -> `06:48:57Z` (4 h 38) :

| Issue | Nb | % des completes |
|---|---|---|
| `completed/cancelled` | **51** | **69 %** |
| `completed/failure` | 14 | 19 % |
| `completed/success` | 9 | 12 % |
| `queued` / `pending` | 26 | — jamais demarres |

```bash
gh api "repos/jsboige/CoursIA/actions/workflows/pr-gate-rerun.yml/runs?per_page=100" \
  -q '[.workflow_runs[]|"\(.status)/\(.conclusion // "-")"]|group_by(.)|map("\(length)x \(.[0])")|.[]'
```

**23 verdicts poses en 4 h 38 pour ~59 PR ouvertes.** C'est ce qui explique que
le compte de PR `BLOCKED` soit reste plat (54 -> 53 -> 55) apres #11409 alors
que le declencheur elargi fire correctement — instruit et poste sur #11405.

## Le mecanisme

`concurrency: group: pr-gate-rerun-<PR>` + `cancel-in-progress: true`. Semantique
**juste** (la derniere re-agregation voit plus de checks settled), mais elle
suppose qu'un run **demarre vite**. Deux faits la mettent en defaut :

1. le job est **long-vecu par conception** — `--timeout-min 90`,
   `timeout-minutes: 100` : il poll une heure et demie en tenant un runner ;
2. sous famine de runners (~930-970 `queued` ce matin), un run reste `queued`
   longtemps.

Combines : la fenetre d'annulabilite devient enorme et la chaine se decapite.

## Le fix — le declencheur EST le poll

`cancel-in-progress: false` reglerait l'annulation mais multiplierait des runs de
90 min par le nombre de declencheurs : le remede nourrirait la famine.

Le job n'a **pas besoin** de poller longtemps. Il fire *apres* qu'une garde a
termine (l'essentiel est settled) ; et s'il trouve du non-settled, **la garde
suivante le re-fire**. Le re-declenchement est deja une boucle de polling
distribuee et **sans runner** — poller 90 min a l'interieur la duplique en
occupant un runner, et c'est precisement ce qui rendait les runs assez
long-vecus pour etre supersedes.

« Detentrice du verdict terminal » — la formule que j'avais employee en laissant
cette jambe a 90 min dans #11409 — designe la **derniere completion de garde**,
pas la duree du poll. Le present diff corrige ma propre lecture.

```
--timeout-min   90 -> 10
timeout-minutes 100 -> 15
```

Runs courts -> ils terminent avant qu'un successeur ne les supersede ->
`cancel-in-progress: true` **redevient inoffensif** en gardant sa semantique
correcte, et la pression sur la file **baisse** au lieu de monter.

C'est le raisonnement de #11409 sur la jambe `pull_request` (90 -> 12 min),
applique a la jambe symetrique.

## Ce qui n'est PAS touche

- `verdict()` (`scripts/pr_gate.py:386-399`) — **hors diff**. « Unsettled = FAIL
  = BLOCKED » intact : aucune PR rouge ne devient mergeable, le pire cas reste
  une PR bloquee, c'est-a-dire aujourd'hui.
- **Aucun trigger `pull_request` ajoute** (verifie : `pull_request present ? False`)
  — le canary `derive_always_on_jobs` continue de sauter ce fichier, pas de
  reveil de l'alarme #9858.
- Les 5 declencheurs `workflow_run` de #11409 : conserves a l'identique.
- `concurrency` : **inchange**. Le commentaire explique pourquoi on ne le touche
  pas, pour que le prochain lecteur ne « corrige » pas dans le mauvais sens.

Diff : `+23/-5`, **un seul fichier YAML**, dont l'essentiel est du commentaire.

## Anteriorite — pas cause par #11409

```
AVANT #11409 (06:24:13Z)   68 completes   66 % cancelled
APRES                       6 completes  100 % cancelled
```

La pathologie est **pre-existante et deja dominante**. L'aggravation par le
passage 2 -> 5 declencheurs est **plausible mecaniquement mais non mesuree** —
6 runs sur 25 min ne prouvent rien, et je le dis plutot que de conclure. Cette
question reste ouverte dans l'acceptance de #11415.

## Pourquoi ca n'a jamais rougi

Un run `cancelled` n'est **ni un echec ni un succes** : aucun rollup, aucune
alarme, aucun compte de defaillance. Le symptome visible etait « les PR restent
BLOCKED », attribue a la file. C'est la classe de defaut ou **« rien trouve » et
« pas regarde » rendent la meme valeur**.

## Validation

- YAML re-parse : `name`, 5 `workflow_run.workflows`, `pull_request` absent,
  `timeout-minutes: 15`, `cancel-in-progress: true` — tous verifies apres edition.
- Mesure post-fix demandee dans l'acceptance de #11415 (viser `cancelled < 20 %`,
  `success + failure > 70 %` sur >= 100 runs), plus une verification sur >= 1 PR
  concrete qu'une garde au vert produit bien un check-run `PR gate` frais sur le
  head SHA.

See #11415. Suite de #11405 / #10433 / #10435.
