### PR TITLE
fix(prosody,#1028): erratic_axes — nommer l'axe, separer "non mesure" de "rien trouve"

### DIFF
--- a/scripts/tests/test_verify_prosody.py
+++ b/scripts/tests/test_verify_prosody.py
@@ -157,6 +157,82 @@ def test_kokoro_v1_ground_truth_is_warn_not_pass():
     assert "ERRATIC" in r["reasons"]
 
 
+# --- erratic_axes: which axis fired, and "not measured" != "nothing fired" --
+
+def test_erratic_axes_names_the_span_axis():
+    r = classify_segment(**_healthy(melody_verdict="EXPRESSIVE",
+                                    melodic_span_st=ERRATIC_SPAN_ST + 2,
+                                    mean_abs_interval_st=1.5))
+    assert r["erratic_axes"] == ["span"]
+
+
+def test_erratic_axes_names_the_motion_axis():
+    r = classify_segment(**_healthy(melody_verdict="EXPRESSIVE",
+                                    melodic_span_st=12.0,
+                                    mean_abs_interval_st=ERRATIC_MOTION_ST + 0.5))
+    assert r["erratic_axes"] == ["motion"]
+
+
+def test_erratic_axes_names_both_when_both_fire():
+    r = classify_segment(**_healthy(melody_verdict="EXPRESSIVE",
+                                    melodic_span_st=ERRATIC_SPAN_ST + 2,
+                                    mean_abs_interval_st=ERRATIC_MOTION_ST + 0.5))
+    assert r["erratic_axes"] == ["span", "motion"]
+
+
+def test_erratic_axes_empty_when_measured_and_nothing_fired():
+    r = classify_segment(**_healthy(melody_verdict="EXPRESSIVE",
+                                    melodic_span_st=11.3,
+                                    mean_abs_interval_st=1.85))
+    assert r["gate"] == "PASS-TO-EAR"
+    assert r["erratic_axes"] == []
+
+
+def test_erratic_axes_is_none_when_the_segment_was_never_evaluated():
+    """The invariant: too short -> the axes were not measured, and that must not
+    be spelled the same way as "measured, nothing fired" ([]). Same separation
+    syllable_pitch.classify_melody already makes for the structural axis."""
+    r = classify_segment(**_healthy(melody_verdict="EXPRESSIVE",
+                                    n_syllables=MIN_SYLLABLES - 1,
+                                    melodic_span_st=40.0,
+                                    mean_abs_interval_st=5.0))
+    assert r["gate"] == "INCONCLUSIVE"
+    assert r["erratic_axes"] is None
+
+
+def test_erratic_does_not_discriminate_on_the_cloning_route():
+    """Regression on a *reading*, not on a threshold.
+
+    Measured on the seven #1028 review clips (2026-08-18): every clip carrying
+    ERRATIC is one of the good EXPRESSIVE takes, and none of the three DRONE
+    takes carries it. A reviewer consumed the bare label as a reservation about
+    one take; it is an abstention that tracks melodic richness on this route.
+    Pinned here so the reading cannot be re-made silently.
+    """
+    # (clip, span_st, motion_st, melody verdict) -- firsthand measurements
+    good = [("B_regenere", 20.4, 2.30), ("G1_melodique", 15.9, 3.06),
+            ("L3_long_melodique", 16.5, 2.94)]
+    drone = [("A_servi_depuis_mai", 12.2, 1.21), ("E_plat_grave", 9.8, 1.29),
+             ("F1_plat_clair", 8.9, 1.63)]
+
+    for name, span, motion in good:
+        r = classify_segment(**_healthy(melody_verdict="EXPRESSIVE",
+                                        n_syllables=80, melodic_span_st=span,
+                                        mean_abs_interval_st=motion))
+        # Asserted on `reasons`, which predates this change: the pin is on the
+        # BEHAVIOUR (good takes carry the flag), so it holds against the module
+        # as it was -- it is a guard on a future silent change, not a proof that
+        # the old code was wrong.
+        assert "ERRATIC" in r["reasons"], f"{name}: expected the flag on a good take"
+
+    for name, span, motion in drone:
+        r = classify_segment(**_healthy(melody_verdict="DRONE",
+                                        n_syllables=80, melodic_span_st=span,
+                                        mean_abs_interval_st=motion))
+        assert "ERRATIC" not in r["reasons"], f"{name}: DRONE must not carry ERRATIC"
+        assert r["gate"] == "REJECT"
+
+
 # --- WARN: DRIFTING / FADING (informational, surface with caveat) ----------
 
 def test_drifting_voice_warns():

--- a/scripts/tts_verification/verify_prosody.py
+++ b/scripts/tts_verification/verify_prosody.py
@@ -45,6 +45,33 @@ Gate outcomes
 * ``WARN``         — surface *to the ear* with a caveat. Reasons: ``ERRATIC`` (over-
                      modulated, the Kokoro class), ``DRIFTING`` (mild timbre drift),
                      ``FADING`` (energy declination — noisy on short clips, informational).
+
+``ERRATIC`` is an *abstention*, not a finding — read it that way
+---------------------------------------------------------------
+The docstring above already says no melody metric can separate over-modulation
+from healthy expressivity, so the flag defers to the ear. It bears repeating at
+the point of consumption, because the bare label reads like a defect and has
+been consumed as one: a review note built on it told a reader the instrument had
+a reservation about one specific take.
+
+Measured on the seven #1028 review clips (2026-08-18), the flag does not
+discriminate on the voice-cloning route — it tracks melodic *richness*:
+
+===========================  =================  =================
+clips                        effective notes    flagged ERRATIC
+===========================  =================  =================
+the 3 flagged                12.4 – 14.9        yes — all EXPRESSIVE
+the 4 not flagged            5.4 – 10.2         no  — incl. all 3 DRONE
+===========================  =================  =================
+
+All three flagged clips are the *good* material; none of the three DRONE clips
+is flagged. The thresholds also sit far below the ground truth that calibrated
+them (Kokoro v1: span 33.6 st, motion 3.43 st/syll), which is the correct bias
+for a send-to-the-ear flag and the reason it is over-inclusive by design.
+
+``erratic_axes`` therefore reports *which* axis fired, so a consumer can see
+whether a clip is near the calibrating pathology or merely melodic. An empty
+list means the flag did not fire — it never means "measured clean".
 * ``PASS-TO-EAR``  — objective floor cleared; the ear makes the final call.
 * ``INCONCLUSIVE`` — too short / too few voiced syllables for a reliable reading
                      (the instruments abstain rather than cry wolf). Needs the ear.
@@ -89,7 +116,11 @@ def classify_segment(
 ) -> Dict[str, object]:
     """Map instrument verdicts to a gate outcome + reasons. Deterministic.
 
-    Returns ``{"gate": <REJECT|WARN|PASS-TO-EAR|INCONCLUSIVE>, "reasons": [...]}``.
+    Returns ``{"gate": <REJECT|WARN|PASS-TO-EAR|INCONCLUSIVE>, "reasons": [...],
+    "erratic_axes": [...]}``. ``erratic_axes`` names which over-modulation axis
+    fired (``"span"`` / ``"motion"``); it is ``None`` — never ``[]`` — when the
+    segment was too short to evaluate, so "not measured" and "measured, nothing
+    fired" never share one value.
     A single REJECT reason wins over any WARN; a WARN wins over PASS-TO-EAR.
     Kept free of audio so the decision policy is unit-testable without clips.
     """
@@ -98,7 +129,9 @@ def classify_segment(
 
     # Not enough voiced material for a reliable reading -> abstain (the ear decides).
     if n_syllables < MIN_SYLLABLES or melody_verdict in (None, "INSUFFICIENT"):
-        return {"gate": "INCONCLUSIVE", "reasons": ["TOO-SHORT"]}
+        # Nothing was measured here: the axes are unevaluated, not clean.
+        return {"gate": "INCONCLUSIVE", "reasons": ["TOO-SHORT"],
+                "erratic_axes": None}
 
     # --- REJECT classes (confident bad) ---
     # Monotone is decided on the SYLLABLE verdict (robust: per-syllable motion +
@@ -116,9 +149,12 @@ def classify_segment(
     # Over-modulation: the Kokoro-v1 failure mode. High span AND/OR high motion
     # is NOT monotony but instability; a melody metric cannot tell it from good
     # expressivity, so flag it for the ear instead of guessing.
-    if (melodic_span_st is not None and melodic_span_st >= ERRATIC_SPAN_ST) or (
-        mean_abs_interval_st is not None and mean_abs_interval_st >= ERRATIC_MOTION_ST
-    ):
+    erratic_axes: List[str] = []
+    if melodic_span_st is not None and melodic_span_st >= ERRATIC_SPAN_ST:
+        erratic_axes.append("span")
+    if mean_abs_interval_st is not None and mean_abs_interval_st >= ERRATIC_MOTION_ST:
+        erratic_axes.append("motion")
+    if erratic_axes:
         warn.append("ERRATIC")
     # Global span flat while the (robust) syllable verdict is not FLAT: borderline
     # monotone on a noisy short-clip global — surface to the ear, do not reject.
@@ -131,10 +167,11 @@ def classify_segment(
         warn.append("FADING")
 
     if reject:
-        return {"gate": "REJECT", "reasons": reject + warn}
+        return {"gate": "REJECT", "reasons": reject + warn,
+                "erratic_axes": erratic_axes}
     if warn:
-        return {"gate": "WARN", "reasons": warn}
-    return {"gate": "PASS-TO-EAR", "reasons": []}
+        return {"gate": "WARN", "reasons": warn, "erratic_axes": erratic_axes}
+    return {"gate": "PASS-TO-EAR", "reasons": [], "erratic_axes": erratic_axes}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Grain: MED/research-code — lane myia-ai-01:CoursIA-2 — prev: MED/research-code #11652

## Le defaut, et il est a moi

`ERRATIC` est une **abstention declaree**. Le module le dit noir sur blanc :

> *High span AND/OR high motion is NOT monotony but instability; a melody metric
> cannot tell it from good expressivity, so flag it for the ear instead of guessing.*

Emis comme une **etiquette nue** dans `reasons`, il se lit comme un constat de
defaut. Je l'ai lu comme tel : dans le dossier de review que le user doit trancher
ce soir, j'avais ecrit que B n'etait « pas un feu vert » et que « le risque
bascule sur le defaut inverse — une voix trop demonstrative ». L'instrument
n'affirme rien de tel, et ne peut pas l'affirmer.

## La mesure qui tranche

7 extraits du dossier de review #1028, mesures firsthand le 2026-08-18
(`analyze_syllables` en process — le CLI ecrirait un PNG dans le dossier du user) :

| extrait | melodie | span | motion | notes eff. | ERRATIC |
|---|---|---:|---:|---:|---|
| A_servi_depuis_mai | DRONE | 12,2 | 1,21 | 6,0 | — |
| E_plat_registre_grave | DRONE | 9,8 | 1,29 | 5,4 | — |
| F1_plat_registre_clair | DRONE | 8,9 | 1,63 | 6,6 | — |
| L2_long_melodique_grave | EXPRESSIVE | 11,3 | 1,85 | 10,2 | — |
| **G1_melodique_registre_grave** | EXPRESSIVE | 15,9 | **3,06** | 12,9 | **motion** |
| **L3_long_melodique_grave** | EXPRESSIVE | 16,5 | **2,94** | 12,4 | **motion** |
| **B_regenere_2026-08-18** | EXPRESSIVE | **20,4** | 2,30 | 14,9 | **span** |

**3 extraits flagues sur 3 = les bons.** **0 des 3 DRONE.** Les flagues portent
12,4 a 14,9 notes effectives, les non-flagues 5,4 a 10,2. Sur la route de clonage
le drapeau ne separe pas le bon du mauvais : il **suit la richesse melodique**.

Et il ne visait pas B en particulier : les deux prises que je donne au user comme
**references melodiques** le portent aussi, sur l'autre axe — ce que l'etiquette
nue rendait invisible.

Les seuils (18,0 st / 2,50 st/syll) sont **loin sous** la verite-terrain qui les a
calibres (Kokoro v1 : 33,6 / 3,43). C'est le **bon** biais pour un drapeau
« envoyer a l'oreille » : sur-inclusif par conception. **Je ne les touche pas.**

## Le correctif

- `classify_segment` rend `erratic_axes` : `["span"]` / `["motion"]` / les deux /
  `[]` — le consommateur voit *quel* axe a tire, donc s'il est pres de la
  pathologie calibrante ou seulement melodique.
- **`None`, jamais `[]`, quand le segment est trop court.** « Non mesure » et
  « mesure, rien n'a tire » cessent de partager une valeur — exactement la
  separation que `classify_melody` applique deja a l'axe structurel (#11652).
  Deuxieme instance du meme defaut epistemique dans le meme instrument, un etage
  plus haut.
- Docstring : la non-discrimination mesuree, au **point de consommation**. Le
  module la documentait deja en tete ; elle n'a pas empeche l'erreur, parce que
  le lecteur d'un verdict ne remonte pas au prologue.

## Verification

```
python -m pytest scripts/tests/test_verify_prosody.py \
                 scripts/tests/test_syllable_pitch_verdict.py -q
-> 38 passed
```

**Controle negatif, honnetement.** Contre le module non corrige : **5 failed,
23 passed**. Les 5 sont les tests d'axes — ils tombent en `KeyError`, ce qui
prouve que la cle est **neuve**, pas que l'ancien comportement etait faux.

Le 6e, `test_erratic_does_not_discriminate_on_the_cloning_route`, **passe contre
le module non corrige** — et c'est voulu : il epingle sur `reasons` (cle
pre-existante) le **comportement** mesure ci-dessus. C'est un garde anti-derive
silencieuse, pas une preuve de bug. Je le dis plutot que de compter 6/6.

## Corrige hors depot

Le README de review du user (`G:\Mon Drive\MyIA\audiobook-1028-review\2026-08-18\`)
portait la lecture fautive. Corrige : il donne desormais le tableau ci-dessus et
dit que le drapeau est une abstention, pas une reserve sur B. Le risque de fatigue
sur six heures reste reel et reste a son oreille — mais l'instrument ne l'objecte
pas, et je n'aurais pas du ecrire qu'il l'objectait.

## Sur le tag

`research-code` (CONTENU) : la livraison est un **resultat mesure sur du materiel
reel qui change ce qui est dit au user**, le code en est le vehicule. Un reviewer
preferant `tooling` (META) serait defendable — dans ce cas mon plancher G-VAR-1
de contenu n'est pas tenu aujourd'hui sur cette lane non plus, et je prefere le
dire que le masquer derriere l'etiquette.

`prev` : meme genre que #11652, autorise hors LIGHT_GENRES si la substance est
distincte (§3). Elle l'est : #11652 traitait l'axe **structurel** saute sous
60 syllabes ; celle-ci traite l'axe **sur-modulation** et une lecture fautive
livree au user. Litmus LIGHT : non — il a fallu mesurer 7 extraits et lire
l'intention de calibration.

See #1028
