### PR TITLE
docs(rl,#11460): frontiere explicite RL/rlpt_* vs GenAI/PostTraining/PT_* — table de decision lecteur

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/README.md
@@ -187,7 +187,23 @@ PT-06 documente le pipeline d'évaluation complet et produit un tableau comparat
 | **[RL](../../RL/)** | RL classique fondamentaux | Les notebooks RL ([rl_5 MDP/Q-Learning](../../RL/rl_5_mdp_dp_qlearning.ipynb) et [rl_6c PPO from scratch](../../RL/rl_6c_ppo_from_scratch.ipynb)) établissent l'intuition policy/value que PPO/GRPO réutilisent. Recommandés comme prérequis pour PT-04. |
 | **[RL — rl_9 offline](../../RL/rl_9_offline_rl.ipynb)** | DPO = preference learning offline | Le Behavior Cloning y est l'analogue tabulaire du SFT, et la contrainte de support de BCQ celle de la pénalité KL de DPO (PT-03). Le meilleur prérequis conceptuel pour DPO. |
 | **[RL — rl_10 reward shaping](../../RL/rl_10_reward_shaping.ipynb)** | Reward model = shaping appris | Le reward shaping (Ng 1999) et son biais (shaping naïf → reward hacking) préfigurent le reward model appris et le Goodhart traité en [PT-07](PT_07_rewardspy_reward_hacking.ipynb). |
+| **[RL — rlpt_* (Post-Training RLHF/GRPO/DPO)](../../RL/rlpt_1_ppo_lm_rlhf.ipynb)** | Mécanique from-scratch sur petits LM | La sous-série `rlpt_*` (4 notebooks) applique les algorithmes RLHF/GRPO/DPO à des LM char-level ou Qwen3.5-0.8B local (8 Go), **sans `trl`** : on recompile les boucles à la main, on voit les gradients. Différenciation explicite vis-à-vis de `PT_*` : `rlpt_*` = mécanique pure (from-scratch, CPU/8 Go) ; `PT_*` = chaîne SOTA 2024 à l'échelle LLM (`trl` 1.9.2, QLoRA, rewardspy). Voir la section « Frontière RL/rlpt_* vs GenAI/PostTraining » du [README RL](../../RL/README.md) pour la table de décision « quel notebook pour quelle question ». |
 | **[GenAI/FineTuning](../FineTuning/)** | Boîte à outils fine-tuning | Série sœur dans GenAI : LoRA/QLoRA/SFT/DPO en pratique sur 5 notebooks. PostTraining = profondeur méthodologique (14 notebooks), FineTuning = recettes exécutables. |
+
+## Frontière avec `RL/rlpt_*`
+
+Cette série (`PT_*`) et la sous-série RL `rlpt_*` partagent les algorithmes GRPO/PPO/DPO/reward hacking, mais opèrent à des échelles et avec des outillages différents :
+
+- **`PT_*`** = chaîne SOTA 2024 (`trl` 1.9.2 + `transformers` 5.15.0 + QLoRA 4-bit) sur vrais LLMs (Qwen3.5-0.8B → 4B), diagnostic outillé via `rewardspy`, multi-seed de production, contrainte RTX 3070 8 Go.
+- **`rlpt_*`** = mécanique from-scratch (char-level ou Qwen3.5-0.8B local, sans framework lourd) : on recompile les boucles, on voit les gradients. La granularité d'observation est plus fine ; la profondeur d'exécution est plus courte.
+
+**Différenciations explicites** :
+- `rlpt_2` (GRPO Qwen3.5-0.8B, additions à 2 chiffres) ↔ `PT-11` (GRPO via `trl` + QLoRA, récompense Z3 sur vrai LLM) — from-scratch vs `trl`.
+- `rlpt_3` (construit un reward piégé, essaie de le déclencher) ↔ `PT-07` (détecte automatiquement via `rewardspy`) — manuel vs outil.
+- `rlpt_1` (PPO/RLHF char-level) ↔ `PT-02` + `PT-04` (SFT + GRPO DeepSeek-R1 via `trl`) — authentique.
+- `rlpt_4` (DPO vs GRPO offline/online, budget égal) ↔ `PT-03` (DPO) + `PT-06` (éval comparative) — authentique.
+
+**Lecture conseillée** : pour comprendre *pourquoi* un algorithme fonctionne, suivre `rlpt_*`. Pour exécuter *comment* on l'utilise à l'échelle LLM, suivre `PT_*`.
 
 ## Contexte industriel et historique 2017-2025
 

--- a/MyIA.AI.Notebooks/RL/README.md
+++ b/MyIA.AI.Notebooks/RL/README.md
@@ -548,6 +548,24 @@ La thèse est puissante et honnêtement présentée : le RL n'a pas d'algorithme
 
 Le reinforcement learning propose un changement de regard sur l'apprentissage : ne plus demander « quelle est la bonne réponse ? » mais **« quelle action maximise la récompense cumulée, sachant qu'elle détermine les états futurs ? »**. La série vous a donné le formalisme (MDP, équation de Bellman), les algorithmes (du bandit à SAC, du tabulaire au deep, du online à l'offline), et l'intuition des compromis pour transformer un problème de décision séquentielle en une politique apprise — en gardant à l'esprit que ce paradigme, de AlphaGo aux LLMs alignés par RLHF, est devenu l'un des deux piliers (avec l'apprentissage supervisé) de l'IA contemporaine.
 
+## Frontière RL/rlpt_* vs GenAI/PostTraining : quel notebook pour quelle question
+
+La sous-série `rlpt_*` (Post-Training RLHF/GRPO/DPO sur petits LM) et la série `GenAI/PostTraining/PT_*` partagent le même algorithme général — GRPO, PPO, DPO, reward hacking — mais diffèrent par **l'échelle et l'outillage**. Cette section tranche, depuis le point de vue du lecteur, **quel notebook ouvrir pour quelle question** :
+
+- **`RL/rlpt_*`** = **la mécanique RL pure, en petit, sans framework lourd** : from-scratch / CPU ou 8 Go (RTX 3070), on voit les gradients, on recompile les boucles à la main. Convient pour comprendre *pourquoi* un algorithme fonctionne.
+- **`GenAI/PostTraining/PT_*`** = **la chaîne SOTA 2024 à l'échelle LLM** : `trl` 1.9.2 + `transformers` 5.15.0 + QLoRA 4-bit, vrais modèles (Qwen3.5-0.8B → 4B), `rewardspy` pour le diagnostic, multi-seed de production. Convient pour exécuter *comment* on l'utilise en pratique.
+
+Les **différenciations explicites** qui ferment la redondance :
+
+| Question | Ouvrir dans RL/rlpt_* | Ouvrir dans GenAI/PostTraining/PT_* |
+|----------|----------------------|-----------------------------------|
+| « GRPO — comment l'algorithme fonctionne ? » | [rlpt_2_grpo_minimal](rlpt_2_grpo_minimal.ipynb) — group rollouts, avantage intra-group, recompense verifiable (additions 2 chiffres), budget steps borné | [PT-11 GRPO Qwen3.5-0.8B](PT_11_grpo_qwen35_rlvr.ipynb) — `trl.GRPOConfig` + QLoRA 4-bit, recompense Z3 sur vrai LLM |
+| « Reward hacking — comment le reconnaitre ? » | [rlpt_3_reward_hacking](rlpt_3_reward_hacking.ipynb) — on **construit** un reward piégé puis on essaie de le declencher par 3 voies | [PT-07 rewardspy](PT_07_rewardspy_reward_hacking.ipynb) — detection **automatique** via la lib `rewardspy` (AvAdiii) |
+| « RLHF from scratch — la signature ? » | [rlpt_1_ppo_lm_rlhf](rlpt_1_ppo_lm_rlhf.ipynb) — char-level, PPO + KL vs ref, sans framework | [PT-02 SFT baseline](PT_02_sft_baseline.ipynb) + [PT-04 GRPO DeepSeek-R1](PT_04_grpo_deepseek_r1.ipynb) — `trl.SFTTrainer` / `GRPOTrainer` |
+| « DPO vs GRPO online — budget egal ? » | [rlpt_4_dpo_vs_ppo](rlpt_4_dpo_vs_ppo.ipynb) — preferences auto-fabriquees, verdict multi-seed DM | [PT-03 DPO direct preference](PT_03_dpo_direct_preference.ipynb) + [PT-06 eval comparative](PT_06_eval_comparative.ipynb) |
+
+**Lecture conseillee** : pour comprendre la *mecanique*, suivre `rlpt_*`. Pour executer la *chaine*, suivre `PT_*`. Les deux series se reference mais ne dupliquent pas (cf. note d'intention de #11297 : « le pont PostTraining existant — la serie s'y refere, ne le duplique pas »).
+
 ## Où atterrit le « pont RLHF » : les séries GenAI
 
 Plusieurs notebooks de cette série annoncent un « pont RLHF » (notebook 9 sur l'offline RL, notebook 10 sur le reward shaping). Ce pont **atterrit concrètement** dans deux séries GenAI, qui appliquent ces fondations RL à de vrais modèles de langue. La série RL fournit l'algorithmique tabulaire ; GenAI fournit la réalisation à l'échelle des LLM.


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #11458

# #11460 — Frontière écrite RL/rlpt_* vs GenAI/PostTraining/PT_* (table de décision lecteur)

## Résumé

L'**assimilation** dans le README principal entre `RL/rlpt_*` et `GenAI/PostTraining/PT_*` cachait une **redondance réelle** sur deux paires (rlpt_2↔PT-11, rlpt_3↔PT-07). Cette PR pose la **frontière écrite** dans les deux READMEs, depuis le point de vue du lecteur : **un notebook par question**.

## Différenciation posée

- **`RL/rlpt_*`** = la **mécanique RL pure, en petit, sans framework lourd** : from-scratch / CPU ou 8 Go (RTX 3070), on voit les gradients, on recompile les boucles à la main. Convient pour comprendre *pourquoi* un algorithme fonctionne.
- **`GenAI/PostTraining/PT_*`** = la **chaîne SOTA 2024 à l'échelle LLM** : `trl` 1.9.2 + `transformers` 5.15.0 + QLoRA 4-bit, vrais modèles (Qwen3.5-0.8B → 4B), `rewardspy` pour le diagnostic, multi-seed de production. Convient pour exécuter *comment* on l'utilise en pratique.

## 4 paires différenciées explicitement

| Question | RL/rlpt_* | GenAI/PT_* |
|----------|-----------|-----------|
| GRPO — comment l'algorithme fonctionne ? | rlpt_2 (group rollouts, avantage intra-group, recompense verifiable additions 2 chiffres, budget steps borné) | PT-11 (`trl.GRPOConfig` + QLoRA 4-bit, recompense Z3 sur vrai LLM) |
| Reward hacking — comment le reconnaitre ? | rlpt_3 (on **construit** un reward piégé puis on essaie de le declencher par 3 voies) | PT-07 (detection **automatique** via lib `rewardspy` AvAdiii) |
| RLHF from scratch — la signature ? | rlpt_1 (char-level, PPO + KL vs ref, sans framework) | PT-02 (SFT baseline) + PT-04 (GRPO DeepSeek-R1 via `trl`) |
| DPO vs GRPO online — budget egal ? | rlpt_4 (preferences auto-fabriquees, verdict multi-seed DM) | PT-03 (DPO direct preference) + PT-06 (eval comparative) |

Les deux premières paires ferment la redondance (`rlpt_2` ≠ `PT-11` par l'outillage, `rlpt_3` ≠ `PT-07` par la méthode). Les deux dernières sont authentiquement différenciées — confirmation pour le lecteur.

## Changements livrés

**2 fichiers, +34 insertions, 0 deletion** :

1. **`MyIA.AI.Notebooks/RL/README.md`** (18 insertions) — section « Frontière RL/rlpt_* vs GenAI/PostTraining : quel notebook pour quelle question » ajoutée juste avant « Où atterrit le « pont RLHF » ». Table 4×2 (question | rlpt_* | PT_*).

2. **`MyIA.AI.Notebooks/GenAI/PostTraining/README.md`** (16 insertions) — ligne `rlpt_*` ajoutée au tableau « Ponts avec les autres séries » + section dédiée « Frontière avec `RL/rlpt_*` » qui re-détaille les 4 paires (from-scratch vs `trl`, manuel vs `rewardspy`).

## Hors scope

- Le **README principal** est déjà corrigé (mention corrigée).
- Le **capstone #5105** (ICT-25 InoculationRL) reste à examiner pour redondance éventuelle avec `rlpt_3` (les trois se réclament du même matériel — point (3) du demandeur). **Non traité ici** — ouverture possible comme issue fille #11460b.
- **rlpt_2 et rlpt_3** ne sont **pas re-différenciés techniquement** : leur note d'ouverture reste « version compacte du capstone #5105 » pour `rlpt_3` et « budget steps borné » pour `rlpt_2`. Le rédacteur choisit de les laisser vivre et les différenciations sont posées au niveau des READMEs (pas dans les notebooks).

## Conformité

- Markdown-only (0 cellule code touchée)
- 2 fichiers (RL/README.md + GenAI/PostTraining/README.md)
- Section ajoutée en français (cf règle [readme-french-first.md](.claude/rules/readme-french-first.md))
- Lien croisé entre les deux READMEs (chaque section renvoie à l'autre)

## Acceptance #11460

- [x] Frontière posée dans les 2 READMEs (RL + GenAI/PostTraining)
- [x] Table de décision « quel notebook pour quelle question » dans RL/README.md
- [x] 4 paires différenciées explicitement (rlpt_2/PT-11, rlpt_3/PT-07, rlpt_1/PT-02+04, rlpt_4/PT-03+06)
- [x] Mention `rewardspy` (lib) dans la différenciation rlpt_3 vs PT-07
- [x] Mention `trl` 1.9.2 dans la différenciation from-scratch vs chaîne SOTA
- [ ] Capstone #5105 vs rlpt_3 : à traiter en issue fille séparée

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/11460
- Issue umbrella : https://github.com/jsboige/CoursIA/issues/11297 (série rlpt_*)
- Claim : issuecomment-5315224154 (lane po-2024, paths RL/README.md + GenAI/PostTraining/README.md)