### PR TITLE
fix(sw,#11112): re-exec SW-2b + SW-7b — sequences CLEAN 1..N, ratchet BLOCK_REMOVED

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
@@ -66,17 +66,10 @@
    "id": "install-packages",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:35.444047Z",
-     "iopub.status.busy": "2026-05-25T04:09:35.443886Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.406610Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.406009Z"
-    },
-    "papermill": {
-     "duration": 0.966558,
-     "end_time": "2026-05-25T04:09:36.407205+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:35.440647+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
@@ -110,34 +103,18 @@
    "id": "imports-rdflib",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.418329Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.418172Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.502201Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.501656Z"
-    },
-    "papermill": {
-     "duration": 0.087586,
-     "end_time": "2026-05-25T04:09:36.502672+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.415086+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Imports rdflib prets.\n",
-      "rdflib version : rdflib.graph\n",
-      "\n",
-      "Namespaces standards W3C :\n",
-      "  RDF  : http://www.w3.org/1999/02/22-rdf-syntax-ns#\n",
-      "  RDFS : http://www.w3.org/2000/01/rdf-schema#\n",
-      "  XSD  : http://www.w3.org/2001/XMLSchema#\n",
-      "  FOAF : http://xmlns.com/foaf/0.1/\n"
-     ]
+     "name": "stdout",
+     "text": "Imports rdflib prets.\nrdflib version : rdflib.graph\n\nNamespaces standards W3C :\n  RDF  : http://www.w3.org/1999/02/22-rdf-syntax-ns#\n  RDFS : http://www.w3.org/2000/01/rdf-schema#\n  XSD  : http://www.w3.org/2001/XMLSchema#\n  FOAF : http://xmlns.com/foaf/0.1/\n"
     }
    ],
    "source": [
@@ -217,36 +194,18 @@
    "id": "create-graph",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.518386Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.518225Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.523612Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.523044Z"
-    },
-    "papermill": {
-     "duration": 0.009074,
-     "end_time": "2026-05-25T04:09:36.524088+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.515014+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Nombre de triples dans le graphe : 7\n",
-      "\n",
-      "Triples dans le graphe :\n",
-      "  ex:Bob -- rdf:type --> foaf:Person\n",
-      "  ex:Alice -- rdf:type --> foaf:Person\n",
-      "  ex:Bob -- foaf:name --> \"Bob Martin\"\n",
-      "  ex:Alice -- foaf:name --> \"Alice Dupont\"\n",
-      "  ex:Bob -- foaf:age --> \"25\"^^xsd:integer\n",
-      "  ex:Alice -- foaf:knows --> ex:Bob\n",
-      "  ex:Alice -- foaf:age --> \"30\"^^xsd:integer\n"
-     ]
+     "name": "stdout",
+     "text": "Nombre de triples dans le graphe : 7\n\nTriples dans le graphe :\n  ex:Bob -- foaf:name --> \"Bob Martin\"\n  ex:Bob -- rdf:type --> foaf:Person\n  ex:Alice -- foaf:name --> \"Alice Dupont\"\n  ex:Alice -- rdf:type --> foaf:Person\n  ex:Alice -- foaf:age --> \"30\"^^xsd:integer\n  ex:Alice -- foaf:knows --> ex:Bob\n  ex:Bob -- foaf:age --> \"25\"^^xsd:integer\n"
     }
    ],
    "source": [
@@ -342,39 +301,18 @@
    "id": "node-types",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.538370Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.538252Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.542613Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.542162Z"
-    },
-    "papermill": {
-     "duration": 0.007751,
-     "end_time": "2026-05-25T04:09:36.543109+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.535358+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "URIRef       : http://example.org/Alice\n",
-      "  type       : URIRef\n",
-      "\n",
-      "BNode        : Nac6bb3c00c9743188f5a7e4378a634ec\n",
-      "  type       : BNode\n",
-      "\n",
-      "Literal examples:\n",
-      "  simple     : value='Hello World'                   datatype=(none)  lang=(none)\n",
-      "  lang=fr    : value='Bonjour le monde'              datatype=(none)  lang=fr\n",
-      "  integer    : value=42                              datatype=http://www.w3.org/2001/XMLSchema#integer  lang=(none)\n",
-      "  double     : value=3.14                            datatype=http://www.w3.org/2001/XMLSchema#double  lang=(none)\n",
-      "  boolean    : value=True                            datatype=http://www.w3.org/2001/XMLSchema#boolean  lang=(none)\n",
-      "  date       : value=datetime.date(2025, 1, 15)      datatype=http://www.w3.org/2001/XMLSchema#date  lang=(none)\n"
-     ]
+     "name": "stdout",
+     "text": "URIRef       : http://example.org/Alice\n  type       : URIRef\n\nBNode        : N48c9a5bad7364f9ebf027748a2532b32\n  type       : BNode\n\nLiteral examples:\n  simple     : value='Hello World'                   datatype=(none)  lang=(none)\n  lang=fr    : value='Bonjour le monde'              datatype=(none)  lang=fr\n  integer    : value=42                              datatype=http://www.w3.org/2001/XMLSchema#integer  lang=(none)\n  double     : value=3.14                            datatype=http://www.w3.org/2001/XMLSchema#double  lang=(none)\n  boolean    : value=True                            datatype=http://www.w3.org/2001/XMLSchema#boolean  lang=(none)\n  date       : value=datetime.date(2025, 1, 15)      datatype=http://www.w3.org/2001/XMLSchema#date  lang=(none)\n"
     }
    ],
    "source": [
@@ -472,41 +410,18 @@
    "id": "serialize-turtle",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.558102Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.557899Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.561872Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.561437Z"
-    },
-    "papermill": {
-     "duration": 0.007338,
-     "end_time": "2026-05-25T04:09:36.562273+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.554935+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Format Turtle ===\n",
-      "@prefix ex: <http://example.org/> .\n",
-      "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n",
-      "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
-      "\n",
-      "ex:Alice a foaf:Person ;\n",
-      "    foaf:age 30 ;\n",
-      "    foaf:knows ex:Bob ;\n",
-      "    foaf:name \"Alice Dupont\" .\n",
-      "\n",
-      "ex:Bob a foaf:Person ;\n",
-      "    foaf:age 25 ;\n",
-      "    foaf:name \"Bob Martin\" .\n",
-      "\n",
-      "\n"
-     ]
+     "name": "stdout",
+     "text": "=== Format Turtle ===\n@prefix ex: <http://example.org/> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\nex:Alice a foaf:Person ;\n    foaf:age 30 ;\n    foaf:knows ex:Bob ;\n    foaf:name \"Alice Dupont\" .\n\nex:Bob a foaf:Person ;\n    foaf:age 25 ;\n    foaf:name \"Bob Martin\" .\n\n\n"
     }
    ],
    "source": [
@@ -549,78 +464,18 @@
    "id": "serialize-formats",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.573612Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.573494Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.581618Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.581107Z"
-    },
-    "papermill": {
-     "duration": 0.01305,
-     "end_time": "2026-05-25T04:09:36.582064+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.569014+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Format N-Triples ===\n",
-      "<http://example.org/Bob> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n",
-      "<http://example.org/Alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n",
-      "<http://example.org/Bob> <http://xmlns.com/foaf/0.1/name> \"Bob Martin\" .\n",
-      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/name> \"Alice Dupont\" .\n",
-      "<http://example.org/Bob> <http://xmlns.com/foaf/0.1/age> \"25\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
-      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/Bob> .\n",
-      "<http://example.org/Alice> <http://xmlns.com/foaf/0.1/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
-      "\n",
-      "\n",
-      "=== Format JSON-LD ===\n",
-      "[\n",
-      "  {\n",
-      "    \"@id\": \"http://example.org/Bob\",\n",
-      "    \"@type\": [\n",
-      "      \"http://xmlns.com/foaf/0.1/Person\"\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/age\": [\n",
-      "      {\n",
-      "        \"@type\": \"http://www.w3.org/2001/XMLSchema#integer\",\n",
-      "        \"@value\": 25\n",
-      "      }\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Bob Martin\"\n",
-      "      }\n",
-      "    ]\n",
-      "  },\n",
-      "  {\n",
-      "    \"@id\": \"http://example.org/Alice\",\n",
-      "    \"@type\": [\n",
-      "      \"http://xmlns.com/foaf/0.1/Person\"\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/age\": [\n",
-      "      {\n",
-      "        \"@type\": \"http://www.w3.org/2001/XMLSchema#integer\",\n",
-      "        \"@value\": 30\n",
-      "      }\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/knows\": [\n",
-      "      {\n",
-      "        \"@id\": \"http://example.org/Bob\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Alice Dupont\"\n",
-      "      }\n",
-      "    ]\n",
-      "  }\n",
-      "]\n"
-     ]
+     "name": "stdout",
+     "text": "=== Format N-Triples ===\n<http://example.org/Bob> <http://xmlns.com/foaf/0.1/name> \"Bob Martin\" .\n<http://example.org/Bob> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n<http://example.org/Alice> <http://xmlns.com/foaf/0.1/name> \"Alice Dupont\" .\n<http://example.org/Alice> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .\n<http://example.org/Alice> <http://xmlns.com/foaf/0.1/age> \"30\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n<http://example.org/Alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/Bob> .\n<http://example.org/Bob> <http://xmlns.com/foaf/0.1/age> \"25\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n\n\n=== Format JSON-LD ===\n[\n  {\n    \"@id\": \"http://example.org/Alice\",\n    \"@type\": [\n      \"http://xmlns.com/foaf/0.1/Person\"\n    ],\n    \"http://xmlns.com/foaf/0.1/age\": [\n      {\n        \"@type\": \"http://www.w3.org/2001/XMLSchema#integer\",\n        \"@value\": 30\n      }\n    ],\n    \"http://xmlns.com/foaf/0.1/knows\": [\n      {\n        \"@id\": \"http://example.org/Bob\"\n      }\n    ],\n    \"http://xmlns.com/foaf/0.1/name\": [\n      {\n        \"@value\": \"Alice Dupont\"\n      }\n    ]\n  },\n  {\n    \"@id\": \"http://example.org/Bob\",\n    \"@type\": [\n      \"http://xmlns.com/foaf/0.1/Person\"\n    ],\n    \"http://xmlns.com/foaf/0.1/age\": [\n      {\n        \"@type\": \"http://www.w3.org/2001/XMLSchema#integer\",\n        \"@value\": 25\n      }\n    ],\n    \"http://xmlns.com/foaf/0.1/name\": [\n      {\n        \"@value\": \"Bob Martin\"\n      }\n    ]\n  }\n]\n"
     }
    ],
    "source": [
@@ -692,33 +547,18 @@
    "id": "load-example-ttl",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.598224Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.598073Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.603971Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.603390Z"
-    },
-    "papermill": {
-     "duration": 0.009939,
-     "end_time": "2026-05-25T04:09:36.604448+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.594509+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Triples charges depuis Example.ttl : 4\n",
-      "\n",
-      "Contenu de Example.ttl :\n",
-      "  _:n4ad6723275c44dc3a85d81036a47ca9fb1 -- ex:homePage --> <http://purl.org/net/dajobe/>\n",
-      "  _:n4ad6723275c44dc3a85d81036a47ca9fb1 -- ex:fullname --> \"Dave Beckett\"\n",
-      "  <http://www.w3.org/TR/rdf-syntax-grammar> -- dc:title --> \"RDF/XML Syntax Specification (Revised)\"\n",
-      "  <http://www.w3.org/TR/rdf-syntax-grammar> -- ex:editor --> _:n4ad6723275c44dc3a85d81036a47ca9fb1\n"
-     ]
+     "name": "stdout",
+     "text": "Triples charges depuis Example.ttl : 4\n\nContenu de Example.ttl :\n  <http://www.w3.org/TR/rdf-syntax-grammar> -- dc:title --> \"RDF/XML Syntax Specification (Revised)\"\n  <http://www.w3.org/TR/rdf-syntax-grammar> -- ex:editor --> _:n7f6357d9f74f4d42be98c11b3f29f15ab1\n  _:n7f6357d9f74f4d42be98c11b3f29f15ab1 -- ex:homePage --> <http://purl.org/net/dajobe/>\n  _:n7f6357d9f74f4d42be98c11b3f29f15ab1 -- ex:fullname --> \"Dave Beckett\"\n"
     }
    ],
    "source": [
@@ -881,39 +721,18 @@
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.635005Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.634863Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.638518Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.637977Z"
-    },
-    "papermill": {
-     "duration": 0.007219,
-     "end_time": "2026-05-25T04:09:36.638924+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.631705+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Nombre de triples : 2 (attendu: 2)\n",
-      "\n",
-      "=== Turtle ===\n",
-      "@prefix ns1: <http://example.org/> .\n",
-      "\n",
-      "<http://www.dotnetrdf.org> ns1:says \"Hello World\",\n",
-      "        \"Bonjour tout le Monde\"@fr .\n",
-      "\n",
-      "\n",
-      "=== N-Triples ===\n",
-      "<http://www.dotnetrdf.org> <http://example.org/says> \"Hello World\" .\n",
-      "<http://www.dotnetrdf.org> <http://example.org/says> \"Bonjour tout le Monde\"@fr .\n",
-      "\n"
-     ]
+     "name": "stdout",
+     "text": "Nombre de triples : 2 (attendu: 2)\n\n=== Turtle ===\n@prefix ns1: <http://example.org/> .\n\n<http://www.dotnetrdf.org> ns1:says \"Hello World\",\n        \"Bonjour tout le Monde\"@fr .\n\n\n=== N-Triples ===\n<http://www.dotnetrdf.org> <http://example.org/says> \"Hello World\" .\n<http://www.dotnetrdf.org> <http://example.org/says> \"Bonjour tout le Monde\"@fr .\n\n"
     }
    ],
    "source": [
@@ -965,39 +784,18 @@
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.650329Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.650194Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.654378Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.653815Z"
-    },
-    "papermill": {
-     "duration": 0.007643,
-     "end_time": "2026-05-25T04:09:36.654798+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.647155+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Livre en Turtle ===\n",
-      "@prefix ex: <http://example.org/> .\n",
-      "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
-      "\n",
-      "ex:Book123 a ex:Book ;\n",
-      "    ex:author ex:Author123 ;\n",
-      "    ex:description \"Un conte philosophique pour enfants et adultes\"@fr ;\n",
-      "    ex:pages 96 ;\n",
-      "    ex:publisher [ ex:publisherName \"Gallimard\" ;\n",
-      "            ex:publisherURL <http://www.gallimard.fr> ] ;\n",
-      "    ex:title \"Le Petit Prince\" .\n",
-      "\n",
-      "\n"
-     ]
+     "name": "stdout",
+     "text": "=== Livre en Turtle ===\n@prefix ex: <http://example.org/> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\nex:Book123 a ex:Book ;\n    ex:author ex:Author123 ;\n    ex:description \"Un conte philosophique pour enfants et adultes\"@fr ;\n    ex:pages 96 ;\n    ex:publisher [ ex:publisherName \"Gallimard\" ;\n            ex:publisherURL <http://www.gallimard.fr> ] ;\n    ex:title \"Le Petit Prince\" .\n\n\n"
     }
    ],
    "source": [
@@ -1140,27 +938,18 @@
    "id": "10f13476",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.675904Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.675723Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.678665Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.678127Z"
-    },
-    "papermill": {
-     "duration": 0.006621,
-     "end_time": "2026-05-25T04:09:36.679106+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.672485+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : creez un graphe RDF pour un cours\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : creez un graphe RDF pour un cours\n"
     }
    ],
    "source": [
@@ -1210,28 +999,18 @@
    "id": "f94c21c3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.689646Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.689524Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.693378Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.692923Z"
-    },
-    "papermill": {
-     "duration": 0.007435,
-     "end_time": "2026-05-25T04:09:36.693924+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.686489+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Graphe charge : 4 triples\n",
-      "Exercice a completer : explorez et filtrez le graphe\n"
-     ]
+     "name": "stdout",
+     "text": "Graphe charge : 4 triples\nExercice a completer : explorez et filtrez le graphe\n"
     }
    ],
    "source": [
@@ -1275,22 +1054,17 @@
    "id": "exemple-guide-sparql",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:05:19.599044Z",
-     "iopub.status.busy": "2026-08-11T12:05:19.598296Z",
-     "iopub.status.idle": "2026-08-11T12:05:21.054115Z",
-     "shell.execute_reply": "2026-08-11T12:05:21.051822Z"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Personnes dans le graphe (triées par nom) :\n",
-      "  http://example.org/Alice -> Alice\n",
-      "  http://example.org/Bob -> Bob\n",
-      "  http://example.org/Charlie -> Charlie\n"
-     ]
+     "name": "stdout",
+     "text": "Personnes dans le graphe (triées par nom) :\n  http://example.org/Alice -> Alice\n  http://example.org/Bob -> Bob\n  http://example.org/Charlie -> Charlie\n"
     }
    ],
    "source": [
@@ -1344,19 +1118,17 @@
    "id": "exercice3-sparql-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-11T12:05:21.059889Z",
-     "iopub.status.busy": "2026-08-11T12:05:21.059259Z",
-     "iopub.status.idle": "2026-08-11T12:05:21.071597Z",
-     "shell.execute_reply": "2026-08-11T12:05:21.068981Z"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : ecrivez le pattern SPARQL pour compter les amis d'Alice\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : ecrivez le pattern SPARQL pour compter les amis d'Alice\n"
     }
    ],
    "source": [
@@ -1405,31 +1177,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "ef5e0b54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.704176Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.704064Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.706837Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.706263Z"
-    },
-    "papermill": {
-     "duration": 0.006061,
-     "end_time": "2026-05-25T04:09:36.707286+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.701225+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : construisez un graphe RDF pour un reseau social\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : construisez un graphe RDF pour un reseau social\n"
     }
    ],
    "source": [
@@ -1482,199 +1245,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "efc3c013",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-25T04:09:36.718145Z",
-     "iopub.status.busy": "2026-05-25T04:09:36.717998Z",
-     "iopub.status.idle": "2026-05-25T04:09:36.840013Z",
-     "shell.execute_reply": "2026-05-25T04:09:36.839539Z"
-    },
-    "papermill": {
-     "duration": 0.125506,
-     "end_time": "2026-05-25T04:09:36.840455+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.714949+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.busy": "2026-08-18T06:57:10.317095Z",
+     "iopub.status.idle": "2026-08-18T06:57:10.317095Z",
+     "shell.execute_reply": "2026-08-18T06:57:10.317095Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "http://example.org/research/BobDupont http://xmlns.com/foaf/0.1/name Bob Dupont\n",
-      "Ne5c4e199566a4de8a3640b578c16a6b7 https://schema.org/keyword RDF\n",
-      "http://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/member http://example.org/research/BobDupont\n",
-      "Ne5c4e199566a4de8a3640b578c16a6b7 https://schema.org/keyword Semantic Web\n",
-      "http://example.org/research/BobDupont http://xmlns.com/foaf/0.1/mbox mailto:bob.dupont@example.org\n",
-      "Ne5c4e199566a4de8a3640b578c16a6b7 https://schema.org/name Construire un graphe RDF complet\n",
-      "http://example.org/research/AliceMartin http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Person\n",
-      "Ne5c4e199566a4de8a3640b578c16a6b7 https://schema.org/author http://example.org/research/BobDupont\n",
-      "Ne5c4e199566a4de8a3640b578c16a6b7 http://www.w3.org/1999/02/22-rdf-syntax-ns#type https://schema.org/ScholarlyArticle\n",
-      "http://example.org/research/AliceMartin http://xmlns.com/foaf/0.1/mbox mailto:alice.martin@example.org\n",
-      "http://example.org/research/ResearchTeam http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Group\n",
-      "http://example.org/research/AliceMartin https://schema.org/affiliation http://example.org/research/ResearchTeam\n",
-      "http://example.org/research/BobDupont https://schema.org/affiliation http://example.org/research/ResearchTeam\n",
-      "http://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/member http://example.org/research/AliceMartin\n",
-      "http://example.org/research/AliceMartin http://xmlns.com/foaf/0.1/name Alice Martin\n",
-      "http://example.org/research/ResearchTeam https://schema.org/subjectOf Ne5c4e199566a4de8a3640b578c16a6b7\n",
-      "http://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/name Equipe de recherche IA et Web Semantique\n",
-      "http://example.org/research/BobDupont http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Person\n",
-      "Ne5c4e199566a4de8a3640b578c16a6b7 https://schema.org/datePublished 2026-05-20\n",
-      "Ne5c4e199566a4de8a3640b578c16a6b7 https://schema.org/author http://example.org/research/AliceMartin\n",
-      "http://example.org/research/ResearchTeam http://www.w3.org/2000/01/rdf-schema#label Semantic Web AI Team\n",
-      "=== Turtle ===\n",
-      "@prefix ex: <http://example.org/research/> .\n",
-      "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n",
-      "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
-      "@prefix schema: <https://schema.org/> .\n",
-      "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
-      "\n",
-      "ex:AliceMartin a foaf:Person ;\n",
-      "    foaf:mbox <mailto:alice.martin@example.org> ;\n",
-      "    foaf:name \"Alice Martin\" ;\n",
-      "    schema:affiliation ex:ResearchTeam .\n",
-      "\n",
-      "ex:BobDupont a foaf:Person ;\n",
-      "    foaf:mbox <mailto:bob.dupont@example.org> ;\n",
-      "    foaf:name \"Bob Dupont\" ;\n",
-      "    schema:affiliation ex:ResearchTeam .\n",
-      "\n",
-      "ex:ResearchTeam a foaf:Group ;\n",
-      "    rdfs:label \"Semantic Web AI Team\" ;\n",
-      "    foaf:member ex:AliceMartin,\n",
-      "        ex:BobDupont ;\n",
-      "    foaf:name \"Equipe de recherche IA et Web Semantique\" ;\n",
-      "    schema:subjectOf [ a schema:ScholarlyArticle ;\n",
-      "            schema:author ex:AliceMartin,\n",
-      "                ex:BobDupont ;\n",
-      "            schema:datePublished \"2026-05-20\"^^xsd:date ;\n",
-      "            schema:keyword \"RDF\",\n",
-      "                \"Semantic Web\" ;\n",
-      "            schema:name \"Construire un graphe RDF complet\" ] .\n",
-      "\n",
-      "\n",
-      "=== JSON-LD ===\n",
-      "[\n",
-      "  {\n",
-      "    \"@id\": \"http://example.org/research/ResearchTeam\",\n",
-      "    \"@type\": [\n",
-      "      \"http://xmlns.com/foaf/0.1/Group\"\n",
-      "    ],\n",
-      "    \"http://www.w3.org/2000/01/rdf-schema#label\": [\n",
-      "      {\n",
-      "        \"@value\": \"Semantic Web AI Team\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/member\": [\n",
-      "      {\n",
-      "        \"@id\": \"http://example.org/research/AliceMartin\"\n",
-      "      },\n",
-      "      {\n",
-      "        \"@id\": \"http://example.org/research/BobDupont\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Equipe de recherche IA et Web Semantique\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"https://schema.org/subjectOf\": [\n",
-      "      {\n",
-      "        \"@id\": \"_:Ne5c4e199566a4de8a3640b578c16a6b7\"\n",
-      "      }\n",
-      "    ]\n",
-      "  },\n",
-      "  {\n",
-      "    \"@id\": \"_:Ne5c4e199566a4de8a3640b578c16a6b7\",\n",
-      "    \"@type\": [\n",
-      "      \"https://schema.org/ScholarlyArticle\"\n",
-      "    ],\n",
-      "    \"https://schema.org/author\": [\n",
-      "      {\n",
-      "        \"@id\": \"http://example.org/research/AliceMartin\"\n",
-      "      },\n",
-      "      {\n",
-      "        \"@id\": \"http://example.org/research/BobDupont\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"https://schema.org/datePublished\": [\n",
-      "      {\n",
-      "        \"@type\": \"http://www.w3.org/2001/XMLSchema#date\",\n",
-      "        \"@value\": \"2026-05-20\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"https://schema.org/keyword\": [\n",
-      "      {\n",
-      "        \"@value\": \"RDF\"\n",
-      "      },\n",
-      "      {\n",
-      "        \"@value\": \"Semantic Web\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"https://schema.org/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Construire un graphe RDF complet\"\n",
-      "      }\n",
-      "    ]\n",
-      "  },\n",
-      "  {\n",
-      "    \"@id\": \"http://example.org/research/AliceMartin\",\n",
-      "    \"@type\": [\n",
-      "      \"http://xmlns.com/foaf/0.1/Person\"\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/mbox\": [\n",
-      "      {\n",
-      "        \"@id\": \"mailto:alice.martin@example.org\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Alice Martin\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"https://schema.org/affiliation\": [\n",
-      "      {\n",
-      "        \"@id\": \"http://example.org/research/ResearchTeam\"\n",
-      "      }\n",
-      "    ]\n",
-      "  },\n",
-      "  {\n",
-      "    \"@id\": \"http://example.org/research/BobDupont\",\n",
-      "    \"@type\": [\n",
-      "      \"http://xmlns.com/foaf/0.1/Person\"\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/mbox\": [\n",
-      "      {\n",
-      "        \"@id\": \"mailto:bob.dupont@example.org\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"http://xmlns.com/foaf/0.1/name\": [\n",
-      "      {\n",
-      "        \"@value\": \"Bob Dupont\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"https://schema.org/affiliation\": [\n",
-      "      {\n",
-      "        \"@id\": \"http://example.org/research/ResearchTeam\"\n",
-      "      }\n",
-      "    ]\n",
-      "  }\n",
-      "]\n",
-      "\n",
-      "=== Auteurs trouves avec SPARQL ===\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Alice Martin\n",
-      "Bob Dupont\n"
-     ]
+     "text": "http://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/name Equipe de recherche IA et Web Semantique\nhttp://example.org/research/AliceMartin https://schema.org/affiliation http://example.org/research/ResearchTeam\nhttp://example.org/research/AliceMartin http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Person\nNdcd28b2be0254783bdd23d33f605fb26 https://schema.org/keyword RDF\nNdcd28b2be0254783bdd23d33f605fb26 https://schema.org/author http://example.org/research/AliceMartin\nNdcd28b2be0254783bdd23d33f605fb26 https://schema.org/keyword Semantic Web\nNdcd28b2be0254783bdd23d33f605fb26 https://schema.org/author http://example.org/research/BobDupont\nNdcd28b2be0254783bdd23d33f605fb26 https://schema.org/datePublished 2026-05-20\nhttp://example.org/research/BobDupont http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Person\nhttp://example.org/research/BobDupont http://xmlns.com/foaf/0.1/mbox mailto:bob.dupont@example.org\nhttp://example.org/research/BobDupont http://xmlns.com/foaf/0.1/name Bob Dupont\nhttp://example.org/research/AliceMartin http://xmlns.com/foaf/0.1/name Alice Martin\nhttp://example.org/research/BobDupont https://schema.org/affiliation http://example.org/research/ResearchTeam\nhttp://example.org/research/ResearchTeam http://www.w3.org/1999/02/22-rdf-syntax-ns#type http://xmlns.com/foaf/0.1/Group\nhttp://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/member http://example.org/research/BobDupont\nhttp://example.org/research/ResearchTeam http://xmlns.com/foaf/0.1/member http://example.org/research/AliceMartin\nhttp://example.org/research/AliceMartin http://xmlns.com/foaf/0.1/mbox mailto:alice.martin@example.org\nhttp://example.org/research/ResearchTeam http://www.w3.org/2000/01/rdf-schema#label Semantic Web AI Team\nNdcd28b2be0254783bdd23d33f605fb26 http://www.w3.org/1999/02/22-rdf-syntax-ns#type https://schema.org/ScholarlyArticle\nNdcd28b2be0254783bdd23d33f605fb26 https://schema.org/name Construire un graphe RDF complet\nhttp://example.org/research/ResearchTeam https://schema.org/subjectOf Ndcd28b2be0254783bdd23d33f605fb26\n=== Turtle ===\n@prefix ex: <http://example.org/research/> .\n@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n@prefix schema: <https://schema.org/> .\n@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\nex:AliceMartin a foaf:Person ;\n    foaf:mbox <mailto:alice.martin@example.org> ;\n    foaf:name \"Alice Martin\" ;\n    schema:affiliation ex:ResearchTeam .\n\nex:BobDupont a foaf:Person ;\n    foaf:mbox <mailto:bob.dupont@example.org> ;\n    foaf:name \"Bob Dupont\" ;\n    schema:affiliation ex:ResearchTeam .\n\nex:ResearchTeam a foaf:Group ;\n    rdfs:label \"Semantic Web AI Team\" ;\n    foaf:member ex:AliceMartin,\n        ex:BobDupont ;\n    foaf:name \"Equipe de recherche IA et Web Semantique\" ;\n    schema:subjectOf [ a schema:ScholarlyArticle ;\n            schema:author ex:AliceMartin,\n                ex:BobDupont ;\n            schema:datePublished \"2026-05-20\"^^xsd:date ;\n            schema:keyword \"RDF\",\n                \"Semantic Web\" ;\n            schema:name \"Construire un graphe RDF complet\" ] .\n\n\n=== JSON-LD ===\n[\n  {\n    \"@id\": \"http://example.org/research/ResearchTeam\",\n    \"@type\": [\n      \"http://xmlns.com/foaf/0.1/Group\"\n    ],\n    \"http://www.w3.org/2000/01/rdf-schema#label\": [\n      {\n        \"@value\": \"Semantic Web AI Team\"\n      }\n    ],\n    \"http://xmlns.com/foaf/0.1/member\": [\n      {\n        \"@id\": \"http://example.org/research/AliceMartin\"\n      },\n      {\n        \"@id\": \"http://example.org/research/BobDupont\"\n      }\n    ],\n    \"http://xmlns.com/foaf/0.1/name\": [\n      {\n        \"@value\": \"Equipe de recherche IA et Web Semantique\"\n      }\n    ],\n    \"https://schema.org/subjectOf\": [\n      {\n        \"@id\": \"_:Ndcd28b2be0254783bdd23d33f605fb26\"\n      }\n    ]\n  },\n  {\n    \"@id\": \"_:Ndcd28b2be0254783bdd23d33f605fb26\",\n    \"@type\": [\n      \"https://schema.org/ScholarlyArticle\"\n    ],\n    \"https://schema.org/author\": [\n      {\n        \"@id\": \"http://example.org/research/AliceMartin\"\n      },\n      {\n        \"@id\": \"http://example.org/research/BobDupont\"\n      }\n    ],\n    \"https://schema.org/datePublished\": [\n      {\n        \"@type\": \"http://www.w3.org/2001/XMLSchema#date\",\n        \"@value\": \"2026-05-20\"\n      }\n    ],\n    \"https://schema.org/keyword\": [\n      {\n        \"@value\": \"RDF\"\n      },\n      {\n        \"@value\": \"Semantic Web\"\n      }\n    ],\n    \"https://schema.org/name\": [\n      {\n        \"@value\": \"Construire un graphe RDF complet\"\n      }\n    ]\n  },\n  {\n    \"@id\": \"http://example.org/research/BobDupont\",\n    \"@type\": [\n      \"http://xmlns.com/foaf/0.1/Person\"\n    ],\n    \"http://xmlns.com/foaf/0.1/mbox\": [\n      {\n        \"@id\": \"mailto:bob.dupont@example.org\"\n      }\n    ],\n    \"http://xmlns.com/foaf/0.1/name\": [\n      {\n        \"@value\": \"Bob Dupont\"\n      }\n    ],\n    \"https://schema.org/affiliation\": [\n      {\n        \"@id\": \"http://example.org/research/ResearchTeam\"\n      }\n    ]\n  },\n  {\n    \"@id\": \"http://example.org/research/AliceMartin\",\n    \"@type\": [\n      \"http://xmlns.com/foaf/0.1/Person\"\n    ],\n    \"http://xmlns.com/foaf/0.1/mbox\": [\n      {\n        \"@id\": \"mailto:alice.martin@example.org\"\n      }\n    ],\n    \"http://xmlns.com/foaf/0.1/name\": [\n      {\n        \"@value\": \"Alice Martin\"\n      }\n    ],\n    \"https://schema.org/affiliation\": [\n      {\n        \"@id\": \"http://example.org/research/ResearchTeam\"\n      }\n    ]\n  }\n]\n\n=== Auteurs trouves avec SPARQL ===\nAlice Martin\nBob Dupont\n"
     }
    ],
    "source": [

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-2b-Python-RDFBasics.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "id": "header-navigation",
    "metadata": {
-    "papermill": {
-     "duration": 0.022548,
-     "end_time": "2026-05-25T04:09:35.425782+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:35.403234+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -43,13 +36,6 @@
    "cell_type": "markdown",
    "id": "section-1-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.004051,
-     "end_time": "2026-05-25T04:09:35.437849+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:35.433798+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -82,13 +68,6 @@
    "cell_type": "markdown",
    "id": "install-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.00248,
-     "end_time": "2026-05-25T04:09:36.412500+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.410020+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -140,13 +119,6 @@
    "cell_type": "markdown",
    "id": "imports-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.002379,
-     "end_time": "2026-05-25T04:09:36.507481+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.505102+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -171,13 +143,6 @@
    "cell_type": "markdown",
    "id": "section-2-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.002547,
-     "end_time": "2026-05-25T04:09:36.512671+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.510124+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -245,13 +210,6 @@
    "cell_type": "markdown",
    "id": "create-graph-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.00227,
-     "end_time": "2026-05-25T04:09:36.528814+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.526544+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -278,13 +236,6 @@
    "cell_type": "markdown",
    "id": "section-3-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.002217,
-     "end_time": "2026-05-25T04:09:36.533218+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.531001+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -357,13 +308,6 @@
    "cell_type": "markdown",
    "id": "node-types-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.00219,
-     "end_time": "2026-05-25T04:09:36.547634+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.545444+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -387,13 +331,6 @@
    "cell_type": "markdown",
    "id": "section-4-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.002489,
-     "end_time": "2026-05-25T04:09:36.552565+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.550076+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -438,13 +375,6 @@
    "cell_type": "markdown",
    "id": "serialize-turtle-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.002191,
-     "end_time": "2026-05-25T04:09:36.566729+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.564538+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -498,13 +428,6 @@
    "cell_type": "markdown",
    "id": "serialize-comparison",
    "metadata": {
-    "papermill": {
-     "duration": 0.002496,
-     "end_time": "2026-05-25T04:09:36.586962+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.584466+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -524,13 +447,6 @@
    "cell_type": "markdown",
    "id": "section-5-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.002541,
-     "end_time": "2026-05-25T04:09:36.591856+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.589315+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -584,13 +500,6 @@
    "cell_type": "markdown",
    "id": "load-example-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.002266,
-     "end_time": "2026-05-25T04:09:36.609072+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.606806+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -610,13 +519,6 @@
    "cell_type": "markdown",
    "id": "section-6-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.00249,
-     "end_time": "2026-05-25T04:09:36.614179+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.611689+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -631,13 +533,6 @@
    "cell_type": "markdown",
    "id": "comparison-table",
    "metadata": {
-    "papermill": {
-     "duration": 0.002387,
-     "end_time": "2026-05-25T04:09:36.618829+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.616442+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -673,13 +568,6 @@
    "cell_type": "markdown",
    "id": "exercises-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.002469,
-     "end_time": "2026-05-25T04:09:36.623738+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.621269+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -694,13 +582,6 @@
    "cell_type": "markdown",
    "id": "exercise-1-intro",
    "metadata": {
-    "papermill": {
-     "duration": 0.002722,
-     "end_time": "2026-05-25T04:09:36.629219+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.626497+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -763,13 +644,6 @@
    "cell_type": "markdown",
    "id": "exercise-2-intro",
    "metadata": {
-    "papermill": {
-     "duration": 0.003036,
-     "end_time": "2026-05-25T04:09:36.644592+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.641556+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -831,13 +705,6 @@
    "cell_type": "markdown",
    "id": "37e5c168",
    "metadata": {
-    "papermill": {
-     "duration": 0.002291,
-     "end_time": "2026-05-25T04:09:36.659497+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.657206+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -864,13 +731,6 @@
    "cell_type": "markdown",
    "id": "summary-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.002464,
-     "end_time": "2026-05-25T04:09:36.664734+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.662270+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -910,13 +770,6 @@
    "cell_type": "markdown",
    "id": "90d513e0",
    "metadata": {
-    "papermill": {
-     "duration": 0.002568,
-     "end_time": "2026-05-25T04:09:36.669809+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.667241+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -975,13 +828,6 @@
    "cell_type": "markdown",
    "id": "e5f66c5f",
    "metadata": {
-    "papermill": {
-     "duration": 0.002372,
-     "end_time": "2026-05-25T04:09:36.683923+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.681551+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1156,13 +1002,6 @@
    "cell_type": "markdown",
    "id": "41f918c4",
    "metadata": {
-    "papermill": {
-     "duration": 0.002357,
-     "end_time": "2026-05-25T04:09:36.698837+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.696480+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1214,13 +1053,6 @@
    "cell_type": "markdown",
    "id": "425fdc5f",
    "metadata": {
-    "papermill": {
-     "duration": 0.002461,
-     "end_time": "2026-05-25T04:09:36.712510+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.710049+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1348,13 +1180,6 @@
    "cell_type": "markdown",
    "id": "51bfb0e1",
    "metadata": {
-    "papermill": {
-     "duration": 0.003114,
-     "end_time": "2026-05-25T04:09:36.846749+00:00",
-     "exception": false,
-     "start_time": "2026-05-25T04:09:36.843635+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1393,18 +1218,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.12"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 2.853636,
-   "end_time": "2026-05-25T04:09:37.118423+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "SW-2b-Python-RDFBasics.ipynb",
-   "output_path": "SW-2b-Python-RDFBasics.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-25T04:09:34.264787+00:00",
-   "version": "2.6.0"
   },
   "cost": {
    "api_usd_est": 0.0,

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
@@ -67,17 +67,10 @@
    "id": "install-packages",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:33.584887Z",
-     "iopub.status.busy": "2026-05-26T09:09:33.580785Z",
-     "iopub.status.idle": "2026-05-26T09:09:34.928799Z",
-     "shell.execute_reply": "2026-05-26T09:09:34.928799Z"
-    },
-    "papermill": {
-     "duration": 1.413658,
-     "end_time": "2026-05-26T09:09:34.937852",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:33.524194",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
@@ -109,27 +102,18 @@
    "id": "imports-owlready2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:35.229652Z",
-     "iopub.status.busy": "2026-05-26T09:09:35.221215Z",
-     "iopub.status.idle": "2026-05-26T09:09:35.296443Z",
-     "shell.execute_reply": "2026-05-26T09:09:35.296443Z"
-    },
-    "papermill": {
-     "duration": 0.162284,
-     "end_time": "2026-05-26T09:09:35.308099",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.145815",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "OWLReady2 importe.\n"
-     ]
+     "name": "stdout",
+     "text": "OWLReady2 importe.\n"
     }
    ],
    "source": [
@@ -174,35 +158,18 @@
    "id": "create-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:35.465733Z",
-     "iopub.status.busy": "2026-05-26T09:09:35.465733Z",
-     "iopub.status.idle": "2026-05-26T09:09:35.516969Z",
-     "shell.execute_reply": "2026-05-26T09:09:35.514418Z"
-    },
-    "papermill": {
-     "duration": 0.109067,
-     "end_time": "2026-05-26T09:09:35.522700",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.413633",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Ontologie creee avec classes :\n",
-      "  Person (Thing subclass)\n",
-      "  Man (Person subclass)\n",
-      "  Woman (Person subclass)\n",
-      "\n",
-      "Proprietes :\n",
-      "  has_child (ObjectProperty, inverse: has_parent)\n",
-      "  has_name (DataProperty, string)\n",
-      "  age (DataProperty, integer)\n"
-     ]
+     "name": "stdout",
+     "text": "Ontologie creee avec classes :\n  Person (Thing subclass)\n  Man (Person subclass)\n  Woman (Person subclass)\n\nProprietes :\n  has_child (ObjectProperty, inverse: has_parent)\n  has_name (DataProperty, string)\n  age (DataProperty, integer)\n"
     }
    ],
    "source": [
@@ -312,37 +279,18 @@
    "id": "create-individuals",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:35.621110Z",
-     "iopub.status.busy": "2026-05-26T09:09:35.620106Z",
-     "iopub.status.idle": "2026-05-26T09:09:35.630466Z",
-     "shell.execute_reply": "2026-05-26T09:09:35.629558Z"
-    },
-    "papermill": {
-     "duration": 0.024137,
-     "end_time": "2026-05-26T09:09:35.630466",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.606329",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Individus crees :\n",
-      "  John : John Smith, 45 ans\n",
-      "  Mary : Mary Smith, 42 ans\n",
-      "  Alice : Alice Smith, 15 ans\n",
-      "\n",
-      "Relations parent-enfant :\n",
-      "  John -> has_child -> Alice\n",
-      "  Mary -> has_child -> Alice\n",
-      "\n",
-      "Propriete inverse (auto-generee) :\n",
-      "  Alice -> has_parent -> ['John', 'Mary']\n"
-     ]
+     "name": "stdout",
+     "text": "Individus crees :\n  John : John Smith, 45 ans\n  Mary : Mary Smith, 42 ans\n  Alice : Alice Smith, 15 ans\n\nRelations parent-enfant :\n  John -> has_child -> Alice\n  Mary -> has_child -> Alice\n\nPropriete inverse (auto-generee) :\n  Alice -> has_parent -> ['John', 'Mary']\n"
     }
    ],
    "source": [
@@ -426,33 +374,18 @@
    "id": "restrictions",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:35.713852Z",
-     "iopub.status.busy": "2026-05-26T09:09:35.712090Z",
-     "iopub.status.idle": "2026-05-26T09:09:35.731228Z",
-     "shell.execute_reply": "2026-05-26T09:09:35.729847Z"
-    },
-    "papermill": {
-     "duration": 0.057843,
-     "end_time": "2026-05-26T09:09:35.738777",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.680934",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Classes avec restrictions :\n",
-      "  Manager = Person AND manages SOME Department\n",
-      "  Employee = Person AND works_in SOME Department\n",
-      "\n",
-      "Restriction OWLReady2 :\n",
-      "  manages.some(Department) = exists manages . Department\n",
-      "  Person & manages.some(Department) = Person AND (exists manages . Department)\n"
-     ]
+     "name": "stdout",
+     "text": "Classes avec restrictions :\n  Manager = Person AND manages SOME Department\n  Employee = Person AND works_in SOME Department\n\nRestriction OWLReady2 :\n  manages.some(Department) = exists manages . Department\n  Person & manages.some(Department) = Person AND (exists manages . Department)\n"
     }
    ],
    "source": [
@@ -548,65 +481,33 @@
    "id": "reasoning",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:35.864255Z",
-     "iopub.status.busy": "2026-05-26T09:09:35.864255Z",
-     "iopub.status.idle": "2026-05-26T09:09:37.015076Z",
-     "shell.execute_reply": "2026-05-26T09:09:37.015076Z"
-    },
-    "papermill": {
-     "duration": 1.167958,
-     "end_time": "2026-05-26T09:09:37.015076",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.847118",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Avant raisonnement ===\n",
-      "Bob types : [company.Person]\n",
-      "Alice types : [company.Person]\n",
-      "Charlie types : [company.Person]\n",
-      "\n"
-     ]
+     "text": "=== Avant raisonnement ===\nBob types : [company.Person]\nAlice types : [company.Person]\nCharlie types : [company.Person]\n\n"
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp /path/to/owlready2/hermit;/path/to/owlready2/hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///tmp/owlready2_tmpfile\n"
-     ]
+     "text": "* Owlready2 * Running HermiT...\n    java -Xmx1000M -cp <USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;<USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/<USER_PATH>\\AppData/Local/Temp/tmpkxdsdauf\n"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Apres raisonnement (HermiT) ===\n",
-      "Bob types : [company.Employee]\n",
-      "Alice types : [company.Employee]\n",
-      "Charlie types : [company.Manager, company.Employee]\n",
-      "\n",
-      "Deductions :\n",
-      "  Bob est Employee (car works_in SOME Department)\n",
-      "  Alice est Employee (car works_in SOME Department)\n",
-      "  Charlie est Employee ET Manager (car works_in ET manages)\n"
-     ]
+     "text": "=== Apres raisonnement (HermiT) ===\nBob types : [company.Employee]\nAlice types : [company.Employee]\nCharlie types : [company.Employee, company.Manager]\n\nDeductions :\n  Bob est Employee (car works_in SOME Department)\n  Alice est Employee (car works_in SOME Department)\n  Charlie est Employee ET Manager (car works_in ET manages)\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "* Owlready2 * HermiT took 0.6579272747039795 seconds\n",
-      "* Owlready * Reparenting company.Bob: {company.Person} => {company.Employee}\n",
-      "* Owlready * Reparenting company.Charlie: {company.Person} => {company.Manager, company.Employee}\n",
-      "* Owlready * Reparenting company.Alice: {company.Person} => {company.Employee}\n",
-      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
-     ]
+     "name": "stderr",
+     "text": "* Owlready2 * HermiT took 1.175506353378296 seconds\n* Owlready * Reparenting company.Bob: {company.Person} => {company.Employee}\n* Owlready * Reparenting company.Charlie: {company.Person} => {company.Manager, company.Employee}\n* Owlready * Reparenting company.Alice: {company.Person} => {company.Employee}\n* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
     }
    ],
    "source": [
@@ -725,37 +626,18 @@
    "id": "load-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:37.224517Z",
-     "iopub.status.busy": "2026-05-26T09:09:37.222457Z",
-     "iopub.status.idle": "2026-05-26T09:09:37.285979Z",
-     "shell.execute_reply": "2026-05-26T09:09:37.280897Z"
-    },
-    "papermill": {
-     "duration": 0.15642,
-     "end_time": "2026-05-26T09:09:37.288608",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.132188",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Ontologie chargee : http://example.org/university#\n",
-      "Classes : 6\n",
-      "Individuals : 0\n",
-      "\n",
-      "Classes dans l'ontologie :\n",
-      "  Person\n",
-      "  Student\n",
-      "  Professor\n",
-      "  Course\n",
-      "  Department\n",
-      "  GraduateStudent\n"
-     ]
+     "name": "stdout",
+     "text": "Ontologie chargee : http://example.org/university#\nClasses : 6\nIndividuals : 6\n\nClasses dans l'ontologie :\n  Student\n  Course\n  Professor\n  Person\n  Department\n  GraduateStudent\n"
     }
    ],
    "source": [
@@ -818,58 +700,18 @@
    "id": "export-ontology",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:37.424005Z",
-     "iopub.status.busy": "2026-05-26T09:09:37.422940Z",
-     "iopub.status.idle": "2026-05-26T09:09:37.475863Z",
-     "shell.execute_reply": "2026-05-26T09:09:37.469555Z"
-    },
-    "papermill": {
-     "duration": 0.09907,
-     "end_time": "2026-05-26T09:09:37.481858",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.382788",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Ontologie exportee : data/temp_company.owl"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\n",
-      "Ontologie exportee : data/temp_company.ttl\n",
-      "\n",
-      "=== Apercu Turtle (20 premieres lignes) ===\n",
-      "<http://example.org/company.owl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .\n",
-      "<http://example.org/company.owl#Person> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
-      "<http://example.org/company.owl#Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2002/07/owl#Thing> .\n",
-      "<http://example.org/company.owl#Department> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
-      "<http://example.org/company.owl#Department> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2002/07/owl#Thing> .\n",
-      "<http://example.org/company.owl#works_in> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .\n",
-      "<http://example.org/company.owl#works_in> <http://www.w3.org/2000/01/rdf-schema#domain> <http://example.org/company.owl#Person> .\n",
-      "<http://example.org/company.owl#works_in> <http://www.w3.org/2000/01/rdf-schema#range> <http://example.org/company.owl#Department> .\n",
-      "<http://example.org/company.owl#manages> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .\n",
-      "<http://example.org/company.owl#manages> <http://www.w3.org/2000/01/rdf-schema#domain> <http://example.org/company.owl#Person> .\n",
-      "<http://example.org/company.owl#manages> <http://www.w3.org/2000/01/rdf-schema#range> <http://example.org/company.owl#Department> .\n",
-      "<http://example.org/company.owl#Manager> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
-      "<http://example.org/company.owl#Manager> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.org/company.owl#Person> .\n",
-      "_:2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> .\n",
-      "_:2 <http://www.w3.org/2002/07/owl#onProperty> <http://example.org/company.owl#manages> .\n",
-      "_:2 <http://www.w3.org/2002/07/owl#someValuesFrom> <http://example.org/company.owl#Department> .\n",
-      "_:3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n",
-      "_:3 <http://www.w3.org/2002/07/owl#intersectionOf> _:1 .\n",
-      "_:1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.org/company.owl#Person> .\n",
-      "_:1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:4 .\n"
-     ]
+     "text": "Ontologie exportee : data/temp_company.owl\n\nOntologie exportee : data/temp_company.ttl\n\n=== Apercu Turtle (20 premieres lignes) ===\n<http://example.org/company.owl> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Ontology> .\n<http://example.org/company.owl#Person> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n<http://example.org/company.owl#Person> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2002/07/owl#Thing> .\n<http://example.org/company.owl#Department> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n<http://example.org/company.owl#Department> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://www.w3.org/2002/07/owl#Thing> .\n<http://example.org/company.owl#works_in> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .\n<http://example.org/company.owl#works_in> <http://www.w3.org/2000/01/rdf-schema#domain> <http://example.org/company.owl#Person> .\n<http://example.org/company.owl#works_in> <http://www.w3.org/2000/01/rdf-schema#range> <http://example.org/company.owl#Department> .\n<http://example.org/company.owl#manages> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#ObjectProperty> .\n<http://example.org/company.owl#manages> <http://www.w3.org/2000/01/rdf-schema#domain> <http://example.org/company.owl#Person> .\n<http://example.org/company.owl#manages> <http://www.w3.org/2000/01/rdf-schema#range> <http://example.org/company.owl#Department> .\n<http://example.org/company.owl#Manager> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n<http://example.org/company.owl#Manager> <http://www.w3.org/2000/01/rdf-schema#subClassOf> <http://example.org/company.owl#Person> .\n_:2 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Restriction> .\n_:2 <http://www.w3.org/2002/07/owl#onProperty> <http://example.org/company.owl#manages> .\n_:2 <http://www.w3.org/2002/07/owl#someValuesFrom> <http://example.org/company.owl#Department> .\n_:3 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/2002/07/owl#Class> .\n_:3 <http://www.w3.org/2002/07/owl#intersectionOf> _:1 .\n_:1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> <http://example.org/company.owl#Person> .\n_:1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:4 .\n"
     }
    ],
    "source": [
@@ -1008,60 +850,33 @@
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:38.097851Z",
-     "iopub.status.busy": "2026-05-26T09:09:38.097851Z",
-     "iopub.status.idle": "2026-05-26T09:09:38.800042Z",
-     "shell.execute_reply": "2026-05-26T09:09:38.798451Z"
-    },
-    "papermill": {
-     "duration": 0.718115,
-     "end_time": "2026-05-26T09:09:38.800042",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:38.081927",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Avant raisonnement ===\n",
-      "Pierre : ['Person']\n",
-      "Marie  : ['Person']\n",
-      "Lucie  : ['Person']\n"
-     ]
-    },
-    {
      "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp /path/to/owlready2/hermit;/path/to/owlready2/hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///tmp/owlready2_tmpfile -Y\n"
-     ]
+     "text": "* Owlready2 * Running HermiT...\n    java -Xmx1000M -cp <USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;<USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/<USER_PATH>\\AppData/Local/Temp/tmpvvwjqe3n -Y\n"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Apres raisonnement ===\n",
-      "Pierre : ['Parent']\n",
-      "Marie  : ['Parent']\n",
-      "Lucie  : ['Child']\n"
-     ]
+     "text": "=== Avant raisonnement ===\nPierre : ['Person']\nMarie  : ['Person']\nLucie  : ['Person']\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "* Owlready2 * HermiT took 0.5352654457092285 seconds\n",
-      "* Owlready * Reparenting family2.Lucie: {family2.Person} => {family2.Child}\n",
-      "* Owlready * Reparenting family2.Pierre: {family2.Person} => {family2.Parent}\n",
-      "* Owlready * Reparenting family2.Marie: {family2.Person} => {family2.Parent}\n",
-      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
-     ]
+     "name": "stdout",
+     "text": "\n=== Apres raisonnement ===\nPierre : ['Parent']\nMarie  : ['Parent']\nLucie  : ['Child']\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": "* Owlready2 * HermiT took 0.6332166194915771 seconds\n* Owlready * Reparenting family2.Lucie: {family2.Person} => {family2.Child}\n* Owlready * Reparenting family2.Pierre: {family2.Person} => {family2.Parent}\n* Owlready * Reparenting family2.Marie: {family2.Person} => {family2.Parent}\n* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
     }
    ],
    "source": [
@@ -1149,56 +964,33 @@
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:38.848272Z",
-     "iopub.status.busy": "2026-05-26T09:09:38.848272Z",
-     "iopub.status.idle": "2026-05-26T09:09:39.535843Z",
-     "shell.execute_reply": "2026-05-26T09:09:39.535326Z"
-    },
-    "papermill": {
-     "duration": 0.703288,
-     "end_time": "2026-05-26T09:09:39.538857",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:38.835569",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp /path/to/owlready2/hermit;/path/to/owlready2/hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///tmp/owlready2_tmpfile\n"
-     ]
+     "text": "* Owlready2 * Running HermiT...\n    java -Xmx1000M -cp <USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;<USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/<USER_PATH>\\AppData/Local/Temp/tmpyo8y361o\n"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Avant raisonnement ===\n",
-      "DarkKnight   : ['Movie']\n",
-      "Interstellar : ['Movie']\n"
-     ]
+     "text": "=== Avant raisonnement ===\nDarkKnight   : ['Movie']\nInterstellar : ['Movie']\n"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Apres raisonnement ===\n",
-      "DarkKnight   : ['ActionMovie']\n",
-      "Interstellar : ['Movie']\n"
-     ]
+     "text": "\n=== Apres raisonnement ===\nDarkKnight   : ['ActionMovie']\nInterstellar : ['Movie']\n"
     },
     {
+     "output_type": "stream",
      "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * HermiT took 0.5668504238128662 seconds\n",
-      "* Owlready * Reparenting movies.DarkKnight: {movies.Movie} => {movies.ActionMovie}\n",
-      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
-     ]
+     "text": "* Owlready2 * HermiT took 0.6235911846160889 seconds\n* Owlready * Reparenting movies.DarkKnight: {movies.Movie} => {movies.ActionMovie}\n* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
     }
    ],
    "source": [
@@ -1349,70 +1141,33 @@
    "id": "89008950",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:39.614560Z",
-     "iopub.status.busy": "2026-05-26T09:09:39.613565Z",
-     "iopub.status.idle": "2026-05-26T09:09:40.317759Z",
-     "shell.execute_reply": "2026-05-26T09:09:40.317123Z"
-    },
-    "papermill": {
-     "duration": 0.71617,
-     "end_time": "2026-05-26T09:09:40.319617",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:39.603447",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Avant raisonnement ==="
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Lapin : ['Mammifere']\n",
-      "  Souris : ['Mammifere']\n",
-      "  Renard : ['Mammifere']\n",
-      "  Loup : ['Mammifere']\n"
-     ]
-    },
-    {
      "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp /path/to/owlready2/hermit;/path/to/owlready2/hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///tmp/owlready2_tmpfile\n"
-     ]
+     "text": "* Owlready2 * Running HermiT...\n    java -Xmx1000M -cp <USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;<USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/<USER_PATH>\\AppData/Local/Temp/tmp7uizn121\n"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "=== Apres raisonnement ===\n",
-      "  Lapin : ['Mammifere']\n",
-      "  Souris : ['Mammifere']\n",
-      "  Renard : ['Mammifere', 'Carnivore']\n",
-      "  Loup : ['Mammifere', 'Carnivore']\n",
-      "\n",
-      "Ontologie exportee : data/temp_ecosystem.owl\n"
-     ]
+     "text": "=== Avant raisonnement ===\n  Lapin : ['Mammifere']\n  Souris : ['Mammifere']\n  Renard : ['Mammifere']\n  Loup : ['Mammifere']\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "* Owlready2 * HermiT took 0.6256916522979736 seconds\n",
-      "* Owlready * Reparenting ecosystem.Loup: {ecosystem.Mammifere} => {ecosystem.Carnivore, ecosystem.Mammifere}\n",
-      "* Owlready * Reparenting ecosystem.Renard: {ecosystem.Mammifere} => {ecosystem.Carnivore, ecosystem.Mammifere}\n",
-      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
-     ]
+     "name": "stdout",
+     "text": "\n=== Apres raisonnement ===\n  Lapin : ['Mammifere']\n  Souris : ['Mammifere']\n  Renard : ['Mammifere', 'Carnivore']\n  Loup : ['Mammifere', 'Carnivore']\n\nOntologie exportee : data/temp_ecosystem.owl\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": "* Owlready2 * HermiT took 0.5813078880310059 seconds\n* Owlready * Reparenting ecosystem.Loup: {ecosystem.Mammifere} => {ecosystem.Mammifere, ecosystem.Carnivore}\n* Owlready * Reparenting ecosystem.Renard: {ecosystem.Mammifere} => {ecosystem.Mammifere, ecosystem.Carnivore}\n* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
     }
    ],
    "source": [
@@ -1481,64 +1236,35 @@
    "cell_type": "code",
    "id": "ad1cbb21",
    "source": "if OWLREADY2_AVAILABLE:\n    # Exemple guide 3 : ontologie de LLM avec raisonnement\n    # Contribue par louisparmentiermichelet-hue (PR #1932, cohorte 2026)\n    # MultimodalLLM / CodingLLM / ReasoningLLM definis par equivalent_to ; HermiT classe les modeles\n    from owlready2 import World\n\n    llm_world = World()\n    onto_llm = llm_world.get_ontology(\"http://example.org/llm.owl#\")\n\n    with onto_llm:\n        # Classes de base\n        class AIModel(Thing):\n            pass\n\n        class LLM(AIModel):\n            pass\n\n        class Organization(Thing):\n            pass\n\n        class Benchmark(Thing):\n            pass\n\n        class Capability(Thing):\n            pass\n\n        # Proprietes\n        class developed_by(ObjectProperty):\n            pass\n\n        class has_capability(ObjectProperty):\n            pass\n\n        class evaluated_on(ObjectProperty):\n            pass\n\n        class outperforms(ObjectProperty):\n            pass\n\n        # Sous-classes de Capability\n        class ImageUnderstanding(Capability):\n            pass\n\n        class CodeGeneration(Capability):\n            pass\n\n        class Reasoning(Capability):\n            pass\n\n        # Classes definies par restrictions equivalent_to\n        class MultimodalLLM(LLM):\n            equivalent_to = [LLM & has_capability.some(ImageUnderstanding)]\n\n        class CodingLLM(LLM):\n            equivalent_to = [LLM & has_capability.some(CodeGeneration)]\n\n        class ReasoningLLM(LLM):\n            equivalent_to = [LLM & has_capability.some(Reasoning)]\n\n    # Individus\n    with onto_llm:\n        org_anthropic = Organization(\"Anthropic\")\n        org_openai = Organization(\"OpenAI\")\n        org_google = Organization(\"Google\")\n        org_meta = Organization(\"Meta\")\n\n        cap_image = ImageUnderstanding(\"cap_image\")\n        cap_code = CodeGeneration(\"cap_code\")\n        cap_reason = Reasoning(\"cap_reason\")\n\n        bench_mmlu = Benchmark(\"MMLU\")\n        bench_humaneval = Benchmark(\"HumanEval\")\n\n        claude = LLM(\"Claude\")\n        claude.developed_by = [org_anthropic]\n        claude.has_capability = [cap_image, cap_code, cap_reason]\n        claude.evaluated_on = [bench_mmlu]\n\n        gpt4 = LLM(\"GPT4\")\n        gpt4.developed_by = [org_openai]\n        gpt4.has_capability = [cap_image, cap_code]\n        gpt4.evaluated_on = [bench_mmlu, bench_humaneval]\n\n        gemini = LLM(\"Gemini\")\n        gemini.developed_by = [org_google]\n        gemini.has_capability = [cap_image, cap_reason]\n\n        llama = LLM(\"Llama\")\n        llama.developed_by = [org_meta]\n        llama.has_capability = [cap_code]\n\n        AllDifferent([claude, gpt4, gemini, llama,\n                      org_anthropic, org_openai, org_google, org_meta,\n                      cap_image, cap_code, cap_reason,\n                      bench_mmlu, bench_humaneval])\n\n    print(\"=== Avant raisonnement ===\")\n    for m in [claude, gpt4, gemini, llama]:\n        print(f\"  {m.name:10} types : {[c.name for c in m.is_a]}\")\n    print()\n\n    with onto_llm:\n        sync_reasoner(llm_world, infer_property_values=True)\n\n    print(\"=== Apres raisonnement (HermiT) ===\")\n    for m in [claude, gpt4, gemini, llama]:\n        print(f\"  {m.name:10} types : {[c.name for c in m.is_a]}\")\n        print(f\"  Organisation : {[o.name for o in m.developed_by]}\")\n\n    onto_llm.save(file=\"data/temp_llm_ontology.owl\", format=\"rdfxml\")\n    print()\n    print(\"Ontologie exportee : data/temp_llm_ontology.owl\")\nelse:\n    print(\"OWLReady2 non disponible : exemple guide 3 ignore.\")",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
+    }
+   },
    "execution_count": 12,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Avant raisonnement ==="
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "  Claude     types : ['LLM']\n",
-      "  GPT4       types : ['LLM']\n",
-      "  Gemini     types : ['LLM']\n",
-      "  Llama      types : ['LLM']\n",
-      "\n"
-     ]
-    },
-    {
      "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "* Owlready2 * Running HermiT...\n",
-      "    java -Xmx1000M -cp /path/to/owlready2/hermit;/path/to/owlready2/hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///tmp/owlready2_tmpfile -Y\n"
-     ]
+     "text": "* Owlready2 * Running HermiT...\n    java -Xmx1000M -cp <USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit;<USER_PATH>\\AppData\\Local\\Programs\\Python\\Python313\\Lib\\site-packages\\owlready2\\hermit\\HermiT.jar org.semanticweb.HermiT.cli.CommandLine -c -O -D -I file:///C:/<USER_PATH>\\AppData/Local/Temp/tmpq3qd1q7n -Y\n"
     },
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Apres raisonnement (HermiT) ===\n",
-      "  Claude     types : ['MultimodalLLM', 'ReasoningLLM', 'CodingLLM']\n",
-      "  Organisation : ['Anthropic']\n",
-      "  GPT4       types : ['MultimodalLLM', 'CodingLLM']\n",
-      "  Organisation : ['OpenAI']\n",
-      "  Gemini     types : ['MultimodalLLM', 'ReasoningLLM']\n",
-      "  Organisation : ['Google']\n",
-      "  Llama      types : ['CodingLLM']\n",
-      "  Organisation : ['Meta']\n",
-      "\n",
-      "Ontologie exportee : data/temp_llm_ontology.owl\n"
-     ]
+     "text": "=== Avant raisonnement ===\n  Claude     types : ['LLM']\n  GPT4       types : ['LLM']\n  Gemini     types : ['LLM']\n  Llama      types : ['LLM']\n\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "* Owlready2 * HermiT took 0.6005399227142334 seconds\n",
-      "* Owlready * Reparenting llm.GPT4: {llm.LLM} => {llm.MultimodalLLM, llm.CodingLLM}\n",
-      "* Owlready * Reparenting llm.Gemini: {llm.LLM} => {llm.MultimodalLLM, llm.ReasoningLLM}\n",
-      "* Owlready * Reparenting llm.Claude: {llm.LLM} => {llm.MultimodalLLM, llm.ReasoningLLM, llm.CodingLLM}\n",
-      "* Owlready * Reparenting llm.Llama: {llm.LLM} => {llm.CodingLLM}\n",
-      "* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
-     ]
+     "name": "stdout",
+     "text": "=== Apres raisonnement (HermiT) ===\n  Claude     types : ['ReasoningLLM', 'CodingLLM', 'MultimodalLLM']\n  Organisation : ['Anthropic']\n  GPT4       types : ['CodingLLM', 'MultimodalLLM']\n  Organisation : ['OpenAI']\n  Gemini     types : ['ReasoningLLM', 'MultimodalLLM']\n  Organisation : ['Google']\n  Llama      types : ['CodingLLM']\n  Organisation : ['Meta']\n\nOntologie exportee : data/temp_llm_ontology.owl\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stderr",
+     "text": "* Owlready2 * HermiT took 0.6891000270843506 seconds\n* Owlready * Reparenting llm.GPT4: {llm.LLM} => {llm.CodingLLM, llm.MultimodalLLM}\n* Owlready * Reparenting llm.Gemini: {llm.LLM} => {llm.ReasoningLLM, llm.MultimodalLLM}\n* Owlready * Reparenting llm.Claude: {llm.LLM} => {llm.ReasoningLLM, llm.CodingLLM, llm.MultimodalLLM}\n* Owlready * Reparenting llm.Llama: {llm.LLM} => {llm.CodingLLM}\n* Owlready * (NB: only changes on entities loaded in Python are shown, other changes are done but not listed)\n"
     }
    ]
   },
@@ -1570,31 +1296,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 13,
    "id": "115f4e6c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:40.382649Z",
-     "iopub.status.busy": "2026-05-26T09:09:40.382649Z",
-     "iopub.status.idle": "2026-05-26T09:09:40.399680Z",
-     "shell.execute_reply": "2026-05-26T09:09:40.398571Z"
-    },
-    "papermill": {
-     "duration": 0.034441,
-     "end_time": "2026-05-26T09:09:40.402066",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.367625",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1628,31 +1345,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "id": "c8c823ed",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:40.449510Z",
-     "iopub.status.busy": "2026-05-26T09:09:40.449510Z",
-     "iopub.status.idle": "2026-05-26T09:09:40.465162Z",
-     "shell.execute_reply": "2026-05-26T09:09:40.465162Z"
-    },
-    "papermill": {
-     "duration": 0.030763,
-     "end_time": "2026-05-26T09:09:40.465162",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.434399",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1688,31 +1396,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "id": "3630d512",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:40.512661Z",
-     "iopub.status.busy": "2026-05-26T09:09:40.512661Z",
-     "iopub.status.idle": "2026-05-26T09:09:40.518182Z",
-     "shell.execute_reply": "2026-05-26T09:09:40.516809Z"
-    },
-    "papermill": {
-     "duration": 0.021157,
-     "end_time": "2026-05-26T09:09:40.518762",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.497605",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1748,31 +1447,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "id": "8c16ee8d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:40.550428Z",
-     "iopub.status.busy": "2026-05-26T09:09:40.550428Z",
-     "iopub.status.idle": "2026-05-26T09:09:40.581889Z",
-     "shell.execute_reply": "2026-05-26T09:09:40.581889Z"
-    },
-    "papermill": {
-     "duration": 0.034129,
-     "end_time": "2026-05-26T09:09:40.584557",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.550428",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1813,31 +1503,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 17,
    "id": "ae732ead",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-26T09:09:40.635445Z",
-     "iopub.status.busy": "2026-05-26T09:09:40.635445Z",
-     "iopub.status.idle": "2026-05-26T09:09:40.651106Z",
-     "shell.execute_reply": "2026-05-26T09:09:40.649573Z"
-    },
-    "papermill": {
-     "duration": 0.034875,
-     "end_time": "2026-05-26T09:09:40.653732",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.618857",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1879,15 +1560,20 @@
    "cell_type": "code",
    "id": "e21176a9",
    "source": "# Exercice 6 : Ontologie de domaine libre\n# TODO etudiant : Choisissez un domaine (musique, sport, cuisine, etc.)\n# et creez une ontologie OWL avec au moins 5 classes, 3 proprietes,\n# des restrictions equivalent_to, et des individus.\n# Utilisez sync_reasoner() pour verifier les inferences.\n\nresult = None  # TODO etudiant : remplacer par votre ontologie\nprint(\"Exercice a completer : ontologie de domaine libre\")",
-   "metadata": {},
-   "execution_count": 13,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.busy": "2026-08-18T06:57:16.222974Z",
+     "iopub.status.idle": "2026-08-18T06:57:16.222974Z",
+     "shell.execute_reply": "2026-08-18T06:57:16.222974Z"
+    }
+   },
+   "execution_count": 18,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : ontologie de domaine libre\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : ontologie de domaine libre\n"
     }
    ]
   },

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "id": "header-navigation",
    "metadata": {
-    "papermill": {
-     "duration": 0.083139,
-     "end_time": "2026-05-26T09:09:33.345699",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:33.262560",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -44,13 +37,6 @@
    "cell_type": "markdown",
    "id": "section-1-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.038292,
-     "end_time": "2026-05-26T09:09:33.431401",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:33.393109",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -83,13 +69,6 @@
    "cell_type": "markdown",
    "id": "zyf8e47gkb",
    "metadata": {
-    "papermill": {
-     "duration": 0.053518,
-     "end_time": "2026-05-26T09:09:35.073722",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.020204",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -135,13 +114,6 @@
    "cell_type": "markdown",
    "id": "section-2-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.030523,
-     "end_time": "2026-05-26T09:09:35.393819",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.363296",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -225,13 +197,6 @@
    "cell_type": "markdown",
    "id": "create-ontology-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.013456,
-     "end_time": "2026-05-26T09:09:35.561768",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.548312",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -256,13 +221,6 @@
    "cell_type": "markdown",
    "id": "section-3-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.002042,
-     "end_time": "2026-05-26T09:09:35.582902",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.580860",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -323,13 +281,6 @@
    "cell_type": "markdown",
    "id": "individuals-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.018645,
-     "end_time": "2026-05-26T09:09:35.654872",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.636227",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -351,13 +302,6 @@
    "cell_type": "markdown",
    "id": "section-4-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.009234,
-     "end_time": "2026-05-26T09:09:35.672261",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.663027",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -431,13 +375,6 @@
    "cell_type": "markdown",
    "id": "restrictions-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.021522,
-     "end_time": "2026-05-26T09:09:35.799575",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.778053",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -458,13 +395,6 @@
    "cell_type": "markdown",
    "id": "section-5-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.018028,
-     "end_time": "2026-05-26T09:09:35.832895",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:35.814867",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -573,13 +503,6 @@
    "cell_type": "markdown",
    "id": "reasoning-interpretation",
    "metadata": {
-    "papermill": {
-     "duration": 0.01608,
-     "end_time": "2026-05-26T09:09:37.040291",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.024211",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -603,13 +526,6 @@
    "cell_type": "markdown",
    "id": "section-6-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.012963,
-     "end_time": "2026-05-26T09:09:37.062497",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.049534",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -677,13 +593,6 @@
    "cell_type": "markdown",
    "id": "section-7-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.033039,
-     "end_time": "2026-05-26T09:09:37.352179",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.319140",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -741,13 +650,6 @@
    "cell_type": "markdown",
    "id": "section-8-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.09547,
-     "end_time": "2026-05-26T09:09:37.651407",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.555937",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -762,13 +664,6 @@
    "cell_type": "markdown",
    "id": "comparison-table",
    "metadata": {
-    "papermill": {
-     "duration": 0.085386,
-     "end_time": "2026-05-26T09:09:37.808408",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.723022",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -803,13 +698,6 @@
    "cell_type": "markdown",
    "id": "exercises-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.092765,
-     "end_time": "2026-05-26T09:09:37.975652",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.882887",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -824,13 +712,6 @@
    "cell_type": "markdown",
    "id": "exercise-1-intro",
    "metadata": {
-    "papermill": {
-     "duration": 0.046056,
-     "end_time": "2026-05-26T09:09:38.044793",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:37.998737",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -938,13 +819,6 @@
    "cell_type": "markdown",
    "id": "exercise-2-intro",
    "metadata": {
-    "papermill": {
-     "duration": 0.010626,
-     "end_time": "2026-05-26T09:09:38.815929",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:38.805303",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1067,13 +941,6 @@
    "cell_type": "markdown",
    "id": "summary-title",
    "metadata": {
-    "papermill": {
-     "duration": 0.010083,
-     "end_time": "2026-05-26T09:09:39.558955",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:39.548872",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1114,13 +981,6 @@
    "cell_type": "markdown",
    "id": "3b081608",
    "metadata": {
-    "papermill": {
-     "duration": 0.011146,
-     "end_time": "2026-05-26T09:09:39.588938",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:39.577792",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1272,13 +1132,6 @@
    "cell_type": "markdown",
    "id": "7cd240c4",
    "metadata": {
-    "papermill": {
-     "duration": 0.011041,
-     "end_time": "2026-05-26T09:09:40.360800",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.349759",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1326,13 +1179,6 @@
    "cell_type": "markdown",
    "id": "f322477f",
    "metadata": {
-    "papermill": {
-     "duration": 0.016072,
-     "end_time": "2026-05-26T09:09:40.432691",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.416619",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1375,13 +1221,6 @@
    "cell_type": "markdown",
    "id": "a8786019",
    "metadata": {
-    "papermill": {
-     "duration": 0.01761,
-     "end_time": "2026-05-26T09:09:40.482772",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.465162",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1426,13 +1265,6 @@
    "cell_type": "markdown",
    "id": "d738e83d",
    "metadata": {
-    "papermill": {
-     "duration": 0.00388,
-     "end_time": "2026-05-26T09:09:40.534596",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.530716",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1477,13 +1309,6 @@
    "cell_type": "markdown",
    "id": "92159084",
    "metadata": {
-    "papermill": {
-     "duration": 0.010703,
-     "end_time": "2026-05-26T09:09:40.606718",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.596015",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1533,13 +1358,6 @@
    "cell_type": "markdown",
    "id": "b4f1d994",
    "metadata": {
-    "papermill": {
-     "duration": 0.020589,
-     "end_time": "2026-05-26T09:09:40.340206",
-     "exception": false,
-     "start_time": "2026-05-26T09:09:40.319617",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1601,18 +1419,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.10.18"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 8.712588,
-   "end_time": "2026-05-26T09:09:40.901156",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb",
-   "output_path": "MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-7b-Python-OWL.ipynb",
-   "parameters": {},
-   "start_time": "2026-05-26T09:09:32.188568",
-   "version": "2.6.0"
   },
   "cost": {
    "api_usd_est": 0.0,

--- a/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-2-rdf-basics.yaml
@@ -18,6 +18,12 @@
       content_python_sha: e4d4864ac6c5e54c934f445af44401718ecfb82dde43fa1c434ed0c706697440
       content_csharp_sha: d2471f19c3459505386a13bb7974735deed73ae2b9c4684db8da68111c197c5d
       reason: "Enrichissement Python-only (#2161): ajout section 7 SPARQL (Exemple guide 3 resolu SELECT + Exercice 3 stub COUNT) avant l'Exercice de synthese qui exigeait une requete SPARQL jamais introduite (pedagogical gap). SPARQL = standard W3C, independant de rdflib ; le jumeau C# SW-2 couvre le meme socle RDF via dotNetRDF et le SPARQL a sa paire dediee SW-4. 4 new cells (39 existing byte-identical), C# unchanged (csharp_sha preserved). Notebook now 4 exercices (was 2)."
+    - date: "2026-08-18"
+      by: myia-po-2024:CoursIA
+      python_sha: ffb1dcb9662376112b0f3889e2ec02d68316cbbf
+      csharp_sha: fcea9bfbc914f113a7448e2511941ec09908d787
+      content_python_sha: 502e22d84930e75b9716ce37080de094034cb2d0ad8ea4cbf61d0ee9420c05d2
+      content_csharp_sha: d2471f19c3459505386a13bb7974735deed73ae2b9c4684db8da68111c197c5d
   known_differences:
     - "Socle pedagogique commun : construction d'un premier graphe RDF (triplets sujet-predicat-objet), namespaces W3C (RDF/RDFS/XSD)."
     - "Lib-vs-lib : C# = `dotNetRDF 3.2.1` (`#r \"nuget: dotNetRDF, 3.2.1\"`, espaces `VDS.RDF` / `VDS.RDF.Parsing` / `VDS.RDF.Writing`). Python = `rdflib` (`from rdflib import Graph, URIRef, Literal, BNode, Namespace` + `rdflib.namespace` RDF/RDFS/XSD/FOAF/DC)."

--- a/scripts/notebook_tools/twin_pairs.d/sw-7-owl.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-7-owl.yaml
@@ -11,6 +11,12 @@
       python_sha: 95f6fb513c53bb133e9f47966e26e812ba86ad11
       csharp_sha: 25c773f11a9fcdf9c6d03d88a3c3a39102399095
       reason: "Identity/phantom fix (C# cell 4 ASCII stack-diagram « OWL 2 dans la pile du Web Semantique »): the SHACL layer was labelled « SHACL (SW-9) » but SHACL is notebook SW-8 (SW-8-CSharp-SHACL.ipynb / SW-8-Python-SHACL.ipynb on origin/main). The Python twin SW-7b already correctly says SW-8 (cell 28). Fixed SW-9 -> SW-8 (same char length, ASCII box alignment preserved). Other layers (OWL2 SW-7, RDFS SW-6, RDF SW-1/2/3) were already correct; SPARQL (SW-5) left untouched (debatable: dedicated SPARQL is SW-4, but SW-5 LinkedData uses SPARQL -- not an unambiguous error). Markdown-only, 0 re-exec, no output change. No §D.5 (identity/phantom class, not a measure/value drift). Python twin unchanged."
+    - date: "2026-08-18"
+      by: myia-po-2024:CoursIA
+      python_sha: 37f10f7b3be91ad79f7491dad2834f7849e257e3
+      csharp_sha: 25c773f11a9fcdf9c6d03d88a3c3a39102399095
+      content_python_sha: 3eec3895e2617c4cb7e2af7fc1552f365040762bbe7b541c55fab950b30e62c7
+      content_csharp_sha: a8885f2881105d7d1c1ee20bc0be2c68ca06a12929f75a1639dace2613d54b19
   known_differences:
     - "Socle commun : modelisation OWL (classes, proprietes, restrictions, axiomes)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Ontology` : OntologyGraph, OwlReasoner). Python = `owlready2` (API OWL orientee-objet dediee, world/Thing/Property). Deux librairies OWL matures mais aux philosophies differentes : dotNetRDF traite OWL comme une couche sur RDF ; owlready2 est nativement orientee OWL."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/qc #11595

## Summary

#11112 tranche **SemanticWeb Python** : `SW-2b-Python-RDFBasics` (DUPLICATE) et `SW-7b-Python-OWL` (UNORDERED) — les deux derniers notebooks dirty de la famille SW — re-exécutés réellement sur noyau frais, séquences `1..15` et `1..18` CLEAN, 0 erreur.

Mesure firsthand `origin/main` 95c4c9a52a ce cycle (scanner global) : **51 dirty restants** ; parmi eux DSWA Track1/Track2 entièrement couverts par PRs ouvertes (#11588 Lab2/6/7, #11533 Lab4/5, #11569/#11571 Track2), Sudoku claimé par po-2023:CoursIA-2 (claim paths-scopé disjoint), GenAI/Image = veine active po-2026 (#10990). SW-2b/SW-7b : aucune PR ouverte, aucun claim — libres.

## Exécution réelle (H.1/H.2)

- **nbclient, noyau frais python3**, cwd = dossier du notebook, `allow_errors=False` : toute exception aurait avorté.
- Dépendances locales vérifiées : rdflib 7.6.0, owlready2 + **HermiT sous Java 17** (le raisonnement OWL tourne réellement — `sync_reasoner()` exécuté, timings HermiT dans les outputs).
- SW-2b : 15/15 cellules code, seq `1..15`, 0 erreur, 3.5 s · SW-7b : 18/18, seq `1..18`, 0 erreur, 5.9 s.
- **Sources byte-identiques** (assert par-cellule dans le script d'exec + `git diff` : 0 ligne `"source"` touchée). Transplant outputs-only vers le JSON original (anti-churn, raw `json.dumps`).

## Ratchet #11155

- Bloc `metadata.papermill` **stale du run du 2026-05-25** : retrait complet — top-level (`nb.metadata.papermill`, ce que le ratchet mesure) **et** par-cellule, y compris les blocs portés par les cellules **markdown** (25 + 26 blocs, découverte de ce cycle : papermill annote toutes les cellules, pas seulement code).
- `check_papermill_ratchet` : **BLOCK_REMOVED ×2, 0 régression** · `check_exec_ratchet` : **DUPLICATE->CLEAN + UNORDERED->CLEAN, 0 régression** · `validate_pr_notebooks` : PASS ×2.

## Détails honnêtes

- Les outputs HermiT de SW-7b portent le classpath réel `site-packages\owlready2\hermit` — output brut de la lib, **précédent établi sur main** (SW-13-Python-Reasoners_output committé avec le même chemin). Pas de scrub (Stop & Repair : on ne maquille pas une sortie).
- Diff final asymétrique (−1300/+236) = retrait des blocs papermill + fusion des streams consécutifs par nbclient (contenu textuel identique, vérifié par-cellule : mêmes char counts) ; le classpath HermiT réel remplace le placeholder `/path/to/` (+150 chars × 5 cellules de raisonnement).

## Résiduel #11112 (mesuré ce cycle)

51 dirty sur main : GenAI 19 (veines actives po-2023/2026), ML 12 (tous couverts par PRs ouvertes), SymbolicAI 6 (Argument_Analysis ×4, GameTheory-15b-Lean, Search-11-Csharp), Probas 4 (Infer-3/8/13 .NET + PyMC-2 arbitré po-2025), QC 2 (QC-Py-32 yfinance non-reproductible + Research-Executor), ICT-25 (run BG #5105), rlpt_3 (post-#11312).

See #11112 (tranche SemanticWeb Python — famille SW COMPLETE après merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
