### PR TITLE
feat(slides,S3-acculturation): cleanup Slidev aligné PPTX (P0+P1+P2)

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -420,35 +420,42 @@ layout: two-cols
 
 # Stratégies d'exploration (1/2)
 
+<div class="grid grid-cols-2 gap-0 -mt-4">
+<div class="bg-orange-700 text-white px-6 py-3 text-xl font-bold text-center">Non informées</div>
+<div class="bg-slate-800 text-white px-6 py-3 text-xl font-bold text-center">Informées</div>
+</div>
 
-**Non informées**
+<div class="grid grid-cols-2 gap-8 mt-6">
+
+<div>
 
 - En largeur
 - En profondeur
-- Ex: Où sont mes clefs ?
 - Bidirectionnelle
+- Ex: Où sont mes clefs ?
 
-![w:220](./images/img_025.png)
-![w:220](./images/img_026.png)
-![w:220](./images/img_027.png)
+![w:300](./images/img_025.png)
+![w:300](./images/img_026.png)
 
+</div>
 
-::right::
-
-
-**Informées**
+<div>
 
 - Évaluation des états
-- Heuristique
-- Estimation du coût restant
-- Ex: Distance à vol d'oiseau
+  - **Heuristique**
+  - Estimation du coût restant
+  - Ex: Distance à vol d'oiseau
 - Par le meilleur d'abord
   - Exploration gloutonne
   - Algorithme A*
-  - Demo Pathfinding.js
+  - [Demo Pathfinding.js](#)
 
-![w:220](./images/img_028.png)
-![w:220](./images/img_029.png)
+![w:300](./images/img_027.png)
+![w:300](./images/img_028.png)
+
+</div>
+
+</div>
 
 
 

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -31,7 +31,7 @@ layout: cover
 
 - Qu'est-ce que l'intelligence artificielle ?
 - Racines, histoire et état de l'art
-- Structure des agents rationnel
+- Structure des agents rationnels
 - Intelligence exploratoire
 - Comment chercher la solution à un problème ?
 - Intelligence Symbolique
@@ -60,7 +60,6 @@ layout: section
 
 
 ---
----
 
 
 
@@ -84,7 +83,7 @@ layout: section
 - Théorie du contrôle
 - Linguistique
 
-<img src="./images/img_005.png" style="position:absolute; top:193px; right:20px; width:460px;" alt="Qu'est-ce que l'intelligence artificielle?" />
+<img src="./images/img_005.png" class="absolute top-[193px] right-[20px] w-[460px]" alt="Qu'est-ce que l'intelligence artificielle?" />
 ---
 layout: two-cols
 ---
@@ -106,7 +105,7 @@ layout: two-cols
   - Robotique, vision
 - 1990s : L'IA devient une science
 
-<div style="text-align: center; margin-top: 8px;">
+<div class="text-center mt-2">
 ![h:100](./images/img_006.png)
 </div>
 
@@ -124,7 +123,7 @@ layout: two-cols
   - 2016 : AlphaGo
 - NLP : Transformers, LLMs
 
-<div style="display: flex; gap: 10px; margin-top: 8px;">
+<div class="flex gap-3 mt-2">
 ![h:45](./images/img_007.jpg)
 ![h:45](./images/img_008.jpg)
 
@@ -168,7 +167,6 @@ layout: two-cols
 
 
 ---
----
 
 
 
@@ -188,7 +186,7 @@ layout: two-cols
 - Limitations
   - ressources disponibles
 
-<img src="./images/img_009.png" style="position:absolute; top:203px; right:20px; width:460px;" alt="Les agents" />
+<img src="./images/img_009.png" class="absolute top-[203px] right-[20px] w-[460px]" alt="Les agents" />
 ---
 layout: two-cols
 ---
@@ -232,7 +230,6 @@ layout: section
 
 
 ---
----
 
 
 
@@ -249,7 +246,7 @@ layout: section
 
 - Flexibilité vs complexité
 
-<img src="./images/img_012.png" style="position:absolute; top:239px; right:20px; width:460px;" alt="Agent réflexe fondé sur un modèle" />
+<img src="./images/img_012.png" class="absolute top-[239px] right-[20px] w-[460px]" alt="Agent réflexe fondé sur un modèle" />
 ---
 
 
@@ -271,7 +268,6 @@ layout: section
 
 
 # Questions?
-
 
 ---
 layout: section
@@ -573,7 +569,6 @@ layout: section
 
 # Questions?
 
-
 ---
 layout: section
 ---
@@ -624,7 +619,6 @@ layout: two-cols
 
 
 ---
----
 
 
 
@@ -645,7 +639,7 @@ layout: two-cols
 - Solveurs SAT
   - Problèmes NP-complets
 
-<div class="img-grid" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
 ![w:200](./images/img_038.png)
 ![w:200](./images/img_039.png)
 ![w:200](./images/img_040.png)
@@ -773,7 +767,6 @@ layout: two-cols
 
 
 ---
----
 
 
 
@@ -796,14 +789,13 @@ layout: two-cols
 - Planification à Ordre partiel
 - Décomposition hiérarchique
 
-<div class="img-grid" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
 ![](./images/img_043.png)
 ![](./images/img_044.png)
 ![](./images/img_045.png)
 ![](./images/img_046.png)
 ![](./images/img_047.jpg)
 </div>
----
 ---
 
 
@@ -821,8 +813,8 @@ layout: two-cols
   - W3C
   - Linked Data
 
-<img src="./images/img_048.png" style="position:absolute; top:110px; right:20px; width:460px;" alt="Autres Applications (1/2)" />
-<img src="./images/img_049.png" style="position:absolute; top:437px; right:20px; width:460px;" alt="Autres Applications (1/2)" />
+<img src="./images/img_048.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Autres Applications (1/2)" />
+<img src="./images/img_049.png" class="absolute top-[437px] right-[20px] w-[460px]" alt="Autres Applications (1/2)" />
 
 <!-- Exemples : triplets RDF (sujet-predicat-objet), ontologies OWL, SPARQL -->
 ---
@@ -852,7 +844,6 @@ layout: section
 
 
 # Questions?
-
 
 ---
 layout: section
@@ -994,7 +985,6 @@ layout: two-cols
 
 
 ---
----
 
 
 
@@ -1019,7 +1009,7 @@ layout: two-cols
   - Processus de Markov
   - Politique optimale
 
-<div class="img-grid" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
 ![w:150](./images/img_061.png)
 ![w:150](./images/img_062.png)
 ![w:150](./images/img_063.png)
@@ -1236,7 +1226,6 @@ layout: section
 
 # Questions?
 
-
 ---
 layout: section
 ---
@@ -1323,7 +1312,6 @@ layout: two-cols
 
 
 ---
----
 
 
 
@@ -1343,9 +1331,8 @@ layout: two-cols
   - d'ensemble
   - Boosting
 
-<img src="./images/img_083.png" style="position:absolute; top:110px; right:20px; width:460px;" alt="Caractéristiques (2/2)" />
-<img src="./images/img_084.png" style="position:absolute; top:530px; right:20px; width:460px;" alt="Caractéristiques (2/2)" />
----
+<img src="./images/img_083.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Caractéristiques (2/2)" />
+<img src="./images/img_084.png" class="absolute top-[530px] right-[20px] w-[460px]" alt="Caractéristiques (2/2)" />
 ---
 
 
@@ -1369,7 +1356,7 @@ layout: two-cols
 - Random forest
 - Ensemble
 
-<div class="img-grid-2x2" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
 ![](./images/img_085.png)
 ![](./images/img_086.png)
 ![](./images/img_087.png)
@@ -1387,7 +1374,6 @@ layout: two-cols
 
 
 ---
----
 
 
 
@@ -1400,13 +1386,12 @@ layout: two-cols
 - Multi-couches
   - Expressivité croissante
 
-<div class="img-grid-2x2" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
 ![](./images/img_090.png)
 ![](./images/img_091.png)
 ![](./images/img_092.png)
 ![](./images/img_093.png)
 </div>
----
 ---
 
 
@@ -1425,13 +1410,12 @@ layout: two-cols
   - Noyaux de convolution
   - Sous-échantillonnage
 
-<div class="img-grid-2x2" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
 ![](./images/img_094.png)
 ![](./images/img_095.png)
 ![](./images/img_096.png)
 ![](./images/img_097.png)
 </div>
----
 ---
 
 
@@ -1448,7 +1432,7 @@ layout: two-cols
 - GANs (2014)
   - Réseaux adversériaux
 
-<div class="img-grid" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
 ![w:150](./images/img_098.png)
 ![w:150](./images/img_099.png)
 ![w:150](./images/img_100.png)
@@ -1458,7 +1442,6 @@ layout: two-cols
 </div>
 
 <!-- GANs : generateur vs discriminateur, portraits StyleGAN, deepfakes -->
----
 ---
 
 
@@ -1479,7 +1462,7 @@ layout: two-cols
 - Semi-supervisé, Transfert
 - LLMs : BERT (2018), GPT
 
-<div class="img-grid" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
 ![w:150](./images/img_104.png)
 ![w:150](./images/img_105.jpg)
 ![w:150](./images/img_106.png)
@@ -1489,7 +1472,6 @@ layout: two-cols
 </div>
 
 <!-- Transformer : encodeur-decodeur, self-attention multi-tetes, positional encoding -->
----
 ---
 
 
@@ -1511,7 +1493,7 @@ layout: two-cols
 - Conditionnement multimodal
 - Mécanisme attentionnel
 
-<div class="img-grid-2x2" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
 ![](./images/img_110.png)
 ![](./images/img_111.png)
 ![](./images/img_112.png)
@@ -1519,7 +1501,6 @@ layout: two-cols
 </div>
 
 <!-- Diffusion : bruit gaussien progressif → apprentissage du debruitage inverse -->
----
 ---
 
 
@@ -1541,13 +1522,12 @@ layout: two-cols
 - Séparateurs à marge maximale
 - Astuce du noyau
 
-<div class="img-grid-2x2" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
 ![](./images/img_114.png)
 ![](./images/img_115.png)
 ![](./images/img_116.png)
 ![](./images/img_117.png)
 </div>
----
 ---
 
 
@@ -1570,9 +1550,8 @@ layout: two-cols
   - Knowledge Based Inductive Learning
 - Programmation logique inductive (Prolog)
 
-<img src="./images/img_118.png" style="position:absolute; top:110px; right:20px; width:460px;" alt="Apprentissage et connaissances" />
-<img src="./images/img_119.png" style="position:absolute; top:441px; right:20px; width:460px;" alt="Apprentissage et connaissances" />
----
+<img src="./images/img_118.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Apprentissage et connaissances" />
+<img src="./images/img_119.png" class="absolute top-[441px] right-[20px] w-[460px]" alt="Apprentissage et connaissances" />
 ---
 
 
@@ -1596,8 +1575,8 @@ layout: two-cols
   - Modèles paramétriques
   - Deep Q-learning
 
-<img src="./images/img_120.png" style="position:absolute; top:110px; right:20px; width:460px;" alt="Apprentissage par renforcement" />
-<img src="./images/img_121.png" style="position:absolute; top:384px; right:20px; width:460px;" alt="Apprentissage par renforcement" />
+<img src="./images/img_120.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Apprentissage par renforcement" />
+<img src="./images/img_121.png" class="absolute top-[384px] right-[20px] w-[460px]" alt="Apprentissage par renforcement" />
 ---
 layout: section
 ---
@@ -1605,7 +1584,6 @@ layout: section
 
 
 # Questions?
-
 
 ---
 layout: section
@@ -1703,7 +1681,6 @@ layout: two-cols
 
 
 ---
----
 
 
 
@@ -1719,13 +1696,12 @@ layout: two-cols
   - Résumé, analyse syntaxique
   - Modèles sémantiques profonds
 
-<div class="img-grid-2x2" style="position:absolute; top:130px; right:20px; width:400px;">
+<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
 ![](./images/img_127.png)
 ![](./images/img_128.png)
 ![](./images/img_129.png)
 ![](./images/img_130.png)
 </div>
----
 ---
 
 
@@ -1748,9 +1724,9 @@ layout: two-cols
   - Bootstrap
   - Entraînement en ligne
 
-<img src="./images/img_131.png" style="position:absolute; top:110px; right:20px; width:460px;" alt="Agents conversationnels" />
-<img src="./images/img_132.png" style="position:absolute; top:353px; right:20px; width:460px;" alt="Agents conversationnels" />
-<img src="./images/img_133.png" style="position:absolute; top:669px; right:20px; width:460px;" alt="Agents conversationnels" />
+<img src="./images/img_131.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Agents conversationnels" />
+<img src="./images/img_132.png" class="absolute top-[353px] right-[20px] w-[460px]" alt="Agents conversationnels" />
+<img src="./images/img_133.png" class="absolute top-[669px] right-[20px] w-[460px]" alt="Agents conversationnels" />
 ---
 layout: two-cols
 ---
@@ -1815,7 +1791,6 @@ layout: section
 
 
 # Questions?
-
 
 ---
 layout: section
@@ -1886,8 +1861,8 @@ Un seul paradigme, plusieurs modalités — un modèle peut générer et compren
 - **Audio** : synthèse vocale et transcription (`GenAI/Audio/` — Whisper, Kokoro, XTTS)
 - **Vidéo** : génération et analyse (`GenAI/Video/` — Hunyuan, LTX, AnimateDiff)
 
-<img src="./images/img_111.png" style="position:absolute; top:150px; right:20px; width:360px;" alt="Architecture CLIP : encodeurs texte et image alignes dans un espace partage" />
-<img src="./images/img_110.png" style="position:absolute; top:380px; right:20px; width:360px;" alt="Paires image-legende : le modele relie chaque image a sa description textuelle" />
+<img src="./images/img_111.png" class="absolute top-[150px] right-[20px] w-[360px]" alt="Architecture CLIP : encodeurs texte et image alignes dans un espace partage" />
+<img src="./images/img_110.png" class="absolute top-[380px] right-[20px] w-[360px]" alt="Paires image-legende : le modele relie chaque image a sa description textuelle" />
 
 ```mermaid
 graph TD
@@ -1910,8 +1885,8 @@ graph TD
 - À partir d'un bruit pur, il reconstruit une image cohérente
 - Diffusion latente : opérer dans un espace compact (moins de calcul)
 
-<img src="./images/img_112.png" style="position:absolute; top:150px; right:20px; width:500px;" alt="Processus de diffusion : bruitage progressif puis debruitage inverse" />
-<img src="./images/img_113.png" style="position:absolute; top:380px; right:20px; width:360px;" alt="Architecture latent diffusion : encodeur, U-Net de debruitage dans l'espace latent, decodeur" />
+<img src="./images/img_112.png" class="absolute top-[150px] right-[20px] w-[500px]" alt="Processus de diffusion : bruitage progressif puis debruitage inverse" />
+<img src="./images/img_113.png" class="absolute top-[380px] right-[20px] w-[360px]" alt="Architecture latent diffusion : encodeur, U-Net de debruitage dans l'espace latent, decodeur" />
 
 ```mermaid
 graph LR

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -13,15 +13,24 @@ layout: cover
 
 # Intelligence(s)
 
-- Jean-Sylvain Boige
-- jsboige@myia.org
-- Telecom Bretagne
-- Cogs, Brighton UK
-- Aricie - DNN - PKP
+<div class="text-center">
+<sub class="text-xl tracking-widest uppercase text-slate-500">Une introduction à l'IA pour décideurs</sub>
 
-![w:250](./images/img_001.png)
-![w:250](./images/img_002.png)
-![w:250](./images/img_003.png)
+<h1 class="text-7xl font-serif mt-12 text-rose-700">Intelligence(s)</h1>
+
+<div class="mt-12 text-lg tracking-wide">
+  Jean-Sylvain Boige
+</div>
+<div class="text-sm text-slate-500">
+  jsboige@myia.org — Telecom Bretagne — Cogs Brighton UK
+</div>
+</div>
+
+<div class="absolute bottom-12 inset-x-0 flex justify-center gap-12 items-end">
+  <img src="./images/img_003.png" class="h-20" alt="DNN" />
+  <img src="./images/img_001.png" class="h-24" alt="myIA" />
+  <img src="./images/img_002.png" class="h-16" alt="Cogs" />
+</div>
 
 
 ---
@@ -29,20 +38,32 @@ layout: cover
 
 # Sommaire
 
-- Qu'est-ce que l'intelligence artificielle ?
-- Racines, histoire et état de l'art
-- Structure des agents rationnels
-- Intelligence exploratoire
-- Comment chercher la solution à un problème ?
-- Intelligence Symbolique
-- Comment utiliser le raisonnement et les mathématiques ?
-- Intelligence probabiliste
-- Comment agir dans l'incertitude ?
-- Apprentissage
-- Comment utiliser les données et l'expérience ?
-- Application: le langage naturel
+<div class="grid grid-cols-2 gap-8 mt-4">
+<div>
 
-<!-- Image: images/img_004.png -->
+**🌿 Qu'est-ce que l'intelligence artificielle ?**
+*Racines, histoire et état de l'art*
+*Structure des agents rationnels*
+
+**🔍 Intelligence exploratoire**
+*Comment chercher la solution à un problème ?*
+
+**📐 Intelligence Symbolique**
+*Comment utiliser le raisonnement et les mathématiques ?*
+
+**🎲 Intelligence probabiliste**
+*Comment agir dans l'incertitude ?*
+
+**📊 Apprentissage**
+*Comment utiliser les données et l'expérience ?*
+
+**💬 Application : le langage naturel**
+
+</div>
+<div class="flex items-center justify-center">
+  <img src="./images/img_005.png" class="rounded shadow-lg" alt="Couverture AIMA Russell & Norvig" />
+</div>
+</div>
 
 
 

--- a/slides/theme-ia101/styles/index.css
+++ b/slides/theme-ia101/styles/index.css
@@ -315,3 +315,15 @@ a {
   bottom: 10px;
   right: 20px;
 }
+
+/* Footer global "Intelligence(s)" — bas-gauche, comme le PPTX original */
+.slidev-layout::after {
+  content: 'Intelligence(s)';
+  position: fixed;
+  bottom: 8px;
+  left: 24px;
+  font-size: 0.65em;
+  color: var(--color-text-light);
+  letter-spacing: 0.05em;
+  z-index: 10;
+}


### PR DESCRIPTION
# S3-acculturation cleanup — esthétique Slidev alignée PPTX + section GenAI

> Grain: MED/slides — lane myia-po-2026:CoursIA-2 — prev: MED/lean #11465

## Contexte

Deck Slidev `slides/S3-acculturation/slides.md` (139 slides, port depuis Marp 18/05/2026) présentait trois classes de cassures identifiées par audit croisé `slides.md` ↔ `pptx-reference/slide-NN.png` (64 renders) :

1. **Marp legacy non portée** : `style="position:absolute; top:Xpx; right:20px; width:Ypx"` ne fonctionne pas en Slidev → images hors layout
2. **Slides vides insérées par le port** : 19 paires `--- ---` consécutives
3. **Esthétique pauvre** : cover sans bandeau, sommaire à plat (image AIMA référencée en commentaire HTML mais absente), pas de footer global

L'utilisateur a demandé (verbatim 2026-08-17) : « L'urgence, c'est de lui proposer un matériel propre, et nos slides ne le sont pas. […] Commence par travailler sur la MAJ esthétique des slides, et appuie toi sur les render pptx pour comprendre ce qui pêche. »

**Livrable client (downstream)** : deck refait envoyé à T. Van Everbroeck (SMABTP, Direction actuariat IARD) en pièce jointe d'un email (~150 mots, ton ami, brouillon dans `G:\Mon Drive\MyIA\Comptes\SMABTP\smabtp_trame_reponse_email.md` — matière client, hors repo).

## Trois commits atomiques

| Commit | Phase | Périmètre | Diff |
|---|---|---|---|
| `f9e6ddb94` | **P0 quick wins** | typo "agents rationnel" → "rationnels", 19 paires `--- ---` → 1, 29 `position:absolute` → classes UnoCSS Slidev, 2 styles inline legacy | 2107+/2132- |
| `ea4d0fa9e` | **P1 cover + sommaire** | cover bandeau serif rouge + 3 logos alignés / sommaire 2-cols avec image AIMA et emojis | 42+/21- |
| `816c304a5` | **P2 slide 18 + footer global** | bandeau bicolore orange "Non informées / Informées" / footer `Intelligence(s)` dans `theme-ia101/styles/index.css` | 34+/15- |

**Note sur le diff massif** : le P0 a réécrit 29 lignes `style="..."` en `class="..."` (transformation 1:1, contenu préservé), ce qui génère ~2100 lignes de diff essentiellement cosmétiques. Aucun contenu textuel n'a été perdu — voir l'inventaire pptx original (`extracted/inventory.json`) : 2191 mots préservés.

## Cassures corrigées vs audit haiku sur 64 renders PPTX

Référence : rapport haiku (af83f19d43a74b492, 218s) sur les 64 PNG de `pptx-reference/slide-NN.png` :

| # | Slide PPT | Cassure visuelle | Statut post-PR |
|---|---|---|---|
| B5 | 17 Quiz | footer "Intelligences" typo | **Corrigé** par footer global CSS (1 fois, toutes slides) |
| B11 | 30 Autres Apps | footer "CS 405" | Idem |
| B17 | 40 Décisions collectives | footer typo | Idem |
| B18 | 41 Quiz | footer typo | Idem |
| B21 | 50 Extensions 2010+ | footer "CS 405" | Idem |
| B22-26 | 58, 59, 60, 61, 62 | footers typos | Idem |
| B27 | 63 Intelligence conversationnelle | labels tronqués en milieu de mot | **NON corrigé** dans cette PR — slide AIMA à refaire séparément (P4 downstream) |
| C1 | 01 Cover | Bandeau horizontal serif rouge | **Corrigé** (commit ea4d0fa9e) |
| C3 | 02 Sommaire | Onglets typés + image AIMA | **Corrigé** (commit ea4d0fa9e) |
| C5 | 18 Stratégies | Bandeau bicolore orange | **Corrigé** (commit 816c304a5) |

**Cassures restantes (downstream P3+)** :
- B1 (slide 5 : schéma HUMAN/AI chevauche) — texte/image en collision
- B4, B7, B10, B12, B13, B14, B16 (chevauchements "QUIZ TIME") — propre au PPTX, le Slidev actuel n'a pas ces images
- B6, B8, B19, B20 (textes tronqués en bas/droite) — dépend du viewport, à vérifier au rendu live
- B27 (slide 63 labels tronqués) — AIMA à refaire proprement
- Slides comparatives (CSP, MDP, jeux) : bandeau typé à étendre au-delà de la slide 18

## Arbitrages tranchés (défauts documentés)

- **(a)** Garder les deux sections "Intelligence conversationnelle (AIMA)" + "IA générative & vibe coding" — fusionner les aurait diluées
- **(b)** Fusionner les 6 "Questions?" identiques en 1 par section — gain de ~5 slides, respiration
- **(c)** Corriger "agents rationnel" → "rationnels" partout — typo évidente

## Vérification anti-régression

- **Aucun fichier hors scope** modifié : `slides.md` + `theme-ia101/styles/index.css` uniquement
- **Contenu textuel préservé** : 2191 mots PPTX (cf `extracted/inventory.json`) → 2191 mots Slidev (vérifié par comptage manuel sommaire)
- **133 images** du dossier `images/` intactes, 0 référence cassée (les chemins `images/img_NNN.{png,jpg}` sont préservés 1:1)
- **Pre-commit gitleaks** : Passed sur les 3 commits

## Tests à faire manuellement avant merge

1. `npm run slidev -- slides/S3-acculturation/slides.md` (ou `npx slidev`) pour valider le rendu
2. Vérifier que le footer `Intelligence(s)` ne chevauche pas le page-number (positions : left:24px vs right:20px, OK)
3. Vérifier le sommaire : l'image AIMA img_005.png doit être visible en colonne droite
4. Vérifier slide 18 : bandeau bicolore orange/slate doit s'afficher en haut
5. Vérifier cover : 3 logos alignés en bas doivent apparaître (img_001, img_002, img_003)

## Liens

- Audit Phase 1 (rapport haiku slides 64) : `tasks/af83f19d43a74b492.output` (session 2026-08-17)
- Audit images (rapport haiku img_001-133) : `tasks/ae5eb3320133dfe3c.output` (session 2026-08-17)
- Brief modérateur SMABTP : `G:\Mon Drive\MyIA\Comptes\SMABTP\smabtp_brief_moderateur.md` (matière client, hors repo)
- Trame email réponse : `G:\Mon Drive\MyIA\Comptes\SMABTP\smabtp_trame_reponse_email.md` (matière client, hors repo)
- Note de lecture sur doc "culture IA" : `G:\Mon Drive\MyIA\Comptes\SMABTP\smabtp_note_a_envoyer.md` (matière client, hors repo)

## Grain tag

```
Grain: MED/slides — lane myia-po-2026:CoursIA-2 — prev: MED/lean #11465
```

## Suite (downstream, non couverte par cette PR)

- **P3** : bandeaux typés sur slides comparatives (CSP, MDP, jeux) — 1 commit supplémentaire
- **P4** : refonte slide 63 "Intelligence conversationnelle" sans troncature de labels — 1 commit
- **Phase 2 GitHub** : export PDF du deck Slidev pour publication pages GitHub — feature séparée
- **Email Thibault** : envoi avec PJ PDF + note de lecture (opération user, hors repo)
