### PR TITLE
fix(genai,#11747): fixture editor password to VALMONT_EDITOR_PASSWORD, no literal default (2 notebooks re-executed)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/autour-du-consent-oauth-du-serveur-mcp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/autour-du-consent-oauth-du-serveur-mcp.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "c17c8f01",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007852,
+     "end_time": "2026-08-19T17:28:28.176890+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:28.169038+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# Le serveur MCP et son autorisation — OAuth de bout en bout\n",
     "\n",
@@ -27,7 +36,16 @@
   {
    "cell_type": "markdown",
    "id": "f1f4a120",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006597,
+     "end_time": "2026-08-19T17:28:28.192770+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:28.186173+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## La serie « AI Engine par son API »\n",
     "\n",
@@ -57,7 +75,16 @@
   {
    "cell_type": "markdown",
    "id": "68efce1b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.021828,
+     "end_time": "2026-08-19T17:28:28.221847+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:28.200019+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Prerequis\n",
     "\n",
@@ -81,11 +108,19 @@
    "id": "14374c12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:31.840935Z",
-     "iopub.status.busy": "2026-08-18T13:23:31.840416Z",
-     "iopub.status.idle": "2026-08-18T13:23:31.979770Z",
-     "shell.execute_reply": "2026-08-18T13:23:31.979770Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:28.252587Z",
+     "iopub.status.busy": "2026-08-19T17:28:28.252036Z",
+     "iopub.status.idle": "2026-08-19T17:28:29.987161Z",
+     "shell.execute_reply": "2026-08-19T17:28:29.984943Z"
+    },
+    "papermill": {
+     "duration": 1.75778,
+     "end_time": "2026-08-19T17:28:29.989126+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:28.231346+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -123,6 +158,7 @@
     "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
     "ADMIN_USER = os.getenv(\"VALMONT_ADMIN_USER\", \"\")\n",
     "APP_PASSWORD = os.getenv(\"VALMONT_APP_PASSWORD\", \"\")\n",
+    "EDITEUR_MDP = os.getenv(\"VALMONT_EDITOR_PASSWORD\")  # fixture consent.editor, posee plus bas\n",
     "print(\"Base URL :\", BASE_URL)\n",
     "\n",
     "creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
@@ -172,7 +208,16 @@
   {
    "cell_type": "markdown",
    "id": "5cf9ed15",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00733,
+     "end_time": "2026-08-19T17:28:30.003823+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:29.996493+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. La carte : deux documents de decouverte\n",
     "\n",
@@ -195,11 +240,19 @@
    "id": "44315eeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:31.983648Z",
-     "iopub.status.busy": "2026-08-18T13:23:31.981614Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.062212Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.061707Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:30.033366Z",
+     "iopub.status.busy": "2026-08-19T17:28:30.032755Z",
+     "iopub.status.idle": "2026-08-19T17:28:30.385621Z",
+     "shell.execute_reply": "2026-08-19T17:28:30.384373Z"
+    },
+    "papermill": {
+     "duration": 0.375854,
+     "end_time": "2026-08-19T17:28:30.386819+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:30.010965+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -246,7 +299,16 @@
   {
    "cell_type": "markdown",
    "id": "e800e05d",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007481,
+     "end_time": "2026-08-19T17:28:30.403034+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:30.395553+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Le plugin est **son propre serveur d'autorisation** : la ressource\n",
     "protegee (le endpoint MCP) et le serveur qui delivre les jetons vivent\n",
@@ -268,18 +330,26 @@
    "id": "d3710f0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.065725Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.065725Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.117723Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.117200Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:30.420247Z",
+     "iopub.status.busy": "2026-08-19T17:28:30.419713Z",
+     "iopub.status.idle": "2026-08-19T17:28:30.676595Z",
+     "shell.execute_reply": "2026-08-19T17:28:30.675166Z"
+    },
+    "papermill": {
+     "duration": 0.267482,
+     "end_time": "2026-08-19T17:28:30.677886+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:30.410404+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "client_id        : 89c5d8ef736655...\n",
+      "client_id        : 075f66323b8178...\n",
       "client_name      : Notebook CoursIA\n",
       "redirect_uris    : ['http://localhost:8888/callback']\n",
       "grant_types      : ['authorization_code', 'refresh_token']\n",
@@ -306,7 +376,16 @@
   {
    "cell_type": "markdown",
    "id": "960eced8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007969,
+     "end_time": "2026-08-19T17:28:30.693735+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:30.685766+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Le serveur a emis un `client_id` **sans demander qui nous etions** — et\n",
     "la reponse porte `token_endpoint_auth_method: none` : c'est un client\n",
@@ -328,11 +407,19 @@
    "id": "d3c3fe09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.121755Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.120249Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.160259Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.160259Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:30.736611Z",
+     "iopub.status.busy": "2026-08-19T17:28:30.736084Z",
+     "iopub.status.idle": "2026-08-19T17:28:30.975694Z",
+     "shell.execute_reply": "2026-08-19T17:28:30.974266Z"
+    },
+    "papermill": {
+     "duration": 0.27478,
+     "end_time": "2026-08-19T17:28:30.977006+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:30.702226+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -356,7 +443,16 @@
   {
    "cell_type": "markdown",
    "id": "17fc0d91",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007716,
+     "end_time": "2026-08-19T17:28:30.992085+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:30.984369+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**PKCE est exige** (RFC 7636) : la demande doit embarquer un\n",
     "`code_challenge`, et l'echange de jeton devra presenter le\n",
@@ -388,18 +484,26 @@
    "id": "62b2bc9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.163743Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.163743Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.286516Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.285901Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:31.020497Z",
+     "iopub.status.busy": "2026-08-19T17:28:31.019887Z",
+     "iopub.status.idle": "2026-08-19T17:28:32.553774Z",
+     "shell.execute_reply": "2026-08-19T17:28:32.552290Z"
+    },
+    "papermill": {
+     "duration": 1.554213,
+     "end_time": "2026-08-19T17:28:32.555060+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:31.000847+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "utilisateur existant : 4\n"
+      "creation : 201\n"
      ]
     },
     {
@@ -419,20 +523,29 @@
     "    print(\"utilisateur existant :\", existant[0][\"id\"])\n",
     "else:\n",
     "    r = requests.post(BASE_URL + \"/wp-json/wp/v2/users\", headers=ENTETES,\n",
-    "                      json={\"username\": \"consent.editor\", \"password\": \"Consent-Editor-2026!\",\n",
+    "                      json={\"username\": \"consent.editor\", \"password\": EDITEUR_MDP,\n",
     "                            \"email\": \"consent.editor@example.test\",\n",
     "                            \"name\": \"consent.editor\", \"roles\": [\"editor\"]}, timeout=60)\n",
     "    print(\"creation :\", r.status_code)\n",
     "\n",
     "session_editor = requests.Session()\n",
-    "ok = login_wordpress(session_editor, \"consent.editor\", \"Consent-Editor-2026!\")\n",
+    "ok = login_wordpress(session_editor, \"consent.editor\", EDITEUR_MDP)\n",
     "print(\"login editor :\", \"OK (302)\" if ok else \"ECHEC\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "interp-editor-fixture",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008252,
+     "end_time": "2026-08-19T17:28:32.571443+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:32.563191+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Pourquoi un editor, et pourquoi il est cree ici\n",
     "\n",
@@ -462,11 +575,19 @@
    "id": "a8dbf224",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.290046Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.288534Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.326152Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.326152Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:32.619492Z",
+     "iopub.status.busy": "2026-08-19T17:28:32.618876Z",
+     "iopub.status.idle": "2026-08-19T17:28:32.886574Z",
+     "shell.execute_reply": "2026-08-19T17:28:32.885311Z"
+    },
+    "papermill": {
+     "duration": 0.308753,
+     "end_time": "2026-08-19T17:28:32.888012+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:32.579259+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -494,7 +615,16 @@
   {
    "cell_type": "markdown",
    "id": "40b7c8b4",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010336,
+     "end_time": "2026-08-19T17:28:32.907100+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:32.896764+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Seuls les administrateurs peuvent autoriser.** Le consentement MCP\n",
     "n'est pas deleguable : un editor du site ne peut pas, par lui-meme,\n",
@@ -525,32 +655,33 @@
    "id": "5aefb3d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.329964Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.329964Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.500391Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.500391Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:32.946897Z",
+     "iopub.status.busy": "2026-08-19T17:28:32.946305Z",
+     "iopub.status.idle": "2026-08-19T17:28:34.453452Z",
+     "shell.execute_reply": "2026-08-19T17:28:34.452118Z"
+    },
+    "papermill": {
+     "duration": 1.539505,
+     "end_time": "2026-08-19T17:28:34.454643+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:32.915138+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "utilisateur existant : 5\n"
+      "creation : 201\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "login admin :"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " OK (302)\n",
+      "login admin : OK (302)\n",
       "\n",
       "authorize (admin + PKCE) : 200\n",
       "formulaire de consentement : True\n",
@@ -589,7 +720,16 @@
   {
    "cell_type": "markdown",
    "id": "f9137d9a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009553,
+     "end_time": "2026-08-19T17:28:34.472206+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:34.462653+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Le formulaire porte tous les parametres de la demande (client,\n",
     "redirect, scope, challenge) plus deux details dignes d'attention :\n",
@@ -636,11 +776,19 @@
    "id": "5e97a1ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.503910Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.503910Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.587510Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.586995Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:34.500165Z",
+     "iopub.status.busy": "2026-08-19T17:28:34.499583Z",
+     "iopub.status.idle": "2026-08-19T17:28:34.736320Z",
+     "shell.execute_reply": "2026-08-19T17:28:34.734899Z"
+    },
+    "papermill": {
+     "duration": 0.257414,
+     "end_time": "2026-08-19T17:28:34.737624+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:34.480210+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -648,8 +796,8 @@
      "output_type": "stream",
      "text": [
       "statut : 302\n",
-      "redirection : http://localhost:8888/callback?code=5a53d2857391a8df54bea4202dd61f0c499621e3d77c...\n",
-      "code d'autorisation : 5a53d2857391a8df...\n"
+      "redirection : http://localhost:8888/callback?code=7f073883e69ed79bc6b1655db920b959c87729422cbb...\n",
+      "code d'autorisation : 7f073883e69ed79b...\n"
      ]
     }
    ],
@@ -670,7 +818,16 @@
   {
    "cell_type": "markdown",
    "id": "ddc3b7e6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008274,
+     "end_time": "2026-08-19T17:28:34.753792+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:34.745518+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Un **302 vers le redirect_uri du client**, avec le code d'autorisation\n",
     "en parametre — exactement le chemin qu'emprunterait le navigateur d'un\n",
@@ -707,11 +864,19 @@
    "id": "64a9fccb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.591023Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.589517Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.648816Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.648816Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:34.798103Z",
+     "iopub.status.busy": "2026-08-19T17:28:34.797551Z",
+     "iopub.status.idle": "2026-08-19T17:28:34.988456Z",
+     "shell.execute_reply": "2026-08-19T17:28:34.987055Z"
+    },
+    "papermill": {
+     "duration": 0.225388,
+     "end_time": "2026-08-19T17:28:34.989755+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:34.764367+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -719,10 +884,10 @@
      "output_type": "stream",
      "text": [
       "statut : 200\n",
-      "  access_token  : 294b6bcb38cda5...\n",
+      "  access_token  : 5de4237dce330d...\n",
       "  token_type    : Bearer\n",
       "  expires_in    : 3600\n",
-      "  refresh_token : 0fb8df1a94e5fd...\n",
+      "  refresh_token : 97f104cc05a341...\n",
       "  scope         : mcp\n"
      ]
     }
@@ -745,7 +910,16 @@
   {
    "cell_type": "markdown",
    "id": "b29fb548",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008277,
+     "end_time": "2026-08-19T17:28:35.006579+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:34.998302+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Le serveur delivre le trio complet : `access_token`, `refresh_token`,\n",
     "`expires_in` — et le `scope` accorde. Le jeton d'acces a une duree de\n",
@@ -791,18 +965,33 @@
    "id": "4b433351",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.652372Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.652372Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.733110Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.732102Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:35.053293Z",
+     "iopub.status.busy": "2026-08-19T17:28:35.052712Z",
+     "iopub.status.idle": "2026-08-19T17:28:35.197408Z",
+     "shell.execute_reply": "2026-08-19T17:28:35.196061Z"
+    },
+    "papermill": {
+     "duration": 0.183932,
+     "end_time": "2026-08-19T17:28:35.198607+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.014675+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "statut : 200\n",
+      "statut :"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 200\n",
       "serverInfo : {'name': 'AI Engine - Maison Valmont', 'version': '0.0.1'}\n",
       "capabilities : ['tools']\n"
      ]
@@ -828,7 +1017,16 @@
   {
    "cell_type": "markdown",
    "id": "interp-initialize-capabilities",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00803,
+     "end_time": "2026-08-19T17:28:35.215084+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.207054+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Ce que `initialize` etablit — et ce qu'il ne fait pas\n",
     "\n",
@@ -861,11 +1059,19 @@
    "id": "b06fce76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.735969Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.735969Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.821438Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.821438Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:35.263316Z",
+     "iopub.status.busy": "2026-08-19T17:28:35.262694Z",
+     "iopub.status.idle": "2026-08-19T17:28:35.386567Z",
+     "shell.execute_reply": "2026-08-19T17:28:35.385188Z"
+    },
+    "papermill": {
+     "duration": 0.164667,
+     "end_time": "2026-08-19T17:28:35.387804+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.223137+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -894,7 +1100,16 @@
   {
    "cell_type": "markdown",
    "id": "interp-tool-call-delegation",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008254,
+     "end_time": "2026-08-19T17:28:35.404480+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.396226+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### L'appel d'outil : la delegation devient concrete\n",
     "\n",
@@ -921,7 +1136,16 @@
   {
    "cell_type": "markdown",
    "id": "559e7bd3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.034188,
+     "end_time": "2026-08-19T17:28:35.446921+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.412733+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Trois cles pour un meme serveur\n",
     "\n",
@@ -945,7 +1169,16 @@
   {
    "cell_type": "markdown",
    "id": "6ea98df8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.045346,
+     "end_time": "2026-08-19T17:28:35.500563+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.455217+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 8. Nettoyage\n",
     "\n",
@@ -962,24 +1195,26 @@
    "id": "3ad99ba6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.824742Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.824742Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.970306Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.970306Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:35.560035Z",
+     "iopub.status.busy": "2026-08-19T17:28:35.559454Z",
+     "iopub.status.idle": "2026-08-19T17:28:35.887927Z",
+     "shell.execute_reply": "2026-08-19T17:28:35.886543Z"
+    },
+    "papermill": {
+     "duration": 0.364649,
+     "end_time": "2026-08-19T17:28:35.889258+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.524609+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "statut : 200 | corps : \n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "statut : 200 | corps : \n",
       "appel MCP apres revocation : 401\n"
      ]
     }
@@ -1006,7 +1241,16 @@
   {
    "cell_type": "markdown",
    "id": "interp-revocation-immediate",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008078,
+     "end_time": "2026-08-19T17:28:35.906079+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.898001+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### La revocation est immediate, et c'est une propriete a verifier\n",
     "\n",
@@ -1033,7 +1277,16 @@
   {
    "cell_type": "markdown",
    "id": "4b2fc85a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.030719,
+     "end_time": "2026-08-19T17:28:35.945173+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.914454+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Bilan\n",
     "\n",
@@ -1065,7 +1318,16 @@
   {
    "cell_type": "markdown",
    "id": "dbcf3dc8",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.027134,
+     "end_time": "2026-08-19T17:28:35.980902+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.953768+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercices\n",
     "\n",
@@ -1081,11 +1343,19 @@
    "id": "7fb04745",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.973362Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.973362Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.978390Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.977884Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:36.011065Z",
+     "iopub.status.busy": "2026-08-19T17:28:36.010495Z",
+     "iopub.status.idle": "2026-08-19T17:28:36.015994Z",
+     "shell.execute_reply": "2026-08-19T17:28:36.014729Z"
+    },
+    "papermill": {
+     "duration": 0.024888,
+     "end_time": "2026-08-19T17:28:36.017174+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:35.992286+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1106,11 +1376,19 @@
    "id": "43ef58a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.981396Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.981396Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.986446Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.985416Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:36.036067Z",
+     "iopub.status.busy": "2026-08-19T17:28:36.035554Z",
+     "iopub.status.idle": "2026-08-19T17:28:36.040928Z",
+     "shell.execute_reply": "2026-08-19T17:28:36.039706Z"
+    },
+    "papermill": {
+     "duration": 0.016226,
+     "end_time": "2026-08-19T17:28:36.042125+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:36.025899+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1132,11 +1410,19 @@
    "id": "4415d2dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-18T13:23:32.989315Z",
-     "iopub.status.busy": "2026-08-18T13:23:32.987632Z",
-     "iopub.status.idle": "2026-08-18T13:23:32.992317Z",
-     "shell.execute_reply": "2026-08-18T13:23:32.992317Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:28:36.062719Z",
+     "iopub.status.busy": "2026-08-19T17:28:36.062144Z",
+     "iopub.status.idle": "2026-08-19T17:28:36.068206Z",
+     "shell.execute_reply": "2026-08-19T17:28:36.066833Z"
+    },
+    "papermill": {
+     "duration": 0.027429,
+     "end_time": "2026-08-19T17:28:36.079416+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:28:36.051987+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1170,7 +1456,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 22.802067,
+   "end_time": "2026-08-19T17:28:36.659785+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "autour-du-consent-oauth-du-serveur-mcp.ipynb",
+   "output_path": "autour-du-consent-oauth-du-serveur-mcp.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-19T17:28:13.857718+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/.env.example
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/.env.example
@@ -32,6 +32,12 @@ VALMONT_LLM_MODEL_NAME=Qwen 3.6 35B A3B
 # Application password cree a l'etape 5 du README (wp user application-password create)
 VALMONT_APP_PASSWORD=
 
+# --- Fixture editeur consent.editor (posee par le notebook OAuth, relue par
+# le notebook assistant de l'editeur) --------------------------------------
+# Choisir une valeur quelconque : les DEUX notebooks lisent cette meme
+# variable, sans defaut litteral dans le code (#11747).
+VALMONT_EDITOR_PASSWORD=change-me-editor-password
+
 # --- Comparaison directe moteur (notebook donnees structurees, OPTIONNEL) ---
 # Le meme moteur, vu depuis la machine hote (le .env ci-dessus donne
 # l adresse vue depuis le container). Sert a la mesure avec/sans

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/README.md
@@ -76,6 +76,11 @@ docker exec valmont-wordpress_cli-1 sh -c "wp user application-password create $
 Les notebooks lisent `instance-jetable/.env` (base URL + admin + app password).
 Rien d'autre n'est requis : ils appellent l'API de l'instance en HTTP local.
 
+Le compte de test `consent.editor` — créé par le notebook OAuth puis réutilisé
+par le notebook assistant de l'éditeur — porte le mot de passe
+`VALMONT_EDITOR_PASSWORD` (même `.env`) : choisir une valeur, aucun défaut
+littéral dans les notebooks (#11747).
+
 ## Verification rapide
 
 ```powershell

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/interroger-lassistant-de-lediteur-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/interroger-lassistant-de-lediteur-par-l-api.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "f6e3c9e7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006634,
+     "end_time": "2026-08-19T17:29:47.450605+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:47.443971+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# L'assistant de l'editeur — la quatrieme face du plugin\n",
     "\n",
@@ -31,7 +40,16 @@
   {
    "cell_type": "markdown",
    "id": "df5b6bb0",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005477,
+     "end_time": "2026-08-19T17:29:47.464174+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:47.458697+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## La serie « AI Engine par son API »\n",
     "\n",
@@ -60,7 +78,16 @@
   {
    "cell_type": "markdown",
    "id": "3b65073c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005786,
+     "end_time": "2026-08-19T17:29:47.475883+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:47.470097+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Prerequis\n",
     "\n",
@@ -85,11 +112,19 @@
    "id": "9cd19138",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:12.961039Z",
-     "iopub.status.busy": "2026-08-19T03:09:12.961039Z",
-     "iopub.status.idle": "2026-08-19T03:09:13.157789Z",
-     "shell.execute_reply": "2026-08-19T03:09:13.157789Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:29:47.508590Z",
+     "iopub.status.busy": "2026-08-19T17:29:47.508020Z",
+     "iopub.status.idle": "2026-08-19T17:29:48.933402Z",
+     "shell.execute_reply": "2026-08-19T17:29:48.931990Z"
+    },
+    "papermill": {
+     "duration": 1.434957,
+     "end_time": "2026-08-19T17:29:48.934896+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:47.499939+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -97,8 +132,20 @@
      "output_type": "stream",
      "text": [
       "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
-      "Base URL : http://localhost:8093\n",
-      "utilisateur editor existant : 4\n",
+      "Base URL : http://localhost:8093\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "utilisateur editor existant : 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "login editor : OK (302)\n"
      ]
     }
@@ -131,7 +178,7 @@
     "creds = base64.b64encode(f\"{ADMIN_USER}:{APP_PASSWORD}\".encode()).decode()\n",
     "ENTETES = {\"Authorization\": \"Basic \" + creds, \"Content-Type\": \"application/json\"}\n",
     "\n",
-    "EDITEUR_MDP = \"Consent-Editor-2026!\"  # compte de test, instance jetable, pose par le notebook OAuth\n",
+    "EDITEUR_MDP = os.getenv(\"VALMONT_EDITOR_PASSWORD\")  # fixture consent.editor, posee par le notebook OAuth (meme .env)\n",
     "\n",
     "\n",
     "def login_wordpress(session, utilisateur, mot_de_passe):\n",
@@ -184,7 +231,16 @@
   {
    "cell_type": "markdown",
    "id": "9c8859d1",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006161,
+     "end_time": "2026-08-19T17:29:48.947652+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:48.941491+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Ou vit la route\n",
     "\n",
@@ -204,11 +260,19 @@
    "id": "644f4797",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:13.160217Z",
-     "iopub.status.busy": "2026-08-19T03:09:13.160217Z",
-     "iopub.status.idle": "2026-08-19T03:09:13.192821Z",
-     "shell.execute_reply": "2026-08-19T03:09:13.192821Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:29:48.963014Z",
+     "iopub.status.busy": "2026-08-19T17:29:48.962481Z",
+     "iopub.status.idle": "2026-08-19T17:29:49.114651Z",
+     "shell.execute_reply": "2026-08-19T17:29:49.113256Z"
+    },
+    "papermill": {
+     "duration": 0.161716,
+     "end_time": "2026-08-19T17:29:49.115690+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:48.953974+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -241,7 +305,16 @@
   {
    "cell_type": "markdown",
    "id": "b353c731",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006594,
+     "end_time": "2026-08-19T17:29:49.128727+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:49.122133+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Deux familles vivent ici : les `files/*` (televersement, liste,\n",
     "suppression — la memoire de fichiers du plugin) et les deux `submit` :\n",
@@ -267,18 +340,26 @@
    "id": "2e692118",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:13.194826Z",
-     "iopub.status.busy": "2026-08-19T03:09:13.194826Z",
-     "iopub.status.idle": "2026-08-19T03:09:13.280024Z",
-     "shell.execute_reply": "2026-08-19T03:09:13.279499Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:29:49.143989Z",
+     "iopub.status.busy": "2026-08-19T17:29:49.143466Z",
+     "iopub.status.idle": "2026-08-19T17:29:49.418766Z",
+     "shell.execute_reply": "2026-08-19T17:29:49.417424Z"
+    },
+    "papermill": {
+     "duration": 0.284752,
+     "end_time": "2026-08-19T17:29:49.419948+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:49.135196+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "nonce visiteur (start_session) : 1fdb4809a8\n"
+      "nonce visiteur (start_session) : a0520dd9ae\n"
      ]
     },
     {
@@ -307,7 +388,16 @@
   {
    "cell_type": "markdown",
    "id": "d1eaad36",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006267,
+     "end_time": "2026-08-19T17:29:49.432735+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:49.426468+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**403, `rest_cookie_invalid_nonce`.** Le refus est precis : ce n'est\n",
     "pas l'identite qui manque (la session editor est valide), c'est le\n",
@@ -340,18 +430,26 @@
    "id": "1b3550ae",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:13.281610Z",
-     "iopub.status.busy": "2026-08-19T03:09:13.281610Z",
-     "iopub.status.idle": "2026-08-19T03:09:13.346869Z",
-     "shell.execute_reply": "2026-08-19T03:09:13.346252Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:29:49.447976Z",
+     "iopub.status.busy": "2026-08-19T17:29:49.447397Z",
+     "iopub.status.idle": "2026-08-19T17:29:52.593779Z",
+     "shell.execute_reply": "2026-08-19T17:29:52.592530Z"
+    },
+    "papermill": {
+     "duration": 3.155836,
+     "end_time": "2026-08-19T17:29:52.595020+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:49.439184+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "nonce extrait de wp-admin : 9e2b48c339\n",
+      "nonce extrait de wp-admin : 4eda12041a\n",
       "longueur : 10 caracteres\n"
      ]
     }
@@ -366,7 +464,16 @@
   {
    "cell_type": "markdown",
    "id": "cbf0e15a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006722,
+     "end_time": "2026-08-19T17:29:52.608763+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:52.602041+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Dix caracteres hexadecimaux — le format nonce de WordPress, court par\n",
     "design : un nonce n'a pas vocation a etre fort face au brute force\n",
@@ -392,11 +499,19 @@
    "id": "e6017d94",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:13.349480Z",
-     "iopub.status.busy": "2026-08-19T03:09:13.349480Z",
-     "iopub.status.idle": "2026-08-19T03:09:13.375219Z",
-     "shell.execute_reply": "2026-08-19T03:09:13.374700Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:29:52.624472Z",
+     "iopub.status.busy": "2026-08-19T17:29:52.623920Z",
+     "iopub.status.idle": "2026-08-19T17:29:52.806618Z",
+     "shell.execute_reply": "2026-08-19T17:29:52.805043Z"
+    },
+    "papermill": {
+     "duration": 0.192422,
+     "end_time": "2026-08-19T17:29:52.807883+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:52.615461+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -418,7 +533,16 @@
   {
    "cell_type": "markdown",
    "id": "378d11c6",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007219,
+     "end_time": "2026-08-19T17:29:52.822647+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:52.815428+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**400, « Empty message. »** — le refus le plus utile qui soit : la\n",
     "route a bien recu *quelque chose*, l'a trouve **vide**, et son\n",
@@ -446,11 +570,19 @@
    "id": "409461df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:13.377950Z",
-     "iopub.status.busy": "2026-08-19T03:09:13.377311Z",
-     "iopub.status.idle": "2026-08-19T03:09:15.991504Z",
-     "shell.execute_reply": "2026-08-19T03:09:15.991504Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:29:52.838921Z",
+     "iopub.status.busy": "2026-08-19T17:29:52.838320Z",
+     "iopub.status.idle": "2026-08-19T17:29:55.959694Z",
+     "shell.execute_reply": "2026-08-19T17:29:55.958188Z"
+    },
+    "papermill": {
+     "duration": 3.131182,
+     "end_time": "2026-08-19T17:29:55.960836+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:52.829654+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -460,7 +592,7 @@
       "statut : 200\n",
       "cles de la reponse : ['actions', 'feedbackId', 'reply', 'success', 'usage']\n",
       "reply  : La capitale de la France est Paris.\n",
-      "usage  : {'prompt_tokens': 25, 'completion_tokens': 189, 'total_tokens': 214, 'price': None, 'queries': 1, 'accuracy': 'estimated'}\n",
+      "usage  : {'prompt_tokens': 45, 'completion_tokens': 10, 'total_tokens': 55, 'price': None, 'queries': 1, 'accuracy': 'estimated'}\n",
       "actions: []\n"
      ]
     }
@@ -479,12 +611,24 @@
   {
    "cell_type": "markdown",
    "id": "0aebb4db",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00675,
+     "end_time": "2026-08-19T17:29:55.974360+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:55.967610+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Trois choses dans cette reponse. La completion elle-meme, banale.\n",
-    "Le **usage** : la completion affiche 189 tokens pour sept mots rendus — la phrase visible n'est que la pointe emergee. Rien d'anormal : l'environnement declare est un modele **a raisonnement**\n",
-    "(les grains precedents de la serie l'ont mesure sur d'autres routes),\n",
-    "qui depense du raisonnement avant la phrase. L'assistant de l'editeur\n",
+    "Le **usage** : la completion affiche 10 tokens pour sept mots rendus —\n",
+    "ici le cout suit la phrase visible au mot pres. Ce compteur n'a pas\n",
+    "toujours cette tete : branche sur un modele **a raisonnement** (les\n",
+    "grains precedents de la serie l'ont mesure sur d'autres routes), le meme\n",
+    "usage enfle de tout le raisonnement depense avant la phrase — la reponse\n",
+    "visible n'en est que la pointe emergee. L'assistant de l'editeur\n",
     "expose cette depense telle quelle — information precieuse pour qui\n",
     "s'interroge sur le cout d'une aide a l'ecriture interpolee a chaque\n",
     "frappe. Et enfin **`actions: []`** — le champ vide qui dit tout : le\n",
@@ -509,19 +653,27 @@
    "id": "be97b486",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:15.995518Z",
-     "iopub.status.busy": "2026-08-19T03:09:15.995004Z",
-     "iopub.status.idle": "2026-08-19T03:09:31.636531Z",
-     "shell.execute_reply": "2026-08-19T03:09:31.636531Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:29:55.990742Z",
+     "iopub.status.busy": "2026-08-19T17:29:55.990168Z",
+     "iopub.status.idle": "2026-08-19T17:29:59.092752Z",
+     "shell.execute_reply": "2026-08-19T17:29:59.091437Z"
+    },
+    "papermill": {
+     "duration": 3.112623,
+     "end_time": "2026-08-19T17:29:59.094073+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:55.981450+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "sans instructions : 200 | reply : Le lion. | 2 mots\n",
-      "avec instructions : 200 | reply : tortue de mer | 3 mots\n"
+      "sans instructions : 200 | reply : L'éléphant. | 1 mots\n",
+      "avec instructions : 200 | reply : Lion. | 1 mots\n"
      ]
     }
    ],
@@ -541,17 +693,30 @@
   {
    "cell_type": "markdown",
    "id": "4d6c5da5",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006739,
+     "end_time": "2026-08-19T17:29:59.107762+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:59.101023+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "La comparaison ci-dessus dit l'essentiel : le meme message, avec et\n",
-    "sans contrainte posee en instructions, ne produit pas la meme forme\n",
-    "de reponse. Sans contrainte, la reponse fait 2 mots (« Le lion. ») ; avec la consigne « exactement trois mots », elle en fait exactement 3 (« tortue de mer ») — la contrainte posee en instructions est respectee a la lettre, jusque dans la forme de la reponse. Pour le\n",
-    "projet client, cette distinction etait le nerf des agents d'ateliers\n",
-    "(grain 2) : un persona est une instruction, et ce qui n'est pas dans\n",
-    "les instructions n'est pas dans le comportement. La face editeur\n",
-    "retrouve la meme physique — preuve que la distinction ne depend pas\n",
-    "de la surface (chatbot public ou assistant interne), mais du moteur\n",
-    "commun.\n",
+    "La comparaison ci-dessus dit l'essentiel : le champ `instructions` est\n",
+    "ecoute — le meme message y change de reponse (« L'éléphant. » sans\n",
+    "consigne, « Lion. » avec). Mais la consigne de forme « exactement trois\n",
+    "mots » n'est pas tenue par ce moteur local : les deux replies font un\n",
+    "mot. La tenue litterale d'une contrainte de forme est une capacite du\n",
+    "moteur, pas de la route — la consigne descend bien jusqu'a la reponse,\n",
+    "son execution reste a la hauteur du moteur branche. Pour le projet\n",
+    "client, la distinction reste le nerf des agents d'ateliers (grain 2) :\n",
+    "un persona est une instruction, et ce qui n'est pas dans les\n",
+    "instructions n'est pas dans le comportement — ce qui y est ne s'execute\n",
+    "qu'a hauteur du moteur. La face editeur retrouve la meme physique — la\n",
+    "distinction ne depend pas de la surface (chatbot public ou assistant\n",
+    "interne), mais du moteur commun.\n",
     "\n",
     "## 7. La memoire : qui la porte ?\n",
     "\n",
@@ -568,32 +733,40 @@
    "id": "f427d27d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:31.640162Z",
-     "iopub.status.busy": "2026-08-19T03:09:31.640162Z",
-     "iopub.status.idle": "2026-08-19T03:09:58.443429Z",
-     "shell.execute_reply": "2026-08-19T03:09:58.443429Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:29:59.124639Z",
+     "iopub.status.busy": "2026-08-19T17:29:59.124069Z",
+     "iopub.status.idle": "2026-08-19T17:30:15.348851Z",
+     "shell.execute_reply": "2026-08-19T17:30:15.347486Z"
+    },
+    "papermill": {
+     "duration": 16.235127,
+     "end_time": "2026-08-19T17:30:15.350186+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:29:59.115059+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tour 1 : 200 | C'est noté ! J'ai bien enregistré que ton animal préféré est\n"
+      "tour 1 : 200 | Je comprends que vous avez mentionné un animal spécifique : \n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tour 2 (sans historique) : 200 | reply : Inconnu\n"
+      "tour 2 (sans historique) : 200 | reply : Chat\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "tour 3 (avec historique) : 200 | reply : Lynx\n",
+      "tour 3 (avec historique) : 200 | reply : Le lynx.\n",
       "le lynx est dans le tour 2 : False | dans le tour 3 : True\n"
      ]
     }
@@ -621,9 +794,18 @@
   {
    "cell_type": "markdown",
    "id": "cb287c48",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007156,
+     "end_time": "2026-08-19T17:30:15.365097+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:15.357941+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
-    "Lecture des trois lignes ci-dessus : le tour 2, isole, rend « Inconnu » — la route est stateless, chaque appel repart de zero — et le tour 3, qui re-apporte l'historique, rend « Lynx ». La memoire n'a jamais ete dans le serveur. La memoire de conversation\n",
+    "Lecture des trois lignes ci-dessus : le tour 2, isole, rend « Chat » — la route est stateless, chaque appel repart de zero — et le tour 3, qui re-apporte l'historique, rend « Le lynx. ». La memoire n'a jamais ete dans le serveur. La memoire de conversation\n",
     "n'est pas dans le serveur : elle est a la charge du **client**, qui\n",
     "renvoie le fil. C'est le contrat du grain 6 retrouve a l'identique\n",
     "cote editeur : le chatbot public portait son historique dans\n",
@@ -649,18 +831,26 @@
    "id": "521248f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:09:58.446554Z",
-     "iopub.status.busy": "2026-08-19T03:09:58.446554Z",
-     "iopub.status.idle": "2026-08-19T03:10:00.578154Z",
-     "shell.execute_reply": "2026-08-19T03:10:00.577382Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:30:15.382248Z",
+     "iopub.status.busy": "2026-08-19T17:30:15.381683Z",
+     "iopub.status.idle": "2026-08-19T17:30:17.510538Z",
+     "shell.execute_reply": "2026-08-19T17:30:17.509143Z"
+    },
+    "papermill": {
+     "duration": 2.13893,
+     "end_time": "2026-08-19T17:30:17.511911+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:15.372981+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "environnement reel de l'instance : vllm-local\n"
+      "environnement reel de l'instance : llm-local\n"
      ]
     },
     {
@@ -690,7 +880,16 @@
   {
    "cell_type": "markdown",
    "id": "0e0690a9",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006738,
+     "end_time": "2026-08-19T17:30:17.525812+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:17.519074+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "Les deux mesures tranchent : avec l'`envId` **correct** lu\n",
     "dynamiquement, la completion passe — le champ est ecoute, l'appelant\n",
@@ -718,11 +917,19 @@
    "id": "48a9a774",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:10:00.580675Z",
-     "iopub.status.busy": "2026-08-19T03:10:00.580675Z",
-     "iopub.status.idle": "2026-08-19T03:10:00.586106Z",
-     "shell.execute_reply": "2026-08-19T03:10:00.586106Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:30:17.542029Z",
+     "iopub.status.busy": "2026-08-19T17:30:17.541326Z",
+     "iopub.status.idle": "2026-08-19T17:30:17.549294Z",
+     "shell.execute_reply": "2026-08-19T17:30:17.547799Z"
+    },
+    "papermill": {
+     "duration": 0.017983,
+     "end_time": "2026-08-19T17:30:17.550516+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:17.532533+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -745,7 +952,16 @@
   {
    "cell_type": "markdown",
    "id": "a5f70ec7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007142,
+     "end_time": "2026-08-19T17:30:17.565071+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:17.557929+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Aucune** — et c'est la reponse attendue : le mecanisme de rotation\n",
     "ne s'active que sur un nonce en fin de vie (le code le declenche\n",
@@ -786,7 +1002,16 @@
   {
    "cell_type": "markdown",
    "id": "43d4c728",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010091,
+     "end_time": "2026-08-19T17:30:17.585535+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:17.575444+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Bilan\n",
     "\n",
@@ -818,7 +1043,16 @@
   {
    "cell_type": "markdown",
    "id": "5598401e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007122,
+     "end_time": "2026-08-19T17:30:17.610031+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:17.602909+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercices\n",
     "\n",
@@ -834,11 +1068,19 @@
    "id": "95700e9d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:10:00.589170Z",
-     "iopub.status.busy": "2026-08-19T03:10:00.589170Z",
-     "iopub.status.idle": "2026-08-19T03:10:00.593851Z",
-     "shell.execute_reply": "2026-08-19T03:10:00.592845Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:30:17.628115Z",
+     "iopub.status.busy": "2026-08-19T17:30:17.627565Z",
+     "iopub.status.idle": "2026-08-19T17:30:17.633377Z",
+     "shell.execute_reply": "2026-08-19T17:30:17.631902Z"
+    },
+    "papermill": {
+     "duration": 0.017417,
+     "end_time": "2026-08-19T17:30:17.634628+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:17.617211+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -860,11 +1102,19 @@
    "id": "aa41ee9a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:10:00.596112Z",
-     "iopub.status.busy": "2026-08-19T03:10:00.596112Z",
-     "iopub.status.idle": "2026-08-19T03:10:00.599617Z",
-     "shell.execute_reply": "2026-08-19T03:10:00.599617Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:30:17.652466Z",
+     "iopub.status.busy": "2026-08-19T17:30:17.651920Z",
+     "iopub.status.idle": "2026-08-19T17:30:17.657870Z",
+     "shell.execute_reply": "2026-08-19T17:30:17.656349Z"
+    },
+    "papermill": {
+     "duration": 0.016348,
+     "end_time": "2026-08-19T17:30:17.659068+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:17.642720+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -887,11 +1137,19 @@
    "id": "84709a30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T03:10:00.601626Z",
-     "iopub.status.busy": "2026-08-19T03:10:00.601626Z",
-     "iopub.status.idle": "2026-08-19T03:10:00.606217Z",
-     "shell.execute_reply": "2026-08-19T03:10:00.605690Z"
-    }
+     "iopub.execute_input": "2026-08-19T17:30:17.676015Z",
+     "iopub.status.busy": "2026-08-19T17:30:17.675467Z",
+     "iopub.status.idle": "2026-08-19T17:30:17.681148Z",
+     "shell.execute_reply": "2026-08-19T17:30:17.679929Z"
+    },
+    "papermill": {
+     "duration": 0.015882,
+     "end_time": "2026-08-19T17:30:17.682320+00:00",
+     "exception": false,
+     "start_time": "2026-08-19T17:30:17.666438+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -926,7 +1184,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.13"
+   "version": "3.13.7"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 37.615258,
+   "end_time": "2026-08-19T17:30:18.157000+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "interroger-lassistant-de-lediteur-par-l-api.ipynb",
+   "output_path": "interroger-lassistant-de-lediteur-par-l-api.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-19T17:29:40.541742+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2024:CoursIA-2 — prev: MED/lean #11802

## Summary

Le mot de passe fixture du compte de test `consent.editor` quitte le code source des deux notebooks pour `VALMONT_EDITOR_PASSWORD` (`instance-jetable/.env`), **sans défaut littéral** — exactement le remède que #11747 spécifie (et non le `os.getenv("KEY", "littéral")` que `secrets-hygiene.md` règle 2 interdit). Les deux notebooks sont **ré-exécutés de bout en bout** (C.2) sur une instance jetable montée localement ce cycle.

## Acceptance #11747 (4/4)

| # | Critère | Mesure |
|---|---|---|
| 1 | Aucun défaut littéral sur la variable | `os.getenv("VALMONT_EDITOR_PASSWORD")` — aucun second argument (nb1 cell config, nb2 cell config) |
| 2 | Les deux notebooks lisent la même variable, littéral disparu | `grep -c "Consent-Editor-2026!"` = **0** dans les deux fichiers (vérifié par script, assertion) |
| 3 | `.env.example` + README étape 5 documentent la variable | `.env.example` : bloc `VALMONT_EDITOR_PASSWORD=change-me-editor-password` + commentaire (valeur au choix, même variable pour poser et utiliser le compte) ; README étape 5 : paragraphe dédié |
| 4 | Les deux notebooks ré-exécutés (C.2) | Papermill end-to-end : nb1 **15/15 cells, ec 1..15, 0 erreur** ; nb2 **13/13 cells, ec 1..13, 0 erreur**. La fixture fonctionne en réel : `creation : 201` puis `login editor : OK (302)` depuis la valeur `.env` |

## Le chemin d'exécution réel (preuves)

Instance jetable montée intégralement sur cette lane ce cycle (règle F — réparer/exécuter, jamais contourner) :

- **Pile** : `docker compose -f docker-compose.jetable.example.yml up -d` — WordPress 6.8.3-php8.2 + MariaDB 10.11 + wp-cli, port 8093, healthy ; permaliens activés (`/wp-json/` répond en JSON).
- **Plugin** : AI Engine 3.7.0 téléchargé depuis downloads.wordpress.org, activé ; seed `seed-valmont.php` exécuté (`env 'llm-local' branché`, chatbot « valmont », application passwords autorisés).
- **LLM local** : Qwen2.5-1.5B-Instruct servi en CUDA (RTX 3070, torch 2.6.0+cu124) par un shim FastAPI OpenAI-compatible (`/v1/chat/completions`, `/v1/models`) sur `:11434` — l'URL exacte que `.env.example` documente (`host.docker.internal:11434/v1`). Vérifié depuis le container WordPress. Le 0.5B (cache HF) a été écarté sur **mesure** : il rate la démo mémoire de nb2 (« Le lion » au lieu du lynx, test direct préalable) — le 1.5B la tient.
- **Comptes** : `consent.editor` (rôle editor) et `consent.admin` créés par nb1 via l'API REST, **avec le mot de passe lu dans `.env`** — la chaîne complète du fix est exercée en réel.

## Diagnostic dérive (§D.5, règle D)

- **Cause : (c) moteur local différent** — les outputs de base provenaient d'un moteur 35B a raisonnement (usage 189 tokens pour 7 mots) ; la ré-exécution locale (1.5B non-raisonnement) produit des valeurs légitimement différentes (usage 10 tokens).
- **Prose ré-alignée** (md 14/16/18 de nb2) : chaque valeur citée est désormais dans l'output adjacent — `10 tokens` (cell 13), `« L'éléphant. »/« Lion. »` 1 mot (cell 15), `« Chat »/« Le lynx. »` False/True (cell 17). La démo mémoire (stateless vs historique) et le routage envId/model (500 « The environment is required. ») reproduisent **à l'identique** les phénomènes de la base. La contrainte « exactement trois mots » n'est pas tenue par le moteur local léger — la prose le dit désormais honnêtement (tenue littérale = capacité du moteur, pas de la route).
- **Verdict : CAUSE_FIXED** (ré-exécution fraîche + prose alignée sur les outputs réels).

## Vérifications

- `validate_pr_notebooks.py origin/main <2 notebooks>` : **2/2 PASS** (28 code cells).
- `detect_markdown_rendering.py --check` : **0 nouvelle violation**.
- `check_exec_ratchet.py origin/main` : **0 régression** (séquences 1..15 et 1..13 propres).
- Sources au format liste-de-lignes préservé (0 cellule string) ; `.env` local jamais stagé (gitignore vérifié `git check-ignore`).
- Catalogue/CATALOG-STATUS : inchangés (aucun fichier catalogue dans le diff).

Closes #11747
See #11707

## Coordination

- Claim scopé posé : `[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/**` (comment 5345186274) ; livré — claim à considérer released au merge.
- G-VAR-1 : MED/genai (genre CONTENU — notebooks ré-exécutés avec outputs réels) ; G-VAR-3 : prev MED/lean #11802 → genres distincts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
