### PR TITLE
fix(translation,#11988): assouplir invariant drift_with_filled_text_en apres seeding T1

### DIFF
--- a/scripts/translation/tests/test_demo_t3_t4_acceptance.py
+++ b/scripts/translation/tests/test_demo_t3_t4_acceptance.py
@@ -95,9 +95,17 @@ def test_drift_count_is_consistent():
     assert drift["src_drift_total"] > 0
     # src_drift_in_csv <= src_drift_total (toutes les cellules sont dans le CSV test)
     assert drift["src_drift_in_csv"] <= drift["src_drift_total"]
-    # Tous les drifts observes sur le perimetre de test sont des cellules markdown
-    # dont text_en est rempli (issue #10042).
-    assert drift["drift_with_filled_text_en"] == drift["src_drift_in_csv"]
+    # drift_with_filled_text_en <= src_drift_in_csv (les cellules SRC_DRIFT
+    # avec text_en rempli sont un sous-ensemble des cellules en drift du CSV
+    # test). Le T1 full-perimeter seeding #11934 a falsifie src_hash sur des
+    # cellules non-traduites (text_en vide) -- elles sont en SRC_DRIFT mais
+    # leur text_en n'est PAS rempli. C'est un etat legitime : le seeding
+    # marque le besoin de retraduction sans inventer un text_en. Le pivot
+    # #10287 / #10042 ne pretendait pas que TOUTES les SRC_DRIFT ont text_en
+    # rempli ; il dit que les SRC_DRIFT avec text_en rempli doivent etre
+    # eligibles au plan T3 -- c'est ce que verifie test_t3_captures_drift_now
+    # (assert translations_planned >= drift_with_filled_text_en).
+    assert drift["drift_with_filled_text_en"] <= drift["src_drift_in_csv"]
 
 
 def test_t3_captures_drift_now():


### PR DESCRIPTION
## Summary

Fix #11988: `test_drift_count_is_consistent` rouge sur tout merge ref frais depuis le seeding T1 #11934. L'invariant du test — `drift_with_filled_text_en == src_drift_in_csv` — suppose que TOUTES les cellules SRC_DRIFT du CSV ont `text_en` rempli. Le seeding T1 a falsifié `src_hash` sur des cellules non-traduites (text_en vide), laissant sur main des SRC_DRIFT avec text_en vide — état légitime (le seeding marque le besoin de retraduction sans inventer un text_en).

## Repro

`scripts/translation/tests/test_demo_t3_t4_acceptance.py::test_drift_count_is_consistent` lève `assert 3 == 5` sur main isole (issue #11988 mesure 5 vs 3 sur la branche PR #11976 merge ref, mais le pattern est identique : text_en vide vs rempli).

## Fix

Assouplir l'invariant d'égalité stricte en inégalité faible :

- `assert drift["drift_with_filled_text_en"] == drift["src_drift_in_csv"]` → `assert drift["drift_with_filled_text_en"] <= drift["src_drift_in_csv"]`

Le pivot #10287 / #10042 ne prétendait pas que TOUTES les SRC_DRIFT ont text_en rempli ; il dit que les SRC_DRIFT **avec** text_en rempli doivent être éligibles au plan T3. C'est ce que vérifie `test_t3_captures_drift_now` (assert `translations_planned >= drift_with_filled_text_en`), pas le test que ce PR corrige.

## Commentaire du test mis à jour

L'ancien commentaire disait « Tous les drifts observes sur le perimetre de test sont des cellules markdown dont text_en est rempli ». Le nouveau commentaire explique pourquoi on relâche en `<=` : les cellules SRC_DRIFT avec text_en vide sont un état légitime post-seeding, pas un défaut du détecteur. Le pivot sémantique est explicité (référence à #11934, #10287, #10042, `test_t3_captures_drift_now`).

## Verification

| Test | Avant | Après |
|---|---|---|
| `test_drift_count_is_consistent` | FAIL `assert 3 == 5` | PASS |
| `test_couture_active` | PASS | PASS |
| `test_t3_captures_drift_now` | PASS | PASS |
| `test_t4_render_byte_stable` | PASS | PASS |
| `pytest scripts/translation/tests/` (338 tests) | n/a (1 rouge) | 338/338 verts |

## Perimetre

Perimetre : 1 fichier (`scripts/translation/tests/test_demo_t3_t4_acceptance.py`).

## G-VAR-3

Ce grain est `MED/tooling` (assouplissement d'invariant de test). Pivot META→META par rapport à c.417 (guard), substance distincte (c.417 = delivered-urn attestation, c.418 = fix bug fleet-wide). Pas de LIGHT consécutif (c.417 = MED, c.418 = MED), G-VAR-3 respecté.

## Out of scope

- **Compléter les `text_en` des cellules driftées résiduelles** (option 2 de l'issue) : crée de la dette de traduction. Le seeding a explicitement laissé text_en vide pour signaler « pas encore traduit », c'est l'état voulu.
- **#11754** (Papermill silencieux worktree) : autre bug, autre grain, autre cycle.
- **PR #11976** : Search/Part2-CSP, périmètre disjoint du CSV finetuning. Le fix n'y sera pas plié (un seul sujet par PR).

See #11988.