### PR TITLE
fix(test,#11934): main casse — le litmus drift mesure un delta, plus un total dependant de la dette du corpus

### DIFF
--- a/scripts/translation/tests/test_demo_t3_t4_acceptance.py
+++ b/scripts/translation/tests/test_demo_t3_t4_acceptance.py
@@ -82,10 +82,23 @@ def test_couture_active():
 def test_drift_count_is_consistent():
     """Le nombre de cellules en SRC_DRIFT est rapporte de maniere coherente.
 
-    Fixture synthetique (voir _make_drifted_csv) : le corpus live etant
-    resynchronise par l'amorcage #10329 etape 2, la demonstration du drift
-    s'appuie sur un CSV derive falsifie, pas sur la dette reelle.
+    Fixture synthetique (voir _make_drifted_csv) : le drift est garanti par
+    falsification de 2 lignes, pas par la dette reelle du corpus.
+
+    L'assertion porte sur le DELTA que la falsification introduit, jamais sur
+    les totaux absolus. La version d'origine comparait
+    ``drift_with_filled_text_en == src_drift_in_csv``, ce qui n'est vrai que si
+    le corpus live porte zero dette -- l'etat du jour ou #10329 etape 2 l'a
+    resynchronise, et d'aucun autre : la moindre re-execution d'un notebook
+    FineTuning fait rederiver des ``src_hash`` et casse l'egalite. Mesure du
+    2026-08-20 sur ``main`` : ``finetuning.csv`` reporte 3 lignes en drift dont
+    1 seule avec ``text_en`` rempli, d'ou ``assert 3 == 5``.
+
+    Le meme piege avait ete vu et desamorce dans ``test_t3_captures_drift_now``
+    (#11934, commentaire « l'egalite stricte ne tenait que sur l'ancien corpus
+    endette ») ; il est reste entier dans ce test-ci.
     """
+    base = _run_demo("--csv", str(Path("translations") / "genai" / "finetuning.csv"))["drift"]
     drifted_csv = _make_drifted_csv()
     try:
         report = _run_demo("--csv", str(drifted_csv))
@@ -95,9 +108,16 @@ def test_drift_count_is_consistent():
     assert drift["src_drift_total"] > 0
     # src_drift_in_csv <= src_drift_total (toutes les cellules sont dans le CSV test)
     assert drift["src_drift_in_csv"] <= drift["src_drift_total"]
-    # Tous les drifts observes sur le perimetre de test sont des cellules markdown
-    # dont text_en est rempli (issue #10042).
-    assert drift["drift_with_filled_text_en"] == drift["src_drift_in_csv"]
+    # Les 2 lignes falsifiees ont text_fr ET text_en remplis : chacune ajoute
+    # +1 a src_drift_in_csv ET +1 a drift_with_filled_text_en (pivot #10287 --
+    # un drift dont la traduction est deja remplie doit etre detecte quand
+    # meme). La dette preexistante s'annule dans la difference, donc le test
+    # mesure la propriete voulue et rien d'autre.
+    #
+    # Controle negatif (2026-08-20) : en portant la fixture de 2 a 3 lignes
+    # falsifiees, ce test echoue en « assert (6 - 3) == 2 ». Il mord.
+    assert drift["src_drift_in_csv"] - base["src_drift_in_csv"] == 2
+    assert drift["drift_with_filled_text_en"] - base["drift_with_filled_text_en"] == 2
 
 
 def test_t3_captures_drift_now():


### PR DESCRIPTION
Grain: MED/test — lane myia-ai-01:CoursIA — prev: MED/docs #11982

## Périmètre

`scripts/translation/tests/test_demo_t3_t4_acceptance.py`, +25/−7. Rien d'autre.

## `main` est cassé, et le rouge tombe sur les PRs des autres

`Scripts Tests (CPU)` est rouge sur **au moins 6 PRs ouvertes** (#11902, #11929, #11935, #11974, #11976, #11980, #11983). Le même test, partout :

```
scripts/translation/tests/test_demo_t3_t4_acceptance.py::test_drift_count_is_consistent
E   assert 3 == 5
====== 1 failed, 8832 passed, 31 skipped, 5 xfailed in 171.79s ======
```

Ce n'est pas leur faute : la rupture est sur `main`. Bisect sur les 32 commits du jour :

```
$ git bisect start e2cdd3d51 fbe61eb57
$ git bisect run python -m pytest scripts/translation/tests/test_demo_t3_t4_acceptance.py -q
0a3dddbd1df51cf5f60ce47969e122163308d9af is the first bad commit
  feat(translation,#10329): T1 full-perimeter seeding on main — indexing debt 889 -> 0 (#11934)
```

## Pourquoi le test ne pouvait pas tenir

Le litmus comparait deux **totaux absolus** :

```python
assert drift["drift_with_filled_text_en"] == drift["src_drift_in_csv"]
```

L'égalité n'est vraie que si le corpus live porte **zéro dette** — l'état exact du jour où l'amorçage T1 a resynchronisé tous les `src_hash`, et d'aucun autre. Le docstring de la fixture le dit lui-même : *« src_drift_total est passé à 0 sur le CSV live »*. C'est un **présent daté**, écrit comme un invariant.

La moindre re-exécution d'un notebook FineTuning fait redériver des `src_hash`. Mesure sur `main` à `e2cdd3d51` :

```
$ python scripts/translation/demo_t3_t4_acceptance.py --csv translations/genai/finetuning.csv
"src_drift_in_csv": 3,  "drift_with_filled_text_en": 1
```

3 lignes en drift réel, dont 1 seule avec `text_en` rempli. La fixture en ajoute 2 (les deux avec `text_fr` **et** `text_en`) → `src_drift_in_csv = 5`, `drift_with_filled_text_en = 1 + 2 = 3`. D'où `assert 3 == 5`, à l'unité près.

## La correction

L'assertion porte sur le **delta** que la falsification introduit, mesuré contre une ligne de base prise sur le CSV intact :

```python
base = _run_demo("--csv", "translations/genai/finetuning.csv")["drift"]
...
assert drift["src_drift_in_csv"]          - base["src_drift_in_csv"]          == 2
assert drift["drift_with_filled_text_en"] - base["drift_with_filled_text_en"] == 2
```

La dette préexistante s'annule dans la différence. Le test mesure la propriété qu'il prétend garder — *un drift dont la traduction est déjà remplie est détecté quand même*, le pivot #10287 — et **rien d'autre**.

C'est **plus strict** que l'original : l'ancien acceptait n'importe quelle égalité de totaux, le nouveau épingle le delta exact que la fixture produit.

## Vérification

| Contrôle | Résultat |
|---|---|
| `pytest scripts/translation/tests/ -q` | **338 passed** in 35.86s |
| **Contrôle négatif** — fixture portée de 2 à 3 lignes falsifiées | **échoue** : `assert (6 - 3) == 2` |

Le contrôle négatif est là parce qu'un test qui passe ne prouve pas qu'il mord. Celui-ci mord.

## Le sibling — c'est la deuxième fois

`test_t3_captures_drift_now`, **dans le même fichier**, portait le même piège et a été désamorcé par #11934 elle-même, qui l'écrit noir sur blanc :

> *« l'egalite stricte plan == drift_with_filled ne tenait que sur l'ancien corpus endette »*

L'auteur a vu la classe, l'a nommée, l'a corrigée **dans un test** — et le test voisin, à trente lignes de là, a gardé le défaut entier. Corriger un mécanisme dupliqué sans greper son jumeau laisse la moitié du défaut en place ; c'est le même motif que #11532 / #11627 (deux ratchets identiques mot pour mot, le second redécouvert deux heures plus tard par des PRs rouges à tort).

## Ce que l'incident dit du merge-gate, moi compris

`Scripts Tests (CPU)` de #11934 a tourné à **11:32Z** et est passé. La PR a été mergée à **16:24Z** — **cinq heures plus tard**, sur un `main` qui avait avancé entre-temps.

Le vert était réel. Il portait simplement sur une base qui n'existait plus. **Un check vert a une base, et cette base a une date de péremption** — `mergeStateStatus: CLEAN` ne dit rien de cet écart, et je n'ai pas posé la question en mergeant. Le remède est mécanique : `gh pr update-branch` avant de merger un vert de plusieurs heures.

Aggravant : `Scripts Tests (CPU)` ne tourne **que** sur `pull_request`. `main` ne le lance jamais. La rupture est donc invisible là où elle vit, et ne se manifeste que comme un rouge sur les PRs **suivantes** — qui le lisent naturellement comme le leur. Six lanes ont hérité d'un défaut qu'aucune n'a écrit.

See #11934, #10329, #10287.
