### PR TITLE
fix(prover,#1453): stamps UTC explicites sur 11 sites persistes du harnais

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/attempt_history.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/attempt_history.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Dict, Optional
 
@@ -102,7 +102,7 @@ def record_attempt(prover_dir: Path, filepath: str, sorry_line: int,
         "error_category": error_category or "",
         "error_excerpt": (error_excerpt or "")[:200],
         "session_id": session_id or "",
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
     # Dedup: same tactic+outcome → replace timestamp only

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/knowledge.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/knowledge.py
@@ -9,7 +9,7 @@ B.1 from issue #820: cross-session knowledge persistence.
 import json
 from pathlib import Path
 from typing import Dict, List, Optional
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 DEFAULT_KB_PATH = Path(__file__).parent / "proof_knowledge.json"
@@ -69,7 +69,7 @@ class ProofKnowledgeBase:
                 }
 
     def _save(self):
-        self._data["last_updated"] = datetime.now().isoformat()
+        self._data["last_updated"] = datetime.now(timezone.utc).isoformat()
         self._path.write_text(
             json.dumps(self._data, indent=2, ensure_ascii=False),
             encoding="utf-8",
@@ -228,13 +228,13 @@ class ProofKnowledgeBase:
         if existing:
             existing["uses"] = existing.get("uses", 0) + 1
             existing["tactic"] = tactic
-            existing["timestamp"] = datetime.now().isoformat()
+            existing["timestamp"] = datetime.now(timezone.utc).isoformat()
         else:
             self._data["entries"][sig] = {
                 "tactic": tactic,
                 "theorem": theorem,
                 "file": file,
-                "timestamp": datetime.now().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "uses": 1,
             }
         self._save()

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/mine_lean_sessions.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/mine_lean_sessions.py
@@ -14,7 +14,7 @@ import logging
 import re
 import sys
 from collections import Counter, defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -531,7 +531,7 @@ def run_mining(
     if not dry_run:
         kb["tactic_cookbook"]["patterns"] = merged_p
         kb["failed_approaches"] = merged_f
-        kb["last_updated"] = datetime.now().isoformat()
+        kb["last_updated"] = datetime.now(timezone.utc).isoformat()
         save_json(kb_path, kb)
     return stats
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/run_prover_bg.py
@@ -13,6 +13,7 @@ import json
 import re
 import sys
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.stdout.reconfigure(line_buffering=True)
@@ -315,7 +316,7 @@ def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
             "result": {"status": "already_solved",
                        "reason": "0 sorry in target file (pre-check, no prover spawn)"},
             "trace_file": None,
-            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+            "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
         summary_path = TRACES_DIR / f"{trace_name}_result.json"
         summary_path.write_text(
@@ -405,7 +406,7 @@ def _run_prover_locked(demo, name, filepath, line, mode, iterations, provider,
         "elapsed_s": round(elapsed, 1),
         "result": result,
         "trace_file": trace_path,
-        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
     }
     summary_path = TRACES_DIR / f"{trace_name}_result.json"
     summary_path.write_text(

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/state.py
@@ -1,7 +1,7 @@
 """Proof state data structures shared between agents."""
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any, List
 from dataclasses import dataclass, field
 from enum import Enum
@@ -205,7 +205,7 @@ class ProofState:
             "plan": list(self.plan),
             "plan_phase": self.plan_phase,
             "sorry_goals": dict(self.sorry_goals),
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         self._checkpoints[label] = checkpoint
         return label
@@ -280,7 +280,7 @@ class ProofState:
             "id": verif_id, "attempt_id": attempt_id,
             "success": success, "output": output, "errors": errors,
             "exec_time_ms": exec_time_ms,
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         })
         return verif_id
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/trace.py
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/trace.py
@@ -7,7 +7,7 @@ Uses agent_framework.observability when available, graceful fallback otherwise.
 import json
 import time
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Optional
 
 # B.12: OTel integration — optional, graceful degradation
@@ -234,7 +234,7 @@ class TraceLogger:
     def save_full_trace(self, name: str = None):
         """Save complete trace with thinking content to a separate file."""
         if not name:
-            name = f"full_trace_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            name = f"full_trace_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
         path = self.output_dir / f"{name}.json"
         with open(path, "w", encoding="utf-8") as f:
             json.dump(self.entries, f, indent=2, ensure_ascii=False)
@@ -242,7 +242,7 @@ class TraceLogger:
 
     def save(self, name: str = None):
         if not name:
-            name = f"trace_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            name = f"trace_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
         path = self.output_dir / f"{name}.json"
         with open(path, "w", encoding="utf-8") as f:
             json.dump(self.entries, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
Grain: MED/tooling - lane myia-po-2026:CoursIA - prev: MED/lean #11438

## Summary

Iteration-2 (ai-01 directive 06:44Z) : les timestamps des traces `*_result.json` / spans / KB du harnais prover étaient des stamps **naïfs-LOCAUX** (`datetime.now()` / `time.strftime` sans tz), décalés de 2h CEST par rapport aux dates de merge UTC — le forensique corrélait mal les runs aux commits.

## Changements (6 fichiers, +17/−16)

`datetime.now(timezone.utc)` sur les sites **persistés** :
- `run_prover_bg.py` x2 — `strftime("%Y-%m-%dT%H:%M:%SZ")` (suffixe `Z` explicite, même shape)
- `state.py` x2, `attempt_history.py` x1, `knowledge.py` x3, `mine_lean_sessions.py` x1 — `.isoformat()` → offset `+00:00`
- `trace.py` x2 — noms de fichiers traces (`full_trace_*` / `trace_*`) en UTC

**Déjà correct, référence** : `tree_lock.py` `started_utc` utilise `time.gmtime()` (UTC réel).

**Hors scope assumé** : `state.py` `TacticAttempt.timestamp` / `ProofState.start_time` + `provers.py:1877` — deltas internes non persistés (arithmétique cohérente en local ; passer un seul côté casserait le delta).

**Compatibilité consommateurs** : `analyze_traces.py` lit `timestamp[:10]` (date part) — compatible `Z` / `+00:00`.

## Validation

- `python -m pytest -q` (agent_tests) : **680 passed** (baseline origin/main).
- 0 notebook touché, 0 `.lean` touché.

See #1453 (epic co-évolution prover).
