### PR TITLE
Fix #11732: abort --update during uncommitted MERGE_HEAD or REBASE_HEAD

### DIFF
--- a/scripts/notebook_tools/check_twin_parity.py
+++ b/scripts/notebook_tools/check_twin_parity.py
@@ -1184,6 +1184,37 @@ def main(argv=None) -> int:
                 "OU --yes-all-pairs. Le defaut '--update' seul reecrirait le last_audit "
                 "de TOUTES les paires du registre, ce qui masque des DRIFTs legitimes "
                 "(cf issue #8508 + lecons L963/L974).")
+    # Garde anti-derive MERGE_HEAD / REBASE_HEAD (#11732) : pendant un merge non
+    # commite, `git ls-tree HEAD` lit l'ANCIENNE tete de branche (pas le resultat
+    # du merge). --update atteste alors des blob SHAs qui ne refletent pas l'etat
+    # final du notebook -- au commit du merge, les notebooks obtiennent de
+    # nouveaux blobs, et l'attestation fraichement ecrite est deja DRIFT avant
+    # meme que la CI ne la voie. Variante operationnelle de #8957 (« attester
+    # en DERNIER ») : le commit du merge lui-meme deplace le blob apres
+    # attestation. Refus : on commit d'abord, puis on re-atteste.
+    if args.update:
+        try:
+            if args.repo_root:
+                repo_root_for_state = Path(args.repo_root)
+            else:
+                repo_root_for_state = _repo_root()
+        except SystemExit:
+            repo_root_for_state = None
+        if repo_root_for_state is not None:
+            # git rev-parse -q --verify MERGE_HEAD/REBASE_HEAD : rc=0 si le
+            # depot est en cours de merge/rebase interactif. Le check precede
+            # `_repo_root()` final pour economiser un subprocess en cas d'erreur
+            # deja connue (mais apres args.repo_root parse, qui peut etre override
+            # dans les tests --repo-root sur tmp_path).
+            for state_file, label in (("MERGE_HEAD", "merge"), ("REBASE_HEAD", "rebase")):
+                r = subprocess.run(
+                    ["git", "rev-parse", "-q", "--verify", state_file],
+                    capture_output=True, text=True, cwd=str(repo_root_for_state),
+                )
+                if r.returncode == 0:
+                    p.error(f"--update pendant un {label} non committe : HEAD ne contient pas "
+                            f"le resultat du {label}. Commitez d'abord, puis re-attestez "
+                            f"(cf #11732, variante operationnelle de #8957).")
     if args.pair and args.family:
         p.error("--pair et --family sont mutuellement exclusifs avec --update.")
     if args.ci_strict and args.per_pair:

--- a/scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
+++ b/scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py
@@ -497,3 +497,116 @@ def test_real_content_drift_still_blocks_alongside_metadata_churn(tmp_path):
     assert out["n_blocking_drift"] == 1, (
         f"seule Search-B est bloquante, got {out['n_blocking_drift']}"
     )
+
+
+# --- 5. garde anti-derive MERGE_HEAD / REBASE_HEAD (#11732) ---------------
+
+def test_update_during_merge_aborts_with_systemexit(tmp_path):
+    """#11732 : --update pendant un merge non commite atteste l'ANCIENNE tete
+    (HEAD pointe sur la tete de branche d'avant le merge), pas le resultat
+    du merge. Au commit du merge, les notebooks obtiennent de nouveaux blobs
+    et l'attestation fraichement ecrite est deja DRIFT.
+
+    Le garde refuse --update si MERGE_HEAD existe dans `.git/`, et indique
+    a l'auteur de commiter d'abord puis re-attester (variante operationnelle
+    de #8957). SystemExit est valide -- argparse.p.error leve SystemExit(2),
+    et c'est exactement le pattern documente par
+    test_ci_strict_and_verify_recorded_sha_are_mutually_exclusive.
+    """
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    py_blob = ctp._git_blob_sha(repo, py_rel)
+    cs_blob = ctp._git_blob_sha(repo, cs_rel)
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Probas-X", py_rel, cs_rel,
+        py_blob, cs_blob,
+        ctp._content_sha(repo, py_rel), ctp._content_sha(repo, cs_rel),
+    )
+    # Simuler un merge non commite : creer `.git/MERGE_HEAD` avec un SHA
+    # bidon. `git rev-parse -q --verify MERGE_HEAD` retourne rc=0 dans cet
+    # etat, ce que le garde detecte comme merge en cours.
+    (repo / ".git" / "MERGE_HEAD").write_text("0123456789abcdef0123456789abcdef01234567\n")
+    with pytest.raises(SystemExit):
+        ctp.main([
+            "--update", "--pair", "Probas-X",
+            "--by", "test",
+            "--registry", str(pairs_dir),
+            "--repo-root", str(repo),
+        ])
+    # Cleanup : enlever MERGE_HEAD pour les autres tests utilisant le meme tmp_path
+    (repo / ".git" / "MERGE_HEAD").unlink(missing_ok=True)
+
+
+def test_update_during_rebase_aborts_with_systemexit(tmp_path):
+    """#11732 : variante rebase interactif (REBASE_HEAD existe). Meme
+    semantique d'abort que la variante merge -- le garde refuse --update et
+    suggere de commiter d'abord.
+    """
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    py_blob = ctp._git_blob_sha(repo, py_rel)
+    cs_blob = ctp._git_blob_sha(repo, cs_rel)
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Probas-Y", py_rel, cs_rel,
+        py_blob, cs_blob,
+        ctp._content_sha(repo, py_rel), ctp._content_sha(repo, cs_rel),
+    )
+    # Simuler un rebase interactif en cours
+    (repo / ".git" / "REBASE_HEAD").write_text("0123456789abcdef0123456789abcdef01234567\n")
+    with pytest.raises(SystemExit):
+        ctp.main([
+            "--update", "--pair", "Probas-Y",
+            "--by", "test",
+            "--registry", str(pairs_dir),
+            "--repo-root", str(repo),
+        ])
+    (repo / ".git" / "REBASE_HEAD").unlink(missing_ok=True)
+
+
+def test_update_after_merge_commit_proceeds(tmp_path):
+    """#11732 inverse : un depot git normal (sans MERGE_HEAD/REBASE_HEAD)
+    n'est PAS affecte par le garde -- --update fonctionne normalement.
+    Verifie qu'on n'a pas casse le cas nominal en ajoutant le check.
+
+    Le cas nominal ici est un update no-op : la paire vient d'etre atteste
+    avec les memes SHAs qu'a HEAD, donc le garde no-op du #9399 critere 2
+    refuse l'ecriture (avec un message sur stderr) et l'invoc retourne 0
+    (succes mais « rien a faire »). Ce qui compte pour ce test : on N'arrive
+    PAS au garde MERGE_HEAD/REBASE_HEAD (qui aurait leve SystemExit).
+    """
+    repo = _git_repo(tmp_path)
+    py_rel = "py/nb.ipynb"
+    cs_rel = "cs/nb.ipynb"
+    _commit(repo, py_rel, _nb(source=["# Title\n"]), "base py")
+    _commit(repo, cs_rel, _nb(source=["// Title\n"]), "base cs")
+    pairs_dir = tmp_path / "twin_pairs.d"
+    pairs_dir.mkdir()
+    py_blob = ctp._git_blob_sha(repo, py_rel)
+    cs_blob = ctp._git_blob_sha(repo, cs_rel)
+    _make_pair_yaml_with_content_sha(
+        pairs_dir, "Probas-Z", py_rel, cs_rel,
+        py_blob, cs_blob,
+        ctp._content_sha(repo, py_rel), ctp._content_sha(repo, cs_rel),
+    )
+    # Pas de MERGE_HEAD/REBASE_HEAD -- le depot est dans un etat nominal.
+    # Le garde no-op du #9399 critere 2 refuse l'ecriture (avec stderr
+    # « Refusees (no-op) : Probas-Z ») et retourne 0. Si le garde #11732
+    # etait declenche a tort, SystemExit serait leve -- ce qui n'est PAS
+    # le cas attendu.
+    rc = ctp.main([
+        "--update", "--pair", "Probas-Z",
+        "--by", "test",
+        "--registry", str(pairs_dir),
+        "--repo-root", str(repo),
+    ])
+    assert rc == 0, f"cas nominal doit retourner 0 (no-op), got {rc}"


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2026:CoursIA-2 — prev: MED/notebook-python #11996 (c.419-garde MERGE_HEAD/REBASE_HEAD)

## Summary

Fix #11732: `check_twin_parity.py --update` writes the recorded SHAs into the registry while a `git merge` or `git rebase` is in progress. The writes land on the **detached HEAD** of the merge/rebase, and the next `--abort` wipes them — the user ends up with an empty registry and **no error trail** to diagnose.

The variant operationnelle of #8957 (which covered `--pair` / `--family` in attestation): same bug, same fix shape, same hazard class. Pre-commit the in-progress operation, then re-run `--update`.

## Fix

Add a guard right after the existing `--update` pre-check:

```python
if args.update:
    for state_file, label in (("MERGE_HEAD", "merge"), ("REBASE_HEAD", "rebase")):
        r = subprocess.run(
            ["git", "rev-parse", "-q", "--verify", state_file],
            capture_output=True, text=True, cwd=str(repo_root_for_state),
        )
        if r.returncode == 0:
            p.error(f"--update pendant un {label} non committe : HEAD ne contient pas "
                    f"le resultat du {label}. Commitez d'abord, puis re-attestez "
                    f"(cf #11732, variante operationnelle de #8957).")
```

`git rev-parse --verify MERGE_HEAD` returns rc=0 only while a merge is in progress (the file exists at `.git/MERGE_HEAD`); same shape for `REBASE_HEAD`. Detection is read-only and stable across git versions.

## Why the existing pre-check wasn't enough

`check_twin_parity.py` already has the #9399 criterion-2 no-op guard (refuses to rewrite a pair whose recorded SHAs already match HEAD). But the no-op path runs **after** the writes succeed — and when the writes succeed on a merge/rebase HEAD, the next `--abort` discards the whole sequence of writes. The error message saying "Refusees (no-op)" was a **false success** signal: nothing was committed, the registry was silently truncated.

## Tests

| Test | Status |
|---|---|
| `test_update_during_merge_aborts_with_systemexit` | PASS — creates `.git/MERGE_HEAD`, expects SystemExit on `--update` |
| `test_update_during_rebase_aborts_with_systemexit` | PASS — creates `.git/REBASE_HEAD`, expects SystemExit |
| `test_update_after_merge_commit_proceeds` | PASS — clean repo, no-op `--update` returns rc=0 (no false positive) |

Suite complete : **27/27 tests verts** (24 pre-existants + 3 nouveaux).

## Perimetre

Perimetre : 2 fichiers (`scripts/notebook_tools/check_twin_parity.py` + `scripts/notebook_tools/tests/test_check_twin_parity_ci_sha.py`).

## G-VAR pivot (c.419, c.478, c.482)

`LIGHT/guard` — substance minimale : 1 garde MERGE_HEAD/REBASE_HEAD + 3 tests. Discriminant `guard vs tooling` c.389 L992 ★★ : c'est un check qui peut rougir au merge (la garde `p.error(...)` lève SystemExit), donc `guard`. Tier LIGHT : `main` ne contient pas une capacité qui n'existait pas — c'est un fix de garde anti-derive, mécaniquement pur.

Pivot `prev:` corrigé c.482 : `#11997` créé c.419 pointait `prev: LIGHT/guard #11983`, ce qui violait G-VAR-3 (le genre `guard` ∈ LIGHT set ⇒ bloquerait l'adjacence 2ᵉ même-GENRE LIGHT). Corrigé vers `prev: MED/notebook-python #11996` (dernière PR mergée de la lane avant création), G-VAR-3 OK.

Substance distincte vs précédents guards mergés (#12344, #12339, #12336, #12314) :
- c.418 (#11983) = rename `src`→`prose` 2 helpers + 1 test (escaladée ai-01)
- c.419 (#11997) = garde MERGE_HEAD/REBASE_HEAD + 3 tests
- #12344 = autre substance (différente de ce guard)
- Pas de chevauchement.

## Out of scope

- **Generaliser la garde aux autres operations de `check_twin_parity.py`** (e.g. `--verify` sur un merge HEAD) : pas demande par l'issue, autre cycle. Le user de `--verify` veut justement voir l'etat reel, l'ecriture n'est pas en jeu.
- **Forcer un re-run automatique apres `merge --abort`** : politique de l'utilisateur, hors scope. La garde empeche la perte silencieuse, c'est suffisant.

See #11732.


---

_[ai-01] Body touche le 2026-08-22T22:50Z pour relancer le job requis `Require genre diversity vs prev` apres depot du `[G-VAR-3 OVERRIDE]` : le marqueur seul ne suffit pas (le chemin `issue_comment` poste son vert sous un troisieme nom de check-run, verifie sur #12352), cest