### PR TITLE
fix(pr-gate,#11793): add red-only-at-reread test, fix docstring, dedup header

### DIFF
--- a/scripts/tests/test_pr_gate.py
+++ b/scripts/tests/test_pr_gate.py
@@ -259,7 +259,9 @@ def test_wait_loop_times_out_into_a_failure():
 # `FAIL -- timed out waiting for: (none listed)` even though the set is fully
 # green. The fix is a final re-read at the deadline: an empty `pending` AND
 # empty `bad` after the re-read is treated as a clean settle (after the rule-8
-# canary). Acceptance tests below pin the four cases listed in #11751.
+# canary). Acceptance tests below pin the cases listed in #11751 (the four
+# originally enumerated by the issue, plus the red-only-at-reread control
+# added by #11793 to exercise the `if final_bad:` deadline branch).
 
 
 def test_11751_phantom_fail_recovers_when_constituent_settles_in_gap():
@@ -309,12 +311,13 @@ def test_11751_genuine_still_pending_named_after_reread():
 
 
 def test_11751_red_constituent_observed_in_reread_is_not_a_pass():
-    """A check that flips red between polls is reported by name.
+    """A red observed in the LOOP (fail-fast path) is reported by name.
 
     Negative control for the recovery path: an all-green gate would be
-    indistinguishable from a gate that lost track of a red. The re-read uses
-    the same `classify` path that runs in the loop, so a red observed at the
-    re-read is reported exactly like a red observed in any other poll.
+    indistinguishable from a gate that lost track of a red. The fail-fast
+    branch `if bad:` at the top of the loop reports a red observed at any
+    poll by name -- this test pins that path (a red seen at poll 1, before
+    the deadline re-read ever runs).
     """
     def fetch(_repo, _sha):
         return [run("Broken CI", "failure", status="completed")]
@@ -325,6 +328,43 @@ def test_11751_red_constituent_observed_in_reread_is_not_a_pass():
     )
     assert code == 1
     assert "Broken CI" in msg
+
+
+def test_11751_red_appearing_only_at_reread_is_reported_by_name():
+    """A red observed ONLY at the deadline re-read is reported by name.
+
+    Companion to the previous test (#11793 N1). The fail-fast `if bad:` at the
+    top of the loop covers a red seen at any poll; this test pins the
+    deadline re-read branch `if final_bad:` -- the one that protects against
+    a constituent flipping red in the gap between the last poll and the
+    re-read. Without it, the recovery path (`if not final_pending and not
+    final_bad`) could mask a fresh red by routing it through the
+    already-settled happy path. The fetch mock yields:
+
+      poll 1: 1 pending  (constituent still in flight at last poll)
+      re-read: 1 failure (constituent completes red in the gap)
+
+    Verdict must be FAIL with the constituent named -- not the `(none listed)`
+    placeholder the pre-#11751 code emitted.
+    """
+    polls = []
+
+    def fetch(_repo, _sha):
+        polls.append(1)
+        return {1: [run("Slow CI", None, status="in_progress")]}.get(
+            len(polls),
+            [run("Slow CI", "failure", status="completed")],
+        )
+
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=0, poll_sec=0,
+        settle_polls=2, sleep=lambda _s: None, fetch=fetch, now=_clock(),
+    )
+    assert code == 1, msg
+    assert "Slow CI" in msg, (
+        "a red appearing at the deadline re-read must be named, not hidden"
+    )
+    assert len(polls) == 2, "the deadline path must trigger exactly one re-read"
 
 
 def test_11751_no_path_emits_none_listed_placeholder():
@@ -344,9 +384,6 @@ def test_11751_no_path_emits_none_listed_placeholder():
         "an empty unsettled verdict must declare itself a gate bug, "
         "not look like a benign display"
     )
-
-
-# --- legacy commit statuses --------------------------------------------------
 
 
 # --- legacy commit statuses --------------------------------------------------


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet #11806

# fix(pr-gate,#11793): un 5� test exerce la branche deadline `if final_bad:`, docstring test 3 corrigé, header legacy dedoublé

Traite **#11793**, les deux nits de NanoClaw sur la PR #11765 (fix #11751).

## N1 — le contrôle négatif du re-read n'exerçait pas la branche `if final_bad:`

Le test existant `test_11751_red_constituent_observed_in_reread_is_not_a_pass` avait un `fetch` **constant** (la rouge est là dès le 1ᵉʳ poll). C'est le fail-fast `if bad:` en tête de boucle qui produisait le verdict — la branche **`if final_bad:`** du bloc d'échéance, celle que le test prétendait couvrir, n'était **jamais atteinte**.

Vérifié : avant cette PR, sur `main`, le test passe aussi bien avec la branche `if final_bad:` correctement codée (FAIL par nom) qu'avec une variante qui la remplace par un `pass` silencieux (PASS). **Test vert des deux côtés d'un fix = test qui ne prouve rien.**

### Le nouveau test : `test_11751_red_appearing_only_at_reread_is_reported_by_name`

Le `fetch` produit deux phases distinctes :

```python
phases = iter([
    [run("Slow CI", None, status="in_progress")],     # poll 1 : pending
    [run("Slow CI", "failure", status="completed")],  # re-read : rouge
])
```

Le poll 1 met `pending=["Slow CI"]`, `quiet_streak=0`, et le deadline (`timeout_min=0`, `now()` avance de 10 s à chaque appel) tire avant le poll 2. Le code entre donc dans la branche d'échéance, `fetch` re-lit, et `final_bad=["Slow CI"]` — c'est **exactement** la séquence dangereuse pour laquelle le contrôle négatif existe : un constituant qui flipe au rouge **dans le gap** entre le dernier poll et la re-read.

**Vérification du contrôle positif** : la branche `if final_bad:` a été temporairement remplacée par `return 0, "PASS -- swallowed"` dans `scripts/pr_gate.py`, le test a été lancé, et il a **échoué** avec `code=0` au lieu du `code=1` attendu. La branche étant restaurée, le test repasse. Le nouveau test rougit au bon moment, et seulement au bon moment.

```diff
+def test_11751_red_appearing_only_at_reread_is_reported_by_name():
+    """A red observed ONLY at the deadline re-read is reported by name.
+
+    Companion to the previous test (#11793 N1). The fail-fast `if bad:` at the
+    top of the loop covers a red seen at any poll; this test pins the
+    deadline re-read branch `if final_bad:` -- the one that protects against
+    a constituent flipping red in the gap between the last poll and the
+    re-read. Without it, the recovery path (`if not final_pending and not
+    final_bad`) could mask a fresh red by routing it through the
+    already-settled happy path.
+    ...
+    """
+    polls = []
+    def fetch(_repo, _sha):
+        polls.append(1)
+        return {1: [run("Slow CI", None, status="in_progress")]}.get(
+            len(polls),
+            [run("Slow CI", "failure", status="completed")],
+        )
+    code, msg = pr_gate.wait_and_decide(
+        "o/r", "sha", "PR gate", timeout_min=0, poll_sec=0,
+        settle_polls=2, sleep=lambda _s: None, fetch=fetch, now=_clock(),
+    )
+    assert code == 1, msg
+    assert "Slow CI" in msg
+    assert len(polls) == 2, "the deadline path must trigger exactly one re-read"
```

## N1-bis — docstring du test 3 (l'existant)

Le docstring du test `test_11751_red_constituent_observed_in_reread_is_not_a_pass` annonçait « A check that flips red between polls » alors que son `fetch` est constant. Le docstring est corrigé pour décrire ce que le `fetch` **produit réellement** (rouge vue dès le poll 1, fail-fast en tête de boucle) :

```diff
 def test_11751_red_constituent_observed_in_reread_is_not_a_pass():
-    """A check that flips red between polls is reported by name.
-
-    Negative control for the recovery path: an all-green gate would be
-    indistinguishable from a gate that lost track of a red. The re-read uses
-    the same `classify` path that runs in the loop, so a red observed at the
-    re-read is reported exactly like a red observed in any other poll.
+    """A red observed in the LOOP (fail-fast path) is reported by name.
+
+    Negative control for the recovery path: an all-green gate would be
+    indistinguishable from a gate that lost track of a red. The fail-fast
+    branch `if bad:` at the top of the loop reports a red observed at any
+    poll by name -- this test pins that path (a red seen at poll 1, before
+    the deadline re-read ever runs).
     """
```

Le test **garde sa valeur** (pinner le fail-fast), mais le nouveau test 5 pin la branche deadline. Les deux ensemble couvrent les deux endroits où un rouge peut être perdu.

## N2 — header dupliqué (cosmétique)

`# --- legacy commit statuses ---` apparaissait 2 fois au head de la section legacy (artefact d'insertion des 4 tests #11751). Zéro impact fonctionnel, mais la duplication est corrigée :

```diff
 # --- legacy commit statuses --------------------------------------------------

-# --- legacy commit statuses --------------------------------------------------

 def test_legacy_status_error_maps_to_failure():
```

Vérifié : `grep -c "# --- legacy commit statuses ---" scripts/tests/test_pr_gate.py` = **1** (était 2).

## Header comment du groupe #11751

Le commentaire en tête du groupe `# --- #11751 --` annonçait « Acceptance tests below pin the four cases listed in #11751 ». On en a maintenant cinq (les quatre originaux + le contrôle positif du re-read). Le commentaire est mis à jour pour refléter le compte réel :

```diff
-# canary). Acceptance tests below pin the four cases listed in #11751.
+# canary). Acceptance tests below pin the cases listed in #11751 (the four
+# originally enumerated by the issue, plus the red-only-at-reread control
+# added by #11793 to exercise the `if final_bad:` deadline branch).
```

## Acceptance (#11793)

- [x] le 5ᵉ test **échoue** si on remplace la branche `if final_bad:` par un `pass` silencieux (vérifié firsthand : la variante a été testée, `code=0` au lieu de `1`)
- [x] le 5ᵉ test **passe** sur la version non-buggée de `pr_gate.py`
- [x] le docstring du test 3 décrit ce que son `fetch` produit réellement (fail-fast loop, pas re-read)
- [x] `# --- legacy commit statuses ---` revient à **1** occurrence (grep vérifié)
- [x] `python -m pytest scripts/tests/test_pr_gate.py scripts/tests/test_pr_gate_missing.py` reste vert : **63/63** (était 62 — 52 `test_pr_gate.py` + 10 `test_pr_gate_missing.py`)

## Pourquoi ce fix plutôt qu'un commit de plus sur #11765

#11765 ferme la course qui rend `PR gate` faussement rouge, et **12 PR ouvertes portent ce faux rouge en ce moment** (cf. dashboard coordinateur). Un commit de plus sur la branche renvoie la PR dans une file CI saturée et retarde d'autant le déblocage de ces 12. Le mandat courant nomme le vieillissement comme le préjudice ; les deux nits ne le justifient pas.

## Grain tag

`Grain: MED/guard — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-dotnet #11806`

Genres : `guard` (META — test qui fence le PR gate, pas un notebook de contenu). G-VAR-3 OK : genre guard **précédent** = #11785 c.1331p277 (il y a plusieurs cycles), pas consécutif.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
