### PR TITLE
fix(slides,#11508): budget de hauteur partagé pour les images S3 — 11 débordements → 7

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -104,7 +104,7 @@ layout: section
 - Théorie du contrôle
 - Linguistique
 
-<img src="./images/img_005.png" class="absolute top-[193px] right-[20px] w-[460px]" alt="Qu'est-ce que l'intelligence artificielle?" />
+<img src="./images/img_005.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Qu'est-ce que l'intelligence artificielle?" />
 ---
 layout: two-cols
 ---
@@ -207,7 +207,7 @@ layout: two-cols
 - Limitations
   - ressources disponibles
 
-<img src="./images/img_009.png" class="absolute top-[203px] right-[20px] w-[460px]" alt="Les agents" />
+<img src="./images/img_009.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Les agents" />
 ---
 layout: two-cols
 ---
@@ -267,7 +267,7 @@ layout: section
 
 - Flexibilité vs complexité
 
-<img src="./images/img_012.png" class="absolute top-[239px] right-[20px] w-[460px]" alt="Agent réflexe fondé sur un modèle" />
+<img src="./images/img_012.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Agent réflexe fondé sur un modèle" />
 ---
 
 
@@ -841,8 +841,10 @@ layout: two-cols
   - W3C
   - Linked Data
 
-<img src="./images/img_048.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Autres Applications (1/2)" />
-<img src="./images/img_049.png" class="absolute top-[437px] right-[20px] w-[460px]" alt="Autres Applications (1/2)" />
+<div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
+<img src="./images/img_048.png" class="w-full object-contain" alt="Autres Applications (1/2)" />
+<img src="./images/img_049.png" class="w-full object-contain" alt="Autres Applications (1/2)" />
+</div>
 
 <!-- Exemples : triplets RDF (sujet-predicat-objet), ontologies OWL, SPARQL -->
 ---
@@ -1359,8 +1361,10 @@ layout: two-cols
   - d'ensemble
   - Boosting
 
-<img src="./images/img_083.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Caractéristiques (2/2)" />
-<img src="./images/img_084.png" class="absolute top-[530px] right-[20px] w-[460px]" alt="Caractéristiques (2/2)" />
+<div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
+<img src="./images/img_083.png" class="w-full object-contain" alt="Caractéristiques (2/2)" />
+<img src="./images/img_084.png" class="w-full object-contain" alt="Caractéristiques (2/2)" />
+</div>
 ---
 
 
@@ -1578,8 +1582,10 @@ layout: two-cols
   - Knowledge Based Inductive Learning
 - Programmation logique inductive (Prolog)
 
-<img src="./images/img_118.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Apprentissage et connaissances" />
-<img src="./images/img_119.png" class="absolute top-[441px] right-[20px] w-[460px]" alt="Apprentissage et connaissances" />
+<div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
+<img src="./images/img_118.png" class="w-full object-contain" alt="Apprentissage et connaissances" />
+<img src="./images/img_119.png" class="w-full object-contain" alt="Apprentissage et connaissances" />
+</div>
 ---
 
 
@@ -1603,8 +1609,10 @@ layout: two-cols
   - Modèles paramétriques
   - Deep Q-learning
 
-<img src="./images/img_120.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Apprentissage par renforcement" />
-<img src="./images/img_121.png" class="absolute top-[384px] right-[20px] w-[460px]" alt="Apprentissage par renforcement" />
+<div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
+<img src="./images/img_120.png" class="w-full object-contain" alt="Apprentissage par renforcement" />
+<img src="./images/img_121.png" class="w-full object-contain" alt="Apprentissage par renforcement" />
+</div>
 ---
 layout: section
 ---
@@ -1752,9 +1760,11 @@ layout: two-cols
   - Bootstrap
   - Entraînement en ligne
 
-<img src="./images/img_131.png" class="absolute top-[110px] right-[20px] w-[460px]" alt="Agents conversationnels" />
-<img src="./images/img_132.png" class="absolute top-[353px] right-[20px] w-[460px]" alt="Agents conversationnels" />
-<img src="./images/img_133.png" class="absolute top-[669px] right-[20px] w-[460px]" alt="Agents conversationnels" />
+<div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
+<img src="./images/img_131.png" class="w-full object-contain" alt="Agents conversationnels" />
+<img src="./images/img_132.png" class="w-full object-contain" alt="Agents conversationnels" />
+<img src="./images/img_133.png" class="w-full object-contain" alt="Agents conversationnels" />
+</div>
 ---
 layout: two-cols
 ---

--- a/slides/theme-ia101/styles/index.css
+++ b/slides/theme-ia101/styles/index.css
@@ -327,3 +327,81 @@ a {
   letter-spacing: 0.05em;
   z-index: 10;
 }
+
+/* ------------------------------------------------------------------ */
+/* Grilles d'images heritees du port Marp                              */
+/*                                                                     */
+/* `img-grid` / `img-grid-2x2` etaient utilisees dans le markdown sans  */
+/* jamais avoir ete definies : les images tombaient en flux vertical,   */
+/* chacune jusqu'a `max-h-[300px]`, dans un canvas qui fait 552px de    */
+/* haut. Deux images empilees suffisaient donc a sortir de la slide,    */
+/* et au-dela de trois les suivantes etaient purement invisibles.       */
+/*                                                                     */
+/* La grille donne aux images un budget de hauteur PARTAGE, au lieu     */
+/* d'un plafond individuel qui ne borne rien collectivement.            */
+/* ------------------------------------------------------------------ */
+
+.img-grid,
+.img-grid-2x2 {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-auto-rows: minmax(0, 1fr);
+  align-items: center;
+  justify-items: center;
+  gap: 8px;
+}
+
+/* Conteneur positionne : `top` est declare inline dans la slide, `bottom`
+   ferme la boite — la hauteur se deduit et s'adapte a chaque slide. */
+.img-grid.absolute,
+.img-grid-2x2.absolute {
+  bottom: 40px;
+}
+
+/* Conteneur en flux : budget fixe, sous le bloc de texte. */
+.img-grid:not(.absolute),
+.img-grid-2x2:not(.absolute) {
+  height: 300px;
+}
+
+/* Specificite (0,1,1) : l'emporte sur les utilitaires `max-h-[300px]` et
+   `w-[150px]` poses inline, qui datent du port et ne bornent que l'image
+   prise isolement. */
+.img-grid > img,
+.img-grid-2x2 > img {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+/* ------------------------------------------------------------------ */
+/* Pile d'images pleine largeur                                        */
+/*                                                                     */
+/* Meme cause, autre symptome : le port avait recopie les coordonnees   */
+/* absolues du PPTX (repere de 720px de haut) dans un canvas Slidev de  */
+/* 552px. Un `top-[530px]` posait une image a 22px du bas, et un        */
+/* `top-[669px]` la placait entierement hors champ.                     */
+/* ------------------------------------------------------------------ */
+
+.img-stack {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-auto-rows: minmax(0, 1fr);
+  align-items: center;
+  justify-items: center;
+  gap: 8px;
+}
+
+.img-stack.absolute {
+  bottom: 40px;
+}
+
+.img-stack > img {
+  width: 100%;
+  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}


### PR DESCRIPTION
Grain: MED/slides — lane myia-ai-01:CoursIA — prev: MED/slides #11505

Premier grain de l'Epic #11508. Correctif **systémique** du débordement par le
bas dans `S3-acculturation` : deux règles CSS dans le thème partagé, et cinq
réécritures mécaniques dans le markdown. Aucune retouche slide par slide.

## La cause, qui n'est pas celle qu'on croyait

Le diagnostic qui circulait — « une colonne d'images empilées sans budget de
hauteur » — décrivait le symptôme. La cause est plus bête et plus complète :

**`img-grid` et `img-grid-2x2` n'ont jamais été définies.** Les noms de classe
viennent du port Marp ; la règle correspondante n'a pas suivi. Les 21 conteneurs
qui les portent dans `slides.md` n'ont donc **aucune** mise en forme : les images
tombent en flux vertical, chacune jusqu'à son `max-h-[300px]` inline.

Le canvas Slidev fait **552 px** de haut. Deux images empilées suffisent donc à
sortir de la slide ; au-delà de trois, les suivantes sont purement invisibles.
`max-h-[300px]` est un plafond **par image** — il ne borne rien collectivement,
et c'est exactement ce que le port a cru poser.

**Deuxième famille, même racine.** Cinq slides n'utilisent pas `img-grid` mais
des `<img class="absolute top-[Npx]">` aux coordonnées **codées en dur**,
recopiées du repère PPTX (720 px de haut) dans un canvas qui en fait 552. D'où
un `top-[530px]` qui pose une image à 22 px du bas — et, sur la slide 65, un
`top-[669px]` qui la plaçait **entièrement hors champ**.

## Le correctif

`theme-ia101/styles/index.css`, deux règles :

- **`.img-grid` / `.img-grid-2x2`** — grille `auto-fit` qui donne aux images un
  budget de hauteur **partagé** au lieu d'un plafond individuel. Les conteneurs
  en `absolute` reçoivent `bottom: 40px` : `top` étant déclaré inline slide par
  slide, la hauteur se déduit et s'adapte d'elle-même.
- **`.img-stack`** — variante à une colonne pour les images pleine largeur.

La sélection `.img-grid > img` a une spécificité (0,1,1) : elle l'emporte sur les
utilitaires `max-h-[300px]` / `w-[150px]` posés inline par le port, sans qu'il
faille les retirer un par un ni recourir à `!important`.

`slides.md` : les 5 groupes d'images à coordonnées en dur (11 images) sont
enveloppés dans un `.img-stack`, ce qui **supprime les coordonnées** au lieu de
les corriger — un `top` recalculé à la main redeviendrait faux au premier
changement de canvas.

## Mesure

Débordement par le bas mesuré automatiquement sur les 82 rendus PNG (encre dans
les 6 dernières lignes de pixels, hors fond de page et hors fond sombre de
section), avant et après, sur la même base `main` :

| | slides en débordement |
|---|---|
| `main` | **11** |
| avec ce correctif | **7** |
| résorbées | 4 (31, 49, 59, 65) |
| nouvelles | **0** |

**Et un second chiffre, qui compte davantage.** Appliqué par-dessus #11505, le
même correctif fait passer le deck de **13 à 4**, soit 9 résorbées. L'écart n'est
pas une contradiction, c'est le mécanisme :

sur `main` aujourd'hui, les images des slides `img-grid` **ne sont pas rendues** —
elles s'affichent en **texte littéral** (`![](./images/img_114.png)`) au milieu de
la slide, vestige des hints Marp que #11505 convertit. Une image non rendue ne
déborde pas. Le débordement de ces cinq slides n'apparaît qu'une fois #11505
mergée, et ce correctif-ci l'attend déjà.

Autrement dit : sur `main` seul, la règle `.img-stack` fait le travail visible ;
la règle `.img-grid` est posée d'avance pour le jour où les images existeront.

## Vérification visuelle

Les slides corrigées ont été relues **au rendu**, pas au source :

- **65** — les *trois* images sont maintenant visibles et cadrées. La troisième
  (`top-[669px]`) ne l'était pas du tout. C'est du contenu **récupéré**.
- **57** — les quatre images tiennent dans une grille 2×2. Avant : deux
  invisibles, une qui sortait franchement du cadre.
- **49**, **31**, **59** — la deuxième image, qui mordait sur le bas, est cadrée.

## Une note sur l'instrument

Le détecteur d'encre a un faux positif connu et assumé : la **slide 1**, dont le
fond en dégradé gris clair n'est pas du blanc pur et se compte donc comme de
l'encre. Vérifiée à l'œil, la couverture est propre. Elle est comptée dans les 13
« avant » comme dans les 4 « après » — donc neutre au bilan, mais il vaut mieux
l'écrire que de laisser croire à un défaut résiduel de plus.

## Portée

Les 15 decks Slidev du dépôt utilisent `theme-ia101`, mais seul
`S3-acculturation` emploie `img-grid` aujourd'hui. La règle ne change donc rien
ailleurs **à cette heure** — et couvre d'avance les decks qui seront portés
depuis Marp, où le même nom de classe réapparaîtra.

## G-VAR-3

Deuxième grain `slides` consécutif sur cette lane, tous deux MED et de classe
CONTENU. Substances distinctes : #11505 retirait des visuels hors-sujet et
réparait les hints Marp ; celui-ci pose un budget de hauteur. Rien de commun,
au-delà du deck.

See #11508
