### PR TITLE
feat(twin-registry,#10382): search-7 MCTS-And-Beyond — bascule verdict résiduelle RECOVERABLE-LOCAL -> SOTA-OK

### DIFF
--- a/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml
@@ -3,8 +3,8 @@
   python: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond.ipynb
   csharp: MyIA.AI.Notebooks/Search/Part1-Foundations/Search-7-MCTS-And-Beyond-Csharp.ipynb
   parity_level: native-both
-  bridge_verdict: RECOVERABLE-LOCAL
-  bridge_verdict_reason: "pyspiel 2.0.1 natif Windows + pythonnet 3.0.5 bridge .NET 10 -> CPython 3.11.9 -> pyspiel (DLL designee par PYTHONNET_PYDLL, pas de chemin hardcode). Les DEUX jumeaux invoquent reellement OpenSpiel/MCTSBot(seed=42, 1000 sim, c=sqrt(2)) sur tic_tac_toe et obtiennent l'action 4 (cross-twin proof)."
+  bridge_verdict: SOTA-OK
+  bridge_verdict_reason: "Les DEUX jumeaux invoquent reellement OpenSpiel/MCTSBot(seed=42, 1000 sim, c=sqrt(2)) sur tic_tac_toe et obtiennent l'action 4 (cross-twin proof) : Python en direct (pyspiel 2.0.1 natif Windows, cellule 16, `pyspiel.load_game('tic_tac_toe')` + `mcts.MCTSBot`) ; C# via bridge pythonnet 3.0.5 (.NET -> CPython -> pyspiel, `Runtime.PythonDLL` designee par `PYTHONNET_PYDLL`, cellule pont executee, outputs reels `action = 4`, 0 erreur, sequence [1..17]). Verdict SOTA-OK (bascule registre #10382, 2026-08-20, lane myia-po-2026:CoursIA) : le pont est LIVRE et EXECUTE dans le notebook committe -- le verdict RECOVERABLE-LOCAL historique decrivait l'etat d'avant-livraison (reclassification #10459, tranche po-2026:CoursIA-2) et n'avait pas ete rebascule. Meme cas de figure que GT-7 (2026-08-16) et app-15 (2026-08-18). `parity_level: native-both` deja basculee par la reclassification (les DEUX jumeaux invoquent le meme moteur pyspiel, Python en direct, C# via bridge)."
   audits:
     - date: "2026-08-01"
       by: myia-po-2024:CoursIA-2


### PR DESCRIPTION
Grain: MED/tooling -- lane myia-po-2026:CoursIA

Quoi: #10382 tranche search-7 — bascule verdict residuelle RECOVERABLE-LOCAL -> SOTA-OK : le pont pyspiel/pythonnet etait LIVRE et EXECUTE depuis la reclassification #10459 mais bridge_verdict n'avait jamais ete rebascule
Preuve: adjudication firsthand des DEUX notebooks committes — C# : cellule pont pythonnet (outputs reels "MCTSBot (seed=42, 1000 sim, c=sqrt(2)) : action = 4", 0 erreur, EXEC_COUNTS [1..17]) ; Python : cellule 16 "Action MCTS (OpenSpiel, seed=42, 1000 sim, c=sqrt(2)): 4" — cross-twin proof ; check_twin_parity 157/157 OK ; --update refuse en no-op (#9399 : les SHAs attestes par l'audit de la reclassification #10459 sont deja ceux de HEAD, aucun notebook touche, diff = 2 lignes de registre)
Perimetre: scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml (1 fichier, bridge_verdict + reason ; parity_level native-both deja en place ; aucun notebook modifie)

## Summary

Tranche du rollout #10382 (re-adjudication firsthand des verdicts du registre
de parite). Le cas search-7 est une **bascule residuelle** : la
reclassification #10459 (tranche lane soeur po-2026:CoursIA-2) avait livre le
pont dans les DEUX notebooks et bascule `parity_level -> native-both`, mais
`bridge_verdict` etait reste `RECOVERABLE-LOCAL` — un verdict qui decrivait
l'etat d'AVANT-livraison et contredisait son propre `bridge_verdict_reason`
(qui documente le pont execute et la cross-twin proof).

### Preuves firsthand (notebooks committes, aucun changement requiert)

- **C#** (`Search-7-MCTS-And-Beyond-Csharp.ipynb`) : cellule pont
  `#r "nuget: pythonnet..."` executee (ec, outputs reels
  `MCTSBot (seed=42, 1000 sim, c=sqrt(2)) : action = 4 (centre, strategie
  Morpion optimale)`, `Bridge .NET -> CPython -> pyspiel 2.0.1 -> MCTSBot :
  OK`), 0 output d'erreur, sequence d'execution [1..17] monotone propre.
- **Python** (`Search-7-MCTS-And-Beyond.ipynb`) : cellule 16
  `Action MCTS (OpenSpiel, seed=42, 1000 sim, c=sqrt(2)): 4` — la meme
  action 4 que le C# : cross-twin proof.
- `known_differences` documentait deja toute la reclassification (livraison
  des deux ponts, justification cellule par cellule).

### Pourquoi --update n'a pas ecrit d'entree d'audit

`check_twin_parity.py --update --pair` REFUSE en no-op (#9399) : les SHAs
attestes par l'audit de la reclassification sont deja ceux de HEAD — aucun
notebook n'a bouge, une nouvelle entree aux SHAs identiques serait un faux
audit. La bascule vit dans `bridge_verdict` + `bridge_verdict_reason`
(datee et signee lane).

### Precedents de la meme famille de bascule

GT-7 (2026-08-16, "pont execute dans le notebook committe, verdict non
rebasculé") et app-15 (2026-08-18, arbitrage #11200 Option A).

### Verifications

- `check_twin_parity.py` : 157/157 paires OK, 0 DRIFT, 0 MISSING.
- Diff : 1 fichier, 2 insertions / 2 deletions (registre seul, catalog
  byte-identique, aucun notebook, aucun script).
- Aucune cellule modifiee -> pas de re-exec requise (C.2/C.3 intacts).

See #10382 (tranche du rollout twin-parity, pas de close)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
