### PR TITLE
fix(ci): annuler la génération supplantée des workflows de PR — 42 % du CI dépensé pour rien

### DIFF
--- a/.github/workflows/bare-cross-dir-load-gate.yml
+++ b/.github/workflows/bare-cross-dir-load-gate.yml
@@ -86,6 +86,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: bare-cross-dir-load-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bare-cross-dir-load:
     name: "No bare cross-dir #load in changed notebooks"

--- a/.github/workflows/bash-syntax-advisory.yml
+++ b/.github/workflows/bash-syntax-advisory.yml
@@ -36,6 +36,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: bash-syntax-advisory-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   syntax-check:
     name: bash -n every scripts .sh

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -38,6 +38,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: catalog-drift-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   catalog-drift:
     name: "Notebook catalog drift (read-only)"

--- a/.github/workflows/cell-order-gate.yml
+++ b/.github/workflows/cell-order-gate.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: cell-order-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cell-order:
     name: "No cell-ordering regression in changed notebooks"

--- a/.github/workflows/cjk-residue-advisory.yml
+++ b/.github/workflows/cjk-residue-advisory.yml
@@ -47,6 +47,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: cjk-residue-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cjk-residue-advisory:
     name: "CJK residue advisory (label, non-blocking)"

--- a/.github/workflows/degenerate-figure-gate.yml
+++ b/.github/workflows/degenerate-figure-gate.yml
@@ -60,6 +60,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: degenerate-figure-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   degenerate-figure:
     name: "No degenerate figure in changed notebooks"

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -18,6 +18,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: docs-link-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-links:
     runs-on: ubuntu-latest

--- a/.github/workflows/dotnet-nuget-block-advisory.yml
+++ b/.github/workflows/dotnet-nuget-block-advisory.yml
@@ -46,6 +46,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: dotnet-nuget-block-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dotnet-nuget-block-advisory:
     name: ".NET exec-block-without-nuget advisory (label, non-blocking)"

--- a/.github/workflows/exercises-advisory.yml
+++ b/.github/workflows/exercises-advisory.yml
@@ -42,6 +42,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: exercises-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   exercises-advisory:
     name: "Exercises >= 3 advisory (label, non-blocking)"

--- a/.github/workflows/fabricated-output-gate.yml
+++ b/.github/workflows/fabricated-output-gate.yml
@@ -65,6 +65,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: fabricated-output-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fabricated-output:
     name: "No fabricated text output in changed notebooks"

--- a/.github/workflows/hooks-parity.yml
+++ b/.github/workflows/hooks-parity.yml
@@ -22,6 +22,10 @@ on:
       - "scripts/check_hooks_parity.py"
       - "scripts/setup_hooks.py"
 
+concurrency:
+  group: hooks-parity-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   parity:
     name: parity gate

--- a/.github/workflows/ict-tests.yml
+++ b/.github/workflows/ict-tests.yml
@@ -46,6 +46,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ict-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ict-tests:
     name: ICT ${{ matrix.suite-name }}

--- a/.github/workflows/label-paths-guard.yml
+++ b/.github/workflows/label-paths-guard.yml
@@ -35,6 +35,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: label-paths-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   label-paths-guard:
     name: "Label-poser workflows self-cover (blocking)"

--- a/.github/workflows/lane-claim-guard.yml
+++ b/.github/workflows/lane-claim-guard.yml
@@ -39,6 +39,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: lane-claim-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Blocking. Nom portant `-required` -> is_advisory() = False (pr_gate.py).
   # Pas de filtre `paths:` : un job filtre par chemin reste `pending` a vie sur

--- a/.github/workflows/lean-argumentation.yml
+++ b/.github/workflows/lean-argumentation.yml
@@ -41,6 +41,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-argumentation-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-calibration.yml
+++ b/.github/workflows/lean-calibration.yml
@@ -39,6 +39,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-calibration-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-conway-cgt.yml
+++ b/.github/workflows/lean-conway-cgt.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-conway-cgt-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-conway.yml
+++ b/.github/workflows/lean-conway.yml
@@ -89,6 +89,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-conway-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-decision-theory.yml
+++ b/.github/workflows/lean-decision-theory.yml
@@ -68,6 +68,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-decision-theory-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-erc20.yml
+++ b/.github/workflows/lean-erc20.yml
@@ -48,6 +48,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-erc20-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-finiteness.yml
+++ b/.github/workflows/lean-finiteness.yml
@@ -46,6 +46,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-finiteness-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-galois.yml
+++ b/.github/workflows/lean-galois.yml
@@ -48,6 +48,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-galois-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-game-defs-ext.yml
+++ b/.github/workflows/lean-game-defs-ext.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-game-defs-ext-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-game-defs.yml
+++ b/.github/workflows/lean-game-defs.yml
@@ -30,6 +30,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-game-defs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-game-theory.yml
+++ b/.github/workflows/lean-game-theory.yml
@@ -81,6 +81,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-game-theory-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-grothendieck.yml
+++ b/.github/workflows/lean-grothendieck.yml
@@ -62,6 +62,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-grothendieck-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-i18n-drift.yml
+++ b/.github/workflows/lean-i18n-drift.yml
@@ -37,6 +37,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-i18n-drift-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   i18n-drift:
     name: "i18n sibling drift"

--- a/.github/workflows/lean-kelly.yml
+++ b/.github/workflows/lean-kelly.yml
@@ -33,6 +33,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-kelly-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-knot.yml
+++ b/.github/workflows/lean-knot.yml
@@ -102,6 +102,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-knot-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-learning-theory.yml
+++ b/.github/workflows/lean-learning-theory.yml
@@ -44,6 +44,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-learning-theory-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-mathlib-examples.yml
+++ b/.github/workflows/lean-mathlib-examples.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-mathlib-examples-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-mimo.yml
+++ b/.github/workflows/lean-mimo.yml
@@ -47,6 +47,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-mimo-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-minimax.yml
+++ b/.github/workflows/lean-minimax.yml
@@ -37,6 +37,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-minimax-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-planning.yml
+++ b/.github/workflows/lean-planning.yml
@@ -34,6 +34,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-planning-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-search.yml
+++ b/.github/workflows/lean-search.yml
@@ -37,6 +37,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-search-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-sensitivity.yml
+++ b/.github/workflows/lean-sensitivity.yml
@@ -37,6 +37,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-sensitivity-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-social-choice-peters.yml
+++ b/.github/workflows/lean-social-choice-peters.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-social-choice-peters-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/lean-social-choice.yml
+++ b/.github/workflows/lean-social-choice.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-social-choice-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   fail-on-sorry:
     name: "Proof integrity (no sorry)"

--- a/.github/workflows/lean-sudoku.yml
+++ b/.github/workflows/lean-sudoku.yml
@@ -30,6 +30,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: lean-sudoku-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ci:
     uses: jsboige/CoursIA/.github/workflows/lean-build.yml@main

--- a/.github/workflows/machine-dep-timing-advisory.yml
+++ b/.github/workflows/machine-dep-timing-advisory.yml
@@ -36,6 +36,10 @@ on:
             - 'scripts/notebook_tools/check_machine_dep_timing.py'
             - 'scripts/notebook_tools/tests/test_check_machine_dep_timing.py'
 
+concurrency:
+  group: machine-dep-timing-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     machine-dep-timing:
         runs-on: ubuntu-latest

--- a/.github/workflows/manifest-description-visuelle-gate.yml
+++ b/.github/workflows/manifest-description-visuelle-gate.yml
@@ -48,6 +48,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: manifest-description-visuelle-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   manifest-description-visuelle:
     name: "MANIFEST.md description_visuelle field enforced on changed files"

--- a/.github/workflows/markdown-table-guard.yml
+++ b/.github/workflows/markdown-table-guard.yml
@@ -44,6 +44,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: markdown-table-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   md-table-syntax-advisory:
     name: "Markdown table syntax advisory (label, non-blocking)"

--- a/.github/workflows/md-content-loss-gate.yml
+++ b/.github/workflows/md-content-loss-gate.yml
@@ -45,6 +45,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: md-content-loss-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   md-content-loss:
     name: "No markdown content loss in changed notebooks"

--- a/.github/workflows/ml-tests.yml
+++ b/.github/workflows/ml-tests.yml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ml-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ml-tests:
     name: ML Pipeline Tests (CPU)

--- a/.github/workflows/notebook-exec-sequence-ratchet.yml
+++ b/.github/workflows/notebook-exec-sequence-ratchet.yml
@@ -36,6 +36,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: notebook-exec-sequence-ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ratchet:
     name: Ratchet (base vs PR)

--- a/.github/workflows/notebook-execution-required.yml
+++ b/.github/workflows/notebook-execution-required.yml
@@ -44,6 +44,10 @@ permissions:
   issues: write
   pull-requests: write
 
+concurrency:
+  group: notebook-execution-required-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   detect-changes:
     name: Detect notebook changes

--- a/.github/workflows/notebook-navlink-check.yml
+++ b/.github/workflows/notebook-navlink-check.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: notebook-navlink-check-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-navlinks:
     runs-on: ubuntu-latest

--- a/.github/workflows/notebook-output-failure-ratchet.yml
+++ b/.github/workflows/notebook-output-failure-ratchet.yml
@@ -35,6 +35,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: notebook-output-failure-ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ratchet:
     name: Ratchet (base vs PR)

--- a/.github/workflows/notebook-papermill-ratchet.yml
+++ b/.github/workflows/notebook-papermill-ratchet.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: notebook-papermill-ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ratchet:
     name: Ratchet (base vs PR)

--- a/.github/workflows/notebook-validation.yml
+++ b/.github/workflows/notebook-validation.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: notebook-validation-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate-notebooks:
     runs-on: ubuntu-latest

--- a/.github/workflows/owui-playwright-check.yml
+++ b/.github/workflows/owui-playwright-check.yml
@@ -33,6 +33,10 @@ defaults:
 permissions:
   contents: read
 
+concurrency:
+  group: owui-playwright-check-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   compile-collect:
     name: Compile & Collect (no live server)

--- a/.github/workflows/pedagogy-density-advisory.yml
+++ b/.github/workflows/pedagogy-density-advisory.yml
@@ -42,6 +42,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: pedagogy-density-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pedagogy-density-advisory:
     name: "Pedagogy density >= 1200 c/cell advisory (label, non-blocking)"

--- a/.github/workflows/pr-gate-rerun.yml
+++ b/.github/workflows/pr-gate-rerun.yml
@@ -79,6 +79,15 @@ concurrency:
 jobs:
   reaggregate:
     name: Re-aggregate after guard flip
+    # A CANCELLED guard produced no verdict, so there is nothing to
+    # re-aggregate -- and its payload carries the SUPERSEDED head SHA, so
+    # acting on it would rerun a gate for a head that is no longer the PR's.
+    # Before the ref-keyed concurrency groups added alongside this, guard
+    # cancellations were rare; now every superseded generation ends this way,
+    # which would have turned each saved guard run into a wasted gate rerun.
+    if: >-
+      github.event_name != 'workflow_run'
+      || github.event.workflow_run.conclusion != 'cancelled'
     runs-on: ubuntu-latest
     steps:
       - name: Re-run the original PR gate for the PR head

--- a/.github/workflows/prose-counts-guard.yml
+++ b/.github/workflows/prose-counts-guard.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: prose-counts-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prose-counts:
     runs-on: ubuntu-latest

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -45,6 +45,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: regression-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     name: "No notebook health regression"

--- a/.github/workflows/repo-size-advisory.yml
+++ b/.github/workflows/repo-size-advisory.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: repo-size-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   large-blob-advisory:
     name: Large blob advisory (>= 10 MiB)

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -89,6 +89,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: scripts-tests-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   scripts-tests:
     name: Scripts Tests (CPU)

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -35,6 +35,10 @@ permissions:
 # workflow removes the third-party pin entirely by invoking the docker image
 # directly. Drift detector below asserts parity between hook and CI at runtime.
 
+concurrency:
+  group: secret-scan-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   gitleaks:
     name: Gitleaks secret scanner

--- a/.github/workflows/slides-build-advisory.yml
+++ b/.github/workflows/slides-build-advisory.yml
@@ -68,6 +68,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: slides-build-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   slides-build-advisory:
     name: "Slidev build advisory (label, non-blocking)"

--- a/.github/workflows/stale-base-warning.yml
+++ b/.github/workflows/stale-base-warning.yml
@@ -10,6 +10,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: stale-base-warning-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-base-age:
     name: Check base branch staleness

--- a/.github/workflows/svg-broken-geometry-gate.yml
+++ b/.github/workflows/svg-broken-geometry-gate.yml
@@ -58,6 +58,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: svg-broken-geometry-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   svg-broken-geometry:
     name: "No SVG broken-geometry (negative-dim) defect in changed notebooks"

--- a/.github/workflows/svg-decimal-comma-gate.yml
+++ b/.github/workflows/svg-decimal-comma-gate.yml
@@ -53,6 +53,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: svg-decimal-comma-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   svg-decimal-comma:
     name: "No SVG decimal-comma defect in changed notebooks"

--- a/.github/workflows/svg-empty-display-gate.yml
+++ b/.github/workflows/svg-empty-display-gate.yml
@@ -108,6 +108,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: svg-empty-display-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   svg-empty-display:
     name: "No SVG empty-display defect in changed notebooks"

--- a/.github/workflows/svg-offscreen-flat-gate.yml
+++ b/.github/workflows/svg-offscreen-flat-gate.yml
@@ -49,6 +49,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: svg-offscreen-flat-gate-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   svg-offscreen-flat:
     name: "No offscreen-flat SVG in changed notebooks"

--- a/.github/workflows/testpaths-coverage-guard.yml
+++ b/.github/workflows/testpaths-coverage-guard.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: testpaths-coverage-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     name: testpaths vs CI coverage

--- a/.github/workflows/translation-drift.yml
+++ b/.github/workflows/translation-drift.yml
@@ -27,6 +27,10 @@ permissions:
   contents: read
   pull-requests: write
 
+concurrency:
+  group: translation-drift-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   translation-drift:
     name: "Translation drift (read-only)"

--- a/.github/workflows/translation-guard.yml
+++ b/.github/workflows/translation-guard.yml
@@ -33,6 +33,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: translation-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     name: "No hand-edited translation files on feature branch"

--- a/.github/workflows/translation-parity.yml
+++ b/.github/workflows/translation-parity.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: translation-parity-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   parity:
     runs-on: ubuntu-latest

--- a/.github/workflows/twin-parity.yml
+++ b/.github/workflows/twin-parity.yml
@@ -53,6 +53,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: twin-parity-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   twin-parity:
     name: "Twin parity audit (#8057)"

--- a/.github/workflows/validation-matrix.yml
+++ b/.github/workflows/validation-matrix.yml
@@ -26,6 +26,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: validation-matrix-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -38,6 +38,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: variation-light-genre-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-light-genre-signals:
     name: G-VAR-2/3 GENRE signals (advisory, #10020)

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -49,6 +49,10 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: variation-tag-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-variation-tag:
     name: Check Grain tag conformity


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #11729

## Ce que je cherchais, et ce que j'ai trouvé à la place

Cinq PR (#11338, #11428, #11446, #11522, #11709) portaient `PR gate` comme
seul rouge. J'ai relancé leur gate à la main, puis cherché pourquoi
`pr-gate-stale-sweep.yml` n'en avait vu **qu'une** sur cinq. J'ai commencé par
soupçonner son filtre — il exige que tous les checks non-gate soient
`completed` — et j'ai failli le « corriger ».

**Le filtre avait raison et c'est ma relance qui était l'erreur.** Mesuré
firsthand : chacune des cinq portait au moins un check-run encore `queued`,
depuis 2 h 35 à 3 h 16 :

| PR | check sibling encore `queued` | depuis |
|---|---|---|
| #11428 | No degenerate figure in changed notebooks | 03:39Z |
| #11446 | probeAddresses banner guard · Notebook catalog drift | 04:12Z |
| #11522 | check_interp_positioning.py | 03:59Z |
| #11709 | No hand-edited translation files | 04:20Z |
| #11338 | Gitleaks secret scanner · Gitleaks positive controls | 04:17Z |

Le gate n'était pas périmé : il attendait, légitimement, un constituant qui
n'a jamais démarré. Relancer l'agrégateur au-dessus d'un ensemble incomplet
— ce que le filtre refuse de faire par conception — ne pouvait que produire
un second timeout. Les cinq PR sont d'ailleurs restées `BLOCKED` après mes
relances.

## La vraie cause : la file d'attente, et ce qu'on y met pour rien

Mesuré à 06:57Z : **15 jobs en exécution, 34 runs en file**, et
**466 runs créés dans l'heure écoulée**. Ce n'est pas un incident, c'est un
régime permanent — 270 / 469 / 461 runs sur les trois dernières heures.

En recoupant chaque run avec le plus récent de son couple
(workflow × branche) :

```
runs créés dans l'heure          : 466
déjà supplantés à leur création  : 194   (42 %)
```

**42 % du CI est dépensé sur des générations que personne ne lira** — un
`git push` de plus sur la même branche a rendu leur verdict caduc avant
qu'elles ne démarrent. Et sur 86 workflows déclenchés par `pull_request`,
**72 n'annulent pas leur propre génération supplantée** :

```
avec cancel-in-progress : 14
sans                    : 72
```

## Le correctif

Groupe de concurrence clé-par-ref sur les 71 workflows concernés (motif
maison déjà porté par les 14 autres, ex. `banner-guard.yml`) :

```yaml
concurrency:
  group: <workflow>-${{ github.ref }}
  cancel-in-progress: true                                         # 37 pull_request seul
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}   # 34 push aussi
```

**Un run `push` sur `main` n'est jamais annulé** : un SHA intermédiaire de
`main` est le seul enregistrement de ce qu'il portait, ses gardes doivent
aboutir. C'est pourquoi les 34 workflows qui écoutent aussi `push` prennent
l'expression conditionnelle et non `true` — et c'est aussi pourquoi ce
changement ne récupère **pas** les 96 runs supplantés côté `main` (mes propres
batches de merge), qui restent volontairement exécutés.

`orphaned-delivery-scan.yml` est **exclu** : son groupe global avec
`cancel-in-progress: false` est une sérialisation délibérée.

### Interaction que ce changement crée, et qu'il doit donc réparer

`pr-gate-rerun.yml` écoute `workflow_run: types: [completed]` sur cinq gardes
— et `completed` inclut `cancelled`. Rendre les gardes annulables aurait donc
transformé chaque run économisé en une **relance de gate sur un SHA périmé**
(le payload d'un run annulé porte le head supplanté). D'où le second volet :

```yaml
if: github.event_name != 'workflow_run'
    || github.event.workflow_run.conclusion != 'cancelled'
```

Une garde annulée n'a produit **aucun verdict** : il n'y a rien à ré-agréger.
Correct indépendamment du reste, nécessaire avec.

## Pourquoi ça ne desserre aucune garde

`scripts/pr_gate.py` était **déjà** conçu pour ça — règle 2 du docstring,
`dedupe_latest` : une génération supplantée est écartée, et `cancelled` reste
dans `CONCLUSION_BAD` pour la **plus récente**. Je l'ai exécuté plutôt que cru
sur parole :

```
supplantée cancelled + neuve success   -> PASS   (le cas de ce changement)
la PLUS RÉCENTE est cancelled          -> FAIL   <- contrôle négatif
un vrai échec reste un échec           -> FAIL   <- contrôle négatif
cancelled seul (aucun successeur)      -> FAIL   <- contrôle négatif
A supplanté-vert + B en échec          -> FAIL   <- contrôle négatif
```

Quatre des cinq contrôles sont **négatifs** : ils prouvent que le gate peut
encore rougir. Un lot entièrement vert serait indiscernable d'un gate
débranché.

Suites du dépôt : `test_pr_gate.py` **48 passed**, `test_workflow_branch_pattern.py`
+ `test_check_workflow_label_paths.py` + `test_audit_workflow_path_filters.py`
**43 passed**. 101 workflows re-parsés en YAML, 0 bloc `concurrency` dupliqué,
0 collision de nom de groupe entre workflows.

## Le gain, mesuré et **plus petit** que le titre

Restreint aux runs que **ce** changement aurait effectivement annulés — donc
hors `main`, hors workflows déjà équipés, hors CodeQL/dynamic :

```
runs créés dans l'heure                  : 466
déjà supplantés                          : 194  (42 %)
  dont sur branche de PR                 :  98  (21 %)
  QUE CE CHANGEMENT ANNULE               :  65  (14 %)
```

**14 %, pas 42 %.** Ça ne « répare » pas la saturation : à 15 jobs
concurrents pour 466 arrivées/heure, le déficit est structurel. Ça retire
65 runs/heure d'attente pure devant une file de 34, et ça fait disparaître
tout seul le pire contributeur unique (une branche à 97 runs/heure, dont 49
supplantés).

## Ce que ça ne fait pas

- **Ça ne débloque aucune des cinq PR d'aujourd'hui.** Leurs runs `queued`
  sont déjà dans la file ; ce changement réduit l'entrée, pas l'arriéré.
- **Ça ne touche pas `pr-gate-stale-sweep.yml`.** Son filtre est correct —
  c'est moi qui l'avais mal lu. Il classe cependant un sibling `cancelled` en
  « non-vert » et exclut la PR : conservateur, jamais permissif, mais à
  revoir maintenant que les `cancelled` vont devenir fréquents. Sujet séparé.
- **Ça ne réduit pas les 62 runs/heure de `PR gate (re-aggregate)`** au-delà
  du volet `cancelled` ci-dessus. Le fan-out lui-même est porteur (#10433) ;
  je ne le touche pas ici.

## Aveu de genre

Quatrième grain `guard` consécutif de cette lane (#11716, #11727, #11729,
celui-ci) — de la monoculture META caractérisée, et j'en suis le
coordinateur qui a écrit l'organe. Je **n'utilise pas** le marqueur
`[G-VAR-3 OVERRIDE]` que je viens de livrer pour blanchir mon propre grain :
s'en servir sur soi est exactement ce qu'il existe pour empêcher. Le grain de
contenu `notebook-python` que j'ai promis en `next:` sur #11727 reste dû, et
il passe avant celui-ci.

See #11685.

## Contre-mesure faite APRÈS la rédaction, qui nuance le gain

Avant d'ouvrir cette PR j'ai voulu vérifier qu'elle attaquait bien l'arriéré, en énumérant les 512 runs alors en file et en marquant ceux dont le SHA n'est plus le dernier de leur branche :

```
queued total : 512
branches     :  42
supplantés   :  13     <- 2,5 %
```

**Ma prémisse était fausse.** La file n'est pas faite de générations caduques : elle est faite d'environ **44 workflows par branche** sur 42 branches actives, tous sur le SHA courant. C'est du fan-out **légitime** — les 44 sont de vraies gardes qui ont un verdict à rendre.

Les deux mesures ne se contredisent pas, elles portent sur des objets différents : 42 % des runs **créés dans l'heure** étaient supplantés *à leur création* (fenêtre qui incluait mes 17 rebases, soit le pic de supersession), contre 2,5 % des runs **actuellement en file**. Un run supplanté ne stationne pas : il s'exécute et sort.

Ce que ça change pour cette PR : elle reste correcte et son gain de 65 runs/heure tient, mais **elle ne draine pas l'arriéré et ne le drainerait pas** — le body le disait déjà, la mesure le durcit. La saturation est un problème de **capacité** (≈ 20 jobs concurrents pour 44 gardes × 42 branches), pas de gaspillage récupérable. Le levier qui réduirait vraiment le fan-out est le filtrage par chemin des gardes, et c'est un autre sujet.


