### PR TITLE
fix(search,#11112): re-exec Search-11-Csharp — sequence CLEAN 1..18 (GeneticSharp cache-local)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part1-Foundations/Search-11-Metaheuristics-Csharp.ipynb
@@ -55,69 +55,59 @@
    "id": "667cd988",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:31.702187Z",
-     "iopub.status.busy": "2026-07-07T11:08:31.697281Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.109433Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.104433Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fonctions de benchmark :\r\n"
-     ]
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": ""
+     }
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Nom          Type             Optimum             \r\n"
-     ]
+     "name": "stdout",
+     "text": "Fonctions de benchmark :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Nom          Type             Optimum             \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Sphere       Unimodale        [0,...,0], f=0      \r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Rastrigin    Multimodale      [0,...,0], f=0      \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Sphere       Unimodale        [0,...,0], f=0      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Rosenbrock   Vallee etroite   [1,...,1], f=0      \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Rastrigin    Multimodale      [0,...,0], f=0      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Ackley       Multimodale      [0,...,0], f=0      \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Rosenbrock   Vallee etroite   [1,...,1], f=0      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Verif : Sphere(0)=0,000000  Rastrigin(0)=0,000000  Rosenbrock(1)=0,000000  Ackley(0)=0,000000  (tous attendus ~0)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Ackley       Multimodale      [0,...,0], f=0      \r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nVerif : Sphere(0)=0,000000  Rastrigin(0)=0,000000  Rosenbrock(1)=0,000000  Ackley(0)=0,000000  (tous attendus ~0)\r\n"
     }
    ],
    "source": [
@@ -195,19 +185,17 @@
    "id": "94147613",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.111432Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.111432Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.225473Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.225473Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "PSO implemente.\r\n"
-     ]
+     "name": "stdout",
+     "text": "PSO implemente.\r\n"
     }
    ],
    "source": [
@@ -285,47 +273,37 @@
    "id": "9c7c0280",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.226473Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.226473Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.287017Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.287017Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "PSO sur Rastrigin (dim=10, 300 epochs, 50 particules) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "PSO sur Rastrigin (dim=10, 300 epochs, 50 particules) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Solution (4 premiers) : [0,0002, -0,0000, 0,0001, 0,9950, ...]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Solution (4 premiers) : [0,0002, -0,0000, 0,0001, 0,9950, ...]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Objectif : 5,969905\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Objectif : 5,969905\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Temps : 5,2 ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Temps : 9,5 ms\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Optimal attendu : [0,...,0], f=0\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Optimal attendu : [0,...,0], f=0\r\n"
     }
    ],
    "source": [
@@ -355,69 +333,52 @@
    "id": "b34d90b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.287017Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.287017Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.361401Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.361401Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Epoch    gbest fitness    Amelioration  \r\n"
-     ]
+     "name": "stdout",
+     "text": "Epoch    gbest fitness    Amelioration  \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "----------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "----------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "10       69,258704        1,0           x\r\n"
-     ]
+     "name": "stdout",
+     "text": "10       69,258704        1,0           x\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "20       57,704372        1,2           x\r\n"
-     ]
+     "name": "stdout",
+     "text": "20       57,704372        1,2           x\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "50       44,423136        1,6           x\r\n"
-     ]
+     "name": "stdout",
+     "text": "50       44,423136        1,6           x\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "100      27,319939        2,5           x\r\n"
-     ]
+     "name": "stdout",
+     "text": "100      27,319939        2,5           x\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "200      1,064067         65,1          x\r\n"
-     ]
+     "name": "stdout",
+     "text": "200      1,064067         65,1          x\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "La fitness gbest decroit monotone : exploration globale rapide, puis raffinement fin du bassin optimal.\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nLa fitness gbest decroit monotone : exploration globale rapide, puis raffinement fin du bassin optimal.\r\n"
     }
    ],
    "source": [
@@ -488,10 +449,10 @@
    "id": "multiseed-pso-c840",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T03:22:54.344033Z",
-     "iopub.status.busy": "2026-07-24T03:22:54.343777Z",
-     "iopub.status.idle": "2026-07-24T03:22:54.484799Z",
-     "shell.execute_reply": "2026-07-24T03:22:54.484198Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "source": [
@@ -520,110 +481,79 @@
    "execution_count": 5,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "PSO sur Rastrigin (dim=10, 200 epochs, 30 particules) - 8 seeds independants\r\n"
-     ]
+     "name": "stdout",
+     "text": "PSO sur Rastrigin (dim=10, 200 epochs, 30 particules) - 8 seeds independants\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Seed   gbest final    lecture\r\n"
-     ]
+     "name": "stdout",
+     "text": "Seed   gbest final    lecture\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "1      6,1629         bassin secondaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "1      6,1629         bassin secondaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "2      6,5554         bassin secondaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "2      6,5554         bassin secondaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "3      4,3139         bassin secondaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "3      4,3139         bassin secondaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "4      5,1778         bassin secondaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "4      5,1778         bassin secondaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "5      3,1368         bassin secondaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "5      3,1368         bassin secondaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "6      7,9811         bassin secondaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "6      7,9811         bassin secondaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "7      2,9884         bassin secondaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "7      2,9884         bassin secondaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "8      5,2554         bassin secondaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "8      5,2554         bassin secondaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Moyenne = 5,196   Ecart-type = 1,598   [min 2,988, max 7,981]\r\n"
-     ]
+     "name": "stdout",
+     "text": "Moyenne = 5,196   Ecart-type = 1,598   [min 2,988, max 7,981]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "L'ecart-type (1,60) confirme la dispersion : un seul run (seed 42 ci-dessus)\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nL'ecart-type (1,60) confirme la dispersion : un seul run (seed 42 ci-dessus)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "ne representative pas la distribution reelle des issues. D'ou l'obligation du multi-seed.\r\n"
-     ]
+     "name": "stdout",
+     "text": "ne representative pas la distribution reelle des issues. D'ou l'obligation du multi-seed.\r\n"
     }
    ]
   },
@@ -645,23 +575,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "1e96380c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.362400Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.362400Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.410987Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.410987Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "SA implemente.\r\n"
-     ]
+     "name": "stdout",
+     "text": "SA implemente.\r\n"
     }
    ],
    "source": [
@@ -728,51 +656,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "c1c09331",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T18:02:50.207698Z",
-     "iopub.status.busy": "2026-07-17T18:02:50.207521Z",
-     "iopub.status.idle": "2026-07-17T18:02:50.281803Z",
-     "shell.execute_reply": "2026-07-17T18:02:50.281193Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "SA sur Ackley (dim=10, 30000 itérations) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "SA sur Ackley (dim=10, 30000 itérations) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Solution (4 premiers) : [6,0180, -6,9937, 0,7097, 5,0060, ...]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Solution (4 premiers) : [6,0180, -6,9937, 0,7097, 5,0060, ...]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Objectif : 15,844004\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Objectif : 15,844004\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Temps : 43,8 ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Temps : 61,1 ms\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Optimal attendu : [0,...,0], f=0\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Optimal attendu : [0,...,0], f=0\r\n"
     }
    ],
    "source": [
@@ -803,23 +721,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "ca37d6c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T18:02:50.283223Z",
-     "iopub.status.busy": "2026-07-17T18:02:50.283008Z",
-     "iopub.status.idle": "2026-07-17T18:02:50.307552Z",
-     "shell.execute_reply": "2026-07-17T18:02:50.307390Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "GA implemente.\r\n"
-     ]
+     "name": "stdout",
+     "text": "GA implemente.\r\n"
     }
    ],
    "source": [
@@ -899,51 +815,41 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "7f15778e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.498726Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.498726Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.542475Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.542475Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "GA sur Rosenbrock (dim=10, 200 generations) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "GA sur Rosenbrock (dim=10, 200 generations) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Solution (4 premiers) : [0,3682, 0,1484, 0,0275, 0,0095, ...]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Solution (4 premiers) : [0,3682, 0,1484, 0,0275, 0,0095, ...]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Objectif : 8,068804\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Objectif : 8,068804\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Temps : 2,9 ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Temps : 5,1 ms\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Optimal attendu : [1,...,1], f=0\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Optimal attendu : [1,...,1], f=0\r\n"
     }
    ],
    "source": [
@@ -969,66 +875,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "30dcd02d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.542475Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.542475Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.714910Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.713910Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Fonction     PSO          SA           GA          \r\n"
-     ]
+     "name": "stdout",
+     "text": "Fonction     PSO          SA           GA          \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Sphere       0,0000       0,0065       0,0002      \r\n"
-     ]
+     "name": "stdout",
+     "text": "Sphere       0,0000       0,0065       0,0002      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Rastrigin    4,9968       39,8989      8,5265      \r\n"
-     ]
+     "name": "stdout",
+     "text": "Rastrigin    4,9968       39,8989      8,5265      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Rosenbrock   6,5656       3,5938       8,0688      \r\n"
-     ]
+     "name": "stdout",
+     "text": "Rosenbrock   6,5656       3,5938       8,0688      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Ackley       0,0122       0,2686       6,3691      \r\n"
-     ]
+     "name": "stdout",
+     "text": "Ackley       0,0122       0,2686       6,3691      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Tendances : Sphere (unimodale) = facile pour tous ; Rastrigin/Ackley (multimodales) = PSO souvent au-dessus ; Rosenbrock (vallee) = GA robuste.\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nTendances : Sphere (unimodale) = facile pour tous ; Rastrigin/Ackley (multimodales) = PSO souvent au-dessus ; Rosenbrock (vallee) = GA robuste.\r\n"
     }
    ],
    "source": [
@@ -1064,66 +955,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "18c09e06",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.716146Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.714910Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.813901Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.813901Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "PopSize    Meilleure      Moyenne        Temps (ms)  \r\n"
-     ]
+     "name": "stdout",
+     "text": "PopSize    Meilleure      Moyenne        Temps (ms)  \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "10         6,767508       10,904264      0,7         \r\n"
-     ]
+     "name": "stdout",
+     "text": "10         6,767508       10,904264      1,2         \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "30         4,991659       7,090220       2,0         \r\n"
-     ]
+     "name": "stdout",
+     "text": "30         4,991659       7,090220       3,6         \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "50         3,019542       4,873531       3,5         \r\n"
-     ]
+     "name": "stdout",
+     "text": "50         3,019542       4,873531       6,1         \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "100        2,113923       6,225824       7,4         \r\n"
-     ]
+     "name": "stdout",
+     "text": "100        2,113923       6,225824       12,4        \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Une population plus large ameliore la meilleure fitness atteinte (plus d'exploration), au prix du temps (lineaire en popSize).\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nUne population plus large ameliore la meilleure fitness atteinte (plus d'exploration), au prix du temps (lineaire en popSize).\r\n"
     }
    ],
    "source": [
@@ -1163,142 +1039,106 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "8062a3c9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T18:02:50.732780Z",
-     "iopub.status.busy": "2026-07-17T18:02:50.732582Z",
-     "iopub.status.idle": "2026-07-17T18:02:50.807966Z",
-     "shell.execute_reply": "2026-07-17T18:02:50.807624Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Optimum analytique : x=17,1429, y=15,7143, profit=1057,1429\r\n"
-     ]
+     "name": "stdout",
+     "text": "Optimum analytique : x=17,1429, y=15,7143, profit=1057,1429\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "PSO : x=17,1429, y=15,7143, profit=1057,1429 (0,3 ms)\r\n"
-     ]
+     "name": "stdout",
+     "text": "PSO : x=17,1429, y=15,7143, profit=1057,1429 (0,3 ms)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "SA  : x=17,1600, y=15,7049, profit=1057,1425 (0,9 ms)\r\n"
-     ]
+     "name": "stdout",
+     "text": "SA  : x=17,1600, y=15,7049, profit=1057,1425 (0,9 ms)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Concordance avec l'optimum analytique (x=17,143, y=15,714, profit=1057,143) : les metaheuristiques le retrouvent.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Concordance avec l'optimum analytique (x=17,143, y=15,714, profit=1057,143) : les metaheuristiques le retrouvent.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Profit saisonnier (multimodal) - PSO vs SA sur 5 seeds :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Profit saisonnier (multimodal) - PSO vs SA sur 5 seeds :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Seed   PSO profit   SA profit    PSO (x,y)            SA (x,y)            \r\n"
-     ]
+     "name": "stdout",
+     "text": "Seed   PSO profit   SA profit    PSO (x,y)            SA (x,y)            \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "------------------------------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "------------------------------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "0      1173,97      1173,12      (17,01, 16,99)       (16,98, 17,08)      \r\n"
-     ]
+     "name": "stdout",
+     "text": "0      1173,97      1173,12      (17,01, 16,99)       (16,98, 17,08)      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "42     1173,97      1173,63      (17,01, 16,99)       (17,06, 17,02)      \r\n"
-     ]
+     "name": "stdout",
+     "text": "42     1173,97      1173,63      (17,01, 16,99)       (17,06, 17,02)      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "123    1173,97      1170,41      (17,01, 16,99)       (19,60, 14,48)      \r\n"
-     ]
+     "name": "stdout",
+     "text": "123    1173,97      1170,41      (17,01, 16,99)       (19,60, 14,48)      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "456    1170,81      1171,92      (19,61, 14,41)       (17,15, 16,92)      \r\n"
-     ]
+     "name": "stdout",
+     "text": "456    1170,81      1171,92      (19,61, 14,41)       (17,15, 16,92)      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "789    1173,97      1173,97      (17,01, 16,99)       (17,02, 16,99)      \r\n"
-     ]
+     "name": "stdout",
+     "text": "789    1173,97      1173,97      (17,01, 16,99)       (17,02, 16,99)      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "PSO : meilleur profit = 1173,97, moyenne = 1173,34\r\n"
-     ]
+     "name": "stdout",
+     "text": "PSO : meilleur profit = 1173,97, moyenne = 1173,34\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "SA  : meilleur profit = 1173,97, moyenne = 1172,61\r\n"
-     ]
+     "name": "stdout",
+     "text": "SA  : meilleur profit = 1173,97, moyenne = 1172,61\r\n"
     }
    ],
    "source": [
@@ -1418,72 +1258,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "f58a08dc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.849016Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.849016Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.898888Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.898888Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "TSP (15 villes) par recuit simule (voisinage 2-opt) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "TSP (15 villes) par recuit simule (voisinage 2-opt) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Tour aleatoire initial : 548,69\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Tour aleatoire initial : 548,69\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Tour optimise (SA)     : 284,64\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Tour optimise (SA)     : 284,64\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Amelioration           : 1,93x\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Amelioration           : 1,93x\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Permutation optimale   : [9,12,3,6,0,8,10,7, ...]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Permutation optimale   : [9,12,3,6,0,8,10,7, ...]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Le voisinage 2-opt (inversion de segment) est le standard pour le TSP : il remodele localement\r\n"
-     ]
+     "name": "stdout",
+     "text": "Le voisinage 2-opt (inversion de segment) est le standard pour le TSP : il remodele localement\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "le tour pour eliminer les arenes croisees, la ou un simple swap de 2 villes est trop faible.\r\n"
-     ]
+     "name": "stdout",
+     "text": "le tour pour eliminer les arenes croisees, la ou un simple swap de 2 villes est trop faible.\r\n"
     }
    ],
    "source": [
@@ -1550,66 +1374,57 @@
   {
    "cell_type": "code",
    "id": "search11-tr2-code-solve",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
+    }
+   },
    "execution_count": 14,
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>GeneticSharp, 3.1.4</span></li></ul></div></div>"
-      ]
-     },
+     "output_type": "display_data",
      "metadata": {},
-     "output_type": "display_data"
+     "data": {
+      "text/html": "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>GeneticSharp, 3.1.4</span></li></ul></div></div>"
+     }
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "GeneticSharp (UniformCrossover + FlipBit, dim=10, 50 ind x 200 gen, seed 42) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "GeneticSharp (UniformCrossover + FlipBit, dim=10, 50 ind x 200 gen, seed 42) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Fonction     Objectif       Temps   \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Fonction     Objectif       Temps   \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Sphere       0,0000         1643     ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Sphere       0,0000         2174     ms\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Rastrigin    58,2798        757      ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Rastrigin    58,2798        1565     ms\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Rosenbrock   560,6489       431      ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Rosenbrock   560,6489       536      ms\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Ackley       19,9668        426      ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Ackley       19,9668        535      ms\r\n"
     }
    ],
    "source": [
@@ -1680,92 +1495,75 @@
   {
    "cell_type": "code",
    "id": "search11-tr2-code-compare",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
+    }
+   },
    "execution_count": 15,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Comparaison lib-vs-lib sur le benchmark (dim=10, 200 generations, seed 42) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Comparaison lib-vs-lib sur le benchmark (dim=10, 200 generations, seed 42) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Fonction     GA from-scratch    GeneticSharp      \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Fonction     GA from-scratch    GeneticSharp      \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Sphere       0,0002             0,0000            \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Sphere       0,0002             0,0000            \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Rastrigin    8,5265             58,2798           \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Rastrigin    8,5265             58,2798           \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Rosenbrock   8,0688             560,6489          \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Rosenbrock   8,0688             560,6489          \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Ackley       6,3691             19,9668           \r\n"
-     ]
+     "name": "stdout",
+     "text": "  Ackley       6,3691             19,9668           \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Les deux GA retombent vers f=0 sur Sphere (convexe, facile). Sur les fonctions plus\r\n"
-     ]
+     "name": "stdout",
+     "text": "Les deux GA retombent vers f=0 sur Sphere (convexe, facile). Sur les fonctions plus\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "difficiles, l'ecart reflege le codage : le from-scratch (genes continus, croisement\r\n"
-     ]
+     "name": "stdout",
+     "text": "difficiles, l'ecart reflege le codage : le from-scratch (genes continus, croisement\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "arithmetique, mutation gaussienne) vs GeneticSharp (genes binaires, flip-bit) -- deux\r\n"
-     ]
+     "name": "stdout",
+     "text": "arithmetique, mutation gaussienne) vs GeneticSharp (genes binaires, flip-bit) -- deux\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "designs de GA legitimes, chacun avec ses forces selon le paysage.\r\n"
-     ]
+     "name": "stdout",
+     "text": "designs de GA legitimes, chacun avec ses forces selon le paysage.\r\n"
     }
    ],
    "source": [
@@ -1818,32 +1616,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "id": "4b9a9b16",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T18:02:50.955741Z",
-     "iopub.status.busy": "2026-07-17T18:02:50.955515Z",
-     "iopub.status.idle": "2026-07-17T18:02:51.017023Z",
-     "shell.execute_reply": "2026-07-17T18:02:51.016889Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 1 a completer : implementez ABC et comparez-le a PSO sur Rastrigin.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 1 a completer : implementez ABC et comparez-le a PSO sur Rastrigin.\r\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(9,21): warning CS0649: Le champ 'ABC.Best' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\n(9,21): warning CS0649: Le champ 'ABC.Best' n'est jamais assigné et aura toujours sa valeur par défaut null\r\n\r\n"
     }
    ],
    "source": [
@@ -1867,23 +1659,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "id": "3ef799df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-17T18:02:51.018408Z",
-     "iopub.status.busy": "2026-07-17T18:02:51.018181Z",
-     "iopub.status.idle": "2026-07-17T18:02:51.032219Z",
-     "shell.execute_reply": "2026-07-17T18:02:51.031971Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 2 a completer : fitness w=lineaire(?) vs w=constante(0) vs w=exponentiel(0).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 2 a completer : fitness w=lineaire(?) vs w=constante(0) vs w=exponentiel(0).\r\n"
     }
    ],
    "source": [
@@ -1898,23 +1688,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "id": "3443558b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-07T11:08:33.956558Z",
-     "iopub.status.busy": "2026-07-07T11:08:33.956558Z",
-     "iopub.status.idle": "2026-07-07T11:08:33.966571Z",
-     "shell.execute_reply": "2026-07-07T11:08:33.966571Z"
+     "iopub.execute_input": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.busy": "2026-08-18T07:20:14.048740Z",
+     "iopub.status.idle": "2026-08-18T07:20:14.048740Z",
+     "shell.execute_reply": "2026-08-18T07:20:14.048740Z"
     }
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 3 a completer : Schwefel(420.9687,...)=0,0001 (attendu ~0), optimiser en dim=10 : 0 (a completer).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 3 a completer : Schwefel(420.9687,...)=0,0001 (attendu ~0), optimiser en dim=10 : 0 (a completer).\r\n"
     }
    ],
    "source": [

--- a/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-11-metaheuristics.yaml
@@ -43,6 +43,12 @@
       csharp_sha: ac366782eb567725eea37d1aa9fe0264a3ab1541
       content_python_sha: ce0b4d0b87e3f963e70ad0bcfd4de4a9c5e7b087630e5379c5cc1101a8825023
       content_csharp_sha: dce689a469dd323686332ca9508192b5f6f410f7511d562dc87bbead6c45dcc8
+    - date: "2026-08-18"
+      by: myia-po-2024:CoursIA
+      python_sha: a01c7ef86b42aa96eb33e081d682e7b98e8355f3
+      csharp_sha: 8a882e759991dc7a0af2c82376334eaeaa884a74
+      content_python_sha: ce0b4d0b87e3f963e70ad0bcfd4de4a9c5e7b087630e5379c5cc1101a8825023
+      content_csharp_sha: 098a90cd675c7f17f5b3c5debca7305463f1abd7d4788b1ab3a34fa91ad15df4
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: |
     Python = MEALPy (librairie metaheuristique 40+ algos, MIT) -- vrai SOTA ecosysteme Python. C# = GeneticSharp (librairie .NET GA/evolutionnaire reference, LGPL) post Tranche 2 -- vrai SOTA ecosysteme .NET. Les DEUX cotes branchent une librairie native de leur ecosysteme (mealpy + geneticsharp). Tranche 1 C# from-scratch (PSO/SA/GA) preservee + Tranche 2 ajoute GeneticSharp sur 4 fonctions benchmark -- lib-vs-lib cote-a-cote avec from-scratch. Asymetrie de couverture (ABC + BRO cote Python, GA + TSP cote C#) asumee native-both parity_level. Verdict SOTA-OK.


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11596

## Summary

#11112 tranche **Search-11-Metaheuristics-Csharp** (famille Search, kernel `.net-csharp`) : séquence `[1..5, 5, 6..12, 14, 15..18]` (DUPLICATE + GAP) → re-exec réelle, **CLEAN 1..18**, 0 erreur.

Chemin de re-exec **testé en amont** (règle mémoire dotnet-headless-nuget-blocker : vérifier le chemin AVANT de claimer) : `#r "nuget: GeneticSharp"` **non versionné** résout depuis le cache NuGet local (3.1.4 présent) — cellule-test 1-ligne exécutée en 10 s avant claim.

## Exécution réelle

- **nbclient, noyau frais `.net-csharp`**, cwd = dossier du notebook, `allow_errors=False` : 18/18 cellules, seq `1..18`, 0 erreur, 14,9 s au total.
- Sources byte-identiques (transplant outputs-only ; l'assert par-cellule tolère la seule normalisation de ligne vide finale par nbformat).
- Probe banner strippée post-re-exec (règle secrets-hygiene .NET, `strip_probe_banner.py --apply` : 1 banner fixée).

## Déterminisme vérifié

13/18 stream outputs **byte-identiques** au commit — les valeurs algorithmiques (fitness, convergence PSO/SA/GA, multi-seed 8 runs) se reproduisent exactement (seeds partout : `seed = 42`, `SeededRandomization` GeneticSharp). Les 5 cellules divergentes ne diffèrent **que sur des timings machine-dépendants** (ms d'exécution : 5,2→9,5 ms, 43,8→61,1 ms, 2,9→5,1 ms, 1643→2174 ms, colonne temps d'epoch 0,7→1,2) — remplacés par ceux du run frais, ce sont les vraies sorties.

**Aucune désync d'interprétation** : scan des cellules markdown contre ces valeurs — aucune ne cite un timing (le nettoyage #9439 des timings stale du recap a déjà blinder ce point).

## Validation

- `check_exec_ratchet` : **DUPLICATE->CLEAN, 0 régression** · `check_papermill_ratchet` : vert (0 bloc sur ce notebook, avant comme après) · `validate_pr_notebooks` : PASS (18 cells) · 0 chemin absolu dans les outputs.

## Résiduel #11112 (après merge)

~49 dirty : GenAI 19 (veines actives), ML 12 (PRs ouvertes), Argument_Analysis ×4 (python3 ; groupe-I2 = travail étudiant à qualifier), GameTheory-15b-Lean (re-exec Lean coûteuse), Infer-3/8/13 (.NET, faisable par ce même chemin si Infer.NET en cache), PyMC-2 (po-2025), ICT-25 (run BG), rlpt_3.

See #11112 (tranche Search Csharp — famille Search COMPLETE après merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
