### PR TITLE
docs(video,#9434): drain exact API timings from 01-2-GPT-5-Video-Understanding markdown

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb
@@ -1249,9 +1249,7 @@
    "id": "interp-analysis-29d463",
    "metadata": {},
    "source": [
-    "### Lecture du résultat : GPT-5 lit vraiment les frames, en deux passes\n",
-    "\n",
-    "Deux appels `POST https://api.openai.com/v1/chat/completions` répondent `HTTP/1.1 200 OK`. La première passe (description image par image) prend `22.99s` pour `2940 tokens` (765 en prompt, 2175 en completion) : GPT-5 décrit chaque frame — `Frame 1 (t=0.0s)`, `Frame 2 (t=1.4s)`, `Frame 3 (t=2.8s)` — l'espacement de 1,4 s correspondant aux 8 frames échantillonnées sur 10 s. La seconde passe (raisonnement temporel) prend `19.66s` pour `2572 tokens` (792 + 1780) et restitue une structure que seul le contenu visuel permet : `5 scènes distinctes` identifiées, avec leurs instants de transition (`vers 2.8s`, `vers 4.2s`, `vers 7.1s`, `vers 8.5s`) et une narration de cycle jour-nuit (matin → midi → après-midi → soir → nuit) qui correspond exactement au script de génération de la cellule précédente."
+    "Deux appels `POST https://api.openai.com/v1/chat/completions` répondent `HTTP/1.1 200 OK`. La première passe (description image par image) prend de l'ordre d'une vingtaine de secondes pour quelques milliers de tokens — latence et volumétrie exactes imprimées par la cellule ci-dessus, elles varient à chaque appel : GPT-5 décrit chaque frame — `Frame 1 (t=0.0s)`, `Frame 2 (t=1.4s)`, `Frame 3 (t=2.8s)` — l'espacement de 1,4 s correspondant aux 8 frames échantillonnées sur 10 s. La seconde passe (raisonnement temporel) est de durée comparable (voir la sortie pour les valeurs mesurées) et restitue une structure que seul le contenu visuel permet : `5 scènes distinctes` identifiées, avec des transitions attendues à ~2, ~4, ~6 et ~8 s — les cinq scènes du script durent 2 s chacune — tandis que les instants effectivement détectés sont imprimés par la cellule (le modèle n'est pas seedé : ils varient légèrement d'un appel à l'autre), et une narration de cycle jour-nuit (matin → midi → après-midi → soir → nuit) qui correspond exactement au script de génération de la cellule précédente."
    ]
   },
   {
@@ -1270,7 +1268,7 @@
    "source": [
     "**Les appels d'analyse ci-dessus aboutissent en HTTP 200.** GPT-5 reçoit les 8 frames encodées en base64 et produit une analyse structurée (sorties commitées ci-dessus).\n",
     "\n",
-    "- **Description de scène (Analyse 1)** : le modèle décrit chaque frame individuellement (couleurs dominantes, formes, texte visible) puis synthétise la progression temporelle, pour ~2175 tokens de complétion.\n",
+    "- **Description de scène (Analyse 1)** : le modèle décrit chaque frame individuellement (couleurs dominantes, formes, texte visible) puis synthétise la progression temporelle, pour de l'ordre de deux milliers de tokens de complétion (volumétrie exacte dans la sortie).\n",
     "- **Raisonnement temporel (Analyse 2)** : GPT-5 identifie les 5 scènes, les moments de transition et le thème narratif (cycle jour-nuit).\n",
     "\n",
     "**Point critique sur `max_completion_tokens`** : GPT-5 est un modèle de raisonnement — les tokens de réflexion interne sont décomptés du budget `completion`. Avec un budget trop faible (p.ex. 1000), l'intégralité est consommée par le raisonnement et `message.content` reste **vide** (HTTP 200 mais réponse vide). C'est pourquoi `max_tokens = 8000` ici laisse au modèle la place de produire un contenu visible *après* sa phase de réflexion. La cellule suivante (Video Q&A) applique la même logique."


### PR DESCRIPTION
## Summary

Tranche du drainage #9434 (item : valeurs quantitatives tenues par la sortie, pas par la prose) sur `GenAI/Video/01-Foundation/01-2-GPT-5-Video-Understanding.ipynb`.

La cellule d'interprétation 17 épinglait des valeurs **mesurées dupliquées des outputs commités** (exécution 2026-08-08, modèle gpt-5-2025-08-07) :

| Valeur épinglée | Classe #9434 | Dupliquée de l'output ? |
|---|---|---|
| `22.99s` / `19.66s` (latences des 2 passes API) | machine/API-dep | oui (vérifié : présentes dans les outputs) |
| `2940 tokens (765 + 2175)` / `2572 (792 + 1780)` | API-dep | oui |
| `vers 2.8s / 4.2s / 7.1s / 8.5s` (transitions détectées) | inférence non-seedée | oui |
| `~2175 tokens de complétion` (cell 18) | API-dep (précision fallacieuse sous tilde) | oui |

Chaque re-run contredira la prose (latence API variable, modèle non seedé) — exactement la pathologie que #9434 draine : la prose reconstitue le défaut qu'elle corrige.

## Le geste

- **Ordres de grandeur** : « de l'ordre d'une vingtaine de secondes pour quelques milliers de tokens », « durée comparable ».
- **Valeurs CONSTRUCTIVES** (structurelles, stables) : transitions **attendues** à ~2, ~4, ~6 et ~8 s — les cinq scènes du script durent 2 s chacune — ce qui explique *pourquoi* le modèle détecte des transitions régulières au lieu de recopier *quand* il les a détectées à la dernière exécution.
- **Renvoi à la sortie** comme source unique (« latence et volumétrie exactes imprimées par la cellule ci-dessus »).

**Gardés (structurels, dérivent pas)** : `Frame 1 (t=0.0s), Frame 2 (t=1.4s)...` (échantillonnage déterministe 8 frames / 10 s), `10.0s à 24 images/seconde` (arithmétique 240/24), `5 scènes distinctes` (compte discret validé par la construction), durées estimées pédagogiques.

## Sélection G.1 (candidats écartés, firsthand)

Corpus re-scanné sur **worktree frais origin/main** (218 notebooks à findings temporels — un premier scan sur l'arbre local stale 4211 commits derrière était invalide). Écartés par FP documentés : `11_Job_Shop_Scheduling` (heures = données du problème JSSP, classe FP-B), `CSP-6-Hybridization` (tout en ~ = déjà conforme + nœuds/branches structurels), `Texte/9_Production_Patterns` (logs didactiques typographiques et chronologies hypothétiques « si nous avions configuré » — pas des mesures), `Audio/*` (scope familial po-2025), Sudoku/Lean-10 (déjà drainés sur main).

## Validation

- Markdown-only : +3/-5, cellules code byte-identiques, outputs précédents valides (exception C.2 markdown-only)
- `check_interp_positioning.py` : 0 findings
- `count_exercises.py` : seuil respecté (0 sub-threshold)
- Re-scan `scan_quant_classify.py --notebook` : 30 → 21 findings ; les 21 résiduels = FP structurels documentés ci-dessus (timestamps d'échantillonnage, arithmétique fps, durées estimées)

See #9434 (contribution partielle à l'epic — le stock exact restant sur GenAI/Video se poursuit)

Grain: MED/notebook-python — lane myia-po-2026:CoursIA — prev: MED/tooling #11814