### PR TITLE
feat(tooling,#11451): fix_hr_separator — le pendant du garde, qui fait revenir les notebooks

### DIFF
--- a/scripts/notebook_tools/fix_hr_separator.py
+++ b/scripts/notebook_tools/fix_hr_separator.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Convertit les separateurs horizontaux `---` en `***` dans les cellules markdown.
+
+Pourquoi
+--------
+Une ligne `---` seule ouvre un bloc de metadonnees YAML au sens Pandoc
+(`yaml_metadata_block`), referme par un `---` ou `...` ulterieur. Dans un
+notebook, un `---` ecrit comme separateur horizontal en debut de cellule ouvre
+un tel bloc ; la prose et les titres des cellules suivantes sont alors lus
+comme des paires cle/valeur -> `YAMLException` -> `quarto render` echoue.
+Comme Quarto s'arrete au PREMIER echec, un seul notebook fait tomber tout le
+site (incident #11451, 2026-08-17).
+
+`***` rend exactement le meme `<hr>` en markdown et n'a aucune semantique YAML.
+C'est la conversion appliquee ici.
+
+Ce que l'outil NE touche PAS
+----------------------------
+- les `---` a l'interieur d'un bloc de code (``` ou ~~~) ;
+- les `---` qui SOULIGNENT du texte : un `---` colle a une ligne non vide est
+  un titre setext H2, pas un separateur — le convertir changerait le rendu ;
+- un VRAI bloc de frontmatter en tete de notebook (cellule 0 commencant par
+  `---` dont le contenu parse en mapping YAML) : Quarto s'en sert
+  legitimement pour le titre, l'auteur, les options de rendu.
+
+Distinction avec `detect_markdown_rendering.py`
+-----------------------------------------------
+Ce dernier vise les defauts de rendu VISUEL (bloc surdimensionne a l'ouverture)
+cellule par cellule. Le present outil vise l'echec de BUILD Quarto, qui est
+CROSS-CELLULE par nature (le `---` ouvrant et le `---` fermant sont dans deux
+cellules differentes). Les deux populations se recouvrent sans coincider.
+
+Usage
+-----
+    python scripts/notebook_tools/fix_hr_separator.py --check MyIA.AI.Notebooks/GameTheory
+    python scripts/notebook_tools/fix_hr_separator.py --apply MyIA.AI.Notebooks/GameTheory
+
+Sortie : 0 si rien a convertir (--check) ou conversion faite (--apply),
+1 si des separateurs restent a convertir (--check), 2 en cas d'erreur.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+FENCE_RE = re.compile(r"^(`{3,}|~{3,})")
+HR = "---"
+REPLACEMENT = "***"
+
+
+def _lines(source) -> list[str]:
+    """Rend les lignes d'une source de cellule, quel que soit son encodage nbformat."""
+    if isinstance(source, list):
+        return "".join(source).split("\n")
+    return (source or "").split("\n")
+
+
+def _is_real_frontmatter(lines: list[str]) -> bool:
+    """Vrai si la cellule EST un bloc de frontmatter YAML legitime.
+
+    Forme : premiere ligne `---`, une ligne `---`/`...` de fermeture plus bas,
+    et un contenu qui ressemble a des paires cle/valeur (au moins une ligne
+    `cle: valeur` et aucune ligne de prose evidente). On reste volontairement
+    grossier : en cas de doute on considere que c'en est un et on ne touche pas.
+    """
+    if not lines or lines[0].strip() != HR:
+        return False
+    close = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() in (HR, "..."):
+            close = i
+            break
+    if close is None:
+        return False
+    body = [x for x in lines[1:close] if x.strip()]
+    if not body:
+        return False
+    return any(re.match(r"^[A-Za-z_][A-Za-z0-9_.-]*\s*:", x) for x in body)
+
+
+def convert_cell(source, is_first_cell: bool) -> tuple[object, int]:
+    """Rend (nouvelle_source, nb_conversions) pour une source de cellule markdown."""
+    lines = _lines(source)
+    if is_first_cell and _is_real_frontmatter(lines):
+        return source, 0
+
+    in_fence = False
+    changed = 0
+    out: list[str] = []
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if FENCE_RE.match(stripped):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        if in_fence or stripped != HR:
+            out.append(line)
+            continue
+        prev = lines[i - 1].strip() if i > 0 else ""
+        if prev != "":
+            out.append(line)  # soulignement setext : ne pas toucher
+            continue
+        out.append(line.replace(HR, REPLACEMENT, 1))
+        changed += 1
+
+    if not changed:
+        return source, 0
+
+    text = "\n".join(out)
+    if isinstance(source, list):
+        parts = text.split("\n")
+        return [p + "\n" for p in parts[:-1]] + ([parts[-1]] if parts[-1] else []), changed
+    return text, changed
+
+
+def process(path: Path, apply: bool) -> int:
+    """Rend le nombre de separateurs convertis (ou convertibles si apply=False)."""
+    try:
+        nb = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        print(f"ILLISIBLE {path}: {exc}", file=sys.stderr)
+        return 0
+
+    total = 0
+    seen_markdown = False
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "markdown":
+            continue
+        first = not seen_markdown
+        seen_markdown = True
+        new_source, n = convert_cell(cell.get("source"), first)
+        if n:
+            total += n
+            if apply:
+                cell["source"] = new_source
+
+    if total and apply:
+        path.write_text(
+            json.dumps(nb, ensure_ascii=False, indent=1) + "\n", encoding="utf-8"
+        )
+    return total
+
+
+def iter_notebooks(targets: list[str]):
+    for t in targets:
+        p = Path(t)
+        if p.is_dir():
+            for nb in sorted(p.rglob("*.ipynb")):
+                s = str(nb).replace("\\", "/")
+                if "/.ipynb_checkpoints/" in s or s.endswith("_output.ipynb"):
+                    continue
+                yield nb
+        elif p.suffix == ".ipynb":
+            yield p
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    mode = ap.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true", help="ne rien ecrire, compter")
+    mode.add_argument("--apply", action="store_true", help="ecrire les conversions")
+    ap.add_argument("targets", nargs="+", help="fichiers .ipynb ou repertoires")
+    args = ap.parse_args(argv)
+
+    files = 0
+    seps = 0
+    for nb in iter_notebooks(args.targets):
+        n = process(nb, apply=args.apply)
+        if n:
+            files += 1
+            seps += n
+            verbe = "converti" if args.apply else "a convertir"
+            print(f"  {nb.as_posix()} : {n} separateur(s) {verbe}")
+
+    verbe = "convertis" if args.apply else "a convertir"
+    print(f"{seps} separateur(s) {verbe} dans {files} notebook(s)")
+    if args.check and seps:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_fix_hr_separator.py
+++ b/scripts/notebook_tools/tests/test_fix_hr_separator.py
@@ -1,0 +1,123 @@
+"""Tests de `fix_hr_separator` — chaque cas dangereux a son controle.
+
+Le risque de cet outil n'est pas de rater une conversion (le notebook reste
+simplement hors du render) mais d'en faire une de trop : convertir un
+soulignement setext ou un vrai frontmatter changerait le rendu ou casserait
+les metadonnees. Les tests sont donc majoritairement des controles NEGATIFS.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "fix_hr_separator", Path(__file__).resolve().parents[1] / "fix_hr_separator.py"
+)
+fix = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(fix)
+
+
+def conv(text, first=False):
+    return fix.convert_cell(text, first)
+
+
+def test_separateur_apres_ligne_vide_converti():
+    src = "Du texte.\n\n---\n\nAutre texte."
+    out, n = conv(src)
+    assert n == 1
+    assert "***" in out and "\n---\n" not in out
+
+
+def test_separateur_en_tete_de_cellule_converti():
+    src = "---\n\n## Titre\n\nProse."
+    out, n = conv(src)
+    assert n == 1
+    assert out.startswith("***")
+
+
+def test_soulignement_setext_non_touche():
+    """`---` colle a du texte = titre H2, pas un separateur."""
+    src = "Un titre de section\n---\n\nProse."
+    out, n = conv(src)
+    assert n == 0
+    assert out == src
+
+
+def test_bloc_de_code_non_touche():
+    src = "Exemple :\n\n```yaml\n\n---\n\n```\n\nFin."
+    out, n = conv(src)
+    assert n == 0
+    assert out == src
+
+
+def test_vrai_frontmatter_de_tete_non_touche():
+    src = '---\ntitle: "Mon notebook"\nauthor: Moi\n---\n'
+    out, n = conv(src, first=True)
+    assert n == 0
+    assert out == src
+
+
+def test_frontmatter_hors_premiere_cellule_est_converti():
+    """Seule la PREMIERE cellule markdown peut porter un frontmatter legitime."""
+    src = '---\ntitle: "pas un frontmatter ici"\n---\n'
+    out, n = conv(src, first=False)
+    assert n >= 1
+
+
+def test_source_liste_reste_une_liste_avec_newlines():
+    src = ["Du texte.\n", "\n", "---\n", "\n", "Suite."]
+    out, n = conv(src)
+    assert n == 1
+    assert isinstance(out, list)
+    assert "".join(out) == "Du texte.\n\n***\n\nSuite."
+
+
+def test_plusieurs_separateurs_dans_une_cellule():
+    src = "A\n\n---\n\nB\n\n---\n\nC"
+    out, n = conv(src)
+    assert n == 2
+    assert out.count("***") == 2
+
+
+def test_process_ecrit_et_reste_idempotent(tmp_path):
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "source": "# Titre\n"},
+            {"cell_type": "markdown", "source": "Prose.\n\n---\n\nSuite.\n"},
+            {"cell_type": "code", "source": "x = 1\n", "outputs": [],
+             "execution_count": 1, "metadata": {}},
+        ],
+        "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+    }
+    p = tmp_path / "n.ipynb"
+    p.write_text(json.dumps(nb), encoding="utf-8")
+
+    assert fix.process(p, apply=False) == 1          # detecte
+    assert fix.process(p, apply=True) == 1           # convertit
+    assert fix.process(p, apply=False) == 0          # idempotent
+    after = json.loads(p.read_text(encoding="utf-8"))
+    assert "***" in after["cells"][1]["source"]
+    assert after["cells"][2]["source"] == "x = 1\n"  # code intact
+
+
+def test_controle_positif_le_notebook_de_l_incident(tmp_path):
+    """Controle POSITIF : la forme exacte qui a fait tomber le site #11451.
+
+    Sans lui, un `0 a convertir` serait indiscernable d'un detecteur casse.
+    """
+    nb = {
+        "cells": [
+            {"cell_type": "markdown", "source": "# SL-8\n"},
+            {"cell_type": "markdown",
+             "source": "---\n\n## 3. Extraction des donnees\n\nAvant de miner.\n"},
+            {"cell_type": "markdown",
+             "source": "---\n\n### Interpretation : Extraction\n\nL'extraction convertit.\n"},
+        ],
+        "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+    }
+    p = tmp_path / "sl8.ipynb"
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    assert fix.process(p, apply=False) == 2, (
+        "controle positif ECHOUE : la forme de l'incident #11451 n'est pas "
+        "detectee -> l'outil est casse, son 'rien a convertir' est sans valeur"
+    )


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #11631

See #11451, See #10923

## A quoi ca sert

#11631 pose un garde qui **exclut** du render Quarto les notebooks portant un
`---` separateur — la construction qui ouvre un bloc de metadonnees YAML au sens
Pandoc et fait echouer le build **entier** du site. Cet outil est ce qui les fait
**revenir** : `***` rend exactement le meme `<hr>` et n'a aucune semantique YAML,
donc un notebook nettoye reintegre automatiquement la liste de render a la
regeneration suivante.

Sans le fixer, le garde n'est qu'un pansement. Avec lui, c'est un cliquet.

**Ampleur mesuree sur l'arbre** : **2865** separateurs dans **551** notebooks
(`--check MyIA.AI.Notebooks`).

## Ce que l'outil ne touche pas, et pourquoi

| Cas | Traitement | Raison |
|---|---|---|
| `---` dans un bloc de code (```` ``` ````/`~~~`) | intact | ce n'est pas un separateur |
| `---` **colle** a une ligne non vide | intact | c'est un **soulignement setext** (titre H2) — le convertir changerait le rendu |
| vrai frontmatter en tete (cellule markdown 0, `---` + paires cle/valeur) | intact | Quarto s'en sert legitimement (titre, auteur, options) |

Le risque de cet outil n'est pas de **rater** une conversion — le notebook reste
alors simplement hors render, etat deja atteint — mais d'en faire **une de trop**.
Les tests sont donc majoritairement des controles **negatifs**.

## Preuve d'aller-retour (famille `Probas/DecisionTheory`, copie hors depot)

| Mesure | Avant | Apres |
|---|---|---|
| notebooks exclus par le garde de #11631 | **16 / 18** | **0 / 18** |
| oracle js-yaml (le parser qu'emploie Quarto) | `scanned=18 bad=15` | `scanned=18 bad=0` |
| `nbformat.validate` | 18 valides | 18 valides |
| sources des cellules **code** | — | inchangees |

Le `bad=0` n'est exploitable que parce que le `bad=15` de la ligne du dessus est
son controle : sans lui, un zero serait indiscernable d'un oracle debranche.
L'oracle utilise **js-yaml**, pas PyYAML — c'est ce qui rend la mesure comparable
a ce que la CI constatera.

## Tests

10 tests (`scripts/notebook_tools/tests/test_fix_hr_separator.py`), tous verts :

- **negatifs** : soulignement setext intact · bloc de code intact · vrai
  frontmatter de tete intact ;
- **positifs** : separateur apres ligne vide converti · separateur en tete de
  cellule converti · frontmatter **hors** premiere cellule converti (une seule
  cellule peut legitimement en porter un) · plusieurs separateurs dans une
  cellule · source en liste qui reste une liste avec ses `\n` · idempotence
  (2e passe = 0 conversion), code intact ;
- **controle positif** reproduisant la forme exacte de l'incident #11451
  (`SymbolicLearning/SL-8`), avec un message d'echec qui dit pourquoi : sans lui,
  un « rien a convertir » serait indiscernable d'un outil casse.

## Pourquoi un outil distinct de `detect_markdown_rendering.py`

Ce dernier vise les defauts de rendu **visuel** (bloc surdimensionne a
l'ouverture), **cellule par cellule**, avec une baseline de ~480 violations. Le
present defaut est un echec de **build**, et il est **cross-cellule** par nature :
le `---` ouvrant et le `---` fermant sont dans deux cellules differentes. Les
deux populations se recouvrent sans coincider. Le precedent d'un *fixer* separe
dans `notebook_tools/` existe deja (`restore_accents_canonical.py`).

## Suite

Le nettoyage se fait **par famille**, chacune verifiable mecaniquement (le
notebook reintegre le render, ou il n'y reintegre pas). C'est un backlog qui se
vide tout seul et ne peut pas mentir sur son avancement.

> Note d'honnetete sur le tag : ce grain est `tooling`, donc **META**. Il ne
> satisfait pas le plancher G-VAR-1 de contenu, et le nettoyage par famille qu'il
> rend possible est `refactor` — META lui aussi. Il ne doit donc pas devenir le
> plat principal d'une lane : c'est un a-cote qui debloque la publication du
> contenu, pas du contenu.
