### PR TITLE
fix(prover,#1453): garde d'ecriture — ne jamais persister un etat aggrave (REGRESSED)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/decomposition_regression.py
@@ -34,7 +34,11 @@ from __future__ import annotations
 
 from typing import Optional
 
-__all__ = ["is_decomposition_regression", "is_same_count_zero_verified"]
+__all__ = [
+    "is_decomposition_regression",
+    "is_same_count_zero_verified",
+    "is_worsened_unproven",
+]
 
 
 def is_decomposition_regression(
@@ -83,3 +87,23 @@ def is_same_count_zero_verified(
     if verified_tactic_count is None:
         return False
     return final_sorry == original_sorry_count and verified_tactic_count == 0
+
+def is_worsened_unproven(
+    final_sorry: int,
+    original_sorry_count: int,
+    proof_found: bool,
+) -> bool:
+    """Return True iff the run ENDED with MORE sorries than it started and no
+    target was proved (the #1453 iteration-2 write-guard).
+
+    The multi-agent path's kept-snapshot branch (provers.py:893-901) can
+    write ``last_ok_content`` whose sorry count ROSE -- a decomposition the
+    agent edited but never verified closed (L2551 4->8 was committed exactly
+    this way, then mislabelled ``structural_only``). The harness must never
+    persist a worsened file: the write-guard reverts to the entry state and
+    marks the run REGRESSED. ``proof_found`` is exempt: a run that proved the
+    target sorry is genuine progress even if collateral sorries grew, and
+    reverting would throw away the proof.
+    """
+    return final_sorry > original_sorry_count and not proof_found
+

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -1012,6 +1012,29 @@ class MultiAgentSorryProver:
                     )
                     final_sorry = _verify_sorry
                     structural_progress = False
+                    # #1453 iter-3 build-aware write-guard: the iter-2 guard
+                    # above compared TEXT counts (2==2), so the kept-snapshot
+                    # branch persisted a file whose BUILD-aware count actually
+                    # grew (2->3, one implicit sorry via apply?/exact?/
+                    # solve_by_elim). structural_progress=False alone does not
+                    # revert -- the worsened file stays on disk while the run
+                    # is merely marked non-success. Re-check the write-guard
+                    # with the build-aware count and revert on a genuine rise.
+                    if is_worsened_unproven(
+                            final_sorry, original_sorry_count, proof_found):
+                        print(
+                            f"  REGRESSED (build-aware): text count was "
+                            f"{original_sorry_count}, build reveals {_verify_sorry}"
+                            f" ({_verify_sorry - original_sorry_count} implicit "
+                            f"sorry, no proof). Reverting to the entry state -- "
+                            f"the harness never persists a build-aware-worsened "
+                            f"file (#1453 iter-3 guard)."
+                        )
+                        Path(filepath).write_text(original_content, encoding="utf-8")
+                        final_sorry = original_sorry_count
+                        structural_progress = False
+                        tactic_tools._best_content = None
+                        tactic_tools._best_sorry_count = original_sorry_count
 
         # Success now also covers structural progress: file changed but
         # compiles, even if sorry count didn't decrease. Provers.py used to

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/provers.py
@@ -20,6 +20,7 @@ from .p4_final_verify import _evaluate_final_verify
 from .decomposition_regression import (
     is_decomposition_regression,
     is_same_count_zero_verified,
+    is_worsened_unproven,
 )
 from .lean_utils import (
     extract_sorry_block, get_goal_state, verify_sorry_replacement,
@@ -878,6 +879,9 @@ class MultiAgentSorryProver:
             # Default value so the success check after finally always has it,
             # even if an exception is raised mid-block before the verify runs.
             final_build_ok = False
+            # #1453 iter-2 write-guard latch: True when a run ENDED with MORE
+            # sorries than it started and proved nothing (reverted to entry).
+            regressed = False
 
             best_content = getattr(tactic_tools, "best_content", None)
             best_sorry = getattr(tactic_tools, "best_sorry_count",
@@ -899,6 +903,25 @@ class MultiAgentSorryProver:
                     Path(filepath).write_text(last_ok_content, encoding="utf-8")
                     final_sorry = last_ok_sorry if last_ok_sorry is not None else final_sorry
                     structural_progress = True
+
+            if is_worsened_unproven(final_sorry, original_sorry_count, proof_found):
+                # #1453 iter-2 write-guard: a run that ENDED with more sorries
+                # than it started and proved nothing must never persist that
+                # worsened file (L2551 4->8 was committed exactly this way via
+                # the kept-snapshot branch above, then mislabelled
+                # structural_only). Revert to the entry state and mark the run
+                # REGRESSED -- success is structurally impossible afterwards.
+                print(
+                    f"  REGRESSED: sorry {original_sorry_count} -> {final_sorry}"
+                    f" (delta>0, no proof). Reverting to the entry state -- the"
+                    f" harness never persists a worsened file (#1453 iter-2 guard)."
+                )
+                Path(filepath).write_text(original_content, encoding="utf-8")
+                final_sorry = original_sorry_count
+                structural_progress = False
+                regressed = True
+                tactic_tools._best_content = None
+                tactic_tools._best_sorry_count = original_sorry_count
 
             # MANDATORY final build verification on the committed file. This
             # catches false positives where the snapshot's build_check was
@@ -1061,6 +1084,7 @@ class MultiAgentSorryProver:
                  and verified_tactic_count > 0)
              or structural_progress)
             and final_build_ok
+            and not is_worsened_unproven(final_sorry, original_sorry_count, proof_found)
         )
         self.trace.end_session_span(success, f"{original_sorry_count}->{final_sorry}")
 
@@ -1149,6 +1173,10 @@ class MultiAgentSorryProver:
             # restructuring) so forensic ROI ranks these runs honestly instead
             # of counting an unproven sorry-spray as progress.
             "decomposition_regression": decomposition_regression,
+            # #1453 iter-2 write-guard: True when the run ended worsened and
+            # unproven (sorry delta>0, no proof_found) and the file was
+            # reverted to its entry state. Never persisted as success.
+            "regressed": regressed,
             # P5a-search (#7477 forensic): session-level reasoning wall-clock
             # latched either in the multi-agent `except _asyncio.TimeoutError`
             # or the autonomous WALL-CLOCK CAP branch. Surfaced so

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
@@ -43,6 +43,7 @@ _spec.loader.exec_module(_dr)
 
 classify = _dr.is_decomposition_regression
 same_count_churn = _dr.is_same_count_zero_verified
+worsened_unproven = _dr.is_worsened_unproven
 
 
 # ── Acceptance: the founder incident classifies as regression ──────────────
@@ -162,3 +163,39 @@ class TestSameCountZeroVerified:
 
     def test_exported_in_all(self):
         assert "is_same_count_zero_verified" in _dr.__all__
+
+# ── #1453 iter-2: never persist a worsened state ───────────────────────────
+
+class TestWorsenedUnproven:
+    """The write-guard predicate: a run that ENDED with MORE sorries than it
+    started and proved nothing must be reverted + marked REGRESSED, never
+    persisted as success (L2551 4->8, L849 10->11)."""
+
+    def test_flags_l2551_founder(self):
+        """The founding incident: 4 -> 8 with no proof is a worsened unproven
+        state (the file was persisted as structural_only, success=True)."""
+        assert worsened_unproven(8, 4, False) is True
+
+    def test_flags_l849_increase(self):
+        """10 -> 11, no proof -- same class, smaller magnitude."""
+        assert worsened_unproven(11, 10, False) is True
+
+    def test_same_count_not_its_territory(self):
+        """final == original is not a worsened state (FX-8 / equality guard)."""
+        assert worsened_unproven(4, 4, False) is False
+
+    def test_drop_not_its_territory(self):
+        """A sorry DROP is real progress, never a worsened state."""
+        assert worsened_unproven(2, 4, False) is False
+
+    def test_proof_found_exempt(self):
+        """Proving the target IS progress even if collateral sorries grew --
+        reverting would throw away the proof."""
+        assert worsened_unproven(8, 4, True) is False
+
+    def test_returns_real_bool(self):
+        assert type(worsened_unproven(8, 4, False)) is bool
+
+    def test_exported_in_all(self):
+        assert "is_worsened_unproven" in _dr.__all__
+

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_decomposition_regression.py
@@ -199,3 +199,28 @@ class TestWorsenedUnproven:
     def test_exported_in_all(self):
         assert "is_worsened_unproven" in _dr.__all__
 
+
+
+# ── #1453 iter-3: build-aware blind spot ─────────────────────────────────────
+
+class TestBuildAwareBlindSpot:
+    """#1453 iter-3: the write-guard compared TEXT counts, so a build that
+    reveals an implicit sorry (apply?/exact?/solve_by_elim finding nothing)
+    grows the BUILD-AWARE count 2->3 while the text stays 2==2. The text guard
+    passes and the kept-snapshot branch persists a file whose effective count
+    rose. The guard must therefore be re-checked with the build-aware count,
+    which is exactly what is_worsened_unproven does once given that count."""
+
+    def test_text_same_count_passes_old_guard(self):
+        """2 == 2 text: the iter-2 guard sees no worsening (the blind spot)."""
+        assert worsened_unproven(2, 2, False) is False
+
+    def test_buildaware_rise_flags_with_build_count(self):
+        """Build reveals 2 -> 3: the SAME predicate flags it once fed the
+        build-aware count. This is the iter-3 re-check."""
+        assert worsened_unproven(3, 2, False) is True
+
+    def test_buildaware_rise_still_respects_proof_exemption(self):
+        """A build-aware rise with a proof is still exempt (revert would throw
+        the proof away)."""
+        assert worsened_unproven(3, 2, True) is False

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_guards.py
@@ -4123,3 +4123,58 @@ def test_build_fail_storm_guard_passes_below_cap(tactic_tools):
     err = out.get("error", "")
     assert "BUILD_FAIL_STORM" not in err
 
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #1453 iter-3 — the build-aware write-guard re-check in prove_sorry
+#
+# iter-2 (#11445) added is_worsened_unproven as the write-guard; it compared
+# TEXT counts, so text 2==2 passed while the build-aware count (final_verify
+# ["sorry_count"]) actually grew 2->3 via an implicit sorry. structural_progress
+# was demoted but the kept-snapshot file stayed on disk. iter-3 re-runs the
+# guard with the build-aware count and reverts on a genuine rise. The wiring
+# test below FAILS against the iter-2-only source (no second is_worsened_unproven
+# call after the build-aware adoption) -- it is the regression lock for the fix.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_iter3_buildaware_writeguard_recheck_wired():
+    """prove_sorry re-checks is_worsened_unproven AFTER the build-aware count
+    adoption (iter-3): the text guard alone (2==2) lets a build-aware rise
+    2->3 through the kept-snapshot branch."""
+    import ast
+    import inspect
+    from prover.provers import MultiAgentSorryProver
+
+    src_lines = inspect.getsource(MultiAgentSorryProver.prove_sorry).splitlines()
+
+    # Locate the build-aware adoption `if` by indentation: its condition line
+    # and every subsequent line strictly more indented form its body.
+    adopt_idx = next(
+        i for i, line in enumerate(src_lines)
+        if line.lstrip().startswith("if isinstance(_verify_sorry, int)")
+    )
+    adopt_indent = len(src_lines[adopt_idx]) - len(src_lines[adopt_idx].lstrip())
+
+    def _block_lines(start: int, base_indent: int) -> list[str]:
+        out = []
+        for line in src_lines[start + 1:]:
+            indent = len(line) - len(line.lstrip())
+            if indent <= base_indent or not line.strip():
+                if indent <= base_indent:
+                    break
+                continue
+            out.append(line)
+        return out
+
+    # The re-check must be lexically INSIDE the adoption block. A call AFTER
+    # that block (the iter-2 success-gate `not is_worsened_unproven(...)`)
+    # does NOT satisfy iter-3 -- the kept-snapshot branch already persisted by
+    # then, and demoting structural_progress alone leaves the file on disk.
+    body = _block_lines(adopt_idx, adopt_indent)
+    assert any("is_worsened_unproven" in line for line in body), (
+        "the build-aware adoption block must contain an is_worsened_unproven "
+        "re-check (iter-3): text 2==2 passes the text guard, but the build "
+        "reveals 2->3 and the file must be reverted, not just demoted to "
+        "structural_progress=False"
+    )


### PR DESCRIPTION
Grain: MED/tooling - lane myia-po-2026:CoursIA - prev: MED/tooling #11449

## Summary

Iteration-2 directive ai-01 (2026-08-17 06:44Z): « Précondition avant de lancer le harnais sur fichier réel : poser la garde sorry_delta > 0 ». Le harnais ne doit **jamais** persister un fichier dont le count sorry **augmente** sans que rien ne soit prouvé.

Le branche kept-snapshot (provers.py:893-901) écrivait `last_ok_content` même quand `final > original` — L2551 a été committé exactement ainsi (4→8, mislabellé `structural_only`/`success=True`, forensic #7477). Cette garde ferme le trou au niveau du workflow, là où le reclassement P3 ne faisait que classer.

## Changements (3 fichiers, 89 insertions)

- **`decomposition_regression.py`** : nouveau prédicat `is_worsened_unproven(final_sorry, original_sorry_count, proof_found)` — `final > original` ET pas de `proof_found`. `proof_found` exempt (prouver la cible = progrès réel même si sorries collatérales croissent — reverter jetterait la preuve). Exporté dans `__all__`.
- **`provers.py`** (chemin multi, dans le `finally:` post-boucle) :
  - latch `regressed = False` à côté du défaut `final_build_ok = False` ;
  - **write-guard** après le branche kept-snapshot : si `is_worsened_unproven(...)` → revert à `original_content` + reset `_best_content`/`_best_sorry_count` + `structural_progress = False` + `regressed = True` + message `REGRESSED` ;
  - success calc : `and not is_worsened_unproven(...)` — une run REGRESSED est structurellement `success = False` ;
  - résultat : nouveau champ `"regressed": regressed` dans `*_result.json` (forensic lisible).
- **`tests/test_decomposition_regression.py`** : `TestWorsenedUnproven` (7 tests) — L2551 4→8 flags, L849 10→11 flags, same-count hors territoire (FX-8), drop hors territoire, `proof_found` exempt, bool réel, export `__all__`.

## Commit 2 — itér-3 build-aware (13438a81e, 3 fichiers, +103)

**Iter-3 directive ai-01 (DM 2026-08-17T20:41Z)**: « un test qui reproduit exactement ton cas (texte 2==2, build 2->3) et qui échoue sur la garde actuelle ».

**Le trou (découvert par itér-3, lien avec #1500)** : la garde itér-2 compare les comptes **TEXTE** (`final_sorry` depuis `count_real_sorries`). Or `compile()` replie déjà le warning `apply?/exact?/solve_by_elim` dans `final_verify["sorry_count"]` (build-aware, #1500). Cas réel : texte 2==2 → la garde itér-2 laisse persister le kept-snapshot, mais le build révèle 2→3 (sorry implicite). `structural_progress=False` seul **ne revert pas** — le fichier aggravé reste sur disque, la run est juste marquée non-success.

**Fix** : dans le bloc d'adoption build-aware (`if isinstance(_verify_sorry, int) and _verify_sorry > final_sorry:`), **re-check** `is_worsened_unproven` avec le compte build-aware → revert à `original_content` + reset `_best_content`/`_best_sorry_count` + `structural_progress=False` sur hausse vérifiée (message `REGRESSED (build-aware)`). La garde ne persiste **jamais** un fichier dont le compte build-aware croît sans preuve.

**Tests** :
- `TestBuildAwareBlindSpot` (3 tests) — reproduit exactement le cas : texte 2==2 passe l'ancienne garde (`False`), build 2→3 la déclenche (`True`), exemption preuve respectée (2→3 avec `proof_found=True` → `False`).
- `test_iter3_buildaware_writeguard_recheck_wired` — cablage lexical : le re-check `is_worsened_unproven` doit être **dans** le bloc d'adoption (par indentation), pas le success-gate itér-2 qui arrive après. Vérifié : échoue sur le source itér-2 seul (testé via `git show 7a7551399`), passe sur le fix.

## Validation (critère B — 0 `.lean` touché, `lake build` non applicable)

- `python -m pytest tests/test_prover_guards.py tests/test_decomposition_regression.py -q` : **230 passed** (199 guards + 31 decomposition), 1.47 s.
- `python -m py_compile prover/provers.py prover/decomposition_regression.py` : OK.
- `grep -c sorry` : **0 fichier `.lean` touché** — aucune preuve modifiée (SSD discipline 22/08 : pas de `lake build` lourd sur l'arbre partagé).

## Interaction avec la taxonomie P3 (#7477) — inchangée

La taxonomie `structural_only` vs `decomposition_regression` est **délibérée** (ai-01 07:30Z point 5, #7477/#7629 : « Rien à corriger là-dessus »). Cette garde **ne touche pas** à la taxonomie : elle agit **en amont** — une run qui finirait aggravée et non prouvée est reventée avant d'être classée. Le success-decoupling (06:44Z item 1) est subsumé : revert → `structural_progress=False` → `success=False`, sans modifier le reclassement.

## Pourquoi cette PR est un prérequis

La PR doit être **mergée avant** le sweep BG knot_lean (directive 08:48Z) : le harnais doit tourner **depuis** une version qui protège les fichiers réels. La garde est le filet de sécurité du sweep — sans elle, un kept-snapshot aggravé sur Conway.lean serait committé comme `structural_only`.

See #1453 (epic co-évolution prover). See #7477 (forensic fondateur P3). See #1500 (comptes build-aware).

