### PR TITLE
fix(guard,#11808): stale-sweep fold (run_id, name) — un rouge homonyme ne peut plus etre efface par un vert etranger

### DIFF
--- a/.github/workflows/pr-gate-stale-sweep.yml
+++ b/.github/workflows/pr-gate-stale-sweep.yml
@@ -136,14 +136,19 @@ jobs:
           : > /tmp/runs.jsonl
           while read -r NUM SHA FORK; do
             [ -z "${NUM:-}" ] && continue
+            # details_url (.../actions/runs/{run_id}/job/{job_id}) is collected
+            # on purpose: it is the only field carrying the run id, which the
+            # selector needs to fold check-runs per (run_id, name) instead of
+            # per name -- three workflows emit a job named "Ratchet (base vs
+            # PR)" and a name-only fold merges their verdicts (#11808).
             BODY=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
-                     --jq '[.check_runs[] | {name, status, conclusion, started_at}]' 2>/dev/null) || continue
+                     --jq '[.check_runs[] | {name, status, conclusion, started_at, details_url}]' 2>/dev/null) || continue
             printf '{"number":%s,"sha":"%s","fork":%s,"checks":%s}\n' "$NUM" "$SHA" "${FORK:-false}" "$BODY" >> /tmp/runs.jsonl
           done < /tmp/openprs.txt
           echo "[stale-sweep] open PRs inspected: $(wc -l < /tmp/runs.jsonl | tr -d ' ')"
 
           python - <<'PY' > /tmp/candidates.txt
-          import json, os
+          import json, os, re, sys
 
           # REST /check-runs is lowercase where GraphQL's rollup is uppercase.
           # A check counts as settled-green when it has completed with a
@@ -164,22 +169,39 @@ jobs:
           # Test seam: the shipped selector is exec'd verbatim by
           # scripts/tests/test_pr_gate_sweep_select.py, which points this at a
           # fixture. Default is the sweep's own collection file.
+          #
+          # Fold key is (run_id, name), NEVER the name alone (#11808). Three
+          # workflows emit a job displaying the same name "Ratchet (base vs
+          # PR)"; folding by name lets the most recent of the three erase the
+          # verdicts of the other two -- measured 2026-08-19 on #11804: an
+          # Output-Failure SUCCESS at 16:21 covered a live Papermill FAILURE
+          # from 16:19, and this sweep re-ran a gate on a PR that was NOT
+          # healthy. The run id is not in the REST payload; details_url
+          # (.../actions/runs/{run_id}/job/{job_id}) carries it at no extra
+          # API call. `gh run rerun` rewrites a run's check-run IN PLACE, so
+          # same (run_id, name) keeps latest-wins -- the fold's original
+          # purpose, a superseded attempt of the SAME workflow -- and only the
+          # cross-workflow merge disappears.
+          def _fold_key(c):
+              m = re.search(r"/runs/(\d+)/", c.get("details_url") or "")
+              return (m.group(1) if m else "unattributed", c.get("name") or "?")
+
+          def _diag(p, why, blockers):
+              print(f'[stale-sweep] #{p["number"]}: red gate, kept out -- {why}: '
+                    + ", ".join(blockers), file=sys.stderr)
+
           for line in open(os.environ.get("SWEEP_RUNS_FILE", "/tmp/runs.jsonl"),
                            encoding="utf-8"):
               line = line.strip()
               if not line:
                   continue
               p = json.loads(line)
-              # Same-name check-runs accumulate on a SHA (reruns, re-dispatch).
-              # For NON-required checks, only the most recent one matters: a
-              # guard that failed and was re-run green must not keep a PR out
-              # of the pool.
               latest = {}
               for c in (p.get("checks") or []):
-                  name = c.get("name") or "?"
+                  key = _fold_key(c)
                   started = c.get("started_at") or ""
-                  if name not in latest or started >= latest[name][0]:
-                      latest[name] = (started, c)
+                  if key not in latest or started >= latest[key][0]:
+                      latest[key] = (started, c)
 
               # `PR gate` is the REQUIRED check, and there latest-wins is FALSE.
               # Two check-runs bearing a required name can coexist on one SHA in
@@ -199,13 +221,25 @@ jobs:
               if not any((c.get("conclusion") or "") in RED for c in gate_legs):
                   continue
 
-              others = [(n, c) for n, (t, c) in latest.items() if n != "PR gate"]
+              others = [(k, c) for k, (t, c) in latest.items() if k[1] != "PR gate"]
               # Every other check must be finished AND green. An unfinished one
               # means the gate may still be legitimately waiting: re-aggregating
               # then would just burn another verdict on the same incomplete set.
-              if not all((c.get("status") or "") == "completed" for _, c in others):
+              # Exclusions are NAMED on stderr (#11808): "1 candidate, N
+              # excluded" is indistinguishable from a disconnected filter, and
+              # the #11804 incident was read off exactly such a count.
+              unfinished = [k for k, c in others
+                            if (c.get("status") or "") != "completed"]
+              if unfinished:
+                  _diag(p, "unfinished", [
+                      f"{k[1]}[run {k[0]}]" for k in unfinished])
                   continue
-              if not all((c.get("conclusion") or "") in GREEN for _, c in others):
+              red_others = [(k, c) for k, c in others
+                            if (c.get("conclusion") or "") not in GREEN]
+              if red_others:
+                  _diag(p, "red", [
+                      f"{k[1]}[run {k[0]}]={c.get('conclusion')}"
+                      for k, c in red_others])
                   continue
 
               print(f'{p["number"]} {p["sha"]} {str(p.get("fork", False)).lower()}')

--- a/scripts/tests/test_pr_gate_sweep_select.py
+++ b/scripts/tests/test_pr_gate_sweep_select.py
@@ -14,7 +14,9 @@ Incident fondateur du genre (#11656) : un organe accepte au merge sans avoir
 jamais cree un seul job. Le heredoc n'est pas exec-able par CI seul ; ce test
 est la seule execution hors-run du selecteur livré.
 
-Acceptance #11862 (3 cas) + regressions du comportement historique :
+Acceptance #11862 (3 cas) + #11808 (repli par (run_id, name), pas par nom --
+trois workflows emettent un job homonyme "Ratchet (base vs PR)") + regressions
+du comportement historique :
   1. gate ``cancelled`` seul -> relance (comportement NOUVEAU ; ce test echoue
      sur le RED sans ``cancelled``, c'est le test de falsification) ;
   2. gate ``cancelled`` + autre check rouge -> abstention ;
@@ -60,6 +62,12 @@ SELECTOR = _extract_selector()
 
 def _run_selector(tmp_path, rows):
     """Exec le selecteur livré sur des lignes de fixtures, capture stdout."""
+    return _run_selector_both(tmp_path, rows).stdout
+
+
+def _run_selector_both(tmp_path, rows):
+    """Comme _run_selector mais rend le process complet (stdout + stderr) --
+    les diagnostics d'exclusion (#11808) vont sur stderr."""
     fixture = tmp_path / "runs.jsonl"
     fixture.write_text(
         "".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8"
@@ -70,19 +78,28 @@ def _run_selector(tmp_path, rows):
         capture_output=True, text=True, encoding="utf-8", env=env, cwd=tmp_path,
     )
     assert out.returncode == 0, out.stderr
-    return out.stdout
+    return out
 
 
 def _pr(number, checks, sha="deadbeef", fork=False):
-    return {
-        "number": number,
-        "sha": sha,
-        "fork": fork,
-        "checks": [
-            {"name": n, "status": s, "conclusion": c, "started_at": t}
-            for (n, s, c, t) in checks
-        ],
-    }
+    """checks = tuples (name, status, conclusion, started_at[, run_id]).
+
+    Sans 5e element, la fixture ne porte pas de details_url : le selecteur
+    replie alors sous la cle sentinel ``unattributed`` (comportement des
+    donnees collectees avant #11808). Avec un run_id, la fixture porte le
+    details_url REST (.../actions/runs/{run_id}/job/...).
+    """
+    rows = []
+    for ch in checks:
+        n, s, c, t = ch[:4]
+        row = {"name": n, "status": s, "conclusion": c, "started_at": t}
+        if len(ch) > 4 and ch[4]:
+            row["details_url"] = (
+                "https://github.com/jsboige/CoursIA/actions/runs/"
+                f"{ch[4]}/job/96158568958"
+            )
+        rows.append(row)
+    return {"number": number, "sha": sha, "fork": fork, "checks": rows}
 
 
 GATE_OK = ("PR gate", "completed", "success", "2026-01-01T10:00:00Z")
@@ -161,3 +178,78 @@ def test_selector_has_cancelled_in_red_not_green(tmp_path):
     assert m and "cancelled" in m.group(0)
     m = re.search(r'GREEN = \{[^}]*\}', SELECTOR)
     assert m and "cancelled" not in m.group(0)
+
+
+# --- #11808 : le repli des check-runs par NOM fusionne des workflows homonymes ---
+
+# L'incident mesure sur #11804 (2026-08-19) : trois workflows emettent un job
+# affichant "Ratchet (base vs PR)". Replie par nom, le SUCCESS 16:21 (Exec
+# Sequence) efface le FAILURE 16:19 (Papermill) -- la sweep a relance le gate
+# d'une PR qui portait un rouge vivant.
+RATCHET_OK_1616 = ("Ratchet (base vs PR)", "completed", "success",
+                   "2026-08-19T16:16:01Z", 32274924047)
+RATCHET_FAIL_1619 = ("Ratchet (base vs PR)", "completed", "failure",
+                     "2026-08-19T16:19:45Z", 32274924272)
+RATCHET_OK_1621 = ("Ratchet (base vs PR)", "completed", "success",
+                   "2026-08-19T16:21:06Z", 32274924088)
+
+
+def test_same_name_three_workflows_red_not_erased(tmp_path):
+    """Acceptance 1 (#11808) -- le test de falsification : trois check-runs
+    homonymes de run_ids DIFFERENTS, [SUCCESS, FAILURE, SUCCESS]. Le repli par
+    nom garde le plus recent (vert) et declare la PR saine ; la PR doit au
+    contraire rester HORS candidats tant qu'un des trois est rouge. Ce test
+    echoue sur le RED d'avant le fix (la PR y etait candidate)."""
+    out = _run_selector(
+        tmp_path,
+        [_pr(109, [GATE_FAIL, RATCHET_OK_1616, RATCHET_FAIL_1619, RATCHET_OK_1621])],
+    )
+    assert out.strip() == ""
+
+
+def test_same_run_rerun_latest_wins(tmp_path):
+    """Acceptance 2 : non-regression du latest-wins INTRA-workflow -- memes
+    run_id et nom, FAILURE 16:19 puis SUCCESS 16:21 : la relance efface son
+    propre verdict perime, la PR reste candidate."""
+    fail_then_green = [
+        ("Hermes review", "completed", "failure", "2026-01-01T16:19:00Z", 111),
+        ("Hermes review", "completed", "success", "2026-01-01T16:21:00Z", 111),
+    ]
+    out = _run_selector(tmp_path, [_pr(110, [GATE_FAIL] + fail_then_green)])
+    assert out.strip() == "110 deadbeef false"
+
+
+def test_cross_workflow_green_and_red_keeps_pr_out(tmp_path):
+    """Meme nom, deux run_ids, un vert + un rouge (sans troisieme leg) : le
+    rouge d'un AUTRE workflow suffit a ecarter -- variante minimale du cas
+    #11804."""
+    out = _run_selector(
+        tmp_path, [_pr(111, [GATE_FAIL, RATCHET_FAIL_1619, RATCHET_OK_1621])]
+    )
+    assert out.strip() == ""
+
+
+def test_excluded_pr_names_its_blocking_check(tmp_path):
+    """Acceptance 5 : la sortie NOMME, pour chaque PR ecartee, quel check
+    l'ecarte (et son run) -- sur stderr, pour ne pas polluer candidates.txt.
+    Un compte seul serait indiscernable d'un filtre debranche (#11804)."""
+    proc = _run_selector_both(
+        tmp_path,
+        [_pr(109, [GATE_FAIL, RATCHET_FAIL_1619, RATCHET_OK_1621])],
+    )
+    assert proc.stdout.strip() == ""
+    assert "#109" in proc.stderr
+    assert "Ratchet (base vs PR)" in proc.stderr
+    assert "failure" in proc.stderr
+    assert "32274924272" in proc.stderr
+
+
+def test_excluded_incomplete_pr_names_its_blocking_check(tmp_path):
+    """Meme acceptance 5, cas d'un check inacheve (le gate attend peut-etre
+    legitiment) -- nomme aussi, verdict 'unfinished'."""
+    queued = ("Ratchet (base vs PR)", "queued", None,
+              "2026-08-19T16:21:06Z", 32274924088)
+    proc = _run_selector_both(tmp_path, [_pr(112, [GATE_FAIL, queued])])
+    assert proc.stdout.strip() == ""
+    assert "#112" in proc.stderr
+    assert "unfinished" in proc.stderr


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA
Quoi:       Le stale-sweep replie les check-runs par (run_id, name) au lieu du nom seul + nomme le check qui ecarte chaque PR exclue
Preuve:     pytest 14/14 (falsifieur #11808 ECHOUE sur le RED verifie par stash : '109 deadbeef false' == '') + replay pool live 22 PRs (0 candidat, diagnostics nommant les blockers)
Perimetre:  .github/workflows/pr-gate-stale-sweep.yml + scripts/tests/test_pr_gate_sweep_select.py ; hors scope : renommage des jobs homonymes (refuse par l'issue)

## Summary

Trois workflows (`Notebook Papermill Ratchet`, `Notebook Exec Sequence Ratchet`,
`Notebook Output Failure Ratchet`) emettent chacun un job affichant le meme nom
`Ratchet (base vs PR)`. Le selecteur du stale-sweep repliait les check-runs par
**nom** (latest-wins) : le verdict le plus recent d'un workflow **effaçait**
celui des deux autres. Mesure sur #11804 (issue) : FAILURE Papermill 16:19
couvert par SUCCESS Exec Sequence 16:21 → la sweep a relancé le gate d'une PR
portant un rouge vivant, et a loggé une absence de rouge là où il y en avait un.

## Le fix

1. **Cle de pliage = (run_id, name)**, jamais le nom seul. Le run_id se lit
   dans `details_url` (`.../actions/runs/{run_id}/job/{job_id}`) — ajoute a la
   projection jq de la collecte, zero appel API supplementaire. `gh run rerun`
   reecrit le check-run **en place** : memes (run_id, name) → latest-wins
   preserve (le pliage intra-workflow reste celui d'origine) ; seule la fusion
   **inter**-workflows disparait. Check-runs sans details_url (CodeQL default
   setup, verdicts postes) → sentinel `unattributed` : repli par nom comme
   avant, jamais un vert par defaut.
2. **Diagnostics nommes** (acceptance 5) : chaque PR a gate rouge ecartee
   imprime sur stderr `#N: red gate, kept out -- red: <check>[run <id>]=<verdict>`
   (ou `unfinished`). Un compte seul etait indiscernable d'un filtre debranche.

## Acceptance (5/5)

1. **Falsifieur echoue avant le fix** — `test_same_name_three_workflows_red_not_erased` :
   3 homonymes run_ids distincts `[SUCCESS 16:16, FAILURE 16:19, SUCCESS 16:21]`
   (run ids reels de l'incident) → PR ecartee. Prouve par stash du workflow :
   sur le RED, `'109 deadbeef false' == ''` (la PR etait candidate).
2. **Latest-wins intra-workflow preserve** — `test_same_run_rerun_latest_wins` :
   meme run_id, FAILURE puis SUCCESS → vert, candidate.
3. **AND sur PR gate inchangé** — `test_two_gate_legs_and_not_latest_wins`
   (regression #11532 existante) : les legs de gate ne sont JAMAIS pliees.
4. **Controle negatif pool live** — replay du selecteur livré sur les 22 PRs
   ouvertes (memes appels REST que la sweep, `details_url` inclus) :
   **0 candidat**, 6+ PRs ecartees avec nom du check fautif (ex. #11920 :
   `Scripts Tests (CPU)=failure, Twin parity audit (#8057)=failure`). Les deux
   selecteurs (ancien/nouveau) accordent sur le pool actuel — aucune PR n'y
   exhibe le pattern ; la discrimination #11804 vit dans le fixture aux
   timestamps/run-ids de l'incident.
5. **Sortie nominative** — `test_excluded_pr_names_its_blocking_check` (+ variante
   unfinished) : stderr nomme `#PR`, le check, le run, le verdict.

Suite complete : **14/14 pass** (8 existantes intactes — les fixtures sans
`details_url` replient sous `unattributed`, comportement d'origine preserve).

Closes #11808

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>