### PR TITLE
feat(twin,#11200): arbitrage residuel SOLVER_FREE/AMBIGUOUS -- 5 flips + listing 20 semantic

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-2-normalform-part-2-support-enumeration.yaml
@@ -2,10 +2,15 @@
   family: GameTheory/.NET-Parity
   python: MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Part2-Python.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/GameTheory-2-NormalForm-Csharp-Part2.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Pont SOTA rajoute cote C# (mandat #10382) : gambit-enummixed via CLI Process.Start sur les 4 jeux canoniques (RPS, RPS biaise, Prisonnier, Matching Pennies). Axes binding (#10459) : CLI pur (axe 3) -- AUCUN binding .NET/NuGet (axe 1), AUCUN P/Invoke (axe 2), AUCUNE IKVM (axe 4), AUCUN PythonNet (axe 5). nashpy (Python) et Gambit (McKelvey-McLennan-Page, CLI autonome GPL-2.0) sont deux libs differentes (axe 6) couvrant le meme role (support enumeration pour NE mixtes) -> pont desormais SYMETRIQUE. Comparaison numerique (cellule 24 du C#) : 4/4 equilibres gambit apparaillent le from-scratch BCL (dist < 1e-3) + exploitabilite = 0 partout (premier principe verifie). From-scratch BCL .NET conserve : le pont est EN PLUS jamais A LA PLACE."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 13c27d9afd12ca9f9f5dc96c00aa761d8d5bb87c
+      csharp_sha: 10b8e4e17ac1cc612830d0c1f188cb9b8531bdea
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint nashpy (import nashpy + nash.Game(g.U1, g.U2), cell23), C# atteint l'oracle Gambit gambit-enummixed via Process.Start (cell24, McKelvey-McLennan-Page, comparaison numerique from-scratch vs Gambit sur 4 jeux canoniques). Meme configuration de parite moteur que GameTheory-4 bascule en Vague 5 (nashpy <-> Gambit). NB : le hit 'IKVM' du detecteur etait un commentaire 'AUCUNE IKVM' documentant l'axe binding CLI pur (#10459) -- artefact. Usage verifie firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-07"
       by: myia-po-2025:CoursIA
       python_sha: 13c27d9afd12ca9f9f5dc96c00aa761d8d5bb87c

--- a/scripts/notebook_tools/twin_pairs.d/socialchoice-4-computational-aggregation-sat-z3.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/socialchoice-4-computational-aggregation-sat-z3.yaml
@@ -2,8 +2,13 @@
   family: GameTheory/SocialChoice
   python: MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3.ipynb
   csharp: MyIA.AI.Notebooks/GameTheory/SocialChoice/04-Computational-Aggregation-SAT-Z3-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 55b19576fd2c02160625ca3eebeaf023bce06c2b
+      csharp_sha: a889aa74d072a98a1459feb819d1fb6ba7f51d3c
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint z3-solver (from z3 import (...), encodage SAT des aggregations), C# atteint Microsoft.Z3 (using Microsoft.Z3 + new Context(), 7 occurrences). Meme moteur Z3 via les bindings officiels. Entree issue du bucket SOLVER_FREE du detecteur -- le hit Z3 etait reel des deux cotes. Usage verifie firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: f42738edd2aadd75ac4653d1dc4ba41b464c48b3

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-03-tactics.yaml
@@ -2,10 +2,15 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-03-Tactics-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 EST le moteur SOTA, branche NATIVEMENT des deux cotes : Microsoft.Z3 (NuGet officiel) et pyz3 sont les deux bindings de la meme lib C++ Z3 sous-jacente (pas un pont intermediaire type IKVM/PythonNet). Parite firsthand sur Tactic('simplify') cellule 1 des deux notebooks : meme output SMT-LIB canonique — C# '(not (<= x 0))' == Python 'Not(x <= 0)' et C# '(= y (+ 5 x))' == Python 'y == 1 + x'. Aucune asymetrie de machinerie a corriger."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 596992096613fb08367a5e41fae56b1b01254572
+      csharp_sha: e6afd62be0a2544fd62cc7f9013fa370adc0cafd
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint z3-solver (from z3 import *, tactiques TryFor/Simplify/Then), C# atteint Microsoft.Z3 (using Microsoft.Z3 + new Context(), 5 occurrences). Meme moteur Z3 via les bindings officiels. Entree issue du bucket AMBIGUOUS du detecteur -- parite Z3 confirmee firsthand. Usage verifie firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 596992096613fb08367a5e41fae56b1b01254572

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-05-quantifiers-proofs.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-05-quantifiers-proofs.yaml
@@ -2,10 +2,15 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-05-Quantifiers-Proofs-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 quantifiers & proofs branche NATIVEMENT des deux cotes : Microsoft.Z3 .NET (`#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, ctx.MkForall/MkExists, Solver.Check() = Status.UNSATISFIABLE = preuve par refutation) et pyz3 (`from z3 import *`, ForAll/Exists, prove() par refutation, Fermat last theorem = unknown) sont les deux bindings officiels du meme coeur C++ Z3 — pas un pont intermediaire. Aucune asymetrie de machinerie a corriger."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: eb97e27e946c3c2e8e6c3e46e02e4abf0655e3d9
+      csharp_sha: 1934af8e843c3bc8359671b0f47f0614b2af126b
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint z3-solver (from z3 import *, quantificateurs/proofs), C# atteint Microsoft.Z3 (using Microsoft.Z3 + Context + Optimize/Solver, 21 occurrences). Meme moteur Z3 via les bindings officiels. Entree issue du bucket AMBIGUOUS du detecteur -- parite Z3 confirmee firsthand. Usage verifie firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 6d85c875a279e2db3161677684c9fb2433503195

--- a/scripts/notebook_tools/twin_pairs.d/z3-python-06-advanced-optimization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/z3-python-06-advanced-optimization.yaml
@@ -2,10 +2,15 @@
   family: SMT/Z3-API
   python: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-API/Z3-Python-06-Advanced-Optimization-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   bridge_verdict: SOTA-OK
   bridge_verdict_reason: "Z3 optimization (MaxSAT / objectifs hierarchiques / front de Pareto) branchee NATIVEMENT des deux cotes : Microsoft.Z3 .NET (`#r \"nuget: Microsoft.Z3\"` + `using Microsoft.Z3;`, ctx.MkOptimize/MkMaximize/MkAssertSoft) et pyz3 (`from z3 import *`, Optimize/maximize/assert_soft) sont les deux bindings officiels du meme coeur C++ Z3 — pas un pont intermediaire. Concept porte au twin C# c.8052/#3801 (capstone budget 100->80, cas non-degenere, DRIFT resorbe). Aucune asymetrie de machinerie a corriger."
   audits:
+    - date: "2026-08-18"
+      by: myia-po-2026:CoursIA
+      python_sha: 21568eafac5f6a33ccccf09748fabdb00ac651ce
+      csharp_sha: 09839b0862080005043750fa15b42b91a8ab13cb
+      reason: "parity_level basculee -> native-both (arbitrage ai-01 2026-08-16 #11200 Option A, parite de moteur lib-vs-lib) : Python atteint z3-solver (from z3 import *, optimization avancee), C# atteint Microsoft.Z3 (using Microsoft.Z3 + new Context()). Meme moteur Z3 via les bindings officiels. Entree issue du bucket AMBIGUOUS du detecteur -- parite Z3 confirmee firsthand. Usage verifie firsthand sur les notebooks de la paire (re-grep origin/main 2026-08-18). bridge_verdict_reason inchangee."
     - date: "2026-08-04"
       by: myia-po-2023:CoursIA
       python_sha: 21568eafac5f6a33ccccf09748fabdb00ac651ce


### PR DESCRIPTION
## Summary

Arbitrage per-entrée du résiduel #11200 après Vague 5 (#11608) : les buckets **SOLVER_FREE (12)** et **AMBIGUOUS (13)** du détecteur, vérifiés entrée par entrée par lecture des notebooks des deux côtés (re-grep origin/main, 2026-08-18).

**5 flips** (parité moteur constatée firsthand) + **20 maintenus `semantic`** avec justification (listing = critère d'acceptance « lister, ne pas basculer en masse »).

## Les 5 flips

| Entrée | Python | C# |
|---|---|---|
| socialchoice-4 | `from z3 import (...)` | `using Microsoft.Z3` + `new Context()` (7 occ) |
| z3-python-03 | `from z3 import *` | `#r nuget Microsoft.Z3` + `Context` (5 occ) |
| z3-python-05 | `from z3 import *` | `using Microsoft.Z3` + `Optimize/Solver` (21 occ) |
| z3-python-06 | `from z3 import *` | `using Microsoft.Z3` + `new Context()` |
| gametheory-2-part2 | `nash.Game(g.U1, g.U2)` (nashpy, cell23) | Gambit `gambit-enummixed` via `Process.Start` (cell24) — même configuration que GameTheory-4 (Vague 5) |

Note gt-2-part2 : le hit `IKVM` du détecteur était un **commentaire** « AUCUNE IKVM... Gambit est un .exe autonome » (artefact).

## Les 20 maintenus `semantic` (listing)

**From-scratch des deux côtés (aucun moteur détecté dans les notebooks)** : app-20-sudokubenchmark, gt-10/12/16/8/9 (les hits pymc/Infer.NET du détecteur venaient du texte `bridge_verdict_reason` des yaml, pas des notebooks), gt-4c-nashexistence, gt-6-evolutiontrust, planners-9-htn, sudoku-2-dancinglinks, sudoku-6-aima-csp, sudoku-14-bdd, sudoku-8-humanstrategies (hit networkx = texte yaml).

**Asymétriques (moteur d'un seul côté — pas de parité)** : gt-2-normalform (nashpy py seul), gt-11-bayesiangames (scipy py seul), csp-9-distributed (networkx py seul), gt-13-imperfectinfo-cfr (pyspiel py seul), gt-17-multiagent-rl (pyspiel py seul), gt-7-extensiveform (networkx+pyspiel py seul), ml-5-timeseries (ML.NET cs seul).

## Validation

- `check_twin_parity.py --json` : **157/157 OK, drift 0, missing 0** (re-vérifié sur la branche)
- Tests pytest twin : **43 PASS**
- Scanner : SOLVER_FREE 12 → 10, AMBIGUOUS 13 → 10, ALREADY_NATIVE_BOTH 102 → 107
- YAML parse OK (158 fichiers)
- Fichiers **disjoints** de #11608 (branche indépendante depuis origin/main)

See #11200 (contribution partielle — listing des 20 semantic documenté)

Grain: MED/twin-parity - lane myia-po-2026:CoursIA - prev: MED/twin-parity #11608
