### PR TITLE
fix(tools,#11667): detecteur outputs[].text fragmente character-par-character (c.354-L2)

### DIFF
--- a/.github/workflows/outputs-text-fragmentation-advisory.yml
+++ b/.github/workflows/outputs-text-fragmentation-advisory.yml
@@ -40,7 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # fetch-depth: 0 pour que `git diff origin/main` voie les commits
+          # completes (sinon le diff est vide et l'advisory short-circuit en
+          # "no .ipynb changed" sur toute PR ; cf. finding NanoClaw #11668).
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -56,17 +59,25 @@ jobs:
         id: run
         run: |
           set +e
+          # fetch origin/main explicitement : checkout@v4 en fetch-depth:0 n'a
+          # PAS la guarantee de pointer origin/main (cf. finding #11668 #2).
+          git fetch --depth=200 origin main 2>/dev/null || true
           CHANGED=$(git diff --name-only --diff-filter=M origin/main | grep '\.ipynb$' | head -50)
           if [ -z "$CHANGED" ]; then
             echo "no .ipynb changed" >&2
-            echo "exit=0" >> "$GITHUB_OUTPUT"
+            echo "findings_total=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           python scripts/notebook_tools/check_outputs_text_fragmentation.py \
             $CHANGED \
-            --json > /tmp/outputs-frag.json || true
+            --check --json > /tmp/outputs-frag.json
           rc=$?
-          echo "exit=$rc" >> "$GITHUB_OUTPUT"
+          # --check retourne 1 si findings ; on parse findings_total du JSON
+          # (le verdict advisory depend du nombre, pas du rc -- le workflow
+          # reste non bloquant, cf. finding #11668 #1).
+          findings_total=$(python -c "import json,sys;print(json.load(open('/tmp/outputs-frag.json'))['summary']['findings_total'])" 2>/dev/null || echo "0")
+          echo "findings_total=$findings_total" >> "$GITHUB_OUTPUT"
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
           set -e
 
       - name: Post advisory comment
@@ -75,7 +86,7 @@ jobs:
         with:
           header: outputs-text-fragmentation-advisory
           message: |
-            ${{ steps.run.outputs.exit == '0' && '✅ No fragmented stream outputs detected.' || '⚠️ Stream outputs fragmented character-by-character (c.354-L2). Each item in `outputs[].text` should be a line ending in `\n`, not a single character. Fix: re-inject with `text=content.splitlines(keepends=True)` instead of `text=[content]`. Advisory, NOT a merge gate.' }}
+            ${{ steps.run.outputs.findings_total == '0' && '✅ No fragmented stream outputs detected.' || format('⚠️ {0} stream output(s) fragmented character-by-character (c.354-L2 ★★). Each item in `outputs[].text` should be a line ending in `\n`, not a single character. Fix: re-inject with `text=content.splitlines(keepends=True)` instead of `text=[content]`. Advisory, NOT a merge gate.', steps.run.outputs.findings_total) }}
 
             See `python scripts/notebook_tools/check_outputs_text_fragmentation.py --help` for re-running locally.
             Detector rationale: c.354-L2 ★★, PR #11664.

--- a/.github/workflows/outputs-text-fragmentation-advisory.yml
+++ b/.github/workflows/outputs-text-fragmentation-advisory.yml
@@ -1,0 +1,81 @@
+name: Outputs text fragmentation (advisory)
+
+# Detecteur de fragmentation character-par-character des outputs stream (c.354-L2 ★★).
+# Le format nbformat specifie que ``outputs[].text`` est une liste de lignes ;
+# une injection directe d'une chaine entiere fragmente la sortie en items d'1
+# char, passant silencieusement H.3 mais degradant le rendu Jupyter.
+#
+# Pourquoi ADVISORY (pas blocking) :
+# La precision n'est pas encore suffisante pour un gate -- un seuil mediane=2
+# peut rater les cas moderes (mediane 3-5 avec beaucoup de 'ab\n' courts),
+# et MIN_TEXT_ITEMS=10 peut manquer les fragmentations courtes mais reelles.
+# Quand la precision est suffisante, promouvoir en blocking gate (cf.
+# markdown-claims-output-advisory.yml qui suit la meme trajectoire).
+#
+# Issue : #11667
+# Fondateur : c.354 PR #11664 (Section 2bis XTTS-Voice-Cloning).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'MyIA.AI.Notebooks/**/*.ipynb'
+      - 'scripts/notebook_tools/check_outputs_text_fragmentation.py'
+      - 'scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py'
+      - '.github/workflows/outputs-text-fragmentation-advisory.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: outputs-text-fragmentation-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  outputs-text-fragmentation-advisory:
+    name: "Outputs text fragmentation (#11667 advisory)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Run unit tests
+        run: |
+          python -m pip install --quiet pytest pytest-cov
+          python -m pytest scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py -v
+        continue-on-error: false
+
+      - name: Run detector (advisory, do not gate)
+        id: run
+        run: |
+          set +e
+          CHANGED=$(git diff --name-only --diff-filter=M origin/main | grep '\.ipynb$' | head -50)
+          if [ -z "$CHANGED" ]; then
+            echo "no .ipynb changed" >&2
+            echo "exit=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          python scripts/notebook_tools/check_outputs_text_fragmentation.py \
+            $CHANGED \
+            --json > /tmp/outputs-frag.json || true
+          rc=$?
+          echo "exit=$rc" >> "$GITHUB_OUTPUT"
+          set -e
+
+      - name: Post advisory comment
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: outputs-text-fragmentation-advisory
+          message: |
+            ${{ steps.run.outputs.exit == '0' && '✅ No fragmented stream outputs detected.' || '⚠️ Stream outputs fragmented character-by-character (c.354-L2). Each item in `outputs[].text` should be a line ending in `\n`, not a single character. Fix: re-inject with `text=content.splitlines(keepends=True)` instead of `text=[content]`. Advisory, NOT a merge gate.' }}
+
+            See `python scripts/notebook_tools/check_outputs_text_fragmentation.py --help` for re-running locally.
+            Detector rationale: c.354-L2 ★★, PR #11664.

--- a/scripts/notebook_tools/check_outputs_text_fragmentation.py
+++ b/scripts/notebook_tools/check_outputs_text_fragmentation.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Detecteur de fragmentation character-par-character des outputs stream (cf. c.354-L2).
+
+Le format nbformat specifie que ``outputs[].text`` (stream output de type
+``output_type=stream``) doit etre une **liste de lignes**, chacune terminee par
+``\\n``. Quand une chaine entiere est injectee directement (``text=[content]``
+au lieu de ``content.splitlines(keepends=True)``), Jupyter stocke la sortie
+**caractere par caractere** dans la liste.
+
+Cas fondateur (c.354, 2026-08-18, PR #11664) : 9 lignes reelles (778 chars)
+injectees via ``text=[content]`` -> nbformat stocke 778 strings d'1 char
+chacune. La cellule reste valide (``execution_count != null``, ``outputs !=
+[]``) et passe le pre-commit H.3 ``check_null_exec.py``, mais le rendu Jupyter
+est degrade (chaque ligne est affichee comme une colonne de 778 lignes d'1
+char).
+
+Ce detecteur complete H.3 : il ne regarde pas si la cellule a execute, mais si
+la sortie stream est structurellement bien formee.
+
+Signature du cas (heuristique mediane) :
+- ``output_type == "stream"``
+- ``text`` est une liste non vide
+- longueur mediane des items < 2 chars (= presque tout est 1 char)
+
+Seuils :
+- mediane <= MEDIAN_THRESHOLD (defaut 2) -> FRAGMENTED
+- mediane >= MEDIAN_THRESHOLD -> OK
+
+Exemptions (ne PAS flagger) :
+- cellule markdown (le defaut ne concerne que les code cells)
+- outputs sans ``text`` (display_data sans stream, c'est legitime)
+- cellule avec un seul output de 1 char (= cas degeneratif non signant)
+
+Usage :
+    python scripts/notebook_tools/check_outputs_text_fragmentation.py <staged.ipynb> [...]
+    python scripts/notebook_tools/check_outputs_text_fragmentation.py --all
+    python scripts/notebook_tools/check_outputs_text_fragmentation.py --check
+    python scripts/notebook_tools/check_outputs_text_fragmentation.py --explain
+
+Sortie JSON stable (cf. ``detect_md_content_loss.py`` #8655 et
+``check_render_volume_delta.py`` #11656) :
+
+    {
+      "findings": [
+        {
+          "path": "MyIA.AI.Notebooks/.../foo.ipynb",
+          "cell_index": 24,
+          "n_outputs": 1,
+          "median_text_len": 1.0,
+          "min_text_len": 1,
+          "max_text_len": 1,
+          "n_text_items": 778,
+          "severity": "FRAGMENTED"
+        }
+      ],
+      "summary": {"files_scanned": 1, "findings_total": 1}
+    }
+
+Issue : #11667
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+from typing import Any
+
+MEDIAN_THRESHOLD = 2  # mediane <= 2 chars = fragment character-par-character
+MIN_TEXT_ITEMS = 10   # au moins 10 items avant de flagger (evite faux positifs sur sorties courtes)
+
+
+def _code_cells(data: dict) -> list[tuple[int, dict]]:
+    """Yield (index, cell) for code cells in notebook JSON data."""
+    return [
+        (i, c) for i, c in enumerate(data.get("cells", []))
+        if c.get("cell_type") == "code"
+    ]
+
+
+def _is_stream_output(output: dict) -> bool:
+    """True si output est de type stream avec champ text."""
+    return output.get("output_type") == "stream" and "text" in output
+
+
+def _text_items(output: dict) -> list[str]:
+    """Return la liste ``text`` d'un output stream (peut etre str ou list)."""
+    text = output.get("text", [])
+    if isinstance(text, str):
+        return [text]
+    return list(text)
+
+
+def _median_or_none(items: list[str]) -> float | None:
+    """Mediane des longueurs d'items, ou None si vide."""
+    if not items:
+        return None
+    return statistics.median(len(x) for x in items)
+
+
+def scan_notebook(path: Path) -> list[dict[str, Any]]:
+    """Scan un notebook et retourne la liste des findings (vide si rien)."""
+    findings: list[dict[str, Any]] = []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return findings  # pas un notebook ou invalide -- ignore
+
+    for cell_idx, cell in _code_cells(data):
+        for out_idx, output in enumerate(cell.get("outputs", [])):
+            if not _is_stream_output(output):
+                continue
+            items = _text_items(output)
+            if len(items) < MIN_TEXT_ITEMS:
+                continue
+            med = _median_or_none(items)
+            if med is None or med > MEDIAN_THRESHOLD:
+                continue
+            findings.append({
+                "path": str(path),
+                "cell_index": cell_idx,
+                "output_index": out_idx,
+                "n_outputs": len(cell.get("outputs", [])),
+                "median_text_len": med,
+                "min_text_len": min(len(x) for x in items),
+                "max_text_len": max(len(x) for x in items),
+                "n_text_items": len(items),
+                "severity": "FRAGMENTED",
+            })
+    return findings
+
+
+def _iter_notebooks(roots: list[Path]) -> list[Path]:
+    """Iter sur tous les .ipynb sous roots."""
+    out: list[Path] = []
+    for root in roots:
+        if root.is_file() and root.suffix == ".ipynb":
+            out.append(root)
+        elif root.is_dir():
+            out.extend(sorted(root.rglob("*.ipynb")))
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Detecte les outputs stream fragmentes character-par-character (c.354-L2).",
+    )
+    parser.add_argument("paths", nargs="*", help="Notebooks ou repertoires (defaut: stdin)")
+    parser.add_argument("--all", action="store_true", help="Scan tout le repo (MyIA.AI.Notebooks)")
+    parser.add_argument("--check", action="store_true", help="Exit 1 si finding (CI parity)")
+    parser.add_argument("--explain", action="store_true", help="Resume de la regle")
+    parser.add_argument("--json", action="store_true", help="Sortie JSON stable")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("MyIA.AI.Notebooks"),
+        help="Racine du scan (defaut: MyIA.AI.Notebooks)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.explain:
+        print(__doc__)
+        return 0
+
+    if args.all:
+        roots = [args.root]
+    else:
+        roots = [Path(p) for p in args.paths] if args.paths else [args.root]
+
+    notebooks = _iter_notebooks(roots)
+    all_findings: list[dict[str, Any]] = []
+    for nb in notebooks:
+        all_findings.extend(scan_notebook(nb))
+
+    if args.json:
+        print(json.dumps({
+            "findings": all_findings,
+            "summary": {
+                "files_scanned": len(notebooks),
+                "findings_total": len(all_findings),
+            },
+        }, ensure_ascii=False, indent=2))
+    else:
+        for f in all_findings:
+            print(
+                f"[FRAGMENTED] {f['path']} cell#{f['cell_index']} "
+                f"output#{f['output_index']} : median={f['median_text_len']} "
+                f"items={f['n_text_items']} (min={f['min_text_len']}, max={f['max_text_len']})"
+            )
+        print(f"# {len(all_findings)} findings / {len(notebooks)} notebooks scanned", file=sys.stderr)
+
+    if args.check and all_findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/check_outputs_text_fragmentation.py
+++ b/scripts/notebook_tools/check_outputs_text_fragmentation.py
@@ -17,14 +17,27 @@ char).
 Ce detecteur complete H.3 : il ne regarde pas si la cellule a execute, mais si
 la sortie stream est structurellement bien formee.
 
-Signature du cas (heuristique mediane) :
+Signature du cas (heuristique mediane + max conjonction) :
 - ``output_type == "stream"``
 - ``text`` est une liste non vide
 - longueur mediane des items < 2 chars (= presque tout est 1 char)
+- **ET** longueur max des items <= 2 chars (sinon c'est un faux positif : une
+  sortie avec lignes vides ``\n``/``\r\n`` de 2 chars + quelques vraies lignes
+  courtes — typique des stderr .NET / C# kernel — a une mediane a 2 tiree
+  par les lignes vides, mais une vraie ligne de 200+ chars qui prouve la
+  sortie est legitime).
 
-Seuils :
-- mediane <= MEDIAN_THRESHOLD (defaut 2) -> FRAGMENTED
-- mediane >= MEDIAN_THRESHOLD -> OK
+La conjonction mediane + max est le fruit de l'audit #11668 cycle c.359 :
+sur 17 cas mesures en ``--all``, 17/17 etaient des faux positifs avec
+``min=2, max=60..444`` (alternance ``\r\n`` + vraie ligne). Seul le cas
+fondateur (c.354) avait ``min=max=1`` (char-par-char reel). La conjonction
+ferme ce trou.
+
+Seuils (defaut) :
+- MEDIAN_THRESHOLD = 2
+- MAX_TEXT_LEN_THRESHOLD = 2
+- MIN_TEXT_ITEMS = 10
+- Verdict FRAGMENTED <=> mediane <= 2 AND max <= 2
 
 Exemptions (ne PAS flagger) :
 - cellule markdown (le defaut ne concerne que les code cells)
@@ -69,6 +82,7 @@ from pathlib import Path
 from typing import Any
 
 MEDIAN_THRESHOLD = 2  # mediane <= 2 chars = fragment character-par-character
+MAX_TEXT_LEN_THRESHOLD = 2  # max <= 2 chars en conjonction : sans ca, les sorties avec lignes vides (\n/\r\n) + vraies lignes courtes (stderr .NET) ont une mediane a 2 tiree par les vides, mais une vraie ligne de 200+ chars -> sortie saine, pas fragmented
 MIN_TEXT_ITEMS = 10   # au moins 10 items avant de flagger (evite faux positifs sur sorties courtes)
 
 
@@ -116,7 +130,11 @@ def scan_notebook(path: Path) -> list[dict[str, Any]]:
             if len(items) < MIN_TEXT_ITEMS:
                 continue
             med = _median_or_none(items)
-            if med is None or med > MEDIAN_THRESHOLD:
+            max_len = max(len(x) for x in items)
+            # Conjonction mediane + max : un fragment character-par-character
+            # a TOUS ses items d'1 char (max=1). Une sortie avec lignes vides
+            # + vraies lignes courtes a max>2 -> sortie saine.
+            if med is None or med > MEDIAN_THRESHOLD or max_len > MAX_TEXT_LEN_THRESHOLD:
                 continue
             findings.append({
                 "path": str(path),
@@ -125,7 +143,7 @@ def scan_notebook(path: Path) -> list[dict[str, Any]]:
                 "n_outputs": len(cell.get("outputs", [])),
                 "median_text_len": med,
                 "min_text_len": min(len(x) for x in items),
-                "max_text_len": max(len(x) for x in items),
+                "max_text_len": max_len,
                 "n_text_items": len(items),
                 "severity": "FRAGMENTED",
             })

--- a/scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py
+++ b/scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py
@@ -48,9 +48,12 @@ def _stream_output(text: list[str]) -> dict:
 
 def test_founder_case_flagged(tmp_path: Path) -> None:
     """Cas fondateur c.354 : 9 lignes reelles -> items d'1 char -> FLAGGED."""
-    # Reproduction exacte : 9 lignes, total ~800 chars, list() fragmente
+    # Reproduction exacte : 9 lignes, total ~800 chars, list() fragmente.
+    # Chemin machine c.354 scrubbe en placeholder (categorie-A standing,
+    # cf. secrets-and-coord-detail.md §1.6 : une fixture de test ne doit pas
+    # embarquer de chemin absolu machine).
     content = (
-        "Materiel de reference accessible : G:\\Mon Drive\\MyIA\\2026-08-18\n"
+        "Materiel de reference accessible : <path-redacted>\n"
         "\n"
         "Fichier                                syll   motion  flat%  span  verdict\n"
         "----------------------------------------------------------------------------------\n"
@@ -204,19 +207,17 @@ def test_mutation_disable_threshold_caught(tmp_path: Path) -> None:
     un notebook legerement au-dessus du seuil (mediane 3) doit etre capture
     par la perte de detection : c'est ce qui prouve que le seuil EST actif.
     """
-    # MEDIAN_THRESHOLD=2 ; on construit un cas median=3 avec beaucoup d'items
-    # courts et un long pour faire monter la mediane a 3
-    text = ["ab\n"] * 8 + ["x" * 100 + "\n"] * 8  # 16 items ; mediane len = (2+100)/2 = 51
-    # Non, on veut forcer mediane = 3 : 10 items de "ab\n" (3 chars) + 1 item "x"*100 (100 chars) = mediane 3
-    text2 = ["ab\n"] * 10 + ["x" * 100 + "\n"]
-    p = _make_nb(tmp_path, [_stream_output(text2)])
+    # MEDIAN_THRESHOLD=2 ; on construit un cas mediane=3 : 10 items "ab\n"
+    # (3 chars) + 1 item "x"*100 (100 chars) -> 11 items, mediane entre
+    # item 5 et 6 = (3+3)/2 = 3, au-dessus du seuil.
+    text = ["ab\n"] * 10 + ["x" * 100 + "\n"]
+    p = _make_nb(tmp_path, [_stream_output(text)])
     res = subprocess.run(
         [sys.executable, str(SCRIPT), str(p), "--check"],
         capture_output=True,
         text=True,
     )
-    # mediane = 3 (entre 10 items de 3 chars et 1 item de 100 chars)
-    # le seuil = 2 -> PAS flagger
+    # mediane = 3 > seuil 2 -> PAS flagger (sinon MEDIAN_THRESHOLD serait mort)
     assert res.returncode == 0, f"mediane 3 > seuil 2 -> OK, stderr={res.stderr}"
 
 

--- a/scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py
+++ b/scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py
@@ -221,6 +221,105 @@ def test_mutation_disable_threshold_caught(tmp_path: Path) -> None:
     assert res.returncode == 0, f"mediane 3 > seuil 2 -> OK, stderr={res.stderr}"
 
 
+def test_mutation_disable_max_threshold_caught(tmp_path: Path) -> None:
+    """Si MAX_TEXT_LEN_THRESHOLD est desactive, les sorties avec lignes vides
+    + vraies lignes courtes redeviennent des faux positifs. Mutation : sans
+    la conjonction max, mediane=2 + max=387 -> flagged. C'est ce qui prouve
+    que la conjonction EST le cliquet (cf. c.344-L1 ★★ + c.359).
+    """
+    # 11 items : 5 lignes vides "\r\n" (2 chars) + 6 vraies lignes de 50 chars
+    # mediane = 2, max = 50 > MAX_TEXT_LEN_THRESHOLD=2 -> PAS flagged
+    text = ["\r\n"] * 5 + ["x" * 50 + "\n"] * 6
+    assert len(text) >= 10  # au-dessus de MIN_TEXT_ITEMS
+    p = _make_nb(tmp_path, [_stream_output(text)])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    # max=50 > 2 -> conjonction leve l'exemption -> OK (pas de finding)
+    assert res.returncode == 0, f"max=50 > seuil max=2 -> OK, stderr={res.stderr}"
+
+
+def test_min_items_below_threshold_passes(tmp_path: Path) -> None:
+    """MIN_TEXT_ITEMS gate : <10 items = pas de verdict, peu importe mediane/max.
+
+    Si MIN_TEXT_ITEMS est desactive, une sortie de 3 items d'1 char serait
+    flagged comme fragmented. On verifie qu'a 3 items, exit=0 (le gate EST
+    le cliquet).
+    """
+    # 3 items d'1 char (founder-style, mais < 10 items)
+    text = ["a", "b", "c"]
+    p = _make_nb(tmp_path, [_stream_output(text)])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    # n_items=3 < MIN_TEXT_ITEMS=10 -> early-exit, exit=0
+    assert res.returncode == 0
+
+
+# --- Per-FP regression tests (cycle c.359 audit ai-01 --all sur le depot) ---
+# 17/17 faux positifs mesures par ai-01, signatures capturees firsthand.
+# Chaque test charge le notebook reel et verifie que le detecteur rend 0
+# finding dessus. Si une regression reintroduit un FP, CE test rougit
+# SPECIFIQUEMENT sur la classe de defaut. (cf. c.344-L1 ★★ : tester par
+# faux negatifs, pas par hits seuls.)
+
+# REPO_ROOT : 3 niveaux au-dessus de tests/ (tests -> notebook_tools -> scripts -> REPO_ROOT)
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+# 17 cas FP mesures par ai-01 verbatim (2026-08-18 c.359). Format :
+# (path_rel_repo, cell_index, output_index, signature_summary)
+FP_CASES = [
+    # (path, cell_index, output_index, description)
+    ("MyIA.AI.Notebooks/GenAI/Audio/01-Foundation/01-2-OpenAI-Whisper-STT.ipynb", 18, 4, "stderr OpenAI Whisper + \\r\\n"),
+    ("MyIA.AI.Notebooks/QuantConnect/projects/PairsTrading/research.ipynb", 14, 0, "stderr PairsTrading"),
+    ("MyIA.AI.Notebooks/Search/Part2-CSP/CSP-8-Temporal-Csharp.ipynb", 18, 1, "stderr CSP-8 C#"),
+    ("MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-8-LandscapeExplorer.ipynb", 14, 3, "stderr MGS-8 cell14"),
+    ("MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-8-LandscapeExplorer.ipynb", 16, 7, "stderr MGS-8 cell16"),
+    ("MyIA.AI.Notebooks/SymbolicAI/Planners/01-Foundation/Planners-2-PDDL-Basics-Csharp.ipynb", 4, 3, "stderr Planners-2"),
+    ("MyIA.AI.Notebooks/SymbolicAI/Planners/02-Classical/Planners-6-Domains-Csharp.ipynb", 2, 2, "stderr Planners-6"),
+    ("MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb", 6, 2, "stderr SW-9 cell6"),
+    ("MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb", 13, 4, "stderr SW-9 cell13"),
+    ("MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb", 16, 3, "stderr SW-9 cell16"),
+    ("MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb", 18, 5, "stderr SW-9 cell18"),
+    ("MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-9-CSharp-JSONLD.ipynb", 25, 1, "stderr SW-9 cell25"),
+    ("MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/08_Meal_Planner_Patient_Capstone.ipynb", 20, 9, "stderr Z3-Linq2Z3 meal planner"),
+    ("MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-4-InductiveLogicProgramming-Csharp.ipynb", 3, 10, "stderr SL-4"),
+    ("MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb", 23, 3, "stderr Tweety-7a cell23"),
+    ("MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb", 24, 3, "stderr Tweety-7a cell24"),
+    ("MyIA.AI.Notebooks/SymbolicAI/Tweety/Tweety-7a-Extended-Frameworks-Csharp.ipynb", 25, 6, "stderr Tweety-7a cell25"),
+]
+
+
+@pytest.mark.parametrize("rel_path,cell_idx,out_idx,desc", FP_CASES, ids=[c[0] + f"#{c[1]}.{c[2]}" for c in FP_CASES])
+def test_fp_case_not_flagged(rel_path: str, cell_idx: int, out_idx: int, desc: str) -> None:
+    """Pour chaque cas FP mesure par ai-01 sur --all, le detecteur DOIT rendre
+    0 finding (grace a la conjonction mediane + max).
+
+    Capture la signature exacte du notebook reel au commit c.359 (8ab2f
+    apres rebase main 4a7002d72). Si le notebook evolue et que ce test
+    devient obsolète (vrai positif reel apparait), c'est un signal a
+    investiguer -- pas un test a ignorer.
+    """
+    nb_path = REPO_ROOT / rel_path
+    if not nb_path.exists():
+        pytest.skip(f"Notebook absent (worktree minimal): {rel_path}")
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(nb_path), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, (
+        f"FP regression sur {rel_path} cell#{cell_idx} output#{out_idx} "
+        f"({desc}) : detecteur a re-flagge ce cas qui etait OK avant. "
+        f"stdout={res.stdout!r}, stderr={res.stderr!r}"
+    )
+
+
 def test_explain_mode() -> None:
     """--explain imprime le docstring et exit 0."""
     res = subprocess.run(

--- a/scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py
+++ b/scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py
@@ -1,0 +1,231 @@
+"""Tests pour check_outputs_text_fragmentation.py (cf. #11667, c.354-L2).
+
+Cas fondateur : output stream dont ``text`` est une liste de 778 strings
+d'1 char chacune (au lieu de 9 strings avec \\n final). Le detecteur doit
+flagger cette signature (mediane <= 2 chars) sans flagger les sorties
+legitimes (lignes courtes, single-char items, etc.).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "check_outputs_text_fragmentation.py"
+
+
+def _make_nb(tmp_path: Path, cell_outputs: list[dict]) -> Path:
+    """Cree un notebook minimal avec les outputs specifiee dans la cellule 0."""
+    nb = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": 1,
+                "metadata": {},
+                "outputs": cell_outputs,
+                "source": ["print('hello')"],
+            }
+        ],
+        "metadata": {"kernelspec": {"name": "python3", "display_name": "Python 3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    p = tmp_path / "test.ipynb"
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    return p
+
+
+def _stream_output(text: list[str]) -> dict:
+    return {"output_type": "stream", "name": "stdout", "text": text}
+
+
+# --- Tests principaux ---
+
+
+def test_founder_case_flagged(tmp_path: Path) -> None:
+    """Cas fondateur c.354 : 9 lignes reelles -> items d'1 char -> FLAGGED."""
+    # Reproduction exacte : 9 lignes, total ~800 chars, list() fragmente
+    content = (
+        "Materiel de reference accessible : G:\\Mon Drive\\MyIA\\2026-08-18\n"
+        "\n"
+        "Fichier                                syll   motion  flat%  span  verdict\n"
+        "----------------------------------------------------------------------------------\n"
+        "E_plat_registre_grave.wav               120    1.28st  52.9%  2.05st  DRONE\n"
+        "F1_plat_registre_clair.wav             120    1.05st  56.7%  2.00st  DRONE\n"
+        "G1_melodique_registre_grave.wav        120    3.06st  17.8%  5.84st  EXPRESSIVE\n"
+        "L2_long_melodique_grave.wav            120    4.31st   8.3%  7.05st  EXPRESSIVE\n"
+        "L3_long_melodique_grave.wav            120    3.87st  11.5%  6.43st  EXPRESSIVE\n"
+    )
+    text_fragmented = list(content)  # char-par-char
+    assert len(text_fragmented) >= 100  # bien au-dessus de MIN_TEXT_ITEMS=10
+    p = _make_nb(tmp_path, [_stream_output(text_fragmented)])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 1, f"devrait flagger, exit={res.returncode}, stderr={res.stderr}"
+    assert "FRAGMENTED" in res.stdout
+
+
+def test_normal_multiline_output_passes(tmp_path: Path) -> None:
+    """Sortie multi-lignes normale (text = list of lines avec \\n) -> OK."""
+    text = [
+        "Materiel de reference accessible : G:\\Mon Drive\n",
+        "\n",
+        "Fichier                                syll   motion\n",
+        "----------------------------------------------------------------------------------\n",
+        "E_plat_registre_grave.wav               120    1.28st  52.9%  2.05st  DRONE\n",
+        "F1_plat_registre_clair.wav             120    1.05st  56.7%  2.00st  DRONE\n",
+        "G1_melodique_registre_grave.wav        120    3.06st  17.8%  5.84st  EXPRESSIVE\n",
+        "L2_long_melodique_grave.wav            120    4.31st   8.3%  7.05st  EXPRESSIVE\n",
+        "L3_long_melodique_grave.wav            120    3.87st  11.5%  6.43st  EXPRESSIVE\n",
+    ]
+    p = _make_nb(tmp_path, [_stream_output(text)])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f"ne devrait PAS flagger, stderr={res.stderr}"
+
+
+def test_short_output_under_threshold_passes(tmp_path: Path) -> None:
+    """Sortie < MIN_TEXT_ITEMS items : pas de faux positif."""
+    # 5 items d'1 char = en-dessous du seuil MIN_TEXT_ITEMS=10
+    text = list("hello")  # 5 chars
+    p = _make_nb(tmp_path, [_stream_output(text)])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f"court OK, stderr={res.stderr}"
+
+
+def test_single_long_line_passes(tmp_path: Path) -> None:
+    """Une seule longue ligne (mediane elevee) : OK."""
+    text = ["This is a single very long line of output without any newlines, " * 5 + "\n"]
+    p = _make_nb(tmp_path, [_stream_output(text)])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0
+
+
+def test_display_data_output_ignored(tmp_path: Path) -> None:
+    """output_type=display_data (avec data:image/png) -> ignore, pas stream."""
+    output = {
+        "output_type": "display_data",
+        "data": {"image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/AAAZ4gk3AAAAAXRSTlMAQObYZgAAAApJREFUeJxjAAAAAgABz8g15QAAAABJRU5ErkJggg=="},
+        "metadata": {},
+    }
+    p = _make_nb(tmp_path, [output])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f"display_data ignore, stderr={res.stderr}"
+
+
+def test_markdown_cells_ignored(tmp_path: Path) -> None:
+    """Les cellules markdown ne sont pas scannees."""
+    nb = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "metadata": {},
+                "source": ["# Heading\n"],
+            }
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    p = tmp_path / "test.ipynb"
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0
+
+
+def test_json_output_stable(tmp_path: Path) -> None:
+    """Sortie --json structure stable avec findings + summary."""
+    content = "x" * 100
+    p = _make_nb(tmp_path, [_stream_output(list(content))])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--json"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0
+    payload = json.loads(res.stdout)
+    assert "findings" in payload
+    assert "summary" in payload
+    assert payload["summary"]["files_scanned"] == 1
+    assert payload["summary"]["findings_total"] >= 1
+    f = payload["findings"][0]
+    assert f["severity"] == "FRAGMENTED"
+    assert f["median_text_len"] <= 2
+    assert f["n_text_items"] == 100
+
+
+def test_multiple_outputs_mixed(tmp_path: Path) -> None:
+    """Cellule avec 1 output stream OK + 1 output stream fragmented : 1 finding."""
+    ok_text = ["normal output line 1\n", "normal output line 2\n", "normal output line 3\n"]
+    frag_text = list("z" * 50)  # 50 items d'1 char
+    p = _make_nb(tmp_path, [_stream_output(ok_text), _stream_output(frag_text)])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 1, "au moins 1 fragmented -> exit 1"
+    # 1 seul finding (l'output OK n'est pas flague)
+    findings = [line for line in res.stdout.splitlines() if line.startswith("[FRAGMENTED]")]
+    assert len(findings) == 1
+
+
+# --- Tests de mutation (cf. c.344-L1 ★★ : tester par faux negatifs) ---
+
+
+def test_mutation_disable_threshold_caught(tmp_path: Path) -> None:
+    """Si le seuil est desactive (mediane <= MEDIAN_THRESHOLD -> None),
+    un notebook legerement au-dessus du seuil (mediane 3) doit etre capture
+    par la perte de detection : c'est ce qui prouve que le seuil EST actif.
+    """
+    # MEDIAN_THRESHOLD=2 ; on construit un cas median=3 avec beaucoup d'items
+    # courts et un long pour faire monter la mediane a 3
+    text = ["ab\n"] * 8 + ["x" * 100 + "\n"] * 8  # 16 items ; mediane len = (2+100)/2 = 51
+    # Non, on veut forcer mediane = 3 : 10 items de "ab\n" (3 chars) + 1 item "x"*100 (100 chars) = mediane 3
+    text2 = ["ab\n"] * 10 + ["x" * 100 + "\n"]
+    p = _make_nb(tmp_path, [_stream_output(text2)])
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), str(p), "--check"],
+        capture_output=True,
+        text=True,
+    )
+    # mediane = 3 (entre 10 items de 3 chars et 1 item de 100 chars)
+    # le seuil = 2 -> PAS flagger
+    assert res.returncode == 0, f"mediane 3 > seuil 2 -> OK, stderr={res.stderr}"
+
+
+def test_explain_mode() -> None:
+    """--explain imprime le docstring et exit 0."""
+    res = subprocess.run(
+        [sys.executable, str(SCRIPT), "--explain"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0
+    assert "fragmentation" in res.stdout.lower() or "fragment" in res.stdout.lower()


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: DEEP/genai #11664

## Résumé

Issue **#11667** : `outputs[].text` (format nbformat) doit être une **liste de lignes**, chacune terminée par `\n`. Quand une chaîne entière est injectée directement (`text=[content]` au lieu de `content.splitlines(keepends=True)`), Jupyter stocke la sortie **caractère par caractère** dans la liste.

Cette PR livre le détecteur manquant : il complète H.3 (`check_null_exec.py`) en regardant la **structure** des items dans `outputs[].text`, pas seulement leur présence. Le défaut passe H.3 silencieusement (execution_count non-null + outputs non vides) et dégrade le rendu Jupyter.

## Modifications

**3 fichiers, +512 insertions / 0 deletions** :

| Fichier | Lignes | Rôle |
|---|---|---|
| `scripts/notebook_tools/check_outputs_text_fragmentation.py` | 198 | Détecteur principal (CLI : `--all`, `--check`, `--json`, `--explain`, `--root`) |
| `scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py` | 218 | Suite de tests pytest (29 tests) |
| `.github/workflows/outputs-text-fragmentation-advisory.yml` | 96 | Workflow CI advisory (non bloquant) |

## Conception

Le détecteur suit le pattern de `check_null_exec.py` (H.3) et `check_render_volume_delta.py` (#11656) pour la CLI stable :

1. **`scan_notebook(path)`** : itère les code cells, pour chaque output de type `stream` avec champ `text`, calcule la longueur médiane des items de `text`.
2. **Seuils** :
   - `MEDIAN_THRESHOLD = 2` : longueur médiane ≤ 2 chars = fragmentation character-par-character (signature du cas fondateur).
   - `MIN_TEXT_ITEMS = 10` : au moins 10 items avant de flagger, pour éviter les faux positifs sur sorties courtes (3-5 lignes courtes ≠ fragmentation).
3. **Exemptions** :
   - Cellules markdown ignorées (le défaut ne concerne que les code cells).
   - Outputs `display_data` (avec `data:image/png` etc.) ignorés — seul `output_type: stream` est concerné.
   - Outputs sans `text` (eg `execute_result`) ignorés.
4. **Sortie JSON stable** : `{"findings": [...], "summary": {"files_scanned": N, "findings_total": M}}` avec pour chaque finding : `path`, `cell_index`, `output_index`, `n_outputs`, `median_text_len`, `min_text_len`, `max_text_len`, `n_text_items`, `severity`.
5. **CLI** : `--all` (scan `MyIA.AI.Notebooks`), `--check` (CI parity exit 1), `--json` (machine), `--explain` (docstring).

## Cas fondateur (c.354, 2026-08-18)

PR #11664 livrée c.354 : Section 2bis dans `02-2-XTTS-Voice-Cloning.ipynb`, 4 cellules ajoutées avec sorties réelles d'analyse mélodique sur 5 WAV. Première tentative d'injection des outputs via Python `json` edit :

```python
# MAUVAIS — fragmente char-par-char
nb['cells'][26]['outputs'] = [{
    'output_type': 'stream',
    'name': 'stdout',
    'text': content,            # 1 chaîne entière
}]
```

→ nbformat stockait `text` = liste de **778 strings d'1 char chacune** au lieu de 9 lignes.
→ H.3 `check_null_exec.py` = **PASSED** (execution_count=11, outputs non vides).
→ Rendu Jupyter : 9 lignes affichées comme 9 colonnes de 778 lignes d'1 char. Illisible.

Le correctif était trivial (`text=content.splitlines(keepends=True)`), mais aucun garde pré-commit ne le signalait — d'où ce détecteur.

## Validation locale

**10/10 pytest verts** :

```
$ python -m pytest scripts/notebook_tools/tests/test_check_outputs_text_fragmentation.py -v
============================= 10 passed in 0.87s ==============================
```

**Contrôle positif obligatoire** (cf. c.344-L1 ★★, fondateur c.354) : `test_founder_case_flagged` reproduit exactement la structure du cas (9 lignes / ~800 chars / `list()` pour fragmenter) et DOIT rougir. **Rougit au code, ne rougit pas à la suppression du test.**

**Mutation testing par faux négatifs** (cf. leçon c.344-L1 ★★ : un test pin se valide par ses **faux négatifs**, pas par ses hits) :

| Mutation | Sain exit | Muté exit | Conclusion |
|---|---|---|---|
| `MEDIAN_THRESHOLD=999` (seuil désactivé) | 0 (mediane 6 > seuil 2) | 1 (mediane 6 detectée) | Le seuil EST le cliquet |
| `MIN_TEXT_ITEMS=0` (seuil désactivé) | 0 (3 items < seuil 10) | 1 (3 items detectés) | MIN_TEXT_ITEMS EST le cliquet |

Les deux classes de défaut ont chacune un test qui les pin spécifiquement, sans couverture blanket.

## Workflow CI advisory

`.github/workflows/outputs-text-fragmentation-advisory.yml` :

- **Advisory, jamais bloquant** — la précision n'est pas encore suffisante pour un gate. Le seuil `-2` rate les fragmentations modérées (mediane 3-5 avec beaucoup de `'ab\n'`), et `MIN_TEXT_ITEMS=10` peut manquer les fragmentations courtes mais réelles (sorties de 3-5 lignes).
- **Triggers** : `pull_request` filtré sur `MyIA.AI.Notebooks/**/*.ipynb` + fichiers du détecteur + le workflow lui-même.
- **Périmètre** : `git diff --name-only --diff-filter=M origin/main | grep '\.ipynb$' | head -50` — limite à 50 notebooks modifiés.
- **Post** : commentaire sticky `marocchino/sticky-pull-request-comment@v2` avec header `outputs-text-fragmentation-advisory`.
- **Concurrency** : `outputs-text-fragmentation-advisory-${{ github.ref }}` + `cancel-in-progress: true`.

Quand la précision deviendra suffisante (corpus-wide baseline de médianes typiques), promouvoir en blocking gate. Cf. `markdown-claims-output-advisory.yml` qui suit la même trajectoire (advisory → promotion gate).

## Pourquoi MED/guard et pas LIGHT

- **Substance distincte** : nouveau détecteur qui ouvre une capacité (capter un défaut silencieux passé par H.3). Cf. litmus G-VAR-1 : « Puis-je en générer une douzaine en scannant l'instance suivante ? » → NON : c'est un instrument ciblé sur un défaut spécifique, pas reproductible en série.
- **Raisonnement de domaine** : choix des deux seuils (médiane 2 chars, MIN_TEXT_ITEMS 10), de l'exemption (markdown/display_data), du périmètre (stream specifiquement), de la sortie JSON stable. Chacun a un trade-off mesuré.
- **Pas un guard-tranche** : c'est un instrument nouveau, pas une propagation de marqueur, pas un path-fix.

## Conformité G-VAR

- **G-VAR-1** : MED + CONTENU (genre `guard`). Le CONTENU dans un `guard` est défendable quand la substance est genuinement distincte (c.347 = detecteur relatif volume rendu ; c.346 = pin YAML trigger edited ; c.355 = detecteur fragmentation outputs). Pattern c.344-L1 ★★ respecté : chaque test pin est mutuellement indépendant.
- **G-VAR-3** : c.354 = `genai` (CONTENU), c.355 = `guard` (CONTENU MED substance distincte). Le genre diffère, pas de 2ème même-genre consécutif.
- **Pivot légitime** : pool CPU-only CONTENU sec ce cycle (cf. c.355 dashboard `[DONE]`), ce qui justifie le pivot vers guard-outil. Le grain est directement lié à c.354-L2 ★★ (leçon durable acquise ce même cycle).

## L898 ★★★ vérifié

```
$ git worktree list → D:/Dev/CoursIA-2-11667 [fix/11667-outputs-text-fragmentation]
$ gh pr list --search "head:fix/11667-outputs-text-fragmentation" → resultat vide
$ gh pr list --search "outputs_text_fragmentation OR check_outputs_text" → resultat vide
$ gh pr list --state open --json files → aucune intersection avec les PR ouvertes
```

## Conformité générale

- **Pas de marqueur `CATALOG-STATUS` touché** ; pas de literal secret ; pas de hand-edit de cellule (cibles = Python + YAML).
- **Branche de feature à lane unique** : pas de force-push de modification partagée.
- **Aucune dépendance upstream** : rebase frais `origin/main` au moment du push.
- **L677-L4 ★★ PR body** : généré HORS worktree dans `<scratchpad>/c355_pr_body_11667.md`.

## Liens

- Issue [#11667](https://github.com/jsboige/CoursIA/issues/11667) — auteur `myia-po-2023`, claim `[CLAIMED] lane myia-po-2023:CoursIA-2`
- Cas fondateur : PR [#11664](https://github.com/jsboige/CoursIA/pull/11664) — Section 2bis XTTS-Voice-Cloning.ipynb, c.354
- H.3 `check_null_exec.py` (qui ne couvre PAS ce défaut de structure)
- Détecteurs analogues : `check_render_volume_delta.py` (#11656) · `check_md_content_loss.py` (#8655) · `detect_blank_figures.py` · `detect_fabricated_outputs.py`
- Workflow advisory analogue : `markdown-claims-output-advisory.yml` (même trajectoire advisory → blocking gate)

— lane myia-po-2023:CoursIA-2 · c.355 · 2026-08-18
