### PR TITLE
fix(lean,#11827): grothendieck_lean v4.32.0 -> v4.32.1 -- dernier lake sur le kernel au bug de soundness (See #11256)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lakefile.lean
@@ -8,7 +8,7 @@ package «grothendieck» where
   ]
 
 require mathlib from git
-  "https://github.com/leanprover-community/mathlib4.git" @ "v4.32.0"
+  "https://github.com/leanprover-community/mathlib4.git" @ "v4.32.1"
 
 -- Convention i18n EPIC #4980 (ratifiée user 04/07, finding 2 ai-01) :
 -- `globs` (et non `roots`) pour que `lake build` auto-découvre les siblings

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lean-toolchain
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/grothendieck_lean/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.32.0
+leanprover/lean4:v4.32.1


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2024:CoursIA — prev: MED/lean #11820

Closes #11827 · See #11256 (dernier lake résiduel)

## Summary

`grothendieck_lean` passe de `v4.32.0` à `v4.32.1` — le **point release du 2026-07-22 qui corrige un bug de soundness du noyau** (leanprover/lean4#14484, fix #14498). C'était le **seul lake du dépôt** resté sur le kernel touché : mesuré firsthand sur `origin/main` avant ce grain, 21 toolchains `v4.32.1`, grothendieck seul en `v4.32.0` (héritage : #11256 l'avait mis hors périmètre quand son pin était `v4.31.0-rc1` ; #10986 l'a ensuite avancé à `v4.32.0`, le replaçant dans la classe point-release).

**2 pins movés, 0 source touché** (protocole tranche #11318) :
- `lean-toolchain` : `leanprover/lean4:v4.32.0` → `v4.32.1`
- `lakefile.lean:11` : mathlib `@ "v4.32.0"` → `@ "v4.32.1"`

## Validation (règle B — 4 éléments)

1. **Compte `sorry` réel** (`count_code_sorry.py --json`, champ `distinct_code_sorry`) : grothendieck_lean **0 → 0** (mesuré sur tout le lake ; `naive_sorry` 98 = prose seule).
2. **`lake build` SUCCESS local** (miroir WSL `~/lakes/grothendieck_lean`, ext4, toolchain v4.32.1, mathlib v4.32.1 via cache (décompression complète au setup)) :
   ```
   ✔ [2906/2907] Built Grothendieck (3.6s)
   Build completed successfully (2907 jobs).
   EXIT=0
   ```
   (Full rebuild 2907 jobs sous le nouveau toolchain — contre 817 en incrémental v4.32.0.)
3. **Proof integrity** : job `proof-integrity` **câblé** sur ce lake (`lean-grothendieck.yml` invoque `lean-axiom.yml`) — `LeanVerifier.check_axioms(fail_on_sorry=True)` couvre les 51 modules FR + siblings EN. Aucun `sorry`/`native_decide`/`Classical.choice` : 0 source touché.
4. **Refactor prover Python** : N/A.

**i18n** (`check_i18n_siblings.py grothendieck_lean`) : 53/54 paires byte-identical + 1 consumer-pattern, **0 drift / 0 orphan**.

## Scope

2 fichiers (`lean-toolchain` + `lakefile.lean`), +2/−2 lignes. Une PR = un sujet (G.4) : les 4 lakes hors périmètre #11256 (`conway_cgt_lean`, `social_choice_lean_peters`…) ne sont PAS emportés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

