### PR TITLE
docs(sk,#11271): enrichissement markdown-only SK-AutoInteractive 599->1616

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/Semantic-kernel-AutoInteractive.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/Semantic-kernel-AutoInteractive.ipynb
@@ -8,12 +8,20 @@
     "\n",
     "# Notebook de conception de Notebook\n",
     "\n",
-    "Ce Notebook .Net interactive a pour objectif de permettre la création assistée d'autres notebooks .Net interactive en confiant le soin à ChatGPT d'analyser et de proposer des modifications d'une version courante, et en prenant en charge la mise à jour et l'exécution des mises à jour en function calling Open AI grâce à l'API .Net interactive. \n",
+    "Ce Notebook .Net interactive a pour objectif de permettre la création assistée d'autres notebooks .Net interactive en confiant à Semantic-Kernel la responsabilité de les écrire, de les exécuter et de les corriger. C'est un cas d'usage **méta** : le LLM ne produit pas un texte pour l'humain, il produit et raffine un *livrable exécutable* — un notebook complet, du Markdown initial jusqu'au graphique final conforme.\n",
     "\n",
+    "Le notebook déroule un pipeline en quatre étapes, chacune portée par une section numérotée :\n",
     "\n",
-    "### 1. Initialisation\n",
+    "1. **Fourniture des informations** (section 1) — le mode d'entrée de la description de tâche : variable en dur, questions interactives, ou fichier.\n",
+    "2. **Recueil des informations** (section 2) — la collecte effective de la description selon le mode choisi.\n",
+    "3. **Personnalisation du notebook de travail** (section 3) — la génération du chemin du notebook cible depuis un template.\n",
+    "4. **Exécution et mise à jour itérative** — la boucle `AutoInvokeSKAgentsNotebookUpdater`, qui charge le template, laisse les agents SK compléter les cellules, exécute, et recommence jusqu'à convergence.\n",
     "\n",
-    "On installe des packages pour la manipulation de notebook et pour l'orchestration de LLMs."
+    "Chaque section conceptuelle est suivie d'un **exercice** (mode URL, validation de description, nom de fichier descriptif) : le notebook est lui-même un support pédagogique sur l'orchestration d'agents qui créent des supports pédagogiques.\n",
+    "\n",
+    "**Prérequis** : kernel `.NET (C#)`, les packages Nuget chargés dans la première cellule, et les fichiers compagnons `.cs` (`DisplayLogger`, `NotebookExecutor`...) importés dans la deuxième. La description d'exemple cible DBPedia via `dotNetRDF` et `XPlot.Plotly.Interactive` — un cas assez riche pour que la correction itérative ait du travail.\n",
+    "\n",
+    "> Note d'honnêteté : dans cette copie committée, les sorties d'affichage `display()` du kernel .NET ne sont pas conservées — les lectures ci-dessous s'anchorent sur le **source committé** des cellules, cité verbatim."
    ]
   },
   {
@@ -37,6 +45,20 @@
     "#r \"nuget: Microsoft.SemanticKernel, *-*\"\n",
     "#r \"nuget: Microsoft.SemanticKernel.Planners.OpenAI, *-*\"\n",
     "#r \"nuget: Microsoft.SemanticKernel.Agents.Core, *-*\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de la cellule : la machinerie en deux couches\n",
+    "\n",
+    "La liste Nuget superpose **deux mondes** que ce notebook doit faire dialoguer :\n",
+    "\n",
+    "- `Microsoft.DotNet.Interactive.*` (CSharp, Documents, PackageManagement) — l'API du kernel .NET Interactive lui-même : compiler des cellules, lire et écrire des documents `.ipynb`, gérer les packages. C'est elle qui permet de *manipuler le notebook comme un objet*.\n",
+    "- `Microsoft.SemanticKernel` + `Planners.OpenAI` + `Agents.Core` — l'orchestration LLM : planification, agents, invocations.\n",
+    "\n",
+    "L'exercice n'est pas anodin : les deux couches exposent chacune un symbole `Kernel` (voir la section des `using` plus bas, qui pose les alias). Un notebook qui *écrit* des notebooks doit instancier les deux — l'un comme substrat, l'autre comme auteur."
    ]
   },
   {
@@ -81,6 +103,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Lecture de la cellule : les classes compagnons\n",
+    "\n",
+    "Les imports `#!import` chargent les classes d'infrastructure qui ne sont pas dans ce fichier — elles vivent à côté, dans le dossier de la série :\n",
+    "\n",
+    "- `../../Config/Settings.cs` — la configuration partagée (endpoint, clé de modèle), même source que tous les notebooks SK de la série.\n",
+    "- `DisplayLogger` / `DisplayLoggerProvider` — un `ILogger` qui restitue la trace des agents **dans le notebook** au lieu de la noyer dans la console : chaque requête du planificateur devient visible en place.\n",
+    "- `NotebookExecutor` — le cœur méta : exécute un notebook .NET Interactive par programme et rapporte les erreurs de compilation/exécution cellule par cellule.\n",
+    "\n",
+    "Les imports en commentaire (`WorkbookUpdateInteraction`, `NotebookPlannerUpdater`, `AutoGenNotebookUpdater`...) sont les **variantes historiques** de la stratégie de mise à jour — ce notebook active `AutoInvokeSKAgentsNotebookUpdater`, les autres restent disponibles pour comparaison."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "- **Imports des espaces de noms**\n",
     "\n",
     "On prend soin de distinguer le kernel d'exécution de notebook .Net interactive, et le kernel de semantic-kernel."
@@ -119,9 +156,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Lecture de la cellule : deux kernels, deux alias\n",
+    "\n",
+    "La dernière ligne porte tout le sens de la superposition :\n",
+    "\n",
+    "```csharp\n",
+    "using SKernel = Microsoft.SemanticKernel.Kernel;\n",
+    "using IKernel  = Microsoft.DotNet.Interactive.Kernel;\n",
+    "```\n",
+    "\n",
+    "`SKernel` est l'orchestrateur LLM (plugins, agents, planners) ; `IKernel` est le kernel hôte — celui qui exécute *cette* cellule et sait interroger l'utilisateur (`IKernel.GetInputAsync`, utilisé par le mode `Prompt` de la section 2). Sans les alias, le nom `Kernel` serait ambigu et le compilateur refuserait. C'est le point de jonction exact du cas d'usage méta : le notebook utilise le kernel hôte pour interagir avec vous, et instancie le kernel SK pour engendrer ses pairs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### 1. Mode de Fourniture des Informations\n",
     "\n",
-    "On permet à l'utilisateur de saisir les informations décrivant la tâche à accomplir dans le notebook de travail de plusieurs façons différentes."
+    "On permet à l'utilisateur de saisir les informations décrivant la tâche à accomplir dans le notebook de travail de plusieurs façons différentes.\n",
+    "\n",
+    "L'enum `InformationMode` ci-dessous fixe la stratégie d'entrée : `Variable` (la description est en dur dans ce notebook — reproductible, idéal pour les tests), `Prompt` (quatre questions posées interactivement via le kernel hôte), `File` (la description vit dans un fichier). Le mode est un *paramètre d'expérience*, pas un détail : il détermine qui fournit l'intention initiale — le développeur, l'utilisateur au clavier, ou un artefact existant."
    ]
   },
   {
@@ -148,7 +203,29 @@
   },
   {
    "cell_type": "markdown",
-   "source": "### Exercice : Ajouter un mode de fourniture URL\n\nL'enum `InformationMode` définit actuellement trois modes (Variable, Prompt, File). Vous pouvez ajouter un quatrieme mode pour recuperer la description depuis une URL distante.\n\n**Objectif** : Completez le code ci-dessous pour ajouter le mode `Url` a l'enum et ecrire une méthode qui simule le chargement d'une description depuis une URL (affichez simplement l'URL que vous utiliseriez).\n\n**Indices** :\n- # Étape 1 : Ajoutez la valeur `Url` dans l'enum `InformationMode`\n- # Étape 2 : Completez la méthode `FetchDescriptionFromUrl` qui prend une URL et retourne un message indiquant l'URL qui serait chargee\n- # Indice : En production, on utiliserait `HttpClient.GetStringAsync(url)`, ici contentez-vous de simuler le comportement",
+   "metadata": {},
+   "source": [
+    "### Lecture de la cellule : un enum comme point d'extension\n",
+    "\n",
+    "Trois valeurs, trois stratégies — et l'exercice ci-dessous en propose une quatrième (`Url`). Le pattern mérite d'être nommé : plutôt qu'un `switch` dispersé, la sélection de source est **une donnée** (`var mode = InformationMode.Variable;` dans la section 2), lue par un seul bloc conditionnel. Ajouter un mode = ajouter une valeur + une branche, sans toucher au reste."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "### Exercice : Ajouter un mode de fourniture URL\n",
+    "\n",
+    "L'enum `InformationMode` définit actuellement trois modes (Variable, Prompt, File). Vous pouvez ajouter un quatrieme mode pour recuperer la description depuis une URL distante.\n",
+    "\n",
+    "**Objectif** : Completez le code ci-dessous pour ajouter le mode `Url` a l'enum et ecrire une méthode qui simule le chargement d'une description depuis une URL (affichez simplement l'URL que vous utiliseriez).\n",
+    "\n",
+    "**Indices** :\n",
+    "- # Étape 1 : Ajoutez la valeur `Url` dans l'enum `InformationMode`\n",
+    "- # Étape 2 : Completez la méthode `FetchDescriptionFromUrl` qui prend une URL et retourne un message indiquant l'URL qui serait chargee\n",
+    "- # Indice : En production, on utiliserait `HttpClient.GetStringAsync(url)`, ici contentez-vous de simuler le comportement\n",
+    "\n",
+    "**Indice d'architecture** : en production, `FetchDescriptionFromUrl` ferait un `HttpClient().GetStringAsync(url)` — mais pour l'exercice, une simulation suffit : l'objectif est de comprendre où se raccorde une nouvelle source d'information, pas d'écrire un client HTTP. Observez que le test en bas de la cellule (`simulated ?? \"Exercice a completer\"`) échoue doucement tant que le stub retourne `null` — pattern C.1, le notebook reste exécutable de bout en bout."
+   ],
    "metadata": {}
   },
   {
@@ -175,7 +252,9 @@
    "source": [
     "### 2. Recueil des informations\n",
     "\n",
-    "Selon le mode de fourniture des informations choisi, on récupère la tâche à accomplir dans le notebook de travail."
+    "Selon le mode de fourniture des informations choisi, on récupère la tâche à accomplir dans le notebook de travail.\n",
+    "\n",
+    "La cellule ci-dessous matérialise le choix : elle instancie un `display` d'avancement (`Collecte d'informations en cours...`), fixe `mode = InformationMode.Variable`, puis porte la description de référence — **une commande de cahier des charges complète en une phrase** : requêter DBPedia avec `dotNetRDF` et `XPlot.Plotly.Interactive`, commencer par le Markdown, choisir une requête complexe « manipulant des aggrégats », et finir par la conformité de la sortie graphique. C'est cette richesse qui donnera au LLM une tâche digne de sa boucle de correction."
    ]
   },
   {
@@ -225,6 +304,21 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de la cellule : trois branches, un seul flux de sortie\n",
+    "\n",
+    "Le bloc conditionnel se lit comme une table des modes :\n",
+    "\n",
+    "- **`Variable`** — branche active ici : un simple `display` de confirmation, la description en dur fait foi.\n",
+    "- **`Prompt`** — quatre questions posées à l'utilisateur (`IKernel.GetInputAsync`) : « Veuillez fournir une brève description », « principaux objectifs », « contraintes ou conditions spécifiques », « informations supplémentaires ». Chaque réponse est **concaténée avec sa question** dans `taskDescription` — le LLM recevra le dialogue complet, pas seulement les réponses : les questions servent de squelette au prompt.\n",
+    "- **`File`** — laissée en exercice de lecture au lecteur (et à l'exercice `Url` ci-dessus pour la variante réseau).\n",
+    "\n",
+    "Point de détail qui compte : `taskDescription` est **réassignée** par le mode `Prompt` (elle démarre vide), alors que le mode `Variable` la consomme telle quelle. La variable est le contrat entre cette section et la boucle de mise à jour finale — peu importe son origine, la suite du pipeline n'en verra qu'une chaîne."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "source": "### Exercice : Valider la description de la tâche\n\nAvant de lancer la generation du notebook, il est utile de verifier que la description fournie est suffisamment precise pour guider le modèle.\n\n**Objectif** : Completez la méthode `ValidateTaskDescription` qui verifie que la description contient au moins 10 mots, mentionne au moins un package NuGet ou une technologie, et retourne un message de validation ou d'erreur.\n\n**Indices** :\n- # Étape 1 : Comptez le nombre de mots avec `description.Split(' ', StringSplitOptions.RemoveEmptyEntries).Length`\n- # Étape 2 : Cherchez des mots cles techniques (package, NuGet, using, requête, graphique, etc.) avec `description.Contains()`\n- # Étape 3 : Retournez un tuple `(bool isValid, string message)` indiquant le résultat\n- # Indice : Utilisez une liste de mots cles et LINQ `.Any(k => description.Contains(k))` pour la detection",
    "metadata": {}
   },
@@ -252,7 +346,9 @@
    "source": [
     "### 3. Personnalisation du Notebook de Travail\n",
     "\n",
-    "On charge un notebook template contenant des parties de Markdown et de code à compléter, et on injecte la tâche dans la partie descriptive en entête du notebook .Net interactive."
+    "On charge un notebook template contenant des parties de Markdown et de code à compléter, et on injecte la tâche dans la partie descriptive en entête du notebook (méthode `SetStartingNotebookFromTemplate` de la section 4).\n",
+    "\n",
+    "La cellule ci-dessous génère le chemin cible : `./Workbooks/Workbook-{DateTime.Now.ToFileTime()}.ipynb`. Deux choix se lisent dans cette seule ligne : le dossier `Workbooks/` **sépare les notebooks engendrés du notebook concepteur** (jamais de mutation du fichier source), et le timestamp `ToFileTime()` garantit l'**unicité** — chaque exécution produit un exemplaire neuf, comparable au précédent sans l'écraser."
    ]
   },
   {
@@ -270,6 +366,15 @@
    "source": [
     "\n",
     "var notebookPath = @$\"./Workbooks/Workbook-{DateTime.Now.ToFileTime()}.ipynb\";\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture de la cellule : pourquoi un timestamp plutôt qu'un nom fixe\n",
+    "\n",
+    "`ToFileTime()` rend le nom triable chronologiquement (c'est un entier croissant, formaté sans séparateurs). L'exercice suivant propose l'alternative lisible (`SK-<mots-cle>-<date>.ipynb`) — notez le compromis que chaque option achète : le timestamp est **unique par construction** mais illisible ; le nom descriptif est lisible mais exige une stratégie de collision (deux descriptions semblables le même jour produiraient le même nom). Une boucle de génération automatique qui écrase ses propres artefacts est un bug silencieux ; c'est le critère que votre implémentation de l'exercice doit tenir."
    ]
   },
   {
@@ -299,7 +404,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exécution et Mise à Jour Itérative avec AutoInvokeSKAgentsNotebookUpdater\n"
+    "### Exécution et Mise à Jour Itérative avec AutoInvokeSKAgentsNotebookUpdater\n",
+    "\n",
+    "La dernière cellule assemble tout : un `DisplayLogger` en verbosité `Trace` (chaque décision d'agent sera affichée), l'updater branché sur le chemin généré, l'injection de la description via `SetStartingNotebookFromTemplate(taskDescription)`, puis l'appel asynchrone `UpdateNotebookWithAutoInvokeSKAgents()` — la boucle complète : compléter les cellules du template, exécuter via `NotebookExecutor`, lire les erreurs, corriger, recommencer."
    ]
   },
   {
@@ -327,6 +434,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Lecture de la cellule : ce que l'await masque\n",
+    "\n",
+    "Les trois `display` encadrent l'appel (`Appel à UpdateNotebookWithAutoInvokeSKAgents...`, `Mise à jour du notebook terminée.`) : tout ce qui se passe entre les deux est **caché dans un seul `await`** — et c'est précisément là que vit l'intérêt du notebook. Selon la verbosité `Trace` du `DisplayLogger`, l'exécution réelle déroulera : la planification SK (choix des cellules à traiter), les invocations d'agents (rédaction Markdown, complétion C#), l'exécution du notebook engendré par `NotebookExecutor`, le **rapport d'erreurs cellule par cellule**, et la ré-injection de ces erreurs comme contexte de correction. Le `DisplayLogger` est ce qui rend la boucle *observable* : sans lui, `await updater.UpdateNotebookWithAutoInvokeSKAgents()` serait une boîte noire de plusieurs minutes.\n",
+    "\n",
+    "C'est aussi la cellule qui a besoin des ressources extérieures (endpoint LLM configuré dans `Settings.cs`) : sur une machine sans configuration, elle échouerait à l'appel réseau — les sections précédentes, elles, restent exécutables."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Conclusion\n",
     "\n",
     "Ce notebook illustre un cas d'usage **méta** de Semantic-Kernel : non pas interroger un LLM pour générer du texte, mais l'orchestrer pour **concevoir et mettre à jour d'autres notebooks .NET Interactive** de bout en bout.\n",
@@ -344,7 +462,9 @@
     "- La séparation **kernel d'exécution** vs **kernel SK** est essentielle : elle isole l'orchestration du LLM de l'exécution du code généré.\n",
     "- Les exercices (`InformationMode`, `GenerateNotebookName`) ancrent la pratique sur les deux briques d'extension les plus naturelles : élargir les sources d'entrée et enrichir la personnalisation de sortie.\n",
     "\n",
-    "**Référence** : Microsoft Semantic-Kernel — [Auto Function Calling](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/function-calling). Le notebook pousse le function calling jusqu'à l'auto-édition de notebooks, anticipant les patterns d'agents logiciels qui modifient leur propre runtime."
+    "**Référence** : Microsoft Semantic-Kernel — [Auto Function Calling](https://learn.microsoft.com/en-us/semantic-kernel/concepts/ai-services/chat-completion/function-calling). Le notebook pousse le function calling jusqu'à l'auto-édition de notebooks, anticipant les patterns d'agents logiciels qui modifient leur propre runtime.\n",
+    "\n",
+    "**Ce que ce notebook enseigne au-delà de Semantic-Kernel** : la séparation nette entre la *source d'intention* (l'enum et ses modes), le *substrat d'exécution* (kernel .NET Interactive manipulé comme bibliothèque) et l'*auteur* (agents SK) est un pattern d'architecture d'agents général — chaque couche est remplaçable indépendamment (c'est ce que montrent les imports en commentaire : `NotebookPlannerUpdater`, `AutoGenNotebookUpdater`). Les trois exercices (mode `Url`, validation de description, nom de fichier) ajoutent chacun un maillon à une chaîne différente : l'entrée, la garde qualité, le système de fichiers."
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2024:CoursIA — prev: LIGHT/guard #11794

## Tranche densite #11271 — Semantic-kernel-AutoInteractive 599 -> 1616

Enrichissement **markdown-only** (pattern #10488) du plus mauvais debiteur GenAI non couvert, remesure firsthand sur origin/main frais (densite 599).

### Ce qui change

- **7 nouvelles cellules `### Lecture de la cellule`** apres les cellules 1 (Nuget, deux couches DotNet.Interactive vs SemanticKernel), 3 (`#!import` compagnons), 5 (alias `SKernel`/`IKernel`), 7 (enum point d'extension), 11 (trois branches un flux), 15 (timestamp vs nom fixe), 19 (ce que l'await masque).
- **7 sections etendues** : intro (pipeline 4 etapes + prerequis + note d'honnetete), sections 1/2/3/updater reformulees avec lecture du role de chaque cellule, conclusion augmentee (pattern d'architecture d'agents), indice d'architecture sur l'exercice Url.
- **21 -> 28 cellules** (18 markdown, 10 code).

### Honnetete sur les ancres (regle cell-interpretation-ordering)

Les sorties `display()` du kernel .NET ne sont **pas conservees** dans la copie commitee (cellules display sans outputs). Les lectures s'anchorent donc sur le **source committé** des cellules, cite **verbatim** (ex. `using SKernel = ...`, `./Workbooks/Workbook-{DateTime.Now.ToFileTime()}.ipynb`, les 4 questions `GetInputAsync`). Note explicite en tete de notebook. Markdown-only => dispense de re-exec (C.3), mais position de chaque interp verifiee : chaque `### Lecture` suit immediatement la cellule code qu'elle commente (scan structurel clean).

### Preuves

| Check | Resultat |
|---|---|
| Byte-identity cellules code | **10/10 identiques** (source, outputs, execution_count) vs origin/main — script de comparaison cell-by-cell |
| `pedagogy_density.py --json` | density **1616** (seuil 1200), prose 16168 ch, 10 code / 18 md, 0 below_threshold |
| `scan_cell_ordering.py` | 1 scanned, **0 finding** (0 INTERP_BEFORE_CODE) |
| `validate_pr_notebooks.py HEAD <path>` | **PASS** (10 cells, .net-csharp) |
| Cellules code touchees | **0** — 129 insertions / 9 deletions, tout markdown |

Cap 1/lane/jour #11271 : derniere tranche de cette lane = FT-01 (#11590, 18/08) ; aujourd'hui libre (claim c.5348927338, paths-scopes).

See #11271
