### PR TITLE
fix(guard,#11685): bannière transformers fast-path — un repli de perf n'est pas un échec d'outil

### DIFF
--- a/scripts/notebook_tools/check_output_failure_text.py
+++ b/scripts/notebook_tools/check_output_failure_text.py
@@ -109,6 +109,29 @@ _PATTERN_WITNESSES = (
     "simanneal non disponible",
 )
 
+# --- benign banners: matched above, and NOT a tool failure -----------------
+# The emitter says in the same breath that it fell back to a WORKING
+# implementation. The transformers fast-path banner is a PERFORMANCE notice
+# -- identical outputs, slower kernel -- and it is already committed on main
+# in PT_03 and PT_05, merged as the normal state of the PostTraining series
+# (2 occurrences repo-wide, measured 2026-08-19). Blocking PT_02 for carrying
+# the same line would send an author to build a CUDA kernel in order to
+# silence a warning that changed nothing in the notebook (render-volume delta
+# base -> head on #11439: zero loss, PT_02 gains 440 B of widget output).
+#
+# The exception is LITERAL and narrow on purpose. A general "falling back"
+# allowlist would swallow the founding incident itself: its .NET helper ALSO
+# fell back -- to a path that destroyed the SVG. Banners are stripped from a
+# COPY of the text before matching, so a genuine failure sharing the same
+# stream still fires (asserted by --self-test).
+BENIGN_BANNERS = (
+    re.compile(
+        r"\[transformers\]\s*The fast path is not available because one of "
+        r"the required library is not installed\.\s*"
+        r"Falling back to torch implementation\.",
+        re.IGNORECASE),
+)
+
 # --- class 2: absolute path of the executing machine ------------------------
 MACHINE_PATH_PATTERNS = (
     # Windows drive-letter path with at least two segments: D:\dev\CoursIA
@@ -226,8 +249,11 @@ def scan(nb):
     for idx, text in output_texts(nb):
         if not text:
             continue
+        probe = text
+        for _ban in BENIGN_BANNERS:
+            probe = _ban.sub(" ", probe)
         for pat in TOOL_FAILURE_PATTERNS:
-            m = pat.search(text)
+            m = pat.search(probe)
             if m:
                 found["TOOL_FAILURE"].append((idx, m.group(0)[:120]))
                 break
@@ -291,6 +317,26 @@ def self_test(cwd=None):
         if hit:
             failures.append("benign text matched " + str(hit) + ": "
                             + repr(benign))
+
+
+    # Benign banner: matched by "not available", neutralised by
+    # BENIGN_BANNERS -- and it must NOT mask a real failure in the same
+    # stream. Both directions asserted: an exception that only proves it
+    # silences is indistinguishable from a hole.
+    _banner = ("[transformers] The fast path is not available because one of "
+               "the required library is not installed. Falling back to torch "
+               "implementation. To install follow https://github.com/fla-org/"
+               "flash-linear-attention#installation")
+
+    def _one(text):
+        return scan({"cells": [{"cell_type": "code", "outputs": [
+            {"output_type": "stream", "text": text}]}]})["TOOL_FAILURE"]
+
+    if _one(_banner):
+        failures.append("benign transformers fast-path banner still fires")
+    if not _one(_banner + "\nbash: dot: command not found"):
+        failures.append("benign banner masked a real failure in the same "
+                        "stream")
 
     # Replay the founding commit against its parent.
     if git("cat-file", "-e", SELF_TEST_COMMIT, cwd=cwd) is None:


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: MED/guard #11727

## Le faux positif

Le ratchet de #11685 hérite de `check_render_volume_delta` le motif
`not available`, délibérément large — c'est ce qui lui donne sa couverture. Il
attrape donc aussi la bannière transformers, dans `PT_02_sft_baseline` :

```
[transformers] The fast path is not available because one of the required
library is not installed. Falling back to torch implementation.
To install follow https://github.com/fla-org/flash-linear-attention#installation
```

L'émetteur dit **dans la même phrase** qu'il est reparti sur une implémentation
qui marche. C'est une notice de **performance** : sorties identiques, noyau plus
lent. Trois corroborations, pas une :

1. **Elle est déjà sur `main`.** `grep -ro "fast path is not available"
   --include="*.ipynb"` → **2 occurrences**, dans `PT_03_dpo_direct_preference`
   et `PT_05_rlvr_verifiable_rewards` — deux sœurs de la même série, mergées
   comme état normal.
2. **Le delta de volume de rendu de #11439 ne montre aucune perte** (base de
   fusion `a839055b5` → tête) : PT_02 *gagne* 440 o de sortie widget et 599 o de
   flux, rien ne baisse.
3. La bibliothèque manquante est `flash-linear-attention` / `causal-conv1d` : un
   noyau CUDA. Le message du gate — « install the missing tool and RE-EXECUTE »
   — enverrait un auteur le compiler pour faire taire un avertissement qui n'a
   rien changé au notebook.

## Pourquoi l'exception est littérale

Un allowlist général sur « falling back » **avalerait l'incident fondateur
lui-même** : le helper .NET de `988155353` est lui aussi reparti sur un repli —
celui qui a détruit le SVG. Le mot « repli » ne discrimine rien. Seule la
bannière exacte est neutralisée.

Et elle est retirée d'une **copie** du texte avant confrontation, jamais du
scan : un vrai échec partageant le même flux tire toujours.

## Contrôles — dans les deux sens

`--self-test` passe, et **le rejeu du commit fondateur tire toujours** :
`TOOL_FAILURE +18, MACHINE_PATH +12`, planchers tenus. L'exception n'a pas
touché le cas pour lequel le gate existe.

Deux assertions neuves, opposées :

| Entrée | Attendu | Ce qu'elle prouve |
|---|---|---|
| la bannière seule | **muette** | l'exception fait son travail |
| bannière + `bash: dot: command not found` | **tire** | elle ne masque pas un vrai échec du même flux |

La seconde est celle qui compte : une exception dont on ne prouve que le silence
est indiscernable d'un trou.

## Portée mesurée — deux notebooks sur tout le dépôt

`--all` avant / après, sur l'arbre complet :

```
total tool= avant : 92
total tool= apres : 90

<  PT_03_dpo_direct_preference.ipynb tool=1     >  PT_03_... tool=0
<  PT_05_rlvr_verifiable_rewards.ipynb tool=1   >  PT_05_... tool=0
```

Deux lignes changent. Aucune autre.

## Effet

Débloque **#11439** (`Ratchet (base vs PR)` : `TOOL_FAILURE 0 -> 1`,
`cell[26] not available`), et évite que toute re-exécution future de la série
PostTraining rebloque sur la même ligne.

Dette signalée hors scope : PT_03 et PT_05 portent chacun `path=1` — un chemin
machine absolu committé, antérieur, advisory (non gaté). Sujet séparé.

See #11685.

