### PR TITLE
docs(semanticweb,#11601): SW-10 CSharp densite 611->1511 - residu round 1

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-10-CSharp-RDFStar.ipynb
@@ -33,7 +33,8 @@
    "source": [
     "## 1. Installation et espace de noms\n",
     "\n",
-    "dotNetRDF est le moteur .NET natif pour RDF/SPARQL. On charge le NuGet `dotNetRDF` 3.4.1 (le même que `SW-9-CSharp-JSONLD`). On définit les préfixes et URI de base comme le twin Python (`ex:`, `foaf:`, `rdf:`, `xsd:`)."
+    "dotNetRDF est le moteur .NET natif pour RDF/SPARQL. On charge le NuGet `dotNetRDF` 3.4.1 (le même que `SW-9-CSharp-JSONLD`). On définit les préfixes et URI de base comme le twin Python (`ex:`, `foaf:`, `rdf:`, `xsd:`).\n",
+    "Côté espaces de noms, tout vit sous `VDS.RDF.*` : `Graph`/`TripleStore` pour les graphes, `Parsing`/`Writing` pour les sérialisations, `Query` pour SPARQL — miroir des modules `rdflib.graph`/`rdflib.plugins.sparql` du côté Python.\n"
    ]
   },
   {
@@ -91,7 +92,13 @@
     "\n",
     "### 2.1 La réification classique : 4 triplets pour 1 assertion\n",
     "\n",
-    "La réification d'un triplet `(s, p, o)` crée un nœud `stmt` typé `rdf:Statement` relié au triplet original via `rdf:subject`, `rdf:predicate`, `rdf:object`. On peut alors annoter `stmt` (source, confiance, date) sans toucher au fait original."
+    "La réification d'un triplet `(s, p, o)` crée un nœud `stmt` typé `rdf:Statement` relié au triplet original via `rdf:subject`, `rdf:predicate`, `rdf:object`. On peut alors annoter `stmt` (source, confiance, date) sans toucher au fait original.\n",
+    "\n",
+    "Un point clé du vocabulaire : les quatre prédicats (`rdf:type rdf:Statement`, `rdf:subject`, `rdf:predicate`, `rdf:object`) sont **des triplets ordinaires** — le nœud `stmt` est un URI comme un autre, requêtable par SPARQL comme n'importe quelle ressource. La réification n'est pas une construction spéciale du moteur : c'est une convention de modélisation entièrement exprimée en RDF, ce qui explique à la fois sa portabilité totale (tout moteur RDF la comprend) et son coût (rien n'est gratuit puisque tout est explicite).\n",
+    "\n",
+    "### L'exemple filé du notebook\n",
+    "\n",
+    "Tout le notebook s'appuie sur un même scénario : un graphe social où **Alice, Bob, Carol et Dave** sont reliés par `foaf:knows`, chaque relation étant rapportée par une source différente — LinkedIn (fiable), Twitter (moyenne), aucune source, ou une rumeur — avec un score de confiance en conséquence. La réification est ce qui permet au graphe de porter *à la fois* la relation (Alice connaît Bob) et son contexte épistémique (selon LinkedIn, à 95 %) au lieu de les confondre dans un triplet muet.\n"
    ]
   },
   {
@@ -192,7 +199,8 @@
     "| Triplet nu | 1 | excellente | oui (le triplet existe) |\n",
     "| Réification + annotations | **7** | verbeuse | non (le fait original peut ne pas exister) |\n",
     "\n",
-    "C'est précisément ce coût (4 triplets auxiliaires + N annotations) que **RDF-star** (RDF 1.2) vise à éliminer avec la syntaxe `<< s p o >>`. Mais la réification reste le mécanisme portable, indépendant du moteur. La sérialisation Turtle ci-dessous montre les 7 triplets."
+    "C'est précisément ce coût (4 triplets auxiliaires + N annotations) que **RDF-star** (RDF 1.2) vise à éliminer avec la syntaxe `<< s p o >>`. Mais la réification reste le mécanisme portable, indépendant du moteur. La sérialisation Turtle ci-dessous montre les 7 triplets.\n",
+    "À l'échelle, l'arithmétique devient le vrai sujet : annoter 1 000 faits avec 2 annotations chacun coûte 7 000 triplets — et surtout, *toute* requête sur les faits doit désormais traverser la jointure `rdf:Statement` de la section 5. C'est ce coût en volume et en complexité de requête, plus que la verbosité, qui motive RDF-star : mêmes annotations, zéro triplet auxiliaire.\n"
    ]
   },
   {
@@ -239,12 +247,23 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-sw10cs-interp-turtle",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le Turtle compressé rend la réification lisible\n",
+    "\n",
+    "La sérialisation ouvre sur les directives `@prefix` (`rdf:`, `rdfs:`, `xsd:`, `ex:`, `foaf:`) puis compacte chaque triplet réifié sur une ligne `ex:stmt1 rdf:type rdf:Statement ; rdf:subject ... ; rdf:predicate ... ; rdf:object ...` — le point-virgule Turtle (prédicats multiples pour un même sujet) suit exactement la structure du nœud-réification. C'est toute la valeur du format : là où le graphe en mémoire est une collection plate de triplets, le Turtle **compressé** regroupe visuellement les 4 triplets auxiliaires en un bloc par assertion, et les annotations du même nœud à sa suite. Le même contenu en N-Triples (une ligne par triplet, URIs en clair) resterait correct mais illisible — c'est le choix fait ici par `CompressingTurtleWriter`, l'équivalent exact du `serialize(format=\"turtle\")` de rdflib côté Python.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4049d8cd",
    "metadata": {},
    "source": [
     "## 3. Fonction utilitaire `Reify()`\n",
     "\n",
-    "Pour réduire la verbosité, le twin Python définit une fonction `reify(graph, s, p, o)`. Voici l'équivalent C# : elle crée le nœud-réification `rdf:Statement` + les 3 liens, sans répéter le fait original (à ajouter séparément). Retourne le nœud `stmt` pour annotation."
+    "Pour réduire la verbosité, le twin Python définit une fonction `reify(graph, s, p, o)`. Voici l'équivalent C# : elle crée le nœud-réification `rdf:Statement` + les 3 liens, sans répéter le fait original (à ajouter séparément). Retourne le nœud `stmt` pour annotation.\n",
+    "Plutôt que d'écrire les 4 triplets auxiliaires à la main à chaque annotation, on factorise le geste dans un helper — c'est aussi l'occasion d'expliciter son contrat : ce qu'il ajoute au graphe, ce qu'il laisse à l'appelant, et pourquoi.\n"
    ]
   },
   {
@@ -293,6 +312,16 @@
     "g.Assert(new Triple(stmt2, U(\"confidence\"), Confidence(0.60)));\n",
     "\n",
     "Console.WriteLine($\"Apres 2e fait reifie : graphe g = {g.Triples.Count} triplets au total\");\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-sw10cs-interp-reify",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le contrat de `Reify()`\n",
+    "\n",
+    "Après le second appel, le graphe `g` compte **14 triplets** : les 7 du premier fait réifié (1 original + 4 de réification + 2 annotations) plus 7 pour le second. La fonction illustre un contrat important : elle **retourne le nœud-réification** (`IUriNode`) sans l'ajouter au graphe — c'est l'appelant qui décide d'`Assert` le fait original ou non. Cette séparation reflète une subtilité du modèle : la réification décrit une *assertion*, pas un *fait* — le triplet `Alice connaît Carol` peut être réifié (quelqu'un l'affirme) sans exister dans le graphe (le système ne l'endosse pas). C'est aussi ce qui rend le mécanisme général : n'importe quelle cellule peut annoter n'importe quel triplet, y compris un triplet qu'elle refuse d'affirmer elle-même.\n"
    ]
   },
   {
@@ -389,12 +418,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-sw10cs-interp-gk",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le graphe de connaissances assemblé\n",
+    "\n",
+    "**35 triplets** composent maintenant le graphe `gk` : les faits `foaf:knows` entre les quatre personnes, leurs noms, et pour chaque relation un bloc de réification portant `ex:confidence` (le score) et `ex:source` (la provenance). C'est l'échelle où l'inspection à l'œil devient pénible — 35 triplets, 4 sources hétérogènes (LinkedIn, Twitter, aucune, Rumeur), des confiances de 0,30 à 0,95 — et où la question naturelle cesse d'être « qu'y a-t-il dans le graphe ? » pour devenir « **que sait-on, et à quel degré croire chaque chose ?** ». Les deux sections suivantes répondent à cette question dans la langue du moteur : SPARQL.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "044c1b8b",
    "metadata": {},
    "source": [
     "## 5. Interroger les annotations avec SPARQL\n",
     "\n",
-    "Pour extraire les relations annotées, on joint sur `rdf:subject`/`rdf:predicate`/`rdf:object` et on récupère les annotations. La requête ci-dessous liste toutes les relations connues avec leur confiance et source, triées par confiance décroissante."
+    "Pour extraire les relations annotées, on joint sur `rdf:subject`/`rdf:predicate`/`rdf:object` et on récupère les annotations. La requête ci-dessous liste toutes les relations connues avec leur confiance et source, triées par confiance décroissante.\n",
+    "\n",
+    "Ce que la requête fait ne peut pas se faire sans réification : un triplet nu n'a pas de « confiance » ni de « source » à joindre — la jointure ci-dessous existe précisément parce que les annotations vivent sur le nœud `rdf:Statement`.\n"
    ]
   },
   {
@@ -504,12 +545,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-sw10cs-interp-sparql",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : la jointure rdf:Statement restitue les annotations\n",
+    "\n",
+    "La requête produit la table des quatre relations annotées, **triées par confiance décroissante** : Alice→Bob à **0,95** (LinkedIn), Bob→Carol à **0,60** (Twitter), Alice→Dave à **0,50** (source « - »), Carol→Dave à **0,30** (Rumeur). Mécaniquement, chaque ligne est le produit d'une *jointure* : les quatre triplets `rdf:type rdf:Statement` identifient les nœuds-réifications, les patterns `rdf:subject`/`rdf:predicate`/`rdf:object` récupèrent la relation décrite, et les patterns `ex:confidence`/`ex:source` ramènent les annotations du même nœud — tout l'appareil de la section 2, requêté en une passe. Un détail mérite l'œil : la ligne Alice→Dave affiche « - » comme source. Ce n'est pas une donnée manquée par la requête — la relation a été réifiée **sans** annotation `ex:source`, et SPARQL, dont la sémantique est ouverte, ne fabrique rien : le `OPTIONAL` (ou l'absence de pattern obligatoire) laisse la variable non liée, rendue ici par le tiret. Une absence d'information reste une information explicite.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "b0134858",
    "metadata": {},
    "source": [
     "## 6. Filtrer par score de confiance\n",
     "\n",
-    "Cas d'usage clé : séparer les **faits fiables** (confiance ≥ 0,60) des **faits incertains** (< 0,60). On utilise une clause `FILTER` SPARQL."
+    "Cas d'usage clé : séparer les **faits fiables** (confiance ≥ 0,60) des **faits incertains** (< 0,60). On utilise une clause `FILTER` SPARQL.\n",
+    "\n",
+    "Le seuil de 0,60 n'est pas une constante du standard : c'est un choix de politique de consommation, arbitré selon le coût d'une erreur dans chaque sens. Une application de recommandation tolérera 0,40 ; un dossier d'enquête exigera 0,90. SPARQL rend ce choix *externe* au graphe — les données portent des scores continus, la politique vit dans la requête, et changer de seuil ne touche aucune donnée.\n"
    ]
   },
   {
@@ -639,12 +692,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-sw10cs-interp-filter",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : le seuil partitionne exactement\n",
+    "\n",
+    "Le `FILTER (?confidence >= 0.60)` coupe le graphe en deux moitiés : **2 relations fiables** (Alice→Bob 0,95 LinkedIn ; Bob→Carol 0,60 Twitter) et **2 incertaines** (Alice→Dave 0,50 sans source ; Carol→Dave 0,30 Rumeur). La partition n'a rien de magique — 0,60 est un seuil *métier* arbitré ici pour l'exemple — mais sa lecture est instructive : elle recoupe presque exactement la frontière des **sources**. Ce qui passe le seuil vient de plateformes nominatives (LinkedIn, Twitter) ; ce qui échoue est soit sans source, soit une « Rumeur ». La confiance chiffrée et la provenance qualitative racontent la même histoire par deux canaux — c'est précisément pourquoi on a annoté les deux : un consommateur du graphe peut filtrer sur le score, auditer via la source, ou exiger leur accord.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "d555f91f",
    "metadata": {},
    "source": [
     "## 7. Alternative : les graphes nommés\n",
     "\n",
-    "Les **graphes nommés** (Named Graphs) offrent une autre approche pour grouper des triplets par contexte : plutôt que de réifier chaque triplet individuellement, on regroupe un ensemble de triplets sous une URI de graphe. On peut alors annoter le graphe tout entier (provenance, confiance globale). dotNetRDF expose cela via la classe `VDS.RDF.ThreadSafeTripleStore` + `IGraph` nommés."
+    "Les **graphes nommés** (Named Graphs) offrent une autre approche pour grouper des triplets par contexte : plutôt que de réifier chaque triplet individuellement, on regroupe un ensemble de triplets sous une URI de graphe. On peut alors annoter le graphe tout entier (provenance, confiance globale). dotNetRDF expose cela via la classe `VDS.RDF.ThreadSafeTripleStore` + `IGraph` nommés.\n",
+    "\n",
+    "La granularité est le trade-off central : réification = une annotation par triplet (fin, coûteux), graphe nommé = une annotation par source (grossier, économique). En pratique les deux cohabitent — un graphe nommé par source, contenant des triplets réifiés quand le score varie à l'intérieur d'une même source.\n"
    ]
   },
   {
@@ -734,12 +799,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cell-sw10cs-interp-named",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : deux niveaux de granularité pour annoter\n",
+    "\n",
+    "Le store liste ses graphes nommés — `linkedin` et `twitter`, **1 triplet chacun** — et leur contenu : la relation que chaque source affirme. Là où la réification annotait *chaque triplet individuellement* (4 triplets auxiliaires par assertion), le graphe nommé annote *un ensemble entier* d'un seul geste : l'URI du graphe (`ex:linkedin`) joue le rôle de provenance, et toute annotation posée sur cette URI (confiance globale, date de collecte, licence) vaut pour tous ses triplets. Note d'API visible dans le code : en dotNetRDF 3.x, un graphe nommé se construit par `new Graph(IRefNode)` — le nœud-nom définit l'identité — là où l'ancien pattern `BaseUri` laissait `Name == null` et un graphe implicitement « par défaut » ; c'est le piège de migration documenté dans le commentaire de la cellule. Le choix réification vs graphes nommés n'est donc pas esthétique : c'est un arbitrage entre **granularité fine** (chaque triplet porte son propre score) et **granularité de source** (un score par provenance) — le graphe de connaissances de la section 4 utilise la première, ce store la seconde.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1378d546",
    "metadata": {},
    "source": [
     "## 8. Sérialisation et interopérabilité\n",
     "\n",
-    "dotNetRDF supporte plusieurs formats de sérialisation (Turtle, N-Triples, RDF/XML, JSON-LD). Le Turtle (compressé) est le plus lisible pour la réification."
+    "dotNetRDF supporte plusieurs formats de sérialisation (Turtle, N-Triples, RDF/XML, JSON-LD). Le Turtle (compressé) est le plus lisible pour la réification.\n",
+    "\n",
+    "Le test d'interopérabilité le plus simple est l'aller-retour : sérialiser côté C# avec dotNetRDF, relire côté Python avec `rdflib.graph().parse(format=\"turtle\")` — le graphe relit doit être isomorphe au graphe sérialisé. C'est le contrat de la paire SW-10 : le même contenu, prouvé depuis les deux écosystèmes.\n"
    ]
   },
   {
@@ -800,6 +877,16 @@
     "Console.WriteLine($\"Serialisation Turtle : {turtle.Length} caracteres, {gk.Triples.Count} triplets\");\n",
     "Console.WriteLine(\"--- (extrait) ---\");\n",
     "Console.WriteLine(turtle.Substring(0, Math.Min(500, turtle.Length)));\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-sw10cs-interp-serial",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : 1370 caractères pour 35 triplets\n",
+    "\n",
+    "La sérialisation du graphe complet tient en **1370 caractères** pour 35 triplets — environ 39 caractères par triplet, contre plus de 100 en N-Triples où chaque URI est répétée en clair. Le gain vient de la compression : préfixes déclarés une fois, prédicats multiples factorisés par le point-virgule, objets partagés par la virgule. C'est aussi ce qui fait du Turtle le format d'**interopérabilité** pratique : le fichier produit ici est parsable tel quel par rdflib (le twin Python), par Jena, ou par tout moteur conforme — la sérialisation est un encodage du même graphe abstrait, pas une donnée propriétaire. L'aller-retour sérialiser/relire sans perte est l'invariant qui rend la chaîne C# → disque → Python possible.\n"
    ]
   },
   {
@@ -941,7 +1028,20 @@
     "\n",
     "**Navigation** : [`<< SW-9 JSONLD`](SW-9-CSharp-JSONLD.ipynb) | [Index SemanticWeb](README.md) | Jumeau Python : [`SW-10-Python-RDFStar`](SW-10-Python-RDFStar.ipynb)\n",
     "\n",
-    "*Marathon #4956 — parité .NET ⇄ Python. Prong A : vrai moteur dotNetRDF 3.4.1 natif invoqué.*\n"
+    "*Marathon #4956 — parité .NET ⇄ Python. Prong A : vrai moteur dotNetRDF 3.4.1 natif invoqué.*\n",
+    "\n",
+    "### Quelle approche choisir ?\n",
+    "\n",
+    "- **Triplet nu** quand la donnée est certaine et sans contexte à porter — l'essentiel d'un graphe de faits.\n",
+    "- **Réification** quand chaque assertion porte son propre degré de croyance ou sa propre provenance — fusion de sources hétérogènes, graphe de connaissances auditable.\n",
+    "- **Graphe nommé** quand la provenance est homogène par lots — ingestion multi-sources où chaque source parle pour tout ce qu'elle apporte.\n",
+    "- **RDF-star** quand le moteur le supporte : la même expressivité que la réification à la syntaxe près, au prix d'une adoption encore partielle (RDF 1.2).\n",
+    "\n",
+    "La compétence visée n'est pas de connaître les quatre par cœur, mais de *choisir* la granularité d'annotation adaptée à la question « qui affirme quoi, et à quel point le croire ? ».\n",
+    "\n",
+    "### Ce qu'il faut retenir côté C#\n",
+    "\n",
+    "Les gestes du notebook se traduisent un-à-un vers rdflib (`Graph` ↔ `rdflib.Graph`, `Assert` ↔ `add`, `CompressingTurtleWriter` ↔ `serialize(format=\"turtle\")`, `TripleStore` + graphe nommé ↔ `ConjunctiveGraph`/`Dataset`) : la compétence transférable est le *modèle RDF* — réification, nœuds, sérialisation, SPARQL — pas l'API. La différence notable est culturelle : dotNetRDF expose l'identité d'un graphe nommé par son nœud (`Graph(IRefNode)`), quand rdflib la porte par URI — même mathématique, ergonomie propre à chaque écosystème.\n"
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml
@@ -22,6 +22,12 @@
       csharp_sha: e184307cf2a6180399e776bf200058e283fb9bf2
       content_python_sha: a744d091ca142cd7bb5a083eebf29ae36d8e95225c0e6e602f0a48b0701dcbd3
       content_csharp_sha: 3838b11ac074fbc5ab81e9cba575f6b3bf3891c1c0a3eb1743994cd449184107
+    - date: "2026-08-20"
+      by: myia-po-2024:CoursIA
+      python_sha: e0ab6644e61cd72a7a1a6aff3d5ac39181bf9f6b
+      csharp_sha: 3b0c23eef0396b323c920131eea55437b6f79487
+      content_python_sha: a744d091ca142cd7bb5a083eebf29ae36d8e95225c0e6e602f0a48b0701dcbd3
+      content_csharp_sha: 815e78d9bb10dc643bad40665cccb68fc117492fcbd78b8df12a1bf5a5eebffe
   known_differences:
     - "Socle commun : meta-modelisation RDF-star (triplets sur des triplets, quotes nestees)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query` support RDF-star). Python = `rdflib` (`rdflib.term` triplets-nommes). RDF-star est une extension communautaire (pas encore W3C standardise) ; support experimental des deux cotes."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #11945 (substance distincte : autre notebook, autre langage, résidu round 1 sous plancher dur vs round 2)

See #11601 (absorption du résidu round 1 découvert au tirage — umbrella, jamais Closes)

## Summary

Densification markdown-only du notebook C# SW-10-CSharp-RDFStar : **611 → 1511** chars prose/cellule code. Ce notebook était un **résidu round 1** (sous le plancher dur 1200) découvert au tirage du cycle précédent : #11907 avait densifié le jumeau **Python** (1269→1534), le C# était resté à 611 — dernier commit le touchant = strip banner #6370.

**7 cellules de lecture de résultat** insérées, chacune immédiatement après la cellule de code dont elle commente l'output (Turtle compressé · contrat `Reify()` · graphe de connaissances 35 triplets · jointure `rdf:Statement` · filtre confiance · graphes nommés · sérialisation), + **10 étoffements** (exemple filé Alice/Bob/Carol/Dave, vocabulaire rdf des 4 prédicats, note d'échelle, transitions §1/§3, choix du seuil, granularité, interop round-trip, décisionnel de conclusion 4 approches, paragraphe C#-vs-rdflib). Diff : 2 fichiers — `SW-10-CSharp-RDFStar.ipynb` (+109/−9, **0 cellule code touchée**) et `scripts/notebook_tools/twin_pairs.d/sw-10-rdf-star.yaml` (+6, attestation twin re-baselinée, cf section Twin parity) → C.3 dispense de re-exécution, outputs intacts.

## Mesures (garde-fous acceptance #11601)

| Contrôle | Résultat |
|---|---|
| `pedagogy_density.py` avant → après | 611 → **1511** ✓ ≥1500 (cible standard umbrella) |
| `scan_cell_ordering.py` (structurel) | 1 scanned, **0 finding** ✓ |
| `scan_cell_ordering.py --check-interp-anchor` (advisory) | **0 candidate** ✓ |
| `detect_markdown_rendering.py --check` | OK, **no new ERROR-level violation** ✓ |
| Pre-commit H.3 | Passed ✓ |
| Cellules code modifiées | **0** (grep diff `cell_type: code` = 0) ✓ |

Ancrage : le script d'insertion **assert** que chaque valeur pivot citée (`@prefix`, `14 triplets`, `35 triplets`, `0,95`, `FIABLES`, `linkedin`, `1370`) est présente dans l'output de la cellule précédée — échec = pas d'écriture. Le notebook comptait une seule interp (§2) pour 12 cellules code ; il en a désormais 8 + étoffements continus.

## Twin parity (#8057)

Paire `SW-10 RDF-Star` (native-both, dotNetRDF ↔ rdflib) : markdown-only = déplacement de blob SHA → `--update --pair "SW-10 RDF-Star" --by myia-po-2024:CoursIA` exécuté **en dernier commit** après le commit notebook (règle post-#11919). Verdict reproduit sur le tip poussé : `--per-pair --base origin/main` = **157/157 OK**.

## Relation aux tranches sœurs

- #11907 (SW-10 **Python**, 1269→1534, mergé) : le présent PR complète la paire côté C# — les deux jumeaux sont désormais ≥1500.
- Découverte du résidu tracée sur #11601 (commentaire avec re-mesure fresh 611 + disambiguation Python/C#) avant claim.

