### PR TITLE
feat(genai,#11271): FT-01 densite 593 -> 1250 (markdown-only, interps ancrees outputs)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -52,6 +52,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Ce que fait ce notebook\n",
+    "\n",
+    "L'objectif de cette sequence est de comparer, sur un meme modele jouet (GPT-2, 124 M de parametres), les trois strategies classiques de fine-tuning : entrainer tout le reseau, degeler seulement les dernieres couches, ou brancher un adaptateur LoRA. Les imports ci-dessus (`torch`, `transformers`) confirment que l'environnement est pret ; le notebook s'execute sur GPU si disponible, sinon sur CPU avec des temps plus longs mais une logique identique. Chaque section produit une mesure concrete (comptage de parametres, perte d'entrainement, comparaison de generations, taille sur disque) : a la fin, le choix d'une strategie de fine-tuning doit reposer sur des chiffres mesures, pas sur des impressions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 1. Pourquoi fine-tuner ?\n",
     "\n",
     "Les modèles pre-entraines (foundation models) sont capables de tâches générales, mais manquent de specialisation :\n",
@@ -264,6 +273,15 @@
    "id": "cell-c2fa367d"
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : le modele de travail\n",
+    "\n",
+    "La sortie confirme le chargement de `openai-community/gpt2` avec **124 439 808 parametres totaux (124,4 M)**. Deux remarques sur cette etape. D'abord, l'avertissement HF Hub (`unauthenticated requests`) est benin : sans jeton, les telechargements sont simplement limites en debit — apres le premier passage, le modele arrive du cache local. Ensuite, le choix d'un modele de 124 M est volontairement pedagogique : assez grand pour qu'un entrainement complet soit *visiblement* couteux (la section 3 le chiffrera), assez petit pour que les trois strategies tiennent dans un notebook. Le `pad_token` herite de `eos_token` est une specificite GPT-2 (pas de token de padding natif) qu'on retrouvera a la tokenisation de la section 4."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
@@ -367,6 +385,21 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "### Lecture du resultat : le tableau des trois approches\n",
+    "\n",
+    "C'est la mesure centrale du notebook. Le tableau affiche, pour chaque strategie, le nombre exact de parametres entrainables sur les 124 439 808 du modele :\n",
+    "\n",
+    "- **Full Fine-Tuning : 124 439 808 (100,00 %)** — tous les poids bougent ; gradients, etats d'optimiseur et activations doivent etre stocks pour l'integralite du reseau.\n",
+    "- **Partial (2 couches) : 52 773 120 (42,41 %)** — degeler les deux derniers blocs du `transformer` represente deja **pres de la moitie** du modele : les couches de fin de reseau portent les plus larges matrices de projection. « Degeler juste un peu » coute cher.\n",
+    "- **LoRA (r=8) : 294 912 (0,24 %)** — l'adaptateur de rang 8 injecte dans les projections `c_attn` represente **un parametre sur 422**.\n",
+    "\n",
+    "Le ratio LoRA/Full de 0,24 % est la raison d'etre de la methode : au lieu de modifier la matrice de poids $W \\in \\mathbb{R}^{d \\times k}$, LoRA apprend $\\Delta W = B \\times A$ avec $A \\in \\mathbb{R}^{r \\times k}$, $B \\in \\mathbb{R}^{d \\times r}$ et $r = 8 \\ll d, k$. Pour une couche 768 x 768, l'adaptateur ne porte que $2 \\times 768 \\times 8 \\approx 12$ k parametres au lieu de 590 k. La section 6 verifiera que ce ratio se retrouve a l'identique sur la taille des fichiers sur disque."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": "## 4. LoRA en pratique : Fine-tuning sur un style litteraire\n\nNous allons fine-tuner GPT-2 pour generer du texte dans le style de Victor Hugo. Le dataset est un extrait des *Miserables* (domaine public).\n\nLe choix de ce corpus est délibéré à des fins pédagogiques : le registre littéraire du XIXe siècle (phrases longues, vocabulaire archaïsant, tournures descriptives) contraste violemment avec le pré-entraînement de GPT-2 (anglais d'internet contemporain), ce qui rend le transfert de style *visible* à l'œil nu dans les générations. Le corpus est aussi volontairement minuscule (7 segments) — suffisant pour observer un changement de registre en quelques secondes de calcul sur un GPU, trop petit pour un pastiche convaincant. L'objectif est de mettre en évidence le mécanisme, pas de produire un modèle utilisable.",
    "id": "cell-2c50759f"
   },
@@ -432,6 +465,15 @@
     "print(f\"Dataset : {len(train_data)} exemples\")"
    ],
    "id": "cell-09a20769"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : sept segments, pas une encyclopedie\n",
+    "\n",
+    "Le dataset d'entrainement contient exactement **7 segments** extraits des *Miserables* (Victor Hugo, domaine public), comme l'affiche la sortie. C'est un choix assume dont il faut comprendre la portee : sept exemples ne peuvent pas enseigner au modele des *connaissances* — aucune quantite de style ne rattrape un corpus aussi petit — mais ils suffisent largement pour deplacer la *distribution superficielle* du texte : longueur des phrases, lexique, rythme, langue. C'est precisement ce qu'un adaptateur de 294 912 parametres peut apprendre sans casser le modele : une teinte stylistique, pas un savoir. La section 5 montrera que c'est exactement ce qui se produit — y compris les limites (sur-ajustement) inevitables d'un si petit corpus."
+   ]
   },
   {
    "cell_type": "code",
@@ -658,6 +700,15 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "### Lecture du resultat : l'entrainement en chiffres\n",
+    "\n",
+    "Trois valeurs de cette sortie se lisent ensemble. D'abord, la ligne PEFT confirme independamment le comptage de la section 3 : `trainable params: 294,912 || all params: 124,734,720 || trainable%: 0.2364` — le total monte legerement (124,7 M contre 124,4 M) parce que l'adaptateur *s'ajoute* au modele au lieu de le remplacer. Ensuite, la **perte finale vaut 5,0106 apres 13,3 s d'entrainement** : sur un corpus de 7 exemples, la perte chute vite puis stagne — il n'y a presque rien de plus a extraire. Enfin, les avertissements GPU (desquilibre entre cartes, NCCL absent) n'affectent pas un entrainement de cette taille ; ils documentent la configuration materielle. Une perte de ~5 en causal LM sur corpus minuscule n'a rien d'anormal : le modele n'apprend pas a *predire Hugo*, il apprend a *lui ressembler en surface*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": "## 5. Evaluation avant / après\n\nLe seul moyen honnête de mesurer l'effet d'un fine-tuning est une comparaison causale avant/après : même modèle de base, même prompt, même graine aléatoire — seul l'adaptateur LoRA diffère. Tout écart de style entre les deux générations est alors attribuable au fine-tuning, pas au hasard de l'échantillonnage.\n\nNous rechargeons le GPT-2 original (sans adaptateur) et nous émettons le même prompt des deux côtés. Le critère est qualitatif mais précis : le modèle original produit un français générique et souvent incohérent (GPT-2 n'a été pré-entraîné qu'en anglais), tandis que le modèle affiné devrait adopter le registre des *Misérables* — phrases plus longues, tournures littéraires, vocabulaire du XIXe siècle. Sur un dataset aussi petit (7 segments d'entraînement), l'effet est partiel : attendez-vous à un changement de registre perceptible, pas à un pastiche parfait de Victor Hugo.",
    "id": "cell-2fe06360"
   },
@@ -758,6 +809,15 @@
    "id": "cell-e44b2476"
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : avant / apres sur un meme prompt\n",
+    "\n",
+    "La comparaison porte sur le prompt « Dans les rues sombres de Paris ». La **generation originale** derive immediatement hors sujet : enchainements de complements incoherents (« l'ambassadeur sombre, l'equipage, la declaration des consommateurs en France »), repetitions de structure — le GPT-2 de base produit un francais approximatif car son pre-entrainement est majoritairement anglophone. La **generation apres LoRA** adopte un tout autre regime : phrases courtes, numerotees comme des didascalies — « (1) Le rue de Paris. (2) Le rue de Paris. » — la ponctuation et le rythme du corpus d'Hugo percent. Mais la repetition quasi litterale est la signature visible du **sur-ajustement** sur 7 exemples : le modele a memorise des motifs plutot qu'appris une distribution. Gain de style reel, generalisation limitee — exactement le compromis attendu d'un micro-corpus."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
@@ -819,6 +879,15 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "### Lecture du resultat : le test le plus parlant\n",
+    "\n",
+    "Sur « Jean Valjean marchait dans la nuit », l'ecart entre les deux modeles devient net. La generation **originale** bascule carrement en anglais — « (I want you to see) », « It's the moment when the truth is revealed » — puis enchaene un francais incoherent : pour le GPT-2 pre-entraine, un prenom francais n'est pas un signal de langue. La generation **fine-tunee reste integralement en francais**, avec une syntaxe hugolienne approximative (« il vie en vie », « Jusqu'il avait selon ») mais dont la *langue* et le *debit* sont ceux du corpus cible. C'est la demonstration la plus directe de ce qu'un adaptateur LoRA modifie : pas les connaissances du modele, mais la surface statistique de ses productions — ici, la langue dominante et la longueur des propositions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": "## 6. Taille des adaptateurs LoRA\n\nC'est ici que l'avantage de LoRA devient opérationnel, pas seulement théorique. Les matrices de bas rang apprises ($B \\times A$, rang $r=8$) ne pèsent qu'une fraction de pourcent du modèle complet : ~1,2 Mo contre ~498 Mo pour GPT-2 entier. Le code ci-dessous sauvegarde l'adaptateur seul et mesure la taille réelle du fichier `.safetensors` produit, à comparer avec la taille calculée du modèle complet en fp32.\n\nLa conséquence pour le déploiement est décisive : un seul modèle de base de 498 Mo chargé en VRAM, plus N adaptateurs de ~1 Mo chacun sur disque, permet de servir N tâches ou N styles distincts en interchangeant l'adaptateur à la volée — au lieu de maintenir N copies de 498 Mo en mémoire. C'est ce qui fait de LoRA le standard industriel pour servir plusieurs spécialisations d'un même grand modèle derrière une seule instance servie.",
    "id": "cell-dc70a9c6"
   },
@@ -867,6 +936,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Lecture du resultat : l'adaptateur tient dans un megaoctet\n",
+    "\n",
+    "La mesure donne **497,8 Mo pour le modele complet contre 1,18 Mo pour l'adaptateur seul — soit le meme ratio de 0,24 %** que pour les parametres entrainables de la section 3. Cette coherence n'est pas fortuite : l'adaptateur ne stocke que les matrices $A$ et $B$ (294 912 valeurs, ~1,15 Mo en `float32`), tandis que le modele de base porte ses 124,4 M parametres. C'est toute l'economie de deploiement de LoRA : **un seul GPT-2 de base sur disque, plus un adaptateur de ~1,2 Mo par style appris**. Pour servir vingt styles differents, le full fine-tuning exigerait vingt modeles de ~500 Mo (10 Go) ; LoRA exige un modele et vingt megaoctets d'adaptateurs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 7. Nettoyage memoire GPU"
    ],
    "id": "cell-fd8f3de4"
@@ -899,11 +977,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Lecture du resultat : hygiene memoire\n",
+    "\n",
+    "La sortie affiche **24,4 Go de VRAM liberes** apres la liberation des trois objets lourds (`model_original`, `model_to_train`, `trainer`) et le `empty_cache()`. Cette cellule parait accessoire ; elle est en realite ce qui permet au notebook de cohabiter avec d'autres sur la meme carte : pendant la section 5, deux instances de GPT-2 plus l'etat du trainer resident simultanement en memoire, et un kernel qui les garde en vie condamne le prochain entrainement de la session. Le `gc.collect()` cote Python et le `empty_cache()` cote CUDA couvrent les deux niveaux d'allocation — le reflexe vaut pour tout notebook GPU."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## 8. Exercices\n",
     "\n",
     "Appliquez les concepts de ce notebook."
    ],
    "id": "cell-f59529da"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : Exploration du rang LoRA\n",
+    "\n",
+    "Le rang `r` est *le* levier central de LoRA : il fixe la capacite de l'adaptateur, et le nombre de parametres entrainables croit lineairement avec lui. Vous reconfigurerez l'adaptateur avec `r = 2`, `r = 8` puis `r = 32`, et mesurerez l'effet sur le comptage de parametres — l'outil `count_trainable` de la section 3 est deja la pour ca. Question directrice : a partir de quel rang le gain de capacite justifie-t-il le cout ?"
+   ]
   },
   {
    "cell_type": "code",
@@ -927,6 +1023,15 @@
     "print(\"Exercice a completer : comparez les rangs LoRA r=2, 8, 32\")"
    ],
    "id": "cell-4102f87c"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : Fine-tuning sur un autre style\n",
+    "\n",
+    "La methode ne depend pas du corpus : remplacez l'extrait des *Miserables* par un extrait d'un autre auteur (Baudelaire, Verlaine...) et relancez l'entrainement avec la meme configuration LoRA. Observez en particulier ce que la section 5 mesure : la langue, le rythme et la longueur des phrases de la generation changent-ils dans la direction attendue ? Le sur-ajustement observe sur 7 exemples (repetitions litterales) apparait-il aussi vite ?"
+   ]
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Grain: MED/notebook-genai — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11588

## Summary

Tranche densité #11271 : **FT-01-Introduction-FineTuning, 593 → 1250 caractères de prose par cellule de code** (plancher 1200), markdown-only. Mesure fraîche sur `origin/main` (95c4c9a52a) avec l'instrument canonique `pedagogy_density.py` — le tableau de l'issue datait (FT-02 y figurait à 489 mais est déjà au-dessus du plancher sur main).

**11 cellules markdown ajoutées, 0 cellule code modifiée** (13/13 byte-identiques — diff vérifié programmatiquement) :

- 1 intro « Ce que fait ce notebook » (après les imports) ;
- **9 interprétations ancrées sur les outputs réels** (règle cell-interpretation-ordering : chaque interp suit la cellule de code dont l'output contient la valeur citée) : chargement GPT-2 **124 439 808** params, tableau comparatif **Full 100 % / Partial 42,41 % / LoRA 0,24 %** (1 paramètre sur 422, dérivation B×A), dataset **7 segments** Hugo (ce qu'un micro-corpus peut/ne peut pas enseigner), entraînement **perte 5,0106 en 13,3 s** (ligne PEFT `0.2364 %`, l'adaptateur s'ajoute au total), générations avant/après (bascule en **anglais** du modèle original sur « Jean Valjean » vs français maintenu après LoRA, signature du sur-ajustement : répétitions littérales), adaptateur **1,18 Mo vs 497,8 Mo** (même ratio 0,24 %, économie de déploiement), nettoyage **24,4 Go VRAM** (hygiène GPU) ;
- 2 contextes pédagogiques pour les Exercices 1 (rang LoRA) et 2 (autre style) — l'Exercice 3 en avait déjà un.

## Validation

- `pedagogy_density.py` : **1250/1200** — « All judged notebooks meet the density floor ».
- **Sources code byte-identiques** (13/13, diff programmatique) → markdown-only, dispense de re-exécution (C.3), outputs 1..13 CLEAN préservés intact.
- `scan_cell_ordering.py` : **1 clean, 0 finding** (chaque `### Lecture du résultat` suit bien le code dont elle cite l'output — vérifié structurellement).
- Pre-commit : gitleaks, H.3, scrub paths — tous Passed.
- Catalogue byte-identique à main.

See #11271 (tranche FT-01 ; FineTuning restant sur main : FT-04 863, FT-05 1013 ; FT-03 en vol #11506)
