### PR TITLE
fix(guard,#11850): pyyaml absent du runner = scan closure mort en silence + ImportError distinct du YAML invalide

### DIFF
--- a/.github/workflows/markdown-rendering-guard.yml
+++ b/.github/workflows/markdown-rendering-guard.yml
@@ -68,6 +68,13 @@ jobs:
         with:
           python-version: '3.11'
 
+      # The Quarto closure scan (below) reads _quarto.yml via PyYAML -- a bare
+      # setup-python environment does not provide it, and pre-#11850 the
+      # resulting ImportError was swallowed as an "empty render-list", killing
+      # the closure scan while accusing _quarto.yml of being invalid.
+      - name: "Install detector dependencies (pyyaml for the closure scan)"
+        run: pip install pyyaml
+
       - name: "HARD gate -- fail on any NEW frontmatter / setext oversize"
         run: |
           if ! python scripts/notebook_tools/detect_markdown_rendering.py \

--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -534,15 +534,27 @@ def gather(root: Path) -> list[dict]:
 def _quarto_render_list(quarto_yml: Path) -> list[Path]:
     """Files Quarto renders explicitly listed under ``project.render``.
 
-    Returns relative paths (as they appear in the YAML). Empty list on parse
-    failure or missing key -- the caller falls back to the full repo scan.
+    Returns relative paths (as they appear in the YAML). Empty list on a
+    missing file, invalid YAML or missing key -- the caller falls back to the
+    full repo scan. A missing PyYAML dependency is NOT an empty-list case:
+    it raises RuntimeError naming the dependency, so a dead closure scan can
+    never masquerade as "nothing to render" (#11850 -- pre-fix, a runner
+    without pyyaml silently scanned 0 of 792 render-list entries while the
+    error accused _quarto.yml of being empty/invalid).
     """
     if not quarto_yml.exists():
         return []
     try:
         import yaml  # local import: the script otherwise stays yaml-free
+    except ImportError as exc:
+        raise RuntimeError(
+            "pyyaml is not installed -- the Quarto render-list cannot be read. "
+            "This is a missing dependency (fix: pip install pyyaml), NOT an "
+            "empty or invalid quarto-yml."
+        ) from exc
+    try:
         data = yaml.safe_load(quarto_yml.read_text(encoding="utf-8"))
-    except Exception:
+    except yaml.YAMLError:
         return []
     render = (((data or {}).get("project") or {}).get("render") or [])
     out: list[Path] = []
@@ -691,7 +703,8 @@ def gather_closure(repo_root: Path, quarto_yml: Path) -> list[dict]:
     See ``_notebook_targets_from_render_list`` for the definition. Returns the
     same finding shape as ``gather``. Empty list on YAML parse failure (the
     caller decides whether to fail or fall back -- the CLI exits 2 with a
-    clear message).
+    clear message). Raises RuntimeError when pyyaml is missing -- never
+    report an empty closure for an unreadable dependency (#11850).
     """
     render_paths = _quarto_render_list(quarto_yml)
     if not render_paths:
@@ -759,7 +772,13 @@ def main(argv=None) -> int:
         # from any rendered page. See #11630. Repo-root = the directory holding
         # _quarto.yml (we resolve relative to the cwd, same as the YAML path).
         repo_root = args.quarto_yml.resolve().parent
-        render_paths = _quarto_render_list(args.quarto_yml)
+        try:
+            render_paths = _quarto_render_list(args.quarto_yml)
+        except RuntimeError as exc:
+            # Missing pyyaml -- name the dependency, never the YAML file
+            # (#11850: this used to exit as "empty/invalid _quarto.yml").
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
         if not render_paths:
             print(f"error: --closure requires a parseable {args.quarto_yml} "
                   f"with a project.render list; got empty/invalid", file=sys.stderr)

--- a/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
+++ b/scripts/notebook_tools/tests/test_detect_markdown_rendering.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -33,6 +34,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import detect_markdown_rendering  # noqa: E402
 from detect_markdown_rendering import (  # noqa: E402
     _inside_fence_lines,
     _is_frontmatter_block,
@@ -815,6 +817,75 @@ class TestQuartoClosure:
             assert Path(f"docs/{name}.ipynb") in targets, (
                 f"link '...{name}.ipynb<TP>' was dropped from closure: {targets}"
             )
+
+
+class TestQuartoClosureDependency:
+    """Pin the #11850 fix: a missing pyyaml must never read as an empty render-list.
+
+    Pre-fix, ``_quarto_render_list`` swallowed the ImportError from
+    ``import yaml`` behind ``except Exception: return []``, and the CLI
+    reported "empty/invalid _quarto.yml" -- on a runner without pyyaml the
+    closure scan silently covered 0 of 792 render-list entries while accusing
+    a perfectly valid YAML file (the ``handrolled-pattern-set-undercounts-
+    silently`` defect class). These controls hold the two causes apart: a
+    missing dependency is named as a dependency; only genuinely invalid YAML
+    keeps the empty-list path.
+    """
+
+    def _write_yml(self, tmp_path: Path) -> Path:
+        yml = tmp_path / "_quarto.yml"
+        yml.write_text(
+            "project:\n  render:\n    - 'docs/render.md'\n",
+            encoding="utf-8",
+        )
+        return yml
+
+    def test_missing_pyyaml_raises_naming_the_dependency(self, tmp_path, monkeypatch):
+        # A None entry in sys.modules makes `import yaml` raise ImportError.
+        yml = self._write_yml(tmp_path)
+        monkeypatch.setitem(sys.modules, "yaml", None)
+        with pytest.raises(RuntimeError, match="pyyaml"):
+            _quarto_render_list(yml)
+
+    def test_invalid_yaml_still_returns_empty(self, tmp_path):
+        # Genuinely unparseable YAML keeps the OLD contract (empty list) --
+        # the caller's "empty/invalid" message is the right one for it.
+        yml = tmp_path / "_quarto.yml"
+        yml.write_text("project: [unclosed\n", encoding="utf-8")
+        assert _quarto_render_list(yml) == []
+
+    def test_cli_missing_pyyaml_exits_2_blaming_the_dependency(self, tmp_path):
+        # CLI level: run the real script in a subprocess where `import yaml`
+        # raises (a fake yaml.py first on sys.path = pyyaml absent, without
+        # uninstalling anything). The pin: exit 2 with a message that names
+        # the DEPENDENCY, never "empty/invalid".
+        yml = self._write_yml(tmp_path)
+        (tmp_path / "yaml.py").write_text(
+            'raise ImportError("simulated: pyyaml absent")\n', encoding="utf-8"
+        )
+        env = {**os.environ, "PYTHONPATH": str(tmp_path)}
+        script = Path(detect_markdown_rendering.__file__).resolve()
+        r = subprocess.run(
+            [sys.executable, str(script), "--closure", "--quarto-yml", str(yml),
+             str(tmp_path)],
+            capture_output=True, text=True, env=env, cwd=tmp_path,
+        )
+        assert r.returncode == 2, (r.stdout, r.stderr)
+        assert "pyyaml" in r.stderr
+        assert "empty/invalid" not in r.stderr
+
+    def test_cli_with_pyyaml_reads_the_render_list(self, tmp_path):
+        # Positive control: with pyyaml present the CLI reads the render-list
+        # and announces its size (the CI log line "--closure: render-list=N").
+        yml = self._write_yml(tmp_path)
+        script = Path(detect_markdown_rendering.__file__).resolve()
+        r = subprocess.run(
+            [sys.executable, str(script), "--closure", "--quarto-yml", str(yml),
+             str(tmp_path)],
+            capture_output=True, text=True, cwd=tmp_path,
+        )
+        assert r.returncode == 0, (r.stdout, r.stderr)
+        assert "--closure: render-list=1" in r.stderr
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: MED/genai #11847

## Summary

Grain #11850 (dispatch ai-01) : le mode `--closure` de `detect_markdown_rendering.py` était **mort en silence sur CI** — le runner `setup-python` nu ne fournit pas PyYAML, et l'`ImportError` était avalé par un `except Exception: return []` dans `_quarto_render_list`, rendant `[]`. Le scan closure couvrait **0 des 792 entrées** du render-list tout en accusant `_quarto.yml` d'être vide/invalide (classe `handrolled-pattern-set-undercounts-silently`). Repro firsthand confirmé : **792 entrées avec pyyaml, 0 sans**.

Les deux gestes demandés par l'issue :

1. **`pip install pyyaml`** dans `markdown-rendering-guard.yml` — un step d'install après `setup-python`, couvrant les deux invocations (HARD gate l:80 + closure scan l:112).
2. **« Pas pu lire » ≠ « rien trouvé »** dans `_quarto_render_list` : `except ImportError` → `RuntimeError` qui **nomme la dépendance** (`pyyaml is not installed ... NOT an empty or invalid quarto-yml`) ; seul `yaml.YAMLError` garde le chemin empty-list (contrat inchangé pour un YAML réellement invalide). Le caller `--closure` attrape la `RuntimeError` → exit 2 avec le message dépendance, jamais `empty/invalid`.

Le mode `--closure` est conservé (consigne #11630). Le step closure reste informational (`|| true`, #11630).

## Validation

1. **Tests** : `pytest scripts/notebook_tools/tests/test_detect_markdown_rendering.py` → **57/57 pass** (53 existants + 4 nouveaux `TestQuartoClosureDependency`), dont le contrôle positif exigé par l'acceptance : simulation d'absence de pyyaml (faux module `yaml.py` qui lève `ImportError`, en tête de `sys.path`) → exit 2 avec un message parlant de la **dépendance**, assertion `"empty/invalid" not in stderr`. Contrôle négatif : YAML réellement invalide garde `[]`.
2. **Selfcheck** : `--selfcheck` → OK (formes FallacyDetection/02 + SL-8).
3. **Non-régression HARD gate** : `--check --baseline markdown_rendering_baseline.json MyIA.AI.Notebooks` sur l'arbre fixé → exit 0 (« no new ERROR-level violations ») — le fix ne change pas la sémantique de scan du gate.
4. **Closure vivant** : `--closure --quarto-yml _quarto.yml MyIA.AI.Notebooks` → stderr `--closure: render-list=792 closure-targets=1201` (critère d'acceptance #4) — la ligne apparaîtra désormais dans le log CI.
5. Workflow YAML re-validé (`yaml.safe_load` OK).

## Correction de prémisse — les 4 PRs rouges ne le sont PAS à cause de pyyaml (vérifié firsthand)

L'issue affirme : « Quatre PRs rouges **uniquement** à cause de ça, aucune n'ayant de défaut de rendu ». **C'est inexact**, vérifié sur les runs réels (logs + étapes par job) :

| PR | Step réellement rouge | Vraie cause |
|---|---|---|
| #11842 | **HARD gate** (le closure step est **vert** — masqué par `\|\| true`) | 3 NEW `yaml_block_open_no_close` : QC-Py-04 cells #4, #18, #54 |
| #11823 | HARD gate | 3 NEW : QC-Py-Cloud-04-RL-DQN cells #5, #9, #12 |
| #11824 | HARD gate | 7 NEW : QC-Py-12-Backtesting-Analysis cells #3, #10, #31, #42, #61, #66, +1 |
| #11828 | HARD gate | 1 NEW : Sudoku-15-Infer-Csharp cell #47 |

Mécanisme : ces notebooks portent **déjà** des violations baselinées sur `main` (vérifié : QC-Py-04 porte 7 `yaml_block_open_no_close` sur `main` — cells 3, 4, 18, 36, 54, 67, 73 ; le corpus closure en porte 1158). Les enrichissements markdown (les miens) ont édité certaines de ces cellules → **hash-churn** : la violation baselinée réapparaît comme NEW → HARD gate rouge. Le gate fonctionne **comme conçu** (« burn down, do not grow ») ; le défaut pyyaml était réel mais **n'est pas la cause des rouges**.

**Conséquence** : cette PR seule ne fera PAS passer les 4 PRs au vert (acceptance #5 de l'issue non atteignable par ce fix). La résolution des 4 PRs = retirer le `---` décoratif de tête des cellules éditées (brûle la baseline au lieu de la croître) — geste à porter sur les 4 branches concernées (les miennes), que je livre dès le cycle suivant si ai-01 valide cette lecture.

See #11850 (fix complet livré ; acceptance #5 reposait sur une prémisse inexacte — arbitrage ai-01)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
