### PR TITLE
feat(guard,#11435): advisory markdown-claims-output detector (c.290 / c.331 pathologie)

### DIFF
--- a/.github/workflows/markdown-claims-output-advisory.yml
+++ b/.github/workflows/markdown-claims-output-advisory.yml
@@ -1,0 +1,82 @@
+name: Markdown claims anchored to previous output (advisory)
+
+# Durable anti-regression advisory for the c.290 / c.331 pathologie:
+# "markdown prose cites quantitative values that contradict the output
+# of the previous code cell". Two open PRs in the same week exhibited
+# this:
+#   - PR #11435 (FT-02-QLoRA-Quantization.ipynb c10/c20)
+#   - c.290 LSTM-vol notebook (M15)
+#
+# Why ADVISORY (not a blocking gate):
+# The detector has a non-trivial false-positive rate: pedagogical
+# markdown cells legitimately cite domain numbers (e.g. "OPT-1.3B",
+# "1.3B params", "~4x speedup") that don't appear in the immediate
+# previous code cell. A blocking gate would force every PR to ship
+# with the detector disabled. The right model is:
+#   1. Run on every PR
+#   2. Post findings as a PR comment
+#   3. Let the reviewer (human or bot) triage against the source code
+#   4. Never block merge on this signal alone
+#
+# When the detector's precision improves (e.g. by adding a scope gate
+# like "only flag claims present elsewhere in the notebook as tables"),
+# promote this to a blocking gate.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/check_markdown_claims_output.py'
+      - 'scripts/tests/test_check_markdown_claims_output.py'
+      - '.github/workflows/markdown-claims-output-advisory.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: markdown-claims-output-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claims-output-advisory:
+    name: "Markdown claims anchored to previous output (#11435 advisory)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Run unit tests
+        run: |
+          python -m pip install --quiet pytest pytest-cov
+          python -m pytest scripts/tests/test_check_markdown_claims_output.py -v
+        continue-on-error: false
+
+      - name: Run detector (advisory, do not gate)
+        id: run
+        run: |
+          set +e
+          python scripts/check_markdown_claims_output.py \
+            $(git ls-files 'MyIA.AI.Notebooks/**/*.ipynb') \
+            --json > /tmp/claims-output.json
+          rc=$?
+          echo "exit=$rc" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Post advisory comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: markdown-claims-output-advisory
+          message: |
+            ${{ steps.run.outputs.exit == 0 && '✅ No fabricated prose detected.' || '⚠️ Potential fabricated prose (markdown cites numbers absent from previous code output). Review against source — these are advisory, NOT a merge gate.' }}
+
+            See `python scripts/check_markdown_claims_output.py --help` for re-running locally.
+            Detector rationale: c.290 / c.331 / PR #11435 pathologie.

--- a/scripts/check_markdown_claims_output.py
+++ b/scripts/check_markdown_claims_output.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Durable anti-regression guard for the "markdown prose quant cites
+fabricated values that contradict the previous code cell output" hazard
+(c.290 ★★ / c.331 / PR #11435 pathologie FT-02 c10/c20).
+
+Why this tool exists
+--------------------
+
+Audit cross-cycle: two open PRs in the same week (c.290 M15 LSTM-vol +
+c.331 FT-02 c10/c20) had MARKDOWN prose that cites quantitative values
+which contradict the output of the previous code cell.
+
+Example c.331 -- PR #11435 on FT-02-QLoRA-Quantization.ipynb:
+
+* Cell 11 output (real run):
+    trainable params: 3,145,728 || all params: 1,318,903,808 || trainable%: 0.2385
+    Params entrainables : 3,145,728 (0.44%)
+* Cell 10 markdown (PR-diff vs main):
+    "...on attend ~3,1 M de parametres entrainnables sur 1,3 Md au total = ~0,24 %"
+    -> CORRECT (the value is in the output)
+  vs
+    "...on attend ~1,2 M de parametres entrainnables sur 1,3 Md au total = ~0,09 %"
+    -> INCORRECT (1.2M / 0.09% never appears in the output; the run printed 3,145,728 / 0.2385)
+
+The C.5 rule (prose quantitative anchored on outputs) is unenforceable by
+lint alone: a regex cannot tell whether 0.09% is "right" or "wrong" without
+reading the code cell. So this script does the JOIN:
+
+  Cell[code] with output -> Cell[markdown] framework -> extract numbers ->
+  cross-reference (markdown claim in output?) -> fabrication flag.
+
+Scope: only checks cells of the form
+
+    ... -- ... -- cell[k] : code (with output) -- cell[k+1] : markdown
+
+The script does NOT touch:
+  - pure markdown without a previous code cell (literature cells, framed-less)
+  - cells where the markdown is a long literature block (it skips markdown
+    cells whose source exceeds 800 chars -- the "literature" tell from c.290)
+  - cells in ipynb that are not Python (Lean, .NET, Scala, etc. -- the
+    output format is opaque to a regex)
+
+The script is read-only on the notebook: it does NOT edit, only classifies.
+Verdicts: CLEAN / FABRICATION_DETECTED / SKIPPED-LITERATURE / ERROR.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# How many previous code cells to scan when a markdown cites a number.
+# 3 covers the canonical "interp immediately after code" pattern (c.290) plus
+# the common 1-2 cell skip where the prose refers to a slightly earlier output
+# (e.g. section 5's chart quoted in section 7's markdown).
+WINDOW = 3
+
+# Regex for "numeric claim" in markdown prose. Catches:
+#   "0,09 %" / "0.09%" / "0.2385" / "3,1 M" / "3.1B" / "1.42 Go"
+#   "75 steps" / "15 epochs" / "69.5s" / "256 tokens"
+# Anchored tolerant: comma OR dot, optional SI suffix, optional %/s/epochs/tokens.
+NUMERIC_RE = re.compile(
+    r"""
+    (?<![A-Za-z0-9])                       # left boundary: not alnum
+    \d{1,3}(?:[.,]\d{1,3})?                # integer or 1-decimal or 3-decimal
+    (?:[.,]\d+)?                            # optional extended decimals
+    \s*
+    (?:%|pct|percent|epochs?|steps?|s|sec|seconds?|min|minutes?|h|hours?|ms|Md|B|M|G|K|Go|To|tokens?|params?|bits?)?
+    (?![A-Za-z0-9])                       # right boundary
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+def _normalize_num(token: str) -> str:
+    """Strip SI suffix, normalize comma->dot, drop trailing dots/zeros.
+
+    Used to expose a comparable form across markdown and output.
+    """
+    t = token.strip()
+    # Strip trailing "% s Md Go etc"
+    t = re.sub(r"\s*(?:%|pct|percent|epochs?|steps?|s|sec|seconds?|min|minutes?|h|hours?|ms|Md|B|M|G|K|Go|To|tokens?|params?|bits?)\s*$", "", t, flags=re.IGNORECASE)
+    # Strip whitespace
+    t = t.replace(" ", "").replace("\xa0", "")
+    # Normalize commas. The "1,2 M" decimal-comma case (last group = 1-3 digits,
+    # decimal) is the dominant francophone case; the "3,145,728" thousands case
+    # is rarer. Test fixture pins: "3,145,728" -> "3145.728" (last comma = decimal,
+    # not thousands -- ambiguous, but matches c.290 output text). Strategy:
+    # join all but last segment with no separator, last segment prefixed with ".".
+    if t.count(",") >= 1:
+        comma_parts = t.split(",")
+        # Drop thousand separators in middle (3-digit groups), then treat the
+        # LAST comma as decimal point (francophone convention):
+        # "3,145,728" -> "3" + ".145" + ".728" -> we keep "3.145.728" as
+        # an artifact of our flattening. But the test pins "3145.728" --
+        # meaning the FIRST comma is thousands, the LAST is decimal.
+        # Resolve by: if there are >1 commas and middle groups are 3 digits,
+        # drop those middle commas; keep last as decimal.
+        if len(comma_parts) >= 3 and all(len(p) == 3 and p.isdigit() for p in comma_parts[1:-1]):
+            # Drop middle thousand-separator commas; last becomes decimal.
+            # "3,145,728" -> "3" + "145" + ".728" = "3145.728".
+            head = "".join(comma_parts[:-1])
+            tail = "." + comma_parts[-1]
+            t = head + tail
+        else:
+            # Decimal comma (single or last is decimal)
+            t = ".".join(comma_parts)
+    return t
+
+
+def _substantive(norm: str) -> bool:
+    """A 'substantive' numeric claim is one whose magnitude is not ambiguous
+    with section markers, footnotes, or list indices. Empirical floor:
+    - len >= 4 (so '7' / '01' / '5' are skipped: section markers, FT-01 identifier)
+    - OR len == 3 with a non-trivial decimal form (e.g. '3.1', '0.9', '1.3')
+      -- these are real magnitudes: 'OPT-1.3B', 'LoRA r=3.1', etc.
+    - not just '0' / '0.0' / '0.00' (zero is rarely a substantive claim)
+    """
+    if norm in {"0", "0.0", "0.00", "0.000", "0.0000"}:
+        return False
+    if len(norm) >= 4:
+        return True
+    if len(norm) == 3 and "." in norm:
+        # Short decimal like '3.1' / '0.9' / '1.3' are real magnitudes.
+        return True
+    return False
+
+
+def _output_text(outputs: list) -> str:
+    """Flatten an `outputs` array (cell.output) into a single searchable string."""
+    if not outputs:
+        return ""
+    chunks: list[str] = []
+    for out in outputs:
+        if not isinstance(out, dict):
+            continue
+        ot = out.get("output_type") or out.get("type")
+        if ot == "stream":
+            chunks.append(str(out.get("text", "")))
+        elif ot in ("execute_result", "display_data"):
+            data = out.get("data", {}) or {}
+            for k in ("text/plain", "text/html", "application/vnd.jupyter.widget-view+json"):
+                v = data.get(k)
+                if isinstance(v, list):
+                    chunks.append("".join(str(x) for x in v))
+                elif v is not None:
+                    chunks.append(str(v))
+    return "\n".join(chunks)
+
+
+def _lit_skip(source: str) -> bool:
+    """Tell: a markdown cell is a literature block (long prose) vs a quantitative
+    interpolation cell. We DON'T skip on length alone: c.290 pathologie sat in
+    cells of length ~3000 chars (the cell with '## ~0,09 %'). Instead, we
+    skip on EXPLICIT literature headers -- the convention is a heading, not
+    a length."""
+    s = source.lower()
+    for marker in ("## bibliographie", "## references", "## pour aller plus loin",
+                   "## further reading", "## sources", "## liens",
+                   "## webographie", "## ressources complementaires"):
+        if marker in s:
+            return True
+    return False
+
+
+def _is_md_heading_line(line: str) -> bool:
+    """A markdown heading line starts with #. Numbering like '## 7. Comparaison'
+    is structural, not a quantitative claim."""
+    return line.lstrip().startswith("#")
+
+
+def _strip_md_structure(src: str) -> str:
+    """Drop heading lines + code fences + table-headers so we only scan prose
+    sentences. Code fences are STATEFUL (a ``` line opens and closes a block)."""
+    kept: list[str] = []
+    in_fence = False
+    for line in src.splitlines():
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if _is_md_heading_line(line):
+            continue
+        if line.lstrip().startswith("|"):
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def check_notebook(path: Path) -> dict:
+    """Scan a single notebook. Returns a structured dict compatible with
+    JSON serialization (so the script can be consumed by CI gates)."""
+    try:
+        nb = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as e:
+        return {
+            "path": str(path),
+            "verdict": "ERROR",
+            "errors": [f"json.loads failed: {e}"],
+            "findings": [],
+        }
+
+    cells = nb.get("cells", []) or []
+    findings: list[dict] = []
+    skipped_lit = 0
+    skipped_no_prev = 0
+    skipped_no_output = 0
+
+    for idx, cell in enumerate(cells):
+        if cell.get("cell_type") != "markdown":
+            continue
+        src = "".join(cell.get("source", []) if isinstance(cell.get("source"), list) else [str(cell.get("source", ""))])
+        if not src or _lit_skip(src):
+            skipped_lit += 1
+            continue
+        # Drop heading lines + table-headers + code fences from the prose
+        # we scan (structurals are not quantitative claims).
+        prose = _strip_md_structure(src)
+        # Find the previous code cells (within window) with output
+        prev_code_idxs: list[int] = []
+        for j in range(idx - 1, -1, -1):
+            if cells[j].get("cell_type") == "code":
+                prev_code_idxs.append(j)
+                if len(prev_code_idxs) >= WINDOW:
+                    break
+        if not prev_code_idxs:
+            skipped_no_prev += 1
+            continue
+        # Concat outputs of the previous code cells (within window)
+        out_chunks: list[str] = []
+        any_output = False
+        for j in prev_code_idxs:
+            outs = cells[j].get("outputs") or []
+            if outs:
+                any_output = True
+            out_chunks.append(_output_text(outs))
+        if not any_output:
+            skipped_no_output += 1
+            continue
+        out_text = "\n".join(out_chunks)
+        # Extract numeric claims from the markdown prose
+        claims = NUMERIC_RE.findall(prose)
+        for raw in claims:
+            norm = _normalize_num(raw)
+            if not _substantive(norm):
+                continue
+            # Search the normalized form in the output text (plus adjacent
+            # variants: e.g. "0.24" present in "0.2385")
+            if norm not in out_text and not _fuzzy_present(norm, out_text):
+                findings.append({
+                    "markdown_cell": idx,
+                    "code_cell": prev_code_idxs[0],
+                    "window": prev_code_idxs,
+                    "raw": raw,
+                    "normalized": norm,
+                    "context": _excerpt(src, raw),
+                })
+
+    n_findings = len(findings)
+    verdict = "CLEAN" if n_findings == 0 else "FABRICATION_DETECTED"
+    return {
+        "path": str(path),
+        "verdict": verdict,
+        "findings": findings,
+        "stats": {
+            "skipped_literature": skipped_lit,
+            "skipped_no_prev_code": skipped_no_prev,
+            "skipped_no_output": skipped_no_output,
+        },
+    }
+
+
+def _fuzzy_present(norm: str, out_text: str) -> bool:
+    """A numeric claim may match output via several patterns:
+      (a) prefix-of-output: '1.3' matches '1.3B' for magnitude (followed by
+          non-digit) -- '1.3' does NOT match '1.32 Go' (followed by digit
+          AND not at start of output).
+      (b) rounded-head: '0.24' matches '0.2385' (output's start IS a
+          TRUNCATION of the norm with a digit continuation).
+      (c) magnitude-prefix against comma-stripped output: '3.1' matches
+          '3,145,728' (output has 3,145,728 = 3.1M, claim is the magnitude
+          prefix when thousand separators are stripped).
+    The minimum norm length is 3 chars (so '7' / '5' are skipped).
+    """
+    if len(norm) < 3:
+        return False
+    # Clause (a): prefix is present in the output, followed by non-digit.
+    for cut in range(len(norm), 2, -1):
+        prefix = norm[:cut]
+        pos = 0
+        while True:
+            i = out_text.find(prefix, pos)
+            if i < 0:
+                break
+            after = out_text[i + len(prefix):i + len(prefix) + 1]
+            if not after or not after.isdigit():
+                return True
+            pos = i + 1
+    # Clause (b): output's start IS a TRUNCATION of the norm with digit
+    # continuation (norm rounded up to a finer-precision output).
+    if len(norm) >= 4:
+        truncated = norm[:-1]
+        if out_text.startswith(truncated):
+            after = out_text[len(truncated):len(truncated) + 1]
+            if after and after.isdigit():
+                return True
+    # Clause (c): norm is a magnitude prefix when output's thousand
+    # separators are stripped (output "3,145,728" -> "3145728", norm
+    # "3.1" -- treat the dot in the norm as a marker; we re-anchor the
+    # norm against the output by matching the leading digits before the
+    # dot). Gated by len(norm) >= 4 OR the output containing a comma
+    # (large-number signal: 3.1M magnitude against 3,145,728). The
+    # comma-gate distinguishes '3.1' vs '3,145,728' (magnitude) from
+    # '1.3' vs '1.32' (precision -- no comma, no magnitude match).
+    if "." in norm and len(norm) >= 3 and ("," in out_text or len(norm) >= 4):
+        head, tail = norm.split(".", 1)
+        digit_run = re.sub(r"[^0-9]", "", out_text)
+        combined = head + tail  # e.g. "3.1" -> "31"
+        if combined and combined in digit_run:
+            pos = digit_run.find(combined)
+            tail_len = len(digit_run) - (pos + len(combined))
+            # Tolerance: a 7-digit "3,145,728" has 5 trailing digits
+            # after the magnitude "31". Cap at 12 digits total in the
+            # digit_run (8+ trailing) so the magnitude is bounded.
+            if tail_len <= 12:
+                return True
+    return False
+
+
+def _excerpt(src: str, raw: str) -> str:
+    """Return a 70-char excerpt around the raw claim, for diagnostics."""
+    pos = src.find(raw)
+    if pos < 0:
+        return raw[:70]
+    start = max(0, pos - 30)
+    end = min(len(src), pos + len(raw) + 40)
+    return src[start:end].replace("\n", " ")[:120]
+
+
+def render(result: dict) -> str:
+    lines: list[str] = []
+    p = result["path"]
+    v = result["verdict"]
+    head = f"NOTEBOOK {p} -- verdict: {v}"
+    lines.append(head)
+    lines.append("=" * len(head))
+    if result.get("errors"):
+        for e in result["errors"]:
+            lines.append(f"  ! {e}")
+    s = result.get("stats", {})
+    if s:
+        lines.append(
+            f"  scanned: lit-skip={s.get('skipped_literature', 0)}, "
+            f"no-prev={s.get('skipped_no_prev_code', 0)}, "
+            f"no-output={s.get('skipped_no_output', 0)}"
+        )
+    if result["findings"]:
+        lines.append(f"  findings: {len(result['findings'])} potential fabrication(s)")
+        for f in result["findings"]:
+            lines.append(
+                f"    md[{f['markdown_cell']}] (after code[{f['code_cell']}]) "
+                f"raw={f['raw']!r} normalized={f['normalized']!r}"
+            )
+            lines.append(f"      context: ...{f['context']}...")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Detect markdown cells that cite numeric values absent from the "
+            "previous code cell's output (c.290 pathologie, C.5 violation)."
+        ),
+        epilog=(
+            "Exit: 0 CLEAN, 1 FABRICATION_DETECTED, 2 ERROR. "
+            "Use --json for CI gate consumption."
+        ),
+    )
+    ap.add_argument("notebooks", nargs="+", help="paths to .ipynb files")
+    ap.add_argument("--window", type=int, default=WINDOW,
+                    help=f"number of previous code cells to scan (default {WINDOW})")
+    ap.add_argument("--json", action="store_true", dest="as_json",
+                    help="JSON output (one result per notebook)")
+    args = ap.parse_args()
+
+    results: list[dict] = []
+    for nb_path in args.notebooks:
+        p = Path(nb_path)
+        if not p.exists():
+            results.append({
+                "path": str(p),
+                "verdict": "ERROR",
+                "errors": [f"file not found: {p}"],
+                "findings": [],
+            })
+            continue
+        results.append(check_notebook(p))
+
+    if args.as_json:
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+    else:
+        for r in results:
+            print(render(r))
+            print()
+
+    fabricated = sum(1 for r in results if r["verdict"] == "FABRICATION_DETECTED")
+    errored = sum(1 for r in results if r["verdict"] == "ERROR")
+    if errored:
+        return 2
+    return 1 if fabricated else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_markdown_claims_output.py
+++ b/scripts/tests/test_check_markdown_claims_output.py
@@ -1,0 +1,328 @@
+"""Regression tests for check_markdown_claims_output.py (c.331 / c.290 guard).
+
+The script detects markdown cells that cite numeric values absent from the
+previous code cell's output (c.290 pathologie, where prose fabricated
+quantitative claims that didn't match the cell it was supposed to
+interpolate).
+
+The c.290 case in the wild: PR #11435 (myia-po-2023) on FT-02-QLoRA-
+Quantization.ipynb introduced a cell with `~0,09 %` and `~1,2 M` claims
+whose code cell output actually printed `0.2385` and `3,145,728`. The
+markdown and the output pointed at two different things.
+
+These tests pin the detector's invariants on synthetic fixtures so the
+guard cannot regress to false-negative (missing the fabrication) without
+the test runner catching it.
+
+Test classes (one per direction):
+
+* **TestCanonicalClean** — markdown that quotes numbers from the previous
+  code output is CLEAN. The detector must NOT raise a fabrication
+  finding when the number is present in the output.
+* **TestFabricationDetected** — markdown that quotes a number NOT in
+  the previous code output is flagged. The c.290 pathologie live case.
+* **TestLiteratureSkip** — explicit headers ("## Bibliographie",
+  "## References") skip the cell -- the literature convention is a
+  HEADER, not a length.
+* **TestSubstantiveFilter** — short numbers (one/two digits) like
+  section markers ("## 7. Comparaison") are NOT flagged. Only
+  substantive numbers (>= 4 chars normalized) trigger a finding.
+* **TestWindowLookup** — the scan window covers the previous N code
+  cells (default 3). A claim present in cell idx-2 is accepted as
+  anchored even if idx-1 has no output.
+* **TestVerdictLogic** — verdict CLEAN / FABRICATION_DETECTED / ERROR
+  on the fixtures above.
+* **TestStripMdStructure** — heading lines and table headers are
+  dropped from the prose that the regex scans (so "## 7. ..." does
+  not raise a numeric claim).
+* **TestOutputExtraction** — stream + execute_result outputs are both
+  flattened into searchable text.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the script importable
+ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from check_markdown_claims_output import (  # noqa: E402
+    _fuzzy_present,
+    _is_md_heading_line,
+    _lit_skip,
+    _normalize_num,
+    _output_text,
+    _strip_md_structure,
+    _substantive,
+    check_notebook,
+)
+
+
+def _mk_nb(cells: list[dict]) -> dict:
+    """Wrap a list of cells into a minimal valid notebook structure."""
+    return {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _code_cell(source: str, outputs: list) -> dict:
+    return {
+        "cell_type": "code",
+        "execution_count": 1,
+        "metadata": {},
+        "source": source.splitlines(keepends=True),
+        "outputs": outputs,
+    }
+
+
+def _md_cell(source: str) -> dict:
+    return {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": source.splitlines(keepends=True),
+    }
+
+
+def _stream_output(text: str) -> dict:
+    return {"output_type": "stream", "name": "stdout", "text": text}
+
+
+def _exec_output(text: str) -> dict:
+    return {
+        "output_type": "execute_result",
+        "data": {"text/plain": text},
+        "metadata": {},
+    }
+
+
+class TestNormalizeNum:
+    """Pure-function tests for the numeric normalization."""
+
+    def test_strip_si_suffix(self):
+        assert _normalize_num("3,1 M") == "3.1"
+        assert _normalize_num("1.3B") == "1.3"
+        assert _normalize_num("1,16 Go") == "1.16"
+        assert _normalize_num("0,09 %") == "0.09"
+        assert _normalize_num("75 steps") == "75"
+        assert _normalize_num("15 epochs") == "15"
+
+    def test_whitespace_and_nbsp(self):
+        assert _normalize_num("3\xa0145") == "3145"
+
+    def test_comma_vs_dot(self):
+        assert _normalize_num("3,145,728") == "3145.728"
+
+    def test_units_whitespace(self):
+        assert _normalize_num("  256 tokens") == "256"
+
+
+class TestSubstantiveFilter:
+    """The substantive filter rejects short / sentinel numbers."""
+
+    def test_short_numbers_rejected(self):
+        assert not _substantive("0")
+        assert not _substantive("7")
+        assert not _substantive("01")
+        assert not _substantive("5.")
+
+    def test_zero_rejected(self):
+        assert not _substantive("0")
+        assert not _substantive("0.0")
+        assert not _substantive("0.00")
+
+    def test_long_numbers_accepted(self):
+        assert _substantive("0.09")
+        assert _substantive("0.24")
+        assert _substantive("3.1")
+        assert _substantive("1.32")
+        assert _substantive("3145")
+        assert _substantive("23.5")
+
+
+class TestLiteratureSkip:
+    """The lit-skip convention is a HEADER, not a length."""
+
+    def test_bibliographie_skipped(self):
+        assert _lit_skip("## Bibliographie\n\n- [1] ...\n")
+
+    def test_references_skipped(self):
+        assert _lit_skip("## References\n\n1. ...\n")
+
+    def test_long_pedagogical_cell_NOT_skipped(self):
+        """The c.290 pathologie sat in a 3000+ char pedagogical cell."""
+        prose = ("## Lecture du résultat : le moment où la quantization prend effet\n"
+                 + "lorem ipsum " * 200)
+        assert not _lit_skip(prose)
+
+    def test_short_quant_cell_NOT_skipped(self):
+        assert not _lit_skip("On attend ~0,09 % de paramètres entraînables.")
+
+
+class TestHeadingLine:
+    def test_heading_lines_detected(self):
+        assert _is_md_heading_line("## 7. Comparaison")
+        assert _is_md_heading_line("### Lecture")
+        assert _is_md_heading_line("   # title")
+        assert not _is_md_heading_line("not a heading")
+        assert not _is_md_heading_line("`code with # in it`")
+
+
+class TestStripMdStructure:
+    def test_headings_dropped(self):
+        src = "## 7. Comparaison\n\nLe ratio est 0.24."
+        prose = _strip_md_structure(src)
+        assert "##" not in prose
+        assert "Le ratio est 0.24" in prose
+
+    def test_table_lines_dropped(self):
+        src = "| col1 | col2 |\n| --- | --- |\n| 0.24 | 0.99 |\nConclusion: 0.24."
+        prose = _strip_md_structure(src)
+        assert "Conclusion: 0.24" in prose
+        assert "| col1" not in prose
+
+    def test_code_fences_dropped(self):
+        src = "```python\nprint(0.24)\n```\nLe ratio est 0.24."
+        prose = _strip_md_structure(src)
+        assert "print" not in prose
+        assert "Le ratio est 0.24" in prose
+
+
+class TestOutputExtraction:
+    def test_stream_output(self):
+        text = _output_output = _output_text([_stream_output("hello 0.24")])
+        assert "hello 0.24" in text
+
+    def test_execute_result_output(self):
+        text = _output_text([_exec_output("Params: 3,145,728")])
+        assert "3,145,728" in text
+
+    def test_mixed_outputs(self):
+        text = _output_text([
+            _stream_output("Loading...\n"),
+            _exec_output("Result: 0.2385"),
+        ])
+        assert "Loading" in text
+        assert "0.2385" in text
+
+    def test_empty_outputs(self):
+        assert _output_text([]) == ""
+
+
+class TestFuzzyPresent:
+    def test_full_match(self):
+        assert _fuzzy_present("0.24", "0.2385")
+
+    def test_no_match(self):
+        assert not _fuzzy_present("0.09", "0.2385")
+
+    def test_prefix_with_non_digit(self):
+        assert _fuzzy_present("1.3", "1.3B")
+
+    def test_prefix_then_digit_blocked(self):
+        """'1.3' must NOT match '1.32' (different magnitude)."""
+        assert not _fuzzy_present("1.3", "1.32 Go")
+
+    def test_short_norm_skipped(self):
+        assert not _fuzzy_present("7", "0.2385")
+
+
+class TestCanonicalClean:
+    """Markdown that quotes numbers from the previous code output is CLEAN."""
+
+    def test_quote_from_output(self, tmp_path: Path):
+        nb = _mk_nb([
+            _code_cell("print('trainable params: 3,145,728')", [
+                _stream_output("trainable params: 3,145,728 (0.24%)"),
+            ]),
+            _md_cell("On attend ~3,1 M de paramètres, soit ~0,24 %."),
+        ])
+        nb_path = tmp_path / "clean.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        res = check_notebook(nb_path)
+        assert res["verdict"] == "CLEAN", res
+
+
+class TestFabricationDetected:
+    """The c.290 pathologie: prose cites numbers NOT in the previous output."""
+
+    def test_fabrication_in_cell_10(self, tmp_path: Path):
+        nb = _mk_nb([
+            _code_cell("print('trainable params: 3,145,728')", [
+                _stream_output("trainable params: 3,145,728 (0.24%)"),
+            ]),
+            _md_cell("On attend ~1,2 M de paramètres, soit ~0,09 %."),
+        ])
+        nb_path = tmp_path / "fabricated.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        res = check_notebook(nb_path)
+        assert res["verdict"] == "FABRICATION_DETECTED", res
+        findings = res["findings"]
+        # The fabricated claims should be among the findings
+        norms = {f["normalized"] for f in findings}
+        assert "0.09" in norms, findings
+
+    def test_missing_previous_code(self, tmp_path: Path):
+        """Markdown without any preceding code cell is skipped, not flagged."""
+        nb = _mk_nb([
+            _md_cell("On attend ~0,09 %."),
+        ])
+        nb_path = tmp_path / "no_prev.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        res = check_notebook(nb_path)
+        assert res["verdict"] == "CLEAN", res
+        assert res["stats"]["skipped_no_prev_code"] == 1
+
+
+class TestWindowLookup:
+    """The scan window covers the previous N code cells (default 3)."""
+
+    def test_preceding_code_within_window(self, tmp_path: Path):
+        """A claim present in code[idx-2] is accepted via window=2 even
+        if code[idx-1] has no output."""
+        nb = _mk_nb([
+            _code_cell("print('ratio: 0.24')", [_stream_output("ratio: 0.24")]),
+            _code_cell("x = 1", []),  # no output
+            _md_cell("Le ratio observé est 0,24."),
+        ])
+        nb_path = tmp_path / "window.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        res = check_notebook(nb_path)
+        # With window=3 (default), the 2 preceding code cells are both scanned
+        assert res["verdict"] == "CLEAN", res
+
+
+class TestVerdictLogic:
+    def test_clean(self, tmp_path: Path):
+        nb = _mk_nb([
+            _code_cell("print(0.24)", [_stream_output("0.24")]),
+            _md_cell("Le ratio est 0,24."),
+        ])
+        nb_path = tmp_path / "v_clean.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        assert check_notebook(nb_path)["verdict"] == "CLEAN"
+
+    def test_fabricated(self, tmp_path: Path):
+        nb = _mk_nb([
+            _code_cell("print(0.24)", [_stream_output("0.24")]),
+            _md_cell("Le ratio est 0,09."),
+        ])
+        nb_path = tmp_path / "v_fab.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        r = check_notebook(nb_path)
+        assert r["verdict"] == "FABRICATION_DETECTED"
+        assert r["findings"]
+
+    def test_error_on_bad_json(self, tmp_path: Path):
+        nb_path = tmp_path / "broken.ipynb"
+        nb_path.write_text("{not json", encoding="utf-8")
+        r = check_notebook(nb_path)
+        assert r["verdict"] == "ERROR"
+        assert r["errors"]


### PR DESCRIPTION
## feat(guard,#11435): advisory markdown-claims-output detector (c.290 / c.331 pathologie)

### Contexte

PR **#11435** (FT-02-QLoRA-Quantization.ipynb c10/c20) a reintroduit une pathologie observee dans le cycle **c.290** (notebook M15 LSTM-vol) : **la prose markdown cite des valeurs quantitatives qui contredisent la sortie de la cellule code precedente**. Le notebook declarait « ~1,2 M parametres entrainables, ~0,09 % » alors que la sortie imprimait « 3,145,728 (0.24%) ».

La regle C.5 (prose quantitative ancree sur outputs) est **inapplicable par lint** : un regex ne peut pas savoir si `0,09 %` est "juste" ou "faux" sans lire la cellule code. Ce PR fournit **le JOIN** : cellule[code] avec output → cellule[markdown] cadre → extraction des nombres → cross-reference (la valeur claim est-elle dans l'output ?) → flag de fabrication.

### Changements

| Fichier | Type | Description |
|---|---|---|
| `scripts/check_markdown_claims_output.py` | nouveau | detecteur (~370 lignes) : regex numerique tolerant (SI suffixes, comma-decimal), WINDOW=3 cells, fuzzy-match (clause a = prefix non-digit, clause b = norm-truncation match output-prefix, clause c = magnitude match via digit_run pour gros nombres), verdict CLEAN / FABRICATION_DETECTED / SKIPPED-LITERATURE / ERROR |
| `scripts/tests/test_check_markdown_claims_output.py` | nouveau | 31 tests sur 11 classes (NormalizeNum, SubstantiveFilter, LiteratureSkip, HeadingLine, StripMdStructure, OutputExtraction, FuzzyPresent, CanonicalClean, FabricationDetected, WindowLookup, VerdictLogic) ; **31/31 verts** |
| `.github/workflows/markdown-claims-output-advisory.yml` | nouveau | workflow ADVISORY (jamais bloquant) : run pytest + scan `git ls-files` des notebooks → post PR comment via sticky-pull-request-comment |

### Pourquoi ADVISORY, pas gate bloquant

Le detecteur a un **taux de faux positifs non-trivial** : les cellules pedagogiques legitimement citent des nombres de domaine ("OPT-1.3B", "1.3B params", "~4x speedup") qui n'apparaissent pas dans la cellule code immediate. Sur PR #11435, 72 findings dont :
- Les **12 vrais positifs** (md[10]/md[20] : "~0,09 %", "~1,2 M", "0.03", "0.01" qui contredisent l'output)
- ~60 faux positifs (mentions legitimes de "1.3B" / "OPT-1.3B" / "~0,5 Go" qui sont des connaissances de domaine)

Un gate bloquant forcerait chaque PR a le desactiver. Le bon modele est **advisory** : signaler les findings, laisser le reviewer (humain ou bot) trier contre le code source, **ne jamais merger-blocker sur ce seul signal**.

Quand la precision du detecteur augmentera (ex. : ajouter un scope gate "flag seulement les claims aussi presentes ailleurs comme tables/charts"), **promouvoir en gate bloquant**.

### Protocole execute

1. **L898 PRE-WRITE** : `gh pr list --search "11435"` + `git log origin/main --grep "11435"` → substance #11435 distincte de mes PRs recentes (c.328-L1 ★★★, #11545 MERGED).
2. **Worktree isole** : `git worktree add ../CoursIA-11435 -b fix/c331-markdown-claims-output-check origin/main` (catalog R1 preserve).
3. **Substance authentifiee** :
   - 5 bugs du script reveles par les tests, **tous fixes** (fuzzy_present normalise, substantive len==3 decimal, _strip_md_structure stateful code fences, comma-vs-dot thousand vs decimal, fuzzy_present clause b/c split).
   - 31/31 pytest verts.
   - Test sur PR #11435 branche : 72 findings dont les 12 cellules c.290 pathologie (md[10] "0,09 %" / md[20] "0.03 / 0.01 / 1.0 / 0.3") → **detector works**.
4. **Pas de secret en clair** (pre-commit gitleaks).
5. **Pas de hand-edit de cellule** (regle 6 secrets-hygiene : source-leak = corriger la cause, pas scrubber l'output).

### Sortie attendue

| Metrique | Baseline | Cible |
|---|---|---|
| pytest scripts/tests/test_check_markdown_claims_output.py | 0 | **31 passed** |
| Run sur PR #11435 branche | (n/a) | FABRICATION_DETECTED avec 12 cellules c.290 flagged |
| Workflow advisory | (n/a) | run + sticky-comment post sur PR touching `.ipynb` |
| Source `.lean` touche | n/a | 0 (lean rule inapplicable) |

### Criteres d'acceptation

- [ ] pytest 31/31 verts (les tests sont la preuve d'execution)
- [ ] Detector identifie c.290 pathologie sur PR #11435 (md[10] "0,09 %" / md[20] "0.03, 0.01, 1.0")
- [ ] Workflow post un advisory sticky-comment sur PR touchant `.ipynb`
- [ ] Pre-commit gitleaks Passed
- [ ] Catalog R1 preserve (catalog byte-identique a main)

### Conformite aux regles

- **C.1, C.2, C.3** : N/A (script Python, pas notebook).
- **catalog-pr-hygiene.md R1** : catalogue byte-identique a main (3 fichiers ajoutes, pas de regen catalogue).
- **secrets-hygiene.md** : pre-commit gitleaks Passed.
- **git-workflow.md** : pas de force-push, branche `fix/`, `See #11435` (livraison partielle, la fabrication dans le notebook lui-meme reste a corriger ; `Closes` abusif evite).
- **pr-review-discipline.md §B** : pas de Lean touche, sorry unchanged.
- **anti-regression.md** : pas de remplacement de code existant par stub ; nouveau code uniquement.
- **sota-not-workaround.md** : vrai outil SOTA (detecteur AST-style sur `.ipynb`), pas de workaround degrade.

### Note d'audit — pourquoi advisory, pas bloquant

- Le **c.290 pathologie** a ete detecte manuellement par cross-reading (c.290 topic file). Un detecteur automatique aurait raccourci le cycle mais **un faux-positif rate aurait cree du bruit**.
- Le detecteur couvre **uniquement** le pattern "markdown apres code" (WINDOW=3). Les patterns "markdown apres markdown avec table a cote" ne sont **pas couverts** — c'est un choix de scope (limiter le blast radius).
- **Promotion en gate** : previsible quand un lane de precision aura tourne sur 10+ PRs et valide le taux de FP < 5%. Pas avant.

### Limites

- Le notebook FT-02 lui-meme (#11435 PR) reste a corriger par son auteur (substance du PR non livree par ce guard).
- Le pattern "markdown apres markdown" n'est pas couvert.
- Les notebooks `.NET` (Microsoft.SemanticKernel) peuvent avoir des outputs en binary qui ne sont pas textuellement comparables — le script les scanne quand meme (regex numeric reel), avec un taux de FP probablement plus haut.

`See #11435`

### Grain

```
Grain: DEEP/guard — lane myia-po-2023:CoursIA-2 — prev: MED/lean #11587
```

G-VAR-3 OK (`guard` n'est pas `lean`). G-VAR-2 OK (plafond 1 LIGHT par jour, grain DEEP). G-VAR-1 TENU (plancher DEEP/CONTENU : guard = CONTENU selon variation-protocol.md §1 car un guard qui rougit est substance de protection du repo, pas seulement tooling).