### PR TITLE
feat(genai,#11271): densite Video 04-3-Sora-API-Cloud-Video 711 -> 1344 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
@@ -2379,7 +2379,6 @@
    "id": "c6717af6",
    "metadata": {},
    "source": [
-    "---\n",
     "## Conclusion : ce que ce notebook etablit\n",
     "\n",
     "Trois idees a retenir. **(1) L'API Sora comme contrat asynchrone** : le notebook a exerce le cycle complet d'une API video -- soumission d'un job, sondage de statut jusqu'a completion, telechargement du produit, mesure du temps (environ 65 s par generation dans la Section 2) -- derriere un wrapper qui rend ce cycle reproductible, y compris en mode simule quand la cle manque. **(2) Le cout comme fonction du volume** : la comparaison chiffree de la Section 4 montre qu'il n'existe pas de reponse universelle a \"cloud ou local\" ; il existe un seuil de volume mensuel, calculable (exercice 3) et visible sur la courbe, qui separe les deux regimes -- cout marginal lineaire d'un cote, cout fixe plat de l'autre. **(3) Le routage hybride comme synthese** : le squelette de planificateur de la derniere section transforme ce seuil en decision par requete -- chaque demande porte son budget, sa deadline et son exigence de qualite, et le systeme doit choisir le moteur adapte. Les deux exercices terminaux (production avec Sora, systeme hybride complet) prolongent exactement ces trois axes.\n",

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
@@ -113,7 +113,7 @@
     "tags": []
    },
    "source": [
-    "On importe ensuite les bibliotheques necessaires : le client OpenAI pour les appels API, numpy pour l'analyse des couts, et matplotlib pour les visualisations comparatives."
+    "On importe ensuite les bibliotheques necessaires. Le client officiel `openai` porte tous les appels a l'API Sora ; `numpy` alimente les analyses de cout et les visualisations de la Section 4 (tableaux de volumes, courbes comparatives) ; `matplotlib` trace ces comparaisons ; `time` mesure les durees de generation, la grandeur centrale du cloud vs local. Les utilitaires communs de la serie Video sont importes via `sys.path` depuis le dossier parent -- la sortie confirmera `Helpers video importes`, qui apporte notamment le formatage des metriques qu'on retrouvera dans le bilan de session. Ce pattern d'imports conditionnels est le socle qui rend le notebook executable que les services soient disponibles ou non.\n"
    ]
   },
   {
@@ -242,7 +242,7 @@
     "tags": []
    },
    "source": [
-    "Les variables d'environnement et la cle OpenAI sont chargees depuis le fichier `.env`. On verifie également les modes de demonstration pour executer le notebook sans acces reel a l'API Sora."
+    "Les variables d'environnement et la cle OpenAI sont chargees depuis le fichier `.env` -- le mecanisme standard du depot (regle d'hygiene : jamais de cle en litteral dans le code). La cellule suivante verifie simultanement trois choses : la presence du fichier `.env`, les dependances Python requises, et la cle `OPENAI_API_KEY`. Deux issues possibles, toutes deux fonctionnelles -- la sortie de cette execution le montre : `WARNING: .env non trouve` (le fichier absent du repertoire d'execution) MAIS aussitot apres `openai : disponible`, `httpx : disponible`, `imageio : disponible` et `OPENAI_API_KEY : configuree`. Autrement dit, le notebook est retombe sur les variables d'environnement du shell, qui portent la cle : l'execution continue en mode API reelle sans aucune modification. C'est exactement le comportement attendu d'un notebook portable -- la configuration se negocie avec l'environnement, jamais en editant le code.\n"
    ]
   },
   {
@@ -830,6 +830,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3c1cb952",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la couche wrapper autour de l'API\n",
+    "\n",
+    "La sortie detaille l'armature technique : `SoraAPIWrapper initialise`, avec `API reelle : True`, le parametre `use_mock_responses` a `False`, le `Mode mock (fallback)` inactif, et le chemin privilegie explicite -- `appels reels a POST /v1/videos`. Pourquoi un wrapper plutot que des appels `openai` nus ? Parce que l'API Sora est **asynchrone** : la sequence d'appels visible dans la section suivante le montrera -- un `POST /v1/videos` qui retourne immediatement un identifiant de job, une serie de `GET` de sondage du statut jusqu'a completion, puis un `GET .../content` qui telecharge le fichier produit. Le wrapper encapsule cette machine a etats derriere une interface a une seule methode. Les deux booleens affiches (`use_mock_responses` parametre, `Mode mock` fallback) documentent l'autre visage du wrapper : le meme notebook peut servir des reponses simulees de forme identique quand la cle ou le credit manque -- ici les deux sont a False, les sections suivantes utilisent l'API reelle.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-6",
    "metadata": {
     "papermill": {
@@ -1237,6 +1247,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "907bfdce",
+   "metadata": {},
+   "source": [
+    "## Section 3 : Generation image vers video\n",
+    "\n",
+    "La generation image-to-video part d'une image source et l'anime : l'image fournit le **contenu** (composition, couleurs, sujets), le prompt decrit le **mouvement** a produire. C'est le mode privilegie des usages professionnels -- animer un visuel de marque existant, prolonger un plan, tester une direction creative a partir d'une reference fixe -- la ou le text-to-video de la Section 2 part d'une page blanche totale.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 6,
    "id": "cell-9",
@@ -1487,6 +1507,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bccd8d0d",
+   "metadata": {},
+   "source": [
+    "### Interpretation : Generation image -> video\n",
+    "\n",
+    "La sortie montre d'abord la negociation de format -- `Image source : 1280x720 (cible : 1280x720)`, l'image est deja a la resolution demandee, aucun recadrage -- puis le meme cycle asynchrone que la Section 2 : `POST /v1/videos` accepte (200), une serie de sondages `GET` sur l'identifiant du job, et le telechargement final `GET .../content?variant=video`. `Status : success` et la ligne `Sortie API reelle` confirment que la video produite (environ 1,6 MB) vient bien de l'API, pas du mode simule. Difference notable avec le text-to-video : ici la contrainte de coherence visuelle avec l'image source s'ajoute a la generation -- la qualite du resultat depend autant de l'image de depart que du prompt de mouvement.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-10",
    "metadata": {
     "papermill": {
@@ -1501,8 +1531,7 @@
    "source": [
     "## Section 4 : Analyse des couts et comparaison locale vs cloud\n",
     "\n",
-    "Le choix entre generation video locale et cloud depend de plusieurs facteurs :\n",
-    "cout, qualite, latence, et infrastructure disponible."
+    "Le choix entre generation video locale (ComfyUI, modele Wan/Hunyuan sur GPU -- les notebooks 02 de cette serie) et generation cloud (API Sora facturee a la video produite) ne se tranche pas sur la seule qualite : il se tranche sur le **volume d'usage**. En local, le cout marginal d'une generation supplementaire est quasi nul en euros, mais l'infrastructure est un cout fixe eleve, paye d'avance (achat GPU, amortissement mensuel). Dans le cloud, chaque video facture son prix unitaire -- cout marginal eleve, mais zero investissement initial et zero maintenance. La cellule suivante chiffre la comparaison (cout par video, temps de generation, parallelisme) entre Sora et les modeles locaux, puis l'exercice 3 en derive le **seuil de rentabilite** : le volume mensuel exact au-dela duquel le local devient moins cher que le cloud. La reponse a \"cloud ou local ?\" n'est donc pas une propriete des modeles -- c'est une propriete du volume.\n"
    ]
   },
   {
@@ -1830,7 +1859,7 @@
     "tags": []
    },
    "source": [
-    "La visualisation graphique permet d'identifier visuellement le seuil de volume a partir duquel le modèle local devient plus economique que l'API cloud."
+    "La visualisation superpose les deux regimes de cout. **Panneau de gauche** : la courbe cloud (`volumes * 0.25`, 25 cents par video) croit lineairement avec le volume mensuel, tandis que la courbe locale est une droite **plate** au niveau de `gpu_monthly_cost` -- le GPU coute le meme prix mensuel qu'on genere 10 ou 1000 videos. La ligne verticale grise annotee `Seuil : N vid/mois` marque leur croisement : en dessous, le cloud (partie bleue sous la rouge) est moins cher ; au-dessus, le local gagne systematiquement, et l'ecart se creuse avec le volume. **Panneau de droite** : les barres qualitatives rappellent que le cout n'est pas le seul axe -- Sora domine sur la qualite (9 vs 7), la coherence temporelle (9 vs 6), la duree maximale (9 vs 5) et surtout la facilite de mise en place (10 vs 4), tandis que la comparaison compile les revers du cloud : dependance a un service externe et facturation a l'usage. Ensemble, les deux panneaux donnent la decision complete : le volume tranche le cout, les exigences qualitatives tranchent le reste.\n"
    ]
   },
   {
@@ -1922,7 +1951,7 @@
     "tags": []
    },
    "source": [
-    "En mode interactif, l'utilisateur peut tester un prompt personnalise et visualiser en temps reel la reponse simulee de l'API Sora avec les metadonnees de generation."
+    "En mode interactif, l'utilisateur peut tester un prompt personnalise et visualiser la generation. Le mode est volontairement **gouverne et encadre** : la cellule ne s'active que si le parametre Papermill `notebook_mode` vaut `interactive` ET que les widgets sont disponibles (`not skip_widgets`) -- la sortie montree ici affiche la banniere du mode actif. Quatre sorties propres sont prevues selon le contexte : un prompt saisi part vers le meme wrapper `text_to_video` que la Section 2 (avec affichage de 4 frames echantillonnees de la video produite) ; un prompt vide affiche `Mode interactif ignore` ; une interruption ou une fin de flux (`EOFError`) affiche `Mode interactif interrompu` -- c'est ce qui arrive dans un pipeline automatise, ou l'entree standard est fermee ; enfin hors mode interactif, la cellule se contente d'afficher `Mode batch - Interface interactive desactivee`. Ce garde-fou est le motif standard des notebooks executables a la fois par un humain dans Jupyter et par une CI.\n"
    ]
   },
   {
@@ -2236,7 +2265,7 @@
     "tags": []
    },
    "source": [
-    "Le planificateur hybride decide automatiquement de router chaque demande vers Sora ou un modèle local selon le volume, la qualite requise et les contraintes budgetaires."
+    "Le planificateur hybride doit decider automatiquement de router chaque demande vers Sora ou un modele local -- mais attention a la lecture de la sortie : le squelette est un **stub d'exercice**, et `choose_method` retourne pour l'instant la valeur constante `\"degraded\"` (marquee `TODO etudiant`). C'est pourquoi les trois scenarios de test -- budget $1.0/deadline 300 s, budget $0.1/deadline 60 s, budget $5.0/deadline 120 s -- ressortent tous avec `Method: degraded, Status: stub` : aucune decision reelle n'est encore prise. La logique a implementer est documentee dans la docstring : si le budget et la deadline couvrent Sora, partir dans le cloud ; sinon verifier la VRAM disponible pour Hunyuan puis LTX en local ; a defaut, degrader la resolution plutot qu'echouer. Les quatre facteurs de decision (budget max, deadline max, qualite minimale, VRAM disponible) delimitent l'espace du choix -- c'est le motif \"resource-aware routing\" des pipelines de production.\n"
    ]
   },
   {
@@ -2343,6 +2372,19 @@
     "for req in test_requests:\n",
     "    result = scheduler.generate(req)\n",
     "    print(f\"Request: budget=${req['budget']}, deadline={req['deadline']}s -> Method: {result['method']}, Status: {result['status']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6717af6",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Conclusion : ce que ce notebook etablit\n",
+    "\n",
+    "Trois idees a retenir. **(1) L'API Sora comme contrat asynchrone** : le notebook a exerce le cycle complet d'une API video -- soumission d'un job, sondage de statut jusqu'a completion, telechargement du produit, mesure du temps (environ 65 s par generation dans la Section 2) -- derriere un wrapper qui rend ce cycle reproductible, y compris en mode simule quand la cle manque. **(2) Le cout comme fonction du volume** : la comparaison chiffree de la Section 4 montre qu'il n'existe pas de reponse universelle a \"cloud ou local\" ; il existe un seuil de volume mensuel, calculable (exercice 3) et visible sur la courbe, qui separe les deux regimes -- cout marginal lineaire d'un cote, cout fixe plat de l'autre. **(3) Le routage hybride comme synthese** : le squelette de planificateur de la derniere section transforme ce seuil en decision par requete -- chaque demande porte son budget, sa deadline et son exigence de qualite, et le systeme doit choisir le moteur adapte. Les deux exercices terminaux (production avec Sora, systeme hybride complet) prolongent exactement ces trois axes.\n",
+    "\n",
+    "Prochaines etapes dans la serie : `04-4-Production-Video-Pipeline` chaine ces briques en un pipeline reel, et `04-5`/`04-6` repetent l'exercice de comparaison sur les API cloud MiniMax.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #11804

## Summary

Tranche densité de l'EPIC GenAI #11271 pour `GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb` — le notebook le plus déficitaire de la série Video en prose relative (densité **711**, `md_pct 17.8 %` — mesuré frais sur `origin/main` avec l'instrument canonique `pedagogy_density.py`). Après enrichissement : **densité 1344**, prose 9253 → 17484 caractères, 11 → 18 cellules markdown.

Le geste, markdown-only (+49/−7 lignes JSON, **0 cellule code modifiée, 0 `execution_count` changé** — exception C.3) :

| Geste | Détail |
|---|---|
| 6 cellules fines étoffées | imports (172→717 ch), chargement `.env` (190→932), intro Section 4 coûts (197→1005), interprétation visualisation (151→1048), mode interactif (165→1001), scheduler hybride (169→968) |
| Header **Section 3 restitué** | les sections sautaient de 2 à 4 — la génération image→video n'avait pas de section |
| 3 interprétations neuves | wrapper SoraAPIWrapper, image→video, conclusion (3 idées + prochaines étapes) |

**Ancrages vérifiés firsthand** (règle cell-interpretation-ordering — chaque valeur citée lue dans l'output réel de la cellule précédente) :

- l'interp wrapper cite `API reelle : True`, `use_mock_responses (param) : False`, `Mode mock (fallback) : False`, chemin privilégié `POST /v1/videos` — tels qu'affichés ;
- l'interp image→video cite `Image source : 1280x720 (cible : 1280x720)`, le cycle `POST /v1/videos` → sondages `GET` → `GET .../content?variant=video`, `Sortie API reelle` (≈1,6 MB) — et **ne prétend pas** que la Section 2 était en mode démo (les DEUX sections utilisent l'API réelle, vérifié) ;
- l'interp visualisation décrit ce que le CODE trace (courbe cloud `volumes * 0.25` linéaire vs droite locale PLATE `gpu_monthly_cost`, seuil `gpu_monthly_cost/0.25` annoté `Seuil : N vid/mois`, barres qualitatives 5 axes) — pas un rendu imaginé (QA visuel = lanes vision) ;
- l'interp scheduler corrige honnêtement la lecture : `choose_method` retourne `"degraded"` en constant (stub TODO étudiant) — les 3 scénarios de test ressortent tous `Method: degraded, Status: stub`, aucune décision réelle n'est prise.

## Validation

1. `pedagogy_density.py` : densité **711 → 1344** (seuil 1200), `below_threshold: 0`.
2. `scan_cell_ordering.py` : **1 clean, 0 finding** (un INTERP_BEFORE_CODE introduit par un mauvais placement d'insertion a été détecté et corrigé avant commit — la version main sert de contrôle, 0 finding).
3. `validate_pr_notebooks.py` : **1/1 passed** (13 code cells, outputs intacts).
4. C.1 : 0 erreur volontaire. C.2 : outputs intacts (markdown-only). Catalogue byte-identique à main.

## Signalements hors-scope (non traités ici)

- Les outputs commités contiennent des chemins machine (`D:\Dev\CoursIA-2-c10315\...\outputs\video\sora_api_*.mp4`) — classe #10990 (correctif opportuniste au re-exec, jamais scrub à la main).
- La cellule « Exercice 3 : Calcul du seuil » est numérotée 3 alors qu'aucun exercice 1/2 ne la précède (les exercices terminaux sont non numérotés) — incohérence de numérotation héritée, à arbitrer dans un grain séparé.

See #11271 (tranche Video 04-3 ; il reste 15 notebooks Video sous le plancher)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
