### PR TITLE
docs(guard,#11577): exec-sequence ratchet fail-by-design protocol — template + in-gate pointer

### DIFF
--- a/.github/workflows/notebook-exec-sequence-ratchet.yml
+++ b/.github/workflows/notebook-exec-sequence-ratchet.yml
@@ -8,6 +8,16 @@ name: Notebook Exec Sequence Ratchet
 # (tier 1, #11150); this workflow drives check_exec_ratchet.py, which
 # compares each changed notebook base-vs-head and fails only on
 # CLEAN -> non-CLEAN.
+#
+# Fail-by-design acknowledgment (#11577, precedent #11574 freshness):
+# a PR that legitimately re-executes a SINGLE cell (RECOVERABLE-MACHINE
+# loader fix) while the downstream artifact is gitignored (scripts/results
+# /**, GPU 10h+) inevitably soils the sequence -> DUPLICATE/NOT_FROM_1.
+# The guard is CORRECT: it detects exactly what it must. Never hand-edit
+# execution_count to silence it. Instead: document the degraded sequence
+# (base vs head) in the PR body using the template in
+# docs/reference/regles-validation-detail.md ("Ratchet exec-sequence
+# fail-by-design") and get an explicit reviewer ack before merge.
 on:
   pull_request:
     branches: [main]

--- a/docs/reference/regles-validation-detail.md
+++ b/docs/reference/regles-validation-detail.md
@@ -127,6 +127,39 @@ Cf [docs/archive/STABLE_SNAPSHOT.md](../archive/STABLE_SNAPSHOT.md).
 
 ---
 
+## Ratchet exec-sequence (#11112 tier 2) — échecs fail-by-design assumés (#11577)
+
+Le gate `notebook-exec-sequence-ratchet.yml` échoue **par design** sur toute séquence CLEAN → non-CLEAN. Il existe un cas légitime où l'échec est inévitable : une PR RECOVERABLE-MACHINE qui re-exécute **une cellule unique** (ex. fix d'un loader, #11420) sans pouvoir re-exécuter les cellules aval — l'artefact `scripts/results/**` est gitignored et son runtime (GPU, 10 h+) est hors scope de la PR. La cellule re-exécutée bump son `execution_count` → verdict aval DUPLICATE / NOT_FROM_1.
+
+**Critères (les 3 requis simultanément)** :
+
+1. La re-exécution complète du notebook est hors scope vérifiable de la PR (artefact aval gitignored + runtime documenté dans le body).
+2. Le guard est **correct** — il détecte exactement ce qu'il doit détecter. Aucun contournement : jamais de hand-edit d'`execution_count` ni de sortie de cellule (règle 6 [secrets-hygiene.md](../../.claude/rules/secrets-hygiene.md) — falsifier la preuve d'exécution).
+3. Le body PR documente la séquence dégradée (avant/après chiffrés) **et** le reviewer (ai-01) accuse réception explicitement avant merge.
+
+**Précédents** : #11574 (freshness guard fail-by-design, résolu par #11575), #11420 (première instance exec-sequence), #11577 (présente section).
+
+**Template de commentaire PR réutilisable** (copier, remplacer les `<...>`) :
+
+```markdown
+**Ratchet exec-sequence — fail-by-design assumé (pattern #11577)**
+
+La séquence de `<notebook>` passe de CLEAN à `<VERDICT>` sur cette PR :
+
+- base : `<séquence, ex. 1,2,3,4,5>`
+- PR   : `<séquence, ex. 2,2,3,4,5>`
+
+Cause : re-exécution locale de la cellule <N> seule (<raison — ex. fix loader
+RECOVERABLE-MACHINE, issue #...>). Les cellules aval dépendent de l'artefact
+`<chemin gitignored>` (runtime <durée>, hors scope de cette PR).
+
+Le guard est correct — il détecte ce qu'il doit détecter. La re-exécution
+complète est hors scope. Séquence dégradée documentée ici ; ack reviewer
+explicite requis avant merge.
+```
+
+---
+
 ## References connexes
 
 - [.claude/rules/notebook-conventions.md](../../.claude/rules/notebook-conventions.md) — Rules C.1/C.2/C.3 notebook

--- a/scripts/notebook_tools/check_exec_ratchet.py
+++ b/scripts/notebook_tools/check_exec_ratchet.py
@@ -135,6 +135,13 @@ def main():
                   f"{args.base}, is {r['head']} in this PR — re-execute the "
                   f"notebook end-to-end on a fresh kernel before commit",
                   file=sys.stderr)
+        print("If this is an acknowledged single-cell re-exec (RECOVERABLE-"
+              "MACHINE, gitignored downstream artifact): never hand-edit "
+              "execution_count — document the degraded sequence in the PR "
+              "body with the template from docs/reference/regles-validation-"
+              "detail.md 'Ratchet exec-sequence fail-by-design' (#11577) and "
+              "get an explicit reviewer ack before merge.",
+              file=sys.stderr)
         sys.exit(1)
     sys.exit(0)
 

--- a/scripts/notebook_tools/tests/test_check_exec_ratchet.py
+++ b/scripts/notebook_tools/tests/test_check_exec_ratchet.py
@@ -152,6 +152,17 @@ class TestCli:
         assert "REGRESSION" in out.stdout
         assert "::error file=a.ipynb" in out.stderr
 
+    def test_failure_points_to_failbydesign_protocol(self, repo):
+        write_nb(repo, "a.ipynb", make_nb([1, 2, 3]))
+        base = commit(repo, "base")
+        write_nb(repo, "a.ipynb", make_nb([2, 2, 3]))
+        commit(repo, "head")
+        out = self.run_cli(repo, base)
+        assert out.returncode == 1
+        assert "fail-by-design" in out.stderr
+        assert "regles-validation-detail.md" in out.stderr
+        assert "never hand-edit" in out.stderr
+
     def test_exit_0_when_clean_kept(self, repo):
         write_nb(repo, "a.ipynb", make_nb([1, 2, 3]))
         base = commit(repo, "base")


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2023:CoursIA — prev: MED/lean-migration #11602

Closes #11577 (Option C — les 3 critères d'acceptance ci-dessous)

## Scope

Livre l'Option C recommandée par le body : le gate CLEAN→non-CLEAN **reste strict**, et les PRs single-cell re-exec (RECOVERABLE-MACHINE, artefact aval gitignored — précédents #11420, #11574 freshness) obtiennent un chemin d'acknowledgment documenté.

| Fichier | Changement |
|---|---|
| `docs/reference/regles-validation-detail.md` | Section « Ratchet exec-sequence fail-by-design » : 3 critères requis simultanément + **template de commentaire PR réutilisable** (l'ask explicite de l'issue) + précédents |
| `scripts/notebook_tools/check_exec_ratchet.py` | Sur échec : ligne stderr pointant vers le protocole (jamais hand-edit d'execution_count) |
| `scripts/notebook_tools/tests/test_check_exec_ratchet.py` | Test du pointeur (`test_failure_points_to_failbydesign_protocol`) |
| `.github/workflows/notebook-exec-sequence-ratchet.yml` | Paragraphe header documentant le pattern (miroir du style freshness #11441) |

## Validation

- `pytest scripts/notebook_tools/tests/test_check_exec_ratchet.py` : **13/13 passed** (12 existants inchangés + 1 nouveau)
- `yaml.safe_load` sur le workflow modifié : OK
- Diff : +61/−0, 4 fichiers, un seul sujet

## Critères #11577 (Option C)

- [x] Le fail est accepté par design, le guard reste inchangé dans sa logique (aucun contournement)
- [x] Commentaire PR type créé (dans regles-validation-detail.md, copiable par les futures PRs RECOVERABLE-MACHINE)
- [x] Documentation du pattern transférable (workflow header + docs + in-gate pointer au moment exact où le gate échoue)

Note : l'ack reviewer explicite reste un geste humain (ai-01) — ce grain outille le chemin, il ne l'automatise pas.

## G.4 / hygiène

- 1 sujet, 4 fichiers, +61 lignes — pas de composite.
- Catalogue byte-identique à main.