### PR TITLE
feat(sk,#11271): enrichissement pedagogique fort-boyard-python (590->1299 c/cell)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/README.md
@@ -48,7 +48,7 @@ Ces notebooks appliquent Semantic Kernel à des cas d'usage concrets. Ils font p
 | [Semantic-kernel-AutoInteractive](Semantic-kernel-AutoInteractive.ipynb) | C# (.NET) | **Conception de notebook assistée** : SK + OpenAI function calling pour générer et exécuter d'autres notebooks .NET interactifs | 3 |
 | [Créateur de mail personnalisé](Créateur%20de%20mail%20personnalisé.ipynb) | Python | Workflow multi-agents SK (InputCollector, EmailGenerator) pour la rédaction de courriels | 3 |
 | [fort-boyard-csharp](fort-boyard-csharp.ipynb) | C# (.NET) | AgentGroupChat : duel Père Fouras vs Laurent Jalabert (jeu de devinette) | 3 |
-| [fort-boyard-python](fort-boyard-python.ipynb) | Python | Contrepartie Python du duel Fort Boyard (KernelFunctionTerminationStrategy) | 3 |
+| [fort-boyard-python](fort-boyard-python.ipynb) | Python | Contrepartie Python du duel Fort Boyard (TerminationStrategy personnalisee) | 3 |
 
 ## Templates
 

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-python.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-python.ipynb
@@ -2,24 +2,8 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "8a3e31c5",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004236,
-     "end_time": "2026-05-09T23:26:45.554989",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:45.550753",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "**Navigation** : [Index](README.md) | [<< Précédent](fort-boyard-csharp.ipynb)\n",
-    "\n",
-    "# Jeu de devinette : Père Fouras vs Laurent Jalabert\n",
-    "\n",
-    "Dans ce notebook, nous allons simuler le duel légendaire entre le Père Fouras et Laurent Jalabert en utilisant Semantic Kernel avec des agents conversationnels."
-   ]
+   "metadata": {},
+   "source": "**Navigation** : [Index](README.md) | [<< Précédent](fort-boyard-csharp.ipynb)\n\n# Jeu de devinette : Père Fouras vs Laurent Jalabert\n\nDans ce notebook, nous allons simuler le duel légendaire entre le Père Fouras et Laurent Jalabert en utilisant Semantic Kernel avec des agents conversationnels.\n\nCe duel est l'occasion d'étudier une architecture d'orchestration multi-agents complète en miniature : un **kernel** qui héberge le service LLM, deux **agents** au persona opposé (celui qui sait, celui qui cherche), un **AgentGroupChat** qui arbitre l'alternance, et une **stratégie de terminaison** qui décide quand le jeu s'arrête. Ces quatre briques se retrouvent telles quelles dans tout système multi-agents sérieux — comité de revue, débat d'arguments, chaîne de validation — avec exactement les mêmes coutures."
   },
   {
    "cell_type": "code",
@@ -89,65 +73,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0475bc88",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004828,
-     "end_time": "2026-05-09T23:26:56.494903",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.490075",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## 1. Installation et configuration\n",
-    "\n",
-    "Cette cellule prepare l'environnement :\n",
-    "- **semantic-kernel** : SDK pour orchestrer les agents LLM\n",
-    "- **python-dotenv** : Chargement securise des cles API depuis `.env`\n",
-    "- **Logging** : Configuration des logs pour suivre la conversation\n",
-    "\n",
-    "Le fichier `.env` doit contenir `OPENAI_API_KEY` pour l'authentification.\n"
-   ]
+   "metadata": {},
+   "source": "## 1. Installation et configuration\n\nCette cellule prépare l'environnement puis instancie le kernel :\n\n- **semantic-kernel** : le SDK d'orchestration — il fournit le `Kernel` (le conteneur de services), `ChatCompletionAgent` (un participant), `AgentGroupChat` (l'arbitre) et les stratégies de sélection/terminaison ;\n- **python-dotenv** : chargement sécurisé de la clé API depuis `.env` (jamais en dur dans le code) ;\n- **Logging** : configuré au niveau `INFO`, il rendra visible tout le mécanisme d'orchestration tour par tour — qui parle, quand la terminaison est évaluée, combien de tokens consommés.\n\nLe fichier `.env` doit contenir `OPENAI_API_KEY` pour l'authentification. Le modèle par défaut est `gpt-5-mini` (surchargé par `OPENAI_CHAT_MODEL_ID`)."
   },
   {
    "cell_type": "markdown",
-   "id": "12403196",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004188,
-     "end_time": "2026-05-09T23:26:56.503613",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.499425",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Configuration des agents"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "3d9f38c4",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004782,
-     "end_time": "2026-05-09T23:26:56.513262",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.508480",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Le mot a deviner\n",
-    "\n",
-    "La variable `MOT_A_DEVINER` contient le mot que Laurent Jalabert doit trouver. Ce mot est injecte dans le prompt du Pere Fouras mais reste cache pour l'agent devineur.\n",
-    "\n",
-    "La fonction `create_kernel()` créé une instance du Kernel avec le service OpenAI configure.\n"
-   ]
+   "metadata": {},
+   "source": "### Le mot a deviner\n\nLa variable `MOT_A_DEVINER` contient le mot que Laurent Jalabert doit trouver. Regardez bien où il vit : dans le code Python du notebook, **côté orchestrateur** — puis injecté dans le prompt du Père Fouras par f-string à la cellule suivante. Les instructions de Laurent Jalabert, elles, n'en contiennent qu'une description de rôle (« devine le mot en posant des questions fermées ») : l'agent devineur ne voit littéralement jamais la chaîne `anticonstitutionnellement` dans son prompt système.\n\nC'est l'asymétrie d'information qui fait le jeu — et c'est une propriété de conception, pas un accident : dans un vrai système multi-agents, chaque agent ne doit connaître que ce dont son rôle a besoin. La fonction `create_kernel()` crée l'instance du Kernel avec le service OpenAI configuré."
   },
   {
    "cell_type": "code",
@@ -209,67 +141,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60cf0391",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005504,
-     "end_time": "2026-05-09T23:26:56.543941",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.538437",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Conception des prompts\n",
-    "\n",
-    "Les prompts système definissent la personnalite de chaque agent :\n",
-    "- **Pere Fouras** : Donne des indices enigmatiques, parle en charades, ne revele jamais le mot\n",
-    "- **Laurent Jalabert** : Pose des questions fermees (oui/non) pour deviner\n",
-    "\n",
-    "Le mot a deviner est injecte dynamiquement dans le prompt du Pere Fouras via une f-string.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6820704b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005248,
-     "end_time": "2026-05-09T23:26:56.554605",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.549357",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Définition des prompts"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bcef7527",
-   "metadata": {
-    "papermill": {
-     "duration": 0.00467,
-     "end_time": "2026-05-09T23:26:56.563825",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.559155",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Instanciation des agents\n",
-    "\n",
-    "Chaque agent possede :\n",
-    "- Son propre **Kernel** (instance independante)\n",
-    "- Un **nom** unique pour l'identification dans les logs\n",
-    "- Des **instructions** definissant son comportement\n",
-    "\n",
-    "Les deux agents utiliseront le même modèle OpenAI mais avec des rôles différents.\n"
-   ]
+   "metadata": {},
+   "source": "## Conception des prompts et instanciation des agents\n\nLes prompts système définissent la personnalité de chaque agent :\n\n- **Père Fouras** : donne des indices énigmatiques, parle en charades, ne révèle jamais le mot ;\n- **Laurent Jalabert** : pose des questions fermées (oui/non) pour deviner.\n\nChaque prompt suit la même anatomie en trois temps — **rôle** (« Tu es... »), **mission** (faire deviner / deviner), **contrainte de format** (charades / questions fermées). Les personas sont délibérément opposés : sans contrainte explicite, deux agents LLM sur le même modèle convergent rapidement vers un dialogue plat et coopératif qui court-circuite le jeu. La contrainte de format est ce qui force la dynamique question/réponse.\n\nNotez l'injection : le mot à deviner n'entre dans le système que par la f-string du prompt du Père Fouras. Chaque agent possédera ensuite son propre kernel (instance indépendante), un `name` unique pour l'identification dans les logs, et ses `instructions`. Les deux agents utilisent le même modèle OpenAI, mais avec des rôles différents — la spécialisation vient du prompt, pas du modèle."
   },
   {
    "cell_type": "code",
@@ -310,67 +183,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "092180da",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005456,
-     "end_time": "2026-05-09T23:26:56.593888",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.588432",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Stratégie de terminaison personnalisee\n",
-    "\n",
-    "La classe `FortBoyardTerminationStrategy` herite de `TerminationStrategy` et définit quand le jeu se termine :\n",
-    "- **Condition** : Le mot a deviner apparait dans le dernier message\n",
-    "- **Méthode** : `should_terminate()` est appelee après chaque tour\n",
-    "\n",
-    "Cela illustre comment personnaliser le comportement d'arret d'un `AgentGroupChat`.\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c174db03",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005212,
-     "end_time": "2026-05-09T23:26:56.604511",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.599299",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Création des agents avec stratégies personnalisées"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eba0cbb1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005176,
-     "end_time": "2026-05-09T23:26:56.614930",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:56.609754",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Configuration du groupe de discussion\n",
-    "\n",
-    "Le `AgentGroupChat` orchestre les deux agents :\n",
-    "- **agents** : Liste des participants (Pere Fouras et Laurent Jalabert)\n",
-    "- **termination_strategy** : Notre stratégie personnalisee\n",
-    "- **maximum_iterations** : Limite de securite (20 tours max)\n",
-    "\n",
-    "Les agents parlent en alternance jusqu'a ce que le mot soit devine ou la limite atteinte.\n"
-   ]
+   "metadata": {},
+   "source": "## Création des agents\n\n`ChatCompletionAgent` assemble les trois ingrédients préparés ci-dessus : un kernel (qui sait joindre le service), un nom (que l'orchestrateur affichera dans les logs), des instructions (le persona). Les deux agents sont créés de façon symétrique — seule la string d'instructions les distingue, ce qui rend le pattern trivialement extensible à un troisième participant (l'exercice suivant vous le fait construire)."
   },
   {
    "cell_type": "code",
@@ -434,45 +248,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11741c3b",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005266,
-     "end_time": "2026-05-09T23:26:58.837377",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:58.832111",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "### Exécution du jeu\n",
-    "\n",
-    "La fonction `jouer_partie()` lance la conversation :\n",
-    "1. Affiche le mot a deviner (pour le debug)\n",
-    "2. Itere sur `chat.invoke()` qui retourne chaque message en streaming\n",
-    "3. Log chaque intervention avec le rôle de l'agent\n",
-    "4. S'arrete quand la stratégie de terminaison retourne `True`\n",
-    "\n",
-    "Executez cette cellule pour voir le duel en action !\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c68f0287",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005204,
-     "end_time": "2026-05-09T23:26:58.847856",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:58.842652",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Stratégie de terminaison personnalisée"
-   ]
+   "metadata": {},
+   "source": "## Stratégie de terminaison personnalisée\n\nUn group chat a besoin de savoir quand s'arrêter — sinon les agents conversent indéfiniment. Semantic Kernel expose pour cela `TerminationStrategy`, dont on spécialise la méthode `should_agent_terminate` : appelée après chaque tour, elle reçoit l'historique complet et retourne un booléen.\n\nNotre implémentation est volontairement simple : elle regarde si `MOT_A_DEVINER` apparaît dans le **dernier message** (en minuscules). Deux remarques pour la suite :\n\n- c'est un test de **présence**, pas de **victoire** : dès que le mot est prononcé — y compris dans une question comme « est-ce que le mot est X ? » — la partie s'arrête. Observez la sortie de la partie plus bas : c'est exactement ce qui s'y produit ;\n- la comparaison est sensible aux variantes typographiques (accents, casse composée, espaces). L'exercice 3 vous demande de durcir cette détection.\n\nC'est le mécanisme d'arrêt **sémantique** ; il se double d'un filet de sécurité mécanique (`maximum_iterations`) configuré à la cellule suivante."
   },
   {
    "cell_type": "code",
@@ -518,20 +295,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e97aa4b6",
-   "metadata": {
-    "papermill": {
-     "duration": 0.005533,
-     "end_time": "2026-05-09T23:26:58.884854",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:58.879321",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Configuration du groupe de discussion"
-   ]
+   "metadata": {},
+   "source": "**Lecture du code.** `should_agent_terminate` commence par se protéger de l'historique vide, puis prend `history[-1]` — uniquement le dernier message, pas toute la conversation. La comparaison `MOT_A_DEVINER in last_message` est un test de sous-chaîne : insensible à la casse grâce au `.lower()` appliqué des deux côtés, mais aveugle aux accents et aux espaces parasites. La signature `async` n'est pas décorative : dans Semantic Kernel, la stratégie peut elle-même appeler un modèle (pour décider sémantiquement), d'où l'await potentiel — notre version est pure donc immédiate."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Configuration du groupe de discussion\n\nLe `AgentGroupChat` orchestre les deux agents. Sa configuration révèle la séparation des deux arbitrages d'un group chat :\n\n- la **sélection** (qui parle ensuite) — ici laissée au comportement par défaut, l'alternance séquentielle entre les agents listés ;\n- la **terminaison** (quand arrêter) — notre `FortBoyardTerminationStrategy`, avec deux paramètres : `agents=[laurent_jalabert]` (le critère n'est évalué qu'après une intervention du devineur — c'est lui qui peut gagner, pas le maître du jeu) et `maximum_iterations=20` (filet de sécurité mécanique : même si le mot n'est jamais prononcé, la boucle s'arrête).\n\n`AgentGroupChat` maintient par ailleurs l'historique partagé : chaque message devient visible pour les deux agents au tour suivant. C'est ce contexte commun croissant qui permet la cohérence du dialogue — et dont le coût en tokens devient visible dans les logs de la partie."
   },
   {
    "cell_type": "code",
@@ -567,20 +337,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62bce343",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004804,
-     "end_time": "2026-05-09T23:26:58.915355",
-     "exception": false,
-     "start_time": "2026-05-09T23:26:58.910551",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Lancement de la partie !"
-   ]
+   "metadata": {},
+   "source": "**Pourquoi « corrigée » ?** Le commentaire `# Bloc 6 - Configuration corrigée` rappelle une version antérieure où la stratégie n'avait ni liste d'agents ni plafond d'itérations : sans `agents=`, le critère était évalué après *chaque* intervention (y compris celle du Père Fouras — qui prononce le mot dans sa propre tête à chaque prompt) et sans `maximum_iterations`, une partie sans victoire tournait à l'infini. Les deux paramètres ne sont pas du réglage fin : ils sont ce qui rend l'arrêt *correct*."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Lancement de la partie !\n\nLa fonction `jouer_partie()` lance la conversation :\n\n1. elle sème un premier message `USER` (« Pere Fouras, donne-moi un indice ! ») — sans amorce, aucun agent n'a de raison de parler en premier ;\n2. elle itère sur `chat.invoke()`, qui retourne chaque message au fil de la conversation : l'orchestrateur sélectionne l'agent, l'invoque, évalue la terminaison, puis recommence ;\n3. chaque intervention est loggée avec le rôle de l'agent — les logs INFO montrent toute la mécanique : `Selected agent`, `Invoking agent`, l'appel HTTP vers l'API, l'usage de tokens, puis `Evaluating termination criteria`.\n\nExécutez la cellule et lisez la sortie **en entier** : c'est la meilleure radiographie d'un orchestrateur multi-agents que le dépôt puisse offrir."
   },
   {
    "cell_type": "code",
@@ -1425,6 +1188,11 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": "**Lecture de la partie qui vient de se jouer.** La sortie raconte beaucoup plus qu'un duel :\n\n- **14 invocations** en alternance stricte — 7 tours de Père Fouras, 7 de Laurent Jalabert, en ~32 secondes (01:26:58 → 01:27:30). L'orchestrateur séquentiel fonctionne comme prévu : jamais deux interventions consécutives du même agent.\n- **Le Père Fouras joue son rôle à la lettre** : sa charade décompose réellement le mot — « mon premier est le contraire de *pour* » (contre-), « mon deuxième est le grand texte au sommet des lois » (constitution), « mon troisième est une terminaison \"d'une manière\" » (-ment). Le modèle n'a pas reçu la décomposition : il l'a reconstruite depuis le mot injecté.\n- **Laurent s'auto-corrige** : au dernier tour, il commence par « Non. Je dois rester Laurent Jalabert et deviner le mot uniquement avec des questions Oui/Non » — le modèle avait glissé vers un comportement du Père Fouras, et s'en est corrigé lui-même en relisant son propre prompt dans l'historique.\n- **La terminaison s'est déclenchée sur une question, pas sur une victoire** : le dernier message est « *Est-ce que le mot est \"anticonstitutionnellement\" ? (Oui/Non)* » — le log montre `should terminate: True` aussitôt après. Laurent a *prononcé* le mot, il ne l'a pas *confirmé* ; la réponse « Oui » n'aura jamais lieu. C'est la limite du test de sous-chaîne vue à la stratégie de terminaison — et exactement ce que l'exercice 3 vous propose de durcir.\n- **Le coût du contexte partagé est visible** : au premier tour, `prompt_tokens=72` ; au dernier, `prompt_tokens=3029` dont `cached_tokens=2432`. L'historique croît à chaque tour (tous les messages précédents sont renvoyés), et le caching de prompt d'OpenAI amortit la facture sur les tours suivants."
+  },
+  {
+   "cell_type": "markdown",
    "id": "9df42c85",
    "source": "### Exercice : Analyser et modifier la stratégie de terminaison\n\nLa stratégie de terminaison actuelle detecte si le mot a deviner apparait dans le dernier message. Cependant, elle pourrait etre amelioree.\n\n**Objectif** : Completez la fonction `should_agent_terminate_enhanced` ci-dessous pour detecter également les variantes typographiques du mot (majuscules, accents, espaces supplementaires).\n\n**Indices** :\n- # Étape 1 : Normalisez le dernier message (supprimez accents, mettez en minuscules, supprimez espaces)\n- # Étape 2 : Comparez avec le mot cible normalise de la même facon\n- # Indice : Utilisez `unicodedata.normalize('NFKD', text).encode('ASCII', 'ignore').decode()` pour supprimer les accents",
    "metadata": {}
@@ -1447,44 +1215,8 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89ffa822",
-   "metadata": {
-    "papermill": {
-     "duration": 0.006446,
-     "end_time": "2026-05-09T23:27:30.539542",
-     "exception": false,
-     "start_time": "2026-05-09T23:27:30.533096",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "source": [
-    "## Conclusion du jeu Fort Boyard\n",
-    "\n",
-    "Ce notebook a illustre plusieurs concepts avances de Semantic Kernel :\n",
-    "\n",
-    "### Concepts techniques demontres\n",
-    "\n",
-    "1. **Agents conversationnels specialises** : Chaque agent possede sa propre personnalite et son rôle\n",
-    "2. **Stratégie de terminaison personnalisee** : Detection automatique du succes (mot devine)\n",
-    "3. **AgentGroupChat** : Orchestration d'un dialogue structure entre deux agents\n",
-    "4. **Gestion du contexte** : Maintien de l'historique de conversation pour coherence\n",
-    "\n",
-    "### Applications pratiques\n",
-    "\n",
-    "Ce pattern peut etre adapte pour :\n",
-    "- **Jeux educatifs** : Quiz interactifs, devinettes pedagogiques\n",
-    "- **Interviews automatisees** : Un agent questionne, l'autre repond\n",
-    "- **Debat structure** : Deux agents defensent des positions opposees\n",
-    "- **Scénarios de formation** : Simulation de conversations professionnelles\n",
-    "\n",
-    "### Points d'amelioration possibles\n",
-    "\n",
-    "- Ajouter un compteur de tentatives avec limite\n",
-    "- Implementer un système de score base sur le nombre de questions\n",
-    "- Enrichir les indices du Pere Fouras avec des images ou sons\n",
-    "- Logger la conversation complete pour analyse posterieure"
-   ]
+   "metadata": {},
+   "source": "## Conclusion du jeu Fort Boyard\n\nCe notebook a illustré plusieurs concepts avancés de Semantic Kernel :\n\n### Concepts techniques démontrés\n\n1. **Agents conversationnels spécialisés** : chaque agent possède sa propre personnalité et son rôle — la spécialisation vient du prompt, pas du modèle ;\n2. **Stratégie de terminaison personnalisée** : détection automatique du succès (mot deviné), avec ses limites mesurées sur la vraie partie ;\n3. **AgentGroupChat** : orchestration d'un dialogue structuré entre deux agents — sélection (qui parle) et terminaison (quand arrêter) sont deux arbitrages distincts ;\n4. **Gestion du contexte** : maintien de l'historique partagé pour la cohérence — et son coût croissant en tokens, visible dans les logs (72 → 3029 prompt tokens sur 7 tours).\n\n### Applications pratiques\n\nCe pattern peut être adapté pour :\n- **Jeux éducatifs** : quiz interactifs, devinettes pédagogiques ;\n- **Interviews automatisées** : un agent questionne, l'autre répond ;\n- **Débat structuré** : deux agents défendent des positions opposées ;\n- **Scénarios de formation** : simulation de conversations professionnelles.\n\n### Points d'amélioration possibles\n\n- **Durcir la détection de victoire** (exercice 3) : normaliser accents et espaces, et exiger une *affirmation* plutôt qu'une *question* ;\n- **Compter les tours** pour afficher un score (« deviné en 7 questions ») ;\n- **Répondre à la question finale** : la partie s'arrête avant le « Oui » du Père Fouras — une stratégie à deux états (question posée → réponse attendue) ferait un vrai échange final."
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Résumé

Tranche densité du tracker #11271 : `SemanticKernel/fort-boyard-python.ipynb` passe de **590 à 1299** caractères de prose par cellule de code (5907 → 12996 chars sur 10 cellules code). Enrichissement **markdown-only** : les 10 cellules code sont byte-identical (sources, `execution_count`, outputs, ordre — vérifié par assertion dans le script de build), exception C.2 (modification uniquement markdown → outputs précédents valides), **zéro exécution** — conforme au gel disque jusqu'au SSD 22/08.

Grain: MED/notebook-python (CONTENU, tranche densité) — lane myia-po-2026:CoursIA — prev: MED/guard #11675

## Ce que l'enrichissement enseigne (ancré sur l'output réelle de la partie)

La lecture complète de l'output du jeu ([24], 17 859 chars) a fourni les ancrages — toutes les interprétations nouvelles citent des chiffres présents dans les outputs :

- **Interprétation de la partie** (la cellule-manquante du notebook) : 14 invocations en alternance stricte (7+7) en ~32 s ; le Père Fouras **reconstruit une vraie charade** (contre-/constitution/-ment — le modèle n'a pas reçu la décomposition) ; Laurent **s'auto-corrige** au dernier tour en relisant son prompt dans l'historique ; la terminaison s'est déclenchée sur une **question** (« Est-ce que le mot est "anticonstitutionnellement" ? ») et non une victoire — limite du test de sous-chaîne, exactement ce que l'exercice 3 propose de durcir ; le coût du contexte partagé est visible : `prompt_tokens` 72 → 3029 dont `cached_tokens=2432`.
- **Fusion des headers redondants** : [2]+[3] (install/config), [8]+[9]+[10] (prompts/instanciation), [12]+[19] (stratégie), [14]+[21] (groupe), [18]+[23] (lancement) — 5 doublons structurels éliminés, 28 → 25 cellules.
- **3 interprétations nouvelles après code** (terminaison, config corrigée, partie) — pattern notebook-conventions (cellule d'interprétation APRÈS la cellule de code interprétée).
- **Prose de contexte enrichie** : intro (les 4 briques d'orchestration en miniature), mot à deviner (l'asymétrie d'information comme propriété de conception), anatomie des prompts (rôle/mission/contrainte), sélection vs terminaison (les DEUX arbitrages d'un group chat).
- **Conclusion enrichie** : les points d'amélioration renvoient aux observations réelles (répondre à la question finale, compter les tours, durcir la détection).

## Validation

- `pedagogy_density.py` : **PASS** — 1299 ≥ 1200 (590 avant).
- `check_markdown_claims_output.py` (anchor-check ★★★, c.1331p10488) : **CLEAN** — 0 finding ; tous les chiffres cités sont dans les outputs précédentes (14 invocations, 72→3029, cached 2432, 7+7, ~32 s).
- `validate_pr_notebooks.py origin/main <nb>` : PASS 10/10 code cells (EXEC_PROVED inchangés — markdown-only).
- Ratchets papermill/exec : non-applicables (aucune output ni ec modifié) — lancés par sécurité au runbook.
- Cellules code byte-identical : assertion Python dans le build (comparaison des dicts complets) + diff git qui ne montre que des cellules markdown.
- Exercices : 3 existants conservés tels quels (stubs C.1 conformes — `return None`/`print("Exercice a completer")`), aucun ajout nécessaire (plancher ≥3 tenu).
- README série : ligne `fort-boyard-python` corrigée — elle citait `KernelFunctionTerminationStrategy` alors que le notebook sous-classe `TerminationStrategy` directement (classe `FortBoyardTerminationStrategy` définie dans le notebook). **Audit fichier entier §E** : disque 20 `.ipynb` pédagogiques = `CATALOG-STATUS pedagogical_count: 20`, note d'exclusion des sorties NotebookMaker/AutoInteractive présente et correcte, aucun autre écart.
- Catalogue : byte-identique à main (aucun marqueur touché).

## Périmètre

2 fichiers : le notebook (markdown-only) + README série (1 ligne). Aucun autre changement.

See #11271 (tranche, pas clôture du tracker)
