### PR TITLE
fix(site,#11451): separateur --- en tete de cellule lu comme bloc YAML par Quarto (main rouge depuis 17/08 19:09Z)

### DIFF
--- a/MyIA.AI.Notebooks/FallacyDetection/02_fallacy_datasets_landscape.ipynb
+++ b/MyIA.AI.Notebooks/FallacyDetection/02_fallacy_datasets_landscape.ipynb
@@ -119,7 +119,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "### Dataset 1 — Logic / LogicClimate (Jin et al. 2022)\n",
     "\n",
     "**Papier** : Jin et al., *Logical Fallacy Detection*, Findings of EMNLP 2022 — [arXiv:2202.13758](https://arxiv.org/abs/2202.13758). Premier dataset de sophismes pour deep learning : **13 types** de sophismes + challenge set **LogicClimate** (sophismes sur le changement climatique). Repo GitHub : `causalNLP/logical-fallacy`."
@@ -203,7 +203,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "### Dataset 2 — MAFALDA (Helwe et al. 2023)\n",
     "\n",
     "**Papier** : Helwe, Calamai, Paris, Clavel, Suchanek, *MAFALDA: A Benchmark and Comprehensive Study of Fallacy Detection and Classification*, 2023 — [arXiv:2311.09761](https://ar5iv.labs.arxiv.org/html/2311.09761). Benchmark de reference : taxonomie **hierarchique 3 niveaux** (L0 binaire, L1 : 3 categories aristoteliciennes Pathos/Logos/Ethos, **L2 : 23 sophismes fins**). Evaluation zero-shot d'une batterie de LLMs (GPT-3.5, LLaMA-2, Mistral...)."
@@ -296,7 +296,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "### Dataset 3 — IBM Project Debater / debate_speeches\n",
     "\n",
     "Discours d'ouverture de debats annotes (Slonim et al., *Nature* 2021). Reference industrielle de l'argument mining. Dataset HuggingFace : `ibm-research/debate_speeches`."
@@ -386,7 +386,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "### Dataset 4 — IBM-Rank-30k (Gretz et al. 2019)\n",
     "\n",
     "Gretz et al., *A Large-scale Dataset for Argument Quality Ranking*, 2019 — [arXiv:1911.11408](https://arxiv.org/pdf/1911.11408). **30 497 arguments** etiquetes en qualite point-wise (le plus grand a sa sortie). Distinct de la detection de sophisme mais complementaire (qualite argumentative). HuggingFace : `ibm-research/quality_ranking_30k`."
@@ -468,7 +468,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "### Dataset 5 — AraucariaDB (Reed et al., ARG-tech)\n",
     "\n",
     "Premier corpus mondial d'argumentation analysee (diagrammes Toulmin premises/conclusion). Construit via l'outil Araucaria. **Nomme explicitement par le critere d'acceptance 2**. URL : `http://araucaria.arg.tech/`."
@@ -540,7 +540,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "### Dataset 6 — Reddit ChangeMyView (extrait)\n",
     "\n",
     "**Nomme explicitement par le critere d'acceptance 2**. ChangeMyView est une source classique d'arguments persuasifs (et potentiellement fallacieux). Versions publiques sur HF."
@@ -621,7 +621,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "### Dataset 7 — Corpus rhetorique francais (si disponible)\n",
     "\n",
     "La taxonomie Argumentum est **multilingue** (parallele sur 8 langues, avec libelles anglais natifs `text_en` / `desc_en` / `example_en`) ; le francais est la langue initiale, non exclusive. Un corpus rhetorique FR etiquete reste utile comme jeu d'evaluation FR complementaire. Recherche sur HF + GitHub."
@@ -692,7 +692,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## Synthese — paysage des datasets et cardinalite totale\n",
     "\n",
     "Tableau agrege des **>= 5 datasets testes en acces reel** (critere 2). Le **cardinal total** est la somme des datasets accessibles et etiquetes fallacy (Logic + MAFALDA = cibles directes) ; les sources adjacentes (IBM, AraucariaDB, CMV) sont comptees separement car non etiquetees fallacy."

--- a/MyIA.AI.Notebooks/FallacyDetection/03_taxonomy_coverage_gap.ipynb
+++ b/MyIA.AI.Notebooks/FallacyDetection/03_taxonomy_coverage_gap.ipynb
@@ -140,7 +140,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 2. Les étiquettes académiques (encodées depuis les papiers, cités)\n",
     "\n",
     "Les deux taxonomies de référence pour la détection de sophismes par deep learning. Les listes ci-dessous sont encodées depuis les papiers (pas depuis Argumentum), de sorte que la mesure de couverture soit honnête."
@@ -235,7 +235,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 3. L'écart — deux ordres de grandeur\n",
     "\n",
     "La mesure qui requalifie le paysage : la **totalité** des étiquettes fallacy de l'état de l'art académique (deux datasets de référence) représente ~4 % des **feuilles** Argumentum, ~2,5 % des **nœuds**."
@@ -322,7 +322,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 4. Ce que cet écart signifie pour l'Epic (cadrage stratégique)\n",
     "\n",
     "L'écart n'est pas un défaut des datasets académiques — ils sont **délibérément coarse** (13-23 classes pour la reproductibilité expérimentale). Argumentum est **délibérément fine** (894 feuilles, profondeur 0→10) car c'est la grille d'un **jeu** : identifier précisément une feuille obscure dans un contexte complexe. Les conséquences pour l'Epic :\n",


### PR DESCRIPTION
Grain: LIGHT/docs — lane myia-ai-01:CoursIA — prev: MED/slides #11536

## Ce que ca repare

Le site public **n'a plus deploye depuis 2026-08-17T19:09Z**. Tous les runs
non-annules de `Build Quarto site` depuis echouent :

```
ERROR: YAMLException: unidentified alias "*Papier**" (4:11)
 4 | **Papier** : Jin et al., *Logical Fallacy  ...
```

| run | SHA | verdict |
|---|---|---|
| 32058767226 (2026-08-17T19:09Z) | `98c877037` | dernier **success** |
| 32068831653 (2026-08-17T21:00Z) | `e49da9b54` | premier **failure** |
| 32129179747 (2026-08-18T10:55Z) | `a63de7f9a` | failure (7 consecutifs) |

## Cause exacte

Une ligne `---` seule **en tete** d'une cellule markdown ouvre un bloc
`yaml_metadata_block` Pandoc ; le `---` de la cellule suivante le referme.
Le contenu intermediaire n'est pas du YAML : `**Papier**` y est lu comme
l'alias `*Papier**`, non defini -> le rendu s'arrete.

**Pourquoi maintenant, et pas depuis la creation du notebook (d6aa1bc98) ?**
Ces deux notebooks ne sont **pas** dans la render-list de `_quarto.yml`
(verifie : `grep -c '02_fallacy_datasets_landscape\|03_taxonomy_coverage_gap' _quarto.yml` -> `0`).
Ils sont devenus visibles de Quarto le **2026-08-17T20:27Z**, quand
`4bcdae5ef` (#11480) a ajoute deux liens vers eux depuis
`FallacyDetection/README.md` — qui, lui, **est** rendu (ligne 52 de `_quarto.yml`).
Quarto lit les metadonnees d'un `.ipynb` du projet cible par un lien pour
reecrire ce lien vers son `.html` : c'est cette lecture qui casse.

La fenetre colle au commit pres : vert 19:09Z, commit 20:27Z, rouge 21:00Z.

## Correctif

`---` -> `***` en tete des 11 cellules concernees (8 dans `02_`, 3 dans `03_`).
`***` est un thematic break CommonMark au rendu strictement identique, et il
ne peut pas ouvrir un bloc YAML. Diff : **11 lignes**, aucune cellule de code
touchee -> pas de re-execution due (exception markdown-only, C.2).

## Deux mesures que j'ai du corriger en route (honnetete d'instrument)

1. **Mon premier detecteur sur-accusait** : il rendait **351** notebooks
   « cassants » sur 1046, alors que le site etait vert la veille. Le tell
   [[gate-can-over-accuse-not-only-undercount]] a joue : un compte d'items
   sans commune mesure avec la taille du defaut reel. La regle Pandoc est
   correcte, mais elle ne mord que sur les fichiers que Quarto **lit** —
   render-list ou cible d'un lien depuis une page rendue. Les 350 autres
   portent la meme forme sans etre jamais lus.
2. **J'avais d'abord attribue l'echec au notebook comme fichier rendu.**
   Faux : il n'est pas dans la render-list. C'est le lien depuis le README
   qui l'expose. L'attribution correcte change le perimetre du fix (2 fichiers,
   pas 351) et la nature du garde a construire (voir ci-dessous).

## Suivi

La classe de defaut reste ouverte : tout futur lien depuis une page rendue
vers un `.ipynb` portant un `---` en tete de cellule rejouera la panne, et
elle se manifeste **loin** de la PR qui l'a causee (celle-ci ne touchait que
le README). Un garde pre-commit existe deja pour une famille voisine
(« Block NEW oversized markdown-rendering defects (frontmatter / setext) ») :
l'etendre a ce cas est le geste suivant — issue ouverte separement, pas
melangee a ce hotfix.

See #11451
