### PR TITLE
fix(sudoku,#9434): drain Sudoku-18-Comparison wall-clock pin (69.5 s -> ordre de grandeur)

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
@@ -2005,7 +2005,7 @@
     "\n",
     "| Solveur | Variabilite | Explication |\n",
     "|---------|-------------|-------------|\n",
-    "| **Backtracking simple** | Très forte | Certains puzzles se resolvent en ~1 ms (Easy), d'autres depassent le timeout de 30 s (Medium : 69.5 s de recherche avant abandon) |\n",
+    "| **Backtracking simple** | Très forte | Certains puzzles se resolvent en ~1 ms (Easy), d'autres depassent le timeout de 30 s (Medium : plus d'une minute de recherche avant abandon) |\n",
     "| **BT + MRV** | Forte | L'heuristique reduit l'arbre mais reste sensible a la structure du puzzle |\n",
     "| **Norvig** | Très faible | La propagation elimine la plupart de l'alea, temps quasi-constant |\n",
     "| **OR-Tools CP-SAT** | Negligeable | Le solveur industriel est optimise pour des performances predictibles |\n",

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
@@ -36,6 +36,12 @@
       csharp_sha: 616510b87ff6246b70d595aa5dd363969e6b0046
       content_python_sha: b24e597909224241c47cd87b2a7bcd5874553e8695802ffed4e935bd5dc30bd0
       content_csharp_sha: 089e5e138c54fa84e639ce073f7e60435e42b3562e4448400a09c618cd1a758e
+    - date: "2026-08-17"
+      by: myia-po-2024:CoursIA
+      python_sha: 3290e802a2543319399e78f1c8e0cea2263a50be
+      csharp_sha: 616510b87ff6246b70d595aa5dd363969e6b0046
+      content_python_sha: 47d504e5628e7622d08fb293af1e916fde84fde4b179aae185bcba38d4cd28f0
+      content_csharp_sha: 089e5e138c54fa84e639ce073f7e60435e42b3562e4448400a09c618cd1a758e
   known_differences:
     - "Rebaseline 2026-08-14 : DEUX cotes deplaces par drain wallclock #9434 / PR #10874 (remplacement des timings machine-dependants en ms par des ordres de grandeur dans 2 cellules markdown par cote). Parite semantique inchangee (cellules code byte-identiques, aucune sortie, aucun exec_count touche). Attestations = nouveaux blob SHAs des deux cotes."
     - "Rebaseline 2026-08-05 : cote Python deplace par de-hardcodage de la version numpy depuis le markdown (classe ENV #9434, edition markdown-only). Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote C# non modifie. Attestation = nouveau blob SHA du cote Python."


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11506

## Summary

Drain du **seul pin machine-dep réel** résiduel de Sudoku-18-Comparison-Python (issue #9434), isolé par triage firsthand de la famille Sudoku entière sous le scanner v8.

**Edit (markdown-only, C.3 exempt)** — cell 43, table « Variabilite et previsibilite » :

> `Medium : 69.5 s de recherche avant abandon` → `Medium : plus d'une minute de recherche avant abandon`

Convention #10152/#10976 (ordre de grandeur). Le `69.5 s` est une mesure wall-clock brute (temps de recherche backtracking), **absente des outputs commités** — claim prose non reproductible, donc drain. Le `30 s` voisin reste : timeout configuré = domain quantity (précédent #10206), et se reclasse STRUCTUREL post-édition.

## Triage firsthand de la famille Sudoku sous v8 (contexte)

| Notebook | MD v8 | Réels | Résiduel = FP |
|---|---|---|---|
| Sudoku-18-Comparison-Python | 7 | **1** (celui drainé) | 5 : comptes protocole (« 1 puzzle/niveau », « 5 solveurs/4 originaux ») + illustration hypothétique (« 99.9 %/0.1 %/1 ms » de la leçon pratique) |
| Sudoku-18-Comparison-Csharp | 6 | 0 | mêmes classes FP, pas de pin miroir |
| Sudoku-2-DancingLinks-Python | 17 | 0 | c32 auto-documenté (« ordres de grandeur indicatifs issus de leurs notebooks respectifs ») + c17 déjà drainé (« ms live -- regle #9434 ») + déco liste |
| Sudoku-15-Infer-Csharp | 9 | 2 | ** déjà couverts par PR #11440 (collision guard L898 a évité le doublon) ** |
| Sudoku-17-LLM-Python | 21 | ~0 ferme | cluster latences LLM déjà `~`-préfixées (~1.4 s, ~4.2 s) — jugement ouvert, cf. commentaire #9434 |
| Sudoku-4-Annealing | 8 | 0 | refs de cellules, hyperparamètres SA (t0=1.0, alpha=0.999), comptes |

## Validation

- Scanner v8 sur le notebook édité : **7 MD → 5 MD** (les 5 résiduels = FP caractérisés, cf. tableau).
- Code cells byte-identiques (1 ligne markdown changée, diff 1+/1−).
- Twin parity : `check_twin_parity.py` → **OK=157 DRIFT=0** après rebaseline de la paire (2e commit, audit line `2026-08-17 myia-po-2024:CoursIA`).
- Pre-commit H.3 Passed (markdown-only).
- Catalogue byte-identique à main.

See #9434
