### PR TITLE
docs(lean,#3979): calibration_lean README resync — toolchain v4.32.1 + grep-claim fix (§E)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.en.md
@@ -4,7 +4,7 @@ Prover calibration targets for benchmarking the multi-agent Lean prover.
 
 ## Status
 
-- **Toolchain**: v4.31.0-rc1
+- **Toolchain**: v4.32.1 (v4.31.0-rc1 → v4.32.0 via #11307, then soundness bump → v4.32.1 via #11325, cf #11256)
 - **Sorry count**: 0 production (all 4 calibration targets proved; previous "4 sorry" claim matched docstring text inside `/-- ... -/` blocks, not actual `sorry` terms)
 - **Build**: `lake build Calibration` -- SUCCESS
 - **Dependencies**: Mathlib4
@@ -30,14 +30,14 @@ Prover calibration targets for benchmarking the multi-agent Lean prover.
 
 - This module benchmarks the multi-agent Lean prover's ability to close textbook-style proofs
 - All targets now closed; module is retained as a permanent regression suite for prover changes
-- Verification: `grep -nE '^[^/]*\bsorry\b' Calibration/Nash.lean` returns 0 production hits (cf [Lean README](../Lean-1-Setup.ipynb))
+- Verification: code-level count (docstrings `/-- ... -/` and comments `-- ...` stripped) = **0** `sorry` in production (cf [Lean README](../Lean-1-Setup.ipynb)). NB: the naive `grep -nE '^[^/]*\bsorry\b' Calibration/Nash.lean` returns **3** hits on main — all prose inside target F's docstring (L90/96/97), not proof terms
 
 ## Conclusion
 
 This project is a **calibration suite** for the multi-agent Lean prover: four
 textbook-style proof targets (C / D / E / F) in `Calibration/Nash.lean`, all
 **proved with 0 `sorry`** (`lake build Calibration` SUCCESS, toolchain
-`v4.31.0-rc1`).
+`v4.32.1`).
 
 ### Why it exists
 
@@ -50,8 +50,11 @@ proofs surfaces here as a build failure.
 
 An earlier "4 `sorry`" count was a **measurement artefact** — the word "sorry"
 appeared inside `/-- ... -/` docstrings (prose), not as proof terms. A naive
-`grep sorry` over-counted; the correct check
-`grep -nE '^[^/]*\bsorry\b'` (excluding comments/docstrings) returns 0. The
+`grep sorry` over-counted, and the anchored grep
+`grep -nE '^[^/]*\bsorry\b'` is **not sufficient either**: it only excludes
+lines *starting* with `/`, so the indented body of a docstring still matches —
+on main it returns 3 prose hits (target F's docstring). The correct check
+strips docstring blocks before counting; the code-level count is 0. The
 same distinction — `sorry` the tactic vs "sorry" the word — applies across the
 whole Lean series.
 

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean/README.md
@@ -14,7 +14,7 @@ régression du prouveur.
 
 ## Statut
 
-- **Toolchain** : v4.31.0-rc1
+- **Toolchain** : v4.32.1 (v4.31.0-rc1 → v4.32.0 via #11307, puis bump soundness → v4.32.1 via #11325, cf #11256)
 - **Compte de sorry** : 0 en production (les 4 cibles de calibration sont prouvées ; un ancien compte de « 4 sorry » correspondait à du texte de docstring à l'intérieur de blocs `/-- ... -/`, pas à des termes `sorry` réels)
 - **Build** : `lake build Calibration` -- SUCCESS
 - **Dépendances** : Mathlib4
@@ -67,14 +67,14 @@ flowchart LR
 
 - Ce module benchmark la capacité du prouveur Lean multi-agents à clore des preuves de type manuel
 - Toutes les cibles sont désormais fermées ; le module est conservé comme suite de régression permanente pour les changements du prouveur
-- Vérification : `grep -nE '^[^/]*\bsorry\b' Calibration/Nash.lean` retourne 0 correspondance en production (cf [README Lean](../Lean-1-Setup.ipynb))
+- Vérification : comptage code-level (docstrings `/-- ... -/` et commentaires `-- ...` strippés) = **0** `sorry` en production (cf [README Lean](../Lean-1-Setup.ipynb)). NB : le `grep -nE '^[^/]*\bsorry\b' Calibration/Nash.lean` naïf retourne **3** correspondances sur main — toutes en prose dans la docstring de la cible F (L90/96/97), pas des termes de preuve
 
 ## Conclusion
 
 Ce projet est une **suite de calibration** pour le prouveur Lean multi-agents :
 quatre cibles de preuve de type manuel (C / D / E / F) dans
 `Calibration/Nash.lean`, toutes **prouvées avec 0 `sorry`**
-(`lake build Calibration` SUCCESS, toolchain `v4.31.0-rc1`).
+(`lake build Calibration` SUCCESS, toolchain `v4.32.1`).
 
 ### Pourquoi ce module existe
 
@@ -104,10 +104,13 @@ flowchart TD
 
 Un ancien compte de « 4 `sorry` » était un **artéfact de mesure** — le mot
 « sorry » apparaissait à l'intérieur de docstrings `/-- ... -/` (prose), pas
-comme termes de preuve. Un `grep sorry` naïf sur-comptait ; la vérification
-correcte `grep -nE '^[^/]*\bsorry\b'` (en excluant commentaires/docstrings)
-retourne 0. La même distinction — `sorry` la tactique vs « sorry » le mot —
-s'applique à toute la série Lean.
+comme termes de preuve. Un `grep sorry` naïf sur-comptait, et le grep ancré
+`grep -nE '^[^/]*\bsorry\b'` n'est **pas suffisant non plus** : il n'exclut que
+les lignes *commençant* par `/`, donc le corps indenté d'une docstring matche
+encore — sur main il retourne 3 correspondances de prose (docstring de la
+cible F). La vérification correcte strippe les blocs de docstring avant de
+compter ; le comptage code-level retourne 0. La même distinction —
+`sorry` la tactique vs « sorry » le mot — s'applique à toute la série Lean.
 
 ### Où aller ensuite
 


### PR DESCRIPTION
## Summary

Feuille **Calibration** du grain #3979 (résiduel nommé par les RELEASED grothendieck #11444 et knot #11492). Resync §E fichier-entier des 2 READMEs (FR + EN mirror), 2 défauts mesurés firsthand sur `origin/main` 25588a601 :

1. **Toolchain périmée** : le README clamait `v4.31.0-rc1` ; réalité `v4.32.1` (2 sauts — #11307 v4.32.0, puis bump soundness #11325 / #11256). Corrigé dans Statut (avec le chemin de migration) + Conclusion.
2. **Commande de vérification fausse** : le README clamait que `grep -nE '^[^/]*\bsorry\b' Calibration/Nash.lean` « retourne 0 correspondance en production » — elle retourne **3** matches sur main (L90/96/97, prose de la docstring de la cible F). Le grep ancré n'exclut que les lignes *commençant* par `/`, pas le corps indenté des docstrings. Corrigé : comptage code-level (docstrings strippées) = 0, avec le caveat documenté dans la section « leçon du faux positif grep » — qui propageait la même commande insuffisante.

## Audit §E fichier-entier (preuves)

| Claim du README | Vérification firsthand | Verdict |
|---|---|---|
| Toolchain | `git show origin/main:...lean-toolchain` → `v4.32.1` | corrigé (était v4.31.0-rc1) |
| sorry 0 en production | strip docstrings/comments en Python sur Nash.lean → 0 ; grep naïf → 6 (prose) ; grep ancré du README → 3 (prose) | claim 0 OK, commande corrigée |
| 4 modules FR + 4 EN | `git ls-tree` : Calibration{,_en}.lean + {Doomsday,Nash,Nim}{,_en}.lean | OK |
| Cibles C/D/E/F | 4 `theorem` (strictly_domin_defect_pd, pd_defect_is_pure_ne, pd_cooperate_not_ne, pd_defect_is_ne_decomposable) présents dans Nash.lean | OK |
| Build SUCCESS | #11325 (tranche 3 soundness) mergé avec calibration_lean, CI verte | OK |
| Lien README Lean | `Lean-1-Setup.ipynb` existe sur main | OK |

## Détails

- Markdown-only (C.3-exempt, aucune re-exécution requise) ; aucun fichier `.lean` touché.
- Les mentions `v4.31.0-rc1` restantes = le chemin de migration historique (intentionnel).
- Feuille suivante du résiduel #3979 : **sensitivity_lean** (toolchain claimée v4.31.0-rc1, réelle v4.32.0 via #10997).

Grain: MED/readme -- lane myia-po-2026:CoursIA -- prev: MED/tooling #11494

See #3979 (feuille Calibration ; résiduel : sensitivity_lean)
