### PR TITLE
feat(notebook,#11224): QC-Py-Cloud-01-FinBERT-Sentiment density 1010 → 1305

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb
@@ -93,6 +93,14 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture du résultat** : la cellule d'initialisation confirme que l'environnement NumPy + Matplotlib + IPython.display est opérationnel. Le style `seaborn-v0_8-whitegrid` sera appliqué à tous les graphiques du notebook (sentiment vs rendement, distribution des scores). Sans ce préambule vert, les cellules de visualisation en aval lèveraient un `NameError` sur `plt` ; il est volontairement placé en tête de notebook pour court-circuiter ce piège d'exécution. Les exercices étudiants (Partie 6) peuvent réutiliser ces imports tels quels."
+   ],
+   "id": "c0020"
+  },
+  {
+   "cell_type": "markdown",
    "id": "c0004",
    "metadata": {
     "papermill": {
@@ -740,6 +748,14 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture du résultat** : l'algorithme QC FinBERT pèsé par le notebook fait **10110 caractères sur 302 lignes**, de la déclaration `#region imports` jusqu'à l'instruction de liquidation `self.liquidate(self._target_symbol)`. Cette volumétrie est cohérente avec une stratégie complète incluant : (1) filtrage d'univers via `FineFundamental`/`MarketCap`, (2) chargement des actualités Tiingo via `self.AddData(...)`, (3) inférence FinBERT en schedulé `Every(Days)`, (4) agrégation par fenêtre glissante, et (5) déclenchement d'ordres `MarketOrder` selon les seuils `>0.2` / `<-0.2`. Le ratio `caracteres/lignes ≈ 33` reflète un code dense, principalement composé de logique conditionnelle plutôt que de commentaires."
+   ],
+   "id": "c0021"
+  },
+  {
+   "cell_type": "markdown",
    "id": "c0012",
    "metadata": {
     "papermill": {
@@ -913,6 +929,14 @@
     "print(\"Note : Deployez l'algorithme via MCP pour obtenir les resultats reels.\")\n",
     "print('Voir Partie 4 pour le workflow de deploiement complet.')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture du résultat** : les métriques du backtest sont toutes à `None` (Sharpe, CAGR, Max Drawdown, Total trades, Win rate), avec le statut `En attente de deploiement Cloud`. C'est attendu : le notebook affiche des **placeholders** tant que l'algorithme n'a pas été exécuté via MCP sur les serveurs QuantConnect. La partie 4 détaille le workflow `create_compile` -> `create_backtest` -> `read_backtest` qui viendra peupler ces champs. Tant que ce déploiement n'est pas fait, **toute conclusion quantitative est prématurée** ; on ne peut que commenter la structure de la stratégie. C'est précisément la limite d'un notebook pédagogique local : la valeur du moteur SOTA (FinBERT) ne se révèle qu'en environnement Cloud."
+   ],
+   "id": "c0022"
   },
   {
    "cell_type": "markdown",
@@ -1120,6 +1144,14 @@
     "for row in summary:\n",
     "    print(f'  {row[0]:<25}: {row[1]}')\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Lecture du résultat** : le tableau récapitulatif confirme les paramètres-clés de la stratégie : **score sentiment = P(pos) − P(neg)**, seuils d'entrée à `+0.2` / sortie à `-0.2`, fenêtre d'agrégation sur les **5 derniers articles**, rééquilibrage hebdomadaire, univers restreint aux **top 10 actions tech par market cap**, période 2019-2025, capital initial $100,000, et déploiement **MCP QuantConnect Cloud-native** (pas d'exécution locale). Ces seuils volontairement asymétriques (`±0.2`) sont un compromis entre réactivité (capture des retournements) et faux signaux (bruit NLP). Les exercices 1-3 vous amènent à faire varier ces paramètres et à observer l'impact sur la robustesse."
+   ],
+   "id": "c0023"
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/lean #11564

# QC-Py-Cloud-01-FinBERT-Sentiment — enrichissement markdown densité (1010 → 1305)

## Résumé

`QC-Py-Cloud-01-FinBERT-Sentiment.ipynb` (tranche QC family density EPIC #11224)
était à **densité 1010** (sous le seuil 1200 de `pedagogy_density.py`). Cette PR
insère **4 cellules markdown d'interprétation** strictement après la cellule de
code dont elles commentent l'output (pattern #10488 + `cell-interpretation-ordering.md`),
faisant passer la densité à **1305** (`status: ok`).

| Métrique | Avant | Après | Δ |
|---|---|---|---|
| Densité (chars(md)/count(code)) | 1010 | 1305 | **+295 (+29%)** |
| Cellules totales | 24 | 28 | +4 |
| Cellules markdown | 15 | 19 | +4 |
| Cellules code | 9 | 9 | 0 |
| `md_pct` | 36.6 % | 42.8 % | +6.2 |

**Zéro cellule code touchée.** Aucune cellule source `.source` de cellule
code n'a été modifiée — uniquement des cellules markdown insérées. Pas de
ré-exécution Papermill nécessaire (C.3 dispense markdown-only : l'exception
est légitime ici).

## Fichiers modifiés (1)

```
MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb (+28 lignes, 4 cellules markdown)
```

## Ancrage sémantique (pattern #10488 strict)

Chaque cellule d'interprétation est insérée **immédiatement après** la cellule
de code dont l'output contient la valeur citée :

| Nouvelle cellule | Suit la cellule de code | Valeur citée dans l'output | Vérification |
|---|---|---|---|
| `c0020` (cell 3) | cell 2 : `import numpy as np ... print('Environnement pret.')` | `Environnement pret.` | ✓ cite `Environnement pret` et le rôle du préambule |
| `c0021` (cell 12) | cell 11 : `qc_code = '''#region imports ... '''` | `10110 caracteres, 302 lignes` | ✓ cite **10110 caractères**, **302 lignes**, ratio ≈ 33, et la structure de la stratégie |
| `c0022` (cell 17) | cell 16 : `backtest_results = {...}` | `sharpe_ratio: None`, `cagr: None`, etc. | ✓ cite `None` × 5 et le statut `En attente de deploiement Cloud` |
| `c0023` (cell 27) | cell 26 : `summary = [...]` | seuils `>0.2` / `<-0.2`, `5 derniers articles`, `Top 10 actions tech` | ✓ cite seuils `±0.2`, fenêtre 5 articles, top 10 tech, capital $100,000 |

**Aucune cellule d'interprétation ne précède son code** (check structurel
`scan_cell_ordering.py` → `1 clean, 0 finding(s)`).

## Validation

### `pedagogy_density.py` (formula #10479 : chars(md)/count(code))

```
"density": 1305, "md_pct": 42.8, "status": "ok"
```

Seuil 1200 franchi avec marge (+105). `status: ok` = au-dessus du seuil, prêt
pour `validate_pr_notebooks.py`.

### `scan_cell_ordering.py --check-interp-anchor`

```
Scanned 1 notebook(s): 1 clean, 0 finding(s).
```

Zéro mismatch sémantique interp/output. Toutes les valeurs chiffrées citées
dans les nouvelles cellules apparaissent dans l'output de la cellule précédente.

### C.1 — pas d'erreur volontaire

`grep -E "raise NotImplementedError|assert False|^1/0"` → 0 hit. Le notebook
s'exécute end-to-end (inchangé, conforme à l'état pré-PR).

### C.2 — outputs commités

Toutes les cellules code exécutables portent `execution_count != null` ET
`outputs: [...]` cohérents (H.3 check : 0 bad cell). Aucune cellule
d'exercice `# TODO etudiant` touchée.

### H.3 — pré-commit notebook

Aucune cellule code modifiée → pas de violation H.3 (la règle vise les cellules
code re-exécutées, pas les insertions markdown).

## Pourquoi cette tranche

EPIC **#11224** (QC family density, 22 notebooks sous le plancher 1200). Ce
notebook était l'un des **4 candidats** non-claimés au moment de la sélection :

| Notebook | Densité mesurée | État |
|---|---|---|
| QC-Py-04-Research-Workflow | 1231 | au-dessus du seuil (corps #11224 obsolète : 678) |
| QC-Py-33-RL-PPO-Trading | 1469 | au-dessus du seuil |
| QC-Py-27-Production-Deployment | 1398 | au-dessus du seuil |
| **QC-Py-Cloud-01-FinBERT-Sentiment** | **1010** | **seul candidat frais sous le seuil** |

Périmètre claim `[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-Cloud-01-FinBERT-Sentiment.ipynb` →
partition propre au notebook seul, sans epic-wide lock.

## Suite (prochaines tranches #11224)

Les 3 autres notebooks déjà au-dessus du seuil ne nécessitent pas d'enrichissement
(était une erreur du corps #11224, calibrée sur un snapshot antérieur). Les autres
notebooks #11224 (claimés par po-2024 et po-2026) restent à servir selon le
planning de l'EPIC.

## Liens

- Issue : [jsboige/CoursIA#11224](https://github.com/jsboige/CoursIA/issues/11224)
- Claim : `gh issue view 11224 -c` (commentaire `[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: QC-Py-Cloud-01-FinBERT-Sentiment.ipynb`)
- Pattern : [#10488](https://github.com/jsboige/CoursIA/issues/10488) interprétation ancrée sur output
- Formula : [#10479](https://github.com/jsboige/CoursIA/issues/10479) chars(md) / count(code)
- Tranches précédentes mergées : voir PR list filtré `See #11224` sur le repo

## Checklist

- [x] Densité > 1200 (1305)
- [x] Pattern #10488 strict : 4/4 cellules ancrées sur l'output précédent
- [x] `scan_cell_ordering.py` : 1 clean, 0 finding
- [x] C.1 : 0 hit `raise NotImplementedError`/`assert False`/`1/0`
- [x] C.2 : `execution_count != null` + `outputs: [...]` cohérents (H.3 = 0 bad)
- [x] H.3 : aucune cellule code modifiée (markdown-only = dispense C.3)
- [x] Claim posted sur #11224 (paths scopés au notebook)
- [x] worktree-from-fresh-origin (basé sur origin/main @ 95c4c9a52)
- [x] PR body généré HORS worktree (scratchpad `c1331p247_pr_body.md`)