### PR TITLE
feat(lean,#11211): contre-exemple formel — tricolorable_invariant FAUX tel qu'enonce (R2 append-only libre)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant.lean
@@ -1161,6 +1161,19 @@ theorem r2_append_only_wall :
     simp only [emptyDiagram] at this
     omega
 
+
+/-- **Contre-exemple formel (mur R2)** : l'énoncé actuel du maître
+`tricolorable_invariant` n'est pas seulement non-prouvé — pour le constructeur
+`Reidemeister2` libre append-only actuel il est FAUX. -/
+theorem not_tricolorable_invariant_current :
+    ¬ (∀ (d₁ d₂ : KnotDiagram),
+        ReidemeisterEquiv d₁ d₂ → (IsTricolorable d₁ ↔ IsTricolorable d₂)) := by
+  intro h
+  obtain ⟨hr2, htc₂, hnempty⟩ := r2_append_only_wall
+  have hre : ReidemeisterEquiv emptyDiagram twoTwinCrossings :=
+    ReidemeisterEquiv.step (ReidemeisterStep.r2 hr2)
+  exact hnempty ((h emptyDiagram twoTwinCrossings hre).mpr htc₂)
+
 /-! ### Fondation de la cure R2 — la cardinalité est l'unique obstruction
 
 Le mur `r2_append_only_wall` ci-dessus montre le bras descendant FAUX sur le

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/knot_lean/Knots/Invariant_en.lean
@@ -1064,6 +1064,18 @@ theorem r2_append_only_wall :
     simp only [emptyDiagram] at this
     omega
 
+/-- **Formal counterexample (R2 wall)**: the current master statement
+`tricolorable_invariant` is not merely unproved; for the present free append-only
+`Reidemeister2` constructor it is false. -/
+theorem not_tricolorable_invariant_current :
+    ¬ (∀ (d₁ d₂ : KnotDiagram),
+        ReidemeisterEquiv d₁ d₂ → (IsTricolorable d₁ ↔ IsTricolorable d₂)) := by
+  intro h
+  obtain ⟨hr2, htc₂, hnempty⟩ := r2_append_only_wall
+  have hre : ReidemeisterEquiv emptyDiagram twoTwinCrossings :=
+    ReidemeisterEquiv.step (ReidemeisterStep.r2 hr2)
+  exact hnempty ((h emptyDiagram twoTwinCrossings hre).mpr htc₂)
+
 /-! ### R2 cure foundation — cardinality is the only obstruction
 
 The wall `r2_append_only_wall` above shows the descending arm FALSE on the


### PR DESCRIPTION
Grain: DEEP/lean - lane myia-po-2026:CoursIA - prev: MED/lean #11438

## Summary

Le sweep BG knot_lean (itération-2 #1453, harnais avec garde d'écriture active) a dérivé sur la cible `Invariant.lean:350` un **contre-exemple formel qui compile** : le maître `tricolorable_invariant` est **FAUX tel qu'énoncé**.

```lean
theorem not_tricolorable_invariant_current :
    ¬ (∀ (d₁ d₂ : KnotDiagram),
        ReidemeisterEquiv d₁ d₂ → (IsTricolorable d₁ ↔ IsTricolorable d₂)) := by
  intro h
  obtain ⟨hr2, htc₂, hnempty⟩ := r2_append_only_wall
  have hre : ReidemeisterEquiv emptyDiagram twoTwinCrossings :=
    ReidemeisterEquiv.step (ReidemeisterStep.r2 hr2)
  exact hnempty ((h emptyDiagram twoTwinCrossings hre).mpr htc₂)
```

Le constructeur `ReidemeisterStep.r2` **libre append-only** relie le diagramme vide (NON tricolorable, `numEdges = 0`) au diagramme à 2 croisements jumeaux (tricolorable) — c'est le mur nommé déjà prouvé `r2_append_only_wall` (L1151, prouvé sans sorry). La bi-implication du maître L350 ne peut donc pas tenir pour le modèle actuel.

## Portée

- **`Invariant.lean` (FR)** : `not_tricolorable_invariant_current` + docstring FR (convention #4980 — la docstring initialement écrite par l'agent était en anglais dans le fichier FR, corrigée).
- **`Invariant_en.lean` (EN)** : miroir, docstring EN, corps byte-identique (parité i18n validée).

## Validation (critère B — Lean PR)

| # | Preuve |
|---|--------|
| 1 | **sorry counts inchangés** (avant→après, canonique `strip_comments` + `\bsorry\b`) : `Invariant.lean` 2→2, `Invariant_en.lean` 2→2. **0 nouveau sorry.** |
| 2 | **`lake build` SUCCESS** : `Knots.Invariant` 2999 jobs OK, `Knots.Invariant_en` 2999 jobs OK (lake v4.32.0, cache chaud). |
| 3 | **Axiom check** : `#print axioms Knots.not_tricolorable_invariant_current` → `[propext, Quot.sound]` uniquement — aucune preuve `sorry`-contaminée. |
| 4 | **Parité i18n** : `check_i18n_siblings.py` → `1/1 pairs byte-identical`. |

## Framing — vindication, PAS sorry eliminé

La cible L350 n'est pas seulement BLOCKED : **son énoncé actuel est incorrect**. Le fix est un ré-énoncé avec conditions de bien-forme des diagrammes (le « Reidemeister2Connected » de la cure R2, §fondation L1179+), pas une itération de prover. Pattern stable_marriage Lattice (FALSE-as-stated → vindicated, pas solved).

Le run harnais s'est terminé honnêtement : `result_kind: decomposition_regression` (build-aware 2→3, 0 tactic vérifiée), `success: false`, `regressed: false` (la garde d'écriture #11445 n'a pas sauté car le count texte final 2==2 — le fichier n'a pas été aggravé au niveau texte). Les 2 sorries restants (L350 + `unknottingNumber` L2143) sont intacts et toujours ouverts.

See #11211 (epic cure R2 knot). See #1453 (co-évolution harnais prover).

