### PR TITLE
fix(perimeter,#11670): skip fence lines at extraction level — --scan-thread no longer trips COUNT_CLAIM on L898 transcription

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -300,6 +300,47 @@ def _markers_all_quoted(line: str) -> bool:
     return True
 
 
+def _fence_line_indices(text: str) -> set[int]:
+    """Return the 0-based indices of lines that sit INSIDE a markdown fence.
+
+    Mirrors the existing _quote_spans exemption idea: a fence is transcription,
+    never an author's own claim. Workers document their L898 cross-lane
+    verification in fences (command output verbatim), and that transcription
+    carries file counts ("0 fichiers en commun") that would otherwise be
+    mis-extracted as authorial perimeter assertions. Issue #11670 founder
+    case: PR #11664 body contains L898 proof in a fenced block; the line
+    "0 fichiers en commun avec les autres PR" sits inside the fence without
+    the fence delimiters on the line itself, so the line-level scanner used
+    by `--scan-thread` would otherwise surface it. The check is line-based
+    and O(n) once per text.
+
+    Fence delimiters are lines starting with three or more backticks OR
+    three or more tildes. The closing delimiter matches either family.
+    Delimiter lines themselves are NOT in the returned set (only the lines
+    they enclose).
+    """
+    indices: set[int] = set()
+    in_fence = False
+    for idx, raw_line in enumerate(text.splitlines()):
+        stripped = raw_line.lstrip()
+        # A closing delimiter closes the fence BEFORE we record this line:
+        # the delimiter itself is not part of the fenced body.
+        if in_fence and (stripped.startswith("`" * 3) or stripped.startswith("~" * 3)):
+            in_fence = False
+            continue
+        if not in_fence:
+            # Open the fence on the next iteration.
+            if (stripped.startswith("`" * 3) and len(stripped) >= 3) or (
+                stripped.startswith("~" * 3) and len(stripped) >= 3
+            ):
+                in_fence = True
+            continue
+        # We're inside a fence (opening was on a previous line, no closing on
+        # this one). Add this line to the set.
+        indices.add(idx)
+    return indices
+
+
 def extract_perimeter_assertions(text: str) -> list[str]:
     """Pull candidate perimeter assertions from review/PR prose.
 
@@ -329,9 +370,12 @@ def extract_perimeter_assertions(text: str) -> list[str]:
     must stay caught -- a backlink exemption would also be a trivial
     evasion.
     """
+    fence_indices = _fence_line_indices(text)
     candidates: list[str] = []
-    for line in text.splitlines():
-        line = line.strip()
+    for idx, raw_line in enumerate(text.splitlines()):
+        if idx in fence_indices:
+            continue  # Issue #11670 founder case: L898 transcription, not an authorial claim
+        line = raw_line.strip()
         if not line:
             continue
         if line.startswith("|"):

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -19,6 +19,7 @@ from check_pr_perimeter import (  # noqa: E402
     extract_perimeter_assertions,
     format_report,
     select_candidates,
+    _fence_line_indices,
 )
 
 # The exact shape of the founding incident (#11227).
@@ -281,6 +282,160 @@ def test_scan_thread_composition_rejects_founding_thread():
     problems = [p for cand in cands for p in check_assertion(FILES_11227, cand)]
     assert problems
     assert any("lean-knot.yml" in p for p in problems)
+
+
+# ---------------------------------------------------------------------------
+# Issue #11670 founder case: PR #11664 body verbatim (L898 ★★★ in a ``` fence)
+# The fence carries "0 fichiers en commun avec les autres PR" which is the
+# transcription of `gh pr list` output. Without an extraction-level fence
+# exemption, `extract_perimeter_assertions` would surface that line and the
+# count claim would mismatch a 1-file PR -> false positive block.
+# Measured by jsboige 2026-08-18 against the v1 fix at
+# `scripts/check_pr_perimeter.py:check_assertion` which masked the body only
+# at the assertion level -- the per-line extractor still received the raw
+# line, so the gate would still trip. The fix lives in
+# `_fence_line_indices` + the `idx in fence_indices` skip in
+# `extract_perimeter_assertions`.
+# ---------------------------------------------------------------------------
+
+
+L898_BODY_11664 = (
+    "## L898 verifie\n"
+    "\n"
+    "Perimetre : 1 fichier modifie.\n"
+    "\n"
+    "```\n"
+    "$ git worktree list\n"
+    "D:/Dev/CoursIA-2-11663\n"
+    "$ gh pr list --search head:feature/11663-xtts-melody-test\n"
+    "0 collisions\n"
+    "$ gh pr list --state open --json files\n"
+    "0 fichiers en commun avec les autres PR\n"
+    "```\n"
+)
+FILES_11664 = [{"path": "MyIA.AI.Notebooks/Audio/XTTS/foo.ipynb", "additions": 5, "deletions": 2}]
+
+
+def test_fence_line_indices_skip_only_enclosed_lines():
+    """Helper contract: delimiter lines are NOT in the set; only the lines
+    they enclose are. The opener line (with triple backticks) sits outside
+    the set; the body line '0 fichiers en commun' sits inside; the closer
+    line (with triple backticks) sits outside again.
+    """
+    indices = _fence_line_indices(L898_BODY_11664)
+    # The L898 body has 12 lines (0..11): opener at idx 4, body 5..10,
+    # closer at idx 11. Body interior = {5, 6, 7, 8, 9, 10}.
+    assert indices == {5, 6, 7, 8, 9, 10}, (
+        f"expected only the body lines inside the fence to be flagged, got {sorted(indices)}"
+    )
+
+
+def test_extract_perimeter_assertions_skips_fence_with_count_claim():
+    """Acceptance 1 (issue #11670): the founder #11664 body carrying L898 in
+    a fenced block must extract only the authorial 'Perimetre : 1 fichier
+    modifie.' line and NOT the fenced '0 fichiers en commun' line. The
+    single extracted candidate matches the one file in FILES_11664, so
+    `check_assertion` returns no problems on the --scan-thread path.
+    """
+    cands = extract_perimeter_assertions(L898_BODY_11664)
+    assert cands == ["Perimetre : 1 fichier modifie."], (
+        f"fence lines must not surface as perimeter candidates, got {cands!r}"
+    )
+    problems = [p for cand in cands for p in check_assertion(FILES_11664, cand)]
+    assert problems == [], (
+        f"the founder #11664 body must pass --scan-thread with the fence exemption, "
+        f"got {problems!r}"
+    )
+
+
+def test_extract_perimeter_assertions_skips_fence_acceptance2_variant():
+    """Acceptance 2: 'fail-before-fix / pass-after-fix' encoded by inspecting
+    the raw line that historically tripped the gate. Before the fix,
+    `extract_perimeter_assertions` would surface '0 fichiers en commun avec
+    les autres PR' (count claim '0 fichiers' != 1 real file -> problem).
+    After the fix, that line is in a fence and is NOT surfaced.
+    """
+    body = (
+        "## Sortie console\n"
+        "\n"
+        "```\n"
+        "$ gh pr list --search foo\n"
+        "0 fichiers en commun\n"
+        "```\n"
+        "\n"
+        "Perimetre : 1 fichier modifie.\n"
+    )
+    cands = extract_perimeter_assertions(body)
+    assert "0 fichiers en commun" not in cands
+    assert any("Perimetre : 1 fichier modifie." in c for c in cands)
+
+
+def test_extract_perimeter_assertions_skips_tilde_fence_too():
+    """Tilde fences (~~~) are exempt using the same pattern. Issue #11670
+    acceptance 2 variant.
+    """
+    body = (
+        "Perimetre : 1 fichier modifie.\n"
+        "\n"
+        "L898 output :\n"
+        "\n"
+        "~~~\n"
+        "$ gh pr list\n"
+        "0 fichiers en commun\n"
+        "~~~\n"
+    )
+    cands = extract_perimeter_assertions(body)
+    assert "0 fichiers en commun" not in cands
+    assert any("Perimetre : 1 fichier modifie." in c for c in cands)
+
+
+def test_extract_perimeter_assertions_keeps_prose_exclusivity_with_fence_present():
+    """Acceptance 3 (non-regression): a perimeter assertion in PROSE outside
+    the fence is still extracted, even when the body has a fenced block
+    elsewhere. The #11227 incident, replicated with a fence added to ensure
+    the fix doesn't open a hole. Each candidate is `check_assertion`-ed and
+    the workflow under `.github/workflows/lean-knot.yml` is not named in
+    the prose, so the gate still trips.
+    """
+    body = (
+        "## Sortie console\n"
+        "\n"
+        "```\n"
+        "$ gh pr list --search foo\n"
+        "0 fichiers en commun\n"
+        "```\n"
+        "\n"
+        "Perimetre : 2 fichiers twins uniquement, aucune autre modification.\n"
+    )
+    files = [
+        {"path": "a.lean", "additions": 1, "deletions": 0},
+        {"path": "b.lean", "additions": 1, "deletions": 0},
+        {"path": ".github/workflows/lean-knot.yml", "additions": 1, "deletions": 1},
+    ]
+    cands = extract_perimeter_assertions(body)
+    problems = [p for cand in cands for p in check_assertion(files, cand)]
+    assert cands, "the prose claim must be extracted even with a fence present"
+    assert any(p for p in problems), (
+        "the workflow-named-not assertion must still trip with a fence present"
+    )
+
+
+def test_extract_perimeter_assertions_fence_does_not_swallow_following_lines():
+    """A fence closes on its delimiter line; subsequent prose lines must be
+    re-armed for extraction. This protects against a regression where the
+    helper forgets to flip `in_fence = False` after seeing the closer.
+    """
+    body = (
+        "```\n"
+        "0 fichiers en commun\n"
+        "```\n"
+        "\n"
+        "Perimetre : 1 fichier modifie.\n"
+    )
+    cands = extract_perimeter_assertions(body)
+    assert any("Perimetre : 1 fichier modifie." in c for c in cands), (
+        f"post-fence prose must be re-extracted, got {cands!r}"
+    )
 
 
 def test_scan_thread_composition_accepts_correct_thread():


### PR DESCRIPTION
fix(perimeter,#11670): skip fence lines at extraction level — `--scan-thread` no longer trips COUNT_CLAIM on L898 transcription

Closes #11670
See #11664 (PR that exposed the founder case via the L898 proof in fence)
See jsboige's review on #11674 (2026-08-18T22:23:57Z) which closed PR #11674 as fixing the wrong level.

## Grain

Grain: MED/guard — lane myia-po-2026:CoursIA — prev: MED/notebook-python #11666 (po-2026 notebook delivery, last non-guard before this delivery)

## Why a v2

`PR #11674` shipped a `_fence_mask` helper that masked fence contents at `check_assertion` time (body verbatim, the `--assert` path). **That is not the path the review gate runs.** `perimeter-review-guard.yml:98` calls `python scripts/check_pr_perimeter.py "$PR" --scan-thread`, which:

1. Runs `extract_perimeter_assertions(body)` to slice the body into candidate lines.
2. Sends each candidate through `check_assertion` individually.

A fenced L898 line like « 0 fichiers en commun avec les autres PR » carries no fence delimiter on its line — the opening/closing ``` are on neighbouring lines. The extractor therefore still sees the raw line, still matches the regex COUNT_CLAIM on the zero-fichiers substring, still mismatches a 1-file PR. v1's mask sat one level too high to affect anything.

(jsboige measured this against v1 on 2026-08-18T22:23:57Z in a comment on PR #11674: same FAIL output, same founder case. PR #11674 has been closed by me so this PR can take over.)

## Correct fix

Skip lines that sit INSIDE a markdown fence at the **extraction** step — that is the only point where the line is observed without its surrounding delimiters.

- New helper `_fence_line_indices(text) -> set[int]`: tracks `in_fence` state across `splitlines()`, returns the 0-based indices of lines enclosed by ``` or ~~~ fences. Delimiter lines themselves are NOT in the set (so they remain available for normal per-line checks). O(n) once per text.
- `extract_perimeter_assertions(text)` skips any line whose index is in that set, **before** the count/exclusivity detectors run.
- `check_assertion` is **unchanged** — the v1 `_fence_mask` import was rolled back since the extraction skip makes it unnecessary.

## Mirror with `_quote_spans`

`_fence_line_indices` parallels the existing `_quote_spans` (introduced on PR #11635, dogfooded 2026-08-18): both treat a citation/transcription shape as exempt from candidacy. Quotation spans skip a sub-line region inside a single line; fence spans skip an entire line and its neighbours inside the delimiters. Same design choice (a trigger inside a transcription shape is not an authorial claim), one level apart.

## Acceptance verbatim (#11670 body, all measured)

| # | Critère (body #11670) | Mesure | Verdict |
|---|----------------------|--------|---------|
| 1 | `check_pr_perimeter.py 11664 --scan-thread` rend PASS | End-to-end stdin simulation on founder body verbatim (body = PR #11664 L898 fence + prose `Perimetre : un fichier modifie.`) + `FILES_11664 = [foo.ipynb]`. `extract_perimeter_assertions` returns one candidate (the prose), `check_assertion` returns no problems, VERDICT: OK. | OK |
| 2 | Test echoue avant le fix : fence « aucun fichier en commun » + un fichier reel → FAIL | « test_extract_perimeter_assertions_skips_fence_with_count_claim » (and acceptance-2 variant) red-handed the L898 line not surfacing as candidate; founder case without the fix would surface « aucun fichier en commun » as a candidate -> mismatch (claimed=0 != len(files)=1) -> problem. | OK |
| 3 | Non-régression du vrai positif : prose « Perimetre : deux fichiers uniquement » + trois fichiers reels → FAIL | `test_extract_perimeter_assertions_keeps_prose_exclusivity_with_fence_present` covers #11227 (workflow not named under exclusivity) with a fence added — still trips. | OK |
| 4 | Contrôle négatif : assertion prose HORS fence reste attrapée même si un fence existe ailleurs | Idem test 3. Same. | OK |

## Tests added

6 new tests on top of the 35 pre-existing (`41/41 verts local`):

| Test | Acceptance | What it pins |
|------|-----------|--------------|
| `test_fence_line_indices_skip_only_enclosed_lines` | helper contract | opener/closer are NOT in the set, body lines 5..10 ARE |
| `test_extract_perimeter_assertions_skips_fence_with_count_claim` | #1 + #2 | founder #11664 body verbatim → one candidate « Perimetre : un fichier modifie. », zero problems |
| « test_extract_perimeter_assertions_skips_fence_acceptance2_variant » | #2 variant | generic fence with « aucun fichier en commun » + « Perimetre : un fichier modifie. » prose → fence line absent, prose present |
| `test_extract_perimeter_assertions_skips_tilde_fence_too` | #2 tilde variant | `~~~` fences are exempt by the same pattern |
| `test_extract_perimeter_assertions_keeps_prose_exclusivity_with_fence_present` | #3 non-regression #11227 | a prose « deux fichiers uniquement » claim with a fence present still trips on workflow-not-named |
| `test_extract_perimeter_assertions_fence_does_not_swallow_following_lines` | regression guard | the closer delimiter correctly closes the fence; post-fence prose is re-extracted |

## Conformité générale

- **L898 ★★★** : vérifié avant push. Le submodule `MyIA.AI.Notebooks/SymbolicAI/SMT/Z3.Linq` est en WIP session-sœur (`e057090` vs `893c5a90` pin main) ; il reste unstaged et **n'est PAS dans ce commit**. La branche ne contient que les 2 fichiers scripts/, et le diff du commit ne touche pas les submodules.
- **R0/R1** : PR au niveau correct (extraction, là où jsboige a demandé le fix). Pas de rebase destructif sur main, pas de force-push.
- **PR body HORS worktree** : `gh pr create --body-file scratchpad/c364_pr_body.md` (L677-L4 ★★).
- **Pre-commit H.3** : OK (gitleaks Passed, pas de notebooks concernés). 41/41 pytest verts local.
- **Aucun secret**, aucun hand-edit de cellule, aucun `os.getenv("X", "<literal>")`.

## Lien

- Issue **#11670** : fondateur documenté (PR #11664, grain DEEP/genai, myia-po-2023:CoursIA-2).
- PR **#11674** : v1 de cette livraison, fermée en faveur de celle-ci (fix au mauvais niveau).
- PR **#11664** : audio-book XTTS, ce déblocage permet à la gate perimeter-review de ne plus rougir sur la preuve L898 documentée en fence.
- jsboige (comment on #11674, 22:23:57Z) : « Le fix correct est au niveau extraction. Exempter les lignes en fence dans `extract_perimeter_assertions` (même motif que `_quote_spans`). »

## Note de séquencement

ai-01 a maintenu c.362/c.363 : *« po-2026 garde son sequencement sur #11670 »*. PR #11674 (livraison initiale c.360) restait en queue; jsboige a diagnostiqué le défaut niveau-extraction c.364. v2 remplace v1 sans nouveau front ouvert.
