### PR TITLE
test(perimeter,#11659): recover the 2 trigger pin tests lost in #11657

### DIFF
--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -288,3 +288,77 @@ def test_scan_thread_composition_accepts_correct_thread():
     )
     problems = [p for cand in cands for p in check_assertion(FILES_11227, cand)]
     assert problems == []
+
+
+# ---------------------------------------------------------------------------
+# Workflow trigger pin (#11648 — edited re-evaluation)
+# ---------------------------------------------------------------------------
+
+import pathlib
+
+
+def _read_perimeter_workflow() -> str:
+    """Locate and read the perimeter-review-guard.yml from repo root.
+
+    Resolves from this test file's location so the test is independent of cwd.
+    """
+    here = pathlib.Path(__file__).resolve()
+    # scripts/tests/test_check_pr_perimeter.py → repo root = parents[2]
+    repo_root = here.parents[2]
+    wf = repo_root / ".github" / "workflows" / "perimeter-review-guard.yml"
+    return wf.read_text(encoding="utf-8")
+
+
+def test_pull_request_trigger_includes_edited_type():
+    """Issue #11648: ``pull_request:`` MUST list ``edited`` so an assertion
+    correction on the PR body re-triggers the gate.
+
+    Founding measurement: the gate's own body comment claimed "pull_request
+    (opened/synchronize/edited)" but the YAML block did not declare ``types:``,
+    so GitHub defaulted to ``[opened, synchronize, reopened]`` -- ``edited``
+    was silently dropped. A correction on the PR body therefore never
+    re-evaluated the gate, leaving the red bar in place (#11646).
+    """
+    text = _read_perimeter_workflow()
+    # Pull the ``pull_request:`` block (up to the next ``on:``-level key).
+    import re
+    block = re.search(
+        r"^on:\s*\n(?P<body>(?:  [^\n]*\n|\s*\n)+?)(?=^[^ ]|\Z)",
+        text,
+        re.MULTILINE,
+    )
+    assert block, "could not locate `on:` block in perimeter-review-guard.yml"
+    body = block.group("body")
+    # The pull_request sub-block must explicitly name edited.
+    pr_block = re.search(
+        r"^  pull_request:\s*\n((?:    [^\n]*\n)+)", body, re.MULTILINE
+    )
+    assert pr_block, "pull_request sub-block not found"
+    pr_body = pr_block.group(1)
+    assert "types:" in pr_body, (
+        "pull_request: block has no types: clause — GitHub will default to "
+        "[opened, synchronize, reopened] and silently drop `edited`. "
+        "Pin this so a re-eval on PR-body edit actually fires (#11648)."
+    )
+    assert "edited" in pr_body, (
+        "pull_request: types: declared but `edited` missing — without it, "
+        "an assertion correction on the PR body will never re-trigger the gate."
+    )
+
+
+def test_pull_request_review_trigger_includes_edited_type():
+    """Sibling invariant — the review trigger already had ``edited`` from the
+    start (c.342 acceptance), so this test pins that property against
+    accidental regression when editing the workflow.
+    """
+    text = _read_perimeter_workflow()
+    import re
+    rv_block = re.search(
+        r"^  pull_request_review:\s*\n((?:    [^\n]*\n)+)", text, re.MULTILINE
+    )
+    assert rv_block, "pull_request_review sub-block not found"
+    rv_body = rv_block.group(1)
+    assert "types:" in rv_body and "edited" in rv_body, (
+        "pull_request_review: must keep `types: [submitted, edited]` so "
+        "corrected reviews re-trigger the gate."
+    )

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -320,10 +320,14 @@ def test_pull_request_trigger_includes_edited_type():
     re-evaluated the gate, leaving the red bar in place (#11646).
     """
     text = _read_perimeter_workflow()
-    # Pull the ``pull_request:`` block (up to the next ``on:``-level key).
+    # Pull the ``on:`` block body: consecutive lines indented by >= 2 spaces.
+    # Single fixed-prefix branch (like the sibling sub-block regexes below) --
+    # CodeQL HIGH on the previous alternation ``(?:  [^\n]*\n|\s*\n)+?``:
+    # whitespace-only lines matched both branches, giving exponential
+    # backtracking on runs of blank lines.
     import re
     block = re.search(
-        r"^on:\s*\n(?P<body>(?:  [^\n]*\n|\s*\n)+?)(?=^[^ ]|\Z)",
+        r"^on:\s*\n(?P<body>(?:  [^\n]*\n)+)",
         text,
         re.MULTILINE,
     )


### PR DESCRIPTION
## Summary

Re-applies verbatim the test hunk from closed PR #11657 (close-by-substance of #11648): `test_pull_request_trigger_includes_edited_type` + `test_pull_request_review_trigger_includes_edited_type`. The workflow fix itself is already live on main via #11654 (`types: [opened, synchronize, edited, reopened]` + concurrency `event_name`); what was lost in the closure is the **pin** that prevents a future PR from silently dropping `types: edited` again — the #11648 red-bar deadlock (assertion corrected on the body, gate never re-evaluated, bar impossible to extinguish).

- 1 file, test-only — zero workflow change, zero source change.
- Tests read the real YAML from repo root (cwd-independent via `__file__`), assert the `pull_request:` sub-block carries `types:` including `edited`, and pin the review trigger sibling.

## Commit 2 — CodeQL HIGH fix (regex branche unique)

CodeQL flagged the `on:`-block extraction regex as ReDoS HIGH (exponential backtracking): the alternation `(?:  [^\n]*\n|\s*\n)+?` let a whitespace-only line match **both** branches. Rewritten as the fixed-prefix single branch `(?:  [^\n]*\n)+` — the same shape as the sibling sub-block regexes already in this file, which CodeQL accepts. The real workflow YAML has no blank lines inside the `on:` block, so the captured body is identical; comment in-file documents the why.

## Proof

- `pytest scripts/tests/test_check_pr_perimeter.py -q` → **27 passed** (25 + the 2 recovered pins), 0.08s — re-run after the regex fix (commit `25a99ddab`).
- **Contrast check (the pin bites)**: temporarily removing the `types:` clause from the local workflow copy → pin fails with the exact founding message (`pull_request: block has no types: clause — GitHub will default to [opened, synchronize, reopened] and silently drop 'edited'`); restored → passes. The regression the pin guards against is caught, not just the happy path.
- Rebase on origin/main: up to date (base fresh).

## Périmètre

`scripts/tests/test_check_pr_perimeter.py` uniquement, aucune autre modification.

**Grain:** MED/guard (réparation de couverture perdue, pas un organe nouveau) - lane myia-po-2026:CoursIA - prev: MED/notebook-python #11666

Note G-VAR-1/G-VAR-3 : ce guard suivait un guard (#11655) — ban LIGHT adjacency. Sequencement applique (le seul correct pour LIGHT, cf arbitrage ai-01 2026-08-18) : le grain CONTENU de la dette a ete livre d'abord — #11666 (MED/notebook-python, section 10 mesure prosodique 04-10, 2026-08-18T21:36Z) — puis prev re-declare ici sur ce CONTENU et branche re-poussee. La dette CONTENU #11271 (fort-boyard-python 591, mesure firsthand) reste au planning de demain au reset du cap densite.

See #11659
