### PR TITLE
feat(semanticweb,#11601): SW-10 RDFStar density tranche 1269 -> 1534

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
@@ -2882,8 +2882,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "\n",
     "## Exercices\n",
     "\n",
     "Les exemples guides 1 a 3 ci-dessus (critiques de film, requetage SPARQL des reifications, graphe de confiance) demontrent les briques ; les exercices 4 a 6 qui suivent reclament de les **transposer** a des domaines nouveaux :\n",
@@ -2895,6 +2893,20 @@
     "| 6 : Annotations temporelles historiques | Evenements dates | Validite temporelle d'un fait | Section 5.2 |\n",
     "\n",
     "Chaque exercice a sa cellule guidee immédiatement au-dessus : en cas de blocage, etudiez le guide, puis revenez a la version a completer."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e85c0675",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "Le notebook suivant explore les graphes de connaissances (Knowledge Graphs), en combinant les technologies RDF, SPARQL et les patterns vus dans cette serie.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "**Navigation** : [<< 9-JSONLD](SW-9-Python-JSONLD.ipynb) | [Index](README.md) | [11-KnowledgeGraphs >>](SW-11-Python-KnowledgeGraphs.ipynb)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb
@@ -112,7 +112,9 @@
     "tags": []
    },
    "source": [
-    "Verifions la version de rdflib installee."
+    "Verifions la version de rdflib installee.\n",
+    "\n",
+    "La version importe ici plus qu'ailleurs : le support RDF-Star (`<< sujet predicat objet >>` en Turtle-Star) n'est entre dans rdflib qu'a partir de la generation 6.x, et son degre de maturite (parsing, serialisation, requetage SPARQL-Star) evolue encore. Ce notebook demontre donc d'abord **la reification classique rdf:Statement** — supportee par toutes les versions et par tous les outils RDF — avant de montrer, dans chaque interpretation, ce que la syntaxe RDF-Star changerait. Verifier la version en tête de notebook, c'est savoir d'avance quelles des variantes montrees sont executables et lesquelles restent de la documentation cible."
    ]
   },
   {
@@ -253,7 +255,12 @@
     "tags": []
    },
    "source": [
-    "Voyons cela en pratique avec rdflib : la reification classique est verbeuse mais fonctionnelle."
+    "Voyons cela en pratique avec rdflib : la reification classique est le mecanisme standardise (RDF 1.0) pour parler D'UN triplet. La cellule suivante construit a la main les 4 triplets `rdf:subject`, `rdf:predicate`, `rdf:object` et `rdf:type rdf:Statement` qui representent l'assertion « Bob connait Carol », puis lui attache une annotation de confiance.\n",
+    "\n",
+    "Observez deux choses en executant :\n",
+    "\n",
+    "1. **Le fait annoté existe en deux exemplaires independants** : le triplet simple `Bob connait Carol` d'un cote, la structure `rdf:Statement` de l'autre. Rien ne garantit qu'un consommateur du graphe les reliera — c'est la faille documentee dans l'interpretation qui suit.\n",
+    "2. **Le compte de triplets** passe de 1 a 6 pour une seule annotation : c'est ce cout qui motivera la section 2 (fonction utilitaire) puis la comparaison systematique avec RDF-Star."
    ]
   },
   {
@@ -623,12 +630,9 @@
    "source": [
     "### 3.1 Construction programmatique\n",
     "\n",
-    "Grace a la fonction `reify()`, la construction suit un pattern simple :\n",
-    "1. Ajouter le fait original au graphe\n",
-    "2. Appeler `reify()` pour créer le Statement\n",
-    "3. Ajouter les annotations sur le Statement retourne\n",
+    "Cette section attaque le probleme sous l'angle du **code** : au lieu d'ecrire les 4 triplets de reification a la main (section 1), on encapsule la mecanique dans une fonction `reify()` qui rend l'operation reutilisable et sure.\n",
     "\n",
-    "En RDF-Star, les étapes 2-3 se combineraient : le quoted triple `<< s p o >>` joue directement le rôle du Statement."
+    "L'interet pedagogique est de separer ce qui est **contrat RDF** (les 4 triplets sont imposes par la norme, aucun outil ne peut les contourner) de ce qui est **ergonomie de programmate** (l'API avec laquelle on les produit). Quand RDF-Star sera generalise, seule la deuxieme couche changera — la fonction `reify()` deviendra un simple `QuotedTriple(s, p, o)` — et le reste du pipeline (annotations, requetes) restera identique. C'est exactement la comparaison que dresse le tableau de l'interpretation suivante."
    ]
   },
   {
@@ -749,14 +753,9 @@
    "source": [
     "### 3.2 Annotations imbriquees (multi-niveaux)\n",
     "\n",
-    "RDF-Star permet l'imbrication : un quoted triple peut lui-même contenir un quoted triple. Par exemple : \"Alice rapporte que Bob croit que Carol connait Dave\".\n",
+    "Les annotations de la section precedente portaient sur des faits ; ici ce sont **les annotations elles-memes qui sont annotees**. Le cas d'usage : « Bob croit que (Carol connait Dave) », puis « Alice rapporte que (Bob croit que...) ». Chaque niveau d'imbrication ajoute un contexte epistemique — qui sait, qui croit, qui rapporte — sans toucher au fait de base.\n",
     "\n",
-    "En RDF-Star, cela s'ecrirait :\n",
-    "```turtle\n",
-    "<< << ex:Carol foaf:knows ex:Dave >> ex:believedBy ex:Bob >> ex:reportedBy ex:Alice .\n",
-    "```\n",
-    "\n",
-    "Avec la reification, on chaîne les Statements. Construisons cet exemple."
+    "Ce motif est la reponse RDF a un probleme reel des graphes de connaissances : une information n'a pas seulement une valeur, elle a une **chaine de garde**. En intelligence artificielle (agents qui citent d'autres agents, journalisme collaboratif, ouï-dire dans un reseau social), savoir *qui affirme* est aussi important que *ce qui est affirme*. La cellule suivante construit deux niveaux d'imbrication avec la reification classique — comptez les triplets au passage, l'explosion combinatoire est le prix du sans-RDF-Star."
    ]
   },
   {
@@ -922,7 +921,9 @@
    "source": [
     "### 4.1 Construire un graphe de connaissances annote\n",
     "\n",
-    "Creons un graphe plus riche avec des relations annotees : provenance, confiance et dates."
+    "Cette section assemble les briques des sections 1-3 dans un cas d'usage complet : un mini reseau social ou **chaque relation porte sa confiance, sa source et sa date**. C'est le format que produisent reellement les pipelines d'extraction d'information (le notebook SW-12 GraphRAG construit exactement ce genre de graphe a partir d'un LLM).\n",
+    "\n",
+    "Quatre relations y sont encodees, dont une (`Alice connait Dave`, confiance 0.50) qui n'est **pas assertee** — elle n'existe que comme mention annotée. Cette distinction asserte/mentionnee est la motivation profonde de toute la machinerie de reification : un moteur d'inference ne doit pas traiter une rumeur comme un fait. Les requetes SPARQL des cellules 4.2 et 4.3 exploiteront precisement ces annotations pour trier le grain de l'ivraie."
    ]
   },
   {
@@ -1100,7 +1101,9 @@
    "source": [
     "### 4.2 Requêtes SPARQL sur les reifications\n",
     "\n",
-    "Interrogeons le graphe avec SPARQL standard pour extraire les annotations via les patterns de reification."
+    "Annoter ne sert a rien si l'on ne peut pas **interroger** les annotations. Cette cellule montre la premiere requete : retrouver toutes les relations annotees avec leur niveau de confiance.\n",
+    "\n",
+    "Le pattern SPARQL a observer : on ne cherche plus des triplets `?s ?p ?o` directement, mais des `?stmt rdf:type rdf:Statement` dont on deplie ensuite les trois composants `rdf:subject`, `rdf:predicate`, `rdf:object` plus les annotations. La requete est plus verbeuse qu'un motif simple — c'est le cout en lecture de ce que la reification a ajoute en ecriture — mais elle donne acces a une dimension qu'un graphe plat n'a pas : les metadonnees deviennent des donnees de premiere classe, filtrables, aggregables, joignables."
    ]
   },
   {
@@ -1353,14 +1356,9 @@
    "source": [
     "### 5.1 Provenance et attribution\n",
     "\n",
-    "Le cas d'usage le plus naturel : enregistrer **qui** a produit une information, **quand**, et avec **quelle méthode**. Ce pattern s'integre naturellement avec le vocabulaire PROV-O du W3C.\n",
+    "Apres la confiance (qualitative), la **provenance** (d'ou vient le fait ?). Le cas d'usage : deux attributs de Paris — population et superficie — extraits de sources officielles differentes (INSEE pour le recensement, IGN pour la mesure cadastrale), chacune avec sa date et sa methode.\n",
     "\n",
-    "En RDF-Star, cela s'ecrirait de maniere compacte :\n",
-    "```turtle\n",
-    "<< ex:Paris schema:population \"2161000\"^^xsd:integer >>\n",
-    "    prov:wasDerivedFrom ex:INSEE_2023 ;\n",
-    "    prov:generatedAtTime \"2023-12-01\"^^xsd:date .\n",
-    "```"
+    "Ce pattern `prov:wasDerivedFrom` est le socle du W3C PROV, le vocabulaire standard de traçage de provenance. Dans un contexte ou plusieurs sources affirment des valeurs contradictoires pour un meme attribut (le notebook 5.3 y vient), la provenance permet de **trancher par autorite** plutot que par hasard d'ordre d'insertion. L'interpretation suivante montre la version RDF-Star cote a cote : 4 triplets economises par fait annote, la provenance redevient une annotation d'une ligne."
    ]
   },
   {
@@ -2081,7 +2079,9 @@
    "source": [
     "### Serialisation d'un graphe avec reification\n",
     "\n",
-    "Testons les formats disponibles dans rdflib pour un graphe contenant des reifications."
+    "La serialisation est le test de vérité de toute structure RDF : ce qui ne survit pas a un aller-retour texte -> graphe n'existe pas vraiment. Cette cellule ecrit le meme graphe reifie dans plusieurs formats standards (Turtle, N-Triples, RDF/XML, JSON-LD) pour observer comment chacun materialise les blank nodes `rdf:Statement`.\n",
+    "\n",
+    "L'enjeu pratique : deux outils echangent un graphe annote — un extracteur produit du JSON-LD, un triplestore consomme du Turtle. Si la reification est correctement encodee, les annotations traversent ; sinon elles sont silencieusement perdues a la frontiere des formats. Comparez la taille des sorties entre formats au passage : le cout de verbosite de la reification, visible en triplets depuis la section 1, se retrouve amplifie en octets dans les formats verbeux."
    ]
   },
   {
@@ -2884,11 +2884,17 @@
    "source": [
     "---\n",
     "\n",
-    "Le notebook suivant explore les graphes de connaissances (Knowledge Graphs), en combinant les technologies RDF, SPARQL et les patterns vus dans cette serie.\n",
+    "## Exercices\n",
     "\n",
-    "---\n",
+    "Les exemples guides 1 a 3 ci-dessus (critiques de film, requetage SPARQL des reifications, graphe de confiance) demontrent les briques ; les exercices 4 a 6 qui suivent reclament de les **transposer** a des domaines nouveaux :\n",
     "\n",
-    "**Navigation** : [<< 9-JSONLD](SW-9-Python-JSONLD.ipynb) | [Index](README.md) | [11-KnowledgeGraphs >>](SW-11-Python-KnowledgeGraphs.ipynb)"
+    "| Exercice | Domaine | Brique exercee | Guide correspondant |\n",
+    "|----------|---------|----------------|---------------------|\n",
+    "| 4 : Donnees sportives multi-sources | Scores de matchs | Reification + confiance par source | Exemple guide 1 |\n",
+    "| 5 : Agregats SPARQL sur scores | Statistiques | Requetes sur annotations | Exemple guide 2 |\n",
+    "| 6 : Annotations temporelles historiques | Evenements dates | Validite temporelle d'un fait | Section 5.2 |\n",
+    "\n",
+    "Chaque exercice a sa cellule guidee immédiatement au-dessus : en cas de blocage, etudiez le guide, puis revenez a la version a completer."
    ]
   },
   {
@@ -3503,13 +3509,16 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Ce notebook a permis d'explorer les aspects essentiels de sw 10 python rdfstar. Les points cles :\n",
+    "Ce parcours a demontre une seule chose sous six angles : **parler d'un triplet** — l'annoter, le dater, le sourcer, le nuancer — demande une machinerie que le RDF classique n'offre qu'au prix de la reification (4 triplets de structure par fait annote), et que RDF-Star promet d'obtenir nativement.\n",
     "\n",
-    "- Les concepts fondamentaux ont ete presentes et illustres\n",
-    "- Les Exercices proposent une mise en pratique progressive\n",
-    "- Les résultats obtenus permettent de valider la comprehension\n",
+    "| Concept demontre | Avec la reification classique | Ce que RDF-Star changera |\n",
+    "|---|---|---|\n",
+    "| Annoter un fait (confiance, source, date) | 4 + N triplets, existence non garantie | 1 + N, assertion configurable |\n",
+    "| Imbriquer les croyances (Bob croit qu'Alice rapporte...) | Cascade de BNode illisible | `<< << ... >> >>` |\n",
+    "| Requeter les metadonnees | Motif `rdf:Statement` a deplier | Motif direct sur triplets quotés |\n",
+    "| Grouper par contexte | Graphes nommes Dataset | Complementaire (les deux se combinent) |\n",
     "\n",
-    "**Pour aller plus loin** : approfondir les aspects avances du sujet et explorer les liens avec d'autres domaines."
+    "La leçon methodologique independante de l'outillage : un graphe de connaissances utile n'est pas un sac de faits vrais, c'est un sac de faits **qualifies** — par confiance, provenance, temporalite. Le mecanisme exact (reification aujourd'hui, RDF-Star demain) est un detail d'implementation ; les dimensions d'annotation, elles, sont la competence transferable vers SW-12 (GraphRAG) et tout pipeline d'extraction d'information."
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
@@ -16,6 +16,12 @@
       python_sha: 2043be1e638157cf01189d44cfa70f5c4ae061d0
       csharp_sha: e184307cf2a6180399e776bf200058e283fb9bf2
       reason: "Identity/phantom fix (Python cell 58 footer Navigation): the display labels were off-by-one vs the notebook OWN header (cell 0). Header says « 9-JSONLD » and « 11-KnowledgeGraphs », but the footer said « 10-JSONLD » and « 12-KnowledgeGraphs ». The link URLs were already correct in both (SW-9-Python-JSONLD.ipynb, SW-11-Python-KnowledgeGraphs.ipynb) -- only the human-readable labels were wrong. Fixed the 2 footer labels to match the header. Markdown-only, 0 re-exec, no output change. No §D.5 (identity/phantom class, not a measure/value drift). C# twin SW-10-CSharp-RDFStar nav uses a different structure (points to the Python jumeau, no KnowledgeGraphs forward link) and is correct -> csharp unchanged."
+    - date: "2026-08-20"
+      by: myia-po-2026:CoursIA
+      python_sha: e0ab6644e61cd72a7a1a6aff3d5ac39181bf9f6b
+      csharp_sha: e184307cf2a6180399e776bf200058e283fb9bf2
+      content_python_sha: a744d091ca142cd7bb5a083eebf29ae36d8e95225c0e6e602f0a48b0701dcbd3
+      content_csharp_sha: 3838b11ac074fbc5ab81e9cba575f6b3bf3891c1c0a3eb1743994cd449184107
   known_differences:
     - "Socle commun : meta-modelisation RDF-star (triplets sur des triplets, quotes nestees)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query` support RDF-star). Python = `rdflib` (`rdflib.term` triplets-nommes). RDF-star est une extension communautaire (pas encore W3C standardise) ; support experimental des deux cotes."


### PR DESCRIPTION
Perimetre : 2 fichiers — MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-Python-RDFStar.ipynb (enrichissement densite) + scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml (attestation twin du repair footer nav).

Tranche densite round 2 de l'umbrella #11601 : SW-10-Python-RDFStar **1269 -> 1534** c/cell (metrique canonique `pedagogy_density.py`, seuil round 2 = 1500). Suite immediate de la tranche SW-12 (#11906, meme recette).

## Ce qui a ete fait

Enrichissement **markdown-only** de 10 cellules de transition squelettiques (31-435ch -> 500-1000ch chacune) :

| Cellule | Contenu ajoute |
|---|---|
| Version rdflib | Pourquoi la version importe (support RDF-Star generation 6.x) |
| Demo reification classique | Les 2 observations cles avant exec : fait en double exemplaire, cout 1 -> 6 triplets |
| Construction programmatique | Separation contrat RDF vs ergonomie API, ce qui survivra a RDF-Star |
| Annotations imbriquees | Chaine de garde epistemique (qui croit, qui rapporte), motivation KG |
| Graphe de connaissances annote | Format des pipelines d'extraction reels, jonction SW-12 GraphRAG, asserte vs mentionne |
| Requetes SPARQL sur reifications | Pattern rdf:Statement a deplier, metadonnees = donnees de premiere classe |
| Provenance et attribution | Socle W3C PROV, trancher par autorite |
| Section exercices | Table exercice -> domaine -> brique -> guide correspondant |
| Serialisation | Test de verite aller-retour texte -> graphe, perte silencieuse a la frontiere des formats |
| Conclusion | Table synthese par concept demontre + lecon methodologique transferable |

## Validation

- **Densite canonique** : 1534 (29209 -> 35483 chars prose, 23 cellules code) — 0 below threshold
- **Markdown-only** : diff 41+/32-, **0** changement `execution_count`, **0** changement `outputs` (exception C.2)
- **Validateur PR** : `validate_pr_notebooks.py` PASS
- **Ancrage** : prose ancree aux demos reelles du notebook (reification Bob/Carol, KG social avec confiances 0.95/0.60/0.30, provenance Paris INSEE/IGN, annotations temporelles MIT->CNRS->Sorbonne, graphes nommes alice/bob) — aucun claim sur sortie inexistante
- Pre-commit hooks : tous PASS

Grain: MED/notebook-python — lane myia-po-2026:CoursIA — prev: MED/notebook-python #11906 (SW-12, meme rollout umbrella -- variance de lane conservee par famille distincte du prev-genre lane HIGH/lean-proof)

See #11601 (tranche, acceptance umbrella non atteinte : 4/189)

