### PR TITLE
fix(prover,#11421): garde d'egalite vtc=0 sur le chemin multi (moitie symetrique de FX-8)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/decomposition_regression.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-__all__ = ["is_decomposition_regression"]
+__all__ = ["is_decomposition_regression", "is_same_count_zero_verified"]
 
 
 def is_decomposition_regression(
@@ -60,3 +60,26 @@ def is_decomposition_regression(
     if verified_tactic_count is None:
         return False
     return final_sorry > original_sorry_count and verified_tactic_count == 0
+
+
+def is_same_count_zero_verified(
+    final_sorry: int,
+    original_sorry_count: int,
+    verified_tactic_count: Optional[int],
+) -> bool:
+    """Return True iff a kept SAME-COUNT snapshot has zero build-verified
+    tactics (the #11421 symmetry gap of P3).
+
+    P3 closes the net-INCREASE case (``final > original``, see
+    :func:`is_decomposition_regression`). The multi-agent path also sets
+    ``structural_progress = True`` for a kept snapshot where ``final ==
+    original`` (provers.py:890-898: a build-passing snapshot different from
+    the original). With ``verified_tactic_count == 0`` that snapshot is text
+    churn the agent edited without proving anything -- a "decomposition"
+    with no verified sub-goal is not structural progress. Same semantics as
+    P3: ``None`` vtc (legacy caller) returns ``False`` -- cannot classify,
+    preserve prior behaviour rather than guess.
+    """
+    if verified_tactic_count is None:
+        return False
+    return final_sorry == original_sorry_count and verified_tactic_count == 0

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -17,7 +17,10 @@ from agent_framework import ToolResultCompactionStrategy
 from .trace import TraceLogger
 from .state import ProofState, SorryContext, ProofPhase, PHASE_TRANSITIONS, TacticAttempt
 from .p4_final_verify import _evaluate_final_verify
-from .decomposition_regression import is_decomposition_regression
+from .decomposition_regression import (
+    is_decomposition_regression,
+    is_same_count_zero_verified,
+)
 from .lean_utils import (
     extract_sorry_block, get_goal_state, verify_sorry_replacement,
     extract_hypotheses, extract_local_lemmas, build_def_type_warnings,
@@ -1022,6 +1025,20 @@ class MultiAgentSorryProver:
                 f"  DECOMPOSITION_REGRESSION: sorry {original_sorry_count}"
                 f" -> {final_sorry} with 0 verified tactic. Net sorry growth"
                 f" unproven -- not structural progress (#7477 P3)."
+            )
+            structural_progress = False
+        # FX-8s (#11421): the equality case of the gap P3 closes. P3 demotes a
+        # net INCREASE with vtc=0; the structural_progress=True set at the
+        # kept-snapshot branch (:898) for final == original also requires at
+        # least one build-verified tactic. Same-count + vtc=0 = the agent
+        # churned text without proving anything -- not structure.
+        same_count_churn = is_same_count_zero_verified(
+            final_sorry, original_sorry_count, verified_tactic_count)
+        if same_count_churn:
+            print(
+                f"  SAME_COUNT_ZERO_VERIFIED: sorry {original_sorry_count}"
+                f" == {final_sorry} with 0 verified tactic -- snapshot kept"
+                f" without proof, not structural progress (#11421)."
             )
             structural_progress = False
         stmt_mutation = _stmt_mutation_guard(

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
@@ -42,6 +42,7 @@ _dr = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_dr)
 
 classify = _dr.is_decomposition_regression
+same_count_churn = _dr.is_same_count_zero_verified
 
 
 # ── Acceptance: the founder incident classifies as regression ──────────────
@@ -128,3 +129,36 @@ class TestLegacyAndContract:
         ``if result['decomposition_regression']``; it must be a real bool."""
         assert type(classify(8, 4, 0)) is bool
         assert type(classify(6, 4, 2)) is bool
+
+
+# ── #11421: same-count + vtc=0 symmetry guard ──────────────────────────────
+
+class TestSameCountZeroVerified:
+    """#11421: P3 covers the net-INCREASE case; a kept SAME-COUNT snapshot
+    (provers.py:890-898) also needs >= 1 verified tactic to count as
+    structural progress. final == original with vtc=0 is text churn."""
+
+    def test_same_count_zero_verified_flags_churn(self):
+        assert same_count_churn(4, 4, 0) is True
+
+    def test_same_count_with_verified_is_progress(self):
+        assert same_count_churn(4, 4, 1) is False
+        assert same_count_churn(4, 4, 3) is False
+
+    def test_increase_is_not_this_guards_territory(self):
+        """A net increase is P3's case, not this equality guard's."""
+        assert same_count_churn(8, 4, 0) is False
+
+    def test_drop_is_not_this_guards_territory(self):
+        """A drop is FX-6's territory (statement-mutation guard)."""
+        assert same_count_churn(2, 4, 0) is False
+
+    def test_none_verified_preserves_prior_behaviour(self):
+        """Legacy caller with no verified-tactic tracking: cannot classify."""
+        assert same_count_churn(4, 4, None) is False
+
+    def test_returns_real_bool(self):
+        assert type(same_count_churn(4, 4, 0)) is bool
+
+    def test_exported_in_all(self):
+        assert "is_same_count_zero_verified" in _dr.__all__


### PR DESCRIPTION
## Contexte

Issue #11421 (scope lu en entier) : le chemin **multi-agent** de `provers.py:890-898` pose `structural_progress = True` **sans garde `verified_tactic_count`** pour le cas d'égalité `final_sorry == original_sorry_count`. P3 couvre la hausse nette uniquement, FX-6 est orienté baisse, FX-8 vit dans `_classify` que ce chemin n'appelle pas. Résultat : `delta=0 ∧ vtc=0` + snapshot build-passing ≠ original → `success=True` sur un run qui n'a vérifié **aucune** tactique et n'a bougé **aucun** sorry.

## Fix (option 2 de l'acceptance)

Nouvelle fonction `is_same_count_zero_verified` dans `decomposition_regression.py` — même sémantique que P3 (`None → False` : caller legacy non classifiable) :

```python
def is_same_count_zero_verified(final_sorry, original_sorry_count, verified_tactic_count):
    if verified_tactic_count is None:
        return False
    return final_sorry == original_sorry_count and verified_tactic_count == 0
```

Câblée dans `provers.py` juste après le bloc P3 (`:1026`) — position exacte préconisée par l'issue (« ou juste après, comme P3 en `:1020` ») :

```python
same_count_churn = is_same_count_zero_verified(final_sorry, original_sorry_count, verified_tactic_count)
if same_count_churn:
    print(f"  SAME_COUNT_ZERO_VERIFIED: sorry {original_sorry_count} == {final_sorry} with 0 verified tactic -- snapshot kept without proof, not structural progress (#11421).")
    structural_progress = False
```

`structural_progress = False` → le `success` inline de `:1041` (`... or structural_progress`) rend `success = False` dans ce cas. La garde est **additive** : hors du cas `== ∧ vtc=0`, le comportement est strictement inchangé.

## Acceptance de l'issue

- [x] Le chemin multi applique la garde d'égalité (duplication explicite `not (vtc == 0 and final == original)`, comme P3 en `:1020`)
- [x] Test de régression sur le cas exact `delta=0 / vtc=0 / snapshot build-passing ≠ original` → `structural_progress=False` : `TestSameCountZeroVerified` (7 tests, dont `test_same_count_zero_verified_flags_churn` et `test_same_count_with_verified_is_progress`)
- [x] Re-classification a posteriori non requise (les traces sont un journal) — si `analyze_traces` est relancé, `HASHLIFE_P4_SUCC_MEMBERSHIP` et `multi_custom_HashlifeCorrectness_L2855` (les 2 traces `delta=0/vtc=0/success=True` du corps d'issue) basculent hors de `structural_only`
- [x] `lake build` inchangé : **0 fichier `.lean` modifié** (vérifié `git diff origin/main...HEAD --name-only | grep -c '\.lean$'` = 0)

## Preuves critère B (PR Lean)

1. **`grep -c sorry` avant/après** : 0 fichier `.lean` touché → comptes `sorry` inchangés par construction (diff stat : 3 fichiers Python + tests, +76/−2).
2. **Lake build SUCCESS** : **non applicable** — le patch ne touche aucun `.lean`, aucun import Mathlib modifié. L'acceptance de l'issue le dispense explicitement.
3. **Proof integrity** : non applicable (idem, aucun `.lean`).
4. **Justification de la modification du prover Python** : pas un refactor — c'est la **garde additive exigée par l'issue** (moitié symétrique de FX-8/#4909). Le comportement hors `== ∧ vtc=0` est byte-identique.

## Tests

```
670/670 tests verts (pytest tests/ -q depuis agent_tests/), y compris la nouvelle classe TestSameCountZeroVerified.
```

`Grain: MED/lean — lane myia-po-2026:CoursIA — prev: MED/lean #11380`

Closes #11421
