### PR TITLE
feat(gametheory,#11703): GT-6b compagnon lean du 6c — lake game_theory_lean 7 modules noirs -> 0

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-6b-Lean-RepeatedGames.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-6b-Lean-RepeatedGames.ipynb
@@ -1,0 +1,1106 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b4daaeab",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004381,
+     "end_time": "2026-08-20T20:33:55.153268+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.148887+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-6b — Jeux répétés en Lean : le lake `game_theory_lean` dévoilé\n",
+    "\n",
+    "**Compagnon formel de [GameTheory-6c-RepeatedGames-FolkTheorem](GameTheory-6c-RepeatedGames-FolkTheorem.ipynb).**\n",
+    "Le 6c dérive à la main, en Python, l'effondrement par induction arrière, la condition de\n",
+    "crédibilité du grim trigger $\\delta \\geq (T-R)/(T-P)$ et le Folk Theorem. Ce notebook\n",
+    "**6b** montre la contrepartie formelle : le lake\n",
+    "[`game_theory_lean`](game_theory_lean/), dont les modules `RepeatedGames/` (Stage,\n",
+    "Discounting, GrimTrigger, Folk) portent ces résultats **prouvés en Lean 4**, module par\n",
+    "module, fichier réel à l'appui.\n",
+    "\n",
+    "Pourquoi ce compagnon existe : la mesure de visibilité de l'EPIC #11703\n",
+    "(`scripts/lean/scan_lake_notebook_visibility.py`) montrait **7 modules noirs sur 19**\n",
+    "dans `game_theory_lean` — sept fichiers Lean dont *aucune* déclaration n'était citée\n",
+    "par quelque notebook du dépôt que ce soit : `Stage`, `Discounting`, `GrimTrigger`,\n",
+    "`Folk`, `ConeKernel`, `SortedListCounting`, `_SmokeTest`. Un travail formel invisible\n",
+    "est un travail formel que le lecteur ne rencontre jamais : ce notebook les rend\n",
+    "visibles, par extraction directe depuis les fichiers du lake.\n",
+    "\n",
+    "| Module | Rôle | Statut preuve |\n",
+    "|---|---|---|\n",
+    "| `RepeatedGames/Stage.lean` | Le jeu de stage : le Dilemme du Prisonnier paramétré `T, R, P, S` | 0 sorry |\n",
+    "| `RepeatedGames/Discounting.lean` | Sommes géométriques, seuil critique $\\delta^* = (T-R)/(T-P)$ | 0 sorry |\n",
+    "| `RepeatedGames/GrimTrigger.lean` | Le théorème-phare `grim_trigger_sustains_iff` (#4880) | 0 sorry |\n",
+    "| `RepeatedGames/Folk.lean` | Folk Theorem actualisé (Fudenberg-Maskin) | 1 sorry STRETCH assumé |\n",
+    "| `CooperativeGames/ConeKernel.lean` | Noyau cône-fermé pour Bondareva-Farkas (#2959) | 0 sorry |\n",
+    "| `SocialChoice/SortedListCounting.lean` | Helpers de comptage trié pour le median voter | 0 sorry |\n",
+    "| `SocialChoice/_SmokeTest.lean` | Scaffold de smoke test du lake | trivial (1 lemme prouvé) |\n",
+    "\n",
+    "Méthode (pattern des compagnons Lean-15c / Lean-17c) : chaque section **extrait** les\n",
+    "déclarations du fichier réel (parsing léger du source), affiche la première ligne de\n",
+    "docstring — le texte que le lecteur verrait en ouvrant le fichier — et croise avec la\n",
+    "théorie du 6c. Aucune cellule ne « recopie » une preuve : le fichier Lean **est** la\n",
+    "preuve ; ici on apprend où elle vit et ce qu'elle dit.\n",
+    "\n",
+    "**Repère d'orientation** : si vous explorez le disque, le répertoire `repeated_games_lean/` du dossier GameTheory est une **coquille archive** — depuis la PR #6146 (EPIC #4365 Phase-4), les quatre modules sources (`Stage`, `Discounting`, `GrimTrigger`, `Folk`) sont absorbés byte-identique dans `game_theory_lean/RepeatedGames/`, home canonique (`@[default_target]` du lakefile de `game_theory_lean`). C'est ce home canonique que ce notebook lit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f8a86cf9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.165620Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.165386Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.237736Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.237221Z"
+    },
+    "papermill": {
+     "duration": 0.08137,
+     "end_time": "2026-08-20T20:33:55.238561+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.157191+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Lake: MyIA.AI.Notebooks\\GameTheory\\game_theory_lean\n",
+      "  RepeatedGames\\Stage.lean: 7 declarations, 0 sorry (code)\n",
+      "  RepeatedGames\\Discounting.lean: 4 declarations, 0 sorry (code)\n",
+      "  RepeatedGames\\GrimTrigger.lean: 2 declarations, 0 sorry (code)\n",
+      "  RepeatedGames\\Folk.lean: 5 declarations, 1 sorry (code)\n",
+      "  CooperativeGames\\ConeKernel.lean: 16 declarations, 0 sorry (code)\n",
+      "  SocialChoice\\SortedListCounting.lean: 5 declarations, 0 sorry (code)\n",
+      "  SocialChoice\\_SmokeTest.lean: 1 declarations, 0 sorry (code)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import re\n",
+    "from pathlib import Path\n",
+    "\n",
+    "LAKE = Path(\"MyIA.AI.Notebooks/GameTheory/game_theory_lean\")\n",
+    "\n",
+    "# Les 7 modules noirs mesures par scan_lake_notebook_visibility.py (EPIC #11703)\n",
+    "DARK_MODULES = [\n",
+    "    LAKE / \"RepeatedGames/Stage.lean\",\n",
+    "    LAKE / \"RepeatedGames/Discounting.lean\",\n",
+    "    LAKE / \"RepeatedGames/GrimTrigger.lean\",\n",
+    "    LAKE / \"RepeatedGames/Folk.lean\",\n",
+    "    LAKE / \"CooperativeGames/ConeKernel.lean\",\n",
+    "    LAKE / \"SocialChoice/SortedListCounting.lean\",\n",
+    "    LAKE / \"SocialChoice/_SmokeTest.lean\",\n",
+    "]\n",
+    "\n",
+    "DECL_RE = re.compile(\n",
+    "    r\"^(theorem|lemma|def|noncomputable def|structure|inductive|instance)\\s+([A-Za-z_][A-Za-z0-9_']*)\"\n",
+    ")\n",
+    "\n",
+    "def strip_lean_noise(text: str) -> str:\n",
+    "    \"\"\"Retire docstrings /- -/ et commentaires -- pour ne garder que le code.\"\"\"\n",
+    "    text = re.sub(r\"/-.*?-/\", \" \", text, flags=re.S)   # docstrings (non imbriquees)\n",
+    "    text = re.sub(r\"--[^\\n]*\", \" \", text)               # commentaires de ligne\n",
+    "    return text\n",
+    "\n",
+    "def decls_of(path: Path):\n",
+    "    \"\"\"Extrait (kind, name, premiere ligne de docstring) d'un fichier Lean reel.\"\"\"\n",
+    "    lines = path.read_text(encoding=\"utf-8\").splitlines()\n",
+    "    out, in_doc, doc_buf = [], False, []\n",
+    "    for i, ln in enumerate(lines):\n",
+    "        s = ln.strip()\n",
+    "        if s.startswith(\"/-\") and not s.startswith(\"/-!\"):\n",
+    "            in_doc, doc_buf = True, []\n",
+    "            if s.endswith(\"-/\") and len(s) > 2:\n",
+    "                in_doc = False\n",
+    "            continue\n",
+    "        if in_doc:\n",
+    "            if s.endswith(\"-/\"):\n",
+    "                in_doc = False\n",
+    "            elif s and not s.startswith(\"#\") and not s.startswith(\"=\"):\n",
+    "                doc_buf.append(s)\n",
+    "            continue\n",
+    "        m = DECL_RE.match(s)\n",
+    "        if m:\n",
+    "            out.append((m.group(1), m.group(2), doc_buf[0] if doc_buf else \"\"))\n",
+    "            doc_buf = []\n",
+    "    return out\n",
+    "\n",
+    "def code_sorry_count(path: Path) -> int:\n",
+    "    \"\"\"Compte les occurrences de `sorry` sur lignes de CODE (prose retiree).\"\"\"\n",
+    "    return len(re.findall(r\"\\bsorry\\b\", strip_lean_noise(path.read_text(encoding=\"utf-8\"))))\n",
+    "\n",
+    "print(\"Lake:\", LAKE)\n",
+    "for p in DARK_MODULES:\n",
+    "    n = len(decls_of(p))\n",
+    "    print(f\"  {p.relative_to(LAKE)}: {n} declarations, {code_sorry_count(p)} sorry (code)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "149ec537",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003576,
+     "end_time": "2026-08-20T20:33:55.245684+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.242108+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : le lake est réel et mesuré\n",
+    "\n",
+    "Les 7 fichiers existent, portent ensemble une vingtaine de déclarations, et le compte\n",
+    "de `sorry` sur lignes de code (prose retirée) donne déjà le paysage : **0** partout sauf\n",
+    "`Folk.lean` — l'unique `sorry` STRETCH du lake jeux répétés, assumé par l'issue #4880\n",
+    "(« le 0-sorry n'est exigé que sur le théorème-phare »). C'est le même instrument que\n",
+    "`count_code_sorry.py` au principe près : ici, par fichier, pour la lecture pédagogique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db0793f0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003539,
+     "end_time": "2026-08-20T20:33:55.252588+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.249049+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. `Stage.lean` — le jeu de stage : un Dilemme du Prisonnier *forcé par le type*\n",
+    "\n",
+    "Le fichier définit `PDAction` (coopérer / dévier) et la structure `PrisonersDilemma`.\n",
+    "Le geste fort : les quatre inégalités canoniques de Gibbons (1992) — `T > R > P > S`\n",
+    "et `2R > T + S` — sont des **champs de preuve** de la structure. Aucun lemme en aval\n",
+    "n'a besoin d'hypothèse implicite : le PD « bien formé » est un type, pas une\n",
+    "convention. Le 6c posait la matrice en dur ; ici la matrice `stagePayoff` est une\n",
+    "fonction totale sur `PDAction x PDAction`, et `defect_strictly_dominates` **prouve**\n",
+    "que dévier domine strictement — c'est précisément ce qui rend la coopération\n",
+    "irrationnelle en one-shot, et donc non triviale à soutenir dans le jeu répété."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "670b1be1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.263379Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.262744Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.267330Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.266858Z"
+    },
+    "papermill": {
+     "duration": 0.011861,
+     "end_time": "2026-08-20T20:33:55.268284+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.256423+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- RepeatedGames\\Stage.lean (75 lignes) ---\n",
+      "  inductive    PDAction                               \n",
+      "  structure    PrisonersDilemma                       contraintes `T > R > P > S` et `2 * R > T + S` comme champs de preuve,\n",
+      "  def          stagePayoff                            de l'adversaire. Matrice de paiement standard :\n",
+      "  lemma        defect_strictly_dominates              adverse : `T > R` (adversaire coopère) et `P > S` (adversaire dévie).\n",
+      "  lemma        mutual_coop_better_than_mutual_defect  \n",
+      "  lemma        temptation_gt_reward                   \n",
+      "  lemma        punishment_gt_sucker                   \n",
+      "sorry (code): 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = LAKE / \"RepeatedGames/Stage.lean\"\n",
+    "print(f\"--- {p.relative_to(LAKE)} ({len(p.read_text(encoding='utf-8').splitlines())} lignes) ---\")\n",
+    "for kind, name, doc in decls_of(p):\n",
+    "    print(f\"  {kind:12s} {name:38s} {doc[:72]}\")\n",
+    "print(\"sorry (code):\", code_sorry_count(p))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d93b1c2e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003953,
+     "end_time": "2026-08-20T20:33:55.276372+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.272419+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : quatre briques, zéro dette\n",
+    "\n",
+    "`stagePayoff` (la matrice), `PrisonersDilemma` (le PD contraint), puis trois lemmes\n",
+    "qui déplient les champs : `defect_strictly_dominates` (la dominance stricte, le fait\n",
+    "fondateur du one-shot), `mutual_coop_better_than_mutual_defect` (`R > P`), et les deux\n",
+    "inégalités restantes en lecture directe. Tout est prouvé — la domination stricte n'est\n",
+    "pas une intuition, c'est un `cases b` plus les deux champs `hTR` / `hPS`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02bfa3aa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005092,
+     "end_time": "2026-08-20T20:33:55.285571+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.280479+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. `Discounting.lean` — sommes géométriques et seuil critique\n",
+    "\n",
+    "La brique analytique : `geom_sum` (Mathlib `tsum_geometric_of_lt_one`) donne\n",
+    "$\\sum_{n} \\delta^n = (1-\\delta)^{-1}$, d'où les formes closes `coopValue`\n",
+    "$= R/(1-\\delta)$ et `deviateValue` $= T + \\delta P/(1-\\delta)$. Le lemme clé\n",
+    "`coop_ge_deviate_iff` établit l'équivalence **si et seulement si** avec le seuil\n",
+    "$\\delta \\geq (T-R)/(T-P)$ — exactement le $\\delta^* = 0.5$ du 6c pour\n",
+    "$T=3, R=2, P=1, S=0$. La preuve est de l'algèbre réelle pure : `le_div_iff₀`,\n",
+    "`field_simp`, `linarith` — trois tactiques, aucun calcul numérique cité."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cfa6c8fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.297299Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.296931Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.305985Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.304976Z"
+    },
+    "papermill": {
+     "duration": 0.016393,
+     "end_time": "2026-08-20T20:33:55.306927+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.290534+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- RepeatedGames\\Discounting.lean ---\n",
+      "  lemma        geom_sum                               \n",
+      "  noncomputable def coopValue                              \n",
+      "  noncomputable def deviateValue                           \n",
+      "  lemma        coop_ge_deviate_iff                    perpétuelle est au moins aussi bonne que dévier-puis-punir **ssi**\n",
+      "sorry (code): 0\n",
+      "\n",
+      "Seuil theorique delta* = (T-R)/(T-P) = 0.5\n",
+      "  delta=0.40: V_C=  3.33  V_D=  3.67  -> deviation profitable\n",
+      "  delta=0.50: V_C=  4.00  V_D=  4.00  -> cooperation soutenable\n",
+      "  delta=0.60: V_C=  5.00  V_D=  4.50  -> cooperation soutenable\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = LAKE / \"RepeatedGames/Discounting.lean\"\n",
+    "print(f\"--- {p.relative_to(LAKE)} ---\")\n",
+    "for kind, name, doc in decls_of(p):\n",
+    "    print(f\"  {kind:12s} {name:38s} {doc[:72]}\")\n",
+    "print(\"sorry (code):\", code_sorry_count(p))\n",
+    "\n",
+    "# Pont numerique avec le 6c : le seuil sur le PD canonique T=3, R=2, P=1, S=0\n",
+    "T, R, P, S = 3.0, 2.0, 1.0, 0.0\n",
+    "delta_star = (T - R) / (T - P)\n",
+    "print(f\"\\nSeuil theorique delta* = (T-R)/(T-P) = {delta_star}\")\n",
+    "for d in (0.4, delta_star, 0.6):\n",
+    "    coop, dev = R / (1 - d), T + d * P / (1 - d)\n",
+    "    regime = \"cooperation soutenable\" if coop >= dev else \"deviation profitable\"\n",
+    "    print(f\"  delta={d:.2f}: V_C={coop:6.2f}  V_D={dev:6.2f}  -> {regime}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42acd790",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003584,
+     "end_time": "2026-08-20T20:33:55.314329+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.310745+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : le théorème vit déjà dans les nombres du 6c\n",
+    "\n",
+    "Sous le seuil ($\\delta = 0.4$), dévier rapporte plus ; au seuil exactement, égalité ;\n",
+    "au-dessus ($\\delta = 0.6$), la coopération perpétuelle domine. C'est la vérification\n",
+    " numérique du pont `ICT-13` (#4879) : le seuil dérivé à la main dans le 6c et le lemme\n",
+    "`coop_ge_deviate_iff` du lake racontent le même phénomène — l'un en flottants, l'autre\n",
+    "en `iff` prouvé sur les réels de Mathlib."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed46141a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00418,
+     "end_time": "2026-08-20T20:33:55.322343+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.318163+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — tracer la frontière du seuil\n",
+    "\n",
+    "Le lemme `coop_ge_deviate_iff` dit que la frontière est **exactement** la droite\n",
+    "$\\delta^* = (T-R)/(T-P)$. Complétez `frontiere` pour qu'elle retourne, pour chaque\n",
+    "$\\delta$ d'une grille, l'écart $V_C - V_D$ — puis vérifiez numériquement que le\n",
+    "changement de signe arrive bien à $\\delta^*$ pour **plusieurs** PD valides (par\n",
+    "exemple $(T,R,P,S) = (3,2,1,0)$, $(5,3,2,1)$, $(4,3,1,0)$ — vérifiez au passage que\n",
+    "chacun satisfait $T > R > P > S$ et $2R > T+S$).\n",
+    "\n",
+    "*Indice : l'écart $V_C - V_D$ est monotone croissant en $\\delta$ dès que $T > P$ ;\n",
+    "une recherche par dichotomie sur la grille suffit à localiser le zéro à $10^{-6}$\n",
+    "près.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "01868e2a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.333659Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.333107Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.343533Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.342139Z"
+    },
+    "papermill": {
+     "duration": 0.017597,
+     "end_time": "2026-08-20T20:33:55.344247+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.326650+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : frontiere + dichotomie sur 3 PD canoniques\n"
+     ]
+    }
+   ],
+   "source": [
+    "def frontiere(T, R, P, delta):\n",
+    "    \"\"\"Ecart V_C - V_D pour un PD (T, R, P, S) et un facteur d'escompte delta.\n",
+    "\n",
+    "    Etape 1 : former V_C = R / (1 - delta) et V_D = T + delta * P / (1 - delta).\n",
+    "    Etape 2 : retourner V_C - V_D.\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "# TODO etudiant : pour chaque PD de la liste, localiser par dichotomie le zero de\n",
+    "# `frontiere` et verifier qu'il coïncide avec (T - R) / (T - P) a 1e-6 pres.\n",
+    "print(\"Exercice a completer : frontiere + dichotomie sur 3 PD canoniques\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b61b081b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003914,
+     "end_time": "2026-08-20T20:33:55.352274+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.348360+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. `GrimTrigger.lean` — le théorème-phare, 0 sorry (#4880)\n",
+    "\n",
+    "La stratégie `grimNext` (coopérer tant que l'adversaire coopère, dévier pour toujours\n",
+    "dès la première défection), puis le résultat central :\n",
+    "**`grim_trigger_sustains_iff`** — la coopération est soutenable contre déviation en un\n",
+    "coup *si et seulement si* $\\delta \\geq (T-R)/(T-P)$. Ce théorème est le\n",
+    "théorème-phare de l'issue #4880, livré **0 sorry** : sa preuve est une réduction nette\n",
+    "au seuil de `Discounting` (`exact coop_ge_deviate_iff g h0 h1`). Le one-shot deviation\n",
+    "principle fait le reste : pour une stratégie stationnaire, vérifier toutes les\n",
+    "déviation équivaut à vérifier celles d'un seul coup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "be62cf10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.361240Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.361002Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.367844Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.366805Z"
+    },
+    "papermill": {
+     "duration": 0.012709,
+     "end_time": "2026-08-20T20:33:55.368855+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.356146+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- RepeatedGames\\GrimTrigger.lean ---\n",
+      "  def          grimNext                               recopier le coup adverse de la période précédente (coopérer s'il a coopé\n",
+      "  theorem      grim_trigger_sustains_iff              Une déviation unilatérale en un coup n'est pas profitable (i.e. grim tri\n",
+      "sorry (code): 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = LAKE / \"RepeatedGames/GrimTrigger.lean\"\n",
+    "print(f\"--- {p.relative_to(LAKE)} ---\")\n",
+    "for kind, name, doc in decls_of(p):\n",
+    "    print(f\"  {kind:12s} {name:38s} {doc[:72]}\")\n",
+    "print(\"sorry (code):\", code_sorry_count(p))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "50bab853",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00386,
+     "end_time": "2026-08-20T20:33:55.376861+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.373001+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : un théorème-phare qui tient en une ligne\n",
+    "\n",
+    "Deux déclarations : la stratégie, le théorème. Et `sorry (code): 0` — la dette du\n",
+    "sprint #4880 est soldée sur le phare ; l'énoncé `iff` est la forme la plus forte\n",
+    "(caractérisation exacte du seuil, pas une implication partielle). C'est le socle que\n",
+    "le Folk Theorem généralise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f30cb0d9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004672,
+     "end_time": "2026-08-20T20:33:55.385748+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.381076+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. `Folk.lean` — le Folk Theorem, un STRETCH honnête\n",
+    "\n",
+    "Ici le lake assume sa frontière. `IndividuallyRational` et `Feasible` sont **forcés\n",
+    "par le type** (leçon Lidman L39, PR #4899) : les définitions sont des contraintes\n",
+    "structurelles sur les projections de `PrisonersDilemma`, aucune donnée numérique\n",
+    "citée. `discountedPayoff` généralise `coopValue`/`deviateValue` à une trajectoire\n",
+    "arbitraire. Puis `folk_theorem_discounted` : tout paiement faisable strictement\n",
+    "individuellement rationnel est réalisable pour $\\delta$ assez proche de 1 —\n",
+    "Fudenberg-Maskin 1986. Son unique `sorry` est la **direction difficile authentique**\n",
+    "(topologie du polytope des paiements faisables), explicitement STRETCH : la conclusion\n",
+    "est une équation réelle, pas un `True` masqué. Et le cas frontière\n",
+    "`folk_theorem_boundary` ($\\delta = 0$ : le jeu répété collapse au one-shot) est\n",
+    "**prouvé**.\n",
+    "\n",
+    "Le détail qui mérite d'être raconté : le bord de l'énoncé a été **réparé le\n",
+    "2026-08-15** — l'ancien « $\\forall d \\geq \\delta^*$ » sans borne $d < 1$ rendait le\n",
+    "théorème **faux** (à $d \\geq 1$ les séries $\\sum' d^n$ divergent et `tsum` vaut 0,\n",
+    "valeur indésirable : aucun $u \\neq 0$ n'est réalisable). La borne $d < 1$ répare sans\n",
+    "renforcer. Une leçon d'énoncé : un quantificateur omis peut transformer un théorème\n",
+    "vrai en théorème faux *sans que la preuve change d'apparence*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "3a3cc72f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.395885Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.395503Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.402987Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.401862Z"
+    },
+    "papermill": {
+     "duration": 0.013731,
+     "end_time": "2026-08-20T20:33:55.403841+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.390110+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- RepeatedGames\\Folk.lean ---\n",
+      "  def          IndividuallyRational                   individuellement rationnel si chaque coordonnée excède le paiement de\n",
+      "  def          Feasible                               espéré d'une certaine distribution sur les actions jointes. Dans une DP\n",
+      "  noncomputable def discountedPayoff                       d'actions conjointes `a` et facteur d'escompte `δ`. Généralise\n",
+      "  theorem      folk_theorem_discounted                Pour tout paiement faisable strictement individuellement rationnel\n",
+      "  theorem      folk_theorem_boundary                  réduisent aux paiements de stage — le jeu répété collapse au jeu one-sho\n",
+      "sorry (code): 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = LAKE / \"RepeatedGames/Folk.lean\"\n",
+    "print(f\"--- {p.relative_to(LAKE)} ---\")\n",
+    "for kind, name, doc in decls_of(p):\n",
+    "    print(f\"  {kind:12s} {name:38s} {doc[:72]}\")\n",
+    "print(\"sorry (code):\", code_sorry_count(p))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a4b5d58",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004078,
+     "end_time": "2026-08-20T20:33:55.411904+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.407826+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : un seul sorry, et il dit la vérité\n",
+    "\n",
+    "`folk_theorem_discounted` porte l'unique `sorry` du versant jeux répétés — compté,\n",
+    "documenté, priorité BG faible (#4880). Tout le reste (définitions forcées par le type,\n",
+    "cas frontière $\\delta = 0$) est prouvé. C'est ce qu'un STRETCH honnête looks like :\n",
+    "la dette est dans l'énoncé difficile, pas cachée dans un `True`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da25db9f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00414,
+     "end_time": "2026-08-20T20:33:55.420444+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.416304+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — exhiber des poids faisables\n",
+    "\n",
+    "`Feasible g u_row u_col` demande quatre poids $p_{CC}, p_{CD}, p_{DC}, p_{DD} \\geq 0$\n",
+    "sommant à 1 qui réalisent $(u_{row}, u_{col})$ comme paiement espéré. Complétez\n",
+    "`poids_faisables` pour qu'elle retourne les poids (tuple de 4 flottants) réalisant un\n",
+    "cible donnée **quand elle est faisable**, et `None` sinon. Testez sur\n",
+    "$(R, R) = (2, 2)$ (faisable : $p_{CC} = 1$), sur l'alternance\n",
+    "$(2.5, 1.5)$ (faisable : $p_{CD} = p_{DC} = 0.5$), et sur $(3, 3)$ (hors enveloppe :\n",
+    "le max de $u_{row} + u_{col}$ est $2R = 4$).\n",
+    "\n",
+    "*Indice : les quatre sommets de l'enveloppe sont $(R,R), (S,T), (T,S), (P,P)$ ; un\n",
+    "point est faisable ssi il est dans leur enveloppe convexe. Pour les trois cas\n",
+    "demandés, les poids se posent à la main — pas besoin de solveur.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6640d0e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.429678Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.429437Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.436108Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.434987Z"
+    },
+    "papermill": {
+     "duration": 0.012562,
+     "end_time": "2026-08-20T20:33:55.436936+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.424374+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : poids_faisables sur 3 cibles\n"
+     ]
+    }
+   ],
+   "source": [
+    "def poids_faisables(T, R, P, S, u_row, u_col):\n",
+    "    \"\"\"Poids (pCC, pCD, pDC, pDD) realisant (u_row, u_col), ou None si non faisable.\n",
+    "\n",
+    "    Etape 1 : poser le systeme 2x4 (u_row et u_col comme combinaisons des sommets).\n",
+    "    Etape 2 : verifier somme = 1 et poids >= 0 ; sinon retourner None.\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "# TODO etudiant : les trois cas (2,2), (2.5,1.5), (3,3) sur T=3, R=2, P=1, S=0.\n",
+    "print(\"Exercice a completer : poids_faisables sur 3 cibles\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c25ad89",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00409,
+     "end_time": "2026-08-20T20:33:55.445249+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.441159+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. `ConeKernel.lean` — le noyau Bondareva-Farkas (753 lignes, 0 sorry)\n",
+    "\n",
+    "Changement de versant : ce module est la machinerie autonome de la preuve **arrière**\n",
+    "de Bondareva-Shapley par la route Farkas / séparation par hyperplan (épopée #2959,\n",
+    "croisée avec le compagnon [GameTheory-15b](GameTheory-15b-Lean-CooperativeGames.ipynb)\n",
+    "pour le versant coopératif). Le geste architectural : il est **indépendant de\n",
+    "`TUGame`** — la machinerie du cône augmenté est paramétrée par une fonction\n",
+    "caractéristique nue `v : Finset N → ℝ`, ce qui rompt le cycle d'imports qui confinait\n",
+    "la preuve à un brouillon. On y trouve `phiAugLinear` (l'application d'incidence\n",
+    "augmentée), `augCone_mem_iff` (l'appartenance au cône comme témoin `w ≥ 0`),\n",
+    "`augCone_dual_iff` (dualité sur les générateurs), `separatingFunctional_none_neg` (la\n",
+    "condition de signe du décodage) — et le résultat structural : l'enveloppe conique\n",
+    "d'un ensemble fini de vecteurs linéairement indépendants est **fermée**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "484c1177",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.457843Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.457492Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.467505Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.466534Z"
+    },
+    "papermill": {
+     "duration": 0.018268,
+     "end_time": "2026-08-20T20:33:55.468377+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.450109+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- CooperativeGames\\ConeKernel.lean (753 lignes) ---\n",
+      "16 declarations ; affichage des 14 premieres :\n",
+      "  noncomputable def phiAugLinear                           `some i` porte les sommes d'incidence de coalition `∑_{S ∋ i} w S` ;\n",
+      "  noncomputable def phiAugCont                             \n",
+      "  noncomputable def augCone                                \n",
+      "  theorem      conicHull_linearIndependent_isClosed   directement à `augCone v`. Étant donné un point hors de `augCone v`, on \n",
+      "  theorem      mem_cone_iff_exists_li_subset          Tout point d'un cône engendré par un ensemble fini appartient au cône\n",
+      "  theorem      finGenCone_isClosed                    \n",
+      "  theorem      augCone_mem_iff                        \n",
+      "  def          balancedUnit                           \n",
+      "  lemma        augCone_dual_iff                       `f` est non-négative sur `augCone v` ssi elle est non-négative sur chacu\n",
+      "  lemma        gen_apply_some                         `i ∈ S`, sinon `0`. Généralise le cas particulier de la grande coalition\n",
+      "  lemma        gen_apply_none                         \n",
+      "  lemma        gen_decomp                             vaut la combinaison d'incidence sur `S` (un vecteur de base `some i` par\n",
+      "  lemma        gen_apply_linear                       linéaire `f`, `f (générateur S) = ∑ i ∈ S, f (base-some i) + v S * f (ba\n",
+      "  lemma        separatingFunctional_none_neg          vérifie `f (Pi.single none 1) < 0`. Preuve : `0 ≤ f` sur le générateur\n",
+      "sorry (code): 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = LAKE / \"CooperativeGames/ConeKernel.lean\"\n",
+    "decls = decls_of(p)\n",
+    "print(f\"--- {p.relative_to(LAKE)} ({len(p.read_text(encoding='utf-8').splitlines())} lignes) ---\")\n",
+    "print(f\"{len(decls)} declarations ; affichage des 14 premieres :\")\n",
+    "for kind, name, doc in decls[:14]:\n",
+    "    print(f\"  {kind:12s} {name:38s} {doc[:72]}\")\n",
+    "print(\"sorry (code):\", code_sorry_count(p))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "452b18ca",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0041,
+     "end_time": "2026-08-20T20:33:55.476712+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.472612+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : la plus grosse pièce noire du lake, sans dette\n",
+    "\n",
+    "Quinze-plus déclarations sur 753 lignes, **0 sorry** : toute la machinerie\n",
+    "cône-fermé de Bondareva-Farkas est prouvée. C'était le module invisible le plus lourd\n",
+    "du lake — un travail de fond (#2959) qu'aucun notebook ne montrait."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c721a67",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004217,
+     "end_time": "2026-08-20T20:33:55.485475+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.481258+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. `SortedListCounting.lean` et `_SmokeTest.lean` — l'infrastructure SocialChoice\n",
+    "\n",
+    "Deux fichiers utilitaires, noirs eux aussi. `SortedListCounting` factorise l'argument\n",
+    "structurel de comptage requis par `Voting.lean median_voter_theorem_strict` :\n",
+    "décomposer une liste triée en `take k ++ drop k` autour du pivot médian, majorer\n",
+    "`countP (· < l[k])` par `k`, minorer `countP (l[k] ≤ ·)` — le pont qui réduit les\n",
+    "anciens sorries L355/L385 du median voter. `_SmokeTest` est le scaffold de smoke test\n",
+    "du lake : un lemme trivial (`zero_add_smoke`), dont le rôle est de vérifier que le\n",
+    "pipeline compile, pas de porter de la théorie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3172db35",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.495569Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.495197Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.503718Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.502613Z"
+    },
+    "papermill": {
+     "duration": 0.014749,
+     "end_time": "2026-08-20T20:33:55.504452+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.489703+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "--- SocialChoice/SortedListCounting.lean (185 lignes, 5 decls) ---\n",
+      "  theorem      countP_lt_kth_le_half                  strictement inférieurs à `l[k]` est au plus `k`.\n",
+      "  theorem      countP_ge_kth_ge_half_succ             `≥ l[k]` est au moins `l.length - k`.\n",
+      "  theorem      countP_le_kth_ge_half_succ             et un pivot `l[k]`, le nombre d'éléments `≤ l[k]` est au moins `k + 1`.\n",
+      "  theorem      finset_filter_card_eq_toList_countP    \n",
+      "  theorem      finset_filter_lt_card_eq_toList_map_countP `A.card = (univ.toList.map f).countP p` (sans passer par le filtre).\n",
+      "sorry (code): 0\n",
+      "--- SocialChoice/_SmokeTest.lean (8 lignes, 1 decls) ---\n",
+      "  theorem      zero_add_smoke                         \n",
+      "sorry (code): 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for rel in (\"SocialChoice/SortedListCounting.lean\", \"SocialChoice/_SmokeTest.lean\"):\n",
+    "    p = LAKE / rel\n",
+    "    decls = decls_of(p)\n",
+    "    print(f\"--- {rel} ({len(p.read_text(encoding='utf-8').splitlines())} lignes, {len(decls)} decls) ---\")\n",
+    "    for kind, name, doc in decls[:6]:\n",
+    "        print(f\"  {kind:12s} {name:38s} {doc[:72]}\")\n",
+    "    print(\"sorry (code):\", code_sorry_count(p))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da65d8b1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004505,
+     "end_time": "2026-08-20T20:33:55.513162+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.508657+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : l'infra a sa place dans la carte\n",
+    "\n",
+    "`SortedListCounting` porte des preuves complètes (les sorries initiaux ont été comblés\n",
+    "— cycle 25, ai-01 backup po-2026 track 2), et `_SmokeTest` exactement un lemme\n",
+    "prouvé. L'un réduit la dette du median voter, l'autre garde le pipeline vivant :\n",
+    "invisible ne veut pas dire inutile."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f503783b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004188,
+     "end_time": "2026-08-20T20:33:55.521634+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.517446+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — le pont vers `median_voter_theorem_strict`\n",
+    "\n",
+    "L'en-tête de `SortedListCounting.lean` décrit la chaîne de réduction :\n",
+    "`A.card = (univ.toList.filter ...).length = ... = sortedPeaksList.countP (· < median)`\n",
+    "puis `≤ k` par le lemme de comptage. Complétez `plan_pont` pour retourner, sous forme\n",
+    "d'une liste de chaînes, les **quatre étapes** de cette chaîne appliquées au lemme\n",
+    "`countP_lt_kth_le_half` — c'est-à-dire : pourquoi prouver les helpers de comptage\n",
+    "suffit à décharger les sorries L355/L385 de `Voting.lean`.\n",
+    "\n",
+    "*Indice : chaque étape est une réécriture (`Finset.card` → `length` du `filter`,\n",
+    "`Perm.countP_eq` pour passer de `univ.toList.map peaks` à la liste triée, puis le\n",
+    "majorant `k = length / 2`). Étape 1 : la définition de `A`. Étape 2 : le passage\n",
+    "card → length. Étape 3 : la permutation. Étape 4 : le majorant.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "f66877fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.531639Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.531286Z",
+     "iopub.status.idle": "2026-08-20T20:33:55.537696Z",
+     "shell.execute_reply": "2026-08-20T20:33:55.536633Z"
+    },
+    "papermill": {
+     "duration": 0.012594,
+     "end_time": "2026-08-20T20:33:55.538575+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.525981+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : plan_pont (4 etapes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def plan_pont():\n",
+    "    \"\"\"Les 4 etapes de la reduction des sorries L355/L385 de Voting.lean.\n",
+    "\n",
+    "    Etape 1 : definir A (le Finset filtre des pics sous la mediane).\n",
+    "    Etape 2 : reecrire A.card comme length d'un filter sur toList.\n",
+    "    Etape 3 : passer a la liste triee via Perm.countP_eq.\n",
+    "    Etape 4 : majorer par k via le lemme de comptage sur listes triees.\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant\n",
+    "    return None  # TODO etudiant\n",
+    "\n",
+    "print(\"Exercice a completer : plan_pont (4 etapes)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94b1cc96",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00419,
+     "end_time": "2026-08-20T20:33:55.547213+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.543023+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Re-mesure : le lake n'a plus de module noir\n",
+    "\n",
+    "La boucle est bouclée : on relance l'instrument de l'EPIC #11703 sur l'arbre courant.\n",
+    "Avant ce compagnon, `game_theory_lean` comptait **7 modules noirs sur 19**. Chaque\n",
+    "section ci-dessus cite les déclarations des sept fichiers (l'extraction les affiche),\n",
+    "donc le scanner doit maintenant les voir tous."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8b721ea2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-20T20:33:55.557101Z",
+     "iopub.status.busy": "2026-08-20T20:33:55.556830Z",
+     "iopub.status.idle": "2026-08-20T20:34:57.461206Z",
+     "shell.execute_reply": "2026-08-20T20:34:57.460351Z"
+    },
+    "papermill": {
+     "duration": 61.913948,
+     "end_time": "2026-08-20T20:34:57.465106+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:33:55.551158+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1045 notebooks lus, 19 lakes, 2812 declarations\n",
+      "\n",
+      "lake                      decl  large  strict  noirs  compagnon principal\n",
+      "game_theory_lean           445    133      87   0/19  GameTheory/GameTheory-6b-Lean-RepeatedGames.ipynb\n",
+      "\n",
+      "TOTAL 766/2835 (borne haute)  558/2835 (borne basse)  modules invisibles: 35/182\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess, sys\n",
+    "\n",
+    "r = subprocess.run(\n",
+    "    [sys.executable, \"scripts/lean/scan_lake_notebook_visibility.py\",\n",
+    "     \"--lake\", \"game_theory_lean\"],\n",
+    "    capture_output=True, text=True, encoding=\"utf-8\",\n",
+    ")\n",
+    "print(r.stdout.strip() or r.stderr.strip())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdcbadd1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004151,
+     "end_time": "2026-08-20T20:34:57.473462+00:00",
+     "exception": false,
+     "start_time": "2026-08-20T20:34:57.469311+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture du résultat : 7 modules noirs → 0\n",
+    "\n",
+    "La ligne `game_theory_lean` du scanner confirme : plus aucun module noir. Les 445\n",
+    "déclarations du lake restent loin d'être toutes citées (la visibilité *large* n'est pas\n",
+    "l'objectif — l'EPIC vise l'absence de modules *totalement* invisibles), mais chaque\n",
+    "fichier a maintenant sa vitrine : le stage game et sa dominance stricte, le seuil\n",
+    "critique du grim trigger avec son pont numérique 6c, le théorème-phare 0-sorry #4880,\n",
+    "le Folk STRETCH au bord réparé, le noyau Bondareva-Farkas, et l'infra SocialChoice.\n",
+    "\n",
+    "**Ce que ce notebook ajoute au dépôt** : le chemin du lecteur entre la théorie dérivée\n",
+    "à la main (6c) et sa contrepartie formelle (lake) — là où il n'existait rien. See\n",
+    "#11703."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 74.475682,
+   "end_time": "2026-08-20T20:34:57.732859+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-6b-Lean-RepeatedGames.ipynb",
+   "output_path": "MyIA.AI.Notebooks/GameTheory/GameTheory-6b-Lean-RepeatedGames.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-20T20:33:43.257177+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/README.md
+++ b/MyIA.AI.Notebooks/GameTheory/README.md
@@ -211,6 +211,7 @@ flowchart TD
 | 5b | [GameTheory-5b-Lean-Minimax](GameTheory-5b-Lean-Minimax.ipynb) | Lean 4 | Companion **natif** (kernel Lean) : preuve formelle 0-sorry de von Neumann dans le lake `minimax_lean` (Sion), `#check` + `#print axioms` in-kernel — voir [#4054](https://github.com/jsboige/CoursIA/issues/4054) (création du lake) et `LEAN_INVENTORY.md` du dossier | 45 min |
 | 6 | [GameTheory-6-EvolutionTrust](GameTheory-6-EvolutionTrust.ipynb) | Python | Tournoi Axelrod, tit-for-tat, **processus de Moran stochastique (fixation finie, 25 graines)** [#7594], replicator dynamics | 65 min |
 | 6 (C#) | [GameTheory-6-EvolutionTrust-Csharp](GameTheory-6-EvolutionTrust-Csharp.ipynb) | .NET (C#) | Twin C# du 6 : **moteur IPD + tournoi Axelrod + replicator dynamics from-scratch** (BCL .NET 9, 0 NuGet), 7 stratégies (TitForTat/Grudger/Pavlov/...), Euler ODE (See #4956) | 55 min |
+| 6b | [GameTheory-6b-Lean-RepeatedGames](GameTheory-6b-Lean-RepeatedGames.ipynb) | Lean (lecture) | Compagnon **lake** du 6c : les 7 modules noirs de `game_theory_lean` dévoilés par extraction réelle — Stage (PD forcé par le type), Discounting (seuil $\delta^*$ `coop_ge_deviate_iff`), **`grim_trigger_sustains_iff` 0 sorry #4880**, Folk STRETCH (1 sorry assumé, bord réparé), ConeKernel Bondareva-Farkas, infra SocialChoice ; re-mesure visibilité noirs 7→0 (See #11703) | 35 min |
 | 6c | [GameTheory-6c-RepeatedGames-FolkTheorem](GameTheory-6c-RepeatedGames-FolkTheorem.ipynb) | Python | Compagnon **formel** de GT-6 : horizon fini (effondrement par induction arrière), horizon infini, grim trigger, condition $\delta \geq (T-R)/(T-P)$, Folk Theorem (tout paiement IR faisable est SPNE pour $\delta$ assez proche de 1) | 45 min |
 | 6c (C#) | [GameTheory-6c-RepeatedGames-FolkTheorem-Csharp](GameTheory-6c-RepeatedGames-FolkTheorem-Csharp.ipynb) | .NET (C#) | Twin C# du 6c : **grim trigger + tit-for-tat + Folk Theorem from-scratch** (BCL .NET 9, 0 NuGet), série géométrique $\sum \delta^t g = g/(1-\delta)$, condition de crédibilité $\delta^* = (T-R)/(T-P) = 0.5$, comparaison des seuils grim vs TFT ($2/3$), ensemble faisable & IR en ASCII — parité bit-par-bit avec le Python (See #4956) | 45 min |
 
@@ -292,6 +293,7 @@ Chaque notebook introduit un concept ou un modèle spécifique. Le tableau ci-de
 | 4 | NashEquilibrium | Nash mixte, Lemke-Howson, analyse paramétrique, support enumeration |
 | 5 | ZeroSum-Minimax | Théorème minimax, dualité LP, programmation linéaire pour jeux |
 | 6 | EvolutionTrust | Tournoi Axelrod, tit-for-tat, **processus de Moran (stochastic fixation finie vs replicator mean-field)** [#7594], émergence coopération |
+| 6b | Lean-RepeatedGames | Compagnon lake du 6c : extraction des 7 modules noirs de `game_theory_lean` (Stage, Discounting, GrimTrigger 0-sorry #4880, Folk STRETCH, ConeKernel, SortedListCounting, _SmokeTest), pont numérique $\delta^*$ avec le 6c |
 | 6c | RepeatedGames-FolkTheorem | Compagnon formel de GT-6 : Folk Theorem (horizon fini vs infini), condition de crédibilité du grim trigger $\delta \geq (T-R)/(T-P)$, comparaison grim trigger vs tit-for-tat (seuil de patience), ensemble faisable et IR |
 | 7 | ExtensiveForm | Arbres de jeu, ensembles d'information, stratégies comportementales |
 | 8 | CombinatorialGames | Positions P/N, Nim, Grundy values, théorème Sprague-Grundy |
@@ -356,7 +358,7 @@ GameTheory occupe une place à part dans la couche Lean : c'est la famille qui a
 | **GameTheory** (design) | `lean_game_defs_ext` | Vickrey (enchère au second prix = stratégie dominante), théorème de révélation | GameTheory-11b-Lean-BayesianGamesExt |
 | **GameTheory** (coopératif) | `game_theory_lean` (CooperativeGames) | Bondareva-Shapley résolu 0 sorry (#3954), Core non-vide sous balanced | Notebooks 15-15b (coopératif, valeur de Shapley) |
 | **GameTheory** (matching) | `game_theory_lean` (StableMarriage) | Gale-Shapley : existence + optimalité côté proposant | Notebooks 16-2 (matching, Gale-Shapley) |
-| **GameTheory** (jeux répétés) | `repeated_games_lean` | Stratégie grim-trigger **certifiée 0 sorry** (compagnon formel GT-6c, cf #4880) ; stretch restant : théorème Folk complet (`Folk.lean`) | Notebook 6c (RepeatedGames-FolkTheorem) |
+| **GameTheory** (jeux répétés) | `game_theory_lean` (RepeatedGames — home canonique post-#6146, l'ancien lake `repeated_games_lean/` est coquille archive) | Stratégie grim-trigger **certifiée 0 sorry** (cf #4880) ; stretch restant : théorème Folk complet (`Folk.lean`, 1 sorry assumé) | Notebooks 6c (dérivation à la main) + 6b (compagnon lake, visibilité #11703) |
 | **GameTheory** (jeux combinatoires) | `conway_cgt_lean` | Visite guidée (`#check`) de la théorie des jeux combinatoires (Conway CGT) | Notebooks 8/8b (CombinatorialGames, Sprague-Grundy) |
 | **Search** (cross-famille) | `search_lean` (cf. `#4048`) | Consistance + heuristique admissible = optimalité | Search-13 (A*), branchement par preuve de correction |
 | **QuantConnect** (cross-famille) | `kelly_lean` (cf. `#4052`) | Kelly `g(f) ≤ g(f*)` + unicité | QC-Py-10 Risk Management, branchement par fraction risquée |
@@ -732,6 +734,7 @@ GameTheory/
 ├── GameTheory-15b-Lean-CooperativeGames.ipynb
 ├── GameTheory-4c-NashExistence-Python.ipynb        # Side tracks c — approfondissement (Python 4c, 6c, 8c, 15c)
 ├── GameTheory-4c-NashExistence-Csharp.ipynb        #   Jumeau C# (.NET Interactive) — Brouwer point fixe + Matching Pennies (parité #4956)
+├── GameTheory-6b-Lean-RepeatedGames.ipynb          # Compagnon lean (lecture) du 6c — lake game_theory_lean dévoilé, visibilité #11703
 ├── GameTheory-6c-RepeatedGames-FolkTheorem.ipynb
 ├── GameTheory-6c-RepeatedGames-FolkTheorem-Csharp.ipynb  #   Jumeau C# — grim trigger/TFT/Folk Theorem from-scratch (parité #4956)
 ├── GameTheory-8c-CombinatorialGames-Python.ipynb


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA — prev: MED/notebook-python #11994

(G-VAR-3 : 2e grain consecutif notebook-python MED/DEEP, veine compagnons visibilite lean = domaine etabli po-2025 ; substance genuinement distincte — couverture repeated-games game_theory_lean vs feuille de route knot MathlibPrerequisites #11994.)

## Summary

Nouveau notebook **GameTheory-6b-Lean-RepeatedGames.ipynb** (30 cellules, kernel python3, pattern Lean-17c) : compagnon **lake** du 6c — les **7 modules noirs** de `game_theory_lean` (mesure EPIC #11703 : aucun notebook ne citait une seule de leurs declarations) devoiles par **extraction reelle** depuis les fichiers du lake :

- **Stage.lean** — le PD force par le type (contraintes Gibbons en champs de preuve), `defect_strictly_dominates` prouve ;
- **Discounting.lean** — `geom_sum`, formes closes `coopValue`/`deviateValue`, `coop_ge_deviate_iff` (le seuil δ* = (T−R)/(T−P)), **pont numerique** avec le 6c (T=3, R=2, P=1 : δ*=0.5, verifie sous/au-seuil/dessus, gate ICT-13 #4879) ;
- **GrimTrigger.lean** — le theoreme-phare **`grim_trigger_sustains_iff` 0 sorry** (#4880), reduction nette au seuil ;
- **Folk.lean** — STRETCH honnete : 1 sorry authentique (Fudenberg-Maskin, conclusion = equation reelle, pas un True), `folk_theorem_boundary` prouve, bord d'enonce repare 2026-08-15 (∀ d ≥ δ* sans d < 1 rendait le theoreme FAUX — raconte pedagogiquement) ;
- **ConeKernel.lean** — le noyau cone-ferme Bondareva-Farkas, 753 lignes **0 sorry** (#2959), cross-ref GT-15b ;
- **SortedListCounting.lean + _SmokeTest.lean** — infra SocialChoice (pont median voter Voting.lean) + scaffold, documentes comme tels.

3 exercices stubbes (C.1 : `return None  # TODO etudiant`, zero `raise NotImplementedError`), interprets ancrees apres chaque output (regle cell-interpretation-ordering).

README GameTheory : ligne 6b ajoutee aux 3 surfaces (table notebooks, table concepts, arbre) + **correction ligne moteur** : `repeated_games_lean` (coquille archive) → `game_theory_lean` (RepeatedGames, home canonique post-#6146, verifie sur disque : le repertoire standalone est archive lean_lib neutralisee).

## Validation

- **Exec reelle** : papermill python3 30/30 cellules, **0 erreur**, 11 cellules code toutes `execution_count` non-null, outputs stdout coherents ;
- **Re-mesure visibilite** (cellule finale, instrument `scan_lake_notebook_visibility.py --lake game_theory_lean`) : **noirs 7/19 → 0/19**, citations strict 54 → 87, compagnon principal detecte = GT-6b ;
- **C.1** : `grep -cE "raise NotImplementedError|assert False|1/0"` = 0 ; 3 headers `### Exercice N` ;
- **Sorries** : comptage par fichier sur lignes de code (prose retiree) affiche dans le notebook — 0 partout sauf Folk.lean = 1 (STRETCH documente) ; **aucun fichier .lean modifie** → B.1/B.2/B.3 non applicables ;
- **Audit §E README fichier-entier** : 50 ipynb sur disque (hors `_output`) ↔ table notebooks + prose jumeaux C# (l.640 : 23 jumeaux + tranche Part2) + arbre structure — reconciliation complete, le seul absent de la table etait GT-6b (cette PR l'ajoute) ; les jumeaux GT-2 C# sont couverts en prose + arbre (l.694-696), pas un drift ;
- Catalogue : byte-identique a main (aucune regeneration).

See #11703 (V4 game_theory_lean — plus gros trou libre de l'EPIC, noirs 7→0). See #4880 (theoreme-phare montre), See #2959 (ConeKernel).
