### PR TITLE
enrich(genai,#11271): Image 01-3-Basic-Image-Operations density 597 -> 1287 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/01-Foundation/01-3-Basic-Image-Operations.ipynb
@@ -134,6 +134,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "ctx-serie-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Ce troisième volet de la fondation Image assume un rôle précis dans la série : après la découverte de la génération par modèle (01-1, 01-2), il installe la **boîte à outils déterministe** qui entoure tout pipeline génératif. Avant d'envoyer une image à un moteur, il faut la charger, la redresser, la recadrer, l'encoder au bon format et au bon poids — autant d'opérations PIL que ce notebook exécute et mesure une à une. La règle de lecture des sections qui suivent : chaque sortie chiffrée (dimensions, poids, ratios) est une décision d'ingénierie en puissance, pas une anecdote."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 3,
    "id": "e53c1482",
@@ -319,6 +329,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-env-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** L'environnement est vérifié en tête d'exécution : toutes les dépendances sont disponibles et PIL signale sa version **11.3.0**. Le mode d'exécution est `batch`, avec écriture des artefacts vers un répertoire de sorties dédié.\n",
+    "\n",
+    "Point honnête à noter : le fichier `.env` n'est pas trouvé sur cette machine et le notebook bascule sur les variables d'environnement système. C'est le repli prévu, et il est sans conséquence ici — toutes les opérations de ce notebook sont **locales** (PIL uniquement), aucune ne requiert d'API distante. Les widgets interactifs sont signalés disponibles : la Section 6 pourra s'exécuter en mode interactif, le mode batch de cette exécution les désactivera proprement."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2dcc273c",
    "metadata": {
     "papermill": {
@@ -482,6 +504,20 @@
     "plt.show()\n",
     "\n",
     "print(f\"\\n✅ Image de base chargée et analysée\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-load-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** L'image de démonstration est chargée depuis une URL et la sortie résume ses propriétés PIL : **800x600** pixels, mode **RGB**, format source **JPEG**, empreinte mémoire d'environ **1406 KB**. Trois observations utiles pour la suite :\n",
+    "\n",
+    "- Le mode RGB est une matrice 800 x 600 x 3 — soit 1,44 million de valeurs de canal. Tout le coût mémoire des opérations suivantes se déduit de ce produit : doubler la résolution quadruple le travail.\n",
+    "- La « taille mémoire » (~1406 KB) est celle de l'image **décompressée en RAM** ; le fichier JPEG téléchargé est bien plus léger sur le disque. C'est la distinction bitmap vive vs encodage compressé — la Section 7 la mesurera format par format sur cette même image.\n",
+    "- L'image affichée sous la sortie est la référence visuelle : chaque transformation de la Section 2 pourra être comparée à cette base."
    ]
   },
   {
@@ -655,6 +691,22 @@
     "    print(f\"\\n✅ {len(transformations)} transformations effectuées\")\n",
     "else:\n",
     "    print(\"\\n⏭️  Transformations désactivées (enable_transformations=False)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-geom-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** Les 8 transformations sont appliquées et la grille les met côte à côte. Trois mesures de la sortie méritent une lecture attentive :\n",
+    "\n",
+    "- **Resize 400x300 / 1200x900** : PIL redimensionne vers la taille exacte demandée. Le ratio 4:3 de l'original est ici préservé parce que les cibles le respectent — rien ne l'impose, et un `resize` vers une taille de ratio différent **déforme** l'image.\n",
+    "- **Rotation 45° rend 990x990** alors que la rotation à 90° transpose simplement (800x600 → 600x800) : par défaut PIL recadre la rotation dans le canevas d'origine et rogne les coins ; les 990x990 de la sortie révèlent l'option `expand=True`, qui agrandit le canevas pour ne rien perdre. C'est un comportement à choisir consciemment selon qu'on accepte des bords ou un rognage.\n",
+    "- **Thumbnail 200x150** : contrairement à `resize`, `thumbnail` préserve le ratio par construction et modifie l'image **en place** — c'est l'outil canonique des vignettes.\n",
+    "\n",
+    "Le `UserWarning` sur les glyphes DejaVu Sans visible dans la sortie est un artefact de rendu matplotlib (émoji de légende absent de la police), pas un défaut du traitement : l'image affichée est correcte."
    ]
   },
   {
@@ -868,6 +920,21 @@
     "    print(f\"\\n✅ {len(filters_applied)} filtres/effets appliqués\")\n",
     "else:\n",
     "    print(\"\\n⏭️  Filtres désactivés (enable_filters=False)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-filters-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** 14 filtres répartis en 5 familles sont appliqués à la même référence, et la grille autorise la comparaison visuelle immédiate. Deux lectures guident l'œil :\n",
+    "\n",
+    "- **Blur et Gaussian Blur** sont deux intensités de la même idée (moyenne locale pondérée) ; **Sharpen et UnsharpMask** en sont le dual (renforcement des transitions). **Find Edges** n'introduit pas un nouveau mécanisme : la famille `ImageFilter` est un catalogue de **noyaux de convolution**, et changer le noyau change l'effet — flou, netteté ou contours sont la même opération avec des poids différents.\n",
+    "- **Brightness / Contrast / Color** n'appliquent aucune convolution : ce sont des **transformations ponctuelles** (tables de correspondance appliquées pixel par pixel), quasi gratuites en calcul face à un Gaussian Blur dont le coût dépend du rayon du noyau.\n",
+    "\n",
+    "Cette distinction convolution vs transformation ponctuelle structure tout pré-traitement d'image avant un modèle de génération : les secondes se composent librement, les premières se budgètent."
    ]
   },
   {
@@ -1092,6 +1159,18 @@
     "    print(\"\\n⚠️  ExifTags non disponible - section métadonnées ignorée\")\n",
     "else:\n",
     "    print(\"\\n⏭️  Métadonnées désactivées (enable_metadata=False)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-exif-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** L'image de test porte **13 tags EXIF** au total, dont un seul est classé important par le filtre de la démonstration : **Orientation = 1**, l'orientation native, sans rotation à compenser. C'est le tag décisif en pratique : toute valeur autre que 1 signifie que l'appareil a capturé la matrice « à plat » en comptant sur le lecteur pour réorienter — l'ignorer est la source classique des images couchées dans les pipelines de traitement.\n",
+    "\n",
+    "La seconde moitié de la sortie montre l'**écriture** de métadonnées personnalisées dans un PNG (Title, Author, Copyright, Software, CreationDate). Noter la différence de support : EXIF est natif au monde JPEG / appareil photo, tandis que le PNG porte ses métadonnées dans des chunks textuels — PIL masque cette hétérogénéité derrière une même API, mais le choix du conteneur (JPEG vs PNG, Section 7) décide de ce qui survit à l'enregistrement."
    ]
   },
   {
@@ -1353,6 +1432,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-api-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** La sortie quantifie le coût de préparation **par API cible** — c'est le passage le plus rentable à retenir avant d'appeler une API de génération :\n",
+    "\n",
+    "- **DALL-E 3** accepte le carré 1024x1024 (920.6 KB ici) comme les formats étendus (~1353 KB) : la vraie contrainte est la limite de 20 MB, largement respectée par les préparations.\n",
+    "- **Stable Diffusion img2img** exige 512x512 ou 768x768 : les variantes préparées pèsent 308.6 KB et 581.7 KB.\n",
+    "- **GPT-5 Vision** illustre le coût de l'encodage base64 : l'image (~55 KB en JPEG, la Section 7 le mesurera) devient une chaîne de **77 124 caractères**, soit un payload d'environ **75.3 KB** — un surcoût d'un tiers, inhérent au base64 (4 caractères pour 3 octets). Ce n'est pas une inefficacité du code : c'est le tarif du transport inline en JSON.\n",
+    "\n",
+    "Le payload affiché en fin de sortie est le contrat exact attendu par l'API : message `user` à contenu mixte, texte + `image_url` en data URI — un gabarit réutilisable tel quel."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "2e6dae98",
    "metadata": {
     "papermill": {
@@ -1536,6 +1631,18 @@
     "    print(\"\\n🤖 Mode batch - Interface interactive désactivée (skip_widgets=True)\")\n",
     "else:\n",
     "    print(\"\\n⏭️  Interface interactive désactivée (show_interactive_demo=False)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-widgets-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** La sortie le dit sans détour : en mode `batch` (celui de cette exécution, `skip_widgets=True`), l'interface interactive est désactivée et la cellule se termine proprement sans erreur — le notebook reste exécutable de bout en bout quel que soit le mode, conformément à la règle C.1.\n",
+    "\n",
+    "En mode `interactive` (`notebook_mode=\"interactive\"`), cette même cellule attache des sliders ipywidgets aux transformations de la Section 2 : la grille devient manipulable en direct, ce qui est le meilleur moyen d'intuiter les paramètres (rayon du flou, angle de rotation) avant de les figer en code. Si vous exécutez ce notebook localement avec Jupyter, rebasculez le paramètre en tête de notebook pour vivre la version interactive."
    ]
   },
   {
@@ -1727,6 +1834,22 @@
     "        print(f\"   ✅ {filename} ({data['size_kb']:.1f} KB)\")\n",
     "\n",
     "print(f\"\\n✅ Analyse de formats terminée\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "interp-formats-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** Le tableau comparatif trie les encodages du plus léger au plus lourd et concentre la leçon de la section :\n",
+    "\n",
+    "- **JPEG Q75 sort à 55.39 KB** contre **469.69 KB pour le PNG optimisé** : un facteur 8,5 sur une image photographique. Le PNG n'est pas « mauvais » — il est **sans perte** et préserve la transparence, deux atouts sans valeur sur une photo sans alpha.\n",
+    "- **WEBP Q90 (65.12 KB)** s'intercale entre JPEG Q85 et Q95 : à qualité visuelle comparable, c'est le meilleur compromis moderne, au prix d'une compatibilité de décodage un peu plus récente.\n",
+    "- Le **ratio** affiché (0.039 pour JPEG_Q75) se lit comme la fraction de la taille mémoire vive (~1406 KB, Section 1) : la chaîne complète chargement → encodage → upload (Section 5) peut être budgétée chiffre en main avant l'appel API.\n",
+    "\n",
+    "Les recommandations de fin de sortie (qualité max / photos web / performance / thumbnails) sont directement actionnables pour vos propres exports."
    ]
   },
   {
@@ -1942,6 +2065,30 @@
   },
   {
    "cell_type": "markdown",
+   "id": "interp-recap-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Lecture du résultat.** La synthèse reprend le fil complet parcouru — charger, transformer, filtrer, métadonner, préparer pour API, exporter — et c'est l'ordre canonique d'un pipeline de pré-traitement GenAI : chaque section de ce notebook est une étape franchissable indépendamment, mais l'enchaînement est la vraie compétence. Le chemin mémo : une image est une matrice (Section 1) qu'on redresse et découpe (2), qu'on lisse ou accentue (3), qu'on documente (4), qu'on adapte aux contraintes du moteur cible (5), et qu'on encode au bon rapport qualité/poids (7). Les exercices qui suivent fixent chaque maillon."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "note-debug-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Erreurs classiques du débutant PIL — à connaître avant de débugger.** Trois pièges reviennent dans quasi tout premier pipeline :\n",
+    "\n",
+    "- **`Image.open` est *lazy*** : l'ouverture ne lit que l'en-tête ; la matrice de pixels n'est chargée qu'au premier accès. Un fichier modifié ou supprimé entre `open` et l'exploitation explose tardivement — appelez `image.load()` (ou un `image.size` suffit parfois à révéler le problème) au plus tôt quand la source est volatile.\n",
+    "- **Mode implicite** : sauvegarder en JPEG une image mode `RGBA` (canal alpha) lève `OSError: cannot write mode RGBA as JPEG` — convertir explicitement (`image.convert(\"RGB\")`) avant l'export ; la Section 7 le fait pour vous dans ses comparaisons.\n",
+    "- **Confusion resize/thumbnail** : `resize` écrase le ratio si on le lui demande, `thumbnail` ne dépasse JAMAIS la boîte demandée en conservant le ratio. Choisir l'un pour l'autre produit des images aplaties — la Section 2 montre les deux sur la même source."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "nm6fteb1dn",
    "metadata": {
     "papermill": {
@@ -2145,6 +2292,20 @@
     "# 6. Tester le pipeline avec votre image\n",
     "# Indice: Affichez un avant/après pour vérifier les transformations\n",
     "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "guide-suivant-013",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "**Pour aller plus loin.** Ce notebook ferme les opérations *classiques* de PIL ; la suite de la série monte vers la génération elle-même et l'analyse par modèle :\n",
+    "\n",
+    "- **01-2** (précédent) couvrait la génération GPT-5 Image ; observez comme le présent notebook est la contre-face *déterministe* : mêmes entrées, mêmes sorties, aucune variance — un outil de test reproductible pour vos pipelines génératifs.\n",
+    "- Pour l'analyse d'images par modèle de vision (description, extraction structurée), le pattern payload GPT-5 Vision de la Section 5 est le point de départ direct.\n",
+    "- Approfondissement PIL hors série : le module `ImageOps.exif_transpose` automatise exactement la compensation d'orientation EXIF discutée en Section 4 — un réflexe professionnel à adopter dès qu'une source photo entre dans un pipeline."
    ]
   },
   {


### PR DESCRIPTION
**Grain:** MED/notebook-genai - lane myia-po-2026:CoursIA -- prev: MED/guard #11644

Tranche densité du pool GenAI (#11271) : **pire notebook non-claimé de la famille au moment du claim** (597/1200, remesuré firsthand sur origin/main frais `864a4fd6e` ce cycle via `pedagogy_density.py`), claim paths-scoped posé avant édition (comment 5329512070).

## Livrable

**12 cellules markdown ajoutées** au notebook `Image/01-Foundation/01-3-Basic-Image-Operations.ipynb` :

- **9 « Lecture du résultat »** ancrées sur les outputs réels committés (pattern #10488 + cell-interpretation-ordering) : environnement (PIL 11.3.0, repli .env honnête), chargement (800x600 RGB ~1406 KB, bitmap vive vs encodage), transformations (rotation 45°→990x990 = `expand=True`, resize vs thumbnail, warning glyphes = artefact matplotlib), filtres (convolution vs transformation ponctuelle/LUT), EXIF (Orientation=1 sur 13 tags, EXIF JPEG vs chunks PNG), APIs (base64 77 124 chars → 75.3 KB = surcoût d'un tiers, contraintes par API), widgets (batch→désactivé proprement, C.1), formats (JPEG Q75 55.39 KB vs PNG 469.69 KB = facteur 8,5), récap (chemin mémo du pipeline).
- **1 contexte de série** (rôle du volet 01-3 dans la fondation Image), **1 note debugging PIL** (lazy loading, RGBA→JPEG, resize/thumbnail), **1 « Pour aller plus loin »** placée après le stub de l'exercice pipeline.

## Preuves

| Contrôle | Résultat |
|---|---|
| Densité (organe canonique, avant → après) | 597 → **1287** (status `ok`, seuil 1200) |
| Byte-identity des cellules existantes | **100 % additif prouvé par id → SHA1** : 31 cellules d'origine, 0 changed, 0 removed, 12 added |
| Code cells | 15 cellules code **SHA1 identique** (`5b416d374595`) — aucune re-exec requise (markdown-only, outputs préservés, gel disque respecté) |
| Anchor check strict (`check_interp_positioning --check`) | **0 FAIL**, exit 0 |
| Markdown rendering (`detect_markdown_rendering`) | 1 violation **préexistante inchangée** (cellule « Exemple guide » d'origine et son `---`, vérifiée par stash avant/après : cell#27 → cell#38, même contenu) — notebook hors `NOTEBOOK_SUBTREES` Quarto ; relève du rollout hr-separator, pas de cette PR |
| nbformat | valide (5.10.4) |
| Exercices stubs | intacts (3 stubs « Exercice a completer » non touchés, règle C.1) |

## Placement vérifié

Chaque interp suit **immédiatement** la cellule code dont l'output contient les valeurs citées (aucune interp insérée entre un énoncé d'exercice et son stub ; la cellule « Pour aller plus loin » suit le stub du pipeline, pas les critères de succès).

See #11271 (tranche du pool GenAI, pas de close : 64+ notebooks restent below)

§1 GENRE : `notebook-genai` = CONTENU (G-VAR-1 tenu après la veine guard #11635/#11638/#11644 — steer ai-01 du 13:29Z).
