### PR TITLE
feat(lean,#2159): pullback_iinf -- dual iInf manquant de pullback_imap (SieveLattice FR+EN)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean
@@ -17,6 +17,7 @@ identités fondamentales du **pullback le long de morphismes** :
   - `pullback_inf` (Partie 8, `SieveOps.lean`) : pullback préserve ⊓
   - `pullback_union` : pullback préserve ⋃ (joins finis)
   - `pullback_imap` : pullback préserve les bornes supérieures indexées (iSup)
+  - `pullback_iinf` : pullback préserve les bornes inférieures indexées (iInf)
   - `pullback_ofObjects` : pullback distribue `Sieve.ofObjects` selon la cible
   - `mem_iff_pullback_eq_top` : `f ∈ S` ssi `Sieve.pullback f S = ⊤`
 
@@ -149,6 +150,28 @@ theorem pullback_imap {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
     Sieve.pullback f (iSup S) = ⨆ i, Sieve.pullback f (S i) := by
   ext Z g
   simp [Sieve.pullback, iSup, Set.mem_range]
+
+/-!
+## Pullback distribue sur la borne inférieure indexée
+
+Dual de `pullback_imap` : tirer en arrière la borne inférieure d'une
+famille de cribles égale la borne inférieure de leurs pullbacks. C'est
+la propriété d'adjoint droit du pullback dans la connexion de Galois
+`pushforward ⊣ pullback` (`galoisConnection_pushforward_pullback`,
+Mathlib `Sites.Sieves`) : il préserve **toutes** les rencontres, pas
+seulement les intersections binaires.
+
+`pullback_inf` (Partie 8, `SieveOps.lean`) en est le cas particulier
+à deux éléments.
+-/
+
+/-- CALIBRATION (ext + simp) : pullback distribue sur le iInf d'une
+    famille indexée. Dual de `pullback_imap` (borne supérieure indexée). -/
+theorem pullback_iinf {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
+    {ι : Type*} (S : ι → Sieve X) :
+    Sieve.pullback f (iInf S) = ⨅ i, Sieve.pullback f (S i) := by
+  ext Z g
+  simp [Sieve.pullback, iInf, Set.mem_range]
 
 /-!
 ## Pullback distribue `ofObjects` selon la cible

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice_en.lean
@@ -15,6 +15,7 @@ identities of pullback along morphisms:
   - Pullback preserves ⊓ (pullback_inf, in Part 8 SieveOps.lean).
   - Pullback preserves ⋃, the finite join (pullback_union).
   - Pullback preserves indexed suprema, iSup (pullback_imap).
+  - Pullback preserves indexed infima, iInf (pullback_iinf).
   - Pullback distributes `Sieve.ofObjects` across the target (pullback_ofObjects).
   - `f ∈ S` iff `Sieve.pullback f S = ⊤` (mem_iff_pullback_eq_top).
 
@@ -132,6 +133,27 @@ theorem pullback_imap {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
     Sieve.pullback f (iSup S) = ⨆ i, Sieve.pullback f (S i) := by
   ext Z g
   simp [Sieve.pullback, iSup, Set.mem_range]
+
+/-!
+## Pullback distributes over the indexed infimum
+
+Dual of `pullback_imap`: pulling back the infimum of a family of sieves
+equals the infimum of their pullbacks. This is the right-adjoint
+property of pullback in the Galois connection
+`pushforward ⊣ pullback` (`galoisConnection_pushforward_pullback`,
+Mathlib `Sites.Sieves`): it preserves **all** meets, not just binary
+intersections.
+
+`pullback_inf` (Part 8, `SieveOps.lean`) is the two-element special case.
+-/
+
+/-- CALIBRATION (ext + simp): pullback distributes over the iInf of an
+    indexed family. Dual of `pullback_imap` (indexed supremum). -/
+theorem pullback_iinf {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
+    {ι : Type*} (S : ι → Sieve X) :
+    Sieve.pullback f (iInf S) = ⨅ i, Sieve.pullback f (S i) := by
+  ext Z g
+  simp [Sieve.pullback, iInf, Set.mem_range]
 
 /-!
 ## Pullback preserves `ofObjects`


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: MED/lean #11795

## Summary

Nouveau théorème **`pullback_iinf`** dans [SieveLattice.lean](MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/Grothendieck/SieveLattice.lean) (+ sibling EN byte-identical) : le **dual iInf manquant** de `pullback_imap`. La série était asymétrique — `pullback_union` (join binaire) et sa généralisation `pullback_imap` (iSup, livré #9762) existaient, `pullback_inf` (binaire) vit dans `SieveOps.lean`, mais **aucune généralisation iInf indexée n'existait** (grep vérifié sur l'ensemble des fichiers du lake, 51 modules FR + siblings EN).

```lean
theorem pullback_iinf {C : Type*} [Category C] {X Y : C} (f : Y ⟶ X)
    {ι : Type*} (S : ι → Sieve X) :
    Sieve.pullback f (iInf S) = ⨅ i, Sieve.pullback f (S i) := by
  ext Z g
  simp [Sieve.pullback, iInf, Set.mem_range]
```

**Lecture mathématique** : propriété d'adjoint droit du pullback dans la connexion de Galois `pushforward ⊣ pullback` (`galoisConnection_pushforward_pullback`, Mathlib `Sites.Sieves:338`) — le pullback préserve **toutes** les rencontres, pas seulement les intersections binaires. `pullback_inf` (SieveOps) en est le cas particulier à deux éléments. Même pattern de calibration que ses voisins (`ext + simp`).

## Validation (règle B Lean — 4 éléments)

1. **Compte `sorry` réel** (`count_code_sorry.py --json`, champ `distinct_code_sorry`) : grothendieck_lean **0 → 0** (mesuré sur tout le lake ; `naive_sorry` 98 = prose seulement).
2. **`lake build` SUCCESS local** (miroir WSL `~/lakes/grothendieck_lean`, mathlib v4.32.0 épinglé, toolchain v4.32.0) :
   ```
   ✔ [816/817] Built Grothendieck.SieveLattice (11s)
   ✔ [817/817] Built Grothendieck.SieveLattice_en (11s)
   Build completed successfully (817 jobs).
   ```
3. **Proof integrity** : job CI `proof-integrity` **câblé** sur ce lake (`lean-grothendieck.yml` invoque `lean-axiom.yml`) — `LeanVerifier.check_axioms(fail_on_sorry=True)` couvre le module modifié. La preuve est `ext + simp`, aucun `sorry`/`native_decide`/`Classical.choice` ajouté.
4. **Pas de refactor prover Python** — N/A.

**i18n** (`check_i18n_siblings.py --all`) : 213/215 paires byte-identical, **0 drift / 0 orphan** — SieveLattice/SieveLattice_en inclus (statements byte-identiques, docstrings FR/EN).

## Re-grounding #2159 (body stale, consigné au claim c.5345472173)

La « cible nommée encore ouverte `pullback_imap` » du body est **livrée depuis le 2026-08-08** (#9762, fix 9818) — le relevé date du 2026-07-30. Le lake compte 51 modules FR leaf + siblings EN, pas 33.

## Scope

2 fichiers (SieveLattice.lean + SieveLattice_en.lean), +45 lignes, 1 théorème + prose. Pas d'umbrella (module déjà importé), pas de README (aucun compte de théorèmes par module dans le README lake), pas de catalogue. See #2159 (contribution à l'Epic, ne le clôt pas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)



