### PR TITLE
fix(genai,#11513): replace deprecated ipywidgets on_submit + stop traceback leak

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/Créateur de mail personnalisé.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/Créateur de mail personnalisé.ipynb
@@ -6,16 +6,16 @@
    "id": "970c138c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:00.561867Z",
-     "iopub.status.busy": "2026-08-17T10:28:00.561454Z",
-     "iopub.status.idle": "2026-08-17T10:28:00.564768Z",
-     "shell.execute_reply": "2026-08-17T10:28:00.564255Z"
+     "iopub.execute_input": "2026-08-17T20:05:31.995335Z",
+     "iopub.status.busy": "2026-08-17T20:05:31.995152Z",
+     "iopub.status.idle": "2026-08-17T20:05:31.999070Z",
+     "shell.execute_reply": "2026-08-17T20:05:31.998373Z"
     },
     "papermill": {
-     "duration": 0.0086,
-     "end_time": "2026-08-17T10:28:00.565563",
+     "duration": 0.011367,
+     "end_time": "2026-08-17T20:05:32.001866+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:00.556963",
+     "start_time": "2026-08-17T20:05:31.990499+00:00",
      "status": "completed"
     },
     "tags": [
@@ -33,10 +33,10 @@
    "id": "2ca13c49",
    "metadata": {
     "papermill": {
-     "duration": 0.004251,
-     "end_time": "2026-08-17T10:28:00.573295",
+     "duration": 0.00307,
+     "end_time": "2026-08-17T20:05:32.008628+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:00.569044",
+     "start_time": "2026-08-17T20:05:32.005558+00:00",
      "status": "completed"
     },
     "tags": []
@@ -58,10 +58,10 @@
    "metadata": {
     "id": "529b9028-f72c-485b-904c-b83190f3ed60",
     "papermill": {
-     "duration": 0.003044,
-     "end_time": "2026-08-17T10:28:00.580000",
+     "duration": 0.003253,
+     "end_time": "2026-08-17T20:05:32.014976+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:00.576956",
+     "start_time": "2026-08-17T20:05:32.011723+00:00",
      "status": "completed"
     },
     "tags": []
@@ -87,10 +87,10 @@
      "base_uri": "https://localhost:8080/"
     },
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:00.587108Z",
-     "iopub.status.busy": "2026-08-17T10:28:00.586898Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.030085Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.029491Z"
+     "iopub.execute_input": "2026-08-17T20:05:32.023398Z",
+     "iopub.status.busy": "2026-08-17T20:05:32.023198Z",
+     "iopub.status.idle": "2026-08-17T20:05:35.800453Z",
+     "shell.execute_reply": "2026-08-17T20:05:35.799840Z"
     },
     "executionInfo": {
      "elapsed": 3647,
@@ -105,10 +105,10 @@
     "id": "1619b339-9b57-4dd0-b7e3-8767cb02fb33",
     "outputId": "84d401a0-370c-4278-c895-a379af1c48b3",
     "papermill": {
-     "duration": 2.447947,
-     "end_time": "2026-08-17T10:28:03.030956",
+     "duration": 3.782658,
+     "end_time": "2026-08-17T20:05:35.801060+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:00.583009",
+     "start_time": "2026-08-17T20:05:32.018402+00:00",
      "status": "completed"
     },
     "tags": []
@@ -117,7 +117,7 @@
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
      "execution_count": 2,
@@ -180,10 +180,10 @@
    "id": "m8uwi4o9ll",
    "metadata": {
     "papermill": {
-     "duration": 0.002968,
-     "end_time": "2026-08-17T10:28:03.037013",
+     "duration": 0.003495,
+     "end_time": "2026-08-17T20:05:35.808381+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.034045",
+     "start_time": "2026-08-17T20:05:35.804886+00:00",
      "status": "completed"
     },
     "tags": []
@@ -206,10 +206,10 @@
    "metadata": {
     "id": "de963672",
     "papermill": {
-     "duration": 0.002752,
-     "end_time": "2026-08-17T10:28:03.043125",
+     "duration": 0.00349,
+     "end_time": "2026-08-17T20:05:35.815418+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.040373",
+     "start_time": "2026-08-17T20:05:35.811928+00:00",
      "status": "completed"
     },
     "tags": []
@@ -230,10 +230,10 @@
    "id": "e1887fe5-9b45-4fe5-a219-8be2f9c23e09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.051454Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.050770Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.059775Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.059081Z"
+     "iopub.execute_input": "2026-08-17T20:05:35.824662Z",
+     "iopub.status.busy": "2026-08-17T20:05:35.824331Z",
+     "iopub.status.idle": "2026-08-17T20:05:35.833405Z",
+     "shell.execute_reply": "2026-08-17T20:05:35.832791Z"
     },
     "executionInfo": {
      "elapsed": 4,
@@ -247,10 +247,10 @@
     },
     "id": "e1887fe5-9b45-4fe5-a219-8be2f9c23e09",
     "papermill": {
-     "duration": 0.014848,
-     "end_time": "2026-08-17T10:28:03.061135",
+     "duration": 0.014864,
+     "end_time": "2026-08-17T20:05:35.834153+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.046287",
+     "start_time": "2026-08-17T20:05:35.819289+00:00",
      "status": "completed"
     },
     "tags": []
@@ -318,10 +318,10 @@
    "id": "3124e1ba",
    "metadata": {
     "papermill": {
-     "duration": 0.004798,
-     "end_time": "2026-08-17T10:28:03.070951",
+     "duration": 0.003533,
+     "end_time": "2026-08-17T20:05:35.841348+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.066153",
+     "start_time": "2026-08-17T20:05:35.837815+00:00",
      "status": "completed"
     },
     "tags": []
@@ -346,16 +346,16 @@
    "id": "3c5bd899",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.082054Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.081852Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.086282Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.085713Z"
+     "iopub.execute_input": "2026-08-17T20:05:35.850052Z",
+     "iopub.status.busy": "2026-08-17T20:05:35.849767Z",
+     "iopub.status.idle": "2026-08-17T20:05:35.854396Z",
+     "shell.execute_reply": "2026-08-17T20:05:35.853760Z"
     },
     "papermill": {
-     "duration": 0.011759,
-     "end_time": "2026-08-17T10:28:03.087687",
+     "duration": 0.01001,
+     "end_time": "2026-08-17T20:05:35.854945+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.075928",
+     "start_time": "2026-08-17T20:05:35.844935+00:00",
      "status": "completed"
     },
     "tags": []
@@ -393,10 +393,10 @@
    "metadata": {
     "id": "29e7ab58-3a7f-43b9-acea-c70c96e5f2e8",
     "papermill": {
-     "duration": 0.005134,
-     "end_time": "2026-08-17T10:28:03.097422",
+     "duration": 0.003687,
+     "end_time": "2026-08-17T20:05:35.862384+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.092288",
+     "start_time": "2026-08-17T20:05:35.858697+00:00",
      "status": "completed"
     },
     "tags": []
@@ -419,10 +419,10 @@
    "id": "3bec519f-5af8-427e-b8d0-7fa5a24fba55",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.108214Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.107987Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.116133Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.115638Z"
+     "iopub.execute_input": "2026-08-17T20:05:35.872562Z",
+     "iopub.status.busy": "2026-08-17T20:05:35.872343Z",
+     "iopub.status.idle": "2026-08-17T20:05:35.881618Z",
+     "shell.execute_reply": "2026-08-17T20:05:35.881028Z"
     },
     "executionInfo": {
      "elapsed": 2,
@@ -436,10 +436,10 @@
     },
     "id": "3bec519f-5af8-427e-b8d0-7fa5a24fba55",
     "papermill": {
-     "duration": 0.015116,
-     "end_time": "2026-08-17T10:28:03.117188",
+     "duration": 0.014799,
+     "end_time": "2026-08-17T20:05:35.882256+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.102072",
+     "start_time": "2026-08-17T20:05:35.867457+00:00",
      "status": "completed"
     },
     "tags": []
@@ -567,10 +567,10 @@
    "id": "596c19ae",
    "metadata": {
     "papermill": {
-     "duration": 0.00315,
-     "end_time": "2026-08-17T10:28:03.123443",
+     "duration": 0.003758,
+     "end_time": "2026-08-17T20:05:35.889727+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.120293",
+     "start_time": "2026-08-17T20:05:35.885969+00:00",
      "status": "completed"
     },
     "tags": []
@@ -595,16 +595,16 @@
    "id": "bb110d17",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.151610Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.151110Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.160560Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.159276Z"
+     "iopub.execute_input": "2026-08-17T20:05:35.900266Z",
+     "iopub.status.busy": "2026-08-17T20:05:35.900017Z",
+     "iopub.status.idle": "2026-08-17T20:05:35.904265Z",
+     "shell.execute_reply": "2026-08-17T20:05:35.903653Z"
     },
     "papermill": {
-     "duration": 0.027673,
-     "end_time": "2026-08-17T10:28:03.162433",
+     "duration": 0.010213,
+     "end_time": "2026-08-17T20:05:35.905273+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.134760",
+     "start_time": "2026-08-17T20:05:35.895060+00:00",
      "status": "completed"
     },
     "tags": []
@@ -663,10 +663,10 @@
    "metadata": {
     "id": "j-inUMDy4qxt",
     "papermill": {
-     "duration": 0.006753,
-     "end_time": "2026-08-17T10:28:03.176752",
+     "duration": 0.003832,
+     "end_time": "2026-08-17T20:05:35.912865+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.169999",
+     "start_time": "2026-08-17T20:05:35.909033+00:00",
      "status": "completed"
     },
     "tags": []
@@ -687,10 +687,10 @@
    "id": "6f18175f-bd71-40eb-a4c2-9cd9753d6fc5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.186962Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.186564Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.193584Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.192819Z"
+     "iopub.execute_input": "2026-08-17T20:05:35.922081Z",
+     "iopub.status.busy": "2026-08-17T20:05:35.921845Z",
+     "iopub.status.idle": "2026-08-17T20:05:35.927352Z",
+     "shell.execute_reply": "2026-08-17T20:05:35.926688Z"
     },
     "executionInfo": {
      "elapsed": 3,
@@ -704,10 +704,10 @@
     },
     "id": "6f18175f-bd71-40eb-a4c2-9cd9753d6fc5",
     "papermill": {
-     "duration": 0.013035,
-     "end_time": "2026-08-17T10:28:03.194853",
+     "duration": 0.011241,
+     "end_time": "2026-08-17T20:05:35.927950+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.181818",
+     "start_time": "2026-08-17T20:05:35.916709+00:00",
      "status": "completed"
     },
     "tags": []
@@ -767,10 +767,10 @@
    "id": "d381eb8a",
    "metadata": {
     "papermill": {
-     "duration": 0.005898,
-     "end_time": "2026-08-17T10:28:03.205077",
+     "duration": 0.004017,
+     "end_time": "2026-08-17T20:05:35.936005+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.199179",
+     "start_time": "2026-08-17T20:05:35.931988+00:00",
      "status": "completed"
     },
     "tags": []
@@ -795,16 +795,16 @@
    "id": "874b7aec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.216587Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.216370Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.220222Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.219613Z"
+     "iopub.execute_input": "2026-08-17T20:05:35.945575Z",
+     "iopub.status.busy": "2026-08-17T20:05:35.945362Z",
+     "iopub.status.idle": "2026-08-17T20:05:35.949224Z",
+     "shell.execute_reply": "2026-08-17T20:05:35.948510Z"
     },
     "papermill": {
-     "duration": 0.009467,
-     "end_time": "2026-08-17T10:28:03.221442",
+     "duration": 0.009845,
+     "end_time": "2026-08-17T20:05:35.949844+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.211975",
+     "start_time": "2026-08-17T20:05:35.939999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -856,10 +856,10 @@
    "metadata": {
     "id": "1a779b16",
     "papermill": {
-     "duration": 0.004933,
-     "end_time": "2026-08-17T10:28:03.230105",
+     "duration": 0.00399,
+     "end_time": "2026-08-17T20:05:35.957901+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.225172",
+     "start_time": "2026-08-17T20:05:35.953911+00:00",
      "status": "completed"
     },
     "tags": []
@@ -880,10 +880,10 @@
    "id": "OEwJcbbdr2ls",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.239344Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.239069Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.873549Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.873139Z"
+     "iopub.execute_input": "2026-08-17T20:05:35.967454Z",
+     "iopub.status.busy": "2026-08-17T20:05:35.967129Z",
+     "iopub.status.idle": "2026-08-17T20:05:36.642340Z",
+     "shell.execute_reply": "2026-08-17T20:05:36.641645Z"
     },
     "executionInfo": {
      "elapsed": 186,
@@ -897,10 +897,10 @@
     },
     "id": "OEwJcbbdr2ls",
     "papermill": {
-     "duration": 0.640645,
-     "end_time": "2026-08-17T10:28:03.874260",
+     "duration": 0.680922,
+     "end_time": "2026-08-17T20:05:36.642889+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.233615",
+     "start_time": "2026-08-17T20:05:35.961967+00:00",
      "status": "completed"
     },
     "tags": []
@@ -986,10 +986,10 @@
    "metadata": {
     "id": "Er8gBAq06MDl",
     "papermill": {
-     "duration": 0.0033,
-     "end_time": "2026-08-17T10:28:03.880945",
+     "duration": 0.003434,
+     "end_time": "2026-08-17T20:05:36.650093+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.877645",
+     "start_time": "2026-08-17T20:05:36.646659+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1011,10 +1011,10 @@
    "id": "9KLfiYRt6Lh9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.888846Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.888452Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.897725Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.897155Z"
+     "iopub.execute_input": "2026-08-17T20:05:36.658181Z",
+     "iopub.status.busy": "2026-08-17T20:05:36.657909Z",
+     "iopub.status.idle": "2026-08-17T20:05:36.666162Z",
+     "shell.execute_reply": "2026-08-17T20:05:36.665708Z"
     },
     "executionInfo": {
      "elapsed": 56,
@@ -1028,10 +1028,10 @@
     },
     "id": "9KLfiYRt6Lh9",
     "papermill": {
-     "duration": 0.013959,
-     "end_time": "2026-08-17T10:28:03.898484",
+     "duration": 0.013602,
+     "end_time": "2026-08-17T20:05:36.666943+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.884525",
+     "start_time": "2026-08-17T20:05:36.653341+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1114,11 +1114,14 @@
     "\n",
     "    submit_button.on_click(on_submit)\n",
     "\n",
-    "    # Permettre aussi la soumission avec Entrée (via un bouton caché qui se déclenche)\n",
-    "    def handle_submit(sender):\n",
+    "    # Permettre aussi la soumission avec Entrée (via observe sur la valeur, ipywidgets 8+)\n",
+    "    def handle_submit(change):\n",
+    "        # observe() declenche sur chaque changement de 'value' ; avec continuous_update=False,\n",
+    "        # le callback n'est appele que quand l'utilisateur presse Entree ou quitte le champ.\n",
     "        on_submit(None)\n",
     "\n",
-    "    input_widget.on_submit(handle_submit)\n",
+    "    input_widget.continuous_update = False\n",
+    "    input_widget.observe(handle_submit, names='value')\n",
     "\n",
     "    # Affichage des widgets\n",
     "    display(widgets.HBox([input_widget, submit_button]))\n",
@@ -1143,10 +1146,10 @@
    "metadata": {
     "id": "2kfBYFVB6PA0",
     "papermill": {
-     "duration": 0.003233,
-     "end_time": "2026-08-17T10:28:03.905724",
+     "duration": 0.003662,
+     "end_time": "2026-08-17T20:05:36.674278+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.902491",
+     "start_time": "2026-08-17T20:05:36.670616+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1170,10 +1173,10 @@
    "id": "Py3zW4Mg6QyL",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.914149Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.913711Z",
-     "iopub.status.idle": "2026-08-17T10:28:03.919956Z",
-     "shell.execute_reply": "2026-08-17T10:28:03.918897Z"
+     "iopub.execute_input": "2026-08-17T20:05:36.682745Z",
+     "iopub.status.busy": "2026-08-17T20:05:36.682555Z",
+     "iopub.status.idle": "2026-08-17T20:05:36.688849Z",
+     "shell.execute_reply": "2026-08-17T20:05:36.688179Z"
     },
     "executionInfo": {
      "elapsed": 50,
@@ -1187,10 +1190,10 @@
     },
     "id": "Py3zW4Mg6QyL",
     "papermill": {
-     "duration": 0.011563,
-     "end_time": "2026-08-17T10:28:03.921123",
+     "duration": 0.011386,
+     "end_time": "2026-08-17T20:05:36.689399+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.909560",
+     "start_time": "2026-08-17T20:05:36.678013+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1262,9 +1265,9 @@
     "            print(\"\\nMerci d'avoir utilisé notre service de création d'email!\")\n",
     "\n",
     "    except Exception as e:\n",
-    "        print(f\"Erreur: {e}\")\n",
-    "        import traceback\n",
-    "        traceback.print_exc()\n",
+    "        # Evite d'imprimer le traceback complet : il contient le chemin d'installation\n",
+    "        # Python (qui leak dans les outputs du notebook).\n",
+    "        print(f\"Erreur: type={type(e).__name__}, message={e!s}\")\n",
     "\n",
     "print(\"Fonction principale prête\")\n",
     "print(\"Fonction principale prete\")\n"
@@ -1276,10 +1279,10 @@
    "metadata": {
     "id": "88922a4f",
     "papermill": {
-     "duration": 0.003334,
-     "end_time": "2026-08-17T10:28:03.928208",
+     "duration": 0.00344,
+     "end_time": "2026-08-17T20:05:36.696629+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.924874",
+     "start_time": "2026-08-17T20:05:36.693189+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1308,10 +1311,10 @@
      "height": 724
     },
     "execution": {
-     "iopub.execute_input": "2026-08-17T10:28:03.936892Z",
-     "iopub.status.busy": "2026-08-17T10:28:03.936401Z",
-     "iopub.status.idle": "2026-08-17T10:28:33.944856Z",
-     "shell.execute_reply": "2026-08-17T10:28:33.944397Z"
+     "iopub.execute_input": "2026-08-17T20:05:36.704799Z",
+     "iopub.status.busy": "2026-08-17T20:05:36.704606Z",
+     "iopub.status.idle": "2026-08-17T20:05:44.888920Z",
+     "shell.execute_reply": "2026-08-17T20:05:44.887771Z"
     },
     "executionInfo": {
      "elapsed": 38107,
@@ -1326,10 +1329,10 @@
     "id": "92a902b8-41a8-4f59-8c06-47ecacc6fbbd",
     "outputId": "2092b099-4330-4bbe-f32a-b612eb1fe97c",
     "papermill": {
-     "duration": 30.016029,
-     "end_time": "2026-08-17T10:28:33.948163",
+     "duration": 8.189681,
+     "end_time": "2026-08-17T20:05:44.889784+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:03.932134",
+     "start_time": "2026-08-17T20:05:36.700103+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1339,52 +1342,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[InputCollector] J'attends votre réponse au sujet du type d'email.\n",
-      "\n",
-      "Question: Quel type d'email souhaitez-vous (professionnel, amical, autre) ?\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_27100\\1526022849.py:71: DeprecationWarning: on_submit is deprecated. Instead, set the .continuous_update attribute to False and observe the value changing with: mywidget.observe(callback, 'value').\n",
-      "  input_widget.on_submit(handle_submit)\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34bce6ee4ec64994900db1bc3a4aaff9",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(Text(value='', description='Réponse:', layout=Layout(width='400px'), placeholder='Entrez votre …"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c01e3f2081c948e1955a1b5aa1525859",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Output()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[Batch] Workflow interactif ignore (TimeoutError: )\n"
+      "Erreur: type=ServiceResponseException, message=(\"<class 'semantic_kernel.connectors.ai.open_ai.services.open_ai_chat_completion.OpenAIChatCompletion'> service failed to complete the prompt\", APIConnectionError('Connection error.'))\n"
      ]
     }
    ],
@@ -1404,10 +1362,10 @@
    "id": "b36b20ba",
    "metadata": {
     "papermill": {
-     "duration": 0.003193,
-     "end_time": "2026-08-17T10:28:33.955131",
+     "duration": 0.003572,
+     "end_time": "2026-08-17T20:05:44.897010+00:00",
      "exception": false,
-     "start_time": "2026-08-17T10:28:33.951938",
+     "start_time": "2026-08-17T20:05:44.893438+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1480,20 +1438,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 35.812659,
-   "end_time": "2026-08-17T10:28:34.520239",
+   "duration": 14.988658,
+   "end_time": "2026-08-17T20:05:45.459974+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-11112-skmail\\MyIA.AI.Notebooks\\GenAI\\SemanticKernel\\Créateur de mail personnalisé.ipynb",
-   "output_path": "D:\\Dev\\CoursIA-11112-skmail\\MyIA.AI.Notebooks\\GenAI\\SemanticKernel\\Créateur de mail personnalisé_output.ipynb",
+   "input_path": "Créateur de mail personnalisé.ipynb",
+   "output_path": "Créateur de mail personnalisé.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },
-   "start_time": "2026-08-17T10:27:58.707580",
+   "start_time": "2026-08-17T20:05:30.471316+00:00",
    "version": "2.6.0"
   },
   "widgets": {


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: MED/docs #11518

# #11513 — fix ipywidgets `.on_submit()` déprécié → chemin machine dans les outputs commits (SK mail)

## Résumé

Le notebook `MyIA.AI.Notebooks/GenAI/SemanticKernel/Créateur de mail personnalisé.ipynb`
émettait, à chaque exécution, un `DeprecationWarning` sur stderr qui embarquait
le **nom de fichier temporaire qu'ipykernel donne à la cellule**, donc un chemin
absolu portant le nom d'utilisateur (`C:\Users\jsboi\AppData\Local\Temp\ipykernel_...`).
Le chemin restait dans les `outputs` committés (cf. issue #11513).

**Cause-racine triage catégorie (C) « source qui imprime »** ([secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md) règle 6) :
la cellule 20 appelait `input_widget.on_submit(handle_submit)` (API dépréciée
depuis ipywidgets 7, **retirée en 8**). La cellule 22 — `email_workflow()` —
appelait `traceback.print_exc()` qui imprime le chemin d'installation Python
dans toute erreur du workflow (même classe de leak, mais latente tant que la
clé OpenAI est valide).

**Modification** : deux fixes source, **ré-exécution réelle** du notebook
(papermill, cwd neutralisé), suppression complète de tout chemin machine
dans le `.ipynb` commité.

| Fichier | +/− source | Section modifiée |
|---------|------------|---------------------|
| `MyIA.AI.Notebooks/GenAI/SemanticKernel/Créateur de mail personnalisé.ipynb` | **cell 20 + cell 22** | `on_submit(handle_submit)` → `input_widget.continuous_update=False` + `input_widget.observe(handle_submit, names='value')` ; `traceback.print_exc()` → message terse `type=…, message=…` |

## Pourquoi deux cellules modifiées (et pas seulement cell 20)

Issue #11513 cible **explicitement** la cellule 20 (`on_submit` déprécié).
La cellule 22 (`traceback.print_exc()`) est un leak **de même classe**
(source qui imprime un chemin machine dans la sortie) mais **latent** :
il n'apparaît que si le workflow lève une exception. Avec une clé OpenAI
valide (contexte original du PR #11447), l'exception ne se produit pas
et le leak n'est pas visible dans les outputs.

J'ai découvert le leak cellule 22 lors de ma ré-exécution : sans clé OpenAI
réelle, le workflow lève `APIConnectionError`, `email_workflow()` attrape,
appelle `traceback.print_exc()`, et le traceback contient
`C:\Users\jsboi\AppData\Local\Programs\Python\Python313\Lib\site-packages\...`
sur ~30 lignes. La correction cellule 22 est **directement alignée** sur le
triage catégorie (C) de l'issue #11513 : même root cause, même remède
(corriger la source, re-exécuter, le chemin disparaît avec l'erreur).

**Scope respecté** : aucune autre cellule touchée. Les 4 autres notebooks
qui mentionnent `on_submit` (`10-SemanticKernel-NotebookMaker.ipynb`,
`10a-...-batch.ipynb`, `10b-...-batch-parameterized.ipynb`,
`Créateur de mail personnalisé.ipynb`) ne portent **que le nom de fonction
locale** `def on_submit(b)`, **pas l'appel déprécié** — vérifié par
`grep '\.on_submit(' MyIA.AI.Notebooks/**/*.ipynb` (0 résultat).

## Ré-exécution : preuve de succès

```
=== Cell 20 (orchestration) ===
exec_count=10
  [stream]: Orchestration configurée
Configuration OpenAI et etat initialises
Orchestration configuree

=== Cell 24 (workflow execution) ===
exec_count=12
  [stream]: 'Erreur: type=ServiceResponseException, message=(...)'

=== Machine path check ===
OK: no AppData / jsboi / C:\Users / Temp\ipykernel in any output

=== DeprecationWarning check ===
OK: no DeprecationWarning in any output

=== Exec sequence check ===
Code cells: 12
Exec counts: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
OK: continuous sequence (no gaps)
```

**Acceptance #11513** (rappel) :
- [x] l'appel `on_submit` est remplacé par `observe(..., names='value')` (cellule 20)
- [x] le notebook est **ré-exécuté** (papermill) et recommité avec ses sorties
- [x] plus aucun `DeprecationWarning` sur `stderr`, donc plus aucun chemin machine
      dans les `outputs` — vérifiable en cherchant `AppData` dans le `.ipynb`
- [x] `execution_count` reste une séquence complète sans trou

## Stop&Repair — pas de scrub d'outputs

Aucun `output` de cellule n'a été modifié à la main. La suppression de la
ligne `DeprecationWarning` et du chemin machine est la **conséquence** de
la ré-exécution après le fix source (cause catégorie C → remède catégorie C).

**Seule normalisation manuelle tolérée** ([secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md)
règle 6, exceptions) : `metadata.papermill.input_path` et `output_path` mis
au `basename` du fichier (la version commitée provenait d'un worktree
`D:\Dev\CoursIA-11112-skmail\...` du PR #11447 — leak pré-existant, hors
scope du ticket).

## Pourquoi DEEP/notebook-python et pas MED/notebook-python

- **Substance** : 2 fixes source distincts (cell 20 + cell 22), 1 ré-exécution
  complète, découverte et résolution d'un leak latent de même classe.
- **Pédagogie** : le notebook SK est un **exemple résolu** (worked example)
  du pattern `ChatCompletionAgent` × `ipywidgets` × `pydantic state`. Le
  fix préserve la substance pédagogique et **restaure la possibilité de
  copier-coller** le pattern dans les notebooks étudiants sans contaminer
  leurs outputs avec des chemins machine.

`notebook-python` est dans la classe CONTENU de [variation-protocol.md](../../.claude/rules/variation-protocol.md).
Le litmus LIGHT (« pourrais-je en produire une douzaine en scannant
l'instance suivante ? ») répond NON — la combinaison (cause-C widget +
cause-C traceback + ré-exécution réelle sans clé) est **spécifique** à ce
notebook.

## Vérification cross-référentielle

```
grep -rn '\.on_submit(' MyIA.AI.Notebooks/**/*.ipynb
→ 0 résultat (l'API dépréciée n'est plus appelée nulle part)
```

```
grep -rn 'traceback.print_exc()' MyIA.AI.Notebooks/GenAI/SemanticKernel/
→ 0 résultat dans ce notebook (1 occurrence supprimée dans cette PR)
```

## Conformité

- ✓ `variation-tag-guard.yml` : tag `Grain: DEEP/notebook-python — lane ... —
  prev: MED/docs #11518` ligne 1
- ✓ `claim-paths-verify` (c.1331p233 ★★★) : paths déclarés dans le claim initial
  (`MyIA.AI.Notebooks/GenAI/SemanticKernel/Créateur de mail personnalisé.ipynb`)
  existent sur `origin/main` à l'instant T du claim (vérifié via `ls-files`).
- ✓ `catalog-pr-hygiene` : aucun marqueur `CATALOG-STATUS` touché (catalogue
  byte-identique à main).
- ✓ C.2 (commit AVEC outputs) : outputs **réellement ré-exécutés** par papermill,
  pas scrubbés à la main.
- ✓ Stop&Repair : correction de cause + re-execution, **pas de scrub** d'outputs
  (la seule normalisation manuelle est `metadata.papermill.input/output_path`
  au basename, exception autorisée par la règle).
- ✓ Pas de secret inline, pas de cellule notebook supplémentaire touchée.
- ✓ `Closes #11513` (issue entièrement résolue : widget fixé, plus de
  DeprecationWarning, plus de chemin machine dans les outputs).

## Acceptance #11513 finale

- [x] cellule 20 : `.on_submit()` → `.observe(..., names='value')` +
      `continuous_update = False`
- [x] cellule 22 (bonus, même classe de leak) : `traceback.print_exc()` →
      message terse
- [x] notebook **ré-exécuté** via papermill avec cwd neutralisé
- [x] `AppData` / `jsboi` / `C:\Users` / `Temp\ipykernel` absents du `.ipynb`
      commité (vérification script + grep)
- [x] `execution_count` 1..12 sans trou
- [x] 4 notebooks GenAI audités pour le même pattern — 0 occurrence restante

## Hors scope

- **Audit plus large des notebooks SK** : `grep '\.on_submit(' MyIA.AI.Notebooks/**/*.ipynb`
  montre 0 résultat — l'API dépréciée n'est utilisée que dans ce notebook.
  Pas de follow-up nécessaire.
- **Autres `traceback.print_exc()` dans la série GenAI** : aucun dans
  `MyIA.AI.Notebooks/GenAI/SemanticKernel/` (vérifié). Si présents ailleurs,
  à traiter en grain séparé (un scan `grep -rln 'traceback.print_exc()`
  MyIA.AI.Notebooks/` peut servir de point de départ).
- **Re-exécution dans un environnement avec clé OpenAI valide** : la sortie
  `Erreur: type=ServiceResponseException, ...` de la cellule 24 est due
  à l'absence de clé OpenAI sur ce worker (`.env` local pointe sur
  `localhost:1`). Le fix est correct et stable ; un environnement avec clé
  valide produira la sortie pédagogique attendue.

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/11513
- PR précédente (re-exec, exec_count clean) : https://github.com/jsboige/CoursIA/pull/11447
- Claim initial (lane `myia-po-2024:CoursIA-2`, paths scopés) : cf commentaire
  d'issue #11513
- Pivot post-c.1331p240 MED/docs : **G-VAR-3 OK** car substance distincte
  (notebook SK avec cause-C widget + cause-C traceback ≠ frontière
  inter-séries).
- Epic axe-1 SOTA (#3801) : non touché.
- Règle Stop&Repair : [secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md) §6.
