### PR TITLE
fix(twin,#11919): rebaseline les paires orphelines par squash (content_sha no-op)

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -604,6 +604,26 @@ def update_pair(
     # un faux audit au sens du design-gate #9399 critere 2.
     latest = _latest_audit(pair)
     is_noop = bool(latest) and _shas_match(latest, audit)
+    # Cas d'orphelin par squash (#11919) : un squash-merge peut re-hasher le
+    # blob sans toucher le contenu du notebook. Les `python_sha`/`csharp_sha`
+    # (git blob, legacy) enregistres ne sont alors PLUS ancetres de main, mais
+    # les `content_*_sha` sont identiques (le contenu est intact). Le no-op
+    # detection ci-dessus verrait « rien n'a change pedagogiquement » -- mais
+    # `--verify-recorded-sha` detecterait un MISMATCH sur le git blob SHA, et
+    # laisser cette paire en orphelin signifierait qu'aucun `--update` ne peut
+    # la ressoumettre au HEAD courant (le rebaseline necessaire est uniquement
+    # sur les git blob SHA, pas sur le contenu).
+    #
+    # Discrimination : sur un no-op, comparer les git blob SHA du recorded
+    # contre le HEAD. Si au moins un diverge, c'est un orphelin par squash
+    # -> ce n'est PAS un no-op, le rebaseline doit corriger les git blob SHA.
+    if is_noop and latest:
+        rec_py = latest.get("python_sha")
+        rec_cs = latest.get("csharp_sha")
+        if (rec_py is not None and cur_py is not None and rec_py != cur_py) or (
+            rec_cs is not None and cur_cs is not None and rec_cs != cur_cs
+        ):
+            is_noop = False
     return audit, cur_py, is_noop
 
 

--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -330,6 +330,44 @@ def _git_blob_sha(repo_root: Path, rel_path: str, git_ref: str = "HEAD") -> str 
     return None
 
 
+def _blob_ancestor_in(repo_root: Path, blob_sha: str, ref: str = "HEAD") -> bool:
+    """Vrai si `blob_sha` est accessible depuis `ref` (= un commit ancetre le reference).
+
+    Discrimination cle du fix #11919 : un squash-merge peut re-hasher le git
+    blob SHA d'un notebook sans toucher le contenu didactique. Le recorded
+    `python_sha`/`csharp_sha` pointe alors sur un blob qui n'est PLUS ancre
+    d'aucun commit accessible (orphelin par squash). Mais un cas
+    distinct -- metadata-only drift (Sudoku-8/14 BDD, design-gate #9399
+    critere 2) -- produit lui aussi un recorded blob SHA divergent de HEAD
+    (le `_git_blob_sha` actuel change quand `nb["metadata"]` change, meme si
+    `content_*_sha` est preserve). Les deux cas ont la MEME signature sur
+    `rec_X != cur_X`, mais le deuxieme n'est PAS un orphelin : son blob
+    reste accessible (il est reference par un commit ancetre de HEAD, juste
+    pas le commit HEAD lui-meme).
+
+    La discrimination : `git rev-list --objects <ref>` enumere tous les blobs
+    reference par les commits accessibles depuis `<ref>`. Si `blob_sha` y
+    figure, c'est un metadata-only drift (pas un orphelin). Sinon, c'est un
+    orphelin par squash : le rebaseline doit le corriger.
+
+    Cout : `rev-list --objects HEAD` parcourt tout l'historique ; le defacto
+    full scan reste borne par la taille du depot (~5-10s sur CoursIA). Pour
+    un seul test is_noop par paire, c'est acceptable. Une optimisation
+    ulterieure (cache par ref+blob) n'est pas justifiee a c.409.
+    """
+    if not blob_sha or len(blob_sha) != 40:
+        return False
+    r = subprocess.run(
+        ["git", "rev-list", "--objects", ref],
+        capture_output=True, text=True, cwd=str(repo_root),
+    )
+    if r.returncode != 0:
+        return False
+    # Chaque ligne de `rev-list --objects` est soit "<commit_sha>" soit
+    # "<commit_sha> <blob_sha>". On grep simplement le blob SHA sur la sortie.
+    return blob_sha in r.stdout
+
+
 def _content_sha(repo_root: Path, rel_path: str, git_ref: str = "HEAD") -> str | None:
     """SHA-256 canonique du notebook SANS sa metadonnee de niveau carnet (#9399 volet c).
 
@@ -614,15 +652,20 @@ def update_pair(
     # la ressoumettre au HEAD courant (le rebaseline necessaire est uniquement
     # sur les git blob SHA, pas sur le contenu).
     #
-    # Discrimination : sur un no-op, comparer les git blob SHA du recorded
-    # contre le HEAD. Si au moins un diverge, c'est un orphelin par squash
-    # -> ce n'est PAS un no-op, le rebaseline doit corriger les git blob SHA.
+    # Discrimination : sur un no-op, demander a git si le recorded blob SHA
+    # est accessible depuis HEAD (`_blob_ancestor_in`). Un vrai orphelin
+    # (squash) N'EST PAS accessible ; un metadata-only drift l'est (le blob
+    # est reference par un commit ancetre de HEAD, juste pas HEAD lui-meme).
+    # C'est la cle qui distingue les deux cas ayant pourtant la meme
+    # signature `rec_X != cur_X` -- sans cette discrimination, le fix
+    # violerait le design-gate #9399 critere 2 (metadata-only drift DOIT
+    # rester no-op, Sudoku-8/14 BDD du 2026-08-04).
     if is_noop and latest:
         rec_py = latest.get("python_sha")
         rec_cs = latest.get("csharp_sha")
-        if (rec_py is not None and cur_py is not None and rec_py != cur_py) or (
-            rec_cs is not None and cur_cs is not None and rec_cs != cur_cs
-        ):
+        py_orphan = rec_py is not None and not _blob_ancestor_in(repo_root, rec_py)
+        cs_orphan = rec_cs is not None and not _blob_ancestor_in(repo_root, rec_cs)
+        if py_orphan or cs_orphan:
             is_noop = False
     return audit, cur_py, is_noop
 

--- a/scripts/notebook_tools/tests/test_check_twin_parity_squash_orphan.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_squash_orphan.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Detection d'orphelin par squash dans `--update` (#11919).
+
+Le bug fondateur : sur main, le `python_sha` (git blob SHA legacy) enregistre
+sur Probas-13 Crowdsourcing etait un blob orphelin par le squash de #11878.
+Le contenu du notebook etait intact, mais le blob SHA n'etait pas ancre sur
+main. Consequence pratique :
+  - `--verify-recorded-sha` detectait MISMATCH (recorded=bd40c841e143 vs
+    calculated=efce50915b82) ;
+  - `--update` simultanement refusait comme no-op (content_sha identiques =
+    _shas_match True = faux audit).
+
+Deux sous-commandes du meme outil, sur la meme paire, au meme instant :
+l'une dit « incoherent », l'autre dit « rien a faire ».
+
+Le fix : sur un no-op detecte, comparer les git blob SHA du recorded contre
+le HEAD. Si au moins un diverge, c'est un orphelin par squash -> ce n'est
+PAS un no-op, le rebaseline doit corriger les git blob SHA.
+
+Run:
+    pytest scripts/notebook_tools/tests/test_check_twin_parity_squash_orphan.py
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import check_twin_parity as ctp  # noqa: E402
+
+
+# --- helpers -----------------------------------------------------------------
+
+def _git_repo(tmp_path: Path) -> Path:
+    """Un mini-depot git pret a committer des notebooks."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for args in (("init", "-q"), ("config", "user.email", "t@t"),
+                 ("config", "user.name", "t")):
+        subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+    return repo
+
+
+def _nb(source: list[str] | None = None) -> dict:
+    return {
+        "cells": [{
+            "cell_type": "markdown",
+            "source": source if source is not None else ["# Title\n"],
+            "metadata": {},
+        }],
+        "metadata": {"kernelspec": {"name": "python3"}},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+
+
+def _commit(repo: Path, rel: str, nb: dict, msg: str) -> None:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", msg], cwd=repo,
+                   check=True, capture_output=True)
+
+
+def _squash_replace_blob(repo: Path, rel: str, new_content: bytes) -> str:
+    """Simule un squash-merge qui re-hashe le blob sans changer le contenu.
+
+    Truc : on commit un blob DIFFERENT (meme contenu textuel apres json.dumps)
+    qu'on rebascule ensuite. Le SHA change, le contenu non. C'est le scenario
+    fondateur : un agent re-commit en deux etapes distinctes, le SHA git blob
+    final n'est pas celui de l'attestation d'origine, alors que le contenu
+    est identique.
+
+    Retourne le NOUVEAU blob SHA.
+    """
+    # 1. Re-commit avec un padding metadata (le contenu didactique reste
+    #    identique : `_nb(source=...)` produit un notebook stable cote `cells`).
+    #    On usa de `_commit` normal pour poser un SHAsuch que le git blob SHA
+    #    change : modifier la date ou ajouter un champ metadata distinct.
+    #    Ici on ajoute une clef metadata differente (kernelspec.display_name
+    #    change) : le content_sha (metadata-immune) reste identique, mais le
+    #    git blob SHA change.
+    p = repo / rel
+    nb = json.loads(p.read_text(encoding="utf-8"))
+    nb["metadata"]["kernelspec"]["display_name"] = "Python 3 (squash)"
+    p.write_text(json.dumps(nb), encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-qm", "squash repr"], cwd=repo,
+                   check=True, capture_output=True)
+    return ctp._git_blob_sha(repo, rel)
+
+
+def _make_pair_yaml_with_content_sha(
+    pairs_dir: Path, name: str, py_rel: str, cs_rel: str,
+    py_sha: str, cs_sha: str, py_content: str, cs_content: str,
+) -> None:
+    """Ecrit une entree registry file-per-entry (cf #8542) avec content_sha."""
+    entry = pairs_dir / f"{name}.yaml"
+    entry.write_text(
+        f"name: {name}\n"
+        f"family: Search\n"
+        f"python: {py_rel}\n"
+        f"csharp: {cs_rel}\n"
+        f"parity_level: full\n"
+        f"last_audit:\n"
+        f"  date: 2026-08-19\n"
+        f"  by: myia-po-2026:CoursIA-2\n"
+        f"  python_sha: {py_sha}\n"
+        f"  csharp_sha: {cs_sha}\n"
+        f"  content_python_sha: {py_content}\n"
+        f"  content_csharp_sha: {cs_content}\n",
+        encoding="utf-8",
+    )
+
+
+# --- 1. Reproducer du defaut #11919 ----------------------------------------
+
+def test_squash_orphan_mismatch_then_noop_defect(tmp_path):
+    """Defaut fondateur : MISMATCH cote --verify-recorded-sha MAIS no-op cote --update.
+
+    Ce test echoue AVANT le fix appliqué dans update_pair ; il passe apres.
+    """
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+
+    # SHAs AVANT le squash (recorded).
+    py_blob_v1 = ctp._git_blob_sha(repo, py_rel)
+    cs_blob_v1 = ctp._git_blob_sha(repo, cs_rel)
+    py_content = ctp._content_sha(repo, py_rel)
+    cs_content = ctp._content_sha(repo, cs_rel)
+    assert py_blob_v1 and cs_blob_v1 and py_content and cs_content
+
+    # Simuler un squash-merge : le contenu didactique reste le meme, mais le
+    # blob SHA git change (sur le notebook python ; le csharp est laisse tel
+    # quel pour ne declencher qu'un seul cote -- adapte au cas fondateur).
+    new_py_blob = _squash_replace_blob(repo, py_rel, b"")
+    assert new_py_blob != py_blob_v1, "le blob SHA aurait du changer"
+    # content_sha dépend uniquement des cellules -> identiques avant/apres.
+    assert ctp._content_sha(repo, py_rel) == py_content, (
+        "le content_sha est cense etre inchange apres un squash sans modif "
+        "pedagogique"
+    )
+
+    # Ecriture du registre avec les SHAs recorded (pre-squash).
+    pairs_dir = repo / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Probas-13 Crowdsourcing", py_rel, cs_rel,
+        py_blob_v1, cs_blob_v1, py_content, cs_content,
+    )
+
+    # 1. --verify-recorded-sha detecte MISMATCH sur python_sha (le recorded
+    #    pointe sur l'ancien blob, calcule au HEAD trouve le nouveau).
+    verify_rc = ctp.main([
+        "--verify-recorded-sha", "--check", "--json",
+        "--registry", str(pairs_dir),
+        "--repo-root", str(repo),
+    ])
+    assert verify_rc == 1, (
+        f"verify-recorded-sha --check aurait du rougir (MISMATCH), rc={verify_rc}"
+    )
+
+    # 2. --update refuse simultanement comme no-op (le bug) : on capture
+    #    ce que retourne update_pair AVANT le fix (pour comparaison) puis
+    #    on valide le bind --update ne refuse plus.
+    pair = ctp.load_registry(pairs_dir)[0]
+    audit, cur_py, is_noop = ctp.update_pair(repo, pair)
+    assert audit["python_sha"] == new_py_blob, (
+        "le rebaseline devrait calculer le git blob SHA du HEAD (post-squash)"
+    )
+    assert is_noop is False, (
+        "un orphelin par squash devrait PAS etre un no-op : le contenu "
+        "est identique mais le git blob SHA diverge, ce qui est precisement "
+        "la classe de cas que le fix #11919 doit debloquer"
+    )
+
+
+# --- 2. Garde anti-regression : un vrai no-op reste un no-op ----------------
+
+def test_real_noop_still_refused(tmp_path):
+    """Re-implemente le gate no-op : un vrai no-op (content_sha + git blob
+    SHAs tous identiques) DOIT rester refuse.
+    """
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+
+    py_blob = ctp._git_blob_sha(repo, py_rel)
+    cs_blob = ctp._git_blob_sha(repo, cs_rel)
+    py_content = ctp._content_sha(repo, py_rel)
+    cs_content = ctp._content_sha(repo, cs_rel)
+
+    pairs_dir = repo / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Search-X", py_rel, cs_rel,
+        py_blob, cs_blob, py_content, cs_content,
+    )
+
+    pair = ctp.load_registry(pairs_dir)[0]
+    audit, cur_py, is_noop = ctp.update_pair(repo, pair)
+    assert is_noop is True, (
+        "vrai no-op (recorded == HEAD sur content_sha et git blob SHA) doit "
+        "rester refuse (faux audit, design-gate #9399 critere 2)"
+    )
+
+
+# --- 3. Discrimination : un changement pedagogique n'est PAS un no-op -------
+
+def test_real_content_change_is_not_noop(tmp_path):
+    """Un changement de prose reelle -> content_sha diff -> no-op = False."""
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+
+    py_blob_v1 = ctp._git_blob_sha(repo, py_rel)
+    cs_blob_v1 = ctp._git_blob_sha(repo, cs_rel)
+    py_content_v1 = ctp._content_sha(repo, py_rel)
+    cs_content_v1 = ctp._content_sha(repo, cs_rel)
+
+    # Après : changer la prose.
+    _commit(repo, py_rel, _nb(source=["# Title modifié\n"]), "prose edit py")
+
+    pairs_dir = repo / "twin_pairs.d"
+    pairs_dir.mkdir()
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Search-Y", py_rel, cs_rel,
+        py_blob_v1, cs_blob_v1, py_content_v1, cs_content_v1,
+    )
+
+    pair = ctp.load_registry(pairs_dir)[0]
+    audit, cur_py, is_noop = ctp.update_pair(repo, pair)
+    assert is_noop is False, (
+        "un changement de prose reelle -> content_sha diff -> doit "
+        "rebbaseliner (pas un no-op)"
+    )
+    # Sanity : l'audit produit est bien le contenu courant.
+    assert audit["content_python_sha"] != py_content_v1

--- a/scripts/notebook_tools/tests/test_check_twin_parity_squash_orphan.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_squash_orphan.py
@@ -74,29 +74,56 @@ def _commit(repo: Path, rel: str, nb: dict, msg: str) -> None:
 def _squash_replace_blob(repo: Path, rel: str, new_content: bytes) -> str:
     """Simule un squash-merge qui re-hashe le blob sans changer le contenu.
 
-    Truc : on commit un blob DIFFERENT (meme contenu textuel apres json.dumps)
-    qu'on rebascule ensuite. Le SHA change, le contenu non. C'est le scenario
-    fondateur : un agent re-commit en deux etapes distinctes, le SHA git blob
-    final n'est pas celui de l'attestation d'origine, alors que le contenu
-    est identique.
+    Scenario fondateur #11919 : le recorded pointe sur un blob qui N'EST
+    PLUS accessible depuis HEAD (orphelin par squash). On simule cela en :
+      1. capturant le blob v1 (le recorded d'origine),
+      2. creant une branche ephemere qui pose un blob v2 (meme contenu
+         didactique, juste un champ metadata ajoute qui ne touche pas aux
+         cellules -> content_sha reste identique, mais le git blob SHA change),
+      3. detruisant cette branche + reflog expire + gc pour rendre le blob
+         v2 inaccessible depuis HEAD.
 
-    Retourne le NOUVEAU blob SHA.
+    Apres : HEAD contient toujours le blob v1, mais le registre pointe sur
+    le blob v2 (orphelin). Discrimination : `_blob_ancestor_in(HEAD, v2)
+    == False` -> ce n'est PAS un no-op.
+
+    Retourne le blob v2 (recorded sera v2, calcule sera v1).
     """
-    # 1. Re-commit avec un padding metadata (le contenu didactique reste
-    #    identique : `_nb(source=...)` produit un notebook stable cote `cells`).
-    #    On usa de `_commit` normal pour poser un SHAsuch que le git blob SHA
-    #    change : modifier la date ou ajouter un champ metadata distinct.
-    #    Ici on ajoute une clef metadata differente (kernelspec.display_name
-    #    change) : le content_sha (metadata-immune) reste identique, mais le
-    #    git blob SHA change.
+    blob_v1 = ctp._git_blob_sha(repo, rel)
+    # Creer une branche ephemere qui pose un blob distinct.
+    subprocess.run(["git", "checkout", "-q", "-b", "_ephemeral_orphan"],
+                   cwd=repo, check=True, capture_output=True)
+    # Modifier le notebook en ajoutant un champ metadata qui ne touche pas
+    # aux cellules -> content_sha reste stable, mais git blob SHA change.
     p = repo / rel
     nb = json.loads(p.read_text(encoding="utf-8"))
-    nb["metadata"]["kernelspec"]["display_name"] = "Python 3 (squash)"
+    md = dict(nb.get("metadata", {}))
+    md["_squash_orphan_marker"] = "v2-orphaned-on-purpose"
+    nb["metadata"] = md
     p.write_text(json.dumps(nb), encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=repo, check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-qm", "squash repr"], cwd=repo,
+    subprocess.run(["git", "commit", "-qm", "ephemeral feat"], cwd=repo,
                    check=True, capture_output=True)
-    return ctp._git_blob_sha(repo, rel)
+    blob_v2 = ctp._git_blob_sha(repo, rel)
+    assert blob_v2 != blob_v1, "le blob SHA aurait du changer apres le commit ephemere"
+    # Detruire la branche ephemere + reflog + gc pour rendre v2 orphelin.
+    subprocess.run(["git", "checkout", "-q", "-"], cwd=repo,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "branch", "-D", "_ephemeral_orphan"], cwd=repo,
+                   check=True, capture_output=True)
+    subprocess.run(["git", "reflog", "expire", "--expire=now", "--all"],
+                   cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "gc", "--prune=now"], cwd=repo,
+                   check=True, capture_output=True)
+    # Verifier que v2 est bien orphelin depuis HEAD et v1 accessible.
+    assert not ctp._blob_ancestor_in(repo, blob_v2), (
+        f"le blob v2 {blob_v2[:12]} aurait du etre orphelin apres le gc, "
+        f"mais `_blob_ancestor_in` le voit encore."
+    )
+    assert ctp._blob_ancestor_in(repo, blob_v1), (
+        f"le blob v1 {blob_v1[:12]} aurait du rester accessible depuis HEAD"
+    )
+    return blob_v2
 
 
 def _make_pair_yaml_with_content_sha(
@@ -144,8 +171,11 @@ def test_squash_orphan_mismatch_then_noop_defect(tmp_path):
     assert py_blob_v1 and cs_blob_v1 and py_content and cs_content
 
     # Simuler un squash-merge : le contenu didactique reste le meme, mais le
-    # blob SHA git change (sur le notebook python ; le csharp est laisse tel
-    # quel pour ne declencher qu'un seul cote -- adapte au cas fondateur).
+    # blob SHA git change. Apres la simulation, HEAD pointe toujours sur
+    # py_blob_v1, mais le blob v2 (orphelin) est reference par le registre
+    # recorded -- reproduisant le cas fondateur Probas-13 Crowdsourcing ou
+    # le contenu est intact mais le git blob SHA enregistre pointe sur un
+    # blob inaccessible.
     new_py_blob = _squash_replace_blob(repo, py_rel, b"")
     assert new_py_blob != py_blob_v1, "le blob SHA aurait du changer"
     # content_sha dépend uniquement des cellules -> identiques avant/apres.
@@ -153,13 +183,22 @@ def test_squash_orphan_mismatch_then_noop_defect(tmp_path):
         "le content_sha est cense etre inchange apres un squash sans modif "
         "pedagogique"
     )
+    # HEAD est reste sur v1 (la branche ephemere n'a pas ete fusionnee) :
+    cur_py_at_HEAD = ctp._git_blob_sha(repo, py_rel)
+    assert cur_py_at_HEAD == py_blob_v1, (
+        f"HEAD aurait du rester sur v1 ({py_blob_v1[:12]}), "
+        f"mais pointe sur {cur_py_at_HEAD[:12]}"
+    )
 
-    # Ecriture du registre avec les SHAs recorded (pre-squash).
+    # Ecriture du registre : recorded pointe sur le blob ORPHELIN (v2), pas
+    # sur HEAD (v1). C'est precisement le cas fondateur : le contenu est
+    # identique, mais le git blob SHA enregistre n'est plus ancre d'aucun
+    # commit accessible.
     pairs_dir = repo / "twin_pairs.d"
     pairs_dir.mkdir()
     _make_pair_yaml_with_content_sha(
         pairs_dir, "Probas-13 Crowdsourcing", py_rel, cs_rel,
-        py_blob_v1, cs_blob_v1, py_content, cs_content,
+        new_py_blob, cs_blob_v1, py_content, cs_content,
     )
 
     # 1. --verify-recorded-sha detecte MISMATCH sur python_sha (le recorded
@@ -178,13 +217,23 @@ def test_squash_orphan_mismatch_then_noop_defect(tmp_path):
     #    on valide le bind --update ne refuse plus.
     pair = ctp.load_registry(pairs_dir)[0]
     audit, cur_py, is_noop = ctp.update_pair(repo, pair)
-    assert audit["python_sha"] == new_py_blob, (
-        "le rebaseline devrait calculer le git blob SHA du HEAD (post-squash)"
+    # HEAD porte v1 (= py_blob_v1). Le recorded pointait sur v2 (orphelin).
+    # Le rebaseline doit calculer cur_py = HEAD = v1 et lever is_noop=False
+    # (le recorded v2 est orphelin -- le rebaseline ecrase le recorded avec
+    # le SHA accessible, restaurant la coherence).
+    assert cur_py == py_blob_v1, (
+        f"update_pair aurait du calculer cur_py = HEAD = v1 "
+        f"({py_blob_v1[:12]}), a obtenu {cur_py[:12]}"
+    )
+    assert audit["python_sha"] == py_blob_v1
+    assert audit["content_python_sha"] == py_content, (
+        "content_sha doit etre preserve par update_pair"
     )
     assert is_noop is False, (
         "un orphelin par squash devrait PAS etre un no-op : le contenu "
-        "est identique mais le git blob SHA diverge, ce qui est precisement "
-        "la classe de cas que le fix #11919 doit debloquer"
+        "est identique mais le git blob SHA recorded est orphelin (v2), "
+        "ce qui est precisement la classe de cas que le fix #11919 doit "
+        "debloquer via reachability check (_blob_ancestor_in)"
     )
 
 

--- a/scripts/notebook_tools/tests/test_twin_registry_integrity.py
+++ b/scripts/notebook_tools/tests/test_twin_registry_integrity.py
@@ -745,6 +745,9 @@ def test_update_pair_no_op_when_content_sha_matches(tmp_path, monkeypatch):
     import check_twin_parity as ct
     monkeypatch.setattr(ct, "_git_blob_sha", lambda rr, p, git_ref="HEAD": sha_py if p == "X.ipynb" else sha_cs)
     monkeypatch.setattr(ct, "_content_sha", lambda rr, p, git_ref="HEAD": cpy if p == "X.ipynb" else ccs)
+    # Discrimination reachability (#11919) : recorded == courant (meme SHA),
+    # donc trivialement accessible depuis HEAD. Pas un orphelin.
+    monkeypatch.setattr(ct, "_blob_ancestor_in", lambda rr, blob_sha, ref="HEAD": True)
 
     audit, cur_py, is_noop = update_pair(tmp_path, fake_pair)
     assert cur_py == sha_py, "cur_py should match the recorded git blob SHA"
@@ -790,7 +793,14 @@ def test_update_pair_metadata_only_drift_is_noop(tmp_path, monkeypatch):
     git blob SHA mais preserve le content_sha (_shas_match utilise content_sha
     d'abord). -> is_noop True, NE PAS ecrire (sinon faux audit). C'est
     precisement la classe de drift Sudoku-8/14 BDD/9 GraphColoring que le
-    design-gate a designee comme devant etre ignoree."""
+    design-gate a designee comme devant etre ignoree.
+
+    Discrimination reachability (#11919) : le recorded git blob SHA EST
+    accessible depuis HEAD (le commit qui le porte est un ancetre, juste pas
+    HEAD lui-meme -- le buffer metadata a change entre ce commit et HEAD).
+    C'est la difference fondamentale avec un orphelin par squash : dans le
+    cas metadata-only, le blob reste reference par un commit ancetre.
+    """
     fake_pair = {
         "name": "Test-Metadata-Only",
         "family": "Sudoku",
@@ -811,6 +821,11 @@ def test_update_pair_metadata_only_drift_is_noop(tmp_path, monkeypatch):
     # content_sha preserve (la structure pedagogique n'a pas change).
     monkeypatch.setattr(ct, "_git_blob_sha", lambda rr, p, git_ref="HEAD": "1" * 40 if p == "X.ipynb" else "2" * 40)
     monkeypatch.setattr(ct, "_content_sha", lambda rr, p, git_ref="HEAD": "c" * 64 if p == "X.ipynb" else "d" * 64)
+    # Discrimination reachability : le recorded blob SHA EST accessible (le
+    # commit qui le porte est ancetre de HEAD). C'est ce qui distingue
+    # metadata-only drift d'un orphelin par squash (#11919) -- les deux cas
+    # ont la meme signature `rec_X != cur_X`, differencies par reachability.
+    monkeypatch.setattr(ct, "_blob_ancestor_in", lambda rr, blob_sha, ref="HEAD": True)
 
     audit, cur_py, is_noop = update_pair(tmp_path, fake_pair)
     assert cur_py == "1" * 40, "git blob SHA moved (metadata-only change)"
@@ -878,6 +893,9 @@ def test_update_pair_no_op_via_git_blob_sha_fallback(tmp_path, monkeypatch):
     # Calculated content_sha aussi None (legacy total) : _shas_match
     # tombe en fallback git blob SHA, qui sont egaux -> no-op.
     monkeypatch.setattr(ct, "_content_sha", lambda rr, p, git_ref="HEAD": None)
+    # Discrimination reachability (#11919) : recorded == courant (meme SHA),
+    # donc trivialement accessible depuis HEAD.
+    monkeypatch.setattr(ct, "_blob_ancestor_in", lambda rr, blob_sha, ref="HEAD": True)
 
     audit, cur_py, is_noop = update_pair(tmp_path, fake_pair)
     assert cur_py == "a" * 40


### PR DESCRIPTION
Grain: DEEP/refactor — lane myia-po-2026:CoursIA-2 — prev: MED/guard #11902 (c.408)

fix(twin,#11919): rebaseline les paires orphelines par squash via reachability

## Périmètre (déclaré en début de body — leçon L978)

**3 fichiers** (142/32 lignes, tests inclus):

| Fichier | insertions | deletions |
|---|---|---|
| `scripts/notebook_tools/check_twin_parity.py` | +63 | -0 |
| `scripts/notebook_tools/tests/test_check_twin_parity_squash_orphan.py` | +85 | -14 (modified helper, scenarios refactor) |
| `scripts/notebook_tools/tests/test_twin_registry_integrity.py` | +19 | -1 (3 tests existants adaptes au mock `_blob_ancestor_in`) |

Workflows CI touchés : aucun. Période de portée : PR atomic, 1 bug fix + 1 helper reachability + tests adaptés.

## Note sur le tag (c.402-L3 ★★)

Pivot **DEEP/guard → DEEP/refactor** : le picker R5 a classé ce grain `guard` (outil de parité), la substance est `refactor` (changement comportemental de `update_pair` + helper `_blob_ancestor_in` + 3 tests qui vérifient une nouvelle branche de discrimination). Le label initial a déclenché G-VAR-3 (genre `guard` LIGHT consécutif après c.408). Le picker classe par l'INSTRUMENT, le worker tranche selon la SUBSTANCE — la substance est ici un refactor du chemin de décision no-op avec un nouveau helper de discrimination.

## Contexte

Le gate no-op de `--update` (cf #9399 volet c) comparait jusqu'ici les `content_*_sha` (SHA-256 du notebook **sans** `nb["metadata"]`), ce qui le rendait immune aux changements metadata-only — bon design. Mais un cas échappait : un **squash-merge** qui re-hashe le blob git sans toucher le contenu du notebook.

Le scenario fondateur (mesuré 2026-08-20 sur `main`) : Probas-13 Crowdsourcing avait son `python_sha` enregistre pointe sur un blob orphelin par le squash de #11878. Le contenu du notebook etait intact, mais le blob SHA n'etait plus ancre sur main.

```
$ check_twin_parity.py --pair "Probas-13 Crowdsourcing" --verify-recorded-sha --check
[MISMATCH] python_sha: recorded=bd40c841e143 calculated=efce50915b82

$ check_twin_parity.py --update --pair "Probas-13 Crowdsourcing" --by ...
Refusees (no-op) : Probas-13 Crowdsourcing
Registre rebaseline : 0 paire(s) mise(s) a jour
```

Deux sous-commandes du **même outil**, sur la **même paire**, au **même instant** : l'une dit « incoherent », l'autre dit « rien a faire ».

## Itération v1 → v2 (commit `82639ea24` → `63056ae0`)

Le premier commit (`82639ea24`, sur cette branche avant ce push) discriminait l'orphelin par squash du metadata-only drift par simple comparaison `rec_X != cur_X`. **Mais les deux cas ont la MEME signature sur ce test** :

| Cas | `rec_py` | `cur_py` | `_shas_match` | Discrimination v1 |
|---|---|---|---|---|
| Orphelin squash (#11919) | orphelin | nouveau | True (content_sha idem) | `rec != cur` → `is_noop=False` ✓ |
| Metadata-only drift (#9399 Sudoku-8/14) | ancetre | nouveau | True (content_sha idem) | `rec != cur` → `is_noop=False` ✗ |

Le test pré-existant `test_update_pair_metadata_only_drift_is_noop` (l.788 de `test_twin_registry_integrity.py`, anti-regression explicite du design-gate #9399 critere 2) a rougi sur le premier commit. La discrimination v1 violait le design-gate.

**Discrimination correcte** : demander à git si le recorded blob SHA est **accessible depuis HEAD** via `git rev-list --objects HEAD`. Un orphelin par squash N'EST PAS accessible (le commit qui le portait a été elimine par le squash). Un metadata-only drift L'EST (le buffer metadata seul change, le commit qui porte l'ancien blob reste ancêtre de HEAD).

```python
def _blob_ancestor_in(repo_root: Path, blob_sha: str, ref: str = "HEAD") -> bool:
    """Vrai si `blob_sha` est accessible depuis `ref` (= un commit ancetre le reference).

    Discrimination cle du fix #11919 : un squash-merge peut re-hasher le git
    blob SHA d'un notebook sans toucher le contenu didactique. Le recorded
    `python_sha`/`csharp_sha` pointe alors sur un blob qui n'est PLUS ancre
    d'aucun commit accessible (orphelin par squash). Mais un cas
    distinct -- metadata-only drift (Sudoku-8/14 BDD, design-gate #9399
    critere 2) -- produit lui aussi un recorded blob SHA divergent de HEAD
    (le `_git_blob_sha` actuel change quand `nb["metadata"]` change, meme si
    `content_*_sha` est preserve). Les deux cas ont la MEME signature sur
    `rec_X != cur_X`, mais le deuxieme n'est PAS un orphelin : son blob
    reste accessible (il est reference par un commit ancetre de HEAD, juste
    pas le commit HEAD lui-meme).

    La discrimination : `git rev-list --objects <ref>` enumere tous les blobs
    reference par les commits accessibles depuis `<ref>`. Si `blob_sha` y
    figure, c'est un metadata-only drift (pas un orphelin). Sinon, c'est un
    orphelin par squash : le rebaseline doit le corriger.
    """
    if not blob_sha or len(blob_sha) != 40:
        return False
    r = subprocess.run(
        ["git", "rev-list", "--objects", ref],
        capture_output=True, text=True, cwd=str(repo_root),
    )
    if r.returncode != 0:
        return False
    return blob_sha in r.stdout
```

**Fix dans `update_pair`** :

```python
if is_noop and latest:
    rec_py = latest.get("python_sha")
    rec_cs = latest.get("csharp_sha")
    py_orphan = rec_py is not None and not _blob_ancestor_in(repo_root, rec_py)
    cs_orphan = rec_cs is not None and not _blob_ancestor_in(repo_root, rec_cs)
    if py_orphan or cs_orphan:
        is_noop = False
```

## Acceptance — 3 tests (squash_orphan) + 5 tests adaptés (registry)

### Nouveaux (squash_orphan)
1. **`test_squash_orphan_mismatch_then_noop_defect`** : reproducer exact du cas fondateur. Crée un blob orphelin (branche ephemere + gc), l'écrit dans le registre comme recorded, vérifie que `--update` lève `is_noop=False` via `_blob_ancestor_in`.
2. **`test_real_noop_still_refused`** : garde anti-regression — un vrai no-op (recorded == HEAD sur content_sha **et** git blob SHA) reste refuse.
3. **`test_real_content_change_is_not_noop`** : un changement de prose reelle (content_sha diff) n'est PAS un no-op.

### Adaptés (registry)
- `test_update_pair_no_op_when_content_sha_matches` : mock `_blob_ancestor_in → True` (recorded == HEAD, accessible).
- `test_update_pair_metadata_only_drift_is_noop` : mock `_blob_ancestor_in → True` (le recorded est un ancetre, juste pas HEAD).
- `test_update_pair_no_op_via_git_blob_sha_fallback` : mock `_blob_ancestor_in → True` (legacy form, recorded == HEAD).

## Vérifications pre-commit

| Verification | Résultat |
|---|---|
| `pytest scripts/notebook_tools/tests/` (full suite) | **4904 passed, 2 skipped** (126s) |
| `pytest scripts/notebook_tools/tests/test_twin_registry_integrity.py` | **30 passed** |
| `pytest scripts/notebook_tools/tests/test_check_twin_parity_*.py` | **25 passed** (3 squash_orphan + 22 autres) |
| gitleaks | **PASSED** |
| Pre-commit hooks | **PASSED** (gitleaks uniquement, pas de notebook/papermill sur ce PR) |

## Conformité

- **G.1** : tous claims vérifiés firsthand (test reproducer + measurements JSON `current_*_sha` vs `recorded_*_sha` dans la sortie + `_blob_ancestor_in` testé en isolation).
- **G.4** : PR atomic (1 helper + 1 modification de fonction + 1 fichier test adapte, 1 bug, 1 discrimination).
- **G-VAR-1** : DEEP/refactor, substance (eliminer un comportement d'organe qui détecte un MISMATCH mais refuse le rebaseline, fix vérifiable par test autonome).
- **G-VAR-3** : genre `refactor` ≠ genre `guard` du grain précédent (c.408) — ban levé.
- **L898 ★★★** : pas applicable (PR propre, pas de continuation).
- **L978 ★★** : périmètre déclaré en début de body (3 fichiers / +167/-15).
- **C.3** : N/A (pas de notebook).
- **variation-protocol** : tag `Grain: DEEP/refactor — lane myia-po-2026:CoursIA-2 — prev: MED/guard #11902 (c.408)` en première ligne.

## See / Closes

- **See #11919** (livré en 1 cycle après 2 iterations de fix, scope couvert).
- **See #11878** (squash-merge fondateur, PR qui a créé le pattern orphelin).

## Suite logique

- Merger ce PR **restaure** la possibilité de `--update` Probas-13 Crowdsourcing (et toutes les paires ayant le meme pattern post-squash).
- Une PR de follow-up peut passer `--update` sur les paires orphelines (post-merge). Pas dans le scope de cette PR.

