### PR TITLE
fix(probas,#11685): residu Graphviz — 5 graphes de facteurs restaures sur Infer-6, DecInfer-4, DecInfer-10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -960,3 +960,12 @@ MyIA.AI.Notebooks/SymbolicAI/Tweety/dotnet-build/.dialogues-build/
 # consumed by `restore`, deleted when restore completes. Ephemeral (in-flight
 # patch state), never committed.
 .quarto_csharp_fix_manifest.json
+
+# Infer.NET factor-graph render side-artifacts (#11685)
+# InferHelpers/Graphviz rendering writes a timestamped Model_<MM_DD_YY_HH_MM_SS_ff>.gv + .svg
+# pair next to the notebook on every execution — the SVG that matters is embedded in the cell
+# output, these on-disk copies are transient. Timestamped names mean each re-exec drops a new
+# pair, so tracking them accumulates junk forever. Nothing in the repo references them (git
+# ls-files '*.gv' is empty).
+MyIA.AI.Notebooks/**/Model_[0-9]*.gv
+MyIA.AI.Notebooks/**/Model_[0-9]*.svg

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
@@ -116,135 +116,23 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       
-       
-       "\r\n",
-       
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       
-       
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '49572.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": ""
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
-      ]
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.Probabilistic</span></li><li><span>Microsoft.ML.Probabilistic.Compiler</span></li></ul></div><div></div></div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Infer.NET charge.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Infer.NET charge.\r\n"
     }
    ],
    "source": [
@@ -297,18 +185,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "FactorGraphHelper charge.\r\n"
-     ]
+     "name": "stdout",
+     "text": "FactorGraphHelper charge.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Graphviz disponible : False\r\n"
-     ]
+     "name": "stdout",
+     "text": "Graphviz disponible : True\r\n"
     }
    ],
    "source": [
@@ -363,32 +247,24 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Apres 7 succes / 3 echecs :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Apres 7 succes / 3 echecs :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Posterior Infer.NET = Beta(8,0, 4,0) ; mean = 0,667\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Posterior Infer.NET = Beta(8,0, 4,0) ; mean = 0,667\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Formule conjuguee   = Beta(8, 4) ; mean = 0,667\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Formule conjuguee   = Beta(8, 4) ; mean = 0,667\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  => Le moteur recouvre la forme analytique (cas conjugue favorable).\r\n"
-     ]
+     "name": "stdout",
+     "text": "  => Le moteur recouvre la forme analytique (cas conjugue favorable).\r\n"
     }
    ],
    "source": [
@@ -454,64 +330,21 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
+     "name": "stdout",
+     "text": "Modele Beta-Bernoulli : theta (Beta) -> 6 facteurs Bernoulli (un par tirage observe).\r\n"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-9053\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\DecInfer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\Dev\\CoursIA-9053\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\DecInfer\\Model_07_31_26_21_52_10_83.gv\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Modele Beta-Bernoulli : theta (Beta) -> 6 facteurs Bernoulli (un par tirage observe).\r\n"
-     ]
-    },
-    {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_07_31_26_21_52_10_83.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
-      ]
+      "text/html": "\r\n<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_08_19_26_03_11_19_98.svg</div>\r\n    <div style=\"max-width: 800px; overflow: auto;\">\r\n        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n<!-- Generated by graphviz version 14.1.3 (20260303.0454)\r\n -->\r\n<!-- Title: Model Pages: 1 -->\r\n<svg width=\"109pt\" height=\"354pt\"\r\n viewBox=\"0.00 0.00 109.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n<title>Model</title>\r\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 104.75,-349.5 104.75,4 -4,4\"/>\r\n<!-- node0 -->\r\n<g id=\"node1\" class=\"node\">\r\n<title>node0</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M83.5,-345.5C83.5,-345.5 17.25,-345.5 17.25,-345.5 11.25,-345.5 5.25,-339.5 5.25,-333.5 5.25,-333.5 5.25,-321.5 5.25,-321.5 5.25,-315.5 11.25,-309.5 17.25,-309.5 17.25,-309.5 83.5,-309.5 83.5,-309.5 89.5,-309.5 95.5,-315.5 95.5,-321.5 95.5,-321.5 95.5,-333.5 95.5,-333.5 95.5,-339.5 89.5,-345.5 83.5,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">Beta(1,1)[mean=0,5]</text>\r\n</g>\r\n<!-- node1 -->\r\n<g id=\"node2\" class=\"node\">\r\n<title>node1</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M65.38,-263.75C65.38,-263.75 35.38,-263.75 35.38,-263.75 29.38,-263.75 23.38,-257.75 23.38,-251.75 23.38,-251.75 23.38,-239.75 23.38,-239.75 23.38,-233.75 29.38,-227.75 35.38,-227.75 35.38,-227.75 65.38,-227.75 65.38,-227.75 71.38,-227.75 77.38,-233.75 77.38,-239.75 77.38,-239.75 77.38,-251.75 77.38,-251.75 77.38,-257.75 71.38,-263.75 65.38,-263.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n</g>\r\n<!-- node0&#45;&gt;node1 -->\r\n<g id=\"edge1\" class=\"edge\">\r\n<title>node0&#45;&gt;node1</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M50.38,-309.59C50.38,-299.68 50.38,-286.9 50.38,-275.46\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"53.88,-275.7 50.38,-265.7 46.88,-275.7 53.88,-275.7\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"56\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n</g>\r\n<!-- node2 -->\r\n<g id=\"node3\" class=\"node\">\r\n<title>node2</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M65.38,-190.75C65.38,-190.75 35.38,-190.75 35.38,-190.75 29.38,-190.75 23.38,-184.75 23.38,-178.75 23.38,-178.75 23.38,-166.75 23.38,-166.75 23.38,-160.75 29.38,-154.75 35.38,-154.75 35.38,-154.75 65.38,-154.75 65.38,-154.75 71.38,-154.75 77.38,-160.75 77.38,-166.75 77.38,-166.75 77.38,-178.75 77.38,-178.75 77.38,-184.75 71.38,-190.75 65.38,-190.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">theta</text>\r\n</g>\r\n<!-- node1&#45;&gt;node2 -->\r\n<g id=\"edge2\" class=\"edge\">\r\n<title>node1&#45;&gt;node2</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M50.38,-227.56C50.38,-219.98 50.38,-210.85 50.38,-202.29\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"53.88,-202.29 50.38,-192.29 46.88,-202.29 53.88,-202.29\"/>\r\n</g>\r\n<!-- node3 -->\r\n<g id=\"node4\" class=\"node\">\r\n<title>node3</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M65.38,-109C65.38,-109 35.38,-109 35.38,-109 29.38,-109 23.38,-103 23.38,-97 23.38,-97 23.38,-85 23.38,-85 23.38,-79 29.38,-73 35.38,-73 35.38,-73 65.38,-73 65.38,-73 71.38,-73 77.38,-79 77.38,-85 77.38,-85 77.38,-97 77.38,-97 77.38,-103 71.38,-109 65.38,-109\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Bernoulli</text>\r\n</g>\r\n<!-- node2&#45;&gt;node3 -->\r\n<g id=\"edge3\" class=\"edge\">\r\n<title>node2&#45;&gt;node3</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M50.38,-154.45C50.38,-144.52 50.38,-131.81 50.38,-120.45\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"53.88,-120.78 50.38,-110.78 46.88,-120.78 53.88,-120.78\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"65\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probTrue</text>\r\n</g>\r\n<!-- node4 -->\r\n<g id=\"node5\" class=\"node\">\r\n<title>node4</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M88.75,-36C88.75,-36 12,-36 12,-36 6,-36 0,-30 0,-24 0,-24 0,-12 0,-12 0,-6 6,0 12,0 12,0 88.75,0 88.75,0 94.75,0 100.75,-6 100.75,-12 100.75,-12 100.75,-24 100.75,-24 100.75,-30 94.75,-36 88.75,-36\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"50.38\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">recompenses[tirages]</text>\r\n</g>\r\n<!-- node3&#45;&gt;node4 -->\r\n<g id=\"edge4\" class=\"edge\">\r\n<title>node3&#45;&gt;node4</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M50.38,-72.81C50.38,-65.23 50.38,-56.1 50.38,-47.54\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"53.88,-47.54 50.38,-37.54 46.88,-47.54 53.88,-47.54\"/>\r\n</g>\r\n</g>\r\n</svg>\r\n\r\n    </div>\r\n</div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -570,60 +403,44 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Vraie moyenne du bras = 0,70 (inconnue de l algorithme)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Vraie moyenne du bras = 0,70 (inconnue de l algorithme)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  N tirages | posterior mean | ic 95% (approx)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  N tirages | posterior mean | ic 95% (approx)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  ------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "  ------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "          5 | 0,857          | [0,615, 1,000]\r\n"
-     ]
+     "name": "stdout",
+     "text": "          5 | 0,857          | [0,615, 1,000]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "         20 | 0,727          | [0,545, 0,909]\r\n"
-     ]
+     "name": "stdout",
+     "text": "         20 | 0,727          | [0,545, 0,909]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "         50 | 0,769          | [0,656, 0,883]\r\n"
-     ]
+     "name": "stdout",
+     "text": "         50 | 0,769          | [0,656, 0,883]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "        200 | 0,663          | [0,598, 0,728]\r\n"
-     ]
+     "name": "stdout",
+     "text": "        200 | 0,663          | [0,598, 0,728]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  => Le posterior se resserre autour de la vraie moyenne quand N croit.\r\n"
-     ]
+     "name": "stdout",
+     "text": "  => Le posterior se resserre autour de la vraie moyenne quand N croit.\r\n"
     }
    ],
    "source": [
@@ -697,11 +514,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Classe BayesArm definie (modele masque, moteur reutilise).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Classe BayesArm definie (modele masque, moteur reutilise).\r\n"
     }
    ],
    "source": [
@@ -794,25 +609,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compilation (1 fois, warmup BayesArm)        : 235,9 ms\r\n"
-     ]
+     "name": "stdout",
+     "text": "Compilation (1 fois, warmup BayesArm)        : 444,5 ms\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Re-inference (ObservedValue, compile reutilise) : 0,046 ms en moyenne sur 200 appels\r\n"
-     ]
+     "name": "stdout",
+     "text": "Re-inference (ObservedValue, compile reutilise) : 0,040 ms en moyenne sur 200 appels\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Ratio compilation / re-inference              : 5100x\r\n"
-     ]
+     "name": "stdout",
+     "text": "Ratio compilation / re-inference              : 11243x\r\n"
     }
    ],
    "source": [
@@ -883,109 +692,79 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Bandit : K=3 bras, T=200 pas. (theta* inconnu de l algorithme)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Bandit : K=3 bras, T=200 pas. (theta* inconnu de l algorithme)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  pas | bras joue | recompense | posterior means [b1 b2 b3]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  pas | bras joue | recompense | posterior means [b1 b2 b3]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  ---------------------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "  ---------------------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    1 |    bras 3    |     1      | [0,50 0,50 0,67]\r\n"
-     ]
+     "name": "stdout",
+     "text": "    1 |    bras 2    |     1      | [0,50 0,67 0,50]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    2 |    bras 2    |     0      | [0,50 0,33 0,67]\r\n"
-     ]
+     "name": "stdout",
+     "text": "    2 |    bras 2    |     0      | [0,50 0,50 0,50]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    3 |    bras 2    |     0      | [0,50 0,25 0,67]\r\n"
-     ]
+     "name": "stdout",
+     "text": "    3 |    bras 2    |     0      | [0,50 0,40 0,50]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    4 |    bras 1    |     1      | [0,67 0,25 0,67]\r\n"
-     ]
+     "name": "stdout",
+     "text": "    4 |    bras 1    |     1      | [0,67 0,40 0,50]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    5 |    bras 1    |     0      | [0,50 0,25 0,67]\r\n"
-     ]
+     "name": "stdout",
+     "text": "    5 |    bras 1    |     0      | [0,50 0,40 0,50]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   51 |    bras 3    |     1      | [0,33 0,44 0,76]\r\n"
-     ]
+     "name": "stdout",
+     "text": "   51 |    bras 3    |     1      | [0,33 0,56 0,70]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  101 |    bras 3    |     1      | [0,33 0,50 0,76]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  101 |    bras 3    |     1      | [0,33 0,59 0,76]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  200 |    bras 3    |     0      | [0,33 0,46 0,78]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  200 |    bras 3    |     0      | [0,33 0,57 0,78]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  ---------------------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "  ---------------------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Tirages par bras : [4, 11, 185]\r\n"
-     ]
+     "name": "stdout",
+     "text": "Tirages par bras : [7, 28, 165]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Recompense totale = 151/200 (optimal ~ 160)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Recompense totale = 147/200 (optimal ~ 160)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=> Thompson converge vers le bras 3 (le meilleur, theta*=0.8).\r\n"
-     ]
+     "name": "stdout",
+     "text": "=> Thompson converge vers le bras 3 (le meilleur, theta*=0.8).\r\n"
     }
    ],
    "source": [
@@ -1073,53 +852,39 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Regret cumule moyen sur 15 runs (T=200) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Regret cumule moyen sur 15 runs (T=200) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  epsilon-greedy (eps=0,1) : 17,5\r\n"
-     ]
+     "name": "stdout",
+     "text": "  epsilon-greedy (eps=0,1) : 17,5\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  UCB1                       : 19,3\r\n"
-     ]
+     "name": "stdout",
+     "text": "  UCB1                       : 19,3\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Thompson (Infer.NET)       : 6,4\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Thompson (Infer.NET)       : 6,1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=> Thompson (6,4) <= epsilon-greedy (17,5) : l exploration bayesienne\r\n"
-     ]
+     "name": "stdout",
+     "text": "=> Thompson (6,1) <= epsilon-greedy (17,5) : l exploration bayesienne\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   ciblee par le posterior exploite l incertitude la ou l information manque (Prong-B).\r\n"
-     ]
+     "name": "stdout",
+     "text": "   ciblee par le posterior exploite l incertitude la ou l information manque (Prong-B).\r\n"
     }
    ],
    "source": [
@@ -1273,46 +1038,34 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Apres 60 tirages Thompson, estimation P(bras i est le meilleur) sur 2000 echantillons :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Apres 60 tirages Thompson, estimation P(bras i est le meilleur) sur 2000 echantillons :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  bras 1 : P(meilleur) = 0,019  | posterior Beta(1,0,3,0) mean=0,250 (vraie 0,2)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  bras 1 : P(meilleur) = 0,004  | posterior Beta(2,0,4,0) mean=0,333 (vraie 0,2)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  bras 2 : P(meilleur) = 0,029  | posterior Beta(13,0,11,0) mean=0,542 (vraie 0,5)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  bras 2 : P(meilleur) = 0,021  | posterior Beta(6,0,5,0) mean=0,545 (vraie 0,5)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  bras 3 : P(meilleur) = 0,952  | posterior Beta(29,0,9,0) mean=0,763 (vraie 0,8)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  bras 3 : P(meilleur) = 0,975  | posterior Beta(41,0,8,0) mean=0,837 (vraie 0,8)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=> Bras declare meilleur : bras 3 (theta*=0,8).\r\n"
-     ]
+     "name": "stdout",
+     "text": "=> Bras declare meilleur : bras 3 (theta*=0,8).\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   Si P > 0.95, on peut arreter : identification du meilleur bras avec confiance.\r\n"
-     ]
+     "name": "stdout",
+     "text": "   Si P > 0.95, on peut arreter : identification du meilleur bras avec confiance.\r\n"
     }
    ],
    "source": [
@@ -1444,11 +1197,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 1 a completer : Thompson sur 4 bras (K=4).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 1 a completer : Thompson sur 4 bras (K=4).\r\n"
     }
    ],
    "source": [
@@ -1513,11 +1264,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 2 a completer : bandit non-stationnaire avec facteur d oubli.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 2 a completer : bandit non-stationnaire avec facteur d oubli.\r\n"
     }
    ],
    "source": [
@@ -1581,11 +1330,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 3 a completer : impact du prior informatif Beta(50,50) sur Thompson.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 3 a completer : impact du prior informatif Beta(50,50) sur Thompson.\r\n"
     }
    ],
    "source": [
@@ -1650,18 +1397,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 21.016418,
-   "end_time": "2026-07-31T19:52:24.144477",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "DecInfer-10-Thompson-Sampling.ipynb",
-   "output_path": "di10-measout.ipynb",
-   "parameters": {},
-   "start_time": "2026-07-31T19:52:03.128059",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
@@ -102,135 +102,23 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       
-       
-       "\r\n",
-       
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       
-       
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '49840.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": ""
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
-      ]
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.Probabilistic</span></li><li><span>Microsoft.ML.Probabilistic.Compiler</span></li></ul></div><div></div></div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Infer.NET charge !\r\n"
-     ]
+     "name": "stdout",
+     "text": "Infer.NET charge !\r\n"
     }
    ],
    "source": [
@@ -294,18 +182,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "FactorGraphHelper charge !\r\n"
-     ]
+     "name": "stdout",
+     "text": "FactorGraphHelper charge !\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Graphviz disponible : False\r\n"
-     ]
+     "name": "stdout",
+     "text": "Graphviz disponible : True\r\n"
     }
    ],
    "source": [
@@ -371,54 +255,39 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Options disponibles :\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Options disponibles :\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Nom            | Prix    | Securite | Conso   | Confort\r\n"
-     ]
+     "name": "stdout",
+     "text": "Nom            | Prix    | Securite | Conso   | Confort\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "---------------|---------|----------|---------|--------\r\n"
-     ]
+     "name": "stdout",
+     "text": "---------------|---------|----------|---------|--------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Economique A   |  15 000 |        3 |     5,0 |       6\r\n"
-     ]
+     "name": "stdout",
+     "text": "Economique A   |  15 000 |        3 |     5,0 |       6\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Familiale B    |  28 000 |        5 |     6,5 |       8\r\n"
-     ]
+     "name": "stdout",
+     "text": "Familiale B    |  28 000 |        5 |     6,5 |       8\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Sport C        |  45 000 |        4 |     9,0 |       7\r\n"
-     ]
+     "name": "stdout",
+     "text": "Sport C        |  45 000 |        4 |     9,0 |       7\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Hybride D      |  32 000 |        5 |     4,0 |       8\r\n"
-     ]
+     "name": "stdout",
+     "text": "Hybride D      |  32 000 |        5 |     4,0 |       8\r\n"
     }
    ],
    "source": [
@@ -589,98 +458,69 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Test d'independance : Prix vs Securite\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Test d'independance : Prix vs Securite\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Question : Preferez-vous A ou B ?\r\n"
-     ]
+     "name": "stdout",
+     "text": "Question : Preferez-vous A ou B ?\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Contexte 1 (Securite = 3 etoiles) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Contexte 1 (Securite = 3 etoiles) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  A : Prix = 15000 EUR\r\n"
-     ]
+     "name": "stdout",
+     "text": "  A : Prix = 15000 EUR\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  B : Prix = 20000 EUR\r\n"
-     ]
+     "name": "stdout",
+     "text": "  B : Prix = 20000 EUR\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  => Vous preferez probablement A (moins cher)\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "  => Vous preferez probablement A (moins cher)\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Contexte 2 (Securite = 5 etoiles) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Contexte 2 (Securite = 5 etoiles) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  A : Prix = 15000 EUR\r\n"
-     ]
+     "name": "stdout",
+     "text": "  A : Prix = 15000 EUR\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  B : Prix = 20000 EUR\r\n"
-     ]
+     "name": "stdout",
+     "text": "  B : Prix = 20000 EUR\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  => Preferez-vous toujours A ?\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "  => Preferez-vous toujours A ?\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Si votre reponse est la meme dans les deux contextes,\r\n"
-     ]
+     "name": "stdout",
+     "text": "Si votre reponse est la meme dans les deux contextes,\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "alors Prix et Securite sont preferentiellement independants.\r\n"
-     ]
+     "name": "stdout",
+     "text": "alors Prix et Securite sont preferentiellement independants.\r\n"
     }
    ],
    "source": [
@@ -785,62 +625,44 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Poids : Prix=35 %, Securite=30 %, Conso=20 %, Confort=15 %\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Poids : Prix=35 %, Securite=30 %, Conso=20 %, Confort=15 %\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Voiture        | v_prix | v_sec  | v_conso | v_conf | V_total\r\n"
-     ]
+     "name": "stdout",
+     "text": "Voiture        | v_prix | v_sec  | v_conso | v_conf | V_total\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "---------------|--------|--------|---------|--------|--------\r\n"
-     ]
+     "name": "stdout",
+     "text": "---------------|--------|--------|---------|--------|--------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Economique A   |  1,000 |  0,500 |   0,833 |  0,556 |  0,750\r\n"
-     ]
+     "name": "stdout",
+     "text": "Economique A   |  1,000 |  0,500 |   0,833 |  0,556 |  0,750\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Familiale B    |  0,567 |  1,000 |   0,583 |  0,778 |  0,732\r\n"
-     ]
+     "name": "stdout",
+     "text": "Familiale B    |  0,567 |  1,000 |   0,583 |  0,778 |  0,732\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Sport C        |  0,000 |  0,750 |   0,167 |  0,667 |  0,358\r\n"
-     ]
+     "name": "stdout",
+     "text": "Sport C        |  0,000 |  0,750 |   0,167 |  0,667 |  0,358\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Hybride D      |  0,433 |  1,000 |   1,000 |  0,778 |  0,768\r\n"
-     ]
+     "name": "stdout",
+     "text": "Hybride D      |  0,433 |  1,000 |   1,000 |  0,778 |  0,768\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "=> Meilleur choix : Hybride D\r\n"
-     ]
+     "name": "stdout",
+     "text": "\n=> Meilleur choix : Hybride D\r\n"
     }
    ],
    "source": [
@@ -955,95 +777,69 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Decomposition de la valeur multi-attributs :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Decomposition de la valeur multi-attributs :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Voiture        | Prix    | Securite | Conso   | Confort | Contributions\r\n"
-     ]
+     "name": "stdout",
+     "text": "Voiture        | Prix    | Securite | Conso   | Confort | Contributions\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "               | (w=35%) | (w=30%)  | (w=20%) | (w=15%) | ponderees\r\n"
-     ]
+     "name": "stdout",
+     "text": "               | (w=35%) | (w=30%)  | (w=20%) | (w=15%) | ponderees\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "---------------|---------|----------|---------|---------|---------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "---------------|---------|----------|---------|---------|---------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Economique A   |   0,350 |    0,150 |   0,167 |   0,083 | V=0,750\r\n"
-     ]
+     "name": "stdout",
+     "text": "Economique A   |   0,350 |    0,150 |   0,167 |   0,083 | V=0,750\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Familiale B    |   0,198 |    0,300 |   0,117 |   0,117 | V=0,732\r\n"
-     ]
+     "name": "stdout",
+     "text": "Familiale B    |   0,198 |    0,300 |   0,117 |   0,117 | V=0,732\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Sport C        |   0,000 |    0,225 |   0,033 |   0,100 | V=0,358\r\n"
-     ]
+     "name": "stdout",
+     "text": "Sport C        |   0,000 |    0,225 |   0,033 |   0,100 | V=0,358\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Hybride D      |   0,152 |    0,300 |   0,200 |   0,117 | V=0,768\r\n"
-     ]
+     "name": "stdout",
+     "text": "Hybride D      |   0,152 |    0,300 |   0,200 |   0,117 | V=0,768\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Interpretation :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Interpretation :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  - Chaque colonne = contribution ponderee de l'attribut (wi * vi)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - Chaque colonne = contribution ponderee de l'attribut (wi * vi)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  - V total = somme des contributions\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - V total = somme des contributions\r\n"
     }
    ],
    "source": [
@@ -1156,120 +952,84 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Situation de depart (pire option) :\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Situation de depart (pire option) :\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Prix : 45000 EUR (maximum)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Prix : 45000 EUR (maximum)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Securite : 1 etoile (minimum)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Securite : 1 etoile (minimum)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Consommation : 10 L/100km (maximum)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Consommation : 10 L/100km (maximum)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Confort : 1/10 (minimum)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Confort : 1/10 (minimum)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Classez les swings suivants par ordre de preference :\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Classez les swings suivants par ordre de preference :\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  A) Prix : 45000 -> 15000 (economie de 30000 EUR)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  A) Prix : 45000 -> 15000 (economie de 30000 EUR)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  B) Securite : 1 -> 5 etoiles\r\n"
-     ]
+     "name": "stdout",
+     "text": "  B) Securite : 1 -> 5 etoiles\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  C) Consommation : 10 -> 4 L/100km\r\n"
-     ]
+     "name": "stdout",
+     "text": "  C) Consommation : 10 -> 4 L/100km\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  D) Confort : 1 -> 10\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "  D) Confort : 1 -> 10\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Points swing et poids normalises :\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Points swing et poids normalises :\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Securite     : 100 points => poids = 35,7 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Securite     : 100 points => poids = 35,7 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Prix         :  90 points => poids = 32,1 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Prix         :  90 points => poids = 32,1 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Consommation :  50 points => poids = 17,9 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Consommation :  50 points => poids = 17,9 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Confort      :  40 points => poids = 14,3 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Confort      :  40 points => poids = 14,3 %\r\n"
     }
    ],
    "source": [
@@ -1364,11 +1124,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : swing weights et classement des appartements\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : swing weights et classement des appartements\r\n"
     }
    ],
    "source": [
@@ -1480,53 +1238,39 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Poids : k1=0.4, k2=0.35, k3=0.35 (sum = 1.1)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Poids : k1=0.4, k2=0.35, k3=0.35 (sum = 1.1)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Facteur K calcule : -0,2565\r\n"
-     ]
+     "name": "stdout",
+     "text": "Facteur K calcule : -0,2565\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Comparaison des formes :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Comparaison des formes :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  u = (1,1,1) : U_mult = 1,000\r\n"
-     ]
+     "name": "stdout",
+     "text": "  u = (1,1,1) : U_mult = 1,000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  u = (1,0.5,0.5) : U_mult = 0,707\r\n"
-     ]
+     "name": "stdout",
+     "text": "  u = (1,0.5,0.5) : U_mult = 0,707\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  u = (0.5,0.5,0.5) : U_mult = 0,525\r\n"
-     ]
+     "name": "stdout",
+     "text": "  u = (0.5,0.5,0.5) : U_mult = 0,525\r\n"
     }
    ],
    "source": [
@@ -1665,81 +1409,59 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Comparaison forme additive vs multiplicative :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Comparaison forme additive vs multiplicative :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Poids : w1=0.5, w2=0.5, K=0,0000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Poids : w1=0.5, w2=0.5, K=0,0000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Scenario                 | U Additif | U Multiplicatif | Diff\r\n"
-     ]
+     "name": "stdout",
+     "text": "Scenario                 | U Additif | U Multiplicatif | Diff\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "-------------------------|-----------|-----------------|------\r\n"
-     ]
+     "name": "stdout",
+     "text": "-------------------------|-----------|-----------------|------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Bon X, mauvais Y         |     0,550 |           0,550 | 0,000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Bon X, mauvais Y         |     0,550 |           0,550 | 0,000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Mauvais X, bon Y         |     0,550 |           0,550 | 0,000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Mauvais X, bon Y         |     0,550 |           0,550 | 0,000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Mediocre partout         |     0,500 |           0,500 | 0,000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Mediocre partout         |     0,500 |           0,500 | 0,000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Excellent partout        |     0,900 |           0,900 | 0,000\r\n"
-     ]
+     "name": "stdout",
+     "text": "Excellent partout        |     0,900 |           0,900 | 0,000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "K = 0 : Forme additive (pas d'interaction)\r\n"
-     ]
+     "name": "stdout",
+     "text": "K = 0 : Forme additive (pas d'interaction)\r\n"
     }
    ],
    "source": [
@@ -1874,11 +1596,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : forme multiplicative pour choix d'investissement\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : forme multiplicative pour choix d'investissement\r\n"
     }
    ],
    "source": [
@@ -1939,83 +1659,59 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== SMART : Choix de Carriere ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== SMART : Choix de Carriere ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Poids : Salaire=30 %, Equilibre=25 %, \r\n"
-     ]
+     "name": "stdout",
+     "text": "Poids : Salaire=30 %, Equilibre=25 %, \r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "        Passion=25 %, Securite=20 %\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "        Passion=25 %, Securite=20 %\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Carriere           | v_sal | v_wlb | v_pas | v_sec | V_total\r\n"
-     ]
+     "name": "stdout",
+     "text": "Carriere           | v_sal | v_wlb | v_pas | v_sec | V_total\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "-------------------|-------|-------|-------|-------|--------\r\n"
-     ]
+     "name": "stdout",
+     "text": "-------------------|-------|-------|-------|-------|--------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Startup            | 0,400 | 0,222 | 0,889 | 0,333 |  0,464\r\n"
-     ]
+     "name": "stdout",
+     "text": "Startup            | 0,400 | 0,222 | 0,889 | 0,333 |  0,464\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Grande Entreprise  | 0,800 | 0,556 | 0,444 | 0,778 |  0,646\r\n"
-     ]
+     "name": "stdout",
+     "text": "Grande Entreprise  | 0,800 | 0,556 | 0,444 | 0,778 |  0,646\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Fonction Publique  | 0,120 | 0,778 | 0,333 | 1,000 |  0,514\r\n"
-     ]
+     "name": "stdout",
+     "text": "Fonction Publique  | 0,120 | 0,778 | 0,333 | 1,000 |  0,514\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Freelance          | 1,000 | 0,444 | 0,778 | 0,222 |  0,650\r\n"
-     ]
+     "name": "stdout",
+     "text": "Freelance          | 1,000 | 0,444 | 0,778 | 0,222 |  0,650\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Recherche          | 0,000 | 0,667 | 1,000 | 0,556 |  0,528\r\n"
-     ]
+     "name": "stdout",
+     "text": "Recherche          | 0,000 | 0,667 | 1,000 | 0,556 |  0,528\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "=> Meilleur choix avec ces poids : Freelance (V = 0,650)\r\n"
-     ]
+     "name": "stdout",
+     "text": "\n=> Meilleur choix avec ces poids : Freelance (V = 0,650)\r\n"
     }
    ],
    "source": [
@@ -2132,81 +1828,59 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Profils de carriere - Comparaison multi-attributs :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Profils de carriere - Comparaison multi-attributs :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Carriere           | Salaire | Equilibre | Passion | Securite | Score\r\n"
-     ]
+     "name": "stdout",
+     "text": "Carriere           | Salaire | Equilibre | Passion | Securite | Score\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "-------------------|---------|-----------|---------|----------|------\r\n"
-     ]
+     "name": "stdout",
+     "text": "-------------------|---------|-----------|---------|----------|------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Startup            |    0,40 |      0,22 |    0,89 |     0,33 | 0,464\r\n"
-     ]
+     "name": "stdout",
+     "text": "Startup            |    0,40 |      0,22 |    0,89 |     0,33 | 0,464\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Grande Entreprise  |    0,80 |      0,56 |    0,44 |     0,78 | 0,646\r\n"
-     ]
+     "name": "stdout",
+     "text": "Grande Entreprise  |    0,80 |      0,56 |    0,44 |     0,78 | 0,646\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Fonction Publique  |    0,12 |      0,78 |    0,33 |     1,00 | 0,514\r\n"
-     ]
+     "name": "stdout",
+     "text": "Fonction Publique  |    0,12 |      0,78 |    0,33 |     1,00 | 0,514\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Freelance          |    1,00 |      0,44 |    0,78 |     0,22 | 0,650\r\n"
-     ]
+     "name": "stdout",
+     "text": "Freelance          |    1,00 |      0,44 |    0,78 |     0,22 | 0,650\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Recherche          |    0,00 |      0,67 |    1,00 |     0,56 | 0,528\r\n"
-     ]
+     "name": "stdout",
+     "text": "Recherche          |    0,00 |      0,67 |    1,00 |     0,56 | 0,528\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Poids : Salaire=30 %, Equilibre=25 %, Passion=25 %, Securite=20 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "Poids : Salaire=30 %, Equilibre=25 %, Passion=25 %, Securite=20 %\r\n"
     }
    ],
    "source": [
@@ -2288,75 +1962,54 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Analyse de sensibilite : poids du Salaire\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Analyse de sensibilite : poids du Salaire\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "w_salaire | Meilleur choix       | V_meilleur\r\n"
-     ]
+     "name": "stdout",
+     "text": "w_salaire | Meilleur choix       | V_meilleur\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "----------|----------------------|-----------\r\n"
-     ]
+     "name": "stdout",
+     "text": "----------|----------------------|-----------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "     10 % | Recherche            |     0,679\r\n"
-     ]
+     "name": "stdout",
+     "text": "     10 % | Recherche            |     0,679\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "     20 % | Grande Entreprise    |     0,623\r\n"
-     ]
+     "name": "stdout",
+     "text": "     20 % | Grande Entreprise    |     0,623\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "     30 % | Freelance            |     0,650\r\n"
-     ]
+     "name": "stdout",
+     "text": "     30 % | Freelance            |     0,650\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "     40 % | Freelance            |     0,700\r\n"
-     ]
+     "name": "stdout",
+     "text": "     40 % | Freelance            |     0,700\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "     50 % | Freelance            |     0,750\r\n"
-     ]
+     "name": "stdout",
+     "text": "     50 % | Freelance            |     0,750\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=> Le choix optimal change selon l'importance accordee au salaire.\r\n"
-     ]
+     "name": "stdout",
+     "text": "=> Le choix optimal change selon l'importance accordee au salaire.\r\n"
     }
    ],
    "source": [
@@ -2441,662 +2094,474 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Tableau de sensibilite : V selon le poids du Salaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "Tableau de sensibilite : V selon le poids du Salaire\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "w_salaire  |"
-     ]
+     "name": "stdout",
+     "text": "w_salaire  |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Startup   |"
-     ]
+     "name": "stdout",
+     "text": "Startup   |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Grande E  |"
-     ]
+     "name": "stdout",
+     "text": "Grande E  |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Fonction  |"
-     ]
+     "name": "stdout",
+     "text": "Fonction  |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Freelanc  |"
-     ]
+     "name": "stdout",
+     "text": "Freelanc  |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Recherch  |"
-     ]
+     "name": "stdout",
+     "text": "Recherch  |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "-----------|"
-     ]
+     "name": "stdout",
+     "text": "-----------|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "---------|"
-     ]
+     "name": "stdout",
+     "text": "---------|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "---------|"
-     ]
+     "name": "stdout",
+     "text": "---------|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "---------|"
-     ]
+     "name": "stdout",
+     "text": "---------|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "---------|"
-     ]
+     "name": "stdout",
+     "text": "---------|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "---------|"
-     ]
+     "name": "stdout",
+     "text": "---------|"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      10 % |"
-     ]
+     "name": "stdout",
+     "text": "      10 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,483 |"
-     ]
+     "name": "stdout",
+     "text": "   0,483 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,601 |"
-     ]
+     "name": "stdout",
+     "text": "   0,601 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,626 |"
-     ]
+     "name": "stdout",
+     "text": "   0,626 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,550 |"
-     ]
+     "name": "stdout",
+     "text": "   0,550 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,679 |"
-     ]
+     "name": "stdout",
+     "text": "   0,679 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Recherche"
-     ]
+     "name": "stdout",
+     "text": " <-- Recherche"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      15 % |"
-     ]
+     "name": "stdout",
+     "text": "      15 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,478 |"
-     ]
+     "name": "stdout",
+     "text": "   0,478 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,612 |"
-     ]
+     "name": "stdout",
+     "text": "   0,612 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,598 |"
-     ]
+     "name": "stdout",
+     "text": "   0,598 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,575 |"
-     ]
+     "name": "stdout",
+     "text": "   0,575 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,641 |"
-     ]
+     "name": "stdout",
+     "text": "   0,641 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Recherche"
-     ]
+     "name": "stdout",
+     "text": " <-- Recherche"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      20 % |"
-     ]
+     "name": "stdout",
+     "text": "      20 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,474 |"
-     ]
+     "name": "stdout",
+     "text": "   0,474 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,623 |"
-     ]
+     "name": "stdout",
+     "text": "   0,623 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,570 |"
-     ]
+     "name": "stdout",
+     "text": "   0,570 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,600 |"
-     ]
+     "name": "stdout",
+     "text": "   0,600 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,603 |"
-     ]
+     "name": "stdout",
+     "text": "   0,603 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Grande Entreprise"
-     ]
+     "name": "stdout",
+     "text": " <-- Grande Entreprise"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      25 % |"
-     ]
+     "name": "stdout",
+     "text": "      25 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,469 |"
-     ]
+     "name": "stdout",
+     "text": "   0,469 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,635 |"
-     ]
+     "name": "stdout",
+     "text": "   0,635 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,542 |"
-     ]
+     "name": "stdout",
+     "text": "   0,542 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,625 |"
-     ]
+     "name": "stdout",
+     "text": "   0,625 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,565 |"
-     ]
+     "name": "stdout",
+     "text": "   0,565 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Grande Entreprise"
-     ]
+     "name": "stdout",
+     "text": " <-- Grande Entreprise"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      30 % |"
-     ]
+     "name": "stdout",
+     "text": "      30 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,464 |"
-     ]
+     "name": "stdout",
+     "text": "   0,464 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,646 |"
-     ]
+     "name": "stdout",
+     "text": "   0,646 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,514 |"
-     ]
+     "name": "stdout",
+     "text": "   0,514 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,650 |"
-     ]
+     "name": "stdout",
+     "text": "   0,650 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,528 |"
-     ]
+     "name": "stdout",
+     "text": "   0,528 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Freelance"
-     ]
+     "name": "stdout",
+     "text": " <-- Freelance"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      35 % |"
-     ]
+     "name": "stdout",
+     "text": "      35 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,460 |"
-     ]
+     "name": "stdout",
+     "text": "   0,460 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,657 |"
-     ]
+     "name": "stdout",
+     "text": "   0,657 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,486 |"
-     ]
+     "name": "stdout",
+     "text": "   0,486 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,675 |"
-     ]
+     "name": "stdout",
+     "text": "   0,675 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,490 |"
-     ]
+     "name": "stdout",
+     "text": "   0,490 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Freelance"
-     ]
+     "name": "stdout",
+     "text": " <-- Freelance"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      40 % |"
-     ]
+     "name": "stdout",
+     "text": "      40 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,455 |"
-     ]
+     "name": "stdout",
+     "text": "   0,455 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,668 |"
-     ]
+     "name": "stdout",
+     "text": "   0,668 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,458 |"
-     ]
+     "name": "stdout",
+     "text": "   0,458 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,700 |"
-     ]
+     "name": "stdout",
+     "text": "   0,700 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,452 |"
-     ]
+     "name": "stdout",
+     "text": "   0,452 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Freelance"
-     ]
+     "name": "stdout",
+     "text": " <-- Freelance"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      45 % |"
-     ]
+     "name": "stdout",
+     "text": "      45 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,451 |"
-     ]
+     "name": "stdout",
+     "text": "   0,451 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,679 |"
-     ]
+     "name": "stdout",
+     "text": "   0,679 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,429 |"
-     ]
+     "name": "stdout",
+     "text": "   0,429 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,725 |"
-     ]
+     "name": "stdout",
+     "text": "   0,725 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,415 |"
-     ]
+     "name": "stdout",
+     "text": "   0,415 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Freelance"
-     ]
+     "name": "stdout",
+     "text": " <-- Freelance"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      50 % |"
-     ]
+     "name": "stdout",
+     "text": "      50 % |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,446 |"
-     ]
+     "name": "stdout",
+     "text": "   0,446 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,690 |"
-     ]
+     "name": "stdout",
+     "text": "   0,690 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,401 |"
-     ]
+     "name": "stdout",
+     "text": "   0,401 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,750 |"
-     ]
+     "name": "stdout",
+     "text": "   0,750 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0,377 |"
-     ]
+     "name": "stdout",
+     "text": "   0,377 |"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " <-- Freelance"
-     ]
+     "name": "stdout",
+     "text": " <-- Freelance"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Interpretation :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Interpretation :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "- Les valeurs en gras (max par colonne) indiquent le meilleur choix\r\n"
-     ]
+     "name": "stdout",
+     "text": "- Les valeurs en gras (max par colonne) indiquent le meilleur choix\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "- Freelance domine pour w_salaire > 25%\r\n"
-     ]
+     "name": "stdout",
+     "text": "- Freelance domine pour w_salaire > 25%\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "- Recherche domine pour w_salaire < 15%\r\n"
-     ]
+     "name": "stdout",
+     "text": "- Recherche domine pour w_salaire < 15%\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=> Le choix optimal depend fortement des preferences sur le salaire\r\n"
-     ]
+     "name": "stdout",
+     "text": "=> Le choix optimal depend fortement des preferences sur le salaire\r\n"
     }
    ],
    "source": [
@@ -3218,11 +2683,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : analyse de sensibilite multi-attributs\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : analyse de sensibilite multi-attributs\r\n"
     }
    ],
    "source": [
@@ -3305,117 +2768,84 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Distributions des attributs :\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Distributions des attributs :\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Projet A : Rendement ~ Gaussian(0,08, 0,01), Risque ~ Gaussian(0,15, 0,005)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Projet A : Rendement ~ Gaussian(0,08, 0,01), Risque ~ Gaussian(0,15, 0,005)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Projet B : Rendement ~ Gaussian(0,12, 0,02), Risque ~ Gaussian(0,25, 0,01)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Projet B : Rendement ~ Gaussian(0,12, 0,02), Risque ~ Gaussian(0,25, 0,01)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "E[U(Projet A)] = 0,5100\r\n"
-     ]
+     "name": "stdout",
+     "text": "E[U(Projet A)] = 0,5084\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "E[U(Projet B)] = 0,4852\r\n"
-     ]
+     "name": "stdout",
+     "text": "E[U(Projet B)] = 0,4861\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=> Decision optimale : Projet A\r\n"
-     ]
+     "name": "stdout",
+     "text": "=> Decision optimale : Projet A\r\n"
     }
    ],
    "source": [
@@ -3588,47 +3018,34 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Vos resultats SMART :\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Vos resultats SMART :\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Option 1 : V = 0,705\r\n"
-     ]
+     "name": "stdout",
+     "text": "Option 1 : V = 0,705\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Option 2 : V = 0,665\r\n"
-     ]
+     "name": "stdout",
+     "text": "Option 2 : V = 0,665\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Option 3 : V = 0,750\r\n"
-     ]
+     "name": "stdout",
+     "text": "Option 3 : V = 0,750\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Modifiez les valeurs ci-dessus pour votre probleme personnel !\r\n"
-     ]
+     "name": "stdout",
+     "text": "Modifiez les valeurs ci-dessus pour votre probleme personnel !\r\n"
     }
    ],
    "source": [
@@ -3739,141 +3156,99 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Inference Bayesienne des Poids MAUT ===\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Inference Bayesienne des Poids MAUT ===\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Choix observes : Securite, Prix, Securite, Securite, Prix\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Choix observes : Securite, Prix, Securite, Securite, Prix\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Prior (Dirichlet uniforme) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Prior (Dirichlet uniforme) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Pseudo-counts : [1, 1, 1, 1]\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Pseudo-counts : [1, 1, 1, 1]\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Posterior (apres 5 observations) :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Posterior (apres 5 observations) :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  w_Prix         = 33,3 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  w_Prix         = 33,3 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  w_Securite     = 44,4 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  w_Securite     = 44,4 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  w_Consommation = 11,1 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  w_Consommation = 11,1 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  w_Confort      = 11,1 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  w_Confort      = 11,1 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Distribution Dirichlet posterior : Dirichlet(3 4 1 1)\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nDistribution Dirichlet posterior : Dirichlet(3 4 1 1)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Comparaison :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Comparaison :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Swing weights (manuel)  : Prix=35%, Securite=30%, Conso=20%, Confort=15%\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Swing weights (manuel)  : Prix=35%, Securite=30%, Conso=20%, Confort=15%\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Inference bayesienne    : Prix=33 %, Securite=44 %, Conso=11 %, Confort=11 %\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Inference bayesienne    : Prix=33 %, Securite=44 %, Conso=11 %, Confort=11 %\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=> L'inference bayesienne revele les poids IMPLICITES du decideur !\r\n"
-     ]
+     "name": "stdout",
+     "text": "=> L'inference bayesienne revele les poids IMPLICITES du decideur !\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   Ici, la Securite domine (3/5 choix), confirmant son importance.\r\n"
-     ]
+     "name": "stdout",
+     "text": "   Ici, la Securite domine (3/5 choix), confirmant son importance.\r\n"
     }
    ],
    "source": [
@@ -4008,95 +3383,69 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Evolution des poids MAUT : Prior -> Posterior\r\n"
-     ]
+     "name": "stdout",
+     "text": "Evolution des poids MAUT : Prior -> Posterior\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Attribut      | Prior (uniforme) | Posterior (infere) | Evolution\r\n"
-     ]
+     "name": "stdout",
+     "text": "Attribut      | Prior (uniforme) | Posterior (infere) | Evolution\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------|------------------|--------------------|-----------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------|------------------|--------------------|-----------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Prix          |             25 % |             33,3 % |    0,083  ^\r\n"
-     ]
+     "name": "stdout",
+     "text": "Prix          |             25 % |             33,3 % |    0,083  ^\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Securite      |             25 % |             44,4 % |    0,194  ^\r\n"
-     ]
+     "name": "stdout",
+     "text": "Securite      |             25 % |             44,4 % |    0,194  ^\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Consommation  |             25 % |             11,1 % |   -0,139  v\r\n"
-     ]
+     "name": "stdout",
+     "text": "Consommation  |             25 % |             11,1 % |   -0,139  v\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Confort       |             25 % |             11,1 % |   -0,139  v\r\n"
-     ]
+     "name": "stdout",
+     "text": "Confort       |             25 % |             11,1 % |   -0,139  v\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Interpretation :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Interpretation :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  ^ : L'attribut est plus important que prevu (choisi souvent)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  ^ : L'attribut est plus important que prevu (choisi souvent)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  v : L'attribut est moins important que prevu\r\n"
-     ]
+     "name": "stdout",
+     "text": "  v : L'attribut est moins important que prevu\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  = : L'importance reste proche du prior\r\n"
-     ]
+     "name": "stdout",
+     "text": "  = : L'importance reste proche du prior\r\n"
     }
    ],
    "source": [
@@ -4178,134 +3527,71 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'D:\\Dev\\CoursIA-9055\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\DecInfer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Structure du modele bayesien des poids (rendu SVG ci-dessous).\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"D:\\Dev\\CoursIA-9055\\MyIA.AI.Notebooks\\Probas\\DecisionTheory\\DecInfer\\Model_07_31_26_21_55_08_64.gv\"\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Posterior : Dirichlet(2 3 1 1)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Structure du modele bayesien des poids (rendu SVG ci-dessous).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Lecture du factor graph :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - Le noeud Dirichlet (1,1,1,1) encode le prior uniforme sur les poids.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Posterior : Dirichlet(2 3 1 1)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - La variable latente `poids` (simplex de dimension 4) est tiree de ce prior.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - Chaque observation Discrete (choix_observes) conditionne ce prior.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Lecture du factor graph :\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - Le posterior Dirichlet(2 3 1 1) traduit les 3 choix observes (index 1 dominant).\r\n"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - Le noeud Dirichlet (1,1,1,1) encode le prior uniforme sur les poids.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - La variable latente `poids` (simplex de dimension 4) est tiree de ce prior.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - Chaque observation Discrete (choix_observes) conditionne ce prior.\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - Le posterior Dirichlet(2 3 1 1) traduit les 3 choix observes (index 1 dominant).\r\n"
-     ]
-    },
-    {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_07_31_26_21_55_08_64.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
-      ]
+      "text/html": "\r\n<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_08_19_26_03_11_09_25.svg</div>\r\n    <div style=\"max-width: 800px; overflow: auto;\">\r\n        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n<!-- Generated by graphviz version 14.1.3 (20260303.0454)\r\n -->\r\n<!-- Title: Model Pages: 1 -->\r\n<svg width=\"146pt\" height=\"354pt\"\r\n viewBox=\"0.00 0.00 146.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n<title>Model</title>\r\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 141.5,-349.5 141.5,4 -4,4\"/>\r\n<!-- node0 -->\r\n<g id=\"node1\" class=\"node\">\r\n<title>node0</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M84.62,-345.5C84.62,-345.5 52.88,-345.5 52.88,-345.5 46.88,-345.5 40.88,-339.5 40.88,-333.5 40.88,-333.5 40.88,-321.5 40.88,-321.5 40.88,-315.5 46.88,-309.5 52.88,-309.5 52.88,-309.5 84.62,-309.5 84.62,-309.5 90.62,-309.5 96.62,-315.5 96.62,-321.5 96.62,-321.5 96.62,-333.5 96.62,-333.5 96.62,-339.5 90.62,-345.5 84.62,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">vDirichlet1</text>\r\n</g>\r\n<!-- node1 -->\r\n<g id=\"node2\" class=\"node\">\r\n<title>node1</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M83.75,-263.75C83.75,-263.75 53.75,-263.75 53.75,-263.75 47.75,-263.75 41.75,-257.75 41.75,-251.75 41.75,-251.75 41.75,-239.75 41.75,-239.75 41.75,-233.75 47.75,-227.75 53.75,-227.75 53.75,-227.75 83.75,-227.75 83.75,-227.75 89.75,-227.75 95.75,-233.75 95.75,-239.75 95.75,-239.75 95.75,-251.75 95.75,-251.75 95.75,-257.75 89.75,-263.75 83.75,-263.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Random</text>\r\n</g>\r\n<!-- node0&#45;&gt;node1 -->\r\n<g id=\"edge1\" class=\"edge\">\r\n<title>node0&#45;&gt;node1</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M68.75,-309.59C68.75,-299.68 68.75,-286.9 68.75,-275.46\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"72.25,-275.7 68.75,-265.7 65.25,-275.7 72.25,-275.7\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"74.38\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">dist</text>\r\n</g>\r\n<!-- node2 -->\r\n<g id=\"node3\" class=\"node\">\r\n<title>node2</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M83.75,-190.75C83.75,-190.75 53.75,-190.75 53.75,-190.75 47.75,-190.75 41.75,-184.75 41.75,-178.75 41.75,-178.75 41.75,-166.75 41.75,-166.75 41.75,-160.75 47.75,-154.75 53.75,-154.75 53.75,-154.75 83.75,-154.75 83.75,-154.75 89.75,-154.75 95.75,-160.75 95.75,-166.75 95.75,-166.75 95.75,-178.75 95.75,-178.75 95.75,-184.75 89.75,-190.75 83.75,-190.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">poids</text>\r\n</g>\r\n<!-- node1&#45;&gt;node2 -->\r\n<g id=\"edge2\" class=\"edge\">\r\n<title>node1&#45;&gt;node2</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M68.75,-227.56C68.75,-219.98 68.75,-210.85 68.75,-202.29\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"72.25,-202.29 68.75,-192.29 65.25,-202.29 72.25,-202.29\"/>\r\n</g>\r\n<!-- node3 -->\r\n<g id=\"node4\" class=\"node\">\r\n<title>node3</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M83.75,-109C83.75,-109 53.75,-109 53.75,-109 47.75,-109 41.75,-103 41.75,-97 41.75,-97 41.75,-85 41.75,-85 41.75,-79 47.75,-73 53.75,-73 53.75,-73 83.75,-73 83.75,-73 89.75,-73 95.75,-79 95.75,-85 95.75,-85 95.75,-97 95.75,-97 95.75,-103 89.75,-109 83.75,-109\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Discrete</text>\r\n</g>\r\n<!-- node2&#45;&gt;node3 -->\r\n<g id=\"edge3\" class=\"edge\">\r\n<title>node2&#45;&gt;node3</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M68.75,-154.45C68.75,-144.52 68.75,-131.81 68.75,-120.45\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"72.25,-120.78 68.75,-110.78 65.25,-120.78 72.25,-120.78\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"77.38\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">probs</text>\r\n</g>\r\n<!-- node4 -->\r\n<g id=\"node5\" class=\"node\">\r\n<title>node4</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M125.5,-36C125.5,-36 12,-36 12,-36 6,-36 0,-30 0,-24 0,-24 0,-12 0,-12 0,-6 6,0 12,0 12,0 125.5,0 125.5,0 131.5,0 137.5,-6 137.5,-12 137.5,-12 137.5,-24 137.5,-24 137.5,-30 131.5,-36 125.5,-36\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"68.75\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">choix_observes[observations]</text>\r\n</g>\r\n<!-- node3&#45;&gt;node4 -->\r\n<g id=\"edge4\" class=\"edge\">\r\n<title>node3&#45;&gt;node4</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M68.75,-72.81C68.75,-65.03 68.75,-55.62 68.75,-46.86\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"72.25,-47.05 68.75,-37.05 65.25,-47.05 72.25,-47.05\"/>\r\n</g>\r\n</g>\r\n</svg>\r\n\r\n    </div>\r\n</div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -4496,18 +3782,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 13.520904,
-   "end_time": "2026-07-31T19:55:09.335498",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "DecInfer-4-Multi-Attribute.ipynb",
-   "output_path": "di4-out.ipynb",
-   "parameters": {},
-   "start_time": "2026-07-31T19:54:55.814594",
-   "version": "2.6.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {

--- a/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
+++ b/MyIA.AI.Notebooks/Probas/Infer/Infer-6-Debugging.ipynb
@@ -85,135 +85,23 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       
-       
-       "\r\n",
-       
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       
-       
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '49004.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": ""
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Microsoft.ML.Probabilistic, 0.4.2504.701</span></li><li><span>Microsoft.ML.Probabilistic.Compiler, 0.4.2504.701</span></li></ul></div></div>"
-      ]
+      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Microsoft.ML.Probabilistic</span></li><li><span>Microsoft.ML.Probabilistic.Compiler</span></li></ul></div><div></div></div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Infer.NET pret !\r\n"
-     ]
+     "name": "stdout",
+     "text": "Infer.NET pret !\r\n"
     }
    ],
    "source": [
@@ -333,25 +221,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "FactorGraphHelper charge !\r\n"
-     ]
+     "name": "stdout",
+     "text": "FactorGraphHelper charge !\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Graphviz disponible : False\r\n"
-     ]
+     "name": "stdout",
+     "text": "Graphviz disponible : True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Usage: display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()))\r\n"
-     ]
+     "name": "stdout",
+     "text": "Usage: display(HTML(FactorGraphHelper.GetLatestFactorGraphHtml()))\r\n"
     }
    ],
    "source": [
@@ -418,61 +300,44 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Erreur : Model has no support ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Erreur : Model has no support ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "SOLUTION : Elargir le prior\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nSOLUTION : Elargir le prior\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Resultat avec prior large : Gaussian.PointMass(100)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Resultat avec prior large : Gaussian.PointMass(100)\r\n"
     }
    ],
    "source": [
@@ -555,85 +420,36 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Visualisation : Modele avec prior large ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Visualisation : Modele avec prior large ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
+     "name": "stdout",
+     "text": "Resultat : Gaussian.PointMass(100)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-8892-infer6ep\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Le factor graph montre la structure simple : prior -> observation\r\n"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-8892-infer6ep\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_30_26_01_27_46_96.gv\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Resultat : Gaussian.PointMass(100)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Le factor graph montre la structure simple : prior -> observation\r\n"
-     ]
-    },
-    {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_07_30_26_01_27_46_96.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
-      ]
+      "text/html": "\r\n<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_08_19_26_03_10_41_48.svg</div>\r\n    <div style=\"max-width: 800px; overflow: auto;\">\r\n        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n<!-- Generated by graphviz version 14.1.3 (20260303.0454)\r\n -->\r\n<!-- Title: Model Pages: 1 -->\r\n<svg width=\"134pt\" height=\"199pt\"\r\n viewBox=\"0.00 0.00 134.00 199.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 194.75)\">\r\n<title>Model</title>\r\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-194.75 130,-194.75 130,4 -4,4\"/>\r\n<!-- node0 -->\r\n<g id=\"node1\" class=\"node\">\r\n<title>node0</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M42,-190.75C42,-190.75 12,-190.75 12,-190.75 6,-190.75 0,-184.75 0,-178.75 0,-178.75 0,-166.75 0,-166.75 0,-160.75 6,-154.75 12,-154.75 12,-154.75 42,-154.75 42,-154.75 48,-154.75 54,-160.75 54,-166.75 54,-166.75 54,-178.75 54,-178.75 54,-184.75 48,-190.75 42,-190.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"27\" y=\"-169.45\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">50</text>\r\n</g>\r\n<!-- node1 -->\r\n<g id=\"node2\" class=\"node\">\r\n<title>node1</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M78,-109C78,-109 48,-109 48,-109 42,-109 36,-103 36,-97 36,-97 36,-85 36,-85 36,-79 42,-73 48,-73 48,-73 78,-73 78,-73 84,-73 90,-79 90,-85 90,-85 90,-97 90,-97 90,-103 84,-109 78,-109\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"63\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n</g>\r\n<!-- node0&#45;&gt;node1 -->\r\n<g id=\"edge1\" class=\"edge\">\r\n<title>node0&#45;&gt;node1</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M34.63,-154.84C39.25,-144.62 45.24,-131.34 50.53,-119.63\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"53.58,-121.37 54.5,-110.82 47.2,-118.49 53.58,-121.37\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"55.78\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n</g>\r\n<!-- node3 -->\r\n<g id=\"node4\" class=\"node\">\r\n<title>node3</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M78,-36C78,-36 48,-36 48,-36 42,-36 36,-30 36,-24 36,-24 36,-12 36,-12 36,-6 42,0 48,0 48,0 78,0 78,0 84,0 90,-6 90,-12 90,-12 90,-24 90,-24 90,-30 84,-36 78,-36\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"63\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">100</text>\r\n</g>\r\n<!-- node1&#45;&gt;node3 -->\r\n<g id=\"edge3\" class=\"edge\">\r\n<title>node1&#45;&gt;node3</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M63,-72.81C63,-65.03 63,-55.62 63,-46.86\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"66.5,-47.05 63,-37.05 59.5,-47.05 66.5,-47.05\"/>\r\n</g>\r\n<!-- node2 -->\r\n<g id=\"node3\" class=\"node\">\r\n<title>node2</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M114,-190.75C114,-190.75 84,-190.75 84,-190.75 78,-190.75 72,-184.75 72,-178.75 72,-178.75 72,-166.75 72,-166.75 72,-160.75 78,-154.75 84,-154.75 84,-154.75 114,-154.75 114,-154.75 120,-154.75 126,-160.75 126,-166.75 126,-166.75 126,-178.75 126,-178.75 126,-184.75 120,-190.75 114,-190.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"99\" y=\"-169.45\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0,01</text>\r\n</g>\r\n<!-- node2&#45;&gt;node1 -->\r\n<g id=\"edge2\" class=\"edge\">\r\n<title>node2&#45;&gt;node1</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M91.37,-154.84C86.75,-144.62 80.76,-131.34 75.47,-119.63\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"78.8,-118.49 71.5,-110.82 72.42,-121.37 78.8,-118.49\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"97.78\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n</g>\r\n</g>\r\n</svg>\r\n\r\n    </div>\r\n</div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -707,102 +523,74 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Probleme : Convergence vers mode symetrique ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Probleme : Convergence vers mode symetrique ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Donnees : 60 points bimodaux, moyenne empirique = -0,124\r\n"
-     ]
+     "name": "stdout",
+     "text": "Donnees : 60 points bimodaux, moyenne empirique = -0,124\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- Cas 1 : Prior symetrique  means[k] ~ Gaussian(0, prec=10) ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "--- Cas 1 : Prior symetrique  means[k] ~ Gaussian(0, prec=10) ---\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  means[0] = 5,0737\r\n"
-     ]
+     "name": "stdout",
+     "text": "  means[0] = 5,0737\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  means[1] = 5,0737\r\n"
-     ]
+     "name": "stdout",
+     "text": "  means[1] = 5,0737\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  -> Collapse symetrique : les deux composantes sont identiques\r\n"
-     ]
+     "name": "stdout",
+     "text": "  -> Collapse symetrique : les deux composantes sont identiques\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "     (le modele ne parvient pas a separer les deux modes).\r\n"
-     ]
+     "name": "stdout",
+     "text": "     (le modele ne parvient pas a separer les deux modes).\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- Cas 2 : Prior asymetrique  means[0] ~ G(-5,1), means[1] ~ G(+5,1) ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "--- Cas 2 : Prior asymetrique  means[0] ~ G(-5,1), means[1] ~ G(+5,1) ---\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  means[0] = -5,1493\r\n"
-     ]
+     "name": "stdout",
+     "text": "  means[0] = -5,1493\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  means[1] = 4,9088\r\n"
-     ]
+     "name": "stdout",
+     "text": "  means[1] = 4,9088\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  -> Convergence : les deux modes sont separement identifies.\r\n"
-     ]
+     "name": "stdout",
+     "text": "  -> Convergence : les deux modes sont separement identifies.\r\n"
     }
    ],
    "source": [
@@ -987,67 +775,49 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Comparaison EP vs VMP ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Comparaison EP vs VMP ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Observations : 2,1, 1,9, 2,3, 2, 1,8, 2,2\r\n"
-     ]
+     "name": "stdout",
+     "text": "Observations : 2,1, 1,9, 2,3, 2, 1,8, 2,2\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Moyenne empirique : 2,050\r\n"
-     ]
+     "name": "stdout",
+     "text": "Moyenne empirique : 2,050\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "EP  : Gaussian(2,048, 0,0808)\r\n"
-     ]
+     "name": "stdout",
+     "text": "EP  : Gaussian(2,048, 0,0808)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "VMP : Gaussian(2,048, 0,07725)\r\n"
-     ]
+     "name": "stdout",
+     "text": "VMP : Gaussian(2,048, 0,07725)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Note : VMP tend a avoir une variance plus faible (sous-estime l'incertitude)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Note : VMP tend a avoir une variance plus faible (sous-estime l'incertitude)\r\n"
     }
    ],
    "source": [
@@ -1171,116 +941,84 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== EP vs VMP sur régression logistique (non-conjugué) ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== EP vs VMP sur régression logistique (non-conjugué) ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "algo  iters   mean[0]   mean[1]    flag\r\n"
-     ]
+     "name": "stdout",
+     "text": "algo  iters   mean[0]   mean[1]    flag\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "EP       1    30,500    27,000   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "EP       1    30,500    27,000   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "EP       2    -7,490    -6,986   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "EP       2    -7,490    -6,986   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "EP       5     1,507     1,191   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "EP       5     1,507     1,191   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "EP      10     1,446     1,138   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "EP      10     1,446     1,138   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "EP      50     1,446     1,138   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "EP      50     1,446     1,138   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "EP     100     1,446     1,138   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "EP     100     1,446     1,138   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "VMP      1     0,168     0,640   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "VMP      1     0,168     0,640   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "VMP      2     0,911     1,077   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "VMP      2     0,911     1,077   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "VMP      5     1,312     1,085   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "VMP      5     1,312     1,085   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "VMP     10     1,368     1,075   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "VMP     10     1,368     1,075   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "VMP     50     1,453     1,143   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "VMP     50     1,453     1,143   ok\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "VMP    100     1,453     1,143   ok\r\n"
-     ]
+     "name": "stdout",
+     "text": "VMP    100     1,453     1,143   ok\r\n"
     }
    ],
    "source": [
@@ -1374,11 +1112,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : diagnostiquer et corriger le melange gaussien\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : diagnostiquer et corriger le melange gaussien\r\n"
     }
    ],
    "source": [
@@ -1464,11 +1200,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : visualiser le factor graph EP vs VMP\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : visualiser le factor graph EP vs VMP\r\n"
     }
    ],
    "source": [
@@ -1541,68 +1275,49 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Outils de Debug ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Outils de Debug ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Options de debug activees :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Options de debug activees :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  - ShowProgress : affiche les iterations\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - ShowProgress : affiche les iterations\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  - ShowWarnings : affiche les avertissements du compilateur\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - ShowWarnings : affiche les avertissements du compilateur\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Compiling model..."
-     ]
+     "name": "stdout",
+     "text": "Compiling model..."
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "done.\r\n"
-     ]
+     "name": "stdout",
+     "text": "done.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Resultat : mu ~ Gaussian(2,5, 0,5)\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nResultat : mu ~ Gaussian(2,5, 0,5)\r\n"
     }
    ],
    "source": [
@@ -1701,86 +1416,36 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Visualisation du Factor Graph ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Visualisation du Factor Graph ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
+     "name": "stdout",
+     "text": "Resultat : hyperMean ~ Gaussian(3,74, 0,9106)\r\n"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-8892-infer6ep\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-8892-infer6ep\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_30_26_01_27_55_54.gv\"\n",
-      "\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Resultat : hyperMean ~ Gaussian(3,74, 0,9106)\r\n"
-     ]
-    },
-    {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_07_30_26_01_27_55_54.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
-      ]
+      "text/html": "\r\n<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_08_19_26_03_10_48_73.svg</div>\r\n    <div style=\"max-width: 800px; overflow: auto;\">\r\n        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n<!-- Generated by graphviz version 14.1.3 (20260303.0454)\r\n -->\r\n<!-- Title: Model Pages: 1 -->\r\n<svg width=\"280pt\" height=\"354pt\"\r\n viewBox=\"0.00 0.00 280.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n<title>Model</title>\r\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 276,-349.5 276,4 -4,4\"/>\r\n<!-- node0 -->\r\n<g id=\"node1\" class=\"node\">\r\n<title>node0</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M42,-345.5C42,-345.5 12,-345.5 12,-345.5 6,-345.5 0,-339.5 0,-333.5 0,-333.5 0,-321.5 0,-321.5 0,-315.5 6,-309.5 12,-309.5 12,-309.5 42,-309.5 42,-309.5 48,-309.5 54,-315.5 54,-321.5 54,-321.5 54,-333.5 54,-333.5 54,-339.5 48,-345.5 42,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"27\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0</text>\r\n</g>\r\n<!-- node1 -->\r\n<g id=\"node2\" class=\"node\">\r\n<title>node1</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M111,-263.75C111,-263.75 81,-263.75 81,-263.75 75,-263.75 69,-257.75 69,-251.75 69,-251.75 69,-239.75 69,-239.75 69,-233.75 75,-227.75 81,-227.75 81,-227.75 111,-227.75 111,-227.75 117,-227.75 123,-233.75 123,-239.75 123,-239.75 123,-251.75 123,-251.75 123,-257.75 117,-263.75 111,-263.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"96\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n</g>\r\n<!-- node0&#45;&gt;node1 -->\r\n<g id=\"edge1\" class=\"edge\">\r\n<title>node0&#45;&gt;node1</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M41.63,-309.59C50.93,-298.84 63.14,-284.73 73.64,-272.6\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"76.02,-275.19 79.92,-265.33 70.73,-270.61 76.02,-275.19\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"74.26\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n</g>\r\n<!-- node3 -->\r\n<g id=\"node4\" class=\"node\">\r\n<title>node3</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M115.25,-190.75C115.25,-190.75 76.75,-190.75 76.75,-190.75 70.75,-190.75 64.75,-184.75 64.75,-178.75 64.75,-178.75 64.75,-166.75 64.75,-166.75 64.75,-160.75 70.75,-154.75 76.75,-154.75 76.75,-154.75 115.25,-154.75 115.25,-154.75 121.25,-154.75 127.25,-160.75 127.25,-166.75 127.25,-166.75 127.25,-178.75 127.25,-178.75 127.25,-184.75 121.25,-190.75 115.25,-190.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"96\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">hyperMean</text>\r\n</g>\r\n<!-- node1&#45;&gt;node3 -->\r\n<g id=\"edge3\" class=\"edge\">\r\n<title>node1&#45;&gt;node3</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M96,-227.56C96,-219.98 96,-210.85 96,-202.29\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"99.5,-202.29 96,-192.29 92.5,-202.29 99.5,-202.29\"/>\r\n</g>\r\n<!-- node2 -->\r\n<g id=\"node3\" class=\"node\">\r\n<title>node2</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M114,-345.5C114,-345.5 84,-345.5 84,-345.5 78,-345.5 72,-339.5 72,-333.5 72,-333.5 72,-321.5 72,-321.5 72,-315.5 78,-309.5 84,-309.5 84,-309.5 114,-309.5 114,-309.5 120,-309.5 126,-315.5 126,-321.5 126,-321.5 126,-333.5 126,-333.5 126,-339.5 120,-345.5 114,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"99\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0,1</text>\r\n</g>\r\n<!-- node2&#45;&gt;node1 -->\r\n<g id=\"edge2\" class=\"edge\">\r\n<title>node2&#45;&gt;node1</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M98.36,-309.59C97.99,-299.68 97.51,-286.9 97.08,-275.46\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"100.59,-275.56 96.71,-265.7 93.59,-275.83 100.59,-275.56\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"112.3\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n</g>\r\n<!-- node4 -->\r\n<g id=\"node5\" class=\"node\">\r\n<title>node4</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M121,-109C121,-109 91,-109 91,-109 85,-109 79,-103 79,-97 79,-97 79,-85 79,-85 79,-79 85,-73 91,-73 91,-73 121,-73 121,-73 127,-73 133,-79 133,-85 133,-85 133,-97 133,-97 133,-103 127,-109 121,-109\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"106\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n</g>\r\n<!-- node3&#45;&gt;node4 -->\r\n<g id=\"edge4\" class=\"edge\">\r\n<title>node3&#45;&gt;node4</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M82.02,-154.51C77.04,-146.28 73.4,-136.22 76.75,-127 77.8,-124.1 79.21,-121.27 80.85,-118.56\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"83.6,-120.72 86.62,-110.56 77.93,-116.62 83.6,-120.72\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"85.38\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n</g>\r\n<!-- node7 -->\r\n<g id=\"node8\" class=\"node\">\r\n<title>node7</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M208,-109C208,-109 178,-109 178,-109 172,-109 166,-103 166,-97 166,-97 166,-85 166,-85 166,-79 172,-73 178,-73 178,-73 208,-73 208,-73 214,-73 220,-79 220,-85 220,-85 220,-97 220,-97 220,-103 214,-109 208,-109\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"193\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n</g>\r\n<!-- node3&#45;&gt;node7 -->\r\n<g id=\"edge7\" class=\"edge\">\r\n<title>node3&#45;&gt;node7</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M99.99,-154.29C102.83,-145.21 107.45,-134.47 114.75,-127 120.99,-120.61 138.59,-112.51 155.53,-105.72\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"156.42,-109.12 164.46,-102.23 153.88,-102.6 156.42,-109.12\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"123.38\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n</g>\r\n<!-- node6 -->\r\n<g id=\"node7\" class=\"node\">\r\n<title>node6</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M121,-36C121,-36 91,-36 91,-36 85,-36 79,-30 79,-24 79,-24 79,-12 79,-12 79,-6 85,0 91,0 91,0 121,0 121,0 127,0 133,-6 133,-12 133,-12 133,-24 133,-24 133,-30 127,-36 121,-36\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"106\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">3</text>\r\n</g>\r\n<!-- node4&#45;&gt;node6 -->\r\n<g id=\"edge6\" class=\"edge\">\r\n<title>node4&#45;&gt;node6</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M106,-72.81C106,-65.03 106,-55.62 106,-46.86\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"109.5,-47.05 106,-37.05 102.5,-47.05 109.5,-47.05\"/>\r\n</g>\r\n<!-- node5 -->\r\n<g id=\"node6\" class=\"node\">\r\n<title>node5</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M191.25,-190.75C191.25,-190.75 158.75,-190.75 158.75,-190.75 152.75,-190.75 146.75,-184.75 146.75,-178.75 146.75,-178.75 146.75,-166.75 146.75,-166.75 146.75,-160.75 152.75,-154.75 158.75,-154.75 158.75,-154.75 191.25,-154.75 191.25,-154.75 197.25,-154.75 203.25,-160.75 203.25,-166.75 203.25,-166.75 203.25,-178.75 203.25,-178.75 203.25,-184.75 197.25,-190.75 191.25,-190.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"175\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">hyperPrec</text>\r\n</g>\r\n<!-- node5&#45;&gt;node4 -->\r\n<g id=\"edge5\" class=\"edge\">\r\n<title>node5&#45;&gt;node4</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M160.03,-154.45C150.81,-143.79 138.81,-129.92 128.46,-117.96\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"131.12,-115.69 121.93,-110.42 125.83,-120.27 131.12,-115.69\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"159.26\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n</g>\r\n<!-- node5&#45;&gt;node7 -->\r\n<g id=\"edge8\" class=\"edge\">\r\n<title>node5&#45;&gt;node7</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M181,-154.45C182.79,-148.85 184.64,-142.58 186,-136.75 187.22,-131.53 188.29,-125.91 189.2,-120.48\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"192.66,-121.03 190.71,-110.61 185.74,-119.97 192.66,-121.03\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"202.66\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n</g>\r\n<!-- node8 -->\r\n<g id=\"node9\" class=\"node\">\r\n<title>node8</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M208,-36C208,-36 178,-36 178,-36 172,-36 166,-30 166,-24 166,-24 166,-12 166,-12 166,-6 172,0 178,0 178,0 208,0 208,0 214,0 220,-6 220,-12 220,-12 220,-24 220,-24 220,-30 214,-36 208,-36\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"193\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">5</text>\r\n</g>\r\n<!-- node7&#45;&gt;node8 -->\r\n<g id=\"edge9\" class=\"edge\">\r\n<title>node7&#45;&gt;node8</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M193,-72.81C193,-65.03 193,-55.62 193,-46.86\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"196.5,-47.05 193,-37.05 189.5,-47.05 196.5,-47.05\"/>\r\n</g>\r\n<!-- node9 -->\r\n<g id=\"node10\" class=\"node\">\r\n<title>node9</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M188,-345.5C188,-345.5 158,-345.5 158,-345.5 152,-345.5 146,-339.5 146,-333.5 146,-333.5 146,-321.5 146,-321.5 146,-315.5 152,-309.5 158,-309.5 158,-309.5 188,-309.5 188,-309.5 194,-309.5 200,-315.5 200,-321.5 200,-321.5 200,-333.5 200,-333.5 200,-339.5 194,-345.5 188,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"173\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">2</text>\r\n</g>\r\n<!-- node10 -->\r\n<g id=\"node11\" class=\"node\">\r\n<title>node10</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M190,-263.75C190,-263.75 160,-263.75 160,-263.75 154,-263.75 148,-257.75 148,-251.75 148,-251.75 148,-239.75 148,-239.75 148,-233.75 154,-227.75 160,-227.75 160,-227.75 190,-227.75 190,-227.75 196,-227.75 202,-233.75 202,-239.75 202,-239.75 202,-251.75 202,-251.75 202,-257.75 196,-263.75 190,-263.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"175\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Sample</text>\r\n</g>\r\n<!-- node9&#45;&gt;node10 -->\r\n<g id=\"edge10\" class=\"edge\">\r\n<title>node9&#45;&gt;node10</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M173.42,-309.59C173.67,-299.68 173.99,-286.9 174.28,-275.46\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"177.77,-275.79 174.52,-265.7 170.77,-275.61 177.77,-275.79\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"183.12\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">shape</text>\r\n</g>\r\n<!-- node10&#45;&gt;node5 -->\r\n<g id=\"edge12\" class=\"edge\">\r\n<title>node10&#45;&gt;node5</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M175,-227.56C175,-219.98 175,-210.85 175,-202.29\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"178.5,-202.29 175,-192.29 171.5,-202.29 178.5,-202.29\"/>\r\n</g>\r\n<!-- node11 -->\r\n<g id=\"node12\" class=\"node\">\r\n<title>node11</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M260,-345.5C260,-345.5 230,-345.5 230,-345.5 224,-345.5 218,-339.5 218,-333.5 218,-333.5 218,-321.5 218,-321.5 218,-315.5 224,-309.5 230,-309.5 230,-309.5 260,-309.5 260,-309.5 266,-309.5 272,-315.5 272,-321.5 272,-321.5 272,-333.5 272,-333.5 272,-339.5 266,-345.5 260,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"245\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0,5</text>\r\n</g>\r\n<!-- node11&#45;&gt;node10 -->\r\n<g id=\"edge11\" class=\"edge\">\r\n<title>node11&#45;&gt;node10</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M230.15,-309.59C220.72,-298.84 208.33,-284.73 197.69,-272.6\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"200.53,-270.53 191.31,-265.33 195.27,-275.15 200.53,-270.53\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"222.44\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">scale</text>\r\n</g>\r\n</g>\r\n</svg>\r\n\r\n    </div>\r\n</div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
+     "output_type": "stream",
      "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Fichiers nettoyes : 1\r\n"
-     ]
+     "text": "\nFichiers nettoyes : 2\r\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -1939,81 +1604,59 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Impact du choix des Priors ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Impact du choix des Priors ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Observations : 3 succes, 2 echecs\r\n"
-     ]
+     "name": "stdout",
+     "text": "Observations : 3 succes, 2 echecs\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "MLE (maximum de vraisemblance) : 0,60\r\n"
-     ]
+     "name": "stdout",
+     "text": "MLE (maximum de vraisemblance) : 0,60\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Uniforme Beta(1,1)        -> Posterieur : mean = 0,571\r\n"
-     ]
+     "name": "stdout",
+     "text": "Uniforme Beta(1,1)        -> Posterieur : mean = 0,571\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Centre Beta(2,2)          -> Posterieur : mean = 0,556\r\n"
-     ]
+     "name": "stdout",
+     "text": "Centre Beta(2,2)          -> Posterieur : mean = 0,556\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Informatif Beta(5,5)      -> Posterieur : mean = 0,533\r\n"
-     ]
+     "name": "stdout",
+     "text": "Informatif Beta(5,5)      -> Posterieur : mean = 0,533\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Biaise succes Beta(8,2)   -> Posterieur : mean = 0,733\r\n"
-     ]
+     "name": "stdout",
+     "text": "Biaise succes Beta(8,2)   -> Posterieur : mean = 0,733\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Observation : Le prior influence le posterieur, surtout avec peu de donnees.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Observation : Le prior influence le posterieur, surtout avec peu de donnees.\r\n"
     }
    ],
    "source": [
@@ -2115,11 +1758,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : test de depistage medical\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : test de depistage medical\r\n"
     }
    ],
    "source": [
@@ -2245,39 +1886,29 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Diagnostic : test ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Diagnostic : test ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Distribution : Gaussian(2,727, 0,9091)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Distribution : Gaussian(2,727, 0,9091)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Moyenne : 2,7273\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Moyenne : 2,7273\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Variance : 0,909091\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Variance : 0,909091\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     }
    ],
    "source": [
@@ -2437,106 +2068,51 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Visualisation : Modele corrige ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Visualisation : Modele corrige ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Problem with converting DOT to SVG\r\n"
-     ]
+     "name": "stdout",
+     "text": "Moyenne posterieure : Gaussian(49,48, 2,826)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exception message: \"An error occurred trying to start process 'dot' with working directory 'C:\\dev\\CoursIA-8892-infer6ep\\MyIA.AI.Notebooks\\Probas\\Infer'. Le fichier spécifié est introuvable.\"\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "If \"dot\" program is not installed, install Graphviz\n",
-      "and add a path to \"dot\" to the PATH\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "Le factor graph valide la structure :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "DOT file is saved to \"C:\\dev\\CoursIA-8892-infer6ep\\MyIA.AI.Notebooks\\Probas\\Infer\\Model_07_30_26_01_27_57_23.gv\"\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - 'moyenne' avec prior Gaussian large\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Moyenne posterieure : Gaussian(49,48, 2,826)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - 'precision' avec prior Gamma(2, 0.5)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "  - 'observation' conditionnee sur les deux parametres\r\n"
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Le factor graph valide la structure :\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - 'moyenne' avec prior Gaussian large\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - 'precision' avec prior Gamma(2, 0.5)\r\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "  - 'observation' conditionnee sur les deux parametres\r\n"
-     ]
-    },
-    {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "<div style='padding: 10px; border: 1px solid #f0ad4e; background: #fcf8e3; border-radius: 5px;'>\n",
-       "                <strong>Graphviz non disponible.</strong><br/>\n",
-       "                Copiez le contenu de <code>Model_07_30_26_01_27_57_23.gv</code> sur <a href='https://viz-js.com/' target='_blank'>viz-js.com</a>\n",
-       "            </div>"
-      ]
+      "text/html": "\r\n<div style=\"margin: 10px 0; padding: 10px; border: 1px solid #ddd; border-radius: 5px; background: #fafafa;\">\r\n    <div style=\"font-weight: bold; margin-bottom: 8px; color: #333;\">Model_08_19_26_03_10_50_34.svg</div>\r\n    <div style=\"max-width: 800px; overflow: auto;\">\r\n        <?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\r\n<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\"\r\n \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\r\n<!-- Generated by graphviz version 14.1.3 (20260303.0454)\r\n -->\r\n<!-- Title: Model Pages: 1 -->\r\n<svg width=\"278pt\" height=\"354pt\"\r\n viewBox=\"0.00 0.00 278.00 354.00\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\r\n<g id=\"graph0\" class=\"graph\" transform=\"scale(1 1) rotate(0) translate(4 349.5)\">\r\n<title>Model</title>\r\n<polygon fill=\"white\" stroke=\"none\" points=\"-4,4 -4,-349.5 274,-349.5 274,4 -4,4\"/>\r\n<!-- node0 -->\r\n<g id=\"node1\" class=\"node\">\r\n<title>node0</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M42,-345.5C42,-345.5 12,-345.5 12,-345.5 6,-345.5 0,-339.5 0,-333.5 0,-333.5 0,-321.5 0,-321.5 0,-315.5 6,-309.5 12,-309.5 12,-309.5 42,-309.5 42,-309.5 48,-309.5 54,-315.5 54,-321.5 54,-321.5 54,-333.5 54,-333.5 54,-339.5 48,-345.5 42,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"27\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">25</text>\r\n</g>\r\n<!-- node1 -->\r\n<g id=\"node2\" class=\"node\">\r\n<title>node1</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M114,-263.75C114,-263.75 84,-263.75 84,-263.75 78,-263.75 72,-257.75 72,-251.75 72,-251.75 72,-239.75 72,-239.75 72,-233.75 78,-227.75 84,-227.75 84,-227.75 114,-227.75 114,-227.75 120,-227.75 126,-233.75 126,-239.75 126,-239.75 126,-251.75 126,-251.75 126,-257.75 120,-263.75 114,-263.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"99\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n</g>\r\n<!-- node0&#45;&gt;node1 -->\r\n<g id=\"edge1\" class=\"edge\">\r\n<title>node0&#45;&gt;node1</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M42.27,-309.59C51.97,-298.84 64.71,-284.73 75.67,-272.6\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"78.14,-275.08 82.24,-265.31 72.94,-270.39 78.14,-275.08\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"75.94\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n</g>\r\n<!-- node3 -->\r\n<g id=\"node4\" class=\"node\">\r\n<title>node3</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M114,-190.75C114,-190.75 84,-190.75 84,-190.75 78,-190.75 72,-184.75 72,-178.75 72,-178.75 72,-166.75 72,-166.75 72,-160.75 78,-154.75 84,-154.75 84,-154.75 114,-154.75 114,-154.75 120,-154.75 126,-160.75 126,-166.75 126,-166.75 126,-178.75 126,-178.75 126,-184.75 120,-190.75 114,-190.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"99\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">moyenne</text>\r\n</g>\r\n<!-- node1&#45;&gt;node3 -->\r\n<g id=\"edge3\" class=\"edge\">\r\n<title>node1&#45;&gt;node3</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M99,-227.56C99,-219.98 99,-210.85 99,-202.29\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"102.5,-202.29 99,-192.29 95.5,-202.29 102.5,-202.29\"/>\r\n</g>\r\n<!-- node2 -->\r\n<g id=\"node3\" class=\"node\">\r\n<title>node2</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M114,-345.5C114,-345.5 84,-345.5 84,-345.5 78,-345.5 72,-339.5 72,-333.5 72,-333.5 72,-321.5 72,-321.5 72,-315.5 78,-309.5 84,-309.5 84,-309.5 114,-309.5 114,-309.5 120,-309.5 126,-315.5 126,-321.5 126,-321.5 126,-333.5 126,-333.5 126,-339.5 120,-345.5 114,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"99\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0,01</text>\r\n</g>\r\n<!-- node2&#45;&gt;node1 -->\r\n<g id=\"edge2\" class=\"edge\">\r\n<title>node2&#45;&gt;node1</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M99,-309.59C99,-299.68 99,-286.9 99,-275.46\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"102.5,-275.7 99,-265.7 95.5,-275.7 102.5,-275.7\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"113.62\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n</g>\r\n<!-- node4 -->\r\n<g id=\"node5\" class=\"node\">\r\n<title>node4</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M150,-109C150,-109 120,-109 120,-109 114,-109 108,-103 108,-97 108,-97 108,-85 108,-85 108,-79 114,-73 120,-73 120,-73 150,-73 150,-73 156,-73 162,-79 162,-85 162,-85 162,-97 162,-97 162,-103 156,-109 150,-109\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"135\" y=\"-88.28\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Gaussian</text>\r\n</g>\r\n<!-- node3&#45;&gt;node4 -->\r\n<g id=\"edge4\" class=\"edge\">\r\n<title>node3&#45;&gt;node4</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M106.81,-154.45C111.39,-144.31 117.27,-131.27 122.48,-119.73\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"125.66,-121.2 126.58,-110.65 119.28,-118.32 125.66,-121.2\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"127.78\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">mean</text>\r\n</g>\r\n<!-- node6 -->\r\n<g id=\"node7\" class=\"node\">\r\n<title>node6</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M150,-36C150,-36 120,-36 120,-36 114,-36 108,-30 108,-24 108,-24 108,-12 108,-12 108,-6 114,0 120,0 120,0 150,0 150,0 156,0 162,-6 162,-12 162,-12 162,-24 162,-24 162,-30 156,-36 150,-36\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"135\" y=\"-14.12\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">50</text>\r\n</g>\r\n<!-- node4&#45;&gt;node6 -->\r\n<g id=\"edge6\" class=\"edge\">\r\n<title>node4&#45;&gt;node6</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M135,-72.81C135,-65.03 135,-55.62 135,-46.86\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"138.5,-47.05 135,-37.05 131.5,-47.05 138.5,-47.05\"/>\r\n</g>\r\n<!-- node5 -->\r\n<g id=\"node6\" class=\"node\">\r\n<title>node5</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M186,-190.75C186,-190.75 156,-190.75 156,-190.75 150,-190.75 144,-184.75 144,-178.75 144,-178.75 144,-166.75 144,-166.75 144,-160.75 150,-154.75 156,-154.75 156,-154.75 186,-154.75 186,-154.75 192,-154.75 198,-160.75 198,-166.75 198,-166.75 198,-178.75 198,-178.75 198,-184.75 192,-190.75 186,-190.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"171\" y=\"-168.88\" font-family=\"Times New Roman,serif\" font-size=\"10.00\" fill=\"#0000ff\">precision</text>\r\n</g>\r\n<!-- node5&#45;&gt;node4 -->\r\n<g id=\"edge5\" class=\"edge\">\r\n<title>node5&#45;&gt;node4</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M163.19,-154.45C158.61,-144.31 152.73,-131.27 147.52,-119.73\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"150.72,-118.32 143.42,-110.65 144.34,-121.2 150.72,-118.32\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"169.78\" y=\"-129.15\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">precision</text>\r\n</g>\r\n<!-- node7 -->\r\n<g id=\"node8\" class=\"node\">\r\n<title>node7</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M186,-345.5C186,-345.5 156,-345.5 156,-345.5 150,-345.5 144,-339.5 144,-333.5 144,-333.5 144,-321.5 144,-321.5 144,-315.5 150,-309.5 156,-309.5 156,-309.5 186,-309.5 186,-309.5 192,-309.5 198,-315.5 198,-321.5 198,-321.5 198,-333.5 198,-333.5 198,-339.5 192,-345.5 186,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"171\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">2</text>\r\n</g>\r\n<!-- node8 -->\r\n<g id=\"node9\" class=\"node\">\r\n<title>node8</title>\r\n<path fill=\"#000000\" stroke=\"black\" d=\"M186,-263.75C186,-263.75 156,-263.75 156,-263.75 150,-263.75 144,-257.75 144,-251.75 144,-251.75 144,-239.75 144,-239.75 144,-233.75 150,-227.75 156,-227.75 156,-227.75 186,-227.75 186,-227.75 192,-227.75 198,-233.75 198,-239.75 198,-239.75 198,-251.75 198,-251.75 198,-257.75 192,-263.75 186,-263.75\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"171\" y=\"-243.03\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#ffffff\">Sample</text>\r\n</g>\r\n<!-- node7&#45;&gt;node8 -->\r\n<g id=\"edge7\" class=\"edge\">\r\n<title>node7&#45;&gt;node8</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M171,-309.59C171,-299.68 171,-286.9 171,-275.46\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"174.5,-275.7 171,-265.7 167.5,-275.7 174.5,-275.7\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"180\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">shape</text>\r\n</g>\r\n<!-- node8&#45;&gt;node5 -->\r\n<g id=\"edge9\" class=\"edge\">\r\n<title>node8&#45;&gt;node5</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M171,-227.56C171,-219.98 171,-210.85 171,-202.29\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"174.5,-202.29 171,-192.29 167.5,-202.29 174.5,-202.29\"/>\r\n</g>\r\n<!-- node9 -->\r\n<g id=\"node10\" class=\"node\">\r\n<title>node9</title>\r\n<path fill=\"none\" stroke=\"none\" d=\"M258,-345.5C258,-345.5 228,-345.5 228,-345.5 222,-345.5 216,-339.5 216,-333.5 216,-333.5 216,-321.5 216,-321.5 216,-315.5 222,-309.5 228,-309.5 228,-309.5 258,-309.5 258,-309.5 264,-309.5 270,-315.5 270,-321.5 270,-321.5 270,-333.5 270,-333.5 270,-339.5 264,-345.5 258,-345.5\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"243\" y=\"-324.2\" font-family=\"Times New Roman,serif\" font-size=\"9.00\" fill=\"#000000\">0,5</text>\r\n</g>\r\n<!-- node9&#45;&gt;node8 -->\r\n<g id=\"edge8\" class=\"edge\">\r\n<title>node9&#45;&gt;node8</title>\r\n<path fill=\"none\" stroke=\"black\" d=\"M227.73,-309.59C218.03,-298.84 205.29,-284.73 194.33,-272.6\"/>\r\n<polygon fill=\"black\" stroke=\"black\" points=\"197.06,-270.39 187.76,-265.31 191.86,-275.08 197.06,-270.39\"/>\r\n<text xml:space=\"preserve\" text-anchor=\"middle\" x=\"219.56\" y=\"-283.9\" font-family=\"Times New Roman,serif\" font-size=\"8.00\" fill=\"#d3d3d3\">scale</text>\r\n</g>\r\n</g>\r\n</svg>\r\n\r\n    </div>\r\n</div>"
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "warning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.3.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=10.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\nwarning CS1701: En supposant que la référence d'assembly 'Microsoft.AspNetCore.Html.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' utilisée par 'Microsoft.DotNet.Interactive' correspond à l'identité 'Microsoft.AspNetCore.Html.Abstractions, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' de 'Microsoft.AspNetCore.Html.Abstractions', il se peut que vous deviez fournir une stratégie runtime\r\n\r\n"
     }
    ],
    "source": [
@@ -2610,130 +2186,94 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Modele CASSE execute : prior trop concentre + Gamma(shape<1) + obs a 500 ecarts-types ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Modele CASSE execute : prior trop concentre + Gamma(shape<1) + obs a 500 ecarts-types ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Diagnostic : moyenne (modele casse) ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Diagnostic : moyenne (modele casse) ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Distribution : Gaussian(0,0002382, 0,01)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Distribution : Gaussian(0,0002382, 0,01)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Moyenne : 0,0002\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Moyenne : 0,0002\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Variance : 0,010000\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Variance : 0,010000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Diagnostic : precision (modele casse) ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Diagnostic : precision (modele casse) ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Distribution : Gamma(0,6003, 0,0007935)[mean=0,0004764]\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Distribution : Gamma(0,6003, 0,0007935)[mean=0,0004764]\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Moyenne : 0,0005\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Moyenne : 0,0005\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Variance : 0,000000\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Variance : 0,000000\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      ">>> Symptome : la moyenne posterieure (~0) n'a quasi pas bouge malgre l'observation a 50.\r\n"
-     ]
+     "name": "stdout",
+     "text": ">>> Symptome : la moyenne posterieure (~0) n'a quasi pas bouge malgre l'observation a 50.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    Le prior N(0, var=0.01) etait si concentre que la donnee n'a pas pu le deplacer :\r\n"
-     ]
+     "name": "stdout",
+     "text": "    Le prior N(0, var=0.01) etait si concentre que la donnee n'a pas pu le deplacer :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    le diagnostic de variance seul passe (0.01 est 'raisonnable'), MAIS la moyenne est\r\n"
-     ]
+     "name": "stdout",
+     "text": "    le diagnostic de variance seul passe (0.01 est 'raisonnable'), MAIS la moyenne est\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    a 500 ecarts-types de l'observation - echec de type 'prior ecrase la donnee', invisible\r\n"
-     ]
+     "name": "stdout",
+     "text": "    a 500 ecarts-types de l'observation - echec de type 'prior ecrase la donnee', invisible\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    au seul controle de variance. C'est ce constat qui motive les corrections de la cellule\r\n"
-     ]
+     "name": "stdout",
+     "text": "    au seul controle de variance. C'est ce constat qui motive les corrections de la cellule\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "    suivante (prior precision 0.01 -> la moyenne suit la donnee, comme on le verra : ~49.5).\r\n"
-     ]
+     "name": "stdout",
+     "text": "    suivante (prior precision 0.01 -> la moyenne suit la donnee, comme on le verra : ~49.5).\r\n"
     }
    ],
    "source": [
@@ -2795,60 +2335,44 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "=== Exercice : Debugger ce modele ===\r\n"
-     ]
+     "name": "stdout",
+     "text": "=== Exercice : Debugger ce modele ===\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Corrections appliquees :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Corrections appliquees :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "1. Prior sur moyenne : precision 0.01 (large) au lieu de 100 (etroit)\r\n"
-     ]
+     "name": "stdout",
+     "text": "1. Prior sur moyenne : precision 0.01 (large) au lieu de 100 (etroit)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "2. Prior sur precision : Gamma(2, 0.5) au lieu de Gamma(0.1, 0.1)\r\n"
-     ]
+     "name": "stdout",
+     "text": "2. Prior sur precision : Gamma(2, 0.5) au lieu de Gamma(0.1, 0.1)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "3. Variables nommees avec .Named()\r\n"
-     ]
+     "name": "stdout",
+     "text": "3. Variables nommees avec .Named()\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Resultats : moyenne ~ Gaussian(49,48, 2,826), precision ~ Gamma(2, 0,4876)[mean=0,9752]\r\n"
-     ]
+     "name": "stdout",
+     "text": "Resultats : moyenne ~ Gaussian(49,48, 2,826), precision ~ Gamma(2, 0,4876)[mean=0,9752]\r\n"
     }
    ],
    "source": [
@@ -3030,11 +2554,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer\r\n"
     }
    ],
    "source": [
@@ -3169,11 +2691,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : debugging regression bayesienne\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : debugging regression bayesienne\r\n"
     }
    ],
    "source": [
@@ -3275,18 +2795,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 16.302891,
-   "end_time": "2026-06-06T14:50:48.895337+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "Infer-6-Debugging.ipynb",
-   "output_path": "Infer-6-Debugging_output.ipynb",
-   "parameters": {},
-   "start_time": "2026-06-06T14:50:32.592446+00:00",
-   "version": "2.6.0"
   },
   "polyglot_notebook": {
    "kernelInfo": {

--- a/scripts/notebook_tools/twin_pairs.d/probas-6-debugging.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-6-debugging.yaml
@@ -26,6 +26,13 @@
       csharp_sha: 7a620e4f99806eb368c890e2ada2e9f8c83a0b2e
       content_python_sha: b665bf080f937710e18c735a31e46a486b3c9bedcf860ab487f38dc7304f3e44
       content_csharp_sha: adcfbaacdc960af3d68454b59d768b8a91ccbdf57b141e3a4f572adbc998cf16
+    - date: "2026-08-19"
+      by: myia-ai-01:CoursIA
+      reason: "Re-exec C#-only (#11685, residu de l'incident Graphviz #11622/#11691) : le cote Infer portait 9 hits de banniere d'echec d'outil (dot absent du PATH au moment de sa derniere execution), donc 3 graphes de facteurs manquants. Re-execution reelle kernel .net-csharp avec dot 14.1.3 sur le PATH (19/19 cellules, 0 erreur), puis strip_probe_banner.py --apply, puis cet --update en dernier (#8957). Sources byte-identiques (55040 caracteres inchanges) : aucune cellule source touchee, seules les sorties ont bouge -- blocs SVG 0 -> 3 (c10 4046 B, c28 12185 B, c41 9756 B), volume de sorties +20514 B. Cote python NON touche : python_sha et content_python_sha inchanges."
+      python_sha: 76d2f1fabc983e6752960b198ab567e627ce1f79
+      csharp_sha: a02e8a388fdca12b792594f7b5af9a3444a64b34
+      content_python_sha: b665bf080f937710e18c735a31e46a486b3c9bedcf860ab487f38dc7304f3e44
+      content_csharp_sha: a13e1ba953f4e778e78ffffdcea52b97e91ca4e17a7ac97239983f28460d17f8
   known_differences:
   - 'Socle pedagogique commun : debugging de modeles probabilistes (diagnostics d''inference) modelise dans les deux stacks.'
   - 'Moteurs d''inference distincts : C# Infer.NET = inference deterministe approchee (Expectation Propagation / Variational


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-ai-01:CoursIA — prev: MED/guard #11686

## Le résidu que #11691 avait explicitement laissé

#11691 a réparé les deux notebooks abîmés par le merge `9881553` et a nommé ce qu'il ne couvrait pas : trois notebooks portaient des bannières Graphviz **antérieures** à cet incident, jamais réparées. Les voici.

Ils étaient restés en plan pour une raison matérielle : ils tournent tous sur le kernel `.net-csharp`, et `dot` doit être **sur le PATH du processus qui lance le kernel**. po-2023 a établi firsthand que l'installation échouait chez eux (choco cassé, winget absent, GitLab 404, releases interrompues) — verdict `RECOVERABLE-MACHINE`, que j'ai accepté. ai-01 est la seule lane du cluster où `dot` et le kernel .NET sont vérifiés ensemble, donc j'ai pris le grain.

## Ce qui était perdu : cinq graphes de facteurs, pas trois bannières

C'est le point que le compte de bannières masquait. Chaque bannière ne signalait pas un message parasite à côté d'un rendu correct — elle **remplaçait** le rendu :

| Notebook | cellule | `text/html` avant | après |
|---|---|---|---|
| `Infer-6-Debugging` | 10 | 323 B | **4 046 B** |
| | 28 | 323 B | **12 185 B** |
| | 41 | 323 B | **9 756 B** |
| `DecInfer-4-Multi-Attribute` | 46 | 323 B | **5 257 B** |
| `DecInfer-10-Thompson-Sampling` | 9 | 323 B | **5 244 B** |

**Blocs `<svg>` : 0 → 5.** Les 323 B identiques partout sont le squelette HTML vide que le helper émet quand `dot` manque. Un notebook de *debugging de modèles probabilistes* dont les trois graphes de facteurs sont absents ne montre pas ce qu'il enseigne.

## La réparation — Stop & Repair, aucune sortie retouchée

```
Infer-6-Debugging              19/19 cellules, 0 erreur, 20,5 s
DecInfer-4-Multi-Attribute     22/22 cellules, 0 erreur, 13,6 s
DecInfer-10-Thompson-Sampling  13/13 cellules, 0 erreur, 26,0 s
```

Kernel `.net-csharp` via `dotnet_executor.py`, `dot` 14.1.3 sur le PATH. Puis `strip_probe_banner.py --apply` (obligatoire après toute re-exec .NET), puis — **et seulement alors, après le commit des notebooks** — `check_twin_parity.py --update` (#8957).

L'ordre a une conséquence mesurable ici : le rebaseline lit le blob **à HEAD**, pas l'arbre de travail. Lancé avant le commit il rendait « no-op, les SHAs enregistrés sont déjà ceux du carnet » — une attestation vide, du même genre que le dégât n°3 de #11691. C'est l'ordre inverse qui produit un `csharp_sha` n'ayant jamais été le blob de rien.

## Contrôle anti-#11351 : où sont partis les octets ?

Le diff affiche **−2 401 lignes**. Mon propre garde-fou dit qu'un tel chiffre est un signal, pas un détail — donc le compte par cellule et par type MIME, contre la **base de fusion** :

```
                              sources          sorties
Infer-6-Debugging       55040 -> 55040      11508 -> 32022   (+20514)
DecInfer-4              53050 -> 53050      13295 -> 14579   (+1284)
DecInfer-10             31637 -> 31637       7472 ->  8742   (+1270)
```

**Aucune source n'a bougé d'un octet** sur les trois — c'est une re-exécution pure, C.3 respecté. Le volume de **sorties augmente** partout. Le seul retrait est la bannière `probeAddresses` (3 389 → 194 B par notebook, strip mandaté par L532).

Les −2 401 lignes sont donc une re-sérialisation JSON des tableaux de flux : les bannières d'échec étaient des dizaines de lignes courtes, les SVG sont des chaînes longues. **Zéro livrable rendu perdu.**

## État après

```
bannières d'outil    : 15 -> 0
chemins machine      : 10 -> 0
output_type=error    : 0
execution_count nul  : 0
```

Les trois notebooks disparaissent du sweep `check_output_failure_text.py --all` (120 lignes restantes, aucune n'est l'un d'eux). Le garde en mode ratchet — celui livré par #11686, celui qui aurait bloqué le merge fautif — passe.

```
check_twin_parity --verify-recorded-sha : 157 paires, OK=157 MISMATCH=0
check_twin_parity --check               : 157 paires, DRIFT=0 MISSING=0
pytest test_twin_registry_integrity.py  : 30 passed
```

`content_python_sha` est inchangé : le jumeau PyMC n'a pas été touché, seul le côté C# a bougé, et le registre le dit.

## Un à-côté, nommé plutôt que laissé traîner

La re-exécution dépose à côté du notebook une paire `Model_<horodatage>.gv` + `.svg` — le SVG qui compte est **dans la sortie de cellule**, ces copies sur disque sont transitoires. Le nom étant horodaté, chaque re-exec en dépose une nouvelle. Rien dans le dépôt n'y fait référence (`git ls-files '*.gv'` est vide), donc `.gitignore`, avec le raisonnement écrit sur place.

## Ce que cette PR ferme

Le fil ouvert par le user sur `9881553` avait trois brins : le dégât (#11691, mergé), le garde CI qui aurait dû l'attraper (#11686, mergé), et le résidu — celui-ci. `Closes #11685`.

Closes #11685. See #11691. See #8957. See #11112.
