### PR TITLE
feat(vibe,#12012): Mistral Vibe worker integration - harnais .vibe/

### DIFF
--- a/.vibe/AGENTS.md
+++ b/.vibe/AGENTS.md
@@ -1,0 +1,133 @@
+# AGENTS.md - Mistral Vibe Workspace Configuration (CoursIA)
+# Instructions specifiques au workspace D:\dev\CoursIA
+
+**Workspace:** CoursIA  
+**Machine:** myia-po-2025  
+**Role:** Worker agent (30min cycles, aligned sur scheduler myia-ai-01)  
+**Commande:** `.vibe/commands/continue.md`  
+**Config locale:** `.vibe/config.toml` (override global si besoin)  
+
+---
+
+## Configuration locale
+
+### Fichiers du harnais
+```
+D:\dev\CoursIA\.vibe\
+├── config.toml          # Config MCP locale (override ~/.vibe/config.toml)
+├── AGENTS.md           # Instructions workspace (ce fichier)
+└── commands\
+    └── continue.md      # Commande worker principale
+```
+
+### MCP roo-state-manager (stdio local)
+
+**Outils disponibles** (noms complets avec server prefix) :
+- roo-state-manager_roosync_dashboard
+- roo-state-manager_roosync_messages
+- roo-state-manager_roosync_search
+- roo-state-manager_codebase_search
+- roo-state-manager_conversation_browser
+- Et 10 autres...
+
+**Permissions:** `permission = "always"` dans config.toml
+
+---
+
+## Commande Worker : `.vibe/commands/continue.md`
+
+### Workflow (30 min max)
+
+**Phase 1 : Contexte**
+1. roosync_messages(action:"inbox", status:"unread")
+2. roosync_dashboard(action:"read", type:"workspace", section:"all")
+3. Filtrer par machine:myia-po-2025
+4. git checkout main && git pull --ff-only
+
+**Phase 2 : Priorisation**
+- P0 : Missions coordinateur HIGH/URGENT
+- P1 : Taches [CLAIMED] par myia-po-2025
+- P2 : Pool global -> Poser [CLAIMED] <#N> -- <machine:myia-po-2025> <ts>
+
+**Phase 3 : Execution**
+- 1 sujet = 1 PR, catalogue byte-identique
+- Notebooks : C.1/C.2/H.3
+- Toujours SOTA, jamais workaround (regle F)
+
+**Phase 4 : Rapport**
+1. Commit + PR AVANT [DONE]
+2. [DONE] <machine:myia-po-2025> <resume> -- PR#<N> -- grade: <A/B/C>
+3. [ASK USER] separe si bloqueur
+
+---
+
+## Fallback MCP
+
+### Lecture directe des fichiers GDrive
+```
+G:/Mon Drive/Synchronisation/RooSync/.shared-state/dashboards/workspace-CoursIA.md
+G:/Mon Drive/Synchronisation/RooSync/.shared-state/dashboards/workspace-CoursIA-2.md
+G:/Mon Drive/Synchronisation/RooSync/.shared-state/dashboards/workspace-roo-extensions.md
+```
+
+### Commande git/gh
+```bash
+gh issue list --state open --json number,title,labels
+gh pr list --state open --author @me
+```
+
+---
+
+## Scheduler
+
+- Frequence : 30 min (staggered)
+- Alignment : scheduler myia-ai-01 (schtasks)
+- Commande : `vibe --prompt .vibe/commands/continue.md --timeout 1800 --agent auto-approve`
+
+---
+
+## Notes specifiques Vibe
+
+1. Pas de session persistante -> etablir contexte depuis dashboard
+2. CLI non-interactif -> checkpoints frequents dans dashboard
+3. mistral-medium-3.5 -> utiliser bash pour execution code
+4. Timeout a 27 min : commit [WIP] + [DONE-PARTIAL]
+5. MCP stdio fonctionne -> utiliser noms complets: roo-state-manager_*
+
+---
+
+## Exemples
+
+```
+# Lire dashboard
+roosync_dashboard(action: "read", type: "workspace", section: "all")
+
+# Poster message
+roosync_dashboard(action: "append", type: "workspace", tags: ["DONE"], content: "[DONE] myia-po-2025: PR #12345 -- grade: A")
+
+# Chercher
+roosync_search(query: "fix main red", limit: 10)
+```
+
+---
+
+## Erreurs connues
+
+| Erreur | Solution |
+|--------|----------|
+| Tool call failed (silent) | Verifier config.toml, redemarrer |
+| HTTP 502/429 | Attendre 5h, fallback GDrive |
+| MCP not found | Verifier cwd dans config.toml |
+
+---
+
+## Changelog
+
+| Date | Action | Par |
+|------|--------|-----|
+| 2026-08-20 | Creation + correction MCP | jsboige + Mistral Vibe |
+| 2026-08-20 | Annonce dans 3 dashboards | Mistral Vibe |
+
+---
+
+*"La mer, pas le burin" — Alexandre Grothendieck*

--- a/.vibe/commands/continue.md
+++ b/.vibe/commands/continue.md
@@ -1,0 +1,143 @@
+# Continue - Cycle worker Mistral Vibe (mistral-medium-3.5)
+
+**Lane:** myia-po-2025 (detectee via hostname)  
+**Workspace:** D:\dev\CoursIA  
+**Modele:** mistral-medium-3.5  
+**Frequence:** 30 min (staggered, aligne sur scheduler myia-ai-01)  
+**Config MCP:** `~/.vibe/config.toml` (TOML, Vibe 3.5+) + `.vibe/config.toml` (local override)
+
+---
+
+## Protocole OBLIGATOIRE (identique a Claude Code)
+
+### Phase 1 : Contexte (30s)
+
+1. **Inbox DM EN PREMIER** :
+   `roo-state-manager_roosync_messages(action:"inbox", status:"unread")`
+   -> Le DM coordinateur (ai-01) est le canal de decision, survit a la condensation.
+
+2. **Dashboard workspace** :
+   `roo-state-manager_roosync_dashboard(action:"read", type:"workspace", section:"all")`
+   -> Chercher `[DISPATCH->inbox]` et `steers` pour `machine:myia-po-2025`.
+
+3. **Filtre lane** : Ne traiter que messages adresses a cette lane/machine.
+
+4. **Git** :
+   ```bash
+   git checkout main && git pull --ff-only
+   git status
+   ```
+   -> Si arbre sale (WIP autrui) : worktree isole
+   `git worktree add ../CoursIA-<sujet> -b feature/<sujet> origin/main`
+
+---
+
+### Phase 2 : Priorisation
+
+**P0** : Missions coordinateur HIGH/URGENT (DM ou dashboard)  
+**P1** : Taches `[CLAIMED]` par `myia-po-2025` non terminees  
+**P2** : Pool global (`gh issue list --state open` cross-lane)  
+   -> Poser `[CLAIMED] <#N> -- <machine:myia-po-2025> <ts>` AVANT de commencer
+
+> **Regle** : >=1 PR/wakeup = PLANCHER. "Rien a faire" avec >0 issues = echec.
+
+---
+
+### Phase 3 : Execution
+
+- **PR** : 1 sujet = 1 PR. Catalogue byte-identique a main.
+  `Closes #N` si issue resolue, sinon `See #N`.
+- **Notebooks** : C.1 (pas d'erreur), C.2 (commit AVEC outputs), H.3 (pre-commit).
+- **Outils** : Toujours SOTA, jamais workaround degrade (regle F).
+- **Env casse** : Reparer, pas contourner.
+- **Skills** : Uniquement si delegation explicite.
+
+---
+
+### Phase 4 : Rapport OBLIGATOIRE (avant timeout)
+
+1. **Commit + PR AVANT le rapport** -- jamais de [DONE] sur travail non commite.
+2. **Dashboard** :
+   `[DONE] <machine:myia-po-2025> <resume> -- PR#<N> -- grade: <A/B/C>`
+3. **Bloqueurs** : Tag `[ASK USER]` **separe** du [DONE]. Repeter a CHAQUE fin.
+4. **DM coordinateur** : Repondre si mission traitee.
+5. **MEMORY.md** : MAJ si lecon durable.
+
+---
+
+## Notes specifiques Vibe
+
+### MCP roo-state-manager
+
+**Noms complets des outils** (avec prefix server) :
+```
+roo-state-manager_roosync_dashboard
+roo-state-manager_roosync_messages
+roo-state-manager_roosync_search
+roo-state-manager_roosync_indexing
+roo-state-manager_codebase_search
+roo-state-manager_read_vscode_logs
+roo-state-manager_export_data
+roo-state-manager_roosync_compare_config
+roo-state-manager_roosync_baseline
+roo-state-manager_roosync_config
+roo-state-manager_roosync_inventory
+roo-state-manager_roosync_mcp_management
+roo-state-manager_roosync_storage_management
+roo-state-manager_roosync_diagnose
+roo-state-manager_conversation_browser
+```
+
+**Permissions** : `permission = "always"` dans `~/.vibe/config.toml`
+
+### Fallback si MCP echoue
+
+1. **Reessayer** : 1x apres 10s
+2. **Poster erreur** : `[MCP-ERROR] <timestamp> : <details>`
+3. **Mode degrade** : Utiliser lecture directe GDrive :
+   ```
+   G:/Mon Drive/Synchronisation/RooSync/.shared-state/dashboards/
+   ```
+4. **Ou git/gh** : `gh issue list --state open`
+
+---
+
+## Raccourcis utiles
+
+| Commande | Action |
+|----------|--------|
+| `gh issue list --state open --json number,title,labels` | Liste issues |
+| `git worktree list` | Voir worktrees |
+| `gh pr list --state open --author @me` | Mes PRs |
+
+---
+
+## Configuration
+
+**Global** : `~/.vibe/config.toml`  
+**Local** : `.vibe/config.toml` (override global)  
+**AGENTS.md** : `~/.vibe/AGENTS.md` (user) + `.vibe/AGENTS.md` (workspace)
+
+---
+
+## Erreurs connues
+
+| Probleme | Solution |
+|----------|----------|
+| MCP non charge | Verifier config.toml, redemarrer session |
+| HTTP 502/429 | Attendre reset (5h), fallback GDrive |
+| Tool call silent fail | Utiliser noms complets: roo-state-manager_* |
+| Worktree conflict | git worktree prune + rebase frais |
+
+---
+
+## Changelog
+
+| Date | Action | Par |
+|------|--------|-----|
+| 2026-08-20 | Creation initiale | jsboige + Mistral Vibe |
+| 2026-08-20 | Correction noms outils MCP | Mistral Vibe |
+
+---
+
+*"La mer, pas le burin" — Alexandre Grothendieck*

--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -1,0 +1,62 @@
+# Mistral Vibe Workspace Configuration - CoursIA
+# Local override de ~/.vibe/config.toml
+# Machine: myia-po-2025
+# Workspace: D:\dev\CoursIA
+
+# Héritage : Ce fichier override ~/.vibe/config.toml pour ce workspace
+# Format: TOML (Vibe 3.5+)
+# Documentation: https://github.com/mistralai/mistral-vibe/blob/main/README.md#mcp-server-configuration
+
+---
+
+## MCP Servers (stdio transport)
+# Note: Les paths sont relatifs au workspace ou absolus machine-specific
+# Pour une configuration portable, utiliser les paths réseau ou variable d'environnement
+
+# roo-state-manager (herité du global ~/.vibe/config.toml)
+# Si besoin d'override local, decommenter ci-dessous:
+#[[mcp_servers]]
+#name = "roo-state-manager"
+#transport = "stdio"
+#command = "node"
+#args = ["d:/dev/roo-extensions/mcps/internal/servers/roo-state-manager/mcp-wrapper.cjs"]
+#cwd = "d:/dev/roo-extensions/mcps/internal/servers/roo-state-manager/"
+#startup_timeout_sec = 20.0
+#tool_timeout_sec = 180.0
+
+---
+
+## Tool Permissions (roo-state-manager)
+# Permissions locales qui s'ajoutent au global
+
+[tools.roo-state-manager_roosync_dashboard]
+permission = "always"
+
+[tools.roo-state-manager_roosync_messages]
+permission = "always"
+
+[tools.roo-state-manager_roosync_search]
+permission = "always"
+
+---
+
+## Session & Logging
+
+[session_logging]
+enabled = true
+save_dir = ".vibe/logs/session"
+session_prefix = "coursia-session"
+
+---
+
+## Agent Configuration
+
+# Default agent for worker mode
+default_agent = "auto-approve"
+
+---
+
+## Notes
+# - Ce fichier est optionnel : si absent, Vibe utilise ~/.vibe/config.toml
+# - Pour ajouter des MCP : `vibe mcp add <name> --transport stdio --command <cmd> --args <args>`
+# - Les permissions tools sont cumulatives (global + local)

--- a/.vibe/config.toml
+++ b/.vibe/config.toml
@@ -7,7 +7,11 @@
 # Format: TOML (Vibe 3.5+)
 # Documentation: https://github.com/mistralai/mistral-vibe/blob/main/README.md#mcp-server-configuration
 
----
+# Default agent for worker mode (doit rester AVANT le premier header [table] :
+# en TOML, une cle apres un header appartient a cette table)
+default_agent = "auto-approve"
+
+# ---
 
 ## MCP Servers (stdio transport)
 # Note: Les paths sont relatifs au workspace ou absolus machine-specific
@@ -24,7 +28,7 @@
 #startup_timeout_sec = 20.0
 #tool_timeout_sec = 180.0
 
----
+# ---
 
 ## Tool Permissions (roo-state-manager)
 # Permissions locales qui s'ajoutent au global
@@ -38,7 +42,7 @@ permission = "always"
 [tools.roo-state-manager_roosync_search]
 permission = "always"
 
----
+# ---
 
 ## Session & Logging
 
@@ -47,14 +51,12 @@ enabled = true
 save_dir = ".vibe/logs/session"
 session_prefix = "coursia-session"
 
----
+# ---
 
 ## Agent Configuration
+# (default_agent figure en tete de fichier : cle top-level TOML)
 
-# Default agent for worker mode
-default_agent = "auto-approve"
-
----
+# ---
 
 ## Notes
 # - Ce fichier est optionnel : si absent, Vibe utilise ~/.vibe/config.toml


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2025:CoursIA — prev: DEEP/notebook-lean #12031

## Summary

Intégration de **Mistral Vibe** (mistral-medium-3.5) comme 10e worker dans la flotte CoursIA, aligné sur le protocole Claude Code (Phases 1-4 : inbox DM d'abord, plancher ≥ 1 PR/wakeup, [DONE] post-commit, [ASK USER] séparé).

## Changes

- `.vibe/AGENTS.md` — instructions workspace-level pour le worker Vibe (133 L)
- `.vibe/commands/continue.md` — commande worker 30 min, protocole identique Claude Code (143 L)
- `.vibe/config.toml` — configuration MCP locale, override de `~/.vibe/config.toml` (62 L)

## Configuration

- MCP roo-state-manager : **fonctionnel** (stdio local, testé)
- Outils avec permissions `always` : `roosync_dashboard` (read/append), `roosync_messages` (inbox/DM), `roosync_search`
- Protocole : identique aux workers Claude Code
- Dashboard : annonces postées dans CoursIA, CoursIA-2, roo-extensions

## Nits Hermes levées (commit 43805883f)

1. **Séparateurs TOML** : les `---` nus (invalides en TOML, rejet du fichier entier par un parseur strict) deviennent `# ---`. Vérifié : `tomllib` parse le fichier, les 3 tables `[tools.*]` chargent, `session_logging` charge.
2. **Bug latent révélé au passage** : `default_agent = "auto-approve"` arrivait après le header `[session_logging]` — niché dans cette table au lieu d'être top-level (invisible avant, puisque le fichier entier était rejeté). Déplacé en tête de fichier ; vérifié top-level au parse.
3. **Body PR réparé** : le template avait mangé les backticks — les noms d'outils (`roosync_dashboard`, `roosync_messages`, `roosync_search`) et les chemins de fichiers sont restaurés.

## Next Steps

- [ ] Configuration schtask via myia-ai-01:roo-extensions (30 min staggered)
- [ ] Validation cycle worker complet

See #12012
