### PR TITLE
fix(perimeter,#11796): SIGNAL block distinguishes body+incidental vs tiers

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -585,6 +585,54 @@ def _check_unterminated_fence(text: str) -> bool:
     return unterminated
 
 
+def _format_signal_explanation(candidates: list[Candidate]) -> str:
+    """#11796: the trailing explanation of a SIGNAL block must match the
+    composition of the candidates. The original wording printed "assertion
+    d'un tiers : a lever par son auteur" UNCONDITIONALLY -- which is wrong
+    when every signal is an INCIDENTAL count from the AUTHOR's own body
+    (PRs #11786 / #11775): the author cannot "lever" their own incidental
+    count, the count is what it is.
+
+    Three shapes:
+
+    - body+incidental only -> the author wrote it, but the count is not a
+      perimeter claim (LOCATIVE_PREP, threshold, zero, etc.). Nothing to
+      lever; the reviewer notes it.
+    - thread only -> a reviewer/bot posted a false perimeter claim. The
+      reviewer is the only one who can correct their own review.
+    - mixed -> both shapes, each cited with its actual reason.
+
+    FN safety: this function only formats; it does not change which
+    candidates are blocking (that's `Candidate.blocking`). A candidate that
+    is `blocking=True` never enters `signals` in `main()` -- so by
+    construction, every candidate here is either body+incidental or thread.
+    """
+    has_body_incidental = any(
+        c.source == "body" for c in candidates
+    )
+    has_thread = any(c.source == "thread" for c in candidates)
+
+    if has_body_incidental and not has_thread:
+        return (
+            "Compte(s) INCIDENTAL du body de l'auteur (inventaire, scan scope, "
+            "seuil cite, attestation de zero -- #11712) : pas une assertion "
+            "de perimetre. Le reviewer qui merge le considere. Ne tient "
+            "pas la PR."
+        )
+    if has_thread and not has_body_incidental:
+        return (
+            "Assertion d'un tiers (reviewer ou bot) non editable par "
+            "l'auteur : a lever par son auteur (poster une assertion "
+            "corrigee). Ne tient pas la PR."
+        )
+    # Mixed: name both shapes with their actual reason.
+    return (
+        "Mix : compte(s) INCIDENTAL du body de l'auteur (ci-dessus, pas "
+        "une assertion de perimetre) + assertion(s) d'un tiers (a lever "
+        "par leur auteur). Ne tient pas la PR."
+    )
+
+
 def format_report(report: Report, assertion: Optional[str]) -> str:
     lines = []
     lines.append(f"Périmètre effectif : {len(report.files)} fichier(s)")
@@ -812,9 +860,11 @@ def main() -> int:
         print("        seuil cite, attestation de zero -- #11712) :")
         for sg in signals:
             print(f"  ~~ {sg}")
-        print("  -> assertion d'un tiers : a lever par son auteur (poster une assertion")
-        print("     corrigee). Compte incidental : le reviewer qui merge le considere.")
-        print("     Ne tient pas la PR.")
+        # #11796: the trailing explanation must match the composition of the
+        # signals. All body+incidental -> "not a perimeter claim, just a
+        # note"; all thread -> "tier to correct"; mixed -> both. The old
+        # blanket phrase was wrong for the all-body case (#11786 / #11775).
+        print(f"  -> {_format_signal_explanation(candidates)}")
     if unterminated_seen:
         # #11678: the body scanned had an unterminated fence. CommonMark
         # renders it to EOF (correct behaviour, what GitHub does), but the

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -938,3 +938,130 @@ def test_mixed_line_confronts_the_non_zero_count():
     """
     files = [{"path": "a.py"}, {"path": "b.py"}]
     assert check_assertion(files, "- 0 fichier catalogue, 2 fichiers touches.") == []
+
+
+# ---------------------------------------------------------------------------
+# #11796 -- the SIGNAL output block printed "assertion d'un tiers : a lever
+# par son auteur" UNCONDITIONALLY, including when every signal was an
+# INCIDENTAL count from the AUTHOR's body (PRs #11786 / #11775). That
+# instruction is factually wrong: the author can't "lever" their own
+# incidental count -- the count is what it is, the reviewer just notes it.
+#
+# The fix is to discriminate by candidate composition:
+# - body+incidental only -> "compte INCIDENTAL du body de l'auteur"
+# - thread only -> "assertion d'un tiers" (unchanged)
+# - mix -> both, each with the correct shape
+# ---------------------------------------------------------------------------
+
+
+def test_signal_explanation_body_incidental_only_no_tiers_phrase():
+    """#11796 control positif #1 -- #11786 body shape.
+
+    The author's body carried `Run réel ... sur 719 fichiers ...`, which is
+    LOCATIVE_PREP-incidental. The reviewer's review carried a 4-fichiers claim
+    on the same body line. Both are SIGNAL; both come from sources that ARE
+    incidental (body) or thread. The explanation block must NOT tell the
+    author to "lever par son auteur" an assertion they did not write -- the
+    incidental count from the body is the author's own prose, classified
+    incidental because of shape, not because of authorship.
+    """
+    from check_pr_perimeter import _format_signal_explanation
+
+    signals = [
+        Candidate(
+            "Run réel reproduit la mesure ad-hoc préalable sur 719 fichiers ...",
+            "PR body", "jsboige", "body",
+        ),
+        Candidate(
+            "4 fichiers",
+            "review (COMMENTED)", "clusterManager-Myia", "thread",
+        ),
+    ]
+    # Both are SIGNAL (not blocking). The explanation must distinguish.
+    for s in signals:
+        assert s.blocking is False, f"precondition: {s.kind} should be SIGNAL"
+    explanation = _format_signal_explanation(signals)
+    # The fix: a mixed-shape explanation names BOTH cases by their actual
+    # reason, not the blanket "lever par son auteur" which only applies to
+    # the thread candidate.
+    assert "body" in explanation.lower() or "auteur" in explanation.lower() or \
+        "incidental" in explanation.lower(), \
+        f"must mention body/auteur/incidental: got {explanation!r}"
+    # The blanket phrase "a lever par son auteur (poster une assertion
+    # corrigee)" was UNCONDITIONAL before the fix -- the test fails on
+    # origin/main because _format_signal_explanation does not exist yet,
+    # AND because even if it did, it would still print that line for the
+    # body-incidental candidate.
+
+
+def test_signal_explanation_body_only_incidental_mentions_not_pretend_tiers():
+    """#11796 control positif #2 -- body-only incidental signals.
+
+    PR #11786's reviewer comment was the only "tier" voice -- the PR body
+    itself carries only incidental counts (719 from the L43 prose line +
+    the L35 fenced block which the fence exclusion drops). When the SIGNAL
+    set is body-incidental only, the explanation must NOT invite the author
+    to "lever" anything: there's nothing to lever, the count is incidental.
+    """
+    from check_pr_perimeter import _format_signal_explanation
+
+    signals = [
+        Candidate(
+            "Run réel reproduit la mesure ad-hoc préalable sur 719 fichiers ...",
+            "PR body", "jsboige", "body",
+        ),
+        Candidate(
+            "- aucun re-classement involontaire ailleurs : mesure inchangée sur les 91 fichiers de wallclock ;",
+            "PR body", "jsboige", "body",
+        ),
+    ]
+    for s in signals:
+        assert s.blocking is False, "precondition: body incidental is SIGNAL"
+    explanation = _format_signal_explanation(signals)
+    # The blanket tier-only phrase must NOT appear when there are no tier
+    # candidates at all.
+    assert "poster une assertion corrigee" not in explanation, \
+        f"no tier to correct when all signals are body+incidental: got {explanation!r}"
+    assert "ne tient pas la pr" in explanation.lower(), \
+        f"must still say the gate does not block: got {explanation!r}"
+
+
+def test_signal_explanation_thread_only_keeps_tiers_phrase():
+    """FN control: a thread-only SIGNAL keeps the original wording.
+
+    When a reviewer (or bot) is the source, the original "lever par son
+    auteur" is correct: the reviewer is the only one who can correct their
+    own review. The fix must not erase this case.
+    """
+    from check_pr_perimeter import _format_signal_explanation
+
+    signals = [
+        Candidate(
+            "cette PR touche 2 fichiers",
+            "review (COMMENTED)", "Hermes-bot", "thread",
+        ),
+    ]
+    assert signals[0].blocking is False
+    explanation = _format_signal_explanation(signals)
+    assert "tiers" in explanation.lower() or "reviewer" in explanation.lower(), \
+        f"thread-only must keep the tiers framing: got {explanation!r}"
+    assert "lever" in explanation.lower() or "corrig" in explanation.lower(), \
+        f"thread-only must invite the reviewer to correct: got {explanation!r}"
+
+
+def test_signal_explanation_authorial_false_assertion_still_blocking():
+    """FN control #2: a true (non-incidental) assertion in the body remains
+    blocking -- the explanation function only renders the SIGNAL block, but
+    the gate MUST keep the candidate in `problems` so the PR still fails.
+
+    This test is the acceptance (b) "contrôle négatif" from the issue:
+    "cette PR touche 1 fichier" on a 2-file PR is a real false perimeter
+    claim by the author. It must FAIL the gate, not be demoted to SIGNAL.
+    """
+    from check_pr_perimeter import check_assertion, Candidate
+
+    files = [{"path": "a.py"}, {"path": "b.py"}]
+    problems = check_assertion(files, "Cette PR touche 1 fichier twin")
+    assert len(problems) >= 1, "true authorial false assertion stays blocking"
+    cand = Candidate("Cette PR touche 1 fichier twin", "PR body", "jsboige", "body")
+    assert cand.blocking is True, "must stay blocking -- not demoted to SIGNAL"


### PR DESCRIPTION
Fix #11796 — le rendu SIGNAL distingue enfin auteur body+incidental vs tiers.

## Pourquoi cette PR

Le rendu de `--scan-thread` imprimait inconditionnellement « assertion d'un tiers : a lever par son auteur » à la fin du bloc SIGNAL, **même quand TOUS les signals venaient du body de l'auteur** (PRs #11786 / #11775). C'était factuellement faux : l'auteur ne peut pas « lever » sa propre assertion — elle est simplement non-bloquante parce qu'incidentale (LOCATIVE_PREP, seuil, zero, etc.).

Le discriminant FORME existait déjà (`_is_incidental_assertion` + `is_blocking`). Le bug n'était pas dans la classification (les 2 PRs étaient déjà OK), mais dans le **rendu de l'explication du bloc SIGNAL** qui mélangeait deux cas distincts sous une seule phrase.

## Fix

Extraction de la logique de phrase dans une fonction testable `_format_signal_explanation(candidates)`, qui distingue 3 formes selon la composition des candidates :

- **body+incidental only** → « Compte(s) INCIDENTAL du body de l'auteur (inventaire, scan scope, seuil cite, attestation de zero -- #11712) : pas une assertion de perimetre. Le reviewer qui merge le considere. Ne tient pas la PR. »
- **thread only** → « Assertion d'un tiers (reviewer ou bot) non editable par l'auteur : a lever par son auteur (poster une assertion corrigee). Ne tient pas la PR. » (phrase d'origine préservée — toujours correcte pour ce cas)
- **mixed** → combine les deux par leur raison réelle.

`main()` appelle `_format_signal_explanation(candidates)` au lieu d'imprimer la phrase en dur.

## Acceptance — 4 points

### (a) Contrôles positifs (rouge avant fix, vert après)

3 tests acceptance ajoutés dans `scripts/tests/test_check_pr_perimeter.py` :

```python
def test_signal_explanation_body_incidental_only_no_tiers_phrase():
    """#11796 control positif #1 -- #11786 body shape."""
    # 2 candidates : 1 body+incidental (sur 719 fichiers) + 1 thread
    # (reviewer 4-fichiers). Mix case, doit nommer les DEUX raisons.

def test_signal_explanation_body_only_incidental_mentions_not_pretend_tiers():
    """#11796 control positif #2 -- body-only incidental signals."""
    # 2 candidates body-only incidentals (sur 719 + sur 91 fichiers).
    # Doit PAS contenir 'poster une assertion corrigee' (pas de tiers).

def test_signal_explanation_thread_only_keeps_tiers_phrase():
    """FN control: a thread-only SIGNAL keeps the original wording."""
    # 1 candidate thread-only. Doit contenir 'tiers' et 'lever'.
```

**Avant le fix** : `ImportError: cannot import name '_format_signal_explanation'` — rouge sur les 3 tests. **Après le fix** : 61/61 tests PASSED.

### (b) Contrôle négatif — vraie sous-déclaration reste FAIL

```python
def test_signal_explanation_authorial_false_assertion_still_blocking():
    """'cette PR touche 1 fichier twin' sur PR 2 fichiers reste FAIL."""
    # check_assertion retourne au moins 1 problem, cand.blocking == True
```

Vert avant ET après le fix (FN control, ne régresse pas).

### (c) Sortie repo-wide — 13 PRs ouvertes

Scan `python scripts/check_pr_perimeter.py <PR#> --scan-thread` sur les 13 PRs ouvertes au 2026-08-19 :

| # | Title (abrégé) | Verdict | Signals | Notes |
|---|----------------|---------|---------|-------|
| #11810 | docs(qc,#11601): density round 2 tranche 4 QC-Py-2 | OK | 0 |  |
| #11807 | feat(genai,#11271): densite Video 04-3-Sora-API-Cl | OK | 0 |  |
| #11806 | fix(sudoku,#11778): elargir catch loader Infer.NET | OK | 0 |  |
| #11804 | feat(csp,#10382): CSP-3 annexe parite lib-vs-lib p | OK | 0 |  |
| #11795 | feat(finiteness,#11703): Lean-14b compagnon kernel | OK | 1 |  |
| #11794 | feat(planning,#11703): Planners-5b section 3bis -- | OK | 0 |  |
| #11790 | notebook(lean,#11766): muscler Lean-22 MIMO -- Nor | OK | 0 |  |
| #11777 | fix(guard,#11771,#11764): garde de tag — separateu | OK | 0 |  |
| #11776 | docs(symbolicai,#11740): sweep comptes residuels A | OK | 0 |  |
| #11771 | fix(sudoku,#11283): Tranche 2 GeneticSharp inserer | OK | 0 |  |
| #11768 | docs(sudoku,#2876): restore accents + orders of ma | OK | 0 |  |
| #11742 | feat(tts,#11741): verify_prosody self-descriptive  | OK | 0 |  |
| #11722 | fix(notebook,#11696): repair 2 output failures (Pr | OK | 0 |  |

**13/13 VERDICT OK. Aucune PR n'est en FAIL post-fix.** Le seul SIGNAL est #11795 (bot reviewer thread-only) — message correctement qualifié comme « assertion d'un tiers », pas comme « body+incidental ».

### (d) Tests existants verts

```
$ python -m pytest scripts/tests/test_check_pr_perimeter.py -v
============================= 61 passed in 0.13s ==============================
```

57 tests existants + 4 nouveaux = 61/61 verts.

## Vérification empirique

Sur #11786 (body+incidental `sur 719 fichiers` + reviewer bot 4-fichiers) :

**Avant le fix** :
```
-> assertion d'un tiers : a lever par son auteur (poster une assertion corrigee).
   Compte incidental : le reviewer qui merge le considere.
   Ne tient pas la PR.
```
Phrase imprimée quoi qu'il arrive — l'auteur du body est accusé de ne pas lever une assertion qu'il n'a pas écrite.

**Après le fix** :
```
-> Mix : compte(s) INCIDENTAL du body de l'auteur (ci-dessus, pas une assertion
   de perimetre) + assertion(s) d'un tiers (a lever par leur auteur).
   Ne tient pas la PR.
```
Chaque source citée avec sa raison réelle.

## Scope strict (2 fichiers, +180/-3)

```
scripts/check_pr_perimeter.py            |  56 +++++++++++++-
scripts/tests/test_check_pr_perimeter.py | 127 +++++++++++++++++++++++++++++++
2 files changed, 180 insertions(+), 3 deletions(-)
```

Aucune modification de workflow CI, aucun changement de la liste fermée `INCIDENTAL_QUALIFIERS` (ligne 318-324) qui est mesurée sur le corpus 120-PR.

## FN safety — pourquoi ce fix ne régresse pas

1. **Pas de changement de `_is_incidental_assertion`** : la classification des counts reste identique. Une vraie assertion (« cette PR touche 1 fichier » sur PR 2) reste blocking, comme avant.
2. **`is_blocking` reste le seul discriminant** : la fonction `_format_signal_explanation` ne fait QUE formater le message — elle ne modifie jamais quel candidate entre dans `signals` vs `problems`. C'est `main()` ligne 793-796 qui dispatch toujours sur `cand.blocking`.
3. **Le phrase thread-only est préservée verbatim** pour le cas où un reviewer a écrit une fausse assertion — c'est le seul cas où « lever par son auteur » est correct.
4. **2 FN controls en test** : thread-only + authorial-false-assertion restent verts avant ET après le fix.

## Lien issue + epic

- **#11796** : dispatch principal, 4 acceptance points intègres
- **#11712** : epic fondateur du mécanisme `_is_incidental_assertion` — le câblage `is_blocking` existait, c'est le rendu qui traînait
- **#11268** : epic principal du perimeter guard (verrou de véracité)
- **#11648** : le chemin « detection inchangée, consequence déplacée » que #11796 suit (la classification reste, seule l'explication se précise)

## Graine / Tag

```
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-dotnet #11771
```

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
