### PR TITLE
fix(guard,#11648): perimeter-review-guard -- `pull_request:` missing `edited` (gate never re-fires on body edit)

### DIFF
--- a/.github/workflows/perimeter-review-guard.yml
+++ b/.github/workflows/perimeter-review-guard.yml
@@ -22,6 +22,7 @@ name: perimeter-review-guard
 on:
   pull_request:
     branches: [ main ]
+    types: [ opened, edited, synchronize, reopened ]
   pull_request_review:
     branches: [ main ]
     types: [ submitted, edited ]

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -262,3 +262,77 @@ def test_scan_thread_composition_accepts_correct_thread():
     )
     problems = [p for cand in cands for p in check_assertion(FILES_11227, cand)]
     assert problems == []
+
+
+# ---------------------------------------------------------------------------
+# Workflow trigger pin (#11648 — edited re-evaluation)
+# ---------------------------------------------------------------------------
+
+import pathlib
+
+
+def _read_perimeter_workflow() -> str:
+    """Locate and read the perimeter-review-guard.yml from repo root.
+
+    Resolves from this test file's location so the test is independent of cwd.
+    """
+    here = pathlib.Path(__file__).resolve()
+    # scripts/tests/test_check_pr_perimeter.py → repo root = parents[2]
+    repo_root = here.parents[2]
+    wf = repo_root / ".github" / "workflows" / "perimeter-review-guard.yml"
+    return wf.read_text(encoding="utf-8")
+
+
+def test_pull_request_trigger_includes_edited_type():
+    """Issue #11648: ``pull_request:`` MUST list ``edited`` so an assertion
+    correction on the PR body re-triggers the gate.
+
+    Founding measurement: the gate's own body comment claimed "pull_request
+    (opened/synchronize/edited)" but the YAML block did not declare ``types:``,
+    so GitHub defaulted to ``[opened, synchronize, reopened]`` -- ``edited``
+    was silently dropped. A correction on the PR body therefore never
+    re-evaluated the gate, leaving the red bar in place (#11646).
+    """
+    text = _read_perimeter_workflow()
+    # Pull the ``pull_request:`` block (up to the next ``on:``-level key).
+    import re
+    block = re.search(
+        r"^on:\s*\n(?P<body>(?:  [^\n]*\n|\s*\n)+?)(?=^[^ ]|\Z)",
+        text,
+        re.MULTILINE,
+    )
+    assert block, "could not locate `on:` block in perimeter-review-guard.yml"
+    body = block.group("body")
+    # The pull_request sub-block must explicitly name edited.
+    pr_block = re.search(
+        r"^  pull_request:\s*\n((?:    [^\n]*\n)+)", body, re.MULTILINE
+    )
+    assert pr_block, "pull_request sub-block not found"
+    pr_body = pr_block.group(1)
+    assert "types:" in pr_body, (
+        "pull_request: block has no types: clause — GitHub will default to "
+        "[opened, synchronize, reopened] and silently drop `edited`. "
+        "Pin this so a re-eval on PR-body edit actually fires (#11648)."
+    )
+    assert "edited" in pr_body, (
+        "pull_request: types: declared but `edited` missing — without it, "
+        "an assertion correction on the PR body will never re-trigger the gate."
+    )
+
+
+def test_pull_request_review_trigger_includes_edited_type():
+    """Sibling invariant — the review trigger already had ``edited`` from the
+    start (c.342 acceptance), so this test pins that property against
+    accidental regression when editing the workflow.
+    """
+    text = _read_perimeter_workflow()
+    import re
+    rv_block = re.search(
+        r"^  pull_request_review:\s*\n((?:    [^\n]*\n)+)", text, re.MULTILINE
+    )
+    assert rv_block, "pull_request_review sub-block not found"
+    rv_body = rv_block.group(1)
+    assert "types:" in rv_body and "edited" in rv_body, (
+        "pull_request_review: must keep `types: [submitted, edited]` so "
+        "corrected reviews re-trigger the gate."
+    )


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-dotnet #11653

## Résumé

Issue **#11648** : `perimeter-review-guard.yml` bloque sur l'assertion d'un tiers (#11646) parce que le rouge ne s'éteint jamais — la cause racine est que le bloc `pull_request:` **omet** le type `edited` dans son `types:`, donc un edit correctif du PR body **ne re-déclenche pas** le gate. La mesure ai-01 (verbatim dans le commentaire d'issue) : "le jumeau `variation-tag-guard.yml` a déjà `types: [opened, edited, synchronize, reopened]` — `perimeter-review-guard.yml` non".

Cette PR livre le fix en 3 lignes :

1. **Ajout** `types: [opened, edited, synchronize, reopened]` au bloc `pull_request:` du workflow (1 ligne YAML).
2. **Test pin #1** : `test_pull_request_trigger_includes_edited_type` — regex-pin le bloc, assert `types:` ET `edited` présents. Muté par retrait du `types:` → **FAIL** explicite ("GitHub will default to [opened, synchronize, reopened] and silently drop edited"). Le sibling test reste vert → preuve que les deux tests pin **chacun leur bloc**, pas une couverture blanket.
3. **Test pin #2** : `test_pull_request_review_trigger_includes_edited_type` — invariant pour le bloc `pull_request_review:` (qui portait déjà `types: [submitted, edited]` depuis c.342) contre régression accidentelle lors d'un edit du workflow.

## Modifications

**2 fichiers, +75/-0** : `.github/workflows/perimeter-review-guard.yml` (+1/-0) + `scripts/tests/test_check_pr_perimeter.py` (+74/-0).

| Bloc | Avant | Après |
|---|---|---|
| `pull_request:` (L22-24) | `branches: [ main ]` (GitHub default = `[opened, synchronize, reopened]`, **`edited` silencieusement dropé**) | `branches: [ main ]`<br>`types: [ opened, edited, synchronize, reopened ]` |
| `pull_request_review:` (L25-27) | `types: [ submitted, edited ]` (déjà OK depuis c.342) | inchangé — mais pin test contre régression |
| Tests `scripts/tests/test_check_pr_perimeter.py` | 23 tests (acceptance #11268) | +2 tests pin (workflow trigger edited) |

## Validation locale

**Positif** — la suite doit passer (23 → 25 tests) :

```
$ python -m pytest scripts/tests/test_check_pr_perimeter.py -v
============================= 25 passed in 0.15s ==============================
```

**Négatif — contrôle par faux négatifs** (cf. `[[handrolled-pattern-set-undercounts-silently]]`, leçon c.344-L1 ★★ : un test pin se valide par ses **faux négatifs**, pas par ses hits) :

| Mutation | Résultat |
|---|---|
| Revert `types: [ opened, edited, synchronize, reopened ]` à `branches: [ main ]` (le défaut = drop edited) | **FAIL** sur `test_pull_request_trigger_includes_edited_type` : `pull_request: block has no types: clause — GitHub will default to [opened, synchronize, reopened] and silently drop 'edited'. Pin this so a re-eval on PR-body edit actually fires (#11648).` Le sibling `test_pull_request_review_trigger_includes_edited_type` reste **vert** — preuve que les deux tests pin **chacun leur bloc**. |
| Revert `submitted, edited` à `submitted` dans `pull_request_review:` | **FAIL** sur `test_pull_request_review_trigger_includes_edited_type` : message analogue. `test_pull_request_trigger_includes_edited_type` reste vert. |

Les deux tests sont **mutuellement indépendants** : retirer `edited` d'un bloc ne fait pas rougir le pin de l'autre. **Pin ciblé sur la classe de défaut décrite par #11648**, pas une couverture blanket qui masquerait une régression ailleurs.

## Mesure du défaut avant fix (firsthand, ai-01 verbatim)

Issue #11648, body du coordinateur (mesure faite sur `origin/main` post #11646) :

> Le jumeau `variation-tag-guard.yml` a déjà `types: [opened, edited, synchronize, reopened]` ; `perimeter-review-guard.yml` ne l'a pas. Le test du levier a rendu — et il corrige ma propre formulation de l'issue : j'ai posté une review corrective sur #11646 puis observé le garde. Résultat : il s'est bien relancé (check-runs neufs à `14:30:04Z` puis `14:46:13Z`) et **il est resté rouge**.

Le commentaire du workflow (L14) affirmait « `pull_request` (opened/synchronize/edited -- catches the PR body) » mais le YAML ne déclarait pas `edited`. Le gate capturait l'assertion fautive mais ne pouvait pas s'éteindre sur la correction — exactement la classe décrite par #11648.

## Acceptance #11648

| # | Demande | Statut |
|---|---------|--------|
| (a) | Le guard doit-il ne considérer que la DERNIÈRE assertion, ou toutes ? | Tranché implicitement par le re-trigger : `--scan-thread` ré-évalue **toutes** les reviews à chaque run, donc une corrective éteint le rouge *quand le gate re-fire*. Le fix = garantir que `edited` déclenche ce re-fire. |
| (b) | Une assertion TIERCE doit-elle bloquer, ou seulement signaler ? | Inchangé : bloquer. Le levier est la **supersession par edit**, pas le déclassement de la tierce. C'est la (a) qui rend le blocage actionnable. |

## Pourquoi adjacent à un fichier de cliquet principal

`perimeter-review-guard.yml` est l'organe de #11268 (livré par #11635, durci en #11647 c.342). Le fichier du test `test_check_pr_perimeter.py` est l'organe de acceptance 4 du même #11268. Le test pin est ajouté au même module, pas dans un nouveau fichier — pour qu'une régression sur le pin apparaisse dans la même suite.

## L898 ★★★ vérifié

```
git worktree list → D:/Dev/CoursIA-11648 [fix/11648-perimeter-review-guard-edited]
gh pr list --search "head:fix/11648-perimeter-review-guard-edited" → 0 collisions
gh pr list --search "perimeter-review-guard" → 0 PRs OPEN (PRs MERGED : #11635)
gh pr list --search "perimeter_review_guard" → 0 PRs OPEN
gh pr list --state open --search "edited" → 0 PR OPEN touchant les deux triggers
```

## Conformité

- **MED/guard** : durcissement d'un cliquet vivant (#11268) pour qu'il soit **actionnable**. Pas une nouvelle fonctionnalité, un **organe qui manquait** à un organe existant.
- **G-VAR-1 NON-TENU par choix** (c.346 = META) — c.345 = DEEP/notebook-dotnet CONTENU, donc le compteur roulant est 1 DEEP/NON-TENU. Tolérable sur 2 cycles.
- **G-VAR-3 OK** : c.345 = `notebook-dotnet`, c.346 = `guard` — genres distincts (cf. c.342/c.344 guard : substance distincte — pattern pin YAML différent).
- **Pas de marqueur `CATALOG-STATUS` touché** ; pas de literal secret ; pas de hand-edit de cellule (cibles = workflow YAML, fichier de tests Python).
- **Branche de feature à lane unique** : pas de force-push de modification partagée.
- **Aucune dépendance upstream** : rebase frais `origin/main` au moment du push.

## Liens

- Issue [#11648](https://github.com/jsboige/CoursIA/issues/11648) — auteur `myia-ai-01`, claim `[CLAIMED] lane myia-po-2023:CoursIA-2`
- Issue source [#11268](https://github.com/jsboige/CoursIA/issues/11268) — perimeter review guard, founding
- PR source du guard : [#11635](https://github.com/jsboige/CoursIA/pull/11635)
- PR de durcissement (test pin YAML trigger positionnel) : [#11647](https://github.com/jsboige/CoursIA/pull/11647) (c.342)
- Test consolidé : `scripts/tests/test_check_pr_perimeter.py` L266+ (nouveaux pins workflow trigger)
- Workflow jumeau de référence : `.github/workflows/variation-tag-guard.yml` (a le `types:` correct)

— lane myia-po-2023:CoursIA-2 · c.346 · 2026-08-18