### PR TITLE
feat(lean,#11721): SC-7c compagnon natif lean4-wsl erc20_lean — 17/17 declarations evaluees

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7c-ERC20-Lean-Native-Companion.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SmartContracts/02-Solidity-Advanced/SC-7c-ERC20-Lean-Native-Companion.ipynb
@@ -1,0 +1,1480 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2c45e064",
+   "metadata": {},
+   "source": [
+    "# SC-7c : ERC-20 — compagnon natif Lean (kernel `lean4-wsl`)\n",
+    "\n",
+    "**Navigation** : [<< Précédent : SC-7b (Companion python3)](./SC-7b-ERC20-Lean-Verification-Companion.ipynb) | [Retour au sommaire SmartContracts](../README.md) | [Suivant : SC-8 (DeFi Primitives) >>](./SC-8-DeFi-Primitives.ipynb)\n",
+    "\n",
+    "***\n",
+    "\n",
+    "## Pourquoi un compagnon natif Lean\n",
+    "\n",
+    "Le notebook compagnon `SC-7b` (kernel `python3`) lit les **sources** du lake `erc20_lean` et en extrait les signatures pour les afficher. C'est une lecture statique : le code Lean n'est **pas exécuté**. Ce notebook-ci passe au kernel `lean4-wsl` et **évalue** chaque déclaration (`#check`, `#print axioms`, `#eval`) : la signature affichée est alors le produit réel du compilateur Lean, pas le texte lu dans le fichier.\n",
+    "\n",
+    "C'est la différence de fond entre un **loader** et un **compagnon natif** : ici, le noyau Lean certifie que chaque énoncé compile, que les preuves sont closes, et quels axiomes elles utilisent. Le lake `erc20_lean` formalise l'invariant fondateur d'un jeton ERC-20 — la conservation de l'offre totale (`∑ balances = totalSupply`) — et le prouve préservé par chaque opération standard (`mint`, `burn`, `transfer`), puis par toute suite atteignable d'opérations.\n",
+    "\n",
+    "**Lake** : `MyIA.AI.Notebooks/SymbolicAI/SmartContracts/erc20_lean` — 4 modules, 17 déclarations (State : 2, Ops : 3, Invariant : 12). Exécution avec le répertoire du lake comme répertoire de travail (le kernel `lean4-wsl` découvre le lake et son LEAN_PATH en remontant depuis le cwd)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "522f3648",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:28.443865Z",
+     "iopub.status.busy": "2026-08-20T10:58:28.443739Z",
+     "iopub.status.idle": "2026-08-20T10:58:31.911808Z",
+     "shell.execute_reply": "2026-08-20T10:58:31.910971Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Verification de l&#39;environnement : import du lake erc20_lean construit.</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Si cette cellule affiche une erreur d&#39;import, le lake n&#39;est pas dans le</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- LEAN_PATH du kernel (executer depuis le repertoire du lake, cf. README).</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Ops</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">import</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Invariant</span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Verification de l'environnement : import du lake erc20_lean construit.\\n-- Si cette cellule affiche une erreur d'import, le lake n'est pas dans le\\n-- LEAN_PATH du kernel (executer depuis le repertoire du lake, cf. README).\\nimport ERC20.State\\nimport ERC20.Ops\\nimport ERC20.Invariant\\n\"}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"env\": 0}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Verification de l'environnement : import du lake erc20_lean construit.\n",
+       "-- Si cette cellule affiche une erreur d'import, le lake n'est pas dans le\n",
+       "-- LEAN_PATH du kernel (executer depuis le repertoire du lake, cf. README).\n",
+       "import ERC20.State\n",
+       "import ERC20.Ops\n",
+       "import ERC20.Invariant\n",
+       "\n",
+       "--% env 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Verification de l'environnement : import du lake erc20_lean construit.\\n-- Si cette cellule affiche une erreur d'import, le lake n'est pas dans le\\n-- LEAN_PATH du kernel (executer depuis le repertoire du lake, cf. README).\\nimport ERC20.State\\nimport ERC20.Ops\\nimport ERC20.Invariant\\n\"}\n",
+       "Raw output:\n",
+       "{\"env\": 0}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Verification de l'environnement : import du lake erc20_lean construit.\n",
+    "-- Si cette cellule affiche une erreur d'import, le lake n'est pas dans le\n",
+    "-- LEAN_PATH du kernel (executer depuis le repertoire du lake, cf. README).\n",
+    "import ERC20.State\n",
+    "import ERC20.Ops\n",
+    "import ERC20.Invariant\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bbcd1b52",
+   "metadata": {},
+   "source": [
+    "## 1. L'état du contrat et l'invariant (module `State`)\n",
+    "\n",
+    "Le lake modélise un jeton ERC-20 par une machine à états finie : `State n` porte `balances : Address n → ℕ` et `totalSupply : ℕ`, avec `Address n := Fin n` (un nombre fini de détenteurs potentiels, muni d'un `Fintype`). L'invariant fondateur `supplyInvariant` dit que la somme des soldes égale l'offre totale."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "2de7d0cd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:31.913335Z",
+     "iopub.status.busy": "2026-08-20T10:58:31.913198Z",
+     "iopub.status.idle": "2026-08-20T10:58:32.130043Z",
+     "shell.execute_reply": "2026-08-20T10:58:32.129043Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module State : 3 declarations (Address = abbrev, State, supplyInvariant)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk0\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk0\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Type</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk2\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk2\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Module State : 3 declarations (Address = abbrev, State, supplyInvariant)\\n#check ERC20.Address\\n#check ERC20.State\\n#check ERC20.supplyInvariant\\n\", \"env\": 0}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.Address (n : ℕ) : Type\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.State (n : ℕ) : Type\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.supplyInvariant {n : ℕ} (s : ERC20.State n) : Prop\"}],\r\n",
+       " \"env\": 1}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Module State : 3 declarations (Address = abbrev, State, supplyInvariant)\n",
+       "#check ERC20.Address\n",
+       "──────▶  ERC20.Address (n : ℕ) : Type\n",
+       "#check ERC20.State\n",
+       "──────▶  ERC20.State (n : ℕ) : Type\n",
+       "#check ERC20.supplyInvariant\n",
+       "──────▶  ERC20.supplyInvariant {n : ℕ} (s : ERC20.State n) : Prop\n",
+       "\n",
+       "--% env 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Module State : 3 declarations (Address = abbrev, State, supplyInvariant)\\n#check ERC20.Address\\n#check ERC20.State\\n#check ERC20.supplyInvariant\\n\", \"env\": 0}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.Address (n : ℕ) : Type\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.State (n : ℕ) : Type\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.supplyInvariant {n : ℕ} (s : ERC20.State n) : Prop\"}],\r\n",
+       " \"env\": 1}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Module State : 3 declarations (Address = abbrev, State, supplyInvariant)\n",
+    "#check ERC20.Address\n",
+    "#check ERC20.State\n",
+    "#check ERC20.supplyInvariant\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "295115d1",
+   "metadata": {},
+   "source": [
+    "### Lecture de la sortie\n",
+    "\n",
+    "`supplyInvariant s := ∑ a, s.balances a = s.totalSupply` est une `Prop`. Le `#check` certifie que la définition type-checke, et le noyau accepte `Fin n` comme ensemble fini (`Fintype`), rendant la somme sur `Address n` bien définie. C'est le pendant formel de l'`assert` Solidity absent du contrat : ici l'invariant vit dans le type."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a2faa7e",
+   "metadata": {},
+   "source": [
+    "## 2. Les opérations standard (module `Ops`)\n",
+    "\n",
+    "Trois transitions : `mint` (création), `burn` (destruction), `transfer` (déplacement). Chacune transforme un `State n` en un autre `State n`. Ce sont des fonctions **totales** — les gardes (solde suffisant pour `burn`/`transfer`) sont portées par les théorèmes du module `Invariant`, pas par les définitions : exactement la séparation Solidity (la fonction modifie, le `require` protège)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "406d9e85",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:32.131298Z",
+     "iopub.status.busy": "2026-08-20T10:58:32.131155Z",
+     "iopub.status.idle": "2026-08-20T10:58:32.339102Z",
+     "shell.execute_reply": "2026-08-20T10:58:32.338167Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Module Ops : 3 declarations</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk3\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk3\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>mint</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>mint<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk4\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk4\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>burn</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>burn<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk5\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk5\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>transfer<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Module Ops : 3 declarations\\n#check ERC20.mint\\n#check ERC20.burn\\n#check ERC20.transfer\", \"env\": 1}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.mint {n : ℕ} (s : ERC20.State n) (dst : ERC20.Address n) (amount : ℕ) : ERC20.State n\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.burn {n : ℕ} (s : ERC20.State n) (src : ERC20.Address n) (amount : ℕ) : ERC20.State n\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.transfer {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ) : ERC20.State n\"}],\r\n",
+       " \"env\": 2}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Module Ops : 3 declarations\n",
+       "#check ERC20.mint\n",
+       "──────▶  ERC20.mint {n : ℕ} (s : ERC20.State n) (dst : ERC20.Address n) (amount : ℕ) : ERC20.State n\n",
+       "#check ERC20.burn\n",
+       "──────▶  ERC20.burn {n : ℕ} (s : ERC20.State n) (src : ERC20.Address n) (amount : ℕ) : ERC20.State n\n",
+       "#check ERC20.transfer\n",
+       "──────▶  ERC20.transfer {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ) : ERC20.State n\n",
+       "--% env 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Module Ops : 3 declarations\\n#check ERC20.mint\\n#check ERC20.burn\\n#check ERC20.transfer\", \"env\": 1}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.mint {n : ℕ} (s : ERC20.State n) (dst : ERC20.Address n) (amount : ℕ) : ERC20.State n\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.burn {n : ℕ} (s : ERC20.State n) (src : ERC20.Address n) (amount : ℕ) : ERC20.State n\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.transfer {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ) : ERC20.State n\"}],\r\n",
+       " \"env\": 2}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Module Ops : 3 declarations\n",
+    "#check ERC20.mint\n",
+    "#check ERC20.burn\n",
+    "#check ERC20.transfer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "81a76330",
+   "metadata": {},
+   "source": [
+    "### Lecture de la sortie\n",
+    "\n",
+    "Les signatures révèlent la symétrie ERC-20 vue dans SC-7b : `transfer` déplace (`src -= amount`, `dst += amount`) sans toucher `totalSupply` ; `mint`/`burn` ajustent les soldes ET l'offre en parallèle. La soustraction `-` sur `ℕ` est tronquée : sans garde, un `burn` excessif détruirait silencieusement des tokens — c'est précisément ce que `transfer_no_underflow` (section 4) interdit de prouver à tort."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4637c7d",
+   "metadata": {},
+   "source": [
+    "## 3. Les lemmes auxiliaires de sommation (module `Invariant`, 1/3)\n",
+    "\n",
+    "Avant les théorèmes de préservation, le lake établit trois lemmes de `Finset.sum` : un split sur un membre d'un finset, un split sur l'univers entier, et la majoration d'un solde par l'offre totale sous invariant."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ddd87332",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:32.340539Z",
+     "iopub.status.busy": "2026-08-20T10:58:32.340406Z",
+     "iopub.status.idle": "2026-08-20T10:58:32.561959Z",
+     "shell.execute_reply": "2026-08-20T10:58:32.561226Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Lemmes auxiliaires (3)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk6\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk6\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>sum_split_mem</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>sum_split_mem<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>Finset<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n))<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)\n",
+       "<span class=\"w\">  </span>(ha<span class=\"w\"> </span>:<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s,<span class=\"w\"> </span>f<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>f<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>s<span class=\"bp\">.</span>erase<span class=\"w\"> </span>a,<span class=\"w\"> </span>f<span class=\"w\"> </span>x</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk7\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk7\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>sum_univ_split</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>sum_univ_split<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(f<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x,<span class=\"w\"> </span>f<span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>f<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span><span class=\"bp\">∑</span><span class=\"w\"> </span>x<span class=\"w\"> </span><span class=\"bp\">∈</span><span class=\"w\"> </span>Finset<span class=\"bp\">.</span>univ<span class=\"bp\">.</span>erase<span class=\"w\"> </span>a,<span class=\"w\"> </span>f<span class=\"w\"> </span>x</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk8\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk8\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>balance_le_totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>balance_le_totalSupply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(a<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>a<span class=\"w\"> </span><span class=\"bp\">≤</span><span class=\"w\"> </span>s<span class=\"bp\">.</span>totalSupply</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 3</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Lemmes auxiliaires (3)\\n#check ERC20.sum_split_mem\\n#check ERC20.sum_univ_split\\n#check ERC20.balance_le_totalSupply\", \"env\": 2}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.sum_split_mem {n : ℕ} (f : ERC20.Address n → ℕ) (s : Finset (ERC20.Address n)) (a : ERC20.Address n)\\n  (ha : a ∈ s) : ∑ x ∈ s, f x = f a + ∑ x ∈ s.erase a, f x\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.sum_univ_split {n : ℕ} (f : ERC20.Address n → ℕ) (a : ERC20.Address n) :\\n  ∑ x, f x = f a + ∑ x ∈ Finset.univ.erase a, f x\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.balance_le_totalSupply {n : ℕ} (s : ERC20.State n) (a : ERC20.Address n) (h : ERC20.supplyInvariant s) :\\n  s.balances a ≤ s.totalSupply\"}],\r\n",
+       " \"env\": 3}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Lemmes auxiliaires (3)\n",
+       "#check ERC20.sum_split_mem\n",
+       "──────▶  ERC20.sum_split_mem {n : ℕ} (f : ERC20.Address n → ℕ) (s : Finset (ERC20.Address n)) (a : ERC20.Address n)\n",
+       "  (ha : a ∈ s) : ∑ x ∈ s, f x = f a + ∑ x ∈ s.erase a, f x\n",
+       "#check ERC20.sum_univ_split\n",
+       "──────▶  ERC20.sum_univ_split {n : ℕ} (f : ERC20.Address n → ℕ) (a : ERC20.Address n) :\n",
+       "  ∑ x, f x = f a + ∑ x ∈ Finset.univ.erase a, f x\n",
+       "#check ERC20.balance_le_totalSupply\n",
+       "──────▶  ERC20.balance_le_totalSupply {n : ℕ} (s : ERC20.State n) (a : ERC20.Address n) (h : ERC20.supplyInvariant s) :\n",
+       "  s.balances a ≤ s.totalSupply\n",
+       "--% env 3\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Lemmes auxiliaires (3)\\n#check ERC20.sum_split_mem\\n#check ERC20.sum_univ_split\\n#check ERC20.balance_le_totalSupply\", \"env\": 2}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.sum_split_mem {n : ℕ} (f : ERC20.Address n → ℕ) (s : Finset (ERC20.Address n)) (a : ERC20.Address n)\\n  (ha : a ∈ s) : ∑ x ∈ s, f x = f a + ∑ x ∈ s.erase a, f x\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.sum_univ_split {n : ℕ} (f : ERC20.Address n → ℕ) (a : ERC20.Address n) :\\n  ∑ x, f x = f a + ∑ x ∈ Finset.univ.erase a, f x\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.balance_le_totalSupply {n : ℕ} (s : ERC20.State n) (a : ERC20.Address n) (h : ERC20.supplyInvariant s) :\\n  s.balances a ≤ s.totalSupply\"}],\r\n",
+       " \"env\": 3}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Lemmes auxiliaires (3)\n",
+    "#check ERC20.sum_split_mem\n",
+    "#check ERC20.sum_univ_split\n",
+    "#check ERC20.balance_le_totalSupply"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f2f524c4",
+   "metadata": {},
+   "source": [
+    "## 4. Les théorèmes de préservation (module `Invariant`, 2/3)\n",
+    "\n",
+    "Le cœur du lake : chaque opération standard **préserve** `supplyInvariant`. `mint_preserves_supply`, `burn_preserves_supply` (sous garde de solde), `transfer_preserves_supply` (sous garde et adresses distinctes) le prouvent ; `transfer_no_underflow` prouve que le transfert garde la trace exacte du débit de la source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "69f9095d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:32.563264Z",
+     "iopub.status.busy": "2026-08-20T10:58:32.563136Z",
+     "iopub.status.idle": "2026-08-20T10:58:32.783651Z",
+     "shell.execute_reply": "2026-08-20T10:58:32.782827Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Theoremes de preservation par operation (4)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk9\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk9\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>mint_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>mint_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
+       "<span class=\"w\">  </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>mint<span class=\"w\"> </span>s<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chka\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chka\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>burn_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>burn_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
+       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>burn<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkb\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkb\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>transfer_preserves_supply<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
+       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>(hne<span class=\"w\"> </span>:<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≠</span><span class=\"w\"> </span>dst)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>transfer<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkc\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkc\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer_no_underflow</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>transfer_no_underflow<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(src<span class=\"w\"> </span>dst<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Address<span class=\"w\"> </span>n)<span class=\"w\"> </span>(amount<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)\n",
+       "<span class=\"w\">  </span>(hguard<span class=\"w\"> </span>:<span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">≥</span><span class=\"w\"> </span>amount)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>(ERC20<span class=\"bp\">.</span>transfer<span class=\"w\"> </span>s<span class=\"w\"> </span>src<span class=\"w\"> </span>dst<span class=\"w\"> </span>amount)<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">∧</span>\n",
+       "<span class=\"w\">    </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src<span class=\"w\"> </span><span class=\"bp\">-</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>amount<span class=\"w\"> </span><span class=\"bp\">=</span><span class=\"w\"> </span>s<span class=\"bp\">.</span>balances<span class=\"w\"> </span>src</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 4</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Theoremes de preservation par operation (4)\\n#check ERC20.mint_preserves_supply\\n#check ERC20.burn_preserves_supply\\n#check ERC20.transfer_preserves_supply\\n#check ERC20.transfer_no_underflow\", \"env\": 3}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.mint_preserves_supply {n : ℕ} (s : ERC20.State n) (dst : ERC20.Address n) (amount : ℕ)\\n  (h : ERC20.supplyInvariant s) : ERC20.supplyInvariant (ERC20.mint s dst amount)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.burn_preserves_supply {n : ℕ} (s : ERC20.State n) (src : ERC20.Address n) (amount : ℕ)\\n  (hguard : s.balances src ≥ amount) (h : ERC20.supplyInvariant s) : ERC20.supplyInvariant (ERC20.burn s src amount)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.transfer_preserves_supply {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ)\\n  (hguard : s.balances src ≥ amount) (hne : src ≠ dst) (h : ERC20.supplyInvariant s) :\\n  ERC20.supplyInvariant (ERC20.transfer s src dst amount)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.transfer_no_underflow {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ)\\n  (hguard : s.balances src ≥ amount) :\\n  (ERC20.transfer s src dst amount).balances src = s.balances src - amount ∧\\n    s.balances src - amount + amount = s.balances src\"}],\r\n",
+       " \"env\": 4}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Theoremes de preservation par operation (4)\n",
+       "#check ERC20.mint_preserves_supply\n",
+       "──────▶  ERC20.mint_preserves_supply {n : ℕ} (s : ERC20.State n) (dst : ERC20.Address n) (amount : ℕ)\n",
+       "  (h : ERC20.supplyInvariant s) : ERC20.supplyInvariant (ERC20.mint s dst amount)\n",
+       "#check ERC20.burn_preserves_supply\n",
+       "──────▶  ERC20.burn_preserves_supply {n : ℕ} (s : ERC20.State n) (src : ERC20.Address n) (amount : ℕ)\n",
+       "  (hguard : s.balances src ≥ amount) (h : ERC20.supplyInvariant s) : ERC20.supplyInvariant (ERC20.burn s src amount)\n",
+       "#check ERC20.transfer_preserves_supply\n",
+       "──────▶  ERC20.transfer_preserves_supply {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ)\n",
+       "  (hguard : s.balances src ≥ amount) (hne : src ≠ dst) (h : ERC20.supplyInvariant s) :\n",
+       "  ERC20.supplyInvariant (ERC20.transfer s src dst amount)\n",
+       "#check ERC20.transfer_no_underflow\n",
+       "──────▶  ERC20.transfer_no_underflow {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ)\n",
+       "  (hguard : s.balances src ≥ amount) :\n",
+       "  (ERC20.transfer s src dst amount).balances src = s.balances src - amount ∧\n",
+       "    s.balances src - amount + amount = s.balances src\n",
+       "--% env 4\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Theoremes de preservation par operation (4)\\n#check ERC20.mint_preserves_supply\\n#check ERC20.burn_preserves_supply\\n#check ERC20.transfer_preserves_supply\\n#check ERC20.transfer_no_underflow\", \"env\": 3}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.mint_preserves_supply {n : ℕ} (s : ERC20.State n) (dst : ERC20.Address n) (amount : ℕ)\\n  (h : ERC20.supplyInvariant s) : ERC20.supplyInvariant (ERC20.mint s dst amount)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.burn_preserves_supply {n : ℕ} (s : ERC20.State n) (src : ERC20.Address n) (amount : ℕ)\\n  (hguard : s.balances src ≥ amount) (h : ERC20.supplyInvariant s) : ERC20.supplyInvariant (ERC20.burn s src amount)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.transfer_preserves_supply {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ)\\n  (hguard : s.balances src ≥ amount) (hne : src ≠ dst) (h : ERC20.supplyInvariant s) :\\n  ERC20.supplyInvariant (ERC20.transfer s src dst amount)\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.transfer_no_underflow {n : ℕ} (s : ERC20.State n) (src dst : ERC20.Address n) (amount : ℕ)\\n  (hguard : s.balances src ≥ amount) :\\n  (ERC20.transfer s src dst amount).balances src = s.balances src - amount ∧\\n    s.balances src - amount + amount = s.balances src\"}],\r\n",
+       " \"env\": 4}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Theoremes de preservation par operation (4)\n",
+    "#check ERC20.mint_preserves_supply\n",
+    "#check ERC20.burn_preserves_supply\n",
+    "#check ERC20.transfer_preserves_supply\n",
+    "#check ERC20.transfer_no_underflow"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec73427f",
+   "metadata": {},
+   "source": [
+    "### Lecture de la sortie\n",
+    "\n",
+    "Chaque `#check` confirme que l'énoncé type-checke et que sa preuve (dans le source `Invariant.lean`) est close par le noyau — pas de `sorry`. C'est la certification formelle que Solidity ne peut pas donner : aucune séquence gardée de `mint`/`burn`/`transfer` ne peut violer la conservation de l'offre."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dca04d1",
+   "metadata": {},
+   "source": [
+    "## 5. La fermeture par atteignabilité (module `Invariant`, 3/3)\n",
+    "\n",
+    "Les opérations individuelles préservent l'invariant, mais un contrat réel en enchaîne beaucoup. Le lake formalise cette composition par deux déclarations **inductives** : `Op` (une étape, constructeurs `mint`/`burn`/`transfer`) et `Reachable` (la fermeture réflexive-transitive, constructeurs `refl`/`step`). Le lemme `op_preserves_invariant` remonte à un pas, le théorème `reachable_preserves_invariant` à une suite entière, par induction sur la trace.\n",
+    "\n",
+    "**Piège de couverture** : ces deux declarations sont `inductive`. Un extracteur manuel qui n'énumère que `theorem`/`lemma`/`def` les compte à tort comme absentes (15/17 au lieu de 17/17 — mesuré sur #11710). Les `#check` ci-dessous confirment qu'elles existent et type-checkent sous le noyau."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "99e21ac8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:32.784965Z",
+     "iopub.status.busy": "2026-08-20T10:58:32.784827Z",
+     "iopub.status.idle": "2026-08-20T10:58:33.016355Z",
+     "shell.execute_reply": "2026-08-20T10:58:33.015125Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Inductives : une etape, puis la fermeture transitive</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkd\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkd\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Op</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>Op<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chke\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chke\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Reachable</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>Reachable<span class=\"w\"> </span>(n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n<span class=\"w\"> </span><span class=\"bp\">→</span><span class=\"w\"> </span><span class=\"kt\">Prop</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Preservation : un pas, puis une suite entiere</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chkf\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chkf\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>op_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>op_preserves_invariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>s&#39;<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(hop<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Op<span class=\"w\"> </span>n<span class=\"w\"> </span>s<span class=\"w\"> </span>s&#39;)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)<span class=\"w\"> </span>:\n",
+       "<span class=\"w\">  </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s&#39;</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk10\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk10\"><span class=\"bp\">#</span>check<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>reachable_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> ERC20<span class=\"bp\">.</span>reachable_preserves_invariant<span class=\"w\"> </span>{n<span class=\"w\"> </span>:<span class=\"w\"> </span>ℕ}<span class=\"w\"> </span>(s<span class=\"w\"> </span>s&#39;<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span>n)<span class=\"w\"> </span>(h<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s)\n",
+       "<span class=\"w\">  </span>(hr<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>Reachable<span class=\"w\"> </span>n<span class=\"w\"> </span>s<span class=\"w\"> </span>s&#39;)<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s&#39;</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 5</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Inductives : une etape, puis la fermeture transitive\\n#check ERC20.Op\\n#check ERC20.Reachable\\n-- Preservation : un pas, puis une suite entiere\\n#check ERC20.op_preserves_invariant\\n#check ERC20.reachable_preserves_invariant\", \"env\": 4}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.Op (n : ℕ) : ERC20.State n → ERC20.State n → Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.Reachable (n : ℕ) : ERC20.State n → ERC20.State n → Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.op_preserves_invariant {n : ℕ} (s s' : ERC20.State n) (hop : ERC20.Op n s s') (h : ERC20.supplyInvariant s) :\\n  ERC20.supplyInvariant s'\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.reachable_preserves_invariant {n : ℕ} (s s' : ERC20.State n) (h : ERC20.supplyInvariant s)\\n  (hr : ERC20.Reachable n s s') : ERC20.supplyInvariant s'\"}],\r\n",
+       " \"env\": 5}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Inductives : une etape, puis la fermeture transitive\n",
+       "#check ERC20.Op\n",
+       "──────▶  ERC20.Op (n : ℕ) : ERC20.State n → ERC20.State n → Prop\n",
+       "#check ERC20.Reachable\n",
+       "──────▶  ERC20.Reachable (n : ℕ) : ERC20.State n → ERC20.State n → Prop\n",
+       "-- Preservation : un pas, puis une suite entiere\n",
+       "#check ERC20.op_preserves_invariant\n",
+       "──────▶  ERC20.op_preserves_invariant {n : ℕ} (s s' : ERC20.State n) (hop : ERC20.Op n s s') (h : ERC20.supplyInvariant s) :\n",
+       "  ERC20.supplyInvariant s'\n",
+       "#check ERC20.reachable_preserves_invariant\n",
+       "──────▶  ERC20.reachable_preserves_invariant {n : ℕ} (s s' : ERC20.State n) (h : ERC20.supplyInvariant s)\n",
+       "  (hr : ERC20.Reachable n s s') : ERC20.supplyInvariant s'\n",
+       "--% env 5\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Inductives : une etape, puis la fermeture transitive\\n#check ERC20.Op\\n#check ERC20.Reachable\\n-- Preservation : un pas, puis une suite entiere\\n#check ERC20.op_preserves_invariant\\n#check ERC20.reachable_preserves_invariant\", \"env\": 4}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.Op (n : ℕ) : ERC20.State n → ERC20.State n → Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\": \"ERC20.Reachable (n : ℕ) : ERC20.State n → ERC20.State n → Prop\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.op_preserves_invariant {n : ℕ} (s s' : ERC20.State n) (hop : ERC20.Op n s s') (h : ERC20.supplyInvariant s) :\\n  ERC20.supplyInvariant s'\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"ERC20.reachable_preserves_invariant {n : ℕ} (s s' : ERC20.State n) (h : ERC20.supplyInvariant s)\\n  (hr : ERC20.Reachable n s s') : ERC20.supplyInvariant s'\"}],\r\n",
+       " \"env\": 5}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Inductives : une etape, puis la fermeture transitive\n",
+    "#check ERC20.Op\n",
+    "#check ERC20.Reachable\n",
+    "-- Preservation : un pas, puis une suite entiere\n",
+    "#check ERC20.op_preserves_invariant\n",
+    "#check ERC20.reachable_preserves_invariant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47788069",
+   "metadata": {},
+   "source": [
+    "### Lecture de la sortie\n",
+    "\n",
+    "`Reachable n s s'` signifie : `s'` est atteignable depuis `s` par zéro, une ou plusieurs opérations valides. `reachable_preserves_invariant` dit : si `s` satisfait l'invariant, tout état atteignable le satisfait encore. C'est le théorème final qui fait de `supplyInvariant` un **invariant de sûreté** du contrat ERC-20 formalisé — pas seulement une propriété de chaque transition isolée, mais de toute exécution atteignable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51897bed",
+   "metadata": {},
+   "source": [
+    "## 6. Axiomes et intégrité des preuves\n",
+    "\n",
+    "Une preuve Lean n'a de valeur que si l'on sait sur quoi elle repose. `#print axioms` liste les axiomes utilisés par une preuve ; les trois standards de Mathlib (`propext`, `Classical.choice`, `Quot.sound`) sont la logique classique usuelle. Tout axiome supplémentaire serait un trou à documenter.\n",
+    "\n",
+    "C'est le contrôle d'intégrité que le compagnon python3 ne peut pas faire : lire le texte d'une preuve ne dit pas quels axiomes elle invoque — le noyau, lui, le sait."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "38855c00",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:33.017940Z",
+     "iopub.status.busy": "2026-08-20T10:58:33.017783Z",
+     "iopub.status.idle": "2026-08-20T10:58:33.223722Z",
+     "shell.execute_reply": "2026-08-20T10:58:33.222932Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Axiomes utilises par les theoremes cles</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk11\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk11\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>mint_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>ERC20<span class=\"bp\">.</span>mint_preserves_supply&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk12\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk12\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>burn_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>ERC20<span class=\"bp\">.</span>burn_preserves_supply&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk13\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk13\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer_preserves_supply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>ERC20<span class=\"bp\">.</span>transfer_preserves_supply&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk14\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk14\"><span class=\"bp\">#</span>print<span class=\"w\"> </span>axioms<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>reachable_preserves_invariant</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"bp\">&#39;</span>ERC20<span class=\"bp\">.</span>reachable_preserves_invariant&#39;<span class=\"w\"> </span>depends<span class=\"w\"> </span>on<span class=\"w\"> </span>axioms:<span class=\"w\"> </span>[propext,<span class=\"w\"> </span>Classical<span class=\"bp\">.</span>choice,<span class=\"w\"> </span>Quot<span class=\"bp\">.</span>sound]</blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 6</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Axiomes utilises par les theoremes cles\\n#print axioms ERC20.mint_preserves_supply\\n#print axioms ERC20.burn_preserves_supply\\n#print axioms ERC20.transfer_preserves_supply\\n#print axioms ERC20.reachable_preserves_invariant\", \"env\": 5}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'ERC20.mint_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'ERC20.burn_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'ERC20.transfer_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'ERC20.reachable_preserves_invariant' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 6}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Axiomes utilises par les theoremes cles\n",
+       "#print axioms ERC20.mint_preserves_supply\n",
+       "──────▶  'ERC20.mint_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "#print axioms ERC20.burn_preserves_supply\n",
+       "──────▶  'ERC20.burn_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "#print axioms ERC20.transfer_preserves_supply\n",
+       "──────▶  'ERC20.transfer_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "#print axioms ERC20.reachable_preserves_invariant\n",
+       "──────▶  'ERC20.reachable_preserves_invariant' depends on axioms: [propext, Classical.choice, Quot.sound]\n",
+       "--% env 6\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Axiomes utilises par les theoremes cles\\n#print axioms ERC20.mint_preserves_supply\\n#print axioms ERC20.burn_preserves_supply\\n#print axioms ERC20.transfer_preserves_supply\\n#print axioms ERC20.reachable_preserves_invariant\", \"env\": 5}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 2, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 2, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'ERC20.mint_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'ERC20.burn_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'ERC20.transfer_preserves_supply' depends on axioms: [propext, Classical.choice, Quot.sound]\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 6},\r\n",
+       "   \"data\":\r\n",
+       "   \"'ERC20.reachable_preserves_invariant' depends on axioms: [propext, Classical.choice, Quot.sound]\"}],\r\n",
+       " \"env\": 6}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Axiomes utilises par les theoremes cles\n",
+    "#print axioms ERC20.mint_preserves_supply\n",
+    "#print axioms ERC20.burn_preserves_supply\n",
+    "#print axioms ERC20.transfer_preserves_supply\n",
+    "#print axioms ERC20.reachable_preserves_invariant"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "149d1c86",
+   "metadata": {},
+   "source": [
+    "### Lecture de la sortie\n",
+    "\n",
+    "Si la sortie ne liste que `propext`, `Classical.choice`, `Quot.sound`, les preuves sont honnêtes : vérifiées par le noyau modulo la logique classique. Aucun `sorryAx` ne doit apparaître — sa présence signalerait une preuve trouée."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80a8680e",
+   "metadata": {},
+   "source": [
+    "## 7. Une trace concrète sous le noyau\n",
+    "\n",
+    "Construisons un `State` à trois adresses, mintons, transférons, et **calculons** offre et somme des soldes après chaque pas — sous le vrai noyau Lean (`#eval`), pas en Python. La machine à états du lake s'exécute : on voit `totalSupply` et la somme des soldes rester égales à chaque transition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ba0c0e80",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:33.225038Z",
+     "iopub.status.busy": "2026-08-20T10:58:33.224909Z",
+     "iopub.status.idle": "2026-08-20T10:58:33.469632Z",
+     "shell.execute_reply": "2026-08-20T10:58:33.468805Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Etat initial : 3 adresses, soldes nuls, offre 0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>s0<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"bp\">⟨!</span>[<span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>,<span class=\"w\"> </span><span class=\"mi\">0</span>],<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"bp\">⟩</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk15\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk15\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s0<span class=\"bp\">.</span>totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk16\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk16\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s0<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s0<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s0<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">0</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 7</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Etat initial : 3 adresses, soldes nuls, offre 0\\ndef s0 : ERC20.State 3 := \\u27e8![0, 0, 0], 0\\u27e9\\n#eval s0.totalSupply\\n#eval s0.balances 0 + s0.balances 1 + s0.balances 2\", \"env\": 6}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"0\"}],\r\n",
+       " \"env\": 7}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Etat initial : 3 adresses, soldes nuls, offre 0\n",
+       "def s0 : ERC20.State 3 := ⟨![0, 0, 0], 0⟩\n",
+       "#eval s0.totalSupply\n",
+       "─────▶  0\n",
+       "#eval s0.balances 0 + s0.balances 1 + s0.balances 2\n",
+       "─────▶  0\n",
+       "--% env 7\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Etat initial : 3 adresses, soldes nuls, offre 0\\ndef s0 : ERC20.State 3 := \\u27e8![0, 0, 0], 0\\u27e9\\n#eval s0.totalSupply\\n#eval s0.balances 0 + s0.balances 1 + s0.balances 2\", \"env\": 6}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"0\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"0\"}],\r\n",
+       " \"env\": 7}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Etat initial : 3 adresses, soldes nuls, offre 0\n",
+    "def s0 : ERC20.State 3 := ⟨![0, 0, 0], 0⟩\n",
+    "#eval s0.totalSupply\n",
+    "#eval s0.balances 0 + s0.balances 1 + s0.balances 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6d706208",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:33.470794Z",
+     "iopub.status.busy": "2026-08-20T10:58:33.470677Z",
+     "iopub.status.idle": "2026-08-20T10:58:33.688622Z",
+     "shell.execute_reply": "2026-08-20T10:58:33.687890Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Pas 1 : mint de 100 tokens a l&#39;adresse 0</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>s1<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>mint<span class=\"w\"> </span>s0<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">100</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk17\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk17\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s1<span class=\"bp\">.</span>totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk18\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk18\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s1<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s1<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s1<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 8</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Pas 1 : mint de 100 tokens a l'adresse 0\\ndef s1 : ERC20.State 3 := ERC20.mint s0 0 100\\n#eval s1.totalSupply\\n#eval s1.balances 0 + s1.balances 1 + s1.balances 2\", \"env\": 7}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"100\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"100\"}],\r\n",
+       " \"env\": 8}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Pas 1 : mint de 100 tokens a l'adresse 0\n",
+       "def s1 : ERC20.State 3 := ERC20.mint s0 0 100\n",
+       "#eval s1.totalSupply\n",
+       "─────▶  100\n",
+       "#eval s1.balances 0 + s1.balances 1 + s1.balances 2\n",
+       "─────▶  100\n",
+       "--% env 8\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Pas 1 : mint de 100 tokens a l'adresse 0\\ndef s1 : ERC20.State 3 := ERC20.mint s0 0 100\\n#eval s1.totalSupply\\n#eval s1.balances 0 + s1.balances 1 + s1.balances 2\", \"env\": 7}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"100\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"100\"}],\r\n",
+       " \"env\": 8}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Pas 1 : mint de 100 tokens a l'adresse 0\n",
+    "def s1 : ERC20.State 3 := ERC20.mint s0 0 100\n",
+    "#eval s1.totalSupply\n",
+    "#eval s1.balances 0 + s1.balances 1 + s1.balances 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "10b53a19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:33.690448Z",
+     "iopub.status.busy": "2026-08-20T10:58:33.690312Z",
+     "iopub.status.idle": "2026-08-20T10:58:33.912124Z",
+     "shell.execute_reply": "2026-08-20T10:58:33.911312Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Pas 2 : transfer de 30 de l&#39;adresse 0 vers l&#39;adresse 1</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>s2<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span><span class=\"mi\">3</span><span class=\"w\"> </span>:=<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>transfer<span class=\"w\"> </span>s1<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"mi\">30</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk19\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk19\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s2<span class=\"bp\">.</span>totalSupply</label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1a\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1a\"><span class=\"bp\">#</span>eval<span class=\"w\"> </span>s2<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s2<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">1</span><span class=\"w\"> </span><span class=\"bp\">+</span><span class=\"w\"> </span>s2<span class=\"bp\">.</span>balances<span class=\"w\"> </span><span class=\"mi\">2</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"> <span class=\"mi\">100</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 9</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Pas 2 : transfer de 30 de l'adresse 0 vers l'adresse 1\\ndef s2 : ERC20.State 3 := ERC20.transfer s1 0 1 30\\n#eval s2.totalSupply\\n#eval s2.balances 0 + s2.balances 1 + s2.balances 2\", \"env\": 8}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"100\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"100\"}],\r\n",
+       " \"env\": 9}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Pas 2 : transfer de 30 de l'adresse 0 vers l'adresse 1\n",
+       "def s2 : ERC20.State 3 := ERC20.transfer s1 0 1 30\n",
+       "#eval s2.totalSupply\n",
+       "─────▶  100\n",
+       "#eval s2.balances 0 + s2.balances 1 + s2.balances 2\n",
+       "─────▶  100\n",
+       "--% env 9\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Pas 2 : transfer de 30 de l'adresse 0 vers l'adresse 1\\ndef s2 : ERC20.State 3 := ERC20.transfer s1 0 1 30\\n#eval s2.totalSupply\\n#eval s2.balances 0 + s2.balances 1 + s2.balances 2\", \"env\": 8}\n",
+       "Raw output:\n",
+       "{\"messages\":\r\n",
+       " [{\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 5},\r\n",
+       "   \"data\": \"100\"},\r\n",
+       "  {\"severity\": \"info\",\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 0},\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 5},\r\n",
+       "   \"data\": \"100\"}],\r\n",
+       " \"env\": 9}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Pas 2 : transfer de 30 de l'adresse 0 vers l'adresse 1\n",
+    "def s2 : ERC20.State 3 := ERC20.transfer s1 0 1 30\n",
+    "#eval s2.totalSupply\n",
+    "#eval s2.balances 0 + s2.balances 1 + s2.balances 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdace94f",
+   "metadata": {},
+   "source": [
+    "### Lecture de la trace\n",
+    "\n",
+    "À l'état initial, offre `0`, somme des soldes `0`. Après le `mint` : offre `100`, somme `100 + 0 + 0 = 100` — les deux bougent **ensemble**. Après le `transfer` : offre toujours `100`, somme `70 + 30 + 0 = 100` — l'offre n'a pas bougé, les soldes se sont déplacés. La conservation tient à chaque pas, et les théorèmes de la section 4 garantissent qu'elle tiendra pour **toute** trace gardée : le Monte-Carlo de SC-7b suggérait la propriété, le noyau la certifie.\n",
+    "\n",
+    "*Pour aller plus loin* : la trace `s0 → mint → transfer → burn` est un témoin `ERC20.Reachable 3 s0 s3` ; le théorème `reachable_preserves_invariant` s'applique alors mécaniquement (voir l'exercice 2)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4e1d1ab",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Les exercices suivants sont à compléter. Ils utilisent le lake `erc20_lean` et les définitions `s0`/`s1`/`s2` de la section 7. Remplacer chaque `sorry` par une preuve ; les indices sont dans les commentaires."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "426a3c6f",
+   "metadata": {},
+   "source": [
+    "### Exercice 1 : certifier l'invariant de l'état initial\n",
+    "\n",
+    "Prouver `supplyInvariant s0` : la somme des trois soldes nuls vaut l'offre nulle.\n",
+    "\n",
+    "*Indice* : déplier `supplyInvariant` et `s0`, puis `simp` évalue la somme sur `Fin 3`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5ca75b5d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:33.913537Z",
+     "iopub.status.busy": "2026-08-20T10:58:33.913398Z",
+     "iopub.status.idle": "2026-08-20T10:58:34.117337Z",
+     "shell.execute_reply": "2026-08-20T10:58:34.116449Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 1 : a completer</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1b\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1b\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>exo1_s0_invariant<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>s0<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 10</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 0</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 1 : a completer\\n-- TODO etudiant\\ntheorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\\n  sorry\", \"env\": 9}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"sorries\":\r\n",
+       " [{\"proofState\": 0,\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant s0\",\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 25},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 10}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 1 : a completer\n",
+       "-- TODO etudiant\n",
+       "theorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\n",
+       "        ─────────────────▶ 🟨 declaration uses `sorry`\n",
+       "  sorry\n",
+       "--% env 10\n",
+       "--% prove 0\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 1 : a completer\\n-- TODO etudiant\\ntheorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\\n  sorry\", \"env\": 9}\n",
+       "Raw output:\n",
+       "{\"sorries\":\r\n",
+       " [{\"proofState\": 0,\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant s0\",\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 25},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 10}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 1 : a completer\n",
+    "-- TODO etudiant\n",
+    "theorem exo1_s0_invariant : ERC20.supplyInvariant s0 := by\n",
+    "  sorry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1253738",
+   "metadata": {},
+   "source": [
+    "### Exercice 2 : certifier le burn en bout de trace\n",
+    "\n",
+    "Prouver que brûler 20 tokens à l'adresse 0 depuis `s2` préserve l'invariant.\n",
+    "\n",
+    "*Etape 1* : prouver `supplyInvariant s2` en remontant la trace (exo 1 + `mint_preserves_supply` + `transfer_preserves_supply`, la garde `s1.balances 0 ≥ 30` et la distinction `0 ≠ 1` se montrent par `rfl`/`decide`). *Etape 2* : appliquer `burn_preserves_supply` avec la garde `s2.balances 0 ≥ 20`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "439259e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:34.118587Z",
+     "iopub.status.busy": "2026-08-20T10:58:34.118429Z",
+     "iopub.status.idle": "2026-08-20T10:58:34.332683Z",
+     "shell.execute_reply": "2026-08-20T10:58:34.331564Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 2 : a completer</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1c\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1c\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>exo2_burn_preserved<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>(ERC20<span class=\"bp\">.</span>burn<span class=\"w\"> </span>s2<span class=\"w\"> </span><span class=\"mi\">0</span><span class=\"w\"> </span><span class=\"mi\">20</span>)<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 11</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 1</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 2 : a completer\\n-- TODO etudiant\\ntheorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\\n  sorry\", \"env\": 10}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"sorries\":\r\n",
+       " [{\"proofState\": 1,\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant (ERC20.burn s2 0 20)\",\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 27},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 11}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 2 : a completer\n",
+       "-- TODO etudiant\n",
+       "theorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\n",
+       "        ───────────────────▶ 🟨 declaration uses `sorry`\n",
+       "  sorry\n",
+       "--% env 11\n",
+       "--% prove 1\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 2 : a completer\\n-- TODO etudiant\\ntheorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\\n  sorry\", \"env\": 10}\n",
+       "Raw output:\n",
+       "{\"sorries\":\r\n",
+       " [{\"proofState\": 1,\r\n",
+       "   \"pos\": {\"line\": 4, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant (ERC20.burn s2 0 20)\",\r\n",
+       "   \"endPos\": {\"line\": 4, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 3, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 3, \"column\": 27},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 11}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 2 : a completer\n",
+    "-- TODO etudiant\n",
+    "theorem exo2_burn_preserved : ERC20.supplyInvariant (ERC20.burn s2 0 20) := by\n",
+    "  sorry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11712508",
+   "metadata": {},
+   "source": [
+    "### Exercice 3 : un état de votre choix\n",
+    "\n",
+    "`monEtat` distribue 50 tokens sur 4 adresses. (a) Vérifier par `#eval` que la somme des soldes vaut 50. (b) Prouver `supplyInvariant monEtat`. (c) Bonus : minté 10 et appliquer le théorème de préservation.\n",
+    "\n",
+    "*Indice* : la somme sur `Fin 4` se calcule comme sur `Fin 3` — `simp` déplie la notation `![...]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "4e39c0bc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T10:58:34.334109Z",
+     "iopub.status.busy": "2026-08-20T10:58:34.333957Z",
+     "iopub.status.idle": "2026-08-20T10:58:34.547148Z",
+     "shell.execute_reply": "2026-08-20T10:58:34.546150Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        \n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/alectryon.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://lean-lang.org/lean4/doc/pygments.css\">\n",
+       "        <link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/gh/utensil/lean4_jupyter@main/vendor/lean4_jupyter.css\">\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/alectryon.js\"></script>\n",
+       "        <script src=\"https://lean-lang.org/lean4/doc/highlight.js\"></script>\n",
+       "    \n",
+       "        <div class=\"alectryon-root alectryon-centered\">\n",
+       "            <pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- Exercice 3 : a completer</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"kn\">def</span><span class=\"w\"> </span>monEtat<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>State<span class=\"w\"> </span><span class=\"mi\">4</span><span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"bp\">⟨!</span>[<span class=\"mi\">10</span>,<span class=\"w\"> </span><span class=\"mi\">15</span>,<span class=\"w\"> </span><span class=\"mi\">20</span>,<span class=\"w\"> </span><span class=\"mi\">5</span>],<span class=\"w\"> </span><span class=\"mi\">50</span><span class=\"bp\">⟩</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><input class=\"alectryon-toggle\" id=\"chk1d\" style=\"display: none\" type=\"checkbox\"><label class=\"alectryon-input\" for=\"chk1d\"><span class=\"kn\">theorem</span><span class=\"w\"> </span>exo3_monEtat_invariant<span class=\"w\"> </span>:<span class=\"w\"> </span>ERC20<span class=\"bp\">.</span>supplyInvariant<span class=\"w\"> </span>monEtat<span class=\"w\"> </span>:=<span class=\"w\"> </span><span class=\"k\">by</span></label><small class=\"alectryon-output\"><div><div class=\"alectryon-messages\"><blockquote class=\"alectryon-message\"><span class=\"bp\">🟨</span><span class=\"w\"> </span>declaration<span class=\"w\"> </span>uses<span class=\"w\"> </span><span class=\"ss\">`sorry</span><span class=\"bp\">`</span></blockquote></div></div></small></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\">  <span class=\"gr\">sorry</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% env 12</span></span></span></pre>\n",
+       "<pre class=\"alectryon-io highlight\"><!-- Generator: Alectryon --><span class=\"alectryon-sentence\"><span class=\"alectryon-input\"><span class=\"c1\">--% prove 2</span></span></span></pre>\n",
+       "        </div>\n",
+       "        <details>\n",
+       "            <summary>Raw input</summary>\n",
+       "            <code>{\"cmd\": \"-- Exercice 3 : a completer\\n-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\\ndef monEtat : ERC20.State 4 := \\u27e8![10, 15, 20, 5], 50\\u27e9\\n-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\\ntheorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\\n  sorry\", \"env\": 11}</code>\n",
+       "        </details>\n",
+       "        <details>\n",
+       "            <summary>Raw output</summary>\n",
+       "            <code>{\"sorries\":\r\n",
+       " [{\"proofState\": 2,\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant monEtat\",\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 30},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 12}</code>\n",
+       "        </details>\n",
+       "    "
+      ],
+      "text/plain": [
+       "-- Exercice 3 : a completer\n",
+       "-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\n",
+       "def monEtat : ERC20.State 4 := ⟨![10, 15, 20, 5], 50⟩\n",
+       "-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\n",
+       "theorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\n",
+       "        ──────────────────────▶ 🟨 declaration uses `sorry`\n",
+       "  sorry\n",
+       "--% env 12\n",
+       "--% prove 2\n",
+       "\n",
+       "Raw input:\n",
+       "{\"cmd\": \"-- Exercice 3 : a completer\\n-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\\ndef monEtat : ERC20.State 4 := \\u27e8![10, 15, 20, 5], 50\\u27e9\\n-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\\ntheorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\\n  sorry\", \"env\": 11}\n",
+       "Raw output:\n",
+       "{\"sorries\":\r\n",
+       " [{\"proofState\": 2,\r\n",
+       "   \"pos\": {\"line\": 6, \"column\": 2},\r\n",
+       "   \"goal\": \"⊢ ERC20.supplyInvariant monEtat\",\r\n",
+       "   \"endPos\": {\"line\": 6, \"column\": 7}}],\r\n",
+       " \"messages\":\r\n",
+       " [{\"severity\": \"warning\",\r\n",
+       "   \"pos\": {\"line\": 5, \"column\": 8},\r\n",
+       "   \"endPos\": {\"line\": 5, \"column\": 30},\r\n",
+       "   \"data\": \"declaration uses `sorry`\"}],\r\n",
+       " \"env\": 12}"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "-- Exercice 3 : a completer\n",
+    "-- TODO etudiant (la question (a) est deja ecrite : decommenter apres verification)\n",
+    "def monEtat : ERC20.State 4 := ⟨![10, 15, 20, 5], 50⟩\n",
+    "-- #eval monEtat.balances 0 + monEtat.balances 1 + monEtat.balances 2 + monEtat.balances 3\n",
+    "theorem exo3_monEtat_invariant : ERC20.supplyInvariant monEtat := by\n",
+    "  sorry"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Lean 4 (WSL)",
+   "language": "lean4",
+   "name": "lean4-wsl"
+  },
+  "language_info": {
+   "codemirror_mode": "lean4",
+   "file_extension": ".lean",
+   "mimetype": "text/x-lean4",
+   "name": "lean4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/lean/setup_native_lean4_import.py
+++ b/scripts/lean/setup_native_lean4_import.py
@@ -48,6 +48,7 @@ REPL_TOOLCHAIN_TAGS = {
     "v4.30.0-rc2": "repl-4.30.0-rc2",
     "v4.31.0-rc1": "repl-4.31.0-rc1",
     "v4.32.0": "repl-4.32.0",
+    "v4.32.1": "repl-4.32.1",
 }
 # Durable fork of utensil/lean4_jupyter baking the direct-launch patch directly into
 # repl.py (survives a clean ``pip install``/reinstall, closing the durability gap of the


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2026:CoursIA — prev: DEEP/lean #11946 (c.410)

Quoi:       Nouveau notebook compagnon natif SC-7c (kernel lean4-wsl) pour le lake erc20_lean, 17/17 declarations evaluees reellement
Preuve:     nbclient end-to-end sur mirror WSL natif v4.32.1 (kernel lean4-wsl, repl matche) — 13/13 cellules code execution_count 1..13, outputs reels, coverage instrument 17/17
Perimetre:  SC-7c-ERC20-Lean-Native-Companion.ipynb (nouveau) + 1 ligne mapping repl v4.32.1 dans scripts/lean/setup_native_lean4_import.py ; hors scope : fix du globs lakefile (signale ci-dessous)
