### PR TITLE
fix(guard,#11998): blocs fenced normalises en mots — conversion ASCII->Mermaid != troncature

### DIFF
--- a/scripts/notebook_tools/detect_md_content_loss.py
+++ b/scripts/notebook_tools/detect_md_content_loss.py
@@ -305,7 +305,21 @@ def _normalize(md_text: str) -> str:
     #    qu'un titre legitiment demote en callout soit compte comme "nouveau"
     #    contenu par rapport au titre original.
     t = re.sub(r"^[ \t]*>\s*\*\*[^*\n]*:\*\*\s*$", "", t, flags=re.M)
-    # 3. Espaces : on compare le volume de PROSE, pas la mise en forme.
+    # 3. Contenu des blocs fenced (code/mermaid) : on ne retient que les
+    #    caracteres de MOTS (lettres/chiffres/accents). Le remplacement d'un
+    #    bloc ASCII par un bloc Mermaid equivalent (#11962/#3801) conserve
+    #    chaque label mais debarrasse le padding box-drawing (`+---+`, `->`,
+    #    espaces d'alignement) -- le volume BRUT chute mecaniquement sous le
+    #    seuil alors que l'information est intacte (mesure sur PR #11998 :
+    #    ratio 0.656 sur une conversion sans perte). Symetriquement, une
+    #    VRAIE troncature de bloc fenced (labels effaces) reste detectee :
+    #    ce sont les mots qui portent l'information, pas l'art ASCII.
+    #    Meme slot design que l'exception frontmatter-cost (#8904/#8919) :
+    #    distinguer la transformation legitime de la troncature reelle.
+    def _fence_words(content: str) -> str:
+        return re.sub(r"[^0-9A-Za-zÀ-ÿ_]+", "", content)
+    t = re.sub(r"(```[^\n`]*\n)(.*?)(```)", lambda m: m.group(1) + _fence_words(m.group(2)) + m.group(3), t, flags=re.DOTALL)
+    # 4. Espaces : on compare le volume de PROSE, pas la mise en forme.
     t = re.sub(r"\s+", "", t)
     return t
 

--- a/scripts/notebook_tools/tests/test_detect_md_content_loss.py
+++ b/scripts/notebook_tools/tests/test_detect_md_content_loss.py
@@ -703,3 +703,96 @@ class TestFrontmatterCostReviewFixes:
         head = _nb(_md(body))  # aucun metadata.cost
         r = self._scan(tmp_path, base, head)
         assert any(f["kind"] == "FRONTMATTER_COST_DIVERGENCE" for f in r["findings"])
+
+
+# ---------------------------------------------------------------------------
+# Fenced-block remplacement (vocabulaire #11998 : ASCII -> Mermaid, EPIC
+# #11962 / Prong-A #3801). Un bloc fenced remplace par un bloc fenced
+# equivalent conserve les MOTS (labels) mais debarrasse le padding
+# box-drawing : le volume BRUT chute mecaniquement sous le seuil alors que
+# l'information est intacte. La normalisation ne retient des blocs fenced
+# que leurs caracteres de mots (meme slot design que #8904/#8919).
+# ---------------------------------------------------------------------------
+ASCII_FLOWCHART = (
+    "### Architecture du pipeline\n\n"
+    "```\n"
+    "    +------------------+\n"
+    "    | Universe Filter  |     Coarse: Vol > $10M, Price > $10\n"
+    "    | (Coarse + Fine)  | --> Fine: Market Cap > $5B\n"
+    "    +--------+---------+     -> 30 stocks\n"
+    "             |\n"
+    "             v\n"
+    "    +------------------+\n"
+    "    |  Alpha Model     |     Momentum 60 jours\n"
+    "    | (Momentum)       | --> Direction, Magnitude, Confidence\n"
+    "    +--------+---------+     -> Insights\n"
+    "             |\n"
+    "             v\n"
+    "    +------------------+\n"
+    "    | Risk Management  |     Max DD 5%, Max Sector 25%\n"
+    "    | (Composite)      | --> Ajuste les targets\n"
+    "    +------------------+     -> Targets ajustes\n"
+    "```\n"
+)
+
+MERMAID_FLOWCHART = (
+    "### Architecture du pipeline\n\n"
+    "```mermaid\n"
+    'flowchart TD\n'
+    '    UF["Universe Filter (Coarse + Fine)<br/>Coarse: Vol > $10M, Price > $10<br/>Fine: Market Cap > $5B -> 30 stocks"] --> AM["Alpha Model (Momentum)<br/>Momentum 60 jours -> Direction, Magnitude, Confidence"]\n'
+    '    AM --> RM["Risk Management (Composite)<br/>Max DD 5%, Max Sector 25% -> Targets ajustes"]\n'
+    "```\n"
+)
+
+# Forme reelle mesuree sur PR #11998 QC-Py-14 cell 80 (ratio brut 0.656 < 0.75).
+class TestFencedBlockReplacement:
+    def test_ascii_to_mermaid_no_signal(self):
+        # La conversion EPIC #11962 : labels conserves, padding ASCII debarrasse.
+        base = _nb(_md(ASCII_FLOWCHART))
+        head = _nb(_md(MERMAID_FLOWCHART))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert findings == []
+
+    def test_mermaid_to_ascii_no_signal(self):
+        # Symetrie : la conversion inverse ne doit pas signaler non plus.
+        base = _nb(_md(MERMAID_FLOWCHART))
+        head = _nb(_md(ASCII_FLOWCHART))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert findings == []
+
+    def test_fenced_labels_deleted_still_signals(self):
+        # Controle positif : un bloc fenced dont les LABELS sont effaces
+        # (padding seul reste) est une vraie troncature -> signal conserve.
+        gutted = (
+            "### Architecture du pipeline\n\n"
+            "```\n"
+            "+--------+\n"
+            "|        | -->\n"
+            "+--------+\n"
+            "```\n"
+        )
+        base = _nb(_md(ASCII_FLOWCHART))
+        head = _nb(_md(gutted))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert len(findings) == 1 and findings[0]["kind"] == "TRUNCATED_CELL"
+        assert findings[0]["ratio"] < dml.DROP_THRESHOLD
+
+    def test_prose_truncated_beside_intact_fence_still_signals(self):
+        # Prose tronquee autour d'un bloc fenced intact : le signal reste
+        # (la normalisation fenced ne desarme pas la detection de prose).
+        before = (
+            "## Objectif\n\n" + ("Contenu pedagogique substantiel autour du schema. " * 12)
+            + "\n\n" + ASCII_FLOWCHART
+        )
+        after = "## Objectif\n\nCourt.\n\n" + ASCII_FLOWCHART
+        base = _nb(_md(before))
+        head = _nb(_md(after))
+        findings = dml._compare_cells(dml.extract_md_cells(base), dml.extract_md_cells(head))
+        assert any(f["kind"] == "TRUNCATED_CELL" for f in findings)
+
+    def test_normalize_keeps_fence_words_drops_padding(self):
+        # Unite : le contenu fenced normalise ne retient que les mots.
+        n = dml._normalize("```\n+---+-->|\n| A | B |\n+---+\n```")
+        # les caracteres box-drawing sont retires, les labels gardes
+        assert "+" not in n and "-" not in n
+        assert "A" in n and "B" in n


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: DEEP/infra-secrets #12000 (rotation ComfyUI-Video)

# fix(guard,#11998): blocs fenced normalisés en contenu-de-mots — une conversion ASCII→Mermaid n'est pas une troncature

Follow-up annoncé dans le triage CI de **PR #11998** (tranche QuantConnect de l'EPIC #11962). PR distincte de celle qu'il débloque : un garde ne se modifie pas dans la PR qu'il juge.

## Le défaut

`detect_md_content_loss.py` mesure le volume d'une cellule en **caractères normalisés bruts, blocs fenced inclus**. Une conversion ASCII→Mermaid (mandat EPIC #11962 / Prong-A #3801) conserve chaque label mais débarrasse le padding box-drawing (`+---+`, `->`, espaces d'alignement) : le volume chute **mécaniquement** sous le seuil 0.75 alors que l'information est intacte. Mesuré sur PR #11998 : QC-Py-14 cell 80, **ratio 0.656** sur une conversion sans perte (chaque seuil, chaque étape, chaque vocabulaire d'origine préservés dans les labels Mermaid).

Même slot design que l'exception frontmatter-cost **#8904/#8919** (« chute mécanique du ratio → faux positif ; on détecte ce cas pour le distinguer d'une troncature réelle »).

## Le fix (normalisation, PAS un rétrécissement de détection)

Dans `_normalize()` : le **contenu** de chaque bloc fenced est réduit à ses caractères de mots (lettres/chiffres/accents/underscore), symétriquement des deux côtés (base et head). Le padding est de la présentation ; les mots sont l'information. La détection de troncature reste intégralement active :

- un bloc fenced dont les **labels** sont effacés (padding seul) → toujours signalé
- une **prose** tronquée à côté d'un bloc intact → toujours signalé
- toutes les classes #8655 (démotion accidentelle) et #8919 (frontmatter cost) → inchangées

## Tests (5 nouveaux + 46 existants = 51 verts)

`test_detect_md_content_loss.py` :

1. **ASCII→Mermaid sans perte** (forme exacte mesurée QC-Py-14 c80) → **aucun signal**
2. Symétrie Mermaid→ASCII → aucun signal
3. **Labels effacés** (padding seul reste) → `TRUNCATED_CELL` conservé
4. Prose tronquée + fenced intact → signal conservé
5. Unité : `_normalize` retire `+`/`-`/`|` du contenu fenced, garde les labels

## Recette repo-wide (OLD vs NEW)

- **12 PRs mergées récentes** touchant des notebooks (re-run base=baseRefOid vs head=mergeCommit, 0 erreur de refs) : findings **OLD=0, NEW=0** — delta nul, aucun faux positif introduit, aucun vrai finding éteint.
- **Contrôle positif** (branche #11998) : les 3 notebooks convertis passent `OLD=[TRUNCATED_CELL] → NEW=[]` — exactement la classe mécanique visée, rien d'autre.

Au merge de cette PR, **PR #11998 reverdit** au prochain run (sa conversion est justifiée en review ET désormais reconnue par le vocabulaire du détecteur).

## Périmètre (2 fichiers, +108/-1)

Périmètre : 2 fichiers — `scripts/notebook_tools/detect_md_content_loss.py` (+13/-1) et `scripts/notebook_tools/tests/test_detect_md_content_loss.py` (+95/-0). Aucune autre modification. PR atomique (1 domaine guard).

See #11998 (débloque), See #11962 (EPIC conversion), See #3801 (Prong-A)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
