### PR TITLE
fix(gate): OVERRIDE coordinateur + mention verdicts (#11639)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -39,7 +39,12 @@ Ce qui leve un nit — et ce qui ne le leve PAS
     approbation d'un tiers (ni l'un ni l'autre) n'eteint pas la reserve —
     c'est la classe #10761 que l'organe existe pour bloquer (mesure #11494 :
     24,3 % des levees etaient BYSTANDER). L'echappement B.0 (issue de suivi
-    nommee) reste le chemin quand la reserve exige l'arbitrage d'un tiers.
+    nommee) reste le chemin quand la reserve exige l'arbitrage d'un tiers —
+    et depuis #11639, l'arbitrage ECRIT du coordinateur porte une trappe
+    nommee : `[OVERRIDE] lane <machine:workspace>` + phrase de levee (meme
+    convention ecrite que les claims #10223). Pas une ouverture generale :
+    la borne tient pour tout autre tiers, et un override POST-marge ne peut
+    pas avoir eteint une reserve avant la decision de merge.
 
 Ne levent RIEN :
   - **un commit pousse apres le nit** : un push muet est indiscernable d'un push
@@ -92,6 +97,20 @@ AGENT_PREFIXES = (
     "[ACK", "[RELEASED", "[OVERRIDE", "[MERGED", "[WARN", "[ERROR", "[ASK",
     "[REPLY", "[PROPOSAL", "[BLOCKED", "[ESCALATION",
 )
+
+# #11639 — l'arbitrage ECRIT du coordinateur. B.0 ne restreint pas l'auteur
+# d'une reponse de levée (« une reponse ecrite sur la PR qui nomme la
+# remarque »), mais `_lift_eligible` ne creditait que l'auteur du nit ou
+# celui de la PR : tout arbitrage coordinateur laissait le gate rouge, et le
+# merge se faisait a EXIT=1 en routine (#11479 — mesure : merge 13:06:39Z,
+# override ecrit 13:07:40Z). La trappe est NOMMEE, pas generale : elle exige
+# le marqueur de lane ecrit (`[OVERRIDE] lane <machine:workspace>`, meme
+# convention ecrite que les claims #10223) ET une phrase de levee (LIFT_MARKER,
+# deja exige par explicit_lifts) — un OVERRIDE nu ne leve rien. Les bornes
+# temporelles restent entieres : un override POST-merge ne peut pas avoir
+# eteint une reserve avant la decision de merge (borne #10761).
+COORDINATOR_LOGINS = {"myia-ai-01", "jsboige"}
+OVERRIDE_LANE = re.compile(r"\[OVERRIDE\]\s+lane\s+\S+")
 
 # Marqueurs de reserve d'un reviewer bot (le verdict est dans le body, pas l'etat).
 CONCERN_MARKERS = (
@@ -152,6 +171,38 @@ _QUOTED_RANGES = re.compile(r"```.*?```|«.*?»|`[^`]*`", re.DOTALL)
 def _strip_quoted(body: str) -> str:
     """Retire les segments cites (guillemets typo, backtick, bloc code)."""
     return _QUOTED_RANGES.sub(" ", body)
+
+# #11636 — use vs mention, 2e reformulation de la classe #11246 : un rapport
+# de correction qui NOMME le verdict qu'il corrige n'emet pas de reserve. Cas
+# fondateur #11628 (mesure : le SEUL item bloquant du gate) :
+#   « Fix review ai-01 (CHANGES_REQUESTED) — commit 06956bd0a. »
+# Le nom du verdict est entre PARENTHESES, pas entre guillemets —
+# `_strip_quoted` ne le voyait pas et aucun CITERS ne matche « review ai-01 ( ».
+# L'incitation etait inversee : le rapport le PLUS precis etait classe
+# BOT-CONCERN pendant qu'un « done » passait. Deux conditions CUMULATIVES,
+# pour ne pas transformer une emission parenthesee en mention : (1) un
+# verbe/locution de REFERENCE (fix, corrige, suite a, en reponse a, levee...)
+# dans les 40 chars qui precedent la parenthese ouvrante — un nom d'agent peut
+# s'intercaler, meme mecanique que l'attribution de `_is_cited` ; (2) un nom
+# de verdict FORMEL `[A-Z][A-Z_]{3,}` immediatement entre parentheses.
+# L'emission reelle reste « MARKER: » nue ou portee par le state de la review —
+# les marqueurs naturels (« avant merge », « a changer ») ne sont pas des noms
+# de verdict et restent hors de cette voie.
+_MENTION_VERDICT = re.compile(
+    r"(?i)\b(?:fix(?:ed|ée?e?)?|corrig\w+|suite\s+[àa]|en\s+r[ée]ponse\s+[àa]"
+    r"|r[ée]ponse\s+[àa]|lev\w+|lift\w*|adress\w+|trait\w+|repondu\s+[àa])"
+    r"[^()\n]{0,40}\(\s*([A-Z][A-Z_]{3,})\s*\)")
+
+
+def _strip_mentioned_verdicts(body: str) -> str:
+    """Neutralise les noms de verdict cites en position de mention (#11636).
+
+    Remplace le verdict par des espaces de meme longueur : les offsets du
+    reste du body sont preserves (les fenetres de `_is_cited` restent
+    calibrees sur la vraie position des occurrences survivantes).
+    """
+    return _MENTION_VERDICT.sub(
+        lambda m: m.group(0).replace(m.group(1), " " * len(m.group(1))), body)
 
 # NOTE — proposition ecartee (triage 07-15..07-31, retiree au rebase 2026-08-16).
 # Un `NO_CONCERN_TAIL_MARKERS` dechargeant tout body dont les 300 derniers chars
@@ -400,7 +451,12 @@ def classify(author: str, body: str) -> str | None:
     # l'annonce conditionnee n'est pas une levee, le commentaire continue)
     if has_live_marker(body, (VERDICT_POSITIVE,)):
         return None  # verdict structurel positif rendu : il decide, la prose ne compte plus
-    live_concern = has_live_marker(body, CONCERN_MARKERS)
+    # #11636 : la recherche porte le body nettoye de ses verdicts MENTIONNES —
+    # un rapport de correction qui nomme le verdict qu'il corrige n'emet pas
+    # de reserve. Uniquement pour CONCERN_MARKERS : LIFT_MARKERS et
+    # VERDICT_POSITIVE gardent le body brut (surface minimale du fix — le
+    # controle positif deux formes vit dans les tests, cote a cote).
+    live_concern = has_live_marker(_strip_mentioned_verdicts(body), CONCERN_MARKERS)
     if not live_concern and has_live_marker(body, POSITIVE_MARKERS):
         return None  # approbation sans reserve vivante : la review conclut, ne reserve pas
     if stripped.startswith(AGENT_PREFIXES):
@@ -473,8 +529,12 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     # commentaire de bot CI ou un tag de protocole nu n'a jamais repondu a rien.
     # On porte l'AUTEUR de chaque evenement de levee : la borne #11145 en a
     # besoin (auteur seul = les temps plats de #11222 ne suffisaient pas).
+    # Le body est porte pour la trappe OVERRIDE de `_lift_eligible` (#11639) :
+    # elle doit voir le marqueur `[OVERRIDE] lane …` de la levee, pas
+    # seulement son auteur.
     lift_events = [
-        (ts(c["createdAt"]), (c.get("author") or {}).get("login", ""))
+        (ts(c["createdAt"]), (c.get("author") or {}).get("login", ""),
+         c.get("body", "") or "")
         for c in (pr_data.get("comments") or []) if can_lift(c)
     ]
 
@@ -487,17 +547,27 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
     # d'exclusion can_lift ne s'applique pas — un state APPROVED n'est pas du
     # bruit de protocole, meme depuis un reviewer bot.
     approved_rereviews = [
-        (ts(r.get("submittedAt")), (r.get("author") or {}).get("login", ""))
+        (ts(r.get("submittedAt")), (r.get("author") or {}).get("login", ""), "")
         for r in (pr_data.get("reviews") or [])
         if r.get("state") == "APPROVED"
         and (r.get("author") or {}).get("login", "") not in BOT_LOGINS
     ]
-    approved_rereviews = [(t, a) for (t, a) in approved_rereviews if t]
+    approved_rereviews = [x for x in approved_rereviews if x[0] is not None]
     lift_events += approved_rereviews
-    lift_events = [(t, a) for (t, a) in lift_events if t]
+    lift_events = [x for x in lift_events if x[0] is not None]
 
-    def _lift_eligible(lift_author: str, nit_author: str) -> bool:
-        return lift_author in (nit_author, pr_author)
+    def _lift_eligible(lift_author: str, nit_author: str,
+                       lift_body: str = "") -> bool:
+        if lift_author in (nit_author, pr_author):
+            return True
+        # #11639 : l'override NOMME du coordinateur — l'arbitre tiers de B.0.
+        # La restriction d'auteur reste la regle pour tout le monde (elle
+        # bloque l'auto-levee d'un bystander, #11145) ; seule la trappe ecrite
+        # s'ajoute. Un OVERRIDE sans phrase de levee n'entre meme pas ici :
+        # can_lift l'a ecarte (tag de protocole nu), et explicit_lifts exige
+        # un LIFT_MARKER.
+        return (lift_author in COORDINATOR_LOGINS
+                and bool(OVERRIDE_LANE.search(lift_body or "")))
 
     # Fenetre 2026-08-16 (#11222) : les temps plats ne suffisent pas pour un
     # CHANGES_REQUESTED. Une PHRASE explicite de levee (LIFT_MARKER non
@@ -559,16 +629,16 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
             # NLP documentee dans can_lift.
             lifted = any(
                 when < t < cutoff and author == login
-                for (t, author) in approved_rereviews
+                for (t, author, _) in approved_rereviews
             ) or any(
-                when < t < cutoff and _lift_eligible(lifter, login)
-                for (t, lifter, _) in explicit_lifts
+                when < t < cutoff and _lift_eligible(lifter, login, lift_body)
+                for (t, lifter, lift_body) in explicit_lifts
             )
             if lifted:
                 continue
         elif any(
-            when < t < cutoff and _lift_eligible(lift_author, login)
-            for (t, lift_author) in lift_events
+            when < t < cutoff and _lift_eligible(lift_author, login, lift_body)
+            for (t, lift_author, lift_body) in lift_events
         ):
             continue  # reponse de l'auteur du nit ou de l'auteur de la PR
         # Un commit poussé après le nit ne le lève PAS à lui seul : sur #10761,

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -841,3 +841,123 @@ def test_bystander_explicit_lift_ne_leve_pas_changes_requested():
     bystander = {"author": {"login": "clusterManager-Myia"}, "createdAt": at(12),
                  "body": "Les 2 points sont adresses, commit abc123."}
     assert run_cr([bystander])["blocked"] is True
+
+
+# --- #11639 : l'arbitrage ECRIT du coordinateur. B.0 ne restreint pas
+# l'auteur d'une reponse de levée, mais `_lift_eligible` ne creditait que
+# l'auteur du nit ou celui de la PR : tout arbitrage coordinateur laissait
+# le gate rouge, et le merge se faisait a EXIT=1 en routine — repete, ca
+# enseigne a merger rouge. La trappe est NOMMEE : `[OVERRIDE] lane <m:w>` +
+# phrase de levée (LIFT_MARKER), par un compte coordinateur. Pas une
+# ouverture generale : la restriction d'auteur #11145 tient pour tous les
+# autres.
+#
+# Mesure retro #11479 (timestamps reels) : reserve Hermes 2026-08-17T13:38Z,
+# levée nominative d'ai-01 13:06:34Z, merge 13:06:39Z, override ecrit
+# 13:07:40Z — 61 s APRES le merge. La borne anti-retroactivite (#10761 : un
+# commentaire post-merge n'a pas pu lever la reserve avant la decision)
+# exclut l'override reel : le retro live de #11479 reste EXIT=1, et c'est
+# voulu. La convention que ce correctif etablit : l'OVERRIDE s'ecrit AVANT
+# le merge (comme toute levée) — le test retro simule ce decalage.
+
+HERMES_REVIEW_11479 = {
+    "author": {"login": "clusterManager-Myia"},
+    "state": "COMMENTED", "submittedAt": "2026-08-17T13:38:00Z",
+    "body": "[Hermes] COMMENT_WITH_CONCERNS — tests exécutés en local : 44/44 "
+            "pass, mais 2 edge cases non couverts (issue #11058)",
+}
+MERGED_11479 = datetime(2026, 8, 18, 13, 6, 39, tzinfo=timezone.utc)
+
+OVERRIDE_BODY = (
+    "**[OVERRIDE] lane myia-ai-01:CoursIA** — Levée de la réserve Hermes "
+    "du 2026-08-17, en nommant chacun de ses points : gap 1 retiré par "
+    "Hermes lui-même, gaps 2-3 reportés sur #11058."
+)
+
+
+def run_coord(comments=(), reviews=(), merged=MERGED_11479):
+    """PR d'un worker NON coordinateur, reserve posee par un tiers — la
+    trappe OVERRIDE est le seul chemin de levée (ni SELF ni PR_AUTHOR)."""
+    data = {
+        "number": 0, "title": "t", "author": {"login": "myia-po-2026"},
+        "comments": list(comments),
+        "reviews": [HERMES_REVIEW_11479, *reviews],
+        "commits": [{"committedDate": "2026-08-18T12:00:00Z"}],
+    }
+    return mod.analyse(data, [], merged)
+
+
+def test_coord_override_avec_levee_leve():
+    """Acceptance 1 : [OVERRIDE] lane + phrase de levée par un coordinateur
+    leve la reserve qu'il arbitre — le seul chemin ouvert a l'arbitre tiers."""
+    lift = {"author": {"login": "myia-ai-01"},
+            "createdAt": "2026-08-18T13:06:34Z", "body": OVERRIDE_BODY}
+    assert run_coord([lift])["blocked"] is False
+
+
+def test_coord_override_nu_ne_leve_rien():
+    """Acceptance 2 : un [OVERRIDE] sans phrase de levée ne lève rien —
+    l'override doit DIRE ce qu'il arbitre (can_lift l'écarte comme tag de
+    protocole nu, aucun LIFT_MARKER ne le réintroduit)."""
+    bare = {"author": {"login": "myia-ai-01"},
+            "createdAt": "2026-08-18T13:06:34Z",
+            "body": "[OVERRIDE] lane myia-ai-01:CoursIA — arbitrage : le "
+                    "point 3 est traité en argument, voir #11058."}
+    assert run_coord([bare])["blocked"] is True
+
+
+def test_tiers_avec_levee_sans_override_ne_leve_pas():
+    """Acceptance 3 (non-regression #11145) : un tiers quelconque qui écrit
+    une phrase de levée SANS override ne lève toujours pas — la restriction
+    d'auteur tient pour tout le monde sauf la trappe nommée."""
+    third = {"author": {"login": "myia-po-2024"},
+             "createdAt": "2026-08-18T13:06:34Z",
+             "body": "Les 2 points sont adressés, reportés sur #11058."}
+    assert run_coord([third])["blocked"] is True
+
+
+def test_override_par_un_non_coordinateur_ne_leve_pas():
+    """La trappe est coordinateur-only : un worker qui écrit lui-même
+    `[OVERRIDE] lane …` + phrase de levée ne leve pas la reserve d'un tiers
+    (il n'est ni l'auteur du nit, ni celui de la PR, ni arbitre)."""
+    fake = {"author": {"login": "myia-po-2024"},
+            "createdAt": "2026-08-18T13:06:34Z",
+            "body": "[OVERRIDE] lane myia-po-2024:CoursIA-2 — Levée de la "
+                    "réserve Hermes, reportée sur #11058."}
+    assert run_coord([fake])["blocked"] is True
+
+
+def test_retro_11479_reel_override_post_merge_ne_leve_pas():
+    """Retro #11479 tel que l'historique réel le porte (timestamps exacts) :
+    merge 13:06:39Z, override écrit 13:07:40Z. La borne anti-retroactivite
+    (#10761) exclut l'override postérieur — le retro live reste EXIT=1, la
+    convention à suivre est d'écrire l'override AVANT le merge."""
+    lift = {"author": {"login": "myia-ai-01"},
+            "createdAt": "2026-08-18T13:07:40Z", "body": OVERRIDE_BODY}
+    assert run_coord([lift])["blocked"] is True
+
+
+def test_retro_11479_simule_override_pre_merge_leve():
+    """Le même retro, override déplacé AVANT le merge : le mécanisme crédite
+    l'arbitrage écrit — c'est la démonstration que seul l'ordonnancement
+    historique (et non le mécanisme) laissait #11479 à EXIT=1."""
+    lift = {"author": {"login": "myia-ai-01"},
+            "createdAt": "2026-08-18T13:06:34Z", "body": OVERRIDE_BODY}
+    assert run_coord([lift])["blocked"] is False
+
+
+def test_coord_override_leve_aussi_le_state_changes_requested():
+    """La trappe couvre la branche état natif (branche A) comme la branche
+    commentaire (branche B) : un CHANGES_REQUESTED d'un reviewer arbitré par
+    override écrit se lève aussi."""
+    cr = {"author": {"login": "hermes-bot"},
+          "state": "CHANGES_REQUESTED", "submittedAt": at(10),
+          "body": "CHANGES_REQUESTED: 2 edge cases non couverts."}
+    lift = {"author": {"login": "myia-ai-01"}, "createdAt": at(12),
+            "body": OVERRIDE_BODY}
+    data = {
+        "number": 0, "title": "t", "author": {"login": "myia-po-2026"},
+        "comments": [lift], "reviews": [cr],
+        "commits": [{"committedDate": at(19)}],
+    }
+    assert mod.analyse(data, [], MERGED)["blocked"] is False

--- a/scripts/tests/test_check_unaddressed_nits_mention.py
+++ b/scripts/tests/test_check_unaddressed_nits_mention.py
@@ -1,0 +1,137 @@
+"""Tests use vs mention de CONCERN_MARKERS (#11636), 2e reformulation de la
+classe fermee pour CONDITIONAL_LIFT (#11246).
+
+Un rapport de correction qui NOMME le verdict qu'il corrige n'emets pas de
+reserve. Cas fondateur #11628 (mesure : le SEUL item bloquant du gate au
+moment du merge) :
+
+    Fix review ai-01 (CHANGES_REQUESTED) — commit 06956bd0a.
+
+Le nom du verdict est entre PARENTHESES, pas entre guillemets — `_strip_quoted`
+ne le voyait pas et aucun CITERS ne matche « review ai-01 («. L'incitation
+etait inversee : le rapport le PLUS precis etait classe BOT-CONCERN pendant
+qu'un « done » passait — le gate penalisait exactement le comportement que
+B.0 cherche a obtenir.
+
+La classe est rare et mesurée (1/60 PRs mergees, #11636) : le correctif est
+etroit — verbe/locution de reference + nom de verdict FORMEL entre
+parentheses, deux conditions cumulatives. Une emission parenthesee sans
+verbe de reference reste vivante (controle positif).
+
+Aucun appel reseau : classify/has_live_marker sont purs.
+"""
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+CHECK_PATH = HERE.parent / "check_unaddressed_nits.py"
+
+spec = importlib.util.spec_from_file_location("check_unaddressed_nits", CHECK_PATH)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["check_unaddressed_nits"] = mod
+spec.loader.exec_module(mod)
+
+# Corps EXACT du commentaire 2026-08-18T12:17:52Z de #11628 (auteur po-2026,
+# poste via gh CLI donc sans CRLF). C'etait le seul item bloquant du gate.
+FIXTURE_11628_BODY = (
+    "Fix review ai-01 (CHANGES_REQUESTED) — commit 06956bd0a.\n"
+    "\n"
+    "Re-alignement de la couche interpretation sur les sorties du run "
+    "committe : md[9,28,30,34,36,40,44]. Au-dela de la liste du review, "
+    "md[9] (reference prospective 'Sharpe 0.683, +50,12 %') corrige aussi — "
+    "G.1.\n"
+    "\n"
+    "Recit retourne honnetement : le modele ATTEINT sa barre (val_sharpe "
+    "1.218 > 0.7, checkpoint charge = episode 200, le dernier), +184,62 % "
+    "total / +41,98 % annualise OOS, MaxDD -26,55 %, win rate 53,46 %, 2806 "
+    "trades, actions Hold 4076 / Buy 3558 / Sell 942 / Close 2704 (net-long "
+    "avec rotation active). md[30] re-ecrit : le best-checkpoint n'a pas eu "
+    "a trancher CE run (pic = fin) mais aurait preserve le +0,655 de l'ep 60 "
+    "sans la recuperation de l'ep 200.\n"
+    "\n"
+    "Splice chirurgical JSON : seules les 7 cellules markdown changent "
+    "(verifie par id nbformat), 0 cellule code, outputs intacts, sources "
+    "byte-identiques a main. Diff markdown-only -> pas de re-exec (gel "
+    "disque)."
+)
+
+MENTION = "Fix review ai-01 (CHANGES_REQUESTED) — commit 06956bd0a."
+USAGE = ("[Hermes] — CHANGES_REQUESTED : la cellule 19 casse C.2, "
+         "a corriger avant merge.")
+
+
+def test_mention_et_usage_cote_a_cote():
+    """Acceptance 1+2 : les DEUX formes dans le MEME test — la mention
+    (rapport de correction) ne reserve pas, l'usage (vraie reserve) reserve.
+    Verifier une seule forme par test laisserait un fix tuer l'autre."""
+    assert mod.classify("myia-po-2026", MENTION) is None
+    assert mod.classify("hermes-bot", USAGE) == "BOT-CONCERN"
+
+
+def test_has_live_marker_faux_sur_mention_vrai_sur_usage():
+    """Acceptance de #11636 : has_live_marker rend False sur la mention ET
+    True sur l'usage, dans la meme invocation — sinon on remplace un faux
+    positif par un faux negatif, qui lui ne se signale pas."""
+    assert mod.has_live_marker(
+        mod._strip_mentioned_verdicts(MENTION), mod.CONCERN_MARKERS) is False
+    assert mod.has_live_marker(
+        mod._strip_mentioned_verdicts(USAGE), mod.CONCERN_MARKERS) is True
+
+
+def test_fixture_reelle_11628_nest_plus_un_nit():
+    """Corps complet du commentaire fondateur : rapport de correction, pas
+    une reserve. AVANT le fix, c'etait l'unique item bloquant du gate."""
+    assert mod.classify("myia-po-2026", FIXTURE_11628_BODY) is None
+
+
+def test_emission_parenthesee_sans_verbe_reste_vivante():
+    """Controle du cumul : un verdict entre parentheses SANS verbe de
+    reference devant est une EMISSION (« (CHANGES_REQUESTED) sur la ligne
+    19 »), pas une mention — la parenthese seule n'exempte rien."""
+    bare = "(CHANGES_REQUESTED) sur la ligne 19, a corriger avant merge."
+    assert mod.classify("hermes-bot", bare) == "BOT-CONCERN"
+
+
+def test_agent_intercale_entre_verbe_et_parenthese():
+    """Le cas reel porte un nom d'agent entre le verbe et la parenthese
+    (« Fix review ai-01 (…) ») : la fenetre de 40 chars l'accepte, meme
+    mecanique que l'attribution de `_is_cited`."""
+    spaced = "Fix review hermes, relue au passage (CHANGES_REQUESTED) — commit abc."
+    assert mod.classify("myia-po-2026", spaced) is None
+
+
+def test_locutions_de_reference_couvertes():
+    """La famille decrite par #11636, au-dela du cas fondateur : suite a / en
+    reponse a / corrige."""
+    for body in (
+        "Suite a la review ai-01 (CHANGES_REQUESTED) du 12:38, les 7 cellules "
+        "sont re-alignees — commit 06956bd0a.",
+        "En reponse a ton verdict (NEEDS_CHANGES) : le split est fait.",
+        "Corrige la reponse de po-2023 (COMMENT_WITH_CONCERNS) — commit def456.",
+    ):
+        assert mod.classify("myia-po-2026", body) is None, body
+
+
+def test_verdict_nu_hors_parenthese_reste_vivant():
+    """Non-regression : le meme verbe de reference suivi d'un verdict NU
+    (hors parentheses) reste une emission potentielle — la voie ne touche
+    QUE la forme parenthesee."""
+    naked = "Fix review ai-01 CHANGES_REQUESTED — commit 06956bd0a."
+    assert mod.classify("hermes-bot", naked) == "BOT-CONCERN"
+
+
+def test_retro_11628_le_gate_passe():
+    """Le livrable en retro : PR de po-2026 portant le rapport de correction
+    reeel, mergee ensuite — plus aucun signal bloquant."""
+    data = {
+        "number": 0, "title": "t", "author": {"login": "myia-po-2026"},
+        "comments": [{"author": {"login": "myia-po-2026"},
+                      "createdAt": "2026-08-18T12:17:52Z",
+                      "body": FIXTURE_11628_BODY}],
+        "reviews": [],
+        "commits": [{"committedDate": "2026-08-18T12:30:00Z"}],
+    }
+    merged = datetime(2026, 8, 18, 13, 30, tzinfo=timezone.utc)
+    assert mod.analyse(data, [], merged)["blocked"] is False


### PR DESCRIPTION
**Grain:** MED/guard - lane myia-po-2026:CoursIA -- prev: MED/tooling (#11641)

Deux défauts du même organe (`scripts/check_unaddressed_nits.py`, gate B.0), corrigés dans la même passe comme le demande #11639 (« les deux se corrigent dans la même passe »).

## 1. #11639 — la trappe OVERRIDE du coordinateur

`_lift_eligible` (ligne ~499) ne créditait une levée que de l'auteur du nit ou de l'auteur de la PR : tout arbitrage coordinateur laissait le gate rouge, et le merge se faisait à `EXIT=1` en routine.

Correctif : une levée portant `[OVERRIDE] lane <machine:workspace>` **et** un LIFT_MARKER (exigé par `explicit_lifts`/`can_lift`), écrite par un compte coordinateur (`COORDINATOR_LOGINS = {myia-ai-01, jsboige}` — les comptes qui mergent, CLAUDE.md §A), lève le nit. La restriction d'auteur #11145 reste la règle pour tout autre tiers — la trappe est nommée, pas une ouverture générale.

| Acceptance #11639 | Statut | Preuve |
|---|---|---|
| `[OVERRIDE] lane` + LIFT_MARKER par coord lève le nit | OK | `test_coord_override_avec_levee_leve` + `test_coord_override_leve_aussi_le_state_changes_requested` (branches A et B) |
| `[OVERRIDE]` sans phrase de levée ne lève rien | OK | `test_coord_override_nu_ne_leve_rien` (écarté dès `can_lift` : tag de protocole nu) |
| Tiers quelconque sans OVERRIDE ne lève toujours rien | OK | `test_tiers_avec_levee_sans_override_ne_leve_pas` + `test_override_par_un_non_coordinateur_ne_leve_pas` |
| Vérifié sur #11479 (rétro) : gate EXIT=0 | **ÉCART documenté** | voir ci-dessous |

### L'écart #11479, mesuré sur l'historique réel

L'acceptance 4 est **inatteignable sur l'historique tel quel**, par ordonnancement des timestamps réels :

- réserve Hermes : 2026-08-17T13:38Z
- levée nominative d'ai-01 : **13:06:34Z** (LIFT_MARKER, sans `[OVERRIDE]`)
- merge : **13:06:39Z**
- override écrit : **13:07:40Z** — **61 s APRÈS le merge**

La borne anti-rétroactivité (un commentaire post-merge n'a pas pu lever la réserve avant la décision de merge — la protection de l'incident fondateur #10761) exclut l'override réel, et la levée nominative pré-merge ne porte pas le marqueur. Le rétro live de #11479 reste donc `EXIT=1` **et c'est voulu** : le mécanisme, lui, est prouvé par paire minimale dans les tests — même override déplacé à 13:06:34Z (pré-merge) → `blocked=False` (`test_retro_11479_reel_override_post_merge_ne_leve_pas` / `test_retro_11479_simule_override_pre_merge_leve`). La convention que ce correctif établit : **l'OVERRIDE s'écrit AVANT le merge**, comme toute levée. Les deux voies qui feraient passer #11479 en rétro ont été écartées délibérément : créditer la levée nominative d'un coord sans marqueur rouvrirait l'auto-levée tiers (rejetée par la spec) ; accepter un override post-merge affaiblirait la borne #10761 (tout merge complaisant pourrait être régularisé post-hoc).

## 2. #11636 — use vs mention sur CONCERN_MARKERS

`Fix review ai-01 (CHANGES_REQUESTED) — commit 06956bd0a.` (#11628) était classé `BOT-CONCERN` : le gate bloquait sur le rapport de correction lui-même — le rapport le PLUS précis était pénalisé pendant qu'un « done » passait. 2e reformulation de la classe #11246 ; le verdict cité est entre parenthèses, hors de portée de `_strip_quoted` et des CITERS.

Correctif (piste 1 de l'issue, surface minimale) : `_strip_mentioned_verdicts` neutralise un nom de verdict formel `[A-Z][A-Z_]{3,}` entre parenthèses **lorsque** un verbe/locution de référence (fix, corrigé, suite à, en réponse à, levée…) le précède dans les 40 chars — un nom d'agent peut s'intercaler (`Fix review ai-01 (…)`), même mécanique d'attribution que `_is_cited`. Appliqué **uniquement** à la recherche `CONCERN_MARKERS` : `LIFT_MARKERS` et `VERDICT_POSITIVE` gardent le body brut. Les deux conditions sont cumulatives : une émission parenthésée sans verbe de référence reste vivante (`(CHANGES_REQUESTED) sur la ligne 19` → `BOT-CONCERN`).

| Acceptance #11636 | Statut | Preuve |
|---|---|---|
| `Fix review ai-01 (CHANGES_REQUESTED) — commit <sha>` plus classé BOT-CONCERN | OK | `test_fixture_reelle_11628_nest_plus_un_nit` (corps exact, figé) |
| Vraie réserve avec `CHANGES_REQUESTED` toujours classée | OK | `test_mention_et_usage_cote_a_cote` + `test_has_live_marker_faux_sur_mention_vrai_sur_usage` |
| Test unitaire deux formes côte à côte | OK | même test, les deux asserts |
| `--audit --limit 400` sans régression, chiffres avant/après | OK | **18 → 17 flagged** sur 400 scannées (fenêtre 2026-08-15→2026-08-18) : DISAPPEARED = #11628 seul (le cas visé), **APPEARED = 0** |

## Matrice live complète (avant push, leçon over-exemption)

| Gate | PRE | POST | Attendu |
|---|---|---|---|
| #11628 (cas fondateur mention) | EXIT=1 | **EXIT=0** | libéré |
| #10761 (incident fondateur, contrôle positif) | EXIT=1 | **EXIT=1** | intact |
| #11479 (OVERRIDE réel post-merge) | EXIT=1 | **EXIT=1** | documenté ci-dessus |

Tests : **90/90** (77 existants inchangés + 13 nouveaux). Aucun autre fichier touché (+340/−13, 3 fichiers).

## §3 — distinction déclarée (prev MED/tooling #11641, avant lui MED/guard #11635/#11638)

Genre maintenu `guard` (discriminant §1 : un check qui peut passer au rouge — ce correctif modifie les exit codes du gate B.0). Sujet et mécanisme **genuinement distincts** des grains guard adjacents : #11635 = nouveau workflow CI de confrontation d'assertions de périmètre ; #11638 = selfcheck greffé sur le détecteur markdown ; la présente = comportement de levée/classification du gate nits B.0 (trappe d'auteur + une classe use-vs-mention). Trois organes, trois mécanismes, aucun chevauchement de fichiers.

See #11639 (acceptance 4 en écart documenté — arbitrage coordinateur bienvenu sur la lecture)
Closes #11636
