### PR TITLE
fix(ml,#11112): re-exec Lab2-RFP-Analysis sequence UNORDERED -> CLEAN 1..8 (stage 3)

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day2-Document-Agents/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day2-Document-Agents/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
@@ -5,10 +5,10 @@
    "id": "d6923f62",
    "metadata": {
     "papermill": {
-     "duration": 0.002885,
-     "end_time": "2026-05-02T16:13:28.277567+00:00",
+     "duration": 0.006374,
+     "end_time": "2026-08-17T21:09:11.648918+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:28.274682+00:00",
+     "start_time": "2026-08-17T21:09:11.642544+00:00",
      "status": "completed"
     },
     "tags": []
@@ -39,10 +39,10 @@
    "id": "41e8e92d",
    "metadata": {
     "papermill": {
-     "duration": 0.001853,
-     "end_time": "2026-05-02T16:13:28.283079+00:00",
+     "duration": 0.001609,
+     "end_time": "2026-08-17T21:09:11.654602+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:28.281226+00:00",
+     "start_time": "2026-08-17T21:09:11.652993+00:00",
      "status": "completed"
     },
     "tags": []
@@ -64,10 +64,10 @@
    "id": "d04128bc",
    "metadata": {
     "papermill": {
-     "duration": 0.0024,
-     "end_time": "2026-05-02T16:13:28.287715+00:00",
+     "duration": 0.002003,
+     "end_time": "2026-08-17T21:09:11.659431+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:28.285315+00:00",
+     "start_time": "2026-08-17T21:09:11.657428+00:00",
      "status": "completed"
     },
     "tags": []
@@ -82,16 +82,16 @@
    "id": "cce8d28f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:28.292539Z",
-     "iopub.status.busy": "2026-05-02T16:13:28.292225Z",
-     "iopub.status.idle": "2026-05-02T16:13:28.675843Z",
-     "shell.execute_reply": "2026-05-02T16:13:28.675505Z"
+     "iopub.execute_input": "2026-08-17T21:09:11.663422Z",
+     "iopub.status.busy": "2026-08-17T21:09:11.663422Z",
+     "iopub.status.idle": "2026-08-17T21:09:20.769300Z",
+     "shell.execute_reply": "2026-08-17T21:09:20.769300Z"
     },
     "papermill": {
-     "duration": 0.386991,
-     "end_time": "2026-05-02T16:13:28.676616+00:00",
+     "duration": 9.108949,
+     "end_time": "2026-08-17T21:09:20.770367+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:28.289625+00:00",
+     "start_time": "2026-08-17T21:09:11.661418+00:00",
      "status": "completed"
     },
     "tags": []
@@ -119,10 +119,10 @@
    "id": "ae09d1c0",
    "metadata": {
     "papermill": {
-     "duration": 0.001546,
-     "end_time": "2026-05-02T16:13:28.679930+00:00",
+     "duration": 0.002004,
+     "end_time": "2026-08-17T21:09:20.774546+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:28.678384+00:00",
+     "start_time": "2026-08-17T21:09:20.772542+00:00",
      "status": "completed"
     },
     "tags": []
@@ -143,16 +143,16 @@
    "id": "cbce3c96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:28.683755Z",
-     "iopub.status.busy": "2026-05-02T16:13:28.683545Z",
-     "iopub.status.idle": "2026-05-02T16:13:30.005732Z",
-     "shell.execute_reply": "2026-05-02T16:13:30.005340Z"
+     "iopub.execute_input": "2026-08-17T21:09:20.779996Z",
+     "iopub.status.busy": "2026-08-17T21:09:20.779996Z",
+     "iopub.status.idle": "2026-08-17T21:09:24.105080Z",
+     "shell.execute_reply": "2026-08-17T21:09:24.105080Z"
     },
     "papermill": {
-     "duration": 1.325012,
-     "end_time": "2026-05-02T16:13:30.006521+00:00",
+     "duration": 3.329131,
+     "end_time": "2026-08-17T21:09:24.106083+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:28.681509+00:00",
+     "start_time": "2026-08-17T21:09:20.776952+00:00",
      "status": "completed"
     },
     "tags": []
@@ -207,10 +207,10 @@
    "id": "aaa2262f",
    "metadata": {
     "papermill": {
-     "duration": 0.00184,
-     "end_time": "2026-05-02T16:13:30.010147+00:00",
+     "duration": 0.001997,
+     "end_time": "2026-08-17T21:09:24.110100+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:30.008307+00:00",
+     "start_time": "2026-08-17T21:09:24.108103+00:00",
      "status": "completed"
     },
     "tags": []
@@ -225,16 +225,16 @@
    "id": "63d887da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:30.013819Z",
-     "iopub.status.busy": "2026-05-02T16:13:30.013606Z",
-     "iopub.status.idle": "2026-05-02T16:13:32.358175Z",
-     "shell.execute_reply": "2026-05-02T16:13:32.357204Z"
+     "iopub.execute_input": "2026-08-17T21:09:24.116549Z",
+     "iopub.status.busy": "2026-08-17T21:09:24.115529Z",
+     "iopub.status.idle": "2026-08-17T21:09:26.503365Z",
+     "shell.execute_reply": "2026-08-17T21:09:26.503365Z"
     },
     "papermill": {
-     "duration": 2.347997,
-     "end_time": "2026-05-02T16:13:32.359632+00:00",
+     "duration": 2.39184,
+     "end_time": "2026-08-17T21:09:26.504369+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:30.011635+00:00",
+     "start_time": "2026-08-17T21:09:24.112529+00:00",
      "status": "completed"
     },
     "tags": []
@@ -271,10 +271,10 @@
    "id": "a860ab14",
    "metadata": {
     "papermill": {
-     "duration": 0.003079,
-     "end_time": "2026-05-02T16:13:32.368287+00:00",
+     "duration": 0.002063,
+     "end_time": "2026-08-17T21:09:26.508976+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:32.365208+00:00",
+     "start_time": "2026-08-17T21:09:26.506913+00:00",
      "status": "completed"
     },
     "tags": []
@@ -289,16 +289,16 @@
    "id": "b01c6b1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:32.380520Z",
-     "iopub.status.busy": "2026-05-02T16:13:32.380323Z",
-     "iopub.status.idle": "2026-05-02T16:13:32.386705Z",
-     "shell.execute_reply": "2026-05-02T16:13:32.384998Z"
+     "iopub.execute_input": "2026-08-17T21:09:26.514992Z",
+     "iopub.status.busy": "2026-08-17T21:09:26.514992Z",
+     "iopub.status.idle": "2026-08-17T21:09:26.518261Z",
+     "shell.execute_reply": "2026-08-17T21:09:26.518261Z"
     },
     "papermill": {
-     "duration": 0.015319,
-     "end_time": "2026-05-02T16:13:32.389081+00:00",
+     "duration": 0.007276,
+     "end_time": "2026-08-17T21:09:26.519266+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:32.373762+00:00",
+     "start_time": "2026-08-17T21:09:26.511990+00:00",
      "status": "completed"
     },
     "tags": []
@@ -343,10 +343,10 @@
    "id": "73c7309b",
    "metadata": {
     "papermill": {
-     "duration": 0.005718,
-     "end_time": "2026-05-02T16:13:32.401674+00:00",
+     "duration": 0.00255,
+     "end_time": "2026-08-17T21:09:26.523814+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:32.395956+00:00",
+     "start_time": "2026-08-17T21:09:26.521264+00:00",
      "status": "completed"
     },
     "tags": []
@@ -363,16 +363,16 @@
    "id": "59d16d6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:32.410979Z",
-     "iopub.status.busy": "2026-05-02T16:13:32.410511Z",
-     "iopub.status.idle": "2026-05-02T16:13:35.776362Z",
-     "shell.execute_reply": "2026-05-02T16:13:35.775737Z"
+     "iopub.execute_input": "2026-08-17T21:09:26.530980Z",
+     "iopub.status.busy": "2026-08-17T21:09:26.530980Z",
+     "iopub.status.idle": "2026-08-17T21:09:29.244732Z",
+     "shell.execute_reply": "2026-08-17T21:09:29.243711Z"
     },
     "papermill": {
-     "duration": 3.373283,
-     "end_time": "2026-05-02T16:13:35.777246+00:00",
+     "duration": 2.718744,
+     "end_time": "2026-08-17T21:09:29.245723+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:32.403963+00:00",
+     "start_time": "2026-08-17T21:09:26.526979+00:00",
      "status": "completed"
     },
     "tags": []
@@ -386,11 +386,11 @@
       "\n",
       "Proposition technique:\n",
       "\n",
-      "1. **Approche proposée:** Nous proposons de mettre en place un système de prévision des ventes basé sur des modèles de Machine Learning utilisant des séries temporelles. Ces modèles permettront d'anticiper la demande et ainsi réduire les surplus de stocks de 15% tout en maintenant un niveau de service optimal. De plus, nous développerons un dashboard interactif pour visualiser les prévisions et les données en temps réel.\n",
+      "1. **Approche proposée:** Nous proposons de mettre en place un système de prévision des ventes basé sur des modèles de Machine Learning spécialisés dans l'analyse de séries temporelles. Ces modèles permettront de prédire avec précision la demande future, ce qui aidera à réduire les surplus de stocks de 15% en optimisant les niveaux de stockage et les commandes.\n",
       "\n",
-      "2. **Technologies clés:** Nous utiliserons des outils de Machine Learning tels que Python avec les bibliothèques scikit-learn et TensorFlow pour la modélisation des séries temporelles. Pour la création du dashboard interactif, nous opterons pour des technologies web comme HTML, CSS et JavaScript avec des frameworks comme React ou Angular pour une expérience utilisateur fluide et intuitive.\n",
+      "2. **Technologies clés:** Nous utiliserons des outils et des langages de programmation tels que Python, TensorFlow et scikit-learn pour développer les modèles de Machine Learning. Nous mettrons en place un dashboard interactif utilisant des technologies web comme HTML, CSS et JavaScript pour permettre une visualisation claire et intuitive des prévisions de ventes.\n",
       "\n",
-      "3. **Livrables:** À la date limite de fin du T4 2025, nous livrerons un système de prévision des ventes basé sur des modèles de Machine Learning opérationnels, intégrés dans le système existant du client. De plus, nous fournirons un dashboard interactif permettant de visualiser les prévisions de manière claire et concise, facilitant ainsi la prise de décision pour la gestion des stocks.\n"
+      "3. **Livrables:** À la date limite de fin du T4 2025, nous livrerons au client un système opérationnel de prévision des ventes basé sur des modèles de Machine Learning, ainsi qu'un dashboard interactif permettant de visualiser les prévisions en temps réel. Le client pourra ainsi prendre des décisions éclairées pour réduire les surplus de stocks et optimiser sa gestion des stocks.\n"
      ]
     }
    ],
@@ -408,10 +408,10 @@
    "id": "5d4552c9",
    "metadata": {
     "papermill": {
-     "duration": 0.00192,
-     "end_time": "2026-05-02T16:13:35.781173+00:00",
+     "duration": 0.002099,
+     "end_time": "2026-08-17T21:09:29.251354+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:35.779253+00:00",
+     "start_time": "2026-08-17T21:09:29.249255+00:00",
      "status": "completed"
     },
     "tags": []
@@ -435,63 +435,171 @@
   {
    "cell_type": "markdown",
    "id": "8e833adf",
-   "source": "### Exercice 1 : Generer une estimation de budget\n\nDans cet exercice, vous allez créer une chaîne LangChain qui estime le budget d'un projet a partir des informations extraites de l'appel d'offre. L'objectif est de faire raisonner le LLM sur les couts probables (développement, infrastructure, maintenance).\n\n**Objectif** : A partir des données extraites (`exigences_techniques`, `date_limite`), generer une estimation de budget structuree.\n\n**Indices** :\n- Definissez un template qui demande au LLM d'estimer un budget en Jours-Homme et en euros\n- Utilisez `ChatPromptTemplate.from_template()` puis l'opérateur `|` pour créer la chaîne\n- Invoquez la chaîne avec les données de `extracted_data`",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "917e216a",
-   "source": "# Exercice 1 : Estimation de budget\n# Creez une chaine LangChain qui estime le budget du projet\n\n# Etape 1: Definissez le template de prompt\n# Indice: demandez au LLM d'estimer en JH et en euros, pour le developpement et l'infrastructure\nbudget_template = None  # Remplacez None par votre template avec {exigences_techniques} et {date_limite}\n\n# Etape 2: Creez le prompt et la chaine avec LCEL\n# Indice: ChatPromptTemplate.from_template(...) puis | llm\nbudget_prompt = None\nbudget_chain = None\n\n# Etape 3: Invoquez la chaine avec les donnees extraites precedemment\n# Indice: budget_chain.invoke({\"exigences_techniques\": extracted_data[\"exigences_techniques\"], ...})\n# response_budget = ...\n\nprint(\"Exercice 1 a completer : estimation de budget avec LangChain\")",
-   "metadata": {},
-   "execution_count": 7,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "52182217",
-   "source": "### Exercice 2 : Comparer deux appels d'offres\n\nDans un contexte reel, un avant-vente doit souvent comparer plusieurs opportunites. Cet exercice vous demande de créer une chaîne qui compare l'appel d'offre existant avec un second document fictif, et produit une synthese comparative.\n\n**Objectif** : Créer une chaîne qui prend en entree deux textes d'appels d'offres et retourne un tableau comparatif en JSON.\n\n**Indices** :\n- Definissez un template avec deux variables : `{offre_1}` et `{offre_2}`\n- Le format JSON de sortie pourrait contenir : `critere`, `offre_1_valeur`, `offre_2_valeur`, `recommandation`\n- Créez un second texte d'appel d'offre fictif dans une variable `offre_2_texte`",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "42e66402",
-   "source": "# Exercice 2 : Comparaison de deux appels d'offres\n\n# Etape 1: Definissez un second appel d'offre fictif\n# Indice: ecrivez un texte similaire a l'appel d'offre original avec des exigences differentes\noffre_2_texte = None  # Remplacez None par un texte d'appel d'offre fictif\n\n# Etape 2: Definissez le template de comparaison\n# Indice: le template doit contenir {offre_1} et {offre_2} comme variables\ncomparaison_template = None  # Remplacez None par votre template\n\n# Etape 3: Creez le prompt et la chaine\n# Indice: meme pattern que les exercices precedents\ncomparaison_prompt = None\ncomparaison_chain = None\n\n# Etape 4: Testez avec les deux offres\n# Indice: comparaison_chain.invoke({\"offre_1\": document[0].page_content, \"offre_2\": offre_2_texte})\n\nprint(\"Exercice 2 a completer : comparaison de deux appels d'offres\")",
-   "metadata": {},
-   "execution_count": 8,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
+   "metadata": {
+    "papermill": {
+     "duration": 0.003536,
+     "end_time": "2026-08-17T21:09:29.258892+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T21:09:29.255356+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 : Generer une estimation de budget\n",
+    "\n",
+    "Dans cet exercice, vous allez créer une chaîne LangChain qui estime le budget d'un projet a partir des informations extraites de l'appel d'offre. L'objectif est de faire raisonner le LLM sur les couts probables (développement, infrastructure, maintenance).\n",
+    "\n",
+    "**Objectif** : A partir des données extraites (`exigences_techniques`, `date_limite`), generer une estimation de budget structuree.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Definissez un template qui demande au LLM d'estimer un budget en Jours-Homme et en euros\n",
+    "- Utilisez `ChatPromptTemplate.from_template()` puis l'opérateur `|` pour créer la chaîne\n",
+    "- Invoquez la chaîne avec les données de `extracted_data`"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "917e216a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:09:29.264516Z",
+     "iopub.status.busy": "2026-08-17T21:09:29.264516Z",
+     "iopub.status.idle": "2026-08-17T21:09:29.268022Z",
+     "shell.execute_reply": "2026-08-17T21:09:29.268022Z"
+    },
+    "papermill": {
+     "duration": 0.007051,
+     "end_time": "2026-08-17T21:09:29.268022+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T21:09:29.260971+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : estimation de budget avec LangChain\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : Estimation de budget\n",
+    "# Creez une chaine LangChain qui estime le budget du projet\n",
+    "\n",
+    "# Etape 1: Definissez le template de prompt\n",
+    "# Indice: demandez au LLM d'estimer en JH et en euros, pour le developpement et l'infrastructure\n",
+    "budget_template = None  # Remplacez None par votre template avec {exigences_techniques} et {date_limite}\n",
+    "\n",
+    "# Etape 2: Creez le prompt et la chaine avec LCEL\n",
+    "# Indice: ChatPromptTemplate.from_template(...) puis | llm\n",
+    "budget_prompt = None\n",
+    "budget_chain = None\n",
+    "\n",
+    "# Etape 3: Invoquez la chaine avec les donnees extraites precedemment\n",
+    "# Indice: budget_chain.invoke({\"exigences_techniques\": extracted_data[\"exigences_techniques\"], ...})\n",
+    "# response_budget = ...\n",
+    "\n",
+    "print(\"Exercice 1 a completer : estimation de budget avec LangChain\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52182217",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003011,
+     "end_time": "2026-08-17T21:09:29.274246+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T21:09:29.271235+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 : Comparer deux appels d'offres\n",
+    "\n",
+    "Dans un contexte reel, un avant-vente doit souvent comparer plusieurs opportunites. Cet exercice vous demande de créer une chaîne qui compare l'appel d'offre existant avec un second document fictif, et produit une synthese comparative.\n",
+    "\n",
+    "**Objectif** : Créer une chaîne qui prend en entree deux textes d'appels d'offres et retourne un tableau comparatif en JSON.\n",
+    "\n",
+    "**Indices** :\n",
+    "- Definissez un template avec deux variables : `{offre_1}` et `{offre_2}`\n",
+    "- Le format JSON de sortie pourrait contenir : `critere`, `offre_1_valeur`, `offre_2_valeur`, `recommandation`\n",
+    "- Créez un second texte d'appel d'offre fictif dans une variable `offre_2_texte`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "42e66402",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:09:29.280891Z",
+     "iopub.status.busy": "2026-08-17T21:09:29.280891Z",
+     "iopub.status.idle": "2026-08-17T21:09:29.284413Z",
+     "shell.execute_reply": "2026-08-17T21:09:29.284413Z"
+    },
+    "papermill": {
+     "duration": 0.008643,
+     "end_time": "2026-08-17T21:09:29.285428+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T21:09:29.276785+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : comparaison de deux appels d'offres\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : Comparaison de deux appels d'offres\n",
+    "\n",
+    "# Etape 1: Definissez un second appel d'offre fictif\n",
+    "# Indice: ecrivez un texte similaire a l'appel d'offre original avec des exigences differentes\n",
+    "offre_2_texte = None  # Remplacez None par un texte d'appel d'offre fictif\n",
+    "\n",
+    "# Etape 2: Definissez le template de comparaison\n",
+    "# Indice: le template doit contenir {offre_1} et {offre_2} comme variables\n",
+    "comparaison_template = None  # Remplacez None par votre template\n",
+    "\n",
+    "# Etape 3: Creez le prompt et la chaine\n",
+    "# Indice: meme pattern que les exercices precedents\n",
+    "comparaison_prompt = None\n",
+    "comparaison_chain = None\n",
+    "\n",
+    "# Etape 4: Testez avec les deux offres\n",
+    "# Indice: comparaison_chain.invoke({\"offre_1\": document[0].page_content, \"offre_2\": offre_2_texte})\n",
+    "\n",
+    "print(\"Exercice 2 a completer : comparaison de deux appels d'offres\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "id": "216fa782",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:35.785208Z",
-     "iopub.status.busy": "2026-05-02T16:13:35.785057Z",
-     "iopub.status.idle": "2026-05-02T16:13:35.788347Z",
-     "shell.execute_reply": "2026-05-02T16:13:35.787718Z"
+     "iopub.execute_input": "2026-08-17T21:09:29.290665Z",
+     "iopub.status.busy": "2026-08-17T21:09:29.290665Z",
+     "iopub.status.idle": "2026-08-17T21:09:29.294277Z",
+     "shell.execute_reply": "2026-08-17T21:09:29.294277Z"
     },
     "papermill": {
-     "duration": 0.006303,
-     "end_time": "2026-05-02T16:13:35.789142+00:00",
+     "duration": 0.008235,
+     "end_time": "2026-08-17T21:09:29.295282+00:00",
      "exception": false,
-     "start_time": "2026-05-02T16:13:35.782839+00:00",
+     "start_time": "2026-08-17T21:09:29.287047+00:00",
      "status": "completed"
     },
     "tags": []
@@ -535,22 +643,61 @@
   {
    "cell_type": "markdown",
    "id": "26c0e0e2",
-   "source": "### Exercice 3 : Créer une chaîne d'extraction personnalisee\n\nCréez votre propre chaîne LangChain en modifiant le template d'extraction pour extraire des informations différentes du document d'appel d'offre (client, budget, technologies).",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.001989,
+     "end_time": "2026-08-17T21:09:29.300010+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T21:09:29.298021+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 : Créer une chaîne d'extraction personnalisee\n",
+    "\n",
+    "Créez votre propre chaîne LangChain en modifiant le template d'extraction pour extraire des informations différentes du document d'appel d'offre (client, budget, technologies)."
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "cell-4eb0b399",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003136,
+     "end_time": "2026-08-17T21:09:29.305130+00:00",
+     "exception": false,
+     "start_time": "2026-08-17T21:09:29.301994+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## References\n",
     "\n",
     "1. LangChain, *LangChain Expression Language (LCEL)*, 2023, `python.langchain.com/docs/concepts/lcel`. Syntaxe déclarative de composition de chaînes via l'opérateur tube `|` ; chaque composant implémente l'interface `Runnable` (*batch*, asynchrone, *streaming*). Primitive centrale de ce laboratoire (`extraction_prompt | llm`).\n",
     "2. H. Chase, *LangChain*, octobre 2022, `github.com/langchain-ai/langchain`. Framework modulaire open-source pour applications LLM — chaînes composables, *tools*, mémoire. Référence bibliographique détaillée au Lab 8 (ADK Introduction).\n"
-   ],
-   "id": "cell-4eb0b399"
+   ]
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "openai",
+   "api_usd_est": 0.01,
+   "cpu_min": 2,
+   "external_account": "openai",
+   "free_alternative": "ollama",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-23T13:00Z",
+   "network": true,
+   "notes": "Agent LangChain (Document Agent) pour analyser un appel d'offre (RFP) PDF.\nUtilise ChatOpenAI(model='gpt-3.5-turbo', temperature=0) par defaut ; fallback\nOllama local mentionne en commentaire dans cell[5].\nCout estime : ~$0.01 par execution complete (document ~2-3K tokens + extraction).\nNecessite OPENAI_API_KEY en variable d'environnement.",
+   "reduced_pedagogical": "gpt-3.5-turbo",
+   "reproducibility": "MED",
+   "validator": "papermill",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -566,36 +713,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 9.608341,
-   "end_time": "2026-05-02T16:13:36.153435+00:00",
+   "duration": 20.422102,
+   "end_time": "2026-08-17T21:09:30.192847+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Lab2-RFP-Analysis.ipynb",
    "output_path": "Lab2-RFP-Analysis.ipynb",
    "parameters": {},
-   "start_time": "2026-05-02T16:13:26.545094+00:00",
+   "start_time": "2026-08-17T21:09:09.770745+00:00",
    "version": "2.7.0"
-  },
-  "cost": {
-   "api_usd_est": 0.01,
-   "api_provider": "openai",
-   "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": true,
-   "external_account": "openai",
-   "free_alternative": "ollama",
-   "reduced_pedagogical": "gpt-3.5-turbo",
-   "reproducibility": "MED",
-   "metadata_written": "2026-07-23T13:00Z",
-   "validator": "papermill",
-   "notes": "Agent LangChain (Document Agent) pour analyser un appel d'offre (RFP) PDF.\nUtilise ChatOpenAI(model='gpt-3.5-turbo', temperature=0) par defaut ; fallback\nOllama local mentionne en commentaire dans cell[5].\nCout estime : ~$0.01 par execution complete (document ~2-3K tokens + extraction).\nNecessite OPENAI_API_KEY en variable d'environnement."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/genai #11527

See #11112 (contribution partielle : 1 notebook de plus re-exécuté, l'epic étage 3 reste ouverte).

## Summary

Re-exécution complète de `Lab2-RFP-Analysis.ipynb` (DataScienceWithAgents, Track1-LangChain) : séquence **UNORDERED -> CLEAN 1..8** (non-monotone au claim — mesuré `[1,2,3,4,5,7,8,6]` : la cellule 17 « Exercice : créez votre propre chaîne » avait été exécutée après la 16).

**Défaut initial** : session interactive désordonnée (ordre d'exécution ≠ ordre du fichier).

**Fix** : re-exécution intégrale in-order via papermill (kernel `coursia-ml-pymc` → coursia-ml-training, `--cwd` dossier du notebook).

**Exécution réelle** : API OpenAI — `gpt-3.5-turbo` (modèle codé en dur dans la source, servi par le compte, probe vérifié 1.6 s avant le run). Cellule 7 (extraction) : JSON **identique au baseline** (`objectif_metier` = « Réduire les surplus de stocks de 15% », `date_limite` = « Fin du T4 2025 » — température 0). Cellule 11 (génération de proposition) : nouvelle ébauche cohérente (reformulation légitime du même contenu).

## Validation

- `check_exec_sequence.py` : **CLEAN 1..8** (8 cellules code).
- `check_exec_ratchet.py origin/main` (post-rebase) : **1 changed, 0 régression** (UNORDERED->CLEAN).
- **C.3-strict : sources byte-identiques** — contenu texte des 20 cellules identique au baseline. Le diff porte 5 cellules `"source": "str"` -> `"source": ["list"]` : canonicalisation nbformat par papermill (artefact standard, contenu inchangé — même pattern que #11527, 2 lignes, mergée).
- 0 erreur d'exécution.
- `validate_pr_notebooks.py` : **1/1 PASS** (8 cells).
- Fuite chemin : `detect_papermill_path_leak.py` **0 finding**. Un premier run émettait un `DeprecationWarning langchain-community` (sunset) avec chemin ipykernel en stderr — cause corrigée côté environnement (`PYTHONWARNINGS=ignore` à l'exécution), **aucune sortie hand-éditée, aucune source modifiée** ; le baseline n'avait aucun stderr sur cette cellule.
- `metadata.cost` préservé (clés réordonnées par nbformat, valeurs identiques) ; cell ids 20/20.
- Base rebasée sur `origin/main` frais avant push (catalog-pr-hygiene HARD 2).

## Note d'environnement

Packages `langchain`, `langchain-core`, `langchain-openai`, `langchain-community`, `pypdf` installés dans `coursia-ml-training` (règle F — absents de l'env, requis par le notebook).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
