### PR TITLE
docs(sensitivity_lean,#3979): resync README FR+EN to disk state (toolchain v4.32.0, root sibling 5+5 i18n)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.en.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.en.md
@@ -11,11 +11,11 @@ Complete mini-project: **0 sorry, 0 axiom** beyond Lean core axioms.
 
 ## Status
 
-- **Toolchain**: `v4.31.0-rc1`
+- **Toolchain**: `v4.32.0` (migrated from `v4.31.0-rc1` by #10997 ; Mathlib pin `v4.32.0`)
 - **Sorry**: **0** — every proof is closed
-- **Build**: `lake build Sensitivity` — SUCCESS
+- **Build**: `lake build Sensitivity` — SUCCESS (1970 jobs, v4.32.0, #10997) ; `#print axioms Sensitivity.huang_degree_theorem` (+ `_en`) = `[propext, Classical.choice, Quot.sound]` — zero `sorryAx`
 - **Dependencies**: Mathlib4
-- **i18n coverage (EPIC #4980)**: lake fully bilingual FR/EN — 4 `.lean` modules shipped as FR canonical + 4 `*_en.lean` mirror siblings on `main` (`Sensitivity/Hypercube_en.lean`, `Sensitivity/VectorSpace_en.lean`, `Sensitivity/Operator_en.lean`, `Sensitivity/MainTheorem_en.lean`). Convention EPIC #4980 Option A: docstrings `/-- ... -/` and `-- ...` comments differ between FR and EN, signatures and proofs remain byte-identical.
+- **i18n coverage (EPIC #4980)**: lake fully bilingual FR/EN — 5 FR-canonical `.lean` files (root aggregator + 4 modules) + 5 `*_en.lean` mirror siblings on `main` (`Sensitivity_en.lean`, `Sensitivity/Hypercube_en.lean`, `Sensitivity/VectorSpace_en.lean`, `Sensitivity/Operator_en.lean`, `Sensitivity/MainTheorem_en.lean`). Convention EPIC #4980 Option A: docstrings `/-- ... -/` and `-- ...` comments differ between FR and EN, signatures and proofs remain byte-identical.
 
 ## What it formalizes
 
@@ -43,7 +43,7 @@ interlacing theorem forces a high-degree vertex in any large induced subgraph.
 
 | File | `_en` | Lines | sorry | Content |
 |------|-------|------:|------:|---------|
-| `Sensitivity.lean` | — | 1 | 0 | Root import umbrella |
+| `Sensitivity.lean` | `Sensitivity_en.lean` | 19 | 0 | Root import umbrella (imports-only) |
 | `Sensitivity/Hypercube.lean` | `Hypercube_en.lean` | 124 | 0 | Boolean hypercube `Q n`, vertices, adjacency |
 | `Sensitivity/VectorSpace.lean` | `VectorSpace_en.lean` | 132 | 0 | Real vector space of Boolean functions, `ℝ^{2^n}` basis |
 | `Sensitivity/Operator.lean` | `Operator_en.lean` | 100 | 0 | Sensitivity and block-sensitivity operators |

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/sensitivity_lean/README.md
@@ -11,11 +11,11 @@ Mini-projet complet : **0 sorry, 0 axiome** au-delà des axiomes du cœur de Lea
 
 ## Statut
 
-- **Toolchain** : `v4.31.0-rc1`
+- **Toolchain** : `v4.32.0` (migrée depuis `v4.31.0-rc1` par #10997 ; Mathlib pin `v4.32.0`)
 - **Sorry** : **0** — chaque preuve est close
-- **Build** : `lake build Sensitivity` — SUCCESS
+- **Build** : `lake build Sensitivity` — SUCCESS (1970 jobs, v4.32.0, #10997) ; `#print axioms Sensitivity.huang_degree_theorem` (+ `_en`) = `[propext, Classical.choice, Quot.sound]` — zéro `sorryAx`
 - **Dépendances** : Mathlib4
-- **Couverture i18n (EPIC #4980)** : lake entièrement bilingue FR/EN — 4 modules `.lean` livrés en FR canonique + 4 siblings `*_en.lean` miroirs sur `main` (`Sensitivity/Hypercube_en.lean`, `Sensitivity/VectorSpace_en.lean`, `Sensitivity/Operator_en.lean`, `Sensitivity/MainTheorem_en.lean`). Convention EPIC #4980 Option A : docstrings `/-- ... -/` et commentaires `-- ...` diffèrent entre FR et EN, signatures et preuves byte-identiques.
+- **Couverture i18n (EPIC #4980)** : lake entièrement bilingue FR/EN — 5 fichiers `.lean` FR canoniques (racine agrégatrice + 4 modules) + 5 siblings `*_en.lean` miroirs sur `main` (`Sensitivity_en.lean`, `Sensitivity/Hypercube_en.lean`, `Sensitivity/VectorSpace_en.lean`, `Sensitivity/Operator_en.lean`, `Sensitivity/MainTheorem_en.lean`). Convention EPIC #4980 Option A : docstrings `/-- ... -/` et commentaires `-- ...` diffèrent entre FR et EN, signatures et preuves byte-identiques.
 
 ## Ce qui est formalisé
 
@@ -84,7 +84,7 @@ flowchart TD
 
 | Fichier | `_en` | Lignes | sorry | Contenu |
 |---------|-------|-------:|------:|---------|
-| `Sensitivity.lean` | — | 1 | 0 | Ombrelle d'import racine |
+| `Sensitivity.lean` | `Sensitivity_en.lean` | 19 | 0 | Ombrelle d'import racine (imports-only) |
 | `Sensitivity/Hypercube.lean` | `Hypercube_en.lean` | 124 | 0 | Hypercube booléen `Q n`, sommets, adjacence |
 | `Sensitivity/VectorSpace.lean` | `VectorSpace_en.lean` | 132 | 0 | Espace vectoriel réel des fonctions booléennes, base `ℝ^{2^n}` |
 | `Sensitivity/Operator.lean` | `Operator_en.lean` | 100 | 0 | Opérateurs de sensibilité et de sensibilité par blocs |


### PR DESCRIPTION
Grain: MED/readme — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #11491

## Summary

Feuille **sensitivity_lean** du grain #3979 — resync §E fichier-entier des 2 READMEs (FR + EN mirror), même pattern que les feuilles knot (#11492) et calibration (#11496). Résiduel nommé par po-2026 cycle 21, claim paths-scopé posé via l'outil.

**3 drifts mesurés firsthand sur `origin/main`, corrigés dans les 2 miroirs :**

1. **Toolchain** : README claimait `v4.31.0-rc1`, réel `v4.32.0` — `lean-toolchain` lu sur disque, corroboré par le pin Mathlib `@ "v4.32.0"` du lakefile (migration #10997).
2. **Table modules, ligne racine** : `Sensitivity.lean` listée `_en: —` à 1 ligne — or `Sensitivity_en.lean` **existe** (19 lignes, agrégateur imports-only documenté « FR-seule canonique / jumeau anglais » dans sa propre docstring). Corrigé : sibling nommé, 19 lignes, annotation imports-only.
3. **Couverture i18n** : « 4 modules + 4 siblings » → **5 + 5** (racine agrégatrice incluse dans les deux langues).

## Claims vérifiés inchangés (audit fichier-entier, pas seulement les lignes touchées)

- **Sorry 0** : `count_code_sorry.py --json` → sensitivity_lean `distinct_code_sorry: 0`, `naive: 0`.
- **Ancres L51/L84** : `exists_eigenvalue` L51, `huang_degree_theorem` L84 — exactes dans `MainTheorem.lean`.
- **Build + axiomes** : repris du body #10997 — `lake build` SUCCESS 1970 jobs sous v4.32.0 ; `#print axioms Sensitivity.huang_degree_theorem` (+ `_en`) = `[propext, Classical.choice, Quot.sound]`, zéro `sorryAx`. Cité dans le README (la ligne Build ne portait aucune preuve avant).
- **Lignes des 4 modules** : 124/132/100/135 — toutes exactes.
- **Dépendance Mathlib4** ✓ (lakefile).

## Validation

- Markdown-only 8+/8− sur 2 fichiers, 0 cellule notebook touchée (C.3 exempt de re-exec ; H.3 : « no files to check »).
- 0 marqueur `CATALOG-STATUS` dans ces READMEs — pas de contrainte catalogue.
- Miroirs FR/EN synchrones (mêmes 3 corrections).

## Note G-VAR-1 (honnête)

Genre META (`readme`) — le plancher CONTENU de la lane reste porté par #11476/#11482/#11485 (SC-4 PythonNet DEEP, App-14, Search-7) **en attente review ai-01** depuis ce matin ; la file review est le goulot documenté (dashboard cycles 7-9). Cette PR épuise le résiduel nommé du grain #3979 sans ajouter à la congestion review au-delà d'un diff 16 lignes.

See #3979
