### PR TITLE
enrich(notebook,#11271): FT-01 Introduction-FineTuning density 593→1968 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -24,6 +24,19 @@
    "id": "cell-24754727"
   },
   {
+   "cell_type": "markdown",
+   "id": "cell-add26685b1114b1f",
+   "metadata": {},
+   "source": [
+    "### Vérification de l'environnement",
+    "",
+    "Avant tout chargement de modèle, on vérifie la disponibilité du GPU et sa capacité. Ce notebook est dimensionné pour un GPU avec environ 4 Go de VRAM (GPT-2 = 124M params en float32 = ~500 Mo, plus les états d'optimiseur Adam qui doublent la consommation). Sur un GPU plus modeste (CPU-only), le notebook reste fonctionnel mais l'étape de fine-tuning sera **très** lente — à titre indicatif, comptez 5-10 minutes au lieu de 13 secondes pour les 10 époques sur un CPU moderne.",
+    "",
+    "L'import de `torch` au début est délibérément minimal : on n'importe que `torch`, `os`, et `gc`. `gc` sera utilisé à la fin pour libérer la mémoire GPU avant la sortie du notebook. Le pattern `if torch.cuda.is_available(): ...` permet au notebook de **tourner aussi sur CPU** en mode dégradé — la branche GPU est skipped silencieusement sans casser l'exécution.",
+    "\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -127,6 +140,23 @@
    "metadata": {},
    "source": "## 3. Comparaison des paramètres entrainables\n\nLa théorie de la section 2 annonçait ~0,5 % de paramètres entraînables pour LoRA contre 100 % pour le full fine-tuning — vérifions-le sur un modèle réel. Le nombre de paramètres entraînables est la grandeur qui détermine tout le reste : la VRAM consommée pendant l'entraînement (chaque paramètre déroulé porte en plus son gradient et son état d'optimiseur, soit ~3-4× sa taille en fp16/fp32), le coût de stockage du résultat, et la vitesse de convergence.\n\nNous chargeons GPT-2 (124 M de paramètres) et appliquons les trois configurations via la fonction `count_trainable` définie ci-dessous : full (tous les poids dégelés), partial (seules les 2 dernières couches du transformeur + la tête `lm_head`), et LoRA (un adaptateur de rang 8 sur les projections d'attention `c_attn`). Le tableau récapitulatif confirmera l'écart d'un facteur ~400 entre LoRA et le full fine-tuning — c'est cet écart qui rend le fine-tuning d'un LLM possible sur un GPU grand public.",
    "id": "cell-dfcac0ae"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-beef8dbe6c9743c1",
+   "metadata": {},
+   "source": [
+    "### Chargement du modèle de base",
+    "",
+    "GPT-2 (124 millions de paramètres, publié par OpenAI en 2019) est notre sujet d'expérience. Plusieurs raisons à ce choix :",
+    "",
+    "- **Taille modeste** : 124M paramètres tient dans 500 Mo en float32, ce qui permet de travailler sans quantization sur un GPU grand public.",
+    "- **Pré-entraînement anglais** : c'est exactement ce qui rend l'expérience de fine-tuning intéressante — on va demander au modèle d'adapter un style de génération pour lequel il n'a jamais été explicitement entraîné (le français littéraire du XIXe).",
+    "- **Compatibilité peft** : GPT-2 utilise une architecture de transformeur classique (`c_attn` pour les projections d'attention Q/K/V concaténées), ce qui en fait une cible de choix pour les adaptateurs LoRA de la bibliothèque `peft`.",
+    "",
+    "La cellule ci-dessous charge le tokenizer et le modèle via `transformers`. Notez l'astuce `tokenizer.pad_token = tokenizer.eos_token` : GPT-2 n'a pas de token de padding par défaut (il a été entraîné causalement, sans masque de padding), mais le `DataCollatorForLanguageModeling` en aura besoin pour batcher les séquences.",
+    "\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -288,6 +318,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "cell-0191d913656b4eaf",
+   "metadata": {},
+   "source": [
+    "### Trois configurations appliquées au même modèle",
+    "",
+    "Le code ci-dessous applique successivement les trois configurations sur la **même instance de modèle**, ce qui permet de comparer les comptes de paramètres dans un contexte expérimental strictement contrôlé. L'ordre est délibéré : on part du full fine-tuning (référence), on passe au partial (intermédiaire), on termine par LoRA (le plus économe). Chaque configuration **modifie l'état interne du modèle** (les `requires_grad` flags), et le code recharge explicitement `model_lora` à partir de zéro pour LoRA afin de partir d'un modèle frais — sinon les flags `requires_grad` de la configuration précédente « contamineraient » la mesure LoRA.",
+    "",
+    "Notez l'usage de `get_peft_model` de la bibliothèque `peft` : cette fonction **enveloppe** le modèle original sans le modifier, en remplaçant chaque module ciblé (`c_attn`) par un `Linear` + `LoRA` qui contient la matrice de base gelée plus l'adaptateur $B \\times A$ entraînable. Le compte de paramètres affiché par `print_trainable_parameters()` ne reflète que les paramètres **LoRA** — pas les paramètres du modèle original, qui restent accessibles mais sont gelés.",
+    "\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
@@ -420,6 +463,23 @@
     "Le protocole est volontairement **petit et reproductible** : 7 segments d'entrainement, un adaptateur r=8, une dizaine d'epochs. L'objectif n'est pas de produire un modele utile, mais de rendre chaque etape observable en quelques secondes sur un GPU grand public -- et de donner un point de comparaison honnete quand, dans FT-02, le meme exercice sera rejoue sous contrainte de VRAM."
    ],
    "id": "cell-2c50759f"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-e1ca3c6f18d449c7",
+   "metadata": {},
+   "source": [
+    "### Choix pédagogique du corpus Hugo",
+    "",
+    "Ce notebook utilise un extrait des *Misérables* de Victor Hugo (domaine public) comme corpus de fine-tuning. Trois raisons à ce choix :",
+    "",
+    "- **Contraste maximal avec le pré-entraînement.** GPT-2 a été pré-entraîné sur du texte anglais d'internet contemporain (Reddit, news, fiction anglophone). Le français du XIXe siècle (phrases longues, vocabulaire archaïsant, tournures descriptives) est un *out-of-distribution* fort. L'effet du fine-tuning sera donc visible même sur quelques exemples.",
+    "- **Domaine public = pas de problème de licence.** Vous pouvez réutiliser ce notebook, le corpus, et l'adapter sans contrainte.",
+    "- **Volume minimal mais suffisant pour observer un transfert de style.** Sept segments de 2-4 phrases chacun suffisent pour que GPT-2 commence à imiter la cadence hugolienne. En dessous, le modèle ne « voit » pas assez pour adapter son style ; au-dessus, l'effet devient imperceptible à l'œil nu parce qu'il est dilué.",
+    "",
+    "Ce n'est **pas** un corpus pour publier un modèle utilisable. Le but est de mettre le mécanisme en évidence : à la fin de l'entraînement, le modèle devrait produire des phrases plus longues, avec un vocabulaire plus littéraire, même si la grammaire reste approximative.",
+    "\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -750,6 +810,19 @@
    "id": "cell-2fe06360"
   },
   {
+   "cell_type": "markdown",
+   "id": "cell-bc69f5ff746140d0",
+   "metadata": {},
+   "source": [
+    "### Pourquoi une évaluation *causale* avant/après",
+    "",
+    "L'évaluation naïve — prendre un seul prompt et comparer une génération du modèle original à une génération du modèle fine-tuné — est piégeuse. Elle confond deux effets : le changement de style induit par le fine-tuning, **et** le hasard de l'échantillonnage (top_p, temperature). Avec `temperature=0.8` et `do_sample=True`, deux appels successifs au même modèle sur le même prompt produisent des sorties différentes. Si on ne compare qu'une seule génération de chaque côté, on ne sait pas si l'écart observé est dû au fine-tuning ou au RNG.",
+    "",
+    "La bonne pratique, appliquée ici, est de garder le prompt identique, la graine aléatoire aussi identique que faire se peut (Python `torch` est déterministe quand `seed=42` est fixé), et de ne faire varier qu'**un seul facteur** entre les deux côtés : la présence ou l'absence de l'adaptateur LoRA. C'est le seul design expérimental qui permet d'attribuer l'écart observé au fine-tuning.",
+    "\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
@@ -1039,6 +1112,19 @@
     "Chaque exercice reutilise une cellule du corps du notebook comme point d'appui : l'exercice 1 reprend le tableau de la section 3 (les 294 912 parametres de r=8 ne sont qu'un point de la courbe), l'exercice 2 remplace le corpus de la section 4, l'exercice 3 fait varier le learning rate autour de la perte finale mesuree en section 4. Les stubs s'executent sans erreur : ils affichent un message d'attente et rendent la main."
    ],
    "id": "cell-f59529da"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-cc0d52a5e14c4d0e",
+   "metadata": {},
+   "source": [
+    "### Préparation des exercices",
+    "",
+    "Les trois exercices de cette section sont progressifs : ils commencent par faire varier un seul hyperparamètre en gardant le reste du pipeline inchangé (rangs LoRA), puis élargissent à un changement de corpus (style littéraire), et terminent par une exploration plus risquée mais très pédagogique (learning rate). Gardez à l'esprit la contrainte de ressources : un entraînement de 10 époques sur 7 segments avec GPT-2 prend environ 13 secondes sur un RTX 3090. Vous pouvez donc itérer rapidement — l'idée est d'observer des tendances, pas de publier un résultat.",
+    "",
+    "Pour chaque exercice, **mesurez avant de conclure** : comptez les paramètres entraînables, affichez la perte finale, et surtout **comparez visuellement deux générations** plutôt que de vous fier à un chiffre de perte. La perte est un proxy nécessaire mais notoirement insuffisant pour évaluer un modèle de langage : un modèle peut avoir une perte basse et générer du texte incohérent, et inversement.",
+    "\n"
+   ]
   },
   {
    "cell_type": "code",

--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -28,11 +28,11 @@
    "id": "cell-add26685b1114b1f",
    "metadata": {},
    "source": [
-    "### Vérification de l'environnement",
-    "",
-    "Avant tout chargement de modèle, on vérifie la disponibilité du GPU et sa capacité. Ce notebook est dimensionné pour un GPU avec environ 4 Go de VRAM (GPT-2 = 124M params en float32 = ~500 Mo, plus les états d'optimiseur Adam qui doublent la consommation). Sur un GPU plus modeste (CPU-only), le notebook reste fonctionnel mais l'étape de fine-tuning sera **très** lente — à titre indicatif, comptez 5-10 minutes au lieu de 13 secondes pour les 10 époques sur un CPU moderne.",
-    "",
-    "L'import de `torch` au début est délibérément minimal : on n'importe que `torch`, `os`, et `gc`. `gc` sera utilisé à la fin pour libérer la mémoire GPU avant la sortie du notebook. Le pattern `if torch.cuda.is_available(): ...` permet au notebook de **tourner aussi sur CPU** en mode dégradé — la branche GPU est skipped silencieusement sans casser l'exécution.",
+    "### Vérification de l'environnement\n",
+    "\n",
+    "Avant tout chargement de modèle, on vérifie la disponibilité du GPU et sa capacité. Ce notebook est dimensionné pour un GPU avec environ 4 Go de VRAM (GPT-2 = 124M params en float32 = ~500 Mo, plus les états d'optimiseur Adam qui doublent la consommation). Sur un GPU plus modeste (CPU-only), le notebook reste fonctionnel mais l'étape de fine-tuning sera **très** lente — à titre indicatif, comptez 5-10 minutes au lieu de 13 secondes pour les 10 époques sur un CPU moderne.\n",
+    "\n",
+    "L'import de `torch` au début est délibérément minimal : on n'importe que `torch`, `os`, et `gc`. `gc` sera utilisé à la fin pour libérer la mémoire GPU avant la sortie du notebook. Le pattern `if torch.cuda.is_available(): ...` permet au notebook de **tourner aussi sur CPU** en mode dégradé — la branche GPU est skipped silencieusement sans casser l'exécution.\n",
     "\n"
    ]
   },
@@ -146,15 +146,15 @@
    "id": "cell-beef8dbe6c9743c1",
    "metadata": {},
    "source": [
-    "### Chargement du modèle de base",
-    "",
-    "GPT-2 (124 millions de paramètres, publié par OpenAI en 2019) est notre sujet d'expérience. Plusieurs raisons à ce choix :",
-    "",
-    "- **Taille modeste** : 124M paramètres tient dans 500 Mo en float32, ce qui permet de travailler sans quantization sur un GPU grand public.",
-    "- **Pré-entraînement anglais** : c'est exactement ce qui rend l'expérience de fine-tuning intéressante — on va demander au modèle d'adapter un style de génération pour lequel il n'a jamais été explicitement entraîné (le français littéraire du XIXe).",
-    "- **Compatibilité peft** : GPT-2 utilise une architecture de transformeur classique (`c_attn` pour les projections d'attention Q/K/V concaténées), ce qui en fait une cible de choix pour les adaptateurs LoRA de la bibliothèque `peft`.",
-    "",
-    "La cellule ci-dessous charge le tokenizer et le modèle via `transformers`. Notez l'astuce `tokenizer.pad_token = tokenizer.eos_token` : GPT-2 n'a pas de token de padding par défaut (il a été entraîné causalement, sans masque de padding), mais le `DataCollatorForLanguageModeling` en aura besoin pour batcher les séquences.",
+    "### Chargement du modèle de base\n",
+    "\n",
+    "GPT-2 (124 millions de paramètres, publié par OpenAI en 2019) est notre sujet d'expérience. Plusieurs raisons à ce choix :\n",
+    "\n",
+    "- **Taille modeste** : 124M paramètres tient dans 500 Mo en float32, ce qui permet de travailler sans quantization sur un GPU grand public.\n",
+    "- **Pré-entraînement anglais** : c'est exactement ce qui rend l'expérience de fine-tuning intéressante — on va demander au modèle d'adapter un style de génération pour lequel il n'a jamais été explicitement entraîné (le français littéraire du XIXe).\n",
+    "- **Compatibilité peft** : GPT-2 utilise une architecture de transformeur classique (`c_attn` pour les projections d'attention Q/K/V concaténées), ce qui en fait une cible de choix pour les adaptateurs LoRA de la bibliothèque `peft`.\n",
+    "\n",
+    "La cellule ci-dessous charge le tokenizer et le modèle via `transformers`. Notez l'astuce `tokenizer.pad_token = tokenizer.eos_token` : GPT-2 n'a pas de token de padding par défaut (il a été entraîné causalement, sans masque de padding), mais le `DataCollatorForLanguageModeling` en aura besoin pour batcher les séquences.\n",
     "\n"
    ]
   },
@@ -322,11 +322,11 @@
    "id": "cell-0191d913656b4eaf",
    "metadata": {},
    "source": [
-    "### Trois configurations appliquées au même modèle",
-    "",
-    "Le code ci-dessous applique successivement les trois configurations sur la **même instance de modèle**, ce qui permet de comparer les comptes de paramètres dans un contexte expérimental strictement contrôlé. L'ordre est délibéré : on part du full fine-tuning (référence), on passe au partial (intermédiaire), on termine par LoRA (le plus économe). Chaque configuration **modifie l'état interne du modèle** (les `requires_grad` flags), et le code recharge explicitement `model_lora` à partir de zéro pour LoRA afin de partir d'un modèle frais — sinon les flags `requires_grad` de la configuration précédente « contamineraient » la mesure LoRA.",
-    "",
-    "Notez l'usage de `get_peft_model` de la bibliothèque `peft` : cette fonction **enveloppe** le modèle original sans le modifier, en remplaçant chaque module ciblé (`c_attn`) par un `Linear` + `LoRA` qui contient la matrice de base gelée plus l'adaptateur $B \\times A$ entraînable. Le compte de paramètres affiché par `print_trainable_parameters()` ne reflète que les paramètres **LoRA** — pas les paramètres du modèle original, qui restent accessibles mais sont gelés.",
+    "### Trois configurations appliquées au même modèle\n",
+    "\n",
+    "Le code ci-dessous applique successivement les trois configurations sur la **même instance de modèle**, ce qui permet de comparer les comptes de paramètres dans un contexte expérimental strictement contrôlé. L'ordre est délibéré : on part du full fine-tuning (référence), on passe au partial (intermédiaire), on termine par LoRA (le plus économe). Chaque configuration **modifie l'état interne du modèle** (les `requires_grad` flags), et le code recharge explicitement `model_lora` à partir de zéro pour LoRA afin de partir d'un modèle frais — sinon les flags `requires_grad` de la configuration précédente « contamineraient » la mesure LoRA.\n",
+    "\n",
+    "Notez l'usage de `get_peft_model` de la bibliothèque `peft` : cette fonction **enveloppe** le modèle original sans le modifier, en remplaçant chaque module ciblé (`c_attn`) par un `Linear` + `LoRA` qui contient la matrice de base gelée plus l'adaptateur $B \\times A$ entraînable. Le compte de paramètres affiché par `print_trainable_parameters()` ne reflète que les paramètres **LoRA** — pas les paramètres du modèle original, qui restent accessibles mais sont gelés.\n",
     "\n"
    ]
   },
@@ -469,15 +469,15 @@
    "id": "cell-e1ca3c6f18d449c7",
    "metadata": {},
    "source": [
-    "### Choix pédagogique du corpus Hugo",
-    "",
-    "Ce notebook utilise un extrait des *Misérables* de Victor Hugo (domaine public) comme corpus de fine-tuning. Trois raisons à ce choix :",
-    "",
-    "- **Contraste maximal avec le pré-entraînement.** GPT-2 a été pré-entraîné sur du texte anglais d'internet contemporain (Reddit, news, fiction anglophone). Le français du XIXe siècle (phrases longues, vocabulaire archaïsant, tournures descriptives) est un *out-of-distribution* fort. L'effet du fine-tuning sera donc visible même sur quelques exemples.",
-    "- **Domaine public = pas de problème de licence.** Vous pouvez réutiliser ce notebook, le corpus, et l'adapter sans contrainte.",
-    "- **Volume minimal mais suffisant pour observer un transfert de style.** Sept segments de 2-4 phrases chacun suffisent pour que GPT-2 commence à imiter la cadence hugolienne. En dessous, le modèle ne « voit » pas assez pour adapter son style ; au-dessus, l'effet devient imperceptible à l'œil nu parce qu'il est dilué.",
-    "",
-    "Ce n'est **pas** un corpus pour publier un modèle utilisable. Le but est de mettre le mécanisme en évidence : à la fin de l'entraînement, le modèle devrait produire des phrases plus longues, avec un vocabulaire plus littéraire, même si la grammaire reste approximative.",
+    "### Choix pédagogique du corpus Hugo\n",
+    "\n",
+    "Ce notebook utilise un extrait des *Misérables* de Victor Hugo (domaine public) comme corpus de fine-tuning. Trois raisons à ce choix :\n",
+    "\n",
+    "- **Contraste maximal avec le pré-entraînement.** GPT-2 a été pré-entraîné sur du texte anglais d'internet contemporain (Reddit, news, fiction anglophone). Le français du XIXe siècle (phrases longues, vocabulaire archaïsant, tournures descriptives) est un *out-of-distribution* fort. L'effet du fine-tuning sera donc visible même sur quelques exemples.\n",
+    "- **Domaine public = pas de problème de licence.** Vous pouvez réutiliser ce notebook, le corpus, et l'adapter sans contrainte.\n",
+    "- **Volume minimal mais suffisant pour observer un transfert de style.** Sept segments de 2-4 phrases chacun suffisent pour que GPT-2 commence à imiter la cadence hugolienne. En dessous, le modèle ne « voit » pas assez pour adapter son style ; au-dessus, l'effet devient imperceptible à l'œil nu parce qu'il est dilué.\n",
+    "\n",
+    "Ce n'est **pas** un corpus pour publier un modèle utilisable. Le but est de mettre le mécanisme en évidence : à la fin de l'entraînement, le modèle devrait produire des phrases plus longues, avec un vocabulaire plus littéraire, même si la grammaire reste approximative.\n",
     "\n"
    ]
   },
@@ -814,11 +814,11 @@
    "id": "cell-bc69f5ff746140d0",
    "metadata": {},
    "source": [
-    "### Pourquoi une évaluation *causale* avant/après",
-    "",
-    "L'évaluation naïve — prendre un seul prompt et comparer une génération du modèle original à une génération du modèle fine-tuné — est piégeuse. Elle confond deux effets : le changement de style induit par le fine-tuning, **et** le hasard de l'échantillonnage (top_p, temperature). Avec `temperature=0.8` et `do_sample=True`, deux appels successifs au même modèle sur le même prompt produisent des sorties différentes. Si on ne compare qu'une seule génération de chaque côté, on ne sait pas si l'écart observé est dû au fine-tuning ou au RNG.",
-    "",
-    "La bonne pratique, appliquée ici, est de garder le prompt identique, la graine aléatoire aussi identique que faire se peut (Python `torch` est déterministe quand `seed=42` est fixé), et de ne faire varier qu'**un seul facteur** entre les deux côtés : la présence ou l'absence de l'adaptateur LoRA. C'est le seul design expérimental qui permet d'attribuer l'écart observé au fine-tuning.",
+    "### Pourquoi une évaluation *causale* avant/après\n",
+    "\n",
+    "L'évaluation naïve — prendre un seul prompt et comparer une génération du modèle original à une génération du modèle fine-tuné — est piégeuse. Elle confond deux effets : le changement de style induit par le fine-tuning, **et** le hasard de l'échantillonnage (top_p, temperature). Avec `temperature=0.8` et `do_sample=True`, deux appels successifs au même modèle sur le même prompt produisent des sorties différentes. Si on ne compare qu'une seule génération de chaque côté, on ne sait pas si l'écart observé est dû au fine-tuning ou au RNG.\n",
+    "\n",
+    "La bonne pratique, appliquée ici, est de garder le prompt identique, la graine aléatoire aussi identique que faire se peut (Python `torch` est déterministe quand `seed=42` est fixé), et de ne faire varier qu'**un seul facteur** entre les deux côtés : la présence ou l'absence de l'adaptateur LoRA. C'est le seul design expérimental qui permet d'attribuer l'écart observé au fine-tuning.\n",
     "\n"
    ]
   },
@@ -1118,11 +1118,11 @@
    "id": "cell-cc0d52a5e14c4d0e",
    "metadata": {},
    "source": [
-    "### Préparation des exercices",
-    "",
-    "Les trois exercices de cette section sont progressifs : ils commencent par faire varier un seul hyperparamètre en gardant le reste du pipeline inchangé (rangs LoRA), puis élargissent à un changement de corpus (style littéraire), et terminent par une exploration plus risquée mais très pédagogique (learning rate). Gardez à l'esprit la contrainte de ressources : un entraînement de 10 époques sur 7 segments avec GPT-2 prend environ 13 secondes sur un RTX 3090. Vous pouvez donc itérer rapidement — l'idée est d'observer des tendances, pas de publier un résultat.",
-    "",
-    "Pour chaque exercice, **mesurez avant de conclure** : comptez les paramètres entraînables, affichez la perte finale, et surtout **comparez visuellement deux générations** plutôt que de vous fier à un chiffre de perte. La perte est un proxy nécessaire mais notoirement insuffisant pour évaluer un modèle de langage : un modèle peut avoir une perte basse et générer du texte incohérent, et inversement.",
+    "### Préparation des exercices\n",
+    "\n",
+    "Les trois exercices de cette section sont progressifs : ils commencent par faire varier un seul hyperparamètre en gardant le reste du pipeline inchangé (rangs LoRA), puis élargissent à un changement de corpus (style littéraire), et terminent par une exploration plus risquée mais très pédagogique (learning rate). Gardez à l'esprit la contrainte de ressources : un entraînement de 10 époques sur 7 segments avec GPT-2 prend environ 13 secondes sur un RTX 3090. Vous pouvez donc itérer rapidement — l'idée est d'observer des tendances, pas de publier un résultat.\n",
+    "\n",
+    "Pour chaque exercice, **mesurez avant de conclure** : comptez les paramètres entraînables, affichez la perte finale, et surtout **comparez visuellement deux générations** plutôt que de vous fier à un chiffre de perte. La perte est un proxy nécessaire mais notoirement insuffisant pour évaluer un modèle de langage : un modèle peut avoir une perte basse et générer du texte incohérent, et inversement.\n",
     "\n"
    ]
   },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-python #11595 (QC density)

## Summary

Tranche #11271 sous-série FineTuning : un notebook, une PR, markdown-only. Enrichit `MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb` (density **593 → 1968** chars markdown / cellule code, plancher 1200).

## Substance ajoutée

6 cellules markdown insérées (transitions manquantes entre code-code consécutifs + intro exercices). Aucune cellule code touchée, aucun output modifié (C.3 dispense Papermill) :

| Insertion | Position | Rôle pédagogique |
|---|---|---|
| 1 | Avant `cell-2853ccbc` (setup GPU) | Contexte env : VRAM requise, mode dégradé CPU |
| 2 | Avant `cell-c2fa367d` (load model) | Choix GPT-2 (taille modeste, pré-entraînement anglais), astuce `pad_token` |
| 3 | Avant `cell-de59f036` (3 configs) | Contrôle expérimental : contamination `requires_grad`, mécanisme `get_peft_model` |
| 4 | Avant `cell-09a20769` (dataset Hugo) | Choix corpus : contraste OOD, domaine public, volume minimal/suffisant |
| 5 | Avant `cell-e44b2476` (eval) | Évaluation causale : design expérimental, attribution écart (RNG vs fine-tuning) |
| 6 | Avant `cell-4102f87c` (Exercice 1) | Progressivité : mesure avant conclusion, observation > perte |

## Acceptance (vérifiée localement)

- `pedagogy_density.py` : **1968** (cible 1200, original 593) ✓
- `scan_cell_ordering.py` : **0 finding** (aucune cellule `INTERP_BEFORE_CODE`) ✓
- C.1 : **0** violation volontaire (`raise NotImplementedError` / `assert False` / `1/0`) ✓
- C.2 : **13/13** cellules code avec `execution_count != null` ✓
- Byte-identity code : **0** mismatch sur les 13 cellules code (source + outputs + execution_count) ✓
- Pre-commit 5/5 PASSED (gitleaks + probeAddresses + NuGet cache + papermill paths + H.3)

## Pourquoi ce grain (R6, R7, G-VAR-1, G-VAR-3)

- **MED/notebook-python** = genre CONTENU, fait valoir une capacité distinctive (l'enrichissement ancré sur output) — répond à G-VAR-1.
- **1 tranche / 1 lane / 1 jour** = respecte le plafond explicite du tracker #11271.
- **prev = DEEP/notebook-python #11595** — substance distincte (QC density vs GenAI density, scope #11224 vs #11271), G-VAR-3 OK.
- **Pool global** : pas un grain de po-2025 ni po-2023 — po-2025 claimé Audio/Vibe-Coding, po-2023 n'a pas de claim GenAI actif sur cette sous-série.

## Périmètre disjoint

- **Audio** (po-2025, tranches #11534/#11538/#11543) : sous-série différente, hors scope.
- **Vibe-Coding** (po-2025, tranches #11540+) : sous-série différente, hors scope.
- **Image** (potentiel po-2025) : sous-série différente, non claimée ici.

## Liens

- Issue parente : #11271 (GenAI density tracker)
- Méthodologie : #11224 (QC density, modèle pour ce tracker)
- Registre : scripts/notebook_tools/pedagogy_density.py
- Validation : scripts/notebook_tools/scan_cell_ordering.py

## Test plan

- [ ] Reviewer : vérifier que les 6 insertions sont ancrées sur l'output adjacent (cell-interpretation-ordering)
- [ ] Reviewer : confirmer byte-identity sur les 13 cellules code (C.3 dispense Papermill, output inchangé)
- [ ] CI : pre-commit H.3 + gitleaks doivent passer (vérifié localement, 5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
