### PR TITLE
feat(twin-parity,#11200): bascule native-both Vague 2 -- 7 paires ML.NET/Python

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-1-introduction.yaml
@@ -2,10 +2,15 @@
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-1-Introduction.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 736ca5bc84443703871b0889ec8fe8413b5246c3
+      csharp_sha: badb7ba30e145498996a823e9d2b69e8fb31ea1a
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft.ML (moteur ML SOTA de l'ecosysteme .NET), Python atteint scikit-learn/lightgbm (moteurs ML SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant."
     - date: "2026-07-31"
       by: myia-po-2024:CoursIA-2
       python_sha: 736ca5bc84443703871b0889ec8fe8413b5246c3

--- a/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-2-data-features.yaml
@@ -2,10 +2,15 @@
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-2-Data&Features.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 101ab5a0f5a70557bcddc84c4ebfebadbb8ecc64
+      csharp_sha: 2a158cc55996dead23a76fd0f495efc6f17e6ff0
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft.ML (moteur ML SOTA de l'ecosysteme .NET), Python atteint scikit-learn/lightgbm (moteurs ML SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant."
     - date: "2026-08-02"
       by: myia-po-2024:CoursIA-2
       python_sha: 101ab5a0f5a70557bcddc84c4ebfebadbb8ecc64

--- a/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-3-entrainement-automl.yaml
@@ -2,10 +2,15 @@
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-3-Entrainement&AutoML.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 98273947fbf527c3d46e44760a5f8ba849433e1a
+      csharp_sha: 58f6ae3832011e841390b35858288e9c51eeb3e5
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft.ML (moteur ML SOTA de l'ecosysteme .NET), Python atteint scikit-learn/lightgbm (moteurs ML SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant."
     - date: "2026-07-31"
       by: myia-po-2024:CoursIA-2
       python_sha: 695da4960a0c19888c1e5917040ed84d5ee520be

--- a/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-4-evaluation.yaml
@@ -2,10 +2,15 @@
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-4-Evaluation.ipynb
-  parity_level: surface
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 2d84290fefedd8f816a737a8de1f270c2a4a328b
+      csharp_sha: 92b4291a20d6eb88ec9d57ca862419d518c2f87f
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft.ML (moteur ML SOTA de l'ecosysteme .NET), Python atteint scikit-learn/lightgbm (moteurs ML SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant."
     - date: "2026-08-02"
       by: myia-po-2024:CoursIA-2
       python_sha: 2d84290fefedd8f816a737a8de1f270c2a4a328b

--- a/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-7-recommendation.yaml
@@ -2,10 +2,15 @@
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-7-Recommendation.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 77524721813b30cc81946ec94cf4f9ed6c69531a
+      csharp_sha: 539b615ca402254cff49b8d895bbacb7f4236c75
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft.ML (moteur ML SOTA de l'ecosysteme .NET), Python atteint scikit-learn/lightgbm (moteurs ML SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant."
     - date: "2026-08-01"
       by: myia-po-2024:CoursIA-2
       python_sha: 77524721813b30cc81946ec94cf4f9ed6c69531a

--- a/scripts/notebook_tools/twin_pairs.d/ml-8-clustering.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-8-clustering.yaml
@@ -2,10 +2,15 @@
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-8-Clustering.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 98249788bd0a3541acd82d2f47e1dd645ac154b1
+      csharp_sha: 9406692311322fed00c51c257131dfe204399768
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft.ML (moteur ML SOTA de l'ecosysteme .NET), Python atteint scikit-learn/lightgbm (moteurs ML SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant."
     - date: "2026-07-31"
       by: myia-po-2023:CoursIA
       python_sha: 98249788bd0a3541acd82d2f47e1dd645ac154b1

--- a/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/ml-9-anomaly-detection.yaml
@@ -2,10 +2,15 @@
   family: ML.NET/Python
   python: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection-Python.ipynb
   csharp: MyIA.AI.Notebooks/ML/ML.Net/ML-9-Anomaly-Detection.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib #10382 (moteurs distincts, chacun prod) : C# = Microsoft.ML (NuGet officiel Microsoft.ML, native .NET : Microsoft.ML.Transforms/Regression/Clustering/TimeSeries) et Python = scikit-learn (pip sklearn, native Python) -- chaque cote atteint le moteur SOTA ML de son ecosysteme, ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML refs + execution_count, Python sklearn imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 060c0e79c3e5c800eee790bddccf0f1462cce4d7
+      csharp_sha: 90a7e5d2452e029ec98a1e1b331492a17ba843a1
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft.ML (moteur ML SOTA de l'ecosysteme .NET), Python atteint scikit-learn/lightgbm (moteurs ML SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant."
     - date: "2026-08-04"
       by: myia-po-2024:CoursIA-2
       python_sha: 060c0e79c3e5c800eee790bddccf0f1462cce4d7


### PR DESCRIPTION
## Summary

Vague 2 du balayage **Option A** (parité de moteur, lib-vs-lib — arbitrage ai-01 2026-08-16 sur #11200) : bascule `parity_level: semantic/surface -> native-both` sur les **7 paires ML.NET/Python** du registre twin (`ml-1/2/3/4/7/8/9`).

Chaque côté atteint le moteur ML SOTA de son écosystème :
- **C#** = `Microsoft.ML` (moteur ML officiel .NET : Transforms/Regression/Clustering/TimeSeries)
- **Python** = `scikit-learn` / `lightgbm` (moteurs ML natifs Python)

Suite directe de la **Vague 1** #11465 (8 paires Search/Z3) — fichiers **disjoints**, même pattern d'audit. Suite du claim actif de `myia-po-2026:CoursIA-2` (2026-08-17T10:39Z sur #11200).

## Changes

- 7 fichiers `scripts/notebook_tools/twin_pairs.d/ml-*.yaml` : flip `parity_level` + entrée d'audit en tête des audits (date 2026-08-18, `python_sha`/`csharp_sha` frais `git ls-tree origin/main`, reason citant l'arbitrage).
- `bridge_verdict`, `bridge_verdict_reason`, `known_differences` : **inchangés** (le bridge était déjà documenté dans le verdict existant).

## Validation

- **Re-parse YAML 7/7 OK** après flip (`yaml.safe_load` sur chaque fichier, racine liste, `doc[0]`).
- **Scanner** (`scan_native_both_drift.py`, branche feature/c174-11200-twin-sweep) exécuté sur le checkout AVANT/APRÈS :
  - `TRIVIAL_BASCULE: 64 -> 57` (−7, exactement les 7 flips)
  - `ALREADY_NATIVE_BOTH: 37 -> 44` (+7)
  - Aucun autre compteur n'a bougé.
- Shas `ls-tree origin/main` frais par fichier (ml-1 736ca5bc/badb7ba3, ml-2 101ab5a0/2a158cc5, ml-3 98273947/58f6ae38, ml-4 2d84290f/92b4291a, ml-7 77524721/539b615c, ml-8 98249788/94066923, ml-9 060c0e79/90a7e5d2).
- Catalogue byte-identique à main (aucun fichier catalogue touché).

## État du balayage après cette vague

15/64 TRIVIAL_BASCULE traitées (V1 8 + V2 7). Restent : Probas 19, SemanticWeb 11, Sudoku 6, Tweety 6, Search 6, GameTheory 1 + SOLVER_FREE 12 + AMBIGUOUS 13 (ces deux dernières catégories nécessitent le scanner sur branche feature/c174-11200-twin-sweep à merger d'abord).

Grain: MED/twin-parity — lane myia-po-2026:CoursIA — prev: DEEP/notebook-dotnet #11557

See #11200
See #10382