### PR TITLE
feat(probas,#11601): DecInfer-9 Gittins density tranche 1316 -> 1527

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb
@@ -847,8 +847,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "\n",
     "## 3. Politiques de decision\n",
     "\n",
     "### 3.1 Politique gloutonne (greedy)\n",
@@ -2497,8 +2495,6 @@
     "tags": []
    },
    "source": [
-    "---\n",
-    "\n",
     "## 6. Exemples numeriques\n",
     "\n",
     "### Exemple guide 1 : Bandit a 2 bras Bernoulli\n",

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb
@@ -853,7 +853,14 @@
     "\n",
     "### 3.1 Politique gloutonne (greedy)\n",
     "\n",
-    "La politique la plus simple : a chaque étape, jouer le bras avec la meilleure moyenne empirique. Le problème : elle peut se bloquer sur un bras sous-optimal si l'exploration initiale est defavorable."
+    "La politique la plus simple : a chaque etape, jouer le bras avec la meilleure moyenne empirique. Le probleme : elle peut se bloquer sur un bras sous-optimal si l'exploration initiale est defavorable.\n",
+    "\n",
+    "Cette section est le pivot pedagogique du notebook : jusqu'ici (sections 1-2) on a defini le **cadre** — bandit, somme actualisee, propriete geometrique du facteur d'actualisation. A partir de maintenant, la question change de nature : parmi toutes les strategies jouables, lesquelles sont **prouvablement bonnes** ? La reponse s'obtient en deux temps, et les deux cellules qui suivent les incarnent :\n",
+    "\n",
+    "1. La cellule greedy formalise la strategie la plus naturelle (exploiter ce qui semble le meilleur) — lisible, mais non optimale ;\n",
+    "2. La cellule contre-exemple prouve en Lean **pourquoi** elle echoue : un scenario a 2 bras ou la moyenne empirique apres un tirage ment sur l'ordre reel des bras (0.8 observe contre 0.3 vrai ; 0.2 observe contre 0.7 vrai), et ou le greedy, fige sur cette erreur initiale, ne s'en remet jamais.\n",
+    "\n",
+    "Le contre-exemple n'est pas decoratif : c'est lui qui **motive** l'indice de Gittins de la section 4 — une politique qui ne peut pas se bloquer, parce qu'elle valorise l'incertitude residuelle au lieu de l'ignorer."
    ]
   },
   {
@@ -2492,16 +2499,20 @@
    "source": [
     "---\n",
     "\n",
-    "## 6. Exemples numériques\n",
+    "## 6. Exemples numeriques\n",
     "\n",
     "### Exemple guide 1 : Bandit a 2 bras Bernoulli\n",
     "\n",
-    "Scénario :\n",
+    "Scenario :\n",
     "- Bras A : Bernoulli(0.3), prior Beta(1,1)\n",
     "- Bras B : Bernoulli(0.7), prior Beta(1,1)\n",
     "- $\\gamma = 0.95$\n",
     "\n",
-    "Après 10 tirages de chaque bras, calculer les indices de Gittins approximes et determiner quel bras jouer."
+    "Apres 10 tirages de chaque bras, calculer les indices de Gittins approximes et determiner quel bras jouer.\n",
+    "\n",
+    "Cette derniere section redescend du formel au numerique, et c'est un mouvement pedagogique assumé : les theoremes des sections 3-5 garantissent que l'indice de Gittins est optimal, mais **aucun d'eux ne dit comment le calculer**. La cellule suivante encadre le compromis entre exactitude et cout, sur le cas le plus classique (bras Bernoulli, conjugaison Beta-Binomiale).\n",
+    "\n",
+    "Les parametres a posteriori suivent la regle de conjugaison : observer 3 succes en 10 tirages sur un prior Beta(1,1) donne Beta(4,8) — moyenne 0.333 ; observer 7 succes donne Beta(8,4) — moyenne 0.667. Le calcul de l'indice lui-meme (une supremum sur les politiques d'arret actualisees) n'a pas de forme close : le notebook le calcule par la borne d'approximation etablie en section 4, exactement comme le font les implementations de reference. Comparez l'indice du bras A obtenu avec la colonne « Incertitude » du tableau de la section 4.2 : un bras mal connu garde un indice superieur a sa moyenne — c'est le fantême du bonus d'exploration UCB1, qui reapparait ici sous forme bayesienne."
    ]
   },
   {


### PR DESCRIPTION
Perimetre : 1 fichier (MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-9-Lean-Gittins.ipynb).

Tranche densite round 2 de l'umbrella #11601 : DecInfer-9-Lean-Gittins **1316 -> 1527** c/cell (metrique canonique `pedagogy_density.py`). Troisieme tranche de la session (SW-12 #11906 ALL_GREEN, SW-10 #11907 en CI).

## Ce qui a ete fait

Enrichissement **markdown-only** des 2 cellules de transition squelettiques (les seules sous 400ch du notebook) :

| Cellule | Avant | Contenu ajoute |
|---|---|---|
| Transition section 3 (politiques) | 272ch | Le pivot pedagogique du notebook : la question passe de « definir le cadre » (sections 1-2) a « quelles strategies sont prouvablement bonnes » ; role des 2 cellules qui suivent (formalisation greedy, contre-exemple) ; pourquoi le contre-exemple motive l'indice de Gittins |
| Transition section 6 (exemples) | 303ch | Le mouvement formel -> numerique assume : les theoremes garantissent l'optimalite mais aucun ne dit comment calculer l'indice ; regle de conjugaison Beta appliquee au scenario (3 succes/10 -> Beta(4,8) moyenne 0.333) ; lien avec la colonne Incertitude du tableau 4.2 et le bonus UCB1 |

## Validation

- **Densite canonique** : 1527 (13161 -> 15271 chars prose, 10 cellules code) — 0 below threshold
- **Markdown-only** : diff 15+/4-, **0** changement `execution_count`, **0** changement `outputs` (exception C.2)
- **Validateur PR** : `validate_pr_notebooks.py` PASS (10 cells, kernel lean4-wsl)
- **Ancrage** : prose ancree aux demos reelles du notebook — contre-exemple greedy (0.8 observe / 0.3 vrai vs 0.2 / 0.7 vrai, visible dans l'output committe cell[10]), posterieurs Beta(4,8)/Beta(8,4) du scenario cell[21], tableau priors de la section 4.2
- Pre-commit hooks : tous PASS

## Note perimetre Lean

Ce notebook est un Lean notebook (kernel lean4-wsl) mais la tranche est **markdown-only** : aucune preuve, aucun tactic, aucun bloc Lean touche — seule la prose d'encadrement pedagogique. Pas de `grep -c sorry` a produire (sources Lean inchanges, diff = 15 insertions markdown).

Grain: MED/notebook-python — lane myia-po-2026:CoursIA — prev: MED/notebook-python #11907 (SW-10, meme rollout umbrella, famille distincte du prev-genre lane)

See #11601 (tranche, acceptance umbrella non atteinte : 5/189)
