### PR TITLE
fix(guard,#11771,#11764): garde de tag — separateur apres `Grain` + `notebook-lean` absent de l'enumeration

### DIFF
--- a/.claude/rules/variation-protocol.md
+++ b/.claude/rules/variation-protocol.md
@@ -32,13 +32,13 @@ Le litmus LIGHT est le **cœur anti-gaming** : guards, resyncs, ledger-entries, 
 
 ### GENRE — énumération CLOSE
 
-`lean` · `qc` · `training` · `genai` · `notebook-python` · `notebook-dotnet` · `slides` · `docs` · `guard` · `refactor` · `ledger` · `readme` · `test` · `tooling` · `research-code`.
+`lean` · `qc` · `training` · `genai` · `notebook-python` · `notebook-dotnet` · `notebook-lean` · `slides` · `docs` · `guard` · `refactor` · `ledger` · `readme` · `test` · `tooling` · `research-code`.
 
 **L'énumération se partitionne en deux, et la frontière porte G-VAR-1 :**
 
 | Classe | Genres | Ce qu'un grain y produit |
 |---|---|---|
-| **CONTENU** | `lean` · `qc` · `training` · `genai` · `notebook-python` · `notebook-dotnet` · `slides` · `research-code` | une capacité, une preuve, un résultat, du matériel pédagogique — ce que le dépôt existe pour offrir |
+| **CONTENU** | `lean` · `qc` · `training` · `genai` · `notebook-python` · `notebook-dotnet` · `notebook-lean` · `slides` · `research-code` | une capacité, une preuve, un résultat, du matériel pédagogique — ce que le dépôt existe pour offrir |
 | **META** | `guard` · `tooling` · `ledger` · `docs` · `readme` · `test` · `refactor` | l'outillage, les garde-fous et la prose *autour* du contenu — nécessaire, jamais suffisant |
 
 Un genre META n'est pas inférieur — un guard qui rougit au bon moment vaut mieux qu'un notebook de plus — mais une flotte qui ne produit que du META construit un atelier sans rien y fabriquer.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,8 +16,10 @@ TIER (test objectif, detail dans .claude/rules/variation-protocol.md) :
           (enrichissement + re-exec, audit borne qui change une decision, refactor + tests verts, README fichier-entier corrigeant un drift structurel reel).
   LIGHT = generable en serie par scan (guard-tranche, path-fix, doc-resync +1/-1, ledger append, fix accent/leak/FP).
           Litmus : « pourrais-je en generer une douzaine a la chaine en scannant l'instance d'a-cote ? » -> oui = LIGHT, quel que soit le label.
-GENRE : lean . qc . training . genai . notebook-python . notebook-dotnet . docs . guard . refactor . ledger . readme . test
-Gates durs : plancher du cycle = DEEP ou MED (G-VAR-1) ; <=1 LIGHT/lane/jour, agrege (G-VAR-2) ; pas 2x le meme genre LIGHT consecutif (G-VAR-3).
+GENRE : lean . qc . training . genai . notebook-python . notebook-dotnet . notebook-lean . slides
+        . research-code . docs . guard . refactor . ledger . readme . test . tooling
+        CONTENU (satisfait le plancher G-VAR-1) = les 9 premiers ; META = les 7 derniers.
+Gates durs : plancher du cycle = DEEP ou MED (G-VAR-1) ; budget LIGHT = max(1, grains_du_jour//3) par lane, agrege (G-VAR-2) ; pas 2x le meme genre LIGHT consecutif (G-VAR-3).
 -->
 
 ## Summary

--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -149,7 +149,7 @@ jobs:
               note_defect variation-tag-malformed
             fi
             if [ "$GENRE_VALID" != "True" ]; then
-              echo "::warning::GENRE '${GENRE:-vide}' hors enumeration §1 (lean, qc, training, genai, notebook-python, notebook-dotnet, slides, docs, guard, refactor, ledger, readme, test, tooling, research-code). G-VAR-3 compare des genres consecutifs : un genre inedit rend l'adjacence invisible. Mappe-le sur le genre qui decrit le TYPE DE TRAVAIL, pas le repertoire traverse."
+              echo "::warning::GENRE '${GENRE:-vide}' hors enumeration §1 (lean, qc, training, genai, notebook-python, notebook-dotnet, notebook-lean, slides, docs, guard, refactor, ledger, readme, test, tooling, research-code). G-VAR-3 compare des genres consecutifs : un genre inedit rend l'adjacence invisible. Mappe-le sur le genre qui decrit le TYPE DE TRAVAIL, pas le repertoire traverse."
               note_defect variation-tag-genre-offlist
             fi
             if [ -z "$LANE" ] || [ "$LANE" = "None" ]; then
@@ -475,7 +475,7 @@ jobs:
           Grain: <DEEP|MED|LIGHT>/<genre> -- lane <machine:workspace> -- prev: <TIER>/<GENRE> #<PR>
           \`\`\`
 
-          Le \`<genre>\` doit figurer dans l'enumeration §1 de \`variation-protocol.md\` (lean, qc, training, genai, notebook-python, notebook-dotnet, slides, docs, guard, refactor, ledger, readme, test, tooling, research-code). Les 3 formes tolerées par l'extracteur : \`Grain: TIER/GENRE\`, \`**Grain:** TIER/GENRE\`, \`## Grain\` + tag sur la ligne suivante. La lane doit suivre le format \`<machine>:<workspace>\` (cf. \`lane-claim-protocol.md\`).
+          Le \`<genre>\` doit figurer dans l'enumeration §1 de \`variation-protocol.md\` (lean, qc, training, genai, notebook-python, notebook-dotnet, notebook-lean, slides, docs, guard, refactor, ledger, readme, test, tooling, research-code). Les 3 formes tolerées par l'extracteur : \`Grain: TIER/GENRE\`, \`**Grain:** TIER/GENRE\`, \`## Grain\` + tag sur la ligne suivante. La lane doit suivre le format \`<machine>:<workspace>\` (cf. \`lane-claim-protocol.md\`).
           EOF
           )" 2>/dev/null || true
 

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -126,12 +126,15 @@ def _strip_title_hashes(flat: str) -> str:
 
 # --- extraction -------------------------------------------------------------
 
-# `Grain` then an OPTIONAL colon and any whitespace (incl. newlines), then
-# TIER / GENRE. The `[:\\s]*` is the whole #9485 fix in one atom: it accepts
+# `Grain` then a REQUIRED separator (colon and/or whitespace, incl. newlines),
+# then TIER / GENRE. `[:\\s]+` (one-or-more, #11771) keeps the whole #9485
+# tolerance while refusing a ZERO-width separator: with `*`, the word
+# `Graine` matched as `Grain` + `e / Tag` and a conformant PR was labelled
+# variation-tag-malformed + variation-tag-genre-offlist. It accepts
 # `Grain:`, `Grain `, `Grain\\n\\n`, `Grain :` (space then colon). TIER is the
 # alphabetic word before `/`; GENRE is the token after (letters, digits, _,-).
 _GRAIN_FULL_RE = re.compile(
-    r"Grain[:\s]*([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)", re.IGNORECASE
+    r"Grain[:\s]+([A-Za-z]+)\s*/\s*([A-Za-z0-9_-]+)", re.IGNORECASE
 )
 
 # `lane` (case-insensitive), optional whitespace, optional colon, whitespace,

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -564,8 +564,8 @@ def parse_short_header(body: str | None) -> dict:
 TIERS = ("DEEP", "MED", "LIGHT")
 GENRES = (
     "lean", "qc", "training", "genai", "notebook-python", "notebook-dotnet",
-    "slides", "docs", "guard", "refactor", "ledger", "readme", "test",
-    "tooling", "research-code",
+    "notebook-lean", "slides", "docs", "guard", "refactor", "ledger", "readme",
+    "test", "tooling", "research-code",
 )
 
 

--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -58,7 +58,8 @@ REPO = "jsboige/CoursIA"
 # Enumeration CLOSE de variation-protocol.md, partitionnee CONTENU / META.
 CONTENU = {
     "lean", "qc", "training", "genai",
-    "notebook-python", "notebook-dotnet", "slides", "research-code",
+    "notebook-python", "notebook-dotnet", "notebook-lean", "slides",
+    "research-code",
 }
 META = {"guard", "tooling", "ledger", "docs", "readme", "test", "refactor"}
 
@@ -66,6 +67,12 @@ META = {"guard", "tooling", "ledger", "docs", "readme", "test", "refactor"}
 # Volontairement grossier -- le genre infere est une *aide au tri*, pas un
 # verdict : l'agent pose le vrai tag Grain: lui-meme.
 GENRE_RULES: list[tuple[str, str]] = [
+    # AVANT la regle `lean` generique : un notebook a kernel Lean est du
+    # travail de NOTEBOOK (materiel pedagogique), pas du travail de lake.
+    # L'ordre compte -- la regle generique ci-dessous matcherait "notebook
+    # Lean" en premier et le genre notebook-lean serait inatteignable.
+    # `[.]ipynb` == `\.ipynb` sans backslash a transporter.
+    (r"(?=.*(?:notebook|[.]ipynb|companion))(?=.*lean)", "notebook-lean"),
     (r"\.lean\b|\blean[-_ ]|\blake\b|sorry|mathlib|grothendieck|knot|hashlife|tao\b", "lean"),
     (r"quantconnect|\bqc[-_ (]|backtest|quantbook|lean-cli|sharpe", "qc"),
     (r"training|post[- ]?training|\bppo\b|fine[- ]?tun|checkpoint|walk[- ]?forward", "training"),

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -437,12 +437,29 @@ def test_prev_close_keyword_all_inflections():
 
 
 def test_prev_canonical_genres_pass():
-    # The 15 canonical genres contain NO closing keyword -> all pass.
-    for genre in ("lean", "qc", "training", "genai", "notebook-python",
-                  "notebook-dotnet", "slides", "docs", "guard", "refactor",
-                  "ledger", "readme", "test", "tooling", "research-code"):
+    # Iterate gt.GENRES itself, NOT a copy of it. A hardcoded list here would
+    # be a fourth duplicate of the enumeration, silently drifting from the one
+    # the guard actually enforces -- which is the very defect that let
+    # notebook-lean be labelled off-list while the cap ranked it CONTENT.
+    for genre in gt.GENRES:
         hits = gt.find_prev_close_keywords(f"prev: MED/{genre} #100")
         assert hits == [], f"canonical genre {genre} must NOT be flagged"
+
+
+def test_notebook_lean_is_canonical_content_genre():
+    # Regression guard for the two-organ disagreement (#11764): the cap
+    # canonicalized notebook-lean -> lean (CONTENT, correct) while the tag
+    # guard rejected it as off-list, labelling legitimate Lean-notebook grains
+    # variation-tag-genre-offlist. Both organs must now agree.
+    assert "notebook-lean" in gt.GENRES
+
+    import variation_light_cap as vlc  # sys.path already set at module level
+
+    canon = vlc.canonicalize_genre("notebook-lean")
+    assert canon == "notebook-lean", (
+        f"membership in GENRES must win over compound reduction, got {canon!r}"
+    )
+    assert canon not in vlc.LIGHT_GENRES, "a Lean notebook is CONTENT, never LIGHT"
 
 
 def test_prev_close_keyword_backtick_wrapped():

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -554,3 +554,42 @@ def test_find_non_closing_refs_empty_and_none():
     assert gt.find_non_closing_refs(None) == []
     assert gt.find_non_closing_refs("") == []
     assert gt.find_non_closing_refs("nothing here") == []
+
+
+def test_grain_word_boundary_graine_heading_does_not_shadow_real_tag():
+    # #11771 (mesure 2026-08-19) : le body portait un titre `## Graine / Tag`
+    # AVANT sa ligne `Grain:` conforme. Le motif acceptait ZERO separateur apres
+    # `Grain`, donc « Graine » matchait comme `Grain` suivi de « e / Tag » et
+    # l'extracteur rendait tier="E" / genre="tag" -- deux labels rouges
+    # (variation-tag-malformed + variation-tag-genre-offlist) sur une PR dont le
+    # tag etait parfaitement conforme. Un separateur est desormais EXIGE.
+    body = """## Graine / Tag
+
+Grain: DEEP/notebook-dotnet -- lane myia-po-2026:CoursIA-2
+"""
+    g = gt.parse_grain_tag(body)
+    assert g is not None
+    assert g["tier"] == "DEEP"
+    assert g["genre"] == "notebook-dotnet"
+
+
+def test_grain_word_boundary_graine_alone_is_not_a_tag():
+    # Controle negatif : « Graine » SEULE ne doit produire aucun tag -- sinon le
+    # fix ne ferait que deplacer le faux positif au lieu de le fermer.
+    assert gt.parse_grain_tag("## Graine / Tag\n") is None
+
+
+def test_grain_separator_forms_still_accepted_after_boundary_fix():
+    # Non-regression #9485 : les 5 formes tolerees survivent au durcissement
+    # (chacune porte au moins un separateur apres `Grain`).
+    for body in (
+        "Grain: LIGHT/guard -- lane myia-po-2023:CoursIA",
+        "**Grain:** LIGHT/guard - lane myia-po-2023:CoursIA",
+        "## Grain\n\nLIGHT/guard -- lane myia-po-2023:CoursIA",
+        "`Grain` LIGHT/guard -- lane myia-po-2023:CoursIA",
+        "**Grain** : LIGHT/guard -- lane myia-po-2023:CoursIA",
+    ):
+        g = gt.parse_grain_tag(body)
+        assert g is not None, body
+        assert g["tier"] == "LIGHT", body
+        assert g["genre"] == "guard", body


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: DEEP/tooling #11837

Deux defauts du **meme** garde de tag de variation, trouves a vingt minutes
d'ecart. Ils touchent le meme fichier (`scripts/grain_tag.py`) et le meme test.

## 1. `Grain` sans separateur lu comme un tag (#11771)

L'extracteur matchait `Grain` sans exiger de separateur, donc un mot commencant
par ces cinq lettres (`Grainy`, `Graine`) ouvrait une tentative de parse. Le
motif exige desormais le separateur.

    "Grain: MED/notebook-lean - lane ... - prev: ..."  -> {'tier':'MED', 'genre':'notebook-lean', ...}
    "Grainy business here"                             -> None
    "Graine de projet"                                 -> None

## 2. `notebook-lean` absent de l'enumeration (#11764)

Le defaut n'etait pas une entree manquante : **les deux organes rendaient des
verdicts contradictoires**.

    notebook-lean -> canon=lean   dans GENRES(tag guard)=False   LIGHT=False

`variation_light_cap.canonicalize_genre` reduisait le compose a sa tete
(`notebook-lean` -> `lean`, CONTENU -- correct), pendant que `grain_tag.GENRES`
l'ignorait, donc `variation-tag-guard` posait `variation-tag-genre-offlist` sur
des grains de notebook Lean legitimes. C'est le label que porte **#11743**, un
grain de la forme meme que le mandat **#11703** demande (« ma preference quand
c'est possible va a un Notebook sous kernel Lean a cote du Notebook Python »).
Le harnais penalisait la forme qu'il reclame.

L'enumeration etait dupliquee en **5 endroits** ; corriger une copie en laissant
le jumeau est un defaut deja paye (#11532 repare, `check_exec_ratchet.py`
identique redecouvert 2 h plus tard par #11627) :

| Surface | Ce qui change |
|---|---|
| `scripts/grain_tag.py` | `GENRES` -- l'autorite. La membership est testee **avant** la reduction du compose, donc `notebook-lean` canonicalise vers lui-meme |
| `scripts/pick_idle_grain.py` | `CONTENU` + regle d'inference placee **avant** la regle `lean` generique -- sans quoi « notebook Lean » matche `lean` en premier et le genre reste inatteignable |
| `.claude/rules/variation-protocol.md` | enumeration + partition CONTENU |
| `.github/workflows/variation-tag-guard.yml` | les 2 chaines de message |
| `.github/pull_request_template.md` | enumeration |

**Deux derives PRE-EXISTANTES du template**, corrigees au passage : il lui
manquait `slides`, `tooling`, `research-code`, et il decrivait G-VAR-2 comme
« <=1 LIGHT/lane/jour » alors que le budget est proportionnel
(`max(1, grains//3)`) depuis #11154. Une description de gate fausse **dans le
harnais** enseigne l'inverse du gate a chaque lecture.

## Preuves

**Controle negatif** -- une suite entierement verte est aussi ce que produit un
test debranche, donc le test neuf doit rougir **sans** le fix :

    notebook-lean retire de GENRES : EXIT=1
      assert 'notebook-lean' in gt.GENRES
      AssertionError: assert 'notebook-lean' in ('lean','qc',...,'notebook-dotnet',...)
    remis                          : EXIT=0

**Inference, positif ET negatif** (le controle negatif est ce qui prouve que la
nouvelle regle n'a pas avale le genre `lean`) :

    « Companion notebook Lean pour le lake Grothendieck »  -> notebook-lean
    « Lean-15c Grothendieck Companion .ipynb »             -> notebook-lean
    « retirer un sorry de Mathlib dans le lake knot »      -> lean
    « lake build hashlife casse »                          -> lean
    « notebook Python sur les transformers »               -> notebook-python

**Suites** : 144 tests verts (`test_grain_tag.py` + `test_variation_light_cap.py`),
exit code capture par `out=$(cmd); rc=$?` et non derriere un pipe -- le code
serait celui du `tail`.

`test_prev_canonical_genres_pass` figeait sa **propre** copie des 15 genres : une
4e duplication, qui aurait derive en silence. Il itere desormais `gt.GENRES`.

## Sur le repliement des deux defauts en un grain

Je l'ecris parce que la meme operation pourrait se lire comme une esquive de mon
propre gate. Ma lane enchainait `guard` apres `guard #11753`, et
`Require genre diversity vs prev:` a rougi sur cette PR -- correctement. Livrer
les deux fixes separement aurait produit **deux** grains `guard` consecutifs,
donc un second rouge.

Le repliement ne fabrique pas du contenu et ne leve pas le gate : il reduit ma
production `guard` a **un** grain, ce que G-VAR-3 vise precisement, et cette PR
**reste tenue** jusqu'a ce qu'un grain de CONTENU de ma lane merge (#11763,
`notebook-dotnet`, d'ou le `prev:` ci-dessus). Je ne me suis pas auto-override.
Si un relecteur juge que deux defauts distincts ne forment pas un sujet, le
split est legitime -- il coutera un cycle de plus a #11743, qui porte le label
fautif.

See #11771. See #11764. See #11170.



---

**Note sur le champ `prev:` (corrige a la baisse, pas a la hausse).** Il
declarait `LIGHT/notebook-dotnet #11763`, ce qui etait exact a la redaction.
Depuis, ma lane a merge **#11758 (`MED/guard`, 16:49:06Z)**. Le vrai grain
precedent est donc celui-la, et le declarer rend cette PR **adjacente**
(guard apres guard) : la correction me coute le merge au lieu de me le donner.
Je la fais quand meme, parce qu'un `prev:` qu'on ne met a jour que lorsque ca
arrange n'est plus un fait, c'est un levier.

---

_Tag corrige par ai-01 au merge (2026-08-19T21:1xZ) : le champ prev: pointait #11758 (MED/guard, merge 16:49Z), qui n'est plus le grain precedent de la lane. Le dernier grain merge de myia-ai-01:CoursIA est #11837 (DEEP/tooling, 20:51Z) — verifie sur gh pr list --state merged, pas de memoire. Il n'y a donc pas d'adjacence guard-guard : la correction retablit la realite du plateau, elle ne contourne pas G-VAR-3._

_Ancien tag : `Grain: MED/guard - lane myia-ai-01:CoursIA - prev: MED/guard #11758`_
