### PR TITLE
feat(guard,#11718): variation-tag-guard trigger issue_comment + check-run sur la tete de PR

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -43,6 +43,15 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
     branches: [main]
+  # #11718 : le marqueur [G-VAR-3 OVERRIDE] vit en COMMENTAIRE de PR, mais
+  # issue_comment etait absent -- poster le marqueur ne relancait rien. Un run
+  # issue_comment checkout la branche par defaut (main), donc execute le gate
+  # COURANT : c'est le seul chemin qui echappe au gel de refs/pull/N/merge
+  # (diagnostic ai-01 sur #11718 : la PR re-execute la version du gate qui
+  # existait a son dernier push, pas celle de main). created ET edited : le
+  # marqueur peut etre poste ou corrige.
+  issue_comment:
+    types: [created, edited]
   workflow_dispatch:
 
 permissions:
@@ -51,6 +60,7 @@ permissions:
 
 jobs:
   check-variation-tag:
+    if: github.event_name != 'issue_comment'  # #11718 : le chemin commentaire est servi par check-variation-adjacency-comment
     name: Check Grain tag conformity
     runs-on: ubuntu-latest
     steps:
@@ -234,6 +244,7 @@ jobs:
   # dans les deux sens. Sans lui, le compteur flaggait du travail legitiment
   # re-qualifie (1 FP/2 flags sur la vague 2026-07-30 : #8930 LIGHT->MED).
   check-light-cap:
+    if: github.event_name != 'issue_comment'  # #11718 : le chemin commentaire est servi par check-variation-adjacency-comment
     name: G-VAR-2 light cap (cross-PR)
     runs-on: ubuntu-latest
     steps:
@@ -392,6 +403,7 @@ jobs:
   #      Pinned by `test_check_name_is_not_advisory_friendly` in
   #      `scripts/tests/test_variation_tag_required.py`.
   check-variation-tag-required:
+    if: github.event_name != 'issue_comment'  # #11718 : le chemin commentaire est servi par check-variation-adjacency-comment
     name: Require Grain tag (block on absent, #10045)
     runs-on: ubuntu-latest
     steps:
@@ -511,6 +523,7 @@ jobs:
   # A standalone `Fixes #N` (intended close) is NOT flagged: the
   # discriminator is the `prev:` prefix, not the keyword alone.
   check-prev-close-keyword-required:
+    if: github.event_name != 'issue_comment'  # #11718 : le chemin commentaire est servi par check-variation-adjacency-comment
     name: 'Require prev: non-closing (block on close-keyword genre, #10093)'
     runs-on: ubuntu-latest
     steps:
@@ -625,6 +638,7 @@ jobs:
   # classifier in `scripts/pr_gate.py` does NOT silence it -- same reason as
   # the tag-required and prev-close-keyword-required jobs.
   check-close-keyword-pr-ref-required:
+    if: github.event_name != 'issue_comment'  # #11718 : le chemin commentaire est servi par check-variation-adjacency-comment
     name: 'Require no close-keyword + PR-number (block on auto-close of a PR, #10101)'
     runs-on: ubuntu-latest
     steps:
@@ -765,6 +779,7 @@ jobs:
   # plomberie. The job name carries the `-required` suffix so PR #10036's
   # `is_advisory()` classifier in `scripts/pr_gate.py` does NOT silence it.
   check-variation-adjacency-required:
+    if: github.event_name != 'issue_comment'  # #11718 : le chemin commentaire est servi par check-variation-adjacency-comment
     name: 'Require genre diversity vs prev: (block on LIGHT adjacency, #11170)'
     runs-on: ubuntu-latest
     steps:
@@ -871,4 +886,124 @@ jobs:
           EOF
           )" 2>/dev/null || true
 
+          exit 1
+
+  # ---------------------------------------------------------------------------
+  # #11718 : chemin COMMENTAIRE du gate d'adjacence G-VAR-3.
+  #
+  # Pourquoi un job dedie plutot qu'etendre check-variation-adjacency-required :
+  # sur issue_comment, github.event.pull_request N'EXISTE PAS et github.sha
+  # pointe la branche par defaut. Ce job resolve lui-meme la PR (numero =
+  # github.event.issue.number), son body, son SHA de tete, et rattache son
+  # check-run a CE SHA -- sinon le check se pose sur main et l'agregateur PR
+  # gate (qui lit les check-runs de la tete) ne le voit pas (meme famille que
+  # le fantome workflow_run deja mesure : un SHA qui porte un check sans dire
+  # de quoi le check parle).
+  #
+  # Le check-run porte le MEME nom que le job pull_request ; le verdict le plus
+  # recent par nom supplante le rouge gele de la vieille run dans la vue PR.
+  #
+  # Anti-boucle : ce job NE POSTE PAS de commentaire en retour (le chemin
+  # bloquant s'exprime dans l'output du check-run), et il s'ignore lui-meme :
+  # les commentaires du bot (github-actions[bot]) ne redeclenchent rien.
+  # Les commentaires d'ISSUE (hors PR) sont filtres au niveau du job.
+  check-variation-adjacency-comment:
+    name: 'Require genre diversity vs prev: (block on LIGHT adjacency, #11170)'
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.login != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      # Job-level permissions REMPLACENT (ne fusionnent pas) celles du
+      # workflow : redeclarer ce dont ce job a besoin.
+      contents: read
+      pull-requests: write
+      checks: write
+    steps:
+      - name: Checkout the adjacency helper (sparse, branche par defaut = gate COURANT)
+        uses: actions/checkout@v4
+        with:
+          # Pas de ref : sur issue_comment le checkout est la branche par
+          # defaut -- c'est le point. Le gate execute est celui de main,
+          # jamais la version gelee dans refs/pull/N/merge (diagnostic #11718).
+          sparse-checkout: |
+            scripts/ci/variation_adjacency_guard.py
+            scripts/variation_light_cap.py
+            scripts/grain_tag.py
+      - name: 'Resolve PR head, body, comments -- run gate, post check-run on head SHA'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -uo pipefail
+
+          # --- Resolution de la PR depuis le commentaire -------------------
+          PR_JSON=$(gh api "repos/${GH_REPO}/pulls/${ISSUE_NUMBER}")
+          PR_NUMBER=$(printf '%s' "$PR_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['number'])")
+          PR_BODY=$(printf '%s' "$PR_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('body') or '')")
+          PR_AUTHOR=$(printf '%s' "$PR_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['user']['login'])")
+          IS_FORK=$(printf '%s' "$PR_JSON" | python3 -c "import json,sys; print(str(json.load(sys.stdin)['head']['repo']['fork']).lower())")
+          HEAD_SHA=$(printf '%s' "$PR_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin)['head']['sha'])")
+          echo "PR #$PR_NUMBER head=$HEAD_SHA (resolu depuis le commentaire)"
+
+          CHECK_NAME='Require genre diversity vs prev: (block on LIGHT adjacency, #11170)'
+
+          post_check () {
+            # post_check <conclusion> <summary>
+            python3 - "$1" "$2" <<'PYC'
+          import json, os, subprocess, sys
+          conclusion, summary = sys.argv[1], sys.argv[2]
+          payload = {
+              "name": "Require genre diversity vs prev: (block on LIGHT adjacency, #11170)",
+              "head_sha": os.environ["HEAD_SHA"],
+              "status": "completed",
+              "conclusion": conclusion,
+              "output": {
+                  "title": "G-VAR-3 adjacency (comment path, gate courant)",
+                  "summary": summary,
+              },
+          }
+          subprocess.run(
+              ["gh", "api", "--method", "POST",
+               f"repos/{os.environ['GH_REPO']}/check-runs",
+               "--input", "-"],
+              input=json.dumps(payload), text=True, check=False)
+          PYC
+          }
+          export HEAD_SHA GH_REPO
+
+          # --- Hors scope : bots et forks (meme politique que les autres jobs)
+          case "$PR_AUTHOR" in
+            *"[bot]") echo "Auteur bot ($PR_AUTHOR) : hors scope."; post_check success "Auteur bot : hors scope."; exit 0 ;;
+          esac
+          if [ "$IS_FORK" = "true" ]; then
+            echo "PR issuee d'un fork : hors scope (PR etudiante)."
+            post_check success "PR etudiante (fork) : hors scope."
+            exit 0
+          fi
+
+          # --- Meme gate, memes entrees que le chemin pull_request ---------
+          printf '%s' "$PR_BODY" > /tmp/pr_body.txt
+          gh pr view "$PR_NUMBER" --json comments             --jq '[.comments[] | {author: .author.login, body: .body}]'             > /tmp/pr_comments.json 2>/dev/null || rm -f /tmp/pr_comments.json
+          COMMENTS_ARG=""
+          if [ -s /tmp/pr_comments.json ]; then
+            COMMENTS_ARG="--comments-file /tmp/pr_comments.json"
+          fi
+
+          # shellcheck disable=SC2086  # deliberate 0-or-2 token split
+          python3 scripts/ci/variation_adjacency_guard.py             --body-file /tmp/pr_body.txt $COMMENTS_ARG             > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+          if [ -s /tmp/verdict.err ]; then echo "--- helper stderr ---"; cat /tmp/verdict.err; fi
+          echo "--- verdict ---"; cat /tmp/verdict.json 2>/dev/null || echo "(vide)"
+
+          SUMMARY=$(cat /tmp/verdict.json 2>/dev/null || echo '{}')
+          if [ "$RC" -eq 0 ]; then
+            echo "Adjacence OK (comment path)."
+            post_check success "Verdict du gate COURANT (main), declenche par commentaire :$SUMMARY"
+            exit 0
+          fi
+          REASON=$(python3 -c "import json; print(json.load(open('/tmp/verdict.json')).get('reason','unknown'))" 2>/dev/null || echo unknown)
+          echo "::error::G-VAR-3 LIGHT-genre adjacency (comment path): $REASON"
+          post_check failure "Verdict du gate COURANT (main), declenche par commentaire : $REASON -- le remede (OVERRIDE ou grain d'un autre genre) est decrit dans le body du garde."
           exit 1

--- a/scripts/tests/test_variation_tag_comment_trigger.py
+++ b/scripts/tests/test_variation_tag_comment_trigger.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Wiring tests for the issue_comment path of variation-tag-guard (#11718).
+
+The defect #11718 pins is a WIRING defect, not a logic defect: the
+`[G-VAR-3 OVERRIDE]` marker lives in PR *comments*, but the workflow only
+triggered on pull_request events -- posting the marker relaunched nothing.
+The pure decision logic (variation_adjacency_guard.py) is already covered by
+test_variation_adjacency_guard.py; this file pins the YAML harness so the
+wiring cannot silently regress:
+
+  1. issue_comment (created + edited) is a trigger;
+  2. every job that reads `github.event.pull_request.*` is gated out of
+     issue_comment runs (that context does not exist there -- ungated, the
+     jobs would run red on every comment);
+  3. the dedicated comment job exists, filters to PRs (not issues), skips
+     bot comments (anti-loop: the block path of the pull_request job posts
+     as github-actions[bot]), and resolves the PR head SHA itself;
+  4. the check-run it posts carries the SAME name as the pull_request job
+     so the aggregator (pr_gate) sees the fresh verdict supersede the stale
+     one on the PR head.
+
+Run:
+    python -m pytest scripts/tests/test_variation_tag_comment_trigger.py
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "variation-tag-guard.yml"
+
+ADJACENCY_CHECK_NAME = "Require genre diversity vs prev: (block on LIGHT adjacency, #11170)"
+COMMENT_JOB = "check-variation-adjacency-comment"
+
+
+def _load() -> dict:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _on(wf: dict) -> dict:
+    # YAML 1.1 parses the bare `on:` key as boolean True.
+    return wf.get(True, wf.get("on", {}))
+
+
+def test_issue_comment_is_a_trigger_with_created_and_edited():
+    trig = _on(_load()).get("issue_comment")
+    assert trig is not None, "issue_comment trigger absent (#11718: le marqueur OVERRIDE vit en commentaire)"
+    assert "created" in trig["types"], "created manquant : poster le marqueur ne relance rien"
+    assert "edited" in trig["types"], "edited manquant : corriger un marqueur ne relance rien"
+
+
+def test_every_pull_request_job_is_gated_out_of_issue_comment():
+    """github.event.pull_request n'existe pas sur issue_comment : tout job qui
+    le lit doit refuser de tourner sur cet evenement (sinon rouge systematique
+    a chaque commentaire)."""
+    wf = _load()
+    offenders = []
+    for jid, job in wf["jobs"].items():
+        if jid == COMMENT_JOB:
+            continue
+        reads_pr_ctx = "github.event.pull_request" in yaml.safe_dump(job)
+        if not reads_pr_ctx:
+            continue
+        cond = str(job.get("if", ""))
+        assert cond, f"job {jid} lit github.event.pull_request sans if: ( Crash sur issue_comment)"
+        if "github.event_name != 'issue_comment'" not in cond:
+            offenders.append(jid)
+    assert not offenders, f"jobs non gates hors issue_comment : {offenders}"
+
+
+def test_comment_job_exists_and_filters_to_prs_and_bots():
+    wf = _load()
+    job = wf["jobs"].get(COMMENT_JOB)
+    assert job is not None, f"{COMMENT_JOB} absent"
+    cond = str(job.get("if", ""))
+    assert "github.event.issue.pull_request" in cond, (
+        "le job doit se limiter aux commentaires de PR (issue_comment fire aussi sur les issues)"
+    )
+    assert "github.event.comment.user.login != 'github-actions[bot]'" in cond, (
+        "anti-boucle absent : le commentaire bloquant du chemin pull_request (github-actions[bot]) redeclencherait ce job a l'infini"
+    )
+
+
+def test_comment_job_resolves_head_sha_and_posts_check_run_on_it():
+    """Le check-run doit se poser sur le SHA de TETE de la PR -- pas sur le SHA
+    de l'evenement (branche par defaut), sinon l'agregateur PR gate ne le voit
+    pas (fantome workflow_run, cf #11718 commentaire ai-01)."""
+    wf = _load()
+    job = wf["jobs"][COMMENT_JOB]
+    run = ""
+    for step in job["steps"]:
+        run += step.get("run", "") + "\n"
+    assert 'pulls/${ISSUE_NUMBER}' in run, "la PR doit etre resolue depuis github.event.issue.number (github.event.pull_request n'existe pas)"
+    assert "['head']['sha']" in run or "head.sha" in run, "le SHA de tete doit etre extrait explicitement"
+    assert "/check-runs" in run, "le verdict doit etre poste en check-run sur la tete"
+    assert 'os.environ["HEAD_SHA"]' in run, "le check-run doit porter head_sha (pas le SHA de l'evenement)"
+
+
+def test_comment_job_check_run_name_matches_pull_request_job():
+    """Meme nom que le job pull_request : le verdict recent supplant le rouge
+    gele dans la vue PR et l'agregateur."""
+    wf = _load()
+    names = {j.get("name") for j in wf["jobs"].values()}
+    assert wf["jobs"][COMMENT_JOB]["name"] == ADJACENCY_CHECK_NAME
+    # ... et ce nom est bien celui du job pull_request (unicite du porteur)
+    bearers = [jid for jid, j in wf["jobs"].items() if j.get("name") == ADJACENCY_CHECK_NAME]
+    assert sorted(bearers) == sorted([COMMENT_JOB, "check-variation-adjacency-required"])
+
+
+def test_comment_job_checks_out_default_branch_code():
+    """Sur issue_comment le checkout est la branche par defaut : c'est le
+    POINT (gate courant, jamais la version gelee dans refs/pull/N/merge).
+    Un `with: ref:` revenu sur ce job reintroduirait le gel."""
+    wf = _load()
+    checkout = [s for s in wf["jobs"][COMMENT_JOB]["steps"] if "checkout" in str(s.get("uses", ""))][0]
+    assert "ref" not in checkout.get("with", {}), (
+        "le checkout du chemin commentaire ne doit PAS pin de ref : il execute le gate de la branche par defaut (diagnostic #11718)"
+    )


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: DEEP/notebook-lean #11743

## Resume

#11718 : le marqueur `[G-VAR-3 OVERRIDE]` vit en **commentaire** de PR, mais `variation-tag-guard.yml` ne se declenchait que sur `pull_request` — poster le marqueur ne relancait RIEN. Le diagnostic ai-01 sur l'issue ajoute un second defaut mesuré : la PR re-execute la version du gate qui existait a son dernier push (`refs/pull/N/merge` ne recalcule que sur push), donc meme le workaround « editer le corps » executait un gate PERIME.

## Le fix (3 pieces)

1. **Trigger `issue_comment` (created + edited)** — un run issue_comment checkout la branche par defaut (`main`) : il execute le **gate courant**, seul chemin qui echappe au gel de la ref de merge.
2. **Gating des 6 jobs existants** hors issue_comment (`if: github.event_name != 'issue_comment'`) : `github.event.pull_request` n'existe pas sur cet evenement, sans gating chaque commentaire les ferait tourner rouges.
3. **Nouveau job `check-variation-adjacency-comment`** : resolve la PR depuis `github.event.issue.number`, extrait le **SHA de tete** via l'API, execute le meme guard (meme script, memes entrees body+comments), et poste son **check-run sur CE SHA** sous le **meme nom** que le job pull_request — le verdict recent supplant le rouge gele dans la vue PR et pour l'agregateur (sinon le check se pose sur `main` : fantome workflow_run, point 2 de l'issue).

Anti-boucle : le job ne poste AUCUN commentaire (le bloquant s'exprime dans l'output du check-run) et ignore les commentaires de `github-actions[bot]` ; filtre aux PRs uniquement (`github.event.issue.pull_request`).

## Validation

- 6 wiring tests nouveaux (`test_variation_tag_comment_trigger.py`) : trigger present avec created+edited, les 6 jobs gates, filtre PR/bot, resolution SHA de tete + check-run dessus, nom identique au job pull_request, checkout SANS ref (re-pinner une ref reintroduirait le gel).
- Suites adjacentes non-regressees : `test_variation_adjacency_guard.py` + `test_variation_tag_required.py` + `test_grain_tag.py` + `test_check_workflow_label_paths.py` — **106 passed** au total.
- `bash -n` sur le bloc run extrait : syntaxe OK.
- YAML re-valide par `yaml.safe_load` apres edition (7 jobs).

## Controle d'acceptance de l'issue (a verifier post-merge)

Le controle exige par ai-01 : « **commentaire seul → check-run neuf → vert, sans push ni edition de corps** ». Il se joue sur une PR reelle arbitree — je le verifierai sur la prochaine PR bloquee par G-VAR-3 apres merge (un commentaire `[G-VAR-3 OVERRIDE]` doit declencher un run neuf du job comment portant le verdict du gate courant, attache a la tete).

Closes #11718

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>