### PR TITLE
docs(sudoku,#9434): drain MACHINE-DEP wall-clock from Sudoku-14-BDD-Csharp

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb
@@ -89,7 +89,7 @@
     "| **Structure** | Graphe de décision explicite | Formules logiques |\n",
     "| **Opérations** | Union, Intersection, Réduction | SAT solving |\n",
     "| **Mémoïsation** | Naturelle (partage de sous-graphes) | Via Z3 |\n",
-    "| **Performance** | < 1 ms (résolution, cf. §6) | ~ 20 ms |\n",
+    "| **Performance** | (mesure, voir cellule precedente) | (mesure, voir cellule precedente) |\n",
     "| **Authenticité** | ⭐⭐⭐ Vrais automates | ⭐⭐ Compilation |\n",
     "\n",
     "### 1.2 Pourquoi BDD?\n",
@@ -115,7 +115,10 @@
     "     1   2  ...  9\n",
     "     |   |      |\n",
     "    feuille (valeur choisie)\n",
-    "```"
+    "```\n",
+    "\n",
+    "\n",
+    "> **Note (mandat #9377/#9434)** : les **durées wall-clock** (`< 1 ms`, `~ 20 ms`) de cette table comparative sont **machine-dépendantes** par construction (compile .NET + JIT + GC, charge CPU du runner) et **drainées**. Le **rapport d'ordres de grandeur** (BDD ≈≪ Z3 sur ce puzzle) est **reproductible d'une exécution à l'autre** et **conservé**. Les **mesures exactes** restent **visibles** dans les cellules de mesure amont (§6 du présent notebook pour la mesure BDD/MDD ; cellule de banc d'essai `[24]` du notebook Sudoku-12-Z3-Csharp pour la mesure Z3). La pédagogie de cette cellule **tient sur la discrimination théorique** (vrais automates vs compilation SMT), pas sur les ratios quantitatifs qui rebougent à chaque machine.\n"
    ]
   },
   {
@@ -1782,9 +1785,12 @@
     "\n",
     "**Sortie obtenue** : Le solveur trouve la solution, mais avec des performances similaires au backtracking classique.\n",
     "\n",
-    "**Temps de résolution** : moins d'une milliseconde sur le puzzle facile testé (0,46 ms mesurée à la cellule précédente).\n",
+    "**Temps de résolution** : moins d'une milliseconde sur le puzzle facile testé ((mesure, voir cellule precedente) — valeur ponctuelle indicative, var d'une machine à l'autre).\n",
     "\n",
-    "**Point important** : Bien que nous ayons construit des MDD pour illustrer la théorie, l'approche pratique pour Sudoku utilise le backtracking direct. Les MDD brillent vraiment pour des contraintes plus locales ou des problèmes de vérification."
+    "**Point important** : Bien que nous ayons construit des MDD pour illustrer la théorie, l'approche pratique pour Sudoku utilise le backtracking direct. Les MDD brillent vraiment pour des contraintes plus locales ou des problèmes de vérification.\n",
+    "\n",
+    "\n",
+    "> **Note (mandat #9377/#9434)** : la **durée wall-clock** (`0,46 ms`) est **machine-dépendante** par construction (compile .NET + JIT + GC, charge CPU du runner) et **drainée** au profit d'un référal à la cellule de mesure amont. La **tendance qualitative** (ordre de grandeur < 1 ms sur grille facile) est **reproductible** et **conservée** en prose. La mesure exacte reste visible dans la cellule de code immédiatement précédente (sortie `Kernel.Elapsed` / `Stopwatch`).\n"
    ]
   },
   {
@@ -2485,7 +2491,7 @@
     "| **Structure** | Variables Z3 + contraintes | Graphe de décision |\n",
     "| **Opérations** | Conjonction de contraintes | Produit d'automates |\n",
     "| **Vérification** | SAT solving | Parcours de graphe |\n",
-    "| **Performance** | ~ 20 ms | < 1 ms (résolution, cf. §6) |\n",
+    "| **Performance** | (mesure, voir cellule precedente) | (mesure, voir cellule precedente) |\n",
     "| **Authenticité** | ⭐⭐ Approche hybride | ⭐⭐⭐ Vrais automates |\n",
     "| **Pragmatisme** | ⭐⭐⭐ Production-ready | ⭐ Théorique |\n",
     "\n",
@@ -2506,7 +2512,10 @@
     "\n",
     "Laquelle est \"meilleure\"? Dépendez de votre objectif :\n",
     "- Pour résoudre des Sudoku : Z3\n",
-    "- Pour comprendre la théorie : BDD/MDD"
+    "- Pour comprendre la théorie : BDD/MDD\n",
+    "\n",
+    "\n",
+    "> **Note (mandat #9377/#9434)** : les **durées wall-clock** de cette table comparative sont **machine-dépendantes** par construction et **drainées**. Le **rapport d'ordres de grandeur** (Z3 ~ 20 ms vs BDD ≈≪ 1 ms sur ce puzzle) est **reproductible d'une exécution à l'autre** et **conservé**. Les **mesures exactes** restent **visibles** dans les cellules de mesure amont (cellule `[24]` du notebook Sudoku-12-Z3-Csharp pour la mesure Z3 ; §6 du présent notebook pour la mesure BDD/MDD).\n"
    ]
   },
   {
@@ -2556,10 +2565,13 @@
     "\n",
     "| # | Notebook | Approche | Temps (Easy) | Pureté \"automata\" |\n",
     "|---|----------|----------|--------------|-------------------|\n",
-    "| 12 | **SFA + Z3** | Compilation vers SMT | ~20 ms | ⭐ |\n",
-    "| 14 | **BDD/MDD** | Automates purs | < 1 ms (cf. §6) | ⭐⭐⭐ |\n",
+    "| 12 | **SFA + Z3** | Compilation vers SMT | (mesure, voir cellule precedente) | ⭐ |\n",
+    "| 14 | **BDD/MDD** | Automates purs | (mesure, voir cellule precedente) | ⭐⭐⭐ |\n",
     "\n",
-    "Les deux approches ont leur place : l'une pour la pratique, l'autre pour la théorie."
+    "Les deux approches ont leur place : l'une pour la pratique, l'autre pour la théorie.\n",
+    "\n",
+    "\n",
+    "> **Note (mandat #9377/#9434)** : les **durées wall-clock** (`~20 ms`, `< 1 ms`) de cette table de synthèse finale sont **machine-dépendantes** par construction et **drainées**. Le **rapport d'ordres de grandeur** (Z3 ~ 20 ms vs BDD ≈≪ 1 ms sur ce puzzle) est **reproductible d'une exécution à l'autre** et **conservé**. Les **mesures exactes** restent **visibles** dans les cellules de mesure amont (cellule `[24]` du notebook Sudoku-12-Z3-Csharp pour la mesure Z3 ; §6 du présent notebook pour la mesure BDD/MDD). La synthèse pédagogique **tient sur la discrimination théorique** (SFA compilation vs BDD automates purs), pas sur les valeurs quantitatives ponctuelles.\n"
    ]
   },
   {
@@ -2651,8 +2663,11 @@
     "\n",
     "- Un BDD **non réduit** pour `x AND y` compte **5 nœuds** (cf. cellule 7, où les deux feuilles `False` ne sont pas fusionnées) ; la **réduction** BDD partage ces terminaux identiques et descend à **4 nœuds**. C'est sur des fonctions plus complexes que ce partage de sous-graphes fait décoller l'avantage du BDD face à une table de vérité exponentielle (2ⁿ lignes).\n",
     "- Le MDD d'une seule ligne Sudoku atteint **5 611 771 nœuds** (vs 9! = 362 880 permutations valides) : l'explosion d'états rend les MDD complets impraticables pour Sudoku.\n",
-    "- Le solveur MDD est en réalité **hybride** (backtracking + vérification MDD), résolu en **0,46 ms** sur grille Easy.\n",
-    "- **Z3/SMT (Sudoku-12)** reste l'approche de production (~166-470 ms en bitvectors selon la difficulté), tandis que les BDD excellent en **model checking et vérification formelle**.\n"
+    "- Le solveur MDD est en réalité **hybride** (backtracking + vérification MDD), résolu en **(mesure, voir cellule precedente)** sur grille Easy (valeur ponctuelle indicative).\n",
+    "- **Z3/SMT (Sudoku-12)** reste l'approche de production (bitvectors, ordre de grandeur conservé d'une machine à l'autre : voir cellule de mesure amont du notebook Sudoku-12-Z3-Csharp), tandis que les BDD excellent en **model checking et vérification formelle**.\n",
+    "\n",
+    "\n",
+    "> **Note (mandat #9377/#9434)** : les **durées wall-clock** (`0,46 ms`, `166-470 ms`) de cette cellule récapitulative sont **machine-dépendantes** par construction (compile .NET + JIT + GC, charge CPU du runner) et **drainées**. Les **faits reproductibles** (résolution réussie, ordre de grandeur global, existence d'une explosion d'états des MDD) sont **conservés**. Les **mesures exactes** restent **visibles** dans les cellules de mesure amont (cellule `[24]` du notebook Sudoku-12-Z3-Csharp pour la mesure Z3 bitvector ; cellule de code immédiatement précédente du présent notebook pour la mesure MDD `0,46 ms`). Les **tailles de graphes** (5 611 771 nœuds MDD, 4-5 nœuds BDD) sont **déterministes** (forme canonique BDD, construction MDD systématique) et **non affectées** par la dérive machine — elles sont **conservées telles quelles**.\n"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-14-bdd.yaml
@@ -28,7 +28,14 @@
       csharp_sha: bd3bfcbc76970adb03fc4441d7436365f3b18c39
       content_python_sha: 1bfc5722a332acb62b38fc19af0f8a32cdddb604b0867e3949607b1897c9db07
       content_csharp_sha: b6d2e21965204ae8e8f039f12dee48fdaba7cc6867c9dade16b04871206cdeca
+    - date: "2026-08-17"
+      by: myia-po-2025:CoursIA-2
+      python_sha: 8672bbe7b5508c8dbca73e17d6d1a0af2f68ab00
+      csharp_sha: 1697a55967ca23ab5b9d59c16a288a7616470f14
+      content_python_sha: 1bfc5722a332acb62b38fc19af0f8a32cdddb604b0867e3949607b1897c9db07
+      content_csharp_sha: 30c5780f18c7a712890624cc5c1230601ea3915341c96416a1add77035ab4bb2
   known_differences:
     - "Socle pedagogique commun : resolution du Sudoku par automates a decision binaire (BDD / MDD, Binary/Multi-valued Decision Diagrams), meme concept (codage booleen des contraintes, reduction canonique du graphe de decision, satisfaction via parcours). Le notebook Python declare explicitement etre le jumeau du C# (« Jumeau Python du notebook Sudoku-14-BDD-Csharp.ipynb »)."
     - "Divergence d'implementation : les deux cotes hand-rollent les BDD/MDD from scratch (pas de lib BDD tierce) -- le Python via dataclasses/typing, le C# via System.Collections.Generic + System.Linq. Meme reconstruction pedagogique de l'automate, idiomes de langage differents."
     - "Parite structurelle proche : Python 14 cellules code / 19 markdown ; C# 15 cellules code / 25 markdown. Arc pedagogique identique (construction du BDD -> reduction -> resolution)."
+    - "Rebaseline 2026-08-17 : cote C# draine wall-clock MACHINE-DEP en cell[1] (table comparative BDD vs Z3, `< 1 ms` / `~ 20 ms`), cell[29] (interp solveur MDD, `0,46 ms`), cell[33] (table comparative finale, `~ 20 ms` / `< 1 ms`), cell[34] (table synthèse finale, `~20 ms` / `< 1 ms`), cell[37] (cellule récapitulative, `0,46 ms` / `166-470 ms`). Total ~10 wall-clock drainés. Cote Python non modifie (Python notebook non vise par cette tranche, le twin pair conserve sa parité semantique). Attestation = blob SHA C# avance (1697a55... depuis bd3bfcb...)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #11470

## Résumé

EPIC #9434 — **tranche `Sudoku-14-BDD-Csharp`** (claim narrow ré-pose, `pool != saturated` confirmé). Drain des **wall-clock MACHINE-DEP** dispersés dans le notebook : **~10 wall-clock** drainés sur **5 cellules markdown** (cell[1] comparative BDD vs Z3, cell[29] interp solveur MDD, cell[33] tableau final comparatif, cell[34] table synthèse finale, cell[37] cellule récapitulative). Wall-clock drainés : `< 1 ms`, `~ 20 ms`, `0,46 ms`, `~20 ms`, `~166-470 ms`, `2ᵉ 0,46 ms`. Édition markdown-only — aucune cellule code touchée, aucun `execution_count` modifié, aucune sortie réécrite (Stop & Repair règle 6 respectée, C.3 scope strict : un seul notebook, 5 cellules markdown).

Les **5 cellules `X min`** (cell[0] `25 min`, cell[2] `15 min`, cell[9] `15 min`, cell[13] `20 min`, cell[22] `15 min`, cell[26] `20 min`) sont des **estimations pédagogiques de durée par section** — **non MACHINE-DEP**, elles restent.

## Note sur le claim narrow

Claim initial posté sur **Sudoku-12-Z3-Csharp** (c.1301+193 démarrage) s'est avéré **sans résidu** : la cellule `[25]` de Sudoku-12-Z3-Csharp porte déjà la mention explicite `« temps absolus mesurés dynamiquement par la cellule de banc d'essai ci-dessus, règle #9434 »` (drain déjà appliqué antérieurement). **RELEASED** posté sur #9434 + **re-claim narrow** sur Sudoku-14-BDD-Csharp.

## Diagnostic dérive (C.4 — section obligatoire)

### Cause

`Sudoku-14-BDD-Csharp.ipynb` cellules [1], [29], [33], [34], [37] contenaient **~10 wall-clock** cumulés. Ces valeurs sont **machine-dépendantes** par construction (compile .NET + JIT + GC, charge CPU du runner, mesure `Stopwatch`).

Le mandat #9377/#9434 (« les données quantitatives doivent être tenues par le CI, pas dans la prose ») avait été appliqué à 11+ tranches précédentes — incluant les côtés Sudoku-13-SymbolicAutomata-{Csharp,Python} (c.1301+192 PR #11470) et Sudoku-15-Infer-{Csharp,Python} (c.1301+189 PR #11440 + c.1301+190 PR #11446). **Sudoku-14-BDD-Csharp avait échappé** à ces passes.

### Verdict

**CAUSE_FIXED** — drain mécanique des wall-clock des 5 cellules, **remplacement** par :
- Cellules [1], [33], [34] (3 tables comparatives BDD/MDD vs Z3) → `(mesure, voir cellule precedente)` (placeholder qui pointe vers les cellules de mesure amont du notebook Sudoku-12-Z3-Csharp cell[24] pour la mesure Z3, et §6 du présent notebook pour la mesure BDD/MDD)
- Cellule [29] (interp solveur MDD) → `(mesure, voir cellule precedente) — valeur ponctuelle indicative, var d'une machine à l'autre` (référal à la cellule de code immédiatement précédente, sortie `Kernel.Elapsed` / `Stopwatch`)
- Cellule [37] (récapitulatif) → `(mesure, voir cellule precedente)` sur `0,46 ms` ; `~166-470 ms` → reformulé en `bitvectors, ordre de grandeur conservé d'une machine à l'autre : voir cellule de mesure amont du notebook Sudoku-12-Z3-Csharp`
- **Tailles de graphes** (`5 611 771 nœuds`, `4-5 nœuds`) **conservées** : ces valeurs sont **déterministes** (forme canonique BDD, construction MDD systématique) et **non affectées** par la dérive machine.

### Pourquoi drain plutôt que ré-exécution

Règle C.5 + Stop & Repair règle 6 : une **valeur de perf/timing** dans un notebook **ré-exécutable localement** se corrige par une **ré-exécution fraîche** plutôt qu'un alignement markdown chirurgical. Mais **dans ce cas, la valeur est par construction MACHINE-DEP** (wall-clock = runtime kernel .NET + mesure `Stopwatch`) — la ré-exécution ne stabiliserait pas la valeur, elle la rendrait simplement plus récente (toujours fausse ailleurs). Le bon fix est le **retrait** (drain), pas la ré-exécution (qui re-épinglerait une valeur qui rebougera). Alignement avec les tranches #11440 (c.1301+189) + #11446 (c.1301+190) + #11470 (c.1301+192) livrées précédemment, qui avaient le même raisonnement.

### Conserve (reproductible d'une exécution à l'autre)

- **Résultat de résolution** : `solveur trouve la solution` (sortie déterministe)
- **Tendance qualitative comparative** : `BDD/MDD ≈≪ Z3 sur ce puzzle`, `ordre de grandeur global conservé`, `MDD explode pour Sudoku complet`, `BDD brillent en model checking`
- **Tailles canoniques** : `5 611 771 nœuds MDD`, `4-5 nœuds BDD` (forme canonique, déterministe)
- **Structure du banc d'essai** : la liste des 4 encodeages Z3, leur substrat, leur verdict (résolu / TIMEOUT / etc.)

## Détail du diff

### Cell[1] (md, comparative BDD vs Z3)

| Avant | Après |
|---|---|
| `\| **Performance** \| < 1 ms (résolution, cf. §6) \| ~ 20 ms \|` | `\| **Performance** \| (mesure, voir cellule precedente) \| (mesure, voir cellule precedente) \|` |

**+ Meta-note ajoutée** : mandat #9377/#9434 explicite, justification de la conservation du rapport d'ordres de grandeur (BDD ≈≪ Z3 sur ce puzzle), référal cellule de mesure §6 et notebook Sudoku-12-Z3-Csharp cell[24].

### Cell[29] (md, interprétation solveur MDD)

| Avant | Après |
|---|---|
| `moins d'une milliseconde sur le puzzle facile testé (0,46 ms mesurée à la cellule précédente).` | `moins d'une milliseconde sur le puzzle facile testé ((mesure, voir cellule precedente) — valeur ponctuelle indicative, var d'une machine à l'autre).` |

**+ Meta-note** : wall-clock drainé, fait reproductible (résolution réussie) conservé, référal à la cellule de code immédiatement précédente (sortie `Kernel.Elapsed` / `Stopwatch`).

### Cell[33] (md, tableau comparatif final)

| Avant | Après |
|---|---|
| `\| **Performance** \| ~ 20 ms \| < 1 ms (résolution, cf. §6) \|` | `\| **Performance** \| (mesure, voir cellule precedente) \| (mesure, voir cellule precedente) \|` |

**+ Meta-note** : référal à cellule `[24]` du notebook Sudoku-12-Z3-Csharp + §6 du présent notebook.

### Cell[34] (md, table synthèse finale)

| Avant | Après |
|---|---|
| `\| 12 \| **SFA + Z3** \| Compilation vers SMT \| ~20 ms \| ⭐ \|` | `\| 12 \| **SFA + Z3** \| Compilation vers SMT \| (mesure, voir cellule precedente) \| ⭐ \|` |
| `\| 14 \| **BDD/MDD** \| Automates purs \| < 1 ms (cf. §6) \| ⭐⭐⭐ \|` | `\| 14 \| **BDD/MDD** \| Automates purs \| (mesure, voir cellule precedente) \| ⭐⭐⭐ \|` |

**+ Meta-note** : synthèse pédagogique sur la discrimination théorique (SFA compilation vs BDD automates purs), pas sur les valeurs quantitatives ponctuelles.

### Cell[37] (md, cellule récapitulative)

| Avant | Après |
|---|---|
| `résolu en **0,46 ms** sur grille Easy.` | `résolu en **(mesure, voir cellule precedente)** sur grille Easy (valeur ponctuelle indicative).` |
| `~166-470 ms en bitvectors selon la difficulté` | `bitvectors, ordre de grandeur conservé d'une machine à l'autre : voir cellule de mesure amont du notebook Sudoku-12-Z3-Csharp` |

**+ Meta-note** : taille canonique BDD/MDD (`5 611 771 nœuds`, `4-5 nœuds`) **conservée** — déterministe, non affectée par la dérive machine.

## Statistiques

- **~10 wall-clock drainés** dans 5 cellules markdown
- **+26 / −11** sur le notebook (chiffre `git diff --stat`)
- **5 cellules markdown touchées**, 0 cellule code, 0 output, 0 exec_count
- **5 cellules `X min` préservées** (estimations pédagogiques, non MACHINE-DEP)
- **twin-parity rebaseline** : `Sudoku-14 BDD` csharp_sha `bd3bfcbc... → 1697a559...`, content_csharp_sha `b6d2e219... → 30c5780f...` (commit `2fbdbdea9`)
- Total : **1 entrée audit ajoutée** au registre (#8057), **1 entrée known_differences** ajoutée

## Vérification

- **C.1** : aucune cellule code touchée (markdown-only)
- **C.2** : `execution_count` + `outputs` non modifiés (markdown-only)
- **C.3** : scope strict = un seul notebook, 5 cellules markdown (cf diff stat)
- **C.4** : section Diagnostic dérive + verdict `CAUSE_FIXED` présente dans ce body
- **C.5** : drain (retrait) plutôt que ré-épingle pour les valeurs MACHINE-DEP — conforme au tableau de décision C.5
- **Stop & Repair règle 6** : aucune sortie de cellule committee hand-éditée
- **H.3** : pas de cellule code touchée, pre-commit 6/6 PASS (gitleaks, probe strip, papermill scrub, markdown frontmatter, oversized, H.3)
- **twin-parity** : 157/157 OK, DRIFT=0, MISSING=0 vérifié post-rebaseline

## Pattern appliqué

Précédent direct : **PR #11470** (c.1301+192, Sudoku-13-SymbolicAutomata-Csharp) + **PR #11446** (c.1301+190, Sudoku-15-Infer-Python) + **PR #11440** (c.1301+189, Sudoku-15-Infer-Csharp). Cette PR = **4ᵉ tranche de la vague #9434 livrée par po-2025** dans la même semaine, toutes sur le pattern C.5 + C.4 + twin-parity rebaseline 2 commits séparés.

## Claim scope

Re-pose du claim scope narrow sur issue #9434 (RELEASED posté sur Sudoku-12-Z3-Csharp puis re-pose sur Sudoku-14-BDD-Csharp) :

> `[CLAIMED] lane myia-po-2025:CoursIA-2 -- paths: MyIA.AI.Notebooks/Sudoku/Sudoku-14-BDD-Csharp.ipynb`

→ débloque les autres lanes sur les tranches restantes (Sudoku-11-Choco-Python, Sudoku-17-LLM-Python, Sudoku-18-Comparison, etc.).

## Umbrella

Voir #9434 — Epic vivante, 12 tranches mergées + PR #11440 (c.1301+189) + PR #11446 (c.1301+190) + PR #11470 (c.1301+192) + cette PR = **14ᵉ tranche**.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
