### PR TITLE
feat(twin-parity,#11200): bascule native-both Vague 3 -- 15 paires Probas Infer.NET/PyMC

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-1-setup.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-1-Setup.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-1-Setup.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: d7f6c2180b23d7ba10cbf84c317130a14bad28e5
+      csharp_sha: 08d80a7b526cec74e667ecb04eca32cc443374de
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2
       python_sha: d66cca0ab2869a855a3d57c7a23072d9409c9ab5

--- a/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-10-model-selection.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-10-Model-Selection.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-10-Model-Selection.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 4481dfa722eff68e157a8beaf4287ad3bf1bd1c4
+      csharp_sha: bd2e254a7fc1a1a387c7cb66c52325c385309509
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 4aef3828fcb8976eabcfbc56000d50487dc619e2

--- a/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-11-topic-models.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-11-Topic-Models.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-11-Topic-Models.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 9f95808fd0654099f12d9a40dac437d508f4125e
+      csharp_sha: e61bc677cace7fe0525f0f2d3d065fd6ac16a793
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 60fbbf573921efe05e991d4d04f773144f4a6779

--- a/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-12-modeles-hierarchiques.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-12-Modeles-Hierarchiques.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-12-Modeles-Hierarchiques.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 49badb1775f020524bacc681a50ab573fbe01eec
+      csharp_sha: 3606ff946d2c9622571442060c48a53d5cf14910
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 91a08f3e69ac3eec7a3341d281a7b5386f018b5a

--- a/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-13-Crowdsourcing.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-13-Crowdsourcing.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 246ba905ee53e1dcbae37a711e47a1622eac72b7
+      csharp_sha: cd3a596713c655135eb79b91dabd651fa03f0d35
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 246ba905ee53e1dcbae37a711e47a1622eac72b7

--- a/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-14-sequences.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-14-Sequences.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-14-Sequences.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: fc662a501dc293442f03ed0736cb5d77680c5358
+      csharp_sha: 1780a6871a8dd4eb0d5fbc8a8a137c229bf67ae7
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 81c45947b4322974083d5dedaff85a5aa8dc97d8

--- a/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-15-recommenders.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-15-Recommenders.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-15-Recommenders.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: ef25910c68c997d06b87c0880fc4862e9373b672
+      csharp_sha: 8515db78ca285f0803e3ea0aee906ce3f2f5fa13
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 2139bf0a6063766923006eb2a30fa9791dd01e2d

--- a/scripts/notebook_tools/twin_pairs.d/probas-2-gaussian-mixtures.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-2-gaussian-mixtures.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-2-Gaussian-Mixtures.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-2-Gaussian-Mixtures.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: cdbe03ebede1425d353d1b578415d44d650bf36d
+      csharp_sha: bb5e960f34d3078ab2c857945c5f368e57c988a3
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-03"
       by: myia-po-2024:CoursIA-2
       python_sha: 643d15d579b04ba4d571684b542ae01c7afb60a9

--- a/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-3-factor-graphs.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-3-Factor-Graphs.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-3-Factor-Graphs.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 8be87123cf063f6743db86bcd1bb2cd97f944020
+      csharp_sha: 4024549ae3bb76a1fa276174a77c6602fa9671c2
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2
       python_sha: 5929bd4bbe321ca89056a4d92209fdb5b30bc821

--- a/scripts/notebook_tools/twin_pairs.d/probas-4-bayesian-networks.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-4-bayesian-networks.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-4-Bayesian-Networks.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-4-Bayesian-Networks.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 1eaf878c9bd25b664c687b12d6e61bc68eb20533
+      csharp_sha: 9935364fad5fda48d306b739658ed36e63b1dddc
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-07-30"
       by: myia-po-2024:CoursIA-2
       python_sha: 1eaf878c9bd25b664c687b12d6e61bc68eb20533

--- a/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-5-causal-inference.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-5-Causal-Inference.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-5-Causal-Inference.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 9c569a28a0d7395d0211dfc26a9d0a00cd03f4d2
+      csharp_sha: 85bc41d76098400b0727d7ea7b6184d021704f4c
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2
       python_sha: 9c569a28a0d7395d0211dfc26a9d0a00cd03f4d2

--- a/scripts/notebook_tools/twin_pairs.d/probas-6-debugging.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-6-debugging.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-6-Debugging.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 76d2f1fabc983e6752960b198ab567e627ce1f79
+      csharp_sha: 7a620e4f99806eb368c890e2ada2e9f8c83a0b2e
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 5be9114fb786b0af0162783143398e61fd5c8f90

--- a/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-7-skills-irt.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-7-Skills-IRT.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-7-Skills-IRT.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 11375befea475f214935935283ae3a1da08ec3eb
+      csharp_sha: 605d0f4b203dcabe7969c33da632779c0e3fef7f
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2
       python_sha: f1f4080df62766027a4583aaee04b435dd931374

--- a/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-8-trueskill.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-8-TrueSkill.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-8-TrueSkill.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: cc111b5f9f915ac7cf64a577a473cc6fe0ce0cc7
+      csharp_sha: c9a371fce477c487466ee3549cae114c9963d418
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-01"
       by: myia-po-2026:CoursIA
       python_sha: 14097169f417cf18752f051f0f41f61802871844

--- a/scripts/notebook_tools/twin_pairs.d/probas-9-classification.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-9-classification.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-9-Classification.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-9-Classification.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 5171f5eac673b08f03930ad3cf8ba67516cea121
+      csharp_sha: 6902462cf7e1edda8485a90902f85c3fa382d860
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les 38 notebooks (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-07-29"
       by: myia-po-2023:CoursIA-2
       python_sha: 5171f5eac673b08f03930ad3cf8ba67516cea121


### PR DESCRIPTION
Grain: MED/twin-parity — lane myia-po-2026:CoursIA — prev: MED/notebook-python #11575

## Summary

Vague 3 du balayage **Option A** (parité de moteur, lib-vs-lib — arbitrage ai-01 2026-08-16 sur #11200) : bascule `parity_level: semantic -> native-both` sur **15 paires Probas** du registre twin (`probas-1..15`).

Chaque côté atteint le moteur probabiliste SOTA de son écosystème :
- **C#** = `Microsoft Infer.NET` (`Microsoft.ML.Probabilistic`, NuGet officiel, native .NET, inférence variationnelle EP/VMP)
- **Python** = `PyMC` (pip pymc, native Python, NUTS/HMC + ADVI)

Suite directe des Vagues 1 (#11465, 8 paires Search/Z3) et 2 (#11559, 7 paires ML.NET, OPEN) — fichiers **disjoints**, même pattern. Suite du claim actif de `myia-po-2026:CoursIA` (2026-08-17T10:39Z sur #11200, paths `twin_pairs.d/*.yaml` hors `_schema.yaml`).

**Tranche limitée à 15 fichiers** (seuil §A pr-review-discipline : > 15 changedFiles = split). Les 4 restantes (`probas-16..19`) suivent en Vague 3b.

## Changes

- 15 fichiers `scripts/notebook_tools/twin_pairs.d/probas-{1..15}-*.yaml` : flip `parity_level` + entrée d'audit en tête (date 2026-08-18, `python_sha`/`csharp_sha` frais `git ls-tree origin/main`, reason citant l'arbitrage).
- `bridge_verdict`, `bridge_verdict_reason`, `known_differences` : **inchangés** (le bridge était déjà documenté SOTA-OK lib-vs-lib par le verdict existant, rationale identique sur les 19 paires, citée par owner #10382 « PyMC vs Infer, 2 moteurs qui brillent »).

## Validation

- **Re-parse YAML 15/15 OK** après flip (`yaml.safe_load`, racine liste, `doc[0]`, audit head daté 2026-08-18, shas 40-car).
- **Vérif firsthand G.1 (pas propagation du claim du registre)** : re-grep imports des 30 notebooks de la tranche le 2026-08-18 — `import pymc|from pymc` présent côté Python **30/30**, `Microsoft.ML.Probabilistic` présent côté C# **30/30**.
- **Scanner** (`scan_native_both_drift.py`, branche feature/c174-11200-twin-sweep, exécuté par placement temporaire puis retiré du worktree) :
  - `TRIVIAL_BASCULE: 64 -> 49` (−15, exactement les 15 flips)
  - `ALREADY_NATIVE_BOTH: 37 -> 52` (+15)
  - `SOLVER_FREE: 12`, `AMBIGUOUS: 13` : inchangés.
- Catalogue byte-identique à main (aucun fichier catalogue touché). Aucun notebook touché.

## État du balayage après cette vague

30/64 TRIVIAL_BASCULE traitées (V1 8 + V2 7 + V3 15). Restent : Probas 4 (16..19), SemanticWeb 11, Sudoku 6, Tweety 6, Search 6, GameTheory 1 + SOLVER_FREE 12 + AMBIGUOUS 13 (scanner c174 à merger d'abord).

See #11200
See #10382