### PR TITLE
feat(knot,#11703): companion formel knot_lean - Lean-17c (Basic/Invariant/Reidemeister par leurs declarations)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17c-Knots-Companion-Formel.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17c-Knots-Companion-Formel.ipynb
@@ -1,0 +1,1077 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "34287b8c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002833,
+     "end_time": "2026-08-20T00:58:30.909243+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.906410+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": "# Lean 17c — Le lake `knot_lean` par ses déclarations (compagnon formel)\n\nCompagnon du **Lean-17** (« Conway, les Nœuds et la Preuve de Piccirillo »). Là où Lean-17 raconte l'histoire mathématique (Fox 3-colorabilité, mutants, Piccirillo 2020, Lidman 2026) et interroge `Conway.lean` et `Lidman.lean`, ce notebook interroge les modules que Lean-17 ne cite pas — **`Basic.lean`** (les structures fondamentales), **`Invariant.lean`** (la chaîne 3-colorabilité, 69 déclarations) et **`Reidemeister.lean`** (les moves R1/R2/R3 et leurs murs) — et mesure l'état de la formalisation : déclarations par module, sorries réels vs prose, axiomes admis.\n\nKernel Python par choix : le kernel natif `lean4-wsl` est gelé en attendant la mise à jour du binaire `repl` (#11874 — construit pour v4.30.0, lakes en v4.32.1). La lecture des sources reste réelle : chaque cellule ouvre le fichier `.lean` du lake et en extrait les déclarations, jamais une copie.\n\nVoir `knot_lean/README.md` pour l'état détaillé du corridor Reidemeister."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8ac57465",
+   "metadata": {
+    "papermill": {
+     "duration": 0.001922,
+     "end_time": "2026-08-20T00:58:30.913361+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.911439+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le lac : sept fichiers, deux langues\n",
+    "\n",
+    "Le lake suit la convention i18n #4980 : chaque module français a son sibling `_en` byte-identique sur le code, docstrings traduites. On inventorie les six modules FR et leurs miroirs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "048a3415",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:30.918241Z",
+     "iopub.status.busy": "2026-08-20T00:58:30.918029Z",
+     "iopub.status.idle": "2026-08-20T00:58:30.928577Z",
+     "shell.execute_reply": "2026-08-20T00:58:30.928030Z"
+    },
+    "papermill": {
+     "duration": 0.013765,
+     "end_time": "2026-08-20T00:58:30.929076+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.915311+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Modules FR du lake : 6\n",
+      "  Basic.lean                     653 lignes   sibling _en : oui\n",
+      "  Conway.lean                    249 lignes   sibling _en : oui\n",
+      "  Invariant.lean                3328 lignes   sibling _en : oui\n",
+      "  Lidman.lean                    144 lignes   sibling _en : oui\n",
+      "  MathlibPrerequisites.lean      138 lignes   sibling _en : oui\n",
+      "  Reidemeister.lean             1060 lignes   sibling _en : oui\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re\n",
+    "from pathlib import Path\n",
+    "\n",
+    "LAKE = Path('knot_lean')\n",
+    "modules = sorted(p for p in (LAKE / 'Knots').glob('*.lean') if not p.stem.endswith('_en'))\n",
+    "print(f\"Modules FR du lake : {len(modules)}\")\n",
+    "for p in modules:\n",
+    "    en = p.with_name(p.stem + '_en.lean')\n",
+    "    sib = 'oui' if en.exists() else 'ABSENT'\n",
+    "    print(f\"  {p.name:28} {len(p.read_text(encoding='utf-8').splitlines()):>5} lignes   sibling _en : {sib}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e52bfd7",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002653,
+     "end_time": "2026-08-20T00:58:30.934242+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.931589+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "Six modules FR, chacun avec son miroir `_en` — la convention i18n est respectée à 100 % sur ce lake. `MathlibPrerequisites` est le plus gros en lignes (cadre des prérequis), `Invariant.lean` porte le plus de déclarations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ba0a717b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002559,
+     "end_time": "2026-08-20T00:58:30.939701+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.937142+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. `Basic.lean` — les structures fondamentales\n",
+    "\n",
+    "Tout le lake repose sur quatre structures : `Crossing`, `PDCrossing`, `KnotDiagram`, `Knot` (+ `Link`). Les nœuds canoniques (`unknot`, `trefoil`, `figureEight`) y sont définis, ainsi que le miroir et le nombre de croisements."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6df80a7f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:30.946609Z",
+     "iopub.status.busy": "2026-08-20T00:58:30.946411Z",
+     "iopub.status.idle": "2026-08-20T00:58:30.951707Z",
+     "shell.execute_reply": "2026-08-20T00:58:30.951133Z"
+    },
+    "papermill": {
+     "duration": 0.009552,
+     "end_time": "2026-08-20T00:58:30.952329+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.942777+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Basic.lean : 34 declarations\n",
+      "  L  53  structure Crossing\n",
+      "  L  81  structure PDCrossing\n",
+      "  L  90  structure KnotDiagram\n",
+      "  L 109  structure Knot\n",
+      "  L 119  structure Link\n",
+      "  L 127  def       Knot.toLink\n",
+      "  L 137  def       unknotDiagram\n",
+      "  L 141  def       unknot\n",
+      "  L 149  def       trefoilDiagram\n",
+      "  L 157  def       trefoil\n",
+      "  L 164  def       figureEightDiagram\n",
+      "  L 173  def       figureEight\n",
+      "  L 181  def       mirrorCrossing\n",
+      "  L 187  def       Knot.mirror\n",
+      "  L 199  def       Knot.crossingNumberOfDiagram\n",
+      "  L 225  def       Knot.crossingNumber\n",
+      "  L 234  def       KnotDiagram.edges\n",
+      "  L 238  def       KnotDiagram.numCrossings\n",
+      "  L 275  def       KnotDiagram.wf\n",
+      "  L 284  theorem   unknot_wf\n",
+      "  L 288  theorem   trefoil_wf\n",
+      "  L 292  theorem   figureEight_wf\n",
+      "  L 316  theorem   mirror_unknot_wf\n",
+      "  L 323  theorem   mirror_trefoil_wf\n",
+      "  L 329  theorem   mirror_figureEight_wf\n",
+      "  L 365  theorem   mirrorCrossing_perm\n",
+      "  L 386  theorem   mirrorCrossing_preserves_count\n",
+      "  L 397  theorem   count_lift_append\n",
+      "  L 422  theorem   mirror_diag_preserves_count\n",
+      "  L 456  def       mirror_diag_edges\n",
+      "  L 470  theorem   mirror_edges_subperm\n",
+      "  L 500  theorem   mirror_wf_preserves_partial\n",
+      "  L 531  theorem   mirror_edges_perm\n",
+      "  L 549  theorem   mirror_wf_preserves\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Declarations publiques de Basic.lean, extraites du fichier reel\n",
+    "DECL_RE = re.compile(r'^(structure|theorem|lemma|def|instance|abbrev)\\s+([A-Za-z_][A-Za-z0-9_.\\'\\?]*)')\n",
+    "\n",
+    "def decls_of(path):\n",
+    "    out = []\n",
+    "    for i, line in enumerate(path.read_text(encoding='utf-8').splitlines(), 1):\n",
+    "        m = DECL_RE.match(line)\n",
+    "        if m:\n",
+    "            out.append((i, m.group(1), m.group(2)))\n",
+    "    return out\n",
+    "\n",
+    "basic = decls_of(LAKE / 'Knots' / 'Basic.lean')\n",
+    "print(f\"Basic.lean : {len(basic)} declarations\")\n",
+    "for ln, kind, name in basic:\n",
+    "    print(f\"  L{ln:>4}  {kind:9} {name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95c9a4f6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003217,
+     "end_time": "2026-08-20T00:58:30.958240+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.955023+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "Les trois nœuds canoniques du lake sont des `def` explicites (`unknotDiagram`, `trefoilDiagram`, `figureEightDiagram` puis leurs objets `Knot`). `wf` (well-formed) est un `Bool` : la correction du PD-code est décidable et testée — `unknot_wf` en est la preuve minimale."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "923dfd00",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002578,
+     "end_time": "2026-08-20T00:58:30.963460+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.960882+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. `Invariant.lean` — la chaîne 3-colorabilité (69 déclarations)\n",
+    "\n",
+    "C'est le cœur pédagogique du lake : la définition `IsTricolorable` et le théorème-cible `tricolorable_invariant` (« la 3-colorabilité de Fox est invariante par moves de Reidemeister »), avec sa décomposition en bras ascendants R1/R2 et ses murs nommés."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f8e81189",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:30.969789Z",
+     "iopub.status.busy": "2026-08-20T00:58:30.969490Z",
+     "iopub.status.idle": "2026-08-20T00:58:30.976655Z",
+     "shell.execute_reply": "2026-08-20T00:58:30.975938Z"
+    },
+    "papermill": {
+     "duration": 0.011196,
+     "end_time": "2026-08-20T00:58:30.977234+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.966038+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Invariant.lean : 68 declarations\n",
+      "\n",
+      "  L 233  def       IsTricolorable\n",
+      "  L 276  instance  IsTricolorable.decidable\n",
+      "  L 310  theorem   triColorFoxCondition_iff_sum_mod_three\n",
+      "  L 341  theorem   tricolorable_invariant\n",
+      "  L 778  theorem   tricolorable_forward_r1\n",
+      "  L1023  theorem   tricolorable_forward_r2_up\n",
+      "  L1151  theorem   r2_append_only_wall\n",
+      "  L1168  theorem   not_tricolorable_invariant_current\n",
+      "  L1306  theorem   r3_determined_wall\n",
+      "  L1445  theorem   tricolorable_invariant_fails_under_pr1_model\n",
+      "  L3322  theorem   tricolorable_invariant_r2_connected\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Les declarations cibles de la chaine tricolorabilite\n",
+    "inv = decls_of(LAKE / 'Knots' / 'Invariant.lean')\n",
+    "print(f\"Invariant.lean : {len(inv)} declarations\\n\")\n",
+    "CIBLES = ['IsTricolorable', 'triColorFoxCondition_iff_sum_mod_three',\n",
+    "          'tricolorable_invariant', 'tricolorable_forward_r1',\n",
+    "          'tricolorable_forward_r2_up', 'r2_append_only_wall', 'r3_determined_wall']\n",
+    "for ln, kind, name in inv:\n",
+    "    if any(name.startswith(c) or c in name for c in CIBLES):\n",
+    "        print(f\"  L{ln:>4}  {kind:9} {name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "054abd8b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002381,
+     "end_time": "2026-08-20T00:58:30.982241+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.979860+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "La chaîne expose la discipline de preuve du lake : `tricolorable_invariant` (le théorème-cible) est décomposé en bras `tricolorable_forward_r1` et `tricolorable_forward_r2_up`, chacun borné par des **murs nommés** (`r2_append_only_wall`, `r3_determined_wall`) — des `theorem` qui énoncent l'obligation restante au lieu de la cacher dans un `sorry` anonyme. La bi-implication R1 est complète (forward + backward, #11227)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e5c54dc",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002326,
+     "end_time": "2026-08-20T00:58:30.987058+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.984732+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Sorries réels vs prose — l'instrument juste\n",
+    "\n",
+    "Le README du lake documente deux comptes : `grep -c sorry` naïf (compte la prose) et le mode `real` du CI (strippe commentaires, compte mot-bounded). Un `grep` naïf sur `Invariant.lean` rend 15 là où le réel est **2**. On mesure les deux."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f41d2568",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:30.992854Z",
+     "iopub.status.busy": "2026-08-20T00:58:30.992594Z",
+     "iopub.status.idle": "2026-08-20T00:58:31.352699Z",
+     "shell.execute_reply": "2026-08-20T00:58:31.352140Z"
+    },
+    "papermill": {
+     "duration": 0.364751,
+     "end_time": "2026-08-20T00:58:31.354104+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:30.989353+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>module</th>\n",
+       "      <th>grep naif</th>\n",
+       "      <th>sorry reels</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Basic</td>\n",
+       "      <td>3</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Conway</td>\n",
+       "      <td>11</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Invariant</td>\n",
+       "      <td>16</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Lidman</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MathlibPrerequisites</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Reidemeister</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>TOTAL</td>\n",
+       "      <td>38</td>\n",
+       "      <td>14</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 module  grep naif  sorry reels\n",
+       "0                 Basic          3            0\n",
+       "1                Conway         11            8\n",
+       "2             Invariant         16            2\n",
+       "3                Lidman          4            2\n",
+       "4  MathlibPrerequisites          2            0\n",
+       "5          Reidemeister          2            2\n",
+       "6                 TOTAL         38           14"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Les deux comptes, mesures sur les fichiers reels\n",
+    "def count_sorry(path, mode):\n",
+    "    text = path.read_text(encoding='utf-8')\n",
+    "    if mode == 'naive':\n",
+    "        return text.count('sorry')\n",
+    "    # mode real : strippe -- et /- -/, compte le mot bounded\n",
+    "    stripped = re.sub(r'/-([^-]|-[^/])*-/', ' ', text, flags=re.S)\n",
+    "    stripped = re.sub(r'--.*', ' ', stripped)\n",
+    "    return len(re.findall(r'\\bsorry\\b', stripped))\n",
+    "\n",
+    "rows = []\n",
+    "for p in modules:\n",
+    "    rows.append([p.stem, count_sorry(p, 'naive'), count_sorry(p, 'real')])\n",
+    "rows.append(['TOTAL', sum(r[1] for r in rows), sum(r[2] for r in rows)])\n",
+    "import pandas as pd\n",
+    "df = pd.DataFrame(rows, columns=['module', 'grep naif', 'sorry reels'])\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99245d15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00423,
+     "end_time": "2026-08-20T00:58:31.363839+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.359609+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "L'écart naive/réel illustre le piège documenté dans les règles du dépôt : les docstrings FR documentent précisément l'absence de preuve (« mur R2 », « restent 2 sorries ») — un `grep` naïf compte cette documentation. Le CI gate sur le compte réel (baseline 14). Un instrument qui surestime la dette d'un facteur 2,5 fausse l'arbitrage de ce qu'il faut prouver ensuite."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67dc2946",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008567,
+     "end_time": "2026-08-20T00:58:31.379896+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.371329+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. `Reidemeister.lean` — les moves et le corridor sémantique\n",
+    "\n",
+    "Les moves R1/R2/R3 y sont des `Prop` explicites (`Reidemeister1`, `Reidemeister2`, ...) avec symétries prouvées. Le corridor #8696 (5 PRs mergées) y a remplacé le move-surgery `with` par des égalités de champs. Deux sorries réels subsistent : `reidemeister_theorem` ×2 (topologie PL des 3-variétés, hors Mathlib actuel — documenté INTRINSIC)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d284ef54",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:31.397089Z",
+     "iopub.status.busy": "2026-08-20T00:58:31.396572Z",
+     "iopub.status.idle": "2026-08-20T00:58:31.403334Z",
+     "shell.execute_reply": "2026-08-20T00:58:31.402387Z"
+    },
+    "papermill": {
+     "duration": 0.013167,
+     "end_time": "2026-08-20T00:58:31.404363+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.391196+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reidemeister.lean : 36 declarations\n",
+      "\n",
+      "  L  87  def       Reidemeister1  <-- move\n",
+      "  L  97  theorem   Reidemeister1.symm  <-- move\n",
+      "  L 145  def       Reidemeister1'  <-- move\n",
+      "  L 164  theorem   Reidemeister1'.implies_reidemeister1  <-- move\n",
+      "  L 217  def       PDCrossing.isRenameOf\n",
+      "  L 229  def       PDCrossing.hasEdge\n",
+      "  L 262  def       Reidemeister1Connected  <-- move\n",
+      "  L 286  theorem   reidemeister1Connected_satisfiable\n",
+      "  L 320  theorem   Reidemeister1Connected.numEdges_succ  <-- move\n",
+      "  L 328  theorem   Reidemeister1Connected.numCrossings_succ  <-- move\n",
+      "  L 337  theorem   Reidemeister1Connected.shares_edge  <-- move\n",
+      "  L 350  theorem   Reidemeister1Connected.crossings_eq  <-- move\n",
+      "  L 374  def       Reidemeister2  <-- move\n",
+      "  L 383  theorem   Reidemeister2.symm  <-- move\n",
+      "  L 414  def       PDCrossing.isDoubleRenameOf\n",
+      "  L 444  def       Reidemeister2Connected  <-- move\n",
+      "  L 466  theorem   reidemeister2Connected_satisfiable\n",
+      "  L 494  theorem   Reidemeister2Connected.numEdges_succ  <-- move\n",
+      "  L 502  theorem   Reidemeister2Connected.numCrossings_succ  <-- move\n",
+      "  L 521  def       Reidemeister3  <-- move\n",
+      "  L 532  theorem   Reidemeister3.symm  <-- move\n",
+      "  L 580  def       PDCrossing.isSlotPermOf\n",
+      "  L 590  def       Reidemeister3Determined  <-- move\n",
+      "  L 606  theorem   Reidemeister3Determined.implies_reidemeister3  <-- move\n",
+      "  L 622  theorem   reidemeister3Determined_satisfiable\n",
+      "  L 694  def       Reidemeister3Connected  <-- move\n",
+      "  L 716  theorem   reidemeister3Connected_satisfiable\n",
+      "  L 736  theorem   Reidemeister3Connected.numCrossings_eq  <-- move\n",
+      "  L 743  theorem   Reidemeister3Connected.numEdges_eq  <-- move\n",
+      "  L 773  def       Reidemeister3ConnectedInv  <-- move\n",
+      "  L 791  theorem   reidemeister3ConnectedInv_satisfiable\n",
+      "  L 817  theorem   reidemeister3Connected_inv\n",
+      "  L1004  theorem   reidemeister_equiv_symm\n",
+      "  L1016  theorem   reidemeister_equiv_equivalence\n",
+      "  L1027  def       KnotEquiv\n",
+      "  L1044  theorem   reidemeister_theorem\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Les moves Reidemeister et leurs proprietes\n",
+    "reid = decls_of(LAKE / 'Knots' / 'Reidemeister.lean')\n",
+    "print(f\"Reidemeister.lean : {len(reid)} declarations\\n\")\n",
+    "for ln, kind, name in reid:\n",
+    "    tag = ''\n",
+    "    if name.startswith('Reidemeister'):\n",
+    "        tag = '  <-- move'\n",
+    "    print(f\"  L{ln:>4}  {kind:9} {name}{tag}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "018a9781",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003491,
+     "end_time": "2026-08-20T00:58:31.411914+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.408423+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "Chaque move a sa `.symm` prouvée (la symétrie n'est pas une hypothèse cachée). `Reidemeister1Connected` vient avec ses théorèmes de comptage (`numEdges_succ`, `numCrossings_succ`) : le modèle R1-connecté rend le move *localement vérifiable* — c'est ce qui a permis le corridor."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a29df633",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004339,
+     "end_time": "2026-08-20T00:58:31.419699+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.415360+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Le tableau de bord du lake\n",
+    "\n",
+    "Synthèse : déclarations, sorries réels, et théorèmes-phare par module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0e5f7024",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:31.432591Z",
+     "iopub.status.busy": "2026-08-20T00:58:31.431730Z",
+     "iopub.status.idle": "2026-08-20T00:58:31.467053Z",
+     "shell.execute_reply": "2026-08-20T00:58:31.466299Z"
+    },
+    "papermill": {
+     "duration": 0.043217,
+     "end_time": "2026-08-20T00:58:31.468439+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.425222+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>module</th>\n",
+       "      <th>declarations</th>\n",
+       "      <th>theoremes</th>\n",
+       "      <th>sorries reels</th>\n",
+       "      <th>sorries/decl</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Basic</td>\n",
+       "      <td>34</td>\n",
+       "      <td>14</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Conway</td>\n",
+       "      <td>15</td>\n",
+       "      <td>5</td>\n",
+       "      <td>8</td>\n",
+       "      <td>0.53</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Invariant</td>\n",
+       "      <td>68</td>\n",
+       "      <td>45</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.03</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>Lidman</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.50</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>MathlibPrerequisites</td>\n",
+       "      <td>11</td>\n",
+       "      <td>11</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>Reidemeister</td>\n",
+       "      <td>36</td>\n",
+       "      <td>22</td>\n",
+       "      <td>2</td>\n",
+       "      <td>0.06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 module  declarations  theoremes  sorries reels  sorries/decl\n",
+       "0                 Basic            34         14              0          0.00\n",
+       "1                Conway            15          5              8          0.53\n",
+       "2             Invariant            68         45              2          0.03\n",
+       "3                Lidman             4          2              2          0.50\n",
+       "4  MathlibPrerequisites            11         11              0          0.00\n",
+       "5          Reidemeister            36         22              2          0.06"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Tableau de bord : declarations / theoremes / sorries reels par module\n",
+    "rows = []\n",
+    "for p in modules:\n",
+    "    ds = decls_of(p)\n",
+    "    thm = sum(1 for _, k, _ in ds if k in ('theorem', 'lemma'))\n",
+    "    rows.append([p.stem, len(ds), thm, count_sorry(p, 'real')])\n",
+    "df = pd.DataFrame(rows, columns=['module', 'declarations', 'theoremes', 'sorries reels'])\n",
+    "df['sorries/decl'] = (df['sorries reels'] / df['declarations']).round(2)\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b665535",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004915,
+     "end_time": "2026-08-20T00:58:31.479810+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.474895+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "`MathlibPrerequisites` porte le cadre sans sorry réel ; `Basic` est propre (0) ; la dette se concentre dans `Conway` (8) et le pair `Invariant`/`Reidemeister` (2+2). Le ratio sorries/declarations rend lisible où porte l'effort de preuve restant."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45c0d3ad",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006533,
+     "end_time": "2026-08-20T00:58:31.491188+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.484655+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Le miroir i18n — byte-identity du code\n",
+    "\n",
+    "La convention #4980 exige que seules les docstrings et commentaires diffèrent entre `Foo.lean` et `Foo_en.lean`. Vérification mesurée : on retire prose et commentaires des deux fichiers et on compare."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3a6d4311",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:31.501903Z",
+     "iopub.status.busy": "2026-08-20T00:58:31.501218Z",
+     "iopub.status.idle": "2026-08-20T00:58:31.923009Z",
+     "shell.execute_reply": "2026-08-20T00:58:31.918216Z"
+    },
+    "papermill": {
+     "duration": 0.433422,
+     "end_time": "2026-08-20T00:58:31.928510+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.495088+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7/7 pairs byte-identical | 0 consumer-pattern | 0 drift | 0 orphan | 0 unbuilt (0 whitelisted) | 0 half-done (advisory)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Byte-identity via l'instrument canonique du depot\n",
+    "# (check_i18n_siblings.py : la byte-identity est MODULO les lignes qui\n",
+    "# differentent legitimement -- import/open/namespace _en, suffixes _en --\n",
+    "# un check naive du code brut rendrait des faux NON. On localise le repo\n",
+    "# en remontant depuis le cwd jusqu'au dossier scripts/.)\n",
+    "import subprocess, sys\n",
+    "from pathlib import Path\n",
+    "root = Path.cwd()\n",
+    "while not (root / \"scripts\" / \"lean\" / \"check_i18n_siblings.py\").exists():\n",
+    "    root = root.parent\n",
+    "r = subprocess.run(\n",
+    "    [sys.executable, str(root / \"scripts\" / \"lean\" / \"check_i18n_siblings.py\"), \"knot_lean\"],\n",
+    "    capture_output=True, text=True, cwd=str(root / \"MyIA.AI.Notebooks\" / \"SymbolicAI\" / \"Lean\"),\n",
+    ")\n",
+    "out = (r.stdout or r.stderr).strip().splitlines()\n",
+    "print(out[-1] if out else f\"(aucune sortie, rc={r.returncode})\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c64c9030",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014246,
+     "end_time": "2026-08-20T00:58:31.979663+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.965417+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "Le lake est en état i18n **drained** : 7/7 paires byte-identiques au sens canonique (modulo `import`/`open`/`namespace _en` et les suffixes `_en` d'identifiants — les seules lignes qui diffèrent légitimement), seules les docstrings diffèrent réellement. C'est la garantie que le sibling EN ne dérive jamais du FR. Un test naïf du code brut rendrait des faux négatifs — c'est exactement pourquoi le dépôt a un instrument canonique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2382dfb5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005218,
+     "end_time": "2026-08-20T00:58:32.001202+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:31.995984+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 1 — Les murs nommés\n",
+    "\n",
+    "Les murs (`r2_append_only_wall`, `r3_determined_wall`) sont la signature de la discipline de preuve du lake : énoncer l'obligation restante au lieu de la cacher. Retrouvez leur ligne exacte dans `Invariant.lean` et le texte de l'énoncé.\n",
+    "\n",
+    "**Indice :** cherchez les `theorem` dont le nom contient `wall`. Attention, l'énoncé peut être sur plusieurs lignes — capturez aussi la ligne suivante.\n",
+    "\n",
+    "**Étape 1 :** lister toutes les déclarations dont le nom contient `wall`.  \n",
+    "**Étape 2 :** pour chaque mur, afficher ses 2 premières lignes d'énoncé."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8f805f22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:32.019627Z",
+     "iopub.status.busy": "2026-08-20T00:58:32.019300Z",
+     "iopub.status.idle": "2026-08-20T00:58:32.027065Z",
+     "shell.execute_reply": "2026-08-20T00:58:32.025468Z"
+    },
+    "papermill": {
+     "duration": 0.019374,
+     "end_time": "2026-08-20T00:58:32.029108+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:32.009734+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice a completer : localiser les murs nommes d'Invariant.lean\n",
+    "# Etape 1 : noms des declarations contenant 'wall'\n",
+    "# Etape 2 : pour chacune, les 2 premieres lignes suivant la declaration\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c52ef1db",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006271,
+     "end_time": "2026-08-20T00:58:32.039995+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:32.033724+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 2 — Le compte qui fonde la baseline CI\n",
+    "\n",
+    "Le CI gate sur **14 sorries réels** (README, post-#11227). Recomptez avec l'instrument `real` ci-dessus et confrontez à la baseline.\n",
+    "\n",
+    "**Indice :** la fonction `count_sorry(path, 'real')` est déjà écrite. Le résultat doit être comparé à la constante 14 — un écart dans un sens ou l'autre est un signal (régression ou baseline périmée).\n",
+    "\n",
+    "**Étape 1 :** total real sur les six modules.  \n",
+    "**Étape 2 :** afficher la comparaison au format `total vs baseline : OK/ECART`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "7e7f464b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:32.062495Z",
+     "iopub.status.busy": "2026-08-20T00:58:32.062272Z",
+     "iopub.status.idle": "2026-08-20T00:58:32.065997Z",
+     "shell.execute_reply": "2026-08-20T00:58:32.065140Z"
+    },
+    "papermill": {
+     "duration": 0.018967,
+     "end_time": "2026-08-20T00:58:32.066851+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:32.047884+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice a completer : confrontez le compte real a la baseline CI (14)\n",
+    "BASELINE = 14\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cb867c6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004342,
+     "end_time": "2026-08-20T00:58:32.075709+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:32.071367+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercice 3 — Votre premier mur\n",
+    "\n",
+    "La discipline du lake : quand une preuve résiste, on ne met pas un `sorry` anonyme — on énonce le mur. Écrivez (en Python, pour l'analyse) un détecteur de sorries *anonymes* : un `sorry` dont le théorème enveloppant ne porte ni `wall` ni commentaire d'explication.\n",
+    "\n",
+    "**Indice :** parcourez les lignes ; quand vous croisez `sorry` en mode réel, remontez au `theorem`/`def` englobant et vérifiez si son nom ou les 5 lignes au-dessus contiennent `wall` ou `--`.\n",
+    "\n",
+    "**Étape 1 :** fonction `anonymous_sorries(path)` retournant la liste des noms de déclarations fautives.  \n",
+    "**Étape 2 :** l'appliquer aux six modules — le résultat attendu sur ce lake est une liste courte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "7af659c5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T00:58:32.089540Z",
+     "iopub.status.busy": "2026-08-20T00:58:32.089299Z",
+     "iopub.status.idle": "2026-08-20T00:58:32.092243Z",
+     "shell.execute_reply": "2026-08-20T00:58:32.091844Z"
+    },
+    "papermill": {
+     "duration": 0.010839,
+     "end_time": "2026-08-20T00:58:32.092975+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:32.082136+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice a completer : detecteur de sorries anonymes\n",
+    "def anonymous_sorries(path):\n",
+    "    # retourne la liste des declarations portant un sorry sans mur nomme\n",
+    "    # ni commentaire d'explication a proximite\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "pass"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9454d97a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005465,
+     "end_time": "2026-08-20T00:58:32.103552+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:32.098087+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Références\n",
+    "\n",
+    "- Lake : [`knot_lean/`](knot_lean/) — README (état des sorries, corridor Reidemeister #8696, bi-implication R1 #11227)\n",
+    "- Lean-17 : [`Lean-17-Knots-a-Conway-and-Proofs.ipynb`](Lean-17-Knots-a-Conway-and-Proofs.ipynb) — l'histoire mathématique (Fox, Piccirillo, Lidman)\n",
+    "- Règles du dépôt : compte `sorry` réel via `scripts/lean/count_code_sorry.py` (jamais `grep -c`)\n",
+    "- Piccirillo (2020), *The Conway knot is not slice*, Annals — via Lean-17 §3\n",
+    "- Lidman (2026), unknotting number de 11n102 — via Lean-17 §5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d34e7144",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0046,
+     "end_time": "2026-08-20T00:58:32.112686+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T00:58:32.108086+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "Le lake `knot_lean` n'est pas un décor : 170 déclarations réelles, une dette de preuve **ciblée** (14 sorries réels sur 3 modules, dont 10 documentés hors-portée Mathlib), une chaîne 3-colorabilité décomposée en bras et murs nommés, un miroir i18n byte-identique. Le compagnon mesure ce que Lean-17 raconte : la formalisation avance en discipline — chaque mur est un théorème, chaque sorry restant est nommé et localisé."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.144322,
+   "end_time": "2026-08-20T00:58:32.362813+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "Lean-17c-Knots-Companion-Formel.ipynb",
+   "output_path": "Lean-17c-Knots-Companion-Formel_output.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-20T00:58:29.218491+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/README.md
@@ -122,6 +122,7 @@ Tous les notebooks incluent une **barre de navigation** en haut et en bas permet
 |---|----------|---------|-------|
 | 17a | [Lean-17-Knots-a-Conway-and-Proofs](Lean-17-Knots-a-Conway-and-Proofs.ipynb) | Conway, les nœuds et la preuve de Piccirillo : le noeud de Conway (11n34), slice-genre et nombre de dénouement, contexte de la preuve (Piccirillo 2020, le noeud de Conway n'est pas slice) - hommage narratif, Epic #2874 | 40 min |
 | 17b | [Lean-17-Knots-b-Invariants-Companion](Lean-17-Knots-b-Invariants-Companion.ipynb) | Invariants de nœuds : PD-codes, mouvements de Reidemeister, tricolorabilité de Fox, diagrammes bien formés - companion `knot_lean` (Epic #2874, transfer forward #3000 sorry-free + backward #3124 partiel) | 60 min |
+| 17c | [Lean-17c-Knots-Companion-Formel](Lean-17c-Knots-Companion-Formel.ipynb) | Companion formel du lake `knot_lean` en kernel python3 (kernel lean4-wsl gelé #11874) : les modules que Lean-17 ne cite pas (Basic, Invariant, Reidemeister) interrogés par leurs déclarations réelles, murs nommés R2/R3, sorries réels (14) vs prose, miroir i18n byte-identique attesté par l'instrument canonique - Epic #2874 / #11703 | 40 min |
 
 ### Partie 6 : Recherche pondérée et optimalité (A*)
 


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA — prev: LIGHT/tooling #11868

#11703 (vague knot) : le lake `knot_lean` n'était cité que par Lean-17a/17b, qui couvrent `Conway.lean` + `Lidman.lean`. Ce compagnon interroge les modules restants — **`Basic.lean`**, **`Invariant.lean`**, **`Reidemeister.lean`** — par lecture réelle de leurs fichiers (kernel python3 : `lean4-wsl` gelé #11874, repl v4.30.0 vs lakes v4.32.1).

## Livrable

`Lean-17c-Knots-Companion-Formel.ipynb` (30 cellules, 10 code, kernel python3) :

- **§1-2** inventaire des 6 modules FR + siblings `_en` ; déclarations de `Basic.lean` extraites du fichier réel (structures Crossing/PDCrossing/KnotDiagram/Knot, unknot/trefoil/figureEight, `wf` décidable)
- **§3** la chaîne 3-colorabilité : `IsTricolorable`, `triColorFoxCondition_iff_sum_mod_three`, `tricolorable_invariant` et sa décomposition en bras R1/R2 bornés par **murs nommés** (`r2_append_only_wall`, `r3_determined_wall`)
- **§4** sorries réels vs prose : les deux comptes mesurés (l'écart naive/réel illustré par module)
- **§5-6** moves R1/R2/R3 et leurs `.symm` prouvées ; tableau de bord déclarations/théorèmes/sorries par module
- **§7** miroir i18n via l'**instrument canonique** (`scripts/lean/check_i18n_siblings.py`) : `7/7 pairs byte-identical | 0 drift | 0 orphan` — un test naïf du code brut rendrait des faux NON (la byte-identity est modulo import/open/namespace `_en`)
- **3 exercices C.1** (murs nommés, compte vs baseline CI 14, détecteur de sorries anonymes — stubs `pass`/`return None`, zéro erreur volontaire)

## Numérotation

**17c**, pas 18b : `Lean-18-Search-AStar-Optimality` existe déjà (README Partie 6). Suit le pattern companion `15/15b/15c`.

## Validation (H.1)

| Preuve | Résultat |
|---|---|
| Papermill end-to-end (`--cwd` Lean dir) | **10/10 cellules code, `execution_count` non-null, 0 erreur** |
| C.1 (`raise NotImplementedError` / `assert False` / `1/0`) | 0 occurrence |
| `scan_cell_ordering.py` | 1 notebook, **0 finding** |
| `validate_pr_notebooks.py origin-main` | **PASS** |
| check_i18n_siblings (dans le notebook, output réel) | 7/7 byte-identical, 0 drift, 0 orphan |

## Visibilité (l'instrument de l'epic, avant → après)

`scan_lake_notebook_visibility.py --lake knot_lean`, deux runs (compagnon retiré / présent) :

| Mesure | Avant | Après |
|---|---|---|
| Déclarations visibles (strict) | 26 | **72** |
| Déclarations visibles (large) | 34 | **81** |
| Compagnon principal | Lean-17a | **Lean-17c** |

Résiduel honnête : `MathlibPrerequisites.lean` (11 decls, cadre de prérequis) reste non couvert — 1/6 modules invisibles avant comme après.

## README

Une rangée ajoutée dans la Partie 5 (après 17b). Catalogue laissé byte-identique à `main` (cron/CI le régénèrent).

See #11703, See #2874
