### PR TITLE
feat(genai,#11271): densite Video 04-1-Educational-Video-Generation 691 -> 1231 (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb
@@ -1846,7 +1846,6 @@
    "id": "96da6fbb",
    "metadata": {},
    "source": [
-    "---\n",
     "## Conclusion : ce que ce notebook etablit\n",
     "\n",
     "L'idee structurante : **une video educative est un artefact declare, pas compose a la main**. La Section 1 a montre que toute la timeline (7 slides, 40 s de contenu, 46 s avec transitions) derive d'une structure unique ; les Sections 2 a 4 ont transforme cette declaration en images (Pillow, 1280x720), en flux temporel (1380 frames avec fondus de 30 frames par jonction) et en rendu vivant (overlays sur chaque frame, 113 frames/s) ; la Section 5 a referme la boucle avec un export MP4 navigable -- marqueurs de chapitres horodates, chacun correspondant exactement a la slide declaree. Deuxieme lecon, technique : la **resilience par fallback** -- moviepy absent, le pipeline a bascule sur imageio sans interruption, et le bilan de session l'atteste. Ce pipeline local, deterministe et CPU-only, est le socle que les notebooks suivants complexifient : 04-2 y ajoute les workflows creatifs, 04-3 le replace face a l'API cloud Sora (et a son facteur cout par video), 04-4 l'industrialise.\n"

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb
@@ -101,7 +101,7 @@
     "tags": []
    },
    "source": [
-    "On importe ensuite toutes les bibliotheques du pipeline educatif : traitement d'images, generation video, synthese vocale et utilitaires de rendu textuel."
+    "On importe ensuite toutes les bibliotheques du pipeline educatif. `Pillow` (PIL) est le moteur de rendu des slides -- chaque diapositive devient une image PNG composee a la main (fond, titres, boites de texte) ; `numpy` structure les frames et les tableaux de parametres ; `imageio` assemble les frames en fichier video -- c'est elle qui servira de moteur d'encodage, la sortie de session le confirmera ; les utilitaires communs de la serie Video (importes via `sys.path` depuis le dossier parent) apportent les helpers de formatage et de sauvegarde. Ce notebook est volontairement **autosuffisant** : aucune API externe n'est requise, tout le pipeline (slides, transitions, overlays, export) s'execute en local sur CPU -- c'est le contrepoint pedagogique des notebooks cloud (04-3, 04-5, 04-6) de la meme serie.\n"
    ]
   },
   {
@@ -217,7 +217,7 @@
     "tags": []
    },
    "source": [
-    "Les variables d'environnement et les dependances sont ensuite verifiees : Pillow pour le rendu des slides, moviepy pour l'assemblage video, et OpenAI TTS pour la narration."
+    "Les variables d'environnement et les dependances sont ensuite verifiees. La sortie de cette execution montre les deux cas possibles du chargement : cote configuration, le `.env` a bien ete trouve et charge (ligne `.env charge depuis : ...` -- le chemin affiche depend de la machine d'execution) ; cote dependances, une nuance importante apparaît : `moviepy : NON INSTALLE` alors que `imageio : disponible`. Le pipeline ne s'arrete pas pour autant -- la cellule de statistiques de fin confirmera que l'encodage a ete porte par `imageio`, le fallback designe. C'est le pattern de resilience du depot : chaque etape verifie son outil primaire, et l'absence de l'un degrade proprement vers l'autre au lieu d'echouer.\n"
    ]
   },
   {
@@ -364,9 +364,7 @@
    "source": [
     "## Section 1 : Definition du contenu educatif\n",
     "\n",
-    "La première étape de la creation d'une video educative est la definition du contenu.\n",
-    "Chaque slide est défini par un titre, un corps de texte, et optionnellement des points cles.\n",
-    "Cette structure permet de generer automatiquement les visuels et le timing."
+    "La premiere etape de la creation d'une video educative n'est pas technique : c'est **editoriale**. Avant de produire une seule frame, le notebook definit le contenu du cours sous forme structuree -- une liste de slides, chacune avec son titre, son **type** (`title`, `content`, `diagram` -- le type gouverne le gabarit de rendu) et sa duree d'affichage. Cette structure est la source de verite unique du pipeline : la generation des images (Section 2), les transitions (Section 3) et les marqueurs de chapitres de l'export final (Section 5) derivent tous de ces declarations. Modifier le cours = modifier cette structure, jamais les etapes suivantes -- c'est le principe de separation contenu/presentation applique a la video.\n"
    ]
   },
   {
@@ -496,6 +494,16 @@
   },
   {
    "cell_type": "markdown",
+   "id": "84b410e4",
+   "metadata": {},
+   "source": [
+    "### Interpretation : la declaration structuree du cours\n",
+    "\n",
+    "La sortie affiche la structure declaree : **7 slides**, duree de contenu cumulee **40 s**, portee a **46.0 s** une fois les transitions ajoutees. La nomenclature des types apparait dans la structure du cours -- ouverture et fermeture en `title` (4 s chacune), quatre slides `content` (6 s), et la slide `diagram` sur l'architecture d'un reseau de neurones qui recoit la duree la plus longue (8 s) : le temps d'affichage suit la densite du contenu, un schema demande plus de lecture qu'un titre. Les 46.0 s annoncées ici sont la duree que l'export final mesurera exactement -- la declaration est bien la source de verite de toute la timeline.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-6",
    "metadata": {
     "papermill": {
@@ -510,9 +518,7 @@
    "source": [
     "## Section 2 : Generation des images de slides\n",
     "\n",
-    "Chaque slide est rendu sous forme d'image PNG avec Pillow.\n",
-    "Le rendu comprend un fond colore, le titre, les points cles et un pied de page.\n",
-    "Pour les slides de type \"diagram\", nous generons une visualisation spécifique."
+    "Chaque slide est rendu sous forme d'image PNG a partir de sa declaration structuree -- c'est le role de `Pillow` : composer un canvas 1280x720, poser le fond, placer le titre et le corps selon le **gabarit du type** de la slide (une slide `title` centre un grand texte, une slide `content` aligne des bullet points, une slide `diagram` reserve de l'espace au schema). La sortie affiche la progression slide par slide, et le tableau d'interpretation qui suit detaille les caracteristiques produites. Le rendu est deterministe : la meme structure produit les memes images, ce qui rend la video reproductible au pixel pres -- contrairement a une generation par modele.\n"
    ]
   },
   {
@@ -774,6 +780,16 @@
     "\n",
     "Les transitions entre slides rendent la video plus fluide et professionnelle.\n",
     "Nous implementons ici un fondu enchaine (cross-dissolve) entre chaque paire de slides consecutifs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "192d7df7",
+   "metadata": {},
+   "source": [
+    "## Section 3 : Transitions animees entre slides\n",
+    "\n",
+    "Une video n'est pas une suite d'images statiques : chaque enchainement de slides est rejoint par une **transition animee** (fondu). La cellule decompose chaque slide en frames statiques -- duree d'affichage x 30 fps -- puis ajoute des frames de transition entre elles. La sortie chiffre le cout : les slides de 4 s produisent 120 frames, celles de 6 s en produisent 180, la slide diagram 8 s en produit 240, et chaque jonction ajoute 30 frames de fondu -- soit **1380 frames assemblees** au total, pour une memoire estimee d'environ 3,6 GB si toutes les frames vivaient en RAM simultanement. C'est la premiere fois que le pipeline rencontre la contrainte de volume : la video est un artefact lourd, et chaque seconde de contenu coute 30 images a produire, transformer et encoder.\n"
    ]
   },
   {
@@ -1062,6 +1078,16 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "99de6b50",
+   "metadata": {},
+   "source": [
+    "## Section 4 : Overlays dynamiques\n",
+    "\n",
+    "Les slides statiques et leurs transitions forment la colonne vertebrale ; les **overlays dynamiques** habillent chaque frame d'elements en mouvement -- barre de progression, indicateur de chapitre, elements qui apparaissent au fil du temps. Contrairement aux slides (rendues une fois), les overlays s'appliquent **frame par frame** sur les 1380 frames assemblees : la sortie mesure ce traitement a 12.17 s, soit une cadence de 113 frames par seconde. C'est le poste de calcul le plus lourd du pipeline avant l'encodage, et le motif des optimisations classiques du genre (ne recomposer que la zone changeante, pre-calculer les calques statiques) que l'exercice suivant invite a explorer.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "cell-11",
@@ -1197,8 +1223,7 @@
    "source": [
     "## Section 5 : Assemblage et export de la video finale\n",
     "\n",
-    "Toutes les frames sont pretes. Nous les encodons maintenant en fichier MP4\n",
-    "avec imageio et le codec H.264. Un apercu visuel confirme le résultat."
+    "Toutes les frames sont pretes -- slides avec transitions et overlays. L'export les assemble en un fichier MP4 : resolution, framerate, duree, et surtout les **marqueurs de chapitres**, derives de la structure declarée en Section 1 -- chaque slide devient un chapitre horodate, ce qui rend la video navigable (table des matieres cliquable dans un lecteur compatible). C'est la derniere etape du pipeline, et celle qui produit l'artefact final partageable : le meme contenu, les memes images, la meme timeline -- reconstruisibles de bout en bout a partir de la declaration initiale.\n"
    ]
   },
   {
@@ -1431,7 +1456,7 @@
     "tags": []
    },
    "source": [
-    "Les statistiques de session enregistrent les temps de generation, les tailles de fichiers produits et le bilan de la session pour la tracabilite du pipeline educatif."
+    "Les statistiques de session ferment le notebook avec la traçabilite complete du pipeline : date et mode d'execution, nombre de slides, total de frames (1380), duree et resolution de la video produite, fichiers generes avec leurs tailles, et surtout le **bilan des dependances reellement utilisees** -- la sortie confirme ici que l'encodage a ete porte par `imageio` (moviepy etait absent, la resilience de la Section 0 a tenu son role) pendant que `diffusers` et `openai`, presents dans l'environnement, n'ont pas ete sollicites par ce pipeline local. Les prochaines etapes rappellees en fin de sortie pointent vers les notebooks suivants de la serie : workflows creatifs (04-2), generation cloud Sora (04-3) et pipeline de production (04-4).\n"
    ]
   },
   {
@@ -1731,7 +1756,7 @@
     "tags": []
    },
    "source": [
-    "Le générateur de visuels pedagogiques produit automatiquement des images adaptees a chaque type de contenu : diagrammes, schemas de flux, illustrations conceptuelles."
+    "Le generateur de visuels pedagogiques doit produire automatiquement des images adaptees a chaque type de contenu -- mais la lecture de la sortie doit etre honnete : la classe est un **squelette d'exercice**, les methodes sont marquees `TODO` et retournent des stubs. La logique a implementer est documentee dans la structure : un type de contenu (`definition`, `exemple`, `schema`, `comparaison`) doit declencher un gabarit de rendu distinct -- exactement ce que la Section 2 fait a la main avec `title`/`content`/`diagram`, mais pilote par une classification automatique du texte. L'exercice fait ainsi le pont entre le pipeline declare (ce notebook) et un pipeline *genere* -- ou le contenu brut devient video sans qu'aucune structure n'ait ete ecrite a la main.\n"
    ]
   },
   {
@@ -1814,6 +1839,17 @@
     "for c in concepts:\n",
     "    visual = generator.generate(c, c['type'])\n",
     "    # visual.save(f\"visual_{c['type']}.png\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96da6fbb",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "## Conclusion : ce que ce notebook etablit\n",
+    "\n",
+    "L'idee structurante : **une video educative est un artefact declare, pas compose a la main**. La Section 1 a montre que toute la timeline (7 slides, 40 s de contenu, 46 s avec transitions) derive d'une structure unique ; les Sections 2 a 4 ont transforme cette declaration en images (Pillow, 1280x720), en flux temporel (1380 frames avec fondus de 30 frames par jonction) et en rendu vivant (overlays sur chaque frame, 113 frames/s) ; la Section 5 a referme la boucle avec un export MP4 navigable -- marqueurs de chapitres horodates, chacun correspondant exactement a la slide declaree. Deuxieme lecon, technique : la **resilience par fallback** -- moviepy absent, le pipeline a bascule sur imageio sans interruption, et le bilan de session l'atteste. Ce pipeline local, deterministe et CPU-only, est le socle que les notebooks suivants complexifient : 04-2 y ajoute les workflows creatifs, 04-3 le replace face a l'API cloud Sora (et a son facteur cout par video), 04-4 l'industrialise.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2025:CoursIA-2 — prev: MED/genai #11807 (substance distincte : pipeline local déclaratif vs API cloud — notebook différent, contenu différent)

## Summary

2e tranche densité Video de l'EPIC #11271 : `GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb` — le plus déficitaire restant (densité **691**, mesuré frais sur `origin/main`). Après enrichissement : **densité 1231**, prose 8985 → 16007 caractères, 15 → 20 cellules markdown.

Markdown-only (+49/−13 lignes JSON, **0 cellule code modifiée, 0 `execution_count` changé** — exception C.3) :

| Geste | Détail |
|---|---|
| 7 cellules fines étoffées | imports (154→813), dépendances (172→713), intro Section 1 (300→774), Section 2 (265→714), Section 5 (201→637), stats session (166→743), générateur (166→765) |
| Headers **Sections 3 et 4 restitués** | les sections sautaient de 2 à 5 — transitions et overlays n'avaient pas de header (même classe de défaut que 04-3, corrigé dans #11807) |
| 1 interprétation neuve | la déclaration structurée du cours (Section 1) |

**Ancrages vérifiés firsthand** (chaque valeur citée lue dans l'output réel de la cellule précédente) :

- déclaration : 7 slides, contenu 40 s → 46.0 s avec transitions, types `title`/`content`/`diagram` avec durées 4/6/8 s ;
- transitions : 120/180/240 frames par slide (durée×30 fps), 30 frames par jonction, total **1380 frames**, mémoire ~3639 MB ;
- overlays : **12.17 s** sur 1380 frames, **113 frames/s** ;
- résilience : `moviepy : NON INSTALLE` → bilan de session atteste l'encodage par `imageio` (le fallback raconté est le vrai, vécu par cette exécution) ;
- export : 1280x720, 46.0 s, chapitres horodatés 0→46 s alignés sur les slides déclarées.

## Validation

1. `pedagogy_density.py` : **691 → 1231** (seuil 1200), `below_threshold: 0`.
2. `scan_cell_ordering.py` : **1 clean, 0 finding** (contrôle main : 0 finding également — aucune régression d'ordre introduite).
3. `validate_pr_notebooks.py` : **1/1 passed** (13 code cells, outputs intacts).
4. C.1 : 0 erreur volontaire. Catalogue byte-identique à main.

## Signalements hors-scope (non traités ici)

- Output cellule 5 : `.env charge depuis: D:\Dev\CoursIA-11112-sk2\...` — chemin machine committé, classe #10990 (correctif opportuniste au prochain re-exec, jamais scrub).
- « Exercice 3 » numéroté sans exercices 1/2 — incohérence héritée (déjà signalée sur 04-3), à arbitrer en grain séparé.

Veine #11271 pour ma lane : 2/2 (cap atteint) — le prochain grain passera par le picker.

See #11271 (tranche Video 04-1 ; 14 notebooks Video restent sous le plancher)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
