### PR TITLE
fix(slides,#10950): le fond du theme couvre le canvas entier (bande blanche sur slide courte)

### DIFF
--- a/slides/theme-ia101/styles/index.css
+++ b/slides/theme-ia101/styles/index.css
@@ -20,6 +20,11 @@
   background-color: var(--color-bg);
   padding: 28px 40px;
   text-align: left;
+  /* Le fond doit couvrir le canvas entier : sans hauteur, la boite est
+   * dimensionnee par son contenu, et une slide courte laisse une bande
+   * blanche sous le pale (mesure : pale s'arretant a 442px pour 552). */
+  min-height: 100%;
+  box-sizing: border-box;
 }
 
 /* Headers */


### PR DESCRIPTION
Grain: MED/slides — lane myia-ai-01:CoursIA — prev: MED/twin #11918

## Le défaut

`.slidev-layout`, dans le thème partagé `theme-ia101`, porte un `background-color` **sans hauteur**. Une boîte CSS sans hauteur est dimensionnée par son contenu : dès qu'une slide est plus courte que le canvas, le fond pâle s'arrête avec le texte et le reste du canvas passe en blanc.

Mesuré : sur une slide courte, le pâle s'arrête à **442 px** pour un canvas de **552 px** — 110 px de bande blanche en bas, sur un fond qui devrait être uniforme.

## Le correctif

```css
min-height: 100%;
box-sizing: border-box;
```

`box-sizing` n'est pas décoratif ici : le padding `28px 40px` est déjà appliqué à cette boîte, donc sans lui `min-height: 100%` déborderait de 56 px verticalement et rendrait une barre de scroll dans le canvas.

## Portée

Le défaut est dans le **thème**, pas dans un deck : les **19 decks** du dépôt en héritent. Aucun contenu de deck n'est touché par cette PR — le diff est de 5 lignes dans une seule feuille de style.

## Vérification

`slidev build` sur `S3-acculturation/slides.md` avec cette feuille : **EXIT=0**, 939 modules, 12,81 s. C'est une vérification de non-régression du build, pas une preuve de rendu — le jugement visuel de la composition reste dû, et il appartient à une lane qui voit (mandat user 2026-08-20, cf #11923).

## Contexte

Trouvé en instrumentant la campagne axe 2 #10950 (conversion `two-cols` → images en absolu). Il est livré **séparément** de la campagne : c'est un défaut de thème indépendant du contenu des slides, et le mêler à une tranche de conversion aurait rendu les deux inaudibles.

See #10950
