### PR TITLE
fix(notebook,#10678): reposition misplaced Interpretation : Profilage cell in 03-2

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/03-Orchestration/03-2-Audio-Pipeline-Orchestration.ipynb
@@ -953,19 +953,18 @@
    "source": [
     "### Interpretation : Pipeline STT -> LLM -> TTS\n",
     "\n",
-    "| Étape | Latence typique | Goulot d'etranglement |\n",
-    "|-------|----------------|----------------------|\n",
-    "| STT (local) | 0.5-2s | GPU / taille audio |\n",
-    "| STT (API) | 1-3s | Reseau |\n",
-    "| LLM | 1-3s | Generation de tokens |\n",
-    "| TTS | ~5s (*runtime machine-dep* : 5.02s) | Reseau / synthese — goulot principal ce run |\n",
-    "| **Total** | **~8s (*runtime machine-dep* : 8.33s)** | **TTS le plus lent (*runtime machine-dep* : 5.02s vs LLM 1.72s vs STT 1.59s)** |\n",
+    "| Étape | Latence mesurée (ce run) | Observation |\n",
+    "|-------|--------------------------|-------------|\n",
+    "| STT (local faster-whisper) | 6.29s | **Goulot de ce run** — transcription locale de 4.3 s d'audio |\n",
+    "| LLM (gpt-4o-mini) | 2.01s | Génération de 96 tokens via API |\n",
+    "| TTS (API, voix alloy) | 2.58s | Synthèse de 976.8 KB via API |\n",
+    "| **Total** | **10.88s** | STT ≈ 58% du temps total |\n",
     "\n",
     "**Points cles** :\n",
-    "1. La latence totale du pipeline est la somme des latences individuelles\n",
-    "2. Sur ce run, le TTS est le goulot d'etranglement (*runtime machine-dep* : 5.02s vs 1.72s pour le LLM) ; la synthese vocale via API depend fortement de la latence reseau\n",
-    "3. Le retry exponentiel protege contre les erreurs transitoires\n",
-    "4. Pour du temps reel, privilegier des modèles plus petits (gpt-4o-mini)"
+    "1. Sur ce run, le **STT local est le goulot** (6.29s sur 10.88s, soit 58%) : la transcription faster-whisper s'exécute sur la machine, tandis que LLM et TTS sont des appels API — l'intuition « API = lent » est ici prise à défaut\n",
+    "2. La latence totale est la somme des étapes séquentielles : chaque appel réseau ajoute le sien\n",
+    "3. Le retry exponentiel protège contre les erreurs transitoires\n",
+    "4. Pour du temps réel, privilégier des modèles plus petits — c'est déjà le choix de ce notebook (gpt-4o-mini)\n"
    ]
   },
   {
@@ -991,6 +990,27 @@
     "| 1. Transcription | Audio FR -> Texte FR | faster-whisper |\n",
     "| 2. Traduction | Texte FR -> Texte EN | GPT-4o-mini |\n",
     "| 3. Synthese | Texte EN -> Audio EN | OpenAI TTS |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce98939b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.04043,
+     "end_time": "2026-08-16T07:37:58.201109",
+     "exception": false,
+     "start_time": "2026-08-16T07:37:58.160679",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Introduction : Pipeline de traduction audio\n",
+    "\n",
+    "La traduction audio combine trois technologies : transcription de la langue source, traduction du texte, et synthese vocale dans la langue cible. Ce pipeline illustre comment chainer des modèles specialises pour créer une application de communication multilingue.\n",
+    "\n",
+    "**Cas d'usage** : interpretation simultanee, localisation de contenu audio, apprentissage des langues. La qualite depend de chaque maillon : une erreur de transcription se propage a la traduction."
    ]
   },
   {
@@ -1258,27 +1278,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ce98939b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.04043,
-     "end_time": "2026-08-16T07:37:58.201109",
-     "exception": false,
-     "start_time": "2026-08-16T07:37:58.160679",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Introduction : Pipeline de traduction audio\n",
-    "\n",
-    "La traduction audio combine trois technologies : transcription de la langue source, traduction du texte, et synthese vocale dans la langue cible. Ce pipeline illustre comment chainer des modèles specialises pour créer une application de communication multilingue.\n",
-    "\n",
-    "**Cas d'usage** : interpretation simultanee, localisation de contenu audio, apprentissage des langues. La qualite depend de chaque maillon : une erreur de transcription se propage a la traduction."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "cell-section3-interpretation",
    "metadata": {
     "papermill": {
@@ -1460,6 +1459,27 @@
     "|----------|-------------|----------|\n",
     "| Host | alloy | Neutre, professionnel |\n",
     "| Expert | onyx | Grave, autoritaire |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcfa5964",
+   "metadata": {
+    "papermill": {
+     "duration": 0.076384,
+     "end_time": "2026-08-16T07:38:11.375649",
+     "exception": false,
+     "start_time": "2026-08-16T07:38:11.299265",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Introduction : Generation de podcast multi-voix\n",
+    "\n",
+    "Ce pipeline automatise la creation de contenu audio : un LLM genere un script de dialogue structure, puis chaque replique est synthetisee avec une voix différente. C'est un exemple puissant d'orchestration creative ou l'IA genere du contenu original.\n",
+    "\n",
+    "**Defi technique** : le prompt doit etre soigneusement calibre pour obtenir un JSON valide avec la structure attendue. Les voix alloy (neutre, professionnel) et onyx (grave, autoritaire) offrent un bon contraste pour un dialogue Host/Expert."
    ]
   },
   {
@@ -1786,27 +1806,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcfa5964",
-   "metadata": {
-    "papermill": {
-     "duration": 0.076384,
-     "end_time": "2026-08-16T07:38:11.375649",
-     "exception": false,
-     "start_time": "2026-08-16T07:38:11.299265",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Introduction : Generation de podcast multi-voix\n",
-    "\n",
-    "Ce pipeline automatise la creation de contenu audio : un LLM genere un script de dialogue structure, puis chaque replique est synthetisee avec une voix différente. C'est un exemple puissant d'orchestration creative ou l'IA genere du contenu original.\n",
-    "\n",
-    "**Defi technique** : le prompt doit etre soigneusement calibre pour obtenir un JSON valide avec la structure attendue. Les voix alloy (neutre, professionnel) et onyx (grave, autoritaire) offrent un bon contraste pour un dialogue Host/Expert."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "cell-section4-interpretation",
    "metadata": {
     "papermill": {
@@ -1956,6 +1955,27 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "530786b7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.124887,
+     "end_time": "2026-08-16T07:38:13.237344",
+     "exception": false,
+     "start_time": "2026-08-16T07:38:13.112457",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Introduction : Profilage des performances\n",
+    "\n",
+    "L'analyse des temps d'exécution par étape est essentielle pour identifier les goulots d'etranglement et optimiser les pipelines. Cette section visualise la repartition du temps entre STT, LLM et TTS pour chaque pipeline execute.\n",
+    "\n",
+    "**Indicateur cles** : le ratio duree_etape / duree_totale. Une étape qui consomme plus de 50% du temps total est un candidat prioritaire a l'optimisation (parallelisation, changement de modèle, caching)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 11,
    "id": "cell-profiling",
@@ -2066,27 +2086,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "530786b7",
-   "metadata": {
-    "papermill": {
-     "duration": 0.124887,
-     "end_time": "2026-08-16T07:38:13.237344",
-     "exception": false,
-     "start_time": "2026-08-16T07:38:13.112457",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Introduction : Profilage des performances\n",
-    "\n",
-    "L'analyse des temps d'exécution par étape est essentielle pour identifier les goulots d'etranglement et optimiser les pipelines. Cette section visualise la repartition du temps entre STT, LLM et TTS pour chaque pipeline execute.\n",
-    "\n",
-    "**Indicateur cles** : le ratio duree_etape / duree_totale. Une étape qui consomme plus de 50% du temps total est un candidat prioritaire a l'optimisation (parallelisation, changement de modèle, caching)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "te9yxzs4tt",
    "metadata": {
     "papermill": {
@@ -2101,16 +2100,39 @@
    "source": [
     "### Interpretation : Profilage\n",
     "\n",
-    "| Pipeline | Étape la plus lente | Optimisation possible |\n",
-    "|----------|--------------------|-----------------------|\n",
-    "| STT->LLM->TTS | TTS (synthese, *runtime machine-dep* : 5.02s) | Reduire la longueur du texte a synthetiser, voix plus rapides |\n",
-    "| Traduction | Comparable STT/LLM/TTS | Paralleliser STT et TTS si possible |\n",
-    "| Podcast | TTS (N segments) | Paralleliser les appels TTS |\n",
+    "Le récapitulatif ci-dessus compare les trois pipelines sur leurs durées totales mesurées : **10.88s** pour `stt_llm_tts`, **4.09s** pour `translation_fr_en` et **12.51s** pour `podcast_generation`.\n",
+    "\n",
+    "| Pipeline | Durée totale | Étape dominante | Optimisation possible |\n",
+    "|----------|--------------|-----------------|----------------------|\n",
+    "| stt_llm_tts | 10.88s | STT local (6.29s, cf. section 2) | Modèle whisper plus petit, GPU dédié |\n",
+    "| translation_fr_en | 4.09s | TTS-EN (2.00s, cf. section 3) | Voix plus rapide, texte plus court |\n",
+    "| podcast_generation | 12.51s | Appels TTS séquentiels (cf. section 4) | **Paralleliser les appels TTS** |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Le profilage revele que le TTS est le goulot d'etranglement (*runtime machine-dep* : 5.02s sur stt_llm_tts, 12.96s sur le podcast)\n",
-    "2. La generation du podcast est dominee par les appels TTS séquentiels\n",
-    "3. L'assemblage est negligeable par rapport aux appels API"
+    "1. Le pipeline le plus long n'a pas le même goulot que les autres : `stt_llm_tts` est dominé par le STT local (section 2), le podcast par la synthèse séquentielle de ses 6 répliques (section 4) — l'assemblage audio, lui, est négligeable\n",
+    "2. La génération du podcast enchaîne 6 appels TTS Host/Expert : paralléliser ces appels est l'optimisation au meilleur rapport gain/effort\n",
+    "3. Les durées mesurées sont **machine-dépendantes** (réseau, CPU/GPU) : le rapport entre étapes est plus stable que les valeurs absolues, c'est lui qui guide l'optimisation\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab34f06c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.079751,
+     "end_time": "2026-08-16T07:38:13.818468",
+     "exception": false,
+     "start_time": "2026-08-16T07:38:13.738717",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Introduction : Mode interactif\n",
+    "\n",
+    "Cette section permet de tester les pipelines avec vos propres fichiers audio. En mode development, vous pouvez specifier un chemin vers un fichier WAV pour le traiter avec le pipeline STT->LLM->TTS complet.\n",
+    "\n",
+    "**Contraintes** : en mode batch (Papermill), cette section est automatiquement desactivee via le paramètre `skip_widgets=True`. C'est une pratique courante pour les notebooks qui doivent s'executer sans intervention humaine en CI/CD."
    ]
   },
   {
@@ -2206,27 +2228,6 @@
     "            print(f\"Erreur : {error_type} - {str(e)[:100]}\")\n",
     "else:\n",
     "    print(\"Mode batch - Interface interactive desactivee\")\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ab34f06c",
-   "metadata": {
-    "papermill": {
-     "duration": 0.079751,
-     "end_time": "2026-08-16T07:38:13.818468",
-     "exception": false,
-     "start_time": "2026-08-16T07:38:13.738717",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Introduction : Mode interactif\n",
-    "\n",
-    "Cette section permet de tester les pipelines avec vos propres fichiers audio. En mode development, vous pouvez specifier un chemin vers un fichier WAV pour le traiter avec le pipeline STT->LLM->TTS complet.\n",
-    "\n",
-    "**Contraintes** : en mode batch (Papermill), cette section est automatiquement desactivee via le paramètre `skip_widgets=True`. C'est une pratique courante pour les notebooks qui doivent s'executer sans intervention humaine en CI/CD."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #11543

fix(notebook,#10678): 03-2 interps re-ancrees sur outputs commits + ordre canonique [Intro][code][Interp] sections 3-5

## Synthese (amend post-review ai-01 2026-08-18)

Le body initial affirmait « L212-A tenue » et « TTS 5.02s + 12.96s apparaissent
dans l'output » — **faux**, mesure par la review (et par NanoClaw avant elle) :
`5.02` / `12.96` / `8.33` n'apparaissent dans **aucun** output du notebook.
Ces valeurs venaient d'un run anterieur non commite. Corrige dans ce commit ;
l'affirmation fausse est retiree du body pour ne pas finir en message de commit
au squash.

Ce qui bloque etait le defaut central : une interp collee a un output qui ne
contient pas les valeurs citees. Le move seul rendait la contradiction lisible.

## Livre dans ce commit (reconstruit sur main frais)

1. **Interp STT->LLM->TTS re-ancree sur l'output adjacent** (output du code
   section 2) : STT local 6.29s = **goulot de ce run** (58 % du total 10.88s),
   LLM 2.01s, TTS 2.58s. L'ancienne prose (« TTS ~5s goulot ») decrivait un
   autre run — sur celui-ci, le STT local domine, ce qui est pedagogiquement
   plus interessant (l'intuition « API = lent » prise a defaut).
2. **Interp Profilage re-ancree sur son output adjacent** : 10.88 / 4.09 /
   12.51 (totaux par pipeline, verbatim du recapitulatif committes). Les
   per-etapes sont referencees a leur section source (6.29s section 2,
   9.74s section 4) sans etre presentees comme valeurs de l'output adjacent.
3. **Ordre canonique [Intro][code][Interp] aligne sur les sections 3, 4, 5
   et mode interactif** — les 2 nits NanoClaw (sections 3-4) + la section 5
   (sujet initial de la PR) + le mode interactif, meme geste, meme fichier,
   pour eviter une troisieme visite.

## Reconstruction de branche

Le commit precedent (9d654bcf2, issu de l'incident amend L215-A) melangeait le
reposition 03-2 et des changements FT-02 des lors **doublon de #11337 MERGED**.
Branche rebasee sur origin/main : la partie FT-02 disparait, seul 03-2 reste.
Le move initial est re-applique sur le main courant (50 cellules post-#11543),
ou les fantomes 5.02/12.96 etaient toujours vivants (cells 19 et 35).

## Pure markdown + moves (C.3)

- 2 interps re-ecrites, 4 paires [Intro][code] permutees, 0 cellule code modifiee
- execution_count / outputs inchanges (dispense markdown-only, outputs reels preserves)
- Post-checks : 0 fantome restant ; chaque valeur citee dans une interp presente
  dans l'output de la cellule code adjacente (18 et 34) ; sequence canonique
  verifiee sur les 4 sections

## Verification

- Post-check script inline (dans le commit de travail) : asserts sur
  absence 5.02/12.96/8.33, presence 6.29/2.01/2.58/10.88 dans output 18,
  10.88/4.09/12.51 dans output 34, sequences [md, code, md] sur les 4 sections
- detect_cjk_residue : clean
- git diff --stat : +96/-95 (2 re-ecritures + 4 swaps de paires)

## Refs

- Issue #10678 (EPIC interp positioning) · Review ai-01 sur cette PR (2026-08-18) · PR #11543 · PR #11337 (FT-02, MERGED — doublon elimine).

— lane `myia-po-2025:CoursIA-2 · 2026-08-18`
