### PR TITLE
docs(slides,#10950): motif de mise en page des decks — la grille n'etait pas impossible, il manquait une ligne vide

### DIFF
--- a/docs/reference/slides-layout-pattern.md
+++ b/docs/reference/slides-layout-pattern.md
@@ -1,0 +1,81 @@
+# Slidev — motif de mise en page des decks de cours
+
+Cible : les decks `slides/**` portes par la campagne **#10950**. Ecrit apres qu'un diagnostic « les grilles sont impossibles dans Slidev » ait bloque trois iterations de reparation sur un deck. Le constat qui l'a produit etait vrai ; la conclusion ne l'etait pas.
+
+## La baseline, c'est le PPTX du user
+
+Mandat user (2026-08-20) : *« la baseline, ce sont les render de mes pptx [...] si c'est encore plus moche, alors pas la peine d'aller plus loin »*. Et sur la composition : *« La baseline pptx n'est pas bicolonne. Certains slides ont LE TEXTE en bicolonnes [...] mais les images ont toujours ete positionnees a la main. »*
+
+D'ou les trois regles ci-dessous. Elles ne sont pas un style-guide : ce sont les contraintes qui reproduisent le rendu de reference.
+
+## Les trois regles
+
+1. **Layout `default`, `h1` pleine largeur.** Ne **jamais** utiliser `two-cols` pour un titre + deux colonnes de texte : le theme pose `h1 { border-bottom: 2px solid var(--color-accent) }` ([`slides/theme-ia101/styles/index.css`](../../slides/theme-ia101/styles/index.css)), donc sous `two-cols` le filet suit la colonne et **la barre de titre est coupee en deux**. C'est le defaut visuel que le user a explicitement demande de supprimer.
+
+2. **Le texte bicolonne va dans un `<div class="grid grid-cols-2 gap-10">` au niveau du corps, sous le titre.** Pas dans un layout, pas autour du titre.
+
+3. **Chaque image est placee a la main, en absolu** : `class="absolute top-[Npx] left-[Npx]"` (ou `right-[Npx]`). **Jamais dans le flot.** Une image en flot se centre, pousse le texte, et laisse la moitie de la slide vide — c'est exactement ce que la bicolonne avait ete introduite pour eviter, et qu'elle n'a pas evite.
+
+## Le piege qui fait croire les grilles impossibles
+
+Mettre une liste markdown dans un `<div class="grid">` fait rendre a Vue :
+
+```
+Element is missing end tag
+```
+
+**Cause : la regle HTML-block de markdown-it.** Un bloc HTML se ferme sur une **ligne vide**, et le parsing markdown ne reprend qu'**apres** cette ligne vide. Sans elle, la liste est avalee dans le HTML brut et le fragment devient invalide.
+
+Le remede n'est donc pas d'abandonner la grille : c'est une ligne vide.
+
+```markdown
+<div class="grid grid-cols-2 gap-10">
+<div>
+
+**Titre de colonne**
+
+- premiere puce
+- seconde puce
+
+</div>
+<div>
+
+**Autre colonne**
+
+- ...
+
+</div>
+</div>
+```
+
+**Les lignes vides apres chaque `<div>` ouvrant et avant chaque `</div>` fermant ne sont pas cosmetiques — elles sont le mecanisme.** Les retirer casse le rendu.
+
+Contre-exemple deja present dans le depot avant que le diagnostic « impossible » soit pose : [`slides/S3-acculturation/deck-executif.md:39-41`](../../slides/S3-acculturation/deck-executif.md#L39-L41) — un `grid grid-cols-3` qui construit, et qui porte la ligne vide.
+
+## Geometrie du canvas — 980 x 552, et le facteur d'echelle
+
+Sans `canvasWidth` / `aspectRatio` / `canvasHeight` dans le headmatter, Slidev applique son defaut : **980 x 552**. Verifier le headmatter avant d'ecrire le moindre `top-[Npx]` — un deck calcule contre une autre constante produit des positions fausses **partout**, et l'erreur se propage a chaque reparation suivante.
+
+**`getBoundingClientRect` rend des px MIS A L'ECHELLE**, pas des px CSS. Diviser par `scaler.width / 980` avant toute comparaison a une utilitaire `top-[Npx]` / `max-h-[Npx]`. Facteur mesure sur un viewport 1280 : **1,3061**. Sans cette division on lit « 391 px » sur un element a `max-h-[300px]` et on diagnostique un debordement qui n'existe pas.
+
+## Mesurer un deck servi — l'instrument doit nommer ce qu'il mesure
+
+Le DOM d'un deck Slidev contient **une `.slidev-layout` par slide** (82 sur le deck S3-acculturation), et **une seule est visible** : toutes les autres ont une bounding box de taille **0**. Un `document.querySelector('.slidev-layout')` attrape la premiere, donc une cachee, donc `width = 0` — et tout calcul divise par ce zero rend `null` **sans erreur**.
+
+Selectionner la visible par aire maximale, et **faire rendre a l'instrument l'identite de ce qu'il vient de mesurer** (le `h1` de la slide) a cote de la valeur. C'est ce qui distingue « mesure d'une slide vide » de « mesure de la bonne slide ».
+
+## Ce qu'une mesure de debordement ne dit pas
+
+Un controle `bottom > canvasHeight` est necessaire et **tres insuffisant** : il **certifie implicitement tout ce qu'il ne teste pas**. Une slide dont la moitie droite est vide, dont les images sont centrees dans le flot et dont une note orpheline chevauche le pied de page peut passer ce controle sans broncher.
+
+**Directive user (2026-08-20) : sur une composition, le plancher mecanisable n'est jamais le critere d'acceptation.** Un `slidev build` EXIT=0 prouve que le deck *construit*, rien de son rendu. L'acceptation reste un jugement visuel, porte par une lane qui **voit** (cf [`cluster-agents.md` §Capacite vision](cluster-agents.md)). Une estimation arithmetique de hauteur de contenu ne remplace pas non plus le regard : mesuree une fois a **224 px** d'ecart avec le rendu reel.
+
+## Fond du theme
+
+`.slidev-layout` porte `background-color` ; sans hauteur, la boite est dimensionnee par son contenu et **toute slide courte laisse une bande blanche** en bas du canvas (mesure : pale s'arretant a 436 px et 393 px sur deux slides d'un canvas de 552). Corrige par `min-height: 100%` + `box-sizing: border-box` — le padding `28px 40px` etant deja sur cette boite. C'est **du theme**, donc les 19 decks en heritent : ne pas le recorriger deck par deck.
+
+## Voir aussi
+
+- **#10950** — campagne de refonte des decks
+- [`cluster-agents.md`](cluster-agents.md) — routage du QA visuel vers une lane qui voit
+- [`slide-analyzer-sk-agent.md`](slide-analyzer-sk-agent.md) — analyse de deck par vision


### PR DESCRIPTION
Grain: MED/docs — lane myia-ai-01:CoursIA — prev: MED/slides #11979

## Pourquoi ce document

Le motif de mise en page demande par le user pour les decks de cours — **titre pleine largeur + texte bicolonne dans le corps + images placees a la main** — avait ete diagnostique **impossible** dans Slidev : Vue rend `Element is missing end tag` des qu'une liste markdown entre dans un `<div class="grid">`. Trois iterations de reparation sur un deck se sont construites sur ce diagnostic, en cherchant des contournements (couper des puces, dedoublonner du contenu, remettre les images dans le flot) plutot qu'en le refutant.

**Le constat etait exact. La conclusion ne l'etait pas.**

Cause : la regle **HTML-block de markdown-it** — un bloc HTML se ferme sur une **ligne vide**, et le parsing markdown ne reprend qu'apres elle. Sans ligne vide, la liste est avalee dans le HTML brut et le fragment devient invalide.

Un contre-exemple vivait deja dans le depot pendant tout ce temps : [`slides/S3-acculturation/deck-executif.md:39-41`](../blob/main/slides/S3-acculturation/deck-executif.md#L39-L41), un `grid grid-cols-3` qui construit — et qui porte la ligne vide en l.40.

## Verifie deux fois

- `slidev build` sur la variante grille + lignes vides : **EXIT=0, 12,81 s** ;
- **rendu regarde a l'ecran** (le build ne prouve rien du rendu) : titre pleine largeur avec le filet rouge traversant toute la slide, deux colonnes de texte, trois images en absolu, moitie droite occupee, **zero contenu perdu**.

## Ce que le document consigne d'autre

Les quatre choses qui ont fait echouer les tentatives precedentes, et qui se re-paieront a chaque deck si elles ne sont ecrites nulle part :

| | |
|---|---|
| **Constante de canvas** | **980 x 552** par defaut sans `canvasWidth`/`aspectRatio` dans le headmatter. Un deck calcule contre une autre constante produit des positions fausses partout, et l'erreur se propage a chaque reparation |
| **Facteur d'echelle** | `getBoundingClientRect` rend des px **mis a l'echelle** (1,3061 mesure ici), pas des px CSS. Sans division on lit « 391 px » sur un `max-h-[300px]` et on diagnostique un debordement inexistant |
| **82 `.slidev-layout` dans le DOM** | une seule est visible, toutes les autres ont une bounding box de **taille 0**. `querySelector` attrape une cachee, la division rend `null` **sans erreur**. D'ou : selectionner par aire maximale **et faire nommer a l'instrument la slide qu'il vient de mesurer** |
| **Portee d'un controle de debordement** | `bottom > canvas` **certifie implicitement tout ce qu'il ne teste pas**. Une slide a moitie vide, images centrees dans le flot, note orpheline sur le pied de page, le passe sans broncher. Ecart mesure entre une estimation arithmetique de hauteur et le rendu reel : **224 px** |

## Portee

Documentation seule — aucun deck modifie, aucun comportement change. Le correctif de fond du theme est livre separement en **#11979** ; l'application du motif aux slides restantes appartient aux lanes qui portent les decks.

Ce document ne prononce **aucune acceptation visuelle** : conformement a la directive user du 2026-08-20, sur une composition le plancher mecanisable n'est jamais le critere d'acceptation, et le jugement reste porte par une lane qui voit.

See #10950
