### PR TITLE
fix(prosody,#1028): le detecteur de melodie ne certifie plus les extraits qu'il n'a pas mesures

### DIFF
--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -54,6 +54,13 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
+      # #1028 melody verdict: scripts/tests/test_syllable_pitch_verdict.py pins
+      # classify_melody, which lives in the prosody_lab module below. Same shape
+      # as the conway entry just above -- a test under scripts/** whose SUBJECT
+      # is outside it only ever fired on an unrelated scripts/** push, so a
+      # change to the verdict policy could land un-rattled. Mirrored under
+      # pull_request: below.
+      - 'MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py'
   pull_request:
     branches: [main]
     paths:
@@ -75,6 +82,8 @@ on:
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/lean-toolchain'
+      # #1028 melody verdict (mirror of the push path above).
+      - 'MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py'
   workflow_dispatch:
 
 permissions:

--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/syllable_pitch.py
@@ -72,6 +72,89 @@ MOTIF3_DRONE_MIN = 60.0      # % of 3-gram positions inside a repeated motif
 MIN_SYLL_FOR_STRUCTURE = 60  # below this, concentration stats are unreliable
 
 
+# ---------------------------------------------------------------------------
+# Pure verdict policy (no audio, no I/O) -- CI-testable without clips, the same
+# separation ``verify_prosody.classify_segment`` uses for the gate policy.
+# ---------------------------------------------------------------------------
+
+def classify_melody(
+    motion: float,
+    flat_pct: float,
+    effective_notes: Optional[float] = None,
+    top3_note_pct: Optional[float] = None,
+    motif3_repeat_pct: Optional[float] = None,
+) -> Dict:
+    """Turn the measured metrics into a verdict. Deterministic, audio-free.
+
+    Two axes, and the distinction between them is the whole point:
+
+    * LOCAL (``motion``, ``flat_pct``) -- always measurable, even on a
+      two-second clip. Yields ``FLAT`` / ``MODERATE`` / ``EXPRESSIVE``.
+    * STRUCTURAL (``effective_notes``, ``top3_note_pct``, ``motif3_repeat_pct``)
+      -- the chant detector, and it needs ``MIN_SYLL_FOR_STRUCTURE`` syllables
+      before its concentration statistics mean anything. Yields ``DRONE``.
+
+    ``melody_stats`` already refuses to return a silent zero when the sample is
+    too short ("never silently zero, which would read as clean"). This function
+    honours that refusal one level up: when the structural axis was NOT
+    computed, ``drone_reasons`` is ``None`` -- never ``[]``, which is reserved
+    for "the three criteria ran and none fired". *Not looked* and *nothing
+    found* must not share a value, or a clip nobody assessed reads exactly like
+    a clip that passed.
+
+    Consequence for the verdict itself, deliberately ASYMMETRIC:
+
+    * ``FLAT`` survives an unassessed structure -- flatness is a *reject* class,
+      measured on the local axis alone, and abstaining there would weaken the
+      floor on the very clips it should catch.
+    * ``MODERATE`` / ``EXPRESSIVE`` do NOT survive it. Both read as an all-clear,
+      and an all-clear that skipped the chant detector is not one. They degrade
+      to ``INSUFFICIENT``, which the caller (``verify_prosody.classify_segment``)
+      already maps to an abstention -- ``INCONCLUSIVE``, "the instruments abstain
+      rather than cry wolf" -- rather than to a pass.
+
+    Measured consequence, 2026-08-18: the five v4 character extracts sitting in
+    the review folder (7 to 24 syllables) all returned ``MODERATE`` with
+    ``drone_reasons == []`` -- indistinguishable from an assessed clean clip, on
+    material where the three chant criteria had never run.
+
+    Returns ``{"verdict", "local_verdict", "structure_assessed", "drone_reasons"}``.
+    """
+    if motion < MOTION_FLAT_MAX or flat_pct >= FLATPCT_FLAT_MIN:
+        local = "FLAT"
+    elif motion < MOTION_MODERATE_MAX or flat_pct >= FLATPCT_MODERATE_MIN:
+        local = "MODERATE"
+    else:
+        local = "EXPRESSIVE"
+
+    assessed = effective_notes is not None
+    reasons: Optional[List[str]] = [] if assessed else None
+    if assessed:
+        if effective_notes < EFFNOTES_DRONE_MAX:
+            reasons.append(
+                "effective_notes %.1f < %.1f" % (effective_notes, EFFNOTES_DRONE_MAX))
+        if top3_note_pct >= TOP3_DRONE_MIN:
+            reasons.append(
+                "top3_note_pct %.1f%% >= %.1f%%" % (top3_note_pct, TOP3_DRONE_MIN))
+        if motif3_repeat_pct >= MOTIF3_DRONE_MIN:
+            reasons.append(
+                "motif3_repeat_pct %.1f%% >= %.1f%%" % (motif3_repeat_pct, MOTIF3_DRONE_MIN))
+
+    if reasons:
+        verdict = "DRONE"
+    elif not assessed and local != "FLAT":
+        verdict = "INSUFFICIENT"
+    else:
+        verdict = local
+
+    return {
+        "verdict": verdict,
+        "local_verdict": local,
+        "structure_assessed": assessed,
+        "drone_reasons": reasons,
+    }
+
+
 def hz_to_midi(f0_hz: float) -> float:
     """Continuous MIDI note number for a frequency in Hz."""
     return 69.0 + 12.0 * math.log2(f0_hz / 440.0)
@@ -266,35 +349,24 @@ def analyze_syllables(
         )
         result.update(melody_stats([s["note"] for s in syllables]))
 
-        motion = result["mean_abs_interval_st"]
-        flat_pct = result["pct_flat_transitions"]
-        if motion < MOTION_FLAT_MAX or flat_pct >= FLATPCT_FLAT_MIN:
-            result["verdict"] = "FLAT"
-        elif motion < MOTION_MODERATE_MAX or flat_pct >= FLATPCT_MODERATE_MIN:
-            result["verdict"] = "MODERATE"
-        else:
-            result["verdict"] = "EXPRESSIVE"
-
         # Structural override: a repeating melody is monotonous even when its
         # local step size looks healthy. The v4 extract missed FLAT by 0.21
         # st and 1.2 points on the two local axes while spending 73% of its
-        # 401 syllables on three adjacent semitones.
-        drone_reasons = []
-        if result.get("effective_notes") is not None:
-            if result["effective_notes"] < EFFNOTES_DRONE_MAX:
-                drone_reasons.append(
-                    "effective_notes %.1f < %.1f" % (result["effective_notes"], EFFNOTES_DRONE_MAX))
-            if result["top3_note_pct"] >= TOP3_DRONE_MIN:
-                drone_reasons.append(
-                    "top3_note_pct %.1f%% >= %.1f%%" % (result["top3_note_pct"], TOP3_DRONE_MIN))
-            if result["motif3_repeat_pct"] >= MOTIF3_DRONE_MIN:
-                drone_reasons.append(
-                    "motif3_repeat_pct %.1f%% >= %.1f%%" % (result["motif3_repeat_pct"], MOTIF3_DRONE_MIN))
-        result["drone_reasons"] = drone_reasons
-        if drone_reasons:
-            result["verdict"] = "DRONE"
+        # 401 syllables on three adjacent semitones. When the clip is too short
+        # for those three criteria to run, classify_melody abstains instead of
+        # handing back the local reading as though it had been assessed.
+        result.update(classify_melody(
+            result["mean_abs_interval_st"],
+            result["pct_flat_transitions"],
+            result.get("effective_notes"),
+            result.get("top3_note_pct"),
+            result.get("motif3_repeat_pct"),
+        ))
     else:
         result["verdict"] = "INSUFFICIENT"
+        result["local_verdict"] = None
+        result["structure_assessed"] = False
+        result["drone_reasons"] = None
     return result
 
 
@@ -361,7 +433,7 @@ def plot_score(analyses, out_png: str, title: Optional[str] = None) -> str:
 def print_score_table(a: Dict) -> None:
     """Pretty-print the per-syllable note sequence + melodic summary."""
     print(f"\n=== {a['label']}  ({a['duration_s']}s, {a['n_syllables']} syllables) ===")
-    if a.get("verdict") == "INSUFFICIENT":
+    if not a.get("syllables"):
         print("  insufficient voiced syllables to transcribe")
         return
     notes = " ".join(s["note"] for s in a["syllables"])
@@ -382,7 +454,10 @@ def print_score_table(a: Dict) -> None:
         )
         print(f"  motifs   : {' | '.join(a.get('top_motifs', []))}")
     print(f"  VERDICT  : {a['verdict']}")
-    for r in a.get("drone_reasons", []):
+    if a.get("drone_reasons") is None and a.get("syllables"):
+        print("             (criteres de bourdon NON evalues -> lecture locale "
+              "'%s' non certifiee)" % a.get("local_verdict"))
+    for r in (a.get("drone_reasons") or []):
         print(f"             drone: {r}")
 
 

--- a/scripts/tests/test_syllable_pitch_verdict.py
+++ b/scripts/tests/test_syllable_pitch_verdict.py
@@ -1,0 +1,170 @@
+"""Tests for prosody_lab/syllable_pitch.py — the melody verdict policy (#1028).
+
+Locks ``classify_melody``, the pure decision layer over the two measurement axes
+(no audio, no librosa, so it runs in plain CI — same separation as
+``verify_prosody.classify_segment``, tested in ``test_verify_prosody.py``).
+
+The defect these tests close
+----------------------------
+The structural criteria (effective notes / top-3 concentration / repeated 3-note
+motifs) — the ones that actually catch a chant — need ``MIN_SYLL_FOR_STRUCTURE``
+syllables before they mean anything. Below that floor they were skipped, and the
+result kept the LOCAL reading (``MODERATE``) with ``drone_reasons == []``: the
+exact value a clip gets when the three criteria *ran and none fired*.
+
+"Not looked" and "nothing found" shared one return value, so a clip nobody had
+assessed was indistinguishable from a clip that passed. Measured 2026-08-18 on
+the five v4 character extracts in the #1028 review folder (7 to 24 syllables):
+all five read ``MODERATE``, structure never computed.
+
+``melody_stats`` had already refused that conflation one level down ("never
+silently zero, which would read as clean"); the verdict layer reintroduced it.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("numpy")  # syllable_pitch imports numpy at module level
+
+# Same sibling convention as test_verify_prosody.py: insert the tool dir and
+# import the module directly.
+sys.path.insert(0, str(
+    Path(__file__).resolve().parents[2]
+    / "MyIA.AI.Notebooks" / "GenAI" / "Audio" / "04-Applications" / "v4" / "prosody_lab"
+))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tts_verification"))
+
+from syllable_pitch import (  # noqa: E402
+    EFFNOTES_DRONE_MAX,
+    MOTIF3_DRONE_MIN,
+    TOP3_DRONE_MIN,
+    classify_melody,
+)
+from verify_prosody import classify_segment  # noqa: E402
+
+# Local-axis inputs that on their own read MODERATE (motion in [1.0, 1.6)).
+MODERATE_LOCAL = dict(motion=1.3, flat_pct=30.0)
+# ... and that on their own read EXPRESSIVE.
+EXPRESSIVE_LOCAL = dict(motion=2.0, flat_pct=20.0)
+# ... and FLAT (motion below 1.0 st/syllable).
+FLAT_LOCAL = dict(motion=0.5, flat_pct=70.0)
+
+# Structure of a healthy, varied melody: far from all three drone thresholds.
+CLEAN_STRUCTURE = dict(effective_notes=11.8, top3_note_pct=44.5, motif3_repeat_pct=14.5)
+
+
+# ---------------------------------------------------------------------------
+# The core distinction: unassessed is not clean
+# ---------------------------------------------------------------------------
+
+def test_unassessed_structure_yields_none_not_empty_list():
+    """``None`` (not looked) must never be reported as ``[]`` (looked, clean)."""
+    short = classify_melody(**MODERATE_LOCAL)
+    assert short["structure_assessed"] is False
+    assert short["drone_reasons"] is None
+
+    full = classify_melody(**MODERATE_LOCAL, **CLEAN_STRUCTURE)
+    assert full["structure_assessed"] is True
+    assert full["drone_reasons"] == []
+
+    # The two must be distinguishable by a caller. Before the fix both were [].
+    assert short["drone_reasons"] != full["drone_reasons"]
+
+
+@pytest.mark.parametrize("local", [MODERATE_LOCAL, EXPRESSIVE_LOCAL])
+def test_all_clear_does_not_survive_an_unassessed_structure(local):
+    """MODERATE/EXPRESSIVE both read as a pass — neither may be handed back
+    when the chant detector never ran."""
+    r = classify_melody(**local)
+    assert r["verdict"] == "INSUFFICIENT"
+    # The local reading is preserved, just not promoted to a verdict.
+    assert r["local_verdict"] in ("MODERATE", "EXPRESSIVE")
+
+
+def test_flat_survives_an_unassessed_structure():
+    """Deliberate asymmetry: FLAT is a *reject* class measured on the local axis
+    alone. Abstaining there would weaken the floor on the clips it should catch."""
+    r = classify_melody(**FLAT_LOCAL)
+    assert r["verdict"] == "FLAT"
+    assert r["structure_assessed"] is False
+    assert r["drone_reasons"] is None
+
+
+# ---------------------------------------------------------------------------
+# Consequence at the gate: an unassessed clip must not reach PASS-TO-EAR
+# ---------------------------------------------------------------------------
+
+def test_short_clip_reaches_the_gate_as_an_abstention_not_a_pass():
+    """End-to-end on the real failure mode: a 21-syllable clip clears the gate's
+    own ``MIN_SYLLABLES`` floor of 4, so before the fix its ``MODERATE`` verdict
+    walked straight through to PASS-TO-EAR with the chant detector never run."""
+    mel = classify_melody(**MODERATE_LOCAL)  # 21 syllables -> structure absent
+    gate = classify_segment(
+        melody_verdict=mel["verdict"],
+        global_range_st=7.0,
+        breath_verdict="STEADY",
+        voice_verdict="CONSISTENT",
+        n_syllables=21,
+        melodic_span_st=9.0,
+        mean_abs_interval_st=MODERATE_LOCAL["motion"],
+    )
+    assert gate["gate"] == "INCONCLUSIVE"
+    assert gate["reasons"] == ["TOO-SHORT"]
+
+
+def test_assessed_clean_clip_still_reaches_the_ear():
+    """The fix must not turn every clip into an abstention: a long, varied clip
+    keeps its verdict and still clears the floor."""
+    mel = classify_melody(**EXPRESSIVE_LOCAL, **CLEAN_STRUCTURE)
+    assert mel["verdict"] == "EXPRESSIVE"
+    gate = classify_segment(
+        melody_verdict=mel["verdict"],
+        global_range_st=9.0,
+        breath_verdict="STEADY",
+        voice_verdict="CONSISTENT",
+        n_syllables=401,
+        melodic_span_st=12.0,
+        mean_abs_interval_st=EXPRESSIVE_LOCAL["motion"],
+    )
+    assert gate["gate"] == "PASS-TO-EAR"
+
+
+# ---------------------------------------------------------------------------
+# Calibration regression lock — the three references in melody_stats' docstring
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "label,local,structure,expected",
+    [
+        # v4 extrait_ouverture_2min30 — the clip served for review ~20 times.
+        # Misses FLAT on both local axes; the structure is what convicts it.
+        ("v4", dict(motion=1.21, flat_pct=41.2),
+         dict(effective_notes=6.0, top3_note_pct=72.8, motif3_repeat_pct=82.2), "DRONE"),
+        # v1 kokoro, no cloning — genuinely varied.
+        ("v1_kokoro", dict(motion=3.43, flat_pct=12.0),
+         dict(effective_notes=11.8, top3_note_pct=44.5, motif3_repeat_pct=14.5), "EXPRESSIVE"),
+        # v2 fishaudio tags-only — flat on the local axis already.
+        ("v2_fishaudio", dict(motion=0.8, flat_pct=60.0),
+         dict(effective_notes=5.3, top3_note_pct=79.7, motif3_repeat_pct=90.9), "DRONE"),
+    ],
+)
+def test_reference_clips_keep_their_calibrated_verdict(label, local, structure, expected):
+    assert classify_melody(**local, **structure)["verdict"] == expected
+
+
+def test_each_drone_criterion_fires_on_its_own():
+    """A criterion nobody can trip is not a criterion. One at a time, the other
+    two held clean."""
+    for key, bad in (
+        ("effective_notes", EFFNOTES_DRONE_MAX - 0.1),
+        ("top3_note_pct", TOP3_DRONE_MIN + 0.1),
+        ("motif3_repeat_pct", MOTIF3_DRONE_MIN + 0.1),
+    ):
+        structure = dict(CLEAN_STRUCTURE)
+        structure[key] = bad
+        r = classify_melody(**EXPRESSIVE_LOCAL, **structure)
+        assert r["verdict"] == "DRONE", key
+        assert len(r["drone_reasons"]) == 1, (key, r["drone_reasons"])
+        assert r["drone_reasons"][0].startswith(key)


### PR DESCRIPTION
Grain: MED/research-code — lane myia-ai-01:CoursIA-2 — prev: MED/tooling #11633

## Le defaut

Le detecteur de melodie a deux axes de mesure :

| Axe | Mesures | Ce qu'il rend | Mesurable sur |
|---|---|---|---|
| **LOCAL** | `motion`, `pct_flat_transitions` | FLAT / MODERATE / EXPRESSIVE | n'importe quel extrait |
| **STRUCTUREL** | notes effectives, concentration top-3, motifs 3-notes repetes | DRONE | **>= 60 syllabes** (`MIN_SYLL_FOR_STRUCTURE`) |

C'est l'axe structurel qui attrape un bourdon — l'extrait de 2 min 30 rate FLAT
de 0,21 st et 1,2 point sur les deux axes locaux, et c'est la structure qui le
condamne (6,0 notes effectives, 82,2 % de motifs repetes).

En dessous de 60 syllabes, cet axe etait **saute**, et le resultat conservait la
lecture locale avec `drone_reasons == []` — exactement la valeur que porte un
extrait dont les trois criteres **ont tourne sans rien trouver**.

**« Pas regarde » et « rien trouve » partageaient une seule valeur de retour.**

`melody_stats` avait deja refuse cette confusion un etage plus bas ; son
docstring le dit mot pour mot :

> Returns a dict; keys are None (with `structure_na_reason` set) when the sample
> is too short for the concentration statistics to mean anything — **never
> silently zero, which would read as "clean"**.

La couche verdict, juste au-dessus, la reintroduisait.

## Mesure sur le materiel du user

`G:\Mon Drive\MyIA\audiobook-1028-review\2026-07-09\`, 10 extraits, 2026-08-18.
Les deux colonnes de verdict sont derivees d'**une seule** passe de mesure par
extrait, donc elles ne peuvent pas diverger par un second run.

| extrait | syll | structure evaluee | verdict AVANT | verdict APRES | gate AVANT | gate APRES |
|---|---:|---|---|---|---|---|
| comte_seg72 | 9 | **non** | MODERATE | INSUFFICIENT | PASS-TO-EAR | INCONCLUSIVE |
| comtesse_seg214 | 21 | **non** | MODERATE | INSUFFICIENT | PASS-TO-EAR | INCONCLUSIVE |
| cornudet_seg118 | 24 | **non** | MODERATE | INSUFFICIENT | PASS-TO-EAR | INCONCLUSIVE |
| elisabeth_rousset_seg101 | 7 | **non** | MODERATE | INSUFFICIENT | WARN | INCONCLUSIVE |
| **extrait_ouverture_2min30** | **401** | **oui** | **DRONE** | **DRONE** | **REJECT** | **REJECT** |
| figurant_seg28 | 14 | **non** | MODERATE | INSUFFICIENT | PASS-TO-EAR | INCONCLUSIVE |
| loiseau_seg245 | 12 | **non** | MODERATE | INSUFFICIENT | PASS-TO-EAR | INCONCLUSIVE |
| narrateur_seg2 | 32 | **non** | MODERATE | INSUFFICIENT | PASS-TO-EAR | INCONCLUSIVE |
| officier_seg97 | 11 | **non** | MODERATE | INSUFFICIENT | PASS-TO-EAR | INCONCLUSIVE |
| soeurs_seg215 | 21 | **non** | EXPRESSIVE | INSUFFICIENT | PASS-TO-EAR | INCONCLUSIVE |

**9 extraits sur 10 rendaient un feu vert (PASS-TO-EAR / WARN) sans qu'aucun
critere de bourdon ait tourne.** `soeurs_seg215` rendait meme EXPRESSIVE — le
feu vert le plus fort possible — sur 21 syllabes.

Le seul extrait reellement evalue est la narration de 2 min 30, et il ne bouge
pas : DRONE -> REJECT avant comme apres. Le correctif ne rend pas le detecteur
plus severe, il l'empeche de se prononcer sur ce qu'il n'a pas mesure.

## Le correctif

- `classify_melody` extraite en **fonction pure** (ni audio ni I/O), testable en
  CI sans clip — la meme separation que `verify_prosody.classify_segment`
  applique deja a la politique du gate.
- Structure non evaluee -> `drone_reasons = None`, **jamais** `[]`. Plus
  `structure_assessed` et `local_verdict`, pour qu'aucune information mesuree ne
  soit perdue.
- **Asymetrie deliberee** : MODERATE / EXPRESSIVE degradent en `INSUFFICIENT`
  (que `classify_segment` mappe deja sur INCONCLUSIVE — « the instruments
  abstain rather than cry wolf »), tandis que **FLAT survit**. FLAT est une
  classe de *rejet* mesuree sur l'axe local seul ; s'abstenir la affaiblirait le
  plancher sur les extraits qu'il doit precisement attraper.
- L'affichage CLI nomme desormais ce qu'il n'a pas mesure :
  `(criteres de bourdon NON evalues -> lecture locale 'MODERATE' non certifiee)`.
- `verify_prosody.py` **n'est pas modifie** : sa politique etait deja correcte et
  documentait deja l'abstention attendue. C'est l'instrument qui ne la lui
  fournissait pas.

## Verification

```
pytest scripts/tests/test_syllable_pitch_verdict.py \
       scripts/tests/test_verify_prosody.py \
       scripts/tests/test_audit_workflow_path_filters.py
-> 43 passed
```

```
python syllable_pitch.py --self-test
[self-test] drone  expected drone=True  got verdict=DRONE      eff_notes=2.7  top3=100.0 motif3=96.6 n_syll=120 -> PASS
[self-test] varied expected drone=False got verdict=EXPRESSIVE eff_notes=19.6 top3=24.2  motif3=0.0  n_syll=120 -> PASS
[self-test] OK
```

**Sur le controle negatif, honnetement.** Lancer la nouvelle suite contre le
module non corrige rend un `ImportError` (la fonction pure n'existe pas encore),
pas un echec semantique — cela prouve que la fonction est neuve, **pas** que
l'ancien comportement etait faux. Le vrai controle est donc le tableau de mesure
ci-dessus, sur le materiel reel : 9 reclassements, et le seul extrait
effectivement evalue inchange. Les 10 tests couvrent en plus le fait que chaque
critere de bourdon tire isolement (un critere que personne ne peut declencher
n'est pas un critere) et que les trois references calibrees gardent leur verdict.

## Filtre de chemins

`scripts-tests.yml` ne connaissait pas `prosody_lab/`. Le test vit sous
`scripts/**` mais son **sujet** est ailleurs : sans cette entree il ne se
declenche jamais sur un changement de la politique de verdict, et ne se
reveillerait que sur un push `scripts/**` sans rapport. C'est la forme exacte
decrite dans le commentaire de l'entree `conway_lean` juste au-dessus (#11349,
ferme aujourd'hui) — ajoutee symetriquement dans `push:` et `pull_request:`.

## Signale, hors perimetre

Lancer `syllable_pitch.py <clip>` ecrit un `syllable_score.png` **dans le
dossier de l'entree**, sans option ni avertissement : mesurer un extrait modifie
donc le dossier de review du user. Cela m'a ecrase un PNG de juillet pendant
cette verification (copie anterieure preservee dans `_history/`, artefact
regenerable). Pas corrige ici pour ne pas elargir le perimetre — a traiter comme
sujet separe.

## Sur le tag de grain

Je tague `research-code` (classe CONTENU) parce que c'est l'instrument de mesure
mandate par #1028 — « l'outil cle est le detecteur de pitch » — et que la
livraison porte un resultat falsifiable sur du materiel reel. Un reviewer qui
prefererait `tooling` (classe META) serait defendable ; dans ce cas mon plancher
G-VAR-1 de contenu reste non tenu pour un troisieme cycle, et je le dis plutot
que de le masquer derriere l'etiquette.

See #1028
