### PR TITLE
fix(slides): S3-acculturation tient dans le cadre — 12 slides débordaient

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -1013,6 +1013,7 @@ layout: two-cols
 
 # Prise de décision
 
+<div class="dense-list">
 
 - Théorie de la décision
   - Que faire?
@@ -1031,6 +1032,8 @@ layout: two-cols
 - Décision complexe
   - Processus de Markov
   - Politique optimale
+
+</div>
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
 <img src="./images/img_061.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />

--- a/slides/S3-acculturation/style.css
+++ b/slides/S3-acculturation/style.css
@@ -1,0 +1,60 @@
+/* S3-acculturation — ajustements de mise en page
+ *
+ * Contexte : la migration PPTX -> Slidev a posé un plafond uniforme
+ * `max-h-[300px]` sur chaque image, sans égard pour ce que la colonne
+ * d'accueil peut se permettre. Une image de 300 px CSS dans une colonne
+ * utile de ~540 px passe encore seule ; avec un titre, un chapeau et cinq
+ * puces, elle pousse le contenu hors du cadre 980x552. Slide 37 empile
+ * cinq images à ce plafond : la colonne monte à 765 px pour 647 utiles.
+ *
+ * Mesuré sur le rendu (93 slides, hauteur des boîtes contre le bas de la
+ * page) : 12 slides débordaient, de 8 à 146 px.
+ *
+ * Le correctif ne retouche aucune image et ne retire aucun contenu. Il
+ * borne le layout à la page, fait des colonnes des conteneurs flex, et
+ * rend les images compressibles : `object-contain` étant déjà posé sur
+ * chacune, réduire la boîte préserve le rapport d'aspect. L'image cède
+ * l'espace au texte, qui lui ne peut pas se réduire.
+ */
+
+/* 1. Le layout ne dépasse jamais la page. Sans cette borne, les colonnes
+ *    grandissent avec leur contenu et rien ne déclenche la compression. */
+.slidev-layout.two-cols {
+  height: 100%;
+  max-height: 100%;
+}
+
+/* 2. Colonnes = conteneurs flex verticaux. `min-height: 0` lève le
+ *    minimum implicite qui, autrement, empêche un enfant flex de passer
+ *    sous sa taille de contenu. */
+.slidev-layout.two-cols > .col-left,
+.slidev-layout.two-cols > .col-right {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+/* 3. Les images cèdent en premier (`flex-shrink: 1`), le texte jamais. */
+.slidev-layout img {
+  flex: 0 1 auto;
+  min-height: 0;
+  object-fit: contain;
+}
+
+/* 4. Les grilles d'images sont elles-mêmes compressibles, et leurs
+ *    images suivent la grille plutôt que leur plafond individuel. */
+.slidev-layout .img-grid,
+.slidev-layout .img-grid-2x2 {
+  min-height: 0;
+  flex: 0 1 auto;
+}
+
+/* 5. Listes à forte densité (slide « Prise de décision » : 17 puces sur une
+ *    seule colonne, la grille d'images occupant la droite en absolu). Le
+ *    texte ne peut pas céder par flex : on resserre la typographie plutôt
+ *    que de retirer des puces. */
+.slidev-layout .dense-list ul {
+  font-size: 0.86em;
+  line-height: 1.35;
+}


### PR DESCRIPTION
Grain: MED/slides — lane myia-ai-01:CoursIA — prev: MED/guard #11532

## Ce qui se voyait

Douze slides du deck S3-acculturation débordaient du cadre : le contenu passait sous le bord bas de la page, tronqué à la projection comme à l'export PDF. C'est une part directe de la plainte qui a mis l'Epic slides à l'arrêt — les decks migrés « restaient bien plus moches que les pptx ».

Mesuré sur le rendu réel (Slidev v51, parcours des 85 slides, hauteur de chaque boîte comparée au bas de sa page) :

| Slide | Titre | Débordement |
|---:|---|---:|
| 16 | Formulation de problèmes | 58 px |
| 19 | Stratégies d'exploration (1/2) | 35 px |
| 20 | Stratégies d'exploration (2/2) | 83 px |
| 21 | Jeux | 31 px |
| 22 | Problèmes à satisfaction de contraintes | 146 px |
| 29 | Analyse rhétorique | 8 px |
| 37 | Réseaux bayésiens dynamiques | 118 px |
| 38 | Prise de décision | 55 px |
| 40 | Théorie des jeux (2/2) | 23 px |
| 42 | Conception de mécanismes | 58 px |
| 48 | Caractéristiques (1/2) | 130 px |
| 63 | Grammaires | 45 px |

## La cause

La migration PPTX → Slidev a posé un plafond **uniforme** `max-h-[300px]` sur chaque image, sans égard pour ce que la colonne d'accueil peut se permettre. Une colonne utile fait ~540 px CSS. Une image de 300 px y passe seule ; avec un titre, un chapeau et cinq puces, elle chasse le reste hors du cadre. Slide 37 empile **cinq** images à ce plafond : la colonne monte à 765 px pour 647 utiles.

Rien n'était cassé dans le CSS — le plafond était correctement appliqué. Il était simplement trop généreux, et rien ne forçait l'image à céder : les colonnes n'étaient pas bornées, elles grandissaient avec leur contenu et poussaient le layout au-delà de la page.

## Le correctif

Un `style.css` (le deck n'en avait aucun), quatre règles :

1. le layout `two-cols` est borné à la hauteur de la page — sans cette borne, rien ne déclenche la compression ;
2. les colonnes deviennent des conteneurs flex verticaux, avec `min-height: 0` pour lever le minimum implicite qui empêche un enfant flex de passer sous sa taille de contenu ;
3. les images cèdent en premier (`flex: 0 1 auto`), le texte jamais — `object-contain` étant déjà posé sur chacune, réduire la boîte préserve le rapport d'aspect ;
4. les grilles d'images sont elles-mêmes compressibles.

**Aucune image n'est retouchée, aucun contenu n'est retiré.** Sur slide 16, l'image passe de 300 à 256 px CSS ; le reste de la colonne est intact.

Slide 38 est le seul cas différent : 18 puces sur une colonne unique (la grille d'images occupe la droite en absolu). Le texte ne peut pas céder par flex — la liste est enveloppée dans `.dense-list` et resserrée typographiquement (0,86 em, interligne 1,35). Les 18 puces et les 4 images restent en place ; vérifié après coup dans le DOM.

## Vérification

Balayage des 85 slides, mesure de chaque élément contre le bas **et** le bord droit de sa page :

```
avant : 12 slides débordent (8 à 146 px)
après :  0
```

Aucun débordement n'apparaît sur les 73 slides qui n'en avaient pas — c'est le contrôle qui compte pour une règle CSS globale. Aucun débordement à droite non plus, avant comme après.

Vérification visuelle (captures) sur les trois cas les plus lourds : 22, 37, 38. Slide 37 aligne désormais ses cinq vignettes en bas de colonne ; slide 38 retrouve la grille 2×2 du PPTX d'origine.

### Note sur l'instrument de mesure

Le balayage a produit trois faux zéros avant d'être fiable, tous du même genre — « rien trouvé » et « pas regardé » rendaient la même valeur :

- en vue `/print`, seule la page 1 est mise en page : un garde `if (height < 50) return` sautait les 84 autres **en silence** ;
- sélectionner « la `.slidev-page` visible la plus haute » mesurait toujours la slide 1, `currentSlideNo` étant mis à jour **avant** la fin de la transition — révélé en faisant reporter le titre, auquel toutes les slides répondaient « Intelligence(s) » ;
- le premier jet de règle CSS n'a rien changé du tout : le fichier avait été créé après le démarrage du serveur, et Vite ne découvre pas une cible d'auto-import apparue à chaud.

L'instrument final est calé sur un contrôle positif : slide 16, `li` « Solution = Séquence », dépassement de 17 px — conforme à la capture.

## Portée

Deux fichiers, un deck. Aucun notebook, aucun catalogue. Le fichier `style.css` est local au deck : il ne touche pas les 17 autres.

See #11508
