### PR TITLE
perf(ci,#11782): gate comment-path adjacency job on [G-VAR-3 OVERRIDE] marker

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -913,10 +913,21 @@ jobs:
   # Les commentaires d'ISSUE (hors PR) sont filtres au niveau du job.
   check-variation-adjacency-comment:
     name: 'Require genre diversity vs prev: (block on LIGHT adjacency, #11170)'
+    # #11782 : garde d'entree sur la presence du marqueur. Un if: de job est
+    # evalue SANS allouer de runner -- un commentaire sans [G-VAR-3 OVERRIDE]
+    # ne coute rien du tout. Sans lui, chaque commentaire de PR (steer, ACK,
+    # review, reponse) relance ce job pour ne rien decider : un fil de 10
+    # messages valait autant de runs qu'une refonte du code. Le marqueur est
+    # le seul objet que ce job sait evaluer (#11718), tout le reste est du
+    # passage a vide. NB : combine en ET a la condition existante -- la forme
+    # `event_name != 'issue_comment' || contains(...)` censee dans l'issue
+    # laisserait AUSSI entrer les evenements pull_request dans ce job chemin-
+    # commentaire (doublon du job pull_request, acceptance 3 de #11782).
     if: >-
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request &&
-      github.event.comment.user.login != 'github-actions[bot]'
+      github.event.comment.user.login != 'github-actions[bot]' &&
+      contains(github.event.comment.body, '[G-VAR-3 OVERRIDE]')
     runs-on: ubuntu-latest
     permissions:
       # Job-level permissions REMPLACENT (ne fusionnent pas) celles du

--- a/scripts/tests/test_variation_tag_comment_trigger.py
+++ b/scripts/tests/test_variation_tag_comment_trigger.py
@@ -18,6 +18,9 @@ wiring cannot silently regress:
   4. the check-run it posts carries the SAME name as the pull_request job
      so the aggregator (pr_gate) sees the fresh verdict supersede the stale
      one on the PR head.
+  5. an entry guard keeps the job off comments that carry no
+     [G-VAR-3 OVERRIDE] marker (#11782) -- a comment without the marker is
+     information-free for this gate and must cost zero runner time.
 
 Run:
     python -m pytest scripts/tests/test_variation_tag_comment_trigger.py
@@ -116,4 +119,28 @@ def test_comment_job_checks_out_default_branch_code():
     checkout = [s for s in wf["jobs"][COMMENT_JOB]["steps"] if "checkout" in str(s.get("uses", ""))][0]
     assert "ref" not in checkout.get("with", {}), (
         "le checkout du chemin commentaire ne doit PAS pin de ref : il execute le gate de la branche par defaut (diagnostic #11718)"
+    )
+
+
+def test_comment_job_entry_guard_requires_override_marker():
+    """#11782 : le job ne doit tourner QUE sur les commentaires portant le
+    marqueur -- un if: de job est evalue sans allouer de runner, donc un
+    commentaire sans [G-VAR-3 OVERRIDE] ne coute rien. Sans ce garde, chaque
+    commentaire de PR (steer, ACK, review, reponse) relance le job pour ne
+    rien decider : le guard ne lit les commentaires QUE pour le marqueur
+    (variation_adjacency_guard.parse_override), tout le reste est du passage
+    a vide.
+
+    Le garde doit rester COMBINE en ET a `github.event_name == 'issue_comment'`
+    : la forme `event_name != 'issue_comment' || contains(...)` (esquissee
+    dans l'issue) laisserait aussi entrer les evenements pull_request dans ce
+    job chemin-commentaire -- doublon du job pull_request (acceptance 3).
+    """
+    wf = _load()
+    cond = str(wf["jobs"][COMMENT_JOB].get("if", ""))
+    assert "github.event_name == 'issue_comment'" in cond, (
+        "le garde marqueur ne doit pas remplacer la restriction issue_comment (acceptance 3 de #11782)"
+    )
+    assert "contains(github.event.comment.body, '[G-VAR-3 OVERRIDE]')" in cond, (
+        "garde d'entree absent : tout commentaire de PR relance le job (#11782 -- 11 runs/edition mesures sur #11405)"
     )


### PR DESCRIPTION
## Summary

`check-variation-adjacency-comment` (ajoute par #11764) tournait sur **tout** `issue_comment` de PR (created + edited) : steer coordinateur, ACK worker, review Hermes, simple reponse -- chaque commentaire coutait un runner. Or le garde sous-jacent (`variation_adjacency_guard.parse_override`, scripts/ci/variation_adjacency_guard.py:110) ne lit les commentaires **que** pour y chercher `[G-VAR-3 OVERRIDE]` : un commentaire sans marqueur n'apporte aucune information a ce gate, c'est du passage a vide pur.

Le garde d'entree propose par #11782 est applique : un `if:` de job est evalue **sans allouer de runner**, un commentaire sans marqueur ne coute plus rien du tout.

## Implementation

Condition `contains(github.event.comment.body, '[G-VAR-3 OVERRIDE]')` **combinee en ET** a la condition existante. La forme esquissee dans l'issue (`github.event_name != 'issue_comment' || contains(...)`) n'a PAS ete reprise telle quelle : elle admettrait aussi les evenements `pull_request` dans ce job chemin-commentaire (doublon du job `check-variation-adjacency-required`, regression de l'acceptance 3). Le `if:` final garde donc `github.event_name == 'issue_comment' && ... && contains(...)`.

## Acceptance (#11782)

| # | Critere | Statut |
|---|---------|--------|
| 1 | Contrôle positif : commentaire AVEC marqueur declenche toujours le job | **pre-merge** : garanti par la condition ET (le marqueur est le seul facteur ajoute) ; **post-merge** : a verifier par un commentaire marque sur une PR reelle (au cycle suivant le merge) |
| 2 | Contrôle negatif : commentaire sans marqueur = aucun run, compte sur une PR reelle | **AVANT (mesure sur #11810, main sans garde)** : commentaire sans marqueur (5345525804, 17:13Z) -> run issue_comment 32280351952 cree, job chemin-commentaire 96157405570 **started puis cancelled** (runner alloue, coupe par supersession concurrency ~3 min plus tard), les 6 autres jobs skipped -- cout reel consomme pour zero information ; **APRES (post-merge)** : meme commentaire -> job chemin-commentaire attendu `skipped` comme les 6 autres (aucun runner), verification a poster sur #11782 |
| 3 | Filtre limite a `issue_comment` ; `pull_request` inchange | Passe par le test 7 : le `if:` doit TOUJOURS contenir `github.event_name == 'issue_comment'` (ET, pas OU) |
| 4 | 6 tests wiring verts + 7e pinant le garde | `7 passed in 0.22s` (test_variation_tag_comment_trigger.py) |

Correction d'honnetete : la premiere version de ce body annoncait un « 3e check-run apparu (id 96269798763) » -- chiffre extrapole avant lecture de la mesure reelle, AUCUN check-run n'a ete poste (le job a ete cancelled avant). Les faits ci-dessus sont relus depuis l'API (`gh api .../runs/32280351952/jobs`).

Preuve exec tests :

```
scripts/tests/test_variation_tag_comment_trigger.py::test_issue_comment_is_a_trigger_with_created_and_edited PASSED [ 14%]
scripts/tests/test_variation_tag_comment_trigger.py::test_comment_job_exists_and_filters_to_prs_and_bots PASSED [ 42%]
scripts/tests/test_variation_tag_comment_trigger.py::test_comment_job_resolves_head_sha_and_posts_check_run_on_it PASSED [ 57%]
scripts/tests/test_variation_tag_comment_trigger.py::test_comment_job_check_run_name_matches_pull_request_job PASSED [ 71%]
scripts/tests/test_variation_tag_comment_trigger.py::test_comment_job_checks_out_default_branch_code PASSED [ 85%]
scripts/tests/test_variation_tag_comment_trigger.py::test_comment_job_entry_guard_requires_override_marker PASSED [100%]
============================== 7 passed in 0.22s ==============================
```

## Note anti-regression G-VAR-3 (#11718)

Le chemin override reste intact : le marqueur est TOUJOURS ce qui declenche, et `edited` reste dans les types de trigger -- corriger un marqueur mal forme relance le gate. Le seul cas retire : un evenement d'edition qui RETIRE le marqueur d'un commentaire (le body courant n'a plus le marqueur -> pas de run). Ce cas etait deja non-couvert par le chemin pull_request (une edition de commentaire n'y declenche rien non plus) et le prochain push de la PR rejoue le gate sans l'override : pas de regression par rapport a la proposition de l'issue, qui a exactement la meme propriete (`contains` sur le body COURANT).

Closes #11782

Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: MED/notebook-python #11810