### PR TITLE
fix(guard,#11985): 6 out-of-perimeter count forms + body-level rule 1 in perimeter guard

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -321,6 +321,8 @@ INCIDENTAL_QUALIFIERS = frozenset({
     "nouvelle", "nouvelles", "varies", "variés", "synthetiques",
     "synthétiques", "scripts", "cache", "generes", "générés", "produits",
     "produites", "sources", "source",
+    # #11985 formes 3-4: artifact kinds and scan inventories.
+    "audio", "distinct", "distincts", "distinctes", "non-notebook",
 })
 # A cited threshold ("< 15 fichiers", ">= 10 fichiers") quotes a rule, it does
 # not claim a perimeter.
@@ -351,6 +353,61 @@ NEGATED_DIFF_TAIL = re.compile(
     r"|intacts?|untouched|unchanged|unmodified)\b",
     re.IGNORECASE,
 )
+# ---------------------------------------------------------------------------
+# #11985 -- counts that describe ANOTHER OBJECT than the PR's head. Measured
+# on the 20/08 corpus: 7 of 9 perimeter-red PRs were false positives, and the
+# founding asymmetry is that the guard's EQUALITY confrontation (claimed ==
+# len(files)) can never validate these shapes -- it confronts a sub-sum, an
+# inventory, a past revision or a rejected alternative. Same path as #11712:
+# detection UNCHANGED (the line is still extracted and printed), only the
+# consequence moves.
+# ---------------------------------------------------------------------------
+# Forme 5, past self-description: an imparfait + a commit SHA or a #PR ref on
+# the same line describe a SUPERSEDED version of the PR. The diffstat in that
+# line measures the old commit, not the head -- so this rule overrides the
+# diffstat guard (#11790: "couvrait 160 fichiers / +31502/-80470", real PR = 1
+# file). The imparfait is closed-list: genuine perimeter assertions are in the
+# present tense.
+PAST_REFERENCE = re.compile(
+    r"\b(?:couvrait|contenait|comprenait|comportait|touchait)\b", re.IGNORECASE
+)
+HASH_OR_PR_REF = re.compile(r"\b[0-9a-f]{7,40}\b|#\d+")
+# Forme 6, counterfactual: the count describes the PR that was NOT written.
+# The marker must sit BEFORE the first count -- "3 fichiers plutot que 15"
+# keeps its authorial 3. Measured on #11963: "> 1 PR composite (15 fichiers /
+# >3000 lignes)".
+COUNTERFACTUAL_MARKER = re.compile(
+    r"(?:au lieu de|plut[oô]t que|plut[oô]t d'|contrefactuel|\bcomposite\b)",
+    re.IGNORECASE,
+)
+# Forme 1, enumeration component: "X.py (...) + N fichiers de tests" -- the
+# body enumerates 1 + 2 = 3 (exact), the guard reads the sub-sum 2 and can
+# never validate it (#11935). Requires a NAMED file before the "+ N fichiers
+# de tests" tail: the shape is an enumeration of components, not a total.
+ENUMERATION_TAIL = re.compile(
+    r"\+\s*\d+\s*fichiers?\s+de\s+tests?\b", re.IGNORECASE
+)
+NAMED_FILE = re.compile(
+    r"\b[\w.-]+\.(?:py|cs|yml|yaml|json|md|ipynb|ts|js|sh|toml|cfg|ini)\b",
+    re.IGNORECASE,
+)
+# Forme 4, scan result: a "N hits" antecedent before the count ("Apres : 1
+# hit / 1 fichier") counts what the detector FOUND, not what the PR modifies
+# (#11966 l.42).
+HIT_ANTECEDENT = re.compile(r"\b\d+\s*hits?\b", re.IGNORECASE)
+# Formes 2-4, two-word qualifier window: artifact kinds and enumeration tails
+# are often compound ("fichiers audio generes", "fichiers de tests", "fichier
+# test adapte") -- the closed list matches the first OR second word after the
+# count, or their pair.
+# "de tests"/"de test" deliberately ABSENT: the enumeration form 1 requires
+# the "+ N fichiers de tests" tail AND a named file on the line
+# (ENUMERATION_TAIL + NAMED_FILE below). A bare pair would make
+# "2 fichiers de tests modifies" incidental with no named-file guard (#11985
+# FN control).
+INCIDENTAL_QUALIFIER_PAIRS = frozenset({
+    "audio generes", "audio générés",
+    "test adapte", "test adapté",
+})
 DIFFSTAT_NEIGHBORHOOD = re.compile(
     r"\+\d+\s*/\s*[-−]?\d+|insertions?|deletions?|\blignes?\b|\blines?\b",
     re.IGNORECASE,
@@ -374,12 +431,19 @@ def _count_is_incidental(line: str) -> bool:
     """True when every count on the line denotes something other than the PR's
     file list. Caller-facing guarantee: a line with a scope word or a diffstat
     neighborhood is NEVER incidental via the qualifier/locative rules (FN
-    safety, #11712 acceptance). Two shapes override even those guards, because
+    safety, #11712 acceptance). Four shapes override even those guards, because
     they can never be validated by the guard's EQUALITY confrontation anyway:
-    a zero count (a PR never has 0 files) and a comparison-prefixed count
-    ("< 15 fichiers" cites a threshold; the guard confronts claimed ==
-    len(files), which "<" is not)."""
+    a zero count (a PR never has 0 files), a comparison-prefixed count
+    ("< 15 fichiers" cites a threshold), and -- #11985 -- a count describing
+    ANOTHER object than the head (a table row, a superseded revision, a
+    rejected alternative, an enumeration sub-sum)."""
     low = line.lower()
+    # #11985 forme 4 (table case): a markdown table row is a report structure
+    # (the tube separates the qualifier from its number -- no cell pairing is
+    # a perimeter claim). Extraction already skips rows; this pins the
+    # classification for any direct caller.
+    if line.lstrip().startswith("|"):
+        return True
     matches = list(COUNT_CLAIM.finditer(line))
     if not matches:
         return False
@@ -387,6 +451,16 @@ def _count_is_incidental(line: str) -> bool:
     first_before = line[: first.start()].rstrip()
     if int(first.group(1)) == 0 or COMPARISON_PREFIX.search(first_before):
         return True
+    # #11985 formes 5/6/1 -- the count describes another object than the head:
+    # its diffstat and scope words belong to that object, so these rules sit
+    # BEFORE the guards below.
+    if PAST_REFERENCE.search(low) and HASH_OR_PR_REF.search(line):
+        return True  # superseded revision: "couvrait 160 fichiers" (#11790)
+    marker = COUNTERFACTUAL_MARKER.search(low)
+    if marker and first.start() > marker.start():
+        return True  # rejected alternative: "1 PR composite (15 fichiers)" (#11963)
+    if ENUMERATION_TAIL.search(line) and NAMED_FILE.search(line):
+        return True  # enumeration sub-sum: "X.py + 2 fichiers de tests" (#11935)
     if _has_strong_scope(low) or DIFFSTAT_NEIGHBORHOOD.search(line):
         return False
     for m in matches:
@@ -408,9 +482,26 @@ def _count_is_incidental(line: str) -> bool:
         after = line[m.end():]
         if NEGATED_DIFF_TAIL.match(after):
             continue
+        # #11985 forme 4: a scan antecedent ("1 hit / 1 fichier") -- the count
+        # is what the detector found, not what the PR modifies (#11966).
+        if HIT_ANTECEDENT.search(line[: m.start()]):
+            continue
+        # #11985 formes 2-3: compound qualifier window -- the kind or the
+        # enumeration tail can sit on the SECOND word after the count
+        # ("fichiers audio generes", "fichier test adapte").
         mw = re.match(r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)", after)
+        mw2 = re.match(
+            r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)"
+            r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)",
+            after,
+        )
         if mw and mw.group(1).lower() in INCIDENTAL_QUALIFIERS:
             continue  # "N fichiers MP3/scratch/restants/..." -- kind or remainder
+        if mw2:
+            pair = f"{mw2.group(1)} {mw2.group(2)}".lower()
+            if (mw2.group(1).lower() in INCIDENTAL_QUALIFIERS
+                    or pair in INCIDENTAL_QUALIFIER_PAIRS):
+                continue  # "N fichiers audio generes / de tests / test adapte"
         return False  # this count looks authorial -> the line stays blocking
     return True
 
@@ -757,6 +848,38 @@ def fetch_review_thread(pr: int) -> list[dict]:
     return items
 
 
+def _first_confrontable_count(text: str) -> Optional[int]:
+    """The count `check_assertion` would confront for this text: the first
+    non-zero file-count claim outside fences (None when there is none)."""
+    scan_target = _fence_mask(text)
+    mm = next(
+        (m for m in COUNT_CLAIM.finditer(scan_target) if int(m.group(1)) != 0),
+        None,
+    )
+    return int(mm.group(1)) if mm else None
+
+
+# A count-mismatch problem starts with this prefix (the wording is ours, in
+# check_assertion). Used by the #11985 body-level downgrade to reclassify ONLY
+# count mismatches -- exclusivity violations (#11268-2) and unverifiable
+# wordings keep their blocking force in every case.
+COUNT_MISMATCH_PREFIX = "l'assertion pretend"
+
+
+def is_downgradable_mismatch(cand: "Candidate", problem: str) -> bool:
+    """#11985 regle 1: a blocking count-mismatch from a body that ALSO
+    declares the effective count elsewhere is reclassified to SIGNAL. The
+    rule never disarms: it fires only on count mismatches (never on the
+    #11268-2 workflow criterion) and only when a DECLARATIVE candidate of the
+    same body states the effective count -- an incidental scan scope carrying
+    the right number by coincidence does not validate a wrong header."""
+    return (
+        cand.blocking
+        and cand.body_declares_effective_count
+        and problem.startswith(COUNT_MISMATCH_PREFIX)
+    )
+
+
 @dataclass
 class Candidate:
     """One perimeter assertion, with what decides its consequence."""
@@ -766,6 +889,13 @@ class Candidate:
     author: str
     source: str  # "body" (author-controlled -> blocking) | "thread" (signal)
     ts: str = ""
+    # #11985 regle 1: True when the SAME body carries another, DECLARATIVE
+    # candidate whose count EQUALS the effective file count. The body then
+    # asserts its perimeter correctly somewhere; its other count mismatches
+    # (atomicity arguments, produced artifacts, scan residues) are reclassified
+    # from blocking to signal by the caller. Filled by `select_candidates`
+    # when given `n_files`; the `blocking` property below is untouched.
+    body_declares_effective_count: bool = False
 
     @property
     def blocking(self) -> bool:
@@ -789,7 +919,9 @@ class Candidate:
         return self.source == "body" and not _is_incidental_assertion(self.text)
 
 
-def select_candidates(items: list[dict]) -> tuple[list[Candidate], int | None]:
+def select_candidates(
+    items: list[dict], n_files: Optional[int] = None
+) -> tuple[list[Candidate], int | None]:
     """Extract assertions, keeping only each thread author's LAST ones.
 
     #11648-b1 (supersession). The founding measurement: on #11646 the guard
@@ -811,6 +943,12 @@ def select_candidates(items: list[dict]) -> tuple[list[Candidate], int | None]:
     The flag does NOT change the gate's verdict (CommonMark-fence-to-EOF is
     correct rendering); it makes the false-negative shadow visible to the
     reviewer AND actionable (the author is told which line to close).
+
+    #11985 regle 1: when `n_files` is given, each body's candidates get
+    `body_declares_effective_count` set iff a DECLARATIVE (non-incidental)
+    candidate of that same body states the effective count. The body then
+    asserts its perimeter correctly somewhere, and the caller reclassifies
+    that body's other count mismatches as signals.
     """
     body_items = [i for i in items if i.get("source") != "thread"]
     thread_items = [i for i in items if i.get("source") == "thread"]
@@ -823,8 +961,18 @@ def select_candidates(items: list[dict]) -> tuple[list[Candidate], int | None]:
             _, opener = _fence_line_indices(body)
             if opener is not None:
                 orphan_opener = opener
-        for text in extract_perimeter_assertions(body):
-            out.append(Candidate(text, item["kind"], item["author"], "body"))
+        body_candidates = [
+            Candidate(text, item["kind"], item["author"], "body")
+            for text in extract_perimeter_assertions(body)
+        ]
+        if n_files is not None and any(
+            not _is_incidental_assertion(c.text)
+            and _first_confrontable_count(c.text) == n_files
+            for c in body_candidates
+        ):
+            for c in body_candidates:
+                c.body_declares_effective_count = True
+        out.extend(body_candidates)
 
     # Per thread author, keep the latest assertion-carrying review.
     latest: dict[str, tuple[str, int, dict, list[str]]] = {}
@@ -875,7 +1023,9 @@ def main() -> int:
     signals: list[str] = []
     orphan_opener: int | None = None
     if args.scan_thread:
-        candidates, body_orphan = select_candidates(fetch_review_thread(args.pr))
+        candidates, body_orphan = select_candidates(
+            fetch_review_thread(args.pr), n_files=len(report.files)
+        )
         if body_orphan is not None:
             orphan_opener = body_orphan
         for cand in candidates:
@@ -883,8 +1033,12 @@ def main() -> int:
                 line = f"[{cand.kind} / {cand.author}] {p}"
                 # Every catch stays visible either way -- the detector is not
                 # disarmed, only its consequence is placed where it can be
-                # acted on (#11648).
-                if cand.blocking:
+                # acted on (#11648). #11985 regle 1: a count mismatch from a
+                # body that declares the effective count elsewhere is a
+                # signal, not a block -- the body asserts its perimeter
+                # correctly; the mismatched count denotes another object
+                # (atomicity argument, produced artifact, scan residue).
+                if cand.blocking and not is_downgradable_mismatch(cand, p):
                     report.problems.append(line)
                 else:
                     signals.append(line)

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -18,8 +18,10 @@ from check_pr_perimeter import (  # noqa: E402
     extract_baseline_moves,
     extract_perimeter_assertions,
     format_report,
+    is_downgradable_mismatch,
     select_candidates,
     _check_unterminated_fence,
+    _count_is_incidental,
     _fence_line_indices,
 )
 
@@ -1183,3 +1185,198 @@ def test_signal_explanation_authorial_false_assertion_still_blocking():
     assert len(problems) >= 1, "true authorial false assertion stays blocking"
     cand = Candidate("Cette PR touche 1 fichier twin", "PR body", "jsboige", "body")
     assert cand.blocking is True, "must stay blocking -- not demoted to SIGNAL"
+# ---------------------------------------------------------------------------
+# #11985 -- the six out-of-perimeter count forms and the body-level rule.
+# Every test uses the EXACT line measured on the 20/08 corpus (the issue's
+# recipe: "not a paraphrase -- it is the table tube, the passe compose and the
+# word 'generes' that carry the defect").
+# ---------------------------------------------------------------------------
+
+
+def test_11985_form_table_row_is_incidental():
+    """#11964: the tube separates the qualifier from its number -- no cell
+    pairing is a perimeter claim. Extraction already skips rows; this pins
+    the classification for any direct caller."""
+    line = "| Fichiers avec flowchart(s) ASCII | 10 |"
+    assert _count_is_incidental(line) is True
+
+
+def test_11985_form_scan_result_distinct_is_incidental():
+    """#11964: '10 fichiers distincts, chacun avec 1-3 flowcharts' counts what
+    the detector FOUND, not what the PR modifies (real PR: 3 files)."""
+    line = "10 fichiers distincts, chacun avec 1-3 flowcharts."
+    assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is False
+
+
+def test_11985_form_past_self_description_is_incidental():
+    """#11790 l.5: an imparfait + commit SHA describes the SUPERSEDED initial
+    PR -- its diffstat (+31502/-80470) measures the old commit, not the head
+    (real PR: 1 file). This rule overrides the diffstat guard."""
+    line = (
+        "Le PR #11790 initial (commit 3b221fa1c) couvrait "
+        "**160 fichiers / +31502/-80470 lignes** :"
+    )
+    assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is False
+
+
+def test_11985_past_tense_without_hash_or_pr_ref_still_blocks():
+    """FN control: an imparfait ALONE is not a superseded-revision proof --
+    the closed rule requires a SHA or a #PR ref on the same line."""
+    line = "La version precedente couvrait 3 fichiers."
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is True
+
+
+def test_11985_form_inventory_non_notebook_is_incidental():
+    """#11790 l.7/l.64: '155 fichiers non-notebook' inventories the RESTS of
+    the original commit (kind-of-artifact qualifier, like mp3/mathlib)."""
+    line = "- 155 fichiers non-notebook (rules, workflows, scripts, tests, translations)"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is False
+
+
+def test_11985_form_counterfactual_is_incidental():
+    """#11963: '> 1 PR composite (15 fichiers / >3000 lignes)' describes the
+    PR that was NOT written. The marker sits BEFORE the count; the line's
+    'lignes' would otherwise trip the diffstat guard."""
+    line = (
+        "3 PRs distinctes (cette PR + 2 a venir) > 1 PR composite "
+        "(15 fichiers / >3000 lignes)."
+    )
+    assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is False
+
+
+def test_11985_counterfactual_count_before_marker_still_blocks():
+    """FN control: when the count comes BEFORE the marker it describes the
+    real object ('3 fichiers plutot que 15') and stays authorial."""
+    line = "3 fichiers plutot que 15 fichiers dans une PR composite."
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is True
+
+
+def test_11985_form_enumeration_component_is_incidental():
+    """#11935: 'check_twin_parity.py (...) + 2 fichiers de tests' enumerates
+    1 + 2 = 3 (exact); the guard reads the sub-sum 2 and its equality
+    confrontation can never validate it."""
+    line = (
+        "Perimetre:  scripts/notebook_tools/check_twin_parity.py "
+        "(_shas_match + messages CLI) + 2 fichiers de tests"
+    )
+    assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is False
+
+
+def test_11985_enumeration_tail_without_named_file_still_blocks():
+    """FN control: the enumeration rule requires a NAMED file before the
+    '+ N fichiers de tests' tail -- a bare tail stays authorial."""
+    line = "2 fichiers de tests modifies"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is True
+
+
+def test_11985_form_produced_artifacts_is_incidental():
+    """#11956: '2 fichiers audio generes, HTTP/1.1 200 OK' attests REAL
+    EXECUTION -- the artifacts are cell outputs, not repo files (real PR:
+    5 files). The compound kind sits on the SECOND word after the count."""
+    line = (
+        "- 04-2 c6 : execution reelle via OpenAI TTS "
+        "(2 fichiers audio generes, HTTP/1.1 200 OK)"
+    )
+    assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is False
+
+
+def test_11985_form_scan_hit_antecedent_is_incidental():
+    """#11966 l.42: '1 hit / 1 fichier' is a scan residue -- the 'hit'
+    antecedent before the count marks detector output (real PR: 4 files)."""
+    line = (
+        "- **Apres** : 1 hit / 1 fichier (le **21 notebooks** dans la "
+        "conclusion de GT-15b cell#49 -- voir Residuel ci-dessous)."
+    )
+    assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is False
+
+
+def test_11985_issue_positive_control_stays_incidental():
+    """The issue's own control: the three ALREADY-covered forms keep
+    classifying correctly (a BLOQUANT-everywhere would be indistinguishable
+    from a disarmed classifier)."""
+    for line in [
+        "pour rester sous le seuil A de pr-review-discipline.md "
+        "(<=15 fichiers, <=3000 lignes, 1 feature)",
+        "scan sur 73 fichiers",
+        "inventaire : 22 fichiers MP3",
+    ]:
+        assert _count_is_incidental(line) is True, line[:50]
+
+
+def test_11985_rule1_body_correct_count_downgrades_other_mismatches():
+    """#11951: the body declares '3 fichiers / +167/-15' (exact, declarative)
+    AND carries the G.4 atomicity argument '1 helper + 1 modification +
+    1 fichier test adapte' (count 1). The correct declaration reclassifies
+    the OTHER count mismatches of the SAME body from blocking to signal."""
+    body = (
+        "## Summary\n"
+        "- **G.4** : PR atomic (1 helper + 1 modification de fonction "
+        "+ 1 fichier test adapte, 1 bug, 1 discrimination).\n"
+        "- **L978 ★★** : périmètre déclaré en début de body (3 fichiers / +167/-15).\n"
+    )
+    items = [{"kind": "PR body", "author": "a", "body": body,
+              "source": "body", "ts": ""}]
+    candidates, _ = select_candidates(items, n_files=3)
+    assert len(candidates) == 2, "both lines stay detected (detection unchanged)"
+    arg = next(c for c in candidates if "helper" in c.text)
+    decl = next(c for c in candidates if "+167/-15" in c.text)
+    # The atomicity argument keeps its line-level blocking property -- the
+    # downgrade lives in the ROUTING, not in blocking.
+    assert arg.blocking is True
+    assert arg.body_declares_effective_count is True
+    assert decl.body_declares_effective_count is True
+    mismatch = check_assertion(
+        [{"path": "a.py"}, {"path": "b.py"}, {"path": "c.py"}], arg.text
+    )[0]
+    assert mismatch.startswith("l'assertion pretend")
+    assert is_downgradable_mismatch(arg, mismatch) is True
+
+
+def test_11985_rule1_never_touches_exclusivity_problems():
+    """FN control (#11268-2): a body that declares the right count still
+    BLOCKS on an exclusivity claim that does not name the touched workflow."""
+    cand = Candidate(
+        "Perimetre : 2 fichiers uniquement, aucune autre modification.",
+        "PR body", "author", "body",
+    )
+    cand.body_declares_effective_count = True
+    problem = (
+        "assertion d'exclusivite sans nommer le workflow touche "
+        ".github/workflows/x.yml (critere #11268-2)"
+    )
+    assert is_downgradable_mismatch(cand, problem) is False
+
+
+def test_11985_rule1_requires_declarative_correct_count():
+    """FN control: an INCIDENTAL count that happens to carry the right number
+    (a scan scope) does not validate a wrong header -- only a DECLARATIVE
+    candidate stating the effective count arms the downgrade."""
+    body = (
+        "## Summary\n"
+        "- Perimetre (1 fichier, source-only)\n"
+        "- scan sur 2 fichiers\n"
+    )
+    items = [{"kind": "PR body", "author": "a", "body": body,
+              "source": "body", "ts": ""}]
+    candidates, _ = select_candidates(items, n_files=2)
+    header = next(c for c in candidates if "Perimetre" in c.text)
+    assert header.blocking is True
+    assert header.body_declares_effective_count is False, (
+        "an incidental scan scope must not arm the downgrade"
+    )


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA

Quoi: #11985 -- perimeter-review-guard, 6 formes de comptes hors-perimetre + regle 1 body-level
Preuve: pytest 82/82 (67 existants + 15 nouveaux) ; recette repo-wide avant/apres ci-dessous ; ligne EXACTE du corpus dans chaque test
Perimetre: scripts/check_pr_perimeter.py (164+/10-) + scripts/tests/test_check_pr_perimeter.py (197+)

## Summary

`check_pr_perimeter.py` classait BLOQUANT des comptes qui ne mesurent pas le
perimetre de la PR. L'issue #11985 en recense 6 formes sur le corpus du 20/08,
avec une regle body-level pour le cas #11951. Detection INCHANGEE (extraction
+ confrontation identiques) : seule la consequence bouge (BLOQUANT -> SIGNAL),
comme en #11712.

### Les 6 formes (chacune avec sa ligne exacte du corpus en test)

| # | Forme | Corpus | Mecanisme |
|---|-------|--------|-----------|
| 1 | Composante d'enumeration `X.py (...) + 2 fichiers de tests` | #11935 | `ENUMERATION_TAIL` (`+ N fichiers de tests`) **ET** fichier nomme sur la ligne (`NAMED_FILE`) |
| 2 | Argument d'atomicite G.4 `1 fichier test adapte` | #11951 | paire deux-mots `test adapte` dans `INCIDENTAL_QUALIFIER_PAIRS` |
| 3 | Artefacts produits `2 fichiers audio generes, HTTP/1.1 200 OK` | #11956 | paire `audio generes` (atteste l'execution, pas des fichiers du repo) |
| 4 | Resultat de scan `10 fichiers distincts` / ligne de tableau | #11964 | `distinct` dans `INCIDENTAL_QUALIFIERS` + retour precoce ligne de tableau |
| 5 | Auto-description passee `couvrait 160 fichiers` + SHA/#PR | #11790 | `PAST_REFERENCE` + `HASH_OR_PR_REF` sur la meme ligne (decrit la revision supersedee, override le guard diffstat) |
| 6 | Contrefactuel `> 1 PR composite (15 fichiers)` | #11963 | `COUNTERFACTUAL_MARKER` (`au lieu de`, `plutot que`, `composite`) AVANT le compte |

Plus : antecedent `N hits` (#11966 l.42, `1 hit / 1 fichier` = residu de scan),
inventaire `non-notebook` (#11790 l.7/l.64).

### Regle 1 (body-level, cas #11951)

Si un candidate DECLARATIF du meme body porte le compte effectif
(`_first_confrontable_count == n_files`), les AUTRES count-mismatches de ce
body deviennent SIGNAL (`body_declares_effective_count` + routage
`is_downgradable_mismatch`). Le champ `blocking` de `Candidate` est INTACT --
le downgrade vit dans le routage, pas dans la propriete.

**Jamais downgradables** : les problemes d'exclusivite #11268-2, les
count-mismatches d'un body sans declaration declarative correcte.

### Controles FN (l'issue les exige)

- `La version precedente couvrait 3 fichiers.` (imparfait SANS SHA/#PR) reste BLOQUANT
- `3 fichiers plutot que 15 fichiers` (compte AVANT le marqueur) reste BLOQUANT
- `2 fichiers de tests modifies` (queue SANS fichier nomme) reste BLOQUANT
- Un scope incidental (`scan sur 2 fichiers`) n'arme PAS le downgrade d'un header faux

Le 3e controle a attrape un exces de la premiere implementation : la paire
`de tests` rendait incidental `2 fichiers de tests modifies` sans garde-fou.
Retiree de `INCIDENTAL_QUALIFIER_PAIRS` -- la forme 1 passe exclusivement par
`ENUMERATION_TAIL + NAMED_FILE` (qui exige le `+` et le fichier nomme).

## Recette repo-wide (exigee par l'issue)

Harnais : `gh pr list --state open --limit 100` -> `check_pr_perimeter.py
--scan-thread` sur chaque PR, grep VERDICT: FAIL, dans le worktree.

**Avant (base e2cdd3d51, 20/08) : 10 ROUGES** -- 11978, 11968, 11966, 11964,
11963, 11956, 11951, 11935, 11905, 11790.

**Apres : 3 ROUGES** -- `11978`, `11968`, `11905` (les 7 FP -- 11790, 11935,
11951, 11956, 11963, 11964, 11966 -- passent VERT ; log complet de la passe
apres : `RED 11978`, `RED 11968`, `RED 11905`, `BASELINE DONE`, aucun autre).

Attendus restants (vrais positifs, NON corriges par cette PR) :
- **#11905** : header `Perimetre (1 fichier)` vs 2 fichiers reels (lane po-2023)
- **#11978** : exclusivite sans nommer le workflow touche (criteres #11268-2, hors scope #11985)
- **#11968** : header `Perimetre (1 fichier)` vs 2 reels

Divergence vs le `9 -> 2` de l'issue : #11968 est apparu APRES la redaction
de l'issue ; investigation firsthand = 3e vrai positif (header « Perimetre
(1 fichier) » vs 2 fichiers reels, aucune autre declaration dans le body).
Cible du jour ajustee : **10 -> 3**.

## Tests

`python -m pytest scripts/tests/test_check_pr_perimeter.py -q` ->
`82 passed` (67 existants + 15 nouveaux : 6 formes + controles FN + controle
positif #11712 + 3 tests regle 1). Chaque forme teste AUSSI
`extract_perimeter_assertions(line) == [line]` (detection inchangee).

See #11985 (pas Closes : la recette finale exige validation des 3 restants)
