### PR TITLE
feat(tooling,#11723): UNFINISHED_FENCE localise la ligne de l'opener orphelin

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -466,18 +466,20 @@ def _markers_all_quoted(line: str) -> bool:
     return True
 
 
-def _fence_line_indices(text: str) -> tuple[set[int], bool]:
-    """Return (in_fence_indices, unterminated_at_eof).
+def _fence_line_indices(text: str) -> tuple[set[int], int | None]:
+    """Return (in_fence_indices, orphan_opener_line).
 
     The set contains the 0-based indices of lines that sit INSIDE a markdown
-    fence. The boolean is True iff a fence was opened but never closed -- in
-    CommonMark terms the fence runs to EOF, which is the correct rendering
-    behaviour (and what GitHub does), but it has a perverse downstream
-    consequence: every line after the orphan opener is excluded from the
-    scan, and the gate becomes a silent no-op for the rest of the body. The
-    boolean lets `--scan-thread` distinguish "no candidates found" from "no
-    candidates read", which is exactly the false-negative shape that
-    #11678's founder case measured.
+    fence. The int is the 0-based index of the orphan opener line -- the
+    delimiter that was opened but never closed, so the fence runs to EOF --
+    and None when every fence is closed (#11723). In CommonMark terms the
+    fence running to EOF is the correct rendering behaviour (and what GitHub
+    does), but it has a perverse downstream consequence: every line after
+    the orphan opener is excluded from the scan, and the gate becomes a
+    silent no-op for the rest of the body. Localizing the opener lets
+    `--scan-thread` distinguish "no candidates found" from "no candidates
+    read" AND point the author at the exact line to close, which is exactly
+    the false-negative shape #11678's founder case measured.
 
     Mirrors the existing _quote_spans exemption idea: a fence is transcription,
     never an author's own claim. Workers document their L898 cross-lane
@@ -497,12 +499,14 @@ def _fence_line_indices(text: str) -> tuple[set[int], bool]:
     """
     indices: set[int] = set()
     in_fence = False
+    orphan_opener: int | None = None
     for idx, raw_line in enumerate(text.splitlines()):
         stripped = raw_line.lstrip()
         # A closing delimiter closes the fence BEFORE we record this line:
         # the delimiter itself is not part of the fenced body.
         if in_fence and (stripped.startswith("`" * 3) or stripped.startswith("~" * 3)):
             in_fence = False
+            orphan_opener = None
             continue
         if not in_fence:
             # Open the fence on the next iteration.
@@ -510,11 +514,12 @@ def _fence_line_indices(text: str) -> tuple[set[int], bool]:
                 stripped.startswith("~" * 3) and len(stripped) >= 3
             ):
                 in_fence = True
+                orphan_opener = idx
             continue
         # We're inside a fence (opening was on a previous line, no closing on
         # this one). Add this line to the set.
         indices.add(idx)
-    return indices, in_fence
+    return indices, orphan_opener
 
 
 def extract_perimeter_assertions(text: str) -> list[str]:
@@ -578,11 +583,13 @@ def _check_unterminated_fence(text: str) -> bool:
     candidacy, and the gate becomes a no-op for the rest of the body. Issue
     #11678 makes this distinction visible: "no candidates found" is no
     longer indistinguishable from "no candidates read". This wraps
-    `_fence_line_indices` and discards the index set, keeping the unterminated
-    flag for callers that only need the boolean (`--scan-thread`).
+    `_fence_line_indices` and discards the index set AND the opener line
+    (#11723), keeping the boolean for callers that only need "is there an
+    orphan" -- callers that need to localize it read `_fence_line_indices`
+    directly.
     """
     _, unterminated = _fence_line_indices(text)
-    return unterminated
+    return unterminated is not None
 
 
 def _format_signal_explanation(candidates: list[Candidate]) -> str:
@@ -747,7 +754,7 @@ class Candidate:
         return self.source == "body" and not _is_incidental_assertion(self.text)
 
 
-def select_candidates(items: list[dict]) -> tuple[list[Candidate], bool]:
+def select_candidates(items: list[dict]) -> tuple[list[Candidate], int | None]:
     """Extract assertions, keeping only each thread author's LAST ones.
 
     #11648-b1 (supersession). The founding measurement: on #11646 the guard
@@ -762,21 +769,25 @@ def select_candidates(items: list[dict]) -> tuple[list[Candidate], bool]:
     silence, not a retraction. The PR body is never superseded: there is only
     one of it, and it is always the current text.
 
-    Returns (candidates, unterminated_body_fence). The latter is True iff
-    the PR body had a fence opened but never closed before EOF -- the
-    silent-no-op shape #11678 measured on #11675/serde. The flag does NOT
-    change the gate's verdict (CommonMark-fence-to-EOF is correct rendering);
-    it makes the false-negative shadow visible to the reviewer.
+    Returns (candidates, orphan_opener_line). The latter is the 0-based line
+    index of the FIRST body-scanning-order body that had a fence opened but
+    never closed before EOF (None when every body is clean) -- the
+    silent-no-op shape #11678 measured on #11675/serde, localized per #11723.
+    The flag does NOT change the gate's verdict (CommonMark-fence-to-EOF is
+    correct rendering); it makes the false-negative shadow visible to the
+    reviewer AND actionable (the author is told which line to close).
     """
     body_items = [i for i in items if i.get("source") != "thread"]
     thread_items = [i for i in items if i.get("source") == "thread"]
 
     out: list[Candidate] = []
-    unterminated_seen = False
+    orphan_opener: int | None = None
     for item in body_items:
         body = item["body"]
-        if _check_unterminated_fence(body):
-            unterminated_seen = True
+        if orphan_opener is None:
+            _, opener = _fence_line_indices(body)
+            if opener is not None:
+                orphan_opener = opener
         for text in extract_perimeter_assertions(body):
             out.append(Candidate(text, item["kind"], item["author"], "body"))
 
@@ -798,7 +809,7 @@ def select_candidates(items: list[dict]) -> tuple[list[Candidate], bool]:
             out.append(
                 Candidate(text, item["kind"], author, "thread", item.get("ts") or "")
             )
-    return out, unterminated_seen
+    return out, orphan_opener
 
 
 def main() -> int:
@@ -827,11 +838,11 @@ def main() -> int:
     if args.assertion:
         report.problems.extend(check_assertion(report.files, args.assertion))
     signals: list[str] = []
-    unterminated_seen = False
+    orphan_opener: int | None = None
     if args.scan_thread:
-        candidates, unterminated_body = select_candidates(fetch_review_thread(args.pr))
-        if unterminated_body:
-            unterminated_seen = True
+        candidates, body_orphan = select_candidates(fetch_review_thread(args.pr))
+        if body_orphan is not None:
+            orphan_opener = body_orphan
         for cand in candidates:
             for p in check_assertion(report.files, cand.text):
                 line = f"[{cand.kind} / {cand.author}] {p}"
@@ -865,18 +876,21 @@ def main() -> int:
         # note"; all thread -> "tier to correct"; mixed -> both. The old
         # blanket phrase was wrong for the all-body case (#11786 / #11775).
         print(f"  -> {_format_signal_explanation(candidates)}")
-    if unterminated_seen:
+    if orphan_opener is not None:
         # #11678: the body scanned had an unterminated fence. CommonMark
         # renders it to EOF (correct behaviour, what GitHub does), but the
         # downstream perimeter scan sees an empty second half. Emit a
         # non-blocking notice so the reviewer can ask the author to close
-        # the fence or split the body. A scan with 0 candidates and a
-        # `unterminated: true` is a different shape from a scan with 0
+        # the fence or split the body. A scan with 0 candidates and an
+        # unterminated fence is a different shape from a scan with 0
         # candidates and a clean read -- the former is suspect, the latter
-        # is just clean.
+        # is just clean. #11723: the notice names the orphan opener's line
+        # (1-based for the human reading the PR body in a browser/editor) --
+        # a signal that does not localize gets watched, not acted on.
         print("")
-        print("UNFINISHED_FENCE: True")
-        print("  -> le body de la PR contient une fence ``` ou ~~~ non fermee.")
+        print(f"UNFINISHED_FENCE: orphan opener at line {orphan_opener + 1} (1-based)")
+        print("  -> le body de la PR contient une fence ``` ou ~~~ non fermee,")
+        print(f"     ouverte a la ligne {orphan_opener + 1} et jamais fermee.")
         print("     CommonMark la rend jusqu'en fin de body, ce qui est correct ;")
         print("     mais le scan de perimetre a ignore toutes les lignes qu'elle")
         print("     enferme. Demander a l'auteur de fermer la fence (ou de la")

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -331,8 +331,8 @@ def test_fence_line_indices_skip_only_enclosed_lines():
     assert indices == {5, 6, 7, 8, 9, 10}, (
         f"expected only the body lines inside the fence to be flagged, got {sorted(indices)}"
     )
-    assert unterminated is False, (
-        "a well-formed fence (opener + closer) must NOT be reported unterminated"
+    assert unterminated is None, (
+        "a well-formed fence (opener + closer) must NOT report an orphan opener"
     )
 
 
@@ -474,11 +474,13 @@ def test_unterminated_fence_helper_pins_true_on_founder_body():
     assert _check_unterminated_fence(L11678_FOUNDER_BODY) is True, (
         "orphan opener on founder body must raise unterminated_fence"
     )
-    # Direct: the tuple's second element also carries the flag.
-    indices, unterminated = _fence_line_indices(L11678_FOUNDER_BODY)
-    assert unterminated is True, (
-        "_fence_line_indices must report unterminated_at_eof when an opener "
-        "is never closed"
+    # Direct: the tuple's second element carries the orphan opener's line
+    # index (#11723) -- pinned, not just boolean: founder body lines are
+    # 0:"intro", 1:"```", so the orphan opener is 0-based index 1.
+    indices, orphan_opener = _fence_line_indices(L11678_FOUNDER_BODY)
+    assert orphan_opener == 1, (
+        f"_fence_line_indices must return the orphan opener's 0-based index "
+        f"(1 on the founder body), got {orphan_opener!r}"
     )
     # The flag must NOT silently swallow the closing state: every line from
     # the orphan opener onward (but NOT the opener itself) is in the set.
@@ -506,8 +508,8 @@ def test_unterminated_fence_helper_pins_false_on_closed_fence():
         "a fully closed fence must NOT trip unterminated_fence"
     )
     indices, unterminated = _fence_line_indices(body)
-    assert unterminated is False, (
-        "well-formed opener+closer must report unterminated_at_eof=False"
+    assert unterminated is None, (
+        "well-formed opener+closer must report no orphan opener (None)"
     )
     # Opener and closer are NOT in the set; the body line IS in the set.
     assert 1 not in indices and 3 not in indices, (
@@ -535,8 +537,8 @@ def test_unterminated_fence_propagates_through_select_candidates():
     )
     items = [{"kind": "body", "author": "owner", "body": body_closed, "source": "body"}]
     cands, unterminated = select_candidates(items)
-    assert unterminated is False, (
-        "closed body must NOT trip unterminated_body_fence"
+    assert unterminated is None, (
+        "closed body must NOT report an orphan opener"
     )
     assert all(check_assertion(FILES_OK, c.text) == [] for c in cands), (
         "matching prose claim over the right perimeter must still pass"
@@ -552,9 +554,9 @@ def test_unterminated_fence_propagates_through_select_candidates():
         "source": "body",
     }]
     cands_bad, unterminated_bad = select_candidates(items_bad)
-    assert unterminated_bad is True, (
-        "founder body with orphan opener must propagate the flag "
-        "through select_candidates"
+    assert unterminated_bad == 1, (
+        "founder body with orphan opener must propagate its 0-based line "
+        "index (1) through select_candidates, not just a boolean"
     )
     # The body line of the founder case still surfaces as a candidate
     # (the orphan fence does NOT swallow the line for the perimeter
@@ -567,6 +569,42 @@ def test_unterminated_fence_propagates_through_select_candidates():
     ), (
         "orphan fence swallows the post-opener line from the scan; "
         "this is the silent-no-op shape #11678 measures"
+    )
+
+
+def test_orphan_opener_line_is_pinned_on_founder_case():
+    """#11723 acceptance 3: the orphan opener's line number is PINNED at both
+    levels, not just its existence. An index that is off by one localizes the
+    defect to the wrong line -- worse than no index at all, because the
+    reviewer stops trusting the notice (``assert is not None`` would let an
+    index of 0, 2 or 4 pass silently).
+
+    Founder #11678 body layout (0-based): 0 "intro", 1 "```" (orphan opener,
+    never closed), 2 "$ echo hi", 3 "", 4 "Perimetre : ...". The orphan
+    opener is therefore 0-based index 1 -- printed as line 2 (1-based) in the
+    ``UNFINISHED_FENCE`` notice.
+    """
+    _, opener = _fence_line_indices(L11678_FOUNDER_BODY)
+    assert opener == 1, (
+        f"founder body's orphan opener sits at 0-based index 1, got {opener!r}"
+    )
+    _, propagated = select_candidates([{
+        "kind": "body",
+        "author": "owner",
+        "body": L11678_FOUNDER_BODY,
+        "source": "body",
+    }])
+    assert propagated == 1, (
+        f"select_candidates must carry the same pinned index, got {propagated!r}"
+    )
+
+    # Off-by-one guard: an orphan opener placed one line lower must pin one
+    # index lower -- the value must track the opener's actual position, not
+    # a constant.
+    body_lower = "intro\ntitle\n```\n$ echo hi\n"
+    _, opener_lower = _fence_line_indices(body_lower)
+    assert opener_lower == 2, (
+        f"opener moved to 0-based index 2 must be reported as 2, got {opener_lower!r}"
     )
 
 


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2025:CoursIA-2 — prev: DEEP/notebook-dotnet #11866

#11723 : `_fence_line_indices` retourne désormais l'**index de ligne de l'opener orphelin** (le délimiteur ``` ou ~~~ ouvert jamais fermé), pas seulement un booléen — la notice `UNFINISHED_FENCE` nomme la ligne à fermer.

## Acceptance → livré

| # | Critère | Preuve |
|---|---|---|
| 1 | Index du dernier opener non fermé, `None` si tout fermé, **documenté** | `tuple[set[int], int | None]` — docstring : « the int is the 0-based index of the orphan opener line … None when every fence is closed » |
| 2 | La notice imprime ce numéro | `UNFINISHED_FENCE: orphan opener at line {n} (1-based)` + la ligne est répétée dans le corps français de la notice (« ouverte a la ligne N et jamais fermee ») |
| 3 | Test épinglant la **valeur** sur le founder case #11678 | `test_orphan_opener_line_is_pinned_on_founder_case` : `== 1` aux deux niveaux (`_fence_line_indices` + propagation `select_candidates`), **plus un garde off-by-one** (opener déplacé à l'index 2 → rapporté 2) — un test `is not None` laisserait passer un index faux |

## Changements

- `_fence_line_indices` : `(set, bool)` → `(set, int | None)` ; suit `orphan_opener` ouvert/fermé au fil du scan.
- `_check_unterminated_fence` : garde son contrat `bool` (`is not None`) — docstring dit explicitement que qui veut localiser lit `_fence_line_indices` directement.
- `select_candidates` : second retour `int | None` = index 0-based du premier opener orphelin (bodies dans l'ordre du scan, premier gagnant, documenté).
- `main()` : notice passe de `UNFINISHED_FENCE: True` muet à la ligne nommée (1-based pour l'humain qui lit le body dans un navigateur).

## Tests

**62/62 passent** (58 préexistants adaptés aux nouvelles signatures — `is False` → `is None`, `is True` → `== 1` — plus le test dédié #11723). Aucune suppression de couverture : les tests #11678 existants assertent toujours leurs sémantiques (helper bool, ensemble d'indices, propagation), ils pincent désormais la valeur au lieu de la vérité booleénne.

## Note pool

Label `candidate-delivered` retiré sur l'issue (commentaire avec preuve) : faux positif — la PR cross-référencée #11680 est la PR fondatrice, pas une livraison. Closes #11723.

Closes #11723
