### PR TITLE
fix(ci,#11416): paginate check-runs in pr_gate — au-delà de 100 runs, plus de verdicts perdus en silence

### DIFF
--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -299,6 +299,12 @@ def dedupe_latest(checks: Sequence[dict]) -> list[dict]:
     all of them makes a benign concurrency cancellation indistinguishable from a
     real failure. Ordering key is `started_at` then `id`, both monotonic per name;
     entries missing both keep their input order as a last resort.
+
+    NOTE: the monotonicity premise holds at the check-run level
+    (`commits/<sha>/check-runs` — a rerun creates a fresh entry, larger id AND
+    started_at), NOT at the `actions/runs` level, where an attempt=2 of an old
+    run keeps a smaller id while starting later. dedupe_latest is only fed by
+    the former (#11416).
     """
     best: dict[str, tuple[tuple, dict]] = {}
     for index, check in enumerate(checks):
@@ -500,9 +506,18 @@ def fetch_checks(repo: str, sha: str) -> list[dict]:
     """Union of check runs and legacy commit statuses for one SHA."""
     checks: list[dict] = []
 
-    runs = _gh_api(f"repos/{repo}/commits/{sha}/check-runs?per_page=100")
-    if isinstance(runs, dict):
-        for run in runs.get("check_runs", []):
+    # Paginate check-runs (per_page=100 cap): judging a subset of the runs on a
+    # busy SHA would silently drop verdicts. total_count is the authoritative
+    # stop condition; an empty page is the defensive fallback.
+    page = 1
+    while True:
+        runs = _gh_api(
+            f"repos/{repo}/commits/{sha}/check-runs?per_page=100&page={page}"
+        )
+        if not isinstance(runs, dict):
+            break
+        page_runs = runs.get("check_runs", [])
+        for run in page_runs:
             checks.append(
                 {
                     "name": run.get("name"),
@@ -512,6 +527,12 @@ def fetch_checks(repo: str, sha: str) -> list[dict]:
                     "id": run.get("id"),
                 }
             )
+        if not page_runs:
+            break
+        total = runs.get("total_count")
+        if total is not None and len(checks) >= total:
+            break
+        page += 1
 
     combined = _gh_api(f"repos/{repo}/commits/{sha}/status")
     if isinstance(combined, dict):

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -740,3 +740,42 @@ def test_post_failure_is_non_fatal(monkeypatch, capsys):
     err = capsys.readouterr().err
     assert "check-run POST failed" in err
     assert "stale check stays" in err
+
+
+# --- fetch_checks pagination (#11416 annexe) ---------------------------------
+
+
+def _fake_paginated_api(responses):
+    """Return a _gh_api stand-in yielding canned pages in order."""
+    calls = {"n": 0}
+
+    def fake(path):
+        # Only check-runs paths paginate here; the statuses call returns empty.
+        if "/check-runs" not in path:
+            return {"statuses": []}
+        idx = calls["n"]
+        calls["n"] += 1
+        return responses[min(idx, len(responses) - 1)]
+
+    return fake
+
+
+def test_fetch_checks_paginates_beyond_100(monkeypatch):
+    """Runs past the per_page=100 cap must not be judged on a subset."""
+    page1 = {"total_count": 150, "check_runs": [run(f"c{i}", "success", rid=i) for i in range(100)]}
+    page2 = {"total_count": 150, "check_runs": [run(f"c{i}", "success", rid=i) for i in range(100, 150)]}
+    monkeypatch.setattr(pr_gate, "_gh_api", _fake_paginated_api([page1, page2]))
+
+    checks = pr_gate.fetch_checks("o/r", "deadbeef")
+    assert len(checks) == 150
+    assert {c["name"] for c in checks} == {f"c{i}" for i in range(150)}
+
+
+def test_fetch_checks_stops_on_empty_page(monkeypatch):
+    """An empty page terminates the loop even if total_count is missing."""
+    page1 = {"check_runs": [run("a", "success")]}  # no total_count key
+    monkeypatch.setattr(pr_gate, "_gh_api", _fake_paginated_api([page1, {"check_runs": []}]))
+
+    checks = pr_gate.fetch_checks("o/r", "deadbeef")
+    assert len(checks) == 1
+    assert checks[0]["name"] == "a"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/tooling #11434

## Summary

Annexe coord (msg-20260817T085900-1k4ag6, dossier #11415/#11416 = lane) : `scripts/pr_gate.py:503` ne pagine pas (`repos/.../commits/<sha>/check-runs?per_page=100` seul). Au-delà de 100 check-runs sur un SHA, l'agrégateur juge un **sous-ensemble arbitraire, en silence** — une PR busy verrait des verdicts perdus sans aucun signal.

- **`fetch_checks`** : boucle de pagination (`page=1..N`). `total_count` = condition d'arrêt autoritative ; page vide = fallback défensif. Le statut legacy reste one-shot (endpoint plafonné à 100 par GitHub — hors périmètre signalé).
- **`dedupe_latest` docstring** : la prémissse de monotonie (`started_at` puis `id`) ne vaut qu'au niveau check-run (`commits/<sha>/check-runs` crée des entrées neuves au rerun — id ET started_at plus grands), PAS au niveau `actions/runs` où un attempt=2 d'un run ancien garde un id plus petit en démarrant plus tard. Le code était correct (le coord l'a vérifié en mesurant l'entrée réelle) ; le docstring était trompeur.
- **Tests** : +2 unitaires — paginate au-delà de 100 (150 runs / 2 pages, tous collectés) ; stop sur page vide sans `total_count`.

## Test plan

- `python -m pytest scripts/tests/test_pr_gate.py` : **48/48 pass** (46 existants + 2 nouveaux).
- `py_compile` OK sur les 2 fichiers.
- Comportement inchangé sous 100 runs (total_count max observé = 95 sur #11377) — la fix ne prend effet qu'au-delà du cap.
- 0 fichier catalogue, 2 fichiers touchés.

See #11416 (la PR qui répare la file) — cette annexe corrige une limitation d'agrégation du même fichier.