### PR TITLE
fix(twin,#11878): main rouge — re-attester Probas-13, blob orphelin par squash

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml
@@ -27,6 +27,12 @@
       csharp_sha: bd40c841e1432ae51fe6b34fa7c6977569c5feb3
       content_python_sha: e13cd18278d50e554dba2ee3c64b36240335c15b36ece62fc85157d210ceba0d
       content_csharp_sha: fc82fa1b910d12205b6c3c197b690f2e57d212a4457ec0f0585f62c7c4c80fb4
+    - date: "2026-08-20"
+      by: myia-ai-01:CoursIA
+      python_sha: 246ba905ee53e1dcbae37a711e47a1622eac72b7
+      csharp_sha: efce50915b827a78caa4fd913531b0aaf26d3169
+      content_python_sha: e13cd18278d50e554dba2ee3c64b36240335c15b36ece62fc85157d210ceba0d
+      content_csharp_sha: fc82fa1b910d12205b6c3c197b690f2e57d212a4457ec0f0585f62c7c4c80fb4
   known_differences:
   - '2026-07-28 (myia-po-2023) #8711 / See #8081 : FERME l''asymetrie sources entre jumeaux -- Infer-13 portait une
     cellule "Sources canoniques" (table Raykar 2010, Karger 2011, Dawid-Skene 1979, Whitehill 2009, Kim-Ghahramani


### PR DESCRIPTION
Grain: MED/ledger — lane myia-ai-01:CoursIA — prev: MED/guard #11916

**`main` était rouge.** `Scripts Tests (CPU)` échouait sur `main` lui-même — je l'ai découvert en diagnostiquant l'échec de ma propre PR #11916, et le contrôle sur `main` (`6257543c8`) rend exactement la même erreur. Toute PR ouverte héritait donc d'un rouge qu'aucune lane ne pouvait réparer chez elle.

## Le défaut

```
FAILED test_twin_registry_integrity.py::test_audit_shas_exist_in_file_history
  AssertionError: sha(s) du dernier audit jamais apparu(s) comme blob :
  Probas-13 Crowdsourcing.csharp_sha = bd40c841e143
```

C'est la classe **squash-orphan**. L'attestation du 2026-08-20 a été posée **en cours de branche** pendant #11878 (`Infer-13-Crowdsourcing DIRTY -> CLEAN 1..15`) ; le notebook a ensuite été retouché, et le squash a collapsé le commit intermédiaire. Le blob attesté n'a jamais atteint `main` — celui qui y est arrivé est `efce50915b82`.

Le détail qui rend le diagnostic sûr plutôt que plausible : `git cat-file -t bd40c841e143` répond **`blob`**. L'objet *existe* (il a été fetché avec la branche), il n'a simplement jamais été le blob de ce fichier dans un commit atteignable. Un test qui aurait cherché « l'objet existe-t-il ? » aurait donc répondu oui et manqué le défaut ; celui-ci cherche « a-t-il été le blob de ce fichier ? », et c'est la bonne question.

## Ce que la réparation change — et ce qu'elle ne change pas

| | avant | après |
|---|---|---|
| `csharp_sha` du dernier audit | `bd40c841e143` (jamais sur main) | `efce50915b82` (blob réel) |
| `content_csharp_sha` | `fc82fa1b910d` | `fc82fa1b910d` — **inchangé** |
| parité des jumeaux | `DRIFT=0` | `DRIFT=0` |

**Le contenu du notebook n'a pas bougé** : seule la comptabilité était périmée. C'est la signature même d'un squash — le contenu arrive, l'identité de l'objet intermédiaire non.

Vérification après coup, 157 paires : `OK=157 DRIFT=0 MISSING=0` et `MISMATCH=0`, et les 30 tests d'intégrité du registre passent.

## Un angle mort de l'outil, qui vaut d'être signalé

`--update` a **refusé** la réparation :

> `Refusees (no-op, --update facultatif) : les SHAs enregistres sont deja ceux du carnet a HEAD`

Le garde no-op (#9399 critère 2) compare les **content SHAs** — et par cette mesure, rien n'a effectivement changé. Mais le test d'intégrité, lui, vérifie les **blob SHAs**. Les deux instruments ne mesurent pas la même grandeur, si bien que l'outil canonique de réparation considère qu'il n'y a rien à réparer précisément dans le cas où il y a quelque chose à réparer. Il a fallu `--force`, qui affiche alors un avertissement de « faux audit » — trompeur ici : l'information nouvelle est réelle, elle est simplement invisible à la mesure qu'emploie le garde.

Ce n'est pas corrigé dans cette PR — je répare `main` d'abord, en scope étroit. Issue de suivi pour le garde : **#11919**.

## Périmètre

**1 fichier** : `scripts/notebook_tools/twin_pairs.d/probas-13-crowdsourcing.yaml` (+6 lignes, une entrée d'audit). Aucun notebook touché, aucun script modifié.

