### PR TITLE
feat(twin-parity,#11200): bascule native-both Vague 1 -- 8 paires (3 familles)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -2,11 +2,17 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
+
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `cvxpy` (optimisation convexe exacte du portefeuille) + `pygad` (algorithme genetique) + stdlib. C# = `#r nuget: GeneticSharp` (moteur GA .NET reel : `PortfolioChromosome : ChromosomeBase`, `PortfolioFitness : IFitness`, generation reproductible seed 42) + BCL pure pour l'enumeration exacte K=2. Verdict SOTA-OK : le C# atteint un moteur de production de son ecosysteme (GeneticSharp, deja en service App-10b/App-9b/Sudoku-3) qui couvre le concept enseigne cote GA ; cote Python, `pygad` est son pendant GA (couvert par GeneticSharp) et `cvxpy` (convexe exact) n'a pas d'equivalent .NET en service dans le depot — la part convexe from-scratch/BCL est la contrepartie honnete. Rien a recuperer : le C# ne bride aucun moteur manquant. parity_level: semantic preserve."
   audits:
   - date: '2026-08-04'
+    - date: "2026-08-17"
+      by: myia-po-2026:CoursIA-2
+      python_sha: 51d488274798ccf06956376bdd355d9fbc753515
+      csharp_sha: 7023d3ba7fe5e0ce0624ee2806ea06851c4e382e
+      reason: "parity_level basculee semantic -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A : chaque cote atteint un moteur SOTA de son ecosysteme (lib-vs-lib). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant (lib SOTA Python / lib SOTA C#)."
     by: myia-po-2023:CoursIA
     python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
     csharp_sha: dad13c7fac88520807664b25ab6b95095f608677

--- a/scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling.yaml
@@ -2,7 +2,8 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
+
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `ortools` PyPI (Google, Apache-2.0, CP-SAT solver SOTA-tier : `from ortools.sat.python import cp_model` + `CpModel()` + variables match[round][home][away] + `AddExactlyOne` pour home/away + `AddBoolOr` constraints non-consecutifs + `solver.Solve()`). C# = `Google.OrTools` NuGet (Google, Apache-2.0, meme solver CP-SAT : `#r \"nuget: Google.OrTools\"` + `using Google.OrTools.Sat;`) + `ScottPlot` NuGet (MIT-license, viz supplementaire du calendrier : `#r \"nuget: ScottPlot\"` + `using ScottPlot;` + `Plot()` heatmap render). Verdict SOTA-OK : les DEUX cotes utilisent LE MEME solveur Google OR-Tools CP-SAT natif pour la planification, le ScottPlot cote C# est un helper viz optionnel (le notebook PY utilise matplotlib/heatmap equivalent, asymetrie mineure de lib viz). Asymetrie documentee : parity_level: semantic (vs native-both) car la viz ScottPlot/matplotlib n'est PAS dans le bridge CP-SAT, le semantisme = same calendar output independant de la viz."
   audits:
@@ -37,6 +38,11 @@
       csharp_sha: cff8412cd42cc696afdb430a1c5984c3154c34e3
       content_python_sha: 6bc97a786ead73280efd5ab9062fd87f8625ba308268932374d4234885dbbb46
       content_csharp_sha: 81391e972cf2cdef018dbab00a6b3c1877347ff8c3c4a9de45a191218f34ca89
+    - date: "2026-08-17"
+      by: myia-po-2026:CoursIA-2
+      python_sha: 2da1143851d2ac59ae66254495bb661aaddcd68c
+      csharp_sha: cff8412cd42cc696afdb430a1c5984c3154c34e3
+      reason: "parity_level basculee semantic -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A : chaque cote atteint un moteur SOTA de son ecosysteme (lib-vs-lib). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant (lib SOTA Python / lib SOTA C#)."
   known_differences:
     - "Socle pedagogique commun : Planning sportif / Sports scheduling (CSP : round-robin, contraintes equipes) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles."
     - "Idiomes framework : Python = OR-Tools CP-SAT + dataclass ; C# = Google.OrTools.Sat NuGet + ScottPlot viz."

--- a/scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml
@@ -2,7 +2,8 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
+
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -44,6 +45,11 @@
       csharp_sha: 6d92004320fa7e4b11e457c3c2298f6935b604f1
       content_python_sha: e3fd067407b9c0a72bd6f908597d9594b4087e5e306543dc2257427e1e96b11e
       content_csharp_sha: c1f0ffebdb1cfdd2ae32788157cc6b0e7cf84a650e80fc4851620ceeae877966
+    - date: "2026-08-17"
+      by: myia-po-2026:CoursIA-2
+      python_sha: 0ad3e3f90ea3483c29256e8c91a1f5284d3d5d24
+      csharp_sha: 6d92004320fa7e4b11e457c3c2298f6935b604f1
+      reason: "parity_level basculee semantic -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A : chaque cote atteint un moteur SOTA de son ecosysteme (lib-vs-lib). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant (lib SOTA Python / lib SOTA C#)."
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = minizinc (binding Python pour MiniZinc modeling language, MIT, https://github.com/MiniZinc/libminizinc, dekker 2024) + OR-Tools CP-SAT (driver pour cross-solve depuis MiniZinc) + numpy + matplotlib (19 cellules code). C# = Google.OrTools.Sat (NuGet, C# binding OR-Tools CP-SAT 9.11) + System.* BCL, 14 cellules code. Verdict SOTA-OK (lib-vs-lib) : Python invoque minizinc (modeling language) + OR-Tools CP-SAT (solver backend) ; C# invoque Google.OrTools.Sat (C# binding du MEME engine OR-Tools CP-SAT 9.11). MiniZinc utilise OR-Tools comme solver backend par defaut, donc les deux cotes aboutissent au MEME moteur CP-SAT reel. L'asymetrie est mineure : Python passe par la couche modeling language MiniZinc (plus declarative, plus haut niveau d'abstraction), C# utilise directement le binding CP-SAT (plus proche du moteur). parity_level: semantic preserve (post-#10382 les deux cotes utilisent le MEME solver)."
   known_differences:

--- a/scripts/notebook_tools/twin_pairs.d/app-9-edgedetection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-9-edgedetection.yaml
@@ -2,7 +2,8 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
+
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
@@ -14,6 +15,11 @@
       csharp_sha: a2cc061a4109cfd9aef63b92fd16d152f5430a73
       content_python_sha: 5b06a29776e27caae58aeaadb641fe07b114e32feb6aa22307e37fb9b43dda12
       content_csharp_sha: 95c8832f379c55fde58990536acc162774564ef0e98470f174cd7fc84d6178ac
+    - date: "2026-08-17"
+      by: myia-po-2026:CoursIA-2
+      python_sha: a783da437fdbb5773339cc4c7b1c648ebd1e3169
+      csharp_sha: a2cc061a4109cfd9aef63b92fd16d152f5430a73
+      reason: "parity_level basculee semantic -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A : chaque cote atteint un moteur SOTA de son ecosysteme (lib-vs-lib). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant (lib SOTA Python / lib SOTA C#)."
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = DEAP (Distributed Evolutionary Algorithms in Python, MIT, https://github.com/DEAP/deap, Fortin 2012) + scipy.signal.sobel (filtre sobel pour detection de contours) + pygad (Python Genetic Algorithm, MIT) + matplotlib + numpy (17 cellules code). C# = Emgu.CV (wrapper C# OpenCV 4.x, Apache-2.0, https://github.com/emgucv/emgucv) + SkiaSharp (binding .NET Skia, MIT, https://github.com/mono/SkiaSharp) + GeneticSharp (lib C# algorithmes genetiques, MIT, https://github.com/giacomelli/GeneticSharp) (12 cellules code). Verdict SOTA-OK (lib-vs-lib, deux ecosystemes natifs) : Python utilise l'ecosysteme SciPy + DEAP (lib SOTA evolutionary computation) + scipy.signal (filtre sobel) ; C# utilise l'ecosysteme OpenCV via Emgu.CV (lib SOTA computer vision) + SkiaSharp (bitmaps) + GeneticSharp (algorithmes genetiques). Les deux ecosystemes invoquent de vraies libs SOTA de leur stack natif (Python scientifique / C# computer vision). Detection de contours = application canonique des deux cotes. parity_level: semantic preserve."
   known_differences:

--- a/scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml
@@ -2,12 +2,18 @@
   family: SymbolicAI/SymbolicLearning
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
+
   audits:
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: c7e229126c670dac3e3d119b56b8f727003bce8a
       csharp_sha: 376249822ecee95d86a8d1f806a99b7595486bc7
+    - date: "2026-08-17"
+      by: myia-po-2026:CoursIA-2
+      python_sha: c7e229126c670dac3e3d119b56b8f727003bce8a
+      csharp_sha: 376249822ecee95d86a8d1f806a99b7595486bc7
+      reason: "parity_level basculee semantic -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A : chaque cote atteint un moteur SOTA de son ecosysteme (lib-vs-lib). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant (lib SOTA Python / lib SOTA C#)."
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `rdflib` (Python KG/OWL/RDF library, MIT, Krech/Davey/ettwig 2024) pour construction/manipulation RDF + `AMIE` (rule mining SOTA, Gal?rraga/Te formulas 2015) pour decouverte de regles de Horn. C# = `dotNetRDF` (equivalent .NET de rdflib, MIT/LGPL, Rob Vesse 2009-2024) + `AMIE`. Verdict SOTA-OK (lib-vs-lib) : les deux cotes invoquent de vraies librairies KG SOTA (rdflib ? dotNetRDF sont equivalents par construction, AMIE est partage). Le C# inclut une section explicite 'Correspondance Python <-> C#' cartographiant les API rdflib <-> dotNetRDF -- intention de parite declaree. L'asymetrie de couverture (Python 62 cells / 22 code vs C# 32 cells / 15 code) est sur la prose pedagogique et la visualisation (ASCII vs matplotlib), pas sur la machinerie SOTA. C'est le twin le plus proche lib-vs-lib de la famille SL : KG foundations = manipuler les vraies librairies (rdflib/dotNetRDF + AMIE) avant d'ecrire from-scratch. `parity_level: semantic` preserve."
   known_differences:

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml
@@ -2,7 +2,8 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
+
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 EST le moteur SOTA SMT, branche NATIVEMENT des deux cotes : Microsoft.Z3 (NuGet officiel, `#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, API Context ctx.MkSolver/MkConst) et pyz3 (pip z3-solver, `from z3 import *`, API fonctionnelle Solver()/Int()) sont les deux bindings de la meme lib C++ Z3 sous-jacente — pas un pont intermediaire type IKVM/PythonNet. Parite firsthand sur le concept central (SMT de base, contrainte insatisfiable) cellule 5 des deux notebooks : Python pyz3 `s.check() -> unsat` (x>5 ET x<3) == C# Microsoft.Z3 `s.check() -> UNSATISFIABLE`, meme verdict du meme moteur. Aucune asymetrie de machinerie a corriger."
   audits:
@@ -22,6 +23,11 @@
       csharp_sha: e8c5ee11e355b64c065e339e4199c23a97115462
       content_python_sha: f9c0451a32a8ca918b8a29c77f1b11fa619edfb703b1d1cf3f9d9f8b595c2fe2
       content_csharp_sha: 86fe390ef793212678b6829c5a96847a22021bcc9cc848720f40d53e9ef4fa59
+    - date: "2026-08-17"
+      by: myia-po-2026:CoursIA-2
+      python_sha: 1dce7f1d5495aacad37cdac4fd21f9d211589840
+      csharp_sha: e8c5ee11e355b64c065e339e4199c23a97115462
+      reason: "parity_level basculee semantic -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A : chaque cote atteint un moteur SOTA de son ecosysteme (lib-vs-lib). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant (lib SOTA Python / lib SOTA C#)."
   known_differences:
     - "Python : pyz3 (z3-solver), `from z3 import *`, API fonctionnelle (Solver(), Int('x'), s.check() -> sat/unsat)."
     - "C# : Microsoft.Z3 .NET, `using Microsoft.Z3;`, API orientee Context (ctx.MkSolver(), ctx.MkConst(...), Status.TRUE)."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
@@ -2,7 +2,8 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
+
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 EST le moteur SOTA SMT, branche NATIVEMENT des deux cotes : pyz3 (pip z3-solver, `from z3 import *`, API fonctionnelle Solver()/Int()/Distinct()) et Microsoft.Z3 (NuGet officiel, `#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, API Context ctx.MkSolver/MkIntConst/MkDistinct) sont les deux bindings de la meme lib C++ Z3 sous-jacente — pas un pont intermediaire type IKVM/PythonNet. Parite firsthand sur le concept central (resolution de Sudoku par encodage SMT) cellule 5 des deux notebooks : meme structure de contrainte (domaine 1-9 via `>=1,<=9`/`MkGe,MkLe`, indices figes `==`/`MkEq`, unicite `Distinct()`/`MkDistinct()` par ligne + colonne + bloc 3x3) -> meme verdict `s.check()==sat`/`s.Check()==Status.SATISFIABLE` -> 'Puzzle facile : resolu' + la meme grille 9x9 resolue. Aucune asymetrie de machinerie a corriger."
   audits:
@@ -22,6 +23,11 @@
       csharp_sha: 9922b667c446285537c687626cd76c6aa5cbcc9f
       content_python_sha: 3607d23ded635bccfe9269d290d4830ae0608451d9ece9013354daea4ac523ff
       content_csharp_sha: 8f1c53c018d1f3f96621997a3c88580846eff039607d7341fbf6a64e3c337ff6
+    - date: "2026-08-17"
+      by: myia-po-2026:CoursIA-2
+      python_sha: 31ede72cdc3c4895792d29b26e360cb2d31b66da
+      csharp_sha: 9922b667c446285537c687626cd76c6aa5cbcc9f
+      reason: "parity_level basculee semantic -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A : chaque cote atteint un moteur SOTA de son ecosysteme (lib-vs-lib). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant (lib SOTA Python / lib SOTA C#)."
   known_differences:
     - "Python : pyz3. C# : Microsoft.Z3 .NET (idiomes API comme NB-01)."
     - "Cote Python : modelisation Sudoku (81 cellules Int 1-9, alldifferent lignes/colonnes/blocs). Doc-honesty cures c.19 (PR #8045 : compte indices ~35 -> 30 pour puzzle_facile). SHA rebaseline c.802 apres DRIFT detecte par check_twin_parity.py : 4dcb5921 -> 1d3b1932 (commit e8a3be3ae merge le 2026-07-23)."

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml
@@ -2,7 +2,8 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
+
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 string/regex theory (SeqSort) branchee NATIVEMENT des deux cotes : Microsoft.Z3 .NET (`#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, ctx.MkRange/MkConcat/MkRe/MkInRe sur Seq) et pyz3 (`from z3 import *`, Range/Concat/Plus/Re/InRe sur Seq) sont les deux bindings officiels du meme coeur C++ Z3 sous-jacent — pas un pont intermediaire type IKVM/PythonNet. Concept string-regex (date AAAA-MM-JJ sous-contrainte en groupes longueur-fixe) demontre des deux cotes. Aucune asymetrie de machinerie a corriger."
   audits:
@@ -16,6 +17,11 @@
       csharp_sha: dad296706c9d68300cd4184e60a0ba5bd794780a
       content_python_sha: 8ba920d8f6f6b0c18eb0653165aa21db2dc9486f4d856048055cc45da1ae6bdc
       content_csharp_sha: 18b2b6ee50648326822b73659e6a5b78d1bff65db3e8276c35d8e30da8d1328d
+    - date: "2026-08-17"
+      by: myia-po-2026:CoursIA-2
+      python_sha: 4c04fe94faf2b0e2aea04dead81f1f46edf60b11
+      csharp_sha: dad296706c9d68300cd4184e60a0ba5bd794780a
+      reason: "parity_level basculee semantic -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A : chaque cote atteint un moteur SOTA de son ecosysteme (lib-vs-lib). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant (lib SOTA Python / lib SOTA C#)."
   known_differences:
     - "Edition C# twin 2026-08-14 (myia-po-2024:CoursIA-2, #10488 density) : enrichissement markdown du jumeau C# seul (474->882 c/cell), 8 sections 'Implémentation C#' ajoutees apres les explications existantes -- detail binding-spcifique .NET (types de retour SeqExpr/IntExpr/ReExpr/BoolExpr, casts obligatoires, MkExtract exigent des IntExpr, MkConcat/MkUnion tableaux types, Status enum vs is_sat, Model.Eval + trim guillemets, decidable sans quantificateurs). Rattrapage partiel du Python twin, deja dense avec son propre contenu binding pyz3. Aucune divergence algorithmique : C.3 byte-identique (0 cellule code touchee, sources+outputs+exec_count inchanges) -- divergence markdown-only, le C# comble son retard pedagogique vers le Python, pas l'inverse (precedent Sudoku-6 AIMA-CSP 2026-08-12 po-2025)."
     - "Python : pyz3 (Range, Concat, Plus, Re, InRe, Length sur Seq). C# : Microsoft.Z3 .NET (ctx.MkRange, MkConcat, MkRe...)."


### PR DESCRIPTION
# Twin_pairs native-both Vague 1 — bascule 8 paires (3 familles)

> Grain: MED/lean — lane myia-po-2026:CoursIA-2 — prev: MED/docs #11452

## Contexte

Issue **#11200** constate que `parity_level: native-both` a deux sens incompatibles
dans `scripts/notebook_tools/twin_pairs.d/` : celui que documente `_schema.yaml`
(« traduction fidèle cellule-par-cellule ») et celui qu'appliquent les 37 paires
qui portent la valeur (parité de moteur, mandat « lib-vs-lib » de #10382).

Arbitrage ai-01 **2026-08-16 Option A** : `native-both` retient le sens **parité
de moteur** (chaque côté fait le travail du notebook au moyen d'un moteur de
production/reference externe). PR **#11301** a réécrit `_schema.yaml` en
conséquence (po-2024, MERGED).

PR **#11452** (c.174, lane po-2026:CoursIA-2, encore OPEN) a ajouté le script
diagnostic `scan_native_both_drift.py` qui distingue 5 catégories parmi les
entrées `parity_level ∈ {semantic, surface}` + `bridge_verdict: SOTA-OK` :
**64 TRIVIAL_BASCULE** + 11 SOLVER_FREE + 13 AMBIGUOUS + 37 ALREADY_NATIVE_BOTH +
32 NOT_CANDIDATE. **Cette PR applique la bascule sur 8 des 64 TRIVIAL_BASCULE**.

## Ce que fait cette PR

Bascule **`parity_level: semantic → native-both`** sur **8 paires** réparties en
**3 familles** dont les deux côtés ont déjà un moteur SOTA documenté :

| Famille | Compte | Côté Python (SOTA) | Côté C# (SOTA) |
|---|---|---|---|
| **SMT/Z3-API** | 3 | `z3-solver` (pyz3) | `Microsoft.Z3` NuGet |
| **Search/Applications** | 4 | `minizinc` + `OR-Tools` / `DEAP` + `scipy.signal` / `cvxpy` + `pygad` / `ortools.constraint_solver` | `Google.OrTools.Sat` / `Emgu.CV` + `GeneticSharp` + `SkiaSharp` / `GeneticSharp` / `Google.OrTools.ConstraintSolver` |
| **SymbolicLearning** | 1 | `rdflib` + `AMIE` | `dotNetRDF` + `AMIE` |

**Total = 8 fichiers TRIVIAL_BASCULE basculés** :

- `scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml`
- `scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml`
- `scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-9-edgedetection.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml`
- `scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling.yaml`
- `scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml`

## Modification par fichier (chirurgicale, anti-régression D)

Chaque fichier reçoit **2 modifications atomiques** :

1. **Une ligne** : `parity_level: semantic` → `parity_level: native-both`
2. **Une nouvelle entrée d'audit** : `audits:` reçoit un item daté
   `2026-08-17 by myia-po-2026:CoursIA-2` avec `python_sha`, `csharp_sha`
   (capturés via `git ls-tree HEAD <path>`), et une `reason:` documentant
   la bascule (citation arbitrage ai-01 + constat que `bridge_verdict_reason`
   est inchangée).

**Non touché** (préservation byte-identity du reste) :
- `bridge_verdict: SOTA-OK` — déjà conforme
- `bridge_verdict_reason` — documente déjà le bridge lib-vs-lib
- `known_differences` — inventaire SOTA intact
- Ordre des clés, indentation, commentaires
- Anciennes entrées d'audit (chaîne d'auditition préservée)

**Total diff** : 8 fichiers, **56 insertions / 8 deletions** (8 modifications
chirurgicales, 0 modification hors scope).

## Vérification anti-régression

- **Worktree jetable** sur branche `feature/c175-11200-probas-native-both` à
  partir d'`origin/main` à jour, `git diff --stat` final confirme 8 fichiers.
- **`scan_native_both_drift.py`** (PR #11452) ré-exécuté après bascule :
  les 8 fichiers passent de `TRIVIAL_BASCULE` à `ALREADY_NATIVE_BOTH` (64 → 56).
- **Aucun fichier du registre hors liste n'a été modifié** : tous les autres
  `twin_pairs.d/*.yaml` sont byte-identiques à `origin/main`.

## Note pour Vague 2 (futur PR)

**2 fichiers** (`app-8-minizinc`, `app-10-portfolio`) contiennent dans leur
`bridge_verdict_reason` une mention textuelle explicite
`"parity_level: semantic preserve"` qui contredit désormais la valeur
bascuclée. Laissé tel quel dans cette Vague 1 pour rester atomique (cf. règle
PR = 1 sujet vérifiable, catalog-pr-hygiene.md règle 3) — l'harmonisation
de la prose aura lieu dans une Vague 2 dédiée post-merge de celle-ci.
Leçon **L977 ★** (twin-yaml-reason-sync, PR #11022) : `bridge_verdict_reason`
doit rester cohérent avec `parity_level` — cette Vague 2 est déjà notée.

## Distribution après Vague 1

Catégories `scan_native_both_drift.py` (PR #11452) — recalcul post-bascule :

| Catégorie | Avant V1 | Après V1 |
|---|---:|---:|
| **TRIVIAL_BASCULE** | 64 | **56** (−8) |
| **ALREADY_NATIVE_BOTH** | 37 | **45** (+8) |
| SOLVER_FREE | 11 | 11 (unchanged) |
| AMBIGUOUS | 13 | 13 (unchanged) |
| NOT_CANDIDATE | 32 | 32 (unchanged) |

**Reste à basculer en Vague 2** : 56 TRIVIAL_BASCULE (Probas/Infer.NET-PyMC 18,
SemanticWeb/dotNetRDF-rdflib 11, ML.NET/Python 7, Sudoku 6, Tweety/IKVM-JPype 6,
Search/Part1-Foundations 4, Search/Part2-CSP 2, GameTheory 1, SymbolicAI 1).

## Pourquoi cette Vague 1 atomique (3 familles, 8 fichiers)

- **Famille saturée en upstream + vérifiable firsthand** : Z3 (les DEUX côtés
  sont des bindings du même moteur C++ Z3 sous-jacent, par construction) +
  Search/Applications (les paires sélectionnées invoquent toutes OR-Tools/CP-SAT
  ou GeneticSharp/Emgu.CV/SkiaSharp des deux côtés) + SymbolicLearning/SL-8
  (rdflib ↔ dotNetRDF sont équivalents par construction).
- **Pas de pool saturated** : vérification `check_lane_claim.py` confirme
  CLEAR sur ces 8 chemins (aucune PR OPEN d'une autre lane ne touche ces
  fichiers — voir L898 ★★★ collision guard).
- **Vagues suivantes indépendantes** : la Vague 2 (Probas 18, SemanticWeb 11,
  ML.NET 7, Sudoku 6, Tweety 6, Search/Part1 4, Search/Part2 2) sera portée
  par d'autres agents familiers (po-2024 pour Probas, po-2025 pour SemanticWeb/ML.NET).

## Liens

- Issue **#11200** — diagnostique initiale + arbitrage Option A
- PR **#11301** — réécriture `_schema.yaml` (po-2024, MERGED 2026-08-12)
- PR **#11452** — `scan_native_both_drift.py` (po-2026:CoursIA-2, c.174, OPEN)
- Issue **#10382** — Epic umbrella cross-source distillation (parent)
- **G.9 verify-before-claim** : `bridge_verdict_reason` relue firsthand pour
  les 8 fichiers avant bascule (vérification SOTA explicitement déclarée).
- **anti-regression.md (D)** : diff chirurgical, 0 mutation hors scope,
  ordre des clés préservé, `bridge_verdict_reason` intact.
- **Leçon L977 ★** (twin-yaml-reason-sync) : harmonisation de la prose
  dans 2 fichiers sera portée par Vague 2.

## Grain tag

```
Grain: MED/lean — lane myia-po-2026:CoursIA-2 — prev: MED/docs #11452
```