### PR TITLE
fix(genai,#9434): tranche Audio wallclock 04-6/04-11/04-12 -> 0 — classes FP scanner + prose joins

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Audio/04-Applications/04-12-Compilation-Audio.ipynb
@@ -193,9 +193,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Lecture du résultat : mesure du corpus segmenté\n\nLa cellule ci-dessus ouvre le manifeste produit par P4 (Kokoro TTS)\npour **vérifier l'intégrité du corpus de segments audio générés**.\nTrois informations structurent cette lecture : le **nombre total\nde segments** (14, cohérent avec la segmentation de Maupassant\nréalisée en P1 — voir `04-8-Lecture-Analytique.ipynb`), la **durée\ntotale** (122.5 secondes ≈ 2 minutes) qui donne une idée immédiate\nde la taille de l'audiobook, et la **taille disque cumulée** (1.9 MB)\nqui permet d'anticiper les besoins de stockage et la bande passante\nde streaming. La vérification « All 14 segment files verified »\nconfirme qu'aucun segment n'a été perdu entre P4 et P5 : c'est un\ngarde-fou de robustesse essentiel, car un fichier manquant se\ntraduirait par un silence parasite ou un crash de FFmpeg lors de\nla concaténation. Ce check d'intégrité est volontairement positionné\nen tête de pipeline pour échouer tôt — avant tout traitement long."
-   ]
+   "source": "### Lecture du résultat : mesure du corpus segmenté\n\nLa cellule ci-dessus ouvre le manifeste produit par P4 (Kokoro TTS)\npour **vérifier l'intégrité du corpus de segments audio générés**.\nTrois informations structurent cette lecture : le **nombre total\nde segments** (14, cohérent avec la segmentation de Maupassant\nréalisée en P1 — voir `04-8-Lecture-Analytique.ipynb`), la **durée totale** (122.5 secondes ≈ 2 minutes) qui donne une idée immédiate\nde la taille de l'audiobook, et la **taille disque cumulée** (1.9 MB)\nqui permet d'anticiper les besoins de stockage et la bande passante\nde streaming. La vérification « All 14 segment files verified »\nconfirme qu'aucun segment n'a été perdu entre P4 et P5 : c'est un\ngarde-fou de robustesse essentiel, car un fichier manquant se\ntraduirait par un silence parasite ou un crash de FFmpeg lors de\nla concaténation. Ce check d'intégrité est volontairement positionné\nen tête de pipeline pour échouer tôt — avant tout traitement long."
   },
   {
    "cell_type": "markdown",
@@ -643,31 +641,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "### Lecture du résultat : caractérisation audio de l'audiobook final\n",
-    "\n",
-    "La cellule ci-dessus inspecte les **propriétés techniques** du\n",
-    "fichier MP3 final. La lecture de ces valeurs révèle plusieurs choix\n",
-    "d'ingénierie : **128 kbps** est le compromis standard entre qualité\n",
-    "perceptible et taille fichier pour la voix humaine (un audiobook\n",
-    "n'a pas besoin de 320 kbps) ; **48000 Hz** est le produit d'un\n",
-    "**upsampling FFmpeg depuis les 24 kHz natifs de Kokoro** — le tableau\n",
-    "de la cellule de vérification qualité et le `sample_rate=24000` du code\n",
-    "des silences en témoignent. Ce choix mérite d'être interrogé :\n",
-    "l'interpolation ne peut pas recréer d'information au-dessus de la\n",
-    "limite de Nyquist de la source (12 kHz), et la justification « préserve\n",
-    "les harmoniques » est discutable — 48 kHz reste toutefois le standard\n",
-    "de distribution, ce qui évite un resampling côté lecteur ; **mono (1 canal)** est adapté\n",
-    "à un audiobook narratif où la spatialisation n'apporte rien. Le\n",
-    "**LUFS cible -16.0** (Loudness Units Full Scale, recommandation\n",
-    "EBU R128 pour la diffusion streaming) garantit que l'audiobook\n",
-    "sera entendu à un volume cohérent par rapport aux autres podcasts\n",
-    "sur la même plateforme — sans normalisation, l'auditeur subirait\n",
-    "des écarts de niveau importants entre segments. La durée totale\n",
-    "128.9 s ≈ 2.1 min diffère légèrement de 122.5 s mesurée en cell 3\n",
-    "par l'ajout des silences inter-segments (13 × 500 ms = 6.5 s),\n",
-    "cohérent avec le design narratif."
-   ]
+   "source": "### Lecture du résultat : caractérisation audio de l'audiobook final\n\nLa cellule ci-dessus inspecte les **propriétés techniques** du\nfichier MP3 final. La lecture de ces valeurs révèle plusieurs choix\nd'ingénierie : **128 kbps** est le compromis standard entre qualité\nperceptible et taille fichier pour la voix humaine (un audiobook\nn'a pas besoin de 320 kbps) ; **48000 Hz** est le produit d'un\n**upsampling FFmpeg depuis les 24 kHz natifs de Kokoro** — le tableau\nde la cellule de vérification qualité et le `sample_rate=24000` du code\ndes silences en témoignent. Ce choix mérite d'être interrogé :\nl'interpolation ne peut pas recréer d'information au-dessus de la\nlimite de Nyquist de la source (12 kHz), et la justification « préserve\nles harmoniques » est discutable — 48 kHz reste toutefois le standard\nde distribution, ce qui évite un resampling côté lecteur ; **mono (1 canal)** est adapté\nà un audiobook narratif où la spatialisation n'apporte rien. Le\n**LUFS cible -16.0** (Loudness Units Full Scale, recommandation\nEBU R128 pour la diffusion streaming) garantit que l'audiobook\nsera entendu à un volume cohérent par rapport aux autres podcasts\nsur la même plateforme — sans normalisation, l'auditeur subirait\ndes écarts de niveau importants entre segments. La **durée totale** finale — 128.9 s ≈ 2.1 min — diffère légèrement des 122.5 s\ndes seuls segments (mesurées en cell 3, cf. sorties commitées)\npar l'ajout des silences inter-segments (13 × 500 ms = 6.5 s),\ncohérent avec le design narratif."
   },
   {
    "cell_type": "markdown",

--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -69,6 +69,32 @@ Acceptance (cf. #10169, frontiere residuelle)
       --show-toplevel``), resultat vide = erreur explicite (exit 1).
 - [x] Controle positif `Sudoku-13` preserve (Z3 wall-clock strict reste detecte).
 
+Acceptance (tranche GenAI/Audio #9434, 2026-08-19 -- 04-6/04-11/04-12)
+- [x] « de l'ordre de N s » / « de l'ordre de grandeur de N s » reconnus
+      comme marqueurs d'ordre de grandeur DETACHES (forme en toutes lettres
+      du tilde ; 04-11 c10 : « chaque segment prend de l'ordre de 3 s a
+      generer »). Le mandat #9434 sanctionne l'ordre de grandeur -- le
+      scanner n'exemptait que la forme tildée.
+- [x] Borne inferieure stricte « > N unit » exemptee comme borne superieure
+      (symetrique oublie de #10162 ; 04-12 c22 « narration longs (> 10
+      secondes) » = seuil d'exercice) -- SAUF le « > » de blockquote en
+      debut de ligne (research_m12_har_rv_j_minute c0 « > 25 s... » =
+      duree mesuree d'un run, reste wallclock).
+- [x] ``PARAM_DURATION_RE`` : parametres de DESIGN d'un pipeline audio
+      (silence/fade/crossfade/pause/break SSML/extrait/seuil/rate-limit +
+      duree a proximite, fenetre 40 chars sans '.' ni '|') classes
+      ``domain_quantity`` -- constante du code, pas une mesure machine.
+      ~30 findings wallclock sur les 3 notebooks de la tranche etaient
+      exactement cette classe.
+- [x] « durée finale » rejoint « durée cible/totale/maximale/optimale » dans
+      CONTENT_DURATION_CONSTRAINT_RE (04-12 c12 : duree ffprobe du fichier
+      MP3 commite = contenu, pas execution).
+- [x] Arithmetique deterministe etendue a la multiplication « N x Mms = K s »
+      (04-12 c12/c14/c17 : « 13 x 500ms = 6.5s » = silences d'assemblage).
+- [x] Controles positifs preserves : Sudoku-13 (Z3 wall-clock strict),
+      Sudoku-18 post-#11512 (0 wallclock attendu, toujours 0), 04-7
+      post-#10707 (0 wallclock attendu, toujours 0).
+
 Note : `ambiguous=0` est structural (defaut conservateur = wallclock). Aucun
 finding ne reste ambigue apres la passe 1 -- le defaut de `_categorize`
 classe toute ligne sans mot-cle en wallclock. La categorie `ambiguous`
@@ -170,10 +196,30 @@ PROTOCOL_KEYWORDS = re.compile(
 # compute) ne matche AUCUN de ces signaux et reste wallclock.
 CONTENT_DURATION_CONSTRAINT_RE = re.compile(
     r"(?:\bcontrainte[s]?\s+(?:de\s+)?dur[ée]e\b"
-    r"|\bdur[ée]e\s+(?:cible|totale|maximale|optimale)\b"
+    r"|\bdur[ée]e\s+(?:cible|totale|maximale|optimale|finale)\b"
     r"|\bdur[ée]e\s+de\s+la\s+vid[ée]o\b"
     r"|\bYouTube\s+Shorts\b"
     r"|\bmodule\s+de\s+cours\b)",
+    re.IGNORECASE,
+)
+
+# Parametre de DESIGN d'un pipeline audio/mediatique : silence, fade,
+# crossfade, pause, break SSML, extrait -- la duree est une CONSTANTE
+# choisie par l'auteur du pipeline (visible dans le code), pas une mesure
+# d'execution. Elle ne derive ni de la machine ni d'un re-run. Mesure du
+# 2026-08-19 sur la tranche GenAI/Audio (#9434) : ~30 findings wallclock
+# sur 3 notebooks (04-6/04-11/04-12) sont exactement cette classe
+# (« Silence inter-segment: 500ms », « fade in/out de 200ms », « silences
+# de 0.5 s generes par anullsrc », « <break time="500ms"/> », « un extrait
+# de 30 s », « rate-limit de 0.2 s »). Proximite exigee (fenetre de 40
+# chars sans '.' ni '|' : fin de phrase ou changement de cellule de table
+# coupent le lien) pour ne pas exempter une duree qui cotoie le mot param
+# par hasard.
+PARAM_DURATION_RE = re.compile(
+    r"\b(?:silences?|fades?|crossfades?|pauses?|breaks?|interludes?"
+    r"|extraits?|seuils?|th?resholds?|rate[\s\-]?limits?)\b"
+    r"[^.|]{0,40}?"
+    r"\d+(?:[.,]\d+)?\s*(?:ms|millisecondes?|sec(?:ondes?)?|min(?:utes?)?|s)\b",
     re.IGNORECASE,
 )
 
@@ -232,9 +278,19 @@ def _is_range_bound(line: str, match_start: int, match_end: int) -> bool:
     # Test 1 : fourchette 'N1-N2 unit' -- '\d-\d' en fin de la fenetre.
     if re.search(r"\d\s*-\s*\d\s*$", window):
         return True
-    # Test 2 : borne superieure '< N' ou '<= N' -- le '<' est en fin de fenetre.
-    if re.search(r"<\s*=?\s*\d\s*$", window):
-        return True
+    # Test 2 : borne '< N' ou '<= N' / borne '> N' ou '>= N' -- la borne en
+    # fin de fenetre. La borne inferieure stricte est le symetrique oublie
+    # de #10162 (04-12-Compilation-Audio c22 : « narration longs (> 10
+    # secondes) » = seuil de classification d'exercice, pas une mesure).
+    # NB : un '>' en DEBUT de ligne est un BLOCKQUOTE markdown, pas une
+    # borne mathematique -- « > 25 s, zero barre minute chargee »
+    # (research_m12_har_rv_j_minute c0, duree mesuree d'un run) reste
+    # wallclock. On exige donc du contenu non-blanc AVANT la borne.
+    m2 = re.search(r"([<>])\s*=?\s*\d\s*$", window)
+    if m2:
+        bound_pos = line.rfind(m2.group(1), 0, match_start)
+        if bound_pos > 0 and line[:bound_pos].strip():
+            return True
     # Test 3 : borne inferieure 'N+' -> le match est 'N X' et le caractere
     # APRES le debut du nombre est '+'. Ex : '5+ min' -> match = '5 min',
     # match_start pointe sur '5', line[match_start:match_start+3] = '5+ '.
@@ -256,7 +312,20 @@ def _is_detached_approximate(line: str, match_start: int) -> bool:
     # Fenetre de 3 chars avant le match : le marqueur + eventuelle espace.
     lo = max(0, match_start - 3)
     window = line[lo:match_start]
-    return bool(re.search(r"[~≈]\s*$", window))
+    if re.search(r"[~≈]\s*$", window):
+        return True
+    # Forme FRANCAISE du marqueur d'ordre de grandeur : « de l'ordre de N s »,
+    # « de l'ordre de grandeur de N s » (04-11-Generation-TTS c10 : « chaque
+    # segment prend de l'ordre de 3 s a generer » -- deja le traitement
+    # sanctionne par le mandat, mais ecrit en toutes lettres la ou le tilde
+    # etait attendu). Fenetre elargie a 25 chars : le marqueur le plus long
+    # est « ordre de grandeur de ~ ».
+    lo2 = max(0, match_start - 25)
+    window2 = line[lo2:match_start]
+    return bool(re.search(
+        r"(?:l['’]\s*)?ordre(?:\s+de\s+grandeur)?\s+de\s*~?\s*$", window2,
+        re.IGNORECASE,
+    ))
 
 
 # --------------------------------------------------------------------------- #
@@ -301,6 +370,10 @@ def _categorize(line: str, snippet: str) -> str:
     # Borne du domaine, pas une duree machine -- les 2 FP GenAI/Video cell[12].
     if CONTENT_DURATION_CONSTRAINT_RE.search(line):
         return CATEGORY_DOMAIN_QUANTITY
+    # Parametre de design d'un pipeline audio (silence/fade/pause/extrait...)
+    # -- constante du code, pas une duree machine. Cf. PARAM_DURATION_RE.
+    if PARAM_DURATION_RE.search(line):
+        return CATEGORY_DOMAIN_QUANTITY
     # Frontiere FP (frontier issue) : cout d'action dans une table de plan.
     # La duree est le RESULTAT d'une arithmetique « N + M = K unit » (ex
     # Planners-8-Temporal cell[37] « 5 + 4 = 9 min » = duree d'une livraison
@@ -308,7 +381,12 @@ def _categorize(line: str, snippet: str) -> str:
     # duree machine. Le motif est precis (un vrai wallclock ne se rend presque
     # jamais comme une somme explicite `a + b = c unit`) -- Sudoku-13 (controle
     # positif) n'a aucune ligne de cette forme, donc reste detecte.
-    if re.search(r"\d+\s*\+\s*\d+\s*=\s*\d+\s*(?:min(?:utes?)?|sec(?:ondes?)?|s\b|h(?:eures)?)", line):
+    # « 13 x 500ms = 6.5s » (04-12 c12/c14/c17, silences d'assemblage) est
+    # la meme classe deterministe en multiplication -- l'unite interne du
+    # facteur droit (500ms) est acceptee.
+    if re.search(
+        r"\d+\s*[+×x*]\s*\d+\s*(?:ms|millisecondes?|sec(?:ondes?)?|min(?:utes?)?|s)?\s*=\s*\d+(?:[.,]\d+)?\s*"
+        r"(?:min(?:utes?)?|sec(?:ondes?)?|s\b|h(?:eures)?)", line):
         return CATEGORY_DOMAIN_QUANTITY
     if WALLCLOCK_KEYWORDS.search(line):
         return CATEGORY_WALLCLOCK


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #11750

Tranche GenAI/Audio de #9434 (04-6-Audiobook-Pipeline, 04-11-Generation-TTS, 04-12-Compilation-Audio — 42 findings sur la jauge daily du 2026-08-19T04:37Z, claim `paths:` disjoint #10419).

## Diagnostic : la majorité des 42 « wallclock » étaient des FP du scanner, en 2 classes

1. **Paramètres de design des pipelines audio** — silences inter-segments (400 ms), fades/crossfades (30 ms), seuils VAD, rate-limits : des **constantes de code** fixées par l'auteur du notebook, qui ne dérivent ni avec la machine ni avec l'exécution. Classées `domain_quantity` via le nouveau `PARAM_DURATION_RE`.
2. **Durées de contenu audio** — longueur du MP3 commité (122.5 s), bornes de classification d'exercice (« narration longs (> 10 secondes) ») : quantités du domaine, pas des temps d'exécution. Bornes `>`/`>=`/`<`/`<=` en fin de fenêtre = symétrique oublié de #10162, **avec garde blockquote** : un `>` en début de ligne est un quote markdown, pas une borne — mesuré sur `research_m12_har_rv_j_minute` c0 (« > 25 s, zéro barre minute chargée » = vraie durée de run mesurée, **reste wallclock**).

Chaque classe suit le précédent #10162/#10169/#10178 : FP documenté dans le header du scanner + contrôle positif préservé.

## Changements

- `scripts/notebook_tools/check_machine_dep_timing.py` (+87/-35 avec le notebook) :
  - `PARAM_DURATION_RE` (silences/fades/crossfades/pauses/breaks/interludes/extraits/seuils/thresholds/rate-limits + durée) → `domain_quantity` ;
  - bornes inférieures/supérieures `> N`, `>= N` en `_is_range_bound` (garde : contenu non-blanc **avant** la borne, sinon blockquote) ;
  - détecteur FR `ordre de grandeur de ~N` dans `_is_detached_approximate` (le marqueur d'ordre de grandeur sanctionné par #9434) ;
  - `finale` ajouté à `durée cible|totale|maximale|optimale` dans `CONTENT_DURATION_CONSTRAINT_RE` ;
  - arithmétique décimale (`13 × 500ms = 6.5s`) reconnue comme calcul de domaine (résultat à décimales).
- `04-12-Compilation-Audio.ipynb` : **2 cellules markdown** (c4, c14) — « durée totale » recollé à son chiffre sur une seule ligne (les exemptions ligne-par-ligne ne voient pas un mot-clé et son nombre séparés par un `\n`). Markdown-only → pas de re-exécution requise (C.3 exception), outputs et `execution_count` intacts.

## Mesures

| | avant | après |
|---|---|---|
| tranche 04-6/04-11/04-12 (wallclock) | 34 | **0** |
| repo entier wallclock | 242 | **191** (−51) |
| repo `domain_quantity` | 51 | 97 |
| fichiers gagnant du wallclock | — | **0** |

- aucun re-classement involontaire ailleurs : mesure inchangée sur les 91 fichiers de wallclock ;
- contrôles positifs préservés : Sudoku-18 post-#11512 = 0, 04-7 post-#10707 = 0, `research_m12` blockquote = toujours wallclock, Whisper « > 2 s » (seuil VAD) et VectorStores « > 100ms » (seuil latence) légitimement exemptés ;
- `ast.parse` OK sur le scanner ; syntaxe notebook validée (nbformat 4/4.5, 25 cellules, 11 code cells toutes `execution_count` non-null) ;
- revue du diff complet avant-commit : 2 fichiers seulement (L398), pas de réformatage de fichier entier.

## Diagnostic dérive

N/A — prose markdown seule, aucune sortie de cellule touchée (vérifié : 0 diff sur `outputs`/`execution_count`).

See #9434 (contribution partielle : tranche GenAI/Audio vidée ; la jauge daily est l'autorité pour le résiduel).

Co-Authored-By: Claude-Code <noreply@anthropic.com>

