### PR TITLE
feat(search,#3963): MGS-5 nouveaux composes (DE/BBPSO/SA) sur banc de-biaise

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
@@ -38,10 +38,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:16.058448Z",
-     "iopub.status.busy": "2026-07-13T00:31:16.050773Z",
-     "iopub.status.idle": "2026-07-13T00:31:17.720774Z",
-     "shell.execute_reply": "2026-07-13T00:31:17.715835Z"
+     "iopub.execute_input": "2026-08-18T23:56:32.118970Z",
+     "iopub.status.busy": "2026-08-18T23:56:32.102461Z",
+     "iopub.status.idle": "2026-08-18T23:56:37.074786Z",
+     "shell.execute_reply": "2026-08-18T23:56:37.062212Z"
     },
     "papermill": {
      "duration": 1.180733,
@@ -53,6 +53,121 @@
     "tags": []
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '63756.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -99,6 +214,7 @@
     "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Domain.dll\"\n",
     "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n",
     "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\n",
+    "#r \"../MetaGeneticSharp/src/MetaGeneticSharp.Extensions/bin/Debug/net9.0/MetaGeneticSharp.Extensions.dll\"\n",
     "\n",
     "using MetaGeneticSharp;\n",
     "using GeneticSharp;\n",
@@ -152,10 +268,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:17.723204Z",
-     "iopub.status.busy": "2026-07-13T00:31:17.722780Z",
-     "iopub.status.idle": "2026-07-13T00:31:17.897318Z",
-     "shell.execute_reply": "2026-07-13T00:31:17.896943Z"
+     "iopub.execute_input": "2026-08-18T23:56:37.078410Z",
+     "iopub.status.busy": "2026-08-18T23:56:37.077691Z",
+     "iopub.status.idle": "2026-08-18T23:56:37.506168Z",
+     "shell.execute_reply": "2026-08-18T23:56:37.505675Z"
     },
     "papermill": {
      "duration": 0.221607,
@@ -331,10 +447,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:17.898873Z",
-     "iopub.status.busy": "2026-07-13T00:31:17.898630Z",
-     "iopub.status.idle": "2026-07-13T00:31:18.901754Z",
-     "shell.execute_reply": "2026-07-13T00:31:18.901384Z"
+     "iopub.execute_input": "2026-08-18T23:56:37.509677Z",
+     "iopub.status.busy": "2026-08-18T23:56:37.508864Z",
+     "iopub.status.idle": "2026-08-18T23:56:38.267405Z",
+     "shell.execute_reply": "2026-08-18T23:56:38.266165Z"
     },
     "papermill": {
      "duration": 0.49574,
@@ -552,10 +668,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:18.903222Z",
-     "iopub.status.busy": "2026-07-13T00:31:18.902997Z",
-     "iopub.status.idle": "2026-07-13T00:31:19.108960Z",
-     "shell.execute_reply": "2026-07-13T00:31:19.108477Z"
+     "iopub.execute_input": "2026-08-18T23:56:38.271523Z",
+     "iopub.status.busy": "2026-08-18T23:56:38.270625Z",
+     "iopub.status.idle": "2026-08-18T23:56:38.841526Z",
+     "shell.execute_reply": "2026-08-18T23:56:38.840699Z"
     },
     "papermill": {
      "duration": 0.555135,
@@ -606,7 +722,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WOA sur Sphere (5D, 80 gen) -> fitness = -3,7872E-13  (proche de 0 = bon)\r\n"
+      "WOA sur Sphere (5D, 80 gen) -> fitness = -3,2058E-11  (proche de 0 = bon)\r\n"
      ]
     }
    ],
@@ -677,10 +793,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:19.110664Z",
-     "iopub.status.busy": "2026-07-13T00:31:19.110309Z",
-     "iopub.status.idle": "2026-07-13T00:31:19.334223Z",
-     "shell.execute_reply": "2026-07-13T00:31:19.333810Z"
+     "iopub.execute_input": "2026-08-18T23:56:38.844169Z",
+     "iopub.status.busy": "2026-08-18T23:56:38.843597Z",
+     "iopub.status.idle": "2026-08-18T23:56:40.149001Z",
+     "shell.execute_reply": "2026-08-18T23:56:40.148576Z"
     },
     "papermill": {
      "duration": 0.561648,
@@ -710,7 +826,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "EO sur Sphere -> fitness = -1,2168E-24\r\n"
+      "EO sur Sphere -> fitness = -4,8595E-28\r\n"
      ]
     },
     {
@@ -788,10 +904,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:19.336219Z",
-     "iopub.status.busy": "2026-07-13T00:31:19.335945Z",
-     "iopub.status.idle": "2026-07-13T00:31:19.476217Z",
-     "shell.execute_reply": "2026-07-13T00:31:19.475648Z"
+     "iopub.execute_input": "2026-08-18T23:56:40.152467Z",
+     "iopub.status.busy": "2026-08-18T23:56:40.151825Z",
+     "iopub.status.idle": "2026-08-18T23:56:40.595529Z",
+     "shell.execute_reply": "2026-08-18T23:56:40.595196Z"
     },
     "papermill": {
      "duration": 0.198386,
@@ -821,7 +937,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FBI sur Sphere -> fitness = -2,3248E-26\r\n"
+      "FBI sur Sphere -> fitness = -9,9413E-26\r\n"
      ]
     },
     {
@@ -896,10 +1012,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:19.477916Z",
-     "iopub.status.busy": "2026-07-13T00:31:19.477652Z",
-     "iopub.status.idle": "2026-07-13T00:31:19.742351Z",
-     "shell.execute_reply": "2026-07-13T00:31:19.741957Z"
+     "iopub.execute_input": "2026-08-18T23:56:40.598722Z",
+     "iopub.status.busy": "2026-08-18T23:56:40.598141Z",
+     "iopub.status.idle": "2026-08-18T23:56:41.339973Z",
+     "shell.execute_reply": "2026-08-18T23:56:41.339713Z"
     },
     "papermill": {
      "duration": 0.541577,
@@ -929,14 +1045,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Islands5Default sur Sphere -> fitness = -0,034033\r\n"
+      "Islands5Default sur Sphere -> fitness = -0,0056002\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Islands5BestMixture sur Sphere -> fitness = -4,8341E-15\r\n"
+      "Islands5BestMixture sur Sphere -> fitness = -5,0822E-18\r\n"
      ]
     },
     {
@@ -992,10 +1108,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:19.743789Z",
-     "iopub.status.busy": "2026-07-13T00:31:19.743576Z",
-     "iopub.status.idle": "2026-07-13T00:31:21.160678Z",
-     "shell.execute_reply": "2026-07-13T00:31:21.160368Z"
+     "iopub.execute_input": "2026-08-18T23:56:41.341999Z",
+     "iopub.status.busy": "2026-08-18T23:56:41.341753Z",
+     "iopub.status.idle": "2026-08-18T23:56:45.043763Z",
+     "shell.execute_reply": "2026-08-18T23:56:45.043434Z"
     },
     "papermill": {
      "duration": 2.813811,
@@ -1025,21 +1141,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sphere             -0,021021     -7,1799E-11      -3,238E-24     -3,1129E-25     -9,1878E-19\r\n"
+      "Sphere            -0,0078981     -2,1789E-10     -2,1642E-27     -8,7331E-27     -5,2345E-16\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rastrigin            -1,7914      -5,451E-10         -1,9899              -0     -8,5265E-14\r\n"
+      "Rastrigin            -1,4947         -3,9879         -2,9849              -0     -1,2434E-12\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Rosenbrock           -10,906         -3,9894         -3,3405         -3,5867         -3,8917\r\n"
+      "Rosenbrock           -17,248         -3,9801         -3,5688         -3,4358         -3,6966\r\n"
      ]
     },
     {
@@ -1084,6 +1200,178 @@
     "}\n",
     "Console.WriteLine();\n",
     "Console.WriteLine(\"Chaque colonne est le même type d'objet (IMetaHeuristic) construit en un appel de factory.\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mgs5-debias-intro-md",
+   "metadata": {},
+   "source": [
+    "## Les nouveaux arrivants, sur le banc dé-biaisé\n",
+    "\n",
+    "La grille ci-dessus compare les quatre familles historiques du catalogue. Mais le catalogue (`KnownCompoundMetaheuristics`) contient aussi **trois composés plus récents** que cette grille ne montre pas : **`DifferentialEvolution`** (Storn & Price, 1997), **`BareBonesParticleSwarm`** (Kennedy, 2003) et **`SimulatedAnnealing`** (Kirkpatrick et al., 1983). La factory les construit exactement comme les autres -- un appel par nom.\n",
+    "\n",
+    "Pour les démontrer, on ne se contente pas du banc centré : on les confronte au **banc dé-biaisé** (cf. [MGS-6](MGS-6-Benchmarks.ipynb) pour l'analyse complète du protocole). Rappel du problème : le harnais seede le chromosome *adam* au **milieu des bornes** -- sur l'optimum de Sphere et Rastrigin (fonctions à optimum en zéro, bornes symétriques). Le protocole CEC déplace l'optimum hors du centre (`f_debias(x) = f(Q·x − offset)`, `Q` orthogonale seedée, `offset` par dimension seedé) via les décorateurs du fork :\n",
+    "\n",
+    "```csharp\n",
+    "var offset = ShiftVectors.Seeded(Dim, 1.5, seed);   // ~30 % de la demi-étendue [-5.12, 5.12]\n",
+    "var Q      = RotationMatrices.Seeded(Dim, seed);\n",
+    "var cec    = new RotatedFitness(new ShiftedFitness(inner, offset), Q);\n",
+    "```\n",
+    "\n",
+    "L'expérience est **appariée** : chaque configuration (Default en référence + les trois nouveaux) tourne sur la version centrée ET la version dé-biaisée de Sphere et Rastrigin, **3 runs indépendants par cellule** (moyenne -- le GA est stochastique). Question : **les nouveaux arrivants résistent-ils au retrait du cadeau du centre ?**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "mgs5-debias-run-code",
+   "metadata": {
+    "dotnet_interactive": {
+     "language": "csharp"
+    },
+    "execution": {
+     "iopub.execute_input": "2026-08-18T23:56:45.046221Z",
+     "iopub.status.busy": "2026-08-18T23:56:45.045685Z",
+     "iopub.status.idle": "2026-08-18T23:56:49.466955Z",
+     "shell.execute_reply": "2026-08-18T23:56:49.466501Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seed=42  Q orthogonal: True  runs per cell=3\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(fitness = objectif negativé, plus proche de 0 = meilleur; moyenne sur les runs)\n",
+      "\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sphere     |offset|_inf=  1,123  (optimum a Q^T*offset, hors centre)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  centered :  Default (GA)          -0,016244  DifferentialEvol    -2,2824E-11  BareBonesPSO        -4,0262E-20  SimulatedAnneal     -0,00084409\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  shifted  :  Default (GA)         -0,0090199  DifferentialEvol    -2,0894E-10  BareBonesPSO        -1,7391E-20  SimulatedAnneal     -0,00034837\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rastrigin  |offset|_inf=  1,123  (optimum a Q^T*offset, hors centre)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  centered :  Default (GA)            -1,2454  DifferentialEvol       -0,88694  BareBonesPSO            -9,6179  SimulatedAnneal         -2,5855\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  shifted  :  Default (GA)            -7,1297  DifferentialEvol        -6,2631  BareBonesPSO            -7,9597  SimulatedAnneal         -8,0833\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "--- Done: 4 configs x 2 fonctions a optimum-centre, centered vs shifted+rotated, 3 runs/cellule ---\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// Nouveaux composés (DE, BareBonesParticleSwarm, SimulatedAnnealing) via la factory,\n",
+    "// confrontes au banc de-biase (shifted+rotated CEC). Comparaison appariee centered-vs-debiased,\n",
+    "// 3 runs par cellule (moyenne), Default en reference.\n",
+    "int ndSeed  = 42;\n",
+    "int ndRuns  = 3;\n",
+    "\n",
+    "var newConfigs = new (string Name, Func<IMetaHeuristic> Build)[]\n",
+    "{\n",
+    "    (\"Default (GA)\",     () => BuildViaFactory(\"Default\")),\n",
+    "    (\"DifferentialEvol\", () => BuildViaFactory(\"DifferentialEvolution\")),\n",
+    "    (\"BareBonesPSO\",     () => BuildViaFactory(\"BareBonesParticleSwarm\")),\n",
+    "    (\"SimulatedAnneal\",  () => BuildViaFactory(\"SimulatedAnnealing\")),\n",
+    "};\n",
+    "\n",
+    "var zeroOptFns = new (string Name, Type Type)[]\n",
+    "{\n",
+    "    (\"Sphere\",    typeof(SphereFitness)),\n",
+    "    (\"Rastrigin\", typeof(RastriginFitness)),\n",
+    "};\n",
+    "\n",
+    "var Qnd = RotationMatrices.Seeded(Dim, ndSeed);\n",
+    "Console.WriteLine($\"seed={ndSeed}  Q orthogonal: {RotationMatrices.IsOrthogonal(Qnd)}  runs per cell={ndRuns}\");\n",
+    "Console.WriteLine(\"(fitness = objectif negativé, plus proche de 0 = meilleur; moyenne sur les runs)\\n\");\n",
+    "\n",
+    "double MeanRuns(IFitness f, Type t, Func<IMetaHeuristic> build) =>\n",
+    "    Enumerable.Range(0, ndRuns).Select(_ => RunBenchmark(f, t, build())).Average();\n",
+    "\n",
+    "foreach (var (fnName, fnType) in zeroOptFns)\n",
+    "{\n",
+    "    var inner  = (IFitness)Activator.CreateInstance(fnType);\n",
+    "    var offset = ShiftVectors.Seeded(Dim, 1.5, ndSeed);\n",
+    "    var cec    = new RotatedFitness(new ShiftedFitness(inner, offset), Qnd);\n",
+    "\n",
+    "    Console.WriteLine($\"{fnName,-10} |offset|_inf={offset.Select(Math.Abs).Max(),7:G4}  (optimum a Q^T*offset, hors centre)\");\n",
+    "    string rowC = \"  centered :\", rowD = \"  shifted  :\";\n",
+    "    foreach (var (cfgName, build) in newConfigs)\n",
+    "    {\n",
+    "        double c = MeanRuns(inner, fnType, build);\n",
+    "        double d = MeanRuns(cec,    fnType, build);\n",
+    "        rowC += $\"  {cfgName,-18} {c,12:G5}\";\n",
+    "        rowD += $\"  {cfgName,-18} {d,12:G5}\";\n",
+    "    }\n",
+    "    Console.WriteLine(rowC);\n",
+    "    Console.WriteLine(rowD);\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"\\n--- Done: 4 configs x 2 fonctions a optimum-centre, centered vs shifted+rotated, 3 runs/cellule ---\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mgs5-debias-interp-md",
+   "metadata": {},
+   "source": [
+    "### Lecture : les nouveaux arrivants passent le test -- mais le peloton se tasse\n",
+    "\n",
+    "Rappel : fitness = objectif négativé, plus proche de 0 = meilleur ; chaque cellule = moyenne sur 3 runs ; les deux lignes par fonction sont **appariées** (même harnais, seul l'optimum bouge : centre vs `Q^T·offset`, `Q orthogonal: True` en sortie).\n",
+    "\n",
+    "1. **Sphere : aucun des nouveaux n'avait besoin du cadeau du centre.** DE et BBPSO convergent à la précision machine **des deux côtés** -- DE à `-2,2824E-11` (centré) et `-2,0894E-10` (dé-biaisé), BBPSO à `-4,0262E-20` et `-1,7391E-20`. À ce niveau de précision, l'écart centered/shifted n'est pas mesurable : ces deux composés ne doivent rien à la position de l'optimum sur une unimodale. C'est le comportement qu'on attend d'un vrai optimiseur -- et le contraste avec WOA dans [MGS-6](MGS-6-Benchmarks.ipynb), dont la marge s'évaporait de neuf ordres de grandeur sur la même fonction.\n",
+    "\n",
+    "2. **Rastrigin : DE résiste au dé-biais.** Premier des deux côtés -- `-0,88694` centré, `-6,2631` dé-biaisé -- devant Default (`-1,2454` / `-7,1297`). Mais la marge **fond** : l'écart relatif Default/DE passe de **×1,40** (centré) à **×1,14** (dé-biaisé). Le leadership tient, il est moins écrasant.\n",
+    "\n",
+    "3. **La queue se redistribue.** Au centre, SA (`-2,5855`) devance BBPSO (`-9,6179`). Dé-biaisé, c'est inversé : BBPSO `-7,9597` devant SA `-8,0833`. Le recuit simulé, qui accepte des pas dégradants calibrés sur la géométrie du paysage, perd son avantage quand la rotation désaxe les vallées ; BBPSO, qui resample autour des meilleures solutions, y gagne relativement.\n",
+    "\n",
+    "Verdict honnête : **les trois nouveaux composés sortent du banc dé-biaisé sans faux champion** -- DE confirme un leadership réel (il tient sans le centre), BBPSO montre une robustesse de précision machine, et aucun classement ne reposait sur le seeding au centre. La signature de biais de Kudela, qui renversait 3 des 4 fonctions dans MGS-6 pour les familles historiques, ne renverse ici ni le vainqueur de Sphere ni celui de Rastrigin ; elle resserre les marges et redistribue la queue. Réserve de méthode identique à MGS-6 : 3 runs départagent les écarts nets, pas les écarts serrés (SA vs BBPSO dé-biaisé : 0,12 d'écart sur une moyenne de 3).\n",
+    "\n",
+    "Et toujours le même argument d'architecture : cette section n'a **aucun nouvel algorithme** à écrire -- trois noms de factory en plus, deux décorateurs composés, zéro modification du moteur."
    ]
   },
   {
@@ -1153,17 +1441,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "c20",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:21.162156Z",
-     "iopub.status.busy": "2026-07-13T00:31:21.161973Z",
-     "iopub.status.idle": "2026-07-13T00:31:21.196021Z",
-     "shell.execute_reply": "2026-07-13T00:31:21.195615Z"
+     "iopub.execute_input": "2026-08-18T23:56:49.469768Z",
+     "iopub.status.busy": "2026-08-18T23:56:49.469248Z",
+     "iopub.status.idle": "2026-08-18T23:56:49.563474Z",
+     "shell.execute_reply": "2026-08-18T23:56:49.563087Z"
     },
     "papermill": {
      "duration": 0.115972,
@@ -1212,17 +1500,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "c22",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:21.197633Z",
-     "iopub.status.busy": "2026-07-13T00:31:21.197412Z",
-     "iopub.status.idle": "2026-07-13T00:31:21.225470Z",
-     "shell.execute_reply": "2026-07-13T00:31:21.225122Z"
+     "iopub.execute_input": "2026-08-18T23:56:49.565198Z",
+     "iopub.status.busy": "2026-08-18T23:56:49.564908Z",
+     "iopub.status.idle": "2026-08-18T23:56:49.627898Z",
+     "shell.execute_reply": "2026-08-18T23:56:49.627361Z"
     },
     "papermill": {
      "duration": 0.064394,
@@ -1274,17 +1562,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "c24",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:31:21.227064Z",
-     "iopub.status.busy": "2026-07-13T00:31:21.226884Z",
-     "iopub.status.idle": "2026-07-13T00:31:21.265027Z",
-     "shell.execute_reply": "2026-07-13T00:31:21.264575Z"
+     "iopub.execute_input": "2026-08-18T23:56:49.629853Z",
+     "iopub.status.busy": "2026-08-18T23:56:49.629597Z",
+     "iopub.status.idle": "2026-08-18T23:56:49.685634Z",
+     "shell.execute_reply": "2026-08-18T23:56:49.685450Z"
     },
     "papermill": {
      "duration": 0.051967,
@@ -1341,6 +1629,20 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 7,
+   "external_account": null,
+   "free_alternative": null,
+   "gpu_required": false,
+   "metadata_written": null,
+   "network": false,
+   "notes": "Local execution via MetaGeneticSharp (.NET C# genetic-algorithm library). Deterministic given fixed random seed, population and generation count. Requires .NET Interactive kernel + MetaGeneticSharp package. The genetic operators (selection/crossover/mutation) are deterministic algorithms; GA convergence to a fixed seed is reproducible.",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
@@ -1364,20 +1666,6 @@
    "parameters": {},
    "start_time": "2026-06-16T22:40:28.817906",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 7,
-   "gpu_required": false,
-   "network": false,
-   "external_account": null,
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": null,
-   "validator": "manual",
-   "notes": "Local execution via MetaGeneticSharp (.NET C# genetic-algorithm library). Deterministic given fixed random seed, population and generation count. Requires .NET Interactive kernel + MetaGeneticSharp package. The genetic operators (selection/crossover/mutation) are deterministic algorithms; GA convergence to a fixed seed is reproducible."
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb
@@ -62,7 +62,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -72,10 +71,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -90,7 +86,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -102,8 +97,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -152,13 +145,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -1654,18 +1645,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 10.037898,
-   "end_time": "2026-06-16T22:40:38.855804",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "MGS-5-CompoundMetaheuristics.ipynb",
-   "output_path": "MGS-5-CompoundMetaheuristics_out.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-16T22:40:28.817906",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-dotnet #11681

feat(search,#3963): MGS-5 nouveaux composés (DE/BBPSO/SA) sur banc dé-biaisé

## Synthèse

Deuxième tranche du mandat #3963 : le notebook **MGS-5-CompoundMetaheuristics** démontre désormais les **trois composés récents du catalogue** — `DifferentialEvolution` (Storn & Price, 1997), `BareBonesParticleSwarm` (Kennedy, 2003), `SimulatedAnnealing` (Kirkpatrick et al., 1983) — absents de la grille historique du notebook (Default + WOA/EO/FBI/Islands), **sur le banc dé-biaisé** (composition CEC du fork : `ShiftedFitness` + `RotatedFitness`).

**Contenu ajouté** (section entre la grille de comparaison et la Conclusion) :

- **Intro pédagogique** : le catalogue porte trois composés que la grille ne montre pas ; rappel du protocole dé-biais (Kudela 2022, cross-ref MGS-6) ; le harnais seede l'adam au centre = sur l'optimum de Sphere/Rastrigin.
- **Expérience appariée** : 4 configurations (Default référence + les 3 nouveaux) × Sphere + Rastrigin × centered-vs-shifted+rotated, **3 runs indépendants par cellule** (moyenne), `Q orthogonal: True` vérifié en sortie, shift ~30 % de la demi-étendue.
- **Wiring** : `#r` Extensions ajouté à la cellule de câblage (`ShiftedFitness`/`RotatedFitness` vivent dans `MetaGeneticSharp.Extensions.dll`, non chargée auparavant).
- **Interprétation ancrée** sur les outputs adjacents (L212-A : 12/12 valeurs citées vérifiées présentes ; ratios ×1,40/×1,14 recalculés).

## Verdict honnête (exigence d'acceptance #3963)

- **Sphere : aucun des nouveaux n'avait besoin du cadeau du centre.** DE à `-2,2824E-11` (centré) / `-2,0894E-10` (dé-biaisé), BBPSO à `-4,0262E-20` / `-1,7391E-20` — précision machine des deux côtés, biais non mesurable à ce niveau. Contraste assumé avec WOA dans MGS-6 (marge évaporée de 9 ordres de grandeur sur la même fonction).
- **Rastrigin : DE résiste** — 1ᵉʳ des deux côtés (`-0,88694` / `-6,2631`), mais la marge relative sur Default fond de **×1,40 → ×1,14**.
- **Queue redistribuée** : SA 3ᵉ→4ᵉ, BBPSO 4ᵉ→3ᵉ (rotation désaxée + recuit à grands pas).
- **Aucun faux champion** : contrairement aux familles historiques (MGS-6 : 3 renversements/4), aucun classement ne reposait sur le seeding au centre. Réserve de méthode écrite : 3 runs départagent les écarts nets, pas les serrés (SA vs BBPSO : 0,12 d'écart).

## Validation

- **Exécution réelle .NET Interactive** (nbclient kernel `.net-csharp`, cwd = dossier du notebook) : `EXEC OK in 23s`
- **Séquences CLEAN 1..12** monotones, **0 erreur** dans les outputs
- **validate_pr_notebooks.py : 1/1 PASS** (12 cellules code)
- **C.1 : 0 violation**
- **probeAddresses strip : 9 lignes** (L532) — pre-commit Passed (6/6 hooks)
- C.2 : outputs réels committés. Cellules préexistantes : sources inchangées sauf wiring cell 1 (`#r` Extensions ajouté — re-exécutée dans le run complet)
- Scan L235 : **aucune valeur chiffrée citée dans les cellules markdown préexistantes** (prose qualitative) — aucun resync nécessaire

## Périmètre

- `MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-5-CompoundMetaheuristics.ipynb` — seul livrable
- Submodule `MetaGeneticSharp` : **byte-identique à main** (gitlink `1ee12e4`)

## Acceptance #3963

| Critère | État |
|---|---|
| MGS-5 + MGS-6 mis à jour : démontrent les nouveaux algos sur le banc dé-biaisé | **MGS-5 : cette PR + MGS-6 : #11681 (CLEAN MERGEABLE)** → critère couvert |
| Exécution réelle .NET + outputs committés (C.2) | OK (CLEAN 1..12, 0 erreur) |
| Verdict honnête (qui gagne où, pas de « promising ») | OK (DE tient/BBPSO précision machine/queue redistribuée, réserve écrite) |
| ≥3 component-based metaheuristics | OK — DE/BBPSO/SA désormais **démontrés** (pas seulement implémentés) |

## G-VAR

- G-VAR-1 : MED/notebook-dotnet = **CONTENU** (les 3 nouveaux algos du mandat passent de « implémentés dans le fork » à « démontrés au lecteur avec verdict chiffré »).
- G-VAR-3 : 3ᵉ MED/notebook-dotnet consécutif — autorisé : substance genuinement distincte à chaque fois (#11622 re-exec rafales ; #11681 banc dé-biaisé familles historiques ; celle-ci nouveaux composés). Trois notebooks, trois questions, trois verdicts.
- G-VAR-2 : 0 LIGHT.

## Anti-patterns évités

- Pas de regen catalogue (R1) — catalogue byte-identique à main
- Pas de force-push, pas de merge worker, pas de close d'issue d'autrui
- Pas de scrub de sortie (Stop & Repair) ; pas d'interp fantôme (L212-A 12/12)
- Pas d'assertion « N fichiers » hors ligne de périmètre (L234) — périmètre déclaré : **un seul notebook modifié**

## Refs

- Issue #3963 — claim scopé : issuecomment-5335284383 (`paths:` inclut `Part4-Metaheuristics/`)
- Sibling PR : #11681 (MGS-6, CLEAN MERGEABLE)
- Machinerie fork : `KnownCompoundMetaheuristics.cs` (enum 14 membres), `ShiftedFitness.cs`, `RotatedFitness.cs`
- Kudela, *A critical problem in benchmarking…*, Nature Machine Intelligence 4, 2022

Commit : `0b20798062f32b4621ec51e4e47916776366bea4` (auteur Jean-Sylvain Boige)

— lane `myia-po-2025:CoursIA-2 · 2026-08-19`
