### PR TITLE
fix(genai,#11624): CUDA_DEVICE_ORDER=PCI_BUS_ID on tts-multi GPU services

### DIFF
--- a/docker-configurations/services/tts-multi/docker-compose.yml
+++ b/docker-configurations/services/tts-multi/docker-compose.yml
@@ -76,6 +76,11 @@ services:
         target: /root/.cache
 
     environment:
+      # CUDA_DEVICE_ORDER=PCI_BUS_ID: the container's default CUDA enumeration
+      # is fastest-first, which inverts the host nvidia-smi order on this
+      # mixed-GPU host (measured on tts-qwen, #11624: model loaded on GPU0 /
+      # display GPU despite *_GPU_ID=1). PCI-bus order matches nvidia-smi.
+      - CUDA_DEVICE_ORDER=PCI_BUS_ID
       - CUDA_VISIBLE_DEVICES=${KOKORO_GPU_ID:-1}
       - NVIDIA_VISIBLE_DEVICES=${KOKORO_GPU_ID:-1}
       - PYTHONUNBUFFERED=1
@@ -128,6 +133,8 @@ services:
         target: /root/.cache
 
     environment:
+      # Same enumeration fix as tts-kokoro (see comment there, #11624).
+      - CUDA_DEVICE_ORDER=PCI_BUS_ID
       - CUDA_VISIBLE_DEVICES=${TADA_GPU_ID:-1}
       - NVIDIA_VISIBLE_DEVICES=${TADA_GPU_ID:-1}
       - PYTHONUNBUFFERED=1
@@ -185,6 +192,13 @@ services:
         target: /root/.cache
 
     environment:
+      # Same enumeration fix as tts-kokoro (see comment there, #11624) —
+      # measured on this very service: the vLLM-Omni container loaded the
+      # 1.7B model on GPU0 (3080 Ti Laptop, the display GPU — freeze pattern
+      # 2026-06-21) despite device_ids ['1'] and CUDA_VISIBLE_DEVICES=1.
+      # NOTE: CUDA_VISIBLE_DEVICES must stay an integer index — the app
+      # int()s it, a UUID breaks startup (ValueError).
+      - CUDA_DEVICE_ORDER=PCI_BUS_ID
       - CUDA_VISIBLE_DEVICES=${QWEN_GPU_ID:-1}
       - NVIDIA_VISIBLE_DEVICES=${QWEN_GPU_ID:-1}
       - PYTHONUNBUFFERED=1


### PR DESCRIPTION
Grain: MED/infra - lane myia-po-2023:CoursIA -- prev: DEEP/genai #11646

## Summary

Follow-up declared in #11646: the GPU routing fix measured during the #11624
TTS work, ported into the canonical compose.

The container's default CUDA enumeration is **fastest-first**, which inverts
the host nvidia-smi order on this mixed-GPU host. Measured on tts-qwen: the
vLLM-Omni container loaded the 1.7B model on **GPU0 (3080 Ti Laptop, the
display GPU — freeze pattern 2026-06-21)** despite `device_ids: ['1']` and
`CUDA_VISIBLE_DEVICES=1`. With `CUDA_DEVICE_ORDER=PCI_BUS_ID`, GPU1 (the
3090) takes the ~9 GB residency and GPU0 stays at ~266 MiB (verified live
during the #11624 session, before/after).

## Change

`CUDA_DEVICE_ORDER=PCI_BUS_ID` added to the three GPU services of
`docker-configurations/services/tts-multi/docker-compose.yml`:

- `tts-qwen` — the measured case (vLLM-Omni), full comment incl. the UUID
  constraint: `CUDA_VISIBLE_DEVICES` must stay an integer index (the app
  int()s it; a UUID breaks startup with `ValueError`).
- `tts-kokoro`, `tts-tada` — same mechanism, same `*_GPU_ID:-1` intent
  (nvidia-smi index 1); the env is order-only, no behavior change if a
  service's enumeration already matched.

## Validation

- `yaml.safe_load` parses the file; all 3 services carry the env pair
  `CUDA_DEVICE_ORDER` + `CUDA_VISIBLE_DEVICES` in their environment list.
- Live before/after measurement performed on tts-qwen during #11624
  (GPU1 9000 MiB / GPU0 266 MiB after the fix) — this PR just persists it.

No catalog files touched. Audio/docker stacks unmodified otherwise.

See #11624 (infra follow-up of PR #11646)

Generated with [Claude Code](https://claude.com/claude-code)