### PR TITLE
docs(qc,#11601): density round 2 tranche 4 QC-Py-27 Production-Deployment 1398->1576

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-27-Production-Deployment.ipynb
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> **[REFERENCE QC Cloud]**\n> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n> L'environnement local ne dispose pas de QuantBook ni de l'historical data feed.\n> Pour executer : cloner le projet QC associe, ouvrir `research.ipynb`, executer cellule par cellule.\n"
+    "> **[REFERENCE QC Cloud]** Ce notebook s'exécute en local (simulation du pipeline de déploiement) ; les cellules marquées `[REFERENCE QC]` contiennent le code à copier tel quel dans **QC Lab** (cloud QuantConnect), où seul il peut être exécuté contre l'infrastructure réelle — backtests cloud, paper trading sur données live, déploiement live. La séparation est volontaire : la logique de transition et de monitoring se lit et se comprend localement ; la plomberie QC (brokerages, résolutions de données, handlers d'ordres) vit dans le cloud, avec ses identifiants et ses limites de rate."
    ],
    "id": "cell-613fd687"
   },
@@ -443,7 +443,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 1.2 : Critères de transition personnalises\n\nAjoutez un critere de transition entre paper trading et live trading : le **backtest return** doit depasser 15% ET le **Max Drawdown** doit rester sous 20%.\n\n**Indices** :\n- `# Indice` : Utilisez les metriques `backtest_return` et `max_drawdown` du LifecycleManager\n- `# Étape 1` : Définir les seuils (return > 15%, drawdown < 20%)\n- `# Étape 2` : Ajouter les conditions dans la méthode de transition\n- `# Étape 3` : Logger le résultat de chaque condition"
+    "### Exercice 1.2 : Critères de transition personnalisés\n",
+    "\n",
+    "La transition paper → live ne se décide pas sur un seuil universel : une stratégie market-making tolère un tracking error minime mais pas une seconde de latence, une stratégie mensuelle de rotation supporte un mois rouge mais pas un turnover explosif. À vous de définir **vos** critères — ceux qui correspondent au profil de risque de la stratégie déployée.\n",
+    "\n",
+    "**Cahier des charges** : à partir du `LifecycleStateMachine` ci-dessus, écrivez un validateur qui n'autorise la transition `PAPER → LIVE` que si trois conditions indépendantes sont réunies (par exemple : nombre minimal de jours de paper, ratio Sharpe dans la bande, drawdown sous plafond). Le squelette est fourni — chaque condition manquante doit nommer **laquelle** échoue, pas seulement renvoyer `False`."
    ],
    "id": "cell-a58c0a99"
   },
@@ -706,7 +710,9 @@
    "id": "75a52b96",
    "metadata": {},
    "source": [
-    "On prépare ici le déploiement de l'algorithme en production en configurant les paramètres de live trading et les connexions aux courtiers."
+    "On prépare ici le déploiement de l'algorithme en production en configurant les paramètres du paper trading. Le paper trading n'est pas une formalité avant le live : c'est le **seul** test qui exécute la stratégie contre des données réelles qui n'existaient pas au moment de l'écriture — ni overfit possible, ni lookahead. La question qu'il tranche n'est pas « la stratégie est-elle rentable ? » (le backtest la déjà estimée) mais « **le code se comporte-t-il identiquement hors de son environnement de calibration ?** ». Les écarts typiques que seul le paper révèle : sliders de données manquants en live, ordres rejetés par la marge réelle, horloges de marché différentes, exception levée par un symbole non tradé ce jour-là.\n",
+    "\n",
+    "Le tracker ci-dessous simule ce suivi : il agrège jour après jour les métriques du paper trading (PnL, Sharpe glissant, drawdown) et les compare aux **bornes de référence du backtest**. La discipline est celle du ratio paper/backtest : un Sharpe qui s'effondre hors de sa bande de tolérance signale un backtest trop confiant, pas un mois de malchance."
    ]
   },
   {
@@ -924,7 +930,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercice 2.2 : Ratio Sharpe paper vs backtest\n\nCalculez le **ratio de Sharpe** entre le paper trading et le backtest. Un ratio proche de 1.0 indique une bonne coherence. Un ratio < 0.5 signale un problème de deploiement.\n\n**Indices** :\n- `# Indice` : Ratio = `paper_sharpe / backtest_sharpe`\n- `# Étape 1` : Extraire le Sharpe du paper trading\n- `# Étape 2` : Extraire le Sharpe du backtest\n- `# Étape 3` : Calculer le ratio et interpreter"
+    "### Exercice 2.2 : Ratio Sharpe paper vs backtest\n",
+    "\n",
+    "Le test de dégradation le plus standard du passage au réel : le Sharpe du paper trading devrait rester dans une **bande** autour du Sharpe du backtest. Un ratio trop bas signale un backtest trop confiant (fuite de données, coûts sous-estimés) ; un ratio *trop élevé* est tout aussi suspect — soit la fenêtre de paper est trop courte pour être significative, soit la chance a mal tourné dans le backtest.\n",
+    "\n",
+    "**Cahier des charges** : complétez la fonction qui calcule le ratio Sharpe(paper)/Sharpe(backtest) et le classifie — `ACCEPT` dans la bande [0.7, 1.3], `INVESTIGATE` en périphérie, `REJECT` au-delà. Attention au cas dégénéré : un Sharpe backtest proche de zéro rend le ratio instable, la classification doit le traiter explicitement plutôt que diviser par ~0."
    ],
    "id": "cell-e0e38754"
   },
@@ -1889,7 +1899,9 @@
    "id": "22f62f7a",
    "metadata": {},
    "source": [
-    "On met en place les mécanismes de surveillance et d'alertes pour superviser l'algorithme en conditions réelles de marché."
+    "On met en place les mécanismes de surveillance et d'alertes pour superviser l'algorithme déployé. En production, la stratégie vit sans son auteur : ce qui remplace la vigilance humaine, c'est un **système de monitoring gradué** — des métriques continues (exposition, turnover, erreur de tracking vs benchmark), des seuils d'alerte calibrés en deux niveaux (warning = investigation, critical = intervention immédiate), et un journal d'événements qui permet de reconstituer a posteriori *pourquoi* le système a pris une décision. La règle pratique : toute alerte doit être **actionnable** — une métrique surveillée sans seuil ni conséquence est de la décor, pas du contrôle.\n",
+    "\n",
+    "La démonstration ci-dessous exécute un cycle de monitoring complet sur des journées simulées : elle montre la graduation warning → critical quand les conditions se dégradent, et le retour au vert quand elles se rétablissent."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2026:CoursIA — prev: DEEP/notebook-lean #11798

See #11601 (tranche 4 du round 2 — contribution partielle à l'umbrella)

## Summary

Enrichissement markdown-only de `QC-Py-27-Production-Deployment.ipynb` : densité **1398 → 1576** c/cellule (cible round-2 : ≥1500). Aucune cellule code touchée — les outputs committés restent valides (exception C.2 markdown-only).

**Note de mesure** : le claim initial citait 1001/1200 — mesure prise sur un arbre partagé stale. Sur `origin/main` frais (72f32839a), la baseline réelle était **1398** (bande round-2 1200-2000). La tranche reste légitime (sous la cible 1500), la baseline est corrigée dans ce body.

## Ce qui a été enrichi

- **Intro section paper trading** (138ch → ~1200ch) : le paper trading comme seul test out-of-sample par construction (pas d'overfit possible, pas de lookahead), les écopes typiques que seul le paper révèle, le ratio paper/backtest comme discipline.
- **Intro section monitoring** (121ch → ~1000ch) : la graduation warning → critical, la règle « toute alerte doit être actionnable », le journal d'événements.
- **Exercice 1.2** : cahier des charges explicite (validateur de transition PAPER → LIVE à 3 conditions indépendantes, messages nommant la condition défaillante).
- **Exercice 2.2** : le test de dégradation Sharpe paper/backtest avec sa bande [0.7, 1.3], le cas dégénéré Sharpe backtest ≈ 0 (division instable à traiter explicitement).
- **Notice REFERENCE QC Cloud** : ce que la séparation local/cloud implique opérationnellement.

## Validation

| Gate | Résultat |
|---|---|
| `pedagogy_density.py --json` | density **1576** ≥ 1500 ✓ |
| `count_exercises.py` | conforming ≥3 ✓ (6 exercices : 1.1, 1.2, 2.1, 2.2, 3.1, 3.2) |
| `check_pr_exercises.py` | 0 below threshold ✓ |
| `check_interp_positioning.py` | 0 findings ✓ |
| Scope | 1 fichier, +18/-6 lignes JSON, markdown-only |

## Scope de l'umbrella

Tranches livrées : 1 (QC-Py-23b #11600), 2 (QC-Py-26 #11609), 3 (QC-Py-21 #11792). Cette tranche 4 = QC-Py-27. Vérifié sur main : QC-Py-19/SW-10/SW-12 sont déjà ≥1200 avec label OK (dans la bande mais non réclamés — pour un prochain cycle si pertinent).