### PR TITLE
fix(notebook-tools,#11756): widen comment-skip to also check error outputs

### DIFF
--- a/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
+++ b/scripts/notebook_tools/tests/test_validate_pr_notebooks.py
@@ -650,6 +650,101 @@ class TestValidateNotebookLeanTextErrors:
         result = validate_notebook(nb)
         assert result["passed"] is True
 
+    # ----------------------------------------------------------------- #11756
+    # Source-list-collapse pitfall: a Lean cell whose `source` is a single
+    # list element with no trailing "\n" collapses to ONE line under
+    # `source.split("\n")`. If that one line starts with `--`, the gate
+    # classified the entire cell as a comment and skipped it — even when
+    # its outputs carry `severity: error`. The "comment-only" discriminant
+    # must therefore also pass the OUTPUT shape, not just the source shape.
+
+    def test_11756_lean_source_collapse_with_error_not_skipped(self, tmp_path):
+        """Lean cell whose source is single-element (no '\n') starting with
+        `--` but whose output is a Lean error message — NOT a comment, must
+        be counted in `total_code` and flagged."""
+        # Source as a single list element without trailing newline → collapse.
+        # The cell is a real attempt, not a comment, BECAUSE the output is an
+        # error payload.
+        err_out = {
+            "output_type": "display_data",
+            "data": {"text/plain": [
+                '{"messages": [{"severity": "error", "pos": {"line": 1, '
+                '"column": 1}, "data": "unexpected end of input"}]}',
+            ]},
+        }
+        cell = {
+            "cell_type": "code",
+            "source": ["-- some single-line typo that happens to start with --"],
+            "execution_count": 2,
+            "outputs": [err_out],
+        }
+        nb = _write_nb(tmp_path / "test.ipynb", [cell],
+                       kernelspec={"name": "lean4", "language": "lean4"})
+        result = validate_notebook(nb)
+        # BEFORE the fix: this cell was silently skipped (treated as
+        # comment), `total_code == 0`, `passed is True`. AFTER the fix:
+        # counted as code, error output blocks the notebook.
+        assert result["total_code"] == 1, (
+            f"#11756 collapse: cell with error output was skipped "
+            f"(total_code={result['total_code']})"
+        )
+        assert result["passed"] is False
+        assert any("Lean toolchain error" in e for e in result["errors"])
+
+    def test_11756_lean_real_comment_cell_still_skipped(self, tmp_path):
+        """A genuine Lean comment cell — multi-line, all `--`, NO output — is
+        still a true comment and must remain skipped (fix mustn't regress the
+        #5151 carve-out)."""
+        cell = {
+            "cell_type": "code",
+            "source": [
+                "--\n",
+                "-- Description de la transition, aucun code exécutable.\n",
+                "-- (commentaire multi-ligne, pas une cellule de code effective)",
+            ],
+            "execution_count": None,
+            "outputs": [],
+        }
+        nb = _write_nb(tmp_path / "test.ipynb", [cell],
+                       kernelspec={"name": "lean4", "language": "lean4"})
+        result = validate_notebook(nb)
+        assert result["total_code"] == 0
+        assert result["passed"] is True
+
+    def test_11756_csharp_collapse_with_error_not_skipped(self, tmp_path):
+        """Same carve-out for C#: a `//`-prefixed collapse-skip must NOT
+        silence a cell whose kernel threw an error. For .NET the H.1 error
+        output is *advisory* (`SKIP_EXEC_KERNELS` policy: CI cannot Papermill-
+        exec a .NET kernel), so the verdict stays `passed=True` — but the
+        cell MUST still be counted as ``total_code == 1`` (the structural
+        signal: this is real code, not a comment). The point of #11756 was
+        not to flip .NET from green→red but to prevent comment-skip from
+        silencing `total_code` entirely."""
+        err_out = {
+            "output_type": "error",
+            "ename": "Exception",
+            "evalue": "boom",
+            "traceback": ["RuntimeError: boom"],
+        }
+        cell = {
+            "cell_type": "code",
+            "source": ["// single-line typo that happens to start with //"],
+            "execution_count": 1,
+            "outputs": [err_out],
+        }
+        nb = _write_nb(tmp_path / "test.ipynb", [cell],
+                       kernelspec={"name": ".net-csharp", "language": "C#"})
+        result = validate_notebook(nb)
+        assert result["total_code"] == 1, (
+            "#11756 mirror: C# '//'-collapsed cell with error output was skipped"
+        )
+        # .NET .net-csharp is in SKIP_EXEC_KERNELS → H.1 advisory → passed=True
+        # is the documented behaviour. The carve-out does NOT change the
+        # advisory policy; it only ensures the cell is counted. The error is
+        # still surfaced as an "advisory" entry for the reviewer to spot.
+        assert result["passed"] is True
+        assert any("advisory" in e for e in result["errors"])
+
 
 # ---------------------------------------------------------------------------
 # validate_notebook — blank-render forensic verdict (#6971 / L644-L1)

--- a/scripts/notebook_tools/validate_pr_notebooks.py
+++ b/scripts/notebook_tools/validate_pr_notebooks.py
@@ -183,7 +183,11 @@ def get_kernel_name(nb_path: Path) -> str:
 def _output_text(output: dict) -> str:
     """Concatenate the textual payload of an output so text-rendered errors
     (Lean/alectryon) can be scanned. Covers display_data / execute_result
-    (text/plain + text/html) and stream outputs."""
+    (text/plain + text/html), stream outputs, and the IPython-native
+    ``output_type: "error"`` (ename/evalue/traceback — emitted by kernels
+    including C# / .NET Interactive on exception, needed for the #11756
+    mirror: a `//`-collapsed cell whose kernel threw an error is not a
+    comment, regardless of the source-line shape)."""
     parts = []
     otype = output.get("output_type")
     if otype in ("display_data", "execute_result"):
@@ -194,6 +198,16 @@ def _output_text(output: dict) -> str:
     elif otype == "stream":
         t = output.get("text", "")
         parts.append("".join(t) if isinstance(t, list) else str(t))
+    elif otype == "error":
+        # IPython error format: ename + evalue + traceback[]. The traceback
+        # itself contains "Exception" strings that re-fire the
+        # ("error" in text and "no errors" not in text) branch reliably, but
+        # the explicit ename/evalue keep the test deterministic for short
+        # tracebacks (e.g. .NET Interactive kernels emit terse tracebacks).
+        parts.append(str(output.get("ename", "")))
+        parts.append(str(output.get("evalue", "")))
+        for line in output.get("traceback", []) or []:
+            parts.append("".join(line) if isinstance(line, list) else str(line))
     return " ".join(parts)
 
 
@@ -300,8 +314,37 @@ def validate_notebook(nb_path: Path) -> dict:
         else:
             comment_prefix = "#"
         lines = [l.strip() for l in source.split("\n") if l.strip()]
+        # A real `--`/`//`/`#` comment cell carries NO error output (true
+        # transition notes, not executable). The collapse pitfall of #11756:
+        # if `source` is a single list element without trailing "\n",
+        # `source.split("\n")` yields one line — and that ONE line, starting
+        # with `--` by accident or by very-short typo, would silently skip an
+        # entire cell whose outputs carry `severity: error`. The discriminant
+        # is therefore the OUTPUT, not the source shape alone. If the cell
+        # produced error payloads (Lean REPL `{"messages":[{"severity":"error"
+        # , ...}]}`, or printable Lean error text in stream/output), it is a
+        # code cell that FAILED — never a comment. Mirror the scan_c1
+        # no-cell-output-scrubbing rule (#6 of [secrets-hygiene.md]): we don't
+        # skip on shape, we skip on (shape AND outcome). Conversion of #11665
+        # lives separately for `.ipynb` `_output.ipynb` parity (c.147) — the
+        # present carve-out only widens the comment-skip when an error
+        # accompanies it.
         if all(l.startswith(comment_prefix) for l in lines):
-            continue
+            outputs = cell.get("outputs", [])
+            has_error_output = False
+            if outputs:
+                for out in outputs:
+                    raw = json.dumps(out)
+                    text = _output_text(out).lower() if out else ""
+                    if (
+                        '"severity":"error"' in raw
+                        or "unexpected" in text
+                        or ("error" in text and "no errors" not in text)
+                    ):
+                        has_error_output = True
+                        break
+            if not has_error_output:
+                continue
 
         result["total_code"] += 1
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/readme #11759

Fix #11756 : `validate_pr_notebooks` rendait GREEN un notebook Lean dont 10/11 cellules portaient une erreur de compilation, quand `source` est un élément de liste unique (sans `\n` final) qui commence par `--` — le gate classait la cellule comme commentaire et la sautait silencieusement.

## Reproduction founder

Une cellule Lean telle que :

```json
{
  "cell_type": "code",
  "source": ["-- une typo en single-line (sans \\n final)"],
  "execution_count": 2,
  "outputs": [{
    "output_type": "display_data",
    "data": {"text/plain": ["{\"messages\":[{\"severity\":\"error\",\"data\":\"unexpected end of input\"}]}"]}
  }]
}
```

→ avant le fix : la cellule est sautée (comment-skip), `total_code == 0`, `passed is True`. **10/11 cellules rouges en silence, CI verte.**

## Cause racine

```python
lines = [l.strip() for l in source.split("\n") if l.strip()]
if all(l.startswith(comment_prefix) for l in lines):
    continue  # skip — jamais vérifié plus loin
```

Le discriminant n'était que la **forme** du source. Quand `source` est `["-- foo"]` (élément unique, pas de `\n`), `split("\n")` rend `["-- foo"]`, `startswith("--")` → True → skip. Aucune lecture des `outputs`.

## Fix

Le discriminant devient **(forme ET absence d'erreur)** :

1. **`_output_text`** étendu pour couvrir `output_type: "error"` (format IPython natif — `ename`/`evalue`/`traceback[]`) en plus des `display_data`/`execute_result`/`stream` déjà gérés. Les kernels C# / .NET Interactive émettent ce format quand une exception est levée.

2. **Carve-out conditionnel** dans `validate_pr_notebooks.py` : si `all(l.startswith(comment_prefix))` ET les `outputs` contiennent un payload d'erreur (Lean `severity: error` JSON, ou traceback IPython), la cellule est **comptée** (`total_code += 1`) et la logique H.1 existante la flag comme erreur. Sinon → commentaire légitime, skip.

## Périmètre strict

- **Modifié** : `scripts/notebook_tools/validate_pr_notebooks.py` (+44/-3) + `scripts/notebook_tools/tests/test_validate_pr_notebooks.py` (+95/-0) — strictement les 2 fichiers du validateur.
- **Inchangé** : tous les autres scripts (pas de scope creep), aucun notebook reformaté, aucun `.lean`.

## Tests

3 nouveaux cas dans `TestValidateNotebookLeanTextErrors` :

| Test | Scénario | Attendu |
|---|---|---|
| `test_11756_lean_source_collapse_with_error_not_skipped` | Lean single-element `-- foo` + `severity:error` | `total_code == 1`, `passed is False`, "Lean toolchain error" flag |
| `test_11756_lean_real_comment_cell_still_skipped` | Lean multi-ligne `-- ... --` sans outputs | `total_code == 0`, `passed is True` (régression de #5151 préservée) |
| `test_11756_csharp_collapse_with_error_not_skipped` | C# `// foo` + `output_type: "error"` | `total_code == 1`, `passed is True` (advisory par `SKIP_EXEC_KERNELS`), erreur surfaced comme advisory |

**Validation** : `pytest scripts/notebook_tools/tests/test_validate_pr_notebooks.py` = **62/62 PASSED** (3 ajouts, 0 régression sur les 59 préexistants).

## Lien issue

`Closes #11756`.

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
