### PR TITLE
feat(lean,#11162): novelty bound for oscillators — trajectory bounded by p states, horizon-independent

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway.lean
@@ -82,6 +82,7 @@ import Conway.Life.HashlifeMarginDemo
 import Conway.Life.ConeGeometry
 import Conway.Life.LightCone
 import Conway.Life.Pillars
+import Conway.Life.Novelty
 import Conway.KochenSpecker
 import Conway.FreeWillTheorem
 import Conway.MathlibMap

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Novelty.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Novelty.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 CoursIA. Tous droits reserves.
+Distribue sous licence Apache 2.0 comme decrit dans le fichier LICENSE.
+
+## Jeu de la Vie de Conway — Borne de nouveaute pour la classe des oscillateurs
+
+Axe EFFICACITE de hashlife (#11162) : la quantite qui fait tenir Golly n'est
+pas le confinement (`jumpCaptured`, #11007 — la licence) mais la NOVEAUTE,
+c'est-a-dire la stabilite de l'ensemble des etats visites le long de la
+trajectoire. Ce module formalise l'invariant de stabilite pour la classe
+la plus simple : les oscillateurs.
+
+**Resultat.** Si `evolve p g = g` avec `p > 0` (g est un point fixe de la
+p-ieme iteratee — la periode au sens de `isOscillator`), alors la trajectoire
+complete `t |-> evolve t g` ne visite que des etats deja apparus dans les `p`
+premiers instants (`novelty_bound_of_period`), donc il existe un `Finset` de
+cardinal au plus `p` contenant toute la trajectoire
+(`trajectory_states_le_of_period`). La nouveaute au niveau grille est bornee
+par `p`, independamment de l'horizon : c'est le pendant quantitatif du
+constat empirique « Golly est rapide sur les oscillateurs ».
+
+**Portee et limite, documentees.** La borne est au niveau GRILLE (etats
+distincts). La nouveaute operationnelle de hashlife se mesure au niveau des
+NOEUDS de macrocells (taux de hit du cache de memoisation, avec partage de
+sous-arbres) : pour un oscillateur borde, chaque etat periodique engendre un
+arbre dont les sous-arbres se repetent, mais le passage grille -> arbre de
+macrocells a une taille qui croit avec la fenetre, et la borne au niveau
+noeud demande une induction sur la structure de `MacroCell` qui reste
+hors de portee de ce module (diagnostic ecrit, cf #11162 acceptation :
+l'alternative « borne deriverie ou diagnostic » est ici le diagnostic de la
+borne noeud, la borne grille etant livree).
+
+La caracterisation « quels motifs ont une nouveaute persistante » est
+indecidable a la limite (Life est Turing-complet : une machine de Turing
+programmee encode la production infinie de motifs neufs) — les patterns
+pathologiques (MT, #6724) sont les temoins de ce plafond.
+
+Ce module est entierement prouve (aucun `sorry`, aucun axiome natif).
+-/
+
+/-
+  Convention i18n (EPIC #4980, decision user 2026-07-04) : ce fichier est **FR canonique**,
+  avec son miroir anglais dans le fichier sibling `Novelty_en.lean` (modele sibling
+  pair ratifie 2026-07-04, cf `code-style.md` §Lean i18n). Les enonces de theoremes,
+  les tactiques Lean, les noms de lemmes et les references Mathlib restent en anglais
+  (compat Mathlib 4) ; seules les docstrings de theoreme et ce bloc d'en-tete different
+  entre les deux fichiers.
+-/
+
+import Conway.Life
+import Conway.Life.HashlifeCorrectness.Foundation
+
+namespace Conway
+namespace Life
+
+/-! ## Multiples de la periode
+
+Le lemme d'iteration `evolve_add` (Foundation, P4.4) dit que `evolve` est un
+morphisme de l'addition : composer `q` blocs de periode `p` ramene a l'etat
+initial. C'est la seule arithmetique dont la borne a besoin. -/
+
+/-- La periode se re-applique en tout point de la trajectoire : si
+`evolve p g = g`, alors `evolve p (evolve m g) = evolve m g` pour tout `m`.
+C'est la commutativite de l'addition des iteratees qui le donne :
+`p + m = m + p`, et le bloc `p` cote droit se reduit par `hp`. -/
+theorem evolve_period_shift (g : Grid) (p : Nat) (hp : evolve p g = g) (m : Nat) :
+    evolve p (evolve m g) = evolve m g := by
+  rw [← evolve_add, Nat.add_comm, evolve_add, hp]
+
+/-- Tout multiple de la periode laisse tout point de la trajectoire invariant :
+si `evolve p g = g`, alors `evolve (p * q) (evolve m g) = evolve m g` pour
+tous `q`, `m` — le bloc `p * q` se decompose en `q` blocs `p`, chacun se
+reduisant par `evolve_period_shift`. -/
+theorem evolve_mul_shift (g : Grid) (p : Nat) (hp : evolve p g = g) (q m : Nat) :
+    evolve (p * q) (evolve m g) = evolve m g := by
+  induction q with
+  | zero => simp
+  | succ q ih => rw [Nat.mul_succ, evolve_add, evolve_period_shift g p hp m, ih]
+
+/-- Tout multiple de la periode ramene a l'etat initial : si `evolve p g = g`,
+alors `evolve (p * q) g = g` pour tout `q` (cas `m = 0` du shift). -/
+theorem evolve_mul_of_period (g : Grid) (p : Nat) (hp : evolve p g = g) (q : Nat) :
+    evolve (p * q) g = g := by
+  simpa using evolve_mul_shift g p hp q 0
+
+/-! ## Borne de nouveaute (niveau grille)
+
+L'invariant de stabilite : apres `p` instants, la trajectoire ne produit plus
+d'etat neuf. Tout ce qui est visite a l'instant `t` est deja apparu a un
+instant `r < p`. -/
+
+/-- **Borne de nouveaute pour un oscillateur** : si `evolve p g = g` avec
+`p > 0`, alors tout etat visite a un instant quelconque `t` est deja apparu
+dans les `p` premiers instants — la trajectoire ne produit jamais d'etat
+neuf apres la periode. Le temoin est le reste `t % p`. -/
+theorem novelty_bound_of_period (g : Grid) (p : Nat) (hp0 : 0 < p)
+    (hp : evolve p g = g) (t : Nat) :
+    ∃ r, r < p ∧ evolve t g = evolve r g := by
+  obtain ⟨r, hr, hdecomp⟩ : ∃ r, r < p ∧ t = p * (t / p) + r :=
+    ⟨t % p, Nat.mod_lt t hp0, (Nat.div_add_mod t p).symm⟩
+  refine ⟨r, hr, ?_⟩
+  rw [hdecomp, evolve_add, evolve_mul_shift g p hp (t / p) r]
+
+/-- **Cardinal de la trajectoire** : la trajectoire complete d'un oscillateur
+de periode `p` tient dans un `Finset` de cardinal au plus `p`. C'est la
+formulation ensembliste de « au plus `p` etats distincts », le pendant
+formel du constat empirique « Golly est rapide sur les oscillateurs » :
+le taux de hit de la memoisation ne peut pas se degrader avec l'horizon. -/
+theorem trajectory_states_le_of_period (g : Grid) (p : Nat) (hp0 : 0 < p)
+    (hp : evolve p g = g) :
+    ∃ s : Finset Grid, s.card ≤ p ∧ ∀ t : Nat, evolve t g ∈ s := by
+  refine ⟨(Finset.range p).image (fun r => evolve r g),
+    Finset.card_image_le.trans_eq (Finset.card_range p), fun t => ?_⟩
+  obtain ⟨r, hr, heq⟩ := novelty_bound_of_period g p hp0 hp t
+  exact Finset.mem_image.2 ⟨r, Finset.mem_range.2 hr, heq.symm⟩
+
+/-! ## Application : le blinker
+
+Le blinker (periode 2, `blinker_period_two` dans `Conway.Life`) visite au
+plus 2 etats — l'horizontal et le vertical — quel que soit l'horizon. -/
+
+/-- La trajectoire du blinker horizontal (periode 2) tient dans un `Finset`
+de cardinal au plus 2 : deux etats distincts, jamais plus, quel que soit
+l'horizon de simulation. -/
+theorem blinker_h_trajectory_states_le :
+    ∃ s : Finset Grid, s.card ≤ 2 ∧ ∀ t : Nat, evolve t blinker_h ∈ s :=
+  trajectory_states_le_of_period _ 2 (by norm_num) (by decide)
+
+end Life
+end Conway

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Novelty_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/Novelty_en.lean
@@ -1,0 +1,133 @@
+/-
+Copyright (c) 2026 CoursIA. All rights reserved.
+Distributed under the Apache 2.0 license as described in the LICENSE file.
+
+## Conway's Game of Life — Novelty bound for the class of oscillators
+
+The EFFICIENCY axis of hashlife (#11162): the quantity that makes Golly
+fast is not confinement (`jumpCaptured`, #11007 — the licence) but
+NOVELTY, i.e. the stability of the set of states visited along the
+trajectory. This module formalizes the stability invariant for the
+simplest class: oscillators.
+
+**Result.** If `evolve p g = g` with `p > 0` (g is a fixed point of the
+p-th iterate — the period in the sense of `isOscillator`), then the whole
+trajectory `t |-> evolve t g` only visits states already seen within the
+first `p` steps (`novelty_bound_of_period`), hence there exists a `Finset`
+of cardinal at most `p` containing the entire trajectory
+(`trajectory_states_le_of_period`). The grid-level novelty is bounded by
+`p`, independently of the horizon: this is the quantitative counterpart of
+the empirical fact "Golly is fast on oscillators".
+
+**Scope and limit, documented.** The bound is at the GRID level (distinct
+states). The operational novelty of hashlife is measured at the level of
+MACROCELL NODES (memoization cache hit rate, with subtree sharing): for a
+bounded oscillator each periodic state grows a tree whose subtrees repeat,
+but the grid -> macrocell tree passage has a size growing with the window,
+and the node-level bound requires an induction over the `MacroCell`
+structure which remains out of reach of this module (written diagnosis,
+cf #11162 acceptance: the "derived bound or diagnosis" alternative is here
+the diagnosis of the node-level bound, the grid-level bound being
+delivered).
+
+The characterization "which patterns have persistent novelty" is
+undecidable in the limit (Life is Turing-complete: a programmed Turing
+machine encodes the infinite production of new patterns) — pathological
+patterns (TM, #6724) are the witnesses of this ceiling.
+
+This module is fully proved (no `sorry`, no native axioms).
+-/
+
+/-
+  i18n convention (EPIC #4980, user decision 2026-07-04): this file is the
+  **English sibling** of the canonical French `Novelty.lean` (sibling-pair
+  model ratified 2026-07-04, cf `code-style.md` §Lean i18n). Theorem
+  statements, Lean tactics, lemma names and Mathlib references stay in
+  English (Mathlib 4 compatibility); only theorem docstrings and this
+  header block differ between the two files.
+-/
+
+import Conway.Life
+import Conway.Life.HashlifeCorrectness.Foundation
+
+namespace Conway_en
+open Conway
+namespace Life_en
+open Life
+
+/-! ## Multiples of the period
+
+The iteration lemma `evolve_add` (Foundation, P4.4) says that `evolve` is a
+morphism of addition: composing `q` blocks of period `p` returns to the
+initial state. This is the only arithmetic the bound needs. -/
+
+/-- The period re-applies at every point of the trajectory: if
+`evolve p g = g`, then `evolve p (evolve m g) = evolve m g` for all `m`.
+This is the commutativity of iterate addition at work: `p + m = m + p`,
+and the `p` block on the right reduces by `hp`. -/
+theorem evolve_period_shift (g : Grid) (p : Nat) (hp : evolve p g = g) (m : Nat) :
+    evolve p (evolve m g) = evolve m g := by
+  rw [← evolve_add, Nat.add_comm, evolve_add, hp]
+
+/-- Every multiple of the period leaves every point of the trajectory
+invariant: if `evolve p g = g`, then `evolve (p * q) (evolve m g) = evolve m g`
+for all `q`, `m` — the `p * q` block decomposes into `q` blocks `p`, each
+reducing by `evolve_period_shift`. -/
+theorem evolve_mul_shift (g : Grid) (p : Nat) (hp : evolve p g = g) (q m : Nat) :
+    evolve (p * q) (evolve m g) = evolve m g := by
+  induction q with
+  | zero => simp
+  | succ q ih => rw [Nat.mul_succ, evolve_add, evolve_period_shift g p hp m, ih]
+
+/-- Every multiple of the period returns to the initial state: if
+`evolve p g = g`, then `evolve (p * q) g = g` for all `q` (the `m = 0`
+case of the shift). -/
+theorem evolve_mul_of_period (g : Grid) (p : Nat) (hp : evolve p g = g) (q : Nat) :
+    evolve (p * q) g = g := by
+  simpa using evolve_mul_shift g p hp q 0
+
+/-! ## Novelty bound (grid level)
+
+The stability invariant: after `p` steps, the trajectory produces no new
+state. Everything visited at time `t` has already been seen at some time
+`r < p`. -/
+
+/-- **Novelty bound for an oscillator**: if `evolve p g = g` with `p > 0`,
+then every state visited at an arbitrary time `t` has already been seen
+within the first `p` steps — the trajectory never produces a new state
+after the period. The witness is the remainder `t % p`. -/
+theorem novelty_bound_of_period (g : Grid) (p : Nat) (hp0 : 0 < p)
+    (hp : evolve p g = g) (t : Nat) :
+    ∃ r, r < p ∧ evolve t g = evolve r g := by
+  obtain ⟨r, hr, hdecomp⟩ : ∃ r, r < p ∧ t = p * (t / p) + r :=
+    ⟨t % p, Nat.mod_lt t hp0, (Nat.div_add_mod t p).symm⟩
+  refine ⟨r, hr, ?_⟩
+  rw [hdecomp, evolve_add, evolve_mul_shift g p hp (t / p) r]
+
+/-- **Trajectory cardinal**: the whole trajectory of an oscillator of
+period `p` fits in a `Finset` of cardinal at most `p`. This is the
+set-theoretic formulation of "at most `p` distinct states", the formal
+counterpart of the empirical fact "Golly is fast on oscillators": the
+memoization hit rate cannot degrade with the horizon. -/
+theorem trajectory_states_le_of_period (g : Grid) (p : Nat) (hp0 : 0 < p)
+    (hp : evolve p g = g) :
+    ∃ s : Finset Grid, s.card ≤ p ∧ ∀ t : Nat, evolve t g ∈ s := by
+  refine ⟨(Finset.range p).image (fun r => evolve r g),
+    Finset.card_image_le.trans_eq (Finset.card_range p), fun t => ?_⟩
+  obtain ⟨r, hr, heq⟩ := novelty_bound_of_period g p hp0 hp t
+  exact Finset.mem_image.2 ⟨r, Finset.mem_range.2 hr, heq.symm⟩
+
+/-! ## Application: the blinker
+
+The blinker (period 2, `blinker_period_two` in `Conway.Life`) visits at
+most 2 states — horizontal and vertical — whatever the horizon. -/
+
+/-- The trajectory of the horizontal blinker (period 2) fits in a `Finset`
+of cardinal at most 2: two distinct states, never more, whatever the
+simulation horizon. -/
+theorem blinker_h_trajectory_states_le :
+    ∃ s : Finset Grid, s.card ≤ 2 ∧ ∀ t : Nat, evolve t blinker_h ∈ s :=
+  trajectory_states_le_of_period _ 2 (by norm_num) (by decide)
+
+end Life_en
+end Conway_en


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11533

## Summary

Étape 1 de l'acceptance #11162 : **invariant de stabilité (nouveauté) formalisé en Lean pour la classe des oscillateurs** — nouveau module `Conway/Life/Novelty.lean` (+ sibling EN `Novelty_en.lean`, pattern #4980 sibling-pair, vérifié `check_i18n_siblings.py` **1/1 byte-identical**), importé depuis le root aggregator `Conway.lean` (+1 ligne).

**Résultats** (période au sens de `isOscillator` : `evolve p g = g`, `p > 0`) :

1. `evolve_period_shift` — la période s'applique en tout point de la trajectoire (`evolve p (evolve m g) = evolve m g`), par commutativité des itérées (`Nat.add_comm` + `evolve_add` de Foundation) ;
2. `evolve_mul_shift` — tout multiple `p * q` laisse tout point invariant (récurrence sur `q`) ;
3. `evolve_mul_of_period` — cas `m = 0` : `evolve (p * q) g = g` ;
4. `novelty_bound_of_period` — **tout état visité à un instant quelconque `t` est déjà apparu dans les `p` premiers instants** (témoin `r = t % p` via `Nat.div_add_mod`) : la trajectoire ne produit jamais d'état neuf après la période ;
5. `trajectory_states_le_of_period` — **la trajectoire complète tient dans un `Finset Grid` de cardinal ≤ `p`** (`(Finset.range p).image (evolve · g)`, `Finset.card_image_le`) : au plus `p` états distincts, indépendamment de l'horizon — le pendant formel du constat empirique « Golly est rapide sur les oscillateurs » (taux de hit de mémoïsation borné, ne se dégrade pas avec `t`) ;
6. `blinker_h_trajectory_states_le` — application au blinker (période 2, `blinker_period_two` par `decide` dans `Conway.Life`) : au plus 2 états quel que soit l'horizon.

**L'alternative de l'acceptance « borne dérivée ou diagnostic » est honorée des deux côtés** : borne **grille** dérivée (ci-dessus) ; borne **nœud** (macrocells, cache avec partage de sous-arbres) diagnostiquée hors de portée dans l'en-tête du module — elle demande une induction sur `MacroCell` avec taille d'arbre croissant avec la fenêtre. La métaphore MT/indécidabilité (#6724) est citée comme plafond de la caractérisation générale.

## Anti-régression (règle B)

- **`sorry` réel avant/après** (`count_code_sorry.py --json`, `distinct_code_sorry`) : conway_lean **1 → 1** inchangé (naïf 167→169 = le mot « sorry » dans la prose de mes 2 docstrings). 0 `native_decide`.
- **`lake build` SUCCESS (ciblé)** : `lake build Conway.Life.Novelty Conway.Life.Novelty_en` → **`Build completed successfully (8662 jobs)`** (WSL local, toolchain v4.32.0, mathlib v4.32.0, clôture d'imports complète incl. `Conway.Life.HashlifeCorrectness.Foundation`) — log collé en commentaire. **Build default-target complet interrompu localement 4× par OOM WSL** (hôte saturé, modules HashlifeCorrectness/Walls lourds) : la complétion du root aggregator est portée par le CI `lean-conway.yml` — les 2 modules sont de toute façon dans le default target par auto-découverte des globs du lakefile (`.submodules Conway`), indépendamment de l'import root.
- **Proof integrity (B.3) — non applicable, câblage** : le job bloquant de `lean-conway.yml` cible `Conway.KochenSpecher,Conway.FreeWillTheorem` — clôture d'imports n'atteignant pas le module leaf `Conway.Life.Novelty`. Équivalent local mesuré (`#print axioms`, collé en commentaire) : les 8 théorèmes (FR + EN) dépendent uniquement de `propext, Quot.sound` (+ `Classical.choice` sur les deux existentiels) — **aucun `sorryAx`, aucun `native_decide`**, sous-ensemble de l'allowlist du gate.
- i18n : `check_i18n_siblings.py Novelty.lean Novelty_en.lean` → **1/1 byte-identical** (signatures + preuves identiques, docstrings FR/EN seulement).

## Validation

- Fichiers `.lean` uniquement (aucune cellule notebook → H.3/C.2 non applicables).
- Catalogue byte-identique à main (aucun fichier catalogue touché).
- Ajout net : 2 nouveaux modules + 1 import dans le root ; zéro fichier existant modifié au-delà de l'import.

See #11162 (acceptance point 1 livré ; point 2 — probe Golly fast/slow par famille — reste ouvert)
