### PR TITLE
fix(csp,#11891): FFD benchmark — capacité locale, sortie ré-exécutée

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part2-CSP/CSP-5-Optimization.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "id": "b4de4ca2",
    "metadata": {
-    "papermill": {
-     "duration": 0.004862,
-     "end_time": "2026-06-04T18:50:01.028474+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.023612+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -49,17 +42,10 @@
    "id": "6ec0404c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:07.515635Z",
-     "iopub.status.busy": "2026-08-20T01:47:07.515173Z",
-     "iopub.status.idle": "2026-08-20T01:47:27.926240Z",
-     "shell.execute_reply": "2026-08-20T01:47:27.925225Z"
-    },
-    "papermill": {
-     "duration": 0.492645,
-     "end_time": "2026-06-04T18:50:01.524824+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.032179+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:36.470206Z",
+     "iopub.status.busy": "2026-08-20T11:09:36.470008Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.221309Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.220703Z"
     },
     "tags": []
    },
@@ -98,13 +84,6 @@
    "cell_type": "markdown",
    "id": "306de6dd",
    "metadata": {
-    "papermill": {
-     "duration": 0.004195,
-     "end_time": "2026-06-04T18:50:01.533088+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.528893+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -128,13 +107,6 @@
    "cell_type": "markdown",
    "id": "1982aae1",
    "metadata": {
-    "papermill": {
-     "duration": 0.003462,
-     "end_time": "2026-06-04T18:50:01.540214+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.536752+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -165,17 +137,10 @@
    "id": "62568836",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:27.931262Z",
-     "iopub.status.busy": "2026-08-20T01:47:27.930465Z",
-     "iopub.status.idle": "2026-08-20T01:47:27.959071Z",
-     "shell.execute_reply": "2026-08-20T01:47:27.957720Z"
-    },
-    "papermill": {
-     "duration": 0.011051,
-     "end_time": "2026-06-04T18:50:01.554690+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.543639+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.222651Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.222422Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.228248Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.227789Z"
     },
     "tags": []
    },
@@ -263,13 +228,6 @@
    "cell_type": "markdown",
    "id": "b3m3dasghtm",
    "metadata": {
-    "papermill": {
-     "duration": 0.003058,
-     "end_time": "2026-06-04T18:50:01.561281+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.558223+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -290,17 +248,10 @@
    "id": "b67b84bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:27.961782Z",
-     "iopub.status.busy": "2026-08-20T01:47:27.961542Z",
-     "iopub.status.idle": "2026-08-20T01:47:28.118370Z",
-     "shell.execute_reply": "2026-08-20T01:47:28.115865Z"
-    },
-    "papermill": {
-     "duration": 0.036962,
-     "end_time": "2026-06-04T18:50:01.603237+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.566275+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.229356Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.229133Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.248417Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.247810Z"
     },
     "tags": []
    },
@@ -335,13 +286,6 @@
    "cell_type": "markdown",
    "id": "t6d5qg7xaub",
    "metadata": {
-    "papermill": {
-     "duration": 0.003464,
-     "end_time": "2026-06-04T18:50:01.610474+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.607010+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -362,17 +306,10 @@
    "id": "d31f7f49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:28.125547Z",
-     "iopub.status.busy": "2026-08-20T01:47:28.124557Z",
-     "iopub.status.idle": "2026-08-20T01:47:29.376128Z",
-     "shell.execute_reply": "2026-08-20T01:47:29.365626Z"
-    },
-    "papermill": {
-     "duration": 0.093298,
-     "end_time": "2026-06-04T18:50:01.708432+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.615134+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.249748Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.249576Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.329878Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.329367Z"
     },
     "tags": []
    },
@@ -433,13 +370,6 @@
    "cell_type": "markdown",
    "id": "0f823815",
    "metadata": {
-    "papermill": {
-     "duration": 0.003721,
-     "end_time": "2026-06-04T18:50:01.716022+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.712301+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -459,13 +389,6 @@
    "cell_type": "markdown",
    "id": "ab96e4f1",
    "metadata": {
-    "papermill": {
-     "duration": 0.003736,
-     "end_time": "2026-06-04T18:50:01.723267+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.719531+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -500,17 +423,10 @@
    "id": "0119fcb8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:29.393395Z",
-     "iopub.status.busy": "2026-08-20T01:47:29.390778Z",
-     "iopub.status.idle": "2026-08-20T01:47:29.433775Z",
-     "shell.execute_reply": "2026-08-20T01:47:29.423100Z"
-    },
-    "papermill": {
-     "duration": 0.009438,
-     "end_time": "2026-06-04T18:50:01.736432+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.726994+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.331308Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.331163Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.336074Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.335597Z"
     },
     "tags": []
    },
@@ -577,13 +493,6 @@
    "cell_type": "markdown",
    "id": "9ml2fzd7jfl",
    "metadata": {
-    "papermill": {
-     "duration": 0.003687,
-     "end_time": "2026-06-04T18:50:01.743938+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.740251+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -604,17 +513,10 @@
    "id": "a959f3a5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:29.453182Z",
-     "iopub.status.busy": "2026-08-20T01:47:29.451547Z",
-     "iopub.status.idle": "2026-08-20T01:47:29.498638Z",
-     "shell.execute_reply": "2026-08-20T01:47:29.497442Z"
-    },
-    "papermill": {
-     "duration": 0.011313,
-     "end_time": "2026-06-04T18:50:01.758914+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.747601+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.337402Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.337226Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.359234Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.358328Z"
     },
     "tags": []
    },
@@ -647,13 +549,6 @@
    "cell_type": "markdown",
    "id": "ceba52b5",
    "metadata": {
-    "papermill": {
-     "duration": 0.003871,
-     "end_time": "2026-06-04T18:50:01.766672+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.762801+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -690,13 +585,6 @@
    "cell_type": "markdown",
    "id": "e5dffc51",
    "metadata": {
-    "papermill": {
-     "duration": 0.00397,
-     "end_time": "2026-06-04T18:50:01.774448+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.770478+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -722,13 +610,6 @@
      "iopub.status.busy": "2026-03-04T16:41:05.670909Z",
      "iopub.status.idle": "2026-03-04T16:41:05.678858Z",
      "shell.execute_reply": "2026-03-04T16:41:05.677760Z"
-    },
-    "papermill": {
-     "duration": 0.003741,
-     "end_time": "2026-06-04T18:50:01.782022+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.778281+00:00",
-     "status": "completed"
     },
     "tags": []
    },
@@ -758,13 +639,6 @@
    "cell_type": "markdown",
    "id": "9a33254d",
    "metadata": {
-    "papermill": {
-     "duration": 0.003595,
-     "end_time": "2026-06-04T18:50:01.789311+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.785716+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -777,17 +651,10 @@
    "id": "cutting-stock-func",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:29.501619Z",
-     "iopub.status.busy": "2026-08-20T01:47:29.501256Z",
-     "iopub.status.idle": "2026-08-20T01:47:29.513218Z",
-     "shell.execute_reply": "2026-08-20T01:47:29.512059Z"
-    },
-    "papermill": {
-     "duration": 0.010992,
-     "end_time": "2026-06-04T18:50:01.803958+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.792966+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.361192Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.360903Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.367747Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.367353Z"
     },
     "tags": []
    },
@@ -882,13 +749,6 @@
    "cell_type": "markdown",
    "id": "v6zkppessk",
    "metadata": {
-    "papermill": {
-     "duration": 0.003727,
-     "end_time": "2026-06-04T18:50:01.811499+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.807772+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -909,17 +769,10 @@
    "id": "9766c313",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:29.516301Z",
-     "iopub.status.busy": "2026-08-20T01:47:29.515973Z",
-     "iopub.status.idle": "2026-08-20T01:47:29.544491Z",
-     "shell.execute_reply": "2026-08-20T01:47:29.543691Z"
-    },
-    "papermill": {
-     "duration": 0.015161,
-     "end_time": "2026-06-04T18:50:01.830800+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.815639+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.369079Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.368956Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.383204Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.382718Z"
     },
     "tags": []
    },
@@ -958,13 +811,6 @@
    "cell_type": "markdown",
    "id": "f976b227",
    "metadata": {
-    "papermill": {
-     "duration": 0.004134,
-     "end_time": "2026-06-04T18:50:01.838924+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.834790+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -998,13 +844,6 @@
    "cell_type": "markdown",
    "id": "5012b0fc",
    "metadata": {
-    "papermill": {
-     "duration": 0.00426,
-     "end_time": "2026-06-04T18:50:01.847352+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.843092+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1037,17 +876,10 @@
    "id": "6f3fd960",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:29.547229Z",
-     "iopub.status.busy": "2026-08-20T01:47:29.546826Z",
-     "iopub.status.idle": "2026-08-20T01:47:29.559612Z",
-     "shell.execute_reply": "2026-08-20T01:47:29.558704Z"
-    },
-    "papermill": {
-     "duration": 0.011975,
-     "end_time": "2026-06-04T18:50:01.863619+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.851644+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.384434Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.384318Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.390566Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.390059Z"
     },
     "tags": []
    },
@@ -1160,13 +992,6 @@
    "cell_type": "markdown",
    "id": "5f72e6dd",
    "metadata": {
-    "papermill": {
-     "duration": 0.004112,
-     "end_time": "2026-06-04T18:50:01.872031+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.867919+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1177,13 +1002,6 @@
    "cell_type": "markdown",
    "id": "rh2if8n2qkk",
    "metadata": {
-    "papermill": {
-     "duration": 0.004157,
-     "end_time": "2026-06-04T18:50:01.880254+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.876097+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1205,17 +1023,10 @@
    "id": "ca44e3de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:29.562231Z",
-     "iopub.status.busy": "2026-08-20T01:47:29.561830Z",
-     "iopub.status.idle": "2026-08-20T01:47:29.590399Z",
-     "shell.execute_reply": "2026-08-20T01:47:29.589492Z"
-    },
-    "papermill": {
-     "duration": 0.013503,
-     "end_time": "2026-06-04T18:50:01.897957+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.884454+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.391648Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.391537Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.410208Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.409227Z"
     },
     "tags": []
    },
@@ -1267,13 +1078,6 @@
    "cell_type": "markdown",
    "id": "10b954fc",
    "metadata": {
-    "papermill": {
-     "duration": 0.00394,
-     "end_time": "2026-06-04T18:50:01.905933+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.901993+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1300,13 +1104,6 @@
    "cell_type": "markdown",
    "id": "51095ee2",
    "metadata": {
-    "papermill": {
-     "duration": 0.004354,
-     "end_time": "2026-06-04T18:50:01.914333+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.909979+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1333,17 +1130,10 @@
    "id": "64f599ff",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:29.592935Z",
-     "iopub.status.busy": "2026-08-20T01:47:29.592727Z",
-     "iopub.status.idle": "2026-08-20T01:47:29.604215Z",
-     "shell.execute_reply": "2026-08-20T01:47:29.603465Z"
-    },
-    "papermill": {
-     "duration": 0.010058,
-     "end_time": "2026-06-04T18:50:01.928248+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.918190+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:09:37.411685Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.411549Z",
+     "iopub.status.idle": "2026-08-20T11:09:37.416608Z",
+     "shell.execute_reply": "2026-08-20T11:09:37.416211Z"
     },
     "tags": []
    },
@@ -1353,8 +1143,8 @@
      "output_type": "stream",
      "text": [
       "CP-SAT optimal: 2 bins\n",
-      "FFD heuristic:  1 bins\n",
-      "Gap: -50.0%\n"
+      "FFD heuristic:  3 bins\n",
+      "Gap: 50.0%\n"
      ]
     }
    ],
@@ -1388,26 +1178,23 @@
     "        'status': 'HEURISTIC'\n",
     "    }\n",
     "\n",
-    "# Comparaison\n",
-    "ffd_result = bin_packing_ffd(items, capacity)\n",
+    "# Comparaison — instance de la section 1 (items [2,2,2,3,5,6], capacité 10)\n",
+    "# La variable globale capacity peut avoir été écrasée par une section ultérieure\n",
+    "# (Knapsack: capacity = 20) — utiliser une variable locale pour FFD afin que la\n",
+    "# comparaison CP-SAT vs FFD porte BIEN sur la même instance.\n",
+    "capacity_local = 10  # capacité de la section 1 Bin Packing\n",
+    "ffd_result = bin_packing_ffd(items, capacity_local)\n",
     "print(f\"CP-SAT optimal: {bpp_result['num_bins']} bins\")\n",
     "print(f\"FFD heuristic:  {ffd_result['num_bins']} bins\")\n",
     "if bpp_result['num_bins']:\n",
     "    gap = (ffd_result['num_bins'] - bpp_result['num_bins']) / bpp_result['num_bins'] * 100\n",
-    "    print(f\"Gap: {gap:.1f}%\")"
+    "    print(f\"Gap: {gap:.1f}%\")\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "ae6d9851",
    "metadata": {
-    "papermill": {
-     "duration": 0.003747,
-     "end_time": "2026-06-04T18:50:01.935834+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.932087+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1451,10 +1238,10 @@
    "id": "scaling-benchmark",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:47:29.606516Z",
-     "iopub.status.busy": "2026-08-20T01:47:29.606246Z",
-     "iopub.status.idle": "2026-08-20T01:48:01.619593Z",
-     "shell.execute_reply": "2026-08-20T01:48:01.618145Z"
+     "iopub.execute_input": "2026-08-20T11:09:37.417845Z",
+     "iopub.status.busy": "2026-08-20T11:09:37.417684Z",
+     "iopub.status.idle": "2026-08-20T11:10:08.364000Z",
+     "shell.execute_reply": "2026-08-20T11:10:08.362597Z"
     }
    },
    "outputs": [
@@ -1471,28 +1258,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    6     3       2  50.0%   0.000s      0.02s    OPTIMAL\n"
+      "    6     3       2  50.0%   0.000s      0.01s    OPTIMAL\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   20     6       6   0.0%   0.000s      0.08s    OPTIMAL\n"
+      "   20     6       6   0.0%   0.000s      0.04s    OPTIMAL\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   50    15      14   7.1%   0.000s      1.28s    OPTIMAL\n"
+      "   50    15      14   7.1%   0.000s      0.48s    OPTIMAL\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  100    30      30   0.0%   0.000s     30.62s   FEASIBLE\n"
+      "  100    30      30   0.0%   0.000s     30.41s   FEASIBLE\n"
      ]
     }
    ],
@@ -1546,13 +1333,6 @@
    "cell_type": "markdown",
    "id": "9du53myvfqi",
    "metadata": {
-    "papermill": {
-     "duration": 0.003604,
-     "end_time": "2026-06-04T18:50:01.943106+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.939502+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1570,13 +1350,6 @@
    "cell_type": "markdown",
    "id": "h2ha8li6gbe",
    "metadata": {
-    "papermill": {
-     "duration": 0.003677,
-     "end_time": "2026-06-04T18:50:01.950450+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.946773+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1595,17 +1368,10 @@
    "id": "qimxekd7ur",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:01.623567Z",
-     "iopub.status.busy": "2026-08-20T01:48:01.623111Z",
-     "iopub.status.idle": "2026-08-20T01:48:01.639318Z",
-     "shell.execute_reply": "2026-08-20T01:48:01.637772Z"
-    },
-    "papermill": {
-     "duration": 0.011146,
-     "end_time": "2026-06-04T18:50:01.980725+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.969579+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:08.367012Z",
+     "iopub.status.busy": "2026-08-20T11:10:08.366698Z",
+     "iopub.status.idle": "2026-08-20T11:10:08.382322Z",
+     "shell.execute_reply": "2026-08-20T11:10:08.380949Z"
     },
     "tags": []
    },
@@ -1719,13 +1485,6 @@
    "cell_type": "markdown",
    "id": "2wgurgb2klh",
    "metadata": {
-    "papermill": {
-     "duration": 0.003941,
-     "end_time": "2026-06-04T18:50:01.988823+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.984882+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1752,13 +1511,6 @@
    "cell_type": "markdown",
    "id": "f60f676f",
    "metadata": {
-    "papermill": {
-     "duration": 0.004054,
-     "end_time": "2026-06-04T18:50:01.997107+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:01.993053+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1783,17 +1535,10 @@
    "id": "da1f4020",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:01.643048Z",
-     "iopub.status.busy": "2026-08-20T01:48:01.642727Z",
-     "iopub.status.idle": "2026-08-20T01:48:01.669860Z",
-     "shell.execute_reply": "2026-08-20T01:48:01.668711Z"
-    },
-    "papermill": {
-     "duration": 0.016842,
-     "end_time": "2026-06-04T18:50:02.017945+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.001103+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:08.385385Z",
+     "iopub.status.busy": "2026-08-20T11:10:08.385074Z",
+     "iopub.status.idle": "2026-08-20T11:10:08.430134Z",
+     "shell.execute_reply": "2026-08-20T11:10:08.428714Z"
     },
     "tags": []
    },
@@ -1805,7 +1550,7 @@
       "Status      : OPTIMAL\n",
       "Valeur tot  : 31\n",
       "  Sac 0 (10/10) : objets [0, 6]  valeur = 12\n",
-      "  Sac 1 (15/15) : objets [1, 3, 5]  valeur = 19\n"
+      "  Sac 1 (15/15) : objets [2, 3, 7]  valeur = 19\n"
      ]
     }
    ],
@@ -1875,13 +1620,6 @@
    "cell_type": "markdown",
    "id": "e02fa64c",
    "metadata": {
-    "papermill": {
-     "duration": 0.00436,
-     "end_time": "2026-06-04T18:50:02.026502+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.022142+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1907,17 +1645,10 @@
    "id": "bf3bea48",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:01.673506Z",
-     "iopub.status.busy": "2026-08-20T01:48:01.673062Z",
-     "iopub.status.idle": "2026-08-20T01:48:01.680824Z",
-     "shell.execute_reply": "2026-08-20T01:48:01.679534Z"
-    },
-    "papermill": {
-     "duration": 0.008535,
-     "end_time": "2026-06-04T18:50:02.039784+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.031249+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:08.432938Z",
+     "iopub.status.busy": "2026-08-20T11:10:08.432623Z",
+     "iopub.status.idle": "2026-08-20T11:10:08.441447Z",
+     "shell.execute_reply": "2026-08-20T11:10:08.439944Z"
     },
     "tags": []
    },
@@ -1949,13 +1680,6 @@
    "cell_type": "markdown",
    "id": "83ae34cd6045",
    "metadata": {
-    "papermill": {
-     "duration": 0.00574,
-     "end_time": "2026-06-04T18:50:02.050462+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.044722+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -1970,17 +1694,10 @@
    "id": "f827a0561e2b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:01.684554Z",
-     "iopub.status.busy": "2026-08-20T01:48:01.684102Z",
-     "iopub.status.idle": "2026-08-20T01:48:02.349928Z",
-     "shell.execute_reply": "2026-08-20T01:48:02.348577Z"
-    },
-    "papermill": {
-     "duration": 0.042731,
-     "end_time": "2026-06-04T18:50:02.097998+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.055267+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:08.444326Z",
+     "iopub.status.busy": "2026-08-20T11:10:08.443804Z",
+     "iopub.status.idle": "2026-08-20T11:10:09.117423Z",
+     "shell.execute_reply": "2026-08-20T11:10:09.116083Z"
     },
     "tags": []
    },
@@ -2066,13 +1783,6 @@
    "cell_type": "markdown",
    "id": "b1d221dd",
    "metadata": {
-    "papermill": {
-     "duration": 0.004472,
-     "end_time": "2026-06-04T18:50:02.108296+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.103824+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -2097,17 +1807,10 @@
    "id": "3d088149",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:02.353408Z",
-     "iopub.status.busy": "2026-08-20T01:48:02.352986Z",
-     "iopub.status.idle": "2026-08-20T01:48:02.361288Z",
-     "shell.execute_reply": "2026-08-20T01:48:02.360032Z"
-    },
-    "papermill": {
-     "duration": 0.008346,
-     "end_time": "2026-06-04T18:50:02.124057+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.115711+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:09.120486Z",
+     "iopub.status.busy": "2026-08-20T11:10:09.120011Z",
+     "iopub.status.idle": "2026-08-20T11:10:09.129941Z",
+     "shell.execute_reply": "2026-08-20T11:10:09.128599Z"
     },
     "tags": []
    },
@@ -2140,13 +1843,6 @@
    "cell_type": "markdown",
    "id": "c1ddac3773e5",
    "metadata": {
-    "papermill": {
-     "duration": 0.006502,
-     "end_time": "2026-06-04T18:50:02.134883+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.128381+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -2161,17 +1857,10 @@
    "id": "51138822929d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:02.364562Z",
-     "iopub.status.busy": "2026-08-20T01:48:02.364174Z",
-     "iopub.status.idle": "2026-08-20T01:48:02.405417Z",
-     "shell.execute_reply": "2026-08-20T01:48:02.404195Z"
-    },
-    "papermill": {
-     "duration": 0.015952,
-     "end_time": "2026-06-04T18:50:02.154658+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.138706+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:09.133015Z",
+     "iopub.status.busy": "2026-08-20T11:10:09.132550Z",
+     "iopub.status.idle": "2026-08-20T11:10:09.160283Z",
+     "shell.execute_reply": "2026-08-20T11:10:09.159019Z"
     },
     "tags": []
    },
@@ -2277,13 +1966,6 @@
    "cell_type": "markdown",
    "id": "a5270faf",
    "metadata": {
-    "papermill": {
-     "duration": 0.004089,
-     "end_time": "2026-06-04T18:50:02.163204+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.159115+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -2318,17 +2000,10 @@
    "id": "37d34d49",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:02.408465Z",
-     "iopub.status.busy": "2026-08-20T01:48:02.408073Z",
-     "iopub.status.idle": "2026-08-20T01:48:02.419040Z",
-     "shell.execute_reply": "2026-08-20T01:48:02.417760Z"
-    },
-    "papermill": {
-     "duration": 0.008984,
-     "end_time": "2026-06-04T18:50:02.176333+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.167349+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:09.163002Z",
+     "iopub.status.busy": "2026-08-20T11:10:09.162545Z",
+     "iopub.status.idle": "2026-08-20T11:10:09.170048Z",
+     "shell.execute_reply": "2026-08-20T11:10:09.168850Z"
     },
     "tags": []
    },
@@ -2366,13 +2041,6 @@
    "cell_type": "markdown",
    "id": "a0444de9ee78",
    "metadata": {
-    "papermill": {
-     "duration": 0.004372,
-     "end_time": "2026-06-04T18:50:02.185347+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.180975+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -2387,17 +2055,10 @@
    "id": "02d726f5244c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:02.422664Z",
-     "iopub.status.busy": "2026-08-20T01:48:02.422146Z",
-     "iopub.status.idle": "2026-08-20T01:48:02.492091Z",
-     "shell.execute_reply": "2026-08-20T01:48:02.490849Z"
-    },
-    "papermill": {
-     "duration": 0.024899,
-     "end_time": "2026-06-04T18:50:02.214461+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.189562+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:09.173161Z",
+     "iopub.status.busy": "2026-08-20T11:10:09.172625Z",
+     "iopub.status.idle": "2026-08-20T11:10:09.231229Z",
+     "shell.execute_reply": "2026-08-20T11:10:09.229848Z"
     },
     "tags": []
    },
@@ -2525,13 +2186,6 @@
    "cell_type": "markdown",
    "id": "7bb9cf4a",
    "metadata": {
-    "papermill": {
-     "duration": 0.003944,
-     "end_time": "2026-06-04T18:50:02.222309+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.218365+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -2558,17 +2212,10 @@
    "id": "56c1757e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:02.494965Z",
-     "iopub.status.busy": "2026-08-20T01:48:02.494613Z",
-     "iopub.status.idle": "2026-08-20T01:48:02.501596Z",
-     "shell.execute_reply": "2026-08-20T01:48:02.500355Z"
-    },
-    "papermill": {
-     "duration": 0.008239,
-     "end_time": "2026-06-04T18:50:02.234707+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.226468+00:00",
-     "status": "completed"
+     "iopub.execute_input": "2026-08-20T11:10:09.234150Z",
+     "iopub.status.busy": "2026-08-20T11:10:09.233855Z",
+     "iopub.status.idle": "2026-08-20T11:10:09.242423Z",
+     "shell.execute_reply": "2026-08-20T11:10:09.240927Z"
     },
     "tags": []
    },
@@ -2618,10 +2265,10 @@
    "id": "annexe-libvslib-d1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:02.504682Z",
-     "iopub.status.busy": "2026-08-20T01:48:02.504290Z",
-     "iopub.status.idle": "2026-08-20T01:48:02.571177Z",
-     "shell.execute_reply": "2026-08-20T01:48:02.569929Z"
+     "iopub.execute_input": "2026-08-20T11:10:09.245183Z",
+     "iopub.status.busy": "2026-08-20T11:10:09.244892Z",
+     "iopub.status.idle": "2026-08-20T11:10:09.310743Z",
+     "shell.execute_reply": "2026-08-20T11:10:09.309305Z"
     }
    },
    "outputs": [
@@ -2629,14 +2276,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Bin Packing : nombre optimal de bins = 3 (capacite 10) [1 ms]"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "Bin Packing : nombre optimal de bins = 3 (capacite 10) [1 ms]\n",
       "  Bin 0 (charge 2/10) : objets [4] tailles [2]\n",
       "  Bin 1 (charge 9/10) : objets [1, 2] tailles [5, 4]\n",
       "  Bin 2 (charge 9/10) : objets [0, 3] tailles [2, 7]\n"
@@ -2719,10 +2359,10 @@
    "id": "annexe-libvslib-d2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:02.573879Z",
-     "iopub.status.busy": "2026-08-20T01:48:02.573546Z",
-     "iopub.status.idle": "2026-08-20T01:48:02.583075Z",
-     "shell.execute_reply": "2026-08-20T01:48:02.582048Z"
+     "iopub.execute_input": "2026-08-20T11:10:09.313677Z",
+     "iopub.status.busy": "2026-08-20T11:10:09.313031Z",
+     "iopub.status.idle": "2026-08-20T11:10:09.324768Z",
+     "shell.execute_reply": "2026-08-20T11:10:09.323565Z"
     }
    },
    "outputs": [
@@ -2782,10 +2422,10 @@
    "id": "annexe-libvslib-d3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:02.586276Z",
-     "iopub.status.busy": "2026-08-20T01:48:02.585919Z",
-     "iopub.status.idle": "2026-08-20T01:48:13.914059Z",
-     "shell.execute_reply": "2026-08-20T01:48:13.913011Z"
+     "iopub.execute_input": "2026-08-20T11:10:09.327434Z",
+     "iopub.status.busy": "2026-08-20T11:10:09.327192Z",
+     "iopub.status.idle": "2026-08-20T11:10:20.275082Z",
+     "shell.execute_reply": "2026-08-20T11:10:20.273807Z"
     }
    },
    "outputs": [
@@ -2793,7 +2433,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Cutting Stock : nombre optimal de barres = 10 (longueur stock 10) [11.3 s]\n",
+      "Cutting Stock : nombre optimal de barres = 10 (longueur stock 10) [10.9 s]\n",
       "  Barre 0 (9/10) : longueurs [9]\n",
       "  Barre 1 (9/10) : longueurs [9]\n",
       "  Barre 2 (9/10) : longueurs [9]\n",
@@ -2866,10 +2506,10 @@
    "id": "annexe-libvslib-d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T01:48:13.916728Z",
-     "iopub.status.busy": "2026-08-20T01:48:13.916442Z",
-     "iopub.status.idle": "2026-08-20T01:48:13.930707Z",
-     "shell.execute_reply": "2026-08-20T01:48:13.929548Z"
+     "iopub.execute_input": "2026-08-20T11:10:20.278165Z",
+     "iopub.status.busy": "2026-08-20T11:10:20.277547Z",
+     "iopub.status.idle": "2026-08-20T11:10:20.289569Z",
+     "shell.execute_reply": "2026-08-20T11:10:20.288315Z"
     }
    },
    "outputs": [
@@ -2940,13 +2580,6 @@
    "cell_type": "markdown",
    "id": "83458ba2",
    "metadata": {
-    "papermill": {
-     "duration": 0.004019,
-     "end_time": "2026-06-04T18:50:02.242595+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.238576+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -2967,13 +2600,6 @@
    "cell_type": "markdown",
    "id": "r3ev9tfw19",
    "metadata": {
-    "papermill": {
-     "duration": 0.00408,
-     "end_time": "2026-06-04T18:50:02.250723+00:00",
-     "exception": false,
-     "start_time": "2026-06-04T18:50:02.246643+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [

--- a/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/csp-5-optimization.yaml
@@ -46,6 +46,12 @@
       csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
       content_python_sha: efe22459e4104b3632c044970a290cf88ae914fe6cf64876cfbb472e9b1c5a66
       content_csharp_sha: 842524dae2c561df22a19efde82c8fcd0583b66367fec5ede557160eb2dc019d
+    - date: "2026-08-20"
+      by: myia-po-2025:CoursIA-2
+      python_sha: bf5f52bd081b7b501ff1fc60e6c33f25202e1686
+      csharp_sha: cd0d73e8fee0fe5c17b2a5df10554a32f2d9498e
+      content_python_sha: acacb71af448b4ab8927d10528b6abd094c64e781685ff3b36f5dcc4e36a155f
+      content_csharp_sha: 842524dae2c561df22a19efde82c8fcd0583b66367fec5ede557160eb2dc019d
   known_differences:
     - "Rebridge 2026-08-20 (myia-po-2025:CoursIA-2, #10382) : annexe 'parite lib-vs-lib' ajoutee au twin Python (9 cellules avant References, ids annexe-libvslib-*) -- pychoco rejoue les 4 demos Choco du twin C# (BPP reification+scalar, Knapsack scalar, Cutting Stock bin_packing globale, Portfolio lineaire) sur les instances exactes des cellules 6/8/10/12 du C#. Re-exec complete du notebook (25 cellules code, 0 erreur, nbconvert --execute). Convergence 4/4 : 3 bins, 31/{0,1,3}, 10 barres meme structure, 27/{0,1,4}. Verdict flip RECOVERABLE-LOCAL -> SOTA-OK (le remede nomme dans le verdict precedent -- pychoco pour aligner les 2 jambes sur Choco -- est applique). Twin C# non modifie."
     - "Edition 2026-08-17 (myia-po-2025:CoursIA, #9434) : le twin Python a evacue ses durees wall-clock machine-dependantes de la prose d'interpretation de la cellule 33 (benchmark FFD vs CP-SAT, pins ~20 ms / ~0,5 s / limite 30 s / < 1 ms / n <= 50 en une seconde) au profit d'ordres de grandeur + renvois vers la sortie du benchmark (cellule 32 ci-dessus), avec note mandat #9377/#9434. Les resultats deterministes (gaps 50 %/0 %/7 %, statuts OPTIMAL/FEASIBLE) sont conserves verbatim. Markdown-only, pas de re-exec (exception C.2). Twin C# non modifie (pins absents cote C#, 19 cellules sans benchmark scaling). Parite semantique tenue : socle optimisation, modelisation, contraintes, benchmark empirique inchanges."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/fix #11891 STALE_BLOCK (commit d11fe1ca200)

#11891 — REPAIR `No fabricated text output` rouge sur CSP-5-Optimization cell#29.

## Le défaut (mesuré firsthand sur la branche)

cell#29 sortie branchée : `CP-SAT optimal: 2 bins / FFD heuristic: 1 bins / Gap: -50.0 %`
cell#29 sortie origin/main : `CP-SAT optimal: 2 bins / FFD heuristic: 3 bins / Gap: 50.0 %`

Le code source est byte-identique entre main et la branche ; seule la sortie diffère. La cellule Benchmark FFD utilise la **variable globale `capacity`** ; or, entre la section "1. Bin Packing" (cell#6 `capacity = 10`) et "2. Knapsack" (cell#13 `capacity = 20`), la variable est écrasée. À la ré-exécution end-to-end propre post-annexe parité, `capacity == 20`, l'instance `[2,2,2,3,5,6]` (somme 20) tient dans 1 bin — sortie fabricatee "FFD heuristic: 1 bin".

Detector `No fabricated text output` attrape la régression. Cause = scope global non protégé entre sections.

## Remède (cause → re-exec, pas scrub d'output)

1. **Cause = neutralisée dans cell#29** : déclaration locale `capacity_local = 10` (capacité de la section BPP), passée à `bin_packing_ffd(items, capacity_local)`. Commentaire dans la cellule documente le piège.
2. **Ré-exécution end-to-end** : `nbclient.NotebookClient(nb, kernel_name='python3')` sur le notebook complet, **pas** papermill (cf. L237 ★★ pour le strip préalable de metadata.papermill racine + par cellule).
3. **Sortie corrigée** : cell#29 = `CP-SAT optimal: 2 bins / FFD heuristic: 3 bins / Gap: 50.0 %`. Identique à cell#30 interprétation (gap 50 % annoncé depuis l'origine) et cell#32 (scaling à 6 items).

## Conformité Stop & Repair (secrets-hygiene R6)

Zéro hand-edit d'`outputs`. La nouvelle sortie **est celle produite par le code ré-exécuté**, au prix d'un fix minimal (1 ligne de code + 1 commentaire). Pas de scrub.

## Vérifications (prouvées)

- 25/25 code cells exécutées, 0 erreur, 0 cellule sans `execution_count` (H.3 PASS)
- cell#29 `ec=11`, output conforme au commentaire de cell#30 et au scaling cell#32
- `metadata.papermill` stripé racine + par cellule (STALE_BLOCK, suite du commit d11fe1ca2)
- CKJ post-edit : 0 parasite Unicode
- pre-commit gitleaks + scrub papermill paths + strip probe banner + H.3 PASS
- twin-parity attestation mise à jour : `python scripts/notebook_tools/check_twin_parity.py --update --pair "CSP-5 Optimization"` post-commit `5a645d680`. csharp_sha inchangé (`cd0d73e8fee0`), content_python_sha recalculé par la ré-exec.

## Cible / portée

**Target = `feature/csp5-pychoco-parity`** (la branche de #11891), **pas** `main`. Le fix #11891 doit se merger dans la PR d'origine (11891), pas en cascade sur main. PR squelettique, à squash-merge par ai-01 dans #11891 ou en fast-forward.

## Diagnostics honnêtes

- Cell#29 reste vulnérable si une section ultérieure touche `capacity`. La fix locale suffit, mais le notebook gagnerait un mini-cadrage `if 'bpp_items' not in globals()` au début de cell#29 (out of scope pour ce PR Repair).
- `#8057` twin parity : la nouvelle attestation sera reprise par le prochain `check_twin_parity --update` quand la branche sera squashed dans `#11891`. Pas de drift attendu.

See #11891 · L898 vérifié (single ownership `fix/11891-csp5-fabricated-output`, aucun PR ouvert pré-existant sur ce sujet côté cette branche).
