### PR TITLE
fix(symb,#9434): tranche SymbolicAI wallclock 19->1 — 6 classes FP scanner + drainage Z3-09

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SMT/Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb
@@ -103,7 +103,6 @@
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
-       
        "    function timeout(ms, promise) {\r\n",
        "        return new Promise(function (resolve, reject) {\r\n",
        "            setTimeout(function () {\r\n",
@@ -113,10 +112,7 @@
        "        })\r\n",
        "    }\r\n",
        "\r\n",
-       
-       
        "\r\n",
-       
        "\r\n",
        "            if (!rootUrl.endsWith('/')) {\r\n",
        "                rootUrl = `${rootUrl}/`;\r\n",
@@ -131,7 +127,6 @@
        "                    headers: {\r\n",
        "                        'Content-Type': 'text/plain'\r\n",
        "                    },\r\n",
-       
        "                }));\r\n",
        "\r\n",
        "                if (response.status == 200) {\r\n",
@@ -143,8 +138,6 @@
        "    }\r\n",
        "}\r\n",
        "\r\n",
-       
-       
        "        .then((root) => {\r\n",
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
@@ -193,13 +186,11 @@
        "    \r\n",
        "    \r\n",
        "    require_script.onload = function() {\r\n",
-       
        "    };\r\n",
        "\r\n",
        "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
        "}\r\n",
        "else {\r\n",
-       
        "}\r\n",
        "\r\n",
        "    </script>\r\n",
@@ -956,11 +947,7 @@
     "c.8252). Le pari #4616 se repose pour les bandes : l'expansion `MkIte` + `MkAdd` « tomberait-elle »\n",
     "elle aussi ? Sur une bande pondérée réelle (énergies du cache jusqu'à ~144 000 kJ), la réponse est plus\n",
     "tranchée que le 653x de la §3.4. La cellule mesure une **échelle** sur des sous-ensembles croissants de\n",
-    "candidats — même formule, bande recalculée sur chaque sous-ensemble : l'expansion passe de 0,29 s (200\n",
-    "candidats) à 8,7 s (1 600), puis **ne rend plus du tout** à l'échelle pleine (R = 3 717 : trois\n",
-    "exécutions interrompues au bout de 600 s en développement, et le *soft timeout* Z3 posé sur le solveur\n",
-    "n'arrive pas à interrompre la normalisation des grands coefficients). Le natif, lui, reste **plat** :\n",
-    "de 0,01 à 0,03 s à chaque échelon et 0,05 s à R plein. La propagation pseudo-booléenne de Z3 ne se perd pas dans\n",
+    "candidats — même formule, bande recalculée sur chaque sous-ensemble : l'expansion passe de l'ordre de la seconde dès quelques centaines de candidats à plusieurs secondes à 1 600, puis **ne rend plus du tout** à l'échelle pleine (R = 3 717 : interrompue en développement à la borne du protocole de bench, cf. la sortie de la cellule suivante — et le *soft timeout* Z3 posé sur le solveur n'arrive pas à interrompre la normalisation des grands coefficients). Le natif, lui, reste **plat** : des centisecondes à chaque échelon, jusqu'à l'échelle pleine. La propagation pseudo-booléenne de Z3 ne se perd pas dans\n",
     "l'expansion arithmétique — elle n'y entre jamais."
    ]
   },

--- a/scripts/notebook_tools/check_machine_dep_timing.py
+++ b/scripts/notebook_tools/check_machine_dep_timing.py
@@ -95,6 +95,41 @@ Acceptance (tranche GenAI/Audio #9434, 2026-08-19 -- 04-6/04-11/04-12)
       Sudoku-18 post-#11512 (0 wallclock attendu, toujours 0), 04-7
       post-#10707 (0 wallclock attendu, toujours 0).
 
+Acceptance (tranche SymbolicAI #9434, 2026-08-19 -- 19 wallclock -> 1)
+- [x] ``TIMEOUT_LIMIT_RE`` : timeout/limite de temps POSE sur le pipeline
+      (solveur, build, service) = constante de config, classe
+      ``domain_quantity``. 5 findings SymbolicAI (Planners-7 c16, Lean-13
+      c25, FD-Legacy c3/c14, RDF.Net c69) + 12 findings TN verifies
+      firsthand sur d'autres familles (la classe reparait une lacune
+      repo-wide : tout timeout de config etait flagge wallclock).
+- [x] ``STUDENT_PACING_RE`` etendu au pacing IMPERATIF (« prenez 5 minutes
+      pour lire », « (essayez 5 min) ») et a la borne ADVISORY cold-start
+      (« peut prendre 30 minutes a plusieurs heures », « Si ca prend plus
+      de 15 minutes, interrompez ») -- attente adressee a l'etudiant, pas
+      mesure. Le passe mesure « a pris plus de » ne matche pas.
+- [x] ``PROTOCOL_KEYWORDS`` etendu aux cadences d'INFRASTRUCTURE
+      (cadence/cron/periodicite) -- Lean-20 c7 « 30 min cadence » = periode
+      du cron du cluster, constante de config.
+- [x] Trois exemptions positionnelles : numero de section DECIMAL dans un
+      header (« ### 2.3 MIN (FIN) » = section sur l'axiome MIN de
+      Conway-Kochen, Lean-16f c9), conversion d'UNITE parenthetique d'une
+      constante primaire (« 500s (8.3 min) », FD-Legacy c9 -- la forme
+      entiere etait deja couverte par la parenthese pacing #10162),
+      traduction litterale d'un ``sleep()`` du code (« sleep(0.1) ... 100ms
+      », Argument_Analysis_UI c22 -- la valeur EST le code).
+- [x] Drainage prose reel (le seul) : Z3-Linq2Z3/09 c16 -- 5 epingles
+      numeriques dupliquant les sorties committes de la cellule de mesure
+      c17 (0,29 s / 8,7 s / 600 s / 0,01-0,03 s / 0,05 s) remplacees par
+      des descripteurs + renvoi aux sorties live ; le 600 s devient « la
+      borne du protocole de bench » (constante, cf. sortie).
+- [x] Controle de non-regression repo-wide : diff base->new sur 1033
+      notebooks = 25 findings neutralises (13 cibles + 12 timeouts TN
+      verifies ligne par ligne), 0 finding apparu. Sudoku-13-Python etait
+      deja a 0 sur la base (draine par une PR anterieure) -- le controle
+      positif vit dans les tests unitaires (Z3 25,2 s), tous verts.
+- [x] Lean-22 c7 (30 minutes) RESTE wallclock : hors perimetre de cette
+      tranche (rework actif po-2024, claim paths Sudoku-18).
+
 Note : `ambiguous=0` est structural (defaut conservateur = wallclock). Aucun
 finding ne reste ambigue apres la passe 1 -- le defaut de `_categorize`
 classe toute ligne sans mot-cle en wallclock. La categorie `ambiguous`
@@ -179,7 +214,12 @@ PROTOCOL_KEYWORDS = re.compile(
     r"\b(?:settle[\s\-_]?delay|settlement|temps\s+de\s+bloc|block[\s\-]?time|"
     r"blocs?(?:\s+(?:d['Ee]thereum|ethereum|de\s+bitcoin|bitcoin))?|"
     r"finalit[ée]|epoch|slot|confirmation|consensus|"
-    r"canal\s+de\s+paiement|payment\s+channel)\b",
+    r"canal\s+de\s+paiement|payment\s+channel|"
+    # Tranche SymbolicAI #9434 (2026-08-19) : cadence d'INFRASTRUCTURE
+    # (« Cluster CoursIA (4 workers, 30 min cadence) » -- Lean-20 c7).
+    # La duree est la periode du cron, constante de configuration du
+    # cluster, pas une mesure machine.
+    r"cadences?|crons?|p[ée]riodicit[ée]|intervalle\s+de\s+r[ée]veil)\b",
     re.IGNORECASE,
 )
 
@@ -223,6 +263,25 @@ PARAM_DURATION_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Constante de CONFIG d'execution : timeout / limite de temps POSE sur le
+# pipeline (solveur, build, service externe) -- le chiffre est un parametre
+# choisi par l'auteur (visible dans le code qui le pose), pas une mesure
+# machine. Mesure du 2026-08-19 sur la tranche SymbolicAI (#9434) : 5
+# findings wallclock sur 5 notebooks etaient exactement cette classe
+# (« Lancons le solveur CP-SAT avec un timeout de 30 secondes », « timeout
+# de 15 minutes » via wsl_papermill, « Un timeout de 30 minutes est
+# configure », « Le temps total est limite a 30 minutes », « Timeout =
+# 30000, // 30 secondes » dans un listing C# en markdown). Proximite 40
+# chars sans '.' ni '|' comme PARAM_DURATION_RE. NB : « limite a N » sans
+# mot temps/timeout reste volontairement ABSENT de cette classe -- la forme
+# « limitee a N requetes » est un quota de domaine, pas notre sujet ici.
+TIMEOUT_LIMIT_RE = re.compile(
+    r"\b(?:time[\s\-]?outs?|temps\s+total\s+(?:est\s+)?limit[ée]\s+(?:a|à)\b)"
+    r"[^.|]{0,40}?"
+    r"\d+(?:[.,]\d+)?\s*(?:ms|millisecondes?|sec(?:ondes?)?|min(?:utes?)?|s)\b",
+    re.IGNORECASE,
+)
+
 # Pacing pedagogique : la cellule H1/H2/H3 documente l'effort demande a
 # l'etudiant. Ligne entiere exoneree (cf. arbitrage jsboige 14:05:37Z #9434).
 # Le motif "**Notebook** : ... 30-60 min selon niveau" est aussi couvert --
@@ -251,7 +310,16 @@ STUDENT_PACING_RE = re.compile(
     # probabilite de domaine (P(trajet < 18 min)), PAS de pacing, et ne doit PAS
     # etre exemptee (cf. brainstorm G.1 : sur-exemption cassait la propagation
     # per-cell #10162 et flagait des wallclock reels « plus de 4 secondes »).
-    r"|\d+\s*(?:min(?:utes?)?|sec(?:ondes?)?|h(?:eures)?)\s*\(\s*(?:lecture|cours|travaux\s+pratiques|tp\b))",
+    r"|\d+\s*(?:min(?:utes?)?|sec(?:ondes?)?|h(?:eures)?)\s*\(\s*(?:lecture|cours|travaux\s+pratiques|tp\b)"
+    # Extensions tranche SymbolicAI (#9434, 2026-08-19) : pacing IMPERATIF
+    # adresse a l'etudiant (« prenez 5 minutes pour lire », « (essayez 5
+    # min) ») et borne ADVISORY de garde cold-start (« peut prendre 30
+    # minutes a plusieurs heures », « Si ca prend plus de 15 minutes,
+    # interrompez »). L'un et l'autre parlent de l'ATTENTE attendue de
+    # l'etudiant, pas d'une mesure d'execution ; la forme passe « a pris
+    # plus de N » (mesure) ne matche pas « prend plus de » (present).
+    r"|\b(?:essayez|prenez|accordez[\s\-]?vous|consacrez)\b[^.|\n]{0,30}?\d+(?:[.,]\d+)?\s*(?:min(?:utes?)?|sec(?:ondes?)?|s)\b"
+    r"|\b(?:peut\s+(?:prendre|durer)|prend\s+plus\s+de|prendre\s+plus\s+de)\b)",
     re.IGNORECASE,
 )
 
@@ -328,6 +396,60 @@ def _is_detached_approximate(line: str, match_start: int) -> bool:
     ))
 
 
+# --- Exemptions positionnelles tranche SymbolicAI (#9434, 2026-08-19) ----- #
+# Trois formes ou le match MACHINE_RE n'est PAS une duree mais un token
+# derive d'une constante : numero de section decimal, conversion d'unite
+# parenthetique, traduction litterale d'un sleep() du code.
+
+
+def _is_section_number(line: str, match_start: int, snippet: str) -> bool:
+    """Numero de section DECIMAL dans un header markdown.
+
+    « ### 2.3 MIN (FIN) -- l'independance des choix » (Lean-16f cell[9]) :
+    le match « 2.3 MIN » est le titre de la section 2.3 portant sur l'axiome
+    MIN de Conway-Kochen -- pas « 2,3 minutes ». Discriminant double : le
+    snippet COMMENCE par un decimal (une vraie duree s'ecrit « 2,3 min » ou
+    « 2 min 30 », jamais en position de titre) et un header markdown
+    (#..######) precede immediatement le match.
+    """
+    if not re.match(r"\d+[.,]\d+", snippet):
+        return False
+    lo = max(0, match_start - 8)
+    return bool(re.search(r"#{2,6}\s*$", line[lo:match_start]))
+
+
+def _is_unit_conversion(line: str, match_start: int) -> bool:
+    """Conversion D'UNITE entre parentheses d'une constante primaire.
+
+    « | Recherche | 500s (8.3 min) | 8000 MB | » (Fast-Downward-Legacy
+    cell[9]) : le match « 8.3 min » derive arithmetiquement de la borne de
+    config 500s posee par l'auteur de la table -- c'est la meme constante
+    convertie, pas une mesure machine. Discriminant : une valeur+unite de
+    temps ouvre la parenthese immediatement avant le match. (La forme
+    entiere « (5 min) » etait deja exoneree par la parenthese pacing
+    #10162 ; seul le decimal lui echappait.)
+    """
+    lo = max(0, match_start - 16)
+    return bool(re.search(
+        r"\d+(?:[.,]\d+)?\s*(?:ms|s|sec(?:ondes?)?)\s*\(\s*$", line[lo:match_start],
+        re.IGNORECASE,
+    ))
+
+
+def _is_code_constant_translation(line: str, match_start: int) -> bool:
+    """Traduction litterale d'une constante sleep() du code, meme ligne.
+
+    « `ui_events().poll(10)` avec `sleep(0.1)` = polling toutes les 100ms »
+    (Argument_Analysis_UI cell[22]) : le 100ms est la conversion affichee de
+    la constante `sleep(0.1)` visible dans la ligne -- il ne peut pas
+    deriver d'une machine a l'autre puisqu'il EST le code. Discriminant :
+    un appel sleep(N) apparait AVANT le match dans la meme ligne.
+    """
+    return bool(re.search(
+        r"\bsleep\s*\(\s*\d+(?:[.,]\d+)?\s*\)", line[:match_start],
+    ))
+
+
 # --------------------------------------------------------------------------- #
 #  Taxonomie de sortie
 # --------------------------------------------------------------------------- #
@@ -373,6 +495,10 @@ def _categorize(line: str, snippet: str) -> str:
     # Parametre de design d'un pipeline audio (silence/fade/pause/extrait...)
     # -- constante du code, pas une duree machine. Cf. PARAM_DURATION_RE.
     if PARAM_DURATION_RE.search(line):
+        return CATEGORY_DOMAIN_QUANTITY
+    # Constante de CONFIG d'execution (timeout/limite pose sur le pipeline)
+    # -- cf. TIMEOUT_LIMIT_RE. Parametre du code, pas une mesure machine.
+    if TIMEOUT_LIMIT_RE.search(line):
         return CATEGORY_DOMAIN_QUANTITY
     # Frontiere FP (frontier issue) : cout d'action dans une table de plan.
     # La duree est le RESULTAT d'une arithmetique « N + M = K unit » (ex
@@ -461,6 +587,15 @@ def _scan_notebook(nb_path: Path) -> list[dict]:
                 # Residu 2 #10169 : tilde DETACHE (`~ 2 min`, marqueur + espace).
                 # Ordre de grandeur, comme le tilde colle et la fourchette.
                 if _is_detached_approximate(line, m.start()):
+                    continue
+                # Tranche SymbolicAI #9434 : token derive d'une constante
+                # (numero de section decimal, conversion d'unite
+                # parenthetique, traduction d'un sleep() du code).
+                if _is_section_number(line, m.start(), snippet):
+                    continue
+                if _is_unit_conversion(line, m.start()):
+                    continue
+                if _is_code_constant_translation(line, m.start()):
                     continue
                 category = _categorize(line, snippet)
                 findings.append({

--- a/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
+++ b/scripts/notebook_tools/tests/test_check_machine_dep_timing.py
@@ -26,10 +26,14 @@ from check_machine_dep_timing import (  # noqa: E402
     _scan_notebook,
     _is_range_bound,
     _is_detached_approximate,
+    _is_section_number,
+    _is_unit_conversion,
+    _is_code_constant_translation,
     _repo_root,
     PROTOCOL_KEYWORDS,
     CONTENT_DURATION_CONSTRAINT_RE,
     DISTRIBUTION_KEYWORDS,
+    TIMEOUT_LIMIT_RE,
     CATEGORY_WALLCLOCK,
     CATEGORY_DISTRIBUTION,
     CATEGORY_AMBIGUOUS,
@@ -1090,3 +1094,120 @@ def test_collect_targets_all_with_paths_warns(tmp_path: Path, monkeypatch, capsy
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# --------------------------------------------------------------------------- #
+#  Tranche SymbolicAI #9434 (2026-08-19) : 6 classes FP nouvelles + frontieres
+# --------------------------------------------------------------------------- #
+
+
+def test_timeout_limit_re_real_instances() -> None:
+    """Timeout/limite de config POSE sur le pipeline = parametre, pas mesure.
+
+    Instances reelles (5 findings wallclock -> domain_quantity sur 5
+    notebooks SymbolicAI) : Planners-7 c16, Lean-13 c25, FD-Legacy c3/c14,
+    RDF.Net c69. Frontieres negaties : sans timeout/limite dans la ligne,
+    la duree reste un wallclock potentiel -- pas d'exemption silencieuse.
+    """
+    for line in [
+        "Lancons le solveur CP-SAT avec un timeout de 30 secondes et observons le makespan.",
+        "le build s'execute via wsl_papermill avec un timeout de 15 minutes.",
+        "Un timeout de 30 minutes est configure pour gerer les compilations longues.",
+        "Le temps total est limité à 30 minutes",
+        "Timeout = 30000,  // 30 secondes",
+        "Gestion des timeouts (3 000 ms par defaut -- parametre de configuration)",
+    ]:
+        assert TIMEOUT_LIMIT_RE.search(line), f"attendu parametre timeout : {line}"
+    assert not TIMEOUT_LIMIT_RE.search("Le run s'est termine en 30 secondes.")
+    assert not TIMEOUT_LIMIT_RE.search("Resolution du modele en 15 minutes.")
+
+
+def test_student_pacing_imperative_forms() -> None:
+    """Pacing IMPERATIF et borne ADVISORY cold-start = attente de l'etudiant.
+
+    Instances reelles : Lean-2 c45 « prenez 5 minutes pour lire », Lean-3
+    c53 « (essayez 5 min) », Lean-10 c27 « Si ca prend plus de 15 minutes,
+    interrompez », Lean-10 c54 « peut prendre 30 minutes a plusieurs
+    heures ». Frontiere : le PASSE mesure « a pris plus de » ne matche pas.
+    """
+    for line in [
+        "prenez 5 minutes pour lire ces solutions comme des exemples.",
+        "1. Ecrivez la preuve sans regarder l'exemple resolu (essayez 5 min).",
+        "Si ca prend plus de 15 minutes, interrompez le kernel et passez en mode SKIP.",
+        "Le premier tracing peut prendre 30 minutes a plusieurs heures.",
+    ]:
+        assert STUDENT_PACING_RE.search(line), f"attendu pacing : {line}"
+    assert not STUDENT_PACING_RE.search("Le premier tracing a pris plus de 30 minutes.")
+
+
+def test_protocol_keywords_infra_cadence() -> None:
+    """Cadence d'INFRASTRUCTURE (cron du cluster) = constante de config.
+
+    Instance reelle : Lean-20 c7 « Cluster CoursIA (4 workers, 30 min
+    cadence) ». La periode du cron ne derive pas de la machine.
+    """
+    assert PROTOCOL_KEYWORDS.search("Cluster CoursIA (4 workers, 30 min cadence)")
+    assert not PROTOCOL_KEYWORDS.search("Le build a pris 30 min.")
+
+
+def test_section_number_decimal_in_header() -> None:
+    """« ### 2.3 MIN (FIN) » = section 2.3 sur l'axiome MIN, pas 2,3 minutes.
+
+    Discriminant double : snippet decimal + header markdown immediat avant.
+    Frontiere : le MEME decimal hors header reste un wallclock potentiel.
+    """
+    line = "### 2.3 MIN (FIN) -- l'independance des choix"
+    assert _is_section_number(line, line.index("2.3 MIN"), "2.3 MIN")
+    assert not _is_section_number("Le build a dure 2.3 MIN", 16, "2.3 MIN")
+    assert not _is_section_number("### 30 min de build", 4, "30 min")
+
+
+def test_unit_conversion_parenthetical() -> None:
+    """« 500s (8.3 min) » = conversion de la constante primaire, pas mesure.
+
+    Instance reelle : Fast-Downward-Legacy c9 (bornes de config du solveur).
+    La forme entiere « (5 min) » etait deja couverte par la parenthese
+    pacing #10162 ; seul le decimal lui echappait.
+    """
+    line = "| Recherche | 500s (8.3 min) | 8000 MB |"
+    assert _is_unit_conversion(line, line.index("8.3 min"))
+    assert not _is_unit_conversion("mesure finale (8.3 min d'ecart au chrono)", 14)
+    assert not _is_unit_conversion("La resolution a pris 8.3 min au total.", 0)
+
+
+def test_code_constant_translation_sleep() -> None:
+    """« sleep(0.1) ... 100ms » = traduction de la constante du code.
+
+    Instance reelle : Argument_Analysis_UI c22. La valeur ne peut pas
+    deriver d'une machine : elle EST le code affiche dans la ligne.
+    """
+    line = "- **Blocage** : `ui_events().poll(10)` avec `sleep(0.1)` = polling toutes les 100ms"
+    assert _is_code_constant_translation(line, line.index("100ms"))
+    assert not _is_code_constant_translation("Le polling prend 100ms par cycle.", 0)
+
+
+def test_symbolicai_fp_pipeline_end_to_end() -> None:
+    """Pipeline complet : les lignes FP SymbolicAI ne produisent AUCUN
+    finding wallclock, et un wallclock strict voisin reste detecte.
+
+    Contrôle du branchement (pas seulement des helpers isoles) : chaque
+    ligne ci-dessous etait un finding wallclock reel avant la tranche.
+    """
+    nb = _make_nb([
+        _md_cell("Lancons le solveur CP-SAT avec un timeout de 30 secondes."),
+        _md_cell("Si ca prend plus de 15 minutes, interrompez le kernel."),
+        _md_cell("### 2.3 MIN (FIN) -- l'independance des choix"),
+        _md_cell("| Recherche | 500s (8.3 min) | 8000 MB |"),
+        _md_cell(
+            "La duree d'execution est 2.4 s pour 1000 iterations."
+        ),
+    ])
+    try:
+        findings = _scan_notebook(nb)
+        wallclock = [f for f in findings if f["category"] == CATEGORY_WALLCLOCK]
+        snippets = [f["snippet"] for f in wallclock]
+        assert snippets == ["2.4 s"], (
+            f"attendu uniquement le wallclock strict, trouve : {snippets}"
+        )
+    finally:
+        nb.unlink()


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-python #11797

Tranche **SymbolicAI** de #9434 : jauge wallclock famille **19 → 1** (le 1 restant = Lean-22 c7, hors périmètre — rework actif po-2024). Même forme que la tranche Audio #11775 : classes FP documentées au scanner + **1 seul drainage prose réel**.

> **Rebasée** sur `origin/main` post-merge de #11775 (commit 8d2b1f494) — plus de dépendance de stack. Les exemptions Audio #11775 sont dans la base ; les 6 classes SymbolicAI s'ajoutent par-dessus. Tests 55/55 re-vérifiés post-rebase.

## Livrable (3 fichiers)

**1. Drainage réel — `Z3-Linq2Z3/09_Meal_Planner_Convergence_Scale.ipynb` cell[16]** (markdown-only, aucune cellule code touchée) : les 5 épingles numériques de l'intro §3.5 (« 0,29 s (200 candidats) à 8,7 s (1 600) », « 600 s », « 0,01 à 0,03 s », « 0,05 s ») **dupliquaient les sorties committées de la cellule de mesure c17** (`n=200 ... 0,29s`, `n=1600 ... 8,68s`, `Echelle pleine ... 0,05s ; pas de reponse sous 600 s`). Cas canonique #9434 : au prochain passage kernel sur une autre machine la prose contredirait la sortie. Remplacées par des descripteurs (« de l'ordre de la seconde », « plusieurs secondes », « des centisecondes ») + renvoi explicite « cf. la sortie de la cellule suivante ». Le 600 s devient « la borne du protocole de bench » (constante du protocole, valeur live dans la sortie). Les valeurs pédagogiques restent toutes dans la sortie committée c17.

**2. Scanner — 6 classes FP** (`check_machine_dep_timing.py`) :

| Classe | Instances réelles | Mécanisme |
|---|---|---|
| `TIMEOUT_LIMIT_RE` | Planners-7 c16 « timeout de 30 secondes », Lean-13 c25, FD-Legacy c3/c14, RDF.Net c69 « Timeout = 30000, // 30 secondes » | timeout/limite POSE sur le pipeline = constante de config → `domain_quantity` |
| Pacing **impératif** | Lean-2 c45 « prenez 5 minutes », Lean-3 c53 « (essayez 5 min) » | extension `STUDENT_PACING_RE` |
| Pacing **advisory** cold-start | Lean-10 c27 « Si ca prend plus de 15 minutes, interrompez », c54 « peut prendre 30 minutes a plusieurs heures » | idem ; le passé mesure « a pris plus de » ne matche pas |
| Cadence d'infra | Lean-20 c7 « Cluster CoursIA (4 workers, 30 min cadence) » | extension `PROTOCOL_KEYWORDS` (cadence/cron/périodicité) |
| Section décimale dans header | Lean-16f c9 « ### 2.3 MIN (FIN) » = section 2.3 sur l'axiome MIN de Conway-Kochen, pas 2,3 minutes | exemption positionnelle (décimal + `###` avant) |
| Conversion d'unité / traduction de code | FD-Legacy c9 « 500s (8.3 min) », AA-UI c22 « sleep(0.1) … 100ms » | exemptions positionnelles (la valeur dérive d'une constante, pas d'une machine) |

**3. Tests — 7 nouveaux** (`test_check_machine_dep_timing.py`) : chaque classe avec instances réelles **+ frontières négatives** (« a pris plus de », « s'est terminé en », décimal hors header, sans `sleep()`), + un test end-to-end du pipeline (les 5 lignes FP → 0 finding, le wallclock strict voisin → détecté). **55/55 passed**.

## Preuves d'exécution

- Jauge famille : `check_machine_dep_timing.py MyIA.AI.Notebooks/SymbolicAI` → `scanned=237 wallclock=1` (reste : Lean-22 c7 uniquement, claim po-2024) ;
- **Non-régression repo-wide** (G.1) : diff base→new sur 1033 notebooks = **25 findings neutralisés, 0 apparu**. Les 12 hors SymbolicAI attrapés par `TIMEOUT_LIMIT_RE` ont été **vérifiés ligne par ligne firsthand** — tous des timeouts de config (ex : Sudoku-0-Csharp c10 « 3 000 ms par défaut — paramètre de configuration du solveur », 02-5 c11 « timeout de 10 secondes », ComfyUI-Video c15 « Timeouts (5 min max) ») : la classe réparait une lacune repo-wide réelle ;
- Contrôles positifs : tests unitaires 55/55 (le Z3 strict « 25,2 s » reste détecté) ; Sudoku-18 = 0 attendu = 0 ; Sudoku-13-Python était **déjà** à 0 sur la base (drainé par une PR antérieure — le contrôle positif vit dans les tests, pas le notebook) ;
- `pytest scripts/notebook_tools/tests/test_check_machine_dep_timing.py` → `55 passed in 44s` ;
- Notebook : markdown-only → pas de re-exec requise (C.3) ; 0 violation C.1 ; 0 parasite CJK ; nbformat validate OK ; pre-commit H.3 Passed.

## Diagnostic dérive

La prose c16 dupliquait des valeurs mesurées **présentes dans les sorties committées** de c17 (classe (a)-canonique #9434 : re-pin qui contredit la sortie au prochain passage kernel). Verdict : **CAUSE_FIXED** — drainage vers descripteurs + renvoi aux sorties live, aucune valeur ré-alignée à la main.

## Verdict SOTA

N/A — pas de moteur impliqué (prose + scanner).

See #9434 (tranche SymbolicAI ; Audio/#11775 et SymbolicAI/this = même veine scanner, le résidu famille est Lean-22 seul).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
