### PR TITLE
fix(mgs,#1203): MGS-2 re-exec post-rebase — faux Constat Rastrigin corrigé, honnêteté statistique

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-2-Composition.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-2-Composition.ipynb
@@ -2,7 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8626bea1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009463,
+     "end_time": "2026-08-20T12:27:37.864861+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:37.855398+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "# MGS-2 : Composition de métaheuristiques -- Match et primitives de contrôle\n",
     "\n",
@@ -26,7 +36,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "d7d7f5c6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015097,
+     "end_time": "2026-08-20T12:27:37.901183+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:37.886086+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 1. Pourquoi composer des métaheuristiques ?\n",
     "\n",
@@ -56,21 +76,145 @@
   {
    "cell_type": "code",
    "execution_count": 1,
+   "id": "48158845",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:27.608669Z",
-     "iopub.status.busy": "2026-07-13T00:30:27.603070Z",
-     "iopub.status.idle": "2026-07-13T00:30:29.616180Z",
-     "shell.execute_reply": "2026-07-13T00:30:29.607842Z"
+     "iopub.execute_input": "2026-08-20T12:27:37.960889Z",
+     "iopub.status.busy": "2026-08-20T12:27:37.947122Z",
+     "iopub.status.idle": "2026-08-20T12:27:40.296369Z",
+     "shell.execute_reply": "2026-08-20T12:27:40.287517Z"
     },
+    "papermill": {
+     "duration": 2.384805,
+     "end_time": "2026-08-20T12:27:40.296547+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:37.911742+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
    },
    "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\r\n",
+       "<div>\r\n",
+       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
+       "    </div>\r\n",
+       "    <script type='text/javascript'>\r\n",
+       
+       "    function timeout(ms, promise) {\r\n",
+       "        return new Promise(function (resolve, reject) {\r\n",
+       "            setTimeout(function () {\r\n",
+       "                reject(new Error('timeout'))\r\n",
+       "            }, ms)\r\n",
+       "            promise.then(resolve, reject)\r\n",
+       "        })\r\n",
+       "    }\r\n",
+       "\r\n",
+       
+       
+       "\r\n",
+       
+       "\r\n",
+       "            if (!rootUrl.endsWith('/')) {\r\n",
+       "                rootUrl = `${rootUrl}/`;\r\n",
+       "            }\r\n",
+       "\r\n",
+       "            try {\r\n",
+       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
+       "                    method: 'POST',\r\n",
+       "                    cache: 'no-cache',\r\n",
+       "                    mode: 'cors',\r\n",
+       "                    timeout: 1000,\r\n",
+       "                    headers: {\r\n",
+       "                        'Content-Type': 'text/plain'\r\n",
+       "                    },\r\n",
+       
+       "                }));\r\n",
+       "\r\n",
+       "                if (response.status == 200) {\r\n",
+       "                    return rootUrl;\r\n",
+       "                }\r\n",
+       "            }\r\n",
+       "            catch (e) { }\r\n",
+       "        }\r\n",
+       "    }\r\n",
+       "}\r\n",
+       "\r\n",
+       
+       
+       "        .then((root) => {\r\n",
+       "        // use probing to find host url and api resources\r\n",
+       "        // load interactive helpers and language services\r\n",
+       "        let dotnetInteractiveRequire = require.config({\r\n",
+       "        context: '39136.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "                paths:\r\n",
+       "            {\r\n",
+       "                'dotnet-interactive': `${root}resources`\r\n",
+       "                }\r\n",
+       "        }) || require;\r\n",
+       "\r\n",
+       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
+       "\r\n",
+       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
+       "                let paths = {};\r\n",
+       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
+       "                \r\n",
+       "                let internalRequire = require.config({\r\n",
+       "                    context: extensionCacheBuster,\r\n",
+       "                    paths: paths,\r\n",
+       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
+       "                    }) || require;\r\n",
+       "\r\n",
+       "                return internalRequire\r\n",
+       "            };\r\n",
+       "        \r\n",
+       "            dotnetInteractiveRequire([\r\n",
+       "                    'dotnet-interactive/dotnet-interactive'\r\n",
+       "                ],\r\n",
+       "                function (dotnet) {\r\n",
+       "                    dotnet.init(window);\r\n",
+       "                },\r\n",
+       "                function (error) {\r\n",
+       "                    console.log(error);\r\n",
+       "                }\r\n",
+       "            );\r\n",
+       "        })\r\n",
+       "        .catch(error => {console.log(error);});\r\n",
+       "    }\r\n",
+       "\r\n",
+       "// ensure `require` is available globally\r\n",
+       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
+       "    let require_script = document.createElement('script');\r\n",
+       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
+       "    require_script.setAttribute('type', 'text/javascript');\r\n",
+       "    \r\n",
+       "    \r\n",
+       "    require_script.onload = function() {\r\n",
+       
+       "    };\r\n",
+       "\r\n",
+       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
+       "}\r\n",
+       "else {\r\n",
+       
+       "}\r\n",
+       "\r\n",
+       "    </script>\r\n",
+       "</div>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -144,7 +288,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6bafbf08",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010929,
+     "end_time": "2026-08-20T12:27:40.314575+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:40.303646+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 2. Le mécanisme de Match\n",
@@ -177,16 +331,25 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "50bf4203",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:29.619096Z",
-     "iopub.status.busy": "2026-07-13T00:30:29.618732Z",
-     "iopub.status.idle": "2026-07-13T00:30:30.065938Z",
-     "shell.execute_reply": "2026-07-13T00:30:30.065608Z"
+     "iopub.execute_input": "2026-08-20T12:27:40.330214Z",
+     "iopub.status.busy": "2026-08-20T12:27:40.329896Z",
+     "iopub.status.idle": "2026-08-20T12:27:40.842281Z",
+     "shell.execute_reply": "2026-08-20T12:27:40.841643Z"
     },
+    "papermill": {
+     "duration": 0.518834,
+     "end_time": "2026-08-20T12:27:40.842463+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:40.323629+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -281,7 +444,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "ea67c842",
+   "metadata": {
+    "papermill": {
+     "duration": 0.017814,
+     "end_time": "2026-08-20T12:27:40.872079+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:40.854265+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Demonstration : Stratégie de match\n",
     "\n",
@@ -297,13 +470,22 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "899ba4c7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:30.068127Z",
-     "iopub.status.busy": "2026-07-13T00:30:30.067808Z",
-     "iopub.status.idle": "2026-07-13T00:30:31.222056Z",
-     "shell.execute_reply": "2026-07-13T00:30:31.221516Z"
-    }
+     "iopub.execute_input": "2026-08-20T12:27:40.923070Z",
+     "iopub.status.busy": "2026-08-20T12:27:40.921944Z",
+     "iopub.status.idle": "2026-08-20T12:27:42.690218Z",
+     "shell.execute_reply": "2026-08-20T12:27:42.690015Z"
+    },
+    "papermill": {
+     "duration": 1.79655,
+     "end_time": "2026-08-20T12:27:42.690323+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:40.893773+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -338,21 +520,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current + Neighbor (adjacent)  21,0000         Neighbor (adjacent)\r\n"
+      "Current + Neighbor (adjacent)  11,0000         Neighbor (adjacent)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current + Random (diversifie)  11,0000         Random (diversifie)\r\n"
+      "Current + Random (diversifie)  38,0000         Random (diversifie)\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Current + Best (elitiste)      29,0000         Best (elitiste)\r\n"
+      "Current + Best (elitiste)      22,0000         Best (elitiste)\r\n"
      ]
     },
     {
@@ -402,11 +584,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "45c684c3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00484,
+     "end_time": "2026-08-20T12:27:42.702233+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:42.697393+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Stratégies de match\n",
     "\n",
-    "**Sortie obtenue** : Les trois stratégies convergent vers des valeurs proches de 0, mais avec des différences de qualite.\n",
+    "**Sortie obtenue** : Les trois stratégies atteignent des f(x) dispersés (≈11 à ≈38 sur ce run unique par configuration), loin de l'optimum 0 à ce budget de 50 générations. Un run par configuration ne départage pas les trois matchs : sur l'output précédemment committé (moteur pré-rebase), l'ordre était Random ≈11 < Neighbor ≈21 < Best ≈29 -- Random y était **meilleur**, il est ici **dernier**. C'est la variance run-à-run, pas un signal de qualité.\n",
     "\n",
     "| Stratégie | Comportement | Forces | Limites |\n",
     "|-----------|-------------|--------|---------|\n",
@@ -423,7 +615,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "8fe4703b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007471,
+     "end_time": "2026-08-20T12:27:42.715175+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:42.707704+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 3. Primitives de contrôle de flux\n",
@@ -460,16 +662,25 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "f6ae9831",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:31.224110Z",
-     "iopub.status.busy": "2026-07-13T00:30:31.223839Z",
-     "iopub.status.idle": "2026-07-13T00:30:32.307469Z",
-     "shell.execute_reply": "2026-07-13T00:30:32.306959Z"
+     "iopub.execute_input": "2026-08-20T12:27:42.732983Z",
+     "iopub.status.busy": "2026-08-20T12:27:42.732616Z",
+     "iopub.status.idle": "2026-08-20T12:27:44.381332Z",
+     "shell.execute_reply": "2026-08-20T12:27:44.381095Z"
     },
+    "papermill": {
+     "duration": 1.659005,
+     "end_time": "2026-08-20T12:27:44.381461+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:42.722456+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -507,14 +718,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Default (baseline)   33,0000      23,0000      34,0000     \r\n"
+      "Default (baseline)   14,0000      11,0000      8,0000      \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SizeBased(25/25)     14,0000      27,0000      35,0000     \r\n"
+      "SizeBased(25/25)     6,0000       38,0000      7,0000      \r\n"
      ]
     },
     {
@@ -528,14 +739,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default moyenne : 30,0000\r\n"
+      "  Default moyenne : 11,0000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SizeBased moyenne: 25,3333\r\n"
+      "  SizeBased moyenne: 17,0000\r\n"
      ]
     },
     {
@@ -617,7 +828,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "e4b16f8c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005282,
+     "end_time": "2026-08-20T12:27:44.392868+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:44.387586+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : SizeBasedMetaHeuristic\n",
     "\n",
@@ -639,16 +860,25 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "bda48baf",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:32.309421Z",
-     "iopub.status.busy": "2026-07-13T00:30:32.309159Z",
-     "iopub.status.idle": "2026-07-13T00:30:33.806010Z",
-     "shell.execute_reply": "2026-07-13T00:30:33.805660Z"
+     "iopub.execute_input": "2026-08-20T12:27:44.406157Z",
+     "iopub.status.busy": "2026-08-20T12:27:44.405872Z",
+     "iopub.status.idle": "2026-08-20T12:27:45.875469Z",
+     "shell.execute_reply": "2026-08-20T12:27:45.875232Z"
     },
+    "papermill": {
+     "duration": 1.476484,
+     "end_time": "2026-08-20T12:27:45.875593+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:44.399109+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -693,35 +923,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 11,0000   "
+      " 45,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 27,0000   "
+      " 13,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 38,0000   "
+      " 13,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 14,0000   "
+      " 34,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 25,0000   "
+      " 31,0000   "
      ]
     },
     {
@@ -742,7 +972,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 9,0000    "
+      " 13,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 34,0000   "
      ]
     },
     {
@@ -756,21 +993,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 19,0000   "
+      " 26,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 35,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 11,0000   "
+      " 31,0000   "
      ]
     },
     {
@@ -791,14 +1021,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default moyenne  : 23,0000\r\n"
+      "  Default moyenne  : 27,2000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  GenPhased moyenne: 16,8000\r\n"
+      "  GenPhased moyenne: 22,8000\r\n"
      ]
     },
     {
@@ -874,7 +1104,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "2036674b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00667,
+     "end_time": "2026-08-20T12:27:45.889375+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:45.882705+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : GenerationMetaHeuristic\n",
     "\n",
@@ -895,16 +1135,25 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "23b42205",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:33.807975Z",
-     "iopub.status.busy": "2026-07-13T00:30:33.807720Z",
-     "iopub.status.idle": "2026-07-13T00:30:35.898799Z",
-     "shell.execute_reply": "2026-07-13T00:30:35.898428Z"
+     "iopub.execute_input": "2026-08-20T12:27:45.905020Z",
+     "iopub.status.busy": "2026-08-20T12:27:45.904727Z",
+     "iopub.status.idle": "2026-08-20T12:27:47.748955Z",
+     "shell.execute_reply": "2026-08-20T12:27:47.748677Z"
     },
+    "papermill": {
+     "duration": 1.851752,
+     "end_time": "2026-08-20T12:27:47.749073+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:45.897321+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -949,28 +1198,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 18,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 10,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 16,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 26,0000   "
+      " 42,0000   "
      ]
     },
     {
@@ -978,6 +1206,27 @@
      "output_type": "stream",
      "text": [
       " 30,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 43,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 17,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 11,0000   "
      ]
     },
     {
@@ -998,28 +1247,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 21,0000   "
+      " 25,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 22,0000   "
+      " 33,0000   "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 15,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 26,0000   "
+      " 9,0000    "
      ]
     },
     {
@@ -1027,6 +1269,13 @@
      "output_type": "stream",
      "text": [
       " 14,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 15,0000   "
      ]
     },
     {
@@ -1047,14 +1296,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default moyenne     : 20,0000\r\n"
+      "  Default moyenne     : 28,6000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  StageSwitch moyenne : 19,6000\r\n"
+      "  StageSwitch moyenne : 19,2000\r\n"
      ]
     },
     {
@@ -1134,7 +1383,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "1ba39a91",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008753,
+     "end_time": "2026-08-20T12:27:47.766942+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:47.758189+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : StageSwitchMetaHeuristic\n",
     "\n",
@@ -1156,7 +1415,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "42c15c30",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008598,
+     "end_time": "2026-08-20T12:27:47.783817+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:47.775219+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 4. Composition en action\n",
@@ -1187,16 +1456,25 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "90fce899",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:35.901066Z",
-     "iopub.status.busy": "2026-07-13T00:30:35.900699Z",
-     "iopub.status.idle": "2026-07-13T00:30:37.332031Z",
-     "shell.execute_reply": "2026-07-13T00:30:37.328885Z"
+     "iopub.execute_input": "2026-08-20T12:27:47.800407Z",
+     "iopub.status.busy": "2026-08-20T12:27:47.800078Z",
+     "iopub.status.idle": "2026-08-20T12:27:48.908751Z",
+     "shell.execute_reply": "2026-08-20T12:27:48.900867Z"
     },
+    "papermill": {
+     "duration": 1.118143,
+     "end_time": "2026-08-20T12:27:48.908884+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:47.790741+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -1262,21 +1540,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 21,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 32,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 14,0000   "
+      " 24,0000   "
      ]
     },
     {
@@ -1290,7 +1554,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 42,0000   "
+      " 28,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 9,0000    "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 35,0000   "
      ]
     },
     {
@@ -1311,21 +1589,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 15,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 25,0000   "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 17,0000   "
+      " 18,0000   "
      ]
     },
     {
@@ -1339,7 +1603,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 15,0000   "
+      " 35,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 21,0000   "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " 30,0000   "
      ]
     },
     {
@@ -1360,21 +1638,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default moyenne   : 25,8000\r\n"
+      "  Default moyenne   : 23,2000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Composed moyenne  : 19,0000\r\n"
+      "  Composed moyenne  : 25,4000\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Amelioration      : 26,4%\r\n"
+      "  Amelioration      : -9,5%\r\n"
      ]
     },
     {
@@ -1493,11 +1771,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f771e0ab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008667,
+     "end_time": "2026-08-20T12:27:48.927335+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:48.918668+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Interpretation : Stratégie composee\n",
     "\n",
-    "**Sortie obtenue** : La stratégie composee combine les avantages de chaque primitive.\n",
+    "**Sortie obtenue** : sur Sphere, la stratégie composée ne montre pas d'avantage stable. Sur ce run : Composée ≈25,4 contre Default ≈23,2 (« amélioration » −10 %) ; sur l'output précédemment committé : 19,0 contre 25,8 (**+26 %**). L'indicateur change de signe selon l'exécution -- 5 runs non seedés ne départagent pas les deux configurations sur un paysage convexe.\n",
     "\n",
     "| Niveau | Primitive | Paramètres | Effet |\n",
     "|--------|-----------|------------|-------|\n",
@@ -1509,14 +1797,24 @@
     "1. La composition est **hiérarchique** : chaque niveau delegue aux niveaux inferieurs\n",
     "2. Le moteur appelle `RegisterParameters()` recursivement sur toute la hiérarchie, garantissant que les caches de chaque niveau sont initialises\n",
     "3. La stratégie composee est un objet C# ordinaire -- elle peut etre parametree, serialisee, testee unitairement\n",
-    "4. Sur un problème unimodale comme Sphere, l'avantage peut etre marginal ; c'est sur les problemes **multimodaux** et **contraints** que la composition montre tout son potentiel\n",
+    "4. Sur un problème unimodale comme Sphere, l'avantage peut etre marginal, voire négatif selon le run ; c'est sur les problemes **multimodaux** et **contraints** que la composition a une chance de montrer son potentiel -- à condition de le mesurer honnêtement (cf section 5)\n",
     "\n",
     "> **Note technique** : `GenerationMetaHeuristic` wrappe l'index avec `(GenerationsNumber - 1) % TotalPhaseSize`, donc le cycle se repete au-dela de 40 générations. Pour une évolution de 80 générations, on aurait deux cycles complets exploration -> exploitation."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "3e91bffe",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008774,
+     "end_time": "2026-08-20T12:27:48.945434+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:48.936660+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "## 5. Resume\n",
@@ -1549,7 +1847,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a8cb8be8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009144,
+     "end_time": "2026-08-20T12:27:48.963819+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:48.954675+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -1568,17 +1876,27 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "f6a0d8ec",
+   "metadata": {
+    "papermill": {
+     "duration": 0.007853,
+     "end_time": "2026-08-20T12:27:48.980690+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:48.972837+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## 5. La composition se discriminant-elle ? Le test du paysage multimodal\n",
     "\n",
-    "Sur la fonction **Sphere** (convexe, unimodale), *toutes* les stratégies de composition des sections précédentes convergent vers l'optimum global `(0, 0, 0, 0)` : la composition parait sans intérêt, puisqu'un hill-climber ou une simple descente y arriverait aussi. C'est le piege classique d'une **demonstration degeneree** -- un moteur de recherche globale (métaheuristique) montre sur un paysage ou la recherche globale n'apporte rien.\n",
+    "Sur la fonction **Sphere** (convexe, unimodale), les stratégies des sections précédentes n'ont **pas** convergé vers l'optimum global `(0, 0, 0, 0)` : à ce budget de générations, les f(x) restent dispersés (≈11 à ≈38 en section 2, moyennes ≈23 contre ≈25 en section 4) et les classements changent d'une exécution à l'autre. Aucune stratégie ne s'y détache -- un paysage convexe à ce budget ne **départage** rien, et un hill-climber ou une simple descente s'en sortirait aussi bien que n'importe laquelle. C'est le piege classique d'une **demonstration degeneree** -- montrer un moteur de recherche globale sur un paysage ou la recherche globale n'apporte rien de mesurable.\n",
     "\n",
     "Pour **faire valoir** la capacite distinctive de la composition (adapter la stratégie selon le contexte pour entretenir la diversite et s'echapper des optima locaux), il faut un paysage **multimodal**. La fonction de **Rastrigin**, benchmark canonique, est riche en optima locaux :\n",
     "\n",
     "$$f(\\mathbf{x}) = 10n + \\sum_{i=1}^{n} \\left[ x_i^2 - 10 \\cos(2\\pi x_i) \\right], \\quad x_i \\in [-5.12, 5.12]$$\n",
     "\n",
-    "Minimisee en `(0,...,0) = 0`, mais parsemee d'une foret d'optima locaux. Sur un tel paysage, une strategy trop convergente (Default pur, crossover constant) a tendance a stagner dans un basin local ; une strategy diversifiee (alternance exploration/exploitation via `Génération` + `StageSwitch`) s'echappe et atteint un meilleur optimum. **C'est la que la composition devient visible** -- la ou Sphere la masquait.\n",
+    "Minimisee en `(0,...,0) = 0`, mais parsemee d'une foret d'optima locaux. Sur un tel paysage, une strategy trop convergente (Default pur, crossover constant) a tendance a stagner dans un bassin local ; une strategy diversifiee (alternance exploration/exploitation via `Génération` + `StageSwitch`) **devrait** mieux s'echapper des basins. **C'est l'hypothèse que le test suivant confronte aux mesures** -- avec une leçon en retour : un avantage attendu n'est pas un avantage mesuré (cf la lecture du résultat ci-dessous).\n",
     "\n",
     "Comparons, sur Rastrigin 4D (5 runs chacune) : `DefaultMetaHeuristic` (baseline sans composition), `SizeBasedMetaHeuristic` (crossover aggressif puis conservateur), et la strategy **composee** `Génération + StageSwitch + Match` (reutilisant les helpers de la section 4)."
    ]
@@ -1586,13 +1904,22 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "f4fca457",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:37.335179Z",
-     "iopub.status.busy": "2026-07-13T00:30:37.334806Z",
-     "iopub.status.idle": "2026-07-13T00:30:41.308388Z",
-     "shell.execute_reply": "2026-07-13T00:30:41.308020Z"
-    }
+     "iopub.execute_input": "2026-08-20T12:27:49.002282Z",
+     "iopub.status.busy": "2026-08-20T12:27:49.001883Z",
+     "iopub.status.idle": "2026-08-20T12:27:51.652692Z",
+     "shell.execute_reply": "2026-08-20T12:27:51.652495Z"
+    },
+    "papermill": {
+     "duration": 2.662727,
+     "end_time": "2026-08-20T12:27:51.652796+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:48.990069+00:00",
+     "status": "completed"
+    },
+    "tags": []
    },
    "outputs": [
     {
@@ -1613,21 +1940,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Default (sans composition)   f(x) =   3,200\r\n"
+      "  Default (sans composition)   f(x) =   7,400\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  SizeBased(25/25 crossover)   f(x) =   4,400\r\n"
+      "  SizeBased(25/25 crossover)   f(x) =   5,400\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Composee (Gen+Stage+Match)   f(x) =   4,600\r\n"
+      "  Composee (Gen+Stage+Match)   f(x) =   5,400\r\n"
      ]
     },
     {
@@ -1641,37 +1968,52 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Constat : sur Sphere, ces strategies donnaient ~le meme optimum (0).\r\n"
+      "Classement observe (meilleure d'abord) : SizeBased 5,4  <  Composee 5,4  <  Default 7,4\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Sur Rastrigin (multimodal), l'ecart devient visible : la strategy la plus\r\n"
+      "Constat : a 5 runs non seedees, cet ecart n'est pas significatif -- l'ordre peut\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "diversifiee (Composee, qui alterne exploration/exploitation) echappe mieux aux\r\n"
+      "s'inverser d'une execution a l'autre (discipline multi-seed du depot). La Composee\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "optima locaux. C'est la capacite distinctive de la composition, invisible sur Sphere.\r\n"
+      "arrive ici au rang 1/3 : l'avantage attendu de la diversite ne se lit pas\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "directement dans ce test. Un recit plausible ne remplace pas la mesure : departager\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ces strategies exigerait plus de runs ou un seed fixe.\r\n"
      ]
     }
    ],
    "source": [
     "// Section 5 : test du paysage multimodal (Rastrigin) -- la composition devient-elle visible ?\n",
-    "// Sur Sphere (convexe), toutes les strategies convergent vers 0 : la composition parait\n",
-    "// inutile (un hill-climber y arriverait aussi). Sur Rastrigin (multimodal, riche en optima\n",
-    "// locaux), une strategy qui entretient la diversite s'echappe des basins : c'est la que la\n",
-    "// composition devient VISIBLE. f(x) = 10n + sum( x_i^2 - 10*cos(2*pi*x_i) ), x_i in [-5.12, 5.12].\n",
+    "// Sur Sphere (convexe), a 50 generations les strategies des sections precedentes atteignent\n",
+    "// des f(x) disperses (~4 a ~42 selon les runs) qu'aucun ecart fiable ne separe : il faut un\n",
+    "// paysage qui discrimine. Sur Rastrigin (multimodal, riche en optima locaux), l'hypothese a\n",
+    "// tester : une strategy qui entretient la diversite s'echapperait mieux des basins locaux.\n",
+    "// f(x) = 10n + sum( x_i^2 - 10*cos(2*pi*x_i) ), x_i in [-5.12, 5.12].\n",
     "\n",
     "public class RastriginFitness : IFitness\n",
     "{\n",
@@ -1733,25 +2075,57 @@
     "Console.WriteLine($\"  SizeBased(25/25 crossover)   f(x) = {fSize,7:F3}\");\n",
     "Console.WriteLine($\"  Composee (Gen+Stage+Match)   f(x) = {fComposed,7:F3}\");\n",
     "Console.WriteLine(new string('=', 74));\n",
-    "Console.WriteLine(\"Constat : sur Sphere, ces strategies donnaient ~le meme optimum (0).\");\n",
-    "Console.WriteLine(\"Sur Rastrigin (multimodal), l'ecart devient visible : la strategy la plus\");\n",
-    "Console.WriteLine(\"diversifiee (Composee, qui alterne exploration/exploitation) echappe mieux aux\");\n",
-    "Console.WriteLine(\"optima locaux. C'est la capacite distinctive de la composition, invisible sur Sphere.\");"
+    "var classement = new[] { (\"Default\", fDefault), (\"SizeBased\", fSize), (\"Composee\", fComposed) }\n",
+    "    .OrderBy(p => p.Item2).ToArray();\n",
+    "int rangComposee = 1 + classement.Count(p => p.Item2 < fComposed);\n",
+    "Console.WriteLine($\"Classement observe (meilleure d'abord) : {string.Join(\"  <  \", classement.Select(p => $\"{p.Item1} {p.Item2:F1}\"))}\");\n",
+    "Console.WriteLine(\"Constat : a 5 runs non seedees, cet ecart n'est pas significatif -- l'ordre peut\");\n",
+    "Console.WriteLine(\"s'inverser d'une execution a l'autre (discipline multi-seed du depot). La Composee\");\n",
+    "Console.WriteLine($\"arrive ici au rang {rangComposee}/3 : l'avantage attendu de la diversite ne se lit pas\");\n",
+    "Console.WriteLine(\"directement dans ce test. Un recit plausible ne remplace pas la mesure : departager\");\n",
+    "Console.WriteLine(\"ces strategies exigerait plus de runs ou un seed fixe.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mgs2-lecture-sec5",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : ce que le test établit (et ce qu'il ne dit pas)\n",
+    "\n",
+    "**Ce que montre ce run** : SizeBased ≈5,4 ≈ Composée ≈5,4 < Default ≈7,4 -- la Composée arrive première ex æquo.\n",
+    "\n",
+    "**Pourquoi ne pas conclure dessus** : sur l'output précédemment committé de cette même cellule (moteur pré-rebase), le classement était Default 3,2 < SizeBased 4,4 < Composée 4,6 -- la Composée y était **dernière**. À 5 runs non seedées, l'ordre observé n'est pas stable : ce test ne couronne personne. La donnée robuste est l'instabilité elle-même (même constat que le sweep $p_c$ de MGS-1 : la variance est le résultat, pas l'ordre).\n",
+    "\n",
+    "**Ce que le notebook établit** : le **mécanisme** de composition fonctionne -- les trois niveaux (génération → étape → match) s'enchaînent, s'exécutent sans erreur et produisent un GA complet sur deux paysages différents.\n",
+    "\n",
+    "**Ce qu'il ne dit pas** : que la composition aide ou nuit sur Rastrigin. Le départager exigerait plus de runs, un seed fixe, et probablement un budget plus grand -- c'est exactement la discipline multi-seed des expériences ML du dépôt.\n",
+    "\n",
+    "> **Piège pédagogique évacué** : le « Constat » imprimé par la version précédente de cette cellule affirmait que la Composée « échappe mieux aux optima locaux » alors que **ses propres chiffres committés la plaçaient dernière** (4,6, la pire des trois). Un récit plausible ne remplace pas la mesure.\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "a79c46cd",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:41.310458Z",
-     "iopub.status.busy": "2026-07-13T00:30:41.310172Z",
-     "iopub.status.idle": "2026-07-13T00:30:41.348140Z",
-     "shell.execute_reply": "2026-07-13T00:30:41.347913Z"
+     "iopub.execute_input": "2026-08-20T12:27:51.674088Z",
+     "iopub.status.busy": "2026-08-20T12:27:51.673784Z",
+     "iopub.status.idle": "2026-08-20T12:27:51.716546Z",
+     "shell.execute_reply": "2026-08-20T12:27:51.716108Z"
     },
+    "papermill": {
+     "duration": 0.054506,
+     "end_time": "2026-08-20T12:27:51.716701+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:51.662195+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -1791,7 +2165,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "a3719276",
+   "metadata": {
+    "papermill": {
+     "duration": 0.014343,
+     "end_time": "2026-08-20T12:27:51.756169+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:51.741826+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 2 : Combiner SizeBased et Match pour une stratégie hybride\n",
     "\n",
@@ -1811,16 +2195,25 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "c4aac3c3",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:41.349839Z",
-     "iopub.status.busy": "2026-07-13T00:30:41.349517Z",
-     "iopub.status.idle": "2026-07-13T00:30:41.380652Z",
-     "shell.execute_reply": "2026-07-13T00:30:41.380153Z"
+     "iopub.execute_input": "2026-08-20T12:27:51.777390Z",
+     "iopub.status.busy": "2026-08-20T12:27:51.776962Z",
+     "iopub.status.idle": "2026-08-20T12:27:51.809842Z",
+     "shell.execute_reply": "2026-08-20T12:27:51.809606Z"
     },
+    "papermill": {
+     "duration": 0.04437,
+     "end_time": "2026-08-20T12:27:51.809969+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:51.765599+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -1859,7 +2252,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "4156a2b8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.010169,
+     "end_time": "2026-08-20T12:27:51.830439+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:51.820270+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "## Exercice 3 : Stratégie multi-phases avec Génération + StageSwitch\n",
     "\n",
@@ -1881,16 +2284,25 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "91b83afe",
    "metadata": {
     "dotnet_interactive": {
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-07-13T00:30:41.382312Z",
-     "iopub.status.busy": "2026-07-13T00:30:41.382069Z",
-     "iopub.status.idle": "2026-07-13T00:30:41.420471Z",
-     "shell.execute_reply": "2026-07-13T00:30:41.420233Z"
+     "iopub.execute_input": "2026-08-20T12:27:51.853052Z",
+     "iopub.status.busy": "2026-08-20T12:27:51.852731Z",
+     "iopub.status.idle": "2026-08-20T12:27:51.911494Z",
+     "shell.execute_reply": "2026-08-20T12:27:51.911173Z"
     },
+    "papermill": {
+     "duration": 0.06888,
+     "end_time": "2026-08-20T12:27:51.911652+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:51.842772+00:00",
+     "status": "completed"
+    },
+    "tags": [],
     "vscode": {
      "languageId": "csharp"
     }
@@ -1935,7 +2347,17 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "id": "6fbaa0a1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.015331,
+     "end_time": "2026-08-20T12:27:51.940814+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T12:27:51.925483+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -1944,6 +2366,20 @@
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "none",
+   "api_usd_est": 0.0,
+   "cpu_min": 7,
+   "external_account": null,
+   "free_alternative": null,
+   "gpu_required": false,
+   "metadata_written": null,
+   "network": false,
+   "notes": "Local execution via MetaGeneticSharp (.NET C# genetic-algorithm library). Deterministic given fixed random seed, population and generation count. Requires .NET Interactive kernel + MetaGeneticSharp package. The genetic operators (selection/crossover/mutation) are deterministic algorithms; GA convergence to a fixed seed is reproducible.",
+   "reduced_pedagogical": null,
+   "reproducibility": "HIGH",
+   "validator": "manual"
+  },
   "kernelspec": {
    "display_name": ".NET (C#)",
    "language": "C#",
@@ -1956,21 +2392,19 @@
    "pygments_lexer": "csharp",
    "version": "13.0"
   },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "none",
-   "cpu_min": 7,
-   "gpu_required": false,
-   "network": false,
-   "external_account": null,
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "HIGH",
-   "metadata_written": null,
-   "validator": "manual",
-   "notes": "Local execution via MetaGeneticSharp (.NET C# genetic-algorithm library). Deterministic given fixed random seed, population and generation count. Requires .NET Interactive kernel + MetaGeneticSharp package. The genetic operators (selection/crossover/mutation) are deterministic algorithms; GA convergence to a fixed seed is reproducible."
+  "papermill": {
+   "default_parameters": {},
+   "duration": 16.801557,
+   "end_time": "2026-08-20T12:27:52.185245+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "d:\\dev\\CoursIA-1203-mgs1\\MyIA.AI.Notebooks\\Search\\Part4-Metaheuristics\\MGS-2-Composition.ipynb",
+   "output_path": "d:\\dev\\CoursIA-1203-mgs1\\MyIA.AI.Notebooks\\Search\\Part4-Metaheuristics\\MGS-2-Composition.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-20T12:27:35.383688+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-dotnet #11941 (substance distincte : correction d'un faux constat committé + classement dynamique immunitaire à la stochasticité, vs validation re-exec + sweep pc)

Deuxième tranche de validation post-rebase de la série MGS (suite de #11941). See #1203 (contribution partielle — l'EPIC reste ouverte).

## Livré — MGS-2-Composition re-exécuté contre le moteur rebase

Re-exécution complète (kernel `.net-csharp`, **11/11 cellules, 0 erreur**, chaîne 1-11) + `strip_probe_banner` (9 lignes) + H.3 vérifié (0 `probeAddresses` résiduel, 0 `execution_count` null, 0 erreur volontaire).

## 1 — Fix d'un faux « Constat » imprimé en dur (le cœur de la tranche)

La cellule Rastrigin (section 5) imprimait un récit **contraint par ses propres chiffres committés** :

> « l'ecart devient visible : la strategy la plus diversifiee (Composee) echappe mieux aux optima locaux »

…alors que l'output committé sur `origin/main` (vérifié firsthand, `git show`) affichait **Default 3,2 < SizeBased 4,4 < Composée 4,6** — la Composée **dernière**. Le commentaire d'en-tête de la cellule portait la même prémisse fausse (« sur Sphere, toutes les strategies convergent vers 0 » — contredit par les outputs des sections 2-4 : f(x) ≈ 4 à ≈ 42).

**Correctif** : le récit hardcoded est remplacé par un **classement dynamique calculé sur les valeurs mesurées** (`OrderBy` sur les trois moyennes, rang de la Composée dérivé des données) + caveat multi-seed. Immunitaire à la stochasticité : quel que soit le run committé, l'output imprimé reste cohérent avec ses propres nombres. Sur le run frais : `SizeBased 5,4 ≈ Composée 5,4 < Default 7,4` (rang 1/3) — la Composée passe de **dernière** (output précédent committé) à **première ex æquo** (celui-ci) : l'instabilité de l'ordre est le finding, pas l'ordre.

## 2 — Prose réalignée sur les outputs (les deux outputs committés servent de preuve)

- **md 7** (interprétation match) : « convergent vers des valeurs proches de 0 » → les f(x) vont de ≈11 à ≈38 sur le run committé ; un run unique par config ne départage pas (l'output précédent committé classait Random **meilleur**, le run frais le classe **dernier**)
- **md 17** (interprétation composée) : « combine les avantages de chaque primitive » → l'« amélioration » mesurée vaut **+26,4 %** sur l'output committé et **−9,5 %** sur le run frais : elle change de signe selon l'exécution, 5 runs non seedés ne départagent pas (même discipline que le sweep $p_c$ de MGS-1 #11941)
- **md 20** (prémisse section 5) : « toutes les stratégies convergent vers l'optimum global (0,0,0,0) » → **fausse**, reformulée : à ce budget, rien ne converge et le paysage convexe ne **départage** rien — le piège de la démonstration dégénérée est conservé, mais via la route factuelle correcte ; l'affirmation « la composition devient visible » devient explicitement l'**hypothèse testée**
- **Nouvelle cellule « Lecture du résultat »** après le test Rastrigin : ce que le test établit (le mécanisme de composition fonctionne, 3 niveaux enchaînés) vs ce qu'il ne dit pas (que la composition aide ou nuit — départager exigerait plus de runs / seed fixe), avec encart documentant le piège pédagogique évacué

## Preuves

- Re-exec : 11/11, 0 erreur, `execution_count` 1-11, 0 `probeAddresses` résiduel
- Les deux outputs committés (avant/après) cités en prose sont vérifiables : `git show origin/main:MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-2-Composition.ipynb` (cellules 6/16/21 : 21/11/29 · 25,8/19,0/+26,4 % · 3,2/4,4/4,6)
- `git diff --stat` : 1 fichier, +584/−150

## Diagnostic dérive (C.4, cf #8364)

Les outputs changent (GA non seedé + moteur rebase #10859). Cause = **(e) stochasticité non-seedée** + **cause première additionnelle : prose narrative préfaite contredite par ses propres outputs** (le « Constat » affirmait l'inverse des chiffres committés — classe antérieure de dérive, le récit avait été écrit pour un résultat espéré jamais mesuré). Verdict : **CAUSE_FIXED pour le récit** — le constat est désormais dérivé des valeurs mesurées au moment de l'exécution (dynamique), et la prose ne claim que des faits stables (mécanisme fonctionne ; l'ordre n'est pas stable à 5 runs). La stochasticité elle-même est documentée in situ.

## Résiduel (hors scope, tranches suivantes #1203)

- 20 notebooks MGS restants aux outputs pré-rebase (MGS-5/16/18 prioritaires — sweeps multi-configs)
- Le classement Rastrigin exigerait un protocole seedé pour départager (plus de runs, seed fixe) — noté dans la cellule Lecture
