### PR TITLE
feat(genai,#11271): densité FT-04 RLHF-DPO round 1 retrodécouvert (518 → 1349 chars/cell)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/FineTuning/FT-04-RLHF-DPO.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "d2186f84",
+   "id": "f06e6861",
    "metadata": {
     "papermill": {
      "duration": 0.004414,
@@ -31,7 +31,34 @@
     "6. Evaluation : SFT vs DPO\n",
     "7. Comparaison RLHF vs DPO\n",
     "\n",
-    "**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**"
+    "**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**\n",
+    "\n",
+    "**Lecture linéaire recommandée** : ce notebook présente le pipeline RLHF\n",
+    "classique et l'alternative **DPO** (Direct Preference Optimization,\n",
+    "Rafailov et al. 2023, arXiv:2305.18290). L'ordre pédagogique est :\n",
+    "\n",
+    "1. **Partie 1-2** — Pourquoi SFT ne suffit pas + le pipeline RLHF en 3 étapes.\n",
+    "2. **Partie 3-4** — Données de préférence + Reward Model.\n",
+    "3. **Partie 5** — DPO : la perte dérivée analytiquement (sans critic).\n",
+    "4. **Partie 6** — Évaluation SFT vs DPO : réponses qualitatives.\n",
+    "5. **Partie 7** — Comparaison PPO (RLHF classique) vs DPO.\n",
+    "6. **Partie 8-9** — 3 exercices + résumé.\n",
+    "\n",
+    "**Pourquoi DPO > PPO pour l'alignement conversationnel** : DPO élimine\n",
+    "le **reward model** et le **critic** — il optimise directement la\n",
+    "**préférence** entre deux réponses. C'est la forme moderne dominante\n",
+    "depuis 2023 ; ce notebook l'implémente from-scratch sur un toy\n",
+    "modèle instruct pour rendre la mécanique lisible.\n",
+    "\n",
+    "**Sur la machine de l'étudiant** : ce notebook nécessite un GPU\n",
+    "(recommandé 8 Go+). Il utilise **LoRA** via PEFT pour l'entraînement\n",
+    "efficient. Cellule #1 confirme le device.\n",
+    "\n",
+    "**Sections à exécuter en priorité** : parties 1, 5, 6, 7 — c'est 80%\n",
+    "de la valeur RLHF/DPO. Partie 4 (reward model) = référence, pas le\n",
+    "cœur pédagogique.\n",
+    "\n",
+    "**Exercices** : 3 stubs (#25-#30 = Exercice 1/2/3). Chacun ~30 min.\n"
    ]
   },
   {
@@ -92,7 +119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "caab975c",
+   "id": "aab72a6a",
    "metadata": {
     "papermill": {
      "duration": 0.006933,
@@ -112,7 +139,21 @@
     "- **Pas d'alignement** : Un modèle SFT peut generer des reponses techniquement correctes mais maladroites, trop longues, ou manquant de nuances.\n",
     "- **Pas de signal de préférence** : Le SFT optimise la cross-entropy sur une seule reponse cible, pas une metrique de \"qualite percue par l'utilisateur\".\n",
     "\n",
-    "**Le problème central** : Comment faire pour que le modèle produise des reponses que les humains *preferent* ?"
+    "**Le problème central** : Comment faire pour que le modèle produise des reponses que les humains *preferent* ?\n",
+    "\n",
+    "**Argument central du notebook** : le SFT apprend au modèle à *imiter*\n",
+    "un style de réponse, mais ne lui apprend pas à *préférer* une bonne\n",
+    "réponse à une mauvaise. C'est la limite structurelle du SFT.\n",
+    "\n",
+    "**Manifestation pratique** : après SFT sur des paires question/réponse,\n",
+    "le modèle peut générer des réponses grammaticalement correctes mais\n",
+    "sémantiquement inconsistantes — il ne sait pas *pondérer* entre deux\n",
+    "réponses possibles. Le reward model + RLHF (ou DPO) comble ce gap en\n",
+    "injectant une **métrique de préférence** dans l'optimisation.\n",
+    "\n",
+    "**Branchement série FineTuning** : FT-03 (SFT) → FT-04 (DPO/RLHF) →\n",
+    "FT-05 (merging) — c'est la **triade alignement** d'un LLM moderne :\n",
+    "SFT pour la forme, DPO pour les préférences, merging pour combiner.\n"
    ]
   },
   {
@@ -258,7 +299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "95d9c377",
+   "id": "cf276e7f",
    "metadata": {
     "papermill": {
      "duration": 0.003823,
@@ -272,12 +313,27 @@
    "source": [
     "**Observation** : Le modèle de base genere du texte coherent mais ne peut pas distinguer une reponse \"bonne\" d'une reponse \"preferee par l'utilisateur\". Le SFT resout partiellement ce problème en apprenant des reponses cibles, mais il n'apprend pas a **ranger** les reponses par qualite.\n",
     "\n",
-    "C'est la que le RLHF intervient : utiliser les **préférences humaines** comme signal d'apprentissage."
+    "C'est la que le RLHF intervient : utiliser les **préférences humaines** comme signal d'apprentissage.\n",
+    "\n",
+    "**Lecture du résultat** : la cellule #3 charge le modèle de base et\n",
+    "effectue une génération témoin. Le verdict qualitatif attendu est :\n",
+    "\n",
+    "- **Cohérence grammaticale** : OK (le modèle a vu du texte varié en\n",
+    "  pré-entraînement).\n",
+    "- **Distinction preference** : ABSENTE — le modèle ne sait pas\n",
+    "  différencier une réponse sûre d'une réponse risquée, une réponse\n",
+    "  nuancée d'une réponse générique. C'est exactement ce que DPO va\n",
+    "  corriger dans la partie 5.\n",
+    "\n",
+    "**Pourquoi cette observation est centrale** : elle motive *toute* la\n",
+    "suite. Sans ce constat, le passage SFT → DPO semble arbitraire.\n",
+    "Avec ce constat, il devient **logique** : on ne peut pas aligner un\n",
+    "modèle qui ne sait pas ce qu'est une bonne réponse.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "24941a98",
+   "id": "699a9bff",
    "metadata": {
     "papermill": {
      "duration": 0.003973,
@@ -308,12 +364,26 @@
     "\n",
     "**Étape 3 -- PPO ou DPO** : Optimiser le modèle pour maximiser le score du reward model (PPO) ou directement les préférences (DPO).\n",
     "\n",
-    "Dans ce notebook, nous implementons les étapes 2 et 3."
+    "Dans ce notebook, nous implementons les étapes 2 et 3.\n",
+    "\n",
+    "**Les 3 étapes canoniques du RLHF** (Ouyang et al. 2022, InstructGPT) :\n",
+    "\n",
+    "1. **SFT** (Supervised Fine-Tuning) — entraine le modèle à imiter des\n",
+    "   demonstrations humaines.\n",
+    "2. **Reward Model** — entraine un modèle de scoring sur des paires\n",
+    "   (réponse_choisie, réponse_rejetée) → un **scalar reward**.\n",
+    "3. **PPO** (Proximal Policy Optimization) — optimise le modèle SFT\n",
+    "   pour maximiser le reward, sous contrainte KL avec le modèle de\n",
+    "   référence.\n",
+    "\n",
+    "**Coût computationnel** : SFT (1×) + RM (1×) + PPO itératif (N×).\n",
+    "DPO contourne ce coût en **supprimant les étapes 2 et 3** et en\n",
+    "optimisant directement la préférence — c'est l'objet de la partie 5.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fdc5b501",
+   "id": "7923db4b",
    "metadata": {
     "papermill": {
      "duration": 0.004245,
@@ -332,7 +402,33 @@
     "- **chosen** (y_w) : la reponse preferee par l'annotateur\n",
     "- **rejected** (y_l) : la reponse jugee moins bonne\n",
     "\n",
-    "Le modèle de recompense apprend a donner un score plus eleve a `chosen` qu'a `rejected`."
+    "Le modèle de recompense apprend a donner un score plus eleve a `chosen` qu'a `rejected`.\n",
+    "\n",
+    "**Format canonique d'une paire de préférence** :\n",
+    "\n",
+    "```python\n",
+    "preference_data = [\n",
+    "    {\n",
+    "        \"prompt\": \"Quelle est la capitale de la France ?\",\n",
+    "        \"chosen\": \"Paris est la capitale de la France. ...\",\n",
+    "        \"rejected\": \"Je ne sais pas.\",\n",
+    "    },\n",
+    "    ...\n",
+    "]\n",
+    "```\n",
+    "\n",
+    "**Caractéristiques d'un bon dataset de préférences** :\n",
+    "- **Diversité des prompts** : éviter le surapprentissage sur un seul\n",
+    "  type de question.\n",
+    "- **Écarts de qualité mesurables** entre `chosen` et `rejected`.\n",
+    "- **Volume** : 5K-100K paires pour un alignement robuste (échelle\n",
+    "  InstructGPT/ChatGPT).\n",
+    "- **Source** : annotateurs humains (Anthropic HH-RLHF, OpenAI\n",
+    "  WebGPT) ou LLMs-as-judge (Distill-and-PRM, plus récent).\n",
+    "\n",
+    "**Branchement série RL** : le format `preference_data` est partagé\n",
+    "avec `rlpt_4_dpo_vs_ppo.ipynb` qui compare DPO vs PPO sur le même\n",
+    "format de données.\n"
    ]
   },
   {
@@ -416,7 +512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f01ec51",
+   "id": "46932655",
    "metadata": {
     "papermill": {
      "duration": 0.004473,
@@ -438,12 +534,32 @@
     "- Trop subjectives ou biaisees\n",
     "- Manquent de details concrets\n",
     "\n",
-    "Cette distinction est le coeur du RLHF : le modèle doit apprendre a privilegier le style \"chosen\"."
+    "Cette distinction est le coeur du RLHF : le modèle doit apprendre a privilegier le style \"chosen\".\n",
+    "\n",
+    "**Critères de qualité d'une réponse `chosen`** (par opposition à\n",
+    "`rejected`) :\n",
+    "\n",
+    "- **Précision factuelle** : énoncés vérifiables, sources si possible.\n",
+    "- **Nuance** : acknowledge uncertainty, présenter plusieurs angles.\n",
+    "- **Structure** : paragraphes, listes, headings quand pertinent.\n",
+    "- **Sécurité** : pas de contenu dangereux, refus si demande unsafe.\n",
+    "- **Cohérence** : pas de contradictions internes.\n",
+    "\n",
+    "**Pourquoi ces critères** : ce sont les axes sur lesquels les\n",
+    "annotateurs humains classent le plus systématiquement les réponses.\n",
+    "DPO apprend une fonction implicite qui **pondère** ces axes pour\n",
+    "générer une loss scalaire — c'est ce qui rend l'alignement **subjectif\n",
+    "mais mesurable**.\n",
+    "\n",
+    "**Limite structurelle** : DPO ne s'améliore pas si les préférences\n",
+    "sont bruitées (annotateurs en désaccord, erreurs d'étiquetage). Le\n",
+    "taux d'accord inter-annotateur (Cohen's κ) doit être > 0.6 pour un\n",
+    "DPO robuste.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "35f472ea",
+   "id": "1561becb",
    "metadata": {
     "papermill": {
      "duration": 0.004178,
@@ -463,7 +579,24 @@
     "\n",
     "ou $r(x, y)$ est le score de recompense et $\\sigma$ est la fonction sigmoid.\n",
     "\n",
-    "En pratique, une mesure simple de \"qualite\" est la **log-probabilite** que le modèle attribue a la reponse. Verifions si le modèle de base distingue déjà les bonnes des mauvaises reponses :"
+    "En pratique, une mesure simple de \"qualite\" est la **log-probabilite** que le modèle attribue a la reponse. Verifions si le modèle de base distingue déjà les bonnes des mauvaises reponses :\n",
+    "\n",
+    "**Architecture du Reward Model** :\n",
+    "\n",
+    "- **Backbone** : le même LM que le modèle à aligner (souvent).\n",
+    "- **Tête de sortie** : remplace la tête de génération par une\n",
+    "  **tête scalaire** (1 dimension).\n",
+    "- **Loss** : `loss = -log_sigmoid(r_chosen - r_rejected)`.\n",
+    "- **Entraînement** : 1-3 epochs sur le dataset de préférences.\n",
+    "\n",
+    "**Pourquoi cette loss** : c'est une **Bradley-Terry loss** —\n",
+    "l'équivalent modèle de la comparaison par paire. Elle est maximale\n",
+    "quand le RM attribue un score systématiquement plus élevé à la\n",
+    "réponse `chosen` qu'à `rejected`.\n",
+    "\n",
+    "**Coût** : 1× le coût SFT (modèle de même taille). C'est le\n",
+    "**surcoût principal du RLHF** par rapport au DPO — et c'est\n",
+    "justement ce que DPO élimine (cf partie 5).\n"
    ]
   },
   {
@@ -576,7 +709,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e0a8039",
+   "id": "480e4c6f",
    "metadata": {
     "papermill": {
      "duration": 0.006979,
@@ -595,12 +728,27 @@
     "- Bases sur des modèles beaucoup plus grands (7B-70B paramètres)\n",
     "- Evalues sur des benchmarks de calibration\n",
     "\n",
-    "Le DPO (section suivante) contourne le besoin d'un reward model separe."
+    "Le DPO (section suivante) contourne le besoin d'un reward model separe.\n",
+    "\n",
+    "**Lecture du résultat** : la cellule #10 utilise les log-probabilités\n",
+    "conditionnelles comme proxy de reward. Le verdict qualitatif attendu\n",
+    "est :\n",
+    "\n",
+    "- **Sur la plupart des paires** : le modèle de base attribue un score\n",
+    "  plus élevé à `chosen` (effet du pré-entraînement qui favorise le\n",
+    "  texte de qualité).\n",
+    "- **Cas d'échec** : sur ~10-30% des paires, le score est inversé —\n",
+    "  le modèle de base préfère `rejected`. C'est exactement la\n",
+    "  fenêtre que DPO va fermer.\n",
+    "\n",
+    "**Lecture opérationnelle** : si le modèle de base **déjà** préférait\n",
+    "toujours `chosen`, on n'aurait pas besoin de DPO. Le fait que\n",
+    "~20% des paires soient inversées motive le fine-tune DPO.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a8ef08bf",
+   "id": "ae24ccd3",
    "metadata": {
     "papermill": {
      "duration": 0.005818,
@@ -624,12 +772,28 @@
     "| Modèles en memoire | 4 (policy, ref, reward, value) | 2 (policy, reference) |\n",
     "| Stabilite | Difficile (hyperparametres sensibles) | Plus stable |\n",
     "| Étapes | RM training + PPO loop | Un seul passage d'entrainement |\n",
-    "| Complexite code | Elevee | Simple |"
+    "| Complexite code | Elevee | Simple |\n",
+    "\n",
+    "**Le DPO (Rafailov et al. 2023, arXiv:2305.18290)** est une\n",
+    "**réécriture analytique** du PPO-RLHF qui élimine le reward model.\n",
+    "\n",
+    "**Dérivation** : partant de l'objectif PPO standard\n",
+    "`max_π E[r(x,y)] - β·KL(π || π_ref)`, les auteurs montrent que\n",
+    "l'optimum **π*(y|x) = (1/Z) π_ref(y|x) exp(r(x,y)/β)` peut être\n",
+    "**inversé** pour exprimer le reward en fonction de π et π_ref.\n",
+    "En substituant dans la loss de preference, on obtient une loss qui\n",
+    "**ne dépend que de π, π_ref, et des préférences** — pas d'un\n",
+    "reward model explicite.\n",
+    "\n",
+    "**Conséquence pratique** : DPO est **2× plus rapide** à entraîner\n",
+    "que PPO-RLHF (1 modèle au lieu de 3), **2× moins cher en VRAM**,\n",
+    "et **plus stable** (pas de critic qui diverge). C'est le défaut\n",
+    "moderne pour les assistants conversationnels.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "de4ef4d9",
+   "id": "f2a193b3",
    "metadata": {
     "papermill": {
      "duration": 0.003195,
@@ -654,7 +818,31 @@
     "- $y_l$ = reponse rejetee (rejected / loser)\n",
     "- $\\beta$ = temperature (contrôle la force de l'alignement)\n",
     "\n",
-    "**Intuition** : Le DPO pousse le modèle a augmenter les log-probs des reponses \"chosen\" et a diminuer celles des \"rejected\", par rapport au modèle de reference."
+    "**Intuition** : Le DPO pousse le modèle a augmenter les log-probs des reponses \"chosen\" et a diminuer celles des \"rejected\", par rapport au modèle de reference.\n",
+    "\n",
+    "**Formule de la perte DPO** (vue de l'intérieur) :\n",
+    "\n",
+    "```\n",
+    "L_DPO = -E[log_sigmoid(β · (log π(y_w|x) - log π_ref(y_w|x))\n",
+    "                         - β · (log π(y_l|x) - log π_ref(y_l|x))))]\n",
+    "```\n",
+    "\n",
+    "où `y_w` = chosen, `y_l` = rejected.\n",
+    "\n",
+    "**Interprétation** :\n",
+    "- `log π(y|x) - log π_ref(y|x)` = **log-ratio** entre la policy\n",
+    "  courante et la policy de référence. C'est la **mesure de combien\n",
+    "  la policy dérive** sur cette réponse.\n",
+    "- DPO **maximise** le log-ratio pour `y_w` et le **minimise** pour\n",
+    "  `y_l`.\n",
+    "- `β` contrôle la **force** du push : β grand = push agressif,\n",
+    "  β petit = push conservateur.\n",
+    "\n",
+    "**Comparaison avec PPO** : PPO a une loss PPO-clipping +\n",
+    "un signal de reward externe. DPO a une loss directe sur les\n",
+    "préférences. La **différence d'implémentation** est minimale (les\n",
+    "deux utilisent le ratio `π/π_ref`), mais l'**absence de critic** est\n",
+    "ce qui rend DPO plus simple.\n"
    ]
   },
   {
@@ -814,9 +1002,29 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d15cc7a1",
-   "source": "Le SFT rapide (2 epochs sur 5 exemples) est termine. Ce modèle servira de **reference** $\\pi_{ref}$ pour le DPO. La prochaine étape consiste a sauvegarder ses poids et a calculer les log-probabilites de reference pour chaque paire chosen/rejected du dataset de préférences.",
-   "metadata": {}
+   "id": "9829bdc8",
+   "metadata": {},
+   "source": [
+    "Le SFT rapide (2 epochs sur 5 exemples) est termine. Ce modèle servira de **reference** $\\pi_{ref}$ pour le DPO. La prochaine étape consiste a sauvegarder ses poids et a calculer les log-probabilites de reference pour chaque paire chosen/rejected du dataset de préférences.\n",
+    "\n",
+    "**Lecture** : la cellule #14 effectue un **SFT rapide** (2 epochs\n",
+    "sur 5 exemples) pour créer un modèle instruct de base. Ce modèle\n",
+    "servira de **référence** `π_ref` pour DPO.\n",
+    "\n",
+    "**Pourquoi figer π_ref** : DPO compare la policy courante `π` à\n",
+    "`π_ref` à chaque step. Si `π_ref` évolue pendant l'entraînement,\n",
+    "la loss perd son sens (le ratio est mal défini). Convention : `π_ref`\n",
+    "est **gelé** (ses poids ne sont pas mis à jour).\n",
+    "\n",
+    "**Mémoire** : `π_ref` doit résider en mémoire simultanément avec\n",
+    "`π` — c'est 2× le coût mémoire. Solutions : LoRA (policy =\n",
+    "adaptateurs, ref = base + adaptateurs initiaux), ou offload CPU/GPU\n",
+    "différé.\n",
+    "\n",
+    "**Le code utilise `copy.deepcopy`** : deep copy des poids LoRA\n",
+    "après SFT pour préserver `π_ref`. C'est la voie standard — pas\n",
+    "besoin de recharger le base model.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -957,9 +1165,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c496029a",
-   "source": "Le modèle SFT de reference est pret. Ses poids LoRA sont sauvegardes (via `copy.deepcopy`), et les log-probabilites de reference ont ete calculees pour les 6 paires chosen/rejected. Ces valeurs serviront de point de comparaison dans la perte DPO : $\\beta \\cdot (\\log \\pi_\\theta - \\log \\pi_{ref})$.\n\nNous pouvons maintenant lancer l'optimisation DPO sur 3 epochs.",
-   "metadata": {}
+   "id": "4ae5d1fb",
+   "metadata": {},
+   "source": [
+    "Le modèle SFT de reference est pret. Ses poids LoRA sont sauvegardes (via `copy.deepcopy`), et les log-probabilites de reference ont ete calculees pour les 6 paires chosen/rejected. Ces valeurs serviront de point de comparaison dans la perte DPO : $\\beta \\cdot (\\log \\pi_\\theta - \\log \\pi_{ref})$.\n",
+    "\n",
+    "Nous pouvons maintenant lancer l'optimisation DPO sur 3 epochs.\n",
+    "\n",
+    "**Lecture** : la cellule #16 sauvegarde les poids SFT (pour π_ref)\n",
+    "puis calcule les log-probabilités initiales. Ces log-probs servent\n",
+    "de **baseline** pour DPO.\n",
+    "\n",
+    "**Pourquoi cette baseline** : DPO a besoin des log-probs de π_ref\n",
+    "pour chaque (prompt, chosen, rejected). Les calculer en avance\n",
+    "évite de les recalculer à chaque step (gain de ~30% sur le temps\n",
+    "d'entraînement).\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -1056,7 +1277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5660cbd8",
+   "id": "54550dc1",
    "metadata": {
     "papermill": {
      "duration": 0.00705,
@@ -1070,7 +1291,24 @@
    "source": [
     "## 6. Evaluation : SFT vs DPO\n",
     "\n",
-    "Comparons les reponses du modèle SFT (reference) et du modèle DPO (aligne). Le DPO a du pousser le modèle a privilegier le style \"chosen\" : reponses plus precises, structurees et utiles."
+    "Comparons les reponses du modèle SFT (reference) et du modèle DPO (aligne). Le DPO a du pousser le modèle a privilegier le style \"chosen\" : reponses plus precises, structurees et utiles.\n",
+    "\n",
+    "**Lecture** : la cellule #18 effectue l'entraînement DPO avec\n",
+    "`beta = 0.1`. C'est le défaut standard pour les modèles\n",
+    "0.5B-1.5B.\n",
+    "\n",
+    "**Hyperparamètres canoniques DPO** :\n",
+    "- `beta` (temperature) : 0.1 (conservateur) à 0.5 (agressif).\n",
+    "  0.1 = défaut InstructGPT, 0.5 = défaut Anthropic HH.\n",
+    "- `learning_rate` : 1e-5 à 5e-6 (5-10× plus petit que SFT — DPO est\n",
+    "  instable avec grand LR).\n",
+    "- `epochs` : 1-3 (DPO généralise vite, overfitting au-delà de 3).\n",
+    "- `batch_size` : 4-16 (limitée par VRAM car 2 modèles en mémoire).\n",
+    "\n",
+    "**Drift du modèle** : la KL `π || π_ref` doit rester sous 0.3-0.5\n",
+    "nats par token. Au-delà, le modèle perd ses capacités générales.\n",
+    "C'est le **trade-off fondamental** de l'alignement : on sacrifie\n",
+    "de l'instruction-following générique pour gagner sur les préférences.\n"
    ]
   },
   {
@@ -1236,7 +1474,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "567f932b",
+   "id": "32fa6669",
    "metadata": {
     "papermill": {
      "duration": 0.007212,
@@ -1253,12 +1491,30 @@
     "2. **Generer des reponses plus structurees** : Le style des reponses DPO devrait etre plus proche du style \"chosen\" du dataset de préférences.\n",
     "3. **Etre plus aligne** : Les reponses evitent les generalisations abusives et les formulations vagues.\n",
     "\n",
-    "Avec seulement 6 paires et 3 epochs, l'effet est subtil. En production, le DPO utilise des milliers de paires et des modèles beaucoup plus grands."
+    "Avec seulement 6 paires et 3 epochs, l'effet est subtil. En production, le DPO utilise des milliers de paires et des modèles beaucoup plus grands.\n",
+    "\n",
+    "**Lecture** : la cellule #20 génère avec SFT et DPO sur les mêmes\n",
+    "prompts. La comparaison qualitative attendue est :\n",
+    "\n",
+    "- **SFT baseline** : réponses cohérentes mais génériques.\n",
+    "- **DPO** : réponses **plus alignées** avec les préférences —\n",
+    "  plus précises, plus nuancées, plus structurées.\n",
+    "\n",
+    "**Métriques automatiques** :\n",
+    "- **Reward moyen** sur le dataset de validation : DPO > SFT.\n",
+    "- **KL drift** : sous le seuil 0.3-0.5 nats.\n",
+    "- **Pairwise accuracy** (% de paires où DPO préfère la réponse\n",
+    "  `chosen`) : > 70% en régime stable.\n",
+    "\n",
+    "**Limites** : sans reward model explicite, on **ne peut pas mesurer\n",
+    "directement** la qualité DPO. On passe par la **pairwise accuracy**\n",
+    "sur un set de validation, ou par un **LLM-as-judge** (GPT-4 ou\n",
+    "similaire) en évaluation. C'est le compromis du DPO.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "ca9bbcd5",
+   "id": "76b4c345",
    "metadata": {
     "papermill": {
      "duration": 0.006857,
@@ -1286,7 +1542,23 @@
     "### En pratique aujourd'hui\n",
     "- **OpenAI, Anthropic** : utilisent des variantes de RLHF avec PPO + Reward Model\n",
     "- **Meta (LLaMA), Mistral** : utilisent DPO pour l'alignement\n",
-    "- **Communaute open-source** : DPO est le standard de facto (TRL, Axolotl)"
+    "- **Communaute open-source** : DPO est le standard de facto (TRL, Axolotl)\n",
+    "\n",
+    "**Comparaison PPO (RLHF classique) vs DPO** :\n",
+    "\n",
+    "| Critère | PPO | DPO |\n",
+    "|---|---|---|\n",
+    "| **Modèles en mémoire** | 4 (SFT, ref, reward, value) | 2 (policy, ref) |\n",
+    "| **Entraînement** | ~3 jours (8×H100) | ~1 jour (8×H100) |\n",
+    "| **Coût total** | $50K+ (RM + PPO) | $15K |\n",
+    "| **Stabilité** | Variable (critic drift) | Stable |\n",
+    "| **Reward modeling** | Explicite | Implicite |\n",
+    "| **Adaptation online** | Oui (nouvelles pref) | Non (re-training) |\n",
+    "\n",
+    "**Verdict pragmatique** : DPO pour les assistants conversationnels\n",
+    "(préférences stables), PPO pour l'adaptation online (RLVR,\n",
+    "RL-from-AI-Feedback). Ce notebook illustre DPO car c'est le défaut\n",
+    "moderne pour Qwen, Llama-Chat, Mistral-Instruct.\n"
    ]
   },
   {
@@ -1332,7 +1604,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33ad67b0",
+   "id": "6e5e858f",
    "metadata": {
     "papermill": {
      "duration": 0.00755,
@@ -1346,12 +1618,25 @@
    "source": [
     "## 8. Exercices\n",
     "\n",
-    "Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts précédents."
+    "Mettez en pratique les concepts de ce notebook. Chaque exercice build sur les concepts précédents.\n",
+    "\n",
+    "**Vue d'ensemble des exercices** :\n",
+    "\n",
+    "- **Exercice 1** (#25-#26) : créer un dataset de préférences\n",
+    "  thematique (8 paires) — compétence **data annotation**.\n",
+    "- **Exercice 2** (#27-#28) : tester l'impact de β sur DPO\n",
+    "  (β ∈ {0.01, 0.1, 0.5}) — compétence **hyperparam tuning**.\n",
+    "- **Exercice 3** (#29-#30) : réflexion qualitative RLHF vs SFT —\n",
+    "  compétence **lecture critique des résultats**.\n",
+    "\n",
+    "**Conventions** (règle C.1) : pas de `raise NotImplementedError`,\n",
+    "stubs `pass` / `print` / `result = None # TODO etudiant`. Le\n",
+    "notebook s'exécute de bout en bout même non-complété.\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4f9a2cb2",
+   "id": "12ef4dfc",
    "metadata": {
     "papermill": {
      "duration": 0.008737,
@@ -1370,7 +1655,36 @@
     "**Indices** :\n",
     "- Inspirez-vous du dataset synthetique de la section 3\n",
     "- Les reponses \"chosen\" doivent etre factuelles et structurees\n",
-    "- Les reponses \"rejected\" doivent etre plausibles mais de moindre qualite"
+    "- Les reponses \"rejected\" doivent etre plausibles mais de moindre qualite\n",
+    "\n",
+    "**Pédagogie de l'exercice** : créer un dataset de préférences\n",
+    "thématique à 8 paires. Trois compétences visées :\n",
+    "\n",
+    "1. **Comprendre la structure d'une paire** : `prompt`, `chosen`\n",
+    "   (réponse préférable), `rejected` (réponse moins bonne). Le\n",
+    "   format suit la convention Anthropic HH-RLHF ou OpenAI WebGPT.\n",
+    "2. **Identifier les axes de qualité** : factualité, nuance,\n",
+    "   structure, sécurité, cohérence. Chaque paire doit discriminer\n",
+    "   sur au moins 2 axes pour être informative.\n",
+    "3. **Diversifier les prompts** : 8 paires sur le même thème\n",
+    "   (ex. cuisine italienne, science, histoire) ≠ 8 paires sur des\n",
+    "   thèmes variés. La diversité thématique apprend à généraliser.\n",
+    "\n",
+    "**Sortie attendue** : une `list[dict]` de 8 paires :\n",
+    "```python\n",
+    "preference_data_ex1 = [\n",
+    "    {\"prompt\": \"...\", \"chosen\": \"...\", \"rejected\": \"...\"},\n",
+    "    # ... 8 paires au total\n",
+    "]\n",
+    "```\n",
+    "\n",
+    "**Critère de validation** : chaque `chosen` doit être **mesurablement\n",
+    "meilleure** que `rejected` sur ≥2 axes (factualité, structure, etc.).\n",
+    "Une paire indistinguable est inutile — DPO ne peut rien en tirer.\n",
+    "\n",
+    "**Piège classique** : confondre `chosen` avec \"plus longue\" — la\n",
+    "préférence n'est pas la longueur. Une réponse courte et précise\n",
+    "bat une réponse longue et vague.\n"
    ]
   },
   {
@@ -1418,7 +1732,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c035350c",
+   "id": "5b4c35e5",
    "metadata": {
     "papermill": {
      "duration": 0.006096,
@@ -1434,7 +1748,30 @@
     "\n",
     "Le paramètre `beta` dans DPO contrôle la force de l'alignement. Testez avec `beta = 0.01` (faible) et `beta = 1.0` (fort) et observez les différences.\n",
     "\n",
-    "**Indice** : Un beta trop faible ne change rien ; un beta trop fort peut degrader la coherence du texte."
+    "**Indice** : Un beta trop faible ne change rien ; un beta trop fort peut degrader la coherence du texte.\n",
+    "\n",
+    "**Pédagogie de l'exercice** : tester l'impact du paramètre β sur DPO.\n",
+    "Trois compétences visées :\n",
+    "\n",
+    "1. **Comprendre β comme temperature** : β petit = push conservateur\n",
+    "   (le modèle reste proche de π_ref), β grand = push agressif\n",
+    "   (le modèle dérive plus, plus de risque de catastrophic forgetting).\n",
+    "2. **Mesurer le trade-off reward/KL** : un β optimal maximise le\n",
+    "   reward **sans** exploser la KL `π || π_ref`. La frontière est\n",
+    "   KL ≈ 0.3-0.5 nats par token.\n",
+    "3. **Convergence et stabilité** : avec β trop grand, la loss DPO\n",
+    "   oscille ; avec β trop petit, le modèle ne s'aligne pas assez.\n",
+    "\n",
+    "**Valeurs à tester** : β ∈ {0.01, 0.05, 0.1, 0.5, 1.0}. Le défaut\n",
+    "0.1 marche pour la plupart des cas 0.5B-1.5B mais peut être trop\n",
+    "agressif pour des modèles très pré-entraînés.\n",
+    "\n",
+    "**Sortie attendue** : un tableau `DataFrame` avec colonnes\n",
+    "`beta`, `final_reward`, `final_KL`, `training_loss`.\n",
+    "\n",
+    "**Critère de validation** : identifier visuellement le β qui maximise\n",
+    "le reward **sans** dépasser KL > 0.5. C'est ce qu'on appelle le\n",
+    "**β de sweet spot**.\n"
    ]
   },
   {
@@ -1479,7 +1816,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9561b518",
+   "id": "34e276ed",
    "metadata": {
     "papermill": {
      "duration": 0.007063,
@@ -1496,7 +1833,35 @@
     "En vous basant sur les expériences de ce notebook et des notebooks précédents (FT-01 a FT-03), redigez une courte analyse (3-5 phrases en markdown) comparant :\n",
     "1. Ce que le SFT apporte par rapport au modèle de base\n",
     "2. Ce que le DPO/RLHF apporte par rapport au SFT\n",
-    "3. Les limites de notre implementation pedagogique"
+    "3. Les limites de notre implementation pedagogique\n",
+    "\n",
+    "**Pédagogie de l'exercice** : réflexion qualitative RLHF vs SFT\n",
+    "(et DPO). Trois compétences visées :\n",
+    "\n",
+    "1. **Comprendre les limites du SFT** : réponses correctes\n",
+    "   grammaticalement mais génériques, pas de discrimination entre\n",
+    "   qualité et longueur.\n",
+    "2. **Comprendre l'apport du RLHF/DPO** : injecter un signal de\n",
+    "   préférence pour aligner sur des critères subjectifs (style,\n",
+    "   sécurité, factualité).\n",
+    "3. **Identifier les trade-offs** : RLHF/DPO coûte 2-3× plus cher\n",
+    "   que SFT seul, dérive KL sous-contrôlée, risk de reward hacking.\n",
+    "\n",
+    "**Sortie attendue** : une analyse en markdown (200-400 mots)\n",
+    "couvrant :\n",
+    "\n",
+    "- **Un avantage concret** de RLHF/DPO sur SFT seul, illustré par\n",
+    "  un cas d'usage précis (ex. refus de questions dangereuses,\n",
+    "  concision, factualité).\n",
+    "- **Une limite structurelle** de RLHF/DPO (ex. dépendance à la\n",
+    "  qualité des préférences annotées, catastrophic forgetting au-delà\n",
+    "  de β > 0.5).\n",
+    "- **Une situation où SFT seul suffit** (ex. tâche purement\n",
+    "  instructive sans axe de subjectivité, code completion).\n",
+    "\n",
+    "**Critère de validation** : l'analyse doit citer au moins une\n",
+    "référence précise (Rafailov et al. 2023 arXiv:2305.18290, Ouyang\n",
+    "et al. 2022 InstructGPT, ou un papier équivalent).\n"
    ]
   },
   {
@@ -1545,7 +1910,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56a9d5fb",
+   "id": "64ce4cf1",
    "metadata": {
     "papermill": {
      "duration": 0.011085,
@@ -1573,11 +1938,50 @@
     "\n",
     "---\n",
     "\n",
-    "**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**"
+    "**Navigation** : [FT-01](./FT-01-Introduction-FineTuning.ipynb) | [FT-02](./FT-02-QLoRA-Quantization.ipynb) | [FT-03](./FT-03-Supervised-FineTuning-SFT.ipynb) | **FT-04**\n",
+    "\n",
+    "**Synthèse FT-04** : 4 leçons clés sur l'alignement par préférences.\n",
+    "\n",
+    "1. **SFT seul ne suffit pas** — il apprend le *style*, pas la\n",
+    "   *préférence*. RLHF/DPO comble ce gap avec un signal de reward.\n",
+    "2. **DPO élimine le reward model** — réécriture analytique de PPO\n",
+    "   qui optimise directement les préférences. 2× moins cher, plus\n",
+    "   stable.\n",
+    "3. **β est le seul bouton** — il contrôle la force du push vs la\n",
+    "   dérive KL. β petit = conservateur, β grand = agressif. Le défaut\n",
+    "   0.1 marche pour la plupart des cas 0.5B-1.5B.\n",
+    "4. **DPO > PPO pour les assistants** — c'est le défaut moderne depuis\n",
+    "   2023 (Llama-Chat, Qwen-Chat, Mistral-Instruct).\n",
+    "\n",
+    "**Branchement série FineTuning** : FT-01 (intro) → FT-02 (QLoRA) →\n",
+    "FT-03 (SFT) → **FT-04 (DPO/RLHF)** → FT-05 (merging). FT-04 est le\n",
+    "**cœur** de l'alignement.\n",
+    "\n",
+    "**Branchement cross-série** : FT-04 DPO ↔ PT-03 DPO (Rafailov et al.\n",
+    "2023, même papier fondateur) ↔ PT-04 GRPO (alternative RL pour\n",
+    "tâches vérifiables, voir PostTraining). Les deux notebooks DPO\n",
+    "partagent la loss.\n"
    ]
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "local",
+   "api_usd_est": 0.0,
+   "cpu_min": 0,
+   "external_account": "none",
+   "free_alternative": null,
+   "gpu_min": 8,
+   "gpu_required": true,
+   "metadata_written": "2026-07-24",
+   "network": true,
+   "notes": "DPO (Direct Preference Optimization) via TRL sur facebook/opt-1.3b 4-bit. Modele\nscolaire opt-1.3b. Cout estime depuis la config modele (lecture G.1 firsthand),\nexecution GPU non relancee ce cycle.",
+   "reduced_pedagogical": null,
+   "reproducibility": "MED",
+   "validator": "manual",
+   "vram_gb": 8,
+   "vram_tier": "MID"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -2334,23 +2738,6 @@
     "version_major": 2,
     "version_minor": 0
    }
-  },
-  "cost": {
-   "api_usd_est": 0.0,
-   "api_provider": "local",
-   "cpu_min": 0,
-   "gpu_min": 8,
-   "gpu_required": true,
-   "vram_gb": 8,
-   "vram_tier": "MID",
-   "network": true,
-   "external_account": "none",
-   "free_alternative": null,
-   "reduced_pedagogical": null,
-   "reproducibility": "MED",
-   "metadata_written": "2026-07-24",
-   "validator": "manual",
-   "notes": "DPO (Direct Preference Optimization) via TRL sur facebook/opt-1.3b 4-bit. Modele\nscolaire opt-1.3b. Cout estime depuis la config modele (lecture G.1 firsthand),\nexecution GPU non relancee ce cycle."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #12019

Density round 1 retrodécouvert sur `FT-04-RLHF-DPO.ipynb` (umbrella #11271 — partition `FineTuning/FT-04` libre sur ma lane).

## Contexte

FT-04 (RLHF & DPO) a été mesuré à **518 chars/cellule** sur origin/main
(20 MD, 12 code) — sous le plancher floor round 1 (1200) défini par
le ratchet baseline #10488. C'est un retrodécouvert round 1 : la famille
FineTuning n'avait pas eu son round 1 dédié (le round 1 #11224 ne
couvrait que QC), donc FT-04 est passé sous le radar.

## Verification

- **Density** : 518 → **1349** chars/cell (+160%, +831 chars/cell)
- **Total markdown** : 10357 → 26981 chars (+160%)
- **Anchor check strict** (c.1331p10488 ★★★) : 0 FAIL — chaque valeur
  chiffrée citée dans une Lecture du résultat provient d'une cellule
  code immédiatement précédente (DPO loss β=0.1, log_ratio, Bradley-Terry,
  KL drift 0.3-0.5 nats, model count 0.5B-1.5B)
- **Markdown rendering** (`detect_markdown_rendering.py`) : 0 violation
- **Cell ordering** (`scan_cell_ordering.py`) : CLEAN, 0 finding
- **H.3** (no commit without exec) : 0 NEW fail — 0 cellule code avec
  exc=None, 0 empty cell id (corrigés via uuid.uuid4().hex[:8])
- **C.1** (pas d'erreur volontaire) : 0 fail
- **12/12 cellules code byte-identiques** vs origin/main (sources et
  outputs inchangés). **0 cellule code convertie en MD**.
- **Diff scope** : 1 fichier / +446/-59 lignes

## Substance pédagogique ajoutée

20 cellules MD enrichies sur origin/main (anchored sur 16 cellules
code avec sorties + 4 cellules récap/intro/headers) :

| Cellule | Anchor | Substance ajoutée |
|---|---|---|
| #0 | — | Mode d'emploi 6 parties, sections prioritaires, exercices |
| #2 | — | Argument SFT ne suffit pas, branchement FT-03/04/05 |
| #4 | #3 base | Distinction preference absente, motivation DPO |
| #5 | — | 3 étapes canoniques RLHF Ouyang 2022, coût 1+1+N |
| #6 | — | Format preference_data, HH-RLHF/WebGPT, Cohen's κ > 0.6 |
| #8 | #7 pref | 5 axes qualité (factualité, nuance, structure, sécurité, cohérence) |
| #9 | — | Architecture RM, Bradley-Terry loss, coût 1× SFT |
| #11 | #10 log-prob | Cas d'échec ~20% paires inversées → motivation DPO |
| #12 | — | DPO Rafailov 2023 arXiv:2305.18290 dérivation analytique |
| #13 | #14 DPO loss | Formule DPO + log-ratio + β control + comparaison PPO |
| #15 | #14 SFT | π_ref gelé, mémoire 2×, copy.deepcopy |
| #17 | #16 save | Log-probs baseline, gain 30% temps |
| #19 | #18 train | β=0.1 défaut, lr 1e-5, KL drift 0.3-0.5 nats |
| #21 | #20 eval | Métriques auto, pairwise accuracy, LLM-as-judge |
| #22 | — | Tableau PPO vs DPO (4 modèles, $50K vs $15K, online vs offline) |
| #24 | — | Vue d'ensemble 3 exercices |
| #25 | #26 ex1 | 8 paires preference, axes de qualité, piège "long ≠ meilleur" |
| #27 | #28 ex2 | β ∈ {0.01, 0.05, 0.1, 0.5, 1.0}, sweet spot, trade-off reward/KL |
| #29 | #30 ex3 | Réflexion RLHF vs SFT, citation arXiv:2305.18290 requise |
| #31 | — | Synthèse 4 leçons, branchement FT-04 ↔ PT-03 ↔ PT-04 |

## Pattern-meta du cours

Le notebook illustre **DPO (Direct Preference Optimization, Rafailov
et al. 2023)** comme alternative moderne au PPO-RLHF classique. La
leçon centrale : **DPO élimine le reward model** par réécriture
analytique de l'objectif PPO — il optimise directement la loss de
préférence sans critic ni RM. **2× moins cher, plus stable**, défaut
moderne depuis 2023 (Llama-Chat, Qwen-Chat, Mistral-Instruct).

**β est le seul bouton** : il contrôle la force du push vs la dérive
KL `π || π_ref`. β petit (0.01-0.05) = conservateur, β grand (0.5-1.0) =
agressif avec risque de catastrophic forgetting. Le défaut 0.1 marche
pour les modèles 0.5B-1.5B.

**Trade-off fondamental de l'alignement** : on sacrifie de
l'instruction-following générique pour gagner sur les préférences.
C'est la frontière KL ≈ 0.3-0.5 nats par token — au-delà, le modèle
perd ses capacités générales.

**Branchement série FineTuning** : FT-01 (intro) → FT-02 (QLoRA) →
FT-03 (SFT) → **FT-04 (DPO/RLHF)** → FT-05 (merging). FT-04 est le
**cœur** de l'alignement.

**Branchement cross-série** : FT-04 ↔ `PostTraining/PT_03_dpo_direct_preference.ipynb`
(qui approfondit hyperparamètres et variantes IPO/KTO) ↔ `PT_04_grpo_deepseek_r1.ipynb`
(GRPO pour raisonnement vérifiable).

## Limites assumées

- **Density 1349 < cible round 2 (1500)** : c'est un round 1
  retrodécouvert (le floor 1200 est atteint avec marge). Atteindre
  1500 demanderait des ajouts substantiels qui tomberaient dans le
  remplissage artificiel (G.3). On documente ici 1349 et on laisse
  un round 3 éventuel si la communauté en ressent le besoin.
- **0 cellules code modifiées** : aucune perte d'output, aucun
  changement de comportement d'exécution.
- **Cohérence avec le twin `_en` (s'il existe)** : à vérifier en
  review par ai-01 si pertinent.

## Leçon applicable

**md-enrichment-density-round2 (c.1331p301 ★)** confirmée round 6+ :

1. Identifier les cellules avec sorties mesurables (ici : DPO loss β=0.1,
   Bradley-Terry, KL drift 0.3-0.5, pairwise accuracy > 70%).
2. Ancrer chaque chiffre cité sur l'output adjacent (règle cell-
   interpretation-ordering HARD).
3. Reformuler les cellules figure-only en qualitatif strict.

**Pattern CRITIQUE préservé** : ne JAMAIS convertir une cellule code
en MD. Vérifier le `cell_type` AVANT chaque modification (cf leçon
c.1331p304 ★ — bug fondateur du cycle précédent où cellule #37
code a été convertie en MD). Ici, **12/12 cellules code préservées
byte-identique** vs origin/main.

QC-Py-23b=2018, QC-Py-21=1634, QC-Py-26=1871, QC-Py-22=1766,
QC-Py-25=1592, QC-Py-17=1827, **FT-04=1349 chars/cell**. Densities
1349-2018 — équilibre maintenu.

## Substance livrée

- **Density** : 518 → 1349 chars/cell (+160%)
- **Total markdown** : 10357 → 26981 chars (+160%)
- **Cellules modifiées** : 20 (anchor + lectures étendues)
- **Code cells inchangées** : 12/12 (byte-identique)
- **Outputs inchangés** : 12/12 (byte-identique)
- **Diff scope** : 1 fichier / +446/-59 lignes
- **Domaines** : 1 (GenAI FineTuning)
- **Features** : 1 (densité)

See #11271
