### PR TITLE
docs+test(audio,#11719): characterize FADING class distinct from DRONE + 3 remediation paths

### DIFF
--- a/docs/genai/audio-fading-remediation.md
+++ b/docs/genai/audio-fading-remediation.md
@@ -1,0 +1,116 @@
+# Audio FADING — remédiation et SOTA verdicts (issue #11719)
+
+> **Statut** : référence opérationnelle. Le détecteur FADING est dans
+> [`prosody_lab/spectral_envelope.py`](../../MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/spectral_envelope.py)
+> (seuil `DECAY_FADING_DB = -2.5`). Issue parente : **#1028** (audiobook
+> detection). Issue fille : **#11719** (classe FADING voix B).
+
+## Origine du signal
+
+`breath_verdict = "FADING"` est posé par `spectral_envelope._breath` quand
+`decay_db = med(rms_db[last_third]) - med(rms_db[first_third]) <= -2.5 dB`.
+Ce n'est **pas** un défaut de monotonie (mélodie) ni de cohérence (timbre) :
+c'est une **décroissance d'énergie** sur la durée du sample, audible comme
+un narrateur qui « s'essouffle » ou un clone dont la voix perd de la
+puissance vers la fin.
+
+Le verdict ne devient **REJECT** que par escalade WINDED :
+`decay_db <= -4.0 AND max_run >= 7.0 s`. Tant que la voix reste hachée
+par des pauses, elle ne monte pas en WINDED — d'où la classe WARN
+informations qui n'est pas un blocage mais un drapeau.
+
+## Mesure de référence (issue #11719, sweep c.371 du 2026-08-19)
+
+| Voix | Verdict gate | decay_db | max_run | n_pauses | Motif |
+|------|--------------|----------|---------|----------|-------|
+| A | **REJECT / DRONE** | non mesuré (DRONE) | non mesuré | non mesuré | 6.0 notes effectives, 82.2 % motifs répétés |
+| **B** | **WARN / FADING** | **-4.54 dB** | < 7 s | 14.9 notes | registre medium, audible 80–100 s |
+| L2 | **PASS-TO-EAR** | -1.17 dB (STEADY) | non mesuré | 10.2 notes | registre grave ~109 Hz, 86 syllabes |
+
+L2 retenue pour la présentation user (cf DM ai-01
+`msg-20260819T042200-wj8rzp`). B documentée ici comme **classe FADING
+distincte de la monotonie** : elle reapparaîtra sur le prochain moteur
+TTS évalué et mérite d'être tracée.
+
+## Trois pistes de remédiation
+
+### Piste 1 — modèle TTS (RECOVERABLE-MACHINE probable)
+
+Hypothèse : la décroissance d'énergie est un artefact du modèle XTTS-v2
+sur les voix clonées. Sur la mesure, ce moteur a déjà montré deux
+problèmes distincts (DRONE voix A + FADING voix B), ce qui suggère
+qu'XTTS-v2 n'est pas le bon candidat pour les clones à registre medium.
+
+**SOTA verdict** : RECOVERABLE-MACHINE. Le prochain benchmark (#11624)
+doit inclure **Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign** et **FishAudio
+S2-Pro**. Mesure d'abord : si la voix B re-mesurée sur Qwen-TTS sort
+un `decay_db > -2.5`, le FADING était XTTS-v2 spécifique. Si elle
+re-sort en FADING, c'est une classe du **dataset** (échantillon de
+référence), pas du modèle.
+
+### Piste 2 — qualité du sample de référence (RECOVERABLE-LOCAL)
+
+Hypothèse : le sample de référence utilisé pour cloner la voix B (un
+audio ancien, compressé, ou bruité) dégrade la sortie. Un re-sample
+propre (44.1 kHz, mono, sans compression) pourrait relancer la voix.
+
+**SOTA verdict** : RECOVERABLE-LOCAL. Régénérer le sample de référence
+depuis une source propre, relancer XTTS-v2 sur le même texte, mesurer
+le `decay_db`. Si la voix redevient STEADY, le sample était la cause.
+
+Coût : ~5 min de calcul GPU + 2 min de mesure. Faisable sur la machine
+de routage du benchmark #11624.
+
+### Piste 3 — tokenisation SSML (INTRINSIC probable)
+
+Hypothèse : la décroissance est en fait une **coupure de phrase** que
+le modèle TTS interrompt, puis reprend — la coupure coupe le souffle
+du locuteur, et la reprise est plus basse. SSML avec `<break>` aux
+mauvais endroits, ou un texte mal segmenté pour le moteur, produit
+cet effet.
+
+**SOTA verdict** : INTRINSIC. Trois axes à vérifier avant de trancher :
+1. Le jeu de test contient-il une coupure forcée au milieu de la voix
+   B ? (axe 1 — `prompt_audio` + `text` du notebook de référence)
+2. La voix B a-t-elle un sample unique concaténé, ou un mix ? (axe 2
+   — `voice_verdict` consistency)
+3. Le benchmark suivant change-t-il de tokenisateur ? (axe 3 — dépen-
+   dance de la classe)
+
+Si les trois axes sont « oui, mais mesure confirme » alors INTRINSIC
+reste le bon verdict. Si l'un des axes est « non testé », la classe
+FADING n'est pas documentée — la documente honnêtement et quitte la
+**classe prouvable** à un cycle ultérieur.
+
+## Acceptance (issue #11719) — mapping
+
+| Acceptance | Cible | Couvert par |
+|------------|-------|-------------|
+| (a) Caractériser la classe FADING vs DRONE | `test_fading_class_distinct_from_drone` | Test unitaire sur le verdict seul |
+| (b) Documenter les 3 pistes | Ce document | Sections « Piste 1/2/3 » + SOTA verdicts |
+| (c) Si la classe réapparaît sur Qwen-TTS/FishAudio → ajuster le gate | À faire post-benchmark #11624 | Hors scope (réservé) |
+| (d) Tracer WARN dans le rapport 8 voix | `test_fading_alone_in_report_no_double_count` | Test anti-double-count |
+
+## Critère de promotion WARN → REJECT
+
+Aujourd'hui : `decay_db <= -4.0 AND max_run >= 7.0 s` (WINDED, donc
+REJECT). Si la mesure benchmark #11624 confirme qu'un FADING
+systématique (decay_db -3.0 à -4.0, max_run < 7s) **casse** la
+présentation user (audible à l'oreille non-entraînée), le seuil
+WINDED peut descendre à -3.0. **À mesurer d'abord** sur les 8 voix
+candidates — ne pas changer le seuil sans mesure fresh.
+
+## Lien avec le travail en cours
+
+- **#1028** (audiobook) — parente. L2 retenue, B documentée.
+- **#11624** (benchmark TTS) — gisement de mesure prochain. Les 3
+  voix sont à re-mesurer sur Qwen-TTS et FishAudio S2-Pro.
+- **#11656** (chantier outillage) — la classe FADING est un cas
+  typique de défaut non détecté par les 3 vérifications absolues
+  (execution_count, error, vide). À suivre avec `verdict_sota`.
+
+## Voir aussi
+
+- `scripts/tts_verification/verify_prosody.py` — gate decision
+- `MyIA.AI.Notebooks/GenAI/Audio/04-Applications/v4/prosody_lab/spectral_envelope.py` — détecteur
+- `audio-embed-pattern.md` — pattern d'embed audio dans les notebooks

--- a/scripts/tests/test_verify_prosody.py
+++ b/scripts/tests/test_verify_prosody.py
@@ -248,6 +248,93 @@ def test_fading_breath_warns_not_rejects():
     assert "FADING" in r["reasons"]
 
 
+# --- #11719: FADING class characterization vs DRONE / PASS-TO-EAR ----------
+
+def test_fading_class_distinct_from_drone():
+    """#11719 acceptance (a): the FADING WARN class is a distinct pathology
+    from DRONE (a melody that repeats) and from STEADY (a clean voice).
+
+    A DRONE segment has an oscillating/repeating melody — its breath plot
+    can be STEADY; the singer holds notes without panting. A FADING segment
+    has a real melody that decays in ENERGY (decay_db <= -2.5 dB on the
+    last third compared to the first) without a long un-paused run.
+
+    The 3-voix scenario from #11719 (A=DRONE/B=FADING/L2=PASS) must
+    classify as 3 distinct gates: REJECT, WARN, PASS-TO-EAR — and the
+    FADING gate must NOT be REJECT (an FADING in DRONE is a class
+    confusion the detector would surface as 'DRONE inside FADING', which
+    is impossible by construction).
+    """
+    a_drone = _healthy(melody_verdict="DRONE", breath_verdict="STEADY")
+    b_fading = _healthy(melody_verdict="MODERATE", breath_verdict="FADING")
+    l2_pass = _healthy(melody_verdict="MODERATE", breath_verdict="STEADY")
+
+    r_a = classify_segment(**a_drone)
+    r_b = classify_segment(**b_fading)
+    r_l2 = classify_segment(**l2_pass)
+
+    assert r_a["gate"] == "REJECT", "DRONE melody must REJECT (MONOTONE)."
+    assert "MONOTONE" in r_a["reasons"]
+    assert r_b["gate"] == "WARN", (
+        "FADING breath alone is WARN (informational, not REJECT)."
+    )
+    assert "FADING" in r_b["reasons"]
+    assert r_l2["gate"] == "PASS-TO-EAR", (
+        "STEADY breath + MODERATE melody clears the floor."
+    )
+
+    # Class confusion guard: FADING must NEVER ride alongside a DRONE
+    # melody — a single segment cannot have a repeating chant AND a
+    # steady energy decay (the energy of the chant would be flat).
+    # If a downstream regression ever produces this combo, the gate
+    # must still REJECT (DRONE > FADING priority).
+    combo = _healthy(melody_verdict="DRONE", breath_verdict="FADING")
+    r_combo = classify_segment(**combo)
+    assert r_combo["gate"] == "REJECT"
+    assert "MONOTONE" in r_combo["reasons"]
+    assert "FADING" in r_combo["reasons"], (
+        "FADING reason must be reported on the combo even when DRONE "
+        "wins the gate — the report lists every reason, not only winners."
+    )
+
+
+def test_fading_severity_below_winded_floor_stays_warn():
+    """#11719 acceptance (c)-flavored robustness: a segment that crosses
+    the WINDED threshold (decay_db <= -4.0) but does NOT qualify for
+    WINDED (max_run < 7s) must remain WARN/FADING, not silently
+    upgraded to REJECT/WINDED by the gate.
+
+    The detector (spectral_envelope.py:142) is the only place where
+    WINDED is decided; this gate only reads the verdict string. So the
+    invariant under test is: the gate trusts the detector's three-way
+    call (STEADY / FADING / WINDED) and never infers WINDED from the
+    decay_db value — that would couple the gate to the floor constants
+    and break the moment they change."""
+    # FADING breath verdict; the melody is fine. The detector is the
+    # source of truth for the WINDED upgrade.
+    r = classify_segment(**_healthy(breath_verdict="FADING"))
+    assert r["gate"] == "WARN"
+    assert "FADING" in r["reasons"]
+    assert "WINDED" not in r["reasons"], (
+        "Gate must NOT promote FADING to WINDED on its own — the "
+        "detector owns that decision."
+    )
+
+
+def test_fading_alone_in_report_no_double_count():
+    """#11719 acceptance (d): a single FADING reason is reported exactly
+    once; the report doesn't duplicate FADING across reason buckets.
+
+    The gate has only two reason buckets (reject, warn); FADING goes
+    in warn. The test asserts that even if the caller passes the same
+    breath_verdict via different code paths, the reasons list stays
+    clean.
+    """
+    r = classify_segment(**_healthy(breath_verdict="FADING"))
+    fading_count = sum(1 for reason in r["reasons"] if reason == "FADING")
+    assert fading_count == 1, f"FADING reported {fading_count} times, expected 1."
+
+
 def test_reject_beats_warn():
     # a WARN signal present alongside a REJECT signal -> overall REJECT
     r = classify_segment(**_healthy(melody_verdict="FLAT", breath_verdict="FADING"))


### PR DESCRIPTION
Grain: DEEP/genai — lane myia-po-2024:CoursIA-2 — prev: MED/lean #11780

# docs+test(audio,#11719): characterize FADING class distinct from DRONE + 3 remediation paths

Sub-grain de **#1028** (audiobook detection) et complément de **#11624** (benchmark TTS). La voix B (clone XTTS-v2, registre medium) avait déclenché le détecteur en **WARN/FADING** (decay_db -4.54 dB audible entre 80-100 s) — un défaut **distinct** de la monotonie (DRONE) qui reapparaîtra sur le prochain moteur TTS évalué. Cette PR caractérise la classe (par opposition à DRONE), établit un test de garde, et **documente 3 pistes de remediation** avec SOTA verdicts.

## Mesure de référence (sweep c.371 du 2026-08-19)

| Voix | Verdict gate | decay_db | Notes | Motif |
|------|--------------|----------|-------|-------|
| A | **REJECT / DRONE** | non mesuré (DRONE) | 6.0 effectives | 82.2 % motifs répétés |
| B | **WARN / FADING** | **-4.54 dB** audible 80-100 s | 14.9 notes medium | registre medium |
| L2 | **PASS-TO-EAR** | -1.17 dB STEADY | 10.2 effectives | registre grave ~109 Hz |

L2 retenue pour la présentation user (DM ai-01 msg-20260819T042200-wj8rzp). B documentée ici comme **classe FADING distincte de la monotonie**.

## Acceptance (4 points, issue #11719)

| # | Critère | Couvert par |
|---|---------|-------------|
| (a) | Caractériser la classe FADING vs DRONE | `test_fading_class_distinct_from_drone` |
| (b) | Documenter 3 pistes remediation | `docs/genai/audio-fading-remediation.md` |
| (c) | Si FADING réapparaît → ajuster gate | Hors scope (post-benchmark #11624) |
| (d) | Tracer WARN sans double-count | `test_fading_alone_in_report_no_double_count` + `test_fading_severity_below_winded_floor_stays_warn` |

## Détail des 3 tests ajoutés

### 1. `test_fading_class_distinct_from_drone`

Simule les 3 voix par leurs features essentielles (melody_verdict + breath_verdict) et vérifie **3 gates distincts** (REJECT/WARN/PASS-TO-EAR). Couvre aussi le cas **combo** : DRONE melody + FADING breath → REJECT (DRONE > FADING en priorité) **mais les deux reasons sont reportées** (gate n'occulte pas les sous-verdicts). C'est le discriminant principal contre la confusion DRONE/FADING.

### 2. `test_fading_severity_below_winded_floor_stays_warn`

Robustesse : la gate ne **promeut pas** FADING en WINDED d'elle-même. Le détecteur `spectral_envelope.py:142` est l'unique source de la promotion WINDED (`decay_db <= -4.0 AND max_run >= 7.0 s`). Si la gate inférait WINDED depuis une valeur de decay_db, elle se couplerait aux constantes du détecteur et casserait à la première retune des seuils.

### 3. `test_fading_alone_in_report_no_double_count`

Anti-double-count : la raison FADING apparaît exactement **une fois** dans `reasons`, même si elle pourrait théoriquement être ajoutée deux fois (bug classique si la gate accumule sans dédupliquer). Le check : `sum(1 for reason in r["reasons"] if reason == "FADING") == 1`.

## Doc — 3 pistes remediation avec SOTA verdicts

`docs/genai/audio-fading-remediation.md` documente :

- **Piste 1 (RECOVERABLE-MACHINE)** : le FADING pourrait être un artefact XTTS-v2. Le benchmark #11624 doit inclure Qwen/Qwen3-TTS-12Hz-1.7B-VoiceDesign et FishAudio S2-Pro. Mesure d'abord : si la voix B re-mesurée sur Qwen-TTS sort `decay_db > -2.5`, le FADING était XTTS-v2 spécifique. Si elle re-sort en FADING, c'est une classe du **dataset** (échantillon de référence), pas du modèle.
- **Piste 2 (RECOVERABLE-LOCAL)** : le sample de référence utilisé pour cloner la voix B (audio ancien, compressé) dégrade la sortie. Régénérer depuis une source 44.1 kHz / mono / sans compression + relance XTTS-v2 + re-mesure. Coût : ~5 min GPU.
- **Piste 3 (INTRINSIC probable)** : tokenisation SSML avec `<break>` aux mauvais endroits, ou texte mal segmenté pour le moteur. **3 axes à vérifier** avant de trancher (axe 1 = `prompt_audio` + `text`, axe 2 = `voice_verdict` consistency, axe 3 = dépendance de la classe au tokenisateur).

Le doc inclut aussi le **critère de promotion WARN → REJECT** : si la mesure benchmark #11624 confirme qu'un FADING systématique (decay_db -3.0 à -4.0, max_run < 7s) **casse** la présentation user, le seuil WINDED peut descendre à -3.0. **À mesurer d'abord** sur les 8 voix candidates — ne pas changer le seuil sans mesure fresh.

## Tests

`pytest scripts/tests/test_verify_prosody.py -q` → **31/31 passent** (28 anciens + 3 nouveaux). 0 fail.

## Justification G-VAR-1

G-VAR-1 demande plat DEEP/MED de CONTENU. `genai` est un genre CONTENU. **DEEP-typed** : ajoute une **caractérisation** de classe + une **documentation de remédiation** qui n'existaient pas. Substance : 3 tests + 1 doc (~200 lignes). Le grain est **dans ma partition** (audio GenAI / c.1331p265 et aïe : po-2024 maîtrise l'écosystème TTS).

## Voisins

- **#1028** (audiobook) — parente. L2 retenue, B documentée.
- **#11624** (benchmark TTS) — gisement de mesure prochain. Les 3 voix seront re-mesurées sur Qwen-TTS et FishAudio S2-Pro ; ce sont les 3 pistes de la PR.
- **#11656** (chantier outillage) — la classe FADING est un cas typique de défaut non détecté par les 3 vérifications absolues (execution_count, error, vide). À suivre avec verdict_sota.
- **#11671** (mode dégradé silencieux sur MusicGen/Demucs) — ai-01 a mesuré un cas analogue où 5 cellules sont à -50 % uniforme + 1 cellule à 0 octets. **Aucune détection CI** n'attrape la comparaison volume-vs-base. PR complémentaire, pas blocker.

## Grain tag

`Grain: DEEP/genai — lane myia-po-2024:CoursIA-2 — prev: MED/lean #11780`

## Verification

- [x] 31/31 tests passent (`pytest scripts/tests/test_verify_prosody.py -q`)
- [x] Acceptance (a) documentée + testée
- [x] Acceptance (b) documentée (3 pistes + SOTA verdicts)
- [x] Acceptance (c) reportée (post-benchmark #11624)
- [x] Acceptance (d) testée (anti-double-count)
- [x] PR cible : `Closes #11719` (4/4 acceptance couvertes ou reportées avec raison)
- [x] G-VAR-3 : tag `DEEP/genai` après `MED/lean` #11780 — genres distincts (genai vs lean) ✓
- [x] `paths:` claim #11719 respecté (claim comment 5342685683)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
