### PR TITLE
fix(slides,#11508): cure d'accents tranche 1 — decks 01-04 (222 substitutions relues)

### DIFF
--- a/slides/01-introduction/slides.md
+++ b/slides/01-introduction/slides.md
@@ -46,7 +46,7 @@ image: ./images/img_001.jpg
     </ul>
   </li>
   <li v-click>Intelligence exploratoire
-    <ul><li>Comment chercher la solution a un probleme ?</li></ul>
+    <ul><li>Comment chercher la solution a un problème ?</li></ul>
   </li>
   <li v-click>Intelligence Symbolique
     <ul><li>Comment utiliser le raisonnement et les mathematiques ?</li></ul>
@@ -58,7 +58,7 @@ image: ./images/img_001.jpg
     <ul><li>Comment tenir compte des autres ?</li></ul>
   </li>
   <li v-click>Apprentissage
-    <ul><li>Comment utiliser les données et l'experience ?</li></ul>
+    <ul><li>Comment utiliser les données et l'expérience ?</li></ul>
   </li>
   <li v-click>Application : le langage naturel</li>
 </ul>
@@ -70,12 +70,12 @@ image: ./images/img_001.jpg
 - Presentation du cursus
 - Introduction
   - Qu'est-ce que l'intelligence artificielle?
-  - Les domaines d'etude
+  - Les domaines d'étude
   - Un peu d'histoire
   - L'état de l'art
-- Systemes d'agents
+- Systèmes d'agents
   - Agents rationnels
-  - Environnements taches
+  - Environnements tâches
   - Types d'Agents
 - Presentation des projets de groupe
 
@@ -89,7 +89,7 @@ A l'issue de ce cours, vous serez capables de :
   - Identifier les principaux domaines et leurs applications
   - Disposer des bases pour approfondir chacun d'entre eux
 - **Concevoir des programmes intelligents dans des domaines varies :**
-  - Recherche de solutions et jeux strategiques
+  - Recherche de solutions et jeux stratégiques
   - Representation de connaissances et raisonnement logique
   - Modelisation probabiliste et prise de decision sous incertitude
   - Apprentissage automatique (supervise, non supervise, par renforcement)
@@ -99,13 +99,13 @@ A l'issue de ce cours, vous serez capables de :
 
 # Objectifs du cours (2/2)
 
-- **Concevoir des systemes intelligents en conditions réelles**
-  - Integrer les differentes briques pour construire un systeme complet
+- **Concevoir des systèmes intelligents en conditions réelles**
+  - Integrer les différentes briques pour construire un système complet
   - Gerer les contraintes du monde réel : incertitude, temps de calcul, données imparfaites
-- **BONUS : Mieux comprendre l'intelligence elle-meme**
+- **BONUS : Mieux comprendre l'intelligence elle-même**
   - Comment l'intelligence emerge-t-elle dans la nature ?
   - Comment fonctionne le cerveau humain, et en quoi l'IA s'en inspire ?
-  - Comment definir et mesurer la rationalite ?
+  - Comment définir et mesurer la rationalite ?
 
 ---
 
@@ -116,7 +116,7 @@ A l'issue de ce cours, vous serez capables de :
 <li>Resolution de problemes</li>
 <li>Bases de connaissances et logique</li>
 <li>Raisonnement probabiliste</li>
-<li>Theorie des jeux</li>
+<li>Théorie des jeux</li>
 <li>Apprentissage</li>
 <li>Traitement du langage naturel</li>
 <li>Presentations des projets</li>
@@ -136,12 +136,12 @@ layout: section
 - Presentation du cursus
 - **Introduction**
   - Qu'est-ce que l'intelligence artificielle?
-  - Les domaines d'etude
+  - Les domaines d'étude
   - Un peu d'histoire
   - L'état de l'art
-- Systemes d'agents
+- Systèmes d'agents
   - Agents rationnels
-  - Environnements taches
+  - Environnements tâches
   - Types d'agents
 - TP: Mise en place de l'environnement de travail
 - Presentation des projets de groupe
@@ -153,10 +153,10 @@ layout: section
 <img src="./images/img_002.png" style="position:absolute; top:80px; right:20px; width:340px;" alt="Quatre definitions de l'IA" />
 
 - **Des definitions multiples et un concept evolutif**
-  - L'IA n'a pas de definition unique : elle recouvre des<br>approches tres differentes
-  - Concevoir un systeme intelligent n'implique pas de<br>comprendre l'intelligence
+  - L'IA n'a pas de definition unique : elle recouvre des<br>approches très différentes
+  - Concevoir un système intelligent n'implique pas de<br>comprendre l'intelligence
 - **Une definition qui evolue avec la technologie :**
-  - Automates → Calculateurs → Algorithmes →<br>Bases de connaissances → Systemes experts →<br>Apprentissage profond → IA generative
+  - Automates → Calculateurs → Algorithmes →<br>Bases de connaissances → Systèmes experts →<br>Apprentissage profond → IA generative
 
 ---
 
@@ -178,15 +178,15 @@ imageClass: mid-right large
 
 L'IA est une discipline profondement interdisciplinaire :
 
-- **Philosophie :** logique, methodes de raisonnement, nature de l'esprit, langage, apprentissage
+- **Philosophie :** logique, méthodes de raisonnement, nature de l'esprit, langage, apprentissage
 - **Mathematiques :** representation formelle et preuve, algorithmes, calcul, complexite, (in)decidabilite, probabilités
-- **Economie :** utilite, theorie de la decision, theorie des jeux, agents economiques rationnels
+- **Economie :** utilite, théorie de la decision, théorie des jeux, agents economiques rationnels
 - **Biologie :** intelligence naturelle et animale, evolution
 - **Neurosciences :** substrat physique de l'activite mentale (cerveau, neurones, plasticite)
-- **Psychologie :** perception, cognition, controle moteur, comportement, techniques experimentales
+- **Psychologie :** perception, cognition, contrôle moteur, comportement, techniques experimentales
 - **Informatique :** puissance de calcul, logiciel, architectures, langages
-- **Theorie du controle :** maximiser une fonction objective dans le temps, retroaction
-- **Linguistique :** grammaires, representation du sens, semantique
+- **Théorie du contrôle :** maximiser une fonction objective dans le temps, retroaction
+- **Linguistique :** grammaires, representation du sens, sémantique
 
 ---
 layout: image-overlay
@@ -205,7 +205,7 @@ image: ./images/img_004.png
   - Samuel (jeu de dames), Newell & Simon (theoricien logique)
   - Gelernter (geometrie), naissance de Lisp
 - **1965** : Robinson propose un algorithme complet<br>de raisonnement logique
-- **1969-79** : age d'or des systemes experts<br>(bases de connaissances)
+- **1969-79** : age d'or des systèmes experts<br>(bases de connaissances)
 
 ---
 
@@ -214,10 +214,10 @@ image: ./images/img_004.png
 **Maturite et "hivers de l'IA" (1970-2010)**
 
 - **1970s** : l'IA se heurte a la complexite calculatoire -- premier "hiver"
-- **1980s** : l'IA devient une industrie (robotique, vision, systemes experts)
+- **1980s** : l'IA devient une industrie (robotique, vision, systèmes experts)
 - **1986** : retour des reseaux de neurones grace a la retropropagation
 - **1990s** : l'IA se mathematise (probabilités, optimisation)
-- **2000s** : data mining, apprentissage bayesien, web semantique
+- **2000s** : data mining, apprentissage bayesien, web sémantique
 
 **Renaissance et explosion (2010-aujourd'hui)**
 
@@ -360,7 +360,7 @@ image: ./images/img_020.png
 # Penser de facon rationnelle : lois de la raison
 
 - **Depuis Aristote : quels sont les arguments corrects ?**
-  - La logique formelle fournit des regles de derivation rigoureuses
+  - La logique formelle fournit des règles de derivation rigoureuses
 - **La logique au service de l'IA**
   - Representer les faits du monde sous forme formelle
   - Utiliser l'inference pour deduire de nouvelles connaissances
@@ -368,7 +368,7 @@ image: ./images/img_020.png
 - **Limites de l'approche purement logique**
   - Le monde réel est incertain (capteurs imparfaits, information incomplete)
   - Tout comportement intelligent ne relève pas d'une délibération logique
-  - En pratique, il faut aussi definir des buts et evaluer des couts
+  - En pratique, il faut aussi définir des buts et evaluer des couts
 
 ---
 
@@ -379,9 +379,9 @@ image: ./images/img_020.png
 - **Agir rationnellement n'implique pas forcement de penser**
   - Un réflexe (cligner des yeux) peut être rationnel sans délibération
   - Mais la reflexion reste un outil puissant au service de l'action
-- **Lien avec la theorie de la decision**
+- **Lien avec la théorie de la decision**
   - Evaluer les états possibles et les actions disponibles
-  - Maximiser l'utilite esperee, meme sous incertitude
+  - Maximiser l'utilite esperee, même sous incertitude
 - **C'est l'approche centrale de ce cours** : concevoir des agents rationnels
 
 ---
@@ -393,16 +393,16 @@ layout: section
 ---
 
 
-# Systemes d'agents
+# Systèmes d'agents
 
 - Presentation du cursus
 - Introduction
   - Qu'est-ce que l'intelligence artificielle?
-  - Les domaines d'etude
+  - Les domaines d'étude
   - Un peu d'histoire
   - L'état de l'art
 - **Agents rationnels**
-- **Environnements taches**
+- **Environnements tâches**
 - **Types d'agents**
 - TP: Mise en place de l'environnement de travail
 - Presentation des projets de groupe
@@ -434,7 +434,7 @@ image: ./images/img_021.png
 - **Decision basee sur** : la suite des percepts recus et les connaissances prealables
 - **Rationnel ne signifie pas omniscient**
   - L'agent explore pour completer ses connaissances
-  - Il s'adapte par l'experience (apprentissage)
+  - Il s'adapte par l'expérience (apprentissage)
   - Il est reactif *et* proactif
 
 ---
@@ -469,7 +469,7 @@ image: ./images/img_021.png
 
 ---
 
-# Environnement de tache
+# Environnement de tâche
 
 **Description PEAS:**
 - **P**erformance (Mesure de)
@@ -489,7 +489,7 @@ image: ./images/img_021.png
 
 ---
 
-# Environnements de tache: exemples
+# Environnements de tâche: exemples
 
 <div class="center-image">
 <img src="./images/img_028.png" style="max-width: 800px; margin: auto; display: block;">
@@ -499,14 +499,14 @@ image: ./images/img_021.png
 
 # Types d'environnement (1/2)
 
-Chaque environnement de tache possede des proprietes qui influencent la conception de l'agent :
+Chaque environnement de tâche possede des proprietes qui influencent la conception de l'agent :
 
 - **Completement vs partiellement observable**
   - L'agent a-t-il acces a l'etat complet de l'environnement ?
-- **Deterministe vs stochastique**
+- **Déterministe vs stochastique**
   - L'etat suivant est-il entierement determine par l'état courant et l'action ?
-  - Cas particulier : *strategique* = deterministe sauf les actions des autres agents
-- **Episodique vs sequentiel**
+  - Cas particulier : *stratégique* = déterministe sauf les actions des autres agents
+- **Episodique vs séquentiel**
   - Les decisions sont-elles independantes ou liees entre elles ?
 - **Statique vs dynamique**
   - L'environnement change-t-il pendant que l'agent delibere ?
@@ -530,13 +530,13 @@ Chaque environnement de tache possede des proprietes qui influencent la concepti
 <div v-click="3">
 
 - **Connu vs inconnu**
-  - L'agent connait-il les regles de l'environnement ?
+  - L'agent connait-il les règles de l'environnement ?
 
 </div>
 
 <div v-click="4">
 
-**En pratique**, le monde réel combine les cas les plus difficiles : partiellement observable, stochastique, sequentiel, dynamique, continu, multiagent.
+**En pratique**, le monde réel combine les cas les plus difficiles : partiellement observable, stochastique, séquentiel, dynamique, continu, multiagent.
 
 </div>
 
@@ -585,7 +585,7 @@ Un agent naif pourrait stocker une table "percepts → action" :<br>la table ser
 
 - **Pas de memoire**
 - **Percepts courants**
-- **Regles Conditions / Actions**
+- **Règles Conditions / Actions**
 
 <div v-click="1">
 
@@ -611,7 +611,7 @@ Un agent naif pourrait stocker une table "percepts → action" :<br>la table ser
 
 <img src="./images/img_035.png" style="position:absolute; bottom:30px; right:30px; width:320px; background:white; padding:4px; border-radius:4px;" alt="Pseudocode agent fonde sur un modèle" />
 
-**Caracteristiques :**
+**Caractéristiques :**
 
 - Etat du monde
 - Historique des percepts
@@ -666,10 +666,10 @@ Un agent naif pourrait stocker une table "percepts → action" :<br>la table ser
 
 **Quatre composants internes :**
 
-- **Element de performance** : choisit les actions
-- **Element d'apprentissage** : ameliore la performance<br>a partir de l'experience
-- **Critique** : evalue les resultats par rapport a un standard fixe
-- **Generateur de problemes** : suggere des actions exploratoires
+- **Élément de performance** : choisit les actions
+- **Élément d'apprentissage** : ameliore la performance<br>a partir de l'expérience
+- **Critique** : evalue les résultats par rapport a un standard fixe
+- **Générateur de problemes** : suggere des actions exploratoires
 
 **Formes d'apprentissage :** supervise, par renforcement, non supervise
 
@@ -726,7 +726,7 @@ Trois niveaux de representation des etats, du plus simple au plus expressif :
 <li>Resolution de problemes</li>
 <li>Bases de connaissances et logique</li>
 <li>Raisonnement probabiliste</li>
-<li>Theorie des jeux</li>
+<li>Théorie des jeux</li>
 <li>Apprentissage</li>
 <li>Traitement du langage naturel</li>
 <li>Presentations des projets</li>
@@ -738,13 +738,13 @@ Trois niveaux de representation des etats, du plus simple au plus expressif :
 
 Chaque chapitre du cours est accompagne de travaux pratiques sous forme de notebooks Jupyter :
 
-- **Exploration** : `Search/Part1-Foundations/` (11 notebooks), `Search/Part2-CSP/` (9 notebooks), `Sudoku/` (16 notebooks) -- recherche, CSP, algorithmes genetiques, optimisation
+- **Exploration** : `Search/Part1-Foundations/` (11 notebooks), `Search/Part2-CSP/` (9 notebooks), `Sudoku/` (16 notebooks) -- recherche, CSP, algorithmes génétiques, optimisation
 - **Logique** : `SymbolicAI/` -- Z3, Tweety, Lean 4, argumentation, smart-contracts
 - **Probabilités** : `Probas/Infer/` -- inference bayesienne, reseaux de decision (Infer.NET)
 - **Jeux** : `GameTheory/` -- equilibres de Nash, jeux bayesiens, MARL (OpenSpiel)
 - **Apprentissage** : `ML/` -- classification, regression, renforcement (ML.NET)
 - **IA Generative** : `GenAI/` -- Image (19 notebooks), Audio (16), Video (16), Texte (10)
-- **Trading** : `QuantConnect/` -- 28 notebooks + 67 strategies backtestees
+- **Trading** : `QuantConnect/` -- 28 notebooks + 67 stratégies backtestees
 
 > **Depot :** `github.com/jsboige/CoursIA` > dossier `MyIA.AI.Notebooks/`
 

--- a/slides/02-resolution-problemes/slides.md
+++ b/slides/02-resolution-problemes/slides.md
@@ -304,7 +304,7 @@ fonction EXPLORER-GRAPHE(probleme) retourne une solution, ou echec
 ## États != Noeuds
 
 - Un **Etat** : représentation de la configuration réelle
-- Un **Noeud** : structure de donnees de l'exploration
+- Un **Noeud** : structure de données de l'exploration
   - état, parent, action, coût g(x), profondeur
 
 ## Fonction NOEUD-FILS
@@ -324,7 +324,7 @@ fonction NOEUD-FILS(probleme, parent, action) retourne un noeud
 
 Une stratégie d'exploration définit l'ordre de développement des noeuds.
 
-## Criteres d'évaluation
+## Critères d'évaluation
 
 - **Completude** : garantie d'obtenir une solution si elle existe
 - **Optimalite** : garantie d'obtenir une solution de coût minimal
@@ -396,7 +396,7 @@ Les stratégies non informées (aveugle) utilisent uniquement la définition du 
 - Equivaut à l'exploration en largeur d'abord si le coût d'étapes est uniforme
 - En théorie de graphes = algorithme de Dijkstra
 
-## Caracteristiques
+## Caractéristiques
 
 - Complet? Oui, si coût d'étape >= epsilon
 - Complexité en temps et en espace: O(b^(1+plafond(C*/epsilon)))
@@ -413,7 +413,7 @@ Les stratégies non informées (aveugle) utilisent uniquement la définition du 
   - Frontiere = **Pile** (LIFO)
   - Branches explorees non conservees
 
-## Caracteristiques
+## Caractéristiques
 
 - **Complet ?** Non : profondeur infinie ou boucles
 - **Temps** : O(b^m), mauvais si m >> d
@@ -434,7 +434,7 @@ Les stratégies non informées (aveugle) utilisent uniquement la définition du 
 - Les noeuds de profondeur l n'ont pas de successeur
 - Complet si l >= d = diamêtre de l'espace des états
 
-## Implementation recursive
+## Implementation récursive
 
 ```
 fonction Exploration-Profondeur-Limitee(probleme, limite) retourne une solution, ou echec/arret
@@ -477,7 +477,7 @@ fonction Exploration-Iterative-Profondeur(probleme) retourne une solution, ou ec
   - N_DLS = 1 + 10 + 100 + 1,000 + 10,000 + 100,000 = 111,111
   - N_IDS = 6 + 50 + 400 + 3,000 + 20,000 + 100,000 = 123,456
 
-## Caracteristiques
+## Caractéristiques
 
 - Complet: Oui | Temps: O(b^d) | Espace: O(b*d) | Optimale: Oui si coût d'étape = 1
 
@@ -492,7 +492,7 @@ fonction Exploration-Iterative-Profondeur(probleme) retourne une solution, ou ec
 ## Quand on connait l'état but
 
 - Double exploration vers l'aval et vers l'amont
-- Interet : O(b^(d/2)) + O(b^(d/2)) est tres inferieur à O(b^d)
+- Intérêt : O(b^(d/2)) + O(b^(d/2)) est très inferieur à O(b^d)
 
 ## Exemple courant
 
@@ -501,7 +501,7 @@ fonction Exploration-Iterative-Profondeur(probleme) retourne une solution, ou ec
 ## Difficultes
 
 - Nécessite une fonction Prédécesseurs
-- Controle de l'intersection
+- Contrôle de l'intersection
   - maintient de la frontiere, même en profondeur + hachage pour comparaison
   - + Solution non optimale même en largeur -> continuer pour trouver les raccourcis
 - États buts complexes
@@ -559,7 +559,7 @@ layout: section
   - f(n) = g(n) + h(n)
   - Développé le noeud avec le plus petit f(n)
 
-## Caracteristiques
+## Caractéristiques
 
 - Complet? Non, peut être piégé dans un maximum local
 - Temps? O(b^m) mais un bon heuristique donne des bons résultats
@@ -594,7 +594,7 @@ layout: section
 
 ---
 
-# Caracteristiques de A*
+# Caractéristiques de A*
 
 <img src="./images/img_023.png" style="position:absolute; top:120px; right:20px; width:380px;" alt="Contours A* sur carte Roumanie" />
 
@@ -625,7 +625,7 @@ layout: section
 
 - A* avec approfondissement itératif (IDA*)
   - Coupe: coût f le plus faible parmi les noeuds en depassement
-- Exploration recursive par le meilleur d'abord (RBFS)
+- Exploration récursive par le meilleur d'abord (RBFS)
   - Espace en mémoire linéaire: valeur f du meilleur chemin alternatif
   - Recursion avec valeur rapportee: meilleure valeur f des enfants oublies
   - Mais exces inverse: trop peu de mémoire et trop de "redéveloppements"
@@ -671,7 +671,7 @@ layout: section
 ## Sous-problèmes
 
 - Exemple: taquin (pieces 1,2,3,4)
-- **Bases de donnees de motifs**: coût exact sous-problèmes = heuristique générale
+- **Bases de données de motifs**: coût exact sous-problèmes = heuristique générale
 - **Motifs disjoints** : question de l'additivité des heuristiques admissibles
 
 ## Apprentissage d'heuristiques
@@ -851,14 +851,14 @@ layout: section
     - Formule de Newton pour trouver g(x) = 0 : x <- x - g(x) / g'(x)
     - En prenant pour g le gradient de f: x <- x - H^-1(x) nabla f(x)
       - avec H matrice Hessienne des derivees secondes de f
-    - Methodes modernes (RMSProp, ADAM)
+    - Méthodes modernes (RMSProp, ADAM)
 
 ## Optimisation sous contrainte
 
 - Contraintes sur les variables
 - Programmation linéaire
   - <- inegalites formant ensemble convexe (pas de trous)
-  - Tres etudie -> complexité polynomiale
+  - Très etudie -> complexité polynomiale
 
 ---
 layout: section
@@ -1132,7 +1132,7 @@ Minimax(s) = { Utilite(s) si Test-Terminal(s)
 - Classe d'équivalence -> valeur attendue (utilité pondérée)
 - Mais trop de classes -> valeur matérielle -> fonction linéaire pondérée
   - Eval(s) = w1*f1(s) + w2*f2(s) + ... + wn*fn(s)
-- Mais non independance des attributs -> fonction non linéaire
+- Mais non indépendance des attributs -> fonction non linéaire
 - Si pas d'expérience, possibilité d'apprentissage (1 fou = 3 pions!)
 
 ## Exploration avec arret
@@ -1170,7 +1170,7 @@ Minimax(s) = { Utilite(s) si Test-Terminal(s)
 
 ## Principe -- simulations statistiques
 
-Pas d'heuristique d'évaluation : **remplacee par des rollouts** (simulations aléatoires jusqu'a fin de partie).
+Pas d'heuristique d'évaluation : **remplacée par des rollouts** (simulations aléatoires jusqu'a fin de partie).
 
 ## Algorithme (boucle)
 
@@ -1224,7 +1224,7 @@ Go, Échecs (AlphaZero), planification en jeux partiellement observables.
 ## Décisions optimales
 
 - **Arbre de jeu** : états, actions, résultats, test terminal, utilité
-- **Minimax** : valeur optimale, algorithme recursif
+- **Minimax** : valeur optimale, algorithme récursif
 - **Alpha-Beta** : élagage pour réduire la taille de l'arbre explore
 
 ## Décisions imparfaites
@@ -1350,13 +1350,13 @@ layout: section
 
 ## Techniques
 
-- **Forward Checking**: Apres assignation, éliminer les valeurs incompatibles des variables non assignees
+- **Forward Checking**: Après assignation, éliminer les valeurs incompatibles des variables non assignees
 - **Arc Consistency (AC)**: Pour chaque contrainte binaire (X,Y), éliminer les valeurs de X qui n'ont pas de support dans Y
 
 ## Algorithme AC-3
 
 - Propage la coherence d'arc à travers le reseau de contraintes
-- Tres efficace mais complexe
+- Très efficace mais complexe
 
 ---
 
@@ -1436,7 +1436,7 @@ layout: section
 
 # Techniques de résolution des CSPs
 
-## Methodes traditionnelles
+## Méthodes traditionnelles
 
 - Backtracking + heuristiques
 - Propagation de contraintes, Forward checking
@@ -1448,7 +1448,7 @@ layout: section
 - Integration CP/SAT/SMT: Utilisation de techniques telles que Lazy Clause Generation pour apprendre les conflits
   - Exemple: Le solver CP-SAT de Google OR-Tools
 
-- Hybridation avec metaheuristiques: Combinaison d'exploration locale (min-conflicts) avec des phases de reparation par CP
+- Hybridation avec métaheuristiques: Combinaison d'exploration locale (min-conflicts) avec des phases de reparation par CP
   - Large Neighborhood Search
 
 ---
@@ -1458,7 +1458,7 @@ layout: section
 ## Variables discrêtes
 
 - Domaines finis: n variables, taille de domaine d -> O(d^n) assignations complètes
-- Domaines infinis: Entiers, chaines de caracteres etc.
+- Domaines infinis: Entiers, chaînes de caractères etc.
   - Ex: planification de cours
   - Besoin d'un langage de contraintes (DebutCours1 + 5 <= DebutCours2)
 
@@ -1572,7 +1572,7 @@ layout: section
 - Couplage inférence + exploration
 - Heuristiques de choix de variables et de valeurs
 - Forward checking et Backjumping : orientent vers les conflits et accelerent la recherche
-- Exploration locale : Min-Conflicts tres efficace, même avec de nombreuses variables
+- Exploration locale : Min-Conflicts très efficace, même avec de nombreuses variables
 
 ---
 

--- a/slides/03-logique/slides.md
+++ b/slides/03-logique/slides.md
@@ -77,7 +77,7 @@ fonction KB-AGENT(percept) retourne une action
 ## Composants
 
 - Une base de connaissance (KB), composee d'enonces formules dans un langage formel de representation des connaissances
-- Un systeme d'infrence (raisonnement) qui produit de nouveaux enonces pour prendre des decisions
+- Un système d'infrence (raisonnement) qui produit de nouveaux enonces pour prendre des decisions
 
 ## Fonctions principales
 
@@ -99,7 +99,7 @@ layout: default
 <img src="./images/img_003.png" style="position:absolute; top:50px; right:10px; height:280px;" alt="Grille du monde du Wumpus" />
 
 
-## Jeu de role simpliste
+## Jeu de rôle simpliste
 
 ### Environnement
 
@@ -139,11 +139,11 @@ layout: default
 
 ## Syntaxe
 
-- Definit les enonces possibles dans le langage
+- Définit les enonces possibles dans le langage
 
-## Semantique
+## Sémantique
 
-- Definit le sens des enonces
+- Définit le sens des enonces
 - Relation entre les enonces et le monde réel
 
 ## Proposition logique
@@ -159,17 +159,17 @@ layout: default
 - EQUIVAUT (equivalence)
 
 
-<img src="./images/img_007.png" style="position:absolute; top:60px; right:20px; width:300px;" alt="Relation semantique enonces et monde réel" />
+<img src="./images/img_007.png" style="position:absolute; top:60px; right:20px; width:300px;" alt="Relation sémantique enonces et monde réel" />
 
 ---
 layout: default
 ---
 
-# Proprietes des systemes de representation
+# Proprietes des systèmes de representation
 
 ## Correction
 
-- Preserve la validite semantique
+- Preserve la validite sémantique
 - Derive des consequences valides
 
 ## Coherence / Consistance
@@ -189,14 +189,14 @@ layout: default
 
 ## Ontologie et Epistemologie
 
-- **Ontologie** : etude de ce qui existe dans le monde modelise
-- **Epistemologie** : etude de ce qui peut etre connu par l'agent
+- **Ontologie** : étude de ce qui existe dans le monde modelise
+- **Epistemologie** : étude de ce qui peut etre connu par l'agent
 
 ## Comparaison
 
 | Logique | Variables | Quantifie sur | Decidable ? |
 |---------|-----------|---------------|-------------|
-| Propositionnelle | Symboles booleens | -- | Oui (NP-complet) |
+| Propositionnelle | Symboles booléens | -- | Oui (NP-complet) |
 | Premier ordre (FOL) | Objets du domaine | Variables | Semi-decidable |
 | Ordre superieur (HOL) | Relations, fonctions | Relations | Non |
 | Modale | + mondes possibles | Necessaire/possible | Selon variante |
@@ -228,7 +228,7 @@ layout: default
 - P OU Q : vrai si au moins un est vrai
 - NON P : vrai si P est faux
 - P => Q : vrai si P est faux ou Q est vrai
-- P <=> Q : vrai si P et Q ont meme valeur de verite
+- P <=> Q : vrai si P et Q ont même valeur de verite
 
 ---
 layout: default
@@ -257,7 +257,7 @@ layout: default
 layout: default
 ---
 
-# Semantique de la logique propositionnelle
+# Sémantique de la logique propositionnelle
 
 ## Interpretation
 
@@ -296,7 +296,7 @@ layout: default
 
 # Infrence propositionnelle
 
-## Entailment (consequence semantique)
+## Entailment (consequence sémantique)
 
 - KB |= alpha : "KB entraine alpha"
 - Alpha est vrai dans tous les modèles ou KB est vrai
@@ -307,19 +307,19 @@ layout: default
 
 ## Demonstration d'infrence
 
-1. **Methodes de verification de modèle**
+1. **Méthodes de verification de modèle**
    - Enumerer toutes les interpretations
    - Verifier que alpha est vrai quand KB est vrai
 
-2. **Methodes de preuve**
-   - Deriver alpha a partir de KB en utilisant des regles d'infrence
+2. **Méthodes de preuve**
+   - Deriver alpha a partir de KB en utilisant des règles d'infrence
 
 ---
 layout: default
 ---
 
 
-# Regles d'infrence
+# Règles d'infrence
 
 ## Modus Ponens
 
@@ -365,7 +365,7 @@ layout: default
 - Au plus un litteral positif: P OU NON Q1 OU ... OU NON Qm
 - Equivaut a: (Q1 ET Q2 ET ... ET Qm) => P
 
-## Regle de resolution
+## Règle de resolution
 
 - Deux clauses avec des litteraux complementaires peuvent etre combinees
 - (P OU Q), (NON P OU R) |- (Q OU R)
@@ -389,7 +389,7 @@ image: ./images/img_015.png
 2. Ajouter NON alpha a l'ensemble de clauses
 3. Appliquer la resolution jusqu'a obtenir la clause vide (contradiction) ou ne plus pouvoir progresser
 
-**Resultat** : si la clause vide est derivee, alors KB |= alpha (preuve par refutation).
+**Résultat** : si la clause vide est derivee, alors KB |= alpha (preuve par refutation).
 
 </div>
 
@@ -403,16 +403,16 @@ layout: default
 <img src="./images/img_013.png" style="position:absolute; bottom:26px; right:44px; width:165px;" alt="Clauses Forward Chaining" />
 
 
-## Forward Chaining (chaine avant)
+## Forward Chaining (chaîne avant)
 
 - Partir des faits connus
-- Appliquer les regles pour deduire de nouveaux faits
+- Appliquer les règles pour deduire de nouveaux faits
 - Continuer jusqu'a ce que le but soit atteint<br>ou plus aucun fait nouveau
 
-## Backward Chaining (chaine arriere)
+## Backward Chaining (chaîne arriere)
 
 - Partir du but
-- Chercher les regles dont le but est la conclusion
+- Chercher les règles dont le but est la conclusion
 - Recursivement chercher a prouver les premisses
 
 ## Comparaison
@@ -425,7 +425,7 @@ layout: default
 layout: default
 ---
 
-# Proprietes des systemes d'infrence
+# Proprietes des systèmes d'infrence
 
 ## Correctitude (Soundness)
 
@@ -480,9 +480,9 @@ layout: default
 
 ## DPLL
 
-- Enumeration recursive en profondeur d'abord
+- Enumeration récursive en profondeur d'abord
 - **Elagage** : une clause est vraie si un litteral est vrai, un enonce est faux si une clause est fausse
-- **Heuristique des symboles purs** : toujours le meme signe -> litteral doit etre vrai
+- **Heuristique des symboles purs** : toujours le même signe -> litteral doit etre vrai
 - **Heuristique des clauses unitaires** : assignation de ces clauses en premier
 
 
@@ -520,7 +520,7 @@ layout: default
 - Equivaut a Min-Conflits pour les CSPs
 - Evaluation = nombre de clauses non satisfaites
 
-## Caracteristiques
+## Caractéristiques
 
 - Problemes simples sous-contraints / sur-contraints
 - Ratio nb clauses / nb symboles -> seuil de satisfiabilite
@@ -568,8 +568,8 @@ layout: default
 
 ## Estimation logique des etats
 
-- Probleme : inférence de plus en plus longue (t<sub>0</sub>+1+1+...)
-- Solution : mise en cache des resultats intermediaires
+- Problème : inférence de plus en plus longue (t<sub>0</sub>+1+1+...)
+- Solution : mise en cache des résultats intermediaires
 
 ## MAJ etat de croyance
 
@@ -605,7 +605,7 @@ layout: default
 ## Definition
 
 - Syntaxe : Symboles, connecteurs
-- Semantique : Valeurs de verite
+- Sémantique : Valeurs de verite
 
 ## Inference
 
@@ -639,7 +639,7 @@ layout: default
   - O1,1 <=> (W1,1 OU W1,2 OU W2,1)
   - O1,2 <=> (W1,1 OU W1,2 OU W1,3 OU W2,2)
   - ...
-- Besoin d'une regle par case!
+- Besoin d'une règle par case!
 
 ## Logique du premier ordre
 
@@ -679,19 +679,19 @@ layout: default
 layout: default
 ---
 
-# Semantique de la logique du premier ordre
+# Sémantique de la logique du premier ordre
 
 ## Interpretation
 
 - Domaine: ensemble non vide d'objets
-- Interpretation des constantes: elements du domaine
+- Interpretation des constantes: éléments du domaine
 - Interpretation des fonctions: applications du domaine vers le domaine
 - Interpretation des predicats: relations sur le domaine
 
 ## Satisfaction
 
-- Une interpretation satisfait ∀x P(x) si P(x) est vrai pour tout element du domaine
-- Une interpretation satisfait ∃x P(x) si P(x) est vrai pour au moins un element
+- Une interpretation satisfait ∀x P(x) si P(x) est vrai pour tout élément du domaine
+- Une interpretation satisfait ∃x P(x) si P(x) est vrai pour au moins un élément
 
 ## Modèle
 
@@ -733,7 +733,7 @@ layout: default
 - Un enonce qui ne contient aucune variable "libre"
 - Toutes les variables sont "liees" a des quantificateurs existentiels ou universels
 
-## Regles d'inference quantifiees
+## Règles d'inference quantifiees
 
 - Instanciations universelle et existentielle
   - ∀x P(x) |- P(A)
@@ -811,7 +811,7 @@ layout: default
 - Qu'est-ce qu'un bon argument ?
 - Qu'est-ce qu'un argument fallacieux ?
 
-## Themes
+## Thèmes
 
 - Taxonomie des arguments fallacieux
 - Biais cognitifs
@@ -830,7 +830,7 @@ layout: default
 
 ## Un standard procedural efficace
 
-- Les regles de base pour une discussion fructueuse
+- Les règles de base pour une discussion fructueuse
 
 ## Un standard ethique important
 
@@ -904,7 +904,7 @@ layout: default
 
 # Qu'est-ce qu'un bon argument ? (1/2)
 
-## 5 criteres
+## 5 critères
 
 1. **Structure bien formee**
    - Pas de contradictions entre premisses et avec la conclusion
@@ -912,7 +912,7 @@ layout: default
 2. **Premisses pertinentes** pour la verite de la conclusion
    - Pas de premisses inutiles, les liens doivent etre explicites
 3. **Premisses acceptables** par une personne raisonnable
-   - Connaissance commune, ou confirmee par l'experience
+   - Connaissance commune, ou confirmee par l'expérience
    - Defendue ou defendable par une source accessible
    - Temoignage non controversee par une autorite competente
    - Conclusion d'un autre bon argument
@@ -924,18 +924,18 @@ layout: default
 
 # Qu'est-ce qu'un bon argument ? (2/2)
 
-## Criteres (suite)
+## Critères (suite)
 
 4. **Premisses suffisantes** a demontrer la conclusion
    - Difficile a systematiser
-   - Cf. certaines sciences (echantillons statistiques) ou experience
+   - Cf. certaines sciences (echantillons statistiques) ou expérience
 5. **Refutation effective** des critiques anticipees
    - Le plus difficile, manque le plus souvent
    - Permet de departager de "presque" bons arguments
 
 ## Renforcer un argument
 
-- Balayer ces 5 criteres et le modifier en consequence
+- Balayer ces 5 critères et le modifier en consequence
 
 ---
 layout: default
@@ -945,7 +945,7 @@ layout: default
 
 ## Definition
 
-- La violation de l'un des criteres definissant un bon argument
+- La violation de l'un des critères definissant un bon argument
   - Faille structurelle
   - Premisse non pertinente
   - Premisse sous le standard d'acceptabilite
@@ -966,7 +966,7 @@ layout: default
 ## Denoncer un argument fallacieux
 
 - Autodestruction par reconstruction en forme standard
-- Methode du contre-exemple absurde
+- Méthode du contre-exemple absurde
 
 ## Fair-play
 
@@ -979,13 +979,13 @@ layout: default
 layout: default
 ---
 
-# Semantique de la logique du premier ordre (details)
+# Sémantique de la logique du premier ordre (details)
 
 ## Transposition dans le monde
 
 - Interpretation des domaines (Constantes -> objets), connecteurs, quantificateurs
 - Predicats, fonctions -> relations entre objets
-- Egalite -> memes objets
+- Egalite -> mêmes objets
 
 ## Interpretation d'enonce
 
@@ -1004,22 +1004,22 @@ layout: default
 layout: default
 ---
 
-# Semantique de la logique du premier ordre (2/2)
+# Sémantique de la logique du premier ordre (2/2)
 
-## Semantique de base de données
+## Sémantique de base de données
 
 - Hypothese des noms uniques
 - Les enonces atomiques inconnus sont presumes faux (hypothese de monde clos)
-- Fermeture du domaine (pas plus d'elements que les constantes données)
+- Fermeture du domaine (pas plus d'éléments que les constantes données)
 
-## Infrence en FOL : Operations Tell, Ask
+## Infrence en FOL : Opérations Tell, Ask
 
 - Assertions -> Tell (ex: TELL(KB, King(John)))
-- Requetes / buts -> Ask (ex: ASK(KB, King(John)))
+- Requêtes / buts -> Ask (ex: ASK(KB, King(John)))
 - Substitution / liste de liaison -> AskVars (ex: ASKVARS(KB, Person(x)))
 - Reduction a l'inference propositionnelle
-  - Regles des quantificateurs + symboles fermes => symboles propositionnels
-  - Procedure complete mais semi-decidable (Godel), tres lente
+  - Règles des quantificateurs + symboles fermes => symboles propositionnels
+  - Procedure complete mais semi-decidable (Godel), très lente
 
 ---
 layout: default
@@ -1029,7 +1029,7 @@ layout: default
 
 ## Chainages
 
-- **Chainage avant** : bases de données deductives, systemes de production
+- **Chainage avant** : bases de données deductives, systèmes de production
 - **Chainage arriere** : programmation logique (Prolog) + memoisation
 
 ## Exemple : le crime du Colonel West
@@ -1050,8 +1050,8 @@ layout: default
 
 ## Resolution
 
-- Systeme de preuve complet
-- Strategies pour reduire l'espace de resolution<br>(demodulation, paramodulation)
+- Système de preuve complet
+- Stratégies pour reduire l'espace de resolution<br>(demodulation, paramodulation)
 - Demonstrateurs de theoremes sophistiques :<br>OTTER, E-prover
 
 ## Notations
@@ -1070,7 +1070,7 @@ layout: default
 
 - Convertir en logique propositionnelle
 - Remplacer les variables par toutes les constantes possibles
-- Probleme: explosion combinatoire
+- Problème: explosion combinatoire
 
 ## Unification
 
@@ -1099,7 +1099,7 @@ layout: default
 
 - Unifier P(x, Jean) et P(Marie, y)
   - MGU: &#123;x/Marie, y/Jean&#125;
-  - Resultat: P(Marie, Jean)
+  - Résultat: P(Marie, Jean)
 
 - Unifier P(x, x) et P(Jean, Marie)
   - Echec: impossible d'unifier
@@ -1119,14 +1119,14 @@ layout: default
 ## Principe
 
 1. Partir des faits connus
-2. Pour chaque regle, trouver les substitutions qui satisfont les premisses
+2. Pour chaque règle, trouver les substitutions qui satisfont les premisses
 3. Ajouter les conclusions correspondantes
 4. Repeter jusqu'a ce que le but soit atteint
 
 ## Exemple
 
 - Faits: Humain(Socrate)
-- Regle: ∀x (Humain(x) => Mortel(x))
+- Règle: ∀x (Humain(x) => Mortel(x))
 - Substitution: &#123;x/Socrate&#125;
 - Nouveau fait: Mortel(Socrate)
 
@@ -1142,14 +1142,14 @@ layout: default
 ## Principe
 
 1. Partir du but
-2. Chercher les regles dont le but est la conclusion
-3. Pour chaque regle, chercher les substitutions et prouver les premisses
+2. Chercher les règles dont le but est la conclusion
+3. Pour chaque règle, chercher les substitutions et prouver les premisses
 4. Recursivement
 
 ## Exemple
 
 - But: Mortel(Socrate)
-- Regle: ∀x (Humain(x) => Mortel(x))
+- Règle: ∀x (Humain(x) => Mortel(x))
 - Substitution: &#123;x/Socrate&#125;
 - Nouveau but: Humain(Socrate)
 - Fait connu: Humain(Socrate) -> Succes!
@@ -1187,7 +1187,7 @@ layout: default
 ## FOL vs HOL
 
 - **FOL** quantifie sur des variables representant des **objets**
-- **HOL** (Higher-Order Logic) quantifie sur les **relations et fonctions elles-memes**
+- **HOL** (Higher-Order Logic) quantifie sur les **relations et fonctions elles-mêmes**
 
 ## Exemples
 
@@ -1202,7 +1202,7 @@ layout: default
 
 - **Tweety** : framework Java pour logiques argumentatives
 - **E-prover** : demonstrateur automatique pour FOL
-- **Lean** : assistant de preuve interactif, tres actif en mathematiques
+- **Lean** : assistant de preuve interactif, très actif en mathematiques
 
 ---
 layout: default
@@ -1227,18 +1227,18 @@ layout: default
 
 # Logique modale (2/2)
 
-## Syntaxe : operateurs
+## Syntaxe : opérateurs
 
 - "◊" (diamant = possibilite)
 - "□" (carre = necessite)
 
-## Semantique : mondes possibles
+## Sémantique : mondes possibles
 
 ## Applications
 
 - Philosophie (modalites epistemiques)
-- Informatique (systemes multi-agents, verification formelle)
-- Mathematiques (theorie des ensembles, des jeux, de la preuve)
+- Informatique (systèmes multi-agents, verification formelle)
+- Mathematiques (théorie des ensembles, des jeux, de la preuve)
 - Argumentation (raisonnement modal, mondes possibles)
 - Argumentum
 
@@ -1269,8 +1269,8 @@ layout: default
 ## Extensions de Dung
 
 - **ASPIC** (SPecification and Interrogation with Constraints)
-  - Regles, contraintes, attaques entre arguments
-  - Satisfaction des regles, validite des arguments, resolution des conflits
+  - Règles, contraintes, attaques entre arguments
+  - Satisfaction des règles, validite des arguments, resolution des conflits
 - **ABA** (Assumption-Based Argumentation)
   - Utilisation d'ensembles d'hypotheses
   - Relations de soutien et d'attaques
@@ -1307,15 +1307,15 @@ layout: default
 layout: default
 ---
 
-# Solveurs Modulo Theorie et optimiseurs (1/2)
+# Solveurs Modulo Théorie et optimiseurs (1/2)
 
 ## Issus de SAT, rajoute
 
-- Des theories arithmetiques
+- Des théories arithmetiques
 - Les quantificateurs du premier ordre
 - Certaines techniques de resolution d'equations ou d'optimisation mathematique
 
-## Tres populaires
+## Très populaires
 
 - Representation + riche que SAT mais **decidables** = sweet spot
 - Ex : Verification de circuits electroniques et de code/protocoles critiques
@@ -1325,11 +1325,11 @@ layout: default
 layout: default
 ---
 
-# Solveurs Modulo Theorie et optimiseurs (2/2)
+# Solveurs Modulo Théorie et optimiseurs (2/2)
 
-## Theories
+## Théories
 
-- Egalite de fonctions, differences
+- Egalite de fonctions, différences
 - Arithmetique lineaire entière, rationnelle, réelle
 - Tableaux, arithmetique non lineaire, vecteur de bits
 
@@ -1366,7 +1366,7 @@ layout: default
 - Modèle interne du monde
 - Representation du changement -> calcul situationnel
 - Proprietes perpetuelles -> proprietes cachees des lieux
-- Regles causales, de diagnostique
+- Règles causales, de diagnostique
 - Ex: (l1,l2,s) At(Wumpus,l1,s) ∧ Adjacent(l1,l2) => Smelly(l2)
 - Axiomes de persistance, d'effets, problemes de qualifications
 - Ingenierie de données -> modeliser le bon niveau
@@ -1435,12 +1435,12 @@ layout: default
 - Representation explicite des connaissances
 - Raisonnement automatique
 
-## Systemes experts
+## Systèmes experts
 
 - Base de connaissances + Moteur d'infrence
 - Domaines: medecine, diagnostic, configuration
 
-## Web semantique
+## Web sémantique
 
 - RDF, OWL: representation des connaissances sur le web
 - SPARQL: interrogation des connaissances
@@ -1462,14 +1462,14 @@ layout: default
 
 # Planification
 
-## Probleme de planification
+## Problème de planification
 
 - Trouver une sequence d'actions qui permettent d'atteindre un objectif a partir d'un etat initial
-- Donner la liste des instances d'operations, qui, executees a partir de l'etat initial, vont modifier l'etat du monde a un etat qui satisfait le but
+- Donner la liste des instances d'opérations, qui, executees a partir de l'etat initial, vont modifier l'etat du monde a un etat qui satisfait le but
 
-## Planification et resolution de probleme
+## Planification et resolution de problème
 
-- Souvent memes types de problemes
+- Souvent mêmes types de problemes
 - Planification plus expressive
 - Exploration de l'espace de plan en plus de l'espace d'etats
 - Sous-objectifs independants reduisent la complexite
@@ -1486,7 +1486,7 @@ layout: default
 - Similaire a la logique du premier ordre (FOL)
 - Etat: At(Truck1, Melbourne) ET At(Truck2, Sydney)
 - Chaque etat est appele un fluent
-- Semantique de DB (ce qui n'est pas explicite est presume faux)
+- Sémantique de DB (ce qui n'est pas explicite est presume faux)
 - Les enonces sont fermes, sans fonction
 
 ## Schema d'action
@@ -1548,7 +1548,7 @@ layout: default
 - Construction des sous-plans
 - Ordre reconcilie par application de contraintes
 
-## Decomposition hierarchique
+## Decomposition hiérarchique
 
 - Distinction des buts a decomposer
 - Primitives atomiques pour les atteindre
@@ -1593,7 +1593,7 @@ layout: default
 
 # Heuristiques pour la planification
 
-## Probleme relache
+## Problème relache
 
 - Ignorer les preconditions
 - Ignorer les delete lists
@@ -1604,7 +1604,7 @@ layout: default
 
 ## Decomposition
 
-- Diviser le probleme en sous-problemes independants
+- Diviser le problème en sous-problemes independants
 
 ## Landmarks
 
@@ -1619,7 +1619,7 @@ layout: default
 
 ## Structure de données
 
-- Generee a partir d'un probleme de planification
+- Generee a partir d'un problème de planification
 - Divisee en niveaux:
   - Niveaux d'etats Si: Les fluents peuvent etre vrais au niveau i
   - Niveaux d'actions Ai: Les actions applicables a l'étape i
@@ -1726,7 +1726,7 @@ layout: default
 
 ## Preconditions -> Axiomes de Possibilite
 
-## Operateurs: descriptions de comment le monde change
+## Opérateurs: descriptions de comment le monde change
 
 - ∀(a,s) Have(Milk, Result(a,s)) <=><br>((a=Buy(Milk) ET At(Grocery,s))<br>OU (Have(Milk, s) ET a≠Drop(Milk)))
 
@@ -1772,23 +1772,23 @@ h2 { margin-top: 0.3em !important; margin-bottom: 0.1em !important; }
 ## Plan non lineaire
 
 - Étapes &#123;S1, S2, S3...&#125;
-  - Description d'operateurs + pre et post-conditions
+  - Description d'opérateurs + pre et post-conditions
 - Liens causaux &#123;... (Si, C, Sj) ...&#125;
 - Contraintes d'ordre &#123;... Si &lt; Sj ...&#125;
 
 ## Plan complet
 
 - Toutes les étapes sont incluses
-- Chaine de causalite
+- Chaîne de causalite
 - Validite temporelle
 
 ---
 layout: default
 ---
 
-# Decomposition hierarchique
+# Decomposition hiérarchique
 
-<img src="./images/img_035.png" style="position:absolute; top:92px; right:30px; width:255px;" alt="SIPE-2 decomposition hierarchique" />
+<img src="./images/img_035.png" style="position:absolute; top:92px; right:30px; width:255px;" alt="SIPE-2 decomposition hiérarchique" />
 <img src="./images/img_036.png" style="position:absolute; top:288px; right:58px; width:200px;" alt="Build House HTN" />
 
 <style scoped>
@@ -1802,17 +1802,17 @@ h2 { margin-top: 0.3em !important; margin-bottom: 0.1em !important; }
 - Planning -> scheduling
 - Actions conditionnelles, incertaines, dynamiques
 
-## Planifier =/= Programmer un evenement
+## Planifier =/= Programmer un événement
 
 - Allouer des ressources, respecter des contraintes
 - Planifier -> raisonnement
 - Programmer -> CSPs
 
-## Decomposition hierarchique
+## Decomposition hiérarchique
 
-- Operateurs abstraits -> vers les Buts intermediaires
+- Opérateurs abstraits -> vers les Buts intermediaires
 - Primitives de bas niveau: Executable
-- Operateurs non primitifs: Buts, actions abstraites
+- Opérateurs non primitifs: Buts, actions abstraites
 
 ---
 layout: default
@@ -1826,9 +1826,9 @@ layout: default
 - Dans l'espace des plans (planification partiellement ordonnees, HTN, etc.)
 - Base sur les contraintes (GraphPlan, SATPlan etc.)
 - Calcul situationnel
-- Planification hierarchique
+- Planification hiérarchique
 
-## Strategies d'exploration
+## Stratégies d'exploration
 
 - Planification progressive
 - Regression des buts
@@ -1864,7 +1864,7 @@ h2 { margin-top: 0.3em !important; margin-bottom: 0.1em !important; }
 
 - Reification: predicats et constantes
   - BallonDeBasket(b) -> Membre(b, BallonsDeBasket)
-- Hierarchie: taxonomies (sous-classes), heritage
+- Hiérarchie: taxonomies (sous-classes), heritage
 - Partitions: Disjoints + decomposition exhaustive
 - Composition: PartieDe(x,y)
 - Mesure: Unites (Centimetre, Pouces)
@@ -1878,7 +1878,7 @@ h2 { margin-top: 0.3em !important; margin-bottom: 0.1em !important; }
 layout: default
 ---
 
-# Web semantique
+# Web sémantique
 
 
 ## Resource Description Framework (RDF)
@@ -1889,12 +1889,12 @@ layout: default
 
 ## RDFS et OWL
 
-- Classes definies
+- Classes définies
 - Contraintes
 
 ## SPARQL
 
-- Requetes sur "Triple Stores"
+- Requêtes sur "Triple Stores"
 
 ## Linked Data
 
@@ -1908,10 +1908,10 @@ layout: default
 layout: default
 ---
 
-# Systemes de raisonnement
+# Systèmes de raisonnement
 
 
-## Reseaux semantiques
+## Reseaux sémantiques
 
 - Proche des formalismes UML/Merise
 - Infrence par navigation, heritage, reification
@@ -1930,14 +1930,14 @@ layout: default
 - Circonscription, logique par defaut
 
 
-<img src="./images/img_044.png" style="position:absolute; top:50px; right:10px; width:300px;" alt="Systemes de raisonnement diagrammes" />
+<img src="./images/img_044.png" style="position:absolute; top:50px; right:10px; width:300px;" alt="Systèmes de raisonnement diagrammes" />
 
 ---
 layout: default
 ---
 
 
-# Systemes a maintenance de verite
+# Systèmes a maintenance de verite
 
 <style scoped>
 .slidev-layout { font-size: 0.88em; }
@@ -1948,7 +1948,7 @@ h2 { margin-top: 0.3em !important; margin-bottom: 0.1em !important; }
 
 - Statut par defaut -> revision des faits infenes faux
 - Tell(KB, not P) -> Retract(KB, P)
-- Probleme: si P->Q doit-on annuler Q?
+- Problème: si P->Q doit-on annuler Q?
 
 ## Fondes sur la justification (JTMS)
 
@@ -1960,7 +1960,7 @@ h2 { margin-top: 0.3em !important; margin-bottom: 0.1em !important; }
 - Envisager simultanement plusieurs hypotheses
 - Chaque enonce comporte les hypotheses qui peuvent le rendre vrai
 
-## Generateurs d'explications
+## Générateurs d'explications
 
 - Hypotheses = explications raisonnables
 - Explications minimales (Ockham)
@@ -2005,12 +2005,12 @@ layout: default
 
 - Meta-modèles de données
 
-## Web semantique
+## Web sémantique
 
 - Representation de faits
-- Pile semantique du W3C
+- Pile sémantique du W3C
 
-## Systemes de raisonnement
+## Systèmes de raisonnement
 
 - Maintenance de la verite
 
@@ -2105,19 +2105,19 @@ jpype.startJVM(classpath=["libs/*"])
 PlBeliefSet = jpype.JClass("org.tweetyproject.logics.pl.syntax.PlBeliefSet")
 ```
 
-JDK 17 + 35 JARs telecharges automatiquement par le notebook de setup. Aucune installation systeme requise.
+JDK 17 + 35 JARs telecharges automatiquement par le notebook de setup. Aucune installation système requise.
 
 ---
 
 # Tweety — cartographie des notebooks
 
-| # | Notebook | Theme | Duree |
+| # | Notebook | Thème | Duree |
 |---|----------|-------|-------|
 | 1 | Setup | JVM, JARs, outils externes | 20 min |
 | 2 | Basic-Logics | Propositionnelle, FOL | 45 min |
 | 3 | Advanced-Logics | DL, Modale, QBF, Conditionnelle | 40 min |
 | 4 | Belief-Revision | MUS, MaxSAT, incoherence | 50 min |
-| 5 | Abstract-Argumentation | Dung AF, semantiques, CF2 | 55 min |
+| 5 | Abstract-Argumentation | Dung AF, sémantiques, CF2 | 55 min |
 | 6 | Structured-Argumentation | ASPIC+, DeLP, ABA, ASP | 60 min |
 | 7a | Extended-Frameworks | ADF, Bipolar, WAF, SAF | 50 min |
 | 7b | Ranking-Probabilistic | Ranking, probabiliste | 40 min |
@@ -2153,7 +2153,7 @@ result = reasoner.query(kb, parser.parseFormula("c"))
 
 **Postulats AGM** (Alchourron-Gardenfors-Makinson, 1985) :
 
-| Operation | Notation | Effet |
+| Opération | Notation | Effet |
 |-----------|----------|-------|
 | Expansion | K + α | Ajoute α sans verification |
 | Contraction | K - α | Retire α et ses consequences |
@@ -2172,9 +2172,9 @@ result = reasoner.query(kb, parser.parseFormula("c"))
 
 **Definition** : `AF = (A, R)` graphe oriente arguments + relation d'attaque.
 
-**Semantiques** :
+**Sémantiques** :
 
-| Semantique | Definition |
+| Sémantique | Definition |
 |------------|------------|
 | **Conflict-free** | Aucun argument n'attaque un autre dans le set |
 | **Admissible** | Conflict-free + defend ses membres |
@@ -2183,7 +2183,7 @@ result = reasoner.query(kb, parser.parseFormula("c"))
 | **Preferred** | Maximale parmi les admissibles |
 | **Stable** | Conflict-free + attaque tout le reste |
 | **Semi-stable** | Preferred maximisant le range |
-| **CF2** | Recursif sur SCC |
+| **CF2** | Récursif sur SCC |
 
 Reference : Dung, *"On the Acceptability of Arguments"*, AIJ 1995.
 
@@ -2231,7 +2231,7 @@ reach(X, Y) :- reach(X, Z), edge(Z, Y).
 
 ---
 
-# Notebooks 8-9 — Agents et preferences
+# Notebooks 8-9 — Agents et préférences
 
 **Dialogues argumentatifs** (Walton & Krabbe, 1995) :
 - **Persuasion** : convaincre
@@ -2240,9 +2240,9 @@ reach(X, Y) :- reach(X, Z), edge(Z, Y).
 - **Inquiry** : decouvrir la verite
 - **Deliberation** : decider d'une action
 
-**Theorie sociale du choix** :
+**Théorie sociale du choix** :
 - Theoreme d'Arrow (1951) : impossibilite
-- Regles : Plurality, Borda, Condorcet, Copeland, STV
+- Règles : Plurality, Borda, Condorcet, Copeland, STV
 - Lien serie GameTheory : port Lean d'Arrow dans `social_choice_lean/`
 
 ---
@@ -2255,7 +2255,7 @@ layout: section
 
 # Qu'est-ce que Lean 4 ?
 
-**Lean 4** : assistant de preuves et langage de programmation fonctionnel base sur la **theorie des types dependants**.
+**Lean 4** : assistant de preuves et langage de programmation fonctionnel base sur la **théorie des types dependants**.
 
 - Successeur de Lean 3, reecriture complete (2021)
 - Auteur principal : Leonardo de Moura (Microsoft Research, AWS)
@@ -2273,7 +2273,7 @@ Reference : de Moura & Ullrich, *"The Lean 4 Theorem Prover and Programming Lang
 
 # Lean — cartographie des notebooks
 
-| # | Notebook | Theme | Duree |
+| # | Notebook | Thème | Duree |
 |---|----------|-------|-------|
 | 1 | Setup | elan, kernel Jupyter | 15 min |
 | 2 | Dependent-Types | Calcul des Constructions | 35 min |
@@ -2291,7 +2291,7 @@ Reference : de Moura & Ullrich, *"The Lean 4 Theorem Prover and Programming Lang
 
 ---
 
-# Modes d'execution suggeres
+# Modes d'exécution suggeres
 
 | Mode | Notebooks | Temps |
 |------|-----------|-------|
@@ -2371,7 +2371,7 @@ example (n : Nat) : n + 0 = n ∧ n * 1 = n := by omega
 example (a b : ℝ) : a^2 - b^2 = (a-b)*(a+b) := by polyrith
 ```
 
-**Recherche** : **Loogle** (syntaxique), **Moogle** (semantique).
+**Recherche** : **Loogle** (syntaxique), **Moogle** (sémantique).
 
 ---
 
@@ -2393,7 +2393,7 @@ example (a b : Nat) : a + b = b + a := by
 - 99.5% sur miniF2F (vs 85% AlphaProof)
 - Problemes Erdos en cours de formalisation
 
-**Microsoft Agent Framework** (Notebook 9) : orchestration sequentielle, concurrente, group chat, handoff.
+**Microsoft Agent Framework** (Notebook 9) : orchestration séquentielle, concurrente, group chat, handoff.
 
 ---
 
@@ -2414,7 +2414,7 @@ with Dojo(theorem) as dojo:
 
 **TorchLean** — verification de NN :
 
-| Methode | Complexite | Precision |
+| Méthode | Complexite | Precision |
 |---------|------------|-----------|
 | **IBP** (Interval Bound Propagation) | O(n) | Faible |
 | **CROWN** (Linear Relaxation) | O(n^2) | Moyenne |
@@ -2425,13 +2425,13 @@ with Dojo(theorem) as dojo:
 
 # Notebook 12 — Theoreme de sensibilité
 
-**Huang (2019)** : reponse au probleme de sensibilité (ouvert depuis 1988).
+**Huang (2019)** : reponse au problème de sensibilité (ouvert depuis 1988).
 
-> Pour toute fonction booleenne `f : {0,1}^n → {0,1}`, sensibilité `s(f)` et degre `deg(f)` sont polynomialement equivalents : `deg(f) ≤ s(f)^4`.
+> Pour toute fonction booleenne `f : {0,1}^n → {0,1}`, sensibilité `s(f)` et degré `deg(f)` sont polynomialement equivalents : `deg(f) ≤ s(f)^4`.
 
 **Outils** :
 - Hypercube `{0,1}^n`
-- Signing matrix `A_n` (recursive, eigenvalues ±√n)
+- Signing matrix `A_n` (récursive, eigenvalues ±√n)
 - Cauchy interlacing
 
 **Port Lean 4** (en cours) :
@@ -2455,7 +2455,7 @@ layout: section
 
 # Percees recentes (2024-2026)
 
-| Annee | Systeme | Accomplissement |
+| Annee | Système | Accomplissement |
 |-------|---------|------------------|
 | 2023 | **LeanDojo** | RAG ReProver, NeurIPS 2023 |
 | 2024 | **AlphaProof** | IMO 2024 silver-medal |
@@ -2485,7 +2485,7 @@ layout: section
 - LLM in-editor : **LeanCopilot, AlphaProof**
 
 **Convergence pratique** :
-- Tweety encode des semantiques de Dung en ASP (Clingo)
+- Tweety encode des sémantiques de Dung en ASP (Clingo)
 - Lean **prouve** la correction des algorithmes argumentatifs
 - LLMs (GPT-4o, Claude Opus) generent **+** verifient via les deux
 
@@ -2497,7 +2497,7 @@ layout: section
 |-------|--------------------------------|
 | **Argument_Analysis** | Tweety = backend Java pour l'analyse de textes argumentatifs |
 | **GameTheory** | Notebook 9 Tweety (vote) + `social_choice_lean/` (Arrow, Sen) |
-| **SmartContracts** | Verification Solidity (Certora, SMTChecker) — meme stack SAT/SMT |
+| **SmartContracts** | Verification Solidity (Certora, SMTChecker) — même stack SAT/SMT |
 | **ML** | TorchLean (Lean 11/11a) : verification de NN entraines |
 | **Search** | CSP : preuves de correction via Lean |
 | **Planners** | Dialogues argumentatifs (Tweety 8) ↔ planification PDDL |
@@ -2528,7 +2528,7 @@ jupyter notebook Tweety-1-Setup.ipynb
 # 3. Executer toutes les cellules, puis passer a Tweety-2
 ```
 
-JDK 17 et 35 JARs telecharges automatiquement. Aucune installation systeme requise.
+JDK 17 et 35 JARs telecharges automatiquement. Aucune installation système requise.
 
 **Validation rapide** :
 
@@ -2618,7 +2618,7 @@ jupyter notebook MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
 
 **Lean** :
 
-| Outil | Role |
+| Outil | Rôle |
 |-------|------|
 | **elan** | Gestionnaire de versions |
 | **lake** | Build system |
@@ -2641,7 +2641,7 @@ jupyter notebook MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-1-Setup.ipynb
 - [Theorem Proving in Lean 4](https://leanprover.github.io/theorem_proving_in_lean4/)
 - [Mathlib4 Docs](https://leanprover-community.github.io/mathlib4_docs/)
 - [Loogle](https://loogle.lean-lang.org/) — recherche syntaxique
-- [Moogle](https://www.moogle.ai/) — recherche semantique
+- [Moogle](https://www.moogle.ai/) — recherche sémantique
 - [Lean Zulip](https://leanprover.zulipchat.com/)
 - [Mathematics in Lean](https://leanprover-community.github.io/mathematics_in_lean/)
 

--- a/slides/04-probabilites/slides.md
+++ b/slides/04-probabilites/slides.md
@@ -1,7 +1,7 @@
 ---
 theme: ../theme-ia101
 title: "Intelligence Artificielle - Probabilites"
-info: IA 101 - Incertitude et modeles probabilistes
+info: IA 101 - Incertitude et modèles probabilistes
 paginate: true
 drawings:
   persist: false


### PR DESCRIPTION
Grain: MED/slides — lane myia-ai-01:CoursIA — prev: MED/tooling #11548

Première tranche de contenu du lot **L1** de l'Epic slides, que l'Epic identifie comme *« probablement la première cause du "plus moche que le PPTX" : avant toute question de mise en page, le texte projeté est fautif »*.

L'outil qui produit ce diff est **#11548** (adaptateur `.md` de la cure canonique #2876). Cette PR n'ajoute aucun code — uniquement le résultat, relu.

## Ce qui change

| Deck | Substitutions | Lignes modifiées |
|---|---|---|
| `01-introduction` | 56 | 50 |
| `02-resolution-problemes` | 25 | 23 |
| `03-logique` | 140 | 140 |
| `04-probabilites` | 1 | 1 |

**222 substitutions, 86 paires distinctes, 214 lignes de diff** — accents-only, `214 insertions(+) / 214 deletions(-)` : chaque ligne modifiée l'est en place, aucune ligne ajoutée ni supprimée. Le nombre de lignes de chaque fichier est identique avant et après (vérifié ligne à ligne). Aucune valeur de `src=` / `style=` / `class=` n'est modifiée.

Les fins de ligne sont préservées **par fichier** : le deck 02 est committé en **CRLF**, le deck 01 en **LF**, et `.gitattributes` ne couvre pas `slides/**/*.md`. Sans cette précaution le deck 02 rendait 3210 lignes de diff pour ses 25 cures — un diff qui n'est plus accents-only, exactement la classe de défaut que le registre #2876 existe pour fermer (#7105/#7124/#7132). Le correctif est dans #11548 ; relancer la cure depuis `main` avant que #11548 ne soit mergée reproduirait l'artefact.

## Cinq tokens anglais restaurés à la main

Le dictionnaire canonique est conservateur — il n'inclut que les paires dont la forme non accentuée n'est **pas** un mot français valide. Mais il ne sait pas qu'un mot est **anglais**. J'ai énuméré les formes distinctes du diff et relu les substitutions une à une ; cinq étaient fautives et sont restaurées, chacune vérifiée dans son contexte :

| Ligne | Token | Pourquoi |
|---|---|---|
| `03-logique:2125` | `Preferences` | colonne « Notebook » d'un tableau — c'est un **nom de fichier réel** (`Tweety-9-Preferences.ipynb`) |
| `03-logique:2594` | `Elements` | titre d'ouvrage **anglais** : Besnard & Hunter (2008), *Elements of Argumentation* |
| `04-probabilites:1109` | `different` | phrase **anglaise** citée (« …describing different systems, and a sequence of observations ») |
| `04-probabilites:1730` | `Iteration` | nom d'algorithme **anglais** : *Value Iteration* |
| `04-probabilites:1752` | `Iteration` | nom d'algorithme **anglais** : *Policy Iteration* |

C'est la relecture humaine qui attrape cette classe, pas l'outil — et c'est la raison pour laquelle l'application est découpée en tranches relisables plutôt que faite d'un bloc sur 18 decks.

Trois autres cas ont été examinés puis **conservés curés**, après lecture du contexte :

- `## Themes` (03:814) et `## Theories` (03:1330) — sections françaises (suivies de « Taxonomie des arguments fallacieux » et « Egalite de fonctions, differences »).
- `alt="Systemes de raisonnement diagrammes"` et `alt="SIPE-2 decomposition hierarchique"` — le texte alternatif est de la prose, lue par les lecteurs d'écran ; le laisser curable est une décision explicite de #11548.
- Les identifiants CamelCase sont intacts par construction, vérifié : `ExecutionModel`, `SelectionModel`, `VolumeWeightedAveragePrice`, `InverseVolatility-Rank` — le cœur matche sur frontière de mot, donc `execution` en prose est curé sans que `ExecutionModel` ne bouge.

## Ce que cette tranche ne fait pas

**Le dictionnaire ne couvre que ~27 % des formes strippées des decks** (161 paires pour 3558 occurrences détectées). Restent non accentués, entre autres : `derivation`, `definition`, `Integrer`, `utilite`, `esperee`, `rationalite`, `Egalite`, `Mathematiques`, `arithmetiques`, `Interpretation`, `evalue`, `Decomposition`, `Implementation`. Les curer demande une **extension du dictionnaire**, qui est un grain distinct et nettement plus risqué (chaque paire ajoutée doit être non ambiguë).

Deux trouvailles à traiter ailleurs, signalées plutôt que corrigées ici :

1. **`Infrence`** (03-logique:588 et :1015) n'est pas une forme strippée mais une **faute de frappe** (« Inférence » amputée). Le dictionnaire d'accents ne peut pas la voir. → grain orthographe.
2. **L'incohérence CRLF/LF des decks** est réelle (02 en CRLF, 01 en LF, `.gitattributes` muet sur `slides/**`). La corriger ici mélangerait une renormalisation à une cure d'accents. → grain séparé.

## Suite

Tranches 2 (`05`–`08`) et 3 (`S1`, `S2`, `S3`, `S4-*`, `S6`, `S7`, `S8`) sur le même protocole : application, énumération des formes distinctes, relecture, restauration des collisions anglaises. Les exceptions déjà repérées pour ces tranches — `Model selection`, `Variations on a theme`, l'expansion ASPIC, le titre de Boole, « Role of GenAI in Creating Alpha », et le nom de notebook `QC-Py-14-Portfolio-Construction-Execution` — sont notées.

See #11508
