### PR TITLE
feat(aspire,#11516): 04-Aspire-Streaming-Agent — Channels + BackgroundService + minimal API typée (Grain 3)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/04-Aspire-Streaming-Agent.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/04-Aspire-Streaming-Agent.ipynb
@@ -908,7 +908,7 @@
     "\n",
     "Dans le projet [`StreamingAgent.App/`](StreamingAgent.App/), ces trois briques forment un service réel : un `AgentService` hôte (canaux inbound/outbound) exposé par des endpoints typés (`/health`, `/greet`, `/stream`), vérifiable par `curl`. Le même contrat — flux d'événements, cycle de vie hôte, endpoints typés — gouverne les services de la pile GenAI orchestrée par Aspire (les notebooks [01](01-Aspire-Orchestration-GenAi.ipynb) et [02](02-Aspire-GenAiStack-Reel.ipynb)).\n",
     "\n",
-    "**Pour aller plus loin** : brancher l'observabilité (même famille, grain [#11516](https://github.com/jsboige/CoursIA/issues/11516) A9) — `ActivitySource` au moment de chaque token, trace OTLP du flux complet. Le mécanisme de l'[observabilité dans la série SemanticKernel](../SemanticKernel/04-Filters-Observability.ipynb) s'applique tel quel à ce service.\n"
+    "**Pour aller plus loin** : brancher l'observabilité (même famille, grain [#11516](https://github.com/jsboige/CoursIA/issues/11516) A9) — `ActivitySource` au moment de chaque token, trace OTLP du flux complet. Le mécanisme de l'[observabilité dans la série SemanticKernel](../SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb) s'applique tel quel à ce service.\n"
    ]
   }
  ],

--- a/MyIA.AI.Notebooks/GenAI/Aspire/04-Aspire-Streaming-Agent.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/04-Aspire-Streaming-Agent.ipynb
@@ -1,0 +1,931 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e4d93e1e",
+   "metadata": {},
+   "source": [
+    "# Aspire : un agent streaming en C# — Channels, BackgroundService, minimal API typée\n",
+    "\n",
+    "Ce notebook couvre les grains **A1** et **A2** de l'Epic [#10473](https://github.com/jsboige/CoursIA/issues/10473) — *The Unexpected AI Stack: C#/.NET* (issue [#11516](https://github.com/jsboige/CoursIA/issues/11516)). La ligne de parité visée :\n",
+    "\n",
+    "| Situation | Modèle classique (Task/T) | Pattern streaming (.NET) |\n",
+    "|---|---|---|\n",
+    "| Réponse d'un agent | Une seule valeur `Task<string>` à la fin | **`System.Threading.Channels`** : un flux d'événements consommé en temps réel |\n",
+    "| Cycle de vie du service | Boucle manuelle fragile | **`BackgroundService`** : démarrage/arrêt géré par le host |\n",
+    "| Exposition du flux | Endpoint non typé, contrat implicite | **Minimal API typée .NET 10** : requête et résultat fortement typés |\n",
+    "\n",
+    "Le fil rouge : un **service d'agent** qui reçoit des demandes en entrée et streame ses événements (tokens, progression, fin) en sortie — le même contrat que les services de la pile GenAI du dépôt, mais exprimé en pur .NET.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf441fe3",
+   "metadata": {},
+   "source": [
+    "## Contexte : pourquoi un flux, pas une valeur ?\n",
+    "\n",
+    "Notre pile GenAI (whisper, vLLM, ComfyUI) produit des réponses **par étapes** : un utilisateur qui pose une question à un agent voit les tokens arriver un par un, pas un mur de texte à la fin. Un appel classique `Task<T>` impose d'attendre la réponse complète ; un **flux** (`Channel` + `await foreach`) affiche la progression dès le premier événement.\n",
+    "\n",
+    "Le pattern à construire, en trois briques :\n",
+    "\n",
+    "1. **Un canal inbound** : les demandes arrivent (channel non borné, faible volume).\n",
+    "2. **Un canal outbound** : le service publie ses événements (tokens, `done`).\n",
+    "3. **Un service hôte** (`BackgroundService`) qui connecte les deux.\n",
+    "\n",
+    "Nous commençons par la brique la plus simple : un canal et son flux.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4fcd1fcc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:46:47.600549Z",
+     "iopub.status.busy": "2026-08-17T21:46:47.594545Z",
+     "iopub.status.idle": "2026-08-17T21:46:50.528502Z",
+     "shell.execute_reply": "2026-08-17T21:46:50.523992Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '42184.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.Extensions.Hosting.Abstractions, 10.0.11</span></li></ul></div></div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ".NET 10.0.11\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Channels : System.Threading.Channels.Channel`1[[System.Int32, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BackgroundService : Microsoft.Extensions.Hosting.BackgroundService\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#r \"nuget: Microsoft.Extensions.Hosting.Abstractions\"\n",
+    "\n",
+    "using System.Threading.Channels;\n",
+    "using Microsoft.Extensions.Hosting;\n",
+    "\n",
+    "Console.WriteLine($\".NET {Environment.Version}\");\n",
+    "Console.WriteLine($\"Channels : {typeof(Channel<int>).FullName}\");\n",
+    "Console.WriteLine($\"BackgroundService : {typeof(BackgroundService).FullName}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2db3c0e",
+   "metadata": {},
+   "source": [
+    "## A1 — Channels : la file d'événements\n",
+    "\n",
+    "`Channel<T>` est une file thread-safe, avec deux faces : un **`Writer`** (le producteur écrit) et un **`Reader`** (le consommateur lit). Le consommateur n'importe pas : dès qu'un élément est écrit, il peut le lire — c'est le cœur du streaming.\n",
+    "\n",
+    "Dans l'exemple ci-dessous, l'agent écrit sa réponse **token par token** ; le client lit chaque token dès son arrivée, sans attendre la fin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c68001b9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:46:50.529502Z",
+     "iopub.status.busy": "2026-08-17T21:46:50.529502Z",
+     "iopub.status.idle": "2026-08-17T21:46:51.231447Z",
+     "shell.execute_reply": "2026-08-17T21:46:51.231447Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recu : Bonjour\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recu : je\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recu : suis\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recu : un\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recu : agent\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recu : streaming\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "recu : .\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Flux termine, canal ferme.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Une réponse d'agent, produite morceau par morceau.\n",
+    "var tokens = new[] { \"Bonjour\", \"je\", \"suis\", \"un\", \"agent\", \"streaming\", \".\" };\n",
+    "var canal = Channel.CreateUnbounded<string>();\n",
+    "\n",
+    "// Producteur : l'agent écrit chaque token des qu'il est disponible.\n",
+    "var producteur = Task.Run(async () =>\n",
+    "{\n",
+    "    foreach (var t in tokens)\n",
+    "    {\n",
+    "        await canal.Writer.WriteAsync(t);\n",
+    "        await Task.Delay(50);\n",
+    "    }\n",
+    "    canal.Writer.Complete();\n",
+    "});\n",
+    "\n",
+    "// Consommateur : le client lit le flux en temps reel.\n",
+    "var consommateur = Task.Run(async () =>\n",
+    "{\n",
+    "    await foreach (var t in canal.Reader.ReadAllAsync())\n",
+    "        Console.WriteLine($\"recu : {t}\");\n",
+    "});\n",
+    "\n",
+    "await Task.WhenAll(producteur, consommateur);\n",
+    "Console.WriteLine(\"Flux termine, canal ferme.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ae39d0d",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- **`Writer.WriteAsync`** ne bloque jamais sur un canal non borné : le producteur écrit sans contrainte.\n",
+    "- **`Writer.Complete()`** signale la fin du flux : le consommateur voit sa boucle `await foreach` se terminer.\n",
+    "- **`Reader.ReadAllAsync`** remplace une attente globale par une itération au fil de l'eau.\n",
+    "\n",
+    "Sans canal, le producteur devrait bufferiser la réponse entière avant de la rendre. Avec un canal, le premier token est **consommable 50 ms après le début de la production** — c'est la différence entre une réponse monolithique et une réponse en continu.\n",
+    "\n",
+    "### Exercice 1 — la backpressure d'un canal borné\n",
+    "\n",
+    "Un canal non borné accepte tout ; un canal **borné** (capacité limitée) **bloque le producteur** quand la file est pleine : c'est la **backpressure**. Un consommateur lent ralentit alors le producteur au lieu d'accumuler des millions d'éléments en mémoire. Exécutez d'abord le code tel quel (canal non borné), puis remplacez `CreateUnbounded` par un canal borné de capacité 2 et comparez les temps de blocage du producteur."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2b840a99",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:46:51.232451Z",
+     "iopub.status.busy": "2026-08-17T21:46:51.232451Z",
+     "iopub.status.idle": "2026-08-17T21:46:52.130010Z",
+     "shell.execute_reply": "2026-08-17T21:46:52.129476Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[producteur] emet 1 (bloque 0 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[consommateur] traite 1\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[producteur] emet 2 (bloque 0 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[producteur] emet 3 (bloque 0 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[producteur] emet 4 (bloque 0 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[producteur] emet 5 (bloque 0 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[consommateur] traite 2\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[consommateur] traite 3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[consommateur] traite 4\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[consommateur] traite 5\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 : comparer avec un canal borne de capacite 2.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 : backpressure avec un canal borne.\n",
+    "// Le producteur emet 5 elements toutes les 10 ms ; le consommateur en traite\n",
+    "// un toutes les 150 ms. Avec un canal NON borne, le producteur ne ralentit\n",
+    "// jamais ; avec un canal borne (capacite 2), il est bloque des que la file\n",
+    "// est pleine.\n",
+    "\n",
+    "// TODO Etudiant 1 : remplacer CreateUnbounded par un canal borne :\n",
+    "//     Channel.CreateBounded<int>(new BoundedChannelOptions(2));\n",
+    "// TODO Etudiant 2 : comparer les temps de blocage entre les deux versions\n",
+    "//     et conclure sur la valeur de la backpressure.\n",
+    "\n",
+    "var canalEx = Channel.CreateUnbounded<int>();\n",
+    "\n",
+    "var producteurEx = Task.Run(async () =>\n",
+    "{\n",
+    "    for (var i = 1; i <= 5; i++)\n",
+    "    {\n",
+    "        var t0 = Environment.TickCount64;\n",
+    "        await canalEx.Writer.WriteAsync(i);\n",
+    "        Console.WriteLine($\"[producteur] emet {i} (bloque {Environment.TickCount64 - t0} ms)\");\n",
+    "        await Task.Delay(10);\n",
+    "    }\n",
+    "    canalEx.Writer.Complete();\n",
+    "});\n",
+    "\n",
+    "var consommateurEx = Task.Run(async () =>\n",
+    "{\n",
+    "    await foreach (var i in canalEx.Reader.ReadAllAsync())\n",
+    "    {\n",
+    "        Console.WriteLine($\"[consommateur] traite {i}\");\n",
+    "        await Task.Delay(150);\n",
+    "    }\n",
+    "});\n",
+    "\n",
+    "await Task.WhenAll(producteurEx, consommateurEx);\n",
+    "Console.WriteLine(\"Exercice 1 : comparer avec un canal borne de capacite 2.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e811a7c4",
+   "metadata": {},
+   "source": [
+    "## A2 — BackgroundService : le service d'agent\n",
+    "\n",
+    "Un canal seul ne fait pas un service : il faut un **cycle de vie**. `BackgroundService` fournit la structure : `ExecuteAsync` tourne tant que le host est démarré, et un `CancellationToken` est passé au service pour l'arrêt propre.\n",
+    "\n",
+    "Le pattern du service d'agent :\n",
+    "\n",
+    "| Canal | Rôle |\n",
+    "|---|---|\n",
+    "| `_inbound` (`Channel<AgentRequest>`) | Les **demandes** entrantes, écrites par le client |\n",
+    "| `_outbound` (`Channel<AgentEvent>`) | Les **événements** publiés par le service, lus par le client |\n",
+    "\n",
+    "`ExecuteAsync` consomme `_inbound` et, pour chaque demande, streame les événements sur `_outbound` — exactement le moteur d'un agent de chat.\n",
+    "\n",
+    "La cellule suivante déclare uniquement les **types** (record + service) ; ils sont ensuite utilisés dans la cellule d'exécution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3d89127a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:46:52.130515Z",
+     "iopub.status.busy": "2026-08-17T21:46:52.130515Z",
+     "iopub.status.idle": "2026-08-17T21:46:52.301979Z",
+     "shell.execute_reply": "2026-08-17T21:46:52.300979Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "using System.Threading;\n",
+    "\n",
+    "// Contrat du service d'agent : des demandes en entree, un flux d'evenements en sortie.\n",
+    "public record AgentRequest(string Prompt);\n",
+    "public record AgentEvent(string Kind, string Payload);\n",
+    "\n",
+    "// Le coeur du pattern : un BackgroundService qui consomme le canal inbound\n",
+    "// (les demandes) et streame les evenements sur le canal outbound.\n",
+    "public class StreamingAgentService : BackgroundService\n",
+    "{\n",
+    "    private readonly Channel<AgentRequest> _inbound = Channel.CreateUnbounded<AgentRequest>();\n",
+    "    private readonly Channel<AgentEvent> _outbound = Channel.CreateUnbounded<AgentEvent>();\n",
+    "\n",
+    "    public ChannelWriter<AgentRequest> Inbound => _inbound.Writer;\n",
+    "    public ChannelReader<AgentEvent> Outbound => _outbound.Reader;\n",
+    "\n",
+    "    protected override async Task ExecuteAsync(CancellationToken stoppingToken)\n",
+    "    {\n",
+    "        try\n",
+    "        {\n",
+    "            await foreach (var req in _inbound.Reader.ReadAllAsync(stoppingToken))\n",
+    "            {\n",
+    "                Console.WriteLine($\"[service] recois \\\"{req.Prompt}\\\"\");\n",
+    "                foreach (var mot in req.Prompt.Split(' '))\n",
+    "                {\n",
+    "                    await _outbound.Writer.WriteAsync(new AgentEvent(\"token\", mot), stoppingToken);\n",
+    "                    await Task.Delay(40, stoppingToken);\n",
+    "                }\n",
+    "                await _outbound.Writer.WriteAsync(new AgentEvent(\"done\", req.Prompt), stoppingToken);\n",
+    "            }\n",
+    "        }\n",
+    "        finally\n",
+    "        {\n",
+    "            _outbound.Writer.Complete();\n",
+    "        }\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "272e18de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:46:52.302979Z",
+     "iopub.status.busy": "2026-08-17T21:46:52.302979Z",
+     "iopub.status.idle": "2026-08-17T21:46:52.475976Z",
+     "shell.execute_reply": "2026-08-17T21:46:52.474975Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[service] recois \"Bonjour monde streaming\"\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[client] token : Bonjour\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[client] token : monde\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[client] token : streaming\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[client] done : Bonjour monde streaming\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Service termine proprement.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Demarrage du service sans hote complet : BackgroundService est un IHostedService.\n",
+    "var service = new StreamingAgentService();\n",
+    "var execution = service.StartAsync(CancellationToken.None);\n",
+    "\n",
+    "await service.Inbound.WriteAsync(new AgentRequest(\"Bonjour monde streaming\"));\n",
+    "service.Inbound.Complete(); // plus de demandes : le service termine sa boucle.\n",
+    "\n",
+    "await foreach (var evt in service.Outbound.ReadAllAsync())\n",
+    "    Console.WriteLine($\"[client] {evt.Kind} : {evt.Payload}\");\n",
+    "\n",
+    "await execution;\n",
+    "Console.WriteLine(\"Service termine proprement.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39c067b4",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- **`StartAsync`** lance `ExecuteAsync` ; le service tourne en arrière-plan tant qu'on ne l'arrête pas.\n",
+    "- **`Inbound.Complete()`** ferme le canal des demandes : la boucle du service se termine, le `finally` complète `_outbound`, et `await execution` se libère.\n",
+    "- Le client lit le flux **pendant** que le service produit : tokens + `done` arrivent dans l'ordre du traitement.\n",
+    "\n",
+    "Dans une application réelle, `StreamingAgentService` est enregistré avec `builder.Services.AddHostedService<...>()` et le host gère le cycle de vie complet (démarrage au boot, arrêt gracieux sur Ctrl+C).\n",
+    "\n",
+    "### Exercice 2 — étendre le contrat avec la progression\n",
+    "\n",
+    "Le flux actuel émet `token` puis `done`, mais le client ne voit pas **où on en est**. Étendre le contrat pour émettre un événement `progress` avant chaque token (par exemple `ProgressEvent(Produced, Total)`), puis re-exécuter la cellule d'exécution : le client doit afficher la progression."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ede74e6f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:46:52.475976Z",
+     "iopub.status.busy": "2026-08-17T21:46:52.475976Z",
+     "iopub.status.idle": "2026-08-17T21:46:52.499256Z",
+     "shell.execute_reply": "2026-08-17T21:46:52.499256Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : etendre le contrat du service avec un evenement Progress.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1. Declarer un record ProgressEvent(Produced, Total) ci-dessous ;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2. Dans StreamingAgentService.ExecuteAsync (cellule des types), ecrire un\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     evenement progress avant chaque token (compter Produced sur Total) ;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3. Re-executer la cellule d'execution : le client affiche la progression.\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 : ajouter la progression au flux du service.\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 2 a completer : etendre le contrat du service avec un evenement Progress.\");\n",
+    "Console.WriteLine(\"  1. Declarer un record ProgressEvent(Produced, Total) ci-dessous ;\");\n",
+    "Console.WriteLine(\"  2. Dans StreamingAgentService.ExecuteAsync (cellule des types), ecrire un\");\n",
+    "Console.WriteLine(\"     evenement progress avant chaque token (compter Produced sur Total) ;\");\n",
+    "Console.WriteLine(\"  3. Re-executer la cellule d'execution : le client affiche la progression.\");\n",
+    "\n",
+    "// TODO Etudiant : declarer ici l'evenement de progression, puis etendre le service.\n",
+    "public record ProgressEvent(int Produced, int Total);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bcd7f2e",
+   "metadata": {},
+   "source": [
+    "## A3 — Exposer le flux : minimal API typée .NET 10\n",
+    "\n",
+    "Le service tourne ; reste à l'**exposer** en HTTP. La minimal API .NET 10 apporte deux briques typées :\n",
+    "\n",
+    "- **`TypedResults.Ok(...)` / `TypedResults.Text(...)`** : chaque endpoint retourne un `IResult` **fortement typé** — le compilateur vérifie que l'on ne retourne pas un corps au mauvais type.\n",
+    "- **Handler en classe** : l'endpoint est une classe avec une méthode statique dont les **paramètres sont résolus par le framework** — la requête JSON désérialisée dans un `record`, les services injectés depuis le DI.\n",
+    "\n",
+    "Le projet [`StreamingAgent.App/`](StreamingAgent.App/) du dossier réalise le pattern complet : un `AgentService` (BackgroundService + Channels inbound/outbound, comme dans la partie A2) exposé par trois endpoints typés. Le notebook le **lance réellement** (`dotnet run`), l'interroge, puis l'arrête.\n",
+    "\n",
+    "> Prérequis : le projet doit être compilé une fois (`dotnet build` dans `StreamingAgent.App/`) — la cellule ci-dessous le fait si besoin via `dotnet run` (build incrémental)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "fa87d045",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:46:52.500256Z",
+     "iopub.status.busy": "2026-08-17T21:46:52.500256Z",
+     "iopub.status.idle": "2026-08-17T21:46:54.075829Z",
+     "shell.execute_reply": "2026-08-17T21:46:54.074831Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/health -> 200 : {\"status\":\"ok\",\"service\":\"streaming-agent\"}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/greet -> 200 : {\"message\":\"Bonjour Claude depuis un endpoint typé .NET 10.\"}\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/stream -> 200 : [{\"kind\":\"token\",\"payload\":\"Bonjour\"},{\"kind\":\"token\",\"payload\":\"monde\"},{\"kind\":\"token\",\"payload\":\"streaming\"},{\"kind\":\"done\",\"payload\":\"Bonjour monde streaming\"}]\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Service arrete (processus termine).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Diagnostics;\n",
+    "using System.IO;\n",
+    "using System.Net.Http;\n",
+    "using System.Text;\n",
+    "\n",
+    "// Lance le service d'agent en arriere-plan, requete ses endpoints types, puis l'arrete.\n",
+    "var projet = Path.Combine(Environment.CurrentDirectory, \"StreamingAgent.App\");\n",
+    "Process proc = null;\n",
+    "try\n",
+    "{\n",
+    "    if (!Directory.Exists(projet))\n",
+    "    {\n",
+    "        Console.WriteLine($\"Projet introuvable : {projet}\");\n",
+    "        Console.WriteLine(\"Re-executer ce notebook depuis le dossier MyIA.AI.Notebooks/GenAI/Aspire.\");\n",
+    "    }\n",
+    "    else\n",
+    "    {\n",
+    "        proc = Process.Start(new ProcessStartInfo(\n",
+    "            \"dotnet\", \"run --no-build --project \\\"\" + projet + \"\\\" -- --urls http://127.0.0.1:5128\")\n",
+    "        {\n",
+    "            WorkingDirectory = projet,\n",
+    "        });\n",
+    "\n",
+    "        using var client = new HttpClient { BaseAddress = new Uri(\"http://127.0.0.1:5128\") };\n",
+    "\n",
+    "        // Poll du endpoint /health jusqu'a ce que le serveur ecoute.\n",
+    "        HttpResponseMessage health = null;\n",
+    "        for (var i = 0; i < 40 && health is null; i++)\n",
+    "        {\n",
+    "            try { health = await client.GetAsync(\"/health\"); }\n",
+    "            catch (HttpRequestException) { await Task.Delay(250); }\n",
+    "        }\n",
+    "        var healthBody = health is null ? \"indisponible\" : await health.Content.ReadAsStringAsync();\n",
+    "        Console.WriteLine($\"/health -> {(int)(health?.StatusCode ?? 0)} : {healthBody}\");\n",
+    "\n",
+    "        var corpsGreet = new StringContent(\"{\\\"name\\\":\\\"Claude\\\"}\", Encoding.UTF8, \"application/json\");\n",
+    "        var greet = await client.PostAsync(\"/greet\", corpsGreet);\n",
+    "        Console.WriteLine($\"/greet -> {(int)greet.StatusCode} : {await greet.Content.ReadAsStringAsync()}\");\n",
+    "\n",
+    "        var corpsFlux = new StringContent(\"{\\\"prompt\\\":\\\"Bonjour monde streaming\\\"}\", Encoding.UTF8, \"application/json\");\n",
+    "        var flux = await client.PostAsync(\"/stream\", corpsFlux);\n",
+    "        Console.WriteLine($\"/stream -> {(int)flux.StatusCode} : {await flux.Content.ReadAsStringAsync()}\");\n",
+    "    }\n",
+    "}\n",
+    "finally\n",
+    "{\n",
+    "    if (proc is not null)\n",
+    "    {\n",
+    "        try { proc.Kill(entireProcessTree: true); } catch (InvalidOperationException) { }\n",
+    "        await proc.WaitForExitAsync();\n",
+    "        Console.WriteLine(\"Service arrete (processus termine).\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11b6ad70",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- **`app.MapGet(\"/health\", () => TypedResults.Ok(new HealthResponse(...)))`** : le résultat est un `Ok<HealthResponse>` — le type de la réponse est vérifié à la compilation.\n",
+    "- **`GreetHandler.Handle`** : la classe d'endpoint reçoit la requête JSON **désérialisée dans le `record GreetRequest`** — plus de `FromBody` implicite ni de dictionnaire non typé.\n",
+    "- **`/stream`** : l'endpoint écrit la demande dans le canal **inbound** du service, lit le flux **outbound** jusqu'à l'événement `done`, et retourne le JSON typé. Les tokens sont produits toutes les 80 ms par `AgentService` — la réponse montre la séquence réelle.\n",
+    "\n",
+    "Voir [`StreamingAgent.App/Program.cs`](StreamingAgent.App/Program.cs) pour l'implémentation complète du service et des endpoints.\n",
+    "\n",
+    "### Exercice 3 — concevoir l'endpoint typé du service\n",
+    "\n",
+    "La minimal API .NET 10 expose des endpoints « en classe » : une **requête fortement typée** en entrée, un **résultat fortement typé** en sortie. Modéliser le même contrat, puis l'appliquer au service du notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6c659d9b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T21:46:54.076831Z",
+     "iopub.status.busy": "2026-08-17T21:46:54.076831Z",
+     "iopub.status.idle": "2026-08-17T21:46:54.158263Z",
+     "shell.execute_reply": "2026-08-17T21:46:54.158263Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : implementer l'endpoint type du service.\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1. Declarer GreetRequest / GreetResponse (records) ci-dessous ;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  2. Declarer l'interface IStreamEndpoint<in T> avec HandleAsync ;\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  3. Implementer GreetEndpoint : IStreamEndpoint<GreetRequest> retournant\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     la reponse typee (voir StreamingAgent.App/Program.cs pour le modele reel).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Threading;\n",
+    "\n",
+    "// EXERCICE 3 : concevoir l'endpoint type du service.\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 3 a completer : implementer l'endpoint type du service.\");\n",
+    "Console.WriteLine(\"  1. Declarer GreetRequest / GreetResponse (records) ci-dessous ;\");\n",
+    "Console.WriteLine(\"  2. Declarer l'interface IStreamEndpoint<in T> avec HandleAsync ;\");\n",
+    "Console.WriteLine(\"  3. Implementer GreetEndpoint : IStreamEndpoint<GreetRequest> retournant\");\n",
+    "Console.WriteLine(\"     la reponse typee (voir StreamingAgent.App/Program.cs pour le modele reel).\");\n",
+    "\n",
+    "// TODO Etudiant : completer le contrat et l'implementation.\n",
+    "public record GreetRequest(string Name);\n",
+    "public record GreetResponse(string Message);\n",
+    "\n",
+    "public interface IStreamEndpoint<in T>\n",
+    "{\n",
+    "    Task<GreetResponse> HandleAsync(T request, CancellationToken ct);\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "818e0870",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le pattern complet d'un agent streaming en C# tient en trois briques qui se composent :\n",
+    "\n",
+    "| Brique | API | Rôle |\n",
+    "|---|---|---|\n",
+    "| File d'événements | `System.Threading.Channels` | `Writer`/`Reader`, backpressure, flux `await foreach` |\n",
+    "| Cycle de vie | `BackgroundService` | `ExecuteAsync`, arrêt coopératif par `CancellationToken` |\n",
+    "| Exposition | Minimal API typée .NET 10 | `TypedResults`, handler en classe, injection DI |\n",
+    "\n",
+    "Dans le projet [`StreamingAgent.App/`](StreamingAgent.App/), ces trois briques forment un service réel : un `AgentService` hôte (canaux inbound/outbound) exposé par des endpoints typés (`/health`, `/greet`, `/stream`), vérifiable par `curl`. Le même contrat — flux d'événements, cycle de vie hôte, endpoints typés — gouverne les services de la pile GenAI orchestrée par Aspire (les notebooks [01](01-Aspire-Orchestration-GenAi.ipynb) et [02](02-Aspire-GenAiStack-Reel.ipynb)).\n",
+    "\n",
+    "**Pour aller plus loin** : brancher l'observabilité (même famille, grain [#11516](https://github.com/jsboige/CoursIA/issues/11516) A9) — `ActivitySource` au moment de chaque token, trace OTLP du flux complet. Le mécanisme de l'[observabilité dans la série SemanticKernel](../SemanticKernel/04-Filters-Observability.ipynb) s'applique tel quel à ce service.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/README.md
@@ -67,5 +67,5 @@ sans collision — ports randomisés, noms de conteneurs suffixés.
 - Issue [#10838](https://github.com/jsboige/CoursIA/issues/10838) · Issue [#10857](https://github.com/jsboige/CoursIA/issues/10857) · Epic [#10473](https://github.com/jsboige/CoursIA/issues/10473)
 - Digestion [#11516](https://github.com/jsboige/CoursIA/issues/11516) (Parts 3-5 : streaming agent, tests d'intégration, observabilité) — série source [chrlschn.dev](https://chrlschn.dev/blog/2026/08/the-unexpected-ai-stack-csharp-dotnet-part-4/)
 - Grain #10474 : backend d'observabilité OTLP [`aspire-otel/`](../SemanticKernel/aspire-otel/) (même pattern SDK file-based)
-- Observabilité de la série SemanticKernel : [`04-Filters-Observability.ipynb`](../SemanticKernel/04-Filters-Observability.ipynb) (même famille A9, application directe au service streaming)
+- Observabilité de la série SemanticKernel : [`04-Filters-Observability.ipynb`](../SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb) (même famille A9, application directe au service streaming)
 - Pile GenAI : [`docker-configurations/`](../../../docker-configurations/)

--- a/MyIA.AI.Notebooks/GenAI/Aspire/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/README.md
@@ -19,6 +19,8 @@ paradigme de test absent du dépôt, démontré réel ».
 | [`GenAiStackReel.AppHost-wt2/apphost.cs`](GenAiStackReel.AppHost-wt2/apphost.cs) | Copie pour la 2e instance isolée |
 | [`01-Aspire-Orchestration-GenAi.ipynb`](01-Aspire-Orchestration-GenAi.ipynb) | Notebook .NET Interactive : lancement `--isolated` de **deux instances simultanées**, `aspire describe`/`logs`, transcription réelle par le service orchestré, 3 exercices |
 | [`02-Aspire-GenAiStack-Reel.ipynb`](02-Aspire-GenAiStack-Reel.ipynb) | Notebook #10857 : deux instances isolées de la pile réelle, `describe`/`logs`, **appels traversants authentifiés** (complétion vLLM `qwen3.6-35b-a3b`, `system_stats` ComfyUI), 3 exercices |
+| [`04-Aspire-Streaming-Agent.ipynb`](04-Aspire-Streaming-Agent.ipynb) | Notebook #11516 (A1+A2) : le pattern **agent streaming** en .NET — `System.Threading.Channels` (canaux inbound/outbound, backpressure), `BackgroundService` (cycle de vie), minimal API typée `TypedResults` — 3 exercices |
+| [`StreamingAgent.App/`](StreamingAgent.App/) | Projet .NET 10 du notebook 04 : un service d'agent réel (BackgroundService + Channels) exposé par des endpoints typés `/health`, `/greet`, `/stream` |
 | [`05-Aspire-Tests-Integration.ipynb`](05-Aspire-Tests-Integration.ipynb) | Notebook #11516 Grain 2 (axes A5/A6/A7) : **tests d'intégration modernes** — TUnit + Microsoft Testing Platform, Testcontainers Postgres 18 jetable à port aléatoire, isolation par rollback transactionnel, filtres `--treenode-filter`, 3 exercices |
 | [`IntegrationTests/`](IntegrationTests/) | Projet de tests auto-contenu (TUnit 1.65 + Testcontainers.PostgreSql 4.14 + EF Core 10 sur `net10.0`) : `dotnet test` démarre un vrai Postgres 18, 5/5 tests verts, conteneur auto-purgé |
 | [`assets/echantillon-test-fr.wav`](assets/echantillon-test-fr.wav) | Échantillon audio FR de test (synthèse SAPI Windows) envoyé au service orchestré |
@@ -30,6 +32,7 @@ paradigme de test absent du dépôt, démontré réel ».
 - GPU NVIDIA (le conteneur exige `--gpus all` ; la config est dans l'AppHost, `CUDA_VISIBLE_DEVICES=1` = RTX 3090 externe)
 - Cache HuggingFace hôte contenant le modèle `faster-whisper-large-v3-turbo` (sinon, premier appel = téléchargement ~1.6 Go, une seule fois)
 - Pour le notebook 02 (#10857) : la **pile réelle** joignable — conteneur `comfyui-qwen` démarré (8188) et `VLLM_API_KEY` rendu dans `GenAI/.env` (modèle : [`.env.example`](../.env.example)) via `scripts/secrets/render_envs.py` depuis `master.env`
+- Pour le notebook 04 (#11516) : **aucun Docker requis** — `StreamingAgent.App` compile avec le SDK .NET 10 seul (`dotnet build`), puis le notebook le lance et l'interroge (port local 5128)
 - Pour le notebook 05 / `IntegrationTests/` (#11516 Grain 2) : Docker suffit — l'image `postgres:18` est tirée au premier `dotnet test` (~30 s), les conteneurs de test s'auto-purgent
 
 ## Démarrage rapide
@@ -64,4 +67,5 @@ sans collision — ports randomisés, noms de conteneurs suffixés.
 - Issue [#10838](https://github.com/jsboige/CoursIA/issues/10838) · Issue [#10857](https://github.com/jsboige/CoursIA/issues/10857) · Epic [#10473](https://github.com/jsboige/CoursIA/issues/10473)
 - Digestion [#11516](https://github.com/jsboige/CoursIA/issues/11516) (Parts 3-5 : streaming agent, tests d'intégration, observabilité) — série source [chrlschn.dev](https://chrlschn.dev/blog/2026/08/the-unexpected-ai-stack-csharp-dotnet-part-4/)
 - Grain #10474 : backend d'observabilité OTLP [`aspire-otel/`](../SemanticKernel/aspire-otel/) (même pattern SDK file-based)
+- Observabilité de la série SemanticKernel : [`04-Filters-Observability.ipynb`](../SemanticKernel/04-Filters-Observability.ipynb) (même famille A9, application directe au service streaming)
 - Pile GenAI : [`docker-configurations/`](../../../docker-configurations/)

--- a/MyIA.AI.Notebooks/GenAI/Aspire/StreamingAgent.App/Program.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/StreamingAgent.App/Program.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using System.Threading.Channels;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+var builder = WebApplication.CreateBuilder(new WebApplicationOptions { Args = args });
+// builder.Logging.ClearProviders();
+builder.Services.AddSingleton<AgentService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<AgentService>());
+var app = builder.Build();
+
+app.MapGet("/health", () => TypedResults.Ok(new HealthResponse("ok", "streaming-agent")));
+app.MapPost("/greet", GreetHandler.Handle);
+app.MapPost("/stream", StreamHandler.Handle);
+
+if (args.Length == 0)
+{
+    app.Urls.Add("http://127.0.0.1:5128");
+}
+app.Run();
+
+public record HealthResponse(string Status, string Service);
+public record GreetRequest(string Name);
+public record GreetResponse(string Message);
+public record StreamRequest(string Prompt);
+public record AgentRequest(string Prompt);
+public record AgentEvent(string Kind, string Payload);
+
+// Handler en classe typée : requête forte en entrée, TypedResults en sortie.
+// (Le contrat "endpoint as class" de la minimal API : une méthode statique
+// dont les paramètres sont résolus par le framework — requête JSON + services DI.)
+public static class GreetHandler
+{
+    public static IResult Handle(GreetRequest request)
+        => TypedResults.Ok(new GreetResponse($"Bonjour {request.Name} depuis un endpoint typé .NET 10."));
+}
+
+public static class StreamHandler
+{
+    public static async Task<IResult> Handle(StreamRequest request, AgentService service, CancellationToken ct)
+    {
+        await service.SubmitAsync(new AgentRequest(request.Prompt), ct);
+        var events = new List<AgentEvent>();
+        await foreach (var evt in service.Stream.ReadAllAsync(ct))
+        {
+            events.Add(evt);
+            if (evt.Kind == "done")
+            {
+                break;
+            }
+        }
+        return TypedResults.Text(JsonSerializer.Serialize(events, new JsonSerializerOptions(JsonSerializerDefaults.Web)), "application/json");
+    }
+}
+
+public sealed class AgentService : BackgroundService
+{
+    private readonly Channel<AgentRequest> _inbound = Channel.CreateUnbounded<AgentRequest>();
+    private readonly Channel<AgentEvent> _outbound = Channel.CreateUnbounded<AgentEvent>();
+
+    public ChannelReader<AgentEvent> Stream => _outbound.Reader;
+
+    public ValueTask SubmitAsync(AgentRequest request, CancellationToken ct)
+        => _inbound.Writer.WriteAsync(request, ct);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await foreach (var request in _inbound.Reader.ReadAllAsync(stoppingToken))
+            {
+                foreach (var word in request.Prompt.Split(' '))
+                {
+                    await _outbound.Writer.WriteAsync(new AgentEvent("token", word), stoppingToken);
+                    await Task.Delay(80, stoppingToken);
+                }
+                await _outbound.Writer.WriteAsync(new AgentEvent("done", request.Prompt), stoppingToken);
+            }
+        }
+        finally
+        {
+            _outbound.Writer.Complete();
+        }
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/StreamingAgent.App/StreamingAgent.App.csproj
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/StreamingAgent.App/StreamingAgent.App.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <InvariantGlobalization>true</InvariantGlobalization>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

Grain 3 (A1+A2) de ma digestion [#11516](https://github.com/jsboige/CoursIA/issues/11516), débloqué par po-2024 (RELEASED 20:57Z) : le pattern **agent streaming** en .NET — du canal à l'endpoint typé.

- **`04-Aspire-Streaming-Agent.ipynb`** (nouveau) : 8 cellules code exécutées kernel `.net-csharp`, 3 exercices stubs C.1, prose FR.
  - **A1** `System.Threading.Channels` : Writer/Reader, flux `await foreach`, backpressure (exercice : canal borné).
  - **A2** `BackgroundService` : canaux inbound/outbound, cycle de vie, `CancellationToken`.
  - **A3** minimal API typée : `TypedResults` + handler en classe, endpoints `/health`, `/greet`, `/stream` interrogés réellement.
- **`StreamingAgent.App/`** (nouveau projet .NET 10, `FrameworkReference Microsoft.AspNetCore.App`) : le service d'agent réel (BackgroundService + Channels) exposé par les 3 endpoints typés. Lancé par le notebook (`dotnet run --no-build` + requêtes HTTP), puis arrêté (`Kill(entireProcessTree)`).
- **README Aspire** : table Contenu (04 + projet), prérequis 04 (aucun Docker requis), Voir aussi #11516.

## Validation (critère D notebook + H.2)

- Notebook exécuté **end-to-end via nbclient** (kernel `.net-csharp`) : **8/8 cellules code, 0 erreur**, outputs réels — flux de tokens temps réel, service reçoit/streame, 3 endpoints `200` avec JSON (`/stream` : tokens + `done`, camelCase).
- `StreamingAgent.App` : `dotnet build` OK, endpoints testés en live (health/greet/stream → 200).
- `probeAddresses` banner strippé (`strip_probe_banner.py`), `bin/`/`obj/` gitignored, hooks H.3 passés.

## Verdict SOTA — `IEndpointHandler` : INTRINSIC documenté

Le grain mentionne « minimal API typée `TypedResults`/`IEndpointHandler` net10 ». Vérification sur la machine (regle F / sota-not-workaround) : **`IEndpointHandler` est ABSENT du ref pack installé** `Microsoft.AspNetCore.App.Ref 10.0.11` (`strings` sur la dll : aucun symbole) ; réseau indisponible pour mettre à jour le ref pack. La démo utilise le pattern **réellement disponible** : handler en classe typé (requête forte en entrée, `TypedResults` en sortie) — framework ASP.NET Core réel, pas de workaround. `TypedResults` vérifié présent dans le ref pack.

## Note de séquence

PR #11530 (po-2024, `03-Aspire-Observabilite`) est dans la fournée ai-01. Si le README Aspire entre en conflit à l'insertion du 03, rebase mineur — le 04 est numéroté après le 03.

Grain: MED/notebook-dotnet — lane myia-po-2026:CoursIA — prev: DEEP/prover #11445

See #10473. See #10475. See #11516 (contribution partielle : G3 = A1+A2).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
