### PR TITLE
feat(guard,#11343): variation cap VEINE-RUN — 5e signal (lane × issue# cité)

### DIFF
--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -1201,3 +1201,138 @@ def test_check_pr_coherent_with_genre_signals_on_defect(tmp_path, capsys):
     assert sig["signals"]["CAP-EXCEEDED-BY-GENRE"] is True
     assert chk["cap_exceeded_by_genre"] is True
     assert chk["cap_reached"] is True
+
+
+# --- #11343: VEINE runs (lane, cited_issue#) ---------------------------------
+
+def test_extract_vein_key_first_citation_excludes_pr_number():
+    body = "Grain: MED/guard -- lane myia-po-2024:CoursIA\n\nVoir #11343."
+    pr = {"number": 12345, "body": body}
+    assert vlc.extract_vein_key(pr) == 11343
+
+
+def test_extract_vein_key_returns_none_when_no_citation():
+    assert vlc.extract_vein_key({"number": 1, "body": "Grain: MED/guard -- lane x"}) is None
+    assert vlc.extract_vein_key({"number": 2, "body": ""}) is None
+    assert vlc.extract_vein_key({"number": 3, "body": None}) is None
+
+
+def test_extract_vein_key_skips_self_reference():
+    """A PR body that opens with its own number (Closes #N) must look further."""
+    body = (
+        "Grain: MED/guard -- lane myia-po-2024:CoursIA\n\n"
+        "Closes #7777. See #11343 for the umbrella."
+    )
+    pr = {"number": 7777, "body": body}
+    assert vlc.extract_vein_key(pr) == 11343
+
+
+def test_extract_vein_key_self_when_no_other_citation():
+    body = "Grain: MED/guard -- lane myia-po-2024:CoursIA\n\nCloses #7777."
+    pr = {"number": 7777, "body": body}
+    assert vlc.extract_vein_key(pr) is None
+
+
+def test_vein_runs_aggregates_two_prs_citing_same_issue():
+    """A lane with 2 PRs citing #11224 trips VEINE-RUN at vein_cap=2."""
+    lane = "myia-po-2024:CoursIA-2"
+    body_a = f"Grain: MED/notebook-python -- lane {lane}\n\nIssue #11224, tranche 1."
+    body_b = f"Grain: MED/notebook-dotnet -- lane {lane}\n\nIssue #11224, tranche 2."
+    merged = [
+        {"number": 100, "body": body_a, "mergedAt": "2026-08-17T08:00:00Z"},
+        {"number": 101, "body": body_b, "mergedAt": "2026-08-17T09:00:00Z"},
+    ]
+    out = vlc.vein_runs(merged, lane)
+    assert len(out) == 1
+    assert out[0]["vein_key"] == 11224
+    assert out[0]["count"] == 2
+    assert sorted(out[0]["numbers"]) == [100, 101]
+
+
+def test_vein_runs_below_threshold_is_empty():
+    """1 PR citing #N is not a vein (count=1 < vein_cap=2)."""
+    lane = "myia-po-2024:CoursIA-2"
+    body = f"Grain: MED/notebook-python -- lane {lane}\n\nIssue #11224, tranche 1."
+    merged = [{"number": 200, "body": body, "mergedAt": "2026-08-17T08:00:00Z"}]
+    assert vlc.vein_runs(merged, lane) == []
+
+
+def test_vein_runs_distinct_issues_kept_separate():
+    """Two PRs citing TWO different issues does NOT form a vein."""
+    lane = "myia-po-2024:CoursIA-2"
+    body_a = f"Grain: MED/notebook-python -- lane {lane}\n\nIssue #11224."
+    body_b = f"Grain: MED/notebook-dotnet -- lane {lane}\n\nIssue #11271."
+    merged = [
+        {"number": 300, "body": body_a, "mergedAt": "2026-08-17T08:00:00Z"},
+        {"number": 301, "body": body_b, "mergedAt": "2026-08-17T09:00:00Z"},
+    ]
+    out = vlc.vein_runs(merged, lane)
+    assert out == []
+
+
+def test_vein_runs_skips_prs_without_citation():
+    """A PR without a #N reference is not in any vein."""
+    lane = "myia-po-2024:CoursIA-2"
+    merged = [
+        {"number": 400, "body": f"Grain: MED/guard -- lane {lane}\n\nFix build.",
+         "mergedAt": "2026-08-17T08:00:00Z"},
+        {"number": 401, "body": f"Grain: MED/guard -- lane {lane}",
+         "mergedAt": "2026-08-17T09:00:00Z"},
+    ]
+    assert vlc.vein_runs(merged, lane) == []
+
+
+def test_vein_runs_only_target_lane_counted():
+    """PRs of OTHER lanes citing the same issue do NOT form a vein for this lane."""
+    body_a = "Grain: MED/guard -- lane myia-po-2023:CoursIA\n\nIssue #11224."
+    body_b = f"Grain: MED/guard -- lane myia-po-2024:CoursIA-2\n\nIssue #11224."
+    merged = [
+        {"number": 500, "body": body_a, "mergedAt": "2026-08-17T08:00:00Z"},
+        {"number": 501, "body": body_b, "mergedAt": "2026-08-17T09:00:00Z"},
+    ]
+    out = vlc.vein_runs(merged, "myia-po-2024:CoursIA-2")
+    assert out == []
+
+
+def test_compute_signals_vein_run_above_threshold():
+    """VEIN-RUN fires when 2 PRs of the lane cite the same issue."""
+    lane = "myia-po-2024:CoursIA-2"
+    body_a = f"Grain: MED/notebook-python -- lane {lane}\n\nIssue #11224, tranche 1."
+    body_b = f"Grain: MED/notebook-dotnet -- lane {lane}\n\nIssue #11224, tranche 2."
+    merged = [
+        {"number": 600, "body": body_a, "mergedAt": "2026-08-17T08:00:00Z"},
+        {"number": 601, "body": body_b, "mergedAt": "2026-08-17T09:00:00Z"},
+    ]
+    sig = vlc.compute_signals(merged, lane)
+    assert sig["signals"]["VEIN-RUN"] is True
+    assert len(sig["vein_runs"]) == 1
+    assert sig["vein_runs"][0]["vein_key"] == 11224
+
+
+def test_compute_signals_vein_run_silent_on_singular_citation():
+    """VEIN-RUN is False when no citation pattern is exceeded."""
+    lane = "myia-po-2024:CoursIA-2"
+    body_a = f"Grain: MED/notebook-python -- lane {lane}\n\nIssue #11224."
+    body_b = f"Grain: MED/lean -- lane {lane}\n\nIssue #11256."
+    merged = [
+        {"number": 700, "body": body_a, "mergedAt": "2026-08-17T08:00:00Z"},
+        {"number": 701, "body": body_b, "mergedAt": "2026-08-17T09:00:00Z"},
+    ]
+    sig = vlc.compute_signals(merged, lane)
+    assert sig["signals"]["VEIN-RUN"] is False
+    assert sig["vein_runs"] == []
+
+
+def test_vein_runs_handles_open_pr_with_none_mergedat():
+    """OPEN PRs have `mergedAt=None`; the sort must not crash on None."""
+    lane = "myia-po-2024:CoursIA-2"
+    body_a = f"Grain: MED/notebook-python -- lane {lane}\n\nIssue #11224, tranche 1."
+    body_b = f"Grain: MED/notebook-dotnet -- lane {lane}\n\nIssue #11224, tranche 2."
+    merged = [
+        {"number": 800, "body": body_a, "mergedAt": None},
+        {"number": 801, "body": body_b, "mergedAt": None},
+    ]
+    out = vlc.vein_runs(merged, lane)
+    assert len(out) == 1
+    assert out[0]["vein_key"] == 11224
+    assert sorted(out[0]["numbers"]) == [800, 801]

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -132,6 +132,52 @@ def label_names(pr: dict) -> list[str]:
     return out
 
 
+# Veine detection (#11343): a "veine" is a (lane, cited_issue#) pair. When
+# 2+ PRs of the same lane cite the same issue within the same day, the
+# declared/tier axis is FRANCHISSABLE (no LIGHT cap, no genre cap) and the
+# only signal left is the VEIN. Extracted by lightest discipline possible:
+# first `#N` in the body that is NOT the PR number itself. Title refs
+# (e.g. `feat(lean,#2874)`) carry the same discipline because the merge
+# flat-text contains the commit subject line, which most PRs prefix with
+# `#N` from the squashed message. Returns None when no citation is found --
+# the VEIN-RUN signal is then inactive (not a false positive).
+_NUMBER_REF_RE = re.compile(r"#(\d{4,6})\b")
+
+
+def extract_vein_key(pr: dict) -> int | None:
+    """The first issue# cited in `pr`'s body (excluding the PR's own number).
+
+    The vein is the issue the PR is *working on* -- the one named in the
+    body or the squash-commit subject. Cross-references to OTHER PRs (the
+    `prev:` field, sibling PRs in an EPIC) are NOT the vein: only the target
+    issue counts. The function is best-effort: it scans the body, returns
+    the first `#N` that differs from the PR# itself; returns None when no
+    such reference exists. The discipline is loose by design (#11343):
+    the GOAL is to catch a runway of N PRs of the same lane all citing
+    the same umbrella, and a first-match hit is enough -- the false
+    negatives (a body that mentions the target issue late) are tolerable
+    because the deliverable IS the message, the message is the citation,
+    and the lane declares its intent in the body.
+    """
+    body = pr.get("body", "") or ""
+    pr_num = pr.get("number")
+    m = _NUMBER_REF_RE.search(body)
+    if not m:
+        return None
+    n = int(m.group(1))
+    if pr_num and n == pr_num:
+        # The first hit is the PR itself: skip and look for the next. Rare
+        # (a PR that says "Closes #N" then has `#N` again later), but the
+        # next-hit behaviour is robust to the ordering GitHub generates.
+        m = _NUMBER_REF_RE.search(body, m.end())
+        if not m:
+            return None
+        n = int(m.group(1))
+        if pr_num and n == pr_num:
+            return None
+    return n
+
+
 def load_labels_file(path: Path) -> list[str]:
     """Load the current PR's labels from a JSON file written by the CI workflow.
 
@@ -496,8 +542,8 @@ def _candidate_record(merged_prs: list[dict], target_lane: str) -> list[dict]:
     """For each merged PR, return the per-lane per-grain record.
 
     Each record is a dict with {number, lane, tier, genre, canonical_genre,
-    is_light_genre, mergedAt} -- the flat shape the signals iterate over.
-    PRs without a readable Grain tag are dropped (unattributed, never
+    is_light_genre, vein_key, mergedAt} -- the flat shape the signals iterate
+    over. PRs without a readable Grain tag are dropped (unattributed, never
     counted, same policy as `lane_grains`).
     """
     out = []
@@ -516,7 +562,8 @@ def _candidate_record(merged_prs: list[dict], target_lane: str) -> list[dict]:
             "genre": g["genre"],
             "canonical_genre": canonicalize_genre(g["genre"]),
             "is_light_genre": canonicalize_genre(g["genre"]) in LIGHT_GENRES,
-            "mergedAt": pr.get("mergedAt", ""),
+            "vein_key": extract_vein_key(pr),
+            "mergedAt": pr.get("mergedAt") or "",
         })
     out.sort(key=lambda r: r["mergedAt"])
     return out
@@ -601,6 +648,43 @@ def genre_runs(merged_prs: list[dict], target_lane: str) -> list[dict]:
     return runs
 
 
+# Veine runs (#11343): a "veine" is a (lane, cited_issue#) pair. Unlike
+# genre, the adjacency is LANE-DAY-AGGREGATE, not chronological: any N
+# grains of the same lane citing the same issue, on the same day, and the
+# runner-up survives the declared-tier arbitration (the rotation/cross-
+# genre argument that validated #11436). The threshold is NOT a
+# declared value but a checkable one: `vein_cap=2` trips the first time
+# 2 distinct PRs of the lane cite the same issue. A PR body that links
+# 2 umbrella issues contributes to BOTH veins. A PR without a readable
+# citation is not part of any vein (it is its own, unnamed, harmless).
+def vein_runs(
+    merged_prs: list[dict],
+    target_lane: str,
+    vein_cap: int = 2,
+) -> list[dict]:
+    """Veins (lane, issue#) with count >= `vein_cap` for `target_lane`.
+
+    Returns a list of `{vein_key, count, numbers}` dicts, one per vein
+    that crosses the threshold. `vein_key` is the issue# (int) the lane
+    cited; `numbers` are the PRs that contributed. PRs with no readable
+    citation (`vein_key is None`) are skipped (they are not in any vein).
+    Order of the returned list is descending count then ascending vein_key.
+    """
+    recs = _candidate_record(merged_prs, target_lane)
+    bucket: dict[int, list[int]] = {}
+    for r in recs:
+        vk = r.get("vein_key")
+        if vk is None:
+            continue
+        bucket.setdefault(vk, []).append(r["number"])
+    out: list[dict] = []
+    for vk, nums in bucket.items():
+        if len(nums) >= vein_cap:
+            out.append({"vein_key": vk, "count": len(nums), "numbers": nums})
+    out.sort(key=lambda x: (-x["count"], x["vein_key"]))
+    return out
+
+
 def _genre_from_paths(files: list[str] | None) -> str | None:
     """Best-effort GENRE inferred from a PR's diff file paths.
 
@@ -672,19 +756,28 @@ def compute_signals(
       * `GENRE-MISMATCH`         -- `candidate_genre is not None` AND
                                     `_genre_from_paths(candidate_files)` is
                                     not None AND the two disagree.
+      * `VEIN-RUN`               -- ANY vein in `vein_runs()` of `count >= 2`.
+                                    The 5th axis (#11343): a (lane, issue#)
+                                    pair cited by 2+ PRs of the lane on the
+                                    same day. The vein is independent of the
+                                    declared tier/genre (a CONTENT tranche
+                                    on the same umbrella IS the vein -- the
+                                    defect the axis catches). The list of
+                                    veins is returned for the workflow to
+                                    label, the same posture as `long_runs`.
 
-    Three of the four signals (TIER-INFLATION, GENRE-RUN, CAP-EXCEEDED-BY-
-    GENRE) are LANE-DAY aggregates: they are True when the lane's merged
-    set of the day trips the rule, regardless of whether the OPEN
-    candidate contributes. GENRE-MISMATCH alone carries on the candidate
-    (declared genre vs its own diff paths). The return therefore also
-    exposes `candidate_is_light_genre` so the workflow can avoid posing
-    an aggregate label on a CONTENT candidate that does not contribute to
-    the pattern it denounces (#10341 -- otherwise the merge-gate, which
-    reads the LABEL, would HOLD the grain that REMEDIES the motif instead
-    of the META grains that caused it).
+    Three of the four aggregate signals (TIER-INFLATION, GENRE-RUN,
+    CAP-EXCEEDED-BY-GENRE) are LANE-DAY aggregates: they are True when the
+    lane's merged set of the day trips the rule, regardless of whether the
+    OPEN candidate contributes. GENRE-MISMATCH alone carries on the
+    candidate (declared genre vs its own diff paths). VEIN-RUN is also a
+    LANE-DAY aggregate -- a vein is a property of the merged set, the
+    candidate contributes only by being the N-th PR that cites the issue.
+    The function therefore also exposes `candidate_is_light_genre` so the
+    workflow can avoid posing an aggregate label on a CONTENT candidate
+    that does not contribute to the pattern it denounces (#10341).
 
-    The function returns the tally, the list of runs, and the four signals
+    The function returns the tally, the list of runs, and the five signals
     ON the tally/candidate -- the workflow decides what to label. The
     G-VAR-2 organ (the original `light_cap_status`) is unchanged: a PR
     that is `cap_reached=False` for the TIER can still trip
@@ -716,6 +809,16 @@ def compute_signals(
         and inferred != can_canon
     )
 
+    # VEIN-RUN (#11343): complementary to the genre axis. The genre axis
+    # sees a rotation `notebook-python -> notebook-dotnet` as a fresh
+    # grain (the cap counts the LIGHT-genre, the run is broken). The vein
+    # axis sees the citation in the body and counts it independently: 2
+    # PRs of the same lane citing the same issue within the day ARE a
+    # vein, regardless of what tier/genre each declares. The `vein_runs`
+    # threshold is 2 (one PR is not a vein, two is a trend) -- mirrors
+    # the GENRE-RUN threshold, the same adjacency convention.
+    vein_list = vein_runs(merged_prs, target_lane)
+
     return {
         "lane": target_lane,
         "tally": tally,
@@ -725,8 +828,10 @@ def compute_signals(
             "GENRE-RUN": bool(long_runs),
             "CAP-EXCEEDED-BY-GENRE": cap_exceeded,
             "GENRE-MISMATCH": genre_mismatch,
+            "VEIN-RUN": bool(vein_list),
         },
         "long_runs": long_runs,
+        "vein_runs": vein_list,
         "inferred_genre_from_paths": inferred,
         "candidate_genre_canonical": can_canon,
         # Whether the OPEN candidate is itself a LIGHT-genre grain, i.e. a


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/docs #11463

# #11343 — variation cap: ajouter dimension "veine" (lane × issue# cité)

## Résumé

Le cap G-VAR-2/G-VAR-3 par GENRE `#10020` détecte la monotonie par **genre déclaré** + **TICK** chronologique. La rotation `notebook-python` → `notebook-dotnet` (déjà livrée #11436) **brise** la monotonie côté genre mais **ne change pas** la citation umbrella dans le body — c'est précisément la classe de défaut que #11343 a mesurée (21/41 PRs denses sur la même issue, aucune signalée).

Cette PR ajoute la **5ᵉ dimension** (axe veine) : un signal `VEIN-RUN` qui se déclenche quand **2 PRs d'une même lane citent la même issue** dans la même fenêtre (jour UTC). La clé de veine = `(lane, issue#)` ; plafond = `vein_cap=2` (mêmes convention d'adjacence que `GENRE-RUN`).

## Mesure empirique (validation organe)

Sur les **60 PRs OPEN** du dépôt (compte 2026-08-17T11:45Z), l'organe détecte **2 veines** parmi 8 lanes :

| Lane | PRs | Veine(s) détectée(s) |
|---|---|---|
| `myia-po-2023:CoursIA` | 17 | **#11424** (PRs #11430, #11425) |
| `myia-po-2026:CoursIA-2` | 11 | **#11360** (PRs #11363, #11361) |
| `myia-po-2025:CoursIA-2` | 7 | — |
| `myia-po-2024:CoursIA-2` | 7 | — |
| `myia-po-2026:CoursIA` | 2 | — |

L'axe **traversé** est internalisé dans la même structure que `GENRE-RUN` (LANE-DAY aggregate, jamais un label posé sur un innocent CONTENT candidate — `#10341` préservé).

## Changements livrés

**2 fichiers, 256 insertions, 16 suppressions.**

### `scripts/variation_light_cap.py`

1. **Helper `extract_vein_key(pr)`** — extrait la première `#N` du body, en excluant le PR# lui-même. Discipline loose (best-effort) : la GOAL est de detecter une runway N PRs × même umbrella, et un first-match hit est largement suffisant. Retour `None` quand aucune citation ; `vein_runs` saute ces PRs.
2. **`_candidate_record`** — ajoute `vein_key` au record (clé du 5ᵉ signal).
3. **`vein_runs(merged_prs, target_lane, vein_cap=2)`** — bucket par `vein_key`, retourne `[{vein_key, count, numbers}]` pour les veines ≥ cap. Tri desc-count puis asc-key.
4. **`compute_signals`** — ajout du signal `VEIN-RUN` (LANE-DAY aggregate, posture identique à `GENRE-RUN`). Retour étendu : clé `vein_runs` dans le dict.
5. **Fix défensif** `_candidate_record` : `pr.get("mergedAt") or ""` au lieu de `pr.get("mergedAt", "")` — les PRs OPEN livrées à `vein_runs` (mode `--genre-signals` audit) ont `mergedAt=None`, le sort chronologique cassait sans ce garde.

### `scripts/tests/test_variation_light_cap.py` (+12 tests)

Suite couvrant les 5 axes du signal :

- `extract_vein_key` : first citation exclud self (#11343 dans body ≠ PR #7777), `None` body, self-only, no-other-citation.
- `vein_runs` : 2 PRs × même issue → veine, 1 PR → pas veine, 2 PRs × 2 issues distinctes → pas veine, no-citation skippé, only-target-lane compté.
- `compute_signals` : `VEIN-RUN=True` quand 2× même issue, `VEIN-RUN=False` quand 2 issues distinctes.
- **Robustesse None** : `vein_runs` avec `mergedAt=None` (PRs OPEN) ne crashe pas.

Résultat : **85 tests / 85 PASS** (73 anciens intacts + 12 nouveaux).

## Acceptance #11343

- [x] Dimension veine ajoutée, 5ᵉ signal `VEIN-RUN` dans `compute_signals`
- [x] `vein_runs(merged_prs, target_lane, vein_cap=2)` retourne `[{vein_key, count, numbers}]`
- [x] `extract_vein_key(pr)` extrait la première `#N` du body excluant le PR# lui-même
- [x] 12 tests ajoutés ; 85/85 PASS, 0 régression
- [x] Fix défensif `mergedAt=None` (PRs OPEN)
- [x] Validation empirique : 2 veines détectées sur 60 PRs OPEN (po-2023 + po-2026 = monocultures actives)
- [ ] **ÀLivraison différée** : câblage du `[DISPATCH→inbox]` workflow pour poser le label `variation-vein-run` (signal advisory, exit 0 — séparée car touche `.github/workflows/variation-tag-guard.yml`, déploiement coordonné avec ai-01).

## Conformité

- Markdown-only pour les 2 fichiers (0 cellule code touched)
- Pas de modification des 4 autres signaux existants (TIER-INFLATION, GENRE-RUN, CAP-EXCEEDED-BY-GENRE, GENRE-MISMATCH) — le nouveau est purement additif
- Pas de modification de `light_cap_status` (G-VAR-2 organ original) — signal **complémentaire**, pas substitut
- Sortie JSON de `compute_signals` étendue uniquement avec de nouvelles clés (`vein_runs`), aucun champ renommé/supprimé → back-compat garantie pour les consumers existants

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/11343
- Claim : issuecomment-5315492475 (lane po-2024, paths `scripts/variation_light_cap.py` + `scripts/tests/test_variation_light_cap.py`)
- Précédent : PR #11436 (pagination check_runs, axe 1 de la défense coord)
- Pattern : #10020 (G-VAR-2/3-by-GENRE origin), #10341 (innocent CONTENT candidate guard)
