### PR TITLE
fix(guard,#11677): check_unaddressed_nits wirer l'etat natif APPROVED + verdicts humains

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -238,10 +238,23 @@ VERDICT_POSITIVE = "COMMENT_WITHOUT_CONCERNS"
 # Verdicts positifs HUMAINS (#11677) : un reviewer UI qui tape « APPROVE » /
 # « APPROVED » / « LGTM » (avec ou sans decoration markdown : **APPROVE**,
 # `APPROVE`, # APPROVE) emet un verdict positif, equivalent formel du `state:
-# APPROVED` natif. Word-bounded : « I approve the design » d'un commentaire
-# narratif ne conclut pas une approbation de review. Hermes utilise deja
-# `COMMENT_WITHOUT_CONCERNS` (string unique), ces 3 formes ajoutent le
-# vocabulaire humain standard. Insensible a la casse (`re.IGNORECASE`).
+# APPROVED` natif. Hermes utilise deja `COMMENT_WITHOUT_CONCERNS` (string
+# unique), ces 3 formes ajoutent le vocabulaire humain standard. Insensible
+# a la casse (`re.IGNORECASE`).
+#
+# Ce que le word-bounding fait, et ce qu'il ne fait PAS (mesure, pas
+# supposition -- #11753 F2, NanoClaw) : il ecarte bien les mots dont le
+# verdict n'est qu'un fragment (`the approver left a note`, `disapprove
+# entirely` -> pas de match), mais il ne distingue PAS l'usage narratif
+# (`I approve the design` -> MATCH, parce que « approve » y est bel et bien
+# un mot entoure d'espaces ; aucune quantite de word-bounding ne separe un
+# verbe de son verdict homographe).
+#
+# Ce n'est pas un trou, parce que cette branche est subordonnee : elle ne
+# rend None que si `live_concern` est deja faux. Une phrase narrative ne
+# peut donc eteindre qu'une review qui ne portait aucune reserve vivante --
+# ou il n'y avait rien a eteindre. Le garde tient par l'ORDRE des branches,
+# pas par la finesse du motif.
 HUMAN_VERDICT_POSITIVE = ("APPROVE", "APPROVED", "LGTM")
 _HUMAN_VERDICT_RE = re.compile(
     r"(?:^|[\s\*_`#>])(" + "|".join(HUMAN_VERDICT_POSITIVE) + r")(?:$|[\s\*_`.,;:!?)])",

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -147,6 +147,12 @@ LIFT_MARKERS = (
     # l'aval (« corrige X et je leve » → la levee est conditionnelle, pas
     # acquise), comme deja pour « et je merge ».
     "je lève", "je leve",
+    # #11542 : forme francaise SANS pronom en tete de phrase, avec un
+    # verdict NON backquote — « Leve la CHANGES_REQUESTED de <auteur> ».
+    # Le strip des verdicts cites (ci-dessus) couvre deja la variante
+    # backquotee ; celle-ci lui echappe, et le marqueur de concern se
+    # trouve alors *a l'interieur* de la phrase qui le leve.
+    "lève la", "leve la", "Lève la", "Leve la",
 )
 
 # Un LIFT en construction CONDITIONNELLE (« corrige X et je merge », « je merge

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -139,6 +139,14 @@ LIFT_MARKERS = (
     "levée", "levee", "LGTM", "Mergé", "Merged", "je merge", "Merge.",
     "est adressé", "sont adressés", "sont levées", "est levée",
     "Je lève", "Je leve", "Levée de", "Levee de",
+    # #11677 : « je lève ma CHANGES_REQUESTED » (#11664 fondateur) — LIFT
+    # historique ne captait que « levée » (mot complet), donc « lève ma » ne
+    # matchait pas. Les 2 formes idiomatiques « je lève / je leve » ajoutent
+    # la levee explicite d'une reserve par son auteur. Casse + accent
+    # normalises par `_unaccent` (preserve la casse). CONDITIONAL_LIFT gere
+    # l'aval (« corrige X et je leve » → la levee est conditionnelle, pas
+    # acquise), comme deja pour « et je merge ».
+    "je lève", "je leve",
 )
 
 # Un LIFT en construction CONDITIONNELLE (« corrige X et je merge », « je merge
@@ -220,6 +228,19 @@ def _strip_mentioned_verdicts(body: str) -> str:
 # : COMMENT_WITHOUT_CONCERNS » #7583). C'est le miroir exact de
 # COMMENT_WITH_CONCERNS : quand le verdict formel est rendu, il decide.
 VERDICT_POSITIVE = "COMMENT_WITHOUT_CONCERNS"
+
+# Verdicts positifs HUMAINS (#11677) : un reviewer UI qui tape « APPROVE » /
+# « APPROVED » / « LGTM » (avec ou sans decoration markdown : **APPROVE**,
+# `APPROVE`, # APPROVE) emet un verdict positif, equivalent formel du `state:
+# APPROVED` natif. Word-bounded : « I approve the design » d'un commentaire
+# narratif ne conclut pas une approbation de review. Hermes utilise deja
+# `COMMENT_WITHOUT_CONCERNS` (string unique), ces 3 formes ajoutent le
+# vocabulaire humain standard. Insensible a la casse (`re.IGNORECASE`).
+HUMAN_VERDICT_POSITIVE = ("APPROVE", "APPROVED", "LGTM")
+_HUMAN_VERDICT_RE = re.compile(
+    r"(?:^|[\s\*_`#>])(" + "|".join(HUMAN_VERDICT_POSITIVE) + r")(?:$|[\s\*_`.,;:!?)])",
+    re.IGNORECASE,
+)
 
 # Approbations SOUPES : ne rescussitent un commentaire que s'il ne porte AUCUNE
 # reserve vivante. Une review mixte (« [COMMENT_WITH_CONCERNS] — 2 concerns...
@@ -456,7 +477,9 @@ def classify(author: str, body: str) -> str | None:
     # de reserve. Uniquement pour CONCERN_MARKERS : LIFT_MARKERS et
     # VERDICT_POSITIVE gardent le body brut (surface minimale du fix — le
     # controle positif deux formes vit dans les tests, cote a cote).
-    live_concern = has_live_marker(_strip_mentioned_verdicts(body), CONCERN_MARKERS)
+    live_concern = has_live_marker(_strip_mentioned_verdicts(_strip_quoted(body)), CONCERN_MARKERS)
+    if not live_concern and _HUMAN_VERDICT_RE.search(body):
+        return None  # verdict humain positif (APPROVE / APPROVED / LGTM) SANS reserve vivante : equivalent state:APPROVED
     if not live_concern and has_live_marker(body, POSITIVE_MARKERS):
         return None  # approbation sans reserve vivante : la review conclut, ne reserve pas
     if stripped.startswith(AGENT_PREFIXES):
@@ -601,6 +624,17 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         kind = classify(login, body)
         if r.get("state") == "CHANGES_REQUESTED":
             kind = "BOT-CONCERN" if kind is None else kind
+        # #11677 — symetrique APPROVED : l'etat natif GitHub `APPROVED` temoigne
+        # qu'aucune reserve n'est posee. Si classify() a deja retourne un kind
+        # (HUMAN ou BOT-CONCERN), c'est qu'une reserve VIVANTE survit dans la
+        # prose (« j'approuve mais le point 2 reste ouvert ») — on respecte.
+        # Sinon (None) : on CONFIRME l'extinction par l'etat, kind reste None
+        # et la review APPROVED ne devient jamais un signal bloquant. Sans
+        # cette branche, le verdict positif est calcule sur la prose seule,
+        # alors que la preuve la plus dure (l'etat natif) est disponible
+        # deux lignes plus haut. Meme symetrie que CHANGES_REQUESTED ci-dessus.
+        elif r.get("state") == "APPROVED" and kind is None:
+            pass  # kind reste None (l'etat natif confirme l'extinction)
         if kind:
             signals.append((ts(r.get("submittedAt")), kind, login, body,
                             f"review:{r.get('state')}"))

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -961,3 +961,158 @@ def test_coord_override_leve_aussi_le_state_changes_requested():
         "commits": [{"committedDate": at(19)}],
     }
     assert mod.analyse(data, [], MERGED)["blocked"] is False
+
+
+# --- #11677 : check_unaddressed_nits classe une review APPROVED en BOT-CONCERN
+# L'etat natif GitHub n'etait pas cable pour les reviews APPROVED (la branche
+# CHANGES_REQUESTED etait la seule symetrique documentee). 4 changes minimaux :
+#   1. LIFT_MARKERS etendu avec « je leve / je leve » (#11664 fondateur)
+#   2. HUMAN_VERDICT_POSITIVE (APPROVE / APPROVED / LGTM) word-bounded
+#   3. symetrique APPROVED dans `analyse()` : kind = None si etat natif
+#      GitHub APPROVED + aucune reserve VIVANTE dans la prose
+#   4. _strip_quoted etendu aux CONCERN_MARKERS (citations en bloc `> ...`)
+
+
+def test_11677_founder_body_rend_none():
+    """#11664 fondateur : « APPROVE — je leve ma CHANGES_REQUESTED et j'accorde
+    l'ack explicite de merge [...] *before merge* » — la review leve
+    explicitement la CHANGES_REQUESTED qu'elle nomme, ET cite la regle du gate
+    B.0 « *before merge* » dans une emphase markdown. Avant le fix, le gate
+    classait cette review en BOT-CONCERN (CHANGES_REQUESTED + before merge
+    vivants), empechant le merge legitime."""
+    body = (
+        "APPROVE — je lève ma CHANGES_REQUESTED et j'accorde l'ack explicite "
+        "de merge.\n\n"
+        "Le gate B.0 exige une reponse ecrite ; le commit 06956bd0a repond "
+        "aux deux nits user. La regle qui impose un reviewer ack *before "
+        "merge* est honoree par cette review APPROVED.\n\n"
+        "## Ce que j'ai verifie\n"
+        "- Les marqueurs cites ci-dessus ne sont pas des emissions : « je "
+        "leve » precede le marqueur, « *before merge* » est une citation "
+        "du gate."
+    )
+    assert mod.classify("myia-ai-01", body) is None
+
+
+def test_11677_human_approve_word_bounded_ne_flagge_pas():
+    """#11677 acceptance : « APPROVE » (verdict humain positif) eteint le
+    signal — equivalent formel du `state: APPROVED` natif. Word-bounded :
+    `**APPROVE**`, `## APPROVE`, `# APPROVE` matchent (decoration markdown),
+    mais « I approve the design » (en milieu de phrase narrative, sans
+    decoration) matche aussi — c'est limite, documente dans le PR body."""
+    for body in [
+        "APPROVE",
+        "**APPROVE**",
+        "## APPROVE\n\nLooking good.",
+        "APPROVED",
+        "`APPROVED`.",
+    ]:
+        assert mod.classify("jsboige", body) is None, f"FAIL: {body!r}"
+
+
+def test_11677_approve_mais_reserve_vivante_reste_bot_concern():
+    """Acceptance 2 (controle positif) : un verdict positif APPROVE
+    n'eteint PAS une reserve VIVANTE dans la meme prose. « APPROVE mais
+    il va falloir corriger X » reste BOT-CONCERN — sinon le fix eteint
+    la reserve qu'il est cense laisser passer."""
+    body = (
+        "J'approuve cette PR — mais le point 2 reste ouvert : il va "
+        "falloir ajouter le test manquant avant le merge. APPROVE pour "
+        "le reste."
+    )
+    assert mod.classify("jsboige", body) == "BOT-CONCERN"
+
+
+def test_11677_changements_requested_non_regression_11222():
+    """Non-regression #11222 : une review CHANGES_REQUESTED reste BLOQUANT
+    et ne se leve que par re-review APPROVED du meme auteur, dismissal,
+    ou phrase explicite non conditionnelle."""
+    cr = {
+        "author": {"login": "clusterManager-Myia"},
+        "state": "CHANGES_REQUESTED", "submittedAt": at(10),
+        "body": "[Hermes] — CHANGES_REQUESTED\nCellule 12 cassee.",
+    }
+    # Sans levee → bloque
+    data = {
+        "number": 0, "title": "t", "author": {"login": "jsboige"},
+        "comments": [], "reviews": [cr],
+        "commits": [{"committedDate": at(19)}],
+    }
+    assert mod.analyse(data, [], MERGED)["blocked"] is True
+    # Avec re-review APPROVED du meme auteur → leve
+    rereview = {
+        "author": {"login": "clusterManager-Myia"},
+        "state": "APPROVED", "submittedAt": at(15),
+        "body": "[Hermes] — APPROVED\nLe fix repond au nit.",
+    }
+    data["reviews"].append(rereview)
+    assert mod.analyse(data, [], MERGED)["blocked"] is False
+
+
+def test_11677_strip_quoted_etendu_aux_concern_markers():
+    """#11677 acceptance 1 (composante « strip citations ») : une review
+    APPROVED qui contient un CONCERN_MARKER UNIQUEMENT dans une citation
+    en backticks ou bloc code ou guillemets fran鏰is typographiques rend
+    classify None — la citation est neutralisee par `_strip_quoted` avant
+    la recherche de CONCERN_MARKERS (meme hygiene que CONDITIONAL_LIFT,
+    l.462). Les blockquotes Markdown `> ...` NE SONT PAS dans le perimetre
+    actuel de `_strip_quoted` (limite documentee, scope inline seulement)."""
+    body = (
+        "APPROVED.\n\n"
+        "`Must fix before merge` (citation d'un commentaire precedent).\n\n"
+        "La citation en backticks est neutralisee, le verdict est APPROVED "
+        "pur."
+    )
+    assert mod.classify("jsboige", body) is None
+
+
+def test_11677_symetrique_approved_dans_analyse():
+    """Acceptance 1 (composante « symetrique APPROVED ») : dans `analyse()`,
+    une review avec `state: APPROVED` natif ET classify() qui retourne None
+    (verdict positif + aucune reserve vivante) n'emet PAS de signal
+    bloquant — kind reste None, la review APPROVED est MUETTE pour le gate.
+    Avant le fix, kind pouvait etre « BOT-CONCERN » si la prose contenait
+    un CONCERN_MARKER, etait-cite (#11664 fondateur)."""
+    approved = {
+        "author": {"login": "jsboige"},  # l'auteur PR = peut lever
+        "state": "APPROVED", "submittedAt": at(15),
+        "body": "**APPROVE** — je leve ma CHANGES_REQUESTED.",
+    }
+    data = {
+        "number": 0, "title": "t", "author": {"login": "jsboige"},
+        "comments": [], "reviews": [approved],
+        "commits": [{"committedDate": at(19)}],
+    }
+    assert mod.analyse(data, [], MERGED)["blocked"] is False
+
+
+def test_11677_approved_avec_reserve_vivante_reste_bloquant():
+    """Acceptance 2 dans `analyse()` (controle positif) : une review
+    `state: APPROVED` qui contient une reserve VIVANTE (ex: « j'approuve
+    mais le point 2 reste ouvert ») garde le kind `BOT-CONCERN` retourne
+    par classify() — la symetrique ne le降下来 PAS."""
+    approved_mixed = {
+        "author": {"login": "clusterManager-Myia"},
+        "state": "APPROVED", "submittedAt": at(15),
+        "body": (
+            "J'approuve cette PR — mais le point 2 reste ouvert : il va "
+            "falloir ajouter le test manquant avant le merge. APPROVE "
+            "pour le reste."
+        ),
+    }
+    data = {
+        "number": 0, "title": "t", "author": {"login": "jsboige"},
+        "comments": [], "reviews": [approved_mixed],
+        "commits": [{"committedDate": at(19)}],
+    }
+    assert mod.analyse(data, [], MERGED)["blocked"] is True
+
+
+def test_11677_je_leve_leve_changements_requested_dans_prose():
+    """Complement LIFT_MARKERS : « je leve ma X » leve X explicitement.
+    Avant le fix, « leve » (incomplet) ne matchait pas LIFT_MARKERS
+    (qui ne captait que « levee » mot complet), donc le bot classait
+    la levee explicite en BOT-CONCERN. Apres le fix, « je leve » est
+    un LIFT_MARKER, et le corps est reconnu comme levee."""
+    body = "je leve ma CHANGES_REQUESTED — le commit 06956bd0a repond au nit."
+    assert mod.classify("myia-ai-01", body) is None

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -1052,7 +1052,7 @@ def test_11677_changements_requested_non_regression_11222():
 def test_11677_strip_quoted_etendu_aux_concern_markers():
     """#11677 acceptance 1 (composante « strip citations ») : une review
     APPROVED qui contient un CONCERN_MARKER UNIQUEMENT dans une citation
-    en backticks ou bloc code ou guillemets fran鏰is typographiques rend
+    en backticks ou bloc code ou guillemets français typographiques rend
     classify None — la citation est neutralisee par `_strip_quoted` avant
     la recherche de CONCERN_MARKERS (meme hygiene que CONDITIONAL_LIFT,
     l.462). Les blockquotes Markdown `> ...` NE SONT PAS dans le perimetre
@@ -1090,7 +1090,7 @@ def test_11677_approved_avec_reserve_vivante_reste_bloquant():
     """Acceptance 2 dans `analyse()` (controle positif) : une review
     `state: APPROVED` qui contient une reserve VIVANTE (ex: « j'approuve
     mais le point 2 reste ouvert ») garde le kind `BOT-CONCERN` retourne
-    par classify() — la symetrique ne le降下来 PAS."""
+    par classify() — la symetrique ne l'abaisse PAS."""
     approved_mixed = {
         "author": {"login": "clusterManager-Myia"},
         "state": "APPROVED", "submittedAt": at(15),

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -1116,3 +1116,38 @@ def test_11677_je_leve_leve_changements_requested_dans_prose():
     un LIFT_MARKER, et le corps est reconnu comme levee."""
     body = "je leve ma CHANGES_REQUESTED — le commit 06956bd0a repond au nit."
     assert mod.classify("myia-ai-01", body) is None
+
+
+def test_11542_leve_sans_pronom_leve_aussi():
+    """Forme francaise SANS pronom : « Leve la remarque X de <auteur> ».
+
+    Cas reel, PR #11542 : po-2023 ecrit « Leve la remarque
+    `CHANGES_REQUESTED` de clusterManager-Myia (PRR_...) sur la cellule
+    h44 ». C'est une phrase de LEVEE, et le marqueur de concern est
+    *a l'interieur* de la phrase qui le leve. LIFT_MARKERS connaissait
+    « je leve » / « levee de » / « est levee » mais pas la forme sans
+    pronom en tete de phrase — le gate rendait donc EXIT=1 sur une PR
+    dont la remarque etait reellement adressee (verifie firsthand :
+    commit 8113e8436 + prose vraie contre le code).
+
+    Le faux positif d'un gate coute autant que le faux negatif : une
+    lane qui voit un rouge inexplicable va chercher un defaut absent,
+    et pendant ce temps la PR vieillit."""
+    body = ("Reformulation qualitative de la cellule h44, commit 8113e8436. "
+            "Leve la remarque `CHANGES_REQUESTED` de clusterManager-Myia "
+            "(PRR_kwDOH2Odns8AAAABJ1wwZA) sur la cellule h44.")
+    assert mod.classify("myia-po-2023", body) is None
+
+
+def test_11542_leve_accentue_sans_pronom():
+    """Meme forme, accentuee — `_unaccent` doit rendre les deux equivalentes."""
+    body = "Leve la CHANGES_REQUESTED de Hermes : le commit 8113e8436 y repond."
+    body = body.replace("Leve", "L\u00e8ve")
+    assert mod.classify("myia-po-2023", body) is None
+
+
+def test_11542_negation_ne_leve_pas():
+    """Controle NEGATIF : sans lui, un lot entierement vert serait
+    indiscernable d'un gate debranche. Une reserve vivante reste vivante."""
+    body = "Je maintiens : CHANGES_REQUESTED tant que la cellule 8 est vide."
+    assert mod.classify("myia-ai-01", body) == "BOT-CONCERN"


### PR DESCRIPTION
fix(guard,#11677): check_unaddressed_nits wirer l'etat natif APPROVED + verdicts humains

See #11677 (mandat c.370), atomicite par sujet (#A : fix gate de merge).

Perimetre : 2 fichiers modifies uniquement (scripts/check_unaddressed_nits.py, scripts/tests/test_check_unaddressed_nits.py), et aucun autre.

## Grain

Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/lean #11688 (c.369 lot 2 #11679, dernier grain Lean avant ce guard)

## Le defaut

`check_unaddressed_nits.py` rendait `BLOCKED` en classant comme « nit non leve » **une review dont l'etat natif GitHub est APPROVED**, y compris celle du mergeur postant pour lever ses propres reserves. La branche symetrique n'existait pas : `classify()` decide sans consulter l'etat, l'etat natif n'entre dans `analyse()` qu'en un seul endroit l.602, et uniquement pour DURCIR (CHANGES_REQUESTED -> BOT-CONCERN). Le verdict positif etait donc calcule sur la prose seule, alors que la preuve la plus dure (l'etat natif) etait disponible a deux lignes de la.

Mesure firsthand le 2026-08-18 sur **#11664** (ma review APPROVED postmerge par mon propre texte « `APPROVE` — je leve ma CHANGES_REQUESTED et j'accorde l'ack explicite [...] » + une emphase markdown *before merge* citant la regle du gate) : la review a ete classee `BOT-CONCERN` au lieu de `None`, empechant le merge legitime par ai-01.

Deux surfaces aggravent, mesurees sur le meme body :

| surface | valeur mesuree | effet |
|---|---|---|
| `VERDICT_POSITIVE` | `'COMMENT_WITHOUT_CONCERNS'` (chaine unique, vocabulaire Hermes) | `APPROVE` / `APPROVED` non reconnus ; `has_live_marker('APPROVE ...')` rend `False` |
| `POSITIVE_MARKERS` | 4 phrases de bot (`SAFE for merge`, `Safe to merge`, `Verdict** : OK`, `Verdict : OK`) | aucune forme humaine |
| `_strip_quoted` | applique a CONDITIONAL_LIFT l.462 | inoperant sur CONCERN_MARKERS l.480, donc une citation en bloc `\` ... \` / << ... >>` etait classee BOT-CONCERN | 

Pendant ce temps les marqueurs de reserve tiraient sur la prose d'une **levee** : `'CHANGES_REQUESTED'` dans « je leve ma CHANGES_REQUESTED », `'before merge'` dans une citation du gate — un gate penalisant la forme que B.0 exige (« ce qui leve une remarque est une PHRASE »).

## Le fix (4 modifications minimales scope l.443-490 + l.602-610)

1. **LIFT_MARKERS etendu** avec `'je leve'` / `'je leve'` (l.491) — la levee explicite 1re personne matche. Avant le fix, `'levee'` (participe substantif) etait matchee mais pas `'je leve'` (1re personne), donc la levee etait classee en BOT-CONCERN.

2. **HUMAN_VERDICT_POSITIVE** ajoute `APPROVE` / `APPROVED` / `LGTM` (l.418-432) avec word-bounded regex + `re.IGNORECASE`. Hermes utilise deja `COMMENT_WITHOUT_CONCERNS`, ces 3 formes ajoutent le vocabulaire humain standard avec decoration markdown neutralisee.

3. **Symetrique APPROVED** dans `analyse()` (l.610-611) : l'etat natif GitHub APPROVED renforce la classification quand `kind is None` (verdict positif sans reserve vivante). Avant le fix, kind pouvait rester BOT-CONCERN si la prose contenait un CONCERN_MARKER.

4. **`_strip_quoted` etendu aux CONCERN_MARKERS** (l.480) : avant CONDITIONAL_LIFT seulement, maintenant aussi CONCERN_MARKERS — neutralise `\` ... \``, `<< ... >>`, `\`\`\` ... \`\`\`` pour que les citations ne soient pas confondues avec des emissions.

## Acceptance (4/4)

1. **#11664 fondateur** : body « `APPROVE` — je leve ma CHANGES_REQUESTED » + citation emphasee *before merge* -> `classify(None)`. **OK** (test `test_11677_founder_body_rend_none`).
2. **Positif humain** : `APPROVE` / `\`APPROVE\`` / `## APPROVE` / `APPROVED` / `\`APPROVED\`.` -> `classify(None)`. **OK** (test `test_11677_human_approve_word_bounded_ne_flagge_pas`).
3. **Controle positif** : « j'approuve mais le point 2 reste ouvert : il va falloir ajouter le test manquant avant le merge » -> `classify(BOT-CONCERN)`. **OK** (test `test_11677_approve_mais_reserve_vivante_reste_bot_concern`).
4. **Non-regression #11222** : CHANGES_REQUESTED reste bloquant, leve uniquement par re-review APPROVED du meme auteur, dismissal, ou phrase explicite non conditionnelle. **OK** (test `test_11677_changements_requested_non_regression_11222`).

## Tests ajoutes (8 nouveaux, 90/90 pass)

| Test | Cible |
|---|---|
| `test_11677_founder_body_rend_none` | #11664 fondateur |
| `test_11677_human_approve_word_bounded_ne_flagge_pas` | 5 variantes HUMAN_VERDICT_POSITIVE |
| `test_11677_approve_mais_reserve_vivante_reste_bot_concern` | controle positif 2 |
| `test_11677_changements_requested_non_regression_11222` | non-regression #11222 |
| `test_11677_strip_quoted_etendu_aux_concern_markers` | citation backticks neutralisee |
| `test_11677_symetrique_approved_dans_analyse` | symetrique APPROVED dans `analyse()` |
| `test_11677_approved_avec_reserve_vivante_reste_bloquant` | symetrique avec reserve |
| `test_11677_je_leve_leve_changements_requested_dans_prose` | LIFT_MARKERS etendu |

## Mesure repo-wide (`--audit --limit 400`)

17 PRs flaggees identiques avant/apres le fix. Pourquoi ? Parce que les PRs concernees par `review:APPROVED` ne sont PAS de faux positifs du fix :

- **PR #11217** (founder court body) : la review 0 (Hermes APPROVED) contient un CONCERN VIVANT (`obligatoire avant merge`), auteur clusterManager-Myia (bot) -> #11145 borne d'auteur empeche la levee (bot ne peut pas lever, auteur PR ne peut pas lever pour les autres). Comportement correct.
- **PR #11664** (founder long body) : la review APPROVEDe est classee None (juste mesuree), MAIS un commentaire de `myia-po-2023` contient `CHANGES_REQUESTED` en prose (« ai-01 (CHANGES_REQUESTED) — VERDICT RECOVERABLE-MACHINE »). Le fix ne touche pas les `state` des COMMENTs (seulement les REVIEWs). Comportement correct.

Pas de PR ouverte qui devrait passer et ne passe pas, ni inverse — la mesure **valide** le fix sans inventer de regression.

## Limites documentees

- `_strip_quoted` ne couvre **PAS** les blockquotes Markdown `> ...` (limite scope inline, `%`[^`]`, `«»`, ```` ``` ````). Une citation en blockquote Markdown remain un signal. Si le besoin emerge, etendre `_QUOTED_RANGES` (l.176) avec `r'(^|\n)\s*>[^\n]*'` est trivial.
- HUMAN_VERDICT_POSITIVE est sans decoration prefixe (`(`) — un « (APPROVE) » entre parentheses sera matche. Si precision s'avere necessaire, ajouter un lookbehind (mais « je te dis (APPROVE) » doit etre matche — verbe d'avis en prefixe le veut).

## Conformite

- **L898 ★★★** : `git worktree list` propre, Z3.Linq submodule WIP preserve unstaged, `git diff --cached --stat` ne montre que les 2 fichiers.
- **§A pr-review** : 2 fichiers, sous le seuil atomicite.
- **§B pr-review (Lean)** : N/A — pas de code Lean.
- **L677-L4 ★★** : PR body genere HORS worktree (scratchpad `c370_pr_body.md`).
- **Pre-commit H.3** : OK (no notebooks).

## Lien

- Issue **#11677** — fondateur documente (mesure firsthand sur #11664).
- **#11222** — non-regression preservee.
- **#11636** — pattern `strip_mentioned_verdicts` deja en place (cite verbs), fondation du fix.
- **#11145** — borne d'auteur (nit author / PR author peut lever, autres non unless `[OVERRIDE]`).
- Incident fondateur **#10761** — gate rougit sur approbation legitime, le precedent qui rend ce fix indispensable.