### PR TITLE
docs(fallacydetection,#11451): retire false French-only taxonomy claim and requalify Jessynoo as bootstrap

### DIFF
--- a/MyIA.AI.Notebooks/FallacyDetection/README.md
+++ b/MyIA.AI.Notebooks/FallacyDetection/README.md
@@ -11,10 +11,10 @@ Série de notebooks pour la **détection et classification de sophismes** (falla
 | Phase | Livrable | Statut |
 |---|---|---|
 | 1 — Survey SOTA | [docs/research/fallacy-detection-survey.md](../../docs/research/fallacy-detection-survey.md) | livré |
-| 1 — Extraction Jessynoo | [data/jessynoo_rfallacy_anonymized.csv](data/jessynoo_rfallacy_anonymized.csv) + [scripts/fallacy_detection/extract_jessynoo_fallacy.py](../../scripts/fallacy_detection/extract_jessynoo_fallacy.py) | livré |
-| 1 — Paysage datasets | ≥ 5 datasets testés en accès réel | à livrer |
+| 1 — Extraction Jessynoo | [data/jessynoo_rfallacy_anonymized.csv](data/jessynoo_rfallacy_anonymized.csv) + [scripts/fallacy_detection/extract_jessynoo_fallacy.py](../../scripts/fallacy_detection/extract_jessynoo_fallacy.py) | livré (bootstrap de câblage — voir § Corpus) |
+| 1 — Paysage datasets | ≥ 5 datasets testés en accès réel | à livrer (cible Phase 2 — corpus académiques annotés) |
 | 1 — Inventaire SAE Qwen | ≥ 3 tailles (gate de faisabilité) | à livrer |
-| 2 — Dataset builder | projection de la taxonomie Argumentum | Phase 2 |
+| 2 — Dataset builder | produit cartésien **Scénarii × Fallacy** (167 × 1408) + corpus académiques annotés | Phase 2 |
 | 3 — Fine-tuning (série FT) | mémorisation du motif général→particulier | Phase 3 |
 | 4 — Post-training (série PT) | utilisation du workflow | Phase 4 |
 | 5 — Analyse SAE (strate 6 ICT) | features « motif » FT vs PT | gate de succès, Phase 5 |
@@ -30,6 +30,23 @@ Corpus r/fallacy extrait et anonymisé depuis le Data Export Reddit du compte `u
 - **Anonymisation** : chaque mention `u/<tiers>` dans les corps est remplacée par un token stable `u/[USER_N]` (indexation déterministe par tri du nom). 5 usernames tiers cités ont été anonymisés. Les mentions `r/...` (subreddits publics) et les URLs de référence (Wikipedia, RationalWiki) sont conservées — ce sont des contenus publics, pas des PII.
 - **Colonnes PII supprimées** : `ip` (PII par nature, même si vide dans le sous-ensemble), `permalink`/`link` (l'URL Reddit est réversible vers l'original et déferait l'anonymatisation `u/` des tiers cités dans le corps). Schéma retenu : `id` (opaque, base36, non réversible sans l'API Reddit), `date`, `subreddit`, `kind` (comment/post), `title`, `url`, `body`.
 
-### Constat important pour les phases aval
+### Constat important pour les phases aval (révision 2026-08-17, cf #11451)
 
-Le corpus Jessynoo r/fallacy est en **anglais** (0 mot-clé français sur 69 items). La taxonomie Argumentum (grilles d'étiquettes) est en **français** (1408 sophismes / 8 familles). La Phase 2 (dataset builder) devra traiter ce **décalage de langue étiquettes-vs-corpus** (traduction des étiquettes, ou corpus multilingue, ou restriction initiale au sous-ensemble Argumentum couvert par les datasets académiques anglophones — cf survey §5.1).
+**Le « décalage de langue étiquettes-vs-corpus » présenté ci-dessous comme un *obstacle* de la Phase 2 n'existe pas.** La taxonomie Argumentum est déjà **multilingue** : le CSV [`Argumentum Fallacies - Taxonomy.csv`](../../SymbolicAI/Argument_Analysis/Argumentum/Cards/Fallacies/Argumentum%20Fallacies%20-%20Taxonomy.csv) porte huit groupes de colonnes — `text_*` + `desc_*` + `example_*` + `link_*` (avec `Family_*` + `Subfamily_*` + `Subsubfamily_*` quand pertinent) — suffixés `_fr`, `_en`, `_ru`, `_ar`, `_fa`, `_zh`, `_es`, `_pt`. Mesure firsthand (`head -1 ... | tr ',' '\n' | grep -oE '_(fr|en|ru|ar|fa|zh|es|pt)$' | sort | uniq -c`) :
+
+```
+   4 _fr    6 _en    7 _ru    7 _ar    7 _fa    7 _zh    7 _es    7 _pt
+```
+
+Un corpus anglophone s'étiquette directement avec les colonnes `_en` ; un corpus espagnol avec les `_es` ; etc. Aucune traduction supplémentaire n'est nécessaire pour exploiter le multilingue.
+
+**Le corpus Jessynoo n'est pas un dataset d'entraînement** : 69 items (67 commentaires + 2 posts) en anglais, c'est trop peu pour entraîner, et il n'a jamais eu cette vocation. Son rôle est de **câbler l'extracteur** (anonymisation PII, format de sortie, intégration Phase 1 — voir `scripts/fallacy_detection/extract_jessynoo_fallacy.py`). Pour l'entraînement, deux voies se complètent :
+
+1. **Corpus académiques annotés** — déjà mesurés par `02_fallacy_datasets_landscape.ipynb` (cible Phase 1 — Paysage datasets à livrer) ;
+2. **Corpus synthétique par produit cartésien Scénarii × Fallacy** — `167 × 1408` exemples étiquetés *par construction*, couverture uniforme de la taxonomie qu'aucun corpus naturel ne donne. C'est cette seconde voie qui porte l'échelle nécessaire aux Phases 3-5.
+
+Ancienne rédaction (avant #11451) :
+
+> Le corpus Jessynoo r/fallacy est en **anglais** (0 mot-clé français sur 69 items). La taxonomie Argumentum (grilles d'étiquettes) est en **français** (1408 sophismes / 8 familles). La Phase 2 (dataset builder) devra traiter ce **décalage de langue étiquettes-vs-corpus** (traduction des étiquettes, ou corpus multilingue, ou restriction initiale au sous-ensemble Argumentum couvert par les datasets académiques anglophones — cf survey §5.1).
+
+— class="affirmation propagée sans confrontation à la source" (#11450 sœur sur le README racine). Le CSV est à trois commandes de distance ; la mesure y est directe.


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #11446

## Résumé

[#11451](https://github.com/jsboige/CoursIA/issues/11451) — **FallacyDetection README correctif** : retrait de l'affirmation fausse « La taxonomie Argumentum est en français » (§ « Constat important pour les phases aval ») et requalification du rôle du corpus Jessynoo (69 items r/fallacy) en **bootstrap de câblage**, pas jeu d'entraînement. Édition **markdown-only** sur un README : aucun code modifié, aucun script touché, aucune cellule notebook.

## Acceptance checklist (cf #11451)

- [x] Corriger le § « Constat important pour les phases aval » : retirer le décalage de langue, écrire la disponibilité des 8 langues et ce qu'elle permet
- [x] Requalifier le § « Corpus » : amorçage explicitement présenté comme bootstrap de câblage, non comme jeu d'entraînement (annotation sur la ligne 14 du tableau « Chaîne des phases »)
- [x] Écrire la stratégie de données réelle (académique + synthétique Scénarii × Fallacy) dans la chaîne des phases (ligne 17 du tableau + § constat révisé)
- [x] Vérifier que la ligne « Phase 2 — Dataset builder : projection de la taxonomie Argumentum » du tableau reflète bien le produit cartésien (ligne 17 modifiée)

## Diagnostic (G.9 — vérification à la source)

L'**affirmation erronée** était :

> La taxonomie Argumentum (grilles d'étiquettes) est en **français** (1408 sophismes / 8 familles). La Phase 2 (dataset builder) devra traiter ce **décalage de langue étiquettes-vs-corpus** (traduction des étiquettes, ou corpus multilingue, ou restriction initiale au sous-ensemble Argumentum couvert par les datasets académiques anglophones — cf survey §5.1).

**Vérification firsthand** (mesure directe sur le CSV du sous-module) :

```bash
head -1 "MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argumentum/Cards/Fallacies/Argumentum Fallacies - Taxonomy.csv" \
  | tr ',' '\n' \
  | grep -oE '_(fr|en|ru|ar|fa|zh|es|pt)$' \
  | sort | uniq -c
#   4 _fr    6 _en    7 _ru    7 _ar    7 _fa    7 _zh    7 _es    7 _pt
```

→ **8 langues** (suffixes de colonnes `text_*` + `desc_*` + `example_*` + `link_*` + `Family_*` / `Subfamily_*` / `Subsubfamily_*`). Le « décalage de langue » est un **faux problème** : un corpus espagnol s'étiquette avec `_es`, un corpus russe avec `_ru`, etc. — aucun effort de traduction supplémentaire n'est nécessaire.

**Cause de la classe de défaut** : affirmation de README propagée **sans confrontation à la source**. Le CSV est à trois commandes de distance ; la mesure y est directe. Sister issue côté README racine : #11450 (Epic #11259) — la première rédaction avait recopié l'affirmation du README de série au lieu de la vérifier. Corrigé côté README racine par ai-01 ; le README de série portait encore la version fausse.

## Modifications

### Tableau « Chaîne des phases » (3 lignes)

| Ligne | Avant | Après |
|---|---|---|
| 14 | `livré` | `livré (bootstrap de câblage — voir § Corpus)` |
| 15 | `à livrer` | `à livrer (cible Phase 2 — corpus académiques annotés)` |
| 17 | `produit cartésien Scénarii × Fallacy` | `produit cartésien **Scénarii × Fallacy** (167 × 1408) + corpus académiques annotés` (Phase 2) |

### § « Constat important pour les phases aval » (section complète remplacée)

- **Ancienne rédaction** préservée en citation (transparence : le lecteur voit l'affirmation corrigée)
- **Nouvelle rédaction** : ouverture sur le fait que la taxonomie Argumentum est multilingue (8 langues documentées avec mesure firsthand), requalification du Jessynoo en bootstrap de câblage, énoncé de la stratégie de données réelle (corpus académiques + corpus synthétique Scénarii × Fallacy)

## Statistiques

- **1 fichier modifié** : `MyIA.AI.Notebooks/FallacyDetection/README.md` (README de série, 53 lignes)
- **+22 / −5** sur le README
- **0 fichier de code** touché (pas de re-exécution requise, pas de pre-commit H.3)
- **cjk-post-edit filter** : 0 parasite

## Vérification

- **G.9 verify-before-claim** : mesure firsthand documentée dans le § diagnostic (les chiffres sont dans le README et dans le body PR)
- **Stop & Repair règle 6** : aucune sortie de cellule touchée (README = pas un notebook, pas d'output)
- **C.1 / C.2 / C.3 / H.3** : N/A (pas un notebook)
- **L903 grain tag** : `Grain: MED/readme — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #11446` (G-VAR-3 rotation réussie : 2× consécutif MED/notebook-python c.1301+189+190 → MED/readme c.1301+191)

## Claim scope

Claim scope narrow sur issue #11451 :

> `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: MyIA.AI.Notebooks/FallacyDetection/README.md`

→ débloque les autres lanes sur d'autres tranches du même EPIC #10355.

## Umbrella

Voir #11451 (issue opérationnelle) + #10355 (Epic parent FallacyDetection) + #11450 (sœur côté README racine, déjà corrigée par ai-01).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
