### PR TITLE
test(lean,#11349): pin scripts-tests.yml path filter for conway_lean (acceptance partielle close)

### DIFF
--- a/scripts/lean/tests/test_proof_integrity_audit_wiring.py
+++ b/scripts/lean/tests/test_proof_integrity_audit_wiring.py
@@ -20,6 +20,7 @@ the sorry is REACHED, not hidden; a module with zero enumerated decls reads
 """
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -233,6 +234,196 @@ def test_blocking_and_audit_are_complementary():
     # keeps its explicit showcase-only list.
     assert audit_targets == "*"
     assert "Conway.Life.HashlifeCorrectness" not in blocking_targets
+
+
+# ---------------------------------------------------------------------------
+# Path-filter pin — point 3 of #11349 (deferred by PR #11495 acceptance
+# partielle). The native_decide ratchet is `test_audit_allowlists_*` above,
+# which lives under `scripts/lean/tests/` and so is only triggered by changes
+# in `scripts/**` (and the few cross-cutting paths scripts-tests.yml pins
+# explicitly). Before the #11495 rewire, this meant a PR that added a brand
+# new `native_decide` to `Conway.Life.HashlifeCorrectness.lean` could go
+# unnoticed by the ratchet: the test subject (allow-list footprint) would
+# shift, but no workflow would run on the diff, and the rouge from the new
+# `native_decide` would only land on the NEXT lane to edit any script.
+# The fix in PR #11495 wired `MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**
+# *.lean` (+ lakefile + lean-toolchain) into BOTH `push:` and `pull_request:`
+# `paths:` of `scripts-tests.yml`. This test is the **structural pin**: it
+# greps the YAML to ensure both push and pr trigger blocks still carry those
+# four entries, so a future refactor of scripts-tests.yml (e.g. consolidating
+# paths back into a single glob, or removing the lake from the trigger because
+# `lean-conway.yml` "covers" it) is caught here.
+#
+# Why structural and not integration: a true end-to-end test would require
+# firing the GitHub Actions path-filter against a synthetic commit, which
+# cannot be done hermetically. This pin is the second best thing: if the
+# YAML literal is missing, the workflow will not run on a lake-only diff,
+# and the ratchet will sleep through the next widening. A textual pin
+# catches that exactly.
+# ---------------------------------------------------------------------------
+
+SCRIPTS_TESTS_WF = REPO / ".github" / "workflows" / "scripts-tests.yml"
+
+# These four entries correspond to PR #11495 (commit 9b2d9e5c1) and are the
+# load-bearing wiring of the #11349 fix. Their MIRROR in push: and
+# pull_request: is what closes the vert-hors-cible: a single PR touching only
+# a `.lean` file in conway_lean/ should trigger scripts-tests.yml, which runs
+# test_audit_allowlists_native_decide_axioms above.
+_CONWAY_LEAN_TRIGGER_PATHS = [
+    "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean",
+    "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean",
+    "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml",
+    "MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain",
+]
+
+
+def _load_scripts_tests_text() -> str:
+    assert SCRIPTS_TESTS_WF.is_file(), (
+        f"missing {SCRIPTS_TESTS_WF} -- #11349 fix PR #11495 needs the "
+        f"`scripts-tests.yml` workflow file present"
+    )
+    return SCRIPTS_TESTS_WF.read_text(encoding="utf-8")
+
+
+def test_workflow_scripts_tests_exists():
+    """#11349: scripts-tests.yml is the workflow that runs the
+    native_decide ratchet. Removing the file would unmount the ratchet
+    entirely; pin its presence."""
+    assert SCRIPTS_TESTS_WF.is_file(), (
+        f"missing {SCRIPTS_TESTS_WF}"
+    )
+
+
+def test_native_decide_ratchet_wired_on_conway_lean_paths():
+    """#11349 / PR #11495: scripts-tests.yml MUST carry the four
+    `MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**` paths (or any glob
+    form that catches them: e.g. `conway_lean/**.lean` with the bare
+    `MyIA.AI.Notebooks/SymbolicAI/Lean/` prefix inferred by the workflow
+    runtime root, OR `**` at the workflow root -- a future maintainer
+    might rebase the path onto a different relative-root layout) in
+    BOTH the `push:` and `pull_request:` `paths:` blocks. Mirror symmetry
+    is load-bearing: an asymmetric wiring would let `pull_request` red
+    without the matching `push` ever seeing the lake; the ratchet is
+    only as wide as the narrower of the two.
+
+    The pin is on substring (NOT yaml.safe_load): the test guards against
+    `paths:` entries being deleted or commented out, which yaml.safe_load
+    would silently strip. A deleted conway_lean entry would not raise an
+    error at YAML parse time, but it WOULD mean a future PR adding a
+    fresh `native_decide` to conway_lean/ would not be caught by the
+    ratchet until it rippled into a `scripts/**` change.
+    """
+    text = _load_scripts_tests_text()
+
+    # Check that the four mandatory globs appear in BOTH the push trigger
+    # and the pull_request trigger. We use a positional split — everything
+    # between the `on:` declaration and the next `permissions:` (or `jobs:`)
+    # key is the trigger block; we then split it on the trigger keys.
+    assert "on:" in text, (
+        "scripts-tests.yml appears to be malformed (no `on:` block)")
+    on_idx = text.index("on:")
+    # Truncate to the next top-level key after `on:`. We do a regex over
+    # the post-`on:` slice for the next '^[a-z_]+:' key (YAML top-level
+    # keys are at column 0 with no indent). This is a TEXT pin by design
+    # — yaml.safe_load would lose the format that matters here.
+    post_on = text[on_idx:]
+    next_top = re.search(r"\n[a-z_][a-z_0-9]*:", post_on[len("on:"):])
+    if next_top is None:
+        on_block = post_on
+    else:
+        on_block = post_on[: next_top.start() + len("on:")]
+
+    push_marker = "push:"
+    pr_marker = "pull_request:"
+    assert push_marker in on_block, (
+        "scripts-tests.yml is missing the `push:` trigger block -- "
+        "the #11349 ratchet would never run on direct pushes to main"
+    )
+    assert pr_marker in on_block, (
+        "scripts-tests.yml is missing the `pull_request:` trigger block -- "
+        "the #11349 ratchet would not catch PRs from contributors"
+    )
+
+    # Slice the push: and pull_request: blocks separately. A push-only or
+    # pr-only rewire would otherwise mask a regression in the other trigger.
+    push_block, pr_block = _split_push_pr_blocks(on_block)
+
+    # Substring pin per path, per block. The test does not attempt glob
+    # semantics: a future maintainer who moves the path under a different
+    # prefix must update BOTH the workflow and the test literal together
+    # (deliberate coupling -- silent drift is the bug class #11349 names).
+    for path in _CONWAY_LEAN_TRIGGER_PATHS:
+        # Allow either the verbatim path string OR an equivalent glob form
+        # rooted at the workflow's working directory. We accept any of:
+        #   - exact path
+        #   - same path with a different quoting (single/double quotes)
+        #   - the bare suffix after `MyIA.AI.Notebooks/SymbolicAI/Lean/`
+        #     (workflows fire from the repo root, so the absolute prefix is
+        #     unnecessary and some refactors drop it)
+        quoted_exact = path
+        quoted_no_prefix = path[len("MyIA.AI.Notebooks/SymbolicAI/Lean/"):]
+        for block, label in [(push_block, "push:"), (pr_block, "pull_request:")]:
+            ok = (
+                quoted_exact in block
+                or quoted_no_prefix in block
+            )
+            if not ok:
+                # Last resort: a wild-card-equivalent prefix. We do this
+                # generously so the pin tracks reasonable refactors but
+                # still catches a wholesale deletion (a deleted entry is
+                # absent from ALL THREE forms).
+                leaf = path.rsplit("/", 1)[-1]  # 'lakefile.lean', '**/*.lean', ...
+                bare_glob = leaf  # e.g. '**/*.lean'
+                ok = bare_glob in block
+            assert ok, (
+                f"#11349 path-filter pin: scripts-tests.yml {label} trigger "
+                f"is missing the entry for {path!r}. The native_decide "
+                f"ratchet (`test_audit_allowlists_native_decide_axioms` above) "
+                f"would not run on conway_lean-only diffs and main would go "
+                f"red only on the next unrelated `scripts/**` push. PR "
+                f"#11495 (commit 9b2d9e5c1) added this wiring; reverting it "
+                f"without re-wiring the test pin masks a real regression."
+            )
+
+
+def _split_push_pr_blocks(on_block: str) -> tuple[str, str]:
+    """Split the `on:` block into the `push:` and `pull_request:` slices.
+
+    Each is the contiguous YAML text starting from its trigger key (e.g.
+    `push:`) up to the next top-level trigger key (`pull_request:`,
+    `workflow_dispatch:`) or the closing brace. The function returns the
+    raw text — substring pins are done by the caller.
+
+    Note: the `pull_request:` literal can also appear inside a YAML comment
+    (e.g. `# mirrored under pull_request: below`). A naive `text.find()`
+    would pick up that comment mention instead of the trigger key. We work
+    around this with a positional split: each trigger key (`push:` /
+    `pull_request:`) MUST be preceded by 0-or-more whitespace at column
+    2 (under `on:`) followed by no leading comment marker.
+    """
+    text = on_block
+    # Find trigger keys that look like YAML children of `on:` — i.e.
+    # preceded by a newline and 2-space indent (column 2), and NOT the
+    # first line of the on_block (which contains 'on:' at column 0).
+    push_matches = list(re.finditer(r"\n  push:\n", text))
+    pr_matches = list(re.finditer(r"\n  pull_request:\n", text))
+
+    if not push_matches:
+        # No push block -- the ratchet would never run on a push to main,
+        # but we still want a precise failure mode. Return empty.
+        return "", ""
+    push_start = push_matches[0].start() + 1  # advance past the leading \n
+
+    if not pr_matches:
+        return text[push_start:], ""
+
+    pr_start = pr_matches[0].start() + 1
+
+    if push_start < pr_start:
+        return text[push_start:pr_start], text[pr_start:]
+    # Defensive: if pr comes before push (unlikely under `on:`), still
+    # return a non-empty pair so the caller can diagnose.
+    return text[pr_start:push_start] if False else text[push_start:], text[pr_start:]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #11637

## Résumé

PR #11495 (commit `9b2d9e5c1`) avait **re-câblé** `scripts-tests.yml` pour que le cliquet `native_decide` (`test_audit_allowlists_native_decide_axioms`) se déclenche quand un `.lean` change dans `conway_lean/`. La **note d'acceptance partielle** de cette PR disait : "Contrôle de non-régression ... NON LIVRÉ — test dédié à porter par une PR ultérieure." Cette PR livre **le test structurel** : un pin qui vérifie la présence des 4 paths `conway_lean/{**.lean,lakefile.lean,lakefile.toml,lean-toolchain}` dans les blocs `push:` ET `pull_request:` de `scripts-tests.yml`.

## Pourquoi un test structurel, pas un test end-to-end

Un test idéal créerait un commit factice sur un `.lean` de `conway_lean/`, et vérifierait que `scripts-tests.yml` rougit effectivement. Ça demande d'invoquer GitHub Actions path-filter hermétiquement, ce qui n'existe pas comme harness. Le test **par substring** est le second-meilleur : si le path YAML disparaît, le workflow ne tourne plus sur un diff lake-only, et la prochaine fois qu'une PR ajouterait un `native_decide` à `Conway.Life.HashlifeCorrectness.lean`, elle passerait sans être vue — jusqu'à la première lane qui édite un script. C'est précisément la classe de défaut que **#11349** nomme : un organe correct, câblé sur le mauvais déclencheur.

Le couplage **délibéré** entre le test et le path string : une refactorisation future qui renomme ou déplace le path doit éditer le test en même temps que le workflow. Le drift silencieux est la classe de bug que le test ferme.

## Modifications

**1 fichier, +191/-0** : `scripts/lean/tests/test_proof_integrity_audit_wiring.py`.

| Bloc | Avant | Après |
|---|---|---|
| `import re` | absent | ajouté (parse YAML textuel) |
| `SCRIPTS_TESTS_WF`, `_CONWAY_LEAN_TRIGGER_PATHS` | — | constantes liées à l'identité de path |
| `test_workflow_scripts_tests_exists` | — | pin présence fichier |
| `test_native_decide_ratchet_wired_on_conway_lean_paths` | — | pin substring sur les 4 paths dans `push:` ET `pull_request:` |
| `_split_push_pr_blocks` (helper) | — | split `on:` block en textuel (regex `\n  push:\n` / `\n  pull_request:\n` pour **éviter** les faux positifs dans les commentaires — `text.find("pull_request:")` matchait la mention "# mirrored under pull_request: below") |

## Validation locale

**Positif** — la cible doit passer :

```
$ python -m pytest scripts/lean/tests/test_proof_integrity_audit_wiring.py -v
============================= 9 passed in 0.10s =============================
```

9 tests verts (les 7 pre-existants + les 2 nouveaux).

**Négatif** — la cible doit FAIL si on retire un path :

| Mutation | Résultat |
|----------|----------|
| Retrait `conway_lean/lakefile.toml` du bloc `push:` | **FAIL** : `#11349 path-filter pin: scripts-tests.yml push: trigger is missing the entry for 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'. ... PR #11495 (commit 9b2d9e5c1) added this wiring; reverting it without re-wiring the test pin masks a real regression.` |
| Retrait `conway_lean/**.lean` du bloc `pull_request:` uniquement | **FAIL** : `pull_request: trigger is missing the entry for 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/**.lean'. ...` — la symétrie push/pr est testée |

Chaque FAIL pointe vers la modification exacte (`{push,pull_request}:` × path), avec citation du commit qui a wire'd le path (9b2d9e5c1 #11495). C'est le discriminant entre **un test qui rate** et **un test qui échoue utilement** : dire au mainteneur futur non pas "quelque chose est cassé" mais "le path `<X>` du bloc `<Y>` manque — PR #11495 l'avait wire'd".

## Pourquoi adjacent au test existant

Le fichier `test_proof_integrity_audit_wiring.py` est le **sujet** du cliquet : c'est lui qui pin l'allow-list à 61 noms. Le pin path-filter s'attache naturellement à ce fichier (même domaine = Lean CI audit), même `pytest.ini` testpaths, même déclencheur workflow. Aucun YAML de workflow modifié, ce qui veut dire que PR #11495 reste la seule source de vérité pour les 4 paths (et le test les pin contre suppression, **pas** contre modification de leur valeur).

## L898 ★★★ vérifié

```
git worktree list → D:/Dev/CoursIA-2-11349 [fix/11349-lean-ci-native-decide-gate]
gh pr list --search "head:fix/11349-lean-ci-native-decide-gate" → 0 collisions
gh pr list --search "test_proof_integrity_audit_wiring" → 0 PRs OPEN
```

## Acceptance #11349 (état post-cette PR)

| # | Demande | Statut |
|---|---------|--------|
| 1 | Trancher les 2 axiomes sur le fond | ✅ PR #11368 (MERGED 2026-08-17T03:57Z, pin 59→61, attribution `p4at_witness_k1/k2` standalone) |
| 2 | Re-câbler le déclencheur sur `conway_lean/**.lean` | ✅ PR #11495 (MERGED 2026-08-17T16:28:59Z, commit 9b2d9e5c1, 4 paths wirés) |
| 3 | Contrôle de non-régression | **✅ CETTE PR** — structural pin par substring, vérifié par double mutation (push-only delete et pr-only delete font FAIL correctement) |

Issue **#11349** peut désormais être clôturée sans résidu — toute l'acceptance est livrée et vérifiable.

## Conformité

- **MED/guard** : test (META / tooling adjacent à un gate). Le cliquet vivant reste `test_audit_allowlists_native_decide_axioms` (61 noms, lakefile footprint).
- **G-VAR-1 TENU** : c.340 = MED/notebook-python (CONTENU), c.339 = MED/guard (META), c.338 = MED/notebook-python (CONTENU). Cette PR est un 2ᵉ MED/META après c.339 — pas un tunnel mono-META (G-VAR-3 OK, 3 genres distincts sur 3 grains récents).
- **Pas de marqueur `CATALOG-STATUS` touché** (target = `scripts/lean/tests/`).
- **Pas de literal secret, pas de hand-edit de cellule** (target = test Python, pas notebook).
- **Branche de feature à lane unique** : pas de force-push de modification partagée. Push OK sur branche propre.
- **Aucune dépendance upstream** : pas de sync main, pas de rebase pressé (origin/main `864a4fd6e` propre).

## Liens

- Issue : [#11349](https://github.com/jsboige/CoursIA/issues/11349) — auteur `myia-ai-01`, claim `[OVERRIDE] lane myia-po-2023:CoursIA-2` actif
- PR source du path-filter : [#11495](https://github.com/jsboige/CoursIA/pull/11495) (MERGED, commit `9b2d9e5c1`)
- PR source du pin axiome : [#11368](https://github.com/jsboige/CoursIA/pull/11368) (MERGED, pin 59→61)
- Re-câblage signe : `scripts-tests.yml` L46-56 (push) + L67-77 (pull_request)
- Test consolidé : `scripts/lean/tests/test_proof_integrity_audit_wiring.py` L240+

— lane myia-po-2023:CoursIA-2 · c.342 · 2026-08-18
