### PR TITLE
feat(tooling,#11508): scan_slides_image_refs — inventaire L4 du referencement des images slides

### DIFF
--- a/scripts/notebook_tools/scan_slides_image_refs.py
+++ b/scripts/notebook_tools/scan_slides_image_refs.py
@@ -1,0 +1,158 @@
+"""Scan du referencement des images des decks slides/ (EPIC #11508, lot L4).
+
+Mesure, par deck, dans quelle classe tombe chaque fichier de ``<deck>/images/`` :
+
+  ACTIVE          reference dans un .md Slidev (hors ``slides.marp.md``) sur une
+                  ligne NON commentee -- l'image est rendue par le deck actif
+  COMMENT_TRAPPED reference dans un .md Slidev uniquement sur des lignes
+                  ``<!-- ... -->`` -- le port a conserve la reference en
+                  commentaire HTML, elle n'est jamais rendue (classe de defaut
+                  #4 de l'EPIC, corrigee a la main sur S3-acculturation)
+  MARP_ONLY       absente des .md Slidev, presente dans le ``slides.marp.md``
+                  legacy -- le port a perdu l'image entierement (cas extreme :
+                  05-theorie-des-jeux, 54/54)
+  NOWHERE         aucune reference nulle part -- fichier orphelin
+
+Le verdict final (une image COMMENT_TRAPPED doit-elle etre restauree, une
+NOWHERE supprimee ?) reste un jugement de domaine -- notamment visuel : une lane
+sans vision ne prononce pas qu'un rendu est correct (model-delegation). Ce scan
+mesure, il ne qualifie pas.
+
+Heuristique de commentaire : ligne dont le contenu, espaces de tete retires,
+commence par ``<!--``. Un commentaire multi-lignes ouvre par ``<!--`` mais les
+refs sont comptees par ligne ; les decks existants utilisent des commentaires
+mono-ligne ``<!-- Image: images/img_089.png -->`` (verifie sur les 12 decks
+porteurs). ``COURSE_RECAP_*`` est exclu (notes de session, pas un deck).
+
+Usage:
+  python scan_slides_image_refs.py --repo <racine>            # table lisible
+  python scan_slides_image_refs.py --repo <racine> --json     # sortie machine
+  python scan_slides_image_refs.py --repo <racine> --deck 03-logique
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REF_RE = re.compile(r"images/([\w\-. ]+\.\w{3,4})")
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"}
+
+
+def _is_comment_line(line: str) -> bool:
+    return line.lstrip().startswith("<!--")
+
+
+def _refs_by_class(files: list[Path]) -> tuple[set[str], set[str]]:
+    """Retourne (refs actives, refs piegees en commentaire) sur l'ensemble des fichiers."""
+    active, trapped = set(), set()
+    for md in files:
+        try:
+            text = md.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line in text.splitlines():
+            names = REF_RE.findall(line)
+            if not names:
+                continue
+            bucket = trapped if _is_comment_line(line) else active
+            for n in names:
+                bucket.add(n)
+    return active, trapped
+
+
+def scan_deck(deck_dir: Path) -> dict:
+    images = {
+        f.name
+        for f in (deck_dir / "images").iterdir()
+        if f.is_file() and f.suffix.lower() in IMAGE_EXTS
+    }
+    all_md = [p for p in deck_dir.glob("*.md") if "RECAP" not in p.name]
+    slidev_md = [p for p in all_md if "marp" not in p.name]
+    marp_md = [p for p in all_md if "marp" in p.name]
+
+    active, trapped = _refs_by_class(slidev_md)
+    marp_refs, _ = _refs_by_class(marp_md)
+
+    classes: dict[str, list[str]] = {"ACTIVE": [], "COMMENT_TRAPPED": [], "MARP_ONLY": [], "NOWHERE": []}
+    for name in sorted(images):
+        if name in active:
+            classes["ACTIVE"].append(name)
+        elif name in trapped:
+            classes["COMMENT_TRAPPED"].append(name)
+        elif name in marp_refs:
+            classes["MARP_ONLY"].append(name)
+        else:
+            classes["NOWHERE"].append(name)
+    return {
+        "deck": deck_dir.name,
+        "total": len(images),
+        "classes": classes,
+    }
+
+
+def scan_slides_dir(slides_dir: Path) -> list[dict]:
+    decks = sorted(
+        d
+        for d in slides_dir.iterdir()
+        if d.is_dir() and (d / "images").is_dir()
+    )
+    return [scan_deck(d) for d in decks]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", required=True, help="Racine du depot (contient slides/)")
+    ap.add_argument("--deck", help="Limiter a un deck (nom du sous-dossier)")
+    ap.add_argument("--json", action="store_true", help="Sortie JSON machine")
+    args = ap.parse_args(argv)
+
+    slides_dir = Path(args.repo) / "slides"
+    if not slides_dir.is_dir():
+        print(f"ERREUR: {slides_dir} introuvable", file=sys.stderr)
+        return 2
+
+    if args.deck:
+        deck_dir = slides_dir / args.deck
+        if not (deck_dir / "images").is_dir():
+            print(f"ERREUR: {deck_dir} sans dossier images/", file=sys.stderr)
+            return 2
+        results = [scan_deck(deck_dir)]
+    else:
+        results = scan_slides_dir(slides_dir)
+
+    totals = {k: 0 for k in ("ACTIVE", "COMMENT_TRAPPED", "MARP_ONLY", "NOWHERE")}
+    grand = 0
+    for r in results:
+        grand += r["total"]
+        for k in totals:
+            totals[k] += len(r["classes"][k])
+
+    if args.json:
+        print(json.dumps({"decks": results, "totals": totals, "grand_total": grand}, ensure_ascii=False, indent=1))
+        return 0
+
+    header = f'{"deck":40s} {"imgs":>4s} {"active":>6s} {"comment":>7s} {"marp-only":>9s} {"nowhere":>7s}'
+    print(header)
+    print("-" * len(header))
+    for r in results:
+        c = r["classes"]
+        print(
+            f'{r["deck"]:40s} {r["total"]:4d} {len(c["ACTIVE"]):6d} '
+            f'{len(c["COMMENT_TRAPPED"]):7d} {len(c["MARP_ONLY"]):9d} {len(c["NOWHERE"]):7d}'
+        )
+    print("-" * len(header))
+    rate = 100 * totals["ACTIVE"] / grand if grand else 0.0
+    print(
+        f'TOTAL {grand} fichiers | actifs {totals["ACTIVE"]} ({rate:.0f}%) | '
+        f'pieges-commentaire {totals["COMMENT_TRAPPED"]} | marp-only {totals["MARP_ONLY"]} | '
+        f'orphelins {totals["NOWHERE"]}'
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_scan_slides_image_refs.py
+++ b/scripts/notebook_tools/tests/test_scan_slides_image_refs.py
@@ -1,0 +1,78 @@
+"""Tests de scan_slides_image_refs (EPIC #11508 L4) — fixture couvrant les 4 classes."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scan_slides_image_refs import main, scan_slides_dir  # noqa: E402
+
+
+def _make_deck(root: Path):
+    deck = root / "slides" / "fixture-deck"
+    (deck / "images").mkdir(parents=True)
+    for n in ("a_active.png", "b_trapped.png", "c_marp.png", "d_nowhere.png"):
+        (deck / "images" / n).write_bytes(b"x")
+    (deck / "slides.md").write_text(
+        "# deck\n\n"
+        "![schema](images/a_active.png)\n"
+        "<!-- Image: images/b_trapped.png -->\n",
+        encoding="utf-8",
+    )
+    (deck / "slides.marp.md").write_text(
+        "# marp\n![](images/c_marp.png)\n![](images/b_trapped.png)\n",
+        encoding="utf-8",
+    )
+    # d_nowhere n'est referencee que dans le RECAP (exclu du scan) : NOWHERE
+    (deck / "COURSE_RECAP_2026.md").write_text(
+        "![](images/d_nowhere.png)\n", encoding="utf-8"
+    )
+    return deck
+
+
+def test_four_classes(tmp_path):
+    _make_deck(tmp_path)
+    results = scan_slides_dir(tmp_path / "slides")
+    assert len(results) == 1
+    c = results[0]["classes"]
+    assert c["ACTIVE"] == ["a_active.png"]
+    assert c["COMMENT_TRAPPED"] == ["b_trapped.png"]
+    assert c["MARP_ONLY"] == ["c_marp.png"]
+    assert c["NOWHERE"] == ["d_nowhere.png"]
+    assert results[0]["total"] == 4
+
+
+def test_non_image_files_ignored(tmp_path):
+    deck = _make_deck(tmp_path)
+    (deck / "images" / "notes.txt").write_text("pas une image", encoding="utf-8")
+    results = scan_slides_dir(tmp_path / "slides")
+    assert results[0]["total"] == 4
+
+
+def test_main_table_and_json(tmp_path, capsys):
+    _make_deck(tmp_path)
+    rc = main(["--repo", str(tmp_path)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "fixture-deck" in out
+    assert "TOTAL 4 fichiers | actifs 1 (25%)" in out
+
+    rc = main(["--repo", str(tmp_path), "--json"])
+    import json
+
+    data = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert data["grand_total"] == 4
+    assert data["totals"] == {
+        "ACTIVE": 1,
+        "COMMENT_TRAPPED": 1,
+        "MARP_ONLY": 1,
+        "NOWHERE": 1,
+    }
+
+
+def test_main_single_deck(tmp_path, capsys):
+    _make_deck(tmp_path)
+    rc = main(["--repo", str(tmp_path), "--deck", "fixture-deck"])
+    assert rc == 0
+    assert "fixture-deck" in capsys.readouterr().out


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/lean #11781

## Summary

Instrument du **lot L4** de #11508 : le taux de référencement des 702 images que l'EPIC demande de mesurer (« images jamais référencées (702 fichiers pour 18 decks : le taux de référencement est à mesurer) »). Aucun outil existant ne couvrait ce périmètre (vérifié : `scan_media_render.py` = primitives media notebooks GenAI ; `scripts/slides/` = `build_advisory.sh` seul).

Classement de chaque fichier `slides/<deck>/images/` en 4 classes :

| Classe | Définition | Défaut EPIC correspondant |
|---|---|---|
| `ACTIVE` | référencée dans un `.md` Slidev (hors `.marp.md`, hors `COURSE_RECAP_*`) sur une ligne non commentée | — |
| `COMMENT_TRAPPED` | référencée dans un `.md` Slidev **uniquement** sur des lignes `<!-- ... -->` | défaut #4 (« images perdues en commentaire HTML » — corrigé à la main sur S3) |
| `MARP_ONLY` | absente des `.md` Slidev, présente dans le `slides.marp.md` legacy | port ayant perdu l'image entièrement |
| `NOWHERE` | aucune référence nulle part | orphelin |

Le scanner mesure, il ne qualifie pas : le verdict par image (restaurer une COMMENT_TRAPPED ? supprimer une NOWHERE ?) reste un jugement de domaine — notamment **visuel** pour le placement (une lane sans vision ne prononce pas qu'un rendu est correct).

## Mesure sur origin/main (worktree frais, 2026-08-19)

```
deck                                     imgs active comment marp-only nowhere
01-introduction                            40     33       0         5       2
02-resolution-problemes                    59     37       0        19       3
03-logique                                 46     29       0        17       0
04-probabilites                           110     59      51         0       0
05-theorie-des-jeux                        54      0       0        54       0
06-apprentissage                          140     15     125         0       0
07-elargissements                          9      0       6         0       3
08-ia-generative                           36     22      11         0       3
_assets                                     2      0       0         0       2
S1-argumentation                           21     10       8         0       3
S2-ia-exploratoire-symbolique              54     40      14         0       0
S3-acculturation                          133    118       1        14       0
S4-trading-algorithmique                   15     11       0         0       4
TOTAL 719 fichiers | actifs 374 (52%) | pieges-commentaire 216 | marp-only 109 | orphelins 20
```

Faits saillants (postés aussi sur l'EPIC) : **52 % seulement des images sont rendues** ; `05-theorie-des-jeux` a perdu 100 % de ses 54 images (toutes MARP_ONLY — le port Slidev n'en mentionne aucune) ; `06-apprentissage` en a 125 piégées en commentaires HTML. L'inventaire chiffré complet va en commentaire de #11508 (rapport = issue/dashboard, jamais un fichier committé — harness-hygiene).

## Validation

- `python -m pytest scripts/notebook_tools/tests/test_scan_slides_image_refs.py -q` : **4 passed** (les 4 classes sur une fixture dédiée, exclusion RECAP, exclusion non-images, sortie table + JSON, mode `--deck`).
- Run réel reproduit la mesure ad-hoc préalable sur 719 fichiers (mêmes comptes par deck après re-scission commentaire/marp — la classification outil est plus fine que le scan ad-hoc qui lumpait les 216 COMMENT_TRAPPED dans marp-only).
- Outils dédiés respectés : ajout dans `scripts/notebook_tools/` (emplacement mandaté), pas de script ad-hoc en racine.

## Diff

2 fichiers : `scripts/notebook_tools/scan_slides_image_refs.py` (+~170) + `scripts/notebook_tools/tests/test_scan_slides_image_refs.py` (+~80). Aucun deck modifié, catalogue byte-identique à main.

See #11508 (L4 : infrastructure de mesure ; les tranches de fix — restauration COMMENT_TRAPPED, rattrapage MARP_ONLY, purge NOWHERE — restent à prendre, QA visuel sur lanes vision)

Co-Authored-By: Claude-Code <noreply@anthropic.com>

