### PR TITLE
feat(lean,#6724): classe 2 spaceships — stabilisation moteur mémoïsé à translation près

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/conway_lean/Conway/Life/HashlifeCorrectness.lean
@@ -7347,5 +7347,88 @@ exactement l'état initial. -/
 #eval evolve 2 blinker_h == blinker_h
 #eval evolveHashlifeFastMemo 8 blinker_h == blinker_h
 
+/-! ## Axe efficacité (#6724) : stabilisation du moteur, classe 2 — motifs à répétition par tuiles (spaceships)
+
+Le pendant « space-filler » de la classe 1 : un vaisseau de période `p` et de
+déplacement `v` ne produit lui aussi qu'un nombre borné d'états — à translation
+près. L'arbre de macrocells se stabilise de la même façon : les tuiles se
+récurent, le cache sert indéfiniment les mêmes nœuds (front qui avance à
+vitesse bornée `|v|/p` par génération, structure interne périodique). Cette
+section formalise ce retour : pour un spaceship, tout horizon retombe sur
+l'état `n % p` du cycle, translaté de `(n / p) • v`. -/
+
+/-- Vaisseau de période `p` et de déplacement `v` : au moins une étape, une
+    grille canonique, et l'état initial réapparaît après `p` générations,
+    translaté de `v`. Classe « motifs à tuiles répétées / space-fillers » de
+    l'axe efficacité #6724 (le glider en est le représentant canonique).
+    La canonicalité n'est pas cosmétique : sans elle `shift (0, 0) g ≠ g`
+    (le `sortDedup` de `shift` réordonne), et le retour du motif à `k = 0`
+    échouerait. -/
+def IsSpaceship (p : Nat) (v : Int × Int) (g : Grid) : Prop :=
+  0 < p ∧ Canonical g ∧ evolve p g = shift v g
+
+/-- Une étape de spaceship : avancer de `p` générations revient à translater
+    l'état courant — la brique additive de la trajectoire. -/
+theorem evolve_spaceship_step (p : Nat) (v : Int × Int) (g : Grid)
+    (h : evolve p g = shift v g) (n : Nat) :
+    evolve (n + p) g = shift v (evolve n g) := by
+  rw [evolve_add, h, ← evolve_shift]
+
+/-- Tout multiple de la période reproduit le motif translaté de `k • v` :
+    la trajectoire sémantique d'un spaceship ne visite que `p` états à
+    translation près. -/
+theorem evolve_spaceship_mul (p : Nat) (v : Int × Int) (g : Grid)
+    (h : evolve p g = shift v g) (hg : Canonical g) :
+    ∀ k, evolve (k * p) g = shift (k * v.1, k * v.2) g := by
+  obtain ⟨v1, v2⟩ := v
+  intro k
+  induction k with
+  | zero => simp [evolve, shift_zero hg]
+  | succ k ih =>
+      rw [Nat.succ_mul, evolve_spaceship_step p (v1, v2) g h, ih, shift_shift]
+      apply congrArg (fun w => shift w g)
+      ext <;> (simp only [Nat.succ_eq_add_one]; push_cast; ring)
+
+/-- Stabilisation du moteur mémoïsé sur la classe des spaceships : tout
+    horizon multiple de la période fait retomber le moteur sur l'état
+    initial translaté de `k • v`. L'invariant « l'arbre se stabilise »
+    formalisé pour la classe des motifs à tuiles répétées (critère « axe
+    efficacité » de #6724, classe 2) : la sortie du moteur ne quitte jamais
+    la famille translatée du motif — le front avance à vitesse bornée, la
+    structure interne reste confinée au cycle à `p` états. -/
+theorem evolveHashlifeFastMemo_spaceship_stable
+    (p k : Nat) (v : Int × Int) (g : Grid) (hsp : IsSpaceship p v g)
+    (hcap : ∀ t ≤ k * p, jumpCaptured (gridToMacroCellWithOffset (evolve t g)).2 = true) :
+    evolveHashlifeFastMemo (k * p) g = shift (k * v.1, k * v.2) g := by
+  rw [evolveHashlifeFastMemo_eq_evolveHashlifeFast, hashlife_correctN _ _ hcap,
+    evolve_spaceship_mul p v g hsp.2.2 hsp.2.1 k]
+
+/-- Horizon général : tout horizon `n` retombe sur l'état `n % p` du cycle,
+    translaté de `(n / p) • v` — le prolongement du théorème de cycle de la
+    classe 1 aux spaceships. -/
+theorem evolveHashlifeFastMemo_spaceship_cycle
+    (p n : Nat) (v : Int × Int) (g : Grid) (hsp : IsSpaceship p v g)
+    (hcap : ∀ t ≤ n, jumpCaptured (gridToMacroCellWithOffset (evolve t g)).2 = true) :
+    evolveHashlifeFastMemo n g
+      = shift ((n / p) * v.1, (n / p) * v.2) (evolve (n % p) g) := by
+  rw [evolveHashlifeFastMemo_eq_evolveHashlifeFast, hashlife_correctN n g hcap]
+  obtain ⟨v1, v2⟩ := v
+  have key : ∀ m q : Nat, evolve (m + q * p) g
+      = shift (q * v1, q * v2) (evolve m g) := by
+    intro m q
+    rw [evolve_add, evolve_spaceship_mul p (v1, v2) g hsp.2.2 hsp.2.1 q, evolve_shift]
+  have hn : n % p + n / p * p = n := by
+    rw [Nat.mul_comm]; exact Nat.mod_add_div n p
+  calc evolve n g = evolve (n % p + n / p * p) g := by rw [hn]
+    _ = shift ((n / p) * v1, (n / p) * v2) (evolve (n % p) g) := key (n % p) (n / p)
+
+/-! Sanity witnesses : le glider est un vaisseau de période 4 et de
+déplacement `(1, -1)` (témoin `glider_spaceship` de `Conway.Life`), et le
+moteur mémoïsé le stabilise — à tout multiple de la période il redonne
+l'état initial translaté de `k • (1, -1)`. -/
+
+#eval evolve 4 glider == shift (1, -1) glider
+#eval evolveHashlifeFastMemo 8 glider == shift (2, -2) glider
+
 end Life
 end Conway


### PR DESCRIPTION
Grain: MED/lean — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #11813

#6724 axe efficacité, **classe 2 (space-filler à tuile répétée)** : le pendant spaceship de la classe 1 oscillateurs (#11799). Un vaisseau de période `p` et de déplacement `v` ne visite que `p` états **à translation près** — l'arbre de macrocells se stabilise de la même façon (le cache resert indéfiniment les mêmes nœuds, front à vitesse bornée `|v|/p`). Cette tranche formalise ce retour au niveau sémantique du moteur mémoïsé.

## Livrable (`HashlifeCorrectness.lean`, ~90 lignes après la classe 1)

| Élément | Rôle |
|---|---|
| `def IsSpaceship (p v g) : Prop := 0 < p ∧ Canonical g ∧ evolve p g = shift v g` | la classe des motifs à tuile répétée. La canonicalité est **nécessaire mathématiquement** : sans elle `shift (0,0) g ≠ g` (le `sortDedup` de `shift` réordonne, `shift_zero` l.418 de `GridCanonical.lean` exige `Canonical g`) et le retour du motif à `k = 0` échouerait — documenté dans la docstring |
| `evolve_spaceship_step` | brique additive : `evolve (n + p) g = shift v (evolve n g)` (par `evolve_add` + `evolve_shift`) |
| `evolve_spaceship_mul` | tout multiple de la période reproduit le motif translaté de `k • v` — la trajectoire ne visite que `p` états à translation près |
| `evolveHashlifeFastMemo_spaceship_stable` | miroir exact de `_oscillator_stable` (l.7336) : à tout multiple de la période, le moteur mémoïsé redonne l'état initial translaté de `k • v`, sous hypothèse de capture `hashlife_correctN` |
| `evolveHashlifeFastMemo_spaceship_cycle` | miroir de `_oscillator_cycle` (l.7319) : tout horizon `n` retombe sur l'état `n % p` du cycle translaté de `(n / p) • v` |
| `#eval` witnesses | `evolve 4 glider == shift (1,-1) glider` / `evolveHashlifeFastMemo 8 glider == shift (2,-2) glider` — miroir des witnesses blinker de la classe 1 ; le glider a déjà son témoin formel Bool (`glider_spaceship`, `Conway.Life` l.249) |

Briques réutilisées (0 nouveau sorry, 0 axiome) : `evolve_add` (Foundation l.2839), `evolve_shift` (GridCanonical l.392), `shift_shift` (l.402), `shift_zero` (l.418), `hashlife_correctN` + `evolveHashlifeFastMemo_eq_evolveHashlifeFast` (comme la classe 1).

## Preuves d'exécution

- `lake build Conway.Life.HashlifeCorrectness` : **EXIT=0** (WSL), post-écriture ;
- `python scripts/lean/count_code_sorry.py --json` : `distinct_code_sorry` inchangé (conway = 1, le `MarginFragment` pré-existant, hors périmètre) ;
- witnesses `#eval` : les deux affichent `true` dans la sortie de build.

## Diagnostic dérive / Verdict SOTA

N/A — preuve formelle (pas de notebook), pas de moteur substitué (Lean + Mathlib = l'outil réel).

See #6724 (axe efficacité, classe 2 ; classe 1 oscillateurs = #11799). Ne ferme pas l'epic : reste le versant structurel du cache (réutilisation effective des nœuds) + les autres axes P4-mpr/murs.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
