### PR TITLE
fix(ci,#11861): le garde d'expression accusait la prose qui documente le defaut — main rouge, file bloquee

### DIFF
--- a/scripts/tests/test_workflow_expression_escapes.py
+++ b/scripts/tests/test_workflow_expression_escapes.py
@@ -18,6 +18,23 @@ par construction (`total_count: 0` jobs, `--log` vide, `--log-failed` vide).
 « Rien trouve » et « pas regarde » y rendent la meme chose -- exactement la
 famille de defauts que le depot corrige par un organe plutot que par de la
 vigilance.
+
+Ce qu'il ne doit PAS faire (correctif 2026-08-20) : accuser la *prose qui
+documente* le defaut. La premiere version scannait le texte brut, donc un
+commentaire YAML citant la forme fautive -- precisement la note d'incident
+deposee en tete de `degraded-mode-advisory.yml` -- comptait comme occurrence.
+Les deux PRs (#11861 le detecteur, #11863 la note) etaient vertes isolement et
+rouges combinees : `main` a passe ~1 h 20 rouge sur une jambe portant **zero**
+defaut reel, ce qui bloque toute la file. Un gate peut sur-accuser autant que
+sous-compter, et sa sur-accusation se paie en PRs qui vieillissent.
+
+Le scan porte donc sur ce que GitHub **rend** : les valeurs de l'arbre YAML.
+Les commentaires en sont absents (le parser les jette) ; les blocs `run: |` y
+sont presents (ce sont des chaines), donc une expression fautive glissee dans
+un commentaire *shell* d'un bloc `run:` reste attrapee -- GitHub rend
+l'expression avant que le shell ne voie le `#`, et meurt pareil. Ce dernier
+point porte son propre test : un detecteur se recette par ses faux negatifs,
+jamais par ses hits.
 """
 
 import glob
@@ -26,6 +43,7 @@ import os
 import re
 
 import pytest
+import yaml
 
 BACKSLASH = chr(92)
 
@@ -54,6 +72,47 @@ def _offenders(text):
     return [m.group(0) for m in _EXPRESSION.finditer(text) if _ESCAPED_QUOTE.search(m.group(0))]
 
 
+def _rendered_strings(doc):
+    """Toutes les chaines de l'arbre YAML -- ce que GitHub Actions rendra.
+
+    Les commentaires YAML n'y sont pas (le parser les jette) ; les blocs
+    scalaires (`run: |`, `body: |`) y sont, ainsi que les cles.
+    """
+    out = []
+    stack = [doc]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, str):
+            out.append(node)
+        elif isinstance(node, dict):
+            for key, value in node.items():
+                stack.append(key)
+                stack.append(value)
+        elif isinstance(node, (list, tuple)):
+            stack.extend(node)
+    return out
+
+
+def _offenders_in_source(text):
+    """Offenders d'un source de workflow, commentaires YAML exclus."""
+    found = []
+    for chunk in _rendered_strings(yaml.safe_load(text)):
+        found.extend(_offenders(chunk))
+    return found
+
+
+def _locate(raw, expr):
+    """Ligne de `expr` dans `raw`, en sautant les lignes de commentaire YAML."""
+    lines = raw.splitlines()
+    fallback = 0
+    for match in re.finditer(re.escape(expr), raw):
+        line = raw[: match.start()].count("\n") + 1
+        fallback = fallback or line
+        if not lines[line - 1].lstrip().startswith("#"):
+            return line
+    return fallback
+
+
 def test_positive_control_detects_the_known_bad_form():
     """Le controle positif du detecteur, dans la meme invocation que son usage.
 
@@ -68,13 +127,62 @@ def test_positive_control_detects_the_known_bad_form():
     assert not _offenders(good), "le detecteur accuse la forme correcte (doublement)"
 
 
+def test_bad_form_inside_a_run_block_is_still_caught():
+    """Le faux negatif a ne PAS ouvrir en corrigeant la sur-accusation.
+
+    Un bloc `run: |` est une chaine rendue par GitHub : une expression fautive
+    posee dans un commentaire *shell* y tue le run exactement pareil, car
+    l'expression est rendue avant que le shell ne voie le `#`. Exclure les
+    commentaires YAML ne doit pas aveugler le detecteur ici.
+    """
+    src = (
+        "on: push\n"
+        "jobs:\n"
+        "  j:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: |\n"
+        "          # ${{ github.event_name == 'push' && 'il s"
+        + BACKSLASH
+        + "'abstient' || 'ok' }}\n"
+        "          echo hello\n"
+    )
+    assert _offenders_in_source(src), "un bloc run: est rendu par GitHub : il doit rester scanne"
+
+
+def test_yaml_comment_quoting_the_bad_form_is_not_an_offender():
+    """Regression #11861 x #11863 : la prose qui documente n'est pas le defaut.
+
+    Une note d'incident citant la forme fautive dans un commentaire YAML n'est
+    jamais rendue par GitHub. L'accuser rougit `main` et bloque la file entiere
+    pour zero defaut reel.
+    """
+    src = (
+        "# Note : `${{ x == '0' && 'il s"
+        + BACKSLASH
+        + "'abstient' || 'ok' }}` a tue le run.\n"
+        "on: push\n"
+        "jobs:\n"
+        "  j:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - run: echo ok\n"
+    )
+    assert _offenders(src), "controle : le texte brut porte la forme, sinon ce test ne prouve rien"
+    assert not _offenders_in_source(src), "un commentaire YAML ne doit pas etre accuse"
+
+
 def test_no_backslash_escaped_quote_in_any_workflow_expression():
     found = []
     for path in _workflow_files():
         text = io.open(path, encoding="utf-8").read()
-        for expr in _offenders(text):
-            line = text[: text.index(expr)].count("\n") + 1
-            found.append(f"{os.path.basename(path)}:{line}: {expr[:120]}")
+        try:
+            offenders = _offenders_in_source(text)
+        except yaml.YAMLError as exc:
+            found.append(f"{os.path.basename(path)}: YAML invalide -- {exc}")
+            continue
+        for expr in offenders:
+            found.append(f"{os.path.basename(path)}:{_locate(text, expr)}: {expr[:120]}")
 
     assert not found, (
         "apostrophe echappee par backslash dans une expression GitHub Actions -- "


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-ai-01:CoursIA — prev: LIGHT/tooling #11880

## Pourquoi c'est urgent

`main` est **rouge sur `Scripts Tests (CPU)` depuis 2026-08-19T23:41Z** (~1 h 20 au moment du fix), et cette jambe bloque **toutes** les PRs ouvertes. Le défaut accusé n'existe pas : le garde accuse la prose qui *documente* le défaut.

## La cause — une collision de cascade

| PR | Ce qu'elle a livré | Verte isolément |
|---|---|---|
| **#11861** | le détecteur d'apostrophe-échappée, qui scanne le **texte brut** des workflows | oui |
| **#11863** | `degraded-mode-advisory.yml`, dont la note d'incident en tête **cite** la forme fautive pour les relecteurs suivants | oui |

Les deux ne se sont jamais vues. Combinées : le commentaire YAML compte comme une occurrence, et `main` passe rouge.

## Vérification firsthand avant de toucher au code

- `degraded-mode-advisory.yml:30` est un **commentaire YAML** — `sed -n '30p' … | grep -qE '^\s*#'` → vrai.
- Le workflow n'est **pas** mort : ses 4 derniers runs sont `completed/success`, il crée bien ses jobs. La classe que le garde vise (0 job, aucun log) n'est pas réalisée ici.
- Scan repo-wide, **texte brut vs valeurs YAML** : `1` offender contre `0`. L'écart est exactement ce commentaire — **aucun défaut réel n'est masqué** par le correctif.

## Le correctif

Le scan porte désormais sur ce que GitHub **rend** : les valeurs de l'arbre YAML.

- les **commentaires YAML** en sont absents (le parser les jette) → plus de sur-accusation ;
- les blocs **`run: |`** y restent présents (ce sont des chaînes) → une expression fautive glissée dans un commentaire *shell* d'un bloc `run:` est **toujours** attrapée : GitHub rend l'expression avant que le shell ne voie le `#`, et meurt pareil.

## Recette par les faux négatifs, pas par les hits

Un détecteur se recette par ce qu'il pourrait cesser de voir. Deux tests neufs :

- `test_bad_form_inside_a_run_block_is_still_caught` — **le faux négatif que ce correctif ne doit pas ouvrir**.
- `test_yaml_comment_quoting_the_bad_form_is_not_an_offender` — la régression #11861 × #11863, avec son propre contrôle interne (`assert _offenders(src)` sur le texte brut, sinon le test ne prouverait rien).

Le contrôle positif d'origine et la garde de répertoire non vide sont conservés.

```
5 passed in 0.34s
  test_positive_control_detects_the_known_bad_form            PASSED
  test_bad_form_inside_a_run_block_is_still_caught            PASSED
  test_yaml_comment_quoting_the_bad_form_is_not_an_offender   PASSED
  test_no_backslash_escaped_quote_in_any_workflow_expression  PASSED
  test_workflow_dir_is_non_empty                              PASSED
```

## Ce que je n'ai pas fait, et pourquoi

Je **n'ai pas** touché à `degraded-mode-advisory.yml`. Retirer la note d'incident pour faire taire le garde aurait supprimé la documentation qui explique le défaut aux relecteurs suivants — c'est le gate qui mesurait la mauvaise grandeur, pas la prose qui était fautive.

See #11861
