### PR TITLE
fix(tooling,#9434): scan_quant_classify v7 — immunité tag de drain « machine-dep » + propagation seeds cross-cellules (corpus 5577→4867)

### DIFF
--- a/scripts/notebook_tools/scan_quant_classify.py
+++ b/scripts/notebook_tools/scan_quant_classify.py
@@ -241,6 +241,20 @@ DATA_LIST_MARKERS = ("{", "~ ", " valeurs", "observations)")
 SEED_KEYWORDS = ("seed=", "random_state=", "np.random.seed", "torch.manual_seed",
                  "tf.random.set_seed", "rng.seed", "np_seed")
 
+# v7 (#9434, c.5316759237): appels de seed GLOBAL posés dans le CODE. La règle 2
+# (SEED_KEYWORDS) ne voit que le contexte local de la valeur ; elle manque le cas
+# dominant — le seed est posé une fois dans la cellule d'imports, et toutes les
+# valeurs stochastiques citées en prose DANS LES CELLULES SUIVANTES sont
+# déterministes (mesuré : QC-Py-22 seedé en cellule 8, 44/53 findings STOCH
+# re-signés ; App-14 : 18 STOCH re-signés sur main, absorbés au merge de #11482
+# qui pose les seeds).
+# Instances locales (rng.seed, np.random.default_rng) exclues : elles ne seedent
+# pas le RNG global du module.
+GLOBAL_SEED_CALL_RE = re.compile(
+    r"\b(?:random\.seed|np\.random\.seed|numpy\.random\.seed|"
+    r"torch\.manual_seed|tf\.random\.set_seed)\s*\("
+)
+
 
 # --------------------------------------------------------------------------- #
 #  Dataclasses
@@ -299,16 +313,19 @@ def _extract_context(text: str, match_start: int, match_end: int, window: int = 
 
 
 def _classify_quant_value(
-    raw: str, value: float, prefix: str, suffix: str
+    raw: str, value: float, prefix: str, suffix: str,
+    seeded_upstream: bool = False,
 ) -> tuple[str, str]:
     """Classifie une valeur quantitative selon le contexte. Renvoie (classe, rationale).
 
     Ordre d'application des regles (la premiere qui matche gagne) :
+    0. Tag de drain « machine-dep » dans le contexte → STRUCTUREL (déjà drainé)
     1. STRUCTUREL si mot-cle structurel detecte dans prefix+suffix
     2. SEED dans prefix → bascule STOCHASTIQUE → STRUCTUREL
     3. ENV-DEP si pattern semver ou mot-cle env
     4. MACHINE-DEP si unite temporelle ou mot-cle machine-dep
     5. STOCHASTIQUE-NON-SEEDEE si mot-cle stochastique
+       (sauf seeded_upstream: seed global posé en amont → STRUCTUREL)
     6. STRUCTUREL par defaut (classe residuelle surete)
 
     Le defaut STRUCTUREL evite les faux positifs massifs sur les valeurs
@@ -322,6 +339,22 @@ def _classify_quant_value(
     # (v2 c.1272 inchange ; remonte ici pour proteger la regle MACHINE-DEP
     # anti-FP c.1275 qui doit respecter la liste.)
     in_data_list = any(marker in full_context for marker in DATA_LIST_MARKERS)
+
+    # 0 (v7, #9434 c.5316759237): immunité tag de drain « machine-dep ». Les
+    #     vagues de drain (#9664, #11482, ...) posent une convention de prose :
+    #     la valeur absolue est remplacée par un ordre de grandeur accompagné du
+    #     tag explicite (« *runtime machine-dep* : ~0,5 s ici », « Speedup
+    #     wall-clock *machine-dep* (CPython + charge) »). Le scanner re-signait
+    #     ces valeurs : les mots-clé légitimes « runtime » / « wall clock » du
+    #     contexte taggé déclenchent MACHINE-DEP — re-signaler du drain DÉJÀ
+    #     FAIT. Mesuré firsthand : SW-13 47 findings → 0 réel, QC-Py-22 53 → 1
+    #     réel (PR #11487 « 52/53 FP »), Lean-10 52 → 0. Le tag est un marqueur
+    #     d'auteur « déjà assumé machine-dep » → STRUCTUREL.
+    #     Failure-mode SAFE : absorbe vers STRUCTUREL uniquement — un tag trop
+    #     large garde une vraie valeur en STRUCTUREL (sur-correction inoffensive
+    #     pour un triage), jamais l'inverse.
+    if "machine-dep" in full_context:
+        return ("STRUCTUREL", "tag de drain « machine-dep » explicite (déjà assumé)")
 
     # 0. Filtre semver : si le raw match EST un semver, c'est env-dep en soi.
     if SEMVER_RE.fullmatch(raw):
@@ -460,6 +493,13 @@ def _classify_quant_value(
             # une mesure stochastique.
             if kw in ("moyenne", "mean", "variance") and any(mod in full_context for mod in NONSTOCH_MODIFIERS):
                 continue
+            # v7 (#9434, c.5316759237): seed global posé dans une cellule code
+            # EN AMONT (analyse cross-cellules) → la valeur citée est
+            # déterministe, pas « non-seedée ». N'absorbe que STOCHASTIQUE :
+            # un seed ne rend ni un temps (MACHINE-DEP) ni une version
+            # (ENV-DEP) déterministes.
+            if seeded_upstream:
+                return ("STRUCTUREL", "stochastique seede (seed global posé en amont dans le code)")
             return ("STOCHASTIQUE-NON-SEEDEE", f"mot-cle stochastique: {kw!r}")
 
     # 8. STRUCTUREL par defaut (classe residuelle)
@@ -488,13 +528,25 @@ def analyze_notebook_quant(path: str | os.PathLike) -> NotebookQuantClasses:
     findings: list[QuantClassFinding] = []
     by_class: dict[str, int] = {cls: 0 for cls in QUANT_CLASSES}
 
+    # v7 (#9434, c.5316759237): première cellule code où un seed GLOBAL est
+    # posé. Les valeurs stochastiques citées en prose APRÈS cette cellule sont
+    # déterministes (exécution séquentielle du notebook) → seeded_upstream.
+    # Condition temporelle stricte (seed_cell_index < i) : une prose AVANT le
+    # seed commente une sortie produite sans lui.
+    seeded_cell_index: int | None = None
+
     for i, c in enumerate(cells):
-        if c.get("cell_type") != "markdown":
-            continue
         source = c.get("source") or []
         text = "".join(source) if isinstance(source, list) else str(source)
         if not text:
             continue
+        if c.get("cell_type") == "code":
+            if seeded_cell_index is None and GLOBAL_SEED_CALL_RE.search(text):
+                seeded_cell_index = i
+            continue
+        if c.get("cell_type") != "markdown":
+            continue
+        seeded_upstream = seeded_cell_index is not None and seeded_cell_index < i
         # Reutilisation de l'extraction D5 v3 (qui filtre les annees, #issues,
         # PRJ42, semver simplifie stricte, etc.) — mais on doit scanner le
         # texte brut pour les versions, donc on **re-scan** avec nos propres
@@ -511,7 +563,7 @@ def analyze_notebook_quant(path: str | os.PathLike) -> NotebookQuantClasses:
             if re.fullmatch(r"\d{4}", raw) and 1900 <= v <= 2099:
                 continue
             prefix, suffix = _extract_context(text, m.start(), m.end())
-            cls, rationale = _classify_quant_value(raw, v, prefix, suffix)
+            cls, rationale = _classify_quant_value(raw, v, prefix, suffix, seeded_upstream=seeded_upstream)
             # Tronque le snippet pour le rapport.
             snippet = text.strip().splitlines()
             snippet_str = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]

--- a/scripts/notebook_tools/tests/test_scan_quant_classify.py
+++ b/scripts/notebook_tools/tests/test_scan_quant_classify.py
@@ -1179,3 +1179,144 @@ class TestC130123PostCablageCorpusDelta:
             f"accuracy seed=42 aurait du rester STRUCTUREL, got {cls}. "
             f"Filtre v4 trop large."
         )
+
+
+# --------------------------------------------------------------------------- #
+#  v7 (c.5316759237): immunité tag de drain « machine-dep » + propagation
+#  seeds cross-cellules. Fondé sur la mesure firsthand des re-signaux massifs
+#  de prose DÉJÀ drainée : SW-13 47/47 FP, QC-Py-22 52/53 FP (#11487),
+#  Lean-10 52/52 FP, App-14 ~33/52 FP post-#11482.
+# --------------------------------------------------------------------------- #
+
+
+class TestV7DrainedTagImmunity:
+    """Le tag « machine-dep » posé par les vagues de drain marque du drain DÉJÀ FAIT."""
+
+    def test_drained_tag_absorbs_tagged_timing(self):
+        """« *runtime machine-dep* : ~0,5 s ici » = drain déjà fait → STRUCTUREL.
+
+        Cas mesuré SW-13 : le kw légitime « runtime » du contexte taggé
+        déclenchait MACHINE-DEP sur une valeur déjà remplacée par un ordre de
+        grandeur par la vague de drain précédente.
+        """
+        cls, rationale = _classify_quant_value("0,5", 0.5,
+                                               "*runtime machine-dep* : ~",
+                                               " s sur cette machine")
+        assert cls == "STRUCTUREL", (
+            f"timing taggé machine-dep = drain déjà fait, got {cls} ({rationale})"
+        )
+        assert "machine-dep" in rationale
+
+    def test_drained_tag_absorbs_tagged_speedup(self):
+        """« Speedup wall-clock *machine-dep* (CPython + charge) » → STRUCTUREL.
+
+        Cas mesuré App-14/GT-8 : « wall clock » kw machine-dep légitime matchait
+        la colonne taggée déjà drainée.
+        """
+        cls, _ = _classify_quant_value("72", 72.0,
+                                       "speedup wall-clock *machine-dep* (cpython + charge",
+                                       ")")
+        assert cls == "STRUCTUREL", (
+            f"speedup taggé machine-dep = drain déjà fait, got {cls}"
+        )
+
+    def test_falsification_genuine_timing_untagged_stays_machine_dep(self):
+        """Sans tag, un vrai pin wall-clock RESTE MACHINE-DEP (l'immunité ne sur-corrige pas)."""
+        cls, _ = _classify_quant_value("15", 15.0,
+                                       "prend environ ",
+                                       " secondes sur cette machine")
+        assert cls == "MACHINE-DEP", (
+            f"genuine pin wall-clock non taggé doit rester MACHINE-DEP, got {cls}"
+        )
+
+    def test_falsification_semver_untagged_stays_env_dep(self):
+        """Sans tag, un semver reste ENV-DEP."""
+        cls, _ = _classify_quant_value("2.4.6", 2.4,
+                                       "cette analyse utilise numpy ",
+                                       " et python 3.11")
+        assert cls == "ENV-DEP", f"genuine semver doit rester ENV-DEP, got {cls}"
+
+
+class TestV7SeedPropagation:
+    """Seed global posé en amont dans le code → stochastique déterministe."""
+
+    def test_seeded_upstream_absorbs_stochastic(self):
+        cls, rationale = _classify_quant_value("0.87", 0.87,
+                                               "accuracy de validation : ",
+                                               "", seeded_upstream=True)
+        assert cls == "STRUCTUREL", (
+            f"accuracy avec seed global en amont = déterministe, got {cls} ({rationale})"
+        )
+        assert "seed" in rationale
+
+    def test_falsification_no_seed_keeps_stochastic(self):
+        cls, _ = _classify_quant_value("0.87", 0.87,
+                                       "accuracy de validation : ",
+                                       "", seeded_upstream=False)
+        assert cls == "STOCHASTIQUE-NON-SEEDEE", (
+            f"sans seed en amont, accuracy reste STOCHASTIQUE-NON-SEEDEE, got {cls}"
+        )
+
+    def test_falsification_seed_does_not_absorb_machine_dep(self):
+        """Un seed ne rend pas un temps d'exécution déterministe."""
+        cls, _ = _classify_quant_value("15", 15.0,
+                                       "prend environ ",
+                                       " secondes sur cette machine", seeded_upstream=True)
+        assert cls == "MACHINE-DEP", (
+            f"un seed ne détermine pas un wall-clock, doit rester MACHINE-DEP, got {cls}"
+        )
+
+    def _write_nb(self, tmp_path, cells, name):
+        p = tmp_path / name
+        p.write_text(json.dumps({"cells": cells}), encoding="utf-8")
+        return analyze_notebook_quant(p)
+
+    def test_cross_cell_seed_before_prose_demotes_stoch(self, tmp_path):
+        """random.seed(42) en cellule 0, prose accuracy en cellule 2 → STRUCTUREL."""
+        result = self._write_nb(tmp_path, [
+            {"cell_type": "code", "source": ["import random\nrandom.seed(42)\n"]},
+            {"cell_type": "code", "source": ["score = run_eval()\n"]},
+            {"cell_type": "markdown", "source": ["Accuracy obtenue : 0.87 sur le jeu de validation.\n"]},
+        ], "seed_before.ipynb")
+        acc = [f for f in result.findings if f.raw_match == "0.87"]
+        assert len(acc) == 1, f"0.87 introuvable dans {result.by_class}"
+        assert acc[0].quant_class == "STRUCTUREL", (
+            f"0.87 après seed global = déterministe, got {acc[0].quant_class} "
+            f"({acc[0].rationale})"
+        )
+
+    def test_cross_cell_seed_after_prose_keeps_stoch(self, tmp_path):
+        """Prose AVANT le seed : la sortie commentée a été produite sans seed → STOCH."""
+        result = self._write_nb(tmp_path, [
+            {"cell_type": "markdown", "source": ["Accuracy obtenue : 0.87 sur le jeu de validation.\n"]},
+            {"cell_type": "code", "source": ["import random\nrandom.seed(42)\n"]},
+        ], "seed_after.ipynb")
+        acc = [f for f in result.findings if f.raw_match == "0.87"]
+        assert len(acc) == 1
+        assert acc[0].quant_class == "STOCHASTIQUE-NON-SEEDEE", (
+            f"0.87 avant le seed reste STOCHASTIQUE-NON-SEEDEE, got {acc[0].quant_class}"
+        )
+
+    def test_local_rng_does_not_count_as_global_seed(self, tmp_path):
+        """default_rng est instance-local : ne seede pas le RNG global du module."""
+        result = self._write_nb(tmp_path, [
+            {"cell_type": "code", "source": ["import numpy as np\nrng = np.random.default_rng(42)\n"]},
+            {"cell_type": "markdown", "source": ["Accuracy obtenue : 0.87 sur le jeu de validation.\n"]},
+        ], "local_rng.ipynb")
+        acc = [f for f in result.findings if f.raw_match == "0.87"]
+        assert len(acc) == 1
+        assert acc[0].quant_class == "STOCHASTIQUE-NON-SEEDEE", (
+            f"default_rng est local, 0.87 doit rester STOCHASTIQUE, got {acc[0].quant_class}"
+        )
+
+    def test_torch_manual_seed_counts(self, tmp_path):
+        """torch.manual_seed est un seed global reconnu (cas QC-Py-22 : seedé cellule 8)."""
+        result = self._write_nb(tmp_path, [
+            {"cell_type": "code", "source": ["import torch\ntorch.manual_seed(42)\n"]},
+            {"cell_type": "markdown", "source": ["Accuracy obtenue : 0.87 sur le jeu de validation.\n"]},
+        ], "torch_seed.ipynb")
+        acc = [f for f in result.findings if f.raw_match == "0.87"]
+        assert len(acc) == 1
+        assert acc[0].quant_class == "STRUCTUREL", (
+            f"0.87 après torch.manual_seed = déterministe, got {acc[0].quant_class}"
+        )


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #11485

## Summary

Le scanner `scan_quant_classify.py` (triage 4-classes #9434, non câblé CI)
re-signalait massivement du drain **déjà fait**. Deux causes mesurées firsthand
sur 4 notebooks témoins (tri de ce cycle + PR concurrente #11487) :

1. **La prose déjà drainée re-signalée** : les vagues de drain (#9664, #11482,
   #11485…) remplacent la valeur absolue par un ordre de grandeur accompagné du
   tag « `*machine-dep*` » (« `*runtime machine-dep* : ~0,5 s ici` », « Speedup
   wall-clock `*machine-dep*` (CPython + charge) »). Le tag n'étant pas connu du
   scanner, les mots-clé légitimes « runtime » / « wall clock » du contexte
   taggé déclenchaient MACHINE-DEP — re-signaler du drain **déjà fait**.
2. **Les valeurs seedées re-signalées** : le seed est posé une fois dans la
   cellule d'imports ; le classifieur ne voit que le contexte local de chaque
   valeur, jamais les cellules voisines. QC-Py-22 (seedé cellule 8,
   `torch.manual_seed` + `np.random.seed`) voyait 44/53 findings STOCH
   re-signés — corroboré indépendamment par #11487 (« 52/53 findings FP,
   seeded run »).

## Le fix (v7, failure-mode-safe)

Même asymétrie que les guards v4/v5/v6 : **absorbe vers STRUCTUREL uniquement,
jamais vers drainable** — un guard trop large garde une vraie valeur en
STRUCTUREL (sur-correction inoffensive pour un triage), jamais l'inverse.

- **Règle 0 — immunité tag** : « machine-dep » dans le contexte (prefix/suffix)
  → STRUCTUREL (« déjà assumé »).
- **`GLOBAL_SEED_CALL_RE` + propagation temporelle** : seeds globaux
  (`random.seed` / `np.random.seed` / `numpy.random.seed` /
  `torch.manual_seed` / `tf.random.set_seed`) détectés dans les cellules code ;
  une valeur STOCHASTIQUE citée en prose **après** la cellule du seed (condition
  stricte `seed_cell_index < i`) devient STRUCTUREL. Un seed ne rend ni un
  temps (MACHINE-DEP) ni une version (ENV-DEP) déterministes — ces classes
  sont inchangées. Instances locales (`default_rng`) exclues.

## Mesure (calibration avant tout câblage — l'outil reste triage-only)

| Notebook (témoin trié firsthand) | Avant | Après | Note |
|---|---|---|---|
| SW-13-Python-Reasoners | 47 | 14 | résidus = FP domaine (« owl 2 » standard, comptes) + pins non-taggués (drain légitime à faire) |
| QC-Py-22-Deep-Learning-LSTM | 53 | 9 | corrobore #11487 « 52/53 FP » |
| App-14-ConnectFour-Adversarial | 52 | 28 | 18 STOCH absorbés **au merge** de #11482 (en file) qui pose les seeds |
| Lean-10-LeanDojo | 52 | 52 | **correct** : plages « 5-15 min » ni taggées ni seedées = drain à faire, le scanner doit continuer à les signaler |

**Corpus complet (1019 NB)** : drainable **5577 → 4867** (−710) — MACHINE
2177→1942, STOCH 1519→1056, ENV 1881→1869.

**Sanity anti-sur-correction (ICT-25)** : 28→20 STOCH. Seed global posé en
cellule 33 → seules les valeurs postérieures sont absorbées (8), les 20
antérieures (sorties produites sans seed) restent signalées — la condition
temporelle stricte fait son travail.

## Tests

92/92 verts : 81 existants (golden sets #8052, Probas, ArgAnalysis, ML/DfA v4,
nits c.1273, guards v5/v6 — zéro régression) + 11 nouveaux (TestV7) dont
**4 falsifications** : genuine pin wall-clock non-taggué reste MACHINE-DEP,
semver reste ENV-DEP, STOCH sans seed conservé, seed n'absorbe pas MACHINE-DEP.

## Note G-VAR-1 (honnête)

Ce grain est `tooling` (META), pas CONTENU : les grains CONTENU disponibles ce
cycle étaient verrouillés (#1621 vérifié satisfait → fermeture proposée, #11256
saturé, QC-Py-22 concurrent #11487, App-14 en file #11482). Le MED tient au
litmus (« change quelque chose » : 4 verdicts de notebooks changent sur mesure
mesurée), mais le plancher CONTENU du cycle a été porté par #11482/#11485
(livrées ce cycle par cette lane). Le prochain grain de la lane sera CONTENU.

See #9434
