### PR TITLE
fix(aspire,#11848): cellule nettoyage — dire ce que aspire stop fait reellement + geste effectif

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/01-Aspire-Orchestration-GenAi.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/01-Aspire-Orchestration-GenAi.ipynb
@@ -114,12 +114,12 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "AppHost (wt1) : D:\\dev\\CoursIA-vid343\\MyIA.AI.Notebooks\\GenAI\\Aspire\\GenAiStack.AppHost\r\n"
+     "text": "AppHost (wt1) : C:\\dev\\CoursIA-11848\\MyIA.AI.Notebooks\\GenAI\\Aspire\\GenAiStack.AppHost\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "AppHost (wt2) : D:\\dev\\CoursIA-vid343\\MyIA.AI.Notebooks\\GenAI\\Aspire\\GenAiStack.AppHost-wt2\r\n"
+     "text": "AppHost (wt2) : C:\\dev\\CoursIA-11848\\MyIA.AI.Notebooks\\GenAI\\Aspire\\GenAiStack.AppHost-wt2\r\n"
     },
     {
      "output_type": "stream",
@@ -129,7 +129,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Echantillon   : D:\\dev\\CoursIA-vid343\\MyIA.AI.Notebooks\\GenAI\\Aspire\\assets\\echantillon-test-fr.wav\r\n"
+     "text": "Echantillon   : C:\\dev\\CoursIA-11848\\MyIA.AI.Notebooks\\GenAI\\Aspire\\assets\\echantillon-test-fr.wav\r\n"
     },
     {
      "output_type": "stream",
@@ -312,7 +312,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\u001b[2mDémarrage de l’application Aspire en arrière-plan...\u001b[0m\r\n\r\n           \u001b[1;38;5;2mAppHost\u001b[0m:  apphost.cs                                                                                             \r\n                                                                                                                            \r\n   \u001b[1;38;5;2mTableau de bord\u001b[0m:  \u001b]8;id=2021999349;https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b\\https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b]8;;\u001b\\                                       \r\n                                                                                                                            \r\n          \u001b[1;38;5;2mJournaux\u001b[0m:  \u001b]8;id=1548037962;file:///C:/Users/jsboi/.aspire/logs/cli_20260819T195232561_detach-child_2508571847a24d019787b16f6eee02a1.log\u001b\\C:\\Users\\jsboi\\.aspire\\logs\\cli_20260819T195232561_detach-child_2508571847a24d019787b16f6eee02a1.log\u001b]8;;\u001b\\   \r\n                                                                                                                            \r\n               \u001b[1;38;5;2mPID\u001b[0m:  48344                                                                                                  \r\n\r\n\u001b[38;5;2m✅\u001b[0m AppHost a démarré correctement.\r\n\r\n"
+     "text": "\u001b[2mDémarrage de l’application Aspire en arrière-plan...\u001b[0m\r\n\r\n           \u001b[1;38;5;2mAppHost\u001b[0m:  apphost.cs                                                                                             \r\n                                                                                                                            \r\n   \u001b[1;38;5;2mTableau de bord\u001b[0m:  \u001b]8;id=1017975033;https://localhost:61952/login?t=abd1a515126f3bafe7fa42a03c02a6da\u001b\\https://localhost:61952/login?t=abd1a515126f3bafe7fa42a03c02a6da\u001b]8;;\u001b\\                                       \r\n                                                                                                                            \r\n          \u001b[1;38;5;2mJournaux\u001b[0m:  \u001b]8;id=1094815659;file:///C:/Users/jsboi/.aspire/logs/cli_20260819T224002446_detach-child_127a263fb6144e4e8a9650690fb49c41.log\u001b\\C:\\Users\\jsboi\\.aspire\\logs\\cli_20260819T224002446_detach-child_127a263fb6144e4e8a9650690fb49c41.log\u001b]8;;\u001b\\   \r\n                                                                                                                            \r\n               \u001b[1;38;5;2mPID\u001b[0m:  43896                                                                                                  \r\n\r\n\u001b[38;5;2m✅\u001b[0m AppHost a démarré correctement.\r\n\r\n"
     }
    ],
    "source": [
@@ -370,7 +370,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌─────────────┬───────────┬─────────┬───────────┬────────────────────────┐\r\n│ \u001b[1mNom\u001b[0m         │ \u001b[1mType\u001b[0m      │ \u001b[1mÉtat\u001b[0m    │ \u001b[1mIntégrité\u001b[0m │ \u001b[1mURLs\u001b[0m                   │\r\n├─────────────┼───────────┼─────────┼───────────┼────────────────────────┤\r\n│ \u001b]8;id=854249969;https://localhost:56391/?resource=whisper-api-vfcyzdzx\u001b\\\u001b[38;5;222mwhisper-api\u001b[0m\u001b]8;;\u001b\\ │ Container │ \u001b[38;5;2mRunning\u001b[0m │ \u001b[38;5;2mHealthy\u001b[0m   │ \u001b]8;id=978713128;http://localhost:56392\u001b\\http://localhost:56392\u001b]8;;\u001b\\ │\r\n└─────────────┴───────────┴─────────┴───────────┴────────────────────────┘\r\n\r\n"
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌─────────────┬───────────┬─────────┬───────────┬────────────────────────┐\r\n│ \u001b[1mNom\u001b[0m         │ \u001b[1mType\u001b[0m      │ \u001b[1mÉtat\u001b[0m    │ \u001b[1mIntégrité\u001b[0m │ \u001b[1mURLs\u001b[0m                   │\r\n├─────────────┼───────────┼─────────┼───────────┼────────────────────────┤\r\n│ \u001b]8;id=718362401;https://localhost:61952/?resource=whisper-api-wbbgnzgq\u001b\\\u001b[38;5;222mwhisper-api\u001b[0m\u001b]8;;\u001b\\ │ Container │ \u001b[38;5;2mRunning\u001b[0m │ \u001b[38;5;2mHealthy\u001b[0m   │ \u001b]8;id=1225584553;http://localhost:61953\u001b\\http://localhost:61953\u001b]8;;\u001b\\ │\r\n└─────────────┴───────────┴─────────┴───────────┴────────────────────────┘\r\n\r\n"
     },
     {
      "output_type": "stream",
@@ -385,7 +385,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌───────────────────────────────┬─────────┬────────┬───────┬─────────┬──────────────────────────────────────────────────────────────────┐\r\n│ \u001b[1mChemin d’accès\u001b[0m                │ \u001b[1mStatus\u001b[0m  │ \u001b[1mSDK\u001b[0m    │ \u001b[1mPID\u001b[0m   │ \u001b[1mCLI PID\u001b[0m │ \u001b[1mTableau de bord\u001b[0m                                                  │\r\n├───────────────────────────────┼─────────┼────────┼───────┼─────────┼──────────────────────────────────────────────────────────────────┤\r\n│ GenAiStack.AppHost\\apphost.cs │ running │ 13.4.6 │ 48344 │ 32192   │ \u001b]8;id=1286491098;https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b\\https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b]8;;\u001b\\ │\r\n└───────────────────────────────┴─────────┴────────┴───────┴─────────┴──────────────────────────────────────────────────────────────────┘\r\n\r\n"
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌───────────────────────────────┬─────────┬────────┬───────┬─────────┬──────────────────────────────────────────────────────────────────┐\r\n│ \u001b[1mChemin d’accès\u001b[0m                │ \u001b[1mStatus\u001b[0m  │ \u001b[1mSDK\u001b[0m    │ \u001b[1mPID\u001b[0m   │ \u001b[1mCLI PID\u001b[0m │ \u001b[1mTableau de bord\u001b[0m                                                  │\r\n├───────────────────────────────┼─────────┼────────┼───────┼─────────┼──────────────────────────────────────────────────────────────────┤\r\n│ GenAiStack.AppHost\\apphost.cs │ running │ 13.4.6 │ 43896 │ 48048   │ \u001b]8;id=1413297931;https://localhost:61952/login?t=abd1a515126f3bafe7fa42a03c02a6da\u001b\\https://localhost:61952/login?t=abd1a515126f3bafe7fa42a03c02a6da\u001b]8;;\u001b\\ │\r\n└───────────────────────────────┴─────────┴────────┴───────┴─────────┴──────────────────────────────────────────────────────────────────┘\r\n\r\n"
     }
    ],
    "source": [
@@ -468,7 +468,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "URL du service orchestre (instance A) : http://localhost:56392\r\n"
+     "text": "URL du service orchestre (instance A) : http://localhost:61953\r\n"
     },
     {
      "output_type": "stream",
@@ -583,12 +583,12 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\u001b[2mDémarrage de l’application Aspire en arrière-plan...\u001b[0m\r\n\r\n           \u001b[1;38;5;2mAppHost\u001b[0m:  apphost.cs                                                                                             \r\n                                                                                                                            \r\n   \u001b[1;38;5;2mTableau de bord\u001b[0m:  \u001b]8;id=665276441;https://localhost:64053/login?t=9a7ab1e90a18f8ad0d4d54545b4e0910\u001b\\https://localhost:64053/login?t=9a7ab1e90a18f8ad0d4d54545b4e0910\u001b]8;;\u001b\\                                       \r\n                                                                                                                            \r\n          \u001b[1;38;5;2mJournaux\u001b[0m:  \u001b]8;id=1251164721;file:///C:/Users/jsboi/.aspire/logs/cli_20260819T195302859_detach-child_4f6e9781f9b847fcbb476ccb217ac693.log\u001b\\C:\\Users\\jsboi\\.aspire\\logs\\cli_20260819T195302859_detach-child_4f6e9781f9b847fcbb476ccb217ac693.log\u001b]8;;\u001b\\   \r\n                                                                                                                            \r\n               \u001b[1;38;5;2mPID\u001b[0m:  54224                                                                                                  \r\n\r\n\u001b[38;5;2m✅\u001b[0m AppHost a démarré correctement.\r\n\r\n"
+     "text": "\u001b[2mDémarrage de l’application Aspire en arrière-plan...\u001b[0m\r\n\r\n           \u001b[1;38;5;2mAppHost\u001b[0m:  apphost.cs                                                                                             \r\n                                                                                                                            \r\n   \u001b[1;38;5;2mTableau de bord\u001b[0m:  \u001b]8;id=1971673254;https://localhost:58688/login?t=8b35cd6485a43f5d3b1ac235845866f5\u001b\\https://localhost:58688/login?t=8b35cd6485a43f5d3b1ac235845866f5\u001b]8;;\u001b\\                                       \r\n                                                                                                                            \r\n          \u001b[1;38;5;2mJournaux\u001b[0m:  \u001b]8;id=1786780690;file:///C:/Users/jsboi/.aspire/logs/cli_20260819T224041058_detach-child_7d88ed21b26342bc8f0aa22d3929b38a.log\u001b\\C:\\Users\\jsboi\\.aspire\\logs\\cli_20260819T224041058_detach-child_7d88ed21b26342bc8f0aa22d3929b38a.log\u001b]8;;\u001b\\   \r\n                                                                                                                            \r\n               \u001b[1;38;5;2mPID\u001b[0m:  35348                                                                                                  \r\n\r\n\u001b[38;5;2m✅\u001b[0m AppHost a démarré correctement.\r\n\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌─────────────┬───────────┬─────────┬───────────┬────────────────────────┐\r\n│ \u001b[1mNom\u001b[0m         │ \u001b[1mType\u001b[0m      │ \u001b[1mÉtat\u001b[0m    │ \u001b[1mIntégrité\u001b[0m │ \u001b[1mURLs\u001b[0m                   │\r\n├─────────────┼───────────┼─────────┼───────────┼────────────────────────┤\r\n│ \u001b]8;id=1900202500;https://localhost:64053/?resource=whisper-api-kfxcbefm\u001b\\\u001b[38;5;222mwhisper-api\u001b[0m\u001b]8;;\u001b\\ │ Container │ \u001b[38;5;2mRunning\u001b[0m │ \u001b[38;5;2mHealthy\u001b[0m   │ \u001b]8;id=1695160795;http://localhost:64052\u001b\\http://localhost:64052\u001b]8;;\u001b\\ │\r\n└─────────────┴───────────┴─────────┴───────────┴────────────────────────┘\r\n\r\n"
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌─────────────┬───────────┬─────────┬───────────┬────────────────────────┐\r\n│ \u001b[1mNom\u001b[0m         │ \u001b[1mType\u001b[0m      │ \u001b[1mÉtat\u001b[0m    │ \u001b[1mIntégrité\u001b[0m │ \u001b[1mURLs\u001b[0m                   │\r\n├─────────────┼───────────┼─────────┼───────────┼────────────────────────┤\r\n│ \u001b]8;id=1316964531;https://localhost:58688/?resource=whisper-api-rvxjtvah\u001b\\\u001b[38;5;222mwhisper-api\u001b[0m\u001b]8;;\u001b\\ │ Container │ \u001b[38;5;2mRunning\u001b[0m │ \u001b[38;5;2mHealthy\u001b[0m   │ \u001b]8;id=1953247650;http://localhost:58687\u001b\\http://localhost:58687\u001b]8;;\u001b\\ │\r\n└─────────────┴───────────┴─────────┴───────────┴────────────────────────┘\r\n\r\n"
     }
    ],
    "source": [
@@ -650,17 +650,17 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌───────────────────────────────────┬─────────┬────────┬───────┬─────────┬──────────────────────────────────────────────────────────────────┐\r\n│ \u001b[1mChemin d’accès\u001b[0m                    │ \u001b[1mStatus\u001b[0m  │ \u001b[1mSDK\u001b[0m    │ \u001b[1mPID\u001b[0m   │ \u001b[1mCLI PID\u001b[0m │ \u001b[1mTableau de bord\u001b[0m                                                  │\r\n├───────────────────────────────────┼─────────┼────────┼───────┼─────────┼──────────────────────────────────────────────────────────────────┤\r\n│ GenAiStack.AppHost\\apphost.cs     │ running │ 13.4.6 │ 48344 │ 32192   │ \u001b]8;id=2084089366;https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b\\https://localhost:56391/login?t=e15a78e2448c3b97ba51aaaf3c982067\u001b]8;;\u001b\\ │\r\n│ GenAiStack.AppHost-wt2\\apphost.cs │ running │ 13.4.6 │ 54224 │ 42072   │ \u001b]8;id=112587784;https://localhost:64053/login?t=9a7ab1e90a18f8ad0d4d54545b4e0910\u001b\\https://localhost:64053/login?t=9a7ab1e90a18f8ad0d4d54545b4e0910\u001b]8;;\u001b\\ │\r\n└───────────────────────────────────┴─────────┴────────┴───────┴─────────┴──────────────────────────────────────────────────────────────────┘\r\n\r\n"
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n┌───────────────────────────────────┬─────────┬────────┬───────┬─────────┬──────────────────────────────────────────────────────────────────┐\r\n│ \u001b[1mChemin d’accès\u001b[0m                    │ \u001b[1mStatus\u001b[0m  │ \u001b[1mSDK\u001b[0m    │ \u001b[1mPID\u001b[0m   │ \u001b[1mCLI PID\u001b[0m │ \u001b[1mTableau de bord\u001b[0m                                                  │\r\n├───────────────────────────────────┼─────────┼────────┼───────┼─────────┼──────────────────────────────────────────────────────────────────┤\r\n│ GenAiStack.AppHost\\apphost.cs     │ running │ 13.4.6 │ 43896 │ 48048   │ \u001b]8;id=1785957287;https://localhost:61952/login?t=abd1a515126f3bafe7fa42a03c02a6da\u001b\\https://localhost:61952/login?t=abd1a515126f3bafe7fa42a03c02a6da\u001b]8;;\u001b\\ │\r\n│ GenAiStack.AppHost-wt2\\apphost.cs │ running │ 13.4.6 │ 35348 │ 48608   │ \u001b]8;id=1019441166;https://localhost:58688/login?t=8b35cd6485a43f5d3b1ac235845866f5\u001b\\https://localhost:58688/login?t=8b35cd6485a43f5d3b1ac235845866f5\u001b]8;;\u001b\\ │\r\n└───────────────────────────────────┴─────────┴────────┴───────┴─────────┴──────────────────────────────────────────────────────────────────┘\r\n\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "URL du service orchestre (instance B) : http://localhost:64052\r\n"
+     "text": "URL du service orchestre (instance B) : http://localhost:58687\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Ports distincts : True  (A=56392, B=64052)\r\n"
+     "text": "Ports distincts : True  (A=61953, B=58687)\r\n"
     },
     {
      "output_type": "stream",
@@ -675,7 +675,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "whisper-api-kfxcbefm  127.0.0.1:64077->8190/tcp\nwhisper-api-vfcyzdzx  127.0.0.1:56405->8190/tcp\n\r\n"
+     "text": "whisper-api-rvxjtvah  127.0.0.1:58714->8190/tcp\nwhisper-api-wbbgnzgq  127.0.0.1:61970->8190/tcp\n\r\n"
     }
    ],
    "source": [
@@ -761,7 +761,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n\u001b[2mRécupération des journaux...\u001b[0m\r\n\u001b[38;5;222m[whisper-api]\u001b[0m No custom certificate authorities to configure for 'whisper-api'. Default certificate authority trust behavior will be used.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m 416a76cc39dda965fd7eae74062899295f1f432f0e8ed36e5309959bdaef8a3d\r\n\u001b[38;5;222m[whisper-api]\u001b[0m [sys] Added new ContainerNetworkConnection: ContainerName = whisper-api-vfcyzdzx\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m 416a76cc39dda965fd7eae74062899295f1f432f0e8ed36e5309959bdaef8a3d\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m ==========\r\n\u001b[38;5;222m[whisper-api]\u001b[0m == CUDA ==\r\n\u001b[38;5;222m[whisper-api]\u001b[0m ==========\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m CUDA Version 12.1.0\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m This container image and its contents are governed by the NVIDIA Deep Learning Container License.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m By pulling and using the container, you accept the terms and conditions of this license:\r\n\u001b[38;5;222m[whisper-api]\u001b[0m https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m *************************\r\n\u001b[38;5;222m[whisper-api]\u001b[0m ** DEPRECATION NOTICE! **\r\n\u001b[38;5;222m[whisper-api]\u001b[0m *************************\r\n\u001b[38;5;222m[whisper-api]\u001b[0m THIS IMAGE IS DEPRECATED and is scheduled for DELETION.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m     https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/support-policy.md\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m Starting Whisper API...\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Model: large-v3-turbo\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Device: cuda\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Compute Type: int8_float16\r\n\u001b[38;5;222m[whisper-api]\u001b[0m WARNING:auth-middleware:AUTH_ENABLED=false - Authentication explicitly DISABLED\r\n\u001b[38;5;222m[whisper-api]\u001b[0m WARNING:auth-middleware:Auth middleware NOT installed - API is open\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Started server process [1]\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Waiting for application startup.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Started idle checker (timeout: 1200s)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Starting idle checker task (interval: 60s)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Application startup complete.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Uvicorn running on http://0.0.0.0:8190 (Press CTRL+C to quit)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Loading model: whisper\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Loading Whisper model: large-v3-turbo on cuda (int8_float16)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/mobiuslabsgmbh/faster-whisper-large-v3-turbo/revision/main \"HTTP/1.1 307 Temporary \r\nRedirect\"\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/dropbox-dash/faster-whisper-large-v3-turbo/revision/main \"HTTP/1.1 200 OK\"\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Model whisper loaded in 15.0s\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:Processing audio with duration 00:08.178\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \u001b[0;93m2026-08-19 19:53:03.171453034 [W:onnxruntime:Default, telemetry.cc:800 operator()] Failed to persist telemetry device ID; using an in-memory identifier\u001b[m\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:VAD filter removed 00:00.482 of audio\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:Detected language 'fr' with probability 1.00\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Transcribed 8.2s audio in 15.79s (lang: fr)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     172.19.0.1:45984 - \"POST /v1/audio/transcriptions HTTP/1.1\" 200 OK\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     127.0.0.1:35788 - \"GET /health HTTP/1.1\" 200 OK\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     127.0.0.1:34718 - \"GET /health HTTP/1.1\" 200 OK\r\n\r\n"
+     "text": "\u001b[2mScanning for running AppHosts...\u001b[0m\r\n\u001b[2mRécupération des journaux...\u001b[0m\r\n\u001b[38;5;222m[whisper-api]\u001b[0m No custom certificate authorities to configure for 'whisper-api'. Default certificate authority trust behavior will be used.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m bf2a2bd2646add722c5a281e8388616b9a0d70bc07664bad19cf465db4a1b16a\r\n\u001b[38;5;222m[whisper-api]\u001b[0m [sys] Added new ContainerNetworkConnection: ContainerName = whisper-api-wbbgnzgq\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m ==========\r\n\u001b[38;5;222m[whisper-api]\u001b[0m == CUDA ==\r\n\u001b[38;5;222m[whisper-api]\u001b[0m ==========\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m CUDA Version 12.1.0\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m Container image Copyright (c) 2016-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m This container image and its contents are governed by the NVIDIA Deep Learning Container License.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m By pulling and using the container, you accept the terms and conditions of this license:\r\n\u001b[38;5;222m[whisper-api]\u001b[0m https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m A copy of this license is made available in this container at /NGC-DL-CONTAINER-LICENSE for your convenience.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m *************************\r\n\u001b[38;5;222m[whisper-api]\u001b[0m ** DEPRECATION NOTICE! **\r\n\u001b[38;5;222m[whisper-api]\u001b[0m *************************\r\n\u001b[38;5;222m[whisper-api]\u001b[0m THIS IMAGE IS DEPRECATED and is scheduled for DELETION.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m     https://gitlab.com/nvidia/container-images/cuda/blob/master/doc/support-policy.md\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m Starting Whisper API...\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Model: large-v3-turbo\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Device: cuda\r\n\u001b[38;5;222m[whisper-api]\u001b[0m Compute Type: int8_float16\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \r\n\u001b[38;5;222m[whisper-api]\u001b[0m bf2a2bd2646add722c5a281e8388616b9a0d70bc07664bad19cf465db4a1b16a\r\n\u001b[38;5;222m[whisper-api]\u001b[0m WARNING:auth-middleware:AUTH_ENABLED=false - Authentication explicitly DISABLED\r\n\u001b[38;5;222m[whisper-api]\u001b[0m WARNING:auth-middleware:Auth middleware NOT installed - API is open\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Started server process [1]\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Waiting for application startup.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Started idle checker (timeout: 1200s)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Starting idle checker task (interval: 60s)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Application startup complete.\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     Uvicorn running on http://0.0.0.0:8190 (Press CTRL+C to quit)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Loading model: whisper\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Loading Whisper model: large-v3-turbo on cuda (int8_float16)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/mobiuslabsgmbh/faster-whisper-large-v3-turbo/revision/main \"HTTP/1.1 307 Temporary \r\nRedirect\"\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET https://huggingface.co/api/models/dropbox-dash/faster-whisper-large-v3-turbo/revision/main \"HTTP/1.1 200 OK\"\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET \r\nhttps://huggingface.co/api/models/mobiuslabsgmbh/faster-whisper-large-v3-turbo/tree/0a363e9161cbc7ed1431c9597a8ceaf0c4f78fcf?recursive=true&expand=false \r\n\"HTTP/1.1 307 Temporary Redirect\"\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:httpx:HTTP Request: GET \r\nhttps://huggingface.co/api/models/dropbox-dash/faster-whisper-large-v3-turbo/tree/0a363e9161cbc7ed1431c9597a8ceaf0c4f78fcf?recursive=true&expand=false \"HTTP/1.1\r\n200 OK\"\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:lazy-model:Model whisper loaded in 16.6s\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:Processing audio with duration 00:08.178\r\n\u001b[38;5;222m[whisper-api]\u001b[0m \u001b[0;93m2026-08-19 22:40:40.161607108 [W:onnxruntime:Default, telemetry.cc:800 operator()] Failed to persist telemetry device ID; using an in-memory identifier\u001b[m\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:VAD filter removed 00:00.482 of audio\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:faster_whisper:Detected language 'fr' with probability 1.00\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:whisper-api:Transcribed 8.2s audio in 17.48s (lang: fr)\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     172.21.0.1:47496 - \"POST /v1/audio/transcriptions HTTP/1.1\" 200 OK\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     127.0.0.1:45564 - \"GET /health HTTP/1.1\" 200 OK\r\n\u001b[38;5;222m[whisper-api]\u001b[0m INFO:     127.0.0.1:51282 - \"GET /health HTTP/1.1\" 200 OK\r\n\r\n"
     }
    ],
    "source": [
@@ -961,23 +961,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Conclusion\n",
-    "\n",
-    "En une session : l'AppHost Aspire a **orchestré** notre service GenAI réel (whisper-api, image locale, GPU), a été **lancé en deux instances simultanées** (`--isolated`, ports distincts prouvés), **interrogé** (`describe`, `ps`), **journalisé** (`logs`) et a **servi une transcription réelle**. Les commandes clés :\n",
-    "\n",
-    "| Commande | Rôle |\n",
-    "|---|---|\n",
-    "| `aspire run --detach --isolated` | lancer l'AppHost en arrière-plan, ports randomisés |\n",
-    "| `aspire ps` / `aspire describe <res>` | lister les AppHosts / snapshot d'une ressource (état, intégrité, URL) |\n",
-    "| `aspire logs <res>` | journaux unifiés de la ressource |\n",
-    "| `aspire stop` | arrêter l'instance (et ses conteneurs) |\n",
-    "\n",
-    "La comparaison avec la pile manuelle : le YAML compose fixe les ports et exige une duplication par worktree ; l'AppHost C# **déclare** la ressource une fois, et `--isolated` fournit l'isolation — orchestrer notre pile GenAI est désormais du **code exécuté**, pas de la prose. Voir aussi le backend d'observabilité OTLP du grain #10474 (`aspire-otel/`) pour la télémétrie.",
-    "\n",
-    "\n",
-    "Le bilan de ce notebook tient en une mesure : `Ports distincts : True (A=56367, B=49404)`. Une seule declaration C# (`apphost.cs`), un service reel (transcription HTTP 200), deux instances simultanees sans collision de ports — la dette d'orchestration decrite en ouverture est couverte par l'isolation, et chaque affirmation de cette conclusion a ete mesuree dans les sorties qui precedent.\n"
-   ]
+   "source": "## Conclusion\n\nEn une session : l'AppHost Aspire a **orchestré** notre service GenAI réel (whisper-api, image locale, GPU), a été **lancé en deux instances simultanées** (`--isolated`, ports distincts prouvés), **interrogé** (`describe`, `ps`), **journalisé** (`logs`) et a **servi une transcription réelle**. Les commandes clés :\n\n| Commande | Rôle |\n|---|---|\n| `aspire run --detach --isolated` | lancer l'AppHost en arrière-plan, ports randomisés |\n| `aspire ps` / `aspire describe <res>` | lister les AppHosts / snapshot d'une ressource (état, intégrité, URL) |\n| `aspire logs <res>` | journaux unifiés de la ressource |\n| `aspire stop` | arrêter l'AppHost ; le sort des conteneurs dépend du runtime Docker local (le nettoyage effectif est fait par la cellule finale) |\n\nLa comparaison avec la pile manuelle : le YAML compose fixe les ports et exige une duplication par worktree ; l'AppHost C# **déclare** la ressource une fois, et `--isolated` fournit l'isolation — orchestrer notre pile GenAI est désormais du **code exécuté**, pas de la prose. Voir aussi le backend d'observabilité OTLP du grain #10474 (`aspire-otel/`) pour la télémétrie.\n\nLe bilan de ce notebook tient en une mesure structurelle : la ligne `Ports distincts : True` de la section 4, adossée aux deux conteneurs `whisper-api-<suffixe>` visibles dans `docker ps`. Une seule declaration C# (`apphost.cs`), un service reel (transcription HTTP 200), deux instances simultanees sans collision de ports — la dette d'orchestration decrite en ouverture est couverte par l'isolation, et chaque affirmation de cette conclusion a ete mesuree dans les sorties qui precedent (les ports et suffixes exacts varient a chaque execution ; ce sont les lignes verbatim, pas les valeurs, qui portent la preuve)."
   },
   {
    "cell_type": "code",
@@ -1013,16 +997,35 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Instances arretees - conteneurs Aspire supprimes, pile manuelle intacte.\r\n"
+     "text": "\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Conteneurs Aspire residuels apres stop : 2\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  whisper-api-rvxjtvah\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  whisper-api-wbbgnzgq\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "whisper-api-rvxjtvah\nwhisper-api-wbbgnzgq\n\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "AppHosts arretes ; conteneurs orchestres residuels retires ; pile manuelle intacte.\r\n"
     }
    ],
-   "source": [
-    "using System.IO; using System.Net.Http; using System.Text.RegularExpressions; using System.Threading.Tasks;\n",
-    "// Nettoyage : arreter les deux instances (Aspire supprime leurs conteneurs a l'arret).\n",
-    "Console.WriteLine(AspireShell.Aspire(AspireShell.DirWt1, \"stop\"));\n",
-    "Console.WriteLine(AspireShell.Aspire(AspireShell.DirWt2, \"stop\"));\n",
-    "Console.WriteLine(\"Instances arretees - conteneurs Aspire supprimes, pile manuelle intacte.\");"
-   ]
+   "source": "using System.IO; using System.Net.Http; using System.Text.RegularExpressions; using System.Threading.Tasks;\n// Nettoyage : arreter les deux AppHosts. `aspire stop` arrete l'ORCHESTRATEUR ;\n// le sort du conteneur depend du runtime Docker local -- observe sur Docker\n// Desktop/Windows (2 runs consecutifs) : les conteneurs whisper-api-<suffixe>\n// restent Up apres un stop reussi. On l'observe ici, puis on retire les\n// residuels. La pile manuelle (conteneur \"whisper-api\" SANS suffixe) n'est\n// jamais touchee : le filtre exige le tiret du suffixe Aspire.\nConsole.WriteLine(AspireShell.Aspire(AspireShell.DirWt1, \"stop\"));\nConsole.WriteLine(AspireShell.Aspire(AspireShell.DirWt2, \"stop\"));\nConsole.WriteLine();\n\n// Observation : conteneurs orchestres encore vivants apres le stop ?\nvar residuels = AspireShell.Run(AspireShell.DirWt1, \"docker\",\n    \"ps --filter name=whisper-api- --format \\\"{{.Names}}\\\"\");\nvar noms = new System.Collections.Generic.List<string>();\nforeach (var ligne in residuels.Split('\\n')) {\n    var n = ligne.Trim();\n    if (n.StartsWith(\"whisper-api-\")) noms.Add(n);\n}\nConsole.WriteLine($\"Conteneurs Aspire residuels apres stop : {noms.Count}\");\nforeach (var n in noms) Console.WriteLine($\"  {n}\");\n\n// Nettoyage effectif : c'est ce geste (rm -f), pas `aspire stop`, qui libere\n// les conteneurs orchestres sur ce runtime.\nif (noms.Count > 0)\n    Console.WriteLine(AspireShell.Run(AspireShell.DirWt1, \"docker\",\n        $\"rm -f {string.Join(\" \", noms)}\"));\nConsole.WriteLine(\"AppHosts arretes ; conteneurs orchestres residuels retires ; pile manuelle intacte.\");"
   }
  ],
  "metadata": {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2026:CoursIA — prev: MED/tooling #11863

## Summary

Corrige le mensonge de la cellule 26 de `01-Aspire-Orchestration-GenAi.ipynb` (« Aspire supprime leurs conteneurs a l'arret ») : commentaire reformule sur l'observation, geste de nettoyage EFFECTIF ajoute, ligne de table de la conclusion alignee. **1 fichier, +42/-39.**

## Le defaut, re-confirme sur CE run (3e observation, 2e machine)

L'issue #11848 documentait l'observation po-2025 (Docker Desktop Windows, 2 runs consecutifs). Ce run sur **po-2026** (Docker Desktop 29.7.2, RTX 3080 Ti) reproduit exactement le defaut — sortie reelle de la cellule 26 commitee :

```
✅ apphost.cs stopped successfully.          <- x2 (wt1, wt2)
Conteneurs Aspire residuels apres stop : 2
  whisper-api-rvxjtvah
  whisper-api-wbbgnzgq
whisper-api-rvxjtvah                          <- sortie du docker rm -f
whisper-api-wbbgnzgq
AppHosts arretes ; conteneurs orchestres residuels retires ; pile manuelle intacte.
```

`aspire stop` arrete l'AppHost ; les conteneurs restent Up sur ce runtime.

## Le fix

1. **Cellule 26** : commentaire corrige (le sort du conteneur depend du runtime Docker local) + observation (`docker ps --filter name=whisper-api-`) + nettoyage effectif (`docker rm -f`) des residuels. **La pile manuelle est epargnee par construction** : son conteneur s'appelle `whisper-api` (sans suffixe, `container_name:` explicite du compose), le filtre exige le tiret du suffixe Aspire (`whisper-api-`), et le garde C# re-verifie le prefixe avant le rm.
2. **Conclusion (markdown)** : la ligne `| aspire stop | arretter l'instance (et ses conteneurs) |` reformulee (elle repetait le meme mensonge) + paragraphe final rendu structurel — les ports/suffixes varient a chaque execution, ce sont les lignes verbatim (`Ports distincts : True`, deux conteneurs suffixes dans docker ps) qui portent la preuve, pas les valeurs gelees (extension du principe #11847 aux cellules 15/17).

## Validation (re-exec complete, regle F appliquee)

- **Env installe sur cette machine pour ce grain** : aspire.cli 13.5.0 (deja present), image `whisper-api-whisper-api` buildee depuis `docker-configurations/services/whisper-api/`, modele faster-whisper-large-v3-turbo (~1,6 Go) pre-telecharge dans le cache HF hote (bind-mounte par l'AppHost), `models/` recree (gitignore, absent du worktree frais).
- **Execution reelle end-to-end** : `dotnet_executor.py` **11/11 cellules, 0 erreur, 64,2 s** — les DEUX AppHosts lances (`--detach --isolated`), transcription **reelle HTTP 200** (`{"text":"Bonjour du cluster Aspire...","language":"fr","duration":8.178375}`), preuve d'isolation (`Ports distincts : True`), puis le nettoyage observe + retire les 2 residuels.
- `validate_pr_notebooks.py` : **PASS** (11 cells, .net-csharp).
- C.1 : 0 erreur volontaire (grep `raise NotImplementedError|assert False|1/0` = 0).
- Hygiene machine post-run : 0 conteneur whisper residuel (`docker ps -a | grep whisper` vide).

## Residuel

Aucun. L'issue est entierement couverte : commentaire corrige (point 1 du corps), geste de nettoyage effectif ajoute (point 2, option "OU" retenue), prose soutient la sortie partout ou le sujet apparait (conclusion).

Closes #11848

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>