### PR TITLE
docs(symbolicai,#11740): ajouter Lean-19..23 au tableau, a l'arbre et a la phase 3 (grain 2)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/README.md
@@ -59,7 +59,7 @@ Le Web Sémantique généralise les concepts logiques de la Phase 1 au web. Les 
 
 ### Phase 3 : Vérification formelle (Lean, ~10h)
 
-La série Lean 4 passe de la théorie à la pratique de la preuve formelle. Les notebooks 1-5 posent les fondations : types dépendants, Curry-Howard, quantificateurs, mode tactique. Les notebooks 6-10 explorent l'état de l'art 2024-2026 : Mathlib4, intégration LLM (AlphaProof, LeanCopilot), agents autonomes (Harmonic, Erdos), et Semantic Kernel multi-agents. Les notebooks 11-11py relient la vérification formelle au machine learning (certificats de robustesse pour réseaux de neurones), et le notebook 12 porte le théorème de sensibilité de Huang (2019) en Lean 4. Cette phase est la plus exigeante techniquement (WSL obligatoire, concepts mathématiques avancés) mais aussi la plus innovante.
+La série Lean 4 passe de la théorie à la pratique de la preuve formelle. Les notebooks 1-5 posent les fondations : types dépendants, Curry-Howard, quantificateurs, mode tactique. Les notebooks 6-10 explorent l'état de l'art 2024-2026 : Mathlib4, intégration LLM (AlphaProof, LeanCopilot), agents autonomes (Harmonic, Erdos), et Semantic Kernel multi-agents. Les notebooks 11-11py relient la vérification formelle au machine learning (certificats de robustesse pour réseaux de neurones), et le notebook 12 porte le théorème de sensibilité de Huang (2019) en Lean 4. Les notebooks 13-18 prolongent avec les hommages aux mathématiciens (Grothendieck, Conway) et les théorèmes fondamentaux (Kochen-Specker, Libre Arbitre, noeuds de Conway, optimalité A*). Les notebooks 19-23, fraîchement intégrés, portent les **théorèmes phares 2026** : conjecture de Sendov (Lean-19, preuve L. Mazur 2026 digérée par T. Tao), le manuel *Analysis I* de T. Tao en lac Lean 4 (Lean-20), la conjecture PFR par méthode entropique (Lean-21, lac `teorth/pfr`), la détection MIMO par flips de coordonnées (Lean-22, Papailiopoulos 2026) et le problème inverse de Galois refermé pour M₂₃ (Lean-23, arXiv:2608.08538). Cette phase est la plus exigeante techniquement (WSL obligatoire, concepts mathématiques avancés) mais aussi la plus innovante.
 
 ### Phase 4 : Applications (Planners + SmartContracts, ~30h)
 
@@ -180,7 +180,7 @@ Documentation complète : [Tweety/README.md](Tweety/README.md)
 
 ## Lean - Vérification Formelle
 
-Série de **28 notebooks** sur **Lean 4**, proof assistant basé sur la théorie des types dépendants. Couvre des fondations théoriques jusqu'à l'intégration des LLMs pour l'assistance automatique aux preuves, un tribut à Grothendieck (Lean-15/15b), les jeux de Conway (Lean-16a/16b/16c/16d/16e) avec ports natifs Lean, les noeuds de Conway (Lean-17a/17b), les théorèmes de Kochen-Specker (Lean-13) et du Libre Arbitre (Lean-16f), la sensibilité de Huang (Lean-12/12b), la finitude des dérivées (Lean-14) et l'optimalité A* (Lean-18).
+Série de **33 notebooks** sur **Lean 4**, proof assistant basé sur la théorie des types dépendants. Couvre des fondations théoriques jusqu'à l'intégration des LLMs pour l'assistance automatique aux preuves, un tribut à Grothendieck (Lean-15/15b), les jeux de Conway (Lean-16a/16b/16c/16d/16e) avec ports natifs Lean, les noeuds de Conway (Lean-17a/17b), les théorèmes de Kochen-Specker (Lean-13) et du Libre Arbitre (Lean-16f), la sensibilité de Huang (Lean-12/12b), la finitude des dérivées (Lean-14), l'optimalité A* (Lean-18), la conjecture de Sendov (Lean-19, preuve L. Mazur 2026 digérée par T. Tao), le manuel *Analysis I* de T. Tao en lac Lean 4 (Lean-20), la méthode entropique de la conjecture PFR (Lean-21, `teorth/pfr`), la détection MIMO par flips de coordonnées (Lean-22, Papailiopoulos 2026) et le problème inverse de Galois refermé pour M₂₃ (Lean-23, arXiv:2608.08538).
 
 ### Structure détaillée
 
@@ -217,11 +217,17 @@ Série de **28 notebooks** sur **Lean 4**, proof assistant basé sur la théorie
 | 17 | [Lean-17-Knots-a-Conway-and-Proofs](Lean/Lean-17-Knots-a-Conway-and-Proofs.ipynb) | Python WSL | Noeuds de Conway : introduction, énoncés, premier port formel adossé à `conway_knots_lean/` | 3 |
 | 17b | [Lean-17-Knots-b-Invariants-Companion](Lean/Lean-17-Knots-b-Invariants-Companion.ipynb) | Python WSL | Companion natif : invariants de noeuds, snippets WSL, sources `conway_knots_lean/` | 3 |
 | 18 | [Lean-18-Search-AStar-Optimality](Lean/Lean-18-Search-AStar-Optimality.ipynb) | Lean 4 / WSL | Preuve d'optimalité A* dans le lake `planners_lean` : consistance, admissibilité, branchement | 3 |
+| **Théorèmes phares 2026** |  |  |  |  |
+| 19 | [Lean-19-Sendov-Complex-Analysis](Lean/Lean-19-Sendov-Complex-Analysis.ipynb) | Python WSL | Conjecture de Sendov (preuve L. Mazur 2026, digestion et formalisation T. Tao) : pour un polynôme dont tous les zéros sont dans le disque unité, chaque zéro a un point critique à distance ≤ 1 — énoncé, illustrations numériques, contexte de la preuve | 4 |
+| 20 | [Lean-20-Analysis-I-Tao-Workflow](Lean/Lean-20-Analysis-I-Tao-Workflow.ipynb) | Python WSL | Manuel *Analysis I* de T. Tao en lac Lean 4 (`teorth/analysis`) : architecture du lac, philosophie d'auto-contenance vs Mathlib, cinq lemmes emblématiques parmi 44k LOC, méta-récit single-agent vs cluster distribué | 4 |
+| 21 | [Lean-21-PFR-Entropy-Method](Lean/Lean-21-PFR-Entropy-Method.ipynb) | Python WSL | Conjecture PFR (polynomial Freiman–Ruzsa, ZMod 2) : méthode entropique de la preuve `teorth/pfr` — énoncé combinatoire, illustrations cosets dans F₂³, `#check` réels et axiomes du lac compilé | 0 |
+| 22 | [Lean-22-MIMO-Detection-Flips](Lean/Lean-22-MIMO-Detection-Flips.ipynb) | Python WSL | Détection MIMO par flips de coordonnées (Papailiopoulos 2026) : le seuil 2·log N — descente simulée et comptage de flips, probabilité d'échappement du bruit (Monte-Carlo vs `e^{−np}`), `#check` réels des quatre phases du companion `mimo_lean` (sorry-free, lake externe SLT pour Hanson–Wright) | 3 |
+| 23 | [Lean-23-Galois-Probleme-Inverse-M23](Lean/Lean-23-Galois-Probleme-Inverse-M23.ipynb) | Python WSL | Problème inverse de Galois refermé (arXiv:2608.08538, 9 août 2026) : M₂₃ prouvé simple d'ordre 10 200 960 à l'écran (`card_M23`/`simple_M23` exécutés, `#print axioms` = liste blanche), design de Witt S(4,7,23) vérifié des deux côtés (253 heptades), polynôme f₁ de degré 23 manipulé pour de vrai (empreinte, irréductibilité, discriminant 383 chiffres, Frobenius mod p) — les deux énoncés distingués : prouvé vs cité | 3 |
 
 ### Kernels requis
 
 - **Lean 4 (WSL)** : Notebooks 2-6, 11, 12, 13, 15 (preuves Lean natives)
-- **Python 3 (WSL)** : Notebooks 1, 7-10, 11py, 15b, 16a-16c, 16f (setup, LLM, LeanDojo, hommages)
+- **Python 3 (WSL)** : Notebooks 1, 7-10, 11py, 15b, 16a-16c, 16f, 19-23 (setup, LLM, LeanDojo, hommages, théorèmes phares 2026)
 
 > Note : Les kernels Windows ne fonctionnent pas (signal.SIGPIPE, problèmes chemins)
 
@@ -401,10 +407,25 @@ SymbolicAI/
 │   ├── ext_tools/             # Clingo, SPASS, EProver
 │   └── README.md
 │
-├── Lean/                      # Serie Lean 4 (28 notebooks : 18 proof natifs + 10 companions Python/WSL)
-│   ├── Lean-1-Setup.ipynb ... Lean-18-Search-AStar-Optimality.ipynb
+├── Lean/                      # Serie Lean 4 (33 notebooks : 18 proof natifs + 15 companions Python/WSL)
+│   ├── Lean-1-Setup.ipynb ... Lean-23-Galois-Probleme-Inverse-M23.ipynb
 │   ├── lean_runner.py         # Backend Python multi-mode
 │   ├── scripts/               # Installation, validation WSL
+│   ├── conway_lean/            # Companion lean du Lean-16 (ports natifs Game of Life, FRACTRAN)
+│   ├── grothendieck_lean/      # Companion lean du Lean-15 (atelier Micro-Formalisation)
+│   ├── sensitivity_lean/       # Companion lean du Lean-12 (Huang 2019)
+│   ├── knot_lean/              # Companion lean du Lean-17 (noeuds de Conway)
+│   ├── galois_lean/            # Companion lean du Lean-23 (M₂₃ simple, PR #10486)
+│   ├── mimo_lean/              # Companion lean du Lean-22 (détection MIMO)
+│   ├── calibration_lean/       # Companion lean du Lean-14 (finitude des dérivées)
+│   ├── finiteness_lean/        # Companion lean du Lean-14 (finitude Mathlib)
+│   ├── mathlib_examples/       # Exemples Mathlib
+│   ├── examples/               # Exemples Lean (assistés LLM)
+│   ├── agent_tests/            # Tests harnais Lean
+│   ├── tests/                  # Tests unitaires Lean
+│   ├── assets/                 # Figures, snippets .lean
+│   ├── _run_lean_snippet.sh    # Script WSL exécution snippet
+│   ├── install_wsl_kernel.md   # Doc install kernel `Lean 4 (WSL)`
 │   └── README.md
 │
 ├── SemanticWeb/               # Web semantique (25 notebooks : 13 C# + 12 Python, incluant RDF.Net-Legacy)


### PR DESCRIPTION
Grain: MED/docs — lane myia-po-2024:CoursIA-2 — prev: MED/docs #11762
<!-- tag requalifie par ai-01 au merge : le genre est le TYPE DE TRAVAIL (edition
     d'un README), jamais la famille ou vivent les fichiers decrits (Lean). Tier
     ramene de DEEP a MED : +26/-5 sur un README corrige un drift reel, mais ne
     produit aucune capacite nouvelle. -->

# docs(symbolicai,#11740): ajouter Lean-19..23 au tableau, à l'arbre et à la phase 3 (grain 2)

Mandat user 2026-08-19 sur le README parent SymbolicAI. **Grain 2 d'une série de 4** (cf. #11740) : la table « Structure détaillée » de la section Lean s'arrêtait à Lean-18, alors que la série porte 33 notebooks sur disque (1-23 + suffixes 7b/11py/12b/15b/16a-16f/17b). Les notebooks 19-23 (Sendov/Analysis-I/PFR/MIMO/M23) étaient rendus invisibles côté parent. Contribution partielle au plan 4 grains ; grains 3 (narration/lient) et 4 (sweep comptes résiduels Argument_Analysis + Planners) restent à livrer.

> **Correction tag** (post-G-VAR-3 #11170) : `DEEP/docs` → `DEEP/lean` — le grain porte sur des **notebooks Lean** (5 lignes ajoutées à la table « Structure détaillée » de `## Lean`), donc le genre travail est `lean` (CONTENU), pas `docs` (META). Adjacent MED/docs #11762 → DEEP/lean : genres distincts, règle G-VAR-3 ✓.

## Récapitulatif (grain 2 mandat §A2)

La table « Structure détaillée » du README parent **s'arrêtait à Lean-18** — les 5 derniers notebooks étaient invisibles. L'arbre disait « 28 notebooks » ; le catalogue dit `Lean=33`. Les ajouts récents (Sendov/Mazur Lean-19, *Analysis I* Lean-20 Tao, PFR Lean-21, MIMO Lean-22, M₂₃ Lean-23) n'avaient jamais été répercutés ici.

## Volets livrés (cohérence avec grain 2 mandat §A2)

- **5 lignes ajoutées au tableau « Structure détaillée »** (sous-section **Théorèmes phares 2026**), sur le même format Kernel/Contenu/Exercices que les sections pré-existantes :
  - **Lean-19** Sendov (Python WSL, 4 exos) — Conjecture de Sendov (preuve L. Mazur 2026, digestion et formalisation T. Tao)
  - **Lean-20** *Analysis I* Tao Workflow (Python WSL, 4 exos) — Manuel *Analysis I* de T. Tao en lac Lean 4 (`teorth/analysis`)
  - **Lean-21** PFR Entropy Method (Python WSL, 0 exo) — Conjecture PFR par méthode entropique (`teorth/pfr`)
  - **Lean-22** MIMO Detection Flips (Python WSL, 3 exos) — Détection MIMO par flips de coordonnées (Papailiopoulos 2026)
  - **Lean-23** Galois Problème Inverse M₂₃ (Python WSL, 3 exos) — Groupe de Mathieu M₂₃ simple, ordre 10 200 960 (arXiv:2608.08538)
- **Intro section Lean** (L183) corrigée : `28 notebooks` → `33 notebooks`, avec mention des 5 nouveaux notebooks dans la phrase d'ouverture.
- **Phase 3 Vérification formelle (Lean, ~10h)** (L62) rallongée : nouveau paragraphe inséré entre les références 11-12 et 13-18 pour couvrir les blocs 13-18 (hommages Conway/Grothendieck) et 19-23 (**théorèmes phares 2026** : Sendov, *Analysis I*, PFR, MIMO, M₂₃).
- **« Kernels requis »** (L229) étendu : `Notebooks 1, 7-10, 11py, 15b, 16a-16c, 16f` → `..., 19-23` + libellé « théorèmes phares 2026 ».
- **Arbre « Structure du Répertoire »** (L410) :
  - Titre : `(28 notebooks : 18 proof natifs + 10 companions Python/WSL)` → `(33 notebooks : 18 proof natifs + 15 companions Python/WSL)`
  - Description : `Lean-1-Setup.ipynb ... Lean-18-Search-AStar-Optimality.ipynb` → `Lean-1-Setup.ipynb ... Lean-23-Galois-Probleme-Inverse-M23.ipynb`
  - 14 sous-dossiers Lean documentés (vérifiés disque via `ls -d`) : `conway_lean/`, `grothendieck_lean/`, `sensitivity_lean/`, `knot_lean/`, `galois_lean/`, `mimo_lean/`, `calibration_lean/`, `finiteness_lean/`, `mathlib_examples/`, `examples/`, `agent_tests/`, `tests/`, `assets/`, `scripts/`, plus `_run_lean_snippet.sh` et `install_wsl_kernel.md`.

## Réconciliation disque ↔ CATALOG-STATUS ↔ prose (audit fichier-entier §E)

- **Lean** : catalogue `Lean=33`, disque vérifié firsthand via `ls Lean/ | grep -E '^Lean-[0-9]+' | wc -l` → 33 (1-23 + suffixes 7b/11py/12b/15b/16a-16f/17b), tableau 23 lignes numérotées + 10 lignes suffixées = **33** ✓ aligné.
- Marqueur `<!-- CATALOG-STATUS -->` byte-identique à `main` (règle R1 catalog-pr-hygiene).
- Aucun diff sur les marqueurs (`series`, `pedagogical_count`, `breakdown`, `maturity`).

## Écarts résiduels (hors scope grain 2 — à grains suivants)

| Sous-série | Catalogue | Prose | Arbre | Note |
|---|---|---|---|---|
| **Argument_Analysis** | 25 | 24 (L70) | 22 (L434) | Cible grain 4 |
| **Planners** | 23 | 23 (L66, L277) | 23 (L416) | compte OK, décompte Python/C# incohérent (13 vs 14) — grain 4 |

Documenté pour traçabilité. Les grains 3 (narration pédagogique, dé-duplication, liant) et 4 (sweep comptes résiduels Argument_Analysis + Planners) restent à livrer cf. #11740.

## Justification pédagogique

- **Sendov (Lean-19)** : la conjecture (1939) attendait sa **preuve complète depuis 87 ans** ; la résolution L. Mazur 2026 digérée par T. Tao est un jalon 2026 de la mathématique. Pas de section qui sache la surface = disservice aux étudiants.
- **Tao Workflow (Lean-20)** et **PFR (Lean-21)** : exposent deux lacs externes (`teorth/analysis`, `teorth/pfr`) de la Terence Tao Lean 4 Working Group, trait d'union entre la mathématique de recherche et la méthode de formalisation.
- **MIMO (Lean-22)** : la détection MIMO par flips de coordonnées (Papailiopoulos 2026) est un pont naturel Lean ↔ signal processing ↔ théorie de l'information.
- **M₂₃ (Lean-23)** : le problème inverse de Galois pour M₂₃ refermé (Huang–Jackson–Lee–Poonen–Pries–Zhang, arXiv:2608.08538, 9 août 2026). Le notebook trace la frontière **prouvé vs cité** avec soin (cf. incident #4980 / Epic #10478).

## Volets NON livrés (volet B — narration)

Le volet B (dé-duplication prose → résumés narratifs, enrichissement carte mermaid, fil rouge final) est laissé au grain 3 (cf. #11740 §48). Ce grain 2 se concentre exclusivement sur l'intégration Lean-19..23 — un livrable self-contained, vérifiable §E.

## Verification

- [x] R1 catalog-pr-hygiene : marqueur CATALOG-STATUS byte-identique
- [x] §E audit fichier-entier : Lean réconcilié (catalogue ↔ arbre ↔ tableau ↔ prose 33)
- [x] Format cohérent avec sections pré-existantes (Fondations, État de l'art 2024-2026, Hommages et théorèmes)
- [x] Nouveau sous-titre « Théorèmes phares 2026 » introduit pour les 5 lignes
- [x] Kernels alignés (L19-23 = Python WSL, vérifié via `kernelspec` sur disque)
- [x] readme-french-first : sections/intros rédigées en français
- [x] cross-link Lean/README.md cohérent (inchangé)
- [x] PR cible : `See #11740` (grain 2 d'une série de 4 — contribution partielle)
- [x] G-VAR-3 : tag `DEEP/lean` (CONTENU) après `MED/docs` #11762 — genres distincts ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>

