### PR TITLE
fix(twin-parity,#11428): python_sha de l'attestation 2026-08-18 en retard d'un commit (main rouge)

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/sudoku-1-backtracking.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-1-backtracking.yaml
@@ -36,7 +36,7 @@
       note: "Audit post re-execution #11112 tranche (cycle c.291). Source patch minimal cell[3] PUZZLES_DIR -> PUZZLES_DIR.name (Stop & Repair #11302 precedent), outputs refrais (13/13 cells clean, sequence [1..13]). CSharp unchanged (blob/content inchanges)."
     - date: "2026-08-18"
       by: myia-po-2023:CoursIA-2
-      python_sha: 1e1c74f35b5951383b3e0b46f291933955226831
+      python_sha: 8c018779bd7016caba01cdb4c9c45fcaf8aa509b
       csharp_sha: 915c605ea97f5871ff97ba57e94aa2da8716bf2c
       content_python_sha: cfb12738a9abd6b7c9c789b390a1df7e67482b7741cc5868d298a84a9973940d
       content_csharp_sha: d4119b1a371b3bca22b3ab795621ed3428d3f575835d3de724b89167d58623ab


### PR DESCRIPTION
Grain: MED/ledger — lane myia-ai-01:CoursIA — prev: MED/guard #11731

## `main` est rouge, et c'est mon merge qui l'a cassé

`Scripts Tests (CPU)` échoue sur `main` depuis **`58ba34520`** — le squash-merge de #11428, que j'ai mergé ce matin. Quatre runs consécutifs rouges (09:07, 09:18, 09:24, 09:44Z), toujours la même assertion :

```
FAILED scripts/notebook_tools/tests/test_twin_registry_integrity.py::test_audit_shas_exist_in_file_history
  sha(s) du dernier audit jamais apparu(s) comme blob :
  ["Sudoku-1 Backtracking.python_sha = 1e1c74f35b59 (jamais blob d'aucun fichier ...)"]
1 failed, 8624 passed, 31 skipped, 5 xfailed
```

Le blocage est **fleet-wide** : `PR gate` agrège ce job, donc toute PR dont le gate se ré-agrège après ce merge hérite du rouge. C'est exactement la classe d'usure que le mandat en cours vise — des PR qui vieillissent sur un rouge qui ne leur appartient pas.

## Ce que j'ai cru d'abord, et pourquoi c'était faux

Premier réflexe : « le test marche sur un clone incomplet, il sur-accuse ». Deux mesures l'ont écarté :

- `scripts-tests.yml:108` fait `fetch-depth: 0` — l'historique est complet.
- Le blob `1e1c74f35b59` **existe** dans mon clone local, à `e3276e5b6` et `0589b2e44`. Mais `git merge-base --is-ancestor` répond **NO** pour les deux : ce sont des commits de la branche, rendus inatteignables par le squash.

À ce stade la lecture « artefact de squash » était plausible. Elle est fausse aussi, et c'est la troisième mesure qui tranche :

```
blob à la tête de PR #11428 : 8c018779bd7016caba01cdb4c9c45fcaf8aa509b
blob sur main               : 8c018779bd7016caba01cdb4c9c45fcaf8aa509b   ← identiques
```

**Le squash a préservé le contenu exactement.** Si l'attestation avait cité le blob de la tête, elle serait vraie sur `main`. Elle cite le blob d'un commit **antérieur**.

## La vraie cause : un rebaseline à moitié fait

Sur la branche, `e3276e5b6` a produit le blob `1e1c74f35b59`. Le commit **suivant**, `dc07fa3c5` — *« strip stale metadata.papermill block + rebaseline twin SHAs »* — a mis à jour `content_python_sha` (`1bac9173` → `cfb12738`) **sans** mettre à jour `python_sha`.

Le tell est visible à l'œil nu dans le registre, et vaut d'être retenu : deux enregistrements successifs portent **le même `python_sha` et deux `content_python_sha` différents**.

```yaml
- date: "2026-08-17"
  python_sha: 1e1c74f35b59...          # blob X
  content_python_sha: 1bac9173...      # contenu A
- date: "2026-08-18"
  python_sha: 1e1c74f35b59...          # blob X   ← même blob
  content_python_sha: cfb12738...      # contenu B ← contenu différent
```

Un blob **est** son contenu. Deux contenus pour un blob est impossible : l'un des deux champs n'a pas suivi.

## Le correctif — un champ, mesuré et non déduit

```
git rev-parse origin/main:...Sudoku-1-Backtracking-Python.ipynb
  -> 8c018779bd7016caba01cdb4c9c45fcaf8aa509b
_content_sha(origin/main)  -> cfb12738a9ab...   (déjà attesté, inchangé)
csharp_sha                 -> 915c605ea97f...   (== main, inchangé)
```

`python_sha` du seul enregistrement 2026-08-18 : `1e1c74f35b59…` → `8c018779bd70…`. **1 insertion, 1 deletion.** Les enregistrements historiques ne sont pas touchés (le test ne porte que sur le dernier ; un sha ancien peut légitimement pointer un path antérieur).

## Vérifications

| Contrôle | Résultat |
|---|---|
| Suite complète du fichier | **30 passed** |
| **Contrôle négatif** — fix reverté (`git stash`) | **1 failed**, même assertion, même sha |
| `check_twin_parity.py --check` | **157 paires, OK=157, DRIFT=0, MISSING=0** |
| Referents grepés | aucune PR ouverte ne touche `twin_pairs.d/sudoku-1-backtracking.yaml` |

Le contrôle négatif est le point : sans lui, un lot entièrement vert serait indiscernable d'un test débranché.

## Ce que ce n'est pas

**Ce n'est pas une fabrication**, et le test n'a **pas** de faux positif. Il mesurait juste une attestation périmée d'un commit. Le nom du verdict (`fabricated`) est plus dur que le fait : `_classify_attested_sha` range dans cette branche tout sha absent de l'historique du carnet, sans pouvoir distinguer « inventé » de « vrai un commit trop tôt ». La distinction n'est pas cosmétique — elle décide si on ouvre un incident d'intégrité ou si on corrige un champ. Je la note ici plutôt que d'ouvrir une issue de renommage : le message d'assertion cite le sha, donc l'investigation est de toute façon à dix secondes.

## Aveu de genre

`ledger` est un genre LIGHT, et ma lane est déjà en dépassement de veine META. **Je ne revendique pas ce grain comme le plancher du cycle** : c'est une réparation de dégât que *j'ai* causé en mergeant, pas un pick. Le grain de contenu `notebook-python` promis en `next:` reste dû et passe avant tout nouveau grain de harnais.

See #11428.
