### PR TITLE
fix(search-part1,#11335): restore monotone execution_count Search-6 tranche 2/4

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb
@@ -6,10 +6,10 @@
    "metadata": {
     "id": "nav-header",
     "papermill": {
-     "duration": 0.015878,
-     "end_time": "2026-05-23T01:51:57.810504",
+     "duration": 0.005071,
+     "end_time": "2026-08-17T07:43:36.926175+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:57.794626",
+     "start_time": "2026-08-17T07:43:36.921104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -46,18 +46,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:51:57.832019Z",
-     "iopub.status.busy": "2026-05-23T01:51:57.831858Z",
-     "iopub.status.idle": "2026-05-23T01:51:58.643445Z",
-     "shell.execute_reply": "2026-05-23T01:51:58.642938Z"
+     "iopub.execute_input": "2026-08-17T07:43:36.938200Z",
+     "iopub.status.busy": "2026-08-17T07:43:36.937957Z",
+     "iopub.status.idle": "2026-08-17T07:43:38.739860Z",
+     "shell.execute_reply": "2026-08-17T07:43:38.738995Z"
     },
     "id": "imports",
     "outputId": "0ffa3126-c485-4eda-d045-900adea674f0",
     "papermill": {
-     "duration": 0.833415,
-     "end_time": "2026-05-23T01:51:58.643919",
+     "duration": 1.80865,
+     "end_time": "2026-08-17T07:43:38.740574+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:57.810504",
+     "start_time": "2026-08-17T07:43:36.931924+00:00",
      "status": "completed"
     },
     "tags": []
@@ -94,10 +94,10 @@
    "metadata": {
     "id": "intro-section",
     "papermill": {
-     "duration": 0.03991,
-     "end_time": "2026-05-23T01:51:58.762577",
+     "duration": 0.004919,
+     "end_time": "2026-08-17T07:43:38.750796+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:58.722667",
+     "start_time": "2026-08-17T07:43:38.745877+00:00",
      "status": "completed"
     },
     "tags": []
@@ -123,7 +123,9 @@
     "| **Tour a tour** | Les joueurs jouent alternativement |\n",
     "| **Déterministe** | Le résultat d'une action est certain (pas de hasard) |\n",
     "| **Fini** | Le jeu se termine toujours en un nombre fini de coups |\n",
-    "\n\n> *Ancres savantes -- von Neumann, J. (1928), Zur Théorie der Gesellschaftsspiele, Mathematische Annalen 100:295-320 (théorème minimax, fondement des jeux à somme nulle, dont découle l'algorithme Minimax d'évaluation de l'arbre de jeu) ; Shannon, C.E. (1950), Programming a Computer for Playing Chess, Philosophical Magazine 41(314):256-275 (propose l'évaluation minimax de l'arbre de jeu avec fonction d'évaluation statique — l'acte de naissance de la programmation de jeux par ordinateur) ; Knuth, D.E. & Moore, R.W. (1975), An Analysis of Alpha-Beta Pruning, Artificial Intelligence 6(4):293-326 (analyse complète de l'élagage alpha-bêta, borne O(b^(m/2)) sur l'arbre élagué vs O(b^m) pour Minimax brut) ; Zobrist, A.L. (1970), A New Hashing Method with Application for Game Playing, ICCV Report 88, University of Wisconsin (hachage de Zobrist pour indexer les positions de jeu dans les tables de transposition) ; Korf, R.E. (1985), Depth-first Iterative-Deepening: An Optimal Admissible Tree Search, Artificial Intelligence 27(1):97-109 (approfondissement itératif, recherche par profondeur croissante bornée en temps).*"
+    "\n",
+    "\n",
+    "> *Ancres savantes -- von Neumann, J. (1928), Zur Théorie der Gesellschaftsspiele, Mathematische Annalen 100:295-320 (théorème minimax, fondement des jeux à somme nulle, dont découle l'algorithme Minimax d'évaluation de l'arbre de jeu) ; Shannon, C.E. (1950), Programming a Computer for Playing Chess, Philosophical Magazine 41(314):256-275 (propose l'évaluation minimax de l'arbre de jeu avec fonction d'évaluation statique — l'acte de naissance de la programmation de jeux par ordinateur) ; Knuth, D.E. & Moore, R.W. (1975), An Analysis of Alpha-Beta Pruning, Artificial Intelligence 6(4):293-326 (analyse complète de l'élagage alpha-bêta, borne O(b^(m/2)) sur l'arbre élagué vs O(b^m) pour Minimax brut) ; Zobrist, A.L. (1970), A New Hashing Method with Application for Game Playing, ICCV Report 88, University of Wisconsin (hachage de Zobrist pour indexer les positions de jeu dans les tables de transposition) ; Korf, R.E. (1985), Depth-first Iterative-Deepening: An Optimal Admissible Tree Search, Artificial Intelligence 27(1):97-109 (approfondissement itératif, recherche par profondeur croissante bornée en temps).*"
    ]
   },
   {
@@ -132,10 +134,10 @@
    "metadata": {
     "id": "game-model-section",
     "papermill": {
-     "duration": 0.047962,
-     "end_time": "2026-05-23T01:51:58.874491",
+     "duration": 0.005198,
+     "end_time": "2026-08-17T07:43:38.761000+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:58.826529",
+     "start_time": "2026-08-17T07:43:38.755802+00:00",
      "status": "completed"
     },
     "tags": []
@@ -160,17 +162,17 @@
    "id": "game-class",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:51:58.980006Z",
-     "iopub.status.busy": "2026-05-23T01:51:58.978091Z",
-     "iopub.status.idle": "2026-05-23T01:51:59.009597Z",
-     "shell.execute_reply": "2026-05-23T01:51:59.004040Z"
+     "iopub.execute_input": "2026-08-17T07:43:38.773069Z",
+     "iopub.status.busy": "2026-08-17T07:43:38.772654Z",
+     "iopub.status.idle": "2026-08-17T07:43:38.778955Z",
+     "shell.execute_reply": "2026-08-17T07:43:38.778157Z"
     },
     "id": "game-class",
     "papermill": {
-     "duration": 0.082848,
-     "end_time": "2026-05-23T01:51:59.013603",
+     "duration": 0.013101,
+     "end_time": "2026-08-17T07:43:38.779623+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:58.930755",
+     "start_time": "2026-08-17T07:43:38.766522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -184,7 +186,50 @@
      ]
     }
    ],
-   "source": "# Classe de base abstraite pour un jeu a somme nulle\nfrom abc import ABC, abstractmethod\n\nclass JeuSommeNulle(ABC):\n    \"\"\"Interface pour un jeu a somme nulle a information parfaite.\"\"\"\n\n    @abstractmethod\n    def etat_initial(self) -> Any:\n        \"\"\"Retourne l'etat initial du jeu.\"\"\"\n        pass\n\n    @abstractmethod\n    def joueur(self, etat: Any) -> str:\n        \"\"\"Retourne le joueur qui doit jouer ('MAX' ou 'MIN').\"\"\"\n        pass\n\n    @abstractmethod\n    def actions(self, etat: Any) -> List[Any]:\n        \"\"\"Retourne la liste des actions legales.\"\"\"\n        pass\n\n    @abstractmethod\n    def resultat(self, etat: Any, action: Any) -> Any:\n        \"\"\"Retourne le nouvel etat apres l'action.\"\"\"\n        pass\n\n    @abstractmethod\n    def est_terminal(self, etat: Any) -> bool:\n        \"\"\"Le jeu est-il termine ?\"\"\"\n        pass\n\n    @abstractmethod\n    def utilite(self, etat: Any, joueur: str) -> float:\n        \"\"\"Valeur de l'etat terminal pour le joueur (+1, 0, -1).\"\"\"\n        pass\n\n    @abstractmethod\n    def afficher(self, etat: Any) -> str:\n        \"\"\"Representation textuelle de l'etat.\"\"\"\n        pass\n\nprint(\"Classe JeuSommeNulle definie (ABC, 7 methodes abstraites pour jeux a somme nulle)\")"
+   "source": [
+    "# Classe de base abstraite pour un jeu a somme nulle\n",
+    "from abc import ABC, abstractmethod\n",
+    "\n",
+    "class JeuSommeNulle(ABC):\n",
+    "    \"\"\"Interface pour un jeu a somme nulle a information parfaite.\"\"\"\n",
+    "\n",
+    "    @abstractmethod\n",
+    "    def etat_initial(self) -> Any:\n",
+    "        \"\"\"Retourne l'etat initial du jeu.\"\"\"\n",
+    "        pass\n",
+    "\n",
+    "    @abstractmethod\n",
+    "    def joueur(self, etat: Any) -> str:\n",
+    "        \"\"\"Retourne le joueur qui doit jouer ('MAX' ou 'MIN').\"\"\"\n",
+    "        pass\n",
+    "\n",
+    "    @abstractmethod\n",
+    "    def actions(self, etat: Any) -> List[Any]:\n",
+    "        \"\"\"Retourne la liste des actions legales.\"\"\"\n",
+    "        pass\n",
+    "\n",
+    "    @abstractmethod\n",
+    "    def resultat(self, etat: Any, action: Any) -> Any:\n",
+    "        \"\"\"Retourne le nouvel etat apres l'action.\"\"\"\n",
+    "        pass\n",
+    "\n",
+    "    @abstractmethod\n",
+    "    def est_terminal(self, etat: Any) -> bool:\n",
+    "        \"\"\"Le jeu est-il termine ?\"\"\"\n",
+    "        pass\n",
+    "\n",
+    "    @abstractmethod\n",
+    "    def utilite(self, etat: Any, joueur: str) -> float:\n",
+    "        \"\"\"Valeur de l'etat terminal pour le joueur (+1, 0, -1).\"\"\"\n",
+    "        pass\n",
+    "\n",
+    "    @abstractmethod\n",
+    "    def afficher(self, etat: Any) -> str:\n",
+    "        \"\"\"Representation textuelle de l'etat.\"\"\"\n",
+    "        pass\n",
+    "\n",
+    "print(\"Classe JeuSommeNulle definie (ABC, 7 methodes abstraites pour jeux a somme nulle)\")"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -192,10 +237,10 @@
    "metadata": {
     "id": "tictactoe-section",
     "papermill": {
-     "duration": 0.031371,
-     "end_time": "2026-05-23T01:51:59.094722",
+     "duration": 0.006313,
+     "end_time": "2026-08-17T07:43:38.790602+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.063351",
+     "start_time": "2026-08-17T07:43:38.784289+00:00",
      "status": "completed"
     },
     "tags": []
@@ -215,18 +260,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:51:59.135323Z",
-     "iopub.status.busy": "2026-05-23T01:51:59.135159Z",
-     "iopub.status.idle": "2026-05-23T01:51:59.142397Z",
-     "shell.execute_reply": "2026-05-23T01:51:59.141928Z"
+     "iopub.execute_input": "2026-08-17T07:43:38.801238Z",
+     "iopub.status.busy": "2026-08-17T07:43:38.800957Z",
+     "iopub.status.idle": "2026-08-17T07:43:38.809974Z",
+     "shell.execute_reply": "2026-08-17T07:43:38.809265Z"
     },
     "id": "tictactoe-class",
     "outputId": "8095c631-decd-4bc7-bcad-850846369168",
     "papermill": {
-     "duration": 0.029361,
-     "end_time": "2026-05-23T01:51:59.143522",
+     "duration": 0.015134,
+     "end_time": "2026-08-17T07:43:38.810621+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.114161",
+     "start_time": "2026-08-17T07:43:38.795487+00:00",
      "status": "completed"
     },
     "tags": []
@@ -316,10 +361,10 @@
    "metadata": {
     "id": "aaa9b982",
     "papermill": {
-     "duration": 0.026729,
-     "end_time": "2026-05-23T01:51:59.170251",
+     "duration": 0.005128,
+     "end_time": "2026-08-17T07:43:38.820396+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.143522",
+     "start_time": "2026-08-17T07:43:38.815268+00:00",
      "status": "completed"
     },
     "tags": []
@@ -352,10 +397,10 @@
    "metadata": {
     "id": "minimax-section",
     "papermill": {
-     "duration": 0.008981,
-     "end_time": "2026-05-23T01:51:59.193566",
+     "duration": 0.004699,
+     "end_time": "2026-08-17T07:43:38.830091+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.184585",
+     "start_time": "2026-08-17T07:43:38.825392+00:00",
      "status": "completed"
     },
     "tags": []
@@ -393,18 +438,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:51:59.239725Z",
-     "iopub.status.busy": "2026-05-23T01:51:59.239463Z",
-     "iopub.status.idle": "2026-05-23T01:52:01.183920Z",
-     "shell.execute_reply": "2026-05-23T01:52:01.182598Z"
+     "iopub.execute_input": "2026-08-17T07:43:38.840758Z",
+     "iopub.status.busy": "2026-08-17T07:43:38.840427Z",
+     "iopub.status.idle": "2026-08-17T07:43:40.485215Z",
+     "shell.execute_reply": "2026-08-17T07:43:40.484189Z"
     },
     "id": "minimax-impl",
     "outputId": "34905489-07a6-4fa4-e344-6103f39f3bbd",
     "papermill": {
-     "duration": 1.986038,
-     "end_time": "2026-05-23T01:52:01.182516",
+     "duration": 1.651443,
+     "end_time": "2026-08-17T07:43:40.486025+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:51:59.196478",
+     "start_time": "2026-08-17T07:43:38.834582+00:00",
      "status": "completed"
     },
     "tags": []
@@ -466,10 +511,10 @@
    "metadata": {
     "id": "8dc4ff51",
     "papermill": {
-     "duration": 0.008781,
-     "end_time": "2026-05-23T01:52:01.201932",
+     "duration": 0.005671,
+     "end_time": "2026-08-17T07:43:40.498368+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:01.193151",
+     "start_time": "2026-08-17T07:43:40.492697+00:00",
      "status": "completed"
     },
     "tags": []
@@ -502,10 +547,10 @@
    "metadata": {
     "id": "minimax-analysis",
     "papermill": {
-     "duration": 0.008615,
-     "end_time": "2026-05-23T01:52:01.218295",
+     "duration": 0.00659,
+     "end_time": "2026-08-17T07:43:40.511188+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:01.209680",
+     "start_time": "2026-08-17T07:43:40.504598+00:00",
      "status": "completed"
     },
     "tags": []
@@ -529,10 +574,10 @@
    "metadata": {
     "id": "alphabeta-section",
     "papermill": {
-     "duration": 0.005608,
-     "end_time": "2026-05-23T01:52:01.231696",
+     "duration": 0.007469,
+     "end_time": "2026-08-17T07:43:40.525387+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:01.226088",
+     "start_time": "2026-08-17T07:43:40.517918+00:00",
      "status": "completed"
     },
     "tags": []
@@ -563,18 +608,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:01.256066Z",
-     "iopub.status.busy": "2026-05-23T01:52:01.255816Z",
-     "iopub.status.idle": "2026-05-23T01:52:03.151786Z",
-     "shell.execute_reply": "2026-05-23T01:52:03.150907Z"
+     "iopub.execute_input": "2026-08-17T07:43:40.541380Z",
+     "iopub.status.busy": "2026-08-17T07:43:40.541011Z",
+     "iopub.status.idle": "2026-08-17T07:43:42.050831Z",
+     "shell.execute_reply": "2026-08-17T07:43:42.049957Z"
     },
     "id": "alphabeta-impl",
     "outputId": "e00eae70-363a-4b9f-8c8d-56845ac63313",
     "papermill": {
-     "duration": 1.919135,
-     "end_time": "2026-05-23T01:52:03.150831",
+     "duration": 1.51883,
+     "end_time": "2026-08-17T07:43:42.051506+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:01.231696",
+     "start_time": "2026-08-17T07:43:40.532676+00:00",
      "status": "completed"
     },
     "tags": []
@@ -584,9 +629,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Minimax: valeur=0, temps=1.1103s\n",
-      "Alpha-Beta: valeur=0, temps=0.0367s\n",
-      "Speedup: 30.3x\n"
+      "Minimax: valeur=0, temps=1.4496s\n",
+      "Alpha-Beta: valeur=0, temps=0.0517s\n",
+      "Speedup: 28.0x\n"
      ]
     }
    ],
@@ -651,10 +696,10 @@
    "metadata": {
     "id": "627318e5",
     "papermill": {
-     "duration": 0.011109,
-     "end_time": "2026-05-23T01:52:03.161940",
+     "duration": 0.004612,
+     "end_time": "2026-08-17T07:43:42.061154+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:03.150831",
+     "start_time": "2026-08-17T07:43:42.056542+00:00",
      "status": "completed"
     },
     "tags": []
@@ -687,10 +732,10 @@
    "metadata": {
     "id": "iterative-deepening-section",
     "papermill": {
-     "duration": 0.014836,
-     "end_time": "2026-05-23T01:52:03.193790",
+     "duration": 0.006297,
+     "end_time": "2026-08-17T07:43:42.073501+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:03.178954",
+     "start_time": "2026-08-17T07:43:42.067204+00:00",
      "status": "completed"
     },
     "tags": []
@@ -710,18 +755,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:03.229402Z",
-     "iopub.status.busy": "2026-05-23T01:52:03.228896Z",
-     "iopub.status.idle": "2026-05-23T01:52:04.066494Z",
-     "shell.execute_reply": "2026-05-23T01:52:04.061525Z"
+     "iopub.execute_input": "2026-08-17T07:43:42.088288Z",
+     "iopub.status.busy": "2026-08-17T07:43:42.088043Z",
+     "iopub.status.idle": "2026-08-17T07:43:42.645521Z",
+     "shell.execute_reply": "2026-08-17T07:43:42.644669Z"
     },
     "id": "iterative-deepening-impl",
     "outputId": "bc00184b-f1b0-4eaa-e271-0eed965bd926",
     "papermill": {
-     "duration": 0.874651,
-     "end_time": "2026-05-23T01:52:04.068441",
+     "duration": 0.5662,
+     "end_time": "2026-08-17T07:43:42.646274+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:03.193790",
+     "start_time": "2026-08-17T07:43:42.080074+00:00",
      "status": "completed"
     },
     "tags": []
@@ -731,7 +776,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Iterative Deepening: valeur=0.00, action=0, profondeur=18\n"
+      "Iterative Deepening: valeur=0.00, action=0, profondeur=14\n"
      ]
     }
    ],
@@ -814,10 +859,10 @@
    "metadata": {
     "id": "5d62e6c9",
     "papermill": {
-     "duration": 0.011734,
-     "end_time": "2026-05-23T01:52:04.103822",
+     "duration": 0.005142,
+     "end_time": "2026-08-17T07:43:42.656941+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.092088",
+     "start_time": "2026-08-17T07:43:42.651799+00:00",
      "status": "completed"
     },
     "tags": []
@@ -849,10 +894,10 @@
    "metadata": {
     "id": "transposition-section",
     "papermill": {
-     "duration": 0.008612,
-     "end_time": "2026-05-23T01:52:04.123561",
+     "duration": 0.005293,
+     "end_time": "2026-08-17T07:43:42.667071+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.114949",
+     "start_time": "2026-08-17T07:43:42.661778+00:00",
      "status": "completed"
     },
     "tags": []
@@ -872,18 +917,18 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:04.163616Z",
-     "iopub.status.busy": "2026-05-23T01:52:04.163077Z",
-     "iopub.status.idle": "2026-05-23T01:52:04.248458Z",
-     "shell.execute_reply": "2026-05-23T01:52:04.246661Z"
+     "iopub.execute_input": "2026-08-17T07:43:42.678191Z",
+     "iopub.status.busy": "2026-08-17T07:43:42.677899Z",
+     "iopub.status.idle": "2026-08-17T07:43:42.698590Z",
+     "shell.execute_reply": "2026-08-17T07:43:42.697699Z"
     },
     "id": "transposition-impl",
     "outputId": "d55a8202-0622-4ca7-b269-8fb761d11d31",
     "papermill": {
-     "duration": 0.109051,
-     "end_time": "2026-05-23T01:52:04.249653",
+     "duration": 0.027319,
+     "end_time": "2026-08-17T07:43:42.699333+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.140602",
+     "start_time": "2026-08-17T07:43:42.672014+00:00",
      "status": "completed"
     },
     "tags": []
@@ -893,7 +938,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Alpha-Beta + Transposition: valeur=0, temps=0.0086s\n",
+      "Alpha-Beta + Transposition: valeur=0, temps=0.0113s\n",
       "Cache: 1565 hits, 3010 misses\n"
      ]
     }
@@ -963,10 +1008,10 @@
    "metadata": {
     "id": "064d99f8",
     "papermill": {
-     "duration": 0.028062,
-     "end_time": "2026-05-23T01:52:04.319218",
+     "duration": 0.004915,
+     "end_time": "2026-08-17T07:43:42.709341+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.291156",
+     "start_time": "2026-08-17T07:43:42.704426+00:00",
      "status": "completed"
     },
     "tags": []
@@ -998,10 +1043,10 @@
    "metadata": {
     "id": "benchmark-section",
     "papermill": {
-     "duration": 0.02217,
-     "end_time": "2026-05-23T01:52:04.367385",
+     "duration": 0.004713,
+     "end_time": "2026-08-17T07:43:42.719380+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.345215",
+     "start_time": "2026-08-17T07:43:42.714667+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1020,18 +1065,18 @@
      "height": 633
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:04.397835Z",
-     "iopub.status.busy": "2026-05-23T01:52:04.397556Z",
-     "iopub.status.idle": "2026-05-23T01:52:11.337028Z",
-     "shell.execute_reply": "2026-05-23T01:52:11.332805Z"
+     "iopub.execute_input": "2026-08-17T07:43:42.730186Z",
+     "iopub.status.busy": "2026-08-17T07:43:42.729840Z",
+     "iopub.status.idle": "2026-08-17T07:43:44.780987Z",
+     "shell.execute_reply": "2026-08-17T07:43:44.780122Z"
     },
     "id": "benchmark-code",
     "outputId": "65944d28-83b4-4b83-8997-3686c981910c",
     "papermill": {
-     "duration": 6.957527,
-     "end_time": "2026-05-23T01:52:11.342234",
+     "duration": 2.057708,
+     "end_time": "2026-08-17T07:43:44.781673+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:04.384707",
+     "start_time": "2026-08-17T07:43:42.723965+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1068,23 +1113,23 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Minimax</td>\n",
-       "      <td>1.265373</td>\n",
+       "      <td>1.540238</td>\n",
        "      <td>0</td>\n",
        "      <td>1.0x</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Alpha-Beta</td>\n",
-       "      <td>0.043211</td>\n",
+       "      <td>0.043019</td>\n",
        "      <td>0</td>\n",
-       "      <td>29.3x</td>\n",
+       "      <td>35.8x</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Alpha-Beta + Trans</td>\n",
-       "      <td>0.009066</td>\n",
+       "      <td>0.009090</td>\n",
        "      <td>0</td>\n",
-       "      <td>139.6x</td>\n",
+       "      <td>169.4x</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1092,9 +1137,9 @@
       ],
       "text/plain": [
        "           Algorithme  Temps (s)  Valeur Speedup\n",
-       "0             Minimax   1.265373       0    1.0x\n",
-       "1          Alpha-Beta   0.043211       0   29.3x\n",
-       "2  Alpha-Beta + Trans   0.009066       0  139.6x"
+       "0             Minimax   1.540238       0    1.0x\n",
+       "1          Alpha-Beta   0.043019       0   35.8x\n",
+       "2  Alpha-Beta + Trans   0.009090       0  169.4x"
       ]
      },
      "metadata": {},
@@ -1102,7 +1147,7 @@
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUCJJREFUeJzt3QecFOX9OP4HLCAq2AuC3SjYRexGLLEGjSWWkFhj1JzGnmiMJdYYo2L01Nh71MREE41oNLYo6lmw5OwiYseCSLHB/V6f5/vf/e8dd3B33MBx936/XsPtzs7OPjszO8xnPk/pUldXV5cAAACANte17VcJAAAACLoBAACgQDLdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDzKaWXXbZtO+++6bZyaBBg/LUHs3qssW+jH3a3GXnm2++1JG1ZHu0J3EMrbbaaqm9uOaaa1KXLl3SU089ldqzBx98MJcz/nZkrT1vv/XWW3n7xP4EZj+CbqDdeeONN9JBBx2Ull9++dS9e/fUs2fPtPHGG6cLLrggTZo0aVYXD2aKiRMnplNOOaXDByEA0NHNOasLAFDprrvuSj/84Q9Tt27d0t57750zRl9//XX673//m4499tj0v//9L1122WU2WkrplVdeSV27unfaUVx++eVpypQp9YLu3/72t/lxe60dALSM8zZ0ToJuoN0YOXJk2nPPPdMyyyyT/vOf/6Qll1yy/FpVVVV6/fXXc1DeEUWwFTcXIrPfXHFjgtnfhAkT0rzzzpvmmmuuWV2UTrvtO8P5gll3DNTV1aUvv/wyzTPPPM7b0ElJkQDtxu9///s0fvz4dOWVV9YLuEtWXHHFdPjhh5eff/vtt+m0005LK6ywQr6QibZyv/71r9NXX31V730x//vf/36uprvuuuvmC5/VV1+9XG33b3/7W34eF7ADBgxIzz77bKPtZ9988820zTbb5Au03r17p1NPPTVfTFX6wx/+kDbaaKO08MIL58+J9f31r3+d6rtE27xDDz003XjjjWnVVVfN5R82bFiL1tGwbeA333yTM6MrrbRS/i7x/k022ST9+9//rve+uKGx6aab5u+xwAILpJ122im99NJL9ZaJas1RxrjREZ8Ry/Xq1Svtt99+OQPbHFEjIfZNfIf11lsvPfLII40uF/vr5JNPzvs3tkPfvn3TL3/5y6n2Y3yP+D5RltgfK6+8ct7f03P11VenLbbYIi222GJ5/f3790+XXHJJs77DqFGj0o477pi3Vbz/yCOPTPfcc0+jbU//8pe/5H0V33eRRRZJP/7xj9O7777b6LEUTSi23377NP/886chQ4ZM1YY52m8uuuii+XHs0/i8mGK/VIr1/+AHP8jrjOWPOeaYNHny5KnagcYxVV1dnZts9OjRI2299dZp9OjR+fiN31CfPn1yueNY+PTTT6faDnfffXf5mIky77DDDrnWSaUPPvggHx+xrtjO8RuO9UUZpuf222/PtVriuI2/f//735sMNocOHZp/M7Hs4osvnpuifPbZZ9P9jGlt+5asN7bFZpttlt8fTV8GDhyYbrrppqmWq62tTZtvvnne3ksttVQ+v7X22J/W+SKOgQMOOCCfk2L+csstlw455JAclDf8rKOOOiofJ7Efd9555zRmzJhW7evGxHETx1+cS2M7x7bZbrvt0nPPPTfVsu+8804+bit/Vw2/c3zfWE9j55u99torLbHEEvWO9eaUe1rHwGuvvZZ23XXXvN44BuI4jpvAn3/+eYvPJaX/c+JcUfo/509/+lOj5+2WbLfGvPzyy2m33XZLCy20UC53fN4//vGPZr0XmHlkuoF245///GcOCiLgbI6f/vSn6dprr80XHEcffXR64okn0llnnZUDyIYX7RE8/uhHP8oX0hEMRRAyePDgdOmll+bA7ec//3leLt6/++67T1UFMC7utt1227TBBhvki+e44I2L5Qj8I/guiXbnEaTFhVxc9N588825uvydd96ZLwIbBr+33nprvriMIK0UcLVkHZUiIIvyx3aJIHfcuHG586Rnnnkmfe9738vL3HffffmCLrZzLB9t5C+88MLcZj6Wa9hxVWyLuIiP9cbrV1xxRb7gPPvss6e5b+LGSWzr2JdHHHFEvmER3ykuDCOwKIlgJ+ZH84Gf/exnqV+/fumFF15I559/fnr11VdzMBbi4jkuYtdYY428veOCN/bpo48+mqYnLoojUInPmXPOOfNxFvs7PjtqUEwrAxYX2O+//36+2RMX4xFcPfDAA1MtG50bRcAZAVhsqw8//DDvxyhf3MSJGwUlcczEzZu4gRDHYQRlDUVgFOWO4CmCo1122SXPj+9feUzGetZff/28nti35557br7REe+rFMFaHEuHHXZYvsiPYzj2bXy/uHnwq1/9Km/POBYiALjqqqvK773++uvTPvvskz8r9nsEQVG2KH98t9IxEwFL7Kf4jJj30Ucf5Rslb7/99jQ7RLv33nvzeyOAiW33ySeflIP3huKYKm3rX/ziF7l2zEUXXZTLEdt6erUFmtr2zV1vLLP//vvn4+n444/P+zWWifNBnF9KIliP80Xst9jOcdMstnEEVvH7a8mxP63zxXvvvZd/62PHjs3rWGWVVXIQHp8X+2nuuecuvz/2y4ILLpjPW3EjJG4yxLpuueWWFu/rxsRvPMoc56o4Z8RvIALNuEERNyDipkCIc86WW26Zj4vY1jE/Pje+X6U99tgj3ygqNTkqiTLFbzgC1znmmKPF5W7sGIjfRsyLwD+2U/zWYzvGOTe2bdxwbOm5JP4PiZsDcWwdeOCB+SbhjGy3xsTvLc7dcVPnuOOOyzcc4hiJGxq33XZbPncA7UQdQDvw+eefR8q4bqeddmrW8iNGjMjL//SnP603/5hjjsnz//Of/5TnLbPMMnneY489Vp53zz335HnzzDNP3ahRo8rz//SnP+X5DzzwQHnePvvsk+cddthh5XlTpkyp22GHHermnnvuujFjxpTnT5w4sV55vv7667rVVlutbosttqg3P9bXtWvXuv/9739TfbfmriO+V5StZM0118xlmpa11lqrbrHFFqv75JNPyvOee+65XJa99967PO/kk0/OZdx///3rvX/nnXeuW3jhhaf5GVHe+Iz4rK+++qo8/7LLLsvr3Gyzzcrzrr/++vzZjzzySL11XHrppXnZRx99ND8///zz8/PKbd1cDbdn2GabbeqWX375evOiXJVlO/fcc/Nn3n777eV5kyZNqltllVXqHSOl7xv7KF4vufPOO/NyJ5100lTH0nHHHTdVmeK12Kcl8V1j2dgXjS0br5166qn15q+99tp1AwYMKD8fOXJkXm7RRRetGzt2bHn+8ccfn+fHMfPNN9+U5++11175mP7yyy/z8y+++KJugQUWqDvwwAPrfc4HH3xQ16tXr/L8zz77LK/vnHPOqWupOE6WXHLJeuW799578/oqt0ccIzHvxhtvrPf+YcOGNTq/oaa2fXPXG+Wbf/7569Zff/16+7l0PiiJYyjed91115Xnxe9giSWWqNt1111bfOxP63wRv9mYX1NTM9X3LZXp6quvzu/faqut6pXzyCOPrJtjjjnK2725+7opccxMnjy53rw4/rp161bvOB06dGguz6233lqeN2HChLoVV1yx3u8qyrrUUkvV22Yh3hfLPfzwwy0ud1PHwLPPPpvn/+Uvf2mTc0np/5w4hhpqeN5u7nYr/ZZjf5ZsueWWdauvvnr591rabhtttFHdSiutNM3vAsxcqpcD7UJkZUNU92uOf/3rX/lvVJesFBnv0LDtd2TRNtxww/LzyA6GyPQtvfTSU82P7ENDkRVqWN0zMiSRYSyJaoSV2a6omhhVHiNL3FBkMqJcDbVkHZUi6xaZj6gm2ZjI2I4YMSJniCLjXBLZ08iEl7ZppYMPPrje8yhHZCJL+6sxkV2PLGe8tzLTFp9byhhVVsmODF9k6D7++OPyFPsllLLKpUzxHXfcUa+zseao3J6xLWP9se1jH1dWHW0ospeRQYqsVklU34ysVWPfNzJelW1so1ZCfK/G+iFomIlurcb2T2PHbmTRKrd96TiPWh+RsaucH8d0qVp8ZKoj0xcZu8r9ExnGWLa0f2Ibx76OrHlzqno3PCYjS1lZvjgeG/424liJZeK1yrJElf6olttYDYTGNNz2zV1vbIsvvvgiZxQbtqWO80GleF9s25LYNpGRrtw3zT32mzpfxO8gMqRRYyeqFDfUsEyRCa+cF8dK1JaIJhQt2ddNidonpdpBsd44T5SagVSeu+I8E00PooZSSWSbo3wNyx/HbSwfzY5KIjMfv8vIVLe23A2PgdKxF9XBp9V8piXnkshaR/Z8epq73RqKGitROyBqUsRxWfre8f743Ph/oGHzFmDWUb0caBeiHVuIi4fmiAvFuFCJtpCVolpgBGilC8mSysC68iKrsqpz5fyGgUN8VlTJrvSd73wn/61ssxrVEU8//fQcSFS2UWx4AVy6KGtMS9ZRKapdRxvaKFe0i43qrT/5yU/KVZJL26Sxao5x8R8XnA07FWq43aJ6amn7lPZZQ6XPibbllaKKbsNtGBeG0Ryg1H65oQhmS1VNo2p7VJ2PoCeqp0bV3bhwn14P7lE9OKrUDh8+fKoL6rhQbngjoPJ7RFXthtu94TE3re0aAVVUH64UQW5jVadbKgK/htst9k9jQW9rj//SDZxSINhQ6RiIwCGq9cZNr2gPHc0wojlAjEAQv8mmNHWshIZBR5Ql9lc0b5jWsTItjW375q432gGH5ozBHZ/R8LiJffP888+3+Nhv6nwR7bHj5ldzxwSf1m+5VJ7m7OumxE2AaFJx8cUX5+r5le2to3+Jyn0ev6GG26ex30/87qMafLRRjur7EXxHEB5Vtkvvb2m5GzsGYtvGDdzzzjsvN8WIGxJxsy1unFSeH1pyLmnq/N7a7dZQNAeJShAnnnhinpo6huIGBTDrCbqBdiEujKLt2osvvtii900vEC0ptf1r7vyGHaQ1R3QUFhdq3/3ud/MFVGRzItCMznca62ipMmvS2nVUivdEYBDZ4GgnG0FqtA+NdusRrLZGW26fpi44o51rXOw2phQUxrZ6+OGHc9YqMseRhY6MV1xox3dtqpyxPSJAj+A3PiPWF1nHuHCPbdPSrHlbqMxszYimvnNLlp3e/i1tn2gz21jwXJklj7b7kXWN7GvcwIlAINpoRzZu7bXXTjMqyhKBcQRFjWkqeJ3etm+L9bbmd9PcY39a54u2LFNL9nVjzjzzzLzPo817dM4XtWliW8dx0drfWdy8ifbY0U45gu5oQx1twiMYL2lpuZv6/UV/CFEbp3T+jPbmcfw+/vjjOUhv6bmkufurtdut9Fr0wdBURr3hDUJg1hF0A+1GZMaix+vIIlRWBW9MDCsWFx2R5YgsbUl0QhNVDeP1thSfFVUIS9ntEJ0dhVInPdFxTWQfI+CoHM4rAubmmtF1xAVbdAYVU2SFIhCPDtMi6C5tk+jgp7EecKNzprYYOqf0ObFvKrNP0bt6ZHLWXHPN8rzIJEcvvXExO70bKHEhGsvFFBe9cbF6wgkn5EB8q622avQ9cZEetQUiU1aZ6WtOVeT4HtGRUQQllWWLDFNj3ze2a8NsW8xr7bHY3BtKRYr9EyIobWobN1w+st0xxf5fa621cjBzww03TPdYaajhcRrrjqYc0XHUjAagrVlvaVvEjcG2CGZacuw3dTMgbla29EbltMrTkn3dUHTeFr21RyeKleJ8HOeWyn0eZW74u2rsvBSi+nRkgiOrHzfa4nwbwXhblbtS3ASJ6Te/+U167LHH8jERNy2j5tGMnEvaYrs1VKo1FDdlZ/R7A8XTphtoN2KonAj6IkCM4LmhyDTExVeI4V5CVD2sVMoaTauX79aK3oxL4oIxnscFT1w0lzJJcRHZcMimhr0QT8uMrCPa8lWKdoERHJSqqEfWPIKg6PE9LuhK4gI4MjulbTqjon1pBARxsVo5bFH0/Fz5uaUL6mh3ePnll0+1nshoRXX30NgwVvFdQsOhhhrL7lVmGKMaaHNuYkT2KMpWOfxOjLXbsKzxfeOCP75vZVliCKOoPtzaY7HUs3bDbTYzxTaIwC5ucMRNk4ZKQ05FVdvYNpUiGIo+Gqa1fyqPyco2sdFON254NDxW4ncR2cCGokfq1m6n5q43hlmL7xPZz4bftTU1P5p77E/rJlT0Uh3BYPQr0FBLy9TcfT2t31rDz4x26w3bFcd5JnpdrxwGMY6fuOHamMhqxzEUx0jUcInt1pblDhHQx76uFMF3bOPS8Tsj55K22G4NxTln0KBBuafz6BuhNd8bmHlkuoF2Iy7Sowp1XGRF9jrag0Z7xQjcIusQFyKl8U0jWxqdL8WFWlwUR2c2Tz75ZL4wiwvRyBy0pcg+xwVffGZ0zhMBVVRzjuHGStVPI7iKoD/aUkdVyGhPF0PeROBb2ZZzWmZkHdHJUlyERQdQkfGOC/G4sK3sAO6cc87JQxZFTYIY27c0ZFi0RWw4BnRrxY2IyAxFu8vI/Mb+jAx3XJw2bNMdbc6j6mh0CBYZo8gsRQAUmfeYXxrnNtqrR/Xy2D6RKYvtEtXvo9pnqUOlxkSgFFVAo9pzlCey/xHkxAVrYxeqlWL5uLESHTTFkGERIEYV5FInWqUsXXzfaM8ctQviOIzlS0OGRVYuxiBujci6xj6N7F7UsIh9Gr+H5rbhbQsRzMQwSbGf1llnnTxucRzvMdxTHP+xv2IbRa2PuPkUAVGUOar0xrB9sR3iPdMSQWzs19iPUcU2brDEMRlDM1V2oBXbNvZJLB/9HcS+jW0fWfI4N8T2ruycq7mau97YFlGNOG4KxtBw8fuMdtGRrY6gMc49LdHcY39aItCMG2bxHUrDjsVxHeWOvgQqh6prq309rZpK8TuN30EMFRjDn8XvpeFvPjoijPXE+f3pp5/Ov6uoGt7Y0HkhyhLnv6jVEgFwZdXytih3iCYQcZ6MjtvitxYBeJQpAuIYzm5GzyXT0tzt1pj4vyF+N3GDILZrvCd+c1FbLMZCb+5Y38BMMJN7SweYrldffTUP87Lsssvm4YtimJ6NN9647sILL6w3NEoMdfTb3/62brnllquba6656vr27ZuHQqpcpjRES2NDacUpsKqqqt680rAslUMfxfAu8847b90bb7xRt/XWW9f16NGjbvHFF89DOTUc6uXKK6/MQ7XEcC8xtFQM71Iafmt6n93SdTQceub000+vW2+99fLwOTEUWrz3jDPOyENaVbrvvvvy9oxlevbsWTd48OC62traesuUPq/hEF2l4YdiO03PxRdfnPdNfI911103D/HTcFiuEOU7++yz61ZdddW87IILLpiHvYp9G0PJhfvvvz8PJ9e7d+98TMTfGN4qjpXp+cc//lG3xhpr1HXv3j0fU/FZV1111VTfo7Gyvfnmm/nYiW0Vw24dffTRdbfddlt+7+OPP15v2VtuuSUP2RXfYaGFFqobMmRI3TvvvFNvmdKx1JiGQ4aFGOYutkV858rhw5paT8PjpLHjOcSwTI0NkVTavw2HoIrlY2ikGIIptuMKK6xQt++++9Y99dRT+fWPP/44H89xzEW5YrkYWqtyWKhpiW3ar1+/vO369+9f97e//a3R7VEaei62SeyTODfEkEm//OUv6957771pfsa0tn1L1hvHUwzJVPr9xG/uz3/+c/n1OIbiWG7s8xt+n+Yc+9M7X8SQhzF0WByfsY4YviqWLQ3XN6192nB4xObs66bEeTd+HzH8W2ybOMcMHz680d9VlHnHHXfM59JFFlmk7vDDDy8P0dawPOGEE07Ir8WwYk1pTrmbOgbidx7DI8Z74r3x+918883zubI155Km/s9pasiw5my3xoYMC/H/Uuz/GJIu/h+MYda+//3v1/31r39tclsBM1+X+GdmBPcAs6vIrkfGuDLrRucVTRoiex2ZJD0DAwDTo003ADQhqt9Xira80YYyhrgScAMAzaFNNwA0IcYCj56Ko7Ov6DQpeuGONrdNDS8FANCQoBsAmhA9I8d45xFkRydX0UnYzTffPFVnTgAATdGmGwAAAAqiTTcAAAAURNANAAAABdGmexqmTJmS3nvvvTT//POnLl26FLUPAAAAmM3E6NtffPFF6t27d+ratel8tqB7GiLg7tu3bxH7BwAAgA5g9OjRqU+fPk2+LuiehshwlzZiz549237vAAAAMFsaN25cTtKW4samCLqnoVSlPAJuQTcAAAANTa8pso7UAAAAoCCCbgAAACiIoBsAAAAKIugGAACAggi6oRkefvjhtP3226dFF100d5QQ06WXXjrd95177rlp0KBBackll0zdunVLyyyzTNpnn33Sm2++OdWyzz//fNptt93yZ8w999xpqaWWSrvvvnv59bfeeqv82Q2nK664otHPP/bYY8vLbLDBBvY1AADMZHovh2Z45pln0r///e+0/PLLp48//rjZ2+zCCy9Mb7/9dlp55ZXTPPPMk0aOHJmuu+66dO+996ZXXnml3Cv+f//737T11lunSZMm5XmrrrpqGj9+fLrjjjsaXe/6669f7/liiy021TL/+c9/ctAPAADMOjLd0Aw/+clP8jh899xzT4u214EHHpgz1C+99FLObh9xxBF5/gcffJDuv//+/Liuri4vFwH3kCFD8mvPPvtseu2115oM8B9//PF604477ljv9U8//TTtvffe+SbBOuus0+g6Ivhfa6218riCMfXr1y9/TwAAoO0IuqEZFl544ZypbqkTTjghLb300uXnm266aflxVDcvVSt/+eWXywF4ZMV79eqVtthii/Tqq682ut6ogj7ffPOltddeO1122WVpypQp9V7/2c9+lj788MN044035oC6oeeeey7tu++++e8SSyyRll122fTOO++kG264ocXfEQAAaJqgG2aSyZMn5wA5RAZ6yy23zI+jmnnJTTfdlHr06JEfP/DAA7k9eGTKG1Yl7927d348YsSIdNBBB6Xjjz++/PqVV16ZbrvttnTKKadMVQ295PXXX88B/ne+8538+S+88EIaO3Zseuihhwr45gAA0HkJumEmmDBhQtp5551z9fTILP/zn/8sZ7q//fbb8nIHHHBAznpHMD3HHHPkdt3XXHNNObsdWfHIYEeGOtqK9+/fv9x2/Ouvv06jR4/OVdi/+93v1gvEG9p4443TggsumDPpkcWP4PznP/954dsBAAA6G0E3FCzaaG+22WY50I7M8qOPPloOlkP0Ul4ycODA/He55ZbLQXYoZbrnnXfetPrqq5eXXWihhdJ2222XH0d78Gj//cYbb+RA/YknnsgdskUV9EceeSQvU1NTk59HVjsC///973/p7LPPzh24ffHFFzkLv/nmm+f3AgAAbUPQDW0kqouvssoq9TLMEdjGUF1PP/10bs89fPjwXLW80nrrrVfuxfypp57Kf0eNGpXGjBmTH6+00kr5b/RkHr2el0R18GHDhpUD8lKQHr766qucXY+p1N47/sbzqOb+3nvv5fX/8pe/TLfcckuqra3NZY9loid1AACgbQi6oRn+9re/pRVXXDG3sS456aST8rzocTxEljnaR7///vvlZXbZZZccQIfIJsdY3xGEx1QaWzs6aIv21yHmRS/ia665Zg6OIyMdnaKF6NF8m222SQsssEB+vW/fvjmoDxE8zzXXXLl80Va7coose4gq5PE8eiyPIDvWEe3D43ncCCh15laZTQcAAGaMcbqhGWK4sAiqK0WmOKY+ffo0+b7IOJdEO+1K2267bfnxkUcembPdQ4cOzUOFRdY6hgE766yzyhnswYMH56rmUT09OkKLYH2NNdZIhx9+eNp9991btB8jyN5zzz1zlfNo1x3txyMIr6qqytXNAQCAttGlLlJfNBloxdBNn3/+ebn6LwAAAIxrZryoejkAAAAURPXyDiKGj4req4H2bZFFFklLL730rC4GAAAziaC7gwTc/VZZJU2cNGlWFwWYjh7zzJNeevllgTcAQCch6O4AIsMdAfcNW22V+i200KwuDtCElz79NP34vvvyb1a2GwCgcxB0dyARcK9TMVYzAAAAs5aO1AAAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAgHT7ovvPOO9PKK6+cVlpppXTFFVfM6uIAAADQicyZOrBvv/02HXXUUemBBx5IvXr1SgMGDEg777xzWnjhhWd10QAAAOgEOnSm+8knn0yrrrpqWmqppdJ8882Xtttuu3TvvffO6mIBAADQSbTroPvhhx9OgwcPTr17905dunRJt99++1TLVFdXp2WXXTZ17949rb/++jnQLnnvvfdywF0Sj999992ZVn4AAAA6t3YddE+YMCGtueaaObBuzC233JKrj5988snpmWeeyctus8026aOPPprpZQUAAIDZKuiO6uCnn356bofdmPPOOy8deOCBab/99kv9+/dPl156aerRo0e66qqr8uuRIa/MbMfjmNeUr776Ko0bN67eBAAAAB0y6J6Wr7/+Oj399NNpq622Ks/r2rVrfj58+PD8fL311ksvvvhiDrbHjx+f7r777pwJb8pZZ52VO1wrTX379p0p3wUAAICOabYNuj/++OM0efLktPjii9ebH88/+OCD/HjOOedM5557btp8883TWmutlY4++uhp9lx+/PHHp88//7w8jR49uvDvAQAAQMfVoYcMCzvuuGOemqNbt255AgAAgE6d6V5kkUXSHHPMkT788MN68+P5EkssMcvKBQAAALN90D333HOnAQMGpPvvv788b8qUKfn5hhtuOEvLBgAAAO2+enl0fvb666+Xn48cOTKNGDEiLbTQQmnppZfOw4Xts88+ad11182dpg0dOjQPMxa9mQMAAMCs1q6D7qeeeip3glYSQXaIQPuaa65Je+yxRxozZkw66aSTcudp0VnasGHDpupcDQAAAGaFdh10Dxo0KNXV1U1zmUMPPTRPAAAA0N7Mtm26i1RdXZ369++fBg4cOKuLAgAAwGxM0N2IqqqqVFtbm2pqamb+HgEAAKDDEHQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0N2I6urq1L9//zRw4MCitjsAAACdgKC7EVVVVam2tjbV1NTM/D0CAABAhyHoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIuhtRXV2d+vfvnwYOHFjUdgcAAKATEHQ3oqqqKtXW1qaampqZv0cAAADoMATdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0N2I6urq1L9//zRw4MCitjsAAACdgKC7EVVVVam2tjbV1NTM/D0CAABAhyHoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLobkR1dXXq379/GjhwYFHbHQAAgE5A0N2IqqqqVFtbm2pqamb+HgEAAKDDEHQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0N2I6urq1L9//zRw4MCitjsAAACdgKC7EVVVVam2tjbV1NTM/D0CAABAhyHoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIuhtRXV2d+vfvnwYOHFjUdgcAAKATEHQ3oqqqKtXW1qaampqZv0cAAADoMATdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUBBBNwAAABRE0A0AAAAFEXQDAABAQQTdAAAAUJA5W/Omb775Jn3wwQdp4sSJadFFF00LLbRQ25cMAAAAOkum+4svvkiXXHJJ2myzzVLPnj3Tsssum/r165eD7mWWWSYdeOCBqaamptjSAgAAQEcLus8777wcZF999dVpq622SrfffnsaMWJEevXVV9Pw4cPTySefnL799tu09dZbp2233Ta99tprxZccAAAAOkL18shgP/zww2nVVVdt9PX11lsv7b///unSSy/NgfkjjzySVlpppbYuKwAAAHS8oPvPf/5zs1bWrVu3dPDBB89omQAAAKBDmOHey8eNG5erm7/00kttUyIAAADorEH37rvvni666KL8eNKkSWndddfN89ZYY4102223FVFGAAAA6BxBd7Tt3nTTTfPjv//976muri6NHTs2/fGPf0ynn356EWUEAACAzhF0f/755+VxuYcNG5Z23XXX1KNHj7TDDjvotRwAAABmJOju27dvHiZswoQJOeiOYcLCZ599lrp3797S1QEAAEDn7r280hFHHJGGDBmS5ptvvrT00kunQYMGlaudr7766kWUEQAAADpH0P3zn/88j8s9evTo9L3vfS917fp/yfLll19em24AAACYkaA7RI/l0Vv5yJEj0worrJDmnHPO3KYbAAAAmIE23RMnTkwHHHBA7jxt1VVXTW+//Xaef9hhh6Xf/e53qSOorq5O/fv3TwMHDpzVRQEAAKAzBd3HH398eu6559KDDz5Yr+O0rbbaKt1yyy2pI6iqqkq1tbWppqZmVhcFAACAzlS9/Pbbb8/B9QYbbJC6dOlSnh9Z7zfeeKOtywcAAACdJ9M9ZsyYtNhii001P4YQqwzCAQAAoLPr2ppO1O66667y81KgfcUVV6QNN9ywbUsHAAAAnal6+Zlnnpm222673Ob522+/TRdccEF+/Nhjj6WHHnqomFICAABAZ8h0b7LJJmnEiBE54F599dXTvffem6ubDx8+PA0YMKCYUgIAAEBnGac7xua+/PLL2740AAAA0NmC7nHjxjV7hT179pyR8gAAAEDnCroXWGCBZvdMPnny5BktEwAAAHSeoPuBBx4oP37rrbfScccdl/bdd99yb+XRnvvaa69NZ511VnElBQAAgNlMs4LuzTbbrPz41FNPTeedd17aa6+9yvN23HHH3KnaZZddlvbZZ59iSgoAAAAdvffyyGrHWN0Nxbwnn3yyrcoFAAAAnS/o7tu3b6M9l19xxRX5NQAAAKCVQ4adf/75adddd0133313Wn/99fO8yHC/9tpr6bbbbmvp6gAAAKDDanGme/vtt88B9uDBg9Onn36ap3j86quv5tcAAACAVma6Q58+fdKZZ57ZmrcCAABAp9GqoHvs2LG5SvlHH32UpkyZUu+1vffeu63KBgAAAJ0r6P7nP/+ZhgwZksaPH5969uyZunTpUn4tHgu6AQAAoJVtuo8++ui0//7756A7Mt6fffZZeYr23QAAAEArg+533303/eIXv0g9evRo6VsBAACgU2lx0L3NNtukp556qpjSAAAAQGdu073DDjukY489NtXW1qbVV189zTXXXPVe33HHHduyfAAAANB5gu4DDzww/z311FOnei06Ups8eXLblAwAAAA6W9DdcIgwAAAAoI3adAMAAAAFBt0PPfRQGjx4cFpxxRXzFO24H3nkkdasCgAAADqsFgfdN9xwQ9pqq63ykGExdFhM88wzT9pyyy3TTTfdVEwpAQAAoDO06T7jjDPS73//+3TkkUeW50Xgfd5556XTTjst/ehHP2rrMgIAAEDnyHS/+eabuWp5Q1HFfOTIkW1VLgAAAOh8QXffvn3T/fffP9X8++67L78GAAAAtLJ6+dFHH52rk48YMSJttNFGed6jjz6arrnmmnTBBRe0dHUAAADQYbU46D7kkEPSEksskc4999x066235nn9+vVLt9xyS9ppp52KKCMAAAB0jqA77LzzznkCAAAA2rBNd01NTXriiSemmh/znnrqqZauDgAAADqsFgfdVVVVafTo0VPNf/fdd/NrAAAAQCuD7tra2rTOOutMNX/ttdfOrwEAAACtDLq7deuWPvzww6nmv//++2nOOVvVRBwAAAA6pBYH3VtvvXU6/vjj0+eff16eN3bs2PTrX/86fe9732vr8gEAAMBsq8Wp6T/84Q/pu9/9blpmmWVylfIQY3Yvvvji6frrry+ijAAAANA5gu6llloqPf/88+nGG29Mzz33XJpnnnnSfvvtl/baa68011xzFVNKAAAAmA21qhH2vPPOm372s5+1fWkAAACgM7fpDlGNfJNNNkm9e/dOo0aNyvPOP//8dMcdd7R1+QAAAKDzBN2XXHJJOuqoo9J2222XPvvsszR58uQ8f8EFF0xDhw4toowAAADQOYLuCy+8MF1++eXphBNOqDdE2LrrrpteeOGFti4fAAAAdJ6ge+TIkeVeyxuO3z1hwoS2KhcAAAB0vqB7ueWWy0OENTRs2LDUr1+/tioXAAAAdL7ey6M9d1VVVfryyy9TXV1devLJJ9Of//zndNZZZ6UrrrgitUc777xzevDBB9OWW26Z/vrXv87q4gAAANBJtDjo/ulPf5rH5v7Nb36TJk6cmH70ox/lXswvuOCCtOeee6b26PDDD0/7779/uvbaa2d1UQAAAOhEWjVO95AhQ/IUQff48ePTYostltqzQYMG5Uw3AAAAtOs23ZMmTcrBdujRo0d+HkOF3Xvvva0qwMMPP5wGDx6cs+VdunRJt99++1TLVFdXp2WXXTZ17949rb/++rlKOwAAAHS4oHunnXZK1113XX48duzYtN5666Vzzz03z48xvFsqejxfc801c2DdmFtuuSW3Iz/55JPTM888k5fdZptt0kcffVReZq211kqrrbbaVNN7773X4vIAAADALKteHoHv+eefnx9Hp2RLLLFEevbZZ9Ntt92WTjrppHTIIYe0aH3bbbddnppy3nnnpQMPPDDtt99++fmll16a7rrrrnTVVVel4447Ls9rrDd1AAAAmO0y3VG1fP7558+Po0r5Lrvskrp27Zo22GCDNGrUqDYt3Ndff52efvrptNVWW/3/Be7aNT8fPnx4amtfffVVGjduXL0JAAAAZlrQveKKK+Z216NHj0733HNP2nrrrfP8qO7ds2fP1JY+/vjjNHny5LT44ovXmx/PP/jgg2avJ4L0H/7wh+lf//pX6tOnT5MBewx71qtXr/LUt2/fGf4OAAAAdF4tDrqjCvkxxxyTOzaLTs023HDDctZ77bXXTu3Rfffdl8aMGZOz9O+88065zA0df/zx6fPPPy9PcWMBAAAAZlqb7t122y1tsskm6f3338+dmpVsueWWaeedd05taZFFFklzzDFH+vDDD+vNj+fRlrytdevWLU8AAAAwSzLdIQLeyGpH++qS6MV8lVVWSW1p7rnnTgMGDEj3339/ed6UKVPy86ay1QAAADBbBd0HH3xwrpbdHDHE14033tjsAowfPz73Pl7qgXzkyJH58dtvv52fx3Bhl19+ebr22mvTSy+9lHtHj2HGSr2ZAwAAwGxdvXzRRRdNq666atp4443T4MGD07rrrpt69+6dunfvnj777LNUW1ub/vvf/6abb745z7/sssuaXYCnnnoqbb755uXnEWSHffbZJ11zzTVpjz32yO2xoy15dJ4WY3IPGzZsqs7VAAAAYLYMuk877bR06KGHpiuuuCJdfPHFOciuFEOIRQ/hEWxvu+22LSrAoEGDUl1d3TSXic+OCQAAADpkR2qRWT7hhBPyFNntqP49adKk3NnZCiuskLp06VJsSQEAAKCj914eFlxwwTx1VNXV1XmKMcIBAABgpvZe3tFVVVXlKvQ1NTWzuigAAADMxgTdAAAAUBBBNwAAABRE0A0AAADtJeiOHssnTpxYfj5q1Kg0dOjQdO+997Z12QAAAKBzBd077bRTuu666/LjsWPHpvXXXz+de+65ef4ll1xSRBkBAACgcwTdzzzzTNp0003z47/+9a95/O7Idkcg/sc//rGIMgIAAEDnCLqjavn888+fH0eV8l122SV17do1bbDBBjn4BgAAAFoZdK+44orp9ttvT6NHj0733HNP2nrrrfP8jz76KPXs2TN1BNXV1al///5p4MCBs7ooAAAAdKag+6STTkrHHHNMWnbZZdN6662XNtxww3LWe+21104dQVVVVaqtrU01NTWzuigAAADMxuZs6Rt22223tMkmm6T3338/rbnmmuX5W265Zdp5553bunwAAADQeYLusMQSS+QpqpiHvn375qw3AAAAMAPVy7/99tt04oknpl69euUq5jHF49/85jfpm2++aenqAAAAoMNqcab7sMMOS3/729/S73//+3J77uHDh6dTTjklffLJJ8bqBgAAgNYG3TfddFO6+eab03bbbVeet8Yaa+Qq5nvttZegGwAAAFpbvbxbt265SnlDyy23XJp77rlbujoAAADosFocdB966KHptNNOS1999VV5Xjw+44wz8msAAABAK6uXP/vss+n+++9Pffr0KQ8Z9txzz6Wvv/46Dxu2yy67lJeNtt8AAADQWbU46F5ggQXSrrvuWm9etOfuSKqrq/M0efLkWV0UAAAAOlPQffXVV6eOrqqqKk/jxo3Lw6EBAADATGnTDQAAABSU6Y6xuE866aT0wAMPpI8++ihNmTKl3uuffvppS1cJAAAAHVKLg+6f/OQn6fXXX08HHHBAWnzxxVOXLl2KKRkAAAB0tqD7kUceSf/973/LPZcDAAAAbdSme5VVVkmTJk1q6dsAAACg02lx0H3xxRenE044IT300EO5fXf08F05AQAAADMwTncE11tssUW9+XV1dbl9t7GtAQAAoJVB95AhQ9Jcc82VbrrpJh2pAQAAQFsG3S+++GJ69tln08orr9zStwIAAECn0uI23euuu24aPXp0MaUBAACAzpzpPuyww9Lhhx+ejj322LT66qvnquaV1lhjjbYsHwAAAHSeoHuPPfbIf/fff//yvOhArSN1pFZdXZ2njvBdAAAAmI2C7pEjR6aOrqqqKk/RS3uvXr1mdXEAAADoLEH3MsssU0xJAAAAoLN3pBauv/76tPHGG6fevXunUaNG5XlDhw5Nd9xxR1uXDwAAADpP0H3JJZeko446Km2//fZp7Nix5XbPCyywQA68AQAAgFYG3RdeeGG6/PLL0wknnJDmmGOOekOJvfDCCy1dHQAAAHRYXVvTkdraa6891fxu3bqlCRMmtFW5AAAAoPMF3cstt1waMWLEVPOHDRuW+vXr11blAgAAgM7Te/mpp56ajjnmmNyeO4bT+vLLL/PY3E8++WT685//nM4666x0xRVXFFtaAAAA6IhB929/+9t08MEHp5/+9KdpnnnmSb/5zW/SxIkT049+9KPci/kFF1yQ9txzz2JLCwAAAB0x6I6sdsmQIUPyFEH3+PHj02KLLVZU+QAAAKDjB92hS5cu9Z736NEjTwAAAMAMdqT2ne98Jy200ELTnACAmefmm29O66yzTm76Ff8P77bbbumNN95o1hCg/fv3z6OPRI21/fffP3344YeNLvvss8/m5eLme0wvv/xy+bX77rsvbbrppmnRRRdNc889d17XoEGD0h133FFvHccdd1zacMMN8+vdu3dPyy+/fDrssMPSRx991AZbAQA6SKY72nX36tWruNIAAM125ZVX5r5WSqOLfPLJJ+m2225LjzzySHruuefSEkss0ej7TjzxxHT66afnxyuttFJ655130tVXX52GDx+enn766Xq12CZNmpT7b/n6668bXdeLL76Ypz59+uQpAvKHHnoolyGmjTbaKC939tlnpznmmCOPdDLXXHPlIUgvuuii9OCDD+aydu3a4gFVAGC20KL/4aKjtH322WeaU0dQXV2d7/4PHDhwVhcFABoVQXBkj8Ouu+6a3nzzzfTSSy+l+eefP2ePzzzzzEbfF9nsCIDD0UcfnV599dX0+OOPlzPYl156ab3lY9SSmP/DH/6w0fUdcsgh6bPPPksvvPBCzojfeeedef6UKVNyEF9ywgknpPfffz8v9/bbb+cyhwjYI+gOkydPTscff3zOgkc2PDL36667bjrnnHMcBQB0/KC7YXvujiyGRKutrU01NTWzuigA0Kj4P+rjjz/Oj0sBbIwmssEGG+THw4YNa/R9UR38m2++qfe+NdZYI6244opTve+f//xnDsKjGvj222/f6Pqi2vmoUaPy56699tpp8ODBeX5krktZ7hCZ9aiCHiLjXflarKN00/t3v/tdDspXXnnltPDCC+cg/a677nIUANDxg+7K3ssBgFlr9OjR5ceVo4gsvvji+W8ErjPyvg8++CAdcMABafXVV0+///3vp1mWqIL+xBNPpBEjRuTH8847b25rHm24GzNhwoR03XXX5ccbb7xxrl0WXnvttfx3v/32y9nveB5V5mW6AegUQXdUEzM0GAC0b629Sd7wfQcddFD64osv0k033ZSrek/LKquskt8fAXJkqiOo/tnPfpaeeeaZqZYdM2ZM2nLLLXNQHe/7y1/+Un7t+9//fq5Zd8UVV6Sllloqbb755jlDrqNWAGZnei0BgNlQ3759y48rewAvPV566aVn6H0RFEe78ag2Pt9886WDDz64vOyAAQPSr371q6nWHcFxzF9wwQXT2LFj0x/+8Id6r7/yyit5fZEVj7/R0dqSSy5Zfn2bbbbJgfqvf/3rXFU92ptH+/PIho8fP76FWwgA2gdBNwDMhqKzz2jzHKLH8vDee+/lTtHCtttum/9GNjmm6Ck8RJZ5zjnnrPe+559/Pr3++uv13leq5RZZ65i++uqr8vyJEyeWn0dW+tNPPy2/9thjj+WAO8T7Sh5++OHcjjs6fIthzR544IG0yCKL1PtOUY5o933GGWfkDtmiJ/VS528RsAPA7EjQDQCzoRgTu9RDeQTP0eN3DMcVVcIjmC31bB7BakylTtdiGLFjjz02Pz733HNzh2WRdY7q4TF8WFQrD2+99VaeV5piSLGS6CV96NCh+XFU/47mZ/HeaJu9ySablKuq77333uX3fO9738vBeVQfj3bjMZZ3fG5MpY7Sbr311pyJj2x7ZNOjPXmIIcxWWGGFmbJdAaCtCboBYDYV7aZvuOGGtNZaa+UsdwS0u+yyS842R0/mTYlMcgTNkQGP8bKj47MY9jOy0fG4pcOJRrAf1dOjOnhk36Oa+L/+9a9y7+ihNM53BORPPvlkrmJemqKdd/jud7+bM+2RYY+hxGLZLbbYIt19991pgQUWaPV2AoBZqUudbsmbNG7cuNSrV6/0+eefp549e6b2Ktq/RUbg6d13T+v8f8OxAO3PM2PGpAG33pqrzK6zzjqzujgAAMyEeFGmGwAAAAryfz2pAEAbi3a7pXbEQPsW/QA01eM9ADNG0A1AIQH3yv36pS8nTrR1YTbQvUeP9MpLLwm8AQog6AagzUWGOwLudU47Kc233DK2MLRj40eOSs+ceGr+3cp2A7Q9QTcAhYmAe4F+K9vCAECnpSM1AAAAKIigGwAAAAoi6AYAAICCCLobUV1dnfr3758GDhxY1HYHAACgExB0N6KqqirV1tammpqamb9HAAAA6DAE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQXcjqqurU//+/dPAgQOL2u4AAAB0AoLuRlRVVaXa2tpUU1Mz8/cIAAAAHYagGwAAAAoi6AYAAICCCLoBAACgIIJuAAAAKIigGwAAAAoi6AYAAICCCLoBAACgIIJuAAAAKIigGwAAAAoi6AYAAICCCLoBAACgIIJuAAAAKIigGwAAAAoi6AYAAICCCLoBAACgIIJuAAAAKIigGwAAAAoi6AYAAICCCLoBAACgIIJuAAAAKIigGwAAAAoi6AYAAICCCLoBAACgIIJuAAAAKIigGwAAAAoi6AYAAICCCLoBAACgIIJuAAAAKIigGwAAAAoi6G5EdXV16t+/fxo4cGBR2x0AAIBOQNDdiKqqqlRbW5tqampm/h4BAACgwxB0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFAQQTcAAAAURNANAAAABRF0AwAAQEEE3QAAAFCQDh90jx49Og0aNCj1798/rbHGGukvf/nLrC4SAAAAnUSHD7rnnHPONHTo0FRbW5vuvffedMQRR6QJEybM6mIBAECHdfPNN6d11lknzTPPPGmhhRZKu+22W3rjjTem+74LL7wwJ8u6deuWFltssbT//vunDz/8sN4y8Tzmx+uxXCx/0UUX1Vvmm2++yTHA6quvnuadd960yCKLpCFDhqR33nmn3nJ/+tOf0iabbJKX6dKlS55efvnlNtoK0EmC7iWXXDKttdZa+fESSyyRf3CffvrprC4WAAB0SFdeeWXaa6+90rPPPpuvxSdPnpxuu+22tNFGG6UPPvigyfedeOKJ6Re/+EV66aWX0jLLLJPGjx+frr766lxrdeLEiXmZSJ5tttlmeX68HsvF8ocddlg66aSTyus68MAD05FHHplefPHFtNxyy+V5N910Uw6wP//88/Jyd999dy7noosuWug2oXOb5UH3ww8/nAYPHpx69+6d7yzdfvvtUy1TXV2dll122dS9e/e0/vrrpyeffLJVn/X000/nH33fvn3boOQAAEClr7/+Oh133HH58a677prefPPNHBTPP//86aOPPkpnnnlmoxssstdnn312fnz00UenV199NT3++OPlzPOll15azky/8soreX68HssdddRR+bXf/e53eT1ffPFFuv766/O8Y445Jgfer7/+es5mjxo1KscWJRdffHEaN25cOuWUU5rckRHcH3LIITmGiMx6BOgbb7xxuvbaa+18Zo+gO+5WrbnmmvUO/kq33HJL/iGdfPLJ6ZlnnsnLbrPNNvlHWxKZ7NVWW22q6b333isvE9ntvffeO1122WUz5XsBAEBnU1NTkz7++ONy0B0iubbBBhvkx8OGDWv0fffdd1+uEl75vuiPacUVV6z3vshMh5VWWim/Xrl8vP/+++9PdXV1eQpdu/5fuBNBeuVnlUTZ5phjjml+p8igR9A/ZsyYtOqqq+YbCE888UR64IEHWrGF6IzmnNUF2G677fLUlPPOOy9XD9lvv/3y8zjg77rrrnTVVVeV76KNGDFimp/x1VdfpR/84Ad5+ajWMq3lYiqJu14AAEDzOzEuiTbXJYsvvnj++/bbb7f4fa+99lr5faXlGlt3af09e/ZM2267bQ7Qf//736d//etfuVp7qV+nd999t0W7Mz6/VP39hBNOKCf0KssM7TrTPb3qKVElfKuttirPi7tV8Xz48OHNWkfc5dp3333TFltskX7yk59Mc9mzzjor9erVqzyphg4AADOulHku4n2NLXPjjTemn//856lPnz65int0trbuuuvm1+aaa64WlSGawpaC7mhDHrVuo8O3ymAfZtugO6qmRBvshgd0PJ9WJwyVHn300VxFPdqKRzX0mF544YVGlz3++ONzxwqlyd0rAABovsqkVWVz0NLjpZdeeobeV1qusWUql1twwQVz89W4no8M94MPPpjbeoeVV165Rbv0Zz/7WXrooYdyk9dVVlklJwWjDXhlYhBm26C7LUQPhVOmTMlV0EtTDB3QmOgYIaqjVE4AAEDzDBw4MC288ML5cfRYHqKfpej0LES17xDBa0ylob623HLLPNRv5fuef/753AFa5ftKf6PKd7xeuXxksGM9IYYLjjbYJeecc07ugC3sueeeLdqd0YlztOX+wx/+kO65555055135vn/+9//0ieffOLQYPYOumN4r+jYoLGx+WL4LwAAoP2Ye+65yz2URzC8/PLLp379+uUsc1zbl/pkigA4plKna3Ftf+yxx+bH5557bs5GR+drUXU8Ok076KCD8mvxN57H/Hg9los+oEK8v1RDNtpxL7XUUrlaefz91a9+lefvvPPOeczwkpgfnbWVXg9RfTzm/fGPf8zP42+UL4YeGzBgQH49xHpjDHKYrYPu+NHGgR29EJZE1jqeb7jhhrO0bAAAQOPVsW+44YbcrDOy3NFz+C677JIee+yx3Ft4U84444w0dOjQnAEfOXJkHuJrn332yUMMx+Mw33zz5areMT/mxXKxfLwv3l9SGs3onXfeyYF9ZKqjU7Vbb721Xk/mkcx744036lVRj87YYl50lhZ22GGHtOmmm6ZJkyblZqoxjHG0847AvnJd0G57L49x70rVRkL8cKIKeNw1ijYZ0XYiflTR8cF6662Xf1DRLqPUmzkAANC+DBkyJE8t6fwsAtjDDz88T9Oy5JJLpmuuuWaay0Q19FJV9GmJ9UxvXXvttVeeYLYNup966qm0+eabl5+XBrePQDt+AHvssUdujxHj40XnaXHHLMbp01sgAAAA7d0sD7oHDRo03aEADj300DwBAMCMiKrDpXbEQPu2yCKLNNnj/exklgfdAAAwswLulfv1S19OnGiDw2yge48e6ZWXXprtA29BdyNiTL+YYoxwAAA6hshwR8C92rFnpnmXXn5WFweYhglvv5lePOfX+Xcr6O6Aqqqq8jRu3LjUq1evWV0cAADaUATcPVfsZ5sCM0W7HjIMAAAAZmeCbgAAACiIoBsAAAAKIugGAACAggi6AQAAoCCCbgAAACiIoBsAAAAKIuhuRHV1derfv38aOHBgUdsdAACATkDQ3YiqqqpUW1ubampqZv4eAQAAoMMQdAMAAEBBBN0AAABQEEE3AAAAFETQDQAAAAURdAMAAEBBBN0AAABQkDmLWnFHUFdXl/+OGzcutWfjx4//v7/ffJPGff31rC4O0IT4jea/48e3+/NKW52Xvp04KX0zfsKsLg4wDfE77XTnpkkT07cT/u8x0D59O2liuz83lcpVihub0qVuekt0Yu+8807q27fvrC4GAAAA7dTo0aNTnz59mnxd0D0NU6ZMSe+9916af/75U5cuXYrYPzDNO2dx0yd+xD179rSlgFnOeQloj5ybmFUif/3FF1+k3r17p65dm265rXr5NMSGm9YdC5gZIuAWdAPtifMS0B45NzEr9OrVa7rL6EgNAAAACiLoBgAAgIIIuqGd6tatWzr55JPzX4D2wHkJaI+cm2jvdKQGAAAABZHpBgAAgIIIugEAAKAggm4AAAAoiKAbCjJo0KB0xBFHNHv5t956K3Xp0iWNGDHCPgGa5cEHH8znjbFjxzZ7i51yyilprbXWsoWhE3GugFlL0A0tsO++++YL3IMPPniq16qqqvJrsUz429/+lk477bRmr7tv377p/fffT6uttpp9AtQzfPjwNMccc6Qddtih3Z8fS9PCCy+ctt122/T888+3eD0/+MEPCisndFSzw3mio50rrrnmmnrfpbEpkiog6IYWiuD45ptvTpMmTSrP+/LLL9NNN92Ull566fK8hRZaKM0///zNXm/8R7nEEkukOeec0z4B6rnyyivTYYcdlh5++OH03nvvtdutExfOcfMwpvvvvz+fz77//e/P6mJBpzC7nCfa+7miVPOwOfbYY4/y94hpww03TAceeGC9eXHdWPL1118XWHLaM0E3tNA666yTT6CRyS6JxxFwr7322k1WL1922WXTmWeemfbff/8cjMfyl112WZPVy0tVwe6555683nnmmSdtscUW6aOPPkp333136tevX+rZs2f60Y9+lCZOnFhez7Bhw9Imm2ySFlhggXz3OP4Te+ONN8qvX3fddWm++eZLr732Wnnez3/+87TKKqvUWw/QPowfPz7dcsst6ZBDDskZrMisNCVei9/+7bffnlZaaaXUvXv3tM0226TRo0dPtez111+fz0u9evVKe+65Z/riiy+afR6Z1li5cfMwpqjCftxxx+XPHjNmTHmZeL777rvndcfNyZ122qmcCYqq79dee2264447ylmiOBeGX/3qV+k73/lO6tGjR1p++eXTiSeemL755psWb0/o7OeJ4FzRNuLarHTOi2nuuefO56jS8zgH7rrrrumMM85IvXv3TiuvvHL5/Lvuuuvm68FYLq7l4vqupHQNGDckYrlY50YbbZReeeWV8jLPPfdc2nzzzfM64npwwIAB6amnnmqjb0ZbE3RDK0TgfPXVV5efX3XVVWm//fab7vvOPffcfPJ89tlnc6Ab/zlWnkAbExehF110UXrsscfKF6tDhw7NmfW77ror3XvvvenCCy8sLz9hwoR01FFH5RNvnKy7du2adt555zRlypT8+t5775223377NGTIkPTtt9/mdVxxxRXpxhtvzCd1oH259dZb802xuFj78Y9/nM83dXV1TS4fN8/iAi9usD366KO5vXcE1ZUigI7A/M4778zTQw89lH73u981+zzS3CDghhtuSCuuuGIO3EMEyXETIC4SH3nkkVy+uAkYWa/IAB1zzDH5HFeZBYsLzRDviUChtrY2XXDBBenyyy9P559/fiu2KHQ8LT1PBOeKmSPOoXGt9+9//zufb0vnwmiCGIFznIvjxmOpeWKlE044IV87xrk4agPE9WdJXMf16dMn1dTUpKeffjoH+HPNNddM+la0WB3QbPvss0/dTjvtVPfRRx/VdevWre6tt97KU/fu3evGjBmTX4tlwmabbVZ3+OGHl9+7zDLL1P34xz8uP58yZUrdYostVnfJJZfk5yNHjoz/HeueffbZ/PyBBx7Iz++7777ye84666w874033ijPO+igg+q22WabJssc5Yr3vPDCC+V5n376aV2fPn3qDjnkkLrFF1+87owzznAUQDu10UYb1Q0dOjQ//uabb+oWWWSRfH6oPE989tln+fnVV1+dnz/++OPl97/00kt53hNPPJGfn3zyyXU9evSoGzduXHmZY489tm799ddv0XmkoTj3zTHHHHXzzjtvnmL5JZdcsu7pp58uL3P99dfXrbzyyvn8V/LVV1/VzTPPPHX33HNPeT1xLp2ec845p27AgAHTXQ46+3kiOFc0/1xRuh5rjYbXfnE+i+usOM9NS01NTf7ML774oslrwLvuuivPmzRpUn4+//zz111zzTWtKiczn0w3tMKiiy5arr4VGe94vMgii0z3fWussUb5cVQbiipFldWJpveexRdfvFy1snJe5Tqi2vhee+2Vl4nqRlF9NLz99tvlZRZccMHc9uuSSy5JK6ywQr47CrQ/kR158skn8286RKYj2hDG77cpsczAgQPLzyP7FVW5X3rppfK8OC9U9jmx5JJLtug8st122+UMdUyrrrpq+X1R1TGayMQU5Y6sdiw7atSo/HpkdV5//fX82aX3RxXz6BdjetXXo+rsxhtvnM+b8b7f/OY39c5r0Fm15jxRWs654v/EeazhOa30PKY4j7XW6quvnqudV4rM9ODBg3NTwzgfbrbZZnl+w3Na5TVgnKdD6VwdtZF++tOfpq222irXVGpOEyBmHT02QStFFZ9DDz00P66urm7WexpW+4nAe3rVNSvfE8tPbx1xEl9mmWVy1ctoPxSvRY/oDTvviI5WovO2qL4ZVUlb0ukbMHPERXM0A4nfcklUGY2209HspLVm9DwSTVJKnUlWrmveeefN1clLYrloMx7rOf3003OV82h3GM1ZGruZOa1emaMq5W9/+9scyMc6o0PLqHYJnd30zhPxe2mtznKu+Ne//lXuI+Ldd9/N/fJUDuEabbdbK75rpbjmirLFFN8vvk8E2/G84bVaw2vAUNr+0fww2oJHM8Ho6+fkk0/O3zWaAtH+CLqhlUptEOMkGCfK9uCTTz7Jd7zjP61NN900z/vvf/871XLRPvzss89O//znP3PnRHHzIDovAtqPuIiOdtlxsbj11lvXey2Gyfnzn/+cs9iNvS/a/6233nr5eZwTol13dL7YVueRpZZaqlnrivNjtAcvXXRHR5SRsV5sscVyBr0xkRGaPHnyVOesuLCP9o0lpew5dGbNOU80Nsxp6b3OFf8nzi8lpVFkKm8KtKWXX345n2cjO13q2by1HaBF55IxHXnkkbmmQ9S+FHS3T6qXQytFljiqa0anPvG4PYhq49FhUfSKHlU4//Of/+TqR5Wih+Kf/OQn6Re/+EWuLhV3WeMi+K9//essKzcwtehw57PPPksHHHBAzhxVTtEbblNVRyMzEsMGPfHEE7kKY3TOs8EGG5SD8LY4jzTlq6++Sh988EGe4vwY5YiMVWTDQmSgoilO9FgeHamNHDky99Ib56N33nknLxNV2WO83gj8P/7445x9ip7YIxMUWZyoQvnHP/4x/f3vf3fY0Om19jzhXDHrRJXyuLkYneC++eab6R//+EfuVK0l4kZmJEzi/Bk3IKNTyuhQrbk3V5n5BN0wAyJT01S2ZlaIjFJclMaFdvyHG3c+zznnnHrLHH744bmqUwxfVmprFI8POuigXKUKaB/iYjna6jVWNTQupiMzEsFpQ9HvQ9RgiWqH0QY62iPGjbW2PI80JYYai3aHMa2//vr5IvAvf/lLrqpZKls0bYmLzl122SVfIEawEG26S+fSGOM2emCOkR6i2mVcTO644465HHGRGUORReY7hgyDzq6154ngXDFrxHkt+gSKc2P//v1zxvsPf/hDi9YRyZ7IlseINJHpjlEfIpES1eppn7pEb2qzuhAAwIyLC7kjjjgiVycHcK6A9kGmGwAAAAoi6AYAAICCqF4OAAAABZHpBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgIIIugEAAKAggm4AAAAoiKAbAAAACiLoBgAAgFSM/wdfV2T/OYa9HQAAAABJRU5ErkJggg==",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAHqCAYAAAAZLi26AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAT8dJREFUeJzt3QmcXfP9P/5PYsmCxBJCiFhLRq0Ru4pKrUXRXy1pba2iQ+0ttdZaVcQypShaSy3VakuFUkUJxhJLxy4lKIk1stiS+T/en+//3sedyUwyM5ljJjPP5+NxuffMufd+7rnnnpzX+Ww96uvr6xMAAADQ7nq2/0sCAAAAQegGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AaYR62wwgpp3333TfOSESNG5Ftn1NFli+8yvtOWrrvwwgunrqw126MziX3oq1/9auosrr766tSjR4/02GOPpc7sX//6Vy5n/L8ra+tx+7///W/ePvF9AvMeoRvodF555ZV04IEHppVWWin17t079evXL2266abpggsuSNOnT+/o4sGXYtq0aemUU07p8iEEALq6+Tu6AACVbr/99vT//t//S7169Up77713rjH67LPP0r///e90zDHHpP/85z/psssu6+hidgovvPBC6tnTtdOu4vLLL08zZ85sELp//vOf5/udtXUA0DqO29A9Cd1ApzF+/Pi0xx57pCFDhqR//vOfaZlllin/rbq6Or388ss5lHdFEbbi4kLU7LdUXJhg3jd16tS00EILpQUWWKCji9Jtt313OF7QcftAfX19+uSTT1KfPn0ct6GbcqkN6DR++ctfpilTpqTf/va3DQJ3ySqrrJIOO+yw8uMvvvginXbaaWnllVfOJzLRV+5nP/tZ+vTTTxs8L5Z/85vfzM10119//Xzis+aaa5ab7f7pT3/Kj+MEdtiwYenJJ59ssv/sq6++mrbZZpt8gjZo0KB06qmn5pOpSr/61a/SJptskpZYYon8PvF6f/zjH2f5LNE375BDDknXXXddWmONNXL5x4wZ06rXaNw38PPPP881o6uuumr+LPH8zTbbLP3jH/9o8Ly4oLH55pvnz7HoooumnXfeOT333HMN1olmzVHGuNAR7xHr9e/fP+233365BrYlokVCfDfxGTbYYIP0wAMPNLlefF8nn3xy/n5jOwwePDj95Cc/meV7jM8RnyfKEt/Haqutlr/vObnqqqvS17/+9bTUUkvl16+qqkqXXHJJiz7Da6+9lnbaaae8reL5RxxxRLrzzjub7Ht688035+8qPu+AAQPSd7/73fTmm282uS9FF4rtt98+LbLIImnUqFGz9GGO/ptLLrlkvh/fabxf3OJ7qRSv/61vfSu/Zqx/9NFHpxkzZszSDzT2qZqamtxlo2/fvmnrrbdOEyZMyPtv/IaWW265XO7YF95///1ZtsMdd9xR3meizDvssENudVLp7bffzvtHvFZs5/gNx+tFGebk1ltvza1aYr+N///5z39uNmyOHj06/2Zi3YEDB+auKB988MEc32N22741rxvbYosttsjPj64vw4cPT9dff/0s69XV1aUtt9wyb+9ll102H9/auu/P7ngR+8D3v//9fEyK5SuuuGI6+OCDcyhv/F5HHnlk3k/ie9xll13SpEmT2vRdNyX2m9j/4lga2zm2zXbbbZeeeuqpWdZ944038n5b+btq/Jnj88brNHW82XPPPdPSSy/dYF9vSblntw+89NJLabfddsuvG/tA7MdxEfijjz5q9bGk9G9OHCtK/+b85je/afK43Zrt1pTnn38+ffvb306LL754Lne831//+tcWPRf48qjpBjqNv/3tbzkUROBsiR/84Afpd7/7XT7hOOqoo9IjjzySzjrrrBwgG5+0R3jca6+98ol0hKEIITvuuGO69NJLc3D70Y9+lNeL53/nO9+ZpQlgnNxtu+22aaONNsonz3HCGyfLEfwjfJdEv/MIaXEiFye9N9xwQ24uf9ttt+WTwMbh96abbsonlxHSSoGrNa9RKQJZlD+2S4TcyZMn58GTnnjiifSNb3wjr3P33XfnE7rYzrF+9JG/6KKLcp/5WK/xwFWxLeIkPl43/n7FFVfkE86zzz57tt9NXDiJbR3f5eGHH54vWMRnihPDCBYlEXZieXQf+OEPf5iGDh2annnmmXT++eenF198MYexECfPcRK71lpr5e0dJ7zxnT744INpTuKkOIJKvM/888+f97P4vuO9owXF7GrA4gT7f//7X77YEyfjEa7uvffeWdaNwY0icEYAi231zjvv5O8xyhcXceJCQUnsM3HxJi4gxH4YoayxCEZR7ghPEY523XXXvDw+f+U+Ga+z4YYb5teJ7/bcc8/NFzrieZUirMW+dOihh+aT/NiH47uNzxcXD37605/m7Rn7QgSAK6+8svzca665Ju2zzz75veJ7jxAUZYvyx2cr7TMRWOJ7iveIZRMnTswXSl5//fXZDoh211135edGgIlt995775XDe2OxT5W29Y9//OPcOubiiy/O5YhtPafWAs1t+5a+bqyz//775/3puOOOy99rrBPHgzi+lERYj+NFfG+xneOiWWzjCFbx+2vNvj+748Vbb72Vf+sffvhhfo3VV189h/B4v/ieFlxwwfLz43tZbLHF8nErLoTERYZ4rRtvvLHV33VT4jceZY5jVRwz4jcQQTMuUMQFiLgoEOKYs9VWW+X9IrZ1LI/3jc9Xaffdd88XikpdjkqiTPEbjuA633zztbrcTe0D8duIZRH8YzvFbz22YxxzY9vGBcfWHkvi35C4OBD71gEHHJAvEs7NdmtK/N7i2B0XdY499th8wSH2kbigccstt+RjB9BJ1AN0Ah999FFUGdfvvPPOLVp/3Lhxef0f/OAHDZYfffTRefk///nP8rIhQ4bkZQ899FB52Z133pmX9enTp/61114rL//Nb36Tl997773lZfvss09eduihh5aXzZw5s36HHXaoX3DBBesnTZpUXj5t2rQG5fnss8/qv/rVr9Z//etfb7A8Xq9nz571//nPf2b5bC19jfhcUbaStddeO5dpdtZZZ536pZZaqv69994rL3vqqadyWfbee+/yspNPPjmXcf/992/w/F122aV+iSWWmO17RHnjPeK9Pv300/Lyyy67LL/mFltsUV52zTXX5Pd+4IEHGrzGpZdemtd98MEH8+Pzzz8/P67c1i3VeHuGbbbZpn6llVZqsCzKVVm2c889N7/nrbfeWl42ffr0+tVXX73BPlL6vPEdxd9LbrvttrzeSSedNMu+dOyxx85SpvhbfKcl8Vlj3fgumlo3/nbqqac2WL7uuuvWDxs2rPx4/Pjxeb0ll1yy/sMPPywvP+644/Ly2Gc+//zz8vI999wz79OffPJJfvzxxx/XL7roovUHHHBAg/d5++236/v3719e/sEHH+TXO+ecc+pbK/aTZZZZpkH57rrrrvx6ldsj9pFYdt111zV4/pgxY5pc3lhz276lrxvlW2SRReo33HDDBt9z6XhQEvtQPO/3v/99eVn8DpZeeun63XbbrdX7/uyOF/GbjeW1tbWzfN5Sma666qr8/JEjRzYo5xFHHFE/33zzlbd7S7/r5sQ+M2PGjAbLYv/r1atXg/109OjRuTw33XRTednUqVPrV1lllQa/qyjrsssu22CbhXherHf//fe3utzN7QNPPvlkXn7zzTe3y7Gk9G9O7EONNT5ut3S7lX7L8X2WbLXVVvVrrrlm+fda2m6bbLJJ/aqrrjrbzwJ8uTQvBzqFqJUN0dyvJf7+97/n/0dzyUpR4x0a9/2OWrSNN964/DhqB0PU9C2//PKzLI/ah8aiVqhxc8+oIYkaxpJoRlhZ2xVNE6PJY9QSNxY1GVGuxlrzGpWi1i1qPqKZZFOixnbcuHG5hihqnEui9jRqwkvbtNJBBx3U4HGUI2oiS99XU6J2PWo547mVNW3xvqUao8om2VHDFzV07777bvkW30so1SqXaor/8pe/NBhsrCUqt2dsy3j92PbxHVc2HW0sai+jBilqtUqi+WbUWjX1eaPGq7KPbbRKiM/V1DgEjWui26qp76epfTdq0Sq3fWk/j1YfUWNXuTz26VKz+Kipjpq+qLGr/H6ihjHWLX0/sY3ju45a85Y09W68T0YtZWX5Yn9s/NuIfSXWib9VliWa9Eez3KZaIDSl8bZv6evGtvj4449zjWLjvtRxPKgUz4ttWxLbJmqkK7+blu77zR0v4ncQNaTRYieaFDfWuExRE165LPaVaC0RXSha8103J1qflFoHxevGcaLUDaTy2BXHmeh6EC2USqK2OcrXuPyx38b60e2oJGrm43cZNdVtLXfjfaC070Vz8Nl1n2nNsSRqraP2fE5aut0aixYr0TogWlLEfln63PH8eN/4d6Bx9xag42heDnQK0Y8txMlDS8SJYpyoRF/IStEsMAJa6USypDJYV55kVTZ1rlzeODjEe0WT7Epf+cpX8v8r+6xGc8TTTz89B4nKPoqNT4BLJ2VNac1rVIpm19GHNsoV/WKjeev3vve9cpPk0jZpqpljnPzHCWfjQYUab7donlraPqXvrLHS+0Tf8krRRLfxNowTw+gOUOq/3FiE2VJT02jaHk3nI/RE89Rouhsn7nMaCTiaB0eT2rFjx85yQh0nyo0vBFR+jmiq3Xi7N97nZrddI1BF8+FKEXKbajrdWhH8Gm+3+H6aCr1t3f9LF3BKQbCx0j4QwSGa9cZFr+gPHd0wojtAzEAQv8nmNLevhMahI8oS31d0b5jdvjI7TW37lr5u9AMOLZmDO96j8X4T383TTz/d6n2/ueNF9MeOi18tnRN8dr/lUnla8l03Jy4CRJeKX//617l5fmV/6xhfovI7j99Q4+3T1O8nfvfRDD76KEfz/QjfEcKjyXbp+a0td1P7QGzbuIB73nnn5a4YcUEiLrbFhZPK40NrjiXNHd/but0ai+4g0QjixBNPzLfm9qG4QAF0PKEb6BTixCj6rj377LOtet6cgmhJqe9fS5c3HiCtJWKgsDhR+9rXvpZPoKI2J4JmDL7T1EBLlbUmbX2NSvGcCAZRGxz9ZCOkRv/Q6LceYbUt2nP7NHfCGf1c42S3KaVQGNvq/vvvz7VWUXMctdBR4xUn2vFZmytnbI8I6BF+4z3i9aLWMU7cY9u0tta8PVTWbM2N5j5za9ad0/db2j7RZ7ap8FxZSx5996PWNWpf4wJOBIHoox21ceuuu26aW1GWCMYRiprSXHid07Zvj9dty++mpfv+7I4X7Vmm1nzXTTnzzDPzdx593mNwvmhNE9s69ou2/s7i4k30x45+yhG6ow919AmPMF7S2nI39/uL8RCiNU7p+Bn9zWP/ffjhh3NIb+2xpKXfV1u3W+lvMQZDczXqjS8QAh1H6AY6jagZixGvoxahsil4U2JasTjpiFqOqKUtiUFooqlh/L09xXtFE8JS7XaIwY5CaZCeGLgmah8jcFROCxOBuaXm9jXihC0Gg4pb1ApFEI8B0yJ0l7ZJDPDT1Ai4MThTe0ydU3qf+G4qa59idPWoyVl77bXLy6ImOUbpjZPZOV1AiRPRWC9ucdIbJ6vHH398DuIjR45s8jlxkh6tBaKmrLKmryVNkeNzxEBGEUoqyxY1TE193tiujWvbYllb98WWXlAqUnw/IUJpc9u48fpR2x23+P7XWWedHGauvfbaOe4rjTXeT+O1oytHDBw1twG0La9b2hZxYbA9wkxr9v3mLgbExcrWXqicXXla8103FoO3xWjtMYhipTgex7Gl8juPMjf+XTV1XArRfDpqgqNWPy60xfE2wnh7lbtSXASJ2wknnJAeeuihvE/ERctoeTQ3x5L22G6NlVoNxUXZuf3cQPH06QY6jZgqJ0JfBMQIz41FTUOcfIWY7iVE08NKpVqj2Y3y3VYxmnFJnDDG4zjhiZPmUk1SnEQ2nrKp8SjEszM3rxF9+SpFv8AIB6Um6lFrHiEoRnyPE7qSOAGOmp3SNp1b0b80AkGcrFZOWxQjP1e+b+mEOvodXn755bO8TtRoRXP30NQ0VvFZQuOphpqq3ausYYxmoC25iBG1R1G2yul3Yq7dxmWNzxsn/PF5K8sSUxhF8+G27oulkbUbb7MvU2yDCHZxgSMumjRWmnIqmtrGtqkUYSjGaJjd91O5T1b2iY1+unHBo/G+Er+LqA1sLEakbut2aunrxjRr8Xmi9rPxZ21Ly4+W7vuzuwgVo1RHGIxxBRprbZla+l3P7rfW+D2j33rjfsVxnIlR1yunQYz9Jy64NiVqtWMfin0kWrjEdmvPcocI9PFdV4rwHdu4tP/OzbGkPbZbY3HMGTFiRB7pPMZGaMvnBr48arqBTiNO0qMJdZxkRe119AeN/ooR3KLWIU5ESvObRm1pDL4UJ2pxUhyD2Tz66KP5xCxORKPmoD1F7XOc8MV7xuA8EaiimXNMN1ZqfhrhKkJ/9KWOppDRny6mvIngW9mXc3bm5jVikKU4CYsBoKLGO07E48S2cgC4c845J09ZFC0JYm7f0pRh0Rex8RzQbRUXIqJmKPpdRs1vfJ9Rwx0np437dEef82g6GgOCRY1R1CxFAIqa91hemuc2+qtH8/LYPlFTFtslmt9Hs8/SgEpNiaAUTUCj2XOUJ2r/I+TECWtTJ6qVYv24sBIDNMWUYREQowlyaRCtUi1dfN7ozxytC2I/jPVLU4ZFrVzMQdwWUesa32nU7kULi/hO4/fQ0j687SHCTEyTFN/Teuutl+ctjv09pnuK/T++r9hG0eojLj5FIIoyR5PemLYvtkM8Z3YixMb3Gt9jNLGNCyyxT8bUTJUDaMW2je8k1o/xDuK7jW0fteRxbIjtXTk4V0u19HVjW0Qz4rgoGFPDxe8z+kVHbXWExjj2tEZL9/3ZiaAZF8ziM5SmHYv9OsodYwlUTlXXXt/17Foqxe80fgcxVWBMfxa/l8a/+RiIMF4nju+PP/54/l1F0/Cmps4LUZY4/kWrlgjAlU3L26PcIbpAxHEyBm6L31oE8ChTBOKYzm5ujyWz09Lt1pT4tyF+N3GBILZrPCd+c9FaLOZCb+lc38CX4EseLR1gjl588cU8zcsKK6yQpy+KaXo23XTT+osuuqjB1Cgx1dHPf/7z+hVXXLF+gQUWqB88eHCeCqlyndIULU1NpRWHwOrq6gbLStOyVE59FNO7LLTQQvWvvPJK/dZbb13ft2/f+oEDB+apnBpP9fLb3/42T9US073E1FIxvUtp+q05vXdrX6Px1DOnn356/QYbbJCnz4mp0OK5Z5xxRp7SqtLdd9+dt2es069fv/odd9yxvq6ursE6pfdrPEVXafqh2E5z8utf/zp/N/E51l9//TzFT+NpuUKU7+yzz65fY4018rqLLbZYnvYqvtuYSi7cc889eTq5QYMG5X0i/h/TW8W+Mid//etf69daa6363r17530q3uvKK6+c5XM0VbZXX3017zuxrWLaraOOOqr+lltuyc99+OGHG6x744035im74jMsvvji9aNGjap/4403GqxT2pea0njKsBDT3MW2iM9cOX1Yc6/TeD9pan8OMS1TU1Mklb7fxlNQxfoxNVJMwRTbceWVV67fd9996x977LH893fffTfvz7HPRblivZhaq3JaqNmJbTp06NC87aqqqur/9Kc/Nbk9SlPPxTaJ7ySODTFl0k9+8pP6t956a7bvMbtt35rXjf0ppmQq/X7iN/eHP/yh/PfYh2Jfbur9G3+eluz7czpexJSHMXVY7J/xGjF9Vaxbmq5vdt9p4+kRW/JdNyeOu/H7iOnfYtvEMWbs2LFN/q6izDvttFM+lg4YMKD+sMMOK0/R1rg84fjjj89/i2nFmtOScje3D8TvPKZHjOfEc+P3u+WWW+ZjZVuOJc39m9PclGEt2W5NTRkW4t+l+P5jSrr4dzCmWfvmN79Z/8c//rHZbQV8+XrEf76McA8wr4ra9agxrqx1o/uKLg1Rex01SUYGBgDmRJ9uAGhGNL+vFH15ow9lTHElcAMALaFPNwA0I+YCj5GKY7CvGDQpRuGOPrfNTS8FANCY0A0AzYiRkWO+8wjZMchVDBJ2ww03zDKYEwBAc/TpBgAAgILo0w0AAAAFEboBAACgIPp0z8bMmTPTW2+9lRZZZJHUo0ePji4OAAAAnUT01P7444/ToEGDUs+ezddnC92zEYF78ODBHV0MAAAAOqkJEyak5ZZbrtm/C92zETXcpY3Yr1+/ji4OAAAAncTkyZNzJW0pNzZH6J6NUpPyCNxCNwAAAI3NqSuygdQAAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRta4P7770/bb799WnLJJfNACXG79NJL5/i8U045pbx+49sXX3wxy/oxz9/KK6/c7Hu88847af/9909LLbVU6tWrV6qqqkoXX3xxg3WuvvrqtO222+ZpC3r37p2WXXbZtOuuu6annnqqHbYEAADQGkYvhxZ44okn0j/+8Y+00korpXfffbfVzx8wYEAO03Ma5fCQQw5Jr776apOvMXXq1LTFFlukF154IfXp0ycNGTIkPffcc+nQQw9NEydOTKeeemo5dN933325rCussEJe/89//nO666670jPPPJNWXHHFVpcfAABoGzXd0ALf+9738jx8d955Z5uev8MOO6SHH364wW2++eZrsM5NN92Ufv/736fvfOc7Tb7Gb37zmxygI6zH81988cV05JFH5r/94he/yLXg4Vvf+laqq6tLr7zySnr++efT6NGjy6H91ltvLb9evNc666yT5xWM29ChQ/PnBAAA2o/QDS2wxBJL5Nrltrrlllvy85dZZpn0zW9+Mz355JMN/j5hwoR04IEHpmHDhqXTTz+9yde444478v9XXXXVtNZaa+X7u+22W/7/559/nu655558//DDD88BumTzzTcv348m6SGamu+77775/0svvXSuEX/jjTfStdde2+bPCAAAzErzcihY1GhHsJ1//vlzzfPtt9+e7r777jR27Ni07rrrppkzZ+Ya5gjO119/fVpggQWafJ0I5iH6c5cMHDiwfP/1119v8nmXXHJJ/v/iiy9eDukvv/xyqq+vT1/5yldyE/WePXumGTNmpAcffLBdPzsAAHR3arqhQHvttVfub/3SSy/lcDtmzJi8/NNPP001NTX5/gUXXJD7YMf/IwS3RgTn5sRAbT/84Q/TFVdckRZeeOHcr7sU0jfddNO02GKL5SbqUYu/4YYbph/96Edz9VkBAIBZCd1QoAjRUcNcss022+SQW1kzXRpV/LDDDsvheI011iivH03FN9lkk3x/8ODB+f8R4ksq7y+//PINRkHfcccd0+WXX56D9r333pu+9rWvlf8eNe//+c9/0tlnn5223nrrvP5ll12Wttxyy/TII48Usi0AAKA7ErqhnWy11VZp9dVXT8cdd1x5WYTaymbfMQL6e++9l+9HP+pKMdBZ3KZNm1ZeFjXipccxDViIWvOnn3663Fc8RJP0eP/w5ptv5n7cUaseU4pFiF5//fUbvNdbb72VJk2alH7yk5+kG2+8MQ+8FmWPpu7//ve/233bAABAdyV0Qwv86U9/SqusskoaMWJEedlJJ52Ul40aNSo/jtHCY3Tx//3vfw36U0e4jum9IgBHTXdYaKGFci12aYqvaCZeuo0fP77B88eNG5fvx0BrMYharLPRRhul1VZbLZ133nn5b8ccc0y56XjM412qPY91d99997x+3E477bS8PEL22muvnfuHxwjmMb1Y9DcPa665ZsFbEwAAug8DqUELxHRhEaorRU1x3JZbbrlmn/ezn/0s3Xzzzbkpd8y/HeE7+lOfeOKJOTS3RjQ9j77fUZMeg7FFOI/a6YMOOig3Ta+sHS+JfuSVYv0QIXuPPfZItbW1uV93DPYWIby6ujo3NwcAANpHj/rZjcTUzUXQ6t+/f/roo49Sv379Oro4AAAAzGN5UfNyAAAAKIjm5V1EDNb17rvvdnQxgDkYMGBAg5HmAQDo2oTuLhK4h66+epo2fXpHFwWYg759+qTnnn9e8AYA6CaE7i4gargjcF87cmQaWjEnNNC5PPf+++m7d9+df7NCNwBA9yB0dyERuNdbcsmOLgYAAAD/PwOpAQAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQkC4fum+77ba02mqrpVVXXTVdccUVHV0cAAAAupH5Uxf2xRdfpCOPPDLde++9qX///mnYsGFpl112SUsssURHFw0AAIBuoEvXdD/66KNpjTXWSMsuu2xaeOGF03bbbZfuuuuuji4WAAAA3USnDt33339/2nHHHdOgQYNSjx490q233jrLOjU1NWmFFVZIvXv3ThtuuGEO2iVvvfVWDtwlcf/NN9/80soPAABA99apQ/fUqVPT2muvnYN1U2688cbcfPzkk09OTzzxRF53m222SRMnTvzSywoAAADzVOiO5uCnn3567ofdlPPOOy8dcMABab/99ktVVVXp0ksvTX379k1XXnll/nvUkFfWbMf9WNacTz/9NE2ePLnBDQAAALpk6J6dzz77LD3++ONp5MiR5WU9e/bMj8eOHZsfb7DBBunZZ5/NYXvKlCnpjjvuyDXhzTnrrLPygGul2+DBg7+UzwIAAEDXNM+G7nfffTfNmDEjDRw4sMHyePz222/n+/PPP38699xz05ZbbpnWWWeddNRRR8125PLjjjsuffTRR+XbhAkTCv8cAAAAdF1desqwsNNOO+VbS/Tq1SvfAAAAoFvXdA8YMCDNN9986Z133mmwPB4vvfTSHVYuAAAAmOdD94ILLpiGDRuW7rnnnvKymTNn5scbb7xxh5YNAAAAOn3z8hj87OWXXy4/Hj9+fBo3blxafPHF0/LLL5+nC9tnn33S+uuvnwdNGz16dJ5mLEYzBwAAgI7WqUP3Y489lgdBK4mQHSJoX3311Wn33XdPkyZNSieddFIePC0GSxszZswsg6sBAABAR+jUoXvEiBGpvr5+tusccsgh+QYAAACdzTzbp7tINTU1qaqqKg0fPryjiwIAAMA8TOhuQnV1daqrq0u1tbUdXRQAAADmYUI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURuptQU1OTqqqq0vDhwzu6KAAAAMzDhO4mVFdXp7q6ulRbW9vRRQEAAGAeJnQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidDehpqYmVVVVpeHDh3d0UQAAAJiHCd1NqK6uTnV1dam2trajiwIAAMA8TOgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN1NqKmpSVVVVWn48OEdXRQAAADmYUJ3E6qrq1NdXV2qra3t6KIAAAAwDxO6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQobsJNTU1qaqqKg0fPryjiwIAAMA8TOhuQnV1daqrq0u1tbUdXRQAAADmYUI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6m1BTU5OqqqrS8OHDO7ooAAAAzMOE7iZUV1enurq6VFtb29FFAQAAYB4mdAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURuptQU1OTqqqq0vDhwzu6KAAAAMzDhO4mVFdXp7q6ulRbW9vRRQEAAGAeJnQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUJD52/Kkzz//PL399ttp2rRpackll0yLL754+5cMAAAAuktN98cff5wuueSStMUWW6R+/fqlFVZYIQ0dOjSH7iFDhqQDDjgg1dbWFltaAAAA6Gqh+7zzzssh+6qrrkojR45Mt956axo3blx68cUX09ixY9PJJ5+cvvjii7T11lunbbfdNr300kvFlxwAAAC6QvPyqMG+//770xprrNHk3zfYYIO0//77p0svvTQH8wceeCCtuuqq7V1WAAAA6Hqh+w9/+EOLXqxXr17poIMOmtsyAQAAQJcw16OXT548OTc3f+6559qnRAAAANBdQ/d3vvOddPHFF+f706dPT+uvv35ettZaa6VbbrmliDICAABA9wjd0bd78803z/f//Oc/p/r6+vThhx+mCy+8MJ1++ulFlBEAAAC6R+j+6KOPyvNyjxkzJu22226pb9++aYcddjBqOQAAAMxN6B48eHCeJmzq1Kk5dMc0YeGDDz5IvXv3bu3LAQAAQPcevbzS4YcfnkaNGpUWXnjhtPzyy6cRI0aUm52vueaaRZQRAAAAukfo/tGPfpTn5Z4wYUL6xje+kXr2/L/K8pVWWkmfbgAAAJib0B1ixPIYrXz8+PFp5ZVXTvPPP3/u0w0AAADMRZ/uadOmpe9///t58LQ11lgjvf7663n5oYcemn7xi1+09uUAAACgy2p16D7uuOPSU089lf71r381GDht5MiR6cYbb2zv8gEAAED3aV5+66235nC90UYbpR49epSXR633K6+80t7lAwAAgO5T0z1p0qS01FJLzbI8phCrDOEAAADQ3fVsyyBqt99+e/lxKWhfccUVaeONN27f0gEAAEB3al5+5plnpu222y7V1dWlL774Il1wwQX5/kMPPZTuu+++YkoJAAAA3aGme7PNNkvjxo3LgXvNNddMd911V25uPnbs2DRs2LBiSgkAAADdZZ7umJv78ssvb//SAAAAQHcL3ZMnT27xC/br129uygMAAADdK3QvuuiiLR6ZfMaMGWleV1NTk29d4bMAAADQyUP3vffeW77/3//+Nx177LFp3333LY9WHv25f/e736WzzjordQXV1dX5FjX8/fv37+jiAAAAMI9qUejeYostyvdPPfXUdN5556U999yzvGynnXbKg6pddtllaZ999immpAAAANDVRy+PWu2Yq7uxWPboo4+2V7kAAACg+4XuwYMHNzly+RVXXJH/BgAAALRxyrDzzz8/7bbbbumOO+5IG264YV4WNdwvvfRSuuWWW1r7cgAAANBltbqme/vtt88Be8cdd0zvv/9+vsX9F198Mf8NAAAAaGNNd1huueXSmWee2ZanAgAAQLfRptD94Ycf5iblEydOTDNnzmzwt7333ru9ygYAAADdK3T/7W9/S6NGjUpTpkxJ/fr1Sz169Cj/Le4L3QAAANDGPt1HHXVU2n///XPojhrvDz74oHyL/t0AAABAG0P3m2++mX784x+nvn37tvapAAAA0K20OnRvs8026bHHHiumNAAAANCd+3TvsMMO6Zhjjkl1dXVpzTXXTAsssECDv++0007tWT4AAADoPqH7gAMOyP8/9dRTZ/lbDKQ2Y8aM9ikZAAAAdLfQ3XiKMAAAAKCd+nQDAAAABYbu++67L+24445plVVWybfox/3AAw+05aUAAACgy2p16L722mvTyJEj85RhMXVY3Pr06ZO22mqrdP311xdTSgAAAOgOfbrPOOOM9Mtf/jIdccQR5WURvM8777x02mmnpb322qu9ywgAAADdo6b71VdfzU3LG4sm5uPHj2+vcgEAAED3C92DBw9O99xzzyzL77777vw3AAAAoI3Ny4866qjcnHzcuHFpk002ycsefPDBdPXVV6cLLrigtS8HAAAAXVarQ/fBBx+cll566XTuueemm266KS8bOnRouvHGG9POO+9cRBkBAACge4TusMsuu+QbAAAA0I59umtra9Mjjzwyy/JY9thjj7X25QAAAKDLanXorq6uThMmTJhl+Ztvvpn/BgAAALQxdNfV1aX11ltvluXrrrtu/hsAAADQxtDdq1ev9M4778yy/H//+1+af/42dREHAACALqnVoXvrrbdOxx13XProo4/Kyz788MP0s5/9LH3jG99o7/IBAADAPKvVVdO/+tWv0te+9rU0ZMiQ3KQ8xJzdAwcOTNdcc00RZQQAAIDuEbqXXXbZ9PTTT6frrrsuPfXUU6lPnz5pv/32S3vuuWdaYIEFiiklAAAAzIPa1Al7oYUWSj/84Q/bvzQAAADQnft0h2hGvtlmm6VBgwal1157LS87//zz01/+8pf2Lh8AAAB0n9B9ySWXpCOPPDJtt9126YMPPkgzZszIyxdbbLE0evToIsoIAAAA3SN0X3TRRenyyy9Pxx9/fIMpwtZff/30zDPPtHf5AAAAoPuE7vHjx5dHLW88f/fUqVPbq1wAAADQ/UL3iiuumKcIa2zMmDFp6NCh7VUuAAAA6H6jl0d/7urq6vTJJ5+k+vr69Oijj6Y//OEP6ayzzkpXXHFFMaUEAACA7hC6f/CDH+S5uU844YQ0bdq0tNdee+VRzC+44IK0xx57FFNKAAAA6C7zdI8aNSrfInRPmTIlLbXUUu1fMgAAAOhufbqnT5+ew3bo27dvfhxThd11111FlA8AAAC6T+jeeeed0+9///t8/8MPP0wbbLBBOvfcc/PymMMbAAAAaGPofuKJJ9Lmm2+e7//xj39MSy+9dHrttddyEL/wwgtb+3IAAADQZbU6dEfT8kUWWSTfjyblu+66a+rZs2faaKONcvgGAAAA2hi6V1lllXTrrbemCRMmpDvvvDNtvfXWefnEiRNTv379WvtyAAAA0GW1OnSfdNJJ6eijj04rrLBC2nDDDdPGG29crvVed911U2e0yy67pMUWWyx9+9vf7uiiAAAA0I20OnRHcH399dfTY489lsaMGVNevtVWW6Xzzz8/dUaHHXZYefA3AAAA6NTzdMfgaXGrFKOYd1YjRoxI//rXvzq6GAAAAHQzLarpPuigg9Ibb7zRohe88cYb03XXXdfiAtx///1pxx13TIMGDUo9evTI/cUbq6mpyc3Ze/funZu0P/rooy1+fQAAAOjUNd1LLrlkWmONNdKmm26aA/L666+fQ3KE4A8++CDV1dWlf//73+mGG27Iyy+77LIWF2Dq1Klp7bXXTvvvv38eCb2pEH/kkUemSy+9NAfu0aNHp2222Sa98MILaamllsrrrLPOOumLL76Y5bnRzzzKAwAAAJ02dJ922mnpkEMOSVdccUX69a9/nUN2pZhCbOTIkTlsb7vttq0qwHbbbZdvzTnvvPPSAQcckPbbb7/8OML37bffnq688sp07LHH5mXjxo1L7eHTTz/Nt5LJkye3y+sCAADQPbW4T/fAgQPT8ccfn29Rux2DqU2fPj0NGDAgrbzyyrlpeHv77LPP0uOPP56OO+648rKYEzwC/tixY9v9/c4666z085//vN1fFwAAgO6pTQOpxfRbcSvau+++m2bMmJEDf6V4/Pzzz7f4dSKkP/XUU7kp+3LLLZduvvnm8lRnlSLcR1P2ypruwYMHz+WnAAAAoLtqU+ie19x9990tWq9Xr175BgAAAB0yT/eXKZquzzfffOmdd95psDweN56yDAAAADqbTh26F1xwwTRs2LB0zz33lJfNnDkzP26qeTgAAAB0Jh3evHzKlCnp5ZdfLj8eP358Ho188cUXT8svv3zuY73PPvvkaco22GCDPGVY9M0ujWYOAAAAXSZ0x4jl9fX1qW/fvvnxa6+9lv785z+nqqqqtPXWW7e6AI899ljacssty49LA5lF0L766qvT7rvvniZNmpROOumk9Pbbb+c5uceMGTPL4GoAAAAwz4funXfeOe26667poIMOSh9++GHacMMN0wILLJBHGo85tQ8++OBWvd6IESNyiJ+dmCM8bgAAANCl+3Q/8cQTafPNN8/3//jHP+Ya56jt/v3vf58uvPDC1BXU1NTkmvvhw4d3dFEAAADoTqF72rRpaZFFFsn377rrrlzr3bNnz7TRRhvl8N0VVFdXp7q6ulRbW9vRRQEAAKA7he5VVlkl3XrrrWnChAnpzjvvLPfjnjhxYurXr18RZQQAAIDuEbpjQLOjjz46rbDCCnk08dLUXVHrve666xZRRgAAAOgeA6l9+9vfTptttln63//+l9Zee+3y8q222irtsssu7V0+AAAA6F7zdC+99NL5Fk3Mw+DBg3OtNwAAADAXzcu/+OKLdOKJJ6b+/fvnJuZxi/snnHBC+vzzz1v7cgAAANBltbqm+9BDD01/+tOf0i9/+ctyf+6xY8emU045Jb333nvpkksuKaKcAAAA0PVD9/XXX59uuOGGtN1225WXrbXWWrmJ+Z577il0AwAAQFubl/fq1Ss3KW9sxRVXTAsuuGDqCmpqalJVVVUaPnx4RxcFAACA7hS6DznkkHTaaaelTz/9tLws7p9xxhn5b11BdXV1qqurS7W1tR1dFAAAALpT8/Inn3wy3XPPPWm55ZYrTxn21FNPpc8++yxPG7brrruW142+3wAAANBdtTp0L7roomm33XZrsCz6cwMAAABzGbqvuuqq1j4FAAAAuqVW9+kGAAAACqrpjrm4TzrppHTvvfemiRMnppkzZzb4+/vvv9/alwQAAIAuqdWh+3vf+156+eWX0/e///00cODA1KNHj2JKBgAAAN0tdD/wwAPp3//+d3nkcgAAAKCd+nSvvvrqafr06a19GgAAAHQ7rQ7dv/71r9Pxxx+f7rvvvty/e/LkyQ1uXUFNTU2qqqpKw4cP7+iiAAAA0N3m6Y5w/fWvf73B8vr6+ty/e8aMGWleV11dnW/xOfv379/RxQEAAKC7hO5Ro0alBRZYIF1//fUGUgMAAID2DN3PPvtsevLJJ9Nqq63W2qcCAABAt9LqPt3rr79+mjBhQjGlAQAAgO5c033ooYemww47LB1zzDFpzTXXzE3NK6211lrtWT4AAADoPqF79913z//ff//9y8uiX3dXGkgNAAAAOiR0jx8/vl3eGAAAALq6VofuIUOGFFMSAAAA6O4DqYVrrrkmbbrppmnQoEHptddey8tGjx6d/vKXv7R3+QAAAKD7hO5LLrkkHXnkkWn77bdPH374YbkP96KLLpqDNwAAANDG0H3RRRelyy+/PB1//PFpvvnmazCV2DPPPJO6gpqamlRVVZWGDx/e0UUBAACgO4XuGEht3XXXnWV5r1690tSpU1NXUF1dnerq6lJtbW1HFwUAAIDuFLpXXHHFNG7cuFmWjxkzJg0dOrS9ygUAAADdZ/TyU089NR199NG5P3fUBH/yySd5bu5HH300/eEPf0hnnXVWuuKKK4otLQAAAHTF0P3zn/88HXTQQekHP/hB6tOnTzrhhBPStGnT0l577ZVHMb/gggvSHnvsUWxpAQAAoCuG7qjVLhk1alS+ReieMmVKWmqppYoqHwAAAHT90B169OjR4HHfvn3zDQAAAJjL0P2Vr3xlluDd2Pvvv9+alwQAAIAuq1WhO/p19+/fv7jSAAAAQHcN3TFQmv7bAAAA0M7zdM+pWTkAAADQxtBdOXo5AAAA0I6he+bMmZqWA0Anc8MNN6T11lsv9enTJy2++OLp29/+dnrllVfm+LyLLrooVVVVpV69euV/3/fff//0zjvvNLnuk08+mdeLVm9xe/7558t/u/vuu9Pmm2+ellxyybTgggvm1xoxYkT6y1/+MlfvCQDdLnQDAJ3Lb3/727TnnnvmULzMMsukGTNmpFtuuSVtsskm6e233272eSeeeGL68Y9/nJ577rk0ZMiQNGXKlHTVVVflsDxt2rQG606fPj3ttdde6bPPPmvytZ599tl8W3rppdMaa6yRPv7443TfffelXXfdNT300ENtek8A6EqE7ibU1NTkK/HDhw/v6KIAQJMiBB977LH5/m677ZZeffXVHGgXWWSRNHHixHTmmWc2+byoWT777LPz/aOOOiq9+OKL6eGHHy7XYF966aUN1j/yyCPz8v/3//5fk6938MEHpw8++CA988wzOfzfdttt5RZyY8eObdV7RhCP1xs8eHCuDY/a80033TT97ne/a7ftBgBfNqG7CdXV1amuri7V1tZ2dFEAoEnxb9S7775bDt1h0KBBaaONNsr3x4wZ0+Tzojn4559/3uB5a621VlpllVVmed7f/va3HIgPPfTQtP322zf5ehGOX3vttfy+6667btpxxx3z8p49e+Ya99a850knnZTfb9KkSbnWPC4gPPLII+nee++d6+0FAB1F6AaAedCECRPK9yvHXBk4cGD+/+uvvz5Xz4vm6d///vfTmmuumX75y1/OtizRBD3C8bhx4/L9hRZaKPc133jjjVv1ni+99FK5KfoTTzyRa++j1v6II45o0TYBgM5I6AaALqSts400ft6BBx6Y+2dff/31qXfv3rN97uqrr56f/95776Vf/OIXaerUqemHP/xhDs6tec9SLXmE7uj3vc022+TB10rhHADmRUI3AMyDot9zSdQGN76//PLLz9XznnrqqdxvPJqNL7zwwumggw4qrzts2LD005/+dJbXjtHTY/liiy2WPvzww/SrX/2qVe8ZQT0GYYt+5BHkH3/88XTKKaekkSNHtmrbAEBnInQDwDwoBvtcYokl8v0YsTy89dZbeYCysO222+b/R3iN28UXX5wfb7XVVmn++edv8Lynn346vfzyyw2eVxoMLWqt4/bpp5+Wl8do46XHV1xxRXr//ffLf4sRyyNwh3hea97z0UcfzX25I6zfeeed5UHZ/vOf/+RadACYFwndADAPijmxSyOUR5BdaaWV0tChQ3OT8AEDBpRHNn/hhRfyrTToWkztdcwxx+T75557blpttdVybXY09V511VVzs/Lw3//+Ny8r3WJ6r5IYJX306NH5/umnn577acdzY+aPzTbbrNxsfO+9927Ve1544YV53RVXXDHXpkfz8rDsssvmWnQAmBcJ3QAwj4rm2Ndee21aZ511ci13TMFVmh87RjJvzhlnnJFDc9SAjx8/Pg98ts8++6T7778/32+NPfbYI4f9aCoeU4FF7XuE5b///e/lkcpb+p477LBD2nzzzfNgbDEFWfQlj37e8Vrx2QBgXtSjvq0jrnQDkydPTv37908fffRR6tevX+qsYqCaqBF4/DvfSestuWRHFwdoxhOTJqVhN92U+6mut956HV0cAAC+hLyophsAAAAK8n+jmgBAO4u5l0v9iIHOLcYBaG7EewDmjtANQCGBe7WhQ9Mn06Z1dFGAFujdt2964bnnBG+AAgjdALS7qOGOwL3eaSelhVcc0tHFAWZjyvjX0hMnnpp/t0I3QPsTugEoTATuRYeu1tHFAADoMAZSAwAAgIII3QAAAFAQoRsAAAAKInQ3oaamJlVVVaXhw4d3dFEAAACYhwndTaiurk51dXWptra2o4sCAADAPEzoBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0N6GmpiZVVVWl4cOHd3RRAAAAmIcJ3U2orq5OdXV1qba2tqOLAgAAwDxM6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0N2EmpqaVFVVlYYPH97RRQEAAGAeJnQ3obq6OtXV1aXa2tqOLgoAAADzMKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABRG6AQAAoCBCNwAAABRE6AYAAICCCN0AAABQEKEbAAAACiJ0AwAAQEGEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAAAoiNANAAAABenyoXvChAlpxIgRqaqqKq211lrp5ptv7ugiAQBAl3bDDTek9dZbL/Xp0yctvvji6dvf/nZ65ZVX5vi8iy66KJ+39+rVKy211FJp//33T++8806DdeJxLI+/x3qx/sUXX9xgnc8//zyNHj06rbnmmmmhhRZKAwYMSKNGjUpvvPFGg/V+85vfpM022yyv06NHj3x7/vnn22krQDcJ3fPPP3/+wdXV1aW77rorHX744Wnq1KkdXSwAAOiSfvvb36Y999wzPfnkk2mZZZZJM2bMSLfcckvaZJNN0ttvv93s80488cT04x//OD333HNpyJAhacqUKemqq67KFWjTpk3L68R5/BZbbJGXx99jvVj/0EMPTSeddFL5tQ444IB0xBFHpGeffTatuOKKedn111+fA/ZHH31UXu+OO+7I5VxyySUL3SZ0b10+dMcPfZ111sn3l1566XyV6/333+/oYgEAQJfz2WefpWOPPTbf32233dKrr76aQ/EiiyySJk6cmM4888wmnxe112effXa+f9RRR6UXX3wxPfzww+Wa50svvbRcM/3CCy/k5fH3WO/II4/Mf/vFL36RX+fjjz9O11xzTV529NFH5+D98ssv59rs1157LdXU1JTf99e//nWaPHlyOuWUU5r9TBHuDz744DR48OBcsx4BfdNNN02/+93v2nHL0ZV1eOi+//7704477pgGDRqUfzy33nrrLOvED2OFFVZIvXv3ThtuuGF69NFH2/Rejz/+eL7SFj8YAACgfdXW1qZ33323HLpDnOdvtNFG+f6YMWOafN7dd9+dm4RXPi+6hq6yyioNnhc102HVVVfNf69cP55/zz33pPr6+nwLPXv+X9yJnFH5XiVRtvnmm2+2nylq0CP0T5o0Ka2xxhr5AsIjjzyS7r333jZsIbqjDg/d0URk7bXXbnDFqdKNN96Yr16dfPLJ6YknnsjrbrPNNvlKWUnUZH/1q1+d5fbWW2+V14na7b333jtddtllX8rnAgCA7ibGUyqJPtclAwcOzP9//fXX5+p5pfWaWqe0Xr9+/dK2226bH//yl7/M/bojvJe6mL755put+kwvvfRSufl75JGovY8sEs3XoSXmTx1su+22y7fmnHfeeblPxn777Zcfx1Wm22+/PV155ZXlpivjxo2b7Xt8+umn6Vvf+lZeP/qSzG69uJVEUxMAAGDulGqei3heU+tcd9116YQTTkh//etfc0hef/31c7/wxx57LC2wwAKtKkO0yr3tttty6I4KvNVXXz1nigMPPLBVr0P31eE13XPqExJNwkeOHFleFk1E4vHYsWNb9BrxI9x3333T17/+9fS9731vtuueddZZqX///uWbZugAANBylefPlS1TS/eXX375uXpeab2m1qlcb7HFFsstaaNmPGq4//Wvf+W+3mG11VZr1Wf64Q9/mO67777c+jYCd+ST6ANemVFgng3d0R8k+mBXNhkJ8Xh2Ix9WevDBB3MT9egrHs3Q4/bMM880ue5xxx2XRzMs3SqbuQAAALM3fPjwtMQSS+T7MWJ5iC6fMehZKDX7jvAat9JUX1tttVWedajyeU8//XQeAK3yeaX/R5Pv+Hvl+lGDHa8TYuai6INdcs455+QB2MIee+zRqs8U40lFX+5f/epX6c4778y13uE///lPeu+999q0neheOrx5edFiWoCZM2e2aN0YjTBuAABA6y244IJ5hPJoeh1heKWVVsrBNGqZYxahUvfQUgAuDboWswwdc8wxueXpueeem/72t7/lCrBotRqDppWacsf/YwTzCN0xOFvUfMcI5iGeX6qs+/vf/55+9rOf5b7cUZlWGutpl112yXOGl/z0pz/N5SzVgocYPyoCfExfFrcLL7wwV+Itt9xyec7x0oWAZZddNj+GebqmO36YMZpgDP1fKR7HDxMAAOhcojn2tddem1uYRtiNkcN33XXX9NBDD+XRwptzxhlnpNGjR+ca8PHjx+cpvvbZZ58821HcDwsvvHBu6h3LY1msF+vH8+L5JaWBld94440c7KOmOgZVu+mmmxqMZB654pVXXmnQRD0GY4tlpWmGd9hhh7T55pun6dOn5xazMaNS9POOYF/5WjBP1nTHlbJhw4blof9jILQQtdbx+JBDDuno4gEAAE0YNWpUvrVm8LMIsIcddli+zc4yyyyTrr766tmuE83QS03RZydeZ06vteeee+YbzLOhOyabLzXRCHG1KkYjj6YaMRBCDFgQV7JixMENNtggX8WKwRBKo5kDAABAZ9XhoTuG7d9yyy3LjyNkhwjacdVp9913z4MgxKT0MXhaNFMZM2bMLIOrAQDAnETT4VI/YqBzGzBgQLMj3s9LOjx0jxgxYo7z70VTcs3JAQCY28C92tCh6ZNp0zq6KEAL9O7bN73w3HPzfPDu8NDdGcWcfnGL6coAAOgaooY7AvdXjzkzLbT8Sh1dHGA2pr7+anr2nJ/l363Q3QVVV1fn2+TJk1P//v07ujgAALSjCNz9Vhna0cUAuolOPWUYAAAAzMuEbgAAACiI0A0AAAAFEboBAACgIEI3AAAAFEToBgAAgIII3QAAAFAQobsJNTU1qaqqKg0fPryjiwIAAMA8TOhuQnV1daqrq0u1tbUdXRQAAADmYUI3AAAAFEToBgAAgIII3QAAAFAQoRsAAAAKInQDAABAQYRuAAAAKMj8Rb1wV1BfX5//P3ny5NSZTZky5f/+//nnafJnn3V0cYBmxG80/3/KlE5/XGmv49IX06anz6dM7ejiALMRv9Nud2yaPi19MfX/7gOd0xfTp3X6Y1OpXKXc2Jwe9XNaoxt744030uDBgzu6GAAAAHRSEyZMSMstt1yzfxe6Z2PmzJnprbfeSossskjq0aNHRxeHbiaunMVFn/gR9+vXr6OLA+C4BHRKjk10lIjSH3/8cRo0aFDq2bP5ntual89GbLjZXbGAL0P84+EfEKAzcVwCOiPHJjpC//7957iOgdQAAACgIEI3AAAAFETohk6qV69e6eSTT87/B+gMHJeAzsixic7OQGoAAABQEDXdAAAAUBChGwAAAAoidAMAAEBBhG4oyIgRI9Lhhx/e4vX/+9//ph49eqRx48YVWi6g6/jXv/6Vjxsffvhhi59zyimnpHXWWafQcgGdi2MFdCyhG1ph3333zf9oHXTQQbP8rbq6Ov8t1gl/+tOf0mmnndbi1x48eHD63//+l7761a+2a5mBed/YsWPTfPPNl3bYYYfU2Y+PpdsSSyyRtt122/T000+3+nW+9a1vFVZO6KrmheNEVztWXH311Q0+S1O3qFQBoRtaKcLxDTfckKZPn15e9sknn6Trr78+Lb/88uVliy++eFpkkUVa/LrxD+XSSy+d5p9//nYvMzBv++1vf5sOPfTQdP/996e33nordVZx4hwXD+N2zz335OPZN7/5zY4uFnQL88pxorMfK0otD1ti9913L3+OuG288cbpgAMOaLAszhtLPvvsswJLTmcmdEMrrbfeevkAGjXZJXE/Ave6667bbPPyFVZYIZ155plp//33z2E81r/sssuabV5eagp255135tft06dP+vrXv54mTpyY7rjjjjR06NDUr1+/tNdee6Vp06aVX2fMmDFps802S4suumi+ehz/iL3yyivlv//+979PCy+8cHrppZfKy370ox+l1VdfvcHrAJ3DlClT0o033pgOPvjgXIMVNSvNib/Fb//WW29Nq666aurdu3faZptt0oQJE2ZZ95prrsnHpf79+6c99tgjffzxxy0+jjQn5siNi4dxi2apxx57bH7vSZMmldeJx9/5znfya8fFyZ133rlcExTNWX/3u9+lv/zlL+VaojgWhp/+9KfpK1/5Surbt29aaaWV0oknnpg+//zzVm9P6O7HieBY0T7i3Kz0OeK24IIL5vctPY7Ptdtuu6UzzjgjDRo0KK222mrlbbr++uvn88FYL87l4vyupHQOGBckYr14zU022SS98MIL5XWeeuqptOWWW+bXiPPBYcOGpccee6yQz8ncE7qhDSI4X3XVVeXHV155Zdpvv/3m+Lxzzz03HzyffPLJHHTjH8fKA2hT4h+Wiy++OD300EPlf4BGjx6da9Zvv/32dNddd6WLLrqovP7UqVPTkUcemQ+8cbDu2bNn2mWXXdLMmTPz3/fee++0/fbbp1GjRqUvvvgiv8YVV1yRrrvuunxQBzqXm266KV8Ui5O17373u/l4U19f3+z6cfEsTvDiAtuDDz6Y+3DGiXKlOCmOk+3bbrst3+677770i1/8osXHkZaGgGuvvTatssoq+WQ8xIlvnNjHSeIDDzyQyxcXAaPWK2qAjj766HyMq6wFixPNEM+JoFBXV5cuuOCCdPnll6fzzz+/DVsUup7WHieCY8WXI7ZLnOv94x//yNuw9PmiC2IE59i+cTGh1D2x0vHHH5/PHWP7RmuAOP8sifO45ZZbLtXW1qbHH388B/wFFljgS/1stEI90GL77LNP/c4771w/ceLE+l69etX/97//zbfevXvXT5o0Kf8t1glbbLFF/WGHHVZ+7pAhQ+q/+93vlh/PnDmzfqmllqq/5JJL8uPx48fHv471Tz75ZH5877335sd33313+TlnnXVWXvbKK6+Ulx144IH122yzTbNljnLFc5555pnysvfff79+ueWWqz/44IPrBw4cWH/GGWe02zYC2tcmm2xSP3r06Hz/888/rx8wYEA+PlQeJz744IP8+KqrrsqPH3744fLzn3vuubzskUceyY9PPvnk+r59+9ZPnjy5vM4xxxxTv+GGG7bqONJYHPvmm2+++oUWWijfYv1lllmm/vHHHy+vc80119Svttpq+fhX8umnn9b36dOn/s477yy/ThxL5+Scc86pHzZs2BzXg+5+nAiOFS0/VpTOx9qi8blflDHOs6Lss1NbW5vf8+OPP272HPD222/Py6ZPn54fL7LIIvVXX311m8rJl09NN7TBkksuWW6+FTXecX/AgAFzfN5aa61Vvh/NhqJJUWVzojk9Z+DAgeXmUpXLKl8jmo3vueeeeZ1obhRNwsLrr79eXmexxRbLfb8uueSStPLKK+ero0DnE7Ujjz76aP5Nh6jpiD6E8fttTqwzfPjw8uOo/Yrmmc8991x5WRwXKsecWGaZZVp1HNluu+1yrVPc1lhjjfLzoqljdJGJW5Q7aqpi3ddeey3/PWp1Xn755fzepedHs9EYF2NOTVKj6eymm26aj5vxvBNOOKHBcQ26q7YcJ0rrOVb8nyhb43KWHsctytZWa665Zm52Xilqpnfcccfc1TA+4xZbbJGXNy5n5TlgbPtQ2v7RwuAHP/hBGjlyZG590JJm/XQcIzZBG0UTn0MOOSTfr6mpadFzGjf7ieA9pyZYlc+J9ef0GnEQHzJkSG5OFf2H4m8xInrjwTtioJUYvC2aZEXzsNYM+gZ8OeKkObqBxG+5JJqMRn/I6HbSVnN7HIkuKaXBJCtfa6GFFspNREtivegHGq9z+umn52ak0e8wurM0dTFzdqMyR1PKn//85/nkPF4zBrSMZpfQ3c3pOBG/l7bqLseKv//97+V+32+++WYel6dyCtfou91W8VkrxTlXlC1u8fni80TYjseNz9UanwOG0vaP7ofRFzy6CcZYPyeffHL+rNG8n85H6IY2KvUrioNgHCg7g/feey9f8Y5/tDbffPO87N///vcs60X/8LPPPjv97W9/ywOOxMWDGJAE6DziJDr6WsbJ4tZbb93gbzFNzh/+8IdcM9XU86L/3wYbbJAfxzEh+mrG4IvtdRxZdtllW/RacXyMPp6lk+4YiDJqoZZaaqlcK9aUqBGaMWPGLMesOLGP/o0lpRox6M5acpxoaprT0nMdK/5PPKekNItM5UWB9vT888/nbRe106WRzds6AFoMGBe3I444Irc4iNaXQnfnpHk5tFHUEkcTrBioI+53BtFsPAYhiVHRo1nWP//5z9z8qFKMOvq9730v/fjHP87NpeIqa/zD9sc//rHDyg3MKgbc+eCDD9L3v//9XHNUeYvRcJtrOho1IzFt0COPPJKbMMbgPBtttFH5xLo9jiPN+fTTT9Pbb7+db3F8jHJEjVXUhoWogYquODEKcQyONH78+DxKbxyP3njjjbxONE+N+XrjZP7dd9/NtU8xunLUBEUtTjShvPDCC9Of//znFm9L6KraepwIjhUdI5qUxwWDGAT31VdfTX/961/zoGqtERcnosIktklcVIiB5mJAtZZeMOHLJ3TDXIirr81dge0IcZU4/qGJfzzjH9y48nnOOec0WOewww7LTZ1i+rJSX6O4f+CBB+YmVUDnECfL0VevqaahcTIdNSNxwtlYjPsQLVii2WH0a4z+iHFhrT2PI82J6YOi32HcNtxww3wSePPNN+emmqWyRdeWOOncdddd8wlihIXop1k6lsYctzECc8z0EM0u42Ryp512yuWIk8yYXihqs2IaIOju2nqcCI4VHSPKGmMCxeetqqrKNd6/+tWvWvUaUdkTteUxI03UdMdI7lGREs3q6Zx6xGhqHV0IAGDuxYnc4YcfnpuIAjTHsQK+XGq6AQAAoCBCNwAAABRE83IAAAAoiJpuAAAAKIjQDQAAAAURugEAAKAgQjcAAAAUROgGAACAggjdAAAAUBChGwAAAAoidAMAAEBBhG4AAABIxfj/AETUH1OycGljAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 1000x500 with 1 Axes>"
       ]
@@ -1165,10 +1210,10 @@
    "metadata": {
     "id": "ecf56b75",
     "papermill": {
-     "duration": 0.027675,
-     "end_time": "2026-05-23T01:52:11.421077",
+     "duration": 0.005695,
+     "end_time": "2026-08-17T07:43:44.793257+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.393402",
+     "start_time": "2026-08-17T07:43:44.787562+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1197,7 +1242,16 @@
   {
    "cell_type": "markdown",
    "id": "nc-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005337,
+     "end_time": "2026-08-17T07:43:44.803980+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T07:43:44.798643+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 7.1 Comptage déterministe des nœuds : la réduction EXACTE de l'élagage\n",
     "\n",
@@ -1208,24 +1262,24 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "nc-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T12:07:38.473154Z",
-     "iopub.status.busy": "2026-07-24T12:07:38.472767Z",
-     "iopub.status.idle": "2026-07-24T12:07:39.924969Z",
-     "shell.execute_reply": "2026-07-24T12:07:39.924335Z"
+     "iopub.execute_input": "2026-08-17T07:43:44.817168Z",
+     "iopub.status.busy": "2026-08-17T07:43:44.816822Z",
+     "iopub.status.idle": "2026-08-17T07:43:46.423600Z",
+     "shell.execute_reply": "2026-08-17T07:43:46.422660Z"
     },
     "papermill": {
-     "duration": 1.460165,
-     "end_time": "2026-07-24T12:07:39.926195",
+     "duration": 1.614602,
+     "end_time": "2026-08-17T07:43:46.424281+00:00",
      "exception": false,
-     "start_time": "2026-07-24T12:07:38.466030",
+     "start_time": "2026-08-17T07:43:44.809679+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "execution_count": 9,
    "outputs": [
     {
      "name": "stdout",
@@ -1316,7 +1370,16 @@
   {
    "cell_type": "markdown",
    "id": "nc-interp",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005422,
+     "end_time": "2026-08-17T07:43:46.435556+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T07:43:46.430134+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture — la réduction de l'élagage, mesurée EXACTEMENT.** Sur l'arbre complet du Tic-Tac-Toe (549 946 nœuds pour le minimax exhaustif), l'élagage alpha-beta n'en visite que 18 297, soit **~30× moins** — et la table de transposition ramène le compte des nœuds *réellement développés* à 3 010 (1 565 autres étant servis depuis le cache), soit **~183× moins** que le minimax pur et **~6× moins** qu'alpha-beta seul.\n",
     "\n",
@@ -1331,7 +1394,16 @@
   {
    "cell_type": "markdown",
    "id": "sec72-prongb-header",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004881,
+     "end_time": "2026-08-17T07:43:46.445905+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T07:43:46.441024+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### 7.2 Quand l'élagage devient *nécessaire* : un jeu dont l'arbre minimax explose\n",
     "\n",
@@ -1346,11 +1418,19 @@
    "id": "sec72-prongb-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-25T23:05:26.674821Z",
-     "iopub.status.busy": "2026-07-25T23:05:26.674509Z",
-     "iopub.status.idle": "2026-07-25T23:05:32.331324Z",
-     "shell.execute_reply": "2026-07-25T23:05:32.330367Z"
-    }
+     "iopub.execute_input": "2026-08-17T07:43:46.457502Z",
+     "iopub.status.busy": "2026-08-17T07:43:46.457195Z",
+     "iopub.status.idle": "2026-08-17T07:43:52.975950Z",
+     "shell.execute_reply": "2026-08-17T07:43:52.974962Z"
+    },
+    "papermill": {
+     "duration": 6.525853,
+     "end_time": "2026-08-17T07:43:52.976696+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T07:43:46.450843+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1523,7 +1603,16 @@
   {
    "cell_type": "markdown",
    "id": "sec72-prongb-interp",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005593,
+     "end_time": "2026-08-17T07:43:52.988259+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T07:43:52.982666+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Lecture — la bascule de l'utile à l'indispensable.** Sur le Tic-Tac-Toe (§7.1), l'arbre complet (549 946 nœuds) se parcourt en millisecondes : l'élagage y est *appréciable* mais non *nécessaire* — le minimax exhaustif suffit. Sur le jeu $5 \\times 5$ (aligner 4), la situation bascule :\n",
     "\n",
@@ -1541,10 +1630,10 @@
    "metadata": {
     "id": "exercices-section",
     "papermill": {
-     "duration": 0.095695,
-     "end_time": "2026-05-23T01:52:11.518787",
+     "duration": 0.005171,
+     "end_time": "2026-08-17T07:43:52.998610+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.423092",
+     "start_time": "2026-08-17T07:43:52.993439+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1579,25 +1668,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "o8n7ldilw8",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:11.713447Z",
-     "iopub.status.busy": "2026-05-23T01:52:11.711521Z",
-     "iopub.status.idle": "2026-05-23T01:52:11.767138Z",
-     "shell.execute_reply": "2026-05-23T01:52:11.758628Z"
+     "iopub.execute_input": "2026-08-17T07:43:53.010829Z",
+     "iopub.status.busy": "2026-08-17T07:43:53.010508Z",
+     "iopub.status.idle": "2026-08-17T07:43:53.016572Z",
+     "shell.execute_reply": "2026-08-17T07:43:53.015668Z"
     },
     "id": "o8n7ldilw8",
     "outputId": "ba99b363-232c-4fd5-fbed-30a94d877075",
     "papermill": {
-     "duration": 0.163577,
-     "end_time": "2026-05-23T01:52:11.771188",
+     "duration": 0.01324,
+     "end_time": "2026-08-17T07:43:53.017209+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.607611",
+     "start_time": "2026-08-17T07:43:53.003969+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1659,10 +1748,10 @@
    "metadata": {
     "id": "5f5508cf",
     "papermill": {
-     "duration": 0.085328,
-     "end_time": "2026-05-23T01:52:11.890245",
+     "duration": 0.00518,
+     "end_time": "2026-08-17T07:43:53.027940+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.804917",
+     "start_time": "2026-08-17T07:43:53.022760+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1673,21 +1762,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "0sdp0t3db7ro",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.052933Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.050969Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.088862Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.080541Z"
+     "iopub.execute_input": "2026-08-17T07:43:53.040210Z",
+     "iopub.status.busy": "2026-08-17T07:43:53.039996Z",
+     "iopub.status.idle": "2026-08-17T07:43:53.043790Z",
+     "shell.execute_reply": "2026-08-17T07:43:53.043067Z"
     },
     "id": "0sdp0t3db7ro",
     "papermill": {
-     "duration": 0.167301,
-     "end_time": "2026-05-23T01:52:12.107874",
+     "duration": 0.010919,
+     "end_time": "2026-08-17T07:43:53.044412+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:11.940573",
+     "start_time": "2026-08-17T07:43:53.033493+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1720,10 +1809,10 @@
    "metadata": {
     "id": "52c7cc97",
     "papermill": {
-     "duration": 0.02955,
-     "end_time": "2026-05-23T01:52:12.174534",
+     "duration": 0.006039,
+     "end_time": "2026-08-17T07:43:53.055781+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.144984",
+     "start_time": "2026-08-17T07:43:53.049742+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1734,25 +1823,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "7aqlxw701c3",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.351409Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.350009Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.396374Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.387365Z"
+     "iopub.execute_input": "2026-08-17T07:43:53.068536Z",
+     "iopub.status.busy": "2026-08-17T07:43:53.068233Z",
+     "iopub.status.idle": "2026-08-17T07:43:53.073149Z",
+     "shell.execute_reply": "2026-08-17T07:43:53.072394Z"
     },
     "id": "7aqlxw701c3",
     "outputId": "2e179132-c5be-439b-c967-28ddf93efb6a",
     "papermill": {
-     "duration": 0.146833,
-     "end_time": "2026-05-23T01:52:12.400002",
+     "duration": 0.012553,
+     "end_time": "2026-08-17T07:43:53.073832+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.253169",
+     "start_time": "2026-08-17T07:43:53.061279+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1800,10 +1889,10 @@
    "metadata": {
     "id": "279946a9",
     "papermill": {
-     "duration": 0.084835,
-     "end_time": "2026-05-23T01:52:12.551452",
+     "duration": 0.005722,
+     "end_time": "2026-08-17T07:43:53.085296+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.466617",
+     "start_time": "2026-08-17T07:43:53.079574+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1814,25 +1903,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "m7qk49cywe",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.730509Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.728523Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.764310Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.760570Z"
+     "iopub.execute_input": "2026-08-17T07:43:53.099325Z",
+     "iopub.status.busy": "2026-08-17T07:43:53.098982Z",
+     "iopub.status.idle": "2026-08-17T07:43:53.104569Z",
+     "shell.execute_reply": "2026-08-17T07:43:53.103810Z"
     },
     "id": "m7qk49cywe",
     "outputId": "775a2367-2b56-44dc-a95f-12ec1c565cde",
     "papermill": {
-     "duration": 0.136765,
-     "end_time": "2026-05-23T01:52:12.762134",
+     "duration": 0.012988,
+     "end_time": "2026-08-17T07:43:53.105281+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.625369",
+     "start_time": "2026-08-17T07:43:53.092293+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1885,28 +1974,39 @@
   {
    "cell_type": "markdown",
    "id": "80b7c394",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006997,
+     "end_time": "2026-08-17T07:43:53.118483+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T07:43:53.111486+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "### Extension du modèle\n\nVariante de la recherche adversariale avec evaluation heuristique avancee."
+    "### Extension du modèle\n",
+    "\n",
+    "Variante de la recherche adversariale avec evaluation heuristique avancee."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "d8trzalzkan",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.840382Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.839435Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.849118Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.847921Z"
+     "iopub.execute_input": "2026-08-17T07:43:53.130556Z",
+     "iopub.status.busy": "2026-08-17T07:43:53.130237Z",
+     "iopub.status.idle": "2026-08-17T07:43:53.134782Z",
+     "shell.execute_reply": "2026-08-17T07:43:53.134098Z"
     },
     "id": "d8trzalzkan",
     "papermill": {
-     "duration": 0.054179,
-     "end_time": "2026-05-23T01:52:12.847871",
+     "duration": 0.011686,
+     "end_time": "2026-08-17T07:43:53.135398+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.793692",
+     "start_time": "2026-08-17T07:43:53.123712+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1946,10 +2046,10 @@
    "metadata": {
     "id": "b252120f",
     "papermill": {
-     "duration": 0.009767,
-     "end_time": "2026-05-23T01:52:12.875825",
+     "duration": 0.005376,
+     "end_time": "2026-08-17T07:43:53.146330+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.866058",
+     "start_time": "2026-08-17T07:43:53.140954+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1960,25 +2060,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "au3i41rhmcu",
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-23T01:52:12.897056Z",
-     "iopub.status.busy": "2026-05-23T01:52:12.896685Z",
-     "iopub.status.idle": "2026-05-23T01:52:12.903852Z",
-     "shell.execute_reply": "2026-05-23T01:52:12.902703Z"
+     "iopub.execute_input": "2026-08-17T07:43:53.162230Z",
+     "iopub.status.busy": "2026-08-17T07:43:53.161952Z",
+     "iopub.status.idle": "2026-08-17T07:43:53.166620Z",
+     "shell.execute_reply": "2026-08-17T07:43:53.165938Z"
     },
     "id": "au3i41rhmcu",
     "outputId": "25f4944b-ce8e-4862-d827-04a9eb61f0f7",
     "papermill": {
-     "duration": 0.018852,
-     "end_time": "2026-05-23T01:52:12.904224",
+     "duration": 0.014091,
+     "end_time": "2026-08-17T07:43:53.167254+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.885372",
+     "start_time": "2026-08-17T07:43:53.153163+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2037,10 +2137,10 @@
    "metadata": {
     "id": "882136fd",
     "papermill": {
-     "duration": 0.011367,
-     "end_time": "2026-05-23T01:52:12.926879",
+     "duration": 0.006326,
+     "end_time": "2026-08-17T07:43:53.179406+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.915512",
+     "start_time": "2026-08-17T07:43:53.173080+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2055,10 +2155,10 @@
    "metadata": {
     "id": "conclusion-section",
     "papermill": {
-     "duration": 0.009721,
-     "end_time": "2026-05-23T01:52:12.946828",
+     "duration": 0.005634,
+     "end_time": "2026-08-17T07:43:53.190979+00:00",
      "exception": false,
-     "start_time": "2026-05-23T01:52:12.937107",
+     "start_time": "2026-08-17T07:43:53.185345+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2089,13 +2189,39 @@
     "---\n",
     "\n",
     "**Navigation** : [<< Recherche informee](Search-3-Informed.ipynb) | [Index](../README.md) | [MCTS >>](Search-7-MCTS-And-Beyond.ipynb)\n",
-    "\n\n### References academiques\n\n- von Neumann, J. (1928). Zur Théorie der Gesellschaftsspiele. Mathematische Annalen 100:295-320.\n- Shannon, C.E. (1950). Programming a Computer for Playing Chess. Philosophical Magazine 41(314):256-275.\n- Knuth, D.E. & Moore, R.W. (1975). An Analysis of Alpha-Beta Pruning. Artificial Intelligence 6(4):293-326.\n- Zobrist, A.L. (1970). A New Hashing Method with Application for Game Playing. ICCV Report 88, University of Wisconsin.\n- Korf, R.E. (1985). Depth-first Iterative-Deepening: An Optimal Admissible Tree Search. Artificial Intelligence 27(1):97-109.\n\n"
+    "\n",
+    "\n",
+    "### References academiques\n",
+    "\n",
+    "- von Neumann, J. (1928). Zur Théorie der Gesellschaftsspiele. Mathematische Annalen 100:295-320.\n",
+    "- Shannon, C.E. (1950). Programming a Computer for Playing Chess. Philosophical Magazine 41(314):256-275.\n",
+    "- Knuth, D.E. & Moore, R.W. (1975). An Analysis of Alpha-Beta Pruning. Artificial Intelligence 6(4):293-326.\n",
+    "- Zobrist, A.L. (1970). A New Hashing Method with Application for Game Playing. ICCV Report 88, University of Wisconsin.\n",
+    "- Korf, R.E. (1985). Depth-first Iterative-Deepening: An Optimal Admissible Tree Search. Artificial Intelligence 27(1):97-109.\n",
+    "\n"
    ]
   }
  ],
  "metadata": {
   "colab": {
    "provenance": []
+  },
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 2,
+   "external_account": "none",
+   "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": false,
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "NONE"
   },
   "kernelspec": {
    "display_name": "Python 3",
@@ -2112,36 +2238,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 17.302546,
-   "end_time": "2026-05-23T01:52:13.509207",
+   "duration": 18.361369,
+   "end_time": "2026-08-17T07:43:53.649408+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb",
-   "output_path": "MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb",
+   "input_path": "C:\\dev\\CoursIA-2-11335-search11\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-6-AdversarialSearch.ipynb",
+   "output_path": "C:\\dev\\CoursIA-2-11335-search11\\MyIA.AI.Notebooks\\Search\\Part1-Foundations\\Search-6-AdversarialSearch.ipynb",
    "parameters": {},
-   "start_time": "2026-05-23T01:51:56.206661",
+   "start_time": "2026-08-17T07:43:35.288039+00:00",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "qcc_tokens_est": 0,
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
-   "external_account": "none",
-   "free_alternative": "self",
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-28",
-   "validator": "manual"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml
@@ -20,6 +20,12 @@
       csharp_sha: a1d30fc3fabf281b7f7297e79718c7a63c2c1de4
       content_python_sha: c8ad22f3ee02da732413d4c8faef0ade1d66b1d0fabf92f862ca7c5b94fe4e86
       content_csharp_sha: 7a7860990ddbaea6bbe17c1d17c72526a8cfec74a74edfc124fd78451fc52ec4
+    - date: "2026-08-17"
+      by: myia-po-2024:CoursIA-2
+      python_sha: b265faab1f5432be929dcc2b60d1a19daa426174
+      csharp_sha: a1d30fc3fabf281b7f7297e79718c7a63c2c1de4
+      content_python_sha: 773ac22b23913c6fe1b6e4215f8e45a261b17e922694ce9830f93bd94fad3eea
+      content_csharp_sha: 7a7860990ddbaea6bbe17c1d17c72526a8cfec74a74edfc124fd78451fc52ec4
   bridge_verdict: RECOVERABLE-LOCAL
   bridge_verdict_reason: |
     Python = BCL-style from-scratch pedagogical (numpy/matplotlib + dict/list for minimax/alpha-beta, transposition table). C# = from-scratch BCL (System.Collections.Generic Dictionary/Stack for game tree, no NuGet SOTA). Both cote from-scratch on the coeur algorithmique (minimax, alpha-beta, iterative deepening) -- no third-party solver invoked, no SOTA bridge applicable (minimax is the sujet, pas le sub-strat). Verdict RECOVERABLE-LOCAL (both from-scratch pedagogical assume).


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11387

## Pourquoi ce grain

Tranche 2/4 de la cohorte Search- DIRTY (cf #11387 tranche 1/4 + #11112). `Search-6-AdversarialSearch.ipynb` (Python) porte une **séquence `execution_count` non monotone** (`[9, 10, 9, 10, …]`) — défaut que H.3 / `validate_pr_notebooks.py` ne regardent pas (gates = existence, pas cohérence de séquence).

## Diagnostic (firsthand, origin/main `7cb378abd`)

```bash
$ python scripts/notebook_tools/check_exec_sequence.py MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb --json
{
  "summary": {"scanned": 1, "fully_executed": 1, "clean": 0, "dirty": 1,
              "buckets": {"DUPLICATE": 1, "UNORDERED": 0, "NOT_FROM_1": 0, "GAP": 0}},
  "records": [{"verdict": "DUPLICATE",
               "sequence": [9, 10, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32],
               "sequence_head": [9, 10, 9, 10, 11, 12, 13, 14, 15, 16]}]
}
```

Cellules 3+4 partagent `execution_count: 9,10` au lieu de monotone. Ce PR tranche Search-6 propre (worktree-from-origin/main post-fetch, branche `feature/11388-search6-monotone`).

## Fix (`re-exec papermill` kernel python3)

```bash
$ python scripts/notebook_tools/batch_reexecute.py \
    --path MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb \
    --max 1 --timeout 600
[1/1] Search\Part1-Foundations\Search-6-AdversarialSearch.ipynb (kernel=python3)...
  -> SUCCESS (27s elapsed)
```

**Vérification post-fix** :

```bash
$ python -c "import json; nb=json.load(open('MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb')); \
              print([c.get('execution_count') for c in nb['cells'] if c['cell_type']=='code'])"
[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
```

16/16 cells exécutées, 0 null, séquence `[1..16]` strictement monotone. C.2 maintenu (outputs commités).

## Rebaseline `twin_pairs.d` (apprentissage c.1331x175 ★★)

Re-exec déplace blob SHA (`b754eeadf` → `b265faab1`). Le carnet de parité `twin_pairs.d/search-6-adversarialsearch.yaml` référençait l'ancien SHA. **Rebaseline `--update` faite en 2ᵉ commit** (l'instrument lit `git ls-tree HEAD`, pas le stage — donc commit d'abord, update ensuite, 2 commits) :

```bash
$ python scripts/notebook_tools/check_twin_parity.py --update --pair "Search-6 AdversarialSearch" --by "myia-po-2024:CoursIA-2"
Registre rebaseline : 1 paire(s) mise(s) a jour -> C:\dev\CoursIA-2-11388-search6\scripts/notebook_tools\twin_pairs.d
```

4ᵉ entrée d'audit ajoutée : `date: 2026-08-17 / by: myia-po-2024:CoursIA-2 / python_sha: b265faab1...`. `check_twin_parity.py --check` → **157 OK / 0 DRIFT / 0 MISSING**.

## Périmètre strict

- **Mono-fichier** : `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-6-AdversarialSearch.ipynb` (le `_Csharp.ipynb` est intact, partition C# managed hors-périmètre).
- **Catalogue, README, marqueurs `CATALOG-STATUS`** : intacts.
- **Aucune modification de code** — seulement `execution_count` et `outputs` restaurés, et `start_time`/`end_time` Papermill (timestamps de re-exec).
- **Diff légitime** : 342 insertions / 233 suppressions = 99% de timestamps restaurés, 1 tranche DUPLICATE [9,10,9,10,...] restaurée à monotone [1..16]. C'est le **churn attendu d'un re-exec** (C.2).

## Vrai outil SOTA, pas workaround

- **Pas de hand-edit** d'`outputs` (Stop & Repair, [secrets-hygiene.md](.claude/rules/secrets-hygiene.md) règle 6) : le notebook a été re-exécuté en kernel frais, pas maquillé.
- **Pas de simple stash Git** : la séquence monotone est un invariant de session kernel, pas un état stashable / cherry-pickable.
- **Pas de pre-commit H.3 bypass** : le pre-commit `validate_pr_notebooks.py` vérifiera `execution_count != null` — ici 16/16 cells passent.

## Acceptance

- [x] Diagnostic chiffré DUPLICATE `[9, 10, 9, 10, …]` → monotone `[1..16]` (post-fix).
- [x] `python scripts/notebook_tools/check_exec_sequence.py` → verdict `CLEAN` sur ce notebook.
- [x] 16/16 cells `execution_count != null` (C.2, H.3).
- [x] 0 violation C.1 (pas de `raise NotImplementedError` / `assert False` / `1/0`).
- [x] LF line endings.
- [x] Twin parity OK (157/0/0 — rebaseline intégrée).
- [x] Catalogue byte-identique à main (R1 catalog-pr-hygiene).
- [x] Pas de modification du `_Csharp.ipynb`.

## Cohorte Search- restante (tranches futures)

| Tranche | Notebook | Verdict | Statut |
|---|---|---|---|
| 1/4 | Search-11-Metaheuristics | DUPLICATE [1,2,3,5,5,6,…] | PR #11387 EN CI |
| **2/4** | **Search-6-AdversarialSearch** | **DUPLICATE [9,10,9,10,…]** | **PR #11388** |
| 3/4 | Search-8-DancingLinks | UNORDERED | À claimer |
| 4/4 | CSP-6-Hybridization | DUPLICATE | À claimer |

## Liens

- Issue umbrella : #11335 (préparation Quarto C# — pré-condition Python, **See #11335**)
- PR cohérente : #11387 (tranche 1/4 Search-11)
- Outil de mesure : `scripts/notebook_tools/check_exec_sequence.py` (#11112 orgue)
- Twin parity : `scripts/notebook_tools/twin_pairs.d/search-6-adversarialsearch.yaml` (4 audits cumulés)
- Apprentissage : c.1331x175 ★★ (re-exec déplace blob SHA → rebaseline après commit, pas avant)
