### PR TITLE
feat(quant,#9434): scanner v8 — guard min-domaine, absorbe les « N min » de variables modélisées (Infer-2 30/30 MD FP -> 0)

### DIFF
--- a/scripts/notebook_tools/scan_quant_classify.py
+++ b/scripts/notebook_tools/scan_quant_classify.py
@@ -29,7 +29,7 @@ machine-dep / env-dep / stochastique = a deriver ou retirer.
 ## Cas ambigus
 
 - `Durée estimée : 45 minutes` (effort etudiant, pacing pedagogique) = **TN structurel/pédagogique**, **hors scope drainage** (arbitrage 2026-08-06 ai-01, cf #9434 thread). Le classifier le classe STRUCTUREL grace au contexte `Durée estimée`.
-- Posterieurs bayesiens en minutes (Infer-101 moyennes/variances de trajets) = donnees deterministes, **TN**, classes STRUCTUREL grace au contexte `posterior`/`moyenne`/`variance`.
+- Posterieurs bayesiens en minutes (Infer-2 moyennes/variances de trajets) = donnees deterministes, **TN**, classes STRUCTUREL grace au contexte `posterior`/`moyenne`/`variance` — et depuis v8 par le **guard min-domaine** (fenetre elargie 120 + kws domaine `cluster`/`départ`/`fenêtre`), qui tient cette promesse la ou la fenetre 40 de la regle 1 echouait (mesure Infer-2 : 30/30 MACHINE-DEP = FP avant v8, 0 reel).
 
 CLI `--check` avec exit codes 0/1/2 distincts (succes / finding / usage).
 
@@ -76,6 +76,12 @@ _TIME_UNITS = (
     r"\b\d+\s*(?:ns|nanosecondes?)\b",
 )
 TIME_UNIT_RE = re.compile("|".join(_TIME_UNITS), re.IGNORECASE)
+
+# v8 (#9434): seule l'unite « min »/« minutes » est ambigue — c'est aussi
+# l'unite de VARIABLES MODELEES du domaine (durees de trajet bayesiennes
+# d'Infer-2), pas seulement du runtime. Extraite de _TIME_UNITS pour le
+# guard min-domaine (regle 4, _is_modeled_minute).
+MIN_UNIT_RE = re.compile(r"\b\d+\s*(?:min|minutes?)\b", re.IGNORECASE)
 
 # Regex strictes pour les versions (env-dep) — pattern semver simplifie.
 SEMVER_RE = re.compile(r"\b\d+\.\d+\.\d+(?:[a-zA-Z0-9._+-]*)?\b")
@@ -144,6 +150,27 @@ STRUCT_KEYWORDS = (
     # (FP : `temps d'apprentissage du modele: 42 s` = runtime). Le mot-composé
     # `inference bayesienne` reste, qui preserve la couverture Probas (20 fichiers).
     "inference bayesienne", "inférence bayésienne",
+)
+
+# v8 (#9434, c.b34166ee cycle 11): vocabulaire domaine ADDITIONNEL pour le
+# guard « min-domaine » UNIQUEMENT (regle 4, cf. _is_modeled_minute). Ces kws
+# ne vont PAS dans STRUCT_KEYWORDS (regle 1) : « cluster »/« départ » y
+# absorberaient des timings non-min (« le cluster de GPU répond en 200 ms »).
+# Ici ils ne s'appliquent qu'a une valeur portant l'unite « min »/« minutes »
+# SANS aucun kw runtime dans la fenetre elargie — double evidence.
+# Mesure Infer-2 (30/30 MACHINE-DEP = FP min-domaine) : « fenêtre optimale de
+# départ 14-18 min », « les deux clusters trouvés », tables de posteriors.
+MODELED_MINUTE_EXTRA_KEYWORDS = (
+    "cluster", "départ", "depart", "fenêtre", "fenetre",
+    "arrivée", "arrivee", "arriver", "arrivé", "retard", "avance",
+    "marge", "bruit", "observations", "observation", "distribution",
+    "commute",
+    # Formes mesurees cell 57/68 Infer-2 (tables markdown de posteriors) :
+    # vocabulaire de modelisation ABBREGE en table (« (3 obs) », « un seul
+    # mode », « melange (2 comp) ») ou specifique au corpus (« événements
+    # extraordinaires » = clusters nommes, mesure c.57 ET c.65).
+    "obs", "mode", "melange", "mélange",
+    "ordinaire", "événement", "evenement",
 )
 
 # v3 (c.1275): anti-FP Argument_Analysis — STRUCTURAL_LOCATIONS sont des
@@ -312,9 +339,39 @@ def _extract_context(text: str, match_start: int, match_end: int, window: int = 
     return prefix.lower(), suffix.lower()
 
 
+def _is_modeled_minute(
+    raw: str, prefix: str, suffix: str, wide_context: str = "",
+) -> bool:
+    """Guard « min-domaine » v8 (#9434) : l'unite « min » d'une variable modelee.
+
+    La regle 4 classe « 15,33 min » en MACHINE-DEP via TIME_UNIT_RE — faux pour
+    les durees de trajet bayesiennes (Infer-2 : 30/30 MACHINE-DEP = FP, 0 reel).
+    La regle 1 (STRUCT_KEYWORDS bayesiens : moyenne/trajet/posterior...) ne les
+    attrape pas toujours : fenetre 40 chars trop courte (« moyenne » hors
+    fenetre) ou kw hors voisinage immediat (« clusters » a 45+ chars d'une
+    table de resultats).
+
+    Double evidence (failure-mode safe — n'absorbe QUE vers STRUCTUREL) :
+    (a) la valeur porte l'unite min/minutes (pas ms/s/h, non ambigues) ;
+    (b) AUCUN kw runtime (_MACHINE_DEP_PATTERN) dans la fenetre elargie ;
+    (c) >=1 kw STRUCT/bayesien OU domaine (MODELED_MINUTE_EXTRA_KEYWORDS)
+        dans la fenetre elargie (120 chars, cf. scan loop).
+    Un vrai timing runtime « le run prend 15 min » reste MACHINE-DEP.
+    """
+    local_ctx = (prefix + " " + raw + " " + suffix).lower()
+    if not MIN_UNIT_RE.search(local_ctx):
+        return False
+    wide = (wide_context or local_ctx).lower()
+    if _MACHINE_DEP_PATTERN.search(wide):
+        return False
+    if any(kw in wide for kw in STRUCT_KEYWORDS):
+        return True
+    return any(kw in wide for kw in MODELED_MINUTE_EXTRA_KEYWORDS)
+
+
 def _classify_quant_value(
     raw: str, value: float, prefix: str, suffix: str,
-    seeded_upstream: bool = False,
+    seeded_upstream: bool = False, wide_context: str = "",
 ) -> tuple[str, str]:
     """Classifie une valeur quantitative selon le contexte. Renvoie (classe, rationale).
 
@@ -324,6 +381,7 @@ def _classify_quant_value(
     2. SEED dans prefix → bascule STOCHASTIQUE → STRUCTUREL
     3. ENV-DEP si pattern semver ou mot-cle env
     4. MACHINE-DEP si unite temporelle ou mot-cle machine-dep
+       (v8: SAUF unite « min » a double evidence domaine — cf. _is_modeled_minute)
     5. STOCHASTIQUE-NON-SEEDEE si mot-cle stochastique
        (sauf seeded_upstream: seed global posé en amont → STRUCTUREL)
     6. STRUCTUREL par defaut (classe residuelle surete)
@@ -459,6 +517,18 @@ def _classify_quant_value(
     #    structurel matche dans le contexte — `rung 42 ms` doit rester MACHINE-DEP
     #    runtime, pas STRUCTUREL). v2 (c.1272): data-list exempte.
     if not in_data_list and (TIME_UNIT_RE.search(raw) or TIME_UNIT_RE.search(prefix + suffix)):
+        # v8 (#9434, c.b34166ee cycle 11): guard « min-domaine ». L'unite
+        # « min »/« minutes » est ambigue : unite runtime MAIS aussi unite de
+        # variables modelisees du domaine (durees de trajet bayesiennes
+        # Infer-2 : « arriver en moins de 15 minutes », « cluster ordinaire
+        # 15,33 min », « ecart-type (2.15 min) pour 3 observations »). Mesure
+        # firsthand : Infer-2 30/30 MACHINE-DEP = FP min-domaine, 0 reel.
+        # Le docstring module (« Cas ambigus ») promettait STRUCTUREL via le
+        # contexte bayesien — la regle 1 ne tient pas la promesse (fenetre 40
+        # trop courte, kw hors voisinage). Ce guard la tient, a double
+        # evidence (cf. _is_modeled_minute), failure-mode safe.
+        if _is_modeled_minute(raw, prefix, suffix, wide_context):
+            return ("STRUCTUREL", "unité « min » = variable modélisée du domaine, pas runtime (guard min-domaine v8)")
         return ("MACHINE-DEP", f"unite temporelle detectee: {raw!r}")
 
     # 5. STRUCTURAL_LOCATIONS (c.1275) — anti-FP Argument_Analysis : mots-cles
@@ -563,7 +633,15 @@ def analyze_notebook_quant(path: str | os.PathLike) -> NotebookQuantClasses:
             if re.fullmatch(r"\d{4}", raw) and 1900 <= v <= 2099:
                 continue
             prefix, suffix = _extract_context(text, m.start(), m.end())
-            cls, rationale = _classify_quant_value(raw, v, prefix, suffix, seeded_upstream=seeded_upstream)
+            # v8: fenetre elargie 120 chars pour le guard min-domaine — la
+            # fenetre 40 de la regle 1 laisse « moyenne »/« clusters » hors
+            # champ des posteriors bayesiens en minutes (lecon c.4).
+            wide_prefix, wide_suffix = _extract_context(text, m.start(), m.end(), window=120)
+            wide_context = f"{wide_prefix} {raw} {wide_suffix}"
+            cls, rationale = _classify_quant_value(
+                raw, v, prefix, suffix,
+                seeded_upstream=seeded_upstream, wide_context=wide_context,
+            )
             # Tronque le snippet pour le rapport.
             snippet = text.strip().splitlines()
             snippet_str = next((ln.strip() for ln in snippet if ln.strip()), "")[:120]

--- a/scripts/notebook_tools/tests/test_scan_quant_classify.py
+++ b/scripts/notebook_tools/tests/test_scan_quant_classify.py
@@ -1320,3 +1320,129 @@ class TestV7SeedPropagation:
         assert acc[0].quant_class == "STRUCTUREL", (
             f"0.87 après torch.manual_seed = déterministe, got {acc[0].quant_class}"
         )
+
+# --------------------------------------------------------------------------- #
+#  v8 (#9434) : guard « min-domaine » — l'unite « min » d'une variable
+#  modelisee (duree de trajet bayesienne) n'est pas du runtime.
+#
+#  NB construction : le raw ne porte JAMAIS l'unite (le regex extrait le nombre
+#  seul). La regle 4 ne se declenche que si une AUTRE valeur-unite « N min »
+#  tombe dans la fenetre 40 du prefix+suffix (cas reel : tables de posteriors
+#  « 15,33 min ... 2,15 min »). Les tests ci-dessous reproduisent cette
+#  adjacence, sinon ils passeraient trivialement sans exercer le guard.
+# --------------------------------------------------------------------------- #
+
+
+class TestV8ModeledMinuteGuard:
+    """Infer-2 (mesure 2026-08-17) : 30/30 MACHINE-DEP etaient des FP min-domaine."""
+
+    def test_commute_arrival_absorbs(self):
+        """« arriver en moins de 15 minutes ... fenêtre de départ 14-18 min » (c23)."""
+        cls, rationale = _classify_quant_value(
+            "15", 15.0,
+            "probabilité d'arriver en moins de ",
+            " minutes, et une fenêtre de départ entre 14 et 18 min",
+            wide_context=("probabilité d'arriver en moins de 15 minutes, et une "
+                          "fenêtre de départ entre 14 et 18 min"),
+        )
+        assert cls == "STRUCTUREL", f"min-domaine doit etre absorbe, got {cls} ({rationale})"
+
+    def test_cluster_table_absorbs_beyond_40_chars(self):
+        """« 26,69 min » table de clusters (c65) : « clusters » a >40 chars -> seul
+        le wide window (120) le voit. La fenetre 40 ne porte AUCUN kw domaine."""
+        cls, rationale = _classify_quant_value(
+            "26,69", 26.69,
+            "dit « ordinaire » = ",
+            " et « extraordinaire » = 14,96 min. les deux c",
+            wide_context=("le modèle dit « ordinaire » = 26,69 min et « extraordinaire » "
+                          "= 14,96 min. les deux clusters trouvés"),
+        )
+        assert cls == "STRUCTUREL", f"clusters hors fenetre 40 = min-domaine, got {cls} ({rationale})"
+
+    def test_struct_kw_via_wide_absorbs(self):
+        """« moyenne » a >40 chars (lecon c.4) : STRUCT_KEYWORDS vu via wide window."""
+        cls, _ = _classify_quant_value(
+            "15,33", 15.33,
+            "estimation ponctuelle de ",
+            " min (contre 12,8 min pour le second mode)",
+            wide_context=("estimation ponctuelle de 15,33 min (contre 12,8 min pour le "
+                          "second mode), la moyenne postérieure du temps de trajet"),
+        )
+        assert cls == "STRUCTUREL", f"moyenne hors fenetre 40 doit etre vue en wide, got {cls}"
+
+    def test_falsification_runtime_kw_blocks_guard(self):
+        """Un kw runtime dans le wide BLOCKE l'absorption, « trajet » n'y change rien."""
+        cls, _ = _classify_quant_value(
+            "15", 15.0,
+            "le run complet prend ",
+            " minutes, soit 3 min de plus qu'avant",
+            wide_context=("le run complet prend 15 minutes, soit 3 min de plus "
+                          "qu'avant, sur ce trajet de traitement"),
+        )
+        assert cls == "MACHINE-DEP", f"« prend »/« run » runtime doit rester MACHINE-DEP, got {cls}"
+
+    def test_falsification_benchmark_min_stays(self):
+        """« benchmark ... 9 min » : runtime dans le wide -> MACHINE-DEP."""
+        cls, _ = _classify_quant_value(
+            "15", 15.0,
+            "benchmark total : ",
+            " minutes pour l'expérience (record : 9 min)",
+            wide_context="benchmark total : 15 minutes pour l'expérience (record : 9 min)",
+        )
+        assert cls == "MACHINE-DEP", f"benchmark min reste MACHINE-DEP, got {cls}"
+
+    def test_falsification_hours_unit_not_absorbed(self):
+        """Le guard ne s'applique qu'a « min » : « 1 h » avec « cluster » reste MD."""
+        cls, _ = _classify_quant_value(
+            "2", 2.0,
+            "l'entraînement complet a pris ",
+            " h (contre 1 h au cluster précédent)",
+            wide_context="l'entraînement complet a pris 2 h (contre 1 h au cluster de gpu)",
+        )
+        assert cls == "MACHINE-DEP", f"« cluster » ne doit pas absorber une unite h, got {cls}"
+
+    def test_falsification_no_domain_kw_stays(self):
+        """« vaut 15 min ici » : ni runtime ni domaine -> pas d'absorption."""
+        cls, _ = _classify_quant_value(
+            "15", 15.0,
+            "la valeur mesurée vaut ",
+            " min ici, contre 12 min la semaine dernière",
+            wide_context="la valeur mesurée vaut 15 min ici, contre 12 min la semaine dernière",
+        )
+        assert cls == "MACHINE-DEP", f"sans evidence double, pas d'absorption, got {cls}"
+
+
+class TestV8ModeledMinuteIntegration:
+    """Integration via analyze_notebook_quant : wide window a travers la boucle reelle."""
+
+    @staticmethod
+    def _write_nb(tmp_path, cells, name):
+        p = tmp_path / name
+        p.write_text(json.dumps({"cells": cells}), encoding="utf-8")
+        return analyze_notebook_quant(p)
+
+    def test_cluster_table_notebook_absorbs(self, tmp_path):
+        """Table de posteriors (c65) : fenetre 40 sans kw, « clusters » vu en wide."""
+        result = self._write_nb(tmp_path, [
+            {"cell_type": "markdown", "source": [
+                "Le modèle dit « ordinaire » = 26,69 min et « extraordinaire » = 14,96 min. "
+                "Les deux clusters trouvés séparent les trajets.\n"
+            ]},
+        ], "commute_table.ipynb")
+        machine_dep = [f for f in result.findings if f.quant_class == "MACHINE-DEP"]
+        assert machine_dep == [], (
+            f"table de clusters en min = min-domaine, got MD: {[(f.raw_match, f.rationale) for f in machine_dep]}"
+        )
+
+    def test_runtime_min_notebook_stays_machine_dep(self, tmp_path):
+        """Falsification end-to-end : un vrai pin runtime en minutes reste MACHINE-DEP."""
+        result = self._write_nb(tmp_path, [
+            {"cell_type": "markdown", "source": [
+                "Le tri s'exécute en 15 minutes sur ce corpus de 1000 éléments, "
+                "puis 9 min de sauvegarde.\n"
+            ]},
+        ], "runtime.ipynb")
+        machine_dep = [f for f in result.findings if f.quant_class == "MACHINE-DEP"]
+        assert len(machine_dep) >= 1, (
+            f"genuine runtime min doit rester MACHINE-DEP, got {result.by_class}"
+        )


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA — prev: MED/readme #11499

## Summary

Scanner **v8** de `scan_quant_classify.py` (post-merge #11490) : **guard « min-domaine »** — la 4ᵉ classe FP mesurée firsthand (cycle 11) sur le corpus réel.

**Mesure d'établissement** (avant tout code) : `Infer-2-Gaussian-Mixtures.ipynb` portait **30 MACHINE-DEP, tous FP min-domaine** — l'unité « min »/« minutes » y est celle de la **variable modélisée** (durées de trajet bayésiennes : « arriver en moins de 15 minutes », « fenêtre optimale de départ entre 14 et 18 min », « cluster ordinaire = 26,69 min », tables de posteriors `| simple (3 obs) | 15.33 min | 2.15 min |`). Le docstring module promettait STRUCTUREL « grâce au contexte posterior/moyenne/variance » — la règle 1 ne tient pas la promesse : fenêtre 40 chars trop courte (« moyenne » hors fenêtre — leçon c.4) ou kw abrégé/hors voisinage en table (« obs », « clusters » à 45+ chars).

**Résultat : Infer-2 30 MACHINE-DEP → 0** (580 STRUCTUREL, 3 STOCH inchangés).

## Le guard — double évidence, failure-mode safe

Absorbe vers STRUCTUREL UNIQUEMENT si (cf. `_is_modeled_minute`) :

1. la valeur porte l'unité **min/minutes** (pas `ms`/`s`/`h`, non ambiguës) ;
2. **AUCUN** kw runtime (`_MACHINE_DEP_PATTERN` : prend/run/benchmark/exécute…) dans la **fenêtre élargie 120** (nouveau paramètre `wide_context`, construit dans la scan loop) ;
3. ≥1 kw STRUCT/bayésien (`STRUCT_KEYWORDS` réutilisé) **OU** domaine (`MODELED_MINUTE_EXTRA_KEYWORDS`, guard-only : cluster/départ/fenêtre/arriver/retard/marge/bruit/distribution/obs/mode/mélange/ordinaire/événement — formes mesurées c.23/41/57/65/68).

Les kws extra ne vont PAS dans `STRUCT_KEYWORDS` (règle 1) : « cluster »/« mode » y absorberaient des timings non-min (« le cluster de GPU répond en 200 ms ») — ils ne s'appliquent qu'à l'unité min sans kw runtime.

## Validation

- **101/101 tests verts** (92 existants + 9 nouveaux : `TestV8ModeledMinuteGuard` 7 unitaires, `TestV8ModeledMinuteIntegration` 2 end-to-end).
- **Falsifications** (le guard ne sur-corrige pas) : « le run complet prend 15 minutes » reste MACHINE-DEP (runtime prioritaire, même avec « trajet » dans le wide) · « benchmark … (record : 9 min) » reste · unité `h` avec « cluster » pas absorbée · sans kw domaine, pas d'absorption.
- **Note construction des tests** : le raw ne porte jamais l'unité — la règle 4 ne se déclenche que si une AUTRE valeur-unité « N min » est dans la fenêtre 40 (cas réel des tables) ; les tests reproduisent cette adjacence.
- **Cross-famille inchangé** (mesuré après rebase) : Sudoku-18-Comparison 7 MD (unités `s`, transcriptions) · Sudoku-18b 1 MD · App-1-NQueens 2 MD · App-11-Picross 3 MD — **0 vrai timing runtime absorbé**.
- Rebase frais sur `origin/main` d3daeb9013 + suite re-passée post-rebase.

## Note honnête — demi-mission annulée par mesure

Le dispatch v8 mentionnait « random.seed dans GLOBAL_SEED_CALL_RE ». **Mesuré : `random.seed` y est déjà** (l.253-256 de v7) — le gap noté au cycle 5 était une mauvaise caractérisation (Sudoku-18b montre 0 STOCH, la propagation tient). Aucun changelog de ce côté : corriger un gap inexistant serait du bruit.

## Note G-VAR-1 (honnête)

Genre META (`guard`) MED (FP class mesurée + falsifications + corpus delta cross-famille — pas générable en scannant l'instance suivante). Le plancher CONTENU de la lane reste porté par #11476/#11482/#11485 (SC-4 PythonNet DEEP, App-14, Search-7) **en attente review ai-01** — la file review reste le goulot documenté (dashboard cycles 7-11).

See #9434
