### PR TITLE
fix(genai,#11112): re-exec Texte 4_Function_Calling -> execution sequence CLEAN 1..22

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb
@@ -1,14 +1,42 @@
 {
  "cells": [
   {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f0246c73",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T09:27:12.620535Z",
+     "iopub.status.busy": "2026-08-17T09:27:12.620221Z",
+     "iopub.status.idle": "2026-08-17T09:27:12.625965Z",
+     "shell.execute_reply": "2026-08-17T09:27:12.625217Z"
+    },
+    "papermill": {
+     "duration": 0.016513,
+     "end_time": "2026-08-17T09:27:12.627740",
+     "exception": false,
+     "start_time": "2026-08-17T09:27:12.611227",
+     "status": "completed"
+    },
+    "tags": [
+     "injected-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Parameters\n",
+    "BATCH_MODE = \"true\"\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "5b84890e",
    "metadata": {
     "papermill": {
-     "duration": 0.006667,
-     "end_time": "2026-06-24T09:52:07.332399",
+     "duration": 0.008095,
+     "end_time": "2026-08-17T09:27:12.644797",
      "exception": false,
-     "start_time": "2026-06-24T09:52:07.325732",
+     "start_time": "2026-08-17T09:27:12.636702",
      "status": "completed"
     },
     "tags": []
@@ -33,20 +61,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "id": "48290080",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:07.343568Z",
-     "iopub.status.busy": "2026-06-24T09:52:07.343194Z",
-     "iopub.status.idle": "2026-06-24T09:52:13.219434Z",
-     "shell.execute_reply": "2026-06-24T09:52:13.218752Z"
+     "iopub.execute_input": "2026-08-17T09:27:12.659261Z",
+     "iopub.status.busy": "2026-08-17T09:27:12.658893Z",
+     "iopub.status.idle": "2026-08-17T09:27:17.805817Z",
+     "shell.execute_reply": "2026-08-17T09:27:17.804925Z"
     },
     "papermill": {
-     "duration": 5.883121,
-     "end_time": "2026-06-24T09:52:13.220536",
+     "duration": 5.155049,
+     "end_time": "2026-08-17T09:27:17.806975",
      "exception": false,
-     "start_time": "2026-06-24T09:52:07.337415",
+     "start_time": "2026-08-17T09:27:12.651926",
      "status": "completed"
     },
     "tags": []
@@ -59,7 +87,7 @@
       "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
       "WARNING: Ignoring invalid distribution ~penai (C:\\Python313\\Lib\\site-packages)\n",
       "\n",
-      "[notice] A new release of pip is available: 25.0.1 -> 26.1.2\n",
+      "[notice] A new release of pip is available: 25.0.1 -> 26.2.1\n",
       "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
      ]
     },
@@ -68,7 +96,7 @@
      "output_type": "stream",
      "text": [
       "Note: you may need to restart the kernel to use updated packages.\n",
-      ".env charge depuis: .env\n"
+      "WARNING: .env non trouve, utilisation variables environnement\n"
      ]
     },
     {
@@ -143,10 +171,10 @@
    "id": "zaczlvwkkjc",
    "metadata": {
     "papermill": {
-     "duration": 0.005185,
-     "end_time": "2026-06-24T09:52:13.232236",
+     "duration": 0.004097,
+     "end_time": "2026-08-17T09:27:17.815282",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.227051",
+     "start_time": "2026-08-17T09:27:17.811185",
      "status": "completed"
     },
     "tags": []
@@ -157,20 +185,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "jydx81iabdo",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:13.246699Z",
-     "iopub.status.busy": "2026-06-24T09:52:13.246082Z",
-     "iopub.status.idle": "2026-06-24T09:52:13.252625Z",
-     "shell.execute_reply": "2026-06-24T09:52:13.251930Z"
+     "iopub.execute_input": "2026-08-17T09:27:17.826872Z",
+     "iopub.status.busy": "2026-08-17T09:27:17.826295Z",
+     "iopub.status.idle": "2026-08-17T09:27:17.831558Z",
+     "shell.execute_reply": "2026-08-17T09:27:17.830452Z"
     },
     "papermill": {
-     "duration": 0.016089,
-     "end_time": "2026-06-24T09:52:13.253841",
+     "duration": 0.013204,
+     "end_time": "2026-08-17T09:27:17.832680",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.237752",
+     "start_time": "2026-08-17T09:27:17.819476",
      "status": "completed"
     },
     "tags": []
@@ -212,10 +240,10 @@
    "id": "h27jbzg4aqj",
    "metadata": {
     "papermill": {
-     "duration": 0.005956,
-     "end_time": "2026-06-24T09:52:13.265929",
+     "duration": 0.009625,
+     "end_time": "2026-08-17T09:27:17.849052",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.259973",
+     "start_time": "2026-08-17T09:27:17.839427",
      "status": "completed"
     },
     "tags": []
@@ -229,10 +257,10 @@
    "id": "f3f669a7",
    "metadata": {
     "papermill": {
-     "duration": 0.006954,
-     "end_time": "2026-06-24T09:52:13.279414",
+     "duration": 0.004359,
+     "end_time": "2026-08-17T09:27:17.857487",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.272460",
+     "start_time": "2026-08-17T09:27:17.853128",
      "status": "completed"
     },
     "tags": []
@@ -265,20 +293,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "42573906",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:13.294344Z",
-     "iopub.status.busy": "2026-06-24T09:52:13.293975Z",
-     "iopub.status.idle": "2026-06-24T09:52:13.300591Z",
-     "shell.execute_reply": "2026-06-24T09:52:13.299855Z"
+     "iopub.execute_input": "2026-08-17T09:27:17.870599Z",
+     "iopub.status.busy": "2026-08-17T09:27:17.870145Z",
+     "iopub.status.idle": "2026-08-17T09:27:17.876561Z",
+     "shell.execute_reply": "2026-08-17T09:27:17.875388Z"
     },
     "papermill": {
-     "duration": 0.015662,
-     "end_time": "2026-06-24T09:52:13.301942",
+     "duration": 0.01416,
+     "end_time": "2026-08-17T09:27:17.877749",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.286280",
+     "start_time": "2026-08-17T09:27:17.863589",
      "status": "completed"
     },
     "tags": []
@@ -356,10 +384,10 @@
    "id": "c39d73e7",
    "metadata": {
     "papermill": {
-     "duration": 0.006735,
-     "end_time": "2026-06-24T09:52:13.315528",
+     "duration": 0.00412,
+     "end_time": "2026-08-17T09:27:17.886589",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.308793",
+     "start_time": "2026-08-17T09:27:17.882469",
      "status": "completed"
     },
     "tags": []
@@ -384,20 +412,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "b34e8b8c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:13.331439Z",
-     "iopub.status.busy": "2026-06-24T09:52:13.331092Z",
-     "iopub.status.idle": "2026-06-24T09:52:13.338542Z",
-     "shell.execute_reply": "2026-06-24T09:52:13.337742Z"
+     "iopub.execute_input": "2026-08-17T09:27:17.897584Z",
+     "iopub.status.busy": "2026-08-17T09:27:17.896972Z",
+     "iopub.status.idle": "2026-08-17T09:27:17.904243Z",
+     "shell.execute_reply": "2026-08-17T09:27:17.903441Z"
     },
     "papermill": {
-     "duration": 0.01709,
-     "end_time": "2026-06-24T09:52:13.339702",
+     "duration": 0.014545,
+     "end_time": "2026-08-17T09:27:17.905312",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.322612",
+     "start_time": "2026-08-17T09:27:17.890767",
      "status": "completed"
     },
     "tags": []
@@ -457,10 +485,10 @@
    "id": "9540c947",
    "metadata": {
     "papermill": {
-     "duration": 0.0072,
-     "end_time": "2026-06-24T09:52:13.353231",
+     "duration": 0.006921,
+     "end_time": "2026-08-17T09:27:17.917430",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.346031",
+     "start_time": "2026-08-17T09:27:17.910509",
      "status": "completed"
     },
     "tags": []
@@ -490,10 +518,10 @@
    "id": "e9c585e2",
    "metadata": {
     "papermill": {
-     "duration": 0.005626,
-     "end_time": "2026-06-24T09:52:13.364269",
+     "duration": 0.006635,
+     "end_time": "2026-08-17T09:27:17.929028",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.358643",
+     "start_time": "2026-08-17T09:27:17.922393",
      "status": "completed"
     },
     "tags": []
@@ -511,20 +539,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "f1a10a84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:13.378627Z",
-     "iopub.status.busy": "2026-06-24T09:52:13.378110Z",
-     "iopub.status.idle": "2026-06-24T09:52:20.625550Z",
-     "shell.execute_reply": "2026-06-24T09:52:20.624606Z"
+     "iopub.execute_input": "2026-08-17T09:27:17.943552Z",
+     "iopub.status.busy": "2026-08-17T09:27:17.942893Z",
+     "iopub.status.idle": "2026-08-17T09:27:26.003823Z",
+     "shell.execute_reply": "2026-08-17T09:27:26.003156Z"
     },
     "papermill": {
-     "duration": 7.255255,
-     "end_time": "2026-06-24T09:52:20.626898",
+     "duration": 8.069664,
+     "end_time": "2026-08-17T09:27:26.004880",
      "exception": false,
-     "start_time": "2026-06-24T09:52:13.371643",
+     "start_time": "2026-08-17T09:27:17.935216",
      "status": "completed"
     },
     "tags": []
@@ -572,10 +600,10 @@
    "id": "e4784ced",
    "metadata": {
     "papermill": {
-     "duration": 0.006562,
-     "end_time": "2026-06-24T09:52:20.639943",
+     "duration": 0.0052,
+     "end_time": "2026-08-17T09:27:26.014841",
      "exception": false,
-     "start_time": "2026-06-24T09:52:20.633381",
+     "start_time": "2026-08-17T09:27:26.009641",
      "status": "completed"
     },
     "tags": []
@@ -605,10 +633,10 @@
    "id": "01655071",
    "metadata": {
     "papermill": {
-     "duration": 0.008254,
-     "end_time": "2026-06-24T09:52:20.655394",
+     "duration": 0.008203,
+     "end_time": "2026-08-17T09:27:26.028056",
      "exception": false,
-     "start_time": "2026-06-24T09:52:20.647140",
+     "start_time": "2026-08-17T09:27:26.019853",
      "status": "completed"
     },
     "tags": []
@@ -630,20 +658,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "35909f52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:20.676344Z",
-     "iopub.status.busy": "2026-06-24T09:52:20.675844Z",
-     "iopub.status.idle": "2026-06-24T09:52:26.292452Z",
-     "shell.execute_reply": "2026-06-24T09:52:26.291818Z"
+     "iopub.execute_input": "2026-08-17T09:27:26.043469Z",
+     "iopub.status.busy": "2026-08-17T09:27:26.043212Z",
+     "iopub.status.idle": "2026-08-17T09:27:29.196142Z",
+     "shell.execute_reply": "2026-08-17T09:27:29.195185Z"
     },
     "papermill": {
-     "duration": 5.63061,
-     "end_time": "2026-06-24T09:52:26.293460",
+     "duration": 3.163115,
+     "end_time": "2026-08-17T09:27:29.196969",
      "exception": false,
-     "start_time": "2026-06-24T09:52:20.662850",
+     "start_time": "2026-08-17T09:27:26.033854",
      "status": "completed"
     },
     "tags": []
@@ -669,9 +697,7 @@
      "output_type": "stream",
      "text": [
       "\n",
-      "Réponse finale: Actuellement à Lyon : 22 °C, ensoleillé, humidité ~45 %. \n",
-      "\n",
-      "Souhaitez-vous la prévision pour les prochaines heures/jours ou un conseil vestimentaire ?\n"
+      "Réponse finale: Actuellement à Lyon : 22°C, ensoleillé, humidité 45%. Voulez-vous la prévision sur plusieurs jours ou l'heure par heure ?\n"
      ]
     }
    ],
@@ -729,10 +755,10 @@
    "id": "76e50050",
    "metadata": {
     "papermill": {
-     "duration": 0.004197,
-     "end_time": "2026-06-24T09:52:26.302195",
+     "duration": 0.004623,
+     "end_time": "2026-08-17T09:27:29.206221",
      "exception": false,
-     "start_time": "2026-06-24T09:52:26.297998",
+     "start_time": "2026-08-17T09:27:29.201598",
      "status": "completed"
     },
     "tags": []
@@ -764,10 +790,10 @@
    "id": "9f9487e1",
    "metadata": {
     "papermill": {
-     "duration": 0.0052,
-     "end_time": "2026-06-24T09:52:26.311933",
+     "duration": 0.004431,
+     "end_time": "2026-08-17T09:27:29.215014",
      "exception": false,
-     "start_time": "2026-06-24T09:52:26.306733",
+     "start_time": "2026-08-17T09:27:29.210583",
      "status": "completed"
     },
     "tags": []
@@ -785,20 +811,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "c947a8a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:26.323495Z",
-     "iopub.status.busy": "2026-06-24T09:52:26.323211Z",
-     "iopub.status.idle": "2026-06-24T09:52:26.330127Z",
-     "shell.execute_reply": "2026-06-24T09:52:26.329388Z"
+     "iopub.execute_input": "2026-08-17T09:27:29.224899Z",
+     "iopub.status.busy": "2026-08-17T09:27:29.224635Z",
+     "iopub.status.idle": "2026-08-17T09:27:29.230329Z",
+     "shell.execute_reply": "2026-08-17T09:27:29.229482Z"
     },
     "papermill": {
-     "duration": 0.014422,
-     "end_time": "2026-06-24T09:52:26.331244",
+     "duration": 0.012112,
+     "end_time": "2026-08-17T09:27:29.231295",
      "exception": false,
-     "start_time": "2026-06-24T09:52:26.316822",
+     "start_time": "2026-08-17T09:27:29.219183",
      "status": "completed"
     },
     "tags": []
@@ -889,10 +915,10 @@
    "id": "50118133",
    "metadata": {
     "papermill": {
-     "duration": 0.005665,
-     "end_time": "2026-06-24T09:52:26.342104",
+     "duration": 0.005,
+     "end_time": "2026-08-17T09:27:29.241253",
      "exception": false,
-     "start_time": "2026-06-24T09:52:26.336439",
+     "start_time": "2026-08-17T09:27:29.236253",
      "status": "completed"
     },
     "tags": []
@@ -917,20 +943,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8f1bb285",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:26.355765Z",
-     "iopub.status.busy": "2026-06-24T09:52:26.355307Z",
-     "iopub.status.idle": "2026-06-24T09:52:37.558793Z",
-     "shell.execute_reply": "2026-06-24T09:52:37.558052Z"
+     "iopub.execute_input": "2026-08-17T09:27:29.253111Z",
+     "iopub.status.busy": "2026-08-17T09:27:29.252665Z",
+     "iopub.status.idle": "2026-08-17T09:27:35.046262Z",
+     "shell.execute_reply": "2026-08-17T09:27:35.045184Z"
     },
     "papermill": {
-     "duration": 11.212139,
-     "end_time": "2026-06-24T09:52:37.559888",
+     "duration": 5.801554,
+     "end_time": "2026-08-17T09:27:35.047833",
      "exception": false,
-     "start_time": "2026-06-24T09:52:26.347749",
+     "start_time": "2026-08-17T09:27:29.246279",
      "status": "completed"
     },
     "tags": []
@@ -961,13 +987,9 @@
      "text": [
       "\n",
       "Réponse finale:\n",
-      "C’est fait.\n",
-      "\n",
-      "- Heure à Paris : 11:52:31 (24 juin 2026), fuseau Europe/Paris.  \n",
-      "- Météo actuelle à Paris : 18 °C, nuageux, humidité 65 %.  \n",
-      "- Rappel créé : \"Réunion équipe\" pour demain (25 juin 2026) à 09:00 — priorité normale.\n",
-      "\n",
-      "Souhaitez‑vous modifier ou annuler ce rappel, ajouter une alarme/notification, ou recevoir la prévision pour la journée ?\n"
+      "Il est 11:27:33 le 17 août 2026 à Paris.  \n",
+      "Le temps à Paris : 18°C, nuageux, humidité 65%.  \n",
+      "Le rappel \"Réunion équipe\" pour demain à 09:00 a bien été créé (priorité normale).\n"
      ]
     }
    ],
@@ -993,10 +1015,10 @@
    "id": "880c605e",
    "metadata": {
     "papermill": {
-     "duration": 0.004353,
-     "end_time": "2026-06-24T09:52:37.568957",
+     "duration": 0.004327,
+     "end_time": "2026-08-17T09:27:35.058099",
      "exception": false,
-     "start_time": "2026-06-24T09:52:37.564604",
+     "start_time": "2026-08-17T09:27:35.053772",
      "status": "completed"
     },
     "tags": []
@@ -1028,7 +1050,16 @@
   {
    "cell_type": "markdown",
    "id": "dd4f2a94",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004569,
+     "end_time": "2026-08-17T09:27:35.066810",
+     "exception": false,
+     "start_time": "2026-08-17T09:27:35.062241",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1 : Définir et appeler un nouvel outil simple\n",
     "\n",
@@ -1046,9 +1077,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "id": "2ffa1390",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T09:27:35.077253Z",
+     "iopub.status.busy": "2026-08-17T09:27:35.077036Z",
+     "iopub.status.idle": "2026-08-17T09:27:35.081351Z",
+     "shell.execute_reply": "2026-08-17T09:27:35.080459Z"
+    },
+    "papermill": {
+     "duration": 0.011005,
+     "end_time": "2026-08-17T09:27:35.082481",
+     "exception": false,
+     "start_time": "2026-08-17T09:27:35.071476",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Exercice 1 : Définir et appeler un nouvel outil simple\n",
@@ -1091,7 +1137,16 @@
   {
    "cell_type": "markdown",
    "id": "e951365a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006882,
+     "end_time": "2026-08-17T09:27:35.096531",
+     "exception": false,
+     "start_time": "2026-08-17T09:27:35.089649",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2 : Orchestrateur d'appels parallèles\n",
     "\n",
@@ -1109,9 +1164,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "id": "c871f368",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T09:27:35.115560Z",
+     "iopub.status.busy": "2026-08-17T09:27:35.115149Z",
+     "iopub.status.idle": "2026-08-17T09:27:35.120121Z",
+     "shell.execute_reply": "2026-08-17T09:27:35.119392Z"
+    },
+    "papermill": {
+     "duration": 0.015175,
+     "end_time": "2026-08-17T09:27:35.121127",
+     "exception": false,
+     "start_time": "2026-08-17T09:27:35.105952",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "# Exercice 2 : Orchestrateur d'appels parallèles\n",
@@ -1191,10 +1261,10 @@
    "id": "548e366f",
    "metadata": {
     "papermill": {
-     "duration": 0.005761,
-     "end_time": "2026-06-24T09:52:37.578948",
+     "duration": 0.005412,
+     "end_time": "2026-08-17T09:27:35.131689",
      "exception": false,
-     "start_time": "2026-06-24T09:52:37.573187",
+     "start_time": "2026-08-17T09:27:35.126277",
      "status": "completed"
     },
     "tags": []
@@ -1219,20 +1289,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
    "id": "7d3bd0ee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:37.593173Z",
-     "iopub.status.busy": "2026-06-24T09:52:37.592830Z",
-     "iopub.status.idle": "2026-06-24T09:52:52.013015Z",
-     "shell.execute_reply": "2026-06-24T09:52:52.012210Z"
+     "iopub.execute_input": "2026-08-17T09:27:35.144317Z",
+     "iopub.status.busy": "2026-08-17T09:27:35.143848Z",
+     "iopub.status.idle": "2026-08-17T09:27:51.472104Z",
+     "shell.execute_reply": "2026-08-17T09:27:51.471112Z"
     },
     "papermill": {
-     "duration": 14.429057,
-     "end_time": "2026-06-24T09:52:52.014288",
+     "duration": 16.334914,
+     "end_time": "2026-08-17T09:27:51.473164",
      "exception": false,
-     "start_time": "2026-06-24T09:52:37.585231",
+     "start_time": "2026-08-17T09:27:35.138250",
      "status": "completed"
     },
     "tags": []
@@ -1265,7 +1335,7 @@
       "Question: Quelle est la météo à Paris?\n",
       "\n",
       "Avec tool_choice='none' (pas d'appel de fonction):\n",
-      "  Réponse directe: Désolé — je n’ai pas accès aux données météorologiques en temps réel en ce moment, donc je ne peux p...\n",
+      "  Réponse directe: Je n’ai pas accès aux données météo en direct pour l’instant, donc je ne peux pas donner la situatio...\n",
       "\n",
       "=== Test 3: tool_choice='required' ===\n"
      ]
@@ -1339,10 +1409,10 @@
    "id": "7e0422ed",
    "metadata": {
     "papermill": {
-     "duration": 0.005649,
-     "end_time": "2026-06-24T09:52:52.029238",
+     "duration": 0.005241,
+     "end_time": "2026-08-17T09:27:51.483732",
      "exception": false,
-     "start_time": "2026-06-24T09:52:52.023589",
+     "start_time": "2026-08-17T09:27:51.478491",
      "status": "completed"
     },
     "tags": []
@@ -1369,10 +1439,10 @@
    "id": "1f4dd289",
    "metadata": {
     "papermill": {
-     "duration": 0.005768,
-     "end_time": "2026-06-24T09:52:52.040724",
+     "duration": 0.006011,
+     "end_time": "2026-08-17T09:27:51.494407",
      "exception": false,
-     "start_time": "2026-06-24T09:52:52.034956",
+     "start_time": "2026-08-17T09:27:51.488396",
      "status": "completed"
     },
     "tags": []
@@ -1398,20 +1468,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 13,
    "id": "e2e10f40",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:52:52.054522Z",
-     "iopub.status.busy": "2026-06-24T09:52:52.054030Z",
-     "iopub.status.idle": "2026-06-24T09:53:15.092278Z",
-     "shell.execute_reply": "2026-06-24T09:53:15.091642Z"
+     "iopub.execute_input": "2026-08-17T09:27:51.507177Z",
+     "iopub.status.busy": "2026-08-17T09:27:51.506785Z",
+     "iopub.status.idle": "2026-08-17T09:28:08.561479Z",
+     "shell.execute_reply": "2026-08-17T09:28:08.560614Z"
     },
     "papermill": {
-     "duration": 23.046754,
-     "end_time": "2026-06-24T09:53:15.093341",
+     "duration": 17.062656,
+     "end_time": "2026-08-17T09:28:08.563177",
      "exception": false,
-     "start_time": "2026-06-24T09:52:52.046587",
+     "start_time": "2026-08-17T09:27:51.500521",
      "status": "completed"
     },
     "tags": []
@@ -1428,7 +1498,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "À Berlin il fait 20°C, conditions variables, humidité 50%. Besoin d'autre chose ?\n",
+      "Voici la météo actuelle pour Berlin :\n",
+      "- Température : 20 °C\n",
+      "- Conditions : variable\n",
+      "- Humidité : 50 %\n",
       "\n",
       "=== Test 2: Fonction inexistante ===\n"
      ]
@@ -1437,21 +1510,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Je ne peux pas effectuer de paiements ni acheter directement un billet pour vous, mais je peux tout faire pour faciliter la réservation : chercher et comparer les vols, proposer les meilleures options (prix/horaires/compagnies), préparer toutes les informations à copier-coller pour réserver, vous indiquer les liens de réservation et les étapes, et créer un rappel pour payer ou pour le départ.\n",
+      "Je peux t’aider à trouver et réserver un billet, mais je ne peux pas effectuer le paiement à ta place. Pour commencer, donne-moi ces informations (ou dis-moi si tu veux que je propose des options) :\n",
       "\n",
-      "Pour commencer, donnez-moi ces informations :\n",
-      "1. Ville / aéroport de départ (ex. Paris CDG ou juste « Paris »)  \n",
-      "2. Ville / aéroport d’arrivée  \n",
-      "3. Dates (aller et retour si applicable) — êtes-vous flexible ? (+/- jours)  \n",
-      "4. Aller simple ou aller-retour ou multi-destinations ?  \n",
-      "5. Nombre de voyageurs et âges (adulte/enfant/bébé)  \n",
-      "6. Classe souhaitée (éco, premium éco, business)  \n",
-      "7. Budget approximatif ou préférence (moins cher, direct, le plus rapide, compagnie préférée)  \n",
-      "8. Bagages à enregistrer ? Besoin de siège spécifique, repas, ou autres services ?  \n",
-      "9. Passeport / visas (nationalité et pays de destination) — utile pour vérifier exigences d’entrée.  \n",
-      "10. Voulez-vous que je crée un rappel pour finaliser la réservation ou pour le jour du vol ?\n",
+      "1. Trajet : aller-simple, aller-retour ou multi-destinations ?\n",
+      "2. Ville / aéroport de départ :\n",
+      "3. Ville / aéroport d’arrivée :\n",
+      "4. Dates : date de départ et date de retour (ou flexibilité ± jours) :\n",
+      "5. Nombre de passagers et âges (adulte/enfant/bébé) :\n",
+      "6. Classe : économique, premium économique, business, première :\n",
+      "7. Budget approximatif ou préférence tarifaire (le moins cher / le plus rapide / 1 escale max / sans escale) :\n",
+      "8. Compagnies aériennes à privilégier ou à éviter :\n",
+      "9. Besoin particulier (bagage enregistré, siège spécifique, assistance mobilité, animaux, visa) :\n",
+      "10. Préfères-tu que je te propose plusieurs options à comparer, que je prépare les informations pour que tu réserves, ou que je crée un rappel pour t’occuper de la réservation plus tard ?\n",
       "\n",
-      "Donnez-moi ces infos et je lance la recherche et vous propose les meilleures options avec liens et instructions de réservation.\n",
+      "Si tu veux, je peux aussi :\n",
+      "- Te proposer les meilleures dates moins chères si tes dates sont flexibles.\n",
+      "- Préparer un récapitulatif prêt à copier-coller dans un formulaire de réservation.\n",
+      "- Créer un rappel pour réserver à une heure précise.\n",
+      "\n",
+      "Que souhaites-tu que je fasse maintenant ?\n",
       "\n",
       "=== Test 3: Arguments invalides ===\n"
      ]
@@ -1460,17 +1537,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Vous avez utilisé des espaces réservés — je peux le faire, mais j’ai besoin des valeurs réelles.\n",
+      "Je peux le faire — j’ai juste besoin de précisions. Quel(s) élément(s) voulez-vous exactement ?\n",
       "\n",
-      "Remplacez :\n",
-      "- ????? par le nom de la ville (ex. Paris, Lyon, New York)\n",
-      "- @@@@ par l’unité de température : celsius ou fahrenheit\n",
+      "1) Ville (ou coordonnées) : ex. Paris, Lyon, Montréal  \n",
+      "2) Unité de température : \"celsius\" ou \"fahrenheit\"  \n",
+      "3) Type : météo actuelle ou prévision (et si prévision, pour quel jour/heure)  \n",
       "\n",
-      "Exemples de requêtes valides :\n",
-      "- Météo à Paris température en celsius\n",
-      "- Météo à New York température en fahrenheit\n",
+      "Exemples de message que je peux traiter immédiatement :  \n",
+      "- « Météo à Paris, température en celsius (actuelle) »  \n",
+      "- « Météo à New York, température en fahrenheit, prévision pour demain 14:00 »\n",
       "\n",
-      "Voulez-vous la météo actuelle ou une prévision (demain, 3 jours, 7 jours) ? Dites-moi la ville et l’unité, et je la récupère.\n"
+      "Donnez ces infos et j’affiche la météo.\n"
      ]
     }
    ],
@@ -1540,10 +1617,10 @@
    "id": "d1cd7aba",
    "metadata": {
     "papermill": {
-     "duration": 0.005236,
-     "end_time": "2026-06-24T09:53:15.104508",
+     "duration": 0.008561,
+     "end_time": "2026-08-17T09:28:08.577729",
      "exception": false,
-     "start_time": "2026-06-24T09:53:15.099272",
+     "start_time": "2026-08-17T09:28:08.569168",
      "status": "completed"
     },
     "tags": []
@@ -1572,10 +1649,10 @@
    "id": "16910de6",
    "metadata": {
     "papermill": {
-     "duration": 0.006194,
-     "end_time": "2026-06-24T09:53:15.116076",
+     "duration": 0.004394,
+     "end_time": "2026-08-17T09:28:08.588375",
      "exception": false,
-     "start_time": "2026-06-24T09:53:15.109882",
+     "start_time": "2026-08-17T09:28:08.583981",
      "status": "completed"
     },
     "tags": []
@@ -1596,20 +1673,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "id": "0a574db2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:53:15.129369Z",
-     "iopub.status.busy": "2026-06-24T09:53:15.129094Z",
-     "iopub.status.idle": "2026-06-24T09:53:15.134279Z",
-     "shell.execute_reply": "2026-06-24T09:53:15.133250Z"
+     "iopub.execute_input": "2026-08-17T09:28:08.599533Z",
+     "iopub.status.busy": "2026-08-17T09:28:08.599155Z",
+     "iopub.status.idle": "2026-08-17T09:28:08.602872Z",
+     "shell.execute_reply": "2026-08-17T09:28:08.602012Z"
     },
     "papermill": {
-     "duration": 0.013377,
-     "end_time": "2026-06-24T09:53:15.135368",
+     "duration": 0.011283,
+     "end_time": "2026-08-17T09:28:08.604103",
      "exception": false,
-     "start_time": "2026-06-24T09:53:15.121991",
+     "start_time": "2026-08-17T09:28:08.592820",
      "status": "completed"
     },
     "tags": []
@@ -1659,10 +1736,10 @@
    "id": "067f0c4d",
    "metadata": {
     "papermill": {
-     "duration": 0.005428,
-     "end_time": "2026-06-24T09:53:15.146305",
+     "duration": 0.003992,
+     "end_time": "2026-08-17T09:28:08.615483",
      "exception": false,
-     "start_time": "2026-06-24T09:53:15.140877",
+     "start_time": "2026-08-17T09:28:08.611491",
      "status": "completed"
     },
     "tags": []
@@ -1678,20 +1755,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "id": "a1e18713",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:53:15.159573Z",
-     "iopub.status.busy": "2026-06-24T09:53:15.159262Z",
-     "iopub.status.idle": "2026-06-24T09:53:23.053489Z",
-     "shell.execute_reply": "2026-06-24T09:53:23.052933Z"
+     "iopub.execute_input": "2026-08-17T09:28:08.625835Z",
+     "iopub.status.busy": "2026-08-17T09:28:08.625177Z",
+     "iopub.status.idle": "2026-08-17T09:28:15.120648Z",
+     "shell.execute_reply": "2026-08-17T09:28:15.119502Z"
     },
     "papermill": {
-     "duration": 7.902813,
-     "end_time": "2026-06-24T09:53:23.054605",
+     "duration": 6.501909,
+     "end_time": "2026-08-17T09:28:15.122118",
      "exception": false,
-     "start_time": "2026-06-24T09:53:15.151792",
+     "start_time": "2026-08-17T09:28:08.620209",
      "status": "completed"
     },
     "tags": []
@@ -1709,24 +1786,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Voici les cours de Machine Learning de plus de 20 heures que j’ai trouvés :\n",
+      "Voici les cours de Machine Learning de plus de 20 heures trouvés (2) :\n",
       "\n",
-      "1. Deep Learning Avancé  \n",
-      "   - ID : 3  \n",
-      "   - Durée : 30 heures  \n",
-      "   - Niveau : Avancé  \n",
-      "   - Prix : 299 €\n",
+      "- Deep Learning Avancé  \n",
+      "  - ID : 3  \n",
+      "  - Durée : 30 heures  \n",
+      "  - Niveau : Avancé  \n",
+      "  - Prix : 299 €\n",
       "\n",
-      "2. Computer Vision  \n",
-      "   - ID : 5  \n",
-      "   - Durée : 25 heures  \n",
-      "   - Niveau : Avancé  \n",
-      "   - Prix : 349 €\n",
+      "- Computer Vision  \n",
+      "  - ID : 5  \n",
+      "  - Durée : 25 heures  \n",
+      "  - Niveau : Avancé  \n",
+      "  - Prix : 349 €\n",
       "\n",
-      "Souhaitez-vous que je :  \n",
-      "- vous inscrive à un de ces cours (lequel ?),  \n",
-      "- affiche le programme détaillé / les prérequis,  \n",
-      "- filtre par prix ou niveau ?\n"
+      "Souhaitez-vous voir le programme détaillé d’un de ces cours, vous inscrire, ou filtrer par prix/niveau ?\n"
      ]
     }
    ],
@@ -1786,10 +1860,10 @@
    "id": "748f5d6c",
    "metadata": {
     "papermill": {
-     "duration": 0.005539,
-     "end_time": "2026-06-24T09:53:23.066127",
+     "duration": 0.007991,
+     "end_time": "2026-08-17T09:28:15.138501",
      "exception": false,
-     "start_time": "2026-06-24T09:53:23.060588",
+     "start_time": "2026-08-17T09:28:15.130510",
      "status": "completed"
     },
     "tags": []
@@ -1816,10 +1890,10 @@
    "id": "d2bedbef",
    "metadata": {
     "papermill": {
-     "duration": 0.005564,
-     "end_time": "2026-06-24T09:53:23.077065",
+     "duration": 0.007733,
+     "end_time": "2026-08-17T09:28:15.153983",
      "exception": false,
-     "start_time": "2026-06-24T09:53:23.071501",
+     "start_time": "2026-08-17T09:28:15.146250",
      "status": "completed"
     },
     "tags": []
@@ -1832,20 +1906,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "d0b3ccbe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:53:23.091733Z",
-     "iopub.status.busy": "2026-06-24T09:53:23.091431Z",
-     "iopub.status.idle": "2026-06-24T09:53:40.771290Z",
-     "shell.execute_reply": "2026-06-24T09:53:40.769969Z"
+     "iopub.execute_input": "2026-08-17T09:28:15.169772Z",
+     "iopub.status.busy": "2026-08-17T09:28:15.169525Z",
+     "iopub.status.idle": "2026-08-17T09:28:40.276255Z",
+     "shell.execute_reply": "2026-08-17T09:28:40.275164Z"
     },
     "papermill": {
-     "duration": 17.689795,
-     "end_time": "2026-06-24T09:53:40.773165",
+     "duration": 25.116536,
+     "end_time": "2026-08-17T09:28:40.277408",
      "exception": false,
-     "start_time": "2026-06-24T09:53:23.083370",
+     "start_time": "2026-08-17T09:28:15.160872",
      "status": "completed"
     },
     "tags": []
@@ -1866,41 +1940,53 @@
      "text": [
       "\n",
       "Résultat:\n",
-      "Voici une proposition de journée pour demain en partant de réveil 7h, sport 8h, travail 9h. J’ai inclus durées et petites astuces — dites-moi si vous voulez que j’ajuste selon votre trajet, horaire de fin de travail, ou préférences.\n",
+      "Voici une proposition de planning pour demain, basée sur réveil à 7h, sport à 8h et début du travail à 9h. Je propose aussi 3 variantes selon la durée de ton entraînement (30 / 45 / 60 min) — choisis celle qui te convient ou dis-moi la durée exacte et je l’ajuste.\n",
       "\n",
-      "Proposition d’emploi du temps\n",
-      "- 07:00 — Réveil : verre d’eau, 2 min d’étirements, allumer la lumière pour bien se réveiller.\n",
-      "- 07:00–07:20 — Routine matinale courte : toilette rapide / brossage des dents / habillage.\n",
-      "- 07:20–07:40 — Petit-déjeuner léger et énergie (ex. bol de flocons + fruit, ou yaourt + banane) + préparation du sac.\n",
-      "- 07:40–07:55 — Préparation/trajectoire vers le lieu du sport ou échauffement à la maison.\n",
-      "- 08:00–08:45 (ou 08:00–09:00 selon votre séance) — Séance de sport.\n",
-      "- 08:45–09:00 — Retour / cool-down / douche rapide / changement (si votre travail est à distance, 10–15 min suffisent souvent).\n",
-      "- 09:00 — Début du travail : 5–15 min pour regarder rapidement les mails et définir 3 priorités de la matinée.\n",
+      "Variante A — entraînement 30 min\n",
+      "- 07:00 — Réveil : hydratation, 1–2 min d’étirements doux, faire le lit\n",
+      "- 07:05–07:25 — Routine matinale : toilette rapide, habillage\n",
+      "- 07:25–07:40 — Petit-déjeuner rapide / café\n",
+      "- 07:40–07:55 — Préparation / vérifier sac / trajet\n",
+      "- 08:00–08:30 — Sport (30 min)\n",
+      "- 08:30–08:45 — Douche rapide + se préparer pour la journée\n",
+      "- 08:45–09:00 — Derniers préparatifs / courte méditation ou plan de la journée\n",
+      "- 09:00 — Début du travail\n",
       "\n",
-      "Exemple d’après-midi productif (ajustable)\n",
-      "- 09:15–11:00 — Bloc de deep work 1 (tâche prioritaire).\n",
-      "- 11:00–11:15 — Pause courte (marche, boire de l’eau).\n",
-      "- 11:15–12:30 — Suite / réunions courtes.\n",
-      "- 12:30–13:30 — Déjeuner et pause réelle (éviter écran).\n",
-      "- 13:30–15:30 — Bloc de deep work 2.\n",
-      "- 15:30–15:45 — Pause goûter / étirements.\n",
-      "- 15:45–17:30 — Réponses aux mails, réunions, tâches administratives.\n",
-      "- 17:30–18:00 — Récap de la journée + planification des 3 tâches du lendemain.\n",
+      "Variante B — entraînement 45 min (recommandée si tu veux un peu plus)\n",
+      "- 07:00 — Réveil\n",
+      "- 07:00–07:20 — Routine matinale (hydrater, étirements, faire le lit)\n",
+      "- 07:20–07:35 — Petit-déjeuner\n",
+      "- 07:35–07:50 — Préparation / trajet\n",
+      "- 08:00–08:45 — Sport (45 min)\n",
+      "- 08:45–09:00 — Douche rapide + préparation\n",
+      "- 09:00 — Début du travail\n",
       "\n",
-      "Soirée (suggestion)\n",
-      "- 18:00–19:30 — Temps libre / repas / activités sociales.\n",
-      "- 19:30–21:00 — Temps personnel (lecture, hobby, préparation douce pour le lendemain).\n",
-      "- 21:00–22:30 — Routine de coucher : déconnexion progressive, écran réduit, préparation des affaires du matin.\n",
-      "- 22:30 — Coucher (ajustez selon votre besoin de sommeil).\n",
+      "Variante C — entraînement 60 min\n",
+      "- 07:00 — Réveil\n",
+      "- 07:00–07:15 — Routine matinale légère\n",
+      "- 07:15–07:35 — Petit-déjeuner (quelque chose d’énergétique)\n",
+      "- 07:35–07:50 — Préparation / départ\n",
+      "- 08:00–09:00 — Sport (60 min)\n",
+      "- 09:00–09:15 — Douche rapide / finir de se préparer (si possible 15 min)\n",
+      "- 09:15 — Début du travail (si ton travail doit absolument commencer à 9h, prends plutôt A ou B)\n",
       "\n",
-      "Conseils pratiques\n",
-      "- Si vous avez un trajet jusqu’au travail, prévoyez 10–30 min supplémentaires entre sport et début de travail selon la distance.\n",
-      "- Limitez la consultation d’emails le matin: 10–15 min suffisent pour prioriser, puis bloc de concentration.\n",
-      "- Utilisez la méthode Pomodoro (25/5) pour garder l’énergie sur les blocs de deep work.\n",
-      "- Préparez votre tenue et sac la veille pour gagner du temps le matin.\n",
-      "- Hydratation et petite collation post-sport (banane, yaourt) pour éviter la baisse d’énergie.\n",
+      "Suggestions pour la journée de travail\n",
+      "- Pause courte 5–10 min toutes les 60–90 min pour étirer/relaxer les yeux\n",
+      "- Pause déjeuner ~12:30–13:30 (ou selon ton horaire)\n",
+      "- Bloque 15–30 min en fin de matinée ou d’après-midi pour organiser les tâches importantes\n",
       "\n",
-      "Souhaitez-vous que je crée des rappels pour le réveil, la séance de sport et le début du travail (avec heure et priorité) ? Si oui, précisez la priorité ou je les crée en priorité “normale”. Vous voulez aussi que je tienne compte d’un trajet ou d’une heure de fin de travail ?\n"
+      "Soir (exemple)\n",
+      "- 17:30–18:30 — Fin du travail / trajet / décompression\n",
+      "- 19:00 — Dîner\n",
+      "- 20:00–21:30 — Temps libre / tâches personnelles / lecture\n",
+      "- 22:30 — Préparation au coucher\n",
+      "- 23:00 — Coucher (ajuste selon ton besoin de sommeil)\n",
+      "\n",
+      "Veux-tu que je :\n",
+      "1) crée des rappels pour réveil, sport et début du travail ? Si oui, pour quelles heures et avec quelle priorité ?\n",
+      "2) adapte le planning selon la durée exacte du sport, ton temps de trajet, ou ton heure de fin de travail ?\n",
+      "\n",
+      "Dis-moi quelle variante tu préfères (A/B/C) et si tu veux que je programme les rappels.\n"
      ]
     }
    ],
@@ -1921,10 +2007,10 @@
    "id": "4ad3741e",
    "metadata": {
     "papermill": {
-     "duration": 0.004933,
-     "end_time": "2026-06-24T09:53:40.785775",
+     "duration": 0.004657,
+     "end_time": "2026-08-17T09:28:40.287096",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.780842",
+     "start_time": "2026-08-17T09:28:40.282439",
      "status": "completed"
     },
     "tags": []
@@ -1952,10 +2038,10 @@
    "id": "a42f73fc",
    "metadata": {
     "papermill": {
-     "duration": 0.004783,
-     "end_time": "2026-06-24T09:53:40.794372",
+     "duration": 0.008543,
+     "end_time": "2026-08-17T09:28:40.301040",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.789589",
+     "start_time": "2026-08-17T09:28:40.292497",
      "status": "completed"
     },
     "tags": []
@@ -1976,20 +2062,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "53225242",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:53:40.805166Z",
-     "iopub.status.busy": "2026-06-24T09:53:40.804893Z",
-     "iopub.status.idle": "2026-06-24T09:53:40.809441Z",
-     "shell.execute_reply": "2026-06-24T09:53:40.808734Z"
+     "iopub.execute_input": "2026-08-17T09:28:40.319873Z",
+     "iopub.status.busy": "2026-08-17T09:28:40.319257Z",
+     "iopub.status.idle": "2026-08-17T09:28:40.324812Z",
+     "shell.execute_reply": "2026-08-17T09:28:40.323907Z"
     },
     "papermill": {
-     "duration": 0.011565,
-     "end_time": "2026-06-24T09:53:40.810717",
+     "duration": 0.017496,
+     "end_time": "2026-08-17T09:28:40.326709",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.799152",
+     "start_time": "2026-08-17T09:28:40.309213",
      "status": "completed"
     },
     "tags": []
@@ -2040,10 +2126,10 @@
    "id": "f14376f5",
    "metadata": {
     "papermill": {
-     "duration": 0.005083,
-     "end_time": "2026-06-24T09:53:40.820604",
+     "duration": 0.007614,
+     "end_time": "2026-08-17T09:28:40.340508",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.815521",
+     "start_time": "2026-08-17T09:28:40.332894",
      "status": "completed"
     },
     "tags": []
@@ -2091,20 +2177,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "7febbfbb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:53:40.832224Z",
-     "iopub.status.busy": "2026-06-24T09:53:40.832014Z",
-     "iopub.status.idle": "2026-06-24T09:53:40.835956Z",
-     "shell.execute_reply": "2026-06-24T09:53:40.835429Z"
+     "iopub.execute_input": "2026-08-17T09:28:40.356879Z",
+     "iopub.status.busy": "2026-08-17T09:28:40.356580Z",
+     "iopub.status.idle": "2026-08-17T09:28:40.360154Z",
+     "shell.execute_reply": "2026-08-17T09:28:40.359655Z"
     },
     "papermill": {
-     "duration": 0.010704,
-     "end_time": "2026-06-24T09:53:40.836745",
+     "duration": 0.01323,
+     "end_time": "2026-08-17T09:28:40.361396",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.826041",
+     "start_time": "2026-08-17T09:28:40.348166",
      "status": "completed"
     },
     "tags": []
@@ -2132,10 +2218,10 @@
    "id": "362ff050",
    "metadata": {
     "papermill": {
-     "duration": 0.004135,
-     "end_time": "2026-06-24T09:53:40.845540",
+     "duration": 0.007516,
+     "end_time": "2026-08-17T09:28:40.376753",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.841405",
+     "start_time": "2026-08-17T09:28:40.369237",
      "status": "completed"
     },
     "tags": []
@@ -2160,10 +2246,10 @@
    "id": "jrf33gd4drb",
    "metadata": {
     "papermill": {
-     "duration": 0.004386,
-     "end_time": "2026-06-24T09:53:40.854192",
+     "duration": 0.007434,
+     "end_time": "2026-08-17T09:28:40.392211",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.849806",
+     "start_time": "2026-08-17T09:28:40.384777",
      "status": "completed"
     },
     "tags": []
@@ -2198,20 +2284,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "618da34f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:53:40.864125Z",
-     "iopub.status.busy": "2026-06-24T09:53:40.863917Z",
-     "iopub.status.idle": "2026-06-24T09:53:40.868977Z",
-     "shell.execute_reply": "2026-06-24T09:53:40.868407Z"
+     "iopub.execute_input": "2026-08-17T09:28:40.404804Z",
+     "iopub.status.busy": "2026-08-17T09:28:40.404022Z",
+     "iopub.status.idle": "2026-08-17T09:28:40.409510Z",
+     "shell.execute_reply": "2026-08-17T09:28:40.409117Z"
     },
     "papermill": {
-     "duration": 0.01126,
-     "end_time": "2026-06-24T09:53:40.869864",
+     "duration": 0.012972,
+     "end_time": "2026-08-17T09:28:40.410508",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.858604",
+     "start_time": "2026-08-17T09:28:40.397536",
      "status": "completed"
     },
     "tags": []
@@ -2291,20 +2377,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "wkuuzdfnn1p",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:53:40.879549Z",
-     "iopub.status.busy": "2026-06-24T09:53:40.879357Z",
-     "iopub.status.idle": "2026-06-24T09:53:40.885850Z",
-     "shell.execute_reply": "2026-06-24T09:53:40.885015Z"
+     "iopub.execute_input": "2026-08-17T09:28:40.421795Z",
+     "iopub.status.busy": "2026-08-17T09:28:40.421344Z",
+     "iopub.status.idle": "2026-08-17T09:28:40.427378Z",
+     "shell.execute_reply": "2026-08-17T09:28:40.426928Z"
     },
     "papermill": {
-     "duration": 0.012383,
-     "end_time": "2026-06-24T09:53:40.886655",
+     "duration": 0.012359,
+     "end_time": "2026-08-17T09:28:40.428093",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.874272",
+     "start_time": "2026-08-17T09:28:40.415734",
      "status": "completed"
     },
     "tags": []
@@ -2376,10 +2462,10 @@
    "id": "ur2hgay78t",
    "metadata": {
     "papermill": {
-     "duration": 0.004969,
-     "end_time": "2026-06-24T09:53:40.896413",
+     "duration": 0.004502,
+     "end_time": "2026-08-17T09:28:40.437329",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.891444",
+     "start_time": "2026-08-17T09:28:40.432827",
      "status": "completed"
     },
     "tags": []
@@ -2390,20 +2476,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "wa91f7filva",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:53:40.906263Z",
-     "iopub.status.busy": "2026-06-24T09:53:40.906034Z",
-     "iopub.status.idle": "2026-06-24T09:54:07.698954Z",
-     "shell.execute_reply": "2026-06-24T09:54:07.697954Z"
+     "iopub.execute_input": "2026-08-17T09:28:40.448268Z",
+     "iopub.status.busy": "2026-08-17T09:28:40.448057Z",
+     "iopub.status.idle": "2026-08-17T09:29:09.288270Z",
+     "shell.execute_reply": "2026-08-17T09:29:09.287634Z"
     },
     "papermill": {
-     "duration": 26.800046,
-     "end_time": "2026-06-24T09:54:07.701133",
+     "duration": 28.846525,
+     "end_time": "2026-08-17T09:29:09.289181",
      "exception": false,
-     "start_time": "2026-06-24T09:53:40.901087",
+     "start_time": "2026-08-17T09:28:40.442656",
      "status": "completed"
     },
     "tags": []
@@ -2438,25 +2524,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "  Appel: get_travel_time({'origin': 'Part-Dieu', 'destination': 'Salle 300', 'transport': 'transports'})\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Appel: get_travel_time({'origin': 'Part-Dieu', 'destination': 'Musée des Beaux-Arts', 'transport': 'transports'})\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\n",
       "Résultat final:\n",
-      "Parfait — voici une proposition simple et prête à organiser :\n",
+      "Parfait — je peux m’occuper de ça. Voici ce que je propose d’emblée, à partir des infos disponibles :\n",
       "\n",
-      "1) Événement ce soir vers 19h\n",
-      "- Spectacle recommandé : \"Nuits de la Peur\" au Théâtre de la Croix-Rousse, début 19:00, tarif ~15€.\n",
-      "- Départ depuis Part‑Dieu → trajet en transports en commun estimé : ~15 min.\n",
-      "- Conseil pratique : prévoir de partir vers 18:20–18:30 pour être large (temps pour ticket, montée éventuelle, trouver sa place).\n",
+      "Événements ce soir (Lyon)\n",
+      "- \"Nuits de la Peur\" — Théâtre de la Croix‑Rousse — 19:00 — 15€.  \n",
+      "  Temps de trajet estimé depuis Part‑Dieu : ~15 min en transports en commun.\n",
+      "- Alternative : Concert Jazz — Salle 300 — 20:30 — 25€. (Si vous vouliez quelque chose plutôt un peu plus tard.)\n",
+      "- L'expo au Musée des Beaux‑Arts ferme à 18:00 donc elle n'est pas possible ce soir à 19h.\n",
       "\n",
-      "2) Dîner italien pas cher après le spectacle\n",
-      "- Estimation de timing : si le spectacle dure ~1h30, vous pourriez viser une table vers 21:00–21:30. Pour un spectacle plus court/long, je peux adapter l’horaire.\n",
-      "- Budget indicatif : plats italiens/pizzas abordables généralement entre 10€ et 20€ par personne.\n",
-      "- Où : voulez-vous un restaurant proche du Théâtre de la Croix‑Rousse (pour marcher après le spectacle) ou plutôt proche de la Part‑Dieu (si vous préférez retourner vers la gare) ?\n",
+      "Avant que je cherche et réserve un restaurant italien bon marché, quelques questions rapides pour ajuster la recherche :\n",
+      "1) Quel spectacle choisissez‑vous (Nuits de la Peur à 19:00 ou le Concert Jazz à 20:30) ?  \n",
+      "2) Préférence pour le resto : proche du théâtre (Croix‑Rousse) pour y aller après le spectacle, ou plutôt proche de la Part‑Dieu (retour facile) ?  \n",
+      "3) Pour combien de personnes et à quelle heure voulez‑vous dîner (immédiatement après le spectacle ou avant) ?  \n",
+      "4) Voulez‑vous que je réserve la table pour vous ? Si oui, indiquez les demandes spéciales (terrasse, calme, végétarien, etc.).  \n",
+      "5) Budget approximatif par personne (ex. <15€, 15–25€) ?\n",
       "\n",
-      "Je peux :\n",
-      "- Chercher et vous proposer 2–3 restaurants italiens bon marché près du lieu choisi, avec adresses et temps de trajet, ou\n",
-      "- Réserver directement une table (si oui, dites-moi : nombre de personnes, heure souhaitée et toute demande particulière).\n",
-      "\n",
-      "Que préférez-vous ?\n"
+      "Dites‑moi vos choix et je lance la recherche / réservation.\n"
      ]
     }
    ],
@@ -2489,10 +2588,10 @@
    "id": "oh5p3m1wfhd",
    "metadata": {
     "papermill": {
-     "duration": 0.004454,
-     "end_time": "2026-06-24T09:54:07.712429",
+     "duration": 0.005166,
+     "end_time": "2026-08-17T09:29:09.299428",
      "exception": false,
-     "start_time": "2026-06-24T09:54:07.707975",
+     "start_time": "2026-08-17T09:29:09.294262",
      "status": "completed"
     },
     "tags": []
@@ -2526,10 +2625,10 @@
    "id": "rx6verosmb",
    "metadata": {
     "papermill": {
-     "duration": 0.005748,
-     "end_time": "2026-06-24T09:54:07.723559",
+     "duration": 0.004857,
+     "end_time": "2026-08-17T09:29:09.309304",
      "exception": false,
-     "start_time": "2026-06-24T09:54:07.717811",
+     "start_time": "2026-08-17T09:29:09.304447",
      "status": "completed"
     },
     "tags": []
@@ -2604,20 +2703,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "vgvqp2b6vjn",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T09:54:07.736531Z",
-     "iopub.status.busy": "2026-06-24T09:54:07.736106Z",
-     "iopub.status.idle": "2026-06-24T09:54:07.740868Z",
-     "shell.execute_reply": "2026-06-24T09:54:07.739611Z"
+     "iopub.execute_input": "2026-08-17T09:29:09.320633Z",
+     "iopub.status.busy": "2026-08-17T09:29:09.320239Z",
+     "iopub.status.idle": "2026-08-17T09:29:09.323886Z",
+     "shell.execute_reply": "2026-08-17T09:29:09.323115Z"
     },
     "papermill": {
-     "duration": 0.01249,
-     "end_time": "2026-06-24T09:54:07.741886",
+     "duration": 0.010414,
+     "end_time": "2026-08-17T09:29:09.324718",
      "exception": false,
-     "start_time": "2026-06-24T09:54:07.729396",
+     "start_time": "2026-08-17T09:29:09.314304",
      "status": "completed"
     },
     "tags": []
@@ -2659,6 +2758,22 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "openai",
+   "api_usd_est": 0.04,
+   "cpu_min": 5,
+   "external_account": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
+   "gpu_required": false,
+   "metadata_written": "2026-07-23",
+   "network": true,
+   "notes": "~6 appels gpt-5-mini avec function calling (tokens supplementaires pour le schema d'outils).",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -2678,31 +2793,17 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 122.934204,
-   "end_time": "2026-06-24T09:54:08.194799",
+   "duration": 119.099921,
+   "end_time": "2026-08-17T09:29:09.778516",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-24T09:52:05.260595",
+   "input_path": "D:\\Dev\\CoursIA-11112-texte4\\MyIA.AI.Notebooks\\GenAI\\Texte\\4_Function_Calling.ipynb",
+   "output_path": "D:\\Dev\\CoursIA-11112-texte4\\MyIA.AI.Notebooks\\GenAI\\Texte\\4_Function_Calling_output.ipynb",
+   "parameters": {
+    "BATCH_MODE": "true"
+   },
+   "start_time": "2026-08-17T09:27:10.678595",
    "version": "2.7.0"
-  },
-  "cost": {
-   "api_usd_est": 0.04,
-   "api_provider": "openai",
-   "cpu_min": 5,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": true,
-   "external_account": "openai",
-   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
-   "reduced_pedagogical": null,
-   "reproducibility": "MED",
-   "metadata_written": "2026-07-23",
-   "validator": "manual",
-   "notes": "~6 appels gpt-5-mini avec function calling (tokens supplementaires pour le schema d'outils)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: MED/tooling #11436

See #11112 (contribution partielle — l'epic reste ouverte).

## Problème

`MyIA.AI.Notebooks/GenAI/Texte/4_Function_Calling.ipynb` portait une séquence `execution_count` **non monotone** `[1..8, 1, 1, 9..19]` : les cellules d'exercice (22/24) avaient été relancées isolément à `ec=1` après le corps du notebook, et l'exemple corrigé étudiant se terminait en 16..19 — aucune session unique. Violation #11112 (les gates H.1/H.3 vérifient l'existence des compteurs, pas leur cohérence).

## Fix

Re-execution end-to-end (papermill, kernel python3, **121 s**) :

- **Séquence CLEAN 1..22** (vérifié : `counts == list(range(1, N+1))`, 0 `null`, 0 erreur).
- **Appels API OpenAI réels** (gpt-5-mini, clé injectée via `--env`, BATCH_MODE=false) : `finish_reason=tool_calls` (premier appel météo), boucle agentique Lyon → `get_weather({'location': 'Lyon', 'unit': 'celsius'})` + réponse 22°C, `tool_choice` forcé → `get_weather` sur "Bonjour", gestion d'erreurs fallback Berlin.
- Cellule Parameters papermill injectée en tête (`BATCH_MODE = "true"`) — pattern déjà committé par 11/12 dans #11398.
- **Sources byte-identiques** à origin/main hors renum des compteurs (vérifié par comparaison JSON des 52 cellules, type + source hors `\r`).
- EOL normalisé LF (0 CR).

## Validation

```
notebook_tools.py validate: OK — 0 warning, 0 erreur
0 error output, 0 execution_count null, 0 pattern interdit
git diff --cached: 1 ligne "source" (cellule Parameters ajoutée), reste = outputs régénérés
```

Aucun autre fichier touché (0 catalogue, 0 README).