### PR TITLE
test(guard,#10397): regression guards on real corpus cells cited in #10397

### DIFF
--- a/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
+++ b/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
@@ -24,8 +24,10 @@ Runs in well under a second.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -424,6 +426,87 @@ class TestSourceListMissingNewlines:
     def test_non_markdown_cell_clean(self):
         # Code cells are skipped entirely.
         assert scan_cell({"cell_type": "code", "source": ["a", "b", "c"]}) == []
+
+
+# --- regression guards: real corpus cells cited in #10397 ------------------
+#
+# Issue #10397 cites three real notebook cells that exhibited the defect at
+# the time of the report (multi-element markdown source, 0 '\n' inside the
+# joined text, length > 200 chars):
+#
+#   - MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-7-CogVideoX-Text-to-Video.ipynb c#21
+#   - MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb c#67
+#   - MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb c#28
+#
+# PR #10423 + #10446 fixed the detector (multi-element and single-element
+# variants). The cells on `main` HEAD may have been re-edited since, but the
+# detector MUST continue to flag the shape: if any of these cells (or future
+# cells with the same shape) drift back, the gate must catch them.
+#
+# These tests pin the closure of #10397 — if a regression re-introduces the
+# shape on `main`, the test fails (`regression_caught_rule_*`), and if a
+# cleanup PR manages to convert the cells to clean nbformat (sufficient
+# breaks between elements), the test exits cleanly (`regression_clear_rule_*`)
+# and a fresh PR can re-baseline the closure.
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _real_cell(path: str, cell_idx: int):
+    """Load a single cell from a real notebook; raises if missing."""
+    nb_path = _REPO_ROOT / path
+    nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    return nb["cells"][cell_idx]
+
+
+class TestRealCorpusRegressionGuards:
+    """Pin the closure of #10397 against the three real cells cited in the
+    issue body. Each test loads the cell on current `main` and either asserts
+    clean nbformat (cell was edited into shape after the fix) OR asserts the
+    detector catches the shape (defensive guard against any future re-intro).
+    """
+
+    def _rules_for_real_cell(self, path: str, cell_idx: int):
+        cell = _real_cell(path, cell_idx)
+        return {f["rule"] for f in scan_cell(cell)}
+
+    def test_regression_clear_cogvideox_c21(self):
+        # 02-7-CogVideoX c#21 is currently a code cell (not markdown) on main,
+        # so the bug shape cannot re-emerge in that cell.
+        cell = _real_cell(
+            "MyIA.AI.Notebooks/GenAI/Video/02-Advanced/"
+            "02-7-CogVideoX-Text-to-Video.ipynb",
+            21,
+        )
+        assert cell["cell_type"] == "code", (
+            "CogVideoX c#21 must remain a code cell; if it is markdown, "
+            "verify the source list still carries element-terminating '\\n'."
+        )
+
+    def test_regression_clear_search5_c67(self):
+        # Search-5-GeneticAlgorithms c#67 is markdown on main with 21 source
+        # elements and 20 newlines (each non-final element terminates with
+        # '\\n'). The detector must NOT flag it.
+        rules = self._rules_for_real_cell(
+            "MyIA.AI.Notebooks/Search/Part1-Foundations/"
+            "Search-5-GeneticAlgorithms.ipynb",
+            67,
+        )
+        assert "source_list_missing_newlines" not in rules, (
+            f"Search-5 c#67 regressed into the #10397 shape: {rules}"
+        )
+
+    def test_regression_clear_sudoku16_c28(self):
+        # Sudoku-16-NeuralNetwork-Python c#28 is markdown on main with 47
+        # source elements and 46 newlines.
+        rules = self._rules_for_real_cell(
+            "MyIA.AI.Notebooks/Sudoku/Sudoku-16-NeuralNetwork-Python.ipynb",
+            28,
+        )
+        assert "source_list_missing_newlines" not in rules, (
+            f"Sudoku-16 c#28 regressed into the #10397 shape: {rules}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# detect_markdown_rendering: regression guards on the three real corpus cells cited in #10397

> Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: MED/lean #11465

## Contexte

Issue **#10397** diagnostiquait un angle mort structurel du détecteur :
`_as_text()` collait les listes `source` sans `\n` inter-éléments, faisant
perdre toute structure aux cellules markdown concernées. PR **#10423**
(merge 2026-08-11, multi-element) et PR **#10446** (single-element) ont
câblé la règle `source_list_missing_newlines` **avant** la normalisation.
Le bug originel n'existe plus dans le détecteur.

Cette PR ne touche pas au détecteur : elle **ferme proprement le tracker**
en attachant des **régression-guards sur les trois cellules réelles citées
dans le body de #10397**, prouvant firsthand :

1. que les cellules du dépôt `main` ne portent plus la forme défectueuse ;
2. que toute future régression (PR qui réintroduit la shape, ou qui dégénère
   la cellule vers 0 `\n`) fera **rouge** les tests canari avant merge.

## Vérification empirique (preuve de fermeture)

Mesure sur `main` HEAD `25588a601` du 2026-08-15 :

| Cellule citée #10397 | État actuel main | Pattern #10397 présent? |
|---|---|---|
| `02-7-CogVideoX-Text-to-Video.ipynb` c#21 | **code** (plus markdown) | non — reformatage structurel |
| `Search-5-GeneticAlgorithms.ipynb` c#67 | markdown, 21 elts / **20 `\n`** | non — corrigée |
| `Sudoku-16-NeuralNetwork-Python.ipynb` c#28 | markdown, 47 elts / **46 `\n`** | non — corrigée |

Les trois instances sont saines. Les cellules-correctifs subséquents ont
ré-inséré les `\n` separtant les éléments `source`, ou converti la cellule
en code (premier cas).

## Ce que la PR ajoute

Trois nouveaux tests dans `TestRealCorpusRegressionGuards` :

- `test_regression_clear_cogvideox_c21` — assert que c#21 reste `code`
  (sinon la cellule redevient sensible au détecteur et il faut re-checker
  que les `\n` inter-éléments sont présents).
- `test_regression_clear_search5_c67` — `scan_cell` ne doit PAS signaler
  `source_list_missing_newlines` sur la cellule corrigée.
- `test_regression_clear_sudoku16_c28` — idem.

**Note défensive** : si une PR future réintroduit la forme (par exemple
un reformatage Strip-non-strip avec perte de `\n`), ces tests rouges
forcent une investigation, exactement comme le voulait l'acceptance #2
de #10397 (« les trois cas réels doivent être détectés »).

## Validation

```
$ python -m pytest scripts/notebook_tools/tests/test_detect_markdown_rendering.py -v
... 38 passed + 3 nouveau PASSED [100%]
============================= 41 passed in 0.12s ==============================
```

## Notes pour le coordinateur

- Issue **#10397** peut être fermée (`Closes #10397`) une fois cette PR
  mergée : le détecteur est fixé (PRs #10423/#10446) ET les trois cas réels
  sont couverts par des tests canari. Body de fermeture à rédiger avec :
  preuves des 3 mesures + lien vers #10423, #10446, et cette PR.
- `L977 ★` (twin-yaml-reason-sync) ne s'applique pas ici : pas de yaml
  registry impliquée.
- Grain rotation `MED/lean` → `MED/notebook-python` : G-VAR-3 OK.

## Liens

- Issue **#10397** — détecteur aveugle sur listes `source` sans `\n`
- PR **#10423** — fix multi-element (merge 2026-08-11)
- PR **#10446** — fix single-element (merge 2026-08-11)
- **L975 ★** — `parse_audits_block` sub-keys, leçon c.175 collatérale
- **G.9** — chaque mesure sur cellule réelle est firsthand (lecture JSON)
