### PR TITLE
feat(tooling,#11725): scan_machine_path_outputs — le compte de la classe chemin-machine devient reproductible

### DIFF
--- a/scripts/notebook_tools/scan_machine_path_outputs.py
+++ b/scripts/notebook_tools/scan_machine_path_outputs.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Mesure de la classe #11725 : chemins machine dans les SORTIES commitees.
+
+`D:\\Dev\\...`, `C:\\Users\\...` imprimés par un notebook (env_path absolu,
+`Path.cwd()`, `os.path.abspath`, `__file__`, chemin de modele local,
+`FileNotFoundError`...) leake le layout disque de l'auteur. Le pre-commit
+`strip_machine_paths.py` n'attrape que le nom d'utilisateur .NET ;
+`detect_papermill_path_leak.py` ne lit que la metadata papermill. Aucun
+organe ne mesurait la classe dans les outputs eux-memes -- le compte de
+l'issue etait a re-mesurer a la main au lieu d'etre rejoue.
+
+Ce scanner rend le compte reproductible (acceptance #1 de #11725). Il lit
+EXCLUSIVEMENT les outputs (`text`, `data['text/*']`, `traceback`) -- jamais
+les sources : un chemin dans une source est un choix d'auteur, dans une
+sortie c'est un residu d'execution.
+
+Advisory par defaut (exit 0) : l'issue pose une decroissance **par
+attrition** au fil des re-executions faites pour d'autres motifs, pas un
+rollout frontal. `--check` existe pour un futur gate CI.
+
+Usage
+-----
+
+    # Mesure par defaut (GenAI, racine de l'issue)
+    python scan_machine_path_outputs.py
+
+    # Chemin arbitraire
+    python scan_machine_path_outputs.py MyIA.AI.Notebooks/GenAI/Audio
+
+    # JSON structure pour tooling en aval
+    python scan_machine_path_outputs.py --json
+
+    # CI dry-run (exit 1 si non-nul)
+    python scan_machine_path_outputs.py --check
+
+Acceptance (#11725)
+- [x] Le scan devient reproductible (ce script, sortie JSON + compacte)
+- [x] Le compte se re-mesure au lieu de se recopier
+"""
+import argparse
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+# Drive letter + antislash + racine layout-auteur. Equivalent au pattern de
+# reproduction de l'issue (`[A-Za-z]:` + chr(92)*2 + `(?:Dev|dev|Users|MyIA)`
+# avec re.I) : deux antislashs en regex = un antislash litteral dans le texte
+# parse du notebook.
+MACHINE_PATH_RE = re.compile(r"[A-Za-z]:\\(?:Dev|dev|Users|MyIA)", re.IGNORECASE)
+
+SKIP_DIRS = {".ipynb_checkpoints", ".lake", "_archives", "node_modules"}
+
+
+def iter_output_texts(outputs):
+    """Genere chaque chaine de sortie d'une liste d'outputs ipynb.
+
+    Couvre les trois surfaces portees par l'issue : `text` (stream/error
+    implicite via execute_result texte brut), `data['text/*']`, `traceback`.
+    Les outputs binaires (images...) n'ont pas de texte a fuiter.
+    """
+    for out in outputs:
+        if not isinstance(out, dict):
+            continue
+        text = out.get("text")
+        if isinstance(text, str):
+            yield text
+        elif isinstance(text, list):
+            for piece in text:
+                if isinstance(piece, str):
+                    yield piece
+        data = out.get("data")
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if not key.startswith("text/"):
+                    continue
+                if isinstance(value, str):
+                    yield value
+                elif isinstance(value, list):
+                    for piece in value:
+                        if isinstance(piece, str):
+                            yield piece
+        tb = out.get("traceback")
+        if isinstance(tb, list):
+            for piece in tb:
+                if isinstance(piece, str):
+                    yield piece
+
+
+def scan_notebook(nb_path: Path):
+    """Retourne la liste des occurrences (prefix, snippet) d'un notebook."""
+    hits = []
+    try:
+        nb = json.loads(nb_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return hits
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        for text in iter_output_texts(cell.get("outputs", [])):
+            for m in MACHINE_PATH_RE.finditer(text):
+                start = max(0, m.start() - 30)
+                end = min(len(text), m.end() + 40)
+                snippet = text[start:end].replace("\n", " ")
+                hits.append({
+                    "prefix": m.group(0).upper(),
+                    "snippet": snippet,
+                })
+    return hits
+
+
+def scan_tree(root: Path):
+    """Scanne les .ipynb d'une racine. Retourne l'inventaire structure."""
+    notebooks = {}
+    scanned = 0
+    for nb_path in sorted(root.rglob("*.ipynb")):
+        if any(part in SKIP_DIRS for part in nb_path.parts):
+            continue
+        scanned += 1
+        hits = scan_notebook(nb_path)
+        if hits:
+            # Chemin relatif a la racine : sortie portable (independante du
+            # worktree/clone qui execute le scan) et famille derivable.
+            notebooks[str(nb_path.relative_to(root)).replace("\\", "/")] = hits
+    by_prefix = Counter()
+    by_family = defaultdict(Counter)
+    for nb, hits in notebooks.items():
+        for hit in hits:
+            by_prefix[hit["prefix"]] += 1
+            family = "/".join(nb.split("/")[:-1]) or "(racine)"
+            by_family[family][nb] += 1
+    return {
+        "root": str(root),
+        "scanned": scanned,
+        "notebooks_with_hits": len(notebooks),
+        "occurrences": sum(len(h) for h in notebooks.values()),
+        "by_prefix": dict(by_prefix.most_common()),
+        "by_family": {
+            fam: {"notebooks": len(counts), "occurrences": sum(counts.values())}
+            for fam, counts in sorted(
+                by_family.items(),
+                key=lambda kv: -sum(kv[1].values()),
+            )
+        },
+        "notebooks": notebooks,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("--json", action="store_true", help="Sortie JSON structuree")
+    parser.add_argument("--check", action="store_true",
+                        help="Exit 1 si occurrences > 0 (futur CI bloquant)")
+    parser.add_argument("paths", nargs="*",
+                        help="Racines a scanner (defaut: MyIA.AI.Notebooks/GenAI)")
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    roots = [repo_root / p for p in args.paths] if args.paths else [
+        repo_root / "MyIA.AI.Notebooks" / "GenAI"
+    ]
+    inventories = [scan_tree(root) for root in roots]
+    combined = {
+        "scanned": sum(inv["scanned"] for inv in inventories),
+        "notebooks_with_hits": sum(inv["notebooks_with_hits"] for inv in inventories),
+        "occurrences": sum(inv["occurrences"] for inv in inventories),
+        "by_prefix": dict(sum((Counter(inv["by_prefix"]) for inv in inventories),
+                              Counter()).most_common()),
+        "trees": inventories,
+    }
+
+    if args.json:
+        print(json.dumps(combined, indent=2, ensure_ascii=False))
+    else:
+        print(f"scanned={combined['scanned']} "
+              f"notebooks_with_hits={combined['notebooks_with_hits']} "
+              f"occurrences={combined['occurrences']}")
+        for prefix, count in combined["by_prefix"].items():
+            print(f"  {prefix}: {count}")
+        for tree in combined["trees"]:
+            for fam, stats in list(tree["by_family"].items())[:10]:
+                print(f"  {fam}: {stats['notebooks']} notebooks, "
+                      f"{stats['occurrences']} occurrences")
+
+    if args.check and combined["occurrences"] > 0:
+        print(f"FAIL: {combined['occurrences']} machine-path occurrences "
+              f"remain (#11725)", file=sys.stderr)
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/notebook_tools/test_scan_machine_path_outputs.py
+++ b/scripts/notebook_tools/test_scan_machine_path_outputs.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tests du scanner #11725 (chemins machine dans les sorties commitees).
+
+Prouvent les trois surfaces portees par l'issue (text, data['text/*'],
+traceback), le silence sur les sources, le silence sur les notebook propres,
+et le collapse des variantes de casse dans les prefixes.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from scan_machine_path_outputs import MACHINE_PATH_RE, scan_notebook, scan_tree
+
+
+def make_notebook(outputs):
+    return {
+        "cells": [{"cell_type": "code", "outputs": outputs, "source": []}],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def write_notebook(root: Path, rel: str, nb) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(nb, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+def test_clean_notebook_has_no_hits(tmp_path):
+    nb = make_notebook([
+        {"output_type": "stream", "name": "stdout", "text": [" modele charge\n"]},
+    ])
+    path = write_notebook(tmp_path, "clean.ipynb", nb)
+    assert scan_notebook(path) == []
+
+
+def test_stream_output_text_counted(tmp_path):
+    nb = make_notebook([
+        {"output_type": "stream", "name": "stdout",
+         "text": ["env_path=D:\\Dev\\CoursIA\\.env\n"]},
+    ])
+    path = write_notebook(tmp_path, "stream.ipynb", nb)
+    hits = scan_notebook(path)
+    assert len(hits) == 1
+    assert hits[0]["prefix"] == "D:\\DEV"
+
+
+def test_data_text_plain_counted(tmp_path):
+    nb = make_notebook([
+        {"output_type": "execute_result",
+         "data": {"text/plain": ["WindowsPath('c:\\users\\jsboi\\models\\qwen')"]},
+         "metadata": {}},
+    ])
+    path = write_notebook(tmp_path, "data.ipynb", nb)
+    hits = scan_notebook(path)
+    assert len(hits) == 1
+    assert hits[0]["prefix"] == "C:\\USERS"
+
+
+def test_data_binary_key_ignored(tmp_path):
+    nb = make_notebook([
+        {"output_type": "display_data",
+         "data": {"image/png": ["D:\\Dev\\CoursIA\\img.png"]},
+         "metadata": {}},
+    ])
+    path = write_notebook(tmp_path, "binary.ipynb", nb)
+    assert scan_notebook(path) == []
+
+
+def test_traceback_counted(tmp_path):
+    nb = make_notebook([
+        {"output_type": "error", "ename": "FileNotFoundError",
+         "evalue": "missing",
+         "traceback": ["FileNotFoundError: D:\\dev\\myia\\weights.bin introuvable"]},
+    ])
+    path = write_notebook(tmp_path, "tb.ipynb", nb)
+    hits = scan_notebook(path)
+    assert len(hits) == 1
+    assert hits[0]["prefix"] == "D:\\DEV"
+
+
+def test_source_path_not_counted(tmp_path):
+    nb = make_notebook([])
+    nb["cells"][0]["source"] = ["env_path = r'D:\\Dev\\CoursIA\\.env'"]
+    path = write_notebook(tmp_path, "src.ipynb", nb)
+    assert scan_notebook(path) == []
+
+
+def test_case_variants_collapse_to_same_prefix(tmp_path):
+    nb = make_notebook([
+        {"output_type": "stream", "name": "stdout",
+         "text": ["d:\\dev\\a\n", "D:\\Dev\\b\n", "d:\\Dev\\c\n"]},
+    ])
+    path = write_notebook(tmp_path, "case.ipynb", nb)
+    hits = scan_notebook(path)
+    assert len(hits) == 3
+    assert {h["prefix"] for h in hits} == {"D:\\DEV"}
+
+
+def test_non_code_cell_ignored(tmp_path):
+    nb = {
+        "cells": [
+            {"cell_type": "markdown",
+             "source": ["doc: fichier sous D:\\Dev\\CoursIA\\data"]},
+        ],
+        "metadata": {}, "nbformat": 4, "nbformat_minor": 5,
+    }
+    path = write_notebook(tmp_path, "md.ipynb", nb)
+    assert scan_notebook(path) == []
+
+
+def test_scan_tree_relative_paths_and_family(tmp_path):
+    write_notebook(tmp_path, "Audio/x.ipynb", make_notebook([
+        {"output_type": "stream", "name": "stdout", "text": ["D:\\Dev\\a\n"]},
+    ]))
+    write_notebook(tmp_path, "Audio/y.ipynb", make_notebook([]))
+    write_notebook(tmp_path, "Texte/z.ipynb", make_notebook([
+        {"output_type": "stream", "name": "stdout", "text": ["C:\\Users\\b\n"]},
+    ]))
+    inv = scan_tree(tmp_path)
+    assert inv["scanned"] == 3
+    assert inv["notebooks_with_hits"] == 2
+    assert inv["occurrences"] == 2
+    assert set(inv["notebooks"]) == {"Audio/x.ipynb", "Texte/z.ipynb"}
+    assert inv["by_family"]["Audio"]["occurrences"] == 1
+
+
+def test_scan_tree_skips_checkpoint_dirs(tmp_path):
+    write_notebook(tmp_path, ".ipynb_checkpoints/w.ipynb", make_notebook([
+        {"output_type": "stream", "name": "stdout", "text": ["D:\\Dev\\a\n"]},
+    ]))
+    inv = scan_tree(tmp_path)
+    assert inv["scanned"] == 0
+    assert inv["occurrences"] == 0
+
+
+def test_regex_shape_matches_single_backslash_only():
+    # Un seul antislash litteral doit matcher ; deux antislashs (chemin
+    # echappe dans du JSON brut par exemple) ne matchent pas doublement.
+    assert MACHINE_PATH_RE.search("D:\\Dev\\x")
+    assert MACHINE_PATH_RE.search("c:\\users\\x")
+    assert MACHINE_PATH_RE.search("D:\\MyIA\\x")
+    assert not MACHINE_PATH_RE.search("D:\\Other\\x")
+    assert not MACHINE_PATH_RE.search("D:Dev")
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #11775

Acceptance **#1** de #11725 : le scan de reproduction de l'issue devient un organe reproductible — le compte se **re-mesure** au lieu de se recopier.

## Livrable

- **`scripts/notebook_tools/scan_machine_path_outputs.py`** (nouveau) : mesure la classe « chemin machine dans une sortie commitée » (`D:\Dev`, `C:\Users`, `D:\MyIA`…). Lit **exclusivement les outputs** (`text`, `data['text/*']`, `traceback`) — jamais les sources : un chemin dans une source est un choix d'auteur, dans une sortie c'est un résidu d'exécution. Regex = celle de la reproduction de l'issue (drive + antislash + racine layout-auteur). Sorties : compacte / `--json` structurée (préfixes collapsés par casse, familles en chemins **relatifs à la racine scannée** — sortie portable, indépendante du worktree), `--check` pour un futur gate CI. Advisory, exit 0 par défaut — cohérent avec la décroissance **par attrition** que l'issue pose (pas de rollout frontal).
- **`scripts/notebook_tools/test_scan_machine_path_outputs.py`** : 11 tests — les 3 surfaces de l'issue (stream / data text / traceback), silence sur sources / cellules markdown / clés binaires (`image/png`), collapse des variantes de casse en un préfixe canonique, familles relatives, skip `.ipynb_checkpoints`, forme du regex (1 antislash littéral, `D:Dev` sans séparateur ne matche pas).

## Re-mesure sur `origin/main` (GenAI)

| | rédaction issue (2026-08-19T05:37Z) | ce scan (branche, même base `abcec1405`) |
|---|---|---|
| notebooks scannés | 178 | 181 |
| porteurs | 46 (post-#11589) | **44** |
| occurrences | 117 | **113** |
| préfixes | D:\Dev 79 + D:\dev 5 + d:\Dev 3 + d:\dev 1 · C:\Users 27 + c:\users 14 | D:\DEV 75 · C:\USERS 38 (casse collapsée) |

L'écart 46→44 / 117→113 n'est pas un écart de détection : **l'attrition a déjà opéré** depuis la mesure de l'issue (des re-exécutions faites pour d'autres motifs ont drainé 2 notebooks) — exactement le mécanisme que l'issue designe. Têtes de liste inchangées (Audio/02-Advanced, Texte, Audio/04-Applications, Aspire).

## Contexte urne delivered

Cette issue était flag `candidate-delivered` (FP : la PR mergée #11589 la référence, mais ne livre que 5 notebooks de la cause sœur #10990). Label retiré avec justification (commentaire 2026-08-19), issue vivante par design (catalogue à attrition, fermeture = résidu documenté).

## Preuves

- `pytest scripts/notebook_tools/test_scan_machine_path_outputs.py -q` : **11 passed** ;
- scan live : `scanned=181 notebooks_with_hits=44 occurrences=113` (sortie collée dans le body ci-dessus) ;
- `git diff --numstat` : 2 fichiers, +347/0 (L398) ;
- découverte signalée (hors scope, pré-existant sur `main`) : `python -m pytest scripts/notebook_tools/` échoue à **collecter** `test_capture_user_remarks.py` (ImportError ligne 21 sous pytest, alors que l'import direct du module réussit) — non touché par cette PR.

See #11725 (acceptance #1 livrée ; les acceptances 2-3 sont l'attrition et la fermeture au résidu documenté — hors périmètre de cette PR).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
