### PR TITLE
docs(image,#9434): drain measured GPU timings from 03-3-Performance-Optimization markdown

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb
@@ -334,7 +334,7 @@
    "source": [
     "Les structures de données de profilage (`@dataclass PerfMetrics`, `GPUProfiler`) encapsulent les métriques GPU. Le design est volontairement minimal : chaque mesure porte son temps d'exécution (ms), sa mémoire peak (MB), son timestamp — et le `GPUProfiler` historise ces mesures dans `metrics_history`, ce qui permettra à la cellule de finalisation de calculer la moyenne de session sur **tous les tests exécutés**.\n",
     "\n",
-    "**Lecture d'architecture** : séparer la *capture* (dataclass passive) de l'*accumulation* (profiler) est ce qui rend les comparaisons honnêtes. Quand la Section 8 affichera « Baseline 303.3 ms vs FP16 127.9 ms », ces deux nombres auront été produits par le même instrument, avec la même granularité — pas par deux `time.time()` improvisés dans deux cellules différentes. En optimisation, la méthodologie de mesure est aussi importante que la technique mesurée : un speedup mesuré avec des horloges différentes n'est pas un speedup."
+    "**Lecture d'architecture** : séparer la *capture* (dataclass passive) de l'*accumulation* (profiler) est ce qui rend les comparaisons honnêtes. Quand la Section 8 affichera la baseline face à la même génération en FP16, ces deux nombres auront été produits par le même instrument, avec la même granularité — pas par deux `time.time()` improvisés dans deux cellules différentes. En optimisation, la méthodologie de mesure est aussi importante que la technique mesurée : un speedup mesuré avec des horloges différentes n'est pas un speedup."
    ]
   },
   {
@@ -571,7 +571,7 @@
     "tags": []
    },
    "source": [
-    "La simulation de la baseline mesure les performances **sans aucune optimisation** : alloue le tenseur de ~1000 MB, simule ~500 ms de compute, profile le tout. Le résultat de référence qui sort de cette cellule : **841.3 ms** d'exécution, **1500.0 MB** de mémoire peak. C'est le zéro de l'échelle — la cellule suivante en tire la lecture complète.\n",
+    "La simulation de la baseline mesure les performances **sans aucune optimisation** : alloue le tenseur de ~1000 MB, simule ~500 ms de compute, profile le tout. Le résultat de référence qui sort de cette cellule : **moins d'une seconde** d'exécution (valeur exacte dans la sortie), **1500.0 MB** de mémoire peak. C'est le zéro de l'échelle — la cellule suivante en tire la lecture complète.\n",
     "\n",
     "**Pourquoi une simulation plutôt qu'un vrai pipeline Stable Diffusion** : la simulation isole la *mécanique de mesure* du *bruit des poids réels*. Un vrai UNet charge des gigaoctets, compilent des kernels, chauffe le GPU — autant de facteurs qui feraient varier la baseline de run en run et pollueraient les ratios. Ici la baseline est déterministe, donc chaque speedup mesuré ensuite est attribuable à la technique d'optimisation seule. La contrepartie : les chiffres absolus (841 ms) ne sont pas ceux d'une génération réelle — ils sont un **terrain d'essai calibré** pour comparer des techniques entre elles."
    ]
@@ -653,7 +653,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Lecture de la baseline** — la génération de référence mesure **841,3 ms** et consomme **1500 MB** de VRAM sur le RTX 3090 (24 GB). Ces deux chiffres sont les **zéros de l'échelle** : tous les speedups de la suite seront des ratios par rapport à 841,3 ms, toutes les économies mémoire des deltas par rapport à 1500 MB.\n",
+    "**Lecture de la baseline** — la génération de référence se mesure en **fractions de seconde** et consomme **1500 MB** de VRAM sur le RTX 3090 (24 GB) — valeurs exactes dans la sortie ci-dessus. Ces deux chiffres sont les **zéros de l'échelle** : tous les speedups de la suite seront des ratios par rapport à cette référence, toutes les économies mémoire des deltas par rapport à 1500 MB.\n",
     "\n",
     "**Pourquoi 1500 MB est un chiffre rassurant pour la suite** : la baseline n'occupe que ~6 % de la VRAM disponible (1500/24576 MB), ce qui laisse une marge énorme pour le batching (Section 5) et déplace la contrainte vers le **temps** plutôt que la mémoire. Sur un GPU plus petit (8 GB), la même baseline représenterait ~19 % — le batching serait alors limité par la VRAM avant de l'être par le compute. Le profilage de la baseline dit donc, avant toute optimisation, *quel* sera le bottleneck dominant de cette machine : ici le temps, là-bas la mémoire. C'est le diagnostic qui oriente toute la suite du notebook."
    ]
@@ -975,16 +975,18 @@
    "source": [
     "**Lecture du test FP16 vs FP32** — le tableau mérite une lecture ligne par ligne :\n",
     "\n",
-    "| Test | Temps (ms) | Throughput |\n",
-    "|---|---|---|\n",
-    "| Baseline - FP32 | 841.3 | 1.19 img/s |\n",
-    "| Test - FP32 | 112.8 | 8.87 img/s |\n",
-    "| Test - FP16 | 112.8 | 8.86 img/s |\n",
-    "| Test - BF16 | 5582.5 | 0.18 img/s |\n",
+    "Le tableau complet (temps par test, mémoire, throughput) est imprimé par la cellule ci-dessus. Sa structure, reproductible à chaque exécution :\n",
     "\n",
-    "1. **Baseline vs Test-FP32 (841.3 → 112.8 ms, ×7.5)** : les deux sont en FP32 — l'accélération ne vient PAS de la précision mais de l'échauffement (première exécution compile/alloue, les suivantes sont plus rapides) et du mécanisme de simulation lui-même. C'est le piège classique du benchmarking GPU : **la première mesure est toujours la plus lente**. Comparer une baseline « à froid » à un optimisé « à chaud » surestime n'importe quelle technique.\n",
-    "2. **Test-FP32 vs Test-FP16 (112.8 vs 112.8)** : à workload simulé égal, FP16 n'apporte rien ici — la simulation ne fait pas de vraies multiplications matricielles intensives qui bénéficieraient des Tensor Cores. Sur un vrai UNet, FP16 donne typiquement ×1.5-2 en compute ; ici, seul le gain **mémoire** (2000 vs 4000 MB) est réel.\n",
-    "3. **L'anomalie BF16 (5582.5 ms, ×50 plus lent)** : contre-intuitif alors que la détection recommandait BF16 ! Explication : la simulation alloue et convertit les tenseurs à chaque itération, et le chemin de conversion BF16 sur ce pattern précis est défavorable. **Leçon** : une recommandation statique (« BF16 supporté ») ne vaut pas une mesure — la Section 8, sur le pipeline complet, tranchera avec le vrai benchmark."
+    "| Test | Temps relatif | Lecture |\n",
+    "|---|---|---|\n",
+    "| Baseline - FP32 | référence (à froid) | la plus lente de la série |\n",
+    "| Test - FP32 | ~7-8x plus rapide | même précision : le gain vient de l'échauffement |\n",
+    "| Test - FP16 | identique au Test-FP32 | la précision n'apporte rien ici |\n",
+    "| Test - BF16 | ~50x plus lent | pathologique sur ce mécanisme |\n",
+    "\n",
+    "1. **Baseline vs Test-FP32 (cold → chaud, rapport ~x7)** : les deux sont en FP32 — l'accélération ne vient PAS de la précision mais de l'échauffement (première exécution compile/alloue, les suivantes sont plus rapides) et du mécanisme de simulation lui-même. C'est le piège classique du benchmarking GPU : **la première mesure est toujours la plus lente**. Comparer une baseline « à froid » à un optimisé « à chaud » surestime n'importe quelle technique.\n",
+    "2. **Test-FP32 vs Test-FP16 (temps quasi identiques — voir le tableau)** : à workload simulé égal, FP16 n'apporte rien ici — la simulation ne fait pas de vraies multiplications matricielles intensives qui bénéficieraient des Tensor Cores. Sur un vrai UNet, FP16 donne typiquement ×1.5-2 en compute ; ici, seul le gain **mémoire** (2000 vs 4000 MB) est réel.\n",
+    "3. **L'anomalie BF16 (~50× plus lent que FP32)** : contre-intuitif alors que la détection recommandait BF16 ! Explication : la simulation alloue et convertit les tenseurs à chaque itération, et le chemin de conversion BF16 sur ce pattern précis est défavorable. **Leçon** : une recommandation statique (« BF16 supporté ») ne vaut pas une mesure — la Section 8, sur le pipeline complet, tranchera avec le vrai benchmark."
    ]
   },
   {
@@ -2769,18 +2771,20 @@
    "source": [
     "**Lecture du benchmark** — le tableau mesure trois configurations sur pipeline complet :\n",
     "\n",
-    "| Configuration | Temps moy (ms) | Mémoire (MB) | Speedup |\n",
-    "|---|---|---|---|\n",
-    "| Baseline (FP32) | 303.3 | 1500.0 | 1.00× |\n",
-    "| FP16 | 127.9 | 750.0 | **2.37×** |\n",
-    "| FP16 + Optimisations | 88.3 | 750.0 | **3.44×** |\n",
+    "| Configuration | Mémoire (MB) | Speedup (nature reproductible) |\n",
+    "|---|---|---|\n",
+    "| Baseline (FP32) | 1500.0 | 1.00× (référence) |\n",
+    "| FP16 | 750.0 | **~2.4×** |\n",
+    "| FP16 + Optimisations | 750.0 | **~3.4×** |\n",
+    "\n",
+    "(Les temps moyens mesurés et les speedups exacts de cette exécution sont imprimés par la cellule ci-dessus.)\n",
     "\n",
     "Deux lectures essentielles :\n",
     "\n",
-    "1. **Les speedup se vérifient par division directe** : 303.3/127.9 = 2.37 ✓, 303.3/88.3 = 3.44 ✓. FP16 seul double la vitesse ET divise la mémoire par deux (1500 → 750 MB) — c'est la technique au meilleur rapport gain/coût du notebook. Le palier suivant (2.37× → 3.44×) ajoute 45 % de vitesse supplémentaire via les optimisations composées (attention, compile) — sans gain mémoire additionnel.\n",
-    "2. **Notez que la baseline du benchmark (303.3 ms) diffère de la baseline simulée de la Section 2 (841.3 ms)** : ce sont deux instruments différents — simulation à froid vs pipeline complet à température établie. Les speedup ne se rapportent **qu'à la baseline du même tableau**. Un speedup n'a de sens que dans son propre référentiel : c'est la discipline de mesure qui rend les comparaisons honnêtes.\n",
+    "1. **Les speedup se vérifient par division directe** — première habitude d'audit d'un benchmark : divisez le temps baseline par le temps de la ligne optimisée dans le tableau imprimé par la cellule, et comparez au speedup affiché. FP16 seul double la vitesse ET divise la mémoire par deux (1500 → 750 MB) — c'est la technique au meilleur rapport gain/coût du notebook. Le palier suivant (~2.4× → ~3.4×) ajoute ~45 % de vitesse supplémentaire via les optimisations composées (attention, compile) — sans gain mémoire additionnel.\n",
+    "2. **Notez que la baseline du benchmark diffère de la baseline simulée de la Section 2** (comparez les deux dans leurs sorties respectives) : ce sont deux instruments différents — simulation à froid vs pipeline complet à température établie. Les speedup ne se rapportent **qu'à la baseline du même tableau**. Un speedup n'a de sens que dans son propre référentiel : c'est la discipline de mesure qui rend les comparaisons honnêtes.\n",
     "\n",
-    "**Pourquoi le profil « agressif » (3.44×) n'est pas toujours le bon choix** : il cumule FP16 + compilation + optimisations d'attention — chacune ajoute un coût caché (compilation à froid de plusieurs dizaines de secondes, contraintes de version). Le profil modéré (2.37×) capture l'essentiel du gain sans ces coûts. Le choix est un arbitrage speedup/qualité/latence-à-froid que seul le cas d'usage tranche : prototype interactif vs serveur de production."
+    "**Pourquoi le profil « agressif » (~3.4×) n'est pas toujours le bon choix** : il cumule FP16 + compilation + optimisations d'attention — chacune ajoute un coût caché (compilation à froid de plusieurs dizaines de secondes, contraintes de version). Le profil modéré (~2.4×) capture l'essentiel du gain sans ces coûts. Le choix est un arbitrage speedup/qualité/latence-à-froid que seul le cas d'usage tranche : prototype interactif vs serveur de production."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Tranche #9434 (drainage valeurs quantitatives) : `GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb` — 5 sites markdown drainés en 2 passes (+24/-20). Uniquement des cellules **markdown** modifiées (aucune cellule code touchée → outputs inchangés, pas de re-exécution requise).

## Sites drainés

| Cell | Avant | Après |
|---|---|---|
| 7 | citation anticipée des valeurs Section 8 (`303.3 ms vs 127.9 ms`) — **driftée** (ne matchait même plus la Section 8 réelle) | renvoi qualitatif « la baseline face à la même génération en FP16 » |
| 12 | `**841.3 ms**` | « moins d'une seconde (valeur exacte dans la sortie) » |
| 14 | zéro-d'échelle `841,3 ms` (virgule française) | « fractions de seconde » + renvoi sortie ; 1500 MB VRAM **gardés** (data-sheet) |
| 23 | tableau mesuré 841.3/112.8/112.8/5582.5 ms + throughputs | structure qualitative reproductible (~7-8x échauffement, FP16 = FP32, BF16 ~50x pathologique) + renvoi « tableau imprimé par la cellule » |
| 55 | tableau final 303.3/127.9/88.3 ms + speedups 2.37×/3.44× | tildes **~2.4×/~3.4×** + réflexe d'audit « vérifiez par division » conservé comme sujet pédagogique |

## Classement (cf classes #9434)

- **machine-dep/stochastique** : timings GPU RTX 3090 (841.3, 112.8, 5582.5, 303.3, 127.9, 88.3 ms), throughputs dérivés (1.19/8.87/0.18 img/s), speedups dérivés (×7.5, 2.37×, 3.44×) → drainés
- **structurel** : ratio ~7-8x échauffement, FP16≈FP32 à workload égal, BF16 ~50x pathologique, halving mémoire 1500→750 MB, palier ~45 % → gardés en nature reproductible
- **data-sheet** : 1500 MB VRAM, RTX 3090 24 GB → gardés

## Preuves

- Vérification pré-drain : les 9 valeurs pinées étaient PRÉSENTES dans les outputs committés avant drain (chaque markdown drainé renvoie à une sortie qui contient la valeur).
- Vérification post-drain (script, markdown cells uniquement) : `841.3 841,3 112.8 5582.5 303.3 127.9 88.3 2.37 3.44` → **0 occurrence dans les cellules markdown**, toutes présentes dans les outputs.
- Diff : +24/-20, 1 fichier, format JSON préservé (sources string restées string).
- Catalogue : byte-identique à main (aucun régén).
- Rebase frais sur origin/main (8478316a4) avant push.

See #9434

Grain: LIGHT/notebook-python — lane myia-po-2026:CoursIA — prev: MED/notebook-python #11833

---

_Tag requalifie par ai-01 au merge._ `drain` n'est pas dans l'enumeration fermee des
genres : c'est un alias, normalise en `notebook-python` (le travail edite le markdown
d'un notebook). Le `prev:` est corrige au passage — #11833 etait tague
`MED/notebook-python`, pas `LIGHT/drain`. La requalification est portee dans le **body**
et non en commentaire : postee ailleurs que dans l'organe, elle laisserait le cap
continuer de compter le mauvais genre.

_Mesure du cap au merge_ (`variation_light_cap.py --replay <60 PR mergees>`) :
`budget=3 spent=2` — dans le budget, donc pas de HOLD. Mais `vein_exceeded=true`,
`vein_key=9434`, `vein_count=3` : la lane a sature la veine #9434 aujourd'hui.
Conformement a R8, cela **ne bloque pas** cette tranche deja ecrite — « on ne jette pas
du travail ecrit ». C'est la **prochaine** PR de la lane qui doit passer par
`pick_idle_grain.py --lane myia-po-2026:CoursIA` plutot que de re-claimer #9434.
