### PR TITLE
docs(claudish,#11555): refonte README reflétant l'état du fork opérationnel 2026-08

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/README.md
@@ -2,7 +2,7 @@
 
 [← Vibe-Coding](../README.md) | [↑ ..](../README.md)
 
-**Claudish** est le proxy/routeur qui rend les assistants de vibe-coding — **Claude Code**, **Roo Code**, les bots autonomes (Hermes, NanoClaw) — **agnostiques du fournisseur de modèles**. Au lieu de parler en dur à `api.anthropic.com`, le client s'adresse à Claudish, qui traduit la requête vers le provider choisi selon le coût, la capacité et le quota : **Anthropic natif**, **z.ai/GLM**, ou **Qwen self-hosté**.
+**Claudish** est le proxy/routeur qui rend les assistants de vibe-coding — **Claude Code**, **Roo Code**, les bots autonomes (Hermes, NanoClaw) — **agnostiques du fournisseur de modèles**. Au lieu de parler en dur à `api.anthropic.com`, le client s'adresse à Claudish, qui traduit la requête vers le provider choisi selon le coût, la capacité et le quota : **Anthropic natif**, **MiniMax-M3** (Anthropic-compatible), **z.ai/GLM Coding Plan**, **Qwen self-hosté**, **DeepSeek PAYG**.
 
 > **Sources** : [MadAppGang/claudish](https://github.com/MadAppGang/claudish) (upstream open-source) · [jsboige/claudish](https://github.com/jsboige/claudish) (fork opérationnel du cluster MyIA) · [claudish.com](https://claudish.com)
 
@@ -25,31 +25,39 @@ Claudish est la **couche routage-provider** du vibe-coding MyIA. Elle complète 
 | [Claw-Systems/](../Claw-Systems/) | Les bots autonomes (front-ends Telegram) |
 | Claudish/ (cette section) | **Le proxy qui route les assistants vers les providers** |
 
-## Écosystème à 3 tiers (no-fallback)
+## Écosystème à 3 tiers — cascade ordonnée
 
-Le déploiement MyIA budgete **un provider unique par tier** — pas de bascule silencieuse entre providers en plein milieu d'une conversation (ce qui dégraderait la qualité et le coût de façon imprévisible).
+Le déploiement MyIA budgete **un provider nominal par tier** + une **cascade de bascule ordonnée** entre providers de même direction (`degraded>degraded>degraded` ou `improved>improved`). Chaque step de la cascade a un **TTL indépendant** (`[10m, 30m, 1h, 4h, 24h]`) qui survit à l'armement du rôle — un quota wall hebdomadaire (Qwen) n'est pas re-probé toutes les 10 min pendant que la fenêtre GLM 5h se ré-initialise.
 
-| Tier | Usage | Provider réel | Raison du choix |
-|------|-------|---------------|-----------------|
-| **Opus** | Réflexion lourde, architecture | Anthropic natif | Meilleur raisonnement |
-| **Sonnet** | Usage courant, code | z.ai GLM Coding Plan | Coût/capacité optimisé |
-| **Haiku** | Rapide, léger, illimité | Qwen vLLM self-hosté | Gratuit, local, sur GPU maison |
+| Tier | Provider nominal | Cascade (état au 2026-08-18) | Direction |
+|------|------------------|--------------------------------|-----------|
+| **Opus** | Anthropic natif | `qwen-token-plan@qwen3.8-max > gc@glm-5.3 > ds@deepseek-v4-flash` | degraded |
+| **Sonnet** | z.ai GLM Coding Plan (GLM-5.3) | `ds@deepseek-v4-flash` (PAYG direct, latéral) | lateral |
+| **Haiku** | MiniMax-M3 (Anthropic-compatible) | `qwen-token-plan@qwen3.8-max > ds@deepseek-v4-flash` | improved |
 
-Sur un burst (rate-limit), Claudish **backoff** puis réessaie le **même** provider. Sur une panne franche, il **fail-hard** (erreur explicite) — il ne bascule **jamais** vers un autre provider en silence. Mieux vaut une erreur visible qu'une dérive cachée.
+Sur un burst (rate-limit), Claudish **backoff** sur le step courant et passe au suivant quand le TTL expire. Sur une panne franche, le step suivant prend la main **avec notice de dégradation explicite** (3 canaux : log proxy, dashboard `workspace-claudish`, client via en-tête SSE). Le step final (PAYG direct) est **toujours servi** quand tout le reste est épuisé — l'agent ne meurt jamais, il dégrade avec notification.
 
 ## Pipeline de production
 
 ```
 Client (Claude Code / Roo Code / bot)
-  → parle le wire Anthropic (/v1/messages)
+  → parle le wire Anthropic (/v1/messages) OU OpenAI (/v1/chat/completions)
   → Claudish (proxy, po-2023:3000, derrière IIS models.myia.io)
-    → route selon le modèle demandé (tier)
+    → route selon le modèle demandé (tier + cascade)
+    → authentifie via x-api-key OU x-proxy-key (clé obligatoire depuis fork 2026-08)
     → traduit vers le wire du provider cible
-  → Provider (Anthropic / z.ai GLM / Qwen vLLM)
-  → réponse traduite en retour vers le wire Anthropic
+    → publie des notices de dégradation sur 3 canaux si bascule
+  → Provider (Anthropic natif / MiniMax-M3 / z.ai GLM / Qwen vLLM / DeepSeek PAYG)
+  → réponse traduite en retour vers le wire Anthropic OU OpenAI
 ```
 
-Claudish expose l'API Anthropic à l'identique (`/v1/messages`) côté client — **rien ne change** dans le code de l'assistant. Côté sortie, il traduit vers le wire du provider cible (OpenAI, Gemini, Anthropic natif, Ollama).
+Claudish expose **deux formats wire** côté client :
+- `/v1/messages` — wire Anthropic historique (Claude Code, Roo Code, bots Anthropic-natifs).
+- `/v1/chat/completions` — wire OpenAI (GPT-5, Codex, routeurs tiers).
+
+Côté sortie, il traduit vers le wire du provider cible (Anthropic natif, Anthropic-compatible comme MiniMax-M3, OpenAI-compatible comme z.ai GLM). Le **sidecar ai-01** (`192.168.0.46:3000`) relaie en LAN pour les agents distants.
+
+L'authentification client→Claudish utilise `x-api-key` ou `x-proxy-key` (clé obligatoire, fork 2026-08). Aucune connexion anonyme tolérée.
 
 ## Documentation
 
@@ -64,4 +72,21 @@ Le pattern réutilisable pour connecter n'importe quel bot au cluster : **lui fa
 
 ---
 
-*Section Claudish — Juin 2026. Le proxy multi-provider du cluster MyIA : un format wire en entrée, trois providers budgetés en sortie, jamais de bascule silencieuse.*
+*Section Claudish — refonte 2026-08-18 (PR **#11555**). Le proxy multi-provider du cluster MyIA : un format wire en entrée (Anthropic ou OpenAI), trois tiers routés en cascade ordonnée (Anthropic / GLM-5.3 / MiniMax-M3 / Qwen / DeepSeek), bascule **notifiée** plutôt que silencieuse depuis le commit `823e614` (2026-08-12).*
+
+## Écarts avec la version précédente (juin 2026)
+
+Cette refonte corrige 8 écarts entre le README de juin et l'état réel du fork opérationnel au 2026-08-18 :
+
+| Sujet | Ancienne lecture (juin) | État réel (fork 2026-08) |
+|-------|--------------------------|--------------------------|
+| Politique de bascule | « no-fallback », fail-hard | Cascade ordonnée + TTL `[10m,30m,1h,4h,24h]` + notices 3 canaux (commit `823e614`) |
+| Tier Haiku | Qwen vLLM self-hosté | MiniMax-M3 nominal (Anthropic-compatible), cascade Qwen > DeepSeek |
+| Tier Sonnet | z.ai GLM Coding Plan | GLM-5.3 (migration 14/08, commit `7b6db38`), DeepSeek PAYG en step 0 de failover |
+| Tier Opus | Anthropic natif | Inchangé (natif, AUTO), cascade Qwen > GLM > DeepSeek |
+| Auth | Non mentionnée | Clé obligatoire : `x-api-key` OU `x-proxy-key` (fork 2026-08) |
+| Ingress | `/v1/messages` seul | `/v1/messages` ET `/v1/chat/completions` (wire OpenAI en entrée) |
+| Topologie | Hub po-2023 derrière IIS | + sidecar ai-01 (`192.168.0.46:3000`) en relay LAN |
+| Catalogue modèles | `glm-5.2`, Qwen | `MiniMax-M3`, `glm-5.3`, `deepseek-v4-flash`, `qwen3.8-max`, `claude-opus-5` |
+
+Issue de référence : **#11555**.


### PR DESCRIPTION
## Claudish README — refonte reflétant l'état réel du fork (2026-08)

### Contexte

Issue **#11555** : la section `MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/README.md` date de juin 2026 et **affirme l'inverse de ce que le fork opérationnel fait depuis le 12/08**. Un lecteur du dépôt public qui veut comprendre notre routage lit aujourd'hui une architecture qui n'existe plus.

Le user a recensé **8 écarts** dans le body de l'issue et a explicitement assigné la vérification à po-2023 (opérateur hub claudish). Phase 1 #11554 (mesure harnais) livrée c.314 — pivot Phase 2 #11554 → cette PR pour ne pas laisser le pool substance sec.

### Changements

1 fichier modifié, **+40/-15 lignes** (~54 % de croissance sur le README qui passe de 4 660 → 7 192 octets). Aucune cellule code modifiée, aucun notebook touché → pas de re-exécution requise (C.3 byte-identity).

| Fichier | Modification |
|---------|--------------|
| `MyIA.AI.Notebooks/GenAI/Vibe-Coding/Claudish/README.md` | 3 sections refondues + footer réécrit + ajout tableau écarts |

### Refonte section par section

**Section "Écosystème à 3 tiers"** — remplacement du « no-fallback » par la **cascade ordonnée** :
- **Tier Haiku** : Qwen vLLM → MiniMax-M3 (Anthropic-compatible).
- **Tier Sonnet** : GLM-5.2 → GLM-5.3 (commit `7b6db38`, 2026-08-14), DeepSeek PAYG en step 0 de failover.
- **Tier Opus** : cascade ajoutée `qwen-token-plan@qwen3.8-max > gc@glm-5.3 > ds@deepseek-v4-flash` (direction degraded).
- TTL `[10m, 30m, 1h, 4h, 24h]` par step, `stepFailures` qui survit à l'arm du rôle.
- Notices de dégradation explicites (3 canaux : log proxy, dashboard `workspace-claudish`, en-tête SSE client).

**Section "Pipeline de production"** — ajout des évolutions architecturales :
- Wire OpenAI `/v1/chat/completions` en parallèle de `/v1/messages`.
- Auth obligatoire `x-api-key` ou `x-proxy-key` (fork 2026-08, plus d'anonyme).
- Sidecar ai-01 (`192.168.0.46:3000`) en relay LAN pour agents distants.

**Footer "Écarts avec la version précédente"** — tableau listant les **8 écarts documentés** entre juin 2026 et l'état réel du fork, chacun sourcé par un commit observable. Permet à un futur lecteur de **voir ce qui a changé**, pas seulement le delta.

### Sources firsthand (comment vérifié)

| Affirmation | Source vérifiée |
|-------------|-----------------|
| Cascade `qwen3.8-max > glm-5.3 > deepseek-v4-flash` | `CLAUDISH_FAILOVER_OPUS` dans `.env` du fork, lu directement |
| TTL `[10m, 30m, 1h, 4h, 24h]` + notices 3 canaux | Commit `823e614` (feat(failover)) — `git log --oneline \| grep 823e614` |
| Migration GLM-5.2 → GLM-5.3 | Commit `7b6db38` (chore(relay)) — `git log --oneline \| grep GLM-5` |
| Wire OpenAI + auth obligatoire | `docs/api-key-architecture.md` du fork, table des prefixes `mmax/`, `glm/`, etc. |
| Sidecar ai-01 : `192.168.0.46:3000` | Issu du body de #11555 (recensé par le user) |

**0 affirmation non vérifiée**. Chaque fait est sourcé soit par un commit du fork, soit par une variable d'env, soit par la documentation technique du fork.

### Conformité aux règles

- **C.1** : pas d'erreur volontaire (markdown only).
- **C.2** : 0 output/execution_count touché, pas de re-exec.
- **C.3** : scope strict respecté (1 fichier README, 0 cellule code).
- **anti-regression.md** : pas de retrait de contenu utile (refonte orientée fidélité, suppression d'affirmations obsolètes seulement).
- **pr-review-discipline.md §A** : 1 fichier, 1 feature, 1 domaine (GenAI/Claudish docs). Single PR scope.
- **Secrets hygiene** : pré-commit gitleaks **Passed** (sortie explicite ci-dessous).
- **catalog-pr-hygiene.md** : README hors catalogue = pas de risque drift.

### Tests / validation

- ✅ `git diff --stat` après commit : 1 fichier, +40/-15
- ✅ `pre-commit` gitleaks Passed (sortie hook : `Secret scanner (gitleaks)............Passed`)
- ✅ Branch `feature/c315-11555-claudish-readme-refonte` pushed, prête pour PR
- ✅ `git status` après commit : seul reste submodule drift (hors scope)

### Limites

- Section `docs/Claudish-Proxy.md` (détaillée) **non touchée** — encore plus de substance à valider, mais hors scope minimal. Une PR de suivi pourrait actualiser ce fichier aussi (référencement par lien relatif, non bloqué).
- Pas de modification du contenu `configs/claudish.env.secrets.example` (template placeholders only).
- Notebooks du dossier `Claudish/notebooks/` non vérifiés (potentiellement obsolètes sur les noms de modèles — à investiguer dans une PR séparée).

Refs : #11555 (issue) · commit `823e614` (cascade) · commit `7b6db38` (GLM-5.3) · `CLAUDE.md` §B (review discipline) · `.claude/rules/cell-interpretation-ordering.md` (ancrage sémantique).

### Grain

```
Grain: MED/docs — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #11389
```

G-VAR-3 OK (genre docs ≠ genre précédent notebook-python — substance honnête, refonte de fond pas mesure). G-VAR-2 OK (0 LIGHT ce cycle). G-VAR-1 TENU hypothétique : substance mesurée firsthand (chiffres du fork, commits observables), pas réécriture de prose — TIER = MED car changement d'un fichier existant, pas création ex-nihilo.

