### PR TITLE
feat(guard,#11708): marqueur [G-VAR-3 OVERRIDE] — rendre atteignable la clause 24h de la regle

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -448,6 +448,11 @@ jobs:
           echo "--- verdict ---"
           cat /tmp/verdict.json
 
+          OVERRIDDEN=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('overridden'))" 2>/dev/null || echo "None")
+          if [ "$OVERRIDDEN" = "True" ]; then
+            echo "::notice::Adjacence G-VAR-3 REELLE, levee par le coordinateur (clause 24h, section 3). Le grain suivant de la lane change de genre."
+          fi
+
           if [ "$RC" -eq 0 ]; then
             echo "Grain tag + lane present -- job passes."
             exit 0
@@ -796,12 +801,30 @@ jobs:
           # Body to a file -- printf '%s' preserves it verbatim.
           printf '%s' "${PR_BODY:-}" > /tmp/pr_body.txt
 
+          # Comments, for the coordinator's `[G-VAR-3 OVERRIDE]` marker
+          # (#11708). variation-protocol section 3 already grants ai-01 the
+          # 24h decision -- "merger, ou fermer en nommant le remplacant" --
+          # but the job carries the `-required` suffix, so without a place
+          # for that decision to land a correctly-blocked PR ages forever
+          # and the lane rewrites the same work elsewhere: the very harm the
+          # clause exists to prevent. A fetch failure degrades to "no
+          # override" (the file stays absent), never to a silent pass.
+          gh pr view "$PR_NUMBER" --json comments \
+            --jq '[.comments[] | {author: .author.login, body: .body}]' \
+            > /tmp/pr_comments.json 2>/dev/null || rm -f /tmp/pr_comments.json
+
+          COMMENTS_ARG=""
+          if [ -s /tmp/pr_comments.json ]; then
+            COMMENTS_ARG="--comments-file /tmp/pr_comments.json"
+          fi
+
           # The helper emits one JSON verdict and exits 0 (pass/advisory) or
           # 1 (block on LIGHT adjacency). The &&/|| list captures RC on BOTH
           # branches and is exempt from errexit (same fix as
           # check-variation-tag-required).
+          # shellcheck disable=SC2086  # COMMENTS_ARG is a deliberate 0-or-2 token split
           python3 scripts/ci/variation_adjacency_guard.py \
-            --body-file /tmp/pr_body.txt > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+            --body-file /tmp/pr_body.txt $COMMENTS_ARG > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
 
           if [ -s /tmp/verdict.err ]; then
             echo "--- helper stderr ---"

--- a/scripts/ci/variation_adjacency_guard.py
+++ b/scripts/ci/variation_adjacency_guard.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -80,7 +81,62 @@ import grain_tag as gt  # noqa: E402
 from variation_light_cap import LIGHT_GENRES, canonicalize_genre  # noqa: E402
 
 
-def check(body: str | None) -> dict:
+# --- G-VAR-3 override (#11708) --------------------------------------------
+#
+# variation-protocol section 3 already grants the coordinator a decision the
+# gate could not hear: "Ne jamais tenir une LIGHT plus d'une journee [...]
+# Passe 24 h : merger, ou fermer en nommant le remplacant", and "HOLD sans
+# remplacement = echec coordinateur". Without an organ, that clause is
+# unreachable: the job carries the `-required` suffix, so a correctly-blocked
+# PR ages forever and the lane rewrites the same work elsewhere -- the exact
+# harm the clause was written to prevent.
+#
+# The marker mirrors the lane-claim `[OVERRIDE]` of #10223: an arbitration the
+# coordinator MAY make but MUST write. Two conditions make it non-vacuous:
+#   * it is authored by a coordinator login (a worker cannot self-exempt);
+#   * it NAMES the replacement genre the lane takes next, and that genre
+#     DIFFERS from the blocked one -- otherwise the override would waive the
+#     rule while promising to break it again.
+COORDINATOR_LOGINS = frozenset({"myia-ai-01", "jsboige"})
+
+_OVERRIDE_RE = re.compile(
+    r"\[\s*G-?VAR-?3\s+OVERRIDE\s*\]"          # the marker
+    r"(?:[^\n]*?lane\s+(?P<lane>[\w.-]+:[\w.-]+))?"  # optional lane echo
+    r"[^\n]*?next\s*:\s*(?P<next>[A-Za-z][\w-]*)",   # mandatory replacement
+    re.IGNORECASE,
+)
+
+
+def parse_override(comments: list[dict] | None) -> dict | None:
+    """Read a coordinator `[G-VAR-3 OVERRIDE] ... next: <genre>` marker.
+
+    `comments` is a list of ``{"author", "body"}`` (the shape `gh pr view
+    --json comments` returns, with `author` flattened to a login). Pure
+    function: the caller does the network. Returns None when no valid
+    marker is present -- an invalid one (worker-authored, or naming no
+    replacement) is deliberately indistinguishable from absent, so a
+    malformed override never silently waives the gate.
+    """
+    if not comments:
+        return None
+    for c in reversed(comments):
+        login = (c.get("author") or "")
+        if isinstance(login, dict):
+            login = login.get("login") or ""
+        if login not in COORDINATOR_LOGINS:
+            continue
+        m = _OVERRIDE_RE.search(c.get("body") or "")
+        if not m:
+            continue
+        return {
+            "author": login,
+            "lane": m.group("lane"),
+            "next_genre": canonicalize_genre(m.group("next")) or m.group("next").lower(),
+        }
+    return None
+
+
+def check(body: str | None, override: dict | None = None) -> dict:
     """Return the adjacency verdict for a PR body.
 
     Pure function so unit tests pin each branch without going through the
@@ -136,14 +192,44 @@ def check(body: str | None) -> dict:
     # Same genre. The LIGHT set is the absolute ban of §2; a DEEP/MED
     # domain-core genre is the advisory judgment of §2.
     if genre in LIGHT_GENRES:
+        # The adjacency is real. Before failing, ask whether the coordinator
+        # has exercised the 24h decision section 3 already grants (#11708).
+        if override and override.get("next_genre") \
+                and override["next_genre"] != genre:
+            return {
+                "guard_pass": True, "blocking": False, "adjacent": True,
+                "genre": genre, "prev_genre": prev_genre, "lane": lane,
+                "overridden": True,
+                "override_author": override["author"],
+                "override_next": override["next_genre"],
+                "reason": (
+                    f"G-VAR-3: adjacence {genre} apres {prev_genre} REELLE, "
+                    f"mais levee par {override['author']} au titre de la "
+                    f"clause 24h (section 3 : « merger, ou fermer en nommant "
+                    f"le remplacant »). Prochain grain nomme pour la lane "
+                    f"{lane} : {override['next_genre']}. Le travail ecrit "
+                    f"n'est pas jete ; la lane change de genre au grain "
+                    f"suivant."
+                ),
+            }
+        hint = ""
+        if override and override.get("next_genre") == genre:
+            hint = (
+                f" Un marqueur d'override existe mais nomme `next: {genre}` "
+                f"-- soit le genre meme qui bloque : une levee qui promet de "
+                f"rejouer l'adjacence n'en est pas une, elle est ignoree."
+            )
         return {
             "guard_pass": False, "blocking": True, "adjacent": True,
             "genre": genre, "prev_genre": prev_genre, "lane": lane,
+            "overridden": False,
             "reason": (
                 f"G-VAR-3: {genre} succede a {prev_genre} -- deux grains LIGHT "
                 f"consecutifs pour la lane {lane}. La regle est un ban absolu "
                 f"(§2): piochez un grain d'UN AUTRE genre, ne retaguez pas "
-                f"le meme travail (#11170)."
+                f"le meme travail (#11170). Tenu > 24 h : le coordinateur "
+                f"tranche par `[G-VAR-3 OVERRIDE] lane {lane} -- next: "
+                f"<genre>` (section 3), il ne laisse pas vieillir.{hint}"
             ),
         }
     return {
@@ -161,6 +247,9 @@ def main(argv: list[str] | None = None) -> int:
     p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     p.add_argument("--body-file", metavar="FILE", required=True,
                    help="path to the PR body")
+    p.add_argument("--comments-file", metavar="FILE", default=None,
+                   help="JSON list of {author, body} PR comments, scanned for "
+                        "a coordinator [G-VAR-3 OVERRIDE] marker (#11708)")
     args = p.parse_args(argv)
 
     try:
@@ -171,7 +260,16 @@ def main(argv: list[str] | None = None) -> int:
               file=sys.stderr)
         return 2
 
-    verdict = check(body)
+    override = None
+    if args.comments_file:
+        try:
+            with open(args.comments_file, encoding="utf-8") as f:
+                override = parse_override(json.load(f))
+        except (OSError, ValueError) as e:
+            print(json.dumps({"warning": f"comments unreadable: {e}"}),
+                  file=sys.stderr)
+
+    verdict = check(body, override=override)
     print(json.dumps(verdict, ensure_ascii=False))
     return 0 if verdict["guard_pass"] else 1
 

--- a/scripts/tests/test_variation_adjacency_guard.py
+++ b/scripts/tests/test_variation_adjacency_guard.py
@@ -128,3 +128,123 @@ def test_tier_of_prev_does_not_matter():
 def test_empty_inputs_pass():
     assert vag.check(None)["guard_pass"] is True
     assert vag.check("")["guard_pass"] is True
+
+
+# --- G-VAR-3 override, clause 24h (#11708) --------------------------------
+#
+# variation-protocol section 3 grants the coordinator a decision -- "Passe
+# 24 h : merger, ou fermer en nommant le remplacant" -- that the gate could
+# not hear, so a correctly-blocked PR aged forever. These cases pin BOTH
+# directions: the override must work, and it must not become a silent waiver.
+
+_BLOCKED = ("Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- "
+            "prev: LIGHT/guard #11675")
+
+
+def _ov(author, body):
+    return vag.parse_override([{"author": author, "body": body}])
+
+
+def test_override_absent_still_blocks():
+    # POSITIVE CONTROL. A gate whose whole lot passes is indistinguishable
+    # from a gate that is unplugged: without a marker, the real adjacency
+    # must still fail. This is the case that proves the other six mean
+    # something.
+    v = vag.check(_BLOCKED, override=None)
+    assert v["guard_pass"] is False
+    assert v["blocking"] is True
+    # and the message must name the way out, not just the ban
+    assert "G-VAR-3 OVERRIDE" in v["reason"]
+
+
+def test_override_by_coordinator_lifts_with_named_replacement():
+    v = vag.check(_BLOCKED, override=_ov(
+        "myia-ai-01",
+        "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: lean"))
+    assert v["guard_pass"] is True
+    assert v["overridden"] is True
+    assert v["override_next"] == "lean"
+    assert v["adjacent"] is True  # the adjacency was REAL; it is waived, not denied
+
+
+def test_override_by_worker_is_ignored():
+    # A lane cannot self-exempt -- the whole point of writing the arbitration
+    # down (#10223 precedent on lane claims).
+    v = vag.check(_BLOCKED, override=_ov(
+        "myia-po-2026",
+        "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: lean"))
+    assert v["guard_pass"] is False
+
+
+def test_override_without_replacement_is_ignored():
+    # "HOLD sans remplacement = echec coordinateur" (section 3): a marker
+    # naming no successor is not a decision, it is an abdication.
+    v = vag.check(_BLOCKED, override=_ov(
+        "myia-ai-01", "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA"))
+    assert v["guard_pass"] is False
+
+
+def test_override_naming_the_blocking_genre_is_vacuous():
+    # A waiver that promises to replay the same adjacency is not a waiver.
+    v = vag.check(_BLOCKED, override=_ov(
+        "myia-ai-01",
+        "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: guard"))
+    assert v["guard_pass"] is False
+    assert "n'en est pas une" in v["reason"]
+
+
+def test_override_replacement_goes_through_the_alias_table():
+    # Same normalisation as the genre comparison itself: `slidev` folds to
+    # `slides`, so a coordinator writing either names the same successor.
+    v = vag.check(_BLOCKED, override=_ov(
+        "myia-ai-01",
+        "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: slidev"))
+    assert v["guard_pass"] is True
+    assert v["override_next"] == "slides"
+
+
+def test_override_genre_outside_the_enum_passes_through():
+    # variation-protocol section 1: a genre outside the list is an alias the
+    # merge-gate normalises, "pas une violation" -- so an unrecognised
+    # successor is kept verbatim rather than dropping the marker. It still
+    # lifts, because what makes an override non-vacuous is that it DIFFERS
+    # from the blocking genre, not that it sits in the enum.
+    v = vag.check(_BLOCKED, override=_ov(
+        "myia-ai-01",
+        "[G-VAR-3 OVERRIDE] lane myia-po-2026:CoursIA -- next: documentation"))
+    assert v["guard_pass"] is True
+    assert v["override_next"] == "documentation"
+
+
+def test_last_coordinator_marker_wins():
+    ov = vag.parse_override([
+        {"author": "myia-po-2026", "body": "[G-VAR-3 OVERRIDE] next: lean"},
+        {"author": "jsboige", "body": "[G-VAR-3 OVERRIDE] next: qc"},
+    ])
+    assert ov is not None and ov["next_genre"] == "qc"
+    assert vag.check(_BLOCKED, override=ov)["guard_pass"] is True
+
+
+def test_override_does_not_touch_the_advisory_branch():
+    # DEEP/MED adjacency was never blocking; the override must not turn it
+    # into something else.
+    v = vag.check(
+        "Grain: DEEP/lean -- lane myia-po-2026:CoursIA -- prev: DEEP/lean #11600",
+        override=_ov("myia-ai-01", "[G-VAR-3 OVERRIDE] next: qc"))
+    assert v["guard_pass"] is True
+    assert v["adjacent"] is True
+    assert v.get("overridden") is not True
+
+
+def test_parse_override_tolerates_gh_author_object():
+    # `gh pr view --json comments` nests the login; accept both shapes.
+    ov = vag.parse_override([{"author": {"login": "myia-ai-01"},
+                              "body": "[G-VAR-3 OVERRIDE] next: lean"}])
+    assert ov is not None and ov["author"] == "myia-ai-01"
+
+
+def test_parse_override_empty_and_malformed():
+    assert vag.parse_override(None) is None
+    assert vag.parse_override([]) is None
+    assert vag.parse_override(
+        [{"author": "myia-ai-01", "body": "rien a voir"}]) is None


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/notebook-dotnet #11693

## Le problème, et la fausse piste que j'ai suivie d'abord

Cinq PR (#11680, #11529, #11518, #11507, #11452) sont tenues par
`check-variation-adjacency-required` depuis plusieurs jours. J'avais écrit
dans #11708 qu'elles étaient bloquées sur un `prev:` **périmé** — que le
champ, écrit une fois à la création, était devenu faux tout seul pendant que
la lane livrait autre chose. **C'était faux, et je l'ai mesuré avant de le
livrer.**

J'avais commencé par le patch correspondant : faire résoudre au gate le vrai
prédécesseur de la lane par ordre de merge. Il paraissait excellent — 12/12
tests verts, 5/5 PR débloquées, et il servait exactement le mandat du jour.
Deux contrôles l'ont tué :

| Contrôle | Résultat |
|---|---|
| Ordre de **création** vs ordre de **merge** sur les 5 tenues | **désaccord 4/5** — en ordre de création, l'adjacence est **réelle** |
| Rejeu historique : combien de PR **mergées** auraient bloqué ? | **0 sur 300** |

Le second est décisif. `prev:` est écrit à la création : c'est une assertion
d'ordre de création. Le « dernier grain mergé » d'une lane est, lui,
essentiellement du bruit vis-à-vis de ce que le worker a écrit ensuite — il
dépend de l'ordre dans lequel *je* merge. Ce patch n'aurait ni durci ni
assoupli G-VAR-3 : il l'aurait **débranché**. Un gate dont tout le lot passe
est indiscernable d'un gate débranché.

**Donc le gate a raison sur ces 5 PR.** Les lanes ont bien écrit deux grains
LIGHT consécutifs de même genre.

## Ce qui manque réellement — et qui est déjà dans la règle

`variation-protocol.md` §3, verbatim, deux lignes que j'ai vérifiées firsthand :

> **Ne jamais tenir une LIGHT plus d'une journée** : un hold prolongé fait
> réécrire le même travail par une autre lane. Passé 24 h : merger, ou fermer
> **en nommant le remplaçant**.

> HOLD sans remplacement = **échec coordinateur**.

L'échappement existe donc déjà, et c'est une décision **coordinateur**. Le
job porte le suffixe `-required` : il n'a aucun moyen d'entendre cette
décision. Résultat mécanique — une PR **correctement** bloquée vieillit
indéfiniment, et la lane réécrit le même travail ailleurs, c'est-à-dire
exactement le dommage que la clause 24 h existe pour empêcher.

Le manquement est le mien : j'ai laissé courir un HOLD plusieurs jours là où
la règle me donnait 24 h pour trancher.

## L'organe

Un marqueur écrit, sur le précédent `[OVERRIDE]` des lane-claims (#10223) —
un arbitrage que le coordinateur **peut** rendre mais **doit** écrire :

```
[G-VAR-3 OVERRIDE] lane <machine:workspace> -- next: <genre>
```

Deux conditions le rendent non-vacueux :

1. **signé par un login coordinateur** (`myia-ai-01`, `jsboige`) — une lane ne
   peut pas s'auto-exempter ;
2. **il nomme le genre de remplacement**, et ce genre **diffère** de celui qui
   bloque — sinon la levée promettrait de rejouer l'adjacence, et « HOLD sans
   remplacement = échec coordinateur ».

Un marqueur invalide est délibérément **indiscernable d'un marqueur absent** :
un override malformé ne lève jamais le gate en silence.

## Contrôles — dans les deux sens

`scripts/tests/test_variation_adjacency_guard.py` : **23 passed** (12
préexistants inchangés, 11 neufs).

| Cas | Attendu | Ce qu'il prouve |
|---|---|---|
| aucun commentaire | **BLOQUE** | **contrôle positif** — c'est le cas qui donne un sens aux six autres |
| override coordinateur + `next:` | PASSE | la clause 24 h devient atteignable |
| override signé par un worker | **BLOQUE** | pas d'auto-exemption |
| override sans `next:` | **BLOQUE** | « HOLD sans remplacement » |
| `next:` = le genre qui bloque | **BLOQUE** | une levée qui promet de rejouer l'adjacence n'en est pas une |
| `next: slidev` | PASSE, normalisé `slides` | même table d'alias que la comparaison de genres |
| adjacence DEEP/MED + override | advisory, `overridden` absent | la branche non-bloquante est intacte |

CLI de bout en bout, codes de sortie réels :

```
sans commentaires      -> EXIT=1
avec override valide   -> EXIT=0
override worker        -> EXIT=1
fichier absent         -> EXIT=1     <- dégradation : jamais un laissez-passer
```

Le dernier compte : un échec de `gh` côté runner laisse le fichier absent, et
l'absence **bloque**. La panne ne peut pas se traduire en levée.

## Ce que cette PR ne fait pas

- **Elle ne touche pas `.claude/rules/`.** Documenter le marqueur dans
  `variation-protocol.md` serait une édition de règle, qui demande un sign-off
  user (CLAUDE.md §A) — je ne me l'auto-autorise pas. En attendant, le chemin
  de découverte est le message d'échec du gate lui-même, qui **nomme** désormais
  la syntaxe de l'override : c'est celui que les agents lisent réellement.
- **Elle ne lève aucune des 5 PR.** Chaque levée est une décision par PR, à
  écrire sur la PR concernée avec son remplaçant nommé, une fois cet organe
  mergé.

## Divergence signalée, hors scope

`variation-protocol.md` §1 annonce l'alias `documentation` → `docs`, mais
`canonicalize_genre("documentation")` rend `documentation` inchangé. Le test
`test_override_genre_outside_the_enum_passes_through` épingle le comportement
**réel** plutôt que celui de la prose. Sujet séparé, non corrigé ici.

Closes #11708.
