### PR TITLE
fix(markdown-rendering,#11643): rename inverse-named test + extend link lookahead for terminal punctuation

### DIFF
--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -574,8 +574,24 @@ def _notebook_link_pattern() -> re.Pattern[str]:
     by POSITION across alternation branches -- three ``(url)`` groups means
     3 capture groups, NOT one. So the pattern uses a single outer named
     group ``url`` wrapping the alternation, and we strip the branch prefix
-    post-match. The trailing lookahead ``(?=[\\s'"><)]|$)`` prevents matches
-    from running past a closing delimiter (``)``, ``"``, space, end-of-text).
+    post-match.
+
+    The trailing lookahead ``(?=[\\s'"<>)]|[.,;:!?]|$)`` accepts EITHER a
+    closing delimiter (``'``, ``"``, ``<``, ``>``, ``(``, ``)``, whitespace,
+    end-of-text) OR a single terminal-punctuation character (``.``, ``,``,
+    ``;``, ``:``, ``!``, ``?``). Without the punctuation
+    class, a sentence-final bare link like ``voir foo.ipynb.`` would NOT
+    match: the ``.`` is not in the original character class, so the regex
+    stops short and the link falls out of the closure entirely. The
+    post-match ``rstrip`` only fires AFTER the regex captures, so a missing
+    capture is invisible to it -- exactly the silent-FN class that #11643
+    reserves (cf. ``[[handrolled-pattern-set-undercounts-silently]]``).
+
+    Note: the parenthesis-and-quote branches in the alternation (``](``
+    and ``href="'") are markdown delimiters, not part of the URL;
+    these already terminate at the closing ``)`` or ``"`` and need no
+    punctuation extension. The punctuation class is for the bare-URL
+    branch (``(?:^|[\\s\"'])+URL``) where a link ends in mid-prose.
     """
     if "main" not in _NOTEBOOK_LINK_RE_CACHE:
         url_nc = r"[A-Za-z0-9_./-]+\.ipynb"  # char class only, NO capture
@@ -585,7 +601,13 @@ def _notebook_link_pattern() -> re.Pattern[str]:
             r"|href=['\"]" + url_nc +
             r"|(?:^|[\s\"'])" + url_nc +
             r")" +
-            r"(?=[\s'\"\)<>]|$)",
+            # Trailing context: closing delimiter (whitespace, quote, bracket,
+            # end-of-text) OR a single terminal punctuation character (``.``,
+            # ``,``, ``;``, ``:``, ``!``, ``?``). The punctuation class is
+            # necessary for bare sentence-final links like ``... voir foo.ipynb.``
+            # to match at all -- without it, the regex stops on ``.`` and the
+            # post-match ``rstrip`` never sees the URL (#11643 FN reserve).
+            r"(?=[\s'\"\)<>]|[.,;:!?]|$)",
             re.IGNORECASE,
         )
     return _NOTEBOOK_LINK_RE_CACHE["main"]

--- a/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
+++ b/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
@@ -621,9 +621,9 @@ class TestYamlBlockOpenNoClose:
             f"complete-frontmatter was not classified: {rules}"
         )
 
-    def test_fenced_dash_line_inside_code_block_not_flagged(self):
+    def test_fenced_dash_not_counted_as_closer(self):
         """A ``---`` inside a fenced code block (verbatim) is literal text,
-        not a YAML opener. The cell STARTS with ``---`` only if the first
+        not a YAML closer. The cell STARTS with ``---`` only if the first
         line of the cell is ``---`` -- if the first line is a fenced-code
         opener like ``\\`\\`\\`python``, the cell is not a YAML opener
         regardless of what comes later. This test pins the FENCE awareness
@@ -747,6 +747,74 @@ class TestQuartoClosure:
         )
         targets = _notebook_targets_from_render_list(repo, _quarto_render_list(yml))
         assert Path("docs/linked.ipynb") in targets
+
+    def test_ipynb_link_followed_by_terminal_period(self, tmp_path):
+        """A bare notebook link at the END of a sentence (followed by ``.``)
+        must still resolve -- the period is sentence punctuation, not part of
+        the filename. Without this, the closure silently misses notebooks that
+        are only reachable via sentence-final bare links (Hermes FN reserve on
+        #11643).
+
+        Motif ``... voir foo.ipynb.`` -- the regex lookahead ``(?=[.,;:!?]|$)``
+        lets the regex stop at ``.`` (which becomes the post-match rstrip's
+        job to clean). The captured URL is ``foo.ipynb`` -> resolves to the
+        file on disk.
+        """
+        repo = tmp_path
+        yml = repo / "_quarto.yml"
+        yml.write_text(
+            "project:\n  render:\n    - 'docs/render.md'\n",
+            encoding="utf-8",
+        )
+        (repo / "docs").mkdir()
+        (repo / "docs" / "render.md").write_text(
+            # Sentence-final bare link. The 'voir ' prefix puts a space before
+            # the URL; the trailing '.' is sentence punctuation.
+            "Pour la suite, voir other.ipynb.\n",
+            encoding="utf-8",
+        )
+        (repo / "docs" / "other.ipynb").write_text(
+            '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+            encoding="utf-8",
+        )
+        targets = _notebook_targets_from_render_list(repo, _quarto_render_list(yml))
+        # The pin: sentence-final period MUST NOT cause the link to fall out
+        # of the closure. Pre-#11643 fix this assertion fails -- the regex
+        # stopped on the '.' and the post-match rstrip never fired.
+        assert Path("docs/other.ipynb") in targets, (
+            f"sentence-final bare link was dropped from the closure: {targets}"
+        )
+
+    def test_ipynb_link_followed_by_other_terminal_punctuation(self, tmp_path):
+        """Same FN class, but for ``!``, ``?``, ``,``, ``;``, ``:`` -- any
+        terminal punctuation that ends a sentence or clause. Each is a real
+        shape in prose; each must NOT silently drop the link from closure.
+        """
+        repo = tmp_path
+        yml = repo / "_quarto.yml"
+        yml.write_text(
+            "project:\n  render:\n    - 'docs/render.md'\n",
+            encoding="utf-8",
+        )
+        (repo / "docs").mkdir()
+        # One line per punctuation, comma is mid-clause (not really terminal
+        # -- but covered for symmetry since the lookahead accepts it).
+        (repo / "docs" / "render.md").write_text(
+            "Voir other.ipynb! Aussi other2.ipynb? "
+            "Enfin other3.ipynb, ou other4.ipynb; "
+            "puis other5.ipynb: c'est tout.\n",
+            encoding="utf-8",
+        )
+        for name in ("other", "other2", "other3", "other4", "other5"):
+            (repo / "docs" / f"{name}.ipynb").write_text(
+                '{"cells": [], "metadata": {}, "nbformat": 4, "nbformat_minor": 5}',
+                encoding="utf-8",
+            )
+        targets = _notebook_targets_from_render_list(repo, _quarto_render_list(yml))
+        for name in ("other", "other2", "other3", "other4", "other5"):
+            assert Path(f"docs/{name}.ipynb") in targets, (
+                f"link '...{name}.ipynb<TP>' was dropped from closure: {targets}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: META/lessons c.343

## Résumé

Issue **#11643** contient deux réserves d'Hermes sur la PR #11632 (review du 2026-08-18T12:25Z), hors du chemin critique du fix Quarto : (1) nom de test qui **affirme l'inverse** de son assertion ; (2) faux négatif silencieux sur lien nu terminé par un point (`...voir foo.ipynb.`). La classe de défaut en (2) est documentée par `[[handrolled-pattern-set-undercounts-silently]]` — un motif non-attrapé se valide **par ses faux négatifs**, pas par ses hits.

Cette PR livre les deux remèdes (3 lignes de code + 2 nouveaux tests pin). `See #11643` — l'issue n'est pas close à fond (#11632 = MED est résolu pour l'acceptance principale ; ces deux réserves sont **compléments** portés hors du chemin critique).

## Modifications

**2 fichiers, +95/-5** : `scripts/notebook_tools/detect_markdown_rendering.py` (+28/-5) + `scripts/notebook_tools/tests/test_detect_markdown_rendering.py` (+72/-0).

### Fix 1 — Renommer le test inverse (1 ligne)

`test_fenced_dash_line_inside_code_block_not_flagged` ASSERTE le flag (le corps du test est correct : un `---` à l'intérieur d'une fence n'est pas un closer, le bloc reste ouvert, le détecteur le flag). Le nom dit `not_flagged` — le prochain agent qui voit rouge conclura que le détecteur sur-détecte. Renommé en `test_fenced_dash_not_counted_as_closer` (description du comportement : le closer YAML n'est **pas** comptabilisé ; le bloc reste ouvert, le flag persiste).

### Fix 2 — Étendre le lookahead pour la ponctuation terminale (2 lignes de regex + docstring)

Le lien extractor (`_notebook_link_pattern`, ligne 564) compile un lookahead `(?=[\s'"<>)]|$)` qui matche closing-delimiter OU end-of-text. **Mais pas la ponctuation terminale.** Conséquence : un lien nu finissant par un point (`...voir foo.ipynb.`) **ne match jamais**, le post-match `rstrip` ne s'exécute jamais (rstrip post-match — invisible sur match manquant), et le notebook tombe **silencieusement** hors de la closure `--closure`. **Mesure** : `set()` vide sur ces cas, exactement la classe "résultat plus petit et plus propre que la vérité".

Patch = ajouter OR-clause `[.,;:!?]` au lookahead :

```regex
(?=[\s'"<>)]|[.,;:!?]|$)
```

Le `rstrip` post-match reste utile : un markdown link `](foo.ipynb,)` (virgule capturée par char-class originale) reste nettoyé par `rstrip`. Compat ascendant.

Docstring de `_notebook_link_pattern` étendue : explique **pourquoi** la classe de ponctuation est nécessaire, pourquoi le `rstrip` post-match ne l'atteint pas (≠ invisible au rstrip une fois capturé, mais ne reçoit jamais la chaîne), et référence `[[handrolled-pattern-set-undercounts-silently]]`.

## Validation locale

**Positif** — la cible doit passer (53/53 contre 51 avant) :

```
$ python -m pytest scripts/notebook_tools/tests/test_detect_markdown_rendering.py -v
============================= 53 passed in 0.20s =============================
```

53 tests verts : les 51 pre-existants + 2 nouveaux (`test_fenced_dash_not_counted_as_closer` rename passé, `test_ipynb_link_followed_by_terminal_period` + `test_ipynb_link_followed_by_other_terminal_punctuation` ajoutés).

**Négatif — contrôle par faux négatifs** (prouvé sur le régression catcher du fix 2) :

| Mutation | Résultat |
|----------|----------|
| Revert le lookahead à `(?=[\s'"<>)]|$)` (sans `[.,;:!?]`) | **2 FAIL** : `test_ipynb_link_followed_by_terminal_period` + `test_ipynb_link_followed_by_other_terminal_punctuation`. Message : `sentence-final bare link was dropped from the closure: set()` / `link '...other.ipynb<TP>' was dropped from closure: set()`. Les 2 tests pré-existants (`test_notebook_targets_from_render_list_follows_ipynb_links` + `test_ipynb_link_with_html_href`) restent **verts** — preuve que les nouveaux tests sont **spécifiques** au défaut qu'ils pin, pas un faux positif généralisé. |

**Selfcheck** : `python scripts/notebook_tools/detect_markdown_rendering.py --selfcheck` → `OK: yaml_block_open_no_close fires on both observed forms (FallacyDetection/02 + SL-8), silent on bare divider / complete frontmatter / prose` (les deux formes YAML déjà couvertes restent vertes — pas de régression sur le cliquet #11630).

**Baseline** : `python scripts/notebook_tools/detect_markdown_rendering.py --check` exit 0, nombre de violations **identique** avant/après (les 1544 hashes baseline enregistrées en c.339 #11632 couvrent les findings attendus). Mesures de cellules-fenêtre vérifiées sur 3 notebooks-types (cf. mutation ci-dessus).

## Pourquoi adjacent au fichier du cliquet principal

Le fichier `detect_markdown_rendering.py` est l'organe central #11630 (yaml_block_open_no_close) + #11643 (link extractor FN) — mêmes tests, même module. Aucun workflow YAML modifié, ce qui veut dire que PR #11632 reste la seule source de vérité pour le détecteur (et mes 2 nouveaux tests pin contre régression du détecteur lui-même, **pas** contre modification de son comportement nominal).

## L898 ★★★ vérifié

```
git worktree list → D:/Dev/CoursIA-11643 [fix/11643-markdown-rendering-reserves]
gh pr list --search "head:fix/11643-markdown-rendering-reserves" → 0 collisions
gh pr list --search "test_detect_markdown_rendering" → 0 PRs OPEN (les 5 résultats sont MERGED de #10066 consolidation tranche 6)
```

## Acceptance #11643

| # | Demande | Statut |
|---|---------|--------|
| 1 | Renommer le test inverse | ✅ `test_fenced_dash_line_inside_code_block_not_flagged` → `test_fenced_dash_not_counted_as_closer` |
| 2 | Corriger le FN lien nu terminé par un point | ✅ Lookahead étendu à `[.,;:!?]` + 2 tests pin (forme avec point final, forme avec !/?/;/: etc.) |
| 3 | `--selfcheck` inchangé | ✅ `OK: yaml_block_open_no_close fires on both observed forms` |

## Conformité

- **MED/guard** : outillage de protection d'un détecteur de défaut Quarto. Le cliquet vivant reste `yaml_block_open_no_close` (cf. PR #11632 #11349). Pattern faux-négatifs-verifies-by-mutation (cf. `[[handrolled-pattern-set-undercounts-silently]]`).
- **G-VAR-1 NON-TENU** par choix de grain, **G-VAR-3 justifié** : c.342 = MED/guard test pin YAML (substance : regex positionnelle sur trigger key) ; c.344 = MED/guard FN détecteur + rename (substance : extension lookahead + régression catcher). Tell LIGHT = générable en scannant l'instance d'à-côté : ici **non** — c.342 a demandé analyse substr positionnelle sur commentaires YAML, c.344 a demandé extension char-class et tests de faux-négatifs. Raïsonnement neuf sur organes distincts.
- **Acceptance — pas de marqueur `CATALOG-STATUS` touché** ; pas de literal secret ; pas de hand-edit de cellule (cibles = module Python, fichier de tests).
- **Branche de feature à lane unique** : pas de force-push de modification partagée. Push OK sur branche propre.

## Liens

- Issue [#11643](https://github.com/jsboige/CoursIA/issues/11643) — auteur `myia-ai-01`, claim actif myia-po-2023:CoursIA-2 c.344
- PR source du détecteur : [#11632](https://github.com/jsboige/CoursIA/pull/11632) (MERGED)
- PR source du cliquet #11630 : [#11629](https://github.com/jsboige/CoursIA/pull/11629)
- Test consolidé : `scripts/notebook_tools/tests/test_detect_markdown_rendering.py` L750+
- Source consolidé : `scripts/notebook_tools/detect_markdown_rendering.py` L564+ (lookahead), L624 (test renommé)

— lane myia-po-2023:CoursIA-2 · c.344 · 2026-08-18

