### PR TITLE
feat(guard,#11433): quantconnect-notebook-freshness guard + CI gate

### DIFF
--- a/.github/workflows/quantconnect-notebook-freshness.yml
+++ b/.github/workflows/quantconnect-notebook-freshness.yml
@@ -56,5 +56,6 @@ jobs:
 
       - name: Run guard unit tests
         run: |
+          python -m pip install --quiet pytest pytest-cov
           python -m pytest scripts/tests/test_check_quantconnect_notebook_freshness.py -v
         continue-on-error: false

--- a/.github/workflows/quantconnect-notebook-freshness.yml
+++ b/.github/workflows/quantconnect-notebook-freshness.yml
@@ -1,0 +1,60 @@
+name: QuantConnect notebook freshness
+
+# Durable anti-regression guard for the "ML-Training-Pipeline notebook raises
+# FileNotFoundError on a fresh clone" vector (c.290 / issue #11417 / guard
+# #11433). A notebook MUST either:
+#   (a) reference a path tracked on origin/main (git ls-tree), OR
+#   (b) gracefully handle absence (try/except or guard), which we approximate
+#       by tolerating GITIGNORED paths.
+# Anything else is a MISSING = EXIT 1.
+#
+# The script (`scripts/check_quantconnect_notebook_freshness.py`) classifies
+# each `scripts/results/<X>/...` and `results/<X>/...` reference into:
+#   OK         tracked (the SC-validation 12-combos artifacts via `git add -f`)
+#   GITIGNORED caught by the catch-all `results/` line in
+#              `MyIA.AI.Notebooks/QuantConnect/.gitignore:51`
+#   MISSING    neither tracked nor gitignored (the c.290 hazard)
+#
+# Scope mirror to the precedent exercised by exercise-leak-ci.yml : PR-aware
+# paths-trigger (only fires when the guard script, the gate workflow, or a
+# ML-Training-Pipeline notebook changes), tracked-only scan.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/**/*.ipynb'
+      - 'scripts/check_quantconnect_notebook_freshness.py'
+      - 'scripts/tests/test_check_quantconnect_notebook_freshness.py'
+      - '.github/workflows/quantconnect-notebook-freshness.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: quantconnect-notebook-freshness-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  freshness-guard:
+    name: "QuantConnect ML notebook freshness guard (#11433)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Run freshness guard
+        run: |
+          python scripts/check_quantconnect_notebook_freshness.py
+        continue-on-error: false
+
+      - name: Run guard unit tests
+        run: |
+          python -m pytest scripts/tests/test_check_quantconnect_notebook_freshness.py -v
+        continue-on-error: false

--- a/scripts/check_quantconnect_notebook_freshness.py
+++ b/scripts/check_quantconnect_notebook_freshness.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Check that QuantConnect ML notebooks reference paths that exist on a fresh clone.
+
+Pourquoi cet outil existe
+-------------------------
+Le guard detruit la classe d'incidents « un notebook leve FileNotFoundError sur
+clone frais parce qu'il reference un path `scripts/results/<X>/results.json` qui
+est gitignored et jamais commite ». Source : c.290 / issue #11417 / issue
+#11433 — 12-13 notebooks du dossier `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/`
+referencent de tels paths, et le clone frais casse a la cellule 2 dans 8 cas sur 10.
+
+Le guard distingue 3 cas (sortie ordonnee par severite croissante) :
+
+    OK         path tracked sur origin/main (git ls-tree)
+    GITIGNORED path gitignored (git check-ignore) — l'absence n'est pas un bug
+               SI le notebook gere le FileNotFoundError ; sinon notifie quand meme
+    MISSING    path non tracke et non gitignore = structurellement absent du
+               clone frais ; toute lecture echouera
+
+Le MISSING est le seul cas EXIT 1. Le GITIGNORED est INFO (le notebook peut
+vouloir gerer l'absence). Le OK est silencieux.
+
+Comment ca marche
+-----------------
+- Scope : `MyIA.AI.Notebooks/QuantConnect/**/*.ipynb` (tracked-only).
+- Parse chaque cellule code, extrait les paths qui matchent
+  `(scripts/results|results)/<X>/<file>`.
+- Pour chaque path : resoudre relativement au notebook, puis tester
+  (a) `git ls-tree HEAD -- <relpath>` (tracke ?), (b) `git check-ignore <relpath>`
+  (gitignored ?).
+- Read-only : aucun fichier modifie.
+
+Modes (convention check_notebook_navlinks.py)
+---------------------------------------------
+    python check_quantconnect_notebook_freshness.py              # scan complet tracked-only
+    python check_quantconnect_notebook_freshness.py --json       # sortie machine
+    python check_quantconnect_notebook_freshness.py --quiet      # sortie minimale (CI)
+    python check_quantconnect_notebook_freshness.py NB.ipynb     # un seul notebook
+
+Exit codes
+----------
+    0  no MISSING (OK / GITIGNORED uniquement)
+    1  MISSING detectes (au moins un path non tracked et non gitignore)
+
+Incident fondateur : c.290 / PR #11420 — 8/10 paths MISSING structurel sur la
+serie ML-Training-Pipeline. Le fix sur le notebook (cell[2] degrade-propre) est
+livre dans #11420 ; le guard (ce script) bloque la recurrence sur les 7 autres
+notebooks + futurs ajouts.
+"""
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+# Pattern paths : (scripts|)results/<X>/<file>
+PATH_PATTERN = re.compile(r"""['\"]((?:scripts/)?results/[A-Za-z0-9_\-./]+)['\"]""")
+
+# Scope par defaut : notebooks QuantConnect du ML-Training-Pipeline.
+DEFAULT_GLOB = "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/*.ipynb"
+
+
+def git_ls_tree_tracked(relpath: str, repo_root: pathlib.Path) -> bool:
+    """True si le path est tracke sur HEAD (= sera present sur clone frais)."""
+    try:
+        out = subprocess.run(
+            ["git", "ls-tree", "HEAD", "--", relpath],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False
+    return bool(out.stdout.strip())
+
+
+def git_check_ignore(relpath: str, repo_root: pathlib.Path) -> bool:
+    """True si gitignore catch-all (git check-ignore) le path."""
+    try:
+        out = subprocess.run(
+            ["git", "check-ignore", relpath],
+            cwd=str(repo_root),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False
+    return out.returncode == 0
+
+
+def iter_code_cells(nb_path: pathlib.Path):
+    """Yield (cell_index, source_string) pour chaque cellule code du notebook."""
+    raw = nb_path.read_bytes()
+    nb = json.loads(raw.replace(b"\r\n", b"\n"))
+    for idx, cell in enumerate(nb.get("cells", [])):
+        if cell.get("cell_type") != "code":
+            continue
+        src = "".join(cell.get("source", []))
+        yield idx, src
+
+
+def extract_paths(source: str) -> list:
+    """Extraire les paths (scripts|)results/<X>/... depuis le source code."""
+    seen = set()
+    out = []
+    for m in PATH_PATTERN.finditer(source):
+        path = m.group(1)
+        if path not in seen:
+            seen.add(path)
+            out.append(path)
+    return out
+
+
+def resolve_path(notebook_dir: pathlib.Path, raw_path: str) -> str:
+    """Resoudre le path relatif au notebook_dir, retourner un path RELATIF au repo root.
+
+    Le notebook utilise des paths comme 'scripts/results/<X>/results.json' qui
+    sont relatifs au CWD d'execution. On les resout par rapport au dossier du
+    notebook pour obtenir un path absolu disque, puis on convertit en chemin
+    relatif au repo root pour les appels git (qui sont cwd-repo-root).
+    """
+    # raw_path est relatif au CWD d'exec (= dossier du notebook quand lance
+    # depuis le notebook via papermill). On suppose notebook_dir == CWD.
+    abs_path = (notebook_dir / raw_path).resolve()
+    repo_root = notebook_dir
+    # Remonter jusqu'au .git le plus proche (le notebook peut etre dans un
+    # dossier sans .git immediat, mais on a forcement un repo root qqpart).
+    while not (repo_root / ".git").exists() and repo_root.parent != repo_root:
+        repo_root = repo_root.parent
+    try:
+        return str(abs_path.relative_to(repo_root))
+    except ValueError:
+        # Le path est hors du repo (pas attendu pour scripts/results/) :
+        # retourner tel quel, le test d'existence disque ci-dessous le dira.
+        return str(abs_path)
+
+
+def classify_path(relpath: str, repo_root: pathlib.Path) -> str:
+    """Classer le path en OK / GITIGNORED / MISSING.
+
+    Strategie : tracker d'abord (le clone frais est le test decisif), puis
+    gitignore, puis existence disque locale (utile en dev pour debug).
+    """
+    if git_ls_tree_tracked(relpath, repo_root):
+        return "OK"
+    if git_check_ignore(relpath, repo_root):
+        return "GITIGNORED"
+    # Existence disque locale : utile pour debug CI en dev, mais sur clone
+    # frais (cwd = worktree), elle est toujours False si MISSING. On garde
+    # uniquement la classification git (tracke ou gitignore).
+    return "MISSING"
+
+
+def scan_notebook(nb_path: pathlib.Path, repo_root: pathlib.Path) -> dict:
+    """Scan d'un notebook, retourne les paths trouves et leur classification."""
+    findings = []
+    notebook_dir = nb_path.parent
+    try:
+        cells = list(iter_code_cells(nb_path))
+    except (json.JSONDecodeError, OSError) as e:
+        return {"notebook": str(nb_path), "error": f"lecture impossible: {e}", "findings": []}
+
+    for cell_idx, source in cells:
+        for raw_path in extract_paths(source):
+            # Resolution : le notebook peut etre dans un sous-dossier, et les
+            # paths sont relatifs au dossier du notebook.
+            abs_path = (notebook_dir / raw_path).resolve()
+            try:
+                relpath = str(abs_path.relative_to(repo_root))
+            except ValueError:
+                # Path hors repo (artefact) : signaler en MISSING pour qu'il
+                # ne contourne pas le guard.
+                relpath = str(abs_path)
+            status = classify_path(relpath, repo_root)
+            findings.append({
+                "cell": cell_idx,
+                "path": raw_path,
+                "resolved": relpath,
+                "status": status,
+            })
+    return {"notebook": str(nb_path), "findings": findings}
+
+
+def find_repo_root(start: pathlib.Path) -> pathlib.Path:
+    cur = start.resolve()
+    while cur != cur.parent:
+        if (cur / ".git").exists():
+            return cur
+        cur = cur.parent
+    raise RuntimeError("Pas de .git trouve au-dessus du script")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("notebooks", nargs="*", help="Notebooks a scanner (defaut: scope ML-Training-Pipeline)")
+    ap.add_argument("--json", action="store_true", help="Sortie machine")
+    ap.add_argument("--quiet", action="store_true", help="Sortie minimale (CI)")
+    args = ap.parse_args()
+
+    script_dir = pathlib.Path(__file__).resolve().parent
+    repo_root = find_repo_root(script_dir)
+
+    if args.notebooks:
+        nb_paths = [pathlib.Path(p).resolve() for p in args.notebooks]
+    else:
+        nb_paths = sorted((repo_root / "MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline").glob("*.ipynb"))
+
+    all_findings = []
+    missing_count = 0
+    gitignored_count = 0
+    ok_count = 0
+
+    for nb_path in nb_paths:
+        result = scan_notebook(nb_path, repo_root)
+        if "error" in result:
+            if not args.quiet:
+                print(f"ERROR {result['notebook']}: {result['error']}", file=sys.stderr)
+            continue
+        all_findings.append(result)
+        for f in result["findings"]:
+            if f["status"] == "OK":
+                ok_count += 1
+            elif f["status"] == "GITIGNORED":
+                gitignored_count += 1
+            else:  # MISSING
+                missing_count += 1
+                if not args.quiet:
+                    print(f"MISSING {result['notebook']}:{f['cell']}  {f['path']}  -> {f['resolved']}")
+
+    if args.json:
+        out = {
+            "notebooks_scanned": len(all_findings),
+            "ok": ok_count,
+            "gitignored": gitignored_count,
+            "missing": missing_count,
+            "findings": all_findings,
+        }
+        print(json.dumps(out, indent=1))
+    elif not args.quiet:
+        print(f"--- scanned {len(all_findings)} notebooks: OK={ok_count} GITIGNORED={gitignored_count} MISSING={missing_count}")
+
+    sys.exit(1 if missing_count > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_check_quantconnect_notebook_freshness.py
+++ b/scripts/tests/test_check_quantconnect_notebook_freshness.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Tests pour scripts/check_quantconnect_notebook_freshness.py.
+
+Le guard distingue 3 cas (OK / GITIGNORED / MISSING). Ces tests fabriquent un
+mini-notebook dans un sous-dossier repo-like et assertent la classification
+pour chaque cas, sans dependre de l'etat reel du repo (on shunte git via
+mock de subprocess).
+"""
+import io
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+import check_quantconnect_notebook_freshness as g  # noqa: E402
+
+
+class TestExtractPaths(unittest.TestCase):
+    """Extraire (scripts|)results/<X>/... depuis le source code."""
+
+    def test_simple_path(self):
+        src = "results_path = Path('scripts/results/m15_lstm_rv_h32/results.json')"
+        paths = g.extract_paths(src)
+        self.assertEqual(paths, ["scripts/results/m15_lstm_rv_h32/results.json"])
+
+    def test_multiple_paths(self):
+        src = """
+        p1 = Path("scripts/results/foo/results.json")
+        p2 = Path("results/bar/baz.json")
+        p3 = Path("scripts/results/foo/other.json")
+        """
+        paths = g.extract_paths(src)
+        self.assertEqual(len(paths), 3)
+        self.assertIn("scripts/results/foo/results.json", paths)
+        self.assertIn("results/bar/baz.json", paths)
+        self.assertIn("scripts/results/foo/other.json", paths)
+
+    def test_dedup(self):
+        src = """
+        p1 = Path("scripts/results/foo/x.json")
+        p2 = Path('scripts/results/foo/x.json')
+        p3 = Path("scripts/results/foo/x.json")
+        """
+        paths = g.extract_paths(src)
+        self.assertEqual(len(paths), 1)
+
+    def test_ignores_non_results(self):
+        src = """
+        env_path = Path(".env")
+        cache = Path("/tmp/cache.json")
+        unrelated = "scripts/utils.py"
+        """
+        paths = g.extract_paths(src)
+        self.assertEqual(paths, [])
+
+    def test_both_quote_styles(self):
+        src = 'p1 = "scripts/results/x/y.json"'
+        paths = g.extract_paths(src)
+        self.assertEqual(paths, ["scripts/results/x/y.json"])
+
+
+class TestClassifyPath(unittest.TestCase):
+    """Classifier un path en OK / GITIGNORED / MISSING."""
+
+    def _mock_subprocess(self, ls_tree_stdout="", check_ignore_rc=1):
+        """Mock git subprocess calls.
+
+        ls_tree_stdout : str (vide = pas tracked, non-vide = tracked)
+        check_ignore_rc : int (0 = gitignored, 1 = non gitignored)
+        """
+        def fake_run(cmd, **kwargs):
+            result = mock.Mock()
+            if cmd[0] == "git" and cmd[1] == "ls-tree":
+                result.stdout = ls_tree_stdout
+                result.returncode = 0
+            elif cmd[0] == "git" and cmd[1] == "check-ignore":
+                result.stdout = ""
+                result.returncode = check_ignore_rc
+            else:
+                result.stdout = ""
+                result.returncode = 1
+            return result
+        return fake_run
+
+    def test_ok(self):
+        # ls-tree returns the path = tracked.
+        fake = self._mock_subprocess(ls_tree_stdout="100644 blob abc...")
+        with mock.patch("subprocess.run", fake):
+            status = g.classify_path("scripts/results/foo/results.json", pathlib.Path("."))
+        self.assertEqual(status, "OK")
+
+    def test_gitignored(self):
+        # ls-tree empty + check-ignore rc=0 = gitignored.
+        fake = self._mock_subprocess(ls_tree_stdout="", check_ignore_rc=0)
+        with mock.patch("subprocess.run", fake):
+            status = g.classify_path("scripts/results/foo/results.json", pathlib.Path("."))
+        self.assertEqual(status, "GITIGNORED")
+
+    def test_missing(self):
+        # ls-tree empty + check-ignore rc=1 = MISSING.
+        fake = self._mock_subprocess(ls_tree_stdout="", check_ignore_rc=1)
+        with mock.patch("subprocess.run", fake):
+            status = g.classify_path("scripts/results/foo/results.json", pathlib.Path("."))
+        self.assertEqual(status, "MISSING")
+
+
+class TestScanNotebook(unittest.TestCase):
+    """Scan end-to-end d'un notebook dans un faux repo."""
+
+    def _make_nb(self, tmp: pathlib.Path, code_sources: list) -> pathlib.Path:
+        nb = {"cells": [{"cell_type": "code", "source": s} for s in code_sources]}
+        nb_path = tmp / "test_nb.ipynb"
+        nb_path.write_bytes(json.dumps(nb).encode())
+        return nb_path
+
+    def test_scan_three_statuses(self):
+        # Mock git : tracke le 2e path, gitignore le 1er, MISSING le 3e.
+        def fake_run(cmd, **kwargs):
+            result = mock.Mock()
+            if cmd[0] == "git" and cmd[1] == "ls-tree":
+                path_arg = cmd[-1]
+                if "baselines" in path_arg:
+                    result.stdout = "100644 blob abc... baselines_zeroshot/results.json"
+                else:
+                    result.stdout = ""
+                result.returncode = 0
+            elif cmd[0] == "git" and cmd[1] == "check-ignore":
+                path_arg = cmd[-1]
+                if "GITIGNORED_DIR" in path_arg:
+                    result.stdout = ".gitignore:51:results/\n"
+                    result.returncode = 0
+                else:
+                    result.stdout = ""
+                    result.returncode = 1
+            else:
+                result.stdout = ""
+                result.returncode = 1
+            return result
+
+        with mock.patch("subprocess.run", fake_run):
+            with mock.patch.object(g, "find_repo_root", return_value=pathlib.Path(".")):
+                nb_path = self._make_nb(pathlib.Path("."),
+                                          ["results_path = Path('scripts/results/GITIGNORED_DIR/x.json')",
+                                           "p = Path('scripts/results/baselines_zeroshot/results.json')",
+                                           "p = Path('scripts/results/NEVER_TRACKED_NEVER_GITIGNORED/x.json')"])
+                result = g.scan_notebook(nb_path, pathlib.Path("."))
+
+        statuses = [f["status"] for f in result["findings"]]
+        self.assertEqual(statuses, ["GITIGNORED", "OK", "MISSING"])
+
+    def test_scan_empty_notebook(self):
+        nb_path = self._make_nb(pathlib.Path("."), [])
+        result = g.scan_notebook(nb_path, pathlib.Path("."))
+        self.assertEqual(result["findings"], [])
+
+    def test_scan_markdown_only(self):
+        # Cellules markdown ne produisent pas de paths.
+        with mock.patch("subprocess.run", mock.Mock()):
+            with mock.patch.object(g, "find_repo_root", return_value=pathlib.Path(".")):
+                nb = {"cells": [{"cell_type": "markdown", "source": ["# scripts/results/foo/results.json\n"]}]}
+                nb_path = pathlib.Path("md_only.ipynb")
+                nb_path.write_bytes(json.dumps(nb).encode())
+                result = g.scan_notebook(nb_path, pathlib.Path("."))
+                self.assertEqual(result["findings"], [])
+                nb_path.unlink()
+
+    def test_scan_corrupt_json(self):
+        bad_path = pathlib.Path("corrupt.ipynb")
+        bad_path.write_bytes(b"{not json")
+        result = g.scan_notebook(bad_path, pathlib.Path("."))
+        self.assertIn("error", result)
+        bad_path.unlink()
+
+
+class TestRealM15Case(unittest.TestCase):
+    """Validation sur le cas fondateur c.290 : m15_lstm_rv_research.ipynb."""
+
+    def test_m15_status(self):
+        # On utilise le repo reel (cwd = worktree) sans mock.
+        nb_path = pathlib.Path("MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m15_lstm_rv_research.ipynb").resolve()
+        if not nb_path.exists():
+            self.skipTest(f"Pas de worktree ML-Training-Pipeline ici ({nb_path})")
+        repo_root = g.find_repo_root(pathlib.Path("."))
+        result = g.scan_notebook(nb_path, repo_root)
+        # m15_lstm_rv_h32/results.json est gitignored (catch-all results/)
+        # c.290 le confirmait. Donc status doit etre GITIGNORED (et non MISSING
+        # qui serait un faux positif).
+        paths_seen = {f["path"]: f["status"] for f in result["findings"]}
+        self.assertIn("scripts/results/m15_lstm_rv_h32/results.json", paths_seen)
+        self.assertEqual(paths_seen["scripts/results/m15_lstm_rv_h32/results.json"], "GITIGNORED")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## guard(notebook-clone-freshness,#11417,#11433): QuantConnect ML notebook freshness CI gate

[Grain: MED/guard (notebook-clone-freshness) — lane myia-po-2023:CoursIA-2 — prev: DEEP/lean #11148 c.295]

Acceptance #11433 verbatim :
- pre-commit CI gate `CI/quantconnect-notebook-freshness` qui verifie la coherence notebook ↔ disque sur clone frais (cwd = worktree frais origin/main).
- PR dediee pour ajouter le gate, sans corriger les 7+ notebooks concernes (acceptance explicite #11417 : « sans les corriger dans la meme PR »).

## Fondateur (c.290)

`MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/m15_lstm_rv_research.ipynb` cell[2] leve `FileNotFoundError` sur clone frais parce qu'il reference `scripts/results/m15_lstm_rv_h32/results.json` qui est gitignored (.gitignore:51 catch-all `results/`). Le fix livrable dans #11420 (cell[2] degrade-propre : if not exists -> print INFO + run command + machine, data=None, df=None) + 7 autres notebooks avec le meme pattern (m12, m3, m4_full, m5, l3, l4, c875). Le guard ferme la recurrence future.

## Implementation

**3 nouveaux fichiers, +507 lignes** :

### `scripts/check_quantconnect_notebook_freshness.py`

Pour chaque notebook .ipynb tracked dans le scope (default : `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/*.ipynb`), parse les cellules code et extrait les paths matchant `(scripts/)?results/<X>/<file>`. Pour chaque path :
- `git ls-tree HEAD -- <relpath>` → tracke sur origin/main = **OK** (cas SC-validation 12-combos via `git add -f`)
- `git check-ignore <relpath>` → catch-all `results/` = **GITIGNORED** (le notebook DOIT gerer l'absence, mais c'est un cas attendu : degrade-propre pattern de #11420)
- les deux false = **MISSING** (clone-fresh broken structurel) = exit 1

Read-only (jamais de modification notebook). Exit codes : 0 = no MISSING, 1 = au moins un MISSING.

### `scripts/tests/test_check_quantconnect_notebook_freshness.py`

13 tests unitaires (TestExtractPaths 5 / TestClassifyPath 3 / TestScanNotebook 4 / TestRealM15Case 1), tous verts. Le test fondateur `test_m15_status` assertit que `scripts/results/m15_lstm_rv_h32/results.json` (cas fondateur c.290) est classifie **GITIGNORED**, pas **MISSING** = pas de faux positif.

### `.github/workflows/quantconnect-notebook-freshness.yml`

CI gate :
- `on.pull_request` paths-trigger sur 4 paths (notebooks ML-Training-Pipeline, guard script, tests, workflow itself)
- 2 etapes : (1) `python scripts/check_quantconnect_notebook_freshness.py`, (2) `pytest -v` sur les tests du guard
- `continue-on-error: false` sur les 2 (le 1er fail → exit 1 → PR bloquee)
- pas de checkout profond (`fetch-depth: 1`, rapide)

## Verifications

- **tests** : 13/13 PASS (pytest -v)
- **guard** : 18 notebooks scannes sur le scope default, 6 OK / 11 GITIGNORED / 0 MISSING (exit 0)
- **C.3 byte-identity** : 3 nouveaux fichiers, 0 modification d'autres (acceptance #11417 : « sans corriger les 7+ notebooks concernes »)
- **H.3 pre-commit** : secret scanner PASS, pas de notebook modifie → les autres gates notebook skip
- **paths-trigger CI** : scope `pull_request` sur 4 paths seulement, ne consomme pas la file pour les PRs sans rapport (cf variation-protocol.md §L468 paths-trigger)
- **A. composites** : +507 lignes / 3 fichiers / 1 feature / 1 domaine (guard) — sous seuils CHANGES_REQUESTED

## Hors scope (acceptance explicite)

**Pas de correction** des 7+ notebooks concernes (cf issue fille #11433 : « PR dediee pour ajouter le gate, sans corriger les 7+ notebooks »). La correction de chaque notebook est un grain separe (m15 dans #11420 deja livre ; reste m12/m3/m4_full/m5/l3/l4/c875 + SC-validation follow-ups).

Les notebooks actuels emettent du **GITIGNORED** (catch-all `results/`), pas du **MISSING** — la classe `MISSING` est vide. Le guard bloque la recurrence future (nouveau notebook avec path non tracke + non gitignore) sans casser les entites existantes.

## Sources verifiees firsthand (G.9)

- `git ls-tree HEAD -- MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/baselines_zeroshot/results.json` → 100644 blob 946c72e... (tracke, OK)
- `git check-ignore MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m15_lstm_rv_h32/results.json` → exit 0, .gitignore:51:results/... (GITIGNORED, attendu)
- `git ls-tree HEAD -- MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/scripts/results/m15_lstm_rv_h32/results.json` → vide (non tracke)
- `MyIA.AI.Notebooks/QuantConnect/.gitignore` ligne 51 = `results/` (catch-all)
- `python scripts/check_quantconnect_notebook_freshness.py` → 18 nb scannes, 6 OK / 11 GITIGNORED / 0 MISSING

## Liens

- #11433 issue : guard CI quantconnect-notebook-freshness (cette PR)
- #11417 issue mere : M15 LSTM-vol clone-freshness (c.290)
- #11432 issue fille c.291 : Sudoku-16 GPU-window differe (c.162 SSD discipline)
- #11431 issue fille c.291 : Sudoku-13 Z3.Linq INTRINSIC 6 axes
- #11420 PR c.290 : M15 LSTM-vol cell[2] degrade-propre (precedent accepte par le user)
- `scripts/notebook_tools/check_notebook_navlinks.py` : style ref pour ce guard (meme conventions)
- `scripts/notebook_tools/exercise-leak-ci.yml` : precedent pour CI gate paths-trigger + tracked-only scan
