### PR TITLE
enrich(genai,#11271): Video 01-1-Operations-Basics density 717 -> 1312 markdown-only

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-1-Video-Operations-Basics.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-1-Video-Operations-Basics.ipynb
@@ -332,6 +332,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "md-lecture-amorce",
+   "metadata": {},
+   "source": "### Lecture du résultat — amorçage\n\nLa cellule d'amorçage ci-dessus fait d'une pierre trois coups, et sa sortie le prouve :\n\n- **`Dependances: 13/13 disponibles`** : les helpers vidéo (`helpers_video.py`) et les treize\n  dépendances déclarées sont importés d'un bloc — le notebook ne découvrira pas une\n  bibliothèque manquante à mi-parcours, tout a été vérifié AVANT la première frame.\n- **`Mode : interactive, FPS : 24, Duree : 5s`** : les paramètres Papermill ont été digérés\n  (cellule 2). En mode `BATCH_MODE = \"true\"`, ces mêmes lignes afficheraient `batch` et la\n  cellule interactive (§6) se court-circuiterait sans erreur.\n- **`Sortie : ...outputs/video_basics`** : tous les artefacts produits dans ce notebook\n  (vidéos de test, frames extraites) atterrissent dans ce sous-dossier — jamais à côté des\n  sources. C'est le contrat de la série Video : le dossier de sortie est créé au besoin.\n\nL'horodatage (`08:05:43`) servira de référence : la cellule de statistiques finales\naffichera `08:05:47` — quatre secondes d'exécution utile pour tout le notebook."
+  },
+  {
+   "cell_type": "markdown",
    "id": "y61smzz1vyj",
    "metadata": {
     "papermill": {
@@ -461,6 +467,12 @@
     "    print(f\"Manquantes : {', '.join(missing)}\")\n",
     "    print(\"Les sections correspondantes seront sautees.\")\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-lecture-env",
+   "metadata": {},
+   "source": "### Lecture du résultat — environnement\n\nLa sortie raconte deux choses distinctes, à ne pas confondre :\n\n- **`Aucun fichier .env trouve dans l'arborescence`** n'est **pas** un échec : ce notebook\n  de fondations manipule des vidéos générées localement (CPU), il n'appelle aucun service\n  d'inférence distant. Les notebooks Video qui consomment une API (02-*) exigeront eux le\n  `.env` rendu par `scripts/secrets/render_envs.py` — ici, son absence est le comportement\n  attendu et le message le dit sans lever d'exception.\n- **`Dependances disponibles : 4/4`** : le quatuor cœur — `moviepy 2.1.2` (montage),\n  `ffmpeg-python` (sonde conteneur), `decord` (extraction rapide) et `imageio 2.37.2`\n  (assemblage) — est prêt. La version 2.1.2 de moviepy importe : c'est elle qui impose\n  l'API keyword-only que la cellule d'exercice 1 respecte.\n\nLa distinction importe pour la suite : l'échec d'une dépendance *optionnelle* (l'overlay\ntexte de la section 3) sera signalé dans la sortie mais ne bloquera pas le notebook."
   },
   {
    "cell_type": "markdown",
@@ -827,24 +839,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Exercice 1 : Concatenation avec transition en fondu\n",
-    "\n",
-    "Dans la Section 2, nous avons concatene deux clips bout a bout avec `concatenate_videoclips`. L'objectif de cet exercice est d'ajouter un effet de **fondu enchaine** (crossfade) entre deux segments video.\n",
-    "\n",
-    "**Contexte** : Les transitions fluidisent le montage video. Un fondu enchaine superpose la fin du clip A avec le debut du clip B pendant une courte duree.\n",
-    "\n",
-    "**Étapes** :\n",
-    "1. Decouper la video de test en 3 segments de durees egales\n",
-    "2. Appliquer un fondu sortant sur la fin de chaque segment (`clip.fadeout()`)\n",
-    "3. Appliquer un fondu entrant sur le debut du segment suivant (`clip.fadein()`)\n",
-    "4. Concatener les segments avec une transition de 0.5 seconde\n",
-    "\n",
-    "**Indices** :\n",
-    "- `clip.with_effects([vfx.FadeOut(duration)])` et `clip.with_effects([vfx.FadeIn(duration)])` dans moviepy 2.x\n",
-    "- La duree de transition doit etre inferieure a la duree du segment\n",
-    "- Utilisez `crossfadeout` / `crossfadein` pour un effet plus fluide"
-   ]
+   "source": "### Exercice 1 : Concatenation avec transition en fondu\n\nDans la Section 2, nous avons concatene deux clips bout a bout avec `concatenate_videoclips`. L'objectif de cet exercice est d'ajouter un effet de **fondu enchaine** (crossfade) entre deux segments video.\n\n**Contexte** : Les transitions fluidisent le montage video. Un fondu enchaine superpose la fin du clip A avec le debut du clip B pendant une courte duree.\n\n**Étapes** :\n1. Decouper la video de test en 3 segments de durees egales\n2. Appliquer un fondu sortant sur la fin de chaque segment (`clip.fadeout()`)\n3. Appliquer un fondu entrant sur le debut du segment suivant (`clip.fadein()`)\n4. Concatener les segments avec une transition de 0.5 seconde\n\n**Indices** :\n- `clip.with_effects([vfx.FadeOut(duration)])` et `clip.with_effects([vfx.FadeIn(duration)])` dans moviepy 2.x\n- La duree de transition doit etre inferieure a la duree du segment\n- Utilisez `crossfadeout` / `crossfadein` pour un effet plus fluide\n\n**Relevé chiffré de la sortie ci-dessus** : la source `5.00s` devient un segment\n`2.00s` (`trimmed.mp4`, 32,9 Ko en bilan) — moviepy a ré-encodé en conservant le FPS ;\nla concaténation `4.00s` est exactement `A (0-2s) + B (3-5s)` : la seconde centrale est\nabsente, c'est bien un montage et non une copie. L'**overlay texte** échoue\n(`TypeError: multiple values for argument 'font'`) et la sortie le documente comme\n*fonctionnalité optionnelle* : l'incident moviepy 2.x sur les polices est connu, la\ndégradation est honnête — le pipeline continue, et l'exercice 1 ci-dessous reprend ce\ngeste sur des bases compatibles."
   },
   {
    "cell_type": "code",
@@ -1078,6 +1073,12 @@
   },
   {
    "cell_type": "markdown",
+   "id": "md-lecture-probe",
+   "metadata": {},
+   "source": "### Lecture du résultat — la sonde ffmpeg\n\nLa sortie du probe est le « carte d'identité » du conteneur produit à la section 1, et\nses lignes se recoupent arithmétiquement :\n\n- **`Format : QuickTime / MOV`** : `imageio` a écrit l'extension `.mp4`, mais le conteneur\n  déclaré par ffmpeg est MOV — les deux partagent la famille ISO-BMFF ; c'est une\n  curiosité de conteneur, pas une incohérence de données.\n- **`Bitrate : 105 kbps` × `Duree : 5.00s`** redonne la taille observée :\n  105 000 bits/s × 5 s ÷ 8 ≈ 65,6 Ko, à rapprocher des **`64.1 KB`** pesés sur disque —\n  l'écart de ~2 % est l'en-tête du conteneur et l'arrondi du bitrate moyen. Quand les\n  trois nombres (bitrate, durée, taille) se répondent ainsi, la sonde est cohérente.\n- **`Nombre de flux : 1`** : uniquement la piste vidéo. Notre assemblage n'a produit ni\n  audio ni sous-titres — ajouter une piste audio ferait passer ce compteur à 2.\n\nRetenir le réflexe : **avant tout traitement, sonder** — la durée lue ici (`5.00s`) est\ncelle que le trimming de la section 3 découpe et que decord rééchantillonnera à la\nsection 4. Une seule source de vérité, interrogée trois fois par trois outils.\n\n**Relevé chiffré de la sortie ci-dessus** : `120 frames` générées en `0.18s`\n(numpy vectorisé), ~`105.5 MB` en mémoire vive contre **`64.1 KB`** sur disque — un ratio\nde ~1700× qui illustre pourquoi on écrit des vidéos et jamais des tableaux de frames.\nLa figure 5 axes ci-dessus échantillonne la timeline (t = 0, 3, 6, 9, 12 indices) : la\nrotation du dégradé y est visible, preuve visuelle que les frames ne sont pas identiques."
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-10",
    "metadata": {
     "papermill": {
@@ -1251,6 +1252,12 @@
     "    else:\n",
     "        print(\"Video de test non trouvee ou decord desactive\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-lecture-decord",
+   "metadata": {},
+   "source": "### Lecture du résultat — extraction decord\n\nLa sortie de cette section est la plus riche du notebook ; chaque bloc se lit :\n\n- **`Frames totales : 120`, `FPS moyen : 24.00`, `Duree estimee : 5.00s`** : decord a lu\n  les métadonnées SANS charger les pixels en mémoire — c'est sa force sur\n  `imageio.imread` en boucle. Les trois valeurs recoupent la sonde ffmpeg de la\n  section 3 : mêmes nombres, chemin différent.\n- **`Indices : [0, 17, 34, 51, 68, 85, 102, 119]`** : 8 frames *uniformément* espacées —\n  le pas ≈ 120/8 = 15, premier et dernier index inclusifs. La figure 8 axes ci-dessus\n  montre ce strip : la dérive du dégradé y est lisible de gauche à droite.\n- **Benchmark : `Sequential : 29.9ms` vs `Batch : 15.8ms` → `x1.9`** : demander les 8\n  frames en un seul appel `get_batch` est ~deux fois plus rapide que huit `next()`\n  successifs. Sur 8 frames c'est anecdotique ; sur 8 000 frames d'un clip réel,\n  le même facteur fait la différence entre « interactif » et « pause café ».\n  C'est LE argument de decord face à un lecteur naïf.\n\nLa shape `batch : (8, 480, 640, 3)` confirme la convention NHWC : la bibliothèque rend\nun tenseur prêt pour l'affichage matplotlib — sans transposition."
   },
   {
    "cell_type": "markdown",
@@ -1489,9 +1496,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Les frames ont ete extraites et visualisees. La cellule suivante propose une interface interactive pour choisir un instant spécifique de la video et afficher la frame correspondante."
-   ]
+   "source": "Les frames ont ete extraites et visualisees. La cellule suivante propose une interface interactive pour choisir un instant spécifique de la video et afficher la frame correspondante.\n\nLe rapport ci-dessous illustre le principe : sur les quatre dépendances déclarées,\ntrois ont déjà produit leur artefact — la quatrième (`imageio`) a servi silencieusement à\nl'assemblage. La session tient en trois fichiers dans `outputs/video_basics`, tous\nreproductibles en relançant le notebook."
   },
   {
    "cell_type": "code",
@@ -1584,6 +1589,12 @@
     "else:\n",
     "    print(\"\\nMode batch - Interface interactive desactivee\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-lecture-inter",
+   "metadata": {},
+   "source": "### Lecture du résultat — le mode interactif\n\nLa sortie est volontairement laconique : **`Mode interactif non disponible (execution\nautomatisee)`**. En `BATCH_MODE = \"true\"` (le défaut Papermill), la cellule remplace\nl'invite par ce message et rend la main immédiatement — pas d'erreur, pas d'attente :\nun notebook automatisé doit s'exécuter de bout en bout sans saisie humaine (règle C.1).\n\nPour explorer réellement : passer `notebook_mode = \"interactive\"` en cellule 2 (ou via\nles paramètres Papermill `--p notebook_mode interactive`) et relancer — la même cellule\nproposera alors de saisir un chemin vidéo任意, que l'analyseur de métadonnées de la\nsection 3 traitera. C'est le pattern de toute la série GenAI : **un code, deux régimes**\n(batch pour la validation continue, interactif pour l'apprentissage)."
   },
   {
    "cell_type": "markdown",
@@ -1698,6 +1709,12 @@
     "\n",
     "print(f\"\\nNotebook 01-1 Video Operations termine - {datetime.now().strftime('%H:%M:%S')}\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "md-lecture-stats",
+   "metadata": {},
+   "source": "### Lecture du résultat — bilan de session\n\nLes statistiques finales ferment la boucle ouverte à l'amorçage :\n\n- **Trois fichiers, ~152 Ko au total** : `test_video.mp4` (64,1 Ko, la source générée),\n  `trimmed.mp4` (32,9 Ko — 2 s de contenu), `concatenated.mp4` (55,0 Ko — 4 s). Les\n  tailles suivent les durées : le trim pèse environ la moitié de la source, la\n  concaténation un peu plus que le trim grâce au segment conservé. Le bitrate moyen\n  (~105 kbps) est conservé par moviepy à chaque ré-encriture.\n- **`Date : 08:05:47`** contre `08:05:43` à l'amorçage : quatre secondes pour générer,\n  monter, sonder et extraire — la vidéo 640×480 est un objet de laboratoire bon marché.\n- **`moviepy / ffmpeg-python / decord : utilisees`** : chaque dépendance cœur a tenu son\n  rôle exactement une fois (montage / sonde / extraction) ; `imageio` a servi à\n  l'assemblage initial sans apparaître dans ce récapitulatif.\n\nOù aller ensuite : `01-2-GPT-5-Video-Understanding` (comprendre une vidéo par API),\n`01-4-Video-Enhancement-ESRGAN` (sur-échantillonner ses frames) — ou l'exercice bonus\nci-dessous pour transformer ces manipulations en produit livrable."
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Tranche densité pédagogique #11271 : `GenAI/Video/01-Foundation/01-1-Video-Operations-Basics.ipynb` passe **717 → 1312** chars/cellule (plancher 1200). **Markdown-only** — les 13 cellules code sont byte-identiques (assert dans le script d'enrichissement), pas de re-execution nécessaire (exception C.2 markdown-only ; `execution_count` et outputs inchangés, hooks H.3 verts).

## Changes (+6 cellules markdown, 3 étoffements)

| Cellule ajoutée | Ancrage (faits tirés des outputs réels) |
|---|---|
| Lecture du résultat — amorçage | `Dependances: 13/13`, mode interactive FPS 24 / 5s, sortie `outputs/video_basics`, horodatage 08:05:43 |
| Lecture du résultat — environnement | `Aucun fichier .env` = attendu (rien à récupérer en fondations), 4/4 cœur dont moviepy 2.1.2 |
| Lecture du résultat — probe ffmpeg | recoupement arithmétique 105 kbps × 5 s ÷ 8 ≈ 65,6 Ko vs 64,1 KB pesés, 1 flux |
| Lecture du résultat — decord | indices pas ~15 sur 120 frames, batch (8,480,640,3), benchmark seq 29,9 ms vs batch 15,8 ms = ×1,9, convention NHWC |
| Lecture du résultat — interactif | `Mode interactif non disponible` = dégradation batch-safe volontaire (règle C.1), comment basculer |
| Lecture du résultat — bilan | 3 fichiers 152 Ko (64,1 + 32,9 + 55,0), tailles ∝ durées, 4 s d'exécution utile, chaque dépendance a tenu son rôle |
| Étoffements (3) | interprétation création (ratio mémoire 105,5 MB vs 64,1 KB ≈ 1700×), interprétation moviepy (trim 5→2 s, concat 4 s = trou supprimé, overlay TypeError dégradation honnête), transition stats |

## Validation

- `pedagogy_density.py` : **1312 ≥ 1200** (1 notebook scanned, 0 below).
- Code cells byte-identiques : assert `code_before == code_after` dans le script (13/13).
- `scan_cell_ordering.py` : **1 scanned, 0 finding** (interprétations APRÈS les cellules interprétées).
- Seul fichier touché : le notebook (worktree isolé, catalogue byte-identique à main).
- Claim paths-scopé posé AVANT édition : [issuecomment-5321885729](https://github.com/jsboige/CoursIA/issues/11271#issuecomment-5321885729) — 0 claim Video antérieur au ledger, G-VAR-3 OK (première livraison densité de cette lane, substance distincte des tranches Audio/Vibe-Coding des lanes C2).

## Cadre

- Pattern conforme aux tranches sœurs (#11542, #11543, #11558) : cap 1 notebook/famille/lane/jour respecté (1re tranche Video de cette lane).
- 15 notebooks Video restent sous le plancher (16 au scan − celle-ci) — veine ouverte pour les cycles suivants.

Grain: MED/notebook-genai-density — lane myia-po-2026:CoursIA — prev: MED/twin-parity #11559

See #11271