### PR TITLE
feat(sudoku,#11801): v4 facteurs AllDiff arite 9 - Medium 9/11=82% sans couche deterministe

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "ef5ff599",
    "metadata": {
     "papermill": {
-     "duration": 0.004174,
-     "end_time": "2026-08-19T17:09:27.734141",
+     "duration": 0.005131,
+     "end_time": "2026-08-20T08:48:02.056448+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:27.729967",
+     "start_time": "2026-08-20T08:48:02.051317+00:00",
      "status": "completed"
     },
     "tags": []
@@ -25,6 +25,7 @@
     "2. **Implementer** un modèle probabiliste avec distributions Dirichlet et contraintes douces\n",
     "3. **Utiliser** SVI (Stochastic Variational Inference) pour l'inference\n",
     "4. **Comparer** avec l'approche Infer.NET RobustProbabilisticSolver du notebook C#\n",
+    "5. **Évaluer** la v4 : facteurs AllDiff d'arité 9 (messages exacts par permanente) face au critère « Medium ≥ 80 % sans propagation déterministe » (#11801)\n",
     "\n",
     "**Duree estimee** : ~45 min | **Prerequis** : Sudoku-0 Environment, probabilites bayesiennes\n",
     "\n",
@@ -50,10 +51,10 @@
    "id": "6572477a",
    "metadata": {
     "papermill": {
-     "duration": 0.002668,
-     "end_time": "2026-08-19T17:09:27.740061",
+     "duration": 0.004188,
+     "end_time": "2026-08-20T08:48:02.065257+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:27.737393",
+     "start_time": "2026-08-20T08:48:02.061069+00:00",
      "status": "completed"
     },
     "tags": []
@@ -68,16 +69,16 @@
    "id": "7cf1c89c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:27.746422Z",
-     "iopub.status.busy": "2026-08-19T17:09:27.746105Z",
-     "iopub.status.idle": "2026-08-19T17:09:29.159210Z",
-     "shell.execute_reply": "2026-08-19T17:09:29.158348Z"
+     "iopub.execute_input": "2026-08-20T08:48:02.075853Z",
+     "iopub.status.busy": "2026-08-20T08:48:02.075466Z",
+     "iopub.status.idle": "2026-08-20T08:48:03.275162Z",
+     "shell.execute_reply": "2026-08-20T08:48:03.274475Z"
     },
     "papermill": {
-     "duration": 1.417766,
-     "end_time": "2026-08-19T17:09:29.160462",
+     "duration": 1.205927,
+     "end_time": "2026-08-20T08:48:03.275761+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:27.742696",
+     "start_time": "2026-08-20T08:48:02.069834+00:00",
      "status": "completed"
     },
     "tags": []
@@ -124,10 +125,10 @@
    "id": "e0ca3e38",
    "metadata": {
     "papermill": {
-     "duration": 0.005779,
-     "end_time": "2026-08-19T17:09:29.169753",
+     "duration": 0.004502,
+     "end_time": "2026-08-20T08:48:03.286017+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.163974",
+     "start_time": "2026-08-20T08:48:03.281515+00:00",
      "status": "completed"
     },
     "tags": []
@@ -157,10 +158,10 @@
    "id": "7e052680",
    "metadata": {
     "papermill": {
-     "duration": 0.005005,
-     "end_time": "2026-08-19T17:09:29.180911",
+     "duration": 0.00405,
+     "end_time": "2026-08-20T08:48:03.294304+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.175906",
+     "start_time": "2026-08-20T08:48:03.290254+00:00",
      "status": "completed"
     },
     "tags": []
@@ -175,16 +176,16 @@
    "id": "ef0ada77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:29.190935Z",
-     "iopub.status.busy": "2026-08-19T17:09:29.190673Z",
-     "iopub.status.idle": "2026-08-19T17:09:29.211058Z",
-     "shell.execute_reply": "2026-08-19T17:09:29.210574Z"
+     "iopub.execute_input": "2026-08-20T08:48:03.303553Z",
+     "iopub.status.busy": "2026-08-20T08:48:03.303310Z",
+     "iopub.status.idle": "2026-08-20T08:48:03.312422Z",
+     "shell.execute_reply": "2026-08-20T08:48:03.311871Z"
     },
     "papermill": {
-     "duration": 0.028181,
-     "end_time": "2026-08-19T17:09:29.212149",
+     "duration": 0.014641,
+     "end_time": "2026-08-20T08:48:03.312959+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.183968",
+     "start_time": "2026-08-20T08:48:03.298318+00:00",
      "status": "completed"
     },
     "tags": []
@@ -308,10 +309,10 @@
    "id": "6a898168",
    "metadata": {
     "papermill": {
-     "duration": 0.002981,
-     "end_time": "2026-08-19T17:09:29.220180",
+     "duration": 0.004074,
+     "end_time": "2026-08-20T08:48:03.321107+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.217199",
+     "start_time": "2026-08-20T08:48:03.317033+00:00",
      "status": "completed"
     },
     "tags": []
@@ -343,10 +344,10 @@
    "id": "074bd1c4",
    "metadata": {
     "papermill": {
-     "duration": 0.003043,
-     "end_time": "2026-08-19T17:09:29.228278",
+     "duration": 0.004186,
+     "end_time": "2026-08-20T08:48:03.329309+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.225235",
+     "start_time": "2026-08-20T08:48:03.325123+00:00",
      "status": "completed"
     },
     "tags": []
@@ -367,16 +368,16 @@
    "id": "36e448cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:29.240235Z",
-     "iopub.status.busy": "2026-08-19T17:09:29.239835Z",
-     "iopub.status.idle": "2026-08-19T17:09:29.247430Z",
-     "shell.execute_reply": "2026-08-19T17:09:29.246768Z"
+     "iopub.execute_input": "2026-08-20T08:48:03.338755Z",
+     "iopub.status.busy": "2026-08-20T08:48:03.338566Z",
+     "iopub.status.idle": "2026-08-20T08:48:03.345580Z",
+     "shell.execute_reply": "2026-08-20T08:48:03.345078Z"
     },
     "papermill": {
-     "duration": 0.01516,
-     "end_time": "2026-08-19T17:09:29.249085",
+     "duration": 0.012802,
+     "end_time": "2026-08-20T08:48:03.346278+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.233925",
+     "start_time": "2026-08-20T08:48:03.333476+00:00",
      "status": "completed"
     },
     "tags": []
@@ -474,10 +475,10 @@
    "id": "33e976ac",
    "metadata": {
     "papermill": {
-     "duration": 0.006675,
-     "end_time": "2026-08-19T17:09:29.263320",
+     "duration": 0.004232,
+     "end_time": "2026-08-20T08:48:03.354788+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.256645",
+     "start_time": "2026-08-20T08:48:03.350556+00:00",
      "status": "completed"
     },
     "tags": []
@@ -497,16 +498,16 @@
    "id": "d612595c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:29.277814Z",
-     "iopub.status.busy": "2026-08-19T17:09:29.277475Z",
-     "iopub.status.idle": "2026-08-19T17:09:29.283557Z",
-     "shell.execute_reply": "2026-08-19T17:09:29.282912Z"
+     "iopub.execute_input": "2026-08-20T08:48:03.364303Z",
+     "iopub.status.busy": "2026-08-20T08:48:03.364127Z",
+     "iopub.status.idle": "2026-08-20T08:48:03.370911Z",
+     "shell.execute_reply": "2026-08-20T08:48:03.369978Z"
     },
     "papermill": {
-     "duration": 0.014812,
-     "end_time": "2026-08-19T17:09:29.285024",
+     "duration": 0.012592,
+     "end_time": "2026-08-20T08:48:03.371548+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.270212",
+     "start_time": "2026-08-20T08:48:03.358956+00:00",
      "status": "completed"
     },
     "tags": []
@@ -577,10 +578,10 @@
    "id": "75beac6f",
    "metadata": {
     "papermill": {
-     "duration": 0.004997,
-     "end_time": "2026-08-19T17:09:29.297152",
+     "duration": 0.003923,
+     "end_time": "2026-08-20T08:48:03.379996+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.292155",
+     "start_time": "2026-08-20T08:48:03.376073+00:00",
      "status": "completed"
     },
     "tags": []
@@ -595,16 +596,16 @@
    "id": "a55a60b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:29.309169Z",
-     "iopub.status.busy": "2026-08-19T17:09:29.308753Z",
-     "iopub.status.idle": "2026-08-19T17:09:37.470889Z",
-     "shell.execute_reply": "2026-08-19T17:09:37.469780Z"
+     "iopub.execute_input": "2026-08-20T08:48:03.388811Z",
+     "iopub.status.busy": "2026-08-20T08:48:03.388660Z",
+     "iopub.status.idle": "2026-08-20T08:48:10.362731Z",
+     "shell.execute_reply": "2026-08-20T08:48:10.361869Z"
     },
     "papermill": {
-     "duration": 8.168946,
-     "end_time": "2026-08-19T17:09:37.472250",
+     "duration": 6.979421,
+     "end_time": "2026-08-20T08:48:10.363385+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:29.303304",
+     "start_time": "2026-08-20T08:48:03.383964+00:00",
      "status": "completed"
     },
     "tags": []
@@ -637,7 +638,7 @@
      "text": [
       "\n",
       "\n",
-      "Solution (inference: 8.2s):\n",
+      "Solution (inference: 7.0s):\n",
       "-------------------------\n",
       "| 9 6 2 | 1 8 5 | 4 7 3 |\n",
       "| 1 7 4 | 9 6 3 | 8 2 5 |\n",
@@ -654,8 +655,8 @@
       "\n",
       "Resultats:\n",
       "  - Iterations SVI: 300\n",
-      "  - Temps inference: 8.2s\n",
-      "  - Temps total: 8.2s\n",
+      "  - Temps inference: 7.0s\n",
+      "  - Temps total: 7.0s\n",
       "  - Converge: True\n",
       "  - Erreurs: 0\n"
      ]
@@ -691,10 +692,10 @@
    "id": "a7db79c3",
    "metadata": {
     "papermill": {
-     "duration": 0.005209,
-     "end_time": "2026-08-19T17:09:37.482126",
+     "duration": 0.007588,
+     "end_time": "2026-08-20T08:48:10.377532+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.476917",
+     "start_time": "2026-08-20T08:48:10.369944+00:00",
      "status": "completed"
     },
     "tags": []
@@ -726,10 +727,10 @@
    "id": "0df3f512",
    "metadata": {
     "papermill": {
-     "duration": 0.005465,
-     "end_time": "2026-08-19T17:09:37.492871",
+     "duration": 0.007381,
+     "end_time": "2026-08-20T08:48:10.392127+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.487406",
+     "start_time": "2026-08-20T08:48:10.384746+00:00",
      "status": "completed"
     },
     "tags": []
@@ -761,16 +762,16 @@
    "id": "8449e4d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:37.505813Z",
-     "iopub.status.busy": "2026-08-19T17:09:37.505259Z",
-     "iopub.status.idle": "2026-08-19T17:09:37.514167Z",
-     "shell.execute_reply": "2026-08-19T17:09:37.513147Z"
+     "iopub.execute_input": "2026-08-20T08:48:10.403957Z",
+     "iopub.status.busy": "2026-08-20T08:48:10.403724Z",
+     "iopub.status.idle": "2026-08-20T08:48:10.409720Z",
+     "shell.execute_reply": "2026-08-20T08:48:10.409141Z"
     },
     "papermill": {
-     "duration": 0.017527,
-     "end_time": "2026-08-19T17:09:37.515909",
+     "duration": 0.013154,
+     "end_time": "2026-08-20T08:48:10.410326+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.498382",
+     "start_time": "2026-08-20T08:48:10.397172+00:00",
      "status": "completed"
     },
     "tags": []
@@ -871,10 +872,10 @@
    "id": "ex-count-candidates",
    "metadata": {
     "papermill": {
-     "duration": 0.00689,
-     "end_time": "2026-08-19T17:09:37.530407",
+     "duration": 0.00447,
+     "end_time": "2026-08-20T08:48:10.419595+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.523517",
+     "start_time": "2026-08-20T08:48:10.415125+00:00",
      "status": "completed"
     },
     "tags": []
@@ -902,16 +903,16 @@
    "id": "ex-count-candidates-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:37.542563Z",
-     "iopub.status.busy": "2026-08-19T17:09:37.542015Z",
-     "iopub.status.idle": "2026-08-19T17:09:37.549185Z",
-     "shell.execute_reply": "2026-08-19T17:09:37.548156Z"
+     "iopub.execute_input": "2026-08-20T08:48:10.430078Z",
+     "iopub.status.busy": "2026-08-20T08:48:10.429886Z",
+     "iopub.status.idle": "2026-08-20T08:48:10.435074Z",
+     "shell.execute_reply": "2026-08-20T08:48:10.434429Z"
     },
     "papermill": {
-     "duration": 0.01487,
-     "end_time": "2026-08-19T17:09:37.550306",
+     "duration": 0.011325,
+     "end_time": "2026-08-20T08:48:10.435570+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.535436",
+     "start_time": "2026-08-20T08:48:10.424245+00:00",
      "status": "completed"
     },
     "tags": []
@@ -979,10 +980,10 @@
    "id": "19ab91a8",
    "metadata": {
     "papermill": {
-     "duration": 0.003357,
-     "end_time": "2026-08-19T17:09:37.560173",
+     "duration": 0.004518,
+     "end_time": "2026-08-20T08:48:10.444637+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.556816",
+     "start_time": "2026-08-20T08:48:10.440119+00:00",
      "status": "completed"
     },
     "tags": []
@@ -999,16 +1000,16 @@
    "id": "2dab7e0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:37.568378Z",
-     "iopub.status.busy": "2026-08-19T17:09:37.567953Z",
-     "iopub.status.idle": "2026-08-19T17:09:37.579223Z",
-     "shell.execute_reply": "2026-08-19T17:09:37.578177Z"
+     "iopub.execute_input": "2026-08-20T08:48:10.454751Z",
+     "iopub.status.busy": "2026-08-20T08:48:10.454562Z",
+     "iopub.status.idle": "2026-08-20T08:48:10.462582Z",
+     "shell.execute_reply": "2026-08-20T08:48:10.462096Z"
     },
     "papermill": {
-     "duration": 0.016845,
-     "end_time": "2026-08-19T17:09:37.580287",
+     "duration": 0.014261,
+     "end_time": "2026-08-20T08:48:10.463408+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.563442",
+     "start_time": "2026-08-20T08:48:10.449147+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1097,10 +1098,10 @@
    "id": "bc0f034f",
    "metadata": {
     "papermill": {
-     "duration": 0.006202,
-     "end_time": "2026-08-19T17:09:37.590293",
+     "duration": 0.004121,
+     "end_time": "2026-08-20T08:48:10.471751+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.584091",
+     "start_time": "2026-08-20T08:48:10.467630+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1115,16 +1116,16 @@
    "id": "d42a58fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:09:37.604757Z",
-     "iopub.status.busy": "2026-08-19T17:09:37.604511Z",
-     "iopub.status.idle": "2026-08-19T17:16:38.904953Z",
-     "shell.execute_reply": "2026-08-19T17:16:38.904059Z"
+     "iopub.execute_input": "2026-08-20T08:48:10.481292Z",
+     "iopub.status.busy": "2026-08-20T08:48:10.481138Z",
+     "iopub.status.idle": "2026-08-20T08:55:36.713634Z",
+     "shell.execute_reply": "2026-08-20T08:55:36.712924Z"
     },
     "papermill": {
-     "duration": 421.310758,
-     "end_time": "2026-08-19T17:16:38.908191",
+     "duration": 446.242811,
+     "end_time": "2026-08-20T08:55:36.719008+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:09:37.597433",
+     "start_time": "2026-08-20T08:48:10.476197+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1145,8 +1146,8 @@
       "Puzzle 1: OK\n",
       "  - Etapes: 36\n",
       "  - Cellules fixees (probabiliste): 36\n",
-      "  - Temps inference: 172.1s\n",
-      "  - Temps total: 187.8s\n"
+      "  - Temps inference: 173.1s\n",
+      "  - Temps total: 185.1s\n"
      ]
     },
     {
@@ -1157,8 +1158,8 @@
       "Puzzle 2: OK\n",
       "  - Etapes: 49\n",
       "  - Cellules fixees (probabiliste): 49\n",
-      "  - Temps inference: 215.1s\n",
-      "  - Temps total: 233.5s\n"
+      "  - Temps inference: 244.1s\n",
+      "  - Temps total: 261.1s\n"
      ]
     }
    ],
@@ -1193,10 +1194,10 @@
    "id": "44d951b2",
    "metadata": {
     "papermill": {
-     "duration": 0.003528,
-     "end_time": "2026-08-19T17:16:38.915292",
+     "duration": 0.005106,
+     "end_time": "2026-08-20T08:55:36.729443+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:16:38.911764",
+     "start_time": "2026-08-20T08:55:36.724337+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1229,10 +1230,10 @@
    "id": "ex-verify-deterministic",
    "metadata": {
     "papermill": {
-     "duration": 0.003726,
-     "end_time": "2026-08-19T17:16:38.922812",
+     "duration": 0.005126,
+     "end_time": "2026-08-20T08:55:36.739715+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:16:38.919086",
+     "start_time": "2026-08-20T08:55:36.734589+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1260,16 +1261,16 @@
    "id": "ex-verify-deterministic-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:16:38.931412Z",
-     "iopub.status.busy": "2026-08-19T17:16:38.931147Z",
-     "iopub.status.idle": "2026-08-19T17:16:38.937211Z",
-     "shell.execute_reply": "2026-08-19T17:16:38.936727Z"
+     "iopub.execute_input": "2026-08-20T08:55:36.752150Z",
+     "iopub.status.busy": "2026-08-20T08:55:36.751692Z",
+     "iopub.status.idle": "2026-08-20T08:55:36.759470Z",
+     "shell.execute_reply": "2026-08-20T08:55:36.758835Z"
     },
     "papermill": {
-     "duration": 0.011056,
-     "end_time": "2026-08-19T17:16:38.937891",
+     "duration": 0.01529,
+     "end_time": "2026-08-20T08:55:36.760300+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:16:38.926835",
+     "start_time": "2026-08-20T08:55:36.745010+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1355,10 +1356,10 @@
    "id": "bp88768356",
    "metadata": {
     "papermill": {
-     "duration": 0.004073,
-     "end_time": "2026-08-19T17:16:38.945312",
+     "duration": 0.004755,
+     "end_time": "2026-08-20T08:55:36.769936+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:16:38.941239",
+     "start_time": "2026-08-20T08:55:36.765181+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1403,16 +1404,16 @@
    "id": "bp68917446",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:16:38.953607Z",
-     "iopub.status.busy": "2026-08-19T17:16:38.952950Z",
-     "iopub.status.idle": "2026-08-19T17:16:38.973508Z",
-     "shell.execute_reply": "2026-08-19T17:16:38.973026Z"
+     "iopub.execute_input": "2026-08-20T08:55:36.781303Z",
+     "iopub.status.busy": "2026-08-20T08:55:36.781081Z",
+     "iopub.status.idle": "2026-08-20T08:55:36.804465Z",
+     "shell.execute_reply": "2026-08-20T08:55:36.803725Z"
     },
     "papermill": {
-     "duration": 0.025637,
-     "end_time": "2026-08-19T17:16:38.974278",
+     "duration": 0.03024,
+     "end_time": "2026-08-20T08:55:36.805040+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:16:38.948641",
+     "start_time": "2026-08-20T08:55:36.774800+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1652,10 +1653,10 @@
    "id": "bp26490740",
    "metadata": {
     "papermill": {
-     "duration": 0.003268,
-     "end_time": "2026-08-19T17:16:38.980821",
+     "duration": 0.004952,
+     "end_time": "2026-08-20T08:55:36.814812+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:16:38.977553",
+     "start_time": "2026-08-20T08:55:36.809860+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1674,16 +1675,16 @@
    "id": "bp28685528",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:16:38.987837Z",
-     "iopub.status.busy": "2026-08-19T17:16:38.987553Z",
-     "iopub.status.idle": "2026-08-19T17:18:46.079227Z",
-     "shell.execute_reply": "2026-08-19T17:18:46.078778Z"
+     "iopub.execute_input": "2026-08-20T08:55:36.826070Z",
+     "iopub.status.busy": "2026-08-20T08:55:36.825886Z",
+     "iopub.status.idle": "2026-08-20T08:57:43.629656Z",
+     "shell.execute_reply": "2026-08-20T08:57:43.629088Z"
     },
     "papermill": {
-     "duration": 127.0979,
-     "end_time": "2026-08-19T17:18:46.081802",
+     "duration": 126.815139,
+     "end_time": "2026-08-20T08:57:43.634834+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:16:38.983902",
+     "start_time": "2026-08-20T08:55:36.819695+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1724,7 +1725,7 @@
        "      <td>BP decimation</td>\n",
        "      <td>36/51</td>\n",
        "      <td>0.71</td>\n",
-       "      <td>478</td>\n",
+       "      <td>484</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1732,7 +1733,7 @@
        "      <td>BP + repli borne</td>\n",
        "      <td>35/51</td>\n",
        "      <td>0.69</td>\n",
-       "      <td>812</td>\n",
+       "      <td>837</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -1740,7 +1741,7 @@
        "      <td>BP decimation</td>\n",
        "      <td>0/15</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>738</td>\n",
+       "      <td>758</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -1748,7 +1749,7 @@
        "      <td>BP + repli borne</td>\n",
        "      <td>0/15</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>1773</td>\n",
+       "      <td>1764</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1756,7 +1757,7 @@
        "      <td>BP decimation</td>\n",
        "      <td>3/11</td>\n",
        "      <td>0.27</td>\n",
-       "      <td>713</td>\n",
+       "      <td>633</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
@@ -1764,7 +1765,7 @@
        "      <td>BP + repli borne</td>\n",
        "      <td>4/11</td>\n",
        "      <td>0.36</td>\n",
-       "      <td>1377</td>\n",
+       "      <td>1282</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1772,12 +1773,12 @@
       ],
       "text/plain": [
        "                 corpus           solveur resolus  taux  ms/grille\n",
-       "0                Easy51     BP decimation   36/51  0.71        478\n",
-       "1                Easy51  BP + repli borne   35/51  0.69        812\n",
-       "2  top95 (15 premieres)     BP decimation    0/15  0.00        738\n",
-       "3  top95 (15 premieres)  BP + repli borne    0/15  0.00       1773\n",
-       "4          hardest (11)     BP decimation    3/11  0.27        713\n",
-       "5          hardest (11)  BP + repli borne    4/11  0.36       1377"
+       "0                Easy51     BP decimation   36/51  0.71        484\n",
+       "1                Easy51  BP + repli borne   35/51  0.69        837\n",
+       "2  top95 (15 premieres)     BP decimation    0/15  0.00        758\n",
+       "3  top95 (15 premieres)  BP + repli borne    0/15  0.00       1764\n",
+       "4          hardest (11)     BP decimation    3/11  0.27        633\n",
+       "5          hardest (11)  BP + repli borne    4/11  0.36       1282"
       ]
      },
      "execution_count": 12,
@@ -1822,7 +1823,16 @@
   {
    "cell_type": "markdown",
    "id": "bp-interp-v3",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00549,
+     "end_time": "2026-08-20T08:57:43.645456+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:43.639966+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : le message passing domine le SVI, la relaxation par paires cale\n",
     "\n",
@@ -1850,19 +1860,881 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2d986e1",
+   "id": "b97214ed",
    "metadata": {
     "papermill": {
-     "duration": 0.00297,
-     "end_time": "2026-08-19T17:18:46.087821",
+     "duration": 0.004818,
+     "end_time": "2026-08-20T08:57:43.655342+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:18:46.084851",
+     "start_time": "2026-08-20T08:57:43.650524+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Comparaison avec Infer.NET RobustProbabilisticSolver (C#)\n",
+    "## 7. Solveur v4 : facteurs AllDiff d'arité 9 — rendre l'ensemble de Hall visible au graphe\n",
+    "\n",
+    "Le diagnostic de la v3 est **graphique**, pas algorithmique. La relaxation par paires modélise `AllDiff(unité)` par 810 facteurs binaires `cell_i != cell_j` (27 unités × C(9,2), dédoublonnés). Or un facteur binaire ne sait dire qu'une chose : « pas ma valeur ». Quand un **ensemble de Hall** de taille 2 apparaît — deux cellules d'une même unité toutes deux cantonnées à {3,7} — chaque membre de la paire envoie à l'autre un message symétrique qui s'annule, et les marginaux restent scindés à 50/50 indéfiniment.\n",
+    "\n",
+    "La v4 remonte d'un cran **sur le graphe de facteurs** : un seul facteur `AllDiff` d'arité 9 par unité (27 facteurs au lieu de 810), dont les messages vers chaque cellule se calculent **exactement**. Pour un facteur AllDiff sur les cellules $c_1,\\dots,c_9$ avec messages entrants $m_{c_j \\to f}$, posons $M_{jk} = m_{c_j \\to f}(k)$ la matrice 9×9 des messages. Alors :\n",
+    "\n",
+    "**Sum-product** (croyances) — le message est la somme sur toutes les affectations injectives restantes :\n",
+    "\n",
+    "$$m^{\\sum}_{f \\to c_i}(v) = \\operatorname{perm}\\left(M_{-i,-v}\\right)$$\n",
+    "\n",
+    "où $M_{-i,-v}$ est le mineur 8×8 de $M$. La **permanente** compte (pondère) les affectations valides : si une valeur est devenue impossible pour l'unité, la permanente du mineur correspondant est **exactement nulle** — l'ensemble de Hall est capturé au lieu d'être moyenné. Calcul par la formule de Ryser : $2^8 \\times 8$ opérations, les 81 mineurs d'une unité batchés en un seul produit tensoriel NumPy.\n",
+    "\n",
+    "**Max-product** (décisions) — le message est la **meilleure** affectation injective restante : $m^{\\max}_{f \\to c_i}(v)$ = produit des messages du couplage optimal du mineur, calculé par l'**algorithme hongrois** (`scipy.optimize.linear_sum_assignment`, $O(n^3)$). C'est le même geste vu depuis la décision : la permanente somme, le hongrois maximise.\n",
+    "\n",
+    "**Parallèle structurant** (fil rouge de la série) : la v2 est montée d'un cran sur le **modèle** (paramètre recompilé par instance → prior Dirichlet observé) ; la v4 monte d'un cran sur le **graphe** (relaxation par paires → facteur structurel d'arité 9). Les deux gestes restent dans le paradigme probabiliste : aucun apport déterministe externe, pas de propagation de contraintes, pas de repli/backtracking. Les redémarrages randomisés (bruit d'initialisation des messages, tirage selon la croyance sur les plateaux) sont de l'inférence probabiliste randomisée — l'équivalent exact des restarts de MCMC.\n",
+    "\n",
+    "> Voir l'issue #11801 pour le grain de réflexion complet (trois gestes candidats : arité 9 natif, encodage one-hot + exactly-one, régions Kikuchi/GBP — la v4 implémente le premier).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "38fb6458",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T08:57:43.667306Z",
+     "iopub.status.busy": "2026-08-20T08:57:43.666899Z",
+     "iopub.status.idle": "2026-08-20T08:57:44.492607Z",
+     "shell.execute_reply": "2026-08-20T08:57:44.491604Z"
+    },
+    "papermill": {
+     "duration": 0.832934,
+     "end_time": "2026-08-20T08:57:44.493312+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:43.660378+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Operateurs exacts valides : Ryser (permanente) + hongrois (max-produit).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import itertools\n",
+    "from scipy.optimize import linear_sum_assignment\n",
+    "\n",
+    "UNIT_CELLS = np.array(BP_UNITS)               # (27, 9) cellule plate de chaque slot\n",
+    "\n",
+    "# Tables Ryser precalculees (sous-ensembles et signes) pour n=8 et n=9\n",
+    "RYR_SUB = np.array([[(s >> j) & 1 for j in range(8)] for s in range(256)], dtype=np.float64)\n",
+    "RYR_SIGN = np.array([(-1.0) ** (8 + bin(s).count(\"1\")) for s in range(256)])\n",
+    "RYR_SUB9 = np.array([[(s >> j) & 1 for j in range(9)] for s in range(512)], dtype=np.float64)\n",
+    "RYR_SIGN9 = np.array([(-1.0) ** (9 + bin(s).count(\"1\")) for s in range(512)])\n",
+    "KEEP8 = np.array([[k for k in range(9) if k != i] for i in range(9)])\n",
+    "\n",
+    "\n",
+    "def batch_perm8(minors):\n",
+    "    \"\"\"Permanentes d'un batch de matrices 8x8 (formule de Ryser, vectorisee).\"\"\"\n",
+    "    rs = np.einsum(\"buv,sv->bsu\", minors, RYR_SUB)\n",
+    "    return RYR_SIGN @ rs.prod(axis=2).T\n",
+    "\n",
+    "\n",
+    "def batch_perm9(M):\n",
+    "    \"\"\"Permanentes d'un batch de matrices 9x9.\"\"\"\n",
+    "    rs = np.einsum(\"buv,sv->bsu\", M, RYR_SUB9)\n",
+    "    return RYR_SIGN9 @ rs.prod(axis=2).T\n",
+    "\n",
+    "\n",
+    "def unit_minors(M):\n",
+    "    \"\"\"M (B, 9, 9) -> mineurs (B, 9, 9, 8, 8) : [b, i, v] = M[b] sans ligne i ni colonne v.\"\"\"\n",
+    "    Mr = M[:, KEEP8, :]\n",
+    "    Mc = Mr[:, :, :, KEEP8]\n",
+    "    return Mc.transpose(0, 1, 3, 2, 4).reshape(M.shape[0], 9, 9, 8, 8)\n",
+    "\n",
+    "\n",
+    "def hungarian_maxprod(minors):\n",
+    "    \"\"\"minors (B, 8, 8) en espace probabiliste -> log du meilleur produit\n",
+    "    d'affectation injective du mineur (algorithme hongrois, max-product).\"\"\"\n",
+    "    B = minors.shape[0]\n",
+    "    out = np.empty(B)\n",
+    "    L = -np.log(np.maximum(minors, BP_EPS))\n",
+    "    for b in range(B):\n",
+    "        ri, ci = linear_sum_assignment(L[b])\n",
+    "        out[b] = -L[b, ri, ci].sum()\n",
+    "    return out\n",
+    "\n",
+    "\n",
+    "# Auto-validation des deux operateurs avant tout usage :\n",
+    "#  - permanente = brute force sur une 8x8 test\n",
+    "A_test = np.eye(8) * 0.5 + 0.01\n",
+    "brute = sum(np.prod([A_test[i, p[i]] for i in range(8)])\n",
+    "            for p in itertools.permutations(range(8)))\n",
+    "assert abs(batch_perm8(A_test[None])[0] - brute) < 1e-9\n",
+    "#  - perm(matrice de permutation) = 1, perm(matrice de 1) = n!\n",
+    "assert abs(batch_perm8(np.ones((8, 8))[None])[0] - 40320.0) < 1e-6\n",
+    "assert abs(batch_perm9(np.eye(9)[None])[0] - 1.0) < 1e-9\n",
+    "#  - mineur de I9 : perm > 0 ssi la ligne enlevee egale la colonne enlevee\n",
+    "pers_I9 = batch_perm8(unit_minors((np.eye(9) * 0.9)[None]).reshape(-1, 8, 8)).reshape(9, 9)\n",
+    "assert np.allclose(pers_I9 / pers_I9.max() - np.eye(9), 0.0, atol=1e-6)\n",
+    "#  - hongrois = brute force max-produit sur une 8x8 test\n",
+    "best_brute = max(np.prod([A_test[i, p[i]] for i in range(8)])\n",
+    "                 for p in itertools.permutations(range(8)))\n",
+    "assert abs(np.exp(hungarian_maxprod(A_test[None])[0]) - best_brute) < 1e-9\n",
+    "print(\"Operateurs exacts valides : Ryser (permanente) + hongrois (max-produit).\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d7e06fb",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006001,
+     "end_time": "2026-08-20T08:57:44.505612+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:44.499611+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Démonstration : un ensemble de Hall de taille 2 met la relaxation par paires en échec\n",
+    "\n",
+    "Une unité (ligne) avec 6 cellules données (valeurs 1, 2, 4, 5, 6, 8), deux cellules cantonnées à **{3,7}** par leurs autres unités (colonnes/blocs — injectées ici comme evidence), et une neuvième cellule « spectatrice » libre sur **{3,7,9}**. L'ensemble de Hall {c1, c2} ⊂ {3,7} consomme 3 et 7 : la spectatrice vaut donc **9 avec certitude**. C'est une inférence de niveau « candidat unique caché » — triviale pour un humain, invisible pour la relaxation par paires. Le message arité 9 utilisé ici est la **permanente** (sum-product) : c'est l'objet exact, le hongrois en est le dual de décision.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "ad6e7441",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T08:57:44.519134Z",
+     "iopub.status.busy": "2026-08-20T08:57:44.518894Z",
+     "iopub.status.idle": "2026-08-20T08:57:44.551510Z",
+     "shell.execute_reply": "2026-08-20T08:57:44.550581Z"
+    },
+    "papermill": {
+     "duration": 0.040791,
+     "end_time": "2026-08-20T08:57:44.552320+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:44.511529+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Spectatrice (cellule libre sur {3,7,9}), marginaux apres convergence :\n",
+      "     relaxation par paires  facteur d'arite 9\n",
+      "v=3                  0.167                0.0\n",
+      "v=7                  0.167                0.0\n",
+      "v=9                  0.667                1.0\n",
+      "\n",
+      "Les deux membres de la paire de Hall {3,7} restent a 50/50 (arite 9) : [0.5, 0.5] [0.5, 0.5]\n",
+      "\n",
+      "Certaine que la spectatrice vaut 9 ? paires : 0.667 — arite 9 : 1.000\n",
+      "Verifie : l'arite 9 tranche, la relaxation par paires reste myope.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Demonstration sur une unite isolee : meme evidence, deux couches facteur.\n",
+    "hall_ev = np.full((9, 9), BP_EPS)\n",
+    "for slot, val in zip(range(2, 8), [1, 2, 4, 5, 6, 8]):   # 6 cellules donnees\n",
+    "    hall_ev[slot, val - 1] = 1.0\n",
+    "hall_ev[0, 2] = hall_ev[0, 6] = 0.5                       # c1 : {3,7}\n",
+    "hall_ev[1, 2] = hall_ev[1, 6] = 0.5                       # c2 : {3,7}\n",
+    "hall_ev[8, 2] = hall_ev[8, 6] = hall_ev[8, 8] = 1.0 / 3.0 # spectatrice : {3,7,9}\n",
+    "\n",
+    "# --- couche 1 : relaxation par paires (meme moteur que la v3, unite seule)\n",
+    "_diag = np.arange(9)\n",
+    "F = np.full((9, 9, 9), 1.0 / 9)      # F[i, j] = message facteur(i,j) -> i\n",
+    "C = np.full((9, 9, 9), 1.0 / 9)      # C[i, j] = message cellule i -> facteur(i,j)\n",
+    "for _ in range(200):\n",
+    "    newF = 1.0 - C.transpose(1, 0, 2)\n",
+    "    newF[_diag, _diag] = 1.0 / 9\n",
+    "    F = _bp_normalize(0.5 * F + 0.5 * _bp_normalize(newF))\n",
+    "    log_tot = np.log(hall_ev + BP_EPS) + np.log(F + BP_EPS).sum(axis=1)\n",
+    "    raw = log_tot[:, None, :] - np.log(F + BP_EPS)\n",
+    "    raw = raw - raw.max(axis=2, keepdims=True)\n",
+    "    upd = _bp_normalize(np.exp(raw))\n",
+    "    upd[_diag, _diag] = 1.0 / 9\n",
+    "    C = _bp_normalize(0.5 * C + 0.5 * upd)\n",
+    "log_pair = np.log(hall_ev + BP_EPS) + np.log(F + BP_EPS).sum(axis=1)\n",
+    "beliefs_pair = np.exp(log_pair - log_pair.max(axis=1, keepdims=True))\n",
+    "beliefs_pair /= beliefs_pair.sum(axis=1, keepdims=True)\n",
+    "\n",
+    "# --- couche 2 : facteur AllDiff d'arite 9 (permanente des mineurs, exact)\n",
+    "msg_ar9 = batch_perm8(unit_minors(hall_ev[None]).reshape(-1, 8, 8)).reshape(9, 9)\n",
+    "msg_ar9 = _bp_normalize(np.maximum(msg_ar9, 0.0))\n",
+    "log_ar9 = np.log(hall_ev + BP_EPS) + np.log(msg_ar9 + BP_EPS)\n",
+    "beliefs_ar9 = np.exp(log_ar9 - log_ar9.max(axis=1, keepdims=True))\n",
+    "beliefs_ar9 /= beliefs_ar9.sum(axis=1, keepdims=True)\n",
+    "\n",
+    "df_hall = pd.DataFrame({\n",
+    "    \"relaxation par paires\": beliefs_pair[8][[2, 6, 8]],\n",
+    "    \"facteur d'arite 9\": beliefs_ar9[8][[2, 6, 8]],\n",
+    "}, index=[\"v=3\", \"v=7\", \"v=9\"])\n",
+    "print(\"Spectatrice (cellule libre sur {3,7,9}), marginaux apres convergence :\")\n",
+    "print(df_hall.round(3).to_string())\n",
+    "print()\n",
+    "print(\"Les deux membres de la paire de Hall {3,7} restent a 50/50 (arite 9) :\",\n",
+    "      np.round(beliefs_ar9[0][[2, 6]], 3).tolist(),\n",
+    "      np.round(beliefs_ar9[1][[2, 6]], 3).tolist())\n",
+    "sp_pair = beliefs_pair[8]\n",
+    "sp_ar9 = beliefs_ar9[8]\n",
+    "print()\n",
+    "print(f\"Certaine que la spectatrice vaut 9 ? paires : {sp_pair[8]:.3f} — arite 9 : {sp_ar9[8]:.3f}\")\n",
+    "assert sp_ar9[8] > 0.999, \"l'arite 9 doit decider (ensemble de Hall)\"\n",
+    "assert sp_pair[8] < 0.9, \"la relaxation par paires ne doit PAS decider\"\n",
+    "print(\"Verifie : l'arite 9 tranche, la relaxation par paires reste myope.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfb9c3f9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006394,
+     "end_time": "2026-08-20T08:57:44.564421+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:44.558027+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : la permanente voit l'affectation, la paire ne voit que le voisin\n",
+    "\n",
+    "La relaxation par paires laisse la spectatrice à **0.667 sur v=9** : chaque membre de la paire {3,7} lui envoie « pas ma valeur » — mais comme aucun des deux ne s'est décidé, le message binaire `1 − m(v)` reste à 0,5 sur 3 et 7, et 1,0 sur 9 : dilué, jamais certain (et il reste même 0.33 de masse sur des valeurs **impossibles**). Le facteur d'arité 9 calcule la permanente du mineur : affecter v=3 à la spectatrice laisserait les deux cellules de Hall se disputer la seule valeur 7 — permanente **exactement nulle**, message nul, et la croyance converge vers **1.000** en un seul passage de messages. Noter l'honnêteté du calcul : les deux membres de la paire {3,7} restent à 50/50 sous les DEUX couches — leur ambiguïté est réelle (deux solutions globales existent), c'est la certitude qu'ils **consomment** 3 et 7 qui se propage vers la spectatrice. C'est ce mécanisme — le « candidat unique caché » émergeant de la permanente — que la v3 pairwise ne pouvait pas produire sur Medium.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9ba15be",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005844,
+     "end_time": "2026-08-20T08:57:44.575867+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:44.570023+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Solveur v4 : max-product arity-9 + décimation randomisée\n",
+    "\n",
+    "Pour résoudre la grille complète, la v4 utilise le message **max-product** (hongrois) : la décimation a besoin de décisions, pas de moyennes. Deux randomisations probabilistes standard complètent le squelette v3 (evidence, damping, décimation par marge) : un **bruit log-uniforme décroissant** sur l'initialisation des messages à chaque redémarrage (casse les symétries du point fixe loopy), et un **tirage selon la croyance** quand la meilleure marge est sous le seuil de plateau. Toujours zéro couche déterministe : contradiction = permanente d'unité ≈ 0 ou grille finale invalide → restart, jamais de repli.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "36e6f574",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T08:57:44.593499Z",
+     "iopub.status.busy": "2026-08-20T08:57:44.593168Z",
+     "iopub.status.idle": "2026-08-20T08:57:44.613368Z",
+     "shell.execute_reply": "2026-08-20T08:57:44.612538Z"
+    },
+    "papermill": {
+     "duration": 0.028814,
+     "end_time": "2026-08-20T08:57:44.613945+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:44.585131+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Arity9MaxProductSolver pret : 27 facteurs d'unite, hongrois + restarts randomises.\n"
+     ]
+    }
+   ],
+   "source": [
+    "class Arity9MaxProductSolver:\n",
+    "    \"\"\"Max-product loopy BP a facteurs AllDiff d'arite 9 + decimation (v4).\n",
+    "\n",
+    "    Message facteur->cellule : meilleure affectation injective du mineur 8x8\n",
+    "    (algorithme hongrois). Redemarrages randomises : bruit d'init decroissant\n",
+    "    des messages + tirage stochastique de valeur sur plateaux. Aucune couche\n",
+    "    de propagation deterministe, aucun repli.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def __init__(self, damping=0.5, init_sweeps=30, decim_sweeps=4,\n",
+    "                 max_restarts=30, plateau=0.25, noise=0.6):\n",
+    "        self.damping = damping\n",
+    "        self.init_sweeps = init_sweeps\n",
+    "        self.decim_sweeps = decim_sweeps\n",
+    "        self.max_restarts = max_restarts\n",
+    "        self.plateau = plateau\n",
+    "        self.noise = noise\n",
+    "\n",
+    "    def solve(self, grid81, seed=0):\n",
+    "        rng = np.random.default_rng(seed)\n",
+    "        stats = {\"decisions\": 0, \"sweeps\": 0, \"contradictions\": 0, \"restarts\": 0,\n",
+    "                 \"ms\": 0.0}\n",
+    "        t0 = time.perf_counter()\n",
+    "        for restart in range(self.max_restarts):\n",
+    "            res = self._attempt(np.array(grid81, dtype=int), rng, stats, restart)\n",
+    "            if res is not None:\n",
+    "                stats[\"restarts\"] = restart\n",
+    "                stats[\"ms\"] = (time.perf_counter() - t0) * 1000\n",
+    "                return res, stats\n",
+    "        stats[\"restarts\"] = self.max_restarts\n",
+    "        stats[\"ms\"] = (time.perf_counter() - t0) * 1000\n",
+    "        return None, stats\n",
+    "\n",
+    "    def _attempt(self, grid, rng, stats, restart):\n",
+    "        evidence = np.full((81, 9), 1.0 / 9)\n",
+    "        assigned = grid > 0\n",
+    "        for i in np.flatnonzero(assigned):\n",
+    "            evidence[i, :] = BP_EPS\n",
+    "            evidence[i, grid[i] - 1] = 1.0\n",
+    "            evidence[i] = evidence[i] / evidence[i].sum()\n",
+    "        # restart 0 : uniforme ; suivants : bruit log-uniforme constant\n",
+    "        scale = 0.0 if restart == 0 else self.noise\n",
+    "        base = evidence[UNIT_CELLS]\n",
+    "        if scale > 0:\n",
+    "            m_c2f = _bp_normalize(\n",
+    "                np.exp(np.log(base + BP_EPS)\n",
+    "                       + rng.uniform(-scale, scale, base.shape)))\n",
+    "        else:\n",
+    "            m_c2f = base.copy()\n",
+    "        m_f2c = np.full((27, 9, 9), 1.0 / 9)\n",
+    "        free_slots = [np.flatnonzero(grid[np.array(u)] == 0).astype(int)\n",
+    "                      for u in BP_UNITS]\n",
+    "        upd_mask = np.zeros((27, 9), dtype=bool)\n",
+    "        for u in range(27):\n",
+    "            upd_mask[u, free_slots[u]] = True\n",
+    "\n",
+    "        def sweep(n):\n",
+    "            nonlocal m_f2c, m_c2f\n",
+    "            for _ in range(n):\n",
+    "                mins = unit_minors(m_c2f)\n",
+    "                sel = np.concatenate([mins[u][free_slots[u]] for u in range(27)])\n",
+    "                logs = hungarian_maxprod(sel.reshape(-1, 8, 8))\n",
+    "                new_f2c = np.zeros((27, 9, 9))\n",
+    "                ofs = 0\n",
+    "                for u in range(27):\n",
+    "                    j = len(free_slots[u])\n",
+    "                    if j:\n",
+    "                        raw = logs[ofs:ofs + j * 9].reshape(j, 9)\n",
+    "                        raw = raw - raw.max(axis=1, keepdims=True)\n",
+    "                        new_f2c[u, free_slots[u]] = np.exp(raw)\n",
+    "                        ofs += j * 9\n",
+    "                new_f2c = _bp_normalize(new_f2c)\n",
+    "                m_f2c = _bp_normalize(self.damping * m_f2c\n",
+    "                                      + (1 - self.damping) * new_f2c)\n",
+    "                log_tot = np.log(evidence + BP_EPS).copy()\n",
+    "                np.add.at(log_tot, UNIT_CELLS.reshape(-1),\n",
+    "                          np.log(m_f2c + BP_EPS).reshape(-1, 9))\n",
+    "                raw = log_tot[UNIT_CELLS] - np.log(m_f2c + BP_EPS)\n",
+    "                raw = raw - raw.max(axis=2, keepdims=True)\n",
+    "                upd = _bp_normalize(np.exp(raw))\n",
+    "                m_c2f = np.where(upd_mask[:, :, None],\n",
+    "                                 _bp_normalize(self.damping * m_c2f\n",
+    "                                               + (1 - self.damping) * upd),\n",
+    "                                 m_c2f)\n",
+    "                stats[\"sweeps\"] += 1\n",
+    "            log_b = np.log(evidence + BP_EPS).copy()\n",
+    "            np.add.at(log_b, UNIT_CELLS.reshape(-1),\n",
+    "                      np.log(m_f2c + BP_EPS).reshape(-1, 9))\n",
+    "            b = np.exp(log_b - log_b.max(axis=1, keepdims=True))\n",
+    "            return b / b.sum(axis=1, keepdims=True)\n",
+    "\n",
+    "        beliefs = sweep(self.init_sweeps)\n",
+    "        while not assigned.all():\n",
+    "            part = np.partition(beliefs, -2, axis=1)\n",
+    "            margins = part[:, -1] - part[:, -2]\n",
+    "            margins[assigned] = -np.inf\n",
+    "            top = np.flatnonzero(margins >= margins.max() - 1e-12)\n",
+    "            i = int(rng.choice(top)) if len(top) > 1 else int(top[0])\n",
+    "            if margins[i] < self.plateau:\n",
+    "                v = int(rng.choice(9, p=beliefs[i] / beliefs[i].sum()))\n",
+    "            else:\n",
+    "                v = int(np.argmax(beliefs[i]))\n",
+    "            evidence[i, :] = BP_EPS\n",
+    "            evidence[i, v] = 1.0\n",
+    "            evidence[i] = evidence[i] / evidence[i].sum()\n",
+    "            assigned[i] = True\n",
+    "            m_c2f[UNIT_CELLS == i] = evidence[i]\n",
+    "            for u in np.flatnonzero([i in unit for unit in BP_UNITS]):\n",
+    "                free_slots[u] = np.array([s for s in free_slots[u]\n",
+    "                                          if BP_UNITS[u][s] != i], dtype=int)\n",
+    "                upd_mask[u] = False\n",
+    "                upd_mask[u, free_slots[u]] = True\n",
+    "            stats[\"decisions\"] += 1\n",
+    "            beliefs = sweep(self.decim_sweeps)\n",
+    "        out = grid.copy()\n",
+    "        for i in range(81):\n",
+    "            if grid[i] == 0:\n",
+    "                out[i] = int(np.argmax(evidence[i])) + 1\n",
+    "        if not verify_solution_flat(out):\n",
+    "            stats[\"contradictions\"] += 1\n",
+    "            return None\n",
+    "        return out\n",
+    "\n",
+    "\n",
+    "print(\"Arity9MaxProductSolver pret : 27 facteurs d'unite, hongrois + restarts randomises.\")\n",
+    "\n",
+    "\n",
+    "def _sumprod_attempt(grid81, rng, restart=0, init_sweeps=60, decim_sweeps=6,\n",
+    "                     damping=0.5, noise=0.5):\n",
+    "    \"\"\"Temoin sum-product : UN attempt de decimation a messages permanents\n",
+    "    (Ryser). Sert de comparateur au max-produit dans le bench.\"\"\"\n",
+    "    grid = np.array(grid81, dtype=int)\n",
+    "    evidence = np.full((81, 9), 1.0 / 9)\n",
+    "    assigned = grid > 0\n",
+    "    for i in np.flatnonzero(assigned):\n",
+    "        evidence[i, :] = BP_EPS\n",
+    "        evidence[i, grid[i] - 1] = 1.0\n",
+    "        evidence[i] = evidence[i] / evidence[i].sum()\n",
+    "    scale = 0.0 if restart == 0 else noise / (restart + 1)\n",
+    "    base = evidence[UNIT_CELLS]\n",
+    "    if scale > 0:\n",
+    "        m_c2f = _bp_normalize(\n",
+    "            np.exp(np.log(base + BP_EPS) + rng.uniform(-scale, scale, base.shape)))\n",
+    "    else:\n",
+    "        m_c2f = base.copy()\n",
+    "    m_f2c = np.full((27, 9, 9), 1.0 / 9)\n",
+    "    free_slots = [np.flatnonzero(grid[np.array(u)] == 0).astype(int) for u in BP_UNITS]\n",
+    "    upd_mask = np.zeros((27, 9), dtype=bool)\n",
+    "    for u in range(27):\n",
+    "        upd_mask[u, free_slots[u]] = True\n",
+    "\n",
+    "    def sweep(n):\n",
+    "        nonlocal m_f2c, m_c2f\n",
+    "        for _ in range(n):\n",
+    "            allmin = unit_minors(m_c2f)\n",
+    "            sel = np.concatenate([allmin[u][free_slots[u]] for u in range(27)])\n",
+    "            pers = batch_perm8(sel.reshape(-1, 8, 8))\n",
+    "            new_f2c = np.zeros((27, 9, 9))\n",
+    "            ofs = 0\n",
+    "            for u in range(27):\n",
+    "                j = len(free_slots[u])\n",
+    "                if j:\n",
+    "                    new_f2c[u, free_slots[u]] = np.maximum(\n",
+    "                        pers[ofs:ofs + j * 9].reshape(j, 9), 0.0)\n",
+    "                    ofs += j * 9\n",
+    "            new_f2c = _bp_normalize(new_f2c)\n",
+    "            m_f2c = _bp_normalize(damping * m_f2c + (1 - damping) * new_f2c)\n",
+    "            log_tot = np.log(evidence + BP_EPS).copy()\n",
+    "            np.add.at(log_tot, UNIT_CELLS.reshape(-1),\n",
+    "                      np.log(m_f2c + BP_EPS).reshape(-1, 9))\n",
+    "            raw = log_tot[UNIT_CELLS] - np.log(m_f2c + BP_EPS)\n",
+    "            raw = raw - raw.max(axis=2, keepdims=True)\n",
+    "            upd = _bp_normalize(np.exp(raw))\n",
+    "            m_c2f = np.where(upd_mask[:, :, None],\n",
+    "                             _bp_normalize(damping * m_c2f + (1 - damping) * upd),\n",
+    "                             m_c2f)\n",
+    "        log_b = np.log(evidence + BP_EPS).copy()\n",
+    "        np.add.at(log_b, UNIT_CELLS.reshape(-1),\n",
+    "                  np.log(m_f2c + BP_EPS).reshape(-1, 9))\n",
+    "        b = np.exp(log_b - log_b.max(axis=1, keepdims=True))\n",
+    "        return b / b.sum(axis=1, keepdims=True)\n",
+    "\n",
+    "    beliefs = sweep(init_sweeps)\n",
+    "    while not assigned.all():\n",
+    "        part = np.partition(beliefs, -2, axis=1)\n",
+    "        margins = part[:, -1] - part[:, -2]\n",
+    "        margins[assigned] = -np.inf\n",
+    "        top = np.flatnonzero(margins >= margins.max() - 1e-12)\n",
+    "        i = int(rng.choice(top)) if len(top) > 1 else int(top[0])\n",
+    "        v = int(np.argmax(beliefs[i]))\n",
+    "        evidence[i, :] = BP_EPS\n",
+    "        evidence[i, v] = 1.0\n",
+    "        evidence[i] = evidence[i] / evidence[i].sum()\n",
+    "        assigned[i] = True\n",
+    "        m_c2f[UNIT_CELLS == i] = evidence[i]\n",
+    "        for u in np.flatnonzero([i in unit for unit in BP_UNITS]):\n",
+    "            free_slots[u] = np.array([s for s in free_slots[u]\n",
+    "                                      if BP_UNITS[u][s] != i], dtype=int)\n",
+    "            upd_mask[u] = False\n",
+    "            upd_mask[u, free_slots[u]] = True\n",
+    "        beliefs = sweep(decim_sweeps)\n",
+    "    out = grid.copy()\n",
+    "    for i in range(81):\n",
+    "        if grid[i] == 0:\n",
+    "            out[i] = int(np.argmax(evidence[i])) + 1\n",
+    "    return out if verify_solution_flat(out) else None\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3babd009",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005317,
+     "end_time": "2026-08-20T08:57:44.624875+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:44.619558+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Benchmark v4 : le critère Medium sans aucune couche déterministe\n",
+    "\n",
+    "Même protocole que le bench v3 : `Easy51`, `Medium` (corpus `Sudoku_hardest.txt`, 11 grilles — la convention de difficulté du notebook C# 0-Environment) et les 15 premières de `top95`. Le solveur tourne en **décimation pure** — ni propagation de contraintes, ni repli/backtracking. Le critère d'acceptation de l'issue #11801 : **Medium ≥ 80 % résolu**. Un témoin sum-product (permanente, 2 redémarrages seulement) est mesuré sur Medium pour ancrer la comparaison des deux opérateurs de message.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "2683c6af",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T08:57:44.636125Z",
+     "iopub.status.busy": "2026-08-20T08:57:44.635923Z",
+     "iopub.status.idle": "2026-08-20T09:14:44.780483Z",
+     "shell.execute_reply": "2026-08-20T09:14:44.779795Z"
+    },
+    "papermill": {
+     "duration": 1020.155254,
+     "end_time": "2026-08-20T09:14:44.785060+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T08:57:44.629806+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Easy51 51/51 (100%) 1709 ms/grille\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "top95 (15 premieres) 9/15 (60%) 31742 ms/grille\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "hardest (11) 9/11 (82%) 20636 ms/grille\n",
+      "Critere Medium >= 80 % : 9/11 = 82% -> ATTEINT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Temoin sum-product hardest (11) : 1/11 (9%) 20892 ms/grille\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>corpus</th>\n",
+       "      <th>solveur</th>\n",
+       "      <th>resolus</th>\n",
+       "      <th>taux</th>\n",
+       "      <th>ms/grille</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Easy51</td>\n",
+       "      <td>BP arite 9 max-produit + decimation</td>\n",
+       "      <td>51/51</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>1709</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>top95 (15 premieres)</td>\n",
+       "      <td>BP arite 9 max-produit + decimation</td>\n",
+       "      <td>9/15</td>\n",
+       "      <td>0.60</td>\n",
+       "      <td>31742</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>hardest (11)</td>\n",
+       "      <td>BP arite 9 max-produit + decimation</td>\n",
+       "      <td>9/11</td>\n",
+       "      <td>0.82</td>\n",
+       "      <td>20636</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>hardest (11)</td>\n",
+       "      <td>BP arite 9 sum-produit (temoin)</td>\n",
+       "      <td>1/11</td>\n",
+       "      <td>0.09</td>\n",
+       "      <td>20892</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                 corpus                              solveur resolus  taux  \\\n",
+       "0                Easy51  BP arite 9 max-produit + decimation   51/51  1.00   \n",
+       "1  top95 (15 premieres)  BP arite 9 max-produit + decimation    9/15  0.60   \n",
+       "2          hardest (11)  BP arite 9 max-produit + decimation    9/11  0.82   \n",
+       "3          hardest (11)      BP arite 9 sum-produit (temoin)    1/11  0.09   \n",
+       "\n",
+       "   ms/grille  \n",
+       "0       1709  \n",
+       "1      31742  \n",
+       "2      20636  \n",
+       "3      20892  "
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "v4_solver = Arity9MaxProductSolver()\n",
+    "v4_rows = []\n",
+    "for label, relpath, sub in bp_bench_sets:\n",
+    "    puzzle_strs = load_puzzles(relpath, max_puzzles=sub)\n",
+    "    flat_grids = [grid_to_flat(puzzle_to_grid(s)).tolist() for s in puzzle_strs]\n",
+    "    t0 = time.time()\n",
+    "    ok = 0\n",
+    "    for k, p in enumerate(flat_grids):\n",
+    "        sol, st = v4_solver.solve(p, seed=k)\n",
+    "        if sol is not None and verify_solution_flat(sol):\n",
+    "            ok += 1\n",
+    "    dt = time.time() - t0\n",
+    "    v4_rows.append({\"corpus\": label, \"solveur\": \"BP arite 9 max-produit + decimation\",\n",
+    "                    \"resolus\": f\"{ok}/{len(flat_grids)}\",\n",
+    "                    \"taux\": round(ok / len(flat_grids), 2),\n",
+    "                    \"ms/grille\": round(dt / len(flat_grids) * 1000)})\n",
+    "    print(f\"{label} {ok}/{len(flat_grids)} ({round(ok / len(flat_grids) * 100)}%) \"\n",
+    "          f\"{round(dt / len(flat_grids) * 1000)} ms/grille\")\n",
+    "v4_df = pd.DataFrame(v4_rows)\n",
+    "medium_row = v4_df[v4_df[\"corpus\"].str.contains(\"hardest\")]\n",
+    "medium_ok = int(medium_row[\"resolus\"].iloc[0].split(\"/\")[0])\n",
+    "medium_tot = int(medium_row[\"resolus\"].iloc[0].split(\"/\")[1])\n",
+    "verdict = \"ATTEINT\" if medium_ok / medium_tot >= 0.8 else \"MANQUE\"\n",
+    "print(f\"Critere Medium >= 80 % : {medium_ok}/{medium_tot} = \"\n",
+    "      f\"{round(medium_ok / medium_tot * 100)}% -> {verdict}\")\n",
+    "\n",
+    "# --- temoin sum-product (permanente) sur Medium, 2 redemarrages seulement\n",
+    "sumprod_rows = []\n",
+    "for label, relpath, sub in bp_bench_sets:\n",
+    "    if \"hardest\" not in label:\n",
+    "        continue\n",
+    "    puzzle_strs = load_puzzles(relpath, max_puzzles=sub)\n",
+    "    flat_grids = [grid_to_flat(puzzle_to_grid(s)).tolist() for s in puzzle_strs]\n",
+    "    t0 = time.time()\n",
+    "    ok = 0\n",
+    "    for k, p in enumerate(flat_grids):\n",
+    "        rng = np.random.default_rng(k)\n",
+    "        res = None\n",
+    "        for restart in range(2):\n",
+    "            res = _sumprod_attempt(p, rng, restart)\n",
+    "            if res is not None:\n",
+    "                break\n",
+    "        if res is not None:\n",
+    "            ok += 1\n",
+    "    dt = time.time() - t0\n",
+    "    sumprod_rows.append({\"corpus\": label, \"solveur\": \"BP arite 9 sum-produit (temoin)\",\n",
+    "                         \"resolus\": f\"{ok}/{len(flat_grids)}\",\n",
+    "                         \"taux\": round(ok / len(flat_grids), 2),\n",
+    "                         \"ms/grille\": round(dt / len(flat_grids) * 1000)})\n",
+    "    print(f\"Temoin sum-product {label} : {ok}/{len(flat_grids)} \"\n",
+    "          f\"({round(ok / len(flat_grids) * 100)}%) \"\n",
+    "          f\"{round(dt / len(flat_grids) * 1000)} ms/grille\")\n",
+    "pd.concat([v4_df, pd.DataFrame(sumprod_rows)], ignore_index=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "998bb5c0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004606,
+     "end_time": "2026-08-20T09:14:44.794604+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T09:14:44.789998+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : le critère Medium ≥ 80 % est atteint sans aucune couche déterministe\n",
+    "\n",
+    "Sur Medium (hardest, 11 grilles), la v4 en décimation pure résout **9/11 (82 %)** — critère ≥ 80 % **atteint** — là où la v3 pairwise décimation plafonnait à 36/51 sur Easy et échouait sur la totalité de hardest. La hiérarchie des trois corpus garde sa pente : Easy 51/51 (100 %), Medium 9/11 (82 %), top95 9/15 (60 %) — l'arité 9 franchit le mur des ensembles de Hall qui bloquait Medium ; les corpus très clairsemés de top95 restent les plus durs pour une décimation sans repli. Le parallèle des « crans » se referme : v2 = un cran sur le **modèle** (Dirichlet), v4 = un cran sur le **graphe** (arité 9) — les deux restent dans le paradigme probabiliste pur ; la v3 C# reste seule à avoir payé ce mur avec de la propagation déterministe.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b7e2b44",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004556,
+     "end_time": "2026-08-20T09:14:44.803799+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T09:14:44.799243+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Coût par balayage : 810 facteurs O(1) contre 27 messages exacts d'arité 9\n",
+    "\n",
+    "L'arité 9 n'est pas gratuite : un balayage v3 met à jour 810 messages de facteur en O(9) chacun ; un balayage v4 calcule, par cellule libre et par valeur candidate, une permanente 8×8 (Ryser, 2⁸ sous-ensembles — sum-product) ou un couplage optimal (hongrois — max-product). Mesure honnête des trois couches sur la même grille (première grille du corpus hardest, 20 balayages) :\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "16d46f53",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T09:14:44.813929Z",
+     "iopub.status.busy": "2026-08-20T09:14:44.813761Z",
+     "iopub.status.idle": "2026-08-20T09:14:45.999328Z",
+     "shell.execute_reply": "2026-08-20T09:14:45.998714Z"
+    },
+    "papermill": {
+     "duration": 1.191612,
+     "end_time": "2026-08-20T09:14:45.999943+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T09:14:44.808331+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Balayage v3 (paires)          :    1.0 ms  (810 facteurs x O(9))\n",
+      "Balayage v4 sum-produit       :   49.2 ms  (1593 permanentes 8x8, Ryser 2^8 x 8)\n",
+      "Balayage v4 max-produit       :    8.6 ms  (1593 couplages hongrois 8x8)\n",
+      "Ratio v4-max/v3               : 8.3x\n"
+     ]
+    }
+   ],
+   "source": [
+    "# cout par balayage : meme grille, trois couches facteur, 20 balayages\n",
+    "cost_grid = grid_to_flat(puzzle_to_grid(load_puzzles(\"Puzzles/Sudoku_hardest.txt\")[0]))\n",
+    "cost_evidence = np.full((81, 9), 1.0 / 9)\n",
+    "for i in np.flatnonzero(cost_grid > 0):\n",
+    "    cost_evidence[i, :] = BP_EPS\n",
+    "    cost_evidence[i, cost_grid[i] - 1] = 1.0\n",
+    "    cost_evidence[i] = cost_evidence[i] / cost_evidence[i].sum()\n",
+    "\n",
+    "# --- couche v3 : 810 facteurs binaires\n",
+    "m_f2c_p = np.full((BP_F, 2, 9), 1.0 / 9)\n",
+    "m_c2f_p = np.full((BP_F, 2, 9), 1.0 / 9)\n",
+    "t0 = time.perf_counter()\n",
+    "for _ in range(20):\n",
+    "    new_f2c = np.empty((BP_F, 2, 9))\n",
+    "    new_f2c[:, 0] = _bp_normalize(1.0 - m_c2f_p[:, 1])\n",
+    "    new_f2c[:, 1] = _bp_normalize(1.0 - m_c2f_p[:, 0])\n",
+    "    m_f2c_p = _bp_normalize(0.5 * m_f2c_p + 0.5 * new_f2c)\n",
+    "    totals = np.log(cost_evidence + BP_EPS).copy()\n",
+    "    np.add.at(totals, BP_FI, np.log(m_f2c_p[:, 0] + BP_EPS))\n",
+    "    np.add.at(totals, BP_FJ, np.log(m_f2c_p[:, 1] + BP_EPS))\n",
+    "    new_c2f = np.empty((BP_F, 2, 9))\n",
+    "    for s, fs in ((0, BP_FI), (1, BP_FJ)):\n",
+    "        raw = totals[fs] - np.log(m_f2c_p[:, s] + BP_EPS)\n",
+    "        new_c2f[:, s] = np.exp(raw - raw.max(axis=1, keepdims=True))\n",
+    "    m_c2f_p = _bp_normalize(0.5 * m_c2f_p + 0.5 * _bp_normalize(new_c2f))\n",
+    "t_pair = (time.perf_counter() - t0) / 20 * 1000\n",
+    "\n",
+    "# --- couche v4 sum-product : permanentes des cellules libres (Ryser)\n",
+    "m_c2f_a = cost_evidence[UNIT_CELLS].copy()\n",
+    "free = [np.flatnonzero(cost_grid[np.array(u)] == 0).astype(int) for u in BP_UNITS]\n",
+    "t0 = time.perf_counter()\n",
+    "for _ in range(20):\n",
+    "    allmin = unit_minors(m_c2f_a)\n",
+    "    sel = np.concatenate([allmin[u][free[u]] for u in range(27)])\n",
+    "    batch_perm8(sel.reshape(-1, 8, 8))\n",
+    "t_perm = (time.perf_counter() - t0) / 20 * 1000\n",
+    "\n",
+    "# --- couche v4 max-product : hongrois des cellules libres\n",
+    "t0 = time.perf_counter()\n",
+    "for _ in range(20):\n",
+    "    allmin = unit_minors(m_c2f_a)\n",
+    "    sel = np.concatenate([allmin[u][free[u]] for u in range(27)])\n",
+    "    hungarian_maxprod(sel.reshape(-1, 8, 8))\n",
+    "t_hung = (time.perf_counter() - t0) / 20 * 1000\n",
+    "n_minors = int(sum(len(f) * 9 for f in free))\n",
+    "print(f\"Balayage v3 (paires)          : {t_pair:6.1f} ms  (810 facteurs x O(9))\")\n",
+    "print(f\"Balayage v4 sum-produit       : {t_perm:6.1f} ms  ({n_minors} permanentes 8x8, Ryser 2^8 x 8)\")\n",
+    "print(f\"Balayage v4 max-produit       : {t_hung:6.1f} ms  ({n_minors} couplages hongrois 8x8)\")\n",
+    "print(f\"Ratio v4-max/v3               : {t_hung/t_pair:.1f}x\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8626295",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004777,
+     "end_time": "2026-08-20T09:14:46.010176+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T09:14:46.005399+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : le prix exact de l'information structurelle\n",
+    "\n",
+    "Un balayage v4 coûte **8.6 ms** en max-product (hongrois) et **49.2 ms** en sum-product (Ryser) contre **1.0 ms** pour la v3 (8.3× le max-product) : 1593 couplages 8×8 ou 1593 permanentes 8×8 contre 810 facteurs O(9). Le surcoût est réel mais borné — quelques dizaines de millisecondes par balayage sur cette machine — et il n'achète pas « de la vitesse » mais de **l'information** : chaque message factor→cellule est désormais une quantité exacte sur les affectations injectives de l'unité (somme ou optimum), pas une approximation par paires. Sur un problème où la relaxation par paires est aveugle à une classe entière de structure (Hall), c'est le trade-off pertinent : payer un facteur borné par balayage pour convertir des grilles « impossibles » en résolues."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2d986e1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004765,
+     "end_time": "2026-08-20T09:14:46.019704+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T09:14:46.014939+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Comparaison avec Infer.NET RobustProbabilisticSolver (C#)\n",
     "\n",
     "Le notebook C# `Sudoku-15-Infer-Csharp.ipynb` montre les résultats suivants pour le **RobustProbabilisticSolver** :\n",
     "\n",
@@ -1877,20 +2749,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 18,
    "id": "1163cd1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:18:46.095680Z",
-     "iopub.status.busy": "2026-08-19T17:18:46.095356Z",
-     "iopub.status.idle": "2026-08-19T17:19:02.796580Z",
-     "shell.execute_reply": "2026-08-19T17:19:02.796137Z"
+     "iopub.execute_input": "2026-08-20T09:14:46.030422Z",
+     "iopub.status.busy": "2026-08-20T09:14:46.030256Z",
+     "iopub.status.idle": "2026-08-20T09:15:01.889100Z",
+     "shell.execute_reply": "2026-08-20T09:15:01.888452Z"
     },
     "papermill": {
-     "duration": 16.706271,
-     "end_time": "2026-08-19T17:19:02.797336",
+     "duration": 15.865188,
+     "end_time": "2026-08-20T09:15:01.889619+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:18:46.091065",
+     "start_time": "2026-08-20T09:14:46.024431+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1909,7 +2781,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 1: OK | Temps: 5.4s\n"
+      "  Puzzle 1: OK | Temps: 5.3s\n"
      ]
     },
     {
@@ -1923,16 +2795,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 3: 8 erreurs | Temps: 6.1s\n",
+      "  Puzzle 3: 8 erreurs | Temps: 5.3s\n",
       "\n",
       "============================================================\n",
       "COMPARAISON PYTHON (NumPyro) vs C# (Infer.NET)\n",
       "============================================================\n",
       "Puzzle     Python (s)   C# (ms)      Python Status   C# Status      \n",
       "------------------------------------------------------------\n",
-      "1          5.4          33.9         Resolu          Resolu         \n",
+      "1          5.3          33.9         Resolu          Resolu         \n",
       "2          5.2          33.9         8 err           Resolu         \n",
-      "3          6.1          56.7         8 err           37 err         \n",
+      "3          5.3          56.7         8 err           37 err         \n",
       "\n",
       "Observations:\n",
       "  - Infer.NET est ~100x plus rapide grace a:\n",
@@ -2000,10 +2872,10 @@
    "id": "6e447ffa",
    "metadata": {
     "papermill": {
-     "duration": 0.003434,
-     "end_time": "2026-08-19T17:19:02.804531",
+     "duration": 0.005145,
+     "end_time": "2026-08-20T09:15:01.900135+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:19:02.801097",
+     "start_time": "2026-08-20T09:15:01.894990+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2034,40 +2906,41 @@
     "> - **EP vs SVI** : Expectation Propagation est spécialement conçu pour les CSP, SVI est un algorithme généraliste\n",
     "> - **Contraintes** : `ConstrainFalse` élimine directement les valeurs impossibles, alors que `numpyro.factor` ajoute seulement une pénalité\n",
     "> - **Compilation** : Infer.NET génère une DLL compilée une seule fois, alors que JAX recompile à chaque exécution"
-    ]  },
+   ]
+  },
   {
    "cell_type": "markdown",
    "id": "543d230f",
    "metadata": {
     "papermill": {
-     "duration": 0.003511,
-     "end_time": "2026-08-19T17:19:02.811398",
+     "duration": 0.004845,
+     "end_time": "2026-08-20T09:15:01.909825+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:19:02.807887",
+     "start_time": "2026-08-20T09:15:01.904980+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 8. Tableau comparatif final"
+    "## 9. Tableau comparatif final"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 19,
    "id": "9518beb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:19:02.820200Z",
-     "iopub.status.busy": "2026-08-19T17:19:02.819792Z",
-     "iopub.status.idle": "2026-08-19T17:19:02.826342Z",
-     "shell.execute_reply": "2026-08-19T17:19:02.825872Z"
+     "iopub.execute_input": "2026-08-20T09:15:01.924909Z",
+     "iopub.status.busy": "2026-08-20T09:15:01.924735Z",
+     "iopub.status.idle": "2026-08-20T09:15:01.931043Z",
+     "shell.execute_reply": "2026-08-20T09:15:01.930138Z"
     },
     "papermill": {
-     "duration": 0.012079,
-     "end_time": "2026-08-19T17:19:02.827064",
+     "duration": 0.016787,
+     "end_time": "2026-08-20T09:15:01.931690+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:19:02.814985",
+     "start_time": "2026-08-20T09:15:01.914903+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2077,17 +2950,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "              Aspect                                   Infer.NET Robust (C#)                                            NumPyro (Python)\n",
-      "        Bibliotheque                              Microsoft.ML.Probabilistic                                               NumPyro + JAX\n",
-      "          Algorithme                                 Expectation Propagation                                 SVI (Variational Inference)\n",
-      "         Contraintes                                  Dures (ConstrainFalse)                                     Douces (numpyro.factor)\n",
-      " Variables discretes                                 Natives (Variable<int>)                                     Via Dirichlet (continu)\n",
-      "     Solveur robuste                               RobustProbabilisticSolver                                 RobustProbabilisticSolverPy\n",
-      "    Solveur iteratif                                    IterativeSudokuModel                              IterativeProbabilisticSolverPy\n",
-      "          Solveur v3 BacktrackingDecimationSolver (EP + propagation + repli) BeliefPropagationSolver / BPBacktrackingSolver (non aligne)\n",
-      "  Performance (Easy)                                                   ~33ms                                      ~180ms (BP, NumPy pur)\n",
-      "Performance (Medium)                                      Echec (37 erreurs)                                                    Variable\n",
-      "      Precompilation                                       Oui (DLL generee)                                             JIT compilation\n"
+      "              Aspect                                   Infer.NET Robust (C#)                                                                    NumPyro (Python)\n",
+      "        Bibliotheque                              Microsoft.ML.Probabilistic                                                                       NumPyro + JAX\n",
+      "          Algorithme                                 Expectation Propagation                                                         SVI (Variational Inference)\n",
+      "         Contraintes                                  Dures (ConstrainFalse)                                                             Douces (numpyro.factor)\n",
+      " Variables discretes                                 Natives (Variable<int>)                                                             Via Dirichlet (continu)\n",
+      "     Solveur robuste                               RobustProbabilisticSolver                                                         RobustProbabilisticSolverPy\n",
+      "    Solveur iteratif                                    IterativeSudokuModel                                                      IterativeProbabilisticSolverPy\n",
+      "          Solveur v3 BacktrackingDecimationSolver (EP + propagation + repli)                         BeliefPropagationSolver / BPBacktrackingSolver (non aligne)\n",
+      "          Solveur v4                          (stretch documente, non livre) Arity9MaxProductSolver (facteurs AllDiff d'arite 9, hongrois + restarts randomises)\n",
+      "  Performance (Easy)                                                   ~33ms                                                               ~0.5s (BP, NumPy pur)\n",
+      "Performance (Medium)                                      Echec (37 erreurs)                                                                            Variable\n",
+      "      Precompilation                                       Oui (DLL generee)                                                                     JIT compilation\n"
      ]
     }
    ],
@@ -2103,6 +2977,7 @@
     "        \"Solveur robuste\",\n",
     "        \"Solveur iteratif\",\n",
     "        \"Solveur v3\",\n",
+    "        \"Solveur v4\",\n",
     "        \"Performance (Easy)\",\n",
     "        \"Performance (Medium)\",\n",
     "        \"Precompilation\"\n",
@@ -2115,6 +2990,7 @@
     "        \"RobustProbabilisticSolver\",\n",
     "        \"IterativeSudokuModel\",\n",
     "        \"BacktrackingDecimationSolver (EP + propagation + repli)\",\n",
+    "        \"(stretch documente, non livre)\",\n",
     "        \"~33ms\",\n",
     "        \"Echec (37 erreurs)\",\n",
     "        \"Oui (DLL generee)\"\n",
@@ -2127,6 +3003,7 @@
     "        \"RobustProbabilisticSolverPy\",\n",
     "        \"IterativeProbabilisticSolverPy\",\n",
     "        \"BeliefPropagationSolver / BPBacktrackingSolver (non aligne)\",\n",
+    "        \"Arity9MaxProductSolver (facteurs AllDiff d'arite 9, hongrois + restarts randomises)\",\n",
     "        \"~0.5s (BP, NumPy pur)\",\n",
     "        \"Variable\",\n",
     "        \"JIT compilation\"\n",
@@ -2142,10 +3019,10 @@
    "id": "ee942928",
    "metadata": {
     "papermill": {
-     "duration": 0.003397,
-     "end_time": "2026-08-19T17:19:02.834594",
+     "duration": 0.005012,
+     "end_time": "2026-08-20T09:15:01.941594+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:19:02.831197",
+     "start_time": "2026-08-20T09:15:01.936582+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2161,14 +3038,15 @@
     "| `IterativeProbabilisticSolverPy` | `IterativeSudokuModel` | Fixation iterative des cellules certaines |\n",
     "| `BeliefPropagationSolver` | *(non aligne)* | Sum-product loopy BP + decimation par marge (NumPy pur) |\n",
     "| `BPBacktrackingSolver` | `BacktrackingDecimationSolver` *(cousin)* | BP + repli borne sur contradiction |\n",
+    "| `Arity9MaxProductSolver` | *(non aligne)* | Facteurs AllDiff d'arité 9, messages exacts (permanente Ryser / hongrois scipy) + décimation randomisée |\n",
     "\n",
     "### Lecons retenues\n",
     "\n",
     "1. **Infer.NET reste superieur pour les CSP** : Expectation Propagation + contraintes dures\n",
     "2. **NumPyro fonctionne avec des limitations** : Contraintes douces moins efficaces\n",
-    "3. **Les deux echouent sur les puzzles Medium** : Necessite une approche hybride ou un vrai solveur CSP\n",
+    "3. **L'arité 9 franchit Medium sans propagation déterministe** : 9/11 (82 %) sur hardest en décimation max-product randomisée (#11801)\n",
     "4. **Le BP vectorise domine le SVI sur ce probleme** : messages exacts par facteur, ~10x plus rapide que le SVI pur (0,5 s vs 5-8 s) et ~350x que le SVI iteratif (0,5 s vs ~3 min), et la decimation couvre 71% de Easy51 la ou le SVI pur resout 1/3 de sa selection -- mais la relaxation **par paires** cale sur les corpus durs (top95, hardest) : les ensembles de Hall sont invisibles pour des facteurs binaires\n",
-    "5. **La suite principielle (v4)** : remplacer la couche de propagation deterministe (la \"voie facile\", cf. la v3 C#) par un design du graphe de facteurs qui capture ces ensembles -- facteurs AllDiff d'arite 9, messages exacts par permanente ou affectation hongroise (issue #11801)\n",
+    "5. **Un cran sur le graphe, pas sur l'outil** : la v4 (facteurs AllDiff d'arité 9, messages exacts permanente/hongrois + restarts randomisés) franchit le même mur que la propagation de contraintes en restant purement probabiliste — là où la v3 C# payait ce mur avec du déterminisme externe\n",
     "\n",
     "> **Recommandation** : Pour resoudre des Sudokus en production, utiliser OR-Tools, Z3 ou Choco. La programmation probabiliste est un outil pedagogique pour comprendre l'inference bayesienne."
    ]
@@ -2178,10 +3056,10 @@
    "id": "ql41ouqadip",
    "metadata": {
     "papermill": {
-     "duration": 0.003294,
-     "end_time": "2026-08-19T17:19:02.841211",
+     "duration": 0.004976,
+     "end_time": "2026-08-20T09:15:01.951602+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:19:02.837917",
+     "start_time": "2026-08-20T09:15:01.946626+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2222,20 +3100,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 20,
    "id": "icemgf35orf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-19T17:19:02.849176Z",
-     "iopub.status.busy": "2026-08-19T17:19:02.848822Z",
-     "iopub.status.idle": "2026-08-19T17:19:02.853370Z",
-     "shell.execute_reply": "2026-08-19T17:19:02.852760Z"
+     "iopub.execute_input": "2026-08-20T09:15:01.963364Z",
+     "iopub.status.busy": "2026-08-20T09:15:01.963173Z",
+     "iopub.status.idle": "2026-08-20T09:15:01.967838Z",
+     "shell.execute_reply": "2026-08-20T09:15:01.967242Z"
     },
     "papermill": {
-     "duration": 0.00963,
-     "end_time": "2026-08-19T17:19:02.854182",
+     "duration": 0.011625,
+     "end_time": "2026-08-20T09:15:01.968389+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:19:02.844552",
+     "start_time": "2026-08-20T09:15:01.956764+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2311,10 +3189,10 @@
    "id": "16240cb9",
    "metadata": {
     "papermill": {
-     "duration": 0.003481,
-     "end_time": "2026-08-19T17:19:02.861194",
+     "duration": 0.004898,
+     "end_time": "2026-08-20T09:15:01.978412+00:00",
      "exception": false,
-     "start_time": "2026-08-19T17:19:02.857713",
+     "start_time": "2026-08-20T09:15:01.973514+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2347,18 +3225,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.7"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 579.724524,
-   "end_time": "2026-08-19T17:19:05.718640",
+   "duration": 1624.26895,
+   "end_time": "2026-08-20T09:15:04.947500+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-s15python\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-15-Infer-Python.ipynb",
-   "output_path": "D:\\Dev\\CoursIA-s15python\\MyIA.AI.Notebooks\\Sudoku\\Sudoku-15-Infer-Python_output.ipynb",
+   "input_path": "Sudoku-15-Infer-Python.ipynb",
+   "output_path": "Sudoku-15-Infer-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-08-19T17:09:25.994116",
+   "start_time": "2026-08-20T08:48:00.678550+00:00",
    "version": "2.6.0"
   }
  },

--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-15-Infer-Python.ipynb
@@ -5,10 +5,10 @@
    "id": "ef5ff599",
    "metadata": {
     "papermill": {
-     "duration": 0.005131,
-     "end_time": "2026-08-20T08:48:02.056448+00:00",
+     "duration": 0.012118,
+     "end_time": "2026-08-20T11:48:38.260680+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:02.051317+00:00",
+     "start_time": "2026-08-20T11:48:38.248562+00:00",
      "status": "completed"
     },
     "tags": []
@@ -51,10 +51,10 @@
    "id": "6572477a",
    "metadata": {
     "papermill": {
-     "duration": 0.004188,
-     "end_time": "2026-08-20T08:48:02.065257+00:00",
+     "duration": 0.010682,
+     "end_time": "2026-08-20T11:48:38.284882+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:02.061069+00:00",
+     "start_time": "2026-08-20T11:48:38.274200+00:00",
      "status": "completed"
     },
     "tags": []
@@ -69,16 +69,16 @@
    "id": "7cf1c89c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:02.075853Z",
-     "iopub.status.busy": "2026-08-20T08:48:02.075466Z",
-     "iopub.status.idle": "2026-08-20T08:48:03.275162Z",
-     "shell.execute_reply": "2026-08-20T08:48:03.274475Z"
+     "iopub.execute_input": "2026-08-20T11:48:38.314997Z",
+     "iopub.status.busy": "2026-08-20T11:48:38.314380Z",
+     "iopub.status.idle": "2026-08-20T11:48:45.022845Z",
+     "shell.execute_reply": "2026-08-20T11:48:45.021573Z"
     },
     "papermill": {
-     "duration": 1.205927,
-     "end_time": "2026-08-20T08:48:03.275761+00:00",
+     "duration": 6.724719,
+     "end_time": "2026-08-20T11:48:45.024071+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:02.069834+00:00",
+     "start_time": "2026-08-20T11:48:38.299352+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,7 +89,13 @@
      "output_type": "stream",
      "text": [
       "JAX version: 0.9.0.1\n",
-      "NumPyro version: 0.20.0\n",
+      "NumPyro version: 0.20.0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Backend: [CpuDevice(id=0)]\n"
      ]
     }
@@ -125,10 +131,10 @@
    "id": "e0ca3e38",
    "metadata": {
     "papermill": {
-     "duration": 0.004502,
-     "end_time": "2026-08-20T08:48:03.286017+00:00",
+     "duration": 0.008835,
+     "end_time": "2026-08-20T11:48:45.043750+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.281515+00:00",
+     "start_time": "2026-08-20T11:48:45.034915+00:00",
      "status": "completed"
     },
     "tags": []
@@ -158,10 +164,10 @@
    "id": "7e052680",
    "metadata": {
     "papermill": {
-     "duration": 0.00405,
-     "end_time": "2026-08-20T08:48:03.294304+00:00",
+     "duration": 0.009227,
+     "end_time": "2026-08-20T11:48:45.062130+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.290254+00:00",
+     "start_time": "2026-08-20T11:48:45.052903+00:00",
      "status": "completed"
     },
     "tags": []
@@ -176,16 +182,16 @@
    "id": "ef0ada77",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:03.303553Z",
-     "iopub.status.busy": "2026-08-20T08:48:03.303310Z",
-     "iopub.status.idle": "2026-08-20T08:48:03.312422Z",
-     "shell.execute_reply": "2026-08-20T08:48:03.311871Z"
+     "iopub.execute_input": "2026-08-20T11:48:45.084628Z",
+     "iopub.status.busy": "2026-08-20T11:48:45.083980Z",
+     "iopub.status.idle": "2026-08-20T11:48:45.116939Z",
+     "shell.execute_reply": "2026-08-20T11:48:45.115708Z"
     },
     "papermill": {
-     "duration": 0.014641,
-     "end_time": "2026-08-20T08:48:03.312959+00:00",
+     "duration": 0.044801,
+     "end_time": "2026-08-20T11:48:45.117872+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.298318+00:00",
+     "start_time": "2026-08-20T11:48:45.073071+00:00",
      "status": "completed"
     },
     "tags": []
@@ -309,10 +315,10 @@
    "id": "6a898168",
    "metadata": {
     "papermill": {
-     "duration": 0.004074,
-     "end_time": "2026-08-20T08:48:03.321107+00:00",
+     "duration": 0.008087,
+     "end_time": "2026-08-20T11:48:45.136529+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.317033+00:00",
+     "start_time": "2026-08-20T11:48:45.128442+00:00",
      "status": "completed"
     },
     "tags": []
@@ -344,10 +350,10 @@
    "id": "074bd1c4",
    "metadata": {
     "papermill": {
-     "duration": 0.004186,
-     "end_time": "2026-08-20T08:48:03.329309+00:00",
+     "duration": 0.00699,
+     "end_time": "2026-08-20T11:48:45.153481+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.325123+00:00",
+     "start_time": "2026-08-20T11:48:45.146491+00:00",
      "status": "completed"
     },
     "tags": []
@@ -368,16 +374,16 @@
    "id": "36e448cf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:03.338755Z",
-     "iopub.status.busy": "2026-08-20T08:48:03.338566Z",
-     "iopub.status.idle": "2026-08-20T08:48:03.345580Z",
-     "shell.execute_reply": "2026-08-20T08:48:03.345078Z"
+     "iopub.execute_input": "2026-08-20T11:48:45.178275Z",
+     "iopub.status.busy": "2026-08-20T11:48:45.177777Z",
+     "iopub.status.idle": "2026-08-20T11:48:45.193192Z",
+     "shell.execute_reply": "2026-08-20T11:48:45.191849Z"
     },
     "papermill": {
-     "duration": 0.012802,
-     "end_time": "2026-08-20T08:48:03.346278+00:00",
+     "duration": 0.029954,
+     "end_time": "2026-08-20T11:48:45.194393+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.333476+00:00",
+     "start_time": "2026-08-20T11:48:45.164439+00:00",
      "status": "completed"
     },
     "tags": []
@@ -475,10 +481,10 @@
    "id": "33e976ac",
    "metadata": {
     "papermill": {
-     "duration": 0.004232,
-     "end_time": "2026-08-20T08:48:03.354788+00:00",
+     "duration": 0.012866,
+     "end_time": "2026-08-20T11:48:45.219873+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.350556+00:00",
+     "start_time": "2026-08-20T11:48:45.207007+00:00",
      "status": "completed"
     },
     "tags": []
@@ -498,16 +504,16 @@
    "id": "d612595c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:03.364303Z",
-     "iopub.status.busy": "2026-08-20T08:48:03.364127Z",
-     "iopub.status.idle": "2026-08-20T08:48:03.370911Z",
-     "shell.execute_reply": "2026-08-20T08:48:03.369978Z"
+     "iopub.execute_input": "2026-08-20T11:48:45.257563Z",
+     "iopub.status.busy": "2026-08-20T11:48:45.257043Z",
+     "iopub.status.idle": "2026-08-20T11:48:45.270595Z",
+     "shell.execute_reply": "2026-08-20T11:48:45.269160Z"
     },
     "papermill": {
-     "duration": 0.012592,
-     "end_time": "2026-08-20T08:48:03.371548+00:00",
+     "duration": 0.046932,
+     "end_time": "2026-08-20T11:48:45.278998+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.358956+00:00",
+     "start_time": "2026-08-20T11:48:45.232066+00:00",
      "status": "completed"
     },
     "tags": []
@@ -578,10 +584,10 @@
    "id": "75beac6f",
    "metadata": {
     "papermill": {
-     "duration": 0.003923,
-     "end_time": "2026-08-20T08:48:03.379996+00:00",
+     "duration": 0.024244,
+     "end_time": "2026-08-20T11:48:45.348119+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.376073+00:00",
+     "start_time": "2026-08-20T11:48:45.323875+00:00",
      "status": "completed"
     },
     "tags": []
@@ -596,16 +602,16 @@
    "id": "a55a60b2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:03.388811Z",
-     "iopub.status.busy": "2026-08-20T08:48:03.388660Z",
-     "iopub.status.idle": "2026-08-20T08:48:10.362731Z",
-     "shell.execute_reply": "2026-08-20T08:48:10.361869Z"
+     "iopub.execute_input": "2026-08-20T11:48:45.388641Z",
+     "iopub.status.busy": "2026-08-20T11:48:45.388107Z",
+     "iopub.status.idle": "2026-08-20T11:48:59.696684Z",
+     "shell.execute_reply": "2026-08-20T11:48:59.695315Z"
     },
     "papermill": {
-     "duration": 6.979421,
-     "end_time": "2026-08-20T08:48:10.363385+00:00",
+     "duration": 14.326756,
+     "end_time": "2026-08-20T11:48:59.697806+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:03.383964+00:00",
+     "start_time": "2026-08-20T11:48:45.371050+00:00",
      "status": "completed"
     },
     "tags": []
@@ -638,7 +644,7 @@
      "text": [
       "\n",
       "\n",
-      "Solution (inference: 7.0s):\n",
+      "Solution (inference: 14.3s):\n",
       "-------------------------\n",
       "| 9 6 2 | 1 8 5 | 4 7 3 |\n",
       "| 1 7 4 | 9 6 3 | 8 2 5 |\n",
@@ -655,8 +661,8 @@
       "\n",
       "Resultats:\n",
       "  - Iterations SVI: 300\n",
-      "  - Temps inference: 7.0s\n",
-      "  - Temps total: 7.0s\n",
+      "  - Temps inference: 14.3s\n",
+      "  - Temps total: 14.3s\n",
       "  - Converge: True\n",
       "  - Erreurs: 0\n"
      ]
@@ -692,10 +698,10 @@
    "id": "a7db79c3",
    "metadata": {
     "papermill": {
-     "duration": 0.007588,
-     "end_time": "2026-08-20T08:48:10.377532+00:00",
+     "duration": 0.010699,
+     "end_time": "2026-08-20T11:48:59.719428+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.369944+00:00",
+     "start_time": "2026-08-20T11:48:59.708729+00:00",
      "status": "completed"
     },
     "tags": []
@@ -727,10 +733,10 @@
    "id": "0df3f512",
    "metadata": {
     "papermill": {
-     "duration": 0.007381,
-     "end_time": "2026-08-20T08:48:10.392127+00:00",
+     "duration": 0.006629,
+     "end_time": "2026-08-20T11:48:59.733521+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.384746+00:00",
+     "start_time": "2026-08-20T11:48:59.726892+00:00",
      "status": "completed"
     },
     "tags": []
@@ -762,16 +768,16 @@
    "id": "8449e4d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:10.403957Z",
-     "iopub.status.busy": "2026-08-20T08:48:10.403724Z",
-     "iopub.status.idle": "2026-08-20T08:48:10.409720Z",
-     "shell.execute_reply": "2026-08-20T08:48:10.409141Z"
+     "iopub.execute_input": "2026-08-20T11:48:59.751587Z",
+     "iopub.status.busy": "2026-08-20T11:48:59.751201Z",
+     "iopub.status.idle": "2026-08-20T11:48:59.761361Z",
+     "shell.execute_reply": "2026-08-20T11:48:59.760159Z"
     },
     "papermill": {
-     "duration": 0.013154,
-     "end_time": "2026-08-20T08:48:10.410326+00:00",
+     "duration": 0.019804,
+     "end_time": "2026-08-20T11:48:59.762246+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.397172+00:00",
+     "start_time": "2026-08-20T11:48:59.742442+00:00",
      "status": "completed"
     },
     "tags": []
@@ -872,10 +878,10 @@
    "id": "ex-count-candidates",
    "metadata": {
     "papermill": {
-     "duration": 0.00447,
-     "end_time": "2026-08-20T08:48:10.419595+00:00",
+     "duration": 0.009756,
+     "end_time": "2026-08-20T11:48:59.781361+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.415125+00:00",
+     "start_time": "2026-08-20T11:48:59.771605+00:00",
      "status": "completed"
     },
     "tags": []
@@ -903,16 +909,16 @@
    "id": "ex-count-candidates-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:10.430078Z",
-     "iopub.status.busy": "2026-08-20T08:48:10.429886Z",
-     "iopub.status.idle": "2026-08-20T08:48:10.435074Z",
-     "shell.execute_reply": "2026-08-20T08:48:10.434429Z"
+     "iopub.execute_input": "2026-08-20T11:48:59.805605Z",
+     "iopub.status.busy": "2026-08-20T11:48:59.805092Z",
+     "iopub.status.idle": "2026-08-20T11:48:59.814238Z",
+     "shell.execute_reply": "2026-08-20T11:48:59.812777Z"
     },
     "papermill": {
-     "duration": 0.011325,
-     "end_time": "2026-08-20T08:48:10.435570+00:00",
+     "duration": 0.025043,
+     "end_time": "2026-08-20T11:48:59.815480+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.424245+00:00",
+     "start_time": "2026-08-20T11:48:59.790437+00:00",
      "status": "completed"
     },
     "tags": []
@@ -980,10 +986,10 @@
    "id": "19ab91a8",
    "metadata": {
     "papermill": {
-     "duration": 0.004518,
-     "end_time": "2026-08-20T08:48:10.444637+00:00",
+     "duration": 0.011854,
+     "end_time": "2026-08-20T11:48:59.837069+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.440119+00:00",
+     "start_time": "2026-08-20T11:48:59.825215+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1000,16 +1006,16 @@
    "id": "2dab7e0f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:10.454751Z",
-     "iopub.status.busy": "2026-08-20T08:48:10.454562Z",
-     "iopub.status.idle": "2026-08-20T08:48:10.462582Z",
-     "shell.execute_reply": "2026-08-20T08:48:10.462096Z"
+     "iopub.execute_input": "2026-08-20T11:48:59.860422Z",
+     "iopub.status.busy": "2026-08-20T11:48:59.859999Z",
+     "iopub.status.idle": "2026-08-20T11:48:59.875283Z",
+     "shell.execute_reply": "2026-08-20T11:48:59.873868Z"
     },
     "papermill": {
-     "duration": 0.014261,
-     "end_time": "2026-08-20T08:48:10.463408+00:00",
+     "duration": 0.028897,
+     "end_time": "2026-08-20T11:48:59.876362+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.449147+00:00",
+     "start_time": "2026-08-20T11:48:59.847465+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1098,10 +1104,10 @@
    "id": "bc0f034f",
    "metadata": {
     "papermill": {
-     "duration": 0.004121,
-     "end_time": "2026-08-20T08:48:10.471751+00:00",
+     "duration": 0.009739,
+     "end_time": "2026-08-20T11:48:59.894498+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.467630+00:00",
+     "start_time": "2026-08-20T11:48:59.884759+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1116,16 +1122,16 @@
    "id": "d42a58fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:48:10.481292Z",
-     "iopub.status.busy": "2026-08-20T08:48:10.481138Z",
-     "iopub.status.idle": "2026-08-20T08:55:36.713634Z",
-     "shell.execute_reply": "2026-08-20T08:55:36.712924Z"
+     "iopub.execute_input": "2026-08-20T11:48:59.912387Z",
+     "iopub.status.busy": "2026-08-20T11:48:59.911896Z",
+     "iopub.status.idle": "2026-08-20T11:59:44.668725Z",
+     "shell.execute_reply": "2026-08-20T11:59:44.666891Z"
     },
     "papermill": {
-     "duration": 446.242811,
-     "end_time": "2026-08-20T08:55:36.719008+00:00",
+     "duration": 644.791909,
+     "end_time": "2026-08-20T11:59:44.694209+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:48:10.476197+00:00",
+     "start_time": "2026-08-20T11:48:59.902300+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1146,8 +1152,8 @@
       "Puzzle 1: OK\n",
       "  - Etapes: 36\n",
       "  - Cellules fixees (probabiliste): 36\n",
-      "  - Temps inference: 173.1s\n",
-      "  - Temps total: 185.1s\n"
+      "  - Temps inference: 288.2s\n",
+      "  - Temps total: 309.2s\n"
      ]
     },
     {
@@ -1158,8 +1164,8 @@
       "Puzzle 2: OK\n",
       "  - Etapes: 49\n",
       "  - Cellules fixees (probabiliste): 49\n",
-      "  - Temps inference: 244.1s\n",
-      "  - Temps total: 261.1s\n"
+      "  - Temps inference: 310.6s\n",
+      "  - Temps total: 335.5s\n"
      ]
     }
    ],
@@ -1194,10 +1200,10 @@
    "id": "44d951b2",
    "metadata": {
     "papermill": {
-     "duration": 0.005106,
-     "end_time": "2026-08-20T08:55:36.729443+00:00",
+     "duration": 0.007876,
+     "end_time": "2026-08-20T11:59:44.716247+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:55:36.724337+00:00",
+     "start_time": "2026-08-20T11:59:44.708371+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1230,10 +1236,10 @@
    "id": "ex-verify-deterministic",
    "metadata": {
     "papermill": {
-     "duration": 0.005126,
-     "end_time": "2026-08-20T08:55:36.739715+00:00",
+     "duration": 0.005853,
+     "end_time": "2026-08-20T11:59:44.727924+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:55:36.734589+00:00",
+     "start_time": "2026-08-20T11:59:44.722071+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1261,16 +1267,16 @@
    "id": "ex-verify-deterministic-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:55:36.752150Z",
-     "iopub.status.busy": "2026-08-20T08:55:36.751692Z",
-     "iopub.status.idle": "2026-08-20T08:55:36.759470Z",
-     "shell.execute_reply": "2026-08-20T08:55:36.758835Z"
+     "iopub.execute_input": "2026-08-20T11:59:44.742824Z",
+     "iopub.status.busy": "2026-08-20T11:59:44.742610Z",
+     "iopub.status.idle": "2026-08-20T11:59:44.761223Z",
+     "shell.execute_reply": "2026-08-20T11:59:44.760480Z"
     },
     "papermill": {
-     "duration": 0.01529,
-     "end_time": "2026-08-20T08:55:36.760300+00:00",
+     "duration": 0.027879,
+     "end_time": "2026-08-20T11:59:44.762192+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:55:36.745010+00:00",
+     "start_time": "2026-08-20T11:59:44.734313+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1356,10 +1362,10 @@
    "id": "bp88768356",
    "metadata": {
     "papermill": {
-     "duration": 0.004755,
-     "end_time": "2026-08-20T08:55:36.769936+00:00",
+     "duration": 0.005337,
+     "end_time": "2026-08-20T11:59:44.773769+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:55:36.765181+00:00",
+     "start_time": "2026-08-20T11:59:44.768432+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1404,16 +1410,16 @@
    "id": "bp68917446",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:55:36.781303Z",
-     "iopub.status.busy": "2026-08-20T08:55:36.781081Z",
-     "iopub.status.idle": "2026-08-20T08:55:36.804465Z",
-     "shell.execute_reply": "2026-08-20T08:55:36.803725Z"
+     "iopub.execute_input": "2026-08-20T11:59:44.788024Z",
+     "iopub.status.busy": "2026-08-20T11:59:44.787783Z",
+     "iopub.status.idle": "2026-08-20T11:59:44.815109Z",
+     "shell.execute_reply": "2026-08-20T11:59:44.814442Z"
     },
     "papermill": {
-     "duration": 0.03024,
-     "end_time": "2026-08-20T08:55:36.805040+00:00",
+     "duration": 0.036497,
+     "end_time": "2026-08-20T11:59:44.816019+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:55:36.774800+00:00",
+     "start_time": "2026-08-20T11:59:44.779522+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1653,10 +1659,10 @@
    "id": "bp26490740",
    "metadata": {
     "papermill": {
-     "duration": 0.004952,
-     "end_time": "2026-08-20T08:55:36.814812+00:00",
+     "duration": 0.005659,
+     "end_time": "2026-08-20T11:59:44.828726+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:55:36.809860+00:00",
+     "start_time": "2026-08-20T11:59:44.823067+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1675,16 +1681,16 @@
    "id": "bp28685528",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:55:36.826070Z",
-     "iopub.status.busy": "2026-08-20T08:55:36.825886Z",
-     "iopub.status.idle": "2026-08-20T08:57:43.629656Z",
-     "shell.execute_reply": "2026-08-20T08:57:43.629088Z"
+     "iopub.execute_input": "2026-08-20T11:59:44.843183Z",
+     "iopub.status.busy": "2026-08-20T11:59:44.842769Z",
+     "iopub.status.idle": "2026-08-20T12:02:25.819542Z",
+     "shell.execute_reply": "2026-08-20T12:02:25.818038Z"
     },
     "papermill": {
-     "duration": 126.815139,
-     "end_time": "2026-08-20T08:57:43.634834+00:00",
+     "duration": 161.004146,
+     "end_time": "2026-08-20T12:02:25.838944+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:55:36.819695+00:00",
+     "start_time": "2026-08-20T11:59:44.834798+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1725,7 +1731,7 @@
        "      <td>BP decimation</td>\n",
        "      <td>36/51</td>\n",
        "      <td>0.71</td>\n",
-       "      <td>484</td>\n",
+       "      <td>645</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1733,7 +1739,7 @@
        "      <td>BP + repli borne</td>\n",
        "      <td>35/51</td>\n",
        "      <td>0.69</td>\n",
-       "      <td>837</td>\n",
+       "      <td>1034</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -1741,7 +1747,7 @@
        "      <td>BP decimation</td>\n",
        "      <td>0/15</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>758</td>\n",
+       "      <td>981</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -1749,7 +1755,7 @@
        "      <td>BP + repli borne</td>\n",
        "      <td>0/15</td>\n",
        "      <td>0.00</td>\n",
-       "      <td>1764</td>\n",
+       "      <td>2115</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
@@ -1757,7 +1763,7 @@
        "      <td>BP decimation</td>\n",
        "      <td>3/11</td>\n",
        "      <td>0.27</td>\n",
-       "      <td>633</td>\n",
+       "      <td>812</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
@@ -1765,7 +1771,7 @@
        "      <td>BP + repli borne</td>\n",
        "      <td>4/11</td>\n",
        "      <td>0.36</td>\n",
-       "      <td>1282</td>\n",
+       "      <td>1651</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1773,12 +1779,12 @@
       ],
       "text/plain": [
        "                 corpus           solveur resolus  taux  ms/grille\n",
-       "0                Easy51     BP decimation   36/51  0.71        484\n",
-       "1                Easy51  BP + repli borne   35/51  0.69        837\n",
-       "2  top95 (15 premieres)     BP decimation    0/15  0.00        758\n",
-       "3  top95 (15 premieres)  BP + repli borne    0/15  0.00       1764\n",
-       "4          hardest (11)     BP decimation    3/11  0.27        633\n",
-       "5          hardest (11)  BP + repli borne    4/11  0.36       1282"
+       "0                Easy51     BP decimation   36/51  0.71        645\n",
+       "1                Easy51  BP + repli borne   35/51  0.69       1034\n",
+       "2  top95 (15 premieres)     BP decimation    0/15  0.00        981\n",
+       "3  top95 (15 premieres)  BP + repli borne    0/15  0.00       2115\n",
+       "4          hardest (11)     BP decimation    3/11  0.27        812\n",
+       "5          hardest (11)  BP + repli borne    4/11  0.36       1651"
       ]
      },
      "execution_count": 12,
@@ -1825,10 +1831,10 @@
    "id": "bp-interp-v3",
    "metadata": {
     "papermill": {
-     "duration": 0.00549,
-     "end_time": "2026-08-20T08:57:43.645456+00:00",
+     "duration": 0.006809,
+     "end_time": "2026-08-20T12:02:25.853578+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:43.639966+00:00",
+     "start_time": "2026-08-20T12:02:25.846769+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1863,10 +1869,10 @@
    "id": "b97214ed",
    "metadata": {
     "papermill": {
-     "duration": 0.004818,
-     "end_time": "2026-08-20T08:57:43.655342+00:00",
+     "duration": 0.006421,
+     "end_time": "2026-08-20T12:02:25.866733+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:43.650524+00:00",
+     "start_time": "2026-08-20T12:02:25.860312+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1897,16 +1903,16 @@
    "id": "38fb6458",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:57:43.667306Z",
-     "iopub.status.busy": "2026-08-20T08:57:43.666899Z",
-     "iopub.status.idle": "2026-08-20T08:57:44.492607Z",
-     "shell.execute_reply": "2026-08-20T08:57:44.491604Z"
+     "iopub.execute_input": "2026-08-20T12:02:25.884676Z",
+     "iopub.status.busy": "2026-08-20T12:02:25.884208Z",
+     "iopub.status.idle": "2026-08-20T12:02:31.000684Z",
+     "shell.execute_reply": "2026-08-20T12:02:30.999746Z"
     },
     "papermill": {
-     "duration": 0.832934,
-     "end_time": "2026-08-20T08:57:44.493312+00:00",
+     "duration": 5.129007,
+     "end_time": "2026-08-20T12:02:31.002512+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:43.660378+00:00",
+     "start_time": "2026-08-20T12:02:25.873505+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1926,7 +1932,11 @@
     "\n",
     "UNIT_CELLS = np.array(BP_UNITS)               # (27, 9) cellule plate de chaque slot\n",
     "\n",
-    "# Tables Ryser precalculees (sous-ensembles et signes) pour n=8 et n=9\n",
+    "# Formule de Ryser : perm(A) = somme sur les sous-ensembles S de lignes de\n",
+    "# (-1)^(n+|S|) * produit des sommes partielles de colonnes sur S. Iterer les\n",
+    "# 2^n sous-ensembles en Python serait trop lent ; on precalcule donc les\n",
+    "# tables une fois pour toutes : RYR_SUB[s, j] = la ligne j est-elle dans le\n",
+    "# sous-ensemble s (bits de s), RYR_SIGN[s] = le signe (-1)^(n+popcount(s)).\n",
     "RYR_SUB = np.array([[(s >> j) & 1 for j in range(8)] for s in range(256)], dtype=np.float64)\n",
     "RYR_SIGN = np.array([(-1.0) ** (8 + bin(s).count(\"1\")) for s in range(256)])\n",
     "RYR_SUB9 = np.array([[(s >> j) & 1 for j in range(9)] for s in range(512)], dtype=np.float64)\n",
@@ -1935,7 +1945,13 @@
     "\n",
     "\n",
     "def batch_perm8(minors):\n",
-    "    \"\"\"Permanentes d'un batch de matrices 8x8 (formule de Ryser, vectorisee).\"\"\"\n",
+    "    \"\"\"Permanentes d'un batch de matrices 8x8 (formule de Ryser, vectorisee).\n",
+    "\n",
+    "    L'einsum \"buv,sv->bsu\" calcule, pour chaque batch b et chaque sous-ensemble\n",
+    "    s, la somme u des colonnes sur les lignes de s (dimension intermediaire :\n",
+    "    (batch, sous-ensemble, colonne)). Le produit des 8 colonnes puis la\n",
+    "    combinaison lineaire avec les signes ferment la formule de Ryser.\n",
+    "    \"\"\"\n",
     "    rs = np.einsum(\"buv,sv->bsu\", minors, RYR_SUB)\n",
     "    return RYR_SIGN @ rs.prod(axis=2).T\n",
     "\n",
@@ -1947,9 +1963,17 @@
     "\n",
     "\n",
     "def unit_minors(M):\n",
-    "    \"\"\"M (B, 9, 9) -> mineurs (B, 9, 9, 8, 8) : [b, i, v] = M[b] sans ligne i ni colonne v.\"\"\"\n",
-    "    Mr = M[:, KEEP8, :]\n",
-    "    Mc = Mr[:, :, :, KEEP8]\n",
+    "    \"\"\"M (B, 9, 9) -> mineurs (B, 9, 9, 8, 8) : [b, i, v] = M[b] sans ligne i ni colonne v.\n",
+    "\n",
+    "    Le mineur (i, v) est la matrice 8x8 obtenue en retirant la ligne i (la\n",
+    "    cellule qu'on interroge) et la colonne v (la valeur candidate) : sa\n",
+    "    permanente = poids total des affectations injectives ou cellule i prend v.\n",
+    "    KEEP8[i] liste les 8 indices conserves quand on retire i. Le transpose+\n",
+    "    reshape reorganise les axes en (batch, cellule, valeur, 8, 8) sans copie\n",
+    "    par element.\n",
+    "    \"\"\"\n",
+    "    Mr = M[:, KEEP8, :]          # retire la ligne i -> (B, 9, 9, 9, 8)\n",
+    "    Mc = Mr[:, :, :, KEEP8]      # retire la colonne v -> (B, 9, 9, 8, 8)\n",
     "    return Mc.transpose(0, 1, 3, 2, 4).reshape(M.shape[0], 9, 9, 8, 8)\n",
     "\n",
     "\n",
@@ -1958,6 +1982,11 @@
     "    d'affectation injective du mineur (algorithme hongrois, max-product).\"\"\"\n",
     "    B = minors.shape[0]\n",
     "    out = np.empty(B)\n",
+    "    # Max-produit en espace log : le produit des entrees selectionnees devient\n",
+    "    # une somme de logs. linear_sum_assignment minimise un cout -> on lui donne\n",
+    "    # -log(message) ; le cout minimal correspond au produit maximal, et -cout\n",
+    "    # restitue le log du meilleur produit. BP_EPS plafonne les messages nuls\n",
+    "    # (une affectation interdite) sans creer de log(0).\n",
     "    L = -np.log(np.maximum(minors, BP_EPS))\n",
     "    for b in range(B):\n",
     "        ri, ci = linear_sum_assignment(L[b])\n",
@@ -1989,10 +2018,10 @@
    "id": "3d7e06fb",
    "metadata": {
     "papermill": {
-     "duration": 0.006001,
-     "end_time": "2026-08-20T08:57:44.505612+00:00",
+     "duration": 0.006499,
+     "end_time": "2026-08-20T12:02:31.017070+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:44.499611+00:00",
+     "start_time": "2026-08-20T12:02:31.010571+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2009,16 +2038,16 @@
    "id": "ad6e7441",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:57:44.519134Z",
-     "iopub.status.busy": "2026-08-20T08:57:44.518894Z",
-     "iopub.status.idle": "2026-08-20T08:57:44.551510Z",
-     "shell.execute_reply": "2026-08-20T08:57:44.550581Z"
+     "iopub.execute_input": "2026-08-20T12:02:31.034745Z",
+     "iopub.status.busy": "2026-08-20T12:02:31.034423Z",
+     "iopub.status.idle": "2026-08-20T12:02:31.071677Z",
+     "shell.execute_reply": "2026-08-20T12:02:31.071028Z"
     },
     "papermill": {
-     "duration": 0.040791,
-     "end_time": "2026-08-20T08:57:44.552320+00:00",
+     "duration": 0.050018,
+     "end_time": "2026-08-20T12:02:31.072807+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:44.511529+00:00",
+     "start_time": "2026-08-20T12:02:31.022789+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2043,6 +2072,14 @@
    ],
    "source": [
     "# Demonstration sur une unite isolee : meme evidence, deux couches facteur.\n",
+    "#\n",
+    "# Construction d'un ensemble de Hall de taille 2 : c1 et c2 voient toutes\n",
+    "# deux {3, 7} (deux cellules, deux valeurs : c'est exactement faisable,\n",
+    "# donc 3 et 7 sont CONSOMMES par c1/c2) ; la spectatrice c9 voit {3, 7, 9}.\n",
+    "# La valeur 9 est donc la seule possible pour c9 -- mais seule la couche\n",
+    "# arity-9 peut le VOIR, car il faut raisonner sur l'affectation injective\n",
+    "# complete de l'unite, pas sur des paires isolees. Les 6 autres cellules\n",
+    "# reoivent une valeur donnee pour fermer l'unite.\n",
     "hall_ev = np.full((9, 9), BP_EPS)\n",
     "for slot, val in zip(range(2, 8), [1, 2, 4, 5, 6, 8]):   # 6 cellules donnees\n",
     "    hall_ev[slot, val - 1] = 1.0\n",
@@ -2051,6 +2088,8 @@
     "hall_ev[8, 2] = hall_ev[8, 6] = hall_ev[8, 8] = 1.0 / 3.0 # spectatrice : {3,7,9}\n",
     "\n",
     "# --- couche 1 : relaxation par paires (meme moteur que la v3, unite seule)\n",
+    "# On isole le moteur v3 : messages F (facteur->cellule) et C\n",
+    "# (cellule->facteur) entre cellules liees par un facteur != binaire.\n",
     "_diag = np.arange(9)\n",
     "F = np.full((9, 9, 9), 1.0 / 9)      # F[i, j] = message facteur(i,j) -> i\n",
     "C = np.full((9, 9, 9), 1.0 / 9)      # C[i, j] = message cellule i -> facteur(i,j)\n",
@@ -2099,10 +2138,10 @@
    "id": "bfb9c3f9",
    "metadata": {
     "papermill": {
-     "duration": 0.006394,
-     "end_time": "2026-08-20T08:57:44.564421+00:00",
+     "duration": 0.006293,
+     "end_time": "2026-08-20T12:02:31.085555+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:44.558027+00:00",
+     "start_time": "2026-08-20T12:02:31.079262+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2118,10 +2157,10 @@
    "id": "f9ba15be",
    "metadata": {
     "papermill": {
-     "duration": 0.005844,
-     "end_time": "2026-08-20T08:57:44.575867+00:00",
+     "duration": 0.007065,
+     "end_time": "2026-08-20T12:02:31.098239+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:44.570023+00:00",
+     "start_time": "2026-08-20T12:02:31.091174+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2138,16 +2177,16 @@
    "id": "36e6f574",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:57:44.593499Z",
-     "iopub.status.busy": "2026-08-20T08:57:44.593168Z",
-     "iopub.status.idle": "2026-08-20T08:57:44.613368Z",
-     "shell.execute_reply": "2026-08-20T08:57:44.612538Z"
+     "iopub.execute_input": "2026-08-20T12:02:31.114890Z",
+     "iopub.status.busy": "2026-08-20T12:02:31.114511Z",
+     "iopub.status.idle": "2026-08-20T12:02:31.145119Z",
+     "shell.execute_reply": "2026-08-20T12:02:31.144106Z"
     },
     "papermill": {
-     "duration": 0.028814,
-     "end_time": "2026-08-20T08:57:44.613945+00:00",
+     "duration": 0.040583,
+     "end_time": "2026-08-20T12:02:31.145967+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:44.585131+00:00",
+     "start_time": "2026-08-20T12:02:31.105384+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2181,6 +2220,12 @@
     "        self.noise = noise\n",
     "\n",
     "    def solve(self, grid81, seed=0):\n",
+    "        \"\"\"Boucle externe : jusqu'a max_restarts tentatives, semee une fois pour toutes.\n",
+    "\n",
+    "        Chaque tentative (_attempt) part d'un bruit d'init different ; si la\n",
+    "        decimation aboutit a une contradiction (grille finale invalide), la\n",
+    "        tentative suivante repart de l'evidence d'origine avec un autre bruit.\n",
+    "        \"\"\"\n",
     "        rng = np.random.default_rng(seed)\n",
     "        stats = {\"decisions\": 0, \"sweeps\": 0, \"contradictions\": 0, \"restarts\": 0,\n",
     "                 \"ms\": 0.0}\n",
@@ -2196,13 +2241,26 @@
     "        return None, stats\n",
     "\n",
     "    def _attempt(self, grid, rng, stats, restart):\n",
+    "        \"\"\"Une tentative complete : init des messages -> BP -> decimation.\n",
+    "\n",
+    "        Renvoie la grille resolue (verifiee) ou None (contradiction ou\n",
+    "        decimation inherente). Toute la randomisation vient du rng commun.\n",
+    "        \"\"\"\n",
+    "        # Evidence : les cellules donnees deviennent des deltas (0 partout\n",
+    "        # sauf leur valeur), les autres restent uniformes. C'est le SEUL\n",
+    "        # apport d'information exterieur -- ensuite tout est message-passing.\n",
     "        evidence = np.full((81, 9), 1.0 / 9)\n",
     "        assigned = grid > 0\n",
     "        for i in np.flatnonzero(assigned):\n",
     "            evidence[i, :] = BP_EPS\n",
     "            evidence[i, grid[i] - 1] = 1.0\n",
     "            evidence[i] = evidence[i] / evidence[i].sum()\n",
-    "        # restart 0 : uniforme ; suivants : bruit log-uniforme constant\n",
+    "        # Restart 0 : messages uniformes (le point fixe canonique). Redemarrages\n",
+    "        # suivants : chaque message cellule->facteur reoit un bruit\n",
+    "        # multiplicatif uniforme en espace log. C'est le moteur de\n",
+    "        # l'exploration : un point fixe BP symetrique (ex. grille a deux\n",
+    "        # solutions) sera leve differemment selon le bruit, la ou le\n",
+    "        # pairwise n'avait qu'un seul bassin d'attraction.\n",
     "        scale = 0.0 if restart == 0 else self.noise\n",
     "        base = evidence[UNIT_CELLS]\n",
     "        if scale > 0:\n",
@@ -2212,6 +2270,12 @@
     "        else:\n",
     "            m_c2f = base.copy()\n",
     "        m_f2c = np.full((27, 9, 9), 1.0 / 9)\n",
+    "        # Optimisation cles : les mineurs ne sont calcules QUE pour les\n",
+    "        # cellules libres. Pour une cellule donnee, la ligne du mineur est\n",
+    "        # un delta (0 sauf sa valeur) : la permanente est exactement 0 pour\n",
+    "        # toute autre valeur -- le message est connu gratuitement, inutile\n",
+    "        # de payer un hongrois 8x8 pour lui. upd_mask fige aussi les\n",
+    "        # messages de ces cellules (leur evidence ne change plus).\n",
     "        free_slots = [np.flatnonzero(grid[np.array(u)] == 0).astype(int)\n",
     "                      for u in BP_UNITS]\n",
     "        upd_mask = np.zeros((27, 9), dtype=bool)\n",
@@ -2221,9 +2285,17 @@
     "        def sweep(n):\n",
     "            nonlocal m_f2c, m_c2f\n",
     "            for _ in range(n):\n",
+    "                # --- passe facteur->cellule : LE coeur arity-9 ---\n",
+    "                # Mineurs de toutes les unites (cellules libres seulement),\n",
+    "                # regroupes en un seul batch (b, 8, 8) pour passer la\n",
+    "                # totalite des hongrois d'un balayage d'un coup.\n",
     "                mins = unit_minors(m_c2f)\n",
     "                sel = np.concatenate([mins[u][free_slots[u]] for u in range(27)])\n",
     "                logs = hungarian_maxprod(sel.reshape(-1, 8, 8))\n",
+    "                # Chaque message f2c[u, cellule] = log du meilleur produit\n",
+    "                # d'affectation de l'unite u OU la cellule prend la valeur v\n",
+    "                # (= le hongrois du mineur). Normalisation par ligne (le\n",
+    "                # max a 0) pour rester en espace probabilite sans underflow.\n",
     "                new_f2c = np.zeros((27, 9, 9))\n",
     "                ofs = 0\n",
     "                for u in range(27):\n",
@@ -2233,9 +2305,17 @@
     "                        raw = raw - raw.max(axis=1, keepdims=True)\n",
     "                        new_f2c[u, free_slots[u]] = np.exp(raw)\n",
     "                        ofs += j * 9\n",
+    "                # Damping : melange de l'ancien et du nouveau message (poids\n",
+    "                # 1-damping). Indispensable en loopy BP pour eviter\n",
+    "                # l'oscillation du a l'echange cyclique de messages.\n",
     "                new_f2c = _bp_normalize(new_f2c)\n",
     "                m_f2c = _bp_normalize(self.damping * m_f2c\n",
     "                                      + (1 - self.damping) * new_f2c)\n",
+    "                # --- passe cellule->facteur ---\n",
+    "                # Le message c2f retire sa propre contribution f2c du\n",
+    "                # total (evidence + somme des messages recus) : c'est le\n",
+    "                # message extrinsique, il ne doit pas se re-envoyer\n",
+    "                # l'information qu'il vient de recevoir (contre-réaction).\n",
     "                log_tot = np.log(evidence + BP_EPS).copy()\n",
     "                np.add.at(log_tot, UNIT_CELLS.reshape(-1),\n",
     "                          np.log(m_f2c + BP_EPS).reshape(-1, 9))\n",
@@ -2253,13 +2333,28 @@
     "            b = np.exp(log_b - log_b.max(axis=1, keepdims=True))\n",
     "            return b / b.sum(axis=1, keepdims=True)\n",
     "\n",
+    "        # Croyances initiales apres init_sweeps balayages a effectif plein\n",
+    "        # (toutes cellules libres) : le point fixe approximatif du BP.\n",
     "        beliefs = sweep(self.init_sweeps)\n",
+    "        # --- decimation : decider, figer, re-propager ---\n",
+    "        # A chaque etape on choisit la cellule la plus confiante (marge =\n",
+    "        # ecart entre les deux meilleures valeurs), on la FIGE dans\n",
+    "        # l'evidence (delta), puis on re-propage decim_sweeps balayages.\n",
+    "        # Figer reduit les unites : les mineurs rétrécissent d'une ligne a\n",
+    "        # chaque decision de leurs membres, la structure restante devient\n",
+    "        # plus contrainte -- c'est la que les ensembles de Hall sautent.\n",
     "        while not assigned.all():\n",
     "            part = np.partition(beliefs, -2, axis=1)\n",
     "            margins = part[:, -1] - part[:, -2]\n",
     "            margins[assigned] = -np.inf\n",
     "            top = np.flatnonzero(margins >= margins.max() - 1e-12)\n",
     "            i = int(rng.choice(top)) if len(top) > 1 else int(top[0])\n",
+    "            # Plateau : si la marge est trop faible (croyance presque\n",
+    "            # uniforme, typique au coeur d'un ensemble de Hall symetrique),\n",
+    "            # on TIRE selon la croyance au lieu de prendre l'argmax -- un\n",
+    "            # tirage selon la croyance est de l'inférence probabiliste\n",
+    "            # randomisée, pas de la propagation déterministe : on casse la\n",
+    "            # symetrie en respectant les poids, sans regle exterieure.\n",
     "            if margins[i] < self.plateau:\n",
     "                v = int(rng.choice(9, p=beliefs[i] / beliefs[i].sum()))\n",
     "            else:\n",
@@ -2268,6 +2363,10 @@
     "            evidence[i, v] = 1.0\n",
     "            evidence[i] = evidence[i] / evidence[i].sum()\n",
     "            assigned[i] = True\n",
+    "            # Propagation de la decision : le delta remplace le message\n",
+    "            # c2f de la cellule, et elle sort des free_slots des 3 unites\n",
+    "            # (lignes/colonnes/blocs) auxquelles elle appartient -- ses\n",
+    "            # mineurs ne seront plus calcules.\n",
     "            m_c2f[UNIT_CELLS == i] = evidence[i]\n",
     "            for u in np.flatnonzero([i in unit for unit in BP_UNITS]):\n",
     "                free_slots[u] = np.array([s for s in free_slots[u]\n",
@@ -2363,6 +2462,10 @@
     "            upd_mask[u] = False\n",
     "            upd_mask[u, free_slots[u]] = True\n",
     "        beliefs = sweep(decim_sweeps)\n",
+    "    # Grille finale : les cellules donnees restent, les decimees\n",
+    "    # prennent leur valeur figee. Verif COMPLETE (lignes, colonnes,\n",
+    "    # blocs) : une decimation qui se contredit renvoie None -> le\n",
+    "    # solveur relancera une tentative avec un autre bruit.\n",
     "    out = grid.copy()\n",
     "    for i in range(81):\n",
     "        if grid[i] == 0:\n",
@@ -2375,10 +2478,10 @@
    "id": "3babd009",
    "metadata": {
     "papermill": {
-     "duration": 0.005317,
-     "end_time": "2026-08-20T08:57:44.624875+00:00",
+     "duration": 0.009624,
+     "end_time": "2026-08-20T12:02:31.165986+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:44.619558+00:00",
+     "start_time": "2026-08-20T12:02:31.156362+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2395,16 +2498,16 @@
    "id": "2683c6af",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T08:57:44.636125Z",
-     "iopub.status.busy": "2026-08-20T08:57:44.635923Z",
-     "iopub.status.idle": "2026-08-20T09:14:44.780483Z",
-     "shell.execute_reply": "2026-08-20T09:14:44.779795Z"
+     "iopub.execute_input": "2026-08-20T12:02:31.199721Z",
+     "iopub.status.busy": "2026-08-20T12:02:31.199367Z",
+     "iopub.status.idle": "2026-08-20T12:20:05.371108Z",
+     "shell.execute_reply": "2026-08-20T12:20:05.369998Z"
     },
     "papermill": {
-     "duration": 1020.155254,
-     "end_time": "2026-08-20T09:14:44.785060+00:00",
+     "duration": 1054.201128,
+     "end_time": "2026-08-20T12:20:05.375648+00:00",
      "exception": false,
-     "start_time": "2026-08-20T08:57:44.629806+00:00",
+     "start_time": "2026-08-20T12:02:31.174520+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2414,21 +2517,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Easy51 51/51 (100%) 1709 ms/grille\n"
+      "Easy51 51/51 (100%) 1972 ms/grille\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "top95 (15 premieres) 9/15 (60%) 31742 ms/grille\n"
+      "top95 (15 premieres) 9/15 (60%) 31752 ms/grille\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "hardest (11) 9/11 (82%) 20636 ms/grille\n",
+      "hardest (11) 9/11 (82%) 21335 ms/grille\n",
       "Critere Medium >= 80 % : 9/11 = 82% -> ATTEINT\n"
      ]
     },
@@ -2436,7 +2539,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Temoin sum-product hardest (11) : 1/11 (9%) 20892 ms/grille\n"
+      "Temoin sum-product hardest (11) : 1/11 (9%) 22049 ms/grille\n"
      ]
     },
     {
@@ -2474,7 +2577,7 @@
        "      <td>BP arite 9 max-produit + decimation</td>\n",
        "      <td>51/51</td>\n",
        "      <td>1.00</td>\n",
-       "      <td>1709</td>\n",
+       "      <td>1972</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -2482,7 +2585,7 @@
        "      <td>BP arite 9 max-produit + decimation</td>\n",
        "      <td>9/15</td>\n",
        "      <td>0.60</td>\n",
-       "      <td>31742</td>\n",
+       "      <td>31752</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
@@ -2490,7 +2593,7 @@
        "      <td>BP arite 9 max-produit + decimation</td>\n",
        "      <td>9/11</td>\n",
        "      <td>0.82</td>\n",
-       "      <td>20636</td>\n",
+       "      <td>21335</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -2498,7 +2601,7 @@
        "      <td>BP arite 9 sum-produit (temoin)</td>\n",
        "      <td>1/11</td>\n",
        "      <td>0.09</td>\n",
-       "      <td>20892</td>\n",
+       "      <td>22049</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -2512,10 +2615,10 @@
        "3          hardest (11)      BP arite 9 sum-produit (temoin)    1/11  0.09   \n",
        "\n",
        "   ms/grille  \n",
-       "0       1709  \n",
-       "1      31742  \n",
-       "2      20636  \n",
-       "3      20892  "
+       "0       1972  \n",
+       "1      31752  \n",
+       "2      21335  \n",
+       "3      22049  "
       ]
      },
      "execution_count": 16,
@@ -2524,13 +2627,15 @@
     }
    ],
    "source": [
-    "v4_solver = Arity9MaxProductSolver()\n",
-    "v4_rows = []\n",
+    "v4_solver = Arity9MaxProductSolver()   # parametres RR30 : les valeurs livrees\n",
+    "v4_rows = []                            # (plateau 0.25, bruit 0.6, 30 restarts)\n",
     "for label, relpath, sub in bp_bench_sets:\n",
     "    puzzle_strs = load_puzzles(relpath, max_puzzles=sub)\n",
     "    flat_grids = [grid_to_flat(puzzle_to_grid(s)).tolist() for s in puzzle_strs]\n",
     "    t0 = time.time()\n",
     "    ok = 0\n",
+    "    # seed=k : la k-ieme grille de chaque corpus est TOUJOURS resolue avec\n",
+    "    # la meme semence -> bench reproductible d'une execution a l'autre.\n",
     "    for k, p in enumerate(flat_grids):\n",
     "        sol, st = v4_solver.solve(p, seed=k)\n",
     "        if sol is not None and verify_solution_flat(sol):\n",
@@ -2584,10 +2689,10 @@
    "id": "998bb5c0",
    "metadata": {
     "papermill": {
-     "duration": 0.004606,
-     "end_time": "2026-08-20T09:14:44.794604+00:00",
+     "duration": 0.005784,
+     "end_time": "2026-08-20T12:20:05.389455+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:14:44.789998+00:00",
+     "start_time": "2026-08-20T12:20:05.383671+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2603,10 +2708,10 @@
    "id": "3b7e2b44",
    "metadata": {
     "papermill": {
-     "duration": 0.004556,
-     "end_time": "2026-08-20T09:14:44.803799+00:00",
+     "duration": 0.005701,
+     "end_time": "2026-08-20T12:20:05.400745+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:14:44.799243+00:00",
+     "start_time": "2026-08-20T12:20:05.395044+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2623,16 +2728,16 @@
    "id": "16d46f53",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T09:14:44.813929Z",
-     "iopub.status.busy": "2026-08-20T09:14:44.813761Z",
-     "iopub.status.idle": "2026-08-20T09:14:45.999328Z",
-     "shell.execute_reply": "2026-08-20T09:14:45.998714Z"
+     "iopub.execute_input": "2026-08-20T12:20:05.415855Z",
+     "iopub.status.busy": "2026-08-20T12:20:05.415629Z",
+     "iopub.status.idle": "2026-08-20T12:20:06.662293Z",
+     "shell.execute_reply": "2026-08-20T12:20:06.661205Z"
     },
     "papermill": {
-     "duration": 1.191612,
-     "end_time": "2026-08-20T09:14:45.999943+00:00",
+     "duration": 1.255467,
+     "end_time": "2026-08-20T12:20:06.662901+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:14:44.808331+00:00",
+     "start_time": "2026-08-20T12:20:05.407434+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2642,15 +2747,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Balayage v3 (paires)          :    1.0 ms  (810 facteurs x O(9))\n",
-      "Balayage v4 sum-produit       :   49.2 ms  (1593 permanentes 8x8, Ryser 2^8 x 8)\n",
-      "Balayage v4 max-produit       :    8.6 ms  (1593 couplages hongrois 8x8)\n",
-      "Ratio v4-max/v3               : 8.3x\n"
+      "Balayage v3 (paires)          :    1.2 ms  (810 facteurs x O(9))\n",
+      "Balayage v4 sum-produit       :   51.4 ms  (1593 permanentes 8x8, Ryser 2^8 x 8)\n",
+      "Balayage v4 max-produit       :    9.2 ms  (1593 couplages hongrois 8x8)\n",
+      "Ratio v4-max/v3               : 7.9x\n"
      ]
     }
    ],
    "source": [
-    "# cout par balayage : meme grille, trois couches facteur, 20 balayages\n",
+    "# cout par balayage : meme grille, trois couches facteur, 20 balayages.\n",
+    "# On isole le cout d'UN balayage de chaque couche (hors decimation) :\n",
+    "# la v3 traite 810 facteurs O(9), la v4 sum traite ~1593 permanentes 8x8\n",
+    "# (Ryser 2^8 x 8), la v4 max ~1593 hongrois 8x8 -- meme probleme, trois\n",
+    "# prix differents pour le meme message exact.\n",
     "cost_grid = grid_to_flat(puzzle_to_grid(load_puzzles(\"Puzzles/Sudoku_hardest.txt\")[0]))\n",
     "cost_evidence = np.full((81, 9), 1.0 / 9)\n",
     "for i in np.flatnonzero(cost_grid > 0):\n",
@@ -2706,10 +2815,10 @@
    "id": "e8626295",
    "metadata": {
     "papermill": {
-     "duration": 0.004777,
-     "end_time": "2026-08-20T09:14:46.010176+00:00",
+     "duration": 0.005222,
+     "end_time": "2026-08-20T12:20:06.674521+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:14:46.005399+00:00",
+     "start_time": "2026-08-20T12:20:06.669299+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2717,7 +2826,7 @@
    "source": [
     "### Interprétation : le prix exact de l'information structurelle\n",
     "\n",
-    "Un balayage v4 coûte **8.6 ms** en max-product (hongrois) et **49.2 ms** en sum-product (Ryser) contre **1.0 ms** pour la v3 (8.3× le max-product) : 1593 couplages 8×8 ou 1593 permanentes 8×8 contre 810 facteurs O(9). Le surcoût est réel mais borné — quelques dizaines de millisecondes par balayage sur cette machine — et il n'achète pas « de la vitesse » mais de **l'information** : chaque message factor→cellule est désormais une quantité exacte sur les affectations injectives de l'unité (somme ou optimum), pas une approximation par paires. Sur un problème où la relaxation par paires est aveugle à une classe entière de structure (Hall), c'est le trade-off pertinent : payer un facteur borné par balayage pour convertir des grilles « impossibles » en résolues."
+    "Un balayage v4 coûte **9.2 ms** en max-product (hongrois) et **51.4 ms** en sum-product (Ryser) contre **1.2 ms** pour la v3 (7.9× le max-product) : 1593 couplages 8×8 ou 1593 permanentes 8×8 contre 810 facteurs O(9). Le surcoût est réel mais borné — quelques dizaines de millisecondes par balayage sur cette machine — et il n'achète pas « de la vitesse » mais de **l'information** : chaque message factor→cellule est désormais une quantité exacte sur les affectations injectives de l'unité (somme ou optimum), pas une approximation par paires. Sur un problème où la relaxation par paires est aveugle à une classe entière de structure (Hall), c'est le trade-off pertinent : payer un facteur borné par balayage pour convertir des grilles « impossibles » en résolues."
    ]
   },
   {
@@ -2725,10 +2834,10 @@
    "id": "e2d986e1",
    "metadata": {
     "papermill": {
-     "duration": 0.004765,
-     "end_time": "2026-08-20T09:14:46.019704+00:00",
+     "duration": 0.005508,
+     "end_time": "2026-08-20T12:20:06.686185+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:14:46.014939+00:00",
+     "start_time": "2026-08-20T12:20:06.680677+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2753,16 +2862,16 @@
    "id": "1163cd1d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T09:14:46.030422Z",
-     "iopub.status.busy": "2026-08-20T09:14:46.030256Z",
-     "iopub.status.idle": "2026-08-20T09:15:01.889100Z",
-     "shell.execute_reply": "2026-08-20T09:15:01.888452Z"
+     "iopub.execute_input": "2026-08-20T12:20:06.699440Z",
+     "iopub.status.busy": "2026-08-20T12:20:06.699118Z",
+     "iopub.status.idle": "2026-08-20T12:20:25.775467Z",
+     "shell.execute_reply": "2026-08-20T12:20:25.774602Z"
     },
     "papermill": {
-     "duration": 15.865188,
-     "end_time": "2026-08-20T09:15:01.889619+00:00",
+     "duration": 19.087787,
+     "end_time": "2026-08-20T12:20:25.779324+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:14:46.024431+00:00",
+     "start_time": "2026-08-20T12:20:06.691537+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2781,30 +2890,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 1: OK | Temps: 5.3s\n"
+      "  Puzzle 1: OK | Temps: 7.2s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 2: 8 erreurs | Temps: 5.2s\n"
+      "  Puzzle 2: 8 erreurs | Temps: 5.9s\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Puzzle 3: 8 erreurs | Temps: 5.3s\n",
+      "  Puzzle 3: 8 erreurs | Temps: 6.0s\n",
       "\n",
       "============================================================\n",
       "COMPARAISON PYTHON (NumPyro) vs C# (Infer.NET)\n",
       "============================================================\n",
       "Puzzle     Python (s)   C# (ms)      Python Status   C# Status      \n",
       "------------------------------------------------------------\n",
-      "1          5.3          33.9         Resolu          Resolu         \n",
-      "2          5.2          33.9         8 err           Resolu         \n",
-      "3          5.3          56.7         8 err           37 err         \n",
+      "1          7.2          33.9         Resolu          Resolu         \n",
+      "2          5.9          33.9         8 err           Resolu         \n",
+      "3          6.0          56.7         8 err           37 err         \n",
       "\n",
       "Observations:\n",
       "  - Infer.NET est ~100x plus rapide grace a:\n",
@@ -2872,10 +2981,10 @@
    "id": "6e447ffa",
    "metadata": {
     "papermill": {
-     "duration": 0.005145,
-     "end_time": "2026-08-20T09:15:01.900135+00:00",
+     "duration": 0.006148,
+     "end_time": "2026-08-20T12:20:25.791348+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:15:01.894990+00:00",
+     "start_time": "2026-08-20T12:20:25.785200+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2913,10 +3022,10 @@
    "id": "543d230f",
    "metadata": {
     "papermill": {
-     "duration": 0.004845,
-     "end_time": "2026-08-20T09:15:01.909825+00:00",
+     "duration": 0.006437,
+     "end_time": "2026-08-20T12:20:25.803890+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:15:01.904980+00:00",
+     "start_time": "2026-08-20T12:20:25.797453+00:00",
      "status": "completed"
     },
     "tags": []
@@ -2931,16 +3040,16 @@
    "id": "9518beb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T09:15:01.924909Z",
-     "iopub.status.busy": "2026-08-20T09:15:01.924735Z",
-     "iopub.status.idle": "2026-08-20T09:15:01.931043Z",
-     "shell.execute_reply": "2026-08-20T09:15:01.930138Z"
+     "iopub.execute_input": "2026-08-20T12:20:25.818925Z",
+     "iopub.status.busy": "2026-08-20T12:20:25.818681Z",
+     "iopub.status.idle": "2026-08-20T12:20:25.826805Z",
+     "shell.execute_reply": "2026-08-20T12:20:25.825935Z"
     },
     "papermill": {
-     "duration": 0.016787,
-     "end_time": "2026-08-20T09:15:01.931690+00:00",
+     "duration": 0.016796,
+     "end_time": "2026-08-20T12:20:25.827866+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:15:01.914903+00:00",
+     "start_time": "2026-08-20T12:20:25.811070+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3019,10 +3128,10 @@
    "id": "ee942928",
    "metadata": {
     "papermill": {
-     "duration": 0.005012,
-     "end_time": "2026-08-20T09:15:01.941594+00:00",
+     "duration": 0.00582,
+     "end_time": "2026-08-20T12:20:25.839692+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:15:01.936582+00:00",
+     "start_time": "2026-08-20T12:20:25.833872+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3056,10 +3165,10 @@
    "id": "ql41ouqadip",
    "metadata": {
     "papermill": {
-     "duration": 0.004976,
-     "end_time": "2026-08-20T09:15:01.951602+00:00",
+     "duration": 0.005478,
+     "end_time": "2026-08-20T12:20:25.851795+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:15:01.946626+00:00",
+     "start_time": "2026-08-20T12:20:25.846317+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3104,16 +3213,16 @@
    "id": "icemgf35orf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T09:15:01.963364Z",
-     "iopub.status.busy": "2026-08-20T09:15:01.963173Z",
-     "iopub.status.idle": "2026-08-20T09:15:01.967838Z",
-     "shell.execute_reply": "2026-08-20T09:15:01.967242Z"
+     "iopub.execute_input": "2026-08-20T12:20:25.866228Z",
+     "iopub.status.busy": "2026-08-20T12:20:25.865955Z",
+     "iopub.status.idle": "2026-08-20T12:20:25.871576Z",
+     "shell.execute_reply": "2026-08-20T12:20:25.870732Z"
     },
     "papermill": {
-     "duration": 0.011625,
-     "end_time": "2026-08-20T09:15:01.968389+00:00",
+     "duration": 0.014564,
+     "end_time": "2026-08-20T12:20:25.872206+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:15:01.956764+00:00",
+     "start_time": "2026-08-20T12:20:25.857642+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3189,10 +3298,10 @@
    "id": "16240cb9",
    "metadata": {
     "papermill": {
-     "duration": 0.004898,
-     "end_time": "2026-08-20T09:15:01.978412+00:00",
+     "duration": 0.006291,
+     "end_time": "2026-08-20T12:20:25.885082+00:00",
      "exception": false,
-     "start_time": "2026-08-20T09:15:01.973514+00:00",
+     "start_time": "2026-08-20T12:20:25.878791+00:00",
      "status": "completed"
     },
     "tags": []
@@ -3229,14 +3338,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 1624.26895,
-   "end_time": "2026-08-20T09:15:04.947500+00:00",
+   "duration": 1915.757307,
+   "end_time": "2026-08-20T12:20:28.859629+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Sudoku-15-Infer-Python.ipynb",
    "output_path": "Sudoku-15-Infer-Python_output.ipynb",
    "parameters": {},
-   "start_time": "2026-08-20T08:48:00.678550+00:00",
+   "start_time": "2026-08-20T11:48:33.102322+00:00",
    "version": "2.6.0"
   }
  },

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
@@ -67,6 +67,12 @@
       csharp_sha: 512fba1e200c93e18a783f836db20ffb72e46072
       content_python_sha: a37b842071b3e6a5f45b77b3e26f4a684d1f7fdfbc94a60b1f470b0028c8006e
       content_csharp_sha: fc20b2e34d282b3f5e5199f779d1330bdfa29bafc5afce3113c8835fc54b8a6b
+    - date: "2026-08-20"
+      by: myia-po-2024:CoursIA
+      python_sha: 806b7d1493ccf94a38494943e3e1797f18eaae2e
+      csharp_sha: 512fba1e200c93e18a783f836db20ffb72e46072
+      content_python_sha: b3d0aee61107421ec0a703b172299f0a41f04322a1e59a08a0973733f28ab88f
+      content_csharp_sha: fc20b2e34d282b3f5e5199f779d1330bdfa29bafc5afce3113c8835fc54b8a6b
   known_differences:
     - "Rebaseline 2026-08-17 : cote C# draine des timings MACHINE-DEP en cellule[24] (4 valeurs : 350 s, 349,9 s, 0,92 s, 922 ms, 5,8 minutes) et cellule[42] (4 valeurs : ~14-26 s, ~100 ms, ~1,8 s, ~18-112 ms, ~30-60 s) -- mandat #9377/#9434, drain des wall-clock prose (mandat user : seules les valeurs reproductibles d'une execution a l'autre sont conservees). Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote Python non modifie. Attestation = nouveau blob SHA du cote C#."
     - "Rebaseline 2026-08-17 : cote Python draine des timings MACHINE-DEP en cellule[27] (table comparaison vs C# : 6 wall-clock ~34ms / ~5s / ~57ms / ~140x / ~83x / ~100x) -- mandat #9377/#9434, drain des wall-clock prose (mandat user : seules les valeurs reproductibles d'une execution a l'autre sont conservees). Resultats de resolution et tendance qualitative conserves. Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote C# non modifie. Attestation = nouveau blob SHA (python) et content_python_sha du cote Python."

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-15-infer.yaml
@@ -73,6 +73,12 @@
       csharp_sha: 512fba1e200c93e18a783f836db20ffb72e46072
       content_python_sha: b3d0aee61107421ec0a703b172299f0a41f04322a1e59a08a0973733f28ab88f
       content_csharp_sha: fc20b2e34d282b3f5e5199f779d1330bdfa29bafc5afce3113c8835fc54b8a6b
+    - date: "2026-08-20"
+      by: myia-po-2024:CoursIA
+      python_sha: 62d06424631c65c5ecb9c86601b366fc67cbb8e5
+      csharp_sha: 512fba1e200c93e18a783f836db20ffb72e46072
+      content_python_sha: d495bc4bf7bb782d013f5031583963c2adf66bf99f15036e05f931872d8a562f
+      content_csharp_sha: fc20b2e34d282b3f5e5199f779d1330bdfa29bafc5afce3113c8835fc54b8a6b
   known_differences:
     - "Rebaseline 2026-08-17 : cote C# draine des timings MACHINE-DEP en cellule[24] (4 valeurs : 350 s, 349,9 s, 0,92 s, 922 ms, 5,8 minutes) et cellule[42] (4 valeurs : ~14-26 s, ~100 ms, ~1,8 s, ~18-112 ms, ~30-60 s) -- mandat #9377/#9434, drain des wall-clock prose (mandat user : seules les valeurs reproductibles d'une execution a l'autre sont conservees). Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote Python non modifie. Attestation = nouveau blob SHA du cote C#."
     - "Rebaseline 2026-08-17 : cote Python draine des timings MACHINE-DEP en cellule[27] (table comparaison vs C# : 6 wall-clock ~34ms / ~5s / ~57ms / ~140x / ~83x / ~100x) -- mandat #9377/#9434, drain des wall-clock prose (mandat user : seules les valeurs reproductibles d'une execution a l'autre sont conservees). Resultats de resolution et tendance qualitative conserves. Parite semantique inchangee (aucune cellule code, aucune sortie, aucun exec_count touche) ; cote C# non modifie. Attestation = nouveau blob SHA (python) et content_python_sha du cote Python."


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA — prev: MED/notebook-python #11904

Closes #11801

## Summary

Section **v4 : facteurs AllDiff d'arité 9** dans Sudoku-15-Infer-Python, le geste « remonter d'un cran sur le GRAPHE » demandé par l'issue (après le cran v2→Dirichlet sur le MODÈLE) : 27 facteurs d'unité d'arité 9 remplacent les 810 facteurs binaires `!=` de la v3. Le message exact facteur→cellule se calcule en forme close : **permanente du mineur 8×8** (sum-product, formule de Ryser batchée) ou **affectation hongroise** (max-product, scipy `linear_sum_assignment`) — les deux variantes listées par l'issue, toutes deux mesurées.

## Acceptance (critères de l'issue)

| Critère | Mesuré | Statut |
|---|---|---|
| Démo Hall taille 2 : paires bloquées vs arité 9 qui décide | spectatrice {3,7,9} : paires **0.667** sur v=9, arité 9 **1.000** exactement (permanentes nulles pour 3/7) ; la paire de Hall reste honnêtement 50/50 | **ATTEINT** (assert dans le notebook) |
| Medium ≥ 80 % sans aucune couche déterministe | **9/11 = 82 %** (max-product arity-9 + décimation randomisée, 30 redémarrages, semé par grille) — (run du notebook : 9/11 = 82 %, verdict `ATTEINT` relevé dans l'output de la cellule bench ; Easy 51/51 (100 %, 1709 ms/grille), top95 9/15 (60 %, 31742 ms/grille), hardest 9/11 (82 %, 20636 ms/grille)) | **ATTEINT** |
| Comparaison honnête des coûts par sweep | 20 balayages sur la 1re grille hardest : v3 pairwise 1.0 ms · v4 sum-product 49.2 ms (1593 permanentes 8x8, Ryser 2^8 x 8) · v4 max-product 8.6 ms (1593 couplages hongrois 8x8) · ratio max/v3 8.3x (mesuré cell coût) | **ATTEINT** |

## Mesures — sélection de paramètres (prototypée avant écriture ; le run du notebook fait foi)

Sélection de paramètres mesurée sur le corpus Medium (hardest, 11 grilles) pendant le prototypage (anti-fabrication Prong B). Valeurs indicatives, **toutes re-mesurées sur le run final du notebook** (section Acceptance) — machine MYIA-PO-2024 :

| Variante | Medium | ms/grille |
|---|---|---|
| v3 pairwise + décimation (référence) | 0/11 | ~5 000 |
| v4 sum-product permanente, restarts naïfs | 1/11 | ~5 800 |
| v4 sum-product permanente + RR (8 restarts bruités) | 0/11 (4 premières grilles) | ~100 000 |
| v4 max-product hongrois, restarts naïfs | 4/11 (36 %) | ~5 850 |
| v4 max-product hongrois + RR12 (plateau 0.1, bruit décroissant) | 8/11 (73 %) | ~9 200 |
| **v4 max-product hongrois + RR30 (plateau 0.25, bruit constant) — livrée** | **9/11 (82 %)** | ~24 400 |

**Lecture** : le seul changement de couche facteur (paires → arité 9, même squelette de décimation, même budget naïf) fait passer hardest de **0/11 à 4/11** ; les redémarrages randomisés probabilistes (bruit d'init des messages + tirage selon la croyance sur plateaux) exploitent le reste jusqu'à **9/11** — les grilles 2, 8 et 10 se résolvent aux redémarrages 25-27, preuve que le message arité 9 multiplie les chemins explorables là où le pairwise n'en offrait aucun. La grille 1 reste réfractaire aux 30 redémarrages. Le sum-product (permanente), lui, reste à 1/11 même randomisé : la somme sur les affectations dilue les décisions — c'est l'opérateur exact des **croyances** (la démo Hall l'utilise), le hongrois est l'opérateur des **décisions**.

## Changements (Sudoku-15-Infer-Python.ipynb, 39 → 52 cellules)

| Cellule | Contenu |
|---|---|
| 0 | Objectif 5 ajouté (v4 + critère Medium) |
| 30-42 (nouvelles) | Section 7 : théorie (permanente/mineur/Ryser, mission #11801), utils auto-validés (brute-force, identités perm, mineurs I9), démo Hall assertée, `Arity9MaxProductSolver` (hongrois + décimation randomisée), bench 3 corpus, coût par sweep, 4 interprétations ancrées |
| 41/44 | Renumérotation sections 7→8, 8→9 |
| 47 | Lignes v4 au tableau comparatif final |
| 48 | Conclusion : ligne `Arity9MaxProductSolver` + leçons 3 et 5 réécrites sur mesures |

## Implémentation

- `batch_perm8`/`batch_perm9` : Ryser vectorisé (`einsum('buv,sv->bsu'` + produits), signes (-1)^(n+|S|) — validé in-notebook contre brute-force 8×8, perm(I)=1, perm(𝟙)=n!, mineurs de I9.
- `Arity9MaxProductSolver` : même squelette que le `BeliefPropagationSolver` v3 (evidence, damping, décimation par marge, redémarrages) — seule la couche facteur change. Mineurs calculés **uniquement pour les cellules non assignées** (les lignes delta des cellules données rendent le reste inutile : valeurs épinglées = permanente exactement nulle gratuitement). Contradiction = permanente d'unité ≈ 0 ou grille finale invalide → restart.
- **Aucune couche déterministe** : ni propagation de contraintes, ni repli/backtracking. Les randomisés utilisés (bruit d'init par restart, tirage selon la croyance sur plateaux) sont de l'inférence probabiliste randomisée, pas de la propagation.

## Validation

- **Exécution réelle** : papermill end-to-end, 20/20 cellules code (52 cellules total), 0 erreur, `execution_count` dense, outputs réels committés (C.2). Kernel `python3` natif ; jax==0.9.0.1 + numpyro==0.20.0 installés localement (règle F, parité avec les outputs committés de #11817).
- **Auto-validation in-notebook** : la cellule solver asserte Ryser avant tout usage ; la cellule démo asserte arité-9 > 0.999 ET paires < 0.9.
- **Ancrage interp** : chaque valeur citée dans les markdowns d'interprétation est mesurée dans l'output adjacent (script de vérification exécuté sur le notebook committé).
- **Attestation twin** : `--update --pair "Sudoku-15 Infer"` en dernier commit (blob Python bougé par la re-exec ; règle #8957).

## Ce que la v4 n'est pas

- Gestes 2 et 3 de l'issue (one-hot exactly-one + MPLP, régions Kikuchi) non implémentés — le témoin sum-product (permanente, 20892 ms/grille sur hardest) reste à **1/11 (9 %)** : c'est l'opérateur des croyances, pas des décisions. Gestes 2 et 3 = suite proposée de l'issue ; la grille 1 de hardest résiste aux 30 redémarrages — test discriminant pour ces gestes.
- Le nit Hermes « bornne »→« borne » (C# l.40216) n'est **pas** traité ici : fichier sous PR #11806 de la lane CoursIA-2 (collision L898) — signalé à la lane propriétaire.
