### PR TITLE
fix(aspire,#11701): cmd.exe quoting fix + timeout transcription + prose re-ancree, re-exec reelle GPU

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/01-Aspire-Orchestration-GenAi.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/01-Aspire-Orchestration-GenAi.ipynb
@@ -105,243 +105,66 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       "\r\n",
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '28372.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": ""
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "AppHost (wt1) : D:\\Dev\\CoursIA-AspireGenAi\\MyIA.AI.Notebooks\\GenAI\\Aspire\\GenAiStack.AppHost\r\n"
-     ]
+     "name": "stdout",
+     "text": "AppHost (wt1) : D:\\dev\\CoursIA-vid343\\MyIA.AI.Notebooks\\GenAI\\Aspire\\GenAiStack.AppHost\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "AppHost (wt2) : D:\\Dev\\CoursIA-AspireGenAi\\MyIA.AI.Notebooks\\GenAI\\Aspire\\GenAiStack.AppHost-wt2\r\n"
-     ]
+     "name": "stdout",
+     "text": "AppHost (wt2) : D:\\dev\\CoursIA-vid343\\MyIA.AI.Notebooks\\GenAI\\Aspire\\GenAiStack.AppHost-wt2\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "CLI aspire    : C:\\Users\\jsboi\\.dotnet\\tools\\aspire.cmd\r\n"
-     ]
+     "name": "stdout",
+     "text": "CLI aspire    : C:\\Users\\jsboi\\.dotnet\\tools\\aspire.cmd\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Echantillon   : D:\\Dev\\CoursIA-AspireGenAi\\MyIA.AI.Notebooks\\GenAI\\Aspire\\assets\\echantillon-test-fr.wav\r\n"
-     ]
+     "name": "stdout",
+     "text": "Echantillon   : D:\\dev\\CoursIA-vid343\\MyIA.AI.Notebooks\\GenAI\\Aspire\\assets\\echantillon-test-fr.wav\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "apphost.cs wt1 present : True\r\n"
-     ]
+     "name": "stdout",
+     "text": "apphost.cs wt1 present : True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "apphost.cs wt2 present : True\r\n"
-     ]
+     "name": "stdout",
+     "text": "apphost.cs wt2 present : True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "wav present            : True\r\n"
-     ]
+     "name": "stdout",
+     "text": "wav present            : True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "version CLI aspire     : 13.4.6+87fe259e4fc244c599019a7b1304c85a1488f248\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "version CLI aspire     : 13.5.0+e076d8e427cb3afb528dbd605acd74c3aea69f94\r\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- apphost.cs (wt1) ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "--- apphost.cs (wt1) ---\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "#:sdk Aspire.AppHost.Sdk@13.4.6\n",
-      "using Aspire.Hosting;\n",
-      "\n",
-      "// AppHost Aspire orchestrant un service RÉEL de la pile GenAI locale\n",
-      "// (image locale `whisper-api-whisper-api`, buildée depuis le Dockerfile de\n",
-      "// docker-configurations/services/whisper-api et exécutée par le compose\n",
-      "// manuel) — Epic #10473 *The Unexpected AI Stack*, grain #10838.\n",
-      "//\n",
-      "// L'objectif pédagogique est la ligne de parité « Isolation de ports par\n",
-      "// worktree : à la main  ->  aspire run --isolated » : le même AppHost peut\n",
-      "// être lancé en plusieurs instances simultanées (worktrees de travail), et\n",
-      "// `--isolated` randomise les ports ET isole les user secrets. Deux instances\n",
-      "// orchestrent donc chacune leur propre conteneur whisper-api, sans collision\n",
-      "// docker ni port.\n",
-      "//\n",
-      "// Le secret d'API (API_KEY) n'est PAS un littéral : il est généré à chaque\n",
-      "// démarrage de l'AppHost (Guid) et passé au conteneur — aucune valeur\n",
-      "// sensible dans le dépôt. La configuration non-secrète (modèle, device,\n",
-      "// compute type) suit les valeurs de docker-configurations/services/whisper-api.\n",
-      "//\n",
-      "// Note tooling : SDK file-based `#:sdk Aspire.AppHost.Sdk` (modèle canonique\n",
-      "// SDK-10, cf. aspire-otel/SkOtel.AppHost d'#10498) — pas de csproj.\n",
-      "\n",
-      "var builder = DistributedApplication.CreateBuilder(args);\n",
-      "\n",
-      "// Resource réelle : whisper-api (faster-whisper, OpenAI-compatible ASR).\n",
-      "// Image locale pré-buildée (docker-configurations/services/whisper-api,\n",
-      "// Dockerfile) = SOTA réel de notre pile, aucune réimplémentation.\n",
-      "//\n",
-      "// Le conteneur dépend de deux binds définis par le compose manuel :\n",
-      "//   - ../shared  -> /app/shared  (module lazy_model, requis à l'import)\n",
-      "//   - ./models   -> /app/models  (cache de modèles local)\n",
-      "// Les chemins sont résolus RELATIVEMENT à l'AppHost (racine du dépôt), pour\n",
-      "// que le même source fonctionne depuis n'importe quel worktree.\n",
-      "var repoRoot = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), \"../../../../\"));\n",
-      "\n",
-      "var whisper = builder.AddContainer(\"whisper-api\", \"whisper-api-whisper-api\")\n",
-      "    .WithContainerRuntimeArgs(\"--gpus\", \"all\")           // RTX 3090 (24 GB)\n",
-      "    .WithEnvironment(\"WHISPER_MODEL\", \"large-v3-turbo\")  // config non-secrète\n",
-      "    .WithEnvironment(\"WHISPER_DEVICE\", \"cuda\")\n",
-      "    .WithEnvironment(\"WHISPER_COMPUTE_TYPE\", \"int8_float16\")\n",
-      "    .WithEnvironment(\"PRELOAD_MODEL\", \"false\")           // lazy load : démarrage rapide\n",
-      "    .WithEnvironment(\"IDLE_TIMEOUT\", \"1200\")\n",
-      "    .WithEnvironment(\"CUDA_VISIBLE_DEVICES\", \"0\")\n",
-      "    .WithEnvironment(\"AUTH_ENABLED\", \"false\")            // dev local : auth explicitement\n",
-      "                                                         // désactivée (auth_middleware), aucun secret\n",
-      "    .WithBindMount(Path.Combine(repoRoot, \"docker-configurations/services/shared\"), \"/app/shared\", isReadOnly: true)\n",
-      "    .WithBindMount(Path.Combine(repoRoot, \"docker-configurations/services/whisper-api/models\"), \"/app/models\")\n",
-      "    // Cache HuggingFace HÔTE partagé : le modèle large-v3-turbo téléchargé par le\n",
-      "    // conteneur manuel est réutilisé par le conteneur orchestré (et persiste\n",
-      "    // entre recréations). Même pattern que le volume nommé whisper-cache du compose.\n",
-      "    .WithBindMount(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \".cache/huggingface\"), \"/home/appuser/.cache/huggingface\")\n",
-      "    .WithHttpEndpoint(targetPort: 8190, name: \"http\");   // port hôte éphémère (--isolated)\n",
-      "\n",
-      "builder.Build().Run();\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "#:sdk Aspire.AppHost.Sdk@13.4.6\nusing Aspire.Hosting;\n\n// AppHost Aspire orchestrant un service RÉEL de la pile GenAI locale\n// (image locale `whisper-api-whisper-api`, buildée depuis le Dockerfile de\n// docker-configurations/services/whisper-api et exécutée par le compose\n// manuel) — Epic #10473 *The Unexpected AI Stack*, grain #10838.\n//\n// L'objectif pédagogique est la ligne de parité « Isolation de ports par\n// worktree : à la main  ->  aspire run --isolated » : le même AppHost peut\n// être lancé en plusieurs instances simultanées (worktrees de travail), et\n// `--isolated` randomise les ports ET isole les user secrets. Deux instances\n// orchestrent donc chacune leur propre conteneur whisper-api, sans collision\n// docker ni port.\n//\n// Le secret d'API (API_KEY) n'est PAS un littéral : il est généré à chaque\n// démarrage de l'AppHost (Guid) et passé au conteneur — aucune valeur\n// sensible dans le dépôt. La configuration non-secrète (modèle, device,\n// compute type) suit les valeurs de docker-configurations/services/whisper-api.\n//\n// Note tooling : SDK file-based `#:sdk Aspire.AppHost.Sdk` (modèle canonique\n// SDK-10, cf. aspire-otel/SkOtel.AppHost d'#10498) — pas de csproj.\n\nvar builder = DistributedApplication.CreateBuilder(args);\n\n// Resource réelle : whisper-api (faster-whisper, OpenAI-compatible ASR).\n// Image locale pré-buildée (docker-configurations/services/whisper-api,\n// Dockerfile) = SOTA réel de notre pile, aucune réimplémentation.\n//\n// Le conteneur dépend de deux binds définis par le compose manuel :\n//   - ../shared  -> /app/shared  (module lazy_model, requis à l'import)\n//   - ./models   -> /app/models  (cache de modèles local)\n// Les chemins sont résolus RELATIVEMENT à l'AppHost (racine du dépôt), pour\n// que le même source fonctionne depuis n'importe quel worktree.\nvar repoRoot = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), \"../../../../\"));\n\nvar whisper = builder.AddContainer(\"whisper-api\", \"whisper-api-whisper-api\")\n    .WithContainerRuntimeArgs(\"--gpus\", \"all\")           // RTX 3090 (24 GB)\n    .WithEnvironment(\"WHISPER_MODEL\", \"large-v3-turbo\")  // config non-secrète\n    .WithEnvironment(\"WHISPER_DEVICE\", \"cuda\")\n    .WithEnvironment(\"WHISPER_COMPUTE_TYPE\", \"int8_float16\")\n    .WithEnvironment(\"PRELOAD_MODEL\", \"false\")           // lazy load : démarrage rapide\n    .WithEnvironment(\"IDLE_TIMEOUT\", \"1200\")\n    .WithEnvironment(\"CUDA_VISIBLE_DEVICES\", \"0\")\n    .WithEnvironment(\"AUTH_ENABLED\", \"false\")            // dev local : auth explicitement\n                                                         // désactivée (auth_middleware), aucun secret\n    .WithBindMount(Path.Combine(repoRoot, \"docker-configurations/services/shared\"), \"/app/shared\", isReadOnly: true)\n    .WithBindMount(Path.Combine(repoRoot, \"docker-configurations/services/whisper-api/models\"), \"/app/models\")\n    // Cache HuggingFace HÔTE partagé : le modèle large-v3-turbo téléchargé par le\n    // conteneur manuel est réutilisé par le conteneur orchestré (et persiste\n    // entre recréations). Même pattern que le volume nommé whisper-cache du compose.\n    .WithBindMount(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), \".cache/huggingface\"), \"/home/appuser/.cache/huggingface\")\n    .WithHttpEndpoint(targetPort: 8190, name: \"http\");   // port hôte éphémère (--isolated)\n\nbuilder.Build().Run();\n\r\n"
     }
    ],
    "source": [
@@ -365,11 +188,17 @@
     "        return dir?.FullName ?? throw new DirectoryNotFoundException(\"racine du depot introuvable\");\n",
     "    }\n",
     "\n",
-    "    // Execute une commande (cmd.exe) et capture stdout+stderr.\n",
+    "    // Execute une commande et capture stdout+stderr.\n",
+    "    // Un .cmd EXIGE l'interpreteur cmd.exe ; tout autre executable (ex. docker,\n",
+    "    // resolu via le PATH) est lance DIRECTEMENT, sans shell : cmd.exe /c reecrit\n",
+    "    // toute ligne portant plus d'une paire de guillemets (il retire le premier\n",
+    "    // et le dernier), ce qui cassait les arguments cites -- docker --format\n",
+    "    // \"{{.Names}}\" ressortait en 'docker\" ps ...' non reconnu.\n",
     "    public static string Run(string workDir, string cmd, string args) {\n",
+    "        var viaCmd = cmd.EndsWith(\".cmd\", StringComparison.OrdinalIgnoreCase);\n",
     "        var psi = new System.Diagnostics.ProcessStartInfo {\n",
-    "            FileName = \"cmd.exe\",\n",
-    "            Arguments = $\"/c \\\"{cmd}\\\" {args}\",\n",
+    "            FileName = viaCmd ? \"cmd.exe\" : cmd,\n",
+    "            Arguments = viaCmd ? $\"/c \\\"{cmd}\\\" {args}\" : args,\n",
     "            WorkingDirectory = workDir,\n",
     "            RedirectStandardOutput = true,\n",
     "            RedirectStandardError = true,\n",
@@ -385,21 +214,8 @@
     "    public static string Aspire(string workDir, string args) => Run(workDir, AspireCmd, args);\n",
     "\n",
     "    // Snapshot de la ressource whisper-api de l'instance lancee depuis workDir.\n",
-    "    public static async Task<string> DescribeAsync(string workDir) {\n",
-    "        var psi = new System.Diagnostics.ProcessStartInfo {\n",
-    "            FileName = \"cmd.exe\",\n",
-    "            Arguments = $\"/c \\\"{AspireCmd}\\\" describe whisper-api\",\n",
-    "            WorkingDirectory = workDir,\n",
-    "            RedirectStandardOutput = true,\n",
-    "            RedirectStandardError = true,\n",
-    "            UseShellExecute = false,\n",
-    "            CreateNoWindow = true\n",
-    "        };\n",
-    "        using var p = System.Diagnostics.Process.Start(psi)!;\n",
-    "        var o = p.StandardOutput.ReadToEnd();\n",
-    "        p.WaitForExit(30_000);\n",
-    "        return o + p.StandardError.ReadToEnd();\n",
-    "    }\n",
+    "    public static async Task<string> DescribeAsync(string workDir)\n",
+    "        => Run(workDir, AspireCmd, \"describe whisper-api\");\n",
     "\n",
     "    // Attente (poll) que la ressource soit Healthy.\n",
     "    public static async Task<string> WaitHealthyAsync(string workDir, int maxTries = 40) {\n",
@@ -494,22 +310,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mDémarrage de l’application Aspire en arrière-plan...\u001b[0m\r\n",
-      "\r\n",
-      "           \u001b[1;38;5;2mAppHost\u001b[0m:  apphost.cs                                                                                             \r\n",
-      "                                                                                                                            \r\n",
-      "   \u001b[1;38;5;2mTableau de bord\u001b[0m:  \u001b]8;id=125119718;https://localhost:56366/login?t=b8d00d2b870f83e46092db4773527667\u001b\\https://localhost:56366/login?t=b8d00d2b870f83e46092db4773527667\u001b]8;;\u001b\\                                       \r\n",
-      "                                                                                                                            \r\n",
-      "          \u001b[1;38;5;2mJournaux\u001b[0m:  \u001b]8;id=441064248;file:///C:/Users/jsboi/.aspire/logs/cli_20260814T014748898_detach-child_e48cb1cda803403986f0393ac3a4a0d3.log\u001b\\C:\\Users\\jsboi\\.aspire\\logs\\cli_20260814T014748898_detach-child_e48cb1cda803403986f0393ac3a4a0d3.log\u001b]8;;\u001b\\   \r\n",
-      "                                                                                                                            \r\n",
-      "               \u001b[1;38;5;2mPID\u001b[0m:  46944                                                                                                  \r\n",
-      "\r\n",
-      "\u001b[38;5;2m✅\u001b[0m AppHost a démarré correctement.\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mDémarrage de l’application Aspire en arrière-plan...\u001b[0m\r\n\r\n           \u001b[1;38;5;2mAppHost\u001b[0m:  apphost.cs                                                                                             \r\n                                                                                                                            \r\n   \u001b[1;38;5;2mTableau de bord\u001b[0m:  \u001b]8;id=2021999349;https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b\\https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b]8;;\u001b\\                                       \r\n                                                                                                                            \r\n          \u001b[1;38;5;2mJournaux\u001b[0m:  \u001b]8;id=1548037962;file:///C:/Users/jsboi/.aspire/logs/cli_20260819T195232561_detach-child_2508571847a24d019787b16f6eee02a1.log\u001b\\C:\\Users\\jsboi\\.aspire\\logs\\cli_20260819T195232561_detach-child_2508571847a24d019787b16f6eee02a1.log\u001b]8;;\u001b\\   \r\n                                                                                                                            \r\n               \u001b[1;38;5;2mPID\u001b[0m:  48344                                                                                                  \r\n\r\n\u001b[38;5;2m✅\u001b[0m AppHost a démarré correctement.\r\n\r\n"
     }
    ],
    "source": [
@@ -565,44 +368,24 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n",
-      "┌─────────────┬───────────┬─────────┬───────────┬────────────────────────┐\r\n",
-      "│ \u001b[1mNom\u001b[0m         │ \u001b[1mType\u001b[0m      │ \u001b[1mÉtat\u001b[0m    │ \u001b[1mIntégrité\u001b[0m │ \u001b[1mURLs\u001b[0m                   │\r\n",
-      "├─────────────┼───────────┼─────────┼───────────┼────────────────────────┤\r\n",
-      "│ \u001b]8;id=2112692135;https://localhost:56366/?resource=whisper-api-tdbvgtpv\u001b\\\u001b[38;5;222mwhisper-api\u001b[0m\u001b]8;;\u001b\\ │ Container │ \u001b[38;5;2mRunning\u001b[0m │ \u001b[38;5;2mHealthy\u001b[0m   │ \u001b]8;id=328434051;http://localhost:56367\u001b\\http://localhost:56367\u001b]8;;\u001b\\ │\r\n",
-      "└─────────────┴───────────┴─────────┴───────────┴────────────────────────┘\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌─────────────┬───────────┬─────────┬───────────┬────────────────────────┐\r\n│ \u001b[1mNom\u001b[0m         │ \u001b[1mType\u001b[0m      │ \u001b[1mÉtat\u001b[0m    │ \u001b[1mIntégrité\u001b[0m │ \u001b[1mURLs\u001b[0m                   │\r\n├─────────────┼───────────┼─────────┼───────────┼────────────────────────┤\r\n│ \u001b]8;id=854249969;https://localhost:56391/?resource=whisper-api-vfcyzdzx\u001b\\\u001b[38;5;222mwhisper-api\u001b[0m\u001b]8;;\u001b\\ │ Container │ \u001b[38;5;2mRunning\u001b[0m │ \u001b[38;5;2mHealthy\u001b[0m   │ \u001b]8;id=978713128;http://localhost:56392\u001b\\http://localhost:56392\u001b]8;;\u001b\\ │\r\n└─────────────┴───────────┴─────────┴───────────┴────────────────────────┘\r\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- aspire ps ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "--- aspire ps ---\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n",
-      "┌───────────────────────────────┬─────────┬────────┬───────┬─────────┬──────────────────────────────────────────────────────────────────┐\r\n",
-      "│ \u001b[1mChemin d’accès\u001b[0m                │ \u001b[1mStatus\u001b[0m  │ \u001b[1mSDK\u001b[0m    │ \u001b[1mPID\u001b[0m   │ \u001b[1mCLI PID\u001b[0m │ \u001b[1mTableau de bord\u001b[0m                                                  │\r\n",
-      "├───────────────────────────────┼─────────┼────────┼───────┼─────────┼──────────────────────────────────────────────────────────────────┤\r\n",
-      "│ GenAiStack.AppHost\\apphost.cs │ running │ 13.4.6 │ 46944 │ 22020   │ \u001b]8;id=1388646415;https://localhost:56366/login?t=b8d00d2b870f83e46092db4773527667\u001b\\https://localhost:56366/login?t=b8d00d2b870f83e46092db4773527667\u001b]8;;\u001b\\ │\r\n",
-      "└───────────────────────────────┴─────────┴────────┴───────┴─────────┴──────────────────────────────────────────────────────────────────┘\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌───────────────────────────────┬─────────┬────────┬───────┬─────────┬──────────────────────────────────────────────────────────────────┐\r\n│ \u001b[1mChemin d’accès\u001b[0m                │ \u001b[1mStatus\u001b[0m  │ \u001b[1mSDK\u001b[0m    │ \u001b[1mPID\u001b[0m   │ \u001b[1mCLI PID\u001b[0m │ \u001b[1mTableau de bord\u001b[0m                                                  │\r\n├───────────────────────────────┼─────────┼────────┼───────┼─────────┼──────────────────────────────────────────────────────────────────┤\r\n│ GenAiStack.AppHost\\apphost.cs │ running │ 13.4.6 │ 48344 │ 32192   │ \u001b]8;id=1286491098;https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b\\https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b]8;;\u001b\\ │\r\n└───────────────────────────────┴─────────┴────────┴───────┴─────────┴──────────────────────────────────────────────────────────────────┘\r\n\r\n"
     }
    ],
    "source": [
@@ -683,25 +466,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "URL du service orchestre (instance A) : http://localhost:56367\r\n"
-     ]
+     "name": "stdout",
+     "text": "URL du service orchestre (instance A) : http://localhost:56392\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "HTTP 200\r\n"
-     ]
+     "name": "stdout",
+     "text": "HTTP 200\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "{\"text\":\"Bonjour du cluster Aspire. Cette phrase sera transcrite par le service Whisper Orchestra en temps réel.\",\"language\":\"fr\",\"duration\":8.178375,\"words\":null,\"segments\":null}\r\n"
-     ]
+     "name": "stdout",
+     "text": "{\"text\":\"Bonjour du cluster Aspire. Cette phrase sera transcrite par le service Whisper Orchestra en temps réel.\",\"language\":\"fr\",\"duration\":8.178375,\"words\":null,\"segments\":null}\r\n"
     }
    ],
    "source": [
@@ -713,7 +490,10 @@
     "// Appel REEL : multipart POST de l'echantillon -> transcription faster-whisper.\n",
     "// NB : pas de `using var` au top-level (non supporte par le scripting Roslyn,\n",
     "// CS1002/CS1519 - c.257-L4) : dispose explicite en fin de cellule.\n",
-    "var client = new HttpClient();\n",
+    "// Timeout explicite 10 min : le defaut HttpClient (100 s) expirait au PREMIER\n",
+    "// appel, quand le conteneur telecharge encore le modele (~1,6 Go) depuis HF --\n",
+    "// les appels suivants (modele en cache) sont en secondes.\n",
+    "var client = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };\n",
     "var form = new MultipartFormDataContent();\n",
     "var fs = File.OpenRead(AspireShell.WavPath);\n",
     "form.Add(new StreamContent(fs), \"file\", Path.GetFileName(AspireShell.WavPath));\n",
@@ -801,35 +581,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mDémarrage de l’application Aspire en arrière-plan...\u001b[0m\r\n",
-      "\r\n",
-      "           \u001b[1;38;5;2mAppHost\u001b[0m:  apphost.cs                                                                                             \r\n",
-      "                                                                                                                            \r\n",
-      "   \u001b[1;38;5;2mTableau de bord\u001b[0m:  \u001b]8;id=1415723215;https://localhost:49403/login?t=65b7e9a510afac4eea68c4bb316113d6\u001b\\https://localhost:49403/login?t=65b7e9a510afac4eea68c4bb316113d6\u001b]8;;\u001b\\                                       \r\n",
-      "                                                                                                                            \r\n",
-      "          \u001b[1;38;5;2mJournaux\u001b[0m:  \u001b]8;id=1164728002;file:///C:/Users/jsboi/.aspire/logs/cli_20260814T014815913_detach-child_72e916a662cd4285b5959fae8dbb8af7.log\u001b\\C:\\Users\\jsboi\\.aspire\\logs\\cli_20260814T014815913_detach-child_72e916a662cd4285b5959fae8dbb8af7.log\u001b]8;;\u001b\\   \r\n",
-      "                                                                                                                            \r\n",
-      "               \u001b[1;38;5;2mPID\u001b[0m:  63200                                                                                                  \r\n",
-      "\r\n",
-      "\u001b[38;5;2m✅\u001b[0m AppHost a démarré correctement.\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mDémarrage de l’application Aspire en arrière-plan...\u001b[0m\r\n\r\n           \u001b[1;38;5;2mAppHost\u001b[0m:  apphost.cs                                                                                             \r\n                                                                                                                            \r\n   \u001b[1;38;5;2mTableau de bord\u001b[0m:  \u001b]8;id=665276441;https://localhost:64053/login?t=9a7ab1e90a18f8ad0d4d54545b4e0910\u001b\\https://localhost:64053/login?t=9a7ab1e90a18f8ad0d4d54545b4e0910\u001b]8;;\u001b\\                                       \r\n                                                                                                                            \r\n          \u001b[1;38;5;2mJournaux\u001b[0m:  \u001b]8;id=1251164721;file:///C:/Users/jsboi/.aspire/logs/cli_20260819T195302859_detach-child_4f6e9781f9b847fcbb476ccb217ac693.log\u001b\\C:\\Users\\jsboi\\.aspire\\logs\\cli_20260819T195302859_detach-child_4f6e9781f9b847fcbb476ccb217ac693.log\u001b]8;;\u001b\\   \r\n                                                                                                                            \r\n               \u001b[1;38;5;2mPID\u001b[0m:  54224                                                                                                  \r\n\r\n\u001b[38;5;2m✅\u001b[0m AppHost a démarré correctement.\r\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n",
-      "┌─────────────┬───────────┬─────────┬───────────┬────────────────────────┐\r\n",
-      "│ \u001b[1mNom\u001b[0m         │ \u001b[1mType\u001b[0m      │ \u001b[1mÉtat\u001b[0m    │ \u001b[1mIntégrité\u001b[0m │ \u001b[1mURLs\u001b[0m                   │\r\n",
-      "├─────────────┼───────────┼─────────┼───────────┼────────────────────────┤\r\n",
-      "│ \u001b]8;id=1194608217;https://localhost:49403/?resource=whisper-api-tbafyjdz\u001b\\\u001b[38;5;222mwhisper-api\u001b[0m\u001b]8;;\u001b\\ │ Container │ \u001b[38;5;2mRunning\u001b[0m │ \u001b[38;5;2mHealthy\u001b[0m   │ \u001b]8;id=68970726;http://localhost:49404\u001b\\http://localhost:49404\u001b]8;;\u001b\\ │\r\n",
-      "└─────────────┴───────────┴─────────┴───────────┴────────────────────────┘\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌─────────────┬───────────┬─────────┬───────────┬────────────────────────┐\r\n│ \u001b[1mNom\u001b[0m         │ \u001b[1mType\u001b[0m      │ \u001b[1mÉtat\u001b[0m    │ \u001b[1mIntégrité\u001b[0m │ \u001b[1mURLs\u001b[0m                   │\r\n├─────────────┼───────────┼─────────┼───────────┼────────────────────────┤\r\n│ \u001b]8;id=1900202500;https://localhost:64053/?resource=whisper-api-kfxcbefm\u001b\\\u001b[38;5;222mwhisper-api\u001b[0m\u001b]8;;\u001b\\ │ Container │ \u001b[38;5;2mRunning\u001b[0m │ \u001b[38;5;2mHealthy\u001b[0m   │ \u001b]8;id=1695160795;http://localhost:64052\u001b\\http://localhost:64052\u001b]8;;\u001b\\ │\r\n└─────────────┴───────────┴─────────┴───────────┴────────────────────────┘\r\n\r\n"
     }
    ],
    "source": [
@@ -857,10 +616,9 @@
    "source": [
     "### Lecture : deux AppHosts vivants\n",
     "\n",
-    "Le second lancement s'est déroulé à l'identique — dashboard sur un **autre port**, autre PID. Le snapshot de la ressource de l'instance B montre un URL **différent** : les deux instances coexistent, chacune avec son port hôte éphémère.",
+    "Le second lancement s'est déroulé à l'identique — dashboard sur un **autre port**, autre PID. Le snapshot de la ressource de l'instance B montre un URL **différent** : les deux instances coexistent, chacune avec son port hôte éphémère.\n",
     "\n",
-    "\n",
-    "La sortie repond point par point a l'hypothese. Les DEUX lignes de la table sont `running` — l'AppHost original (PID `46944`) et le second (PID `63200`) coexistent. Chacun a son tableau de bord propre (`56366` pour A, `49403` pour B) et son conteneur `whisper-api` dedie (suffixes `tdbvgtpv` et `tbafyjdz`). Le verdict final est explicite : `Ports distincts : True (A=56367, B=49404)` — les deux services orchestres sont joignables EN MEME TEMPS sur des ports differents. C'est la parite d'isolation promise par `--isolated`, mesuree et non allegee.\n"
+    "La sortie repond point par point a l'hypothese. Les DEUX lignes de la table `aspire ps` sont `running` — l'AppHost original et le second coexistent, chacun avec son PID et son tableau de bord propre. Le verdict final est explicite : `Ports distincts : True` (les valeurs A et B affichees par la cellule) — les deux services orchestres sont joignables EN MEME TEMPS sur des ports differents, et la section `docker ps` montre les DEUX conteneurs `whisper-api-<suffixe>` alive. C'est la parite d'isolation promise par `--isolated`, mesuree et non allegee.\n"
    ]
   },
   {
@@ -885,62 +643,39 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- aspire ps (attendu : 2 AppHosts) ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "--- aspire ps (attendu : 2 AppHosts) ---\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n",
-      "┌───────────────────────────────────┬─────────┬────────┬───────┬─────────┬──────────────────────────────────────────────────────────────────┐\r\n",
-      "│ \u001b[1mChemin d’accès\u001b[0m                    │ \u001b[1mStatus\u001b[0m  │ \u001b[1mSDK\u001b[0m    │ \u001b[1mPID\u001b[0m   │ \u001b[1mCLI PID\u001b[0m │ \u001b[1mTableau de bord\u001b[0m                                                  │\r\n",
-      "├───────────────────────────────────┼─────────┼────────┼───────┼─────────┼──────────────────────────────────────────────────────────────────┤\r\n",
-      "│ GenAiStack.AppHost\\apphost.cs     │ running │ 13.4.6 │ 46944 │ 22020   │ \u001b]8;id=587491167;https://localhost:56366/login?t=b8d00d2b870f83e46092db4773527667\u001b\\https://localhost:56366/login?t=b8d00d2b870f83e46092db4773527667\u001b]8;;\u001b\\ │\r\n",
-      "│ GenAiStack.AppHost-wt2\\apphost.cs │ running │ 13.4.6 │ 63200 │ 50264   │ \u001b]8;id=1396395558;https://localhost:49403/login?t=65b7e9a510afac4eea68c4bb316113d6\u001b\\https://localhost:49403/login?t=65b7e9a510afac4eea68c4bb316113d6\u001b]8;;\u001b\\ │\r\n",
-      "└───────────────────────────────────┴─────────┴────────┴───────┴─────────┴──────────────────────────────────────────────────────────────────┘\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌───────────────────────────────────┬─────────┬────────┬───────┬─────────┬──────────────────────────────────────────────────────────────────┐\r\n│ \u001b[1mChemin d’accès\u001b[0m                    │ \u001b[1mStatus\u001b[0m  │ \u001b[1mSDK\u001b[0m    │ \u001b[1mPID\u001b[0m   │ \u001b[1mCLI PID\u001b[0m │ \u001b[1mTableau de bord\u001b[0m                                                  │\r\n├───────────────────────────────────┼─────────┼────────┼───────┼─────────┼──────────────────────────────────────────────────────────────────┤\r\n│ GenAiStack.AppHost\\apphost.cs     │ running │ 13.4.6 │ 48344 │ 32192   │ \u001b]8;id=2084089366;https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b\\https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b]8;;\u001b\\ │\r\n│ GenAiStack.AppHost-wt2\\apphost.cs │ running │ 13.4.6 │ 54224 │ 42072   │ \u001b]8;id=112587784;https://localhost:64053/login?t=9a7ab1e90a18f8ad0d4d54545b4e0910\u001b\\https://localhost:64053/login?t=9a7ab1e90a18f8ad0d4d54545b4e0910\u001b]8;;\u001b\\ │\r\n└───────────────────────────────────┴─────────┴────────┴───────┴─────────┴──────────────────────────────────────────────────────────────────┘\r\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "URL du service orchestre (instance B) : http://localhost:49404\r\n"
-     ]
+     "name": "stdout",
+     "text": "URL du service orchestre (instance B) : http://localhost:64052\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Ports distincts : True  (A=56367, B=49404)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Ports distincts : True  (A=56392, B=64052)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--- docker ps (conteneurs whisper) ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "--- docker ps (conteneurs whisper) ---\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "'docker\" ps --filter name=whisper-api --format \"{{.Names}}' n’est pas reconnu en tant que commande interne\r\n",
-      "ou externe, un programme exécutable ou un fichier de commandes.\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "whisper-api-kfxcbefm  127.0.0.1:64077->8190/tcp\nwhisper-api-vfcyzdzx  127.0.0.1:56405->8190/tcp\n\r\n"
     }
    ],
    "source": [
@@ -972,13 +707,13 @@
    "source": [
     "### Interprétation : pourquoi `--isolated` supprime la dette\n",
     "\n",
-    "Trois mécanismes, tous **prouvés** par les sorties ci-dessus :\n",
+    "Deux mécanismes **prouvés** par les sorties ci-dessus, un troisième **structurel** (vrai par construction, non observable dans les sorties) :\n",
     "\n",
     "| Mécanisme | Preuve dans les sorties |\n",
     "|---|---|\n",
     "| **Ports randomisés** | l'URL de l'instance A (`http://localhost:PORT_A`) diffère de celle de B (`PORT_B`) — aucun port fixé à la main |\n",
     "| **Noms de conteneurs suffixés** | les deux conteneurs `whisper-api-<suffixe>` coexistent côté Docker (le suffixe aléatoire évite la collision de noms) |\n",
-    "| **User secrets isolés** | chaque instance a son propre ensemble de secrets de développement — un secret modifié dans un worktree ne fuit pas dans l'autre |\n",
+    "| **User secrets isolés** | chaque AppHost est lancé depuis son propre répertoire de worktree, et les user secrets .NET sont stockés par répertoire de projet — un secret modifié dans un worktree ne fuit pas dans l'autre |\n",
     "\n",
     "Le coût de cette isolation en `docker compose` manuel : dupliquer le YAML, renuméroter les ports, relancer à la main. En Aspire : **un drapeau** (`--isolated`) + un répertoire par worktree. C'est exactement la ligne « Isolation de ports par worktree » de la table de parité de l'Epic."
    ]
@@ -1024,64 +759,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n",
-      "\u001b[2mRécupération des journaux...\u001b[0m\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m No custom certificate authorities to configure for 'whisper-api'. Default certificate authority trust behavior will be used.\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m 2d94ac4e184b5c9a74a8393661d9cfd8104b9d198612a58cd425f9dbacbaa610\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m [sys] Added new ContainerNetworkConnection: ContainerName = whisper-api-tdbvgtpv\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m \r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m 2d94ac4e184b5c9a74a8393661d9cfd8104b9d198612a58cd425f9dbacbaa610\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m \r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m ==========\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m == CUDA ==\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m ==========\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m \r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m CUDA Version 12.1.0\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m \r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m \r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m This container image and its contents are governed by the NVIDIA Deep Learning Container License.\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m By pulling and using the container, you accept the terms and conditions of this license:\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m \r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m \r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m *************************\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m ** DEPRECATION NOTICE! **\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m *************************\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m THIS IMAGE IS DEPRECATED and is scheduled for DELETION.\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m     https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/support-policy.md\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m \r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m Starting Whisper API...\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m Model: large-v3-turbo\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m Device: cuda\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m Compute Type: int8_float16\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m WARNING:auth-middleware:AUTH_ENABLED=false - Authentication explicitly DISABLED\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m WARNING:auth-middleware:Auth middleware NOT installed - API is open\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Started server process [1]\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Waiting for application startup.\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Started idle checker (timeout: 1200s)\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Starting idle checker task (interval: 60s)\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Application startup complete.\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Uvicorn running on http://0.0.0.0:8190 (Press CTRL+C to quit)\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     127.0.0.1:48506 - \"GET /health HTTP/1.1\" 200 OK\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Loading model: whisper\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Loading Whisper model: large-v3-turbo on cuda (int8_float16)\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/mobiuslabsgmbh/faster-whisper-large-v3-turbo/revision/main \"HTTP/1.1 307 Temporary \r\n",
-      "Redirect\"\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/dropbox-dash/faster-whisper-large-v3-turbo/revision/main \"HTTP/1.1 200 OK\"\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Model whisper loaded in 13.6s\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:Processing audio with duration 00:08.178\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:VAD filter removed 00:00.482 of audio\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:Detected language 'fr' with probability 1.00\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Transcribed 8.2s audio in 14.37s (lang: fr)\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     192.168.80.1:60456 - \"POST /v1/audio/transcriptions HTTP/1.1\" 200 OK\r\n",
-      "\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     127.0.0.1:54042 - \"GET /health HTTP/1.1\" 200 OK\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n\u001b[2mRécupération des journaux...\u001b[0m\r\n\u001b[38;5;222m[whisper-api]\u001b[0m No custom certificate authorities to configure for 'whisper-api'. Default certificate authority trust behavior will be used.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m 416a76cc39dda965fd7eae74062899295f1f432f0e8ed36e5309959bdaef8a3d\r\n\u001b[38;5;222m[whisper-api]\u001b[0m [sys] Added new ContainerNetworkConnection: ContainerName = whisper-api-vfcyzdzx\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m 416a76cc39dda965fd7eae74062899295f1f432f0e8ed36e5309959bdaef8a3d\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m ==========\r\n\u001b[38;5;222m[whisper-api]\u001b[0m == CUDA ==\r\n\u001b[38;5;222m[whisper-api]\u001b[0m ==========\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m CUDA Version 12.1.0\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m This container image and its contents are governed by the NVIDIA Deep Learning Container License.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m By pulling and using the container, you accept the terms and conditions of this license:\r\n\u001b[38;5;222m[whisper-api]\u001b[0m https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m *************************\r\n\u001b[38;5;222m[whisper-api]\u001b[0m ** DEPRECATION NOTICE! **\r\n\u001b[38;5;222m[whisper-api]\u001b[0m *************************\r\n\u001b[38;5;222m[whisper-api]\u001b[0m THIS IMAGE IS DEPRECATED and is scheduled for DELETION.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m     https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/support-policy.md\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m Starting Whisper API...\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Model: large-v3-turbo\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Device: cuda\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Compute Type: int8_float16\r\n\u001b[38;5;222m[whisper-api]\u001b[0m WARNING:auth-middleware:AUTH_ENABLED=false - Authentication explicitly DISABLED\r\n\u001b[38;5;222m[whisper-api]\u001b[0m WARNING:auth-middleware:Auth middleware NOT installed - API is open\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Started server process [1]\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Waiting for application startup.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Started idle checker (timeout: 1200s)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Starting idle checker task (interval: 60s)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Application startup complete.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Uvicorn running on http://0.0.0.0:8190 (Press CTRL+C to quit)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Loading model: whisper\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Loading Whisper model: large-v3-turbo on cuda (int8_float16)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/mobiuslabsgmbh/faster-whisper-large-v3-turbo/revision/main \"HTTP/1.1 307 Temporary \r\nRedirect\"\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/dropbox-dash/faster-whisper-large-v3-turbo/revision/main \"HTTP/1.1 200 OK\"\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Model whisper loaded in 15.0s\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:Processing audio with duration 00:08.178\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \u001b[0;93m2026-08-19 19:53:03.171453034 [W:onnxruntime:Default, telemetry.cc:800 operator()] Failed to persist telemetry device ID; using an in-memory identifier\u001b[m\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:VAD filter removed 00:00.482 of audio\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:Detected language 'fr' with probability 1.00\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Transcribed 8.2s audio in 15.79s (lang: fr)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     172.19.0.1:45984 - \"POST /v1/audio/transcriptions HTTP/1.1\" 200 OK\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     127.0.0.1:35788 - \"GET /health HTTP/1.1\" 200 OK\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     127.0.0.1:34718 - \"GET /health HTTP/1.1\" 200 OK\r\n\r\n"
     }
    ],
    "source": [
@@ -1154,11 +834,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     }
    ],
    "source": [
@@ -1200,11 +878,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "-1\r\n"
-     ]
+     "name": "stdout",
+     "text": "-1\r\n"
     }
    ],
    "source": [
@@ -1245,20 +921,14 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "(aucune URL exposee)\r\n"
-     ]
+     "name": "stdout",
+     "text": "(aucune URL exposee)\r\n"
     },
     {
-     "name": "stderr",
      "output_type": "stream",
-     "text": [
-      "\r\n",
-      "(8,7): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n",
-      "\r\n"
-     ]
+     "name": "stderr",
+     "text": "\r\n(8,7): warning CS8632: L'annotation pour les types référence Nullable doit être utilisée uniquement dans le code au sein d'un contexte d'annotations '#nullable'.\r\n\r\n"
     }
    ],
    "source": [
@@ -1331,37 +1001,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n",
-      "\u001b[38;5;11m📦\u001b[0m Found running AppHost: apphost.cs\r\n",
-      "\u001b[38;5;9m🛑\u001b[0m Sending stop signal to apphost.cs...\r\n",
-      "\u001b[2mStopping apphost.cs...\u001b[0m\r\n",
-      "\r\n",
-      "\u001b[38;5;2m✅\u001b[0m apphost.cs stopped successfully.\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n\u001b[2mScanning for running AppHosts...\u001b[0m\r\n\u001b[38;5;11m📦\u001b[0m Found running AppHost: apphost.cs\r\n\u001b[38;5;9m🛑\u001b[0m Sending stop signal to apphost.cs...\r\n\u001b[2mStopping apphost.cs...\u001b[0m\r\n\r\n\u001b[38;5;2m✅\u001b[0m apphost.cs stopped successfully.\r\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n",
-      "\u001b[38;5;11m📦\u001b[0m Found running AppHost: apphost.cs\r\n",
-      "\u001b[38;5;9m🛑\u001b[0m Sending stop signal to apphost.cs...\r\n",
-      "\u001b[2mStopping apphost.cs...\u001b[0m\r\n",
-      "\r\n",
-      "\u001b[38;5;2m✅\u001b[0m apphost.cs stopped successfully.\r\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n\u001b[2mScanning for running AppHosts...\u001b[0m\r\n\u001b[38;5;11m📦\u001b[0m Found running AppHost: apphost.cs\r\n\u001b[38;5;9m🛑\u001b[0m Sending stop signal to apphost.cs...\r\n\u001b[2mStopping apphost.cs...\u001b[0m\r\n\r\n\u001b[38;5;2m✅\u001b[0m apphost.cs stopped successfully.\r\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Instances arretees - conteneurs Aspire supprimes, pile manuelle intacte.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Instances arretees - conteneurs Aspire supprimes, pile manuelle intacte.\r\n"
     }
    ],
    "source": [
@@ -1385,18 +1037,6 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 64.793066,
-   "end_time": "2026-08-14T01:48:48.976129",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "01-Aspire-Orchestration-GenAi.ipynb",
-   "output_path": "01-Aspire-Orchestration-GenAi.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-14T01:47:44.183063",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2025:CoursIA-2 — prev: MED/qc #11842

## Summary

Grain #11701 (dispatch ai-01, msg-20260819T190428) : dans `GenAI/Aspire/01-Aspire-Orchestration-GenAi.ipynb`, la cellule 16 (preuve d'isolation) échouait sur une erreur de shell `cmd.exe` — `'docker" ps --filter name=whisper-api --format "{{.Names}}' n'est pas reconnu...` (vérifié firsthand sur `origin/main` : l'erreur est committée dans la sortie) — et la cellule 17 invoquait **exactement cette sortie en échec** comme preuve du mécanisme « noms de conteneurs suffixés ».

### Fix 1 (option b du dispatch : supprimer la classe, pas la contourner) — cellule 3

La cause : `cmd.exe /c` réécrit toute ligne portant **plus d'une paire** de guillemets (retire le 1er et le dernier). Le helper `Run` wrappait systématiquement dans `cmd.exe /c "{cmd}" {args}` — dès que `args` porte des quotes (ici `--format "{{.Names}}"`), la ligne se corrompt.

**Décision écrite (demandée par le dispatch)** : route (b) — **ne pas passer par le shell du tout** quand la cible est un exécutable. `Run` distingue désormais :

- `.cmd` (ex. `aspire.cmd`, un `.cmd` **exige** un interpréteur) → `cmd.exe /c "..." {args}` inchangé (une seule paire de guillemets, les args d'aspire n'en portent aucun — la règle cmd.exe ne mord pas) ;
- tout autre exécutable (ex. `docker`, résolu via le PATH par `Process.Start`) → `FileName = cmd, Arguments = args` **directement**, sans shell intermédiaire — la classe entière des réécritures cmd.exe disparaît.

Pourquoi pas la route (a) (doubler la paire externe `\"\"...\"\"`) : c'est le contournement canonique de la règle, mais il préserve le shell inutile au prix d'une syntaxe fragile que le prochain contributeur lira sans comprendre. La (b) supprime le mécanisme fauteur.

`DescribeAsync` refactoré pour déléguer à `Run` (élimine la duplication du ProcessStartInfo ; aspire.cmd suit le chemin `.cmd` → comportement inchangé).

### Fix 2 (découvert à la re-exécution) — cellule 11

Le premier run complet a échoué sur la cellule 11 (transcription) : `TaskCanceledException` au **timeout HttpClient par défaut de 100 s** — le conteneur téléchargeait encore le modèle faster-whisper (~1,6 Go, chargement paresseux au 1er appel) quand le client a expiré. Fix source (pas de contournement) :

- `new HttpClient()` → `new HttpClient { Timeout = TimeSpan.FromMinutes(10) }`, avec commentaire expliquant le pourquoi (1er appel = téléchargement, appels suivants = secondes) ;
- modèle **pré-téléchargé** dans le cache HF **hôte** (`snapshot_download('mobiuslabsgmbh/faster-whisper-large-v3-turbo')`) — le chemin prévu par l'AppHost, qui bind-mounte `~/.cache/huggingface` dans le conteneur.

### Re-exécution réelle (Stop & Repair — la sortie se répare par exécution, jamais à la main)

Machine **myia-po-2025**, pile complète installée pour ce grain (règle F — la mémoire « po-2025 CPU-only » est **périmée**, vérifié firsthand : RTX 3080 Laptop 16 GB, `docker run --gpus all nvidia-smi` OK) :

- `aspire.cli` 13.5.0 installé (`dotnet tool install --global aspire.cli`) ;
- image `whisper-api-whisper-api` rebuildée depuis `docker-configurations/services/whisper-api/` ;
- exécution complète 27 cellules via `scripts/notebook_tools/dotnet_executor.py` : **11/11 cellules code, 0 erreur, 57,6 s**, `execution_count` 1→11 sur toutes les cellules code (C.2/H.1) ;
- transcription **réelle** : `HTTP 200`, `{"text":"Bonjour du cluster Aspire. Cette phrase sera transcrit...", "language":"fr", "duration":8.18}` — le WAV échantillon transcrit par faster-whisper large-v3-turbo sur GPU ;
- preuve d'isolation cellule 16, sortie réelle :

```
--- docker ps (conteneurs whisper) ---
whisper-api-kfxcbefm  127.0.0.1:64077->8190/tcp
whisper-api-vfcyzdzx  127.0.0.1:56405->8190/tcp
```

Deux conteneurs suffixés coexistent, deux ports hôtes distincts, `Ports distincts : True` — la ligne « noms de conteneurs suffixés » du tableau de la cellule 17 est désormais adossée à une vraie sortie.

### Cellules 15/17 (corrigées dans le même geste, comme exigé)

- **Cellule 15** : la prose citait des valeurs **gelées d'un run précédent** (PID `46944`/`63200`, dashboards `56366`/`49403`, suffixes `tdbvgtpv`/`tbafyjdz`, ports `56367`/`49404`) — fausses pour ce run ET pour tout run futur (ports/suffixes/PIDS éphémères par conception). Remplacées par des ancrages **structurels** présents tels quels dans toute exécution : deux lignes `running` dans `aspire ps`, la ligne verbatim `Ports distincts : True`, deux conteneurs `whisper-api-<suffixe>` dans `docker ps`.
- **Cellule 17** : l'en-tête « Trois mécanismes, tous **prouvés** par les sorties » sur-claimait — les sorties prouvent les ports et les noms suffixés, pas les user secrets. Corrigé en « Deux mécanismes **prouvés**... un troisième **structurel** (vrai par construction, non observable dans les sorties) », et la ligne user secrets reformulée sur son mécanisme (secrets .NET stockés par répertoire de projet, un AppHost par worktree).

## Validation

1. `dotnet_executor.py` : **11/11 cells, 0 errors, 57,6 s** (log ci-dessus).
2. `strip_probe_banner.py --apply` : 1 bannière probeAddresses retirée post-exec.
3. `validate_pr_notebooks.py` : **PASS** (11 cells, `.net-csharp`).
4. Vérif C.1 : 0 erreur volontaire — stubs d'exercices intacts (`pass`-équivalents).
5. Vérif anti-régression pédagogique : 27 cellules conservées, aucun `# Exemple résolu` supprimé ; les déletions du diff sont les **anciennes sorties** (erreur cmd.exe committée sur main dans la cellule 16) remplacées par les sorties réelles de ce run.

## Notes

- Verdict SOTA réévalué : l'issue disait `RECOVERABLE-MACHINE` — **réévalué `SOTA-OK` sur myia-po-2025** (GPU Docker vérifié firsthand ; la contrainte supposée CPU-only ne tient plus).
- Température GPU surveillée pendant la transcription (~84 °C, inference unique de ~8 s d'audio — pas de training, l'interdit mémoire vise le training non supervisé).
- aspire CLI 13.5.0 vs SDK 13.4.6 : la version affichée par la cellule 3 est la sortie réelle de CE run (`13.5.0+e076d8e...`).
- **Défaut adjacent signalé (hors scope, principe 3)** : le commentaire de la cellule 26 (« Aspire supprime leurs conteneurs à l'arrêt », préexistant sur main) est contredit par l'observation — après `aspire stop` réussi, les conteneurs `whisper-api-*` restent `Up` sur cette machine (Docker Desktop). Les conteneurs ont été retirés à la main pour l'hygiène machine ; le commentaire mérite un ajustement en PR séparée.

Closes #11701

Co-Authored-By: Claude-Code <noreply@anthropic.com>
