### PR TITLE
fix(slides,#11508): adaptateur .md — FN listes-seules + FP zone grise EN (delta sur #11548) + cure S1/S2

### DIFF
--- a/scripts/notebook_tools/restore_accents_canonical.py
+++ b/scripts/notebook_tools/restore_accents_canonical.py
@@ -241,6 +241,32 @@ _HTML_ATTR_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Zone grise FR/EN : formes du dictionnaire qui sont AUSSI des mots anglais valides
+# (`strategies`, `execution`, `role`, `iteration`...). Mesure #11508 (commentaire
+# de l'inventaire) : ~15 formes, dont les FP reels ASPIC *Structured Preferences*,
+# Boole *Mathematical Theories*, **Value/Policy Iteration**. Une cure sans garde
+# accentue une ligne entierement anglaise (« The strategies of execution and the
+# role of the model » -> « The stratégies of exécution and the rôle of the model »,
+# mesure firsthand sur l'adaptateur #11548). La detection NEGATIVE (chercher des
+# mots-outils anglais) sous-detecte : « - **Value Iteration** » n'en porte aucun.
+# On exige donc la PREUVE POSITIVE d'un contexte francais (mot-outil univoquement
+# FR sur la ligne) pour curer une forme en collision — doctrine
+# accent-cure-defense-in-depth : ne pas toucher vaut mieux que risquer.
+_EN_COLLIDING_FORMS = {
+    "strategies", "execution", "executions", "experience", "experiences",
+    "preferences", "preference", "role", "roles", "selection",
+    "iteration", "iterations", "theories", "theorie", "scenarios",
+    "element", "elements", "difference", "differences",
+    "operations", "operation", "categories", "categorie",
+    "theme", "themes", "different", "generation", "generations",
+    "scenario", "resultat", "resultats",
+}
+_EN_COLLIDING = {k for k in ACCENT_PAIRS if k in _EN_COLLIDING_FORMS}
+_FR_MARKER_RE = re.compile(
+    r"\b(le|la|les|des|du|de|une|et|ou|dans|pour|sur|avec|par|au|aux|ce|cet|"
+    r"cette|ces|sont|nous|vous|il|elle|ils|elles|qui|que|quoi|dont|mais|donc|"
+    r"puis|en)\b")
+
 
 def _fence_mask(lines: list[str]) -> list[bool]:
     """True pour chaque ligne d'un bloc de code, delimiteurs inclus.
@@ -267,11 +293,19 @@ def _frontmatter_and_fence_mask(lines: list[str]) -> list[bool]:
     Le fence est suivi en premier : un `---` a l'interieur d'un bloc de code n'est
     pas un separateur de slide.
 
-    Un segment (entre deux `---`) est reconnu comme frontmatter quand *toutes* ses
-    lignes non vides sont des cles YAML ou des continuations indentees. Un segment
-    qui porte la moindre ligne de prose n'en est pas un — la direction sure : dans
-    le doute, on ne protege pas plus large que necessaire, mais on ne cure jamais
-    un segment dont chaque ligne ressemble a de la configuration.
+    Un segment (entre deux `---`) est reconnu comme frontmatter quand sa premiere
+    ligne non vide est une cle YAML et que toutes les suivantes sont cles ou
+    continuations indentees. Un segment qui porte la moindre ligne de prose n'en
+    est pas un — la direction sure : dans le doute, on ne protege pas plus large
+    que necessaire, mais on ne cure jamais un segment dont chaque ligne ressemble
+    a de la configuration.
+
+    L'exigence sur la PREMIERE ligne non vide est le correctif d'un faux negatif
+    mesure (po-2024, 2026-08-18) : `_YAML_CONT_RE` matche aussi les items de
+    liste (`^\\s*-\\s`), donc un segment fait uniquement de puces — une slide
+    sans phrase, cas frequent — satisfaisait "toutes lignes = cles ou
+    continuations" et etait protege en bloc : 0 cure la ou la prose etait
+    accentuable. Un frontmatter reel de Slidev commence TOUJOURS par une cle.
     """
     n = len(lines)
     # 1. fences
@@ -285,15 +319,19 @@ def _frontmatter_and_fence_mask(lines: list[str]) -> list[bool]:
         body = [lines[i] for i in seg if lines[i].strip()]
         if not body:
             continue
-        if all(_YAML_KEY_RE.match(ln) or _YAML_CONT_RE.match(ln) for ln in body):
+        if not _YAML_KEY_RE.match(body[0]):
+            continue
+        if all(_YAML_KEY_RE.match(ln) or _YAML_CONT_RE.match(ln) for ln in body[1:]):
             for i in seg:
                 protected[i] = True
     return protected
 
 
 def _cure_markdown_line(line: str) -> tuple[str, int]:
-    """Cure une ligne de markdown pur : masque code inline + attributs HTML, puis
-    delegue au coeur `_cure_line` (qui protege deja les cibles de liens).
+    """Cure une ligne de markdown pur : masque code inline + attributs HTML,
+    applique la zone grise FR/EN (preuve positive de contexte francais pour les
+    formes en collision), puis delegue au coeur `_cure_line` (qui protege deja
+    les cibles de liens).
     """
     spans: list[str] = []
 
@@ -303,6 +341,16 @@ def _cure_markdown_line(line: str) -> tuple[str, int]:
 
     masked = _INLINE_CODE_RE.sub(_mask, line)
     masked = _HTML_ATTR_RE.sub(_mask, masked)
+    if _EN_COLLIDING and not _FR_MARKER_RE.search(masked):
+        # Pas de preuve de contexte francais : neutraliser les formes en
+        # collision en les masquant (le coeur ne les verra pas).
+        def _mask_form(m):
+            spans.append(m.group(0))
+            return "\x00MD{}\x00".format(len(spans) - 1)
+        masked = _CURE_RE.sub(
+            lambda m: _mask_form(m) if m.group(0).lower() in _EN_COLLIDING
+            else m.group(0),
+            masked)
     cured, n = _cure_line(masked)
     for i, original in enumerate(spans):
         cured = cured.replace("\x00MD{}\x00".format(i), original, 1)

--- a/scripts/notebook_tools/tests/test_restore_accents_canonical.py
+++ b/scripts/notebook_tools/tests/test_restore_accents_canonical.py
@@ -462,3 +462,74 @@ class TestMarkdownCli:
         p = _md(tmp_path, original)
         rac.main([str(p), "--dry-run"])
         assert p.read_text(encoding="utf-8") == original
+
+
+# ---------------------------------------------------------------------------
+# 7. faux negatif listes-seules + zone grise FR/EN (delta po-2024 sur #11548)
+# ---------------------------------------------------------------------------
+class TestListOnlySegmentNotFrontmatter:
+    """_YAML_CONT_RE matche aussi les items de liste (`^\s*-\s`) : un segment
+    fait uniquement de puces satisfaisait "toutes lignes = cles ou continuations"
+    et etait protege comme frontmatter -> 0 cure silencieuse. Un frontmatter
+    Slidev reel commence TOUJOURS par une cle : la premiere ligne non vide doit
+    matcher _YAML_KEY_RE."""
+
+    def test_list_only_slide_is_cured(self, tmp_path):
+        deck = "---\ntheme: ../theme-ia101\n---\n\n---\n\n- Les strategies deployees par le modele\n- Le modele de theorie\n\n---\n"
+        p = _md(tmp_path, deck)
+        rac.cure_markdown(p, write=True)
+        out = p.read_text(encoding="utf-8")
+        assert "stratégies" in out and "modèle" in out
+
+    def test_list_line_without_separator_is_cured(self, tmp_path):
+        # variante minimale mesuree : pas meme de separateur ---
+        p = _md(tmp_path, "- Les strategies deployees par le modele\n")
+        res = rac.cure_markdown(p, write=False)
+        assert res["cures"] >= 1
+
+    def test_real_frontmatter_still_protected(self, tmp_path):
+        deck = "---\nlayout: two-cols\n---\n\n- Les strategies du modele\n"
+        p = _md(tmp_path, deck)
+        rac.cure_markdown(p, write=True)
+        out = p.read_text(encoding="utf-8")
+        assert "layout: two-cols" in out  # cle intacte
+        assert "stratégies" in out  # la liste, elle, est curee
+
+
+class TestEnglishGrayZone:
+    """Formes en collision FR/EN : curees seulement sur preuve POSITIVE de
+    contexte francais. La detection negative (mots-outils EN) sous-detecte :
+    `- **Value Iteration**` n'en porte aucun (FP mesure #11508, reproduit sur
+    l'adaptateur #11548 : `The strategies of execution and the role of the
+    model` -> `The stratégies of exécution and the rôle of the model`)."""
+
+    def test_bare_english_term_skipped(self, tmp_path):
+        p = _md(tmp_path, "**Value Iteration**\n**Policy Iteration**\n")
+        rac.cure_markdown(p, write=True)
+        assert "Itération" not in p.read_text(encoding="utf-8")
+
+    def test_english_line_skipped(self, tmp_path):
+        p = _md(tmp_path, "The strategies of execution and the role of the model\n")
+        rac.cure_markdown(p, write=True)
+        out = p.read_text(encoding="utf-8")
+        assert out == "The strategies of execution and the role of the model\n"
+
+    def test_reference_title_skipped(self, tmp_path):
+        p = _md(tmp_path, "Boole, An Investigation of the Mathematical Theories of Logic\n")
+        rac.cure_markdown(p, write=True)
+        assert "Théories" not in p.read_text(encoding="utf-8")
+
+    def test_french_line_same_form_cured(self, tmp_path):
+        # la MEME forme sur une ligne a preuve FR est curee : decision par
+        # contexte, jamais par mot
+        p = _md(tmp_path, "- Les strategies deployees par le modele\n")
+        rac.cure_markdown(p, write=True)
+        assert "stratégies" in p.read_text(encoding="utf-8")
+
+    def test_non_colliding_form_cured_without_fr_marker(self, tmp_path):
+        # les formes HORS collision ne demandent pas de preuve FR : la cure
+        # conservatrice est non-ambigue par construction du dictionnaire
+        p = _md(tmp_path, "Un parametre et un probleme\n")
+        rac.cure_markdown(p, write=True)
+        out = p.read_text(encoding="utf-8")
+        assert "paramètre" in out and "problème" in out

--- a/slides/S1-argumentation/slides.md
+++ b/slides/S1-argumentation/slides.md
@@ -141,7 +141,7 @@ layout: cover
   - et (prémisse de réfutation)
   - Alors (Conclusion)
 
-<!-- Toulmin : Donnees → Garantie → Conclusion, + Fondement, Qualificateur, Refutation -->
+<!-- Toulmin : Données → Garantie → Conclusion, + Fondement, Qualificateur, Refutation -->
 
 
 ---
@@ -465,7 +465,7 @@ layout: two-cols
 - **Objectif de l'inférence logique**
   - Vérifier qu'un énoncé est une conséquence de la KB, i.e. un théorème
 - **Inférence par la preuve**
-  - Utilisation de règles de dérivation cohérentes pour produire une chaine de conclusions conduisant au but
+  - Utilisation de règles de dérivation cohérentes pour produire une chaîne de conclusions conduisant au but
 
 **Exemple de règles cohérentes**
 

--- a/slides/S2-ia-exploratoire-symbolique/slides.md
+++ b/slides/S2-ia-exploratoire-symbolique/slides.md
@@ -1,7 +1,7 @@
 ---
 theme: ../theme-ia101
 title: "Intelligence Artificielle - IA Exploratoire et Symbolique"
-info: IA 101 - Recherche, algorithmes genetiques, logique, SMTs
+info: IA 101 - Recherche, algorithmes génétiques, logique, SMTs
 paginate: true
 drawings:
   persist: false
@@ -790,9 +790,9 @@ layout: two-cols
 
 - **Objectif de l'inférence logique:**
   - Vérifier qu'un énoncé est une conséquence de la KB, i.e. un théorème
-- Inférence par la preuve: utilisation de règles de dérivation cohérentes pour produire une chaine de conclusions conduisant au but
+- Inférence par la preuve: utilisation de règles de dérivation cohérentes pour produire une chaîne de conclusions conduisant au but
 - **Exemple de règles cohérentes**
-  - **REGLE / PREMISSES / CONCLUSION**
+  - **RÈGLE / PREMISSES / CONCLUSION**
   - Modus Ponens : A, A  B  B
   - Introduction du Et : A, B  A  B
   - Elimination du Et : A  B  A
@@ -1027,7 +1027,7 @@ layout: two-cols
 - Décomposition hiérarchique
 
 <img src="./images/img_050.png" width="300" alt="Diagramme planification">
-<img src="./images/img_051.png" width="300" alt="Schema hierarchique">
+<img src="./images/img_051.png" width="300" alt="Schema hiérarchique">
 
 
 
@@ -1046,7 +1046,7 @@ layout: two-cols
 - Web sémantique
   - W3C
 
-<img src="./images/img_052.png" width="280" alt="Ontologies web semantique">
+<img src="./images/img_052.png" width="280" alt="Ontologies web sémantique">
 
 - Linked Data
 
@@ -1090,7 +1090,7 @@ layout: section
 
 - **Exploration** : `Search/Exploration_non_informee_et_informee_intro.ipynb`
   - BFS, DFS, UCS, A* sur carte de Roumanie
-- **Algorithmes genetiques** : `Sudoku/Sudoku-2-Genetic.ipynb`
+- **Algorithmes génétiques** : `Sudoku/Sudoku-2-Genetic.ipynb`
   - `Search/Portfolio_Optimization_GeneticSharp.ipynb`
 - **Z3 / SMT** : `Sudoku/Sudoku-4-Z3.ipynb`
 - **Logique formelle** : `SymbolicAI/Lean/` (10 notebooks)
@@ -1109,4 +1109,4 @@ Jean-Sylvain Boige
 jsboige@myia.org
 
 > **Notebooks associes :** `MyIA.AI.Notebooks/Search/`, `MyIA.AI.Notebooks/Sudoku/`, `MyIA.AI.Notebooks/SymbolicAI/`
-> Tutoriels exploration, algorithmes genetiques, CSP, Z3, logique formelle
+> Tutoriels exploration, algorithmes génétiques, CSP, Z3, logique formelle


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2024:CoursIA — prev: MED/slides #11605(v1)

## Ce que cette PR est devenue — transparence sur la v1

La v1 de cette PR livrait un adaptateur `.md` complet. **Elle collisionnait avec #11548 (ai-01), mergé 3 minutes avant mon claim** : mon garde L898 cherchait les PRs touchant `slides/`, #11548 ne touche que le script — angle mort assumé et documenté. La branche a été **reconstruite sur main** : ce qui reste n'est pas un doublon, mais le correctif de **deux classes de défauts mesurées firsthand sur l'adaptateur mergé**, plus l'application aux decks.

## Défaut 1 — FN : les slides faites uniquement de listes ne sont jamais curées

`_YAML_CONT_RE` matche aussi les items de liste (`^\s*-\s`). Un segment fait uniquement de puces — une slide sans phrase, cas fréquent — satisfaisait « toutes lignes = clés ou continuations » et était **protégé comme frontmatter : 0 cure silencieuse**. Reproduit sur cas minimal (deck à 1 slide en liste → `cures: 0`).

**Correctif** : la première ligne non vide d'un segment-frontmatter doit être une **clé** YAML. Un frontmatter Slidev réel commence toujours par une clé ; une slide en liste non plus.

## Défaut 2 — FP : l'adaptateur sans garde accentue les lignes anglaises

Reproduit firsthand sur l'adaptateur mergé :

```
IN : The strategies of execution and the role of the model
OUT: The stratégies of exécution and the rôle of the model

IN : - **ASPIC (Argumentation with Structured Preferences and Inconsistency Constraints)**
OUT: - **ASPIC (Argumentation with Structured Préférences and Inconsistency Constraints)**   (S1:600)
```

Ce sont exactement les FP que l'inventaire de #11508 (commentaire 2) avait mesurés — « ~15 formes en collision, décision par contexte, pas par mot » — et que #11548 a déférés à la revue d'application. Sans garde dans l'outil, **chaque application deck-by-deck rejoue le risque**.

**Correctif** : polarité **preuve positive**. Une forme en collision (`strategies`, `execution`, `role`, `iteration`…) n'est curée que si la ligne porte un mot-outil univoquement français. La détection négative (chercher des mots-outils anglais) sous-détecte : `- **Value Iteration**` n'en porte aucun — c'est le FP mesuré sur `04-probabilites:1730/:1752` dans l'issue.

## Application S1/S2 (revue ligne par ligne)

- **S1-argumentation** : 2 cures — commentaire HTML Toulmin (`Données`), `chaîne`. Intact : ASPIC (L600), référence Boole (L711) — anglais.
- **S2-ia-exploratoire** : 7 cures — `info:` (`génétiques`, via la whitelist prose de #11548), `chaîne`, `RÈGLE` (all-caps préservée), 2 `alt=`, `génétiques` ×2. Intact : 1 alt gris (`Operations planification` — aucun marqueur FR sur la ligne, laissé à l'arbitrage).

Comparaison directe main vs fix sur les 2 decks : les seuls écarts sont les 3 FP anglais éliminés (ASPIC, Boole, alt gris) — aucune cure légitime perdue.

## Validation

- `pytest scripts/notebook_tools/tests/test_restore_accents_canonical.py` → **55 pass** (+8 : FN minimal, frontmatter réel toujours protégé, polarité par ligne, formes hors collision sans exigence de preuve).
- `slidev build` SUCCESS sur les 2 decks (4.2 s / 4.1 s).
- Diff decks : 9 lignes, mots uniquement.

## Honest disclosure

- Lane sans vision : verdict de rendu différé à ai-01 (règle 2 de l'EPIC).
- La collision v1↔#11548 est un incident de méthode de ma part (garde L898 trop étroit : chemins decks seulement, pas le chemin de l'outil). Consigné en mémoire locale.

See #11508 (L1 : correctif de l'outil + 2 decks applicables ; restent 15 decks + second lot hors dictionnaire conservateur).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
