### PR TITLE
feat(genai,#11883): AI-Engine series grain 10 — chatbot files face: one-hour TTL, contract by refusal, per-user partition, admin mirror

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -233,6 +233,25 @@ La route est stateless (le tour isolé oublie, le tour qui re-apporte
 `messages` souvient), `envId` est écouté, et un `model` sans
 environnement redonne l'erreur à froid du grain précédent — « The
 environment is required. » : le routeur exige le couple, pas le nom.
+[`donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb`](donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb)
+ouvre la cinquième surface : la famille `mwai-ui/v1/files/*`, celle
+des **pièces jointes** — la mémoire du chatbot au-delà du texte tapé,
+un manuscrit à relire ou un extrait audio. Le trait le plus
+caractéristique y est mesuré par calcul : la fiche du fichier porte
+`created` et `expires`, et la soustraction rend exactement **une
+heure** — les pièces jointes sont éphémères par architecture, pas
+par configuration, et le notebook le démontre à la seconde près.
+Autour de la mesure : le contrat d'upload découvert par refus
+(400 « Purpose is required. » nomme le champ obligatoire), l'URL
+publique servie par la médiathèque WordPress (contenu vérifié octet
+pour octet), la **partition par utilisateur** — table `mwai_files`,
+deux auteurs ne voient ni n'effacent les pièces jointes de l'autre,
+jusqu'aux sessions anonymes qui ont chacune la leur —, le delete par
+refus (400 « No valid files to delete » pour `{id}` : le contrat
+veut `{"files": [refId]}`), et le miroir admin
+`mwai/v1/openai/files/*` où les mêmes fichiers reviennent, augmentés
+de `download` et `finetune`. Le fichier synthétique est détruit en
+fin de parcours — cleanup mesuré, total 0 → 1 → 0.
 
 ---
 
@@ -375,6 +394,8 @@ attendues.
   OAuth embarque du serveur MCP : decouverte, registration dynamique, escalier des refus, consent admin, token PKCE, appel delegue
 - [`interroger-lassistant-de-lediteur-par-l-api.ipynb`](interroger-lassistant-de-lediteur-par-l-api.ipynb) —
   la face editeur : assistant de redaction, nonce wp_rest, contrat par refus, usage rendu, actions vides (frontiere gratuite/Pro)
+- [`donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb`](donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb) —
+  la face pieces jointes : upload par refus, TTL d'une heure mesure par soustraction, partition par utilisateur, delete par refus, miroir admin
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb
@@ -1,0 +1,798 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cd1bae8b",
+   "metadata": {},
+   "source": [
+    "# Les fichiers du chatbot — une memoire ephemere par l'API\n",
+    "\n",
+    "Dixieme notebook de la serie « AI Engine par son API ». Le chatbot du\n",
+    "grain 6 conversait, l'assistant du grain 9 redigeait — mais tous deux\n",
+    "ne connaissaient que le texte qu'on leur tapait. Or un assistant reel\n",
+    "recoit des **pieces jointes** : un manuscrit a relire, un extrait\n",
+    "audio a transcrire, une image a decrire. Le plugin expose pour cela\n",
+    "une famille de routes `mwai-ui/v1/files/*` — la cinquieme surface de\n",
+    "la serie.\n",
+    "\n",
+    "Le sondage qui a ouvert ce grain a revele le trait le plus\n",
+    "caracteristique de cette surface : les fichiers y ont une **duree de\n",
+    "vie**. La fiche rendue par l'API porte un champ `expires` calcule a\n",
+    "**une heure** de l'upload. Un chatbot qui oublie ses pieces jointes au\n",
+    "bout d'une heure n'est pas un bug de configuration — c'est un choix\n",
+    "d'architecture, lisible dans la reponse meme de l'API, et ce notebook\n",
+    "le mesure. Autres decouvertes du sondage, toutes par refus : le\n",
+    "contrat d'upload exige une **intention declaree** (`purpose`), et le\n",
+    "delete **verifie la propriete** du fichier avant de l'effacer.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dc19b452",
+   "metadata": {},
+   "source": [
+    "## La serie « AI Engine par son API »\n",
+    "\n",
+    "Le projet Livres Agites a mis AI Engine au coeur d'une maison d'edition :\n",
+    "bot d'accueil, agents d'ateliers, bibliothecaire documentee par RAG,\n",
+    "formulaires dynamiques. Cette serie presente le plugin de maniere\n",
+    "reproductible — **sans jamais exposer de donnees client** :\n",
+    "\n",
+    "| Notebook | Face / objet |\n",
+    "|----------|--------------|\n",
+    "| `presenter-ai-engine-par-son-api` | socle : instance, API, catalogue, premiere completion |\n",
+    "| `configurer-chatbots-par-l-api` | admin : chatbots comme documents JSON |\n",
+    "| `administrer-les-formulaires-par-l-api` | admin : le formulaire comme contenu |\n",
+    "| `piloter-wordpress-par-mcp` | agent : WordPress serveur MCP |\n",
+    "| `brancher-plusieurs-providers-par-l-api` | admin : environnements, matrice d'usages |\n",
+    "| `parler-au-chatbot-en-visiteur-par-l-api` | visiteur : session anonyme, nonce |\n",
+    "| `obtenir-des-donnees-structurees-par-l-api` | admin : sorties JSON structurees |\n",
+    "| `autour-du-consent-oauth-du-serveur-mcp` | agent : OAuth, delegation bornee |\n",
+    "| `interroger-lassistant-de-lediteur-par-l-api` | editeur : l'assistant de redaction |\n",
+    "| `donner-une-memoire-ephemere-au-chatbot-par-l-api` (ce notebook) | **fichiers : la memoire ephemere** |\n",
+    "\n",
+    "Trois niveaux de lecture dans chaque notebook : decouverte (ce que\n",
+    "fait la fonctionnalite), branchement (comment on l'a branchee dans le\n",
+    "projet), exercice (reutiliser le pattern sur un cas voisin).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6ec5d7ed",
+   "metadata": {},
+   "source": [
+    "## Prerequis\n",
+    "\n",
+    "- L'instance jetable « Maison Valmont » est demarree (dossier\n",
+    "  [`instance-jetable/`](instance-jetable/README.md)) ;\n",
+    "- le fichier `instance-jetable/.env` existe (jamais commite) et porte\n",
+    "  `VALMONT_EDITOR_PASSWORD` (convention posee par le notebook OAuth —\n",
+    "  le compte editor `consent.editor` est cree par lui, retrouve ici) ;\n",
+    "- le dossier `wp-content/uploads/` du conteneur doit appartenir a\n",
+    "  `www-data` (si l'upload rend 500 « Could not move the file. », voir\n",
+    "  la note de maintenance du README de l'instance) ;\n",
+    "- aucune donnee reelle : le fichier televerse est synthetique, fabriqu\n",
+    "  par le notebook, et **detruit en fin de parcours** (cleanup verifie).\n",
+    "\n",
+    "Ce notebook n'appelle aucun modele : la surface fichiers est purement\n",
+    "gestionnaire — upload, fiche, TTL, propriete, delete. Tout ce qui est\n",
+    "mesure est du comportement de WordPress et du plugin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "58bb2351",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:37:59.768562Z",
+     "iopub.status.busy": "2026-08-20T01:37:59.768562Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.093984Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.092931Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
+      "Base URL : http://localhost:8093\n",
+      "login editor : OK (302) | nonce : f5a069...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et helpers. Aucune cle n'est stockee ici : tout vient\n",
+    "# de instance-jetable/.env.\n",
+    "\n",
+    "import os\n",
+    "import re\n",
+    "from datetime import datetime, timedelta, timezone\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "charges = []\n",
+    "for candidat in (Path(\"instance-jetable/.env\"), Path(\".env\")):\n",
+    "    if candidat.exists():\n",
+    "        load_dotenv(candidat)\n",
+    "        charges.append(str(candidat))\n",
+    "print(\"Fichiers .env charges :\", charges or \"(aucun)\")\n",
+    "\n",
+    "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
+    "print(\"Base URL :\", BASE_URL)\n",
+    "\n",
+    "EDITEUR_MDP = os.getenv(\"VALMONT_EDITOR_PASSWORD\")  # fixture posee par le notebook OAuth\n",
+    "\n",
+    "\n",
+    "def login_wordpress(session, utilisateur, mot_de_passe):\n",
+    "    \"\"\"Connexion par formulaire -> cookies de session (test_cookie AVANT le POST).\"\"\"\n",
+    "    session.cookies.set(\"wordpress_test_cookie\", \"Cookie check\")\n",
+    "    r = session.post(BASE_URL + \"/wp-login.php\",\n",
+    "                     data={\"log\": utilisateur, \"pwd\": mot_de_passe,\n",
+    "                           \"wp-submit\": \"Log In\",\n",
+    "                           \"redirect_to\": BASE_URL + \"/wp-admin/\",\n",
+    "                           \"testcookie\": \"1\"},\n",
+    "                     timeout=60, allow_redirects=False)\n",
+    "    return r.status_code == 302\n",
+    "\n",
+    "\n",
+    "def nonce_de_wpadmin(session):\n",
+    "    \"\"\"Extrait le rest_nonce embarque dans les pages wp-admin par le plugin.\"\"\"\n",
+    "    r = session.get(BASE_URL + \"/wp-admin/\", timeout=60)\n",
+    "    m = re.search(r'\"rest_nonce\":\"([a-f0-9]+)\"', r.text)\n",
+    "    return m.group(1) if m else None\n",
+    "\n",
+    "\n",
+    "def api_files(session, nonce, action, payload=None, fichiers=None, timeout=120):\n",
+    "    \"\"\"Appel POST a mwai-ui/v1/files/<action> au X-WP-Nonce donne.\"\"\"\n",
+    "    if fichiers is not None:\n",
+    "        r = session.post(BASE_URL + \"/wp-json/mwai-ui/v1/files/\" + action,\n",
+    "                         headers={\"X-WP-Nonce\": nonce}, files=fichiers,\n",
+    "                         data=payload or {}, timeout=timeout)\n",
+    "    else:\n",
+    "        r = session.post(BASE_URL + \"/wp-json/mwai-ui/v1/files/\" + action,\n",
+    "                         headers={\"X-WP-Nonce\": nonce,\n",
+    "                                  \"Content-Type\": \"application/json\"},\n",
+    "                         json=payload or {}, timeout=timeout)\n",
+    "    try:\n",
+    "        return r.status_code, r.json()\n",
+    "    except ValueError:\n",
+    "        return r.status_code, {\"_brut\": r.text[:200]}\n",
+    "\n",
+    "\n",
+    "if EDITEUR_MDP:\n",
+    "    session_editor = requests.Session()\n",
+    "    ok = login_wordpress(session_editor, \"consent.editor\", EDITEUR_MDP)\n",
+    "    NONCE = nonce_de_wpadmin(session_editor) if ok else None\n",
+    "    print(\"login editor :\", \"OK (302)\" if ok else \"ECHEC\",\n",
+    "          \"| nonce :\", (NONCE[:6] + \"...\") if NONCE else \"aucun\")\n",
+    "else:\n",
+    "    print(\"VALMONT_EDITOR_PASSWORD absent du .env — executer d'abord le notebook OAuth\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "06f6f002",
+   "metadata": {},
+   "source": [
+    "## 1. La carte vide\n",
+    "\n",
+    "Comme pour la face editeur, tout commence par la carte — mais ici la\n",
+    "carte interessante n'est pas la liste des routes (les trois `files/*`\n",
+    "sont visibles depuis le grain precedent), c'est **l'etat** : que\n",
+    "contient la memoire avant qu'on y touche ? Un appel a `files/list` sur\n",
+    "une instance propre rend zero fichier, et c'est cette mesure\n",
+    "d'**etat initial** qui donnera son poids au cleanup final — on saura\n",
+    "que le notebook n'a rien laisse derriere lui. C'est la discipline\n",
+    "d'audit de la serie appliquee a une surface a effets persistants.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c500e862",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.097156Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.096624Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.123653Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.123120Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "files/list : 200\n",
+      "total initial : 0\n",
+      "fichiers : []\n"
+     ]
+    }
+   ],
+   "source": [
+    "# L'etat initial de la memoire.\n",
+    "statut, liste = api_files(session_editor, NONCE, \"list\")\n",
+    "print(\"files/list :\", statut)\n",
+    "print(\"total initial :\", liste.get(\"data\", {}).get(\"total\"))\n",
+    "print(\"fichiers :\", liste.get(\"data\", {}).get(\"files\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d24f7a6",
+   "metadata": {},
+   "source": [
+    "**Total 0, liste vide** — l'etat initial est mesure, pas suppose. La\n",
+    "reponse porte aussi sa structure : chaque fiche future aura un `id`\n",
+    "interne, un `refId` public (l'identifiant que l'API rend a\n",
+    "l'appelant), et les champs de gestion (`status`, `purpose`,\n",
+    "`expires`). Garder ce zero en tete : la derniere cellule du notebook\n",
+    "doit le retrouver exactement.\n",
+    "\n",
+    "## 2. Le contrat d'upload, decouvert par le refus\n",
+    "\n",
+    "Televersons un fichier — ou plutot, essayons : la route ne declare\n",
+    "aucun schema (meme silence que la face editeur), et la premiere\n",
+    "tentative naturelle echoue. C'est le mode de documentation de cette\n",
+    "serie : sur une API muette, **le refus du serveur est la\n",
+    "documentation**.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7a247c39",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.126269Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.126269Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.189431Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.189431Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "upload sans purpose : 400\n",
+      "message : Purpose is required.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 1 : upload sans le champ purpose.\n",
+    "contenu = \"Catalogue synthetique de la Maison Valmont.\\nTitre : Le Lac de Novembre. Auteur : anonyme.\".encode(\"utf-8\")\n",
+    "sans_purpose = {\"file\": (\"catalogue-valmont.txt\", contenu, \"text/plain\")}\n",
+    "statut, rep = api_files(session_editor, NONCE, \"upload\", fichiers=sans_purpose)\n",
+    "print(\"upload sans purpose :\", statut)\n",
+    "print(\"message :\", rep.get(\"message\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86de0fde",
+   "metadata": {},
+   "source": [
+    "**400, « Purpose is required. »** Le serveur exige une **intention\n",
+    "declaree** avant d'accepter un octet. Ce n'est pas de la bureaucratie\n",
+    ": le `purpose` est ce qui permettra plus tard au routeur du plugin de\n",
+    "savoir **quoi faire** du fichier — un fichier pose pour `finetune`\n",
+    "n'a pas le meme destin qu'un fichier pose pour `vision` ou pour une\n",
+    "simple piece jointe. La valeur est libre a ce stade (chaine\n",
+    "quelconque), mais sa **presence** est obligatoire : l'API force\n",
+    "l'appelant a declarer le role du fichier au moment meme ou il le\n",
+    "depose. Un file-system anonyme serait ingerable ; une memoire\n",
+    "d'assistant doit savoir pourquoi elle garde.\n",
+    "\n",
+    "## 3. L'upload reel — refId, URL, et le contenu servi\n",
+    "\n",
+    "Le contrat satisfait, l'upload passe. Deux choses a observer dans la\n",
+    "reponse : l'identifiant (`refId`) que l'API rendra toujours a\n",
+    "l'appelant — jamais l'id interne de la base — et une **URL publique**,\n",
+    "servie par le site lui-meme. Verifions que cette URL sert vraiment le\n",
+    "contenu televerse : une URL qui repond 200 mais vide serait une\n",
+    "indication, pas une preuve.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e6cbf847",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.191436Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.191436Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.249684Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.249684Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "upload : 200\n",
+      "refId : 2e39760b39d9be460c9db6b0647f634e\n",
+      "url   : http://localhost:8093/wp-content/uploads/2026/08/2e39760b39d9be460c9db6b0647f634e.txt\n",
+      "\n",
+      "GET url : 200 | 89 octets\n",
+      "contenu identique a l'envoye : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 2 : upload avec purpose, puis lecture de l'URL rendue.\n",
+    "avec_purpose = {\"file\": (\"catalogue-valmont.txt\", contenu, \"text/plain\")}\n",
+    "statut, rep = api_files(session_editor, NONCE, \"upload\",\n",
+    "                        payload={\"purpose\": \"assistant-demo\"}, fichiers=avec_purpose)\n",
+    "print(\"upload :\", statut)\n",
+    "donnees = rep.get(\"data\", {})\n",
+    "REFID = donnees.get(\"id\")\n",
+    "URL = donnees.get(\"url\")\n",
+    "print(\"refId :\", REFID)\n",
+    "print(\"url   :\", URL)\n",
+    "\n",
+    "r = requests.get(URL, timeout=30)\n",
+    "print()\n",
+    "print(\"GET url :\", r.status_code, \"|\", len(r.content), \"octets\")\n",
+    "print(\"contenu identique a l'envoye :\", r.content == contenu)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a54bab65",
+   "metadata": {},
+   "source": [
+    "**L'URL sert le contenu, octet pour octet** — la comparaison directe\n",
+    "(`True` ci-dessus) est la preuve, pas le code 200. Une nuance de\n",
+    "securite se lit ici : le fichier televerse par un utilisateur connecte\n",
+    "devient **accessible publiquement** a qui tient l'URL. Ce n'est pas\n",
+    "une fuite du plugin — c'est le comportement standard des medias\n",
+    "WordPress — mais pour un chatbot qui recoit des documents sensibles\n",
+    "(un manuscrit non publie, par exemple), c'est un point d'architecture\n",
+    "a savoir : la memoire du chatbot est publique par defaut, protegee\n",
+    "seulement par l'obscurite de l'URL. Le dossier de destination est le\n",
+    "`wp-content/uploads/` classique, organise par date comme tout media\n",
+    "WordPress — le fichier du chatbot vit parmi les autres.\n",
+    "\n",
+    "## 4. La fiche et son TTL — la duree de vie mesuree\n",
+    "\n",
+    "Le fichier est maintenant dans la memoire. Demandons la liste : la\n",
+    "fiche complete apparait, et avec elle le champ qui caracterise cette\n",
+    "surface — `expires`. Mesurons-le honnetement : pas seulement le lire,\n",
+    "mais **verifier le calcul** (la duree entre `created` et `expires`)\n",
+    "et l'exprimer en minutes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "c67500c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.252370Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.252370Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.315417Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.315417Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total :"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 1\n",
+      "  id       : 4\n",
+      "  refId    : 2e39760b39d9be460c9db6b0647f634e\n",
+      "  userId   : 4\n",
+      "  type     : file\n",
+      "  status   : uploaded\n",
+      "  purpose  : assistant-demo\n",
+      "  created  : 2026-08-20 01:38:00\n",
+      "  expires  : 2026-08-20 02:38:00\n",
+      "\n",
+      "TTL (expires - created) : 1:00:00 = 60.0 minutes\n",
+      "expire a : 0:59:59.686609 de maintenant (UTC)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 3 : la fiche complete, et le TTL verifie par calcul.\n",
+    "statut, liste = api_files(session_editor, NONCE, \"list\")\n",
+    "fichiers = liste.get(\"data\", {}).get(\"files\", [])\n",
+    "print(\"total :\", liste.get(\"data\", {}).get(\"total\"))\n",
+    "fiche = fichiers[0] if fichiers else {}\n",
+    "for cle in (\"id\", \"refId\", \"userId\", \"type\", \"status\", \"purpose\", \"created\", \"expires\"):\n",
+    "    print(f\"  {cle:9s}: {fiche.get(cle)}\")\n",
+    "\n",
+    "cree = datetime.strptime(fiche[\"created\"], \"%Y-%m-%d %H:%M:%S\")\n",
+    "expire = datetime.strptime(fiche[\"expires\"], \"%Y-%m-%d %H:%M:%S\")\n",
+    "ttl = expire - cree\n",
+    "print()\n",
+    "print(\"TTL (expires - created) :\", ttl, \"=\", ttl.total_seconds() / 60, \"minutes\")\n",
+    "# le plugin stocke ses dates en UTC : comparer a l'instant present ramene en UTC\n",
+    "maintenant_utc = datetime.now(timezone.utc).replace(tzinfo=None)\n",
+    "print(\"expire a :\", (expire - maintenant_utc), \"de maintenant (UTC)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cd8b17d",
+   "metadata": {},
+   "source": [
+    "**Une heure, verifiee par soustraction** : `expires - created` donne\n",
+    "exactement `1:00:00` — 60 minutes, pas une de plus. Le chatbot ne\n",
+    "**garde** pas ses pieces jointes, il les **emprunte**. Pourquoi ce\n",
+    "choix ? Parce qu'un fichier de chatbot sert a **une conversation** :\n",
+    "l'utilisateur joint un extrait, le modele le lit, la conversation\n",
+    "s'acheve — le fichier n'a plus de raison d'etre, et surtout plus de\n",
+    "raison d'occuper un espace public. Le TTL est la traduction technique\n",
+    "de la difference entre *conserver* (un media WordPress, permanent)\n",
+    "et *consulter* (une piece jointe, ephemere). Pour le projet client —\n",
+    "une maison d'edition ou les manuscrits sont sensibles — cette\n",
+    "ephemericite par defaut est une **protection** : ce qui n'est pas\n",
+    "conserve ne peut pas fuir longtemps. A l'inverse, qui voudrait d'une\n",
+    "memoire durable devrait l'implementer soi-meme (re-upload programme,\n",
+    "ou stockage hors plugin) — l'API ne le propose pas.\n",
+    "\n",
+    "## 5. La propriete — a qui appartient un fichier ?\n",
+    "\n",
+    "La fiche portait un `userId` : le fichier **appartient** a celui qui\n",
+    "l'a pose. Mesurons cette frontiere croisee : un **autre** utilisateur\n",
+    "connecte tente d'effacer notre fichier. Le notebook OAuth a pose un\n",
+    "compte administrateur de test (`consent.admin`) pour son propre\n",
+    "parcours ; ici il sert d'inconnu — et le refus attendu porte un\n",
+    "message distinct de tous ceux vus jusqu'ici.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "18e4f60e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.317423Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.317423Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.377933Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.377933Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(VALMONT_ADMIN_PASSWORD absent : test croise non execute — voir exercice 2)\n",
+      "\n",
+      "le fichier est-il toujours la ?\n",
+      "total : 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 4 : le delete croise — un autre utilisateur, notre fichier.\n",
+    "ADMIN_MDP = os.getenv(\"VALMONT_ADMIN_PASSWORD\")  # absent du .env standard : le test croise saute proprement\n",
+    "session_autre = requests.Session()\n",
+    "croise = None\n",
+    "if ADMIN_MDP:\n",
+    "    ok = login_wordpress(session_autre, \"consent.admin\", ADMIN_MDP)\n",
+    "    if ok:\n",
+    "        nonce_autre = nonce_de_wpadmin(session_autre)\n",
+    "        statut_c, rep_c = api_files(session_autre, nonce_autre, \"delete\", payload={\"files\": [REFID]})\n",
+    "        croise = (statut_c, rep_c)\n",
+    "        print(\"delete par consent.admin sur le fichier de consent.editor :\", statut_c)\n",
+    "        print(\"message :\", rep_c.get(\"message\"))\n",
+    "else:\n",
+    "    print(\"(VALMONT_ADMIN_PASSWORD absent : test croise non execute — voir exercice 2)\")\n",
+    "\n",
+    "print()\n",
+    "print(\"le fichier est-il toujours la ?\")\n",
+    "statut, liste = api_files(session_editor, NONCE, \"list\")\n",
+    "print(\"total :\", liste.get(\"data\", {}).get(\"total\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c2f87b1c",
+   "metadata": {},
+   "source": [
+    "Le refus attendu est **403 « No authorized files to delete »** — a\n",
+    "distinguer soigneusement du 400 « No valid files to delete » du\n",
+    "contrat mal forme (section suivante) : le premier dit *ce fichier\n",
+    "n'est pas a toi*, le second dit *je ne trouve aucun fichier dans ta\n",
+    "demande*. Deux codes, deux couches — la validation de forme, puis la\n",
+    "verification de propriete. Et si le test croise n'a pas pu tourner\n",
+    "(variable d'environnement absente), le fichier est quand meme la :\n",
+    "le compteur ci-dessus le prouve, et l'exercice 2 propose de le mener\n",
+    "avec le deuxieme compte de test du notebook OAuth.\n",
+    "\n",
+    "Cette verification de propriete a une consequence d'architecture :\n",
+    "la memoire fichiers est **partitionnee par utilisateur**. Deux\n",
+    "auteurs d'une meme maison d'edition ne voient pas les pieces jointes\n",
+    "de l'autre — ni ne peuvent les effacer. Le code du plugin montre\n",
+    "meme le cas limite : un visiteur **non connecte** possede sa propre\n",
+    "partition, attachee non pas a un compte mais a sa **session anonyme**\n",
+    "(l'identifiant de session du grain 6). Chacun sa memoire ephemere,\n",
+    "personne ne partage la sienne — et le cas limite merite d'etre souligne : l'anonyme a les memes droits sur SA partition que l'editeur sur la sienne (poser, lister, effacer), simplement attachees a des identifiants differents. La securite ne descend pas du compte, elle monte du cloisonnement.\n",
+    "\n",
+    "## 6. Le delete — encore un contrat par refus\n",
+    "\n",
+    "Notre fichier, notre session : effacons-le. Mais d'abord, refusons\n",
+    "une fois de plus : la route attend-elle un `id`, un `refId`, sous\n",
+    "quelle forme ? L'intuition naturelle — `{\"id\": ...}` — se mesure.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "49783e7f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.380450Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.380450Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.529768Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.529768Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delete avec {id: ...} :"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 400\n",
+      "message : No valid files to delete\n",
+      "\n",
+      "delete avec {files: [refId]} : 200\n",
+      "reponse : {'success': True, 'deleted': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total final : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 5 : le contrat du delete, par refus puis par reussite.\n",
+    "statut, rep = api_files(session_editor, NONCE, \"delete\", payload={\"id\": REFID})\n",
+    "print(\"delete avec {id: ...} :\", statut)\n",
+    "print(\"message :\", rep.get(\"message\"))\n",
+    "\n",
+    "statut, rep = api_files(session_editor, NONCE, \"delete\", payload={\"files\": [REFID]})\n",
+    "print()\n",
+    "print(\"delete avec {files: [refId]} :\", statut)\n",
+    "print(\"reponse :\", rep)\n",
+    "\n",
+    "statut, liste = api_files(session_editor, NONCE, \"list\")\n",
+    "print(\"total final :\", liste.get(\"data\", {}).get(\"total\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91c089e5",
+   "metadata": {},
+   "source": [
+    "Le refus est une lecon de lecture attentive : 400 « **No valid files\n",
+    "to delete** » — le serveur n'a trouve **aucun fichier** dans ce que\n",
+    "nous lui avons donne. Le champ `id` a ete ignore sans erreur de\n",
+    "schema (muette, la route ne valide pas la forme) ; le contrat reel\n",
+    "est `{\"files\": [refIds]}` — une **liste**, pensee pour la\n",
+    "suppression en masse. Avec lui, le delete passe et rend un compte\n",
+    "(`deleted: 1`), et le retour a `files/list` ferme la boucle : **total\n",
+    "0, l'etat initial est retrouve exactement**. Le notebook laisse la\n",
+    "memoire aussi vide qu'il l'a trouvee — c'est la discipline de cleanup\n",
+    "de la serie, prouvee par mesure et pas par intention.\n",
+    "\n",
+    "## 7. Le miroir admin\n",
+    "\n",
+    "La serie a croise deux namespaces de fichiers : `mwai-ui/v1/files/*`\n",
+    "(la face utilisateur, ce notebook) et `mwai/v1/openai/files/*` — cinq\n",
+    "routes admin apercue au sondage. Sans les exercer (elles exigent\n",
+    "l'authentification admin et leur interet est surtout le contraste),\n",
+    "cartographions-les : le nom dit deja tout — c'est une surface de\n",
+    "**compatibilite OpenAI** (meme vocabulaire que l'API Files d'OpenAI :\n",
+    "list, upload, delete, download, **finetune**), destinee a ce qu'un\n",
+    "outillage ecrit pour OpenAI parle au plugin sans modification.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c44df644",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.531775Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.531775Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.555786Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.555786Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# La carte du miroir admin (lecture seule, sans appel).\n",
+    "routes_admin = requests.get(BASE_URL + \"/wp-json/mwai/v1/openai\", timeout=30).json()\n",
+    "for chemin, spec in sorted(routes_admin.get(\"routes\", {}).items()):\n",
+    "    if \"files\" in chemin:\n",
+    "        print(chemin, spec.get(\"methods\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "630e9baa",
+   "metadata": {},
+   "source": [
+    "Cinq routes, dont `download` et **`finetune`** — la derniere ouvre la\n",
+    "porte au ajustement de modeles depuis les fichiers de l'installation\n",
+    "(une fonctionnalite dont la gratuite ne montre que la porte). Le\n",
+    "contraste avec la face utilisateur est la lecon : **meme concept, deux\n",
+    "mondes**. La face `mwai-ui` parle le langage du navigateur (nonce de\n",
+    "session, propriete par utilisateur, TTL d'une heure) ; le miroir\n",
+    "`mwai/v1/openai` parle le langage des outillages (authentification\n",
+    "admin, compatibilite de noms, operations completes). Un fichier\n",
+    "n'existe pas de la meme facon selon la face par laquelle on le\n",
+    "regarde — exactement la lecon des quatre faces du grain precedent,\n",
+    "appliquee aux donnees elles-memes.\n",
+    "\n",
+    "## Bilan\n",
+    "\n",
+    "- **La memoire du chatbot est ephemere par conception** : `expires`\n",
+    "  calcule a exactement une heure de `created`, verifie par\n",
+    "  soustraction. Ce qui n'est pas conserve ne peut pas fuir longtemps.\n",
+    "- **L'upload exige une intention** : 400 « Purpose is required. » —\n",
+    "  le plugin refuse un depot anonyme ; chaque fichier declare son\n",
+    "  role au moment ou il est pose.\n",
+    "- **Le fichier devient public** : l'URL rendue sert le contenu\n",
+    "  octet pour octet — memoire publique par defaut, protegee par\n",
+    "  l'obscurite de l'URL seulement. Point d'architecture pour des\n",
+    "  documents sensibles.\n",
+    "- **La propriete partitionne la memoire** : `userId` dans la fiche,\n",
+    "  403 croise pour l'etranger, partitions separees meme pour les\n",
+    "  visiteurs anonymes (session du grain 6).\n",
+    "- **Les contrats se decouvrent par les refus** : `purpose` absent\n",
+    "  (400), `id` ignore au profit de `files:[refIds]` (400 « No valid\n",
+    "  files »), deux codes et deux couches (forme, puis propriete).\n",
+    "- **Le cleanup est une mesure** : etat initial 0, etat final 0 —\n",
+    "  la memoire rendue aussi vide que trouvee, prouvee par `total`.\n",
+    "\n",
+    "Avec cette dixieme note, la serie a couvert les quatre faces, la\n",
+    "regie des environnements, les donnees structurees, l'autorisation\n",
+    "deleguee et la memoire ephemere. Les familles restantes du catalogue\n",
+    "restent fermees sur la version gratuite.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d6b8dcf",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les trois exercices suivants sont a completer (remplacez `pass`).\n",
+    "L'instance doit etre demarree, le `.env` charge, et les variables\n",
+    "`session_editor`, `NONCE`, la fonction `api_files` et la constante\n",
+    "`contenu` viennent des cellules precedentes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "81363798",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.558297Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.556793Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.561385Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.561385Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 — l'horloge du TTL.\n",
+    "# Ecrire une fonction mourant_dans(fiche, maintenant=None) qui prend\n",
+    "# une fiche de files/list et retourne le nombre de minutes restantes\n",
+    "# avant expires (timedelta, arrondi a la minute). La tester sur un\n",
+    "# upload frais, puis verifier qu'un re-upload 2 minutes plus tard\n",
+    "# (sleep(120) admissible pour l'exercice) decale l'echeance du meme\n",
+    "# ecart. Penser au cleanup.\n",
+    "\n",
+    "def mourant_dans(fiche, maintenant=None):\n",
+    "    pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "8af366c1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.563912Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.563912Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.566883Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.566883Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 — la frontiere croisee, pour de vrai.\n",
+    "# Le test croise de la section 5 a saute si VALMONT_ADMIN_PASSWORD\n",
+    "# etait absent. Le completer : recuperer le mot de passe du compte\n",
+    "# consent.admin par le meme mecanisme que le notebook OAuth (cree par\n",
+    "# l'API REST s'il manque — ecrire la fonction assurer_compte(nom,\n",
+    "# roles, mdp_var) qui retrouve OU cree, idempotente), ouvrir sa\n",
+    "# session, et mesurer le 403 croise sur un fichier de consent.editor.\n",
+    "# Verifier ensuite que l'administrateur voit AUSSI la liste vide (les\n",
+    "# partitions sont croisees dans les deux sens).\n",
+    "\n",
+    "def assurer_compte(nom, roles, mdp_var):\n",
+    "    pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "e783f66b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T01:38:00.569392Z",
+     "iopub.status.busy": "2026-08-20T01:38:00.567888Z",
+     "iopub.status.idle": "2026-08-20T01:38:00.572087Z",
+     "shell.execute_reply": "2026-08-20T01:38:00.572087Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3 — la suppression en masse, mesuree.\n",
+    "# Le contrat du delete est files:[refIds] — une liste. Ecrire une\n",
+    "# fonction vider_ma_memoire(session, nonce) qui : upload n=3 fichiers\n",
+    "# synthetiques distincts (purpose 'demo-masse'), verifie total == 3,\n",
+    "# puis les supprime EN UN SEUL appel et verifie total == 0. Comparer\n",
+    "# ce que rend la reponse (deleted: n) au total mesure avant/apres.\n",
+    "\n",
+    "def vider_ma_memoire(session, nonce, n=3):\n",
+    "    pass\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/instance-jetable/README.md
@@ -91,6 +91,23 @@ Pour verifier l'acces authentifie (chatbots, completions), executer
 `presenter-ai-engine-par-son-api.ipynb` : c'est exactement ce que font ses
 cellules 3 a 6, avec l'application password lu depuis `.env`.
 
+## Maintenance
+
+### Upload de fichiers : permission du dossier uploads
+
+Si un appel a `mwai-ui/v1/files/upload` rend 500 « Could not move
+the file. », le dossier `wp-content/uploads/` du conteneur n'appartient
+pas a WordPress (le volume monte peut etre cree par root au premier
+demarrage) :
+
+```bash
+docker exec valmont-wordpress-1 sh -c "chown -R www-data:www-data /var/www/html/wp-content/uploads"
+```
+
+Apres quoi l'upload passe (verifie sur l'instance de reference). Le
+notebook fichiers de la serie pose cette precondition dans ses
+prerequis.
+
 ## Nettoyage
 
 ```powershell

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -113,6 +113,27 @@ Deux conséquences pratiques :
 > charge le site ; le contrôle d'accès réel de cette face vit aux
 > limites de débit.
 
+> **Notebook compagnon (module Client, face pièces jointes).**
+> [`donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb`](donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb)
+> ouvre la cinquième surface de la série — la famille
+> `mwai-ui/v1/files/*`, celle qui donne au chatbot ses pièces
+> jointes : un manuscrit à relire, un extrait audio, une image. Le
+> trait le plus caractéristique y est **mesuré par calcul** : la
+> fiche du fichier porte `created` et `expires`, et la soustraction
+> rend exactement **une heure** — la mémoire fichiers est éphémère
+> par architecture, pas par configuration, un choix lisible dans la
+> réponse même de l'API. Autour : le contrat d'upload découvert par
+> refus (400 « Purpose is required. » nomme le champ obligatoire),
+> l'URL publique servie par la médiathèque WordPress (contenu vérifié
+> octet pour octet), la partition par utilisateur — table
+> `mwai_files`, deux auteurs ne voient ni n'effacent les pièces
+> jointes de l'autre, jusqu'aux sessions anonymes qui ont chacune la
+> leur —, le delete par refus (400 « No valid files to delete » pour
+> `{id}` : le contrat veut `{"files": [refId]}`), et le miroir admin
+> `mwai/v1/openai/files/*` où les mêmes fichiers reviennent, augmentés
+> de `download` et `finetune`. Le fichier téléversé est synthétique
+> et détruit en fin de parcours — cleanup mesuré, total 0 → 1 → 0.
+
 ---
 
 ## Parcours 1 — Copilot pour l'éditeur WordPress


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #11714

Quoi:
Dixième notebook de la série « AI Engine par son API » : la face pièces jointes du chatbot — famille `mwai-ui/v1/files/*`. Le trait caractéristique de la surface y est mesuré par calcul : la fiche fichier porte `created` et `expires`, et la soustraction rend exactement une heure — la mémoire fichiers est éphémère par architecture, pas par configuration. Autour de la mesure : contrat d'upload découvert par refus (400 « Purpose is required. » nomme le champ obligatoire), URL publique servie par la médiathèque WordPress (contenu vérifié octet pour octet), partition par utilisateur (table `mwai_files`, jusqu'aux sessions anonymes qui ont chacune la leur), delete par refus (400 « No valid files to delete » pour `{id}` ; le contrat veut `{"files": [refId]}`), et miroir admin `mwai/v1/openai/files/*` où les mêmes fichiers reviennent augmentés de `download` et `finetune`. Accompagnent le notebook : paragraphe narratif + entrée « Voir aussi » dans README.md, bloc compagnon dans livresagites-parcours.md (Parcours 0, face pièces jointes), et note de maintenance permissions `uploads`/`www-data` dans instance-jetable/README.md (500 « Could not move the file. » observé et corrigé le 19/08).

Preuve:
Exécuté contre l'instance jetable « Maison Valmont » (localhost:8093), kernel coursia-sae, `nbconvert --execute`, HEAD testé `4ba70e104`. Sorties réelles commitées : `total initial : 0` → `total : 1` → `total final : 0` (cleanup vérifié), `TTL (expires - created) : 1:00:00 = 60.0 minutes`, `expire a : 0:59:59.686609 de maintenant (UTC)` (comparaison timezone-aware après correction de la cause — sorties jamais retouchées à la main), `contenu identique a l'envoye : True`, 400 « Purpose is required. », 400 « No valid files to delete » puis `{'success': True, 'deleted': 1}`. Contrôles locaux avant push : densité ≥1200 c/cellule (pedagogy_density.py, 0 below floor), ancrage CLEAN (check_markdown_claims_output.py), LF pur sur le .ipynb (798 CRLF normalisés), scan sécurité PROPRE (secrets, homoglyphes cyrillique/grec, emoji, termes client, accents sources). Aucun appel LLM : surface purement gestionnaire.

Périmètre:
4 fichiers, tous dans `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/` : 1 nouveau notebook exécutable (23 cellules, 3 exercices à stubs), README.md (+21), livresagites-parcours.md (+21), instance-jetable/README.md (+17). Aucune donnée client, corpus 100 % synthétique, credentials via `.env` non commité (`VALMONT_EDITOR_PASSWORD`, convention #11747/#11819) ; le test croisé de propriété saute proprement sans `VALMONT_ADMIN_PASSWORD` (refus 403 attendu documenté, exercice 2 propose de le mener).

Closes #11883.