### PR TITLE
fix(notebooks,#11947): tranche 1 heading_in_list - indices d'exercices en gras (DecInfer + CaseStudies)

### DIFF
--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/solution/Diagnostic-Medical.ipynb
@@ -648,11 +648,11 @@
     "**Contexte** : La classification actuelle (Normal/Pre-diabete/Diabete) est trop grossiere. Un score numérique permet de prioriser les patients et de suivre l'evolution dans le temps.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Combinez la glycémie à jeun, l'HbA1c et le nombre de symptomes en un score pondere\n",
-    "- # Indice 2 : Normalisez chaque indicateur entre 0 et 1 avant de les combiner\n",
-    "- # Étape 1 : Définir les seuils de normalisation pour chaque indicateur\n",
-    "- # Étape 2 : Calculer le score pondere (ex: 40% glycémie, 40% HbA1c, 20% symptomes)\n",
-    "- # Étape 3 : Tester sur les 3 patients de reference et verifier la coherence avec la classification"
+    "- **Indice 1** : Combinez la glycémie à jeun, l'HbA1c et le nombre de symptomes en un score pondere\n",
+    "- **Indice 2** : Normalisez chaque indicateur entre 0 et 1 avant de les combiner\n",
+    "- **Étape 1** : Définir les seuils de normalisation pour chaque indicateur\n",
+    "- **Étape 2** : Calculer le score pondere (ex: 40% glycémie, 40% HbA1c, 20% symptomes)\n",
+    "- **Étape 3** : Tester sur les 3 patients de reference et verifier la coherence avec la classification"
    ]
   },
   {
@@ -1112,11 +1112,11 @@
     "**Contexte** : L'heuristique actuelle mesure le « clutter » résiduel — la somme des inadéquations cliniques (`_coherence_hypothese`) des hypothèses encore candidates. Une heuristique basee uniquement sur l'HbA1c pourrait etre plus rapide mais moins precise.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Implementez une heuristique `h_simple(etat)` qui n'utilise que l'HbA1c du patient\n",
-    "- # Indice 2 : Comparez le nombre d'itérations et le niveau de confiance final\n",
-    "- # Étape 1 : Définir la nouvelle heuristique dans une sous-classe de `AStarDiagnostic`\n",
-    "- # Étape 2 : Executer la recherche sur les 3 patients de test\n",
-    "- # Étape 3 : Comparer les résultats (itérations, confiance, hypotheses) avec l'heuristique originale"
+    "- **Indice 1** : Implementez une heuristique `h_simple(etat)` qui n'utilise que l'HbA1c du patient\n",
+    "- **Indice 2** : Comparez le nombre d'itérations et le niveau de confiance final\n",
+    "- **Étape 1** : Définir la nouvelle heuristique dans une sous-classe de `AStarDiagnostic`\n",
+    "- **Étape 2** : Executer la recherche sur les 3 patients de test\n",
+    "- **Étape 3** : Comparer les résultats (itérations, confiance, hypotheses) avec l'heuristique originale"
    ]
   },
   {
@@ -2033,11 +2033,11 @@
     "**Contexte** : Les interactions medicamenteuses sont une source majeure de risques. L'insuline combinee a certains antidiabetiques oraux augmente le risque d'hypoglycemie severe.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Ajoutez une contrainte Z3 qui limite la dose d'insuline si le patient prend aussi de la metformine\n",
-    "- # Indice 2 : Utilisez `Implies()` et `And()` pour exprimer les conditions\n",
-    "- # Étape 1 : Ajouter la variable booleenne `hypoglycemie_risque` au modèle\n",
-    "- # Étape 2 : Définir les contraintes d'interaction\n",
-    "- # Étape 3 : Tester avec un patient qui a des antecedents d'hypoglycemie et verifier que le solveur refuse certaines combinaisons"
+    "- **Indice 1** : Ajoutez une contrainte Z3 qui limite la dose d'insuline si le patient prend aussi de la metformine\n",
+    "- **Indice 2** : Utilisez `Implies()` et `And()` pour exprimer les conditions\n",
+    "- **Étape 1** : Ajouter la variable booleenne `hypoglycemie_risque` au modèle\n",
+    "- **Étape 2** : Définir les contraintes d'interaction\n",
+    "- **Étape 3** : Tester avec un patient qui a des antecedents d'hypoglycemie et verifier que le solveur refuse certaines combinaisons"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Diagnostic-Medical/student/Diagnostic-Medical.ipynb
@@ -468,11 +468,11 @@
     "**Contexte** : La classification actuelle (Normal/Pre-diabete/Diabete) est trop grossiere. Un score numérique permet de prioriser les patients et de suivre l'evolution dans le temps.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Combinez la glycémie à jeun, l'HbA1c et le nombre de symptomes en un score pondere\n",
-    "- # Indice 2 : Normalisez chaque indicateur entre 0 et 1 avant de les combiner\n",
-    "- # Étape 1 : Définir les seuils de normalisation pour chaque indicateur\n",
-    "- # Étape 2 : Calculer le score pondere (ex: 40% glycémie, 40% HbA1c, 20% symptomes)\n",
-    "- # Étape 3 : Tester sur les 3 patients de reference et verifier la coherence avec la classification"
+    "- **Indice 1** : Combinez la glycémie à jeun, l'HbA1c et le nombre de symptomes en un score pondere\n",
+    "- **Indice 2** : Normalisez chaque indicateur entre 0 et 1 avant de les combiner\n",
+    "- **Étape 1** : Définir les seuils de normalisation pour chaque indicateur\n",
+    "- **Étape 2** : Calculer le score pondere (ex: 40% glycémie, 40% HbA1c, 20% symptomes)\n",
+    "- **Étape 3** : Tester sur les 3 patients de reference et verifier la coherence avec la classification"
    ]
   },
   {
@@ -728,11 +728,11 @@
     "**Contexte** : L'heuristique actuelle utilise une combinaison lineaire d'evidences cliniques. Une heuristique basee uniquement sur l'HbA1c pourrait etre plus rapide mais moins precise.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Implementez une heuristique `h_simple(etat)` qui n'utilise que l'HbA1c du patient\n",
-    "- # Indice 2 : Comparez le nombre d'itérations et le niveau de confiance final\n",
-    "- # Étape 1 : Définir la nouvelle heuristique dans une sous-classe de `AStarDiagnostic`\n",
-    "- # Étape 2 : Executer la recherche sur les 3 patients de test\n",
-    "- # Étape 3 : Comparer les résultats (itérations, confiance, hypotheses) avec l'heuristique originale"
+    "- **Indice 1** : Implementez une heuristique `h_simple(etat)` qui n'utilise que l'HbA1c du patient\n",
+    "- **Indice 2** : Comparez le nombre d'itérations et le niveau de confiance final\n",
+    "- **Étape 1** : Définir la nouvelle heuristique dans une sous-classe de `AStarDiagnostic`\n",
+    "- **Étape 2** : Executer la recherche sur les 3 patients de test\n",
+    "- **Étape 3** : Comparer les résultats (itérations, confiance, hypotheses) avec l'heuristique originale"
    ]
   },
   {
@@ -1151,11 +1151,11 @@
     "**Contexte** : Les interactions medicamenteuses sont une source majeure de risques. L'insuline combinee a certains antidiabetiques oraux augmente le risque d'hypoglycemie severe.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Ajoutez une contrainte Z3 qui limite la dose d'insuline si le patient prend aussi de la metformine\n",
-    "- # Indice 2 : Utilisez `Implies()` et `And()` pour exprimer les conditions\n",
-    "- # Étape 1 : Ajouter la variable booleenne `hypoglycemie_risque` au modèle\n",
-    "- # Étape 2 : Définir les contraintes d'interaction\n",
-    "- # Étape 3 : Tester avec un patient qui a des antecedents d'hypoglycemie et verifier que le solveur refuse certaines combinaisons"
+    "- **Indice 1** : Ajoutez une contrainte Z3 qui limite la dose d'insuline si le patient prend aussi de la metformine\n",
+    "- **Indice 2** : Utilisez `Implies()` et `And()` pour exprimer les conditions\n",
+    "- **Étape 1** : Ajouter la variable booleenne `hypoglycemie_risque` au modèle\n",
+    "- **Étape 2** : Définir les contraintes d'interaction\n",
+    "- **Étape 3** : Tester avec un patient qui a des antecedents d'hypoglycemie et verifier que le solveur refuse certaines combinaisons"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/solution/Oncology-Planning.ipynb
@@ -376,11 +376,11 @@
     "**Contexte** : L'ontologie actuelle contient 4 medicaments. En pratique, les protocoles oncologiques combinent davantage de molecules, et les interactions croisees sont critiques.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Ajoutez \"Paclitaxel\" (toxicite_renale=False, incompatible avec \"Docetaxel\") et \"Carboplatine\" (toxicite_renale=True, incompatible avec \"Cisplatine\")\n",
-    "- # Indice 2 : Verifiez qu'un protocole [\"Cisplatine\", \"Carboplatine\"] declenche bien une alerte d'incompatibilite\n",
-    "- # Étape 1 : Ajouter les nouveaux medicaments au dictionnaire `medicaments`\n",
-    "- # Étape 2 : Peupler le graphe RDF avec les nouveaux triplets\n",
-    "- # Étape 3 : Tester la fonction `verifier_prescription` avec des combinaisons incluant les nouveaux medicaments"
+    "- **Indice 1** : Ajoutez \"Paclitaxel\" (toxicite_renale=False, incompatible avec \"Docetaxel\") et \"Carboplatine\" (toxicite_renale=True, incompatible avec \"Cisplatine\")\n",
+    "- **Indice 2** : Verifiez qu'un protocole [\"Cisplatine\", \"Carboplatine\"] declenche bien une alerte d'incompatibilite\n",
+    "- **Étape 1** : Ajouter les nouveaux medicaments au dictionnaire `medicaments`\n",
+    "- **Étape 2** : Peupler le graphe RDF avec les nouveaux triplets\n",
+    "- **Étape 3** : Tester la fonction `verifier_prescription` avec des combinaisons incluant les nouveaux medicaments"
    ]
   },
   {
@@ -623,11 +623,11 @@
     "**Contexte** : Le prior actuel est `[0.1, 0.6, 0.3]` (10% Resistants, 60% Normaux, 30% Sensibles). Si la population est différente, le diagnostic change.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Modifiez `profil_probs` dans la méthode `model()` pour tester : `[0.33, 0.34, 0.33]` (uniforme), `[0.05, 0.90, 0.05]` (peu de sensibles)\n",
-    "- # Indice 2 : Relancez l'inference SVI et comparez les probabilites a posteriori du profil\n",
-    "- # Étape 1 : Créer une fonction qui accepte le prior en paramètre\n",
-    "- # Étape 2 : Tester 3 configurations de prior différentes\n",
-    "- # Étape 3 : Afficher les posterieurs dans un tableau comparatif"
+    "- **Indice 1** : Modifiez `profil_probs` dans la méthode `model()` pour tester : `[0.33, 0.34, 0.33]` (uniforme), `[0.05, 0.90, 0.05]` (peu de sensibles)\n",
+    "- **Indice 2** : Relancez l'inference SVI et comparez les probabilites a posteriori du profil\n",
+    "- **Étape 1** : Créer une fonction qui accepte le prior en paramètre\n",
+    "- **Étape 2** : Tester 3 configurations de prior différentes\n",
+    "- **Étape 3** : Afficher les posterieurs dans un tableau comparatif"
    ]
   },
   {
@@ -891,11 +891,11 @@
     "**Contexte** : Le contrat actuel enregistre un seul plan. En pratique, les plans peuvent etre modifiés plusieurs fois, et il faut tracer qui a fait quoi et quand.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Ajoutez un attribut `self.historique = []` qui stocke chaque modification\n",
-    "- # Indice 2 : Chaque entree du journal doit contenir : horodatage, auteur, action, hash du plan\n",
-    "- # Étape 1 : Ajouter l'attribut `historique` et le mettre a jour a chaque appel de `enregistrer_plan`\n",
-    "- # Étape 2 : Implementer une méthode `afficher_historique()` qui affiche le journal\n",
-    "- # Étape 3 : Tester en modifiant le plan plusieurs fois et verifier que l'historique est complet"
+    "- **Indice 1** : Ajoutez un attribut `self.historique = []` qui stocke chaque modification\n",
+    "- **Indice 2** : Chaque entree du journal doit contenir : horodatage, auteur, action, hash du plan\n",
+    "- **Étape 1** : Ajouter l'attribut `historique` et le mettre a jour a chaque appel de `enregistrer_plan`\n",
+    "- **Étape 2** : Implementer une méthode `afficher_historique()` qui affiche le journal\n",
+    "- **Étape 3** : Tester en modifiant le plan plusieurs fois et verifier que l'historique est complet"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
+++ b/MyIA.AI.Notebooks/CaseStudies/Oncology-Planning/student/Oncology-Planning.ipynb
@@ -340,11 +340,11 @@
     "**Contexte** : L'ontologie actuelle contient 4 medicaments. En pratique, les protocoles oncologiques combinent davantage de molecules, et les interactions croisees sont critiques.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Ajoutez \"Paclitaxel\" (toxicite_renale=False, incompatible avec \"Docetaxel\") et \"Carboplatine\" (toxicite_renale=True, incompatible avec \"Cisplatine\")\n",
-    "- # Indice 2 : Verifiez qu'un protocole [\"Cisplatine\", \"Carboplatine\"] declenche bien une alerte d'incompatibilite\n",
-    "- # Étape 1 : Ajouter les nouveaux medicaments au dictionnaire `medicaments`\n",
-    "- # Étape 2 : Peupler le graphe RDF avec les nouveaux triplets\n",
-    "- # Étape 3 : Tester la fonction `verifier_prescription` avec des combinaisons incluant les nouveaux medicaments"
+    "- **Indice 1** : Ajoutez \"Paclitaxel\" (toxicite_renale=False, incompatible avec \"Docetaxel\") et \"Carboplatine\" (toxicite_renale=True, incompatible avec \"Cisplatine\")\n",
+    "- **Indice 2** : Verifiez qu'un protocole [\"Cisplatine\", \"Carboplatine\"] declenche bien une alerte d'incompatibilite\n",
+    "- **Étape 1** : Ajouter les nouveaux medicaments au dictionnaire `medicaments`\n",
+    "- **Étape 2** : Peupler le graphe RDF avec les nouveaux triplets\n",
+    "- **Étape 3** : Tester la fonction `verifier_prescription` avec des combinaisons incluant les nouveaux medicaments"
    ]
   },
   {
@@ -497,11 +497,11 @@
     "**Contexte** : Le prior actuel est `[0.1, 0.6, 0.3]` (10% Resistants, 60% Normaux, 30% Sensibles). Si la population est différente, le diagnostic change.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Modifiez `profil_probs` dans la méthode `model()` pour tester : `[0.33, 0.34, 0.33]` (uniforme), `[0.05, 0.90, 0.05]` (peu de sensibles)\n",
-    "- # Indice 2 : Relancez l'inference SVI et comparez les probabilites a posteriori du profil\n",
-    "- # Étape 1 : Créer une fonction qui accepte le prior en paramètre\n",
-    "- # Étape 2 : Tester 3 configurations de prior différentes\n",
-    "- # Étape 3 : Afficher les posterieurs dans un tableau comparatif"
+    "- **Indice 1** : Modifiez `profil_probs` dans la méthode `model()` pour tester : `[0.33, 0.34, 0.33]` (uniforme), `[0.05, 0.90, 0.05]` (peu de sensibles)\n",
+    "- **Indice 2** : Relancez l'inference SVI et comparez les probabilites a posteriori du profil\n",
+    "- **Étape 1** : Créer une fonction qui accepte le prior en paramètre\n",
+    "- **Étape 2** : Tester 3 configurations de prior différentes\n",
+    "- **Étape 3** : Afficher les posterieurs dans un tableau comparatif"
    ]
   },
   {
@@ -664,11 +664,11 @@
     "**Contexte** : Le contrat actuel enregistre un seul plan. En pratique, les plans peuvent etre modifiés plusieurs fois, et il faut tracer qui a fait quoi et quand.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Ajoutez un attribut `self.historique = []` qui stocke chaque modification\n",
-    "- # Indice 2 : Chaque entree du journal doit contenir : horodatage, auteur, action, hash du plan\n",
-    "- # Étape 1 : Ajouter l'attribut `historique` et le mettre a jour a chaque appel de `enregistrer_plan`\n",
-    "- # Étape 2 : Implementer une méthode `afficher_historique()` qui affiche le journal\n",
-    "- # Étape 3 : Tester en modifiant le plan plusieurs fois et verifier que l'historique est complet"
+    "- **Indice 1** : Ajoutez un attribut `self.historique = []` qui stocke chaque modification\n",
+    "- **Indice 2** : Chaque entree du journal doit contenir : horodatage, auteur, action, hash du plan\n",
+    "- **Étape 1** : Ajouter l'attribut `historique` et le mettre a jour a chaque appel de `enregistrer_plan`\n",
+    "- **Étape 2** : Implementer une méthode `afficher_historique()` qui affiche le journal\n",
+    "- **Étape 3** : Tester en modifiant le plan plusieurs fois et verifier que l'historique est complet"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-1-Utility-Foundations.ipynb
@@ -668,9 +668,9 @@
     "5. Testez avec une fonction d'utilite convexe (amateur de risque) et observez si la propriete tient toujours\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Utilisez la classe `Loterie<double>` définie precedemment\n",
-    "- # Indice 2 : Une fonction convexe comme U(x) = x^2 correspond a un amateur de risque\n",
-    "- # Indice 3 : L'axiome d'indépendance est toujours respecte quand on utilise une fonction d'utilite valide"
+    "- **Indice 1** : Utilisez la classe `Loterie<double>` définie precedemment\n",
+    "- **Indice 2** : Une fonction convexe comme U(x) = x^2 correspond a un amateur de risque\n",
+    "- **Indice 3** : L'axiome d'indépendance est toujours respecte quand on utilise une fonction d'utilite valide"
    ]
   },
   {
@@ -1374,9 +1374,9 @@
     "4. Determinez si le second test est justifie en comparant E[U(avec test)] vs E[U(sans test)]\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : L'esperance sur le second test utilise la loi des probabilites totales : P(test2+) x E[U|test2+] + P(test2-) x E[U|test2-]\n",
-    "- # Indice 2 : Le cout du test (-500) s'ajoute a l'utilite de chaque outcome quand on fait le test\n",
-    "- # étape 3 : Utilisez `Variable.Case` ou `Variable.If` pour conditionner le second test sur la variable malade"
+    "- **Indice 1** : L'esperance sur le second test utilise la loi des probabilites totales : P(test2+) x E[U|test2+] + P(test2-) x E[U|test2-]\n",
+    "- **Indice 2** : Le cout du test (-500) s'ajoute a l'utilite de chaque outcome quand on fait le test\n",
+    "- **étape 3** : Utilisez `Variable.Case` ou `Variable.If` pour conditionner le second test sur la variable malade"
    ]
   },
   {
@@ -2421,9 +2421,9 @@
     "5. **Bonus** : Tester avec une richesse initiale différente (ex: 1000 EUR) et observer comment la prime CARA reste constante mais CRRA change\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Pour trouver l'equivalent certain, utilisez une recherche par dichotomie sur l'intervalle [perteBasse - 100, gainHaut + 100]\n",
-    "- # Indice 2 : Pour CRRA, traitez le cas rho = 1 separement avec `Math.Abs(rho - 1) < 1e-6` et utilisez `Math.Log(x)` dans ce cas\n",
-    "- # étape 3 : Prime de risque = E[gain] - CE. Si la prime est positive, l'agent est averse au risque"
+    "- **Indice 1** : Pour trouver l'equivalent certain, utilisez une recherche par dichotomie sur l'intervalle [perteBasse - 100, gainHaut + 100]\n",
+    "- **Indice 2** : Pour CRRA, traitez le cas rho = 1 separement avec `Math.Abs(rho - 1) < 1e-6` et utilisez `Math.Log(x)` dans ce cas\n",
+    "- **étape 3** : Prime de risque = E[gain] - CE. Si la prime est positive, l'agent est averse au risque"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-3-Utility-Money.ipynb
@@ -1604,10 +1604,10 @@
     "4. Verifiez la dominance de second ordre (SSD) entre les fonds restants\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Pour FSD, comparez les CDFs : F_A domine F_B si F_A(x) <= F_B(x) pour tout x\n",
-    "- # Indice 2 : Utilisez la classe `DiscreteLottery` définie precedemment et sa méthode `CDF()`\n",
-    "- # Indice 3 : Pour SSD, comparez les integrales des CDFs : integrale(F_A) <= integrale(F_B) pour tout x\n",
-    "- # Étape 2 : Comparez toutes les 6 paires possibles parmi 4 fonds"
+    "- **Indice 1** : Pour FSD, comparez les CDFs : F_A domine F_B si F_A(x) <= F_B(x) pour tout x\n",
+    "- **Indice 2** : Utilisez la classe `DiscreteLottery` définie precedemment et sa méthode `CDF()`\n",
+    "- **Indice 3** : Pour SSD, comparez les integrales des CDFs : integrale(F_A) <= integrale(F_B) pour tout x\n",
+    "- **Étape 2** : Comparez toutes les 6 paires possibles parmi 4 fonds"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-4-Multi-Attribute.ipynb
@@ -1097,9 +1097,9 @@
     "5. Appliquez la forme additive pour classer les appartements\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Le pire scénario est celui ou TOUS les attributs sont a leur valeur minimale\n",
-    "- # Indice 2 : Un swing \"Prix: 500k -> 200k\" peut etre plus ou moins important qu'un swing \"Trajet: 60min -> 10min\"\n",
-    "- # Indice 3 : Les points refletent la valeur subjective de chaque amelioration, pas l'importance abstraite de l'attribut"
+    "- **Indice 1** : Le pire scénario est celui ou TOUS les attributs sont a leur valeur minimale\n",
+    "- **Indice 2** : Un swing \"Prix: 500k -> 200k\" peut etre plus ou moins important qu'un swing \"Trajet: 60min -> 10min\"\n",
+    "- **Indice 3** : Les points refletent la valeur subjective de chaque amelioration, pas l'importance abstraite de l'attribut"
    ]
   },
   {
@@ -1569,9 +1569,9 @@
     "4. Interpretez le signe de K : les attributs sont-ils complements ou substituts ?\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : K < 0 signifie que les attributs sont substituts (un bon compense un mauvais)\n",
-    "- # Indice 2 : La différence entre U_mult et U_add est maximale quand les attributs sont extremes (0 ou 1)\n",
-    "- # Indice 3 : Si K est proche de 0, la forme additive est une bonne approximation"
+    "- **Indice 1** : K < 0 signifie que les attributs sont substituts (un bon compense un mauvais)\n",
+    "- **Indice 2** : La différence entre U_mult et U_add est maximale quand les attributs sont extremes (0 ou 1)\n",
+    "- **Indice 3** : Si K est proche de 0, la forme additive est une bonne approximation"
    ]
   },
   {
@@ -2656,9 +2656,9 @@
     "4. Identifiez les poids critiques (ceux dont la variation fait changer le choix)\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Enregistrez le classement complet (pas seulement le meilleur) pour detecter les changements subtils\n",
-    "- # Indice 2 : Un poids est \"critique\" si une variation de 5% ou moins fait changer le choix optimal\n",
-    "- # Indice 3 : Les poids non-critiques peuvent etre ajustes sans affecter la decision"
+    "- **Indice 1** : Enregistrez le classement complet (pas seulement le meilleur) pour detecter les changements subtils\n",
+    "- **Indice 2** : Un poids est \"critique\" si une variation de 5% ou moins fait changer le choix optimal\n",
+    "- **Indice 3** : Les poids non-critiques peuvent etre ajustes sans affecter la decision"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-6-Value-Information.ipynb
@@ -602,9 +602,9 @@
     "5. Conclure : un oracle coutant 25 points, faut-il l'acheter ?\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Sans information, E[U(a)] = P(porteur) * U(a, porteur) + P(defavorable) * U(a, defavorable)\n",
-    "- # Indice 2 : Avec information parfaite, pour chaque etat, on choisit la meilleure action\n",
-    "- # Indice 3 : EVPI = E[max U|omega] - max E[U]"
+    "- **Indice 1** : Sans information, E[U(a)] = P(porteur) * U(a, porteur) + P(defavorable) * U(a, defavorable)\n",
+    "- **Indice 2** : Avec information parfaite, pour chaque etat, on choisit la meilleure action\n",
+    "- **Indice 3** : EVPI = E[max U|omega] - max E[U]"
    ]
   },
   {
@@ -1637,9 +1637,9 @@
     "4. Comparer les EVSI nets et recommender la meilleure source\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : P(test+) = sensibilite * P(fav) + (1-specificite) * (1-P(fav))\n",
-    "- # Indice 2 : P(fav|test+) = sensibilite * P(fav) / P(test+)\n",
-    "- # Indice 3 : EVSI_net = EVSI - cout ; choisir la source avec le meilleur EVSI net"
+    "- **Indice 1** : P(test+) = sensibilite * P(fav) + (1-specificite) * (1-P(fav))\n",
+    "- **Indice 2** : P(fav|test+) = sensibilite * P(fav) / P(test+)\n",
+    "- **Indice 3** : EVSI_net = EVSI - cout ; choisir la source avec le meilleur EVSI net"
    ]
   },
   {
@@ -4183,11 +4183,11 @@
     "**Sensibilite de l'analyse** : P(signal croissance|croissance) = 80%, P(signal stagnation|stagnation) = 60%, P(signal recession|recession) = 75%. Pour les autres cas, la probabilite est repartie uniformement.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Sans information, calculer E[U(action)] = Somme P(etat) * U(action, etat) pour chaque action\n",
-    "- # Indice 2 : EVPI = Somme P(etat) * max_action U(action, etat) - max_action E[U(action)]\n",
-    "- # Étape 1 : Determiner la decision optimale sans information et calculer l'EVPI\n",
-    "- # Étape 2 : Construire la matrice de vraisemblance du signal (3x3) et calculer les posteriors par Bayes\n",
-    "- # Étape 3 : Calculer l'EVSI et conclure si l'analyse economique (5k EUR) est rentable"
+    "- **Indice 1** : Sans information, calculer E[U(action)] = Somme P(etat) * U(action, etat) pour chaque action\n",
+    "- **Indice 2** : EVPI = Somme P(etat) * max_action U(action, etat) - max_action E[U(action)]\n",
+    "- **Étape 1** : Determiner la decision optimale sans information et calculer l'EVPI\n",
+    "- **Étape 2** : Construire la matrice de vraisemblance du signal (3x3) et calculer les posteriors par Bayes\n",
+    "- **Étape 3** : Calculer l'EVSI et conclure si l'analyse economique (5k EUR) est rentable"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-7-Expert-Systems.ipynb
@@ -901,9 +901,9 @@
     "4. Comparer les deux decisions et expliquer les différences\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Minimax = argmax_a(min_s U(a,s)), trouver le pire cas de chaque provider\n",
-    "- # Indice 2 : Regret(a,s) = max_a'(U(a',s)) - U(a,s), la perte relative a l'optimum\n",
-    "- # Indice 3 : Comparez les deux résultats. Si différents, identifiez quel critère est le plus adapte selon le contexte"
+    "- **Indice 1** : Minimax = argmax_a(min_s U(a,s)), trouver le pire cas de chaque provider\n",
+    "- **Indice 2** : Regret(a,s) = max_a'(U(a',s)) - U(a,s), la perte relative a l'optimum\n",
+    "- **Indice 3** : Comparez les deux résultats. Si différents, identifiez quel critère est le plus adapte selon le contexte"
    ]
   },
   {
@@ -1933,9 +1933,9 @@
     "4. Recommander un choix pour un entrepreneur risk-averse (gamma = 0.2)\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Pour gamma=0.3, H(Centre-ville) = 0.3*200 + 0.7*(-50) = 25\n",
-    "- # Indice 2 : Le point de bascule se trouve en egalisant les H de deux locaux\n",
-    "- # Indice 3 : Comparez avec les classes `MinimaxDecision` et `MinimaxRegretDecision` définies plus haut"
+    "- **Indice 1** : Pour gamma=0.3, H(Centre-ville) = 0.3*200 + 0.7*(-50) = 25\n",
+    "- **Indice 2** : Le point de bascule se trouve en egalisant les H de deux locaux\n",
+    "- **Indice 3** : Comparez avec les classes `MinimaxDecision` et `MinimaxRegretDecision` définies plus haut"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
+++ b/MyIA.AI.Notebooks/Probas/DecisionTheory/DecInfer/DecInfer-8-Sequential.ipynb
@@ -1481,9 +1481,9 @@
     "5. Analyser l'effet du bonus intermediaire en (2,2) sur la politique\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Les classes `ValueIteration.Solve()` et `PolicyIteration.Solve()` sont déjà définies\n",
-    "- # Indice 2 : Pour changer gamma, recreer le MDP avec `new GridMDP(4, 3, gamma: 0.95)`\n",
-    "- # Indice 3 : Le bonus en (2,2) attire l'agent vers cette case. La politique passe-t-elle par (2,2) ?"
+    "- **Indice 1** : Les classes `ValueIteration.Solve()` et `PolicyIteration.Solve()` sont déjà définies\n",
+    "- **Indice 2** : Pour changer gamma, recreer le MDP avec `new GridMDP(4, 3, gamma: 0.95)`\n",
+    "- **Indice 3** : Le bonus en (2,2) attire l'agent vers cette case. La politique passe-t-elle par (2,2) ?"
    ]
   },
   {
@@ -2701,9 +2701,9 @@
     "5. Tester avec deux bras très proches (0.5 vs 0.51) et observer la difficulte\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Thompson Sampling echantillonne Beta(alpha_i, beta_i) par bras, ou alpha = succes+1, beta = echecs+1\n",
-    "- # Indice 2 : Pour des recompenses gaussiennes, approximer en seuillant a [0,1] pour le comptage succes/echec\n",
-    "- # Indice 3 : Le regret cumule = somme(mu* - reward_t) mesure la perte totale par rapport a l'optimal"
+    "- **Indice 1** : Thompson Sampling echantillonne Beta(alpha_i, beta_i) par bras, ou alpha = succes+1, beta = echecs+1\n",
+    "- **Indice 2** : Pour des recompenses gaussiennes, approximer en seuillant a [0,1] pour le comptage succes/echec\n",
+    "- **Indice 3** : Le regret cumule = somme(mu* - reward_t) mesure la perte totale par rapport a l'optimal"
    ]
   },
   {


### PR DESCRIPTION
## Summary

Tranche 1 de la remédiation #11947 (défaut signalé par le user sur DecInfer-3) : les indices/étapes d'exercices étaient écrits en **heading H1 imbriqué dans une puce** (`- # Indice 1 : ...`), ce qui rend en texte géant sur GitHub. Correction mécanique en **label gras dans la puce** :

```markdown
- # Indice 1 : Pour FSD, comparez les CDFs...   ->   - **Indice 1** : Pour FSD, comparez les CDFs...
```

105 lignes corrigées sur le périmètre DecInfer + CaseStudies (le scanner de ma branche #11929 — règle encore non mergée — mesurait 302 lignes corpus-wide / 114 notebooks ; cette tranche couvre les familles les plus pédagogiquement sensibles : les cas d'étude student/solution et la série d'introduction DecInfer).

## Preuves vérifiables

- **Markdown-only** : seules les `source` de cellules markdown changent — 0 diff sur `execution_count`, 0 diff sur `outputs` (grep sur le diff : 0 hit). Exception C.2 markdown s'applique, pas de re-exec kernel requise.
- **Aucune nouvelle violation des règles existantes** : `detect_markdown_rendering.py` sur les deux racines, avant/après par stash → sortie **IDENTIQUE** (violations préexistantes `yaml_block_open_no_close`/`oversized_hint` inchangées, aucune créée).
- **0 heading_in_list restant sur le périmètre** : vérifié au scanner de la branche #11929 (règle HEADING-IN-LIST, detection 105/105 consommées).
- **Validateur repo** (`notebook_tools.py validate`) : 0 erreur (échantillon par famille : DecInfer-3 OK, Oncology-Planning student OK).
- **Paires student/solution CaseStudies** : même correction symétrique (15 lignes chacune, diff équilibré +109/−109).

## Périmètre : 10 fichiers

DecInfer-1 (9 lignes), DecInfer-3 (4 — le notebook signalé), DecInfer-4 (9), DecInfer-6 (11), DecInfer-7 (6), DecInfer-8 (6), Diagnostic-Medical student+solution (15+15), Oncology-Planning student+solution (15+15). Un seul domaine (prose pédagogique notebooks), une seule feature, catalogue byte-identique à main.

## Résiduel (tranches suivantes, See #11947)

SemanticKernel (51 cellules scanner), QuantConnect/Python (48), Argument_Analysis (24), GenAI Audio/Image/Video/Texte/PostTraining. La règle CI (WARN + baseline absorbée) arrivera au merge de #11929.

See #11947 (tranche 1/5 — l'issue reste ouverte)

Grain: LIGHT/tooling-remediation — lane myia-po-2023:CoursIA — prev: DEEP/genai #11911

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>