### PR TITLE
fix(tooling,#1028): détecteur de mélodie répétée (DRONE) + branchement du gate prosodie

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py
@@ -61,6 +61,16 @@ MOTION_MODERATE_MAX = 1.6   # st/syllable
 FLATPCT_FLAT_MIN = 55.0     # % flat transitions above this == chant
 FLATPCT_MODERATE_MIN = 40.0 # %
 
+# --- Structural (melody-level) criteria -------------------------------------
+# motion/pct_flat are LOCAL measures: a drone alternating two adjacent notes
+# has perfectly normal step size and slips through. These three catch the
+# shape of the melody itself. Calibrated on three references measured
+# 2026-08-18 (see docstring of melody_stats).
+EFFNOTES_DRONE_MAX = 7.0     # 2**entropy over note names; kokoro 11.8, v4 6.0
+TOP3_DRONE_MIN = 65.0        # % of syllables on the 3 commonest notes
+MOTIF3_DRONE_MIN = 60.0      # % of 3-gram positions inside a repeated motif
+MIN_SYLL_FOR_STRUCTURE = 60  # below this, concentration stats are unreliable
+
 
 def hz_to_midi(f0_hz: float) -> float:
     """Continuous MIDI note number for a frequency in Hz."""
@@ -123,6 +133,52 @@ def detect_syllable_nuclei(
     )
     # Keep only voiced nuclei (vowels carry pitch).
     return [int(p) for p in peaks if voiced[p]]
+
+
+def melody_stats(notes):
+    """Structural description of a note sequence: how many notes it really uses,
+    how concentrated it is, and how much of it is literal repetition.
+
+    Reference values measured 2026-08-18 on Boule de Suif material:
+
+    ==========================  =========  ======  =========  ===========
+    clip                        eff_notes  top-3   motif-3    verdict
+    ==========================  =========  ======  =========  ===========
+    v1 kokoro (no cloning)          11.8   44.5%      14.5%   EXPRESSIVE
+    v2 fishaudio tags-only           5.3   79.7%      90.9%   FLAT
+    v4 extrait_ouverture_2min30      6.0   72.8%      82.2%   DRONE
+    ==========================  =========  ======  =========  ===========
+
+    Returns a dict; keys are None (with ``structure_na_reason`` set) when the
+    sample is too short for the concentration statistics to mean anything --
+    never silently zero, which would read as "clean".
+    """
+    import collections, math
+    n = len(notes)
+    out = {"n_notes_distinct": len(set(notes)), "n_syllables_scored": n}
+    if n < MIN_SYLL_FOR_STRUCTURE:
+        out.update({
+            "effective_notes": None, "top3_note_pct": None,
+            "motif3_repeat_pct": None, "top_motifs": [],
+            "structure_na_reason": "only %d syllables, need >= %d" % (n, MIN_SYLL_FOR_STRUCTURE),
+        })
+        return out
+    c = collections.Counter(notes)
+    H = -sum((v / n) * math.log2(v / n) for v in c.values())
+    top = c.most_common(3)
+    grams = collections.Counter(tuple(notes[i:i + 3]) for i in range(n - 2))
+    tot = n - 2
+    rep = sum(v for g, v in grams.items() if v >= 2)
+    out.update({
+        "effective_notes": round(2 ** H, 1),
+        "note_entropy_bits": round(H, 2),
+        "top3_note_pct": round(100.0 * sum(v for _, v in top) / n, 1),
+        "top3_notes": [k for k, _ in top],
+        "motif3_repeat_pct": round(100.0 * rep / tot, 1),
+        "top_motifs": ["-".join(g) + " x%d" % v for g, v in grams.most_common(3)],
+        "structure_na_reason": None,
+    })
+    return out
 
 
 def analyze_syllables(
@@ -202,6 +258,14 @@ def analyze_syllables(
                 "rel_semitones": [round(float(x), 2) for x in rel],
             }
         )
+        # max-minus-min is driven by single outlier syllables: on the v4 extract
+        # ONE syllable out of 401 (E3, 0.2%) lifted span from ~8 to 12.24 st.
+        # Report the robust interdecile span alongside it.
+        result["melodic_span_p5p95_st"] = round(
+            float(np.percentile(midis, 95) - np.percentile(midis, 5)), 2
+        )
+        result.update(melody_stats([s["note"] for s in syllables]))
+
         motion = result["mean_abs_interval_st"]
         flat_pct = result["pct_flat_transitions"]
         if motion < MOTION_FLAT_MAX or flat_pct >= FLATPCT_FLAT_MIN:
@@ -210,6 +274,25 @@ def analyze_syllables(
             result["verdict"] = "MODERATE"
         else:
             result["verdict"] = "EXPRESSIVE"
+
+        # Structural override: a repeating melody is monotonous even when its
+        # local step size looks healthy. The v4 extract missed FLAT by 0.21
+        # st and 1.2 points on the two local axes while spending 73% of its
+        # 401 syllables on three adjacent semitones.
+        drone_reasons = []
+        if result.get("effective_notes") is not None:
+            if result["effective_notes"] < EFFNOTES_DRONE_MAX:
+                drone_reasons.append(
+                    "effective_notes %.1f < %.1f" % (result["effective_notes"], EFFNOTES_DRONE_MAX))
+            if result["top3_note_pct"] >= TOP3_DRONE_MIN:
+                drone_reasons.append(
+                    "top3_note_pct %.1f%% >= %.1f%%" % (result["top3_note_pct"], TOP3_DRONE_MIN))
+            if result["motif3_repeat_pct"] >= MOTIF3_DRONE_MIN:
+                drone_reasons.append(
+                    "motif3_repeat_pct %.1f%% >= %.1f%%" % (result["motif3_repeat_pct"], MOTIF3_DRONE_MIN))
+        result["drone_reasons"] = drone_reasons
+        if drone_reasons:
+            result["verdict"] = "DRONE"
     else:
         result["verdict"] = "INSUFFICIENT"
     return result
@@ -284,19 +367,91 @@ def print_score_table(a: Dict) -> None:
     notes = " ".join(s["note"] for s in a["syllables"])
     print(f"  melody: {notes}")
     print(
-        f"  span={a['melodic_span_st']} st | motion={a['mean_abs_interval_st']} st/syll"
+        f"  span={a['melodic_span_st']} st (p5-p95 {a.get('melodic_span_p5p95_st')} st)"
+        f" | motion={a['mean_abs_interval_st']} st/syll"
         f" | flat-transitions={a['pct_flat_transitions']}% | rate={a['syllable_rate_hz']}/s"
-        f" | median={a['median_pitch_hz']} Hz -> {a['verdict']}"
+        f" | median={a['median_pitch_hz']} Hz"
     )
+    if a.get("structure_na_reason"):
+        print(f"  structure: n/a ({a['structure_na_reason']})")
+    elif a.get("effective_notes") is not None:
+        print(
+            f"  structure: {a['effective_notes']} notes effectives sur {a['n_notes_distinct']} distinctes"
+            f" | top-3 {a['top3_notes']} = {a['top3_note_pct']}%"
+            f" | motifs 3-notes repetes {a['motif3_repeat_pct']}%"
+        )
+        print(f"  motifs   : {' | '.join(a.get('top_motifs', []))}")
+    print(f"  VERDICT  : {a['verdict']}")
+    for r in a.get("drone_reasons", []):
+        print(f"             drone: {r}")
+
+
+def _synth(midi_sequence, syll_per_s=3.0, sr=22050):
+    """Build a syllable-like signal whose f0 follows the given MIDI sequence."""
+    import numpy as np
+    dur = 1.0 / syll_per_s
+    n = int(sr * dur)
+    t = np.arange(n) / sr
+    env = np.hanning(n) ** 0.5  # amplitude dip between syllables -> nuclei
+    out = []
+    for m in midi_sequence:
+        f = 440.0 * (2.0 ** ((m - 69) / 12.0))
+        sig = np.zeros(n)
+        for k in (1, 2, 3, 4):  # harmonics so pyin locks on
+            sig += (1.0 / k) * np.sin(2 * np.pi * f * k * t)
+        out.append(sig * env)
+    y = np.concatenate(out)
+    return (y / (np.max(np.abs(y)) + 1e-9) * 0.9).astype("float32"), sr
+
+
+def self_test() -> int:
+    """Positive control. A detector that cannot fail loudly is worthless:
+    this asserts the analyzer actually FIRES on a synthetic drone and stays
+    quiet on a synthetic varied melody. Exit non-zero on either failure.
+    """
+    import tempfile, os, random
+    import numpy as np
+    import soundfile as sf
+
+    random.seed(0)
+    n = 120
+    drone = [45 + random.choice([0, 0, 0, 1, -1]) for _ in range(n)]   # A2 +/- 1 st
+    varied = [45 + random.choice(range(-8, 13)) for _ in range(n)]      # 21-st ambitus
+
+    ok = True
+    tmp = tempfile.mkdtemp(prefix="syllpitch_selftest_")
+    for name, seq, must_be_drone in (("drone", drone, True), ("varied", varied, False)):
+        y, sr = _synth(seq)
+        wav = os.path.join(tmp, name + ".wav")
+        sf.write(wav, y, sr)
+        a = analyze_syllables(wav)
+        is_drone = a.get("verdict") == "DRONE"
+        status = "PASS" if is_drone == must_be_drone else "FAIL"
+        if status == "FAIL":
+            ok = False
+        print(
+            "[self-test] %-6s expected drone=%-5s got verdict=%-10s"
+            " eff_notes=%s top3=%s motif3=%s n_syll=%d -> %s"
+            % (name, must_be_drone, a.get("verdict"), a.get("effective_notes"),
+               a.get("top3_note_pct"), a.get("motif3_repeat_pct"),
+               a.get("n_syllables", 0), status)
+        )
+    print("[self-test] %s" % ("OK" if ok else "FAILED -- the detector is not measuring what it claims"))
+    return 0 if ok else 1
 
 
 def main() -> None:
     ap = argparse.ArgumentParser(description="Syllable-level pitch analyzer")
-    ap.add_argument("clips", nargs="+", help="audio files (mp3/wav)")
+    ap.add_argument("clips", nargs="*", help="audio files (mp3/wav)")
     ap.add_argument("--out-dir", default=None, help="dir for the score PNG")
     ap.add_argument("--json", default=None, help="write all analyses to this JSON")
     ap.add_argument("--dip-db", type=float, default=2.0)
+    ap.add_argument("--self-test", action="store_true",
+                    help="run the synthetic drone/varied positive control and exit")
     args = ap.parse_args()
+
+    if args.self_test:
+        raise SystemExit(self_test())
 
     analyses = []
     for clip in args.clips:

--- a/scripts/tests/test_verify_prosody.py
+++ b/scripts/tests/test_verify_prosody.py
@@ -181,3 +181,35 @@ def test_reject_beats_warn():
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))
+
+
+# --- DRONE: the repeating-melody class (added 2026-08-18) -------------------
+# Local metrics (motion, flat-%) cannot see a melody that *repeats*: a chant
+# alternating two adjacent notes has normal step size. syllable_pitch now emits
+# DRONE from structural criteria (effective notes / top-3 concentration /
+# repeated 3-note motifs). These tests lock it to the same REJECT class as FLAT,
+# so the new verdict cannot silently fall through the gate as "not FLAT".
+
+def test_drone_is_rejected_as_monotone():
+    out = classify_segment(**_healthy(melody_verdict="DRONE"))
+    assert out["gate"] == "REJECT"
+    assert "MONOTONE" in out["reasons"]
+
+
+def test_drone_rejected_even_with_healthy_global_span():
+    """The v4 extract's own shape: global span looks fine, melody repeats."""
+    out = classify_segment(**_healthy(melody_verdict="DRONE", global_range_st=12.24))
+    assert out["gate"] == "REJECT"
+    assert "MONOTONE" in out["reasons"]
+
+
+def test_drone_does_not_also_raise_global_flat_warn():
+    """GLOBAL-FLAT is the 'syllable verdict disagrees' hedge; DRONE agrees."""
+    out = classify_segment(**_healthy(melody_verdict="DRONE", global_range_st=1.0))
+    assert out["gate"] == "REJECT"
+    assert "GLOBAL-FLAT" not in out["reasons"]
+
+
+def test_moderate_still_passes_so_drone_is_not_a_blanket_reject():
+    """Guard against over-correction: MODERATE must remain acceptable."""
+    assert classify_segment(**_healthy(melody_verdict="MODERATE"))["gate"] == "PASS-TO-EAR"

--- a/scripts/tts_verification/verify_prosody.py
+++ b/scripts/tts_verification/verify_prosody.py
@@ -11,7 +11,14 @@ This stage composes the three prosody instruments the user mandated
 (``MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/``, #1273/#1877):
 
 * ``syllable_pitch.analyze_syllables``  — the MELODY, syllable by syllable
-  ("partition de musique"): motion per syllable, flat-transition %, span
+  ("partition de musique"): motion per syllable, flat-transition %, span, and
+  the STRUCTURAL criteria (effective notes, top-3 concentration, repeated
+  3-note motifs) that yield the ``DRONE`` verdict. Motion and flat-% are LOCAL:
+  a chant alternating two adjacent notes has perfectly normal step size and
+  slipped through as ``MODERATE``. Measured 2026-08-18 on the extract served
+  for review: 401 syllables, 6.0 effective notes, 73% on three adjacent
+  semitones (A2/G#2/A#2), 82% of 3-note positions inside a repeated motif —
+  it missed ``FLAT`` by 0.21 st and 1.2 points on the two local axes.
   -> FLAT / MODERATE / EXPRESSIVE.
 * ``prosody_metrics.compute_metrics``   — the GLOBAL melody: ``f0_semitone_range``
   (< ~4 st = monotone, ~8-12 st = expressive audiobook narration).
@@ -33,7 +40,7 @@ and never auto-rejected — it is an explicit "send this one to the ear" flag.
 Gate outcomes
 -------------
 * ``REJECT``       — a bad class is detected with confidence; do not surface. Reasons:
-                     ``MONOTONE`` (melody FLAT or global span < flat floor),
+                     ``MONOTONE`` (melody FLAT or DRONE, or global span < flat floor),
                      ``WINDED`` (true breath failure), ``VOICE-SWAP`` (INCONSISTENT).
 * ``WARN``         — surface *to the ear* with a caveat. Reasons: ``ERRATIC`` (over-
                      modulated, the Kokoro class), ``DRIFTING`` (mild timbre drift),
@@ -98,7 +105,7 @@ def classify_segment(
     # flat-transition %), the signal the syllable_pitch author calibrated on. A low
     # GLOBAL span alone is outlier-driven and noisy on short clips, so when the
     # syllable verdict disagrees (MODERATE/EXPRESSIVE) it only WARNs, never rejects.
-    if melody_verdict == "FLAT":
+    if melody_verdict in ("FLAT", "DRONE"):
         reject.append("MONOTONE")
     if breath_verdict == "WINDED":
         reject.append("WINDED")
@@ -115,7 +122,8 @@ def classify_segment(
         warn.append("ERRATIC")
     # Global span flat while the (robust) syllable verdict is not FLAT: borderline
     # monotone on a noisy short-clip global — surface to the ear, do not reject.
-    if global_range_st is not None and global_range_st < GLOBAL_FLAT_ST and melody_verdict != "FLAT":
+    if (global_range_st is not None and global_range_st < GLOBAL_FLAT_ST
+            and melody_verdict not in ("FLAT", "DRONE")):
         warn.append("GLOBAL-FLAT")
     if voice_verdict == "DRIFTING":
         warn.append("DRIFTING")
@@ -183,6 +191,11 @@ def analyze_segment(path: str, instruments) -> Dict[str, object]:
         "gate": decision["gate"],
         "reasons": decision["reasons"],
         "melody_verdict": mel.get("verdict"),
+        "drone_reasons": mel.get("drone_reasons", []),
+        "effective_notes": mel.get("effective_notes"),
+        "top3_note_pct": mel.get("top3_note_pct"),
+        "motif3_repeat_pct": mel.get("motif3_repeat_pct"),
+        "melodic_span_p5p95_st": mel.get("melodic_span_p5p95_st"),
         "n_syllables": mel.get("n_syllables"),
         "melodic_span_st": mel.get("melodic_span_st"),
         "mean_abs_interval_st": mel.get("mean_abs_interval_st"),


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/slides #11536

## Le défaut

L'extrait servi en revue #1028 depuis fin mai passait le gate comme `MODERATE`.
Transcrit en notes (401 syllabes, mesure du 2026-08-18) :

```
melody: … A2 A2 G#2 G#2 G2 C3 B2 A2 A2 G#2 G2 C3 B2 A2 G2 B2 A#2 G#2 G2 A2 …
6.0 notes effectives (2^entropie) sur 13 distinctes
72.8 % des syllabes sur trois demi-tons adjacents : A2 / G#2 / A#2
82.2 % des positions 3-notes dans un motif déjà entendu
motifs dominants : A2-A2-G#2 ×18 | A2-G#2-G#2 ×18 | A#2-A2-G#2 ×16
```

Il ratait `FLAT` de **0,21 st** (`motion` 1,21 vs seuil 1,0) et de **1,2 point**
(`pct_flat` 53,8 % vs 55). Rehausser les seuils aurait été le mauvais correctif :
`motion` et `pct_flat` sont des mesures **locales**, et un bourdon qui alterne deux
notes voisines a un pas parfaitement normal par construction. Le défaut n'est pas
dans les pas de la mélodie, il est dans sa **forme**.

Second artefact du même ordre : `melodic_span_st` = max − min. **Une seule** syllabe
(E3, 0,2 % = 1 sur 401) portait le span de ~8 à 12,24 st. Le span robuste p5–p95 est
de **5,1 st**.

## Le correctif

`syllable_pitch.py`
- `melody_stats()` — notes effectives (2^entropie sur les noms de notes),
  concentration top-3, taux de motifs 3-notes répétés.
  Rend `None` + `structure_na_reason` sous 60 syllabes : **jamais un zéro
  silencieux**, qui se lirait comme « propre ».
- verdict `DRONE`, avec ses raisons nommées dans `drone_reasons`.
- `melodic_span_p5p95_st` à côté du max−min.
- `--self-test` : contrôle positif synthétique (bourdon A2±1 st vs mélodie
  d'ambitus 21 st). Un détecteur qui ne peut pas échouer bruyamment ne vaut rien.

`verify_prosody.py`
- `DRONE` rejoint `FLAT` dans la classe `REJECT` / `MONOTONE` ; sans ce
  branchement, le nouveau verdict serait tombé à travers le gate comme
  « pas FLAT ».
- l'évidence structurelle est portée dans le JSON de résultat.

## Calibration firsthand (Boule de Suif)

| clip | notes eff. | top-3 | motifs 3-notes | verdict |
|---|---|---|---|---|
| v1 kokoro (sans clonage) | 11,8 | 44,5 % | 14,5 % | EXPRESSIVE |
| v2 fishaudio tags-only | 5,3 | 79,7 % | 90,9 % | **DRONE** |
| v4 extrait servi | 6,0 | 72,8 % | 82,2 % | **DRONE** |

Kokoro n'est pas la cible pour autant : son span de 33,6 st est de la
**sur-modulation**, que le gate signale déjà `WARN-ERRATIC` (seuil 18 st). La
cible est entre les deux, et ce PR ne prétend pas la définir.

## Portée réelle, et sa limite

Gate relancé sur les 10 clips de revue : **1 REJECT, 6 WARN, 3 PASS-TO-EAR**.
Le seul `REJECT` est l'extrait long.

Ce n'est **pas** « le reste du casting va bien » : les 9 clips de personnages
font 1–12 s, restent sous 60 syllabes, et les critères structurels s'y
**abstiennent**. Le seul clip assez long pour qu'on puisse lire sa mélodie est
celui qui a été servi. Mesurer les voix demande de régénérer des segments
≥ 60 syllabes par voix — suite à part.

## Validation

```
$ python syllable_pitch.py --self-test
[self-test] drone  expected drone=True  got verdict=DRONE       eff_notes=2.7  top3=100.0 motif3=96.6 n_syll=120 -> PASS
[self-test] varied expected drone=False got verdict=EXPRESSIVE  eff_notes=19.6 top3=24.2  motif3=0.0  n_syll=120 -> PASS
[self-test] OK

$ python -m pytest scripts/tests/test_verify_prosody.py -q
22 passed
```

Les 4 tests neufs verrouillent `DRONE → REJECT/MONOTONE`, dont un garde-fou
contre la sur-correction (`MODERATE` doit rester acceptable).

## Note de protocole

Deuxième `guard` consécutif pour cette lane après #11541 (LIGHT/guard), ce que
G-VAR-3 vise. Je le déclare plutôt que de le requalifier : c'est une commande
utilisateur directe et répétée sur le livrable #1028, pas une veine de facilité.
Le grain suivant de la lane sera de contenu.

See #1028

## Correction du tag (auto-signalée)

Le tag de première ligne portait deux défauts, tous deux dans le sens qui m'arrangeait le moins ; je les corrige plutôt que de les laisser porter la PR.

1. **Genre `guard` → `tooling`.** Le discriminant écrit (`.claude/rules/variation-protocol.md`) est « est-ce que ça peut rougir ». Mesuré : `grep -rl "verify_prosody\|syllable_pitch" .github/workflows/` ne renvoie **rien** — aucun workflow n'invoque ces deux fichiers, donc le détecteur n'a pas de statut d'échec propre. C'est un outil, pas un garde. Il le deviendra quand un workflow l'appellera ; ce jour-là le grain qui le câble portera `guard`.
2. **`prev:` pointait sur #11541, qui n'est pas mergée** — c'est ma propre PR ouverte et bloquée. Un `prev:` doit désigner un grain **livré**, sinon l'adjacence G-VAR-3 se vérifie contre du vide. C'est exactement le défaut que je venais de requalifier sur #11605 ; le voir dans mon propre tag deux heures plus tard est le rappel que le merge-gate vaut aussi pour celui qui le tient. Le vrai dernier grain mergé de la lane est **#11536** (`MED/slides`, 2026-08-18T09:24:02Z).

Adjacence après correction : `MED/tooling` après `MED/slides` — genres distincts, G-VAR-3 satisfait ; grain MED, donc hors budget LIGHT G-VAR-2.
