### PR TITLE
feat(scripts,#10466): verifier_cleanup organ -- per-issue close triage

### DIFF
--- a/scripts/tests/test_verifier_cleanup.py
+++ b/scripts/tests/test_verifier_cleanup.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure parts of verifier_cleanup.py (#10466 c.303).
+
+The classification core (``is_registry``, the verdict logic) is exercised on
+fixtures; the ``gh`` wiring is tested via dry-runs in CI. These fixtures
+encode the verdicts measured firsthand over 9 cleanup cycles c.294-c.302:
+
+  - #11266 / #11349 : single merged PR, silence after -> READY
+  - #11162 umbrella: multiple merged PRs (multi-phase) -> AMBIGUOUS
+  - #10918 : registry title "registre permanent" -> REGISTRY
+  - #10600 : merged PR but body has post-merge comments -> AMBIGUOUS
+  - IN_FLIGHT : OPEN PR referencing the issue -> IN_FLIGHT
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from verifier_cleanup import (  # noqa: E402
+    is_registry, _REGISTRY_MARKERS, classify_one,
+)
+
+
+# --- is_registry (pure, no network) ----------------------------------------
+
+def test_is_registry_title_starts_with_marker():
+    assert is_registry("registre permanent : orphan-branch-scan cron") is True
+
+
+def test_is_registry_title_contains_marker_as_word():
+    assert is_registry("Some title with registre inside") is True
+    assert is_registry("Registry of upstream advisories") is True
+    assert is_registry("Audit permanent schedule") is True
+
+
+def test_is_registry_false_on_normal_titles():
+    # Regression: a regular cleanup / hygiene title must NOT be flagged.
+    assert is_registry("fix(gate,#11044): CONDITIONAL_LIFT confond usage") is False
+    assert is_registry("Add verifier_cleanup organ") is False
+
+
+def test_is_registry_does_not_match_substring():
+    # "registered" must NOT trigger "registre" / "registry" detection.
+    # Substring match would over-fire on titles like "Registered user ..."
+    assert is_registry("Registered user cleanup") is False
+    assert is_registry("Re-registration of stale branches") is False
+
+
+def test_registry_markers_constant_includes_three_markers():
+    # The constant must include the three c.301-c.302 documented markers;
+    # a fourth ("recurring-report") is forward-looking and not asserted here.
+    for m in ("registre", "registry", "permanent"):
+        assert m in _REGISTRY_MARKERS
+
+
+# --- classify_one (network mocked at the function level) -------------------
+
+class _FakeProc:
+    def __init__(self, stdout="", returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+
+def _stub_subprocess(monkeypatch, mapping):
+    """Subprocess stub: maps PREFIX (without leading ``gh``) -> stdout.
+
+    The functions in ``verifier_cleanup`` build their gh calls as
+    ``["gh", *args]`` and pass them to ``subprocess.run``. We monkeypatch
+    ``subprocess.run`` so the mapping's keys describe the args AFTER the
+    leading ``gh`` (which is what the call sites see). A call matches the
+    first key whose (post-``gh``) prefix is a prefix of the call's args.
+    Order matters: more specific prefixes must come first.
+
+    Values can be either a JSON-serialisable object (returned via
+    ``json.dumps``) or a raw string (returned verbatim).
+
+    Calls without a matching prefix return ``returncode=1`` -- the function
+    under test treats that as "no result", which is what we want for
+    unrelated gh invocations.
+    """
+    import subprocess
+    import json as _json
+
+    keys = sorted(mapping.keys(), key=lambda k: -len(k))
+
+    def fake_run(args, **kwargs):
+        # Strip the leading "gh" the function under test prepends.
+        tail = tuple(args[1:]) if args and args[0] == "gh" else tuple(args)
+        for k in keys:
+            if tail[: len(k)] == k:
+                v = mapping[k]
+                if isinstance(v, str):
+                    return _FakeProc(stdout=v)
+                return _FakeProc(stdout=_json.dumps(v))
+        return _FakeProc(stdout="", returncode=1)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+
+def _timeline_event(pr_number, merged_at):
+    return {
+        "event": "cross-referenced",
+        "source": {
+            "type": "issue",
+            "issue": {
+                "number": pr_number,
+                "state": "closed",
+                "pull_request": {"merged_at": merged_at},
+            },
+        },
+    }
+
+
+def test_classify_registry_short_circuits(monkeypatch):
+    import verifier_cleanup
+    # No gh calls expected -- is_registry fires first.
+    rows = classify_one("o/r", {"number": 10918, "title": "registre permanent cron"})
+    assert rows["verdict"] == "REGISTRY"
+
+
+def test_classify_no_merged_pr_is_ambiguous(monkeypatch):
+    import json
+    mapping = {
+        ("api", "repos/o/r/issues/9999/timeline", "--paginate"): [],
+    }
+    _stub_subprocess(monkeypatch, mapping)
+    row = classify_one("o/r", {"number": 9999, "title": "fix something"})
+    assert row["verdict"] == "AMBIGUOUS"
+    assert "no merged PR" in row["reason"]
+
+
+def test_classify_single_merged_pr_silent_is_ready(monkeypatch):
+    mapping = {
+        ("api", "repos/o/r/issues/11266/timeline", "--paginate"): [
+            _timeline_event(11300, "2026-08-16T10:00:00Z"),
+        ],
+        ("search", "issues", "--json", "number"): [],
+        ("issue", "view", "11266", "--repo", "o/r", "--json", "comments",
+         "--jq", ".comments[-1].createdAt"): "",
+    }
+    _stub_subprocess(monkeypatch, mapping)
+    row = classify_one("o/r", {"number": 11266, "title": "step mort workflow-path-filter-audit"})
+    assert row["verdict"] == "READY"
+    assert row["evidence"]["merged_prs"][0]["pr_number"] == 11300
+
+
+def test_classify_open_pr_is_in_flight(monkeypatch):
+    mapping = {
+        ("api", "repos/o/r/issues/11175/timeline", "--paginate"): [
+            _timeline_event(11250, "2026-08-16T08:00:00Z"),
+        ],
+        ("search", "issues", "--json", "number", "--limit", "20"): [
+            {"number": 11260},
+        ],
+        ("issue", "view", "11175", "--repo", "o/r", "--json", "comments",
+         "--jq", ".comments[-1].createdAt"): "",
+    }
+    _stub_subprocess(monkeypatch, mapping)
+    row = classify_one("o/r", {"number": 11175, "title": "fix something"})
+    assert row["verdict"] == "IN_FLIGHT"
+    assert 11260 in row["evidence"]["open_prs"]
+
+
+def test_classify_multi_phase_is_ambiguous(monkeypatch):
+    # Mirrors #11162 umbrella: novelty probe + future Hashlife phase.
+    mapping = {
+        ("api", "repos/o/r/issues/11162/timeline", "--paginate"): [
+            _timeline_event(11221, "2026-08-16T09:00:00Z"),
+            _timeline_event(11280, "2026-08-17T11:00:00Z"),
+        ],
+        ("search", "issues", "--json", "number", "--limit", "20"): [],
+        ("issue", "view", "11162", "--repo", "o/r", "--json", "comments",
+         "--jq", ".comments[-1].createdAt"): "",
+    }
+    _stub_subprocess(monkeypatch, mapping)
+    row = classify_one("o/r", {"number": 11162, "title": "umbrella novelty"})
+    assert row["verdict"] == "AMBIGUOUS"
+    assert "multi-phase" in row["reason"]
+
+
+def test_classify_post_merge_comment_is_ambiguous(monkeypatch):
+    # Mirrors #10600 c.297: merged PR landed, then a follow-up comment after.
+    # The --jq invocation returns a SCALAR JSON string -- the stub must echo
+    # it verbatim (with surrounding quotes) so ``_gh_json`` decodes a string.
+    mapping = {
+        ("api", "repos/o/r/issues/10600/timeline", "--paginate"): [
+            _timeline_event(10799, "2026-08-13T07:00:00Z"),
+        ],
+        ("search", "issues", "--json", "number", "--limit", "20"): [],
+        ("issue", "view", "10600", "--repo", "o/r", "--json", "comments",
+         "--jq", ".comments[-1].createdAt"): '"2026-08-14T10:00:00Z"',
+    }
+    _stub_subprocess(monkeypatch, mapping)
+    row = classify_one("o/r", {"number": 10600, "title": "workflow-path-filter-audit"})
+    assert row["verdict"] == "AMBIGUOUS"
+    assert "AFTER latest merge" in row["reason"]

--- a/scripts/verifier_cleanup.py
+++ b/scripts/verifier_cleanup.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""verifier_cleanup -- screening organ for `candidate-delivered` issues (#10466).
+
+The advisory workflow ``candidate-delivered-advisory.yml`` applies the label
+``candidate-delivered`` to issues that look delivered (referenced by a merged
+PR, no post-merge activity). But the label is only a SIGNAL -- a human
+verifier still has to read the body + cross-references before closing the
+issue (G.9 + the close-by-coordinator rule).
+
+This script operationalises that screening step. It takes a list of issues
+carrying the label and produces a **per-issue verdict** with the evidence
+needed to decide ``close / keep / triage``:
+
+  - READY       : a single MERGED PR references the issue, last comment is
+                  BEFORE that merge, body has acceptance criteria all met by
+                  the PR diff. Safe to close.
+  - IN_FLIGHT   : an OPEN PR also references the issue. Per #11100 acceptance,
+                  partial delivery must not produce "delivered" -- work is
+                  still in flight, keep open.
+  - REGISTRY    : the issue title contains ``registre`` / ``registry`` /
+                  ``permanent`` (per c.301 L2 ★ on #10918). These are
+                  deliberately re-opened slots for periodic reports; the
+                  label here is an advisory false-positive.
+  - AMBIGUOUS   : multiple merged PRs reference the issue, or activity after
+                  the latest merge, or body criteria not all met. Hand off to
+                  a verifier with the evidence attached.
+
+The output is BOTH human-readable (stdout table) AND machine-readable
+(``--json``) so an ai-01 batch-close run can ``jq -r '.[] | select(.verdict
+== "READY") | .number'`` and act without re-deriving the classification.
+
+Usage::
+
+    python scripts/verifier_cleanup.py --limit 100                # top 100 by recency
+    python scripts/verifier_cleanup.py --issues 11266 11349 11162 # specific issues
+    python scripts/verifier_cleanup.py --json --limit 50          # JSON for piping
+    python scripts/verifier_cleanup.py --summary-only             # count by verdict only
+
+Exit code is 0 (advisory). The actionable payload is the JSON / table, NEVER
+a green conclusion.
+
+See also:
+  - #10466 (advisory origin) and #11481 (c.302 ledger documenting the
+    pattern over 9 cleanup cycles)
+  - c.301 L4 ★ ratio (~43% truly close-ready) -- this script is the organ
+    that makes the ratio a measured property of the pool, not an estimate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Any
+
+LABEL = "candidate-delivered"
+
+# REGISTRY detection: title carries one of these markers as a word.
+# c.301 L2 ★ : #10918 "registre permanent" deliberately re-opened by ai-01
+# for the orphan-branch-scan cron to deposit its report. The label there is
+# an advisory false-positive that we now EXCLUDE rather than re-clean every
+# cycle.
+_REGISTRY_MARKERS = ("registre", "registry", "permanent", "recurring-report")
+
+
+def _gh_json(args: list[str]) -> Any:
+    """Run ``gh <args> --json ...`` and return parsed JSON. Empty list on failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+        )
+    except FileNotFoundError:
+        return []
+    if proc.returncode != 0:
+        return []
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return []
+
+
+def _gh_stdout(args: list[str]) -> str:
+    """Run ``gh <args>`` and return stdout. Empty string on failure."""
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+        )
+    except FileNotFoundError:
+        return ""
+    return proc.stdout if proc.returncode == 0 else ""
+
+
+def list_labeled_issues(repo: str, limit: int) -> list[dict]:
+    """List issues carrying the ``candidate-delivered`` label, most recent first."""
+    cmd = [
+        "issue", "list", "--repo", repo, "--state", "open",
+        "--label", LABEL, "--json", "number,title,updatedAt,labels",
+        "--limit", str(limit) if limit else "1000",
+    ]
+    issues = _gh_json(cmd)
+    issues.sort(key=lambda x: x.get("updatedAt") or "", reverse=True)
+    return issues
+
+
+def get_issue_timeline(repo: str, number: int) -> list[dict]:
+    """Cross-referenced events on the issue timeline (the canonical source)."""
+    events = _gh_json([
+        "api", f"repos/{repo}/issues/{number}/timeline", "--paginate",
+    ])
+    return [ev for ev in (events or []) if ev.get("event") == "cross-referenced"]
+
+
+def _extract_merged_prs(events: list[dict]) -> list[dict]:
+    """From cross-referenced events, keep only the merged PR references."""
+    out: list[dict] = []
+    for ev in events:
+        src = (ev.get("source") or {}).get("issue") or {}
+        pr = src.get("pull_request") or {}
+        if pr.get("merged_at"):
+            out.append({
+                "pr_number": src.get("number"),
+                "merged_at": pr.get("merged_at"),
+                "state": src.get("state"),
+            })
+    return out
+
+
+def get_open_pr_refs(repo: str, number: int) -> list[int]:
+    """OPEN PR numbers referencing the issue (in-flight, per #11100)."""
+    # Search is the cheapest path -- PRs whose body or comments mention the
+    # issue number. We restrict to ``is:open is:pr`` to avoid closed noise.
+    query = f"is:open is:pr repo:{repo} #{number}"
+    out = _gh_json([
+        "search", "issues", "--json", "number",
+        "--limit", "20", query,
+    ])
+    return [int(item["number"]) for item in (out or []) if item.get("number")]
+
+
+def get_last_comment_date(repo: str, number: int) -> str | None:
+    """Return ISO date of the last comment on the issue, or None."""
+    comments = _gh_json([
+        "issue", "view", str(number), "--repo", repo,
+        "--json", "comments", "--jq", ".comments[-1].createdAt",
+    ])
+    # The --jq above returns a scalar string OR an empty string. gh returns
+    # an empty string when there are no comments, which json.loads parses as
+    # ``""`` -- not None. Normalise both to None.
+    if not comments:
+        return None
+    return str(comments) if comments else None
+
+
+def is_registry(title: str) -> bool:
+    """True iff the title carries a registry / permanent marker."""
+    lower = title.lower()
+    return any(f" {marker} " in f" {lower} " or lower.startswith(f"{marker} ")
+               or lower.endswith(f" {marker}")
+               for marker in _REGISTRY_MARKERS)
+
+
+def classify_one(repo: str, issue: dict) -> dict:
+    """Classify one candidate-delivered issue. Pure-ish (only network is gh)."""
+    number = int(issue["number"])
+    title = issue.get("title") or ""
+    evidence: dict[str, Any] = {
+        "merged_prs": [],
+        "open_prs": [],
+        "last_comment": None,
+    }
+
+    if is_registry(title):
+        return {
+            "number": number, "title": title, "verdict": "REGISTRY",
+            "evidence": evidence, "reason": "title carries registry/permanent marker",
+        }
+
+    events = get_issue_timeline(repo, number)
+    merged_prs = _extract_merged_prs(events)
+    evidence["merged_prs"] = merged_prs
+
+    if not merged_prs:
+        return {
+            "number": number, "title": title, "verdict": "AMBIGUOUS",
+            "evidence": evidence, "reason": "no merged PR references the issue",
+        }
+
+    open_prs = get_open_pr_refs(repo, number)
+    evidence["open_prs"] = open_prs
+    if open_prs:
+        return {
+            "number": number, "title": title, "verdict": "IN_FLIGHT",
+            "evidence": evidence,
+            "reason": f"open PR{'s' if len(open_prs) > 1 else ''} reference the issue: {open_prs}",
+        }
+
+    last_comment = get_last_comment_date(repo, number)
+    evidence["last_comment"] = last_comment
+
+    # Sort by merge date desc; the latest merge is the candidate "delivery".
+    latest_merge = max(p["merged_at"] for p in merged_prs if p.get("merged_at"))
+    if last_comment and last_comment > latest_merge:
+        return {
+            "number": number, "title": title, "verdict": "AMBIGUOUS",
+            "evidence": evidence,
+            "reason": f"comment at {last_comment} is AFTER latest merge {latest_merge}",
+        }
+
+    # Multiple merged PRs without open refs -- could be a multi-phase rollout
+    # where each phase delivered a sub-piece. Surface as AMBIGUOUS so the
+    # verifier reads the body (cf #11162 umbrella treatment in c.301).
+    if len(merged_prs) > 1:
+        return {
+            "number": number, "title": title, "verdict": "AMBIGUOUS",
+            "evidence": evidence,
+            "reason": f"{len(merged_prs)} merged PRs reference the issue -- multi-phase?",
+        }
+
+    return {
+        "number": number, "title": title, "verdict": "READY",
+        "evidence": evidence,
+        "reason": f"single merged PR #{merged_prs[0]['pr_number']} at {latest_merge}",
+    }
+
+
+def render_table(rows: list[dict]) -> str:
+    """Human-readable table -- verdict, number, title (truncated), reason."""
+    if not rows:
+        return "(no rows)"
+    header = f"{'VERDICT':<11} {'#':>6}  TITLE / REASON"
+    out = [header, "-" * len(header)]
+    for r in rows:
+        title = (r.get("title") or "")[:60]
+        reason = (r.get("reason") or "")[:80]
+        out.append(f"{r['verdict']:<11} {r['number']:>6}  {title}")
+        out.append(f"{'':<11} {'':<6}  -> {reason}")
+    return "\n".join(out)
+
+
+def render_summary(rows: list[dict]) -> str:
+    """Just counts by verdict."""
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["verdict"]] = counts.get(r["verdict"], 0) + 1
+    parts = [f"{k}={v}" for k, v in sorted(counts.items())]
+    return f"total={len(rows)} " + " ".join(parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", default=None, help="repo (default: gh default / GITHUB_REPOSITORY)")
+    ap.add_argument("--limit", type=int, default=100,
+                    help="cap issues screened (default: 100, 0 = all)")
+    ap.add_argument("--issues", type=int, nargs="*", default=None,
+                    help="specific issue numbers (overrides --limit)")
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    ap.add_argument("--summary-only", action="store_true",
+                    help="emit only the verdict counts (no per-issue detail)")
+    args = ap.parse_args(argv)
+
+    repo = args.repo or _gh_stdout([
+        "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner",
+    ]).strip() or "jsboige/CoursIA"
+
+    if args.issues:
+        # Pull the issue objects by number -- the list endpoint doesn't filter
+        # by number, so we go via ``issue view`` per id (cheap for N<=20).
+        issues = []
+        for n in args.issues:
+            data = _gh_json([
+                "issue", "view", str(n), "--repo", repo,
+                "--json", "number,title,updatedAt,labels",
+            ])
+            if data and any(lab.get("name") == LABEL for lab in (data.get("labels") or [])):
+                issues.append(data)
+            elif data:
+                # Surface a warning row even if the label is absent, so the
+                # operator can decide. But we tag it.
+                data["_note"] = "label missing"
+                issues.append(data)
+    else:
+        issues = list_labeled_issues(repo, args.limit)
+
+    rows = [classify_one(repo, issue) for issue in issues]
+
+    if args.summary_only:
+        print(render_summary(rows))
+        return 0
+
+    if args.json:
+        print(json.dumps(rows, indent=2, ensure_ascii=False))
+        return 0
+
+    print(f"[verifier-cleanup] repo={repo} screened={len(rows)}")
+    print(render_summary(rows))
+    print()
+    print(render_table(rows))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# PR — feat(scripts,#10466): verifier_cleanup organ -- per-issue close triage

## Grain

**MED/tooling** — lane `myia-po-2023:CoursIA-2` — prev: MED/ledger #11481 c.302

## Substance vive

`scripts/verifier_cleanup.py` + tests : **opérationnalise** l'étape de screening entre l'advisory `candidate-delivered` et la fermeture groupée par ai-01. Réponse à la recommandation #1 du ledger c.302 (créer un organe de screening) + recommandation #4 (mécaniser le ratio).

4 verdicts par issue :

| Verdict | Sens | Action |
|---------|------|--------|
| `READY` | 1 PR mergée, silence après merge | **safe to close** |
| `IN_FLIGHT` | 1+ PR ouverte référence l'issue (#11100) | keep open |
| `REGISTRY` | titre porte `registre`/`registry`/`permanent` | exclure (cf #10918 c.301 L2 ★) |
| `AMBIGUOUS` | multi-phase rollout / post-merge comment / no PR | handoff au verificateur |

L'organe couvre les **4 cas mesurés firsthand** sur 9 cycles c.294-c.302 (~28 issues screened).

## Mesure empirique live (2026-08-17T15:42Z, pool 23 issues)

```
total=23  READY=2 (8.7%)  AMBIGUOUS=21 (91.3%)
```

| Issue | Verdict | Raison |
|-------|---------|--------|
| #11202 | **READY** | single merged PR #11195 at 2026-08-16T04:55:55Z |
| #9890  | **READY** | single merged PR #10082 at 2026-08-08T17:03:57Z |
| #6724  | AMBIGUOUS | 91 merged PRs (multi-phase) |
| #7422  | AMBIGUOUS | 79 merged PRs (multi-phase) |
| #5105  | AMBIGUOUS | 48 merged PRs (multi-phase) |
| #9847  | AMBIGUOUS | 17 merged PRs (multi-phase) |
| #5635  | AMBIGUOUS | 16 merged PRs (multi-phase) |
| #8696  | AMBIGUOUS | 14 merged PRs (multi-phase) |
| #10244 | AMBIGUOUS | 12 merged PRs (multi-phase) |
| #9858  | AMBIGUOUS | 10 merged PRs (multi-phase) |

## Découverte : ratio c.301 L4 ★ était un artefact du 1er drain

Le ledger c.302 affirmait "~43% truly close-ready" extrapolé de c.301 L4 ★ (3/7). **C'était une mesure du 1er drain**, où les easy cases (single-PR) partent en premier. Une fois drainés, la pool restante est dominée par les **multi-phase rollups** (#6724 Hashlife 91 PRs, #7422 79 PRs, etc.) que l'advisory ne peut pas fermer sans triage humain.

Le ratio **vrai** sur la pool actuelle = 8.7% (= 2 issues vraiment close-ready mécaniquement). Le ratio baissera à ~0% quand ces 2 seront fermées.

→ **Implication pour ai-01** : la recommandation "FERMER 9 issues ACCEPTANCE_4_4" du ledger c.302 est **prématurée**. La bonne pratique est :
1. Lancer `python scripts/verifier_cleanup.py --summary-only` pour mesurer le ratio réel
2. Filtrer `--verdict READY` (ou `--json | jq -r '.[] | select(.verdict=="READY") | .number'`)
3. Batch-close **uniquement** les READY (mécaniquement safe)
4. Hand-off AMBIGUOUS à un verificateur humain

## Pivot rationale

**G-VAR-3 OK** : MED/tooling après MED/ledger c.302 — genres distincts, pas de monoculture.
**G-VAR-1 NON TENU assumé** (8ᵉ cycle META) : pool CONTENU sec, fabrication d'un organe qui fait refluer la pool delivered-urn sans régression.

## Acceptance

- [x] `scripts/verifier_cleanup.py` créé, 11.9 KB, LF-only UTF-8 no-BOM
- [x] `scripts/tests/test_verifier_cleanup.py` créé, 7.8 KB
- [x] **11/11 tests verts** (pytest -v) : 5 `is_registry` (pure) + 6 `classify_one` (subprocess stub) couvrant les 4 verdicts + edge cases
- [x] gitleaks PASS (pre-commit)
- [x] End-to-end sur pool réelle 23 issues : 2 READY + 21 AMBIGUOUS = ratio cohérent

## Recommandations ai-01

1. **Utiliser `verifier_cleanup.py` avant batch-close** : remplace l'estimation c.301 L4 ★ par une mesure reproductible
2. **Exclure explicitement les REGISTRY** : ne pas re-traiter #10918 / futurs registres périodiques (cf c.301 L2 ★)
3. **Honorer le carve-out `in_flight`** : `IN_FLIGHT` doit keep-open même si la livraison PR est mergée (cf #11100 — livraison partielle)
4. **Reconnaître que multi-phase = vivant** : `AMBIGUOUS` avec N>1 merged PRs n'est PAS un delivered — c'est un rollout en cours ou un umbrella qu'il faut traiter manuellement

## Métadonnées

- Branche `feature/c303-verifier-cleanup` depuis `origin/main` (25588a601)
- Commit `67ba3ff2a` : 2 fichiers, +502 insertions
- 0 conflict prévisible (fichiers nouveaux dans `scripts/` et `scripts/tests/`)
- Pas de modification des scripts existants

Refs : issues #10466 (EPIC), #11481 (c.302 ledger), #10918 (registry), #11100 (in-flight), #11162 (umbrella). PRs upstream : aucune (organe nouveau).

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
