### PR TITLE
feat(symbolicai,#10382): SL-1 C# twin — pont PythonNet vers aima_knowledge (RECOVERABLE-LOCAL -> SOTA-OK)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
@@ -83,10 +83,10 @@
    "id": "f10b9494",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:33:56.167680Z",
-     "iopub.status.busy": "2026-07-08T06:33:56.153911Z",
-     "iopub.status.idle": "2026-07-08T06:34:01.020339Z",
-     "shell.execute_reply": "2026-07-08T06:34:01.012281Z"
+     "iopub.status.busy": "2026-08-20T18:55:26.849011Z",
+     "iopub.execute_input": "2026-08-20T18:55:26.854815Z",
+     "shell.execute_reply": "2026-08-20T18:55:28.550054Z",
+     "iopub.status.idle": "2026-08-20T18:55:28.554787Z"
     },
     "papermill": {
      "duration": 4.878952,
@@ -99,83 +99,24 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Domaine : 10 attributs\r\n"
-     ]
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": ""
+     }
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exemples : 12 (6 positifs, 6 négatifs)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Domaine : 10 attributs\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Exemples : 12 (6 positifs, 6 négatifs)\r\n"
     }
    ],
-   "source": [
-    "// Définition du domaine : attributs et leurs valeurs possibles.\n",
-    "var ATTRIBUTES = new[] {\n",
-    "    \"Alternate\",    // Yes, No\n",
-    "    \"Bar\",          // Yes, No\n",
-    "    \"Fri/Sat\",      // Yes, No\n",
-    "    \"Hungry\",       // Yes, No\n",
-    "    \"Patrons\",      // None, Some, Full\n",
-    "    \"Price\",        // $, $$, $$$\n",
-    "    \"Raining\",      // Yes, No\n",
-    "    \"Reservation\",  // Yes, No\n",
-    "    \"Type\",         // French, Italian, Thai, Burger\n",
-    "    \"WaitEstimate\", // 0-10, 10-30, 30-60, >60\n",
-    "};\n",
-    "\n",
-    "var ATTRIBUTE_VALUES = new Dictionary<string, string[]> {\n",
-    "    {\"Alternate\",    new[]{\"Yes\",\"No\"}},\n",
-    "    {\"Bar\",          new[]{\"Yes\",\"No\"}},\n",
-    "    {\"Fri/Sat\",      new[]{\"Yes\",\"No\"}},\n",
-    "    {\"Hungry\",       new[]{\"Yes\",\"No\"}},\n",
-    "    {\"Patrons\",      new[]{\"None\",\"Some\",\"Full\"}},\n",
-    "    {\"Price\",        new[]{\"$\",\"$$\",\"$$$\"}},\n",
-    "    {\"Raining\",      new[]{\"Yes\",\"No\"}},\n",
-    "    {\"Reservation\",  new[]{\"Yes\",\"No\"}},\n",
-    "    {\"Type\",         new[]{\"French\",\"Italian\",\"Thai\",\"Burger\"}},\n",
-    "    {\"WaitEstimate\", new[]{\"0-10\",\"10-30\",\"30-60\",\">60\"}},\n",
-    "};\n",
-    "\n",
-    "// Les 12 exemples du restaurant, adaptés de la Table 19.1 d'AIMA.\n",
-    "// (Alternate, Bar, Fri/Sat, Hungry, Patrons, Price, Raining, Reservation,\n",
-    "//  Type, WaitEstimate, WillWait)\n",
-    "var RAW_EXAMPLES = new (string Alternate,string Bar,string FriSat,string Hungry,\n",
-    "    string Patrons,string Price,string Raining,string Reservation,string Type,\n",
-    "    string WaitEstimate,bool WillWait)[] {\n",
-    "    (\"Yes\",\"No\",\"No\",\"Yes\",\"Some\",\"$$$\",\"No\",\"Yes\",\"French\",\"0-10\",  true),\n",
-    "    (\"Yes\",\"No\",\"No\",\"Yes\",\"Full\",\"$\",  \"No\",\"No\", \"Thai\",  \"30-60\", true),\n",
-    "    (\"No\", \"Yes\",\"No\",\"No\", \"Some\",\"$\", \"No\",\"No\", \"Burger\",\"0-10\",  false),\n",
-    "    (\"Yes\",\"No\",\"Yes\",\"Yes\",\"Full\",\"$\", \"Yes\",\"No\",\"Thai\",  \"10-30\", true),\n",
-    "    (\"Yes\",\"No\",\"Yes\",\"No\", \"Full\",\"$$$\",\"No\",\"Yes\",\"French\",\">60\",  false),\n",
-    "    (\"No\", \"Yes\",\"No\",\"Yes\",\"Some\",\"$$\",\"Yes\",\"Yes\",\"Italian\",\"0-10\",true),\n",
-    "    (\"No\", \"Yes\",\"No\",\"No\", \"None\",\"$\", \"Yes\",\"No\", \"Burger\",\"0-10\", false),\n",
-    "    (\"No\", \"No\",\"No\",\"Yes\",\"Some\",\"$$\",\"Yes\",\"Yes\",\"Thai\",  \"0-10\",  true),\n",
-    "    (\"No\", \"Yes\",\"Yes\",\"No\", \"Full\",\"$\", \"Yes\",\"No\", \"Burger\",\"10-30\",false),\n",
-    "    (\"Yes\",\"Yes\",\"Yes\",\"Yes\",\"Full\",\"$$$\",\"No\",\"Yes\",\"Italian\",\"10-30\",false),\n",
-    "    (\"No\", \"No\",\"No\",\"No\", \"None\",\"$\", \"No\",\"No\", \"Thai\",  \"0-10\",  false),\n",
-    "    (\"Yes\",\"Yes\",\"Yes\",\"Yes\",\"Full\",\"$\", \"No\",\"No\", \"Burger\",\"30-60\",true),\n",
-    "};\n",
-    "\n",
-    "// Conversion en dictionnaires { attribut -> valeur }.\n",
-    "List<Dictionary<string,string>> EXAMPLES = RAW_EXAMPLES\n",
-    "    .Select(r => {\n",
-    "        var d = new Dictionary<string,string>();\n",
-    "        d[\"Alternate\"]=r.Alternate; d[\"Bar\"]=r.Bar; d[\"Fri/Sat\"]=r.FriSat;\n",
-    "        d[\"Hungry\"]=r.Hungry; d[\"Patrons\"]=r.Patrons; d[\"Price\"]=r.Price;\n",
-    "        d[\"Raining\"]=r.Raining; d[\"Reservation\"]=r.Reservation; d[\"Type\"]=r.Type;\n",
-    "        d[\"WaitEstimate\"]=r.WaitEstimate; d[\"WillWait\"]=r.WillWait?\"Yes\":\"No\";\n",
-    "        return d;\n",
-    "    }).ToList();\n",
-    "\n",
-    "int nPos = EXAMPLES.Count(e => e[\"WillWait\"]==\"Yes\");\n",
-    "Console.WriteLine($\"Domaine : {ATTRIBUTES.Length} attributs\");\n",
-    "Console.WriteLine($\"Exemples : {EXAMPLES.Count} ({nPos} positifs, {EXAMPLES.Count-nPos} négatifs)\");\n"
-   ]
+   "source": "// Définition du domaine : attributs et leurs valeurs possibles.\nvar ATTRIBUTES = new[] {\n    \"Alternate\",    // Yes, No\n    \"Bar\",          // Yes, No\n    \"Fri/Sat\",      // Yes, No\n    \"Hungry\",       // Yes, No\n    \"Patrons\",      // None, Some, Full\n    \"Price\",        // $, $$, $$$\n    \"Raining\",      // Yes, No\n    \"Reservation\",  // Yes, No\n    \"Type\",         // French, Italian, Thai, Burger\n    \"WaitEstimate\", // 0-10, 10-30, 30-60, >60\n};\n\nvar ATTRIBUTE_VALUES = new Dictionary<string, string[]> {\n    {\"Alternate\",    new[]{\"Yes\",\"No\"}},\n    {\"Bar\",          new[]{\"Yes\",\"No\"}},\n    {\"Fri/Sat\",      new[]{\"Yes\",\"No\"}},\n    {\"Hungry\",       new[]{\"Yes\",\"No\"}},\n    {\"Patrons\",      new[]{\"None\",\"Some\",\"Full\"}},\n    {\"Price\",        new[]{\"$\",\"$$\",\"$$$\"}},\n    {\"Raining\",      new[]{\"Yes\",\"No\"}},\n    {\"Reservation\",  new[]{\"Yes\",\"No\"}},\n    {\"Type\",         new[]{\"French\",\"Italian\",\"Thai\",\"Burger\"}},\n    {\"WaitEstimate\", new[]{\"0-10\",\"10-30\",\"30-60\",\">60\"}},\n};\n\n// Les 12 exemples du restaurant, adaptés de la Table 19.1 d'AIMA.\n// (Alternate, Bar, Fri/Sat, Hungry, Patrons, Price, Raining, Reservation,\n//  Type, WaitEstimate, WillWait)\nvar RAW_EXAMPLES = new (string Alternate,string Bar,string FriSat,string Hungry,\n    string Patrons,string Price,string Raining,string Reservation,string Type,\n    string WaitEstimate,bool WillWait)[] {\n    (\"Yes\",\"No\",\"No\",\"Yes\",\"Some\",\"$$$\",\"No\",\"Yes\",\"French\",\"0-10\",  true),\n    (\"Yes\",\"No\",\"No\",\"Yes\",\"Full\",\"$\",  \"No\",\"No\", \"Thai\",  \"30-60\", true),\n    (\"No\", \"Yes\",\"No\",\"No\", \"Some\",\"$\", \"No\",\"No\", \"Burger\",\"0-10\",  false),\n    (\"Yes\",\"No\",\"Yes\",\"Yes\",\"Full\",\"$\", \"Yes\",\"No\",\"Thai\",  \"10-30\", true),\n    (\"Yes\",\"No\",\"Yes\",\"No\", \"Full\",\"$$$\",\"No\",\"Yes\",\"French\",\">60\",  false),\n    (\"No\", \"Yes\",\"No\",\"Yes\",\"Some\",\"$$\",\"Yes\",\"Yes\",\"Italian\",\"0-10\",true),\n    (\"No\", \"Yes\",\"No\",\"No\", \"None\",\"$\", \"Yes\",\"No\", \"Burger\",\"0-10\", false),\n    (\"No\", \"No\",\"No\",\"Yes\",\"Some\",\"$$\",\"Yes\",\"Yes\",\"Thai\",  \"0-10\",  true),\n    (\"No\", \"Yes\",\"Yes\",\"No\", \"Full\",\"$\", \"Yes\",\"No\", \"Burger\",\"10-30\",false),\n    (\"Yes\",\"Yes\",\"Yes\",\"Yes\",\"Full\",\"$$$\",\"No\",\"Yes\",\"Italian\",\"10-30\",false),\n    (\"No\", \"No\",\"No\",\"No\", \"None\",\"$\", \"No\",\"No\", \"Thai\",  \"0-10\",  false),\n    (\"Yes\",\"Yes\",\"Yes\",\"Yes\",\"Full\",\"$\", \"No\",\"No\", \"Burger\",\"30-60\",true),\n};\n\n// Conversion en dictionnaires { attribut -> valeur }.\nList<Dictionary<string,string>> EXAMPLES = RAW_EXAMPLES\n    .Select(r => {\n        var d = new Dictionary<string,string>();\n        d[\"Alternate\"]=r.Alternate; d[\"Bar\"]=r.Bar; d[\"Fri/Sat\"]=r.FriSat;\n        d[\"Hungry\"]=r.Hungry; d[\"Patrons\"]=r.Patrons; d[\"Price\"]=r.Price;\n        d[\"Raining\"]=r.Raining; d[\"Reservation\"]=r.Reservation; d[\"Type\"]=r.Type;\n        d[\"WaitEstimate\"]=r.WaitEstimate; d[\"WillWait\"]=r.WillWait?\"Yes\":\"No\";\n        return d;\n    }).ToList();\n\nint nPos = EXAMPLES.Count(e => e[\"WillWait\"]==\"Yes\");\nConsole.WriteLine($\"Domaine : {ATTRIBUTES.Length} attributs\");\nConsole.WriteLine($\"Exemples : {EXAMPLES.Count} ({nPos} positifs, {EXAMPLES.Count-nPos} négatifs)\");\n"
   },
   {
    "cell_type": "markdown",
@@ -205,10 +146,10 @@
    "id": "513768b0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:34:01.047173Z",
-     "iopub.status.busy": "2026-07-08T06:34:01.046767Z",
-     "iopub.status.idle": "2026-07-08T06:34:01.570389Z",
-     "shell.execute_reply": "2026-07-08T06:34:01.570100Z"
+     "iopub.status.busy": "2026-08-20T18:55:28.556291Z",
+     "iopub.execute_input": "2026-08-20T18:55:28.556291Z",
+     "shell.execute_reply": "2026-08-20T18:55:28.762873Z",
+     "iopub.status.idle": "2026-08-20T18:55:28.763872Z"
     },
     "papermill": {
      "duration": 0.532991,
@@ -221,100 +162,42 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "G0 (plus générale) : (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "G0 (plus générale) : (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Couvre exemple 1 : True\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Couvre exemple 1 : True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Faux positifs / Faux négatifs : (6, 0)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Faux positifs / Faux négatifs : (6, 0)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Consistante : False\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Consistante : False\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "S0 (plus spécifique) : (∅, ∅, ∅, ∅, ∅, ∅, ∅, ∅, ∅, ∅)\r\n"
-     ]
+     "name": "stdout",
+     "text": "S0 (plus spécifique) : (∅, ∅, ∅, ∅, ∅, ∅, ∅, ∅, ∅, ∅)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Couvre exemple 1 : False\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Couvre exemple 1 : False\r\n"
     }
    ],
-   "source": [
-    "// Une hypothèse = tableau de 10 contraintes (string). null = aucune valeur; \"?\" = joker.\n",
-    "using Hypothesis = string[];\n",
-    "\n",
-    "// Hypothèses extrêmes.\n",
-    "string[] G0 = ATTRIBUTES.Select(_ => \"?\").ToArray();   // la plus générale\n",
-    "string[] S0 = ATTRIBUTES.Select(_ => (string)null).ToArray(); // la plus spécifique\n",
-    "\n",
-    "// Une hypothèse couvre un exemple si chaque contrainte non-\"?\" est satisfaite.\n",
-    "bool Covers(string[] h, Dictionary<string,string> example) {\n",
-    "    for (int i = 0; i < ATTRIBUTES.Length; i++) {\n",
-    "        if (h[i] == null) return false;            // S0 ne couvre rien\n",
-    "        if (h[i] != \"?\" && h[i] != example[ATTRIBUTES[i]]) return false;\n",
-    "    }\n",
-    "    return true;\n",
-    "}\n",
-    "\n",
-    "// Compte les erreurs d'une hypothèse : (faux positifs, faux négatifs).\n",
-    "(int fp, int fn) CountErrors(string[] h, List<Dictionary<string,string>> examples) {\n",
-    "    int fp = 0, fn = 0;\n",
-    "    foreach (var ex in examples) {\n",
-    "        bool pred = Covers(h, ex);\n",
-    "        bool actual = ex[\"WillWait\"]==\"Yes\";\n",
-    "        if (pred && !actual) fp++;\n",
-    "        if (!pred && actual) fn++;\n",
-    "    }\n",
-    "    return (fp, fn);\n",
-    "}\n",
-    "\n",
-    "bool IsConsistent(string[] h, List<Dictionary<string,string>> examples) {\n",
-    "    var (fp, fn) = CountErrors(h, examples);\n",
-    "    return fp == 0 && fn == 0;\n",
-    "}\n",
-    "\n",
-    "string HStr(string[] h) => \"(\" + string.Join(\", \", h.Select(v => v ?? \"∅\")) + \")\";\n",
-    "\n",
-    "Console.WriteLine($\"G0 (plus générale) : {HStr(G0)}\");\n",
-    "Console.WriteLine($\"  Couvre exemple 1 : {Covers(G0, EXAMPLES[0])}\");\n",
-    "var (fp0, fn0) = CountErrors(G0, EXAMPLES);\n",
-    "Console.WriteLine($\"  Faux positifs / Faux négatifs : ({fp0}, {fn0})\");\n",
-    "Console.WriteLine($\"  Consistante : {IsConsistent(G0, EXAMPLES)}\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine($\"S0 (plus spécifique) : {HStr(S0)}\");\n",
-    "Console.WriteLine($\"  Couvre exemple 1 : {Covers(S0, EXAMPLES[0])}\");\n"
-   ]
+   "source": "// Une hypothèse = tableau de 10 contraintes (string). null = aucune valeur; \"?\" = joker.\nusing Hypothesis = string[];\n\n// Hypothèses extrêmes.\nstring[] G0 = ATTRIBUTES.Select(_ => \"?\").ToArray();   // la plus générale\nstring[] S0 = ATTRIBUTES.Select(_ => (string)null).ToArray(); // la plus spécifique\n\n// Une hypothèse couvre un exemple si chaque contrainte non-\"?\" est satisfaite.\nbool Covers(string[] h, Dictionary<string,string> example) {\n    for (int i = 0; i < ATTRIBUTES.Length; i++) {\n        if (h[i] == null) return false;            // S0 ne couvre rien\n        if (h[i] != \"?\" && h[i] != example[ATTRIBUTES[i]]) return false;\n    }\n    return true;\n}\n\n// Compte les erreurs d'une hypothèse : (faux positifs, faux négatifs).\n(int fp, int fn) CountErrors(string[] h, List<Dictionary<string,string>> examples) {\n    int fp = 0, fn = 0;\n    foreach (var ex in examples) {\n        bool pred = Covers(h, ex);\n        bool actual = ex[\"WillWait\"]==\"Yes\";\n        if (pred && !actual) fp++;\n        if (!pred && actual) fn++;\n    }\n    return (fp, fn);\n}\n\nbool IsConsistent(string[] h, List<Dictionary<string,string>> examples) {\n    var (fp, fn) = CountErrors(h, examples);\n    return fp == 0 && fn == 0;\n}\n\nstring HStr(string[] h) => \"(\" + string.Join(\", \", h.Select(v => v ?? \"∅\")) + \")\";\n\nConsole.WriteLine($\"G0 (plus générale) : {HStr(G0)}\");\nConsole.WriteLine($\"  Couvre exemple 1 : {Covers(G0, EXAMPLES[0])}\");\nvar (fp0, fn0) = CountErrors(G0, EXAMPLES);\nConsole.WriteLine($\"  Faux positifs / Faux négatifs : ({fp0}, {fn0})\");\nConsole.WriteLine($\"  Consistante : {IsConsistent(G0, EXAMPLES)}\");\nConsole.WriteLine();\nConsole.WriteLine($\"S0 (plus spécifique) : {HStr(S0)}\");\nConsole.WriteLine($\"  Couvre exemple 1 : {Covers(S0, EXAMPLES[0])}\");\n"
   },
   {
    "cell_type": "markdown",
@@ -346,10 +229,10 @@
    "id": "8a5c6b93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:34:01.595466Z",
-     "iopub.status.busy": "2026-07-08T06:34:01.595036Z",
-     "iopub.status.idle": "2026-07-08T06:34:01.721242Z",
-     "shell.execute_reply": "2026-07-08T06:34:01.720927Z"
+     "iopub.status.busy": "2026-08-20T18:55:28.764875Z",
+     "iopub.execute_input": "2026-08-20T18:55:28.765380Z",
+     "shell.execute_reply": "2026-08-20T18:55:28.822915Z",
+     "iopub.status.idle": "2026-08-20T18:55:28.822915Z"
     },
     "papermill": {
      "duration": 0.134626,
@@ -362,79 +245,27 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Hypothèse initiale : (Yes, No, No, Yes, Full, $, No, No, Thai, 30-60)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Hypothèse initiale : (Yes, No, No, Yes, Full, $, No, No, Thai, 30-60)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Couvre exemple 2 (positif) : True\r\n"
-     ]
+     "name": "stdout",
+     "text": "Couvre exemple 2 (positif) : True\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Après généralisation pour ex1 : (Yes, No, No, Yes, ?, ?, No, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Après généralisation pour ex1 : (Yes, No, No, Yes, ?, ?, No, ?, ?, ?)\r\n"
     }
    ],
-   "source": [
-    "// h1 est-elle plus générale que h2 ? (h1 >= h2)\n",
-    "bool IsMoreGeneralThan(string[] h1, string[] h2) {\n",
-    "    for (int i = 0; i < ATTRIBUTES.Length; i++) {\n",
-    "        if (h1[i] != \"?\" && h1[i] != h2[i]) return false;\n",
-    "    }\n",
-    "    return true;\n",
-    "}\n",
-    "bool IsMoreSpecificThan(string[] h1, string[] h2) => IsMoreGeneralThan(h2, h1);\n",
-    "\n",
-    "// Généralise h pour qu'elle couvre ex (relâche les contraintes contradictoires).\n",
-    "string[] GeneralizeFor(string[] h, Dictionary<string,string> ex) {\n",
-    "    var result = (string[])h.Clone();\n",
-    "    for (int i = 0; i < ATTRIBUTES.Length; i++) {\n",
-    "        if (result[i] == null) result[i] = ex[ATTRIBUTES[i]];       // S0 -> valeur exacte\n",
-    "        else if (result[i] != \"?\" && result[i] != ex[ATTRIBUTES[i]]) result[i] = \"?\";\n",
-    "    }\n",
-    "    return result;\n",
-    "}\n",
-    "\n",
-    "// Énumère toutes les spécialisations de h qui ne couvrent plus ex\n",
-    "// (resserre un \"?\" vers chaque valeur possible SAUF celle de ex).\n",
-    "List<string[]> SpecializeAgainst(string[] h, Dictionary<string,string> ex,\n",
-    "                                  Dictionary<string,string[]> attrVals) {\n",
-    "    var specs = new List<string[]>();\n",
-    "    for (int i = 0; i < ATTRIBUTES.Length; i++) {\n",
-    "        if (h[i] == \"?\") {\n",
-    "            foreach (var val in attrVals[ATTRIBUTES[i]]) {\n",
-    "                if (val == ex[ATTRIBUTES[i]]) continue;  // on exclut la valeur fautive\n",
-    "                var spec = (string[])h.Clone();\n",
-    "                spec[i] = val;\n",
-    "                specs.Add(spec);\n",
-    "            }\n",
-    "        }\n",
-    "    }\n",
-    "    return specs;\n",
-    "}\n",
-    "\n",
-    "var h1 = new string[]{\"Yes\",\"No\",\"No\",\"Yes\",\"Full\",\"$\",\"No\",\"No\",\"Thai\",\"30-60\"};\n",
-    "Console.WriteLine($\"Hypothèse initiale : {HStr(h1)}\");\n",
-    "Console.WriteLine($\"Couvre exemple 2 (positif) : {Covers(h1, EXAMPLES[1])}\");\n",
-    "Console.WriteLine();\n",
-    "var g1 = GeneralizeFor(h1, EXAMPLES[0]);\n",
-    "Console.WriteLine($\"Après généralisation pour ex1 : {HStr(g1)}\");\n"
-   ]
+   "source": "// h1 est-elle plus générale que h2 ? (h1 >= h2)\nbool IsMoreGeneralThan(string[] h1, string[] h2) {\n    for (int i = 0; i < ATTRIBUTES.Length; i++) {\n        if (h1[i] != \"?\" && h1[i] != h2[i]) return false;\n    }\n    return true;\n}\nbool IsMoreSpecificThan(string[] h1, string[] h2) => IsMoreGeneralThan(h2, h1);\n\n// Généralise h pour qu'elle couvre ex (relâche les contraintes contradictoires).\nstring[] GeneralizeFor(string[] h, Dictionary<string,string> ex) {\n    var result = (string[])h.Clone();\n    for (int i = 0; i < ATTRIBUTES.Length; i++) {\n        if (result[i] == null) result[i] = ex[ATTRIBUTES[i]];       // S0 -> valeur exacte\n        else if (result[i] != \"?\" && result[i] != ex[ATTRIBUTES[i]]) result[i] = \"?\";\n    }\n    return result;\n}\n\n// Énumère toutes les spécialisations de h qui ne couvrent plus ex\n// (resserre un \"?\" vers chaque valeur possible SAUF celle de ex).\nList<string[]> SpecializeAgainst(string[] h, Dictionary<string,string> ex,\n                                  Dictionary<string,string[]> attrVals) {\n    var specs = new List<string[]>();\n    for (int i = 0; i < ATTRIBUTES.Length; i++) {\n        if (h[i] == \"?\") {\n            foreach (var val in attrVals[ATTRIBUTES[i]]) {\n                if (val == ex[ATTRIBUTES[i]]) continue;  // on exclut la valeur fautive\n                var spec = (string[])h.Clone();\n                spec[i] = val;\n                specs.Add(spec);\n            }\n        }\n    }\n    return specs;\n}\n\nvar h1 = new string[]{\"Yes\",\"No\",\"No\",\"Yes\",\"Full\",\"$\",\"No\",\"No\",\"Thai\",\"30-60\"};\nConsole.WriteLine($\"Hypothèse initiale : {HStr(h1)}\");\nConsole.WriteLine($\"Couvre exemple 2 (positif) : {Covers(h1, EXAMPLES[1])}\");\nConsole.WriteLine();\nvar g1 = GeneralizeFor(h1, EXAMPLES[0]);\nConsole.WriteLine($\"Après généralisation pour ex1 : {HStr(g1)}\");\n"
   },
   {
    "cell_type": "markdown",
@@ -469,10 +300,10 @@
    "id": "d097393d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:34:01.744711Z",
-     "iopub.status.busy": "2026-07-08T06:34:01.744338Z",
-     "iopub.status.idle": "2026-07-08T06:34:02.060204Z",
-     "shell.execute_reply": "2026-07-08T06:34:02.059885Z"
+     "iopub.status.busy": "2026-08-20T18:55:28.824920Z",
+     "iopub.execute_input": "2026-08-20T18:55:28.824920Z",
+     "shell.execute_reply": "2026-08-20T18:55:28.961006Z",
+     "iopub.status.idle": "2026-08-20T18:55:28.961006Z"
     },
     "papermill": {
      "duration": 0.322566,
@@ -485,188 +316,97 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Trace CBH :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Trace CBH :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Step | Label | Action                    | Hypothèse\r\n"
-     ]
+     "name": "stdout",
+     "text": "Step | Label | Action                    | Hypothèse\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "--------------------------------------------------------------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "--------------------------------------------------------------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   0 |     + | init                      | (Yes, No, No, Yes, Some, $$$, No, Yes, French\r\n"
-     ]
+     "name": "stdout",
+     "text": "   0 |     + | init                      | (Yes, No, No, Yes, Some, $$$, No, Yes, French\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   1 |     + | generalize                | (Yes, No, No, Yes, ?, ?, No, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   1 |     + | generalize                | (Yes, No, No, Yes, ?, ?, No, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   2 |     - | keep (consistent)         | (Yes, No, No, Yes, ?, ?, No, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   2 |     - | keep (consistent)         | (Yes, No, No, Yes, ?, ?, No, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   3 |     + | generalize                | (Yes, No, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   3 |     + | generalize                | (Yes, No, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   4 |     - | keep (consistent)         | (Yes, No, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   4 |     - | keep (consistent)         | (Yes, No, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   5 |     + | generalize                | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   5 |     + | generalize                | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   6 |     - | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   6 |     - | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   7 |     + | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   7 |     + | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   8 |     - | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   8 |     - | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "   9 |     - | BACKTRACK (no valid specialization) | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "   9 |     - | BACKTRACK (no valid specialization) | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  10 |     - | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  10 |     - | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  11 |     + | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  11 |     + | keep (consistent)         | (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "Hypothèse finale CBH : (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "\nHypothèse finale CBH : (?, ?, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Faux positifs : 1, Faux négatifs : 0\r\n"
-     ]
+     "name": "stdout",
+     "text": "Faux positifs : 1, Faux négatifs : 0\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Consistante : False\r\n"
-     ]
+     "name": "stdout",
+     "text": "Consistante : False\r\n"
     }
    ],
-   "source": [
-    "// CBH (AIMA Figure 19.2). Retourne (hypothèse, trace).\n",
-    "(string[] h, List<(int step, bool label, string action, string[] hyp)> trace)\n",
-    "    CurrentBestHypothesis(List<Dictionary<string,string>> examples) {\n",
-    "\n",
-    "    var trace = new List<(int,bool,string,string[])>();\n",
-    "    var first = examples[0];\n",
-    "    string[] h;\n",
-    "    if (first[\"WillWait\"]==\"Yes\")\n",
-    "        h = ATTRIBUTES.Select(a => first[a]).ToArray();   // hypothèse exacte\n",
-    "    else\n",
-    "        h = (string[])G0.Clone();\n",
-    "\n",
-    "    var seen = new List<Dictionary<string,string>>{ first };\n",
-    "    trace.Add((0, first[\"WillWait\"]==\"Yes\", \"init\", h));\n",
-    "\n",
-    "    for (int idx = 1; idx < examples.Count; idx++) {\n",
-    "        var ex = examples[idx];\n",
-    "        bool covers = Covers(h, ex);\n",
-    "        bool label = ex[\"WillWait\"]==\"Yes\";\n",
-    "        string action = \"keep (consistent)\";\n",
-    "\n",
-    "        if (label && !covers) {\n",
-    "            // Faux négatif -> généraliser.\n",
-    "            h = GeneralizeFor(h, ex);\n",
-    "            action = IsConsistent(h, seen.Append(ex).ToList()) ? \"generalize\" : \"generalize (INCONSISTANT)\";\n",
-    "        } else if (!label && covers) {\n",
-    "            // Faux positif -> spécialiser (première consistante).\n",
-    "            var specs = SpecializeAgainst(h, ex, ATTRIBUTE_VALUES);\n",
-    "            bool found = false;\n",
-    "            foreach (var spec in specs) {\n",
-    "                if (IsConsistent(spec, seen)) { h = spec; found = true; break; }\n",
-    "            }\n",
-    "            action = found ? \"specialize\" : \"BACKTRACK (no valid specialization)\";\n",
-    "        } else {\n",
-    "            action = \"keep (consistent)\";\n",
-    "        }\n",
-    "        seen.Add(ex);\n",
-    "        trace.Add((idx, label, action, h));\n",
-    "    }\n",
-    "    return (h, trace);\n",
-    "}\n",
-    "\n",
-    "var (cbhResult, cbhTrace) = CurrentBestHypothesis(EXAMPLES);\n",
-    "Console.WriteLine(\"Trace CBH :\");\n",
-    "Console.WriteLine($\"{\"Step\",4} | {\"Label\",5} | {\"Action\",-25} | Hypothèse\");\n",
-    "Console.WriteLine(new string('-', 80));\n",
-    "foreach (var (step, label, action, hyp) in cbhTrace) {\n",
-    "    Console.WriteLine($\"{step,4} | {(label?\"+\":\"-\"),5} | {action,-25} | {HStr(hyp).Substring(0, Math.Min(45,HStr(hyp).Length))}\");\n",
-    "}\n",
-    "var (fp, fn) = CountErrors(cbhResult, EXAMPLES);\n",
-    "Console.WriteLine($\"\\nHypothèse finale CBH : {HStr(cbhResult)}\");\n",
-    "Console.WriteLine($\"Faux positifs : {fp}, Faux négatifs : {fn}\");\n",
-    "Console.WriteLine($\"Consistante : {IsConsistent(cbhResult, EXAMPLES)}\");\n"
-   ]
+   "source": "// CBH (AIMA Figure 19.2). Retourne (hypothèse, trace).\n(string[] h, List<(int step, bool label, string action, string[] hyp)> trace)\n    CurrentBestHypothesis(List<Dictionary<string,string>> examples) {\n\n    var trace = new List<(int,bool,string,string[])>();\n    var first = examples[0];\n    string[] h;\n    if (first[\"WillWait\"]==\"Yes\")\n        h = ATTRIBUTES.Select(a => first[a]).ToArray();   // hypothèse exacte\n    else\n        h = (string[])G0.Clone();\n\n    var seen = new List<Dictionary<string,string>>{ first };\n    trace.Add((0, first[\"WillWait\"]==\"Yes\", \"init\", h));\n\n    for (int idx = 1; idx < examples.Count; idx++) {\n        var ex = examples[idx];\n        bool covers = Covers(h, ex);\n        bool label = ex[\"WillWait\"]==\"Yes\";\n        string action = \"keep (consistent)\";\n\n        if (label && !covers) {\n            // Faux négatif -> généraliser.\n            h = GeneralizeFor(h, ex);\n            action = IsConsistent(h, seen.Append(ex).ToList()) ? \"generalize\" : \"generalize (INCONSISTANT)\";\n        } else if (!label && covers) {\n            // Faux positif -> spécialiser (première consistante).\n            var specs = SpecializeAgainst(h, ex, ATTRIBUTE_VALUES);\n            bool found = false;\n            foreach (var spec in specs) {\n                if (IsConsistent(spec, seen)) { h = spec; found = true; break; }\n            }\n            action = found ? \"specialize\" : \"BACKTRACK (no valid specialization)\";\n        } else {\n            action = \"keep (consistent)\";\n        }\n        seen.Add(ex);\n        trace.Add((idx, label, action, h));\n    }\n    return (h, trace);\n}\n\nvar (cbhResult, cbhTrace) = CurrentBestHypothesis(EXAMPLES);\nConsole.WriteLine(\"Trace CBH :\");\nConsole.WriteLine($\"{\"Step\",4} | {\"Label\",5} | {\"Action\",-25} | Hypothèse\");\nConsole.WriteLine(new string('-', 80));\nforeach (var (step, label, action, hyp) in cbhTrace) {\n    Console.WriteLine($\"{step,4} | {(label?\"+\":\"-\"),5} | {action,-25} | {HStr(hyp).Substring(0, Math.Min(45,HStr(hyp).Length))}\");\n}\nvar (fp, fn) = CountErrors(cbhResult, EXAMPLES);\nConsole.WriteLine($\"\\nHypothèse finale CBH : {HStr(cbhResult)}\");\nConsole.WriteLine($\"Faux positifs : {fp}, Faux négatifs : {fn}\");\nConsole.WriteLine($\"Consistante : {IsConsistent(cbhResult, EXAMPLES)}\");\n"
   },
   {
    "cell_type": "markdown",
@@ -698,10 +438,10 @@
    "id": "54818407",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:34:02.087606Z",
-     "iopub.status.busy": "2026-07-08T06:34:02.087215Z",
-     "iopub.status.idle": "2026-07-08T06:34:02.288879Z",
-     "shell.execute_reply": "2026-07-08T06:34:02.288663Z"
+     "iopub.status.busy": "2026-08-20T18:55:28.962611Z",
+     "iopub.execute_input": "2026-08-20T18:55:28.962611Z",
+     "shell.execute_reply": "2026-08-20T18:55:29.063927Z",
+     "iopub.status.idle": "2026-08-20T18:55:29.065349Z"
     },
     "papermill": {
      "duration": 0.209968,
@@ -714,170 +454,82 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Trace Version Space :\r\n"
-     ]
+     "name": "stdout",
+     "text": "Trace Version Space :\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " Ex | Label | |G| | |S|\r\n"
-     ]
+     "name": "stdout",
+     "text": " Ex | Label | |G| | |S|\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "-------------------------\r\n"
-     ]
+     "name": "stdout",
+     "text": "-------------------------\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  0 |     + |   1 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  0 |     + |   1 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  1 |     + |   1 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  1 |     + |   1 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  2 |     - |  16 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  2 |     - |  16 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  3 |     + |   8 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  3 |     + |   8 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  4 |     - |  63 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  4 |     - |  63 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  5 |     + |   2 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  5 |     + |   2 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  6 |     - |  16 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  6 |     - |  16 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  7 |     + |   7 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  7 |     + |   7 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  8 |     - |   7 |   1\r\n"
-     ]
+     "name": "stdout",
+     "text": "  8 |     - |   7 |   1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  9 |     - |  20 |   0\r\n"
-     ]
+     "name": "stdout",
+     "text": "  9 |     - |  20 |   0\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " 10 |     - |  20 |   0\r\n"
-     ]
+     "name": "stdout",
+     "text": " 10 |     - |  20 |   0\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      " 11 |     + |   4 |   0\r\n"
-     ]
+     "name": "stdout",
+     "text": " 11 |     + |   4 |   0\r\n"
     }
    ],
-   "source": [
-    "// Candidate Elimination (AIMA Figure 19.3). Retourne (G_set, S_set, trace).\n",
-    "// Les hypothèses sont comparées/hachées via leur représentation string.\n",
-    "(string Gkey, string Skey, List<(int ex,bool label,int g,int s)> trace)\n",
-    "    CandidateElimination(List<Dictionary<string,string>> examples) {\n",
-    "\n",
-    "    // On stocke G et S comme HashSet de string (sérialisation des hypothèses).\n",
-    "    string Ser(string[] h) => string.Join(\"|\", h.Select(v => v ?? \"∅\"));\n",
-    "    string[] Deser(string s) => s.Split('|').Select(v => v==\"∅\"?null:v).ToArray();\n",
-    "\n",
-    "    var G = new HashSet<string>{ Ser(G0) };\n",
-    "    var S = new HashSet<string>{ Ser(S0) };\n",
-    "    var trace = new List<(int,bool,int,int)>();\n",
-    "\n",
-    "    for (int idx = 0; idx < examples.Count; idx++) {\n",
-    "        var ex = examples[idx];\n",
-    "        bool label = ex[\"WillWait\"]==\"Yes\";\n",
-    "\n",
-    "        if (label) {\n",
-    "            // --- Exemple POSITIF ---\n",
-    "            // S : généraliser chaque s qui ne couvre pas ex.\n",
-    "            var Snew = new HashSet<string>();\n",
-    "            foreach (var sk in S) {\n",
-    "                var s = Deser(sk);\n",
-    "                if (!Covers(s, ex)) s = GeneralizeFor(s, ex);\n",
-    "                Snew.Add(Ser(s));\n",
-    "            }\n",
-    "            // G : retirer ceux qui ne couvrent pas ex (incompatibles avec un positif).\n",
-    "            S = Snew;\n",
-    "            G.RemoveWhere(gk => !Covers(Deser(gk), ex));\n",
-    "        } else {\n",
-    "            // --- Exemple NÉGATIF ---\n",
-    "            // G : spécialiser chaque g qui couvre ex (faux positif).\n",
-    "            var Gnew = new HashSet<string>();\n",
-    "            foreach (var gk in G) {\n",
-    "                var g = Deser(gk);\n",
-    "                if (!Covers(g, ex)) { Gnew.Add(gk); continue; }  // déjà OK\n",
-    "                foreach (var spec in SpecializeAgainst(g, ex, ATTRIBUTE_VALUES)) {\n",
-    "                    // ne garder que les spécialisations plus spécifiques qu'au moins un g\n",
-    "                    if (G.Any(gk2 => IsMoreGeneralThan(Deser(gk2), spec)))\n",
-    "                        Gnew.Add(Ser(spec));\n",
-    "                }\n",
-    "            }\n",
-    "            // S : retirer ceux qui couvrent le négatif (incompatibles).\n",
-    "            G = Gnew;\n",
-    "            S.RemoveWhere(sk => Covers(Deser(sk), ex));\n",
-    "        }\n",
-    "        trace.Add((idx, label, G.Count, S.Count));\n",
-    "    }\n",
-    "    return (Ser(G0), Ser(S0), trace);\n",
-    "}\n",
-    "\n",
-    "var (_, _, ceTrace) = CandidateElimination(EXAMPLES);\n",
-    "Console.WriteLine(\"Trace Version Space :\");\n",
-    "Console.WriteLine($\" {\"Ex\",2} | {\"Label\",5} | {\"|G|\",3} | {\"|S|\",3}\");\n",
-    "Console.WriteLine(new string('-', 25));\n",
-    "foreach (var (ex, label, g, s) in ceTrace)\n",
-    "    Console.WriteLine($\" {ex,2} | {(label?\"+\":\"-\"),5} | {g,3} | {s,3}\");\n"
-   ]
+   "source": "// Candidate Elimination (AIMA Figure 19.3). Retourne (G_set, S_set, trace).\n// Les hypothèses sont comparées/hachées via leur représentation string.\n(string Gkey, string Skey, List<(int ex,bool label,int g,int s)> trace)\n    CandidateElimination(List<Dictionary<string,string>> examples) {\n\n    // On stocke G et S comme HashSet de string (sérialisation des hypothèses).\n    string Ser(string[] h) => string.Join(\"|\", h.Select(v => v ?? \"∅\"));\n    string[] Deser(string s) => s.Split('|').Select(v => v==\"∅\"?null:v).ToArray();\n\n    var G = new HashSet<string>{ Ser(G0) };\n    var S = new HashSet<string>{ Ser(S0) };\n    var trace = new List<(int,bool,int,int)>();\n\n    for (int idx = 0; idx < examples.Count; idx++) {\n        var ex = examples[idx];\n        bool label = ex[\"WillWait\"]==\"Yes\";\n\n        if (label) {\n            // --- Exemple POSITIF ---\n            // S : généraliser chaque s qui ne couvre pas ex.\n            var Snew = new HashSet<string>();\n            foreach (var sk in S) {\n                var s = Deser(sk);\n                if (!Covers(s, ex)) s = GeneralizeFor(s, ex);\n                Snew.Add(Ser(s));\n            }\n            // G : retirer ceux qui ne couvrent pas ex (incompatibles avec un positif).\n            S = Snew;\n            G.RemoveWhere(gk => !Covers(Deser(gk), ex));\n        } else {\n            // --- Exemple NÉGATIF ---\n            // G : spécialiser chaque g qui couvre ex (faux positif).\n            var Gnew = new HashSet<string>();\n            foreach (var gk in G) {\n                var g = Deser(gk);\n                if (!Covers(g, ex)) { Gnew.Add(gk); continue; }  // déjà OK\n                foreach (var spec in SpecializeAgainst(g, ex, ATTRIBUTE_VALUES)) {\n                    // ne garder que les spécialisations plus spécifiques qu'au moins un g\n                    if (G.Any(gk2 => IsMoreGeneralThan(Deser(gk2), spec)))\n                        Gnew.Add(Ser(spec));\n                }\n            }\n            // S : retirer ceux qui couvrent le négatif (incompatibles).\n            G = Gnew;\n            S.RemoveWhere(sk => Covers(Deser(sk), ex));\n        }\n        trace.Add((idx, label, G.Count, S.Count));\n    }\n    return (Ser(G0), Ser(S0), trace);\n}\n\nvar (_, _, ceTrace) = CandidateElimination(EXAMPLES);\nConsole.WriteLine(\"Trace Version Space :\");\nConsole.WriteLine($\" {\"Ex\",2} | {\"Label\",5} | {\"|G|\",3} | {\"|S|\",3}\");\nConsole.WriteLine(new string('-', 25));\nforeach (var (ex, label, g, s) in ceTrace)\n    Console.WriteLine($\" {ex,2} | {(label?\"+\":\"-\"),5} | {g,3} | {s,3}\");\n"
   },
   {
    "cell_type": "markdown",
@@ -928,10 +580,10 @@
    "id": "5065a562",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:34:02.330021Z",
-     "iopub.status.busy": "2026-07-08T06:34:02.329743Z",
-     "iopub.status.idle": "2026-07-08T06:34:02.606716Z",
-     "shell.execute_reply": "2026-07-08T06:34:02.606466Z"
+     "iopub.status.busy": "2026-08-20T18:55:29.066356Z",
+     "iopub.execute_input": "2026-08-20T18:55:29.066356Z",
+     "shell.execute_reply": "2026-08-20T18:55:29.226392Z",
+     "iopub.status.idle": "2026-08-20T18:55:29.227393Z"
     },
     "papermill": {
      "duration": 0.284622,
@@ -944,117 +596,121 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Après 4 exemples d'entraînement : |G|=8, |S|=1\r\n"
-     ]
+     "name": "stdout",
+     "text": "Après 4 exemples d'entraînement : |G|=8, |S|=1\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Test set : 8 exemples\r\n"
-     ]
+     "name": "stdout",
+     "text": "Test set : 8 exemples\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  CBH accuracy            : 5/8 = 62,5%\r\n"
-     ]
+     "name": "stdout",
+     "text": "  CBH accuracy            : 5/8 = 62,5%\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  Version Space (vote) accuracy : 4/8 = 50,0%\r\n"
-     ]
+     "name": "stdout",
+     "text": "  Version Space (vote) accuracy : 4/8 = 50,0%\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Hypothèse CBH : (Yes, No, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Hypothèse CBH : (Yes, No, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Frontières S (1) : (Yes, No, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Frontières S (1) : (Yes, No, ?, Yes, ?, ?, ?, ?, ?, ?)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Frontières G (8) : (Yes, ?, ?, ?, ?, ?, ?, ?, ?, ?) ; (?, No, ?, ?, ?, ?, ?, ?, ?, ?) ; (?, ?, Yes, ?, ?, ?, ?, ?, ?, ?)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Frontières G (8) : (Yes, ?, ?, ?, ?, ?, ?, ?, ?, ?) ; (?, No, ?, ?, ?, ?, ?, ?, ?, ?) ; (?, ?, Yes, ?, ?, ?, ?, ?, ?, ?)\r\n"
     }
    ],
-   "source": [
-    "// Comparaison : entraîner sur N_TRAIN=4, tester sur le reste.\n",
-    "int N_TRAIN = 4;\n",
-    "var (_, _, _) = CandidateElimination(EXAMPLES.Take(N_TRAIN).ToList());\n",
-    "\n",
-    "// Reconstruction de G, S pour N_TRAIN=4 (Version Space encore large).\n",
-    "string Ser(string[] h) => string.Join(\"|\", h.Select(v => v ?? \"∅\"));\n",
-    "string[] Deser(string s) => s.Split('|').Select(v => v==\"∅\"?null:v).ToArray();\n",
-    "\n",
-    "// Version Space après 4 exemples (on recalcule G et S explicitement).\n",
-    "var G = new HashSet<string>{ Ser(G0) };\n",
-    "var S = new HashSet<string>{ Ser(S0) };\n",
-    "for (int idx = 0; idx < N_TRAIN; idx++) {\n",
-    "    var ex = EXAMPLES[idx];\n",
-    "    bool label = ex[\"WillWait\"]==\"Yes\";\n",
-    "    if (label) {\n",
-    "        var Snew = new HashSet<string>();\n",
-    "        foreach (var sk in S) { var s = Deser(sk); if (!Covers(s,ex)) s = GeneralizeFor(s,ex); Snew.Add(Ser(s)); }\n",
-    "        S = Snew; G.RemoveWhere(gk => !Covers(Deser(gk), ex));\n",
-    "    } else {\n",
-    "        var Gnew = new HashSet<string>();\n",
-    "        foreach (var gk in G) { var g = Deser(gk); if (!Covers(g,ex)) { Gnew.Add(gk); continue; }\n",
-    "            foreach (var spec in SpecializeAgainst(g,ex,ATTRIBUTE_VALUES))\n",
-    "                if (G.Any(gk2 => IsMoreGeneralThan(Deser(gk2), spec))) Gnew.Add(Ser(spec)); }\n",
-    "        G = Gnew; S.RemoveWhere(sk => Covers(Deser(sk), ex));\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "// CBH après 4 exemples.\n",
-    "var (cbh4, _) = CurrentBestHypothesis(EXAMPLES.Take(N_TRAIN).ToList());\n",
-    "\n",
-    "// Accuracy sur le test set (exemples 4..11).\n",
-    "var testSet = EXAMPLES.Skip(N_TRAIN).ToList();\n",
-    "// Prédiction CBH : Covers(h, ex).\n",
-    "int cbhCorrect = testSet.Count(ex => Covers(cbh4, ex) == (ex[\"WillWait\"]==\"Yes\"));\n",
-    "// Prédiction VS : vote majoritaire (toutes hypothèses entre S et G).\n",
-    "//   Approximation : si tous les s couvrent et aucun g ne couvre -> prédictible,\n",
-    "//   sinon : majorité sur un échantillon (hypothèses S et G directement).\n",
-    "int vsCorrect = 0;\n",
-    "foreach (var ex in testSet) {\n",
-    "    var sCov = S.Count(sk => Covers(Deser(sk), ex));\n",
-    "    var gCov = G.Count(gk => Covers(Deser(gk), ex));\n",
-    "    bool pred = (sCov + gCov) * 2 > (S.Count + G.Count);  // majorité\n",
-    "    if (pred == (ex[\"WillWait\"]==\"Yes\")) vsCorrect++;\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine($\"Après {N_TRAIN} exemples d'entraînement : |G|={G.Count}, |S|={S.Count}\");\n",
-    "Console.WriteLine($\"Test set : {testSet.Count} exemples\");\n",
-    "Console.WriteLine($\"  CBH accuracy            : {cbhCorrect}/{testSet.Count} = {100.0*cbhCorrect/testSet.Count:F1}%\");\n",
-    "Console.WriteLine($\"  Version Space (vote) accuracy : {vsCorrect}/{testSet.Count} = {100.0*vsCorrect/testSet.Count:F1}%\");\n",
-    "Console.WriteLine();\n",
-    "Console.WriteLine(\"Hypothèse CBH : \" + HStr(cbh4));\n",
-    "Console.WriteLine($\"Frontières S ({S.Count}) : \" + string.Join(\" ; \", S.Take(3).Select(s => HStr(Deser(s)))));\n",
-    "Console.WriteLine($\"Frontières G ({G.Count}) : \" + string.Join(\" ; \", G.Take(3).Select(g => HStr(Deser(g)))));\n"
-   ]
+   "source": "// Comparaison : entraîner sur N_TRAIN=4, tester sur le reste.\nint N_TRAIN = 4;\nvar (_, _, _) = CandidateElimination(EXAMPLES.Take(N_TRAIN).ToList());\n\n// Reconstruction de G, S pour N_TRAIN=4 (Version Space encore large).\nstring Ser(string[] h) => string.Join(\"|\", h.Select(v => v ?? \"∅\"));\nstring[] Deser(string s) => s.Split('|').Select(v => v==\"∅\"?null:v).ToArray();\n\n// Version Space après 4 exemples (on recalcule G et S explicitement).\nvar G = new HashSet<string>{ Ser(G0) };\nvar S = new HashSet<string>{ Ser(S0) };\nfor (int idx = 0; idx < N_TRAIN; idx++) {\n    var ex = EXAMPLES[idx];\n    bool label = ex[\"WillWait\"]==\"Yes\";\n    if (label) {\n        var Snew = new HashSet<string>();\n        foreach (var sk in S) { var s = Deser(sk); if (!Covers(s,ex)) s = GeneralizeFor(s,ex); Snew.Add(Ser(s)); }\n        S = Snew; G.RemoveWhere(gk => !Covers(Deser(gk), ex));\n    } else {\n        var Gnew = new HashSet<string>();\n        foreach (var gk in G) { var g = Deser(gk); if (!Covers(g,ex)) { Gnew.Add(gk); continue; }\n            foreach (var spec in SpecializeAgainst(g,ex,ATTRIBUTE_VALUES))\n                if (G.Any(gk2 => IsMoreGeneralThan(Deser(gk2), spec))) Gnew.Add(Ser(spec)); }\n        G = Gnew; S.RemoveWhere(sk => Covers(Deser(sk), ex));\n    }\n}\n\n// CBH après 4 exemples.\nvar (cbh4, _) = CurrentBestHypothesis(EXAMPLES.Take(N_TRAIN).ToList());\n\n// Accuracy sur le test set (exemples 4..11).\nvar testSet = EXAMPLES.Skip(N_TRAIN).ToList();\n// Prédiction CBH : Covers(h, ex).\nint cbhCorrect = testSet.Count(ex => Covers(cbh4, ex) == (ex[\"WillWait\"]==\"Yes\"));\n// Prédiction VS : vote majoritaire (toutes hypothèses entre S et G).\n//   Approximation : si tous les s couvrent et aucun g ne couvre -> prédictible,\n//   sinon : majorité sur un échantillon (hypothèses S et G directement).\nint vsCorrect = 0;\nforeach (var ex in testSet) {\n    var sCov = S.Count(sk => Covers(Deser(sk), ex));\n    var gCov = G.Count(gk => Covers(Deser(gk), ex));\n    bool pred = (sCov + gCov) * 2 > (S.Count + G.Count);  // majorité\n    if (pred == (ex[\"WillWait\"]==\"Yes\")) vsCorrect++;\n}\n\nConsole.WriteLine($\"Après {N_TRAIN} exemples d'entraînement : |G|={G.Count}, |S|={S.Count}\");\nConsole.WriteLine($\"Test set : {testSet.Count} exemples\");\nConsole.WriteLine($\"  CBH accuracy            : {cbhCorrect}/{testSet.Count} = {100.0*cbhCorrect/testSet.Count:F1}%\");\nConsole.WriteLine($\"  Version Space (vote) accuracy : {vsCorrect}/{testSet.Count} = {100.0*vsCorrect/testSet.Count:F1}%\");\nConsole.WriteLine();\nConsole.WriteLine(\"Hypothèse CBH : \" + HStr(cbh4));\nConsole.WriteLine($\"Frontières S ({S.Count}) : \" + string.Join(\" ; \", S.Take(3).Select(s => HStr(Deser(s)))));\nConsole.WriteLine($\"Frontières G ({G.Count}) : \" + string.Join(\" ; \", G.Take(3).Select(g => HStr(Deser(g)))));\n"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sl1-aima-bridge-md",
+   "metadata": {},
+   "source": "## 6bis. Implémentation de référence : aima-python (pont PythonNet)\n\nLe jumeau Python de cette série (section 9) confronte son CBH from-scratch à\n**l'implémentation de référence d'aima-python** (`knowledge.py`, Figure 19.2,\nvendordée dans `reference/aima_knowledge.py`). Cette section fait la même chose\ndepuis C# : un **pont PythonNet** (.NET → CPython) invoque le même module de\nréférence sur les mêmes 12 exemples, avec la même graine (42) et la même\nhypothèse initiale (le premier exemple positif) — la comparaison est\nreproductible entre les deux jumeaux.\n\nLe pont est un **plus**, jamais un remplacement : les sections 4-6 gardent le\nCBH et le Candidate Elimination codés à la main (c'est le sujet du notebook) ;\nla référence externe joue le rôle d'arbitre, exactement comme la section 9 du\njumeau Python.\n"
+  },
+  {
+   "cell_type": "code",
+   "id": "sl1-aima-bridge-code",
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T18:55:29.228392Z",
+     "iopub.execute_input": "2026-08-20T18:55:29.228392Z",
+     "shell.execute_reply": "2026-08-20T18:55:29.863832Z",
+     "iopub.status.idle": "2026-08-20T18:55:29.863832Z"
+    }
+   },
+   "execution_count": 7,
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/html": "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>pythonnet, 3.0.5</span></li></ul></div></div>"
+     }
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Runtime Python : 3.11.9 (tags/v3.11.9:de54cf5, Apr  2 2024, 10:12:12) [MSC v.1938 64 bit (AMD64)]\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  D1: {'Alternate': 'Yes', 'Bar': 'No', 'Fri/Sat': 'No', 'Hungry': 'Yes'}\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  D2: {'Alternate': 'Yes', 'Fri/Sat': 'Yes', 'Hungry': 'Yes', 'Price': '$', 'Raining': 'Yes', 'Type': 'Thai', 'WaitEstimate': '10-30'}\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  D3: {'Alternate': 'No', 'Hungry': 'Yes', 'Patrons': 'Some', 'Raining': 'Yes', 'Reservation': 'Yes', 'Type': 'Italian', 'WaitEstimate': '0-10'}\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  D4: {'Alternate': 'No', 'Fri/Sat': 'No', 'Patrons': 'Some', 'Raining': 'Yes', 'Reservation': 'Yes'}\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  D5: {'Alternate': 'Yes', 'Bar': 'Yes', 'Patrons': 'Full', 'Type': 'Burger', 'WaitEstimate': '30-60'}\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Hypothese trouvee : 5 disjonction(s) en 0,02s\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\nAccuracy de la reference sur les 12 exemples : 12/12\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "PONT .NET -> aima-python : OK\r\n"
+    }
+   ],
+   "source": "#r \"nuget: pythonnet, 3.0.5\"\nusing Python.Runtime;\n\n// Pont .NET -> CPython -> aima_knowledge (aima-python knowledge.py, Fig 19.2)\n// -- la MEME implementation de reference que le jumeau Python (section 9).\n// PYTHONNET_PYDLL (env) designe le CPython de la machine d'execution.\nRuntime.PythonDLL = Environment.GetEnvironmentVariable(\"PYTHONNET_PYDLL\")\n    ?? @\"C:\\Python313\\python313.dll\";\nPythonEngine.Initialize();\nConsole.WriteLine($\"Runtime Python : {PythonEngine.Version}\");\n\nusing (Py.GIL())\n{\n    // Reproduit la section 9 du jumeau Python : graine fixee (la recherche\n    // generalizations/specializations de la reference est stochastique),\n    // memes 12 exemples convertis au format AIMA (cle GOAL booleenne),\n    // hypothese initiale = premier exemple positif.\n    dynamic random = Py.Import(\"random\");\n    random.seed(42);\n    dynamic sysMod = Py.Import(\"sys\");\n    sysMod.path.insert(0, \"reference\");\n    dynamic aima = Py.Import(\"aima_knowledge\");\n    dynamic json = Py.Import(\"json\");\n\n    var aimaPayload = EXAMPLES.Select(e => {\n        var d = e.Where(kv => kv.Key != \"WillWait\").ToDictionary(kv => kv.Key, kv => (object)kv.Value);\n        d[\"GOAL\"] = e[\"WillWait\"] == \"Yes\";\n        return d;\n    });\n    dynamic aimaExamples = json.loads(System.Text.Json.JsonSerializer.Serialize(aimaPayload));\n\n    var firstPos = EXAMPLES.First(e => e[\"WillWait\"] == \"Yes\");\n    var h0 = firstPos.Where(kv => kv.Key != \"WillWait\").ToDictionary(kv => kv.Key, kv => kv.Value);\n    dynamic initialH = json.loads(System.Text.Json.JsonSerializer.Serialize(new[] { h0 }));\n\n    var watch = System.Diagnostics.Stopwatch.StartNew();\n    dynamic h = aima.current_best_learning(aimaExamples, initialH);\n    watch.Stop();\n\n    int nDisj = 0; int i = 1;\n    foreach (dynamic d in h) { nDisj++; Console.WriteLine($\"  D{i++}: {d}\"); }\n    Console.WriteLine($\"Hypothese trouvee : {nDisj} disjonction(s) en {watch.Elapsed.TotalSeconds:F2}s\");\n\n    int correct = 0;\n    foreach (dynamic e in aimaExamples)\n        if ((bool)aima.guess_value(e, h) == (bool)e[\"GOAL\"]) correct++;\n    Console.WriteLine($\"\\nAccuracy de la reference sur les 12 exemples : {correct}/{EXAMPLES.Count}\");\n}\nConsole.WriteLine(\"PONT .NET -> aima-python : OK\");\n"
   },
   {
    "cell_type": "markdown",
@@ -1077,14 +733,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "4b2470bc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:34:02.642208Z",
-     "iopub.status.busy": "2026-07-08T06:34:02.641912Z",
-     "iopub.status.idle": "2026-07-08T06:34:02.741688Z",
-     "shell.execute_reply": "2026-07-08T06:34:02.741303Z"
+     "iopub.status.busy": "2026-08-20T18:55:29.865832Z",
+     "iopub.execute_input": "2026-08-20T18:55:29.865832Z",
+     "shell.execute_reply": "2026-08-20T18:55:29.938134Z",
+     "iopub.status.idle": "2026-08-20T18:55:29.939135Z"
     },
     "papermill": {
      "duration": 0.107826,
@@ -1097,27 +753,12 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice à compléter (sous-espace consistant).\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice à compléter (sous-espace consistant).\r\n"
     }
    ],
-   "source": [
-    "// EXERCICE : Modifier les labels pour rendre le VS consistant sur 12 exemples\n",
-    "public string[] FindConsistentSubspace(List<Dictionary<string,string>> examples) {\n",
-    "    // TODO etudiant : trouvez un sous-ensemble de 6-8 exemples pour lequel le\n",
-    "    // Version Space converge vers une frontière unique (|G|=|S|=1).\n",
-    "    // Indice : utilisez CandidateElimination sur des sous-ensembles et observez |G|, |S|.\n",
-    "    // Etape 1 : itérez sur les sous-ensembles (combinaisons C(12,6)).\n",
-    "    // Etape 2 : calculez |G|, |S| finaux pour chacun.\n",
-    "    // Etape 3 : retournez un sous-ensemble avec |G|=|S|=1.\n",
-    "    return null;  // TODO etudiant\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine(\"Exercice à compléter (sous-espace consistant).\");\n"
-   ]
+   "source": "// EXERCICE : Modifier les labels pour rendre le VS consistant sur 12 exemples\npublic string[] FindConsistentSubspace(List<Dictionary<string,string>> examples) {\n    // TODO etudiant : trouvez un sous-ensemble de 6-8 exemples pour lequel le\n    // Version Space converge vers une frontière unique (|G|=|S|=1).\n    // Indice : utilisez CandidateElimination sur des sous-ensembles et observez |G|, |S|.\n    // Etape 1 : itérez sur les sous-ensembles (combinaisons C(12,6)).\n    // Etape 2 : calculez |G|, |S| finaux pour chacun.\n    // Etape 3 : retournez un sous-ensemble avec |G|=|S|=1.\n    return null;  // TODO etudiant\n}\n\nConsole.WriteLine(\"Exercice à compléter (sous-espace consistant).\");\n"
   },
   {
    "cell_type": "markdown",
@@ -1154,14 +795,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "6d740dea",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:34:02.784258Z",
-     "iopub.status.busy": "2026-07-08T06:34:02.783578Z",
-     "iopub.status.idle": "2026-07-08T06:34:02.915414Z",
-     "shell.execute_reply": "2026-07-08T06:34:02.915093Z"
+     "iopub.status.busy": "2026-08-20T18:55:29.941134Z",
+     "iopub.execute_input": "2026-08-20T18:55:29.941134Z",
+     "shell.execute_reply": "2026-08-20T18:55:29.978832Z",
+     "iopub.status.idle": "2026-08-20T18:55:29.979832Z"
     },
     "papermill": {
      "duration": 0.150627,
@@ -1174,32 +815,12 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 2 a completer : |G| 8 -> 8, |S| 1 -> 1\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 2 a completer : |G| 8 -> 8, |S| 1 -> 1\r\n"
     }
    ],
-   "source": [
-    "// EXERCICE 2 : Affinage de la frontiere — retirer les hypotheses redondantes de G et S.\n",
-    "// (Reprend Ser/Deser definies dans les cellules precedentes.)\n",
-    "public void PruneFrontier(HashSet<string> Gset, HashSet<string> Sset) {\n",
-    "    // TODO etudiant : nettoyer G (retirer tout g strictement moins general qu'un autre g') puis S.\n",
-    "    // Indice : IsMoreGeneralThan(g1, g2) == true signifie g1 >= g2.\n",
-    "    //          g est redondante dans G s'il existe g' dans G avec g' > g (strictement plus general).\n",
-    "    // Etape 1 : construire la liste des hypotheses a retirer de G (g tq existe g' != g, g' >= g et !(g >= g')).\n",
-    "    // Etape 2 : retirer de G. Puis operer symetriquement sur S (s redondante s'il existe s' < s strictement).\n",
-    "    // Etape 3 : verifier que |G| et |S| ne font que decroitre (invariant de minimalite).\n",
-    "}\n",
-    "\n",
-    "// Test sur le VS a N_TRAIN=4 (G a 8 elements, certains redondants).\n",
-    "var G_prune = new HashSet<string>(G);\n",
-    "var S_prune = new HashSet<string>(S);\n",
-    "int gBefore = G_prune.Count, sBefore = S_prune.Count;\n",
-    "PruneFrontier(G_prune, S_prune);\n",
-    "Console.WriteLine($\"Exercice 2 a completer : |G| {gBefore} -> {G_prune.Count}, |S| {sBefore} -> {S_prune.Count}\");"
-   ]
+   "source": "// EXERCICE 2 : Affinage de la frontiere — retirer les hypotheses redondantes de G et S.\n// (Reprend Ser/Deser definies dans les cellules precedentes.)\npublic void PruneFrontier(HashSet<string> Gset, HashSet<string> Sset) {\n    // TODO etudiant : nettoyer G (retirer tout g strictement moins general qu'un autre g') puis S.\n    // Indice : IsMoreGeneralThan(g1, g2) == true signifie g1 >= g2.\n    //          g est redondante dans G s'il existe g' dans G avec g' > g (strictement plus general).\n    // Etape 1 : construire la liste des hypotheses a retirer de G (g tq existe g' != g, g' >= g et !(g >= g')).\n    // Etape 2 : retirer de G. Puis operer symetriquement sur S (s redondante s'il existe s' < s strictement).\n    // Etape 3 : verifier que |G| et |S| ne font que decroitre (invariant de minimalite).\n}\n\n// Test sur le VS a N_TRAIN=4 (G a 8 elements, certains redondants).\nvar G_prune = new HashSet<string>(G);\nvar S_prune = new HashSet<string>(S);\nint gBefore = G_prune.Count, sBefore = S_prune.Count;\nPruneFrontier(G_prune, S_prune);\nConsole.WriteLine($\"Exercice 2 a completer : |G| {gBefore} -> {G_prune.Count}, |S| {sBefore} -> {S_prune.Count}\");"
   },
   {
    "cell_type": "markdown",
@@ -1239,14 +860,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "id": "fa9a1d50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-07-08T06:34:02.949092Z",
-     "iopub.status.busy": "2026-07-08T06:34:02.948772Z",
-     "iopub.status.idle": "2026-07-08T06:34:03.009437Z",
-     "shell.execute_reply": "2026-07-08T06:34:03.009175Z"
+     "iopub.status.busy": "2026-08-20T18:55:29.980832Z",
+     "iopub.execute_input": "2026-08-20T18:55:29.981832Z",
+     "shell.execute_reply": "2026-08-20T18:55:30.007600Z",
+     "iopub.status.idle": "2026-08-20T18:55:30.008606Z"
     },
     "papermill": {
      "duration": 0.069885,
@@ -1259,34 +880,12 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice 3 a completer : vote VS pour exemple 5 (label reel Yes) = (a completer)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice 3 a completer : vote VS pour exemple 5 (label reel Yes) = (a completer)\r\n"
     }
    ],
-   "source": [
-    "// EXERCICE 3 : Prediction par vote majoritaire sur le Version Space complet.\n",
-    "// Contrairement a la cellule 13 (§6) qui n'utilise que les frontieres S et G,\n",
-    "// on enumere ici les hypotheses h du VS (s <= h <= g) et on fait voter chacune.\n",
-    "public string PredictByMajorityVote(HashSet<string> Gset, HashSet<string> Sset,\n",
-    "                                    Dictionary<string,string> ex) {\n",
-    "    // TODO etudiant : enumerer/echantillonner les hypotheses du VS et voter pour ex.\n",
-    "    // Indice : une hypothese h du VS verifie : pour tout s dans S, IsMoreGeneralThan(h, s) ;\n",
-    "    //          et pour tout g dans G, IsMoreGeneralThan(g, h).\n",
-    "    // Etape 1 : generer des candidats h (relacher des contraintes de s, bornees par g).\n",
-    "    // Etape 2 : compter voteYes = #{h : Covers(h, ex)}, voteNo = #{h : !Covers(h, ex)}.\n",
-    "    // Etape 3 : retourner \"Yes\" si voteYes >= voteNo, sinon \"No\".\n",
-    "    // (Etape 4 si grand : echantillonner <=200 hypotheses au lieu d'enumerer exhaustivement.)\n",
-    "    return null;  // TODO etudiant\n",
-    "}\n",
-    "\n",
-    "// Test sur un exemple du test set (ex. exemple 5, label reel Yes).\n",
-    "var ex5 = EXAMPLES[5];\n",
-    "string vote5 = PredictByMajorityVote(G, S, ex5);\n",
-    "Console.WriteLine($\"Exercice 3 a completer : vote VS pour exemple 5 (label reel {ex5[\"WillWait\"]}) = {vote5 ?? \"(a completer)\"}\");"
-   ]
+   "source": "// EXERCICE 3 : Prediction par vote majoritaire sur le Version Space complet.\n// Contrairement a la cellule 13 (§6) qui n'utilise que les frontieres S et G,\n// on enumere ici les hypotheses h du VS (s <= h <= g) et on fait voter chacune.\npublic string PredictByMajorityVote(HashSet<string> Gset, HashSet<string> Sset,\n                                    Dictionary<string,string> ex) {\n    // TODO etudiant : enumerer/echantillonner les hypotheses du VS et voter pour ex.\n    // Indice : une hypothese h du VS verifie : pour tout s dans S, IsMoreGeneralThan(h, s) ;\n    //          et pour tout g dans G, IsMoreGeneralThan(g, h).\n    // Etape 1 : generer des candidats h (relacher des contraintes de s, bornees par g).\n    // Etape 2 : compter voteYes = #{h : Covers(h, ex)}, voteNo = #{h : !Covers(h, ex)}.\n    // Etape 3 : retourner \"Yes\" si voteYes >= voteNo, sinon \"No\".\n    // (Etape 4 si grand : echantillonner <=200 hypotheses au lieu d'enumerer exhaustivement.)\n    return null;  // TODO etudiant\n}\n\n// Test sur un exemple du test set (ex. exemple 5, label reel Yes).\nvar ex5 = EXAMPLES[5];\nstring vote5 = PredictByMajorityVote(G, S, ex5);\nConsole.WriteLine($\"Exercice 3 a completer : vote VS pour exemple 5 (label reel {ex5[\"WillWait\"]}) = {vote5 ?? \"(a completer)\"}\");"
   },
   {
    "cell_type": "markdown",
@@ -1347,11 +946,11 @@
    "name": ".net-csharp"
   },
   "language_info": {
-   "file_extension": ".cs",
-   "mimetype": "text/x-csharp",
    "name": "C#",
-   "pygments_lexer": "csharp",
-   "version": "13.0"
+   "version": "13.0",
+   "mimetype": "text/x-csharp",
+   "file_extension": ".cs",
+   "pygments_lexer": "csharp"
   },
   "papermill": {
    "default_parameters": {},

--- a/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
@@ -951,18 +951,6 @@
    "mimetype": "text/x-csharp",
    "file_extension": ".cs",
    "pygments_lexer": "csharp"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 14.959411,
-   "end_time": "2026-07-08T06:34:03.552156+00:00",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "SL-1-LogicalLearning-Csharp.ipynb",
-   "output_path": "SL-1-LogicalLearning-Csharp.ipynb",
-   "parameters": {},
-   "start_time": "2026-07-08T06:33:48.592745+00:00",
-   "version": "2.7.0"
   }
  },
  "nbformat": 4,

--- a/scripts/notebook_tools/twin_pairs.d/sl-1-logicallearning.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sl-1-logicallearning.yaml
@@ -2,7 +2,7 @@
   family: SymbolicAI/SymbolicLearning
   python: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning.ipynb
   csharp: MyIA.AI.Notebooks/SymbolicAI/SymbolicLearning/SL-1-LogicalLearning-Csharp.ipynb
-  parity_level: semantic
+  parity_level: native-both
   audits:
     - date: "2026-08-01"
       by: myia-po-2023:CoursIA
@@ -14,10 +14,16 @@
       csharp_sha: 8013c9d785020bb014f29f74e4cf64e4a413f595
       content_python_sha: d041e06781b2ed2e041cfcca3786d08777a4a503fbfb12283e79eb0b6841e0ca
       content_csharp_sha: 152ac61c16a03acd5a6729fbbb165e870cfbef28e5ced2d1b4931f87bf3ead79
-  bridge_verdict: RECOVERABLE-LOCAL
-  bridge_verdict_reason: "Python = `aima-python` (AIMA reference implementation, MIT, Russell/Norvig) pour CBH/Candidate Elimination/Version Space sur domaine restaurant + matplotlib pour la visualisation graphique de l'evolution du Version Space ; le coeur pedagogique est code from-scratch (pas de lib ILP tierce). C# = BCL .NET from-scratch (`Dictionary` + `HashSet` + `List<T>`) pour CBH + Candidate Elimination + 10 sections textuelles, sans visualisation graphique. Verdict RECOVERABLE-LOCAL : le coeur pedagogique (CBH = Current-Best-Hypothesis, Candidate Elimination, Version Space sur domaine AIMA restaurant) est PARITABLE des deux cotes (memes algorithmes, meme domaine), l'asymetrie reside dans la portee pedagogique (Python = version de reference complete + visualisation + comparaison aima-python ; C# = tranche focalisee sur les 2 algorithmes). Le socle BCL C# preserve comme choix pedagogique assume (ILP foundations = construire les algorithmes d'apprentissage a la main avant d'utiliser une lib). `parity_level: semantic` preserve : parite sur les concepts cibles malgre l'asymetrie de portee."
+    - date: "2026-08-20"
+      by: myia-po-2026:CoursIA
+      python_sha: c0395f1f0ee82f67cc1827cb9c0323f4def48635
+      csharp_sha: dda5fd3102a097a455af919218a7038472ace4fc
+      content_python_sha: d041e06781b2ed2e041cfcca3786d08777a4a503fbfb12283e79eb0b6841e0ca
+      content_csharp_sha: 8e1eae85db55d6d5bc392ea4a4216c045adaf45a6ae9a09667fe2090b06536a0
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Python = BCL from-scratch pour CBH/Candidate Elimination/Version Space sur domaine restaurant + section 9 confrontant le CBH a l'implementation de reference aima-python (`reference/aima_knowledge.py`, knowledge.py Fig 19.2, MIT, Russell/Norvig). C# = BCL .NET from-scratch (`Dictionary` + `HashSet` + `List<T>`) pour CBH + Candidate Elimination. NB : l'ancienne raison invoquait matplotlib cote Python -- verification firsthand (tranche 2026-08-20) : AUCUN matplotlib dans le jumeau Python, la vraie asymetrie etait la section 9 aima-python. Verdict initial RECOVERABLE-LOCAL (2026-08-01) REVOQUE par la tranche sl-1 (epic #10382, 2026-08-20) : le jumeau C# branche le pendant exact de la section 9 Python -- un pont **PythonNet** (.NET -> CPython, pythonnet 3.0.5 NuGet) invoque le MEME module vendore `reference/aima_knowledge.py`, meme graine (42), meme hypothese initiale (premier exemple positif), memes 12 exemples convertis au format GOAL (section 6bis) : les 5 disjonctions D1-D5 sont byte-identiques a la sortie de la section 9 du jumeau Python, accuracy 12/12 des deux cotes. Le pont est un plus, jamais un remplacement : les sections 4-6 gardent le CBH et le Candidate Elimination codes a la main (sujet du notebook) ; la reference externe joue le role d'arbitre, exactement comme la section 9 Python. Axes binding #10459 : PythonNet = le canal (pythonnet 3.0.5, pas de reimplementation), NuGet = canal du package pythonnet lui-meme, P/Invoke N/A, CLI N/A, IKVM N/A. `parity_level: native-both` : les deux jumeaux referencent le meme moteur de reference (aima_knowledge : import direct cote Python, pont PythonNet cote C#) autour du from-scratch conserve."
   known_differences:
     - "Socle commun : apprentissage logique symbolique -- Current-Best-Hypothesis (CBH) et Version Space / Candidate Elimination, sur le domaine restaurant (AIMA)."
-    - "Asymetrie de couverture : le jumeau Python (58 cellules, 18 code) couvre 9 sections incluant visualisation de l'evolution du Version Space et une section 'implementation de reference : aima-python' ; le jumeau C# (21 cellules, 9 code) est plus compact (10 sections, pas de visualisation graphique)."
-    - "Implementation : les deux cotes codent CBH et Candidate Elimination from-scratch (pas de librairie ILP tierce) -- c'est le coeur pedagogique. Sortie textuelle C# vs matplotlib/aima-python cote Python."
-    - "Le jumeau Python est la version de reference complete (avec comparaison a l'implementation aima-python) ; le C# est la tranche pedagogique focalisee sur les 2 algorithmes."
+    - "Asymetrie de couverture : le jumeau Python (58 cellules, 18 code) couvre 9 sections incluant l'evolution du Version Space, le rasoir d'Occam/MDL et un echantillonnage multi-graines ; le jumeau C# (23 cellules, 10 code) est plus compact (10 sections + section 6bis de reference)."
+    - "Implementation : les deux cotes codent CBH et Candidate Elimination from-scratch (pas de librairie ILP tierce) -- c'est le coeur pedagogique. Sortie textuelle des deux cotes."
+    - "Reference aima-python : les DEUX jumeaux confrontent leur from-scratch au module vendore reference/aima_knowledge.py (graine 42, premier positif comme hypothese initiale, 5 disjonctions identiques, 12/12) -- import direct section 9 cote Python, pont PythonNet section 6bis cote C# (depuis 2026-08-20)."


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet -- lane myia-po-2026:CoursIA

Quoi: #10382 tranche sl-1 — flip RECOVERABLE-LOCAL -> SOTA-OK : pont PythonNet (.NET -> CPython) vers le module de reference vendore aima_knowledge.py, pendant exact de la section 9 du jumeau Python
Preuve: re-exec complete kernel frais EXEC_COUNTS [1..10] ERRORS none ; sortie pont D1-D5 byte-identiques a la section 9 Python, 5 disjonctions, accuracy 12/12 ; check_exec_sequence CLEAN (0 DUPLICATE/UNORDERED/NOT_FROM_1/GAP) ; check_exec_ratchet origin/main CLEAN->CLEAN 0 regression ; check_papermill_ratchet BLOCK_REMOVED (sanctionne) 0 regression ; check_twin_parity 157/157 OK ; leak-scan outputs 0 hit ; strip_probe_banner applique
Perimetre: SL-1-LogicalLearning-Csharp.ipynb (section 6bis : 2 cellules ajoutees + re-exec complete, 21 -> 23 cellules) + twin_pairs.d/sl-1-logicallearning.yaml (verdict + rebaseline atteste)

## Summary

Tranche du rollout #10382 (re-adjudication firsthand des verdicts du registre
de parite). L'entree sl-1 disait RECOVERABLE-LOCAL avec une raison invoquant
matplotlib cote Python — verification firsthand : **aucun matplotlib** dans le
jumeau Python ; la vraie asymetrie etait la section 9 (confrontation du CBH
from-scratch a l'implementation de reference aima-python).

### Ce que fait cette PR

1. **Section 6bis** (2 cellules) dans le jumeau C# : un pont **PythonNet**
   (pythonnet 3.0.5 NuGet, Runtime.PythonDLL -> CPython 3.11) invoque le MEME
   module vendore `reference/aima_knowledge.py` que la section 9 du jumeau
   Python — meme graine (42, la recherche de la reference est stochastique),
   meme hypothese initiale (premier exemple positif), memes 12 exemples
   convertis au format GOAL. Le pont est un **plus, jamais un remplacement** :
   les sections 4-6 gardent le CBH et le Candidate Elimination codes a la main
   (sujet du notebook) ; la reference externe joue le role d'arbitre,
   exactement comme cote Python.
2. **Re-exec complete kernel frais** (dotnet-csharp-run, nbclient,
   DOTNET_ROLL_FORWARD=Major, PYTHONNET_PYDLL -> Python311) : EXEC_COUNTS
   [1..10], 0 erreur, sequence CLEAN. De-churn : 12 cellules restaurees
   verbatim vs origin/main, 9 reellement mises a jour, 2 nouvelles.
3. **Flip du registre** `sl-1-logicallearning.yaml` : `bridge_verdict:
   SOTA-OK`, `parity_level: native-both` (les deux jumeaux referencent le meme
   moteur de reference autour du from-scratch conserve), raison matplotlib
   corrigee, `known_differences` mis a jour, rebaseline atteste EN DERNIER
   (apres strip_probe_banner + retrait du bloc papermill stale).

### Verifications

- Miroir Python prouve : les 5 disjonctions D1-D5 du pont C# sont
  **byte-identiques** aux outputs committes de la section 9 du jumeau Python
  (graine 42, Mersenne Twister deterministe cross-CPython), accuracy 12/12 des
  deux cotes.
- Erreur de compilation du round 2 diagnostiquee au stderr du kernel
  (`CS0029 bool -> string` : `ToDictionary` inferait `Dictionary<string,string>`)
  et corrigee par cast `(object)` — dress rehearsal sur mini-pont avant le
  round 3.
- `PythonEngine.Shutdown()` retire : BinaryFormatter supprime de .NET 9 ->
  PlatformNotSupportedException dans RuntimeData.Stash() ; convention du repo
  (GT-13 cell23) : initialiser sans shutdown.
- Leak-scan des outputs (Users/jsboi/miniconda/C:\dev/CoursIA-*/probeAddresses) :
  0 hit ; banner probeAddresses stripp via `strip_probe_banner.py --apply`.
- `metadata.papermill` stale retire (le bloc decrivait le run papermill de
  juillet, pas le run nbclient commite) : `check_papermill_ratchet` BLOCK_REMOVED,
  transition explicitement sanctionnee, 0 regression.
- Anti-regression : 0 cellule source supprimee (verifie par multiset des
  sources vs origin/main ; le notebook passe de 21 a 23 cellules).
- Registre : `check_twin_parity.py --pair "SL-1 LogicalLearning"` OK,
  157/157 paires OK au passage.

### Axes binding #10459

PythonNet = le canal (pythonnet 3.0.5, pas de reimplementation) ; NuGet = canal
du package pythonnet lui-meme ; P/Invoke N/A ; CLI N/A ; IKVM N/A.

See #10382 (tranche du rollout twin-parity bucket 3, pas de close)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
