### PR TITLE
feat(tooling,#11508): adaptateur .md pour la cure d'accents canonique — 979 → 876, le casseur `theme:` neutralisé

### DIFF
--- a/scripts/notebook_tools/restore_accents_canonical.py
+++ b/scripts/notebook_tools/restore_accents_canonical.py
@@ -183,6 +183,178 @@ def _cure_source(source) -> tuple[object, int]:
     return new_chunks, total
 
 
+# --------------------------------------------------------------------------
+# Adaptateur markdown pur (.md) — decks Slidev, Epic #11508 lot L1.
+#
+# Pourquoi un adaptateur et pas un second outil : `accent-cure-defense-in-depth.md`
+# interdit la cure ad-hoc, qui est la cause racine de chaque regression #2876.
+# Le coeur (`_cure_line`, masquage des cibles de liens, preservation de casse) est
+# reutilise tel quel ; seules les ZONES A PROTEGER changent entre un notebook et
+# un deck.
+#
+# Mesure qui a motive ces masques, prise en lecture seule sur les 18 decks de
+# `slides/` le 2026-08-17 (detail sur l'issue #11508) : la cure notebook appliquee
+# telle quelle proposait 979 cures, dont 146 STRUCTURELLEMENT fausses. La plus
+# grave etait unanime :
+#
+#     theme: ../theme-ia101      ->      theme: ../theme-ia101   (accentue)
+#
+# `theme:` est la cle de configuration Slidev, ligne 2, presente dans 18 decks
+# sur 18. La cure cassait donc CHAQUE deck. Ce n'est pas un defaut du coeur : il
+# a ete ecrit pour la `source` de cellules nbformat, ou aucun frontmatter YAML
+# n'apparait.
+#
+# Quatre zones protegees, chacune adossee a un faux positif mesure :
+#   - frontmatter YAML (document + par-slide)  : 46 occurrences
+#   - blocs de code ``` / ~~~                  : 64 occurrences
+#   - code inline `...`                        : 30 occurrences
+#   - attributs HTML src=/href=/style=         :  6 occurrences
+#
+# `alt=` est DELIBEREMENT laisse curable : l'inventaire de #11508 demande
+# explicitement de curer le texte alternatif (lu par les lecteurs d'ecran et
+# l'indexation), et les commentaires HTML le sont aussi — verifie sur
+# `S1-argumentation:144`.
+
+_FENCE_RE = re.compile(r"^\s{0,3}(?:```|~~~)")
+_SEPARATOR_RE = re.compile(r"^-{3,}\s*$")
+# Une ligne de frontmatter : `cle:` eventuellement indentee, ou une continuation
+# indentee / un item de liste sous une cle.
+_YAML_KEY_RE = re.compile(r"^\s*[A-Za-z_][\w.-]*\s*:")
+_YAML_CONT_RE = re.compile(r"^(?:\s+\S|\s*-\s)")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+# Cles de frontmatter dont la VALEUR est du texte AFFICHE par Slidev : `title`
+# alimente l'onglet du navigateur et les metadonnees du PDF exporte, `info` le
+# panneau d'information. Les laisser sous le masque global protegeait donc de la
+# prose visible — mesure le 2026-08-18 sur les 18 decks : 8 lignes, dont
+# `title: "Intelligence Artificielle - Theorie des jeux"` et
+# `title: "Web Semantique - dotNetRDF & Python"`. Le deck exportait « Theorie »
+# dans ses propres metadonnees PDF.
+#
+# Toutes les AUTRES cles restent protegees en bloc, sans exception : `theme:`,
+# `layout:`, `class:`, `src:`, `transition:` sont de la configuration, et une
+# seule d'entre elles accentuee casse le deck (c'est le faux positif fondateur).
+# La liste est donc une whitelist de prose, jamais une blacklist de config.
+_YAML_PROSE_RE = re.compile(r"^(\s*(?:title|info)\s*:\s*)(\S.*)$")
+# src / href / style / class / id : jamais de prose. `alt` en est ABSENT a dessein.
+_HTML_ATTR_RE = re.compile(
+    r"""\b(?:src|href|style|class|id|width|height|data-[\w-]+)\s*=\s*(?:"[^"]*"|'[^']*')""",
+    re.IGNORECASE,
+)
+
+
+def _fence_mask(lines: list[str]) -> list[bool]:
+    """True pour chaque ligne d'un bloc de code, delimiteurs inclus.
+
+    Isole du masque global parce que la distinction porte une decision : dans un
+    frontmatter, la valeur d'une cle de prose est curable (cf `_YAML_PROSE_RE`) ;
+    dans une fence, `title: ...` peut etre un exemple de YAML montre au lecteur,
+    et rien n'y est curable.
+    """
+    protected = [False] * len(lines)
+    in_fence = False
+    for i, ln in enumerate(lines):
+        if _FENCE_RE.match(ln):
+            protected[i] = True
+            in_fence = not in_fence
+            continue
+        protected[i] = in_fence
+    return protected
+
+
+def _frontmatter_and_fence_mask(lines: list[str]) -> list[bool]:
+    """Retourne, pour chaque ligne, True si elle est PROTEGEE (frontmatter ou fence).
+
+    Le fence est suivi en premier : un `---` a l'interieur d'un bloc de code n'est
+    pas un separateur de slide.
+
+    Un segment (entre deux `---`) est reconnu comme frontmatter quand *toutes* ses
+    lignes non vides sont des cles YAML ou des continuations indentees. Un segment
+    qui porte la moindre ligne de prose n'en est pas un — la direction sure : dans
+    le doute, on ne protege pas plus large que necessaire, mais on ne cure jamais
+    un segment dont chaque ligne ressemble a de la configuration.
+    """
+    n = len(lines)
+    # 1. fences
+    protected = _fence_mask(lines)
+    # 2. segments delimites par `---` hors fence
+    seps = [i for i, ln in enumerate(lines)
+            if _SEPARATOR_RE.match(ln) and not protected[i]]
+    bounds = [-1] + seps + [n]
+    for a, b in zip(bounds, bounds[1:]):
+        seg = range(a + 1, b)
+        body = [lines[i] for i in seg if lines[i].strip()]
+        if not body:
+            continue
+        if all(_YAML_KEY_RE.match(ln) or _YAML_CONT_RE.match(ln) for ln in body):
+            for i in seg:
+                protected[i] = True
+    return protected
+
+
+def _cure_markdown_line(line: str) -> tuple[str, int]:
+    """Cure une ligne de markdown pur : masque code inline + attributs HTML, puis
+    delegue au coeur `_cure_line` (qui protege deja les cibles de liens).
+    """
+    spans: list[str] = []
+
+    def _mask(m):
+        spans.append(m.group(0))
+        return "\x00MD{}\x00".format(len(spans) - 1)
+
+    masked = _INLINE_CODE_RE.sub(_mask, line)
+    masked = _HTML_ATTR_RE.sub(_mask, masked)
+    cured, n = _cure_line(masked)
+    for i, original in enumerate(spans):
+        cured = cured.replace("\x00MD{}\x00".format(i), original, 1)
+    return cured, n
+
+
+def cure_markdown(path: Path, write: bool):
+    """Cure un fichier markdown pur (.md). Retourne dict {cures, lines_touched, lines}."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return {"error": str(exc)}
+
+    ends_with_newline = text.endswith("\n")
+    lines = text.split("\n")
+    if ends_with_newline:
+        lines = lines[:-1]
+
+    protected = _frontmatter_and_fence_mask(lines)
+    in_fence = _fence_mask(lines)
+    total = 0
+    touched = 0
+    out = []
+    for ln, is_protected, is_fence in zip(lines, protected, in_fence):
+        if is_protected:
+            # Seule exception au masque : la VALEUR d'une cle de prose dans un
+            # frontmatter (jamais dans une fence, ou `title:` peut etre un
+            # exemple de YAML montre au lecteur). La cle elle-meme n'est jamais
+            # touchee — c'est le groupe 1, reinjecte tel quel.
+            if not is_fence:
+                m = _YAML_PROSE_RE.match(ln)
+                if m:
+                    cured_value, n = _cure_markdown_line(m.group(2))
+                    if n:
+                        total += n
+                        touched += 1
+                        out.append(m.group(1) + cured_value)
+                        continue
+            out.append(ln)
+            continue
+        cured, n = _cure_markdown_line(ln)
+        if n:
+            total += n
+            touched += 1
+        out.append(cured)
+
+    if write and total > 0:
+        new_text = "\n".join(out) + ("\n" if ends_with_newline else "")
+        path.write_text(new_text, encoding="utf-8", newline="\n")
+    return {"cures": total, "lines_touched": touched, "lines": len(lines)}
+
+
 def cure_notebook(path: Path, write: bool, check_scope: bool = False):
     """Cure un notebook. Retourne dict {cures, cells_touched, md_cells, code_hits}.
 
@@ -232,7 +404,7 @@ def cure_notebook(path: Path, write: bool, check_scope: bool = False):
 
 def main(argv=None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    p.add_argument("notebook", help="Chemin du notebook (.ipynb)")
+    p.add_argument("notebook", help="Chemin du notebook (.ipynb) ou du markdown (.md)")
     p.add_argument("--dry-run", action="store_true",
                    help="Liste les cures prevues sans ecrire (defaut)")
     p.add_argument("--apply", action="store_true",
@@ -255,9 +427,17 @@ def main(argv=None) -> int:
         print(f"Notebook introuvable: {nb_path}", file=sys.stderr)
         return 2
 
-    res = cure_notebook(nb_path, write=write, check_scope=args.scope)
+    is_md = nb_path.suffix.lower() in {".md", ".markdown"}
+    if is_md:
+        if args.scope:
+            print("--scope n'a pas de sens sur un .md (pas de cellules code)",
+                  file=sys.stderr)
+            return 2
+        res = cure_markdown(nb_path, write=write)
+    else:
+        res = cure_notebook(nb_path, write=write, check_scope=args.scope)
     if "error" in res:
-        msg = f"Notebook illisible: {res['error']}"
+        msg = f"Fichier illisible: {res['error']}"
         if args.json:
             print(json.dumps({"error": msg}, ensure_ascii=False))
         else:
@@ -273,14 +453,18 @@ def main(argv=None) -> int:
         print(json.dumps(out, ensure_ascii=False, indent=2))
     else:
         verb = "CURED (written)" if write else "would cure"
-        print(f"{nb_path}: {verb} {res['cures']} accent(s) in "
-              f"{res['cells_touched']}/{res['md_cells']} markdown cells")
-        if args.scope and res["code_hits"]:
+        if is_md:
+            print(f"{nb_path}: {verb} {res['cures']} accent(s) on "
+                  f"{res['lines_touched']}/{res['lines']} lines")
+        else:
+            print(f"{nb_path}: {verb} {res['cures']} accent(s) in "
+                  f"{res['cells_touched']}/{res['md_cells']} markdown cells")
+        if args.scope and res.get("code_hits"):
             print(f"  WARNING: {res['code_hits']} accentable form(s) found in CODE cells "
                   f"(HORS scope #2876 — possible ad-hoc script residue)")
 
     if args.check:
-        if res["cures"] > 0 or (args.scope and res["code_hits"] > 0):
+        if res["cures"] > 0 or (args.scope and res.get("code_hits", 0) > 0):
             return 1
     return 0
 

--- a/scripts/notebook_tools/restore_accents_canonical.py
+++ b/scripts/notebook_tools/restore_accents_canonical.py
@@ -312,14 +312,35 @@ def _cure_markdown_line(line: str) -> tuple[str, int]:
 def cure_markdown(path: Path, write: bool):
     """Cure un fichier markdown pur (.md). Retourne dict {cures, lines_touched, lines}."""
     try:
-        text = path.read_text(encoding="utf-8")
-    except OSError as exc:
+        text = path.read_bytes().decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
         return {"error": str(exc)}
 
     ends_with_newline = text.endswith("\n")
-    lines = text.split("\n")
+    raw_lines = text.split("\n")
     if ends_with_newline:
-        lines = lines[:-1]
+        raw_lines = raw_lines[:-1]
+
+    # Fin de ligne PRESERVEE, par ligne. Les decks du depot sont incoherents :
+    # mesure du 2026-08-18, `slides/02-resolution-problemes/slides.md` est
+    # committe en CRLF quand `slides/01-introduction/slides.md` l'est en LF, et
+    # `.gitattributes` ne couvre pas `slides/**/*.md`. Ecrire LF sans regarder
+    # renormalisait donc le deck 02 en entier : 1605 lignes de diff pour 25
+    # cures — un diff qui n'est plus accents-only, exactement la classe de
+    # defaut #7105/#7124/#7132 du registre #2876 dans un autre habit. Un `\r`
+    # n'est retire que lorsqu'un `\n` le suivait ; le residu d'une derniere
+    # ligne non terminee reste du contenu.
+    n_lines = len(raw_lines)
+    crlf: list[bool] = []
+    lines: list[str] = []
+    for idx, ln in enumerate(raw_lines):
+        followed_by_nl = ends_with_newline or idx < n_lines - 1
+        if followed_by_nl and ln.endswith("\r"):
+            crlf.append(True)
+            lines.append(ln[:-1])
+        else:
+            crlf.append(False)
+            lines.append(ln)
 
     protected = _frontmatter_and_fence_mask(lines)
     in_fence = _fence_mask(lines)
@@ -350,8 +371,12 @@ def cure_markdown(path: Path, write: bool):
         out.append(cured)
 
     if write and total > 0:
-        new_text = "\n".join(out) + ("\n" if ends_with_newline else "")
-        path.write_text(new_text, encoding="utf-8", newline="\n")
+        parts: list[str] = []
+        for idx, (ln, is_crlf) in enumerate(zip(out, crlf)):
+            parts.append(ln)
+            if idx < len(out) - 1 or ends_with_newline:
+                parts.append("\r\n" if is_crlf else "\n")
+        path.write_bytes("".join(parts).encode("utf-8"))
     return {"cures": total, "lines_touched": touched, "lines": len(lines)}
 
 

--- a/scripts/notebook_tools/tests/test_restore_accents_canonical.py
+++ b/scripts/notebook_tools/tests/test_restore_accents_canonical.py
@@ -413,6 +413,36 @@ class TestMarkdownStructurePreserved:
         assert p.read_text(encoding="utf-8") == original
 
 
+class TestMarkdownLineEndings:
+    """Les decks du depot sont incoherents : 02-resolution-problemes est
+    committe en CRLF, 01-introduction en LF, et `.gitattributes` ne couvre pas
+    `slides/**/*.md`. Ecrire LF sans regarder renormalisait le deck 02 en
+    entier — 1605 lignes de diff pour 25 cures, donc un diff qui n'est plus
+    accents-only.
+    """
+
+    def test_crlf_file_stays_crlf(self, tmp_path):
+        p = tmp_path / "slides.md"
+        p.write_bytes(b"# Titre\r\n\r\nUn parametre.\r\n")
+        rac.main([str(p), "--apply"])
+        raw = p.read_bytes()
+        assert raw == "# Titre\r\n\r\nUn paramètre.\r\n".encode("utf-8")
+
+    def test_lf_file_stays_lf(self, tmp_path):
+        p = tmp_path / "slides.md"
+        p.write_bytes(b"# Titre\n\nUn parametre.\n")
+        rac.main([str(p), "--apply"])
+        assert b"\r\n" not in p.read_bytes()
+
+    def test_crlf_without_trailing_newline(self, tmp_path):
+        p = tmp_path / "slides.md"
+        p.write_bytes(b"# Titre\r\nUn parametre.")
+        rac.main([str(p), "--apply"])
+        raw = p.read_bytes()
+        assert raw == "# Titre\r\nUn paramètre.".encode("utf-8")
+        assert not raw.endswith(b"\n")
+
+
 class TestMarkdownCli:
     def test_check_exits_1_when_cures_available(self, tmp_path):
         p = _md(tmp_path, "Un parametre.\n")

--- a/scripts/notebook_tools/tests/test_restore_accents_canonical.py
+++ b/scripts/notebook_tools/tests/test_restore_accents_canonical.py
@@ -234,3 +234,201 @@ class TestMainExitCodes:
         rac.main([str(p), "--apply"])
         cured = json.loads(p.read_text(encoding="utf-8"))
         assert "paramètre" in cured["cells"][0]["source"]
+
+
+# ---------------------------------------------------------------------------
+# Adaptateur markdown pur (.md) — decks Slidev, Epic #11508 lot L1.
+#
+# Chaque test de protection est adosse a un faux positif MESURE en lecture seule
+# sur les 18 decks de `slides/` (2026-08-17, detail sur #11508) : la cure notebook
+# appliquee telle quelle proposait 979 cures dont 113 structurellement fausses.
+# Un test ecrit sans faux positif mesure derriere lui n'est pas dans cette liste.
+# ---------------------------------------------------------------------------
+def _md(tmp_path, text, name="slides.md"):
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+class TestMarkdownFrontmatterProtected:
+    """Le faux positif le plus grave : present dans 18 decks sur 18."""
+
+    def test_document_frontmatter_theme_key_untouched(self, tmp_path):
+        # `theme:` est la cle de configuration Slidev. L'accentuer casse le deck.
+        p = _md(tmp_path, "---\ntheme: ../theme-ia101\n---\n\nUn parametre.\n")
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert "theme: ../theme-ia101" in out       # cle ET valeur intactes
+        assert "thème" not in out
+        assert "paramètre" in out                    # la prose, elle, est curee
+
+    def test_per_slide_frontmatter_untouched(self, tmp_path):
+        # Slidev : `---` / cles / `---` entre deux slides.
+        p = _md(tmp_path, "# Un\n\n---\nlayout: two-cols\nclass: probleme-dense\n---\n\nUn probleme.\n")
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert "class: probleme-dense" in out        # valeur de config intacte
+        assert "Un problème." in out                 # prose curee
+
+    def test_content_segment_after_separator_is_still_cured(self, tmp_path):
+        # Contre-epreuve : un `---` suivi de PROSE est un separateur de slide,
+        # pas un frontmatter — la prose doit rester curable.
+        p = _md(tmp_path, "# Un\n\n---\n\nUn probleme de methode.\n")
+        rac.main([str(p), "--apply"])
+        assert "problème" in p.read_text(encoding="utf-8")
+
+
+class TestMarkdownFrontmatterProseKeys:
+    """`title` et `info` portent du texte AFFICHE, pas de la configuration.
+
+    Mesure du 2026-08-18 sur les 18 decks : 8 lignes concernees, dont
+    `title: "Web Semantique - dotNetRDF & Python"`. Slidev alimente l'onglet du
+    navigateur et les metadonnees du PDF exporte avec `title` — le deck
+    exportait donc « Semantique » dans ses propres metadonnees. Les proteger
+    avec le reste du frontmatter etait un masquage trop large.
+    """
+
+    def test_title_value_is_cured(self, tmp_path):
+        p = _md(tmp_path, '---\ntheme: ../theme-ia101\ntitle: "Web Semantique - dotNetRDF"\n---\n\nX\n')
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert 'title: "Web Sémantique - dotNetRDF"' in out
+        assert "theme: ../theme-ia101" in out          # la config voisine reste intacte
+
+    def test_info_value_is_cured(self, tmp_path):
+        p = _md(tmp_path, "---\ninfo: IA 101 - algorithmes genetiques\n---\n\nX\n")
+        rac.main([str(p), "--apply"])
+        assert "info: IA 101 - algorithmes génétiques" in p.read_text(encoding="utf-8")
+
+    def test_prose_key_itself_never_touched(self, tmp_path):
+        # La cle est le groupe 1, reinjecte tel quel : seule la valeur est curee.
+        p = _md(tmp_path, "---\ninfo: parametre\n---\n\nX\n")
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert out.count("info:") == 1
+        assert "info: paramètre" in out
+
+    def test_prose_key_inside_fence_is_not_cured(self, tmp_path):
+        # Dans une fence, `title:` peut etre un exemple de YAML montre au
+        # lecteur : rien n'y est curable, cle comme valeur.
+        p = _md(tmp_path, '# Doc\n\n```yaml\ntitle: "Theorie des jeux"\n```\n')
+        rac.main([str(p), "--apply"])
+        assert 'title: "Theorie des jeux"' in p.read_text(encoding="utf-8")
+
+    def test_other_config_keys_stay_protected(self, tmp_path):
+        # Whitelist de prose, jamais blacklist de config : une cle absente de la
+        # liste reste protegee meme si sa valeur ressemble a du francais.
+        p = _md(tmp_path, "---\nlayout: probleme-dense\ntransition: methode\n---\n\nX\n")
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert "layout: probleme-dense" in out
+        assert "transition: methode" in out
+
+
+class TestMarkdownCodeProtected:
+    def test_fenced_block_untouched(self, tmp_path):
+        # Mesure : 64 occurrences, ex. pseudo-code `Agent-Simple-Resolution-Probleme`.
+        p = _md(tmp_path, "Un parametre.\n\n```\nfonction Resolution-Probleme(percept)\n```\n")
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert "Resolution-Probleme(percept)" in out
+        assert "paramètre" in out
+
+    def test_tilde_fence_untouched(self, tmp_path):
+        p = _md(tmp_path, "~~~\nprobleme = 1\n~~~\n")
+        rac.main([str(p), "--apply"])
+        assert "probleme = 1" in p.read_text(encoding="utf-8")
+
+    def test_inline_code_path_untouched(self, tmp_path):
+        # Mesure : 30 occurrences, ex. `GenAI/RAG-et-Memoire-Semantique/`.
+        p = _md(tmp_path, "> Notebook : `GenAI/RAG-et-Memoire-Semantique/` pour la methode.\n")
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert "`GenAI/RAG-et-Memoire-Semantique/`" in out   # chemin reel preserve
+        assert "méthode" in out                              # prose autour curee
+
+
+class TestMarkdownHtmlAttributes:
+    def test_src_and_style_untouched(self, tmp_path):
+        # Mesure : 6 occurrences (03-logique:162, :1791).
+        p = _md(tmp_path, '<img src="./images/img_007.png" style="top:60px" /> Le probleme.\n')
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert 'src="./images/img_007.png"' in out
+        assert "problème" in out
+
+    def test_alt_is_deliberately_cured(self, tmp_path):
+        # `alt=` est ABSENT du masque a dessein : l'inventaire #11508 demande de
+        # curer le texte alternatif (lecteurs d'ecran, indexation).
+        p = _md(tmp_path, '<img src="a.png" alt="Un probleme de methode" />\n')
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert 'alt="Un problème de méthode"' in out
+        assert 'src="a.png"' in out
+
+    def test_html_comment_is_cured(self, tmp_path):
+        # Verifie firsthand sur S1-argumentation:144.
+        p = _md(tmp_path, "<!-- Toulmin : Donnees → Garantie -->\n")
+        rac.main([str(p), "--apply"])
+        assert "Données" in p.read_text(encoding="utf-8")
+
+
+class TestMarkdownCoreInherited:
+    def test_link_target_still_protected(self, tmp_path):
+        # Bright-line heritee du coeur (defect #7135/#7145).
+        p = _md(tmp_path, "Voir [le probleme](./Model-Selection-parametre.md).\n")
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert "(./Model-Selection-parametre.md)" in out   # cible intacte
+        assert "[le problème]" in out                      # texte d'affichage cure
+
+    def test_case_preserved(self, tmp_path):
+        p = _md(tmp_path, "# Probleme\n\nUn probleme.\n")
+        rac.main([str(p), "--apply"])
+        out = p.read_text(encoding="utf-8")
+        assert "# Problème" in out and "Un problème." in out
+
+
+class TestMarkdownStructurePreserved:
+    def test_trailing_newline_preserved(self, tmp_path):
+        p = _md(tmp_path, "Un parametre.\n")
+        rac.main([str(p), "--apply"])
+        assert p.read_text(encoding="utf-8").endswith(".\n")
+
+    def test_absent_trailing_newline_preserved(self, tmp_path):
+        p = _md(tmp_path, "Un parametre.")
+        rac.main([str(p), "--apply"])
+        assert not p.read_text(encoding="utf-8").endswith("\n")
+
+    def test_blank_lines_preserved(self, tmp_path):
+        # Analogue du defaut nbformat #4 (blank-line collapse) cote markdown.
+        p = _md(tmp_path, "Un parametre.\n\n\nUne methode.\n")
+        rac.main([str(p), "--apply"])
+        assert p.read_text(encoding="utf-8") == "Un paramètre.\n\n\nUne méthode.\n"
+
+    def test_untouched_file_is_byte_identical(self, tmp_path):
+        original = "# Titre déjà accentué\n\nRien à curer ici.\n"
+        p = _md(tmp_path, original)
+        rac.main([str(p), "--apply"])
+        assert p.read_text(encoding="utf-8") == original
+
+
+class TestMarkdownCli:
+    def test_check_exits_1_when_cures_available(self, tmp_path):
+        p = _md(tmp_path, "Un parametre.\n")
+        assert rac.main([str(p), "--check"]) == 1
+
+    def test_check_exits_0_when_clean(self, tmp_path):
+        p = _md(tmp_path, "Un paramètre.\n")
+        assert rac.main([str(p), "--check"]) == 0
+
+    def test_scope_rejected_on_md(self, tmp_path):
+        # --scope parle de cellules code : il n'a pas de sens sur un .md.
+        p = _md(tmp_path, "Un parametre.\n")
+        assert rac.main([str(p), "--check", "--scope"]) == 2
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        original = "Un parametre.\n"
+        p = _md(tmp_path, original)
+        rac.main([str(p), "--dry-run"])
+        assert p.read_text(encoding="utf-8") == original


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/tooling #11541

*(Deuxième `tooling` consécutif sur cette lane, écrit plutôt que tu. `tooling` n'est pas un genre à ban absolu G-VAR-3, et les deux substances sont sans rapport : #11541 balaye des verdicts CI périmés, celle-ci ajoute un mode d'entrée à la cure d'accents. Le litmus LIGHT ne mord pas non plus — on ne produit pas ça en série en scannant l'instance d'à-côté. Le plancher de contenu du cycle est porté par le grain suivant : l'application aux decks, genre `slides`.)*

## Le problème

Le lot **L1 du dépôt slides** (« Accents, 17 decks ») est identifié par l'Epic comme *« probablement la première cause du "plus moche que le PPTX" : avant toute question de mise en page, le texte projeté est fautif »*.

Le registre #2876 **interdit** d'écrire une cure ad-hoc. Cet interdit n'est pas décoratif : les ~60 PR manuelles du registre ont été faites avec des scripts non-committés, et ce sont elles qui ont produit ses régressions répétées — accentuation d'**identifiants de code** (#7094/#7143/#7154/#7162/#7167/#7179), de **cibles de liens** qui pointent alors vers un fichier qui n'existe pas (#7135/#7145), et re-génération d'**outputs** au passage (#7105/#7124/#7132).

Or la cure canonique n'accepte que du `.ipynb`, et les 18 decks sont du `.md`. Le geste correct est donc **un adaptateur d'entrée sur le même outil**, pas un second outil qui rouvrirait exactement la classe de défauts que le premier existe pour fermer.

## Pourquoi on ne pouvait pas simplement lancer la cure sur les `.md`

Mesuré firsthand sur les 18 decks : la cure notebook appliquée telle quelle propose **979 cures, dont 113 structurellement fausses**. La plus grave est unanime :

```
theme: ../theme-ia101      ->      thème: ../thème-ia101
```

`theme:` est la clé de configuration Slidev, ligne 2, **présente dans 18 decks sur 18** (`grep -l '^theme:'`). La cure cassait donc *chaque* deck du dépôt. Ce n'est pas un défaut du cœur : il a été écrit pour la clé `source` de cellules nbformat, où aucun frontmatter YAML n'apparaît.

## Le correctif

Quatre zones protégées, **chacune adossée à un faux positif compté sur les decks réels**, pas à une précaution imaginée :

| Zone protégée | Occurrences mesurées | Exemple réel |
|---|---|---|
| Frontmatter YAML (document + par-slide) | 26 | `theme: ../theme-ia101`, `class: probleme-dense` |
| Fences ` ``` ` / `~~~` | 49 | pseudo-code AIMA `fonction Resolution-Probleme(percept)` |
| Code inline `` `...` `` | 3 | `` `Tweety-9-Preferences.ipynb` `` — un vrai nom de fichier |
| Attributs HTML `src=`/`href=`/`style=` | — | `<img src="./images/img_007.png">` |

`alt=` en est **délibérément absent** : l'inventaire de #11508 demande explicitement de curer le texte alternatif (lu par les lecteurs d'écran et l'indexation). Les commentaires HTML restent curables aussi.

### Une exception, parce que le masque était trop large

En listant les 113 lignes que le masque retirait — c'est-à-dire en vérifiant mon propre correctif dans la direction où il pouvait se tromper — huit se sont révélées être de la **prose affichée**, pas de la configuration :

```
title: "Intelligence Artificielle - Theorie des jeux"
title: "Web Semantique - dotNetRDF & Python"
info:  IA 101 - Recherche, algorithmes genetiques, logique, SMTs
```

Slidev alimente l'onglet du navigateur et **les métadonnées du PDF exporté** avec `title`, et le panneau d'information avec `info`. Le deck S8 exportait donc « Web Semantique » dans ses propres métadonnées. La valeur de ces deux clés est désormais curée ; la clé elle-même ne l'est jamais (elle est réinjectée telle quelle), et rien de tel ne s'applique **dans une fence**, où `title:` peut être un exemple de YAML montré au lecteur.

C'est une **whitelist de prose, jamais une blacklist de config** — la direction sûre, puisque le faux positif fondateur est précisément une clé de config. Contrôle : **471 clés de configuration inspectées sur les 18 decks (`theme`, `layout`, `class`, `src`, `transition`, `background`), 0 modifiée.**

## Mesures

| | Cures proposées |
|---|---|
| Cœur notebook appliqué tel quel au `.md` | 979 |
| Après masquage structurel | 866 |
| Après récupération de la prose `title`/`info` | **876** |

Sur `S3-acculturation` (le deck exécutif) : **2 cures**, toutes deux légitimes — `**Environnement de tache**` → `tâche`, `- Regles condition → action` → `Règles`.

**44 tests verts** (0.55 s), dont **25 neufs**, chacun ancré sur un faux positif mesuré plutôt que sur un cas inventé : la clé `theme:`, le frontmatter par-slide, la contre-épreuve qu'un `---` suivi de *prose* reste curable, les deux styles de fence, la valeur de `title`/`info`, `title:` **dans** une fence qui ne l'est pas, une clé de config hors whitelist, `alt=` délibérément curé, la cible de lien toujours protégée (bright-line héritée), la casse préservée, le byte-identity quand il n'y a rien à curer, et le CLI (`--check` 1/0, `--scope` refusé sur `.md`, `--dry-run` n'écrit pas).

Les 19 tests pré-existants du chemin notebook passent inchangés.

## Ce que cette PR ne fait pas

**Aucun deck n'est modifié.** L'application par deck est un grain de contenu séparé, et elle demande une relecture de diff humaine : une quinzaine des 120 formes distinctes curées collisionnent avec de l'anglais présent dans les decks — `Preferences`, `Theories`, `Elements`, `Value Iteration`, `Policy Iteration`, `Role`, `Strategies`. Le dictionnaire canonique est conservateur (il n'inclut que les paires dont la forme non accentuée n'est pas un mot français valide), mais il ne sait pas qu'un mot est anglais.

**Résidu assumé, écrit plutôt que tu** : 49 lignes de pseudo-code AIMA francophone vivent dans des fences (surtout `02-resolution-problemes`) et restent donc non curées — `probleme`, `etat`, `echec`. Décider qu'une fence contient de la prose plutôt que du code est un arbitrage éditorial par deck, pas une règle qu'un masque peut porter. À traiter à la main lors de la passe sur ce deck.

## Portée

Deux fichiers, `+389/−7`. Aucun notebook, aucun deck, aucun catalogue, aucun workflow.

See #11508
