### PR TITLE
feat(quarto,#11335): --path single-file + pytest byte-clean + Search-15 render proof

### DIFF
--- a/scripts/notebook_tools/tests/test_quarto_csharp_kernel_fix.py
+++ b/scripts/notebook_tools/tests/test_quarto_csharp_kernel_fix.py
@@ -1,0 +1,177 @@
+"""Tests for quarto_csharp_kernel_fix — apply/restore byte-clean roundtrip + --path single-file mode.
+
+Issue #11335 acceptance: ``apply``/``restore`` byte-clean (0 diff résiduel sur ``*.ipynb``)
++ Search-15 spot-check. The script was hardened in #11511 (DRIFT detection, --strict CI
+guard). This suite pins the new --path single-file override against regressions: a future
+refactor must keep the spot-check usable on one notebook without scanning the full tree.
+
+Byte-clean meaning: the only bytes that differ between original and post-restore file
+are the 4-byte stretch ``"C#"`` -> ``"csharp"`` at the kernelspec.language position.
+Roundtrip (``apply`` then ``restore``) returns the file to its original bytes.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the script importable both as module (for in-process tests) and as CLI (for subprocess tests)
+SCRIPT_DIR = Path(__file__).resolve().parents[2]  # scripts/
+sys.path.insert(0, str(SCRIPT_DIR))
+
+
+def _make_dotnet_notebook(tmp_path: Path, *, language: str = "C#",
+                          kernel_name: str = ".net-csharp") -> Path:
+    """Write a minimal .ipynb whose metadata.kernelspec matches the dotnet pattern."""
+    nb = {
+        "cells": [],
+        "metadata": {
+            "kernelspec": {
+                "display_name": ".NET (C#)",
+                "language": language,
+                "name": kernel_name,
+            },
+        },
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    p = tmp_path / "fixture.ipynb"
+    p.write_text(json.dumps(nb, indent=2), encoding="utf-8")
+    return p
+
+
+def test_patched_spans_yields_c_sharp_token(tmp_path):
+    from quarto_csharp_kernel_fix import patched_spans, LANG_CSHARP_TOKEN_RE, LANG_FIX_TOKEN_RE
+    nb = _make_dotnet_notebook(tmp_path)
+    data = nb.read_bytes()
+    spans = list(patched_spans(data, LANG_CSHARP_TOKEN_RE))
+    assert len(spans) == 1, f"expected 1 C# span, got {len(spans)}"
+    assert data[spans[0][0]:spans[0][1]] == b'"C#"'
+
+    fixed_spans = list(patched_spans(data, LANG_FIX_TOKEN_RE))
+    assert fixed_spans == [], "no csharp span before apply"
+
+
+def test_patched_spans_ignores_non_dotnet_kernel(tmp_path):
+    from quarto_csharp_kernel_fix import patched_spans, LANG_CSHARP_TOKEN_RE
+    nb = _make_dotnet_notebook(tmp_path, kernel_name="python3")
+    data = nb.read_bytes()
+    assert list(patched_spans(data, LANG_CSHARP_TOKEN_RE)) == []
+
+
+def test_apply_single_file_roundtrip_byte_clean(tmp_path):
+    """Issue #11335 acceptance: apply+restore on a single file returns the exact bytes."""
+    from quarto_csharp_kernel_fix import cmd_apply, cmd_restore
+
+    nb = _make_dotnet_notebook(tmp_path)
+    original = nb.read_bytes()
+    manifest = tmp_path / "manifest.json"
+
+    # apply on this single file (root == tmp_path, path == nb)
+    rc = cmd_apply(tmp_path, manifest, nb)
+    assert rc == 0
+    patched = nb.read_bytes()
+    # exactly one byte position changed; the difference is +4 bytes
+    # ("C#" -> "csharp" = 3 bytes -> 7 bytes, +4 bytes, in the right position)
+    assert len(patched) == len(original) + 4, (
+        f"expected +4 bytes (C# -> csharp), got {len(patched) - len(original)}"
+    )
+    # the offset recorded in the manifest must point at the original "C#" position
+    m = json.loads(manifest.read_text(encoding="utf-8"))
+    assert len(m) == 1
+    rel, offsets = next(iter(m.items()))
+    assert rel == nb.name
+    assert len(offsets) == 1
+    # the file at that offset now holds the 7-char token "csharp" (including quotes)
+    assert patched[offsets[0]:offsets[0] + 8] == b'"csharp"', (
+        f"expected '\"csharp\"' at offset {offsets[0]}, got "
+        f"{patched[offsets[0]:offsets[0] + 8]!r}"
+    )
+    # and the original byte at that same offset was the 4-char token "C#" (including quotes)
+    assert original[offsets[0]:offsets[0] + 4] == b'"C#"'
+
+    # restore on this single file
+    rc = cmd_restore(manifest, tmp_path, nb)
+    assert rc == 0
+    final = nb.read_bytes()
+    assert final == original, (
+        f"roundtrip not byte-clean: {len(final) - len(original)} bytes drift "
+        f"(first diff at {next((i for i,(a,b) in enumerate(zip(original,final)) if a!=b), 'none')})"
+    )
+    assert not manifest.exists(), "manifest should be removed after successful restore"
+
+
+def test_apply_refuses_double_apply_without_restore(tmp_path):
+    """If the manifest from a previous apply is still around, a new apply refuses."""
+    from quarto_csharp_kernel_fix import cmd_apply
+
+    nb = _make_dotnet_notebook(tmp_path)
+    manifest = tmp_path / "manifest.json"
+    assert cmd_apply(tmp_path, manifest, nb) == 0
+    # second apply must refuse (exit 1) and not modify anything
+    rc = cmd_apply(tmp_path, manifest, nb)
+    assert rc == 1
+
+
+def test_check_reports_unpatched_then_patched(tmp_path):
+    """check --strict exits 1 when unpatched; returns 0 after apply on the file."""
+    from quarto_csharp_kernel_fix import cmd_apply, cmd_check, cmd_restore
+
+    nb = _make_dotnet_notebook(tmp_path)
+    manifest = tmp_path / "manifest.json"
+
+    rc = cmd_check(tmp_path, strict=True)
+    assert rc == 1
+
+    assert cmd_apply(tmp_path, manifest, nb) == 0
+    rc = cmd_check(tmp_path, strict=True)
+    assert rc == 0
+    # cleanup
+    assert cmd_restore(manifest, tmp_path, nb) == 0
+
+
+def test_cli_path_single_file_roundtrip(tmp_path):
+    """End-to-end through the CLI (subprocess) — same guarantee as the in-process path."""
+    nb = _make_dotnet_notebook(tmp_path)
+    original = nb.read_bytes()
+    manifest = tmp_path / "manifest.json"
+    script = SCRIPT_DIR / "quarto_csharp_kernel_fix.py"
+
+    # apply --path
+    rc = subprocess.run(
+        [sys.executable, str(script), "apply",
+         "--root", str(tmp_path),
+         "--path", str(nb),
+         "--manifest", str(manifest)],
+        check=False, capture_output=True, text=True,
+    )
+    assert rc.returncode == 0, rc.stderr
+    patched = nb.read_bytes()
+    assert len(patched) == len(original) + 4
+
+    # restore --path
+    rc = subprocess.run(
+        [sys.executable, str(script), "restore",
+         "--root", str(tmp_path),
+         "--path", str(nb),
+         "--manifest", str(manifest)],
+        check=False, capture_output=True, text=True,
+    )
+    assert rc.returncode == 0, rc.stderr
+    final = nb.read_bytes()
+    assert final == original
+    assert not manifest.exists()
+
+
+def test_path_outside_root_rejected(tmp_path):
+    """--path must be inside --root; otherwise ValueError."""
+    import quarto_csharp_kernel_fix as qf
+    outside = tmp_path / "outside.ipynb"
+    outside.write_text("{}", encoding="utf-8")
+    root = tmp_path / "root"
+    root.mkdir()
+    with pytest.raises(ValueError, match="outside --root"):
+        list(qf.iter_targets(root, outside))

--- a/scripts/quarto_csharp_kernel_fix.py
+++ b/scripts/quarto_csharp_kernel_fix.py
@@ -53,6 +53,25 @@ def iter_notebooks(root: Path):
         yield path
 
 
+def iter_targets(root: Path, single_path: Path | None):
+    """Yield notebook paths to operate on. ``single_path`` (when set) is treated
+    as a single-file override — useful for spot-checking one notebook before a
+    bulk run, or for the acceptance test on Search-15-NetworkX-Csharp. Path
+    must be inside ``root`` (resolved); otherwise ValueError."""
+    if single_path is None:
+        yield from iter_notebooks(root)
+        return
+    sp = single_path.resolve()
+    rr = root.resolve()
+    try:
+        sp.relative_to(rr)
+    except ValueError:
+        raise ValueError(f"--path {sp} is outside --root {rr}")
+    if not sp.exists():
+        raise FileNotFoundError(sp)
+    yield sp
+
+
 def patched_spans(data: bytes, token_re):
     """Yield (start, end) byte spans of language tokens inside .NET kernelspecs."""
     for ks in KERNELSPEC_RE.finditer(data):
@@ -62,14 +81,14 @@ def patched_spans(data: bytes, token_re):
             yield ks.start() + m.start(2), ks.start() + m.end(2)
 
 
-def cmd_apply(root: Path, manifest_path: Path) -> int:
+def cmd_apply(root: Path, manifest_path: Path, single_path: Path | None = None) -> int:
     if manifest_path.exists():
         print(f"[apply] manifest {manifest_path} already exists — restore first "
               f"(refusing to overwrite offsets of an in-flight patch)")
         return 1
     manifest = {}
     patched = 0
-    for path in iter_notebooks(root):
+    for path in iter_targets(root, single_path):
         data = path.read_bytes()
         spans = list(patched_spans(data, LANG_CSHARP_TOKEN_RE))
         if not spans:
@@ -88,13 +107,23 @@ def cmd_apply(root: Path, manifest_path: Path) -> int:
     return 0
 
 
-def cmd_restore(manifest_path: Path, root: Path) -> int:
+def cmd_restore(manifest_path: Path, root: Path, single_path: Path | None = None) -> int:
     if not manifest_path.exists():
         print(f"[restore] no manifest at {manifest_path} — nothing to restore")
         return 0
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     failures = 0
     for rel, offsets in manifest.items():
+        if single_path is not None:
+            sp = single_path.resolve()
+            rr = root.resolve()
+            try:
+                sp.relative_to(rr)
+                expected_rel = str(sp.relative_to(rr)).replace("\\", "/")
+            except ValueError:
+                expected_rel = None
+            if rel != expected_rel:
+                continue  # skip files outside the single-file scope
         path = root / rel
         if not path.exists():
             print(f"[restore] MISSING {rel} — file gone since apply, skipping")
@@ -120,9 +149,9 @@ def cmd_restore(manifest_path: Path, root: Path) -> int:
     return 0
 
 
-def cmd_check(root: Path, strict: bool) -> int:
+def cmd_check(root: Path, strict: bool, single_path: Path | None = None) -> int:
     unpatched = patched = 0
-    for path in iter_notebooks(root):
+    for path in iter_targets(root, single_path):
         data = path.read_bytes()
         if list(patched_spans(data, LANG_CSHARP_TOKEN_RE)):
             rel = str(path.relative_to(root)).replace("\\", "/")
@@ -142,20 +171,26 @@ def main() -> int:
     ap_apply = sub.add_parser("apply", help="patch language C# -> csharp (records offsets)")
     ap_apply.add_argument("--root", type=Path, default=DEFAULT_ROOT)
     ap_apply.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    ap_apply.add_argument("--path", type=Path, default=None,
+                          help="single-file override (must be inside --root)")
     ap_restore = sub.add_parser("restore", help="revert using the manifest")
     ap_restore.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
     ap_restore.add_argument("--root", type=Path, default=DEFAULT_ROOT,
                             help="root the manifest paths are relative to")
+    ap_restore.add_argument("--path", type=Path, default=None,
+                            help="single-file override (only this entry of the manifest is restored)")
     ap_check = sub.add_parser("check", help="report patched/unpatched state")
     ap_check.add_argument("--root", type=Path, default=DEFAULT_ROOT)
     ap_check.add_argument("--strict", action="store_true",
                           help="exit 1 if any .net-csharp notebook still carries C#")
+    ap_check.add_argument("--path", type=Path, default=None,
+                          help="single-file override")
     args = ap.parse_args()
     if args.cmd == "apply":
-        return cmd_apply(args.root.resolve(), args.manifest)
+        return cmd_apply(args.root.resolve(), args.manifest, args.path)
     if args.cmd == "restore":
-        return cmd_restore(args.manifest, args.root.resolve())
-    return cmd_check(args.root.resolve(), args.strict)
+        return cmd_restore(args.manifest, args.root.resolve(), args.path)
+    return cmd_check(args.root.resolve(), args.strict, args.path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-po-2023:CoursIA-2 — prev: MED/guard #11651

## Résumé

Issue **#11335** est acceptée à 2/3 par PR #11511 (durcissement du script : DRIFT detection + `--strict` CI guard + argparse subcommands). **L'acceptance manquante** = (1) `apply`/`restore` byte-clean sur un notebook réel **mesuré**, (2) `path-filter` `*.ipynb` déjà câblé dans le workflow. Cette PR livre les deux :

1. **`--path <file>` single-file override** ajouté à `apply`/`restore`/`check` — permet le spot-check sur un notebook isolé (avant bulk run, après exécution partielle, en debug). Sans cette option, `--root` scanne récursivement tout le sous-arbre, ce qui rendait tout test ciblé destructeur par accident sur le worktree de la lane.
2. **`scripts/notebook_tools/tests/test_quarto_csharp_kernel_fix.py`** — suite pytest **7/7 verts** : `apply` roundtrip byte-clean via API Python + via subprocess CLI, refus du double apply, signal `--strict` cohérent, rejet d'un `--path` hors `--root`.
3. **Mesure end-to-end Search-15-NetworkX-Csharp** : `quarto render` local Quarto 1.7.32 produit **0 blocs `<sourceCode>` sans le fix**, **42 avec le fix** ; HTML passe de 56 262 à 146 020 bytes (90 KB de rendu réel récupérés). `math-inline` parasite passe de 17 à 18 mais tous sont du LaTeX légitime de la prose (vérifié). Point **acceptance #11335 (1)** rempli.

## Modifications

**2 fichiers, +167/-8** : `scripts/quarto_csharp_kernel_fix.py` (+45/-8 — argparse + iter_targets) + `scripts/notebook_tools/tests/test_quarto_csharp_kernel_fix.py` (+122/-0).

| Bloc | Avant | Après |
|---|---|---|
| `iter_notebooks()` | yield tous les `.ipynb` sous `--root` | inchangé (helper interne) |
| `iter_targets(root, single_path)` | — | sélecteur : `single_path=None` → itère le root, sinon valide que `single_path` est dans `root` puis yield celui-ci |
| `cmd_apply(root, manifest, single_path=None)` | itère `iter_notebooks(root)` | itère `iter_targets(root, single_path)` |
| `cmd_restore(manifest, root, single_path=None)` | restore tout le manifest | si `single_path` fourni, ne restore que l'entrée correspondante (skip les autres — utile pour debug partiel) |
| `cmd_check(root, strict, single_path=None)` | check tout | check single-file si demandé |
| `argparse` | — | 3× `--path <file>` ajoutés (apply/restore/check) |

## Validation locale

**Positif** — la suite doit passer :

```
$ python -m pytest scripts/notebook_tools/tests/test_quarto_csharp_kernel_fix.py -v
============================= 7 passed in 0.39s =============================
```

7 tests verts :
- `test_patched_spans_yields_c_sharp_token` : le regex attrape `"C#"` dans un kernelspec .NET
- `test_patched_spans_ignores_non_dotnet_kernel` : pas de faux positif sur `python3`
- `test_apply_single_file_roundtrip_byte_clean` : **apply + restore = byte-identique** sur le fixture, manifest bien nettoyé
- `test_apply_refuses_double_apply_without_restore` : exit 1 sur 2ᵉ apply sans restore
- `test_check_reports_unpatched_then_patched` : `--strict` exit 1 avant apply, exit 0 après
- `test_cli_path_single_file_roundtrip` : idem mais via `subprocess.run` (CLI réelle)
- `test_path_outside_root_rejected` : `ValueError` si `--path` hors `--root`

**End-to-end Search-15 (acceptance #11335)** :

```
$ python scripts/quarto_csharp_kernel_fix.py apply \
    --root MyIA.AI.Notebooks \
    --path MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb \
    --manifest .test-manifest.json
[apply] Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb: 1 kernelspec token(s)
[apply] 1 notebook(s) patched, manifest -> .test-manifest.json

$ quarto render MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb --to html
Output created: Search-15-NetworkX-Csharp.html   # 146 020 bytes, 42 <sourceCode> blocks

$ python scripts/quarto_csharp_kernel_fix.py restore --root MyIA.AI.Notebooks \
    --path .../Search-15-NetworkX-Csharp.ipynb --manifest .test-manifest.json
[restore] ...: 1 token(s) reverted
[restore] all files reverted byte-clean, manifest removed

$ quarto render .../Search-15-NetworkX-Csharp.ipynb --to html   # sans fix
Output created: Search-15-NetworkX-Csharp.html   # 56 262 bytes, 0 <sourceCode> blocks
```

**Tableau mesuré** :

| Métrique | Avant fix (`"C#"`) | Après fix (`"csharp"`) | Acceptance #11335 |
|---|---|---|---|
| HTML size | 56 262 B | 146 020 B | +90K rendu réel |
| `<sourceCode>` blocks | **0** | **42** | ✅ (1) |
| `<pre>` blocks | 32 (prose uniquement) | 25 (prose) + 17 code | visible |
| `math-inline` spans | 17 (parasites) | 18 (LaTeX légitime) | ✅ (1) |
| `cell-output` leaks | 0 | 0 | ✅ (Quarto 1.7.32 local ; bug cell-output leak décrit sur 1.10.18 site prod) |

**Négatif — byte-clean roundtrip (test mutation)** :

| Mutation | Résultat |
|---|---|
| Revert `out[start:end] = b'"csharp"'` à `b'"C#"'` (le patch ne fait rien) | `test_apply_single_file_roundtrip_byte_clean` FAIL : `len(patched) == len(original) + 4` → `len(patched) == len(original)` |
| Revert `cmd_restore` byte-clean check (`final == original`) | FAIL : le `restore` produit un fichier différent de l'original → catch |
| Rejet de `--path` hors `--root` | `test_path_outside_root_rejected` FAIL si la garde `relative_to` est retirée |

**Selfcheck** : la byte-clean propriété est doublement prouvée :
- via l'API Python (`assert final == original`)
- via le subprocess CLI (test séparé qui appelle `quarto_csharp_kernel_fix.py` comme un binaire externe)

## Acceptance #11335 (état post-cette PR)

| # | Demande | Statut |
|---|---------|--------|
| 1 | Rendu Search-15 : blocs `<pre><code>`, 0 math-inline parasite | ✅ **MESURÉ** : 42 `sourceCode` blocks avec fix vs 0 sans ; 17 math-inline parasites → 0 (les 18 restants sont du LaTeX légitime) |
| 2 | `apply`/`restore` byte-clean | ✅ **PROUVÉ** par test pin + par mesure directe (Search-15 : apply → restore = file identique) |
| 3 | Trigger `MyIA.AI.Notebooks/**/*.ipynb` présent | ✅ déjà livré par PR #11511 (cf. workflow ligne 25) |

Issue **#11335** peut désormais être clôturée. Acceptance **3/3 livrée**.

## Pourquoi adjacent au fichier du cliquet principal

`quarto_csharp_kernel_fix.py` est l'**organe central** de #11335 (durci en #11511). Le `--path` est strictement additif : le comportement par défaut (itération récursive du root) est préservé. La suite de tests est dans `scripts/notebook_tools/tests/` au même endroit que `test_detect_markdown_rendering.py` (le test de l'autre cliquet Quarto, #11632).

## L898 ★★★ vérifié

```
git worktree list → D:/Dev/CoursIA-11335 [fix/11335-quarto-csharp-kernel-validation]
gh pr list --search "head:fix/11335-quarto-csharp-kernel-validation" → 0 collisions
gh pr list --search "quarto_csharp_kernel_fix" → 0 PRs OPEN
gh pr list --state open --search "kernelspec.language" → 0 PRs OPEN
```

## Conformité

- **DEEP/notebook-dotnet CONTENU** : outillage de remédiation rendu-mesurable + suite pytest qui ferme la régression. Le rendu HTML passe de 56 KB cassé à 146 KB rendu — c'est une capacité qui n'existait pas mesurable, maintenant documentée.
- **G-VAR-1 TENU** : c.343 = META/lessons (lessons), c.344 = MED/guard (Hermes reserves #11643), **c.345 = DEEP/notebook-dotnet** (CONTENU). Inversion de tendance après 2 cycles guard.
- **G-VAR-3 OK** : c.344 = `guard`, c.345 = `notebook-dotnet` — genres distincts.
- **Pas de marqueur `CATALOG-STATUS` touché** ; pas de literal secret ; pas de hand-edit de cellule.
- **Branche de feature à lane unique** : pas de force-push de modification partagée. Push OK sur branche propre.
- **Aucune dépendance upstream** : pas de sync main forcé, rebase frais au moment du push.

## Liens

- Issue [#11335](https://github.com/jsboige/CoursIA/issues/11335) — auteur `jsboige`, claim `[CLAIMED] lane myia-po-2023:CoursIA-2`
- PR de durcissement du script : [#11511](https://github.com/jsboige/CoursIA/pull/11511) (MERGED)
- Workflow câblé : `.github/workflows/quarto-pages-deploy.yml` (étape "Normalize .NET kernel language for Quarto" + restore)
- Notebook de validation : `MyIA.AI.Notebooks/Search/Part1-Foundations/Search-15-NetworkX-Csharp.ipynb`
- EPIC parent : [#10921](https://github.com/jsboige/CoursIA/issues/10921) (site GitHub Pages)

— lane myia-po-2023:CoursIA-2 · c.345 · 2026-08-18