### PR TITLE
feat(twin,#11200): Vague 4 bascule native-both — famille Search (10 paires)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -11,67 +11,67 @@
       python_sha: 51d488274798ccf06956376bdd355d9fbc753515
       csharp_sha: 7023d3ba7fe5e0ce0624ee2806ea06851c4e382e
       reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint pygad (moteur genetique de reference en Python), C# atteint GeneticSharp (moteur genetique de reference de l'ecosysteme .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
-  - date: '2026-08-04'
-    by: myia-po-2023:CoursIA
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: dad13c7fac88520807664b25ab6b95095f608677
-  - date: '2026-08-08'
-    by: myia-po-2024:CoursIA
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 0e679cb6c2a1b3ea821e9a0e72db238e39ebcef8
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: d65d9189296d1821c2e871ed3d2968488cdbb693c831729755d9b7fcccab9084
-  - date: '2026-08-08'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 443cb79d128f63e03a41ae99400f5da630084db2
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 2b4046cb859f06d956bc016cac81878b798c0ff8622d659c1ec76882a80d1121
-  - date: '2026-08-08'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 0855da6aca816a8dcec54ff4f62088655ce54cb2
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: f3309247124d8c6f0541f2da2624c997d48d86b81e617dbcceed2145af641809
-  - date: '2026-08-09'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: d06e92c8e9186a9023e080f96c4a78fae8ded399
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 6a5e1fc75d8e3794e6a90836c5286e9c4ca701e87d62dc450f3d713b20012dd0
-  - date: '2026-08-09'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: e500ca2f9b63dd59109c875237d097fd203467c7
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 2d3c0c815ffe6cf7440cfd160cf84920798081dd9aa97376a5a6386b8b5078a6
-  - date: '2026-08-10'
-    by: myia-po-2024:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 01db0d7a49a4ac97aad3d33a978cba6bb1269eb4
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 0b8dbd86ed46149c87a3aa55d8c9c165e664168c83ed71986ca2b30ea4b56abb
-  - date: '2026-08-10'
-    by: myia-po-2024:CoursIA
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 8413a08b13a3f1d3350ca2fa61c5115200f11058
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 2208eba59d6d7d0e5a7361811372e1627e7fbd6afe03524dfc1eb338d1374acd
-  - date: '2026-08-11'
-    by: myia-po-2025:CoursIA-2
-    python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
-    csharp_sha: 7023d3ba7fe5e0ce0624ee2806ea06851c4e382e
-    content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
-    content_csharp_sha: 879e4a17d56b5bcc6aa292f8a1ec1ea2d29c0988615fe47dd5385ddc54a348c2
-  - date: "2026-08-14"
-    by: myia-po-2025:CoursIA-2
-    python_sha: 51d488274798ccf06956376bdd355d9fbc753515
-    csharp_sha: 7023d3ba7fe5e0ce0624ee2806ea06851c4e382e
-    content_python_sha: f37f13a756c8b13a5bc450af320ee2f2bc40804cbb41dc82715a1ace045b1156
-    content_csharp_sha: 879e4a17d56b5bcc6aa292f8a1ec1ea2d29c0988615fe47dd5385ddc54a348c2
+    - date: '2026-08-04'
+      by: myia-po-2023:CoursIA
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: dad13c7fac88520807664b25ab6b95095f608677
+    - date: '2026-08-08'
+      by: myia-po-2024:CoursIA
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: 0e679cb6c2a1b3ea821e9a0e72db238e39ebcef8
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: d65d9189296d1821c2e871ed3d2968488cdbb693c831729755d9b7fcccab9084
+    - date: '2026-08-08'
+      by: myia-po-2024:CoursIA-2
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: 443cb79d128f63e03a41ae99400f5da630084db2
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: 2b4046cb859f06d956bc016cac81878b798c0ff8622d659c1ec76882a80d1121
+    - date: '2026-08-08'
+      by: myia-po-2024:CoursIA-2
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: 0855da6aca816a8dcec54ff4f62088655ce54cb2
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: f3309247124d8c6f0541f2da2624c997d48d86b81e617dbcceed2145af641809
+    - date: '2026-08-09'
+      by: myia-po-2024:CoursIA-2
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: d06e92c8e9186a9023e080f96c4a78fae8ded399
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: 6a5e1fc75d8e3794e6a90836c5286e9c4ca701e87d62dc450f3d713b20012dd0
+    - date: '2026-08-09'
+      by: myia-po-2024:CoursIA-2
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: e500ca2f9b63dd59109c875237d097fd203467c7
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: 2d3c0c815ffe6cf7440cfd160cf84920798081dd9aa97376a5a6386b8b5078a6
+    - date: '2026-08-10'
+      by: myia-po-2024:CoursIA-2
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: 01db0d7a49a4ac97aad3d33a978cba6bb1269eb4
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: 0b8dbd86ed46149c87a3aa55d8c9c165e664168c83ed71986ca2b30ea4b56abb
+    - date: '2026-08-10'
+      by: myia-po-2024:CoursIA
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: 8413a08b13a3f1d3350ca2fa61c5115200f11058
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: 2208eba59d6d7d0e5a7361811372e1627e7fbd6afe03524dfc1eb338d1374acd
+    - date: '2026-08-11'
+      by: myia-po-2025:CoursIA-2
+      python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0
+      csharp_sha: 7023d3ba7fe5e0ce0624ee2806ea06851c4e382e
+      content_python_sha: 059e3dd5a8806c9030dfaa55d8a13ca1c341ec33673c97f95ada57b92a5365be
+      content_csharp_sha: 879e4a17d56b5bcc6aa292f8a1ec1ea2d29c0988615fe47dd5385ddc54a348c2
+    - date: "2026-08-14"
+      by: myia-po-2025:CoursIA-2
+      python_sha: 51d488274798ccf06956376bdd355d9fbc753515
+      csharp_sha: 7023d3ba7fe5e0ce0624ee2806ea06851c4e382e
+      content_python_sha: f37f13a756c8b13a5bc450af320ee2f2bc40804cbb41dc82715a1ace045b1156
+      content_csharp_sha: 879e4a17d56b5bcc6aa292f8a1ec1ea2d29c0988615fe47dd5385ddc54a348c2
   known_differences:
-  - 'Socle pedagogique commun : Optimisation de portefeuille (convex opt cvxpy + GeneticSharp C#) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles.'
-  - 'Idiomes framework : Python = cvxpy convex optimization + math.comb ; C# = GeneticSharp NuGet (GA).'
-  - 'Asymetrie pedagogique : Python met l''accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l''implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents.'
-  - 'Extension cardinalite K : les deux twins demontrent l''inefficacite d''un solveur convexe (Markowitz long-only) face a une contrainte non-convexe (||w||₀ ≤ K). Cote Python : la section 7 du notebook enonce d''abord le discriminant (convexe → cvxpy), puis enumere les C(5,2)=10 paires en resolvant un QP convexe (cvxpy/CLARABEL) sur chacune via `itertools.combinations` (rf=0.02, K=2 → Actions US + Emergents, Sharpe 1.3060), compare au PyGAD GA avec projection top-K dans la fitness (200 generations) — verdict : le GA retrouve l''optimum exact. Cote C# : BCL pure enumeration exhaustive C(5,2)=10 paires avec tangence Tobin analytique par paire (formule fermee w ∝ Σ⁻¹(μ-rf) sur sous-matrice 2x2, rf=0.0 simplifie pedagogiquement, meme instance d''actifs), plus metaheuristique GA (GeneticSharp) avec projection top-K dans le decodeur du chromosome (TopKFitness : IFitness). Verdict croise attendu : Concordance OUI entre enumeration et GA (meme paire trouvee, ecart Sharpe ≈ 0.0000). Demonstration
+    - 'Socle pedagogique commun : Optimisation de portefeuille (convex opt cvxpy + GeneticSharp C#) comme application canonique. Les deux twins couvrent le meme socle theorique (formulation variables/domaines/contraintes, resolution, experimentation) avec parite semantique sur les concepts cibles.'
+    - 'Idiomes framework : Python = cvxpy convex optimization + math.comb ; C# = GeneticSharp NuGet (GA).'
+    - 'Asymetrie pedagogique : Python met l''accent sur le solveur SOTA (OR-Tools CP-SAT / library specialisee) + visualisation matplotlib + experimentation comparative ; le C# demontre l''implementation from-scratch en BCL pure (ou binding NuGet du meme solver pour App-8/10/15), presentation compacte. Meme socle theorique, leviers de demonstration differents.'
+    - 'Extension cardinalite K : les deux twins demontrent l''inefficacite d''un solveur convexe (Markowitz long-only) face a une contrainte non-convexe (||w||₀ ≤ K). Cote Python : la section 7 du notebook enonce d''abord le discriminant (convexe → cvxpy), puis enumere les C(5,2)=10 paires en resolvant un QP convexe (cvxpy/CLARABEL) sur chacune via `itertools.combinations` (rf=0.02, K=2 → Actions US + Emergents, Sharpe 1.3060), compare au PyGAD GA avec projection top-K dans la fitness (200 generations) — verdict : le GA retrouve l''optimum exact. Cote C# : BCL pure enumeration exhaustive C(5,2)=10 paires avec tangence Tobin analytique par paire (formule fermee w ∝ Σ⁻¹(μ-rf) sur sous-matrice 2x2, rf=0.0 simplifie pedagogiquement, meme instance d''actifs), plus metaheuristique GA (GeneticSharp) avec projection top-K dans le decodeur du chromosome (TopKFitness : IFitness). Verdict croise attendu : Concordance OUI entre enumeration et GA (meme paire trouvee, ecart Sharpe ≈ 0.0000). Demonstration
     du discriminant ''convexe → solveur exact, non-convexe → enumeration ou metaheuristique''.'

--- a/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-10-portfolio.yaml
@@ -2,10 +2,15 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10-Portfolio.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-10b-Portfolio-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `cvxpy` (optimisation convexe exacte du portefeuille) + `pygad` (algorithme genetique) + stdlib. C# = `#r nuget: GeneticSharp` (moteur GA .NET reel : `PortfolioChromosome : ChromosomeBase`, `PortfolioFitness : IFitness`, generation reproductible seed 42) + BCL pure pour l'enumeration exacte K=2. Verdict SOTA-OK : le C# atteint un moteur de production de son ecosysteme (GeneticSharp, deja en service App-10b/App-9b/Sudoku-3) qui couvre le concept enseigne cote GA ; cote Python, `pygad` est son pendant GA (couvert par GeneticSharp) et `cvxpy` (convexe exact) n'a pas d'equivalent .NET en service dans le depot — la part convexe from-scratch/BCL est la contrepartie honnete. Rien a recuperer : le C# ne bride aucun moteur manquant. parity_level: semantic preserve."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 51d488274798ccf06956376bdd355d9fbc753515
+      csharp_sha: 7023d3ba7fe5e0ce0624ee2806ea06851c4e382e
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint pygad (moteur genetique de reference en Python), C# atteint GeneticSharp (moteur genetique de reference de l'ecosysteme .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
   - date: '2026-08-04'
     by: myia-po-2023:CoursIA
     python_sha: 483c2648d7816ea12a3c3753a888e6e49cd8f3b0

--- a/scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-15-sportsscheduling.yaml
@@ -2,10 +2,15 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-15-SportsScheduling.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-15b-SportsScheduling-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `ortools` PyPI (Google, Apache-2.0, CP-SAT solver SOTA-tier : `from ortools.sat.python import cp_model` + `CpModel()` + variables match[round][home][away] + `AddExactlyOne` pour home/away + `AddBoolOr` constraints non-consecutifs + `solver.Solve()`). C# = `Google.OrTools` NuGet (Google, Apache-2.0, meme solver CP-SAT : `#r \"nuget: Google.OrTools\"` + `using Google.OrTools.Sat;`) + `ScottPlot` NuGet (MIT-license, viz supplementaire du calendrier : `#r \"nuget: ScottPlot\"` + `using ScottPlot;` + `Plot()` heatmap render). Verdict SOTA-OK : les DEUX cotes utilisent LE MEME solveur Google OR-Tools CP-SAT natif pour la planification, le ScottPlot cote C# est un helper viz optionnel (le notebook PY utilise matplotlib/heatmap equivalent, asymetrie mineure de lib viz). Asymetrie documentee : parity_level: semantic (vs native-both) car la viz ScottPlot/matplotlib n'est PAS dans le bridge CP-SAT, le semantisme = same calendar output independant de la viz."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 2da1143851d2ac59ae66254495bb661aaddcd68c
+      csharp_sha: cff8412cd42cc696afdb430a1c5984c3154c34e3
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint OR-Tools CP-SAT (ortools), C# atteint Google.OrTools (le meme moteur, portage officiel .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: '2026-08-04'
       by: myia-po-2024:CoursIA
       python_sha: a7c58274670a247cb90b36ae75c136183170e21b

--- a/scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-8-minizinc.yaml
@@ -2,8 +2,13 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/CSP/App-8-MiniZinc-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 0ad3e3f90ea3483c29256e8c91a1f5284d3d5d24
+      csharp_sha: 6d92004320fa7e4b11e457c3c2298f6935b604f1
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint OR-Tools CP-SAT (ortools), C# atteint Google.OrTools (le meme moteur, portage officiel .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 5a3556edb46ca5f2be12979620d2f723e3a5b364

--- a/scripts/notebook_tools/twin_pairs.d/app-9-edgedetection.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/app-9-edgedetection.yaml
@@ -2,8 +2,13 @@
   family: Search/Applications
   python: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9-EdgeDetection.ipynb
   csharp: MyIA.AI.Notebooks/Search/Applications/Hybrid/App-9b-EdgeDetection-CSharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: a783da437fdbb5773339cc4c7b1c648ebd1e3169
+      csharp_sha: a2cc061a4109cfd9aef63b92fd16d152f5430a73
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint DEAP (framework evolutionnaire de reference en Python), C# atteint GeneticSharp (moteur genetique de reference de l'ecosysteme .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 5aa7d42e6e941a86dfcedbb3c9aded569d32d2b4

--- a/scripts/notebook_tools/twin_pairs.d/csp-6-hybridization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-6-hybridization.yaml
@@ -2,10 +2,15 @@
   family: Search/Part2-CSP
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-6-Hybridization-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `ortools.sat.python.cp_model` + `cp_model_helper` (Google, Apache-2.0, CP-SAT SOTA hybrid : `CpModel()` + variables + `AddMaxEquality` + `model.Minimize(obj)` + `solver.Solve()` pour hybrid CP-SAT + heuristique de recherche). C# = `Google.OrTools` NuGet (Google, Apache-2.0, meme solveur CP-SAT : `#r \"nuget: Google.OrTools\"` + `using Google.OrTools.Sat;` + `CpModel()` + `AddBoolVar` + `AddMaxEquality` + `solver.Solve()`) + `ScottPlot` NuGet 5.0.55 (MIT-license, viz gantt chart). Verdict SOTA-OK (modele owner c.217 PR #10557 MERGED 2026-08-12 tranche 2 lib-vs-lib) : les DEUX cotes utilisent LE MEME solveur Google OR-Tools CP-SAT natif (meme binding C++ sous-jacent, API symetrique entre les bindings PyPI + NuGet officiels Google), bridge direct sans glue non-SOTA. Asymetrie documentee : ScottPlot cote C# = helper viz uniquement (le PY utilise matplotlib heatmap equivalent, asymetrie mineure de lib viz n'impactant pas le semantisme). `parity_level: semantic` preserve : parite sur les concepts cibles (hybridation CP-SAT, modele relaxe) malgre l'asymetrie de viz."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: cbc900f8f22beb0592eaa099bacf62497faafad6
+      csharp_sha: d35a6e6262a3a2ac3e8837315c5b365d5ec95aff
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint OR-Tools CP-SAT (ortools), C# atteint Google.OrTools (le meme moteur, portage officiel .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2024:CoursIA-2
       python_sha: fd2931b15681647be5458c009420315234cba14b

--- a/scripts/notebook_tools/twin_pairs.d/csp-8-temporal.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-8-temporal.yaml
@@ -2,10 +2,15 @@
   family: Search/Part2-CSP
   python: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `ortools.sat.python.cp_model` (Google, Apache-2.0, CP-SAT SOTA temporal : `CpModel()` + `NewIntervalVar` + `AddNoOverlap2D` pour timeline + Allen algebra composition table 13x13=169 relations + `solver.Solve()` pour feasibility d'un calendrier temporel). C# = `Google.OrTools` NuGet (Google, Apache-2.0, meme solveur CP-SAT : `#r \"nuget: Google.OrTools\"` + `using Google.OrTools.Sat;` + `CpModel()` + `AddBoolVar` + `AddNoOverlap`) + `ScottPlot` NuGet 5.0.55 (MIT-license, timeline gantt chart : `#r \"nuget: ScottPlot, 5.0.55\"` + `using ScottPlot;` + `Plot()` render timeline) + `Microsoft.DotNet.Interactive.Formatting` (output kernel). Verdict SOTA-OK (modele owner c.217 PR #10557 MERGED 2026-08-12 tranche 2 lib-vs-lib) : les DEUX cotes utilisent LE MEME solveur Google OR-Tools CP-SAT natif, modelisation CSP temporel (variables d'intervalle, contraintes non-chevauchement, Allen algebra composition), bridge direct sans glue non-SOTA. Substantive : parite bit-identique sur les solutions de planning (meme solveur, meme encoding), seule asymetrie est la convention snake_case (Python) vs PascalCase (C#) + ScottPlot vs matplotlib viz. `parity_level: semantic` preserve : parite sur les concepts cibles (CSP temporel, Allen algebra) malgre l'asymetrie de viz."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 861917eef8cf7c0eb4dff0c137b2d1981ac40564
+      csharp_sha: 30f285ee17bff43f06bb4ede8f8ad015b865e3f6
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint OR-Tools CP-SAT (ortools), C# atteint Google.OrTools (le meme moteur, portage officiel .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2024:CoursIA-2
       python_sha: e18d331835a9dea4aeb55447bd0b4c2c3c210925

--- a/scripts/notebook_tools/twin_pairs.d/search-1-statespace.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-1-statespace.yaml
@@ -2,10 +2,15 @@
   family: Search/Part1-Foundations
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-1-StateSpace-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "2026-08-16 (po-2025) : design-gate tranche (option a) -- networkx 3.6.1 installe et bridge dans Search-1-StateSpace.ipynb (section 'Verification de l'optimalite avec networkx' : Dijkstra + centralite d'intermediarite, sorties re-executees C.2). Les DEUX cotes invoquent desormais un moteur SOTA-tier (Python = networkx, C# = QuikGraph 2.5.0) : verdict SOTA-OK. parity_level conserve a semantic : la divergence structurelle (11 vs 13 villes) rend la paire non-native sous la lecture 'cellule-par-cellule' du _schema.yaml, et la semantique de native-both reste a trancher (#11200). --- Etat precedent (2026-08-16 ai-01) : la clause 'pas de lib SOTA-tier' ci-dessous est FALSIFIEE cote C#. QuikGraph 2.5.0 (portage .NET de Boost.Graph) s'installe et s'invoque sans obstacle sur la section 'Recherche d'itineraire' ; le pont est livre et execute (Dijkstra sur le franceGraph existant). Cote C# : desormais SOTA-OK. Cote Python : toujours stdlib pure -- networkx n'est PAS installe dans l'env courant, et la question de savoir si Search-1 doit le bridger ou si le role revient a Search-15-NetworkX (meme repertoire) est un design-gate ouvert, d'ou le maintien de parity_level: semantic (l'enum ne porte pas de valeur 'native d'un seul cote'). Verdict RECOVERABLE-LOCAL maintenu : le gap residuel est cote Python et il est local. --- Etat anterieur (2026-08-01..14, conserve pour tracabilite) : Python = stdlib only (collections.deque BFS + copy.deepcopy state cloning + math/numpy helper viz). Pas de lib SOTA-tier pour state-space search en Python pur (la reference AIMA 3e ed. est pedagogique from-scratch). C# = BCL pure (Queue<T> BFS + Stack<T> DFS + LinkedList<T> state space from-scratch, 0 NuGet SOTA tiers)."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 703c4076ee369500682bde8b52ff1411352cc180
+      csharp_sha: 6dae97fd46083e33673cc86dc6f8c2f8a010f639
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint NetworkX (librairie graphes de reference en Python), C# atteint QuikGraph (librairie graphes de reference de l'ecosysteme .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-01"
       by: myia-po-2023:CoursIA-2
       python_sha: eec0668ba49d9b95a067fafc1674a83edccdb055

--- a/scripts/notebook_tools/twin_pairs.d/search-3-informed.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-3-informed.yaml
@@ -2,10 +2,15 @@
   family: Search/Part1-Foundations
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-3-Informed-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = stdlib + networkx (helper viz graph + heuristic lookup) + heapq (priority queue A*/Greedy/Best-First). Pas de lib SOTA-tier Python pour informed search pure (`aima-python` est jouet non maintained, `pySearch` est un essai), le port pedagogique AIMA ch.4 from-scratch reste canonique. C# = `QuikGraph` NuGet (Pelikan521, MIT-license, lib SOTA graphe .NET : `using QuikGraph;` + `using QuikGraph.Algorithms.ShortestPath;` + `DijkstraShortestPathAlgorithm<TVertex,TEdge>` / `AStarShortestPathAlgorithm<TVertex,TEdge>`, version 2.5.0). Verdict SOTA-OK (modèle owner PR #10412 MERGED pour Sudoku-9 / PR #10387 MERGED pour Search-15 NetworkX) : QuikGraph EST la lib SOTA graphe canonique .NET (Bellman-Ford, Dijkstra, A*, BFS, DFS -- tout y est), l'API `AStarShortestPathAlgorithm` permet un bridge direct A* avec heuristique. Asymetrie documentee : PY from-scratch (algos pedagogiques AIMA), C# bridge via lib SOTA (algo canonique)."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: d6ff88e23eddb736cf456cabbab154902b36468a
+      csharp_sha: e4f0c1ecc753255b13cc3e4abfe76598e3805506
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint NetworkX (librairie graphes de reference en Python), C# atteint QuikGraph (librairie graphes de reference de l'ecosysteme .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-04"
       by: myia-po-2024:CoursIA-2
       python_sha: 2ead147f031bb101e5db38c15bf0223628626fce

--- a/scripts/notebook_tools/twin_pairs.d/search-5-geneticalgorithms.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-5-geneticalgorithms.yaml
@@ -2,10 +2,15 @@
   family: Search/Part1-Foundations
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-5-GeneticAlgorithms-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `deap` (Distributed Evolutionary Algorithms in Python, Fortin et al. 2012, MIT-license, lib SOTA GA Python : toolbox + creator + base + fitness maximization via `creator.FitnessMax` + algorithms.eaSimple / eaMuPlusLambda) + `pygad` (Ahmed Gad, MIT-license, GA Python SOTA-tier, interface haut-niveau `pygad.GA(...)` + run()). C# = `MetaGeneticSharp` local (wrapper .NET 9 sur GeneticSharp, MIT-license, 4 DLLs : GeneticSharp.Domain.dll + GeneticSharp.Infrastructure.Framework.dll + MetaGeneticSharp.Domain.dll + GeneticSharp.Infrastructure.dll) + `GeneticSharp` NuGet (dbarbosettig, MIT-license, lib SOTA GA .NET). Verdict SOTA-OK (modèle owner PR #10420 MERGED pour Search-11 tranche 2 + PR #10523 c.215 pour Sudoku-3 Genetic) : les DEUX cotes utilisent une vraie lib GA SOTA (deap+pygad cote PY, GeneticSharp+MetaGeneticSharp cote C#), couverture fonctionnelle equivalente (population / fitness / selection / crossover / mutation / elitism), bridge direct sans glue non-SOTA. Asymetrie documentee : PY a 2 libs (deap bas-niveau + pygad haut-niveau) vs C# 2 DLLs (GeneticSharp base + MetaGeneticSharp wrapper), l'API surface est differente (deap toolbox vs GeneticSharp fluent) mais le potentiel est equivalent."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: df5622e442621da5383052c2e617995fa4ab8304
+      csharp_sha: 9c6f6e3484a3ffdb41d97a2a136fe622a905ea77
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint pygad (moteur genetique de reference en Python), C# atteint GeneticSharp (moteur genetique de reference de l'ecosysteme .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-01"
       by: myia-po-2026:CoursIA
       python_sha: 302e714c9920f536e87ce2d89bff63125d45d0a4

--- a/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-9-linearprogramming.yaml
@@ -2,8 +2,13 @@
   family: Search/Part1-Foundations
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-9-LinearProgramming-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: d1d4f36599e49147f58195e85a475476d269680c
+      csharp_sha: a6d7a7a59ded4ba7732054d17a66c5e40bb80c9f
+      reason: "parity_level basculee -> native-both conformement a l'arbitrage ai-01 2026-08-16 sur #11200 Option A (parite de moteur, lib-vs-lib) : Python atteint OR-Tools (ortools), C# atteint Google.OrTools (le meme moteur, portage officiel .NET). bridge_verdict_reason inchangee -- le bridge etait deja documente dans le verdict existant. Imports verifies firsthand sur les notebooks de la paire (re-grep 2026-08-18)."
     - date: "2026-08-01"
       by: myia-po-2023:CoursIA-2
       python_sha: d1d4f36599e49147f58195e85a475476d269680c


### PR DESCRIPTION
## Summary

**Vague 4** du balayage #11200 (même arbitrage ai-01 2026-08-16 Option A : parité de moteur, lib-vs-lib). Tranche **famille Search complète** : Part1-Foundations (search-1/3/5/9), Part2-CSP (csp-6/8), Applications (app-8/9/10/15) — 10 paires, suite des Vagues 2/3/3b.

## Paires moteurs — vérifiées firsthand

Re-grep des imports des **20 notebooks** sur `origin/main` (2026-08-18) :

| Paire moteur | Entrées | Verdict |
|---|---|---|
| `ortools` ↔ `Google.OrTools` (même moteur, portage officiel .NET) | app-15, app-8, csp-6, csp-8, search-9 | 10/10 imports vérifiés présents |
| `pygad`/`DEAP` ↔ `GeneticSharp` (moteurs génétiques de référence) | app-10, app-9, search-5 | idem |
| `networkx` ↔ `QuikGraph` (librairies graphes de référence) | search-1, search-3 | idem |

**Note csp-8** : les hits `networkx`/`QuikGraph` du détecteur étaient des faux positifs (absents des notebooks vérifiés) — la justification d'audit cite uniquement la paire `ortools` ↔ `Google.OrTools` (les deux vérifiés présents).

Chaque entrée `audits:` porte `python_sha`/`csharp_sha` frais (`git ls-tree origin/main`) + reason citant la paire vérifiée.

## Validation

- Scanner post-flip : **TRIVIAL_BASCULE 64 → 54**, ALREADY_NATIVE_BOTH 37 → 47.
- Changement purement registre (yaml) : `parity_level: semantic → native-both` + entrée audit ; `bridge_verdict`/`known_differences` inchangés.
- 10 fichiers ≤ 15 (§A conforme), un seul sujet.

See #11200 (Vague 4 ; résiduel : ML 7, Sudoku 6, GameTheory 1, SL 1 + SOLVER_FREE 12 / AMBIGUOUS 13 à arbitrer séparément)

Grain: MED/twin-parity — lane myia-po-2026:CoursIA — prev: MED/notebook-genai #11589