### PR TITLE
fix(genai,#9434): residuel GPU wallclock — FT-01 3->0 + 02-7 resume re-aligne sur outputs committes (158.5 s/16 f -> ~573 s/49 f)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-01-Introduction-FineTuning.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "### Vérification de l'environnement\n",
     "\n",
-    "Avant tout chargement de modèle, on vérifie la disponibilité du GPU et sa capacité. Ce notebook est dimensionné pour un GPU avec environ 4 Go de VRAM (GPT-2 = 124M params en float32 = ~500 Mo, plus les états d'optimiseur Adam qui doublent la consommation). Sur un GPU plus modeste (CPU-only), le notebook reste fonctionnel mais l'étape de fine-tuning sera **très** lente — à titre indicatif, comptez 5-10 minutes au lieu de 13 secondes pour les 10 époques sur un CPU moderne.\n",
+    "Avant tout chargement de modèle, on vérifie la disponibilité du GPU et sa capacité. Ce notebook est dimensionné pour un GPU avec environ 4 Go de VRAM (GPT-2 = 124M params en float32 = ~500 Mo, plus les états d'optimiseur Adam qui doublent la consommation). Sur un GPU plus modeste (CPU-only), le notebook reste fonctionnel mais l'étape de fine-tuning sera **très** lente — à titre indicatif, comptez 5-10 minutes au lieu de ~13 secondes pour les 10 époques sur un CPU moderne.\n",
     "\n",
     "L'import de `torch` au début est délibérément minimal : on n'importe que `torch`, `os`, et `gc`. `gc` sera utilisé à la fin pour libérer la mémoire GPU avant la sortie du notebook. Le pattern `if torch.cuda.is_available(): ...` permet au notebook de **tourner aussi sur CPU** en mode dégradé — la branche GPU est skipped silencieusement sans casser l'exécution.\n",
     "\n"
@@ -798,7 +798,7 @@
     "\n",
     "- **`trainable params: 294,912 || all params: 124,734,720 || trainable%: 0.2364`** -- PEFT confirme la mesure de la section 3 (leger denominateur different : 124,7 M car il compte aussi les buffers de l'adaptateur). Seuls ces 0,24 % recoivent des gradients ; le reste du modele est gele.\n",
     "- **`Perte finale : 5.0106`** -- sur 7 exemples, 10 epochs. Ce chiffre n'est **pas** une performance a etaler : il confirme surtout que l'optimisation a tourne sans diverger. Ce sera la valeur de reference de l'exercice 3.\n",
-    "- **`Temps : 13.3s`** -- sur RTX 3090, dix epochs sur GPT-2 en LoRA tiennent en treize secondes. C'est l'argument operationnel de LoRA : le meme budget en full fine-tuning devrait aussi porter les gradients et les etats d'optimiseur des 124 M parametres.\n",
+    "- **`Temps : ...`** -- sur RTX 3090 (runtime *machine-dep*), dix epochs sur GPT-2 en LoRA tiennent en une dizaine de secondes. C'est l'argument operationnel de LoRA : le meme budget en full fine-tuning devrait aussi porter les gradients et les etats d'optimiseur des 124 M parametres.\n",
     "\n",
     "Les avertissements (`GPU imbalance`, `NCCL`, `loss_type=None`) sont ceux d'une station multi-GPU heterogene -- ils documentent l'environnement, rien de l'entraînement lui-meme. La discipline de lecture : un warning s'explique avant de s'elimine."
    ]
@@ -1120,7 +1120,7 @@
    "source": [
     "### Préparation des exercices\n",
     "\n",
-    "Les trois exercices de cette section sont progressifs : ils commencent par faire varier un seul hyperparamètre en gardant le reste du pipeline inchangé (rangs LoRA), puis élargissent à un changement de corpus (style littéraire), et terminent par une exploration plus risquée mais très pédagogique (learning rate). Gardez à l'esprit la contrainte de ressources : un entraînement de 10 époques sur 7 segments avec GPT-2 prend environ 13 secondes sur un RTX 3090. Vous pouvez donc itérer rapidement — l'idée est d'observer des tendances, pas de publier un résultat.\n",
+    "Les trois exercices de cette section sont progressifs : ils commencent par faire varier un seul hyperparamètre en gardant le reste du pipeline inchangé (rangs LoRA), puis élargissent à un changement de corpus (style littéraire), et terminent par une exploration plus risquée mais très pédagogique (learning rate). Gardez à l'esprit la contrainte de ressources : un entraînement de 10 époques sur 7 segments avec GPT-2 prend une dizaine de secondes sur un RTX 3090. Vous pouvez donc itérer rapidement — l'idée est d'observer des tendances, pas de publier un résultat.\n",
     "\n",
     "Pour chaque exercice, **mesurez avant de conclure** : comptez les paramètres entraînables, affichez la perte finale, et surtout **comparez visuellement deux générations** plutôt que de vous fier à un chiffre de perte. La perte est un proxy nécessaire mais notoirement insuffisant pour évaluer un modèle de langage : un modèle peut avoir une perte basse et générer du texte incohérent, et inversement.\n",
     "\n"
@@ -1179,7 +1179,7 @@
     "\n",
     "Le *learning rate* est l'hyperparametre le plus sensible du fine-tuning. Un LR trop faible = convergence lente, un LR trop eleve = divergence et degradation du modèle. Testez différentes valeurs pour trouver le point optimal.\n",
     "\n",
-    "**Point de reference mesure** : avec la configuration du corps du notebook (10 epochs, batch 2), la perte finale affichee etait de **5.0106** en **13.3 s** sur RTX 3090 -- c'est la valeur a battre (ou a degrader volontairement) en faisant varier le learning rate. Un `learning_rate` trop eleve fait typiquement diverger la perte au-dela de cette reference des les premiers steps, un taux trop faible la laisse stagner sans l'atteindre."
+    "**Point de reference mesure** : avec la configuration du corps du notebook (10 epochs, batch 2), la perte finale affichee etait de **5.0106** en **~13 s** sur RTX 3090 -- c'est la valeur a battre (ou a degrader volontairement) en faisant varier le learning rate. Un `learning_rate` trop eleve fait typiquement diverger la perte au-dela de cette reference des les premiers steps, un taux trop faible la laisse stagner sans l'atteindre."
    ],
    "metadata": {},
    "id": "cell-70d4b526"

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-7-CogVideoX-Text-to-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-7-CogVideoX-Text-to-Video.ipynb
@@ -1531,7 +1531,7 @@
     "> **meme prompt, deux graines** → variation intra-prompt (le modele exploite-t-il la coherence temporelle, ou sort-il des frames decousues ?)\n",
     "> **meme graine, deux prompts d'action opposee** → variation inter-prompt (le modele discrimine-t-il \"falling\" vs \"sitting still\" ?).\n",
     "\n",
-    "On genere **4 videos courtes** (16 frames chacune) :\n",
+    "On genere **4 videos courtes** (49 frames chacune) :\n",
     "- `prompt_a seed_a` : pomme qui **tombe**, graine 42\n",
     "- `prompt_a seed_b` : meme prompt, graine 1337 (variation intra-prompt)\n",
     "- `prompt_b seed_a` : pomme **immobile**, meme graine 42 (variation inter-prompt)\n",
@@ -2673,7 +2673,7 @@
    "source": [
     "## 6. Visualisation : 4 frames extraites par video\n",
     "\n",
-    "Pour rester dans les limites de poids du notebook (`.ipynb` > 5 MB = warning git), on extrait **4 frames par video** (indices 0, 5, 10, 15 sur 16 frames) et on les affiche inline. La sequence complete (16 frames) est sauvegardee en MP4 dans `/tmp/cogvideox_outputs/` si l'execution a ete reelle."
+    "Pour rester dans les limites de poids du notebook (`.ipynb` > 5 MB = warning git), on extrait **4 frames par video** (indices proportionnels : debut, 1/3, 2/3, fin) et on les affiche inline. La sequence complete (49 frames) est sauvegardee en MP4 dans `/tmp/cogvideox_outputs/` si l'execution a ete reelle."
    ]
   },
   {
@@ -2877,7 +2877,7 @@
     "\n",
     "**Indice** : 49 frames est la duree native maximale de CogVideoX-2b ; au-dela, le modele extrapolera avec perte de qualite. Pour 32 et 49 frames, vous pouvez avoir besoin de `pipe.vae.enable_tiling()` (deja active) ET de `num_inference_steps` reduit (15 au lieu de 25).\n",
     "\n",
-    "**Note** : ce notebook utilise 16 frames (compromis memoire/vitesse)."
+    "**Note** : ce notebook utilise 49 frames (duree native CogVideoX-2b)."
    ]
   },
   {
@@ -3124,19 +3124,19 @@
     "Cette execution a ete realisee sur :\n",
     "- **Machine** : `myia-po-2023` (worker po-2023 du cluster CoursIA, Windows 11, RTX 3090 24GB)\n",
     "- **GPU** : NVIDIA GeForce RTX 3090, 24 GB VRAM, CUDA 12.4\n",
-    "- **Wall-clock** : 4 generations courtes (16 frames chacune, 25 etapes) en **158.5 s total** (~40 s par generation)\n",
+    "- **Wall-clock** : 4 generations (49 frames chacune, 25 etapes) en **~573 s total** (~145 s par generation ; runtime *machine-dep*, decomposition ci-dessous)\n",
     "- **VRAM peak** : **9.6 GB** (sur 25.8 GB disponibles, soit 37% d'utilisation)\n",
     "- **Licence** : Apache-2.0 (THUDM, verifiee cell-3 par lecture firsthand de LICENSE)\n",
-    "- **Cout estime pour reproduire** : ~3 minutes de GPU + 14 GB de telechargement initial\n",
+    "- **Cout estime pour reproduire** : ~10 minutes de GPU + 14 GB de telechargement initial\n",
     "\n",
     "### Decomposition du wall-clock (Prong B)\n",
     "\n",
     "| Generation | Prompt | Seed | Frames | Wall (s) | VRAM pic (GB) |\n",
     "|---|---|---|---|---|---|\n",
-    "| 1 | pomme qui tombe (apple falling) | 42 | 16 | 40.7 | 9.6 |\n",
-    "| 2 | pomme qui tombe (apple falling) | 1337 | 16 | 39.4 | 9.6 |\n",
-    "| 3 | pomme immobile (apple sitting still) | 42 | 16 | 39.3 | 9.6 |\n",
-    "| 4 | pomme immobile (apple sitting still) | 1337 | 16 | 39.0 | 9.6 |\n",
+    "| 1 | pomme qui tombe (apple falling) | 42 | 49 | ~148 | 9.6 |\n",
+    "| 2 | pomme qui tombe (apple falling) | 1337 | 49 | ~142 | 9.6 |\n",
+    "| 3 | pomme immobile (apple sitting still) | 42 | 49 | ~142 | 9.6 |\n",
+    "| 4 | pomme immobile (apple sitting still) | 1337 | 49 | ~142 | 9.6 |\n",
     "\n",
     "**Observation pedagogique** : les 4 generations presentent un wall-clock et une empreinte VRAM tres homogenes (variation < 5%). C'est le signe que le modele est bien conditionne par le pipeline  +  ; les micro-variations proviennent du scheduler DPM++ et du determinisme de la graine. Pour une discussion du couple discriminant (action vs graine), voir cell-13 (grille 4x4) et cell-14 (interpretation).\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-7-CogVideoX-Text-to-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-7-CogVideoX-Text-to-Video.ipynb
@@ -2960,7 +2960,7 @@
     "- `\"A cat jumping up\"` vs `\"A cat landing down\"`\n",
     "- `\"Wheat field with wind blowing east\"` vs `\"Wheat field with wind blowing west\"`\n",
     "\n",
-    "**Limite attendue** : a 16 frames / 2s, le modele a peu de temps pour rendre une trajectoire claire ; ne vous attendez pas a un resultat cinematographique, mais la discrimination doit etre visible."
+    "**Limite attendue** : le stub genere volontairement court (16 frames = 2 s, parametre par defaut) pour economiser le GPU, plus court que le test de discrimination du corps (49 frames = duree native ~6 s) ; a 2 s le modele a peu de temps pour rendre une trajectoire claire, ne vous attendez pas a un resultat cinematographique, mais la discrimination doit etre visible."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-python #11813

Tranche residuel GPU wallclock de l'EPIC #9434. See #9434 (contribution partielle — l'EPIC reste ouverte). 2 notebooks, 14 remplacements markdown-only (+13/-13), format-preservant, aucune cellule code touchee (exception C.3 markdown-only ; outputs intacts — le scanner ne porte que sur la prose).

## FT-01-Introduction-FineTuning — 3 -> 0 findings wallclock

- c21 (interp du rapport d'entrainement) : citation epinglee `Temps : 13.3s` -> `Temps : ...` + « une dizaine de secondes » + marqueur runtime *machine-dep*
- c38 (exercice 3, point de reference) : « en **13.3 s** » -> « en **~13 s** » ; **perte 5.0106 GARDEE** (resultat algorithmique, c'est la valeur a battre de l'exercice)
- c1 + c35 : mentions en toutes lettres (« au lieu de 13 secondes », « environ 13 secondes ») -> ordres de grandeur
- Source verifiee firsthand : l'output committes de la cellule d'entrainement porte « Temps : 13.3s » — la prose dupliquait le pin exact.

## 02-7-CogVideoX-Text-to-Video — pin 158.5 s draines + resume re-aligne sur les outputs committes

Le resume materiel (c22) decrivait une **execution anterieure** : « 4 generations courtes (16 frames chacune, 25 etapes) en 158.5 s total (~40 s par generation) », tableau 40.7/39.4/39.3/39.0 s, cout « ~3 minutes ». L'output committes de la cellule de generation dit : **49 frames** chacune, **572.9 s total**, 147.7/141.6/141.9/141.7 s par generation. La prose n'avait pas suivi le passage `num_frames` 16 -> 49.

- Wall-clock : ~573 s total, ~145 s par generation (runtime *machine-dep*), tableau ~148/~142/~142/~142, cout ~10 minutes
- Frames 16 -> 49 corrigees partout ou la prose portait le recit obsolete : section 5 (protocole), section 6 (visualisation + indices proportionnels reels du code), exercice 1 (note), resume
- **VRAM peak 9.6 GB gardee** (coherente output/metadata) ; observation « variation < 5% » toujours vraie sur les valeurs reelles (~4.3 %)
- `metadata.cost` (wall_clock_total_s: 158.5) non touche — metadata, pas de prose (a resynchroniser lors d'une future re-exec GPU)
- Residuels c6/c14 « 6 secondes » = duree NATIVE de CogVideoX-2b (49 frames @ 8 fps) — capacite du modele, pas un runtime mesure -> FP documente (classe duree-native, deja vue sur 02-4 SVD)

## Diagnostic derive (C.4, cf #8364)

02-7 : la cause = prose resumant une execution anterieure jamais resynchronisee apres le changement de `num_frames`. Verdict : **CAUSE_FIXED** — re-alignement sur les outputs committes + drainage en ordres de grandeur (la classe ne recidive pas : la valeur exacte reste dans l'output, source de verite, et la prose ne porte plus que des ordres de grandeur). Pas de re-exec GPU dans cette PR : drainage markdown-only, convention etablie de la vague (#11514 QC, #11825/#11826/#11833 Video).

## Tri firsthand du residuel examine — tout FP, classes nommees (evite aux lanes suivantes de re-trier)

| Candidat examine | Findings | Classe FP |
|---|---|---|
| Video/04-1-Educational-Video-Generation | 11 | durees constructives du spec (`"duration": 4`, `slide_duration` — deterministes, verifie contre cell 7) |
| Vibe-Coding/CSharpRepl-Live-Patching | 8 | periode 500 ms de la boucle demo + derivations pedagogiques (3x500ms) |
| Audio/04-3-Music-Composition | 5 | params d'effets (decay=50ms, crossfade 500ms) + range deja marque *machine-dep* |
| Search/App-20 + App-20b (twins) | 7 | deja annote structurel/machine-dep in situ ; budget 60 s = parametre de benchmark |
| QC-Py-15-Parameter-Optimization | 4 | estimations derivees de la constante `time_per_backtest = 5` (1296x5=108 min, 100x5=8.3, 50x5=4.2) |
| QC-Py-26-LLM-Trading-Signals | 4 | latences specs fournisseurs (GPT-4o 500ms etc.) |
| Audio/03-3-Realtime-Voice-API | 3 | chunk size 100ms = parametre constructif de streaming |

## Preuves

- Scanner post-edit (`check_machine_dep_timing.py --category wallclock`) : **FT-01 0** (3 avant) ; 02-7 2 residuels FP duree-native documentes (3 avant)
- `git diff --stat` : 2 fichiers, +13/-13 — aucune cellule code, aucun output touche
- Valeurs de remplacement toutes tirees des outputs committes (572.9 s total ; 147.7/141.6/141.9/141.7 s visibles dans l'output de la cellule de generation)

## Residuel constate (hors scope, signale pour une future passe)

- 02-7 : legende du `print` code « frames t=0/5/10/15 » (cellule code — toucher exigerait re-exec GPU) ; phrase « bien conditionne par le pipeline  +  » (placeholders vides preexistants)
- 02-7 : `metadata.cost.wall_clock_total_s = 158.5` obsolete vs outputs (572.9) — resynchronisable a la prochaine re-exec GPU
- Video/02-2-LTX (10 findings) : ecarte par po-2026 comme « valeurs NON dupliquees des outputs = autre pathologie » — jugement separe
