### PR TITLE
docs(sudoku,#9434): drain MACHINE-DEP timings from Sudoku-15-Infer-Csharp cell[24]+cell[42]

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
@@ -2406,23 +2406,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Interprétation : Performance du solver itératif sur les grilles faciles\n",
-    "\n",
-    "Le solver itératif resout avec succès les grilles faciles mais avec un temps nettement supérieur :\n",
-    "\n",
-    "| Aspect | Valeur observée | Analyse |\n",
-    "|--------|----------------|---------|\n",
-    "| Première résolution | ≈ 350 s (349,9 s mesurés) | Compilation initiale du modèle |\n",
-    "| Seconde résolution | ≈ 0,92 s (922 ms mesurés) | Modèle déjà compilé |\n",
-    "| Erreurs | 0 | Les solutions sont correctes |\n",
-    "| Itérations EP | 50 EP par fixation, ≈ 2150 au total (2 grilles) | Chaque fixation de cellule requiert 50 itérations EP |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. Le paramètre `NbIterationCells = 2` signifie qu'on fixe 2 cellules par itération\n",
-    "2. La première résolution inclut le temps de compilation du modèle (≈ 5,8 minutes)\n",
-    "3. Les résolutions subsequentes sont beaucoup plus rapides\n",
-    "\n",
-    "> **Note technique** : Le nombre important d'itérations EP (plusieurs centaines au total pour une grille facile) s'explique par la réexécution de l'algorithme après chaque fixation de cellule. Cette approche est coûteuse mais permet de propager les contraintes progressivement.\n"
+    "### Interprétation : Performance du solver itératif sur les grilles faciles\n\nLe solver itératif resout avec succès les grilles faciles mais avec un temps nettement supérieur :\n\n| Aspect | Analyse |\n|--------|---------|\n| Première résolution | Compilation initiale du modèle (non mesuré ici, machine-dépendant) |\n| Seconde résolution | Modèle déjà compilé (non mesuré ici, machine-dépendant) |\n| Erreurs | 0 | Les solutions sont correctes |\n| Itérations EP | 50 EP par fixation, ≈ 2150 au total (2 grilles) | Chaque fixation de cellule requiert 50 itérations EP |\n\n**Points clés** :\n1. Le paramètre `NbIterationCells = 2` signifie qu'on fixe 2 cellules par itération\n2. La première résolution inclut le temps de compilation du modèle (coût initial non négligeable, ordre de grandeur de quelques minutes sur cette machine)\n3. Les résolutions subsequentes sont beaucoup plus rapides\n\n> **Note méthodologique** : Les durées observées (350 s, 0,92 s) sont **machine-dépendantes** et ne sont pas retenues dans cette prose (mandat #9377/#9434 : seules les valeurs **reproductibles d'une exécution à l'autre** sont conservées ; les durées wall-clock sont drainées vers les cellules de mesure). Seuls les **comptes d'itérations EP** restent dans la table ci-dessus (2150 itérations pour 2 grilles).\n\n> **Note technique** : Le nombre important d'itérations EP (plusieurs centaines au total pour une grille facile) s'explique par la réexécution de l'algorithme après chaque fixation de cellule. Cette approche est coûteuse mais permet de propager les contraintes progressivement.\n"
    ]
   },
   {
@@ -29472,35 +29456,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
-    "\n",
-    "## Conclusion\n",
-    "\n",
-    "Ce notebook a exploré la **programmation probabiliste** appliquée au Sudoku via Infer.NET, en construisant quatre solveurs de complexité croissante.\n",
-    "\n",
-    "### Progression des solveurs (résultats vérifiés par ré-exécution, kernel `.net-csharp`)\n",
-    "\n",
-    "| Solveur | Principe | Easy (cellule test) | Medium (cellule test) | Temps caractéristique |\n",
-    "|---------|----------|---------------------|----------------------|----------------------|\n",
-    "| **Naïf** | Recompilation à chaque solve | 0 erreur (`a009c961` ec=5) | - | ~14-26 s (recompile à chaque grille, voir `a009c961`) |\n",
-    "| **Robuste** | Dirichlet + compilation unique | 0 erreur (`91759baa` ec=7) | **37 erreurs** (`ea382a18` ec=9) | ~100 ms par grille (après la compilation initiale) |\n",
-    "| **Itératif** | Ré-injection des cellules les plus confiantes | 0 erreur (`96b6b947` ec=11) | **3 erreurs** (`204c7e88` ec=12) | ~1,8 s |\n",
-    "| **Précompilé** | Roslyn DLL réutilisable | 0 erreur (re-exéc. po-2026) | **45 erreurs** (re-exéc. po-2026, stochastique) | ~18-112 ms |\n",
-    "\n",
-    "> **Note méthodologique** : les solveurs **résolvent les grilles Easy sans erreur**, mais **échouent partiellement sur Medium** : EP converge vers des optima locaux qui violent certaines contraintes all-différent (37 erreurs pour le Robuste, 3 pour l'Itératif sur la grille testée). Ce comportement est **stochastique** (dépendant du seed EP et de la grille tirée) et reflète une limite structurelle de l'inférence approximative pure, corrigée partiellement par la réinjection itérative des priors. Le solveur Précompilé est désormais **validé** (re-exécution po-2026 firsthand, `See #8287`) : la précompilation Roslyn fonctionne (DLL compilée puis chargée, aucune `MissingMethodException`), et le solveur se comporte comme les autres — 0 erreur sur Easy, échec stochastique sur Medium (45 erreurs sur la grille testée, même limite EP que le Robuste).\n",
-    "\n",
-    "### Leçons principales\n",
-    "\n",
-    "1. **L'inférence probabiliste (EP) résout les grilles Easy mais échoue partiellement sur Medium** : 0 erreur sur les grilles Easy pour les trois solveurs, mais 37 erreurs (Robuste) / 3 erreurs (Itératif) sur Medium. EP converge vers des optima locaux -- la garantie formelle d'une solution correcte reste le domaine des solveurs déterministes (CSP, SAT, MIP).\n",
-    "2. **L'approche itérative est plus stable** sur les grilles plus complexes grâce à la réinjection des priors (37 -> 3 erreurs), au prix d'un coût computationnel plus élevé (~1,8 s, nombreuses itérations EP).\n",
-    "3. **La précompilation Roslyn** élimine le coût de compilation initial (~30-60 s du solveur naïf) en chargeant directement la DLL compilée : validée (solve en ~18-112 ms après chargement, `See #8287`), avec les mêmes limites EP stochastiques sur Medium que les solveurs recompilés.\n",
-    "4. **Les solveurs déterministes (CSP, SAT, MIP)** des notebooks précédents restent supérieurs en termes de garantie : un hybride probabiliste + propagation de contraintes est la voie prometteuse explorée en exercice.\n",
-    "\n",
-    "### Liens avec les autres approches\n",
-    "\n",
-    "- Les solveurs CSP (Sudoku-10 OR-Tools, Sudoku-11 Choco) garantissent la solution mais sans modélisation probabiliste.\n",
-    "- Z3 (Sudoku-12) offre la vérification formelle la plus robuste.\n",
-    "- L'approche hybride probabiliste + contraintes est explorée dans les exercices de ce notebook.\n"
+    "---\n\n## Conclusion\n\nCe notebook a exploré la **programmation probabiliste** appliquée au Sudoku via Infer.NET, en construisant quatre solveurs de complexité croissante.\n\n### Progression des solveurs (résultats vérifiés par ré-exécution, kernel `.net-csharp`)\n\n| Solveur | Principe | Easy (cellule test) | Medium (cellule test) |\n|---------|----------|---------------------|----------------------|\n| **Naïf** | Recompilation à chaque solve | 0 erreur (`a009c961` ec=5) | - |\n| **Robuste** | Dirichlet + compilation unique | 0 erreur (`91759baa` ec=7) | **37 erreurs** (`ea382a18` ec=9) |\n| **Itératif** | Ré-injection des cellules les plus confiantes | 0 erreur (`96b6b947` ec=11) | **3 erreurs** (`204c7e88` ec=12) |\n| **Précompilé** | Roslyn DLL réutilisable | 0 erreur (re-exéc. po-2026) | **45 erreurs** (re-exéc. po-2026, stochastique) |\n\n> **Note méthodologique (timings retirés)** : Les durées caractéristiques (`~14-26 s`, `~100 ms`, `~1,8 s`, `~18-112 ms`) étaient **machine-dépendantes** et ont été drainées de la table ci-dessus (mandat #9377/#9434). Seuls les **principes algorithmiques** et les **comptes d'erreurs reproductibles** sont retenus ; les coûts wall-clock exacts restent dans les cellules de mesure de chaque solveur. La précompilation Roslyn (`See #8287`) reste qualitativement plus rapide que la recompilation naïve, mais le ratio est machine-dépendant.\n\n> **Note méthodologique** : les solveurs **résolvent les grilles Easy sans erreur**, mais **échouent partiellement sur Medium** : EP converge vers des optima locaux qui violent certaines contraintes all-différent (37 erreurs pour le Robuste, 3 pour l'Itératif sur la grille testée). Ce comportement est **stochastique** (dépendant du seed EP et de la grille tirée) et reflète une limite structurelle de l'inférence approximative pure, corrigée partiellement par la réinjection itérative des priors. Le solveur Précompilé est désormais **validé** (re-exécution po-2026 firsthand, `See #8287`) : la précompilation Roslyn fonctionne (DLL compilée puis chargée, aucune `MissingMethodException`), et le solveur se comporte comme les autres — 0 erreur sur Easy, échec stochastique sur Medium (45 erreurs sur la grille testée, même limite EP que le Robuste).\n\n### Leçons principales\n\n1. **L'inférence probabiliste (EP) résout les grilles Easy mais échoue partiellement sur Medium** : 0 erreur sur les grilles Easy pour les trois solveurs, mais 37 erreurs (Robuste) / 3 erreurs (Itératif) sur Medium. EP converge vers des optima locaux -- la garantie formelle d'une solution correcte reste le domaine des solveurs déterministes (CSP, SAT, MIP).\n2. **L'approche itérative est plus stable** sur les grilles plus complexes grâce à la réinjection des priors (37 -> 3 erreurs), au prix d'un coût computationnel plus élevé (machine-dépendant, nombreuses itérations EP).\n3. **La précompilation Roslyn** élimine le coût de compilation initial du solveur naïf (gain machine-dépendant) en chargeant directement la DLL compilée : validée (solve en temps court après chargement, `See #8287`), avec les mêmes limites EP stochastiques sur Medium que les solveurs recompilés.\n4. **Les solveurs déterministes (CSP, SAT, MIP)** des notebooks précédents restent supérieurs en termes de garantie : un hybride probabiliste + propagation de contraintes est la voie prometteuse explorée en exercice.\n\n### Liens avec les autres approches\n\n- Les solveurs CSP (Sudoku-10 OR-Tools, Sudoku-11 Choco) garantissent la solution mais sans modélisation probabiliste.\n- Z3 (Sudoku-12) offre la vérification formelle la plus robuste.\n- L'approche hybride probabiliste + contraintes est explorée dans les exercices de ce notebook.\n"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
@@ -26,7 +26,14 @@
       csharp_sha: 67a9e214e7cdff686215e7f494bf30d151b0cca1
       content_python_sha: b1ee07eca7b6504fa3398ce9263e423c29407bf8770c9601269869b5eba30e87
       content_csharp_sha: 4e52d4b51759f726c4e932eefc742f05d8a37f508bc982f758db7fb1dd06a1ba
+    - date: "2026-08-17"
+      by: myia-po-2025:CoursIA-2
+      python_sha: 9c9644c74bd05c238944c93c2828fedaf23eabd6
+      csharp_sha: 4f37b203d3e70f7e894b2602ef8333374adf8197
+      content_python_sha: b1ee07eca7b6504fa3398ce9263e423c29407bf8770c9601269869b5eba30e87
+      content_csharp_sha: bc5077c94b514dd5fd8300931684088c1ea14a22dde311216989b7c1fbd1e61f
   known_differences:
+    - "Rebaseline 2026-08-17 : cote C# draine des timings MACHINE-DEP en cellule[24] (4 valeurs : 350 s, 349,9 s, 0,92 s, 922 ms, 5,8 minutes) et cellule[42] (4 valeurs : ~14-26 s, ~100 ms, ~1,8 s, ~18-112 ms, ~30-60 s) -- mandat #9377/#9434, drain des wall-clock prose (mandat user : seules les valeurs reproductibles d'une execution a l'autre sont conservees). Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote Python non modifie. Attestation = nouveau blob SHA du cote C#."
     - "Rebaseline 2026-08-05 : cote Python deplace par de-pin des versions JAX/NumPyro depuis la table de la cellule[3] (criterion 2 #9434, edition markdown-only). Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote C# non modifie. Attestation = nouveau blob SHA du cote Python."
     - "Socle pedagogique commun : resolution PROBABILISTE du Sudoku par inference bayesienne/probabiliste, meme concept (modeliser l'incertitude sur les cases, inferrer les valeurs les plus probables), meme angle (approche non-deterministe par contraste avec les solveurs exacts de la serie)."
     - "Divergence de framework probabiliste : Python = NumPyro (MCMC, inference variationnelle, stochastic) ; C# = Infer.NET (modelisation probabiliste .NET, message passing). Meme paradigme (inference probabiliste), deux frameworks stochastiques distincts -- les sorties numeriques different d'une execution a l'autre (MCMC sampling), parite au niveau du concept et de la demarche, pas des valeurs exactes."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: META/docs #11290

## Résumé

EPIC #9434 — **tranche `Sudoku-15-Infer-Csharp`** (dispatch ai-01 msg-20260817T092916-5q28qx, 2026-08-17T11:29Z HIGH). Drain de **8 valeurs wall-clock MACHINE-DEP/STOCHASTIQUE** dans les cellules markdown[24] et markdown[42] (Conclusion) du notebook. Édition markdown-only — aucune cellule code touchée, aucun `execution_count` modifié, aucun output réécrit (Stop & Repair règle 6 respectée, C.3 scope strict respecté : un seul notebook, deux cellules markdown).

## Diagnostic dérive (C.4 — section obligatoire)

### Cause

`Sudoku-15-Infer-Csharp.ipynb` — la prose pédagogique de deux cellules contenait des **mesures wall-clock** de résolution de grilles Infer.NET (`350 s`, `349,9 s`, `0,92 s`, `922 ms`, `5,8 minutes`, `~14-26 s`, `~100 ms`, `~1,8 s`, `~18-112 ms`, `~30-60 s`). Ces valeurs sont **machine-dépendantes** par construction (compile + JIT + GC + cache L2 + charge CPU) : une ré-exécution du notebook sur une autre machine, ou simplement après un redémarrage de la machine hôte, change ces chiffres sans que la substance pédagogique (algorithme EP + Dirichlet + réinjection itérative des priors) ait changé.

Le mandat #9377/#9434 (« les données quantitatives doivent être tenues par le CI, pas dans la prose ») avait déjà été appliqué à 11+ tranches précédentes (cf historique git : #10096, #10091, #9994, #10119, #10125, #10152, #10154, #10268, #10661, #10874, #10976, #10978 — drain machine-dep wall-clock sur Sudoku-1/8/9/10/13/15 partiel) — mais **Sudoku-15-Infer-Csharp cellule[24] (table « Performance du solver itératif ») et cellule[42] (Conclusion, table « Progression des solveurs ») avaient échappé à ces passes**.

### Verdict

**CAUSE_FIXED** — drain mécanique des valeurs wall-clock dans la prose, remplacement par des formulations qualitatives (ordre de grandeur de quelques minutes pour la compilation initiale, ratio Roslyn vs recompilation qualitative machine-dépendant) **+ meta-note explicite** dans chaque cellule indiquant que les durées wall-clock sont drainées vers les cellules de mesure (mandat #9377/#9434). Aucune valeur n'est ré-épinglée : seules les valeurs **reproductibles d'une exécution à l'autre** restent dans la prose (comptes d'itérations EP, comptes d'erreurs, principes algorithmiques, références `ec=N` cell-by-cell).

### Pourquoi cette voie plutôt qu'une ré-exécution fraîche

Règle C.5 + Stop & Repair règle 6 : une **valeur de perf/timing/accuracy** dans un notebook **ré-exécutable localement** se corrige par une **ré-exécution fraîche**, jamais par un alignement markdown chirurgical. Mais **dans ce cas, la valeur est par construction MACHINE-DEP** (wall-clock = runtime kernel .NET, varie avec la machine) — **la ré-exécution ne stabiliserait pas la valeur**, elle la rendrait simplement plus récente (toujours fausse ailleurs). Le bon fix est le **retrait** (drain), pas la ré-exécution (qui re-épinglerait une valeur qui rebougera).

## Détail du diff

### cellule[24] (table « Performance du solver itératif sur les grilles faciles »)

| Avant | Après |
|---|---|
| `\| Aspect \| Valeur observée \| Analyse \|` (3 colonnes) | `\| Aspect \| Analyse \|` (2 colonnes — colonne `Valeur observée` retirée) |
| `\| Première résolution \| ≈ 350 s (349,9 s mesurés) \| Compilation initiale du modèle \|` | `\| Première résolution \| Compilation initiale du modèle (non mesuré ici, machine-dépendant) \|` |
| `\| Seconde résolution \| ≈ 0,92 s (922 ms mesurés) \| Modèle déjà compilé \|` | `\| Seconde résolution \| Modèle déjà compilé (non mesuré ici, machine-dépendant) \|` |
| Item 2 « La première résolution inclut le temps de compilation du modèle (≈ 5,8 minutes) » | « La première résolution inclut le temps de compilation du modèle (coût initial non négligeable, ordre de grandeur de quelques minutes sur cette machine) » |

**+ Meta-note ajoutée** (juste avant la note technique pré-existante) :
> Les durées observées (350 s, 0,92 s) sont **machine-dépendantes** et ne sont pas retenues dans cette prose (mandat #9377/#9434 : seules les valeurs **reproductibles d'une exécution à l'autre** sont conservées ; les durées wall-clock sont drainées vers les cellules de mesure). Seuls les **comptes d'itérations EP** restent dans la table ci-dessus (2150 itérations pour 2 grilles).

### cellule[42] (Conclusion — table « Progression des solveurs »)

| Avant | Après |
|---|---|
| `\| Solveur \| Principe \| Easy \| Medium \| Temps caractéristique \|` (5 colonnes) | `\| Solveur \| Principe \| Easy \| Medium \|` (4 colonnes — colonne `Temps caractéristique` retirée) |
| `\| **Naïf** \| ... \| ... \| - \| ~14-26 s (recompile à chaque grille, voir \`a009c961\`) \|` | `\| **Naïf** \| ... \| ... \| - \|` |
| `\| **Robuste** \| ... \| ... \| 37 erreurs \| ~100 ms par grille (après la compilation initiale) \|` | `\| **Robuste** \| ... \| ... \| 37 erreurs \|` |
| `\| **Itératif** \| ... \| ... \| 3 erreurs \| ~1,8 s \|` | `\| **Itératif** \| ... \| ... \| 3 erreurs \|` |
| `\| **Précompilé** \| ... \| ... \| 45 erreurs \| ~18-112 ms \|` | `\| **Précompilé** \| ... \| ... \| 45 erreurs \|` |
| Item 2 « au prix d'un coût computationnel plus élevé (~1,8 s, nombreuses itérations EP) » | « au prix d'un coût computationnel plus élevé (machine-dépendant, nombreuses itérations EP) » |
| Item 3 « La précompilation Roslyn élimine le coût de compilation initial (~30-60 s du solveur naïf) en chargeant directement la DLL compilée : validée (solve en ~18-112 ms après chargement, `See #8287`) » | « La précompilation Roslyn élimine le coût de compilation initial du solveur naïf (gain machine-dépendant) en chargeant directement la DLL compilée : validée (solve en temps court après chargement, `See #8287`) » |

**+ Meta-note ajoutée** (juste avant la note méthodologique pré-existante) :
> Les durées caractéristiques (`~14-26 s`, `~100 ms`, `~1,8 s`, `~18-112 ms`) étaient **machine-dépendantes** et ont été drainées de la table ci-dessus (mandat #9377/#9434). Seuls les **principes algorithmiques** et les **comptes d'erreurs reproductibles** sont retenus ; les coûts wall-clock exacts restent dans les cellules de mesure de chaque solveur. La précompilation Roslyn (`See #8287`) reste qualitativement plus rapide que la recompilation naïve, mais le ratio est machine-dépendant.

## Statistiques

- 8 valeurs drainées (4 dans cellule[24] + 4 dans cellule[42] + 2 mentions prose)
- +2/-46 sur le fichier notebook (le drain retire les colonnes `Valeur observée` et `Temps caractéristique` des deux tables)
- 2 cellules markdown touchées, 0 cellule code, 0 output, 0 exec_count
- twin-parity rebaseline : `Sudoku-15 Infer` csharp_sha `67a9e21... → 4f37b20...` + content_csharp_sha `4e52d4... → bc5077c...` (commit `e61af0882`)
- Total : 157/157 paires OK / 0 DRIFT / 0 MISSING après rebaseline (cf `check_twin_parity.py --pair "Sudoku-15 Infer"`)

## Vérification

- C.1 : aucune cellule code touchée, pas de `raise NotImplementedError` introduit
- C.2 : `execution_count` + `outputs` non modifiés (markdown-only)
- C.3 : scope strict = un seul notebook, deux cellules markdown (cf diff stat)
- C.4 : section Diagnostic dérive + verdict `CAUSE_FIXED` présente dans ce body
- C.5 : drain (retrait) plutôt que ré-épingle pour les valeurs MACHINE-DEP — conforme au tableau de décision C.5 (`Machine-dépendant` → `RETIRER`)
- Stop & Repair règle 6 : aucune sortie de cellule committee hand-éditée (markdown-only = pas d'output à maquiller)
- H.3 : pre-commit `execution_count is None and not outputs` = N/A (pas de cellule code touchée) ; passes OK cf log commit

## Pattern appliqué

Précédent direct : **#10268** `docs(sudoku,#9434): drain machine-dependent wallclock from Sudoku-1 interpretation prose` (Sudoku-1-Backtracking-Csharp, commit `5258f0226`) — même pattern : retrait colonne wall-clock + meta-note « les wall-clocks sont machine-dépendants ».

## Claim scope

Re-pose du claim `#9434` epic-wide → scope narrow (cf `gh issue comment 9434` 2026-08-17T11:30Z) :
> `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: MyIA.AI.Notebooks/Sudoku/**, MyIA.AI.Notebooks/GameTheory/**`

→ débloque les autres lanes (Search- po-2024, autres familles EPITA-IS) sur les tranches qu'elles peuvent paralléliser.

## Umbrella

Voir #9434 — Epic vivante, 8 tranches mergées + cette PR = 9ᵉ tranche.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
