### PR TITLE
fix(slides,#11508): cure d'accents tranche 2 — decks 05-08 + S6-S8 + S4 (568 substitutions)

### DIFF
--- a/slides/05-theorie-des-jeux/slides.md
+++ b/slides/05-theorie-des-jeux/slides.md
@@ -1,7 +1,7 @@
 ---
 theme: ../theme-ia101
-title: "Intelligence Artificielle - Theorie des jeux"
-info: IA 101 - Theorie des jeux, analyse strategique, mecanismes
+title: "Intelligence Artificielle - Théorie des jeux"
+info: IA 101 - Théorie des jeux, analyse stratégique, mécanismes
 paginate: true
 drawings:
   persist: false
@@ -10,14 +10,14 @@ mdc: true
 layout: cover
 ---
 
-# Theorie des jeux
+# Théorie des jeux
 
 INTELLIGENCE ARTIFICIELLE -- V
 
-**Analyse strategique**
+**Analyse stratégique**
 
 - Jeux Bayesiens
-- Theorie des mecanismes
+- Théorie des mécanismes
   - Jeux differentiels
 
 ---
@@ -36,7 +36,7 @@ layout: default
 - II. Resolution de problemes
 - III. Bases de connaissances et logique
 - IV. Incertitude et modèles probabilistes
-- **V. Theorie des jeux**
+- **V. Théorie des jeux**
 - VI. Apprentissage
 - VII. Traitement du langage naturel
 - VIII. Presentation projets
@@ -45,7 +45,7 @@ layout: default
 layout: dense
 ---
 
-# Theorie des jeux
+# Théorie des jeux
 
 ## Environnement multi-agent
 
@@ -53,47 +53,47 @@ layout: dense
   - Planification / Synchronisation
   - Multi-Effecteurs / Multi-corps (decouplage)
     - Centralise (state = pool) vs decentralise
-- Decideurs multiples -> theorie des jeux
+- Decideurs multiples -> théorie des jeux
   - But commun / buts propres, adversite et/ou collaboratif
   - Information parfaite / imparfaite
   - A un tour: Joueurs, actions, recompenses
 
-## Etudes des interdependances strategiques
+## Études des interdependances stratégiques
 
 - Objectif double
-  - Design d'agent: Quelle est la meilleure strategie?
-  - Design de mecanisme: Quelles sont les bonnes regles?
-- Optimisation de strategies: pure / mixte (randomisee)
+  - Design d'agent: Quelle est la meilleure stratégie?
+  - Design de mécanisme: Quelles sont les bonnes règles?
+- Optimisation de stratégies: pure / mixte (randomisee)
 - Von Neumann -> Maximin: Jeux a somme nulle
 
 ---
 layout: section
 ---
 
-# Analyse strategique
+# Analyse stratégique
 
 ---
 layout: dense
 ---
 
-# Analyse strategique
+# Analyse stratégique
 
 ## Jeux simultanes
 
 - Matrice de gains
 - Dilemme du prisonnier: Parler ou se taire
-  - Strategie pure strictement dominante (stable)
+  - Stratégie pure strictement dominante (stable)
   - Mais Pareto dominee (global mais instable)
 
 ## IESDS
 
-- Elimination iterative des strategies strictement dominees
+- Elimination iterative des stratégies strictement dominees
 - Reduction progressive de la matrice
 
 ## Equilibre de Nash
 
 - Optimum local dans l'espace des politiques
-- Aucun agent n'a de motivation a changer de strategie
+- Aucun agent n'a de motivation a changer de stratégie
   - = Une loi que personne n'enfreint sans la police
 - Garanti d'exister / importance de la Coordination
 
@@ -106,15 +106,15 @@ layout: dense
 layout: dense
 ---
 
-# Strategies mixtes
+# Stratégies mixtes
 
 ## Occurrences
 
 - Ex: Penalty, pile ou face -- Jeux a somme nulle
-- Distribution probabiliste de strategies pures
+- Distribution probabiliste de stratégies pures
 - Theoreme de Nash: 1 equilibre doit exister
 
-## Algorithme de strategie mixte
+## Algorithme de stratégie mixte
 
 - Utilites esperees -> equations pour l'indifference a l'equilibre
   - `EU_L = sigma_u(-3) + (1-sigma_u)(1) = EU_R = sigma_u(2) + (1-sigma_u)(0)` -> `sigma_u = 1/6`
@@ -129,9 +129,9 @@ layout: dense
 layout: dense
 ---
 
-# Equilibres de strategie mixte
+# Equilibres de stratégie mixte
 
-## Strategie mixte dominant strictement une pure
+## Stratégie mixte dominant strictement une pure
 
 - Ex: 3 lignes, milieu dominee, calcul des probas
 
@@ -144,10 +144,10 @@ layout: dense
 
 - Ex: equilibres partiellement mixtes
 
-## Regle impaire
+## Règle impaire
 
 - Presque tous les jeux ont un nombre impair d'equilibres
-- Nombre infini ou pair generalement lie a la dominance faible
+- Nombre infini ou pair généralement lie a la dominance faible
   - Ex nombre pair: l'argent gratuit
   - Sinon verifier si on n'a pas oublie une mixte
 
@@ -155,14 +155,14 @@ layout: dense
 layout: dense
 ---
 
-# Jeux sequentiels
+# Jeux séquentiels
 
 ## Jeux a tours successifs
 
 - Conflits, negociations etc.
 - Jeu de la guerre des prix (in/out)
   - Accept, out = equilibres
-  - Difference = menace credible?
+  - Différence = menace credible?
 - Equilibre parfait de sous-jeu (SPE)
   - Sous-jeu Firm 2 -> accept
   - "out" plus en equilibre -> question des menaces credibles
@@ -189,11 +189,11 @@ layout: dense
 - Sous-jeux simultanes, Gains independants, connaissance du passe
 - Difficile a dessiner (exponentiel)
 - Theoremes:
-  - Derniere étape -> Equilibre de Nash (passe non modifiable)
+  - Dernière étape -> Equilibre de Nash (passe non modifiable)
   - Autres: jouer equilibres de Nash = 1 equilibre de sous-jeu
   - Mais autres equilibres de sous-jeu possibles (cooperation)
 
-## Strategies de punition
+## Stratégies de punition
 
 - Ex: Prisonnier puis Argent gratuit -> equilibre faible (0,0) = menace de punition
 - Menaces "credibles" importantes
@@ -205,7 +205,7 @@ layout: dense
 ## Problemes de l'induction arriere
 
 - Ex: le millepattes -- equilibre pessimiste, pas constate en pratique
-- Hypotheses -> Maths -> conclusions (probleme: rationalite limitee)
+- Hypotheses -> Maths -> conclusions (problème: rationalite limitee)
 - Induction avant = passe rationnel (supprime un equilibre)
 
 ## Dilemmes repetes
@@ -216,11 +216,11 @@ layout: dense
 layout: dense
 ---
 
-# Formes strategiques avancees
+# Formes stratégiques avancees
 
 ## Raisonner avec des variables
 
-- Ex: bataille des sexes, A>B>C, algorithme de strategie mixte
+- Ex: bataille des sexes, A>B>C, algorithme de stratégie mixte
   - `sigma_u = (b-c)/(a+b-2c)` et `0 < sigma_u < 1`
 - Ex: Topologie complete 2x2
 
@@ -238,8 +238,8 @@ layout: dense
 
 ## Pierre, papier, ciseaux
 
-- Pas de strategie pure -> cycle
-- Support des strategies mixtes, EU egales dans le support
+- Pas de stratégie pure -> cycle
+- Support des stratégies mixtes, EU egales dans le support
 - Theoreme: 2 joueurs, symetrique a somme nulle -> EU = 0
 - Resolution: indifference `sigma_L = 1/4` (ciseaux pour compenser)
 
@@ -247,18 +247,18 @@ layout: dense
 layout: default
 ---
 
-# Espaces de strategies infinis
+# Espaces de stratégies infinis
 
 ## Jeux sans equilibre
 
-- Nombre fini de strategies pures -> Matrices + theoremes de Nash
-- Certains jeux ont une infinite de strategies pures
+- Nombre fini de stratégies pures -> Matrices + theoremes de Nash
+- Certains jeux ont une infinite de stratégies pures
   - Pas de matrice, pas forcement d'equilibre de Nash
 
 ## Duels
 
-- 100 m, 2 balles, precisions differentes (0% a 100m, 100% a 0m)
-- Equilibre = meme distance (preuve par contradiction)
+- 100 m, 2 balles, precisions différentes (0% a 100m, 100% a 0m)
+- Equilibre = même distance (preuve par contradiction)
 - Ex: date de sortie de produits concurrents
 
 ## Loi de Hotelling et l'electeur median
@@ -292,7 +292,7 @@ layout: dense
 
 - N joueurs, Omega etats de la nature, A_i actions du joueur i
 - T_i type du joueur i, U_i recompense, p_i distribution des types
-- Strategies pures: `S_i = {s_i: T_i -> A_i}`
+- Stratégies pures: `S_i = {s_i: T_i -> A_i}`
 
 ## Equilibres de Nash Bayesien
 
@@ -302,7 +302,7 @@ layout: dense
 ## Ex: Dilemme du Sheriff
 
 - Criminel (p) vs civil (1-p), tirer ou pas
-- Strategies dominantes: tirer pour criminel, pas pour civil
+- Stratégies dominantes: tirer pour criminel, pas pour civil
 - Pour le Sheriff: `E(tirer) = p-1`, `E(pas) = -2p`
   - p>1/3 = tirer
 
@@ -312,30 +312,30 @@ layout: dense
 
 # Equilibres Bayesiens parfaits (PBE)
 
-## Jeux sequentiels
+## Jeux séquentiels
 
 - Rappel SPE -> equilibres non plausibles (menaces non credibles)
-- Systemes de croyance: assignations de probabilités sur les types
-  - "Consistant" -> Probabilités par application des strategies (Bayes)
-- Rationalite sequentielle: recompense esperee maximale
+- Systèmes de croyance: assignations de probabilités sur les types
+  - "Consistant" -> Probabilités par application des stratégies (Bayes)
+- Rationalite séquentielle: recompense esperee maximale
 
 ## Definition PBE
 
-- Profile strategique et systeme de croyance consistant tels que les strategies sont sequentiellement rationnelles
+- Profile stratégique et système de croyance consistant tels que les stratégies sont sequentiellement rationnelles
 
 ## Jeux de signalisation
 
 - Emetteur S (connait son type) -> message m, Recepteur R -> action a
-- 3 categories de PBE:
-  - **Pooling**: emetteurs choisissent le meme message (pas de signal)
-  - **Separating**: messages toujours differents -> croyance deterministe
+- 3 catégories de PBE:
+  - **Pooling**: emetteurs choisissent le même message (pas de signal)
+  - **Separating**: messages toujours différents -> croyance déterministe
   - **Semi-separation** (partial-pooling): mixte
 
 ## Exemples
 
 - Jeu de reputation (guerre des prix): pooling ou separating
 - Jeu d'education: doue ou pas, diplome ou pas (signal) -> PBE de separation
-- Biere-quiche: P=0.9 -> pooling, P=0.2 -> strategies mixtes
+- Biere-quiche: P=0.9 -> pooling, P=0.2 -> stratégies mixtes
 
 ---
 layout: section
@@ -362,7 +362,7 @@ layout: dense
   - Nash -> meilleure reponse myope incrementale
 - Cas general similaire a un POMDP + theta
 
-## Theorie des jeux cooperatifs
+## Théorie des jeux cooperatifs
 
 - Utilite transferable de coalition: `G = {N, v}`, `V(C) >= 0`
 - Partitions = Structures de Coalitions CS(N)
@@ -377,23 +377,23 @@ layout: dense
 - Reseaux de contribution marginale (representation compacte)
   - `phi_i(R) = sum x/|C|` pour les coalitions contenant i
 - Structures de coalition optimales: NP-Hard
-  - Bons resultats avec exploration du graphe de structure
+  - Bons résultats avec exploration du graphe de structure
 
 ---
 layout: section
 ---
 
-# Conception de mecanismes
+# Conception de mécanismes
 
 ---
 layout: dense
 ---
 
-# Conception de mecanismes
+# Conception de mécanismes
 
-## Theorie des jeux inverse
+## Théorie des jeux inverse
 
-- Si les agents sont rationnels, quelles sont les bonnes regles?
+- Si les agents sont rationnels, quelles sont les bonnes règles?
 - Dans le cadre Bayesien d'information imparfaite
   - Le "principal" souhaite inciter a reveler la vraie utilite
 
@@ -405,11 +405,11 @@ layout: dense
 
 ## Principe de revelation
 
-- Mecanisme incitatif verace (IC): non manipulable, revelateur
+- Mécanisme incitatif verace (IC): non manipulable, revelateur
   - `theta_hat(theta) = theta`
-- S'il existe un mecanisme y implementant f, alors il existe une version IC
+- S'il existe un mécanisme y implementant f, alors il existe une version IC
 - 2 versions:
-  - **DSIC**: Implementation en strategies dominantes
+  - **DSIC**: Implementation en stratégies dominantes
   - **BNIC**: Equilibre de Nash Bayesien (plus faible)
 
 ---
@@ -424,16 +424,16 @@ layout: dense
 - Enchere anglaise (ascendante): Efficace mais risque de collusion
 - Enchere de Vickrey (second prix)
   - Equilibre DSIC = chacun declare la valeur "honnete"
-  - Tres repandu: eBay, AdWords etc.
+  - Très repandu: eBay, AdWords etc.
 - Theoreme d'equivalence de revenue
 
 ## Bien commun
 
 - Tragedie des communs (ex: pollution)
-  - Strategie de pollution dominante mais pas optimale (Pareto)
+  - Stratégie de pollution dominante mais pas optimale (Pareto)
   - Necessite d'expliciter les externalites (ex: taxe carbone)
 
-## Mecanisme de Vickrey-Clarke-Groves (VCG)
+## Mécanisme de Vickrey-Clarke-Groves (VCG)
 
 - N Encherisseurs declarent utilite de M ressources
 - Allocation maximisant la somme des utilites
@@ -445,19 +445,19 @@ layout: dense
 
 # Allocation par les votes
 
-## Theorie du choix social
+## Théorie du choix social
 
-- Preferences individuelles rationnelles -> Ordre de preference social
+- Préférences individuelles rationnelles -> Ordre de préférence social
 - Proprietes d'une bonne fonction de choix social:
   1. Condition de Pareto / critere d'unanimite
-  2. Independance des alternatives non pertinentes
+  2. Indépendance des alternatives non pertinentes
   3. Pas de dictature
 
-## Resultats negatifs
+## Résultats negatifs
 
 - **Paradoxe de Condorcet**: A,B,C -> 2/3 de mecontents
 - **Theoreme de Arrow**: Impossible de satisfaire 1, 2 et 3 simultanement (>= 3 options)
-- **Theoreme de Gibbard-Satterthwaite**: Toute FCS deterministe avec Pareto et >2 choix est manipulable ou dictatoriale
+- **Theoreme de Gibbard-Satterthwaite**: Toute FCS déterministe avec Pareto et >2 choix est manipulable ou dictatoriale
 
 ---
 layout: dense
@@ -479,9 +479,9 @@ layout: dense
 
 ## Si pas de vainqueur de Condorcet
 
-- Methode **Minimax**: celui qui fait le mieux au pire
-  - Mais tres strategique (ex: anarchistes)
-- Methode de **Schulze**: elimination iterative des derniers du peloton de tete
+- Méthode **Minimax**: celui qui fait le mieux au pire
+  - Mais très stratégique (ex: anarchistes)
+- Méthode de **Schulze**: elimination iterative des derniers du peloton de tete
   - Robuste a la manipulation (electeurs raisonnables)
 
 ---
@@ -490,26 +490,26 @@ layout: dense
 
 # Procedures de votes connues
 
-- **Referendum**: 2 options -> methode de la majorite robuste (la seule)
+- **Referendum**: 2 options -> méthode de la majorite robuste (la seule)
 - **Vote pluraliste uninominal** (n candidats): critique (vote utile)
-- **Vote a second-tour instantane**: Preferences, elimination du dernier
+- **Vote a second-tour instantane**: Préférences, elimination du dernier
   - Pas de critere de Condorcet
-- **Methode de Condorcet**: comparaisons paires a paires -> Schulze
+- **Méthode de Condorcet**: comparaisons paires a paires -> Schulze
 
-## Methodes utilitaristes
+## Méthodes utilitaristes
 
-- **Compte de Borda**: preferences, score = ordre (manipulable)
+- **Compte de Borda**: préférences, score = ordre (manipulable)
 - **Vote par assentiment**: elimination, majorite d'approbation
   - Theoreme de robustesse au mensonge
 - **Scrutin au jugement majoritaire**: mediane des scores
-  - Seule procedure avec majorite d'une meme note validee + monotonie
+  - Seule procedure avec majorite d'une même note validee + monotonie
 
 ## Scrutins stochastiques
 
 - **Scrutin Stochocratique**: option preferee puis tirage au sort
-  - Theoreme d'Hylland: seule methode avec unanimite non strategique
+  - Theoreme d'Hylland: seule méthode avec unanimite non stratégique
 - **Condorcet randomisee**: loterie ponderee dans le peloton de tete
-  - Ponderation selon equilibre de Nash -- critere de Condorcet + non strategique
+  - Ponderation selon equilibre de Nash -- critere de Condorcet + non stratégique
 
 ---
 layout: default
@@ -519,7 +519,7 @@ layout: default
 
 ## Modèle des offres alternees
 
-- Si pas d'accord: Accord de conflit -> fenetre de negociation
+- Si pas d'accord: Accord de conflit -> fenêtre de negociation
 - Nombre de manches:
   - 1 manche: Ultimatum (J1 a tout le pouvoir)
   - 2 manches: J2 a tout le pouvoir
@@ -527,12 +527,12 @@ layout: default
 - Agents impatients: facteurs de discompte `0 <= gamma_i < 1`
   - Offre a l'equilibre: `A_1 = (1-gamma_2)/(1-gamma_1*gamma_2)`
 
-## Domaines orientes taches
+## Domaines orientes tâches
 
-- Offres (T1, T2) de repartitions de taches parmi T
+- Offres (T1, T2) de repartitions de tâches parmi T
 - Protocole de concession monotone
 
-## Strategie de Zeuthen
+## Stratégie de Zeuthen
 
 - Mesure de l'aversion au risque de conflit
 - Le risque plus faible concede, sinon tirage au sort
@@ -541,7 +541,7 @@ layout: default
 layout: default
 ---
 
-# Theorie de la negociation
+# Théorie de la negociation
 
 ## Demarche
 
@@ -576,15 +576,15 @@ layout: dense
 
 # Jeux differentiels
 
-## Theorie des jeux + theorie du controle
+## Théorie des jeux + théorie du contrôle
 
 - Interdependance: agents economiques, pollution, marches
 - Dynamique: habitudes, technologies, accumulations, traffic
-- Comportement strategique: buts antagonistes, choix
+- Comportement stratégique: buts antagonistes, choix
 
 ## Definitions
 
-- Joueurs M={1,...,m}, Vecteur de controle `u_j(t)`
+- Joueurs M={1,...,m}, Vecteur de contrôle `u_j(t)`
 - Vecteur d'etat `x(t)`, equation d'etat: `x'(t) = f(x(t), u(t), t)`
 - Fonction de gain: `J_j = S_j(x(T)) - integral g_j dt` -> Minimisation de L
 
@@ -593,7 +593,7 @@ layout: dense
 - **Boucle ouverte**: conditions initiales + temps: `u_j(t) = mu_j(x_0, t)`
 - **Markovienne**: `u_j(t) = sigma_j(t, x(t))` (lineaire, quadratique, seuil)
 - Non Markovienne: utilisation de l'historique
-- **Hierarchique**: le leader annonce sa strategie
+- **Hiérarchique**: le leader annonce sa stratégie
 
 ---
 layout: dense
@@ -630,17 +630,17 @@ layout: dense
 layout: default
 ---
 
-# Methodes calculatoires
+# Méthodes calculatoires
 
-## Methodes directes
+## Méthodes directes
 
 - Formulation du programme mathematique et resolution
 
-## Methodes indirectes
+## Méthodes indirectes
 
 - Utilisation d'equations differentielles partielles
 
-## Methode d'echantillonnage incremental
+## Méthode d'echantillonnage incremental
 
 - Ex: poursuite evasion
 - RRT -> exploration d'arbre
@@ -673,7 +673,7 @@ layout: default
 - II. Resolution de problemes
 - III. Bases de connaissances et logique
 - IV. Incertitude et modèles probabilistes
-- V. Theorie des jeux
+- V. Théorie des jeux
 - **VI. Apprentissage**
 - VII. Traitement du langage naturel
 - VIII. Presentation projets
@@ -687,11 +687,11 @@ layout: dense
 1. Moteur de recherche augmente par le raisonnement et le langage naturel
 2. Conception de bots de services sur reseaux sociaux
 3. Conception d'un modèle d'inference pour l'analyse de sentiment
-4. Création d'une plateforme semantique LDP
+4. Création d'une plateforme sémantique LDP
 5. Resolution de Captchas par deep learning
-6. Entrainement de strategies de trading algorithmiques sur crypto monnaies
+6. Entrainement de stratégies de trading algorithmiques sur crypto monnaies
 7. Amelioration par l'apprentissage d'un agent joueur de Go simple
-8. Evolution de vaisseaux spatiaux par algorithmes genetiques dans le jeu de la vie
+8. Evolution de vaisseaux spatiaux par algorithmes génétiques dans le jeu de la vie
 9. Pilotage d'un cluster de cache distribue pour le portage d'applications dans le Cloud
 
 ---

--- a/slides/06-apprentissage/slides.md
+++ b/slides/06-apprentissage/slides.md
@@ -1659,7 +1659,7 @@ layout: section
 
 - Given training set
 - Find B that best matches D
-- model sélection
+- model selection
 - parameter estimation
 - Data D
 - Inducer
@@ -1718,7 +1718,7 @@ layout: section
 ---
 
 
-# Model sélection
+# Model selection
 
 - Goal: Select the best network structure, given the data
 - Input:
@@ -1731,7 +1731,7 @@ layout: section
 ---
 
 
-# Structure sélection: Scoring
+# Structure selection: Scoring
 
 - Bayesian: prior over parameters and structure
 - get balance between model complexity and fit to data as a byproduct
@@ -1908,7 +1908,7 @@ layout: section
 ---
 
 
-# Variations on a thème
+# Variations on a theme
 
 - Known structure, fully observable: only need to do parameter estimation
 - Unknown structure, fully observable: do heuristic search through structure space, then parameter estimation

--- a/slides/06-apprentissage/slides.md
+++ b/slides/06-apprentissage/slides.md
@@ -73,9 +73,9 @@ Intelligence Artificielle -- VI
 
 # Agent Apprenant
 
-- **4 modules** : performance, apprentissage, critique, generateur de problemes
+- **4 modules** : performance, apprentissage, critique, générateur de problemes
 - Le module d'apprentissage ameliore le composant de performance a partir du feedback du critique
-- Le generateur de problemes suggere de nouvelles expériences pour enrichir l'apprentissage
+- Le générateur de problemes suggere de nouvelles expériences pour enrichir l'apprentissage
 
 
 ---
@@ -418,7 +418,7 @@ layout: dense
 
 # Résumé arbres de décision
 
-- L’induction d’arbres de decision est l’une des methodes d’apprentissage les plus utilisees
+- L’induction d’arbres de decision est l’une des méthodes d’apprentissage les plus utilisees
 - Surpasse les humains dans de nombreux problemes, apprentissage par gain informationnel
 - **Points forts** : rapide, simple, comprehensible, empiriquement valide, robuste au bruit
 
@@ -607,7 +607,7 @@ layout: dense
 
 <!-- Image: images/img_020.png -->
 
-<!-- Bagging = echantillons paralleles, Boosting = echantillons sequentiels ponderes -->
+<!-- Bagging = echantillons paralleles, Boosting = echantillons séquentiels ponderes -->
 
 
 ---
@@ -732,7 +732,7 @@ layout: two-cols
 # Apprentissage par retropropagation
 
 - **Principe** : propager l'erreur de la sortie vers les couches cachees
-- Calcul du gradient de l'erreur par la règle de la chaine (chain rule)
+- Calcul du gradient de l'erreur par la règle de la chaîne (chain rule)
 - Mise a jour des poids : W_j ← W_j - alpha * dE/dW_j
 - Permet d'entrainer des réseaux multi-couches (invention cle du deep learning)
 
@@ -750,7 +750,7 @@ layout: two-cols
 - 100 exemples
 - Convergence exacte
 - Caractéristiques
-- Bons pour les taches de reconnaissance complexe
+- Bons pour les tâches de reconnaissance complexe
 - Convergence peut être lente
 - Soucis de Minima locaux / surapprentissage
 - Eviter trop de paramètres / d’unités
@@ -1032,7 +1032,7 @@ layout: two-cols
 -  Couches distinctes plus flexibles (MLPs)
 - DeepWalk (plongement appris)
 - Random Walk  skip-grams (~Word2Vec)
-- Softmax hierarchique (optimisation)
+- Softmax hiérarchique (optimisation)
 - GraphSage
 -  DeepWalk pas adaptatif
 - Solution: Agrégation de voisinage
@@ -1293,14 +1293,14 @@ $$y_i(w \cdot x_i + b) \geq 1 \quad \forall i$$
 - **Astuce 1** : Identifier les points les plus proches du plan de separation optimal (les "vecteurs supports") et travailler directement a partir de ces instances.
 
 <div v-click="2">
-- **Astuce 2** : Formuler comme un probleme d'optimisation quadratique et utiliser les techniques de programmation quadratique.
+- **Astuce 2** : Formuler comme un problème d'optimisation quadratique et utiliser les techniques de programmation quadratique.
 </div>
 
 <div v-click="3">
 - **Astuce 3** (le "kernel trick") :
   - Au lieu d'utiliser directement les caractéristiques, representer les données dans un espace de grande dimension construit a partir de fonctions de base (combinaisons polynomiales et gaussiennes des caractéristiques d'origine).
   - Trouver un hyperplan separateur / SVM dans cet espace de grande dimension.
-  - Resultat : un classifieur non lineaire !
+  - Résultat : un classifieur non lineaire !
 
 <!-- SVM : hyperplan optimal, vecteurs supports sur la marge maximale -->
 
@@ -1659,7 +1659,7 @@ layout: section
 
 - Given training set
 - Find B that best matches D
-- model selection
+- model sélection
 - parameter estimation
 - Data D
 - Inducer
@@ -1718,7 +1718,7 @@ layout: section
 ---
 
 
-# Model selection
+# Model sélection
 
 - Goal: Select the best network structure, given the data
 - Input:
@@ -1731,7 +1731,7 @@ layout: section
 ---
 
 
-# Structure selection: Scoring
+# Structure sélection: Scoring
 
 - Bayesian: prior over parameters and structure
 - get balance between model complexity and fit to data as a byproduct
@@ -1908,7 +1908,7 @@ layout: section
 ---
 
 
-# Variations on a theme
+# Variations on a thème
 
 - Known structure, fully observable: only need to do parameter estimation
 - Unknown structure, fully observable: do heuristic search through structure space, then parameter estimation
@@ -2076,7 +2076,7 @@ layout: dense
 - Ex pour TD et Q-learning:
 - **Convergence garantie**
   - pour cas simples uniquement
-- Egalement utile pour apprendre un modèle
+- Également utile pour apprendre un modèle
 - Si observable  Apprentissage inductif
 - Sinon plus difficile (HMM)
 
@@ -2132,7 +2132,7 @@ layout: dense
 - Mise à jour des poids par backpropagation
 - Mais convergence très lente
 -  tricks pour l’accélérer
-- Ex: Experience replay: des scénarios sont gardés en mémoire et rejoués en batchs
+- Ex: Expérience replay: des scénarios sont gardés en mémoire et rejoués en batchs
 -  moins de similarité dans les échantillons  échappe aux minima locaux
 - Problème de l’exploration
 - (cf. bandits manchot)
@@ -2226,7 +2226,7 @@ layout: dense
 - Choix de l’espace d’hypothèses H, paramètres actualisés par l’approche TD
 - Exploration de politique
 - Amélioration directe de π à partir des observations. Domaines stochastiques compliqués
-- Simulations et « Experience replay » importants
+- Simulations et « Expérience replay » importants
 - Deep Q learning
 - Etat de l’art: Deep NN = espace idéal
 - Accélération de la convergence: tricks multiples
@@ -2376,7 +2376,7 @@ layout: section
 
 > **ML.NET** (C#) : `ML/ML.Net/` - Classification, regression, clustering
 > **Reinforcement Learning** : `RL/` - CartPole, DQN, Stable Baselines3
-> **Algorithmes genetiques** : `Sudoku/Sudoku-2-Genetic.ipynb`, `Search/Portfolio_Optimization_GeneticSharp.ipynb`
+> **Algorithmes génétiques** : `Sudoku/Sudoku-2-Genetic.ipynb`, `Search/Portfolio_Optimization_GeneticSharp.ipynb`
 > **Deep Learning et GenAI** : `GenAI/` - Transformers, diffusion, LLMs
 > **Probabilités et inference** : `Probas/` - Infer.NET, réseaux bayesiens
 

--- a/slides/07-elargissements/slides.md
+++ b/slides/07-elargissements/slides.md
@@ -57,7 +57,7 @@ Son impact réel?
   - Objection mathematique
 - **Avancees recentes**
   - GPT 5.2, Claude Opus 4.5, Gemini Pro 3
-  - Raisonnement, ARC, Maths, Developpement
+  - Raisonnement, ARC, Maths, Développement
 
 ---
 layout: dense
@@ -66,7 +66,7 @@ layout: dense
 # L'informalite des comportements humains
 
 - **Critique de Dreyfus et GOFAI**
-  - Les regles logiques sont insuffisantes
+  - Les règles logiques sont insuffisantes
   - Importance de l'embodied cognition
   - Comprendre passe par l'interaction avec le monde physique
 - **Reponse moderne**
@@ -89,7 +89,7 @@ layout: dense
 - **Critique de Turing**
   - "Une machine ne pourra jamais faire X (etre gentille, creative, drole)"
 - **Avancees recentes**
-  - L'IA cree de l'art: Stable Diffusion, DALL-E, Flux, Z-Image, Nano Banana
+  - L'IA créé de l'art: Stable Diffusion, DALL-E, Flux, Z-Image, Nano Banana
   - Resout des problemes scientifiques: AlphaFold
   - Amuse: chatbots avances
   - Creativite musicale: Suno, Udio (bouleverse l'industrie musicale)
@@ -99,7 +99,7 @@ layout: dense
 - **Limites persistantes**
   - Hallucinations, manque de "comprehension"
   - L'IA reste incapable d'emotions ou de conscience réelle
-  - Autonomie simulee = meta-programmes (prompts systemes)
+  - Autonomie simulee = meta-programmes (prompts systèmes)
 
 ---
 layout: dense
@@ -108,18 +108,18 @@ layout: dense
 # L'objection mathematique
 
 - **L'argument de Godel**
-  - Godel (1931): Tout systeme formel suffisamment puissant est limite
-  - Il existe des enonces vrais mais impossibles a prouver dans ce systeme
+  - Godel (1931): Tout système formel suffisamment puissant est limite
+  - Il existe des enonces vrais mais impossibles a prouver dans ce système
 - **Critique historique**
   - Lucas (1961), Penrose (1989): "Les humains comprennent des verites inaccessibles aux machines"
 - **Reponse moderne**
-  - Les humains ne sont pas exempts d'erreurs (ex: probleme des 4 couleurs)
-  - Les machines modernes (reseaux neuronaux, LLMs) ne sont pas des systemes formels rigides
-    - Elles peuvent changer leurs regles (apprentissage automatique)
+  - Les humains ne sont pas exempts d'erreurs (ex: problème des 4 couleurs)
+  - Les machines modernes (reseaux neuronaux, LLMs) ne sont pas des systèmes formels rigides
+    - Elles peuvent changer leurs règles (apprentissage automatique)
     - Elles revoient leurs conclusions (metaraisonnement)
   - 2025: AlphaProof, AlphaGeometry -> Medaille d'or IMO
 - **Limite persistante**
-  - Les systemes humains et artificiels restent soumis aux contraintes des mathematiques
+  - Les systèmes humains et artificiels restent soumis aux contraintes des mathematiques
 
 ---
 layout: dense
@@ -133,7 +133,7 @@ layout: dense
   - Objectif: Evaluer l'intelligence par une conversation convaincante
   - Limite: Test de la "tromperie" plutot que de l'intelligence réelle
   - 2023: GPT-4 a surpasse les performances humaines, mais insuffisant pour evaluer l'AGI
-  - Nouveaux criteres: Resolution de taches complexes, explicabilite, ethique
+  - Nouveaux critères: Resolution de tâches complexes, explicabilite, ethique
 - **La course aux benchmarks**
   - 1960s--2022: Tests specialises (enigmes, reconnaissance d'images)
   - 2023: Saturation de GSM8K (maths) et MMLU (connaissances), depasses par GPT-4, Claude
@@ -159,32 +159,32 @@ layout: dense
 # La chambre chinoise (Searle, 1980)
 
 - **Explication**
-  - Un humain, sans comprendre le chinois, utilise un livre de regles pour simuler des reponses
+  - Un humain, sans comprendre le chinois, utilise un livre de règles pour simuler des reponses
   - Conclusion de Searle: Simuler n'est pas comprendre
 - **Reponses modernes**
-  - La comprehension peut emerger du systeme global (theorie des systemes)
+  - La comprehension peut emerger du système global (théorie des systèmes)
   - Les LLMs illustrent ce debat: production coherente sans comprehension intrinseque
 - **Reflexion rapide**
   - "Comment distinguer comprehension réelle et apparente chez une IA?"
 
 ---
 
-# Theories de la conscience (1/2)
+# Théories de la conscience (1/2)
 
-- **Definir la conscience**
-  - Qualia: Les experiences subjectives (ressentir la chaleur, la douleur)
+- **Définir la conscience**
+  - Qualia: Les expériences subjectives (ressentir la chaleur, la douleur)
   - Conscience comme modèle de soi et du monde
 - **Global Workspace Theory (GWT)**
-  - La conscience est un espace de travail ou differentes parties du cerveau partagent des informations
-  - Applications: Modèles d'attention, taches complexes
-  - Role important de l'inconscient
+  - La conscience est un espace de travail ou différentes parties du cerveau partagent des informations
+  - Applications: Modèles d'attention, tâches complexes
+  - Rôle important de l'inconscient
 - **Integrated Information Theory (IIT)**
-  - La conscience est mesuree par le degre d'integration de l'information (Phi)
-  - Introduit la notion de systemes physiques conscients
+  - La conscience est mesuree par le degré d'integration de l'information (Phi)
+  - Introduit la notion de systèmes physiques conscients
 
 ---
 
-# Theories de la conscience (2/2)
+# Théories de la conscience (2/2)
 
 - **Higher-Order Theory (HOT)**
   - La conscience necessite une pensee sur ses propres etats mentaux (metacognition)
@@ -203,19 +203,19 @@ layout: dense
 # Integrated Information Theory (IIT)
 
 - **La conscience est integree et informationnelle**
-  - Chaque experience consciente est un tout indivisible (integration)
+  - Chaque expérience consciente est un tout indivisible (integration)
   - Elle contient une riche quantite d'informations differenciees (information)
 - **Quantification par Phi ("phi")**
-  - Plus Phi est eleve, plus le systeme est conscient
+  - Plus Phi est eleve, plus le système est conscient
   - Cerveau humain: Phi eleve, ordinateur traditionnel: Phi bas
 - **Cinq axiomes fondamentaux**
   - Existence: La conscience existe intrinsequement
-  - Composition: Structuree en sous-elements (couleurs, formes, sons)
-  - Information: Chaque experience est differente
+  - Composition: Structuree en sous-éléments (couleurs, formes, sons)
+  - Information: Chaque expérience est différente
   - Integration: Unifiee et indivisible
-  - Exclusion: Certaines experiences sont conscientes, d'autres non
+  - Exclusion: Certaines expériences sont conscientes, d'autres non
 - **Applications et implications**
-  - La conscience peut exister dans tout systeme integrant l'information
+  - La conscience peut exister dans tout système integrant l'information
   - Reste difficile a tester experimentalement
 - **Activite**: Decouverte de PyPhi
 
@@ -232,7 +232,7 @@ layout: dense
   - Maximiser les benefices
   - Minimiser les risques
 - **Question pour reflexion**
-  - "Comment garantir que l'IA sert l'interet collectif et non des interets individuels?"
+  - "Comment garantir que l'IA sert l'intérêt collectif et non des intérêts individuels?"
 
 ---
 layout: dense
@@ -241,7 +241,7 @@ layout: dense
 # Armes autonomes letales
 
 - **Definition**
-  - Armes capables de selectionner et de tuer des cibles sans supervision humaine
+  - Armes capables de sélectionner et de tuer des cibles sans supervision humaine
 - **Exemples**
   - Harop Missile (Israel)
   - Kargu Quadcopter (Turquie)
@@ -283,7 +283,7 @@ layout: dense
 - **Types de biais**
   - **Biais de données**: minorites sous-representees
   - **Biais dans les algorithmes**: justice americaine (COMPAS), reconnaissance faciale
-  - **Biais de preferences**: Exemple LLMs
+  - **Biais de préférences**: Exemple LLMs
 - **Solutions**
   - Oversampling des classes minoritaires (SMOTE)
   - Transparence et documentation des données (data sheets)
@@ -303,7 +303,7 @@ layout: dense
   - Certification (ISO, UL)
 - **Explainable AI (XAI)**
   - Exemples: "Pourquoi votre pret a-t-il ete refuse?"
-  - Avancees: SHAP (Shapley, imputation des caracteristiques) ou LIME (Local Interpretable)
+  - Avancees: SHAP (Shapley, imputation des caractéristiques) ou LIME (Local Interpretable)
 - **Exemple concret**
   - Comparaison entre explications humaines et machines
 - **Question ouverte**
@@ -387,9 +387,9 @@ layout: two-cols
 - **La singularite et le transhumanisme**
   - Singularite technologique (Good, Kurzweil)
   - Transhumanisme: Fusion homme-machine
-  - Optimisme vs dangers (controle, survie humaine)
+  - Optimisme vs dangers (contrôle, survie humaine)
 - **Question ouverte**
-  - "Quel futur voulons-nous co-creer avec l'IA?"
+  - "Quel futur voulons-nous co-créer avec l'IA?"
 
 ---
 layout: section
@@ -406,7 +406,7 @@ layout: section
 - **Progres recents en IA**
   - Applications, materiel, composants
 - **Perspectives d'avenir**
-  - IA generale et architecturee
+  - IA générale et architecturee
   - Questions ethiques et societales
 
 ---
@@ -415,13 +415,13 @@ layout: section
 
 - **Avancees majeures**
   - Large deploiement: medecine, finance, transport, communication
-  - Deep learning: depassement des capacités humaines dans des taches spécifiques
+  - Deep learning: depassement des capacités humaines dans des tâches spécifiques
 - **Estimation des experts**
-  - IA generale dans 10 a 100 ans
+  - IA générale dans 10 a 100 ans
   - Trillions de dollars ajoutes a l'economie chaque annee dans la prochaine decennie
 - **Defis**
   - Ethique: biais, equite, potentielle letalite
-  - Developpement durable et controle de l'impact global
+  - Développement durable et contrôle de l'impact global
 
 ---
 
@@ -433,8 +433,8 @@ layout: section
   - Imprimantes 3D et bioprinting pour prototypage rapide
   - Calculateurs miniatures: Arduino, NVIDIA Orin
 - **Applications emergentes**
-  - Robots industriels: environnements controles, taches repetitives
-  - Defis pour le marche domestique: variabilite des environnements et taches complexes
+  - Robots industriels: environnements contrôles, tâches repetitives
+  - Defis pour le marche domestique: variabilite des environnements et tâches complexes
 
 ---
 
@@ -451,27 +451,27 @@ layout: section
 
 ---
 
-# Composants - Selection d'Actions
+# Composants - Sélection d'Actions
 
 - **Complexite**
   - Plans a long terme: milliards d'étapes primitives (ex: obtenir un diplome)
   - Defis dans les environnements partiellement observables (POMDP)
 - **Progres recents**
-  - Representations hierarchiques (MDP hierarchiques)
+  - Representations hiérarchiques (MDP hiérarchiques)
   - Algorithmes pour decomposer le comportement en niveaux successifs
 - **Perspectives**
-  - Developpement de methodes pour representer efficacement les etats et actions sur de longues periodes
+  - Développement de méthodes pour representer efficacement les etats et actions sur de longues periodes
 
 ---
 
-# Composants - Definir les Objectifs
+# Composants - Définir les Objectifs
 
 - **Difficultes**
-  - Modelisation des preferences humaines complexes
-  - Interaction entre preferences individuelles et equite sociale
+  - Modelisation des préférences humaines complexes
+  - Interaction entre préférences individuelles et equite sociale
 - **Progres**
   - Apprentissage par renforcement inverse: apprentissage a partir de demonstrations
-  - Langages pour specifier les preferences (logique temporelle lineaire)
+  - Langages pour specifier les préférences (logique temporelle lineaire)
 - **Exemples concrets**
   - Agents capables de maximiser des objectifs multi-dimensionnels sous incertitude
 
@@ -486,7 +486,7 @@ layout: dense
 - **Progres spectaculaires**
   - Vision par ordinateur, langage naturel, apprentissage par renforcement
 - **Limites**
-  - Dependance excessive a des données annotees massives
+  - Dépendance excessive a des données annotees massives
   - Difficultes avec des données rares ou non structurees
 - **Progres recents**
   - Self-supervised learning, Apprentissage contrastif (GPT)
@@ -495,7 +495,7 @@ layout: dense
   - RL finetuning (O1, Deepseek)
 - **Axes futurs**
   - Apprentissage par transfert: reutiliser les connaissances
-  - Integration apprentissage/connaissance: fusion de l'experience et du raisonnement
+  - Integration apprentissage/connaissance: fusion de l'expérience et du raisonnement
 
 ---
 
@@ -507,9 +507,9 @@ layout: dense
   - Augmentation exponentielle des capacités de traitement (GPU, TPU, FPGA)
 - **Defis**
   - Validation et gestion des données massives (crowdsourcing, validation par LLM)
-  - Conception de systemes robustes pour des domaines complexes
+  - Conception de systèmes robustes pour des domaines complexes
 - **Opportunites**
-  - Modèles universels reutilisables pour plusieurs taches
+  - Modèles universels reutilisables pour plusieurs tâches
   - Modèles open-source (Llama, Gemma, Qwen, Phi) + fine-tunes (LoRAs) et quants
 
 ---
@@ -517,7 +517,7 @@ layout: dense
 # Architectures d'Agents
 
 - **Approches hybrides**
-  - Symbolique: raisonnement et chaines de logique complexe
+  - Symbolique: raisonnement et chaînes de logique complexe
   - Connexionniste: reconnaissance de patterns dans des données bruyantes
 - **Concepts avances**
   - Algorithmes "anytime": amelioration progressive en fonction du temps disponible
@@ -529,17 +529,17 @@ layout: dense
 
 ---
 
-# IA Generale
+# IA Générale
 
 <!-- Image: images/recursive_self_improvement.png -->
 
 - **Objectif**
-  - Creer des agents capables de maitriser plusieurs taches diverses
-- **Probleme**
-  - Aujourd'hui, les systemes sont concus pour des taches spécifiques
+  - Créer des agents capables de maitriser plusieurs tâches diverses
+- **Problème**
+  - Aujourd'hui, les systèmes sont concus pour des tâches spécifiques
   - Manque de diversite comportementale et de generalisation
 - **Progres recents**
-  - Systemes multi-langues ou multi-taches bases sur des modèles de grande taille (ex: GPT)
+  - Systèmes multi-langues ou multi-tâches bases sur des modèles de grande taille (ex: GPT)
 
 ---
 
@@ -547,9 +547,9 @@ layout: dense
 
 - **Etat actuel**
   - IA encore difficile a deployer pour les non-experts
-  - Besoin d'un ecosysteme de developpement accessible et robuste
+  - Besoin d'un ecosysteme de développement accessible et robuste
 - **Proposition de Jeff Dean (Google)**
-  - Construire un enorme modèle universel, puis en extraire les parties pertinentes pour des taches spécifiques
+  - Construire un enorme modèle universel, puis en extraire les parties pertinentes pour des tâches spécifiques
 - **Exemples**
   - Transformers (GPT-4+) avec des milliards de paramètres
   - Montee de l'Open-source
@@ -588,7 +588,7 @@ layout: dense
 - **Modèles proprietaires vs Open-source**
   - USA vs Chine
 - **Sovereign AI**
-  - Chaque nation veut son "cerveau numerique"
+  - Chaque nation veut son "cerveau numérique"
 - **Infrastructure**
   - Course a l'armement (Datacenters, GPUs)
 
@@ -608,11 +608,11 @@ layout: dense
 - **Cosmologie: Le Grand Programmeur Universel**
   - L'univers comme programme compressible
   - Les lois physiques refletent une faible complexite algorithmique (similaire a Wolfram)
-  - Role des intelligences: Decouvrir et optimiser ces regularites, participant a une evolution universelle
+  - Rôle des intelligences: Decouvrir et optimiser ces regularites, participant a une evolution universelle
 - **Impact en IA et Philosophie**
   - En IA: Optimisation algorithmique, comme les reseaux LSTM
   - En cosmologie: Une quete computationnelle naturaliste maximisant l'efficacite algorithmique
-  - Physique Numerique: TEDx Talk
+  - Physique Numérique: TEDx Talk
 
 ---
 layout: section
@@ -630,7 +630,7 @@ layout: section
 - **Explicabilite (XAI)**: `ML/` - ML.NET tutorials
 - **IA Generative et ethique**: `GenAI/` - 58 notebooks
   - DALL-E, Stable Diffusion, ComfyUI, LLMs
-- **Theorie des jeux**: `GameTheory/` - 26 notebooks OpenSpiel
+- **Théorie des jeux**: `GameTheory/` - 26 notebooks OpenSpiel
 
 ---
 layout: end

--- a/slides/08-ia-generative/slides.md
+++ b/slides/08-ia-generative/slides.md
@@ -17,7 +17,7 @@ Intelligence Artificielle -- VIII
 **Panorama, enjeux et pratiques de l'IA generative**
 
 - Decouvrir les bases et les grands principes de l'IA generative
-- Comprendre les differents usages applicatifs (texte, image, audio...)
+- Comprendre les différents usages applicatifs (texte, image, audio...)
 - Identifier les limites et les enjeux ethiques
 
 ---
@@ -63,17 +63,17 @@ imageClass: mid-right
   - Complexite des prompts, intervention humaine necessaire
 - **Approche multidisciplinaire**
   - ML + NLP + Vision par ordinateur
-  - Embeddings + mecanismes d'attention
+  - Embeddings + mécanismes d'attention
 
 ---
 
-# Systemes ISPO
+# Systèmes ISPO
 
-- **Input, Storage, Process, Output** : les quatre fonctions fondamentales d'un systeme informatique
+- **Input, Storage, Process, Output** : les quatre fonctions fondamentales d'un système informatique
   - **Input** : données d'entrée (texte, image, audio, video)
   - **Storage** : memoire des poids du modèle et du contexte de la conversation
   - **Process** : inference par le modèle (attention, generation token par token)
-  - **Output** : resultat genere (texte, image, code, audio...)
+  - **Output** : résultat genere (texte, image, code, audio...)
 - Proprietes : vitesse, precision, regularite, polyvalence, fiabilite, programmabilite
 
 ---
@@ -92,7 +92,7 @@ imageClass: mid-right
 - **Pipeline de données**
   - Acquisition → Nettoyage → Preparation → Annotation
 - **Données synthetiques**
-  - Alternative pour creer en masse, proteger la confidentialite
+  - Alternative pour créer en masse, proteger la confidentialite
   - 2025 : risque de Model Collapse
 
 ---
@@ -106,8 +106,8 @@ imageClass: mid-right
 - **Scalabilite et cout energetique**
   - Necessite d'infrastructures puissantes (datacenters)
   - Optimisations : modèles distilles, datacenters verts
-- **Methodes d'entrainement**
-  - *Apprentissage de base* : tres couteux, modèles fondationnels
+- **Méthodes d'entrainement**
+  - *Apprentissage de base* : très couteux, modèles fondationnels
   - *Fine-Tuning* : ajustement spécifique, LoRAs, RL
   - *Apprentissage en contexte* : peu couteux, prompt engineering
 - **Activite : Sources de données**
@@ -122,11 +122,11 @@ imageClass: mid-right
 # Fonctionnement des LLMs : Tokens et Embeddings
 
 - **Tokens**
-  - Representation numerique des mots
+  - Representation numérique des mots
   - Vocabulaire de 50k a 128k tokens
 - **Embeddings**
   - Representation vectorielle des mots/phrases
-  - Permet de calculer la proximite semantique
+  - Permet de calculer la proximite sémantique
   - *King - Man + Woman = Queen*
 - **Activite : Mind-Meld**
   - Par deux, mots aléatoires simultanes
@@ -162,9 +162,9 @@ imageClass: mid-right
 
 - **Les mots sont choisis en sequence**
   - En fonction de leur probabilité d'occurrence
-  - Dans un contexte donne (= mots qui precedent)
+  - Dans un contexte donne (= mots qui précédent)
 - **Paramètres de generation :**
-  - *Temperature* : controle la variabilite des resultats
+  - *Temperature* : contrôle la variabilite des résultats
   - *Top-p sampling* : seuil de distribution cumulatif
   - *Top-k sampling* : k mots les plus probables
 
@@ -203,7 +203,7 @@ imageClass: mid-right
   - Prototypes visuels, dessins, photos
   - Outils : MidJourney, Stable Diffusion, ChatGPT, Gemini
 - **Litterature et redaction creative**
-  - Scenarios, recits interactifs, co-ecriture, poesie
+  - Scénarios, recits interactifs, co-ecriture, poesie
   - Outils : ChatGPT, Claude, Llama
 - **Entreprenariat et innovation**
   - Ideation, validation d'idees, prototypage
@@ -222,7 +222,7 @@ imageClass: mid-right
 
 - **Positionnement Metier** (ex: Microsoft Copilot)
 - **Communication d'entreprise**
-  - Synthese de contenu, themes majeurs
+  - Synthese de contenu, thèmes majeurs
   - Structuration d'arguments persuasifs
 - **Marketing et interaction client**
   - Contenu reseaux sociaux, blogs, videos publicitaires
@@ -240,14 +240,14 @@ imageClass: mid-right
 - **Recrutement et formation**
   - Descriptions de poste inclusives
   - Resume automatique des candidatures
-  - Scenarios d'entretien personnalises
+  - Scénarios d'entretien personnalises
   - Parcours de formation adaptatifs
 - **Analytics et prise de decision**
   - Automatisation des pipelines de données
   - Modelisation avancee, visualisation rapide
   - Synthese de tableaux de bord complexes
 - **Activite : Campagne Marketing fictive : Nouveau Soda**
-  - Un slogan, 1 visuel, 3 posts reseaux sociaux, 1 scenario de pub
+  - Un slogan, 1 visuel, 3 posts reseaux sociaux, 1 scénario de pub
 
 <!-- Second image: ./images/img_018.jpg -->
 
@@ -274,10 +274,10 @@ layout: dense
 # Techniques : Generation de texte
 
 - **Prompt Engineering** : instructions explicites, few-shot learning, variantes stylistiques
-- **Prompts Systemes** : structuration pour taches complexes (CoT, ToT)
+- **Prompts Systèmes** : structuration pour tâches complexes (CoT, ToT)
 - **RAG** (Retrieval Augmented Generation)
   - Combinaison modèles generatifs + bases documentaires
-  - Chunks, embeddings, requetes contextuelles
+  - Chunks, embeddings, requêtes contextuelles
 - **Function Calling** : appels API, generation structuree
 - **Orchestration** : Semantic Kernel, LangChain
 - **Agentique avancee** : coordination multi-agents (AutoGen, Semantic Kernel)
@@ -405,14 +405,14 @@ layout: dense
 - **Fiabilite** : hallucinations, fabrications, impact confiance
   - Solutions : algorithmes robustes, verification croisee multi-modèles
 - **Tests et validation**
-  - "Auditeurs IA" : detection de biais en scenarios fictifs
+  - "Auditeurs IA" : detection de biais en scénarios fictifs
   - **Activite :** recommandation voyage, sources de données in/out
-- **Securite** : risques de mauvaise utilisation, perte de controle
+- **Securite** : risques de mauvaise utilisation, perte de contrôle
   - Niveaux de securite Anthropic, Constitutional AI
 - **Points critiques** : perte d'emplois, homogeneisation creative, deepfakes
-  - **Activite : Constitutional AI** → definir une constitution, tester
+  - **Activite : Constitutional AI** → définir une constitution, tester
 
-> **Niveaux Anthropic** : ASL-1 (pas de risque) → ASL-2 (risque modere, garde-fous) → ASL-3 (capacités avancees, controle renforce) → ASL-4+ (autonomie, risque systemique)
+> **Niveaux Anthropic** : ASL-1 (pas de risque) → ASL-2 (risque modere, garde-fous) → ASL-3 (capacités avancees, contrôle renforce) → ASL-4+ (autonomie, risque systemique)
 
 ---
 layout: dense
@@ -420,8 +420,8 @@ layout: dense
 
 # Responsabilite sociale
 
-- **Role des entreprises** : transparence, codes ethiques
-- **Role des utilisateurs** : formation, adoption responsable
+- **Rôle des entreprises** : transparence, codes ethiques
+- **Rôle des utilisateurs** : formation, adoption responsable
 - **Impact environnemental**
   - Rapport IEA 2025 : consommation datacenters x2 en 3 ans (= Japon)
 - **IA pour le bien commun**
@@ -429,7 +429,7 @@ layout: dense
   - Surveillance deforestation, gestion des ressources en eau
 - **Activite : Propositions novatrices** (avec et sans guidance)
 
-> **Chiffres cles** : GPT-4 entrainement ≈ 50 GWh | 1 requete ChatGPT ≈ 10x une recherche Google | Datacenters IA : 4% electricite mondiale d'ici 2030 (IEA)
+> **Chiffres cles** : GPT-4 entrainement ≈ 50 GWh | 1 requête ChatGPT ≈ 10x une recherche Google | Datacenters IA : 4% electricite mondiale d'ici 2030 (IEA)
 
 ---
 

--- a/slides/S4-trading-algorithmique/deck-1-fondamentaux.md
+++ b/slides/S4-trading-algorithmique/deck-1-fondamentaux.md
@@ -784,7 +784,7 @@ imageClass: mid-right visible
 
 </div>
 
-> Ref: *Hands-On AI Trading* Ch9 "Rôle of GenAI in Creating Alpha" p.341
+> Ref: *Hands-On AI Trading* Ch9 "Role of GenAI in Creating Alpha" p.341
 
 ---
 

--- a/slides/S4-trading-algorithmique/deck-1-fondamentaux.md
+++ b/slides/S4-trading-algorithmique/deck-1-fondamentaux.md
@@ -19,7 +19,7 @@ Intelligence Artificielle -- S4 -- Partie 1 : Fondamentaux
 - Comprendre les fondamentaux du trading algorithmique
 - Apprendre a utiliser Lean/QuantConnect
 - Concevoir et implementer un algorithme de trading
-- Evaluer et optimiser une strategie algorithmique
+- Evaluer et optimiser une stratégie algorithmique
 - Maitriser le traitement de données et l'IA pour le trading
 
 ---
@@ -34,7 +34,7 @@ Intelligence Artificielle -- S4 -- Partie 1 : Fondamentaux
 <div v-click="1">
 
 - **Pourquoi ce cours ?**
-  - Comprendre les mecanismes qui regissent les marches modernes
+  - Comprendre les mécanismes qui regissent les marches modernes
   - Acquerir les competences pratiques avec Lean/QuantConnect
   - Developper une pensee critique face aux promesses du trading automatise
   - Preparer une carriere en finance quantitative ou en data science financiere
@@ -62,12 +62,12 @@ Ce cours est organise en 3 decks thematiques :
   - Types de trading (HFT, MFT, LFT)
   - Marches financiers et instruments
   - Ordres de trading
-  - Trouver et evaluer une strategie
+  - Trouver et evaluer une stratégie
 
 <div v-click="1">
 
-- **Deck 2 : Strategies et Gestion du Risque**
-  - Strategies de trading (Momentum, Mean Reversion, Arbitrage...)
+- **Deck 2 : Stratégies et Gestion du Risque**
+  - Stratégies de trading (Momentum, Mean Reversion, Arbitrage...)
   - Backtesting et metriques de performance
   - Gestion du risque (Kelly, stop loss, diversification)
 
@@ -88,7 +88,7 @@ Ce cours est organise en 3 decks thematiques :
 **Deck 1 : Fondamentaux** -- ce que nous allons couvrir :
 
 - Qu'est-ce que le trading algorithmique ? Profil du trader quant
-- Types de trading : HFT, MFT, LFT et leurs differences
+- Types de trading : HFT, MFT, LFT et leurs différences
 - Les acteurs du marche (Renaissance, Two Sigma, Citadel, QC)
 <div v-click="1">
 
@@ -99,7 +99,7 @@ Ce cours est organise en 3 decks thematiques :
 <div v-click="2">
 
 - Types d'ordres (Market, Limit, Stop, Trailing, Iceberg, OCO)
-- Trouver et evaluer une strategie (Sharpe, drawdown, pieges)
+- Trouver et evaluer une stratégie (Sharpe, drawdown, pieges)
 - Le livre de reference : *Hands-On AI Trading* (Wiley 2025)
 </div>
 
@@ -113,7 +113,7 @@ Ce cours est organise en 3 decks thematiques :
 
 <div v-click="1">
 
-- **Methodes d'analyse**
+- **Méthodes d'analyse**
   - Analyse technique (indicateurs, patterns graphiques)
   - Données fondamentales (revenus, indicateurs macroeconomiques)
   - Données extra-financieres (flux d'actualites, sentiment du marche)
@@ -123,7 +123,7 @@ Ce cours est organise en 3 decks thematiques :
 
 - **Universalite**
   - Tout ce qui est numerisable peut etre utilise en trading quantitatif
-  - Diversification facilitee sur plusieurs strategies simultanees
+  - Diversification facilitee sur plusieurs stratégies simultanees
 
 </div>
 
@@ -155,7 +155,7 @@ Ce cours est organise en 3 decks thematiques :
 </div>
 <div v-click="3">
 
-- **Experience pratique**
+- **Expérience pratique**
   - Finance et programmation cruciales
   - Avoir des economies pour les periodes sans gains
   - Discipline et gestion du stress indispensables
@@ -197,7 +197,7 @@ Ce cours est organise en 3 decks thematiques :
 </div>
 <div v-click="5">
 
-- **Message** : le trading algo n'est plus reserve aux institutions. Les outils modernes permettent a des individuels de developper et tester des strategies professionnelles.
+- **Message** : le trading algo n'est plus reserve aux institutions. Les outils modernes permettent a des individuels de developper et tester des stratégies professionnelles.
 
 </div>
 
@@ -207,14 +207,14 @@ Ce cours est organise en 3 decks thematiques :
 
 - **Scalabilite**
   - Augmenter les volumes sans effort supplementaire
-  - Gerer plusieurs strategies en parallele, sur differents marches
+  - Gerer plusieurs stratégies en parallele, sur différents marches
   - Passage a l'echelle impossible en trading manuel
 <div v-click="1">
 
 - **Optimisation du temps**
-  - Automatisation des taches repetitives (screening, execution)
+  - Automatisation des tâches repetitives (screening, exécution)
   - Plus de temps pour la recherche et l'amelioration des modèles
-  - Execution 24/7 sur les marches crypto et forex
+  - Exécution 24/7 sur les marches crypto et forex
 </div>
 
 ---
@@ -223,11 +223,11 @@ Ce cours est organise en 3 decks thematiques :
 
 - **Elimination des biais emotionnels**
   - Pas de peur, de cupidite ou d'hesitation
-  - Execution disciplinee selon des regles predefinies
-  - Resultats reproductibles et mesurables
+  - Exécution disciplinee selon des règles predefinies
+  - Résultats reproductibles et mesurables
 <div v-click="1">
 
-- **Autonomie et independance**
+- **Autonomie et indépendance**
   - Pas besoin de clients ni de mandats de gestion
   - Focus sur la performance pure du modèle
   - Possibilite de demarrer avec un capital modeste
@@ -238,15 +238,15 @@ Ce cours est organise en 3 decks thematiques :
 # Types de Trading Algorithmique (1/2)
 
 - **HFT (High-Frequency Trading)**
-  - Operations en millisecondes ou microsecondes
+  - Opérations en millisecondes ou microsecondes
   - Objectif: Exploiter de petites inefficacites du marche
   - Technologie: Necessite une infrastructure technologique de pointe
 
 <div v-click="1">
 
 - **MFT (Medium-Frequency Trading)**
-  - Operations sur des secondes, minutes a quelques heures
-  - Objectif: Arbitrage, suivi de tendance, et autres strategies
+  - Opérations sur des secondes, minutes a quelques heures
+  - Objectif: Arbitrage, suivi de tendance, et autres stratégies
   - Flexibilite: Moins exigeant technologiquement mais necessite une analyse de données robuste
 
 </div>
@@ -256,7 +256,7 @@ Ce cours est organise en 3 decks thematiques :
 # Types de Trading Algorithmique (2/2)
 
 - **LFT (Low-Frequency Trading)** -- notre terrain de jeu dans ce cours
-  - Operations sur des jours, semaines ou mois
+  - Opérations sur des jours, semaines ou mois
   - Objectif : investissement base sur des facteurs fondamentaux ou des indicateurs techniques
   - Accessible avec un PC personnel, Python, et un compte QC gratuit
 
@@ -264,9 +264,9 @@ Ce cours est organise en 3 decks thematiques :
 
 - **Notre positionnement dans ce cours**
   - Nous travaillons en **LFT** (rebalancement journalier a bimensuel)
-  - Capital simule de 100 000 $ pour la comparabilite entre strategies
+  - Capital simule de 100 000 $ pour la comparabilite entre stratégies
   - Objectif Sharpe > 0.5 (battre le buy-and-hold SPY), idealement > 1.0
-  - Les strategies MFT et HFT sont presentees pour la culture mais ne sont pas praticables dans notre cadre
+  - Les stratégies MFT et HFT sont presentees pour la culture mais ne sont pas praticables dans notre cadre
 
 </div>
 
@@ -284,7 +284,7 @@ Ce cours est organise en 3 decks thematiques :
 | **Capital min.** | > 1M$ | 10K - 100K$ | 1K - 50K$ |
 | **Infrastructure** | Co-location, FPGA | Serveur dedie | PC personnel |
 | **Competences** | C++, reseaux, hardware | Python, stats | Finance, analyse |
-| **Barriere a l'entrée** | Tres haute | Moyenne | Basse |
+| **Barriere a l'entrée** | Très haute | Moyenne | Basse |
 
 </div>
 
@@ -332,7 +332,7 @@ Un processus iteratif en 6 étapes :
   - Actions, Forex, Futures, Cryptomonnaies
 <div v-click="1">
 
-- **Roles des Participants**
+- **Rôles des Participants**
   - Traders particuliers, institutionnels, market makers, arbitragistes
   - Fournisseurs de liquidite, preneurs de liquidite
 
@@ -374,13 +374,13 @@ Un processus iteratif en 6 étapes :
 <div v-click="3">
 
 - **Cryptomonnaies**
-  - Monnaies numeriques qui utilisent la cryptographie pour securiser les transactions
+  - Monnaies numériques qui utilisent la cryptographie pour securiser les transactions
   - Aspects reglementaires variables
 </div>
 <div v-click="4">
 
 - **Classes d'actifs**
-  - Categories d'investissement (actions, obligations, matieres premieres)
+  - Catégories d'investissement (actions, obligations, matieres premières)
   - Diversification du risque
 
 </div>
@@ -396,7 +396,7 @@ imageClass: top-right visible
 # Analyse Technique et Fondamentale
 
 - **Analyse Technique**
-  - Etude des graphiques de prix et de volume
+  - Étude des graphiques de prix et de volume
   - Indicateurs : moyennes mobiles, RSI, MACD, Bollinger
   - Patterns : chandeliers, tete-epaules, triangles
   - Un chandelier encode 4 infos : open, close, high, low
@@ -412,7 +412,7 @@ imageClass: top-right visible
 <div v-click="2">
 
 - **Combinaison des deux approches**
-  - Technique pour le timing, fondamentale pour la selection
+  - Technique pour le timing, fondamentale pour la sélection
   - Les traders quantitatifs combinent les deux
 
 </div>
@@ -474,7 +474,7 @@ imageClass: mid-right visible
 <div v-click="3">
 
 - **Latence et Couts**
-  - Delais d'execution: Temps entre la soumission et l'execution d'un ordre
+  - Delais d'exécution: Temps entre la soumission et l'exécution d'un ordre
   - Couts de transaction: Frais associes a l'achat et a la vente d'actifs
 </div>
 <div v-click="4">
@@ -510,7 +510,7 @@ imageClass: mid-right visible
 <div v-click="2">
 
 - **Pourquoi c'est important**
-  - Comprendre le carnet d'ordres est fondamental pour toute strategie
+  - Comprendre le carnet d'ordres est fondamental pour toute stratégie
   - Les market makers profitent du spread
   - Les ordres iceberg cachent la vraie profondeur
 
@@ -523,14 +523,14 @@ imageClass: mid-right visible
 # Types d'Ordres Essentiels
 
 - **Market Order** (Ordre au marche)
-  - Execution immediate au meilleur prix disponible
+  - Exécution immediate au meilleur prix disponible
   - Simple mais risque de slippage en marche peu liquide
 
 <div v-click="1">
 
 - **Limit Order** (Ordre a cours limite)
-  - Execution au prix specifie ou mieux
-  - Controle du prix d'execution, mais pas de garantie d'execution
+  - Exécution au prix specifie ou mieux
+  - Contrôle du prix d'exécution, mais pas de garantie d'exécution
 
 </div>
 <div v-click="2">
@@ -561,14 +561,14 @@ imageClass: mid-right visible
 <div v-click="1">
 
 - **OCO (One-Cancels-Other)**
-  - Deux ordres lies : l'execution de l'un annule automatiquement l'autre
+  - Deux ordres lies : l'exécution de l'un annule automatiquement l'autre
   - Exemple : un take profit et un stop loss simultanes
 
 </div>
 <div v-click="2">
 
 - **OTO (One-Triggers-Other)**
-  - Un ordre declenche automatiquement un autre a son execution
+  - Un ordre declenche automatiquement un autre a son exécution
   - Exemple : achat declenche un stop loss automatique
 
 </div>
@@ -610,14 +610,14 @@ imageClass: mid-right visible
 
 ---
 
-# Trouver une Strategie qui vous Convient (1/2)
+# Trouver une Stratégie qui vous Convient (1/2)
 
 - **Sources d'Idees**
   - Articles academiques, blogs, forums, medias
-  - Suivi des meilleures strategies sur plateformes
+  - Suivi des meilleures stratégies sur plateformes
 <div v-click="1">
 
-- **Modification de Strategies**
+- **Modification de Stratégies**
   - Ajustements pour rentabilite
 
 </div>
@@ -628,7 +628,7 @@ imageClass: mid-right visible
 </div>
 <div v-click="3">
 
-- **Strategies qui vous conviennent**
+- **Stratégies qui vous conviennent**
   - Temps disponible: Temps complet vs temps partiel
   - Academiques vs. Publiques: Complexite vs simplicite
   - Competences en programmation: Elargit les options
@@ -639,7 +639,7 @@ imageClass: mid-right visible
 
 ---
 
-# Trouver une Strategie qui vous Convient (2/2)
+# Trouver une Stratégie qui vous Convient (2/2)
 
 - **Votre Capital de Trading**
   - Ancien minimum conseille de 50 000 $ (pattern day trader rule aux US)
@@ -649,7 +649,7 @@ imageClass: mid-right visible
 <div v-click="1">
 
 - **Votre Objectif**
-  - Revenu regulier : strategies a haute frequence de trades (scalping, mean-reversion intraday)
+  - Revenu regulier : stratégies a haute frequence de trades (scalping, mean-reversion intraday)
   - Gains en capital : suivi de tendance long terme (momentum, allocation tactique)
   - Couverture (hedging) : proteger un portefeuille existant contre les baisses de marche
 
@@ -659,13 +659,13 @@ imageClass: mid-right visible
 - **Votre Tolerance au Risque**
   - Quel drawdown maximum pouvez-vous supporter ? (10% conservateur, 25% modere, 50% agressif)
   - Horizon d'investissement : court terme (semaines) vs long terme (annees)
-  - Regle d'or : ne jamais trader de l'argent dont on ne peut pas se permettre la perte totale
+  - Règle d'or : ne jamais trader de l'argent dont on ne peut pas se permettre la perte totale
 
 </div>
 
 ---
 
-# Comment Evaluer une Strategie?
+# Comment Evaluer une Stratégie?
 
 - **Mesures Standard**
   - **Ratio de Sharpe** : SR = (R_p - R_f) / sigma_p -- le "Saint Graal" de l'evaluation
@@ -674,19 +674,19 @@ imageClass: mid-right visible
 
 <div v-click="1">
 
-- **Criteres de performance**
+- **Critères de performance**
   - Rendement annualise (CAGR) : le rendement compose annuel
   - Volatilite des rendements : mesure du risque
   - Ratio gain/perte moyen : taille moyenne des gains vs pertes
-  - Taux de reussite (win rate) : attention, un win rate de 30% peut etre tres profitable !
+  - Taux de reussite (win rate) : attention, un win rate de 30% peut etre très profitable !
 
 </div>
 <div v-click="2">
 
 - **Exemple concret**
-  - Strategie A : Rendement 15%, Volatilite 20% => Sharpe = 0.75
-  - Strategie B : Rendement 10%, Volatilite 8% => Sharpe = 1.25
-  - La strategie B est meilleure sur base ajustee au risque malgre un rendement brut plus faible
+  - Stratégie A : Rendement 15%, Volatilite 20% => Sharpe = 0.75
+  - Stratégie B : Rendement 10%, Volatilite 8% => Sharpe = 1.25
+  - La stratégie B est meilleure sur base ajustee au risque malgre un rendement brut plus faible
 
 </div>
 
@@ -694,19 +694,19 @@ imageClass: mid-right visible
 
 ---
 
-# Strategies Plausibles et leurs Pieges (1/2)
+# Stratégies Plausibles et leurs Pieges (1/2)
 
-- **Drawdowns** (la realite brutale de toute strategie)
+- **Drawdowns** (la realite brutale de toute stratégie)
   - Perte de valeur depuis un pic : profondeur, duree, et vitesse de recuperation a evaluer
-  - Exemple : notre meilleure strategie (EMA-Cross-Alpha, Sharpe 0.98) a un MaxDD de 19% -- acceptable
+  - Exemple : notre meilleure stratégie (EMA-Cross-Alpha, Sharpe 0.98) a un MaxDD de 19% -- acceptable
   - Mais InverseVolatility-Rank v1 avait un MaxDD de 54.7% -- inacceptable pour un capital réel
-  - Regle : si vous ne pouvez pas dormir avec votre drawdown, reduisez votre exposition
+  - Règle : si vous ne pouvez pas dormir avec votre drawdown, reduisez votre exposition
 <div v-click="1">
 
-- **Slippage** (l'ecart entre theorie et realite)
-  - Difference entre le prix prevu et le prix d'execution réelle
-  - Causes : volatilite, taille de l'ordre, liquidite du marche, latence du systeme
-  - Impact : peut transformer une strategie profitable en strategie perdante sur petits alphas
+- **Slippage** (l'ecart entre théorie et realite)
+  - Différence entre le prix prevu et le prix d'exécution réelle
+  - Causes : volatilite, taille de l'ordre, liquidite du marche, latence du système
+  - Impact : peut transformer une stratégie profitable en stratégie perdante sur petits alphas
 
 </div>
 <div v-click="2">
@@ -714,20 +714,20 @@ imageClass: mid-right visible
 - **Couts de Transaction** (le tueur silencieux de rendements)
   - Commissions : de 0$ (Robinhood) a 0.005$/action (Interactive Brokers)
   - Spread bid-ask : cout cache, particulierement significatif sur les small caps
-  - Impact proportionnel a la frequence : une strategie qui trade 50x/jour paie 50x plus qu'une strategie mensuelle
+  - Impact proportionnel a la frequence : une stratégie qui trade 50x/jour paie 50x plus qu'une stratégie mensuelle
 </div>
 <div v-click="3">
 
-- **Evolution du Marche** (les strategies ont une date de peremption)
+- **Evolution du Marche** (les stratégies ont une date de peremption)
   - Les anomalies disparaissent une fois publiees : les arbitrageurs les exploitent et les eliminent
   - Exemple : l'effet Janvier s'est fortement attenue depuis les annees 2000 (trop connu, trop exploite)
-  - Consequence : une strategie doit etre re-evaluee regulierement, pas juste deployee et oubliee
+  - Consequence : une stratégie doit etre re-evaluee regulierement, pas juste deployee et oubliee
 
 </div>
 
 ---
 
-# Strategies Plausibles et leurs Pieges (2/2)
+# Stratégies Plausibles et leurs Pieges (2/2)
 
 - **Changements de Regime** (le risque le plus sous-estime)
   - Les données historiques pre-COVID ne predisent pas le comportement post-COVID
@@ -737,15 +737,15 @@ imageClass: mid-right visible
 <div v-click="1">
 
 - **Overfitting** (le piege le plus courant en trading quantitatif)
-  - Plus vous testez de strategies, plus vous trouverez de "faux positifs" par hasard
+  - Plus vous testez de stratégies, plus vous trouverez de "faux positifs" par hasard
   - Un Sharpe de 2.0 sur 3 ans avec 50 paramètres est probablement du surajustement
-  - Regle : si votre strategie ne marche que sur une periode precise, elle est overfittee
+  - Règle : si votre stratégie ne marche que sur une periode precise, elle est overfittee
 
 </div>
 <div v-click="2">
 
 - **Frais de financement** (le cout cache du levier)
-  - Positions a marge : interet annuel sur le capital emprunte (4-8% en 2024-2026)
+  - Positions a marge : intérêt annuel sur le capital emprunte (4-8% en 2024-2026)
   - Short selling : cout d'emprunt des titres + risque de rappel (short squeeze, cf. GameStop 2021)
   - Ces frais erosent la performance réelle par rapport au backtest "ideal"
 
@@ -755,7 +755,7 @@ imageClass: mid-right visible
 
 ---
 
-# Intelligence Artificielle et Selection de Stocks
+# Intelligence Artificielle et Sélection de Stocks
 
 - **Scepticisme initial sur l'IA**
   - Tendance a surajuster les données historiques
@@ -771,10 +771,10 @@ imageClass: mid-right visible
 </div>
 <div v-click="2">
 
-- **Strategies "Sous le Radar"**
+- **Stratégies "Sous le Radar"**
   - Marches de niche a faible capacité (small caps, crypto alt coins)
   - Moins d'arbitrage par les grands fonds qui ne s'y interessent pas
-  - Opportunite pour les traders individuels et les petites equipes
+  - Opportunite pour les traders individuels et les petites équipes
 </div>
 <div v-click="3">
 
@@ -784,7 +784,7 @@ imageClass: mid-right visible
 
 </div>
 
-> Ref: *Hands-On AI Trading* Ch9 "Role of GenAI in Creating Alpha" p.341
+> Ref: *Hands-On AI Trading* Ch9 "Rôle of GenAI in Creating Alpha" p.341
 
 ---
 
@@ -794,7 +794,7 @@ imageClass: mid-right visible
 
 <div v-click="1">
 
-- **FAUX** : Beaucoup de strategies perdent de l'argent. Sur nos 67 strategies backtestees, certaines ont un Sharpe negatif.
+- **FAUX** : Beaucoup de stratégies perdent de l'argent. Sur nos 67 stratégies backtestees, certaines ont un Sharpe negatif.
 
 </div>
 
@@ -834,6 +834,6 @@ imageClass: mid-right visible
 layout: section
 ---
 
-# Suite : Strategies et Gestion du Risque
+# Suite : Stratégies et Gestion du Risque
 
 Deck 2

--- a/slides/S4-trading-algorithmique/deck-2-strategies.md
+++ b/slides/S4-trading-algorithmique/deck-2-strategies.md
@@ -1,7 +1,7 @@
 ---
 theme: ../theme-ia101
-title: "S4 Trading Algorithmique - Partie 2 : Strategies et Risque"
-info: Cours Intelligence Artificielle - Strategies de Trading et Gestion du Risque
+title: "S4 Trading Algorithmique - Partie 2 : Stratégies et Risque"
+info: Cours Intelligence Artificielle - Stratégies de Trading et Gestion du Risque
 paginate: true
 drawings:
   persist: false
@@ -10,7 +10,7 @@ mdc: true
 layout: cover
 ---
 
-# Strategies de Trading et Gestion du Risque
+# Stratégies de Trading et Gestion du Risque
 
 Intelligence Artificielle -- S4 -- Partie 2
 
@@ -19,7 +19,7 @@ Intelligence Artificielle -- S4 -- Partie 2
 - Backtesting et plateformes (Lean/QuantConnect)
 - Mesures de performance et pieges
 - Gestion du risque (Kelly, VaR, psychologie)
-- Strategies classiques : mean reversion, momentum, regime switching, factoriels
+- Stratégies classiques : mean reversion, momentum, regime switching, factoriels
 - Panorama ML/AI : du Random Forest aux LLMs
 - Lecons du terrain : 67 projets backtestes, echecs inclus
 
@@ -30,16 +30,16 @@ Livre de reference : *Hands-On AI Trading* (Pik, Chan, Broad, Sun, Singh -- Wile
 # Backtesting (1/2)
 
 - **Le backtesting : votre laboratoire de trading**
-  - Simulation d'une strategie sur des données historiques (prix, volumes, fondamentaux)
-  - Question fondamentale : *"Si j'avais applique cette strategie en 2015, qu'aurais-je obtenu ?"*
-  - C'est la premiere étape obligatoire AVANT d'engager le moindre centime de capital réel
+  - Simulation d'une stratégie sur des données historiques (prix, volumes, fondamentaux)
+  - Question fondamentale : *"Si j'avais applique cette stratégie en 2015, qu'aurais-je obtenu ?"*
+  - C'est la première étape obligatoire AVANT d'engager le moindre centime de capital réel
 <div v-click="1">
 
 - **Pourquoi c'est important**
   - Valider l'efficacite de la recherche avant d'engager du capital réel
   - Experimenter avec des variations (paramètres, periodes, actifs, univers)
   - Estimer les metriques cles : Sharpe, CAGR, drawdown max, win rate, nombre de trades
-  - Comparer objectivement plusieurs strategies entre elles sur la meme periode
+  - Comparer objectivement plusieurs stratégies entre elles sur la même periode
 
 </div>
 <div v-click="2">
@@ -63,11 +63,11 @@ Livre de reference : *Hands-On AI Trading* (Pik, Chan, Broad, Sun, Singh -- Wile
   - Données ajustees pour les splits et dividendes : risque de faux signaux historiques
   - Biais de survie : les entreprises faillies disparaissent des données (vos backtests ne testent que les "gagnants")
   - Slippage et couts de transaction : le backtest "parfait" n'existe pas en conditions réelles
-  - **Regle empirique : le rendement live est 30 a 50% inferieur au backtest** -- prevoir cette marge
+  - **Règle empirique : le rendement live est 30 a 50% inferieur au backtest** -- prevoir cette marge
 <div v-click="1">
 
 - **Dans le cas ou le Machine Learning est utilise**
-  - Le backtesting doit prendre en compte les biais de selection de données
+  - Le backtesting doit prendre en compte les biais de sélection de données
   - Separer convenablement les ensembles (training, validation, test)
   - Evaluer la generalisation sur des données jamais vues
   - **Walk-forward** : decoupe temporelle glissante (jamais de shuffle)
@@ -79,7 +79,7 @@ Livre de reference : *Hands-On AI Trading* (Pik, Chan, Broad, Sun, Singh -- Wile
   - Periode standard : 2015-2026 (11 ans, couvrant bull + bear + COVID + hausse taux)
   - Toujours comparer au benchmark (SPY buy-and-hold, Sharpe ~0.50)
   - Reporter Sharpe, CAGR, MaxDD, et nombre de trades
-  - Capital initial standard : 100 000$ pour la comparabilite entre strategies
+  - Capital initial standard : 100 000$ pour la comparabilite entre stratégies
 
 </div>
 
@@ -97,7 +97,7 @@ Livre de reference : *Hands-On AI Trading* (Pik, Chan, Broad, Sun, Singh -- Wile
 <div v-click="1">
 
 - **MATLAB**
-  - Utilise en institutionnel, excellent pour tester des strategies sur de grands portefeuilles
+  - Utilise en institutionnel, excellent pour tester des stratégies sur de grands portefeuilles
   - Modules statistiques avances (Financial Toolbox, Econometrics Toolbox)
   - Inconvenients: Couteux (~2000$/an) et moins efficace pour executer les trades
 
@@ -121,7 +121,7 @@ Livre de reference : *Hands-On AI Trading* (Pik, Chan, Broad, Sun, Singh -- Wile
 # Plateformes de Backtesting (2/2)
 
 - **TradeStation et autres plateformes proprietaires**
-  - Execution + données integrees, mais langage proprietaire (EasyLanguage) et lock-in courtier
+  - Exécution + données integrees, mais langage proprietaire (EasyLanguage) et lock-in courtier
 
 <div v-click="1">
 
@@ -157,7 +157,7 @@ Livre de reference : *Hands-On AI Trading* (Pik, Chan, Broad, Sun, Singh -- Wile
 
 - **Avantages techniques**
   - Données ajustees (splits, dividendes) : 75,000+ actions US, 100+ forex, 200+ crypto, futures, options
-  - Framework modulaire : Alpha, Portfolio, Risk, Execution (separation des responsabilites)
+  - Framework modulaire : Alpha, Portfolio, Risk, Exécution (separation des responsabilites)
   - ML natif sur le cloud (sklearn, numpy, pandas), paper trading -> live sans changement de code
   - Exemples crypto : `projects/EMA-Cross-Crypto`, `projects/BTC-MACD-ADX`
 
@@ -168,7 +168,7 @@ Livre de reference : *Hands-On AI Trading* (Pik, Chan, Broad, Sun, Singh -- Wile
   - **AlphaModel** : signaux (direction + magnitude + confiance)
   - **PortfolioConstructionModel** : traduit signaux en poids de portefeuille
   - **RiskManagementModel** : limites (MaxDD, trailing stop, position max)
-  - **ExecutionModel** : execution des ordres (VWAP, immediat, market on close)
+  - **ExecutionModel** : exécution des ordres (VWAP, immediat, market on close)
   - Debut : `QC-Py-01-Setup.ipynb` puis `QC-Py-02-Platform-Fundamentals.ipynb`
 
 </div>
@@ -216,7 +216,7 @@ imageClass: mid-right visible
 </div>
 <div v-click="2">
 
-- **Regles pratiques d'interpretation**
+- **Règles pratiques d'interpretation**
   - Sharpe > 0.5 : acceptable, > 1.0 : bon, > 2.0 : excellent (mais verifier l'overfitting)
   - MaxDD < 20% : acceptable pour la plupart des investisseurs (institutionnels : < 10%)
   - Minimum 100 trades pour la significativite statistique
@@ -232,15 +232,15 @@ imageClass: mid-right visible
 - **Look-ahead bias** (le piege le plus dangereux et le plus sournois)
   - Utilisation de données decalees (toujours `shift(1)` en pandas, `History()` en QC)
   - Forward-testing (paper trading) pour valider en conditions réelles sans biais
-  - Exemple classique : utiliser le prix de cloture du jour pour decider d'acheter le meme jour
+  - Exemple classique : utiliser le prix de cloture du jour pour decider d'acheter le même jour
   - Autre piege : normaliser les features sur toute la periode (inclut le futur dans la normalisation)
 <div v-click="1">
 
 - **Data-Snooping Bias** (overfitting sur l'historique -- le tueur silencieux)
   - Peu de paramètres : chaque paramètre est une opportunite d'overfitting
   - Augmentation, division et adaptation des données de backtest (cross-temporal validation)
-  - Test de robustesse : la strategie marche-t-elle sur des periodes/actifs differents ?
-  - Test de Bonferroni : corriger pour les tests multiples (si vous testez 100 strategies, 5 seront "significatives" par hasard a 5%)
+  - Test de robustesse : la stratégie marche-t-elle sur des periodes/actifs différents ?
+  - Test de Bonferroni : corriger pour les tests multiples (si vous testez 100 stratégies, 5 seront "significatives" par hasard a 5%)
   - "If you torture the data long enough, it will confess to anything" -- Ronald Coase
 
 </div>
@@ -251,16 +251,16 @@ imageClass: mid-right visible
 
 - **Modèles de trading sans paramètres** (le Graal de la robustesse)
   - Pas de surajustement possible, fiabilite maximale mais alpha plus faible
-  - Exemple : momentum pur (acheter les 10% meilleurs du mois precedent, vendre les 10% pires)
-  - Le seul "paramètre" est la fenetre temporelle (3, 6, 12 mois) -- tres etudie academiquement
+  - Exemple : momentum pur (acheter les 10% meilleurs du mois précédent, vendre les 10% pires)
+  - Le seul "paramètre" est la fenêtre temporelle (3, 6, 12 mois) -- très etudie academiquement
 
 <div v-click="1">
 
-- **Validation out-of-sample** (la regle d'or de tout backtest serieux)
+- **Validation out-of-sample** (la règle d'or de tout backtest serieux)
   - Split temporel 60/20/20 : entrainement, validation, test final -- jamais de shuffle temporel
-  - Walk-forward : fenetre glissante qui avance dans le temps (simule un deploiement réel)
+  - Walk-forward : fenêtre glissante qui avance dans le temps (simule un deploiement réel)
   - Si le Sharpe chute de >50% hors-echantillon, c'est probablement de l'overfitting
-  - Toutes nos strategies sont backtestees sur 2015-2026 (11 ans, couvrant bull + bear + COVID + hausse des taux)
+  - Toutes nos stratégies sont backtestees sur 2015-2026 (11 ans, couvrant bull + bear + COVID + hausse des taux)
 
 </div>
 
@@ -287,18 +287,18 @@ layout: compact
 <div v-click="3">
 
 - **Repartition du capital de trading** (diversification des alphas)
-  - Repartir entre differentes strategies decorreles pour diminuer la variance globale
+  - Repartir entre différentes stratégies decorreles pour diminuer la variance globale
   - Exemple : 40% trend, 30% mean-reversion, 30% factoriel
 </div>
 <div v-click="4">
 
 - **Couts de Transaction** (souvent sous-estimes)
-  - A integrer dans le Backtest pour des resultats plus realistes
+  - A integrer dans le Backtest pour des résultats plus realistes
   - Composantes : commissions + spread + slippage + impact de marche (pour les gros ordres)
 </div>
 <div v-click="5">
 
-- **Derive des données (data drift)** (le probleme fondamental)
+- **Derive des données (data drift)** (le problème fondamental)
   - Revalider les modèles regulierement (trimestriel minimum)
   - Ce qui marchait il y a 5 ans peut ne plus marcher (regime change)
 
@@ -308,10 +308,10 @@ layout: compact
 
 ---
 
-# Affinement de la Strategie
+# Affinement de la Stratégie
 
-- **Le Probleme** (l'erosion inevitable de l'alpha -- la "loi de la jungle" des marches)
-  - Rendements diminuent quand une strategie devient populaire (alpha decay)
+- **Le Problème** (l'erosion inevitable de l'alpha -- la "loi de la jungle" des marches)
+  - Rendements diminuent quand une stratégie devient populaire (alpha decay)
   - Le marche est un ecosysteme adaptatif : les participants copient ce qui marche, ce qui annule l'avantage
   - Exemple frappant : l'anomalie du "low P/E" (Basu, 1977) a ete reduite de 50% depuis sa publication
 <div v-click="1">
@@ -320,14 +320,14 @@ layout: compact
   - Variations Mineures: Petites variations de paramètres peuvent ameliorer les rendements
   - Exclusion de Stocks: Eviter certains types d'actions (micro-caps illiquides, ADRs)
   - Changement de Timing: Ajuster les points d'entrée et de sortie (rebalancing frequency)
-  - Innovation: Combiner des alphas connus de manière originale (composite strategies)
+  - Innovation: Combiner des alphas connus de manière originale (composite stratégies)
 
 </div>
 <div v-click="2">
 
 - **Exemple du depot : evolution progressive**
   - `EMA-Cross-Stocks` (0.87) -> `EMA-Cross-Alpha` (0.98) -> `EMATrend-Composite` (0.87) -> `Framework_Composite_TrendWeather` (1.16)
-  - Chaque iteration ajoute sophistication mais aussi risque d'overfitting
+  - Chaque itération ajoute sophistication mais aussi risque d'overfitting
 
 </div>
 
@@ -335,11 +335,11 @@ layout: compact
 layout: dense
 ---
 
-# Panorama des Strategies (1/2) -- Classiques
+# Panorama des Stratégies (1/2) -- Classiques
 
 <div class="colored-table">
 
-| Strategie | Categorie | Sharpe | CAGR | MaxDD | Periode |
+| Stratégie | Catégorie | Sharpe | CAGR | MaxDD | Periode |
 |-----------|-----------|--------|------|-------|---------|
 | **Framework_Composite_TrendWeather** | Composite | 1.155 | 19.3% | -14.2% | 2015-2026 |
 | **EMA-Cross-Alpha** | Trend | 0.980 | 17.8% | -18.5% | 2015-2026 |
@@ -360,11 +360,11 @@ Echecs pedagogiques : PairsTrading (-0.36), ForexCarry (-0.32), InverseVolatilit
 layout: dense
 ---
 
-# Panorama des Strategies (2/2) -- ML/AI
+# Panorama des Stratégies (2/2) -- ML/AI
 
 <div class="colored-table">
 
-| Strategie | Modèle ML | Sharpe | Ref Livre |
+| Stratégie | Modèle ML | Sharpe | Ref Livre |
 |-----------|----------|--------|-----------|
 | **ML-Random-Forest** | Random Forest | 0.903 | Ch5 Ex09 |
 | **XGBoost-Classification** | XGBoost | 0.571 | Ch5 |
@@ -414,8 +414,8 @@ layout: compact
 # Lecon M15 : l'horizon de prediction est un hyperparametre critique
 
 - **L'hypothese de base** : "LSTM ne marche pas en finance" est **fausse** -- c'est l'horizon h=1 qui ne marche pas
-- Sur SPY/TLT (actions/obligations) : le signal reste faible meme a h>1 (ratio signal/bruit trop bas)
-- Sur crypto : la vol structurelle cree des tendances exploitables aux horizons 1-6 mois
+- Sur SPY/TLT (actions/obligations) : le signal reste faible même a h>1 (ratio signal/bruit trop bas)
+- Sur crypto : la vol structurelle créé des tendances exploitables aux horizons 1-6 mois
 
 - **Implication pratique pour le quant** :
   1. Ne pas rejeter un modèle sur un seul horizon -- tester h=1, 5, 22, 66, 132
@@ -441,15 +441,15 @@ layout: compact
 - **Maximisation de la Croissance** (formule fondamentale)
   - Objectif : maximiser la croissance **composee** (geometrique) du capital a long terme
   - Formule : g = m - s^2/2 (la croissance composee est REDUITE par la variance)
-  - Implication contre-intuitive : reduire la variance augmente la croissance meme a rendement egal
+  - Implication contre-intuitive : reduire la variance augmente la croissance même a rendement egal
   - Exemple : 10% rendement, 20% vol -> g = 8% ; 10% rendement, 40% vol -> g = 2%
 
 </div>
 <div v-click="2">
 
-- **Eviter la Ruine** (la regle numero zero)
+- **Eviter la Ruine** (la règle numéro zero)
   - Drawdown : mesure de la pire chute depuis le dernier sommet (peak-to-trough)
-  - Regle pratique : limiter le risque a 1-2% du capital par trade (position sizing)
+  - Règle pratique : limiter le risque a 1-2% du capital par trade (position sizing)
   - Exemple du depot : `AllWeather` MaxDD -15% vs `MomentumStrategy` MaxDD -25%
   - La probabilité de ruine augmente exponentiellement avec le levier
 
@@ -474,12 +474,12 @@ imageClass: mid-right visible
 - **Value-at-Risk (VaR)**
   - Estime la perte maximale potentielle sur une periode avec un niveau de confiance
   - Exemple : VaR 95% journaliere = 2% signifie qu'on a 5% de chances de perdre plus de 2%
-  - Methodes : historique, parametrique (gaussien), Monte Carlo
+  - Méthodes : historique, parametrique (gaussien), Monte Carlo
 </div>
 <div v-click="2">
 
 - **Conditional Value-at-Risk (CVaR / Expected Shortfall)**
-  - Estime la perte moyenne au-dela du VaR (dans les pires scenarios)
+  - Estime la perte moyenne au-dela du VaR (dans les pires scénarios)
   - Plus conservateur que le VaR, prend en compte les "fat tails"
   - Prefere par les regulateurs (Bale III) car le CVaR est sous-additif (coherent)
 
@@ -493,11 +493,11 @@ imageClass: mid-right visible
 
 # Exemple : Formule de Kelly en Pratique
 
-- **Scenario typique d'une strategie quantitative**
+- **Scénario typique d'une stratégie quantitative**
   - Probabilité de gain (p) = 55%, Probabilité de perte (q) = 45%
   - Gains moyens = 2%, Pertes moyennes = 1.5%
   - Ratio gain/perte (b) = 2% / 1.5% = 1.33
-  - Ce scenario est realiste : une bonne strategie gagne un peu plus souvent qu'elle ne perd
+  - Ce scénario est realiste : une bonne stratégie gagne un peu plus souvent qu'elle ne perd
 
 <div v-click="1">
 
@@ -505,7 +505,7 @@ imageClass: mid-right visible
   - f* = (p x b - q) / b = (0.55 x 1.33 - 0.45) / 1.33
   - f* = (0.73 - 0.45) / 1.33 = **0.21 soit 21% du capital** par trade (Kelly plein)
   - Demi-Kelly : 10.5% -- recommande en pratique (marge de securite, paramètres incertains)
-  - Quart-Kelly : 5.25% -- pour les traders tres conservateurs
+  - Quart-Kelly : 5.25% -- pour les traders très conservateurs
   - La plupart des fonds ne risquent que 1-5% par trade (beaucoup moins que Kelly)
 
 </div>
@@ -514,10 +514,10 @@ imageClass: mid-right visible
 
 # Formule de Kelly : Intuition et Limites
 
-- **Theorie vs pratique**
+- **Théorie vs pratique**
   - Kelly maximise la croissance composee a long terme (geometrique, pas arithmetique)
   - Un sur-levier (miser plus que Kelly) garantit la ruine mathematique a long terme
-  - La distribution normale sous-estime les evenements extremes ("fat tails")
+  - La distribution normale sous-estime les événements extremes ("fat tails")
 <div v-click="1">
 
 - **En pratique**
@@ -538,16 +538,16 @@ imageClass: mid-right visible
 <div v-click="1">
 
 - **Contagion Financiere** (risque systemique)
-  - 2008 (Lehman) et 2020 (COVID) : tous les actifs baissent en meme temps
+  - 2008 (Lehman) et 2020 (COVID) : tous les actifs baissent en même temps
   - Diversifier entre classes decorreles, mais les correlations augmentent en crise
 
 </div>
 <div v-click="2">
 
-- **Evenements Extremes (Black Swans, Nassim Taleb)**
+- **Événements Extremes (Black Swans, Nassim Taleb)**
   - Kelly ne prend pas en compte les "fat tails" (queues epaisses, kurtosis > 3)
-  - Un evenement "6 sigma" arrive tous les 5-10 ans au lieu de 1x par 1.5M jours
-  - Gestion : VaR, CVaR, stress testing, scenarios Monte Carlo
+  - Un événement "6 sigma" arrive tous les 5-10 ans au lieu de 1x par 1.5M jours
+  - Gestion : VaR, CVaR, stress testing, scénarios Monte Carlo
 
 </div>
 <div v-click="3">
@@ -568,14 +568,14 @@ layout: compact
 - **Risque de Modèle** (le risque que votre modèle soit faux)
   - Biais de survie, biais de lookahead, et erreurs de données (garbage in, garbage out)
   - Changements structurels du marche : nouvelles reglementations, innovations technologiques
-  - Exemple : une strategie entrainee pre-COVID echoue pendant le COVID (changement de regime)
-  - Exemple : une strategie de carry FX qui marchait avant 2020 echoue apres (taux convergents)
+  - Exemple : une stratégie entrainee pre-COVID echoue pendant le COVID (changement de regime)
+  - Exemple : une stratégie de carry FX qui marchait avant 2020 echoue après (taux convergents)
 
 <div v-click="1">
 
 - **Risque Logiciel** (la machine peut se tromper aussi)
   - Bugs, latence et decalages de données (data feed delayed de quelques secondes)
-  - Assurez-vous que le systeme de trading automatise est bien teste et surveille 24/7
+  - Assurez-vous que le système de trading automatise est bien teste et surveille 24/7
   - Exemple celebre : Knight Capital (2012), bug de deploiement, perte de 440M$ en 45 minutes
   - Exemple : un off-by-one dans l'indice des données = look-ahead bias invisible
 
@@ -587,7 +587,7 @@ layout: compact
   - Solution de secours obligatoire : serveurs redondants, plan de recuperation
   - Risque de liquidite : impossible de sortir d'une position pendant un flash crash (bid vide)
   - Risque de contrepartie : faillite du courtier (MF Global 2011 : 1.6Md$, FTX 2022 : 8Md$)
-  - Risque reglementaire : changement de regles en cours de jeu (interdiction du short selling, etc.)
+  - Risque reglementaire : changement de règles en cours de jeu (interdiction du short selling, etc.)
 
 </div>
 
@@ -595,22 +595,22 @@ layout: compact
 
 # Preparation Psychologique (1/2)
 
-- **Emotions en Trading** (meme en algo, le trader doit gerer sa psychologie)
+- **Emotions en Trading** (même en algo, le trader doit gerer sa psychologie)
   - Overtrading en periode de gains : "je suis un genie, augmentons le levier"
   - Aversion au risque en periode de pertes : desactiver l'algo au pire moment (panic exit)
-  - Tentation de modifier les paramètres apres chaque perte (tweaking compulsif)
+  - Tentation de modifier les paramètres après chaque perte (tweaking compulsif)
   - Le trading algorithmique ne supprime PAS l'emotion : il la deplace vers la supervision
-  - Etude : 80% des traders retail perdent de l'argent, principalement a cause de biais psychologiques
+  - Étude : 80% des traders retail perdent de l'argent, principalement a cause de biais psychologiques
 
 <div v-click="1">
 
 - **Biais Comportementaux** (Kahneman & Tversky, Prospect Theory, prix Nobel 2002)
-  - **Effet de dotation** : surestimer ce qu'on possede deja (garder une position perdante trop longtemps)
+  - **Effet de dotation** : surestimer ce qu'on possede déjà (garder une position perdante trop longtemps)
   - **Aversion a la perte** : une perte de 1000$ fait 2x plus mal qu'un gain de 1000$ ne fait plaisir
   - **Biais de confirmation** : ne chercher que les preuves qui confirment notre these initiale
-  - **Biais de representativite** : "la derniere fois que ca ressemblait a ca, le marche a monte"
+  - **Biais de representativite** : "la dernière fois que ca ressemblait a ca, le marche a monte"
   - **Ancrage** : fixer un "prix d'achat" mental qui influence irrationnellement les decisions de vente
-  - **Illusion de controle** : croire qu'on peut predire le marche mieux que les autres
+  - **Illusion de contrôle** : croire qu'on peut predire le marche mieux que les autres
 
 </div>
 
@@ -629,15 +629,15 @@ layout: compact
   - Commencez petit : paper trading pendant 3 mois minimum
   - Ne jamais trader l'argent dont on a besoin (tampon financier obligatoire)
   - Tenir un journal de trading : decisions ET emotions (post-mortem regulier)
-  - Regles de pause : apres 3 pertes consecutives, arreter pour la journee
+  - Règles de pause : après 3 pertes consecutives, arreter pour la journee
 
 </div>
 <div v-click="2">
 
 - **Avantage du trading algorithmique**
   - L'algo execute sans emotion, mais le trader doit resister a l'envie de le "debrancher"
-  - Regle : definir les regles de supervision AVANT le deploiement (MaxDD, perte max/jour)
-  - Arret automatique si regles violees : `MaximumDrawdownPercentPerSecurity`
+  - Règle : définir les règles de supervision AVANT le deploiement (MaxDD, perte max/jour)
+  - Arret automatique si règles violees : `MaximumDrawdownPercentPerSecurity`
 
 </div>
 
@@ -647,7 +647,7 @@ image: ./images/bollinger_bands.png
 imageClass: mid-right visible
 ---
 
-# Strategies de Moyenne Reversion
+# Stratégies de Moyenne Reversion
 
 - **Moyenne Reversion** (concept fondamental en finance)
   - Les prix tendent a revenir vers une moyenne a long terme (hypothese d'Ornstein-Uhlenbeck)
@@ -657,7 +657,7 @@ imageClass: mid-right visible
 <div v-click="1">
 
 - **Pieges courants** (pourquoi la mean-reversion est difficile)
-  - Biais de Survie : actifs delistes faussent les resultats (ils ne "revertent" pas, ils disparaissent)
+  - Biais de Survie : actifs delistes faussent les résultats (ils ne "revertent" pas, ils disparaissent)
   - Co-integration necessaire (pas juste la correlation -- la correlation peut changer sans warning)
   - Plus une anomalie est connue, plus elle s'erode (alpha decay accelere par les ETFs smart-beta)
 </div>
@@ -666,14 +666,14 @@ imageClass: mid-right visible
 
 # Mean Reversion : Projets et Lecons
 
-- **Projets du depot** (resultats backtestes 2015-2026)
+- **Projets du depot** (résultats backtestes 2015-2026)
   - `MeanReversion` (Sharpe 0.29) -- RSI mean-reversion classique sur actions US
   - `PairsTrading` (Sharpe -0.36) -- Echec pedagogique : co-integration instable dans le temps
   - `TrendFilteredMeanReversion` (Sharpe -0.02) -- Mean reversion + filtre SMA200
 <div v-click="1">
 
-- **Pourquoi les resultats sont modestes** (ce que nos backtests revelent)
-  - La mean-reversion fonctionne sur des horizons courts (intraday, quelques jours) mais nos strategies operent en daily/weekly
+- **Pourquoi les résultats sont modestes** (ce que nos backtests revelent)
+  - La mean-reversion fonctionne sur des horizons courts (intraday, quelques jours) mais nos stratégies operent en daily/weekly
   - Sur actions US : le momentum domine le mean-reversion depuis 2010 (marche haussier structurel)
   - Le pairs trading exige une co-integration stable, mais les relations entre actifs derivent (regime changes)
   - Le filtre SMA200 ajoute du "cash drag" : on est souvent hors-marche pendant les meilleures periodes
@@ -694,11 +694,11 @@ image: ./images/macd_chart.png
 imageClass: top-right visible
 ---
 
-# Strategies Fondamentales de Momentum
+# Stratégies Fondamentales de Momentum
 
 - **Momentum** (anomalie la plus documentee en finance)
   - Un actif qui monte tend a continuer a monter
-  - Jegadeesh & Titman (1993) : effet present 30+ ans apres
+  - Jegadeesh & Titman (1993) : effet present 30+ ans après
   - Le MACD est un indicateur classique de momentum
   - Principe : acheter les "gagnants" 3-12 mois, vendre les "perdants"
 <div v-click="1">
@@ -720,7 +720,7 @@ imageClass: top-right visible
 
 ---
 
-# Momentum : Projets et Resultats
+# Momentum : Projets et Résultats
 
 - **Projets du depot** (backtestes 2015-2026)
   - `EMA-Cross-Alpha` (Sharpe 0.98) -- croisement de moyennes mobiles optimise, notre meilleur alpha
@@ -729,7 +729,7 @@ imageClass: top-right visible
   - `DualMomentum` (Sharpe 0.35) -- momentum absolu + relatif (Gary Antonacci)
 <div v-click="1">
 
-- **Ce que nos resultats confirment** (patterns recurrents)
+- **Ce que nos résultats confirment** (patterns recurrents)
   - Le momentum simple (EMA crossover) bat les approches plus sophistiquees sur nos données
   - La rotation sectorielle ajoute de la diversification mais reduit le Sharpe vs stock-picking
   - Le DualMomentum est plus defensif (meilleur MaxDD) mais sacrifie du rendement
@@ -737,7 +737,7 @@ imageClass: top-right visible
 </div>
 <div v-click="2">
 
-- **Lecon** : le momentum est la strategie la plus robuste historiquement, malgre les "crash risks"
+- **Lecon** : le momentum est la stratégie la plus robuste historiquement, malgre les "crash risks"
   - Notebook : `QC-Py-13-Alpha-Models.ipynb`
 
 </div>
@@ -746,10 +746,10 @@ imageClass: top-right visible
 
 ---
 
-# Strategies de Regime Switching (1/2)
+# Stratégies de Regime Switching (1/2)
 
 - **Concept & Types de regimes**
-  - Les Marches varient entre differents regimes qui changent les correlations et la volatilite
+  - Les Marches varient entre différents regimes qui changent les correlations et la volatilite
   - Regimes typiques : haussier/baissier, haute/basse volatilite, inflation/deflation, risk-on/risk-off
   - La Prediction de ces regimes est un defi majeur : les transitions sont rares et soudaines
   - Exemple : le passage au regime COVID (mars 2020) en quelques jours
@@ -769,14 +769,14 @@ imageClass: top-right visible
 layout: compact
 ---
 
-# Strategies de Regime Switching (2/2)
+# Stratégies de Regime Switching (2/2)
 
 - **Modèles probabilistes** (l'elite de la detection de regime)
   - **HMM** (Hidden Markov Models) : detectent les regimes latents (bull/bear/sideways)
   - **Filtre de Kalman** : estimation continue de l'etat cache du marche en temps réel
   - **GARCH a regimes** : volatilite conditionnelle qui change selon l'etat du marche
   - Necessite un modèle de variables hypothetiques ou variables latentes
-  - Tres puissant mais complexe a calibrer : choix du nombre d'etats, initialisation sensible
+  - Très puissant mais complexe a calibrer : choix du nombre d'etats, initialisation sensible
 
 <div v-click="1">
 
@@ -805,7 +805,7 @@ layout: compact
 - **VWAP - Volume Weighted Average Price**
   - Objectif: Obtenir un prix moyen pondere par le volume sur la journee
   - Utilisation: Frequemment utilise en trading institutionnel pour minimiser l'impact du marche
-  - Mecanisme: Calcule le rapport cout/volume a des intervalles reguliers et execute des ordres en fonction
+  - Mécanisme: Calcule le rapport cout/volume a des intervalles reguliers et execute des ordres en fonction
   - Un ordre est "bien execute" s'il bat le VWAP
 
 <div v-click="1">
@@ -813,16 +813,16 @@ layout: compact
 - **TWAP - Time Weighted Average Price**
   - Objectif: Obtenir un prix moyen pondere par le temps
   - Utilisation: Utilise lorsque l'impact du volume sur le prix est moins pertinent
-  - Mecanisme: Divise un gros ordre en plus petits morceaux, executes a intervalles reguliers
+  - Mécanisme: Divise un gros ordre en plus petits morceaux, executes a intervalles reguliers
   - Plus simple que VWAP, utile pour les marches peu liquides
 </div>
 <div v-click="2">
 
-- **TWAP/VWAP sont les standards de l'execution institutionnelle**
+- **TWAP/VWAP sont les standards de l'exécution institutionnelle**
   - Pour eviter un prix moyen trop deforme par un seul gros ordre (market impact)
   - QuantConnect Lean offre un `VolumeWeightedAveragePriceExecutionModel` natif
-  - Dans le framework : c'est le role de l'**ExecutionModel** (separe de la strategie)
-  - Pour un retail trader : les ordres sont assez petits pour que l'execution immediate suffise
+  - Dans le framework : c'est le rôle de l'**ExecutionModel** (separe de la stratégie)
+  - Pour un retail trader : les ordres sont assez petits pour que l'exécution immediate suffise
 
 </div>
 
@@ -832,10 +832,10 @@ image: ./images/security_market_line.png
 imageClass: top-right visible
 ---
 
-# Strategies Basees sur les Données - Modèles Factoriels
+# Stratégies Basees sur les Données - Modèles Factoriels
 
 - **Exposition Factorielle** (decomposer le rendement)
-  - Sensibilité d'un actif aux facteurs systematiques
+  - Sensibilité d'un actif aux facteurs systématiques
   - Macro : taux, inflation, PIB, credit spreads
   - Style : taille, valeur, momentum, quality
   - Fama-French (1992) : ~90% de la variance expliquee
@@ -845,9 +845,9 @@ imageClass: top-right visible
 - **Rendement Factoriel & Spécifique**
   - R(i) = alpha + beta1 x Market + beta2 x SMB
     &nbsp;&nbsp;+ beta3 x HML + epsilon
-  - Factoriel = betas (exposition systematique)
+  - Factoriel = betas (exposition systématique)
   - Spécifique = alpha + epsilon (idiosyncrasique)
-  - Objectif : capturer l'alpha residuel apres controle
+  - Objectif : capturer l'alpha residuel après contrôle
 </div>
 
 ---
@@ -860,15 +860,15 @@ imageClass: top-right visible
   - Aujourd'hui : les 5 facteurs Fama-French + momentum expliquent ~90% de la variance des portefeuilles
 <div v-click="1">
 
-- **Projets du depot** (resultats backtestes 2015-2026)
+- **Projets du depot** (résultats backtestes 2015-2026)
   - `FamaFrench` (Sharpe 0.54) -- Modèle classique 3 facteurs, stable et comprehensible
   - `RiskParity` (Sharpe 0.40) -- Allocation par parite de contribution au risque (Bridgewater-style)
 
 </div>
 <div v-click="2">
 
-- **Application pratique** (comment utiliser les facteurs dans vos strategies)
-  - Les facteurs servent a decomposer votre alpha : votre strategie capte-t-elle du vrai alpha ou juste du beta deguise ?
+- **Application pratique** (comment utiliser les facteurs dans vos stratégies)
+  - Les facteurs servent a decomposer votre alpha : votre stratégie capte-t-elle du vrai alpha ou juste du beta deguise ?
   - Un Sharpe de 1.0 avec un beta de 1.5 est moins impressionnant qu'un Sharpe de 0.5 avec un beta de 0.3
   - Combiner facteurs + momentum est l'approche la plus robuste dans nos backtests
   - Notebook : `QC-Py-10-Risk-Portfolio-Management.ipynb`
@@ -879,7 +879,7 @@ imageClass: top-right visible
 
 ---
 
-# Strategies Basees sur les Données - Sentiment Analysis
+# Stratégies Basees sur les Données - Sentiment Analysis
 
 - **Objectif** (l'alpha cache dans le texte non structure)
   - Exploiter les données textuelles non structurees pour predire les mouvements du marche
@@ -895,10 +895,10 @@ imageClass: top-right visible
 </div>
 <div v-click="2">
 
-- **Mecanisme et pipeline** (de la collecte au signal)
+- **Mécanisme et pipeline** (de la collecte au signal)
   - Le sentiment du marche est extrait des données textuelles (score continu de -1 a +1)
   - Le score de sentiment est utilise comme feature additionnelle pour generer des signaux
-  - Pipeline : collecte texte -> preprocessing -> scoring NLP -> aggregation -> signal -> execution
+  - Pipeline : collecte texte -> preprocessing -> scoring NLP -> aggregation -> signal -> exécution
   - Defis : bruit (faux positifs), latence (le marche reagit en minutes), sarcasme, jargon financier
 </div>
 
@@ -915,7 +915,7 @@ imageClass: top-right visible
 - **Le pipeline concret pour un quant individuel**
   - Source gratuite : Tiingo News API (integree a QC) -- des milliers d'articles/jour
   - Scoring : FinBERT (pre-entraine, ~15% accuracy vs BERT generique) ou LLM via API
-  - Signal : aggreger les scores sur une fenetre temporelle, filtrer le bruit (seuils)
+  - Signal : aggreger les scores sur une fenêtre temporelle, filtrer le bruit (seuils)
   - Integration : le score de sentiment devient une feature parmi d'autres dans votre alpha
 
 </div>
@@ -931,9 +931,9 @@ imageClass: top-right visible
 layout: compact
 ---
 
-# Strategies de Trading a Haute Frequence (1/2)
+# Stratégies de Trading a Haute Frequence (1/2)
 
-- **Principe : exploiter des micro-inefficacites a tres grande vitesse**
+- **Principe : exploiter des micro-inefficacites a très grande vitesse**
   - Profit par trade minuscule (< 0.01%) mais multiplie par des milliers/millions de trades/jour
   - Fournit de la liquidite au marche en echange d'un spread (market making HFT)
   - Represente 50-70% du volume quotidien sur les marches US (estimation SEC)
@@ -942,8 +942,8 @@ layout: compact
 
 - **Ratio de Sharpe Eleve** (la loi des grands nombres en action)
   - Loi des grands nombres : des milliers de petits paris (quasi-)independants chaque jour
-  - Sharpe annualise > 5 courant pour les firmes HFT (vs < 2 pour la plupart des strategies)
-  - Volatilite du P&L tres faible sur une base journaliere (profit presque garanti par jour)
+  - Sharpe annualise > 5 courant pour les firmes HFT (vs < 2 pour la plupart des stratégies)
+  - Volatilite du P&L très faible sur une base journaliere (profit presque garanti par jour)
   - Exemple : Virtu Financial a eu 1 seul jour de perte en 1238 jours de trading (2009-2014)
   - Le HFT est le seul domaine ou le Sharpe est structurellement > 3 grace au volume de trades
 
@@ -952,7 +952,7 @@ layout: compact
 
 - **Difficultes et Defis** (pas pour les debutants)
   - Couts de transaction : a cette echelle, chaque centime de spread compte enormement
-  - Course a la latence : difference de microsecondes = avantage competitif (winner-takes-all)
+  - Course a la latence : différence de microsecondes = avantage competitif (winner-takes-all)
   - Risque de "flash crash" : pertes catastrophiques en quelques millisecondes si le modèle deraille
   - Barrieres a l'entrée colossales : infrastructure coutant des millions de dollars par an
   - Marche oligopolistique : domie par 5-10 firmes (Citadel Securities, Virtu, Jump Trading, etc.)
@@ -961,11 +961,11 @@ layout: compact
 
 ---
 
-# Strategies de Trading a Haute Frequence (2/2)
+# Stratégies de Trading a Haute Frequence (2/2)
 
 - **Machine Learning et AI pour le HFT** (la frontiere technologique)
   - Utilisation de modèles de Deep Learning pour prediction de micro-tendances (tick-level)
-  - Reinforcement Learning pour l'ajustement dynamique de strategies d'execution
+  - Reinforcement Learning pour l'ajustement dynamique de stratégies d'exécution
   - Les modèles doivent etre ultra-rapides : inference en microsecondes (FPGA, ASIC)
   - Tendance : modèles de plus en plus legers (distillation, quantisation) pour la vitesse
 
@@ -973,7 +973,7 @@ layout: compact
 
 - **Latence Ultra-Faible** (la course aux microsecondes)
   - Utilisation de FPGA (Field-Programmable Gate Arrays) pour des ordres en < 1 microseconde
-  - Co-location de serveurs dans le meme datacenter que la bourse (NYSE: Mahwah NJ, CME: Aurora IL)
+  - Co-location de serveurs dans le même datacenter que la bourse (NYSE: Mahwah NJ, CME: Aurora IL)
   - Fibres optiques dediees, micro-ondes et lasers entre datacenters (Chicago-New York en 4ms)
   - Budget infrastructure : 10-100M$/an pour les firmes HFT majeures (Citadel Securities, Virtu, Jump)
 
@@ -991,7 +991,7 @@ layout: compact
 
 ---
 
-# Strategies de Trading Saisonnier
+# Stratégies de Trading Saisonnier
 
 - **Effet de Janvier** (l'effet saisonnier le plus etudie)
   - Petites capitalisations beneficient en janvier (tax-loss selling en decembre)
@@ -1000,8 +1000,8 @@ layout: compact
   - Exemple US : le Russell 2000 surperformait le S&P 500 de ~2% en janvier (1980-2000)
 <div v-click="1">
 
-- **Strategies Mensuelles et "Turn of the Month"**
-  - Acheter/vendre selon la performance du mois precedent (reversal mensuel)
+- **Stratégies Mensuelles et "Turn of the Month"**
+  - Acheter/vendre selon la performance du mois précédent (reversal mensuel)
   - "Sell in May and go away" : effet historique mais inconsistant depuis 2010
   - Turn of the Month : rendements plus eleves les 3 derniers + 3 premiers jours du mois
   - Explication : flux de liquidite des fonds de pension et paies en fin de mois
@@ -1009,7 +1009,7 @@ layout: compact
 </div>
 <div v-click="2">
 
-- **Strategies Matieres Premieres** (ancrees dans la realite physique)
+- **Stratégies Matieres Premières** (ancrees dans la realite physique)
   - Essence et gaz naturel : saisonnalite liee aux saisons physiques (offre/demande réelle)
   - Fiable car base sur besoins economiques réels (petrole en ete = driving season, gaz en hiver = chauffage)
   - Aussi : cereales (saison de plantation/recolte), metaux (construction, saisonnier)
@@ -1019,22 +1019,22 @@ layout: compact
 
 # Trading Saisonnier : Precautions et Projets
 
-- **Precautions** (pourquoi les resultats sont faibles)
+- **Precautions** (pourquoi les résultats sont faibles)
   - Biais de Data-Snooping : avec 252 jours de trading, on trouvera toujours un "pattern" par hasard
   - Les effets saisonniers purs generent peu d'alpha en 2025 (trop connus, trop exploites par les ETFs)
-  - Les saisonnalites fonctionnent mieux comme **filtre additionnel** que comme strategie primaire
+  - Les saisonnalites fonctionnent mieux comme **filtre additionnel** que comme stratégie primaire
 <div v-click="1">
 
-- **Projets du depot** (resultats backtestes 2015-2026)
-  - `TurnOfMonth` (Sharpe 0.13) -- Strategie calendaire pure, alpha quasi nul apres frais
+- **Projets du depot** (résultats backtestes 2015-2026)
+  - `TurnOfMonth` (Sharpe 0.13) -- Stratégie calendaire pure, alpha quasi nul après frais
   - `VIX-TermStructure` (Sharpe 0.05) -- Structure des termes VIX, Sharpe trop faible pour deployer
 
 </div>
 <div v-click="2">
 
-- **Lecon** : nos backtests confirment la theorie -- les anomalies calendaires seules ne suffisent pas
+- **Lecon** : nos backtests confirment la théorie -- les anomalies calendaires seules ne suffisent pas
   - Approche recommandee : utiliser la saisonnalite comme un filtre parmi d'autres (ex: eviter mai-septembre)
-  - La VIX term structure reste un indicateur de regime utile, meme si elle ne genere pas d'alpha seule
+  - La VIX term structure reste un indicateur de regime utile, même si elle ne genere pas d'alpha seule
 
 </div>
 
@@ -1070,23 +1070,23 @@ layout: compact
 
 # Portefeuille a Haut Levier vs Haut Beta (2/2)
 
-- **Ratio de Sharpe et croissance composee** (la theorie de Markowitz)
+- **Ratio de Sharpe et croissance composee** (la théorie de Markowitz)
   - Mesure le rendement ajuste au risque : SR = (R - Rf) / sigma
   - Croissance composee g = m - s^2/2 : proportionnelle au carre du ratio de Sharpe
   - Implication : un portefeuille a faible beta + levier peut battre un portefeuille a haut beta
-  - C'est le fondement theorique de "Betting Against Beta" (Frazzini & Pedersen, 2014)
+  - C'est le fondement théorique de "Betting Against Beta" (Frazzini & Pedersen, 2014)
 <div v-click="1">
 
 - **Allocation d'Actifs** (la decision la plus importante en investissement)
-  - Repartition du portefeuille entre differentes classes d'actifs (actions, obligations, matieres premieres)
+  - Repartition du portefeuille entre différentes classes d'actifs (actions, obligations, matieres premières)
   - Optimisation 23-77 : entre actions a faible beta et obligations pour un risque minimal (Markowitz)
-  - Le "All-Weather" de Ray Dalio : 30% actions, 40% obligations longues, 15% obligations moyennes, 7.5% or, 7.5% matieres premieres
+  - Le "All-Weather" de Ray Dalio : 30% actions, 40% obligations longues, 15% obligations moyennes, 7.5% or, 7.5% matieres premières
 
 </div>
 <div v-click="2">
 
-- **Projets du depot** (resultats backtestes 2015-2026)
-  - `AllWeather` (Sharpe 0.67, MaxDD -15%) -- "Toutes saisons" inspire de Ray Dalio, tres stable
+- **Projets du depot** (résultats backtestes 2015-2026)
+  - `AllWeather` (Sharpe 0.67, MaxDD -15%) -- "Toutes saisons" inspire de Ray Dalio, très stable
   - `Portfolio-Optimization-ML` (Sharpe 0.90, MaxDD -13%) -- Optimisation ML, notre meilleur
   - `RiskParity` (Sharpe 0.40, MaxDD -12%) -- Allocation par parite de contribution au risque
   - Notebook : `QC-Py-21-Portfolio-Optimization-ML.ipynb`
@@ -1095,7 +1095,7 @@ layout: compact
 
 ---
 
-# Lecons apprises : 10 patterns de nos 67 strategies
+# Lecons apprises : 10 patterns de nos 67 stratégies
 
 Ce que 67 backtests et 11 ans de données nous ont enseigne :
 
@@ -1152,14 +1152,14 @@ Ce que 67 backtests et 11 ans de données nous ont enseigne :
 
 ---
 
-# Echecs pedagogiques : pourquoi certaines strategies echouent
+# Echecs pedagogiques : pourquoi certaines stratégies echouent
 
-*"L'experience, c'est le nom que chacun donne a ses erreurs."* -- Oscar Wilde. Documenter les echecs est aussi important que celebrer les succes.
+*"L'expérience, c'est le nom que chacun donne a ses erreurs."* -- Oscar Wilde. Documenter les echecs est aussi important que celebrer les succes.
 
 <div v-click="1">
 
 - **PairsTrading** (Sharpe -0.36) -- l'echec le plus instructif
-  - La co-integration est instable dans le temps (fenetre de 2 ans insuffisante)
+  - La co-integration est instable dans le temps (fenêtre de 2 ans insuffisante)
   - Ce qui marchait en 2010 ne marche plus en 2020 : les marches evoluent
   - La relation statistique entre deux actifs derive inexorablement
   - Test d'Engle-Granger positif en-sample, negatif hors-sample : piege classique
@@ -1169,16 +1169,16 @@ Ce que 67 backtests et 11 ans de données nous ont enseigne :
 
 - **ForexCarry** (Sharpe -0.32) -- victime du regime monetaire
   - La prime de carry s'est evaporee avec la convergence des taux G10 post-2020
-  - Strategie structurellement cassee : quand tous les taux sont proches de zero, pas de carry
-  - Meme apres la hausse des taux 2022-2024, le carry ne s'est pas retabli de facon stable
+  - Stratégie structurellement cassee : quand tous les taux sont proches de zero, pas de carry
+  - Même après la hausse des taux 2022-2024, le carry ne s'est pas retabli de facon stable
 
 </div>
 <div v-click="3">
 
-- **InverseVolatility-Rank** (3 iterations -- exemple d'echec methodique)
+- **InverseVolatility-Rank** (3 itérations -- exemple d'echec methodique)
   - v1 : MaxDD 54.7% -- drawdown inacceptable, allocation trop agressive
   - v2 : MaxDD 22.7% mais Sharpe negatif -- amelioration du risque, rendement toujours negatif
-  - v3 : MaxDD 41%, Sharpe 0.12 -- plafond structurel confirme apres 3 iterations
+  - v3 : MaxDD 41%, Sharpe 0.12 -- plafond structurel confirme après 3 itérations
   - Lecon : parfois l'hypothese de depart est fausse, il faut savoir abandonner
 
 </div>
@@ -1192,7 +1192,7 @@ layout: compact
 <div v-click="1">
 
 - **1990s** : Regression lineaire, facteurs Fama-French (1992)
-  - Les premiers modèles quantitatifs systematiques (LTCM, DE Shaw, Renaissance)
+  - Les premiers modèles quantitatifs systématiques (LTCM, DE Shaw, Renaissance)
 
 </div>
 <div v-click="2">
@@ -1229,7 +1229,7 @@ layout: compact
 
 - **2025** : LLMs pour sentiment, agents IA autonomes
   - Notre `QC-Py-26-LLM-Trading-Signals` -- la frontiere actuelle
-  - Agents autonomes : observation -> raisonnement -> execution en boucle
+  - Agents autonomes : observation -> raisonnement -> exécution en boucle
 
 </div>
 
@@ -1257,7 +1257,7 @@ La question cle n'est pas "quel modèle utiliser ?" mais "ai-je assez de signal 
 
 <div v-click="1">
 
-- **Étape 1** (Ch3) : Classifier direction (up/down) plutot que predire le prix. Definir l'horizon.
+- **Étape 1** (Ch3) : Classifier direction (up/down) plutot que predire le prix. Définir l'horizon.
 - **Étape 2** (Ch4) : 80% du travail -- EDA, outliers, feature engineering, normalisation, PCA. Attention au data leakage.
 
 </div>
@@ -1303,7 +1303,7 @@ layout: two-cols
 - Features correlees sans PCA
 - Données du futur (look-ahead bias)
 
-**Regle d'or** : toute feature doit etre stationnaire (rendements, pas prix) et disponible au moment de la decision (pas de look-ahead).
+**Règle d'or** : toute feature doit etre stationnaire (rendements, pas prix) et disponible au moment de la decision (pas de look-ahead).
 
 </div>
 
@@ -1327,19 +1327,19 @@ layout: compact
 
 <div v-click="1">
 
-- **State** : Features techniques + fondamentales, fenetre 20j (~60 features)
+- **State** : Features techniques + fondamentales, fenêtre 20j (~60 features)
 - **Action** : AGGRESSIVE (80/20) / MODERATE (50/50) / DEFENSIVE (20/80)
 
 </div>
 <div v-click="2">
 
-- **Reward** : Sharpe ratio glissant 30j, replay buffer 5000 experiences
+- **Reward** : Sharpe ratio glissant 30j, replay buffer 5000 expériences
 - **Notre implementation** : `RL-DQN-Trading` (Sharpe 0.53), MLP(64,32), surpasse 60/40
 
 </div>
 <div v-click="3">
 
-- **Limites** : environnement non-stationnaire, signal bruite, plus prometteur pour l'execution (VWAP adaptatif) que pour les signaux alpha
+- **Limites** : environnement non-stationnaire, signal bruite, plus prometteur pour l'exécution (VWAP adaptatif) que pour les signaux alpha
 
 </div>
 
@@ -1396,7 +1396,7 @@ Les marches financiers sont un environnement hostile pour les modèles : bruit e
 </div>
 <div v-click="2">
 
-- **Strategies classiques** : mean-reversion (difficile), momentum (robuste), factoriel (stable)
+- **Stratégies classiques** : mean-reversion (difficile), momentum (robuste), factoriel (stable)
   - Le momentum est l'anomalie la plus persistante de la finance moderne
 </div>
 <div v-click="3">

--- a/slides/S4-trading-algorithmique/deck-3-pratique-lean.md
+++ b/slides/S4-trading-algorithmique/deck-3-pratique-lean.md
@@ -415,7 +415,7 @@ layout: section
 
 </div>
 
-> Notebooks: QC-Py-13-Alpha-Models, QC-Py-14-Portfolio-Construction-Exécution
+> Notebooks: QC-Py-13-Alpha-Models, QC-Py-14-Portfolio-Construction-Execution
 
 ---
 

--- a/slides/S4-trading-algorithmique/deck-3-pratique-lean.md
+++ b/slides/S4-trading-algorithmique/deck-3-pratique-lean.md
@@ -14,7 +14,7 @@ layout: cover
 
 Intelligence Artificielle -- S4
 
-**De la theorie au backtest en 5 minutes : plateforme Lean + agent IA codeur**
+**De la théorie au backtest en 5 minutes : plateforme Lean + agent IA codeur**
 
 - Plateforme QuantConnect : setup, algorithmes, framework Alpha
 - Workflow agentique : VSCode + Claude Code + MCP
@@ -64,7 +64,7 @@ layout: section
 </div>
 <div v-click="2">
 
-- **3. Implementation** : Coder la strategie dans Lean (Python)
+- **3. Implementation** : Coder la stratégie dans Lean (Python)
   - Initialize, OnData, gestion des ordres
 </div>
 <div v-click="3">
@@ -75,7 +75,7 @@ layout: section
 <div v-click="4">
 
 - **5. Paper Trading** : Tester en temps réel sans capital
-  - Derniere validation avant engagement de capital
+  - Dernière validation avant engagement de capital
 </div>
 <div v-click="5">
 
@@ -128,22 +128,22 @@ layout: section
 # Installation de l'Environnement (1/2)
 
 - **QuantConnect Cloud** (recommande pour demarrer)
-  - Creer un compte sur quantconnect.com
+  - Créer un compte sur quantconnect.com
   - Organisations : regroupez vos projets et collaborateurs
   - Noeuds de ressources : backtesting et live trading
 
 <div v-click="1">
 
-- **Lean-cli + VS Code** (pour le developpement local)
+- **Lean-cli + VS Code** (pour le développement local)
   - Synchronisation bidirectionnelle avec le Cloud
-  - Execution locale via containers Docker
+  - Exécution locale via containers Docker
 </div>
 <div v-click="2">
 
 - **Pourquoi le Cloud d'abord ?**
   - Zéro configuration, données incluses
   - Backtests rapides sans installation locale
-  - Creez un compte gratuit sur quantconnect.com
+  - Créez un compte gratuit sur quantconnect.com
 
 </div>
 
@@ -181,7 +181,7 @@ layout: section
 
 - **Sur QuantConnect**
   - My Account -- Request Token Information
-  - Creez un compte gratuit sur quantconnect.com
+  - Créez un compte gratuit sur quantconnect.com
 
 </div>
 <div v-click="2">
@@ -202,7 +202,7 @@ layout: section
 # Environnement d'Algorithme (1/2)
 
 - **QCAlgorithm** : la classe de base de tout algorithme Lean
-  - Modele **evenementiel** : votre code réagit aux données de marché, pas de lookahead possible
+  - Modèle **evenementiel** : votre code réagit aux données de marché, pas de lookahead possible
   - Le moteur garantit que vous ne voyez jamais le futur -- elimine le look-ahead bias par design
   - Strategic Development Framework integre (5 composants modulaires)
 
@@ -237,7 +237,7 @@ layout: section
 
 ---
 
-# Evenements (1/2)
+# Événements (1/2)
 
 - **initialize** : point d'entree de configuration
   - `set_start_date`, `set_end_date`, `set_cash`
@@ -258,7 +258,7 @@ layout: section
 
 ---
 
-# Evenements (2/2)
+# Événements (2/2)
 
 - **on_data (suite)** : logique de decision
   - Verification : `self.portfolio.invested`, seuils de temps
@@ -275,7 +275,7 @@ layout: section
 
 - **Autres points d'entree**
   - `on_securities_changed`, `on_end_of_day`, `on_warmup_finished`
-  - Evenements planifies via `self.schedule`
+  - Événements planifies via `self.schedule`
 
 </div>
 
@@ -301,7 +301,7 @@ layout: section
 
 - **Bonnes pratiques**
   - Toujours laisser au moins 7 jours avant aujourd'hui (données non finalisées)
-  - Definir la monnaie AVANT le cash initial
+  - Définir la monnaie AVANT le cash initial
   - Pour les crypto : `self.set_account_currency("BTC")`
 
 </div>
@@ -403,19 +403,19 @@ layout: section
   - **Alpha Creation** : *Quels signaux generer ?* (insights : direction, magnitude, confiance)
   - **Portfolio Construction** : *Comment allouer le capital ?* (equal weight, optimisation Markowitz, risk parity)
   - **Risk Management** : *Comment limiter les pertes ?* (drawdown max, trailing stop, exposure sectorielle)
-  - **Execution** : *Comment passer les ordres ?* (immediat, VWAP, spread-based)
+  - **Exécution** : *Comment passer les ordres ?* (immediat, VWAP, spread-based)
 
 <div v-click="1">
 
 - **Avantage du framework**
   - Chaque module est interchangeable et testable independamment
   - Possible de mixer primitives bas niveau et modules haut niveau
-  - Facilite la composition : plusieurs Alphas contribuent au meme portefeuille
-  - Exemples complets : `projects/Framework_Composite_*` (4 strategies composites)
+  - Facilite la composition : plusieurs Alphas contribuent au même portefeuille
+  - Exemples complets : `projects/Framework_Composite_*` (4 stratégies composites)
 
 </div>
 
-> Notebooks: QC-Py-13-Alpha-Models, QC-Py-14-Portfolio-Construction-Execution
+> Notebooks: QC-Py-13-Alpha-Models, QC-Py-14-Portfolio-Construction-Exécution
 
 ---
 
@@ -486,7 +486,7 @@ layout: dense
 | **2 - Univers et Assets** | QC-Py-05 a 08 | Universe, Options, Futures, Multi-Asset |
 | **3 - Trading avance** | QC-Py-09 a 12 | Orders, Risk, Indicators, Backtesting |
 | **4 - Framework** | QC-Py-13 a 15 | Alpha, Portfolio, Optimization |
-| **5 - Donnees alternatives** | QC-Py-16 a 17 | Alternative Data, Sentiment |
+| **5 - Données alternatives** | QC-Py-16 a 17 | Alternative Data, Sentiment |
 | **6 - ML classique** | QC-Py-18 a 21 | Features, Classification, Regression, Portfolio-ML |
 | **7 - Deep Learning** | QC-Py-22 a 25 | LSTM, Unsupervised, NLP, RL |
 | **8 - Production** | QC-Py-26 a 28 | LLM-Signals, Deployment, Regime Detection |
@@ -494,7 +494,7 @@ layout: dense
 <div v-click="1">
 
 - **67 projets** dans `QuantConnect/projects/` : des EMA Crossover aux composites multi-Alpha (meilleur Sharpe : 1.16)
-- **Progression** : chaque phase suppose la maitrise des precedentes
+- **Progression** : chaque phase suppose la maitrise des précédentes
 - **Chemin rapide** : Phases 1-3 pour les fondamentaux (~8h), Phase 4 pour le framework (~3h)
 
 </div>
@@ -547,7 +547,7 @@ layout: section
 - **Pourquoi explorer avant de coder ?**
   - Valider votre intuition sur les données avant d'ecrire un algorithme
   - Visualiser les correlations, la distribution des returns, les regimes
-  - Eviter de coder une strategie sur une idee fausse
+  - Eviter de coder une stratégie sur une idee fausse
 
 </div>
 <div v-click="2">
@@ -561,7 +561,7 @@ layout: section
 
 ---
 
-# QuantBook : l'API de Donnees
+# QuantBook : l'API de Données
 
 ```python
 from QuantConnect.Research import *
@@ -582,7 +582,7 @@ df_spy = history.loc["SPY"]
 
 <div v-click="1">
 
-- **Difference cle avec `QCAlgorithm.History()`** :
+- **Différence cle avec `QCAlgorithm.History()`** :
   - QuantBook retourne un **DataFrame pandas** directement
   - Pas de lookahead protection → vous etes responsable de ne pas biaiser
 
@@ -658,14 +658,14 @@ layout: section
 - **Exemples** :
   - Claude Code (Anthropic) -- celui que nous utilisons
   - GitHub Copilot, Cursor, Windsurf
-  - Tous partagent le meme principe : contexte (votre code) + action (modifications)
+  - Tous partagent le même principe : contexte (votre code) + action (modifications)
 </div>
 <div v-click="2">
 
 - **Pour le trading quant** :
-  - L'agent connait l'API QuantConnect, les patterns de strategie, les metriques
+  - L'agent connait l'API QuantConnect, les patterns de stratégie, les metriques
   - Il peut ecrire un algorithme complet, le compiler, le backtester
-  - Il iterere sur les resultats pour ameliorer la strategie
+  - Il iterere sur les résultats pour ameliorer la stratégie
 
 </div>
 
@@ -714,7 +714,7 @@ layout: section
 
 ---
 
-# Le Workflow Agentique en 5 Etapes
+# Le Workflow Agentique en 5 Étapes
 
 ```
 1. IDEE          "Je veux une strategie momentum sur SPY"
@@ -790,7 +790,7 @@ et backteste-le sur 2015-2025 avec 100k USD"
 1. Lit le fichier `main.py` du projet local
 2. Appelle `create_project` dans l'organisation QuantConnect
 3. Appelle `create_file` pour uploader `main.py`
-4. Appelle `create_compile` et attend le resultat
+4. Appelle `create_compile` et attend le résultat
 5. Si erreur de syntaxe : corrige et recompile
 
 </div>
@@ -802,7 +802,7 @@ et backteste-le sur 2015-2025 avec 100k USD"
 **Étape backtest** :
 
 - L'agent appelle `create_backtest(projectId, compileId, name)`
-- Puis `read_backtest(projectId, backtestId)` pour les resultats
+- Puis `read_backtest(projectId, backtestId)` pour les résultats
 
 <div v-click="1">
 
@@ -819,8 +819,8 @@ et backteste-le sur 2015-2025 avec 100k USD"
 </div>
 <div v-click="2">
 
-- **Iteration automatique** : l'agent analyse les metriques, ajuste le code, rebackteste
-- **Votre role** : observer, poser des questions, orienter l'agent
+- **Itération automatique** : l'agent analyse les metriques, ajuste le code, rebackteste
+- **Votre rôle** : observer, poser des questions, orienter l'agent
 
 </div>
 
@@ -831,14 +831,14 @@ et backteste-le sur 2015-2025 avec 100k USD"
 - **Peut faire** :
   - Ecrire un algorithme complet a partir d'une description
   - Corriger les erreurs de syntaxe et de compilation
-  - Lancer des backtests et lire les resultats
+  - Lancer des backtests et lire les résultats
   - Proposer des ameliorations basees sur les metriques
   - Adapter les paramètres pour optimiser les performances
 <div v-click="1">
 
 - **Ne peut pas faire** :
   - Garantir un Sharpe > 2 (surapprentissage = danger)
-  - Remplacer votre jugement sur la coherence de la strategie
+  - Remplacer votre jugement sur la coherence de la stratégie
   - Penser a votre place : vous devez orienter l'agent
   - Detecter tous les biais (look-ahead, survivorship, etc.)
 
@@ -862,7 +862,7 @@ layout: section
 |---------|----------|-----------------------|
 | **Price-based** | return 1j/5j/20j, log-return, vol 30j | Momentum, regime |
 | **Indicator-based** | RSI(14), SMA ratio, EMA ratio, MACD | Overbought, tendance |
-| **Labeling** | rendement futur 10j > seuil → 1/0 | Target du modele |
+| **Labeling** | rendement futur 10j > seuil → 1/0 | Target du modèle |
 
 </div>
 <div v-click="2">
@@ -904,7 +904,7 @@ class SectorMLClassificationAlgorithm(QCAlgorithm):
 
 <div v-click="1">
 
-- Re-entrainement automatique chaque mois sur fenetre glissante de 4 ans
+- Re-entrainement automatique chaque mois sur fenêtre glissante de 4 ans
 - Regime bull/bear detecte par SPY vs SMA200
 
 </div>
@@ -926,8 +926,8 @@ class SectorMLClassificationAlgorithm(QCAlgorithm):
 <div v-click="1">
 
 - **Lecon cle** : le ML seul ne suffit pas — v3 (ML naif) est pire que v2b (momentum pur)
-- L'iteration sur le feature engineering et le regime fait passer de 0.29 a 0.47
-- Une règle simple bien calibrée (Trend-Following) bat le ML sur ce probleme
+- L'itération sur le feature engineering et le regime fait passer de 0.29 a 0.47
+- Une règle simple bien calibrée (Trend-Following) bat le ML sur ce problème
 
 </div>
 <div v-click="2">
@@ -958,7 +958,7 @@ class SectorMLClassificationAlgorithm(QCAlgorithm):
 
 - **Pour votre projet** : si vous choisissez ML, partez du template Advanced
   - `templates/advanced/main.py` : RF sur BTCUSDT, 100 arbres, re-entrainement mensuel
-  - Commencez simple (5 features), ajoutez par iteration
+  - Commencez simple (5 features), ajoutez par itération
 
 </div>
 
@@ -968,7 +968,7 @@ class SectorMLClassificationAlgorithm(QCAlgorithm):
 layout: section
 ---
 
-# Resultats ML — Curriculum V2
+# Résultats ML — Curriculum V2
 
 <br>
 
@@ -1095,7 +1095,7 @@ layout: section
 
 <div v-click="1">
 
-> Un resultat "promising" sur 1 seed x 1 fold = invalide. Seule la replication cross-seed compte.
+> Un résultat "promising" sur 1 seed x 1 fold = invalide. Seule la replication cross-seed compte.
 
 </div>
 
@@ -1107,7 +1107,7 @@ layout: section
 
 ---
 
-# Resultats Composites Avances (1/2)
+# Résultats Composites Avances (1/2)
 
 - **C4.1 : TrendWeather Composite**
   - Combinaison : Trend-Following + Weather signals
@@ -1127,14 +1127,14 @@ layout: section
 
 ---
 
-# Resultats Composites Avances (2/2)
+# Résultats Composites Avances (2/2)
 
 - **C4.3 : Multi-Alpha Ensemble** -- architecture 5 couches complete
   - **Universe** : Top 50 par volume (rebalance hebdo)
   - **Alphas** : EMA Cross + RSI + MACD (3 signaux independants)
   - **Portfolio** : BlackLittermanOptimization (pondere par confiance)
   - **Risk** : MaximumSectorExposure + MaximumDrawdownPercentPortfolio
-  - **Execution** : VolumeWeightedAveragePrice (minimise impact)
+  - **Exécution** : VolumeWeightedAveragePrice (minimise impact)
 
 <div v-click="1">
 
@@ -1144,7 +1144,7 @@ layout: section
 | + Alpha RSI | 0.62 | +0.17 |
 | + PCM BlackLitterman | 0.89 | +0.27 |
 | + Risk Management | 1.05 | +0.16 |
-| **+ Execution VWAP** | **1.31** | **+0.26** |
+| **+ Exécution VWAP** | **1.31** | **+0.26** |
 
 </div>
 <div v-click="2">
@@ -1196,15 +1196,15 @@ layout: section
 | Critere | Poids | Minimum requis |
 |---------|:-----:|----------------|
 | **Backtest** | 30% | Sharpe > 0, periode > 2 ans, comparaison benchmark |
-| **Strategie** | 30% | Logique claire, 2+ indicateurs, stop-loss present |
-| **Presentation** | 20% | Graphiques de resultats, timing 10 min +/- 1 min |
-| **Code** | 20% | Compile sans erreur, README, parametres visibles |
+| **Stratégie** | 30% | Logique claire, 2+ indicateurs, stop-loss present |
+| **Presentation** | 20% | Graphiques de résultats, timing 10 min +/- 1 min |
+| **Code** | 20% | Compile sans erreur, README, paramètres visibles |
 
 </div>
 <div v-click="2">
 
 - **Workflow recommande pour le projet** :
-  1. Choisir une strategie de base parmi les projets du depot
+  1. Choisir une stratégie de base parmi les projets du depot
   2. Utiliser l'agent pour personnaliser (actifs, périodes, seuils)
   3. Valider manuellement : relire le code, verifier les metriques
   4. Documenter vos choix et limites identifiees
@@ -1224,7 +1224,7 @@ layout: section
 
 - **Overfitting** : Sharpe > 3 sur un backtest = probablement surajuste
   - Tester sur des périodes différentes (in-sample / out-of-sample)
-  - Un bon Sharpe réel : 0.5-1.5 pour une strategie robuste
+  - Un bon Sharpe réel : 0.5-1.5 pour une stratégie robuste
 </div>
 <div v-click="2">
 
@@ -1269,5 +1269,5 @@ Jean-Sylvain Boige -- jsboige@myia.org
 - **Claude Code** : claude.ai/code
 - **Documentation QC** : quantconnect.com/docs
 
-> Le trading algorithmique est un domaine ou la pratique precede la theorie.
-> Le meilleur apprentissage : modifiez une strategie existante, backtestez, analysez les resultats, iterez.
+> Le trading algorithmique est un domaine ou la pratique precede la théorie.
+> Le meilleur apprentissage : modifiez une stratégie existante, backtestez, analysez les résultats, iterez.

--- a/slides/S4-trading-exercices/slides.md
+++ b/slides/S4-trading-exercices/slides.md
@@ -22,7 +22,7 @@ TRADING ALGORITHMIQUE AVEC QUANTCONNECT
 layout: section
 ---
 
-# Instructions Generales
+# Instructions Générales
 
 ---
 layout: default
@@ -45,7 +45,7 @@ layout: default
 
 ### Metriques de reference
 
-Pour chaque strategie, mesurez : **Sharpe Ratio**, **CAGR**, **Max Drawdown**, **Win Rate**
+Pour chaque stratégie, mesurez : **Sharpe Ratio**, **CAGR**, **Max Drawdown**, **Win Rate**
 
 ---
 layout: default
@@ -85,9 +85,9 @@ layout: default
 
 ### Ce que vous allez apprendre
 
-- Creer un projet sur QC Cloud
+- Créer un projet sur QC Cloud
 - Comprendre la structure d'un algorithme (`Initialize`, `OnData`)
-- Executer un backtest et lire les resultats
+- Executer un backtest et lire les résultats
 
 ### Sources
 
@@ -100,7 +100,7 @@ layout: default
 
 # Ex01 - Consignes
 
-1. **Creer un projet** `Ex01-Setup` sur QuantConnect Cloud (Python)
+1. **Créer un projet** `Ex01-Setup` sur QuantConnect Cloud (Python)
 
 2. **Implementer un algorithme simple** qui :
    - Trade SPY (S&P 500 ETF)
@@ -111,7 +111,7 @@ layout: default
 
 <v-click>
 
-4. **Analyser les resultats** :
+4. **Analyser les résultats** :
    - Quel est le rendement total ?
    - Quel est le ratio de Sharpe ?
    - Quel est le drawdown maximum ?
@@ -132,7 +132,7 @@ layout: default
 layout: default
 ---
 
-# Ex01 - Resultats Attendus
+# Ex01 - Résultats Attendus
 
 | Metrique | Valeur attendue |
 |----------|----------------|
@@ -159,7 +159,7 @@ layout: default
 
 # Ex02 - Objectif
 
-> Implementer une strategie EMA Crossover avec indicateurs techniques
+> Implementer une stratégie EMA Crossover avec indicateurs techniques
 
 ### Ce que vous allez apprendre
 
@@ -178,9 +178,9 @@ layout: default
 
 # Ex02 - Consignes
 
-1. **Creer un projet** `Ex02-EMA-Cross` sur QC Cloud
+1. **Créer un projet** `Ex02-EMA-Cross` sur QC Cloud
 
-2. **Implementer la strategie EMA Crossover** :
+2. **Implementer la stratégie EMA Crossover** :
    - EMA rapide : 12 periodes
    - EMA lente : 26 periodes
    - Signal d'achat quand la rapide croise au-dessus de la lente
@@ -201,7 +201,7 @@ layout: default
 - `self.EMA(symbol, 12)` et `self.EMA(symbol, 26)` pour les indicateurs
 - Utiliser `Indicator.Updated` ou `self.IndicatorIsReady`
 - Piste : checker `self.fast.Current.Value > self.slow.Current.Value`
-- Attention aux signaux precedents pour detecter le **croisement** (pas juste la position)
+- Attention aux signaux précédents pour detecter le **croisement** (pas juste la position)
 
 </v-click>
 
@@ -209,7 +209,7 @@ layout: default
 layout: default
 ---
 
-# Ex02 - Resultats Attendus
+# Ex02 - Résultats Attendus
 
 | Metrique | Valeur attendue |
 |----------|----------------|
@@ -220,7 +220,7 @@ layout: default
 
 ### Pour aller plus loin
 
-- Tester avec differentes periodes EMA (5/20, 20/50, 50/200)
+- Tester avec différentes periodes EMA (5/20, 20/50, 50/200)
 - Ajouter un filtre de volume
 - Implementer un stop-loss a 5%
 
@@ -259,14 +259,14 @@ layout: default
 
 2. **Identifier les features** utilisees par le modèle :
    - Quels indicateurs techniques ?
-   - Quelle fenetre temporelle ?
+   - Quelle fenêtre temporelle ?
    - Comment les labels sont-ils construits ?
 
 <v-click>
 
 3. **Executer le backtest** sur QC Cloud (periode 2020-2025)
 
-4. **Analyser les resultats** :
+4. **Analyser les résultats** :
    - Le modèle bat-il le buy-and-hold ?
    - Quelle est la precision de prediction ?
    - Y a-t-il des periodes de sous-performance ?
@@ -288,7 +288,7 @@ layout: default
 layout: default
 ---
 
-# Ex03 - Resultats Attendus
+# Ex03 - Résultats Attendus
 
 | Metrique | Valeur de reference |
 |----------|---------------------|
@@ -346,7 +346,7 @@ layout: default
 3. **Executer le backtest** et analyser :
    - Quand le modèle detecte-t-il un changement de regime ?
    - Comment l'allocation SPY/TLT change-t-elle ?
-   - Quel est le role du GLD (10% constant) ?
+   - Quel est le rôle du GLD (10% constant) ?
 
 </v-click>
 
@@ -355,7 +355,7 @@ layout: default
 ### Hints
 
 - `MarkovRegression` de `statsmodels` avec `k_regimes=2`
-- `switching_variance=True` permet des variances differentes par regime
+- `switching_variance=True` permet des variances différentes par regime
 - Allocation : `poids_SPY = prob_low_vol * 0.80`
 - Seuil de confirmation : prob > 0.55 pour rebalancer
 
@@ -365,7 +365,7 @@ layout: default
 layout: default
 ---
 
-# Ex04 - Resultats Attendus
+# Ex04 - Résultats Attendus
 
 | Metrique | Valeur de reference |
 |----------|---------------------|
@@ -482,7 +482,7 @@ layout: default
 2. **Executer le backtest** et analyser
 
 3. **Comparer** avec le Random Forest (Ex03) :
-   - Quelle methode est plus performante ?
+   - Quelle méthode est plus performante ?
    - Laquelle s'adapte mieux aux changements de regime ?
 
 </v-click>
@@ -502,7 +502,7 @@ layout: default
 layout: default
 ---
 
-# Ex06 - Resultats Attendus
+# Ex06 - Résultats Attendus
 
 | Metrique | Valeur de reference |
 |----------|---------------------|
@@ -550,7 +550,7 @@ layout: default
 
 1. **Comprendre l'architecture LSTM** :
    - Comment les cellules LSTM memorisent-elles l'information ?
-   - Quelle est la difference avec un RNN classique ?
+   - Quelle est la différence avec un RNN classique ?
    - Pourquoi `hidden_size = 32` ?
 
 <v-click>
@@ -578,7 +578,7 @@ layout: default
 layout: default
 ---
 
-# Ex07 - Resultats Attendus
+# Ex07 - Résultats Attendus
 
 | Metrique | Valeur de reference |
 |----------|---------------------|
@@ -613,9 +613,9 @@ layout: default
 
 ### Ce que vous allez apprendre
 
-- Formulation du trading comme probleme de RL
+- Formulation du trading comme problème de RL
 - Etat, action, recompense dans un contexte financier
-- Deep Q-Network (DQN) avec experience replay
+- Deep Q-Network (DQN) avec expérience replay
 
 ### Sources
 
@@ -638,7 +638,7 @@ layout: default
 
 2. **Analyser le DQN** :
    - Comment fonctionne l'exploration (epsilon-greedy) ?
-   - Qu'est-ce que l'experience replay ?
+   - Qu'est-ce que l'expérience replay ?
    - Pourquoi un target network ?
 
 </v-click>
@@ -656,7 +656,7 @@ layout: default
 ### Hints
 
 - `epsilon` decroit de 0.3 a 0.05 (exploration -> exploitation)
-- Experience replay : le modèle re-apprend de situations passees
+- Expérience replay : le modèle re-apprend de situations passees
 - Le Q-network est un simple MLP (pas de convolution)
 - Attention au surapprentissage sur une seule periode
 
@@ -666,7 +666,7 @@ layout: default
 layout: default
 ---
 
-# Ex08 - Resultats Attendus
+# Ex08 - Résultats Attendus
 
 | Metrique | Valeur de reference |
 |----------|---------------------|
@@ -676,8 +676,8 @@ layout: default
 
 ### Concepts cles
 
-- **Exploration vs Exploitation** : equilibre entre essayer de nouvelles strategies et exploiter les connues
-- **Experience Replay** : rompt la correlation temporelle des observations
+- **Exploration vs Exploitation** : equilibre entre essayer de nouvelles stratégies et exploiter les connues
+- **Expérience Replay** : rompt la correlation temporelle des observations
 - **Target Network** : stabilise l'apprentissage
 
 ---
@@ -722,7 +722,7 @@ layout: default
 2. **Analyser l'implementation simplifiee** :
    - Comment les valeurs continues sont-elles tokenisees ?
    - Comment le transformer predit-il les tokens futurs ?
-   - Quelle est la difference avec LSTM (Ex07) ?
+   - Quelle est la différence avec LSTM (Ex07) ?
 
 </v-click>
 
@@ -739,7 +739,7 @@ layout: default
 ### Hints
 
 - Chronos tokenize les valeurs en entiers via quantization
-- Le forecasting devient un probleme de "language modeling"
+- Le forecasting devient un problème de "language modeling"
 - Implementation simplifiee dans le projet (pas le vrai package `chronos`)
 - Pour la version complete : `from chronos import ChronosPipeline`
 
@@ -749,7 +749,7 @@ layout: default
 layout: default
 ---
 
-# Ex09 - Resultats Attendus
+# Ex09 - Résultats Attendus
 
 | Metrique | Valeur de reference |
 |----------|---------------------|
@@ -794,7 +794,7 @@ layout: default
 layout: default
 ---
 
-# Resultats Comparatifs (Backtests QC Cloud)
+# Résultats Comparatifs (Backtests QC Cloud)
 
 | Exercice | Sharpe | CAGR | Max DD | Win Rate |
 |----------|--------|------|--------|----------|
@@ -804,7 +804,7 @@ layout: default
 | Ex09 Chronos | 0.774 | 15.54% | 33.72% | ~54% |
 | Ex08 RL | 0.639 | 8.06% | 20.81% | ~53% |
 
-> **Note** : Les performances passees ne garantissent pas les resultats futurs.
+> **Note** : Les performances passees ne garantissent pas les résultats futurs.
 > L'objectif est pedagogique, pas la recherche du meilleur Sharpe.
 
 ---
@@ -816,15 +816,15 @@ layout: default
 ### Avant chaque exercice
 1. Lisez le **notebook de cours** associe
 2. Explorez le **code source** du projet sur GitHub
-3. Notez les **paramètres** et leur role
+3. Notez les **paramètres** et leur rôle
 
 ### Pendant l'exercice
 4. Executez d'abord le backtest **tel quel**
 5. Puis **modifiez un paramètre** a la fois
 6. **Documentez** vos observations
 
-### Apres l'exercice
-7. **Comparez** avec les resultats de reference
+### Après l'exercice
+7. **Comparez** avec les résultats de reference
 8. **Reflechissez** : pourquoi cette performance ?
 9. **Experimentez** avec les suggestions "pour aller plus loin"
 
@@ -845,8 +845,8 @@ layout: default
 
 - Toujours **diviser** la periode (train / validation / test)
 - **Reentrainer** periodiquement les modèles
-- **Diversifier** les strategies plutot qu'optimiser une seule
-- **Questionner** les resultats anormalement bons
+- **Diversifier** les stratégies plutot qu'optimiser une seule
+- **Questionner** les résultats anormalement bons
 
 ---
 layout: cover

--- a/slides/S6-tweety/slides.md
+++ b/slides/S6-tweety/slides.md
@@ -15,7 +15,7 @@ layout: cover
 - Logiques formelles : Propositionnelle, FOL, Modale, DL
 - Argumentation computationnelle : Dung, ASPIC+, ABA
 - Revision de croyances et incoherence
-- Agents dialogiques et preferences
+- Agents dialogiques et préférences
 - Integration Python via JPype
 
 ---
@@ -84,7 +84,7 @@ from org.tweetyproject.logics.fol.syntax import *
 ## Logique Propositionnelle
 
 - Syntaxe : `PlFormula`, `Proposition`, connecteurs (And, Or, Not, Impl)
-- Semantique : `PossibleWorld`, `PlBeliefSet`
+- Sémantique : `PossibleWorld`, `PlBeliefSet`
 - Solveurs : `SimplePlReasoner`, `SatSolver` (SAT4J)
 
 ## Logique du Premier Ordre
@@ -109,7 +109,7 @@ sig.add(Predicate("Mortal", [sig.getSort("Person")]))
 
 ## Description Logics (DL)
 
-- Ontologies TBox / ABox : concepts, roles, individus
+- Ontologies TBox / ABox : concepts, rôles, individus
 - Raisonnement : subsomption, coherence, instanciation
 - Intégration **OWL** via raisonneur HermiT
 
@@ -123,7 +123,7 @@ diamond_phi = Diamond(phi)  # Possibly
 ```
 
 - **QBF** : formules booleennes quantifiees (∀x ∃y ...)
-- **Logique Conditionnelle** : regles conditionnelles et inference non-monotone
+- **Logique Conditionnelle** : règles conditionnelles et inference non-monotone
 
 > **Notebook** : `Tweety-3-Advanced-Logics.ipynb` — 40 min
 
@@ -137,7 +137,7 @@ layout: section
 
 # Tweety 4 — Revision de Croyances
 
-## Le probleme de la revision
+## Le problème de la revision
 
 Quand nouvelles informations **contredisent** les croyances existantes, que faire ?
 
@@ -176,9 +176,9 @@ layout: section
 
 Un framework d'argumentation = `(A, →)` : ensemble d'arguments + relation d'attaque
 
-## Semantiques d'extension
+## Sémantiques d'extension
 
-| Semantique | Definition |
+| Sémantique | Definition |
 |-----------|------------|
 | **Admissible** | auto-defende, sans attaque interne |
 | **Preferred** | maximale admissible |
@@ -200,9 +200,9 @@ af.add(Attack(a, b)); af.add(Attack(b, c))
 
 ## ASPIC+ : Arguments structurees
 
-- **Regles strictes** (modus ponens) et **defeasibles** (revisables)
+- **Règles strictes** (modus ponens) et **defeasibles** (revisables)
 - **Attaques** : rebut, undercut, undermining
-- **Preference** sur les regles pour resoudre les conflits
+- **Préférence** sur les règles pour resoudre les conflits
 
 ## DeLP et ABA
 
@@ -230,7 +230,7 @@ Generalise les frameworks de Dung : **acceptance conditions** par argument
 ## Frameworks bipolaires et ponderés
 
 - **Bipolar AF** : attaque + support
-- **Weighted AF** : poids numeriques sur les attaques
+- **Weighted AF** : poids numériques sur les attaques
 - **SetAF** : attaques d'ensembles d'arguments
 
 ```python
@@ -239,7 +239,7 @@ from org.tweetyproject.arg.bipolar.syntax import BipolarArgFramework
 ```
 
 - **SAF** (Social AF) : agregation de vote sur les attaques
-- **CF2** : semantique pour frameworks avec cycles pairs
+- **CF2** : sémantique pour frameworks avec cycles pairs
 
 > **Notebook** : `Tweety-7a-Extended-Frameworks.ipynb` — 50 min
 
@@ -247,7 +247,7 @@ from org.tweetyproject.arg.bipolar.syntax import BipolarArgFramework
 
 # Tweety 7b — Ranking et Probabiliste
 
-## Semantiques de ranking
+## Sémantiques de ranking
 
 Ordonner les arguments par **force** plutot que les grouper en extensions
 
@@ -256,7 +256,7 @@ Ordonner les arguments par **force** plutot que les grouper en extensions
 | **Categoriser** | Iterative graded semantics |
 | **BBS** | Burden-Based Semantics |
 | **StratInc** | Stratified Incoherence |
-| **Euler** | Force numerique (PageRank-style) |
+| **Euler** | Force numérique (PageRank-style) |
 
 ## Argumentation Probabiliste
 
@@ -300,13 +300,13 @@ session.run()
 
 ---
 
-# Tweety 9 — Preferences et Vote
+# Tweety 9 — Préférences et Vote
 
-## Ordres de preference
+## Ordres de préférence
 
-- **Preference order** : relations totales / partielles sur alternatives
-- **Agregation** : combiner les preferences de plusieurs agents
-- **Theorie du vote** : Borda, Copeland, Schulze, STV
+- **Préférence order** : relations totales / partielles sur alternatives
+- **Agregation** : combiner les préférences de plusieurs agents
+- **Théorie du vote** : Borda, Copeland, Schulze, STV
 
 ```python
 from org.tweetyproject.preferences.syntax import PreferenceOrder
@@ -333,7 +333,7 @@ layout: section
 
 ## Modules couverts dans la serie
 
-| Module | Theme | Notebooks |
+| Module | Thème | Notebooks |
 |--------|-------|-----------|
 | `logics.pl`, `logics.fol` | Logiques de base | 2-3 |
 | `logics.dl`, `logics.ml` | Logiques avancees | 3 |
@@ -342,11 +342,11 @@ layout: section
 | `arg.aspic`, `arg.aba` | Argumentation structuree | 6 |
 | `arg.adf`, `arg.bipolar` | Frameworks etendus | 7a |
 | `agents.dialogues` | Agents dialogiques | 8 |
-| `preferences` | Vote et preferences | 9 |
+| `preferences` | Vote et préférences | 9 |
 
 ## Liens avec les autres series
 
-- **S1-argumentation** : fondements theoriques de l'argumentation
+- **S1-argumentation** : fondements théoriques de l'argumentation
 - **S7-lean** : preuves formelles des theoremes d'impossibilite (Arrow)
 - **03-logique** : cours magistral logique et planification
 
@@ -375,7 +375,7 @@ SymbolicAI/
 
 - Intégration avec **Neo4j** pour les graphes d'argumentation
 - Visualisation interactive des frameworks (D3.js / Cytoscape)
-- Argumentation pour l'**explicabilite des modeles ML**
+- Argumentation pour l'**explicabilite des modèles ML**
 
 ---
 layout: section

--- a/slides/S7-lean/slides.md
+++ b/slides/S7-lean/slides.md
@@ -69,8 +69,8 @@ lean --version  # Lean 4.x.x
 
 ## Kernel Jupyter pour Lean 4
 
-- **lean4jupyter** : execution cellule-par-cellule dans Jupyter
-- **Lake** : systeme de build et de gestion de packages
+- **lean4jupyter** : exécution cellule-par-cellule dans Jupyter
+- **Lake** : système de build et de gestion de packages
 - **Mathlib** : ajout dans `lakefile.lean` via `require mathlib`
 
 ## Verification de l'installation
@@ -203,7 +203,7 @@ layout: section
 
 ## La plus grande bibliotheque de maths formalisees
 
-- **150 000+ theoremes** : algebre, topologie, theorie des nombres, analyse
+- **150 000+ theoremes** : algebre, topologie, théorie des nombres, analyse
 - **Tactiques avancees** : `ring`, `linarith`, `norm_num`, `decide`, `field_simp`
 
 ```lean
@@ -236,7 +236,7 @@ theorem fermat_last_n2 : ∀ a b c : ℕ, a^2 + b^2 = c^2 → ... := by
 
 ## AlphaProof (DeepMind 2024)
 
-- Premier systeme a resoudre des problemes IMO avec Lean
+- Premier système a resoudre des problemes IMO avec Lean
 - **Reinforcement learning** sur l'espace des preuves Lean
 - Certaines preuves verificables mais **non interpretables par un humain**
 
@@ -258,7 +258,7 @@ theorem fermat_last_n2 : ∀ a b c : ℕ, a^2 + b^2 = c^2 → ... := by
 
 - **Orchestrateur** : decompose un theoreme complexe en sous-buts
 - **Prouver** : tente chaque sous-but avec tactiques + LLM
-- **Verifier** : Lean verifie formellement chaque etape
+- **Verifier** : Lean verifie formellement chaque étape
 
 ```python
 from prover.agents import MultiAgentSorryProver
@@ -298,7 +298,7 @@ kernel.add_plugin(lean_plugin, "Lean")
 
 ## Architecture multi-agents pour les preuves
 
-- **Orchestrateur** : planifie la strategie de preuve globale
+- **Orchestrateur** : planifie la stratégie de preuve globale
 - **Tactician** : selectionne les tactiques locales
 - **Checker** : verifie la validite formelle
 - **Explainer** : traduit la preuve en prose mathematique
@@ -309,7 +309,7 @@ kernel.add_plugin(lean_plugin, "Lean")
 
 # Lean 10 — LeanDojo
 
-## Extraction de donnees depuis Mathlib
+## Extraction de données depuis Mathlib
 
 ```python
 from lean_dojo import LeanGitRepo, trace
@@ -362,7 +362,7 @@ theorem network_robust (x : Vector ℝ n) (ε : ℝ) (hε : ε > 0) :
 
 ## Le theoreme (Huang 2019)
 
-**Tout** circuit booleen de profondeur `d` calcule une fonction de sensibilite ≤ `2^(d-1)`.
+**Tout** circuit booléen de profondeur `d` calcule une fonction de sensibilite ≤ `2^(d-1)`.
 Preuve utilisant les **graphes d-dimensionnels et les matrices signing**.
 
 ```lean
@@ -377,7 +377,7 @@ theorem sensitivity_theorem (f : BoolFunc n) (C : Circuit n) :
 ## Significance
 
 - Resout une **conjecture ouverte depuis 30 ans**
-- Premiere preuve formelle en Lean 4 dans ce repo
+- Première preuve formelle en Lean 4 dans ce repo
 
 > **Notebook** : `Lean-12-Sensitivity-Theorem.ipynb` — 60 min
 
@@ -408,7 +408,7 @@ Lean 4
 | Serie | Lien |
 |-------|------|
 | **S1-argumentation** | Argumentation formelle (Tweety ↔ Lean) |
-| **S6-tweety** | Preferences → Arrow's impossibility prouvee en Lean |
+| **S6-tweety** | Préférences → Arrow's impossibility prouvee en Lean |
 | **03-logique** | Cours magistral logique propositionnelle + FOL |
 | **GameTheory** | `social_choice_lean/` : Arrow/Sen/Voting formels |
 

--- a/slides/S8-semantic-web/slides.md
+++ b/slides/S8-semantic-web/slides.md
@@ -1,7 +1,7 @@
 ---
 theme: ../theme-ia101
-title: "Web Semantique - dotNetRDF & Python"
-info: IA 101 - Web semantique, ontologies et graphes de connaissances
+title: "Web Sémantique - dotNetRDF & Python"
+info: IA 101 - Web sémantique, ontologies et graphes de connaissances
 paginate: true
 drawings:
   persist: false
@@ -10,10 +10,10 @@ mdc: true
 layout: cover
 ---
 
-# Web Semantique — RDF, SPARQL, OWL et Knowledge Graphs
+# Web Sémantique — RDF, SPARQL, OWL et Knowledge Graphs
 
-- Modele de donnees : RDF, triplets, graphes nommes
-- Interrogation : SPARQL, requetes federees, Linked Data
+- Modèle de données : RDF, triplets, graphes nommes
+- Interrogation : SPARQL, requêtes federees, Linked Data
 - Schema et ontologies : RDFS, OWL 2, SHACL
 - Web moderne : JSON-LD, RDF-Star, Knowledge Graphs
 - Integration IA : GraphRAG, raisonneurs OWL
@@ -30,16 +30,16 @@ layout: section
 
 ## Objectifs pedagogiques
 
-- Comprendre le **modele RDF** : triplets, URI, types de noeuds, serialisation
+- Comprendre le **modèle RDF** : triplets, URI, types de noeuds, serialisation
 - Interroger des graphes avec **SPARQL** et les endpoints du Web of Data
 - Modeliser des **ontologies** : RDFS (classes, proprietes) et OWL 2 (logiques de description)
-- Valider des donnees avec **SHACL** et manipuler JSON-LD, RDF-Star
+- Valider des données avec **SHACL** et manipuler JSON-LD, RDF-Star
 - Construire des **Knowledge Graphs** et des pipelines **GraphRAG**
 
 ## Prerequis
 
 - C# .NET Interactive (series SW-1 a SW-7) · Python 3.10+ (series SW-2b, SW-4b, SW-5b, SW-7b, SW-8+)
-- Connaissances de base en logique et en bases de donnees relationnelles
+- Connaissances de base en logique et en bases de données relationnelles
 
 ## Duree totale estimee
 
@@ -55,10 +55,10 @@ layout: section
 
 # SW-1 — Configuration et Pile Technologique
 
-## La vision du Web Semantique (Berners-Lee, 2001)
+## La vision du Web Sémantique (Berners-Lee, 2001)
 
-- Web actuel : donnees pour les humains (HTML)
-- Web Semantique : donnees comprehensibles par les **machines**
+- Web actuel : données pour les humains (HTML)
+- Web Sémantique : données comprehensibles par les **machines**
 - Pile technologique : **URI → RDF → RDFS → OWL → SPARQL → SHACL**
 
 ## dotNetRDF : la bibliotheque de reference
@@ -74,7 +74,7 @@ graph.LoadFromFile("data.ttl");
 Console.WriteLine($"Triplets : {graph.Triples.Count}");
 ```
 
-- **dotNetRDF** : parsing, requetes, raisonnement pour .NET
+- **dotNetRDF** : parsing, requêtes, raisonnement pour .NET
 - Formats supportes : Turtle, RDF/XML, N-Triples, JSON-LD
 - Namespace central : `VDS.RDF` + sous-espaces `Parsing`, `Query`, `Writing`
 
@@ -86,7 +86,7 @@ Console.WriteLine($"Triplets : {graph.Triples.Count}");
 
 ## Anatomie d'un triplet RDF
 
-Un triplet = `(sujet, predicat, objet)` — la phrase atomique du Web Semantique
+Un triplet = `(sujet, predicat, objet)` — la phrase atomique du Web Sémantique
 
 | Composant | Type | Exemple |
 |-----------|------|---------|
@@ -145,7 +145,7 @@ print(g.serialize(format="turtle"))
 
 ---
 
-# SW-3 — Operations sur les Graphes
+# SW-3 — Opérations sur les Graphes
 
 ## Lecture et ecriture de fichiers RDF
 
@@ -171,7 +171,7 @@ ttlWriter.Save(merged, writer);
 - **Named Graph** : graphe avec une URI propre (`ex:graph1`)
 - **TripleStore** : ensemble de graphes nommes (quad-store)
 - **InMemoryDataset** : dataset SPARQL multi-graphes
-- Requetes sur l'union de tous les graphes ou un graphe specifique
+- Requêtes sur l'union de tous les graphes ou un graphe spécifique
 
 > **Notebook** : `SW-3-CSharp-GraphOperations.ipynb` — 50 min
 
@@ -183,18 +183,18 @@ layout: section
 
 ---
 
-# SW-4 — SPARQL : Le SQL du Web Semantique
+# SW-4 — SPARQL : Le SQL du Web Sémantique
 
-## Types de requetes SPARQL
+## Types de requêtes SPARQL
 
-| Requete | Usage |
+| Requête | Usage |
 |---------|-------|
 | **SELECT** | Retourne des tables de variables |
 | **CONSTRUCT** | Construit un nouveau graphe RDF |
 | **ASK** | Teste l'existence d'un pattern |
 | **DESCRIBE** | Decrit une ressource |
 
-## Requete SELECT avec dotNetRDF
+## Requête SELECT avec dotNetRDF
 
 ```csharp
 var query = @"
@@ -210,7 +210,7 @@ foreach (var result in results)
     Console.WriteLine($"{result["person"]} → {result["name"]}");
 ```
 
-- **OPTIONAL** : jointure externe · **UNION** : disjonction · **MINUS** : difference
+- **OPTIONAL** : jointure externe · **UNION** : disjonction · **MINUS** : différence
 - Agregats : `COUNT`, `SUM`, `GROUP BY`, `HAVING`
 
 > **Notebooks** : `SW-4-CSharp-SPARQL.ipynb` — 45 min | `SW-4b-Python-SPARQL.ipynb` — 30 min
@@ -223,13 +223,13 @@ foreach (var result in results)
 
 | Etoiles | Critere |
 |---------|---------|
-| ★ | Donnees sur le Web, quelle que soit la licence |
-| ★★ | Donnees structurees (Excel, JSON) |
+| ★ | Données sur le Web, quelle que soit la licence |
+| ★★ | Données structurees (Excel, JSON) |
 | ★★★ | Format ouvert non-proprietaire (CSV, RDF) |
 | ★★★★ | URI pour identifier les ressources |
-| ★★★★★ | Liens vers d'autres sources de donnees |
+| ★★★★★ | Liens vers d'autres sources de données |
 
-## Requetes federees SPARQL
+## Requêtes federees SPARQL
 
 ```csharp
 // Requete sur l'endpoint public DBpedia
@@ -245,7 +245,7 @@ SELECT ?scientist ?birth WHERE {
 } LIMIT 20");
 ```
 
-- **SERVICE** : federe plusieurs endpoints en une requete
+- **SERVICE** : federe plusieurs endpoints en une requête
 - Wikidata SPARQL endpoint : `https://query.wikidata.org/sparql`
 
 > **Notebooks** : `SW-5-CSharp-LinkedData.ipynb` — 50 min | `SW-5b-Python-LinkedData.ipynb` — 35 min
@@ -262,8 +262,8 @@ layout: section
 
 ## Le vocabulaire RDFS
 
-- **`rdfs:subClassOf`** : hierarchie de classes (transitive)
-- **`rdfs:subPropertyOf`** : hierarchie de proprietes
+- **`rdfs:subClassOf`** : hiérarchie de classes (transitive)
+- **`rdfs:subPropertyOf`** : hiérarchie de proprietes
 - **`rdfs:domain`** / **`rdfs:range`** : typage implicite par inference
 - **`rdfs:label`** / **`rdfs:comment`** : documentation lisible
 
@@ -319,7 +319,7 @@ foreach (var sub in person.DirectSubClasses)
 ```
 
 - **OWL 2 EL** : expressivite polynomiale (ontologies medicales)
-- **OWL 2 RL** : regles de production (integration avec bases de donnees)
+- **OWL 2 RL** : règles de production (integration avec bases de données)
 - **OWL 2 DL** : maximum d'expressivite decidable (HermiT, Pellet)
 
 > **Notebooks** : `SW-7-CSharp-OWL.ipynb` — 55 min | `SW-7b-Python-OWL.ipynb` — 45 min
@@ -328,11 +328,11 @@ foreach (var sub in person.DirectSubClasses)
 layout: section
 ---
 
-# Web Semantique Moderne
+# Web Sémantique Moderne
 
 ---
 
-# SW-8 — SHACL : Validation des Donnees RDF
+# SW-8 — SHACL : Validation des Données RDF
 
 ## SHACL vs OWL : deux philosophies
 
@@ -368,7 +368,7 @@ print(results[2])  # rapport Turtle
 
 ---
 
-# SW-9 — JSON-LD : Le Web Semantique rencontre JSON
+# SW-9 — JSON-LD : Le Web Sémantique rencontre JSON
 
 ## JSON-LD : bridge entre JSON et Linked Data
 
@@ -398,7 +398,7 @@ compacted = jsonld.compact(doc, {"foaf": "http://xmlns.com/foaf/0.1/"})
 
 - **`@context`** : mappe les cles JSON vers des URI
 - **`@type`** : declare la classe de l'entite
-- **Framing** : restructurer un graphe RDF en JSON specifique
+- **Framing** : restructurer un graphe RDF en JSON spécifique
 - Adoption massive : Schema.org, ActivityPub, Verifiable Credentials
 
 > **Notebook** : `SW-9-Python-JSONLD.ipynb` — 40 min
@@ -407,7 +407,7 @@ compacted = jsonld.compact(doc, {"foaf": "http://xmlns.com/foaf/0.1/"})
 
 # SW-10 — RDF 1.2 (RDF-Star) : Assertions sur des Assertions
 
-## Le probleme de la reification classique
+## Le problème de la reification classique
 
 **But** : annoter un triplet (confiance, source, date...)
 
@@ -456,7 +456,7 @@ Un **graphe de connaissances** = graphe RDF a grande echelle, oriente metier
 | Exemples | Triplets | Usage |
 |---------|---------|-------|
 | **Wikidata** | ~14 milliards | Encyclopedie universelle |
-| **Google KG** | ~500 milliards | Recherche semantique |
+| **Google KG** | ~500 milliards | Recherche sémantique |
 | **DBpedia** | ~3 milliards | Extraction Wikipedia |
 | **Schema.org** | — | Balisage SEO universel |
 
@@ -527,7 +527,7 @@ for s, p, o in extract_triples(document):
 |-----------|---------|-------------|
 | **owlrl** | Python | Leger, RDFS + OWL RL |
 | **HermiT** | Java | OWL 2 DL complet, reference |
-| **reasonable** | Rust | Tres rapide, OWL RL |
+| **reasonable** | Rust | Très rapide, OWL RL |
 | **Growl** | Python | Interface simple, owlready2 |
 | **Pellet** | Java | OWL 2 DL, explications |
 
@@ -562,16 +562,16 @@ layout: section
 
 ---
 
-# Ecosysteme Web Semantique
+# Ecosysteme Web Sémantique
 
 ## Notebooks de la serie
 
-| Notebook | Theme | Langage | Duree |
+| Notebook | Thème | Langage | Duree |
 |---------|-------|---------|-------|
 | SW-1 | Setup, pile technologique | C# | 20 min |
 | SW-2 / SW-2b | RDF : triplets, serialisation | C# / Python | 45+40 min |
-| SW-3 | Operations graphes, TripleStore | C# | 50 min |
-| SW-4 / SW-4b | SPARQL : requetes, agregats | C# / Python | 45+30 min |
+| SW-3 | Opérations graphes, TripleStore | C# | 50 min |
+| SW-4 / SW-4b | SPARQL : requêtes, agregats | C# / Python | 45+30 min |
 | SW-5 / SW-5b | Linked Data, DBpedia, Wikidata | C# / Python | 50+35 min |
 | SW-6 | RDFS : schema, inference | C# | 45 min |
 | SW-7 / SW-7b | OWL 2 : ontologies, profils | C# / Python | 55+45 min |
@@ -589,7 +589,7 @@ layout: section
 ## Connexions dans le cours IA 101
 
 - **S6-TweetyProject** : raisonnement en Description Logics (DL) via TweetyProject — complement OWL
-- **S7-Lean** : preuves formelles de proprietes logiques — fondements theoriques des ontologies
+- **S7-Lean** : preuves formelles de proprietes logiques — fondements théoriques des ontologies
 - **03-logique** : cours magistral sur la logique, base pour RDFS/OWL
 - **GameTheory/social_choice_lean** : exemple de formalisation avec Arrow/Sen
 
@@ -626,7 +626,7 @@ W3C Semantic Web Stack
 - Integration **Neo4j** (Cypher + plugin RDF) pour visualisation de KG
 - **SPARQL federation** : combiner Wikidata + DBpedia + endpoints prives
 - **Ontologie medicale** : SNOMED-CT, GO (Gene Ontology) avec raisonneurs EL
-- **LLM + SPARQL** : generation automatique de requetes (Text-to-SPARQL)
+- **LLM + SPARQL** : generation automatique de requêtes (Text-to-SPARQL)
 
 ---
 layout: section
@@ -640,6 +640,6 @@ layout: end
 
 # Merci
 
-Serie Web Semantique — IA 101
+Serie Web Sémantique — IA 101
 
 `MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/`


### PR DESCRIPTION
Grain: LIGHT/slides — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-python #11595 (QC density)

## Summary

Lot L1 tranche 2 de l'EPIC #11508 (slides migration Slidev) : applique la cure canonique #2876 via l'adaptateur `.md` (#11548) sur les 11 decks restants après la tranche 1 (#11550 = 01-04).

## Substance tranche 2

| Deck | Cures | Lignes touchées |
|---|---|---|
| 05-theorie-des-jeux | 108 | 94 |
| 06-apprentissage | 17 | 17 |
| 07-elargissements | 75 | 63 |
| 08-ia-generative | 27 | 25 |
| S6-tweety | 23 | 22 |
| S7-lean | 10 | 10 |
| S8-semantic-web | 46 | 42 |
| S4-trading-exercices | 40 | 40 |
| S4 deck-1-fondamentaux | 82 | 70 |
| S4 deck-2-strategies | 155 | 135 |
| S4 deck-3-pratique-lean | 52 | 50 |
| **TOTAL** | **635** | **568** |

Diff global : 568 insertions / 568 deletions (substitutions 1-pour-1 strictes, aucun ajout/suppression de ligne).

## Méthodologie

1. **Application canonique** : `restore_accents_canonical.py --apply` sur 11 decks (l'adaptateur `.md` est sur main depuis #11548).
2. **Audit strict** : pour chaque mot supprimé du `-`, vérification qu'un équivalent (avec ou sans accent) existe dans le `+`. Résultat : **0 truly removed** — toutes les formes stripped retrouvent leur équivalent accentué. Cf. `scratchpad/audit_strict.py`.
3. **Préservation fin de ligne** : tous les decks cible étaient déjà en LF, vérifié après cure.
4. **Pas de faux positifs** : le dictionnaire #2876 exclut les formes où `stripped` est un mot anglais valide (`resolution`, `recompense`, `differentielle`, `interdependance`, etc.) — ces mots restent non-curés par construction. Extension du dico = grain séparé.

## Périmètre disjoint

- **tranche 1 (#11550)** = decks 01-04, déjà mergé (4 decks, 222 substitutions)
- **PR #11605 (po-2024, S1+S2)** = sous-arbres S1-argumentation + S2-ia-exploratoire-symbolique. **Hors scope** de cette tranche. Sera obsolète si po-2024 merge S1/S2 également (mais c'est leur décision ; pas bloquant).
- **S3-acculturation** (3 occurrences) explicitement hors scope — toutes légitimes d'après le body de #11508 (chemins `GenAI/Video/` et mot anglais *Generation* dans *RAG*).
- **Restant après cette tranche** : S1, S2 (PR #11605 orphelin ou à merger par po-2024), S3 (3 occurrences légitimes).

## Pourquoi ce grain (R7, R5, G-VAR-1)

- **DEEP/slides** = genre CONTENU, fait valoir une capacité distinctive (la cure canonique par construction) — répond à G-VAR-1 (plancher DEEP/MED dans un genre de CONTENU).
- **Pool global** : pas un grain de po-2024 ni po-2025 — la lane po-2025 a claimé les tranches Quarto (#10923), la lane po-2024 a claimé L1 lot 1 S1/S2. Tranche 2 = zone franche du pool global, prise par règle proactive-coordination R5 (backlog pickup, jamais siloté).
- **Variété** (G-VAR-3, R6) : prev = DEEP/notebook-python #11595, ce grain = DEEP/slides. Pas le même genre que le précédent. Adjacence OK.

## Liens

- Issue parente : #11508
- Pré-requis fusionnés : #11548 (adaptateur .md), #11550 (tranche 1)
- Registre : #2876 (backlog accents), [docs/reference/accent-cure-defense-in-depth.md](docs/reference/accent-cure-defense-in-depth.md)

---

**Requalification ai-01 (merge-gate, `variation-protocol.md` §3).** Tag d'origine : `Grain: DEEP/slides — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-python #11595 (QC density)`. Requalifie en `Grain: LIGHT/slides — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-python #11595 (QC density)` — 568 substitutions d'accents 1:1 sur 11 decks (+562/-562) est l'illustration canonique du litmus LIGHT : la tranche suivante se genere en scannant le deck d'a cote. `DEEP` demanderait un resultat ou une capacite qui n'existait pas. Le tier est corrige **dans le body** et non en commentaire : le cap G-VAR-2 lit le body, une requalification postee a cote le laisserait compter faux. Budget de la lane verifie avant merge, la requalification ne le depasse pas.
