### PR TITLE
fix(ci,#4362): conway_cgt_lean manifest bumps now trigger the Lean gates (#8712)

### DIFF
--- a/.github/workflows/lean-conway-cgt.yml
+++ b/.github/workflows/lean-conway-cgt.yml
@@ -1,7 +1,10 @@
 name: Lean CI (conway_cgt_lean)
 
 # CI for conway_cgt_lean (GameTheory/conway_cgt_lean).
-# Combinatorial game theory port. 0 sorry (raw=0, verified). Toolchain v4.31.0-rc1.
+# Combinatorial game theory port. 0 sorry (raw=0, verified). Toolchain v4.31.0-rc2
+# by design: matched to upstream CombinatorialGames @ 3c6dcdbc (cf lakefile, #6116).
+# Fleet is on v4.32.1 but upstream never lived under it (jumped v4.31.0-rc2 ->
+# v4.33.0-rc1 in 3c0e6d35): bumping requires a fleet-level call, not a lane one.
 # Consolidated per ai-01 DRY decision (option 2: matrix). See lean-build.yml.
 
 on:
@@ -12,6 +15,10 @@ on:
       - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lean-toolchain'
+      # A manifest bump swaps the Mathlib under the proofs -- it MUST trigger
+      # the axiom/build gates (cf #8712, same class: a gate blind to a change
+      # that alters proof dependencies is no gate).
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lake-manifest.json'
   pull_request:
     branches: [main]
     paths:
@@ -19,6 +26,7 @@ on:
       - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.lean'
       - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lakefile.toml'
       - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lean-toolchain'
+      - 'MyIA.AI.Notebooks/GameTheory/conway_cgt_lean/lake-manifest.json'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2024:CoursIA — prev: DEEP/notebook-dotnet #11976

See #4362

## Summary

La moitié exécutable du grain conway_cgt : le **paths-fix (cf #8712)** (même classe que grothendieck ce matin, #11936). La moitié bump est **gated upstream** — faits firsthand ci-dessous, décision fleet à prendre (ai-01).

Périmètre : 1 fichier (workflow CI).

## Livrable

`lean-conway-cgt.yml` :
- `lake-manifest.json` ajouté aux paths-filters des deux triggers (push + pull_request) — un bump de manifest swaps le Mathlib sous les preuves ; les gates axiom/build doivent se réveiller (cf #8712 : un gate aveugle à un changement qui altère les dépendances de preuve n'est pas un gate).
- Commentaire d'en-tête corrigé et enrichi : il portait "Toolchain v4.31.0-rc1" (périmé deux fois — le lake est à rc2). Documente désormais le pairing délibéré v4.31.0-rc2 ↔ CombinatorialGames `3c6dcdbc` (#6116) et pourquoi le bump fleet est gated.

## Pourquoi le bump v4.32.1 n'est PAS dans cette PR (faits firsthand)

1. conway_cgt_lean est le **seul** lake de la flotte encore hors v4.32.1 (inventaire exhaustif fait : 24 lakes, tous v4.32.1 sauf celui-ci + 1 fixture hors-scope `reference_docs/stable_marriage`).
2. Ce n'est pas un oubli : le lakefile documente le pairing — toolchain apparié à upstream CombinatorialGames `3c6dcdbc` (v4.31.0-rc2) pour que le cache olean mathlib hit (#6116, le `require mathlib` direct non-pinné cassait le build avec deux pin sets divergents).
3. **Upstream n'a jamais vécu sous v4.32.1** : l'historique `git log -- lean-toolchain` de vihdzp/combinatorial-games montre un seul commit toolchain après notre pin — `3c0e6d35` (2026-07-29) qui saute **directement à v4.33.0-rc1** (mathlib `5eec30bc56`).
4. Bumper sous v4.32.1 avec le pin actuel = recompiler mathlib `acbd8f0` depuis les sources sous un toolchain non-apparié : heures de build, risque OOM, aucune garantie de stabilité API. Contre-indiqué.

**Options pour ai-01** (design-gate, pas une décision de lane) :
- **(a)** suivre upstream rc1 (`3c0e6d35` ou master `99a469a2`) → lake seul en v4.33.0-rc1, flotte désynchronisée sur un rc ;
- **(b)** attendre le stable v4.33.0 et mover toute la flotte d'un coup (le pairing remarchera) ;
- **(c)** statu quo pairing v4.31.0-rc2 (le lake build, 0 sorry, rien n'est cassé).

Je recommande **(b)**. Aucune de ces options n'invalide le paths-fix livré ici — il est valable quelle que soit la version.

## Validation

- `yaml.safe_load` sur le workflow modifié : OK.
- Aucun changement de code Lean (`*.lean` inchangés, count_code_sorry 0 attendu — vérifié 0/0/0 avant édition).
- Pre-commit Passed (gitleaks, H.3 — aucun notebook touché).
