### PR TITLE
fix(guard,#11695): _fence_mask au niveau check_assertion — chemin manuel --assert ne lit plus les transcriptions

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -208,10 +208,47 @@ def extract_baseline_moves(diff_text: str) -> list[BaselineMove]:
     return moves
 
 
+def _fence_mask(text: str) -> str:
+    """Blank every line inside a ``` or ~~~ fence (spaces, length preserved).
+
+    Same exemption motif as _fence_line_indices (#11670/#11675, extraction
+    level): a fence is a transcription, never the author's own claim. This
+    mask covers the --assert path, where a reviewer confronts a WHOLE body
+    against the file list: a fenced L898 proof containing "0 fichiers en
+    commun" must not be misread as the author claiming a 0-file perimeter.
+    When the fence PRECEDES the prose claim, search() stops at the fenced
+    zero and the coincidence that let the #11675 founder body pass
+    disappears (#11695).
+    """
+    masked_lines: list[str] = []
+    in_fence = False
+    for raw in text.splitlines(keepends=True):
+        stripped = raw.strip()
+        newline = "\n" if raw.endswith("\n") else ""
+        if in_fence:
+            masked_lines.append(" " * (len(raw) - len(newline)) + newline)
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                in_fence = False
+        elif stripped.startswith("```") or stripped.startswith("~~~"):
+            masked_lines.append(" " * (len(raw) - len(newline)) + newline)
+            in_fence = True
+        else:
+            masked_lines.append(raw)
+    return "".join(masked_lines)
+
+
 def check_assertion(files: list[dict], assertion: str) -> list[str]:
-    """Confront a perimeter assertion with the effective file list."""
+    """Confront a perimeter assertion with the effective file list.
+
+    Fence blocks (transcribed commands, L898 proof) are masked out of the
+    scan (#11695). The final "non verifiable" guard therefore fires for a
+    body composed only of fence transcriptions: no claim OUTSIDE fences
+    means no verifiable author assertion, and such a body must not pass
+    in silence.
+    """
     problems: list[str] = []
-    count_claim = COUNT_CLAIM.search(assertion)
+    scan_target = _fence_mask(assertion)
+    count_claim = COUNT_CLAIM.search(scan_target)
     if count_claim:
         claimed = int(count_claim.group(1))
         if claimed != len(files):
@@ -219,12 +256,12 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
                 f"l'assertion pretend {claimed} fichier(s), la liste effective en compte {len(files)} : "
                 + ", ".join(f["path"] for f in files)
             )
-    exclusive = _has_exclusivity(assertion.lower())
+    exclusive = _has_exclusivity(scan_target.lower())
     if exclusive:
         for f in files:
             if f["path"].startswith(WORKFLOW_PREFIX):
                 base = f["path"].rsplit("/", 1)[-1]
-                if base not in assertion:
+                if base not in scan_target:
                     problems.append(
                         f"assertion d'exclusivite sans nommer le workflow touche {f['path']} "
                         "(critere #11268-2 : tout .github/workflows/** doit etre enumere nommement)"

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -770,3 +770,52 @@ def test_founding_incident_still_blocks_from_the_pr_body():
     blocking = [c for c in cands if c.blocking]
     assert blocking
     assert check_assertion(FILES_11227, blocking[0].text)
+
+
+# --- #11695: --assert false-positives when the fence PRECEDES the prose ---------
+# Measured 2026-08-18 by po-2026 (post-merge verify of #11675): the gate path
+# (--scan-thread) was fixed at extraction level, but the MANUAL reviewer path
+# (--assert, whole body to check_assertion) still trips COUNT_CLAIM on a fenced
+# L898 transcription when it appears BEFORE the correct prose claim -- search()
+# stops at the first occurrence, so the founder body of #11675 passed only by
+# coincidence of ordering. A pass that depends on appearance order proves nothing.
+
+FENCE_FIRST_BODY = (
+    "## Preuve anti-collision (L898)\n"
+    "\n"
+    "```\n"
+    "$ gh pr list --state open --json files\n"
+    "0 fichiers en commun avec les autres PR\n"
+    "```\n"
+    "\n"
+    "Perimetre : 1 fichier modifie.\n"
+)
+FENCE_ONLY_BODY = (
+    "## L898 verifie\n"
+    "\n"
+    "```\n"
+    "$ gh pr list --state open --json files\n"
+    "0 fichiers en commun\n"
+    "```\n"
+)
+FILES_11695 = [{"path": "MyIA.AI.Notebooks/GenAI/Audio/XTTS/foo.ipynb", "additions": 5, "deletions": 2}]
+
+
+def test_assert_fence_before_prose_does_not_misread_transcription():
+    """#11695 case 1: fenced '0 fichiers en commun' BEFORE the prose claim.
+    The transcription is not the author's assertion; the prose claim (1 fichier)
+    matches the file list exactly -> must NOT report a problem."""
+    assert check_assertion(FILES_11695, FENCE_FIRST_BODY) == []
+
+
+def test_assert_fence_only_body_is_not_a_valid_assertion():
+    """#11695 case 2: body made ONLY of a fence transcription carries no
+    verifiable author claim. After the fix, fences are masked in the scan so
+    the count check ignores the transcribed 0 -- and the 'non verifiable'
+    guard, run on the ORIGINAL text, must still flag it (a body of pure
+    transcription cannot pass silently)."""
+    problems = check_assertion(FILES_11695, FENCE_ONLY_BODY)
+    assert problems, "a transcription-only body must not pass in silence"
+    assert not any("pretend 0" in p for p in problems), (
+        f"must not misread the fenced 0 as the author's claim, got: {problems!r}"
+    )


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2026:CoursIA — prev: MED/notebook-python #11713

## Résumé

#11675 a réparé le chemin qui gate (`--scan-thread`, extraction level). Cette PR répare le chemin **manuel** `--assert` (reviewer confronte le body entier) : `_fence_mask` au niveau `check_assertion`, avec les deux reproductions converties en tests **rouges avant le fix** (sorties collées ci-dessous).

## Sorties rouges AVANT le fix (suite sur origin/main inchangé, capture pytest)

```
________ test_assert_fence_before_prose_does_not_misread_transcription ________
scripts\tests\test_check_pr_perimeter.py:808: in test_assert_fence_before_prose_does_not_misread_transcription
    assert check_assertion(FILES_11695, FENCE_FIRST_BODY) == []
E   assert ["l'assertion...TS/foo.ipynb"] == []
E     Left contains one more item: "l'assertion pretend 0 fichier(s), la liste effective en compte 1 : MyIA.AI.Notebooks/GenAI/Audio/XTTS/foo.ipynb"
____________ test_assert_fence_only_body_is_not_a_valid_assertion _____________
scripts\tests\test_check_pr_perimeter.py:819: in test_assert_fence_only_body_is_not_a_valid_assertion
    assert not any("pretend 0" in p for p in problems), (
```

`2 failed, 44 passed` sur main inchangé — les tests décrivent le défaut, pas le code.

## Implémentation

- `_fence_mask(text)` : blanchit chaque ligne en fence ``` ou ~~~ (espaces, longueur préservée, newlines conservées) — même motif d'exemption que `_fence_line_indices` (#11675), appliqué au niveau `check_assertion` pour le chemin `--assert`.
- `check_assertion` : `scan_target = _fence_mask(assertion)` pour COUNT_CLAIM et l'exclusivité. Une fence contenant « 0 fichiers en commun » n'est plus lue comme un claim de périmètre de l'auteur, **quelle que soit sa position** — la réussite ne dépend plus de l'ordre d'apparition.

## Écart documenté vs l'élément 2 de #11674 (l'arbitrage demandait de le porter)

L'élément 2 tel qu'écrit dans #11674 — garde non-verifiable relue sur l'assertion **ORIGINALE** — est **lui-même défectueux** : sur un corps transcription-seule, le compte fence « 0 fichiers » satisfait `COUNT_CLAIM.search(assertion)` → la garde ne se déclenche pas → le corps **passe en silence**, exactement ce que l'élément 2 prétend empêcher (mesuré : le test `test_assert_fence_only_body_is_not_a_valid_assertion` échoue avec la garde sur l'original). J'ai porté l'**intent** plutôt que la lettre : la présence d'un claim vérifiable se mesure sur le texte **hors fence** — un corps de pure transcription est signalé « non verifiable », et c'est le comportement que le test rouge exige.

## Validation

- Suite : **44 → 46, tous verts** (44 = compte sur origin/main actuel ; l'issue citait 41, main a avancé depuis son ouverture).
- Non-régression fondateur : `test_founding_incident_assertion_fails` + `test_founding_incident_still_blocks_from_the_pr_body` verts (#11227 toujours bloqué, prose sans fence inchangée).
- Chemin gate inchangé : `python scripts/check_pr_perimeter.py 11664 --scan-thread` → `VERDICT: OK` sur la branche patchée (l'extraction de #11675 ne dépend pas de check_assertion pour ses candidats).

## Périmètre

2 fichiers : `scripts/check_pr_perimeter.py` (+ helper + scan masqué) et `scripts/tests/test_check_pr_perimeter.py` (+2 tests + fixtures).

Closes #11695
