### PR TITLE
fix(qc,#11698): repair stale filter paths + wrong denominator in research issue template

### DIFF
--- a/docs/qc/qc-research-issue-template.md
+++ b/docs/qc/qc-research-issue-template.md
@@ -2,7 +2,7 @@
 
 > **Epic parent** : [#11698](https://github.com/jsboige/CoursIA/issues/11698)
 > **Label obligatoire** : `quantconnect-research`
-> **Filtre de voisinage** : `docs/qc-strategies-status.md` (source de vérité 130 stratégies)
+> **Filtre de voisinage** : `docs/qc/qc-strategies-status.md` (source de vérité, 111 stratégies)
 
 ## Pourquoi ce template
 
@@ -38,7 +38,7 @@ Copier-coller ce bloc dans le body de la sous-issue. Remplacer chaque `[…]` pa
 
 ### Différenciation vs bouquet existant
 
-- **Filtre** : `docs/qc-strategies-status.md` (livré par #1621 phase 5)
+- **Filtre** : `docs/qc/qc-strategies-status.md` (livré par #1621 phase 5)
 - **Projets voisins** : [lister 1-3 projets existants qui touchent le même angle]
 - **L'article est-il redondant ?** OUI / NON / PARTIELLEMENT [+ justification courte]
 
@@ -52,7 +52,7 @@ Copier-coller ce bloc dans le body de la sous-issue. Remplacer chaque `[…]` pa
 ## Acceptance locale
 
 - [ ] Article lu en entier (≥30 min de lecture effective)
-- [ ] Voisinage `qc-strategies-status.md` re-vérifié
+- [ ] Voisinage `docs/qc/qc-strategies-status.md` re-vérifié
 - [ ] Sources primaires identifiées (≥1) et tracées
 - [ ] Verdict coché avec justification
 - [ ] PR ou commentaire GH associé si verdict CONSOLIDATION / PÉDAGOGIQUE / NOUVEAU
@@ -62,7 +62,7 @@ Copier-coller ce bloc dans le body de la sous-issue. Remplacer chaque `[…]` pa
 - **Epic parent** : [#11698](https://github.com/jsboige/CoursIA/issues/11698)
 - **EPIC sibling** : [#1621](https://github.com/jsboige/CoursIA/issues/1621) (consolidation QC)
 - **EPIC sibling** : [#11168](https://github.com/jsboige/CoursIA/issues/11168) (vérification citations arXiv)
-- **Source de vérité voisinage** : [`docs/qc-strategies-status.md`](./qc-strategies-status.md)
+- **Source de vérité voisinage** : [`docs/qc/qc-strategies-status.md`](./qc-strategies-status.md)
 - **Méthode audit-distillation** : `.claude/rules/audit-cross-source-distillation.md`
 ```
 
@@ -123,7 +123,7 @@ Sans timestamp dans le corps (cf [lane-claim-protocol.md](../../.claude/rules/la
 - Article : « Crowdsourced alpha extraction from SEC filings »
 - Voisinage : aucun projet ne croise avec NLP/SEC filings en QC.
 - Verdict : NOUVEAU
-- Justification : « L'article propose un pipeline NLP→alpha sur les filings SEC, angle non couvert par les 130 projets existants (cf cartographie #1621). Le secteur fundamental US est stratégique pour le cours EPITA-IS. Création d'un notebook `research/research_nlp_sec_alpha.ipynb` standalone (pas un projet complet — un POC de recherche). »
+- Justification : « L'article propose un pipeline NLP→alpha sur les filings SEC, angle non couvert par les 111 projets existants (cf cartographie #1621). Le secteur fundamental US est stratégique pour le cours EPITA-IS. Création d'un notebook `research/research_nlp_sec_alpha.ipynb` standalone (pas un projet complet — un POC de recherche). »
 - PR associée : oui.
 
 ### Exemple 4 — Verdict IGNORE
@@ -145,7 +145,7 @@ Les trois premiers convergent vers une PR, le quatrième est un verdict de clôt
 
 ## Liens projet
 
-- [`docs/qc-strategies-status.md`](./qc-strategies-status.md) — source de vérité 130 stratégies
+- [`docs/qc/qc-strategies-status.md`](./qc-strategies-status.md) — source de vérité, 111 stratégies
 - [`.claude/rules/audit-cross-source-distillation.md`](../../.claude/rules/audit-cross-source-distillation.md) — méthode de distillation d'une source canonique
 - [`.claude/rules/lane-claim-protocol.md`](../../.claude/rules/lane-claim-protocol.md) — claim cross-lane
 - [`.claude/rules/audit-reassessment.md`](../../.claude/rules/audit-reassessment.md) — protocole 4 étapes de vérification


### PR DESCRIPTION
Grain: MED/docs -- lane myia-po-2026:CoursIA
Quoi:       reparation du template de sous-issue QC-research livre par #11702 : 5 occurrences du chemin perime docs/qc-strategies-status.md (dont 1 DANS le bloc copier-coller et 1 dans la checklist d'acceptance -- chaque sous-issue pilote aurait herite du chemin casse) + denominateur aligne sur l'en-tete du fichier de verite (111 strategies, pas 130) en 3 endroits
Preuve:     grep avant : 5 occurrences perimees (L5/L41/L55/L65/L148) + 3x "130" (L5/L126/L148) ; grep apres : 0 des deux ; hrefs relatifs ./qc-strategies-status.md resolvent deja correctement depuis docs/qc/ (fichier cible present) ; les 2 regles referencees (.claude/rules/audit-cross-source-distillation.md, lane-claim-protocol.md) existent sur main
Perimetre:  docs/qc/qc-research-issue-template.md (fichier EXISTANT repare -- le claim initial "nouveau fichier" est amende : le point 3 de l'Epic etait deja livre par #11702, ce grain en repare les defauts) ; hors scope : doublon docs/archive/qc-strategies-status.md (point 2 Phase 1, reste ai-01), contenu du fichier de verite lui-meme

## Contexte

Le point 3 de l'Epic #11698 (template de sous-issue) a ete livre par #11702
AVANT la correction des chemins que ai-01 a faite dans le body de l'Epic. Le
livrable porte donc exactement le defaut corrige dans l'Epic mais pas dans le
fichier : le chemin `docs/qc-strategies-status.md`, alors que le canonique
vit dans `docs/qc/`.

Le point critique : **une occurrence est dans le bloc copier-coller**
(ligne 41) et une autre dans la **checklist d'acceptance** (ligne 55). Toute
sous-issue pilote creee en copiant le template aurait herite du chemin casse,
et l'acceptance « Voisinage re-verifie » pointait un nom nu qui ne matche pas
le chemin complet du filtre.

## Corrections (6 lignes)

| Ligne | Avant | Apres |
|-------|-------|-------|
| 5 (header) | `docs/qc-strategies-status.md` (130 strategies) | `docs/qc/qc-strategies-status.md` (111 strategies) |
| 41 (bloc copier-coller) | `docs/qc-strategies-status.md` | `docs/qc/qc-strategies-status.md` |
| 55 (acceptance) | `qc-strategies-status.md` (nom nu) | `docs/qc/qc-strategies-status.md` |
| 65 (liens) | texte `docs/qc-strategies-status.md` | texte `docs/qc/qc-strategies-status.md` (href `./` inchange, correct) |
| 126 (exemple 3) | « les 130 projets existants » | « les 111 projets existants » |
| 148 (liens projet) | texte + 130 strategies | texte corrige + 111 strategies |

## Denominateur : 111, pas 130

Le fichier de verite lui-meme declare (L6) : « les 111 strategies sous
MyIA.AI.Notebooks/QuantConnect/projects/ (112 entrees brutes, dont _docs/
qui n'est pas une strategie) ». Le 130 de l'Epic = 112 projets + 4
partner-course + 18 notebooks de recherche -- un total d'inventaire, pas le
denominateur de CE fichier. Les mentions ont ete alignees sur l'en-tete du
fichier de verite.

## Ce qui n'a PAS change

- Les hrefs relatifs `./qc-strategies-status.md` (L65, L148) : ils resolvent
  deja correctement depuis `docs/qc/` -- seuls les textes d'affichage etaient faux.
- Structure, conventions (titre/labels/claim/cap), anti-patterns, exemples de
  verdicts : audites, sains, inchanges.
- Le doublon `docs/archive/qc-strategies-status.md` : point 2 de la Phase 1
  de l'Epic, reste au scope ai-01.

See #11698

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
