### PR TITLE
fix(genai,#11851): token witnesses replace prefixes in OAuth notebook output (rule 6 case C)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/autour-du-consent-oauth-du-serveur-mcp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/autour-du-consent-oauth-du-serveur-mcp.ipynb
@@ -108,10 +108,10 @@
    "id": "14374c12",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:28.252587Z",
-     "iopub.status.busy": "2026-08-19T17:28:28.252036Z",
-     "iopub.status.idle": "2026-08-19T17:28:29.987161Z",
-     "shell.execute_reply": "2026-08-19T17:28:29.984943Z"
+     "iopub.execute_input": "2026-08-19T21:38:55.708732Z",
+     "iopub.status.busy": "2026-08-19T21:38:55.708732Z",
+     "iopub.status.idle": "2026-08-19T21:38:55.775836Z",
+     "shell.execute_reply": "2026-08-19T21:38:55.775836Z"
     },
     "papermill": {
      "duration": 1.75778,
@@ -240,10 +240,10 @@
    "id": "44315eeb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:30.033366Z",
-     "iopub.status.busy": "2026-08-19T17:28:30.032755Z",
-     "iopub.status.idle": "2026-08-19T17:28:30.385621Z",
-     "shell.execute_reply": "2026-08-19T17:28:30.384373Z"
+     "iopub.execute_input": "2026-08-19T21:38:55.776844Z",
+     "iopub.status.busy": "2026-08-19T21:38:55.776844Z",
+     "iopub.status.idle": "2026-08-19T21:38:55.866394Z",
+     "shell.execute_reply": "2026-08-19T21:38:55.866394Z"
     },
     "papermill": {
      "duration": 0.375854,
@@ -330,10 +330,10 @@
    "id": "d3710f0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:30.420247Z",
-     "iopub.status.busy": "2026-08-19T17:28:30.419713Z",
-     "iopub.status.idle": "2026-08-19T17:28:30.676595Z",
-     "shell.execute_reply": "2026-08-19T17:28:30.675166Z"
+     "iopub.execute_input": "2026-08-19T21:38:55.867399Z",
+     "iopub.status.busy": "2026-08-19T21:38:55.867399Z",
+     "iopub.status.idle": "2026-08-19T21:38:55.918967Z",
+     "shell.execute_reply": "2026-08-19T21:38:55.918463Z"
     },
     "papermill": {
      "duration": 0.267482,
@@ -349,7 +349,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "client_id        : 075f66323b8178...\n",
+      "client_id        : e7eb3dcc18dc01...\n",
       "client_name      : Notebook CoursIA\n",
       "redirect_uris    : ['http://localhost:8888/callback']\n",
       "grant_types      : ['authorization_code', 'refresh_token']\n",
@@ -407,10 +407,10 @@
    "id": "d3c3fe09",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:30.736611Z",
-     "iopub.status.busy": "2026-08-19T17:28:30.736084Z",
-     "iopub.status.idle": "2026-08-19T17:28:30.975694Z",
-     "shell.execute_reply": "2026-08-19T17:28:30.974266Z"
+     "iopub.execute_input": "2026-08-19T21:38:55.919975Z",
+     "iopub.status.busy": "2026-08-19T21:38:55.919975Z",
+     "iopub.status.idle": "2026-08-19T21:38:55.942794Z",
+     "shell.execute_reply": "2026-08-19T21:38:55.942794Z"
     },
     "papermill": {
      "duration": 0.27478,
@@ -484,10 +484,10 @@
    "id": "62b2bc9c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:31.020497Z",
-     "iopub.status.busy": "2026-08-19T17:28:31.019887Z",
-     "iopub.status.idle": "2026-08-19T17:28:32.553774Z",
-     "shell.execute_reply": "2026-08-19T17:28:32.552290Z"
+     "iopub.execute_input": "2026-08-19T21:38:55.944801Z",
+     "iopub.status.busy": "2026-08-19T21:38:55.944801Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.085165Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.085165Z"
     },
     "papermill": {
      "duration": 1.554213,
@@ -503,7 +503,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "creation : 201\n"
+      "utilisateur existant : 2\n"
      ]
     },
     {
@@ -575,10 +575,10 @@
    "id": "a8dbf224",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:32.619492Z",
-     "iopub.status.busy": "2026-08-19T17:28:32.618876Z",
-     "iopub.status.idle": "2026-08-19T17:28:32.886574Z",
-     "shell.execute_reply": "2026-08-19T17:28:32.885311Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.087426Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.086426Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.112347Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.112347Z"
     },
     "papermill": {
      "duration": 0.308753,
@@ -655,10 +655,10 @@
    "id": "5aefb3d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:32.946897Z",
-     "iopub.status.busy": "2026-08-19T17:28:32.946305Z",
-     "iopub.status.idle": "2026-08-19T17:28:34.453452Z",
-     "shell.execute_reply": "2026-08-19T17:28:34.452118Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.114025Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.114025Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.274809Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.274809Z"
     },
     "papermill": {
      "duration": 1.539505,
@@ -674,7 +674,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "creation : 201\n"
+      "utilisateur existant : 3\n"
      ]
     },
     {
@@ -776,10 +776,10 @@
    "id": "5e97a1ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:34.500165Z",
-     "iopub.status.busy": "2026-08-19T17:28:34.499583Z",
-     "iopub.status.idle": "2026-08-19T17:28:34.736320Z",
-     "shell.execute_reply": "2026-08-19T17:28:34.734899Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.277198Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.276199Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.361613Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.361613Z"
     },
     "papermill": {
      "duration": 0.257414,
@@ -796,8 +796,8 @@
      "output_type": "stream",
      "text": [
       "statut : 302\n",
-      "redirection : http://localhost:8888/callback?code=7f073883e69ed79bc6b1655db920b959c87729422cbb...\n",
-      "code d'autorisation : 7f073883e69ed79b...\n"
+      "redirection : vers le callback (code d'autorisation dans l'URL, voir variable CODE)\n",
+      "code d'autorisation : reçu\n"
      ]
     }
    ],
@@ -809,10 +809,10 @@
     "                       data=donnees, timeout=30, allow_redirects=False)\n",
     "print(\"statut :\", r.status_code)\n",
     "location = r.headers.get(\"Location\", \"\")\n",
-    "print(\"redirection :\", location[:80] + \"...\")\n",
+    "print(\"redirection : vers le callback (code d'autorisation dans l'URL, voir variable CODE)\")\n",
     "m = re.search(r\"[?&]code=([^&]+)\", location)\n",
     "CODE = m.group(1) if m else None\n",
-    "print(\"code d'autorisation :\", (CODE[:16] + \"...\") if CODE else \"(aucun)\")\n"
+    "print(\"code d'autorisation :\", \"reçu\" if CODE else \"(aucun)\")\n"
    ]
   },
   {
@@ -864,10 +864,10 @@
    "id": "64a9fccb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:34.798103Z",
-     "iopub.status.busy": "2026-08-19T17:28:34.797551Z",
-     "iopub.status.idle": "2026-08-19T17:28:34.988456Z",
-     "shell.execute_reply": "2026-08-19T17:28:34.987055Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.363620Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.363620Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.418696Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.418696Z"
     },
     "papermill": {
      "duration": 0.225388,
@@ -884,10 +884,10 @@
      "output_type": "stream",
      "text": [
       "statut : 200\n",
-      "  access_token  : 5de4237dce330d...\n",
+      "  access_token  : présent\n",
       "  token_type    : Bearer\n",
       "  expires_in    : 3600\n",
-      "  refresh_token : 97f104cc05a341...\n",
+      "  refresh_token : présent\n",
       "  scope         : mcp\n"
      ]
     }
@@ -903,7 +903,7 @@
     "print(\"statut :\", r.status_code)\n",
     "jeton = r.json()\n",
     "for cle, val in jeton.items():\n",
-    "    affiche = (str(val)[:14] + \"...\") if isinstance(val, str) and len(str(val)) > 24 else val\n",
+    "    affiche = (\"présent\") if isinstance(val, str) and len(str(val)) > 24 else val\n",
     "    print(f\"  {cle:14s}: {affiche}\")\n"
    ]
   },
@@ -965,10 +965,10 @@
    "id": "4b433351",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:35.053293Z",
-     "iopub.status.busy": "2026-08-19T17:28:35.052712Z",
-     "iopub.status.idle": "2026-08-19T17:28:35.197408Z",
-     "shell.execute_reply": "2026-08-19T17:28:35.196061Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.420093Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.420093Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.493344Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.493344Z"
     },
     "papermill": {
      "duration": 0.183932,
@@ -984,14 +984,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "statut :"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 200\n",
+      "statut : 200\n",
       "serverInfo : {'name': 'AI Engine - Maison Valmont', 'version': '0.0.1'}\n",
       "capabilities : ['tools']\n"
      ]
@@ -1059,10 +1052,10 @@
    "id": "b06fce76",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:35.263316Z",
-     "iopub.status.busy": "2026-08-19T17:28:35.262694Z",
-     "iopub.status.idle": "2026-08-19T17:28:35.386567Z",
-     "shell.execute_reply": "2026-08-19T17:28:35.385188Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.495350Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.495350Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.562826Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.562826Z"
     },
     "papermill": {
      "duration": 0.164667,
@@ -1195,10 +1188,10 @@
    "id": "3ad99ba6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:35.560035Z",
-     "iopub.status.busy": "2026-08-19T17:28:35.559454Z",
-     "iopub.status.idle": "2026-08-19T17:28:35.887927Z",
-     "shell.execute_reply": "2026-08-19T17:28:35.886543Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.563830Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.563830Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.694804Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.694804Z"
     },
     "papermill": {
      "duration": 0.364649,
@@ -1214,7 +1207,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "statut : 200 | corps : \n",
+      "statut :"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 200 | corps : \n",
       "appel MCP apres revocation : 401\n"
      ]
     }
@@ -1343,10 +1343,10 @@
    "id": "7fb04745",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:36.011065Z",
-     "iopub.status.busy": "2026-08-19T17:28:36.010495Z",
-     "iopub.status.idle": "2026-08-19T17:28:36.015994Z",
-     "shell.execute_reply": "2026-08-19T17:28:36.014729Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.696820Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.695820Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.698938Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.698938Z"
     },
     "papermill": {
      "duration": 0.024888,
@@ -1376,10 +1376,10 @@
    "id": "43ef58a6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:36.036067Z",
-     "iopub.status.busy": "2026-08-19T17:28:36.035554Z",
-     "iopub.status.idle": "2026-08-19T17:28:36.040928Z",
-     "shell.execute_reply": "2026-08-19T17:28:36.039706Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.700331Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.700331Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.704889Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.704364Z"
     },
     "papermill": {
      "duration": 0.016226,
@@ -1410,10 +1410,10 @@
    "id": "4415d2dd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:28:36.062719Z",
-     "iopub.status.busy": "2026-08-19T17:28:36.062144Z",
-     "iopub.status.idle": "2026-08-19T17:28:36.068206Z",
-     "shell.execute_reply": "2026-08-19T17:28:36.066833Z"
+     "iopub.execute_input": "2026-08-19T21:38:56.705895Z",
+     "iopub.status.busy": "2026-08-19T21:38:56.705895Z",
+     "iopub.status.idle": "2026-08-19T21:38:56.709404Z",
+     "shell.execute_reply": "2026-08-19T21:38:56.708875Z"
     },
     "papermill": {
      "duration": 0.027429,
@@ -1456,7 +1456,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.11.9"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/autour-du-consent-oauth-du-serveur-mcp.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/autour-du-consent-oauth-du-serveur-mcp.ipynb
@@ -1457,18 +1457,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.11.9"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 22.802067,
-   "end_time": "2026-08-19T17:28:36.659785+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "autour-du-consent-oauth-du-serveur-mcp.ipynb",
-   "output_path": "autour-du-consent-oauth-du-serveur-mcp.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-19T17:28:13.857718+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary

Règle 6 cas **(C) source-leak** ([secrets-hygiene.md](../blob/main/.claude/rules/secrets-hygiene.md) règle 6) : le notebook OAuth `autour-du-consent-oauth-du-serveur-mcp` imprimait des **préfixes de jeton** en sortie committée (`CODE[:16]`, `str(val)[:14]` sur chaque champ du jeton). Fix de la **cause** + **RE-EXÉCUTION** complète (Stop & Repair) — jamais d'edit manuel des outputs.

## Sites corrigés (source, puis re-exec)

| Cell | Avant | Après |
|---|---|---|
| 17 | `print("code d'autorisation :", CODE[:16] + "...")` | `print("code d'autorisation :", "reçu" if CODE else "(aucun)")` |
| 17 | `print("redirection :", location[:80] + "...")` (l'URL complète du callback **contenant le code d'autorisation** passait dans les 80 chars) | renvoi qualitatif « vers le callback (code d'autorisation dans l'URL, voir variable CODE) » |
| 19 | `affiche = (str(val)[:14] + "...")` sur chaque champ du jeton (`access_token : 5de4237dce330d...`) | témoin de présence `("présent")` — la forme prescrite par l'issue |

## Preuves d'exécution réelle

- **Instance Valmont montée de zéro** selon le README `instance-jetable/` (5 étapes) : `docker compose up -d`, `wp core install`, AI Engine 3.7.0 via wordpress.org, seed, application password, `.env` jetable (secrets générés, jamais affichés). Un point non documenté a dû être fixé au montage : **structure de permaliens** requise (`wp option update permalink_structure '/%postname%/'` + flush) sinon les routes MCP discovery répondent 301→HTML au lieu du JSON.
- **Re-exec nbclient end-to-end** (2 passes — la 1re a révélé le résidu cell 17 URL) : **15/15 cellules code exécutées**, `execution_count` tous non-nuls.
- **0 fuite hex-préfixe** dans les outputs finaux (scan regex `[0-9a-f]{10,}` sur toutes les sorties : 0 ligne token/code/callback).
- **Volume de rendu : ratio 1.00** base → tête (3451 → 3437 chars) — aucune dégradation SVG/output (leçon #11351 vérifiée).
- Instance **détruite** après le run (`docker compose down -v`), `.env` local supprimé.

## Notebook 2 — sondage firsthand, inchangé

L'issue cite « les deux notebooks ». Sondage source+outputs de `interroger-lassistant-de-lediteur-par-l-api` : **aucun pattern de préfixe de jeton** (auth Basic construite mais jamais imprimée ; nonces CSRF complets dans les sorties = pas des secrets par design WordPress). Seul le notebook OAuth portait le défaut. Fichier inchangé → pas de re-exec committée (règle C.3 : ne committer que ce qu'on a modifié).

## Diff

1 fichier, +81/-81 (outputs re-exécutés inclus), format JSON préservé. Catalogue byte-identique à main.

Closes #11851

Grain: MED/genai — lane myia-po-2026:CoursIA — prev: MED/guard #11845