### PR TITLE
fix(search,#1203): MGS-1 re-exec post-rebase + prose sweep robustifiee (ordre non significatif a 5 runs)

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-1-Introduction.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-1-Introduction.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "nav-header",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.016096,
+     "end_time": "2026-08-20T12:10:29.501230+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:29.485134+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# MGS-1 : Introduction a MetaGeneticSharp et au moteur autonome\n",
     "\n",
@@ -20,7 +29,7 @@
     "### Prerequis\n",
     "- Notions de base en algorithmes génétiques (sélection, crossover, mutation)\n",
     "- C# .NET 9.0 et .NET Interactive\n",
-    "- GeneticSharp 3.1.4 (charge depuis les DLL du submodule)\n",
+    "- GeneticSharp 3.1.4-9 (upstream master `4406ad7`, charge depuis les DLL du submodule)\n",
     "\n",
     "### Duree estimee : 45 minutes"
    ]
@@ -28,7 +37,16 @@
   {
    "cell_type": "markdown",
    "id": "section-1-why",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007387,
+     "end_time": "2026-08-20T12:10:29.516978+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:29.509591+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Pourquoi MetaGeneticSharp ?\n",
     "\n",
@@ -50,7 +68,7 @@
     "|  MetaPopulation (pas de tri implicite)       |\n",
     "|  FitnessBasedElitistReinsertion              |\n",
     "+----------------------------------------------+\n",
-    "|  GeneticSharp 3.1.4 (amont, non modifie)     |\n",
+    "|  GeneticSharp 3.1.4-9 (amont, non modifie)   |\n",
     "|  Chromosomes, Crossover, Mutation, Sélection |\n",
     "+----------------------------------------------+\n",
     "```\n",
@@ -70,16 +88,139 @@
    "id": "wiring-cell",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:37.033238Z",
-     "iopub.status.busy": "2026-07-13T00:29:37.026414Z",
-     "iopub.status.idle": "2026-07-13T00:29:38.870345Z",
-     "shell.execute_reply": "2026-07-13T00:29:38.863530Z"
+     "iopub.execute_input": "2026-08-20T12:10:29.547835Z",
+     "iopub.status.busy": "2026-08-20T12:10:29.542255Z",
+     "iopub.status.idle": "2026-08-20T12:10:31.795668Z",
+     "shell.execute_reply": "2026-08-20T12:10:31.789408Z"
     },
+    "papermill": {
+     "duration": 2.266487,
+     "end_time": "2026-08-20T12:10:31.795807+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:29.529320+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '49044.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -138,7 +279,16 @@
   {
    "cell_type": "markdown",
    "id": "section-2-architecture",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004347,
+     "end_time": "2026-08-20T12:10:31.804617+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:31.800270+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 2. Architecture du moteur autonome\n",
     "\n",
@@ -183,7 +333,16 @@
   {
    "cell_type": "markdown",
    "id": "section-3-setup-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.003429,
+     "end_time": "2026-08-20T12:10:31.811737+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:31.808308+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Premier exemple : minimisation de Rastrigin (paysage multimodal)\n",
     "\n",
@@ -204,11 +363,19 @@
    "id": "quadratic-setup",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:38.873161Z",
-     "iopub.status.busy": "2026-07-13T00:29:38.872892Z",
-     "iopub.status.idle": "2026-07-13T00:29:39.158728Z",
-     "shell.execute_reply": "2026-07-13T00:29:39.158418Z"
+     "iopub.execute_input": "2026-08-20T12:10:31.823151Z",
+     "iopub.status.busy": "2026-08-20T12:10:31.822822Z",
+     "iopub.status.idle": "2026-08-20T12:10:32.439463Z",
+     "shell.execute_reply": "2026-08-20T12:10:32.438854Z"
     },
+    "papermill": {
+     "duration": 0.62395,
+     "end_time": "2026-08-20T12:10:32.439719+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:31.815769+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -251,11 +418,19 @@
    "id": "quadratic-run",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:39.160321Z",
-     "iopub.status.busy": "2026-07-13T00:29:39.160099Z",
-     "iopub.status.idle": "2026-07-13T00:29:39.714754Z",
-     "shell.execute_reply": "2026-07-13T00:29:39.714104Z"
+     "iopub.execute_input": "2026-08-20T12:10:32.449502Z",
+     "iopub.status.busy": "2026-08-20T12:10:32.449131Z",
+     "iopub.status.idle": "2026-08-20T12:10:33.656013Z",
+     "shell.execute_reply": "2026-08-20T12:10:33.654745Z"
     },
+    "papermill": {
+     "duration": 1.212636,
+     "end_time": "2026-08-20T12:10:33.656234+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:32.443598+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -272,21 +447,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Meilleur chromosome : [2,0000, -2,0000, -3,0000, -1,0000]\r\n"
+      "  Meilleur chromosome : [-4,0000, 3,0000, 0,0000, 0,0000]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Fitness (inverted)  : 0,052632\r\n"
+      "  Fitness (inverted)  : 0,038462\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Objectif Rastrigin f(x) : 18,000000\r\n"
+      "  Objectif Rastrigin f(x) : 25,000000\r\n"
      ]
     },
     {
@@ -300,7 +475,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Temps total          : 836 ms\r\n"
+      "  Temps total          : 246 ms\r\n"
      ]
     }
    ],
@@ -357,17 +532,26 @@
   {
    "cell_type": "markdown",
    "id": "interp-quadratic",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.013233,
+     "end_time": "2026-08-20T12:10:33.681544+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:33.668311+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Premier run avec DefaultMetaHeuristic\n",
     "\n",
-    "**Sortie obtenue** : L'algorithme converge vers un optimum **local** -- un vecteur a coordonnees entieres (p. ex. $[2, -2, -3, -1]$), bien eloigne de l'optimum global $[0,0,0,0]$. C'est la signature d'un paysage multimodal : le GA s'est arrete dans un piege local.\n",
+    "**Sortie obtenue** : L'algorithme converge vers un optimum **local** -- un vecteur a coordonnees entieres (p. ex. $[-4, 3, 0, 0]$), eloigne de l'optimum global $[0,0,0,0]$. C'est la signature d'un paysage multimodal : le GA s'est arrete dans un piege local (run non seede : le piege exact varie d'une execution a l'autre).\n",
     "\n",
     "| Aspect | Valeur | Signification |\n",
     "|--------|--------|---------------|\n",
-    "| Meilleur chromosome | Vecteur entier (p. ex. $[2, -2, -3, -1]$) | Optimum local (piege) |\n",
-    "| Fitness | $1/(1+f)$ modere (p. ex. $\\approx 0{,}05$) | Fitness bas : le GA n'a pas atteint l'optimum global |\n",
-    "| Objectif f(x) | Valeur non nulle (p. ex. $\\approx 18$) | Eloigne du minimum global 0 |\n",
+    "| Meilleur chromosome | Vecteur entier (p. ex. $[-4, 3, 0, 0]$) | Optimum local (piege) |\n",
+    "| Fitness | $1/(1+f)$ modere (p. ex. $\\approx 0{,}04$) | Fitness bas : le GA n'a pas atteint l'optimum global |\n",
+    "| Objectif f(x) | Valeur non nulle (p. ex. $\\approx 25$) | Eloigne du minimum global 0 |\n",
     "| Generations | 50 | Terminaison atteinte |\n",
     "\n",
     "**Points cles** :\n",
@@ -380,7 +564,16 @@
   {
    "cell_type": "markdown",
    "id": "section-4-comparison-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010225,
+     "end_time": "2026-08-20T12:10:33.704469+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:33.694244+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 4. Impact des probabilites de crossover\n",
     "\n",
@@ -395,11 +588,19 @@
    "id": "crossover-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:39.716599Z",
-     "iopub.status.busy": "2026-07-13T00:29:39.716368Z",
-     "iopub.status.idle": "2026-07-13T00:29:41.852212Z",
-     "shell.execute_reply": "2026-07-13T00:29:41.851646Z"
+     "iopub.execute_input": "2026-08-20T12:10:33.720574Z",
+     "iopub.status.busy": "2026-08-20T12:10:33.720122Z",
+     "iopub.status.idle": "2026-08-20T12:10:37.285566Z",
+     "shell.execute_reply": "2026-08-20T12:10:37.285094Z"
     },
+    "papermill": {
+     "duration": 3.57331,
+     "end_time": "2026-08-20T12:10:37.285867+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:33.712557+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -437,21 +638,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0,3      19,000000    9,000000     28,000000    6,693280    \r\n"
+      "0,3      24,800000    14,000000    42,000000    11,478676   \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0,75     35,800000    21,000000    49,000000    9,537295    \r\n"
+      "0,75     19,600000    6,000000     34,000000    11,288933   \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0,95     22,800000    6,000000     30,000000    8,565045    \r\n"
+      "0,95     14,600000    7,000000     29,000000    7,657676    \r\n"
      ]
     },
     {
@@ -529,29 +730,47 @@
   {
    "cell_type": "markdown",
    "id": "interp-comparison",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007176,
+     "end_time": "2026-08-20T12:10:37.304601+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:37.297425+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Impact de la probabilite de crossover\n",
     "\n",
-    "**Sortie obtenue** : Les trois configurations donnent des résultats **nettement différents** -- sur Rastrigin, la probabilite de crossover discrimine (contrairement a la Sphere ou tout convergeait vers 0).\n",
+    "**Sortie obtenue** : Les trois configurations donnent des moyennes du meme ordre avec un ecart-type eleve -- sur Rastrigin, 5 runs ne suffisent pas a separer les probabilites de crossover (contrairement a la Sphere ou tout convergeait vers 0).\n",
     "\n",
-    "| Probabilite pc | Moyenne f(x) | Explication |\n",
-    "|----------------|---------------------|-------------|\n",
-    "| 0.3 (faible) | Moyenne $\\approx 19$ | Peu de recombinaison : preserve les bons blocs trouves |\n",
-    "| 0.75 (defaut) | Moyenne $\\approx 36$ (pire) | Sur ce paysage rugged, trop de crossover casse les blocs de construction |\n",
-    "| 0.95 (elevee) | Moyenne $\\approx 23$ | Recombinaison forte, résultats bruyants (fort ecart-type) |\n",
+    "| Probabilite pc | Moyenne f(x) | Ecart-type |\n",
+    "|----------------|--------------|------------|\n",
+    "| 0.3 (faible) | $\\approx 25$ | $\\approx 11$ |\n",
+    "| 0.75 (defaut) | $\\approx 20$ | $\\approx 11$ |\n",
+    "| 0.95 (elevee) | $\\approx 15$ | $\\approx 8$ |\n",
     "\n",
     "**Points cles** :\n",
-    "1. Contrairement a la Sphere (ou tout convergeait vers 0), Rastrigin rend $p_c$ **discriminant** : les moyennes différent et l'ecart-type est eleve (6 a 10)\n",
-    "2. L'ecart-type mesure la **sensibilite a l'alea** : sur un paysage multimodal, l'initialisation determine dans quel bassin d'optimum local la population tombe -- d'ou la forte variance\n",
-    "3. Le résultat contre-intuitif ($p_c=0{,}75$ ici pire que $0{,}3$) est reel : sur un paysage rugged, trop de crossover decompose les bonnes solutions. C'est toute la lecon -- le choix de $p_c$ n'est pas trivial\n",
+    "1. **L'ordre des moyennes n'est pas significatif** : avec 5 runs et $\\sigma \\approx 8$ a $11$, l'erreur standard $\\sigma/\\sqrt{5} \\approx 4$ a $5$ est du meme ordre que les ecarts entre moyennes ($\\approx 5$). L'ordre observe ($0{,}95 < 0{,}75 < 0{,}3$ ici) peut s'inverser d'une execution a l'autre -- ne pas conclure sur un classement sans plus de runs (c'est la meme discipline que le multi-seed des experiences ML du depot)\n",
+    "2. Le resultat **robuste** est la variance elle-meme : sur un paysage multimodal, l'initialisation determine dans quel bassin d'optimum local la population tombe -- d'ou $\\sigma$ eleve pour chaque $p_c$\n",
+    "3. Comparer honnetement des $p_c$ sur Rastrigin exigerait plus de runs (ou un seed fixe pour la reproductibilite) -- le notebook assume l'alea et l'enseigne plutot que de le cacher\n",
     "4. `DefaultMetaHeuristic` teste la probabilite pour chaque paire adjacente de parents (appariement séquentiel)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "section-5-generations-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.028621,
+     "end_time": "2026-08-20T12:10:37.361669+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:37.333048+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. Suivi de la convergence par generation\n",
     "\n",
@@ -564,11 +783,19 @@
    "id": "convergence-trace",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:41.854005Z",
-     "iopub.status.busy": "2026-07-13T00:29:41.853769Z",
-     "iopub.status.idle": "2026-07-13T00:29:42.060311Z",
-     "shell.execute_reply": "2026-07-13T00:29:42.059900Z"
+     "iopub.execute_input": "2026-08-20T12:10:37.410944Z",
+     "iopub.status.busy": "2026-08-20T12:10:37.407148Z",
+     "iopub.status.idle": "2026-08-20T12:10:38.470247Z",
+     "shell.execute_reply": "2026-08-20T12:10:38.470036Z"
     },
+    "papermill": {
+     "duration": 1.088238,
+     "end_time": "2026-08-20T12:10:38.470355+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:37.382117+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -606,56 +833,56 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1        29,000000           \r\n"
+      "1        24,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5        29,000000           \r\n"
+      "5        24,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "10       29,000000           \r\n"
+      "10       24,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "15       29,000000           \r\n"
+      "15       24,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "20       29,000000           \r\n"
+      "20       24,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "25       29,000000           \r\n"
+      "25       24,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "30       29,000000           \r\n"
+      "30       24,000000           \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "30       29,000000           \r\n"
+      "30       24,000000           \r\n"
      ]
     },
     {
@@ -669,7 +896,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Convergence finale : f(x) = 29,000000\r\n"
+      "Convergence finale : f(x) = 24,000000\r\n"
      ]
     },
     {
@@ -728,7 +955,16 @@
   {
    "cell_type": "markdown",
    "id": "interp-convergence",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.004614,
+     "end_time": "2026-08-20T12:10:38.481296+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:38.476682+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Trace de convergence\n",
     "\n",
@@ -750,7 +986,16 @@
   {
    "cell_type": "markdown",
    "id": "section-6-noop-intro",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008446,
+     "end_time": "2026-08-20T12:10:38.495610+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:38.487164+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 6. Comparaison avec NoOpMetaHeuristic\n",
     "\n",
@@ -765,11 +1010,19 @@
    "id": "noop-comparison",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:42.061697Z",
-     "iopub.status.busy": "2026-07-13T00:29:42.061505Z",
-     "iopub.status.idle": "2026-07-13T00:29:42.174013Z",
-     "shell.execute_reply": "2026-07-13T00:29:42.173650Z"
+     "iopub.execute_input": "2026-08-20T12:10:38.513758Z",
+     "iopub.status.busy": "2026-08-20T12:10:38.513235Z",
+     "iopub.status.idle": "2026-08-20T12:10:39.031127Z",
+     "shell.execute_reply": "2026-08-20T12:10:39.030527Z"
     },
+    "papermill": {
+     "duration": 0.527865,
+     "end_time": "2026-08-20T12:10:39.031426+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:38.503561+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -807,14 +1060,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DefaultMetaHeuristic      15,000000       0,062500        [-3,0000, -1,0000, ...]\r\n"
+      "DefaultMetaHeuristic      12,000000       0,076923        [-1,0000, -3,0000, ...]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "NoOpMetaHeuristic         9,000000        0,100000        [-2,0000, 2,0000, ...]\r\n"
+      "NoOpMetaHeuristic         26,000000       0,037037        [-1,0000, 4,0000, ...]\r\n"
      ]
     },
     {
@@ -875,7 +1128,16 @@
   {
    "cell_type": "markdown",
    "id": "interp-noop",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.01665,
+     "end_time": "2026-08-20T12:10:39.089966+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.073316+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Default vs NoOp\n",
     "\n",
@@ -896,7 +1158,16 @@
   {
    "cell_type": "markdown",
    "id": "section-7-summary",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005215,
+     "end_time": "2026-08-20T12:10:39.104807+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.099592+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 7. Resume\n",
     "\n",
@@ -921,7 +1192,16 @@
   {
    "cell_type": "markdown",
    "id": "exercise-1-header",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.01037,
+     "end_time": "2026-08-20T12:10:39.121688+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.111318+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -944,11 +1224,19 @@
    "id": "exercise-1-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:42.175583Z",
-     "iopub.status.busy": "2026-07-13T00:29:42.175377Z",
-     "iopub.status.idle": "2026-07-13T00:29:42.211401Z",
-     "shell.execute_reply": "2026-07-13T00:29:42.211148Z"
+     "iopub.execute_input": "2026-08-20T12:10:39.195478Z",
+     "iopub.status.busy": "2026-08-20T12:10:39.190442Z",
+     "iopub.status.idle": "2026-08-20T12:10:39.410237Z",
+     "shell.execute_reply": "2026-08-20T12:10:39.409439Z"
     },
+    "papermill": {
+     "duration": 0.248588,
+     "end_time": "2026-08-20T12:10:39.410675+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.162087+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -992,7 +1280,16 @@
   {
    "cell_type": "markdown",
    "id": "exercise-2-header",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.03963,
+     "end_time": "2026-08-20T12:10:39.488921+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.449291+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 2 : Comparer DefaultMetaHeuristic et NoOpMetaHeuristic avec plus de generations\n",
     "\n",
@@ -1012,11 +1309,19 @@
    "id": "exercise-2-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:42.212829Z",
-     "iopub.status.busy": "2026-07-13T00:29:42.212624Z",
-     "iopub.status.idle": "2026-07-13T00:29:42.273378Z",
-     "shell.execute_reply": "2026-07-13T00:29:42.273049Z"
+     "iopub.execute_input": "2026-08-20T12:10:39.574689Z",
+     "iopub.status.busy": "2026-08-20T12:10:39.570242Z",
+     "iopub.status.idle": "2026-08-20T12:10:39.803772Z",
+     "shell.execute_reply": "2026-08-20T12:10:39.803536Z"
     },
+    "papermill": {
+     "duration": 0.275373,
+     "end_time": "2026-08-20T12:10:39.803902+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.528529+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -1042,7 +1347,16 @@
   {
    "cell_type": "markdown",
    "id": "exercise-3-header",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006029,
+     "end_time": "2026-08-20T12:10:39.817884+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.811855+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 3 : Implementer un IMetaHeuristic personnalise\n",
     "\n",
@@ -1064,11 +1378,19 @@
    "id": "exercise-3-code",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:29:42.274669Z",
-     "iopub.status.busy": "2026-07-13T00:29:42.274484Z",
-     "iopub.status.idle": "2026-07-13T00:29:42.305647Z",
-     "shell.execute_reply": "2026-07-13T00:29:42.305298Z"
+     "iopub.execute_input": "2026-08-20T12:10:39.840150Z",
+     "iopub.status.busy": "2026-08-20T12:10:39.839368Z",
+     "iopub.status.idle": "2026-08-20T12:10:39.938273Z",
+     "shell.execute_reply": "2026-08-20T12:10:39.937942Z"
     },
+    "papermill": {
+     "duration": 0.110743,
+     "end_time": "2026-08-20T12:10:39.938447+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.827704+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -1111,7 +1433,16 @@
   {
    "cell_type": "markdown",
    "id": "nav-footer",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.00517,
+     "end_time": "2026-08-20T12:10:39.952231+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:10:39.947061+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -1120,6 +1451,20 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 6,
+   "external_account": null,
+   "free_alternative": null,
+   "gpu_required": false,
+   "metadata_written": null,
+   "network": false,
+   "notes": "Local execution via MetaGeneticSharp (.NET C# genetic-algorithm library). Deterministic given fixed random seed, population and generation count. Requires .NET Interactive kernel + MetaGeneticSharp package. The genetic operators (selection/crossover/mutation) are deterministic algorithms; GA convergence to a fixed seed is reproducible.",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
@@ -1132,19 +1477,17 @@
    "pygments_lexer": "csharp",
    "version": "13.0"
   },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 6,
-   "gpu_required": false,
-   "network": false,
-   "external_account": null,
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": null,
-   "validator": "manual",
-   "notes": "Local execution via MetaGeneticSharp (.NET C# genetic-algorithm library). Deterministic given fixed random seed, population and generation count. Requires .NET Interactive kernel + MetaGeneticSharp package. The genetic operators (selection/crossover/mutation) are deterministic algorithms; GA convergence to a fixed seed is reproducible."
+  "papermill": {
+   "default_parameters": {},
+   "duration": 12.589948,
+   "end_time": "2026-08-20T12:10:40.221217+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "d:\\dev\\CoursIA-1203-mgs1\\MyIA.AI.Notebooks\\Search\\Part4-Metaheuristics\\MGS-1-Introduction.ipynb",
+   "output_path": "d:\\dev\\CoursIA-1203-mgs1\\MyIA.AI.Notebooks\\Search\\Part4-Metaheuristics\\MGS-1-Introduction.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-20T12:10:27.631269+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/README.md
@@ -26,7 +26,7 @@ L'enseignement transversal rejoint celui des Parties 1-2 : aucune métaheuristiq
 | Bibliothèque | Langage | Représentation | Philosophie | Lien |
 |--------------|---------|----------------|-------------|------|
 | **MetaGeneticSharp** | C# .NET 9 | Agnostique (gènes = interfaces GeneticSharp) | **Composants > métaphores** : algorithmes reconstruits depuis des primitives composables | [jsboige/MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) |
-| GeneticSharp | C# .NET | Agnostique (bit, permutation, arbre, float) | Bibliothèque GA classique, opérateurs en interfaces | [giacomelli/GeneticSharp](https://github.com/giacomelli/GeneticSharp) (sous-module, v3.1.4, non patché) |
+| GeneticSharp | C# .NET | Agnostique (bit, permutation, arbre, float) | Bibliothèque GA classique, opérateurs en interfaces | [giacomelli/GeneticSharp](https://github.com/giacomelli/GeneticSharp) (sous-module, v3.1.4-9 / upstream master 4406ad7, non patché) |
 | mealpy | Python | Vecteurs (continus surtout) | Catalogue large, tronc commun vectoriel, très compact | [thieu1995/mealpy](https://github.com/thieu1995/mealpy) |
 | HeuristicLab | C# .NET | Plugin-based, GUI lourde | Plateforme d'expérimentation, optimisation interactive | [heal-research/HeuristicLab](https://github.com/heal-research/HeuristicLab) |
 


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet #11939 (substance distincte : re-exec validation post-rebase + honnetete statistique vs annexe SAT nouvelle)

Première tranche de validation post-rebase de la série MGS. See #1203 (contribution partielle — l'EPIC reste ouverte).

## Contexte : le rebase #10859 n'a jamais été répercuté sur la série

PR #10859 (14/08) a bumpé le gitlink `Search/MetaGeneticSharp` vers le moteur rebase (fork `1ee12e4a0`, GeneticSharp imbriqué `e15ee828` tag 3.1.4 → `4406ad7` upstream master) **sans toucher aucun des 22 notebooks MGS** : les outputs committés dataient du moteur pré-rebase (ex. MGS-5 dernier papermill 2026-06-16) et la prose épinglait « GeneticSharp 3.1.4 ».

## Livré

**Validation du moteur rebase (grounding de la tranche)**
- Submodule imbriqué initialisé au gitlink exact (`4406ad713` = `3.1.4-9-g4406ad7`, FileVersion 3.1.4.0)
- `dotnet build` : 0 erreur (35 warnings CA1416 préexistants)
- `dotnet test` : **359/359 verts** (Domain 171, Extensions 180, Infrastructure 8)

**MGS-1 re-exécuté contre le moteur rebase** (kernel `.net-csharp`, 9/9 cellules, 0 erreur, chaîne 1-9) + `strip_probe_banner` (9 lignes)

**Prose réalignée ET robustifiée** (le vrai finding de la tranche) :
- Cellule 10 (sweep pc) : l'ancienne prose claimait « le résultat contre-intuitif (pc=0.75 pire que 0.3) est réel » — or le sweep fait **5 runs avec σ ≈ 8-11**, soit SE = σ/√5 ≈ 4-5, du même ordre que les écarts entre moyennes (~5) : **l'ordre observé n'est pas significatif et s'inverse selon l'exécution** (le run frais donne 0.95 < 0.75 < 0.3). Reformulation : la variance ELLE-MÊME est le résultat robuste (paysage multimodal, bassin déterminé par l'initialisation) ; un classement exigerait plus de runs ou un seed fixe — même discipline que le multi-seed des expériences ML du dépôt
- Cellule 7 : exemples réalignés sur le run frais ([-4, 3, 0, 0], f ≈ 25, fitness ≈ 0.04) + note explicite « run non seedé : le piège exact varie d'une exécution à l'autre »
- Cellule 16 (Default vs NoOp) : inchangée — la prose qualitative (« Default bat NoOp ») est cohérente avec le run frais (12 < 26). Noté au passage : l'ancien output committé (NoOp 9 < Default 15) contredisait la prose — un run unique non seedé peut inverser ce classement aussi
- Version précisée : « 3.1.4 » → « 3.1.4-9 / upstream master 4406ad7 » (cellule 0, diagramme d'architecture cellule 1, README Part4)

## Diagnostic dérive (C.4, cf #8364)

Les outputs changent (run GA non seedé + moteur rebase). Cause = **(e) stochasticité non-seedée** sur un moteur dont la couche amont a changé (classe d régression dépendance en sur-impression, mais la divergence dominante est la stochasticité : le notebook n'a jamais eu de seed). Verdict : **CAUSE_FIXED pour la prose** — les cellules qui citaient des nombres d'un run unique portent désormais soit les valeurs du run committé, soit des ordres de grandeur, et le claim statistiquement non justifié (ordre du sweep) est remplacé par le claim robuste (variance). La cause (e) ne se « répare » pas par re-exec ; elle se documente, fait ici in situ.

## Preuves

- Re-exec : 9/9 cellules, 0 erreur, `execution_count` 1-9, 0 `probeAddresses` résiduel
- Tests fork post-rebase : `Réussi! échec: 0, réussite: 359` (3 DLLs de test)
- `git diff --stat` : 2 fichiers, +442/-99 (notebook outputs+prose, README 1 ligne)
- Valeurs citées en prose = celles des outputs committés (24.8/19.6/14.6, σ 11.5/11.3/7.7 → ≈25/≈20/≈15, ≈11/≈11/≈8)

## Résiduel constaté (hors scope, pour tranches suivantes)

- 21 notebooks MGS restants aux outputs pré-rebase (MGS-2..MGS-19 + 7b/7c/7d) — même protocole applicable tranche par tranche ; les notebooks à sweeps multi-configs (MGS-5, MGS-16, MGS-18) sont prioritaires (même pathologie potentielle d'ordre non significatif)
- v0.1.0 du fork tagué AVANT le rebase (2026-07-05 vs 2026-08-14) — un v0.1.1 post-rebase serait cohérent (action release = coordinateur/user)
- Publication NuGet absente (nuget.org BlobNotFound) — RECOVERABLE-USER-HAND
