### PR TITLE
fix(ci,#11656): apostrophe backslash-escape killed render-volume-delta-advisory before any job (100/100)

### DIFF
--- a/.github/workflows/render-volume-delta-advisory.yml
+++ b/.github/workflows/render-volume-delta-advisory.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           header: render-volume-delta-advisory
           message: |
-            ${{ steps.run.outputs.findings_total == '0' && '✅ No render volume delta signal (notebooks modified vs merge-base preserve >= 50% of base rendered output per MIME family).' || steps.run.outputs.findings_total == 'abstain' && '⚠️ Render volume delta: **base introuvable** (merge-base origin/main HEAD impossible). Le détecteur s\'abstient -- relancer avec un fetch plus profond, ou rebase la branche sur main. Pas de verdict.' || format('⚠️ {0} render volume delta signal(s): one or more modified notebooks lost >= 50% of their rendered output per MIME family (base = merge-base origin/main HEAD). Review against the source code -- advisory, NOT a merge gate.', steps.run.outputs.findings_total) }}
+            ${{ steps.run.outputs.findings_total == '0' && '✅ No render volume delta signal (notebooks modified vs merge-base preserve >= 50% of base rendered output per MIME family).' || steps.run.outputs.findings_total == 'abstain' && '⚠️ Render volume delta: **base introuvable** (merge-base origin/main HEAD impossible). Le détecteur s''abstient -- relancer avec un fetch plus profond, ou rebase la branche sur main. Pas de verdict.' || format('⚠️ {0} render volume delta signal(s): one or more modified notebooks lost >= 50% of their rendered output per MIME family (base = merge-base origin/main HEAD). Review against the source code -- advisory, NOT a merge gate.', steps.run.outputs.findings_total) }}
 
             See `python scripts/notebook_tools/check_render_volume_delta.py --help` for re-running locally.
             Detector rationale: #11656 / #11351 pathologie (840 B remnants in 195 692 B cells = absolute detectors blind).

--- a/scripts/tests/test_workflow_expression_escapes.py
+++ b/scripts/tests/test_workflow_expression_escapes.py
@@ -1,0 +1,94 @@
+"""Garde de classe : une apostrophe echappee par backslash dans une expression
+GitHub Actions casse le workflow AU DEMARRAGE -- zero job cree, aucun log.
+
+Incident fondateur (2026-08-19) : `render-volume-delta-advisory.yml` a echoue
+**100 fois sur 100** depuis sa creation (15:24:30Z), sans jamais reussir une
+seule fois. Le YAML etait valide (`yaml.safe_load` passait), le fichier etait
+relu par des humains, et le workflow etant *advisory* son rouge permanent a ete
+lu comme du bruit non-bloquant. L'organe de #11656 -- celui qui doit detecter
+la destruction de volume de rendu dans les notebooks -- n'a donc jamais tourne.
+
+La cause : dans une expression `${{ ... }}`, GitHub Actions n'echappe PAS
+l'apostrophe par un backslash. On la **double** (`''`), comme en SQL. Un
+`s\'abstient` a l'interieur d'une chaine d'expression rend l'expression
+inanalysable, et GitHub abandonne le run avant de creer le moindre job.
+
+Ce que ce test ajoute, qu'aucune relecture ne donne : le defaut est **muet**
+par construction (`total_count: 0` jobs, `--log` vide, `--log-failed` vide).
+« Rien trouve » et « pas regarde » y rendent la meme chose -- exactement la
+famille de defauts que le depot corrige par un organe plutot que par de la
+vigilance.
+"""
+
+import glob
+import io
+import os
+import re
+
+import pytest
+
+BACKSLASH = chr(92)
+
+# Une expression GHA, non-gourmande, multi-lignes (les blocs `with: body: |`
+# en contiennent regulierement qui s'etalent sur plusieurs lignes).
+_EXPRESSION = re.compile(r"\$\{\{.*?\}\}", re.S)
+_ESCAPED_QUOTE = re.compile(re.escape(BACKSLASH) + r"'")
+
+_WORKFLOW_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    ".github",
+    "workflows",
+)
+
+
+def _workflow_files():
+    pats = ("*.yml", "*.yaml")
+    out = []
+    for p in pats:
+        out.extend(glob.glob(os.path.join(_WORKFLOW_DIR, p)))
+    return sorted(out)
+
+
+def _offenders(text):
+    """Retourne les expressions du texte qui portent un backslash-apostrophe."""
+    return [m.group(0) for m in _EXPRESSION.finditer(text) if _ESCAPED_QUOTE.search(m.group(0))]
+
+
+def test_positive_control_detects_the_known_bad_form():
+    """Le controle positif du detecteur, dans la meme invocation que son usage.
+
+    Sans lui, un motif casse (backslash mange par un transport heredoc, regex
+    mal echappee) rendrait 0 offender sur tout le depot -- un vert qui ne
+    mesure rien, indiscernable d'un vert qui mesure tout.
+    """
+    bad = "${{ steps.x.outputs.y == '0' && 'il s" + BACKSLASH + "'abstient' || 'ok' }}"
+    assert _offenders(bad), "le detecteur ne voit pas la forme fautive connue"
+
+    good = "${{ steps.x.outputs.y == '0' && 'il s''abstient' || 'ok' }}"
+    assert not _offenders(good), "le detecteur accuse la forme correcte (doublement)"
+
+
+def test_no_backslash_escaped_quote_in_any_workflow_expression():
+    found = []
+    for path in _workflow_files():
+        text = io.open(path, encoding="utf-8").read()
+        for expr in _offenders(text):
+            line = text[: text.index(expr)].count("\n") + 1
+            found.append(f"{os.path.basename(path)}:{line}: {expr[:120]}")
+
+    assert not found, (
+        "apostrophe echappee par backslash dans une expression GitHub Actions -- "
+        "le workflow echouera AU DEMARRAGE (0 job, aucun log). Doubler "
+        "l'apostrophe (`''`) au lieu de la prefixer d'un backslash :\n  "
+        + "\n  ".join(found)
+    )
+
+
+def test_workflow_dir_is_non_empty():
+    """Un scan qui ne trouve aucun fichier rendrait « aucun defaut » a tort."""
+    files = _workflow_files()
+    assert len(files) > 20, f"repertoire de workflows introuvable ou vide : {_WORKFLOW_DIR} ({len(files)})"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: DEEP/notebook-dotnet #11828

fix(ci,#11656): `render-volume-delta-advisory` échouait 100/100 avant tout job — apostrophe échappée par backslash dans une expression `${{ }}`.

## Defect

Ligne 119 du sticky comment : `Le détecteur s\'abstient` — GitHub Actions n'échappe PAS l'apostrophe par backslash dans une expression `${{ ... }}`, on la **double** (`''`). L'expression devient inanalysable et le run meurt **avant de créer le moindre job** :

```
gh api repos/jsboige/CoursIA/actions/runs/32303140387/jobs -q '.total_count'   # 0
```

100 échecs sur 100 depuis la création (2026-08-19T15:24:30Z), y compris sur main. L'organe de #11656 (détecteur de perte de volume de rendu, pathologie #11351 : 195 692 → 3 293 B avec `outputs` peuplés) **n'a jamais émis un seul verdict**. #11656 avait été fermée sur le merge du fichier, pas sur une preuve d'exécution.

## Fix

`s\'abstient` → `s''abstient`. Occurrence unique dans tout le dépôt (contrôle positif dans le test).

## Organ (tests)

`scripts/tests/test_workflow_expression_escapes.py` — 3 tests :
1. Contrôle positif : la forme fauteuse est détectée quand on la plante dans le test (garantit qu'un scan rendant 0 n'est pas un motif cassé)
2. Scan repo-wide : nomme fichier + ligne + extrait pour toute occurrence de `\'` dans une expression de workflow
3. Garde non-vide : un scan sans fichiers rendrait « aucun défaut » à tort

## Controls (rejoués firsthand sur ce worktree, pas hérités de mémoire)

- **Négatif** : `git checkout origin/main -- <workflow>` + pytest → `FAILED ... render-volume-delta-advisory.yml:119 ...` (1 failed, 2 passed)
- **Positif** : fix restauré + pytest → `3 passed in 0.05s`

## Acceptance

Le critère n'est PAS « la PR est verte » (le workflow est advisory, absent du rollup bloquant). C'est **un run de ce workflow qui crée au moins un job** :

```
gh api repos/jsboige/CoursIA/actions/runs/<run>/jobs -q '.total_count'   # > 0
```

La PR touche `.github/workflows/render-volume-delta-advisory.yml`, inclus dans le paths-filter du trigger `pull_request` → le run partira à l'ouverture. Verdict à coller dans ce body dès que le run a rendu.

## Credit

Diagnostic, fix, branche et tests : ai-01 (commit e5233d14f, DM msg-20260819T214258) — sa lane est saturée en `guard` (G-VAR-3), la PR est ouverte sous mon grain. Contrôles rejoués par po-2023 avant ouverture.

Closes #11656-note: #11656 est déjà CLOSED (fermée à tort sur le fichier, pas sur l'exécution) — pas de `Closes`.


## Acceptance — verdict (2026-08-20T00:20Z)

Le workflow a demarre sur la PR et a CREE UN JOB — critere atteint (la pathologie d'origine : 0 job sur 100 runs) :

```
run 32306592062 "Render volume delta detector (advisory)" [queued]
gh api repos/jsboige/CoursIA/actions/runs/32306592062/jobs -q .total_count   # 1
job "Render volume delta (#11656 advisory)" [queued]
```

Job encore en file (saturation CI fleet) — le verdict du detecteur lui-meme rendra quand le runner prendra le job ; pas de notebook modifie dans cette PR, verdict attendu abstain ou 0 findings, non bloquant (advisory).
