### PR TITLE
fix(guard,#11984): nominal revue/review + reference pointable = mention (position D)

### DIFF
--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -282,6 +282,39 @@ _MENTION_VERDICT_LIFTED = re.compile(
     r"\w*\s+\((?:commit\s+[a-f0-9]+|#\d+|PR\s*#?\d+|pull/\d+)\)")
 
 
+# #11984 — Position D : le nominal `revue` / `review` DEVANT le verdict, avec
+# reference pointable APRES. Cinquieme reformulation de la classe use-vs-
+# mention (#11246 → #11636 → #11744 → #11809 → celle-ci) : les correctifs
+# precedents portaient le nominal `verdict` (avec ses determinants) mais pas
+# `revue`/`review`, la facon la plus naturelle d'ecrire la meme mention en
+# francais comme en anglais. Instance fondatrice : #11911, commentaire du
+# 2026-08-20T14:50:21Z — « La revue CHANGES_REQUESTED (07:32Z, SHA
+# `5aa6e035`) pointait 2 defauts » — un rapport de re-review classe
+# BOT-CONCERN comme s'il emettait la reserve qu'il rapporte.
+#
+# ELARGIR une neutralisation ouvre le sens dangereux : le faux negatif (une
+# reserve reelle eteinte), failure mode fondateur de B.0 (#10761) — il ne se
+# signale pas. Le discriminant n'est donc PAS le nominal seul — le contre-
+# exemple de l'issue, « Cette review CHANGES_REQUESTED reste bloquante »,
+# porte le nominal devant le verdict ET emet une reserve vivante. On exige
+# la piste (a) de l'issue, calquee sur le precedent #11809 : une reference
+# POINTABLE entre parentheses dans la suite immediate du verdict — SHA hex
+# 7+, numero PR/issue, date ISO ou horodatage. Un rapport de correction
+# designe l'evenement passe qu'il rapporte (`(07:32Z, SHA ...)`) ; une
+# emission revendique sans pointer. Pas de reference pointable = pas de
+# match = le verdict reste emis. Frontiere elargie a `*` : le mot est
+# souvent en gras (« La **revue** CHANGES_REQUESTED »).
+_MENTION_VERDICT_REVIEW = re.compile(
+    r"(?i)(?:^|[\s,;:(*])"  # frontiere (inclut * pour **revue**)
+    r"(?:le|la|les|du|mon|ma|ce|cet|cette|ces|the|my)?\s*"
+    r"(?:revue|review)(?![:.])"
+    r"[^():\n.]{0,60}?(?-i:([A-Z][A-Z_]{3,}))(?![A-Za-z0-9_])"
+    r"[^():\n.]{0,12}?"
+    r"\([^()\n]{0,80}?"
+    r"(?:[a-f0-9]{7,}|#\d+|\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}(?::\d{2})?Z?)"
+    r"[^()\n]{0,40}\)")
+
+
 def _strip_mentioned_verdicts(body: str) -> str:
     """Neutralise les noms de verdict cites en position de mention (#11636, #11744, #11809).
 
@@ -289,7 +322,7 @@ def _strip_mentioned_verdicts(body: str) -> str:
     reste du body sont preserves (les fenetres de `_is_cited` restent
     calibrees sur la vraie position des occurrences survivantes).
     """
-    for pat in (_MENTION_VERDICT, _MENTION_VERDICT_HEADING, _MENTION_VERDICT_INLINE, _MENTION_VERDICT_LIFTED):
+    for pat in (_MENTION_VERDICT, _MENTION_VERDICT_HEADING, _MENTION_VERDICT_INLINE, _MENTION_VERDICT_LIFTED, _MENTION_VERDICT_REVIEW):
         body = pat.sub(
             lambda m: m.group(0).replace(m.group(1), " " * len(m.group(1))), body)
     return body

--- a/scripts/tests/test_check_unaddressed_nits_mention.py
+++ b/scripts/tests/test_check_unaddressed_nits_mention.py
@@ -214,3 +214,101 @@ def test_11809_commit_sha_sans_verdict_ne_matche_pas():
     body = "Le fix est dans (commit abc1234) — pas un verdict, juste un SHA."
     # classify doit rendre None (pas de CONCERN_MARKER dans cette prose).
     assert mod.classify("hermes-bot", body) is None, body
+
+
+# ---------------------------------------------------------------------------
+# #11984 — Position D : nominal `revue`/`review` + reference pointable.
+# Instance fondatrice : #11911, commentaire 2026-08-20T14:50:21Z (corps
+# EXACT ci-dessous) — un rapport de re-review classe BOT-CONCERN comme
+# s'il emettait la reserve qu'il rapporte. Cinquieme reformulation de la
+# classe use-vs-mention. Le discriminant n'est PAS le nominal seul : le
+# contre-exemple de l'issue (« Cette review CHANGES_REQUESTED reste
+# bloquante ») porte le nominal ET emet une reserve vivante.
+# ---------------------------------------------------------------------------
+
+FIXTURE_11911_BODY = (
+    "Re-review request — la réparation demandée est livrée sur `221349b441` "
+    "(tête actuelle, post-revue).\n"
+    "\n"
+    "La revue CHANGES_REQUESTED (07:32Z, SHA `5aa6e035`) pointait 2 défauts : "
+    "(1) 0 output `image/png` committé, (2) stdout régressé (supprimé). "
+    "Vérifié firsthand sur la tête actuelle :\n"
+    "\n"
+    "**1. Frames image/png présentes** : 8 outputs `image/png` committés dans "
+    "les cells 10/15/20. Re-exéc authentique avec ComfyUI-Video joignable "
+    "(`localhost:8189`, HTTP 401 = service UP, `run_generation=True`).\n"
+    "\n"
+    "CI CLEAN (0 fail). La revue visait l'ancien SHA `5aa6e035` — la tête "
+    "`221349b441` adresse les 2 points bloquants."
+)
+
+
+def test_11984_fixture_reelle_11911_nest_plus_un_nit():
+    """Le corps EXACT du commentaire bloqueur de #11911 : le verdict
+    rapporte est neutralise, le commentaire n'est plus BOT-CONCERN."""
+    assert mod.classify("jsboige", FIXTURE_11911_BODY) is None
+
+
+def test_11984_revue_en_gras_avec_ref_pointable_devient_mention():
+    """« La **revue** CHANGES_REQUESTED (07:32Z, SHA `...`) » — le gras
+    markdown autour du nominal est couvert (frontiere etendue a `*`)."""
+    body = "La **revue** CHANGES_REQUESTED (07:32Z, SHA `5aa6e035`) pointait 2 défauts."
+    assert mod.classify("hermes-bot", body) is None, body
+
+
+def test_11984_anglais_the_review_couvert():
+    body = "the review CHANGES_REQUESTED (07:32Z, SHA 5aa6e035) flagged two defects."
+    assert mod.classify("hermes-bot", body) is None, body
+
+
+def test_11984_reference_pr_issue_couvertes():
+    body = "la revue CHANGES_REQUESTED (cf #11911) est adressée par le commit."
+    assert mod.classify("hermes-bot", body) is None, body
+
+
+def test_11984_contre_exemple_issue_reste_vivant():
+    """LE contre-exemple de l'issue, a ne PAS neutraliser : le nominal est
+    devant le verdict mais il EMET une reserve vivante — aucune reference
+    pointable n'etablit le rapport d'evenement passe."""
+    body = "Cette review CHANGES_REQUESTED reste bloquante."
+    assert mod.classify("hermes-bot", body) == "BOT-CONCERN", body
+
+
+def test_11984_revue_sans_reference_pointable_reste_vivant():
+    """Nominal + verdict mais la suite ne porte pas de reference pointable :
+    la mention n'est pas etablie, le verdict reste emis."""
+    body = "la revue CHANGES_REQUESTED du matin était sévère."
+    assert mod.classify("hermes-bot", body) == "BOT-CONCERN", body
+
+
+def test_11984_parenthese_non_pointable_reste_vivant():
+    """Une parenthese qui ne porte NI SHA, NI numero, NI horodatage ne
+    designe rien : « (de ai-01) » n'etablit pas le rapport passe."""
+    body = "La review CHANGES_REQUESTED (de ai-01) reste bloquante."
+    assert mod.classify("hermes-bot", body) == "BOT-CONCERN", body
+
+
+def test_11984_emission_marker_deux_points_reste_vivante():
+    """« Review CHANGES_REQUESTED: ... » — la forme MARKER: nue reste une
+    emission (le garde `verdict(?![:.])` du nominal + l'absence de paren
+    pointable la preservent)."""
+    body = (
+        "Review CHANGES_REQUESTED: la séquence exec est UNORDERED, "
+        "à corriger avant merge."
+    )
+    assert mod.classify("hermes-bot", body) == "BOT-CONCERN", body
+
+
+def test_11984_forme_11628_non_regie_par_le_nouveau_motif():
+    """Non-regression : « Fix review ai-01 (CHANGES_REQUESTED) — commit ... »
+    reste gere par le motif d'ORIGINE #11636 (verbe de reference + verdict
+    entre parentheses), pas par la position D. Le strip applique au body
+    doit neutraliser le verdict via _MENTION_VERDICT, et le nouveau motif
+    ne doit PAS matcher seul sur cette forme."""
+    body = "Fix review ai-01 (CHANGES_REQUESTED) — commit 06956bd0a."
+    # Le nouveau motif seul ne matche pas (verdict entre parentheses, pas
+    # de parenthese-pointable APRES le verdict).
+    m = mod._MENTION_VERDICT_REVIEW.search(body)
+    assert m is None, body
+    # Le strip global neutralise toujours (via #11636).
+    assert "CHANGES_REQUESTED" not in mod._strip_mentioned_verdicts(body)


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: DEEP/lean #2874 (collision #11958, non livrée) + MED/genai #11975

# fix(guard,#11984): `la revue CHANGES_REQUESTED (07:32Z, SHA ...)` n'est plus compté comme émission

Traite **#11984**. Cinquième reformulation de la classe use-vs-mention (#11246 → #11636 → #11744 → #11809 → celle-ci). Instance fondatrice : **#11911**, commentaire du 2026-08-20T14:50:21Z — un rapport de re-review classé `[BOT-CONCERN]` comme s'il émettait la réserve qu'il rapportait.

## Le défaut

`_MENTION_VERDICT_INLINE` (Position B, #11744) neutralise un verdict précédé d'un mot-clé de mention. La liste porte `verdict` (avec ses déterminants), `nomm*`, `cit*`, `d[ée]crivan?t`, `que je lev*` — mais **pas les nominaux `revue`/`review`**, la façon la plus naturelle d'écrire la même mention en français comme en anglais. « la revue CHANGES_REQUESTED » et « le verdict CHANGES_REQUESTED » sont la même construction ; une seule des deux était reconnue.

Probe sur le corps réel (pré-fix) : `live_concern=True`, `FIRES: 'CHANGES_REQUESTED'`.

## Pourquoi le nominal seul est refusé — le discriminant

Élargir une neutralisation ouvre le **sens dangereux** : le faux négatif (une réserve réelle éteinte), failure mode fondateur de B.0 (#10761) — il ne se signale pas. Le contre-exemple de l'issue :

> Cette review CHANGES_REQUESTED reste bloquante.

porte le nominal devant le verdict **et émet une réserve vivante**. On exige donc la **piste (a)** de l'issue, calquée sur le précédent #11809 (`_MENTION_VERDICT_LIFTED`) : une **référence pointable entre parenthèses** dans la suite immédiate du verdict — SHA hex 7+, numéro `#N` PR/issue, date ISO ou horodatage. Un rapport de correction désigne l'événement passé qu'il rapporte (`(07:32Z, SHA 5aa6e035)`) ; une émission revendique sans pointer. **Pas de référence = pas de match = le verdict reste émis.**

La piste (b) (verbes au passé narratif énumérés) a été écartée : énumérer des verbes est exactement le piège de mot-clés que l'issue diagnostique comme cause de survie de la classe.

## Le nouveau motif `_MENTION_VERDICT_REVIEW` (Position D)

```python
_MENTION_VERDICT_REVIEW = re.compile(
    r"(?i)(?:^|[\s,;:(*])"  # frontiere (inclut * pour **revue**)
    r"(?:le|la|les|du|mon|ma|ce|cet|cette|ces|the|my)?\s*"
    r"(?:revue|review)(?![:.])"
    r"[^():\n.]{0,60}?(?-i:([A-Z][A-Z_]{3,}))(?![A-Za-z0-9_])"
    r"[^():\n.]{0,12}?"
    r"\([^()\n]{0,80}?"
    r"(?:[a-f0-9]{7,}|#\d+|\d{4}-\d{2}-\d{2}|\d{1,2}:\d{2}(?::\d{2})?Z?)"
    r"[^()\n]{0,40}\)")
```

Frontière étendue à `*` : le mot est souvent en gras (« La **revue** CHANGES_REQUESTED »). Le nom de verdict reste formel (`[A-Z][A-Z_]{3,}` non-case-insensitive, comme Position B). Intégré au strip existant (`_strip_mentioned_verdicts`, 5ᵉ motif du tuple).

## Tests (9 nouveaux + 114 existants = 123 verts)

```
scripts\tests\test_check_unaddressed_nits.py ........... 107 passed
scripts\tests\test_check_unaddressed_nits_mention.py ... 16 passed (7 anciens + 9 nouveaux)
```

- **Fixture exacte #11911** (corps verbatim du commentaire bloqueur) → n'est plus un nit
- Gras `**revue**` → mention
- Anglais `the review ... flagged` → mention
- Réf PR/issue `(cf #11911)` → mention
- **Contre-exemple de l'issue** « reste bloquante » → **reste BOT-CONCERN**
- Sans parenthèse → reste vivant
- Parenthèse NON pointable `(de ai-01)` → reste vivant
- Émission `Review CHANGES_REQUESTED: ...` (MARKER:) → reste BOT-CONCERN
- Non-régression : forme #11628 `Fix review ai-01 (CHANGES_REQUESTED)` toujours gérée par le motif d'ORIGINE (le nouveau motif ne matche pas seul)

## Recette repo-wide (acceptance #11984 — 30 jours, 8 fenêtres OLD vs NEW)

Audit OLD (origin/main, sans Position D) vs NEW (cette branche) sur les PRs mergées des 30 derniers jours, 8 fenêtres de 4 jours (partition `--search merged:...`, cap 400/fenêtre) :

| Fenêtre | scanned | OLD blocked | NEW blocked | delta |
|---|---|---|---|---|
| 07-21..07-25 | 400 | 15 | 15 | 0 |
| 07-25..07-29 | 379 | 50 | 50 | 0 |
| 07-29..08-02 | 254 | 23 | 23 | 0 |
| 08-02..08-06 | 400 | 25 | 25 | 0 |
| 08-06..08-10 | 400 | 37 | 37 | 0 |
| 08-10..08-14 | 400 | 19 | 19 | 0 |
| 08-14..08-17 | 400 | 18 | 18 | 0 |
| 08-17..08-21 | 400 | 16 | 16 | 0 |
| **TOTAL 30 j** | **3033** | **203** | **203** | **0** |

**Delta de verdict strictement nul, comparé PR par PR** (ensembles identiques, pas seulement comptes) : aucun finding ne disparaît, aucun n'apparaît. L'acceptance « ouvrir les constats qui changent » est satisfaite **par vacuité** — zéro constat changé, donc zéro réserve réelle éteinte dans le corpus mergé.

Lecture honnête de ce zéro : la forme « revue CHANGES_REQUESTED (réf) » ne portait jamais, seule, le verdict bloquant des PRs **mergées** (leurs findings viennent d'autres surfaces — états de review, threads inline non résolus). L'instance fondatrice #11911 était une PR **ouverte** en mode gate — c'est exactement la surface que la Position D débloque. Le corpus prouve la non-régression rétroactive ; le jeu de tests prouve le comportement en gate (fixture exacte #11911).

## Contrôle positif (acceptance #11984)

`python scripts/check_unaddressed_nits.py 11789` (émission réelle non levée, contrôle debout du #11841) : **GATE-EXIT=1** post-fix. Le garde n'est pas débranché — l'audit NEW ci-dessus maintient 16 findings bloquants sur la seule fenêtre récente.

## Périmètre (2 fichiers, +132/-1)

| Fichier | + | − |
|---|---|---|
| `scripts/check_unaddressed_nits.py` | +34 | −1 |
| `scripts/tests/test_check_unaddressed_nits_mention.py` | +98 | −0 |

Périmètre : 2 fichiers — `scripts/check_unaddressed_nits.py` et `scripts/tests/test_check_unaddressed_nits_mention.py`. Aucune autre modification. PR atomique (1 feature, 1 domaine guard).

Closes #11984

## Voisins

- **#11809 / PR #11841** — prédecesseur immédiat (Position C). Cette PR ajoute la **Position D** sur le même principe de référence pointable.
- **#11744** — Position B (prose inline), reste inchangée.
- **#11911** — l'instance débloquée (le commentaire rapportant est désormais neutralisé au niveau classify, indépendamment de la levée d'auteur).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
