### PR TITLE
fix(twin-parity): csp-3 last-audit python_sha jamais blob -- Scripts Tests rouge sur main, bloque la flotte

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-3-advanced.yaml
@@ -40,6 +40,12 @@
       csharp_sha: 7e97fae158d43d849d56cc0fbd91671452e15184
       content_python_sha: 63a80ea314cee32b4822dcd7d4fc06fc88863e1acfb14f28f65a4c8a266a11ac
       content_csharp_sha: a48883881358fcfcec35103227c761928c7069a50048ebbce1aaf70fbacabec8
+    - date: "2026-08-19"
+      by: myia-po-2024:CoursIA
+      python_sha: f11cb0b7eefd212a6dd08f68c0f22613ad735ac8
+      csharp_sha: 7e97fae158d43d849d56cc0fbd91671452e15184
+      content_python_sha: 63a80ea314cee32b4822dcd7d4fc06fc88863e1acfb14f28f65a4c8a266a11ac
+      content_csharp_sha: a48883881358fcfcec35103227c761928c7069a50048ebbce1aaf70fbacabec8
   known_differences:
     - "Socle pedagogique commun : global constraints (all_different, sum, element) + backtracking avec propagation globale + symetrie breaking (lexicographique)."
     - "Cote C# : Choco-solver (memes recettes infrastructure) - global constraints implementes en Python pur (classe AllDifferent via matching de Hall), cote C# delegue a Choco.IntVar+Constraint via IKVM."


### PR DESCRIPTION
Grain: LIGHT/ledger — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #11839

## Main est rouge — hotfix prioritaire

`test_audit_shas_exist_in_file_history` échoue sur **origin/main HEAD** (vérifié en worktree détaché, 3.88 s) : l'entrée d'audit posée par 11804 sur `csp-3-advanced.yaml` enregistre `python_sha: 7d54b359` pour `CSP-3-Advanced.ipynb` — un SHA absent de l'historique du fichier **sur main** — le blob a existé sur la branche d'origine (commit 465846607), mais le notebook a été re-modifié ensuite (retrait d'un bloc `metadata.papermill` périmé, ee5284f1b) et le **squash-merge** de 11804 a collapse les deux commits : le blob intermédiaire n'a jamais atteint `main`, rendant l'entrée invalidable (analyse corrigée par ai-01, msg 2026-08-19T23:05). Conséquence : `Scripts Tests (CPU)` rouge pour **toute PR basée sur le main courant** (y compris #11839, détecté au triage des guards de ce cycle).

## Cause racine

Mécanique mesurée par ai-01 : `--update` a été joué au **milieu** de la branche (commit 465846607 → blob 7d54b359), puis le notebook a rebougé (ee5284f1b, retrait metadata.papermill — geste délibéré, pas une normalisation pre-commit), et le squash a effacé le commit intermédiaire. Le blob committé sur main est `f11cb0b7` : le SHA enregistré pointe un état intermédiaire orphelin. Le `csharp_sha` (7e97fae1), lui, est correct. Règle couvrante (généralise le rappel de l'outil, #8957) : **`--update` se joue en dernier commit avant push, et si le fichier rebouge ensuite, on rejoue `--update`** — toute édition postérieure orpheline le blob enregistré, et le squash garantit qu'il n'atteindra jamais main. Tout registre qui enregistre un blob SHA en cours de branche est invalide par le squash dès que le fichier est retouché.

## Fix (outillé, zéro SHA écrit à la main)

`check_twin_parity.py --pair "CSP-3 Advanced" --update --force --by myia-po-2024:CoursIA` — append une entrée d'audit fraîche portant les SHAs réels (python `f11cb0b7`, csharp inchangé). Le test d'intégrité valide le **dernier** audit de chaque paire : l'entrée fraîche le satisfait. Le `--force` assume l'avertissement no-op du design-gate 9399 (contenu inchangé) : l'information nouvelle est réelle — c'est la réparation d'un SHA factice, pas une datation d'attestation.

## Validation

- `pytest test_twin_registry_integrity.py` : **30 passed** (sur worktree origin/main avant/après)
- `check_twin_parity.py` : **157 OK / 0 DRIFT / 0 MISSING**

## Scope

1 fichier (csp-3-advanced.yaml), +6 lignes (append d'entrée d'audit par l'outil). See #10382 (contribution à l'epic). Claim posé c.5347832099 (paths: csp-3-advanced.yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


