### PR TITLE
ci(lean,#11699): proof-integrity gate on mimo_lean (tranche 1 / 16 lacs non-cables)

### DIFF
--- a/.github/workflows/lean-mimo.yml
+++ b/.github/workflows/lean-mimo.yml
@@ -12,6 +12,20 @@ name: Lean CI (mimo_lean)
 # sorry-free. This CI guards that NO new `sorry` is introduced
 # (no false positive on prose mentions; catches any new sorry, including
 # `exact sorry`, `theorem foo := by sorry`, `def f : T := sorry`, `<;> sorry`).
+#
+# Proof-integrity gate (See #11699, B.3 criterion). Catches forbidden axioms
+# (transitive `sorryAx`, `native_decide.*`, `Classical.choice` whitelist
+# defaults) that the textual sorry counter cannot see. mimo_lean carries 2
+# `noncomputable def` (Lmmse.lean: B_ρ ; Objective.lean: mimoObj) whose closure
+# pulls `Classical.choice` — whitelisted by default in lean-axiom.yml, so the
+# gate does NOT need an explicit `allow-axioms` entry for those two. The
+# `*` target-modules picks up every compiled module (Bridge, Converse,
+# Descent, Lmmse, NormTails, Objective + _en siblings) via runtime derivation
+# (#10889), so adding a new file lands in the gate by construction -- no
+# hand-maintained list to drift. `include-i18n-siblings: "true"` keeps the 6
+# `_en` mirrors in scope (byte-identical to FR, but enumerated by
+# `#print axioms` independently -- a gate that omits half a bilingual pair
+# is a #8782 pitfall 2).
 
 on:
   push:
@@ -41,3 +55,44 @@ jobs:
       display-name: mimo_lean
       sorry-baseline: "0"
       sorry-filter-mode: real
+
+  # Level 3 proof-integrity gate (criterion B.3 of pr-review-discipline).
+  # Closes #11699 tranche 1 — mimo_lean was not wired into the gate before
+  # this PR (5 of 21 lakes were wired: conway, galois, grothendieck, knot,
+  # sensitivity). `target-modules: "*"` (issue #10889) is the runtime
+  # derivation: the gate walks every compiled .lean under the project root
+  # (minus .lake/.git/lakefile*/lean-toolchain) and inspects each by
+  # construction. `include-i18n-siblings: "true"` enumerates the 6 `_en`
+  # mirrors too — their axioms are byte-identical to FR but
+  # `#print axioms` resolves them independently (See #8782 pitfall 2).
+  # `allow-axioms: ""` — `Classical.choice` is already in the default
+  # whitelist of `lean-axiom.yml`, which covers the 2 `noncomputable def`
+  # of mimo_lean (Lmmse.lean: B_ρ ; Objective.lean: mimoObj) without a
+  # hand-maintained entry. `fail-on-sorry: true` — the lake ships at
+  # baseline 0 (count_code_sorry.py --lake mimo_lean: code_sorry 0,
+  # distinct_code_sorry 0), so any transitive `sorryAx` introduction
+  # must fail the run. Native `Decide.*`/`native_decide.*` will also
+  # fail if introduced (no current usage, measured by `grep -E
+  # 'native_decide|decide' MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean/
+  # *.lean` — 0 hits).
+  #
+  # NOTE: mimo_lean is the FIRST wired lake with a flat layout (all .lean at
+  # the lake root, namespace `Mimo` opens per-file — no `Mimo/` subdir).
+  # `discover_modules(project, None)` therefore yields `{Bridge, Converse,
+  # Descent, Lmmse, NormTails, Objective, _en siblings}` (12 modules) rather
+  # than the `{Mimo.Bridge, Mimo.Converse, ...}` a subdir layout would give.
+  # The runtime gate passes these as-is to LeanVerifier — no namespace prefix
+  # required. (Verified via `python scripts/lean/check_target_coverage.py`
+  # with `--project-path MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean`,
+  # walk = 12 modules.) No advisory target-coverage job below because the
+  # `--lib-root` heuristic in `check_target_coverage.py` does not cover a
+  # flat lake; sensitivity_lean (also wired) takes the same shortcut.
+  proof-integrity:
+    uses: jsboige/CoursIA/.github/workflows/lean-axiom.yml@main
+    with:
+      project-path: MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean
+      display-name: mimo_lean
+      target-modules: "*"
+      include-i18n-siblings: "true"
+      allow-axioms: ""
+      fail-on-sorry: true

--- a/docs/reference/lean-axiom-coverage.md
+++ b/docs/reference/lean-axiom-coverage.md
@@ -193,20 +193,25 @@ forbidden union : []
 
 | Lake | Workflow `lean-*.yml` | Appelle `lean-axiom.yml` ? | Verdict au gate |
 |---|---|---|---|
-| `knot_lean` | `lean-knot.yml` | OUI (pilote) | GREEN post-#8725 |
-| `conway_lean` | `lean-conway.yml` | **NON** | serait RED (113 tactic uses) |
-| 14 autres lacs | workflows existants | **NON** | GREEN si câblés (sauf 3 borderline sur `Classical.choice`) |
+| `knot_lean` | `lean-knot.yml` | OUI (pilote, c.948) | GREEN post-#8725 |
+| `mimo_lean` | `lean-mimo.yml` | OUI (tranche 1, PR #11699 c.367) | GREEN par défaut (2 `noncomputable def` ⇒ `Classical.choice`, whitelist par défaut `lean-axiom.yml` ; `native_decide`/`sorryAx` absents — mesurés firsthand 2026-08-19 sur commit `1ac8a40e6`) |
+| `conway_lean` | `lean-conway.yml` | OUI (c.951, post-#8746) | GREEN (19 noms `native_decide` whitelistés, `target-modules: "*"` runtime derivation #10889, `fail-on-sorry: false` audit job pour les 8 sorries p4) |
+| `galois_lean` | `lean-galois.yml` | OUI (c.1039) | GREEN (footprint mesuré = whitelist par défaut : `[propext, Classical.choice, Quot.sound]`) |
+| `grothendieck_lean` | `lean-grothendieck.yml` | OUI (post-#8941) | GREEN avec `Classical.choice` whitelisté explicitement (théorie intrinsèquement non-constructive, §3.5) |
+| `sensitivity_lean` | `lean-sensitivity.yml` | OUI (c.101) | GREEN (0 `native_decide`, `Classical.choice` whitelist par défaut) |
+| 15 autres lacs | workflows existants | **NON** | GREEN si câblés (sauf 3 borderline sur `Classical.choice` : `sudoku_lean`, `learning_theory_lean`, `decision_theory_lean`) |
 
-Le câblage du gate sur les lacs non-pilotes est un travail séparé qui sort du scope #8738 (chaque workflow lake est un livrable à part avec son `target-modules` adapté).
+Le câblage du gate sur les lacs non-pilotes est un travail séparé qui sort du scope #8738 (chaque workflow lake est un livrable à part avec son `target-modules` adapté). Voir #11699 pour la roadmap tranche-par-tranche des 15 restants (mimo_lean = tranche 1 livrée par PR de cette PR).
 
 ## 5. Acceptance step 3 — verdict
 
 - [x] **knot_lean re-mesuré** : GREEN post-#8725 (cf. [#8738](https://github.com/jsboige/CoursIA/issues/8738) body §« Mesure firsthand »)
-- [x] **conway_lean re-mesuré** : RED — whitelist `native_decide.*` (19 noms explicites) recommandée avec issue nommée `#8749` (triage THEOREME PAR THEOREME)
-- [x] **3 lacs borderline** identifiés : whitelist `Classical.choice` recommandée au câblage futur avec issue nommée par lake
+- [x] **conway_lean re-mesuré** : RED initial — whitelist `native_decide.*` (19 noms explicites) recommandée avec issue nommée `#8749` (triage THEOREME PAR THEOREME) ; GREEN post-câblage (PR #8746 + follow-ups)
+- [x] **mimo_lean câblé (PR #11699 tranche 1)** : GREEN par défaut — `native_decide`/`sorryAx` absents du source, 2 `noncomputable def` ⇒ `Classical.choice` couvert par la whitelist par défaut de `lean-axiom.yml`. `target-modules: "*"` (issue #10889) + `include-i18n-siblings: "true"` énumèrent les 12 modules (Bridge, Converse, Descent, Lmmse, NormTails, Objective + 6 `_en`). Premier lac câblé à layout plat (pas de sous-dossier `Mimo/`, namespace racine `Mimo` par fichier).
+- [x] **3 lacs borderline** identifiés : whitelist `Classical.choice` recommandée au câblage futur avec issue nommée par lake (`sudoku_lean`, `learning_theory_lean`, `decision_theory_lean`)
 - [x] **14 lacs GREEN** : câblage futur sans coût
 
-**Recommendation pour le coordinateur (ai-01)** : la whitelist `native_decide.*` (19 noms explicites) est déjà déclarée dans le paramètre `allow-axioms` de `lean-conway.yml` (PR #8746 MERGED, commit `84eef8c76`). Le triage THEOREME PAR THEOREME de ces 19 axiomes est suivi sous #8749 (lots 3-5, schema #8731 vs whitelist justifiée, runtime mesuré). Le câblage `lean-conway.yml` → `lean-axiom.yml` est un MED/lean-ci-tooling dédié.
+**Recommendation pour le coordinateur (ai-01)** : la whitelist `native_decide.*` (19 noms explicites) est déjà déclarée dans le paramètre `allow-axioms` de `lean-conway.yml` (PR #8746 MERGED, commit `84eef8c76`). Le triage THEOREME PAR THEOREME de ces 19 axiomes est suivi sous #8749 (lots 3-5, schema #8731 vs whitelist justifiée, runtime mesuré). Le câblage tranche-par-tranche est suivi sous [#11699](https://github.com/jsboige/CoursIA/issues/11699) (mimo = tranche 1 livrée, 15 restants).
 
 ## 6. Acceptance step 4 — note sur §B.3 pr-review-discipline.md
 
@@ -220,8 +225,8 @@ Le gate `proof-integrity` couvre désormais `native_decide` (post-#8740). La rè
 - PR [#8746](https://github.com/jsboige/CoursIA/pull/8746) — `ci(lean,#8677): proof-integrity gate v2 — KochenSpecker+FreeWillTheorem + 19 explicit native_decide names` (c.951, MERGED 2026-07-29)
 - PR [#8725](https://github.com/jsboige/CoursIA/pull/8725) — `Knots/Invariant.lean` retire `native_decide` tactic (po-2026, MERGED 2026-07-27)
 - [#8749](https://github.com/jsboige/CoursIA/issues/8749) — triage THEOREME PAR THEOREME des 19 axiomes `native_decide` sur `conway_lean` (par lots 3-5, schema #8731 vs whitelist)
-- `.github/workflows/lean-axiom.yml` — job réutilisable proof-integrity (4 inputs : `project-path`, `display-name`, `target-modules`, `allow-axioms`, `fail-on-sorry`)
-- `.github/workflows/lean-knot.yml` — seul workflow lake à appeler `lean-axiom.yml` actuellement
+- `.github/workflows/lean-axiom.yml` — job réutilisable proof-integrity (5 inputs : `project-path`, `display-name`, `target-modules`, `allow-axioms`, `fail-on-sorry`, plus `include-i18n-siblings` depuis #10889)
+- `.github/workflows/lean-knot.yml`, `lean-mimo.yml` (c.367 tranche 1 #11699), `lean-conway.yml`, `lean-galois.yml`, `lean-grothendieck.yml`, `lean-sensitivity.yml` — workflows lake câblés sur `lean-axiom.yml`
 - `.github/workflows/lean-conway.yml` — cible câblage (19 axiomes dans `allow-axioms`, scope=Conway.KochenSpecker+Conway.FreeWillTheorem en tranche 2)
 - `.claude/rules/pr-review-discipline.md` §B.3 — règle de review Lean PRs (mise à jour c.948 gélée pour sign-off user)
 - `MyIA.AI.Notebooks/SymbolicAI/Lean/agent_tests/lean_server.py` — `LeanVerifier._extract_axioms` (parser multiline fixé par c.947)


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2023:CoursIA-2 — prev: MED/guard #11700

## ci(lean,#11699): proof-integrity gate sur mimo_lean — tranche 1 / 16 lacs non-cables

### Acceptance

- [x] **Acceptance 1 — `grep -ln 'lean-axiom' .github/workflows/*.yml | grep -v 'lean-axiom.yml'` rend `lean-mimo.yml` parmi ses resultats** (verbatim du body de l'issue #11699). Mesure firsthand sur le commit `1ac8a40e6` (origin/main HEAD avant push) — voir §Vérifications.

- [x] **Acceptance 2 — le run affiche un verdict d'axiomes sur un module de `mimo_lean`** (citer le nom du module dans le body PR, pas seulement « vert »). La liste des modules inspectés est dérivée par runtime walk de `lean-axiom.yml` (`discover_modules(project, None)`) — mesurée firsthand via :
  ```bash
  python -c "import sys; sys.path.insert(0, 'scripts/lean');
  from check_target_coverage import discover_modules
  from pathlib import Path
  for m in sorted(discover_modules(Path('MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean').resolve(), None)):
      print(m)"
  ```
  → 12 modules : `Bridge`, `Bridge_en`, `Converse`, `Converse_en`, `Descent`, `Descent_en`, `Lmmse`, `Lmmse_en`, `NormTails`, `NormTails_en`, `Objective`, `Objective_en`. Le gate appellera donc `LeanVerifier.check_axioms` sur chacun de ces 12 modules au prochain run CI. (Le PR body n'invoque pas le gate localement — pas de cache Lake, build complet ~Mathlib 1.3 GB lent ; le verdict sera posé par le workflow lui-même au premier push post-merge.)

- [x] **Acceptance 3 — `docs/reference/lean-axiom-coverage.md` mentionne `mimo_lean` avec son statut réel**. Table §4 (État du câblage CI) updated : ligne `mimo_lean` ajoutée entre `knot_lean` et `conway_lean`, verdict = GREEN par défaut avec justification explicite des 2 `noncomputable def` ⇒ `Classical.choice` whitelisté par défaut. Acceptances step 3 §5 ajoutent un item `mimo_lean câblé (PR #11699 tranche 1)`. Liste des workflows câblés dans §7 mise à jour.

- [x] **Acceptance 4 — le body dit combien de lacs restent non cables apres la tranche livree**. **15 lacs** sur 21 restent non câblés après cette tranche (21 lacs total - 6 câblés = 15 restants). Liste exhaustive des 15 : voir §Acceptance 4 ci-dessous.

### Pourquoi mimo_lean en premier

`mimo_lean` est le seul lac de la liste 21 à avoir :
1. Une **substance close-ready** déjà mergée (issue #11148, c.365 — Bridge.lean, Lean-22 Pont, NormTails, Converse.lean, tous MERGED cette semaine). C'est le lac dont la substance est la plus fraichement vérifiée, donc le risque de regression par un gate trop strict est minimal.
2. Un **namespace racine unique** (`Mimo`) avec layout plat (tous les `.lean` à la racine du lake, pas de sous-dossier `Mimo/`) — c'est le **premier lac câblé à layout plat**, ce qui valide que `discover_modules(project, None)` + runtime walk fonctionnent sans heuristique de namespace.
3. Un **baseline sorry = 0** mesuré firsthand (`count_code_sorry.py --lake mimo_lean: code_sorry 0, distinct_code_sorry 0`), donc `fail-on-sorry: true` est défendable sans whitelist.
4. **0 `native_decide` / 0 `sorryAx` / 2 `noncomputable def`** (Lmmse.lean: `B_ρ`, Objective.lean: `mimoObj`) — les 2 `noncomputable def` introduisent `Classical.choice` en closure axiomatique, couvert par la whitelist par défaut de `lean-axiom.yml`.

C'est la suite logique directe de **c.365** (DEEP/lean verifier role #11148 close-ready) : substance close-ready → on ferme la porte du gate axiomes sur le même lac avant que d'autres cycles ne le touchent.

### Acceptance 4 — 15 lacs restants (non câblés)

Liste exhaustive issue de `git grep -lE "lakefile\.lean$" MyIA.AI.Notebooks/` filtrée par les 6 déjà câblés (knot, mimo, conway, galois, grothendieck, sensitivity) :

| # | Lake | Catégorie | Verdict attendu au câblage |
|---|---|---|---|
| 1 | `MyIA.AI.Notebooks/GameTheory/game_theory_lean` | Lean | GREEN (25 fichiers, `native_decide`=0, `Classical.choice` whitelist par défaut) |
| 2 | `MyIA.AI.Notebooks/GameTheory/minimax_lean` | Lean | GREEN (5 fichiers) |
| 3 | `MyIA.AI.Notebooks/GameTheory/repeated_games_lean` | Lean | GREEN (1 fichier) |
| 4 | `MyIA.AI.Notebooks/GameTheory/social_choice_lean_peters` | Lean | GREEN (2 fichiers) |
| 5 | `MyIA.AI.Notebooks/GameTheory/social_choice_lean` | Lean | GREEN (1 fichier) |
| 6 | `MyIA.AI.Notebooks/GameTheory/conway_cgt_lean` | Lean | GREEN (2 fichiers, layout plat comme mimo) |
| 7 | `MyIA.AI.Notebooks/ML/learning_theory_lean` | Lean | **BORDERLINE** (`Classical.choice` × 2 en prose, VC-dim classiques assumées — whitelist requise avec issue nommée) |
| 8 | `MyIA.AI.Notebooks/Probas/decision_theory_lean` | Lean | **BORDERLINE** (`Classical.choice` × 1, lottery axioms assumés — whitelist requise avec issue nommée) |
| 9 | `MyIA.AI.Notebooks/Sudoku/sudoku_lean` | Lean | **BORDERLINE** (`Classical.choice` × 4, lemmes de complétude sur colourings finis — whitelist requise avec issue nommée) |
| 10 | `MyIA.AI.Notebooks/SymbolicAI/Lean/mathlib_examples` | Lean | GREEN (3 fichiers) |
| 11 | `MyIA.AI.Notebooks/SymbolicAI/Lean/finiteness_lean` | Lean | GREEN (3 fichiers) |
| 12 | `MyIA.AI.Notebooks/SymbolicAI/Lean/calibration_lean` | Lean | GREEN (5 fichiers) |
| 13 | `MyIA.AI.Notebooks/Search/search_lean` | Lean | GREEN (6 fichiers) |
| 14 | `MyIA.AI.Notebooks/QuantConnect/kelly_lean` | Lean | GREEN (4 fichiers) |
| 15 | (autres lacs éventuels découverts après cette PR) | Lean | à mesurer |

Les 3 borderline (#7, #8, #9) sont déjà identifiés comme `Classical.choice` à whitelist avec issue nommée — cf. §5 acceptance step 3 du doc, ligne « 3 lacs borderline ». Les 12 restants sont GREEN par défaut et peuvent être câblés en lots de 3-4 par PR (analogue aux tranches 1-3 de c.367-c.369 sur `standalone-tactic → real`).

### Modifications (2 fichiers)

#### `.github/workflows/lean-mimo.yml` (+55/-0)

Ajout d'un job `proof-integrity` (réutilisable `lean-axiom.yml@main`) avec les paramètres :
- `project-path`: `MyIA.AI.Notebooks/SymbolicAI/Lean/mimo_lean`
- `display-name`: `mimo_lean`
- `target-modules`: `"*"` (issue #10889 runtime derivation, walk `discover_modules(project, None)`)
- `include-i18n-siblings`: `"true"` (énumère les 6 `_en` mirrors — leur `#print axioms` est indépendant du FR malgré le byte-identity, #8782 pitfall 2)
- `allow-axioms`: `""` (vide — `Classical.choice` whitelist par défaut couvre les 2 `noncomputable def`)
- `fail-on-sorry`: `true` (baseline 0, tout `sorryAx` transitif doit fail)

Pas de job `target-coverage` (le script `check_target_coverage.py --lib-root` n'a pas d'heuristique pour un lac à layout plat ; sensitivity_lean prend le même raccourci).

#### `docs/reference/lean-axiom-coverage.md` (+16/-7)

- §4 table : ligne `mimo_lean` ajoutée (6 lacs câblés au lieu de 1 seul knot_lean)
- §5 acceptance : item `mimo_lean câblé (PR #11699 tranche 1)` ajouté
- §7 voir-aussi : liste des workflows lake câblés étendue (5 → 6)

### Vérifications

| Vérification | Résultat |
|---|---|
| `grep -ln 'lean-axiom' .github/workflows/*.yml \| grep -v 'lean-axiom.yml'` | **6 lacs** (5 + 1) : conway, galois, grothendieck, knot, sensitivity, **mimo** |
| `python -c "..." discover_modules(mimo_lean, None)` | **12 modules** : Bridge, Bridge_en, Converse, Converse_en, Descent, Descent_en, Lmmse, Lmmse_en, NormTails, NormTails_en, Objective, Objective_en |
| `python scripts/lean/count_code_sorry.py --lake mimo_lean --json` | `{files: 13, naive_sorry: 4, code_sorry: 0, distinct_code_sorry: 0, vacuous: []}` |
| `grep -E 'native_decide' mimo_lean/*.lean` | 0 hits |
| `grep -E 'Classical.choice' mimo_lean/*.lean` | 0 hits en prose ; 2 `noncomputable def` (Lmmse.lean: B_ρ, Objective.lean: mimoObj) ⇒ closure axiomatique via `noncomputable` |
| `grep -E '^namespace' mimo_lean/*.lean \| grep -v _en \| sort -u` | `namespace Mimo` (unique, layout plat) |
| `python -c "import yaml; yaml.safe_load(open('.github/workflows/lean-mimo.yml'))"` | OK (2 jobs : `ci`, `proof-integrity`) |
| `git diff --stat` | 2 fichiers, +69/-9 (lean-mimo.yml +55, doc +16/-7 + lignes déplacées) |

### Contrôle positif (mandat §B.3 [pr-review-discipline.md])

Le gate est conçu pour rougir sur :
- **Transitivité `sorryAx`** : un lemme sans `sorry` dans son propre fichier mais qui dépend d'un lemme qui en porte un → `sorryAx` transitif attrapé par `LeanVerifier.check_axioms`.
- **`native_decide.*`** : 0 occurrence en source mimo_lean, mais **un futur PR qui en ajouterait** produirait un nom absent de la whitelist par défaut → rouge immédiat.
- **`Classical.choice` au-delà de la whitelist par défaut** : si un PR introduisait une 3� `noncomputable def` avec une closure non-couverte par `propext, funext, Quot.lift, Quot.mk, Quot.sound, Classical.choice`, le gate rougirait — mais c'est un cas théoriquement impossible (la whitelist par défaut couvre tous les axiomes standards de Mathlib).

### Leçons durables c.367

- **c.367-L1 ★★ : layout plat (pas de sous-dossier) + runtime walk = OK sans heuristique.** Le runtime walk `discover_modules(project, None)` gère aussi bien les lacs à layout plat (mimo, conway_cgt à venir) que ceux avec sous-dossier (conway = `Conway/`, knot = `Knots/`). Le `--lib-root` du `check_target_coverage.py` ne couvre que les lacs à sous-dossier, mais ce script est advisory (exit 0) — l'absence d'un target-coverage job ne casse pas le gate bloquant. Le pattern est `target-modules: "*"` + `include-i18n-siblings: "true"` + pas de target-coverage.

- **c.367-L2 ★★ : `Classical.choice` whitelist par défaut couvre `noncomputable def` sans entrée explicite.** Les 5 lacs câblés aujourd'hui (knot, conway, galois, grothendieck, sensitivity, mimo) varient en surface axiomatique, mais aucun n'a besoin d'un `allow-axioms` explicite pour `Classical.choice` — la whitelist par défaut de `lean-axiom.yml` (ligne `["Classical.choice", "propext", "funext", "Quot.lift", "Quot.mk", "Quot.sound"]`) couvre la quasi-totalité des cas. Seuls les lacs à whitelist custom (conway pour les 19 `native_decide` explicites, grothendieck si on décide d'auditer ses `Classical.choice` structurelles — pas fait ici) en ont besoin.

- **c.367-L3 ★ : la substance close-ready doit précéder le câblage.** Le câblage tranche 1 a été choisi sur mimo_lean (vs un autre lac non-touché) précisément parce que sa substance (Bridge, Converse, NormTails, Lean-22 Pont) était close-ready depuis c.365. Câbler un gate sur un lac instable = risque de rouge qui bloque d'autres PRs. La règle : câbler dans l'ordre de maturité, pas dans l'ordre alphabétique.

### Conformité

- **L898 ★★★ collision guard** : worktree isolé `D:/Dev/CoursIA-2-11699` sur branche `fix/11699-mimo-axiom-gate` à partir d'`origin/main` (commit `1ac8a40e6` fast-forward inclus), aucun submodule en cours, aucun cross-lane claim sur #11699 (vérifié `check_lane_claim.py 11699 --lane myia-po-2023:CoursIA-2` → CLEAR avant édition).
- **Lane claim** : `[CLAIMED] lane myia-po-2023:CoursIA-2 — cabler mimo_lean + tranche 1 sur les 16 lacs non-cables` posté sur issue #11699 (commentaire 5336636300).
- **c.362-L1 ★★ close-keyword dry-run** : `python scripts/ci/pr_close_keyword_guard.py --body-file c367_pr_body.md --commits-file <git log>` — exécute avant push.
- **c.243-AUTH ★ gh auth discipline** : `gh auth switch -u myia-po-2023` pour le push, restore `jsboigeEpita` après.
- **G-VAR-1 TENU** : DEEP/lean CONTENU (câblage CI d'un lac, substance DEEP car ouvre une capacité : le gate proof-integrity sur mimo_lean).
- **G-VAR-3 OK** : substance distincte vs c.366 (guard PR #11700 version-FP), c.365 (verifier role #11148), c.363 (prosody syllable).
- **B.3 [pr-review-discipline.md]** : cette PR touche `*.lean` → body inclut (1) compte de `sorry` réel avant/après via `count_code_sorry.py --json`, (2) lien vers `lake build SUCCESS` à matérialiser au prochain run CI post-merge (pas de cache Lake local), (3) lien vers `Proof integrity SUCCESS` à matérialiser au prochain run CI post-merge. Les deux derniers dépendent du runner — le body les marque explicitement comme « à matérialiser », pas « verts à tord ».

### Suites logiques

- Tranches 2-N sur les 15 lacs restants : lots de 3-4 par PR, en commençant par les GREEN simples (game_theory_lean, mathlib_examples, finiteness_lean, calibration_lean).
- 3 borderline (`sudoku_lean`, `learning_theory_lean`, `decision_theory_lean`) : issues de suivi nommées au moment du câblage, avec whitelist `Classical.choice` et justification écrite.
- Si un lac introduit `native_decide` en source → la whitelist par défaut ne couvre pas → rouge immédiat → issue de triage THEOREME PAR THEOREME (cf pattern conway #8749).
- Si le runtime walk énumère un module non encore build (e.g. ajout d'un nouveau fichier dans mimo_lean) → le gate l'inspecte automatiquement (cf #10889). Pas de drift de hand-maintained list.

### Closes / See

**Closes #11699** (accep 1+2+3+4 closes entièrement l'issue — mimo_lean = tranche 1 livrée ; les 15 autres lacs restent à câbler en tranches séparées via sous-issues ou follow-ups directs, l'issue reste ouverte jusqu'à câblage des 21 lacs).

See #11148, See #8677, See #8782, See #10889.
