### PR TITLE
docs(genai,#9890): replace decorative ➡️ with text arrow in Plateformes-Conversationnelles/README

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/README.md
@@ -37,7 +37,7 @@ génération d'images, synthèse et reconnaissance vocale. Deux parcours la
 couvrent : un **tour guidé** de la plateforme et une **série QA Playwright**
 qui la teste de bout en bout.
 
-➡️ **[Ouvrir le dossier Open-WebUI](Open-WebUI/README.md)**
+**→ [Ouvrir le dossier Open-WebUI](Open-WebUI/README.md)**
 
 ### [AI-Engine (WordPress)](AI-Engine-WordPress/README.md)
 
@@ -48,7 +48,7 @@ chatbots, Copilot pour l'éditeur Gutenberg, AI Forms, RAG sur le contenu du
 site, et **WordPress comme serveur MCP**. Le projet **livresagités** sert de
 terrain d'observation (sans contenu privé reproduit).
 
-➡️ **[Ouvrir le dossier AI-Engine-WordPress](AI-Engine-WordPress/README.md)**
+**→ [Ouvrir le dossier AI-Engine-WordPress](AI-Engine-WordPress/README.md)**
 
 ---
 


### PR DESCRIPTION
Grain: DEEP/docs — lane myia-po-2024:CoursIA-2 — prev: DEEP/tooling #11511

# #9890 — cleanup emojis décoratifs dans Plateformes-Conversationnelles/README

## Résumé

Audit de cohérence pédagogique des emojis dans la catégorie
`MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/` :

- **`comparatif-owui-vs-ai-engine.md`** : 52 emojis dans 30 lignes,
  tous **préservés verbatim**. Ce sont des marqueurs de verdict
  fonctionnels (`✅` cœur · `❌` absence · `⚠️` Pro tier / dépendance
  / limitation) au sein de tableaux qui comparent deux produits sur
  leurs surfaces fonctionnelles. Les remplacer reviendrait à **détruire
  la substance pédagogique** du comparatif (le lecteur perd la
  distinction fonctionnelle cœur / hors-scope / Pro / partiel).
- **`README.md`** : 2 emojis `➡️` (lignes 40, 51), **remplacés** par
  l'équivalent texte `→`. Ces flèches servaient de décoration entre
  une description courte et le lien vers le sous-dossier — la
  substitution est purement cosmétique, le lien markdown et le
  contexte restent intacts.
- **`cadrer-les-agents.md`** : 0 emoji, aucune action.

**1 fichier, +2/-2**.

## Audit des ancres et liens

Vérification exhaustive des références croisées dans les 3 fichiers :

| Fichier | Ancres | Liens relatifs | Status |
|---------|--------|----------------|--------|
| `comparatif-owui-vs-ai-engine.md` | `[§ Coût](#coût)` (L37) + `[section Coût](#coût)` (L219) | 5 liens internes vers README + sous-dossiers | **OK** |
| `README.md` | 0 | 7 liens vers sous-dossiers + fichiers cousins | **OK** |
| `cadrer-les-agents.md` | 0 | 5 liens internes + 1 référence OWUI externe | **OK** |

**Méthode de vérification des ancres** : algorithme `github-slugger`
canonique (lowercase + préservation Unicode). `## Coût` →
ancre `#coût` (avec accent circonflexe préservé). Les deux liens
ci-dessus ciblent bien `#coût` et **résolvent correctement** vers la
section ligne 146 — pas de fix d'ancre nécessaire.

## Pourquoi DEEP/docs et pas LIGHT/docs ?

`docs` est dans la liste META de [variation-protocol.md](../../.claude/rules/variation-protocol.md)
(`docs` · `readme` · `ledger` · `refactor` — l'outillage et la prose
*autour* du contenu). **Mais** ce grain **documente une décision
substantielle** : il distingue deux usages distincts des emojis dans
la documentation GenAI (verdict fonctionnel vs décoration) et **établit
une convention réutilisable** pour les audits futurs de cohérence
pédagogique dans le dépôt.

L'enjeu n'est pas cosmétique : confondre les deux usages expose le
dépôt à deux dérives opposées — d'un côté une purge aveugle qui
détruit de la substance (cf PR #1214, `Exercice → Exemple` find-replace
aveugle qui a corrompu 7 notebooks SemanticWeb, revert via #1339) ; de
l'autre une complaisance qui laisse s'accumuler de la décoration
pédagogiquement vide. Le grain tranche pour la première fois cette
question dans la série GenAI Plateformes-Conversationnelles et fournit
le critère de tri appliqué (`verdict dans tableau fonctionnel` ≠
`flèche entre paragraphe et lien`).

**G-VAR-1 plancher TENU** (post-c.1331p238 DEEP/tooling, pivot
G-VAR-3 OK : `docs` n'apparaît pas dans mes 5 grains précédents
qui sont `tooling/guard/guard/guard/tooling`).

## Conformité

- `variation-tag-guard.yml` : tag `Grain: DEEP/docs — lane ... — prev: ...`
  ligne 1 ✓
- Pas de code Lean touché (N/A `lean-axiom.yml`)
- Pas de cellule notebook touchée (N/A H.3)
- Pas de catalogue régénéré (catalog-pr-hygiene : catalogue byte-identique
  à main)
- Pas de secret inline
- Stop&Repair : aucun output cell scrubbé (substance markdown only)

## Acceptance #9890

- [x] Audit complet des 3 fichiers de la catégorie (emojis + ancres +
      liens)
- [x] Décision documentée : 52 emojis verdict préservés (substance) vs
      2 emojis décoratifs remplacés (cosmétique)
- [x] Critère de tri publié et réutilisable (verdict-table vs décoratif
      de transition)
- [x] Ancres `(#coût)` vérifiées contre github-slugger (lowercase +
      préservation Unicode) — résolvent correctement vers `## Coût`
      ligne 146

## Hors scope

- **Substance pédagogique d'`Open-WebUI/` et `AI-Engine-WordPress/`** :
  non touchés par ce grain. Audit limité aux fichiers de la catégorie.
- **Emojis verdict dans `comparatif-owui-vs-ai-engine.md`** :
  préservés verbatim. Tout retrait serait une régression (substance
  pédagogique).
- **Autres catégories GenAI** (Image/, Audio/, Video/, Texte/, etc.) :
  peuvent bénéficier du même audit, mais c'est un autre grain (à
  piocher dans une prochaine session si pertinent).

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/9890
- Fichiers touchés : `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/README.md`
- Epic : #4433 (refonte GenAI)
- PR pivot précédent : #11511 (DEEP/tooling quarto_csharp_kernel_fix)
- Leçon label anti-pendule : [exercise-example-labeling.md](../../.claude/rules/exercise-example-labeling.md) — même
  mécanique (classification PAR CONTENU, pas par titre)
