### PR TITLE
refactor(site,#10923): convertir --- → *** famille SmartContracts (27 notebooks, 290 hr)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-0-Cypherpunk-Origins.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Retour au sommaire](../README.md) | [Suivant : Setup Foundry >>](SC-1-Setup-Foundry.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -51,7 +51,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Le Manifeste Cypherpunk\n",
     "\n",
@@ -189,7 +189,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Hash et integrite\n",
     "\n",
@@ -384,7 +384,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Chaîne de hash (proto-blockchain)\n",
     "\n",
@@ -619,7 +619,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Arbre de Merkle\n",
     "\n",
@@ -893,7 +893,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Proof-of-Work (Hashcash)\n",
     "\n",
@@ -1128,7 +1128,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Signatures numériques\n",
     "\n",
@@ -1368,7 +1368,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. DHT et reseaux pair-a-pair\n",
     "\n",
@@ -1606,7 +1606,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Synthese : de Chaum a Ethereum\n",
     "\n",
@@ -1760,7 +1760,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 9. Exercice : Construire une mini-blockchain complete\n",
     "\n",
@@ -1844,7 +1844,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 10. Resume\n",
     "\n",
@@ -1864,7 +1864,7 @@
     "- L'innovation de Satoshi Nakamoto est la **combinaison** de ces primitives\n",
     "- Comprendre ces fondations permet de mieux apprehender la securite et les limites des blockchains\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-1-Setup-Foundry](SC-1-Setup-Foundry.ipynb) - Installation de l'environnement de développement"
    ]
@@ -1906,7 +1906,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Retour au sommaire](../README.md) | [Suivant : Setup Foundry >>](SC-1-Setup-Foundry.ipynb)\n"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-1-Setup-Foundry.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Cypherpunk Origins](SC-0-Cypherpunk-Origins.ipynb) | [Suivant : Setup Web3py >>](SC-2-Setup-Web3py.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -51,7 +51,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Detection de l'environnement"
    ]
@@ -148,7 +148,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Installation de Foundry\n",
     "\n",
@@ -294,7 +294,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Solidity Compiler (solc)\n",
     "\n",
@@ -389,7 +389,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Premier projet Foundry\n",
     "\n",
@@ -471,7 +471,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Premier contrat Solidity\n",
     "\n",
@@ -627,7 +627,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Test Foundry\n",
     "\n",
@@ -777,7 +777,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Resume de l'environnement"
    ]
@@ -890,7 +890,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. VSCode Extensions recommandees\n",
     "\n",
@@ -900,7 +900,7 @@
     "| **Foundry** | Integration Foundry |\n",
     "| **Error Lens** | Erreurs en ligne |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Points cles\n",
     "\n",
@@ -911,7 +911,7 @@
     "| **Solidity** | Langage smart contracts |\n",
     "| **.t.sol** | Convention pour fichiers de test |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-2-Setup-Web3py](SC-2-Setup-Web3py.ipynb)"
    ]
@@ -1021,7 +1021,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Cypherpunk Origins](SC-0-Cypherpunk-Origins.ipynb) | [Suivant : Setup Web3py >>](SC-2-Setup-Web3py.ipynb)\n"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/00-Foundations/SC-2-Setup-Web3py.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Setup Foundry](SC-1-Setup-Foundry.ipynb) | [Suivant : Solidity Basics >>](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -51,7 +51,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Installation des dependances\n",
     "\n",
@@ -209,7 +209,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Connexion a anvil (blockchain locale)\n",
     "\n",
@@ -333,7 +333,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Compiler un contrat Solidity depuis Python\n",
     "\n",
@@ -462,7 +462,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Deployer le contrat sur anvil\n",
     "\n",
@@ -564,7 +564,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Interagir avec le contrat\n",
     "\n",
@@ -679,7 +679,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Pattern helper reutilisable\n",
     "\n",
@@ -838,7 +838,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Transactions multi-comptes\n",
     "\n",
@@ -937,10 +937,11 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Exemple guide : Deployer et tester un contrat Vault\n",
-    "\n_Resolu par le groupe Antoine Gaillard & Ambroise Durst (contribution PR #2397)._\n",
+    "\n",
+    "_Resolu par le groupe Antoine Gaillard & Ambroise Durst (contribution PR #2397)._\n",
     "\n",
     "Compilez, deployez et testez un coffre-fort Solidity depuis Python."
    ]
@@ -1089,17 +1090,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exercice (a completer) : Événements et plafond de depot\n",
     "\n",
     "En vous inspirant de l'exemple guide ci-dessus, faites evoluer le contrat `Vault` :\n",
     "\n",
-    "1. Ajoutez deux **événements** Solidity `Deposit(address indexed compte, uint256 montant)` ",
-    "et `Withdrawal(address indexed compte, uint256 montant)`, et emettez-les dans `deposit()` et `withdraw()`.\n",
+    "1. Ajoutez deux **événements** Solidity `Deposit(address indexed compte, uint256 montant)` et `Withdrawal(address indexed compte, uint256 montant)`, et emettez-les dans `deposit()` et `withdraw()`.\n",
     "2. Ajoutez un **plafond** : refusez (`require`) tout depot qui ferait depasser un solde individuel de 5 ETH.\n",
-    "3. Redeployez le contrat, effectuez un depot valide puis un depot qui depasse le plafond ",
-    "(attrapez l'exception), et lisez les événements via `contract.events.Deposit().get_logs(...)`.\n"
+    "3. Redeployez le contrat, effectuez un depot valide puis un depot qui depasse le plafond (attrapez l'exception), et lisez les événements via `contract.events.Deposit().get_logs(...)`.\n"
    ],
    "id": "cell-a50e497c"
   },
@@ -1133,7 +1132,7 @@
    "id": "exo2-reentrancy-consigne",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exercice (a completer) : Protection anti-reentrance sur le contrat Vault\n",
     "\n",
@@ -1186,7 +1185,7 @@
    "id": "exo3-calltransact-consigne",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "### Exercice (a completer) : `call()` vs `transact()` -- lecture vs ecriture\n",
     "\n",
@@ -1247,7 +1246,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 9. Resume\n",
     "\n",
@@ -1272,7 +1271,7 @@
     "contract.functions.myFunction(arg).transact({'from': deployer})\n",
     "```\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-3-Solidity-Basics](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb) - Types, variables et structures Solidity (avec deploiement reel)"
    ]
@@ -1297,7 +1296,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Setup Foundry](SC-1-Setup-Foundry.ipynb) | [Suivant : Solidity Basics >>](../01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb)\n"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-3-Solidity-Basics.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "[<< Setup Web3py](../00-Foundations/SC-2-Setup-Web3py.ipynb) | [Suivant : Functions & State >>](SC-4-Functions-State.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -78,7 +78,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Connexion a la blockchain locale\n",
     "\n",
@@ -174,7 +174,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Structure d'un contrat\n",
     "\n",
@@ -276,7 +276,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Types de données (Value Types)\n",
     "\n",
@@ -835,7 +835,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Variables\n",
     "\n",
@@ -1232,7 +1232,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Conversions de types"
    ]
@@ -1350,7 +1350,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Exemples guidés et Exercices"
    ]
@@ -1811,7 +1811,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Résumé\n",
     "\n",
@@ -1824,7 +1824,7 @@
     "| `bytes32` | Bytes fixes | `hex\"abcd\"` |\n",
     "| `string` | Chaîne UTF-8 | `\"Hello\"` |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-4-Functions-State](SC-4-Functions-State.ipynb)"
    ]
@@ -1937,7 +1937,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Setup Web3py](../00-Foundations/SC-2-Setup-Web3py.ipynb) | [Suivant : Functions & State >>](SC-4-Functions-State.ipynb)\n"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-4-Functions-State.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "[<< Solidity Basics](SC-3-Solidity-Basics.ipynb) | [Inheritance >>](SC-5-Inheritance.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -77,7 +77,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Connexion a la blockchain locale\n",
     "\n",
@@ -173,7 +173,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Data Locations\n",
     "\n",
@@ -413,7 +413,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Visibilite des fonctions\n",
     "\n",
@@ -689,7 +689,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Modificateurs de fonction\n",
     "\n",
@@ -970,7 +970,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Custom Modifiers\n",
     "\n",
@@ -1141,7 +1141,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Fonctions speciales"
    ]
@@ -1284,7 +1284,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exemples guidés"
    ]
@@ -1681,7 +1681,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Résumé\n",
     "\n",
@@ -1698,7 +1698,7 @@
     "| `pure` | Aucun accès au storage |\n",
     "| `payable` | Peut recevoir des ETH |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-5-Inheritance](SC-5-Inheritance.ipynb)"
    ]
@@ -1717,7 +1717,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Solidity Basics](SC-3-Solidity-Basics.ipynb) | [Inheritance >>](SC-5-Inheritance.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-5-Inheritance.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Functions & State](SC-4-Functions-State.ipynb) | [Suivant : Errors & Events >>](SC-6-Errors-Events.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -49,7 +49,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Connexion a la blockchain locale\n",
     "\n",
@@ -169,7 +169,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Heritage simple\n",
     "\n",
@@ -407,7 +407,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Heritage multiple\n",
     "\n",
@@ -593,7 +593,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Interfaces\n",
     "\n",
@@ -797,7 +797,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Contrats abstraits\n",
     "\n",
@@ -946,7 +946,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Super et linearisation\n",
     "\n",
@@ -1016,7 +1016,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exemples guidés et Exercices\n",
     "\n",
@@ -1504,7 +1504,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Resume\n",
     "\n",
@@ -1517,7 +1517,7 @@
     "| `abstract` | Contrat partiellement implemente |\n",
     "| `super` | Appel a la fonction parente |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-6-Errors-Events](SC-6-Errors-Events.ipynb)"
    ]
@@ -1559,7 +1559,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Functions & State](SC-4-Functions-State.ipynb) | [Suivant : Errors & Events >>](SC-6-Errors-Events.ipynb)\n"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/01-Solidity-Foundation/SC-6-Errors-Events.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Inheritance](SC-5-Inheritance.ipynb) | [Token Standards >>](../02-Solidity-Advanced/SC-7-Token-Standards.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -48,7 +48,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Connexion a la blockchain locale\n",
     "\n",
@@ -170,7 +170,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Gestion des erreurs\n",
     "\n",
@@ -309,7 +309,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Custom Errors (Solidity 0.8.4+)\n",
     "\n",
@@ -445,7 +445,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Events\n",
     "\n",
@@ -701,7 +701,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Try/Catch pour appels externes"
    ]
@@ -1068,7 +1068,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Exercices"
    ]
@@ -1370,7 +1370,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Resume\n",
     "\n",
@@ -1383,7 +1383,7 @@
     "| `event` | Logging blockchain | - |\n",
     "| `indexed` | Paramètres recherchables | Max 3 |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-7-Token-Standards](../02-Solidity-Advanced/SC-7-Token-Standards.ipynb)"
    ]
@@ -1402,7 +1402,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Inheritance](SC-5-Inheritance.ipynb) | [Token Standards >>](../02-Solidity-Advanced/SC-7-Token-Standards.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-10-Account-Abstraction.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< DAO Governance](SC-9-DAO-Governance.ipynb) | [LLM Assisted >>](SC-11-LLM-Assisted.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -50,7 +50,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Connexion a la blockchain locale\n",
     "\n",
@@ -72,7 +72,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Concepts ERC-4337\n",
     "\n",
@@ -324,7 +324,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Smart Account Simple\n",
     "\n",
@@ -705,7 +705,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Paymaster\n",
     "\n",
@@ -1086,7 +1086,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Flux de Transaction ERC-4337"
    ]
@@ -1198,7 +1198,7 @@
     },
     "tags": []
    },
-   "source": "---\n\n## 5. Exemple guide et Exercice\n\nL'exemple guidé ci-dessous montre un contrat résolu (solution étudiante). Un exercice à compléter suit."
+   "source": "***\n\n## 5. Exemple guide et Exercice\n\nL'exemple guidé ci-dessous montre un contrat résolu (solution étudiante). Un exercice à compléter suit."
   },
   {
    "cell_type": "code",
@@ -1449,7 +1449,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Resume\n",
     "\n",
@@ -1462,7 +1462,7 @@
     "| Bundler | Empaqueteur de transactions |\n",
     "| Social Recovery | Recuperation via gardiens |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-11-LLM-Assisted](SC-11-LLM-Assisted.ipynb)"
    ]
@@ -1487,7 +1487,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< DAO Governance](SC-9-DAO-Governance.ipynb) | [LLM Assisted >>](SC-11-LLM-Assisted.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "[<< Précédent : Account Abstraction](SC-10-Account-Abstraction.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Foundry Testing >>](../03-Foundry-Testing/SC-12-Foundry-Testing.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -87,7 +87,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Introduction\n",
     "\n",
@@ -2311,7 +2311,7 @@
     "- [GitHub Copilot](https://github.com/features/copilot) - Autocompletion IA\n",
     "- [Slither](https://github.com/crytic/slither) - Analyse statique Solidity\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "[<< Précédent : Account Abstraction](SC-10-Account-Abstraction.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Foundry Testing >>](../03-Foundry-Testing/SC-12-Foundry-Testing.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7-Token-Standards.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Précédent : Errors & Events](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) | [Retour au sommaire](../README.md) | [Suivant : DeFi Primitives >>](SC-8-DeFi-Primitives.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -50,7 +50,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Connexion a la blockchain locale\n",
     "\n",
@@ -151,7 +151,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Standard ERC-20\n",
     "\n",
@@ -443,7 +443,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Standard ERC-721 (NFT)\n",
     "\n",
@@ -784,7 +784,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Standard ERC-1155 (Multi-Token)\n",
     "\n",
@@ -1083,7 +1083,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. OpenZeppelin\n",
     "\n",
@@ -1392,7 +1392,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Exemples guidés"
    ]
@@ -1581,7 +1581,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Resume\n",
     "\n",
@@ -1601,7 +1601,7 @@
     "- `safeTransferFrom()` : Transfer securise\n",
     "- `approve()` : Autoriser un transfert\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-8-DeFi-Primitives](SC-8-DeFi-Primitives.ipynb)"
    ]
@@ -1643,7 +1643,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Précédent : Errors & Events](../01-Solidity-Foundation/SC-6-Errors-Events.ipynb) | [Retour au sommaire](../README.md) | [Suivant : DeFi Primitives >>](SC-8-DeFi-Primitives.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-8-DeFi-Primitives.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Token Standards](SC-7-Token-Standards.ipynb) | [DAO Governance >>](SC-9-DAO-Governance.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -50,7 +50,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Connexion a la blockchain locale\n",
     "\n",
@@ -152,7 +152,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Automated Market Maker (AMM)\n",
     "\n",
@@ -756,7 +756,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Price Impact et Slippage\n",
     "\n",
@@ -969,7 +969,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Lending Simplifie\n",
     "\n",
@@ -1351,7 +1351,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Resume\n",
     "\n",
@@ -1368,7 +1368,7 @@
     "3. Toujours définir un slippage tolerance\n",
     "4. Le health factor < 1 declenche la liquidation\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-9-DAO-Governance](SC-9-DAO-Governance.ipynb)"
    ]
@@ -1387,7 +1387,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Token Standards](SC-7-Token-Standards.ipynb) | [DAO Governance >>](SC-9-DAO-Governance.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-9-DAO-Governance.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Précédent : DeFi Primitives](SC-8-DeFi-Primitives.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Account Abstraction >>](SC-10-Account-Abstraction.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -49,7 +49,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Connexion a la blockchain locale\n",
     "\n",
@@ -158,7 +158,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Governance Token\n",
     "\n",
@@ -502,7 +502,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Governor Contract\n",
     "\n",
@@ -945,7 +945,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Timelock Controller\n",
     "\n",
@@ -1269,7 +1269,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Resume\n",
     "\n",
@@ -1285,7 +1285,7 @@
     "- **Quorum** : Participation minimum requise\n",
     "- **Proposal Threshold** : Tokens min pour proposer\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-10-Account-Abstraction](SC-10-Account-Abstraction.ipynb)"
    ]
@@ -1327,7 +1327,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Précédent : DeFi Primitives](SC-8-DeFi-Primitives.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Account Abstraction >>](SC-10-Account-Abstraction.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-12-Foundry-Testing.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Précédent : LLM Assisted](../02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Fuzz & Invariants >>](SC-13-Fuzz-Invariants.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -53,7 +53,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction a Foundry\n",
     "\n",
@@ -289,11 +289,13 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Structure d'un projet Foundry\n",
     "\n",
-    "La commande `forge init` crée une structure standard.\n\n**Pourquoi cette structure est un contrat, pas une suggestion.** `foundry.toml` mappe les noms logiques aux dossiers physiques : `src` (vos contrats de production), `out` (les artifacts de compilation ABI + bytecode), `libs` (où forge cherche les imports). Renommer un dossier sans mettre à jour `foundry.toml` casse silencieusement la compilation ou la résolution d'imports. Les **remappings** (`forge-std/=lib/forge-std/src/`) sont la pièce qui rend les imports Solidity lisibles : au lieu de chemins relatifs fragiles, vos contrats écrivent `import 'forge-std/Test.sol'` et forge le récrit vers le chemin physique. Cette convention-over-configuration est aussi pourquoi `forge init` installe `lib/forge-std/` par défaut : la librairie standard de test attend ce chemin exact."
+    "La commande `forge init` crée une structure standard.\n",
+    "\n",
+    "**Pourquoi cette structure est un contrat, pas une suggestion.** `foundry.toml` mappe les noms logiques aux dossiers physiques : `src` (vos contrats de production), `out` (les artifacts de compilation ABI + bytecode), `libs` (où forge cherche les imports). Renommer un dossier sans mettre à jour `foundry.toml` casse silencieusement la compilation ou la résolution d'imports. Les **remappings** (`forge-std/=lib/forge-std/src/`) sont la pièce qui rend les imports Solidity lisibles : au lieu de chemins relatifs fragiles, vos contrats écrivent `import 'forge-std/Test.sol'` et forge le récrit vers le chemin physique. Cette convention-over-configuration est aussi pourquoi `forge init` installe `lib/forge-std/` par défaut : la librairie standard de test attend ce chemin exact."
    ]
   },
   {
@@ -500,7 +502,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Ecrire des tests avec Solidity\n",
     "\n",
@@ -1050,11 +1052,13 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Cheatcodes (vm)\n",
     "\n",
-    "Les cheatcodes sont des fonctions speciales accessibles via l'objet `vm` pour manipuler l'etat du test.\n\n**Pourquoi les cheatcodes existent (et pourquoi tester en Solidity sans eux serait impossible).** Trois valeurs que le code de production lit sont cryptographiquement ou physiquement impossibles à forger depuis un contrat : `msg.sender` (lié à la signature de la transaction, vous ne pouvez pas signer comme Alice sans sa clé privée), `block.timestamp` / `block.number` (fixés par le réseau), et les soldes ETH (comptabilisés par l'EVM). Sans cheatcodes, tester 'que fait mon contrat si Alice l'appelle dans 30 jours avec 5 ETH' nécessiterait de générer une signature valide et d'attendre -- rendant tout test non-déterministe. `vm.prank`, `vm.deal`, `vm.warp` court-circuitent l'EVM : forge intercepte l'appel au niveau de la VM de test (anvil) et injecte la valeur mockée directement, **sans passer par la cryptographie**. C'est l'API de test de la VM ; c'est ce qui rend les tests Foundry déterministes et ce qui les distingue des suites JS (Hardhat) où il faut câbler des signers et des helpers."
+    "Les cheatcodes sont des fonctions speciales accessibles via l'objet `vm` pour manipuler l'etat du test.\n",
+    "\n",
+    "**Pourquoi les cheatcodes existent (et pourquoi tester en Solidity sans eux serait impossible).** Trois valeurs que le code de production lit sont cryptographiquement ou physiquement impossibles à forger depuis un contrat : `msg.sender` (lié à la signature de la transaction, vous ne pouvez pas signer comme Alice sans sa clé privée), `block.timestamp` / `block.number` (fixés par le réseau), et les soldes ETH (comptabilisés par l'EVM). Sans cheatcodes, tester 'que fait mon contrat si Alice l'appelle dans 30 jours avec 5 ETH' nécessiterait de générer une signature valide et d'attendre -- rendant tout test non-déterministe. `vm.prank`, `vm.deal`, `vm.warp` court-circuitent l'EVM : forge intercepte l'appel au niveau de la VM de test (anvil) et injecte la valeur mockée directement, **sans passer par la cryptographie**. C'est l'API de test de la VM ; c'est ce qui rend les tests Foundry déterministes et ce qui les distingue des suites JS (Hardhat) où il faut câbler des signers et des helpers."
    ]
   },
   {
@@ -1704,11 +1708,13 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Assertions et Logging\n",
     "\n",
-    "Foundry fournit un ensemble complet d'assertions et de fonctions de logging.\n\n**Pourquoi les assertions sont natives et le logging est votre debugger.** Les tests sont écrits **en Solidity** -- donc `assertEq(a, b)` s'exécute directement dans l'EVM pendant le run de test, sans round-trip RPC vers un harnais JS qui comparerait les valeurs. Zéro latence réseau, et l'égalité se compare au niveau du type on-chain (uint256, address, bytes) avec la sémantique exacte du runtime de production. Le logging (`emit log_*`) existe parce que **l'EVM n'a pas de points d'arrêt** : impossible de poser un breakpoint dans une fonction Solidity. Les logs sont votre `printf` debugging -- ils atterrissent dans les traces forge (`-vvv`), qui reconstruct la stack d'appels et les valeurs aux points de log. C'est pourquoi `verbosity` dans `foundry.toml` est un paramètre de premier ordre : il contrôle combien de contexte de trace vous voyez à l'échec."
+    "Foundry fournit un ensemble complet d'assertions et de fonctions de logging.\n",
+    "\n",
+    "**Pourquoi les assertions sont natives et le logging est votre debugger.** Les tests sont écrits **en Solidity** -- donc `assertEq(a, b)` s'exécute directement dans l'EVM pendant le run de test, sans round-trip RPC vers un harnais JS qui comparerait les valeurs. Zéro latence réseau, et l'égalité se compare au niveau du type on-chain (uint256, address, bytes) avec la sémantique exacte du runtime de production. Le logging (`emit log_*`) existe parce que **l'EVM n'a pas de points d'arrêt** : impossible de poser un breakpoint dans une fonction Solidity. Les logs sont votre `printf` debugging -- ils atterrissent dans les traces forge (`-vvv`), qui reconstruct la stack d'appels et les valeurs aux points de log. C'est pourquoi `verbosity` dans `foundry.toml` est un paramètre de premier ordre : il contrôle combien de contexte de trace vous voyez à l'échec."
    ]
   },
   {
@@ -2270,7 +2276,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exemples guidés"
    ]
@@ -2863,7 +2869,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Resume\n",
     "\n",
@@ -2901,7 +2907,7 @@
     "| `assertGt(a, b)` | a > b |\n",
     "| `assertLt(a, b)` | a < b |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-13-Fuzz-Invariants](SC-13-Fuzz-Invariants.ipynb) - Fuzz Testing et invariants"
    ]
@@ -2943,7 +2949,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Précédent : LLM Assisted](../02-Solidity-Advanced/SC-11-LLM-Assisted.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Fuzz & Invariants >>](SC-13-Fuzz-Invariants.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-13-Fuzz-Invariants.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Précédent : Foundry Testing](SC-12-Foundry-Testing.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Formal Verification >>](SC-14-Formal-Verification.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -50,7 +50,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction au Fuzz Testing\n",
     "\n",
@@ -143,7 +143,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Fuzz Test Simple"
    ]
@@ -402,7 +402,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Invariant Testing\n",
     "\n",
@@ -686,7 +686,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. vm.assume vs require\n",
     "\n",
@@ -960,7 +960,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Configuration Fuzz\n",
     "\n",
@@ -1176,7 +1176,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exemple guide et Exercice\n",
     "\n",
@@ -1429,7 +1429,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Resume\n",
     "\n",
@@ -1446,7 +1446,7 @@
     "3. Utiliser des seeds pour reproduire les bugs\n",
     "4. Combiner fuzz tests et tests unitaires\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-14-Formal-Verification](SC-14-Formal-Verification.ipynb)"
    ]
@@ -1635,7 +1635,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Précédent : Foundry Testing](SC-12-Foundry-Testing.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Formal Verification >>](SC-14-Formal-Verification.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/03-Foundry-Testing/SC-14-Formal-Verification.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "[<< Précédent : Fuzz & Invariants](SC-13-Fuzz-Invariants.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Zero-Knowledge Proofs >>](../04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -78,7 +78,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction à la Vérification Formelle\n",
     "\n",
@@ -200,7 +200,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Certora Prover\n",
     "\n",
@@ -495,7 +495,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Commandes Certora\n",
     "\n",
@@ -590,7 +590,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 3b. SMTChecker - Vérification native Solidity\n",
     "\n",
     "Contrairement à Certora (outil externe, commercial), **SMTChecker** est intégré au compilateur Solidity. Il utilise des solveurs SMT (Z3, CVC5) pour vérifier automatiquement des invariants.\n",
@@ -1071,7 +1071,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Patterns Courants\n",
     "\n",
@@ -1296,7 +1296,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Exercices"
    ]
@@ -1419,7 +1419,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "## 6. Résumé\n",
     "\n",
     "| Concept | Description |\n",
@@ -1451,7 +1451,7 @@
     "- Faux positifs possibles\n",
     "- SMTChecker : pas de support complet des boucles\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [Zero-Knowledge Proofs](../04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb)"
    ]
@@ -1493,7 +1493,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Précédent : Fuzz & Invariants](SC-13-Fuzz-Invariants.ipynb) | [Retour au sommaire](../README.md) | [Suivant : Zero-Knowledge Proofs >>](../04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-15-Zero-Knowledge-Proofs.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Formal Verification](../03-Foundry-Testing/SC-14-Formal-Verification.ipynb) | [Homomorphic Encryption >>](SC-16-Homomorphic-Encryption.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -51,7 +51,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction aux preuves a divulgation nulle\n",
     "\n",
@@ -207,7 +207,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. ZKP du logarithme discret (version simplifiee)\n",
     "\n",
@@ -578,7 +578,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Protocole de Schnorr et transformation de Fiat-Shamir\n",
     "\n",
@@ -1224,7 +1224,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Sigma Protocols\n",
     "\n",
@@ -1734,7 +1734,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. zk-SNARKs : vue d'ensemble\n",
     "\n",
@@ -2097,7 +2097,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exemple guide : ZKP de preimage de hash\n",
     "\n",
@@ -2302,7 +2302,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Exercice : ZKP de double preimage de hash\n",
     "\n",
@@ -2389,7 +2389,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Resume\n",
     "\n",
@@ -2423,7 +2423,7 @@
     "- Les zk-SNARKs generalisent les ZKP a des calculs arbitraires (zk-rollups, confidentialite)\n",
     "- Les applications blockchain sont en pleine explosion : scalabilite L2, votes, identite\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-16-Homomorphic-Encryption](SC-16-Homomorphic-Encryption.ipynb) - Chiffrement homomorphe"
    ]
@@ -2465,7 +2465,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Formal Verification](../03-Foundry-Testing/SC-14-Formal-Verification.ipynb) | [Homomorphic Encryption >>](SC-16-Homomorphic-Encryption.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-16-Homomorphic-Encryption.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-15-Zero-Knowledge-Proofs.ipynb) | [Suivant >>](SC-17-E2E-Verifiable-Voting.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -52,7 +52,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Concepts du chiffrement homomorphique\n",
     "\n",
@@ -232,7 +232,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Chiffrement de Paillier (PHE additif)\n",
     "\n",
@@ -779,7 +779,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. CKKS avec TenSEAL (FHE pour nombres reels)\n",
     "\n",
@@ -1137,7 +1137,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. FHE avec Concrete (Zama)\n",
     "\n",
@@ -1315,7 +1315,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Calcul multipartite securise (MPC) et partage de secrets\n",
     "\n",
@@ -1793,7 +1793,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exemple guide : Système de sondage anonyme avec Paillier\n",
     "\n",
@@ -1993,7 +1993,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Exercice : Sondage pondere avec Paillier\n",
     "\n",
@@ -2097,7 +2097,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Resume\n",
     "\n",
@@ -2119,7 +2119,7 @@
     "4. Le **partage de secrets de Shamir** distribue la confiance : aucun participant seul ne connait le secret\n",
     "5. HE et MPC sont **complementaires**, pas concurrents : le choix depend du modèle de confiance\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-17-E2E-Verifiable-Voting](SC-17-E2E-Verifiable-Voting.ipynb) - Combiner zero-knowledge proofs et chiffrement homomorphique pour un système de vote electronique verifiable de bout en bout"
    ]
@@ -2161,7 +2161,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-15-Zero-Knowledge-Proofs.ipynb) | [Suivant >>](SC-17-E2E-Verifiable-Voting.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-16-Homomorphic-Encryption.ipynb) | [Suivant >>](../05-Alternative-Chains/SC-18-Vyper.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -52,7 +52,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Le problème du vote electronique\n",
     "\n",
@@ -94,7 +94,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Chiffrement des bulletins (Paillier)\n",
     "\n",
@@ -335,7 +335,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Decompte homomorphique\n",
     "\n",
@@ -498,7 +498,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3b. Exercice : Simulation d'une attaque par bourrage d'urne\n",
     "\n",
@@ -587,7 +587,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Preuve de validite du bulletin (ZKP simplifiee)\n",
     "\n",
@@ -745,7 +745,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Bulletin board public\n",
     "\n",
@@ -978,7 +978,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5b. Exercice : Verification universelle du bulletin board\n",
     "\n",
@@ -1066,7 +1066,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. ElectionGuard - Le SOTA\n",
     "\n",
@@ -1357,7 +1357,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Exemple guide : Vote preferentiel verifiable\n",
     "\n",
@@ -1523,7 +1523,7 @@
     "\n",
     "**Validation** : la matrice dechiffree verifie les contraintes de permutation (somme de chaque ligne et chaque colonne = 1). En production, cette verification se fait via des preuves ZKP (Chaum-Pedersen) sans dechiffrer.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Exercice : Decompte homomorphique preferentiel\n",
     "\n",
@@ -1612,7 +1612,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 9. Resume\n",
     "\n",
@@ -1635,7 +1635,7 @@
     "- L'integration blockchain (bulletin board sur Ethereum) ajoute l'**immutabilite**\n",
     "- Le vote preferentiel etend le schema one-hot en matrice de permutation chiffree\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-18-Vyper](../05-Alternative-Chains/SC-18-Vyper.ipynb) - Smart contracts en Python-like"
    ]
@@ -1677,7 +1677,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-16-Homomorphic-Encryption.ipynb) | [Suivant >>](../05-Alternative-Chains/SC-18-Vyper.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-18-Vyper.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< E2E Verifiable Voting](../04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb) | [Ripple XRP >>](SC-19-Ripple-XRP.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -51,7 +51,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction a Vyper\n",
     "\n",
@@ -190,7 +190,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Syntaxe Vyper\n",
     "\n",
@@ -600,7 +600,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2b. Exercice : Traduire un contrat Solidity en Vyper\n",
     "\n",
@@ -715,7 +715,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Compilation et deploiement\n",
     "\n",
@@ -1037,7 +1037,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3b. Exercice : Contrat de compteur avec plafond\n",
     "\n",
@@ -1137,7 +1137,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Comparaison Vyper vs Solidity\n",
     "\n",
@@ -1692,7 +1692,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Exercice : Contrat d'enchere en Vyper\n",
     "\n",
@@ -1773,7 +1773,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Resume\n",
     "\n",
@@ -1796,7 +1796,7 @@
     "- Un contrat Vyper deploye est indistinguable d'un contrat Solidity pour l'EVM\n",
     "- L'ecosysteme Vyper est plus restreint mais soutenu par des protocoles majeurs\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-19-Ripple-XRP](SC-19-Ripple-XRP.ipynb) - Contrats sur le reseau Ripple"
    ]
@@ -1838,7 +1838,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< E2E Verifiable Voting](../04-Privacy-Cryptography/SC-17-E2E-Verifiable-Voting.ipynb) | [Ripple XRP >>](SC-19-Ripple-XRP.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-19-Ripple-XRP.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Vyper](SC-18-Vyper.ipynb) | [Bitcoin Scripting >>](SC-20-Bitcoin-Scripting.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -50,7 +50,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction au protocole Ripple et au XRP Ledger\n",
     "\n",
@@ -210,7 +210,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Installation et connexion au Testnet\n",
     "\n",
@@ -538,7 +538,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Transactions XRP\n",
     "\n",
@@ -978,7 +978,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3b. Exercice : Analyseur de transactions XRP\n",
     "\n",
@@ -1091,7 +1091,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Payment Channels (micropaiements)\n",
     "\n",
@@ -1438,7 +1438,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4b. Exercice : Validateur de claims pour Payment Channel\n",
     "\n",
@@ -1558,7 +1558,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Hooks : les smart contracts du XRPL\n",
     "\n",
@@ -1795,7 +1795,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exercice : scénario de paiement cross-currency\n",
     "\n",
@@ -1935,7 +1935,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Resume\n",
     "\n",
@@ -1965,7 +1965,7 @@
     "- [XRPL Testnet Faucet](https://xrpl.org/xrp-testnet-faucet.html)\n",
     "- [Hooks Documentation](https://xrpl-hooks.readme.io/)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-20-Bitcoin-Scripting](SC-20-Bitcoin-Scripting.ipynb) - Le langage Script de Bitcoin"
    ]
@@ -2007,7 +2007,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Vyper](SC-18-Vyper.ipynb) | [Bitcoin Scripting >>](SC-20-Bitcoin-Scripting.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-20-Bitcoin-Scripting.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Ripple XRP](SC-19-Ripple-XRP.ipynb) | [Move & Sui >>](SC-21-Move-Sui.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -50,7 +50,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Le modèle UTXO\n",
     "\n",
@@ -404,7 +404,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1b. Exercice : Analyseur de flux de transactions UTXO\n",
     "\n",
@@ -514,7 +514,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Bitcoin Script\n",
     "\n",
@@ -924,7 +924,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2b. Exercice : Script de depense conditionnelle\n",
     "\n",
@@ -1031,7 +1031,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Construction de transactions Bitcoin\n",
     "\n",
@@ -1365,7 +1365,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Scripts avances\n",
     "\n",
@@ -1802,7 +1802,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4b. Exercice : Construction d'un script P2SH pour heritage\n",
     "\n",
@@ -1921,7 +1921,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Bitcoin vs Ethereum : deux philosophies\n",
     "\n",
@@ -1978,7 +1978,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exemple guide : Escrow avec timelock — Solution etudiante (Jules Lange, TP 2026)\n",
     "\n",
@@ -2188,7 +2188,7 @@
     },
     "tags": []
    },
-   "source": "---\n\n## 6b. Exemple guide (avance) : Escrow avec penalite et delai de grace\n\nCet exemple pousse plus loin le système d'escrow de la section 6 en lui ajoutant des mécanismes de protection avances : un **delai de grace** qui encadre la recuperation des fonds après le timeout.\n\n### Scénario\n\nDans un escrow de commerce electronique, on souhaite encadrer la recuperation après timeout :\n- **Delai de grace** : après le `timeout_blocks`, Bob dispose d'une fenêtre de `grace_period` blocs (200 par defaut) pour recuperer les fonds via sa signature\n- **Expiration** : une fois cette fenêtre ecoulee, Alice peut recuperer ses fonds, Bob n'a plus acces\n\n### Implementation\n\nLa classe `GracePeriodEscrow` (cellule suivante) etend `TimelockEscrow` avec deux méthodes de depense distinctes :\n- `spend_grace_timeout(sig_bob, current_block)` : Bob recupere les fonds dans la fenêtre `[timeout_blocks, timeout_blocks + grace_period[`\n- `spend_expired(sig_alice, current_block)` : Alice recupere les fonds après expiration du delai de grace\n\nChaque méthode verifie l'etat de l'escrow, la position de `current_block` par rapport aux seuils, puis la signature du reclamant. Les quatre scénarios de test (recuperation dans le delai, recuperation après expiration, rejet hors fenêtre, rejet avant timeout) valident le comportement attendu.\n\n> Cet exemple guide est la suite naturelle du worked-example `TimelockEscrow` de la section 6 : il montre comment composer timelock et fenêtre de recuperation pour realiser un escrow de commerce electronique realiste. Les trois exercices a completer (sections 1b, 2b, 4b) restent independants."
+   "source": "***\n\n## 6b. Exemple guide (avance) : Escrow avec penalite et delai de grace\n\nCet exemple pousse plus loin le système d'escrow de la section 6 en lui ajoutant des mécanismes de protection avances : un **delai de grace** qui encadre la recuperation des fonds après le timeout.\n\n### Scénario\n\nDans un escrow de commerce electronique, on souhaite encadrer la recuperation après timeout :\n- **Delai de grace** : après le `timeout_blocks`, Bob dispose d'une fenêtre de `grace_period` blocs (200 par defaut) pour recuperer les fonds via sa signature\n- **Expiration** : une fois cette fenêtre ecoulee, Alice peut recuperer ses fonds, Bob n'a plus acces\n\n### Implementation\n\nLa classe `GracePeriodEscrow` (cellule suivante) etend `TimelockEscrow` avec deux méthodes de depense distinctes :\n- `spend_grace_timeout(sig_bob, current_block)` : Bob recupere les fonds dans la fenêtre `[timeout_blocks, timeout_blocks + grace_period[`\n- `spend_expired(sig_alice, current_block)` : Alice recupere les fonds après expiration du delai de grace\n\nChaque méthode verifie l'etat de l'escrow, la position de `current_block` par rapport aux seuils, puis la signature du reclamant. Les quatre scénarios de test (recuperation dans le delai, recuperation après expiration, rejet hors fenêtre, rejet avant timeout) valident le comportement attendu.\n\n> Cet exemple guide est la suite naturelle du worked-example `TimelockEscrow` de la section 6 : il montre comment composer timelock et fenêtre de recuperation pour realiser un escrow de commerce electronique realiste. Les trois exercices a completer (sections 1b, 2b, 4b) restent independants."
   },
   {
    "cell_type": "code",
@@ -2362,7 +2362,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Resume\n",
     "\n",
@@ -2383,7 +2383,7 @@
     "- Les scripts avances (multisig, timelock, P2SH) couvrent la majorite des besoins en conditions de depense\n",
     "- La philosophie de Bitcoin est **verification**, celle d'Ethereum est **computation**\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-21-Move-Sui](SC-21-Move-Sui.ipynb) - Le langage Move et la blockchain Sui"
    ]
@@ -2425,7 +2425,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Ripple XRP](SC-19-Ripple-XRP.ipynb) | [Move & Sui >>](SC-21-Move-Sui.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-21-Move-Sui.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-21-Move-Sui.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Bitcoin Scripting](SC-20-Bitcoin-Scripting.ipynb) | [Solana & Anchor >>](SC-22-Solana-Anchor.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -50,7 +50,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Introduction a Move\n",
     "\n",
@@ -183,7 +183,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Module Move Simple\n",
     "\n",
@@ -375,7 +375,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Modèle Objet Sui\n",
     "\n",
@@ -735,7 +735,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Commandes Sui CLI\n",
     "\n",
@@ -1166,7 +1166,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Exemples guidés"
    ]
@@ -1363,7 +1363,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Resume\n",
     "\n",
@@ -1376,7 +1376,7 @@
     "| `UID` | Identifiant unique d'objet |\n",
     "| `TxContext` | Contexte de transaction |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-22-Solana-Anchor](SC-22-Solana-Anchor.ipynb)"
    ]
@@ -1395,7 +1395,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Bitcoin Scripting](SC-20-Bitcoin-Scripting.ipynb) | [Solana & Anchor >>](SC-22-Solana-Anchor.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/05-Alternative-Chains/SC-22-Solana-Anchor.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "[<< Move & Sui](SC-21-Move-Sui.ipynb) | [Cross-Chain >>](../06-Real-World/SC-23-Cross-Chain.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -50,7 +50,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Architecture Solana\n",
     "\n",
@@ -141,7 +141,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Programme Anchor Simple"
    ]
@@ -401,7 +401,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. PDAs (Program Derived Addresses)\n",
     "\n",
@@ -636,7 +636,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. CPI (Cross-Program Invocation)"
    ]
@@ -945,7 +945,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Commandes Anchor CLI"
    ]
@@ -1210,7 +1210,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Exemples guidés"
    ]
@@ -1430,14 +1430,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 7. Contributions etudiantes -- exemples guides\n",
     "\n",
-    "Les trois exemples ci-dessous, contribues par un groupe d'etudiants, illustrent les ",
-    "concepts fondamentaux de Solana et Anchor vus dans ce notebook : derivation de PDA, ",
-    "structure d'un programme Anchor, et modèle de comptes Solana. Chaque enonce est suivi de ",
-    "sa solution commentee.\n"
+    "Les trois exemples ci-dessous, contribues par un groupe d'etudiants, illustrent les concepts fondamentaux de Solana et Anchor vus dans ce notebook : derivation de PDA, structure d'un programme Anchor, et modèle de comptes Solana. Chaque enonce est suivi de sa solution commentee.\n"
    ],
    "id": "cell-e888e70e"
   },
@@ -1877,7 +1874,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 8. Resume\n",
     "\n",
@@ -1889,7 +1886,7 @@
     "| CPI | Appel inter-programmes |\n",
     "| Anchor | Framework Rust pour Solana |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Notebook suivant** : [SC-23-Cross-Chain](../06-Real-World/SC-23-Cross-Chain.ipynb)"
    ]
@@ -1908,7 +1905,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Move & Sui](SC-21-Move-Sui.ipynb) | [Cross-Chain >>](../06-Real-World/SC-23-Cross-Chain.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-23-Cross-Chain.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "[<< Solana & Anchor](../05-Alternative-Chains/SC-22-Solana-Anchor.ipynb) | [Testnet Deploy >>](SC-24-Testnet-Deploy.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Enjeux Cross-Chain\n",
     "\n",
@@ -157,7 +157,7 @@
    },
    "outputs": [],
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Chainlink CCIP"
    ]
@@ -595,7 +595,7 @@
    },
    "outputs": [],
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Chain Selectors"
    ]
@@ -877,7 +877,7 @@
    },
    "outputs": [],
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Securite Cross-Chain"
    ]
@@ -1133,7 +1133,7 @@
    },
    "outputs": [],
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Resume"
    ]
@@ -1475,7 +1475,7 @@
     "\n",
     "> Sans le `chainid` dans le hash signe, une signature valide sur Sepolia pourrait etre rejouee sur Mainnet et drainer les fonds.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Q2 — Quelle est la latence minimale pour une transaction cross-chain ?**\n",
     "\n",
@@ -1493,7 +1493,7 @@
     "- Chainlink CCIP attend plusieurs confirmations avant de relayer pour eviter les reorgs\n",
     "- Les bridges \"optimistic\" (Hop, Across) sont plus rapides mais acceptent un risque de reorg\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Q3 — Comment gerer les echecs sur la chaîne destination ?**\n",
     "\n",
@@ -2031,7 +2031,7 @@
    },
    "outputs": [],
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "[<< Solana & Anchor](../05-Alternative-Chains/SC-22-Solana-Anchor.ipynb) | [Testnet Deploy >>](SC-24-Testnet-Deploy.ipynb)"
    ]

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-24-Testnet-Deploy.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-23-Cross-Chain.ipynb) | [Suivant >>](SC-25-Mainnet-Deploy.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -80,7 +80,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Prerequis\n",
     "\n",
@@ -104,7 +104,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0.5 Setup prealable\n",
     "\n",
@@ -145,7 +145,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Transition : Prerequis verifies\n",
     "\n",
@@ -248,7 +248,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Transition : Configuration et connexion\n",
     "\n",
@@ -271,7 +271,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Connexion a Sepolia\n",
     "\n",
@@ -379,7 +379,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Preparation du deployer\n",
     "\n",
@@ -491,7 +491,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Deploiement d'un contrat sur Sepolia\n",
     "\n",
@@ -747,7 +747,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Interaction avec le contrat deploye\n",
     "\n",
@@ -862,7 +862,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Deploiement XRP Testnet\n",
     "\n",
@@ -1148,7 +1148,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 6. Comparaison Testnet vs Mainnet\n",
     "\n",
@@ -1180,7 +1180,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice\n",
     "\n",
@@ -1350,7 +1350,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-23-Cross-Chain.ipynb) | [Suivant >>](SC-25-Mainnet-Deploy.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-25-Mainnet-Deploy.ipynb
@@ -46,7 +46,7 @@
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-24-Testnet-Deploy.ipynb) | [Suivant >>](SC-26-Final-Project.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -82,7 +82,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 0. Pourquoi un L2 ?\n",
     "\n",
@@ -110,7 +110,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 1. Configuration Base (L2 de Coinbase)"
    ]
@@ -226,7 +226,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 2. Estimation du cout\n",
     "\n",
@@ -377,7 +377,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 3. Deploiement sur Base\n",
     "\n",
@@ -645,7 +645,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 4. Verification sur l'explorateur\n",
     "\n",
@@ -671,7 +671,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## 5. Securite mainnet\n",
     "\n",
@@ -704,7 +704,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice\n",
     "\n",
@@ -842,7 +842,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-24-Testnet-Deploy.ipynb) | [Suivant >>](SC-26-Final-Project.ipynb)\n",
     "\n",

--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/06-Real-World/SC-26-Final-Project.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-25-Mainnet-Deploy.ipynb)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -51,7 +51,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Sujet : Système de Vote Decentralise\n",
     "\n",
@@ -92,7 +92,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 1 : Smart Contract de Vote (Solidity)\n",
     "\n",
@@ -186,7 +186,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Transition : Du smart contract au chiffrement client\n",
     "\n",
@@ -322,7 +322,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 2 : Chiffrement des votes (Python)\n",
     "\n",
@@ -396,7 +396,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Transition : Du chiffrement a la preuve de validite\n",
     "\n",
@@ -493,7 +493,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 3 : Preuve de validite (ZKP)\n",
     "\n",
@@ -562,7 +562,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Transition : De la ZKP a l'integration complete\n",
     "\n",
@@ -660,7 +660,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 4 : Integration et deploiement\n",
     "\n",
@@ -731,7 +731,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Transition : De l'integration aux tests\n",
     "\n",
@@ -794,7 +794,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Partie 5 : Tests Foundry (Bonus)\n",
     "\n",
@@ -928,7 +928,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Critères d'evaluation\n",
     "\n",
@@ -961,7 +961,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Conclusion : Synthese du projet\n",
     "\n",
@@ -999,7 +999,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Ressources\n",
     "\n",
@@ -1012,7 +1012,7 @@
     "- [OpenZeppelin Contracts](https://docs.openzeppelin.com/contracts/)\n",
     "- [Foundry Book](https://book.getfoundry.sh/)\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "**Navigation** : [Sommaire](../README.md) | [<< Précédent](SC-25-Mainnet-Deploy.ipynb)\n",
     "\n",


### PR DESCRIPTION
## Summary

Nettoyage de la famille **SymbolicAI/SmartContracts** dans la campagne #10923 : conversion des séparateurs horizontaux `---` → `***` en tête de cellule markdown, via `scripts/notebook_tools/fix_hr_separator.py --apply`. 27 notebooks, 290 séparateurs.

Pourquoi : un `---` en tête de cellule ouvre un bloc `yaml_metadata_block` Pandoc (même suivi d'une ligne vide — réfuté empiriquement par SL-8, #11630) qui casse le rendu Quarto du site. `***` rend le même `<hr>` sans aucune sémantique YAML.

- [Claim du 2026-08-18T15:20Z](https://github.com/jsboige/CoursIA/issues/10923#issuecomment-5328697738) — a-côté désigné (DM ai-01 §5), famille unique (G.4).
- L'outil ne touche ni le vrai front-matter de tête, ni les `---` dans les blocs de code, ni les soulignements setext (`---` collé sous du texte = H2).

Grain: LIGHT/refactor -- lane myia-po-2026:CoursIA -- prev: MED/tooling #11635

*(A-côté plafonné à 1/lane/jour — le plat principal du cycle a été la garde CI périmètre #11635 + le greffage #11638.)*

## Preuves (famille entière, worktree complet)

| Contrôle | Avant | Après |
|----------|-------|-------|
| `fix_hr_separator.py --check` | 290 séparateurs / 27 notebooks | **0 restant** |
| **Oracle js-yaml** (le parser réel de Quarto) | 138 blocs scannés / **133 bad** | **0 / 0** |
| Sources code + outputs (SHA1 par notebook) | — | **27/27 identiques pre/post** (conversion markdown-only, zéro re-execution requise — règle C.2 : aucune cellule code modifiée, `git diff` ne touche que les `source` markdown) |
| `nbformat.validate` | — | 26/27 OK (SC-23-Cross-Chain préexistant, **vérifié par stash pre-apply**, hors scope) |
| `regen_quarto_render.py` | — | no-op — la famille n'est pas encore dans `NOTEBOOK_SUBTREES` ; la tranche future qui l'ajoutera la trouvera propre, la garde #11631 ne l'exclura pas |

## Diff shape (inventaire exhaustif du markdown concaténé pre/post)

306 insertions / 304 délétions sur 27 fichiers. Le contrôle de contenu a comparé le markdown **concaténé** de chaque notebook pre/post (normalisation `***` vers `---`), par opcodes difflib :

| Forme de diff | Occurrences | Nature |
|---|---|---|
| `---` vers `***` (le livrable) | 290 | conversions séparateurs |
| ligne vide retirée juste après un séparateur | 115 | normalisation de l'outil (reflow list-source) — rendu `<hr>` **inchangé** : un hr suivi d'un blank puis d'un heading rend identiquement à un hr suivi directement du heading |
| autre changement de prose/liens/texte | **0** | — |

L'écart JSON (306/304 vs 290/290) = le re-découpage des éléments de la `source` list (un élément `
_Texte…` scindé en `
` + `_Texte…` — même contenu concaténé, éléments JSON différents) + 2 trailing-newline de fin de fichier. Sources code + outputs : SHA1 identiques 27/27 (première table de preuves).

## État de la campagne après cette PR

Familles nettoyées : Probas/DecisionTheory (mesure de référence #11633), **SymbolicAI/SmartContracts 27/27 (cette PR)**. Restantes les plus chargées : GenAI/Audio 26/30, SymbolicAI/Lean 26/33, SymbolicAI/SemanticWeb 24/25, SymbolicAI/SMT 21/46, GenAI/Video 20/21.

See #10923, See #11630
