### PR TITLE
feat(genai,#11516): Aspire Grain 2 — TUnit + Testcontainers Postgres + rollback isolation

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/05-Aspire-Tests-Integration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/05-Aspire-Tests-Integration.ipynb
@@ -1,0 +1,964 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8dbfe5d9",
+   "metadata": {},
+   "source": [
+    "# Aspire : des tests d'intégration modernes — Testcontainers, TUnit, rollback transactionnel\n",
+    "\n",
+    "Ce notebook couvre les axes **A5 + A6 + A7** du **Grain 2** de la digestion #11516\n",
+    "(*The Unexpected AI Stack: C# + .NET*, Part 4) :\n",
+    "\n",
+    "| Axe | Apport | Où le voir |\n",
+    "|---|---|---|\n",
+    "| **A5** | `Testcontainers.PostgreSql` : un Postgres 18 **jetable**, port hôte aléatoire, wait strategy | §2 |\n",
+    "| **A6** | **TUnit** + **Microsoft Testing Platform** (MTP) : paradigme de test absent du dépôt (xUnit/vitest partout) | §1 |\n",
+    "| **A7** | Isolation par **rollback transactionnel** : chaque test repart d'une base intacte, en parallèle | §3 |\n",
+    "\n",
+    "Le livrable à côté de ce notebook : le projet [`IntegrationTests/`](IntegrationTests/) —\n",
+    "exécutable tel quel (`dotnet test`), Docker requis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db9030d5",
+   "metadata": {},
+   "source": [
+    "## Contexte : xUnit partout, et une question d'état\n",
+    "\n",
+    "La sonde de l'issue #11516 sur tout le dépôt ne trouve **aucun** usage réel de TUnit ni de\n",
+    "Testcontainers : les tests du repo sont en xUnit (.NET) et vitest (TS). Ce n'est pas un\n",
+    "problème en soi — mais la Part 4 de la série source démontre un **autre contrat de test**,\n",
+    "conçu pour des agents et des humains :\n",
+    "\n",
+    "1. **pas de base installée à la main** : le conteneur Postgres se lance avec le test, sur un\n",
+    "   port **aléatoire** — plusieurs sessions coexistent sans collision ;\n",
+    "2. **pas d'état résiduel** : chaque test s'exécute dans **sa** transaction, ouverte avant et\n",
+    "   *rollbackée* après — la base est intangible, les tests peuvent tourner en parallèle ;\n",
+    "3. **un runner moderne** : MTP remplace l'ancien pipeline VSTest ; le projet de test est un\n",
+    "   exécutable, filtrable par **arbre** (`--treenode-filter`).\n",
+    "\n",
+    "Chaque brique est montrée **réellement exécutée** ci-dessous : le conteneur démarre sous vos\n",
+    "yeux dans les sorties de `dotnet test`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "fdda22ce",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:18.720609Z",
+     "iopub.status.busy": "2026-08-17T23:49:18.714615Z",
+     "iopub.status.idle": "2026-08-17T23:49:20.814880Z",
+     "shell.execute_reply": "2026-08-17T23:49:20.807124Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '44260.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Projet (relatif a la racine du depot) : MyIA.AI.Notebooks\\GenAI\\Aspire\\IntegrationTests"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Projet IntegrationTests present."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "using System.IO;\n",
+    "// Cellule d'amorcage : chemins partages + helper d'execution.\n",
+    "public static class TestShell {\n",
+    "    public static readonly string RepoRoot = FindRepoRoot(Directory.GetCurrentDirectory());\n",
+    "    public static readonly string ProjectDir = Path.Combine(\n",
+    "        RepoRoot, \"MyIA.AI.Notebooks\", \"GenAI\", \"Aspire\", \"IntegrationTests\");\n",
+    "\n",
+    "    public static string FindRepoRoot(string start) {\n",
+    "        var dir = new DirectoryInfo(start);\n",
+    "        while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, \"docker-configurations\")))\n",
+    "            dir = dir.Parent;\n",
+    "        return dir?.FullName ?? throw new DirectoryNotFoundException(\"racine du depot introuvable\");\n",
+    "    }\n",
+    "\n",
+    "    // Execute une commande et capture stdout + stderr concatenees.\n",
+    "    public static string Run(string workDir, string file, string args, int timeoutMs = 600_000) {\n",
+    "        var psi = new System.Diagnostics.ProcessStartInfo {\n",
+    "            FileName = file, Arguments = args,\n",
+    "            WorkingDirectory = workDir,\n",
+    "            RedirectStandardOutput = true, RedirectStandardError = true,\n",
+    "            UseShellExecute = false, CreateNoWindow = true\n",
+    "        };\n",
+    "        using var p = System.Diagnostics.Process.Start(psi)!;\n",
+    "        var stdout = p.StandardOutput.ReadToEnd();\n",
+    "        var stderr = p.StandardError.ReadToEnd();\n",
+    "        if (!p.WaitForExit(timeoutMs)) { p.Kill(); return \"[TIMEOUT] \" + stdout + stderr; }\n",
+    "        return stdout + stderr;\n",
+    "    }\n",
+    "\n",
+    "    public static string Dotnet(string args) => Run(ProjectDir, \"dotnet.exe\", args);\n",
+    "    public static string Docker(string args) => Run(RepoRoot, \"docker.exe\", args, 120_000);\n",
+    "\n",
+    "    // Projection d'affichage : le resume MTP embarque le chemin absolu de la\n",
+    "    // DLL — on montre les lignes de resume sans la ligne qui le porte.\n",
+    "    public static string Clean(string s) =>\n",
+    "        string.Join(Environment.NewLine,\n",
+    "            s.Split(Environment.NewLine).Where(l => !l.Contains(RepoRoot)));\n",
+    "\n",
+    "\n",
+    "    // Affiche un fichier source du projet, titre en tete.\n",
+    "    public static object ShowFile(string relativePath) {\n",
+    "        var full = Path.Combine(ProjectDir, relativePath);\n",
+    "        var content = File.ReadAllText(full);\n",
+    "        return display($\"--- {relativePath} ---\\n{content}\");\n",
+    "    }\n",
+    "}\n",
+    "display($\"Projet (relatif a la racine du depot) : {Path.GetRelativePath(TestShell.RepoRoot, TestShell.ProjectDir)}\");\n",
+    "display(File.Exists(Path.Combine(TestShell.ProjectDir, \"IntegrationTests.csproj\"))\n",
+    "    ? \"Projet IntegrationTests present.\" : \"PROJET ABSENT !\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0797fec4",
+   "metadata": {},
+   "source": [
+    "## 1. A6 — TUnit + Microsoft Testing Platform : le harnais\n",
+    "\n",
+    "Sur le SDK .NET 10, l'ancien pont VSTest de `dotnet test` n'existe plus : MTP devient le\n",
+    "runner natif. Deux réglages suffisent — une propriété csproj, et le `global.json` qui\n",
+    "déclare le runner pour l'expérience `dotnet test` nouvelle génération."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d570201c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:20.817910Z",
+     "iopub.status.busy": "2026-08-17T23:49:20.816882Z",
+     "iopub.status.idle": "2026-08-17T23:49:20.868602Z",
+     "shell.execute_reply": "2026-08-17T23:49:20.867598Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "--- IntegrationTests.csproj ---\n",
+       "<Project Sdk=\"Microsoft.NET.Sdk\">\r\n",
+       "\r\n",
+       "  <PropertyGroup>\r\n",
+       "    <OutputType>Exe</OutputType>\r\n",
+       "    <TargetFramework>net10.0</TargetFramework>\r\n",
+       "    <ImplicitUsings>enable</ImplicitUsings>\r\n",
+       "    <Nullable>enable</Nullable>\r\n",
+       "    <IsPackable>false</IsPackable>\r\n",
+       "    <!-- Microsoft Testing Platform : `dotnet test` delegue au runner TUnit -->\r\n",
+       "    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>\r\n",
+       "  </PropertyGroup>\r\n",
+       "\r\n",
+       "  <ItemGroup>\r\n",
+       "    <PackageReference Include=\"EFCore.NamingConventions\" Version=\"10.0.1\" />\r\n",
+       "    <PackageReference Include=\"Npgsql.EntityFrameworkCore.PostgreSQL\" Version=\"10.0.3\" />\r\n",
+       "    <PackageReference Include=\"Testcontainers.PostgreSql\" Version=\"4.14.0\" />\r\n",
+       "    <PackageReference Include=\"TUnit\" Version=\"1.65.0\" />\r\n",
+       "  </ItemGroup>\r\n",
+       "\r\n",
+       "</Project>\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- global.json ---\n",
+       "{\n",
+       "  \"test\": {\n",
+       "    \"runner\": \"Microsoft.Testing.Platform\"\n",
+       "  }\n",
+       "}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- SmokeTest.cs ---\n",
+       "using TUnit.Core;\n",
+       "\n",
+       "namespace IntegrationTests;\n",
+       "\n",
+       "/// <summary>\n",
+       "/// Fumigenne : prouve que le harnais TUnit + Microsoft Testing Platform est\n",
+       "/// cable (sans base) — premier reflexe quand on echafaude un projet de tests.\n",
+       "/// </summary>\n",
+       "public class SmokeTest\n",
+       "{\n",
+       "    [Test]\n",
+       "    public async Task SmokeTest_Harness_IsWired()\n",
+       "    {\n",
+       "        // Valeur non constante (le linter TUnit refuse les assertions\n",
+       "        // constantes) : si cette ligne passe, le runner a bien execute du\n",
+       "        // code utilisateur.\n",
+       "        await Assert.That(DateTime.UtcNow.Year).IsGreaterThanOrEqualTo(2026);\n",
+       "    }\n",
+       "}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "TestShell.ShowFile(\"IntegrationTests.csproj\");\n",
+    "TestShell.ShowFile(\"global.json\");\n",
+    "TestShell.ShowFile(\"SmokeTest.cs\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1b84ee32",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:20.870600Z",
+     "iopub.status.busy": "2026-08-17T23:49:20.869600Z",
+     "iopub.status.idle": "2026-08-17T23:49:22.751013Z",
+     "shell.execute_reply": "2026-08-17T23:49:22.751013Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "  total: 1\r\n",
+       "  échec: 0\r\n",
+       "  opération réussie: 1\r\n",
+       "  ignoré: 0\r\n",
+       "  durée: 330ms\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// La fumigenne, via le runner NATIF (executable MTP) : dotnet run -- <args>.\n",
+    "// Le pont `dotnet test` accepte les executions completes, mais refuse les filtres\n",
+    "// sur .NET 10 — le runner natif les accepte tous.\n",
+    "var smoke = TestShell.Dotnet(\"run --no-build -- --treenode-filter \\\"/IntegrationTests/IntegrationTests/SmokeTest/*\\\"\");\n",
+    "display(TestShell.Clean(smoke[smoke.LastIndexOf(\"Résumé\", StringComparison.Ordinal)..]));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "072b1e03",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- **`total: 1`** : le filtre d'arbre `/Assembly/Namespace/Classe/*` a sélectionné exactement\n",
+    "  la classe `SmokeTest` — sans toucher au conteneur (ce test ne touche pas la base).\n",
+    "- Le runner affiche `opération réussie: 1` : `Assert.That(...)` (fluent, asynchrone) est le\n",
+    "  style d'assertion TUnit, distinct du `Assert.True(...)` xUnit.\n",
+    "- `dotnet run --` est la forme **native** : le projet de test est un exécutable MTP ; tous\n",
+    "  ses arguments (`--treenode-filter`, `--list-tests`, `--diagnostic`) passent après `--`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b16aa0ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:22.753235Z",
+     "iopub.status.busy": "2026-08-17T23:49:22.752024Z",
+     "iopub.status.idle": "2026-08-17T23:49:22.924371Z",
+     "shell.execute_reply": "2026-08-17T23:49:22.923373Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : filtrer sur une methode unique et verifier total: 1\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 1 : executer UNE methode precise.\n",
+    "// Objectif : lancer uniquement SmokeTest_Harness_IsWired via --treenode-filter,\n",
+    "// et verifier que le resume affiche total: 1 (et non 5).\n",
+    "// Indice : le dernier segment accepte un joker final — SmokeTest_Harness_IsWired*\n",
+    "// Etape 1 : construire le filtre \"/IntegrationTests/IntegrationTests/SmokeTest/SmokeTest_Harness_IsWired*\"\n",
+    "// Etape 2 : le passer a TestShell.Dotnet(\"run --no-build -- --treenode-filter \\\"...\\\"\")\n",
+    "// Etape 3 : afficher le resume (dernieres lignes) et verifier total: 1\n",
+    "Console.WriteLine(\"Exercice 1 a completer : filtrer sur une methode unique et verifier total: 1\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09e86efa",
+   "metadata": {},
+   "source": [
+    "## 2. A5 — Testcontainers : un Postgres 18 jetable, port aléatoire\n",
+    "\n",
+    "La fixture ne demande **rien** d'installé : elle tire l'image `postgres:18`, démarre le\n",
+    "conteneur sur un **port hôte aléatoire** (jamais 5432 en dur — plusieurs sessions de test\n",
+    "coexistent), attend la double condition de santé (message de log **et** port TCP interne),\n",
+    "crée le schéma, puis s'auto-détruit (`WithAutoRemove`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5b0acf1c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:22.925371Z",
+     "iopub.status.busy": "2026-08-17T23:49:22.925371Z",
+     "iopub.status.idle": "2026-08-17T23:49:22.982347Z",
+     "shell.execute_reply": "2026-08-17T23:49:22.982347Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "--- PgDatabaseFixture.cs ---\n",
+       "using DotNet.Testcontainers.Builders;\n",
+       "using IntegrationTests.Data;\n",
+       "using Microsoft.EntityFrameworkCore;\n",
+       "using Testcontainers.PostgreSql;\n",
+       "using TUnit.Core.Interfaces;\n",
+       "\n",
+       "namespace IntegrationTests;\n",
+       "\n",
+       "/// <summary>\n",
+       "/// Fixture TUnit : demarre UN conteneur Postgres 18 par session de tests,\n",
+       "/// sur un port hote aleatoire (jamais 5432 en dur), puis cree le schema.\n",
+       "/// Un seul conteneur pour toute la session : les tests s'executent en\n",
+       "/// parallele dessus, isoles par rollback transactionnel (cf.\n",
+       "/// <see cref=\"PgTransactionalTestBase\"/>).\n",
+       "/// </summary>\n",
+       "public class PgDatabaseFixture : IAsyncInitializer, IAsyncDisposable\n",
+       "{\n",
+       "    private PostgreSqlContainer? _container;\n",
+       "    private DbContextOptions<TranscriptionDbContext>? _options;\n",
+       "\n",
+       "    private DbContextOptions<TranscriptionDbContext> EnsureOptions()\n",
+       "    {\n",
+       "        if (_container is null)\n",
+       "        {\n",
+       "            throw new InvalidOperationException(\"Le conteneur Postgres n'est pas initialise.\");\n",
+       "        }\n",
+       "\n",
+       "        return _options ??= new DbContextOptionsBuilder<TranscriptionDbContext>()\n",
+       "            .UseNpgsql(_container.GetConnectionString())\n",
+       "            .EnableDetailedErrors(true)\n",
+       "            .UseSnakeCaseNamingConvention()\n",
+       "            .Options;\n",
+       "    }\n",
+       "\n",
+       "    /// <summary>Contexte neuf, branche sur le conteneur de la session.</summary>\n",
+       "    public TranscriptionDbContext CreateContext() => new(EnsureOptions());\n",
+       "\n",
+       "    /// <summary>Chaine de connexion effective (port aleatoire alloue par Docker).</summary>\n",
+       "    public string ConnectionString =>\n",
+       "        _container?.GetConnectionString()\n",
+       "        ?? throw new InvalidOperationException(\"Le conteneur Postgres n'est pas initialise.\");\n",
+       "\n",
+       "    public async Task InitializeAsync()\n",
+       "    {\n",
+       "        _container = new PostgreSqlBuilder(\"postgres:18\")\n",
+       "            // true = port hote ALEATOIRE : plusieurs sessions coexistent sans collision\n",
+       "            .WithPortBinding(5432, true)\n",
+       "            .WithUsername(\"tests\")\n",
+       "            .WithPassword(\"password\")\n",
+       "            .WithDatabase(\"genai_tests\")\n",
+       "            .WithWaitStrategy(\n",
+       "                Wait.ForUnixContainer()\n",
+       "                    .UntilMessageIsLogged(\"database system is ready to accept connections\")\n",
+       "                    .UntilInternalTcpPortIsAvailable(5432))\n",
+       "            .WithAutoRemove(true)\n",
+       "            .Build();\n",
+       "\n",
+       "        await _container.StartAsync();\n",
+       "\n",
+       "        // Schema : EnsureCreated suffit ici (pas de migrations evolutives a\n",
+       "        // rejouer dans un conteneur jetable).\n",
+       "        await using var context = new TranscriptionDbContext(EnsureOptions());\n",
+       "        await context.Database.EnsureCreatedAsync();\n",
+       "    }\n",
+       "\n",
+       "    public async ValueTask DisposeAsync()\n",
+       "    {\n",
+       "        if (_container is not null)\n",
+       "        {\n",
+       "            await _container.DisposeAsync();\n",
+       "        }\n",
+       "\n",
+       "        GC.SuppressFinalize(this);\n",
+       "    }\n",
+       "}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "TestShell.ShowFile(\"PgDatabaseFixture.cs\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0ec94a0d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:22.984539Z",
+     "iopub.status.busy": "2026-08-17T23:49:22.983528Z",
+     "iopub.status.idle": "2026-08-17T23:49:35.030818Z",
+     "shell.execute_reply": "2026-08-17T23:49:35.030818Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\r\n",
+       "  Artéfacts produits dans les dossiers en cours de traitement :\r\n",
+       "\r\n",
+       "Résumé de série de tests : Réussite!\r\n",
+       "  total : 5\r\n",
+       "  échec : 0\r\n",
+       "  réussie : 5\r\n",
+       "  ignoré : 0\r\n",
+       "  durée : 10s 179ms\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// L'execution COMPLETE : dotnet test lance le conteneur, joue les 5 tests, tout disparait.\n",
+    "var full = TestShell.Dotnet(\"test\");\n",
+    "display(TestShell.Clean(full[full.LastIndexOf(\"Exécuter des tests\", StringComparison.Ordinal)..]));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "10f83679",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:35.031827Z",
+     "iopub.status.busy": "2026-08-17T23:49:35.031827Z",
+     "iopub.status.idle": "2026-08-17T23:49:35.193604Z",
+     "shell.execute_reply": "2026-08-17T23:49:35.193604Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(vide) : aucun conteneur postgres:18 residuel — WithAutoRemove a tout nettoye."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// Preuve de l'ephemerite : apres le run, plus AUCUN conteneur postgres residuel.\n",
+    "var residue = TestShell.Docker(\"ps -a --filter ancestor=postgres:18 --format \\\"{{.ID}} {{.Image}} {{.Status}}\\\"\");\n",
+    "display(string.IsNullOrWhiteSpace(residue)\n",
+    "    ? \"(vide) : aucun conteneur postgres:18 residuel — WithAutoRemove a tout nettoye.\"\n",
+    "    : residue);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "caa62da6",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- **`réussie: 5`** en ~10 s à chaud (comptez ~30 s au premier run, tirage de l'image\n",
+    "  compris) — rien à installer, rien à nettoyer après (sortie `(vide)` ci-dessus).\n",
+    "- **`WithPortBinding(5432, true)`** : le `true` demande un port hôte **aléatoire** ; la\n",
+    "  chaîne de connexion lue par `GetConnectionString()` pointe dessus. C'est la fin des\n",
+    "  collisions de port entre worktrees — le même principe que `aspire run --isolated`\n",
+    "  (notebook 01), au niveau du test.\n",
+    "- **Un seul conteneur par session** : `[ClassDataSource<PgDatabaseFixture>(Shared =\n",
+    "  SharedType.PerTestSession)]` — le démarrage est payé une fois, les tests tournent\n",
+    "  dessus en parallèle.\n",
+    "- La **wait strategy** est double (`UntilMessageIsLogged` + `UntilInternalTcpPortIsAvailable`) :\n",
+    "  le port peut écouter avant que Postgres ait fini son init — le message de log est la\n",
+    "  vraie garantie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ca8ec9aa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:35.195274Z",
+     "iopub.status.busy": "2026-08-17T23:49:35.195274Z",
+     "iopub.status.idle": "2026-08-17T23:49:35.246137Z",
+     "shell.execute_reply": "2026-08-17T23:49:35.246137Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : chronometrer sans-base vs avec-base\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 2 : mesurer le cout du conteneur.\n",
+    "// Objectif : chronometrer le smoke test SANS base (filtre SmokeTest) vs les tests\n",
+    "// AVEC base (filtre TranscriptionJobTests), et calculer le surcout conteneur.\n",
+    "// Indice : System.Diagnostics.Stopwatch autour de deux TestShell.Dotnet(...)\n",
+    "// Etape 1 : mesurer le run filtre SmokeTest (pas de conteneur)\n",
+    "// Etape 2 : mesurer le run filtre TranscriptionJobTests (conteneur + 4 tests)\n",
+    "// Etape 3 : afficher les deux durees et leur difference\n",
+    "Console.WriteLine(\"Exercice 2 a completer : chronometrer sans-base vs avec-base\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "709f3b72",
+   "metadata": {},
+   "source": [
+    "## 3. A7 — l'isolation par rollback : chaque test repart de zéro\n",
+    "\n",
+    "Le couple `PgTransactionalTestBase` + tests : **avant** chaque test on ouvre une\n",
+    "transaction, **après** on la rollback. Un test qui écrit ne pollue jamais le suivant —\n",
+    "l'invariant « la table est vide au début d'un test » tient même en parallèle, parce que\n",
+    "les lignes non commises sont invisibles aux autres transactions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b62d0892",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:35.247826Z",
+     "iopub.status.busy": "2026-08-17T23:49:35.247826Z",
+     "iopub.status.idle": "2026-08-17T23:49:35.298751Z",
+     "shell.execute_reply": "2026-08-17T23:49:35.298751Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "--- PgTransactionalTestBase.cs ---\n",
+       "using IntegrationTests.Data;\n",
+       "using Microsoft.EntityFrameworkCore.Storage;\n",
+       "using TUnit.Core;\n",
+       "\n",
+       "namespace IntegrationTests;\n",
+       "\n",
+       "/// <summary>\n",
+       "/// Base transactionnelle : chaque test s'execute dans SA transaction, ouverte\n",
+       "/// en [Before(Test)] et ROLLBACKEE en [After(Test)]. Aucun test ne laisse de\n",
+       "/// ligne derriere lui — l'etat de depart (base vide) est un invariant, et les\n",
+       "/// tests peuvent tourner en parallele sur le meme conteneur.\n",
+       "/// </summary>\n",
+       "public abstract class PgTransactionalTestBase(PgDatabaseFixture pg)\n",
+       "{\n",
+       "    private IDbContextTransaction? _transaction;\n",
+       "\n",
+       "    // TUnit instancie la classe pour CHAQUE test : le champ est frais a chaque fois\n",
+       "    protected TranscriptionDbContext Context = pg.CreateContext();\n",
+       "\n",
+       "    [Before(Test)]\n",
+       "    public async Task BeginTransaction()\n",
+       "    {\n",
+       "        _transaction = await Context.Database.BeginTransactionAsync();\n",
+       "    }\n",
+       "\n",
+       "    [After(Test)]\n",
+       "    public async Task RollbackTransaction()\n",
+       "    {\n",
+       "        if (_transaction is not null)\n",
+       "        {\n",
+       "            await _transaction.RollbackAsync();\n",
+       "            await _transaction.DisposeAsync();\n",
+       "        }\n",
+       "\n",
+       "        await Context.DisposeAsync();\n",
+       "    }\n",
+       "}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "--- TranscriptionJobTests.cs ---\n",
+       "using IntegrationTests.Data;\n",
+       "using Microsoft.EntityFrameworkCore;\n",
+       "using TUnit.Core;\n",
+       "\n",
+       "namespace IntegrationTests;\n",
+       "\n",
+       "/// <summary>\n",
+       "/// Tests d'integration EF Core + Postgres reel (conteneur Testcontainers),\n",
+       "/// isoles par rollback transactionnel. Convention de nommage trois parties :\n",
+       "/// Entite_Etat_Testee_Comportement_Attendu.\n",
+       "/// </summary>\n",
+       "[ClassDataSource<PgDatabaseFixture>(Shared = SharedType.PerTestSession)]\n",
+       "public class TranscriptionJobTests(PgDatabaseFixture pg) : PgTransactionalTestBase(pg)\n",
+       "{\n",
+       "    [Test]\n",
+       "    public async Task TranscriptionJob_WriteThenRead_RoundTrips()\n",
+       "    {\n",
+       "        Context.Jobs.Add(new TranscriptionJob\n",
+       "        {\n",
+       "            FileName = \"echantillon-test-fr.wav\",\n",
+       "            Model = \"faster-whisper-large-v3-turbo\",\n",
+       "            DurationSeconds = 12.5,\n",
+       "            Status = \"Done\",\n",
+       "        });\n",
+       "\n",
+       "        await Context.SaveChangesAsync();\n",
+       "\n",
+       "        Context.ChangeTracker.Clear(); // relecture forcee depuis la base\n",
+       "\n",
+       "        var job = await Context.Jobs.FirstOrDefaultAsync();\n",
+       "\n",
+       "        await Assert.That(job).IsNotNull();\n",
+       "        await Assert.That(job!.FileName).IsEqualTo(\"echantillon-test-fr.wav\");\n",
+       "        await Assert.That(job.Id).IsNotEqualTo(Guid.Empty); // genere par le serveur\n",
+       "    }\n",
+       "\n",
+       "    [Test]\n",
+       "    public async Task TranscriptionJob_AfterEachRollback_TableIsStillEmpty()\n",
+       "    {\n",
+       "        // Preuve d'isolation : meme si WriteThenRead (ou n'importe quel test\n",
+       "        // execute avant/apres en parallele) a COMMITTE dans SA transaction,\n",
+       "        // la table est vide ici — les lignes non commitees sont invisibles,\n",
+       "        // et chaque transaction est rollbackee a la fin de son test.\n",
+       "        var count = await Context.Jobs.CountAsync();\n",
+       "\n",
+       "        await Assert.That(count).IsEqualTo(0);\n",
+       "    }\n",
+       "\n",
+       "    [Test]\n",
+       "    public async Task TranscriptionJob_DuplicateFileName_RejectedByUniqueIndex()\n",
+       "    {\n",
+       "        Context.Jobs.Add(new TranscriptionJob { FileName = \"doublon.wav\", Model = \"m\", Status = \"Pending\" });\n",
+       "        await Context.SaveChangesAsync();\n",
+       "\n",
+       "        Context.ChangeTracker.Clear();\n",
+       "        Context.Jobs.Add(new TranscriptionJob { FileName = \"doublon.wav\", Model = \"m\", Status = \"Pending\" });\n",
+       "\n",
+       "        // L'index UNIQUE pose dans TranscriptionJobConfiguration doit parler :\n",
+       "        // le SAVEINSERT leve DbUpdateException, la transaction est rollbackee.\n",
+       "        await Assert.ThrowsAsync<DbUpdateException>(async () =>\n",
+       "            await Context.SaveChangesAsync());\n",
+       "    }\n",
+       "\n",
+       "    [Test]\n",
+       "    public async Task TranscriptionJob_StatusUpdate_PersistsWithinTransaction()\n",
+       "    {\n",
+       "        var job = new TranscriptionJob { FileName = \"maj.wav\", Model = \"m\", Status = \"Pending\" };\n",
+       "        Context.Jobs.Add(job);\n",
+       "        await Context.SaveChangesAsync();\n",
+       "\n",
+       "        Context.ChangeTracker.Clear();\n",
+       "        var stored = await Context.Jobs.SingleAsync(j => j.FileName == \"maj.wav\");\n",
+       "        stored.Status = \"Done\";\n",
+       "        await Context.SaveChangesAsync();\n",
+       "\n",
+       "        Context.ChangeTracker.Clear();\n",
+       "        var reloaded = await Context.Jobs.SingleAsync(j => j.FileName == \"maj.wav\");\n",
+       "\n",
+       "        await Assert.That(reloaded.Status).IsEqualTo(\"Done\");\n",
+       "    }\n",
+       "}\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "TestShell.ShowFile(\"PgTransactionalTestBase.cs\");\n",
+    "TestShell.ShowFile(\"TranscriptionJobTests.cs\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "804552d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:35.299714Z",
+     "iopub.status.busy": "2026-08-17T23:49:35.299714Z",
+     "iopub.status.idle": "2026-08-17T23:49:47.784879Z",
+     "shell.execute_reply": "2026-08-17T23:49:47.784343Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "  total: 4\r\n",
+       "  échec: 0\r\n",
+       "  opération réussie: 4\r\n",
+       "  ignoré: 0\r\n",
+       "  durée: 10s 747ms\r\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "// La preuve de coexistence : on execute ENSEMBLE les quatre tests de\n",
+    "// TranscriptionJobTests — dont celui qui ECRIT une ligne (WriteThenRead_RoundTrips)\n",
+    "// et celui qui AFFIRME la table vide (AfterEachRollback_TableIsStillEmpty).\n",
+    "var pair = TestShell.Dotnet(\"run --no-build -- --treenode-filter \\\"/IntegrationTests/IntegrationTests/TranscriptionJobTests/TranscriptionJob_*\\\"\");\n",
+    "display(TestShell.Clean(pair[pair.LastIndexOf(\"Résumé\", StringComparison.Ordinal)..]));"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40eff54a",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- **`total: 4`** : les quatre tests passent **ensemble**, dont `WriteThenRead_RoundTrips`\n",
+    "  (qui insère une ligne) et `AfterEachRollback_TableIsStillEmpty` (qui compte zéro ligne).\n",
+    "  C'est la démonstration A7 : le rollback de l'un rend son écriture invisible à l'autre —\n",
+    "  l'ordre d'exécution n'existe plus comme source de vérité.\n",
+    "- `Context.ChangeTracker.Clear()` avant relecture : force EF Core à recharger **depuis la\n",
+    "  base** (dans la transaction du test), pas depuis son cache mémoire.\n",
+    "- **`DuplicateFileName_RejectedByUniqueIndex`** : la contrainte UNIQUE posée dans\n",
+    "  `TranscriptionJobConfiguration` est vérifiée **par le vrai serveur Postgres** — c'est un\n",
+    "  test d'intégration, pas un mock.\n",
+    "- Convention de nommage trois parties : `Entite_Etat_Teste_Comportement_Attendu`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "308fc39d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-17T23:49:47.786562Z",
+     "iopub.status.busy": "2026-08-17T23:49:47.786031Z",
+     "iopub.status.idle": "2026-08-17T23:49:47.796726Z",
+     "shell.execute_reply": "2026-08-17T23:49:47.796726Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : demonstrer l'invisibilite inter-connections\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 3 : l'invisibilite inter-connections.\n",
+    "// Objectif : montrer qu'un deuxieme contexte ne VOIT PAS les lignes non commises\n",
+    "// du premier (lecture sale impossible en READ COMMITTED) — au-dela du rollback.\n",
+    "// Indice : ajouter a TranscriptionJobTests une methode TwoContexts_Uncommitted_Invisible\n",
+    "// qui cree un second contexte via pg.CreateContext(), ecrit+SaveChanges dans le premier,\n",
+    "// puis compte dans le second AVANT tout commit.\n",
+    "// Etape 1 : ecrire le test dans TranscriptionJobTests.cs\n",
+    "// Etape 2 : le faire passer via --treenode-filter (cf. exercice 1)\n",
+    "// Etape 3 : expliquer pourquoi le rollback reste necessaire malgre cette invisibilite\n",
+    "Console.WriteLine(\"Exercice 3 a completer : demonstrer l'invisibilite inter-connections\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cd83e49",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le harnais complet tient en quatre fichiers et un contrat :\n",
+    "\n",
+    "| Brique | Fichier | Garantie |\n",
+    "|---|---|---|\n",
+    "| Runner TUnit + MTP | `IntegrationTests.csproj` + `global.json` | exécutable filtrable, `dotnet test` natif .NET 10 |\n",
+    "| Fumigenne | `SmokeTest.cs` | le harnais est câblé avant d'échafauder |\n",
+    "| Conteneur jetable | `PgDatabaseFixture.cs` | Postgres 18 réel, port aléatoire, auto-purge |\n",
+    "| Isolation | `PgTransactionalTestBase.cs` | rollback par test, parallélisme sans ordre |\n",
+    "\n",
+    "Ce que ce projet **n'est pas** : un remplacement des xUnit du dépôt — c'est la démonstration\n",
+    "d'un paradigme complémentaire (Part 4 de la série source), self-contained à côté des\n",
+    "notebooks de la série Aspire. La suite logique de la digestion #11516 : le grain 1\n",
+    "(observabilité Serilog + OTel, notebook 03) et le grain 3 (agent streaming, notebook 04).\n",
+    "\n",
+    "**Prérequis** pour rejouer : SDK .NET 10, Docker démarré (image `postgres:18` tirée au\n",
+    "premier run), puis `dotnet test` dans `IntegrationTests/`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".NET (C#)",
+   "language": "C#",
+   "name": ".net-csharp"
+  },
+  "language_info": {
+   "file_extension": ".cs",
+   "mimetype": "text/x-csharp",
+   "name": "C#",
+   "pygments_lexer": "csharp",
+   "version": "13.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/Data/TranscriptionJobs.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/Data/TranscriptionJobs.cs
@@ -1,0 +1,60 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace IntegrationTests.Data;
+
+/// <summary>
+/// Modele de domaine pur : une demande de transcription soumise au service
+/// whisper-api de la pile GenAI (cf. notebooks 01/02 de la serie Aspire).
+/// </summary>
+public class TranscriptionJob
+{
+    public Guid Id { get; set; }
+
+    [MaxLength(255)]
+    public string FileName { get; set; } = string.Empty;
+
+    [MaxLength(64)]
+    public string Model { get; set; } = string.Empty;
+
+    public double DurationSeconds { get; set; }
+
+    [MaxLength(16)]
+    public string Status { get; set; } = "Pending";
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+}
+
+/// <summary>
+/// Mapping de stockage EF Core, separe du modele de domaine pur.
+/// </summary>
+public class TranscriptionJobConfiguration : IEntityTypeConfiguration<TranscriptionJob>
+{
+    public void Configure(EntityTypeBuilder<TranscriptionJob> builder)
+    {
+        builder.HasKey(j => j.Id);
+        builder.Property(j => j.FileName).IsRequired();
+        builder.Property(j => j.Model).IsRequired();
+        builder.Property(j => j.Status).IsRequired();
+        builder.Property(j => j.CreatedAtUtc).IsRequired();
+        // Un meme fichier ne peut etre soumis qu'une fois : contrainte UNIQUE
+        // en base, testee par TranscriptionJobTests.
+        builder.HasIndex(j => j.FileName).IsUnique();
+    }
+}
+
+/// <summary>
+/// DbContext EF Core sur Postgres (convention snake_case, comme la source
+/// Part 4 de la digestion #11516).
+/// </summary>
+public class TranscriptionDbContext(DbContextOptions<TranscriptionDbContext> options)
+    : DbContext(options)
+{
+    public DbSet<TranscriptionJob> Jobs => Set<TranscriptionJob>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(TranscriptionDbContext).Assembly);
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/IntegrationTests.csproj
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/IntegrationTests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <!-- Microsoft Testing Platform : `dotnet test` delegue au runner TUnit -->
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EFCore.NamingConventions" Version="10.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.14.0" />
+    <PackageReference Include="TUnit" Version="1.65.0" />
+  </ItemGroup>
+
+</Project>

--- a/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/PgDatabaseFixture.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/PgDatabaseFixture.cs
@@ -1,0 +1,75 @@
+using DotNet.Testcontainers.Builders;
+using IntegrationTests.Data;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+using TUnit.Core.Interfaces;
+
+namespace IntegrationTests;
+
+/// <summary>
+/// Fixture TUnit : demarre UN conteneur Postgres 18 par session de tests,
+/// sur un port hote aleatoire (jamais 5432 en dur), puis cree le schema.
+/// Un seul conteneur pour toute la session : les tests s'executent en
+/// parallele dessus, isoles par rollback transactionnel (cf.
+/// <see cref="PgTransactionalTestBase"/>).
+/// </summary>
+public class PgDatabaseFixture : IAsyncInitializer, IAsyncDisposable
+{
+    private PostgreSqlContainer? _container;
+    private DbContextOptions<TranscriptionDbContext>? _options;
+
+    private DbContextOptions<TranscriptionDbContext> EnsureOptions()
+    {
+        if (_container is null)
+        {
+            throw new InvalidOperationException("Le conteneur Postgres n'est pas initialise.");
+        }
+
+        return _options ??= new DbContextOptionsBuilder<TranscriptionDbContext>()
+            .UseNpgsql(_container.GetConnectionString())
+            .EnableDetailedErrors(true)
+            .UseSnakeCaseNamingConvention()
+            .Options;
+    }
+
+    /// <summary>Contexte neuf, branche sur le conteneur de la session.</summary>
+    public TranscriptionDbContext CreateContext() => new(EnsureOptions());
+
+    /// <summary>Chaine de connexion effective (port aleatoire alloue par Docker).</summary>
+    public string ConnectionString =>
+        _container?.GetConnectionString()
+        ?? throw new InvalidOperationException("Le conteneur Postgres n'est pas initialise.");
+
+    public async Task InitializeAsync()
+    {
+        _container = new PostgreSqlBuilder("postgres:18")
+            // true = port hote ALEATOIRE : plusieurs sessions coexistent sans collision
+            .WithPortBinding(5432, true)
+            .WithUsername("tests")
+            .WithPassword("password")
+            .WithDatabase("genai_tests")
+            .WithWaitStrategy(
+                Wait.ForUnixContainer()
+                    .UntilMessageIsLogged("database system is ready to accept connections")
+                    .UntilInternalTcpPortIsAvailable(5432))
+            .WithAutoRemove(true)
+            .Build();
+
+        await _container.StartAsync();
+
+        // Schema : EnsureCreated suffit ici (pas de migrations evolutives a
+        // rejouer dans un conteneur jetable).
+        await using var context = new TranscriptionDbContext(EnsureOptions());
+        await context.Database.EnsureCreatedAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_container is not null)
+        {
+            await _container.DisposeAsync();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/PgTransactionalTestBase.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/PgTransactionalTestBase.cs
@@ -1,0 +1,37 @@
+using IntegrationTests.Data;
+using Microsoft.EntityFrameworkCore.Storage;
+using TUnit.Core;
+
+namespace IntegrationTests;
+
+/// <summary>
+/// Base transactionnelle : chaque test s'execute dans SA transaction, ouverte
+/// en [Before(Test)] et ROLLBACKEE en [After(Test)]. Aucun test ne laisse de
+/// ligne derriere lui — l'etat de depart (base vide) est un invariant, et les
+/// tests peuvent tourner en parallele sur le meme conteneur.
+/// </summary>
+public abstract class PgTransactionalTestBase(PgDatabaseFixture pg)
+{
+    private IDbContextTransaction? _transaction;
+
+    // TUnit instancie la classe pour CHAQUE test : le champ est frais a chaque fois
+    protected TranscriptionDbContext Context = pg.CreateContext();
+
+    [Before(Test)]
+    public async Task BeginTransaction()
+    {
+        _transaction = await Context.Database.BeginTransactionAsync();
+    }
+
+    [After(Test)]
+    public async Task RollbackTransaction()
+    {
+        if (_transaction is not null)
+        {
+            await _transaction.RollbackAsync();
+            await _transaction.DisposeAsync();
+        }
+
+        await Context.DisposeAsync();
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/SmokeTest.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/SmokeTest.cs
@@ -1,0 +1,19 @@
+using TUnit.Core;
+
+namespace IntegrationTests;
+
+/// <summary>
+/// Fumigenne : prouve que le harnais TUnit + Microsoft Testing Platform est
+/// cable (sans base) — premier reflexe quand on echafaude un projet de tests.
+/// </summary>
+public class SmokeTest
+{
+    [Test]
+    public async Task SmokeTest_Harness_IsWired()
+    {
+        // Valeur non constante (le linter TUnit refuse les assertions
+        // constantes) : si cette ligne passe, le runner a bien execute du
+        // code utilisateur.
+        await Assert.That(DateTime.UtcNow.Year).IsGreaterThanOrEqualTo(2026);
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/TranscriptionJobTests.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/TranscriptionJobTests.cs
@@ -1,0 +1,81 @@
+using IntegrationTests.Data;
+using Microsoft.EntityFrameworkCore;
+using TUnit.Core;
+
+namespace IntegrationTests;
+
+/// <summary>
+/// Tests d'integration EF Core + Postgres reel (conteneur Testcontainers),
+/// isoles par rollback transactionnel. Convention de nommage trois parties :
+/// Entite_Etat_Testee_Comportement_Attendu.
+/// </summary>
+[ClassDataSource<PgDatabaseFixture>(Shared = SharedType.PerTestSession)]
+public class TranscriptionJobTests(PgDatabaseFixture pg) : PgTransactionalTestBase(pg)
+{
+    [Test]
+    public async Task TranscriptionJob_WriteThenRead_RoundTrips()
+    {
+        Context.Jobs.Add(new TranscriptionJob
+        {
+            FileName = "echantillon-test-fr.wav",
+            Model = "faster-whisper-large-v3-turbo",
+            DurationSeconds = 12.5,
+            Status = "Done",
+        });
+
+        await Context.SaveChangesAsync();
+
+        Context.ChangeTracker.Clear(); // relecture forcee depuis la base
+
+        var job = await Context.Jobs.FirstOrDefaultAsync();
+
+        await Assert.That(job).IsNotNull();
+        await Assert.That(job!.FileName).IsEqualTo("echantillon-test-fr.wav");
+        await Assert.That(job.Id).IsNotEqualTo(Guid.Empty); // genere par le serveur
+    }
+
+    [Test]
+    public async Task TranscriptionJob_AfterEachRollback_TableIsStillEmpty()
+    {
+        // Preuve d'isolation : meme si WriteThenRead (ou n'importe quel test
+        // execute avant/apres en parallele) a COMMITTE dans SA transaction,
+        // la table est vide ici — les lignes non commitees sont invisibles,
+        // et chaque transaction est rollbackee a la fin de son test.
+        var count = await Context.Jobs.CountAsync();
+
+        await Assert.That(count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task TranscriptionJob_DuplicateFileName_RejectedByUniqueIndex()
+    {
+        Context.Jobs.Add(new TranscriptionJob { FileName = "doublon.wav", Model = "m", Status = "Pending" });
+        await Context.SaveChangesAsync();
+
+        Context.ChangeTracker.Clear();
+        Context.Jobs.Add(new TranscriptionJob { FileName = "doublon.wav", Model = "m", Status = "Pending" });
+
+        // L'index UNIQUE pose dans TranscriptionJobConfiguration doit parler :
+        // le SAVEINSERT leve DbUpdateException, la transaction est rollbackee.
+        await Assert.ThrowsAsync<DbUpdateException>(async () =>
+            await Context.SaveChangesAsync());
+    }
+
+    [Test]
+    public async Task TranscriptionJob_StatusUpdate_PersistsWithinTransaction()
+    {
+        var job = new TranscriptionJob { FileName = "maj.wav", Model = "m", Status = "Pending" };
+        Context.Jobs.Add(job);
+        await Context.SaveChangesAsync();
+
+        Context.ChangeTracker.Clear();
+        var stored = await Context.Jobs.SingleAsync(j => j.FileName == "maj.wav");
+        stored.Status = "Done";
+        await Context.SaveChangesAsync();
+
+        Context.ChangeTracker.Clear();
+        var reloaded = await Context.Jobs.SingleAsync(j => j.FileName == "maj.wav");
+
+        await Assert.That(reloaded.Status).IsEqualTo("Done");
+    }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/global.json
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/IntegrationTests/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/MyIA.AI.Notebooks/GenAI/Aspire/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/README.md
@@ -1,10 +1,13 @@
 # Aspire — orchestrer notre pile GenAI en C#
 
-Dossier des grains **#10838** et **#10857** de l'Epic **#10473** — *The Unexpected AI Stack: C#/.NET*.
+Dossier des grains **#10838** et **#10857** de l'Epic **#10473** — *The Unexpected AI Stack: C#/.NET*,
+et des grains 1-3 de la digestion **#11516** (Parts 3-5 de la même série).
 Ligne de parité #10838 : « **Isolation de ports par worktree** : à la main →
 **`aspire run --isolated`** ». Ligne de parité #10857 : « **Modéliser la pile
 réelle multi-machines dans un AppHost unique** : endpoints externes référencés
-(ComfyUI, vLLM) + conteneurs orchestrables (whisper-api) ».
+(ComfyUI, vLLM) + conteneurs orchestrables (whisper-api) ». Grain 2 #11516 :
+« **Tests d'intégration modernes** : Testcontainers + TUnit + rollback — le
+paradigme de test absent du dépôt, démontré réel ».
 
 ## Contenu
 
@@ -16,6 +19,8 @@ réelle multi-machines dans un AppHost unique** : endpoints externes référenc�
 | [`GenAiStackReel.AppHost-wt2/apphost.cs`](GenAiStackReel.AppHost-wt2/apphost.cs) | Copie pour la 2e instance isolée |
 | [`01-Aspire-Orchestration-GenAi.ipynb`](01-Aspire-Orchestration-GenAi.ipynb) | Notebook .NET Interactive : lancement `--isolated` de **deux instances simultanées**, `aspire describe`/`logs`, transcription réelle par le service orchestré, 3 exercices |
 | [`02-Aspire-GenAiStack-Reel.ipynb`](02-Aspire-GenAiStack-Reel.ipynb) | Notebook #10857 : deux instances isolées de la pile réelle, `describe`/`logs`, **appels traversants authentifiés** (complétion vLLM `qwen3.6-35b-a3b`, `system_stats` ComfyUI), 3 exercices |
+| [`05-Aspire-Tests-Integration.ipynb`](05-Aspire-Tests-Integration.ipynb) | Notebook #11516 Grain 2 (axes A5/A6/A7) : **tests d'intégration modernes** — TUnit + Microsoft Testing Platform, Testcontainers Postgres 18 jetable à port aléatoire, isolation par rollback transactionnel, filtres `--treenode-filter`, 3 exercices |
+| [`IntegrationTests/`](IntegrationTests/) | Projet de tests auto-contenu (TUnit 1.65 + Testcontainers.PostgreSql 4.14 + EF Core 10 sur `net10.0`) : `dotnet test` démarre un vrai Postgres 18, 5/5 tests verts, conteneur auto-purgé |
 | [`assets/echantillon-test-fr.wav`](assets/echantillon-test-fr.wav) | Échantillon audio FR de test (synthèse SAPI Windows) envoyé au service orchestré |
 
 ## Prérequis
@@ -25,6 +30,7 @@ réelle multi-machines dans un AppHost unique** : endpoints externes référenc�
 - GPU NVIDIA (le conteneur exige `--gpus all` ; la config est dans l'AppHost, `CUDA_VISIBLE_DEVICES=1` = RTX 3090 externe)
 - Cache HuggingFace hôte contenant le modèle `faster-whisper-large-v3-turbo` (sinon, premier appel = téléchargement ~1.6 Go, une seule fois)
 - Pour le notebook 02 (#10857) : la **pile réelle** joignable — conteneur `comfyui-qwen` démarré (8188) et `VLLM_API_KEY` rendu dans `GenAI/.env` (modèle : [`.env.example`](../.env.example)) via `scripts/secrets/render_envs.py` depuis `master.env`
+- Pour le notebook 05 / `IntegrationTests/` (#11516 Grain 2) : Docker suffit — l'image `postgres:18` est tirée au premier `dotnet test` (~30 s), les conteneurs de test s'auto-purgent
 
 ## Démarrage rapide
 
@@ -56,5 +62,6 @@ sans collision — ports randomisés, noms de conteneurs suffixés.
 ## Voir aussi
 
 - Issue [#10838](https://github.com/jsboige/CoursIA/issues/10838) · Issue [#10857](https://github.com/jsboige/CoursIA/issues/10857) · Epic [#10473](https://github.com/jsboige/CoursIA/issues/10473)
+- Digestion [#11516](https://github.com/jsboige/CoursIA/issues/11516) (Parts 3-5 : streaming agent, tests d'intégration, observabilité) — série source [chrlschn.dev](https://chrlschn.dev/blog/2026/08/the-unexpected-ai-stack-csharp-dotnet-part-4/)
 - Grain #10474 : backend d'observabilité OTLP [`aspire-otel/`](../SemanticKernel/aspire-otel/) (même pattern SDK file-based)
 - Pile GenAI : [`docker-configurations/`](../../../docker-configurations/)


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2026:CoursIA — prev: DEEP/lean #11552

See #11516

## Summary

**Grain 2 (axes A5 + A6 + A7)** de la digestion #11516 (Part 4 de la série source *The Unexpected AI Stack: C# + .NET*) — le paradigme de test absent du dépôt (sonde #11516 : TUnit/Testcontainers 0 usage réel, xUnit/vitest partout), démontré **réellement exécuté**.

**Cross-lane pickup** : G2 était l'intention de po-2024 mais Docker y est UAC-blocked ([ASK USER] en attente, dashboard). Docker 29.7.2 vérifié opérationnel sur po-2026 — claim paths-scopé posé sur #11516 (comment 5321485908) avec note de courtoisie/restitution.

## Livrables

| Élément | Contenu |
|---|---|
| `IntegrationTests/` | Projet auto-contenu `net10.0` : **TUnit 1.65 + Testcontainers.PostgreSql 4.14 + EF Core 10** (Npgsql + NamingConventions). Domaine GenAI : `TranscriptionJob` (trophée de la série whisper) |
| `PgDatabaseFixture.cs` | Postgres 18 **jetable** : port hôte **aléatoire** (`WithPortBinding(5432, true)`), wait strategy **double** (log + TCP), `WithAutoRemove`, un conteneur par session (`ClassDataSource` `PerTestSession`) |
| `PgTransactionalTestBase.cs` | Isolation A7 : `[Before(Test)]` BeginTransaction / `[After(Test)]` Rollback — chaque test repart d'une base intacte |
| Tests | 5/5 : smoke + CRUD round-trip + **preuve d'isolation** (table vide coexiste avec le test qui écrit) + **index UNIQUE vérifié par le vrai serveur** + update in-transaction |
| `05-Aspire-Tests-Integration.ipynb` | Notebook .NET Interactive FR : les 3 axes réellement exécutés, filtres `--treenode-filter` validés (classe `…/*` et méthode `…*`), 3 exercices stubs C.1 |
| README Aspire | Ligne 05 + prereq Docker + lien série source |

## Preuves d'exécution (H.1 / D)

- `dotnet test` : **`total : 5, réussie : 5`** sur conteneur Postgres 18 réel (10 s à chaud, ~29 s à froid tirage d'image compris) — sortie complète dans le notebook cell « L'exécution COMPLETE ».
- Filtres treeNode (runner natif `dotnet run --`, le pont `dotnet test` les refuse sur .NET 10) : classe `/IntegrationTests/IntegrationTests/SmokeTest/*` → `total: 1` ; les 4 tests TranscriptionJob → `total: 4`.
- **Éphémérité prouvée** : `docker ps -a --filter ancestor=postgres:18` → `(vide)` après le run.
- Notebook : **11 cellules code, `execution_count` 1..11 complet, 0 erreur, 0 NotImplementedError** (verdict `EXEC_PROVED`), exécuté via nbclient kernel `.net-csharp` natif.
- **0 chemin machine dans les outputs** : projection `TestShell.Clean` définie à la source (drop des lignes portant le repo root) + banner probeAddresses strippée (normalisation autorisée) — vérifié par sonde `C:\`/`AppData`/`fe80::` = 0 hit.
- MTP .NET 10 : `global.json` `test.runner` requis (le pont VSTest de `dotnet test` est retiré du SDK 10) — documenté dans le notebook §1.

## Points d'attention

- `README.md` : conflit de contexte possible avec #11530 (03) et #11537 (04) qui touchent aussi le README Aspire (tous OPEN) — je rebase cette PR après leur merge si besoin.
- Le projet est **auto-contenu** (domaine dans le projet de test, pas de référence à un projet serveur) : justifié par le périmètre du grain (démonstration du paradigme), la série n'ayant pas de projet serveur partagé.
- Pas de `Closes` : contribution à l'epic #11516 (grain 2/3 livrés, grain 1 par po-2024 en revue).

## SOTA (§H)

Vrai outil partout : vraie image Docker `postgres:18`, vrai serveur EF Core + Npgsql (contrainte UNIQUE vérifiée par le serveur, pas un mock), vrai runner TUnit/MTP. Aucune sortie fabriquée.