### PR TITLE
feat(genai,#11483): AI-Engine grain 7 — /ai/json, la case json de la matrice et le null silencieux

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -187,6 +187,19 @@ aucun jeton (design anti-cache), l'amorçage passe par `start_session`
 `chats/submit` au header `X-WP-Nonce` — frontière 401 mesurée sans le
 nonce, et la nuance : un nonce est un anti-CSRF, pas une
 authentification.
+[`obtenir-des-donnees-structurees-par-l-api.ipynb`](obtenir-des-donnees-structurees-par-l-api.ipynb)
+ferme la dernière veine « non prouvée » : la route `/ai/json`. L'appel
+à froid échoue sur `The environment is required.` — la route ignore
+structurellement `envId`/`model` et lit la **case json de la matrice
+d'usages**, vide sur une instance custom-only où le repli interne
+`gpt-5-mini` sans environnement ne peut jamais passer la validation.
+Le notebook reproduit l'erreur, remplit la case par read-modify-write
+du bloc complet, obtient du JSON réellement exploitable (catalogue
+Valmont structuré), puis mesure honnêtement la promesse : le **null
+silencieux** du parser PHP (observable ou neutralisé ?) et la nature
+de la contrainte de format — prompt seul ou `response_format` au
+niveau fil, départagée par comparaison directe avec le moteur.
+État initial restauré à l'identique.
 
 ---
 

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/.env.example
@@ -31,3 +31,10 @@ VALMONT_LLM_MODEL_NAME=Qwen 3.6 35B A3B
 # --- Authentification API pour les notebooks ------------------------------
 # Application password cree a l'etape 5 du README (wp user application-password create)
 VALMONT_APP_PASSWORD=
+
+# --- Comparaison directe moteur (notebook donnees structurees, OPTIONNEL) ---
+# Le meme moteur, vu depuis la machine hote (le .env ci-dessus donne
+# l adresse vue depuis le container). Sert a la mesure avec/sans
+# response_format, hors plugin. Laisser vide pour sauter la comparaison.
+VALMONT_LLM_BASE_URL_MOTEUR=http://127.0.0.1:11434/v1
+VALMONT_LLM_API_KEY_MOTEUR=sk-local

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -272,6 +272,22 @@ champ de configuration de premier niveau.
 > la démonstration est sécurisée par instantané complet en mémoire,
 > puis restauration à l'identique.
 
+> **Notebook compagnon (série « par son API »).**
+> [`obtenir-des-donnees-structurees-par-l-api.ipynb`](obtenir-des-donnees-structurees-par-l-api.ipynb)
+> écrit enfin la case que le précédent ne faisait que lire : la route
+> `/ai/json` ignore structurellement `envId`/`model` et hérite
+> toujours de la case **json** de la matrice — vide par défaut, et
+> sans issue sur une instance custom-only (le repli `gpt-5-mini` sans
+> environnement ne passe jamais la validation : *The environment is
+> required.*). Remplie par read-modify-write du bloc complet, la
+> route rend du JSON directement exploitable — et le notebook mesure
+> ce que vaut la promesse : le **null silencieux** du parser (une
+> réponse non-JSON rend `success: true, data: null` sans un mot)
+> reste réel dans le code mais neutralisé ici, car pour un
+> environnement custom la contrainte descend au **niveau fil**
+> (`response_format`), départagé par comparaison directe avec le
+> moteur — avec et sans. État initial restauré à l'identique.
+
 ---
 
 ## Parcours 3 — WordPress comme serveur MCP métier

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/obtenir-des-donnees-structurees-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/obtenir-des-donnees-structurees-par-l-api.ipynb
@@ -1,0 +1,1247 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "37d2f5eb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002711,
+     "end_time": "2026-08-17T23:14:31.980197",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:31.977486",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# Obtenir des données structurées — la case json, le fallback sans env et le null silencieux\n",
+    "\n",
+    "Septième notebook de la série « AI Engine par son API ». Les notebooks\n",
+    "précédents ont fait parler le chatbot, administré les formulaires,\n",
+    "ouvert WordPress comme serveur MCP et piloté la régie des\n",
+    "environnements. Restait une veine « non prouvée » depuis le premier\n",
+    "grain : la route `/ai/json`, promise pour obtenir des **données\n",
+    "structurées** — un JSON directement exploitable par le code appelant,\n",
+    "pas une phrase à re-parser.\n",
+    "\n",
+    "Le premier sondage s'était heurté à une erreur opaque : `The\n",
+    "environment is required.` Ce notebook part de cette erreur, la\n",
+    "**reproduit**, l'explique par ce que dit la matrice d'usages, puis la\n",
+    "répare proprement — remplir la case `json` de la matrice par\n",
+    "l'API — avant de mesurer honnêtement ce que la route rend réellement :\n",
+    "JSON valide ou `null` silencieux, contrainte portée par le prompt ou\n",
+    "par le protocole.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6b30123",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002098,
+     "end_time": "2026-08-17T23:14:31.984633",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:31.982535",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## La série « AI Engine par son API »\n",
+    "\n",
+    "Le projet Livres Agites a mis AI Engine au coeur d'une maison d'édition :\n",
+    "bot d'accueil, agents d'ateliers, bibliothécaire documentée par RAG,\n",
+    "formulaires dynamiques. Cette série présente le plugin de manière\n",
+    "reproductible — **sans jamais exposer de données client** :\n",
+    "\n",
+    "| Notebook | Contenu |\n",
+    "|----------|---------|\n",
+    "| `presenter-ai-engine-par-son-api` | instance, API, catalogue des chatbots, première completion |\n",
+    "| `configurer-chatbots-par-l-api` | lire, dupliquer, écrire et interroger des chatbots (document JSON global) |\n",
+    "| `administrer-les-formulaires-par-l-api` | CRUD unitaire des formulaires (contenus WordPress), rendu public |\n",
+    "| `piloter-wordpress-par-mcp` | WordPress comme **serveur** MCP : handshake, catalogue, tools/call |\n",
+    "| `brancher-plusieurs-providers-par-l-api` | environnements, matrice d'usages, piège du settings/update |\n",
+    "| `parler-au-chatbot-en-visiteur` | face navigateur : start_session, nonce, anti-CSRF vs authentification |\n",
+    "| `obtenir-des-donnees-structurees` | **ce notebook** : `/ai/json`, la case json, le null silencieux |\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e1f94d65",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:31.989942Z",
+     "iopub.status.busy": "2026-08-17T23:14:31.989734Z",
+     "iopub.status.idle": "2026-08-17T23:14:32.070876Z",
+     "shell.execute_reply": "2026-08-17T23:14:32.070333Z"
+    },
+    "papermill": {
+     "duration": 0.085173,
+     "end_time": "2026-08-17T23:14:32.071878",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:31.986705",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
+      "Base URL : http://localhost:8093\n",
+      "Helpers prets.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et helpers. Aucune cle ni adresse de provider n'est stockee\n",
+    "# dans ce fichier : tout vient de instance-jetable/.env (README, etape 5).\n",
+    "\n",
+    "import base64\n",
+    "import copy\n",
+    "import json\n",
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "# Localisation du .env : a cote du notebook (instance-jetable/.env),\n",
+    "# sinon dans le repertoire courant.\n",
+    "charges = []\n",
+    "for candidat in (Path(\"instance-jetable/.env\"), Path(\".env\")):\n",
+    "    if candidat.exists():\n",
+    "        load_dotenv(candidat)\n",
+    "        charges.append(str(candidat))\n",
+    "print(\"Fichiers .env charges :\", charges or \"(aucun)\")\n",
+    "\n",
+    "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
+    "ADMIN_USER = os.getenv(\"VALMONT_ADMIN_USER\", \"\")\n",
+    "APP_PASSWORD = os.getenv(\"VALMONT_APP_PASSWORD\", \"\")\n",
+    "print(\"Base URL :\", BASE_URL)\n",
+    "\n",
+    "creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
+    "ENTETES = {\"Authorization\": \"Basic \" + creds, \"Content-Type\": \"application/json\"}\n",
+    "\n",
+    "\n",
+    "def api(route, method=\"GET\", payload=None, attendu=None):\n",
+    "    \"\"\"Appel a l'API REST d'administration de AI Engine (mwai/v1).\n",
+    "\n",
+    "    `attendu` : si fourni, n'appelle pas raise_for_status — on veut lire\n",
+    "    le corps d'erreur mesure (ex. HTTP 500), pas le transformer en exception.\n",
+    "    \"\"\"\n",
+    "    r = requests.request(method, BASE_URL + \"/wp-json\" + route,\n",
+    "                         headers=ENTETES, json=payload, timeout=180)\n",
+    "    if attendu is None:\n",
+    "        r.raise_for_status()\n",
+    "    return r\n",
+    "\n",
+    "\n",
+    "def modeles_de(env):\n",
+    "    \"\"\"Les identifiants de modeles declares dans un environnement.\"\"\"\n",
+    "    return [m[\"model\"] if isinstance(m, dict) else m for m in env.get(\"models\", [])]\n",
+    "\n",
+    "\n",
+    "USAGES = [\n",
+    "    (\"chat\",       \"ai_default\"),\n",
+    "    (\"fast\",       \"ai_fast_default\"),\n",
+    "    (\"vision\",     \"ai_vision_default\"),\n",
+    "    (\"images\",     \"ai_images_default\"),\n",
+    "    (\"audio\",      \"ai_audio_default\"),\n",
+    "    (\"json\",       \"ai_json_default\"),\n",
+    "    (\"embeddings\", \"ai_embeddings_default\"),\n",
+    "]\n",
+    "print(\"Helpers prets.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c14b841",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002387,
+     "end_time": "2026-08-17T23:14:32.076881",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.074494",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. L'appel à froid — l'erreur qui avait bloqué le premier sondage\n",
+    "\n",
+    "La route `/ai/json` du namespace `mwai/v1` promet une réponse\n",
+    "structurée. Le raisonnement naïf : comme pour `/ai/completion`, on\n",
+    "devait pouvoir passer `envId` et `model` dans la requête pour choisir\n",
+    "le moteur. Le premier sondage de la série l'avait essayé — et obtenu\n",
+    "une erreur qui n'évoque ni le modèle ni le serveur : *The environment\n",
+    "is required.* Reproduisons-la à froid, sans aucun paramètre de\n",
+    "moteur.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "622eedc5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:32.082957Z",
+     "iopub.status.busy": "2026-08-17T23:14:32.082651Z",
+     "iopub.status.idle": "2026-08-17T23:14:32.132215Z",
+     "shell.execute_reply": "2026-08-17T23:14:32.131663Z"
+    },
+    "papermill": {
+     "duration": 0.054015,
+     "end_time": "2026-08-17T23:14:32.133077",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.079062",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "HTTP 500\n",
+      "{\n",
+      "  \"success\": false,\n",
+      "  \"message\": \"The environment is required.\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 1. Appel a froid : message seul, aucune configuration de moteur.\n",
+    "reponse_froide = api(\"/mwai/v1/ai/json\", method=\"POST\",\n",
+    "                     payload={\"message\": \"Liste les ouvrages du catalogue en JSON.\"},\n",
+    "                     attendu=500)\n",
+    "print(\"HTTP\", reponse_froide.status_code)\n",
+    "try:\n",
+    "    corps = reponse_froide.json()\n",
+    "except ValueError:\n",
+    "    corps = {\"(brut)\": reponse_froide.text[:200]}\n",
+    "print(json.dumps(corps, indent=2, ensure_ascii=False))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c8448563",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002318,
+     "end_time": "2026-08-17T23:14:32.137991",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.135673",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Ce que dit l'erreur\n",
+    "\n",
+    "Le message renvoie à un **environnement** — pas au message, pas au\n",
+    "modèle. La lecture du code du plugin (`rest.php`, fonction\n",
+    "`rest_ai_json`) explique ce qui s'est passé : la route ne transmet que\n",
+    "`params['message']` au moteur de requête JSON. Les paramètres\n",
+    "`envId` / `model` éventuels sont **ignorés structurellement** : on ne\n",
+    "peut pas choisir le moteur au niveau de la requête. La requête JSON\n",
+    "hérite donc toujours de la **case `json` de la matrice d'usages** —\n",
+    "et si cette case est vide, l'appel échoue avant d'avoir touché le\n",
+    "moteur. Voyons cette matrice.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b5e2066d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002129,
+     "end_time": "2026-08-17T23:14:32.142235",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.140106",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. La matrice d'usages — la case json est vide\n",
+    "\n",
+    "Le cinquième notebook (`brancher-plusieurs-providers`) a introduit la\n",
+    "matrice d'usages : pour chaque usage (chat, vision, images, **json**,\n",
+    "embeddings...), un couple `ai_<usage>_default_env` /\n",
+    "`ai_<usage>_default_model` désigne le moteur à utiliser. Il l'avait\n",
+    "**lue** — jamais écrite. Relisons-la : l'instance jetable Maison\n",
+    "Valmont n'a qu'un environnement, `llm-local` (le moteur\n",
+    "auto-hébergé), affecté à l'usage chat.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2fde72b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:32.147453Z",
+     "iopub.status.busy": "2026-08-17T23:14:32.147153Z",
+     "iopub.status.idle": "2026-08-17T23:14:32.191920Z",
+     "shell.execute_reply": "2026-08-17T23:14:32.191489Z"
+    },
+    "papermill": {
+     "duration": 0.048444,
+     "end_time": "2026-08-17T23:14:32.192751",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.144307",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Environnements de modeles (ai_envs) :\n",
+      "  llm-local      [custom ] LLM local (OpenAI-compatible) : ['qwen3:8b']\n",
+      "\n",
+      "usage        environnement    modele\n",
+      "chat         llm-local        qwen3:8b\n",
+      "fast         (defaut plugin)  gpt-5-mini\n",
+      "vision       (defaut plugin)  gpt-5-mini\n",
+      "images       (defaut plugin)  gpt-image-2\n",
+      "audio        (defaut plugin)  whisper-1\n",
+      "json         (defaut plugin)  gpt-5-mini\n",
+      "embeddings   (defaut plugin)  text-embedding-3-small\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 2. Lire la matrice d'usages.\n",
+    "options = api(\"/mwai/v1/settings/options\").json()[\"options\"]\n",
+    "\n",
+    "envs = options.get(\"ai_envs\", [])\n",
+    "print(\"Environnements de modeles (ai_envs) :\")\n",
+    "for e in envs:\n",
+    "    print(f\"  {e['id']:14s} [{e.get('type'):7s}] {e.get('name')} : {modeles_de(e) or '(aucun modele declare)'}\")\n",
+    "\n",
+    "print()\n",
+    "print(f\"{'usage':12s} {'environnement':16s} modele\")\n",
+    "for nom, prefixe in USAGES:\n",
+    "    env = options.get(prefixe + \"_env\") or \"(defaut plugin)\"\n",
+    "    model = options.get(prefixe + \"_model\") or \"-\"\n",
+    "    print(f\"{nom:12s} {env:16s} {model}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60da07a6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002419,
+     "end_time": "2026-08-17T23:14:32.197827",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.195408",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### La case json : vide, avec un résidu de repli\n",
+    "\n",
+    "La colonne `json` affiche l'environnement `(defaut plugin)` — la case\n",
+    "est **vide**. Mais son modèle affiche `gpt-5-mini` : ce n'est pas un\n",
+    "branchement, c'est la **valeur de repli interne** du plugin\n",
+    "(`MWAI_FALLBACK_MODEL_JSON`). Le piège complet se lit maintenant :\n",
+    "\n",
+    "1. la case `json` n'a pas d'environnement ;\n",
+    "2. le plugin retombe sur son modèle de repli `gpt-5-mini` — **sans\n",
+    "   environnement** ;\n",
+    "3. la validation d'une requête exige que le modèle existe **dans un\n",
+    "   environnement déclaré** (ici, seul `llm-local` existe, et il ne\n",
+    "   sert que l'usage chat) ;\n",
+    "4. sur une instance custom-only comme la nôtre, ce repli **ne peut\n",
+    "   jamais passer** — d'où l'erreur à froid, inévitable.\n",
+    "\n",
+    "La seule issue : remplir la case `json` de la matrice. C'est une\n",
+    "écriture — et le cinquième notebook a montré que le seul style\n",
+    "d'écriture sûr ici est le **read-modify-write du bloc complet**.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8d3242d",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004159,
+     "end_time": "2026-08-17T23:14:32.204186",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.200027",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — lire toute la matrice en une structure\n",
+    "\n",
+    "La boucle d'affichage ci-dessus traite les usages un par un. Écrivez\n",
+    "`matrice()` qui retourne la matrice **entière** sous forme de dictionnaire\n",
+    "`{usage: {\"env\": ..., \"model\": ...}}`, avec `env` et `model` à `None`\n",
+    "quand la case est vide (pas la valeur de repli — la valeur **réelle** de\n",
+    "la matrice).\n",
+    "\n",
+    "*Indice : `api(\"/mwai/v1/settings/options\").json()[\"options\"]`, puis la\n",
+    "liste `USAGES` déjà définie. Attention : `options.get(...)` renvoie\n",
+    "`None` pour une clé absente — c'est exactement le marqueur « case vide ».*\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "554a6716",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:32.209453Z",
+     "iopub.status.busy": "2026-08-17T23:14:32.209243Z",
+     "iopub.status.idle": "2026-08-17T23:14:32.212763Z",
+     "shell.execute_reply": "2026-08-17T23:14:32.212234Z"
+    },
+    "papermill": {
+     "duration": 0.007154,
+     "end_time": "2026-08-17T23:14:32.213513",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.206359",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Case chat : None\n",
+      "Case json : None\n"
+     ]
+    }
+   ],
+   "source": [
+    "def matrice():\n",
+    "    \"\"\"Retourne la matrice {usage: {\"env\": ..., \"model\": ...}}.\n",
+    "\n",
+    "    env/model valent None quand la case est vide (pas de repli plugin).\n",
+    "    \"\"\"\n",
+    "    # A COMPLETER : lire settings/options, construire le dictionnaire\n",
+    "    # a partir de la liste USAGES.\n",
+    "    return {}\n",
+    "\n",
+    "\n",
+    "m = matrice()\n",
+    "print(\"Case chat :\", m.get(\"chat\"))\n",
+    "print(\"Case json :\", m.get(\"json\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2984f8c7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002689,
+     "end_time": "2026-08-17T23:14:32.218590",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.215901",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Remplir la case — read-modify-write du bloc complet\n",
+    "\n",
+    "`settings/update` **ne met pas à jour, il remplace** : la leçon\n",
+    "mesurée du cinquième notebook. On ne pousse donc jamais une seule clé\n",
+    "— on relit le bloc `options` **complet**, on modifie **une copie** en\n",
+    "mémoire, on renvoie tout. L'instantané d'origine est conservé : il\n",
+    "servira à la restauration finale (section 6).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "81fca106",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:32.226584Z",
+     "iopub.status.busy": "2026-08-17T23:14:32.226246Z",
+     "iopub.status.idle": "2026-08-17T23:14:32.380311Z",
+     "shell.execute_reply": "2026-08-17T23:14:32.379606Z"
+    },
+    "papermill": {
+     "duration": 0.158717,
+     "end_time": "2026-08-17T23:14:32.381210",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.222493",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Instantane :  105 cles | case json : None 'gpt-5-mini'\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "update           : True | OK\n",
+      "case json apres  : 'llm-local' 'qwen3:8b'\n",
+      "case chat intacte: 'llm-local' 'qwen3:8b'\n",
+      "nb de cles       : 105 -> 105\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 3. Instantane -> modifier la case json -> renvoyer le bloc COMPLET.\n",
+    "instantane = api(\"/mwai/v1/settings/options\").json()[\"options\"]\n",
+    "print(\"Instantane : \", len(instantane), \"cles | case json :\",\n",
+    "      repr(instantane.get(\"ai_json_default_env\")),\n",
+    "      repr(instantane.get(\"ai_json_default_model\")))\n",
+    "\n",
+    "# Le moteur de l'instance, deja branche sur l'usage chat.\n",
+    "ENV = instantane[\"ai_default_env\"]\n",
+    "MODEL = instantane[\"ai_default_model\"]\n",
+    "\n",
+    "nouveau = copy.deepcopy(instantane)\n",
+    "nouveau[\"ai_json_default_env\"] = ENV\n",
+    "nouveau[\"ai_json_default_model\"] = MODEL\n",
+    "\n",
+    "rep = api(\"/mwai/v1/settings/update\", method=\"POST\", payload={\"options\": nouveau}).json()\n",
+    "verif = api(\"/mwai/v1/settings/options\").json()[\"options\"]\n",
+    "print()\n",
+    "print(\"update           :\", rep.get(\"success\"), \"|\", rep.get(\"message\"))\n",
+    "print(\"case json apres  :\", repr(verif.get(\"ai_json_default_env\")),\n",
+    "      repr(verif.get(\"ai_json_default_model\")))\n",
+    "print(\"case chat intacte:\", repr(verif.get(\"ai_default_env\")),\n",
+    "      repr(verif.get(\"ai_default_model\")))\n",
+    "print(\"nb de cles       :\", len(instantane), \"->\", len(verif))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5c4bd96",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002473,
+     "end_time": "2026-08-17T23:14:32.387191",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.384718",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### La case est remplie — sans dégât collatéral\n",
+    "\n",
+    "Le bloc complet est reparti tel quel, à deux clés près : la case\n",
+    "`json` pointe maintenant sur `llm-local` / le modèle local, la case\n",
+    "`chat` n'a pas bougé, et le compte de clés est stable (la signature du\n",
+    "« remplacement propre » — le piège du cinquième notebook montrait un\n",
+    "compte qui s'effondre). La route `/ai/json` a maintenant tout ce qu'il\n",
+    "lui faut. Reste à savoir ce qu'elle rend.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f6c765a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002768,
+     "end_time": "2026-08-17T23:14:32.393277",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.390509",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. La requête réelle — structurer le catalogue Valmont\n",
+    "\n",
+    "L'objectif de la veine : obtenir du **JSON exploitable**, pas une\n",
+    "phrase. La Maison Valmont n'a pas de catalogue en base pour le moteur\n",
+    "(rien dans cette requête ne fait de RAG) — le notebook fournit donc le\n",
+    "matériau dans le message : un extrait de catalogue synthétique, à\n",
+    "restructurer. C'est le cas d'usage canonique de `/ai/json` : la\n",
+    "machine **extrait et structure**, le code appelant consomme.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b928d41f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:32.400012Z",
+     "iopub.status.busy": "2026-08-17T23:14:32.399724Z",
+     "iopub.status.idle": "2026-08-17T23:14:38.707311Z",
+     "shell.execute_reply": "2026-08-17T23:14:38.706324Z"
+    },
+    "papermill": {
+     "duration": 6.312174,
+     "end_time": "2026-08-17T23:14:38.708307",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:32.396133",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "success : True\n",
+      "data    : {\n",
+      "  \"ouvrages\": [\n",
+      "    {\n",
+      "      \"titre\": \"Le Jardin des Vents\",\n",
+      "      \"auteur\": \"Marion Estève\",\n",
+      "      \"genre\": \"roman\",\n",
+      "      \"pages\": 312,\n",
+      "      \"recommendation\": \"reco a l'unanimite\",\n",
+      "      \"lecteurs\": 4\n",
+      "    },\n",
+      "    {\n",
+      "      \"titre\": \"Politique du Sommeil\",\n",
+      "      \"auteur\": \"A. Karabatic\",\n",
+      "      \"genre\": \"essai\",\n",
+      "      \"pages\": 208,\n",
+      "      \"recommendation\": \"reserve\",\n",
+      "      \"lecteurs\": 2\n",
+      "    },\n",
+      "    {\n",
+      "      \"titre\": \"La Cendre des Cartographes\",\n",
+      "      \"auteur\": \"Livia Sorel\",\n",
+      "      \"genre\": \"polar\",\n",
+      "      \"pages\": 440,\n",
+      "      \"recommendation\": \"reco majoritaire\",\n",
+      "      \"lecteurs\": 3\n",
+      "    }\n",
+      "  ]\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4. Extraits bruts du catalogue (fixture synthetique, fournie dans le message).\n",
+    "catalogue_brut = \"\"\"\n",
+    "Retours de la comite de lecture, semaine 24 :\n",
+    "1) \"Le Jardin des Vents\" de Marion Estève, roman, 312 p., reco a l'unanimite, lecteurs: 4\n",
+    "2) essai \"Politique du Sommeil\" d'A. Karabatic, 208 p., reserve, lecteurs: 2\n",
+    "3) \"La Cendre des Cartographes\" (polar) de Livia Sorel, 440 p., reco majoritaire, lecteurs: 3\n",
+    "\"\"\"\n",
+    "\n",
+    "message = (\n",
+    "    \"Voici des extraits des retours de la comite de lecture de la Maison Valmont.\\n\"\n",
+    "    + catalogue_brut\n",
+    "    + \"\\nRetourne un tableau JSON : un objet par ouvrage avec les cles \"\n",
+    "    \"titre, auteur, genre, pages (nombre), recommendation, lecteurs (nombre).\"\n",
+    ")\n",
+    "\n",
+    "rep_json = api(\"/mwai/v1/ai/json\", method=\"POST\",\n",
+    "               payload={\"message\": message}, attendu=None).json()\n",
+    "print(\"success :\", rep_json.get(\"success\"))\n",
+    "if rep_json.get(\"success\"):\n",
+    "    print(\"data    :\", json.dumps(rep_json.get(\"data\"), indent=2, ensure_ascii=False)[:800])\n",
+    "else:\n",
+    "    print(\"message :\", rep_json.get(\"message\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6732f79",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002356,
+     "end_time": "2026-08-17T23:14:38.713808",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:38.711452",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Ce que la route a rendu\n",
+    "\n",
+    "La réponse arrive en HTTP 200, `success: true`, et surtout `data`\n",
+    "est déjà un **objet** — pas une chaîne à re-parser : AI Engine a\n",
+    "décodé le JSON côté serveur. La structure rendue est fidèle au\n",
+    "matériau (titre, auteur, genre, pages en nombre, recommandation,\n",
+    "lecteurs en nombre), avec une liberté que le code appelant doit\n",
+    "connaître : le message demandait « un tableau JSON », le moteur a\n",
+    "rendu **un objet contenant le tableau** (`{\"ouvrages\": [...]}`). La\n",
+    "contrainte « JSON valide » est tenue ; le **schéma** exact, lui, ne\n",
+    "l'est pas — un consommateur robuste cherche le tableau dans la\n",
+    "réponse au lieu d'exiger qu'elle *soit* le tableau.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "936b4a30",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003061,
+     "end_time": "2026-08-17T23:14:38.719199",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:38.716138",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Mesures d'honnêteté\n",
+    "\n",
+    "Une route qui promet du JSON mérite mieux qu'un exemple qui marche.\n",
+    "Trois mesures : (a) la donnée rendue est-elle du JSON **valide** ?\n",
+    "(b) le **null silencieux** — le code du plugin parse la réponse du\n",
+    "moteur avec `json_decode` sous `try/catch`, mais `json_decode` ne\n",
+    "lève jamais d'exception en PHP : une réponse non-JSON rend\n",
+    "`success: true, data: null` — est-ce **observable** ? (c) la\n",
+    "contrainte de format est-elle portée par le **prompt** seul, ou\n",
+    "descend-elle au **niveau fil** (`response_format` du protocole\n",
+    "OpenAI-compatible) ?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9bc9bbef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:38.725486Z",
+     "iopub.status.busy": "2026-08-17T23:14:38.725024Z",
+     "iopub.status.idle": "2026-08-17T23:14:49.252435Z",
+     "shell.execute_reply": "2026-08-17T23:14:49.251744Z"
+    },
+    "papermill": {
+     "duration": 10.531934,
+     "end_time": "2026-08-17T23:14:49.253672",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:38.721738",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cles de la reponse : ['data', 'success']\n",
+      "success : True | data : dict\n",
+      "data serialisable en JSON : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5a. Le retour du moteur : JSON valide, et data == null ?\n",
+    "# La reponse complete contient la sortie brute du moteur dans 'data'\n",
+    "# quand le parsing a reussi. Rejouons l'appel en gardant la reponse brute.\n",
+    "rep_brute = api(\"/mwai/v1/ai/json\", method=\"POST\",\n",
+    "                payload={\"message\": message}, attendu=None).json()\n",
+    "\n",
+    "cles = sorted(rep_brute.keys())\n",
+    "print(\"Cles de la reponse :\", cles)\n",
+    "print(\"success :\", rep_brute.get(\"success\"), \"| data :\", type(rep_brute.get(\"data\")).__name__)\n",
+    "if rep_brute.get(\"data\") is not None:\n",
+    "    valide = True\n",
+    "    try:\n",
+    "        json.dumps(rep_brute[\"data\"])  # data est deja un objet PHP->JSON\n",
+    "    except (TypeError, ValueError):\n",
+    "        valide = False\n",
+    "    print(\"data serialisable en JSON :\", valide)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ae681f17",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:49.260696Z",
+     "iopub.status.busy": "2026-08-17T23:14:49.260478Z",
+     "iopub.status.idle": "2026-08-17T23:14:55.592205Z",
+     "shell.execute_reply": "2026-08-17T23:14:55.591556Z"
+    },
+    "papermill": {
+     "duration": 6.336285,
+     "end_time": "2026-08-17T23:14:55.593281",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:49.256996",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "consigne anti-JSON -> success: True | data: dict | message: None\n",
+      "  -> data rendu quand meme : {\"réponse\": \"Je suis un modèle de langage développé par Alibaba Cloud, conçu pour aider les utilisateurs à obtenir des informations et à accomplir diverses tâches.\"}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "consigne anti-JSON -> success: True | data: dict | message: None\n",
+      "  -> data rendu quand meme : {\"greeting\": \"bonjour\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5b. Le null silencieux : forcer une reponse non-JSON.\n",
+    "# Meme moteur, meme case json, mais une consigne ANTI-JSON : le moteur doit\n",
+    "# produire du texte libre. Si le parsing echoue, success reste-t-il true\n",
+    "# avec data null ?\n",
+    "messages_anti_json = [\n",
+    "    \"Réponds uniquement par une phrase, sans JSON, sans accolades : qui es-tu ?\",\n",
+    "    \"Réponds juste le mot: bonjour. Aucun JSON.\",\n",
+    "]\n",
+    "\n",
+    "for msg in messages_anti_json:\n",
+    "    r = api(\"/mwai/v1/ai/json\", method=\"POST\",\n",
+    "            payload={\"message\": msg}, attendu=None).json()\n",
+    "    print(f\"consigne anti-JSON -> success: {r.get('success')} | \"\n",
+    "          f\"data: {type(r.get('data')).__name__} | message: {r.get('message')}\")\n",
+    "    if r.get(\"data\") is None:\n",
+    "        print(\"  -> null silencieux OBSERVE : success true, data null, aucun message d'erreur\")\n",
+    "    else:\n",
+    "        print(\"  -> data rendu quand meme :\", json.dumps(r[\"data\"], ensure_ascii=False)[:200])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "668dd950",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00235,
+     "end_time": "2026-08-17T23:14:55.599317",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:55.596967",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Le null silencieux : mesuré — et c'est une information\n",
+    "\n",
+    "Résultat de la mesure : la consigne anti-JSON **produit quand même\n",
+    "du JSON**. Le moteur a enveloppé sa phrase dans un objet — la\n",
+    "réponse est parsable, `data` est non nul, aucun message d'erreur. Le\n",
+    "`null` silencieux n'est donc **pas observable** sur cette\n",
+    "configuration, et la raison est instructive : le piège du code\n",
+    "(`json_decode` sous `try/catch` qui n'attrapera jamais rien)\n",
+    "existe toujours, mais il ne peut pas se déclencher tant que le\n",
+    "format est garanti **en aval** de la sortie du moteur. Le jour où la\n",
+    "case `json` pointe un moteur qui **ignore** `response_format`\n",
+    "(vieux llama.cpp, passerelle partielle), la réponse redeviendra du\n",
+    "texte libre — et le plugin rendra `success: true, data: null` sans\n",
+    "un mot. Le piège est réel ; il est simplement neutralisé ici par\n",
+    "l'étage du dessous.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "827e7804",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:14:55.606930Z",
+     "iopub.status.busy": "2026-08-17T23:14:55.606674Z",
+     "iopub.status.idle": "2026-08-17T23:15:07.240538Z",
+     "shell.execute_reply": "2026-08-17T23:15:07.239237Z"
+    },
+    "papermill": {
+     "duration": 11.64068,
+     "end_time": "2026-08-17T23:15:07.242263",
+     "exception": false,
+     "start_time": "2026-08-17T23:14:55.601583",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sans response_format   : bonjour\n",
+      "avec response_format   : {\"response\": \"bonjour\"}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 5c. Prompt-only ou wire-level ? Comparaison au moteur, hors plugin.\n",
+    "# AI Engine ajoute au message un suffixe d'instruction JSON et, pour un\n",
+    "# environnement custom (OpenAI-compatible), envoie response_format au\n",
+    "# niveau fil. On ne peut pas lire le fil depuis l'API WordPress -- mais on\n",
+    "# peut comparer le meme moteur directement : avec et sans response_format.\n",
+    "base_moteur = os.getenv(\"VALMONT_LLM_BASE_URL_MOTEUR\")  # optionnel, .env\n",
+    "\n",
+    "direct = None\n",
+    "if base_moteur:\n",
+    "    H = {\"Authorization\": \"Bearer \" + os.getenv(\"VALMONT_LLM_API_KEY_MOTEUR\", \"sk-local\"),\n",
+    "         \"Content-Type\": \"application/json\"}\n",
+    "    corps = {\"model\": MODEL, \"messages\": [{\"role\": \"user\", \"content\": \"Réponds juste le mot: bonjour\"}], \"max_tokens\": 1000}\n",
+    "    import re as _re\n",
+    "\n",
+    "    def _contenu(rep):\n",
+    "        # qwen3 peut emettre une trace de raisonnement avant la reponse :\n",
+    "        # le budget de tokens doit couvrir les deux, sinon content arrive vide.\n",
+    "        try:\n",
+    "            ch = rep.json()[\"choices\"][0]\n",
+    "            c = (ch[\"message\"].get(\"content\") or \"\")\n",
+    "            fin = ch.get(\"finish_reason\")\n",
+    "        except Exception:\n",
+    "            return \"(pas de choix)\"\n",
+    "        c = _re.sub(r\"<think>.*?</think>\", \"\", c, flags=_re.S).strip()\n",
+    "        return c[:80] if c else f\"(content vide, finish_reason={fin})\"\n",
+    "\n",
+    "    r1 = requests.post(base_moteur + \"/chat/completions\", headers=H,\n",
+    "                       json={**corps}, timeout=120)\n",
+    "    r2 = requests.post(base_moteur + \"/chat/completions\", headers=H,\n",
+    "                       json={**corps, \"response_format\": {\"type\": \"json_object\"}}, timeout=120)\n",
+    "    print(\"sans response_format   :\", _contenu(r1))\n",
+    "    print(\"avec response_format   :\", _contenu(r2))\n",
+    "    direct = True\n",
+    "else:\n",
+    "    print(\"Comparaison directe moteur non configuree (VALMONT_LLM_BASE_URL_MOTEUR absent du .env).\")\n",
+    "    print(\" -> la discrimination prompt-only / wire-level se lit sur 5b :\")\n",
+    "    print(\"    si la consigne anti-JSON produit quand meme du JSON, le format est\")\n",
+    "    print(\"    impose au niveau fil ; si elle produit du texte libre, il ne l'est pas.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe89cc77",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004971,
+     "end_time": "2026-08-17T23:15:07.252987",
+     "exception": false,
+     "start_time": "2026-08-17T23:15:07.248016",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Verdict : wire-level, confirmé par les deux côtés\n",
+    "\n",
+    "Les deux mesures se rejoignent. Côté moteur, la même consigne\n",
+    "anti-JSON rend `bonjour` (texte libre) sans `response_format` et un\n",
+    "objet JSON avec. Côté plugin, la consigne anti-JSON **à travers**\n",
+    "`/ai/json` rend du JSON — le comportement observé est celui de la\n",
+    "colonne *avec* `response_format`. Conclusion mesurée : pour un\n",
+    "environnement de type `custom` (protocole OpenAI-compatible), la\n",
+    "contrainte de format est bien **descendue au niveau fil** par AI\n",
+    "Engine (le moteur chatml du plugin envoie `response_format` avec la\n",
+    "requête au serveur) — elle ne repose pas que sur le suffixe de\n",
+    "prompt ajouté au message. D'où la conséquence pratique : la\n",
+    "robustesse du « JSON garanti » dépend du **serveur** autant que du\n",
+    "plugin — changer `llm-local` pour une passerelle qui ignore\n",
+    "`response_format` changerait silencieusement la garantie.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2e48af3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005912,
+     "end_time": "2026-08-17T23:15:07.263411",
+     "exception": false,
+     "start_time": "2026-08-17T23:15:07.257499",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — sonder la robustesse du JSON\n",
+    "\n",
+    "Une seule requête ne prouve pas une route robuste. Écrivez\n",
+    "`taux_json(messages)` qui envoie chaque message via `/ai/json` et\n",
+    "retourne le taux de réponses avec `data` non nul, plus la liste des\n",
+    "échecs. Testez-la avec : la consigne de catalogue (doit réussir), une\n",
+    "consigne anti-JSON, et une consigne ambiguë (« parle-moi de la Maison\n",
+    "Valmont »).\n",
+    "\n",
+    "*Indice : réutilisez `api(...)` avec `payload={\"message\": m}` ; comptez\n",
+    "`r.get(\"data\") is not None`. Attention au temps : trois appels à un\n",
+    "modèle local, prévoir `timeout` confortable.*\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "d47abaae",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:15:07.276153Z",
+     "iopub.status.busy": "2026-08-17T23:15:07.275576Z",
+     "iopub.status.idle": "2026-08-17T23:15:07.281512Z",
+     "shell.execute_reply": "2026-08-17T23:15:07.280194Z"
+    },
+    "papermill": {
+     "duration": 0.014016,
+     "end_time": "2026-08-17T23:15:07.283560",
+     "exception": false,
+     "start_time": "2026-08-17T23:15:07.269544",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "taux : 0.0 | details : []\n"
+     ]
+    }
+   ],
+   "source": [
+    "def taux_json(messages):\n",
+    "    \"\"\"Retourne (taux_de_reussite, details) sur une liste de messages.\n",
+    "\n",
+    "    Reussite = data non nul dans la reponse /ai/json.\n",
+    "    \"\"\"\n",
+    "    # A COMPLETER : boucle d'appels, comptage des data non nuls,\n",
+    "    # collecte des (message_tronque, success, data_est_null).\n",
+    "    return 0.0, []\n",
+    "\n",
+    "\n",
+    "taux, details = taux_json([\"Réponds juste le mot: bonjour\"])\n",
+    "print(\"taux :\", taux, \"| details :\", details)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd619cab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003682,
+     "end_time": "2026-08-17T23:15:07.294203",
+     "exception": false,
+     "start_time": "2026-08-17T23:15:07.290521",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Restaurer l'état initial\n",
+    "\n",
+    "La re-exécutabilité à froid est un invariant de la série : un\n",
+    "notebook qui laisse l'instance modifiée fausse le suivant. La case\n",
+    "`json` doit revenir à son état d'origine — vide — par le même\n",
+    "read-modify-write du bloc complet, à partir de l'instantané pris\n",
+    "**avant** toute modification.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "93969ac0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:15:07.301880Z",
+     "iopub.status.busy": "2026-08-17T23:15:07.301442Z",
+     "iopub.status.idle": "2026-08-17T23:15:07.392725Z",
+     "shell.execute_reply": "2026-08-17T23:15:07.392202Z"
+    },
+    "papermill": {
+     "duration": 0.096393,
+     "end_time": "2026-08-17T23:15:07.393798",
+     "exception": false,
+     "start_time": "2026-08-17T23:15:07.297405",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "update de restauration : True\n",
+      "case json finale       : None 'gpt-5-mini'\n",
+      "case chat finale       : 'llm-local' 'qwen3:8b'\n",
+      "nb de cles             : 105 -> 105\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 6. Restauration : renvoyer l'instantane d'origine, bloc complet.\n",
+    "retour = api(\"/mwai/v1/settings/update\", method=\"POST\",\n",
+    "             payload={\"options\": instantane}).json()\n",
+    "final = api(\"/mwai/v1/settings/options\").json()[\"options\"]\n",
+    "\n",
+    "print(\"update de restauration :\", retour.get(\"success\"))\n",
+    "print(\"case json finale       :\", repr(final.get(\"ai_json_default_env\")),\n",
+    "      repr(final.get(\"ai_json_default_model\")))\n",
+    "print(\"case chat finale       :\", repr(final.get(\"ai_default_env\")),\n",
+    "      repr(final.get(\"ai_default_model\")))\n",
+    "print(\"nb de cles             :\", len(instantane), \"->\", len(final))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fb0d4c24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003084,
+     "end_time": "2026-08-17T23:15:07.399523",
+     "exception": false,
+     "start_time": "2026-08-17T23:15:07.396439",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — auditer la restauration\n",
+    "\n",
+    "« Les deux cases affichées sont revenues » ne prouve pas que **tout**\n",
+    "est revenu. Écrivez `audit_restauration(avant, apres)` qui compare\n",
+    "deux instantanés complets et retourne la liste des clés différentes\n",
+    "(ajoutées, supprimées, changées de valeur). Un audit propre rend une\n",
+    "liste **vide** — ou l'explique (le plugin écrit-il des compteurs\n",
+    "d'usage entre-temps ?).\n",
+    "\n",
+    "*Indice : les clés sont l'union des deux dictionnaires ; comparez\n",
+    "`avant.get(k)` et `apres.get(k)`. Pour les valeurs imbriquées, une\n",
+    "comparaison par `json.dumps(..., sort_keys=True)` suffit à détecter\n",
+    "un écart.*\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "307f4a80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:15:07.408704Z",
+     "iopub.status.busy": "2026-08-17T23:15:07.408175Z",
+     "iopub.status.idle": "2026-08-17T23:15:07.413988Z",
+     "shell.execute_reply": "2026-08-17T23:15:07.413141Z"
+    },
+    "papermill": {
+     "duration": 0.012349,
+     "end_time": "2026-08-17T23:15:07.415174",
+     "exception": false,
+     "start_time": "2026-08-17T23:15:07.402825",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ecarts : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def audit_restauration(avant, apres):\n",
+    "    \"\"\"Liste des differences (cle, avant, apres) entre deux instantanes.\"\"\"\n",
+    "    # A COMPLETER : union des cles, comparaison des valeurs,\n",
+    "    # retour [(cle, valeur_avant, valeur_apres), ...].\n",
+    "    return []\n",
+    "\n",
+    "\n",
+    "ecarts = audit_restauration(instantane, final)\n",
+    "print(\"ecarts :\", len(ecarts))\n",
+    "for k, va, vp in ecarts[:10]:\n",
+    "    print(f\"  {k}: {str(va)[:50]} -> {str(vp)[:50]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25b32a58",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00288,
+     "end_time": "2026-08-17T23:15:07.420977",
+     "exception": false,
+     "start_time": "2026-08-17T23:15:07.418097",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Ce notebook a fermé la dernière veine « non prouvée » de la série —\n",
+    "et le voyage valait le détour :\n",
+    "\n",
+    "- **l'erreur d'origine était structurelle** : `/ai/json` n'accepte pas\n",
+    "  de moteur dans la requête, il lit la case `json` de la matrice\n",
+    "  d'usages — vide sur une instance custom-only, où le repli\n",
+    "  `gpt-5-mini` sans environnement ne peut jamais passer la validation ;\n",
+    "- **la réparation est une écriture de matrice** : read-modify-write du\n",
+    "  bloc complet, le seul style d'écriture sûr avec `settings/update` ;\n",
+    "- **la promesse « JSON » se mesure** : validité du retour,\n",
+    "  observabilité du `null` silencieux, nature de la contrainte de\n",
+    "  format — chaque mesure est reproductible sur l'instance jetable ;\n",
+    "- **l'état initial est restauré** — la série reste exécutable à froid.\n",
+    "\n",
+    "**Voir aussi** : `brancher-plusieurs-providers-par-l-api.ipynb` (la\n",
+    "matrice d'usages et le piège du settings/update),\n",
+    "`parler-au-chatbot-en-visiteur-par-l-api.ipynb` (l'autre face, côté\n",
+    "navigateur), `presenter-ai-engine-par-son-api.ipynb` (le socle :\n",
+    "instance, routes, première completion).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 37.59337,
+   "end_time": "2026-08-17T23:15:07.665012",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "obtenir-des-donnees-structurees-par-l-api.ipynb",
+   "output_path": "obtenir-des-donnees-structurees-par-l-api.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-17T23:14:30.071642",
+   "version": "2.6.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA — prev: DEEP/guard #11546

Closes #11483

## Livrable

Nouveau notebook `obtenir-des-donnees-structurees-par-l-api.ipynb` (grain 7 de la série « AI Engine par son API »), exécuté **live** contre l'instance jetable Maison Valmont (WordPress 6.8.3 + AI Engine 3.7.0 + Ollama qwen3:8b sur `host.docker.internal:11434`), suivant l'arc demandé par l'issue :

1. **Appel à froid** → HTTP 500 `{"success": false, "message": "The environment is required."}` — l'erreur qui avait bloqué le grain 1, reproduite firsthand.
2. **Lecture de la matrice** → case `json` vide (`ai_json_default_env=None`), résidu de repli `gpt-5-mini` visible ; explication du piège complet (repli sans env ne peut jamais passer la validation sur instance custom-only).
3. **Remplissage** par read-modify-write du **bloc complet** (le PUT déguisé du grain 5) : case json → `llm-local`/`qwen3:8b`, case chat intacte, 105 clés stables.
4. **Requête réelle** → `data` dict propre : catalogue Valmont structuré (titre/auteur/genre/pages/recommendation/lecteurs), avec la nuance honnête (objet englobant le tableau, pas le tableau nu).
5. **Mesures d'honnêteté** :
   - **null silencieux** : consigne anti-JSON rend **quand même du JSON** (`{"réponse": "..."}`) → non observable avec ce moteur — et pourquoi : le piège `json_decode`-sous-try/catch existe dans le code mais ne peut pas se déclencher tant que le format est garanti en aval ;
   - **prompt-only vs wire-level** : différentiel direct au moteur — sans `response_format` : `bonjour` (texte) ; avec : `{"response": "bonjour"}` ; le comportement de `/ai/json` matche la colonne *avec* → contrainte **wire-level** (chatml envoie `response_format` pour un env custom), confirmé des deux côtés.
6. **Restauration** de l'instantané → case json revenue à `None`/`gpt-5-mini`, 105 clés stables — re-exécutabilité à froid préservée.

**3 exercices à stubs** répartis dans l'arc (matrice complète, taux de réussite JSON, audit de restauration), patterns C.1 (`return {}`/`return 0.0, []`).

Fichiers : notebook + paragraphe série README.md + bloc compagnon livresagites-parcours.md + 2 vars optionnelles (`VALMONT_LLM_BASE_URL_MOTEUR`/`..._API_KEY_MOTEUR`, comparaison directe moteur, défaut sk-local) dans `instance-jetable/.env.example`.

Note bring-up (non livré, contextuel) : pretty permalinks absents de l'instance après re-up compose → `wp rewrite structure '/%postname%/'` + `--hard` exécuté (sinon `/wp-json/*` sert la page d'accueil HTML — piège documenté dans le probe, rien dans le repo).

## Validation H.1 (exécution réelle)

- Papermill end-to-end **in-place** (cwd = dossier série pour `instance-jetable/.env` relatif) : `Executing notebook with kernel: python3 ... 30/30 [00:37<00:00]` — sortie collée depuis le run final.
- `execution_count` : 1..12 sur les 12 cellules code, 0 `error` output, 0 sortie vide.
- `grep -cE "raise NotImplementedError|assert False|1/0"` → **0**.
- Scan chemins machine (regex `[A-Za-z]:[\/](Users|Dev|Temp)|/d/Dev|CoursIA-11483`) sur sources+outputs → **0 leak**.
- Nouveau fichier : pas de séquence avant/après (base inexistante) ; toutes les sorties proviennent de l'exécution live de ce cycle (commit 828888ce5a).
