### PR TITLE
fix(lean-ci,#11679): bascule game-defs/game-defs-ext/kelly sorry-filter-mode standalone-tactic → real

### DIFF
--- a/.github/workflows/lean-game-defs-ext.yml
+++ b/.github/workflows/lean-game-defs-ext.yml
@@ -33,4 +33,4 @@ jobs:
       project-path: MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext
       display-name: lean_game_defs_ext
       sorry-baseline: "0"
-      sorry-filter-mode: standalone-tactic
+      sorry-filter-mode: real

--- a/.github/workflows/lean-game-defs.yml
+++ b/.github/workflows/lean-game-defs.yml
@@ -37,4 +37,4 @@ jobs:
       project-path: MyIA.AI.Notebooks/GameTheory/lean_game_defs
       display-name: lean_game_defs
       sorry-baseline: "0"
-      sorry-filter-mode: standalone-tactic
+      sorry-filter-mode: real

--- a/.github/workflows/lean-kelly.yml
+++ b/.github/workflows/lean-kelly.yml
@@ -7,7 +7,7 @@ name: Lean CI (kelly_lean)
 # recourir à la concavité abstraite. Premier Lean lake liant position sizing à un
 # résultat formel (roadmap #4038 Tier 2, issue #4052).
 #
-# sorry-filter-mode=standalone-tactic, baseline=0 : la bibliothèque est intégralement
+# sorry-filter-mode=real, baseline=0 : la bibliothèque est intégralement
 # sans sorry ; les deux théorèmes `kelly_optimal` (f* maximise g) et `kelly_unique`
 # (sur/sous-pari strictement sous-optimaux) sont prouvés. Ce CI garde qu'AUCUN nouveau
 # `sorry` tactic standalone n'est introduit (jamais de faux positif sur les mentions
@@ -40,4 +40,4 @@ jobs:
       project-path: MyIA.AI.Notebooks/QuantConnect/kelly_lean
       display-name: kelly_lean
       sorry-baseline: "0"
-      sorry-filter-mode: standalone-tactic
+      sorry-filter-mode: real


### PR DESCRIPTION
fix(lean-ci,#11679): bascule game-defs/game-defs-ext/kelly sorry-filter-mode standalone-tactic → real

See #11679 (premier lot d'une bascule découpée en plusieurs PRs, atomicité par seuil §A).

Perimetre : 3 fichiers (`.github/workflows/lean-game-defs.yml`, `.github/workflows/lean-game-defs-ext.yml`, `.github/workflows/lean-kelly.yml`), et aucun autre.

## Grain

Grain: MED/lean — lane myia-po-2026:CoursIA-2 — prev: MED/guard #11680 (c.366 perimeter, dernier grain guard avant ce bascule Lean)

## Pourquoi cette bascule

`lean-build.yml` propose quatre modes de comptage `sorry` (cf. `lean-build.yml:100-136`). `standalone-tactic` est le mode le plus restrictif en surface mais le plus dangereux en pratique : il ne compte que les lignes dont le contenu ENTIER est `sorry`, donc il rate :

```
exact sorry
theorem foo : P := sorry
def f : T := sorry
  ... <;> sorry
sorry -- TODO
```

L'incident fondateur est documenté dans `anti-regression.md` §"Compter les `sorry`" : pendant onze jours, le lake `knot_lean` a été qualifié de "résidu" par un reviewer qui lisait un chiffre `2` là où le lake en portait `16`. `knot_lean` est aujourd'hui en `real` avec `sorry-baseline: 14` — c'est l'arbre qui a déclenché la bascule pour les dix-huit workflows restants (cf. issue #11679).

## Mode `real` (lean-build.yml:111-134)

Le mode `real` strip les commentaires Lean `-- ...` et les commentaires imbriqués `/- ... -/`, puis compte les occurrences word-bounded `\bsorry\b`. C'est le **même algorithme** que `count_real_sorries` du harness prover (FX-6 #1453), l'instrument canonique du dépôt. Le mode ignore les mentions de "sorry" en prose de docstring (cf. #5120).

## Mesure firsthander (G.9 strict)

Avant push, j'ai rejoué les **deux** filtres à l'identique de la commande du workflow sur les trois lakes de cette PR :

```
=== MyIA.AI.Notebooks/GameTheory/lean_game_defs ===
  TOTAL: 0   (mode real)
  TOTAL: 0   (mode standalone-tactic)

=== MyIA.AI.Notebooks/GameTheory/lean_game_defs_ext ===
  TOTAL: 0   (mode real)
  TOTAL: 0   (mode standalone-tactic)

=== MyIA.AI.Notebooks/QuantConnect/kelly_lean ===
  TOTAL: 0   (mode real)
  TOTAL: 0   (mode standalone-tactic)
```

`lakefile.lean` de kelly contient une mention `atteignable **0 sorry** sur le théorème phare` dans un commentaire — l'awk strip `--` AVANT le grep, donc cette mention ne compte pas en mode `real`. Mesure confirme.

L'auteur de #11679 a mesuré le même écart nul sur vingt-quatre des vingt-cinq lakes du dépôt (le vingt-cinquième = `knot_lean` qui est déjà sur `real` avec baseline quatorze). Les trois lakes de cette PR sont dans le sous-ensemble des vingt-quatre.

## Acceptance

| # | Critère (issue #11679) | Mesure | Verdict |
|---|----------------------|--------|---------|
| 1 | les workflows portant `sorry-filter-mode: real` s'étendent | Ce lot couvre trois d'entre eux (game-defs, game-defs-ext, kelly). Les restants sont livrés en PRs suivantes (split atomicité §A). | OK lot 1 |
| 2 | CI run de chaque lake reste vert après bascule | Pas de lake build SUCCESS local possible (L954 ★ : `lake build` Mathlib ~2h+ WSL > fenêtre 30 min). Sweep firsthander garantit 0 rouge : aucune baseline à relever. | OK par mesure |
| 3 | sweep rejoué et joint montrant `standalone == real == 0` sur chaque lake vert | Mesures firsthander (tableau ci-dessus) jointe dans la PR. | OK |

## Conformité générale

- **L898 ★★★** : vérifié avant push. Le submodule `MyIA.AI.Notebooks/SymbolicAI/SMT/Z3.Linq` est en WIP session-sœur (`e057090` vs `893c5a90` pin main) ; il reste unstaged et **n'est PAS dans ce commit**. `git diff --cached --stat` ne montre que les trois fichiers workflows.
- **§A pr-review** : trois fichiers modifiés, sous le seuil atomicité. OK.
- **§B pr-review (Lean)** : preuve de progrès vérifiable — sweep firsthander standalone == real == 0 sur chaque lake touché, gain de **fidélité** de l'anti-regression (capture désormais `exact sorry`, `:= sorry`, etc.). `lake build SUCCESS` post-modif NON disponible localement (L954), mais aucune baseline n'est relevée (la mesure garantit zéro rouge — si un lake rougit au prochain run, c'est une dette réelle qui était masquée, à NE PAS relever la baseline, ouvrir une issue de dette par [#11679](https://github.com/jsboige/CoursIA/issues/11679)).
- **L677-L4 ★★** : PR body généré HORS worktree (scratchpad `c367_pr_body.md`).
- **Pre-commit H.3** : OK (gitleaks Passed, pas de notebooks concernés).
- **L954 ★** : assumé — pas de `lake build SUCCESS` local (Mathlib ~2h+ WSL).

## Note de séquencement

c.367 cycle : ai-01 a mergé #11680 (c.366 perimeter fix) et #11675 (c.365 fence fix) sur la branche perimeter ; ce cycle bascule sur le sequencement Lean anti-régression (cf. grain DEEP historique de cette lane sur les lakes). Lots suivants en c.368+ sur le même #11679.

## Lien

- Issue **#11679** — fondateur documenté (dix-huit workflows Lean, bascule préventive).
- PR **#11675** — extraction-level fence fix (c.366), pattern pour "anti-régression Lean" similaire.
- Incident fondateur : knot_lean 2 vs 16 (2026-08-16, c.136 #1453).
