### PR TITLE
feat(lean,#11152): MIMO converse — echec global (etape 3) : no_flip_beats_prob_le

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Bridge.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Bridge.lean
@@ -340,6 +340,89 @@ theorem flip_bat_prob_lower (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ 
         exact (ENNReal.toReal_le_toReal (measure_ne_top _ _)
           (measure_ne_top _ _)).mpr hmassmono
 
+/-! ## Grain 4 (#11152, étape 3) — échec global : l'échappement coordonnée borne le succès ML
+
+La Brique 2 (`gaussian_coordinate_escape_bound`, Phase 3b) borne la probabilité
+que TOUTES les coordonnées du bruit échappent à un même intervalle, par
+indépendance du produit. Ce grain franchit le pas de l'étape 3 de #11152 :
+sous une hypothèse de couverture diagonale (« si une coordonnée du bruit
+tombe dans l'intervalle, un flip bat `x*` »), l'événement « aucun flip ne bat
+`x*` » est inclus dans l'échappement produit, donc a probabilité `≤ e^{−M·p}`.
+C'est le pont de l'échappement par coordonnée (Brique 2) à l'échec global :
+une descente stricte depuis `x*` qui s'en éloigne doit accepter un premier
+flip, qui bat — le terme `log log N` naîtra dans l'assemblage (grain 5) du
+comptage du réseau de codewords. -/
+
+/-- **Échec global (étape 3).** Hypothèse de couverture diagonale : si une
+coordonnée du bruit `w` tombe dans `I(c, ε) = (c−ε/2, c+ε/2] ⊆ [−2, 2]`,
+alors un flip bat `x*`. Alors la probabilité qu'aucun flip ne batte `x*`
+est `≤ exp(−M·ε·φ(2))` avec `φ(2) = exp(−2)/√(2π)`. Enchaînement :
+contraposée de la couverture (« aucun flip ne bat » ⊆ « toutes les
+coordonnées échappent »), transport `stdGaussian = (stdGaussianPi M).map
+(WithLp.toLp 2)` (`stdGaussianPi_map_toLp`), puis Brique 2. -/
+theorem no_flip_beats_prob_le {N M : ℕ} (hM : 0 < M)
+    (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M)) {s c ε : ℝ}
+    (hε : 0 < ε) (hc : |c| + ε / 2 ≤ 2)
+    (hp1 : ε * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤ 1)
+    (hcover : ∀ w : EuclideanSpace ℝ (Fin M),
+      (∃ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∈ Set.Ioc (c - ε / 2) (c + ε / 2)) →
+        ∃ i : Fin N, mimoObj A w s (flipAt i) < mimoObj A w s 0) :
+    (stdGaussian (EuclideanSpace ℝ (Fin M))
+      {w : EuclideanSpace ℝ (Fin M) |
+        ∀ i : Fin N, ¬(mimoObj A w s (flipAt i) < mimoObj A w s 0)}).toReal
+      ≤ Real.exp (-((M : ℝ) * (ε * Real.exp (-2) / Real.sqrt (2 * Real.pi)))) := by
+  have hsub : {w : EuclideanSpace ℝ (Fin M) |
+      ∀ i : Fin N, ¬(mimoObj A w s (flipAt i) < mimoObj A w s 0)} ⊆
+      {w : EuclideanSpace ℝ (Fin M) |
+        ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)} := by
+    intro w hw j hj
+    exact ((hcover w ⟨j, hj⟩).elim hw).elim
+  have hmeas : MeasurableSet
+      {w : EuclideanSpace ℝ (Fin M) |
+        ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)} := by
+    have hEq : {w : EuclideanSpace ℝ (Fin M) |
+        ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)} =
+        ⋂ j : Fin M,
+            {w : EuclideanSpace ℝ (Fin M) |
+              (WithLp.ofLp w : Fin M → ℝ) j ∈ (Set.Ioc (c - ε / 2) (c + ε / 2))ᶜ} := by
+      ext w
+      simp only [Set.mem_setOf_eq, Set.mem_iInter, Set.mem_compl_iff]
+    rw [hEq]
+    refine MeasurableSet.iInter fun j => ?_
+    exact measurableSet_Ioc.compl.preimage
+      (by fun_prop : Measurable (fun w : EuclideanSpace ℝ (Fin M) =>
+        (WithLp.ofLp w : Fin M → ℝ) j))
+  have hpre : (WithLp.toLp 2 : (Fin M → ℝ) → EuclideanSpace ℝ (Fin M)) ⁻¹'
+      {w : EuclideanSpace ℝ (Fin M) |
+        ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)}
+      = {v : Fin M → ℝ | ∀ j : Fin M, v j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)} := by
+    ext v
+    simp only [Set.mem_preimage, Set.mem_setOf_eq]
+  have hmass : (stdGaussian (EuclideanSpace ℝ (Fin M))
+        {w : EuclideanSpace ℝ (Fin M) |
+          ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)})
+      = (stdGaussianPi M
+          {v : Fin M → ℝ | ∀ j : Fin M, v j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)}) := by
+    rw [← stdGaussianPi_map_toLp,
+      Measure.map_apply (by fun_prop :
+        Measurable (WithLp.toLp 2 : (Fin M → ℝ) → EuclideanSpace ℝ (Fin M))) hmeas,
+      hpre]
+  have hesc := gaussian_coordinate_escape_bound (n := M) (c := c) (ε := ε)
+    hM hε hc hp1
+  calc (stdGaussian (EuclideanSpace ℝ (Fin M))
+        {w : EuclideanSpace ℝ (Fin M) |
+          ∀ i : Fin N, ¬(mimoObj A w s (flipAt i) < mimoObj A w s 0)}).toReal
+      ≤ (stdGaussian (EuclideanSpace ℝ (Fin M))
+          {w : EuclideanSpace ℝ (Fin M) |
+            ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j
+              ∉ Set.Ioc (c - ε / 2) (c + ε / 2)}).toReal :=
+        (ENNReal.toReal_le_toReal (measure_ne_top _ _) (measure_ne_top _ _)).mpr
+          (measure_mono hsub)
+    _ = (stdGaussianPi M
+          {v : Fin M → ℝ | ∀ j : Fin M, v j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)}).toReal :=
+        by rw [hmass]
+    _ ≤ Real.exp (-((M : ℝ) * (ε * Real.exp (-2) / Real.sqrt (2 * Real.pi)))) := hesc
+
 end Converse
 
 end Mimo

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Bridge_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/Bridge_en.lean
@@ -338,6 +338,88 @@ theorem flip_bat_prob_lower (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ 
         exact (ENNReal.toReal_le_toReal (measure_ne_top _ _)
           (measure_ne_top _ _)).mpr hmassmono
 
+/-! ## Grain 4 (#11152, step 3) — global failure: coordinate escape bounds ML success
+
+Brick 2 (`gaussian_coordinate_escape_bound`, Phase 3b) bounds the probability
+that ALL noise coordinates escape a common interval, by independence of the
+product. This grain carries out step 3 of #11152: under a diagonal coverage
+hypothesis ("if a noise coordinate lands in the interval, a flip beats
+`x*`"), the event "no flip beats `x*`" is included in the product escape,
+hence has probability `≤ e^{−M·p}`. This is the bridge from per-coordinate
+escape (Brick 2) to global failure: a strict descent away from `x*` must
+accept a first flip, which beats — the `log log N` term will be born in the
+assembly (grain 5) from counting the codeword lattice. -/
+
+/-- **Global failure (step 3).** Diagonal coverage hypothesis: if a noise
+coordinate of `w` lands in `I(c, ε) = (c−ε/2, c+ε/2] ⊆ [−2, 2]`, then a flip
+beats `x*`. Then the probability that no flip beats `x*` is
+`≤ exp(−M·ε·φ(2))` with `φ(2) = exp(−2)/√(2π)`. Chain: contrapositive of
+the coverage ("no flip beats" ⊆ "all coordinates escape"), transport
+`stdGaussian = (stdGaussianPi M).map (WithLp.toLp 2)`
+(`stdGaussianPi_map_toLp`), then Brick 2. -/
+theorem no_flip_beats_prob_le {N M : ℕ} (hM : 0 < M)
+    (A : (Fin N → ℝ) →ₗ[ℝ] EuclideanSpace ℝ (Fin M)) {s c ε : ℝ}
+    (hε : 0 < ε) (hc : |c| + ε / 2 ≤ 2)
+    (hp1 : ε * Real.exp (-2) / Real.sqrt (2 * Real.pi) ≤ 1)
+    (hcover : ∀ w : EuclideanSpace ℝ (Fin M),
+      (∃ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∈ Set.Ioc (c - ε / 2) (c + ε / 2)) →
+        ∃ i : Fin N, mimoObj A w s (flipAt i) < mimoObj A w s 0) :
+    (stdGaussian (EuclideanSpace ℝ (Fin M))
+      {w : EuclideanSpace ℝ (Fin M) |
+        ∀ i : Fin N, ¬(mimoObj A w s (flipAt i) < mimoObj A w s 0)}).toReal
+      ≤ Real.exp (-((M : ℝ) * (ε * Real.exp (-2) / Real.sqrt (2 * Real.pi)))) := by
+  have hsub : {w : EuclideanSpace ℝ (Fin M) |
+      ∀ i : Fin N, ¬(mimoObj A w s (flipAt i) < mimoObj A w s 0)} ⊆
+      {w : EuclideanSpace ℝ (Fin M) |
+        ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)} := by
+    intro w hw j hj
+    exact ((hcover w ⟨j, hj⟩).elim hw).elim
+  have hmeas : MeasurableSet
+      {w : EuclideanSpace ℝ (Fin M) |
+        ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)} := by
+    have hEq : {w : EuclideanSpace ℝ (Fin M) |
+        ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)} =
+        ⋂ j : Fin M,
+            {w : EuclideanSpace ℝ (Fin M) |
+              (WithLp.ofLp w : Fin M → ℝ) j ∈ (Set.Ioc (c - ε / 2) (c + ε / 2))ᶜ} := by
+      ext w
+      simp only [Set.mem_setOf_eq, Set.mem_iInter, Set.mem_compl_iff]
+    rw [hEq]
+    refine MeasurableSet.iInter fun j => ?_
+    exact measurableSet_Ioc.compl.preimage
+      (by fun_prop : Measurable (fun w : EuclideanSpace ℝ (Fin M) =>
+        (WithLp.ofLp w : Fin M → ℝ) j))
+  have hpre : (WithLp.toLp 2 : (Fin M → ℝ) → EuclideanSpace ℝ (Fin M)) ⁻¹'
+      {w : EuclideanSpace ℝ (Fin M) |
+        ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)}
+      = {v : Fin M → ℝ | ∀ j : Fin M, v j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)} := by
+    ext v
+    simp only [Set.mem_preimage, Set.mem_setOf_eq]
+  have hmass : (stdGaussian (EuclideanSpace ℝ (Fin M))
+        {w : EuclideanSpace ℝ (Fin M) |
+          ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)})
+      = (stdGaussianPi M
+          {v : Fin M → ℝ | ∀ j : Fin M, v j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)}) := by
+    rw [← stdGaussianPi_map_toLp,
+      Measure.map_apply (by fun_prop :
+        Measurable (WithLp.toLp 2 : (Fin M → ℝ) → EuclideanSpace ℝ (Fin M))) hmeas,
+      hpre]
+  have hesc := gaussian_coordinate_escape_bound (n := M) (c := c) (ε := ε)
+    hM hε hc hp1
+  calc (stdGaussian (EuclideanSpace ℝ (Fin M))
+        {w : EuclideanSpace ℝ (Fin M) |
+          ∀ i : Fin N, ¬(mimoObj A w s (flipAt i) < mimoObj A w s 0)}).toReal
+      ≤ (stdGaussian (EuclideanSpace ℝ (Fin M))
+          {w : EuclideanSpace ℝ (Fin M) |
+            ∀ j : Fin M, (WithLp.ofLp w : Fin M → ℝ) j
+              ∉ Set.Ioc (c - ε / 2) (c + ε / 2)}).toReal :=
+        (ENNReal.toReal_le_toReal (measure_ne_top _ _) (measure_ne_top _ _)).mpr
+          (measure_mono hsub)
+    _ = (stdGaussianPi M
+          {v : Fin M → ℝ | ∀ j : Fin M, v j ∉ Set.Ioc (c - ε / 2) (c + ε / 2)}).toReal :=
+        by rw [hmass]
+    _ ≤ Real.exp (-((M : ℝ) * (ε * Real.exp (-2) / Real.sqrt (2 * Real.pi)))) := hesc
+
 end Converse
 
 end Mimo_en


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2025:CoursIA-2 — prev: MED/tooling #11606

## Summary

Grain 4 de l'issue #11152 (converse du Thm 2.1 MIMO de Papailiopoulos, étape 3 — échec global). Ajoute le théorème `no_flip_beats_prob_le` dans la section Converse de `Bridge.lean` + miroir i18n `Bridge_en.lean` (namespace `Mimo_en`, docstring EN, preuve byte-identique).

**Énoncé.** Sous une hypothèse de couverture diagonale — si une coordonnée du bruit `w` tombe dans `I(c, ε) = (c−ε/2, c+ε/2] ⊆ [−2, 2]`, alors un flip bat `x*` (`∃ i, mimoObj A w s (flipAt i) < mimoObj A w s 0`) — la probabilité qu'aucun flip ne batte `x*` est `≤ exp(−M·ε·φ(2))` avec `φ(2) = exp(−2)/√(2π)`.

**Preuve (3 temps).**
1. Contraposée de la couverture : « aucun flip ne bat `x*` » ⊆ « toutes les coordonnées échappent à `I(c, ε)` ».
2. Transport : `stdGaussian = (stdGaussianPi M).map (WithLp.toLp 2)` (`stdGaussianPi_map_toLp` + `Measure.map_apply`), préimage = échappement produit, mesurabilité par `MeasurableSet.iInter` + `measurableSet_Ioc`.
3. Brique 2 (`gaussian_coordinate_escape_bound`, déjà en place Converse.lean:368) conclut par indépendance du produit.

Le terme `log log N` naîtra à l'assemblage (grain 5) du comptage du réseau de codewords.

## Validation

### §B.3 Lean (4 éléments)

1. **Compte de `sorry` réel** (instrument `count_code_sorry.py`, jamais `grep -c` qui sur-compte la prose) :
   ```
   mimo_lean : files 13, naive_sorry 4 (prose), code_sorry 0, distinct_code_sorry 0
   ```
   **0 sorry réel** — avant (baseline main) = 0, après = 0. Aucune régression.
2. **Lake build SUCCESS** — `lake build Mimo` FR + `lake build Mimo_en` : **8702 jobs, SUCCESS** sur le lake réchauffé (toolchain v4.32.1, manifest mathlib 520045ab + slt d0f506f, cache Mathlib pré-réchauffé via `lake exe cache get`).
3. **Axiomes** — `#print axioms Mimo.no_flip_beats_prob_le` = `[propext, Classical.choice, Quot.sound]` (idem `Mimo_en`). Aucun `sorryAx`, aucun `native_decide`.
4. **Preuve byte-identique i18n** — `check_i18n_siblings.py` : `OK 1/1 pairs byte-identical | 0 drift | 0 orphan`.

### C.3 Scope re-exec
Aucun notebook modifié — PR Lean pure (2 fichiers `.lean`). Catalogue byte-identique à `main`.

### Diff
`+165 lignes / −0` sur 2 fichiers, aucun code existant supprimé ni stubé. Aucun lien avec `_en` rompu (checker OK).

## Voir

- `See #11152` — contribution partielle (étape 3) : grains 2/3 déjà mergés (#11313/#11342), grain 5 (assemblage `2 log N − log log N − s_N` + `#print axioms`) et grain 6 (notebook Lean-22) restent.
- Claim posé : commentaire `[CLAIMED]` sur #11152 (`paths: MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/**`).
