### PR TITLE
fix(genai,#11112): re-exec 11_Quantization -> execution_count CLEAN 1..14

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "cost-fm-11",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004204,
+     "end_time": "2026-08-17T10:29:11.289419",
+     "exception": false,
+     "start_time": "2026-08-17T10:29:11.285215",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# 11. Quantization\n"
    ]
@@ -14,16 +23,16 @@
    "id": "a1b2c3d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:01.933112Z",
-     "iopub.status.busy": "2026-06-24T14:46:01.932827Z",
-     "iopub.status.idle": "2026-06-24T14:46:01.936961Z",
-     "shell.execute_reply": "2026-06-24T14:46:01.936306Z"
+     "iopub.execute_input": "2026-08-17T10:29:11.300877Z",
+     "iopub.status.busy": "2026-08-17T10:29:11.300462Z",
+     "iopub.status.idle": "2026-08-17T10:29:11.304544Z",
+     "shell.execute_reply": "2026-08-17T10:29:11.303848Z"
     },
     "papermill": {
-     "duration": 0.011243,
-     "end_time": "2026-06-24T14:46:01.938180",
+     "duration": 0.012234,
+     "end_time": "2026-08-17T10:29:11.305989",
      "exception": false,
-     "start_time": "2026-06-24T14:46:01.926937",
+     "start_time": "2026-08-17T10:29:11.293755",
      "status": "completed"
     },
     "tags": [
@@ -39,19 +48,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "ca3c45ce",
+   "id": "3ddc82c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:01.949318Z",
-     "iopub.status.busy": "2026-06-24T14:46:01.948746Z",
-     "iopub.status.idle": "2026-06-24T14:46:01.952019Z",
-     "shell.execute_reply": "2026-06-24T14:46:01.951398Z"
+     "iopub.execute_input": "2026-08-17T10:29:11.318193Z",
+     "iopub.status.busy": "2026-08-17T10:29:11.317838Z",
+     "iopub.status.idle": "2026-08-17T10:29:11.320728Z",
+     "shell.execute_reply": "2026-08-17T10:29:11.320288Z"
     },
     "papermill": {
-     "duration": 0.010057,
-     "end_time": "2026-06-24T14:46:01.953107",
+     "duration": 0.011177,
+     "end_time": "2026-08-17T10:29:11.322116",
      "exception": false,
-     "start_time": "2026-06-24T14:46:01.943050",
+     "start_time": "2026-08-17T10:29:11.310939",
      "status": "completed"
     },
     "tags": [
@@ -69,10 +78,10 @@
    "id": "b2c3d4e5",
    "metadata": {
     "papermill": {
-     "duration": 0.004339,
-     "end_time": "2026-06-24T14:46:01.961851",
+     "duration": 0.00616,
+     "end_time": "2026-08-17T10:29:11.332966",
      "exception": false,
-     "start_time": "2026-06-24T14:46:01.957512",
+     "start_time": "2026-08-17T10:29:11.326806",
      "status": "completed"
     },
     "tags": []
@@ -112,10 +121,10 @@
    "id": "c3d4e5f6",
    "metadata": {
     "papermill": {
-     "duration": 0.004499,
-     "end_time": "2026-06-24T14:46:01.972226",
+     "duration": 0.004152,
+     "end_time": "2026-08-17T10:29:11.341808",
      "exception": false,
-     "start_time": "2026-06-24T14:46:01.967727",
+     "start_time": "2026-08-17T10:29:11.337656",
      "status": "completed"
     },
     "tags": []
@@ -160,10 +169,10 @@
    "id": "d4e5f6a7",
    "metadata": {
     "papermill": {
-     "duration": 0.005693,
-     "end_time": "2026-06-24T14:46:01.983521",
+     "duration": 0.005465,
+     "end_time": "2026-08-17T10:29:11.351517",
      "exception": false,
-     "start_time": "2026-06-24T14:46:01.977828",
+     "start_time": "2026-08-17T10:29:11.346052",
      "status": "completed"
     },
     "tags": []
@@ -182,16 +191,16 @@
    "id": "e5f6a7b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:01.995477Z",
-     "iopub.status.busy": "2026-06-24T14:46:01.995103Z",
-     "iopub.status.idle": "2026-06-24T14:46:08.664887Z",
-     "shell.execute_reply": "2026-06-24T14:46:08.664086Z"
+     "iopub.execute_input": "2026-08-17T10:29:11.361958Z",
+     "iopub.status.busy": "2026-08-17T10:29:11.361576Z",
+     "iopub.status.idle": "2026-08-17T10:29:13.143471Z",
+     "shell.execute_reply": "2026-08-17T10:29:13.142823Z"
     },
     "papermill": {
-     "duration": 6.677216,
-     "end_time": "2026-06-24T14:46:08.665971",
+     "duration": 1.788306,
+     "end_time": "2026-08-17T10:29:13.144830",
      "exception": false,
-     "start_time": "2026-06-24T14:46:01.988755",
+     "start_time": "2026-08-17T10:29:11.356524",
      "status": "completed"
     },
     "tags": []
@@ -208,7 +217,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Pas de GPU disponible\n"
+      "GPU: NVIDIA GeForce RTX 3090 (24.0 GB)\n"
      ]
     }
    ],
@@ -245,10 +254,10 @@
    "id": "f6a7b8c9",
    "metadata": {
     "papermill": {
-     "duration": 0.004012,
-     "end_time": "2026-06-24T14:46:08.673902",
+     "duration": 0.003116,
+     "end_time": "2026-08-17T10:29:13.152458",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.669890",
+     "start_time": "2026-08-17T10:29:13.149342",
      "status": "completed"
     },
     "tags": []
@@ -277,10 +286,10 @@
    "id": "a7b8c9d0",
    "metadata": {
     "papermill": {
-     "duration": 0.003756,
-     "end_time": "2026-06-24T14:46:08.681577",
+     "duration": 0.004339,
+     "end_time": "2026-08-17T10:29:13.159919",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.677821",
+     "start_time": "2026-08-17T10:29:13.155580",
      "status": "completed"
     },
     "tags": []
@@ -318,16 +327,16 @@
    "id": "b8c9d0e1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:08.691114Z",
-     "iopub.status.busy": "2026-06-24T14:46:08.690754Z",
-     "iopub.status.idle": "2026-06-24T14:46:08.697195Z",
-     "shell.execute_reply": "2026-06-24T14:46:08.696565Z"
+     "iopub.execute_input": "2026-08-17T10:29:13.173916Z",
+     "iopub.status.busy": "2026-08-17T10:29:13.173586Z",
+     "iopub.status.idle": "2026-08-17T10:29:13.179418Z",
+     "shell.execute_reply": "2026-08-17T10:29:13.178939Z"
     },
     "papermill": {
-     "duration": 0.012801,
-     "end_time": "2026-06-24T14:46:08.698240",
+     "duration": 0.013586,
+     "end_time": "2026-08-17T10:29:13.180175",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.685439",
+     "start_time": "2026-08-17T10:29:13.166589",
      "status": "completed"
     },
     "tags": []
@@ -390,10 +399,10 @@
    "id": "40274ffc",
    "metadata": {
     "papermill": {
-     "duration": 0.003997,
-     "end_time": "2026-06-24T14:46:08.706567",
+     "duration": 0.004674,
+     "end_time": "2026-08-17T10:29:13.188937",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.702570",
+     "start_time": "2026-08-17T10:29:13.184263",
      "status": "completed"
     },
     "tags": []
@@ -424,16 +433,16 @@
    "id": "145ba24f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:08.716584Z",
-     "iopub.status.busy": "2026-06-24T14:46:08.716155Z",
-     "iopub.status.idle": "2026-06-24T14:46:08.721098Z",
-     "shell.execute_reply": "2026-06-24T14:46:08.720596Z"
+     "iopub.execute_input": "2026-08-17T10:29:13.199486Z",
+     "iopub.status.busy": "2026-08-17T10:29:13.199199Z",
+     "iopub.status.idle": "2026-08-17T10:29:13.205200Z",
+     "shell.execute_reply": "2026-08-17T10:29:13.204358Z"
     },
     "papermill": {
-     "duration": 0.011454,
-     "end_time": "2026-06-24T14:46:08.721974",
+     "duration": 0.013564,
+     "end_time": "2026-08-17T10:29:13.206667",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.710520",
+     "start_time": "2026-08-17T10:29:13.193103",
      "status": "completed"
     },
     "tags": []
@@ -495,10 +504,10 @@
    "id": "c9d0e1f2",
    "metadata": {
     "papermill": {
-     "duration": 0.003738,
-     "end_time": "2026-06-24T14:46:08.729605",
+     "duration": 0.00382,
+     "end_time": "2026-08-17T10:29:13.214075",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.725867",
+     "start_time": "2026-08-17T10:29:13.210255",
      "status": "completed"
     },
     "tags": []
@@ -528,10 +537,10 @@
    "id": "d0e1f2a3",
    "metadata": {
     "papermill": {
-     "duration": 0.0036,
-     "end_time": "2026-06-24T14:46:08.736829",
+     "duration": 0.003378,
+     "end_time": "2026-08-17T10:29:13.222314",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.733229",
+     "start_time": "2026-08-17T10:29:13.218936",
      "status": "completed"
     },
     "tags": []
@@ -587,10 +596,10 @@
    "id": "e1f2a3b4",
    "metadata": {
     "papermill": {
-     "duration": 0.004986,
-     "end_time": "2026-06-24T14:46:08.745629",
+     "duration": 0.004206,
+     "end_time": "2026-08-17T10:29:13.231681",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.740643",
+     "start_time": "2026-08-17T10:29:13.227475",
      "status": "completed"
     },
     "tags": []
@@ -612,16 +621,16 @@
    "id": "f2a3b4c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:08.757136Z",
-     "iopub.status.busy": "2026-06-24T14:46:08.756251Z",
-     "iopub.status.idle": "2026-06-24T14:46:08.765151Z",
-     "shell.execute_reply": "2026-06-24T14:46:08.764440Z"
+     "iopub.execute_input": "2026-08-17T10:29:13.240780Z",
+     "iopub.status.busy": "2026-08-17T10:29:13.240528Z",
+     "iopub.status.idle": "2026-08-17T10:29:13.247475Z",
+     "shell.execute_reply": "2026-08-17T10:29:13.246581Z"
     },
     "papermill": {
-     "duration": 0.016822,
-     "end_time": "2026-06-24T14:46:08.766265",
+     "duration": 0.012959,
+     "end_time": "2026-08-17T10:29:13.248433",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.749443",
+     "start_time": "2026-08-17T10:29:13.235474",
      "status": "completed"
     },
     "tags": []
@@ -693,10 +702,10 @@
    "id": "a3b4c5d6",
    "metadata": {
     "papermill": {
-     "duration": 0.003577,
-     "end_time": "2026-06-24T14:46:08.773582",
+     "duration": 0.003429,
+     "end_time": "2026-08-17T10:29:13.255261",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.770005",
+     "start_time": "2026-08-17T10:29:13.251832",
      "status": "completed"
     },
     "tags": []
@@ -726,10 +735,10 @@
    "id": "b4c5d6e7",
    "metadata": {
     "papermill": {
-     "duration": 0.00369,
-     "end_time": "2026-06-24T14:46:08.780772",
+     "duration": 0.003399,
+     "end_time": "2026-08-17T10:29:13.262703",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.777082",
+     "start_time": "2026-08-17T10:29:13.259304",
      "status": "completed"
     },
     "tags": []
@@ -773,16 +782,16 @@
    "id": "c5d6e7f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:08.790165Z",
-     "iopub.status.busy": "2026-06-24T14:46:08.789773Z",
-     "iopub.status.idle": "2026-06-24T14:46:08.794984Z",
-     "shell.execute_reply": "2026-06-24T14:46:08.794288Z"
+     "iopub.execute_input": "2026-08-17T10:29:13.270762Z",
+     "iopub.status.busy": "2026-08-17T10:29:13.270272Z",
+     "iopub.status.idle": "2026-08-17T10:29:13.275902Z",
+     "shell.execute_reply": "2026-08-17T10:29:13.275302Z"
     },
     "papermill": {
-     "duration": 0.011324,
-     "end_time": "2026-06-24T14:46:08.796032",
+     "duration": 0.01094,
+     "end_time": "2026-08-17T10:29:13.277171",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.784708",
+     "start_time": "2026-08-17T10:29:13.266231",
      "status": "completed"
     },
     "tags": []
@@ -934,10 +943,10 @@
    "id": "8499bea0",
    "metadata": {
     "papermill": {
-     "duration": 0.004026,
-     "end_time": "2026-06-24T14:46:08.803932",
+     "duration": 0.004248,
+     "end_time": "2026-08-17T10:29:13.285616",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.799906",
+     "start_time": "2026-08-17T10:29:13.281368",
      "status": "completed"
     },
     "tags": []
@@ -967,16 +976,16 @@
    "id": "01c21b88",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:08.814046Z",
-     "iopub.status.busy": "2026-06-24T14:46:08.813732Z",
-     "iopub.status.idle": "2026-06-24T14:46:08.818973Z",
-     "shell.execute_reply": "2026-06-24T14:46:08.818313Z"
+     "iopub.execute_input": "2026-08-17T10:29:13.294678Z",
+     "iopub.status.busy": "2026-08-17T10:29:13.294269Z",
+     "iopub.status.idle": "2026-08-17T10:29:13.298955Z",
+     "shell.execute_reply": "2026-08-17T10:29:13.298270Z"
     },
     "papermill": {
-     "duration": 0.012211,
-     "end_time": "2026-06-24T14:46:08.820448",
+     "duration": 0.010779,
+     "end_time": "2026-08-17T10:29:13.300070",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.808237",
+     "start_time": "2026-08-17T10:29:13.289291",
      "status": "completed"
     },
     "tags": []
@@ -1031,10 +1040,10 @@
    "id": "d6e7f8a9",
    "metadata": {
     "papermill": {
-     "duration": 0.005743,
-     "end_time": "2026-06-24T14:46:08.831110",
+     "duration": 0.004757,
+     "end_time": "2026-08-17T10:29:13.309896",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.825367",
+     "start_time": "2026-08-17T10:29:13.305139",
      "status": "completed"
     },
     "tags": []
@@ -1073,10 +1082,10 @@
    "id": "e7f8a9b0",
    "metadata": {
     "papermill": {
-     "duration": 0.004291,
-     "end_time": "2026-06-24T14:46:08.841113",
+     "duration": 0.00372,
+     "end_time": "2026-08-17T10:29:13.317372",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.836822",
+     "start_time": "2026-08-17T10:29:13.313652",
      "status": "completed"
     },
     "tags": []
@@ -1133,16 +1142,16 @@
    "id": "f8a9b0c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:08.851572Z",
-     "iopub.status.busy": "2026-06-24T14:46:08.851140Z",
-     "iopub.status.idle": "2026-06-24T14:46:08.857965Z",
-     "shell.execute_reply": "2026-06-24T14:46:08.857384Z"
+     "iopub.execute_input": "2026-08-17T10:29:13.329087Z",
+     "iopub.status.busy": "2026-08-17T10:29:13.328538Z",
+     "iopub.status.idle": "2026-08-17T10:29:13.334844Z",
+     "shell.execute_reply": "2026-08-17T10:29:13.334122Z"
     },
     "papermill": {
-     "duration": 0.013762,
-     "end_time": "2026-06-24T14:46:08.859253",
+     "duration": 0.013598,
+     "end_time": "2026-08-17T10:29:13.335861",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.845491",
+     "start_time": "2026-08-17T10:29:13.322263",
      "status": "completed"
     },
     "tags": []
@@ -1279,10 +1288,10 @@
    "id": "74c573fd",
    "metadata": {
     "papermill": {
-     "duration": 0.004244,
-     "end_time": "2026-06-24T14:46:08.867846",
+     "duration": 0.003967,
+     "end_time": "2026-08-17T10:29:13.343664",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.863602",
+     "start_time": "2026-08-17T10:29:13.339697",
      "status": "completed"
     },
     "tags": []
@@ -1311,16 +1320,16 @@
    "id": "a20f8fa6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:08.879194Z",
-     "iopub.status.busy": "2026-06-24T14:46:08.878437Z",
-     "iopub.status.idle": "2026-06-24T14:46:08.884093Z",
-     "shell.execute_reply": "2026-06-24T14:46:08.883442Z"
+     "iopub.execute_input": "2026-08-17T10:29:13.354437Z",
+     "iopub.status.busy": "2026-08-17T10:29:13.354020Z",
+     "iopub.status.idle": "2026-08-17T10:29:13.359054Z",
+     "shell.execute_reply": "2026-08-17T10:29:13.358297Z"
     },
     "papermill": {
-     "duration": 0.012917,
-     "end_time": "2026-06-24T14:46:08.885238",
+     "duration": 0.01321,
+     "end_time": "2026-08-17T10:29:13.360587",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.872321",
+     "start_time": "2026-08-17T10:29:13.347377",
      "status": "completed"
     },
     "tags": []
@@ -1330,7 +1339,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer : implementer identify_exclusions()\n",
+      "Exercice a completer : implementer identify_exclusions()"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "Couches a analyser : 7\n"
      ]
     }
@@ -1372,10 +1388,10 @@
    "id": "a9b0c1d2",
    "metadata": {
     "papermill": {
-     "duration": 0.004236,
-     "end_time": "2026-06-24T14:46:08.894227",
+     "duration": 0.003444,
+     "end_time": "2026-08-17T10:29:13.367550",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.889991",
+     "start_time": "2026-08-17T10:29:13.364106",
      "status": "completed"
     },
     "tags": []
@@ -1408,10 +1424,10 @@
    "id": "b0c1d2e3",
    "metadata": {
     "papermill": {
-     "duration": 0.004913,
-     "end_time": "2026-06-24T14:46:08.903602",
+     "duration": 0.003555,
+     "end_time": "2026-08-17T10:29:13.375044",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.898689",
+     "start_time": "2026-08-17T10:29:13.371489",
      "status": "completed"
     },
     "tags": []
@@ -1463,20 +1479,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "id": "c1d2e3f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:08.915156Z",
-     "iopub.status.busy": "2026-06-24T14:46:08.914744Z",
-     "iopub.status.idle": "2026-06-24T14:46:10.115937Z",
-     "shell.execute_reply": "2026-06-24T14:46:10.114664Z"
+     "iopub.execute_input": "2026-08-17T10:29:13.383753Z",
+     "iopub.status.busy": "2026-08-17T10:29:13.383504Z",
+     "iopub.status.idle": "2026-08-17T10:29:14.120873Z",
+     "shell.execute_reply": "2026-08-17T10:29:14.120433Z"
     },
     "papermill": {
-     "duration": 1.208883,
-     "end_time": "2026-06-24T14:46:10.117565",
+     "duration": 0.742486,
+     "end_time": "2026-08-17T10:29:14.121623",
      "exception": false,
-     "start_time": "2026-06-24T14:46:08.908682",
+     "start_time": "2026-08-17T10:29:13.379137",
      "status": "completed"
     },
     "tags": []
@@ -1485,7 +1501,13 @@
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": ".env charge depuis: .env\nAucun endpoint vLLM local configure (OPENAI_BASE_URL_2/3 absents du .env).\nLes benchmarks ci-apres proviennent de la stack de production (3x RTX 4090).\n"
+     "text": [
+      "WARNING: .env non trouve, utilisation variables environnement\n",
+      "Configurez OPENAI_API_KEY_2/3, OPENAI_BASE_URL_2/3, OPENAI_CHAT_MODEL_ID_2/3\n",
+      "Voir le fichier .env.example pour les details de configuration\n",
+      "Aucun endpoint vLLM local configure (OPENAI_BASE_URL_2/3 absents du .env).\n",
+      "Les benchmarks ci-apres proviennent de la stack de production (3x RTX 4090).\n"
+     ]
     }
    ],
    "source": [
@@ -1568,10 +1590,10 @@
    "id": "i069zh3a5i",
    "metadata": {
     "papermill": {
-     "duration": 0.005796,
-     "end_time": "2026-06-24T14:46:10.129997",
+     "duration": 0.003294,
+     "end_time": "2026-08-17T10:29:14.128623",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.124201",
+     "start_time": "2026-08-17T10:29:14.125329",
      "status": "completed"
     },
     "tags": []
@@ -1588,16 +1610,16 @@
    "id": "c52d5886",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:10.142989Z",
-     "iopub.status.busy": "2026-06-24T14:46:10.142641Z",
-     "iopub.status.idle": "2026-06-24T14:46:10.149648Z",
-     "shell.execute_reply": "2026-06-24T14:46:10.148366Z"
+     "iopub.execute_input": "2026-08-17T10:29:14.136166Z",
+     "iopub.status.busy": "2026-08-17T10:29:14.135884Z",
+     "iopub.status.idle": "2026-08-17T10:29:14.140631Z",
+     "shell.execute_reply": "2026-08-17T10:29:14.139815Z"
     },
     "papermill": {
-     "duration": 0.015628,
-     "end_time": "2026-06-24T14:46:10.151316",
+     "duration": 0.009758,
+     "end_time": "2026-08-17T10:29:14.141618",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.135688",
+     "start_time": "2026-08-17T10:29:14.131860",
      "status": "completed"
     },
     "tags": []
@@ -1639,10 +1661,10 @@
    "id": "d2e3f4a5",
    "metadata": {
     "papermill": {
-     "duration": 0.005646,
-     "end_time": "2026-06-24T14:46:10.163297",
+     "duration": 0.003377,
+     "end_time": "2026-08-17T10:29:14.148370",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.157651",
+     "start_time": "2026-08-17T10:29:14.144993",
      "status": "completed"
     },
     "tags": []
@@ -1674,10 +1696,10 @@
    "id": "e3f4a5b6",
    "metadata": {
     "papermill": {
-     "duration": 0.005667,
-     "end_time": "2026-06-24T14:46:10.174869",
+     "duration": 0.003958,
+     "end_time": "2026-08-17T10:29:14.155745",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.169202",
+     "start_time": "2026-08-17T10:29:14.151787",
      "status": "completed"
     },
     "tags": []
@@ -1706,16 +1728,16 @@
    "id": "f4a5b6c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:10.189385Z",
-     "iopub.status.busy": "2026-06-24T14:46:10.188622Z",
-     "iopub.status.idle": "2026-06-24T14:46:10.197593Z",
-     "shell.execute_reply": "2026-06-24T14:46:10.196646Z"
+     "iopub.execute_input": "2026-08-17T10:29:14.165219Z",
+     "iopub.status.busy": "2026-08-17T10:29:14.164980Z",
+     "iopub.status.idle": "2026-08-17T10:29:14.169906Z",
+     "shell.execute_reply": "2026-08-17T10:29:14.169334Z"
     },
     "papermill": {
-     "duration": 0.019195,
-     "end_time": "2026-06-24T14:46:10.199514",
+     "duration": 0.011337,
+     "end_time": "2026-08-17T10:29:14.170657",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.180319",
+     "start_time": "2026-08-17T10:29:14.159320",
      "status": "completed"
     },
     "tags": []
@@ -1802,10 +1824,10 @@
    "id": "a5b6c7d8",
    "metadata": {
     "papermill": {
-     "duration": 0.005782,
-     "end_time": "2026-06-24T14:46:10.211040",
+     "duration": 0.007273,
+     "end_time": "2026-08-17T10:29:14.185290",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.205258",
+     "start_time": "2026-08-17T10:29:14.178017",
      "status": "completed"
     },
     "tags": []
@@ -1847,10 +1869,10 @@
    "id": "b6c7d8e9",
    "metadata": {
     "papermill": {
-     "duration": 0.005744,
-     "end_time": "2026-06-24T14:46:10.222780",
+     "duration": 0.003605,
+     "end_time": "2026-08-17T10:29:14.192562",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.217036",
+     "start_time": "2026-08-17T10:29:14.188957",
      "status": "completed"
     },
     "tags": []
@@ -1879,16 +1901,16 @@
    "id": "c7d8e9f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-24T14:46:10.239307Z",
-     "iopub.status.busy": "2026-06-24T14:46:10.238745Z",
-     "iopub.status.idle": "2026-06-24T14:46:10.247643Z",
-     "shell.execute_reply": "2026-06-24T14:46:10.246415Z"
+     "iopub.execute_input": "2026-08-17T10:29:14.201526Z",
+     "iopub.status.busy": "2026-08-17T10:29:14.201189Z",
+     "iopub.status.idle": "2026-08-17T10:29:14.205645Z",
+     "shell.execute_reply": "2026-08-17T10:29:14.205251Z"
     },
     "papermill": {
-     "duration": 0.021741,
-     "end_time": "2026-06-24T14:46:10.250326",
+     "duration": 0.009643,
+     "end_time": "2026-08-17T10:29:14.206736",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.228585",
+     "start_time": "2026-08-17T10:29:14.197093",
      "status": "completed"
     },
     "tags": []
@@ -1955,10 +1977,10 @@
    "id": "d8e9f0a1",
    "metadata": {
     "papermill": {
-     "duration": 0.006227,
-     "end_time": "2026-06-24T14:46:10.263158",
+     "duration": 0.003417,
+     "end_time": "2026-08-17T10:29:14.213962",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.256931",
+     "start_time": "2026-08-17T10:29:14.210545",
      "status": "completed"
     },
     "tags": []
@@ -1991,10 +2013,10 @@
    "id": "e9f0a1b2",
    "metadata": {
     "papermill": {
-     "duration": 0.008649,
-     "end_time": "2026-06-24T14:46:10.282052",
+     "duration": 0.003307,
+     "end_time": "2026-08-17T10:29:14.220590",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.273403",
+     "start_time": "2026-08-17T10:29:14.217283",
      "status": "completed"
     },
     "tags": []
@@ -2042,10 +2064,10 @@
    "id": "f0a1b2c3",
    "metadata": {
     "papermill": {
-     "duration": 0.006429,
-     "end_time": "2026-06-24T14:46:10.295146",
+     "duration": 0.003682,
+     "end_time": "2026-08-17T10:29:14.227596",
      "exception": false,
-     "start_time": "2026-06-24T14:46:10.288717",
+     "start_time": "2026-08-17T10:29:14.223914",
      "status": "completed"
     },
     "tags": []
@@ -2102,6 +2124,23 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "hf",
+   "api_usd_est": 0.0,
+   "cpu_min": 20,
+   "external_account": "hf",
+   "free_alternative": null,
+   "gpu_min": 32,
+   "gpu_required": true,
+   "metadata_written": "2026-07-23",
+   "network": true,
+   "notes": "Exploration de la quantization (bitsandbytes load_in_4bit, fp8, GPTQ-W4A16) sur Qwen3.5 (0.8B -> 35B-A3B). gpu_required=true, vram range 8-24 Go (MID a HIGH selon le modele). Requiere download de modeles depuis Hugging Face (network=true). Le 35B-A3B (MoE) peut tenir en fp8 sur 24 Go.",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual",
+   "vram_gb": "8-24",
+   "vram_tier": "HIGH"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -2121,34 +2160,17 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 11.320512,
-   "end_time": "2026-06-24T14:46:11.178831",
+   "duration": 5.382749,
+   "end_time": "2026-08-17T10:29:14.897163",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GenAI/Texte/11_Quantization.ipynb",
+   "input_path": "D:\\Dev\\CoursIA-11112-quant\\MyIA.AI.Notebooks\\GenAI\\Texte\\11_Quantization.ipynb",
+   "output_path": "D:\\Dev\\CoursIA-11112-quant\\MyIA.AI.Notebooks\\GenAI\\Texte\\11_Quantization_output.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },
-   "start_time": "2026-06-24T14:45:59.858319",
+   "start_time": "2026-08-17T10:29:09.514414",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "hf",
-   "cpu_min": 20,
-   "gpu_min": 32,
-   "gpu_required": true,
-   "vram_gb": "8-24",
-   "vram_tier": "HIGH",
-   "network": true,
-   "external_account": "hf",
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": "2026-07-23",
-   "validator": "manual",
-   "notes": "Exploration de la quantization (bitsandbytes load_in_4bit, fp8, GPTQ-W4A16) sur Qwen3.5 (0.8B -> 35B-A3B). gpu_required=true, vram range 8-24 Go (MID a HIGH selon le modele). Requiere download de modeles depuis Hugging Face (network=true). Le 35B-A3B (MoE) peut tenir en fp8 sur 24 Go."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary
- Re-exécution papermill complète du notebook 11_Quantization (GenAI/Texte) en mode batch sur GPU local
- `execution_count` CLEAN 1..14 (était `[1..10, 2, 12, 13, 14]` — doublon résidu d'exécution partielle)
- Outputs réels : GPU NVIDIA RTX 3090 détecté, tableaux VRAM BF16/INT8/W4A16 régénérés, stub exercice `identify_exclusions()` conservé (« Exercice a completer »)
- 0 erreur, 0 `NotImplementedError`

## Validation
- Papermill SUCCESS (7.1s, 14 cellules)
- `EXEC_PROVED` : outputs réels (tableaux VRAM, configurations GPTQ)
- Sources byte-identiques à main hors cellule Parameters (normalisation papermill standard)
- Validator : OK 1, 0 warning, 0 erreur

See #11112