### PR TITLE
feat(search,#3963): MGS-6 banc de-biaise shifted+rotated — demo CEC appairee, verdict honnete

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb
@@ -21,8 +21,7 @@
     "\n",
     "Si le design primitives-based est valable, WOA-from-primitives doit être **compétitif** avec Islands (un schéma éprouvé) sur la plupart des surfaces -- sans être une boîte noire. C'est l'argument : la composition ouverte bat ou égale la métaphore opaque.\n",
     "\n",
-    "> **Rappel C.2** : ce notebook s'exécute sur le kernel `.net-csharp` et charge les DLL de MetaGeneticSharp (Domain + Extensions) depuis le build du fork. Prérequis : `dotnet build` dans `../MetaGeneticSharp`.\n",
-    ""
+    "> **Rappel C.2** : ce notebook s'exécute sur le kernel `.net-csharp` et charge les DLL de MetaGeneticSharp (Domain + Extensions) depuis le build du fork. Prérequis : `dotnet build` dans `../MetaGeneticSharp`.\n"
    ]
   },
   {
@@ -34,13 +33,128 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:28.056087Z",
-     "iopub.status.busy": "2026-07-13T00:31:28.048080Z",
-     "iopub.status.idle": "2026-07-13T00:31:30.011656Z",
-     "shell.execute_reply": "2026-07-13T00:31:30.005461Z"
+     "iopub.execute_input": "2026-08-18T23:27:55.742362Z",
+     "iopub.status.busy": "2026-08-18T23:27:55.685939Z",
+     "iopub.status.idle": "2026-08-18T23:28:06.155397Z",
+     "shell.execute_reply": "2026-08-18T23:28:06.140390Z"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '59656.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -118,10 +232,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:30.013819Z",
-     "iopub.status.busy": "2026-07-13T00:31:30.013546Z",
-     "iopub.status.idle": "2026-07-13T00:31:30.645090Z",
-     "shell.execute_reply": "2026-07-13T00:31:30.644828Z"
+     "iopub.execute_input": "2026-08-18T23:28:06.158874Z",
+     "iopub.status.busy": "2026-08-18T23:28:06.158246Z",
+     "iopub.status.idle": "2026-08-18T23:28:08.696975Z",
+     "shell.execute_reply": "2026-08-18T23:28:08.696292Z"
     }
    },
    "outputs": [
@@ -136,14 +250,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  CreateNew #1: 0,8877740097045903, 0,4696965551376344, 3,565883827209473\r\n"
+      "  CreateNew #1: 3,847769713401795, 5,0297613525390625, 1,8859088277816776\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  CreateNew #2: -1,7948925876617432, -2,117683620452881, -3,130363693237305  (diversifie : oui)\r\n"
+      "  CreateNew #2: -3,634868063926697, -2,211926345825195, -2,2481753206253052  (diversifie : oui)\r\n"
      ]
     }
    ],
@@ -216,10 +330,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:30.646927Z",
-     "iopub.status.busy": "2026-07-13T00:31:30.646631Z",
-     "iopub.status.idle": "2026-07-13T00:31:30.823288Z",
-     "shell.execute_reply": "2026-07-13T00:31:30.822765Z"
+     "iopub.execute_input": "2026-08-18T23:28:08.699982Z",
+     "iopub.status.busy": "2026-08-18T23:28:08.699270Z",
+     "iopub.status.idle": "2026-08-18T23:28:09.105753Z",
+     "shell.execute_reply": "2026-08-18T23:28:09.105375Z"
     }
    },
    "outputs": [
@@ -306,10 +420,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:30.825075Z",
-     "iopub.status.busy": "2026-07-13T00:31:30.824791Z",
-     "iopub.status.idle": "2026-07-13T00:31:32.375667Z",
-     "shell.execute_reply": "2026-07-13T00:31:32.375390Z"
+     "iopub.execute_input": "2026-08-18T23:28:09.108246Z",
+     "iopub.status.busy": "2026-08-18T23:28:09.107740Z",
+     "iopub.status.idle": "2026-08-18T23:28:15.655096Z",
+     "shell.execute_reply": "2026-08-18T23:28:15.654681Z"
     }
    },
    "outputs": [
@@ -317,70 +431,70 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sphere          Uniform=   -0,021737  Islands=  -0,0068872  WOA= -2,7178E-09\r\n"
+      "Sphere          Uniform=  -0,0053052  Islands=   -0,017071  WOA=  -4,548E-10\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rastrigin       Uniform=     -1,0265  Islands=    -0,42923  WOA= -3,5099E-09\r\n"
+      "Rastrigin       Uniform=    -0,88736  Islands=    -0,52041  WOA=     -5,3537\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rosenbrock      Uniform=     -2,4353  Islands=     -1,9284  WOA=     -4,6236\r\n"
+      "Rosenbrock      Uniform=     -3,0479  Islands=     -1,7523  WOA=     -1,6774\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Ackley          Uniform=     -0,2873  Islands=     -1,8572  WOA= -5,6485E-05\r\n"
+      "Ackley          Uniform=     -1,2213  Islands=     -2,5538  WOA=  -0,0016045\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Griewank        Uniform=    -0,32697  Islands=    -0,72934  WOA=   -0,020455\r\n"
+      "Griewank        Uniform=    -0,62589  Islands=    -0,90131  WOA=    -0,77349\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Schwefel        Uniform=     -9,2192  Islands=      -9,231  WOA=  4,1338E+14\r\n"
+      "Schwefel        Uniform=     -7,1303  Islands=     -2,1168  WOA=  3,9938E+17\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Michalewicz     Uniform=      4,6148  Islands=      4,6645  WOA=       2,659\r\n"
+      "Michalewicz     Uniform=      4,6814  Islands=      4,5797  WOA=      3,6993\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Zakharov        Uniform=     -1,2317  Islands=    -0,54373  WOA= -0,00024936\r\n"
+      "Zakharov        Uniform=    -0,21025  Islands=     -0,9621  WOA= -7,2391E-05\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Booth (2D)      Uniform=    -0,23228  Islands=  -0,0035282  WOA= -2,0513E-07\r\n"
+      "Booth (2D)      Uniform=     -0,1227  Islands=    -0,11308  WOA=  -0,0041899\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Dixon-Price     Uniform=    -0,19767  Islands=     -3,1247  WOA=   -0,046855\r\n"
+      "Dixon-Price     Uniform=    -0,73212  Islands=    -0,78496  WOA=    -0,10092\r\n"
      ]
     },
     {
@@ -431,15 +545,229 @@
     "\n",
     "La grille ci-dessus répond directement à la critique *\"metaphor exposed\"*. Trois enseignements ressortent typiquement d'un tel banc :\n",
     "\n",
-    "1. **Aucune configuration ne domine partout.** C'est le théorème *No Free Lunch* (Wolpert & Macready, 1997) rendu tangible. Regardez Schwefel (multimodale *déceptive*, optimum loin du centre) : **WOA diverge** -- la fitness explose au lieu de converger -- tandis qu'Islands reste maîtresse. À l'inverse, sur Sphere (unimodale lisse) WOA converge à `0.00000` (`-2,72e-09`) quand Uniform s'arrête à `-0,0217` et Islands à `-0,0069`. **C'est exactement l'argument** : aucune métaphore n'est universellement meilleure, donc le choix doit être *éclairé*, pas *doctrinal*.\n",
+    "1. **Aucune configuration ne domine partout.** C'est le théorème *No Free Lunch* (Wolpert & Macready, 1997) rendu tangible. Regardez Schwefel (multimodale *déceptive*, optimum loin du centre) : **WOA diverge** -- la fitness explose au lieu de converger -- tandis qu'Islands reste maîtresse. À l'inverse, sur Sphere (unimodale lisse) WOA converge à `0.00000` (`-4,55e-10`) quand Uniform s'arrête à `-0,0053` et Islands à `-0,0171`. **C'est exactement l'argument** : aucune métaphore n'est universellement meilleure, donc le choix doit être *éclairé*, pas *doctrinal*.\n",
     "\n",
     "   > **Pourquoi WOA explose-t-elle sur Schwefel ?** Le bubble-net de WOA opère un contrôle-flux *géométrique* : il déplace les gènes continus par des pas proportionnels à la distance à la meilleure solution, sans contrainte de bornes. Sur une surface à grande amplitude (Schwefel vit dans `[-500, 500]`), un pas mal calibré projette un gène hors des bornes et l'amplifie de génération en génération. La *transparence* du composé rend ce diagnostic immédiat -- vous lisez le `IfElse` du bubble-net -- alors qu'une `mealpy.WOA()` vous laisserait devant un résultat absurde sans explication. C'est le gain d'ingénierie de l'approche primitives-based.\n",
     "\n",
-    "2. **WOA-from-primitives est compétitive là où elle est adaptée.** Sur les unimodales (Sphere, Zakharov, Booth, Dixon-Price) et les multimodales \"douces\" (Ackley, Griewank), WOA *reconstruite à partir de briques* tient ou bat la comparaison avec Islands (un schéma standard). Si WOA était une boîte noire mal fichue, elle perdrait systématiquement. Qu'elle tienne la comparaison sur 7/10 fonctions prouve que la reconstruction par composition préserve le pouvoir d'optimisation.\n",
+    "2. **WOA-from-primitives est compétitive là où elle est adaptée.** Sur les unimodales (Sphere, Zakharov, Booth, Dixon-Price) et les multimodales \"douces\" (Ackley, Griewank), WOA *reconstruite à partir de briques* tient ou bat la comparaison avec Islands (un schéma standard). Si WOA était une boîte noire mal fichue, elle perdrait systématiquement. Qu'elle tienne la comparaison sur 7/10 fonctions de cette exécution prouve que la reconstruction par composition préserve le pouvoir d'optimisation.\n",
     "\n",
     "3. **La composition est inspectable.** Là où un `mealpy.WOA()` cache tout dans une fonction, `new WhaleOptimisationAlgorithm().Build()` expose chaque primitive (`Match`, `IfElse`, `GeometricCrossover`). Vous pouvez *modifier* une branche du bubble-net -- par exemple ajouter une borne `Math.Clamp` dans le convertisseur géométrique pour empêcher la divergence Schwefel -- sans réécrire l'algorithme. C'est le gain d'ingénierie que la métaphore opaque refuse.\n",
     "\n",
-    "L'exercice 2 vous demande d'identifier, sur VOS résultats, quelle configuration gagne sur les multimodales vs les unimodales -- et de confronter cette observation au théorème No Free Lunch.\n"
+    "L'exercice 2 vous demande d'identifier, sur VOS résultats, quelle configuration gagne sur les multimodales vs les unimodales -- et de confronter cette observation au théorème No Free Lunch.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "debias-intro-md",
+   "metadata": {},
+   "source": [
+    "## Banc dé-biaisé : sortir l'optimum du centre\n",
+    "\n",
+    "La grille ci-dessus a un angle mort. Parmi les 10 fonctions, **4 ont leur optimum exactement au centre des bornes symétriques** : Sphere, Rastrigin, Ackley, Griewank (optimum en `x* = 0`, bornes `[-a, +a]`). Or le harnais seede le chromosome *adam* au **milieu des bornes** -- c'est-à-dire **sur l'optimum** de ces 4 fonctions. Les 6 autres (Rosenbrock, Schwefel, Michalewicz, Zakharov, Booth, Dixon-Price) ont déjà leur optimum hors du centre ; ces 4 premières, elles, sont structurellement flattées.\n",
+    "\n",
+    "C'est la critique de Kudela (*A critical problem in benchmarking and analysis of evolutionary computation methods*, Nature Machine Intelligence 4, 2022) : les métaheuristiques publiées marquent bien sur les bancs standard en partie parce que l'optimum y est au centre du domaine. Le protocole CEC corrige cela par **translation + rotation** : `f_debias(x) = f(Q·x - offset)`, avec `offset` tiré par dimension (seedé, reproductible) et `Q` une matrice orthogonale seedée. Le fork porte exactement ces briques dans `MetaGeneticSharp.Extensions` :\n",
+    "\n",
+    "```csharp\n",
+    "var offset = ShiftVectors.Seeded(dim, magnitude, seed);  // l'optimum quitte le centre\n",
+    "var Q      = RotationMatrices.Seeded(dim, seed);          // casse l'alignement des axes\n",
+    "var cec    = new RotatedFitness(new ShiftedFitness(inner, offset), Q);\n",
+    "```\n",
+    "\n",
+    "L'expérience est **appariée** : pour chacune des 4 fonctions à optimum-centré, les 3 configurations tournent sur la version centrée ET sur la version shiftée+rotatée, **3 runs indépendants par cellule** (le GA est stochastique -- un run unique peut faire gagner n'importe qui ; la moyenne sur 3 runs donne un verdict défendable). Deux questions :\n",
+    "\n",
+    "1. **Le classement change-t-il** quand l'adam n'est plus seedé sur l'optimum ?\n",
+    "2. La rotation est un *no-op* sur Sphere (symétrie radiale) mais casse l'alignement des vallées de Rastrigin/Ackley -- ajoute-t-elle de la difficulté là où elle a un effet ?\n",
+    "\n",
+    "L'amplitude du shift est calibrée par fonction (~30 % de la demi-étendue) pour que l'optimum déplacé reste dans les bornes : `1.5` pour Sphere/Rastrigin (`[-5.12, 5.12]`), `8.0` pour Ackley (`[-32, 32]`), `150` pour Griewank (`[-600, 600]`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "debias-run-code",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-08-18T23:28:15.657927Z",
+     "iopub.status.busy": "2026-08-18T23:28:15.657374Z",
+     "iopub.status.idle": "2026-08-18T23:28:28.842620Z",
+     "shell.execute_reply": "2026-08-18T23:28:28.841886Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shift seed=42  Q orthogonal: True  runs per cell=3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(fitness = negated objective, closer to 0 = better; mean over runs)\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sphere     |offset|_inf=   1,123  (optimum at Q^T*offset, off-center)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           centered : Uniform= -0,0045609  Islands=  -0,015989  WOA=-3,5066E-11\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           shifted  : Uniform= -0,0035374  Islands=  -0,013895  WOA= -0,0026125\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rastrigin  |offset|_inf=   1,123  (optimum at Q^T*offset, off-center)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           centered : Uniform=    -1,2076  Islands=    -1,0611  WOA=    -5,2395\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           shifted  : Uniform=    -14,918  Islands=    -9,0689  WOA=    -8,0776\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ackley     |offset|_inf=   5,992  (optimum at Q^T*offset, off-center)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           centered : Uniform=    -1,4583  Islands=    -3,3384  WOA= -0,0003237\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           shifted  : Uniform=    -4,0284  Islands=    -2,9838  WOA=    -6,8656\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Griewank   |offset|_inf=   112,3  (optimum at Q^T*offset, off-center)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           centered : Uniform=   -0,79549  Islands=   -0,83074  WOA=   -0,60929\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "           shifted  : Uniform=   -0,89535  Islands=    -0,9168  WOA=    -1,6726\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Done: 4 zero-optimum functions, centered vs shifted+rotated, 3 runs per cell ---\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// De-biased benchmark: PAIRED centered-vs-shifted comparison on the 4 functions\n",
+    "// whose optimum sits exactly at the CENTER of symmetric bounds (the harness seeds\n",
+    "// the adam chromosome ON that optimum). f_debias(x) = f_inner(Q*x - offset) moves\n",
+    "// the optimum to Q^T*offset, off-center, and breaks axis alignment.\n",
+    "// 3 independent runs per cell (stochastic GA), mean reported -- a defensible verdict.\n",
+    "int debiasSeed   = 42;\n",
+    "int debiasSeeds  = 3;\n",
+    "\n",
+    "var debias = new (string Name, Type Type, double ShiftMag)[]\n",
+    "{\n",
+    "    (\"Sphere\",    typeof(SphereFitness),    1.5),   // unimodal control (rotation-invariant)\n",
+    "    (\"Rastrigin\", typeof(RastriginFitness), 1.5),\n",
+    "    (\"Ackley\",    typeof(AckleyFitness),    8.0),\n",
+    "    (\"Griewank\",  typeof(GriewankFitness),  150.0),\n",
+    "};\n",
+    "\n",
+    "var Qdebias = RotationMatrices.Seeded(Dim, debiasSeed);\n",
+    "Console.WriteLine($\"shift seed={debiasSeed}  Q orthogonal: {RotationMatrices.IsOrthogonal(Qdebias)}  runs per cell={debiasSeeds}\");\n",
+    "Console.WriteLine(\"(fitness = negated objective, closer to 0 = better; mean over runs)\\n\");\n",
+    "\n",
+    "double MeanRuns(IFitness f, Type t, Func<IMetaHeuristic> build) =>\n",
+    "    Enumerable.Range(0, debiasSeeds).Select(_ => RunBenchmark(f, t, build())).Average();\n",
+    "\n",
+    "foreach (var (name, type, mag) in debias)\n",
+    "{\n",
+    "    var inner  = (IFitness)Activator.CreateInstance(type);\n",
+    "    var offset = ShiftVectors.Seeded(Dim, mag, debiasSeed);\n",
+    "    var cec    = new RotatedFitness(new ShiftedFitness(inner, offset), Qdebias);\n",
+    "\n",
+    "    Console.WriteLine($\"{name,-10} |offset|_inf={offset.Select(Math.Abs).Max(),8:G4}  (optimum at Q^T*offset, off-center)\");\n",
+    "    double uc = MeanRuns(inner, type, BuildUniform), ic = MeanRuns(inner, type, BuildIslands), wc = MeanRuns(inner, type, BuildWOA);\n",
+    "    double ud = MeanRuns(cec,    type, BuildUniform), id = MeanRuns(cec,    type, BuildIslands), wd = MeanRuns(cec,    type, BuildWOA);\n",
+    "    Console.WriteLine($\"{\"\",-10} centered : Uniform={uc,11:G5}  Islands={ic,11:G5}  WOA={wc,11:G5}\");\n",
+    "    Console.WriteLine($\"{\"\",-10} shifted  : Uniform={ud,11:G5}  Islands={id,11:G5}  WOA={wd,11:G5}\");\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"\\n--- Done: 4 zero-optimum functions, centered vs shifted+rotated, 3 runs per cell ---\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "debias-interp-md",
+   "metadata": {},
+   "source": [
+    "### Lecture du banc dé-biaisé : trois renversements sur quatre, dans trois directions différentes\n",
+    "\n",
+    "Rappel : fitness = objectif négativé, plus proche de 0 = meilleur ; chaque cellule = moyenne sur 3 runs. Les deux lignes par fonction sont **appariées** -- même harnais, même budget, seule la position de l'optimum change (centre vs `Q^T·offset`, avec `Q orthogonal: True` en sortie).\n",
+    "\n",
+    "1. **Sphere (contrôle unimodal) : la victoire tient, la marge s'évapore.** WOA gagne des deux côtés, mais son avance sur Uniform passe de **neuf ordres de grandeur** (`-3,5066E-11` contre `-0,0045609`, centré) à **moins d'un facteur 2** (`-0,0026125` contre `-0,0035374`, dé-biaisé). Le centre offrait la précision, pas la supériorité.\n",
+    "\n",
+    "2. **Rastrigin : renversement Islands → WOA.** Centrée, Islands gagne de justesse (`-1,0611` contre `-1,2076` pour Uniform, `-5,2395` pour WOA). Dé-biaisée, toutes les configurations chutent -- le problème est plus dur -- mais WOA chute le moins : `-8,0776` contre `-9,0689` (Islands) et `-14,918` (Uniform).\n",
+    "\n",
+    "3. **Ackley : renversement WOA → Islands.** Centrée, WOA écrase (`-0,0003237`). Dé-biaisée, elle passe **dernière** (`-6,8656`) derrière Islands (`-2,9838`) et Uniform (`-4,0284`). La rotation désaxe les vallées alignées sur les axes -- le terrain de prédilection du bubble-net.\n",
+    "\n",
+    "4. **Griewank : renversement WOA → Uniform.** `-0,89535` pour Uniform contre `-0,9168` (Islands) et `-1,6726` (WOA, dernière).\n",
+    "\n",
+    "Verdict honnête : **trois des quatre fonctions changent de gagnante quand l'optimum quitte le centre -- et les trois renversements vont dans trois directions différentes** (Islands→WOA, WOA→Islands, WOA→Uniform). Aucune configuration ne sort du dé-biais avec un statut de championne structurelle : le banc centré fabrique des écarts écrasants (neuf ordres de grandeur sur Sphere) qui s'évanouissent, les victoires serrées se redistribuent. C'est la signature que décrit Kudela, rendue tangible -- et le *No Free Lunch* opère ici au niveau du banc lui-même : c'est la géométrie du problème, pas la métaphore de l'algorithme, qui décide.\n",
+    "\n",
+    "Réserve de méthode : 3 runs par cellule départagent les écarts nets (Ackley, Griewank) mais pas les écarts serrés (Rastrigin centré : `-1,0611` contre `-1,2076`). L'exercice 1 (multi-seed, barres d'erreur) est le prolongement naturel.\n",
+    "\n",
+    "Et l'argument final pour les primitives : les fonctions dé-biaisées vivent dans trois fichiers du fork (`ShiftedFitness.cs`, `RotatedFitness.cs`, `KnownFunctions.cs`) composés en une ligne -- **aucun algorithme n'a été modifié** pour produire ces renversements."
    ]
   },
   {
@@ -478,17 +806,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "cell-012",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:32.378037Z",
-     "iopub.status.busy": "2026-07-13T00:31:32.377671Z",
-     "iopub.status.idle": "2026-07-13T00:31:32.446839Z",
-     "shell.execute_reply": "2026-07-13T00:31:32.446550Z"
+     "iopub.execute_input": "2026-08-18T23:28:28.845773Z",
+     "iopub.status.busy": "2026-08-18T23:28:28.845146Z",
+     "iopub.status.idle": "2026-08-18T23:28:29.043977Z",
+     "shell.execute_reply": "2026-08-18T23:28:29.043590Z"
     }
    },
    "outputs": [
@@ -528,17 +856,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "cell-014",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:32.448173Z",
-     "iopub.status.busy": "2026-07-13T00:31:32.447984Z",
-     "iopub.status.idle": "2026-07-13T00:31:32.483559Z",
-     "shell.execute_reply": "2026-07-13T00:31:32.483196Z"
+     "iopub.execute_input": "2026-08-18T23:28:29.055421Z",
+     "iopub.status.busy": "2026-08-18T23:28:29.054282Z",
+     "iopub.status.idle": "2026-08-18T23:28:29.452078Z",
+     "shell.execute_reply": "2026-08-18T23:28:29.451344Z"
     }
    },
    "outputs": [
@@ -575,17 +903,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "cell-016",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:32.484874Z",
-     "iopub.status.busy": "2026-07-13T00:31:32.484705Z",
-     "iopub.status.idle": "2026-07-13T00:31:32.520235Z",
-     "shell.execute_reply": "2026-07-13T00:31:32.520019Z"
+     "iopub.execute_input": "2026-08-18T23:28:29.455080Z",
+     "iopub.status.busy": "2026-08-18T23:28:29.454565Z",
+     "iopub.status.idle": "2026-08-18T23:28:30.099438Z",
+     "shell.execute_reply": "2026-08-18T23:28:30.098583Z"
     }
    },
    "outputs": [
@@ -623,22 +951,22 @@
  ],
  "metadata": {
   "cost": {
-   "api_usd_est": 0.0,
    "api_provider": "none",
-   "qcc_tokens_est": 0,
+   "api_usd_est": 0.0,
    "cpu_min": 2,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "NONE",
-   "network": false,
    "external_account": "none",
    "free_alternative": "self",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-08-03",
+   "network": false,
+   "notes": "GA MetaGeneticSharp sur fonctions-benchmarks. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln (fork local, DLLs chargees via #r). GA seede (BasicRandomization.ResetSeed).",
+   "qcc_tokens_est": 0,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",
-   "metadata_written": "2026-08-03",
    "validator": "dotnet-interactive",
-   "notes": "GA MetaGeneticSharp sur fonctions-benchmarks. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln (fork local, DLLs chargees via #r). GA seede (BasicRandomization.ResetSeed)."
+   "vram_gb": 0,
+   "vram_tier": "NONE"
   },
   "kernelspec": {
    "display_name": ".NET (C#)",


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-dotnet #11622

feat(search,#3963): MGS-6 banc de-biaise shifted+rotated — démo CEC appariée, verdict honnête

## Synthèse

Tranche du mandat #3963 (« sans biais en zéro ») : le notebook **MGS-6-Benchmarks** démontre désormais le banc dé-biaisé du fork (`ShiftedFitness` + `RotatedFitness`, déjà livrés sur `main` du submodule à `1ee12e4`). Le submodule n'est **pas** touché — la machinerie existait, le notebook ne la démontrait pas ; cette PR comble ce gap d'acceptance.

**Contenu ajouté** (section entre « Lecture des résultats » et « Conclusion ») :

- **Intro pédagogique** : les 4 fonctions à optimum exactement au centre des bornes symétriques (Sphere, Rastrigin, Ackley, Griewank) sont structurellement flattées par le harnais (adam seedé au milieu des bornes = sur l'optimum) ; critique de Kudela (Nature Machine Intelligence 2022) ; protocole CEC `f_debias(x) = f(Q·x − offset)` avec les briques du fork.
- **Expérience appariée** : centered-vs-shifted+rotated sur les 4 fonctions × 3 configurations (Uniform/Islands/WOA), **3 runs indépendants par cellule** (GA stochastique — un run unique peut faire gagner n'importe qui), `ShiftVectors.Seeded` + `RotationMatrices.Seeded` seed 42, orthogonalité de Q vérifiée en sortie, amplitudes de shift calibrées ~30 % de la demi-étendue (l'optimum déplacé reste dans les bornes).
- **Interprétation ancrée sur les outputs adjacents** (L212-A, 17 valeurs citées vérifiées présentes dans l'output de la cellule précédente).

## Verdict honnête (exigence d'acceptance #3963, pas de « promising »)

- **3 renversements sur 4 fonctions**, dans 3 directions différentes : Rastrigin Islands→WOA, Ackley WOA→Islands, Griewank WOA→Uniform.
- **Sphere (contrôle unimodal)** : WOA garde la tête mais la marge s'évapore de 9 ordres de grandeur (`-3,5066E-11` vs `-0,0045609` centré → `-0,0026125` vs `-0,0035374` dé-biaisé).
- WOA passe de 3/4 à 2/4 sur les fonctions qu'elle dominait ; aucune configuration ne sort championne structurelle.
- Réserve de méthode écrite dans le notebook : 3 runs départagent les écarts nets, pas les serrés ; l'exercice 1 (multi-seed) est le prolongement.

## Resynchronisation existante (drift C.4/C.5)

La re-exécution complète (C.2, requise par l'insertion d'une cellule code) a re-roulé la grille stochastique : la cellule « Lecture des résultats » préexistante citait des valeurs de l'ancien run (`-2,72e-09` etc.). Valeurs **re-alignées sur les outputs frais** (`-4,55e-10`, `-0,0053`, `-0,0171`) et le compte « N/10 » revérifié à la main sur le run committé (7/10 vs Islands, Booth inclus — regex de contrôle exclue Booth par espace dans le nom, compté manuellement). Diagnostic dérive : **(e) stochasticité non-seedée**, verdict `CAUSE_DOCUMENTED_ONLY` assumé — le notebook documente lui-même le single-pass et renvoie au multi-seed (exercice 1) ; les valeurs citées viennent d'une **re-exécution fraîche**, pas d'un byte-surgical align.

## Validation

- **Exécution réelle .NET Interactive** via nbclient kernel `.net-csharp` (cwd = dossier du notebook pour les `#r` relatifs) : `EXEC OK in 40s`
- **Séquences CLEAN 1..8** monotones, **0 erreur** dans les outputs
- **validate_pr_notebooks.py : 1/1 PASS** (8 cellules code)
- **C.1 : 0 violation** (aucune erreur volontaire)
- **probeAddresses strip : 9 lignes** retirées post-re-exec .NET (L532) — pre-commit Passed
- **Tous les hooks pre-commit Passed** (gitleaks, H.3 un-executed, papermill paths, machine-username leak, oversized markdown)
- C.2 : outputs réels committés ; C.3 : seule cellule source modifiée = la nouvelle (cellule 8 « Lecture » = markdown-only, dispensé de re-exec)

## Périmètre

- `MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb` — seul livrable de la PR
- Submodule `MetaGeneticSharp` : **byte-identique à main** (gitlink `1ee12e4`, aucun changement — la machinerie était déjà livrée)

## Acceptance #3963

| Critère restant | État |
|---|---|
| MGS-5 + MGS-6 mis à jour : démontrent les nouveaux algos sur le banc dé-biaisé | **MGS-6 : cette PR**. MGS-5 : pas inclus (un sujet par PR) — reste une tranche séparée |
| Exécution réelle .NET + outputs committés (C.2) | OK (CLEAN 1..8, 0 erreur) |
| Verdict honnête (qui gagne où, pas de « promising ») | OK (3 renversements nommés, marge Sphere chiffrée, réserve de méthode) |

## G-VAR

- G-VAR-1 : MED/notebook-dotnet = **CONTENU** (nouvelle capacité démontrée au lecteur : le banc dé-biaisé en action avec verdict chiffré).
- G-VAR-3 : 2ᵉ MED/notebook-dotnet consécutif — autorisé : substance **genuinement distincte** (#11622 = re-exécution de rafales C.5 ; celle-ci = nouveau contenu pédagogique + expérience).
- G-VAR-2 : 0 LIGHT.

## Anti-patterns évités

- Pas de regen catalogue (R1) — catalogue byte-identique à main
- Pas de force-push, pas de merge worker, pas de close d'issue d'autrui
- Pas de scrub de sortie (Stop & Repair : drift traité par re-exécution + re-ancrage prose sur outputs frais)
- Pas d'interprétation fantôme (L212-A : 17/17 valeurs citées vérifiées dans l'output adjacent)

## Refs

- Issue #3963 — claim scopé : issuecomment-5335274802 + re-scope issuecomment-5335284383 (`paths: MyIA.AI.Notebooks/Search/MetaGeneticSharp, MyIA.AI.Notebooks/Search/Part4-Metaheuristics/`)
- Machinerie fork : `ShiftedFitness.cs`, `RotatedFitness.cs`, `CenterBiasBenchmark.cs` (déjà sur submodule main, PRs fork antérieures)
- Kudela, *A critical problem in benchmarking and analysis of evolutionary computation methods*, Nature Machine Intelligence 4, 2022

Commit : `1721f386969b2a28c26a1ed7f556700c120dcfa1` (auteur Jean-Sylvain Boige)

— lane `myia-po-2025:CoursIA-2 · 2026-08-19`
