### PR TITLE
fix(ci,#11843): orphaned-delivery-scan en clone partiel - serie workflow 2

### DIFF
--- a/.github/workflows/orphaned-delivery-scan.yml
+++ b/.github/workflows/orphaned-delivery-scan.yml
@@ -58,14 +58,25 @@ jobs:
     # only produce spurious failures on an advisory job.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Checkout (full history)
+      - name: Checkout (full history, blobless)
+        # Partial clone, serie #11843 (workflow 2). The scan interrogates the
+        # commit graph (merge-base --is-ancestor, cat-file -e, diff --quiet
+        # two-dot scoped to candidate paths) and the gh API -- it reads no
+        # repository content blob. blob:none keeps the graph complete; the
+        # fetch below inherits the filter. Sparse-checkout materializes only
+        # scripts/ (14 Mo: the audited script + siblings) instead of the full
+        # 1058 Mo tree. A missing script would fail loudly (python: can't
+        # open file), not silently scan less.
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          filter: blob:none
+          sparse-checkout: scripts
 
       - name: Fetch ALL remote heads
         # actions/checkout@v4 only fetches the default branch. Ancestry of a
         # mergeCommit against origin/main requires every remote head present.
+        # Inherits the blob:none filter of the partial clone (graph only).
         run: |
           git fetch origin '+refs/heads/*:refs/remotes/origin/*' || true
 


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python #12011 (tranche SymbolicAI ASCII->Mermaid)

Quoi:       orphaned-delivery-scan en clone partiel (serie #11843, workflow 2) — blob:none + sparse-checkout: scripts au lieu du clone fetch-depth:0 plein
Preuve:     assert programmatique du bloc checkout {fetch-depth: 0, filter: blob:none, sparse-checkout: scripts} + baseline dry-run du script exit 0 (5 analysees, 0 orphelin) + mesure admission postee sur #11843 : workflow 1 passe de 62s/60s/204s a 8s/4s/8s
Perimetre:  1 fichier workflow, +12/-1, zero changement de logique (le bloc run: du scan est intact) ; hors scope : regression-guard (lit le contenu des notebooks), translation-guard (diff --name-only + renames -> grain dedie), repo-size/secret-scan (lisent des blobs par nature)

## Le gate d'admission de la serie : workflow 1 a TENU

Le body de #11843 conditionnait la suite a la mesure post-merge. Mesuree sur l'etape checkout de `Stale Base Branch Warning` :

| | runs | checkout |
|---|---|---|
| pre-merge 19/08 | 32300438492 / 32297540099 / 32297048441 | 62 s / 60 s / 204 s |
| post-merge 20/08 | 32410803188 / 32410395386 | 8 s / 4 s / 8 s |

Mesure aussi journalisee en commentaire sur #11843.

## Pourquoi orphaned-delivery-scan est un candidat propre

Lecture du code line par line (`scripts/audit/check_orphan_merged_pr.py`, ast + grep) :

- imports **stdlib uniquement** (argparse, datetime, json, pathlib, subprocess, sys) — aucun module frere ;
- interrogations git : `rev-parse --git-dir`, `merge-base --is-ancestor`, `cat-file -e` (existence), `diff --quiet` **deux-points borne aux chemins de la PR candidate** — tout se resout sur le graphe + les arbres ; au pire, un fetch paresseux borne aux chemins d'une PR orpheline candidate (rare, quelques Mo) ;
- donnees PR via `gh` API (GH_TOKEN), pas via le contenu du depot ;
- zero lecture de blob de contenu repo, zero glob de l'arbre (le risque "sparse = scan plus petit sans erreur" documente dans #11843 ne s'applique pas : le script echoue bruyamment si absent).

Seul besoin d'arbre de travail : `scripts/` (14 Mo) pour `scripts/audit/check_orphan_merged_pr.py`. L'arbre materialise passe de 1058 Mo a 14 Mo. Le `git fetch origin '+refs/heads/*'` herite du filtre blob:none (comportement etabli par #11843 workflow 1).

## Verifications

- YAML parse ; 1 seul step checkout ; assert programmatique : `with == {fetch-depth: 0, filter: blob:none, sparse-checkout: scripts}` ;
- baseline : `python scripts/audit/check_orphan_merged_pr.py --days 7 --dry-run --limit 5` -> exit 0 (Analysees: 5, orphelins: 0) ;
- diff +12/-1 sur le seul fichier workflow, bloc `run:` du scan intact.

## Risque, ecrit avant d'etre demande

Clone partiel = chaque blob absent devient un aller-retour reseau si demande. Ce garde n'en demande aucun en regime nominal ; le `diff --quiet` de la detection d'orphelin peut en demander pour les chemins de la PR candidate seulement (borne, rare). Un test de non-regression : la prochaine journee de runs scheduled doit produire les memes verdicts qu'avant.

## Mesure a relever apres merge

Duree de l'etape checkout d'orphaned-delivery-scan sur les runs scheduled + [closed] suivants, comparee aux runs actuels (fetch-depth: 0 plein).

See #11843 (serie clone-partiel, protocole un-par-un ; mesure d'admission du workflow 1 en commentaire).

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
