### PR TITLE
fix(perimeter,#11268): only en mot autonome - read-only n'est pas une exclusivite

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -105,6 +105,29 @@ EXCLUSIVITY_MARKERS = (
     "no other",
 )
 
+# "only" as an exclusivity marker must be a STANDALONE word. Technical
+# compounds -- "read-only", "append-only", "metadata-only" -- carry "only"
+# as a compound modifier (lecture seule), not a perimeter quantifier, and a
+# plain substring match trips criterion #11268-2 on prose about permissions.
+# Measured on #11654: the Hermes line "Sinon LGTM sur le périmètre — aucun
+# secret, permissions read-only inchangées." was flagged as an exclusivity
+# assertion because "only" sat inside "read-only" while "périmètre" supplied
+# the strong scope word. The French markers need no such guard: no hyphenated
+# compound carries "seulement"/"uniquement".
+_ONLY_STANDALONE = re.compile(r"(?<![-\w])only\b", re.IGNORECASE)
+_SUBSTRING_MARKERS = ("uniquement", "seulement", "aucune autre",
+                      "nothing else", "no other")
+
+
+def _has_exclusivity(low: str) -> bool:
+    """Exclusivity check shared by extraction and assertion checking.
+
+    `low` is the lowercased line. French/phrase markers are substring-matched;
+    "only" requires word boundaries AND no hyphen/word char before it.
+    """
+    return (any(m in low for m in _SUBSTRING_MARKERS)
+            or bool(_ONLY_STANDALONE.search(low)))
+
 
 @dataclass
 class BaselineMove:
@@ -196,7 +219,7 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
                 f"l'assertion pretend {claimed} fichier(s), la liste effective en compte {len(files)} : "
                 + ", ".join(f["path"] for f in files)
             )
-    exclusive = any(marker in assertion.lower() for marker in EXCLUSIVITY_MARKERS)
+    exclusive = _has_exclusivity(assertion.lower())
     if exclusive:
         for f in files:
             if f["path"].startswith(WORKFLOW_PREFIX):
@@ -319,7 +342,7 @@ def extract_perimeter_assertions(text: str) -> list[str]:
                 continue  # quoting a count (reported speech), not claiming it
             candidates.append(line)
             continue
-        if any(m in low for m in EXCLUSIVITY_MARKERS) and any(w in low for w in STRONG_SCOPE_WORDS):
+        if _has_exclusivity(low) and any(w in low for w in STRONG_SCOPE_WORDS):
             if _markers_all_quoted(line):
                 continue  # quoting an exclusivity claim, not making it
             candidates.append(line)

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -188,6 +188,32 @@ def test_extract_skips_technical_prose_with_exclusivity_words():
     assert extract_perimeter_assertions(prose) == []
 
 
+def test_extract_skips_read_only_compound():
+    """"only" inside a technical compound is not an exclusivity marker.
+
+    Measured on #11654: the Hermes verdict line "Sinon LGTM sur le périmètre
+    — aucun secret, permissions read-only inchangées." was flagged as an
+    exclusivity assertion (criterion #11268-2, unnamed workflow) because a
+    plain substring match saw "only" inside "read-only" while "périmètre"
+    supplied the strong scope word. A permissions adjective is not a
+    perimeter quantifier.
+    """
+    line = ("Sinon LGTM sur le périmètre — note de sécurité : aucun secret, "
+            "permissions read-only inchangées.")
+    assert extract_perimeter_assertions(line) == []
+    assert not __import__("check_pr_perimeter")._has_exclusivity(
+        "permissions read-only inchangées")
+
+
+def test_only_standalone_still_flags():
+    """The control positive side: a standalone "only" with a scope word stays
+    a live exclusivity assertion -- the fix must not kill the English arm."""
+    assert __import__("check_pr_perimeter")._has_exclusivity(
+        "only change is the workflow file")
+    line = "Only scope change: the workflow file, nothing else."
+    assert extract_perimeter_assertions(line) == [line]
+
+
 def test_extract_skips_markdown_table_rows():
     """A markdown table row is a report structure, not a live assertion.
 


### PR DESCRIPTION
**Grain:** MED/guard - lane myia-po-2026:CoursIA -- prev: MED/notebook-genai #11649

3e itération de l'extracteur `check_pr_perimeter.py` (claim #11268 actif), découverte en dogfoodant : le guard a fait rouge **#11654** sur la review Hermes elle-même — correctement, selon son code — pour une cause qui est un faux positif lexical de l'outil, pas un défaut de la review.

## Le défaut, mesuré

La ligne de verdict Hermes sur #11654 :

> Sinon LGTM sur le périmètre — note de sécurité : aucun secret, permissions **read-only** inchangées.

Chaîne de déclenchement : `"only" in low` (substring) voit « only » **à l'intérieur de « read-only »** + « périmètre » est un strong scope word → la ligne devient une « assertion d'exclusivité » → la PR touche un workflow → le nom du fichier doit être dans la ligne → FAIL (`assertion d'exclusivite sans nommer le workflow touche .github/workflows/perimeter-review-guard.yml`). Un adjectif de permissions n'est pas un quantificateur de périmètre.

Même famille que les composés « append-only », « metadata-only », « line-only » — tous porteurs du même faux positif potentiel.

## Correctif (minimal, chirurgical)

`"only"` exige désormais frontière de mot **et** aucun trait d'union/lettre devant : `(?<![-\w])only\b`. Les marqueurs français (« seulement », « uniquement », « aucune autre ») et les phrases anglaises (« nothing else », « no other ») restent en substring — aucun composé à trait d'union ne les porte. Centralisé dans `_has_exclusivity()` partagé par l'extraction (`extract_perimeter_assertions`) et la confrontation (`check_assertion`).

## Preuves

**Matrice live complète re-validée AVANT push** (discipline over-exemption — le contrôle positif fondateur est le falsifieur le moins cher de toute exemption) :

| PR | Verdict attendu | Verdict mesuré |
|---|---|---|
| #11227 (fondatrice, « uniquement » français) | FAIL | **FAIL (exit 1)** — intact, hors du périmètre du fix |
| #11635 (dogfood originel) | OK | OK |
| #11628 / #11632 (contrôles négatifs) | OK | OK |
| #11649 (ma PR densité) | OK | OK |
| **#11654 (le FP cible)** | OK | **OK (exit 0)** — ligne read-only exemptée, ligne « 1 fichier workflow » reste candidate et son compte est juste (1=1) |

Tests : **25/25**, dont les deux formes côte à côte : `read-only` exempté (ligne Hermes exacte figée) / `Only scope change: the workflow file, nothing else.` toujours candidat live.

## Séquence de merge pour le coordinateur

Le check rouge sur #11654 vient du script de **sa** branche (checkout de la PR). Séquence : (1) merger cette PR ; (2) je rebase #11654 sur main → le guard re-tourne avec le script fixé → vert ; (3) merge #11654. Le body de #11654 documente déjà sa propre situation.

Alternatives écartées : éditer la review Hermes pour lui faire dire autre chose que ce qu'elle a dit (maquiller la review d'un tiers pour faire passer un check — interdit), retagger/contourner le gate.

See #11268

§1 GENRE : `guard` assumé (a-côté borné après le grain CONTENU du cycle #11649 ; prev notebook-genai, pas d'adjacence G-VAR-3).
