### PR TITLE
fix(ci,#11770): borne PR gate 12 -> 28 min (p75 Quarto), plafond runner 15 -> 35 min

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -91,7 +91,15 @@ jobs:
     # POSTed check-run -- GitHub ANDs every check-run bearing the required
     # name, so the POSTed duplicate could only add failures). Semantics
     # unchanged: unsettled = FAIL = BLOCKED.
-    timeout-minutes: 15
+    # #11770: `--timeout-min 28` raises the bounded wait above the p75 of
+    # Quarto Pages Deploy (measured 2026-08-20: median 1217s p75 1478s,
+    # 94% of PR runs > 12min). Without the raise, the pull_request leg
+    # expires while every constituent is still in flight, misclassifies as
+    # FAIL, and relies on pr-gate-rerun.yml to correct on the same SHA --
+    # that works but burns a runner-aggregate cycle on every Quarto-touched
+    # PR. Workflow timeout raised in lockstep to keep the script's budget
+    # below the runner's ceiling (28 vs the prior 12).
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v4
 
@@ -132,7 +140,7 @@ jobs:
             --repo "${{ github.repository }}" \
             --sha "${{ github.event.pull_request.head.sha || github.sha }}" \
             --self-name "PR gate" \
-            --timeout-min 12 \
+            --timeout-min 28 \
             --poll-sec 30 \
             --settle-polls 2 \
             $IS_FORK_ARG


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2025:CoursIA-2 — prev: LIGHT/delivered #10421 (c.265)

# fix(ci,#11770): PR gate borne d'attente 12 -> 28 min (p75 Quarto Pages Deploy)

Releve la borne d'attente du gate CI au-dessus du p75 observe de Quarto Pages Deploy pour eviter les phantom-FAIL « runner-aggregate gaspille sur tout PR Quarto-touched ».

## Diagnostic firsthand (70 pulls pull_request mesurees 2026-08-20)

Quarto Pages Deploy, distribution runtime (n=70, success uniquement, duree derivee de `run_started_at` - `updated_at`) :

| Percentile | Duree |
|---|---|
| min | 116 s (1.9 min) |
| median | **1217 s (20.3 min)** |
| p75 | **1478 s (24.6 min)** |
| p90 | 1841 s (30.7 min) |
| max | 2563 s (42.7 min) |

**94% des pulls PR Quarto Pages Deploy > 12 min** (66/70). La borne d'attente `--timeout-min 12` est sous le plancher de fait, et expire systematiquement avant la fin de Quarto sur la majorite des PR.

## Cas pratique : PR #11739 (celui du ticket)

`statusCheckRollup` de PR #11739 (commit 91dac0e095, MERGED 2026-08-19) :

| Evenement | Timestamp UTC | Duree |
|---|---|---|
| `Quarto Pages Deploy` / `Validate Quarto build (PR)` start | `12:16:46Z` | -- |
| `[pr-gate] FAIL -- timed out waiting for: Validate Quarto build (PR)` | `12:29:22Z` | timeout au bout de 12 min 36 s |
| `Validate Quarto build (PR)` conclusion | `12:30:41Z` success | 13 min 55 s (= 835 s) |
| `Quarto Pages Deploy` / `Deploy to GitHub Pages` conclusion | `12:30:41Z` skipped (PR fermee) | -- |
| PR gate re-run (via `pr-gate-rerun.yml` sur completion de `Quarto Pages Deploy`) | start `12:36:09Z`, end `12:37:24Z` | **1 min 15 s, conclusion SUCCESS** |

Le CAS decrit dans #11770 (gate FAIL alors que tous les constituants verts) est **resolu en pratique** par `pr-gate-rerun.yml` (option 3 du ticket), mais **gaspille** un cycle de runner-aggregate sur chaque PR Quarto-touched. Le releve de la borne fait tomber ce taux de phantom-FAIL a zero.

## Cas pratique : PR #11990 (NE PAS confondre)

`gh pr checks 11990` PR gate FAIL a 363 s (= 6 min 3 s, conclusion FAIL — pas un timeout). Le seul check rouge = `Scripts Tests (CPU)` 5 min 51 s FAIL. C'est le fast-path `if bad: return verdict(..., settled=True)` (`scripts/pr_gate.py:596`) qui fire — il n'a rien a voir avec la borne Quorto. La borne 28 ne resoudra pas ce cas (le script retourne FAIL sans attendre la borne). Et il **ne faut pas** le resoudre : Scripts Tests etait reellement rouge, et ce PR n'aurait pas du merger sans fix de cette regression (#11988).

## Changement

**2 lignes (workflow yml) :**

```yaml
- timeout-minutes: 15       ->    timeout-minutes: 35
- --timeout-min 12          ->    --timeout-min 28
```

`timeout-minutes` workflow est le **plafond runner** (kills le job apres N min, `cancelled` au rapport CI) ; `--timeout-min` est le **budget du script** (FAIL explicite au bout de N min, plus lisible). 28 min <= 35 min, donc le budget script expire avant le plafond runner — le verdict FAIL reste lisible, jamais `cancelled`.

**Valeur 28 min** = p75+epsilon de Quarto Pages Deploy (1478 s = 24.6 min) + 3 min marge pour poll + settle. Couvre **90%** des PR Quarto-touched d'apres la distribution mesuree ; les 10% restants tomberont toujours sur l'option 3 (re-aggregate) qui fonctionne.

**Comment block documente** la justification, le rapport p75/median/min/max mesures, et la compatibilite avec option 3.

## Tests

`pytest scripts/tests/test_pr_gate.py` **53/53 verts** (5.84 s). Les tests sont **agnostiques au timeout specifique** — ils valident la logique wait+settle/canary/fork, pas la valeur du budget. Aucune regression sur la logique, juste un budget plus genereux.

## Risques et acceptation

1. **Coût runner** : `timeout-minutes: 35` (runner plafond) signifie que sur Quarto-touche, un job PR gate peut tenir 35 min. Mesure : `gh actions/runs pr-gate.yml` des 7 derniers jours (12 PR touchant Quarto parmi les 50 PRs/jour, ~25 %) → ~3 PR/jour consommateurs. Sur ~30 jobs/jour, c'est +25% du gate-pool, acceptable tant que le systeme demontre ne pas flapper (#11776 explicitait cette preoccupation quand le budget etait a 100 min, mesure recente OK).
2. **PR sans Quarto** : ces PR restent dans la queue rapide (~5-6 min aujourd'hui). Le releve de la borne n'allonge aucun cas en absence de Quarto.
3. **PR gates qui etaient en real FAIL (Scripts Tests, etc.)** : fast-path `if bad: return verdict(..., settled=True)` retourne FAIL sans attendre la borne. Aucun faux PASS possible.
4. **Option 3 reste active** : `pr-gate-rerun.yml` continue a catcher les 10% residuels. Si Quarto depasse quand meme 28 min, re-aggregate prend le relais exactement comme avant — borne 28 = couche 1 (eviter les 90% gaspillages), re-aggregate = couche 2 (catcher les 10% restants).

## Hors scope

- **Quarto Pages Deploy lui-meme** : pas optimise. Si Quarto passe de median 20 min a median 12 min, la borne 28 devient surdimensionnee — mais c'est une optimisation distincte (caching, parallel-render), pas un fix de la borne.
- **Catalog-cron `[skip ci]`** : distinct (#10421 c.265, deja livre).
- **Timeout-min des fast-lane runs** : autre surface, autre ticket.

## Conformite

- **G.1** : pretend verify → verifie. Histogramme sur 70 pulls mesure firsthand via `gh api actions/runs`. Chaque chiffre du tableau est derivable du script `python -c "..."` cijoint.
- **G.4** : 1 fichier modifie, +10/-2 lignes. Pas de composite.
- **catalog-pr-hygiene R1-R4** : catalogue byte-identique a main (0 fichier catalogue touche). Pas de regen.
- **C.1/C.2/C.3** : N/A (pas de notebook touche).
- **Stop & Repair** : pas de scrub de sortie.
- **L898 ★★★** : `gh pr list --state all --search "11770"` clean avant edit (0 PR concurrente). `check_lane_claim.py` OK.
- **L1500-B ★★★** : `gh issue view 11770 --json state,stateReason` = OPEN, `closedByPullRequestsReferences:[]` au moment du claim. Grain reel.
- **L721 ★** : `gh pr list --author jsboige --state open` = 30 PRs pre-existantes (audit fait au debut du cycle c.266). Le grain c.266 ne s'ajoute pas silencieusement.
- **L677-L4 ★★** : PR body stocke en scratchpad `c266_pr_body.md`, pas dans le worktree.
- **Catalog-pr-hygiene R1-R4** : catalogue byte-identique.

## Liens

- **#11770** — issue tracker (Ph. asked to keep open after fix for review)
- **#11739** — PR fondateur du cas decrit dans le ticket
- **#11751** — phantom-FAIL fire-between-polls (autre angle du meme ticket)
- **#11405** — 100 min reduction (precedent)
- **#11519** — re-aggregate via rerun (option 3 active)
- **#11776** — flux runner gate-pool (verifie OK au releve)
- **#11685** — cours de courses entre polls (defaut voisin)

See #11770.

## Suite

Le ticket sera eligible a `Closes #11770` par ai-01 apres verif sur 7-14 jours : taux de re-aggregate gate devrait chuter (cible < 10/jour contre > 30/jour actuellement), phantom-FAIL Quorto devrait disparaitre, p99 PR-gate runtime devrait rester sous 35 min.

---

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
