### PR TITLE
feat(lean,#11703): Lean-17c couvre MathlibPrerequisites — feuille de route des 11 prerequis, 0 module noir knot_lean

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17c-Knots-Companion-Formel.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17c-Knots-Companion-Formel.ipynb
@@ -5,25 +5,33 @@
    "id": "34287b8c",
    "metadata": {
     "papermill": {
-     "duration": 0.002833,
-     "end_time": "2026-08-20T00:58:30.909243+00:00",
+     "duration": 0.010358,
+     "end_time": "2026-08-20T18:14:33.733045+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.906410+00:00",
+     "start_time": "2026-08-20T18:14:33.722687+00:00",
      "status": "completed"
     },
     "tags": []
    },
-   "source": "# Lean 17c — Le lake `knot_lean` par ses déclarations (compagnon formel)\n\nCompagnon du **Lean-17** (« Conway, les Nœuds et la Preuve de Piccirillo »). Là où Lean-17 raconte l'histoire mathématique (Fox 3-colorabilité, mutants, Piccirillo 2020, Lidman 2026) et interroge `Conway.lean` et `Lidman.lean`, ce notebook interroge les modules que Lean-17 ne cite pas — **`Basic.lean`** (les structures fondamentales), **`Invariant.lean`** (la chaîne 3-colorabilité, 69 déclarations) et **`Reidemeister.lean`** (les moves R1/R2/R3 et leurs murs) — et mesure l'état de la formalisation : déclarations par module, sorries réels vs prose, axiomes admis.\n\nKernel Python par choix : le kernel natif `lean4-wsl` est gelé en attendant la mise à jour du binaire `repl` (#11874 — construit pour v4.30.0, lakes en v4.32.1). La lecture des sources reste réelle : chaque cellule ouvre le fichier `.lean` du lake et en extrait les déclarations, jamais une copie.\n\nVoir `knot_lean/README.md` pour l'état détaillé du corridor Reidemeister."
+   "source": [
+    "# Lean 17c — Le lake `knot_lean` par ses déclarations (compagnon formel)\n",
+    "\n",
+    "Compagnon du **Lean-17** (« Conway, les Nœuds et la Preuve de Piccirillo »). Là où Lean-17 raconte l'histoire mathématique (Fox 3-colorabilité, mutants, Piccirillo 2020, Lidman 2026) et interroge `Conway.lean` et `Lidman.lean`, ce notebook interroge les modules que Lean-17 ne cite pas — **`Basic.lean`** (les structures fondamentales), **`Invariant.lean`** (la chaîne 3-colorabilité, 71 déclarations), **`Reidemeister.lean`** (les moves R1/R2/R3 et leurs murs) et **`MathlibPrerequisites.lean`** (la feuille de route des 11 prérequis Mathlib) — et mesure l'état de la formalisation : déclarations par module, sorries réels vs prose, axiomes admis.\n",
+    "\n",
+    "Kernel Python par choix : le kernel natif `lean4-wsl` est gelé en attendant la mise à jour du binaire `repl` (#11874 — construit pour v4.30.0, lakes en v4.32.1). La lecture des sources reste réelle : chaque cellule ouvre le fichier `.lean` du lake et en extrait les déclarations, jamais une copie.\n",
+    "\n",
+    "Voir `knot_lean/README.md` pour l'état détaillé du corridor Reidemeister."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "8ac57465",
    "metadata": {
     "papermill": {
-     "duration": 0.001922,
-     "end_time": "2026-08-20T00:58:30.913361+00:00",
+     "duration": 0.002655,
+     "end_time": "2026-08-20T18:14:33.739418+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.911439+00:00",
+     "start_time": "2026-08-20T18:14:33.736763+00:00",
      "status": "completed"
     },
     "tags": []
@@ -40,16 +48,16 @@
    "id": "048a3415",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:30.918241Z",
-     "iopub.status.busy": "2026-08-20T00:58:30.918029Z",
-     "iopub.status.idle": "2026-08-20T00:58:30.928577Z",
-     "shell.execute_reply": "2026-08-20T00:58:30.928030Z"
+     "iopub.execute_input": "2026-08-20T18:14:33.746789Z",
+     "iopub.status.busy": "2026-08-20T18:14:33.746516Z",
+     "iopub.status.idle": "2026-08-20T18:14:33.776643Z",
+     "shell.execute_reply": "2026-08-20T18:14:33.774979Z"
     },
     "papermill": {
-     "duration": 0.013765,
-     "end_time": "2026-08-20T00:58:30.929076+00:00",
+     "duration": 0.034909,
+     "end_time": "2026-08-20T18:14:33.778058+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.915311+00:00",
+     "start_time": "2026-08-20T18:14:33.743149+00:00",
      "status": "completed"
     },
     "tags": []
@@ -62,10 +70,10 @@
       "Modules FR du lake : 6\n",
       "  Basic.lean                     653 lignes   sibling _en : oui\n",
       "  Conway.lean                    249 lignes   sibling _en : oui\n",
-      "  Invariant.lean                3328 lignes   sibling _en : oui\n",
+      "  Invariant.lean                3540 lignes   sibling _en : oui\n",
       "  Lidman.lean                    144 lignes   sibling _en : oui\n",
       "  MathlibPrerequisites.lean      138 lignes   sibling _en : oui\n",
-      "  Reidemeister.lean             1060 lignes   sibling _en : oui\n"
+      "  Reidemeister.lean             1069 lignes   sibling _en : oui\n"
      ]
     }
    ],
@@ -87,10 +95,10 @@
    "id": "3e52bfd7",
    "metadata": {
     "papermill": {
-     "duration": 0.002653,
-     "end_time": "2026-08-20T00:58:30.934242+00:00",
+     "duration": 0.002563,
+     "end_time": "2026-08-20T18:14:33.783358+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.931589+00:00",
+     "start_time": "2026-08-20T18:14:33.780795+00:00",
      "status": "completed"
     },
     "tags": []
@@ -105,10 +113,10 @@
    "id": "ba0a717b",
    "metadata": {
     "papermill": {
-     "duration": 0.002559,
-     "end_time": "2026-08-20T00:58:30.939701+00:00",
+     "duration": 0.002145,
+     "end_time": "2026-08-20T18:14:33.787699+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.937142+00:00",
+     "start_time": "2026-08-20T18:14:33.785554+00:00",
      "status": "completed"
     },
     "tags": []
@@ -125,16 +133,16 @@
    "id": "6df80a7f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:30.946609Z",
-     "iopub.status.busy": "2026-08-20T00:58:30.946411Z",
-     "iopub.status.idle": "2026-08-20T00:58:30.951707Z",
-     "shell.execute_reply": "2026-08-20T00:58:30.951133Z"
+     "iopub.execute_input": "2026-08-20T18:14:33.794369Z",
+     "iopub.status.busy": "2026-08-20T18:14:33.794009Z",
+     "iopub.status.idle": "2026-08-20T18:14:33.800116Z",
+     "shell.execute_reply": "2026-08-20T18:14:33.799529Z"
     },
     "papermill": {
-     "duration": 0.009552,
-     "end_time": "2026-08-20T00:58:30.952329+00:00",
+     "duration": 0.010729,
+     "end_time": "2026-08-20T18:14:33.800585+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.942777+00:00",
+     "start_time": "2026-08-20T18:14:33.789856+00:00",
      "status": "completed"
     },
     "tags": []
@@ -205,10 +213,10 @@
    "id": "95c9a4f6",
    "metadata": {
     "papermill": {
-     "duration": 0.003217,
-     "end_time": "2026-08-20T00:58:30.958240+00:00",
+     "duration": 0.002382,
+     "end_time": "2026-08-20T18:14:33.805364+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.955023+00:00",
+     "start_time": "2026-08-20T18:14:33.802982+00:00",
      "status": "completed"
     },
     "tags": []
@@ -223,16 +231,16 @@
    "id": "923dfd00",
    "metadata": {
     "papermill": {
-     "duration": 0.002578,
-     "end_time": "2026-08-20T00:58:30.963460+00:00",
+     "duration": 0.004727,
+     "end_time": "2026-08-20T18:14:33.815735+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.960882+00:00",
+     "start_time": "2026-08-20T18:14:33.811008+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 3. `Invariant.lean` — la chaîne 3-colorabilité (69 déclarations)\n",
+    "## 3. `Invariant.lean` — la chaîne 3-colorabilité (71 déclarations)\n",
     "\n",
     "C'est le cœur pédagogique du lake : la définition `IsTricolorable` et le théorème-cible `tricolorable_invariant` (« la 3-colorabilité de Fox est invariante par moves de Reidemeister »), avec sa décomposition en bras ascendants R1/R2 et ses murs nommés."
    ]
@@ -243,16 +251,16 @@
    "id": "f8e81189",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:30.969789Z",
-     "iopub.status.busy": "2026-08-20T00:58:30.969490Z",
-     "iopub.status.idle": "2026-08-20T00:58:30.976655Z",
-     "shell.execute_reply": "2026-08-20T00:58:30.975938Z"
+     "iopub.execute_input": "2026-08-20T18:14:33.823121Z",
+     "iopub.status.busy": "2026-08-20T18:14:33.822955Z",
+     "iopub.status.idle": "2026-08-20T18:14:33.829145Z",
+     "shell.execute_reply": "2026-08-20T18:14:33.828685Z"
     },
     "papermill": {
-     "duration": 0.011196,
-     "end_time": "2026-08-20T00:58:30.977234+00:00",
+     "duration": 0.010039,
+     "end_time": "2026-08-20T18:14:33.829792+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.966038+00:00",
+     "start_time": "2026-08-20T18:14:33.819753+00:00",
      "status": "completed"
     },
     "tags": []
@@ -262,19 +270,19 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Invariant.lean : 68 declarations\n",
+      "Invariant.lean : 71 declarations\n",
       "\n",
       "  L 233  def       IsTricolorable\n",
       "  L 276  instance  IsTricolorable.decidable\n",
       "  L 310  theorem   triColorFoxCondition_iff_sum_mod_three\n",
-      "  L 341  theorem   tricolorable_invariant\n",
-      "  L 778  theorem   tricolorable_forward_r1\n",
-      "  L1023  theorem   tricolorable_forward_r2_up\n",
-      "  L1151  theorem   r2_append_only_wall\n",
-      "  L1168  theorem   not_tricolorable_invariant_current\n",
-      "  L1306  theorem   r3_determined_wall\n",
-      "  L1445  theorem   tricolorable_invariant_fails_under_pr1_model\n",
-      "  L3322  theorem   tricolorable_invariant_r2_connected\n"
+      "  L 687  theorem   tricolorable_forward_r1\n",
+      "  L 932  theorem   tricolorable_forward_r2_up\n",
+      "  L1060  theorem   r2_append_only_wall\n",
+      "  L1213  theorem   r3_determined_wall\n",
+      "  L1352  theorem   tricolorable_invariant_fails_under_pr1_model\n",
+      "  L3188  theorem   tricolorable_invariant_r2_connected\n",
+      "  L3474  theorem   tricolorable_invariant_r3_connected\n",
+      "  L3489  theorem   tricolorable_invariant\n"
      ]
     }
    ],
@@ -295,10 +303,10 @@
    "id": "054abd8b",
    "metadata": {
     "papermill": {
-     "duration": 0.002381,
-     "end_time": "2026-08-20T00:58:30.982241+00:00",
+     "duration": 0.002313,
+     "end_time": "2026-08-20T18:14:33.834520+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.979860+00:00",
+     "start_time": "2026-08-20T18:14:33.832207+00:00",
      "status": "completed"
     },
     "tags": []
@@ -313,10 +321,10 @@
    "id": "9e5c54dc",
    "metadata": {
     "papermill": {
-     "duration": 0.002326,
-     "end_time": "2026-08-20T00:58:30.987058+00:00",
+     "duration": 0.002371,
+     "end_time": "2026-08-20T18:14:33.839109+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.984732+00:00",
+     "start_time": "2026-08-20T18:14:33.836738+00:00",
      "status": "completed"
     },
     "tags": []
@@ -333,16 +341,16 @@
    "id": "f41d2568",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:30.992854Z",
-     "iopub.status.busy": "2026-08-20T00:58:30.992594Z",
-     "iopub.status.idle": "2026-08-20T00:58:31.352699Z",
-     "shell.execute_reply": "2026-08-20T00:58:31.352140Z"
+     "iopub.execute_input": "2026-08-20T18:14:33.845179Z",
+     "iopub.status.busy": "2026-08-20T18:14:33.844923Z",
+     "iopub.status.idle": "2026-08-20T18:14:34.226494Z",
+     "shell.execute_reply": "2026-08-20T18:14:34.225768Z"
     },
     "papermill": {
-     "duration": 0.364751,
-     "end_time": "2026-08-20T00:58:31.354104+00:00",
+     "duration": 0.385425,
+     "end_time": "2026-08-20T18:14:34.227132+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:30.989353+00:00",
+     "start_time": "2026-08-20T18:14:33.841707+00:00",
      "status": "completed"
     },
     "tags": []
@@ -390,8 +398,8 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Invariant</td>\n",
-       "      <td>16</td>\n",
-       "      <td>2</td>\n",
+       "      <td>8</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -414,8 +422,8 @@
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>TOTAL</td>\n",
-       "      <td>38</td>\n",
-       "      <td>14</td>\n",
+       "      <td>30</td>\n",
+       "      <td>13</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -425,11 +433,11 @@
        "                 module  grep naif  sorry reels\n",
        "0                 Basic          3            0\n",
        "1                Conway         11            8\n",
-       "2             Invariant         16            2\n",
+       "2             Invariant          8            1\n",
        "3                Lidman          4            2\n",
        "4  MathlibPrerequisites          2            0\n",
        "5          Reidemeister          2            2\n",
-       "6                 TOTAL         38           14"
+       "6                 TOTAL         30           13"
       ]
      },
      "execution_count": 4,
@@ -462,10 +470,10 @@
    "id": "99245d15",
    "metadata": {
     "papermill": {
-     "duration": 0.00423,
-     "end_time": "2026-08-20T00:58:31.363839+00:00",
+     "duration": 0.003282,
+     "end_time": "2026-08-20T18:14:34.233532+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.359609+00:00",
+     "start_time": "2026-08-20T18:14:34.230250+00:00",
      "status": "completed"
     },
     "tags": []
@@ -480,10 +488,10 @@
    "id": "67dc2946",
    "metadata": {
     "papermill": {
-     "duration": 0.008567,
-     "end_time": "2026-08-20T00:58:31.379896+00:00",
+     "duration": 0.004336,
+     "end_time": "2026-08-20T18:14:34.242581+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.371329+00:00",
+     "start_time": "2026-08-20T18:14:34.238245+00:00",
      "status": "completed"
     },
     "tags": []
@@ -500,16 +508,16 @@
    "id": "d284ef54",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:31.397089Z",
-     "iopub.status.busy": "2026-08-20T00:58:31.396572Z",
-     "iopub.status.idle": "2026-08-20T00:58:31.403334Z",
-     "shell.execute_reply": "2026-08-20T00:58:31.402387Z"
+     "iopub.execute_input": "2026-08-20T18:14:34.251755Z",
+     "iopub.status.busy": "2026-08-20T18:14:34.251277Z",
+     "iopub.status.idle": "2026-08-20T18:14:34.258412Z",
+     "shell.execute_reply": "2026-08-20T18:14:34.257603Z"
     },
     "papermill": {
-     "duration": 0.013167,
-     "end_time": "2026-08-20T00:58:31.404363+00:00",
+     "duration": 0.01308,
+     "end_time": "2026-08-20T18:14:34.259332+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.391196+00:00",
+     "start_time": "2026-08-20T18:14:34.246252+00:00",
      "status": "completed"
     },
     "tags": []
@@ -553,10 +561,10 @@
       "  L 773  def       Reidemeister3ConnectedInv  <-- move\n",
       "  L 791  theorem   reidemeister3ConnectedInv_satisfiable\n",
       "  L 817  theorem   reidemeister3Connected_inv\n",
-      "  L1004  theorem   reidemeister_equiv_symm\n",
-      "  L1016  theorem   reidemeister_equiv_equivalence\n",
-      "  L1027  def       KnotEquiv\n",
-      "  L1044  theorem   reidemeister_theorem\n"
+      "  L1013  theorem   reidemeister_equiv_symm\n",
+      "  L1025  theorem   reidemeister_equiv_equivalence\n",
+      "  L1036  def       KnotEquiv\n",
+      "  L1053  theorem   reidemeister_theorem\n"
      ]
     }
    ],
@@ -576,10 +584,10 @@
    "id": "018a9781",
    "metadata": {
     "papermill": {
-     "duration": 0.003491,
-     "end_time": "2026-08-20T00:58:31.411914+00:00",
+     "duration": 0.003255,
+     "end_time": "2026-08-20T18:14:34.266091+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.408423+00:00",
+     "start_time": "2026-08-20T18:14:34.262836+00:00",
      "status": "completed"
     },
     "tags": []
@@ -591,39 +599,225 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a29df633",
+   "id": "25cbfad6",
    "metadata": {
     "papermill": {
-     "duration": 0.004339,
-     "end_time": "2026-08-20T00:58:31.419699+00:00",
+     "duration": 0.002947,
+     "end_time": "2026-08-20T18:14:34.272085+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.415360+00:00",
+     "start_time": "2026-08-20T18:14:34.269138+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 6. Le tableau de bord du lake\n",
+    "## 6. `MathlibPrerequisites.lean` — la feuille de route des 11 prérequis\n",
+    "\n",
+    "Ce module ne prouve rien — et c'est son rôle. Chacune de ses 11 déclarations est un théorème **volontairement vide** (`True := trivial`) : ce qui compte n'est pas l'énoncé mais la docstring au-dessus, qui documente **ce que Mathlib ne sait pas encore faire** pour tel résultat de théorie des nœuds (Epic #2874, Phase 1). Trois tiers de difficulté annoncent trois horizons : Tier 1 accessible (les cibles Phase 2), Tier 2 modéré (Alexander, Jones), Tier 3 approfondi (le théorème de Reidemeister, Piccirillo, Lidman, Freedman — les mêmes résultats que Lean-17 raconte historiquement)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "46acbd06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T18:14:34.280082Z",
+     "iopub.status.busy": "2026-08-20T18:14:34.279747Z",
+     "iopub.status.idle": "2026-08-20T18:14:34.290546Z",
+     "shell.execute_reply": "2026-08-20T18:14:34.289730Z"
+    },
+    "papermill": {
+     "duration": 0.015682,
+     "end_time": "2026-08-20T18:14:34.291355+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T18:14:34.275673+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MathlibPrerequisites.lean : 11 declarations, 0 sorry reel\n",
+      "\n",
+      "  Tier 1 (Accessible)    pd_wellformed_prerequisites                #1 : Bien-fondation des PD-codes\n",
+      "  Tier 1 (Accessible)    trefoil_tricolorable_prerequisites         #2 : Le trefoil est tricoloriable\n",
+      "  Tier 1 (Accessible)    unknot_not_tricolorable_prerequisites      #3 : Le noeud trivial n'est pas tricoloriable\n",
+      "  Tier 1 (Accessible)    tricolorable_invariant_prerequisites       #4 : La tricolorabilite est invariante sous R1, R2, R3\n",
+      "  Tier 2 (Modere)        reidemeister_formal_prerequisites          #5 : Mouvements de Reidemeister (description formelle)\n",
+      "                                                                    ref. shua/leanknot possede une formalisation partielle.\n",
+      "  Tier 2 (Modere)        alexander_polynomial_prerequisites         #6 : Polynome d'Alexander\n",
+      "                                                                    ref. Alexander (1928), Crowell & Fox (1963)\n",
+      "  Tier 2 (Modere)        jones_polynomial_prerequisites             #7 : Polynome de Jones via le crochet de Kauffman\n",
+      "                                                                    ref. Jones (1985), Kauffman (1987)\n",
+      "  Tier 3 (Approfondi)    reidemeister_theorem_prerequisites         #8 : Isotopie ambiante <-> equivalence de Reidemeister\n",
+      "                                                                    ref. Reidemeister (1927), Alexander (1928)\n",
+      "  Tier 3 (Approfondi)    piccirillo_prerequisites                   #9 : Theoreme de Piccirillo (Conway non lisse-slice)\n",
+      "                                                                    ref. Piccirillo (2018), arXiv:1808.02923\n",
+      "  Tier 3 (Approfondi)    lidman_prerequisites                       #10 : Theoreme de Lidman (nombre de denouement de 11n102 = 2)\n",
+      "                                                                    ref. Lidman (2026), arXiv:2606.12431\n",
+      "  Tier 3 (Approfondi)    freedman_prerequisites                     #11 : Theoreme de Freedman (Conway topologiquement slice)\n",
+      "                                                                    ref. Freedman (1982), J. Differential Geom.\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>declarations</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>tier</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Tier 1 (Accessible)</th>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Tier 2 (Modere)</th>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Tier 3 (Approfondi)</th>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     declarations\n",
+       "tier                             \n",
+       "Tier 1 (Accessible)             4\n",
+       "Tier 2 (Modere)                 3\n",
+       "Tier 3 (Approfondi)             4"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Les 11 prerequis, extraits du fichier reel, avec tier / enjeu / reference\n",
+    "mp_path = LAKE / 'Knots' / 'MathlibPrerequisites.lean'\n",
+    "mp_text = mp_path.read_text(encoding='utf-8')\n",
+    "\n",
+    "print(f\"MathlibPrerequisites.lean : {len(decls_of(mp_path))} declarations, {count_sorry(mp_path, 'real')} sorry reel\\n\")\n",
+    "\n",
+    "rows = []\n",
+    "tier, enjeu, ref = None, None, ''\n",
+    "for line in mp_text.splitlines():\n",
+    "    m = re.match(r'.*-!\\s*## (Tier \\d)\\s*:\\s*(\\S+)', line)\n",
+    "    if m:\n",
+    "        tier = f\"{m.group(1)} ({m.group(2)})\"\n",
+    "        continue\n",
+    "    m = re.match(r'/--\\s*(#\\d+\\s*:.*)', line)\n",
+    "    if m:\n",
+    "        enjeu = m.group(1)\n",
+    "        continue\n",
+    "    m = re.match(r'Reference\\s*:\\s*(.*)', line)\n",
+    "    if m:\n",
+    "        ref = m.group(1)\n",
+    "        continue\n",
+    "    dm = DECL_RE.match(line)\n",
+    "    if dm:\n",
+    "        rows.append([tier, dm.group(2), enjeu, ref])\n",
+    "        enjeu, ref = None, ''\n",
+    "\n",
+    "for t, name, enjeu, ref in rows:\n",
+    "    print(f\"  {t:22} {name:42} {enjeu}\")\n",
+    "    if ref:\n",
+    "        print(f\"  {'':22} {'':42} ref. {ref}\")\n",
+    "print()\n",
+    "df_mp = pd.DataFrame(rows, columns=['tier', 'declaration', 'enjeu', 'reference'])\n",
+    "df_mp.groupby('tier', sort=False).size().rename('declarations').to_frame()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cc1f357",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003118,
+     "end_time": "2026-08-20T18:14:34.298168+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T18:14:34.295050+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat\n",
+    "\n",
+    "Onze déclarations, **0 sorry réel** : l'instrument du dépôt (`count_code_sorry.py`) les classe « vacuous markers » — ce ne sont pas de la dette de preuve, ce sont de la **documentation formalisée**.\n",
+    "\n",
+    "Le **Tier 1** cible exactement la chaîne 3-colorabilité de §3 (bien-fondé des PD-codes, tricoloriable du trèfle, non-tricoloriable du nœud trivial, invariance R1/R2/R3) — la feuille de route a vieilli dans le bon sens : ce sont ces cibles que §3-§4 montrent en cours de réalisation (bras, murs nommés, sorry restants localisés).\n",
+    "Le **Tier 2** prolonge le corridor de §5 : description formelle des moves, polynôme d'Alexander via Burau/Fox, polynôme de Jones via le crochet de Kauffman.\n",
+    "Le **Tier 3** est l'horizon de recherche : le théorème de Reidemeister (isotopie ambiante ↔ moves) et le trio du nœud de Conway — Piccirillo (non lisse-slice), Freedman (topologiquement slice), Lidman (dénouement de 11n102) — les deux premiers inscrits au [Lean AI Leaderboard](https://lean-lang.org/eval/). Chronologie annoncée pour ce tier : « années à décennies ».\n",
+    "\n",
+    "La feuille de route et l'histoire racontée par Lean-17 se répondent : ce que Lean-17 présente comme résultats mathématiques établis (Piccirillo 2020, Lidman 2026), ce module l'écrit comme ce que Mathlib devrait construire pour qu'ils deviennent des théorèmes Lean."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a29df633",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003136,
+     "end_time": "2026-08-20T18:14:34.304498+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T18:14:34.301362+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Le tableau de bord du lake\n",
     "\n",
     "Synthèse : déclarations, sorries réels, et théorèmes-phare par module."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "0e5f7024",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:31.432591Z",
-     "iopub.status.busy": "2026-08-20T00:58:31.431730Z",
-     "iopub.status.idle": "2026-08-20T00:58:31.467053Z",
-     "shell.execute_reply": "2026-08-20T00:58:31.466299Z"
+     "iopub.execute_input": "2026-08-20T18:14:34.312712Z",
+     "iopub.status.busy": "2026-08-20T18:14:34.312349Z",
+     "iopub.status.idle": "2026-08-20T18:14:34.335967Z",
+     "shell.execute_reply": "2026-08-20T18:14:34.335260Z"
     },
     "papermill": {
-     "duration": 0.043217,
-     "end_time": "2026-08-20T00:58:31.468439+00:00",
+     "duration": 0.028782,
+     "end_time": "2026-08-20T18:14:34.336593+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.425222+00:00",
+     "start_time": "2026-08-20T18:14:34.307811+00:00",
      "status": "completed"
     },
     "tags": []
@@ -677,10 +871,10 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Invariant</td>\n",
-       "      <td>68</td>\n",
-       "      <td>45</td>\n",
-       "      <td>2</td>\n",
-       "      <td>0.03</td>\n",
+       "      <td>71</td>\n",
+       "      <td>48</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.01</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -714,13 +908,13 @@
        "                 module  declarations  theoremes  sorries reels  sorries/decl\n",
        "0                 Basic            34         14              0          0.00\n",
        "1                Conway            15          5              8          0.53\n",
-       "2             Invariant            68         45              2          0.03\n",
+       "2             Invariant            71         48              1          0.01\n",
        "3                Lidman             4          2              2          0.50\n",
        "4  MathlibPrerequisites            11         11              0          0.00\n",
        "5          Reidemeister            36         22              2          0.06"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -742,10 +936,10 @@
    "id": "1b665535",
    "metadata": {
     "papermill": {
-     "duration": 0.004915,
-     "end_time": "2026-08-20T00:58:31.479810+00:00",
+     "duration": 0.002927,
+     "end_time": "2026-08-20T18:14:34.342576+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.474895+00:00",
+     "start_time": "2026-08-20T18:14:34.339649+00:00",
      "status": "completed"
     },
     "tags": []
@@ -760,36 +954,36 @@
    "id": "45c0d3ad",
    "metadata": {
     "papermill": {
-     "duration": 0.006533,
-     "end_time": "2026-08-20T00:58:31.491188+00:00",
+     "duration": 0.002763,
+     "end_time": "2026-08-20T18:14:34.348200+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.484655+00:00",
+     "start_time": "2026-08-20T18:14:34.345437+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "## 7. Le miroir i18n — byte-identity du code\n",
+    "## 8. Le miroir i18n — byte-identity du code\n",
     "\n",
     "La convention #4980 exige que seules les docstrings et commentaires diffèrent entre `Foo.lean` et `Foo_en.lean`. Vérification mesurée : on retire prose et commentaires des deux fichiers et on compare."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "3a6d4311",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:31.501903Z",
-     "iopub.status.busy": "2026-08-20T00:58:31.501218Z",
-     "iopub.status.idle": "2026-08-20T00:58:31.923009Z",
-     "shell.execute_reply": "2026-08-20T00:58:31.918216Z"
+     "iopub.execute_input": "2026-08-20T18:14:34.354582Z",
+     "iopub.status.busy": "2026-08-20T18:14:34.354404Z",
+     "iopub.status.idle": "2026-08-20T18:14:34.690515Z",
+     "shell.execute_reply": "2026-08-20T18:14:34.689714Z"
     },
     "papermill": {
-     "duration": 0.433422,
-     "end_time": "2026-08-20T00:58:31.928510+00:00",
+     "duration": 0.340543,
+     "end_time": "2026-08-20T18:14:34.691460+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.495088+00:00",
+     "start_time": "2026-08-20T18:14:34.350917+00:00",
      "status": "completed"
     },
     "tags": []
@@ -827,10 +1021,10 @@
    "id": "c64c9030",
    "metadata": {
     "papermill": {
-     "duration": 0.014246,
-     "end_time": "2026-08-20T00:58:31.979663+00:00",
+     "duration": 0.003238,
+     "end_time": "2026-08-20T18:14:34.698342+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.965417+00:00",
+     "start_time": "2026-08-20T18:14:34.695104+00:00",
      "status": "completed"
     },
     "tags": []
@@ -845,10 +1039,10 @@
    "id": "2382dfb5",
    "metadata": {
     "papermill": {
-     "duration": 0.005218,
-     "end_time": "2026-08-20T00:58:32.001202+00:00",
+     "duration": 0.003207,
+     "end_time": "2026-08-20T18:14:34.704684+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:31.995984+00:00",
+     "start_time": "2026-08-20T18:14:34.701477+00:00",
      "status": "completed"
     },
     "tags": []
@@ -866,20 +1060,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8f805f22",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:32.019627Z",
-     "iopub.status.busy": "2026-08-20T00:58:32.019300Z",
-     "iopub.status.idle": "2026-08-20T00:58:32.027065Z",
-     "shell.execute_reply": "2026-08-20T00:58:32.025468Z"
+     "iopub.execute_input": "2026-08-20T18:14:34.715279Z",
+     "iopub.status.busy": "2026-08-20T18:14:34.714989Z",
+     "iopub.status.idle": "2026-08-20T18:14:34.718525Z",
+     "shell.execute_reply": "2026-08-20T18:14:34.717736Z"
     },
     "papermill": {
-     "duration": 0.019374,
-     "end_time": "2026-08-20T00:58:32.029108+00:00",
+     "duration": 0.011031,
+     "end_time": "2026-08-20T18:14:34.719153+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:32.009734+00:00",
+     "start_time": "2026-08-20T18:14:34.708122+00:00",
      "status": "completed"
     },
     "tags": []
@@ -897,10 +1091,10 @@
    "id": "c52ef1db",
    "metadata": {
     "papermill": {
-     "duration": 0.006271,
-     "end_time": "2026-08-20T00:58:32.039995+00:00",
+     "duration": 0.003463,
+     "end_time": "2026-08-20T18:14:34.725942+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:32.033724+00:00",
+     "start_time": "2026-08-20T18:14:34.722479+00:00",
      "status": "completed"
     },
     "tags": []
@@ -908,9 +1102,9 @@
    "source": [
     "## Exercice 2 — Le compte qui fonde la baseline CI\n",
     "\n",
-    "Le CI gate sur **14 sorries réels** (README, post-#11227). Recomptez avec l'instrument `real` ci-dessus et confrontez à la baseline.\n",
+    "Le CI gate sur **13 sorries réels** (lean-knot.yml, post-#11958). Recomptez avec l'instrument `real` ci-dessus et confrontez à la baseline.\n",
     "\n",
-    "**Indice :** la fonction `count_sorry(path, 'real')` est déjà écrite. Le résultat doit être comparé à la constante 14 — un écart dans un sens ou l'autre est un signal (régression ou baseline périmée).\n",
+    "**Indice :** la fonction `count_sorry(path, 'real')` est déjà écrite. Le résultat doit être comparé à la constante 13 — un écart dans un sens ou l'autre est un signal (régression ou baseline périmée).\n",
     "\n",
     "**Étape 1 :** total real sur les six modules.  \n",
     "**Étape 2 :** afficher la comparaison au format `total vs baseline : OK/ECART`."
@@ -918,28 +1112,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "7e7f464b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:32.062495Z",
-     "iopub.status.busy": "2026-08-20T00:58:32.062272Z",
-     "iopub.status.idle": "2026-08-20T00:58:32.065997Z",
-     "shell.execute_reply": "2026-08-20T00:58:32.065140Z"
+     "iopub.execute_input": "2026-08-20T18:14:34.733950Z",
+     "iopub.status.busy": "2026-08-20T18:14:34.733644Z",
+     "iopub.status.idle": "2026-08-20T18:14:34.737591Z",
+     "shell.execute_reply": "2026-08-20T18:14:34.736629Z"
     },
     "papermill": {
-     "duration": 0.018967,
-     "end_time": "2026-08-20T00:58:32.066851+00:00",
+     "duration": 0.009032,
+     "end_time": "2026-08-20T18:14:34.738454+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:32.047884+00:00",
+     "start_time": "2026-08-20T18:14:34.729422+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "# Exercice a completer : confrontez le compte real a la baseline CI (14)\n",
-    "BASELINE = 14\n",
+    "# Exercice a completer : confrontez le compte real a la baseline CI (13)\n",
+    "BASELINE = 13\n",
     "pass"
    ]
   },
@@ -948,10 +1142,10 @@
    "id": "3cb867c6",
    "metadata": {
     "papermill": {
-     "duration": 0.004342,
-     "end_time": "2026-08-20T00:58:32.075709+00:00",
+     "duration": 0.00338,
+     "end_time": "2026-08-20T18:14:34.745294+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:32.071367+00:00",
+     "start_time": "2026-08-20T18:14:34.741914+00:00",
      "status": "completed"
     },
     "tags": []
@@ -969,20 +1163,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "id": "7af659c5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-20T00:58:32.089540Z",
-     "iopub.status.busy": "2026-08-20T00:58:32.089299Z",
-     "iopub.status.idle": "2026-08-20T00:58:32.092243Z",
-     "shell.execute_reply": "2026-08-20T00:58:32.091844Z"
+     "iopub.execute_input": "2026-08-20T18:14:34.753303Z",
+     "iopub.status.busy": "2026-08-20T18:14:34.753012Z",
+     "iopub.status.idle": "2026-08-20T18:14:34.757556Z",
+     "shell.execute_reply": "2026-08-20T18:14:34.756562Z"
     },
     "papermill": {
-     "duration": 0.010839,
-     "end_time": "2026-08-20T00:58:32.092975+00:00",
+     "duration": 0.009737,
+     "end_time": "2026-08-20T18:14:34.758384+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:32.082136+00:00",
+     "start_time": "2026-08-20T18:14:34.748647+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1003,10 +1197,10 @@
    "id": "9454d97a",
    "metadata": {
     "papermill": {
-     "duration": 0.005465,
-     "end_time": "2026-08-20T00:58:32.103552+00:00",
+     "duration": 0.003399,
+     "end_time": "2026-08-20T18:14:34.765398+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:32.098087+00:00",
+     "start_time": "2026-08-20T18:14:34.761999+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1017,6 +1211,8 @@
     "- Lake : [`knot_lean/`](knot_lean/) — README (état des sorries, corridor Reidemeister #8696, bi-implication R1 #11227)\n",
     "- Lean-17 : [`Lean-17-Knots-a-Conway-and-Proofs.ipynb`](Lean-17-Knots-a-Conway-and-Proofs.ipynb) — l'histoire mathématique (Fox, Piccirillo, Lidman)\n",
     "- Règles du dépôt : compte `sorry` réel via `scripts/lean/count_code_sorry.py` (jamais `grep -c`)\n",
+    "- Feuille de route : `Knots/MathlibPrerequisites.lean` (Epic #2874, Phase 1) — les 11 prérequis tier par tier\n",
+    "- Lean AI Leaderboard : [conway_knot_not_smoothly_slice](https://lean-lang.org/eval/problems/conway_knot_not_smoothly_slice/), [conway_knot_topologically_slice](https://lean-lang.org/eval/problems/conway_knot_topologically_slice/) — les cibles Tier 3\n",
     "- Piccirillo (2020), *The Conway knot is not slice*, Annals — via Lean-17 §3\n",
     "- Lidman (2026), unknotting number de 11n102 — via Lean-17 §5"
    ]
@@ -1026,10 +1222,10 @@
    "id": "d34e7144",
    "metadata": {
     "papermill": {
-     "duration": 0.0046,
-     "end_time": "2026-08-20T00:58:32.112686+00:00",
+     "duration": 0.003295,
+     "end_time": "2026-08-20T18:14:34.772194+00:00",
      "exception": false,
-     "start_time": "2026-08-20T00:58:32.108086+00:00",
+     "start_time": "2026-08-20T18:14:34.768899+00:00",
      "status": "completed"
     },
     "tags": []
@@ -1037,7 +1233,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "Le lake `knot_lean` n'est pas un décor : 170 déclarations réelles, une dette de preuve **ciblée** (14 sorries réels sur 3 modules, dont 10 documentés hors-portée Mathlib), une chaîne 3-colorabilité décomposée en bras et murs nommés, un miroir i18n byte-identique. Le compagnon mesure ce que Lean-17 raconte : la formalisation avance en discipline — chaque mur est un théorème, chaque sorry restant est nommé et localisé."
+    "Le lake `knot_lean` n'est pas un décor : 171 déclarations réelles, une dette de preuve **ciblée** (13 sorries réels sur 4 modules, dont 10 documentés hors-portée Mathlib), une chaîne 3-colorabilité décomposée en bras et murs nommés, un miroir i18n byte-identique. Le compagnon mesure ce que Lean-17 raconte : la formalisation avance en discipline — chaque mur est un théorème, chaque sorry restant est nommé et localisé."
    ]
   }
  ],
@@ -1061,14 +1257,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 3.144322,
-   "end_time": "2026-08-20T00:58:32.362813+00:00",
+   "duration": 3.179745,
+   "end_time": "2026-08-20T18:14:35.110398+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "Lean-17c-Knots-Companion-Formel.ipynb",
-   "output_path": "Lean-17c-Knots-Companion-Formel_output.ipynb",
+   "output_path": "Lean-17c-Knots-Companion-Formel.out.ipynb",
    "parameters": {},
-   "start_time": "2026-08-20T00:58:29.218491+00:00",
+   "start_time": "2026-08-20T18:14:31.930653+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: LIGHT/ledger #11971

## Résumé

Le compagnon formel du lake `knot_lean` couvrait `Basic.lean`, `Invariant.lean` et `Reidemeister.lean` — mais pas `MathlibPrerequisites.lean`, son 4ᵉ module FR porteur de 11 déclarations. C'était le résiduel explicite de mon [RELEASED] #11703 (2026-08-20T01:13Z) : « MathlibPrerequisites (11 decls) non couvert ». Après cette PR, **le lake knot_lean n'a plus aucun module invisible** (mesure : `scan_lake_notebook_visibility.py`).

## Périmètre (1 fichier)

`MyIA.AI.Notebooks/SymbolicAI/Lean/Lean-17c-Knots-Companion-Formel.ipynb` (371+/175−, dont la re-exec complète des outputs)

## Nouvelle section 6 — la feuille de route des 11 prérequis

Extraction **depuis le fichier réel** (pas une copie) : les 11 déclarations avec leur tier (docstring `/! ## Tier N`), leur enjeu (`#N : ...`) et leur référence bibliographique, chacune **attachée à la bonne déclaration**. Lecture du résultat croisée avec le reste du compagnon :

- **Tier 1 (4 decls)** = la chaîne 3-colorabilité de §3 (bien-fondé PD-codes, trèfle, nœud trivial, invariance R1/R2/R3)
- **Tier 2 (3 decls)** = le corridor Reidemeister de §5 prolongé (description formelle des moves, Alexander via Burau/Fox, Jones via Kauffman)
- **Tier 3 (4 decls)** = l'horizon Conway : Piccirillo, Freedman, Lidman + le théorème de Reidemeister — les cibles [Lean AI Leaderboard](https://lean-lang.org/eval/), même horizon que Lean-17 raconte historiquement

Point pédagogique clé rendu visible : ces 11 théorèmes `True := trivial` sont classés **vacuous markers** par `count_code_sorry.py` (0 sorry réel) — documentation formalisée, pas dette de preuve.

## Alignement sur l'état main post-#11958 (re-exec)

La re-exécution rafraîchit les outputs et corrige au passage la prose périmée : baseline CI **14 → 13** (`lean-knot.yml sorry-baseline: "13"`, Exercice 2 `BASELINE` inclus), total **171 déclarations** (170), `Invariant.lean` **71** (69), conclusion « 4 modules » porteurs de sorries (3). Sections renumérotées 6→7 (tableau de bord), 7→8 (miroir i18n). Références enrichies (MathlibPrerequisites, Leaderboard).

## Preuves

- **Re-exec réelle** : Papermill 2.7.0, kernel python3, 33 cellules, **0 erreur, 0 `execution_count: null`** (les 11 code cells ont `ec` 1..11 séquentielles)
- **Extraction vérifiée** : l'output de la nouvelle cellule affiche les 11 déclarations, répartition 4/3/4 par tier, références correctement attribuées (bug d'attribution décalée trouvé et corrigé à la première exécution)
- **Visibilité mesurée** (`scripts/lean/scan_lake_notebook_visibility.py --lake knot_lean`, contrôle positif intégré) :
  - avant (main) : strict **71**, **1 module noir** / 6
  - après (branche) : strict **83** (+12), **0 module noir**
- **C.1** : aucun `raise NotImplementedError`/`assert False`/`1/0` introduit ; exercices restent des stubs
- **C.3** : seules les cellules source modifiées + insertion ; re-exec complète faite par dessus (notebook 39 Ko)

See #11703 (contribution au résiduel knot ; l'EPIC reste ouverte — autres lakes en cours)
