### PR TITLE
fix(guard,#11155): le ratchet papermill juge la branche, pas son retard

### DIFF
--- a/scripts/notebook_tools/check_papermill_ratchet.py
+++ b/scripts/notebook_tools/check_papermill_ratchet.py
@@ -21,7 +21,9 @@ Everything else is clean, by design of the issue body:
 Usage:
     python check_papermill_ratchet.py <base-ref> [--json]
 
-    base-ref      git ref of the merge base (CI: origin/<base branch>)
+    base-ref      base branch ref (CI: origin/<base branch>). Resolved
+                  internally to merge-base(base-ref, HEAD), so a branch
+                  behind its base is judged on its own diff only.
 
 Head state reads the working tree (in CI the checkout IS the head), base
 state reads the blob via `git show`. Exit code 1 iff at least one
@@ -48,6 +50,25 @@ def git(*args, cwd=None):
     except OSError:
         return None
     return out.stdout if out.returncode == 0 else None
+
+
+def resolve_base(base, cwd=None):
+    """Resolve `base` to merge-base(base, HEAD).
+
+    The gate must judge what the branch CHANGED, not how far behind it is.
+    Comparing a stale branch tree-to-tree against the tip of its base branch
+    reports every notebook the base advanced meanwhile -- with the sign
+    reversed, since the branch still holds the older blob -- and attributes
+    those to the PR.  Measured on #11528 (a one-line markdown fix, 21 commits
+    behind main): 15 changed notebooks / 9 regressions against origin/main,
+    1 / 0 against the merge base.  The false verdict is the dangerous kind:
+    it sends an author to "repair" notebooks they never touched.
+
+    Falls back to the ref as given when no merge base exists (shallow clone,
+    unrelated histories), i.e. the previous behaviour.
+    """
+    out = git("merge-base", base, "HEAD", cwd=cwd)
+    return out.strip() if out and out.strip() else base
 
 
 def changed_notebooks(base, cwd=None):
@@ -137,6 +158,10 @@ def classify(base_state, head_state):
 
 def ratchet(base, cwd=None):
     """One record per changed notebook; regression = stale block ridden."""
+    # Resolved once: the file list and the base-side blobs must be read at
+    # the SAME point, or a notebook the branch AND the base both touched is
+    # compared against the base's newer version.
+    base = resolve_base(base, cwd=cwd)
     records = []
     for path in changed_notebooks(base, cwd=cwd):
         verdict, regression = classify(

--- a/scripts/notebook_tools/tests/test_check_papermill_ratchet.py
+++ b/scripts/notebook_tools/tests/test_check_papermill_ratchet.py
@@ -67,6 +67,55 @@ def commit(repo, msg):
                           encoding="utf-8").stdout.strip()
 
 
+class TestBaseAdvancedMeanwhile:
+    """A branch behind its base is judged on ITS diff, not on the gap.
+
+    Every other test in this file passes a base that is an ANCESTOR of HEAD,
+    where tree-to-tree and merge-base comparisons coincide -- which is why
+    the tree-to-tree diff went unnoticed until #11528 blamed a one-line
+    markdown fix for 9 regressions in notebooks it never opened.
+    """
+
+    def _diverge(self, repo):
+        """base holds two notebooks; the branch edits one, base advances the
+        other. Returns (base_tip_sha, branch_name)."""
+        write_nb(repo, "mine.ipynb", make_nb([OUT1], papermill=PM))
+        write_nb(repo, "theirs.ipynb", make_nb([OUT1], papermill=PM))
+        commit(repo, "base")
+        base_branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo,
+            check=True, capture_output=True, encoding="utf-8").stdout.strip()
+        git_ok(repo, "checkout", "-q", "-b", "feature")
+        nb = make_nb([OUT1], papermill=PM)
+        nb["cells"].insert(0, {"cell_type": "markdown",
+                               "source": "# new prose", "metadata": {}})
+        write_nb(repo, "mine.ipynb", nb)
+        commit(repo, "feature: markdown only")
+        git_ok(repo, "checkout", "-q", base_branch)
+        # the base re-executes the OTHER notebook, block refreshed and all
+        write_nb(repo, "theirs.ipynb", make_nb([OUT2], papermill=PM2))
+        tip = commit(repo, "base advances")
+        git_ok(repo, "checkout", "-q", "feature")
+        return tip
+
+    def test_base_side_changes_are_not_attributed_to_the_branch(self, repo):
+        tip = self._diverge(repo)
+        recs = gate.ratchet(tip, cwd=repo)
+        assert [r["notebook"] for r in recs] == ["mine.ipynb"]
+        assert recs[0]["regression"] is False
+        assert recs[0]["verdict"] == "OUTPUTS_UNCHANGED"
+
+    def test_a_real_regression_on_a_stale_branch_is_still_caught(self, repo):
+        """The fix removes false positives without blunting the gate."""
+        tip = self._diverge(repo)
+        write_nb(repo, "mine.ipynb", make_nb([OUT2], papermill=PM))
+        commit(repo, "feature: outputs changed, block untouched")
+        recs = gate.ratchet(tip, cwd=repo)
+        assert [r["notebook"] for r in recs] == ["mine.ipynb"]
+        assert recs[0]["regression"] is True
+        assert recs[0]["verdict"] == "STALE_BLOCK"
+
+
 class TestRegression:
     def test_changed_outputs_identical_block_fails(self, repo):
         """The exact case #11155: outputs changed, block byte-identical."""


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/notebook-python #11528

## Le défaut

`check_papermill_ratchet.py` liste les notebooks à juger avec

```python
git diff --name-only --diff-filter=ACMR  base HEAD -- *.ipynb
```

— une comparaison **d'arbres**, deux points — alors que sa propre docstring ligne 24 annonçait « git ref of **the merge base** ». La CI lui passe `origin/main`. Sur une branche en retard, le blob plus ancien côté branche se lit comme un retour en arrière : le check attribue à la PR **tout ce que `main` a avancé depuis le point de branchement**.

## La mesure

#11528 est un correctif markdown **d'une ligne**, dans **un** notebook, 21 commits derrière `main`. Le même script, sur la même branche, selon la référence :

```
base = origin/main   →  changed notebooks : 15   regressions : 9   exit 1
base = merge-base    →  changed notebooks : 1    regressions : 0   exit 0
```

Les 9 « régressions » portaient sur GameTheory, PyMC, Planners, Tweety — aucun fichier que la PR n'a ouvert. Le seul notebook réellement modifié était classé correctement (`OUTPUTS_UNCHANGED`) dans les deux cas ; il se noyait dans le bruit.

## Pourquoi ce faux positif-là est nocif

Les défauts d'instrument que ce dépôt a documentés sous-comptent en silence : « rien trouvé » et « pas regardé » rendent la même valeur, plus petite et plus propre que la vérité. Celui-ci est de la famille inverse — il **sur-accuse bruyamment**, et son verdict est actionnable dans le mauvais sens. Un auteur à qui la CI annonce « vous avez régressé `PyMC-8-TrueSkill` » ré-exécute `PyMC-8-TrueSkill`. Sur une machine sans le bon environnement, c'est exactement le geste qui vient de détruire huit graphes de facteurs rendus (#11351, Graphviz absent du runner). Un gate qui envoie réparer ce qui n'est pas cassé est pire qu'un gate absent.

L'effet est en outre proportionnel au retard : plus une branche attend en file, plus le check l'accuse — au moment précis où le backlog est le plus long.

## Le correctif

La base est résolue **une seule fois**, à l'entrée de `ratchet()` :

```python
base = resolve_base(base, cwd=cwd)   # merge-base(base, HEAD)
```

Résoudre à l'entrée plutôt que dans `changed_notebooks` est délibéré : `state_at_base()` lit les blobs côté base via `git show base:path`. Corriger la liste des fichiers sans corriger la référence de lecture aurait comparé un notebook — que la branche **et** `main` ont touché — à la version *plus récente* de `main`. Le défaut aurait changé de place, pas disparu.

Repli sur la référence donnée quand aucune base de fusion n'existe (clone superficiel, histoires sans rapport) : comportement précédent conservé. La CI utilise `fetch-depth: 0`, la base de fusion y est calculable.

## Ce que les tests ne couvraient pas

Les onze tests existants passent tous un `base` qui est un **ancêtre de HEAD** — histoire linéaire, où deux points et trois points coïncident. Le jeu de tests ne contenait aucun cas d'histoire divergente : la seule forme où le défaut est visible. C'est la raison pour laquelle il a survécu à sa propre suite verte.

Deux tests l'ajoutent, et le second est le plus important :

| Test | Ce qu'il établit |
|---|---|
| `test_base_side_changes_are_not_attributed_to_the_branch` | la branche n'est jugée que sur son propre diff |
| `test_a_real_regression_on_a_stale_branch_is_still_caught` | le correctif retire des faux positifs **sans émousser** le gate |

**Contrôle négatif** — les deux échouent sans le correctif :

```
$ git stash push scripts/notebook_tools/check_papermill_ratchet.py
$ python -m pytest ... -k BaseAdvanced -q
2 failed
```

**Après** : `13 passed` (11 anciens + 2 neufs).

## Vérification sur le cas réel

Script corrigé, invoqué exactement comme la CI l'invoque (`origin/main`), sur la branche périmée de #11528 :

```
papermill ratchet -- base origin/main
changed notebooks : 1
regressions       : 0
  OUTPUTS_UNCHANGED  MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claude-Code/notebooks/03-Claude-CLI-References.ipynb
exit=0
```

## Portée

Deux fichiers, +75/−1, aucun notebook touché. Branche coupée sur `origin/main` courant (0 commit de retard) — il aurait été piquant de livrer ce correctif depuis une branche périmée.

See #11155
