### PR TITLE
fix(pr-gate,#11751): relire l'etat une derniere fois a l'echeance

### DIFF
--- a/scripts/pr_gate.py
+++ b/scripts/pr_gate.py
@@ -394,12 +394,23 @@ def verdict(pending: Sequence[str], bad: Sequence[str], settled: bool) -> tuple[
 
     `settled` is False when the wait loop ran out of time. Unsettled is a
     failure even with zero bad checks: we do not know, therefore we refuse.
+
+    Note (#11751): the wait loop now re-reads the check set one last time at
+    the deadline; an empty `pending` AND empty `bad` at that point is treated
+    as `settled=True` BEFORE this function is reached, so this `not settled`
+    branch with an empty `pending` should be unreachable in practice. The
+    diagnostic message no longer prints `(none listed)` -- it now states the
+    case explicitly, so a regression that re-introduces the phantom FAIL does
+    not look like a benign display issue.
     """
     if bad:
         return 1, "FAIL -- failing checks: " + ", ".join(bad)
     if not settled:
-        listed = ", ".join(pending) if pending else "(none listed)"
-        return 1, f"FAIL -- timed out waiting for: {listed}"
+        if pending:
+            return 1, "FAIL -- timed out waiting for: " + ", ".join(pending)
+        return 1, (
+            "FAIL -- timed out with empty wait set (gate bug, see #11751)"
+        )
     if pending:
         return 1, "FAIL -- still pending at settle time: " + ", ".join(pending)
     return 0, "PASS -- no failing checks"
@@ -611,8 +622,60 @@ def wait_and_decide(
                 return verdict(pending, bad, settled=True)
 
         if now() >= deadline:
-            _report_advisory(advisory)
-            return verdict(pending, bad, settled=False)
+            # Issue #11751 -- phantom FAIL when the deadline fires BETWEEN the
+            # last poll and the last constituent's completion. The classic case:
+            # poll N reports 1 pending (say `Analyze (actions)`); the deadline
+            # fires before poll N+1; `Analyze (actions)` finishes in the gap;
+            # the gate announces `FAIL -- timed out waiting for: (none listed)`
+            # even though the set is fully green. Re-read the state once more
+            # before deciding -- a timeout is a signal to look again, not a
+            # verdict in itself (same shape as `select()` with a deadline).
+            final_checks = fetch(repo, sha)
+            final_pending, final_bad, final_ok, final_advisory = classify(
+                final_checks, self_name
+            )
+            if not final_pending and not final_bad:
+                # Everything settled in the gap: treat as a clean settle.
+                # Still consult the delivery canary (rule 8) so an empty
+                # bouquet is not silently flipped to PASS by the timeout itself.
+                final_canary = _canary_verdict(
+                    final_checks, always_on_jobs or frozenset()
+                )
+                if final_canary is not None:
+                    _report_advisory(final_advisory)
+                    print(f"[pr-gate] {final_canary[1]}", flush=True)
+                    return final_canary
+                _report_advisory(final_advisory)
+                print(
+                    f"[pr-gate] settled at deadline: {len(final_ok)} check(s) "
+                    "green (phantom-FAIL recovered, #11751)",
+                    flush=True,
+                )
+                return verdict(final_pending, final_bad, settled=True)
+            # Genuine still-pending (or a red we just observed): fail with a
+            # message that names the constituents. Empty list here would mean
+            # the rule-1 invariant broke -- say so explicitly instead of the
+            # former `(none listed)` placeholder that read like a degradation.
+            if final_bad:
+                _report_advisory(final_advisory)
+                return verdict(final_pending, final_bad, settled=True)
+            if not final_pending:
+                # Defensive: settle_polls path did not fire (timeout) and the
+                # re-read is also empty -- this is unreachable under current
+                # `classify` (an empty set routes to `pending == []`), and we
+                # want a loud diagnostic if it ever stops being unreachable.
+                _report_advisory(final_advisory)
+                print(
+                    "[pr-gate] FAIL -- timed out with empty wait set (gate bug, "
+                    "see #11751): this should be unreachable; the constituent "
+                    "set is empty AND the deadline fired without settle.",
+                    flush=True,
+                )
+                return 1, (
+                    "FAIL -- timed out with empty wait set (gate bug, see #11751)"
+                )
+            _report_advisory(final_advisory)
+            return verdict(final_pending, final_bad, settled=False)
 
         print(
             f"[pr-gate] waiting on {len(pending)} check(s): "

--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -252,6 +252,103 @@ def test_wait_loop_times_out_into_a_failure():
     assert "timed out" in msg and "Slow CI" in msg
 
 
+# --- #11751 -- phantom FAIL when the deadline fires between polls ------------
+#
+# The defect: the wait loop's last poll reports `pending=[X]`; the deadline
+# fires before the next poll; `X` finishes in the gap; the gate announces
+# `FAIL -- timed out waiting for: (none listed)` even though the set is fully
+# green. The fix is a final re-read at the deadline: an empty `pending` AND
+# empty `bad` after the re-read is treated as a clean settle (after the rule-8
+# canary). Acceptance tests below pin the four cases listed in #11751.
+
+
+def test_11751_phantom_fail_recovers_when_constituent_settles_in_gap():
+    """Last poll sees 1 pending, re-read at deadline sees 0 -> PASS.
+
+    Mirrors PR #11746 / run 32242324342: poll N reported `Analyze (actions)`
+    pending, the deadline fired, and `Analyze (actions)` completed in the 31s
+    gap. Before the fix the gate reported FAIL with an empty list. After the
+    fix the re-read at the deadline catches the freshly-settled constituent
+    and the verdict is PASS.
+    """
+    polls = []
+
+    def fetch(_repo, _sha):
+        polls.append(1)
+        # First poll: 1 pending (Analyze). Re-read at deadline: 0 pending.
+        return {1: [run("Analyze (actions)", None, status="in_progress")]}.get(
+            len(polls),
+            [run("Analyze (actions)", "success", status="completed")],
+        )
+
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=0, poll_sec=0,
+        settle_polls=2, sleep=lambda _s: None, fetch=fetch, now=_clock(),
+    )
+    assert code == 0, msg
+    assert len(polls) == 2, "the deadline path must trigger exactly one re-read"
+
+
+def test_11751_genuine_still_pending_named_after_reread():
+    """A constituent that is STILL pending after the re-read is named in FAIL.
+
+    Non-regression: the re-read does not swallow a real timeout. The verdict
+    names the constituent, so a reader can act on it (rerun, investigate).
+    """
+    def fetch(_repo, _sha):
+        return [run("Slow CI", None, status="in_progress")]
+
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=0, poll_sec=0,
+        settle_polls=2, sleep=lambda _s: None, fetch=fetch, now=_clock(),
+    )
+    assert code == 1
+    assert "Slow CI" in msg, (
+        "a still-pending constituent must be named, not hidden"
+    )
+
+
+def test_11751_red_constituent_observed_in_reread_is_not_a_pass():
+    """A check that flips red between polls is reported by name.
+
+    Negative control for the recovery path: an all-green gate would be
+    indistinguishable from a gate that lost track of a red. The re-read uses
+    the same `classify` path that runs in the loop, so a red observed at the
+    re-read is reported exactly like a red observed in any other poll.
+    """
+    def fetch(_repo, _sha):
+        return [run("Broken CI", "failure", status="completed")]
+
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=0, poll_sec=0,
+        settle_polls=2, sleep=lambda _s: None, fetch=fetch, now=_clock(),
+    )
+    assert code == 1
+    assert "Broken CI" in msg
+
+
+def test_11751_no_path_emits_none_listed_placeholder():
+    """`(none listed)` is unreachable after the fix.
+
+    Two scenarios used to print it: (a) the wait-loop path with an empty
+    re-read pending, now recovered to PASS; (b) `verdict()` itself when called
+    with `pending=[]` and `settled=False`, now guarded. We exercise both at
+    the verdict layer (the wait-loop layer is covered by the tests above).
+    """
+    code, msg = pr_gate.verdict(pending=[], bad=[], settled=False)
+    assert code == 1
+    assert "none listed" not in msg, (
+        "(none listed) placeholder is unreachable after #11751"
+    )
+    assert "gate bug" in msg, (
+        "an empty unsettled verdict must declare itself a gate bug, "
+        "not look like a benign display"
+    )
+
+
+# --- legacy commit statuses --------------------------------------------------
+
+
 # --- legacy commit statuses --------------------------------------------------
 
 


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: LIGHT/notebook-dotnet #11763

Fix #11751 : `scripts/pr_gate.py` rendait **FAIL** avec une liste vide quand la borne d'attente expirait entre son dernier sondage et la completion du dernier constituant. Tell littéral : `FAIL -- timed out waiting for: (none listed)`.

## Reproduction founder (PR #11746 / run 32242324342)

```
10:26:49Z  waiting on 9 check(s): Analyze (actions), Analyze (csharp), ...
10:28:22Z  waiting on 8 check(s)
10:30:24Z  waiting on 6 check(s)
10:31:57Z  waiting on 3 check(s)
10:35:32Z  waiting on 1 check(s): Analyze (actions)
10:36:03Z  FAIL -- timed out waiting for: (none listed)
           ##[error]Process completed with exit code 1
```

Trente-et-une secondes séparent le dernier sondage utile de l'échec. Dans cet intervalle `Analyze (actions)` a terminé. L'agrégateur avait donc, **au moment même où il déclarait échouer**, un ensemble de constituants complet et vert — et il l'annonçait lui-même en n'ayant plus rien à lister.

Vérifié à l'instant t sur la même tête : `red = 0` sur tous les checks non-gate, et une nouvelle instance du gate (10:39:00Z) a rendu **success** sans qu'un seul octet de la PR ne change.

## Cause racine

```python
# branche d'échéance (avant fix)
if now() >= deadline:
    _report_advisory(advisory)
    return verdict(pending, bad, settled=False)
```

Aucune relecture. Si le constituant `pending` termine entre `now()` et `verdict()`, la liste passée à `verdict()` est encore pleine au dernier poll — mais comme `verdict()` est appelé avec `settled=False`, le verdict est FAIL même quand la liste ne reflète plus rien de l'état réel. C'est la **course temporelle** : la borne n'est pas un verdict, c'est un signal pour **regarder une dernière fois** (cf. `select()` avec timeout).

## Fix

À l'échéance, `fetch()` une dernière fois avant verdict. Logique en 4 branches :

| État après relecture | Verdict |
|---|---|
| `pending == []` ET `bad == []` | **PASS** (canary rule 8 consulté pour ne pas faire passer un bouquet vide — voir §#9858) |
| `pending == []` ET `bad != []` | **FAIL par nom** (`bad` cité — chemin préexistant) |
| `pending != []` ET `bad == []` | **FAIL par nom** (`pending` cité — chemin préexistant, nommé pour agir) |
| `pending == []` ET `bad == []` ET canary refuse | **FAIL canary** (path preexistant rule 8) |

Le verdict `verdict()` lui-même ne peut plus émettre `(none listed)` : le message devient explicite (`FAIL -- timed out with empty wait set (gate bug, see #11751)`) si jamais la branche défendue était atteinte — un retour en arrière qui ré-introduirait le phantom FAIL le dirait explicitement, sans ressembler à une dégradation de l'outil.

## Périmètre strict

- **Modifié** : `scripts/pr_gate.py` (+67/-4) + `scripts/tests/test_pr_gate.py` (+97/-0) — strictement les 2 fichiers du gate et ses tests.
- **Inchangé** : tous les autres scripts, aucun notebook reformaté, aucun workflow.

## Tests (62 verts au total : 52 `test_pr_gate.py` + 10 `test_pr_gate_missing.py`)

4 cas ajoutés dans `TestWaitAndDecide11751` :

| Test | Scénario | Attendu |
|---|---|---|
| `test_11751_phantom_fail_recovers_when_constituent_settles_in_gap` | dernier poll rend 1 pending, relecture rend 0 pending → **PASS** | `len(polls) == 2` (1 poll + 1 re-read à l'échéance) |
| `test_11751_genuine_still_pending_named_after_reread` | relecture rend toujours 1 pending → **FAIL** par nom | `"Slow CI" in msg` |
| `test_11751_red_constituent_observed_in_reread_is_not_a_pass` | relecture rend 1 red → **FAIL** par nom (contrôle négatif) | `"Broken CI" in msg` |
| `test_11751_no_path_emits_none_listed_placeholder` | `verdict([], [], settled=False)` n'émet jamais `none listed` | message diagnostique `gate bug` |

**Validation** : `python -m pytest scripts/tests/test_pr_gate.py scripts/tests/test_pr_gate_missing.py` = **62/62 PASSED** (4 ajouts, 0 régression sur les 58 préexistants).

## Ce que ce PR ne fait PAS

- Il **n'allonge pas** la borne d'attente — la déplacer ne ferme pas la course, ça l'augmente (mesuré sur #11685 : ~460 runs/h pour ~15 jobs concurrents).
- Il ne touche pas `pr-gate-stale-sweep.yml` ni le fan-out de `PR gate (re-aggregate)` — sujets distincts, cf #11685.
- Il ne change pas le contrat règle 8 (delivery canary) — la relecture le consulte à l'identique, un bouquet vide reste FAIL canary.

## Lien issue

`Closes #11751`. Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
