### PR TITLE
fix(exec,#11112): Argument_Analysis_Ontology_AIF — seq DUPLICATE->CLEAN 1..12

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Argument_Analysis/Argument_Analysis_Ontology_AIF.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "id": "cell-0",
    "metadata": {
-    "papermill": {
-     "duration": 0.008267,
-     "end_time": "2026-07-24T10:27:55.799390",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:55.791123",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -49,13 +42,6 @@
    "cell_type": "markdown",
    "id": "cell-1",
    "metadata": {
-    "papermill": {
-     "duration": 0.002438,
-     "end_time": "2026-07-24T10:27:55.813704",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:55.811266",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -78,13 +64,6 @@
    "cell_type": "markdown",
    "id": "cell-2",
    "metadata": {
-    "papermill": {
-     "duration": 0.002476,
-     "end_time": "2026-07-24T10:27:55.818044",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:55.815568",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -97,41 +76,18 @@
    "id": "cell-3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:55.824125Z",
-     "iopub.status.busy": "2026-07-24T10:27:55.823872Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.199607Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.199106Z"
-    },
-    "papermill": {
-     "duration": 0.37992,
-     "end_time": "2026-07-24T10:27:56.200392",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:55.820472",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Chargement de : D:\\Dev\\CoursIA-aif-distrib-863\\MyIA.AI.Notebooks\\SymbolicAI\\Argument_Analysis\\ontologies\\argumentum_fallacies.owl\n",
-      "Existe : True (taille = 5,904,124 octets)\n",
-      "Longueur du texte : 5,892,331 caracteres, 96,770 lignes\n",
-      "\n",
-      "Cardinalite : ObjectExactCardinality=36, DataExactCardinality=0 (bien formes).\n"
-     ]
-    },
-    {
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "rdflib : installe mais ECHEC au parse -> TypeError: sequence item 0: expected str instance, NoneType found\n",
-      "owlready2 : charge le fichier mais expose 0 classe via l'API Python (idiome annotation-space).\n",
-      "\n",
-      "=> On conserve le parseur regex tolerant : chemin fiable pour extraire la structure.\n"
-     ]
+     "text": "Chargement de : argumentum_fallacies.owl\nExiste : True (taille = 5,904,124 octets)\nLongueur du texte : 5,892,331 caracteres, 96,770 lignes\n\nCardinalite : ObjectExactCardinality=36, DataExactCardinality=0 (bien formes).\nrdflib : installe mais ECHEC au parse -> TypeError: sequence item 0: expected str instance, NoneType found\nowlready2 : charge le fichier mais expose 0 classe via l'API Python (idiome annotation-space).\n\n=> On conserve le parseur regex tolerant : chemin fiable pour extraire la structure.\n"
     }
    ],
    "source": [
@@ -140,7 +96,7 @@
     "import re\n",
     "\n",
     "OWL_PATH = Path(\"ontologies/argumentum_fallacies.owl\").resolve()\n",
-    "print(f\"Chargement de : {OWL_PATH}\")\n",
+    "print(f\"Chargement de : {OWL_PATH.name}\")  # basename, jamais chemin absolu machine\n",
     "print(f\"Existe : {OWL_PATH.exists()} (taille = {OWL_PATH.stat().st_size:,} octets)\")\n",
     "\n",
     "owl_text = OWL_PATH.read_text(encoding=\"utf-8\")\n",
@@ -171,13 +127,6 @@
    "cell_type": "markdown",
    "id": "cell-4",
    "metadata": {
-    "papermill": {
-     "duration": 0.002018,
-     "end_time": "2026-07-24T10:27:56.204867",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.202849",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -188,13 +137,6 @@
    "cell_type": "markdown",
    "id": "cell-5",
    "metadata": {
-    "papermill": {
-     "duration": 0.002196,
-     "end_time": "2026-07-24T10:27:56.209093",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.206897",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -220,39 +162,23 @@
    "id": "cell-6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.215121Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.214909Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.290847Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.289505Z"
-    },
-    "papermill": {
-     "duration": 0.080816,
-     "end_time": "2026-07-24T10:27:56.292182",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.211366",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Declarations owl:Class : 1,513\n",
-      "  - concepts Argumentum : 1,509\n",
-      "  - classes AIF : 4  ['Conflict', 'I-node', 'RA-node', 'CA-node']\n",
-      "\n",
-      "ObjectProperty declarees : 10\n",
-      "  ['hasConflictedElement', 'predatesOn', 'denounces', 'leverages', 'allows', 'opposes', 'inverts', 'mirrors', 'isRelatedTo', 'aifAttackedNode']\n",
-      "\n",
-      "Ancien idiome (individus), desormais absent :\n",
-      "  NamedIndividual         : 0\n",
-      "  ClassAssertion          : 0\n",
-      "  ObjectPropertyAssertion : 0\n",
-      "\n",
-      "AnnotationAssertion : 18,284  (resource=7,773, literal=10,511)\n"
-     ]
+     "name": "stdout",
+     "text": "Declarations owl:Class : 1,513"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\n  - concepts Argumentum : 1,509\n  - classes AIF : 4  ['Conflict', 'I-node', 'RA-node', 'CA-node']\n\nObjectProperty declarees : 10\n  ['hasConflictedElement', 'predatesOn', 'denounces', 'leverages', 'allows', 'opposes', 'inverts', 'mirrors', 'isRelatedTo', 'aifAttackedNode']\n\nAncien idiome (individus), desormais absent :\n  NamedIndividual         : 0\n  ClassAssertion          : 0\n  ObjectPropertyAssertion : 0\n\nAnnotationAssertion : 18,284  (resource=7,773, literal=10,511)\n"
     }
    ],
    "source": [
@@ -302,13 +228,6 @@
    "cell_type": "markdown",
    "id": "cell-7",
    "metadata": {
-    "papermill": {
-     "duration": 0.00325,
-     "end_time": "2026-07-24T10:27:56.299314",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.296064",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -319,13 +238,6 @@
    "cell_type": "markdown",
    "id": "cell-8",
    "metadata": {
-    "papermill": {
-     "duration": 0.003217,
-     "end_time": "2026-07-24T10:27:56.305743",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.302526",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -340,47 +252,18 @@
    "id": "cell-9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.313757Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.313313Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.339780Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.338966Z"
-    },
-    "papermill": {
-     "duration": 0.032022,
-     "end_time": "2026-07-24T10:27:56.341036",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.309014",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "skos:prefLabel extraits : 2,816\n",
-      "Langues : {'FR': 1408, 'EN': 1408}\n",
-      "Concepts distincts (par localname) : 1,306\n",
-      "\n",
-      "Classes de forme Walton-scheme (materialisation AIF_skos) : 100\n",
-      "  - Analogy_Inference_Conflict\n",
-      "  - Analogy_Inference_Conflicted\n",
-      "  - CausalSlipperySlope_Inference_Conflict\n",
-      "  - CausalSlipperySlope_Inference_Conflicted\n",
-      "  - CauseToEffect_Inference_Conflict\n",
-      "  - CauseToEffect_Inference_Conflicted\n",
-      "  - CircumstantialAdHominem_Inference_Conflict\n",
-      "  - CircumstantialAdHominem_Inference_Conflicted\n",
-      "\n",
-      "Schemes Walton detectes dans les prefLabel :\n",
-      "  x Position to Know   : 0 occurrence(s)\n",
-      "  v Sign               : 11 occurrence(s)\n",
-      "  x Cause to Effect    : 0 occurrence(s)\n",
-      "  v Analogy            : 4 occurrence(s)\n",
-      "  x Expert Opinion     : 0 occurrence(s)\n",
-      "  x Popular Opinion    : 0 occurrence(s)\n"
-     ]
+     "name": "stdout",
+     "text": "skos:prefLabel extraits : 2,816\nLangues : {'FR': 1408, 'EN': 1408}\nConcepts distincts (par localname) : 1,306\n\nClasses de forme Walton-scheme (materialisation AIF_skos) : 100\n  - Analogy_Inference_Conflict\n  - Analogy_Inference_Conflicted\n  - CausalSlipperySlope_Inference_Conflict\n  - CausalSlipperySlope_Inference_Conflicted\n  - CauseToEffect_Inference_Conflict\n  - CauseToEffect_Inference_Conflicted\n  - CircumstantialAdHominem_Inference_Conflict\n  - CircumstantialAdHominem_Inference_Conflicted\n\nSchemes Walton detectes dans les prefLabel :\n  x Position to Know   : 0 occurrence(s)\n  v Sign               : 11 occurrence(s)\n  x Cause to Effect    : 0 occurrence(s)\n  v Analogy            : 4 occurrence(s)\n  x Expert Opinion     : 0 occurrence(s)\n  x Popular Opinion    : 0 occurrence(s)\n"
     }
    ],
    "source": [
@@ -429,13 +312,6 @@
    "cell_type": "markdown",
    "id": "cell-10",
    "metadata": {
-    "papermill": {
-     "duration": 0.003097,
-     "end_time": "2026-07-24T10:27:56.347348",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.344251",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -446,13 +322,6 @@
    "cell_type": "markdown",
    "id": "cell-11",
    "metadata": {
-    "papermill": {
-     "duration": 0.003244,
-     "end_time": "2026-07-24T10:27:56.353705",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.350461",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -474,56 +343,18 @@
    "id": "cell-12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.361918Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.361361Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.372980Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.372301Z"
-    },
-    "papermill": {
-     "duration": 0.017089,
-     "end_time": "2026-07-24T10:27:56.374035",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.356946",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Relations (AnnotationAssertion-resource) par predicat :\n",
-      "  Predicat               | Count\n",
-      "  ----------------------------------\n",
-      "  type                   |  1409\n",
-      "  inScheme               |  1408\n",
-      "  narrower               |  1407\n",
-      "  broader                |  1407\n",
-      "  mirrors                |   720\n",
-      "  isRelatedTo            |   642\n",
-      "  leverages              |   402\n",
-      "  aifAttackedNode        |    93\n",
-      "  inverts                |    82\n",
-      "  allows                 |    66\n",
-      "  broadMatch             |    57\n",
-      "  opposes                |    50\n",
-      "  predatesOn             |    13\n",
-      "  closeMatch             |    10\n",
-      "  narrowMatch            |     3\n",
-      "  denounces              |     2\n",
-      "  hasTopConcept          |     1\n",
-      "  topConceptOf           |     1\n",
-      "\n",
-      "  Total predicats distincts : 18\n",
-      "\n",
-      "=> crossLink dans l'OWL : 1,977 AnnotationAssertion\n",
-      "   (mirrors=720, isRelatedTo=642, leverages=402, inverts=82, ...)\n",
-      "   AIF attack : aifAttackedNode=93 (resource -> RA/I/CA-node)\n",
-      "   mapping Walton : broadMatch=57, closeMatch=10, narrowMatch=3\n",
-      "\n",
-      "   NOTE : contrairement a l'ancien OWL (crossLink ABSENT), #763 a cable ces 8 verbes.\n"
-     ]
+     "name": "stdout",
+     "text": "Relations (AnnotationAssertion-resource) par predicat :\n  Predicat               | Count\n  ----------------------------------\n  type                   |  1409\n  inScheme               |  1408\n  narrower               |  1407\n  broader                |  1407\n  mirrors                |   720\n  isRelatedTo            |   642\n  leverages              |   402\n  aifAttackedNode        |    93\n  inverts                |    82\n  allows                 |    66\n  broadMatch             |    57\n  opposes                |    50\n  predatesOn             |    13\n  closeMatch             |    10\n  narrowMatch            |     3\n  denounces              |     2\n  hasTopConcept          |     1\n  topConceptOf           |     1\n\n  Total predicats distincts : 18\n\n=> crossLink dans l'OWL : 1,977 AnnotationAssertion\n   (mirrors=720, isRelatedTo=642, leverages=402, inverts=82, ...)\n   AIF attack : aifAttackedNode=93 (resource -> RA/I/CA-node)\n   mapping Walton : broadMatch=57, closeMatch=10, narrowMatch=3\n\n   NOTE : contrairement a l'ancien OWL (crossLink ABSENT), #763 a cable ces 8 verbes.\n"
     }
    ],
    "source": [
@@ -557,13 +388,6 @@
    "cell_type": "markdown",
    "id": "cell-13",
    "metadata": {
-    "papermill": {
-     "duration": 0.003445,
-     "end_time": "2026-07-24T10:27:56.381211",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.377766",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -585,43 +409,22 @@
    "id": "mir-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T11:55:01.201982Z",
-     "iopub.status.busy": "2026-07-24T11:55:01.201689Z",
-     "iopub.status.idle": "2026-07-24T11:55:01.208328Z",
-     "shell.execute_reply": "2026-07-24T11:55:01.207831Z"
-    },
-    "papermill": {
-     "duration": 0.011138,
-     "end_time": "2026-07-24T11:55:01.209071",
-     "exception": false,
-     "start_time": "2026-07-24T11:55:01.197933",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "execution_count": 5,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "mirrors : 720 triplets au total\n",
-      "  symetriques (a->b ET b->a presents) : 720/720 (100%)\n",
-      "\n",
-      "Top 10 sophismes par nb de miroirs emis :\n",
-      "    8  racism\n",
-      "    7  bow\n",
-      "    6  genuflection\n",
-      "    5  alphabetSoup\n",
-      "    5  corporateJargon\n",
-      "    5  curtsy\n",
-      "    5  salute\n",
-      "    5  theFinger\n",
-      "    5  thumbingOnesNose\n",
-      "    5  alethicModalFallacy\n"
-     ]
+     "name": "stdout",
+     "text": "mirrors : 720 triplets au total\n  symetriques (a->b ET b->a presents) : 720/720 (100%)\n\nTop 10 sophismes par nb de miroirs emis :\n    8  racism\n    7  bow\n    6  genuflection\n    5  alphabetSoup\n    5  corporateJargon\n    5  curtsy\n    5  salute\n    5  theFinger\n    5  thumbingOnesNose\n    5  alethicModalFallacy\n"
     }
-   ],   "source": [
+   ],
+   "source": [
     "# --- Audit du predicat mirrors (720) : symetrie + clusters ---\n",
     "from collections import Counter\n",
     "\n",
@@ -659,13 +462,6 @@
    "cell_type": "markdown",
    "id": "cell-14",
    "metadata": {
-    "papermill": {
-     "duration": 0.003372,
-     "end_time": "2026-07-24T10:27:56.387822",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.384450",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -681,51 +477,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "cell-15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.396151Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.395642Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.411957Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.411355Z"
-    },
-    "papermill": {
-     "duration": 0.02172,
-     "end_time": "2026-07-24T10:27:56.412997",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.391277",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Noeuds lies a l'Equivoque : 3\n",
-      "  - antitheticalEquivocation       -> Équivoque antithétique\n",
-      "  - semanticAmbiguity              -> Équivoque\n",
-      "  - takingAdvantageOfTheNaysayer   -> Équivoque antithétique\n",
-      "\n",
-      "Sous-graphe (AnnotationAssertion-resource) autour de 'semanticAmbiguity' :\n",
-      "  Relations impliquees : 11\n",
-      "  Noeuds impliques : 8\n",
-      "\n",
-      "Triplets :\n",
-      "  semanticAmbiguity                --[type            ]--> Concept                 \n",
-      "  semanticAmbiguity                --[inScheme        ]--> fallacyScheme           \n",
-      "  ambiguity                        --[narrower        ]--> semanticAmbiguity       \n",
-      "  semanticAmbiguity                --[broader         ]--> ambiguity               \n",
-      "  semanticAmbiguity                --[narrower        ]--> vagueness               \n",
-      "  vagueness                        --[broader         ]--> semanticAmbiguity       \n",
-      "  semanticAmbiguity                --[narrower        ]--> polysemicLexicalShift   \n",
-      "  polysemicLexicalShift            --[broader         ]--> semanticAmbiguity       \n",
-      "  semanticAmbiguity                --[narrower        ]--> polysemyBySemanticChange\n",
-      "  polysemyBySemanticChange         --[broader         ]--> semanticAmbiguity       \n",
-      "  semanticAmbiguity                --[aifAttackedNode ]--> RA-node                   <-- AIF attack\n"
-     ]
+     "name": "stdout",
+     "text": "Noeuds lies a l'Equivoque : 3\n  - antitheticalEquivocation       -> Équivoque antithétique\n  - semanticAmbiguity              -> Équivoque\n  - takingAdvantageOfTheNaysayer   -> Équivoque antithétique\n\nSous-graphe (AnnotationAssertion-resource) autour de 'semanticAmbiguity' :\n  Relations impliquees : 11\n  Noeuds impliques : 8\n\nTriplets :\n  semanticAmbiguity                --[type            ]--> Concept                 \n  semanticAmbiguity                --[inScheme        ]--> fallacyScheme           \n  ambiguity                        --[narrower        ]--> semanticAmbiguity       \n  semanticAmbiguity                --[broader         ]--> ambiguity               \n  semanticAmbiguity                --[narrower        ]--> vagueness               \n  vagueness                        --[broader         ]--> semanticAmbiguity       \n  semanticAmbiguity                --[narrower        ]--> polysemicLexicalShift   \n  polysemicLexicalShift            --[broader         ]--> semanticAmbiguity       \n  semanticAmbiguity                --[narrower        ]--> polysemyBySemanticChange\n  polysemyBySemanticChange         --[broader         ]--> semanticAmbiguity       \n  semanticAmbiguity                --[aifAttackedNode ]--> RA-node                   <-- AIF attack\n"
     }
    ],
    "source": [
@@ -765,13 +532,6 @@
    "cell_type": "markdown",
    "id": "cell-16",
    "metadata": {
-    "papermill": {
-     "duration": 0.003063,
-     "end_time": "2026-07-24T10:27:56.419486",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.416423",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -782,13 +542,6 @@
    "cell_type": "markdown",
    "id": "aif-dist-intro",
    "metadata": {
-    "papermill": {
-     "duration": 0.003084,
-     "end_time": "2026-07-24T10:27:56.425642",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.422558",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -805,34 +558,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "aif-dist-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.433237Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.432823Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.440871Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.440072Z"
-    },
-    "papermill": {
-     "duration": 0.013427,
-     "end_time": "2026-07-24T10:27:56.442259",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.428832",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "aifAttackedNode total : 93\n",
-      "  RA-node (undercut, attaque l'inference)  :  61  (66%)\n",
-      "  I-node  (undermine, attaque la premisse) :  29  (31%)\n",
-      "  CA-node (rebut, attaque la conclusion)   :   3  (3%)\n"
-     ]
+     "name": "stdout",
+     "text": "aifAttackedNode total : 93\n  RA-node (undercut, attaque l'inference)  :  61  (66%)\n  I-node  (undermine, attaque la premisse) :  29  (31%)\n  CA-node (rebut, attaque la conclusion)   :   3  (3%)\n"
     }
    ],
    "source": [
@@ -857,13 +598,6 @@
    "cell_type": "markdown",
    "id": "aif-dist-interp",
    "metadata": {
-    "papermill": {
-     "duration": 0.00313,
-     "end_time": "2026-07-24T10:27:56.448811",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.445681",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -891,38 +625,22 @@
    "id": "sc-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T11:35:34.723010Z",
-     "iopub.status.busy": "2026-07-24T11:35:34.722753Z",
-     "iopub.status.idle": "2026-07-24T11:35:34.731110Z",
-     "shell.execute_reply": "2026-07-24T11:35:34.730492Z"
-    },
-    "papermill": {
-     "duration": 0.013838,
-     "end_time": "2026-07-24T11:35:34.732277",
-     "exception": false,
-     "start_time": "2026-07-24T11:35:34.718439",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
-   "execution_count": 7,
+   "execution_count": 8,
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "SCHEME   aifAttackedNode (cible RA/I/CA) : 93 triplets instanciés\n",
-      "   RA-node  :  61\n",
-      "   I-node   :  29\n",
-      "   CA-node  :   3\n",
-      "CONFLICT hasConflictedElement (dédié)    : 0 triplet instancié\n",
-      "SOURCE   aifAttackingNode (l'attaquant)  : 0 triplet instancié\n",
-      "\n",
-      "=> La couche de conflit dédiée (hasConflictedElement) est déclarée\n",
-      "   dans le schéma de l'OWL mais n'a AUCUN triplet instancié.\n"
-     ]
+     "name": "stdout",
+     "text": "SCHEME   aifAttackedNode (cible RA/I/CA) : 93 triplets instanciés\n   RA-node  :  61\n   I-node   :  29\n   CA-node  :   3\nCONFLICT hasConflictedElement (dédié)    : 0 triplet instancié\nSOURCE   aifAttackingNode (l'attaquant)  : 0 triplet instancié\n\n=> La couche de conflit dédiée (hasConflictedElement) est déclarée\n   dans le schéma de l'OWL mais n'a AUCUN triplet instancié.\n"
     }
-   ],   "source": [
+   ],
+   "source": [
     "# --- Scheme vs conflict : aifAttackedNode (scheme) vs hasConflictedElement (conflit dédié) ---\n",
     "from collections import Counter\n",
     "\n",
@@ -967,13 +685,6 @@
    "cell_type": "markdown",
    "id": "cell-17",
    "metadata": {
-    "papermill": {
-     "duration": 0.003369,
-     "end_time": "2026-07-24T10:27:56.455408",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.452039",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -988,31 +699,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "cell-18",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.463051Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.462797Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.466856Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.466254Z"
-    },
-    "papermill": {
-     "duration": 0.008843,
-     "end_time": "2026-07-24T10:27:56.467782",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.458939",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1027,13 +729,6 @@
    "cell_type": "markdown",
    "id": "cell-19",
    "metadata": {
-    "papermill": {
-     "duration": 0.003303,
-     "end_time": "2026-07-24T10:27:56.474157",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.470854",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1046,31 +741,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "cell-20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.481695Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.481431Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.484995Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.484487Z"
-    },
-    "papermill": {
-     "duration": 0.008718,
-     "end_time": "2026-07-24T10:27:56.485791",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.477073",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1085,13 +771,6 @@
    "cell_type": "markdown",
    "id": "cell-21",
    "metadata": {
-    "papermill": {
-     "duration": 0.002879,
-     "end_time": "2026-07-24T10:27:56.492190",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.489311",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1102,31 +781,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "cell-22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.498799Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.498573Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.502060Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.501529Z"
-    },
-    "papermill": {
-     "duration": 0.008298,
-     "end_time": "2026-07-24T10:27:56.503358",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.495060",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1141,13 +811,6 @@
    "cell_type": "markdown",
    "id": "aif-ex4-md",
    "metadata": {
-    "papermill": {
-     "duration": 0.002817,
-     "end_time": "2026-07-24T10:27:56.509407",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.506590",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1160,31 +823,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "aif-ex4-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-24T10:27:56.517453Z",
-     "iopub.status.busy": "2026-07-24T10:27:56.516954Z",
-     "iopub.status.idle": "2026-07-24T10:27:56.521629Z",
-     "shell.execute_reply": "2026-07-24T10:27:56.521011Z"
-    },
-    "papermill": {
-     "duration": 0.009924,
-     "end_time": "2026-07-24T10:27:56.522535",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.512611",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.busy": "2026-08-18T07:50:55.736743Z",
+     "iopub.status.idle": "2026-08-18T07:50:55.736743Z",
+     "shell.execute_reply": "2026-08-18T07:50:55.736743Z"
     },
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\n"
     }
    ],
    "source": [
@@ -1199,13 +853,6 @@
    "cell_type": "markdown",
    "id": "cell-23",
    "metadata": {
-    "papermill": {
-     "duration": 0.003933,
-     "end_time": "2026-07-24T10:27:56.530074",
-     "exception": false,
-     "start_time": "2026-07-24T10:27:56.526141",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1266,18 +913,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 2.869828,
-   "end_time": "2026-07-24T10:27:56.775266",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Argument_Analysis_Ontology_AIF.ipynb",
-   "output_path": "Argument_Analysis_Ontology_AIF.ipynb",
-   "parameters": {},
-   "start_time": "2026-07-24T10:27:53.905438",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #11597

## Summary

#11112 tranche **Argument_Analysis_Ontology_AIF** (famille Argument_Analysis, kernel python3, rdflib pur) : séquence `[1..5, 5, 6..7, 7, 8..10]` (DUPLICATE) → re-exec réelle, **CLEAN 1..12**, 0 erreur. Ontologie `ontologies/argumentum_fallacies.owl` committée sur main (vérifiée : présente, 0 erreur) — run déterministe.

## Exécution réelle (H.1/H.2)

- **nbclient, noyau frais python3**, cwd = dossier du notebook, `allow_errors=False` : 12/12 cellules, seq `1..12`, 0 erreur, 2,8 s.
- **Stop & Repair** (règle secrets-hygiene 6, cas C) : la cellule 3 imprimait `Chargement de : {OWL_PATH}` avec `Path(...).resolve()` — chemin absolu machine (`D:\Dev\...-863\...` sur main, changement de cwd à chaque re-exec). Correction de la **source** (`OWL_PATH.name` → basename, commentaire explicite), pas de scrub d'output. Seule ligne de contenu source modifiée.
- Sources au contenu byte-identiques (vérifié par comparaison cellule par cellule HEAD vs nouveau : seule divergence = la ligne basename intentionnelle). Les 2 lignes de diff restantes sont une normalisation de format JSON (`],   "source": [` compact → séparé), aucun contenu changé.

## Déterminisme vérifié

11/12 cellules **byte-identiques** au commit. La seule cellule divergente est la cellule 3, sur la seule correction basename (`D:\Dev\...` → `argumentum_fallacies.owl`) — aucune valeur algorithmique ne change (comptages de cardinalité, triples rdflib, diagnostics stables). Scan des cellules markdown : aucune citation d'un chemin absolu ou d'un timing machine-dépendant.

## Validation

- `check_exec_ratchet` : **DUPLICATE->CLEAN, 0 régression** · `check_papermill_ratchet` : **BLOCK_REMOVED, 0 régression** (bloc stale du run du 2026-05-25, retrait top-level + par-cellule, tous types) · `validate_pr_notebooks` : PASS (12 cells) · H.3 pre-commit OK · commit `7a857fed2c`.

## Résiduel #11112 (famille Argument_Analysis)

Après merge : Argument_Analysis 4/5 → 3/5 dirty — restent `Agentic-0` (semantic_kernel, LLM non-déterministe), `UI_configuration` (ipywidgets, séquence chaotique), `groupe-I2` (travail étudiant à qualifier), `O-AIF-Short-FR` (hors périmètre court). Voir résidu global ~49 dans #11596/#11597.

See #11112 (tranche Argument_Analysis_Ontology_AIF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
