### PR TITLE
feat(twin,#11200): Vague 5 bascule native-both - 18 TRIVIAL_BASCULE residuelles (5 familles)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-4-nashequilibrium.yaml
@@ -2,10 +2,15 @@
   family: GameTheory/.NET-Parity
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-4-NashEquilibrium-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Pont SOTA rajoute cote C# (mandat #10382) : nashpy (lib SOTA du twin Python, `nash.Game(A,B).support_enumeration()`) invoque depuis le notebook C# via CLI Process.Start (cellule 6.3) sur les 5 jeux canoniques (PD, MP, BoS, RPS, Asym 3x2), en plus du pont Gambit CLI deja branche (cellule 6.2, PR #10442). Axes binding (#10459) : CLI pur (axe 3) -- AUCUN binding .NET/NuGet (axe 1), AUCUN P/Invoke (axe 2), AUCUNE IKVM (axe 4), AUCUN PythonNet (axe 5). Axe 6 : nashpy couvre le meme role que le SupportEnumeration from-scratch (enumeration de supports pour les NE purs et mixtes) -> le pont est desormais wire. Comparaison numerique (cellule 6.3 du C#) : 5/5 jeux concordent (ecart max 3.3e-07, exploitabilite = 0 partout). RPS : nashpy retrouve l'equilibre uniforme (1/3,1/3,1/3) ; BoS : 3 NE (2 purs + mixte 2/3,1/3) ; Asym : 2 NE mixtes -- identiques aux resultats du twin Python (meme moteur nashpy). From-scratch BCL .NET conserve : le pont est EN PLUS jamais A LA PLACE. parity_level `semantic` conservee (cf. jumeaux part-2 et GT-4, precedent pont Gambit)."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74
+      csharp_sha: e3a20c5a309c90f173c5494dc7cd032aa77fe37c
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint scipy.optimize.linprog (solveur LP) et nashpy (cell1 `import nashpy`), C# atteint les binaires Gambit 16.7.0 (gambit-lcp Lemke-Howson + gambit-enummixed via Process.Start, cell25-26) ainsi qu'un pont nashpy de cross-check (cell29). Les deux cotes executent des solveurs d'equilibre de production. NB : le hit 'IKVM' du detecteur etait un artefact (aucune occurrence IKVM dans le notebook C#, verifie par grep). Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: c74eabd61cd743f4247dd1e29cc9a4f813859e74

--- a/scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-8-knowledgegraphs-ilp.yaml
@@ -2,8 +2,13 @@
   family: SymbolicAI/SymbolicLearning
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-8-KnowledgeGraphs-ILP-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: c7e229126c670dac3e3d119b56b8f727003bce8a
+      csharp_sha: 376249822ecee95d86a8d1f806a99b7595486bc7
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint rdflib, C# atteint dotNetRDF 3.4.1 (#r nuget + using VDS.RDF / VDS.RDF.Parsing). Les deux bibliotheques RDF de reference de leur ecosysteme. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: c7e229126c670dac3e3d119b56b8f727003bce8a

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-10-ortools.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-10-ortools.yaml
@@ -2,10 +2,15 @@
   family: Sudoku
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-10-ORTools-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Google OR-Tools (3 sous-modules : ConstraintSolver routing, LinearSolver LP, Sat CP-SAT) : Python = `ortools` PyPI package (`from ortools.sat.python import cp_model`, `from ortools.linear_solver import pywraplp`, `from ortools.constraint_solver import pywrapcp`). C# = `Google.OrTools.{Sat,LinearSolver,ConstraintSolver}` NuGet packages (bindings SWIG officiels). Meme solveur C++ natif upstreams de Google Operations Research, accessible via les bindings Python (.whl) et C# (.nupkg). Verifie firsthand (c.235 audit 2026-08-12, myia-po-2023:CoursIA-2) : Python 30 cells / C# 35 cells, structure pedagogique symetrique (memes configurations de puzzles, memes benchmarks CP-SAT, memes options solver). Pont cross-stack impossible : bindings SWIG non bridgeables (meme pattern que Sudoku-18 precedent c.234). Parite semantique mecaniquement preservee tant que les versions PyPI/NuGet restent synchronisees. Verdict SOTA-OK : OR-Tools est la SOTA OR solver pour les deux stacks."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 70f823c8b712136c465fd938f1b75cf866682fdb
+      csharp_sha: 2b03463a08e447e52305d4e20c6a7c30101ca43a
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint ortools (CP-SAT, 5 imports), C# atteint Google.OrTools (#r nuget + using, 29 occurrences). Meme moteur CP-SAT des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 25c9790ba0ba6e5e4747515ff7fc7c60829569bb

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-11-choco.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-11-choco.yaml
@@ -2,10 +2,15 @@
   family: Sudoku
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-11-Choco-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Java Choco-Solver : C# branche IKVM-Choco via DLL `org.chocosolver.solver.dll` trackee sur disque (Choco 4.10.17, IKVM 8.15.0) + 5 `using org.choco.*` explicites + 18 refs `IKVM` runtime + cells 12. Python branche JPype + 11 refs `choco` + 19 refs `jpype` + `from org.chocosolver.solver import Model` runtime. Meme moteur Java Choco-Solver 4.10.17 des deux cotes, accessible via deux chemins distincts (JPype-JVM-runtime cote Python, IKVM-bytecode .NET cote C#). Verifie firsthand (c.234 audit 2026-08-12, myia-po-2023:CoursIA-2) : DLL trackee, csproj IKVM-Choco deja construit (c.218 PR #10561 \"tranche 5 CSP\" a couvert 5 paires dont Choco-bridgeable), kernel .NET Interactive execute le twin C#. Pont IKVM-bytecode .NET vs JPype-JVM-runtime sur le meme moteur Java. Verdict SOTA-OK : Choco-Solver est la SOTA CSP solver pour les deux stacks, aucun autre solveur ne le remplacerait avantageusement. Build IKVM deja fait sur le runner (DLL trackee = artefact build, pas a reconstruire)."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 7f0b6526246d282b666a5e1305f46f87ef55317a
+      csharp_sha: 225710e79b086d5bf54282e53d6cfe925de53357
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint le solveur Choco 4.10.17 (JAR Maven charge via JPype, cell5), C# atteint Choco via la DLL pre-compilee IKVM (ChocoVersion 4.10.17, cell2). Meme moteur Choco des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: aa49b097f61d8b7feb617d65304c7a327df489cc

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-12-z3.yaml
@@ -2,10 +2,15 @@
   family: Sudoku
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-12-Z3-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Z3 SMT (Microsoft Research, open-source) : Python = `z3-solver` PyPI (`from z3 import Solver, Int, And, Or, Not, sat`, 30 cells code). C# = `Microsoft.Z3` NuGet package (bindings .NET natifs Microsoft officiels, 44 cells code dont 19 cells code + stdlib System.*). Meme solveur Z3 upstreams de Microsoft Research, accessible via les bindings Python (.whl, generes par Z3 Python API) et C# (.nupkg, Microsoft.Z3.NET API). Verifie firsthand (c.235 audit 2026-08-12, myia-po-2023:CoursIA-2) : memes formules SMT (Int sort, And/Or/Not, Distinct, sat check), memes benchmarks (sudoku encode comme 81 Int + 9x9x9 Distinct). Pont cross-stack impossible : Z3 est un solveur C++ natif, les deux bindings sont des API distinctes (Python dynamic vs C# static managed). Parite semantique preservee par la garantie que les deux versions utilisent le meme solver Z3 upstream (memes versions = memes resultats SMT). Verdict SOTA-OK : Z3 est la SOTA SMT solver pour les deux stacks, aucun autre solveur ne le remplacerait avantageusement pour la demonstration SMT."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: dc50ea9dcff0391b2f094da547ee7b50cf2fc791
+      csharp_sha: 7fb3bedc554c5739f37fb0270ba43553b20bb8eb
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint z3-solver (import z3), C# atteint Microsoft.Z3 (#r 'nuget: Microsoft.Z3' + using Microsoft.Z3). Meme moteur Z3 via les bindings officiels. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: b96f422f56c22836ef891e82a3f2df25d59453f1

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
@@ -2,10 +2,15 @@
   family: Sudoku
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib idiomatic-stack probabiliste : Python = NumPyro (SOTA Python probabilistic programming framework sur JAX, MCMC + inference variationnelle, stochastic). C# = Infer.NET (Microsoft Research legacy, SOTA .NET probabilistic programming framework, MCMC + expectation propagation + variational message passing, deterministic compilation). Les deux utilisent la SOTA PPL de leur stack respective. Pont cross-stack impossible : NumPyro est JAX-based (Python only, JAX compile XLA), Infer.NET est .NET only (compilation deterministe vers C#). Aucun bytecode commun bridgeable (pas de JPype, pas d'IKVM -- les deux PPL sont compiles dans leur stack respective). Verifie firsthand (c.235 audit 2026-08-12, myia-po-2023:CoursIA-2) : Python 34 cells / C# 47 cells, structure pedagogique symetrique (modele probabiliste Sudoku, observations, inference posterior). Asymetrie : Python = stochastic MCMC (echantillonnage NUTS), C# = deterministic variational message passing (EP/VMP). Les deux methodes sont SOTA dans leur stack, et l'objectif pedagogique (modeliser l'incertitude sur les valeurs Sudoku) est tenu. Verdict SOTA-OK : lib-vs-lib idiomatic-stack PPL, aucune asymetrie engine-mismatch a corriger."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 9c9644c74bd05c238944c93c2828fedaf23eabd6
+      csharp_sha: 4f37b203d3e70f7e894b2602ef8333374adf8197
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint NumPyro/JAX (SVI, Trace_ELBO, import jax + numpyro.infer), C# atteint Infer.NET (Microsoft.ML.Probabilistic). Les deux cotes executent un moteur de programmation probabiliste de production. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-03"
       by: myia-po-2023:CoursIA
       python_sha: d1282426b7eea1e38e808669eace82467deb0567

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-18-comparison.yaml
@@ -2,10 +2,15 @@
   family: Sudoku
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-18-Comparison-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Google OR-Tools CP-SAT : Python = `ortools` PyPI package (CP-SAT via `from ortools.sat.python import cp_model`, 21 refs `ortools` runtime). C# = `Google.OrTools` NuGet package (CP-SAT via `Google.OrTools.Sat.CpModel`, 15 refs `ortools` + 5 `Google.OrTools` namespace). Meme solveur CP-SAT upstreams de Google Operations Research, accessible via les bindings officiels Python (.whl) et C# (.nupkg). Verifie firsthand (c.234 audit 2026-08-12, myia-po-2023:CoursIA-2) : 68 cells Python / 68 cells C#, structure symetrique (memes benchmarks, memes configurations, memes hard puzzles). Pont cross-stack impossible : CP-SAT est un moteur C++ natif, les deux bindings sont des wrappers SWIG officiels (cp_model.py = SWIG-generated, Google.OrTools.Sat.CpModel = SWIG-generated). Pas de bytecode Python ↔ C# bridgeable ; la parite est garantie par le fait que les deux utilisent la meme version du meme solveur upstream. Verdict SOTA-OK : OR-Tools CP-SAT est la SOTA CP-SAT solver pour les deux stacks, et la parite semantique est mecaniquement preservee tant que les deux versions PyPI/NuGet restent synchronisees (cf c.217 PR #10557 App-tranche-4 precedent qui a verifie 5 paires A-1/3/4/11/15 sur le meme pattern `ortools` ↔ `Google.OrTools`). parity_level `semantic` coherente : idiomes differents (Python dynamique vs C# statique) mais moteur commun."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 3290e802a2543319399e78f1c8e0cea2263a50be
+      csharp_sha: 616510b87ff6246b70d595aa5dd363969e6b0046
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint ortools, C# atteint Google.OrTools (#r 'nuget: Google.OrTools') -- notebook de comparaison multi-solveurs, les moteurs compares (OrTools/Z3/Infer.NET) sont branches nativement des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-03"
       by: myia-po-2023:CoursIA
       python_sha: 36401a556e3553e4dd2a7fc52d4222251f8d6c2e

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-3-genetic.yaml
@@ -2,10 +2,15 @@
   family: Sudoku
   python: MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Python.ipynb
   csharp: MyIA.AI.Notebooks/Sudoku/Sudoku-3-Genetic-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = `pygad` PyPI (Ahmed Gad, MIT-license, GA library SOTA-tier : population, crossover, mutation, fitness, selection ; `import pygad`, `ga_instance = pygad.GA(...)`, `ga_instance.run()`, logging interface). C# = `GeneticSharp` NuGet (dbarbosettig, MIT-license, GA library SOTA-tier .NET : GeneticAlgorithm + Chromosome + Fitness + Operator ; `using GeneticSharp;` + `ga = new GeneticAlgorithm(population, fitness, selection, crossover, mutation)`). Verdict SOTA-OK : les DEUX cotes utilisent une vraie lib GA SOTA (pygad cote PY, GeneticSharp cote C#), couverture fonctionnelle equivalente (population / fitness / selection / crossover / mutation), bridge direct sans glue non-SOTA. Le notebook PY standardise les parametres via `pygad.GA(num_generations=N, ...)` ; le notebook C# fait la meme chose via les proprietes de `GeneticAlgorithm`. Asymetrie mineure : API surface differente (pygad callback-based, GeneticSharp fluent), meme algo."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 6bbc77e5c678aa6808a639631e7fb5486c97bc1a
+      csharp_sha: c2e75a81a961f86d0b228d91d50ae869b5c4b151
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint pygad (cell1 `import pygad`), C# atteint GeneticSharp (#r 'nuget: GeneticSharp' + using). Les deux bibliotheques genetiques de reference de leur ecosysteme. NB : le hit 'stan' du detecteur etait un faux positif. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-03"
       by: myia-po-2024:CoursIA-2
       python_sha: 9d99369424476c432f9edad3e34d8f66af430f2d

--- a/scripts/notebook_tools/twin_pairs.d/tweety-11-causal.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-11-causal.yaml
@@ -2,10 +2,15 @@
   family: Tweety/IKVM-JPype
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-11-Causal-Csharp.ipynb
-  parity_level: surface
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Python = JPype vers la vraie lib Java Tweety causal-1.30 (`from org.tweetyproject.causal.reasoner import ArgumentationBasedCausalReasoner`). C# = §§1-5 from-scratch pedagogique (do-calculus reimplemente, titre 'twin C# from-scratch') + §6 (PR #10570) pont IKVM chargeant `org.tweetyproject.tweety-causal.dll` (DLL build #10566, 13/13 classes causales actives, verifie firsthand via Assembly.GetExportedTypes) : `StructuralCausalModel.intervene()` Java reel invoque sous le runtime IKVM 8.15. Verdict SOTA-OK (pas de workaround degrade) : §6 prouve la parite moteur-contre-moteur -- `do(sprinkler=True)` produit `sprinkler <=> +` (surgery Java reel) IDENTIQUE au do-calculus from-scratch §3 `do(drops=True)` -> `drops <=> +`. Les DEUX cotes executent le meme moteur Java Tweety causal (Python via JPype, C# via IKVM). parity_level reste `surface` car le mode pedagogique primaire reste §§1-5 from-scratch ; §6 est le pont de validation qui confirme la conformite du from-scratch au moteur de reference."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 95aa9b6f604e806ef2e5b08c4cc2f0bb633820cc
+      csharp_sha: ca8b37b73c1335da49d4c594bc40c9cfbe469aea
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint TweetyProject causal via JPype (mode primaire, `from org.tweetyproject.causal.reasoner import ...`), C# atteint le meme moteur Java via le pont IKVM §6 (PR #10570, DLL tweety-causal 13/13 classes verifiees, `StructuralCausalModel.intervene()` reel sous IKVM 8.15). L'ancien label `surface` motivait le maintien par le mode pedagogique primaire from-scratch (§§1-5) -- critere de fidelite structurelle, precisement la lecture abandonnee par l'arbitrage Option A ; sous la semantique parite de moteur, JPype <-> IKVM satisfait native-both. L'asymetrie §§1-5 from-scratch / §6 pont reste documentee dans bridge_verdict_reason et known_differences (inchanges). Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 95aa9b6f604e806ef2e5b08c4cc2f0bb633820cc

--- a/scripts/notebook_tools/twin_pairs.d/tweety-2-basic-logics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-2-basic-logics.yaml
@@ -2,10 +2,15 @@
   family: Tweety/IKVM-JPype
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-2-Basic-Logics-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (Thimm 2012) : C# branche IKVM 8.15.0 + tweety-pl.dll (tracked 0,55 Mo) + 7 refs `org.tweetyproject.*` actifs (using + classes instantiatees), bytecode Java traduit en .NET sans JVM au runtime. Python branche JPype + `from org.tweetyproject.logics.pl.* import` + `from org.tweetyproject.logics.fol.* import`. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : les deux cotes invoquent la meme bibliotheque Java TweetyProject (sat solvers FOL, parser FOPL, raisonneur), seules les idioms de pont different (bytecode .NET vs JVM runtime). DLL source-recompilee (release 8) selon pattern c.220 IKVM causal causal rebuild — pas de maven-shade bytecode 59."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: c4d8a18d4665cefd8ef17374dec4b4c20ffe9e77
+      csharp_sha: 91f537b4dabe9e9846e6474d42af960bf5288122
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint TweetyProject via JPype (10 imports jpype + 26 references org.tweetyproject), C# atteint les DLLs Tweety compilees IKVM (17 references). Meme moteur Tweety des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: d9bd33ad8b9e97f30827123edbfece15a1d630a8

--- a/scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-3-advanced-logics.yaml
@@ -2,10 +2,15 @@
   family: Tweety/IKVM-JPype
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-3-Advanced-Logics-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (logiques conditionnelle, modale, QBF) : C# branche IKVM 8.14.0 + tweety-advanced-logics.dll (tracked) + 8 refs `org.tweetyproject.logics.cl.reasoner` etc. actifs (3 cellules avec using explicite, classes instantiatees). Python branche JPype + `from org.tweetyproject.logics.cl.reasoner import SimpleCReasoner` + meme classe Java `SimpleCReasoner` invoquee. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : les deux cotes appellent le meme solveur TweetyProject (Thimm 2012), pont IKVM-bytecode .NET vs JPype-JVM-runtime. Meme dynamique que tweety-2 et c.220 #10544 dialogues."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 26ba41f102395886cb452772ebd7a1df8bdcc584
+      csharp_sha: 52fd778d91449e795a6abe56218dda183b008190
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint TweetyProject via JPype (6 imports + 24 references), C# atteint les DLLs Tweety compilees IKVM (16 references). Meme moteur Tweety des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 26ba41f102395886cb452772ebd7a1df8bdcc584

--- a/scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-4-belief-revision.yaml
@@ -2,10 +2,15 @@
   family: Tweety/IKVM-JPype
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-4-Belief-Revision-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (revision des croyances AGM, contraction/revision) : C# branche IKVM 8.15.0 + tweety-beliefdynamics.dll (tracked) + 8 refs `org.tweetyproject.*` actifs (3 cellules avec using explicite + classes Java `SimpleKbReiter`, `DefaultRevisionOperator` invoquees). Python branche JPype + `from java.util import ArrayList, HashSet` + `from org.tweetyproject.beliefdynamics.* import` + meme bibliotheque Java TweetyProject. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : les deux cotes operent sur la meme base de connaissances Java (BeliefSet) avec les memes operateurs de revision, pont IKVM-bytecode vs JPype-JVM-runtime."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 9199041fda10f4ea0691c2130d0b77b7530ffea6
+      csharp_sha: a1787c539d0e66bfb4f097a519e55c15dfb9e217
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint TweetyProject via JPype (10 imports + 44 references) et z3 pour les modeles epistemiques, C# atteint les DLLs Tweety compilees IKVM (16 references). Meme moteur Tweety des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: a4518639c3bc575395b112d7cf3d57f4518ec09d

--- a/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-5-abstract-argumentation.yaml
@@ -2,10 +2,15 @@
   family: Tweety/IKVM-JPype
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-5-Abstract-Argumentation-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (argumentation abstraite de Dung + semantique CF2 + 11 notions d'equivalence) : C# branche IKVM 8.15.0 avec `tweety-dung.dll` + `tweety-rpcl.dll` (DLLs source-recompilees selon pattern c.220 IKVM causal rebuild, tracked sur disque) + 30 refs `org.tweetyproject.*` (cell 26 SccCF2Reasoner cell 28 11 notions equivalence via Assembly.LoadFrom + reflection IKVM sur les types exposes par les DLLs shade). Python branche JPype + `from org.tweetyproject.arg.dung.syntax import DungTheory, Argument` + meme moteur Java. Verifie firsthand (c.229, 2026-08-12, po-2023:CoursIA-2) : DLLs source compilees (pas bytecode 59 maven-shade), C# `Console.WriteLine` confirme `DLL tweety-dung chargee : ... v1.30.0`, Python `jpype.getDefaultJVMPath()` + init JVM. NB : le C# N'UTILISE PAS de `using org.tweetyproject` explicite mais instancie les types via reflection `Assembly.LoadFrom(...).GetType(...)` (pattern IKVM 8.x : IKVM traduit les packages Java en types .NET, accessibles par reflection sans `using` direct). Pont IKVM-bytecode .NET vs JPype-JVM-runtime sur le meme moteur Java."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 809a7fa5443afb8aa73aeeb82f870c575aaf1e52
+      csharp_sha: 1cb02535990e166e31594dd2d5b852dd04877aff
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint TweetyProject via JPype (9 imports + 25 references), C# atteint les DLLs Tweety compilees IKVM (20 references). Meme moteur Tweety des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2026:CoursIA
       python_sha: 809a7fa5443afb8aa73aeeb82f870c575aaf1e52

--- a/scripts/notebook_tools/twin_pairs.d/tweety-7b-ranking-probabilistic.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-7b-ranking-probabilistic.yaml
@@ -2,10 +2,15 @@
   family: Tweety/IKVM-JPype
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7b-Ranking-Probabilistic-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Lib-vs-lib meme moteur Java TweetyProject (semantiques de rangement ranking + probabilistes + division) : C# branche IKVM 8.14.0 + tweety-rpcl.dll (tracked) + 23 refs `org.tweetyproject.*` actifs (3 cellules avec using explicite, classes Dung Division, RankingSemantics Java invoquees). Python branche JPype + `from org.tweetyproject.arg.dung.divisions import Division` + meme moteur Java. Verifie firsthand (c.227, 2026-08-12, po-2023:CoursIA-2) : 23 refs = la plus grosse utilisation TweetyProject parmi les paires Tweety du registre (audited individu M-XX), les deux cotes operent sur les memes semantiques ranking (Categorizer-based, Burden-based) avec les memes theorems de comparaison."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: fb7670e9ebe474a93db4534f4f76ded9f8c0e581
+      csharp_sha: c0b08647723dabc8be38dde312640cc43ea67a96
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint TweetyProject via JPype (8 imports + 21 references), C# atteint les DLLs Tweety compilees IKVM (23 references). Meme moteur Tweety des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 8fa3516822bcc10cbc76d6cc77b2bc4d3881d945

--- a/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/tweety-9-preferences.yaml
@@ -2,10 +2,15 @@
   family: Tweety/IKVM-JPype
   python: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-9-Preferences-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Pont livre et verifie firsthand (po-2024, 2026-08-18) : rebuild-preferences.sh recompile la chaine math-1.21 -> commons-1.21 (patchee Java 8 : Files.readString/Path.of/isBlank/strip) -> plugin-1.30 -> preferences-1.30 en javac --release 8 (bytecode major 52, plafond IKVM 8.x = Java SE 8), shade + jspf-core-1.0.2 (major 50, sinon IKVM0100 drope PreferencesPlugin : 43 au lieu de 44 types), dotnet build IKVM 8.15 -> DLL 641 Ko commitee a la racine Tweety/ avec fallback de chargement dans le notebook. Re-exec reel kernel .net-csharp : 9/9 cellules CLEAN, 44 types exposes, BordaScoringPreferenceAggregator(3) instancie. RACINE DE L'ECHEC PRECEDENT : les artefacts Maven Central Tweety sont bytecode major 59 (Java 15, toutes versions y compris 1.21) et les sources v1.30 entieres exigent javac --release 11 (major 55) car commons utilise des APIs Java 11 -- les deux sont silently droppes par IKVM 8.x (warning IKVM0101 'class format error', invisible au rebuild si le cache %TEMP%/ikvm/cache/1 sert une DLL stale). L'ancien pom Maven shade (build-tweety-preferences-shade.pom.xml, supprime) produisait exactement ce major-55 : DLL de 7,4 Mo compilee avec 0 type org.tweetyproject.*. Recette canonique = rebuild-preferences.sh (miroir de rebuild-5shades.sh issue #10411)."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 1c000b05a020e453460d147199c69b529fa14bf1
+      csharp_sha: 1fc5f036c25417d0a123d2d2db97a4b509689182
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint TweetyProject via JPype (6 imports + 8 references), C# atteint le pont IKVM java8-shade reconstruit (PR #11592, DLL 641 Ko, 23 references, verdict SOTA-OK frais). Meme moteur Tweety des deux cotes. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: c2f0fd49cc676439ac5d626abd51f39dca5680a0

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-01-introduction.yaml
@@ -2,10 +2,15 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-01-Introduction-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 EST le moteur SOTA SMT, branche NATIVEMENT des deux cotes : Microsoft.Z3 (NuGet officiel, `#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, API Context ctx.MkSolver/MkConst) et pyz3 (pip z3-solver, `from z3 import *`, API fonctionnelle Solver()/Int()) sont les deux bindings de la meme lib C++ Z3 sous-jacente — pas un pont intermediaire type IKVM/PythonNet. Parite firsthand sur le concept central (SMT de base, contrainte insatisfiable) cellule 5 des deux notebooks : Python pyz3 `s.check() -> unsat` (x>5 ET x<3) == C# Microsoft.Z3 `s.check() -> UNSATISFIABLE`, meme verdict du meme moteur. Aucune asymetrie de machinerie a corriger."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 1dce7f1d5495aacad37cdac4fd21f9d211589840
+      csharp_sha: e8c5ee11e355b64c065e339e4199c23a97115462
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint z3-solver (import z3), C# atteint Microsoft.Z3 (#r 'nuget: Microsoft.Z3' + using Microsoft.Z3). Meme moteur Z3 via les bindings officiels. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 1dce7f1d5495aacad37cdac4fd21f9d211589840

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-02-sudoku.yaml
@@ -2,10 +2,15 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-02-Sudoku-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 EST le moteur SOTA SMT, branche NATIVEMENT des deux cotes : pyz3 (pip z3-solver, `from z3 import *`, API fonctionnelle Solver()/Int()/Distinct()) et Microsoft.Z3 (NuGet officiel, `#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, API Context ctx.MkSolver/MkIntConst/MkDistinct) sont les deux bindings de la meme lib C++ Z3 sous-jacente — pas un pont intermediaire type IKVM/PythonNet. Parite firsthand sur le concept central (resolution de Sudoku par encodage SMT) cellule 5 des deux notebooks : meme structure de contrainte (domaine 1-9 via `>=1,<=9`/`MkGe,MkLe`, indices figes `==`/`MkEq`, unicite `Distinct()`/`MkDistinct()` par ligne + colonne + bloc 3x3) -> meme verdict `s.check()==sat`/`s.Check()==Status.SATISFIABLE` -> 'Puzzle facile : resolu' + la meme grille 9x9 resolue. Aucune asymetrie de machinerie a corriger."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 31ede72cdc3c4895792d29b26e360cb2d31b66da
+      csharp_sha: 9922b667c446285537c687626cd76c6aa5cbcc9f
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint z3-solver (import z3), C# atteint Microsoft.Z3 (#r 'nuget: Microsoft.Z3' + using Microsoft.Z3). Meme moteur Z3 via les bindings officiels. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 31ede72cdc3c4895792d29b26e360cb2d31b66da

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-04-strings-regex.yaml
@@ -2,10 +2,15 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-04-Strings-Regex-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 string/regex theory (SeqSort) branchee NATIVEMENT des deux cotes : Microsoft.Z3 .NET (`#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, ctx.MkRange/MkConcat/MkRe/MkInRe sur Seq) et pyz3 (`from z3 import *`, Range/Concat/Plus/Re/InRe sur Seq) sont les deux bindings officiels du meme coeur C++ Z3 sous-jacent — pas un pont intermediaire type IKVM/PythonNet. Concept string-regex (date AAAA-MM-JJ sous-contrainte en groupes longueur-fixe) demontre des deux cotes. Aucune asymetrie de machinerie a corriger."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 4c04fe94faf2b0e2aea04dead81f1f46edf60b11
+      csharp_sha: dad296706c9d68300cd4184e60a0ba5bd794780a
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint z3-solver (import z3), C# atteint Microsoft.Z3 (#r 'nuget: Microsoft.Z3' + using Microsoft.Z3). Meme moteur Z3 via les bindings officiels. Imports/invocations verifies firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 4c04fe94faf2b0e2aea04dead81f1f46edf60b11


### PR DESCRIPTION
## Summary

Vague 5 de #11200 : bascule des **18 dernieres entrees TRIVIAL_BASCULE** du registre `twin_pairs.d/` vers `native-both` (arbitrage ai-01 2026-08-16, Option A : parite de moteur, lib-vs-lib). Suite des Vagues 2 (#11559) / 3 (#11576) / 3b (#11578) / 4 (#11591, mergee ce matin).

**TRIVIAL_BASCULE epuise** : scanner post-flip 18 -> 0, ALREADY_NATIVE_BOTH 84 -> 102.

## Paires moteurs verifiees firsthand (re-grep des notebooks sur origin/main, 2026-08-18)

| Paires | Python | C# |
|---|---|---|
| sudoku-12, z3-python-01/02/04 | `import z3` (z3-solver) | `#r "nuget: Microsoft.Z3"` + `using Microsoft.Z3` |
| tweety-2/3/4/5/7b/9/11 | JPype -> JARs TweetyProject (`org.tweetyproject.*`) | pont IKVM TweetyProject v1.30 -> DLLs .NET |
| sudoku-10, sudoku-18 | `from ortools...` (5 et 2 imports) | `#r "nuget: Google.OrTools"` (29/10 occurrences) |
| sudoku-11 | Choco 4.10.17 JAR Maven via JPype (cell5) | Choco 4.10.17 via DLL pre-compilee IKVM (cell2) |
| sudoku-3 | `import pygad` (cell1) | `#r "nuget: GeneticSharp"` (5 occurrences) |
| gametheory-4 | `scipy.optimize.linprog` + `import nashpy` (cell1) | binaires Gambit 16.7.0 (`gambit-lcp` Lemke-Howson + `gambit-enummixed`, Process.Start cell25-26) + pont nashpy (cell29) |
| sl-8 | `import rdflib` (2) | `#r "nuget: dotNetRDF, 3.4.1"` + `using VDS.RDF` |
| sudoku-15 | NumPyro/JAX (`SVI`, `Trace_ELBO`, cell2) | `#r "nuget: Microsoft.ML.Probabilistic"` (Infer.NET) |

## Notes de jugement (transparent pour la review)

- **gametheory-4** : le hit `IKVM` du detecteur etait un **artefact** (0 occurrence IKVM dans le notebook C#, verifie par grep). La parite moteur tient via scipy/nashpy (py) <-> Gambit + nashpy (cs).
- **tweety-11** : ancien label `surface` motive par le mode pedagogique primaire from-scratch (SS1-5) -- critere de fidelite structurelle, **lecture abandonnee par l'arbitrage Option A**. Le pont IKVM S6 (PR #10570, 13/13 classes causales verifiees) satisfait la parite moteur ; l'asymetrie reste documentee dans `bridge_verdict_reason` et `known_differences` (inchanges). *Flag pour ai-01 : cas limite surface -> native-both, contester si jugé abusif.*
- **sudoku-15** : moteurs probabilistes differents (NumPyro/JAX vs Infer.NET) mais les deux sont des moteurs de programmation probabiliste de production -- coherent avec le precedent Search-2 (networkx vs QuikGraph).
- **sudoku-3** : hit `stan` du detecteur = faux positif (jamais importe).

## Format (identique Vague 4, #11591)

Chaque entree : `parity_level` basculee + **nouvelle entree audit en tete** (date 2026-08-18, by myia-po-2026:CoursIA, `python_sha`/`csharp_sha` frais via `git ls-tree origin/main`, raison citant les moteurs verifies). `bridge_verdict`, `bridge_verdict_reason`, `known_differences` **inchanges**. Indent 4-space respectee partout (lecon de #11591).

## Validation

- `check_twin_parity.py --json` : **157/157 OK, drift 0, missing 0**
- Tests pytest twin : `test_twin_registry_integrity.py` + `test_check_twin_parity.py` = **43 PASS**
- Scanner `scan_native_both_drift.py` : TRIVIAL_BASCULE 18 -> **0**, SOLVER_FREE 12, AMBIGUOUS 13 (residuel arbitrage, hors scope)
- YAML parse OK sur les 158 fichiers du registre
- Aucun notebook modifie (registry-only, pas de re-exec requise)

See #11200 (Vague 5, contribution partielle -- residuel : SOLVER_FREE 12 / AMBIGUOUS 13 a arbitrer)

Grain: MED/twin-parity - lane myia-po-2026:CoursIA - prev: MED/twin-parity #11591
