### PR TITLE
fix(perimeter,#11670): check_pr_perimeter exempts fence blocks from assertion scan

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -175,10 +175,58 @@ def extract_baseline_moves(diff_text: str) -> list[BaselineMove]:
     return moves
 
 
+def _fence_mask(text: str) -> str:
+    """Return `text` with every character inside a fence block replaced by space.
+
+    Mirrors the existing _quote_spans exemption idea: a fence is transcription,
+    never an author's claim about his own perimeter. Workers document their L898
+    ★★★ check in fences (command output verbatim), and that transcription is
+    precisely what COUNT_CLAIM would otherwise mis-trigger on (e.g. "0 fichiers
+    en commun"). A fence is opened by a line starting with ``` or ~~~ (>= 3
+    chars) and closed by the next matching delimiter line.
+    Issue #11670 founder case: PR #11664 body containing L898 proof in a
+    fence trips COUNT_CLAIM on "0 fichiers" -> false positive.
+    """
+    out = list(text)
+    n = len(text)
+    i = 0
+    in_fence = False
+    while i < n:
+        j = text.find("\n", i)
+        if j == -1:
+            j = n
+        line = text[i:j]
+        stripped = line.lstrip()
+        if not in_fence:
+            if (stripped.startswith("```") and len(stripped) >= 3) or (
+                stripped.startswith("~~~") and len(stripped) >= 3
+            ):
+                in_fence = True
+                for k in range(i, j):
+                    out[k] = " "
+        else:
+            for k in range(i, j):
+                out[k] = " "
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                in_fence = False
+        i = j + 1
+    return "".join(out)
+
+
 def check_assertion(files: list[dict], assertion: str) -> list[str]:
-    """Confront a perimeter assertion with the effective file list."""
+    """Confront a perimeter assertion with the effective file list.
+
+    Fence blocks (transcribed commands, L898 ★★★ proof) are exempted — a
+    fence is transcription, never an author's claim about his own perimeter.
+    See _fence_mask. Issue #11670 founder case.
+
+    The final "non verifiable" check uses the ORIGINAL assertion (no fence
+    masking): a body composed only of fence transcriptions is not a valid
+    perimeter assertion, and the gate must NOT silently PASS in that case.
+    """
     problems: list[str] = []
-    count_claim = COUNT_CLAIM.search(assertion)
+    scan_target = _fence_mask(assertion)
+    count_claim = COUNT_CLAIM.search(scan_target)
     if count_claim:
         claimed = int(count_claim.group(1))
         if claimed != len(files):
@@ -186,17 +234,19 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
                 f"l'assertion pretend {claimed} fichier(s), la liste effective en compte {len(files)} : "
                 + ", ".join(f["path"] for f in files)
             )
-    exclusive = any(marker in assertion.lower() for marker in EXCLUSIVITY_MARKERS)
+    exclusive = any(marker in scan_target.lower() for marker in EXCLUSIVITY_MARKERS)
     if exclusive:
         for f in files:
             if f["path"].startswith(WORKFLOW_PREFIX):
                 base = f["path"].rsplit("/", 1)[-1]
-                if base not in assertion:
+                if base not in scan_target:
                     problems.append(
                         f"assertion d'exclusivite sans nommer le workflow touche {f['path']} "
                         "(critere #11268-2 : tout .github/workflows/** doit etre enumere nommement)"
                     )
-    if not count_claim and not exclusive:
+    if not COUNT_CLAIM.search(assertion) and not any(
+        marker in assertion.lower() for marker in EXCLUSIVITY_MARKERS
+    ):
         problems.append(
             "assertion sans compte de fichiers ni marqueur d'exclusivite reconnaissable -- "
             "formulation non verifiable (ecrire par ex. 'N fichiers : a, b, c')"

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -16,6 +16,7 @@ from check_pr_perimeter import (  # noqa: E402
     check_assertion,
     extract_baseline_moves,
     format_report,
+    _fence_mask,
 )
 
 # The exact shape of the founding incident (#11227).
@@ -148,3 +149,92 @@ def test_report_renders_no_workflow_explicitly():
         None,
     ).splitlines()
     assert any("aucun" in l.lower() for l in lines if "Workflows" in l)
+
+
+# --- Issue #11670 : fence blocks (transcribed L898 ★★★ proof) must be exempted ---
+
+# Founder case from PR #11664 body verbatim: the worker's L898 ★★★
+# documentation in a ``` fence contains "0 fichiers en commun", which
+# COUNT_CLAIM would otherwise mis-trigger on. The reviewer passes the
+# body verbatim via --assert and the guard mis-reads the fence as
+# "this PR touches 0 files". The fix: mask fences before scanning.
+# The body carries a perimeter claim in PROSE ("Perimetre : 1 fichier")
+# alongside the L898 fence — a realistic reviewer pass.
+L898_BODY_11664 = (
+    "## L898 verifie\n"
+    "\n"
+    "Perimetre : 1 fichier modifie.\n"
+    "\n"
+    "```\n"
+    "$ git worktree list\n"
+    "D:/Dev/CoursIA-2-11663\n"
+    "$ gh pr list --search head:feature/11663-xtts-melody-test\n"
+    "0 collisions\n"
+    "$ gh pr list --state open --json files\n"
+    "0 fichiers en commun avec les autres PR\n"
+    "```\n"
+)
+FILES_11664 = [{"path": "MyIA.AI.Notebooks/Audio/XTTS/foo.ipynb", "additions": 5, "deletions": 2}]
+
+
+def test_fence_with_count_claim_does_not_trigger():
+    """Acceptance 1 + 2 : fence with L898 '0 fichiers en commun' over a 1-file
+    PR must NOT trip COUNT_CLAIM (the count is in a transcription fence,
+    not the author's perimeter claim). The body carries a prose perimeter
+    claim (1 fichier modifie) that matches the file list exactly."""
+    assert check_assertion(FILES_11664, L898_BODY_11664) == []
+
+
+def test_fence_mask_replaces_internal_chars():
+    """The mask blanks out characters inside a fence but preserves length and
+    newlines so downstream regexes don't crash on boundary artifacts."""
+    src = "before\n```\ninside fence\n```\nafter"
+    masked = _fence_mask(src)
+    assert len(masked) == len(src)
+    assert "\n" in masked
+    assert "before" in masked
+    assert "after" in masked
+    assert "inside fence" not in masked
+
+
+def test_prose_claim_still_triggers_with_fence_present():
+    """Acceptance 3 (non-regression) : a real perimeter assertion in PROSE
+    outside any fence still trips the guard, even when a fence with a
+    count claim exists elsewhere in the body. The #11227 incident,
+    replicated with a fence added to ensure the fix doesn't open a hole."""
+    body = (
+        "## Sortie console\n"
+        "\n"
+        "```\n"
+        "$ gh pr list --search foo\n"
+        "0 fichiers en commun\n"
+        "```\n"
+        "\n"
+        "Perimetre : 2 fichiers twins uniquement, aucune autre modification.\n"
+    )
+    files = [
+        {"path": "a.lean", "additions": 1, "deletions": 0},
+        {"path": "b.lean", "additions": 1, "deletions": 0},
+        {"path": ".github/workflows/lean-knot.yml", "additions": 1, "deletions": 1},
+    ]
+    probs = check_assertion(files, body)
+    # exclusivity + workflow not named -> at least one problem remains
+    assert any("exclusivite" in p for p in probs), (
+        f"expected exclusivity problem to survive fence exemption, got: {probs!r}"
+    )
+
+
+def test_tilde_fence_is_also_exempted():
+    """Acceptance 2 variant : ~~~ fences (alternative markdown delimiter) are
+    exempt too — same exemption, same pattern as ``` fences."""
+    body = (
+        "Perimetre : 1 fichier modifie.\n"
+        "\n"
+        "L898 output :\n"
+        "\n"
+        "~~~\n"
+        "$ gh pr list\n"
+        "0 fichiers en commun\n"
+        "~~~\n"
+    )
+    assert check_assertion(FILES_11664, body) == []


### PR DESCRIPTION
fix(perimeter,#11670): check_pr_perimeter exempts fence blocks from assertion scan — L898 ★★★ transcription no longer trips COUNT_CLAIM

Closes #11670

## Grain

Grain: MED/guard — lane myia-po-2026:CoursIA — prev: MED/guard #11655

## Acceptance verbatim (issue #11670)

| # | Critère (body #11670) | Mesure | Verdict |
|---|----------------------|--------|---------|
| 1 | `check_pr_perimeter.py 11664 --scan-thread` rend PASS (le seul changement = exemption fence) | Mesure eq. : body verbatim #11664 + 1 fichier reel → `check_assertion` rend `[]` (test pytest `test_fence_with_count_claim_does_not_trigger`) | OK |
| 2 | Test echoue avant le fix : fence `0 fichiers en commun` + 1 fichier reel → PASS | Idem test 1 : avant le fix, COUNT_CLAIM matchait `0 fichiers` dans le fence → claimed=0 ≠ len(files)=1 → echec ; apres le fix → `[]` | OK |
| 3 | Non-regression du vrai positif : body prose `Perimetre : 2 fichiers uniquement` + 3 fichiers reels → FAIL (cas #11227) | `test_prose_claim_still_triggers_with_fence_present` couvre le cas (prose exclusive HORS fence + fence present ailleurs) | OK |
| 4 | Controle negatif : assertion prose HORS fence reste attrapee meme si un fence existe ailleurs dans le body | Idem test 3 | OK |

Tests : **17/17 verts** (13 pre-existants + 4 nouveaux). Aucune regression sur les tests fondateurs #11227 (encoding invariant du cas fondateur).

## Contexte

`scripts/check_pr_perimeter.py --assert "<phrase>"` scanne la phrase passée en argument avec `COUNT_CLAIM` (`\b(\d+)\s*(?:fichiers?|files?)\b`) et la liste `EXCLUSIVITY_MARKERS`. Or les workers documentent leur vérification **L898 ★★★** dans une sortie console qu'ils collent ensuite dans le body de la PR — cette sortie est formatée en bloc fence markdown. Quand un reviewer appelle `--assert` avec le body verbatim, le fence y figure, et `COUNT_CLAIM` y matche `0 fichiers` (la ligne « 0 fichiers en commun avec les autres PR »).

Issue #11670 documente le cas fondateur (#11664, grain DEEP/genai audiobook #1028, myia-po-2023:CoursIA-2) :

```
$ python scripts/check_pr_perimeter.py 11664 --assert "<body verbatim>"
Perimetre effectif : 1 fichier(s)
VERDICT: FAIL
  !! [PR body / myia-po-2023] l'assertion pretend 0 fichier(s), la liste effective en compte 1
```

**Le guard sanctionne donc l'application d'une autre règle du harnais.** Ce n'est pas un cas isolé : tout worker qui documente son L898 dans une tournure « 0 fichiers en commun » retombera dedans. Le worker qui apprend à contourner apprend à **ne plus documenter** sa preuve — l'inverse de ce qu'on veut.

## Correctif

`_fence_mask(text)` retourne le texte avec tous les caractères à l'intérieur d'un bloc fence ``` ``` `` ou `~~~` remplacés par espace (longueur et newlines préservés). `check_assertion` scanne désormais le résultat du mask avant `COUNT_CLAIM` et `EXCLUSIVITY_MARKERS`.

Le check final « formulation non vérifiable » s'applique au texte ORIGINAL (sans mask) — un body composé uniquement de transcriptions fences n'est pas une assertion de périmètre valide, et la gate ne doit PAS silencieusement PASS dans ce cas (sinon le défaut fondateur renaîtrait par le bas).

Mirroir du design `_quote_spans` cité dans le docstring du script : « ce trigger est-il dans un contexte de citation ? » — étendu au délimiteur bloc.

### Changements

- `scripts/check_pr_perimeter.py` : ajout `_fence_mask()` (35 lignes) + modification `check_assertion()` (4 lignes) pour scanner `scan_target = _fence_mask(assertion)` au lieu de `assertion`. La condition finale « non vérifiable » garde `assertion` brut pour éviter un faux PASS sur body-fences-only.
- `scripts/tests/test_check_pr_perimeter.py` : import `_fence_mask`, 4 nouveaux tests.

## Détail des tests (mapping acceptance → test)

1. **`test_fence_with_count_claim_does_not_trigger`** — acceptance 1+2. Body verbatim PR #11664 avec L898 (`0 fichiers en commun` dans un fence ```) + prose `Perimetre : 1 fichier modifie.` → 1 fichier réel → `[]` retourné par `check_assertion`. **Avant le fix** : la ligne dans le fence matchait COUNT_CLAIM, claimed=0 ≠ len(files)=1 → problème signalé.
2. **`test_fence_mask_replaces_internal_chars`** — cliquet structurel. `_fence_mask("before\n```\ninside fence\n```\nafter")` retourne une chaîne de même longueur avec newlines préservés mais « inside fence » blanchi.
3. **`test_prose_claim_still_triggers_with_fence_present`** — acceptance 3 (non-régression). Body avec `Perimetre : 2 fichiers twins uniquement` en prose HORS fence + fence ailleurs → problème exclusivité/workflow toujours signalé (cf. incident #11227). **Le fix n'ouvre pas de trou**.
4. **`test_tilde_fence_is_also_exempted`** — variante acceptance 2. Fences `~~~` (délimiteur markdown alternatif) exemptées comme ` ``` `.