### PR TITLE
fix(ci,#11268): perimeter guard - types: edited + concurrency par event_name

### DIFF
--- a/.github/workflows/perimeter-review-guard.yml
+++ b/.github/workflows/perimeter-review-guard.yml
@@ -11,10 +11,13 @@ name: perimeter-review-guard
 # false file count, or an exclusivity claim that does not name a touched
 # .github/workflows/** file, fails the check on the PR itself.
 #
-# Triggers: pull_request (opened/synchronize/edited -- catches the PR body,
-# INCLUDING body edits: without an explicit `types:` list GitHub's default
-# excludes `edited`, so a false assertion corrected by editing the body would
-# never re-trigger the check -- nit named by ai-01 on #11635) and
+# Triggers: pull_request (opened/synchronize/edited/reopened -- catches the
+# PR body, INCLUDING body edits: without an explicit `types:` list GitHub's
+# default excludes `edited`, so a false assertion corrected by editing the
+# body would never re-trigger the check -- nit named by ai-01 on #11635;
+# `reopened` restores full parity with the default, which the explicit list
+# drops -- a body edited while the PR was closed would otherwise go
+# unchecked until the next review -- nit Hermes on #11654) and
 # pull_request_review (submitted/edited -- re-runs the SAME check name on
 # the same head SHA the moment a review is posted, so a false assertion goes
 # red and blocks the merge; a corrected review turns it green again).
@@ -25,7 +28,7 @@ name: perimeter-review-guard
 on:
   pull_request:
     branches: [ main ]
-    types: [ opened, synchronize, edited ]
+    types: [ opened, synchronize, edited, reopened ]
   pull_request_review:
     branches: [ main ]
     types: [ submitted, edited ]

--- a/.github/workflows/perimeter-review-guard.yml
+++ b/.github/workflows/perimeter-review-guard.yml
@@ -11,8 +11,11 @@ name: perimeter-review-guard
 # false file count, or an exclusivity claim that does not name a touched
 # .github/workflows/** file, fails the check on the PR itself.
 #
-# Triggers: pull_request (opened/synchronize/edited -- catches the PR body)
-# and pull_request_review (submitted/edited -- re-runs the SAME check name on
+# Triggers: pull_request (opened/synchronize/edited -- catches the PR body,
+# INCLUDING body edits: without an explicit `types:` list GitHub's default
+# excludes `edited`, so a false assertion corrected by editing the body would
+# never re-trigger the check -- nit named by ai-01 on #11635) and
+# pull_request_review (submitted/edited -- re-runs the SAME check name on
 # the same head SHA the moment a review is posted, so a false assertion goes
 # red and blocks the merge; a corrected review turns it green again).
 # Baseline moves are reported with direction (issue criterion 3) but do not
@@ -22,6 +25,7 @@ name: perimeter-review-guard
 on:
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, edited ]
   pull_request_review:
     branches: [ main ]
     types: [ submitted, edited ]
@@ -30,8 +34,16 @@ permissions:
   contents: read
   pull-requests: read
 
+# The concurrency group carries github.event_name: the two triggers fire on
+# the SAME (PR, head SHA) pair, and a shared group with cancel-in-progress
+# lets a review-event run CANCEL a still-QUEUED pull_request run (measured on
+# #11649: pull_request run queued 14:26Z under the CI queue backlog, review
+# run started 14:57Z in the same group, the queued run died CANCELLED and
+# left a cancelled check-run on the head SHA). With event_name in the key,
+# pushes supersede pushes and reviews supersede reviews, but the two
+# triggers never cancel each other.
 concurrency:
-  group: perimeter-review-guard-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+  group: perimeter-review-guard-${{ github.event_name }}-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
**Grain:** MED/guard - lane myia-po-2026:CoursIA -- prev: MED/notebook-genai #11649

Tranche résiduelle #11268 (claim actif de la lane, c.14:4xZ) : deux défauts de **déclenchement** du workflow `perimeter-review-guard.yml` (livré #11635), tous deux mesurés sur PR réelle, pas spéculés.

## 1. `types:` absent sur `pull_request` — le body édité ne re-déclenche pas (nit nommé par ai-01)

Le commentaire du workflow annonce « pull_request (opened/synchronize/edited -- catches the PR body) » mais le YAML ne déclare aucun `types:` → GitHub applique le défaut (opened/synchronize/reopened) qui **exclut `edited`**. Conséquence : une fausse assertion de périmètre corrigée en **éditant le body** de la PR ne re-déclenchait jamais le check — doc qui affirmait plus que le code, dans le sens rassurant. Fix : `types: [opened, synchronize, edited]`.

## 2. Concurrency partagée : le review-event tue le PR-event en file d'attente (mesuré sur #11649)

Le groupe `perimeter-review-guard-<PR>-<SHA>` avec `cancel-in-progress: true` est partagé par les DEUX triggers, qui tirent sur la même paire (PR, head SHA). Chronologie mesurée sur ma PR #11649 :

- run `pull_request` démarré **14:26:57Z**, ralenti par la file CI (#11405) ;
- review soumise → run `pull_request_review` **14:57:24Z** dans le **même groupe** → le run `pull_request` meurt **CANCELLED** (`gh run view` : conclusion `cancelled`, log disparu), check-run annulé collé au head SHA.

Fix : `github.event_name` dans la clé du groupe — les pushes se supplantent entre eux, les reviews entre elles, les deux triggers ne s'entretuent plus. Sur #11649 le run annulé a été relancé à la main et le verdict est repassé SUCCESS (le check n'est pas bloquant pour le merge, mais un CANCELLED résiduel par review postée sur PR en file = bruit systématique tant que la queue est chargée — 58 PRs DIRTY/BLOCKED à rebaser la déclencheront).

## Preuves

- YAML valide (`yaml.safe_load`).
- Mesure du défaut 2 : `gh run view 32148381849 --json conclusion` = `cancelled` (event `pull_request`), `gh run view 32148822157` = `success` (event `pull_request_review`), même head SHA `84ed1f934`, rollup = CANCELLED + SUCCESS sur le même nom de check.
- Le défaut 1 est le nit textualisé par ai-01 dans son arbitrage #11635 (« Doc qui affirme plus que le code, dans le sens rassurant »).

Diff : **1 fichier, +15/−3** (workflow + son commentaire). Aucun script touché — `check_pr_perimeter.py` inchangé (23/23 tests déjà en main, #11635).

See #11268 (tranche déclenchement du workflow ; l'outil lui-même est livré et dogfoodé — ce guard a tourné sur #11644 et #11649)

§1 GENRE : `guard` assumé — c'est un a-côté borné (1 fichier) APRÈS le grain CONTENU du cycle (#11649, MED/notebook-genai) qui tient le plancher G-VAR-1 ; pas de retag, la veine prev est notebook-genai (pas d'adjacence G-VAR-3).
