### PR TITLE
fix(ml): PT-11b DM leg directional — p < 0.05 AND sign on the same quantity

### DIFF
--- a/scripts/PostTraining/PT-11b/analyze_pt11b.py
+++ b/scripts/PostTraining/PT-11b/analyze_pt11b.py
@@ -77,16 +77,23 @@ def main():
         dm_per_seed.append((m["seed"], r))
     if dm_per_seed:
         dm_p_median = float(np.median([r.p_value for _, r in dm_per_seed]))
+        dm_diff_median = float(np.median([r.mean_loss_diff for _, r in dm_per_seed]))
         print(f"\nDM per-seed (median p, n_seeds={len(dm_per_seed)}) :")
         for s, r in dm_per_seed:
-            print(f"  seed {s}: dm_stat={r.dm_statistic:.4f}, p={r.p_value:.6f}")
+            print(f"  seed {s}: dm_stat={r.dm_statistic:.4f}, p={r.p_value:.6f}, loss_diff={r.mean_loss_diff:.4f}")
         print(f"  dm_p_median = {dm_p_median:.6f}")
+        print(f"  dm_diff_median = {dm_diff_median:.4f}  (per-seed mean reward gap vs zero baseline)")
     else:
         dm_p_median = 1.0
+        dm_diff_median = 0.0
 
     # 4. Verdict combine (regle C)
     edge_ok = edge_sigma >= 2.0
-    dm_ok = dm_p_median < 0.05
+    # Directional DM leg (#11419 method lesson): p < 0.05 alone says the two
+    # series DIFFER, not which side wins. mean_loss_diff here is the per-seed
+    # mean reward gap vs the zero baseline (positive = model better), so the
+    # DM leg carries significance AND direction on the same quantity.
+    dm_ok = (dm_p_median < 0.05) and (dm_diff_median > 0)
     if edge_ok and dm_ok:
         verdict = "BEATS"
     elif (not edge_ok) and (not dm_ok):
@@ -101,6 +108,7 @@ def main():
     print(f"Steps/seed : {min_len}")
     print(f"edge_sigma : {edge_sigma:.2f}  (>= 2.0 required)")
     print(f"dm_p_median : {dm_p_median:.6f}  (< 0.05 required)")
+    print(f"dm_diff_median : {dm_diff_median:.4f}  (> 0 required, same quantity as the DM)")
     print(f"dm_pooled_p : {dm_pooled.p_value:.6f}")
     print(f"Verdict : {verdict}")
     print("=" * 70)


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: MED/notebook-python #11424

Fix: PT-11b DM verdict leg made directional — p < 0.05 AND sign of the differential on the same quantity. See #11419 (same method class, ai-01's gate fix — this applies the lesson to this repo's own DM gate).

## What

`scripts/PostTraining/PT-11b/analyze_pt11b.py`: `dm_ok` was `dm_p_median < 0.05` — p alone. As ai-01 demonstrated on #11419 (caught by executing a synthetic smoke test, not by re-reading): a small p says the two series DIFFER, not which side wins. My earlier defense ("edge_sigma >= 2.0 carries the direction") was half-right but structurally insufficient: edge_sigma measures the inter-seed reward spread, a DIFFERENT quantity than the per-seed reward gap the DM tests. The DM leg could only veto, never confirm — decorative in the conjunction, not carrying its half of §C.

Fix (l.79-95):

```python
dm_diff_median = float(np.median([r.mean_loss_diff for _, r in dm_per_seed]))
dm_ok = (dm_p_median < 0.05) and (dm_diff_median > 0)
```

`mean_loss_diff` = per-seed mean reward gap vs the zero baseline (dm_test convention: `mean(loss_a - loss_b)`, a=model), positive = model better. Significance AND direction on the same quantity.

## Proof by execution (synthetic smoke test, the tool that exposes this defect class)

| case | p | diff | old dm_ok | new dm_ok |
|---|---|---|---|---|
| GOOD (mean +0.5, 4 seeds) | 0.000000 | +0.4966 | True | True |
| **BAD (mean −0.5, 4 seeds — significantly worse)** | 0.000000 | −0.5037 | **True (BEATS-possible!)** | **False (veto)** |
| NOISE (mean 0.0) | 0.381445 | −0.0045 | False | False |

The BAD row is the defect: the old gate would have let a significantly-worse model pass the DM leg. Now vetoed.

## Scope

- One file, +10/−2. Analysis script (no notebook re-exec needed; no committed outputs).
- Prints updated to expose `dm_diff_median` alongside `dm_p_median`.
