### PR TITLE
docs(decinfer,#11601): DecInfer-10 densification 1272->1681 - 5 lectures de resultats ancrees

### DIFF
--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-10-Thompson-Sampling.ipynb
@@ -473,6 +473,21 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-di10-interp-a",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le posterior se resserre au rythme des données\n",
+    "\n",
+    "À N=5 tirages, le posterior est encore optimiste — moyenne 0,857 pour une vraie moyenne de 0,70 — et son intervalle à 95 % monte jusqu'à 1,000 : cinq observations favorables n'ont encore rien exclu. À N=200, la moyenne descend à 0,663 et l'intervalle [0,598, 0,728] contient la vraie valeur 0,70 : le moteur a digéré les données contradictoires.\n",
+    "\n",
+    "Deux points à retenir pour la suite :\n",
+    "\n",
+    "- **la largeur de l'intervalle passe de 0,385 (N=5) à 0,130 (N=200)** : multiplier les données par 40 ne divise l'incertitude que par ~3 — les premières observations achètent beaucoup plus d'information que les suivantes, et le coût d'apprentissage marginal décroît vite ;\n",
+    "- **l'incertitude reste quantifiée à chaque instant**. Thompson Sampling (section 5) ne tirera pas parti du seul point estimé 0,663 mais de la *distribution* entière : c'est parce que l'intervalle est explicite que l'algorithme saura *où* il manque d'information.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-15063fa1",
    "metadata": {
     "papermill": {
@@ -648,6 +663,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-di10-interp-b",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : pourquoi le moteur compilé change tout\n",
+    "\n",
+    "La mesure donne **444,5 ms** pour la compilation (une seule fois, au constructeur) contre **0,040 ms** par re-inférence — un rapport de **11243x**. C'est ce chiffre qui rend la section suivante possible : un bandit à K=3 bras et T=200 pas exige une inférence à chaque bras joué, soit plusieurs centaines d'appels au moteur. À 444,5 ms l'appel, un seul run coûterait plusieurs minutes ; à 0,040 ms, la boucle complète est imperceptible.\n",
+    "\n",
+    "Infer.NET suit le modèle « compiler une fois, inférer souvent » : la première inférence génère du code spécialisé pour le graphe de facteurs (les 444,5 ms), les suivantes se contentent d'observer de nouvelles données et de relancer l'inférence sur ce code déjà compilé. C'est la différence structurelle entre un moteur probabiliste compilé et un échantillonneur générique qui repartirait de zéro à chaque question.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-5ce3ed6d",
    "metadata": {
     "papermill": {
@@ -807,6 +834,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-di10-interp-c",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : la trace d'un run de Thompson\n",
+    "\n",
+    "La sortie raconte l'algorithme pas à pas :\n",
+    "\n",
+    "- **Pas 1** : l'échantillon posterior du bras 2 sort à 0,67 et gagne l'argmax — alors que le bras 3 (vraie moyenne 0,80) n'a encore rien montré. C'est *l'exploration par échantillonnage* : un posterior encore large peut produire un échantillon élevé par pur hasard, et l'algorithme va vérifier.\n",
+    "- **Pas 4-5** : le bras 2 déçoit (deux échecs, sa moyenne retombe à 0,40) ; le bras 1 prend le relais deux essais, puis cesse presque d'être joué — **7 tirages seulement** en 200 pas, avec un posterior final de moyenne 0,33 (vraie 0,20) : éliminé tôt, mais jamais définitivement, car un posterior reste une distribution — un échantillon élevé pourrait le faire revenir.\n",
+    "- **Pas 51 à 200** : le bras 3 capte l'essentiel des tirages (**165 sur 200**), sa moyenne posterior monte à 0,78 ; les deux autres descendent vers leurs vraies moyennes (0,33 et 0,57).\n",
+    "\n",
+    "Bilan du run : **147 récompenses sur 200**, contre ~160 pour l'oracle qui connaîtrait les vraies moyennes — un regret de run d'environ 13. Toute la compétition exploration/exploitation tient dans cet écart.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-6229c611",
    "metadata": {
     "papermill": {
@@ -948,6 +991,24 @@
     "Console.WriteLine();\n",
     "Console.WriteLine($\"=> Thompson ({regretFinal[2]:F1}) <= epsilon-greedy ({regretFinal[0]:F1}) : l exploration bayesienne\");\n",
     "Console.WriteLine($\"   ciblee par le posterior exploite l incertitude la ou l information manque (Prong-B).\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-di10-interp-d",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : Thompson domine les deux baselines\n",
+    "\n",
+    "Sur 15 runs de T=200 pas, le regret cumulé moyen s'établit à **6,1 pour Thompson**, contre **17,5 pour epsilon-greedy** et **19,3 pour UCB1** — Thompson fait environ trois fois mieux que les deux baselines sur ce terrain.\n",
+    "\n",
+    "Le *pourquoi* se lit dans la mécanique de chaque politique :\n",
+    "\n",
+    "- **epsilon-greedy** explore au hasard : ses 10 % de tirages aléatoires continuent de sonder le bras le plus mauvais même quand plus rien ne justifie de le tester — du regret payé pour aucune information nouvelle ;\n",
+    "- **UCB1** explore par bonus d'optimisme déterministe : efficace, mais son bonus est indexé sur un compteur de visites, pas sur une incertitude *calibrée* par les données observées ;\n",
+    "- **Thompson** alloue l'exploration exactement là où le posterior est encore large — les bras sûrs d'eux-mêmes sont quasi toujours joués, les autres sondés juste ce qu'il faut.\n",
+    "\n",
+    "Réserve honnête : 15 runs, c'est une moyenne courte (l'écart-type n'est pas affiché) — cette cellule est une *illustration pédagogique* du mécanisme, pas un benchmark statistique ; la section théorique ci-dessous donne le cadre du regret logarithmique.\n"
    ]
   },
   {
@@ -1099,6 +1160,18 @@
     "int best = Array.IndexOf(gagnants, gagnants.Max());\n",
     "Console.WriteLine($\"=> Bras declare meilleur : bras {best+1} (theta*={vraiB[best]}).\");\n",
     "Console.WriteLine($\"   Si P > 0.95, on peut arreter : identification du meilleur bras avec confiance.\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-di10-interp-e",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : une autre question, le même moteur\n",
+    "\n",
+    "Après seulement 60 tirages Thompson, l'échantillonnage des posteriors donne **P(bras 3 meilleur) = 0,975**, contre 0,021 pour le bras 2 et 0,004 pour le bras 1 — la règle d'arrêt « P > 0,95 » est déjà franchie. Les posteriors racontent la même histoire en creux : Beta(41,0, 8,0) pour le bras 3 — un posterior concentré, riche en données — contre Beta(2,0, 4,0) pour le bras 1, à peine visité, où le prior uniforme Beta(1,1) se devine encore dans les petits compteurs.\n",
+    "\n",
+    "La nuance conceptuelle mérite d'être soulignée : **minimiser le regret** (jouer bien maintenant) et **identifier le meilleur bras** (savoir avec confiance) sont deux objectifs distincts. Le premier tolère de continuer à jouer un bras presque optimal ; le second exige d'accumuler assez de preuves pour pouvoir arrêter. Thompson Sampling sert les deux avec la même machinerie bayésienne — seule change la question posée aux échantillons : « quel bras jouer ce pas ? » ou « quel bras est le meilleur, et à quel niveau de confiance ? ».\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/lean #11936

See #11601 (tranche prioritaire DecInfer-10 — umbrella, jamais Closes)

## Summary

Densification markdown-only du notebook C#/Infer.NET DecInfer-10-Thompson-Sampling : **1272 → 1681** chars prose/cellule code (cible umbrella ≥1500, plage standard 1500-2000). **5 cellules d'interprétation** insérées, chacune **immédiatement après la cellule de code dont elle commente l'output** (règle cell-interpretation-ordering — les 5 cellules clés : convergence, mesure runtime, trace multi-bras, comparaison de regret, best-arm identification n'avaient aucune lecture de résultat).

Zéros code touché : diff = 5 cellules markdown ajoutées (74 lignes), aucune cellule code modifiée → C.3 dispense de re-exécution (markdown-only), outputs committés intacts (H.3 Passed au commit).

## Mesures (garde-fous acceptance #11601)

| Contrôle | Résultat |
|---|---|
| `pedagogy_density.py` avant → après | 1272 → **1681** (prose 16536 → 21865 chars, 13 code cells) ✓ ≥1500 |
| `scan_cell_ordering.py` (structurel) | **1 scanned, 0 finding** ✓ |
| `scan_cell_ordering.py --check-interp-anchor` (advisory) | **0 candidate** ✓ (une première rédaction citait « vraie moyenne 0,20 » qui vit dans le src mais pas l'output de la cellule précédente — reformulée) |
| `detect_markdown_rendering.py --check` | **OK, no new ERROR-level violation** ✓ |
| Pre-commit H.3 + source-list + oversized-md | Passed / Passed / Passed ✓ |

Ancrage : le script d'insertion **assert** que chaque valeur pivot citée (`0,857`, `11243`, `147/200`, `6,1`, `0,975`) est présente dans l'output de la cellule précédée — échec = pas d'écriture.

## Pourquoi la tranche a changé de cible en cours de cycle (traçabilité #11601)

Le claim initial portait sur QC-Py-26 (tranche prioritaire listée dans le body). Mesure fresh au claim : **1858 — déjà dans la plage cible 1500-2000** (la liste c.1331p258 datait d'avant d'autres enrichissements). Claim re-scopé sur DecInfer-10 (1272 mesuré) avec `[RELEASED]`/`[CLAIMED]` commentés sur l'issue.

**Findings reportés sur #11601** (non traités ici, hors scope de cette tranche) : SW-10-CSharp-RDFStar mesuré **below 1200** — résidu round 1 non couvert par #11594 ; rlpt_4_dpo_vs_ppo mesuré 1219 (candidat round 2 suivant).

## Validation

- Diff : 1 fichier, +74/−1 (la −1 = newline final du round-trip json ident=1, vérifié byte-stable sur le reste).
- Notebook : 37 cellules (13 code, toutes `execution_count != null` + outputs réels, inchangés).
