### PR TITLE
fix(guard,#11627): le ratchet exec-sequence juge la branche, pas son retard (147 -> 2)

### DIFF
--- a/scripts/notebook_tools/check_exec_ratchet.py
+++ b/scripts/notebook_tools/check_exec_ratchet.py
@@ -15,7 +15,9 @@ for visibility only.
 Usage:
     python check_exec_ratchet.py <base-ref> [--json]
 
-    base-ref      git ref of the merge base (CI: origin/<base branch>)
+    base-ref      base branch ref (CI: origin/<base branch>). Resolved
+                  internally to merge-base(base-ref, HEAD), so a branch
+                  behind its base is judged on its own diff only.
 
 Head verdicts read the working tree (in CI the checkout IS the head), base
 verdicts read the blob via `git show`. Exit code 1 iff at least one
@@ -47,6 +49,28 @@ def git(*args, cwd=None):
     except OSError:
         return None
     return out.stdout if out.returncode == 0 else None
+
+
+def resolve_base(base, cwd=None):
+    """Resolve `base` to merge-base(base, HEAD).
+
+    The gate must judge what the branch CHANGED, not how far behind it is.
+    Comparing a stale branch tree-to-tree against the tip of its base branch
+    reports every notebook the base advanced meanwhile -- and, since the
+    branch still holds the older blob, reports them with the sign reversed:
+    a notebook cleaned on main reads as CLEAN -> DIRTY here.  Measured on
+    #11627 (jumeau de #11532): five PRs red on this check without any of
+    them having touched a notebook sequence.
+
+    The false verdict is the dangerous kind -- it sends an author to
+    "re-execute" notebooks they never opened, which is exactly the gesture
+    that destroyed 8 SVG renders on #11351.
+
+    Falls back to the ref as given when no merge base exists (shallow clone,
+    unrelated histories), i.e. the previous behaviour.
+    """
+    out = git("merge-base", base, "HEAD", cwd=cwd)
+    return out.strip() if out and out.strip() else base
 
 
 def changed_notebooks(base, cwd=None):
@@ -90,6 +114,7 @@ def verdict_at_head(path, cwd=None):
 
 def ratchet(base, cwd=None):
     """One record per changed notebook; regression = CLEAN soiled."""
+    base = resolve_base(base, cwd=cwd)
     records = []
     for path in changed_notebooks(base, cwd=cwd):
         base_verdict, _ = verdict_at_base(base, path, cwd=cwd)
@@ -112,17 +137,20 @@ def main():
                     help="Machine-readable output")
     args = ap.parse_args()
 
+    resolved = resolve_base(args.base)
     records = ratchet(args.base)
     regressions = [r for r in records if r["regression"]]
 
     if args.as_json:
         print(json.dumps({
             "base": args.base,
+            "base_resolved": resolved,
             "changed": len(records),
             "regressions": len(regressions),
             "records": records}, ensure_ascii=False, indent=1))
     else:
-        print(f"execution_count ratchet -- base {args.base}")
+        print(f"execution_count ratchet -- base {args.base} "
+              f"(merge-base {resolved[:12]})")
         print(f"changed notebooks : {len(records)}")
         print(f"regressions       : {len(regressions)}")
         for r in records:

--- a/scripts/notebook_tools/tests/test_check_exec_ratchet.py
+++ b/scripts/notebook_tools/tests/test_check_exec_ratchet.py
@@ -127,6 +127,65 @@ class TestRatchetVerdicts:
         assert ratchet.ratchet(base, cwd=repo) == []
 
 
+class TestBaseAdvancedMeanwhile:
+    """A branch behind its base is judged on ITS diff, not on the gap.
+
+    Every other test in this file passes a base that is an ANCESTOR of HEAD,
+    where tree-to-tree and merge-base comparisons coincide -- which is the
+    only topology the suite covered, and why the defect lived here unseen
+    while its byte-identical twin was being fixed (#11532 -> #11627).
+
+    The false verdict here is sign-reversed and therefore convincing: main
+    re-executes a notebook DUPLICATE -> CLEAN, the stale branch still holds
+    the old blob, and a tree-to-tree read calls that CLEAN -> DUPLICATE --
+    a "regression" in a file the branch never opened.
+    """
+
+    def _diverge(self, repo):
+        """base holds two notebooks; the branch edits one, base fixes the
+        other. Returns the base-branch tip sha."""
+        write_nb(repo, "mine.ipynb", make_nb([1, 2, 3]))
+        write_nb(repo, "theirs.ipynb", make_nb([1, 2, 2]))
+        commit(repo, "base")
+        base_branch = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo,
+            check=True, capture_output=True, encoding="utf-8").stdout.strip()
+        git_ok(repo, "checkout", "-q", "-b", "feature")
+        nb = make_nb([1, 2, 3])
+        nb["cells"].insert(0, {"cell_type": "markdown",
+                               "source": "# new prose", "metadata": {}})
+        write_nb(repo, "mine.ipynb", nb)
+        commit(repo, "feature: markdown only")
+        git_ok(repo, "checkout", "-q", base_branch)
+        # main re-executes the OTHER notebook: DUPLICATE -> CLEAN
+        write_nb(repo, "theirs.ipynb", make_nb([1, 2, 3]))
+        tip = commit(repo, "base advances")
+        git_ok(repo, "checkout", "-q", "feature")
+        return tip
+
+    def test_base_side_changes_are_not_attributed_to_the_branch(self, repo):
+        tip = self._diverge(repo)
+        recs = ratchet.ratchet(tip, cwd=repo)
+        assert [r["notebook"] for r in recs] == ["mine.ipynb"]
+        assert recs[0]["regression"] is False
+
+    def test_a_real_regression_on_a_stale_branch_is_still_caught(self, repo):
+        """The fix removes false positives without blunting the gate."""
+        tip = self._diverge(repo)
+        write_nb(repo, "mine.ipynb", make_nb([1, 2, 2]))
+        commit(repo, "feature: sequence soiled")
+        recs = ratchet.ratchet(tip, cwd=repo)
+        assert [r["notebook"] for r in recs] == ["mine.ipynb"]
+        assert recs[0] == {"notebook": "mine.ipynb", "base": "CLEAN",
+                           "head": "DUPLICATE", "regression": True}
+
+    def test_resolve_base_falls_back_when_no_merge_base(self, repo):
+        """Unrelated histories (shallow clone): previous behaviour kept."""
+        write_nb(repo, "a.ipynb", make_nb([1, 2, 3]))
+        commit(repo, "base")
+        assert ratchet.resolve_base("no-such-ref", cwd=repo) == "no-such-ref"
+
+
 class TestExclusions:
     def test_archive_output_research_checkpoints_excluded(self, monkeypatch):
         lines = "a.ipynb\npkg/archive/o.ipynb\npkg/_output/o.ipynb\n" \


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/tooling #11633

## Quoi

`check_exec_ratchet.py` comparait l'**arbre** de la branche a la **tete** de sa
base, pas a leur **base de fusion**. Tout notebook que `main` a fait avancer
depuis le point de divergence etait donc attribue a la PR.

Le signe est inverse, et c'est ce qui rend le faux verdict credible : la branche
detient encore l'ancien blob, donc un notebook **nettoye sur main**
(`DUPLICATE -> CLEAN`) se lit ici `CLEAN -> DUPLICATE`. Le gate accuse la PR
d'avoir salopé un fichier qu'elle n'a jamais ouvert.

## Mesure firsthand — #11428, 170 commits de retard

```
$ git rev-list --count HEAD..origin/main
170

AVANT (arbre-a-arbre)    changed=147  regressions= 58
       CLEAN -> DUPLICATE  GameTheory/GameTheory-10-ForwardInduction-SPE.ipynb
       CLEAN -> UNORDERED  GameTheory/GameTheory-15b-Lean-CooperativeGames.ipynb
       CLEAN -> DUPLICATE  GameTheory/SocialChoice/03-Voting-Methods.ipynb
       CLEAN -> DUPLICATE  GenAI/Audio/04-Applications/04-10-Annotation-Prosodique.ipynb
APRES (merge-base)       changed=  2  regressions=  0
```

147 notebooks accuses pour une PR qui en touche 2. Aucun des quatre notebooks
listes n'apparait dans le diff de #11428.

**Cinq PRs sont rouges derriere ce verdict** : #11622, #11533, #11530, #11527,
#11428. Aucune n'a touche la sequence des notebooks qu'on lui reproche.

## Pourquoi c'est le faux verdict dangereux

Il est **actionnable dans le mauvais sens**. Il envoie l'auteur re-executer des
notebooks qu'il n'a jamais ouverts — le geste exact qui a detruit 8 rendus SVG
sur #11351 (195 KB de rendu tombes a 3,3 KB, Graphviz absent du runner). Un
gate qui sur-accuse ne coute pas seulement du temps : il prescrit le remede qui
casse.

Tell generalisable : **un compte d'items tres superieur a la taille du propre
diff de la PR** (147 contre 2). Quand un gate rend ca, c'est le gate qu'il faut
lire, pas le diff.

## Le correctif

Celui deja pose sur le jumeau papermill par #11532 :

```python
def resolve_base(base, cwd=None):
    out = git("merge-base", base, "HEAD", cwd=cwd)
    return out.strip() if out and out.strip() else base
```

Repli sur la ref telle quelle quand aucune base de fusion n'existe (clone
superficiel, histoires sans rapport) — comportement anterieur preserve.

Le rapport nomme desormais la base **reellement utilisee**
(`base_resolved` en JSON, `(merge-base abc123def456)` en texte) : une mesure
doit dire sur quoi elle porte, sinon un vert hors-cible est indiscernable d'un
vert sur cible.

## Tests — avec controle positif

`TestBaseAdvancedMeanwhile` couvre la topologie que la suite **ignorait
entierement** : une base qui n'est PAS ancetre de HEAD. Les 13 tests
preexistants passaient tous une base ancetre, ou comparaison arbre-a-arbre et
base-de-fusion **coincident** — le defaut vivait dans la seule topologie
absente du jeu de tests.

```
sans le correctif : 3 failed, 13 passed
                    (dont "Left contains one more item: 'theirs.ipynb'")
avec le correctif : 16 passed
```

Trois cas : la branche n'herite pas des changements de la base ; une **vraie**
regression sur branche en retard est **toujours attrapee** (le correctif retire
des faux positifs sans emousser le gate) ; le repli sans base de fusion.

## Ce que je retiens

Le defaut a survecu a la correction de son jumeau — meme fichier a un nom pres,
meme fonction, meme bug — parce que personne n'a grepe la famille apres avoir
resolu #11532 ce matin a 09:23Z. `ls scripts/notebook_tools/check_*ratchet*.py`
coutait dix secondes ; l'omission a coute cinq PRs bloquees une journee.

La question « **ou ailleurs ce code vit-il ?** » se pose **avant de clore**,
pas apres avoir ete redecouvert par deux PRs rouges a tort.

## Note de coordination

Ce grain etait dispatche a `myia-po-2024:CoursIA` (claim de 10:48:48Z). Je l'ai
repris par `[OVERRIDE]` **ecrit sur l'issue** (#11627, commentaire de 14:01:40Z,
`check_lane_claim.py` -> `blocked: false`), apres avoir mesure qu'aucune branche
ni PR n'existait sur le chemin 5 h apres le dispatch, et parce que cinq PRs
saines etaient tenues. Ce n'est pas un reproche a la lane : elle n'a pas eu de
cycle. po-2024 est prevenu par DM.

Le jumeau `check_papermill_ratchet.py` merite le meme `base_resolved` dans son
rapport — hors scope de cet override (`paths:` ne nomme que le fichier exec et
son test), a prendre en suivi.

Closes #11627
