### PR TITLE
fix(slides): S3-acculturation slide 17, figure d'exploration lisible (130x23 -> 516x91)

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -398,7 +398,7 @@ layout: two-cols
   - Jamais + de cannibales
 
 <img src="./images/img_023.png" class="w-[280px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_024.png" class="w-[100px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_024.png" class="w-[460px] max-w-full max-h-[300px] object-contain" />
 
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-ai-01:CoursIA — prev: MED/guard #11645

## Le defaut

`img_024.png` est un bandeau natif **527x93** (ratio 5,67) epingle a `w-[100px]`.
Rendu mesure : **130x23** — un lisere illisible sous le graphe, dans la colonne
droite de la slide 17.

C'est la **seule** largeur inferieure a 150px du deck :

```
24 x w-[150px]   14 x w-[180px]   12 x w-[300px]   11 x w-[400px]
 8 x w-[460px]    7 x w-[220px]    6 x w-[200px]    4 x w-[280px]
 3 x w-[350px]    1 x w-[620px]    1 x w-[380px]    1 x w-[100px]  <-- celle-ci
```

Un oubli isole, pas une convention.

La figure **porte le concept de la slide** : c'est la sequence en 4 etapes
d'expansion de l'arbre (A -> B/C -> D/E ...), qui illustre « Choix des noeuds
= Strategie d'exploration ». A 130x23 elle etait perdue.

## Le correctif

`w-[100px]` -> `w-[460px]` (convention deja utilisee 8 fois dans le deck).

| | avant | apres |
|---|---|---|
| rendu `img_024.png` | 130x23 | **516x91** (natif 527x93) |
| overflow de la slide | y=0 x=0 | **y=0 x=0** |
| `img_023.png` voisine | 365x231 | 365x231 (inchangee) |

Verifie visuellement apres changement : les quatre arbres sont distinguables.

## Ce que la passe QA a mesure — et ce qu'elle n'etablit pas

Passe sur **les 93 slides** du deck (Slidev `nav.total = 93`), instrument dans le
scratchpad, serveur Slidev local, `?clicks=99` :

| axe | resultat |
|---|---|
| overflow (y et x) | **0 slide** sur 93 |
| images cassees (`naturalWidth == 0`) | **0** sur 125 images |
| images illisibles (< 40px) | **1** — celle de cette PR |
| diagrammes mermaid | **11, tous rendus correctement** (verifie a l'ecran) |
| recouvrement image/texte | **axe non concluant, voir ci-dessous** |

**L'axe recouvrement n'est pas rapporte comme un resultat.** Il a leve 8 slides
(4, 8, 11, 31, 49, 58, 59, 65) a 36-50 %. J'en ai inspecte **4 visuellement**
(4, 49, 58, 59) : **toutes propres**, texte a gauche, images a droite, aucune
collision. Le test contre l'**encre** du texte (rect de `Range`) plutot que
contre sa boite de mise en page flague **toujours** — donc je ne tiens pas le
mecanisme, et je ne rapporte pas ces 8 slides comme des defauts. L'axe est
declare non fiable sur ce deck ; les 4 slides non inspectees restent
**non etablies**, ni saines ni defectueuses.

## Trois faux zeros attrapes avant d'etre rapportes

L'instrument a rendu trois resultats faux, tous **plus petits et plus propres**
que la verite — la signature du faux negatif :

1. **48 slides « image 0x0 »** : `querySelector('.slidev-layout')` rend la
   **premiere** layout du DOM. Slidev garde `prev`/`current`/`next` montees, les
   voisines a 0x0 — je mesurais la slide d'a cote. Corrige en retenant la layout
   de plus grande aire. Les 48 « defauts » etaient **zero**.
2. **« 0 overflow sur 93 slides »** : calcule sur ce meme conteneur 0x0, donc
   `scrollHeight - clientHeight = 0` par construction. C'etait un **faux zero**,
   pas un deck sain. Le zero re-mesure sur les vraies boites (aires 1278x391 a
   1278x720) est, lui, valide — coherent avec #11536 qui a corrige les 12 slides
   qui debordaient.
3. **« 0 svg sur 93 slides »** alors que le deck porte 11 fences mermaid : meme
   bug un etage plus bas, `querySelector('.mermaid')` attrapant un conteneur
   placeholder vide (`innerHTML` = 0 caractere) au lieu du diagramme rendu.
   **Capture d'ecran a l'appui : les diagrammes s'affichent parfaitement.**

Chacun aurait produit un rapport faux dans un sens different : inventer 48
defauts, certifier une absence de debordement non mesuree, annoncer 11
diagrammes casses qui vont bien.

## Sur le tag de grain

`slides` est CONTENU. Je tague **MED** : le finding **change une decision** —
voir le commentaire poste sur #10950, ou les premisses de l'issue (145 slides,
38 two-cols) sont corrigees par la mesure (93 slides, 26 two-cols) et ou la
conversion de masse demandee degraderait des slides saines. Un reviewer qui
tiendrait le diff d'une ligne pour LIGHT serait defendable ; dans ce cas mon
plancher G-VAR-1 de contenu n'est pas tenu ce cycle, et je prefere l'ecrire que
de le masquer derriere l'etiquette.

See #10950
