### PR TITLE
feat(qcpy,#11224): QC-Py-12 densite 746 -> 1222 — interps ancrees sur les outputs reels (pattern #10488)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-12-Backtesting-Analysis.ipynb
@@ -39,8 +39,11 @@
     "4. Comparaison avec Benchmark (15 min)\n",
     "5. Insights QuantConnect (15 min)\n",
     "6. Analyse de l'Equity Curve (20 min)\n",
-    "7. Rapport Complet (20 min)",
-    "\n\n> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n"
+    "7. Rapport Complet (20 min)\n",
+    "\n",
+    "> **Note de conception** : Ce notebook contient du code de reference a copier dans QuantConnect Lab (main.py). Les cellules ne sont pas prevues pour etre executees en tant que notebook Jupyter. L'absence d'outputs (execution_count: null) est intentionnelle.\n",
+    "\n",
+    "**Ce que vous saurez faire en sortant de ce notebook** : lire un rapport de backtest complet famille de metriques par famille (rendement, risque ajuste, drawdowns, micro-structure des trades, exposition au marche, robustesse statistique) ; distinguer un verdict de surperformance d'un profil defensif ; reconnaitre les conventions cachees qui font varier un meme ratio d'un rapport a l'autre ; et produire vous-meme le rapport final standardise, localement puis cote QC Cloud. La strategie analysee (MA Crossover sur donnees simulees) sert de cas d'ecole : elle PERD contre son benchmark -- c'est precisement ce qui rend chaque metrique interessante a interpreter."
    ],
    "id": "cell-96b2cbba"
   },
@@ -118,7 +121,9 @@
    "id": "7c391bcc",
    "metadata": {},
    "source": [
-    "On charge ici l'historique de marché et les résultats du backtest pour préparer l'analyse de performance."
+    "On charge ici l'historique de marché et les résultats du backtest pour préparer l'analyse de performance.\n",
+    "\n",
+    "Ce notebook desosse une **analyse de backtest complete** sur les donnees simulees chargees ci-dessous : 504 jours de trading (2022-01-03 a 2023-12-07), une strategie MA Crossover demarree a ~$100 181, un benchmark SPY. La question directrice, du debut a la fin : *ce backtest a-t-il battu son benchmark, et avec quel profil de risque ?* Chaque section apporte une famille de metriques (rendement, risque ajuste, micro-structure des trades, exposition au marche, robustesse) ; la comparaison strategie vs benchmark est systematiquement affichee cote a cote -- juger un chiffre isole n'a pas de sens."
    ]
   },
   {
@@ -156,7 +161,9 @@
     "- Generer des visualisations professionnelles (equity curves, underwater plots, distributions)\n",
     "- Formater des rapports de backtest coherents\n",
     "\n",
-    "Ces helpers evitent de reecrire le même code d'analyse dans chaque projet et garantissent une presentation uniforme des résultats."
+    "Ces helpers evitent de reecrire le même code d'analyse dans chaque projet et garantissent une presentation uniforme des résultats.\n",
+    "\n",
+    "Concretement, ces helpers remplacent du code ad hoc : `backtest_helpers.py` produit les memes metriques que l'onglet Results de QC Cloud (Total Return, CAGR, Sharpe, Sortino, Max Drawdown), ce qui permet de valider une analyse en local avant de consommer des heures de backtest cloud. Contrepartie a connaitre : les conventions du helper (annualisation, fenetres) different legerement des canaux maison du notebook -- la section 7 en fait precisement un enseignement, pas un piege."
    ],
    "metadata": {},
    "id": "cell-c3fd9543"
@@ -346,6 +353,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-read-return",
+   "metadata": {},
+   "source": [
+    "### Lecture du resultat : rendement brut\n",
+    "\n",
+    "Le verdict brut est net : **Total Return 40,50 % pour la strategie contre 48,28 % pour le benchmark** -- la MA Crossover laisse ~7,8 points de rendement sur la table en 1,92 annee. Le CAGR confirme (19,32 % vs 22,71 %) : l'ecart n'est pas un artefact d'annualisation, la strategie perd en moyenne chaque annee simulee. Attention toutefois : un rendement brut inferieur n'est PAS disqualifiant en soi -- une strategie defensive peut legitimement payer du rendement contre du risque en moins. C'est la lecture croisee de la section suivante (volatilite 16,26 % vs 18,52 %, ratios ajustes au risque) qui tranche si l'echange etait favorable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "#### Returns Journaliers, Mensuels et Annuels"
@@ -380,7 +397,9 @@
    "id": "31c94ba5",
    "metadata": {},
    "source": [
-    "On calcule les indicateurs de performance clés tels que le rendement cumulé, le ratio de Sharpe et l'alpha."
+    "On calcule les indicateurs de performance clés tels que le rendement cumulé, le ratio de Sharpe et l'alpha.\n",
+    "\n",
+    "Concretement, trois lectures se superposent toujours : la **tendance** (le rendement cumule monte-t-il regulierement ou par sauts ?), le **risque realise** (l'amplitude des oscillations autour de la tendance), et la **comparaison au benchmark** (meme periode, meme capital initial -- sinon rien n'est comparable). La heatmap ci-dessous ajoute la dimension temporelle : OU les gains et les pertes se concentrent-ils dans le calendrier ?"
    ]
   },
   {
@@ -453,7 +472,9 @@
     "- **Regime detection** : Les annees avec beaucoup de rouge indiquent un regime bear market\n",
     "- **Communication** : Visualisation facile pour presenter la performance a des investisseurs\n",
     "\n",
-    "**Attention** : Ne pas overfiter sur des patterns saisonniers sans validation out-of-sample!"
+    "**Attention** : Ne pas overfiter sur des patterns saisonniers sans validation out-of-sample!\n",
+    "\n",
+    "**Application a ce backtest** : la lecture par annee est ici sans ambiguete -- 2022 cumule les mois rouges profonds (c'est la phase de choc des rates ou se produisent le MaxDD -16,63 % et les 5 pires drawdowns dates de mars-avril 2022, cf. section 2.3), tandis que 2023 alterne mois verts et corrections legeres. Un strategy dont toute la performance tient dans 3-4 colonnes vertes est un pari de timing de regime, pas un moteur de rendement : la question de la robustesse (section 5, Monte Carlo) posera exactement ce diagnostic."
    ],
    "metadata": {},
    "id": "cell-1f504c52"
@@ -757,7 +778,14 @@
     "> **Interpretation**:\n",
     "> - **Sharpe** > 1 : La stratégie genere un bon rendement ajuste au risque total\n",
     "> - **Sortino** > Sharpe : La volatilite haussiere est superieure a la baissiere (bon signe)\n",
-    "> - **Calmar** > 1 : Le CAGR est superieur au max drawdown (acceptable)"
+    "> - **Calmar** > 1 : Le CAGR est superieur au max drawdown (acceptable)\n",
+    "\n",
+    "### Lecture de ce backtest (valeurs mesurees ci-dessus)\n",
+    "\n",
+    "- **Sharpe 1,01 vs 1,03** : meme ajustee au risque total, la strategie ne rattrape pas le benchmark -- l'ecart de rendement (~8 points) depasse ce que la volatilite economisee compense.\n",
+    "- **Volatilite 16,26 % vs 18,52 %** : la strategie est structurellement moins volatile (confirmee par le beta 0,443 mesure en section 4) ; elle obtient un Sharpe quasi equivalent avec environ un tiers de risque de marche en moins.\n",
+    "- **Sortino 1,67 vs 1,77, Calmar 1,16 vs 1,34** : la disadvantage se maintient cote downside ; le Calmar surtout (CAGR / MaxDD) montre une recuperation apres pertes plus lente cote strategie.\n",
+    "- **Lecture d'ensemble** : profil \"defensif mais sous-performant\" -- typique d'une strategie partiellement desensibilisee au marche qui renonce a une partie du beta. Si l'objectif etait de battre SPY, ce backtest echoue ; si l'objectif etait un rendement decent avec moins de vol, il tient sa promesse. Les sections suivantes precisent le prix psychologique (drawdowns) et la finesse de l'edge micro (trades)."
    ],
    "id": "cell-d135c220"
   },
@@ -865,7 +893,9 @@
     "**Benchmark** :\n",
     "- Max DD < 15% : Excellent (niveau hedge fund top-tier)\n",
     "- Max DD 15-25% : Bon pour stratégies individuelles\n",
-    "- Max DD > 30% : Eleve - necessite un fort appetit au risque"
+    "- Max DD > 30% : Eleve - necessite un fort appetit au risque\n",
+    "\n",
+    "**Lecture chiffree de ce backtest** : Max Drawdown **-16,63 %** (benchmark -16,96 % -- protection marginale de 0,33 point seulement : la strategie ne protege pas des krachs), Mean Drawdown **-5,94 %** (le \"niveau de douleur\" habituel : le capital vit en moyenne ~6 % sous son dernier pic), et le chiffre le plus frappant du notebook : **451 jours en drawdown sur 504, soit 89,5 % du temps**. C'est statistiquement normal -- un capital en high-water mark perpetuel n'existe quasi jamais -- mais c'est l'information la plus utile AVANT de vivre la strategie en vrai : la plupart des abandons d'investisseur se produisent dans ces 451 jours-la, pas dans le seul episode du maximum."
    ],
    "metadata": {},
    "id": "cell-e04a7ca7"
@@ -958,7 +988,9 @@
     "**Action** : Si la duree max est trop longue, considerer:\n",
     "- Ajouter un stop-loss (couper les pertes tot)\n",
     "- Diversifier sur plusieurs non-correles\n",
-    "- Reduire la taille des positions pour passer les periodes difficiles"
+    "- Reduire la taille des positions pour passer les periodes difficiles\n",
+    "\n",
+    "**Lecture chiffree** : le plus long episode a dure **286 jours, du 2022-01-13 au 2022-10-26** -- pres de dix mois pour retrouver le pic de janvier 2022. Le detail qui compte : le FOND du drawdown est atteint des mars 2022 (cf. le Top 5 ci-dessous), mais la recuperation complete prend encore sept mois. Profondeur et duree ne vont pas de pair : un -16 % en forme de V recupere vite ; le meme -16 % en forme de L (notre cas) immobilise le capital trois trimestres entiers."
    ],
    "metadata": {},
    "id": "cell-4dca6126"
@@ -1079,7 +1111,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **Point Cle**: L'analyse des drawdowns est cruciale pour la gestion du risque. Un max drawdown de 20% signifie qu'a un moment, un investisseur a vu son capital baisser de 20% depuis son pic - psychologiquement difficile a supporter."
+    "> **Point Cle**: L'analyse des drawdowns est cruciale pour la gestion du risque. Un max drawdown de 20% signifie qu'a un moment, un investisseur a vu son capital baisser de 20% depuis son pic - psychologiquement difficile a supporter.\n",
+    "\n",
+    "**Lecture chiffree** : les cinq pires points se serrent sur **mars-avril 2022** (-16,63 % le 2022-03-16, puis -16,45 % le 2022-04-01, -16,35 %, -16,31 %...). Autrement dit, ce ne sont PAS cinq crises independantes mais **une seule phase de marche** (le choc de remontee des taux de 2022) echantillonnee cinq fois autour de son minimum. Deux lecons pratiques : (1) le \"Top 5 drawdowns\" d'une serie courte mesure la PERSISTANCE d'un regime, pas sa frequence ; (2) des \"diversifications\" de strategies dont les Top 5 s'empilent sur les memes dates ne diversifient rien."
    ],
    "id": "cell-f6ba0311"
   },
@@ -1153,7 +1187,9 @@
    "id": "70e58a03",
    "metadata": {},
    "source": [
-    "On visualise les courbes d'équité et les drawdowns pour évaluer la robustesse de la stratégie."
+    "On visualise les courbes d'équité et les drawdowns pour évaluer la robustesse de la stratégie.\n",
+    "\n",
+    "Deux angles de lecture sur ce graphique : la **trajectoire relative** (l'ecart entre les deux courbes se creuse-t-il continument -- sous-performance structurelle -- ou par episodes -- sensibilité au regime ?) et la **texture du chemin** (la courbe strategie est-elle plus lisse que le benchmark ? c'est la promesse de la volatilite 16,26 % contre 18,52 % mesuree en 1.2, visible a l'oeil nu ici). Une equity curve qui gagne moins mais dort mieux est un compromis legtime -- a condition de l'avoir CHOISI, pas de le decouvrir."
    ]
   },
   {
@@ -1302,7 +1338,9 @@
     "- **Largest Loss vs Average Loss** : Si Largest Loss >> Avg Loss, il y a des \"outliers\" de pertes - verifier la gestion du risque\n",
     "- **Avg Win / Avg Loss** : Ratio de 2:1 est ideal (gagner 2x plus que l'on perd par trade)\n",
     "\n",
-    "**Limitation** : Ces statistiques sont basees sur des trades fermes. Les positions ouvertes ne sont pas comptees."
+    "**Limitation** : Ces statistiques sont basees sur des trades fermes. Les positions ouvertes ne sont pas comptees.\n",
+    "\n",
+    "**Lecture chiffree de ce backtest** : 150 trades, **Win Rate 53,33 %**, Average Win **1,63 %** contre Average Loss **-1,30 %** (R/R 1,25). L'edge micro est mince mais systematique : **Expectancy 0,2606 % par trade** -- multipliee par 150 trades, elle redonne l'ordre de grandeur du Total P&L **39,09 %** affiche juste au-dessus. **Profit Factor 1,43** : chaque euro perdu rapporte 1,43 euro de gain ; au-dessus du seuil de rentabilite (1,0) mais sous le seuil confortable (>1,5) une fois factores les frais reels et le slippage omis par la simulation. Enfin **7 gains consecutifs max contre 6 pertes max** : aucune des deux series ne s'emballe -- profil plat, signature d'un signal frequent a faible edge."
    ],
    "metadata": {},
    "id": "cell-ff41b083"
@@ -1390,7 +1428,9 @@
     "**Signes d'alerte** :\n",
     "- Courbe cumulative en \"sawtooth\" (beaucoup de va-et-vient) : trop de trades ou frais eleves\n",
     "- Longues sections plates : stratégie inactive ou sans signaux\n",
-    "- Croissance acceleree soudaine : peut etre un outlier (chance)"
+    "- Croissance acceleree soudaine : peut etre un outlier (chance)\n",
+    "\n",
+    "**Lecture de l'histogramme affiche** : la distribution des P&L est centree juste a droite de zero, avec une aile droite qui s'etire jusqu'au Largest Win de 3,87 % (chiffre en 3.1) et une aile gauche plafonnee vers le Largest Loss de -2,34 % -- l'asymetrie visible qui produit le Profit Factor 1,43. La courbe cumulative confirme : pente moyenne positive acquise grain par grain, sans saut domine par un trade unique (pas de \"lucky big win\"). Signature d'une strategie de nombreux petits edges plutot que d'un pari concentre -- fragile aux frais de transaction, robuste a un mauvais tirage isole."
    ],
    "metadata": {},
    "id": "cell-22fcb666"
@@ -1452,7 +1492,9 @@
     "**Application pratique** : Utiliser ces analyses pour:\n",
     "- Optimiser le timing des entrees/sorties\n",
     "- Ajuster la taille des positions selon le jour/mois\n",
-    "- Identifier des periodes a risque eleve"
+    "- Identifier des periodes a risque eleve\n",
+    "\n",
+    "L'exercice TODO ci-dessous (analyse temporelle par jour de semaine et par mois) prolonge exactement la methode du notebook : grouper, mesurer, VERDICTER. **Indices** : (1) batir un DataFrame des returns strategie avec une colonne `dayofweek` et une colonne `month` ; (2) comparer la moyenne PAR groupe a la moyenne globale -- un lundi a -0,05 % de moyenne ne parle que rapporte a la volatilite des lundis ; (3) vigilance multiple-testing : avec 12 mois x 5 jours, un ou deux groupes \"significatifs\" sortiront par pur hasard -- un simple t-test par groupe evite de raconter une saisonnalite inexistante."
    ],
    "metadata": {},
    "id": "cell-87967969"
@@ -1566,7 +1608,9 @@
    "id": "c991efa0",
    "metadata": {},
    "source": [
-    "On analyse la distribution des rendements quotidiens pour caractériser le profil risque/rendement."
+    "On analyse la distribution des rendements quotidiens pour caractériser le profil risque/rendement.\n",
+    "\n",
+    "La regression qui suit repond a une question precise : *d'ou vient le rendement de la strategie ?* Si le beta est proche de 1 et l'alpha proche de 0, la strategie est le marche deguise (inutile de payer des frais pour la detenir) ; si le beta est faible mais l'alpha reel, elle genere de la performance independante. C'est le test le plus important pour justifier l'EXISTENCE d'une strategie active -- devant meme son rendement brut."
    ]
   },
   {
@@ -1723,7 +1767,9 @@
     "**Cas d'usage** :\n",
     "- **IR > 1.0** : Excellent - la stratégie \"bat\" le marche avec regularite\n",
     "- **IR = 0.5 - 1.0** : Bon - generation d'alpha solide\n",
-    "- **IR < 0.5** : Faible - l'alpha est inconsistant ou negatif"
+    "- **IR < 0.5** : Faible - l'alpha est inconsistant ou negatif\n",
+    "\n",
+    "**Lecture chiffree** : Tracking Error **17,42 %** annualisee -- enorme face a un IR \"confortable\" qui se construit sur un TE de 3-5 %. **Information Ratio -0,15** : negatif, la performance active MOYENNE est du mauvais cote sur la fenetre. La tension avec l'alpha +7,98 % de la section 4.1 n'est pas une erreur : un alpha de regression annualise peut etre positif pendant que la moyenne des ecarts journaliers reste negative -- la surperformance est CONCENTREE sur quelques semaines, pas etalee. C'est le diagnostic exact d'une strategie qui bat son benchmark par a-coups imprevus plutot que par generation d'alpha reguliere ; un seul des deux chiffres (alpha OU IR) masque ce fait, et c'est la raison pour laquelle un rapport honnete affiche les deux."
    ],
    "metadata": {},
    "id": "cell-9574d094"
@@ -1830,7 +1876,9 @@
    "source": [
     "### 5.2 Structure des Résultats de Backtest QuantConnect\n",
     "\n",
-    "QuantConnect fournit des statistiques detaillees après chaque backtest."
+    "QuantConnect fournit des statistiques detaillees après chaque backtest.\n",
+    "\n",
+    "Le rapport QC Cloud organise l'information en trois blocs hierarchiques -- Performance (rendements et ratios), Risk (volatilite, drawdowns), Alpha/Beta (relation au benchmark) -- chacun horodate sur la periode exacte du backtest. Les champs affiches ci-dessous reproduisent cette structure champ pour champ : savoir naviguer ce format est ce qui permet, en stage comme en production, de lire n'importe quel rapport QuantConnect sans re-apprendre ses habitudes de lecture."
    ],
    "id": "cell-fc15ca65"
   },
@@ -1937,6 +1985,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-read-qcmap",
+   "metadata": {},
+   "source": [
+    "### Correspondance avec l'onglet Results de QC Cloud\n",
+    "\n",
+    "Le bloc ci-dessus reproduit la structure du rapport QuantConnect (Performance / Risk / Alpha-Beta) avec les MEMES valeurs que les sections locales : Total Return 40,50 %, CAGR 19,32 %, Sharpe 1,01, MaxDD -16,63 %. C'est voulu : l'etudiant qui lancera plus tard le backtest sur QC Cloud doit savoir lire les deux formats sans traduction. Les ecarts qui apparaitront sur un vrai cloud (frais, slippage, dividendes du benchmark) degraderont tous les chiffres dans le meme sens -- le squelette de lecture, lui, ne change pas."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -2036,7 +2094,9 @@
    "id": "78ea2761",
    "metadata": {},
    "source": [
-    "On compare les résultats du backtest par rapport au benchmark de référence pour mesurer la valeur ajoutée."
+    "On compare les résultats du backtest par rapport au benchmark de référence pour mesurer la valeur ajoutée.\n",
+    "\n",
+    "La simulation Monte Carlo repond a la question que le backtest unique laisse ouverte : *le resultat observe est-il typique ou chanceux ?* En reechantillonnant les returns journaliers des centaines de fois, on obtient la distribution des futurs PLAUSIBLES ; le backtest reel n'est qu'un seul tirage dans cette distribution. Une strategie dont le resultat realise est dans la queue superieure des simulations doit etre traitee comme un heureux hasard statistique tant qu'un nouveau sample ne confirme pas."
    ]
   },
   {
@@ -2107,7 +2167,9 @@
     "3. **Utilite pratique** :\n",
     "   - **Capital adequacy** : Avoir assez de capital pour le 95e percentile de drawdown\n",
     "   - **Expectations management** : Communiquer les probabilites de performance aux investisseurs\n",
-    "   - **Robustesse check** : Si les percentiles sont très larges, la stratégie est très dependante de la sequence des returns"
+    "   - **Robustesse check** : Si les percentiles sont très larges, la stratégie est très dependante de la sequence des returns\n",
+    "\n",
+    "**Precaution de methode pour ce notebook** : les tirages reechantillonnent les returns OBSERVES de la simulation -- ils explorent l'incertitude d'ordre des evenements, pas l'incertitude de modele (les parametres de la MA Crossover sont supposes connus et stables). Une distribution Monte Carlo etroite dit donc \"l'ordre des jours n'a pas change grand chose\", PAS \"la strategie est robuste a un autre regime de marche\". Les deux questions sont legitimes et differentes ; la seconde demande soit des donnees supplementaires, soit le rolling de la section 6.2."
    ],
    "metadata": {},
    "id": "cell-809e421d"
@@ -2240,7 +2302,9 @@
     "> **Interpretation**:\n",
     "> - **Rolling Sharpe**: Identifie les periodes de bonne/mauvaise performance ajustee au risque\n",
     "> - **Rolling Volatility**: Detecte les changements de regime de volatilite\n",
-    "> - **Rolling Win Rate < 50%**: Periodes difficiles necessitant peut-etre une adaptation"
+    "> - **Rolling Win Rate < 50%**: Periodes difficiles necessitant peut-etre une adaptation\n",
+    "\n",
+    "**Lecture des fenetres glissantes** : ces tracés repondent a la question que les metriques globales des sections 1-2 laissent ouverte -- le Sharpe 1,01 est-il une propriete STABLE de la strategie ou une moyenne sur melange de regimes ? Un Rolling Sharpe qui traverse regulierement le zero dit que non ; une Rolling Volatility qui change de palier signale le changement de regime de marche (choc de taux 2022 vs rallye 2023) ; un Rolling Win Rate qui plonge sous 50 % explique mecaniquement les series de 6 pertes consecutives vues en 3.1. Si les courbes ne sont pas plates, TOUTES les metriques globales de ce notebook doivent se lire comme des moyennes sur melange de regimes, pas comme des proprietes."
    ],
    "id": "cell-e71d6939"
   },
@@ -2474,6 +2538,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-two-sharpe",
+   "metadata": {},
+   "source": [
+    "### Lecture croisee : deux Sharpe, deux alpha\n",
+    "\n",
+    "Le helper affiche **Sharpe 1,0643** la ou la section 1 calculait **1,01**, et **alpha -0,0858** contre **+7,98 %** en section 4.1. Ce ne sont pas des bugs : ce sont des DEFINITIONS differentes -- 503 periodes effectives contre annualisation 252 jours, regression sur returns journaliers contre annualisation directe. C'est le point de vigilance transversal de tout rapport de backtest : *avant de comparer deux chiffres, verifier qu'ils mesurent la meme chose sous la meme convention*. En comite d'investissement, comparer le Sharpe maison (1,01) au Sharpe d'un vendor (1,0643) sans normaliser compare des choux et des carottes -- et sur l'alpha, l'ecart change jusqu'au SIGNE de la conclusion."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "### Visualisation Complete avec Helper\n",
     "\n",
@@ -2516,7 +2590,9 @@
    "id": "5a2e2895",
    "metadata": {},
    "source": [
-    "On résume les statistiques finales du backtest pour produire un rapport de performance synthétique."
+    "On résume les statistiques finales du backtest pour produire un rapport de performance synthétique.\n",
+    "\n",
+    "Le rapport final agrege toutes les familles vues separément : rendement (section 1), risque ajuste (1.2), drawdowns (2), micro-structure des trades (3), exposition au marche (4). C'est le format de sortie d'un analyste -- une page, chiffres verifies, lecturepossible sans re-parcourir le notebook. Les deux blocs suivants montrent sa production par les helpers standardises du repository, puis son application a la comparaison de plusieurs strategies."
    ]
   },
   {
@@ -2588,6 +2664,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "qcpy12-read-comparison",
+   "metadata": {},
+   "source": [
+    "### Lecture du tableau comparatif final\n",
+    "\n",
+    "Sur les sept metriques affichees, la MA Crossover perd sur toutes : Total Return 0,4050 vs 0,4828, CAGR 0,1932 vs 0,2271, Sharpe 1,0643 vs 1,1179, Sortino 1,7651 vs 1,9220, Calmar 1,1619 vs 1,3396 -- seul le Max Drawdown est (tres legerement) meilleur, -0,1663 contre -0,1696. Noter le Win Rate identique (0,5268 des deux cotes) : la strategie ne perd pas parce qu'elle gagne moins souvent, mais parce que ses gains sont plus petits. Un tableau comme celui-ci est la reponse canonique a \"alors, cette strategie ?\" : une ligne par metrique, les deux colonnes, et la lecture qui suit."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "---\n",
@@ -2650,6 +2736,22 @@
     "**Notebook complete. Les metriques de backtest sont essentielles pour evaluer objectivement vos stratégies.**"
    ],
    "id": "cell-06619ddc"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "qcpy12-conclusion",
+   "metadata": {},
+   "source": [
+    "## Conclusion : le verdict honnete\n",
+    "\n",
+    "Sur ces 504 jours de donnees SIMULEES, la MA Crossover ne bat son benchmark sur **aucune** des familles de metriques : rendement brut (40,50 % vs 48,28 %), ratios ajustes au risque (Sharpe 1,01 vs 1,03, Calmar 1,16 vs 1,34), performance active (IR -0,15). Ses vraies qualites : un tiers de volatilite en moins (16,26 % vs 18,52 %), un beta de 0,443 qui la rend partiellement independante du marche, un edge micro coherent (Expectancy 0,2606 %/trade, PF 1,43) -- le profil d'une strategie defensive a faible beta, PAS d'une machine a alpha. Au vocabulaire du depot : **NO BEATS**. Et c'est un resultat pedagogiquement sain : ce notebook apprend a PROUVER une sous-performance, competence au moins aussi rare que celle de revendiquer une surperformance.\n",
+    "\n",
+    "**Les trois chiffres a retenir** : 451/504 jours en drawdown (le cout psychologique permanent), 286 jours pour effacer le pire episode (le cout d'opportunite), Profit Factor 1,43 (la minceur de la marge une fois les vrais frais factures).\n",
+    "\n",
+    "**Exercices de synthese** : (1) refaire tourner `calculate_return_metrics` sur la seule annee 2023 -- le verdict partiel change-t-il de signe ? (2) recalculer le Profit Factor avec 5 bps de frais par trade et determiner le seuil de frais qui annule l'Expectancy ; (3) remplacer le benchmark par 60 % SPY + 40 % cash et verifier que le Sharpe de la strategie devient competitif -- pourquoi ce changement de reference change-t-il la conclusion alors que la strategie, elle, n'a pas change ?\n",
+    "\n",
+    "Suite du parcours : [QC-Py-13-Alpha-Models >>](./QC-Py-13-Alpha-Models.ipynb) -- ou les memes outils de lecture servent a evaluer des modeles d'alpha plutot qu'une strategie technique."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11593

## Summary

#11224 tranche **QC-Py-12-Backtesting-Analysis** : densité pédagogique **746 → 1222** (plancher 1200), markdown-only pattern #10488. Mesure firsthand sur `origin/main` 95c4c9a52a ce cycle : 4 notebooks QC encore sous le plancher (QC-Py-12 : 746, QC-Py-19 : 1192, QC-Py-30 : 991, QC-Py-Cloud-01 : 1010) ; Cloud-01 est claimé par myia-po-2024:CoursIA-2 (01:22Z), QC-Py-12 était libre (aucun claim, aucune PR ouverte).

Le défaut de ce notebook n'était pas l'absence d'interprétations mais leur **généricité** : des blocs « Interprétation » template (« Win Rate > 50 % : … ») qui n'ont jamais lu CE backtest. L'enrichissement ancre chaque lecture sur les **valeurs réellement mesurées dans les outputs committés** :

- Sharpe **1,01 vs 1,03**, vol **16,26 % vs 18,52 %**, Calmar **1,16 vs 1,34** — profil « défensif mais sous-performant »
- **451/504 jours en drawdown (89,5 %)** — le chiffre le plus frappant du notebook
- Durée max DD **286 jours** (2022-01-13 → 2022-10-26), top 5 DD concentrés **mars-avril 2022** (une seule phase de marché, pas cinq crises)
- Expectancy **0,2606 %/trade** × 150 ≈ Total P&L **39,09 %**, PF **1,43** — l'edge micro reconstitué
- Tension pédagogique **alpha +7,98 % vs IR −0,15** (surperformance concentrée, pas régulière)
- **Deux Sharpe, deux alpha** (1,01 vs 1,0643 / +7,98 % vs −0,0858) : lecture croisée des conventions maison vs helper — vérifier la définition avant de comparer deux rapports
- Verdict final honnête **NO BEATS** sur données simulées + 3 exercices de synthèse (re-calcul 2023 seul, seuil de frais annulant l'Expectancy, benchmark 60/40)

## Changes

- 50 → 55 cellules markdown, **34/34 cellules code byte-identiques** (C.3 markdown-only, aucune re-exec due)
- +5 nouvelles cellules (lecture rendement brut, correspondance QC Cloud, deux-Sharpe, lecture tableau comparatif, conclusion) + enrichissement in-place des interps et transitions existantes
- Contexte d'exercice enrichi pour le TODO étudiant (§ patterns temporels, indices + garde multiple-testing)

## Validation

- `pedagogy_density` : **1222/1200**, label below-threshold **0** ✓
- `scan_cell_ordering` : 1 notebook, **0 finding** ✓
- `validate_pr_notebooks` : PASS (34 cells) ✓
- **Ancrage vérifié** (règle cell-interpretation-ordering) : chaque « Lecture » citant N valeurs suit immédiatement le code dont l'output contient ces N valeurs (spot-check mécanique : cells 27/32/39/44/58/63/78) ; les valeurs d'autres sections sont citées avec pointeur explicite
- Catalogue byte-identique à main ✓

See #11224 (tranche QC-Py-12 ; résiduel mesuré sur main après merge : QC-Py-19, QC-Py-30 + Cloud-01 en cours lane CoursIA-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
