### PR TITLE
feat(qc,#11601): densite QC-Py-15 round 2 (1415 -> 1575 chars/cell)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-15-Parameter-Optimization.ipynb
@@ -176,7 +176,7 @@
     "tags": []
    },
    "source": [
-    "On définit ici l'espace des paramètres à explorer lors de l'optimisation de la stratégie algorithmique."
+    "On définit ici l'espace des paramètres à explorer lors de l'optimisation : chaque dimension (période de la moyenne rapide, période de la moyenne lente, stop-loss, take-profit) délimite ce que le moteur d'optimisation aura le droit de choisir. Cet espace est déjà une décision de modélisation : le fixer, c'est décider à l'avance quelles stratégies sont concevables et lesquelles sont hors de propos. Un espace trop large multiplie les combinaisons à tester — chaque test supplémentaire accroît le coût de calcul ET la surface d'overfitting ; un espace trop étroit rabat l'optimum sur son bord, exactement le symptôme que la partie 3 fera apparaître (un take-profit collé à sa valeur maximale). La lecture qui compte ici n'est donc pas « quels paramètres ? » mais « quelle est la forme de l'espace où l'histoire élira les paramètres ? »."
    ]
   },
   {
@@ -1121,7 +1121,7 @@
     "tags": []
    },
    "source": [
-    "On configure le moteur d'optimisation en choisissant la méthode de recherche (grille, aléatoire ou bayésienne)."
+    "On configure le moteur d'optimisation en choisissant la méthode de recherche — grille exhaustive, échantillonnage aléatoire ou optimisation bayésienne — puis la fonction de fitness qui notera chaque combinaison. La méthode de recherche décide de l'exploration (comment l'espace est parcouru) ; la fitness décide du but (ce qui est maximisé). C'est le second choix qui porte le sens : une fitness qui ne maximise que le retour récompense le risque pur, une fitness qui intègre le drawdown ou le Sharpe corrige la lecture. La règle de discipline : définir la fonction d'objectif AVANT de voir les résultats, jamais après — sinon l'optimisation devient une justification à rebours."
    ]
   },
   {
@@ -1449,7 +1449,7 @@
     "tags": []
    },
    "source": [
-    "On lance l'optimisation des paramètres et on collecte les résultats pour chaque combinaison testée."
+    "On lance l'optimisation des paramètres et on collecte les résultats pour chaque combinaison testée. La grille exhaustive est la méthode la plus transparente : fixer les valeurs sur chaque dimension, tester le produit cartésien complet, trier par fitness. La partie 3 en exécutera 672 combinaisons — c'est le prix à payer pour être rigoureusement complet. La conséquence mathématique à garder en tête : plus la grille est dense, plus le meilleur score trouve des paramètres qui épousent les particularités du passé ; la grille est un instrument de mesure, pas une machine à fabriquer des certitudes."
    ]
   },
   {
@@ -2107,7 +2107,9 @@
     "tags": []
    },
    "source": [
-    "### 4.2 Implementation Walk-Forward (15 min)"
+    "### 4.2 Implementation Walk-Forward (15 min)\n",
+    "\n",
+    "La walk-forward découpe l'historique en fenêtres : on optimise sur une fenêtre d'entraînement, on valide sur la suivante, puis on déroule le protocole le long du temps. Chaque fold rejoue la même séquence de décisions sur un horizon glissant, ce qui produit des répétitions indépendantes de la robustesse au lieu d'une mesure unique — et c'est de là que vient l'information, pas d'un score isolé."
    ]
   },
   {
@@ -2202,7 +2204,7 @@
     "tags": []
    },
    "source": [
-    "On agrège les résultats d'optimisation pour identifier les combinaisons de paramètres les plus performantes."
+    "On agrège les résultats d'optimisation de chaque fold pour identifier les combinaisons de paramètres les plus performantes de façon répétée — pas seulement une fois. La différence avec la partie 3 est décisive : le grid search rend un classement unique calculé sur tout le passé, la walk-forward rend un tableau de classements, un par fenêtre. Une combinaison peut gagner une fenêtre par chance et perdre les quinze autres ; celle qui apparaît près du sommet de plusieurs fenêtres différentes est plus digne de confiance, parce que sa performance ne dépend pas du découpage temporel précis. La lecture du tableau agrégé se fait donc en répétitions (fréquence d'apparition dans le haut du classement), pas en ligne unique."
    ]
   },
   {
@@ -3133,7 +3135,7 @@
     "tags": []
    },
    "source": [
-    "On visualise la surface de performance en fonction des paramètres pour détecter les zones optimales."
+    "On visualise la surface de performance en fonction des paramètres pour détecter les zones optimales. La forme de cette surface est l'information la plus précieuse de tout le notebook : un optimum n'est pas seulement une position, c'est un relief. Un pic aigu signifie qu'un léger changement des paramètres effondre la performance — c'est un point fragile, choisi par le bruit. Un plateau signifie que de nombreuses combinaisons voisines donnent la même performance raisonnable : n'importe laquelle est robuste. La technique 2 qui suit formalise ce test de sensibilité : perturber chaque paramètre optimal d'un pas et mesurer la variance du score. Un paramètre dont le score s'effondre à la moindre variation est un paramètre que l'optimisation a appris, pas découvert."
    ]
   },
   {
@@ -3493,7 +3495,7 @@
     "tags": []
    },
    "source": [
-    "On évalue la robustesse des paramètres optimaux en testant leur stabilité sur différentes périodes de marché."
+    "On évalue la robustesse des paramètres optimaux en testant leur stabilité sur différentes périodes de marché. La question n'est pas « cette combinaison est-elle bonne sur l'échantillon qui l'a rendue bonne ? » mais « reste-t-elle raisonnable quand le régime change ? ». Les périodes testées ici font alterner tendance, retour à la moyenne et choc — et la plupart des paramètres ne survivent qu'à un seul régime. La cellule suivante remplace le Sharpe par le Calmar (retour / drawdown maximal) comme fitness : un classement où la robustesse se mesure au creux de la pire période vécue, pas au sommet du meilleur mois."
    ]
   },
   {
@@ -3865,7 +3867,7 @@
     "tags": []
    },
    "source": [
-    "On sélectionne les paramètres finaux en tenant compte du compromis entre performance in-sample et out-of-sample."
+    "On sélectionne les paramètres finaux en tenant compte du compromis entre performance in-sample et out-of-sample. C'est le moment le plus délicat du protocole : le processus de sélection lui-même peut devenir une forme d'optimisation. Deux règles protègent la lecture. D'abord, choisir un critère AVANT d'avoir vu l'OOS (meilleure médiane des folds, plus faible variance, pire cas le moins mauvais) — décider après coup, c'est réintroduire le surapprentissage par la porte du choix. Ensuite, considérer qu'un écart IS/OOS faible et stable vaut un score IS élevé et instable : la robustesse se paie en performance in-sample affichée, et c'est un bon prix."
    ]
   },
   {
@@ -4155,7 +4157,7 @@
     "tags": []
    },
    "source": [
-    "On valide la stratégie optimisée sur un jeu de données de test indépendant pour éviter le surapprentissage."
+    "On valide la stratégie optimisée sur un jeu de données de test indépendant pour éviter le surapprentissage. Ce test final est le gardien du protocole : la fenêtre de test n'a été touchée par aucune décision jusqu'ici — ni configuration de grille, ni choix de fitness, ni sélection des paramètres. C'est ce qui la distingue des folds walk-forward, qui, eux, participent à la sélection. Un même jeu de données, touché par la sélection puis rejoué pour la preuve, ne prouve rien : la validation n'a de valeur que si les données n'ont jamais influencé le choix. La cellule suivante exécute le pipeline complet de bout en bout ; les résultats OOS lus à la sortie sont la seule réponse autorisée à « est-ce que ça marche ? »."
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python -- lane myia-po-2026:CoursIA -- prev: MED/tooling #12002 (twin-registry search-7)

Quoi:       enrichissement markdown de 9 cellules de QC-Py-15 — densité pédagogique 1415 -> 1575 chars/cellule code
Preuve:     python scripts/notebook_tools/pedagogy_density.py --json <nb> : prose 50428 / 32 code cells = 1575 (round-2 cible >= 1500, threshold 1200)
Perimetre:  1 fichier, md-only (blocs "source" de cellules markdown uniquement) ; ni code, ni outputs, ni catalogue, ni README touchés

## Résumé

Tranche round-2 de l'epic densité pédagogique #11601 sur `QC-Py-15-Parameter-Optimization.ipynb`. Les 9 cellules markdown mono-lignes (transitions squelettiques du gabarit) sont remplacées par une prose de transition honnête dans le registre du notebook : ce que la section va faire, quel piège d'optimisation elle illustre, et comment lire la sortie qui arrive. Cellules enrichies : intro espace des paramètres (5), configuration moteur + fitness (22), lancement grid search (27), heading walk-forward + cadrage (42), agrégation des folds (44), surface de performance / relief (63), stabilité inter-régimes + Calmar (71), sélection IS/OOS (78), validation OOS finale (83).

## Mesures first-hand (worktree frais sur origin/main)

```
AVANT  : density 1415 | prose 45290 | 32 code | 60 md | md% 45.3
APRÈS  : density 1575 | prose 50428 | 32 code | 60 md | md% 48.0
```

## Preuve md-only (C.2 : outputs précédents valides)

- `git diff` : 11 insertions / 9 suppressions, toutes des lignes éléments de `"source"` de cellules markdown ; aucun `outputs`, `execution_count` ni `metadata` modifié.
- Notebook sous exception documentée (cell 0 « Note de conception » : cellules code de référence QC Lab non exécutées, `execution_count: null` intentionnel) → aucune re-exécution requise pour un diff markdown-only.
- Exercices 1/2/3 intacts (cells 39/56/68, stubs conservés).
- `notebook_tools.py validate` : OK, 0 warning, 0 error.
- Catalogue byte-identique à main.

See #11601 (contribution partielle à l'epic round-2 ; QC-Py-21 déjà couvert par #12006).

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
