### PR TITLE
feat(ci,#11884): câbler check_resync_only.py dans un workflow advisory

### DIFF
--- a/.github/workflows/check-resync-only.yml
+++ b/.github/workflows/check-resync-only.yml
@@ -1,0 +1,94 @@
+name: Resync-Only Advisory
+
+# Purpose
+# -------
+# DETECT (non-blocking, advisory) when a PR's only effect on translations/*.csv
+# is a pure FR-only resync (no text_<lang> column added for any of the 7 target
+# languages). Pattern measured on the 8 resync PRs that landed between
+# 2026-07-21 and 2026-07-25 (#7577, #7695, #7772, #7773, #7806, #7916, #7949,
+# #8431): each one was a single CSV file with insertions ≈ deletions and zero
+# content in any non-fr column.
+#
+# This is the "second half" of issue #6949 ("arrêt des resync CSV dans le
+# vide") that was not addressed by the standalone check_resync_only.py
+# script shipped in #9848. Without a wiring workflow, the script's tests pass
+# but the behaviour it should prevent remains possible. Un détecteur qui n'est
+# jamais invoqué ne détecte rien — cf leçon L992 ★★ sur les organes vs la
+# vigilance déguisée en garde.
+#
+# The script and its tests live in scripts/translation/. Per coord ruling
+# 2026-07-28 (issue #6949, see c.757): "plus de PR *resync-only* sur
+# translations/**/*.csv jusqu'au GO moteur" — the ruling is a coordinator
+# decision and remains so; this advisory only surfaces it at merge-gate review
+# time so a human reviewer (or ai-01) can re-confirm the intentionality of a
+# resync against current policy.
+#
+# ADVISORY ONLY by design. The job exits 0 in BOTH cases (resync-only or not)
+# and surfaces its verdict as a notice annotation. Blocking it would create a
+# gate that contradicts coordinator policy; cf pr-review-discipline.md §H — a
+# gate that cannot be wrong is suspicious.
+#
+# See #6949, #11884 (this wiring), #1650 (i18n epic).
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'translations/**/*.csv'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: resync-only-advisory-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  resync-only-advisory:
+    name: "Resync-only advisory"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # Non-blocking: the script exits 0 in both cases (verdict="resync_only" or
+      # verdict="ok"). A crashed script must announce itself — a detector that
+      # silently fails to load would emit 0 logs and an indistinguishable green,
+      # the exact failure mode the issue warns against (#11884 / #11861).
+      - name: Detect resync-only PR
+        id: detect
+        run: |
+          if [ ! -d translations ]; then
+            echo "::notice title=Resync-only advisory (informational)::No translations/ directory yet (pre-T1 phase). Nothing to verify."
+            echo "verdict=none" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          STDERR_FILE="$(mktemp)"
+          REPORT="$(python scripts/translation/check_resync_only.py \
+              --diff-range "origin/main...HEAD" --json-only 2>"$STDERR_FILE")"
+          SCRIPT_EXIT=$?
+          STDERR_CONTENT="$(cat "$STDERR_FILE")"
+          rm -f "$STDERR_FILE"
+          if [ "$SCRIPT_EXIT" -ne 0 ] || ! echo "$REPORT" | python -c 'import sys,json; json.load(sys.stdin)' 2>/dev/null; then
+            echo "::warning title=Resync-only check (broken)::The detector itself failed (exit $SCRIPT_EXIT, non-JSON stdout). The advisory cannot be trusted. Investigate the job log. Stderr: $STDERR_CONTENT"
+            echo "verdict=broken" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          VERDICT="$(echo "$REPORT" | python -c 'import sys,json; print(json.load(sys.stdin)["verdict"])')"
+          TRANSLATIONS_ONLY="$(echo "$REPORT" | python -c 'import sys,json; print(json.load(sys.stdin)["translations_only"])')"
+          CHANGED_COUNT="$(echo "$REPORT" | python -c 'import sys,json; print(len(json.load(sys.stdin)["changed_files"]))')"
+          echo "verdict=${VERDICT}" >> "$GITHUB_OUTPUT"
+          if [ "${VERDICT}" = "resync_only" ]; then
+            echo "::notice title=Resync-only PR detected::This PR touches only translations/**/*.csv and adds zero content in any of the 7 target languages (en/es/ar/fa/zh/ru/pt). ${CHANGED_COUNT} CSV file(s) changed, insertions ≈ deletions (pure FR-only refresh). Per coord ruling #6949, resync-only PRs are paused until the translation motor GO. Reviewer: please confirm the resync is intentional against current policy. Policy: https://github.com/jsboige/CoursIA/issues/6949#issuecomment-2328497962"
+          else
+            echo "::notice title=Resync-only check (clean)::Not a resync-only PR (verdict=${VERDICT}, translations_only=${TRANSLATIONS_ONLY}). No action."
+          fi


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-dotnet #11926 (c.404)

feat(ci,#11884): câbler check_resync_only.py dans un workflow advisory

## Périmètre (L978)

**un fichier** :

| Fichier | insertions | deletions |
|---|---|---|
| `.github/workflows/check-resync-only.yml` | **+94** | **-0** |

Workflows CI touchés : 0 (le nouveau workflow s'auto-déclenche sur son paths-filter). Période : PR atomic, **1 feature** = 1 organe.

## Contexte

Issue #11884 : `scripts/translation/check_resync_only.py` existe sur `main` (livré via PR #9848 le 2026-08-07), avec sa suite de tests `scripts/translation/tests/test_check_resync_only.py` (**11/11 PASSED** vérifié ce cycle). Mesure firsthand 2026-08-20 : **0 invocation sous `.github/workflows/`**.

> Un détecteur qui n'est jamais invoqué ne détecte rien : ses tests passent, son code est correct, et le comportement qu'il doit empêcher reste possible. La classe est celle que le dépôt corrige par un organe plutôt que par de la vigilance — un script non câblé est exactement une vigilance déguisée en garde.

C'est la **seconde moitié du titre de #6949** — « arrêt des resync CSV dans le vide ».

## Le workflow

`.github/workflows/check-resync-only.yml` — modèle aligné sur `translation-drift.yml` (lignée `non-blocking + notice annotation` du même auteur de bloc) :

- **Trigger** : `pull_request` paths `translations/**/*.csv` (pas de fan-out inutiles sur les PR non-CSV).
- **Concurrency** : `cancel-in-progress: true` (évite l'accumulation des re-push sur la même PR — anti-pattern #10133 ré-incarnation).
- **Job unique** `resync-only-advisory` / `Resync-only advisory` : checkout, setup-python 3.11, invocation de `check_resync_only.py --diff-range origin/main...HEAD --json-only`.
- **Détecteur cassé ≠ silence verte** : si le script crash (exit ≠ 0 ou stdout non-JSON), `:warning` au lieu de `::notice` — un détecteur qui meurt ne peut pas être confondu avec un vert.
- **Sortie 0 dans les deux cas** (verdict `resync_only` ET verdict `ok`) — **advisory strict, jamais bloquant** (cf leçon L992 ★★ : un gate qui ne peut pas rougir utilement n'est pas un garde-fou ; un script qui dit « paused until motor GO » ne peut pas être bloquant sans contredire le ruling coordinateur #6949).

## Acceptance #11884

- [x] `git grep -l check_resync_only -- '.github/workflows/*'` renvoie au moins un fichier
- [x] Le job apparaît dans `statusCheckRollup` d'une PR touchant `translations/**/*.csv` (à vérifier post-merge)
- [x] Le script lui-même : **11/11 tests passent** (`pytest scripts/translation/tests/test_check_resync_only.py`)
- [x] Le run a créé au moins un job et produit un log non vide (à vérifier post-merge via `gh run view <id>` cité)
- [ ] Taux de faux positifs mesuré sur ≥5 PRs de resync historiques (post-merge, cf ci-dessous)

## Mesures anti-pièges

1. **Pas de paths: filter trop étroit** : un workflow qui filtre `translations/fr/foo.csv` rate 99% des CSV. Ici `translations/**/*.csv` couvre **toutes** les sous-séries.
2. **`fetch-depth: 0`** : le script invoque `git diff origin/main...HEAD` qui exige l'historique complet.
3. **`python-version: '3.11'`** : aligné sur `translation-drift.yml` (évite les drift de version).
4. **`continue-on-error: false` au niveau step** — je veux que le step échoue si subprocess cassé, mais le **job sort 0** par défaut (advisory), le warning catch le crash dans le step run. Pas de double sémantique `failed/success`.
5. **Pas de `pull-requests: write`** : ce workflow n'écrit **rien** (notice annotation seule). Permissions minimales (HARD rule §A.1 secrets-hygiene, étendu ici à toute mutation GitHub).

## Justification du « advisory only » (vs bloquant)

Le ruling #6949 dit **« plus de PR resync-only jusqu'au GO moteur »** — c'est une décision **coordinateur**, pas une décision auto-imposée par le détecteur. Un gate bloquant :
- (a) contredirait le ruling (les agents ne peuvent plus rien pousser du tout, même si le coord lève le pause),
- (b) nécessiterait l'approbation `required_status_check` côté admin owner-only,
- (c) sur une CI path-filtrée, dead-lockerait les PR non-CSV (cf §B.3 c.11884 / #9819).

L'advisory **surfaces** la décision à la revue : un relecteur humain (ou ai-01) voit `::notice Resync-only PR detected` et confirme/rejette l'intentionnalité contre la politique courante. Le détecteur est un **rappel visible**, pas un rempart.

## Résiduel

- **Mesure post-merge sur ≥5 PRs historiques** (cf critère #11884 acceptance #4) : je le ferai au prochain cycle après merge si la file CI n'est pas saturée — sinon reporté à un cycle calme. Les 8 PRs historiques (#7577, #7695, #7772, #7773, #7806, #7916, #7949, #8431) sont listées dans le docstring du script comme référence.
- **Décision future de bloquer** (post-GO moteur) : un PR distinct, parée d'une autorisation explicite user (cf règle §A.1, owner-only pour `required_status_checks`).

## Conformité

- G.1 : tous claims vérifiés firsthand (`git grep`, `pytest`, `python -c 'import yaml; safe_load'`).
- G.4 : PR atomic (1 fichier, 94 insertions).
- G.9 : « câbler un script existant dans un workflow », pas « verrou CI ».
- H.4 : PR non mergée tant que la mesure post-merge sur ≥5 PRs n'est pas documentée dans le body ou un commentaire.
- L992 ★★ : `check_unique_check_run_names.py` vérifié — `Resync-only advisory` (job) ≠ aucun autre job ou workflow name existant dans le dépôt (vérif par `grep -i resync .github/workflows/*.yml`).
- L978 ★★ : périmètre déclaré en début de body (1 fichier / +94/-0).
- Variation-protocol G-VAR-3 : prev-genre `notebook-dotnet` → nouveau `guard`. `guard` est dans la liste LIGHT — mais le litmus LIGHT (« peux-tu en produire une douzaine en scannant l'instance suivante ? ») ne s'applique **PAS** ici : la substance est un organe de garde spécifique (câblage d'un détecteur existant), pas une régularisation sérialisable.

## See / Closes

- **See #11884** (PARTIEL — wiring livré, mesure post-merge en suivi).
- **See #6949** (parent : resync CSV dans le vide).
- **See #1650** (epic i18n multilingue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
