### PR TITLE
fix(guard,#11232): review-coverage advisory + label large-pr-no-review

### DIFF
--- a/.github/workflows/review-coverage-advisory.yml
+++ b/.github/workflows/review-coverage-advisory.yml
@@ -1,0 +1,81 @@
+name: Review coverage advisory
+
+# The missing ORGAN for issue #11232: a PR >threshold with no review (bot or
+# human) reads green on every visible signal -- gh pr checks 0 failures,
+# 0 pending, mergeable: MERGEABLE, reviews[] empty -- yet the coverage hole
+# is the largest defect (measured on the Lean track: #11132 1041 LOC and
+# #11210 883 LOC had NO review at all). The signal is the absence, not the
+# content.
+#
+# This scheduled sweep labels OPEN non-draft PRs (base=main) whose
+# additions exceed the threshold and whose reviews[] is empty, and removes
+# the label when a review arrives (or the diff shrinks below the threshold).
+# The label is a current-state flag, not a sticky one.
+#
+# ADVISORY, never blocking (#11232 "il ne peut pas bloquer, c'est
+# précisément l'absence qui est le défaut"):
+#   - The job ALWAYS exits 0. The actionable payload is the LABEL, NEVER
+#     the green conclusion.
+#   - Draft PRs and PRs targeting a non-main base are excluded by design.
+#   - Threshold is a CLI arg (default 300); tuned in the cron without a
+#     code change. Rationale + history: docs/reference/review-coverage-threshold.md.
+
+on:
+  schedule:
+    # Daily, off-:00 minute (anti-stampede). 06:13 UTC.
+    - cron: '13 6 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log only, apply no labels/comments'
+        required: false
+        type: boolean
+        default: true
+      threshold:
+        description: 'Additions threshold (default 300)'
+        required: false
+        type: number
+        default: 300
+
+permissions:
+  # Labels sur PR (gh pr edit) = pull-requests: write ; commentaires et creation
+  # de labels (gh pr comment / gh label create) = issues: write. Meme set que
+  # pr-gate-missing-advisory.yml / lane-claim-guard.yml / variation-tag-guard.yml.
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: review-coverage-advisory
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    name: "Flag large PRs with no review (advisory)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install gh (system)
+        run: |
+          if ! command -v gh >/dev/null; then
+            sudo apt-get update -qq
+            sudo apt-get install -y -qq gh
+          fi
+          gh --version
+
+      - name: Run sweep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DRY=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then DRY="--dry-run"; fi
+          python scripts/review_coverage.py \
+            $DRY \
+            --threshold "${{ inputs.threshold }}" \
+            --label "large-pr-no-review"

--- a/docs/reference/review-coverage-threshold.md
+++ b/docs/reference/review-coverage-threshold.md
@@ -1,0 +1,110 @@
+# Review-coverage threshold — pourquoi 300, comment l'ajuster
+
+Document de support pour l'organe [`scripts/review_coverage.py`](../../scripts/review_coverage.py)
+et le workflow [`.github/workflows/review-coverage-advisory.yml`](../../.github/workflows/review-coverage-advisory.yml).
+Source : issue **#11232** (review-coverage), mandat 2026-08-16.
+
+## Le problème
+
+Hermes et ai-01 lisent `reviews[]` et les trois surfaces de B.0 de
+[`pr-review-discipline.md`](../../.claude/rules/pr-review-discipline.md). Aucun
+de ces gestes ne détecte **l'absence** de review. Une PR sans review et sans
+réserve ouverte lit vert sur tous les signaux visibles : `gh pr checks` 0
+failures, 0 pending, `mergeable: MERGEABLE`, `reviews[].state` vide.
+
+**Mesure firsthand 2026-08-16** sur la fenêtre Lean :
+
+| PR      | additions | reviews      | signal déclenché                                |
+|---------|-----------|--------------|--------------------------------------------------|
+| #11132  | 1041      | 0            | **aucun** (silence sur tous les indicateurs)     |
+| #11210  | 883       | 0            | **aucun** (silence sur tous les indicateurs)     |
+| #11217  | 318       | 2 (Hermes + ai-01) | `second-reviewer` (parce qu'il y a 1 review) |
+| #11048  | 425       | 1 (Hermes)   | review présente, OK                            |
+
+Les deux plus grosses PRs de la fenêtre — **#11132 et #11210** — n'avaient
+**aucune review** au moment où elles ont été mergées. Le seuil `second-reviewer`
+(200 LOC) a été déclenché par Hermes **uniquement** sur #11217 (qui avait
+**déjà** 1 review : ai-01). Le seuil de Hermes **exigeait** une review, et
+les PRs qui n'en avaient **aucune** étaient littéralement invisibles.
+
+## Le seuil de l'organe
+
+**Défaut : 300 additions.** Argumentation :
+
+- **Au-dessus de 300** : capture #11132 (1041) et #11210 (883), les deux
+  exemples motivants. Justifie l'organe.
+- **En dessous de 300** : la PR #11217 (318) avec 2 reviews reste visible
+  par sa review, pas par le label. Pas de concurrence entre les deux
+  organes.
+- **300 vs 200** : Hermes applique 200. Pourquoi 300 ici ? L'organe
+  `review-coverage` est **fréquent** (cron quotidien) et **labellisant**
+  (le label se voit). Un seuil à 200 ferait flamber le dashboard. 300
+  est la limite haute qui distingue encore la couverture manquante d'une
+  PR dense mais relue.
+
+## Historique
+
+| Date       | Qui | Décision | Justification |
+|------------|-----|----------|---------------|
+| 2026-08-16 | Hermes | 200 LOC (`second-reviewer`) | seuil humain, sur une PR précise |
+| 2026-08-16 | ai-01 | 300 LOC (défaut `review-coverage`) | seuil cron, label visible, frequency quotidienne |
+| 2026-08-17 | po-2024 | 300 (implémentation) | match le défaut décisionnel, ajustable par CLI |
+
+## Comment changer le seuil
+
+Deux mécanismes, **sans toucher au code** :
+
+1. **Workflow dispatch** (one-shot, pour un test) : Actions → "Review coverage
+   advisory" → Run workflow → champ `threshold` (default 300).
+2. **Cron** (permanent, nécessite un edit du YAML) : modifier la ligne
+   `python scripts/review_coverage.py $DRY --threshold 300 --label ...` dans
+   [`.github/workflows/review-coverage-advisory.yml`](../../.github/workflows/review-coverage-advisory.yml).
+   À faire dans une PR dédiée `chore(review-coverage): bump threshold to NNN`.
+
+## Exceptions documentées
+
+- **Draft PRs** : exclues par construction (`isDraft=True` → `skip_draft`).
+  Une PR en draft est par construction non-prête, label = bruit.
+- **Base ≠ main** : exclues par construction. Le label est un signal du
+  coverage hole **de la piste principale** (main-track). Une PR vers
+  `feature/foo` a une audience de revue différente (le propriétaire de
+  la branche, les co-workers).
+- **Reviews de bot** : **comptent**. Une review de `clusterManager-Myia`
+  lève le label. Exclure les bot reviews recréerait le trou sur une
+  surface plus étroite (incident fondateur documenté dans le docstring
+  de `classify`).
+
+## Pourquoi ADVISORY et pas bloquant
+
+L'organe **ne peut pas** bloquer : le défaut est l'**absence** de review, et
+le seul remède est **obtenir une review**. Un check bloquant ferait deux
+choses rédhibitoires :
+
+1. **Bloquer le merge** d'une PR non-reviewée alors que la **vraie**
+   solution est d'**obtenir** une review, pas de bloquer.
+2. **Ne pas bloquer** quand la review arrive, et donc **ne pas** apprendre
+   aux auteurs à demander une review en amont.
+
+L'organe label et commente. Le commentaire nomme l'action (`obtenir une
+review`) et explique pourquoi close/reopen ne suffit pas. Le label est
+**retiré** dès qu'une review arrive (current-state flag, pas sticky).
+
+## Conformité
+
+- **G-VAR-1** : le grain est `MED/guard` (plancher **DEEP/MED CONTENU**
+  est satisfait par le pivot anterior — c.1331p241 = DEEP/notebook-python).
+- **claim-paths-verify** (c.1331p233 ★★★) : paths déclarés au claim :
+  `scripts/review_coverage.py`, `.github/workflows/review-coverage-advisory.yml`,
+  `docs/reference/review-coverage-threshold.md`. Tous créés dans la PR.
+- **catalog-pr-hygiene** : pas de marqueur `CATALOG-STATUS` touché.
+- **H.1** : script CLI testé end-to-end (12 cas pytest), dry-run vérifié
+  sur la fenêtre locale (no-PR-flagged run pour confirmer que le
+  classifier ne bronche pas sur une liste vide).
+
+## Liens
+
+- Issue : https://github.com/jsboige/CoursIA/issues/11232
+- PR : https://github.com/jsboige/CoursIA/pull/XXXXX (à compléter)
+- Tests : `scripts/tests/test_review_coverage.py` (12/12 fixtures)
+- Règle B.0 : [`.claude/rules/pr-review-discipline.md`](../../.claude/rules/pr-review-discipline.md)
+- Variation (G-VAR-1/2/3) : [`.claude/rules/variation-protocol.md`](../../.claude/rules/variation-protocol.md)

--- a/scripts/review_coverage.py
+++ b/scripts/review_coverage.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Review-coverage detector -- the missing ORGAN for issue #11232.
+
+Hermes and the human reviewer (ai-01) read ``reviews[]`` and the three surfaces
+of section B.0 of pr-review-discipline.md. None of those gestures detect a
+review that is simply *absent*. A PR with zero reviews and zero open reserves
+reads green on every visible signal: ``gh pr checks`` 0 failures, 0 pending,
+``mergeable: MERGEABLE``, ``reviews[].state`` empty.
+
+Measured firsthand 2026-08-16 on the Lean track, the absence correlates
+inversely with the diff size: the two largest PRs of the window
+(``#11132`` at 1041 LOC, ``#11210`` at 883 LOC) had **no review at all**,
+bot or human, while the 318-LOC ``#11217`` triggered ``second-reviewer``.
+The threshold is applied inconsistently by the same reviewer, and the
+coverage hole is the larger defect -- this organ targets the hole.
+
+This tool is ADVISORY, never blocking: it cannot block, because the defect
+is the absence of a review and the only remedy is to obtain one. On each
+sweep it:
+
+  - flags OPEN non-draft PRs (base=main) with ``additions > THRESHOLD`` AND
+    ``reviews[]`` empty (no bot, no human) ;
+  - labels ``large-pr-no-review`` (regular) and posts a one-shot comment
+    (marker-guarded, no spam on re-runs) ;
+  - removes the label when a review arrives (or the diff shrinks below the
+    threshold), so the label is a current-state signal, not a sticky one.
+
+Acceptance mirrors the issue body: the signal is the **absence**, not the
+content. A check that posted ``rien trouve`` on a PR with no review would
+itself be the defect; this one labels the absence.
+
+The classification core (``classify``) is a PURE function -- no network --
+so it is unit-tested with fixtures in
+``scripts/tests/test_review_coverage.py``. The ``main`` driver wires it to
+``gh`` and applies/removes labels and comments idempotently.
+
+Usage::
+
+    python scripts/review_coverage.py --dry-run        # log only, no labels
+    python scripts/review_coverage.py                  # apply (CI cron)
+    python scripts/review_coverage.py --threshold 200  # override default
+    python scripts/review_coverage.py --label NAME     # override label name
+
+Exit code is always 0 (advisory). The actionable payload is the set of
+labeled PRs and their comments, NEVER the green conclusion.
+
+Threshold rationale (cf. docs/reference/review-coverage-threshold.md) :
+200 was the threshold Hermes applied to ``#11217`` (318 LOC) per the issue
+body table; 300 is a slightly more permissive default that catches ``#11132``
+and ``#11210`` without flooding the dashboard. The cron reads it from the
+``--threshold`` arg so it can be tuned without a code change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from typing import Iterable
+
+# The label is the *signal* -- a current-state flag the reviewer/coordinator
+# reads. Color is red (the absence is a coverage hole, not a failure).
+LABEL_DEFAULT = "large-pr-no-review"
+LABEL_COLOR = "b60205"
+LABEL_DESC = (
+    "PR > seuil (par defaut 300 additions) sans review (ni bot ni humaine) "
+    "-- couverture review absente (#11232). Le label est retire des qu'une "
+    "review arrive ou que le diff passe sous le seuil."
+)
+
+# Authors whose reviews count as "bot" for this purpose. We do NOT exclude
+# bot reviews; the signal is the absence of any review at all, not the
+# absence of a human one. Hermes approvals count, so do ours. The intent
+# is to surface PRs that *no one* has read.
+# (Kept here as a hook for future narrowing, e.g. "human review only" -- not
+#  used by classify() today.)
+_BOT_AUTHORS: tuple[str, ...] = (
+    "app/github-actions",
+    "github-actions[bot]",
+)
+
+# Marker framing the advisory comment, so re-runs can find and update it.
+# Same pattern as pr-gate-missing: idempotent, not a stream of duplicates.
+COMMENT_MARKER_START = "<!-- REVIEW-COVERAGE:START -->"
+COMMENT_MARKER_END = "<!-- REVIEW-COVERAGE:END -->"
+
+# Remediation text. Must name the action (request a review) explicitly and
+# say that close/reopen does not help (the diff is what the reviewer has to
+# read, not the PR state).
+REMEDIATION = (
+    "Cette PR depasse le seuil de couverture review (par defaut 300 "
+    "additions) et n'a recu **aucune review** -- ni bot, ni humaine.\n\n"
+    "Le label ``large-pr-no-review`` est pose par l'organe "
+    "[`scripts/review_coverage.py`](../../scripts/review_coverage.py) "
+    "porte par l'issue #11232. Aucun remede automatique : il faut "
+    "**obtenir une review** (Hermes, ai-01, ou review humaine).\n\n"
+    "Le label sera **retire des qu'une review arrive** (ou que le diff "
+    "passe sous le seuil). Fermer/rouvrir la PR ne suffit pas -- la "
+    "mesure porte sur le diff, pas sur l'etat de la PR.\n\n"
+    "Seuil, historique et exceptions : cf. "
+    "[`docs/reference/review-coverage-threshold.md`]"
+    "(../../docs/reference/review-coverage-threshold.md)."
+)
+
+THRESHOLD_DEFAULT = 300
+
+
+def classify(pr: dict, threshold: int = THRESHOLD_DEFAULT) -> str:
+    """Classify a PR (as returned by ``gh pr view --json ...``).
+
+    Returns one of:
+      - ``"flag"``     : PR exceeds threshold AND has no review (any author)
+      - ``"clear"``    : PR is below threshold OR has at least one review
+      - ``"skip_draft"``: PR is draft (excluded by design)
+      - ``"skip_base"`` : PR base is not ``main`` (excluded by design)
+
+    The order of checks matters: a draft is a draft even if it is large.
+    The PR is in the ``clear`` class the moment any condition that would
+    lift the flag holds (review present, or below threshold).
+    """
+    # Skips first -- they are not just "no flag", they are "out of scope".
+    if pr.get("isDraft"):
+        return "skip_draft"
+    base_ref = (pr.get("baseRefName") or "").strip()
+    if base_ref and base_ref != "main":
+        return "skip_base"
+
+    additions = pr.get("additions", 0) or 0
+    reviews = pr.get("reviews") or []
+    if additions < threshold:
+        return "clear"
+    if len(reviews) > 0:
+        return "clear"
+    return "flag"
+
+
+def fetch_open_prs(threshold: int) -> list[dict]:
+    """Fetch OPEN non-draft PRs as the minimum JSON the classifier needs.
+
+    Why minimum JSON: ``gh pr list`` on a 800-PR repo with full payloads
+    is slow and noisy. The classifier reads only ``number``, ``title``,
+    ``isDraft``, ``baseRefName``, ``additions``, ``reviews``. We use
+    ``--jq`` to project server-side and skip the rest.
+    """
+    cmd = [
+        "gh", "pr", "list",
+        "--state", "open",
+        "--base", "main",
+        "--json", "number,title,isDraft,baseRefName,additions,reviews,author,url",
+        "--limit", "300",
+    ]
+    out = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    return json.loads(out.stdout)
+
+
+def has_label(pr_number: int, label: str) -> bool:
+    """Return True iff the PR currently carries ``label`` (idempotent core)."""
+    out = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "labels",
+         "--jq", f'[.labels[] | select(.name == "{label}")] | length'],
+        capture_output=True, text=True, check=True,
+    )
+    return out.stdout.strip() == "1"
+
+
+def add_label(pr_number: int, label: str) -> None:
+    """Create the label if missing, then add it. Both steps are idempotent."""
+    subprocess.run(
+        ["gh", "label", "create", label,
+         "--color", LABEL_COLOR, "--description", LABEL_DESC,
+         "--force"],
+        capture_output=True, text=True,
+    )
+    subprocess.run(
+        ["gh", "pr", "edit", str(pr_number), "--add-label", label],
+        capture_output=True, text=True, check=True,
+    )
+
+
+def remove_label(pr_number: int, label: str) -> None:
+    """Idempotent -- if the label is not on the PR, this is a no-op."""
+    subprocess.run(
+        ["gh", "pr", "edit", str(pr_number), "--remove-label", label],
+        capture_output=True, text=True,
+    )
+
+
+def upsert_comment(pr_number: int, body: str) -> None:
+    """Post or update the marker-framed comment. No-op if the body matches.
+
+    The marker is the same as pr-gate-missing: an existing comment with the
+    same markers is replaced wholesale; one without markers is left alone
+    (we do not touch user comments). A re-run posting the exact same body
+    is a no-op (idempotent by content, not just by marker).
+    """
+    out = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "comments",
+         "--jq", ".comments[].body"],
+        capture_output=True, text=True, check=True,
+    )
+    existing = [c for c in out.stdout.split("\n")
+                if COMMENT_MARKER_START in c and COMMENT_MARKER_END in c]
+    framed = f"{COMMENT_MARKER_START}\n{body}\n{COMMENT_MARKER_END}"
+    if existing and existing[0].strip() == framed.strip():
+        return  # no-op
+    # Delete the prior framed comment (if any) then post the new one.
+    for prior in existing:
+        # Find the comment id by re-querying with id field
+        ids = subprocess.run(
+            ["gh", "pr", "view", str(pr_number), "--json", "comments",
+             "--jq", f'[.comments[] | select(.body | contains("{COMMENT_MARKER_START}"))] | .[].id'],
+            capture_output=True, text=True, check=True,
+        )
+        for cid in ids.stdout.split():
+            subprocess.run(
+                ["gh", "pr", "comment", "--delete", cid] if False else
+                ["gh", "api", f"repos/{{owner}}/{{repo}}/issues/comments/{cid}",
+                 "-X", "DELETE"],
+                capture_output=True, text=True,
+            )
+    subprocess.run(
+        ["gh", "pr", "comment", str(pr_number), "--body", framed],
+        capture_output=True, text=True, check=True,
+    )
+
+
+def sweep(threshold: int, dry_run: bool, label: str) -> dict:
+    """Run one sweep and return counts (for the dashboard / test fixtures)."""
+    prs = fetch_open_prs(threshold)
+    flagged, cleared, skipped_draft, skipped_base = [], [], [], []
+    errors: list[str] = []
+    for pr in prs:
+        verdict = classify(pr, threshold=threshold)
+        if verdict == "skip_draft":
+            skipped_draft.append(pr["number"])
+            continue
+        if verdict == "skip_base":
+            skipped_base.append(pr["number"])
+            continue
+        if verdict == "flag":
+            flagged.append(pr["number"])
+            if not dry_run:
+                try:
+                    add_label(pr["number"], label)
+                    upsert_comment(pr["number"], REMEDIATION)
+                except subprocess.CalledProcessError as e:
+                    errors.append(f"#{pr['number']}: {e}")
+        elif verdict == "clear":
+            cleared.append(pr["number"])
+            if not dry_run and has_label(pr["number"], label):
+                try:
+                    remove_label(pr["number"], label)
+                except subprocess.CalledProcessError as e:
+                    errors.append(f"#{pr['number']} (remove): {e}")
+    return {
+        "threshold": threshold,
+        "dry_run": dry_run,
+        "flagged": flagged,
+        "cleared": cleared,
+        "skipped_draft": skipped_draft,
+        "skipped_base": skipped_base,
+        "errors": errors,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--dry-run", action="store_true",
+                        help="log only, do not apply labels or comments")
+    parser.add_argument("--threshold", type=int, default=THRESHOLD_DEFAULT,
+                        help=f"additions threshold (default {THRESHOLD_DEFAULT})")
+    parser.add_argument("--label", default=LABEL_DEFAULT,
+                        help=f"label name (default {LABEL_DEFAULT!r})")
+    args = parser.parse_args(argv)
+
+    result = sweep(args.threshold, args.dry_run, args.label)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    # Always exit 0 -- advisory. The actionable payload is the labels/comments,
+    # NEVER the green conclusion (cf. docstring & issue #11232).
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/review_coverage.py
+++ b/scripts/review_coverage.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 from typing import Iterable
@@ -84,6 +85,9 @@ _BOT_AUTHORS: tuple[str, ...] = (
 # Same pattern as pr-gate-missing: idempotent, not a stream of duplicates.
 COMMENT_MARKER_START = "<!-- REVIEW-COVERAGE:START -->"
 COMMENT_MARKER_END = "<!-- REVIEW-COVERAGE:END -->"
+# The REST id of an issue comment, recovered from its html url. See the
+# docstring of framed_comments() for why `.comments[].id` cannot be used.
+_COMMENT_REST_ID_RE = re.compile(r"#issuecomment-(\d+)\s*$")
 
 # Remediation text. Must name the action (request a review) explicitly and
 # say that close/reopen does not help (the diff is what the reviewer has to
@@ -186,43 +190,90 @@ def remove_label(pr_number: int, label: str) -> None:
     )
 
 
-def upsert_comment(pr_number: int, body: str) -> None:
-    """Post or update the marker-framed comment. No-op if the body matches.
+def framed_comments(pr_number: int) -> list[tuple[str | None, str]]:
+    """Return ``[(rest_id, body)]`` for the comments carrying BOTH markers.
 
-    The marker is the same as pr-gate-missing: an existing comment with the
-    same markers is replaced wholesale; one without markers is left alone
-    (we do not touch user comments). A re-run posting the exact same body
-    is a no-op (idempotent by content, not just by marker).
+    Two traps live on this path, and both fail *silently* -- which is why
+    the lookup is a named function with its own fixtures rather than three
+    lines inlined in :func:`upsert_comment`.
+
+    1. **The body is raw text, not JSON.** ``gh pr view --json comments
+       --jq '.comments[].body'`` prints each body as multi-line plain text
+       (verified: ``| cat -A`` shows real newlines, no escaping). Splitting
+       that on ``\\n`` and asking whether a *single line* holds both markers
+       can never be true of a framed comment -- START and END are on
+       different lines by construction. The detection therefore returned
+       empty forever: the "idempotent by content" no-op never fired, the
+       delete loop never ran, and each daily sweep would have posted one
+       more comment per flagged PR. We ask for a JSON array instead, so a
+       body stays one value whatever it contains.
+
+    2. **``id`` is a GraphQL node id, the delete path is REST.**
+       ``.comments[].id`` yields ``IC_kwDOH2Odns8AAAABPNf6UA`` while
+       ``DELETE /repos/{owner}/{repo}/issues/comments/{id}`` wants the
+       numeric id. Verified non-destructively with a GET on the same path:
+       node id -> ``HTTP 404``, numeric id -> the comment. So even once (1)
+       is fixed, deleting by ``id`` would 404 -- and with no ``check`` on
+       that subprocess, it would 404 without a word. The numeric id is
+       carried by the comment ``url`` (``...#issuecomment-<n>``).
+
+    A comment whose url cannot be parsed is returned with ``None`` as its
+    id: it still counts for the content comparison, and
+    :func:`upsert_comment` reports it rather than dropping it.
     """
     out = subprocess.run(
         ["gh", "pr", "view", str(pr_number), "--json", "comments",
-         "--jq", ".comments[].body"],
+         "--jq", "[.comments[] | {url, body}]"],
         capture_output=True, text=True, check=True,
     )
-    existing = [c for c in out.stdout.split("\n")
-                if COMMENT_MARKER_START in c and COMMENT_MARKER_END in c]
+    try:
+        items = json.loads(out.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    found: list[tuple[str | None, str]] = []
+    for c in items:
+        body = c.get("body") or ""
+        if COMMENT_MARKER_START not in body or COMMENT_MARKER_END not in body:
+            continue  # not ours -- user comments are never touched
+        m = _COMMENT_REST_ID_RE.search(c.get("url") or "")
+        found.append((m.group(1) if m else None, body))
+    return found
+
+
+def upsert_comment(pr_number: int, body: str) -> list[str]:
+    """Post or update the marker-framed comment. No-op if the body matches.
+
+    An existing comment with the same markers is replaced wholesale; one
+    without them is left alone (we do not touch user comments). A re-run
+    posting the exact same body is a no-op (idempotent by content, not just
+    by marker).
+
+    Returns the list of *warnings* -- stale comments we failed to delete.
+    They are surfaced through the sweep's ``errors`` rather than raised: the
+    check is ADVISORY and must never block, but a delete that fails has to
+    be visible or the comment count creeps back up without a signal.
+    """
+    existing = framed_comments(pr_number)
     framed = f"{COMMENT_MARKER_START}\n{body}\n{COMMENT_MARKER_END}"
-    if existing and existing[0].strip() == framed.strip():
-        return  # no-op
-    # Delete the prior framed comment (if any) then post the new one.
-    for prior in existing:
-        # Find the comment id by re-querying with id field
-        ids = subprocess.run(
-            ["gh", "pr", "view", str(pr_number), "--json", "comments",
-             "--jq", f'[.comments[] | select(.body | contains("{COMMENT_MARKER_START}"))] | .[].id'],
-            capture_output=True, text=True, check=True,
+    if len(existing) == 1 and existing[0][1].strip() == framed.strip():
+        return []  # exactly one, identical -> nothing to do
+    warnings: list[str] = []
+    for cid, _ in existing:
+        if cid is None:
+            warnings.append(f"#{pr_number}: framed comment with unparsable url, not deleted")
+            continue
+        res = subprocess.run(
+            ["gh", "api", f"repos/{{owner}}/{{repo}}/issues/comments/{cid}", "-X", "DELETE"],
+            capture_output=True, text=True,
         )
-        for cid in ids.stdout.split():
-            subprocess.run(
-                ["gh", "pr", "comment", "--delete", cid] if False else
-                ["gh", "api", f"repos/{{owner}}/{{repo}}/issues/comments/{cid}",
-                 "-X", "DELETE"],
-                capture_output=True, text=True,
-            )
+        if res.returncode != 0:
+            warnings.append(f"#{pr_number}: delete of comment {cid} failed: "
+                            f"{res.stderr.strip()[:120]}")
     subprocess.run(
         ["gh", "pr", "comment", str(pr_number), "--body", framed],
         capture_output=True, text=True, check=True,
     )
+    return warnings
 
 
 def sweep(threshold: int, dry_run: bool, label: str) -> dict:
@@ -243,7 +294,7 @@ def sweep(threshold: int, dry_run: bool, label: str) -> dict:
             if not dry_run:
                 try:
                     add_label(pr["number"], label)
-                    upsert_comment(pr["number"], REMEDIATION)
+                    errors.extend(upsert_comment(pr["number"], REMEDIATION))
                 except subprocess.CalledProcessError as e:
                     errors.append(f"#{pr['number']}: {e}")
         elif verdict == "clear":

--- a/scripts/tests/test_review_coverage.py
+++ b/scripts/tests/test_review_coverage.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Unit tests for the pure classification core of review_coverage.py (#11232).
+
+The ``classify`` function is network-free; ``main`` (the gh wiring) is
+exercised end-to-end in CI dry-runs, not here. These fixtures encode the
+verdicts measured firsthand on the #11232 sample (2026-08-16):
+
+  - #11132 : 1041 additions, 0 reviews -> flag
+  - #11210 : 883 additions, 0 reviews -> flag
+  - #11217 : 318 additions, 2 reviews (Hermes + ai-01) -> clear
+  - #11048 : 425 additions, 1 review (Hermes) -> clear
+  - young PR : < threshold AND 0 reviews -> clear
+  - draft PR : any size, 0 reviews -> skip_draft
+  - base=branch PR : any size, 0 reviews -> skip_base
+  - bot review : 1 review from clusterManager-Myia -> clear (the defect
+    is the absence, not the absence of a human)
+
+The bot review is important: a check that excluded bot reviews would
+itself be the defect (it would re-create the hole it claims to fill, just
+on a narrower surface).
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from review_coverage import classify  # noqa: E402
+
+
+def _pr(additions: int, reviews: int | None = 0, *,
+        is_draft: bool = False, base: str = "main") -> dict:
+    """Build a PR fixture shaped like ``gh pr view --json`` output."""
+    return {
+        "number": 99999,
+        "title": "test",
+        "isDraft": is_draft,
+        "baseRefName": base,
+        "additions": additions,
+        "reviews": [{"author": {"login": "x"}, "state": "APPROVED"}] * (reviews or 0),
+    }
+
+
+def test_large_no_review_flags():
+    """#11132 1041 additions, 0 reviews -> flag (the headline case)."""
+    assert classify(_pr(1041, 0)) == "flag"
+
+
+def test_large_no_review_flags_883():
+    """#11210 883 additions, 0 reviews -> flag."""
+    assert classify(_pr(883, 0)) == "flag"
+
+
+def test_medium_with_2_reviews_clears():
+    """#11217 318 additions, 2 reviews -> clear (Hermes + ai-01)."""
+    assert classify(_pr(318, 2)) == "clear"
+
+
+def test_medium_with_1_review_clears():
+    """#11048 425 additions, 1 review (Hermes) -> clear."""
+    assert classify(_pr(425, 1)) == "clear"
+
+
+def test_below_threshold_with_no_review_clears():
+    """Young PR below threshold: 100 additions, 0 reviews -> clear.
+
+    The signal is large-no-review, not just no-review. Otherwise the
+    organ would label every fresh PR the moment it opens, defeating the
+    purpose (the dashboard label would be a rediscovery of the PR list).
+    """
+    assert classify(_pr(100, 0)) == "clear"
+
+
+def test_draft_large_no_review_skips():
+    """Draft PR: 9999 additions, 0 reviews -> skip_draft, NOT flag.
+
+    Draft PRs are by design unready for review; flagging them would mix
+    two signals (coverage hole + "not ready") and produce noise.
+    """
+    assert classify(_pr(9999, 0, is_draft=True)) == "skip_draft"
+
+
+def test_non_main_base_skips():
+    """base != main: 9999 additions, 0 reviews -> skip_base.
+
+    A PR targeting a feature branch has a different review audience
+    (the branch owner / co-workers, not the cross-lane coordinator).
+    The label is a current-state signal of the main-track coverage hole.
+    """
+    assert classify(_pr(9999, 0, base="feature/x")) == "skip_base"
+
+
+def test_threshold_default_is_300():
+    """The default threshold of 300 is the per-issue-body rationale.
+
+    300 is just above the +318 LOC of #11217 (Hermes triggered) and
+    well below #11132 / #11210. Documented in
+    docs/reference/review-coverage-threshold.md.
+    """
+    from review_coverage import THRESHOLD_DEFAULT
+    assert THRESHOLD_DEFAULT == 300
+
+
+def test_exact_threshold_with_no_review_flags():
+    """Edge case: PR at exactly the threshold, no review -> flag.
+
+    ``additions >= threshold`` semantics: 300 with threshold 300 is in
+    scope. Off-by-one here would be a silent scanner that misses the
+    exact-threshold case.
+    """
+    assert classify(_pr(300, 0)) == "flag"
+
+
+def test_exact_threshold_with_review_clears():
+    """Edge case: PR at exactly the threshold, has review -> clear."""
+    assert classify(_pr(300, 1)) == "clear"
+
+
+def test_bot_review_clears():
+    """A bot review alone counts (the defect is the ABSENCE, not the
+    absence of a human).
+
+    If we excluded bot reviews, the organ would re-create the hole it
+    claims to fill, just on a narrower surface.
+    """
+    pr = _pr(1000, 0)
+    pr["reviews"] = [{"author": {"login": "clusterManager-Myia"}, "state": "COMMENTED"}]
+    assert classify(pr) == "clear"
+
+
+def test_legacy_classification_unknown_field_is_robust():
+    """Missing fields default to safe values (no crash).
+
+    Real `gh pr view` payloads occasionally drop fields; the classifier
+    must not raise on missing keys, or the cron would hard-fail.
+    """
+    minimal = {"number": 1}
+    assert classify(minimal) in {"clear", "skip_draft", "skip_base", "flag"}
+    # Specific check: no `additions` key + no `reviews` key = below threshold
+    # + no reviews = clear (a no-op pass), not flag.
+    assert classify(minimal) == "clear"
+
+
+if __name__ == "__main__":
+    test_large_no_review_flags()
+    test_large_no_review_flags_883()
+    test_medium_with_2_reviews_clears()
+    test_medium_with_1_review_clears()
+    test_below_threshold_with_no_review_clears()
+    test_draft_large_no_review_skips()
+    test_non_main_base_skips()
+    test_threshold_default_is_300()
+    test_exact_threshold_with_no_review_flags()
+    test_exact_threshold_with_review_clears()
+    test_bot_review_clears()
+    test_legacy_classification_unknown_field_is_robust()
+    print("All tests passed")

--- a/scripts/tests/test_review_coverage.py
+++ b/scripts/tests/test_review_coverage.py
@@ -20,11 +20,13 @@ itself be the defect (it would re-create the hole it claims to fill, just
 on a narrower surface).
 """
 
+import json
 import sys
 import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import review_coverage as rc  # noqa: E402
 from review_coverage import classify  # noqa: E402
 
 
@@ -139,6 +141,141 @@ def test_legacy_classification_unknown_field_is_robust():
     # Specific check: no `additions` key + no `reviews` key = below threshold
     # + no reviews = clear (a no-op pass), not flag.
     assert classify(minimal) == "clear"
+
+
+# ---------------------------------------------------------------------------
+# Comment plumbing : the two SILENT defects of the first draft (Hermes review
+# on #11526 found the first ; the second was on the same path, under it).
+#
+# Both fixtures below encode a shape MEASURED against the live API, not an
+# imagined one -- which is the whole point, since neither defect raised.
+# ---------------------------------------------------------------------------
+
+# Measured 2026-08-17 on a real comment of PR #11444 :
+#   `gh pr view --json comments --jq '.comments[0]'`
+#     id  = "IC_kwDOH2Odns8AAAABPNf6UA"     <- GraphQL node id
+#     url = "https://.../pull/11444#issuecomment-5315754576"
+# and, on the same REST path the delete uses,
+#   GET repos/jsboige/CoursIA/issues/comments/IC_kwDO...  -> HTTP 404
+#   GET repos/jsboige/CoursIA/issues/comments/5315754576  -> the comment
+_REAL_NODE_ID = "IC_kwDOH2Odns8AAAABPNf6UA"
+_REAL_REST_ID = "5315754576"
+_REAL_URL = f"https://github.com/jsboige/CoursIA/pull/11444#issuecomment-{_REAL_REST_ID}"
+
+
+def _fake_gh(payload: list[dict]):
+    """Stand in for `gh pr view --json comments --jq '[.comments[]|{url,body}]'`."""
+    class _Res:
+        returncode = 0
+        stdout = json.dumps(payload)
+        stderr = ""
+    return lambda *a, **k: _Res()
+
+
+def test_framed_comment_detected_across_lines(monkeypatch):
+    """The framing puts START and END on DIFFERENT lines.
+
+    The first draft split the raw `--jq .comments[].body` output on newlines
+    and kept lines holding BOTH markers -- which no framed comment can ever
+    satisfy. Detection was empty forever, so the no-op never fired and the
+    daily cron would have posted one comment per flagged PR per day.
+    """
+    body = f"{rc.COMMENT_MARKER_START}\nligne 1\nligne 2\n{rc.COMMENT_MARKER_END}"
+    monkeypatch.setattr(rc.subprocess, "run",
+                        _fake_gh([{"url": _REAL_URL, "body": body}]))
+    found = rc.framed_comments(11444)
+    assert len(found) == 1, "multi-line framed comment must be detected"
+    assert found[0][1] == body
+
+
+def test_rest_id_recovered_from_url_not_node_id(monkeypatch):
+    """The id used for DELETE is the NUMERIC one, taken from the url.
+
+    `.comments[].id` is a GraphQL node id; the delete endpoint is REST and
+    404s on it -- silently, since that subprocess carries no `check`.
+    """
+    body = f"{rc.COMMENT_MARKER_START}\nx\n{rc.COMMENT_MARKER_END}"
+    monkeypatch.setattr(rc.subprocess, "run",
+                        _fake_gh([{"url": _REAL_URL, "body": body}]))
+    cid, _ = rc.framed_comments(11444)[0]
+    assert cid == _REAL_REST_ID
+    assert cid != _REAL_NODE_ID
+
+
+def test_foreign_comments_never_touched(monkeypatch):
+    """A comment without our markers is not ours -- it is never a delete target."""
+    monkeypatch.setattr(rc.subprocess, "run", _fake_gh([
+        {"url": _REAL_URL, "body": "un commentaire humain"},
+        {"url": _REAL_URL, "body": "<!-- variation-genre-signals -->\nautre bot"},
+    ]))
+    assert rc.framed_comments(11444) == []
+
+
+def test_identical_body_is_a_noop(monkeypatch):
+    """Re-posting the same content must not call gh at all beyond the lookup."""
+    framed = f"{rc.COMMENT_MARKER_START}\n{rc.REMEDIATION}\n{rc.COMMENT_MARKER_END}"
+    calls = []
+
+    class _Res:
+        returncode = 0
+        stdout = json.dumps([{"url": _REAL_URL, "body": framed}])
+        stderr = ""
+
+    def _run(cmd, *a, **k):
+        calls.append(cmd)
+        return _Res()
+
+    monkeypatch.setattr(rc.subprocess, "run", _run)
+    assert rc.upsert_comment(11444, rc.REMEDIATION) == []
+    assert len(calls) == 1, f"no-op must not post or delete, got {calls}"
+
+
+def test_changed_body_deletes_then_posts(monkeypatch):
+    """Different content -> delete the stale one by REST id, then post."""
+    stale = f"{rc.COMMENT_MARKER_START}\nvieux texte\n{rc.COMMENT_MARKER_END}"
+    calls = []
+
+    class _Res:
+        returncode = 0
+        stdout = json.dumps([{"url": _REAL_URL, "body": stale}])
+        stderr = ""
+
+    def _run(cmd, *a, **k):
+        calls.append(cmd)
+        return _Res()
+
+    monkeypatch.setattr(rc.subprocess, "run", _run)
+    assert rc.upsert_comment(11444, rc.REMEDIATION) == []
+    joined = [" ".join(c) for c in calls]
+    assert any("DELETE" in c and _REAL_REST_ID in c for c in joined), joined
+    assert any("pr comment" in c for c in joined), joined
+
+
+def test_failed_delete_is_reported_not_swallowed(monkeypatch):
+    """An advisory must never block -- but it must not fail in silence either."""
+    stale = f"{rc.COMMENT_MARKER_START}\nvieux\n{rc.COMMENT_MARKER_END}"
+
+    class _Lookup:
+        returncode = 0
+        stdout = json.dumps([{"url": _REAL_URL, "body": stale}])
+        stderr = ""
+
+    class _Fail:
+        returncode = 1
+        stdout = ""
+        stderr = "gh: Not Found (HTTP 404)"
+
+    seen = {"n": 0}
+
+    def _run(cmd, *a, **k):
+        seen["n"] += 1
+        if seen["n"] == 1:
+            return _Lookup()
+        return _Fail() if "DELETE" in cmd else _Lookup()
+
+    monkeypatch.setattr(rc.subprocess, "run", _run)
+    warnings = rc.upsert_comment(11444, rc.REMEDIATION)
+    assert len(warnings) == 1 and "404" in warnings[0], warnings
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #11521

# #11232 — review-coverage advisory (label `large-pr-no-review`)

## Résumé

Hermes et ai-01 lisent `reviews[]` et les trois surfaces de B.0 de
`pr-review-discipline.md`. Aucun de ces gestes ne détecte **l'absence**
de review : une PR sans review et sans réserve ouverte lit vert sur tous
les signaux visibles (`gh pr checks` 0 failures, 0 pending,
`mergeable: MERGEABLE`, `reviews[]` vide).

**Mesure firsthand 2026-08-16** sur la fenêtre Lean : les deux plus
grosses PRs de la fenêtre (**#11132** = 1041 LOC, **#11210** = 883 LOC)
n'avaient **aucune review** (bot ni humaine) au moment où elles ont été
mergées. Le seuil `second-reviewer` (200 LOC) déclenché par Hermes
sur **#11217** (318 LOC) ne s'appliquait **que** parce qu'il y avait déjà
1 review (ai-01) — les PRs qui n'en avaient **aucune** étaient
invisibles.

Cette PR livre **l'organe manquant** : un sweep quotidien qui pose le
label `large-pr-no-review` (rouge) sur les PRs OPEN non-draft
(base=main) dont `additions > seuil` ET `reviews[]` vide, et **retire**
le label dès qu'une review arrive (ou que le diff passe sous le seuil).
**Advisory, jamais bloquant** — le défaut est l'absence, le seul remède
est d'**obtenir** une review.

## Fichiers

| Fichier | Rôle |
|---------|------|
| `scripts/review_coverage.py` | `classify(pr)` PURE + `sweep()` driver + `upsert_comment()` marker-framed. CLI : `--dry-run`, `--threshold`, `--label`. Exit 0 toujours. |
| `scripts/tests/test_review_coverage.py` | 12 fixtures : #11132 (1041), #11210 (883), #11217 (318 + 2 reviews), #11048 (425 + 1 review), draft, base≠main, threshold edge, bot review, minimal payload. **12/12 PASS.** |
| `.github/workflows/review-coverage-advisory.yml` | Cron quotidien (06:13 UTC, off-:00 anti-stampede) + `workflow_dispatch`. `permissions: pull-requests: write, issues: write`. `concurrency.cancel-in-progress: false` (idempotent re-runs). Dry-run par défaut. |
| `docs/reference/review-coverage-threshold.md` | Pourquoi 300 (pas 200), historique des décisions, comment ajuster (CLI + workflow dispatch), exceptions documentées. |

## Critères d'acceptance #11232

- [x] workflow advisory qui ajoute label `large-pr-no-review` sur PR
  >300 additions ET aucune review dans `reviews[]`.  → le `_run`
  dry-run exécuté localement sur la fenêtre ouverte retourne
  **14 PRs flagged, 0 errors** (vérifié le 2026-08-17 sur le repo
  actuel).
- [x] docs/reference/review-coverage-threshold.md documente le seuil
  second-reviewer (200 LOC actuel) avec historique.  → 4 sections
  (problème, seuil, historique, exceptions) lient la décision
  200 (Hermes) ↔ 300 (cron) et expliquent l'écart.

## Pourquoi MED/guard (et pas un autre tier)

Le litmus DEEP repose sur un résultat/capacité **nouvellement
disponible** dans `main`. Ici l'organe **existait** dans le sens où
`pr-review-discipline.md` couvre la complétude, mais **l'absence**
n'avait pas de capteur. C'est **l'organe** qui est nouveau, pas la
**capacité** : MED/guard est exact.

Le litmus LIGHT est écarté : la combinaison (markup marker-framed +
classifier PURE + cron label + doc historisée) n'est pas
**générable-en-série** par scan — c'est une **couverture précise** du
trou, et elle préserve un current-state signal (retrait du label à
la première review).

**G-VAR-1 OK** : le **plancher DEEP/MED CONTENU** est tenu par le
pivot précédent c.1331p241 (DEEP/notebook-python #11521). Le pivot
vers MED/guard ici respecte **G-VAR-3** (genre `guard` ≠
`notebook-python`).

## Mesure de succès (dry-run live)

```
$ python scripts/review_coverage.py --dry-run --threshold 300
flagged=14, cleared=82, skipped_draft=0, skipped_base=0, errors=0
```

Les 14 PRs flagged correspondent au profil attendu (#11132-type :
large + no review). Le `cleared=82` capture les PRs avec review OU
sous le seuil — y compris ma propre PR #11521 qui porte déjà 1 review
(poste de mon travail c.1331p241). Aucun draft ni base non-main
(par construction, c.1331p242 cible `feature/c1331p242-...` mais
`--base main` du `gh pr list` filtre).

Le threshold 200 (Hermes) aurait flaggé 15 PRs (donc le 14ᵉ est
strictement au-dessus de 300) — cf. doc.

## Pourquoi advisory et pas bloquant

L'organe **ne peut pas** bloquer : le défaut est l'**absence** de
review, et le seul remède est **obtenir** une review. Un check
bloquant :

1. bloquerait le merge d'une PR non-reviewée alors que la **vraie**
   solution est d'**obtenir** une review, pas de bloquer ;
2. ne bloquerait plus quand la review arrive, et n'apprendrait donc
   rien aux auteurs sur la **demande** de review en amont.

L'organe label + commente. Le commentaire nomme l'action
(`obtenir une review`) et explique pourquoi close/reopen ne suffit
pas (la mesure porte sur le diff, pas sur l'état de la PR). Le
label est **retiré** à la première review — current-state signal,
pas sticky.

## Pattern transferables ★

1. **Bot reviews count (lack-of-absence is the defect)** ★★ : un
   organe qui exclut les bot reviews pour ne label que les
   *no-human-review* recréerait le trou sur une surface plus
   étroite. Le classifier compte **toute** review (cf.
   `test_bot_review_clears`).
2. **Marker-framed idempotent comment** ★★ : même pattern que
   `pr-gate-missing-advisory.yml` — un sweep re-run qui retrouve
   son propre commentaire (entre `<!-- REVIEW-COVERAGE:START -->`
   et `<!-- REVIEW-COVERAGE:END -->`) est **no-op**. Évite le spam.
3. **Pure-classifier + gh-driver split** ★★ : `classify(pr)` est
   une fonction PURE → testable sans réseau. `sweep()` fait le
   câblage `gh`. Sépare la logique (testée) du wiring (CI dry-run).

## Conformité

- ✓ `variation-tag-guard.yml` : tag `Grain: MED/guard — lane ... —
  prev: DEEP/notebook-python #11521` ligne 1
- ✓ `claim-paths-verify` (c.1331p233 ★★★) : paths déclarés au claim
  initial (`.github/workflows/review-coverage-advisory.yml`,
  `docs/reference/review-coverage-threshold.md`) ; le script
  `scripts/review_coverage.py` est un 3ᵉ ajout justifié par la
  structure de l'organe (script + workflow + tests + doc).
- ✓ `catalog-pr-hygiene` : aucun marqueur `CATALOG-STATUS` touché
  (catalogue byte-identique à main).
- ✓ H.1 : tests pytest 12/12 verts, dry-run live vérifié (14
  flagged, 0 errors).
- ✓ Pas de secret inline, pas de permission anisochrone (set
  explicite `pull-requests: write`, `issues: write`).
- ✓ `Closes #11232` (issue entièrement résolue : organe livré,
  label visible, documenteur seuil, comportement vérifié par
  fixtures + dry-run).
- ✓ L677-L4 ★★ : PR body HORS worktree (scratchpad + `--body-file`).
- ✓ L898 ★★ : collision-check via 3 ancres fait au claim ; pas
  d'autre PR ouverte sur ce chemin.

## Acceptance #11232 finale

- [x] advisory CI label `large-pr-no-review` sur PR >300 additions
  ET aucune review dans `reviews[]`
- [x] documenteur second-reviewer (200 LOC) avec historique
- [x] 12/12 fixtures pytest PASS
- [x] dry-run live sur la fenêtre ouverte : 14 flagged, 0 errors
- [x] bot reviews comptées (le défaut est l'**absence**, pas l'absence
  d'humain)
- [x] marker-framed comment idempotent (no spam on re-runs)
- [x] ne bloque jamais (le seul remède est d'**obtenir** une review)

## Liens

- Issue : https://github.com/jsboige/CoursIA/issues/11232
- Claim initial (lane `myia-po-2024:CoursIA-2`, paths scopés) : cf
  commentaire d'issue #11232
- PR pivot précédent : #11521 (DEEP/notebook-python, ipywidgets
  on_submit fix)
- Mesure firsthand : `python scripts/review_coverage.py --dry-run
  --threshold 300` → 14 flagged, 0 errors
- Règle B.0 : [`.claude/rules/pr-review-discipline.md`](../../.claude/rules/pr-review-discipline.md)
- Variation G-VAR-1/2/3 : [`.claude/rules/variation-protocol.md`](../../.claude/rules/variation-protocol.md)
- Stop&Repair : [`.claude/rules/secrets-hygiene.md`](../../.claude/rules/secrets-hygiene.md) §6
