### PR TITLE
feat(track1,#11112): re-exec Labs residuels Lab2/Lab6/Lab7 (CLEAN 1..N) + C.1 fix Lab6

### DIFF
--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day2-Document-Agents/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day2-Document-Agents/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
@@ -82,10 +82,10 @@
    "id": "cce8d28f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:28.292539Z",
-     "iopub.status.busy": "2026-05-02T16:13:28.292225Z",
-     "iopub.status.idle": "2026-05-02T16:13:28.675843Z",
-     "shell.execute_reply": "2026-05-02T16:13:28.675505Z"
+     "iopub.status.busy": "2026-08-18T04:25:38.947388Z",
+     "iopub.execute_input": "2026-08-18T04:25:38.947828Z",
+     "shell.execute_reply": "2026-08-18T04:25:54.311058Z",
+     "iopub.status.idle": "2026-08-18T04:25:54.312547Z"
     },
     "papermill": {
      "duration": 0.386991,
@@ -98,11 +98,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Objet : Appel d'Offre - Solution de Prévision des Ventes. L'entreprise 'Global Retail' recherche un prestataire pour développer un système de prévision des ventes de ses produits phares. Les exigences techniques clés sont l'utilisation de modèles de Machine Learning (séries temporelles) et la livraison d'un dashboard interactif. Le projet doit être livré avant la fin du T4 2025. Notre objectif métier principal est de réduire les surplus de stocks de 15%.\n"
-     ]
+     "name": "stderr",
+     "text": "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\2109615833.py:1: DeprecationWarning: `langchain-community` is being sunset and is no longer actively maintained. See https://github.com/langchain-ai/langchain-community/issues/674 for details and migration guidance toward standalone integration packages.\n  from langchain_community.document_loaders import TextLoader\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Objet : Appel d'Offre - Solution de Prévision des Ventes. L'entreprise 'Global Retail' recherche un prestataire pour développer un système de prévision des ventes de ses produits phares. Les exigences techniques clés sont l'utilisation de modèles de Machine Learning (séries temporelles) et la livraison d'un dashboard interactif. Le projet doit être livré avant la fin du T4 2025. Notre objectif métier principal est de réduire les surplus de stocks de 15%.\n"
     }
    ],
    "source": [
@@ -143,10 +146,10 @@
    "id": "cbce3c96",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:28.683755Z",
-     "iopub.status.busy": "2026-05-02T16:13:28.683545Z",
-     "iopub.status.idle": "2026-05-02T16:13:30.005732Z",
-     "shell.execute_reply": "2026-05-02T16:13:30.005340Z"
+     "iopub.status.busy": "2026-08-18T04:25:54.314653Z",
+     "iopub.execute_input": "2026-08-18T04:25:54.315243Z",
+     "shell.execute_reply": "2026-08-18T04:26:01.429213Z",
+     "iopub.status.idle": "2026-08-18T04:26:01.430050Z"
     },
     "papermill": {
      "duration": 1.325012,
@@ -159,11 +162,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Chaîne d'extraction créée.\n"
-     ]
+     "name": "stdout",
+     "text": "Chaîne d'extraction créée.\n"
     }
    ],
    "source": [
@@ -225,10 +226,10 @@
    "id": "63d887da",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:30.013819Z",
-     "iopub.status.busy": "2026-05-02T16:13:30.013606Z",
-     "iopub.status.idle": "2026-05-02T16:13:32.358175Z",
-     "shell.execute_reply": "2026-05-02T16:13:32.357204Z"
+     "iopub.status.busy": "2026-08-18T04:26:01.431907Z",
+     "iopub.execute_input": "2026-08-18T04:26:01.432357Z",
+     "shell.execute_reply": "2026-08-18T04:26:03.606948Z",
+     "iopub.status.idle": "2026-08-18T04:26:03.608074Z"
     },
     "papermill": {
      "duration": 2.347997,
@@ -241,17 +242,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Informations extraites de l'appel d'offre :\n",
-      "\n",
-      "{\n",
-      "  \"objectif_metier\": \"Réduire les surplus de stocks de 15%\",\n",
-      "  \"exigences_techniques\": \"Utilisation de modèles de Machine Learning (séries temporelles) et livraison d'un dashboard interactif\",\n",
-      "  \"date_limite\": \"Fin du T4 2025\"\n",
-      "}\n"
-     ]
+     "name": "stdout",
+     "text": "Informations extraites de l'appel d'offre :\n\n{\n  \"objectif_metier\": \"Réduire les surplus de stocks de 15%\",\n  \"exigences_techniques\": \"Utilisation de modèles de Machine Learning (séries temporelles) et livraison d'un dashboard interactif\",\n  \"date_limite\": \"Fin du T4 2025\"\n}\n"
     }
    ],
    "source": [
@@ -289,10 +282,10 @@
    "id": "b01c6b1f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:32.380520Z",
-     "iopub.status.busy": "2026-05-02T16:13:32.380323Z",
-     "iopub.status.idle": "2026-05-02T16:13:32.386705Z",
-     "shell.execute_reply": "2026-05-02T16:13:32.384998Z"
+     "iopub.status.busy": "2026-08-18T04:26:03.610179Z",
+     "iopub.execute_input": "2026-08-18T04:26:03.610514Z",
+     "shell.execute_reply": "2026-08-18T04:26:03.614376Z",
+     "iopub.status.idle": "2026-08-18T04:26:03.615382Z"
     },
     "papermill": {
      "duration": 0.015319,
@@ -305,11 +298,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Chaîne de génération créée.\n"
-     ]
+     "name": "stdout",
+     "text": "Chaîne de génération créée.\n"
     }
    ],
    "source": [
@@ -363,10 +354,10 @@
    "id": "59d16d6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:32.410979Z",
-     "iopub.status.busy": "2026-05-02T16:13:32.410511Z",
-     "iopub.status.idle": "2026-05-02T16:13:35.776362Z",
-     "shell.execute_reply": "2026-05-02T16:13:35.775737Z"
+     "iopub.status.busy": "2026-08-18T04:26:03.617118Z",
+     "iopub.execute_input": "2026-08-18T04:26:03.617363Z",
+     "shell.execute_reply": "2026-08-18T04:26:06.262587Z",
+     "iopub.status.idle": "2026-08-18T04:26:06.263542Z"
     },
     "papermill": {
      "duration": 3.373283,
@@ -379,19 +370,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- ÉBAUCHE DE PROPOSITION TECHNIQUE ---\n",
-      "\n",
-      "Proposition technique:\n",
-      "\n",
-      "1. **Approche proposée:** Nous proposons de mettre en place un système de prévision des ventes basé sur des modèles de Machine Learning utilisant des séries temporelles. Ces modèles permettront d'anticiper la demande et ainsi réduire les surplus de stocks de 15% tout en maintenant un niveau de service optimal. De plus, nous développerons un dashboard interactif pour visualiser les prévisions et les données en temps réel.\n",
-      "\n",
-      "2. **Technologies clés:** Nous utiliserons des outils de Machine Learning tels que Python avec les bibliothèques scikit-learn et TensorFlow pour la modélisation des séries temporelles. Pour la création du dashboard interactif, nous opterons pour des technologies web comme HTML, CSS et JavaScript avec des frameworks comme React ou Angular pour une expérience utilisateur fluide et intuitive.\n",
-      "\n",
-      "3. **Livrables:** À la date limite de fin du T4 2025, nous livrerons un système de prévision des ventes basé sur des modèles de Machine Learning opérationnels, intégrés dans le système existant du client. De plus, nous fournirons un dashboard interactif permettant de visualiser les prévisions de manière claire et concise, facilitant ainsi la prise de décision pour la gestion des stocks.\n"
-     ]
+     "name": "stdout",
+     "text": "--- ÉBAUCHE DE PROPOSITION TECHNIQUE ---\n\nProposition technique:\n\n1. **Approche proposée:** Nous proposons de mettre en place un système de prévision des ventes basé sur des modèles de Machine Learning spécialisés dans l'analyse de séries temporelles. Ces modèles permettront de prédire avec précision la demande future, ce qui aidera à réduire les surplus de stocks de 15% tout en maintenant un niveau de service optimal.\n\n2. **Technologies clés:** Nous utiliserons des outils et des langages de programmation tels que Python, TensorFlow et scikit-learn pour développer les modèles de Machine Learning. Pour la création du dashboard interactif, nous opterons pour des technologies web comme HTML, CSS et JavaScript, avec éventuellement l'utilisation de bibliothèques comme D3.js pour la visualisation des données.\n\n3. **Livrables:** À la date limite fixée à la fin du T4 2025, nous livrerons au client un système de prévision des ventes opérationnel intégrant les modèles de Machine Learning, ainsi qu'un dashboard interactif permettant de visualiser les prévisions et les données en temps réel. Le client pourra ainsi prendre des décisions éclairées pour optimiser sa gestion des stocks et atteindre son objectif de réduction des surplus.\n"
     }
    ],
    "source": [
@@ -442,15 +423,20 @@
    "cell_type": "code",
    "id": "917e216a",
    "source": "# Exercice 1 : Estimation de budget\n# Creez une chaine LangChain qui estime le budget du projet\n\n# Etape 1: Definissez le template de prompt\n# Indice: demandez au LLM d'estimer en JH et en euros, pour le developpement et l'infrastructure\nbudget_template = None  # Remplacez None par votre template avec {exigences_techniques} et {date_limite}\n\n# Etape 2: Creez le prompt et la chaine avec LCEL\n# Indice: ChatPromptTemplate.from_template(...) puis | llm\nbudget_prompt = None\nbudget_chain = None\n\n# Etape 3: Invoquez la chaine avec les donnees extraites precedemment\n# Indice: budget_chain.invoke({\"exigences_techniques\": extracted_data[\"exigences_techniques\"], ...})\n# response_budget = ...\n\nprint(\"Exercice 1 a completer : estimation de budget avec LangChain\")",
-   "metadata": {},
-   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-18T04:26:06.265328Z",
+     "iopub.execute_input": "2026-08-18T04:26:06.265607Z",
+     "shell.execute_reply": "2026-08-18T04:26:06.268438Z",
+     "iopub.status.idle": "2026-08-18T04:26:06.269324Z"
+    }
+   },
+   "execution_count": 6,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "text": "Exercice 1 a completer : estimation de budget avec LangChain\n"
     }
    ]
   },
@@ -464,28 +450,33 @@
    "cell_type": "code",
    "id": "42e66402",
    "source": "# Exercice 2 : Comparaison de deux appels d'offres\n\n# Etape 1: Definissez un second appel d'offre fictif\n# Indice: ecrivez un texte similaire a l'appel d'offre original avec des exigences differentes\noffre_2_texte = None  # Remplacez None par un texte d'appel d'offre fictif\n\n# Etape 2: Definissez le template de comparaison\n# Indice: le template doit contenir {offre_1} et {offre_2} comme variables\ncomparaison_template = None  # Remplacez None par votre template\n\n# Etape 3: Creez le prompt et la chaine\n# Indice: meme pattern que les exercices precedents\ncomparaison_prompt = None\ncomparaison_chain = None\n\n# Etape 4: Testez avec les deux offres\n# Indice: comparaison_chain.invoke({\"offre_1\": document[0].page_content, \"offre_2\": offre_2_texte})\n\nprint(\"Exercice 2 a completer : comparaison de deux appels d'offres\")",
-   "metadata": {},
-   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-18T04:26:06.270951Z",
+     "iopub.execute_input": "2026-08-18T04:26:06.271221Z",
+     "shell.execute_reply": "2026-08-18T04:26:06.274566Z",
+     "iopub.status.idle": "2026-08-18T04:26:06.275419Z"
+    }
+   },
+   "execution_count": 7,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "text": "Exercice 2 a completer : comparaison de deux appels d'offres\n"
     }
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "216fa782",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T16:13:35.785208Z",
-     "iopub.status.busy": "2026-05-02T16:13:35.785057Z",
-     "iopub.status.idle": "2026-05-02T16:13:35.788347Z",
-     "shell.execute_reply": "2026-05-02T16:13:35.787718Z"
+     "iopub.status.busy": "2026-08-18T04:26:06.276896Z",
+     "iopub.execute_input": "2026-08-18T04:26:06.277159Z",
+     "shell.execute_reply": "2026-08-18T04:26:06.279659Z",
+     "iopub.status.idle": "2026-08-18T04:26:06.280485Z"
     },
     "papermill": {
      "duration": 0.006303,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day2-Document-Agents/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day2-Document-Agents/Labs/Lab2-RFP-Analysis/Lab2-RFP-Analysis.ipynb
@@ -559,18 +559,6 @@
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
   },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 9.608341,
-   "end_time": "2026-05-02T16:13:36.153435+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Lab2-RFP-Analysis.ipynb",
-   "output_path": "Lab2-RFP-Analysis.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-02T16:13:26.545094+00:00",
-   "version": "2.7.0"
-  },
   "cost": {
    "api_usd_est": 0.01,
    "api_provider": "openai",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
@@ -629,18 +629,6 @@
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
   },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 9.589367,
-   "end_time": "2026-05-02T17:48:36.324828+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Lab6-First-Agent.ipynb",
-   "output_path": "Lab6-First-Agent.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-02T17:48:26.735461+00:00",
-   "version": "2.7.0"
-  },
   "cost": {
    "api_usd_est": 0.02,
    "api_provider": "openai",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab6-First-Agent/Lab6-First-Agent.ipynb
@@ -111,10 +111,10 @@
    "id": "1e0aecc4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:48:28.489369Z",
-     "iopub.status.busy": "2026-05-02T17:48:28.489213Z",
-     "iopub.status.idle": "2026-05-02T17:48:30.035414Z",
-     "shell.execute_reply": "2026-05-02T17:48:30.034998Z"
+     "iopub.status.busy": "2026-08-18T04:28:38.659813Z",
+     "iopub.execute_input": "2026-08-18T04:28:38.660094Z",
+     "shell.execute_reply": "2026-08-18T04:28:56.566833Z",
+     "iopub.status.idle": "2026-08-18T04:28:56.568153Z"
     },
     "papermill": {
      "duration": 1.549334,
@@ -175,10 +175,10 @@
    "id": "38cf4cd1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:48:30.046906Z",
-     "iopub.status.busy": "2026-05-02T17:48:30.046746Z",
-     "iopub.status.idle": "2026-05-02T17:48:30.051745Z",
-     "shell.execute_reply": "2026-05-02T17:48:30.051379Z"
+     "iopub.status.busy": "2026-08-18T04:28:56.571244Z",
+     "iopub.execute_input": "2026-08-18T04:28:56.571780Z",
+     "shell.execute_reply": "2026-08-18T04:28:56.578810Z",
+     "iopub.status.idle": "2026-08-18T04:28:56.580005Z"
     },
     "papermill": {
      "duration": 0.00786,
@@ -240,10 +240,10 @@
    "id": "cdd296c8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:48:30.062578Z",
-     "iopub.status.busy": "2026-05-02T17:48:30.062441Z",
-     "iopub.status.idle": "2026-05-02T17:48:30.109570Z",
-     "shell.execute_reply": "2026-05-02T17:48:30.109145Z"
+     "iopub.status.busy": "2026-08-18T04:28:56.582255Z",
+     "iopub.execute_input": "2026-08-18T04:28:56.582497Z",
+     "shell.execute_reply": "2026-08-18T04:28:56.629439Z",
+     "iopub.status.idle": "2026-08-18T04:28:56.630680Z"
     },
     "papermill": {
      "duration": 0.050108,
@@ -256,11 +256,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Prompt REACT configure avec ChatPromptTemplate\n"
-     ]
+     "name": "stdout",
+     "text": "Prompt REACT configure avec ChatPromptTemplate\n"
     }
    ],
    "source": [
@@ -318,10 +316,10 @@
    "id": "6877d0ac",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:48:30.121407Z",
-     "iopub.status.busy": "2026-05-02T17:48:30.121117Z",
-     "iopub.status.idle": "2026-05-02T17:48:30.233643Z",
-     "shell.execute_reply": "2026-05-02T17:48:30.232993Z"
+     "iopub.status.busy": "2026-08-18T04:28:56.633323Z",
+     "iopub.execute_input": "2026-08-18T04:28:56.633697Z",
+     "shell.execute_reply": "2026-08-18T04:28:57.015237Z",
+     "iopub.status.idle": "2026-08-18T04:28:57.016519Z"
     },
     "papermill": {
      "duration": 0.115687,
@@ -334,19 +332,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Agent REACT cree avec LangGraph\n"
-     ]
+     "name": "stdout",
+     "text": "Agent REACT cree avec LangGraph\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "~\\AppData\\Local\\Temp\\ipykernel_<pid>\\2670171315.py:4: LangGraphDeprecatedSinceV10: create_react_agent has been moved to `langchain.agents`. Please update your import to `from langchain.agents import create_agent`. Deprecated in LangGraph V1.0 to be removed in V2.0.\n",
-      "  graph = create_react_agent(model=llm, tools=tools, prompt=prompt)\n"
-     ]
+     "name": "stderr",
+     "text": "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\2670171315.py:4: LangGraphDeprecatedSinceV10: create_react_agent has been moved to `langchain.agents`. Please update your import to `from langchain.agents import create_agent`. Deprecated in LangGraph V1.0 to be removed in V2.0.\n  graph = create_react_agent(model=llm, tools=tools, prompt=prompt)\n"
     }
    ],
    "source": [
@@ -381,10 +374,10 @@
    "id": "926d2c0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:48:30.243507Z",
-     "iopub.status.busy": "2026-05-02T17:48:30.243219Z",
-     "iopub.status.idle": "2026-05-02T17:48:32.737313Z",
-     "shell.execute_reply": "2026-05-02T17:48:32.732363Z"
+     "iopub.status.busy": "2026-08-18T04:28:57.018828Z",
+     "iopub.execute_input": "2026-08-18T04:28:57.019174Z",
+     "shell.execute_reply": "2026-08-18T04:28:58.977770Z",
+     "iopub.status.idle": "2026-08-18T04:28:58.979220Z"
     },
     "papermill": {
      "duration": 2.503542,
@@ -427,15 +420,20 @@
    "cell_type": "code",
    "id": "13d363d8",
    "source": "# Exercice 1 : Outil de conversion de temperature\n# Creez un outil qui convertit les temperatures et ajoutez-le a l'agent\n\n# Etape 1: Definissez l'outil avec le decorateur @tool\n# Indice: la fonction prend (valeur: float, sens: str) et retourne un float\n# N'oubliez pas la docstring qui explique C2F et F2C\n@tool\ndef convertir_temperature(valeur: float, sens: str) -> float:\n    \"\"\"Convertit une temperature. sens='C2F' pour Celsius vers Fahrenheit, 'F2C' pour l'inverse.\"\"\"\n    pass  # Exercice: implementez la conversion avec un if/elif sur sens\n\n# Etape 2: Creez un agent avec les deux outils (racine carree + temperature)\n# Indice: tools_temp = [calculer_racine_carree, convertir_temperature]\ntools_temp = None  # Remplacez None\ngraph_temp = None  # Remplacez None (create_react_agent(...))\n\n# Etape 3: Testez avec une question de conversion\n# Indice: graph_temp.invoke({\"messages\": [(\"user\", \"Combien font 100 degres Celsius en Fahrenheit ?\")]})})\n\nprint(\"Exercice 1 a completer : outil de conversion de temperature\")",
-   "metadata": {},
-   "execution_count": 7,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-18T04:28:58.981576Z",
+     "iopub.execute_input": "2026-08-18T04:28:58.982029Z",
+     "shell.execute_reply": "2026-08-18T04:28:58.990820Z",
+     "iopub.status.idle": "2026-08-18T04:28:58.992162Z"
+    }
+   },
+   "execution_count": 6,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "text": "Exercice 1 a completer : outil de conversion de temperature\n"
     }
    ]
   },
@@ -449,15 +447,20 @@
    "cell_type": "code",
    "id": "af4844ac",
    "source": "# Exercice 2 : Outil de calcul statistique\n# Creez un outil qui calcule les statistiques descriptives d'une liste de nombres\n\nimport statistics\n\n# Etape 1: Definissez l'outil\n@tool\ndef calculer_statistiques(nombres: list) -> str:\n    \"\"\"\n    Calcule les statistiques descriptives (moyenne, mediane, ecart-type, min, max)\n    d'une liste de nombres. Retourne un resume textuel.\n    \"\"\"\n    pass  # Exercice: calculez mean, median, stdev, min, max et retournez une string\n\n# Etape 2: Creez un agent avec 3 outils (racine carree + temperature + stats)\n# Indice: tools_stats = [calculer_racine_carree, convertir_temperature, calculer_statistiques]\n# Attention: convertir_temperature doit etre definie dans l'Exercice 1 pour etre utilisee ici\ntools_stats = None  # Remplacez None\ngraph_stats = None  # Remplacez None\n\n# Etape 3: Testez avec une question combinant plusieurs outils\n# Indice: \"Quelle est la racine carree de la moyenne de [10, 20, 30, 40, 50] ?\"\n# result_stats = graph_stats.invoke({\"messages\": [(\"user\", \"...\")]})\n\nprint(\"Exercice 2 a completer : outil de calcul statistique\")",
-   "metadata": {},
-   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-18T04:28:58.994567Z",
+     "iopub.execute_input": "2026-08-18T04:28:58.994969Z",
+     "shell.execute_reply": "2026-08-18T04:28:59.004792Z",
+     "iopub.status.idle": "2026-08-18T04:28:59.006135Z"
+    }
+   },
+   "execution_count": 7,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "text": "Exercice 2 a completer : outil de calcul statistique\n"
     }
    ]
   },
@@ -470,16 +473,42 @@
   {
    "cell_type": "code",
    "id": "598cb3f2",
-   "source": "# Exercice 3 : Prompt systeme personnalise\n# Creez un agent avec un prompt systeme pedagogique\n\n# Etape 1: Definissez un nouveau prompt systeme\n# Indice: remplacez le message systeme par des instructions detaillees\nprompt_pedagogique = ChatPromptTemplate.from_messages([\n    (\"system\", None),  # Remplacez None par vos instructions pedagogiques\n    MessagesPlaceholder(\"messages\"),\n])\n\n# Etape 2: Creez l'agent avec le nouveau prompt\n# Indice: create_react_agent(model=llm, tools=[calculer_racine_carree], prompt=prompt_pedagogique)\ngraph_pedago = None  # Remplacez None\n\n# Etape 3: Testez avec une question qui necessite plusieurs etapes\n# Indice: \"Calcule la racine carree de 144, puis dis-moi si le resultat est un nombre premier\"\n# result_pedago = graph_pedago.invoke({\"messages\": [(\"user\", \"...\")]})\n\nprint(\"Exercice 3 a completer : personnalisation du prompt systeme\")",
-   "metadata": {},
-   "execution_count": 9,
+   "source": [
+    "# Exercice 3 : Prompt systeme personnalise\n",
+    "# Creez un agent avec un prompt systeme pedagogique\n",
+    "\n",
+    "# Etape 1: Definissez un nouveau prompt systeme\n",
+    "# Indice: remplacez le message systeme par des instructions detaillees\n",
+    "# prompt_pedagogique = ChatPromptTemplate.from_messages([\n",
+    "#     (\"system\", \"Vos instructions pedagogiques ici\"),  # Remplacez par vos instructions\n",
+    "#     MessagesPlaceholder(\"messages\"),\n",
+    "# ])\n",
+    "prompt_pedagogique = None  # TODO etudiant\n",
+    "\n",
+    "# Etape 2: Creez l'agent avec le nouveau prompt\n",
+    "# Indice: create_react_agent(model=llm, tools=[calculer_racine_carree], prompt=prompt_pedagogique)\n",
+    "graph_pedago = None  # TODO etudiant\n",
+    "\n",
+    "# Etape 3: Testez avec une question qui necessite plusieurs etapes\n",
+    "# Indice: \"Calcule la racine carree de 144, puis dis-moi si le resultat est un nombre premier\"\n",
+    "# result_pedago = graph_pedago.invoke({\"messages\": [(\"user\", \"...\")]})\n",
+    "\n",
+    "print(\"Exercice 3 a completer : personnalisation du prompt systeme\")"
+   ],
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-18T04:28:59.008693Z",
+     "iopub.execute_input": "2026-08-18T04:28:59.009125Z",
+     "shell.execute_reply": "2026-08-18T04:28:59.012787Z",
+     "iopub.status.idle": "2026-08-18T04:28:59.013982Z"
+    }
+   },
+   "execution_count": 8,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "text": "Exercice 3 a completer : personnalisation du prompt systeme\n"
     }
    ]
   },
@@ -526,14 +555,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
    "id": "20603f66",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:48:32.775413Z",
-     "iopub.status.busy": "2026-05-02T17:48:32.775252Z",
-     "iopub.status.idle": "2026-05-02T17:48:32.780681Z",
-     "shell.execute_reply": "2026-05-02T17:48:32.779826Z"
+     "iopub.status.busy": "2026-08-18T04:28:59.016292Z",
+     "iopub.execute_input": "2026-08-18T04:28:59.016717Z",
+     "shell.execute_reply": "2026-08-18T04:28:59.023849Z",
+     "iopub.status.idle": "2026-08-18T04:28:59.025051Z"
     },
     "papermill": {
      "duration": 0.008567,

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
@@ -674,18 +674,6 @@
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
   },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 13.275841,
-   "end_time": "2026-05-02T17:36:16.553486+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Lab7-Data-Analysis-Agent.ipynb",
-   "output_path": "Lab7-Data-Analysis-Agent.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-02T17:36:03.277645+00:00",
-   "version": "2.7.0"
-  },
   "cost": {
    "api_usd_est": 0.05,
    "api_provider": "openai",

--- a/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
+++ b/MyIA.AI.Notebooks/ML/DataScienceWithAgents/Track1-LangChain/Day3-Data-Agents/Labs/Lab7-Data-Analysis-Agent/Lab7-Data-Analysis-Agent.ipynb
@@ -75,10 +75,10 @@
    "id": "8347e543",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:36:04.611939Z",
-     "iopub.status.busy": "2026-05-02T17:36:04.611668Z",
-     "iopub.status.idle": "2026-05-02T17:36:06.858876Z",
-     "shell.execute_reply": "2026-05-02T17:36:06.858006Z"
+     "iopub.status.busy": "2026-08-18T04:29:01.563201Z",
+     "iopub.execute_input": "2026-08-18T04:29:01.563467Z",
+     "shell.execute_reply": "2026-08-18T04:29:19.792486Z",
+     "iopub.status.idle": "2026-08-18T04:29:19.793531Z"
     },
     "papermill": {
      "duration": 2.250337,
@@ -92,10 +92,13 @@
    "outputs": [
     {
      "output_type": "stream",
+     "name": "stderr",
+     "text": "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\3101925311.py:3: DeprecationWarning: `langchain-experimental` is being sunset and is no longer actively maintained. See https://github.com/langchain-ai/langchain-experimental/issues/87 for details.\n  from langchain_experimental.agents.agent_toolkits import create_pandas_dataframe_agent\n"
+    },
+    {
+     "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Imports OK : pandas, langchain_openai, langchain_experimental\n"
-     ]
+     "text": "Imports OK : pandas, langchain_openai, langchain_experimental\nDonnees chargees : 7 lignes, 5 colonnes\n"
     }
    ],
    "source": "import pandas as pd\nfrom langchain_openai import ChatOpenAI\nfrom langchain_experimental.agents.agent_toolkits import create_pandas_dataframe_agent\nimport os\n\n# Assurez-vous d'avoir votre clé API OpenAI dans vos variables d'environnement\n# Par exemple:\n# os.environ[\"OPENAI_API_KEY\"] = \"sk-...\"\n\ndf = pd.read_csv('../Lab4-DataWrangling/transactions.csv')\n\nprint(\"Imports OK : pandas, langchain_openai, langchain_experimental\")\nprint(f\"Donnees chargees : {len(df)} lignes, {len(df.columns)} colonnes\")"
@@ -123,10 +126,10 @@
    "id": "7fd4a313",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:36:06.869606Z",
-     "iopub.status.busy": "2026-05-02T17:36:06.869404Z",
-     "iopub.status.idle": "2026-05-02T17:36:06.903306Z",
-     "shell.execute_reply": "2026-05-02T17:36:06.902051Z"
+     "iopub.status.busy": "2026-08-18T04:29:19.795385Z",
+     "iopub.execute_input": "2026-08-18T04:29:19.795698Z",
+     "shell.execute_reply": "2026-08-18T04:29:19.816762Z",
+     "iopub.status.idle": "2026-08-18T04:29:19.817626Z"
     },
     "papermill": {
      "duration": 0.038724,
@@ -139,110 +142,18 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Données nettoyées et prêtes pour l'agent. Aperçu :\n"
-     ]
+     "name": "stdout",
+     "text": "Données nettoyées et prêtes pour l'agent. Aperçu :\n"
     },
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>date</th>\n",
-       "      <th>id_produit</th>\n",
-       "      <th>categorie</th>\n",
-       "      <th>quantite</th>\n",
-       "      <th>prix_unitaire</th>\n",
-       "      <th>chiffre_affaires</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>2023-10-01</td>\n",
-       "      <td>A101</td>\n",
-       "      <td>Electronique</td>\n",
-       "      <td>5.0</td>\n",
-       "      <td>120.0</td>\n",
-       "      <td>600.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2023-10-01</td>\n",
-       "      <td>B202</td>\n",
-       "      <td>Livre</td>\n",
-       "      <td>10.0</td>\n",
-       "      <td>15.5</td>\n",
-       "      <td>155.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2023-10-02</td>\n",
-       "      <td>A101</td>\n",
-       "      <td>Electronique</td>\n",
-       "      <td>3.0</td>\n",
-       "      <td>120.0</td>\n",
-       "      <td>360.0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>2023-10-03</td>\n",
-       "      <td>C303</td>\n",
-       "      <td>Maison</td>\n",
-       "      <td>2.0</td>\n",
-       "      <td>75.9</td>\n",
-       "      <td>151.8</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>2023-10-03</td>\n",
-       "      <td>B202</td>\n",
-       "      <td>Livre</td>\n",
-       "      <td>6.0</td>\n",
-       "      <td>15.5</td>\n",
-       "      <td>93.0</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "        date id_produit     categorie  quantite  prix_unitaire  \\\n",
-       "0 2023-10-01       A101  Electronique       5.0          120.0   \n",
-       "1 2023-10-01       B202         Livre      10.0           15.5   \n",
-       "2 2023-10-02       A101  Electronique       3.0          120.0   \n",
-       "3 2023-10-03       C303        Maison       2.0           75.9   \n",
-       "4 2023-10-03       B202         Livre       6.0           15.5   \n",
-       "\n",
-       "   chiffre_affaires  \n",
-       "0             600.0  \n",
-       "1             155.0  \n",
-       "2             360.0  \n",
-       "3             151.8  \n",
-       "4              93.0  "
-      ]
-     },
-     "execution_count": 2,
+     "output_type": "execute_result",
      "metadata": {},
-     "output_type": "execute_result"
+     "data": {
+      "text/plain": "        date id_produit     categorie  quantite  prix_unitaire  \\\n0 2023-10-01       A101  Electronique       5.0          120.0   \n1 2023-10-01       B202         Livre      10.0           15.5   \n2 2023-10-02       A101  Electronique       3.0          120.0   \n3 2023-10-03       C303        Maison       2.0           75.9   \n4 2023-10-03       B202         Livre       6.0           15.5   \n\n   chiffre_affaires  \n0             600.0  \n1             155.0  \n2             360.0  \n3             151.8  \n4              93.0  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>date</th>\n      <th>id_produit</th>\n      <th>categorie</th>\n      <th>quantite</th>\n      <th>prix_unitaire</th>\n      <th>chiffre_affaires</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>2023-10-01</td>\n      <td>A101</td>\n      <td>Electronique</td>\n      <td>5.0</td>\n      <td>120.0</td>\n      <td>600.0</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>2023-10-01</td>\n      <td>B202</td>\n      <td>Livre</td>\n      <td>10.0</td>\n      <td>15.5</td>\n      <td>155.0</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>2023-10-02</td>\n      <td>A101</td>\n      <td>Electronique</td>\n      <td>3.0</td>\n      <td>120.0</td>\n      <td>360.0</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>2023-10-03</td>\n      <td>C303</td>\n      <td>Maison</td>\n      <td>2.0</td>\n      <td>75.9</td>\n      <td>151.8</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>2023-10-03</td>\n      <td>B202</td>\n      <td>Livre</td>\n      <td>6.0</td>\n      <td>15.5</td>\n      <td>93.0</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 2
     }
    ],
    "source": [
@@ -300,14 +211,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "id": "f7185256",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:36:06.926397Z",
-     "iopub.status.busy": "2026-05-02T17:36:06.926105Z",
-     "iopub.status.idle": "2026-05-02T17:36:07.277105Z",
-     "shell.execute_reply": "2026-05-02T17:36:07.276660Z"
+     "iopub.status.busy": "2026-08-18T04:29:19.819362Z",
+     "iopub.execute_input": "2026-08-18T04:29:19.819643Z",
+     "shell.execute_reply": "2026-08-18T04:29:21.207222Z",
+     "iopub.status.idle": "2026-08-18T04:29:21.208245Z"
     },
     "papermill": {
      "duration": 0.354802,
@@ -322,9 +233,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Agent LangChain configure : LLM gpt-4o, agent_type=openai-tools, DataFrame transactions\n"
-     ]
+     "text": "Agent LangChain configure : LLM gpt-4o, agent_type=openai-tools, DataFrame transactions\n"
     }
    ],
    "source": "llm = ChatOpenAI(temperature=0, model=\"gpt-4o\")\n\n# Création de l'agent\n# Note: agent_type=\"openai-tools\" est une méthode moderne et robuste qui utilise les \"OpenAI Tools\" pour une meilleure fiabilité.\n# allow_dangerous_code=True est requis pour autoriser l'exécution de code Python dans l'agent\nagent_executor = create_pandas_dataframe_agent(llm, df, agent_type=\"openai-tools\", verbose=True, allow_dangerous_code=True)\n\nprint(\"Agent LangChain configure : LLM gpt-4o, agent_type=openai-tools, DataFrame transactions\")"
@@ -352,10 +261,10 @@
    "id": "f0f55774",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:36:07.287186Z",
-     "iopub.status.busy": "2026-05-02T17:36:07.286862Z",
-     "iopub.status.idle": "2026-05-02T17:36:09.812829Z",
-     "shell.execute_reply": "2026-05-02T17:36:09.812345Z"
+     "iopub.status.busy": "2026-08-18T04:29:21.209981Z",
+     "iopub.execute_input": "2026-08-18T04:29:21.210248Z",
+     "shell.execute_reply": "2026-08-18T04:29:22.553905Z",
+     "iopub.status.idle": "2026-08-18T04:29:22.554986Z"
     },
     "papermill": {
      "duration": 2.529444,
@@ -368,44 +277,27 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n"
-     ]
+     "name": "stdout",
+     "text": "\n\n\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[32;1m\u001b[1;3m\n",
-      "Invoking: `python_repl_ast` with `{'query': 'len(df)'}`\n",
-      "\n",
-      "\n",
-      "\u001b[0m\u001b[36;1m\u001b[1;3m6\u001b[0m"
-     ]
+     "name": "stdout",
+     "text": "\u001b[32;1m\u001b[1;3m\nInvoking: `python_repl_ast` with `{'query': 'len(df)'}`\n\n\n\u001b[0m\u001b[36;1m\u001b[1;3m6\u001b[0m"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[32;1m\u001b[1;3mIl y a 6 lignes dans les données.\u001b[0m\n",
-      "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[32;1m\u001b[1;3mIl y a 6 lignes dans les données.\u001b[0m\n\n\u001b[1m> Finished chain.\u001b[0m\n"
     },
     {
-     "data": {
-      "text/plain": [
-       "{'input': 'Combien y a-t-il de lignes dans les données ?',\n",
-       " 'output': 'Il y a 6 lignes dans les données.'}"
-      ]
-     },
-     "execution_count": 4,
+     "output_type": "execute_result",
      "metadata": {},
-     "output_type": "execute_result"
+     "data": {
+      "text/plain": "{'input': 'Combien y a-t-il de lignes dans les données ?',\n 'output': 'Il y a 6 lignes dans les données.'}"
+     },
+     "execution_count": 4
     }
    ],
    "source": [
@@ -437,10 +329,10 @@
    "id": "cb22fc5e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:36:09.823949Z",
-     "iopub.status.busy": "2026-05-02T17:36:09.823623Z",
-     "iopub.status.idle": "2026-05-02T17:36:12.274460Z",
-     "shell.execute_reply": "2026-05-02T17:36:12.274000Z"
+     "iopub.status.busy": "2026-08-18T04:29:22.556761Z",
+     "iopub.execute_input": "2026-08-18T04:29:22.557080Z",
+     "shell.execute_reply": "2026-08-18T04:29:24.091181Z",
+     "iopub.status.idle": "2026-08-18T04:29:24.092368Z"
     },
     "papermill": {
      "duration": 2.454305,
@@ -453,44 +345,27 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n"
-     ]
+     "name": "stdout",
+     "text": "\n\n\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[32;1m\u001b[1;3m\n",
-      "Invoking: `python_repl_ast` with `{'query': \"df['chiffre_affaires'].sum()\"}`\n",
-      "\n",
-      "\n",
-      "\u001b[0m\u001b[36;1m\u001b[1;3m1839.8\u001b[0m"
-     ]
+     "name": "stdout",
+     "text": "\u001b[32;1m\u001b[1;3m\nInvoking: `python_repl_ast` with `{'query': \"df['chiffre_affaires'].sum()\"}`\n\n\n\u001b[0m\u001b[36;1m\u001b[1;3m1839.8\u001b[0m"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[32;1m\u001b[1;3mLe chiffre d'affaires total réalisé est de 1839.8.\u001b[0m\n",
-      "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[32;1m\u001b[1;3mLe chiffre d'affaires total réalisé est de 1839.8.\u001b[0m\n\n\u001b[1m> Finished chain.\u001b[0m\n"
     },
     {
-     "data": {
-      "text/plain": [
-       "{'input': \"Quel est le chiffre d'affaires total réalisé ?\",\n",
-       " 'output': \"Le chiffre d'affaires total réalisé est de 1839.8.\"}"
-      ]
-     },
-     "execution_count": 5,
+     "output_type": "execute_result",
      "metadata": {},
-     "output_type": "execute_result"
+     "data": {
+      "text/plain": "{'input': \"Quel est le chiffre d'affaires total réalisé ?\",\n 'output': \"Le chiffre d'affaires total réalisé est de 1839.8.\"}"
+     },
+     "execution_count": 5
     }
    ],
    "source": [
@@ -522,10 +397,10 @@
    "id": "f9fde191",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:36:12.285321Z",
-     "iopub.status.busy": "2026-05-02T17:36:12.285041Z",
-     "iopub.status.idle": "2026-05-02T17:36:13.993911Z",
-     "shell.execute_reply": "2026-05-02T17:36:13.993189Z"
+     "iopub.status.busy": "2026-08-18T04:29:24.094439Z",
+     "iopub.execute_input": "2026-08-18T04:29:24.094817Z",
+     "shell.execute_reply": "2026-08-18T04:29:25.306092Z",
+     "iopub.status.idle": "2026-08-18T04:29:25.306954Z"
     },
     "papermill": {
      "duration": 1.712564,
@@ -538,44 +413,27 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n"
-     ]
+     "name": "stdout",
+     "text": "\n\n\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[32;1m\u001b[1;3m\n",
-      "Invoking: `python_repl_ast` with `{'query': \"df['categorie'].unique().tolist()\"}`\n",
-      "\n",
-      "\n",
-      "\u001b[0m\u001b[36;1m\u001b[1;3m['Electronique', 'Livre', 'Maison']\u001b[0m"
-     ]
+     "name": "stdout",
+     "text": "\u001b[32;1m\u001b[1;3m\nInvoking: `python_repl_ast` with `{'query': \"df['categorie'].unique().tolist()\"}`\n\n\n\u001b[0m\u001b[36;1m\u001b[1;3m['Electronique', 'Livre', 'Maison']\u001b[0m"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[32;1m\u001b[1;3mLes catégories de produits uniques sont : Electronique, Livre, et Maison.\u001b[0m\n",
-      "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[32;1m\u001b[1;3mLes catégories de produits uniques sont : Electronique, Livre, et Maison.\u001b[0m\n\n\u001b[1m> Finished chain.\u001b[0m\n"
     },
     {
-     "data": {
-      "text/plain": [
-       "{'input': 'Liste les catégories de produits uniques.',\n",
-       " 'output': 'Les catégories de produits uniques sont : Electronique, Livre, et Maison.'}"
-      ]
-     },
-     "execution_count": 6,
+     "output_type": "execute_result",
      "metadata": {},
-     "output_type": "execute_result"
+     "data": {
+      "text/plain": "{'input': 'Liste les catégories de produits uniques.',\n 'output': 'Les catégories de produits uniques sont : Electronique, Livre, et Maison.'}"
+     },
+     "execution_count": 6
     }
    ],
    "source": [
@@ -607,10 +465,10 @@
    "id": "4ad883c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:36:14.005760Z",
-     "iopub.status.busy": "2026-05-02T17:36:14.005465Z",
-     "iopub.status.idle": "2026-05-02T17:36:15.968087Z",
-     "shell.execute_reply": "2026-05-02T17:36:15.967438Z"
+     "iopub.status.busy": "2026-08-18T04:29:25.308654Z",
+     "iopub.execute_input": "2026-08-18T04:29:25.308954Z",
+     "shell.execute_reply": "2026-08-18T04:29:26.615656Z",
+     "iopub.status.idle": "2026-08-18T04:29:26.617012Z"
     },
     "papermill": {
      "duration": 1.966624,
@@ -623,44 +481,27 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n"
-     ]
+     "name": "stdout",
+     "text": "\n\n\u001b[1m> Entering new AgentExecutor chain...\u001b[0m\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[32;1m\u001b[1;3m\n",
-      "Invoking: `python_repl_ast` with `{'query': \"df.groupby('categorie')['chiffre_affaires'].sum().idxmax()\"}`\n",
-      "\n",
-      "\n",
-      "\u001b[0m\u001b[36;1m\u001b[1;3mElectronique\u001b[0m"
-     ]
+     "name": "stdout",
+     "text": "\u001b[32;1m\u001b[1;3m\nInvoking: `python_repl_ast` with `{'query': \"df.groupby('categorie')['chiffre_affaires'].sum().idxmax()\"}`\n\n\n\u001b[0m\u001b[36;1m\u001b[1;3mElectronique\u001b[0m"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[32;1m\u001b[1;3mLa catégorie qui a généré le plus de chiffre d'affaires est \"Electronique\".\u001b[0m\n",
-      "\n",
-      "\u001b[1m> Finished chain.\u001b[0m\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[32;1m\u001b[1;3mLa catégorie qui a généré le plus de chiffre d'affaires est \"Electronique\".\u001b[0m\n\n\u001b[1m> Finished chain.\u001b[0m\n"
     },
     {
-     "data": {
-      "text/plain": [
-       "{'input': \"Quelle est la catégorie qui a généré le plus de chiffre d'affaires ?\",\n",
-       " 'output': 'La catégorie qui a généré le plus de chiffre d\\'affaires est \"Electronique\".'}"
-      ]
-     },
-     "execution_count": 7,
+     "output_type": "execute_result",
      "metadata": {},
-     "output_type": "execute_result"
+     "data": {
+      "text/plain": "{'input': \"Quelle est la catégorie qui a généré le plus de chiffre d'affaires ?\",\n 'output': 'La catégorie qui a généré le plus de chiffre d\\'affaires est \"Electronique\".'}"
+     },
+     "execution_count": 7
     }
    ],
    "source": [
@@ -697,14 +538,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "id": "f98c128d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T17:36:15.980038Z",
-     "iopub.status.busy": "2026-05-02T17:36:15.979838Z",
-     "iopub.status.idle": "2026-05-02T17:36:15.982643Z",
-     "shell.execute_reply": "2026-05-02T17:36:15.982022Z"
+     "iopub.status.busy": "2026-08-18T04:29:26.619134Z",
+     "iopub.execute_input": "2026-08-18T04:29:26.619518Z",
+     "shell.execute_reply": "2026-08-18T04:29:26.623576Z",
+     "iopub.status.idle": "2026-08-18T04:29:26.624621Z"
     },
     "papermill": {
      "duration": 0.006655,
@@ -719,9 +560,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "text": "Exercice a completer\n"
     }
    ],
    "source": "# Votre code pour l'Exercice 1\n\n# TODO: Formulez et testez vos 3 questions\n# Question 1 - Filtrage\nreponse_filtre = None\n\n# Question 2 - Analyse temporelle\nreponse_temporelle = None\n\n# Question 3 - Question complexe de votre choix\nreponse_complexe = None\n\n# Note: Les réponses seront affichées automatiquement par le mode verbose de l'agent\nprint(\"Exercice a completer\")"
@@ -736,15 +575,20 @@
    "cell_type": "code",
    "id": "0aecdc00",
    "source": "# Exercice 2 : Comparaison de modeles LLM\n# Creez un second agent avec un modele different et comparez les resultats\n\n# Etape 1: Creez un LLM avec un modele different\n# Indice: llm_light = ChatOpenAI(model=\"gpt-3.5-turbo\", temperature=0)\nllm_light = None  # Remplacez None\n\n# Etape 2: Creez un nouvel agent avec ce LLM\n# Indice: create_pandas_dataframe_agent(llm_light, df, agent_type=\"openai-tools\", verbose=True, allow_dangerous_code=True)\nagent_light = None  # Remplacez None\n\n# Etape 3: Posez la meme question complexe aux deux agents\nquestion_test = \"Quelle est la categorie avec le prix unitaire moyen le plus eleve et quel est ce prix ?\"\n\n# Reponse de l'agent gpt-4o (deja existant)\n# reponse_4o = agent_executor.invoke({\"input\": question_test})\n\n# Reponse de l'agent gpt-3.5-turbo\n# reponse_light = agent_light.invoke({\"input\": question_test})\n\n# Etape 4: Comparez les reponses\n# print(\"--- Reponse gpt-4o ---\")\n# print(reponse_4o[\"output\"])\n# print(\"\\n--- Reponse gpt-3.5-turbo ---\")\n# print(reponse_light[\"output\"])\n\nprint(\"Exercice 2 a completer : comparaison de deux modeles LLM\")",
-   "metadata": {},
-   "execution_count": 8,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-18T04:29:26.626493Z",
+     "iopub.execute_input": "2026-08-18T04:29:26.626831Z",
+     "shell.execute_reply": "2026-08-18T04:29:26.631740Z",
+     "iopub.status.idle": "2026-08-18T04:29:26.632926Z"
+    }
+   },
+   "execution_count": 9,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "text": "Exercice 2 a completer : comparaison de deux modeles LLM\n"
     }
    ]
   },
@@ -758,15 +602,20 @@
    "cell_type": "code",
    "id": "931b5c66",
    "source": "# Exercice 3 : Analyse d'un nouveau dataset\n# Creez un DataFrame d'etudiants et demandez a l'agent de l'analyser\n\n# Etape 1: Creez un DataFrame synthetique\n# Indice: utilisez pd.DataFrame() avec un dictionnaire de listes\ndf_etudiants = pd.DataFrame({\n    'Nom': ['Alice', 'Bob', 'Charlie', 'Diana', 'Eve', 'Frank', 'Grace', 'Hugo'],\n    'Age': [20, 22, 19, 21, 23, 20, 22, 21],\n    'Note': [16.5, 12.0, 18.5, 14.0, 9.5, 15.0, 17.5, 11.0],\n    'Filiere': ['Info', 'Maths', 'Info', 'Physique', 'Maths', 'Info', 'Physique', 'Maths']\n})\n\n# Etape 2: Creez un agent analyste pour ce DataFrame\n# Indice: create_pandas_dataframe_agent(llm, df_etudiants, agent_type=\"openai-tools\", verbose=True, allow_dangerous_code=True)\nagent_etudiants = None  # Remplacez None\n\n# Etape 3: Posez des questions analytiques a l'agent\n# Question 1: Moyenne des notes par filiere\n# reponse_moyenne = agent_etudiants.invoke({\"input\": \"Quelle est la moyenne des notes par filiere ?\"})\n\n# Question 2: Identification des outliers\n# reponse_outliers = agent_etudiants.invoke({\"input\": \"Y a-t-il des etudiants dont la note est significativement differente de la moyenne ?\"})\n\n# Question 3: Resume global\n# reponse_resume = agent_etudiants.invoke({\"input\": \"Donne un resume statistique complet de ce dataset\"})\n\nprint(\"Exercice 3 a completer : analyse d'un nouveau dataset avec l'agent\")",
-   "metadata": {},
-   "execution_count": 9,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-18T04:29:26.634975Z",
+     "iopub.execute_input": "2026-08-18T04:29:26.635323Z",
+     "shell.execute_reply": "2026-08-18T04:29:26.640413Z",
+     "iopub.status.idle": "2026-08-18T04:29:26.641481Z"
+    }
+   },
+   "execution_count": 10,
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "text": "Exercice 3 a completer : analyse d'un nouveau dataset avec l'agent\n"
     }
    ]
   },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: DEEP/lean #11579

## Summary

Tranche #11112 « Track1-LangChain Labs résiduels » : re-exécution réelle des 3 derniers labs non-CLEAN de la série (kernel `python3`, nbclient, `OPENAI_API_KEY` injectée par env, LLM réel `gpt-3.5-turbo` via api.openai.com — provider validé par probe direct). Correction C.1 au passage sur Lab6.

| Notebook | exec avant (main) | exec après | erreurs avant → après |
|---|---|---|---|
| Lab2-RFP-Analysis | UNORDERED `[1,2,3,4,5,7,8,6]` | **CLEAN 1..8** | 0 → 0 |
| Lab6-First-Agent | UNORDERED `[1,2,3,4,5,7,8,9,6]` | **CLEAN 1..9** | 0 → 0 |
| Lab7-Data-Analysis-Agent | DUPLICATE `[1,2,1,4,5,6,7,1,8,9]` | **CLEAN 1..10** | 0 → 0 |

**Fix C.1 (Lab6, Exercice 3)** : le stub `("system", None)` passait dans l'exécution historique mais lève `ValueError: Invalid template: None` sous langchain 1.3.15 — une erreur volontaire de facto, interdite par C.1. Remplacé par le pattern canonique (`prompt_pedagogique = None  # TODO etudiant` + constructeur complet en commentaire d'exemple). Titre Exercice conservé, indices et étapes intacts.

**Dépendance (règle F)** : `tabulate` installée localement (requise par l'affichage du pandas-agent de Lab7 — l'absence provoquait `ImportError` + cascade `NameError`).

## Validation (H.1/H.3/C.2)

- Exécution **réelle end-to-end** : nbclient kernel `python3`, `allow_errors=True`, 0 erreur sur les 3 (les appels LLM consomment réellement — outputs contiennent les réponses de l'agent).
- `check_exec_sequence.py` : **CLEAN (1..N) 100%** sur les 3 (plus aucun UNORDERED/DUPLICATE).
- `check_exec_ratchet.py origin/main` : **0 régression**.
- `validate_pr_notebooks.py` : **3/3 PASS** (27 cellules code), H.3 vert au pre-commit.
- **Sources byte-identiques à main** (transplant outputs-only, anti-churn nbformat) hors la cellule stub C.1 de Lab6 — seul diff de source du PR, voulu.
- Normalisation pre-commit : chemins `C:\Users\<user>\...\ipykernel_<pid>` des DeprecationWarnings scrubés par le hook `strip-dotnet-nuget-ext` (1 ligne/notebook).
- Catalogue byte-identique à main (aucun fichier catalogue touché).

See #11112 (tranche Labs Track1 résiduels ; les Demos Track1 restent à couvrir par d'autres tranches)

**Bloc `metadata.papermill` retiré (commit b7bb0ceb3a, gate #11155)** : la re-exec nbclient ne réécrit pas le bloc papermill — outputs changées + bloc byte-identique à main = `STALE_BLOCK` au CI. Le retrait du bloc est la voie sanctionnée par le gate (`BLOCK_REMOVED` autorisé) ; vérifié localement : 3× BLOCK_REMOVED, 0 régression, diff metadata-only (36 lignes).
