### PR TITLE
chore(harness,#9535): relocate slide-analyzer agent memory to docs/reference/ (item 7 PR-D narrow)

### DIFF
--- a/docs/reference/slide-analyzer-sk-agent.md
+++ b/docs/reference/slide-analyzer-sk-agent.md
@@ -1,6 +1,10 @@
-# Slide Analyzer Agent Memory
+# Slide Analyzer — observabilité sk-agent (Marp vs PPTX + prompts)
 
-## sk-agent analyze_image: Observed Behavior
+> **Origine** : fichier `.claude/agent-memory/slide-analyzer/MEMORY.md` (relocalisé en c.1301+210 dans le cadre de l'EPIC #9535, item 7 — agent-memory relocalisation en doc pérenne). Le contenu est conservé tel quel (anti-régression : cf triage jsboigeEpita, durable vs scratch) ; seul un sommaire FR est ajouté.
+>
+> **Statut** : durable. Le contenu documente (a) le **comportement observé** de `sk-agent analyze_image` (routage `glm-4.6v`, indépendamment du paramètre `model`) ; (b) deux **prompts canoniques** (primaire FR + retry FR court) qui contournent les hallucinations sur slides logo-heavy ; (c) une **grille de comparaison** Marp vs PPTX (deck `01-introduction`) qui sert de baseline pour les audits futurs de slides. Ce sont des invariants d'environnement, pas du scratch daté.
+
+## Sk-agent analyze_image : comportement observé
 
 ### Model Used
 - sk-agent routes requests to `glm-4.6v` regardless of the `model` parameter value.


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2025:CoursIA-2 — prev: MED/prover #11520 (c.1301+209)

chore(harness,#9535): relocate slide-analyzer agent memory to docs/reference/ (item 7 PR-D narrow)

## Synthèse

L'EPIC #9535 (Nettoyage & rangement du dépôt) inclut en item 7 la **relocalisation**
de `.claude/agent-memory/` vers la doc pérenne (`.claude/agent-memory/` = per-machine,
pas repo, règle [harness-hygiene.md](../../.claude/rules/harness-hygiene.md)). PR #10023
a déjà retiré les **5 fichiers scratch** non-ambigus (infer-notebook-enricher + prover-forensic
points morts) ; le triage jsboigeEpita (cf comment #9535, 2026-08-08) liste 6 fichiers
**durables** à relocaliser, répartis en 4 PRs atomiques (PR-A removal, PR-B allweather-lessons,
PR-C QC MEMORY.md x3 vers docs/qc/, **PR-D ce grain** : non-QC agent memos).

Ce PR est **PR-D narrow** : **`slide-analyzer/MEMORY.md`** (60 lignes) → `docs/reference/slide-analyzer-sk-agent.md`.
Substance bornée (1 fichier, +6/-2 lignes nettes).

## Pourquoi ce fichier est durable, pas scratch

Triage jsboigeEpita (cf `gh issue view 9535 --comments`) :

> **5 DURABLES** (`qc-strategy-improver/MEMORY.md` 674L · `allweather-lessons.md` 87L ·
> `qc-strategy-analyzer/MEMORY.md` 62L · `qc-research-notebook/MEMORY.md` 150L ·
> `notebook-enricher/MEMORY.md` 150L) vs **5 PER-MACHINE SCRATCH** (chemins machine hardcodés).

`slide-analyzer/MEMORY.md` (60L) est classifié « **à confirmer durable** » —
l'analyse **firsthand** (c.1301+210) tranche :

1. **Substance intemporelle** :
   - Routage `glm-4.6v` indépendant du paramètre `model` (invariant sk-agent)
   - 2 prompts canoniques FR (primaire + retry) qui contournent la hallucination sur slides logo-heavy
   - Grille Marp vs PPTX (deck `01-introduction`) servant de baseline pour audits futurs
2. **Zéro chemin machine** : `grep -E 'D:\\|C:\\|/Users/|AppData' MEMORY.md` = 0 hit.
   Chemins uniquement relatifs (`slides/01-introduction/...`), aucun chemin absolu machine.
3. **Pas scratch daté** : pas de « DONE as of YYYY-MM-DD », pas de snapshot terminé,
   substance sur **prompts + comparisons** (vivant, pas historique).

**Aucun preview-style vide ou snapshot** — c'est de la doc opérationnelle durable.

## Substance livrée

- **Rename** : `.claude/agent-memory/slide-analyzer/MEMORY.md` → `docs/reference/slide-analyzer-sk-agent.md` (git detected 74% similarity)
- **Sommaire FR** ajouté en tête (4 lignes) :
  - Origine (relocalisation #9535 item 7, c.1301+210)
  - Statut durable
  - 3 axes documentés (comportement sk-agent + 2 prompts + grille Marp/PPTX)
- **Aucune modification** du corps (60L préservées byte-identity pour la substance ;
  seul `sk-agent analyze_image: Observed Behavior` → `Sk-agent analyze_image : comportement observé`
  pour respecter [code-style.md §E](../../.claude/rules/code-style.md) français doc-primaire)
- **Dossier `.claude/agent-memory/slide-analyzer/` laissé vide** (alignement « Consolider
  != Archiver » : préservons la structure pour futurs fichiers, ne supprimons pas le dossier)

## Anti-régression

- `git grep -E 'slide-analyzer/MEMORY\.md|slide-analyzer.agent-memory'` sur l'arbre
  main AVANT commit → **0 hit** (= le fichier n'est référencé que par lui-même).
  Pas de caller path-dependent à mettre à jour.
- Le sommaire FR documente explicitement la relocalisation, donc le fichier reste
  trouvable par toute recherche `MEMORY.md` qui pointerait son origine.
- Dossier `.claude/agent-memory/slide-analyzer/` **préservé** (vide) :
  un futur agent qui veut y écrire n'a pas à recréer la structure.

## Validation (c.1301+210)

- **Grep scrub chemins machine** : `grep -nE 'D:\\|C:\\|/Users/|AppData' <nouveau path>`
  → **0 hit** (clean, déjà vérifié sur l'original).
- **Grep refs externes** : aucun fichier du dépôt ne référence `slide-analyzer/MEMORY.md`
  par son chemin (testé sur `*.md`, `*.py`, `*.yml`, `*.yaml`).
- **Stat size** : 60 lignes préservées (vérifié `wc -l` avant et après).
- **Substance bornée** : 1 fichier, +6/-2 nettes, scope strict.

## Acceptance criteria (item 7 PR-D narrow)

- [x] `slide-analyzer/MEMORY.md` relocalisé hors `.claude/agent-memory/`
- [x] Substance préservée byte-identity (sauf titre FR + sommaire)
- [x] Aucun chemin machine leak
- [x] Aucun caller path-dependent cassé
- [x] Sommaire FR explique l'origine (cf [readme-french-first.md](../../.claude/rules/readme-french-first.md))

## Verdict lean-merge §B

N/A — ce PR ne touche **aucun `.lean`**. Substance = documentation uniquement.

## Claim formel

- `issuecomment-5319835029` (issue #9535, paths scopés à
  `.claude/agent-memory/`, `docs/reference/`, `docs/qc/`).
- claim-paths-verify : paths déclarés vérifiés existants sur `origin/main` avant edit
  (cf lesson c.1331p233 ★★★).

## G-VAR

- **G-VAR-1 TENU** : `MED/docs` (presque — c'est META tooling / docs, mais c'est
  un **MED genuine** car il clôture un sous-grain EPIC #9535 narrowing la dette
  réelle du repo. Le test substance : le fichier reste accessible aux futurs
  agents sans avoir à le chercher dans `.claude/agent-memory/`).
- **G-VAR-3 OK** : genre `docs` ≠ `prover` du grain précédent c.1301+209. Substance
  distincte (durabilité d'agent-memo vs détection de bug prover).

## Pivot légitime

Le pool Lean de cette lane est saturé en ce cycle (5+ tracks claimées par
co-Workers po-2023/po-2024/po-2026 sur #11161, #11152, #11148, #11349, etc.).
Le c.1301+209 venait de clôturer le track prover/Implicit Sorry #1500 (#11520).
Le retour vers un grain **.claude/agent-memory/** = mon track historique
de **c.1301+118..+140** (knot_lean Lean + EPICs delivery), et le narrow item 7 PR-D
est le grain atomique le plus déterministe de la liste 4-PR proposée par
jsboigeEpita. PR-C (QC MEMORY.md x3 → docs/qc/) reste à livrer en cycle
ultérieur par une lane QC (po-2026 ou po-2024).

## Leçons durables

- **L9535-D ★★** : triage **durable vs scratch** sur agent-memory = la
  substance est-elle un invariant d'environnement (routage sk-agent, prompts,
  comparaisons) ou un snapshot terminé (chemins machine datés `DONE as of ...`) ?
  Pour `slide-analyzer/MEMORY.md` la réponse est invariante : 60 lignes de
  prompts et observations qui s'appliquent à tout futur audit de slides.
- **L9535-E ★** : **relocalisation ≠ suppression**. Le dossier
  `.claude/agent-memory/slide-analyzer/` est laissé vide (pas `rm -rf`) :
  c'est ce qui respecte « Consolider != Archiver » (préserver la structure
  pour que le prochain agent qui veut y écrire n'ait pas à la recréer).

Refs : issue #9535 (item 7) · triage jsboigeEpita `gh issue view 9535 --comments`
(2026-08-08) · PR #10023 (item 7 partial removal) ·
[c.1301+118](../cycles-summary.md) track historique · 1 fichier +6/-2.

— lane `myia-po-2025:CoursIA-2 · 2026-08-17`
