### PR TITLE
feat(twin-parity,#11200): bascule native-both Vague 3b -- 4 Probas restantes + 11 SemanticWeb dotNetRDF/rdflib

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-16-sparse-gaussian-process.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-16-Sparse-Gaussian-Process.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-16-Sparse-Gaussian-Process.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 4a3d89cb84ea32e95a307f04396253f9291800a4
+      csharp_sha: 3ba21c169e6c85cfbd5185acb5444d3a57d5cbcf
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 5743c084f9060ed197a7acf541bf2611f89c7505

--- a/scripts/notebook_tools/twin_pairs.d/probas-17-kalman-filter.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-17-kalman-filter.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-17-Kalman-Filter.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-17-Kalman-Filter.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 92f49cfd7f33fff4e811fdb0842db13c5223fb57
+      csharp_sha: d939f2694311d205a9c0980da216033ee4481389
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-01"
       by: myia-po-2023:CoursIA
       python_sha: 92f49cfd7f33fff4e811fdb0842db13c5223fb57

--- a/scripts/notebook_tools/twin_pairs.d/probas-18-change-point.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-18-change-point.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-18-Change-Point.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-18-Change-Point.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: a1219285566fe34d6b7d46547791c4d8943c0f64
+      csharp_sha: e696a6c6e93fbbbf880dbc3ea33b77d58df83a88
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: f295cceb90dc134cb19ebda5860bb121a77e2174

--- a/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-19-survival-analysis.yaml
@@ -2,10 +2,15 @@
   family: Probas/Infer.NET-PyMC
   python: MyIA.AI.Notebooks/Probas/PyMC/PyMC-19-Survival-Analysis.ipynb
   csharp: MyIA.AI.Notebooks/Probas/Infer/Infer-19-Survival-Analysis.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib cite par owner #10382 (\"PyMC vs Infer, 2 moteurs qui brillent\") : C# = Microsoft Infer.NET (Microsoft.ML.Probabilistic, NuGet officiel, native .NET, inférence variationnelle EP/VMP) et Python = PyMC (pip pymc, native Python, NUTS/HMC + ADVI). Chaque cote atteint le moteur SOTA de son ecosysteme probabiliste -- ni pont intermediaire ni reimplementation. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# Microsoft.ML.Probabilistic refs + execution_count, Python pymc imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: d951123eb5200aee5cac92f2e6401364fdc2e3c2
+      csharp_sha: 87c507d543517e61008fb47bb65b833b56ef4717
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint Microsoft Infer.NET (Microsoft.ML.Probabilistic, moteur probabiliste SOTA de l'ecosysteme .NET, EP/VMP), Python atteint PyMC (NUTS/HMC + ADVI, moteur probabiliste SOTA de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (pymc / Microsoft.ML.Probabilistic, re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: d4ab43338f4c2f7ace1f3377830af97bed5acf4b

--- a/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 2043be1e638157cf01189d44cfa70f5c4ae061d0
+      csharp_sha: e184307cf2a6180399e776bf200058e283fb9bf2
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 2043be1e638157cf01189d44cfa70f5c4ae061d0

--- a/scripts/notebook_tools/twin_pairs.d/sw-11-knowledge-graphs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-11-knowledge-graphs.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-Python-KnowledgeGraphs.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-11-CSharp-KnowledgeGraphs.ipynb
-  parity_level: surface
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: a10e51c238cde777905354166118fd1bc5ad199a
+      csharp_sha: 47e9629433702421b9bff134b157efe7673ed12c
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: a10e51c238cde777905354166118fd1bc5ad199a

--- a/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Reasoners-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 1eb456c6fac29fcd4f2cc3b145acff04a5775a93
+      csharp_sha: 160675f58686100e1d03eecc047e34698ac4997a
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: a5ef2be10882b29368b2d0ec680ecf828ab59213

--- a/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2-CSharp-RDFBasics.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 6d4e6bfdf2ca676926c76abda7da505698185020
+      csharp_sha: fcea9bfbc914f113a7448e2511941ec09908d787
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 1ec640b95feee7021d0f7df93e598101b878dd13

--- a/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-3-graph-operations.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3b-Python-GraphOperations.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-3-CSharp-GraphOperations.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 91c69994024084bea93a0823230255624b828ce1
+      csharp_sha: d9b84f34b00f68039f500f42cbe354684ee8b8b6
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 91c69994024084bea93a0823230255624b828ce1

--- a/scripts/notebook_tools/twin_pairs.d/sw-4-sparql.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-4-sparql.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4b-Python-SPARQL.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-4-CSharp-SPARQL.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 441dbb88b6d54217818a9ebbca05d097b79cd932
+      csharp_sha: 9e7802abab2015810c17568b31ac4695eb53beae
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 441dbb88b6d54217818a9ebbca05d097b79cd932

--- a/scripts/notebook_tools/twin_pairs.d/sw-5-linked-data.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-5-linked-data.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5b-Python-LinkedData.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-5-CSharp-LinkedData.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 607ce735712708a08ebc37db2f5a7d19a0d16dfc
+      csharp_sha: 9cfb80bc05aa73594102d90d93276e52356a4977
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 607ce735712708a08ebc37db2f5a7d19a0d16dfc

--- a/scripts/notebook_tools/twin_pairs.d/sw-6-rdfs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-6-rdfs.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6b-Python-RDFS.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-6-CSharp-RDFS.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 9e4785fc0879d45754e3e40fd0ae418ca2462993
+      csharp_sha: f7a8a4f6cd60d8ce6484a1eac41072fe304e60f5
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 9e4785fc0879d45754e3e40fd0ae418ca2462993

--- a/scripts/notebook_tools/twin_pairs.d/sw-7-owl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-7-owl.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7-CSharp-OWL.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "OWL dispose de 2 moteurs SOTA de reference, un par ecosysteme : Python = owlready2 (Lamy 2017, reference OWL en Python, world/Thing/Property API nativement orientee OWL ; citee par la doc officielle W3C OWL RL examples) ; .NET = dotNetRDF (VDS.RDF.Ontology, librairie .NET de reference pour RDF+OWL depuis 2010, ~100k lignes, OntologyGraph + OwlReasoner). Les 2 jumeaux branchent leur moteur SOTA natif respectif sur le meme enseignement OWL (classes/proprietes/restrictions/axiomes). Verdict SOTA-OK des deux cotes."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 95f6fb513c53bb133e9f47966e26e812ba86ad11
+      csharp_sha: 25c773f11a9fcdf9c6d03d88a3c3a39102399095
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python) ; cas particulier sw-7 : Python atteint owlready2, moteur OWL de reference en Python (documente dans le verdict existant). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 95f6fb513c53bb133e9f47966e26e812ba86ad11

--- a/scripts/notebook_tools/twin_pairs.d/sw-8-shacl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-8-shacl.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-Python-SHACL.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-8-CSharp-SHACL.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 7415f9039debcbcd90e75a12eab087aba94a7e41
+      csharp_sha: fce2451b700090a2515d64a49e550eae1e0c0e6b
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 7415f9039debcbcd90e75a12eab087aba94a7e41

--- a/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-9-json-ld.yaml
@@ -2,10 +2,15 @@
   family: SemanticWeb/dotNetRDF-rdflib
   python: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-Python-JSONLD.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Modele nominal lib-vs-lib (#10382, comme PyMC/Infer.NET) : C# = dotNetRDF 3.2.1 (NuGet officiel `#r \"nuget: dotNetRDF, 3.2.1\"` + espaces VDS.RDF.*, native .NET) et Python = rdflib (from rdflib import *, native Python). Chaque cote atteint le moteur SOTA de son ecosysteme -- ni pont intermediaire (IKVM/PythonNet) ni reimplementation from-scratch. Aucune asymetrie de machinerie a corriger. Verifie firsthand : C# VDS.RDF refs + execution_count, Python rdflib imports."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 3c4a93bbf202cea7b12de79ff69d36291c49fc0b
+      csharp_sha: d61ac744c1807390a7625d78dd533ffa0511eea3
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : C# atteint dotNetRDF (VDS.RDF.*, librairie RDF/OWL de reference de l'ecosysteme .NET), Python atteint rdflib (moteur RDF natif de reference de l'ecosysteme Python). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 3c4a93bbf202cea7b12de79ff69d36291c49fc0b


### PR DESCRIPTION
Grain: MED/twin-parity — lane myia-po-2026:CoursIA — prev: MED/twin-parity #11576

## Summary

Vague 3b du balayage **Option A** (parité de moteur, lib-vs-lib — arbitrage ai-01 2026-08-16 sur #11200) : bascule `parity_level: semantic|surface -> native-both` sur **15 paires** — les **4 Probas restantes** (`probas-16..19`, complétant la famille 19/19) + les **11 SemanticWeb** (`sw-2..13`, famille complète).

Moteurs par côté :
- **Probas** : C# = `Microsoft Infer.NET` (Microsoft.ML.Probabilistic, EP/VMP), Python = `PyMC` (NUTS/HMC + ADVI)
- **SemanticWeb** : C# = `dotNetRDF` (VDS.RDF.*), Python = `rdflib` — sauf **sw-7-owl** où Python = `owlready2` (moteur OWL de référence, documenté dans le verdict existant)

Suite des Vagues 1 (#11465), 2 (#11559 OPEN), 3 (#11576 OPEN) — fichiers **tous disjoints**. Claim actif `myia-po-2026:CoursIA` (2026-08-17T10:39Z sur #11200). Groupement 15 fichiers (une famille complétée + une famille complète) conforme §A (= limite, pas >) et §E (>50 lignes).

## Changes

- 15 fichiers `twin_pairs.d/` : flip `parity_level` + entrée d'audit en tête (date 2026-08-18, shas frais `git ls-tree origin/main`, reason citant l'arbitrage).
- `bridge_verdict`, `bridge_verdict_reason`, `known_differences` : **inchangés** (le bridge était déjà documenté SOTA-OK lib-vs-lib par les verdicts existants).

## Validation

- **Re-parse YAML 15/15 OK** (racine liste, audit head 2026-08-18, shas 40-car).
- **Vérif firsthand G.1** (re-grep 2026-08-18, pas propagation du registre) :
  - probas-16..19 : `pymc` 4/4 côté Python, `Microsoft.ML.Probabilistic` 4/4 côté C#
  - sw-2..13 : `rdflib|owlready2` 11/11 côté Python, `dotNetRDF|VDS.RDF` 11/11 côté C#
- **Scanner** (`scan_native_both_drift.py`, branche feature/c174-11200-twin-sweep, exécuté par placement temporaire puis retiré) sur **base origin/main** (V3 #11576 non encore mergée, fichiers disjoints) :
  - `TRIVIAL_BASCULE: 64 -> 49` (−15), `ALREADY_NATIVE_BOTH: 37 -> 52` (+15), `SOLVER_FREE: 12`, `AMBIGUOUS: 13` inchangés.
  - Après merge cumulé V3 + V3b : `TRIVIAL_BASCULE: 64 -> 34` (30/64 traitées), familles Probas et SemanticWeb **complètes**.
- Catalogue byte-identique à main. Aucun notebook touché.

## État du balayage après V3+V3b

30/64 TRIVIAL_BASCULE traitées (V1 8 + V2 7 + V3 15 + V3b 15). Restent : Sudoku 6, Tweety 6, Search 6, GameTheory 1 + SOLVER_FREE 12 + AMBIGUOUS 13.

See #11200
See #10382