### PR TITLE
fix(ci,#11835): stale-base-warning en clone partiel — 1,82 Gio transferes pour lire des dates de commits

### DIFF
--- a/.github/workflows/stale-base-warning.yml
+++ b/.github/workflows/stale-base-warning.yml
@@ -19,9 +19,28 @@ jobs:
     name: Check base branch staleness
     runs-on: ubuntu-latest
     steps:
+      # Ce garde ne lit AUCUN contenu de fichier : `git rev-list --count` et
+      # `git show -s --format=%ct` n'interrogent que le graphe de commits
+      # (`-s` supprime le diff). Un `fetch-depth: 0` nu transfere pourtant les
+      # 1,82 Gio du pack -- dont ~800 Mo de revisions historiques de blobs
+      # (une seule cellule TTS pese ~400 Mo en cumul de revisions) -- pour lire
+      # des dates de commits.
+      #
+      # `filter: blob:none` garde le graphe complet, requis par `rev-list
+      # BASE..origin/main --count`, et rend les blobs paresseux ; le
+      # `sparse-checkout` limite ce que l'arbre de travail materialise a
+      # `.github` (0,6 Mo), au lieu des 1058 Mo de HEAD (757 Mo de
+      # MyIA.AI.Notebooks/ + 246 Mo de slides/). Le `git fetch origin main` de
+      # l'etape suivante herite du filtre du clone partiel.
+      #
+      # Mesure attendue, a lire dans la duree de l'etape « Set up job » /
+      # checkout de ce workflow avant et apres : c'est la seule facon de la
+      # constater, elle ne se reproduit pas en local. See #11835.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
+          sparse-checkout: .github
       - name: Check base age
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Grain: MED/guard — lane myia-ai-01:CoursIA — prev: DEEP/tooling #11837

## Le constat

`Stale Base Branch Warning` tire sur **chaque** `pull_request` — c'est l'un des
14 workflows sur 89 qui n'ont pas de filtre `paths:`, et c'est legitime : son
objet est universel. Il clone en `fetch-depth: 0`.

Or il ne lit **aucun contenu de fichier**. Son travail entier :

```bash
git rev-list "$BASE_SHA..origin/main" --count
git show -s --format=%ct "$BASE_SHA"      # -s supprime le diff
git show -s --format=%ct "$MAIN_SHA"
```

Trois interrogations du **graphe de commits**. Zero blob, zero arbre de
contenu.

## Ce que ca coute

Mesure firsthand sur le clone local a `origin/main` :

| | |
|---|---:|
| `size-pack` — ce qu'un `fetch-depth: 0` transfere | **1,82 Gio** |
| somme des blobs atteignables depuis HEAD | 1058 Mo / 8188 fichiers |
| &nbsp;&nbsp;dont `MyIA.AI.Notebooks/` | 757,6 Mo |
| &nbsp;&nbsp;dont `slides/` | 246,0 Mo |
| &nbsp;&nbsp;dont `.github/` | **0,6 Mo** |

L'ecart entre 1,82 Gio et 1058 Mo — environ **800 Mo** — est constitue de
revisions **historiques** de blobs. Le top-12 des plus gros blobs de
l'historique contient **neuf revisions du seul**
`GenAI/Audio/04-Applications/04-11-Generation-TTS.ipynb`, entre 33 et 63 Mo
chacune : **~400 Mo pour l'historique d'un seul fichier**, transferes a chaque
run de ce garde, pour lire des dates de commits.

## Le correctif

```yaml
- uses: actions/checkout@v4
  with:
    fetch-depth: 0
    filter: blob:none        # graphe complet (requis par rev-list), blobs paresseux
    sparse-checkout: .github # arbre materialise : 1058 Mo -> 0,6 Mo
```

`filter: blob:none` preserve exactement ce dont `rev-list BASE..origin/main
--count` a besoin — le graphe de commits complet — et rend les blobs
paresseux. Le `git fetch origin main` de l'etape suivante **herite du filtre**
du clone partiel, donc il ne le contourne pas.

`sparse-checkout: .github` limite ce que l'arbre de travail materialise.

## Pourquoi regler la profondeur n'aurait rien donne

C'est le point qui m'a surpris en mesurant, et il vaut pour toute la classe :

- ce garde a besoin de la **base** de la PR, donc `depth: 1` est impossible ;
- et de toute facon **`depth: 1` transfererait quand meme ~1058 Mo**, puisque
  HEAD lui-meme pese 1 Go.

C'est ce qui explique qu'un garde comme `perimeter-review-guard`, deja en
`depth: 1` et qui n'analyse que des metadonnees de PR, mette **64 s de
checkout pour 2 s d'analyse**. La profondeur n'est pas la variable ; **le
contenu transfere** l'est.

## Perimetre : un workflow, delibirement

Cinq autres always-on sont en `fetch-depth: 0` (`orphaned-delivery-scan`,
`regression-guard`, `repo-size-advisory`, `secret-scan`, `translation-guard`).
Ils ne sont **pas** dans cette PR, pour deux raisons :

1. **La mesure du gain ne se reproduit pas en local** — elle se lit dans la
   duree de l'etape de checkout de ce workflow, avant et apres, sur des PR
   reelles. Une PR qui en change six rendrait le gain non attribuable.
2. **Au moins deux d'entre eux lisent du contenu** (`repo-size-advisory` par
   nature, `secret-scan` selon son mode) et ne sont donc **pas** des candidats
   au `sparse-checkout`. Les traiter en lot supposerait qu'ils se ressemblent ;
   ils ne se ressemblent pas.

Les suivants viendront un par un, et **seulement si celui-ci tient**.

## Le risque, ecrit avant d'etre demande

Un clone partiel deplace le cout : chaque blob absent devient un aller-retour
reseau au moment ou il est demande. Pour un garde qui n'en demande **aucun**,
le gain est integral et le risque nul. Pour un garde qui lirait beaucoup de
blobs historiques, `blob:none` serait une **regression** — c'est exactement
pourquoi cette PR n'en change qu'un, et celui dont j'ai lu le code ligne a
ligne pour etablir qu'il n'en lit aucun.

Et la facon dont ce genre de changement casse en silence, pour qui reprendra
la serie : `sparse-checkout` transforme « scanner tout le depot » en
« scanner ce qui se trouve etre present », **sans lever d'erreur** — un
resultat plus petit et plus propre que la verite. Tout garde a venir qui globe
l'arbre doit soit rester hors du sparse, soit porter un **controle positif**
(un fichier qu'il DOIT trouver, avec arret si le controle rend 0).

## Verification

- YAML parse ; l'etape resultante porte
  `{fetch-depth: 0, filter: blob:none, sparse-checkout: .github}` (assert
  programmatique avant commit).
- Diff : **1 fichier, +19 lignes, 0 suppression**. Aucun changement de logique
  — le bloc `run:` est intact.
- Le comportement observable (commentaire + label `base-stale-14d` au-dela de
  14 j) est inchange : les trois commandes git qui le decident ne dependent que
  du graphe, qui reste complet.

## Mesure a relever apres merge

Duree de l'etape de checkout de `Stale Base Branch Warning`, sur trois PR
successives, comparee aux runs actuels. Si elle ne baisse pas nettement,
c'est que `sparse-checkout` ou le filtre ne s'appliquent pas comme prevu — et
il faudra le dire, pas le supposer.

See #11835.
