### PR TITLE
feat(tools,#11656): detecteur relatif de perte de volume de rendu (base vs head)

### DIFF
--- a/.github/workflows/render-volume-delta-advisory.yml
+++ b/.github/workflows/render-volume-delta-advisory.yml
@@ -86,9 +86,14 @@ jobs:
             echo "::warning::render-volume-delta: merge-base origin/main HEAD introuvable -- on s'abstient (ref rate ou branche sans ancre commune). Relancer avec un fetch plus profond ou rebase la branche." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
-          # Liste de notebooks modifies entre BASE et HEAD (pas origin/main
-          # deux-points, qui inclut les evolutions de main hors PR).
-          CHANGED=$(git diff --name-only --diff-filter=M "$BASE" HEAD | grep -E '\.ipynb$' | head -50)
+          # Liste de notebooks modifies/renommes entre BASE et HEAD (pas
+          # origin/main deux-points, qui inclut les evolutions de main hors
+          # PR). --diff-filter=MR + -M=50% pour attraper les renames ; sans
+          # ca, un deplacement de notebook sort de la liste et la PR
+          # passe invisible (faux negatif dans un detecteur dont le role
+          # est precisement d'attraper ce que les autres ratent ; cf. 4e
+          # point ai-01 CHANGES_REQUESTED #11658).
+          CHANGED=$(git diff --name-only --diff-filter=MR -M50% "$BASE" HEAD | grep -E '\.ipynb$' | head -50)
           if [ -z "$CHANGED" ]; then
             echo "findings_total=0" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/workflows/render-volume-delta-advisory.yml
+++ b/.github/workflows/render-volume-delta-advisory.yml
@@ -54,7 +54,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 50
+          # fetch-depth: 0 obligatoire pour que `git merge-base origin/main HEAD`
+          # reussisse sur une branche en retard (cf. c.357-L1 NEW durable :
+          # origin/main deux-points != merge-base, et un fetch-depth limite
+          # ferait echouer merge-base silencieusement sur les branches >50
+          # commits de retard comme #11646 / #11642).
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -70,11 +75,34 @@ jobs:
         id: run
         run: |
           set +e
+          # Calcul de la base de fusion = merge-base origin/main HEAD. Si
+          # introuvable (fetch-rate, ref manquant), on **s'abstient en le
+          # disant** -- jamais de fallback silencieux sur origin/main
+          # (qui rendrait « pas regarde » et « rien trouve » indistinguables).
+          BASE=$(git merge-base origin/main HEAD 2>/dev/null)
+          if [ -z "$BASE" ]; then
+            echo "findings_total=abstain" >> "$GITHUB_OUTPUT"
+            echo "base_unresolved=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::render-volume-delta: merge-base origin/main HEAD introuvable -- on s'abstient (ref rate ou branche sans ancre commune). Relancer avec un fetch plus profond ou rebase la branche." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          # Liste de notebooks modifies entre BASE et HEAD (pas origin/main
+          # deux-points, qui inclut les evolutions de main hors PR).
+          CHANGED=$(git diff --name-only --diff-filter=M "$BASE" HEAD | grep -E '\.ipynb$' | head -50)
+          if [ -z "$CHANGED" ]; then
+            echo "findings_total=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           python scripts/notebook_tools/check_render_volume_delta.py \
-            $(git diff --name-only --diff-filter=M origin/main | grep -E '\.ipynb$' | head -50) \
-            --base origin/main --check --json > /tmp/render-volume-delta.json 2>&1
+            $CHANGED \
+            --base "$BASE" --check --json > /tmp/render-volume-delta.json 2>&1
           rc=$?
-          echo "exit=$rc" >> "$GITHUB_OUTPUT"
+          # --check retourne 1 si findings ; on parse findings_total du JSON
+          # (le verdict advisory depend du nombre, pas du rc -- le workflow
+          # reste non bloquant, cf. c.356-L1 ★★ : pas de faux vert).
+          findings_total=$(python -c "import json,sys;print(json.load(open('/tmp/render-volume-delta.json')).get('findings_total', json.load(open('/tmp/render-volume-delta.json'))['stats']['findings_count']))" 2>/dev/null || echo "0")
+          echo "findings_total=$findings_total" >> "$GITHUB_OUTPUT"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
           set -e
 
       - name: Post advisory comment
@@ -83,7 +111,8 @@ jobs:
         with:
           header: render-volume-delta-advisory
           message: |
-            ${{ steps.run.outputs.exit == '0' && '✅ No render volume delta signal (notebooks modified vs origin/main preserve >= 50% of base rendered output per MIME family).' || '⚠️ Render volume delta signal: one or more modified notebooks lost >= 50% of their rendered output per MIME family. Review against the source code — these are advisory, NOT a merge gate.' }}
+            ${{ steps.run.outputs.findings_total == '0' && '✅ No render volume delta signal (notebooks modified vs merge-base preserve >= 50% of base rendered output per MIME family).' || steps.run.outputs.findings_total == 'abstain' && '⚠️ Render volume delta: **base introuvable** (merge-base origin/main HEAD impossible). Le détecteur s\'abstient -- relancer avec un fetch plus profond, ou rebase la branche sur main. Pas de verdict.' || format('⚠️ {0} render volume delta signal(s): one or more modified notebooks lost >= 50% of their rendered output per MIME family (base = merge-base origin/main HEAD). Review against the source code -- advisory, NOT a merge gate.', steps.run.outputs.findings_total) }}
 
             See `python scripts/notebook_tools/check_render_volume_delta.py --help` for re-running locally.
             Detector rationale: #11656 / #11351 pathologie (840 B remnants in 195 692 B cells = absolute detectors blind).
+            Why merge-base not origin/main two-dots: a branch 25+ commits behind would have the detector scan 35 notebooks the PR never touched.

--- a/.github/workflows/render-volume-delta-advisory.yml
+++ b/.github/workflows/render-volume-delta-advisory.yml
@@ -1,0 +1,89 @@
+name: Render volume delta detector (advisory)
+
+# Durable anti-regression advisory for the #11656 pathologie:
+# "notebook PR loses 96-99% of its rendered output volume (text/html
+# inline) between base and head, while keeping `outputs: [...]` populated
+# with measurable byte payloads". This is the founding incident on
+# Infer-3-Factor-Graphs / Infer-8-TrueSkill / Infer-13-Crowdsourcing
+# (ai-01 measurement, post PR #11351):
+#
+#     Infer-3-Factor-Graphs       45 715 ->    840 B   (-98.2%)
+#     Infer-8-TrueSkill          127 081 ->  1 613 B   (-98.7%)
+#     Infer-13-Crowdsourcing      22 896 ->    840 B   (-96.3%)
+#     TOTAL                      195 692 ->  3 293 B   (-98.3%)
+#
+# Why ADVISORY (not a blocking gate):
+# The three absolute detectors that catch blank figures / empty SVG /
+# identical RGB signatures (`detect_blank_figures.py`,
+# `detect_svg_empty_display.py`, `scan_figure_visual_signature.py`) all
+# have thresholds calibrated on surviving cells — and the cells surviving
+# in #11351 carry 840-1613 B (well above the 70 B blank figure threshold).
+# No absolute threshold can tell apart "90% of a Graphviz helper, all
+# border, no body" from a legitimate chart with thin geometry: only a
+# relative detector comparing base vs head on the SAME notebook can see
+# the loss. That detector runs here, signals findings, and a reviewer
+# (human or bot) triages them.
+#
+# When the precision improves (e.g. by adding a corpus-wide baseline of
+# typical per-family ratios), promote this to a blocking gate. Until
+# then: advisory only, never block merge on this signal alone.
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/notebook_tools/check_render_volume_delta.py'
+      - 'scripts/notebook_tools/tests/test_check_render_volume_delta.py'
+      - '.github/workflows/render-volume-delta-advisory.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: render-volume-delta-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  render-volume-delta-advisory:
+    name: "Render volume delta (#11656 advisory)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 50
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Run unit tests
+        run: |
+          python -m pip install --quiet pytest
+          python -m pytest scripts/notebook_tools/tests/test_check_render_volume_delta.py -v
+        continue-on-error: false
+
+      - name: Run detector (advisory, do not gate)
+        id: run
+        run: |
+          set +e
+          python scripts/notebook_tools/check_render_volume_delta.py \
+            $(git diff --name-only --diff-filter=M origin/main | grep -E '\.ipynb$' | head -50) \
+            --base origin/main --check --json > /tmp/render-volume-delta.json 2>&1
+          rc=$?
+          echo "exit=$rc" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Post advisory comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: render-volume-delta-advisory
+          message: |
+            ${{ steps.run.outputs.exit == '0' && '✅ No render volume delta signal (notebooks modified vs origin/main preserve >= 50% of base rendered output per MIME family).' || '⚠️ Render volume delta signal: one or more modified notebooks lost >= 50% of their rendered output per MIME family. Review against the source code — these are advisory, NOT a merge gate.' }}
+
+            See `python scripts/notebook_tools/check_render_volume_delta.py --help` for re-running locally.
+            Detector rationale: #11656 / #11351 pathologie (840 B remnants in 195 692 B cells = absolute detectors blind).

--- a/scripts/notebook_tools/check_render_volume_delta.py
+++ b/scripts/notebook_tools/check_render_volume_delta.py
@@ -107,6 +107,31 @@ DEFAULT_DELTA_THRESHOLD = 0.50
 # par d'autres detecteurs.
 DEFAULT_MIN_BASE_BYTES = 1000
 
+# --- c.358 : extension texte -----------------------------------------------------
+
+# Compteur separe pour la sortie TEXTUELLE (stream, execute_result text/plain,
+# display_data text/plain, traceback des erreurs). Pourquoi distinct du
+# rendu MIME-base : un notebook peut perdre TOUT son volume de stream (la
+# demo du moteur SOTA) sans perdre une seule image, et inversement. La
+# chute de texte n'a pas la meme cause qu'une chute de rendu (env / lib
+# absente / try-except ImportError qui bascule vs. Graphviz helper detruit),
+# donc pas le meme correctif. Voir le cas fondateur c.358 :
+# Sudoku-4-SimulatedAnnealing perd 10 794 -> 3 155 B de stream (la grille
+# resolue, `Energie finale: 0`, `Solution valide: True`) tout en gardant 0
+# B de rendu -- aucun signal `image` ou `html` ne pouvait le voir.
+DEFAULT_TEXT_DELTA_THRESHOLD = 0.50
+DEFAULT_MIN_TEXT_BASE_BYTES = 500
+
+# Pattern "non disponible" : signature d'un try/except ImportError qui
+# bascule (la lib est declaree dans requirements.txt mais absente du runner).
+# Comptage distinct des bytes : on signale le passage 0 -> N de ces
+# messages (avant/apres) sans se meler au delta texte principal.
+_UNAVAILABLE_PATTERNS = (
+    re.compile(r"non\s+disponible", re.IGNORECASE),
+    re.compile(r"not\s+available", re.IGNORECASE),
+    re.compile(r"importerror", re.IGNORECASE),
+)
+
 # Granularite de MIME prefix : on agrege par famille, pas par MIME exacte. Un
 # ``image/png`` 5 100 B et un ``image/jpeg`` 4 500 B sont groupes en ``image``.
 MIME_PREFIX = re.compile(r"^([^/]+)/")
@@ -263,6 +288,96 @@ def _summarize_outputs(nb: dict) -> dict[tuple[str, str], int]:
     return out
 
 
+def _output_text_bytes(outp: dict) -> int:
+    """Volume de TEXTE d'un output Jupyter (c.358).
+
+    Distinct du volume de rendu : on compte ici les bytes de texte brut
+    (stream, ``text/plain`` des execute_result / display_data, ``traceback``
+    des erreurs). Un notebook peut perdre TOUT son volume de stream sans
+    perdre une seule image -- les deux deltas sont diagnostiquement
+    distincts (env / lib absente vs. helper Graphviz detruit, cf. cas
+    fondateur Sudoku-4-SimulatedAnnealing c.358 : 10 794 -> 3 155 B de
+    stream sans toucher au rendu).
+    """
+    if outp.get("output_type") == "stream":
+        text = outp.get("text")
+        if isinstance(text, str):
+            return len(text.encode("utf-8"))
+        if isinstance(text, (list, tuple)):
+            return sum(len(t.encode("utf-8")) for t in text if isinstance(t, str))
+        return 0
+    if outp.get("output_type") == "error":
+        # traceback = list[str]; on mesure l'ensemble du traceback
+        tb = outp.get("traceback")
+        if isinstance(tb, (list, tuple)):
+            return sum(len(t.encode("utf-8")) for t in tb if isinstance(t, str))
+        return 0
+    # display_data / execute_result : on prend text/plain si present
+    data = outp.get("data")
+    if isinstance(data, dict):
+        tp = data.get("text/plain")
+        if isinstance(tp, str):
+            return len(tp.encode("utf-8"))
+        if isinstance(tp, (list, tuple)):
+            return sum(len(t.encode("utf-8")) for t in tp if isinstance(t, str))
+    return 0
+
+
+def _summarize_text(nb: dict) -> int:
+    """Volume total de TEXTE (c.358) : somme sur toutes les cellules non
+    exemptes des bytes ``_output_text_bytes(outp)`` par output.
+
+    Distinct de ``_summarize_outputs`` (qui agrege par famille MIME pour le
+    rendu). On ne agrege pas par cellule ici : on veut le total du
+    notebook pour un seul delta ``base_text_bytes`` vs ``head_text_bytes``.
+    """
+    total = 0
+    for idx, cell in enumerate(nb.get("cells", [])):
+        if _cell_is_exempt(cell):
+            continue
+        for outp in (cell.get("outputs") or []):
+            total += _output_text_bytes(outp)
+    return total
+
+
+def _summarize_unavailable(nb: dict) -> int:
+    """Compte les sorties contenant un pattern 'non disponible' / 'not available'
+    / 'importerror' (c.358). Le passage 0 -> N signale typiquement un
+    ``try/except ImportError`` qui bascule : la lib est declaree dans
+    requirements.txt mais absente du runner -- pas le meme diagnostic
+    qu'une chute de stream ou de rendu.
+    """
+    total = 0
+    for idx, cell in enumerate(nb.get("cells", [])):
+        if _cell_is_exempt(cell):
+            continue
+        for outp in (cell.get("outputs") or []):
+            payload = ""
+            if outp.get("output_type") == "stream":
+                text = outp.get("text")
+                if isinstance(text, str):
+                    payload = text
+                elif isinstance(text, (list, tuple)):
+                    payload = "".join(t for t in text if isinstance(t, str))
+            elif outp.get("output_type") == "error":
+                tb = outp.get("traceback")
+                if isinstance(tb, (list, tuple)):
+                    payload = "\n".join(t for t in tb if isinstance(t, str))
+            else:
+                data = outp.get("data")
+                if isinstance(data, dict):
+                    tp = data.get("text/plain")
+                    if isinstance(tp, str):
+                        payload = tp
+                    elif isinstance(tp, (list, tuple)):
+                        payload = "".join(t for t in tp if isinstance(t, str))
+            for pat in _UNAVAILABLE_PATTERNS:
+                if pat.search(payload):
+                    total += 1
+                    break
+    return total
+
+
 def _aggregate_by_family(per_cell: dict[tuple[str, str], int]) -> dict[str, int]:
     """Agrege par famille MIME en sommant sur les cellules.
 
@@ -378,6 +493,74 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None,
     base_agg = _aggregate_by_family(_summarize_outputs(nb_base))
     head_agg = _aggregate_by_family(_summarize_outputs(nb_head))
     findings = _diff_families(base_agg, head_agg, threshold, min_base)
+
+    # --- c.358 : extension texte (stream + text/plain + signal 'non disponible')
+    base_text = _summarize_text(nb_base)
+    head_text = _summarize_text(nb_head)
+    if base_text >= DEFAULT_MIN_TEXT_BASE_BYTES:
+        ratio_text = head_text / base_text if base_text > 0 else 0.0
+        if ratio_text <= DEFAULT_TEXT_DELTA_THRESHOLD and head_text > 0:
+            findings.append({
+                "kind": "TEXT_DELTA",
+                "before_bytes": base_text,
+                "after_bytes": head_text,
+                "ratio": round(ratio_text, 3),
+                "threshold": DEFAULT_TEXT_DELTA_THRESHOLD,
+                "min_base_bytes": DEFAULT_MIN_TEXT_BASE_BYTES,
+            })
+        elif head_text == 0 and base_text > 0:
+            findings.append({
+                "kind": "TEXT_LOST",
+                "before_bytes": base_text,
+                "after_bytes": 0,
+            })
+    base_unav = _summarize_unavailable(nb_base)
+    head_unav = _summarize_unavailable(nb_head)
+    if base_unav == 0 and head_unav > 0:
+        findings.append({
+            "kind": "UNAVAILABLE_SIGNAL",
+            "before_count": 0,
+            "after_count": head_unav,
+        })
+
+    return {
+        "notebook": str(nb_path),
+        "base_ref": base_ref,
+        "head_ref": head_label,
+        "findings": findings,
+        "stats": {
+            "base_total_bytes": sum(base_agg.values()),
+            "head_total_bytes": sum(head_agg.values()),
+            "base_mime_families": sorted(base_agg),
+            "head_mime_families": sorted(head_agg),
+            "threshold": threshold,
+            "min_base_bytes": min_base,
+            # c.358 : dimensions texte separees
+            "base_text_bytes": base_text,
+            "head_text_bytes": head_text,
+            "text_threshold": DEFAULT_TEXT_DELTA_THRESHOLD,
+            "text_min_base_bytes": DEFAULT_MIN_TEXT_BASE_BYTES,
+            "base_unavailable_count": base_unav,
+            "head_unavailable_count": head_unav,
+            "findings_count": len(findings),
+        },
+    }
+
+    return {
+        "notebook": str(nb_path),
+        "base_ref": base_ref,
+        "head_ref": head_label,
+        "findings": findings,
+        "stats": {
+            "base_total_bytes": sum(base_agg.values()),
+            "head_total_bytes": sum(head_agg.values()),
+            "base_mime_families": sorted(base_agg),
+            "head_mime_families": sorted(head_agg),
+            "threshold": threshold,
+            "min_base_bytes": min_base,
+            "findings_count": len(findings),
+        },
+    }
 
     return {
         "notebook": str(nb_path),

--- a/scripts/notebook_tools/check_render_volume_delta.py
+++ b/scripts/notebook_tools/check_render_volume_delta.py
@@ -399,7 +399,17 @@ def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None,
 def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     p.add_argument("notebook", type=Path, help="Chemin vers le .ipynb")
-    p.add_argument("--base", default="origin/main", help="Ref git de la base (defaut origin/main)")
+    p.add_argument(
+        "--base",
+        default=None,
+        help=(
+            "Ref git de la base de PR (defaut: aucun). RECOMMANDE : "
+            "`git merge-base origin/main HEAD` (la base de fusion), PAS "
+            "`origin/main` deux-points. Sur une branche en retard, le "
+            "deux-points inclut les evolutions de main hors PR et fait "
+            "signaler des pertes que la PR n'a pas causees (cf. c.357-L1)."
+        ),
+    )
     p.add_argument("--head", default=None, help="Ref git du head (defaut working tree)")
     p.add_argument("--threshold", type=float, default=DEFAULT_DELTA_THRESHOLD,
                    help=f"Chute relative declenchant un signal (defaut {DEFAULT_DELTA_THRESHOLD})")
@@ -412,6 +422,20 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.notebook.exists():
         print(f"ERROR: notebook introuvable: {args.notebook}", file=sys.stderr)
+        return 2
+
+    # Garde anti-auto-desarmement (c.357-L1 NEW durable) : aucun fallback
+    # silencieux sur `origin/main` deux-points. Si l'appelant ne precise pas
+    # --base, on exige le merge-base explicite. Mieux : echec loud qu'un
+    # verdict silencieusement faux sur 35 notebooks que la PR n'a pas
+    # touches.
+    if args.base is None:
+        print(
+            "ERROR: --base est obligatoire. Precisez la base de fusion "
+            "(`git merge-base origin/main HEAD`) -- PAS `origin/main` "
+            "deux-points (cf. c.357-L1).",
+            file=sys.stderr,
+        )
         return 2
 
     result = scan_notebook(args.notebook, args.base, args.head,

--- a/scripts/notebook_tools/check_render_volume_delta.py
+++ b/scripts/notebook_tools/check_render_volume_delta.py
@@ -1,0 +1,466 @@
+#!/usr/bin/env python3
+"""Detecte la perte de volume de RENDU d'un notebook entre sa base de PR et sa tete (#11656).
+
+Pourquoi cet outil existe
+-------------------------
+Les detecteurs de defaut visuels presents dans le depot
+(``detect_blank_figures.py``, ``detect_svg_empty_display.py``,
+``scan_figure_visual_signature.py``) mesurent tous un **seuil ABSOLU**, sur un
+seul arbre. Le cas fondateur (mesure ai-01 sur PR #11351, base
+``41fb9df9d5``, head ``18d13ddf2133``) prouve leur angle mort :
+
+    Infer-3-Factor-Graphs       45 715 ->    840 B   (-98,2 %)
+    Infer-8-TrueSkill          127 081 ->  1 613 B   (-98,7 %)
+    Infer-13-Crowdsourcing      22 896 ->    840 B   (-96,3 %)
+                                 -------     ------     integralement text/html
+    TOTAL                      195 692 ->  3 293 B   (-98,3 %)
+
+Ces sorties ne sont PAS vides (840-1613 B reste mesurable, > seuil
+blank_figures 70 B) ; elles ne sont PAS ``outputs: []`` (la cellule a un
+output) ; elles ne contiennent PAS de PNG (la perte est du text/html inline
+d'un helper Graphviz). Les trois instruments ne peuvent pas voir ce cas, et
+aucune vigilance supplementaire ne comble cette classe : il faut un organe
+different.
+
+Comment ca marche
+-----------------
+Pour chaque notebook modifie compare entre sa base de PR (defaut
+``origin/main``) et sa tete (working tree ou ref explicite), cet outil :
+
+1. Sommes les volumes de sortie par cellule, par type MIME declare
+   (output ``data`` = MIME majoritaire dans la sortie rendue).
+
+2. Agrège en volume total par (notebook, mime_family) ou ``mime_family in
+   {"text", "image", "html"}``. La cle de granularite est le MIME prefix,
+   pas la MIME exacte (un ``image/png`` 5 100 B et un ``image/jpeg`` 4 500 B
+   sont groupes en ``image``).
+
+3. Seuils (cf. body #11656) :
+   - **DELTA_SIGNAL** : chute >= 50 % du volume (ratio <= 0.5) entre base
+     et head, **ET** volume d'origine >= MIN_BASE_BYTES (1 000 B par
+     famille : eviter le bruit sur quelques octets -- un PNG 70 B qui
+     devient 60 B n'est pas une perte de rendu).
+   - **NEW_MIME** : un type MIME apparait en head absent en base, signale
+     (secondaire -- peut etre un enrichissement legit).
+   - **LOST_MIME** : un type MIME present en base absent en head,
+     signale (primaire -- c'est la signature exacte du cas fondateur).
+
+4. Exemptions explicites (cf. body #11656 + commentaire ai-01) :
+   - Un notebook absent a la base (nouveau fichier, ``path_exists_at_ref``
+     False) est **exempt** : tout est ajout, rien a perdre.
+   - Un ref git invalide (ref manquant, actions/checkout rate) renvoie
+     ``rc=2`` : fail loud preserve (cf. garde anti-auto-desarmement
+     #8655/#8662).
+   - Une sortie EXEMPTE_CELL (cellule explicitement marquee
+     ``"metadata": {"render_exempt": true}`` ou equivalent) ne compte pas
+     dans la somme -- pour les cas ou l'auteur a delibere que le rendu
+     de cette cellule n'etait pas pertinent.
+
+5. Sortie JSON stable (CI machine) ou texte (lecture humaine). Exit codes :
+   - 0 : aucune perte de volume detectee (ou mode non --check)
+   - 1 : perte detectee, --check arme
+   - 2 : erreur structurelle (ref invalide, notebook illisible)
+
+Le seuil -50 % est le compromis demande par ai-01 dans le body #11656 :
+"un defaut **relatif** ; les trois instruments sont **absolus**". Une
+reformulation legitime qui resserre de 10-30 % reste invisible ; une
+detruction de 50 % et plus (le cas fondateur : -96 a -99 %) rougit.
+
+Usage
+-----
+    # un notebook, diff vs origin/main (head = working tree)
+    python check_render_volume_delta.py NB.ipynb --check
+    python check_render_volume_delta.py NB.ipynb --base origin/main --head origin/fix/ma-branche --check
+    # sortie machine
+    python check_render_volume_delta.py NB.ipynb --json
+    # seuils ajustes (utile pour debug ; ne pas toucher en CI)
+    python check_render_volume_delta.py NB.ipynb --threshold 0.7 --min-base 500 --check
+
+Voir aussi
+----------
+- detect_md_content_loss.py -- modele de detecteur base-vs-head (#8655)
+- detect_blank_figures.py / detect_svg_empty_display.py -- instruments
+  absolus qui ratent ce cas
+- scan_figure_visual_signature.py -- signature RGB d'un PNG complet
+- Issue #11656 -- cahier des charges + mesure du cas fondateur
+- PR #11351 -- la PR vivante qui demontre l'angle mort des 3 absolus
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# --- Seuils -----------------------------------------------------------------
+
+# Chute >= 50 % du volume (cf. body #11656 : "seuil -50 %"). Une reformulation
+# legitime qui resserre de 10-30 % reste au-dessus ; une destruction de 50 % et
+# plus rougit (cas fondateur : -96 a -99 %).
+DEFAULT_DELTA_THRESHOLD = 0.50
+# Volume d'origine minimal, par (notebook, mime_family), pour qu'une chute
+# soit signalee. Un PNG de 70 B qui devient 60 B n'est pas une perte ; les
+# sorties de 1 000 B ou plus sont ou du vrai rendu, ou des stubs detectes
+# par d'autres detecteurs.
+DEFAULT_MIN_BASE_BYTES = 1000
+
+# Granularite de MIME prefix : on agrege par famille, pas par MIME exacte. Un
+# ``image/png`` 5 100 B et un ``image/jpeg`` 4 500 B sont groupes en ``image``.
+MIME_PREFIX = re.compile(r"^([^/]+)/")
+
+
+def _mime_family(mime: str) -> str:
+    """Reduit une MIME a sa famille (text, image, html, ...).
+
+    ``text/html`` -> ``text`` ; ``image/png`` -> ``image`` ; ``application/json``
+    -> ``application``. On NE distingue pas text/html de text/plain : un chart
+    SVG inline (``text/html``) et un message d'erreur (``text/plain``)
+    partagent la meme famille ``text``, c'est voulu (le cas fondateur a des
+    sorties ``text/html`` qui passent en dessous du seuil).
+    """
+    m = MIME_PREFIX.match(mime or "")
+    return m.group(1) if m else "other"
+
+
+def _read_notebook_at_ref(nb_path: Path, ref: str) -> dict | None:
+    """Lit le contenu d'un notebook a un ref git donne via ``git show ref:path``."""
+    rel = nb_path.as_posix()
+    try:
+        out = subprocess.run(
+            ["git", "show", f"{ref}:{rel}"],
+            capture_output=True, text=True, encoding="utf-8", check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if out.returncode != 0 or not out.stdout:
+        return None
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _path_exists_at_ref(nb_path: Path, ref: str) -> bool:
+    """True si le chemin existe a ce ref (``git cat-file -e``), False sinon.
+
+    Distingue un notebook **NOUVEAU** (exempt -- rien a perdre, tout est
+    ajout) d'un notebook **EXISTANT mais illisible** (rc=2 -- ref casse,
+    detecteur defectueux, ou NB corrompu a la base). Sans cette distinction,
+    un BASE casse desarme silencieusement le garde -- toute la PR semblerait
+    "nouveau fichier" et rc=0 partout (cf. garde anti-auto-desarmement
+    #8655/#8662).
+    """
+    rel = nb_path.as_posix()
+    try:
+        out = subprocess.run(
+            ["git", "cat-file", "-e", f"{ref}:{rel}"],
+            capture_output=True, check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return out.returncode == 0
+
+
+def _ref_resolves(ref: str) -> bool:
+    """True si le ref git existe, False sinon (gates anti-auto-desarmement)."""
+    try:
+        out = subprocess.run(
+            ["git", "cat-file", "-e", ref],
+            capture_output=True, check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return False
+    return out.returncode == 0
+
+
+def _cell_is_exempt(cell: dict) -> bool:
+    """True si la cellule porte une exemption explicite (``render_exempt``).
+
+    Forme attendue : ``cell.metadata.render_exempt == true`` (booleen YAML)
+    ou ``cell.metadata["render_exempt"] == "true"`` (chaine YAML). On
+    accepte les deux pour tolerer le round-trip YAML/JSON de nbformat. Pas
+    d'exemption au niveau notebook : si l'auteur veut exempter tout un
+    notebook, il pose ``render_exempt: true`` sur chaque cellule concernee
+    (ou split le notebook).
+    """
+    meta = cell.get("metadata") or {}
+    val = meta.get("render_exempt", False)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str) and val.lower() in ("true", "yes", "1"):
+        return True
+    return False
+
+
+def _decode_output_bytes(output: dict) -> int:
+    """Decode les data base64 d'un output Jupyter et retourne le nombre d'octets.
+
+    Gere les deux formes rencontrees dans le depot :
+    - ``output.data`` dict avec MIME -> data : { 'image/png': 'base64,...' }
+    - ``output.text`` str (text/html, text/plain, stream, ...)
+    """
+    data = output.get("data")
+    if isinstance(data, dict):
+        total = 0
+        for mime, payload in data.items():
+            if isinstance(payload, str):
+                # Les data base64 commencent par le payload brut (avec ou sans
+                # prefixe ``data:<mime>;base64,``). On accepte les deux.
+                if payload.startswith("data:"):
+                    try:
+                        b64 = payload.split(",", 1)[1]
+                        total += len(base64.b64decode(b64, validate=False))
+                    except (ValueError, IndexError):
+                        total += len(payload)
+                else:
+                    total += len(payload.encode("utf-8"))
+            elif isinstance(payload, (list, tuple)):
+                # forme stream/output_data : on prend tout en str
+                total += sum(len(p) for p in payload if isinstance(p, str))
+        return total
+    text = output.get("text")
+    if isinstance(text, str):
+        return len(text.encode("utf-8"))
+    if isinstance(text, (list, tuple)):
+        return sum(len(t) for t in text if isinstance(t, str))
+    return 0
+
+
+def _summarize_outputs(nb: dict) -> dict[tuple[str, str], int]:
+    """Agrege les volumes de sortie par (cell_id_or_index, mime_family).
+
+    Retourne ``{(cell_key, mime_family): bytes}``. La cle ``cell_key`` est
+    l'attribut ``id`` de cellule nbformat 4.5+ quand present, sinon l'index
+    de cellule en str. Volume mesure : base64 decode si MIME-image,
+    longueur utf-8 si MIME-text / plaintext / HTML inline.
+
+    NB : on cumule par ``(cell_key, mime_family)`` et pas par MIME exacte :
+    un meme chart SVG inline peut apparaitre sous ``text/html`` ET
+    ``image/svg+xml`` dans le meme output, on veut agreger cela en un seul
+    volume.
+    """
+    out: dict[tuple[str, str], int] = {}
+    for idx, cell in enumerate(nb.get("cells", [])):
+        if _cell_is_exempt(cell):
+            continue
+        cid = cell.get("id") or f"idx{idx}"
+        outs = cell.get("outputs") or []
+        for outp in outs:
+            mime_fam = "other"
+            data = outp.get("data")
+            if isinstance(data, dict) and data:
+                # Famille = la premiere cle MIME trouvee
+                first_mime = next(iter(data.keys()), "")
+                mime_fam = _mime_family(first_mime)
+            elif "text" in outp:
+                mime_fam = _mime_family("text/plain")
+            nbytes = _decode_output_bytes(outp)
+            key = (cid, mime_fam)
+            out[key] = out.get(key, 0) + nbytes
+    return out
+
+
+def _aggregate_by_family(per_cell: dict[tuple[str, str], int]) -> dict[str, int]:
+    """Agrege par famille MIME en sommant sur les cellules.
+
+    Retourne ``{mime_family: bytes_total}``.
+    """
+    agg: dict[str, int] = {}
+    for (_, fam), n in per_cell.items():
+        agg[fam] = agg.get(fam, 0) + n
+    return agg
+
+
+def _diff_families(base_agg: dict[str, int], head_agg: dict[str, int],
+                   threshold: float, min_base: int) -> list[dict]:
+    """Compare les volumes agreges par famille entre base et head.
+
+    Genere les findings ``DELTA_SIGNAL`` (chute >= threshold dans une famille
+    deja presente), ``LOST_MIME`` (famille disparue), ``NEW_MIME`` (famille
+    apparue, secondaire).
+    """
+    findings: list[dict] = []
+    families = set(base_agg) | set(head_agg)
+    for fam in sorted(families):
+        b = base_agg.get(fam, 0)
+        h = head_agg.get(fam, 0)
+        if b == 0 and h == 0:
+            continue
+        if b > 0 and h == 0:
+            # Famille disparue -- le cas fondateur strict : la famille `text`
+            # etait a 195 692 B en base, tombe a 3 293 B en head par perte
+            # majoritaire ; ici on signale aussi une disparition totale
+            # (famille absente du head) qui est un sous-cas.
+            findings.append({
+                "kind": "LOST_MIME",
+                "mime_family": fam,
+                "before_bytes": b,
+                "after_bytes": h,
+            })
+            continue
+        if b == 0 and h > 0:
+            # Famille apparue : peut etre un enrichissement legitime. On
+            # signale en secondaire (le reviewer tranche).
+            findings.append({
+                "kind": "NEW_MIME",
+                "mime_family": fam,
+                "before_bytes": b,
+                "after_bytes": h,
+            })
+            continue
+        # b > 0 et h > 0 : on mesure la chute relative.
+        ratio = h / b
+        if b >= min_base and ratio <= threshold:
+            findings.append({
+                "kind": "DELTA_SIGNAL",
+                "mime_family": fam,
+                "before_bytes": b,
+                "after_bytes": h,
+                "ratio": round(ratio, 3),
+                "threshold": threshold,
+                "min_base_bytes": min_base,
+            })
+    return findings
+
+
+def scan_notebook(nb_path: Path, base_ref: str, head_ref: str | None = None,
+                  threshold: float = DEFAULT_DELTA_THRESHOLD,
+                  min_base: int = DEFAULT_MIN_BASE_BYTES) -> dict:
+    """Compare le volume de rendu d'un notebook entre base_ref et head_ref."""
+    if head_ref is None:
+        try:
+            nb_head = json.loads(nb_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as e:
+            return {"notebook": str(nb_path), "error": f"head unreadable: {e}"}
+        head_label = "working_tree"
+    else:
+        nb_head = _read_notebook_at_ref(nb_path, head_ref)
+        if nb_head is None:
+            return {"notebook": str(nb_path), "error": f"head_ref {head_ref} unreadable"}
+        head_label = head_ref
+
+    # Garde anti-auto-desarmement : un ref de base invalide (ref manquant,
+    # actions/checkout rate) ferait passer toute la PR pour "nouveau
+    # fichier" via ``path_exists_at_ref`` -> False -> exemption -> rc=0.
+    if not _ref_resolves(base_ref):
+        return {"notebook": str(nb_path),
+                "error": f"base_ref {base_ref} introuvable (ref git invalide)"}
+
+    # Notebook NOUVEAU (absent a la base) : exempt (rien a perdre, tout est
+    # ajout). Renvoie un resultat propre (findings=[]) plutot que de
+    # declencher rc=2 / "unreadable" sur toute creation de notebook.
+    if not _path_exists_at_ref(nb_path, base_ref):
+        head_agg = _aggregate_by_family(_summarize_outputs(nb_head))
+        return {
+            "notebook": str(nb_path),
+            "base_ref": base_ref,
+            "head_ref": head_label,
+            "new_file": True,
+            "findings": [],
+            "stats": {
+                "base_total_bytes": 0,
+                "head_total_bytes": sum(head_agg.values()),
+                "head_mime_families": sorted(head_agg),
+                "threshold": threshold,
+                "min_base_bytes": min_base,
+                "findings_count": 0,
+            },
+        }
+
+    nb_base = _read_notebook_at_ref(nb_path, base_ref)
+    if nb_base is None:
+        return {"notebook": str(nb_path),
+                "error": f"base_ref {base_ref} unreadable"}
+
+    base_agg = _aggregate_by_family(_summarize_outputs(nb_base))
+    head_agg = _aggregate_by_family(_summarize_outputs(nb_head))
+    findings = _diff_families(base_agg, head_agg, threshold, min_base)
+
+    return {
+        "notebook": str(nb_path),
+        "base_ref": base_ref,
+        "head_ref": head_label,
+        "findings": findings,
+        "stats": {
+            "base_total_bytes": sum(base_agg.values()),
+            "head_total_bytes": sum(head_agg.values()),
+            "base_mime_families": sorted(base_agg),
+            "head_mime_families": sorted(head_agg),
+            "threshold": threshold,
+            "min_base_bytes": min_base,
+            "findings_count": len(findings),
+        },
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("notebook", type=Path, help="Chemin vers le .ipynb")
+    p.add_argument("--base", default="origin/main", help="Ref git de la base (defaut origin/main)")
+    p.add_argument("--head", default=None, help="Ref git du head (defaut working tree)")
+    p.add_argument("--threshold", type=float, default=DEFAULT_DELTA_THRESHOLD,
+                   help=f"Chute relative declenchant un signal (defaut {DEFAULT_DELTA_THRESHOLD})")
+    p.add_argument("--min-base", type=int, default=DEFAULT_MIN_BASE_BYTES,
+                   dest="min_base",
+                   help=f"Volume d'origine min par famille (defaut {DEFAULT_MIN_BASE_BYTES} B)")
+    p.add_argument("--check", action="store_true", help="Exit 1 si perte detectee (CI)")
+    p.add_argument("--json", action="store_true", help="Sortie JSON machine")
+    args = p.parse_args(argv)
+
+    if not args.notebook.exists():
+        print(f"ERROR: notebook introuvable: {args.notebook}", file=sys.stderr)
+        return 2
+
+    result = scan_notebook(args.notebook, args.base, args.head,
+                           args.threshold, args.min_base)
+
+    if "error" in result:
+        print(f"ERROR: {result['error']}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        nb = result["notebook"]
+        st = result["stats"]
+        fins = result["findings"]
+        print(f"[NOTEBOOK] {nb}")
+        print(f"[BASE]     {result['base_ref']}")
+        print(f"[HEAD]     {result['head_ref']}")
+        if result.get("new_file"):
+            print("[NEW FILE] absent a la base -> exempt "
+                  "(rien a perdre, tout est ajout ; #11656).")
+        print(f"[STATS]    total base={st['base_total_bytes']}B "
+              f"head={st['head_total_bytes']}B | "
+              f"families base={st['base_mime_families']} "
+              f"head={st['head_mime_families']} | "
+              f"seuil={st['threshold']} min_base={st['min_base_bytes']}B | "
+              f"findings={st['findings_count']}")
+        if fins:
+            print("\n[FINDINGS]")
+            for f in fins:
+                kind = f["kind"]
+                fam = f["mime_family"]
+                before = f["before_bytes"]
+                after = f["after_bytes"]
+                if kind == "DELTA_SIGNAL":
+                    print(f"  - {kind}: famille '{fam}' chute de {before}B a {after}B "
+                          f"(ratio {f['ratio']}, seuil {f['threshold']}, "
+                          f"min_base {f['min_base_bytes']}B)")
+                elif kind == "LOST_MIME":
+                    print(f"  - {kind}: famille '{fam}' disparue du head "
+                          f"(base {before}B, head {after}B)")
+                elif kind == "NEW_MIME":
+                    print(f"  - {kind}: famille '{fam}' apparue au head "
+                          f"(base {before}B, head {after}B)")
+
+    if args.check and result["findings"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_check_render_volume_delta.py
+++ b/scripts/notebook_tools/tests/test_check_render_volume_delta.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+"""Tests for ``scripts/notebook_tools/check_render_volume_delta.py`` (#11656).
+
+Why this exists
+---------------
+#11656 demands **contrôle positif obligatoire dans les tests** :
+un cas connu de perte de rendu (mimicking #11351, base 195 692 B -> head
+3 293 B, -98 %) DOIT faire rougir le detecteur. Sans ce cas, l'instrument
+pourrait passer en CI avec un bug silencieux et personne ne le verrait
+avant une vraie perte. Cf. lecons c.344-L1 ★★ et c.342-L1 ★ : un test
+pin se valide par ses **faux negatifs**, pas par ses hits.
+
+Mesure du cas fondateur (ai-01 verbatim, post-merge #11351) :
+
+    Infer-3-Factor-Graphs       45 715 ->    840 B   (-98,2 %)
+    Infer-8-TrueSkill          127 081 ->  1 613 B   (-98,7 %)
+    Infer-13-Crowdsourcing      22 896 ->    840 B   (-96,3 %)
+    TOTAL                      195 692 ->  3 293 B   (-98,3 %)
+
+Ces sorties ne sont PAS vides (840-1613 B > seuil blank_figures 70 B), ne
+sont PAS ``outputs: []``, ne contiennent PAS de PNG (la perte est du
+``text/html`` inline d'un helper Graphviz). Les trois instruments absolus
+ne peuvent pas voir ce cas ; ``check_render_volume_delta.py`` doit le
+voir.
+
+Acceptance gate
+---------------
+La suite pytest DOIT contenir au minimum :
+
+1. **test_known_loss_case_must_rougir** -- le cas fondateur simule
+   (notebook avec sortie ``text/html`` de 12 500 B en base, devenu 250 B
+   en head) DOIT declencher ``DELTA_SIGNAL`` et faire rougir ``--check``.
+2. **test_roundtrip_clean_baseline_passes** -- un notebook inchange entre
+   base et head ne declenche AUCUN finding (rc=0).
+3. **test_new_file_is_exempt** -- un notebook absent a la base ne declenche
+   AUCUN finding (exempt par construction).
+4. **test_exempt_cell_is_skipped** -- une cellule marquee
+   ``render_exempt: true`` ne compte pas dans la somme, meme si sa sortie
+   chute.
+5. **test_min_base_below_threshold_ignored** -- une chute relative sous
+   ``--min-base`` ne declenche pas de finding (evite le bruit sur quelques
+   octets).
+6. **test_ref_invalid_returns_error** -- un ref git invalide declenche
+   rc=2 (garde anti-auto-desarmement, cf. #8655/#8662).
+7. **test_new_mime_is_signaled_but_not_failure** -- une famille MIME
+   apparue au head est signalee mais ne fait PAS rougir en --check par
+   defaut (enrichissement legit).
+
+Les tests sont **mutuellement independants** : un faux (par exemple un
+seuil oublie) ne doit faire rougir que le test qui pin cette specificite,
+pas la suite entiere (cf. mutation testing par faux negatifs, lecon
+c.344-L1 ★★).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+TOOL = HERE.parent / "check_render_volume_delta.py"
+REPO_ROOT = HERE.parents[2]
+
+sys.path.insert(0, str(HERE.parent))
+import check_render_volume_delta as crvd  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cell_with_text_html(text: str, cell_id: str) -> dict:
+    """Construit une cellule avec un output ``text/html`` d'une longueur donnee."""
+    return {
+        "cell_type": "code",
+        "id": cell_id,
+        "metadata": {},
+        "source": [],
+        "execution_count": 1,
+        "outputs": [
+            {
+                "output_type": "display_data",
+                "data": {"text/html": text},
+                "metadata": {},
+            }
+        ],
+    }
+
+
+def _make_cell_with_text_html_bytes(nbytes: int, cell_id: str) -> dict:
+    """Cellule avec une sortie ``text/html`` de ``nbytes`` octets (ASCII fill)."""
+    return _make_cell_with_text_html("x" * nbytes, cell_id)
+
+
+def _make_cell_exempt(text: str, cell_id: str) -> dict:
+    """Cellule dont l'output est marque exempt via ``render_exempt: true``."""
+    return {
+        "cell_type": "code",
+        "id": cell_id,
+        "metadata": {"render_exempt": True},
+        "source": [],
+        "execution_count": 1,
+        "outputs": [
+            {
+                "output_type": "display_data",
+                "data": {"text/html": text},
+                "metadata": {},
+            }
+        ],
+    }
+
+
+def _nb_path() -> Path:
+    """Chemin du notebook que les tests utilisent (relatif a REPO_ROOT)."""
+    return Path("scripts/notebook_tools/tests/fixtures/render_volume_delta_case.ipynb")
+
+
+def _write_nb(rel_path: Path, nb: dict) -> Path:
+    """Ecrit un notebook sur disque (relatif a REPO_ROOT) et retourne le chemin absolu."""
+    abs_path = REPO_ROOT / rel_path
+    abs_path.parent.mkdir(parents=True, exist_ok=True)
+    abs_path.write_text(json.dumps(nb, ensure_ascii=False, indent=1), encoding="utf-8")
+    return abs_path
+
+
+# ---------------------------------------------------------------------------
+# Pure unit tests (sans git)
+# ---------------------------------------------------------------------------
+
+
+def test_mime_family_aggregation():
+    """``text/html`` et ``image/png`` sont agreges par famille."""
+    nbytes_text = 1000
+    nbytes_png_b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII="
+    # Le base64 ci-dessus decode a 60 octets (90 chars de payload, dont 2
+    # de padding ; 90 * 3 / 4 - 2 = ~65, arrondi). On teste juste que
+    # ``image`` est > 0 et agrege par famille (pas la valeur exacte, qui
+    # depend du decoder base64).
+    nb = {
+        "cells": [
+            _make_cell_with_text_html_bytes(nbytes_text, "c1"),
+            {
+                "cell_type": "code",
+                "id": "c2",
+                "metadata": {},
+                "source": [],
+                "execution_count": 1,
+                "outputs": [
+                    {
+                        "output_type": "display_data",
+                        "data": {"image/png": nbytes_png_b64},
+                        "metadata": {},
+                    }
+                ],
+            },
+        ]
+    }
+    per_cell = crvd._summarize_outputs(nb)
+    agg = crvd._aggregate_by_family(per_cell)
+    assert agg.get("text") == nbytes_text
+    assert agg.get("image") is not None and agg["image"] > 0, (
+        f"famille image doit etre agregee avec un volume > 0, got {agg}"
+    )
+
+
+def test_cell_exempt_skipped():
+    """Une cellule ``render_exempt: true`` ne contribue pas au volume."""
+    nb = {
+        "cells": [
+            _make_cell_exempt("x" * 5000, "c1"),  # 5000 B non comptes
+            _make_cell_with_text_html_bytes(200, "c2"),
+        ]
+    }
+    per_cell = crvd._summarize_outputs(nb)
+    agg = crvd._aggregate_by_family(per_cell)
+    assert agg.get("text") == 200, (
+        f"cell exempt doit etre ignoree (volume 200B attendu), got {agg}"
+    )
+
+
+def test_diff_known_loss_triggers_delta_signal():
+    """Cas fondateur : chute 98 % d'une famille MIME -> DELTA_SIGNAL.
+
+    C'est le **contrôle positif obligatoire** demande par #11656. Ce test
+    DOIT rougir si le détecteur ne sait pas voir une perte de 98 %. C'est
+    le miroir du cas reel (#11351, 195 692 B -> 3 293 B).
+    """
+    base_agg = {"text": 12_500, "image": 4_000}
+    head_agg = {"text": 250, "image": 4_000}  # text chute de 98 %
+    findings = crvd._diff_families(base_agg, head_agg,
+                                   threshold=0.50, min_base=1000)
+    delta = [f for f in findings if f["kind"] == "DELTA_SIGNAL"]
+    assert len(delta) == 1, f"cas fondateur doit rougir, got findings={findings}"
+    sig = delta[0]
+    assert sig["mime_family"] == "text"
+    assert sig["before_bytes"] == 12_500
+    assert sig["after_bytes"] == 250
+    assert sig["ratio"] == 0.02  # 250/12500 = 0.02
+
+
+def test_diff_clean_passes_no_find():
+    """Base == head, pas de finding."""
+    base_agg = {"text": 12_500, "image": 4_000}
+    head_agg = {"text": 12_500, "image": 4_000}
+    findings = crvd._diff_families(base_agg, head_agg,
+                                   threshold=0.50, min_base=1000)
+    assert findings == [], f"notebook inchange ne doit rien signaler, got {findings}"
+
+
+def test_diff_lost_mime_triggers():
+    """Une famille disparue (b>0, h=0) declenche LOST_MIME (cas strict)."""
+    base_agg = {"text": 12_500}
+    head_agg = {"text": 12_500, "image": 3_000}  # image apparait
+    # Maintenant l'inverse : base a image, head n'en a plus.
+    base_agg2 = {"text": 12_500, "image": 3_000}
+    head_agg2 = {"text": 12_500}  # image disparue
+    findings = crvd._diff_families(base_agg2, head_agg2,
+                                   threshold=0.50, min_base=1000)
+    lost = [f for f in findings if f["kind"] == "LOST_MIME"]
+    assert len(lost) == 1 and lost[0]["mime_family"] == "image"
+
+
+def test_diff_new_mime_signaled_but_distinct():
+    """Une famille apparue signalee en NEW_MIME, distincte de DELTA_SIGNAL."""
+    base_agg = {"text": 12_500}
+    head_agg = {"text": 12_500, "image": 3_000}
+    findings = crvd._diff_families(base_agg, head_agg,
+                                   threshold=0.50, min_base=1000)
+    new = [f for f in findings if f["kind"] == "NEW_MIME"]
+    assert len(new) == 1 and new[0]["mime_family"] == "image"
+
+
+def test_diff_below_min_base_ignored():
+    """Une chute en-dessous de ``--min-base`` ne rougit PAS (evite bruit)."""
+    base_agg = {"text": 800}  # < min_base 1000
+    head_agg = {"text": 100}
+    findings = crvd._diff_families(base_agg, head_agg,
+                                   threshold=0.50, min_base=1000)
+    assert findings == [], (
+        f"chute sous min_base doit etre ignoree, got findings={findings}"
+    )
+
+
+def test_diff_threshold_respected():
+    """Un ratio > threshold ne rougit PAS (reformulation legitime)."""
+    base_agg = {"text": 12_500}
+    head_agg = {"text": 7_500}  # ratio 0.6 (60 %), > 0.50
+    findings = crvd._diff_families(base_agg, head_agg,
+                                   threshold=0.50, min_base=1000)
+    assert findings == [], (
+        f"chute 60% (au-dessus du seuil 50%) ne doit pas rougir, "
+        f"got findings={findings}"
+    )
+
+
+def test_decode_output_bytes_handles_text_and_data():
+    """``_decode_output_bytes`` gere les deux formes (data dict + text plain)."""
+    out_data = {
+        "output_type": "display_data",
+        "data": {"text/html": "x" * 200},
+    }
+    out_text = {"output_type": "stream", "text": "hello"}
+    assert crvd._decode_output_bytes(out_data) == 200
+    assert crvd._decode_output_bytes(out_text) == 5  # len("hello")
+
+
+def test_decode_handles_data_url_prefix():
+    """Un payload ``data:image/png;base64,XXX`` est decode correctement."""
+    # 1 octet = 4 chars base64 ; 4 octets utiles = padding minimum
+    payload = "iVBORw0KGgo="  # 12 chars base64 -> 9 octets
+    out = {
+        "output_type": "display_data",
+        "data": {"image/png": f"data:image/png;base64,{payload}"},
+    }
+    decoded = crvd._decode_output_bytes(out)
+    # 12 chars / 4 * 3 = 9 octets, arrondi a la baisse pour padding
+    assert decoded >= 6, f"base64 prefix doit decoder, got {decoded}"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (avec subprocess pour valider --check, --json, exit codes)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_new_file_is_exempt(tmp_path):
+    """Notebook absent a la base -> exempt, rc=0, finding_count=0.
+
+    On ecrit un notebook neuf (jamais committe), ``--base origin/main`` ne
+    le trouve pas -> exemption (rien a perdre, tout est ajout).
+    """
+    nb = {
+        "cells": [_make_cell_with_text_html_bytes(5000, "c1")],
+    }
+    nb_rel = _nb_path()
+    _write_nb(nb_rel, nb)
+    try:
+        # --head omis -> working tree (le fichier qu'on vient d'ecrire)
+        result = subprocess.run(
+            [sys.executable, str(TOOL), str(nb_rel),
+             "--base", "origin/main",
+             "--check", "--json"],
+            capture_output=True, text=True, encoding="utf-8",
+            cwd=REPO_ROOT, check=False,
+        )
+        # rc=0 (exempt)
+        assert result.returncode == 0, (
+            f"nouveau fichier doit etre exempt (rc=0), got rc={result.returncode} "
+            f"stderr={result.stderr[:500]}"
+        )
+        # JSON valide
+        out = json.loads(result.stdout)
+        assert out.get("new_file") is True
+        assert out.get("findings") == []
+    finally:
+        # Cleanup
+        (REPO_ROOT / nb_rel).unlink(missing_ok=True)
+
+
+def test_cli_known_loss_case_must_rougir(tmp_path):
+    """#11656 -- contrôle positif obligatoire : un notebook avec perte de
+    98% de son volume de sortie text DOIT faire rougir ``--check``.
+
+    Sans ce test, l'instrument peut passer en CI avec un bug silencieux et
+    personne ne le voit avant une vraie perte.
+
+    Ici, on utilise ``scan_notebook()`` directement (pas le CLI), en lui
+    passant des notebooks en memoire. Le test verify que la detection se
+    fait au niveau de l'API Python (la ou le CI l'appellera), pas
+    seulement dans la fonction ``_diff_families``.
+    """
+    base_nb = {
+        "cells": [_make_cell_with_text_html_bytes(12_500, "c1")],
+    }
+    head_nb = {
+        "cells": [_make_cell_with_text_html_bytes(250, "c1")],  # -98%
+    }
+    # On monkeypatche les helpers git pour bypasser la dependance HEAD.
+    orig_read = crvd._read_notebook_at_ref
+    orig_exists = crvd._path_exists_at_ref
+    orig_resolves = crvd._ref_resolves
+    crvd._read_notebook_at_ref = lambda path, ref: (
+        base_nb if "base" in str(ref) else head_nb
+    )
+    crvd._path_exists_at_ref = lambda path, ref: True
+    crvd._ref_resolves = lambda ref: True
+    try:
+        result = crvd.scan_notebook(
+            Path("dummy.ipynb"), base_ref="base-ref", head_ref="head-ref",
+        )
+    finally:
+        crvd._read_notebook_at_ref = orig_read
+        crvd._path_exists_at_ref = orig_exists
+        crvd._ref_resolves = orig_resolves
+
+    # Cas fondateur : chute 98% -> DELTA_SIGNAL
+    assert result["stats"]["findings_count"] == 1, (
+        f"cas fondateur doit declencher 1 finding, got {result}"
+    )
+    delta = [f for f in result["findings"] if f["kind"] == "DELTA_SIGNAL"]
+    assert len(delta) == 1
+    assert delta[0]["mime_family"] == "text"
+    assert delta[0]["ratio"] == 0.02
+
+
+def test_cli_ref_invalid_returns_error_rc2(tmp_path):
+    """Ref invalide -> rc=2 (garde anti-auto-desarmement #8655/#8662).
+
+    On utilise ``scan_notebook()`` directement : un ref de base invalide
+    (que ``_ref_resolves`` rejette) renvoie un dict avec ``"error"``,
+    que ``main()`` traduit en rc=2.
+    """
+    nb = {"cells": [_make_cell_with_text_html_bytes(5_000, "c1")]}
+    nb_rel = _nb_path()
+    abs_path = _write_nb(nb_rel, nb)
+    try:
+        orig_resolves = crvd._ref_resolves
+        crvd._ref_resolves = lambda ref: False  # ref bidon
+        try:
+            result = crvd.scan_notebook(abs_path, base_ref="ce-ref-bidon")
+        finally:
+            crvd._ref_resolves = orig_resolves
+        assert "error" in result
+        assert "introuvable" in result["error"] or "invalide" in result["error"]
+    finally:
+        abs_path.unlink(missing_ok=True)
+
+
+def test_cli_missing_notebook_returns_error_rc2(tmp_path):
+    """Notebook inexistant sur disque -> rc=2."""
+    result = subprocess.run(
+        [sys.executable, str(TOOL), "scripts/notebook_tools/tests/fixtures/does_not_exist.ipynb",
+         "--base", "HEAD", "--head", "HEAD", "--check"],
+        capture_output=True, text=True, encoding="utf-8",
+        cwd=REPO_ROOT, check=False,
+    )
+    assert result.returncode == 2
+    assert "introuvable" in result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Mutation testing -- revert la logique de seuil DOIT faire rougir
+# test_diff_known_loss_triggers_delta_signal, sans affecter les autres.
+# (Documentation -- pas execute comme test, c'est un commentaire destine
+# a l'auditeur qui verifie que les tests pin SPECIFIQUEMENT le seuil.)
+# ---------------------------------------------------------------------------
+#
+# Revert 1 : _diff_families ignore ``min_base`` (utilise toujours 0)
+# -> test_diff_below_min_base_ignored ROUGE (signal declenche sur 800 B)
+# -> test_diff_known_loss_triggers_delta_signal RESTE VERT (12 500 > 0)
+# -> autres tests : pas de changement.
+#
+# Revert 2 : _diff_families ignore ``threshold`` (utilise toujours 1.0)
+# -> test_diff_threshold_respected ROUGE (chute 60% declenche maintenant)
+# -> test_diff_known_loss_triggers_delta_signal RESTE VERT (98% > 1.0 non,
+#    en fait 0.02 <= 1.0 declencherait ; ce test-ci rougit aussi -- c'est
+#    un signal que le pin n'est pas mutuellement exclusif, et il faut
+#    resserrer : ajouter un test qui pin SPECIFIQUEMENT "98% declenche
+#    alors que 60% ne declenche pas". Cf. TODO en bas.)
+# -> test_diff_clean_passes_no_find RESTE VERT (12 500 == 12 500)
+#
+# Revert 3 : _mime_family retourne toujours "other"
+# -> test_mime_family_aggregation ROUGE (text/image non differencies)
+# -> autres : pas de changement direct.
+#
+# Revert 4 : _cell_is_exempt retourne toujours False
+# -> test_cell_exempt_skipped ROUGE (cell exempt comptee, 5200 au lieu
+#    de 200).
+# -> autres : pas de changement direct.
+
+
+def test_pin_threshold_excludes_moderate_chute():
+    """Pin mutuellement exclusif au précédent : un chute de 60% NE rougit PAS.
+
+    Cf. mutation test 2 ci-dessus : si on casse le seuil (toujours 1.0),
+    CE test rougit EN PLUS de ``test_diff_threshold_respected``. Sans ce
+    test, la mutation ``threshold=1.0`` reste invisible (les deux
+    rougeurs sont confondues en une).
+    """
+    # Cas : base 12 500 B, head 7 500 B = ratio 0.6 (60% de chute).
+    # Seuil 0.50 -> 0.6 > 0.5 -> PAS de finding.
+    base_agg = {"text": 12_500}
+    head_agg = {"text": 7_500}
+    findings = crvd._diff_families(base_agg, head_agg,
+                                   threshold=0.50, min_base=1000)
+    assert findings == [], (
+        f"chute 60% doit PAS rougir au seuil 50%, got findings={findings}"
+    )
+    # Cas : base 12 500 B, head 250 B = ratio 0.02 (98% de chute).
+    # Seuil 0.50 -> 0.02 <= 0.5 -> DOIT rougir.
+    head_agg2 = {"text": 250}
+    findings2 = crvd._diff_families(base_agg, head_agg2,
+                                    threshold=0.50, min_base=1000)
+    delta = [f for f in findings2 if f["kind"] == "DELTA_SIGNAL"]
+    assert len(delta) == 1, (
+        "chute 98% DOIT rougir -- mutation qui casse le seuil ferait "
+        "passer les deux tests simultanement, prouvant que ce pin "
+        "disjoint protege contre la confusion."
+    )

--- a/scripts/notebook_tools/tests/test_check_render_volume_delta.py
+++ b/scripts/notebook_tools/tests/test_check_render_volume_delta.py
@@ -285,38 +285,88 @@ def test_decode_handles_data_url_prefix():
 # ---------------------------------------------------------------------------
 
 
+def _init_git_repo_with_nb(tmp_path: Path, nb: dict, nb_name: str = "new.ipynb") -> tuple[Path, str]:
+    """Initialise un mini-repo git jetable dans ``tmp_path`` avec un commit initial
+    vide, puis commit ``nb_name`` (contenant le notebook ``nb``) en second commit.
+
+    Retourne ``(nb_absolu, nb_rel)`` -- le chemin absolu pour ecrire le
+    fichier et le nom relatif passe au tool CLI (qui le combine avec le cwd
+    pour construire ``git show HEAD:rel``). Les refs accessibles localement
+    sont ``HEAD~1`` (avant le notebook) et ``HEAD`` (avec le notebook), ce qui
+    permet de tester "fichier neuf donc exempt" sans dependre de la
+    topologie du checkout CI (cf. fix (b) DM ai-01 2026-08-18 : un test
+    unitaire ne devrait pas depender de ``origin/main``).
+    """
+    nb_abs = tmp_path / nb_name
+    nb_abs.write_text(json.dumps(nb, ensure_ascii=False, indent=1), encoding="utf-8")
+
+    def _git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path, capture_output=True, text=True, encoding="utf-8",
+            check=check,
+        )
+
+    _git("init", "-q")
+    _git("config", "user.email", "test@example.com")
+    _git("config", "user.name", "Test")
+    # Premier commit : fichier sentinel vide (etabli HEAD~1)
+    sentinel = tmp_path / ".keep"
+    sentinel.write_text("", encoding="utf-8")
+    _git("add", ".keep")
+    _git("commit", "-q", "-m", "init")
+    # Second commit : ajoute le notebook
+    _git("add", nb_name)
+    _git("commit", "-q", "-m", "add notebook")
+    return nb_abs, nb_name
+
+
 def test_cli_new_file_is_exempt(tmp_path):
     """Notebook absent a la base -> exempt, rc=0, finding_count=0.
 
-    On ecrit un notebook neuf (jamais committe), ``--base origin/main`` ne
-    le trouve pas -> exemption (rien a perdre, tout est ajout).
+    Test hermetique : on initialise un mini-repo git jetable dans
+    ``tmp_path`` avec le notebook committe seulement en ``HEAD``. Le tool
+    est appele avec ``--base HEAD~1`` (avant le notebook), ce qui rend le
+    notebook absent a la base : exemption, findings vides, rc=0.
+
+    Pourquoi ne plus utiliser ``--base origin/main`` : sous
+    ``actions/checkout`` (fetch-depth 1) le ref ``origin/main`` n'existe
+    pas, le tool renvoie rc=2, et le test echoue -- alors que le
+    comportement reel est correct (ref invalide = garde
+    anti-auto-desarmement, pas un defaut du detecteur). Cette dependance
+    a la topologie du runner rendait le test inutilement fragile (cf. DM
+    ai-01 2026-08-18T19:05Z, option (b) : rendre le test hermetique).
+
+    Le chemin du notebook est passe en chemin RELATIF (``nb_name``) au tool,
+    combine avec ``cwd=tmp_path`` -- le tool construit ``git show
+    HEAD:new.ipynb`` qui resout dans le repo jetable.
     """
     nb = {
         "cells": [_make_cell_with_text_html_bytes(5000, "c1")],
     }
-    nb_rel = _nb_path()
-    _write_nb(nb_rel, nb)
+    _nb_abs, nb_rel = _init_git_repo_with_nb(tmp_path, nb, nb_name="new.ipynb")
     try:
-        # --head omis -> working tree (le fichier qu'on vient d'ecrire)
+        # --base HEAD~1 -> le notebook n'existe qu'en HEAD -> exempt
+        # --head HEAD    -> on lit la version commitee (pas working tree)
         result = subprocess.run(
-            [sys.executable, str(TOOL), str(nb_rel),
-             "--base", "origin/main",
+            [sys.executable, str(TOOL), nb_rel,
+             "--base", "HEAD~1", "--head", "HEAD",
              "--check", "--json"],
             capture_output=True, text=True, encoding="utf-8",
-            cwd=REPO_ROOT, check=False,
+            cwd=tmp_path, check=False,
         )
         # rc=0 (exempt)
         assert result.returncode == 0, (
             f"nouveau fichier doit etre exempt (rc=0), got rc={result.returncode} "
-            f"stderr={result.stderr[:500]}"
+            f"stderr={result.stderr[:500]} stdout={result.stdout[:500]}"
         )
         # JSON valide
         out = json.loads(result.stdout)
         assert out.get("new_file") is True
         assert out.get("findings") == []
     finally:
-        # Cleanup
-        (REPO_ROOT / nb_rel).unlink(missing_ok=True)
+        # Cleanup handled par tmp_path (fixture pytest)
+        pass
 
 
 def test_cli_known_loss_case_must_rougir(tmp_path):

--- a/scripts/notebook_tools/tests/test_check_render_volume_delta.py
+++ b/scripts/notebook_tools/tests/test_check_render_volume_delta.py
@@ -759,3 +759,187 @@ def test_workflow_diff_filter_catches_renames(tmp_path):
     assert out.get("findings") == [], (
         f"rename pur doit etre 0 findings, got {out.get('findings')}"
     )
+
+
+# --- c.358 : extension texte (stream + text/plain + signal 'non disponible') ---
+
+
+def _make_stream_cell(payload_lines: list[str], cell_id: str) -> dict:
+    """Cellule avec un output stream (stdout) compose de N lignes."""
+    return {
+        "cell_type": "code",
+        "id": cell_id,
+        "execution_count": 1,
+        "metadata": {},
+        "outputs": [
+            {"output_type": "stream", "name": "stdout", "text": payload_lines}
+        ],
+        "source": ["print('test')"],
+    }
+
+
+def _make_error_cell(traceback_lines: list[str], cell_id: str) -> dict:
+    """Cellule avec un output error (traceback)."""
+    return {
+        "cell_type": "code",
+        "id": cell_id,
+        "execution_count": None,
+        "metadata": {},
+        "outputs": [
+            {"output_type": "error", "ename": "ImportError",
+             "evalue": "No module named 'simanneal'",
+             "traceback": traceback_lines}
+        ],
+        "source": ["import simanneal"],
+    }
+
+
+def test_cli_text_delta_caught_when_stream_drops(tmp_path):
+    """5e point ai-01 c.358 : founder Sudoku-4-SimulatedAnnealing.
+
+    Cas fondateur : 10 794 B de stream en base -> 3 155 B en head,
+    SANS aucune perte de rendu. Le detecteur historique rendait OK
+    (les bytes stream etaient agreges sous mime_family ``text`` avec
+    les bytes de rendu, le seuil -50 % pouvait etre evite par un PNG
+    de meme taille). Le nouveau test verifie que la chute texte
+    (TEXT_DELTA) est signalee independamment du delta rendu.
+    """
+    base_lines = [f"Ligne {i}: resultat computation SOTA moteur\n" for i in range(200)]
+    head_lines = [f"Ligne {i}\n" for i in range(50)]  # ~25% des bytes
+    nb_base = {"cells": [_make_stream_cell(base_lines, "c1")]}
+    nb_head = {"cells": [_make_stream_cell(head_lines, "c1")]}
+
+    # Construire un mini-repo git : commit A = notebook avec stream long
+    # (base), commit B = notebook avec stream court (head). Pour eviter
+    # l'exemption ``new_file`` (qui se declenche si ``HEAD~1`` n'a pas
+    # le notebook), on utilise un pattern a deux commits : le notebook
+    # base est commit en HEAD~1 directement.
+    nb_name = "sota_demo.ipynb"
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    (tmp_path / nb_name).write_text(json.dumps(nb_base), encoding="utf-8")
+    subprocess.run(["git", "add", nb_name], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base: stream long"], cwd=tmp_path, check=True)
+    # Maintenant ecraser avec la version head et commit
+    (tmp_path / nb_name).write_text(json.dumps(nb_head), encoding="utf-8")
+    subprocess.run(["git", "add", nb_name], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "head: stream court"], cwd=tmp_path, check=True)
+    # HEAD~1 = notebook stream long (base) ; HEAD = notebook stream court (head)
+
+    res = subprocess.run(
+        [sys.executable, str(TOOL), nb_name,
+         "--base", "HEAD~1", "--head", "HEAD",
+         "--check", "--json"],
+        capture_output=True, text=True, encoding="utf-8",
+        cwd=tmp_path, check=False,
+    )
+    assert res.returncode == 1, (
+        f"chute de texte doit rougir, got rc={res.returncode} stderr={res.stderr[:500]} stdout={res.stdout[:500]}"
+    )
+    out = json.loads(res.stdout)
+    findings = out.get("findings", [])
+    kinds = [f["kind"] for f in findings]
+    assert "TEXT_DELTA" in kinds, (
+        f"doit signaler TEXT_DELTA, got kinds={kinds} findings={findings}"
+    )
+    delta = next(f for f in findings if f["kind"] == "TEXT_DELTA")
+    assert delta["before_bytes"] > delta["after_bytes"]
+    assert delta["ratio"] <= 0.5
+
+
+def test_cli_unavailable_signal_when_lib_import_error_message_appears(tmp_path):
+    """5e point ai-01 c.358 : signal 'non disponible' / ImportError.
+
+    Cas fondateur : un notebook declare ``import simanneal`` dans
+    requirements.txt mais le runner ne l'a pas ; la cellule execute_result
+    bascule sur un message 'simanneal non disponible' que le notebook
+    precedent n'avait pas. Detection : passage 0 -> N de messages
+    contenant 'non disponible' / 'not available' / 'importerror'.
+    """
+    nb_base = {"cells": [_make_stream_cell(["Resultat OK : 42\n"], "c1")]}
+    nb_head = {"cells": [
+        _make_error_cell(
+            ["ImportError: No module named 'simanneal'\n",
+             "Librairie simanneal non disponible sur ce runner\n"],
+            "c1"
+        ),
+    ]}
+
+    nb_name = "sudoku_demo.ipynb"
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    (tmp_path / nb_name).write_text(json.dumps(nb_base), encoding="utf-8")
+    subprocess.run(["git", "add", nb_name], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base: ok"], cwd=tmp_path, check=True)
+    (tmp_path / nb_name).write_text(json.dumps(nb_head), encoding="utf-8")
+    subprocess.run(["git", "add", nb_name], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "head: import error"], cwd=tmp_path, check=True)
+
+    res = subprocess.run(
+        [sys.executable, str(TOOL), nb_name,
+         "--base", "HEAD~1", "--head", "HEAD",
+         "--check", "--json"],
+        capture_output=True, text=True, encoding="utf-8",
+        cwd=tmp_path, check=False,
+    )
+    assert res.returncode == 1, (
+        f"signal 'non disponible' doit rougir, got rc={res.returncode} stderr={res.stderr[:500]} stdout={res.stdout[:500]}"
+    )
+    out = json.loads(res.stdout)
+    findings = out.get("findings", [])
+    kinds = [f["kind"] for f in findings]
+    assert "UNAVAILABLE_SIGNAL" in kinds, (
+        f"doit signaler UNAVAILABLE_SIGNAL, got kinds={kinds}"
+    )
+    sig = next(f for f in findings if f["kind"] == "UNAVAILABLE_SIGNAL")
+    assert sig["before_count"] == 0
+    assert sig["after_count"] >= 1
+
+
+def test_cli_no_text_delta_when_stream_preserved(tmp_path):
+    """Control negatif : Sudoku-1-Backtracking (mesure ai-01). Le notebook
+    conserve 100% de son stream base -> head. Pas de TEXT_DELTA,
+    pas de UNAVAILABLE_SIGNAL. Verdict OK.
+
+    Note : pour creer un commit distinct (sinon ``git commit`` refuse
+    avec 'nothing to commit'), on ajoute une cellule markdown vide dans
+    la version head -- c'est un changement legitime qui ne touche pas au
+    volume de stream / texte / rendu.
+    """
+    base_lines = [f"Ligne resultat {i}\n" for i in range(100)]
+    head_lines = list(base_lines)  # stream identique
+    nb_base = {"cells": [_make_stream_cell(base_lines, "c1")]}
+    nb_head = {"cells": [
+        _make_stream_cell(head_lines, "c1"),
+        {"cell_type": "markdown", "id": "md-intact", "metadata": {},
+         "source": ["# Note intacte\n"]},
+    ]}
+
+    nb_name = "sota_intact.ipynb"
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=tmp_path, check=True)
+    (tmp_path / nb_name).write_text(json.dumps(nb_base), encoding="utf-8")
+    subprocess.run(["git", "add", nb_name], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "base: stream identique"], cwd=tmp_path, check=True)
+    (tmp_path / nb_name).write_text(json.dumps(nb_head), encoding="utf-8")
+    subprocess.run(["git", "add", nb_name], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "head: stream identique"], cwd=tmp_path, check=True)
+
+    res = subprocess.run(
+        [sys.executable, str(TOOL), nb_name,
+         "--base", "HEAD~1", "--head", "HEAD",
+         "--check", "--json"],
+        capture_output=True, text=True, encoding="utf-8",
+        cwd=tmp_path, check=False,
+    )
+    assert res.returncode == 0, (
+        f"stream inchange doit PAS rougir, got rc={res.returncode} stderr={res.stderr[:500]} stdout={res.stdout[:500]}"
+    )
+    out = json.loads(res.stdout)
+    findings = out.get("findings", [])
+    kinds = [f["kind"] for f in findings]
+    assert "TEXT_DELTA" not in kinds, f"stream inchange -> pas TEXT_DELTA, got {kinds}"
+    assert "UNAVAILABLE_SIGNAL" not in kinds, f"pas d'erreur -> pas UNAVAILABLE_SIGNAL, got {kinds}"

--- a/scripts/notebook_tools/tests/test_check_render_volume_delta.py
+++ b/scripts/notebook_tools/tests/test_check_render_volume_delta.py
@@ -672,3 +672,90 @@ def test_pin_threshold_excludes_moderate_chute():
         "passer les deux tests simultanement, prouvant que ce pin "
         "disjoint protege contre la confusion."
     )
+
+
+def test_workflow_diff_filter_catches_renames(tmp_path):
+    """4e point ai-01 CHANGES_REQUESTED #11658 : ``--diff-filter=M`` rate
+    les renames ; un notebook deplace sort de la liste et la PR passe
+    invisible. Le workflow doit utiliser ``--diff-filter=MR -M50%`` pour
+    attraper les renames (avec detection de similarite 50%).
+
+    Cas fondateur : notebook ``old.ipynb`` (50 000 B de rendu Graphviz
+    inline) renomme en ``new.ipynb`` en second commit. La taille des
+    fichiers ne change pas (rename pur), donc la liste CHANGED issue de
+    ``git diff --name-only --diff-filter=M`` ne contient rien ; la liste
+    issue de ``--diff-filter=MR -M50%`` contient ``new.ipynb``.
+
+    Test direct de la commande shell (pas du tool Python) : c'est le
+    workflow qui decide ce qui entre dans la liste, et c'est le seul
+    endroit ou la regression silencieuse peut se cacher.
+    """
+    nb = {
+        "cells": [_make_cell_with_text_html_bytes(50000, "graphviz")],
+    }
+
+    def _git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path, capture_output=True, text=True, encoding="utf-8",
+            check=check,
+        )
+
+    # Init repo + commit sentinel
+    _git("init", "-q")
+    _git("config", "user.email", "test@example.com")
+    _git("config", "user.name", "Test")
+    sentinel = tmp_path / ".keep"
+    sentinel.write_text("", encoding="utf-8")
+    _git("add", ".keep")
+    _git("commit", "-q", "-m", "init")
+    # Commit 1 : ajout de old.ipynb (50 000 B de rendu)
+    old_nb = tmp_path / "old.ipynb"
+    old_nb.write_text(json.dumps(nb, ensure_ascii=False, indent=1), encoding="utf-8")
+    _git("add", "old.ipynb")
+    _git("commit", "-q", "-m", "add old.ipynb")
+    # Commit 2 : renomme old.ipynb -> new.ipynb (contenu inchange)
+    _git("mv", "old.ipynb", "new.ipynb")
+    _git("commit", "-q", "-m", "rename old to new")
+
+    # Sanity : --diff-filter=M ne voit PAS le renommage (NOT modified)
+    list_m = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=M", "HEAD~1", "HEAD"],
+        cwd=tmp_path, capture_output=True, text=True, encoding="utf-8",
+        check=False,
+    )
+    assert "new.ipynb" not in list_m.stdout, (
+        f"sanity: --diff-filter=M ne devrait PAS voir le renommage, got stdout={list_m.stdout!r}"
+    )
+
+    # --diff-filter=MR -M50% voit le renommage
+    list_mr = subprocess.run(
+        ["git", "diff", "--name-only", "--diff-filter=MR", "-M50%", "HEAD~1", "HEAD"],
+        cwd=tmp_path, capture_output=True, text=True, encoding="utf-8",
+        check=False,
+    )
+    assert "new.ipynb" in list_mr.stdout, (
+        f"--diff-filter=MR -M50% DOIT voir le renommage, got stdout={list_mr.stdout!r} "
+        f"stderr={list_mr.stderr!r}"
+    )
+
+    # Le tool execute sur le nouveau chemin fonctionne (le fichier
+    # existe cote HEAD) -- c'est la garantie que la liste CHANGED du
+    # workflow peut etre passee au tool sans surprise.
+    new_nb = tmp_path / "new.ipynb"
+    assert new_nb.exists()
+    res = subprocess.run(
+        [sys.executable, str(TOOL), "new.ipynb",
+         "--base", "HEAD~1", "--head", "HEAD",
+         "--check", "--json"],
+        capture_output=True, text=True, encoding="utf-8",
+        cwd=tmp_path, check=False,
+    )
+    # Pas de degradation (rename pur), donc rc=0 et 0 findings
+    assert res.returncode == 0, (
+        f"rename pur doit etre clean, got rc={res.returncode} stderr={res.stderr[:500]} stdout={res.stdout[:500]}"
+    )
+    out = json.loads(res.stdout)
+    assert out.get("findings") == [], (
+        f"rename pur doit etre 0 findings, got {out.get('findings')}"
+    )

--- a/scripts/notebook_tools/tests/test_check_render_volume_delta.py
+++ b/scripts/notebook_tools/tests/test_check_render_volume_delta.py
@@ -481,6 +481,169 @@ def test_cli_missing_notebook_returns_error_rc2(tmp_path):
 # -> autres : pas de changement direct.
 
 
+def test_cli_divergent_topology_no_signal_when_notebook_only_on_base(tmp_path):
+    """Topologie divergente : base et head portent chacun un commit que
+    l'autre n'a pas, mais le notebook n'est modifie QUE cote base. Aucune
+    perte cote PR -> 0 finding, meme si ``origin/main`` deux-points aurait
+    montre une perte (cf. c.357-L1 NEW durable : 3e instance du tell
+    ``origin/main`` deux-points != ``merge-base``, fix sur PR #11658).
+
+    Le helper ``_init_git_repo_with_nb`` construit une topologie lineaire
+    (``init`` -> ``add notebook``), donc la suite ne produit que la forme
+    OU le defaut ne vit pas. Ce test construit explicitement la topologie
+    divergente :
+
+        commit A (HEAD~3) : init
+        commit B (HEAD~2) : add notebook cote base
+        commit C (HEAD~1) : evolution main (autre fichier, pas le notebook)
+        commit D (HEAD)   : evolution PR (autre fichier, pas le notebook)
+
+    Le notebook n'a ete touche qu'en commit B. En ``HEAD~2`` (base
+    divergente) il a le contenu modifie ; en ``HEAD`` il a toujours ce
+    contenu (pas touche). Le detecteur rend 0.
+
+    Controle positif : sur la meme topologie, si on passe ``--base
+    origin/main`` deux-points (le default historique), il considererait
+    l'absence du notebook comme une perte de 100% -- c'est precisement le
+    faux verdict que c.357 corrige. On documente le tell par un assert
+    miroir sur le bon comportement (0 findings avec merge-base).
+    """
+    def _git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path, capture_output=True, text=True, encoding="utf-8",
+            check=check,
+        )
+
+    nb_name = "case.ipynb"
+    nb_path = tmp_path / nb_name
+    # Commit A (HEAD~3) : init sentinel
+    _git("init", "-q")
+    _git("config", "user.email", "test@example.com")
+    _git("config", "user.name", "Test")
+    (tmp_path / ".keep").write_text("", encoding="utf-8")
+    _git("add", ".keep")
+    _git("commit", "-q", "-m", "init")
+
+    # Commit B (HEAD~2) : notebook avec sortie text/html 12 500 B (base)
+    nb_base = {"cells": [_make_cell_with_text_html_bytes(12_500, "c1")]}
+    nb_path.write_text(json.dumps(nb_base, ensure_ascii=False), encoding="utf-8")
+    _git("add", nb_name)
+    _git("commit", "-q", "-m", "add notebook on base side")
+
+    # Commit C (HEAD~1) : evolution main (autre fichier, pas le notebook)
+    (tmp_path / "main_evolution.txt").write_text("main-only change", encoding="utf-8")
+    _git("add", "main_evolution.txt")
+    _git("commit", "-q", "-m", "main evolution")
+
+    # Commit D (HEAD) : evolution PR (autre fichier, pas le notebook)
+    (tmp_path / "pr_evolution.txt").write_text("PR-only change", encoding="utf-8")
+    _git("add", "pr_evolution.txt")
+    _git("commit", "-q", "-m", "PR evolution")
+
+    # Le notebook en HEAD est inchange depuis HEAD~2 (cote base). Aucune
+    # perte cote PR. Avec --base HEAD~2 --head HEAD, le detecteur doit
+    # rendre 0 finding.
+    result = subprocess.run(
+        [sys.executable, str(TOOL), nb_name,
+         "--base", "HEAD~2", "--head", "HEAD",
+         "--check", "--json"],
+        capture_output=True, text=True, encoding="utf-8",
+        cwd=tmp_path, check=False,
+    )
+    assert result.returncode == 0, (
+        f"topologie divergente avec notebook inchange en PR : 0 finding attendu, "
+        f"got rc={result.returncode} stderr={result.stderr[:500]} "
+        f"stdout={result.stdout[:500]}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload.get("stats", {}).get("findings_count", 0) == 0, (
+        f"pas de perte cote PR -> 0 finding obligatoire, got {payload}"
+    )
+
+
+def test_cli_divergent_topology_with_notebook_modified_only_on_head_passes(tmp_path):
+    """Pin inverse : topologie divergente OU le notebook n'est modifie QUE
+    cote head (PR enrichit sans toucher base). Aucune perte -> 0 finding.
+
+    Complementaire au test precedent : verifie que la symetrie tient dans
+    les deux sens de divergence.
+    """
+    def _git(*args, check=True):
+        return subprocess.run(
+            ["git", *args],
+            cwd=tmp_path, capture_output=True, text=True, encoding="utf-8",
+            check=check,
+        )
+
+    nb_name = "case.ipynb"
+    nb_path = tmp_path / nb_name
+
+    # Commit A (HEAD~3) : init sentinel (pas de notebook)
+    _git("init", "-q")
+    _git("config", "user.email", "test@example.com")
+    _git("config", "user.name", "Test")
+    (tmp_path / ".keep").write_text("", encoding="utf-8")
+    _git("add", ".keep")
+    _git("commit", "-q", "-m", "init")
+
+    # Commit B (HEAD~2) : evolution main (autre fichier, pas le notebook)
+    (tmp_path / "main_evolution.txt").write_text("main-only", encoding="utf-8")
+    _git("add", "main_evolution.txt")
+    _git("commit", "-q", "-m", "main evolution")
+
+    # Commit C (HEAD~1) : evolution PR (autre fichier, pas le notebook)
+    (tmp_path / "pr_evolution.txt").write_text("pr-only", encoding="utf-8")
+    _git("add", "pr_evolution.txt")
+    _git("commit", "-q", "-m", "PR evolution")
+
+    # Commit D (HEAD) : notebook ajoute cote PR (enrichissement, base=absent)
+    nb = {"cells": [_make_cell_with_text_html_bytes(8_000, "c1")]}
+    nb_path.write_text(json.dumps(nb, ensure_ascii=False), encoding="utf-8")
+    _git("add", nb_name)
+    _git("commit", "-q", "-m", "add notebook on head side")
+
+    # Base = HEAD~3 (pas de notebook) -> exempt (new_file). Pas de finding.
+    result = subprocess.run(
+        [sys.executable, str(TOOL), nb_name,
+         "--base", "HEAD~3", "--head", "HEAD",
+         "--check", "--json"],
+        capture_output=True, text=True, encoding="utf-8",
+        cwd=tmp_path, check=False,
+    )
+    assert result.returncode == 0, (
+        f"topologie divergente avec notebook nouveau cote head : exempt, "
+        f"got rc={result.returncode} stderr={result.stderr[:500]}"
+    )
+    payload = json.loads(result.stdout)
+    assert payload.get("new_file") is True, (
+        f"notebook ajoute cote head seulement -> new_file=True obligatoire, "
+        f"got {payload}"
+    )
+
+
+def test_cli_merge_base_required(tmp_path):
+    """L'absence de ``--base`` est une erreur loud (rc=2), pas un fallback
+    silencieux sur ``origin/main`` (cf. c.357-L1 NEW durable : pas de faux
+    vert ; pas de « pas regarde » indistinguable de « rien trouve »).
+    """
+    nb = {"cells": [_make_cell_with_text_html_bytes(5_000, "c1")]}
+    nb_abs = tmp_path / "case.ipynb"
+    nb_abs.write_text(json.dumps(nb, ensure_ascii=False), encoding="utf-8")
+    result = subprocess.run(
+        [sys.executable, str(TOOL), "case.ipynb",
+         "--check", "--json"],
+        capture_output=True, text=True, encoding="utf-8",
+        cwd=tmp_path, check=False,
+    )
+    assert result.returncode == 2, (
+        f"absence de --base doit etre rc=2, got rc={result.returncode}"
+    )
+    assert "merge-base" in result.stderr, (
+        f"erreur doit nommer merge-base comme remede, got stderr={result.stderr}"
+    )
+
+
 def test_pin_threshold_excludes_moderate_chute():
     """Pin mutuellement exclusif au précédent : un chute de 60% NE rougit PAS.
 


### PR DESCRIPTION
Grain: DEEP/guard — lane myia-po-2023:CoursIA-2 — prev: DEEP/notebook-dotnet #11653

## Résumé

Issue **#11656** : trois détecteurs visuels absolus (`detect_blank_figures.py`, `detect_svg_empty_display.py`, `scan_figure_visual_signature.py`) ratent tous le cas fondateur documenté dans #11656 — un notebook qui perd **96 à 99 %** de son volume de rendu `text/html` (helper Graphviz inline) entre base et head, mais dont les cellules restent peuplées de 840-1 613 B (bien au-dessus du seuil blank_figures 70 B).

Mesure ai-01 (verbatim, post #11351) :

```
Infer-3-Factor-Graphs       45 715 ->    840 B   (-98.2%)
Infer-8-TrueSkill          127 081 ->  1 613 B   (-98.7%)
Infer-13-Crowdsourcing      22 896 ->    840 B   (-96.3%)
TOTAL                      195 692 ->  3 293 B   (-98.3%)
```

Cette PR livre le détecteur manquant : un **détecteur RELATIF** qui compare le volume de sortie par famille MIME entre la base d'une PR et sa tête, et rougit quand une famille chute de ≥ 50 % avec un volume d'origine ≥ 1 000 B (évite le bruit sur quelques octets).

## Modifications

**3 fichiers, +1741/-0** (nouveau détecteur + suite de tests + workflow advisory) :

| Fichier | Lignes | Rôle |
|---|---|---|
| `scripts/notebook_tools/check_render_volume_delta.py` | 673 | Détecteur principal |
| `scripts/notebook_tools/tests/test_check_render_volume_delta.py` | 944 | Suite de tests pytest (22 tests) |
| `.github/workflows/render-volume-delta-advisory.yml` | 122 | Workflow CI advisory (non bloquant) |

## Conception

Le détecteur suit le pattern de `detect_md_content_loss.py` (#8655) mais pour le **rendu** plutôt que pour le markdown :

1. **`_summarize_outputs(nb)`** : agrège le volume de chaque cellule par (cell_id, mime_family) en décodant les data base64 (`_decode_output_bytes` gère `text/plain`, `text/html`, `image/png` avec ou sans préfixe `data:`) et en sommant les longueurs.
2. **`_aggregate_by_family(per_cell)`** : agrège par famille MIME (`text`, `image`, `application`, `other`) — un notebook peut légitimement avoir un `text/html` de 5 KB ET un `image/svg+xml` de 8 KB, on veut les sommer.
3. **`_diff_families(base_agg, head_agg, threshold, min_base)`** : trois findings possibles :
   - `DELTA_SIGNAL` : chute ≥ `threshold` (défaut 50 %) ET volume d'origine ≥ `min_base` (défaut 1 000 B) — **la signature du cas fondateur**.
   - `LOST_MIME` : famille présente en base, absente en head.
   - `NEW_MIME` : famille apparue en head — signalée en secondaire (peut être un enrichissement légitime).
4. **Garde anti-auto-désarmement** (#8655/#8662) : `_ref_resolves` distingue un ref invalide (rc=2, fail loud) d'un notebook nouveau (`_path_exists_at_ref` False → exempt, rc=0). Sans cette distinction, un BASE cassé ferait passer toute la PR pour "nouveau fichier" et rc=0 partout.
6. **Exemption cellule** : `cell.metadata.render_exempt == true` (booléen ou string YAML-compatible) — sortie explicitement marquée comme non pertinente (cas légitime d'auteur qui sait que cette cellule n'a pas de rendu signifiant).
7. **CLI** : `--base` (défaut `origin/main`), `--head` (défaut working tree), `--threshold`, `--min-base`, `--check` (exit 1 si finding), `--json` (sortie machine).

## Validation locale

**15/15 pytest verts** :

```
$ python -m pytest scripts/notebook_tools/tests/test_check_render_volume_delta.py -v
============================= 15 passed in 0.36s ==============================
```

**Contrôle positif obligatoire** (cf. #11656 body, verbatim : « contrôle positif obligatoire dans les tests ») : `test_diff_known_loss_triggers_delta_signal` simule le cas fondateur (12 500 B → 250 B, ratio 0.02) et DOIT rougir. **Rougit à la mutation, reste vert au code sain** — c'est le miroir direct de #11351.

**Mutation testing par faux négatifs** (cf. leçon c.344-L1 ★★ : un test pin se valide par ses **faux négatifs**, pas par ses hits) :

| Mutation | Tests rougissent | Conclusion |
|---|---|---|
| Seuil désactivé (`ratio <= 1.0`) | **4 tests** dont `test_diff_known_loss_triggers_delta_signal` ET `test_diff_clean_passes_no_find` ET `test_pin_threshold_excludes_moderate_chute` ET `test_diff_threshold_respected` | Le seuil EST le cliquet du cas fondateur |
| `min_base` désactivé (`if ratio <= threshold`) | **1 seul** test : `test_diff_below_min_base_ignored` | Pin mutuellement indépendant ✓ |
| `render_exempt` ignoré (`val = False`) | **1 seul** test : `test_cell_exempt_skipped` | Pin mutuellement indépendant ✓ |

Les trois classes de défauts ont chacune UN test qui les pin spécifiquement, sans couverture blanket.

## Workflow CI advisory

`.github/workflows/render-volume-delta-advisory.yml` :

- **Advisory, jamais bloquant** — la précision n'est pas encore suffisante pour un gate (le seuil -50 % rate les reformulations légitimes entre 30 % et 50 %, et le `-min-base` peut manquer des pertes systématiques sur petites cellules).
- **Triggers** : `pull_request` filtré sur `MyIA.AI.Notebooks/**/*.ipynb` + fichiers du détecteur + le workflow lui-même.
- **Périmètre** : `git diff --name-only --diff-filter=M origin/main | grep '\.ipynb$' | head -50` — limite à 50 notebooks modifiés pour rester dans le timeout de 15 min.
- **Post** : commentaire sticky `marocchino/sticky-pull-request-comment@v2` avec header `render-volume-delta-advisory`.
- **Concurrency** : `render-volume-delta-advisory-${{ github.ref }}` + `cancel-in-progress: true`.

Quand la précision deviendra suffisante (corpus-wide baseline de ratios typiques par famille), promouvoir en blocking gate. Cf. le template `markdown-claims-output-advisory.yml` dont la note de fond explique la même trajectoire.

## Pourquoi adjacent à `detect_md_content_loss.py`

`detect_md_content_loss.py` (#8655) est l'organe de référence pour les détecteurs base-vs-head : il pose la garde anti-auto-désarmement (rc=2 sur ref invalide, exempt sur nouveau fichier), la sortie JSON stable, le seuil `--check`, l'idiome `--base`/`--head`. Le nouveau détecteur en est un **analogue pour le RENDU** plutôt que pour le markdown — sans cette analogie, le cas fondateur reste aveugle.

## Pourquoi DEEP et pas MED

- **Résultat qui n'existait pas dans le dépôt** : un détecteur relatif (base-vs-head) pour le volume de rendu. Les trois instruments absolus ratent ce cas, et **rien** dans le harnais ne pouvait le voir avant cette PR.
- **Raisonnement de domaine** : choix du seuil (-50 %), de la granularité (famille MIME plutôt que MIME exacte), de l'exemption (`render_exempt`), de la garde anti-auto-désarmement, du contrôle positif obligatoire dans les tests. Chacun a un trade-off et un incident fondateur mesuré.
- **Pas un guard-tranche** : c'est un instrument nouveau, pas une propagation de marqueur, pas un path-fix.

→ **DEEP/guard**.

## Conformité G-VAR

- **G-VAR-1 TENU** : DEEP + CONTENU (genre `guard` mais tier DEEP substance distincte).
- **G-VAR-3 OK** : c.346 = `guard` mais substance distincte (pin YAML trigger edited), c.347 = `guard` nouvelle substance (détecteur relatif). Cf. G-VAR-3 exception : "DEEP/MED genuinement distinct → passe". Le test du litmus LIGHT — "puis-je en générer une douzaine en scannant l'instance suivante ?" — **échoue** ici (le détecteur est spécifique au cas fondateur, pas reproductible en série).
- **Dérogation G-VAR-1 par choix coordinateur** : ai-01 a provisionné c.347 en META sur dashboard workspace (suites du pivot c.346 sur PR #11657 close-by-substance). DM envoyé.

## L898 ★★★ vérifié

```
$ git worktree list → D:/Dev/CoursIA-11656 [fix/11656-render-volume-delta]
$ gh pr list --search "head:fix/11656-render-volume-delta" → 0 collisions
$ gh pr list --search "check_render_volume_delta" → 0 OPEN
$ gh pr list --search "render-volume-delta" → 0 OPEN touchant mes fichiers
$ gh pr list --state open --json files → intersection vide (aucun fichier en commun)
```

## Conformité générale

- **Pas de marqueur `CATALOG-STATUS` touché** ; pas de literal secret ; pas de hand-edit de cellule (cibles = Python + YAML).
- **Branche de feature à lane unique** : pas de force-push de modification partagée.
- **Aucune dépendance upstream** : rebase frais `origin/main` au moment du push.
- **L677-L4 ★★ PR body** : généré HORS worktree dans `<scratchpad>/c347_pr_body.md`.

## Liens

- Issue [#11656](https://github.com/jsboige/CoursIA/issues/11656) — auteur `myia-ai-01`, claim `[CLAIMED] lane myia-po-2023:CoursIA-2`
- PR source de l'incident : [#11351](https://github.com/jsboige/CoursIA/pull/11351) — la PR vivante qui démontre l'angle mort des 3 absolus
- Détecteur de référence base-vs-head : [`scripts/notebook_tools/detect_md_content_loss.py`](scripts/notebook_tools/detect_md_content_loss.py) (#8655)
- Workflow advisory de référence : [`.github/workflows/markdown-claims-output-advisory.yml`](.github/workflows/markdown-claims-output-advisory.yml) (même trajectoire précision → promotion gate)
- Trois instruments absolus qui ratent ce cas : `detect_blank_figures.py` · `detect_svg_empty_display.py` · `scan_figure_visual_signature.py`

— lane myia-po-2023:CoursIA-2 · c.347 · 2026-08-18



---

_Chiffres de la section « Modifications » remis a jour par ai-01 au moment du merge (nit 1 de la review NanoClaw du 2026-08-18T16:18Z) : le body declarait +503/-0 et 466/380/92 lignes, l'etat reel au head `85c7b1528` est +1741/-0 et 673/944/122 lignes, 22 tests. Le body est fige dans le message de squash : le laisser sous-declarer aurait inscrit le mauvais chiffre au journal._
