### PR TITLE
fix(ci,#11349): scripts-tests.yml paths - rewire native_decide ratchet onto conway_lean/**.lean

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -43,6 +43,17 @@ on:
       # run hermetically without agent_framework (see pytest step).
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/forensic_guards.py'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py'
+      # #11349 native_decide ratchet rewire: scripts/lean/tests/test_proof_integrity_audit_wiring.py
+      # pins the conway_lean proof-integrity-audit allow-list to the build-enumerated
+      # footprint (61 names after #11368). The test lives under scripts/** so its only
+      # trigger was an scripts/** push -- which means a PR adding a new native_decide
+      # to conway_lean could pass un-rattled and the rouge would land on the first
+      # next scripts/** pusher. Wire the lake path so the ratchet fires when its
+      # subject moves; mirrored under pull_request: below.
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
   pull_request:
     branches: [main]
     paths:
@@ -59,6 +70,11 @@ on:
       # #6790 prover forensic-guards (mirror of the push paths above).
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/prover/forensic_guards.py'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/tests/test_prover_forensic_guards.py'
+      # #11349 native_decide ratchet rewire (mirror of the push paths above).
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
+      - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: MED/docs #11373

# #11349 — re-câblage du cliquet `native_decide` sur `conway_lean/**.lean`

## Résumé

Le cliquet qui surveille les axiomes `native_decide` interdits dans `conway_lean` — implémenté comme `scripts/lean/tests/test_proof_integrity_audit_wiring.py::test_audit_allowlists_native_decide_axioms` (pin à 61 noms, valeur vérifiée par CI) — était branché **uniquement** sur `scripts/**`, parce que le test habite ce sous-arbre. Conséquence mesurée (#11349, run `31977450010`, branch=`main`) : quand le commit `c3bd40cc1` (`feat(conway,#11161)` grain 3a) a ajouté 2 axiomes `native_decide` à `Conway.Life.HashlifeCorrectness`, **aucun check `Scripts Tests` n'a couru** sur ce SHA (le commit ne touchait pas `scripts/**`). Le ratchet s'est réveillé 2 commits plus loin (`3f0887298`, `feat(editorial,#11259)`, lane différente) — donc la première lane à toucher un script après coup a hérité d'un rouge qui n'était pas le sien. C'est précisément la classe de défaut décrite par l'épisode : un organe correct, câblé sur le mauvais déclencheur (#11268 = périmètre non lu, #11349 = cliquet décoré).

Cette PR **re-câble** le déclencheur pour que le ratchet se déclenche quand **son sujet** bouge (`MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**`).

## Modifications

**1 fichier, +11/-0** : `.github/workflows/scripts-tests.yml`.

| Bloc | Avant | Après |
|---|---|---|
| `on.push.paths` | 11 entrées (toutes sous `scripts/`, `tests/`, `agent_tests/`, et 3 `.github/workflows/*.yml` pincés par `test_workflow_branch_pattern.py`) | +4 entrées : `conway_lean/**.lean`, `lakefile.lean`, `lakefile.toml`, `lean-toolchain` |
| `on.pull_request.paths` | 11 entrées identiques | +4 entrées (mirror strict du bloc push, comme déjà pratiqué pour `#6790` et `#10145`) |

Les 4 paths conway_lean reprennent **exactement** le périmètre de déclenchement de `lean-conway.yml` (L60-72), pour éviter qu'une PR touchant `conway_lean/.gitignore` ou `conway_lean/README.md` réveille inutilement le test sans réveiller le lac.

## Pourquoi le lac ciblé est `conway_lean` (et pas les 18 lakes)

Le test `test_proof_integrity_audit_wiring.py` audit **spécifiquement** la liste blanche de `proof-integrity-audit` dans `lean-conway.yml` (L199-230). Chaque lac Lean a son propre cliquet d'axiomes indépendant :
- `knot_lean` : cliquet dans son propre workflow, test sous `scripts/lean/tests/test_*_knot*`
- `grothendieck_lean`, `mimo_lean`, etc. : idem, périmètre de lac indépendant.

Le re-câblage **par lac** est la granularité correcte : un garde d'axiomes Lean qui ne se réveille pas sur un diff du lac qu'il audit = re-câblage localisé sur **ce** lac.

## Tests

**7/7 PASSED** (`pytest scripts/lean/tests/test_proof_integrity_audit_wiring.py -v`) :

```
test_workflow_exists PASSED
test_blocking_proof_integrity_targets_showcase_modules PASSED
test_advisory_audit_job_wired PASSED
test_audit_targets_sorry_bearing_module PASSED
test_audit_allowlists_native_decide_axioms PASSED   # le pin 61 tient toujours
test_audit_allowlist_is_distinct_from_blocking_gate PASSED
test_blocking_and_audit_are_complementary PASSED
```

Le test continue de pinner le compte d'axiomes à 61 (post-`#11368` MERGED 2026-08-17) : cette PR ne touche pas la liste blanche, ne change pas le pin, ne dérange pas le diagnostic antérieur.

**YAML lint** : `yaml.safe_load` parse les 15 paths (push = PR), symétrie miroir conservée (#6790 pattern).

## Critère d'acceptation #11349

L'acceptance #11349 a trois points ; cette PR traite le **point 2** (re-câblage) — les points 1 et 3 étaient déjà couverts :

| # | Demande | Statut |
|---|---|---|
| 1 | Trancher les 2 axiomes sur le fond | **RÉGLÉ par anticipation dans #11368** (lecture des 2 témoins P4-At, L142-173 du test documente l'attribution) |
| 2 | Re-câbler le déclencheur sur `conway_lean/**.lean` | **LIVRÉ par cette PR** |
| 3 | Contrôle de non-régression (PR factice ajoutant `native_decide` rougit) | NON LIVRÉ — test dédié à porter par une PR ultérieure (cf. *Acceptance partielle* ci-dessous) |

## Acceptance partielle — pourquoi le point 3 reste à livrer

Le contrôle de non-régression (point 3 de l'issue) demande un test qui crée une branche avec un `.lean` modifié ajoutant un `native_decide`, et vérifie que `scripts-tests.yml` rougit à la prochaine exécution. C'est **meta-testable** mais délicat :

- Un test pytest ne peut pas piloter GitHub Actions.
- Une simulation locale doit re-déclencher le path filter, ce qui demande un harness qui n'existe pas dans `pytest.ini`.
- L'option raisonnable = un test qui **valide la cohérence du path filter** (cette PR inclut la modification du filtre, mais pas un test qui simule un changement de `.lean`).

J'**ouvre une issue de suivi** `Fix(point 3 control) — fichier : le path filter re-câblé est-il exercé sur push .lean ?` — pour qu'un cycle ultérieur puisse livrer ce test une fois la première itération de re-câblage mergée (besoin du workflow déjà déployé sur la branche pour scripter un test d'intégration).

## Conformité

- **MED/guard** : substance = re-câblage d'un organe de garde (paths: d'un workflow). Le contrat du cliquet ne change pas : la liste blanche reste pinée à 61, le test reste sous `scripts/lean/tests/`, et le critère `attribute AND non-hollowing` reste le même (test docstring L142-173).
- **Plancher R1 NON TENU** : 3ᵉ MED/META consécutif après #11373 (MED/docs) — signalisé. G-VAR-3 OK parce que genres mélangés (docs/guard/tooling/guard = 4 genres distincts sur 4 grains).
- **Pas de marqueur `CATALOG-STATUS` touché** (target = `.github/workflows/`).
- **Pas de literal secret, pas de hand-edit de cellule** (target = workflow YAML, pas notebook).
- **Pas de force-push** : branche de feature à lane unique (`feature/c1331p232-pick-deef-content` depuis `origin/main`).

## Liens

- Issue parente : https://github.com/jsboige/CoursIA/issues/11349
- Pin historique : PR #11368 (MERGED 2026-08-17T03:57Z) — l'allow-list 59→61 et l'argumentation attributaire
- Épisode analogue : #11268 (Hermes périmètre) — même classe, garde correct câblé sur le mauvais signal
- Workflow re-câblé : `.github/workflows/scripts-tests.yml`
- Test : `scripts/lean/tests/test_proof_integrity_audit_wiring.py`
- Target upstream : `.github/workflows/lean-conway.yml` (L60-72 paths mirror, L199-230 allow-list inchangée)
