### PR TITLE
feat(guard,#11145): borne d'auteur des levees — {auteur nit, auteur PR} seulement

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -33,7 +33,13 @@ Ce qui leve un nit — et ce qui ne le leve PAS
 **leve** que si, entre son horodatage et le merge, on trouve au moins un de :
   - une **reponse ecrite** capable de repondre (cf `can_lift` : ni bot de CI,
     ni tag de protocole nu) ;
-  - pour un thread inline : `isResolved: true` ou `isOutdated: true`.
+  - pour un thread inline : `isResolved: true` ou `isOutdated: true` ;
+  - **de la bonne personne** (borne d'auteur #11145) : l'auteur de la reserve,
+    ou l'auteur de la PR qui repond a son reviewer. Une reponse ou une
+    approbation d'un tiers (ni l'un ni l'autre) n'eteint pas la reserve —
+    c'est la classe #10761 que l'organe existe pour bloquer (mesure #11494 :
+    24,3 % des levees etaient BYSTANDER). L'echappement B.0 (issue de suivi
+    nommee) reste le chemin quand la reserve exige l'arbitrage d'un tiers.
 
 Ne levent RIEN :
   - **un commit pousse apres le nit** : un push muet est indiscernable d'un push
@@ -456,12 +462,21 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     commits = [c for c in commits if c]
     last_commit = max(commits) if commits else None
 
+    # #11145 — borne d'auteur : seules les levees de l'auteur de la reserve OU
+    # de l'auteur de la PR comptent. Mesure #11494 (850 PRs) : SELF 22/37
+    # (59,5 %) + PR_AUTHOR 6/37 (16,2 %) = flux sain preserve ; BYSTANDER 9/37
+    # (24,3 %) = la classe #10761 que l'organe bloque (un tiers — approbation
+    # ou reponse — n'eteint pas une reserve posee par un autre).
+    pr_author = (pr_data.get("author") or {}).get("login", "")
+
     # Seuls les commentaires capables de LEVER comptent (cf can_lift) : un
     # commentaire de bot CI ou un tag de protocole nu n'a jamais repondu a rien.
-    comment_times = [
-        ts(c["createdAt"]) for c in (pr_data.get("comments") or []) if can_lift(c)
+    # On porte l'AUTEUR de chaque evenement de levee : la borne #11145 en a
+    # besoin (auteur seul = les temps plats de #11222 ne suffisaient pas).
+    lift_events = [
+        (ts(c["createdAt"]), (c.get("author") or {}).get("login", ""))
+        for c in (pr_data.get("comments") or []) if can_lift(c)
     ]
-    comment_times = [t for t in comment_times if t]
 
     # Fenetre 05-29..06-04 (#1958) : la RE-REVIEW APPROVED. Le reviewer qui
     # revient approuver apres sa demande de changements A dit que la reserve
@@ -478,7 +493,11 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         and (r.get("author") or {}).get("login", "") not in BOT_LOGINS
     ]
     approved_rereviews = [(t, a) for (t, a) in approved_rereviews if t]
-    comment_times += [t for (t, _) in approved_rereviews]
+    lift_events += approved_rereviews
+    lift_events = [(t, a) for (t, a) in lift_events if t]
+
+    def _lift_eligible(lift_author: str, nit_author: str) -> bool:
+        return lift_author in (nit_author, pr_author)
 
     # Fenetre 2026-08-16 (#11222) : les temps plats ne suffisent pas pour un
     # CHANGES_REQUESTED. Une PHRASE explicite de levee (LIFT_MARKER non
@@ -542,13 +561,16 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
                 when < t < cutoff and author == login
                 for (t, author) in approved_rereviews
             ) or any(
-                when < t < cutoff
-                for (t, _, _) in explicit_lifts
+                when < t < cutoff and _lift_eligible(lifter, login)
+                for (t, lifter, _) in explicit_lifts
             )
             if lifted:
                 continue
-        elif any(when < t < cutoff for t in comment_times):
-            continue  # discute/refuse explicitement apres le nit, avant le merge
+        elif any(
+            when < t < cutoff and _lift_eligible(lift_author, login)
+            for (t, lift_author) in lift_events
+        ):
+            continue  # reponse de l'auteur du nit ou de l'auteur de la PR
         # Un commit poussé après le nit ne le lève PAS à lui seul : sur #10761,
         # le « traitement » était un rebase à 19:41 qui n'adressait aucun des
         # deux nits de 11:07. Le push est reporté comme contexte, pas comme levée
@@ -585,7 +607,9 @@ FIELDS = "number,title,mergedAt,author,comments,reviews,commits,url,state"
 # `commits` porte une connection `authors` par commit : sur un `gh pr list` large,
 # GraphQL depasse son plafond de 500 000 noeuds. L'audit retro liste donc SANS
 # `commits`, puis ne les recupere que pour les PRs reellement candidates.
-LIST_FIELDS = "number,title,mergedAt,url,comments,reviews"
+# `author` est requis depuis #11145 : la borne d'auteur des levees a besoin de
+# l'auteur de la PR, en audit comme en gate.
+LIST_FIELDS = "number,title,mergedAt,url,comments,reviews,author"
 
 
 def gate(pr: int, as_json: bool) -> int:

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -55,6 +55,7 @@ def run(comments, commits=None, threads=None):
     data = {
         "number": 0,
         "title": "t",
+        "author": {"login": "jsboige"},
         "comments": comments,
         "reviews": [],
         "commits": commits if commits is not None else [{"committedDate": at(19)}],
@@ -478,7 +479,8 @@ def test_en_tete_hermes_emission_flagge_malgre_agent():
 
 def run_reviews(reviews):
     data = {
-        "number": 0, "title": "t", "comments": [], "reviews": reviews,
+        "number": 0, "title": "t", "author": {"login": "jsboige"},
+        "comments": [], "reviews": reviews,
         "commits": [{"committedDate": at(19)}],
     }
     return mod.analyse(data, [], MERGED)
@@ -700,7 +702,8 @@ CR_REVIEW = {
 
 def run_cr(comments=(), reviews=()):
     data = {
-        "number": 0, "title": "t", "comments": list(comments),
+        "number": 0, "title": "t", "author": {"login": "jsboige"},
+        "comments": list(comments),
         "reviews": [CR_REVIEW, *reviews],
         "commits": [{"committedDate": at(19)}],
     }
@@ -746,7 +749,8 @@ def test_cr_dismissed_nest_pas_un_signal():
     """Levee (b) : une dismissal GitHub n'est possible que par l'auteur de la
     review (ou un admin) — formellement retiree des la collecte."""
     data = {
-        "number": 0, "title": "t", "comments": [],
+        "number": 0, "title": "t", "author": {"login": "jsboige"},
+        "comments": [],
         "reviews": [{"author": {"login": "myia-ai-01"},
                      "state": "DISMISSED", "submittedAt": at(10),
                      "body": "CHANGES_REQUESTED: cellule 19."}],
@@ -778,3 +782,62 @@ def test_nit_commentaire_garde_le_regime_general():
     reply = {"author": {"login": "jsboige"}, "createdAt": at(12),
              "body": "Bien vu, corrige."}
     assert run([USER_NIT, reply])["blocked"] is False
+
+
+# --- #11145 : la borne d'auteur. Une levee ne compte que si elle vient de
+# l'auteur de la reserve OU de l'auteur de la PR (mesure #11494 sur 850 PRs :
+# SELF 22/37 = 59,5 % + PR_AUTHOR 6/37 = 16,2 % = flux sain preserve ;
+# BYSTANDER 9/37 = 24,3 % = la classe #10761 que l'organe bloque — une
+# approbation ou une reponse d'un tiers n'eteint pas une reserve posee par un
+# autre). Echappement B.0 : issue de suivi nommee.
+
+HERMES_NIT = {
+    "author": {"login": "clusterManager-Myia"}, "createdAt": at(10),
+    "body": "[Hermes] COMMENT_WITH_CONCERNS\n2 cellules manquent d'interp.",
+}
+
+
+def test_bystander_commentaire_ne_leve_pas_un_nit():
+    """#10761 : un tiers (ni auteur de la reserve, ni auteur de la PR) qui
+    repond apres le nit ne l'eteint pas — la reserve reste bloquante."""
+    bystander = {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+                 "body": "Releve de mon cote, plus de conflit."}
+    assert run([USER_NIT, bystander])["blocked"] is True
+
+
+def test_bystander_approved_ne_leve_pas_un_nit():
+    """La classe mesuree #11494 (4 cas Hermes) : un APPROVED d'un reviewer
+    tiers n'eteint pas une reserve posee par un autre."""
+    data = {
+        "number": 0, "title": "t", "author": {"login": "jsboige"},
+        "comments": [USER_NIT],
+        "reviews": [{"author": {"login": "clusterManager-Myia"},
+                     "state": "APPROVED", "submittedAt": at(15),
+                     "body": "De mon cote c'est bon."}],
+        "commits": [{"committedDate": at(19)}],
+    }
+    assert mod.analyse(data, [], MERGED)["blocked"] is True
+
+
+def test_auteur_du_nit_leve_son_nit():
+    """SELF (59,5 %) : l'auteur de la reserve revient repondre — le nit se
+    leve par le regime general borne (auteur == auteur du nit)."""
+    reply = {"author": {"login": "clusterManager-Myia"}, "createdAt": at(12),
+             "body": "Les 2 cellules d'interp sont ajoutees, commit abc."}
+    assert run([HERMES_NIT, reply])["blocked"] is False
+
+
+def test_auteur_pr_repond_a_son_reviewer_leve():
+    """PR_AUTHOR (16,2 %) : le worker (auteur de la PR) repond au reviewer —
+    le flux sain que la borne preserve."""
+    reply = {"author": {"login": "jsboige"}, "createdAt": at(12),
+             "body": "Les 2 cellules d'interp sont ajoutees, commit abc."}
+    assert run([HERMES_NIT, reply])["blocked"] is False
+
+
+def test_bystander_explicit_lift_ne_leve_pas_changes_requested():
+    """#11145 sur l'etat CHANGES_REQUESTED : une PHRASE de levee d'un tiers
+    (ni l'auteur du CR, ni l'auteur de la PR) n'eteint pas l'etat."""
+    bystander = {"author": {"login": "clusterManager-Myia"}, "createdAt": at(12),
+                 "body": "Les 2 points sont adresses, commit abc123."}
+    assert run_cr([bystander])["blocked"] is True


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/correction #11460

Closes #11145 — l'implémentation complète les critères de sortie : concern 2 mesuré (#11494) puis borné ici, concern 1 mesuré « garder le citer re » (#11494, 0 FP), concern 3 répondu.

## Scope

Implémentation de la borne d'auteur demandée par le titre de **#11145** dans `scripts/check_unaddressed_nits.py` (l'organe qui garde tous les merges, incident fondateur #10761). La mesure (PR #11494 MERGED, 850 PRs / 76 nits / 37 levées) :

| Classe | n | % des levées | Sort |
|---|---|---|---|
| SELF (l'auteur de la réserve revient) | 22 | 59.5% | **préservé** (auteur du nit) |
| PR_AUTHOR (le worker répond à son reviewer) | 6 | 16.2% | **préservé** (auteur de la PR) |
| BYSTANDER (un tiers — classe #10761) | 9 | 24.3% | **bloqué** |

## Changement

- `lift_events = [(time, author)]` remplace les `comment_times` plats : chaque événement de levée porte son auteur (les temps seuls de #11222 ne suffisaient plus).
- **Régime général** (nits portés par commentaire) : une réponse ne lève que si `author ∈ {auteur du nit, auteur de la PR}`.
- **CHANGES_REQUESTED / explicit_lifts** : une phrase de levée ne lève que si `author ∈ {auteur du CR, auteur de la PR}`. La re-review APPROVED par l'auteur du CR reste inchangée (SELF, état natif #1958).
- `LIST_FIELDS` porte `author` (audit rétro cohérent avec le gate).
- **Échappement B.0** inchangé : issue de suivi nommée (le message du gate le rappelle déjà).

## Décision (arbitrage ratifié par ai-01 au merge)

La donnée #11494 tranche : borne **« auteur OU auteur-PR »** et non « auteur seul » (qui casserait les 6 levées PR_AUTHOR = flux sain worker→reviewer, +16.2% de bruit inutile) ni « garder » (laisse la classe #10761 ouverte). Le design-gate est posé ici ; ai-01 peut CHANGES_REQUESTED si une autre politique est préférée.

## Validation

- `pytest scripts/tests/test_check_unaddressed_nits.py` : **75 passed** (5 nouveaux : bystander commentaire ne lève pas, bystander APPROVED ne lève pas, SELF lève, PR_AUTHOR lève, bystander explicit-lift ne lève pas un CR).
- Compagnon #11494 : `test_nit_lift_authorship.py` **9/9 passed** (aucune casse d'import).
- Gate live sur mes PRs en vol, tous **OK** sous la borne : #11263 (réserve Hermes levée par ma réponse d'auteur PR), #11602, #11604.
- 2 fichiers, +100/−13 — pas de composite (G.4). Catalogue byte-identique à main.