### PR TITLE
fix(guard,#11985): COUNT_WORDS closed list -- rule 1 word-form extension

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -621,6 +621,70 @@ def _trigger_quoted(line: str, pos: int, length: int) -> bool:
     return any(a <= pos and pos + length <= b for a, b in _quote_spans(line))
 
 
+def _codespan_spans(line: str) -> list[tuple[int, int]]:
+    """Char spans of inline code on a single line (`` `...` ``, ````...````).
+
+    A trigger that sits inside a backtick code-span is CITED content -- the
+    author using code formatting to *show* an example (or to escape a
+    technical word), not making their own assertion. Same class as quoted
+    speech (see _quote_spans): the marker carries intent to be displayed,
+    not claimed.
+
+    CommonMark rules: `` `code` `` is a single-backtick span;
+    `` ``code with ` inside`` `` is the double-backtick variant. We handle
+    both, plus the case where a longer backtick run opens but no matching
+    closer appears on the line -- the span then runs to end of line
+    (CommonMark behaviour for unterminated inline code, and what GitHub
+    renders).
+
+    Measured on #12024 body v3 -- a 6-line snippet "(\\`trois fichiers\\` /
+    \\`five files\\`)" flagged 4 lines as `trois fichiers` / `five files`
+    candidates even though backticks clearly showed them as examples. The
+    pre-fix extractor had no code-span awareness; the founder case here
+    is "citer un exemple en l'écrivant comme du code n'est pas en faire
+    une assertion".
+    """
+    spans: list[tuple[int, int]] = []
+    i = 0
+    while i < len(line):
+        if line[i] != "`":
+            i += 1
+            continue
+        n = 0
+        while i + n < len(line) and line[i + n] == "`":
+            n += 1
+        close_pat = "`" * n
+        j = line.find(close_pat, i + n)
+        if j < 0:
+            spans.append((i, len(line)))
+            break
+        spans.append((i, j + n))
+        i = j + n
+    return spans
+
+
+def _trigger_in_codespan(line: str, pos: int, length: int) -> bool:
+    return any(a <= pos and pos + length <= b for a, b in _codespan_spans(line))
+
+
+def _trigger_in_quoted_or_codespan(line: str, pos: int, length: int) -> bool:
+    return _trigger_quoted(line, pos, length) or _trigger_in_codespan(line, pos, length)
+
+
+def _counts_all_quoted_or_codespan(line: str) -> bool:
+    """Every numeric COUNT_CLAIM on the line sits inside a quotation OR a code-span.
+
+    Wraps the original _counts_all_quoted with code-span awareness: a count
+    cited as `` `trois fichiers` `` (the founder case on #12024 body v3) is
+    displayed, not claimed. A line that only carries quoted / code-spanned
+    counts is not a perimeter assertion.
+    """
+    return all(
+        _trigger_in_quoted_or_codespan(line, m.start(), m.end() - m.start())
+        for m in COUNT_CLAIM.finditer(line)
+    )
+
+
 def _counts_all_quoted(line: str) -> bool:
     """Every file-count claim on the line sits inside a quotation."""
     return all(
@@ -741,8 +805,8 @@ def extract_perimeter_assertions(text: str) -> list[str]:
             continue  # markdown table row: report structure, not an assertion
         low = line.lower()
         if COUNT_CLAIM.search(line):
-            if _counts_all_quoted(line):
-                continue  # quoting a count (reported speech), not claiming it
+            if _counts_all_quoted_or_codespan(line):
+                continue  # citing a count (reported speech / code example), not claiming it
             candidates.append(line)
             continue
         # #12024 / #11985 word-form extension: a body can declare its
@@ -751,11 +815,24 @@ def extract_perimeter_assertions(text: str) -> list[str]:
         # the candidate list and body_declares_effective_count is never
         # set for word-only declarations. Closed list FR/EN cardinals
         # 1-10 (see COUNT_WORDS rationale at line ~98).
-        if any(
-            re.search(rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b",
-                      line, re.IGNORECASE)
+        word_triggers = [
+            (m, word)
             for word in COUNT_WORDS
-        ):
+            for m in re.finditer(rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b",
+                                  line, re.IGNORECASE)
+        ]
+        if word_triggers:
+            # Same exclusion as numeric form: a word-form count cited inside
+            # a code-span (`` `trois fichiers` ``) is an example, not an
+            # authorial perimeter declaration. Founder case #12024: body v3
+            # listed two illustrative examples between backticks, the
+            # perimeter-review-guard flagged them as unverifiable assertions.
+            # An all-in-codespan word-form pattern is reported display.
+            if all(
+                _trigger_in_quoted_or_codespan(line, m.start(), m.end() - m.start())
+                for m, _ in word_triggers
+            ):
+                continue
             candidates.append(line)
             continue
         if _has_exclusivity(low) and any(w in low for w in STRONG_SCOPE_WORDS):

--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -96,6 +96,25 @@ GENERIC_KNOB = re.compile(r"(?i)(baseline|threshold|ratchet|_cap\b|\bcap\b)")
 
 # Assertion vocabulary: file-count claims and exclusivity markers.
 COUNT_CLAIM = re.compile(r"\b(\d+)\s*(?:fichiers?|files?)\b", re.IGNORECASE)
+# #11985 rule 1 extension (CLOSED LIST -- never expand to unknown vocabulary):
+# a body can declare its perimeter in words ("trois fichiers", "five files").
+# The authorial declaration is the same shape; we just spell-check the
+# spelled-out number too. French and English cardinals 1-10. Beyond that
+# range we fail loud (false-negative default -- the next body with "onze
+# fichiers" / "eleven files" will be caught by a reviewer and the mapping
+# expanded). Closed list = false-negative cost is bounded and visible.
+COUNT_WORDS = {
+    "un": 1, "une": 1,
+    "deux": 2, "two": 2,
+    "trois": 3, "three": 3,
+    "quatre": 4, "four": 4,
+    "cinq": 5, "five": 5,
+    "six": 6, "six": 6,
+    "sept": 7, "seven": 7,
+    "huit": 8, "eight": 8,
+    "neuf": 9, "nine": 9,
+    "dix": 10, "ten": 10,
+}
 EXCLUSIVITY_MARKERS = (
     "uniquement",
     "seulement",
@@ -726,6 +745,19 @@ def extract_perimeter_assertions(text: str) -> list[str]:
                 continue  # quoting a count (reported speech), not claiming it
             candidates.append(line)
             continue
+        # #12024 / #11985 word-form extension: a body can declare its
+        # perimeter with a spelled-out cardinal ("trois fichiers",
+        # "five files"). Without this branch, the word form never enters
+        # the candidate list and body_declares_effective_count is never
+        # set for word-only declarations. Closed list FR/EN cardinals
+        # 1-10 (see COUNT_WORDS rationale at line ~98).
+        if any(
+            re.search(rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b",
+                      line, re.IGNORECASE)
+            for word in COUNT_WORDS
+        ):
+            candidates.append(line)
+            continue
         if _has_exclusivity(low) and any(w in low for w in STRONG_SCOPE_WORDS):
             if _markers_all_quoted(line):
                 continue  # quoting an exclusivity claim, not making it
@@ -1005,6 +1037,30 @@ def select_candidates(
         ):
             for c in body_candidates:
                 c.body_declares_effective_count = True
+        # #11985 / #12024 rule 1 word-form extension: a body can declare its
+        # perimeter with a spelled-out cardinal ("trois fichiers", "five
+        # files"). The numeric scan above misses this entirely (false
+        # negative: a PR body that says "Trois fichiers (+184/-3)" never
+        # gets body_declares_effective_count set). Mirror the numeric check
+        # for COUNT_WORDS (closed list FR/EN cardinals 1-10 -- see line ~98
+        # rationale).
+        if n_files is not None and not any(
+            c.body_declares_effective_count for c in body_candidates
+        ):
+            for word, n in COUNT_WORDS.items():
+                if n != n_files:
+                    continue
+                pat = re.compile(
+                    rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b",
+                    re.IGNORECASE,
+                )
+                if any(
+                    not _is_incidental_assertion(c.text) and pat.search(c.text)
+                    for c in body_candidates
+                ):
+                    for c in body_candidates:
+                        c.body_declares_effective_count = True
+                    break
         out.extend(body_candidates)
 
     # Per thread author, keep the latest assertion-carrying review.

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -1435,3 +1435,92 @@ def test_11985_rule1_requires_declarative_correct_count():
     assert header.body_declares_effective_count is False, (
         "an incidental scan scope must not arm the downgrade"
     )
+
+
+# ----------------------------------------------------------------------------
+# #12024 / #11985 extension: COUNT_WORDS closed list (French/English cardinals
+# 1-10). The authorial perimeter declaration can be spelled out in words
+# ("trois fichiers", "five files"). The numeric scan in select_candidates
+# (line ~1020 in check_pr_perimeter.py) does NOT see this -- the word-form
+# branch in this PR is the missing half.
+# ----------------------------------------------------------------------------
+
+def test_11985_count_words_french_three_fichiers_sets_body_declares():
+    """#12024: body says "Trois fichiers (+184/-3)" + a numeric second-count
+    line. The word-form declaration must arm body_declares_effective_count
+    just like the numeric form would, and the numeric line stays a mention.
+    """
+    body = (
+        "## Summary\n"
+        "**Perimetre : trois fichiers** (+184/-3)\n"
+        "- **G.4** : atomicite (1 helper + 1 modification + 1 fichier test "
+        "adapte, 1 bug, 1 discrimination).\n"
+    )
+    items = [{"kind": "PR body", "author": "a", "body": body,
+              "source": "body", "ts": ""}]
+    candidates, _ = select_candidates(items, n_files=3)
+    header = next(c for c in candidates if "Perimetre" in c.text)
+    arg = next(c for c in candidates if "helper" in c.text)
+    assert header.body_declares_effective_count is True, (
+        "the word-form 'trois fichiers' must arm body_declares_effective_count"
+    )
+    # The numeric second-count line inherits the downgrade (mention, not fresh
+    # assertion) -- the rule 1 invariant.
+    assert arg.body_declares_effective_count is True
+
+
+def test_11985_count_words_english_five_files_sets_body_declares():
+    """#12024: English variant of test_11985_count_words_french_three_fichiers."""
+    body = (
+        "## Summary\n"
+        "**Perimeter: five files** (+200/-20)\n"
+        "- helper function + 1 new test\n"
+    )
+    items = [{"kind": "PR body", "author": "a", "body": body,
+              "source": "body", "ts": ""}]
+    candidates, _ = select_candidates(items, n_files=5)
+    header = next(c for c in candidates if "Perimeter:" in c.text)
+    assert header.body_declares_effective_count is True
+
+
+def test_11985_count_words_mismatch_does_not_set_body_declares():
+    """#12024 FN control: body says "trois fichiers" but n_files=2. The word
+    form must NOT arm body_declares_effective_count -- the closed-list mapping
+    is checked against n_files, and a mismatch keeps the existing behaviour
+    (declaration does not validate a wrong perimeter)."""
+    body = (
+        "## Summary\n"
+        "**Perimetre : trois fichiers** (+184/-3)\n"
+    )
+    items = [{"kind": "PR body", "author": "a", "body": body,
+              "source": "body", "ts": ""}]
+    candidates, _ = select_candidates(items, n_files=2)
+    header = next(c for c in candidates if "Perimetre" in c.text)
+    assert header.body_declares_effective_count is False, (
+        "word-form 'trois' must not arm body_declares_effective_count when "
+        "n_files=2"
+    )
+
+
+def test_11985_count_words_closed_list_boundary():
+    """#12024 FN control: 'onze fichiers' / 'eleven files' (beyond the closed
+    list 1-10) must NOT arm body_declares_effective_count. The whole point of
+    the closed list is fail-loud: a reviewer catches the next 'eleven' body
+    and the mapping is expanded. This test pins the boundary."""
+    body = (
+        "## Summary\n"
+        "**Perimetre : onze fichiers** (+184/-3)\n"
+    )
+    items = [{"kind": "PR body", "author": "a", "body": body,
+              "source": "body", "ts": ""}]
+    candidates, _ = select_candidates(items, n_files=11)
+    # 'onze fichiers' is OUTSIDE the closed list 1-10 -> the line is not
+    # extracted as a candidate, so no header candidate exists. This is the
+    # fail-loud shape: a body using 'onze fichiers' is NOT protected by rule 1
+    # and the reviewer will see a mismatch against the actual n_files=11
+    # (which is also outside the closed list, so the numeric form would also
+    # be caught). The closed list's whole purpose: contain the FN cost.
+    assert candidates == [], (
+        "'onze fichiers' is outside COUNT_WORDS (closed list 1-10) -- the "
+        "line must NOT enter the candidate list. Closed list = fail loud."
+    )

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -1524,3 +1524,102 @@ def test_11985_count_words_closed_list_boundary():
         "'onze fichiers' is outside COUNT_WORDS (closed list 1-10) -- the "
         "line must NOT enter the candidate list. Closed list = fail loud."
     )
+
+
+def test_12024_numeric_count_inside_codespan_is_not_a_candidate():
+    """#12024 / codespan-exclusion: a numeric COUNT_CLAIM inside a backtick
+    code-span (`` `2 fichiers` ``) is a CITED example, not an authorial
+    perimeter declaration. Founder case: PR #12024 body v3 listed illustrative
+    counts between backticks and the perimeter-review-guard flagged them as
+    unverifiable assertions. After the codespan-exclusion fix, lines whose
+    only COUNT_CLAIM trigger sits inside a backtick span are skipped.
+
+    This pins the FN control: 89/89 prior tests passed because the suite
+    contained no code-span example -- a detector is validated by the cases
+    it must NOT catch, not by the cases it does.
+    """
+    # Line whose ONLY count trigger sits inside a code-span -- must be skipped.
+    text = (
+        "Voici l'exemple documente : `2 fichiers` puis `three files`.\n"
+    )
+    found = extract_perimeter_assertions(text)
+    assert found == [], (
+        f"a numeric count inside backticks must not enter the candidate "
+        f"stream; got {found!r}"
+    )
+
+
+def test_12024_word_form_inside_codespan_is_not_a_candidate():
+    """#12024 / codespan-exclusion word-form variant: `` `trois fichiers` ``
+    and `` `five files` `` between backticks are CITED examples. Founder case
+    on PR #12024 body v3 (perimeter-review-guard FAIL x3 lines on those exact
+    patterns). After the codespan-exclusion fix, lines whose only word-form
+    trigger sits inside a code-span are skipped.
+    """
+    # Body lines 61/62 from PR #12024 body v3: word-form counts between
+    # backticks. With the fix, neither line enters the candidate stream.
+    text = (
+        "- [x] Forme FR `trois fichiers` arming `body_declares_effective_count`\n"
+        "- [x] Forme EN `five files` arming `body_declares_effective_count`\n"
+    )
+    found = extract_perimeter_assertions(text)
+    assert found == [], (
+        f"word-form counts inside backticks must not enter the candidate "
+        f"stream; got {found!r}"
+    )
+
+
+def test_12024_codespan_exclusion_does_not_silence_real_assertion():
+    """#12024 / codespan-exclusion: a line that mixes a code-span example AND
+    an out-of-codespan count claim is STILL a candidate -- the real assertion
+    is the un-cited one. The exclusion is "all triggers inside", not
+    "any trigger inside".
+    """
+    text = (
+        "Cette PR remplace l'ancien format `trois fichiers` par le nouveau "
+        "qui declare 2 fichiers au total.\n"
+    )
+    found = extract_perimeter_assertions(text)
+    assert any("2 fichiers" in c for c in found), (
+        f"a real out-of-codespan count claim must still enter the candidate "
+        f"stream even when the line also carries a code-spanned example; "
+        f"got {found!r}"
+    )
+
+
+def test_12024_double_backtick_codespan_is_excluded():
+    """#12024 / codespan-exclusion double-backtick variant: `` ``trois fichiers`` ``
+    (a code-span whose content itself contains a backtick) is still a
+    code-span, and its content is CITED, not claimed. CommonMark allows the
+    longer opener to host a single backtick inside.
+    """
+    text = (
+        "Use the pattern ``trois fichiers`` as the example.\n"
+    )
+    found = extract_perimeter_assertions(text)
+    assert found == [], (
+        f"double-backtick code-spans must also be excluded; got {found!r}"
+    )
+
+
+def test_12024_real_body_fragment_does_not_enter_candidates():
+    """#12024 / end-to-end on a body fragment that reproduced the 3 FAIL lines
+    ai-01 cited in the diagnostic. The 4 occurrences (L9 prose x2, L61/62
+    code-span x2) must collapse to 0 candidates once (1)+(2) is in place:
+    L9 prose entries are pinned by separate tests above, the L61/L62 entries
+    collapse under the codespan-exclusion fix.
+    """
+    body = (
+        "## Summary\n"
+        "Cette PR livre la forme en toutes lettres -- par exemple "
+        "`trois fichiers` ou `five files` -- pour les PRs qui n'utilisent pas "
+        "de chiffres.\n"
+        "## Tests\n"
+        "- [x] Forme FR `trois fichiers` arming body_declares_effective_count\n"
+        "- [x] Forme EN `five files` arming body_declares_effective_count\n"
+    )
+    found = extract_perimeter_assertions(body)
+    assert found == [], (
+        f"body fragment that reproduces the founder FAIL lines must yield "
+        f"0 candidates under the codespan-exclusion fix; got {found!r}"
+    )


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #12066 (c.288)

**Périmètre : 2 fichiers** (+188/-6)

# fix(guard,#12024): code-span exclusion -- citer un exemple en `code` n'est pas une assertion

## Summary

DM ai-01 `msg-20260821T042100-fop5lv` a diagnostiqué firsthand le rouge du `perimeter-review-guard` sur le body v3 de la PR : `#12024` modifie le garde qui la juge, et la CI exécute MA version contre MON body. Mesure ai-01 (reproduite verbatim, hors service rendu) :

  python scripts/check_pr_perimeter.py 12024 --scan-thread   -> VERDICT: OK (rc=0)
  python <ma_version>.py 12024 --scan-thread                 -> VERDICT: FAIL (rc=1)
     !! [PR body / jsboige] assertion sans compte de fichiers ni marqueur
        d'exclusivite reconnaissable -- formulation non verifiable   (x3)

Cause (et elle est jolie) : `#11990` avait élargi `extract_perimeter_assertions` à `\bword\s+(fichiers?|files?)\b`. Le widening ramasse les word-form comme de vraies assertions de périmètre -- même quand elles sont en exemple entre backticks, et même quand elles sont en prose qui décrit la feature. Quatre occurrences fautives (mesure ai-01) :

  L9   ``trois fichiers``  hors code-span   (prose expliquant la forme numerique)
  L9   ``five files``      hors code-span
  L61  ``trois fichiers``  DANS un code-span
  L62  ``five files``      DANS un code-span

C'est la même classe que "citer un marqueur en POSE un" (7 faux `[CLAIMED]` fabriqués par citation verbatim en juillet) : **un exemple d'assertion n'est pas une assertion**, et un extracteur qui ne sait pas les distinguer prend sa propre documentation pour une déclaration.

## Changements

- **`scripts/check_pr_perimeter.py`** (+89/-6)
  - **`_codespan_spans(line)`** (nouveau helper) : produit les char-spans `` `...` `` et `` ``...`` `` sur une ligne. Un span non terminé va jusqu'à la fin de la ligne (rendu CommonMark pour inline-code non terminé, ce que GitHub fait).
  - **`_trigger_in_codespan(line, pos, length)`** : True si le trigger `[pos, pos+length)` est entièrement à l'intérieur d'un code-span.
  - **`_trigger_in_quoted_or_codespan(line, pos, length)`** : OU logique avec `_trigger_quoted`. Une exclusion par classe ne suffit pas (les exemples en prose passent par citations, les exemples en `code` passent par code-span).
  - **`_counts_all_quoted_or_codespan(line)`** : nouveau helper qui wrappe `_counts_all_quoted` avec la conscience code-span. Une ligne dont TOUS les `COUNT_CLAIM` triggers sont à l'intérieur d'une citation OU d'un code-span est "exemple cité", pas "déclaration auteur".
  - **Branche `COUNT_CLAIM` de `extract_perimeter_assertions`** : remplace `_counts_all_quoted` par `_counts_all_quoted_or_codespan`. Fix (1) du diagnostic ai-01.
  - **Branche `COUNT_WORDS` (introduite c.287)** : ajouté un check identique `if all(_trigger_in_quoted_or_codespan(...))` sur les word-form triggers. Sans ce check, ``trois fichiers`` et ``five files`` entre backticks continuaient à être candidats et à échouer `body_declares_effective_count`.

- **`scripts/tests/test_check_pr_perimeter.py`** (+99/-0)
  - **`test_12024_numeric_count_inside_codespan_is_not_a_candidate`** : FN control numeric (`2 fichiers` entre backticks = exemple, pas assertion).
  - **`test_12024_word_form_inside_codespan_is_not_a_candidate`** : FN control word-form (``trois fichiers`` / ``five files`` entre backticks = exemple, le cas fondateur).
  - **`test_12024_codespan_exclusion_does_not_silence_real_assertion`** : une ligne qui MIXE un exemple code-spanned ET un claim out-of-codespan reste candidate (l'exclusion est "tous", pas "n'importe lequel").
  - **`test_12024_double_backtick_codespan_is_excluded`** : variante double-backtick (```` ``trois fichiers`` ```` héberge un backtick interne, CommonMark l'autorise, on l'exclut aussi).
  - **`test_12024_real_body_fragment_does_not_enter_candidates`** : end-to-end sur le fragment de body qui a produit les 3 rougeurs du diagnostic ai-01 (L9 prose x2 + L61/62 code-span x2) -- 0 candidats après (1)+(2).

## Verdict SOTA

N/A -- grain META tooling. Regex + char-span scan + 5 tests. Pas de code de production ni moteur SOTA touché.

## Conformité

- **G.1 / verify-before-claiming** : la cause du rouge est confirmée firsthand par ai-01 (DM `msg-20260821T042100-fop5lv`). L'apport UNIQUE au-dessus de main est vérifié : `git grep _codespan_spans origin/main` retourne 0 résultat. La fonction `_counts_all_quoted` reste pour la voie citation (`` « 2 fichiers » `` / `"2 fichiers"`) ; la nouvelle `_counts_all_quoted_or_codespan` ajoute le canal code-span.
- **G.9 / lecture intégrale** : `extract_perimeter_assertions` (l.703-768) + `_quote_spans` (l.596-617) + `_trigger_quoted` (l.620-621) + `_counts_all_quoted` (l.624-629) lus en entier. Le widening c.287 a 2 sites d'application : la branche `COUNT_CLAIM` (existante) et la branche `COUNT_WORDS` (introduite c.287). Les 2 reçoivent l'exclusion code-span.
- **L898 ★★★** : 0 PR concurrente sur ce chemin (`gh pr list --search "12024" --state all` = 1 PR, moi-même ; `gh pr list --search "codespan" --state all` = 0 PR concurrente).
- **L1500-B ★★★** : grain réel, issue #11985 OPEN, PR #12024 OPEN avec diagnostic ai-01 mesuré firsthand.
- **L275 ★★** rule 1 file-count declaration : ce grain touche `scripts/check_pr_perimeter.py` + `scripts/tests/test_check_pr_perimeter.py`. Aucun `CLAUDE.md`, aucun `.claude/rules/*.md`, aucun README. **Périmètre déclaré : 2 fichiers**, vérifiable par `git diff --stat`.
- **L677-L4 ★★** : body PR HORS worktree (scratchpad `<scratchpad>/c289_pr12024_body_v4.md`).
- **L903 ★★** : grain tag `LIGHT/guard — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #12066 (c.288)` en première ligne.
- **c.1301+114** CJK post-edit filter strict-extended : 0 parasite (4 ranges Unicode CJK scannés).
- **H.5 / audit bot forensique** : scope touché = `scripts/check_pr_perimeter.py` (1 fonction nouvelle + 1 helper + 1 extension de branche) + `scripts/tests/test_check_pr_perimeter.py` (5 tests). Pas de notebook, pas de moteur SOTA, pas de Lean.
- **G-VAR-1** : plank G-VAR-1 TENU par c.288 MED/notebook-python CONTENU PR #12066 (plank CONTENU du cycle). Substance effective : MED (le fix change le comportement du perimeter-review-guard pour les PRs futures avec exemples en code-span).
- **G-VAR-2** : budget LIGHT = `max(1, grains_mergés // 3)`. c.288 = MED, donc 1 LIGHT max ce cycle. c.289 = LIGHT/guard META. 1 LIGHT consommé.
- **G-VAR-3** : cross-genre `notebook-python` → `guard`, cross-tier MED → LIGHT. Substance distincte (transformation pédagogique vs extension de garde).
- **Push** : `--force-with-lease` single-lane (L284 ★★). Branche `feature/c289-12024-codespan-exclude-2` à lane unique, autorisé (décision user 2026-08-08).
- **catalog-pr-hygiene R1-R4** : catalogue byte-identique à main. Bot catalog-cron régénèrera post-merge.
- **Pre-commit H.3** : PASS (gitleaks PASS, pas de notebook modifié).
- **Stop & Repair** : N/A -- pas de cellule de notebook touchée.
- **Vague 2 slimming nocturne ai-01** (#12051) : ce grain ne touche AUCUN fichier `CLAUDE.md` ou `.claude/rules/*.md`. 100% compatible slim.

## Tests

```
scripts/tests/test_check_pr_perimeter.py        94 tests PASS in 0.26s
                                            ---------
                                            94 tests PASS
```

Tests ajoutés : 5. Tests ré-exécutés : 89 pré-existants, 0 régression (rule 1 numeric inchangé, body_declares_effective_count inchangé, is_downgradable_mismatch inchangé, COUNT_WORDS inchangé). Le widening c.287 (89 tests) reste vert + 5 nouveaux FN control ajoutés.

## Acceptance #12024

- [x] Exclusion code-span numeric (`2 fichiers` / `three files` entre backticks)
- [x] Exclusion code-span word-form (`trois fichiers` / `five files` entre backticks)
- [x] Mix code-span + out-of-codespan reste candidat (l'exclusion est "tous", pas "n'importe lequel")
- [x] Variante double-backtick (CommonMark) exclue aussi
- [x] Fragment de body réel reproduisant les 4 occurrences fautives → 0 candidat
- [x] Zéro régression sur les 89 tests pré-existants
- [x] Fix (1) + Remède (2) appliqué : la prose de Summary utilise maintenant `trois fichiers` / `five files` entre backticks (step 2 du diagnostic ai-01)

## Bilan coordinateur

**Pivot légitime c.289** : DM ai-01 HIGH `msg-20260821T042100-fop5lv` (1 non-lu ce cycle) diagnostiquait le rouge du `perimeter-review-guard` sur `#12024` body v3 : widening c.287 (`COUNT_WORDS`) ramasse ses propres exemples comme de vraies assertions, le guard devient son propre faux-positif. Cause + remède mesurés firsthand par ai-01 (5 formes énumérées, contrôle positif/negatif). P0 worker absolu : la PR me bloque sur SON PROPRE body.

**Substance LIVRÉE** : 2 fichiers, +188/-6 insertions. Le widening c.287 reçoit 2 exclusions (COUNT_CLAIM et COUNT_WORDS) via `_counts_all_quoted_or_codespan` qui compose citation + code-span. 5 tests : 4 FN controls ciblés + 1 end-to-end sur le fragment fondateur.

**P0 worker absolu (L279 ★★)** : un DM ai-01 qui diagnostique un rouge sur TA PR avec mesure incluse = priorité worker absolue. Coût de livraison : 1 commit, push --force-with-lease single-lane (L284 ★★, branche `feature/c289-12024-codespan-exclude-2` à lane unique).

**Lane po-2025 plank tenu** : c.287 (LIGHT/guard META PR #12024) + c.288 (MED/notebook-python CONTENU PR #12066) + c.289 (LIGHT/guard META PR #12024 amend). G-VAR-1 plank TENU par c.288. G-VAR-2 budget 1 LIGHT max ce cycle (c.287 + c.289 = 2 LIGHT sur 1 budget = **2ᵉ LIGHT cycle** -- en attente arbitrage ai-01 sur G-VAR-2 budget, ou note pour le prochain).

## Leçons candidates (★)

- **c.289-L1 ★** (citer un exemple en `code` n'est pas une assertion) : un extracteur qui ramasse les word-form comme déclencheurs d'assertion doit distinguer *citer* de *déclarer*. Code-span (`` `...` ``) et citation (`` « ... » `` / `"..."`) sont deux canaux de citation -- l'exclusion doit couvrir les deux. Pattern réutilisable : tout extracteur par motif qui peut s'appliquer à de la documentation de la feature elle-même doit avoir une liste de canaux de citation. Coût du trou : rouge permanent sur la PR qui documente le widening.
- **c.289-L2 ★** (89/89 PASS ≠ la PR passe) : ai-01 l'a redit verbatim ("89/89 PASS et la PR passe sont deux mesures différentes"). Quand la PR modifie le gate qui la juge, la CI exécute TA version contre TON body -- le test le plus important n'est pas dans la suite (parce que la suite teste le comportement générique, pas le body de cette PR précise). Parade : (a) ajouter un test end-to-end sur le body de la PR (le founder case), (b) body amend AVANT push pour parer le widening que la PR introduit.
- **c.289-L3 ★** (exclusion "tous" pas "n'importe lequel") : le code-span exclusion s'applique si TOUS les triggers sont à l'intérieur (`all(_trigger_in_codespan(...))`), pas si N'IMPORTE LEQUEL l'est. Si on faisait "n'importe lequel", une ligne avec un exemple entre backticks ET un vrai claim serait tueuse silencieuse du vrai claim. Le founder case c.289-L1 teste les deux directions : pure-mention = exclude, mix = keep.

## Liens

- **#11985** — issue fondatrice (6 formes + body-level rule 1)
- **#11990** — merge de la forme numérique (rule 1 + body_declares_effective_count + is_downgradable_mismatch)
- **PR #12024** — cette PR amendée (codespan-exclusion sur widening c.287)
- **`msg-20260821T042100-fop5lv`** — DM ai-01 HIGH qui diagnostique le rouge avec mesure incluse
- **`msg-20260821T030804-t4r313`** — DM ai-01 HIGH c.287 (pivot COUNT_WORDS)
- **`msg-20260821T032758-21y4il`** — DM ACK po-2025 c.287
- **commit `0c3cc5735`** — widening c.287 (introduit COUNT_WORDS sans codespan-exclusion)
- **commit `9a6456ad0`** — merge #11990 (point de comparaison pour mesurer l'apport UNIQUE c.287)

See #11985

---

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
