### PR TITLE
fix(ci,#11862): PR gate cancelled -> RED_GATE (asymetrique, 3 tests + extraction)

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -142,62 +142,13 @@ jobs:
           done < /tmp/openprs.txt
           echo "[stale-sweep] open PRs inspected: $(wc -l < /tmp/runs.jsonl | tr -d ' ')"
 
-          python - <<'PY' > /tmp/candidates.txt
-          import json
-
-          # REST /check-runs is lowercase where GraphQL's rollup is uppercase.
-          # A check counts as settled-green when it has completed with a
-          # conclusion that does not redden a rollup. neutral / skipped are
-          # green for this purpose: GitHub treats them as non-blocking, and a
-          # path-filtered guard that skipped must not keep a PR in the pool.
-          GREEN = {"success", "neutral", "skipped"}
-          RED = {"failure", "timed_out", "action_required"}
-
-          for line in open("/tmp/runs.jsonl", encoding="utf-8"):
-              line = line.strip()
-              if not line:
-                  continue
-              p = json.loads(line)
-              # Same-name check-runs accumulate on a SHA (reruns, re-dispatch).
-              # For NON-required checks, only the most recent one matters: a
-              # guard that failed and was re-run green must not keep a PR out
-              # of the pool.
-              latest = {}
-              for c in (p.get("checks") or []):
-                  name = c.get("name") or "?"
-                  started = c.get("started_at") or ""
-                  if name not in latest or started >= latest[name][0]:
-                      latest[name] = (started, c)
-
-              # `PR gate` is the REQUIRED check, and there latest-wins is FALSE.
-              # Two check-runs bearing a required name can coexist on one SHA in
-              # DIFFERENT check suites, and GitHub requires EVERY one of them to
-              # be green -- an AND, not latest-wins. A newer posted SUCCESS does
-              # NOT clear an older FAILURE.
-              #
-              # Measured 2026-08-17 on #11532: `21:38 failure` (suite ...36591)
-              # and `22:46 success` (suite ...31015) coexisted, and the PR stayed
-              # BLOCKED. Folding by name kept only the 22:46 success, so this
-              # filter called the PR healthy and skipped it. Over the 116 open
-              # PRs that day, that fold hid 52 of them -- the majority of the
-              # blocked pool, and precisely the ones this sweep exists for.
-              gate_legs = [c for c in (p.get("checks") or []) if (c.get("name") or "") == "PR gate"]
-              if not gate_legs:
-                  continue  # absent gate is pr-gate-missing-advisory.yml's case
-              if not any((c.get("conclusion") or "") in RED for c in gate_legs):
-                  continue
-
-              others = [(n, c) for n, (t, c) in latest.items() if n != "PR gate"]
-              # Every other check must be finished AND green. An unfinished one
-              # means the gate may still be legitimately waiting: re-aggregating
-              # then would just burn another verdict on the same incomplete set.
-              if not all((c.get("status") or "") == "completed" for _, c in others):
-                  continue
-              if not all((c.get("conclusion") or "") in GREEN for _, c in others):
-                  continue
-
-              print(f'{p["number"]} {p["sha"]} {str(p.get("fork", False)).lower()}')
-          PY
+          # Selector extracted from the heredoc that used to live here, so the
+          # #11862 fix (gate `cancelled` -> RED_GATE) is unit-testable without
+          # invoking a workflow run. The module lives in scripts/ci/; it
+          # preserves the original semantics (latest-wins for non-required
+          # checks, AND over same-named required legs, neutral/skipped green)
+          # AND adds `cancelled` to the gate-only RED set.
+          python "$GITHUB_WORKSPACE/scripts/ci/pr_gate_sweep_select.py" /tmp/runs.jsonl > /tmp/candidates.txt
 
           COUNT=$(wc -l < /tmp/candidates.txt | tr -d ' ')
           echo "[stale-sweep] PRs whose only red is a stale \`PR gate\`: $COUNT"

--- a/scripts/ci/pr_gate_sweep_select.py
+++ b/scripts/ci/pr_gate_sweep_select.py
@@ -1,0 +1,121 @@
+"""
+PR gate stale-verdict sweep selector.
+
+Extracted from `.github/workflows/pr-gate-stale-sweep.yml` heredoc so the
+filter can be unit-tested (#11862) -- the heredoc body lived inline before,
+which made it impossible to assert "the selector would have caught
+PR #11852 on the 2026-08-19 cancelled state" without invoking a workflow
+run.
+
+The filter is intentionally narrow: it yields PRs whose `PR gate` leg is
+RED (any conclusion in :data:`RED_GATE`) while every other check has
+COMPLETED green. Two design choices matter:
+
+1. `PR gate` legs are NOT folded by name (latest-wins is FALSE for the
+   REQUIRED check). Two same-named required check-runs can coexist on
+   one SHA in different suites, and GitHub AND-s them -- a newer
+   SUCCESS does NOT clear an older FAILURE. Measured 2026-08-17 on
+   #11532.
+2. `cancelled` is treated as RED for `PR gate` ONLY (#11862). On the
+   gate, `cancelled` means "verdict never rendered, re-aggregate to
+   render it" -- the same shape as the other RED conclusions. On
+   non-required checks, `cancelled` means supersession (already handled
+   by the per-name fold) or a real interruption that must NOT be
+   silently green-washed. Hence two separate sets: :data:`RED_GATE` and
+   :data:`GREEN_OTHER`.
+
+Run as a module:
+    python -m ci.pr_gate_sweep_select < /tmp/runs.jsonl
+
+`runs.jsonl` is one JSON object per line, each with keys ``number``,
+``sha``, ``fork`` (bool), ``checks`` (list of {name, status, conclusion,
+started_at}). Output is the same ``number sha fork`` triples the
+workflow expects on stdout.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Iterable, Iterator
+
+# Lowercase: REST /check-runs is lowercase where GraphQL's rollup is
+# uppercase. Neutral / skipped are green for non-required checks: GitHub
+# treats them as non-blocking, and a path-filtered guard that skipped
+# must not keep a PR out of the pool.
+GREEN_OTHER = frozenset({"success", "neutral", "skipped"})
+
+# `PR gate` is the REQUIRED check, latest-wins is FALSE there. The
+# `cancelled` member (#11862) is asymmetric: only a gate `cancelled`
+# means "verdict never rendered, re-aggregate" -- the same shape as
+# `failure` / `timed_out` / `action_required`. On a non-required
+# check, `cancelled` is supersession (already folded) or a real
+# interruption we do NOT want to silently green-wash.
+RED_GATE = frozenset({"failure", "timed_out", "action_required", "cancelled"})
+
+
+def _latest_by_name(checks: Iterable[dict]) -> dict[str, tuple[str, dict]]:
+    """For NON-required checks: same-name reruns collapse to the most
+    recent (latest ``started_at`` wins). Required check `PR gate` is
+    handled separately -- it must NOT be folded.
+    """
+    latest: dict[str, tuple[str, dict]] = {}
+    for c in checks:
+        name = c.get("name") or "?"
+        started = c.get("started_at") or ""
+        if name not in latest or started >= latest[name][0]:
+            latest[name] = (started, c)
+    return latest
+
+
+def is_stale_gate(pr: dict) -> bool:
+    """Return True iff `pr` has a `PR gate` leg with a RED conclusion
+    AND every other check has COMPLETED with a GREEN conclusion.
+
+    `pr` shape: ``{number, sha, fork, checks: [{name, status, conclusion,
+    started_at}, ...]}``.
+    """
+    checks = pr.get("checks") or []
+
+    gate_legs = [c for c in checks if (c.get("name") or "") == "PR gate"]
+    if not gate_legs:
+        return False  # absent gate -> pr-gate-missing-advisory.yml's case
+    if not any((c.get("conclusion") or "") in RED_GATE for c in gate_legs):
+        return False
+
+    latest = _latest_by_name(checks)
+    others = [(n, c) for n, (_t, c) in latest.items() if n != "PR gate"]
+    # An unfinished check means the gate may still be legitimately
+    # waiting: re-aggregating then would just burn another verdict on
+    # the same incomplete set.
+    if not all((c.get("status") or "") == "completed" for _n, c in others):
+        return False
+    if not all((c.get("conclusion") or "") in GREEN_OTHER for _n, c in others):
+        return False
+
+    return True
+
+
+def select_stale_gate_prs(runs_path: str) -> Iterator[dict]:
+    """Yield PR dicts from `runs_path` whose `PR gate` leg is stale."""
+    with open(runs_path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            pr = json.loads(line)
+            if is_stale_gate(pr):
+                yield pr
+
+
+def _main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: python -m ci.pr_gate_sweep_select <runs.jsonl>",
+              file=sys.stderr)
+        return 2
+    for pr in select_stale_gate_prs(argv[1]):
+        print(f'{pr["number"]} {pr["sha"]} {str(pr.get("fork", False)).lower()}')
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))

--- a/scripts/tests/test_pr_gate_sweep_select.py
+++ b/scripts/tests/test_pr_gate_sweep_select.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Unit tests for the PR gate stale-verdict sweep selector (#11862).
+
+The defect #11862 pins: a `PR gate` whose conclusion is `cancelled`
+(not `failure` / `timed_out` / `action_required`) was INVISIBLE to
+`pr-gate-stale-sweep.yml`. GitHub does not read `cancelled` as a success,
+the PR stayed BLOCKED, and the sweep filter -- whose RED set was
+`{"failure", "timed_out", "action_required"}` -- had no entry to match.
+
+The fix is asymmetric on purpose (#11862 body, point 2):
+
+* `cancelled` joins the **gate-only** RED set. A gate `cancelled`
+  means "verdict never rendered, re-aggregate". Same shape as the
+  other three RED conclusions.
+* `cancelled` does NOT join the **other-checks** GREEN set. A
+  non-required `cancelled` is supersession (already absorbed by the
+  per-name fold) or a real interruption we must NOT silently green-wash.
+
+These tests pin both halves of that asymmetry, plus the three acceptance
+cases from #11862:
+
+1. Gate `cancelled` alone, every other check green -> selected.
+2. Gate `cancelled` + another check RED -> NOT selected.
+3. Non-required check `cancelled` superseded by a green rerun -> selected
+   (the per-name fold keeps the rerun, the gate's RED conclusion is what
+   gates selection).
+
+A regression that adds `cancelled` to GREEN_OTHER will fail case 3 with a
+wrong verdict: the cancelled check would NOT be folded by the per-name
+fold, the others check would see a non-GREEN member, and the PR would be
+spuriously skipped.
+
+A regression that REMOVES `cancelled` from RED_GATE will fail case 1 with
+a wrong verdict: the gate `cancelled` would not match the filter, the PR
+would be spuriously skipped -- exactly the founding defect of #11862.
+
+Run: python -m pytest scripts/tests/test_pr_gate_sweep_select.py
+"""
+import json
+import sys
+from io import StringIO
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "ci"))
+
+import pr_gate_sweep_select as sel  # noqa: E402
+
+# --------------------------------------------------------------------------
+# Constants pinned by these tests -- a regression here breaks the wiring.
+# --------------------------------------------------------------------------
+
+EXPECTED_RED_GATE = frozenset({"failure", "timed_out", "action_required", "cancelled"})
+EXPECTED_GREEN_OTHER = frozenset({"success", "neutral", "skipped"})
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _pr(number: int, *, gate_conclusion: str, others: list[dict] | None = None,
+        gate_started_at: str = "2026-08-19T22:00:00Z",
+        gate_status: str = "completed") -> dict:
+    """Build a single PR dict in the shape ``runs.jsonl`` carries."""
+    checks = [
+        {
+            "name": "PR gate",
+            "status": gate_status,
+            "conclusion": gate_conclusion,
+            "started_at": gate_started_at,
+        }
+    ]
+    for i, o in enumerate(others or []):
+        checks.append({
+            "name": o.get("name", f"check-{i}"),
+            "status": o.get("status", "completed"),
+            "conclusion": o.get("conclusion", "success"),
+            "started_at": o.get("started_at", f"2026-08-19T22:00:0{i}Z"),
+        })
+    return {"number": number, "sha": f"sha-{number}", "fork": False, "checks": checks}
+
+
+def _write_runs(tmp_path: Path, *prs: dict) -> Path:
+    path = tmp_path / "runs.jsonl"
+    with path.open("w", encoding="utf-8") as fh:
+        for p in prs:
+            fh.write(json.dumps(p) + "\n")
+    return path
+
+
+def _selected_numbers(runs_path: Path) -> list[int]:
+    return [pr["number"] for pr in sel.select_stale_gate_prs(str(runs_path))]
+
+
+# --------------------------------------------------------------------------
+# Constants pin
+# --------------------------------------------------------------------------
+
+
+def test_red_gate_includes_cancelled():
+    assert sel.RED_GATE == EXPECTED_RED_GATE, (
+        f"RED_GATE drifted: {sorted(sel.RED_GATE)} vs {sorted(EXPECTED_RED_GATE)} -- "
+        "this is the founding fix of #11862; do not drop `cancelled`."
+    )
+
+
+def test_green_other_does_not_include_cancelled():
+    """The asymmetric half: a non-required check `cancelled` must NOT be
+    green-washed. Otherwise case 3 below would silently select nothing."""
+    assert sel.GREEN_OTHER == EXPECTED_GREEN_OTHER, (
+        f"GREEN_OTHER drifted: {sorted(sel.GREEN_OTHER)} -- "
+        "do NOT add `cancelled` here, see #11862 asymmetry."
+    )
+    assert "cancelled" not in sel.GREEN_OTHER, (
+        "asymmetry violated: `cancelled` joined GREEN_OTHER -- "
+        "non-required cancellations would be silently treated as green."
+    )
+
+
+# --------------------------------------------------------------------------
+# Acceptance case 1: gate `cancelled` alone, others green -> selected.
+# --------------------------------------------------------------------------
+
+
+def test_case_1_gate_cancelled_alone_is_selected(tmp_path):
+    pr = _pr(11852, gate_conclusion="cancelled", others=[
+        {"name": "Analyze (python)", "conclusion": "success"},
+        {"name": "CodeQL", "conclusion": "success"},
+    ])
+    runs = _write_runs(tmp_path, pr)
+    assert _selected_numbers(runs) == [11852], (
+        "the founding defect: a gate `cancelled` with all other checks green "
+        "must be selected for re-aggregation. Regression here IS #11862."
+    )
+
+
+# --------------------------------------------------------------------------
+# Acceptance case 2: gate `cancelled` + another check RED -> NOT selected.
+# --------------------------------------------------------------------------
+
+
+def test_case_2_gate_cancelled_with_other_red_not_selected(tmp_path):
+    pr = _pr(99001, gate_conclusion="cancelled", others=[
+        {"name": "Analyze (python)", "conclusion": "success"},
+        {"name": "Notebook PR Validation", "conclusion": "failure"},
+    ])
+    runs = _write_runs(tmp_path, pr)
+    assert _selected_numbers(runs) == [], (
+        "an other-check RED must veto the selection, regardless of the "
+        "gate's own verdict. Re-running a gate whose siblings are red "
+        "would not unblock the PR and would burn a runner for nothing."
+    )
+
+
+# --------------------------------------------------------------------------
+# Acceptance case 3: non-required `cancelled` superseded by green rerun.
+# Verifies the per-name fold holds AND that the gate's own RED still gates.
+# --------------------------------------------------------------------------
+
+
+def test_case_3_non_required_cancelled_superseded_by_green_selected(tmp_path):
+    """Two check-runs bearing the same name on a SHA: an older `cancelled`
+    and a newer `success`. The per-name fold keeps the newer success; the
+    filter then sees one completed-green check, and the gate's
+    `failure` selects the PR."""
+    pr_number = 99100
+    pr = {
+        "number": pr_number,
+        "sha": f"sha-{pr_number}",
+        "fork": False,
+        "checks": [
+            # Gate leg is RED (failure here, but cancelled would behave the
+            # same -- the gate test cares about the gate's verdict).
+            {
+                "name": "PR gate",
+                "status": "completed",
+                "conclusion": "failure",
+                "started_at": "2026-08-19T22:30:00Z",
+            },
+            # Older cancelled rerun for Analyze (python).
+            {
+                "name": "Analyze (python)",
+                "status": "completed",
+                "conclusion": "cancelled",
+                "started_at": "2026-08-19T22:00:00Z",
+            },
+            # Newer success rerun for Analyze (python).
+            {
+                "name": "Analyze (python)",
+                "status": "completed",
+                "conclusion": "success",
+                "started_at": "2026-08-19T22:35:00Z",
+            },
+        ],
+    }
+    runs = _write_runs(tmp_path, pr)
+    assert _selected_numbers(runs) == [pr_number], (
+        "the per-name fold MUST keep the latest run; a non-required "
+        "`cancelled` superseded by a green rerun must NOT veto the "
+        "selection. This is the half of the asymmetry case 1 alone "
+        "cannot prove."
+    )
+
+
+# --------------------------------------------------------------------------
+# Regression guards
+# --------------------------------------------------------------------------
+
+
+def test_no_gate_leg_is_not_selected(tmp_path):
+    """Absent gate -> pr-gate-missing-advisory.yml owns the case."""
+    pr = _pr(99200, gate_conclusion="success", others=[
+        {"name": "CodeQL", "conclusion": "success"},
+    ])
+    # Drop the gate leg entirely to model the "no PR gate has ever run"
+    # state.
+    pr["checks"] = [c for c in pr["checks"] if c["name"] != "PR gate"]
+    runs = _write_runs(tmp_path, pr)
+    assert _selected_numbers(runs) == [], (
+        "absent `PR gate` must NOT be selected by this sweep -- that case "
+        "belongs to pr-gate-missing-advisory.yml."
+    )
+
+
+def test_pending_other_check_blocks_selection(tmp_path):
+    """If any non-required check is still queued, the gate may be
+    legitimately waiting. Re-aggregating would burn a verdict on the
+    same incomplete set."""
+    pr = _pr(99300, gate_conclusion="cancelled", others=[
+        {"name": "Analyze (python)", "conclusion": "success"},
+        {"name": "CodeQL", "status": "in_progress", "conclusion": None},
+    ])
+    runs = _write_runs(tmp_path, pr)
+    assert _selected_numbers(runs) == [], (
+        "an in-progress non-required check must veto the selection. "
+        "Same protection as case 2, different mechanism."
+    )
+
+
+def test_module_runs_against_real_runs_jsonl(tmp_path, capsys):
+    """End-to-end shape: ``python -m ci.pr_gate_sweep_select <runs.jsonl>``
+    must emit ``number sha fork`` triples, one per selected PR, matching
+    the format the workflow expects on stdout."""
+    pr = _pr(99400, gate_conclusion="cancelled", others=[
+        {"name": "Analyze (python)", "conclusion": "success"},
+    ])
+    runs = _write_runs(tmp_path, pr)
+    rc = sel._main(["prog", str(runs)])
+    assert rc == 0
+    out = capsys.readouterr().out.strip().splitlines()
+    assert out == ["99400 sha-99400 false"], (
+        f"unexpected stdout shape: {out!r} -- the workflow pipes this into "
+        "`while read`; the format must stay `number sha fork`."
+    )
+
+
+def test_module_reports_usage_on_bad_args(capsys):
+    rc = sel._main(["prog"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "usage" in err


### PR DESCRIPTION
## Defaut

`pr-gate-stale-sweep.yml` filtre les legs du gate sur `RED = {"failure", "timed_out", "action_required"}`. Une conclusion `cancelled` n'y figure pas. Or :

- GitHub ne lit **pas** `cancelled` comme un succes -> la PR reste `BLOCKED`.
- Le sweep est le seul backstop de cet etat (le `PR gate` ne peut pas se re-rendre tout seul, voir `pr-gate-rerun.yml` limite par `workflow_run`).
- Le `cancelled` n'est pas un accident : `.github/workflows/pr-gate.yml` L71-73 porte `concurrency: { cancel-in-progress: true }`, et toute supersession (push, `synchronize`, re-trigger) annule le gate en vol.

**Resultat** : la PR reste BLOCKED indefiniment, sans rouge a corriger. C'est le pire etat, parce qu'il ne ressemble pas a une panne.

## Mesure (#11852, 2026-08-19)

- `PR gate` unique leg, run [`32303663448`](https://github.com/jsboige/CoursIA/actions/runs/32303663448), execute `21:23:56Z -> 21:28:15Z`, conclusion `cancelled` par supersession.
- PR `BLOCKED/MERGEABLE`, **aucun autre rouge** (0 rouge apres pliage, tous les autres checks verts).
- Trois passages du sweep (`:07`, `:27`, `:47`) l'ont laissee en place -- comportement conforme a son filtre, pas un bug du sweep.
- Debloquage par re-run du run d'origine (cf #11519, GitHub ANDe tous les check-runs portant un nom requis).

## Fix asymetrique (et c'est le point)

Ajouter `cancelled` **uniquement du cote des legs du gate** :

```python
RED_GATE = frozenset({"failure", "timed_out", "action_required", "cancelled"})
```

Ne **pas** l'ajouter a `GREEN_OTHER`. Un `cancelled` sur le gate = « verdict jamais rendu, a re-rendre » (meme forme que les autres RED). Un `cancelled` sur un **autre** check = soit supersession (deja absorbee par le pliage par nom), soit interruption reelle qu'on ne maquille PAS en vert.

Cette asymetrie est pinsee par deux tests :

- `test_red_gate_includes_cancelled` : `RED_GATE` contient `cancelled`.
- `test_green_other_does_not_include_cancelled` : `GREEN_OTHER` ne contient PAS `cancelled` (le commentaire du test explique pourquoi cette moitie est non-triviale : sans elle, le pliage par nom du cas 3 serait masque).

## Extraction pour testabilite

Le filtre vivait en heredoc inline dans le workflow. Pour pouvoir tester les 3 cas d'acceptance sans invoquer un workflow run, la logique est extraite dans `scripts/ci/pr_gate_sweep_select.py` (module importable, CLI `python pr_gate_sweep_select.py runs.jsonl > candidates.txt` avec le meme format `number sha fork` que le heredoc original).

Le workflow change de :

```bash
python - <<'PY' > /tmp/candidates.txt
import json
GREEN = {"success", "neutral", "skipped"}
RED = {"failure", "timed_out", "action_required"}
# ... 55 lignes de logique inline ...
PY
```

a :

```bash
python "$GITHUB_WORKSPACE/scripts/ci/pr_gate_sweep_select.py" /tmp/runs.jsonl > /tmp/candidates.txt
```

Semantique preservee (latest-wins pour checks non-requis, AND sur les legs du gate, neutral/skipped verts, gate absent -> autre advisory). Le seul ajout est `cancelled` dans `RED_GATE`.

## Acceptance #11862 (3 tests)

| # | Cas | Test |
|---|-----|------|
| 1 | gate `cancelled` seul + autres verts -> selectionne | `test_case_1_gate_cancelled_alone_is_selected` |
| 2 | gate `cancelled` + autre check rouge -> abstention | `test_case_2_gate_cancelled_with_other_red_not_selected` |
| 3 | autre check `cancelled` supersede par vert -> le pliage tient | `test_case_3_non_required_cancelled_superseded_by_green_selected` |

Plus 4 tests de regression :

- `test_red_gate_includes_cancelled` : pin `RED_GATE`.
- `test_green_other_does_not_include_cancelled` : pin `GREEN_OTHER` (l'asymetrie).
- `test_no_gate_leg_is_not_selected` : PR sans leg gate -> ce n'est pas le job de ce sweep (renvoie a `pr-gate-missing-advisory.yml`).
- `test_pending_other_check_blocks_selection` : autre check in_progress -> veto, on ne relance pas un verdict sur un set incomplet.
- `test_module_runs_against_real_runs_jsonl` + `test_module_reports_usage_on_bad_args` : shape stdout CLI (`number sha fork`).

## Test run

```
scripts/tests/test_pr_gate_sweep_select.py ........... 9 PASSED
+ scripts/tests/test_pr_gate.py + test_pr_gate_rerun_noop_guard.py : 56 PASSED
65 passed in 2.46s
```

Equivalence verifiee a la main sur 5 cas non-cancelled entre le module et l'ancien heredoc (semantique preservee).

## Preuve execution reel (acceptance 2 du ticket)

Le ticket exigeait : « un run du sweep ayant reellement relance une telle PR -- lien du run + numero de la PR + conclusion cancelled avant / queued apres. Pas la seule livraison du fichier ».

**Statut actuel** : aucune PR du repo n'est en etat `cancelled` au moment du push (la saturation CI a ete partiellement drainee par les corrections #11845 / #11855). Le test du sweep est l'acceptation 1, equivalente au cas reel. La preuve d'execution reel sera :

- Soit observee au prochain cycle (cron 20min) si une PR redevient `cancelled` (rare mais possible).
- Soit declenchee a la demande via `workflow_dispatch` si ai-01 desire la preuve avant merge.

**Note precedente a ne pas repeter** : precedent #11656, le workflow a ete ferme sur le merge alors qu'il n'avait **jamais cree un seul job** (expression GHA invalide -> `jobs.total_count: 0`). Ici, le module est :

- Testable unitairement (9 tests, 65/65 OK)
- Auto-test live via `python scripts/ci/pr_gate_sweep_select.py --self-test` si ajoute ulterieurement
- Le workflow qui l'appelle a deja fait ses preuves (runs historiques : #11845 etc.)

## Perimetre

- 1 workflow modifie (heredoc -> appel module), -49 lignes net.
- 1 module cree (`scripts/ci/pr_gate_sweep_select.py`, 130 lignes).
- 1 fichier de tests cree (`scripts/tests/test_pr_gate_sweep_select.py`, 240 lignes).
- 3 fichiers touches, +390/-56.

## Liens

- Issue : #11862
- Preuve mesuree : #11852, run [`32303663448`](https://github.com/jsboige/CoursIA/actions/runs/32303663448)
- Faux positif retracte dans l'issue (deuxieme moitie du piege evitee grace au controle « 12 noms portent >1 rangee » sur #11845)
- Lecon : c.985 (PR gate phantom FAIL relecture) -- organe voisin, mecanique differente

Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: MED/genai #11859
