### PR TITLE
feat(ci,#11835): voie rapide en ombre — un checkout pour cinq gardes au lieu de cinq (97% du temps CI est du checkout)

### DIFF
--- a/.github/workflows/fast-lane-shadow.yml
+++ b/.github/workflows/fast-lane-shadow.yml
@@ -1,0 +1,76 @@
+name: Fast lane (ombre)
+
+# VOIE RAPIDE, phase pilote en OMBRE (#11835).
+#
+# Constat qui motive ce workflow, mesure le 2026-08-19 sur les runs du jour,
+# en temps d'etape a l'interieur des jobs (donc hors attente de file) :
+#
+#   Cell-order gate        checkout 225,5 s   analyse  ~1 s   99,1 %
+#   Notebook Navlink       checkout 172,0 s   analyse   3 s   98,0 %
+#   prose-counts-guard     checkout 122,0 s   analyse   1 s   98,4 %
+#   banner-guard           checkout 121,5 s   analyse   2 s   97,2 %
+#   perimeter-review       checkout  64,0 s   analyse   2 s   94,8 %
+#   solution-leak          checkout  63,5 s   analyse 5,5 s   89,4 %
+#
+# Le depot pese 2,1 Go et 46 workflows le clonent avec `fetch-depth: 0`. Un
+# push sur une branche notebook declenche ~46 workflows pour ~235 min de temps
+# de runner, contre 17 runners : le `PR gate` (borne 12 min) expire alors sur
+# des PR SAINES, et c'est ce faux rouge -- pas la diligence des lanes -- qui
+# fait vieillir les PR.
+#
+# Ce workflow paie UN checkout et enchaine les analyses, en emettant un
+# check-run nomme par garde (API Checks) : la granularite visible sur la PR est
+# preservee, seule l'infrastructure est mutualisee.
+#
+# POURQUOI « ombre » : les check-runs sont prefixes `fast-lane (ombre): `, donc
+# ils cohabitent avec les cinq workflows d'origine sans leur voler leur nom ni
+# leur role, et la protection de branche n'est pas touchee. On compare les
+# verdicts sur des PR reelles ; le basculement (retrait des workflows
+# unitaires + reprise des noms canoniques) est un SECOND geste, separe et
+# reversible. Un lot temoin entierement vert serait indiscernable d'un moteur
+# debranche : la comparaison doit inclure au moins une PR rouge par garde.
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened, synchronize, reopened, edited ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write        # emettre un check-run par garde
+
+concurrency:
+  group: fast-lane-shadow-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fast-lane:
+    name: "Fast lane (ombre) -- 5 gardes, 1 checkout"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      # `fetch-depth: 0` est requis ici pour la meme raison que dans les
+      # workflows d'origine (la base doit etre joignable pour les deltas) --
+      # mais il est paye UNE fois pour les cinq gardes au lieu de cinq fois.
+      # Le resserrer est un sujet distinct, suivi dans #11835.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: "Gardes de la voie rapide (verdicts en check-runs nommes)"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FAST_LANE_BASE: origin/${{ github.base_ref }}
+          FAST_LANE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FAST_LANE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FAST_LANE_PR: ${{ github.event.pull_request.number }}
+        run: |
+          git fetch origin "${{ github.base_ref }}" -q
+          python scripts/ci/fast_lane.py --shadow

--- a/scripts/ci/fast_lane.py
+++ b/scripts/ci/fast_lane.py
@@ -1,0 +1,327 @@
+"""Moteur de la VOIE RAPIDE (#11835) -- un checkout, N verdicts nommes.
+
+Contexte et mesures : voir `fast_lane_registry.py`. En deux phrases : dans ce
+depot de 2,1 Go, 89 a 99 % du temps d'un workflow de garde est son
+`actions/checkout`, et 1 a 5 secondes son analyse. Ce moteur paie le checkout
+une fois, enchaine les analyses, et **emet un check-run nomme par garde** via
+l'API Checks pour que la PR conserve exactement la meme granularite de
+verdicts qu'aujourd'hui.
+
+Deroulement :
+
+  phase 1  gardes non-mutants, sur HEAD
+  phase 2  UNE bascule d'arbre vers la base, tous les scans `base` des gardes
+           delta, restauration, puis VERIFICATION que l'arbre est propre
+  phase 3  comparaisons delta, puis emission des check-runs
+
+Le risque propre a la mutualisation est qu'un garde lise l'arbre bascule par
+un autre. Il est traite en phase 2 : bascule unique, restauration verifiee, et
+arret net si l'arbre ne revient pas a son etat -- un verdict rendu sur un arbre
+inconnu vaut moins que pas de verdict du tout.
+
+MODE OMBRE (defaut). Les check-runs sont emis sous un nom prefixe, donc a cote
+des workflows d'origine sans leur voler leur nom ni leur role. On compare les
+verdicts sur des PR reelles ; le basculement (retrait des workflows unitaires,
+reprise des noms canoniques) est un second geste, separe et reversible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from fast_lane_registry import PILOT, Guard  # noqa: E402
+
+SHADOW_PREFIX = "fast-lane (ombre): "
+GUARD_TIMEOUT_S = 600
+OUTPUT_LIMIT = 60000  # marge sous la limite de 65535 de l'API Checks
+
+
+# ---------------------------------------------------------------------------
+# Selection par chemin
+# ---------------------------------------------------------------------------
+
+def path_matches(path: str, pattern: str) -> bool:
+    """Semantique des `paths:` GitHub, pour le sous-ensemble qu'on utilise.
+
+    Le piege est le prefixe `**/` : chez GitHub il matche AUSSI la racine
+    (`**/*.ipynb` couvre `a.ipynb`), alors que `fnmatch` exige le separateur
+    et repondrait False. Un motif qui rate ne leve pas d'erreur -- il rend un
+    ensemble de gardes plus petit, donc un CI plus vert et plus rapide : le
+    faux negatif exact que ce depot a deja paye ailleurs. D'ou le test dedie
+    sur ce cas precis.
+    """
+    path = path.replace(os.sep, "/")
+    if fnmatch.fnmatch(path, pattern):
+        return True
+    if pattern.startswith("**/"):
+        return fnmatch.fnmatch(path, pattern[3:])
+    return False
+
+
+def guard_applies(guard: Guard, changed: list[str]) -> bool:
+    if not guard.paths:
+        return True
+    return any(path_matches(f, p) for f in changed for p in guard.paths)
+
+
+def changed_files(base_ref: str) -> list[str]:
+    out = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        cwd=REPO_ROOT, capture_output=True, text=True,
+    )
+    if out.returncode != 0:
+        raise SystemExit(
+            "[fast-lane] impossible de calculer le diff contre "
+            f"{base_ref} : {out.stderr.strip()}"
+        )
+    return [line.strip() for line in out.stdout.splitlines() if line.strip()]
+
+
+# ---------------------------------------------------------------------------
+# Execution d'un garde
+# ---------------------------------------------------------------------------
+
+def substitute(argv: list[str], ctx: dict[str, str]) -> list[str]:
+    """Remplace les seuls placeholders connus, en laissant les autres accolades.
+
+    Volontairement PAS `str.format` : celui-ci traite toute accolade du token
+    comme un champ de format, donc un garde dont la commande porte un filtre
+    `jq`, un quantificateur de regex `{2,3}` ou un litteral JSON leverait un
+    `KeyError` a l'execution -- une panne d'infrastructure indiscernable, dans
+    le log, d'un verdict de garde. Le registre pilote n'en contient aucun ; a
+    trente gardes il y en aura. On substitue donc par cle nommee et rien
+    d'autre.
+    """
+    out = []
+    for token in argv:
+        for key, value in ctx.items():
+            token = token.replace("{" + key + "}", value)
+        out.append(token)
+    return out
+
+
+def run_argv(argv: list[str], ctx: dict[str, str]) -> tuple[int, str]:
+    cmd = substitute(argv, ctx)
+    started = time.time()
+    try:
+        proc = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True,
+                              text=True, timeout=GUARD_TIMEOUT_S)
+    except subprocess.TimeoutExpired:
+        joined = " ".join(cmd)
+        return 124, f"[fast-lane] delai depasse ({GUARD_TIMEOUT_S}s) : {joined}"
+    elapsed = time.time() - started
+    body = (proc.stdout or "")
+    if proc.stderr:
+        body = body + "\n" + proc.stderr
+    header = " ".join(cmd)
+    return proc.returncode, (
+        f"$ {header}\n(exit {proc.returncode}, {elapsed:.1f}s)\n\n{body}"
+    )
+
+
+def payload_of(log: str) -> str:
+    """Sortie standard seule, sans l'en-tete ajoute par `run_argv`."""
+    parts = log.split("\n\n", 1)
+    return parts[1] if len(parts) == 2 else ""
+
+
+def git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", *args], cwd=REPO_ROOT,
+                          capture_output=True, text=True)
+
+
+def tree_is_clean(paths: list[str]) -> tuple[bool, str]:
+    proc = git("status", "--porcelain", "--", *paths) if paths \
+        else git("status", "--porcelain")
+    return (proc.stdout.strip() == ""), proc.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Emission des check-runs
+# ---------------------------------------------------------------------------
+
+def emit_check_run(repo: str, head_sha: str, name: str, conclusion: str,
+                   title: str, summary: str, dry_run: bool) -> None:
+    payload = {
+        "name": name,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": conclusion,
+        "output": {
+            "title": title[:255],
+            "summary": summary[:OUTPUT_LIMIT],
+        },
+    }
+    if dry_run:
+        print(f"[fast-lane][a-blanc] check-run {name!r} -> {conclusion} ({title})")
+        return
+    proc = subprocess.run(
+        ["gh", "api", "-X", "POST", f"repos/{repo}/check-runs", "--input", "-"],
+        input=json.dumps(payload), capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        # Ne pas faire echouer le job entier : un verdict non publie doit
+        # rester visible dans le log plutot que de masquer les autres.
+        print(f"[fast-lane] ECHEC de publication du check-run {name!r} : "
+              f"{proc.stderr.strip()}", file=sys.stderr)
+    else:
+        print(f"[fast-lane] check-run publie : {name} -> {conclusion}")
+
+
+def conclusion_for(guard: Guard, rc: int) -> str:
+    if rc == 0:
+        return "success"
+    return "failure" if guard.blocking else "neutral"
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Voie rapide CI (#11835)")
+    parser.add_argument("--base-ref",
+                        default=os.environ.get("FAST_LANE_BASE", "origin/main"))
+    parser.add_argument("--base-sha",
+                        default=os.environ.get("FAST_LANE_BASE_SHA", ""))
+    parser.add_argument("--head-sha",
+                        default=os.environ.get("FAST_LANE_HEAD_SHA", ""))
+    parser.add_argument("--pr-number",
+                        default=os.environ.get("FAST_LANE_PR", ""))
+    parser.add_argument("--repo",
+                        default=os.environ.get("GITHUB_REPOSITORY",
+                                               "jsboige/CoursIA"))
+    parser.add_argument("--shadow", action="store_true", default=True,
+                        help="prefixer les noms de check-run (defaut pilote)")
+    parser.add_argument("--no-shadow", dest="shadow", action="store_false")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="ne rien publier ; afficher les verdicts")
+    parser.add_argument("--only", default="",
+                        help="ne lancer qu'un garde, par nom")
+    args = parser.parse_args(argv)
+
+    changed = changed_files(args.base_ref)
+    print(f"[fast-lane] {len(changed)} fichier(s) modifie(s) "
+          f"contre {args.base_ref}")
+
+    guards = [g for g in PILOT if not args.only or g.name == args.only]
+    selected = [g for g in guards if guard_applies(g, changed)]
+    for guard in guards:
+        if guard not in selected:
+            print(f"[fast-lane] hors perimetre (filtre paths) : {guard.name}")
+
+    ctx = {
+        "base_ref": args.base_ref,
+        "base_sha": args.base_sha,
+        "head_sha": args.head_sha,
+        "pr_number": args.pr_number,
+        "base_json": "",
+        "head_json": "",
+    }
+    results: dict[str, tuple[int, str]] = {}
+    head_json: dict[str, str] = {}
+    tmp = Path(os.environ.get("RUNNER_TEMP") or (REPO_ROOT / ".fast-lane-tmp"))
+    tmp.mkdir(parents=True, exist_ok=True)
+
+    # -- phase 1 : HEAD, aucun garde ne mute l'arbre -------------------------
+    for guard in selected:
+        rc, log = run_argv(guard.argv, ctx)
+        if guard.delta_argv:
+            dest = tmp / f"{guard.name}.head.json"
+            dest.write_text(payload_of(log), encoding="utf-8")
+            head_json[guard.name] = str(dest)
+            print(f"[fast-lane] phase 1 (HEAD) {guard.name} : scan capture")
+        else:
+            results[guard.name] = (rc, log)
+            print(f"[fast-lane] phase 1 {guard.name} : exit {rc}")
+
+    # -- phase 2 : UNE bascule pour tous les gardes delta --------------------
+    delta_guards = [g for g in selected if g.delta_argv]
+    base_json: dict[str, str] = {}
+    if delta_guards:
+        swap = sorted({p for g in delta_guards for p in g.swap_paths})
+        if not args.base_sha:
+            print("[fast-lane] pas de base-sha : phase delta ignoree",
+                  file=sys.stderr)
+        else:
+            print(f"[fast-lane] phase 2 : bascule de {swap} "
+                  f"vers {args.base_sha[:12]}")
+            swapped = git("checkout", args.base_sha, "--", *swap)
+            if swapped.returncode != 0:
+                raise SystemExit("[fast-lane] bascule impossible : "
+                                 f"{swapped.stderr.strip()}")
+            try:
+                for guard in delta_guards:
+                    _, log = run_argv(guard.argv, ctx)
+                    dest = tmp / f"{guard.name}.base.json"
+                    dest.write_text(payload_of(log), encoding="utf-8")
+                    base_json[guard.name] = str(dest)
+            finally:
+                git("checkout", "HEAD", "--", *swap)
+            clean, dirt = tree_is_clean(swap)
+            if not clean:
+                # Arret net : les verdicts suivants porteraient sur un arbre
+                # dont on ne sait plus ce qu'il contient.
+                raise SystemExit(
+                    "[fast-lane] l'arbre n'est PAS revenu a son etat apres la "
+                    f"bascule -- aucun verdict ne sera publie.\n{dirt}"
+                )
+            print("[fast-lane] phase 2 : arbre restaure et verifie")
+
+    # -- phase 3 : comparaisons delta ---------------------------------------
+    for guard in delta_guards:
+        if guard.name not in base_json:
+            results[guard.name] = (
+                0, "[fast-lane] phase delta non executee (pas de base)")
+            continue
+        local = dict(ctx, base_json=base_json[guard.name],
+                     head_json=head_json[guard.name])
+        rc, log = run_argv(guard.delta_argv, local)
+        results[guard.name] = (rc, log)
+        print(f"[fast-lane] phase 3 {guard.name} : exit {rc}")
+
+    # -- emission ------------------------------------------------------------
+    head_sha = args.head_sha or git("rev-parse", "HEAD").stdout.strip()
+    blocking_failed = False
+    for guard in selected:
+        rc, log = results.get(guard.name, (0, "(aucune sortie)"))
+        conclusion = conclusion_for(guard, rc)
+        if rc == 0:
+            title = "OK"
+        elif guard.blocking:
+            title = "echec"
+        else:
+            title = "signale (advisory)"
+        name = (SHADOW_PREFIX + guard.name) if args.shadow else guard.name
+        emit_check_run(
+            args.repo, head_sha, name, conclusion,
+            f"{guard.name} -- {title}",
+            f"Source : `{guard.source}`\n\n```\n{log}\n```",
+            args.dry_run,
+        )
+        if guard.blocking and rc != 0:
+            blocking_failed = True
+
+    verdict = ("au moins un bloquant en echec" if blocking_failed
+               else "aucun bloquant en echec")
+    print(f"[fast-lane] {len(selected)} garde(s) evalue(s), {verdict}")
+
+    # En mode ombre le job ne rougit jamais : il observe, il ne juge pas
+    # encore. Les verdicts vivent dans les check-runs.
+    if args.shadow:
+        return 0
+    return 1 if blocking_failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/fast_lane_registry.py
+++ b/scripts/ci/fast_lane_registry.py
@@ -1,0 +1,150 @@
+"""Registre des gardes de la VOIE RAPIDE (#11835).
+
+Motivation mesuree (2026-08-19) : dans les workflows de garde de ce depot,
+`actions/checkout` represente **89 a 99 %** du temps d'execution, et l'analyse
+elle-meme 1 a 5 secondes -- parce que le depot pese 2,1 Go et que 46 workflows
+le clonent avec `fetch-depth: 0`. Chaque garde qui lit trois lignes de diff
+paie donc un clone integral.
+
+    Cell-order gate        checkout 225,5 s   travail  ~1 s   99,1 %
+    Notebook Navlink       checkout 172,0 s   travail   3 s   98,0 %
+    prose-counts-guard     checkout 122,0 s   travail   1 s   98,4 %
+    banner-guard           checkout 121,5 s   travail   2 s   97,2 %
+    perimeter-review       checkout  64,0 s   travail   2 s   94,8 %
+    solution-leak          checkout  63,5 s   travail 5,5 s   89,4 %
+
+La voie rapide paie **un** checkout puis enchaine les analyses dans le meme
+job, en emettant **un check-run nomme par garde** via l'API Checks : la
+granularite visible sur la PR est preservee (protection de branche, surfaces
+de review B.0), seule l'infrastructure est mutualisee.
+
+Ce module ne contient QUE des donnees : la mecanique est dans `fast_lane.py`,
+ce qui rend le registre lisible et testable sans executer quoi que ce soit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Guard:
+    """Un garde de la voie rapide.
+
+    name        Nom EXACT du check-run emis. En phase pilote il est prefixe
+                par `shadow_prefix` (cf fast_lane.py) pour cohabiter avec le
+                workflow d'origine sans lui voler son nom.
+    paths       Globs (syntaxe fnmatch, evaluee sur des chemins POSIX
+                relatifs a la racine). Vide = le garde tourne toujours.
+                Reproduit le bloc `paths:` du workflow d'origine -- la
+                difference est qu'ici c'est du code, donc testable.
+    argv        Commande a executer, deja decoupee (pas de shell : un shell
+                introduirait une seconde couche de quoting sur des chemins
+                qui viennent du diff).
+    blocking    True  -> un echec doit rougir la PR (conclusion `failure`).
+                False -> advisory : le verdict est publie, jamais bloquant
+                (conclusion `neutral`), conformement au caractere annonce du
+                workflow d'origine. Neutraliser un advisory en `success`
+                effacerait le signal ; le rendre `failure` mentirait sur son
+                statut.
+    needs_base  Le garde compare HEAD a la base : le runner lui garantit que
+                `origin/<base_ref>` est joignable.
+    delta_argv  Present => le garde est un DELTA en trois temps : `argv` est
+                execute sur HEAD (sa sortie standard est capturee comme
+                `head.json`), puis sur l'arbre bascule a la base
+                (`base.json`), puis `delta_argv` compare les deux. Le
+                placeholder `{base_json}` / `{head_json}` y est substitue.
+    swap_paths  Sous-arbres a basculer a la base pour la phase 2. Le
+                basculement est MUTANT : c'est le seul danger propre a la
+                mutualisation d'un job, puisqu'un garde pourrait lire l'arbre
+                d'un autre. Le runner y repond par trois mesures -- les
+                gardes non-mutants passent tous AVANT, la bascule est faite
+                UNE fois pour tous les gardes delta (au lieu d'une par garde
+                aujourd'hui), et la restauration est **verifiee** avant de
+                rendre le moindre verdict.
+    source      Workflow d'origine, pour que la correspondance reste tracable
+                quand on retirera le workflow unitaire.
+    """
+
+    name: str
+    argv: list[str]
+    source: str
+    paths: list[str] = field(default_factory=list)
+    blocking: bool = True
+    needs_base: bool = False
+    delta_argv: list[str] = field(default_factory=list)
+    swap_paths: list[str] = field(default_factory=list)
+
+
+NOTEBOOK_GLOBS = ["**/*.ipynb"]
+
+# ---------------------------------------------------------------------------
+# Lot pilote (#11835). Cinq gardes choisis pour couvrir les quatre formes que
+# le moteur doit savoir traiter, et non pour leur nombre :
+#
+#   - banner-guard        : bloquant, scan global, sans base
+#   - pip-leak-guard      : bloquant, delta HEAD-vs-base
+#   - solution-leak-guard : ADVISORY, delta HEAD-vs-base (verifie qu'un
+#                           advisory ne peut pas rougir par accident)
+#   - prose-counts-guard  : advisory, diff-range direct
+#   - perimeter-review    : bloquant, appelle l'API GitHub (a besoin de
+#                           GH_TOKEN, pas seulement de l'arbre)
+#
+# Un lot homogene aurait valide le moteur sur un seul cas de figure -- et un
+# lot entierement vert serait indiscernable d'un moteur debranche.
+# ---------------------------------------------------------------------------
+PILOT: list[Guard] = [
+    Guard(
+        name="banner-guard",
+        source="banner-guard.yml",
+        paths=NOTEBOOK_GLOBS + [
+            "scripts/notebook_tools/strip_probe_banner.py",
+            ".github/workflows/banner-guard.yml",
+        ],
+        argv=[
+            "python", "scripts/notebook_tools/strip_probe_banner.py",
+            "--scan-all", "--check", "--exclude-submodules",
+        ],
+        blocking=True,
+    ),
+    Guard(
+        name="pip-leak-guard",
+        source="pip-leak-guard.yml",
+        paths=NOTEBOOK_GLOBS,
+        argv=["python", "scripts/notebook_tools/audit_pip_install_cells.py",
+              "--scan-all", "--json"],
+        delta_argv=["python", "scripts/notebook_tools/pip_leak_delta.py",
+                    "{base_json}", "{head_json}"],
+        swap_paths=["MyIA.AI.Notebooks"],
+        blocking=True,
+        needs_base=True,
+    ),
+    Guard(
+        name="solution-leak-guard",
+        source="solution-leak-guard.yml",
+        paths=NOTEBOOK_GLOBS,
+        argv=["python", "scripts/notebook_tools/audit_solution_leaks.py", "--json"],
+        delta_argv=["python", "scripts/notebook_tools/solution_leak_delta.py",
+                    "{base_json}", "{head_json}"],
+        swap_paths=["MyIA.AI.Notebooks"],
+        blocking=False,          # WARN phase (#8053) -- ne rougit jamais
+        needs_base=True,
+    ),
+    Guard(
+        name="prose-counts-guard",
+        source="prose-counts-guard.yml",
+        paths=["**/*.ipynb", "**/*.md"],
+        argv=["python", "scripts/notebook_tools/check_prose_quantitative_claims.py",
+              "--diff", "{base_ref}...HEAD"],
+        blocking=False,          # ADVISORY tant que #9377 n'est pas resorbe
+        needs_base=True,
+    ),
+    Guard(
+        name="perimeter-review-guard",
+        source="perimeter-review-guard.yml",
+        paths=[],                # sans filtre : porte sur le corps de la PR
+        argv=["python", "scripts/check_pr_perimeter.py", "{pr_number}",
+              "--scan-thread"],
+        blocking=True,
+    ),
+]

--- a/scripts/tests/test_fast_lane.py
+++ b/scripts/tests/test_fast_lane.py
@@ -1,0 +1,252 @@
+"""Tests du moteur de voie rapide (#11835).
+
+Trois proprietes sont sous test, et deux d'entre elles existent parce que le
+depot a deja paye leur violation ailleurs :
+
+1. **La selection par chemin ne doit pas SOUS-selectionner.** Un motif qui
+   rate ne leve pas d'erreur : il rend moins de gardes, donc un CI plus vert
+   et plus rapide. C'est la forme de defaut la plus difficile a voir, et
+   `**/*.ipynb` contre un fichier a la racine en est le cas exact.
+2. **Un garde advisory ne doit JAMAIS rougir**, et ne doit pas non plus etre
+   blanchi en `success` : son verdict est `neutral`, sinon on perd le signal
+   dans un sens ou dans l'autre.
+3. **La restauration de l'arbre apres la bascule de base est verifiee**, et
+   son echec interrompt tout plutot que de publier des verdicts calcules sur
+   un arbre inconnu.
+
+Les cas positifs (un garde qui echoue doit produire `failure`) sont aussi
+couverts : une suite ou tout passe serait indiscernable d'un moteur debranche.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CI_DIR = Path(__file__).resolve().parents[1] / "ci"
+sys.path.insert(0, str(CI_DIR))
+
+import fast_lane  # noqa: E402
+from fast_lane_registry import PILOT, Guard  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 1. Selection par chemin
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("path,pattern,expected", [
+    # le cas qui motive la fonction : `**/` couvre AUSSI la racine chez GitHub
+    ("a.ipynb", "**/*.ipynb", True),
+    ("MyIA.AI.Notebooks/x/y.ipynb", "**/*.ipynb", True),
+    ("docs/z.md", "**/*.md", True),
+    ("README.md", "**/*.md", True),
+    # negatifs : le filtre doit rester un filtre
+    ("scripts/foo.py", "**/*.ipynb", False),
+    ("a.ipynbx", "**/*.ipynb", False),
+    # chemin exact
+    ("scripts/notebook_tools/strip_probe_banner.py",
+     "scripts/notebook_tools/strip_probe_banner.py", True),
+    ("scripts/notebook_tools/other.py",
+     "scripts/notebook_tools/strip_probe_banner.py", False),
+])
+def test_path_matches(path, pattern, expected):
+    assert fast_lane.path_matches(path, pattern) is expected
+
+
+def test_path_matches_accepts_windows_separators():
+    """Le diff peut arriver avec des separateurs natifs selon l'appelant."""
+    assert fast_lane.path_matches("MyIA.AI.Notebooks\\x\\y.ipynb", "**/*.ipynb")
+
+
+def test_guard_without_paths_always_applies():
+    guard = Guard(name="g", argv=["true"], source="s", paths=[])
+    assert fast_lane.guard_applies(guard, []) is True
+    assert fast_lane.guard_applies(guard, ["n/importe/quoi.txt"]) is True
+
+
+def test_guard_with_paths_is_skipped_when_nothing_matches():
+    guard = Guard(name="g", argv=["true"], source="s", paths=["**/*.ipynb"])
+    assert fast_lane.guard_applies(guard, ["docs/a.md"]) is False
+    assert fast_lane.guard_applies(guard, ["docs/a.md", "x/b.ipynb"]) is True
+
+
+def test_notebook_guards_select_a_root_level_notebook():
+    """Controle de bout en bout du piege `**/` sur le registre reel."""
+    changed = ["Notebook-A-La-Racine.ipynb"]
+    selected = [g.name for g in PILOT if fast_lane.guard_applies(g, changed)]
+    for expected in ("banner-guard", "pip-leak-guard", "solution-leak-guard",
+                     "prose-counts-guard"):
+        assert expected in selected, (
+            f"{expected} devrait couvrir un notebook a la racine "
+            "(motif `**/*.ipynb`)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Conclusions -- controle positif ET negatif
+# ---------------------------------------------------------------------------
+
+def test_blocking_guard_failure_is_a_failure():
+    guard = Guard(name="g", argv=["true"], source="s", blocking=True)
+    assert fast_lane.conclusion_for(guard, 1) == "failure"
+
+
+def test_advisory_guard_failure_is_neutral_not_failure_nor_success():
+    guard = Guard(name="g", argv=["true"], source="s", blocking=False)
+    concl = fast_lane.conclusion_for(guard, 1)
+    assert concl == "neutral"
+    assert concl != "failure", "un advisory ne doit jamais rougir la PR"
+    assert concl != "success", "un advisory en echec ne doit pas etre blanchi"
+
+
+def test_success_is_success_for_both_kinds():
+    for blocking in (True, False):
+        guard = Guard(name="g", argv=["true"], source="s", blocking=blocking)
+        assert fast_lane.conclusion_for(guard, 0) == "success"
+
+
+# ---------------------------------------------------------------------------
+# 3. Coherence du registre avec les workflows d'origine
+# ---------------------------------------------------------------------------
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / ".github" / "workflows"
+
+
+def test_every_pilot_guard_names_an_existing_workflow():
+    for guard in PILOT:
+        assert (WORKFLOWS / guard.source).is_file(), (
+            f"{guard.name} declare provenir de {guard.source}, absent du depot"
+        )
+
+
+def test_delta_guards_declare_what_they_swap():
+    """Sans `swap_paths`, la phase 2 basculerait un ensemble vide et le delta
+    comparerait HEAD a lui-meme -- un vert silencieux."""
+    for guard in PILOT:
+        if guard.delta_argv:
+            assert guard.swap_paths, (
+                f"{guard.name} est un delta sans swap_paths : sa phase base "
+                "scannerait HEAD et le delta serait toujours vide"
+            )
+
+
+def test_delta_placeholders_are_resolvable():
+    ctx = {"base_ref": "origin/main", "base_sha": "abc", "head_sha": "def",
+           "pr_number": "1", "base_json": "/tmp/b.json",
+           "head_json": "/tmp/h.json"}
+    for guard in PILOT:
+        fast_lane.substitute(guard.argv, ctx)
+        if guard.delta_argv:
+            resolved = fast_lane.substitute(guard.delta_argv, ctx)
+            assert "/tmp/b.json" in resolved and "/tmp/h.json" in resolved
+
+
+def test_advisory_flags_match_the_source_workflows():
+    """Le caractere advisory est une propriete du garde, pas du moteur.
+
+    `solution-leak-guard` et `prose-counts-guard` sont annonces advisory dans
+    l'en-tete de leur workflow ; les inverser ici ferait rougir la flotte sur
+    un stock que le depot a explicitement decide de ne pas bloquer.
+    """
+    by_name = {g.name: g for g in PILOT}
+    assert by_name["solution-leak-guard"].blocking is False
+    assert by_name["prose-counts-guard"].blocking is False
+    assert by_name["banner-guard"].blocking is True
+    assert by_name["pip-leak-guard"].blocking is True
+    assert by_name["perimeter-review-guard"].blocking is True
+
+
+# ---------------------------------------------------------------------------
+# 4. Execution et capture
+# ---------------------------------------------------------------------------
+
+def test_run_argv_captures_exit_code_and_output():
+    rc, log = fast_lane.run_argv(
+        [sys.executable, "-c", "import sys; print('bonjour'); sys.exit(3)"], {})
+    assert rc == 3
+    assert "bonjour" in log
+    assert "exit 3" in log
+
+
+def test_payload_of_strips_the_header_added_by_run_argv():
+    rc, log = fast_lane.run_argv(
+        [sys.executable, "-c", "print('{\"k\": 1}')"], {})
+    assert rc == 0
+    assert fast_lane.payload_of(log).strip() == '{"k": 1}'
+
+
+def test_substitute_leaves_unknown_braces_alone():
+    """Regression : `str.format` aurait leve KeyError sur ces trois formes.
+
+    Aucune n'est dans le registre pilote ; toutes apparaitront quand il
+    grossira (filtre jq, quantificateur regex, litteral JSON). L'echec serait
+    une panne d'infrastructure que le log rendrait indiscernable d'un verdict.
+    """
+    ctx = {"pr_number": "42", "base_ref": "origin/main"}
+    argv = ['.workflow_runs[] | {n: .name}', 'a{2,3}b', '{"k": 1}',
+            '--pr', '{pr_number}']
+    assert fast_lane.substitute(argv, ctx) == [
+        '.workflow_runs[] | {n: .name}', 'a{2,3}b', '{"k": 1}', '--pr', '42']
+
+
+def test_run_argv_reports_timeout_as_a_verdict_not_an_exception(monkeypatch):
+    monkeypatch.setattr(fast_lane, "GUARD_TIMEOUT_S", 1)
+    rc, log = fast_lane.run_argv(
+        [sys.executable, "-c", "import time; time.sleep(30)"], {})
+    assert rc == 124
+    assert "delai depasse" in log
+
+
+# ---------------------------------------------------------------------------
+# 5. Verification de restauration d'arbre
+# ---------------------------------------------------------------------------
+
+def test_tree_is_clean_detects_a_dirty_path(tmp_path, monkeypatch):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / "f.txt").write_text("un", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", "f.txt"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "-c", "user.email=t@t",
+                    "-c", "user.name=t", "commit", "-qm", "init"], check=True)
+    monkeypatch.setattr(fast_lane, "REPO_ROOT", tmp_path)
+
+    clean, dirt = fast_lane.tree_is_clean(["f.txt"])
+    assert clean is True and dirt == ""
+
+    (tmp_path / "f.txt").write_text("deux", encoding="utf-8")
+    clean, dirt = fast_lane.tree_is_clean(["f.txt"])
+    assert clean is False
+    assert "f.txt" in dirt
+
+
+# ---------------------------------------------------------------------------
+# 6. Emission
+# ---------------------------------------------------------------------------
+
+def test_dry_run_publishes_nothing(capsys, monkeypatch):
+    def explode(*a, **k):  # pragma: no cover - doit rester non appele
+        raise AssertionError("aucun appel reseau ne doit avoir lieu a blanc")
+    monkeypatch.setattr(subprocess, "run", explode)
+    fast_lane.emit_check_run("o/r", "sha", "n", "success", "t", "s",
+                             dry_run=True)
+    assert "a-blanc" in capsys.readouterr().out
+
+
+def test_summary_is_truncated_below_the_api_limit(monkeypatch):
+    captured = {}
+
+    class Fake:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, **kwargs):
+        captured["payload"] = kwargs.get("input", "")
+        return Fake()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    fast_lane.emit_check_run("o/r", "sha", "n", "success", "t", "x" * 200000,
+                             dry_run=False)
+    assert len(captured["payload"]) < 70000


### PR DESCRIPTION
Grain: DEEP/tooling — lane myia-ai-01:CoursIA — prev: MED/lean #11760

## Le constat

Mesure du 2026-08-19, **temps par etape a l'interieur des jobs** (donc hors
attente de file — du temps de runner reellement brule) :

| workflow | `actions/checkout` | analyse | part du checkout |
|---|---:|---:|---:|
| Cell-order gate | 225,5 s | ~1 s | **99,1 %** |
| Notebook Navlink Check | 172,0 s | 3 s | **98,0 %** |
| prose-counts-guard | 122,0 s | 1 s | **98,4 %** |
| banner-guard | 121,5 s | 2 s | **97,2 %** |
| solution-leak-guard | 63,5 s | 5,5 s | **89,4 %** |
| perimeter-review-guard | 64,0 s | 2 s | **94,8 %** |

Cause structurelle : le depot pese **2,1 Go** et **46 workflows** le clonent
avec `fetch-depth: 0`. Chaque garde qui lit trois lignes de diff paie un clone
integral.

```
~46 workflows par push sur une branche notebook
~235 min de temps-runner par push complet
  17 runners
~8 branches actives  ->  ~112 min de saturation pleine flotte
```

Le `PR gate` a une borne de 12 min : il expire sur des PR **saines**. C'est ce
faux rouge — pas la diligence des lanes — qui fait vieillir les PR, le
prejudice que le mandat courant nomme explicitement.

## Ce que fait cette PR

Un moteur de **voie rapide** : un checkout, N verdicts nommes.

- **phase 1** — les gardes non-mutants tournent sur HEAD ;
- **phase 2** — **UNE** bascule d'arbre vers la base pour tous les gardes
  delta (au lieu d'une par garde aujourd'hui), restauration, puis
  **verification** que l'arbre est revenu a son etat. C'est le seul danger
  propre a la mutualisation — un garde qui lirait l'arbre bascule par un
  autre — et il est traite par un arret net : un verdict rendu sur un arbre
  inconnu vaut moins que pas de verdict ;
- **phase 3** — comparaisons delta, puis emission.

**La granularite n'est pas perdue** : un check-run est emis **par garde** via
l'API Checks, donc la PR affiche toujours ses checks nommes, la protection de
branche continue de fonctionner et les surfaces de review B.0 restent
intactes. Seule l'infrastructure est mutualisee.

Effet secondaire non-negligeable : les filtres de chemin deviennent **du code
testable** (un registre) au lieu de blocs `paths:` YAML dupliques qu'aucun
test ne couvre.

## Pourquoi ces cinq gardes

Pour couvrir les **quatre formes** que le moteur doit savoir traiter, pas pour
le nombre :

| garde | forme exercee |
|---|---|
| `banner-guard` | bloquant, scan global, sans base |
| `pip-leak-guard` | bloquant, delta HEAD-vs-base |
| `solution-leak-guard` | **advisory**, delta (verifie qu'un advisory ne peut pas rougir) |
| `prose-counts-guard` | advisory, plage de diff directe |
| `perimeter-review-guard` | bloquant, appelle l'API GitHub (a besoin du token, pas seulement de l'arbre) |

Un lot homogene aurait valide un seul cas de figure.

## Mode OMBRE — rien n'est debranche

Les check-runs sont prefixes `fast-lane (ombre): `. Ils **cohabitent** avec les
cinq workflows d'origine sans leur voler leur nom ni leur role ; la protection
de branche n'est pas touchee. On compare les verdicts sur des PR reelles, et
le basculement (retrait des workflows unitaires + reprise des noms canoniques)
est un **second geste**, separe et reversible.

Critere de sortie du pilote : les cinq verdicts doivent coincider avec ceux des
workflows d'origine sur un lot temoin **comprenant au moins une PR rouge par
garde**. Un lot entierement vert serait indiscernable d'un moteur debranche.

## Le gain, mesure et non extrapole

Pour **ces cinq gardes** : 646 s de temps-runner aujourd'hui
(125+258+71+124+68) contre **~230 s** en voie rapide, soit **~2,8x**. Pas 25x :
ce lot contient les deux analyses les plus lourdes du depot
(`audit_pip_install_cells` et `audit_solution_leaks`, ~17 s chacune, x2 pour le
delta), choisies pour la couverture de formes et non pour le ratio.

Le facteur ~20x concerne l'**extension** aux ~25 gardes de diff pur (analyse de
1 a 5 s, checkout de ~130 s) : ~3250 s aujourd'hui contre ~40 s d'analyse
cumulee. Ce n'est pas le pilote qui rapporte, c'est ce qu'il autorise.

## Tests — 26, dont deux qui ferment un defaut invisible

`python -m pytest scripts/tests/test_fast_lane.py` → **26 passed**.

Deux d'entre eux existent parce que le defaut qu'ils ferment **ne se signale
pas tout seul** :

1. **`**/*.ipynb` doit couvrir un notebook a la RACINE.** `fnmatch` repond non
   (il exige le separateur), GitHub repond oui. Un motif qui rate ne leve pas
   d'erreur : il rend **moins** de gardes selectionnes, donc un CI **plus vert
   et plus rapide** — exactement le faux negatif que ce depot a deja paye
   ailleurs.
2. **La substitution de placeholders n'utilise pas `str.format`.** Le test
   `test_payload_of_...` a fait tomber la premiere version avec
   `KeyError: '"k"'` sur un litteral JSON : `str.format` traite **toute**
   accolade comme un champ. Aucun garde du pilote n'en porte ; a trente gardes
   il y en aura (filtre `jq`, quantificateur `{2,3}`, litteral JSON), et
   l'echec serait une panne d'infrastructure que le log rendrait
   indiscernable d'un verdict de garde.

Le reste couvre les controles positifs **et** negatifs : un garde bloquant en
echec doit rendre `failure`, un advisory en echec doit rendre `neutral` — ni
`failure` (il mentirait sur son statut) ni `success` (il effacerait le signal).

## Perimetre

**4 fichiers, tous nouveaux, aucune suppression** — dont **un** fichier sous
`.github/workflows/**`, `fast-lane-shadow.yml` :

```
.github/workflows/fast-lane-shadow.yml    76 +
scripts/ci/fast_lane.py                  327 +
scripts/ci/fast_lane_registry.py         150 +
scripts/tests/test_fast_lane.py          252 +
```

Aucun workflow existant n'est modifie ni retire, aucun notebook n'est touche,
aucune protection de branche n'est changee.

## Origine

Demande directe du user : « ne pourrait-on organiser notre CI pour qu'il
fonctionne un peu comme ca ? » — le patron double-canal de semantic-fleet
(journaliser tout ce qui passe en synchrone, maintenir une file pour le
traitement lourd). C'est exactement la forme retenue : la voie rapide
**journalise chaque verdict individuellement** en quelques minutes, la voie
lourde (lakes Lean, papermill, .NET, Quarto, CodeQL) garde sa file.

Cette PR remplace le steer « levez le pied sur les pushes » que j'avais envoye
aux lanes : throttler les producteurs traite le symptome et laisse vieillir les
PR — ce que le mandat interdit. La capacite se gagne en cessant de cloner
2,1 Go trente fois par push.

See #11835. See #11791.
