### PR TITLE
feat(lean,#10478): Pieces 2+3 — notebook Lean-23 Galois inverse M23 + attributions

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-22-MIMO-Detection-Flips.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-22-MIMO-Detection-Flips.ipynb
@@ -13,33 +13,7 @@
     },
     "tags": []
    },
-   "source": [
-    "# Lean-22 : Detection MIMO par flips -- le seuil 2 log N sous preuve Lean\n",
-    "\n",
-    "**Navigation** : [Index](README.md) | [Lean-21 (PFR)](Lean-21-PFR-Entropy-Method.ipynb)\n",
-    "\n",
-    "Ce notebook presente le lake **`mimo_lean`** de ce depot (issue #10984) : le port\n",
-    "formel de l'algorithme de detection MIMO par flips de coordonnées de\n",
-    "**Papailiopoulos (2026)**. Le resultat central du papier est un **seuil de\n",
-    "faisabilite** : la detection ML (maximum de vraisemblance) reussit au-dessus\n",
-    "d'un seuil en ~`2·log N` et echoue en dessous.\n",
-    "\n",
-    "Le lake formalise ce resultat en **quatre phases**, toutes completees et\n",
-    "sorry-free :\n",
-    "\n",
-    "| Phase | Module | Resultat |\n",
-    "|-------|--------|----------|\n",
-    "| 1 | `Descent.lean` | Proposition 9.1 (squelette combinatoire, sans Mathlib) |\n",
-    "| 2 | `Objective.lean` | Lemme 11.1 : forme fermee du cout d'un flip |\n",
-    "| 3a | `Lmmse.lean` | Lemme 5.1 : erreur LMMSE = trace de `B_ρ` |\n",
-    "| 3b | `Converse.lean` | Converse §11 : briques gaussiennes + assemblage (lake externe SLT) |\n",
-    "\n",
-    "Comme dans [Lean-21](Lean-21-PFR-Entropy-Method.ipynb), nous procedons en deux\n",
-    "registres : des **illustrations numeriques** (Python) qui montrent les phenomenes,\n",
-    "puis des **`#check` reels** executes par `lake env lean` sur le lac compile --\n",
-    "les enonces affiches sont ceux que le compilateur Lean 4 a verifies, pas des\n",
-    "paraphrases."
-   ]
+   "source": "# Lean-22 : Detection MIMO par flips -- le seuil 2 log N sous preuve Lean\n\n**Navigation** : [Index](README.md) | [Lean-21 (PFR)](Lean-21-PFR-Entropy-Method.ipynb) | [Lean-23 (Galois) >>](Lean-23-Galois-Probleme-Inverse-M23.ipynb)\n\nCe notebook presente le lake **`mimo_lean`** de ce depot (issue #10984) : le port\nformel de l'algorithme de detection MIMO par flips de coordonnées de\n**Papailiopoulos (2026)**. Le resultat central du papier est un **seuil de\nfaisabilite** : la detection ML (maximum de vraisemblance) reussit au-dessus\nd'un seuil en ~`2·log N` et echoue en dessous.\n\nLe lake formalise ce resultat en **quatre phases**, toutes completees et\nsorry-free :\n\n| Phase | Module | Resultat |\n|-------|--------|----------|\n| 1 | `Descent.lean` | Proposition 9.1 (squelette combinatoire, sans Mathlib) |\n| 2 | `Objective.lean` | Lemme 11.1 : forme fermee du cout d'un flip |\n| 3a | `Lmmse.lean` | Lemme 5.1 : erreur LMMSE = trace de `B_ρ` |\n| 3b | `Converse.lean` | Converse §11 : briques gaussiennes + assemblage (lake externe SLT) |\n\nComme dans [Lean-21](Lean-21-PFR-Entropy-Method.ipynb), nous procedons en deux\nregistres : des **illustrations numeriques** (Python) qui montrent les phenomenes,\npuis des **`#check` reels** executes par `lake env lean` sur le lac compile --\nles enonces affiches sont ceux que le compilateur Lean 4 a verifies, pas des\nparaphrases."
   },
   {
    "cell_type": "markdown",

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-23-Galois-Probleme-Inverse-M23.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-23-Galois-Probleme-Inverse-M23.ipynb
@@ -1,0 +1,842 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cbd23bde",
+   "metadata": {},
+   "source": [
+    "# Lean-23 : Le problème inverse de Galois — M₂₃ refermé le 9 août 2026\n",
+    "\n",
+    "**Série** : SymbolicAI / Lean — Théorie des groupes sporadiques et problème inverse de Galois\n",
+    "\n",
+    "**Navigation** : [<< Lean-22 MIMO](Lean-22-MIMO-Detection-Flips.ipynb) | [Index](README.md)\n",
+    "\n",
+    "**Kernel** : Python 3 (vérifications exécutables sympy + extraction Steiner) + Lean 4 via WSL\n",
+    "(`galois_lean`, source de vérité formelle — sections 3 et 4)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "## Les deux énoncés — à ne jamais confondre\n",
+    "\n",
+    "Ce notebook démontre **à l'écran** deux énoncés de nature mathématique très différente :\n",
+    "\n",
+    "| # | Énoncé | Statut dans ce dépôt | Comment il est établi |\n",
+    "|---|--------|----------------------|----------------------|\n",
+    "| **1** | **M₂₃ est un groupe simple d'ordre 10 200 960** : `card_M23`, `simple_M23` | **PROUVÉ** (mécaniquement, sous Lean 4 + Mathlib) | Théorèmes du lake `galois_lean` exécutés ci-dessous, `#print axioms` affiché |\n",
+    "| **2** | **M₂₃ est un groupe de Galois sur ℚ** : il existe une extension galoisienne de ℚ de groupe M₂₃ | **CITÉ** (préprint arXiv 2608.08538) — **NON formalisé** | Polynôme explicite f₁ de degré 23, vérifié computationnellement (irréductibilité, discriminant, factorisations mod p) ; l'identification du groupe de Galois `23T5` = M₂₃ requiert Magma et n'est **pas** reproduite |\n",
+    "\n",
+    "La confusion entre ces deux énoncés serait la même que celle entre « ce groupe existe et est simple »\n",
+    "et « ce groupe apparaît comme groupe de symétries d'une équation polynomiale à coefficients rationnels ».\n",
+    "Le premier est un fait de théorie des groupes finis ; le second est un fait de théorie des nombres\n",
+    "algébriques — et il a résisté quarante ans de plus."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2927c0b",
+   "metadata": {},
+   "source": [
+    "## 1. L'histoire : de Hilbert au 9 août 2026\n",
+    "\n",
+    "Le **problème inverse de Galois**, posé dans l'ère Hilbert (1890s), demande : *tout groupe fini\n",
+    "est-il le groupe de Galois d'une extension de ℚ ?* Hilbert lui-même contribue l'irréductibilité\n",
+    "de Hilbert (1892), l'outil qui permet de spécialiser des extensions régulières de ℚ(t) en\n",
+    "extensions de ℚ.\n",
+    "\n",
+    "Le cas des **groupes sporadiques** — les 26 exceptions de la classification des groupes simples\n",
+    "finis — a concentré la difficulté. Entre **1984 et 1989**, une vague de travaux (déclenchée par\n",
+    "Thompson pour le Monstre en 1984) réalise **25 des 26 sporadiques** comme groupes de Galois sur\n",
+    "ℚ, essentiellement par le **critère de rigidité** : quand une classe de conjugaison triple du\n",
+    "groupe est rigide, elle force une extension régulière de ℚ(t) unique.\n",
+    "\n",
+    "**M₂₃ a été le dernier.** Pourquoi lui ? Parce qu'il est **non rigide** — aucune triple classe\n",
+    "rigide ne le capture, et les méthodes de la vague 1984-1989 s'arrêtent à sa porte. Il a fallu\n",
+    "attendre le **9 août 2026** : Huang, Jackson, Lee, Poonen, Pries et Zhang\n",
+    "(*The Mathieu group M₂₃ is a Galois group over ℚ*, arXiv:2608.08538) referment le programme en\n",
+    "utilisant **une triple de classes non rigide** et des **applications de Belyi calculées\n",
+    "numériquement** (algorithme de Klug–Musty–Schiavone–Sijsling–Voight). Le programme des\n",
+    "sporadiques est complet.\n",
+    "\n",
+    "M₂₃ lui-même naît plus tôt : c'est le **groupe d'automorphismes du système de Steiner\n",
+    "S(4,7,23)** — le **design de Witt** — découvert par Ernst Witt (1938) via la construction\n",
+    "de Leech. C'est par ce système combinatoire que la preuve Lean ci-dessous l'attrape."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ac94148",
+   "metadata": {},
+   "source": [
+    "## 2. Attributions — qui a prouvé quoi, et sous quelle licence\n",
+    "\n",
+    "Ce notebook assemble trois couches de travail, chacune crédité à sa source :\n",
+    "\n",
+    "| Couche | Auteurs | Référence | Licence |\n",
+    "|--------|---------|-----------|---------|\n",
+    "| Preuve Lean « M₂₃ simple d'ordre 10 200 960 » | **Kenta** (KitaKen1) | Dépôt [`KitaKen1/finite-simple-groups-lean`](https://github.com/KitaKen1/finite-simple-groups-lean), dernier commit 2026-08-06 — vendored dans `galois_lean/Galois/M23Lean4Web.lean` (dérivation CoursIA, 2026-08-11, PR #10486) | **Apache-2.0** (en-tête préservé verbatim dans le fichier) |\n",
+    "| « M₂₃ est un groupe de Galois sur ℚ » | **Xiaoyu Huang, Blake Jackson, Kyu-Hwan Lee, Bjorn Poonen, Rachel Pries, Shaowu Zhang** | Préprint arXiv:2608.08538, soumis le **9 août 2026** | Préprint arXiv (citation académique) |\n",
+    "| Polynôme f₁ et script de vérification Magma | Les six auteurs du préprint | Dépôt [`shaowuz/m23isgalois`](https://github.com/shaowuz/m23isgalois), fichier `polynomial_f1.gp` | Code compagnon du préprint |\n",
+    "\n",
+    "**Politique d'axiomes du dépôt amont** (mesurée à l'import, cf section 3) : `0 sorry`, `0 native_decide`,\n",
+    "`0 axiom` déclarés — la preuve repose uniquement sur les axiomes standard de Mathlib\n",
+    "(`propext`, `Classical.choice`, `Quot.sound`). L'en-tête amont mentionne une assistance\n",
+    "« Claude Code (Fable 5, 1M context) » dans le développement — conservée telle quelle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "21fed7ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:30:55.449243Z",
+     "iopub.status.busy": "2026-08-18T02:30:55.449243Z",
+     "iopub.status.idle": "2026-08-18T02:30:55.479998Z",
+     "shell.execute_reply": "2026-08-18T02:30:55.478981Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lake galois_lean : .../galois_lean  (chemin tronque, convention serie)\n",
+      "Toolchain        : leanprover/lean4:v4.32.1\n",
+      "M23Lean4Web.lean : 8115 lignes\n",
+      "  sorry en position de preuve : 0  (occurrences textuelles : 2 , toutes en commentaire d'en-tete)\n",
+      "  native_decide : 0 ; axiom declares : 0\n",
+      "En-tete licence  : Copyright (c) 2026 Kenta. — upstream: https://github.com/KitaKen1/finite-si\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sys, re, time\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Pattern de la serie : utilitaires Lean cross-plateforme (Epic #2314)\n",
+    "sys.path.insert(0, str(Path.cwd()))\n",
+    "from lean_notebook_utils import (\n",
+    "    find_lean_project, get_lean_project_path,\n",
+    "    run_lake, run_lean_snippet, count_sorry,\n",
+    ")\n",
+    "\n",
+    "GALOIS = find_lean_project('galois_lean')          # Path Windows (operations fichier)\n",
+    "GALOIS_WSL = get_lean_project_path('galois_lean')  # chemin WSL (appels lake/lean)\n",
+    "print('Lake galois_lean : .../' + GALOIS.name + \"  (chemin tronque, convention serie)\")\n",
+    "print('Toolchain        :', (GALOIS / 'lean-toolchain').read_text().strip())\n",
+    "vendored = GALOIS / 'Galois' / 'M23Lean4Web.lean'\n",
+    "src = vendored.read_text(encoding='utf-8')\n",
+    "# Metrique de position de preuve (cf #10478) : sorry en position de terme compte,\n",
+    "# les occurrences dans les commentaires d'en-tete (licence) ne comptent pas.\n",
+    "lines = [l.split('--')[0] for l in src.splitlines()]   # code sans commentaires ligne\n",
+    "code_only = chr(10).join(lines)\n",
+    "bs = chr(92)  # backslash, pour ecrire les regex sans escape de transport\n",
+    "rx_sorry = '(:=' + bs + 's*|by' + bs + 's+|^' + bs + 's*)sorry(?![A-Za-z])'\n",
+    "n_sorry_term = len(re.findall(rx_sorry, code_only, re.M))\n",
+    "n_textual = src.count('sorry')\n",
+    "print('M23Lean4Web.lean :', len(src.splitlines()), 'lignes')\n",
+    "print('  sorry en position de preuve :', n_sorry_term,\n",
+    "        ' (occurrences textuelles :', n_textual, \", toutes en commentaire d'en-tete)\")\n",
+    "print('  native_decide :', len(re.findall('native_decide', code_only)), '; axiom declares :', len(re.findall('^axiom [A-Za-z]', code_only, re.M)))\n",
+    "print(\"En-tete licence  :\", src.splitlines()[1][:75])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f81858e",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "Le lake `galois_lean` (toolchain v4.32.1, Mathlib épinglé) porte la preuve amont **vendored** :\n",
+    "le fichier `M23Lean4Web.lean` (~8 100 lignes) contient toute la couche M₂₂ dont dépend M₂₃,\n",
+    "la construction de M₂₃ comme sous-groupe de Perm(23), sa cardinalité et sa simplicité.\n",
+    "Le compteur **0 sorry / 0 native_decide** confirme la politique d'axiomes annoncée : aucune\n",
+    "preuve trouée, aucune décision déléguée au noyau natif sans preuve."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62d7b786",
+   "metadata": {},
+   "source": [
+    "## 3. M₂₃ exécuté — le groupe prouvé à l'écran\n",
+    "\n",
+    "L'énoncé 1 n'est pas raconté : il est **exécuté**. La cellule suivante fait trois choses :\n",
+    "\n",
+    "1. `lake build` sur le lake — la preuve compile sous **notre** épingle (preuve de buildabilité) ;\n",
+    "2. `#check` les deux théorèmes — Lean affiche leurs énoncés complets ;\n",
+    "3. `#print axioms` — la liste exhaustive des axiomes sur lesquels repose la preuve.\n",
+    "   C'est l'audit d'intégrité : **tout ce qui n'est pas dans la liste blanche standard\n",
+    "   (`propext`, `Classical.choice`, `Quot.sound`) viderait le théorème** (règle §B du dépôt)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a7ca4c6a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:30:55.482127Z",
+     "iopub.status.busy": "2026-08-18T02:30:55.482127Z",
+     "iopub.status.idle": "2026-08-18T02:31:33.277209Z",
+     "shell.execute_reply": "2026-08-18T02:31:33.276656Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lake build rc=0\n",
+      "info: Galois/M23Lean4Web.lean:8113:0: 'Sporadic.simple_M22' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "info: Galois/M23Lean4Web.lean:8114:0: 'Sporadic.card_M23' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "info: Galois/M23Lean4Web.lean:8115:0: 'Sporadic.simple_M23' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "Build completed successfully (1339 jobs).\n",
+      "[lake build en 37.8s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "t0 = time.time()\n",
+    "rc_build, out_build, err_build = run_lake(GALOIS_WSL, 'build', timeout=1200)\n",
+    "combined = (out_build or '') + (err_build or '')\n",
+    "tail = combined.strip().splitlines()[-4:] if combined.strip() else ['(aucune sortie = deja a jour)']\n",
+    "print(f\"lake build rc={rc_build}\")\n",
+    "print('\\n'.join(tail))\n",
+    "print(f\"[lake build en {time.time()-t0:.1f}s]\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e08f55f6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:31:33.279811Z",
+     "iopub.status.busy": "2026-08-18T02:31:33.279811Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.028593Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.027551Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sporadic.card_M23 : Nat.card Sporadic.M23 = 10200960\n",
+      "Sporadic.simple_M23 : IsSimpleGroup Sporadic.M23\n",
+      "'Sporadic.card_M23' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "'Sporadic.simple_M23' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+      "heptadList_length : heptadList.length = 253\n",
+      "PreservesHeptads : Sporadic.Perm23 → Prop\n",
+      "PreservesHeptads.one : PreservesHeptads 1\n",
+      "@PreservesHeptads.mul : ∀ {g h : Sporadic.Perm23}, PreservesHeptads g → PreservesHeptads h → PreservesHeptads (g * h)\n",
+      "\n",
+      "[lean: 170.7s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "snippet = \"\"\"\n",
+    "import Galois.M23Lean4Web\n",
+    "\n",
+    "-- Les deux theoremes, enonces par Lean lui-meme\n",
+    "#check @Sporadic.card_M23\n",
+    "#check @Sporadic.simple_M23\n",
+    "\n",
+    "-- Audit d'integrite : axiomes exacts de chaque preuve\n",
+    "#print axioms Sporadic.card_M23\n",
+    "#print axioms Sporadic.simple_M23\n",
+    "\n",
+    "-- Le systeme de Steiner S(4,7,23) du depot amont\n",
+    "open Sporadic.M23Certificates.SteinerSystem\n",
+    "#check @heptadList_length\n",
+    "#check @PreservesHeptads\n",
+    "#check @PreservesHeptads.one\n",
+    "#check @PreservesHeptads.mul\n",
+    "\"\"\"\n",
+    "t0 = time.time()\n",
+    "out = run_lean_snippet(GALOIS_WSL, snippet, timeout=900, snippet_id='m23_thms')\n",
+    "print(out)\n",
+    "print(f\"[lean: {time.time()-t0:.1f}s]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1374a2ba",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- **`Sporadic.card_M23 : Nat.card M23 = 10200960`** — l'ordre du groupe, calculé par une\n",
+    "  **chaîne de stabilisateurs Schreier–Sims matérialisée** dans la preuve : c'est du comptage\n",
+    "  combinatoire déroulé, pas une table consultée.\n",
+    "- **`Sporadic.simple_M23 : IsSimpleGroup M23`** — la simplicité. La stratégie amont : exclure\n",
+    "  tout sous-groupe normal non trivial, y compris un éventuel sous-groupe normal régulier\n",
+    "  d'ordre 23 par un **certificat de conjugaison**.\n",
+    "- **`#print axioms`** ne rend que `propext, Classical.choice, Quot.sound` — les trois axiomes\n",
+    "  standard de Mathlib. Pas de `sorryAx` (qui signalerait un trou), pas d'axiome `native_decide`\n",
+    "  (qui signalerait une décision non prouvée). **La preuve est close au sens mécanique.**\n",
+    "- **`heptadList_length : heptadList.length = 253`** — le système de Steiner : les 253 heptades\n",
+    "  du design de Witt S(4,7,23), et le fait que la liste en contient exactement 253.\n",
+    "  `PreservesHeptads` définit le sous-groupe de Perm(23) qui préserve le système — c'est la\n",
+    "  **définition combinatoire de M₂₃** — avec sa structure de groupe (`one`, `mul`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bdfa409",
+   "metadata": {},
+   "source": [
+    "## 4. Le design de Witt S(4,7,23) — l'objet combinatoire\n",
+    "\n",
+    "M₂₃ se définit comme groupe d'automorphismes du **système de Steiner S(4,7,23)** : 23 points,\n",
+    "des blocs de 7 points (les **heptades**), tels que **tout sous-ensemble de 4 points est contenu\n",
+    "dans exactement une heptade**. L'aridmétrie force le nombre de blocs :\n",
+    "C(23,4)/C(7,4) = 8855/35 = **253** — exactement ce que `heptadList_length` énonce.\n",
+    "\n",
+    "Extrayons les 253 heptades du fichier Lean et vérifions la propriété définaire **indépendamment**\n",
+    "(en Python, sans Lean) — deux sources de vérité qui se recoupent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2e4ecf38",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.031828Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.031828Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.047699Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.045669Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Blocs extraits : 313 occurrences, 253 distincts\n",
+      "Premieres heptades : [(0, 1, 2, 3, 4, 21, 22), (0, 1, 5, 10, 16, 19, 22), (0, 1, 6, 9, 15, 20, 22)]\n",
+      "\n",
+      "253 attendu (heptadList_length) <-> 253 extraits : CONCORDANT\n",
+      "Arithmetique du design : C(23,4)/C(7,4) = 8855//35 = 253\n"
+     ]
+    }
+   ],
+   "source": [
+    "import itertools\n",
+    "\n",
+    "# Extraction des heptades depuis la source Lean (notation zero-based {a, b, ..., f, g})\n",
+    "blocks_src = re.findall(r'\\{(\\d+(?:,\\s*\\d+){6})\\}', src)\n",
+    "# Les blocs du systeme S(4,7,23) : la deuxieme occurrence du pattern (zone SteinerSystem M23)\n",
+    "heptads = [tuple(int(v) for v in b.split(',')) for b in blocks_src]\n",
+    "# Deduplication conservant l'ordre (la couche M22 contient des blocs a 7 elements distincts)\n",
+    "seen, heptads_uniq = set(), []\n",
+    "for h in heptads:\n",
+    "    if h not in seen:\n",
+    "        seen.add(h); heptads_uniq.append(h)\n",
+    "print(f\"Blocs extraits : {len(heptads)} occurrences, {len(heptads_uniq)} distincts\")\n",
+    "print(\"Premieres heptades :\", heptads_uniq[:3])\n",
+    "# Verifications structurelles elementaires\n",
+    "assert all(len(h) == 7 for h in heptads_uniq), \"heptade de taille != 7\"\n",
+    "assert all(max(h) <= 22 and min(h) >= 0 for h in heptads_uniq), \"point hors de {0..22}\"\n",
+    "n_heptads = len(heptads_uniq)\n",
+    "print(f\"\\n253 attendu (heptadList_length) <-> {n_heptads} extraits : \"\n",
+    "      f\"{'CONCORDANT' if n_heptads == 253 else 'ECART'}\")\n",
+    "print(f\"Arithmetique du design : C(23,4)/C(7,4) = {len(list(itertools.combinations(range(23),4)))}\"\n",
+    "      f\"//{len(list(itertools.combinations(range(7),4)))} = \"\n",
+    "      f\"{len(list(itertools.combinations(range(23),4)))//len(list(itertools.combinations(range(7),4)))}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e51728d5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.050773Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.050773Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.063976Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.062230Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Echantillon de 200 quadruplets : 200/200 dans exactement 1 heptade -- PROPRIETE S(4,7,23) VERIFIEE SUR L'ECHANTILLON\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Propriete definatoire (verification partielle, sous-ensemble des 4-subsets)\n",
+    "# La verification COMPLETE (8855 quadruplets) est l'Exercice 2.\n",
+    "heptad_sets = [frozenset(h) for h in heptads_uniq]\n",
+    "quads = list(itertools.combinations(range(23), 4))\n",
+    "import random\n",
+    "random.seed(42)\n",
+    "sample_quads = random.sample(quads, 200)\n",
+    "bad = 0\n",
+    "for q in sample_quads:\n",
+    "    qs = frozenset(q)\n",
+    "    containing = sum(1 for H in heptad_sets if qs <= H)\n",
+    "    if containing != 1:\n",
+    "        bad += 1\n",
+    "        print(f\"  ANOMALIE : {q} contenu dans {containing} heptades\")\n",
+    "print(f\"Echantillon de 200 quadruplets : {200 - bad}/200 dans exactement 1 heptade\"\n",
+    "      + (\" -- PROPRIETE S(4,7,23) VERIFIEE SUR L'ECHANTILLON\" if bad == 0 else \" -- DEFAUT\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd8f4507",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- L'extraction rend **253 heptades distinctes**, chacune de taille 7 sur les points {0..22} —\n",
+    "  concordant avec `heptadList_length` prouvé en Lean.\n",
+    "- Sur un échantillon aléatoire de 200 quadruplets, chacun est contenu dans **exactement une**\n",
+    "  heptade : le comportement S(4,7,23). La vérification exhaustive (8 855 quadruplets) est\n",
+    "  l'**Exercice 2** — la propriété est faite pour être re-vérifiée par l'étudiant, pas crue.\n",
+    "- Le pont conceptuel : le groupe des permutations de {0..22} préservant l'ensemble des 253\n",
+    "  heptades **est** M₂₃. `PreservesHeptads` (Lean) en est la définition formelle exacte ;\n",
+    "  `blockMap` en est l'action sur les blocs. La théorie des groupes finis rencontre la\n",
+    "  combinatoire des designs : c'est par ce chemin que Witt a construit M₂₃ en 1938, bien avant\n",
+    "  l'ordinateur."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0971b5e7",
+   "metadata": {},
+   "source": [
+    "## 5. La réalisation galoisienne — citée, pas formalisée\n",
+    "\n",
+    "L'énoncé 2 (M₂₃ groupe de Galois sur ℚ) repose sur une chaîne théorique que ce dépôt **ne\n",
+    "formalise pas**. Elle est citée ici pour être honnête sur la frontière entre prouvé et rapporté :\n",
+    "\n",
+    "1. **Application de Belyi et triple non rigide.** Le préprint part d'une extension galoisienne\n",
+    "   régulière de ℚ(t) avec groupe M₂₃, construite par une triple de classes de conjugaison\n",
+    "   **non rigide** — c'est précisément ce qui a bloqué M₂₃ pendant 40 ans : la rigidité, l'outil\n",
+    "   de la vague 1984-1989, ne s'applique pas.\n",
+    "2. **Existence de Riemann** (forme revêtements finis étales ↔ quotients finis de π₁) : le pont\n",
+    "   topologie ↔ arithmétique qui transporte la monodromie en groupe de Galois.\n",
+    "3. **Corps des modules ℚ et descente** du revêtement (références `[CH85]` et `[DD97]` du\n",
+    "   préprint) : prouver que l'extension descend de ℚ̄(t) à ℚ(t).\n",
+    "4. **Spécialisation** (irréductibilité de Hilbert) : de ℚ(t) vers le ℚ du polynôme f₁.\n",
+    "\n",
+    "Le dépôt porte déjà le socle géométrique de cette chaîne dans\n",
+    "[`grothendieck_lean`](grothendieck_lean/README.md) (34 modules, 0 sorry) : sites, faisceaux,\n",
+    "cohomologie — mais **pas** le π₁ étale ni l'existence de Riemann. La phrase qui doit rester\n",
+    "noir sur blanc : **« M₂₃ est un groupe de Galois sur ℚ » n'est PAS formalisé dans ce dépôt** —\n",
+    "il est prouvé dans le préprint, et vérifié computationnellement ci-dessous au niveau du\n",
+    "polynôme, pas au niveau du groupe de Galois."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "57ef6cf8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.067400Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.066729Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.080778Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.079128Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grothendieck_lean : 96 modules .lean sous Grothendieck/\n",
+      "  - Adjunction\n",
+      "  - Adjunction_en\n",
+      "  - Basic\n",
+      "  - Basic_en\n",
+      "  - Calibration\n",
+      "  - Calibration_en\n",
+      "  - CanonicalProps\n",
+      "  - CanonicalProps_en\n",
+      "  - CategoryAndSites\n",
+      "  - CategoryAndSites_en\n",
+      "  - Cech\n",
+      "  - Cech_en\n",
+      "  - Comma\n",
+      "  - Comma_en\n",
+      "  ...\n",
+      "\n",
+      "Chainon MANQUANT pour l'enonce 2 : pi1 etale / existence de Riemann -> non formalise\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Le socle grothendieckien du depot : ce qui existe deja cote formel\n",
+    "gro = find_lean_project('grothendieck_lean')\n",
+    "gro_modules = sorted(p.stem for p in (Path(gro) / 'Grothendieck').rglob('*.lean'))\n",
+    "print(f\"grothendieck_lean : {len(gro_modules)} modules .lean sous Grothendieck/\")\n",
+    "for m in gro_modules[:14]:\n",
+    "    print(\"  -\", m)\n",
+    "print(\"  ...\" if len(gro_modules) > 14 else \"\")\n",
+    "print(\"\\nChainon MANQUANT pour l'enonce 2 : pi1 etale / existence de Riemann -> non formalise\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1cbf1d6",
+   "metadata": {},
+   "source": [
+    "## 6. Le polynôme f₁ — manipulé pour de vrai\n",
+    "\n",
+    "Le préprint produit un polynôme **explicite** de degré 23 à coefficients entiers dont le corps\n",
+    "de décomposition sur ℚ a pour groupe de Galois M₂₃. Le dépôt compagnon\n",
+    "[`shaowuz/m23isgalois`](https://github.com/shaowuz/m23isgalois) le publie au format PARI/GP\n",
+    "(`polynomial_f1.gp`), avec un **auto-contrôle** : une empreinte à six champs calculable\n",
+    "indépendamment. Le fichier dit, pour `f1` : degré 23, 23 monômes, 219 chiffres de coefficients\n",
+    "au total, 14 chiffres pour le plus grand, contenu 1, et `f1(3) mod (2^61−1) = 92254275456192`.\n",
+    "\n",
+    "**Nous chargeons les coefficients ci-dessous et recalculons l'empreinte de toutes pièces.**\n",
+    "C'est la vérification d'intégrité de la transcription : une seule erreur de chiffre casse\n",
+    "l'empreinte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0d5598ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.084576Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.084036Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.092781Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.091538Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "empreinte calculee : [23, 23, 219, 14, 1, 92254275456192]\n",
+      "empreinte attendue : [23, 23, 219, 14, 1, 92254275456192]\n",
+      "TRANSCRIPTION INTEGRE\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Coefficients de f1, transcrits de polynomial_f1.gp (shaowuz/m23isgalois)\n",
+    "# coeff_f1[i] = coefficient de x^i ; l'entree x^22 est absente du fichier (coefficient 0)\n",
+    "coeff_f1 = [\n",
+    "    -3150159884154, 19169943578802, -46185312415788, 53599151839311,\n",
+    "    -28142323927002, 1949980486716, 3961650395556, -1023887308293,\n",
+    "    -194398310718, 35123826654, 3700476348, 10550424369,\n",
+    "    290615166, -1333395744, -42732528, 67672923,\n",
+    "    1545462, -1808490, 18400, 26151,\n",
+    "    -1150, -184, 0, 1,\n",
+    "]\n",
+    "\n",
+    "import math\n",
+    "nz = [abs(c) for c in coeff_f1 if c != 0]\n",
+    "digits = [len(str(a)) for a in nz]\n",
+    "content = 0\n",
+    "for c in coeff_f1:\n",
+    "    content = math.gcd(content, c)\n",
+    "M61 = 2**61 - 1\n",
+    "f1_at_3 = sum(c * pow(3, i, M61) for i, c in enumerate(coeff_f1)) % M61\n",
+    "\n",
+    "fingerprint = [23, len(nz), sum(digits), max(digits), content, f1_at_3]\n",
+    "expected    = [23, 23, 219, 14, 1, 92254275456192]  # f1_expect de polynomial_f1.gp\n",
+    "print(\"empreinte calculee :\", fingerprint)\n",
+    "print(\"empreinte attendue :\", expected)\n",
+    "print(\"TRANSCRIPTION INTEGRE\" if fingerprint == expected else \"ECART -- retranscrire !\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "63f67d15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.096148Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.095567Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.848468Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.847324Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "degre de f1            : 23\n",
+      "factorisation sur Q    : 1 facteur(s) -> IRREDUCTIBLE\n",
+      "discriminant           : 383 chiffres, signe +\n",
+      "  (non nul -> f1 separable : 23 racines complexes distinctes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sympy import Poly, symbols, factor_list, discriminant, GF\n",
+    "x = symbols('x')\n",
+    "f1 = sum(c * x**i for i, c in enumerate(coeff_f1))\n",
+    "poly = Poly(f1, x)\n",
+    "\n",
+    "# 1. Degre\n",
+    "print(f\"degre de f1            : {poly.degree()}\")\n",
+    "# 2. Irreductibilite sur Q (factorisation complete -- 1 facteur = irreductible)\n",
+    "fl = factor_list(f1)\n",
+    "n_factors = len(fl[1])\n",
+    "print(f\"factorisation sur Q    : {n_factors} facteur(s) -> \"\n",
+    "      f\"{'IRREDUCTIBLE' if n_factors == 1 and fl[1][0][1] == 1 else 'REDUCTIBLE'}\")\n",
+    "# 3. Discriminant (383 chiffres, signe +) : 23 racines distinctes\n",
+    "disc = discriminant(f1, x)\n",
+    "print(f\"discriminant           : {len(str(abs(disc)))} chiffres, signe {'+' if disc > 0 else '-'}\")\n",
+    "print(f\"  (non nul -> f1 separable : 23 racines complexes distinctes)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cad28d50",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.849459Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.849459Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.905150Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.904640Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   p | degres des facteurs (deg x mult) | somme\n",
+      "----------------------------------------------------\n",
+      "   2 | [3, 4, 16]                   | 23\n",
+      "   3 | [1, 4, 18]                   | 23\n",
+      "   5 | [1, 11, 11]                  | 23\n",
+      "   7 | [1, 2, 4, 8, 8]              | 23\n",
+      "  11 | [2, 7, 14]                   | 23\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<USER_PATH>\\AppData\\Local\\Programs\\Python\\Python311\\Lib\\site-packages\\sympy\\polys\\polytools.py:6282: SymPyDeprecationWarning: \n",
+      "\n",
+      "Ordered comparisons with modular integers are deprecated.\n",
+      "\n",
+      "            Use e.g. int(a) < int(b) instead of a < b.\n",
+      "\n",
+      "See https://docs.sympy.org/latest/explanation/active-deprecations.html#modularinteger-compare\n",
+      "for details.\n",
+      "\n",
+      "This has been deprecated since SymPy version 1.13. It\n",
+      "will be removed in a future version of SymPy.\n",
+      "\n",
+      "  return sorted(factors, key=key)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 4. Factorisations modulo quelques premiers -- les cycles de Frobenius\n",
+    "print(f\"{'p':>4} | degres des facteurs (deg x mult) | somme\")\n",
+    "print(\"-\" * 52)\n",
+    "for p in (2, 3, 5, 7, 11):\n",
+    "    flp = factor_list(f1, modulus=p)\n",
+    "    degs = sorted(int(Poly(g, x, domain=GF(p)).degree()) * int(m) for g, m in flp[1])\n",
+    "    print(f\"{p:>4} | {str(degs):<28} | {sum(degs)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c33fd85",
+   "metadata": {},
+   "source": [
+    "### Interprétation\n",
+    "\n",
+    "- **Irréductible sur ℚ** : f₁ n'a aucun facteur rationnel — le corps ℚ(α) engendré par une\n",
+    "  racine est de degré 23, et le groupe de Galois (du corps de décomposition) agit\n",
+    "  **transitivement** sur les 23 racines. C'est la signature d'un groupe transitif de degré 23.\n",
+    "- **Discriminant ≠ 0** (383 chiffres, positif) : f₁ est séparable — 23 racines distinctes,\n",
+    "  pas de ramification résiduelle. Le préprint démontre plus fort : le corps de décomposition\n",
+    "  n'est ramifié qu'en **{2, 3, 23}**.\n",
+    "- **Factorisation mod p** : les degrés des facteurs modulo p donnent la décomposition des\n",
+    "  cycles d'un élément de Frobenius — une fenêtre sur la structure du groupe de Galois. Les\n",
+    "  motifs observés (ex. 11+11+1 mod 5, ou 8+8+4+2+1 mod 7) sont cohérents avec des substitutions\n",
+    "  paires à point fixe — le comportement attendu d'un sous-groupe de A₂₃ comme M₂₃.\n",
+    "- **Ce que ces vérifications NE démontrent PAS** : l'identification du groupe de Galois à\n",
+    "  M₂₃ (transitive group **23T5**). Elle requiert Magma (`verify.m` du dépôt compagnon,\n",
+    "  `GaloisGroup` + `GaloisProof` certifiant) et n'est **pas reproduite ici**. Notre chaîne\n",
+    "  sympy établit : degré 23 ✓, irréductible ✓, séparable ✓, Frobenius pairs ✓ — le socle\n",
+    "  computationnel, pas le théorème."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6e7da43",
+   "metadata": {},
+   "source": [
+    "## 7. Exercices"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5abcf042",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.908593Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.907585Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.912436Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.912436Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 a completer : arithmetique de |M23|\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 1 : l'arithmetique de l'ordre de M23.\n",
+    "# Objectif : verifier la decomposition multiplicative 10200960 = 253 * 40320\n",
+    "# et la factorisation premiere |M23| = 2^7 * 3^2 * 5 * 7 * 11 * 23, puis expliquer\n",
+    "# pourquoi 253 et 40320 apparaissent chacun naturellement dans le design de Witt.\n",
+    "# Indice : 253 = nombre d'heptades (section 4) ; 40320 = 8! -- chaque point fixe une\n",
+    "#          structure de \"octade + coordonnees\" heritee de M24 ; le stabilisateur dans M23\n",
+    "#          d'un point est M22, d'ordre |M23|/23.\n",
+    "# Etape 1 : verifier l'egalite 253 * 40320 == 10200960 (contre Sporadic.card_M23)\n",
+    "# Etape 2 : calculer la factorisation premiere de 10200960 et la comparer a 2^7*3^2*5*7*11*23\n",
+    "# Etape 3 : verifier |M23| / 23 == 443520 et chercher a quoi correspond ce nombre pour M22\n",
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 1 a completer : arithmetique de |M23|\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "b3127f64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.915258Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.915258Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.919632Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.919632Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 a completer : verification exhaustive S(4,7,23)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 2 : la propriete definatoire S(4,7,23) -- verification EXHAUSTIVE.\n",
+    "# Objectif : verifier que CHACUN des C(23,4) = 8855 quadruplets de points est contenu\n",
+    "# dans exactement une heptade (la section 4 ne l'a fait que sur un echantillon de 200).\n",
+    "# Indice : construire un index heptade -> frozenset, puis pour chaque quadruplet\n",
+    "#          compter les heptades le contenant ; assert count == 1 pour TOUS.\n",
+    "# Etape 1 : generer les 8855 quadruplets avec itertools.combinations(range(23), 4)\n",
+    "# Etape 2 : pour chaque quadruplet q, compter sum(1 for H in heptad_sets if set(q) <= H)\n",
+    "# Etape 3 : assert sur la totalite, et afficher le compte de quadruplets verifies\n",
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 2 a completer : verification exhaustive S(4,7,23)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "c414bd6e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T02:34:24.922797Z",
+     "iopub.status.busy": "2026-08-18T02:34:24.921797Z",
+     "iopub.status.idle": "2026-08-18T02:34:24.927353Z",
+     "shell.execute_reply": "2026-08-18T02:34:24.926291Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 a completer : empreinte et verifications de f2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# EXERCICE 3 : le second polynome f2 du depot compagnon.\n",
+    "# Objectif : recuperer polynomial_f2.gp depuis https://github.com/shaowuz/m23isgalois,\n",
+    "# transcrire les coefficients de f2, puis reproduire sur f2 les memes verifications\n",
+    "# que la section 6 (empreinte, degre, irreductibilite sur Q, discriminant, factorisation\n",
+    "# mod 2, 3, 5). Le preprint precise : f2 est de hauteur plus petite, a ramification\n",
+    "# dans {2, 7, 23} (contre {2, 3, 23} pour f1).\n",
+    "# Indice : le fichier .gp de f2 embarque sa propre ligne f2_expect -- l'utiliser comme\n",
+    "#          oracle d'empreinte, comme f1_expect en section 6.\n",
+    "# Etape 1 : transcrire coeff_f2 depuis polynomial_f2.gp\n",
+    "# Etape 2 : recalculer l'empreinte et la comparer a f2_expect\n",
+    "# Etape 3 : degre / irreductibilite / discriminant / factorisation mod p, meme format\n",
+    "result = None  # TODO etudiant\n",
+    "print(\"Exercice 3 a completer : empreinte et verifications de f2\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23a28e3b",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "| | Ce notebook a établi | Méthode | Statut |\n",
+    "|---|---|---|---|\n",
+    "| **Énoncé 1** | M₂₃ simple, d'ordre 10 200 960 | Théorèmes Lean exécutés (`card_M23`, `simple_M23`), `#print axioms` = liste blanche standard | **PROUVÉ** (mécaniquement) |\n",
+    "| **Énoncé 2** | M₂₃ groupe de Galois sur ℚ | Préprint cité + f₁ vérifié computationnellement (degré, irréductibilité, séparabilité, Frobenius) | **CITÉ** (non formalisé ; identification 23T5 = Magma, non reproduite) |\n",
+    "| **Pont** | Le design de Witt S(4,7,23) | 253 heptades extraites, propriété S(4,7,23) échantillonnée, `PreservesHeptads` = définition formelle de M₂₃ | **Vérifié des deux côtés** |\n",
+    "\n",
+    "Le problème inverse de Galois sporadique est refermé au sens mathématique (préprint du\n",
+    "9 août 2026) — mais sa formalisation complète (existence de Riemann, descente, spécialisation\n",
+    "de Hilbert) reste ouverte côté Lean, et le socle `grothendieck_lean` en marque le point\n",
+    "d'arrivée naturel. Une noix de plus à grignoter.\n",
+    "\n",
+    "**Prérequis pour rejouer** : WSL avec `elan`/`lake` (build de `galois_lean`, Mathlib v4.32.1\n",
+    "via cache), Python 3 avec `sympy`. Durée d'exécution : ~2 min une fois le lake construit."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -135,8 +135,9 @@ Tous les notebooks incluent une **barre de navigation** en haut et en bas permet
 | 20 | [Lean-20-Analysis-I-Tao-Workflow](Lean-20-Analysis-I-Tao-Workflow.ipynb) | Le manuel *Analysis I* de T. Tao en lac Lean 4 (`teorth/analysis`) : architecture du lac, philosophie d'auto-contenance vs Mathlib, cinq lemmes emblématiques parmi 44k LOC, méta-récit single-agent vs cluster distribué | 40 min |
 | 21 | [Lean-21-PFR-Entropy-Method](Lean-21-PFR-Entropy-Method.ipynb) | La conjecture PFR (polynomial Freiman–Ruzsa, ZMod 2) : méthode entropique de la preuve `teorth/pfr` — énoncé combinatoire, illustrations cosets dans F₂³, `#check` réels et axiomes du lac compilé | 45 min |
 | 22 | [Lean-22-MIMO-Detection-Flips](Lean-22-MIMO-Detection-Flips.ipynb) | Détection MIMO par flips de coordonnées (Papailiopoulos 2026) : le seuil 2·log N — descente simulée et comptage de flips, probabilité d'échappement du bruit (Monte-Carlo vs `e^{−np}`), `#check` réels des quatre phases du companion `mimo_lean` (sorry-free, lake externe SLT pour Hanson–Wright) | 40 min |
+| 23 | [Lean-23-Galois-Probleme-Inverse-M23](Lean-23-Galois-Probleme-Inverse-M23.ipynb) | Le problème inverse de Galois refermé (arXiv:2608.08538, 9 août 2026) : M₂₃ prouvé simple d'ordre 10 200 960 **à l'écran** (`card_M23`/`simple_M23` exécutés, `#print axioms` = liste blanche), design de Witt S(4,7,23) vérifié des deux côtés (253 heptades), polynôme f₁ de degré 23 manipulé pour de vrai (empreinte, irréductibilité, discriminant 383 chiffres, Frobenius mod p) — les deux énoncés distingués : prouvé vs cité | 45 min |
 
-**Durée totale** : ~20h55
+**Durée totale** : ~21h40
 
 ## Acquis d'apprentissage
 
@@ -152,7 +153,7 @@ A l'issue de la série, vous saurez :
 - **Explorer les noix de Conway** en Lean 4 : Game of Life as Computation, Doomsday, FRACTRAN, Look-and-Say, Nim, Angel — port formel de résultats combinatoires iconiques. Notebooks 16a-16e.
 - **Comprendre le théorème du libre arbitre** (Conway-Kochen) : les axiomes SPIN/TWIN/MIN, l'argument en deux temps qui réduit le cas à deux particules au théorème de Kochen-Specker (Notebook 13), et la lecture honnête de sa portée (ce qu'il dit et ne dit pas) — adossé à `FreeWillTheorem.lean` (0 sorry). Notebook 16f.
 - **Formaliser les invariants de nœuds** : PD-codes, mouvements de Reidemeister et tricolorabilité de Fox, en s'appuyant sur le companion `knot_lean` (transfert de tricolorabilité le long d'un twist R1 connecté, preuve forward sorry-free + backward partielle). Notebooks 17a, 17b.
-- **Lire le paysage galoisien moderne** : la preuve formelle que **M₂₃ (groupe sporadique de Mathieu d'ordre 10 200 960) est simple** est *vendored* dans le companion `galois_lean/` (PR #10486, août 2026, Apache-2.0) ; la question ouverte — *M₂₃ est-il un groupe de Galois sur ℚ ?* — est ramenée à un problème de théorie des nombres (polynôme irréductible de degré 23 à racines dans M₂₃, discriminant, identification `23T5 = M23`, Poonen et al., arXiv:2608.08538) — voir Epic #10478 pour le notebook pédagogique à venir.
+- **Lire le paysage galoisien moderne** : la preuve formelle que **M₂₃ (groupe sporadique de Mathieu d'ordre 10 200 960) est simple** est *vendored* dans le companion `galois_lean/` (PR #10486, août 2026, Apache-2.0) ; la réalisation galoisienne — *M₂₃ groupe de Galois sur ℚ* — est **prouvée** dans le préprint (Huang–Jackson–Lee–Poonen–Pries–Zhang, arXiv:2608.08538, 9 août 2026 : polynôme explicite f₁ de degré 23, identification `23T5`) mais **non formalisée** — le notebook [Lean-23](Lean-23-Galois-Probleme-Inverse-M23.ipynb) exécute la preuve formelle côté groupe et vérifie f₁ computationnellement, les deux énoncés soigneusement distingués (Epic #10478).
 
 Pour l'état formel détaillé des modules support (preuves résolues vs `sorry` résiduels), voir [LEAN_INVENTORY.md](../../GameTheory/LEAN_INVENTORY.md), le [README du projet conway_lean](conway_lean/README.md), et le [README du projet grothendieck_lean](grothendieck_lean/README.md).
 
@@ -184,6 +185,7 @@ Pour l'état formel détaillé des modules support (preuves résolues vs `sorry`
 | 16f | Conway-Free-Will-Theorem | ~28 | 3 | 0 | **NOUVEAU** (hommage) |
 | 17a | Knots-a-Conway-and-Proofs | ~13 | 0 | - | **NOUVEAU** (hommage) |
 | 17b | Knots-b-Invariants-Companion | ~19 | 3 | - | **NOUVEAU** |
+| 23 | Galois-Probleme-Inverse-M23 | ~25 | 3 | 0 | **NOUVEAU** (exécution Lean + sympy) |
 
 Tous les notebooks incluent :
 - Navigation header/footer avec liens vers notebooks précédent/suivant
@@ -374,7 +376,7 @@ Lean/
 ├── grothendieck_lean/              # Grothendieck tribute workspace (0 sorry, Lake build)
 ├── knot_lean/                      # Knot theory workspace (théorie des nœuds, companion Lean-17a/b, sorries résiduels documentés, Lake build)
 ├── calibration_lean/               # Cibles de calibration du prouveur multi-agents (Epic #1453, P1-P5) - 0 sorry, Lake build
-├── galois_lean/                    # Problème inverse de Galois : M₂₃ (Mathieu 23) groupe simple + preuve formelle vendored (Apache-2.0, [KitaKen1/finite-simple-groups-lean](https://github.com/KitaKen1/finite-simple-groups-lean)) - 0 sorry, Lake build ; cible pédagogique ouverte Epic #10478 (Poonen et al., arXiv:2608.08538, août 2026)
+├── galois_lean/                    # Problème inverse de Galois : M₂₃ (Mathieu 23) groupe simple + preuve formelle vendored (Apache-2.0, [KitaKen1/finite-simple-groups-lean](https://github.com/KitaKen1/finite-simple-groups-lean)) - 0 sorry, Lake build ; companion du notebook Lean-23 (Epic #10478, arXiv:2608.08538, août 2026)
 ├── mathlib_examples/               # Smoke test Mathlib (ring/linarith/omega/rw, 4 buts) - 0 sorry, Lake build
 ├── agent_tests/                    # Prover daemon (autonomous Lean proof)
 │   ├── multi_agent_proof.py        # CLI principal

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/galois_lean/README.md
@@ -1,6 +1,6 @@
 # Problème inverse de Galois — M₂₃ groupe de Galois sur ℚ
 
-Lake `galois_lean` : couche de preuve pour le notebook **Lean-19** (problème inverse de Galois), autour du groupe sporadique de Mathieu M₂₃.
+Lake `galois_lean` : couche de preuve pour le notebook **[Lean-23](../Lean-23-Galois-Probleme-Inverse-M23.ipynb)** (problème inverse de Galois), autour du groupe sporadique de Mathieu M₂₃.
 
 ## Contexte
 
@@ -29,12 +29,12 @@ Deux énoncés, soigneusement distingués dans le notebook :
 
 ## Pourquoi réutiliser l'amont plutôt que réécrire
 
-Per `sota-not-workaround` : refaire une échelle de petits groupes à côté d'une preuve M₂₃ déjà faite (sorry-free, Apache-2.0) serait la **réimplémentation-jouet** interdite. On réutilise l'amont avec attribution. La partie *from-scratch* du lake (notebook Lean-19) porte sur la **pédagogie du problème inverse de Galois** (vérification indépendante du polynôme de degré 23 via sympy, système de Steiner S(4,7,23), vocabulaire SGA1), pas sur la réémergence de la preuve de groupe.
+Per `sota-not-workaround` : refaire une échelle de petits groupes à côté d'une preuve M₂₃ déjà faite (sorry-free, Apache-2.0) serait la **réimplémentation-jouet** interdite. On réutilise l'amont avec attribution. La partie *from-scratch* du lake (notebook Lean-23) porte sur la **pédagogie du problème inverse de Galois** (vérification indépendante du polynôme de degré 23 via sympy, système de Steiner S(4,7,23), vocabulaire SGA1), pas sur la réémergence de la preuve de groupe.
 
 ## Attribution
 
 - Amont : Copyright (c) 2026 Kenta. — licence Apache-2.0. Chaque fichier dérivé préserve l'en-tête amont + la note *« AI usage: Developed with assistance from Claude Code (Fable 5, 1M context, high reasoning) »*.
-- Le notebook Lean-19 (à venir) documentera explicitement que l'identification `23T5 = M23` (groupe de Galois) requiert Magma propriétaire et n'est **pas** reproduite — seule la vérification du polynôme (degré, irréductibilité, discriminant) est exécutable en sympy.
+- Le notebook Lean-23 documente explicitement que l'identification `23T5 = M23` (groupe de Galois) requiert Magma propriétaire et n'est **pas** reproduite — seule la vérification du polynôme (degré, irréductibilité, discriminant) est exécutable en sympy.
 
 ## Voir aussi
 


### PR DESCRIPTION
## Summary

Pièces **2+3** de #10478 (claim lane myia-po-2026 du 2026-08-11 par dispatch coord, réactivé ce cycle) : le notebook pédagogique `Lean-23-Galois-Probleme-Inverse-M23.ipynb` et les attributions complètes. La Pièce 1 (lake + buildabilité) était déjà livrée (#10486, #11014).

## Livrable

**Notebook 25 cellules (12 code) — kernel python3 + Lean via `lean_notebook_utils`** (pattern Epic #2314, cf Lean-16b) :

| Section | Contenu | Ancrage réel |
|---|---|---|
| Les deux énoncés | tableau PROUVÉ vs CITÉ dès l'intro | — |
| 1. Histoire | Hilbert 1892 → vague 1984-1989 (25/26 par rigidité) → M₂₃ non rigide → 9 août 2026 | arXiv:2608.08538 |
| 2. Attributions | Kenta (Apache-2.0, en-tête vendored) + 6 auteurs préprint + dépôt compagnon | en-tête fichier + arXiv |
| 3. M₂₃ exécuté | `lake build` rc=0 **1339 jobs** (v4.32.1 natif Windows), `#check @Sporadic.card_M23`/`simple_M23`, `#print axioms` = `[propext, Classical.choice, Quot.sound]` | outputs collés |
| 4. Design de Witt | 253 heptades extraites du source Lean, propriété S(4,7,23) échantillonnée 200/200, arithmétique C(23,4)/C(7,4)=253 | outputs réels |
| 5. Chaîne citée | Belyi non rigide → existence de Riemann → descente → Hilbert ; socle `grothendieck_lean` (96 modules listés) ; « NON formalisé » noir sur blanc | listing disque |
| 6. Polynôme f₁ | empreinte 6 champs recalculée = `f1_expect` du .gp, degré 23, **irréductible sur ℚ** (sympy), discriminant 383 chiffres, Frobenius mod 2/3/5/7/11 (deg×mult, somme 23) | outputs réels |
| 7. Exercices | 3 stubs C.1 (arithmétique |M₂₃|, vérification exhaustive S(4,7,23) 8855 quadruplets, f₂ du dépôt compagnon) | — |

**Honnêteté des métriques** : le compteur sorry distingue **position de preuve** (0) des occurrences textuelles (2, toutes en commentaire d'en-tête licence) — la sortie l'affiche explicitement. L'identification `23T5 = M₂₃` (Magma) est déclarée **non reproduite**.

## Preuves d'exécution (H.1)

- nbclient EXEC OK **212 s**, 12/12 cellules code `execution_count` 1..12 monotones, **0 erreur**, **0 chemin machine** (projection `.../galois_lean`, convention série).
- `lake build` SUCCESS complet dans la cellule : `Build completed successfully (1339 jobs)` + les 4 `#print axioms` (M22/M23 × card/simple) tous `[propext, Classical.choice, Quot.sound]`.
- Build du lake effectif : toolchain v4.32.1 **natif Windows** (pivot après stall WSL drvfs — oleans 8639 téléchargés, 5,8 Go, cache-get ~7 min natif NTFS).
- Vérifications sympy pré-testées standalone (irréductibilité <1 s, discriminant 383 chiffres instantané, mod-p factorisations).

## Autres fichiers

- `README.md` série : ligne 23 table Contenu (durée totale 20h55→21h40), acquis « paysage galoisien » actualisé (« à venir » → livré), arbre galois_lean, ligne maturité 23.
- `galois_lean/README.md` : 3 pointeurs « Lean-19 (à venir) » → Lean-23 livré (lien).
- `Lean-22-MIMO` : lien navigation suivant → Lean-23 (seule cellule modifiée = markdown header, outputs inchangés).
- Staleness préexistant signalé (non corrigé, hors scope) : la table « Statut de maturité » s'arrête à 17b — lignes 18-22 manquantes.

## Critères #10478

- [x] notebook exécuté, `execution_count != null` partout, log dans le corps (H.1)
- [x] ≥3 exercices, stubs sans erreur volontaire (C.1)
- [x] les deux énoncés distingués explicitement
- [x] attribution Apache-2.0 + six auteurs + date
- [x] sorry position de preuve = 0, `native_decide` = 0 sur le module (affiché dans la sortie)
- [x] `#print axioms` = liste blanche (affiché)
- [ ] docstrings FR + sibling `_en` du lake : **non applicable** — aucun nouveau fichier .lean dans cette PR

Grain: DEEP/notebook-lean — lane myia-po-2026:CoursIA — prev: MED/notebook-genai-density #11560

See #10478