### PR TITLE
feat(sudoku,#11977): Tranche 3 — PSO canonique MetaGeneticSharp dans Sudoku-5-PSO-Csharp

### DIFF
--- a/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/Sudoku/Sudoku-5-PSO-Csharp.ipynb
@@ -13,25 +13,7 @@
     },
     "tags": []
    },
-   "source": [
-    "# Sudoku-5 : Particle Swarm Optimization (PSO)\n",
-    "\n",
-    "**Niveau** : Métaheuristique  \n",
-    "**Durée** : ~20 min  \n",
-    "**Prérequis** : Sudoku-0-Environment\n",
-    "\n",
-    "## Objectifs d'apprentissage\n",
-    "\n",
-    "1. Comprendre les principes de l'optimisation par essaim de particules\n",
-    "2. Adapter le PSO a la résolution de Sudoku\n",
-    "3. Comparer les performances avec les autres métaheuristiques (GA, SA)\n",
-    "\n",
-    "## Navigation\n",
-    "\n",
-    "| << Précédent | [Index](./README.md) | Suivant >> |\n",
-    "|-------------|---------------------|-----------|\n",
-    "| [Sudoku-4-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Csharp.ipynb) | | [Sudoku-6-AIMA-CSP](Sudoku-6-AIMA-CSP-Csharp.ipynb) |"
-   ]
+   "source": "# Sudoku-5 : Particle Swarm Optimization (PSO)\n\n**Niveau** : Métaheuristique  \n**Durée** : ~20 min  \n**Prérequis** : Sudoku-0-Environment\n\n## Objectifs d'apprentissage\n\n1. Comprendre les principes de l'optimisation par essaim de particules\n2. Adapter le PSO a la résolution de Sudoku\n3. Comparer les performances avec les autres métaheuristiques (GA, SA)\n\n## Navigation\n\n| << Précédent | [Index](./README.md) | Suivant >> |\n|-------------|---------------------|-----------|\n| [Sudoku-4-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Csharp.ipynb) | | [Sudoku-6-AIMA-CSP](Sudoku-6-AIMA-CSP-Csharp.ipynb) |"
   },
   {
    "cell_type": "markdown",
@@ -46,43 +28,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 1. Introduction au PSO\n",
-    "\n",
-    "Le **Particle Swarm Optimization** (PSO) est une métaheuristique inspirée du comportement social des oiseaux et des poissons. Développé par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.\n",
-    "\n",
-    "**Source primaire.** Le PSO a été introduit par James Kennedy et Russell Eberhart dans *Particle Swarm Optimization* (1995), Proceedings of the IEEE International Conference on Neural Networks (Perth, vol. 4, pp. 1942-1948 ; DOI 10.1109/ICNN.1995.488968). Inspire des modèles sociaux de Reynolds sur les vols d'oiseaux, il formalise la notion de particule guidee conjointement par sa meilleure expérience personnelle (pBest) et celle de l'essaim (gBest) -- l'équation de mise a jour ci-dessous en est la formulation canonique.\n",
-    "\n",
-    "### Principes fondamentaux (PSO canonique)\n",
-    "\n",
-    "1. **Particules** : Chaque particule représente une solution candidate\n",
-    "2. **Position** : La position de la particule = configuration de la grille\n",
-    "3. **Vélocité** : Direction et vitesse de deplacement dans l'espace de recherche\n",
-    "4. **pBest** : Meilleure position personnelle de la particule\n",
-    "5. **gBest** : Meilleure position globale de l'essaim\n",
-    "\n",
-    "### Équation de mise a jour (PSO canonique, espace continu)\n",
-    "\n",
-    "```\n",
-    "v(t+1) = w * v(t) + c1 * r1 * (pBest - x(t)) + c2 * r2 * (gBest - x(t))\n",
-    "x(t+1) = x(t) + v(t+1)\n",
-    "```\n",
-    "\n",
-    "Où :\n",
-    "- `w` : poids d'inertie (impact de la vélocité précédente)\n",
-    "- `c1`, `c2` : coefficients d'apprentissage (cognitif et social)\n",
-    "- `r1`, `r2` : nombres aleatoires [0, 1]\n",
-    "\n",
-    "### Adaptation au Sudoku : une variante discrete inspirée de l'essaim\n",
-    "\n",
-    "L'équation de vélocité ci-dessus est définie sur un espace **continu** : additionner une vélocité a une position suppose des coordonnees réelles. Le Sudoku est un problème **combinatoire discret** (permutations de chiffres), où cette addition n'a pas de sens direct. Ce notebook n'implémente donc **pas** l'équation de vélocité canonique ; il utilisé une **heuristique d'essaim discrete** inspirée du PSO et des colonies d'organismes :\n",
-    "\n",
-    "- **Workers** (90%) : exploitent leur voisinage par **échange de deux cases** (recherche locale), en acceptant un voisin s'il réduit l'erreur (ou rarement, via un faible taux de mutation). Un worker qui stagne trop longtemps (`Age > MaxAge`) est reinitialise.\n",
-    "- **Explorers** (10%) : repartent d'une grille **aleatoire** complète a chaque itération, pour diversifier la recherche.\n",
-    "- **Meilleure globale** : l'essaim conserve la meilleure grille rencontree (`bestError` / `bestSolution`), qui est la solution retournee.\n",
-    "\n",
-    "> **A retenir** : il n'y a ici ni champ de vélocité, ni mémoire `pBest` par particule, ni coefficients `w`/`c1`/`c2`. Les workers ne sont pas attires par `gBest` au sens de l'équation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulté a transposer une métaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idée d'essaim (exploration parallèle + mémoire de la meilleure solution), mais le mécanisme de deplacement est entièrement repense (échanges locaux + redémarrages)."
-   ]
+   "source": "## 1. Introduction au PSO\n\nLe **Particle Swarm Optimization** (PSO) est une métaheuristique inspirée du comportement social des oiseaux et des poissons. Développé par Kennedy et Eberhart en 1995, l'algorithme simule un essaim de particules qui explorent l'espace de recherche.\n\n**Source primaire.** Le PSO a été introduit par James Kennedy et Russell Eberhart dans *Particle Swarm Optimization* (1995), Proceedings of the IEEE International Conference on Neural Networks (Perth, vol. 4, pp. 1942-1948 ; DOI 10.1109/ICNN.1995.488968). Inspire des modèles sociaux de Reynolds sur les vols d'oiseaux, il formalise la notion de particule guidee conjointement par sa meilleure expérience personnelle (pBest) et celle de l'essaim (gBest) -- l'équation de mise a jour ci-dessous en est la formulation canonique.\n\n### Principes fondamentaux (PSO canonique)\n\n1. **Particules** : Chaque particule représente une solution candidate\n2. **Position** : La position de la particule = configuration de la grille\n3. **Vélocité** : Direction et vitesse de deplacement dans l'espace de recherche\n4. **pBest** : Meilleure position personnelle de la particule\n5. **gBest** : Meilleure position globale de l'essaim\n\n### Équation de mise a jour (PSO canonique, espace continu)\n\n```\nv(t+1) = w * v(t) + c1 * r1 * (pBest - x(t)) + c2 * r2 * (gBest - x(t))\nx(t+1) = x(t) + v(t+1)\n```\n\nOù :\n- `w` : poids d'inertie (impact de la vélocité précédente)\n- `c1`, `c2` : coefficients d'apprentissage (cognitif et social)\n- `r1`, `r2` : nombres aleatoires [0, 1]\n\n### Adaptation au Sudoku : une variante discrete inspirée de l'essaim\n\nL'équation de vélocité ci-dessus est définie sur un espace **continu** : additionner une vélocité a une position suppose des coordonnees réelles. Le Sudoku est un problème **combinatoire discret** (permutations de chiffres), où cette addition n'a pas de sens direct. Ce notebook n'implémente donc **pas** l'équation de vélocité canonique ; il utilisé une **heuristique d'essaim discrete** inspirée du PSO et des colonies d'organismes :\n\n- **Workers** (90%) : exploitent leur voisinage par **échange de deux cases** (recherche locale), en acceptant un voisin s'il réduit l'erreur (ou rarement, via un faible taux de mutation). Un worker qui stagne trop longtemps (`Age > MaxAge`) est reinitialise.\n- **Explorers** (10%) : repartent d'une grille **aleatoire** complète a chaque itération, pour diversifier la recherche.\n- **Meilleure globale** : l'essaim conserve la meilleure grille rencontree (`bestError` / `bestSolution`), qui est la solution retournee.\n\n> **A retenir** : il n'y a ici ni champ de vélocité, ni mémoire `pBest` par particule, ni coefficients `w`/`c1`/`c2`. Les workers ne sont pas attires par `gBest` au sens de l'équation canonique : chaque worker se compare a sa **propre** erreur courante. C'est un exemple typique de la difficulté a transposer une métaheuristique **continue** (PSO) vers un espace **discret** : on garde l'idée d'essaim (exploration parallèle + mémoire de la meilleure solution), mais le mécanisme de deplacement est entièrement repense (échanges locaux + redémarrages)."
   },
   {
    "cell_type": "code",
@@ -93,10 +39,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:21:57.743324Z",
-     "iopub.status.busy": "2026-05-02T18:21:57.736201Z",
-     "iopub.status.idle": "2026-05-02T18:22:00.825435Z",
-     "shell.execute_reply": "2026-05-02T18:22:00.822430Z"
+     "iopub.status.busy": "2026-08-20T23:54:14.478712Z",
+     "iopub.execute_input": "2026-08-20T23:54:14.487404Z",
+     "shell.execute_reply": "2026-08-20T23:54:17.022641Z",
+     "iopub.status.idle": "2026-08-20T23:54:17.026577Z"
     },
     "papermill": {
      "duration": 3.098579,
@@ -113,31 +59,31 @@
    "outputs": [
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/html": ""
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "# Sudoku-0 : Environnement et Classes de Base (C#)\n\n**Navigation** : [Index](README.md) | [Sudoku-1 Backtracking C# >>](Sudoku-1-Backtracking-Csharp.ipynb)\n\n## Objectifs d'apprentissage\n\nÀ la fin de ce notebook, vous saurez :\n1. Comprendre la structure de données `SudokuGrid` et ses méthodes principales\n2. Utiliser `ISudokuSolver` pour implémenter un solveur de Sudoku\n3. Exploiter `SudokuHelper` pour charger des grilles et tester des solveurs\n4. Comparer les performances de plusieurs solveurs sur différentes difficultés\n\n**Prérequis** : Notions de base en C# (.NET Interactive)  \n**Durée estimée** : ~15 min"
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>Plotly.NET</span></li></ul></div><div></div></div>"
-     },
-     "metadata": {}
+      "text/html": "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>Plotly.NET, 5.1.0</span></li></ul></div></div>"
+     }
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "## Définition de la classe SudokuGrid\n\nNous définissons ici la classe SudokuGrid qui représente une grille de Sudoku et fournit des méthodes pour manipuler et afficher les grilles.\n"
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "stream",
@@ -146,17 +92,17 @@
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "### Interprétation : Structure de données pour la grille Sudoku\n\n**Sortie obtenue** : La classe `SudokuGrid` encapsule toutes les opérations de manipulation, validation et affichage d'une grille de Sudoku 9x9.\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| `Cells[9,9]` | int[,] | Stockage interne des valeurs (0 = vide) |\n| `AllNeighbours` | 27 x 9 positions | Pré-calcul des voisins ligne/colonne/bloc |\n| `CellNeighbours[9][9]` | ~20 positions chacune | Voisins directs de chaque cellule |\n| `GetAvailableNumbers()` | int[] | Candidats valides pour une cellule |\n| `NbErrors()` | int | Nombre de conflits + modifications erronées |\n\n**Points clés** :\n1. **Pré-calcul des voisins** : `AllNeighbours` et `CellNeighbours` sont calculés une seule fois à l'initialisation, évitant les recalculs coûteux\n2. **Conversion flexible** : Méthodes pour convertir entre tableaux 1D, 2D et jagged arrays (utile pour différents formats de fichiers)\n3. **Validation robuste** : `NbErrors` compte à la fois les doublons (ligne/colonne/bloc) et les modifications de indices pré-remplis\n4. **Parsing tolerant** : `ReadMultiSudoku` accepte plusieurs formats (`.`, `X`, `-`, espaces)\n\n> **Note technique** : La structure `CellNeighbours[i][j]` contient environ 20 positions (8 ligne + 8 colonne + 4 bloc, moins les doublons). Ce pré-calcul est crucial pour les performances des algorithmes de backtracking et de propagation de contraintes."
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "## Définition de l'interface ISudokuSolver\n\nNous définissons ici l'interface ISudokuSolver qui sera implémentée par les différentes stratégies de résolution de Sudoku.\n"
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "stream",
@@ -165,17 +111,17 @@
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "### Interprétation : Interface de stratégie\n\n**Sortie obtenue** : L'interface `ISudokuSolver` définit le contrat que tous les solveurs doivent respecter.\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| `Solve(SudokuGrid)` | SudokuGrid | Méthode unique de résolution |\n| Pattern | Stratégie | Permuter les algorithmes sans modifier le code client |\n\n**Points clés** :\n1. **Simplicité** : Une seule méthode `Solve` prenant une grille et retournant une grille résolue\n2. **Flexibilité** : N'importe quel algorithme (backtracking, CSP, métaheuristique) peut implémenter cette interface\n3. **Composabilité** : Les solveurs peuvent être passés en paramètre, stockés dans des listes, testés unitairement\n4. **Extensibilité** : Ajouter un nouveau solver ne nécessite que d'implémenter l'interface\n\n> **Note technique** : Ce design pattern permet à `SudokuHelper.TestSolvers` d'accepter une liste de `(string, ISudokuSolver)` pour comparer tous les algorithmes avec le même code de test."
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "## Définition de la classe SudokuHelper\n\nNous ajoutons ici la classe SudokuHelper qui contient des méthodes utilitaires pour charger  des grilles de Sudoku et tester des solvers.\n\n- `GetSudokus` : Renvoie des listes de Sudoku issues de fichiers de 3 difficultés différentes.\n- `SolveSudoku` : effectue un test simple d'un solver sur un sudoku donné.\n- `TestSolvers` : exécute les tests de performance sur plusieurs solveurs.\n- `DisplayResults` : affiche les résultats des tests sous forme de graphiques.\n\n"
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "stream",
@@ -184,17 +130,17 @@
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "### Interprétation : Infrastructure de test et benchmark\n\n**Sortie obtenue** : La classe `SudokuHelper` fournit une infrastructure complète pour tester et comparer les solveurs de Sudoku.\n\n| Aspect | Valeur | Signification |\n|--------|--------|---------------|\n| `GetSudokus()` | 51/95/100 grilles | Trois niveaux de difficulté (Easy/Medium/Hard) |\n| `TestSolvers()` | Performance multi-solveurs | Exécution parallèle avec timeout |\n| `DisplayResults()` | Graphiques Plotly.NET | Visualisation des temps de résolution |\n| `SolveSudoku()` | Test unitaire | Résolution individuelle avec affichage |\n\n**Points clés** :\n1. **Chargement intelligent** : Recherche récursive du dossier `Puzzles` dans l'arborescence\n2. **Robustesse** : Gestion des timeouts (3 000 ms par défaut — paramètre de configuration du solveur, valeur fixée dans le code) et exceptions\n3. **Mesures** : Temps d'exécution total + nombre de grilles resolues\n4. **Disqualification** : Un solver échouant sur une grille est disqualifié pour la difficulté\n\n> **Note technique** : La méthode `TestSolvers` utilise `Interlocked.Increment` pour un thread-safe incrément du compteur de solutions. Le `CancellationToken` permet d'interrompre proprement les solveurs trop lents."
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "## Exercice : Validation d'une grille Sudoku\n\n### Énoncé\n\nImplémentez une méthode `IsValidSolution` qui vérifie qu'une grille est une solution valide de Sudoku, c'est-à-dire que chaque ligne, chaque colonne et chaque bloc 3x3 contient exactement une fois chaque chiffre de 1 à 9.\n\nUtilisez cette méthode pour valider les résultats de `SudokuHelper.SolveSudoku`.\n\n**Indices :**\n\n- Parcourez les 9 lignes, 9 colonnes et 9 blocs\n- Pour chaque unité, verifiez que les 9 chiffres sont tous présents sans doublon\n- `SudokuGrid.AllNeighbours` contient déjà les indices des unités"
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "stream",
@@ -203,15 +149,13 @@
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/markdown": "## Résumé et perspectives\n\nCe notebook a posé les fondations de toute la série Sudoku en définissant trois composants essentiels. La classe `SudokuGrid` encapsule la représentation d'une grille 9x9 avec le pré-calcul des voisins (`AllNeighbours`, `CellNeighbours`), ce qui évite les recalculs coûteux lors de la résolution. L'interface `ISudokuSolver` implante le pattern Stratégie, permettant de permuter les algorithmes de résolution sans modifier le code client. Enfin, la classe `SudokuHelper` fournit une infrastructure de benchmark complète avec chargement de puzzles, mesures de performance et visualisation Plotly.NET.\n\nL'infrastructure de test (`TestSolvers`, `DisplayResults`) permet de comparer objectivement les solveurs sur trois niveaux de difficulté (Easy, Medium, Hard) avec gestion des timeouts et des disqualifications. Ce cadre de benchmark sera utilisé dans tous les notebooks suivants pour mesurer les performances de chaque algorithme.\n\nLe notebook suivant, [Sudoku-1-Backtracking](Sudoku-1-Backtracking-Csharp.ipynb), utilise ces classes pour implémenter le premier algorithme de résolution : le backtracking récursif avec ses heuristiques d'amélioration."
-     },
-     "metadata": {}
+     }
     }
    ],
-   "source": [
-    "#!import Sudoku-0-Environment-Csharp.ipynb"
-   ]
+   "source": "#!import Sudoku-0-Environment-Csharp.ipynb"
   },
   {
    "cell_type": "markdown",
@@ -226,9 +170,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 2. Implémentation des classes auxiliaires"
-   ]
+   "source": "## 2. Implémentation des classes auxiliaires"
   },
   {
    "cell_type": "code",
@@ -239,10 +181,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:22:00.848726Z",
-     "iopub.status.busy": "2026-05-02T18:22:00.848405Z",
-     "iopub.status.idle": "2026-05-02T18:22:00.939558Z",
-     "shell.execute_reply": "2026-05-02T18:22:00.939269Z"
+     "iopub.status.busy": "2026-08-20T23:54:17.027761Z",
+     "iopub.execute_input": "2026-08-20T23:54:17.028333Z",
+     "shell.execute_reply": "2026-08-20T23:54:17.080925Z",
+     "iopub.status.idle": "2026-08-20T23:54:17.080925Z"
     },
     "papermill": {
      "duration": 0.097587,
@@ -263,139 +205,7 @@
      "text": "MatrixHelper defini.\r\n"
     }
    ],
-   "source": [
-    "// Helper pour la manipulation des matrices Sudoku\n",
-    "public static class MatrixHelperPSO\n",
-    "{\n",
-    "    public const int SIZE = 9;\n",
-    "    public const int BLOCK_SIZE = 3;\n",
-    "\n",
-    "    public static int[,] CreateMatrix(int m, int n)\n",
-    "    {\n",
-    "        return new int[m, n];\n",
-    "    }\n",
-    "\n",
-    "    public static (int row, int column) Corner(int block)\n",
-    "    {\n",
-    "        int r = (block / 3) * 3;\n",
-    "        int c = (block % 3) * 3;\n",
-    "        return (r, c);\n",
-    "    }\n",
-    "\n",
-    "    public static int[,] DuplicateMatrix(int[,] matrix)\n",
-    "    {\n",
-    "        var m = matrix.GetLength(0);\n",
-    "        var n = matrix.GetLength(1);\n",
-    "        var result = CreateMatrix(m, n);\n",
-    "        for (var i = 0; i < m; ++i)\n",
-    "            for (var j = 0; j < n; ++j)\n",
-    "                result[i, j] = matrix[i, j];\n",
-    "        return result;\n",
-    "    }\n",
-    "\n",
-    "    // Cree une matrice aleatoire valide par bloc\n",
-    "    public static int[,] RandomMatrix(Random rnd, int[,] problem)\n",
-    "    {\n",
-    "        var result = DuplicateMatrix(problem);\n",
-    "\n",
-    "        for (var block = 0; block < SIZE; ++block)\n",
-    "        {\n",
-    "            var corner = Corner(block);\n",
-    "            var values = Enumerable.Range(1, SIZE).ToList();\n",
-    "\n",
-    "            // Melanger les valeurs\n",
-    "            for (var k = 0; k < values.Count; ++k)\n",
-    "            {\n",
-    "                var ri = rnd.Next(k, values.Count);\n",
-    "                (values[k], values[ri]) = (values[ri], values[k]);\n",
-    "            }\n",
-    "\n",
-    "            // Retirer les valeurs deja presentes\n",
-    "            var r = corner.row;\n",
-    "            var c = corner.column;\n",
-    "            for (var i = r; i < r + BLOCK_SIZE; ++i)\n",
-    "            {\n",
-    "                for (var j = c; j < c + BLOCK_SIZE; ++j)\n",
-    "                {\n",
-    "                    var value = problem[i, j];\n",
-    "                    if (value != 0)\n",
-    "                        values.Remove(value);\n",
-    "                }\n",
-    "            }\n",
-    "\n",
-    "            // Remplir les cellules vides\n",
-    "            var pointer = 0;\n",
-    "            for (var i = r; i < r + BLOCK_SIZE; ++i)\n",
-    "            {\n",
-    "                for (var j = c; j < c + BLOCK_SIZE; ++j)\n",
-    "                {\n",
-    "                    if (result[i, j] == 0)\n",
-    "                    {\n",
-    "                        result[i, j] = values[pointer++];\n",
-    "                    }\n",
-    "                }\n",
-    "            }\n",
-    "        }\n",
-    "\n",
-    "        return result;\n",
-    "    }\n",
-    "\n",
-    "    // Genere un voisin par echange dans un bloc\n",
-    "    public static int[,] NeighborMatrix(Random rnd, int[,] problem, int[,] matrix)\n",
-    "    {\n",
-    "        var result = DuplicateMatrix(matrix);\n",
-    "\n",
-    "        var block = rnd.Next(0, SIZE);\n",
-    "        var corner = Corner(block);\n",
-    "        var cells = new List<int[]>();\n",
-    "        \n",
-    "        for (var i = corner.row; i < corner.row + BLOCK_SIZE; ++i)\n",
-    "        {\n",
-    "            for (var j = corner.column; j < corner.column + BLOCK_SIZE; ++j)\n",
-    "            {\n",
-    "                if (problem[i, j] == 0)\n",
-    "                    cells.Add(new[] { i, j });\n",
-    "            }\n",
-    "        }\n",
-    "\n",
-    "        if (cells.Count < 2)\n",
-    "            return result;\n",
-    "\n",
-    "        var k1 = rnd.Next(0, cells.Count);\n",
-    "        var inc = rnd.Next(1, cells.Count);\n",
-    "        var k2 = (k1 + inc) % cells.Count;\n",
-    "\n",
-    "        var r1 = cells[k1][0];\n",
-    "        var c1 = cells[k1][1];\n",
-    "        var r2 = cells[k2][0];\n",
-    "        var c2 = cells[k2][1];\n",
-    "\n",
-    "        (result[r1, c1], result[r2, c2]) = (result[r2, c2], result[r1, c1]);\n",
-    "\n",
-    "        return result;\n",
-    "    }\n",
-    "\n",
-    "    // Fusionne deux matrices par blocs\n",
-    "    public static int[,] MergeMatrices(Random rnd, int[,] m1, int[,] m2)\n",
-    "    {\n",
-    "        var result = DuplicateMatrix(m1);\n",
-    "\n",
-    "        for (var block = 0; block < 9; ++block)\n",
-    "        {\n",
-    "            var pr = rnd.NextDouble();\n",
-    "            if (pr < 0.50)\n",
-    "            {\n",
-    "                var corner = Corner(block);\n",
-    "                for (var i = corner.row; i < corner.row + BLOCK_SIZE; ++i)\n",
-    "                    for (var j = corner.column; j < corner.column + BLOCK_SIZE; ++j)\n",
-    "                        result[i, j] = m2[i, j];\n",
-    "            }\n",
-    "        }\n",
-    "\n",
-    "        return result;\n",
-    "    }\n",
-    "}\n\nConsole.WriteLine(\"MatrixHelper defini.\");\n"
-   ]
+   "source": "// Helper pour la manipulation des matrices Sudoku\npublic static class MatrixHelperPSO\n{\n    public const int SIZE = 9;\n    public const int BLOCK_SIZE = 3;\n\n    public static int[,] CreateMatrix(int m, int n)\n    {\n        return new int[m, n];\n    }\n\n    public static (int row, int column) Corner(int block)\n    {\n        int r = (block / 3) * 3;\n        int c = (block % 3) * 3;\n        return (r, c);\n    }\n\n    public static int[,] DuplicateMatrix(int[,] matrix)\n    {\n        var m = matrix.GetLength(0);\n        var n = matrix.GetLength(1);\n        var result = CreateMatrix(m, n);\n        for (var i = 0; i < m; ++i)\n            for (var j = 0; j < n; ++j)\n                result[i, j] = matrix[i, j];\n        return result;\n    }\n\n    // Cree une matrice aleatoire valide par bloc\n    public static int[,] RandomMatrix(Random rnd, int[,] problem)\n    {\n        var result = DuplicateMatrix(problem);\n\n        for (var block = 0; block < SIZE; ++block)\n        {\n            var corner = Corner(block);\n            var values = Enumerable.Range(1, SIZE).ToList();\n\n            // Melanger les valeurs\n            for (var k = 0; k < values.Count; ++k)\n            {\n                var ri = rnd.Next(k, values.Count);\n                (values[k], values[ri]) = (values[ri], values[k]);\n            }\n\n            // Retirer les valeurs deja presentes\n            var r = corner.row;\n            var c = corner.column;\n            for (var i = r; i < r + BLOCK_SIZE; ++i)\n            {\n                for (var j = c; j < c + BLOCK_SIZE; ++j)\n                {\n                    var value = problem[i, j];\n                    if (value != 0)\n                        values.Remove(value);\n                }\n            }\n\n            // Remplir les cellules vides\n            var pointer = 0;\n            for (var i = r; i < r + BLOCK_SIZE; ++i)\n            {\n                for (var j = c; j < c + BLOCK_SIZE; ++j)\n                {\n                    if (result[i, j] == 0)\n                    {\n                        result[i, j] = values[pointer++];\n                    }\n                }\n            }\n        }\n\n        return result;\n    }\n\n    // Genere un voisin par echange dans un bloc\n    public static int[,] NeighborMatrix(Random rnd, int[,] problem, int[,] matrix)\n    {\n        var result = DuplicateMatrix(matrix);\n\n        var block = rnd.Next(0, SIZE);\n        var corner = Corner(block);\n        var cells = new List<int[]>();\n        \n        for (var i = corner.row; i < corner.row + BLOCK_SIZE; ++i)\n        {\n            for (var j = corner.column; j < corner.column + BLOCK_SIZE; ++j)\n            {\n                if (problem[i, j] == 0)\n                    cells.Add(new[] { i, j });\n            }\n        }\n\n        if (cells.Count < 2)\n            return result;\n\n        var k1 = rnd.Next(0, cells.Count);\n        var inc = rnd.Next(1, cells.Count);\n        var k2 = (k1 + inc) % cells.Count;\n\n        var r1 = cells[k1][0];\n        var c1 = cells[k1][1];\n        var r2 = cells[k2][0];\n        var c2 = cells[k2][1];\n\n        (result[r1, c1], result[r2, c2]) = (result[r2, c2], result[r1, c1]);\n\n        return result;\n    }\n\n    // Fusionne deux matrices par blocs\n    public static int[,] MergeMatrices(Random rnd, int[,] m1, int[,] m2)\n    {\n        var result = DuplicateMatrix(m1);\n\n        for (var block = 0; block < 9; ++block)\n        {\n            var pr = rnd.NextDouble();\n            if (pr < 0.50)\n            {\n                var corner = Corner(block);\n                for (var i = corner.row; i < corner.row + BLOCK_SIZE; ++i)\n                    for (var j = corner.column; j < corner.column + BLOCK_SIZE; ++j)\n                        result[i, j] = m2[i, j];\n            }\n        }\n\n        return result;\n    }\n}\n\nConsole.WriteLine(\"MatrixHelper defini.\");\n"
   },
   {
    "cell_type": "markdown",
@@ -410,9 +220,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Représentation d'une grille Sudoku avec calcul de la fonction d'erreur."
-   ]
+   "source": "Représentation d'une grille Sudoku avec calcul de la fonction d'erreur."
   },
   {
    "cell_type": "code",
@@ -423,10 +231,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:22:00.963579Z",
-     "iopub.status.busy": "2026-05-02T18:22:00.963333Z",
-     "iopub.status.idle": "2026-05-02T18:22:01.040297Z",
-     "shell.execute_reply": "2026-05-02T18:22:01.039924Z"
+     "iopub.status.busy": "2026-08-20T23:54:17.081961Z",
+     "iopub.execute_input": "2026-08-20T23:54:17.081961Z",
+     "shell.execute_reply": "2026-08-20T23:54:17.103157Z",
+     "iopub.status.idle": "2026-08-20T23:54:17.103157Z"
     },
     "papermill": {
      "duration": 0.082618,
@@ -447,52 +255,7 @@
      "text": "SudokuPSOGrille defini.\r\n"
     }
    ],
-   "source": [
-    "// Representation d'une grille Sudoku avec calcul d'erreur\n",
-    "public class SudokuPSO\n",
-    "{\n",
-    "    public int[,] CellValues { get; }\n",
-    "\n",
-    "    public SudokuPSO(int[,] cellValues)\n",
-    "    {\n",
-    "        CellValues = MatrixHelperPSO.DuplicateMatrix(cellValues);\n",
-    "    }\n",
-    "\n",
-    "    public static SudokuPSO New(int[,] cellValues)\n",
-    "    {\n",
-    "        return new SudokuPSO(MatrixHelperPSO.DuplicateMatrix(cellValues));\n",
-    "    }\n",
-    "\n",
-    "    public int Error\n",
-    "    {\n",
-    "        get\n",
-    "        {\n",
-    "            return CountErrors(true) + CountErrors(false);\n",
-    "        }\n",
-    "    }\n",
-    "\n",
-    "    private int CountErrors(bool countByRow)\n",
-    "    {\n",
-    "        var errors = 0;\n",
-    "        for (var i = 0; i < MatrixHelperPSO.SIZE; ++i)\n",
-    "        {\n",
-    "            var counts = new int[MatrixHelperPSO.SIZE];\n",
-    "            for (var j = 0; j < MatrixHelperPSO.SIZE; ++j)\n",
-    "            {\n",
-    "                var cellValue = countByRow ? CellValues[i, j] : CellValues[j, i];\n",
-    "                ++counts[cellValue - 1];\n",
-    "            }\n",
-    "\n",
-    "            for (var k = 0; k < MatrixHelperPSO.SIZE; ++k)\n",
-    "            {\n",
-    "                if (counts[k] == 0)\n",
-    "                    ++errors;\n",
-    "            }\n",
-    "        }\n",
-    "        return errors;\n",
-    "    }\n",
-    "}\n\nConsole.WriteLine(\"SudokuPSOGrille defini.\");\n"
-   ]
+   "source": "// Representation d'une grille Sudoku avec calcul d'erreur\npublic class SudokuPSO\n{\n    public int[,] CellValues { get; }\n\n    public SudokuPSO(int[,] cellValues)\n    {\n        CellValues = MatrixHelperPSO.DuplicateMatrix(cellValues);\n    }\n\n    public static SudokuPSO New(int[,] cellValues)\n    {\n        return new SudokuPSO(MatrixHelperPSO.DuplicateMatrix(cellValues));\n    }\n\n    public int Error\n    {\n        get\n        {\n            return CountErrors(true) + CountErrors(false);\n        }\n    }\n\n    private int CountErrors(bool countByRow)\n    {\n        var errors = 0;\n        for (var i = 0; i < MatrixHelperPSO.SIZE; ++i)\n        {\n            var counts = new int[MatrixHelperPSO.SIZE];\n            for (var j = 0; j < MatrixHelperPSO.SIZE; ++j)\n            {\n                var cellValue = countByRow ? CellValues[i, j] : CellValues[j, i];\n                ++counts[cellValue - 1];\n            }\n\n            for (var k = 0; k < MatrixHelperPSO.SIZE; ++k)\n            {\n                if (counts[k] == 0)\n                    ++errors;\n            }\n        }\n        return errors;\n    }\n}\n\nConsole.WriteLine(\"SudokuPSOGrille defini.\");\n"
   },
   {
    "cell_type": "markdown",
@@ -507,9 +270,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Types d'organismes dans l'essaim et algorithme PSO principal."
-   ]
+   "source": "Types d'organismes dans l'essaim et algorithme PSO principal."
   },
   {
    "cell_type": "code",
@@ -520,10 +281,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:22:01.072412Z",
-     "iopub.status.busy": "2026-05-02T18:22:01.071811Z",
-     "iopub.status.idle": "2026-05-02T18:22:01.135867Z",
-     "shell.execute_reply": "2026-05-02T18:22:01.135563Z"
+     "iopub.status.busy": "2026-08-20T23:54:17.104156Z",
+     "iopub.execute_input": "2026-08-20T23:54:17.104156Z",
+     "shell.execute_reply": "2026-08-20T23:54:17.138091Z",
+     "iopub.status.idle": "2026-08-20T23:54:17.138091Z"
     },
     "papermill": {
      "duration": 0.072556,
@@ -544,31 +305,7 @@
      "text": "Types OrganismType et PSOOrganism definis.\r\n"
     }
    ],
-   "source": [
-    "// Types d'organismes dans l'essaim\n",
-    "public enum OrganismType\n",
-    "{\n",
-    "    Worker,    // Exploite le voisinage\n",
-    "    Explorer   // Explore aleatoirement\n",
-    "}\n",
-    "\n",
-    "// Representation d'une particule (organisme)\n",
-    "public class Organism\n",
-    "{\n",
-    "    public OrganismType Type { get; }\n",
-    "    public int[,] Matrix { get; set; }\n",
-    "    public int Error { get; set; }\n",
-    "    public int Age { get; set; }\n",
-    "\n",
-    "    public Organism(OrganismType type, int[,] matrix, int error, int age)\n",
-    "    {\n",
-    "        Type = type;\n",
-    "        Error = error;\n",
-    "        Age = age;\n",
-    "        Matrix = MatrixHelperPSO.DuplicateMatrix(matrix);\n",
-    "    }\n",
-    "}\n\nConsole.WriteLine(\"Types OrganismType et PSOOrganism definis.\");\n"
-   ]
+   "source": "// Types d'organismes dans l'essaim\npublic enum OrganismType\n{\n    Worker,    // Exploite le voisinage\n    Explorer   // Explore aleatoirement\n}\n\n// Representation d'une particule (organisme)\npublic class Organism\n{\n    public OrganismType Type { get; }\n    public int[,] Matrix { get; set; }\n    public int Error { get; set; }\n    public int Age { get; set; }\n\n    public Organism(OrganismType type, int[,] matrix, int error, int age)\n    {\n        Type = type;\n        Error = error;\n        Age = age;\n        Matrix = MatrixHelperPSO.DuplicateMatrix(matrix);\n    }\n}\n\nConsole.WriteLine(\"Types OrganismType et PSOOrganism definis.\");\n"
   },
   {
    "cell_type": "markdown",
@@ -583,9 +320,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 3. Implémentation du solveur PSO"
-   ]
+   "source": "## 3. Implémentation du solveur PSO"
   },
   {
    "cell_type": "code",
@@ -596,10 +331,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:22:01.157410Z",
-     "iopub.status.busy": "2026-05-02T18:22:01.157136Z",
-     "iopub.status.idle": "2026-05-02T18:22:01.254556Z",
-     "shell.execute_reply": "2026-05-02T18:22:01.254342Z"
+     "iopub.status.busy": "2026-08-20T23:54:17.138091Z",
+     "iopub.execute_input": "2026-08-20T23:54:17.167995Z",
+     "shell.execute_reply": "2026-08-20T23:54:17.221488Z",
+     "iopub.status.idle": "2026-08-20T23:54:17.221488Z"
     },
     "papermill": {
      "duration": 0.104195,
@@ -620,167 +355,7 @@
      "text": "Classe PSOSudokuSolver definie.\r\n"
     }
    ],
-   "source": [
-    "using System.Diagnostics;\n",
-    "\n",
-    "public class PSOSudokuSolver : ISudokuSolver\n",
-    "{\n",
-    "    private Random _rnd;\n",
-    "    \n",
-    "    // Parametres configurables\n",
-    "    public int NumOrganisms { get; set; } = 200;      // Taille de l'essaim\n",
-    "    public int MaxEpochs { get; set; } = 5000;        // Iterations max\n",
-    "    public int MaxRestarts { get; set; } = 20;        // Redemarrages max\n",
-    "    public double WorkerRatio { get; set; } = 0.90;  // Proportion de workers\n",
-    "    public int MaxAge { get; set; } = 1000;           // Age max avant reinitialisation\n",
-    "    public double MutationRate { get; set; } = 0.001; // Taux de mutation\n",
-    "\n",
-    "    public SudokuGrid Solve(SudokuGrid s)\n",
-    "    {\n",
-    "        // Conversion SudokuGrid -> int[,]\n",
-    "        int[,] cellsSolver = new int[9, 9];\n",
-    "        for (int i = 0; i < 9; i++)\n",
-    "            for (int j = 0; j < 9; j++)\n",
-    "                cellsSolver[i, j] = s.Cells[i, j];  // Fix: 2D array access\n",
-    "\n",
-    "        var sudoku = new SudokuPSO(cellsSolver);\n",
-    "        var solvedSudoku = Solve(sudoku);\n",
-    "\n",
-    "        // Conversion int[,] -> SudokuGrid\n",
-    "        for (int i = 0; i < 9; i++)\n",
-    "            for (int j = 0; j < 9; j++)\n",
-    "                s.Cells[i, j] = solvedSudoku.CellValues[i, j];  // Fix: 2D array access\n",
-    "\n",
-    "        return s;\n",
-    "    }\n",
-    "\n",
-    "    public SudokuPSO Solve(SudokuPSO sudoku)\n",
-    "    {\n",
-    "        var error = int.MaxValue;\n",
-    "        SudokuPSO bestSolution = null;\n",
-    "        var attempt = 0;\n",
-    "\n",
-    "        while (error != 0 && attempt < MaxRestarts)\n",
-    "        {\n",
-    "            Console.WriteLine($\"Attempt {attempt + 1}/{MaxRestarts}\");\n",
-    "            _rnd = new Random(attempt);\n",
-    "            bestSolution = SolveInternal(sudoku);\n",
-    "            error = bestSolution.Error;\n",
-    "            ++attempt;\n",
-    "        }\n",
-    "\n",
-    "        return bestSolution;\n",
-    "    }\n",
-    "\n",
-    "    private SudokuPSO SolveInternal(SudokuPSO sudoku)\n",
-    "    {\n",
-    "        var numberOfWorkers = (int)(NumOrganisms * WorkerRatio);\n",
-    "        var hive = new Organism[NumOrganisms];\n",
-    "\n",
-    "        var bestError = int.MaxValue;\n",
-    "        SudokuPSO bestSolution = null;\n",
-    "\n",
-    "        // Initialisation de l'essaim\n",
-    "        for (var i = 0; i < NumOrganisms; ++i)\n",
-    "        {\n",
-    "            var organismType = i < numberOfWorkers ? OrganismType.Worker : OrganismType.Explorer;\n",
-    "\n",
-    "            var randomSudoku = SudokuPSO.New(MatrixHelperPSO.RandomMatrix(_rnd, sudoku.CellValues));\n",
-    "            var err = randomSudoku.Error;\n",
-    "\n",
-    "            hive[i] = new Organism(organismType, randomSudoku.CellValues, err, 0);\n",
-    "\n",
-    "            if (err < bestError)\n",
-    "            {\n",
-    "                bestError = err;\n",
-    "                bestSolution = randomSudoku;\n",
-    "            }\n",
-    "        }\n",
-    "\n",
-    "        var epoch = 0;\n",
-    "        while (epoch < MaxEpochs)\n",
-    "        {\n",
-    "            if (epoch % 1000 == 0)\n",
-    "                Console.WriteLine($\"  Epoch {epoch}, Best error: {bestError}\");\n",
-    "\n",
-    "            if (bestError == 0)\n",
-    "                break;\n",
-    "\n",
-    "            // Mise a jour de chaque organisme\n",
-    "            for (var i = 0; i < NumOrganisms; ++i)\n",
-    "            {\n",
-    "                if (hive[i].Type == OrganismType.Worker)\n",
-    "                {\n",
-    "                    // Les workers explorent leur voisinage\n",
-    "                    var neighbor = MatrixHelperPSO.NeighborMatrix(_rnd, sudoku.CellValues, hive[i].Matrix);\n",
-    "                    var neighborSudoku = SudokuPSO.New(neighbor);\n",
-    "                    var neighborError = neighborSudoku.Error;\n",
-    "\n",
-    "                    var p = _rnd.NextDouble();\n",
-    "                    if (neighborError < hive[i].Error || p < MutationRate)\n",
-    "                    {\n",
-    "                        hive[i].Matrix = MatrixHelperPSO.DuplicateMatrix(neighbor);\n",
-    "                        if (neighborError < hive[i].Error)\n",
-    "                            hive[i].Age = 0;\n",
-    "                        hive[i].Error = neighborError;\n",
-    "\n",
-    "                        if (neighborError < bestError)\n",
-    "                        {\n",
-    "                            bestError = neighborError;\n",
-    "                            bestSolution = neighborSudoku;\n",
-    "                        }\n",
-    "                    }\n",
-    "                    else\n",
-    "                    {\n",
-    "                        hive[i].Age++;\n",
-    "                        if (hive[i].Age > MaxAge)\n",
-    "                        {\n",
-    "                            // Reinitialiser le worker stagne\n",
-    "                            var randomSudoku = SudokuPSO.New(MatrixHelperPSO.RandomMatrix(_rnd, sudoku.CellValues));\n",
-    "                            hive[i] = new Organism(OrganismType.Worker, randomSudoku.CellValues, randomSudoku.Error, 0);\n",
-    "                        }\n",
-    "                    }\n",
-    "                }\n",
-    "                else\n",
-    "                {\n",
-    "                    // Les explorers cherchent aleatoirement\n",
-    "                    var randomSudoku = SudokuPSO.New(MatrixHelperPSO.RandomMatrix(_rnd, sudoku.CellValues));\n",
-    "                    hive[i].Matrix = MatrixHelperPSO.DuplicateMatrix(randomSudoku.CellValues);\n",
-    "                    hive[i].Error = randomSudoku.Error;\n",
-    "\n",
-    "                    if (hive[i].Error < bestError)\n",
-    "                    {\n",
-    "                        bestError = hive[i].Error;\n",
-    "                        bestSolution = randomSudoku;\n",
-    "                    }\n",
-    "                }\n",
-    "            }\n",
-    "\n",
-    "            // Fusion du meilleur worker avec le meilleur explorer\n",
-    "            var bestWorkerIndex = Enumerable.Range(0, numberOfWorkers)\n",
-    "                .OrderBy(i => hive[i].Error).First();\n",
-    "            var bestExplorerIndex = Enumerable.Range(numberOfWorkers, NumOrganisms - numberOfWorkers)\n",
-    "                .OrderBy(i => hive[i].Error).First();\n",
-    "            var worstWorkerIndex = Enumerable.Range(0, numberOfWorkers)\n",
-    "                .OrderByDescending(i => hive[i].Error).First();\n",
-    "\n",
-    "            var merged = MatrixHelperPSO.MergeMatrices(_rnd, hive[bestWorkerIndex].Matrix, hive[bestExplorerIndex].Matrix);\n",
-    "            var mergedSudoku = SudokuPSO.New(merged);\n",
-    "\n",
-    "            hive[worstWorkerIndex] = new Organism(OrganismType.Worker, merged, mergedSudoku.Error, 0);\n",
-    "            if (hive[worstWorkerIndex].Error < bestError)\n",
-    "            {\n",
-    "                bestError = hive[worstWorkerIndex].Error;\n",
-    "                bestSolution = mergedSudoku;\n",
-    "            }\n",
-    "\n",
-    "            ++epoch;\n",
-    "        }\n",
-    "\n",
-    "        return bestSolution;\n",
-    "    }\n",
-    "}\n\nConsole.WriteLine(\"Classe PSOSudokuSolver definie.\");\n"
-   ]
+   "source": "using System.Diagnostics;\n\npublic class PSOSudokuSolver : ISudokuSolver\n{\n    private Random _rnd;\n    \n    // Parametres configurables\n    public int NumOrganisms { get; set; } = 200;      // Taille de l'essaim\n    public int MaxEpochs { get; set; } = 5000;        // Iterations max\n    public int MaxRestarts { get; set; } = 20;        // Redemarrages max\n    public double WorkerRatio { get; set; } = 0.90;  // Proportion de workers\n    public int MaxAge { get; set; } = 1000;           // Age max avant reinitialisation\n    public double MutationRate { get; set; } = 0.001; // Taux de mutation\n\n    public SudokuGrid Solve(SudokuGrid s)\n    {\n        // Conversion SudokuGrid -> int[,]\n        int[,] cellsSolver = new int[9, 9];\n        for (int i = 0; i < 9; i++)\n            for (int j = 0; j < 9; j++)\n                cellsSolver[i, j] = s.Cells[i, j];  // Fix: 2D array access\n\n        var sudoku = new SudokuPSO(cellsSolver);\n        var solvedSudoku = Solve(sudoku);\n\n        // Conversion int[,] -> SudokuGrid\n        for (int i = 0; i < 9; i++)\n            for (int j = 0; j < 9; j++)\n                s.Cells[i, j] = solvedSudoku.CellValues[i, j];  // Fix: 2D array access\n\n        return s;\n    }\n\n    public SudokuPSO Solve(SudokuPSO sudoku)\n    {\n        var error = int.MaxValue;\n        SudokuPSO bestSolution = null;\n        var attempt = 0;\n\n        while (error != 0 && attempt < MaxRestarts)\n        {\n            Console.WriteLine($\"Attempt {attempt + 1}/{MaxRestarts}\");\n            _rnd = new Random(attempt);\n            bestSolution = SolveInternal(sudoku);\n            error = bestSolution.Error;\n            ++attempt;\n        }\n\n        return bestSolution;\n    }\n\n    private SudokuPSO SolveInternal(SudokuPSO sudoku)\n    {\n        var numberOfWorkers = (int)(NumOrganisms * WorkerRatio);\n        var hive = new Organism[NumOrganisms];\n\n        var bestError = int.MaxValue;\n        SudokuPSO bestSolution = null;\n\n        // Initialisation de l'essaim\n        for (var i = 0; i < NumOrganisms; ++i)\n        {\n            var organismType = i < numberOfWorkers ? OrganismType.Worker : OrganismType.Explorer;\n\n            var randomSudoku = SudokuPSO.New(MatrixHelperPSO.RandomMatrix(_rnd, sudoku.CellValues));\n            var err = randomSudoku.Error;\n\n            hive[i] = new Organism(organismType, randomSudoku.CellValues, err, 0);\n\n            if (err < bestError)\n            {\n                bestError = err;\n                bestSolution = randomSudoku;\n            }\n        }\n\n        var epoch = 0;\n        while (epoch < MaxEpochs)\n        {\n            if (epoch % 1000 == 0)\n                Console.WriteLine($\"  Epoch {epoch}, Best error: {bestError}\");\n\n            if (bestError == 0)\n                break;\n\n            // Mise a jour de chaque organisme\n            for (var i = 0; i < NumOrganisms; ++i)\n            {\n                if (hive[i].Type == OrganismType.Worker)\n                {\n                    // Les workers explorent leur voisinage\n                    var neighbor = MatrixHelperPSO.NeighborMatrix(_rnd, sudoku.CellValues, hive[i].Matrix);\n                    var neighborSudoku = SudokuPSO.New(neighbor);\n                    var neighborError = neighborSudoku.Error;\n\n                    var p = _rnd.NextDouble();\n                    if (neighborError < hive[i].Error || p < MutationRate)\n                    {\n                        hive[i].Matrix = MatrixHelperPSO.DuplicateMatrix(neighbor);\n                        if (neighborError < hive[i].Error)\n                            hive[i].Age = 0;\n                        hive[i].Error = neighborError;\n\n                        if (neighborError < bestError)\n                        {\n                            bestError = neighborError;\n                            bestSolution = neighborSudoku;\n                        }\n                    }\n                    else\n                    {\n                        hive[i].Age++;\n                        if (hive[i].Age > MaxAge)\n                        {\n                            // Reinitialiser le worker stagne\n                            var randomSudoku = SudokuPSO.New(MatrixHelperPSO.RandomMatrix(_rnd, sudoku.CellValues));\n                            hive[i] = new Organism(OrganismType.Worker, randomSudoku.CellValues, randomSudoku.Error, 0);\n                        }\n                    }\n                }\n                else\n                {\n                    // Les explorers cherchent aleatoirement\n                    var randomSudoku = SudokuPSO.New(MatrixHelperPSO.RandomMatrix(_rnd, sudoku.CellValues));\n                    hive[i].Matrix = MatrixHelperPSO.DuplicateMatrix(randomSudoku.CellValues);\n                    hive[i].Error = randomSudoku.Error;\n\n                    if (hive[i].Error < bestError)\n                    {\n                        bestError = hive[i].Error;\n                        bestSolution = randomSudoku;\n                    }\n                }\n            }\n\n            // Fusion du meilleur worker avec le meilleur explorer\n            var bestWorkerIndex = Enumerable.Range(0, numberOfWorkers)\n                .OrderBy(i => hive[i].Error).First();\n            var bestExplorerIndex = Enumerable.Range(numberOfWorkers, NumOrganisms - numberOfWorkers)\n                .OrderBy(i => hive[i].Error).First();\n            var worstWorkerIndex = Enumerable.Range(0, numberOfWorkers)\n                .OrderByDescending(i => hive[i].Error).First();\n\n            var merged = MatrixHelperPSO.MergeMatrices(_rnd, hive[bestWorkerIndex].Matrix, hive[bestExplorerIndex].Matrix);\n            var mergedSudoku = SudokuPSO.New(merged);\n\n            hive[worstWorkerIndex] = new Organism(OrganismType.Worker, merged, mergedSudoku.Error, 0);\n            if (hive[worstWorkerIndex].Error < bestError)\n            {\n                bestError = hive[worstWorkerIndex].Error;\n                bestSolution = mergedSudoku;\n            }\n\n            ++epoch;\n        }\n\n        return bestSolution;\n    }\n}\n\nConsole.WriteLine(\"Classe PSOSudokuSolver definie.\");\n"
   },
   {
    "cell_type": "markdown",
@@ -795,9 +370,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 4. Test du solveur PSO"
-   ]
+   "source": "## 4. Test du solveur PSO"
   },
   {
    "cell_type": "code",
@@ -808,10 +381,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:22:01.276117Z",
-     "iopub.status.busy": "2026-05-02T18:22:01.275751Z",
-     "iopub.status.idle": "2026-05-02T18:22:01.366121Z",
-     "shell.execute_reply": "2026-05-02T18:22:01.365533Z"
+     "iopub.status.busy": "2026-08-20T23:54:17.221488Z",
+     "iopub.execute_input": "2026-08-20T23:54:17.222487Z",
+     "shell.execute_reply": "2026-08-20T23:54:17.264655Z",
+     "iopub.status.idle": "2026-08-20T23:54:17.264655Z"
     },
     "papermill": {
      "duration": 0.096904,
@@ -838,22 +411,13 @@
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": "-------------------------------\n| 9     2 |       5 | 4     3 | \n| 1       |    6  3 |    2  5 | \n| 5     8 | 4     7 |    6    | \n-------------------------------\n|    2  6 | 3     9 |       1 | \n|    5  7 |    1    | 2  9    | \n|    9    | 6  7    | 5  3    | \n-------------------------------\n| 2  4    | 5  3    | 6       | \n| 7     5 | 2       | 3     4 | \n|    8    |    4  1 | 9  5    | \n-------------------------------"
-     },
-     "metadata": {}
+     }
     }
    ],
-   "source": [
-    "// Chargement des puzzles via SudokuHelper\n",
-    "var puzzles = SudokuHelper.GetSudokus(SudokuDifficulty.Easy);\n",
-    "Console.WriteLine($\"{puzzles.Count} puzzles charges\");\n",
-    "\n",
-    "// Test sur un puzzle facile\n",
-    "var puzzle = puzzles[0];\n",
-    "Console.WriteLine(\"\\nPuzzle original:\");\n",
-    "display(puzzle.ToString());\n"
-   ]
+   "source": "// Chargement des puzzles via SudokuHelper\nvar puzzles = SudokuHelper.GetSudokus(SudokuDifficulty.Easy);\nConsole.WriteLine($\"{puzzles.Count} puzzles charges\");\n\n// Test sur un puzzle facile\nvar puzzle = puzzles[0];\nConsole.WriteLine(\"\\nPuzzle original:\");\ndisplay(puzzle.ToString());\n"
   },
   {
    "cell_type": "markdown",
@@ -868,9 +432,7 @@
     },
     "tags": []
    },
-   "source": [
-    "Résolution d'un puzzle Sudoku avec l'algorithme PSO."
-   ]
+   "source": "Résolution d'un puzzle Sudoku avec l'algorithme PSO."
   },
   {
    "cell_type": "code",
@@ -881,10 +443,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:22:01.398873Z",
-     "iopub.status.busy": "2026-05-02T18:22:01.398325Z",
-     "iopub.status.idle": "2026-05-02T18:22:01.536542Z",
-     "shell.execute_reply": "2026-05-02T18:22:01.536265Z"
+     "iopub.status.busy": "2026-08-20T23:54:17.264655Z",
+     "iopub.execute_input": "2026-08-20T23:54:17.264655Z",
+     "shell.execute_reply": "2026-08-20T23:54:17.364223Z",
+     "iopub.status.idle": "2026-08-20T23:54:17.364223Z"
     },
     "papermill": {
      "duration": 0.149628,
@@ -912,14 +474,14 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "\nSolution trouvee en 45ms:\r\n"
+     "text": "\nSolution trouvee en 51ms:\r\n"
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": "-------------------------------\n| 9  6  2 | 1  8  5 | 4  7  3 | \n| 1  7  4 | 9  6  3 | 8  2  5 | \n| 5  3  8 | 4  2  7 | 1  6  9 | \n-------------------------------\n| 8  2  6 | 3  5  9 | 7  4  1 | \n| 3  5  7 | 8  1  4 | 2  9  6 | \n| 4  9  1 | 6  7  2 | 5  3  8 | \n-------------------------------\n| 2  4  9 | 5  3  8 | 6  1  7 | \n| 7  1  5 | 2  9  6 | 3  8  4 | \n| 6  8  3 | 7  4  1 | 9  5  2 | \n-------------------------------"
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "stream",
@@ -927,24 +489,7 @@
      "text": "\nSolution valide: True\r\n"
     }
    ],
-   "source": [
-    "// Resolution avec PSO\n",
-    "var solver = new PSOSudokuSolver\n",
-    "{\n",
-    "    NumOrganisms = 200,\n",
-    "    MaxEpochs = 3000,\n",
-    "    MaxRestarts = 10\n",
-    "};\n",
-    "\n",
-    "var originalPuzzle = (SudokuGrid)puzzle.Clone();\n",
-    "var stopwatch = Stopwatch.StartNew();\n",
-    "var solution = solver.Solve(puzzle);\n",
-    "stopwatch.Stop();\n",
-    "\n",
-    "Console.WriteLine($\"\\nSolution trouvee en {stopwatch.ElapsedMilliseconds}ms:\");\n",
-    "display(solution.ToString());\n",
-    "Console.WriteLine($\"\\nSolution valide: {solution.IsValid(originalPuzzle)}\");\n"
-   ]
+   "source": "// Resolution avec PSO\nvar solver = new PSOSudokuSolver\n{\n    NumOrganisms = 200,\n    MaxEpochs = 3000,\n    MaxRestarts = 10\n};\n\nvar originalPuzzle = (SudokuGrid)puzzle.Clone();\nvar stopwatch = Stopwatch.StartNew();\nvar solution = solver.Solve(puzzle);\nstopwatch.Stop();\n\nConsole.WriteLine($\"\\nSolution trouvee en {stopwatch.ElapsedMilliseconds}ms:\");\ndisplay(solution.ToString());\nConsole.WriteLine($\"\\nSolution valide: {solution.IsValid(originalPuzzle)}\");\n"
   },
   {
    "cell_type": "markdown",
@@ -959,24 +504,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation : Première résolution\n",
-    "\n",
-    "**Sortie obtenue** : Le solveur a trouve une solution valide avec une seule tentative (Attempt 1/10). Le temps de résolution est mesuré en direct par la cellule 14 (`Stopwatch`) — re-exécutez-la pour la valeur courante (PSO est stochastique : le temps varie selon l'initialisation aléatoire).\n",
-    "\n",
-    "| Métrique | Signification |\n",
-    "|----------|---------------|\n",
-    "| Tentatives | 1/10 — l'initialisation etait favorable |\n",
-    "| Epoch initial error | Error initiale moyenne (plage typique 0-36, stochastique) |\n",
-    "| Solution valide | True — toutes les contraintes Sudoku respectées |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. **Convergence en une tentative** : L'essaim a converge vers error=0 sans redémarrage\n",
-    "2. **Performance rapide** : la résolution est très rapide pour une métaheuristique sur ce puzzle favorable\n",
-    "3. **Initialisation chanceuse** : La matrice aleatoire initiale etait déjà proche de la solution\n",
-    "\n",
-    "> **Note technique** : Cette performance (1 tentative) n'est pas representative. Le benchmark suivant montre que la résolution peut prendre plusieurs dizaines de secondes sur un puzzle de même difficulté. Cette variance illustre l'importance de l'initialisation aleatoire dans les métaheuristiques.\n"
-   ]
+   "source": "### Interprétation : Première résolution\n\n**Sortie obtenue** : Le solveur a trouve une solution valide avec une seule tentative (Attempt 1/10). Le temps de résolution est mesuré en direct par la cellule 14 (`Stopwatch`) — re-exécutez-la pour la valeur courante (PSO est stochastique : le temps varie selon l'initialisation aléatoire).\n\n| Métrique | Signification |\n|----------|---------------|\n| Tentatives | 1/10 — l'initialisation etait favorable |\n| Epoch initial error | Error initiale moyenne (plage typique 0-36, stochastique) |\n| Solution valide | True — toutes les contraintes Sudoku respectées |\n\n**Points clés** :\n1. **Convergence en une tentative** : L'essaim a converge vers error=0 sans redémarrage\n2. **Performance rapide** : la résolution est très rapide pour une métaheuristique sur ce puzzle favorable\n3. **Initialisation chanceuse** : La matrice aleatoire initiale etait déjà proche de la solution\n\n> **Note technique** : Cette performance (1 tentative) n'est pas representative. Le benchmark suivant montre que la résolution peut prendre plusieurs dizaines de secondes sur un puzzle de même difficulté. Cette variance illustre l'importance de l'initialisation aleatoire dans les métaheuristiques.\n"
   },
   {
    "cell_type": "markdown",
@@ -991,29 +519,25 @@
     },
     "tags": []
    },
-   "source": [
-    "## 5. Benchmark sur plusieurs puzzles"
-   ]
+   "source": "## 5. Benchmark sur plusieurs puzzles"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Exercice : Mesurer l'impact du nombre de particules\n",
-    "\n",
-    "**Objectif :**\n",
-    "Testez le solveur PSO avec différentes tailles d'essaim (10, 50, 100, 200)\n",
-    "et analysez l'impact sur le taux de succès et le temps de résolution.\n",
-    "\n",
-    "**Indice :**\n",
-    "Pour chaque taille, lancez le solveur sur les mêmes puzzles et comparez les résultats.\n"
-   ],
+   "source": "## Exercice : Mesurer l'impact du nombre de particules\n\n**Objectif :**\nTestez le solveur PSO avec différentes tailles d'essaim (10, 50, 100, 200)\net analysez l'impact sur le taux de succès et le temps de résolution.\n\n**Indice :**\nPour chaque taille, lancez le solveur sur les mêmes puzzles et comparez les résultats.\n",
    "id": "cell-49c662b6"
   },
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T23:54:17.365525Z",
+     "iopub.execute_input": "2026-08-20T23:54:17.365525Z",
+     "shell.execute_reply": "2026-08-20T23:54:17.379396Z",
+     "iopub.status.idle": "2026-08-20T23:54:17.379396Z"
+    }
+   },
    "outputs": [
     {
      "output_type": "stream",
@@ -1021,15 +545,7 @@
      "text": "Exercice a completer\r\n"
     }
    ],
-   "source": [
-    "// EXERCICE : Mesurer l'impact du nombre de particules\n",
-    "public Dictionary<int, (double SuccessRate, double AvgTime)> TestSwarmSizes(int[,] puzzle, int[] sizes)\n",
-    "{\n",
-    "    // TODO: Testez differentes tailles d'essaim et mesurez les performances\n",
-    "    return null; // TODO etudiant\n",
-    "}\n",
-    "Console.WriteLine(\"Exercice a completer\");"
-   ],
+   "source": "// EXERCICE : Mesurer l'impact du nombre de particules\npublic Dictionary<int, (double SuccessRate, double AvgTime)> TestSwarmSizes(int[,] puzzle, int[] sizes)\n{\n    // TODO: Testez differentes tailles d'essaim et mesurez les performances\n    return null; // TODO etudiant\n}\nConsole.WriteLine(\"Exercice a completer\");",
    "id": "cell-2ac33167"
   },
   {
@@ -1041,10 +557,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:22:01.568936Z",
-     "iopub.status.busy": "2026-05-02T18:22:01.568655Z",
-     "iopub.status.idle": "2026-05-02T18:23:06.622407Z",
-     "shell.execute_reply": "2026-05-02T18:23:06.622134Z"
+     "iopub.status.busy": "2026-08-20T23:54:17.380396Z",
+     "iopub.execute_input": "2026-08-20T23:54:17.380396Z",
+     "shell.execute_reply": "2026-08-20T23:54:59.018694Z",
+     "iopub.status.idle": "2026-08-20T23:54:59.019694Z"
     },
     "papermill": {
      "duration": 65.060946,
@@ -1072,7 +588,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Puzzle 1: 2ms - Succes\r\n"
+     "text": "Puzzle 1: 1ms - Succes\r\n"
     },
     {
      "output_type": "stream",
@@ -1212,7 +728,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Puzzle 2: 12339ms - Succes\r\n"
+     "text": "Puzzle 2: 13581ms - Succes\r\n"
     },
     {
      "output_type": "stream",
@@ -1267,7 +783,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Puzzle 3: 3843ms - Succes\r\n"
+     "text": "Puzzle 3: 4739ms - Succes\r\n"
     },
     {
      "output_type": "stream",
@@ -1472,7 +988,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Puzzle 4: 17252ms - Echec\r\n"
+     "text": "Puzzle 4: 20629ms - Echec\r\n"
     },
     {
      "output_type": "stream",
@@ -1507,7 +1023,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Puzzle 5: 2262ms - Succes\r\n"
+     "text": "Puzzle 5: 2617ms - Succes\r\n"
     },
     {
      "output_type": "stream",
@@ -1517,7 +1033,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Temps moyen: 7140ms\r\n"
+     "text": "  Temps moyen: 8313ms\r\n"
     },
     {
      "output_type": "stream",
@@ -1525,35 +1041,7 @@
      "text": "  Taux de succes: 80%\r\n"
     }
    ],
-   "source": [
-    "// Benchmark sur 5 puzzles faciles\n",
-    "var results = new List<(int puzzle, long timeMs, bool success)>();\n",
-    "\n",
-    "for (int i = 0; i < Math.Min(5, puzzles.Count); i++)\n",
-    "{\n",
-    "    var currentPuzzle = (SudokuGrid)puzzles[i].Clone();\n",
-    "    var currentOriginal = (SudokuGrid)puzzles[i].Clone();\n",
-    "    \n",
-    "    solver = new PSOSudokuSolver\n",
-    "    {\n",
-    "        NumOrganisms = 200,\n",
-    "        MaxEpochs = 3000,\n",
-    "        MaxRestarts = 10\n",
-    "    };\n",
-    "    \n",
-    "    var sw = Stopwatch.StartNew();\n",
-    "    solution = solver.Solve(currentPuzzle);\n",
-    "    sw.Stop();\n",
-    "    \n",
-    "    var isValid = solution.IsValid(currentOriginal);\n",
-    "    results.Add((i + 1, sw.ElapsedMilliseconds, isValid));\n",
-    "    Console.WriteLine($\"Puzzle {i + 1}: {sw.ElapsedMilliseconds}ms - {(isValid ? \"Succes\" : \"Echec\")}\");\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine($\"\\nResume:\");\n",
-    "Console.WriteLine($\"  Temps moyen: {results.Average(r => r.timeMs):0}ms\");\n",
-    "Console.WriteLine($\"  Taux de succes: {results.Count(r => r.success) * 100 / results.Count}%\");\n"
-   ]
+   "source": "// Benchmark sur 5 puzzles faciles\nvar results = new List<(int puzzle, long timeMs, bool success)>();\n\nfor (int i = 0; i < Math.Min(5, puzzles.Count); i++)\n{\n    var currentPuzzle = (SudokuGrid)puzzles[i].Clone();\n    var currentOriginal = (SudokuGrid)puzzles[i].Clone();\n    \n    solver = new PSOSudokuSolver\n    {\n        NumOrganisms = 200,\n        MaxEpochs = 3000,\n        MaxRestarts = 10\n    };\n    \n    var sw = Stopwatch.StartNew();\n    solution = solver.Solve(currentPuzzle);\n    sw.Stop();\n    \n    var isValid = solution.IsValid(currentOriginal);\n    results.Add((i + 1, sw.ElapsedMilliseconds, isValid));\n    Console.WriteLine($\"Puzzle {i + 1}: {sw.ElapsedMilliseconds}ms - {(isValid ? \"Succes\" : \"Echec\")}\");\n}\n\nConsole.WriteLine($\"\\nResume:\");\nConsole.WriteLine($\"  Temps moyen: {results.Average(r => r.timeMs):0}ms\");\nConsole.WriteLine($\"  Taux de succes: {results.Count(r => r.success) * 100 / results.Count}%\");\n"
   },
   {
    "cell_type": "markdown",
@@ -1568,28 +1056,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation : Performance sur puzzles faciles\n",
-    "\n",
-    "**Sortie obtenue** : Benchmark sur 5 puzzles faciles avec 200 organismes, 3000 epochs, 10 redémarrages. Les temps de résolution sont mesurés en direct par la cellule 19 (un `Stopwatch` par puzzle) — re-exécutez-la pour les valeurs courantes (PSO stochastique : grande variance selon l'initialisation).\n",
-    "\n",
-    "| Puzzle | Succès | Tentatives |\n",
-    "|--------|--------|------------|\n",
-    "| 1 | Oui | 1 |\n",
-    "| 2 | Oui | 7 |\n",
-    "| 3 | Oui | 3 |\n",
-    "| 4 | Non | 10 |\n",
-    "| 5 | Oui | 2 |\n",
-    "| **Taux de succès** | **80%** | - |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. **Grande variance** : les temps varient de quelques millisecondes a plusieurs dizaines de secondes selon la chance de l'initialisation (mesurés par la cellule 19)\n",
-    "2. **Taux de succès 80%** : Un puzzle (le 4) n'a pas été résolu malgré 10 tentatives\n",
-    "3. **Convergence rapide quand chanceux** : Le puzzle 1 a converge des l'epochs 0 (initialisation déjà sans erreur)\n",
-    "4. **Stagnation typique** : L'erreur reste souvent bloquee a 2-4 (pres de la solution mais bloquee)\n",
-    "\n",
-    "> **Note technique** : Cette heuristique d'essaim pour Sudoku souffre de problèmes d'optima locaux. L'erreur reste souvent bloquee a 2-4, ce qui signifie que quelques lignes/colonnes ont des doublons. Les redémarrages et la reinitialisation des workers stagnants ne suffisent pas toujours a échapper a ces optima locaux.\n"
-   ]
+   "source": "### Interprétation : Performance sur puzzles faciles\n\n**Sortie obtenue** : Benchmark sur 5 puzzles faciles avec 200 organismes, 3000 epochs, 10 redémarrages. Les temps de résolution sont mesurés en direct par la cellule 19 (un `Stopwatch` par puzzle) — re-exécutez-la pour les valeurs courantes (PSO stochastique : grande variance selon l'initialisation).\n\n| Puzzle | Succès | Tentatives |\n|--------|--------|------------|\n| 1 | Oui | 1 |\n| 2 | Oui | 7 |\n| 3 | Oui | 3 |\n| 4 | Non | 10 |\n| 5 | Oui | 2 |\n| **Taux de succès** | **80%** | - |\n\n**Points clés** :\n1. **Grande variance** : les temps varient de quelques millisecondes a plusieurs dizaines de secondes selon la chance de l'initialisation (mesurés par la cellule 19)\n2. **Taux de succès 80%** : Un puzzle (le 4) n'a pas été résolu malgré 10 tentatives\n3. **Convergence rapide quand chanceux** : Le puzzle 1 a converge des l'epochs 0 (initialisation déjà sans erreur)\n4. **Stagnation typique** : L'erreur reste souvent bloquee a 2-4 (pres de la solution mais bloquee)\n\n> **Note technique** : Cette heuristique d'essaim pour Sudoku souffre de problèmes d'optima locaux. L'erreur reste souvent bloquee a 2-4, ce qui signifie que quelques lignes/colonnes ont des doublons. Les redémarrages et la reinitialisation des workers stagnants ne suffisent pas toujours a échapper a ces optima locaux.\n"
   },
   {
    "cell_type": "markdown",
@@ -1604,29 +1071,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## 6. Influence des paramètres\n",
-    "\n",
-    "### Paramètres clés\n",
-    "\n",
-    "| Paramètre | Effet | Valeur recommandée |\n",
-    "|-----------|-------|-------------------|\n",
-    "| NumOrganisms | Taille de l'essaim | 100-300 |\n",
-    "| MaxEpochs | Itérations par essai | 3000-5000 |\n",
-    "| MaxRestarts | Redémarrages autorisés | 10-20 |\n",
-    "| WorkerRatio | Proportion de workers | 0.85-0.95 |\n",
-    "| MaxAge | Age max avant reinit | 500-1000 |\n",
-    "\n",
-    "### Comparaison avec GA et SA\n",
-    "\n",
-    "| Aspect | PSO | Algorithme Génétique | Recuit Simule |\n",
-    "|--------|-----|---------------------|---------------|\n",
-    "| Inspiration | Oiseaux/poissons | Evolution biologique | Thermodynamique |\n",
-    "| Population | Multiple | Multiple | Unique |\n",
-    "| Exploration | Workers + Explorers | Mutation | Temperature |\n",
-    "| Exploitation | Convergence vers gBest | Crossover | Refroidissement |\n",
-    "| Performance Sudoku | ~1-5s | ~1-10s | ~2-5s |"
-   ]
+   "source": "## 6. Influence des paramètres\n\n### Paramètres clés\n\n| Paramètre | Effet | Valeur recommandée |\n|-----------|-------|-------------------|\n| NumOrganisms | Taille de l'essaim | 100-300 |\n| MaxEpochs | Itérations par essai | 3000-5000 |\n| MaxRestarts | Redémarrages autorisés | 10-20 |\n| WorkerRatio | Proportion de workers | 0.85-0.95 |\n| MaxAge | Age max avant reinit | 500-1000 |\n\n### Comparaison avec GA et SA\n\n| Aspect | PSO | Algorithme Génétique | Recuit Simule |\n|--------|-----|---------------------|---------------|\n| Inspiration | Oiseaux/poissons | Evolution biologique | Thermodynamique |\n| Population | Multiple | Multiple | Unique |\n| Exploration | Workers + Explorers | Mutation | Temperature |\n| Exploitation | Convergence vers gBest | Crossover | Refroidissement |\n| Performance Sudoku | ~1-5s | ~1-10s | ~2-5s |"
   },
   {
    "cell_type": "code",
@@ -1637,10 +1082,10 @@
      "language": "csharp"
     },
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:23:06.725067Z",
-     "iopub.status.busy": "2026-05-02T18:23:06.724775Z",
-     "iopub.status.idle": "2026-05-02T18:23:06.838824Z",
-     "shell.execute_reply": "2026-05-02T18:23:06.838273Z"
+     "iopub.status.busy": "2026-08-20T23:54:59.020694Z",
+     "iopub.execute_input": "2026-08-20T23:54:59.020694Z",
+     "shell.execute_reply": "2026-08-20T23:54:59.064371Z",
+     "iopub.status.idle": "2026-08-20T23:54:59.064371Z"
     },
     "papermill": {
      "duration": 0.133082,
@@ -1683,7 +1128,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "Standard: 2ms - Succes\r\n"
+     "text": "Standard: 1ms - Succes\r\n"
     },
     {
      "output_type": "stream",
@@ -1701,55 +1146,25 @@
      "text": "Agressif: 1ms - Succes\r\n"
     }
    ],
-   "source": [
-    "// Test avec differents parametres\n",
-    "var configurations = new[]\n",
-    "{\n",
-    "    new { Name = \"Conservatif\", Organisms = 100, Epochs = 2000, Restarts = 5 },\n",
-    "    new { Name = \"Standard\", Organisms = 200, Epochs = 3000, Restarts = 10 },\n",
-    "    new { Name = \"Agressif\", Organisms = 300, Epochs = 5000, Restarts = 20 }\n",
-    "};\n",
-    "\n",
-    "var testPuzzle = (SudokuGrid)puzzles[0].Clone();\n",
-    "var testOriginal = (SudokuGrid)puzzles[0].Clone();\n",
-    "\n",
-    "foreach (var config in configurations)\n",
-    "{\n",
-    "    var testSolver = new PSOSudokuSolver\n",
-    "    {\n",
-    "        NumOrganisms = config.Organisms,\n",
-    "        MaxEpochs = config.Epochs,\n",
-    "        MaxRestarts = config.Restarts\n",
-    "    };\n",
-    "    \n",
-    "    var testPuzzleCopy = (SudokuGrid)testPuzzle.Clone();\n",
-    "    var testSw = Stopwatch.StartNew();\n",
-    "    var testSolution = testSolver.Solve(testPuzzleCopy);\n",
-    "    testSw.Stop();\n",
-    "    \n",
-    "    Console.WriteLine($\"{config.Name}: {testSw.ElapsedMilliseconds}ms - {(testSolution.IsValid(testOriginal) ? \"Succes\" : \"Echec\")}\");\n",
-    "}\n"
-   ]
+   "source": "// Test avec differents parametres\nvar configurations = new[]\n{\n    new { Name = \"Conservatif\", Organisms = 100, Epochs = 2000, Restarts = 5 },\n    new { Name = \"Standard\", Organisms = 200, Epochs = 3000, Restarts = 10 },\n    new { Name = \"Agressif\", Organisms = 300, Epochs = 5000, Restarts = 20 }\n};\n\nvar testPuzzle = (SudokuGrid)puzzles[0].Clone();\nvar testOriginal = (SudokuGrid)puzzles[0].Clone();\n\nforeach (var config in configurations)\n{\n    var testSolver = new PSOSudokuSolver\n    {\n        NumOrganisms = config.Organisms,\n        MaxEpochs = config.Epochs,\n        MaxRestarts = config.Restarts\n    };\n    \n    var testPuzzleCopy = (SudokuGrid)testPuzzle.Clone();\n    var testSw = Stopwatch.StartNew();\n    var testSolution = testSolver.Solve(testPuzzleCopy);\n    testSw.Stop();\n    \n    Console.WriteLine($\"{config.Name}: {testSw.ElapsedMilliseconds}ms - {(testSolution.IsValid(testOriginal) ? \"Succes\" : \"Echec\")}\");\n}\n"
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Exercice : Analyser la convergence du PSO\n",
-    "\n",
-    "**Objectif :**\n",
-    "Tracez la courbe de convergence (erreur minimale dans l'essaim en fonction\n",
-    "des itérations) pour un puzzle facile et un puzzle difficile.\n",
-    "\n",
-    "**Indice :**\n",
-    "Enregistrez la meilleure fitness a chaque itération et affichez avec un graphique.\n"
-   ],
+   "source": "## Exercice : Analyser la convergence du PSO\n\n**Objectif :**\nTracez la courbe de convergence (erreur minimale dans l'essaim en fonction\ndes itérations) pour un puzzle facile et un puzzle difficile.\n\n**Indice :**\nEnregistrez la meilleure fitness a chaque itération et affichez avec un graphique.\n",
    "id": "cell-e2a6d0af"
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T23:54:59.064371Z",
+     "iopub.execute_input": "2026-08-20T23:54:59.064371Z",
+     "shell.execute_reply": "2026-08-20T23:54:59.081690Z",
+     "iopub.status.idle": "2026-08-20T23:54:59.081690Z"
+    }
+   },
    "outputs": [
     {
      "output_type": "stream",
@@ -1757,16 +1172,7 @@
      "text": "Exercice a completer\r\n"
     }
    ],
-   "source": [
-    "// EXERCICE : Analyser la convergence du PSO\n",
-    "public List<int> TrackConvergence(int[,] puzzle, int maxIterations = 500)\n",
-    "{\n",
-    "    // TODO: Executez le PSO et enregistrez l'erreur minimale a chaque iteration\n",
-    "    // Retournez la liste des erreurs pour tracer la courbe de convergence\n",
-    "    return null; // TODO etudiant\n",
-    "}\n",
-    "Console.WriteLine(\"Exercice a completer\");"
-   ],
+   "source": "// EXERCICE : Analyser la convergence du PSO\npublic List<int> TrackConvergence(int[,] puzzle, int maxIterations = 500)\n{\n    // TODO: Executez le PSO et enregistrez l'erreur minimale a chaque iteration\n    // Retournez la liste des erreurs pour tracer la courbe de convergence\n    return null; // TODO etudiant\n}\nConsole.WriteLine(\"Exercice a completer\");",
    "id": "cell-f0a31030"
   },
   {
@@ -1782,18 +1188,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Exercice : Analyse et amélioration du PSO\n",
-    "\n",
-    "### Exemple 1 : Analyse de convergence\n",
-    "Modifiez le solveur pour enregistrer l'evolution de `bestError` au fil des epochs et affichez un graphique de convergence.\n",
-    "\n",
-    "### Exemple 2 : Adaptation dynamique\n",
-    "Implémentez une adaptation dynamique de `WorkerRatio` qui augmente l'exploration quand la solution stagne.\n",
-    "\n",
-    "### Exemple 3 : Hybride PSO-SA\n",
-    "Combinez PSO avec le recuit simule : utilisez SA pour affiner les solutions trouvees par PSO."
-   ]
+   "source": "## Exercice : Analyse et amélioration du PSO\n\n### Exemple 1 : Analyse de convergence\nModifiez le solveur pour enregistrer l'evolution de `bestError` au fil des epochs et affichez un graphique de convergence.\n\n### Exemple 2 : Adaptation dynamique\nImplémentez une adaptation dynamique de `WorkerRatio` qui augmente l'exploration quand la solution stagne.\n\n### Exemple 3 : Hybride PSO-SA\nCombinez PSO avec le recuit simule : utilisez SA pour affiner les solutions trouvees par PSO."
   },
   {
    "cell_type": "markdown",
@@ -1808,30 +1203,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Exercice : Hybride PSO avec Recherche Locale\n",
-    "\n",
-    "### Énoncé\n",
-    "\n",
-    "Implémentez un solveur **PSO hybride** qui, lorsque le meilleur organisme stagne pendant plus de `StagnationLimit` epochs, applique une **recherche locale intensive** sur sa solution. Cela permet d'échapper aux optima locaux.\n",
-    "\n",
-    "Modifiez `PSOSudokuSolver` en ajoutant :\n",
-    "\n",
-    "1. `LocalSearchImprove(int[,] matrix, int[,] problem, int maxAttempts)` : Applique des échanges dans tous les blocs et garde le meilleur\n",
-    "2. `StagnationLimit` : Seuil d'epochs sans amélioration avant declenchement\n",
-    "3. Dans la boucle principale : si `epochsWithoutImprovement >= StagnationLimit`, appliquer `LocalSearchImprove` sur `bestSolution`\n",
-    "\n",
-    "### Résultat attendu\n",
-    "\n",
-    "Le PSO hybride devrait :\n",
-    "- Avoir moins de redémarrages (restarts)\n",
-    "- Être plus fiable sur les puzzles difficiles\n",
-    "- Potentiellement être plus lent par epoch mais converger plus vite\n",
-    "\n",
-    "**Indice :**\n",
-    "\n",
-    "Pour `LocalSearchImprove`, essayez tous les échanges possibles dans chaque bloc (pas de melange aleatoire) et gardez celui qui réduit `error`. C'est une variante de la **recherche par descente de gradient locale** adaptee au Sudoku."
-   ]
+   "source": "## Exercice : Hybride PSO avec Recherche Locale\n\n### Énoncé\n\nImplémentez un solveur **PSO hybride** qui, lorsque le meilleur organisme stagne pendant plus de `StagnationLimit` epochs, applique une **recherche locale intensive** sur sa solution. Cela permet d'échapper aux optima locaux.\n\nModifiez `PSOSudokuSolver` en ajoutant :\n\n1. `LocalSearchImprove(int[,] matrix, int[,] problem, int maxAttempts)` : Applique des échanges dans tous les blocs et garde le meilleur\n2. `StagnationLimit` : Seuil d'epochs sans amélioration avant declenchement\n3. Dans la boucle principale : si `epochsWithoutImprovement >= StagnationLimit`, appliquer `LocalSearchImprove` sur `bestSolution`\n\n### Résultat attendu\n\nLe PSO hybride devrait :\n- Avoir moins de redémarrages (restarts)\n- Être plus fiable sur les puzzles difficiles\n- Potentiellement être plus lent par epoch mais converger plus vite\n\n**Indice :**\n\nPour `LocalSearchImprove`, essayez tous les échanges possibles dans chaque bloc (pas de melange aleatoire) et gardez celui qui réduit `error`. C'est une variante de la **recherche par descente de gradient locale** adaptee au Sudoku."
   },
   {
    "cell_type": "code",
@@ -1839,10 +1211,10 @@
    "id": "5ys6x786ahn",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-02T18:23:06.917416Z",
-     "iopub.status.busy": "2026-05-02T18:23:06.916889Z",
-     "iopub.status.idle": "2026-05-02T18:23:07.021563Z",
-     "shell.execute_reply": "2026-05-02T18:23:07.021111Z"
+     "iopub.status.busy": "2026-08-20T23:54:59.081690Z",
+     "iopub.execute_input": "2026-08-20T23:54:59.081690Z",
+     "iopub.status.idle": "2026-08-20T23:54:59.152034Z",
+     "shell.execute_reply": "2026-08-20T23:54:59.152435Z"
     },
     "papermill": {
      "duration": 0.123253,
@@ -1871,49 +1243,27 @@
    "cell_type": "markdown",
    "id": "tranche2-geneticsharp-md",
    "metadata": {},
-   "source": [
-    "## Tranche 2 (#10382) : resolution via GeneticSharp (moteur metaheuristique .NET)\n",
-    "\n",
-    "La **Tranche 1** (sections 2 a 6) implemente l'essaim **from scratch** (workers/explorers,\n",
-    "fusion bloc-par-bloc, redemarrages -- BCL .NET, 0 NuGet). C'est le moteur pedagogique :\n",
-    "comprendre la dynamique essaim sans librairie.\n",
-    "\n",
-    "**Point d'honnetete sur le jumeau Python** : le notebook Python declare `mealpy` (lib PyPI de\n",
-    "metaheuristiques, 233+ algorithmes dont PSO) mais en import **optionnel** (`try/except`) -- son\n",
-    "output committe atteste « mealpy non installe (optionnel) - ce notebook utilise PSO manuel ».\n",
-    "Cote Python comme cote C#, le PSO **execute** est donc manuel (numpy vs System.*) ; l'entree de\n",
-    "registre qui creditait mealpy avait ete redigee depuis la liste d'imports, pas depuis les appels\n",
-    "(meme classe de faux positif que GT-9 networkx, cf #10438). Le registre est corrige avec cette\n",
-    "tranche.\n",
-    "\n",
-    "La parite lib-vs-lib se joue donc sur le cote .NET : cette **Tranche 2** branche **GeneticSharp**,\n",
-    "la librairie .NET de reference pour les algorithmes evolutionnaires (deja en service dans\n",
-    "Sudoku-3 / Sudoku-4 / Search-5 du depot), prescrite pour cette paire par le bucket #10382\n",
-    "(« mealpy/simanneal -> MGS »). A l'instar de ce que `mealpy` offrirait cote Python, GeneticSharp\n",
-    "fournit l'infrastructure (`Population`, selection elite, crossover, mutation, criteres de\n",
-    "terminaison composes, executeur parallele TPL) : on y branche notre probleme Sudoku plutot que\n",
-    "de reimplementer le moteur. La Tranche 1 from scratch est conservee **en plus**, jamais remplacee.\n",
-    "\n",
-    "Le point de vue est complementaire : **essaim** (PSO, Tranche 1) vs **evolution populationnelle**\n",
-    "(GA, Tranche 2) sur les memes puzzles. L'enjeu technique specifique reste l'encodage : un GA de\n",
-    "Sudoku avec chiffres aleatoires par cellule vide converge tres mal ; on adopte l'encodage par\n",
-    "**permutation de ligne** (chaque ligne reste une permutation valide de ses chiffres manquants,\n",
-    "le GA n'optimise que les conflits colonnes + blocs), avec des operateurs **preservant la\n",
-    "structure de permutation** (crossover OX par ligne, mutation par echange intra-ligne)."
-   ]
+   "source": "## Tranche 2 (#10382) : resolution via GeneticSharp (moteur metaheuristique .NET)\n\nLa **Tranche 1** (sections 2 a 6) implemente l'essaim **from scratch** (workers/explorers,\nfusion bloc-par-bloc, redemarrages -- BCL .NET, 0 NuGet). C'est le moteur pedagogique :\ncomprendre la dynamique essaim sans librairie.\n\n**Point d'honnetete sur le jumeau Python** : le notebook Python declare `mealpy` (lib PyPI de\nmetaheuristiques, 233+ algorithmes dont PSO) mais en import **optionnel** (`try/except`) -- son\noutput committe atteste « mealpy non installe (optionnel) - ce notebook utilise PSO manuel ».\nCote Python comme cote C#, le PSO **execute** est donc manuel (numpy vs System.*) ; l'entree de\nregistre qui creditait mealpy avait ete redigee depuis la liste d'imports, pas depuis les appels\n(meme classe de faux positif que GT-9 networkx, cf #10438). Le registre est corrige avec cette\ntranche.\n\nLa parite lib-vs-lib se joue donc sur le cote .NET : cette **Tranche 2** branche **GeneticSharp**,\nla librairie .NET de reference pour les algorithmes evolutionnaires (deja en service dans\nSudoku-3 / Sudoku-4 / Search-5 du depot), prescrite pour cette paire par le bucket #10382\n(« mealpy/simanneal -> MGS »). A l'instar de ce que `mealpy` offrirait cote Python, GeneticSharp\nfournit l'infrastructure (`Population`, selection elite, crossover, mutation, criteres de\nterminaison composes, executeur parallele TPL) : on y branche notre probleme Sudoku plutot que\nde reimplementer le moteur. La Tranche 1 from scratch est conservee **en plus**, jamais remplacee.\n\nLe point de vue est complementaire : **essaim** (PSO, Tranche 1) vs **evolution populationnelle**\n(GA, Tranche 2) sur les memes puzzles. L'enjeu technique specifique reste l'encodage : un GA de\nSudoku avec chiffres aleatoires par cellule vide converge tres mal ; on adopte l'encodage par\n**permutation de ligne** (chaque ligne reste une permutation valide de ses chiffres manquants,\nle GA n'optimise que les conflits colonnes + blocs), avec des operateurs **preservant la\nstructure de permutation** (crossover OX par ligne, mutation par echange intra-ligne)."
   },
   {
    "cell_type": "code",
    "id": "tranche2-geneticsharp-classes",
    "execution_count": 13,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T23:54:59.153439Z",
+     "iopub.execute_input": "2026-08-20T23:54:59.153439Z",
+     "shell.execute_reply": "2026-08-20T23:54:59.243299Z",
+     "iopub.status.idle": "2026-08-20T23:54:59.243299Z"
+    }
+   },
    "outputs": [
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
-      "text/html": "<div><div></div><div><strong>Installing Packages</strong><ul><li><span>GeneticSharp</span></li></ul></div><div></div></div>"
-     },
-     "metadata": {}
+      "text/html": "<div><div></div><div></div><div><strong>Installed Packages</strong><ul><li><span>GeneticSharp, 3.1.4</span></li></ul></div></div>"
+     }
     },
     {
      "output_type": "stream",
@@ -1921,243 +1271,55 @@
      "text": "Tranche 2 prete : SudokuGeneticSharpSolver (chromosome permutation-ligne + operateurs custom thread-safe + contrat ISudokuSolver).\r\n"
     }
    ],
-   "source": [
-    "// === Tranche 2 (#10382) : pont lib-vs-lib vers GeneticSharp (moteur GA .NET de production) ===\n",
-    "// Chromosome par permutation de ligne + fitness conflits + operateurs custom preservant la\n",
-    "// structure (patron Sudoku-4, meme famille de machinery dans le depot).\n",
-    "#r \"nuget: GeneticSharp, 3.1.4\"\n",
-    "using GeneticSharp;\n",
-    "\n",
-    "// --- Chromosome : encodage par permutation de ligne ---\n",
-    "// Une gene par cellule vide ; pour chaque ligne, les cellules vides recoivent une permutation\n",
-    "// (Fisher-Yates) des chiffres manquants de cette ligne --> chaque ligne toujours valide (1-9\n",
-    "// sans doublon), le GA n'optimise que les conflits colonnes + blocs.\n",
-    "// NB : RandomizationProvider.Current (thread-safe) est obligatoire car GeneticSharp parallelise\n",
-    "// l'evaluation via TplTaskExecutor -- un System.Random statique partage provoquerait une course.\n",
-    "public class SudokuRowPermutationChromosome : ChromosomeBase\n",
-    "{\n",
-    "    public SudokuGrid Puzzle { get; }\n",
-    "    public List<(int row, int col)> EmptyCells { get; }\n",
-    "    public Dictionary<int, List<int>> MissingPerRow { get; }\n",
-    "\n",
-    "    public SudokuRowPermutationChromosome(SudokuGrid puzzle) : base(CountEmpty(puzzle))\n",
-    "    {\n",
-    "        Puzzle = puzzle;\n",
-    "        EmptyCells = new List<(int, int)>();\n",
-    "        MissingPerRow = new Dictionary<int, List<int>>();\n",
-    "        for (int r = 0; r < 9; r++)\n",
-    "        {\n",
-    "            var present = new HashSet<int>();\n",
-    "            for (int c = 0; c < 9; c++) if (puzzle.Cells[r, c] != 0) present.Add(puzzle.Cells[r, c]);\n",
-    "            MissingPerRow[r] = Enumerable.Range(1, 9).Where(d => !present.Contains(d)).ToList();\n",
-    "            for (int c = 0; c < 9; c++) if (puzzle.Cells[r, c] == 0) EmptyCells.Add((r, c));\n",
-    "        }\n",
-    "        CreateGenes();\n",
-    "    }\n",
-    "\n",
-    "    private static int CountEmpty(SudokuGrid p)\n",
-    "    {\n",
-    "        int n = 0;\n",
-    "        for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) if (p.Cells[r, c] == 0) n++;\n",
-    "        return n;\n",
-    "    }\n",
-    "\n",
-    "    private List<int> BuildGenes()\n",
-    "    {\n",
-    "        var rnd = RandomizationProvider.Current;\n",
-    "        var res = new List<int>();\n",
-    "        foreach (var grp in EmptyCells.GroupBy(e => e.row))\n",
-    "        {\n",
-    "            var missing = new List<int>(MissingPerRow[grp.Key]);\n",
-    "            for (int i = missing.Count - 1; i > 0; i--) { int j = rnd.GetInt(0, i + 1); (missing[i], missing[j]) = (missing[j], missing[i]); }\n",
-    "            int k = 0; foreach (var cell in grp) res.Add(missing[k++]);\n",
-    "        }\n",
-    "        return res;\n",
-    "    }\n",
-    "\n",
-    "    public override Gene GenerateGene(int index) => new Gene(RandomizationProvider.Current.GetInt(1, 10));\n",
-    "    protected override void CreateGenes() { var g = BuildGenes(); for (int i = 0; i < g.Count; i++) ReplaceGene(i, new Gene(g[i])); }\n",
-    "    public SudokuGrid ToSudokuGrid()\n",
-    "    {\n",
-    "        var g = (SudokuGrid)Puzzle.Clone();\n",
-    "        for (int i = 0; i < EmptyCells.Count; i++) { var (r, c) = EmptyCells[i]; g.Cells[r, c] = (int)GetGene(i).Value; }\n",
-    "        return g;\n",
-    "    }\n",
-    "    public override IChromosome CreateNew()\n",
-    "    {\n",
-    "        var ch = new SudokuRowPermutationChromosome(Puzzle);\n",
-    "        var g = BuildGenes(); for (int i = 0; i < g.Count; i++) ch.ReplaceGene(i, new Gene(g[i]));\n",
-    "        return ch;\n",
-    "    }\n",
-    "    public List<List<int>> RowGeneIndices() =>\n",
-    "        EmptyCells.Select((ec, i) => (ec, i)).GroupBy(x => x.ec.row).Select(g => g.Select(x => x.i).ToList()).ToList();\n",
-    "}\n",
-    "\n",
-    "// --- Fitness : minimiser les conflits (lignes deja valides par construction) ---\n",
-    "public class SudokuGeneticFitness : IFitness\n",
-    "{\n",
-    "    public double Evaluate(IChromosome chromosome)\n",
-    "    {\n",
-    "        var sc = (SudokuRowPermutationChromosome)chromosome;\n",
-    "        return -sc.ToSudokuGrid().NbErrors(sc.Puzzle);\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "// --- Mutation custom : echange de deux cellules DANS la meme ligne ---\n",
-    "public class SudokuRowSwapMutation : MutationBase\n",
-    "{\n",
-    "    public SudokuRowSwapMutation() { IsOrdered = true; }\n",
-    "    protected override void PerformMutate(IChromosome chromosome, float probability)\n",
-    "    {\n",
-    "        var rnd = RandomizationProvider.Current;\n",
-    "        var sc = (SudokuRowPermutationChromosome)chromosome;\n",
-    "        foreach (var rowIdxs in sc.RowGeneIndices())\n",
-    "        {\n",
-    "            if (rowIdxs.Count < 2 || rnd.GetDouble() > probability) continue;\n",
-    "            int a = rnd.GetInt(0, rowIdxs.Count), b = rnd.GetInt(0, rowIdxs.Count);\n",
-    "            if (a == b) continue;\n",
-    "            var ga = chromosome.GetGene(rowIdxs[a]);\n",
-    "            chromosome.ReplaceGene(rowIdxs[a], chromosome.GetGene(rowIdxs[b]));\n",
-    "            chromosome.ReplaceGene(rowIdxs[b], ga);\n",
-    "        }\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "// --- Crossover custom : Ordered Crossover (OX) applique PAR LIGNE ---\n",
-    "public class SudokuRowOrderedCrossover : CrossoverBase\n",
-    "{\n",
-    "    public SudokuRowOrderedCrossover() : base(2, 2) { }\n",
-    "    protected override IChromosome[] PerformCross(IList<IChromosome> parents)\n",
-    "    {\n",
-    "        var rnd = RandomizationProvider.Current;\n",
-    "        var p1 = (SudokuRowPermutationChromosome)parents[0];\n",
-    "        var p2 = (SudokuRowPermutationChromosome)parents[1];\n",
-    "        var c1 = (SudokuRowPermutationChromosome)p1.CreateNew();\n",
-    "        var c2 = (SudokuRowPermutationChromosome)p1.CreateNew();\n",
-    "        var rows = p1.RowGeneIndices();\n",
-    "        for (int ri = 0; ri < rows.Count; ri++)\n",
-    "        {\n",
-    "            var idxs = rows[ri];\n",
-    "            if (idxs.Count < 2) continue;\n",
-    "            int cutA = rnd.GetInt(0, idxs.Count), cutB = rnd.GetInt(0, idxs.Count);\n",
-    "            if (cutA > cutB) (cutA, cutB) = (cutB, cutA);\n",
-    "            OXRow(c1, p1, p2, idxs, cutA, cutB);\n",
-    "            OXRow(c2, p2, p1, idxs, cutA, cutB);\n",
-    "        }\n",
-    "        return new IChromosome[] { c1, c2 };\n",
-    "    }\n",
-    "    private static void OXRow(SudokuRowPermutationChromosome child,\n",
-    "        SudokuRowPermutationChromosome a, SudokuRowPermutationChromosome b, List<int> idxs, int cutA, int cutB)\n",
-    "    {\n",
-    "        var used = new HashSet<int>();\n",
-    "        for (int i = cutA; i <= cutB; i++) { int v = (int)a.GetGene(idxs[i]).Value; child.ReplaceGene(idxs[i], new Gene(v)); used.Add(v); }\n",
-    "        int fill = 0;\n",
-    "        for (int i = 0; i < idxs.Count; i++)\n",
-    "        {\n",
-    "            if (i >= cutA && i <= cutB) continue;\n",
-    "            while (fill < idxs.Count)\n",
-    "            {\n",
-    "                int v = (int)b.GetGene(idxs[fill]).Value; fill++;\n",
-    "                if (!used.Contains(v)) { child.ReplaceGene(idxs[i], new Gene(v)); used.Add(v); break; }\n",
-    "            }\n",
-    "        }\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "// --- Solver GeneticSharp exposant le contrat ISudokuSolver (meme interface que le PSO Tranche 1) ---\n",
-    "// Redemarrages symetriques au PSO : population stagne sans atteindre 0 conflit -> nouvelle population.\n",
-    "public class SudokuGeneticSharpSolver : ISudokuSolver\n",
-    "{\n",
-    "    public int PopulationSize { get; set; } = 500;\n",
-    "    public int MaxGenerations { get; set; } = 400;\n",
-    "    public int Stagnation { get; set; } = 80;\n",
-    "    public int MaxRestarts { get; set; } = 5;\n",
-    "    public int LastGenerations { get; private set; }\n",
-    "    public int LastRestarts { get; private set; }\n",
-    "\n",
-    "    public SudokuGrid Solve(SudokuGrid s)\n",
-    "    {\n",
-    "        SudokuGrid best = null;\n",
-    "        int bestErr = int.MaxValue;\n",
-    "        LastRestarts = 0;\n",
-    "        for (int restart = 0; restart <= MaxRestarts; restart++)\n",
-    "        {\n",
-    "            var fitness = new SudokuGeneticFitness();\n",
-    "            var pop = new Population(PopulationSize, PopulationSize, new SudokuRowPermutationChromosome(s));\n",
-    "            var ga = new GeneticAlgorithm(pop, fitness, new EliteSelection(),\n",
-    "                new SudokuRowOrderedCrossover(), new SudokuRowSwapMutation());\n",
-    "            ga.OperatorsStrategy = new TplOperatorsStrategy();\n",
-    "            ga.TaskExecutor = new TplTaskExecutor();\n",
-    "            ga.CrossoverProbability = 0.75f;\n",
-    "            ga.MutationProbability = 0.2f;\n",
-    "            ga.Termination = new OrTermination(new ITermination[] {\n",
-    "                new FitnessThresholdTermination(0),\n",
-    "                new FitnessStagnationTermination(Stagnation),\n",
-    "                new GenerationNumberTermination(MaxGenerations)\n",
-    "            });\n",
-    "            ga.Start();\n",
-    "            LastGenerations = ga.GenerationsNumber;\n",
-    "            LastRestarts = restart;\n",
-    "            var cand = ((SudokuRowPermutationChromosome)ga.Population.BestChromosome).ToSudokuGrid();\n",
-    "            int err = cand.NbErrors(s);\n",
-    "            if (err < bestErr) { bestErr = err; best = cand; }\n",
-    "            if (err == 0) return best;\n",
-    "        }\n",
-    "        return best;\n",
-    "    }\n",
-    "}\n",
-    "\n",
-    "Console.WriteLine(\"Tranche 2 prete : SudokuGeneticSharpSolver (chromosome permutation-ligne + operateurs custom thread-safe + contrat ISudokuSolver).\");"
-   ]
+   "source": "// === Tranche 2 (#10382) : pont lib-vs-lib vers GeneticSharp (moteur GA .NET de production) ===\n// Chromosome par permutation de ligne + fitness conflits + operateurs custom preservant la\n// structure (patron Sudoku-4, meme famille de machinery dans le depot).\n#r \"nuget: GeneticSharp, 3.1.4\"\nusing GeneticSharp;\n\n// --- Chromosome : encodage par permutation de ligne ---\n// Une gene par cellule vide ; pour chaque ligne, les cellules vides recoivent une permutation\n// (Fisher-Yates) des chiffres manquants de cette ligne --> chaque ligne toujours valide (1-9\n// sans doublon), le GA n'optimise que les conflits colonnes + blocs.\n// NB : RandomizationProvider.Current (thread-safe) est obligatoire car GeneticSharp parallelise\n// l'evaluation via TplTaskExecutor -- un System.Random statique partage provoquerait une course.\npublic class SudokuRowPermutationChromosome : ChromosomeBase\n{\n    public SudokuGrid Puzzle { get; }\n    public List<(int row, int col)> EmptyCells { get; }\n    public Dictionary<int, List<int>> MissingPerRow { get; }\n\n    public SudokuRowPermutationChromosome(SudokuGrid puzzle) : base(CountEmpty(puzzle))\n    {\n        Puzzle = puzzle;\n        EmptyCells = new List<(int, int)>();\n        MissingPerRow = new Dictionary<int, List<int>>();\n        for (int r = 0; r < 9; r++)\n        {\n            var present = new HashSet<int>();\n            for (int c = 0; c < 9; c++) if (puzzle.Cells[r, c] != 0) present.Add(puzzle.Cells[r, c]);\n            MissingPerRow[r] = Enumerable.Range(1, 9).Where(d => !present.Contains(d)).ToList();\n            for (int c = 0; c < 9; c++) if (puzzle.Cells[r, c] == 0) EmptyCells.Add((r, c));\n        }\n        CreateGenes();\n    }\n\n    private static int CountEmpty(SudokuGrid p)\n    {\n        int n = 0;\n        for (int r = 0; r < 9; r++) for (int c = 0; c < 9; c++) if (p.Cells[r, c] == 0) n++;\n        return n;\n    }\n\n    private List<int> BuildGenes()\n    {\n        var rnd = RandomizationProvider.Current;\n        var res = new List<int>();\n        foreach (var grp in EmptyCells.GroupBy(e => e.row))\n        {\n            var missing = new List<int>(MissingPerRow[grp.Key]);\n            for (int i = missing.Count - 1; i > 0; i--) { int j = rnd.GetInt(0, i + 1); (missing[i], missing[j]) = (missing[j], missing[i]); }\n            int k = 0; foreach (var cell in grp) res.Add(missing[k++]);\n        }\n        return res;\n    }\n\n    public override Gene GenerateGene(int index) => new Gene(RandomizationProvider.Current.GetInt(1, 10));\n    protected override void CreateGenes() { var g = BuildGenes(); for (int i = 0; i < g.Count; i++) ReplaceGene(i, new Gene(g[i])); }\n    public SudokuGrid ToSudokuGrid()\n    {\n        var g = (SudokuGrid)Puzzle.Clone();\n        for (int i = 0; i < EmptyCells.Count; i++) { var (r, c) = EmptyCells[i]; g.Cells[r, c] = (int)GetGene(i).Value; }\n        return g;\n    }\n    public override IChromosome CreateNew()\n    {\n        var ch = new SudokuRowPermutationChromosome(Puzzle);\n        var g = BuildGenes(); for (int i = 0; i < g.Count; i++) ch.ReplaceGene(i, new Gene(g[i]));\n        return ch;\n    }\n    public List<List<int>> RowGeneIndices() =>\n        EmptyCells.Select((ec, i) => (ec, i)).GroupBy(x => x.ec.row).Select(g => g.Select(x => x.i).ToList()).ToList();\n}\n\n// --- Fitness : minimiser les conflits (lignes deja valides par construction) ---\npublic class SudokuGeneticFitness : IFitness\n{\n    public double Evaluate(IChromosome chromosome)\n    {\n        var sc = (SudokuRowPermutationChromosome)chromosome;\n        return -sc.ToSudokuGrid().NbErrors(sc.Puzzle);\n    }\n}\n\n// --- Mutation custom : echange de deux cellules DANS la meme ligne ---\npublic class SudokuRowSwapMutation : MutationBase\n{\n    public SudokuRowSwapMutation() { IsOrdered = true; }\n    protected override void PerformMutate(IChromosome chromosome, float probability)\n    {\n        var rnd = RandomizationProvider.Current;\n        var sc = (SudokuRowPermutationChromosome)chromosome;\n        foreach (var rowIdxs in sc.RowGeneIndices())\n        {\n            if (rowIdxs.Count < 2 || rnd.GetDouble() > probability) continue;\n            int a = rnd.GetInt(0, rowIdxs.Count), b = rnd.GetInt(0, rowIdxs.Count);\n            if (a == b) continue;\n            var ga = chromosome.GetGene(rowIdxs[a]);\n            chromosome.ReplaceGene(rowIdxs[a], chromosome.GetGene(rowIdxs[b]));\n            chromosome.ReplaceGene(rowIdxs[b], ga);\n        }\n    }\n}\n\n// --- Crossover custom : Ordered Crossover (OX) applique PAR LIGNE ---\npublic class SudokuRowOrderedCrossover : CrossoverBase\n{\n    public SudokuRowOrderedCrossover() : base(2, 2) { }\n    protected override IChromosome[] PerformCross(IList<IChromosome> parents)\n    {\n        var rnd = RandomizationProvider.Current;\n        var p1 = (SudokuRowPermutationChromosome)parents[0];\n        var p2 = (SudokuRowPermutationChromosome)parents[1];\n        var c1 = (SudokuRowPermutationChromosome)p1.CreateNew();\n        var c2 = (SudokuRowPermutationChromosome)p1.CreateNew();\n        var rows = p1.RowGeneIndices();\n        for (int ri = 0; ri < rows.Count; ri++)\n        {\n            var idxs = rows[ri];\n            if (idxs.Count < 2) continue;\n            int cutA = rnd.GetInt(0, idxs.Count), cutB = rnd.GetInt(0, idxs.Count);\n            if (cutA > cutB) (cutA, cutB) = (cutB, cutA);\n            OXRow(c1, p1, p2, idxs, cutA, cutB);\n            OXRow(c2, p2, p1, idxs, cutA, cutB);\n        }\n        return new IChromosome[] { c1, c2 };\n    }\n    private static void OXRow(SudokuRowPermutationChromosome child,\n        SudokuRowPermutationChromosome a, SudokuRowPermutationChromosome b, List<int> idxs, int cutA, int cutB)\n    {\n        var used = new HashSet<int>();\n        for (int i = cutA; i <= cutB; i++) { int v = (int)a.GetGene(idxs[i]).Value; child.ReplaceGene(idxs[i], new Gene(v)); used.Add(v); }\n        int fill = 0;\n        for (int i = 0; i < idxs.Count; i++)\n        {\n            if (i >= cutA && i <= cutB) continue;\n            while (fill < idxs.Count)\n            {\n                int v = (int)b.GetGene(idxs[fill]).Value; fill++;\n                if (!used.Contains(v)) { child.ReplaceGene(idxs[i], new Gene(v)); used.Add(v); break; }\n            }\n        }\n    }\n}\n\n// --- Solver GeneticSharp exposant le contrat ISudokuSolver (meme interface que le PSO Tranche 1) ---\n// Redemarrages symetriques au PSO : population stagne sans atteindre 0 conflit -> nouvelle population.\npublic class SudokuGeneticSharpSolver : ISudokuSolver\n{\n    public int PopulationSize { get; set; } = 500;\n    public int MaxGenerations { get; set; } = 400;\n    public int Stagnation { get; set; } = 80;\n    public int MaxRestarts { get; set; } = 5;\n    public int LastGenerations { get; private set; }\n    public int LastRestarts { get; private set; }\n\n    public SudokuGrid Solve(SudokuGrid s)\n    {\n        SudokuGrid best = null;\n        int bestErr = int.MaxValue;\n        LastRestarts = 0;\n        for (int restart = 0; restart <= MaxRestarts; restart++)\n        {\n            var fitness = new SudokuGeneticFitness();\n            var pop = new Population(PopulationSize, PopulationSize, new SudokuRowPermutationChromosome(s));\n            var ga = new GeneticAlgorithm(pop, fitness, new EliteSelection(),\n                new SudokuRowOrderedCrossover(), new SudokuRowSwapMutation());\n            ga.OperatorsStrategy = new TplOperatorsStrategy();\n            ga.TaskExecutor = new TplTaskExecutor();\n            ga.CrossoverProbability = 0.75f;\n            ga.MutationProbability = 0.2f;\n            ga.Termination = new OrTermination(new ITermination[] {\n                new FitnessThresholdTermination(0),\n                new FitnessStagnationTermination(Stagnation),\n                new GenerationNumberTermination(MaxGenerations)\n            });\n            ga.Start();\n            LastGenerations = ga.GenerationsNumber;\n            LastRestarts = restart;\n            var cand = ((SudokuRowPermutationChromosome)ga.Population.BestChromosome).ToSudokuGrid();\n            int err = cand.NbErrors(s);\n            if (err < bestErr) { bestErr = err; best = cand; }\n            if (err == 0) return best;\n        }\n        return best;\n    }\n}\n\nConsole.WriteLine(\"Tranche 2 prete : SudokuGeneticSharpSolver (chromosome permutation-ligne + operateurs custom thread-safe + contrat ISudokuSolver).\");"
   },
   {
    "cell_type": "code",
    "id": "tranche2-geneticsharp-demo",
    "execution_count": 14,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T23:54:59.244299Z",
+     "iopub.execute_input": "2026-08-20T23:54:59.244299Z",
+     "shell.execute_reply": "2026-08-20T23:54:59.552110Z",
+     "iopub.status.idle": "2026-08-20T23:54:59.552110Z"
+    }
+   },
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "GeneticSharp : Resolu en 301 ms (33 generations, restart 0)\r\n"
+     "text": "GeneticSharp : Resolu en 259 ms (28 generations, restart 0)\r\n"
     },
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": "-------------------------------\n| 9  6  2 | 1  8  5 | 4  7  3 | \n| 1  7  4 | 9  6  3 | 8  2  5 | \n| 5  3  8 | 4  2  7 | 1  6  9 | \n-------------------------------\n| 8  2  6 | 3  5  9 | 7  4  1 | \n| 3  5  7 | 8  1  4 | 2  9  6 | \n| 4  9  1 | 6  7  2 | 5  3  8 | \n-------------------------------\n| 2  4  9 | 5  3  8 | 6  1  7 | \n| 7  1  5 | 2  9  6 | 3  8  4 | \n| 6  8  3 | 7  4  1 | 9  5  2 | \n-------------------------------"
-     },
-     "metadata": {}
+     }
     }
    ],
-   "source": [
-    "// Resolution du meme puzzle facile que la section 4 (Tranche 1), via GeneticSharp (Tranche 2)\n",
-    "var gaSolver = new SudokuGeneticSharpSolver { PopulationSize = 500, MaxGenerations = 400, Stagnation = 80, MaxRestarts = 5 };\n",
-    "// NB : PSOSudokuSolver.Solve mute la grille passee en place -- puzzles[0] est deja remplie\n",
-    "// par la demo de la section 4 ; on charge une instance FRAICHE du meme puzzle facile.\n",
-    "var gaFresh = SudokuHelper.GetSudokus(SudokuDifficulty.Easy)[0];\n",
-    "var gaPuzzle = (SudokuGrid)gaFresh.Clone();\n",
-    "var gaOriginal = (SudokuGrid)gaFresh.Clone();\n",
-    "\n",
-    "var gaSw = Stopwatch.StartNew();\n",
-    "var gaSolution = gaSolver.Solve(gaPuzzle);\n",
-    "gaSw.Stop();\n",
-    "\n",
-    "Console.WriteLine($\"GeneticSharp : {(gaSolution.IsValid(gaOriginal) ? \"Resolu\" : \"echec\")} en {gaSw.Elapsed.TotalMilliseconds:F0} ms ({gaSolver.LastGenerations} generations, restart {gaSolver.LastRestarts})\");\n",
-    "display(gaSolution.ToString());"
-   ]
+   "source": "// Resolution du meme puzzle facile que la section 4 (Tranche 1), via GeneticSharp (Tranche 2)\nvar gaSolver = new SudokuGeneticSharpSolver { PopulationSize = 500, MaxGenerations = 400, Stagnation = 80, MaxRestarts = 5 };\n// NB : PSOSudokuSolver.Solve mute la grille passee en place -- puzzles[0] est deja remplie\n// par la demo de la section 4 ; on charge une instance FRAICHE du meme puzzle facile.\nvar gaFresh = SudokuHelper.GetSudokus(SudokuDifficulty.Easy)[0];\nvar gaPuzzle = (SudokuGrid)gaFresh.Clone();\nvar gaOriginal = (SudokuGrid)gaFresh.Clone();\n\nvar gaSw = Stopwatch.StartNew();\nvar gaSolution = gaSolver.Solve(gaPuzzle);\ngaSw.Stop();\n\nConsole.WriteLine($\"GeneticSharp : {(gaSolution.IsValid(gaOriginal) ? \"Resolu\" : \"echec\")} en {gaSw.Elapsed.TotalMilliseconds:F0} ms ({gaSolver.LastGenerations} generations, restart {gaSolver.LastRestarts})\");\ndisplay(gaSolution.ToString());"
   },
   {
    "cell_type": "code",
    "id": "tranche2-geneticsharp-compare",
    "execution_count": 15,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T23:54:59.554087Z",
+     "iopub.execute_input": "2026-08-20T23:54:59.554087Z",
+     "shell.execute_reply": "2026-08-20T23:56:26.713594Z",
+     "iopub.status.idle": "2026-08-20T23:56:26.713594Z"
+    }
+   },
    "outputs": [
     {
      "output_type": "display_data",
+     "metadata": {},
      "data": {
       "text/plain": "Running tests..."
-     },
-     "metadata": {}
+     }
     },
     {
      "output_type": "stream",
@@ -2507,97 +1669,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  Epoch 1000, Best error: 4\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 2000, Best error: 4\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Attempt 9/10\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 0, Best error: 37\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
      "text": "Attempt 1/10\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 0, Best error: 38\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 1000, Best error: 4\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 1000, Best error: 14\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 2000, Best error: 4\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 2000, Best error: 14\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Attempt 10/10\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 0, Best error: 35\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Attempt 2/10\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 0, Best error: 37\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 1000, Best error: 6\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 1000, Best error: 7\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 2000, Best error: 4\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "  Epoch 2000, Best error: 7\r\n"
-    },
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": "Attempt 3/10\r\n"
     },
     {
      "output_type": "stream",
@@ -2612,7 +1684,97 @@
     {
      "output_type": "stream",
      "name": "stdout",
+     "text": "  Epoch 1000, Best error: 27\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
      "text": "  Epoch 2000, Best error: 4\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 2000, Best error: 27\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Attempt 9/10\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 0, Best error: 37\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Attempt 2/10\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 0, Best error: 39\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 1000, Best error: 8\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 1000, Best error: 29\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 2000, Best error: 8\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Attempt 10/10\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 0, Best error: 36\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 2000, Best error: 28\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 1000, Best error: 27\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "Attempt 3/10\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 0, Best error: 34\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 2000, Best error: 19\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 1000, Best error: 21\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "  Epoch 2000, Best error: 21\r\n"
     },
     {
      "output_type": "stream",
@@ -2762,7 +1924,7 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  PSO from scratch (Tranche 1) | Easy | 15387 ms | 3 resolus | Success\r\n"
+     "text": "  PSO from scratch (Tranche 1) | Easy | 17793 ms | 3 resolus | Success\r\n"
     },
     {
      "output_type": "stream",
@@ -2772,123 +1934,121 @@
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  PSO from scratch (Tranche 1) | Hard | 15011 ms | 0 resolus | Disqualified\r\n"
+     "text": "  PSO from scratch (Tranche 1) | Hard | 15005 ms | 0 resolus | Disqualified\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  GeneticSharp (Tranche 2, moteur prod) | Easy | 7144 ms | 1 resolus | Disqualified\r\n"
+     "text": "  GeneticSharp (Tranche 2, moteur prod) | Easy | 9455 ms | 1 resolus | Disqualified\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  GeneticSharp (Tranche 2, moteur prod) | Medium | 12638 ms | 0 resolus | Disqualified\r\n"
+     "text": "  GeneticSharp (Tranche 2, moteur prod) | Medium | 14736 ms | 0 resolus | Disqualified\r\n"
     },
     {
      "output_type": "stream",
      "name": "stdout",
-     "text": "  GeneticSharp (Tranche 2, moteur prod) | Hard | 14315 ms | 0 resolus | Disqualified\r\n"
+     "text": "  GeneticSharp (Tranche 2, moteur prod) | Hard | 14451 ms | 0 resolus | Disqualified\r\n"
     }
    ],
-   "source": [
-    "// Comparaison des deux familles metaheuristiques sur les memes puzzles :\n",
-    "// essaim PSO (Tranche 1, from scratch) vs evolution GA (Tranche 2, moteur GeneticSharp).\n",
-    "// Borne a 3 puzzles et 15 s par difficulte pour garder un temps de notebook raisonnable.\n",
-    "var tranche2Solvers = new List<(string Name, ISudokuSolver Solver)>\n",
-    "{\n",
-    "    (\"PSO from scratch (Tranche 1)\", new PSOSudokuSolver\n",
-    "    {\n",
-    "        NumOrganisms = 200, MaxEpochs = 3000, MaxRestarts = 10\n",
-    "    }),\n",
-    "    (\"GeneticSharp (Tranche 2, moteur prod)\", new SudokuGeneticSharpSolver\n",
-    "    {\n",
-    "        PopulationSize = 500, MaxGenerations = 400, Stagnation = 80, MaxRestarts = 5\n",
-    "    })\n",
-    "};\n",
-    "\n",
-    "var tranche2Comparison = SudokuHelper.TestSolvers(tranche2Solvers, numberOfSudokus: 3, timeLimitMilliseconds: 15000);\n",
-    "Console.WriteLine(\"Comparaison PSO (Tranche 1, from scratch) vs GeneticSharp (Tranche 2, moteur production) :\");\n",
-    "foreach (var r in tranche2Comparison)\n",
-    "    Console.WriteLine($\"  {r.SolverName} | {r.Difficulty} | {r.Time:F0} ms | {r.SolvedCount} resolus | {r.Status}\");\n",
-    "SudokuHelper.DisplayResults(tranche2Comparison);"
-   ]
+   "source": "// Comparaison des deux familles metaheuristiques sur les memes puzzles :\n// essaim PSO (Tranche 1, from scratch) vs evolution GA (Tranche 2, moteur GeneticSharp).\n// Borne a 3 puzzles et 15 s par difficulte pour garder un temps de notebook raisonnable.\nvar tranche2Solvers = new List<(string Name, ISudokuSolver Solver)>\n{\n    (\"PSO from scratch (Tranche 1)\", new PSOSudokuSolver\n    {\n        NumOrganisms = 200, MaxEpochs = 3000, MaxRestarts = 10\n    }),\n    (\"GeneticSharp (Tranche 2, moteur prod)\", new SudokuGeneticSharpSolver\n    {\n        PopulationSize = 500, MaxGenerations = 400, Stagnation = 80, MaxRestarts = 5\n    })\n};\n\nvar tranche2Comparison = SudokuHelper.TestSolvers(tranche2Solvers, numberOfSudokus: 3, timeLimitMilliseconds: 15000);\nConsole.WriteLine(\"Comparaison PSO (Tranche 1, from scratch) vs GeneticSharp (Tranche 2, moteur production) :\");\nforeach (var r in tranche2Comparison)\n    Console.WriteLine($\"  {r.SolverName} | {r.Difficulty} | {r.Time:F0} ms | {r.SolvedCount} resolus | {r.Status}\");\nSudokuHelper.DisplayResults(tranche2Comparison);"
   },
   {
    "cell_type": "markdown",
    "id": "tranche2-geneticsharp-interp",
    "metadata": {},
-   "source": [
-    "### Interpretation : GeneticSharp vs essaim PSO sur Sudoku\n",
-    "\n",
-    "Les deux familles metaheuristiques attaquent les memes puzzles avec des dynamiques opposees :\n",
-    "\n",
-    "- **PSO (Tranche 1, from scratch)** : un essaim segmente workers/explorers. Chaque worker\n",
-    "  exploite son voisinage (echange intra-bloc), les explorers resamplent aleatoirement, et le\n",
-    "  meilleur worker fusionne bloc-par-bloc avec le meilleur explorer -- la memorisation est\n",
-    "  implicite (la fusion propage les bons blocs), il n'y a ni vitesse ni pbest/gbest continus :\n",
-    "  c'est une adaptation essaim a l'espace discret du Sudoku.\n",
-    "- **GA (Tranche 2, GeneticSharp)** : une population d'individus combinee par crossover OX par\n",
-    "  ligne et mutation par echange intra-ligne, selection elite, redemarrages en cas de stagnation.\n",
-    "  L'encodage par permutation de ligne est crucial : il garantit des lignes valides par\n",
-    "  construction et reduit l'espace de recherche aux conflits colonnes + blocs.\n",
-    "\n",
-    "Sur la comparaison ci-dessus : aucune des deux familles ne resout Medium/Hard sous la borne de 15 s\n",
-    "(meme constat que Sudoku-4) ; sur les faciles, le GA de production resout 2 puzzles sur 3 contre 1 sur 3\n",
-    "a l'essaim from scratch sur cette execution. Les metaheuristiques sont ici des vehicules pedagogiques :\n",
-    "elles demontrent des dynamiques de recherche, pas une competitivite face a un solveur dedie.\n",
-    "\n",
-    "**Lecon d'ingenierie GeneticSharp** (identique a Sudoku-4, confirmee ici) :\n",
-    "1. **Encodage structurel** : un encodage respectant les contraintes (permutation par ligne)\n",
-    "   fait converger la ou l'encodage naif (chiffre aleatoire par cellule) stagne.\n",
-    "2. **Operateurs preservant la structure** : crossover/mutation standards *brisent* les\n",
-    "   permutations ; les operateurs custom (OX par ligne, echange intra-ligne) preservent l'invariant.\n",
-    "3. **Thread-safety** : `RandomizationProvider.Current` (fourni par GeneticSharp) est obligatoire\n",
-    "   face a la parallelisation TPL de l'evaluation.\n",
-    "\n",
-    "**Lecon lib-vs-lib** : GeneticSharp nous a evite de reimplementer l'infrastructure (population,\n",
-    "selection, terminaisons composees, parallelisme, redemarrages) ; l'effort s'est concentre sur ce\n",
-    "qui est specifique au Sudoku -- encodage et operateurs. Le jumeau Python, dont l'import mealpy\n",
-    "optionnel n'est pas installe, reste pour sa part en implementation manuelle numpy : la mise a\n",
-    "niveau engine (installer mealpy cote Python, ou pont PythonNet) est tracee au registre twin_pairs."
-   ]
+   "source": "### Interpretation : GeneticSharp vs essaim PSO sur Sudoku\n\nLes deux familles metaheuristiques attaquent les memes puzzles avec des dynamiques opposees :\n\n- **PSO (Tranche 1, from scratch)** : un essaim segmente workers/explorers. Chaque worker\n  exploite son voisinage (echange intra-bloc), les explorers resamplent aleatoirement, et le\n  meilleur worker fusionne bloc-par-bloc avec le meilleur explorer -- la memorisation est\n  implicite (la fusion propage les bons blocs), il n'y a ni vitesse ni pbest/gbest continus :\n  c'est une adaptation essaim a l'espace discret du Sudoku.\n- **GA (Tranche 2, GeneticSharp)** : une population d'individus combinee par crossover OX par\n  ligne et mutation par echange intra-ligne, selection elite, redemarrages en cas de stagnation.\n  L'encodage par permutation de ligne est crucial : il garantit des lignes valides par\n  construction et reduit l'espace de recherche aux conflits colonnes + blocs.\n\nSur la comparaison ci-dessus : aucune des deux familles ne resout Medium/Hard sous la borne de 15 s\n(meme constat que Sudoku-4) ; sur les faciles, le GA de production resout 2 puzzles sur 3 contre 1 sur 3\na l'essaim from scratch sur cette execution. Les metaheuristiques sont ici des vehicules pedagogiques :\nelles demontrent des dynamiques de recherche, pas une competitivite face a un solveur dedie.\n\n**Lecon d'ingenierie GeneticSharp** (identique a Sudoku-4, confirmee ici) :\n1. **Encodage structurel** : un encodage respectant les contraintes (permutation par ligne)\n   fait converger la ou l'encodage naif (chiffre aleatoire par cellule) stagne.\n2. **Operateurs preservant la structure** : crossover/mutation standards *brisent* les\n   permutations ; les operateurs custom (OX par ligne, echange intra-ligne) preservent l'invariant.\n3. **Thread-safety** : `RandomizationProvider.Current` (fourni par GeneticSharp) est obligatoire\n   face a la parallelisation TPL de l'evaluation.\n\n**Lecon lib-vs-lib** : GeneticSharp nous a evite de reimplementer l'infrastructure (population,\nselection, terminaisons composees, parallelisme, redemarrages) ; l'effort s'est concentre sur ce\nqui est specifique au Sudoku -- encodage et operateurs. Le jumeau Python, dont l'import mealpy\noptionnel n'est pas installe, reste pour sa part en implementation manuelle numpy : la mise a\nniveau engine (installer mealpy cote Python, ou pont PythonNet) est tracee au registre twin_pairs."
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Tranche 3 (#11977) : le PSO canonique à vélocité via MetaGeneticSharp (lib maison)\n\nLes tranches 1 et 2 ont comparé un essaim PSO écrit à la main et un GA de production.\nLa librairie maison **MetaGeneticSharp** (MGS, submodule `Search/MetaGeneticSharp`) expose\ndésormais le **PSO canonique à vélocité** — la récurrence complète de Shi & Eberhart (1998) :\n\n$$v = w \\cdot v_{prev} + c_1 r_1 (pbest_i - x_i) + c_2 r_2 (gbest - x_i) \\quad ; \\quad x' = x + v$$\n\navec mémoire par-particule (vitesse + record personnel), ce que le bare-bones de Kennedy\n(traction gaussienne sans vitesse) n'exprime pas. C'est exactement la variante que `mealpy`\nfait tourner côté Python (`Sudoku-5-PSO-Python`) : cette tranche donne au notebook C# sa\njambe MGS, pour une comparaison lib-vs-lib à moteur égal (#10382, #11977).\n\n**Encodage** : contrairement au GA de la Tranche 2 (permutations par ligne, gènes entiers),\nle PSO canonique vit dans un espace **continu** — chaque cellule vide est un gene `double`,\ndécodée par arrondi vers 1..9. La validité des lignes n'est donc PAS garantie par\nconstruction ici : le fitness compte les conflits lignes + colonnes + blocs.",
+   "id": "dd1cfbae"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T23:56:26.715105Z",
+     "iopub.execute_input": "2026-08-20T23:56:26.715514Z",
+     "shell.execute_reply": "2026-08-20T23:56:26.823110Z",
+     "iopub.status.idle": "2026-08-20T23:56:26.823638Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "MGS charge. Compound PSO canonique : w=0.7298, c1=c2=1.49618 (Clerc constriction).\r\n"
+    }
+   ],
+   "source": "// === Tranche 3 (#11977) : PSO canonique à vélocité via MetaGeneticSharp (submodule) ===\n// DLLs du build local du submodule (cf MGS-1) ; GeneticSharp 3.1.4 déjà chargé en Tranche 2\n// reste la source résolue pour l'API standard (EliteSelection, UniformCrossover...) — MGS\n// embarque sa couche Metaheuristics au-dessus de cette API (cohabitation vérifiée firsthand).\n#r \"../Search/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/GeneticSharp.Infrastructure.Framework.dll\"\n#r \"../Search/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Infrastructure.dll\"\n#r \"../Search/MetaGeneticSharp/src/MetaGeneticSharp.Domain/bin/Debug/net9.0/MetaGeneticSharp.Domain.dll\"\nusing MetaGeneticSharp;\n\n// --- Chromosome continu : une gene double par cellule vide, bornes [1, 10) --- //\npublic class SudokuPsoChromosome : ChromosomeBase\n{\n    public SudokuGrid Puzzle { get; }\n    public List<(int row, int col)> EmptyCells { get; }\n    private const double LO = 1.0, HI = 10.0;\n\n    public SudokuPsoChromosome(SudokuGrid puzzle) : base(CountEmpty(puzzle))\n    {\n        Puzzle = puzzle;\n        EmptyCells = new List<(int, int)>();\n        for (int r = 0; r < 9; r++)\n            for (int c = 0; c < 9; c++)\n                if (puzzle.Cells[r, c] == 0) EmptyCells.Add((r, c));\n        CreateGenes();\n    }\n    private static int CountEmpty(SudokuGrid p)\n    { int n = 0; foreach (var v in p.Cells) if (v == 0) n++; return n; }\n\n    public override Gene GenerateGene(int index)\n        => new Gene(RandomizationProvider.Current.GetDouble(LO, HI));\n    public override IChromosome CreateNew() => new SudokuPsoChromosome(Puzzle);\n\n    // Decodage : arrondi + clamp vers 1..9\n    public SudokuGrid ToSudokuGrid()\n    {\n        var g = (SudokuGrid)Puzzle.Clone();\n        for (int i = 0; i < EmptyCells.Count; i++)\n        {\n            var (r, c) = EmptyCells[i];\n            double v = (double)GetGene(i).Value;\n            g.Cells[r, c] = Math.Max(1, Math.Min(9, (int)Math.Round(v)));\n        }\n        return g;\n    }\n}\n\n// --- Fitness : -conflits totaux (lignes + colonnes + blocs : rien n'est valide par construction) --- //\npublic class SudokuPsoFitness : IFitness\n{\n    public double Evaluate(IChromosome chromosome)\n        => -SudokuMgsPsoSolver.CountConflicts(((SudokuPsoChromosome)chromosome).ToSudokuGrid());\n}\n\n// --- Solver : MetaGeneticAlgorithm + compound ParticleSwarmOptimization (Clerc constriction) --- //\npublic class SudokuMgsPsoSolver\n{\n    public int PopulationSize { get; set; } = 500;\n    public int MaxGenerations { get; set; } = 400;\n\n    public (SudokuGrid grid, double fitness, int ms) Solve(SudokuGrid puzzle)\n    {\n        var compound = MetaHeuristicsService.CreateMetaHeuristicByName(\n            \"ParticleSwarmOptimization\", maxGenerations: MaxGenerations, populationSize: PopulationSize);\n        var adam = new SudokuPsoChromosome(puzzle);\n        var pop = new MetaPopulation(PopulationSize, PopulationSize, adam);\n        var ga = new MetaGeneticAlgorithm(\n            pop, new SudokuPsoFitness(),\n            new EliteSelection(), new UniformCrossover(0.5f), new UniformMutation(true),\n            compound);\n        ga.Termination = new GenerationNumberTermination(MaxGenerations);\n        ga.Start();\n        var best = (SudokuPsoChromosome)ga.BestChromosome;\n        var ms = 0; // mesure au call-site (Stopwatch)\n        return (best.ToSudokuGrid(), best.Fitness ?? double.NegativeInfinity, ms);\n    }\n\n    public static int CountConflicts(SudokuGrid g)\n    {\n        int conflicts = 0;\n        for (int i = 0; i < 9; i++)\n        {\n            var row = new HashSet<int>(); var col = new HashSet<int>(); var blk = new HashSet<int>();\n            for (int j = 0; j < 9; j++)\n            {\n                if (!row.Add(g.Cells[i, j])) conflicts++;\n                if (!col.Add(g.Cells[j, i])) conflicts++;\n                int br = 3 * (i / 3) + j / 3, bc = 3 * (i % 3) + j % 3;\n                if (!blk.Add(g.Cells[br, bc])) conflicts++;\n            }\n        }\n        return conflicts;\n    }\n}\n\nConsole.WriteLine(\"MGS charge. Compound PSO canonique : w=0.7298, c1=c2=1.49618 (Clerc constriction).\");",
+   "id": "bf449d86"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T23:56:26.825207Z",
+     "iopub.execute_input": "2026-08-20T23:56:26.825207Z",
+     "shell.execute_reply": "2026-08-20T23:56:58.010568Z",
+     "iopub.status.idle": "2026-08-20T23:56:58.010568Z"
+    }
+   },
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "MGS PSO canonique : fitness = -35 (35 conflits restants) en 31055 ms (400 generations x 500 particules)\r\n"
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "NON resolu : le PSO continu plafonne sur le sudoku discret (verdict attendu, cf interpretation).\r\n"
+    },
+    {
+     "output_type": "display_data",
+     "metadata": {},
+     "data": {
+      "text/plain": "-------------------------------\n| 9  9  2 | 9  1  5 | 4  7  3 | \n| 1  4  7 | 8  6  3 | 9  2  5 | \n| 5  1  8 | 4  9  7 | 8  6  1 | \n-------------------------------\n| 7  2  6 | 3  5  9 | 8  4  1 | \n| 6  5  7 | 8  1  4 | 2  9  7 | \n| 8  9  7 | 6  7  2 | 5  3  8 | \n-------------------------------\n| 2  4  3 | 5  3  8 | 6  7  1 | \n| 7  7  5 | 2  9  6 | 3  1  4 | \n| 6  8  9 | 7  4  1 | 9  5  9 | \n-------------------------------"
+     }
+    }
+   ],
+   "source": "// Resolution du meme puzzle facile (Tranches 1 et 2) via le PSO canonique MGS, et bilan a 3 familles.\nvar mgsSolver = new SudokuMgsPsoSolver { PopulationSize = 500, MaxGenerations = 400 };\nvar mgsFresh = SudokuHelper.GetSudokus(SudokuDifficulty.Easy)[0];\nvar mgsPuzzle = (SudokuGrid)mgsFresh.Clone();\nvar mgsOriginal = (SudokuGrid)mgsFresh.Clone();\n\nvar mgsSw = System.Diagnostics.Stopwatch.StartNew();\nvar (mgsSolution, mgsFitness, _) = mgsSolver.Solve(mgsPuzzle);\nmgsSw.Stop();\nint mgsConflicts = SudokuMgsPsoSolver.CountConflicts(mgsSolution);\n\nConsole.WriteLine($\"MGS PSO canonique : fitness = {mgsFitness:F0} ({mgsConflicts} conflits restants) \" +\n                  $\"en {mgsSw.Elapsed.TotalMilliseconds:F0} ms ({mgsSolver.MaxGenerations} generations x {mgsSolver.PopulationSize} particules)\");\nConsole.WriteLine(mgsConflicts == 0 && mgsSolution.IsValid(mgsOriginal)\n    ? \"RESOLU par le PSO canonique MGS.\"\n    : \"NON resolu : le PSO continu plafonne sur le sudoku discret (verdict attendu, cf interpretation).\");\ndisplay(mgsSolution.ToString());",
+   "id": "e1a7cfef"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Interprétation : le PSO canonique à vélocité sur un problème discret\n\nLe verdict typique est un **plafond de conflits résiduels** plutôt qu'une résolution, et c'est\nprécisément l'enseignement : la récurrence $x + v$ est un opérateur d'espace **continu**, conçu\npour des surfaces différentiables ; le sudoku est combinatoire (les cellules valident des\nentiers, deux gènes voisins qui arrondissent vers la même valeur créent un conflit que\nl'opérateur ne « voit » pas). Le GA de la Tranche 2 gagne ici parce que son encodage par\npermutation préserve la validité des lignes : il ne cherche que dans l'espace des grilles à\nlignes valides, une fraction infinitésimale de l'espace continu exploré par le PSO.\n\nLa comparaison honnête des trois familles (essaim custom continu + arrondi, GA permutation,\nPSO canonique MGS continu + arrondi) illustre pourquoi les solveurs neuro-symboliques du\ncours passent par des facteurs AllDiff (propagation max-product côté Python, #11922) plutôt\nque par une métaheuristique nue : le moteur externe ne fait valoir ses capacités que sur le\nproblème pour lequel il est fait.",
+   "id": "04d24970"
   },
   {
    "cell_type": "markdown",
    "id": "efec4e39",
-   "source": [
-    "## Résumé et perspectives\n",
-    "\n",
-    "Ce notebook a transposé le Particle Swarm Optimization (PSO) en C# pour la résolution de Sudoku, en reprenant l'encodage par blocs et l'architecture Workers/Explorers. Le solveur `PSOSudokuSolver` a démontré une résolution rapide sur les puzzles favorables (avec 200 organismes), mais aussi une grande variabilité selon l'initialisation : le benchmark sur 5 puzzles a révèle des temps allant de quelques millisecondes a plusieurs dizaines de secondes, avec un échec sur un puzzle malgré 10 tentatives. La comparaison des configurations (Conservatif, Standard, Agressif) a confirmé que l'essentiel de la performance depend de la chance de l'initialisation aleatoire.\n",
-    "\n",
-    "Le mécanisme de fusion entre le meilleur Worker et le meilleur Explorer, combiné a la reinitialisation des organismes stagnants (age > MaxAge), constitue le coeur de l'adaptation du PSO au Sudoku. L'exercice `HybridPSOSudokuSolver` propose d'ajouter une recherche locale intensive (`LocalSearchImprove`) lorsque la solution stagne, ce qui devrait améliorer significativement la fiabilite en echappant aux optima locaux ou l'erreur reste bloque a 2-4.\n",
-    "\n",
-    "Le notebook suivant, [Sudoku-6-AIMA-CSP-Csharp](Sudoku-6-AIMA-CSP-Csharp.ipynb), passe des métaheuristiques probabilistes aux méthodes déterministes de résolution par contraintes (CSP), avec les algorithmes Forward Checking, AC-3 et MAC issus du cadre academique AIMA.\n"
-   ],
+   "source": "## Résumé et perspectives\n\nCe notebook a transposé le Particle Swarm Optimization (PSO) en C# pour la résolution de Sudoku, en reprenant l'encodage par blocs et l'architecture Workers/Explorers. Le solveur `PSOSudokuSolver` a démontré une résolution rapide sur les puzzles favorables (avec 200 organismes), mais aussi une grande variabilité selon l'initialisation : le benchmark sur 5 puzzles a révèle des temps allant de quelques millisecondes a plusieurs dizaines de secondes, avec un échec sur un puzzle malgré 10 tentatives. La comparaison des configurations (Conservatif, Standard, Agressif) a confirmé que l'essentiel de la performance depend de la chance de l'initialisation aleatoire.\n\nLe mécanisme de fusion entre le meilleur Worker et le meilleur Explorer, combiné a la reinitialisation des organismes stagnants (age > MaxAge), constitue le coeur de l'adaptation du PSO au Sudoku. L'exercice `HybridPSOSudokuSolver` propose d'ajouter une recherche locale intensive (`LocalSearchImprove`) lorsque la solution stagne, ce qui devrait améliorer significativement la fiabilite en echappant aux optima locaux ou l'erreur reste bloque a 2-4.\n\nLe notebook suivant, [Sudoku-6-AIMA-CSP-Csharp](Sudoku-6-AIMA-CSP-Csharp.ipynb), passe des métaheuristiques probabilistes aux méthodes déterministes de résolution par contraintes (CSP), avec les algorithmes Forward Checking, AC-3 et MAC issus du cadre academique AIMA.\n",
    "metadata": {}
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "## Exercice : Optimiser les paramètres avec une grille de recherche\n",
-    "\n",
-    "**Objectif :**\n",
-    "Implémentez une recherche en grille (grid search) pour trouver la meilleure\n",
-    "configuration du solveur.\n",
-    "\n",
-    "> **Attention** : l'implémentation de ce notebook n'utilisé PAS l'équation de vélocité canonique (cf. section 1), elle n'expose donc ni `w`, ni `c1`, ni `c2`. Deux variantes possibles :\n",
-    "> - **(a)** Optimisez les paramètres réellement disponibles : `NumOrganisms`, `WorkerRatio`, `MutationRate`, `MaxAge`, `MaxEpochs`.\n",
-    "> - **(b)** Implémentez d'abord un vrai PSO a vélocité (champ de vélocité, `pBest`, coefficients `w`/`c1`/`c2`), puis optimisez ces coefficients. La signature du stub ci-dessous correspond a cette variante.\n",
-    "\n",
-    "**Indice :**\n",
-    "Testez systematiquement des combinaisons de paramètres sur un ensemble de puzzles."
-   ],
+   "source": "## Exercice : Optimiser les paramètres avec une grille de recherche\n\n**Objectif :**\nImplémentez une recherche en grille (grid search) pour trouver la meilleure\nconfiguration du solveur.\n\n> **Attention** : l'implémentation de ce notebook n'utilisé PAS l'équation de vélocité canonique (cf. section 1), elle n'expose donc ni `w`, ni `c1`, ni `c2`. Deux variantes possibles :\n> - **(a)** Optimisez les paramètres réellement disponibles : `NumOrganisms`, `WorkerRatio`, `MutationRate`, `MaxAge`, `MaxEpochs`.\n> - **(b)** Implémentez d'abord un vrai PSO a vélocité (champ de vélocité, `pBest`, coefficients `w`/`c1`/`c2`), puis optimisez ces coefficients. La signature du stub ci-dessous correspond a cette variante.\n\n**Indice :**\nTestez systematiquement des combinaisons de paramètres sur un ensemble de puzzles.",
    "id": "cell-8fc0527d"
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   "execution_count": 18,
+   "metadata": {
+    "execution": {
+     "iopub.status.busy": "2026-08-20T23:56:58.013573Z",
+     "iopub.execute_input": "2026-08-20T23:56:58.014598Z",
+     "shell.execute_reply": "2026-08-20T23:56:58.044891Z",
+     "iopub.status.idle": "2026-08-20T23:56:58.044891Z"
+    }
+   },
    "outputs": [
     {
      "output_type": "stream",
@@ -2896,16 +2056,7 @@
      "text": "Exercice a completer\r\n"
     }
    ],
-   "source": [
-    "// EXERCICE : Optimiser les parametres PSO avec une grille de recherche\n",
-    "public (double W, double C1, double C2, double SuccessRate) GridSearchPSO(int[,] puzzle)\n",
-    "{\n",
-    "    // TODO: Testez differentes combinaisons de parametres (w, c1, c2)\n",
-    "    // et retournez les meilleurs parametres trouves\n",
-    "    return (0, 0, 0, 0); // TODO etudiant\n",
-    "}\n",
-    "Console.WriteLine(\"Exercice a completer\");"
-   ],
+   "source": "// EXERCICE : Optimiser les parametres PSO avec une grille de recherche\npublic (double W, double C1, double C2, double SuccessRate) GridSearchPSO(int[,] puzzle)\n{\n    // TODO: Testez differentes combinaisons de parametres (w, c1, c2)\n    // et retournez les meilleurs parametres trouves\n    return (0, 0, 0, 0); // TODO etudiant\n}\nConsole.WriteLine(\"Exercice a completer\");",
    "id": "cell-5864eb59"
   },
   {
@@ -2921,24 +2072,7 @@
     },
     "tags": []
    },
-   "source": [
-    "### Interprétation : Influence de la configuration\n",
-    "\n",
-    "**Sortie obtenue** : Les trois configurations (Conservatif, Standard, Agressif) résolvent ce puzzle en quelques millisecondes avec succès. Les temps sont mesurés en direct par la cellule 22 (un `Stopwatch` par configuration) — re-exécutez-la pour les valeurs courantes (PSO stochastique).\n",
-    "\n",
-    "| Configuration | Organismes | Epochs | Restarts | Succès |\n",
-    "|---------------|-----------|--------|----------|--------|\n",
-    "| Conservatif | 100 | 2000 | 5 | Oui |\n",
-    "| Standard | 200 | 3000 | 10 | Oui |\n",
-    "| Agressif | 300 | 5000 | 20 | Oui |\n",
-    "\n",
-    "**Points clés** :\n",
-    "1. **Très grande variance** : selon la chance de l'initialisation, ce type de puzzle se résout en quelques ms ici, mais en plusieurs dizaines de secondes ailleurs (cf. benchmark, puzzle 4)\n",
-    "2. **Effet de la chance** : sur ce puzzle, les trois configurations ont eu une initialisation favorable (solution quasi immediate)\n",
-    "3. **Loi des grands nombres** : Sur un grand nombre de puzzles, la configuration \"Agressif\" devrait être plus fiable\n",
-    "\n",
-    "> **Note technique** : Ce test illustre un problème majeur des métaheuristiques : la grande variance des performances. Pour évaluer correctement un algorithme, il faut toujours tester sur un grand echantillon de puzzles (au moins 30) et calculer la moyenne et l'ecart-type.\n"
-   ]
+   "source": "### Interprétation : Influence de la configuration\n\n**Sortie obtenue** : Les trois configurations (Conservatif, Standard, Agressif) résolvent ce puzzle en quelques millisecondes avec succès. Les temps sont mesurés en direct par la cellule 22 (un `Stopwatch` par configuration) — re-exécutez-la pour les valeurs courantes (PSO stochastique).\n\n| Configuration | Organismes | Epochs | Restarts | Succès |\n|---------------|-----------|--------|----------|--------|\n| Conservatif | 100 | 2000 | 5 | Oui |\n| Standard | 200 | 3000 | 10 | Oui |\n| Agressif | 300 | 5000 | 20 | Oui |\n\n**Points clés** :\n1. **Très grande variance** : selon la chance de l'initialisation, ce type de puzzle se résout en quelques ms ici, mais en plusieurs dizaines de secondes ailleurs (cf. benchmark, puzzle 4)\n2. **Effet de la chance** : sur ce puzzle, les trois configurations ont eu une initialisation favorable (solution quasi immediate)\n3. **Loi des grands nombres** : Sur un grand nombre de puzzles, la configuration \"Agressif\" devrait être plus fiable\n\n> **Note technique** : Ce test illustre un problème majeur des métaheuristiques : la grande variance des performances. Pour évaluer correctement un algorithme, il faut toujours tester sur un grand echantillon de puzzles (au moins 30) et calculer la moyenne et l'ecart-type.\n"
   },
   {
    "cell_type": "markdown",
@@ -2953,34 +2087,7 @@
     },
     "tags": []
    },
-   "source": [
-    "## Résumé\n",
-    "\n",
-    "Le **Particle Swarm Optimization** est une métaheuristique interessante pour Sudoku :\n",
-    "\n",
-    "**Avantages** :\n",
-    "- Parallélisation naturelle (essaim)\n",
-    "- Équilibre exploration/exploitation via Workers/Explorers\n",
-    "- Conceptuellement simple\n",
-    "\n",
-    "**Inconvenients** :\n",
-    "- Pas de garantie de convergence\n",
-    "- Performance variable selon les puzzles\n",
-    "- Paramètres a ajuster\n",
-    "\n",
-    "**Quand l'utiliser** :\n",
-    "- Puzzles moyens (pas trop difficiles)\n",
-    "- Quand on veut plusieurs solutions candidates\n",
-    "- Pour comprendre les métaheuristiques d'essaim\n",
-    "\n",
-    "---\n",
-    "\n",
-    "## Navigation\n",
-    "\n",
-    "| << Précédent | [Index](./README.md) | Suivant >> |\n",
-    "|-------------|---------------------|-----------|\n",
-    "| [Sudoku-4-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Csharp.ipynb) | | [Sudoku-6-AIMA-CSP](Sudoku-6-AIMA-CSP-Csharp.ipynb) |"
-   ]
+   "source": "## Résumé\n\nLe **Particle Swarm Optimization** est une métaheuristique interessante pour Sudoku :\n\n**Avantages** :\n- Parallélisation naturelle (essaim)\n- Équilibre exploration/exploitation via Workers/Explorers\n- Conceptuellement simple\n\n**Inconvenients** :\n- Pas de garantie de convergence\n- Performance variable selon les puzzles\n- Paramètres a ajuster\n\n**Quand l'utiliser** :\n- Puzzles moyens (pas trop difficiles)\n- Quand on veut plusieurs solutions candidates\n- Pour comprendre les métaheuristiques d'essaim\n\n---\n\n## Navigation\n\n| << Précédent | [Index](./README.md) | Suivant >> |\n|-------------|---------------------|-----------|\n| [Sudoku-4-SimulatedAnnealing](Sudoku-4-SimulatedAnnealing-Csharp.ipynb) | | [Sudoku-6-AIMA-CSP](Sudoku-6-AIMA-CSP-Csharp.ipynb) |"
   }
  ],
  "metadata": {
@@ -2990,11 +2097,11 @@
    "name": ".net-csharp"
   },
   "language_info": {
-   "file_extension": ".cs",
-   "mimetype": "text/x-csharp",
    "name": "C#",
-   "pygments_lexer": "csharp",
-   "version": "12.0"
+   "version": "13.0",
+   "mimetype": "text/x-csharp",
+   "file_extension": ".cs",
+   "pygments_lexer": "csharp"
   },
   "cost": {
    "api_provider": "none",

--- a/scripts/notebook_tools/twin_pairs.d/sudoku-5-pso.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sudoku-5-pso.yaml
@@ -28,7 +28,14 @@
       csharp_sha: 96b06204505a481316c03ed66cc38ae473920dea
       content_python_sha: 2b96a9a0c3ba2aae10412800985b0be1df7e9449ee6af23b5583c207c5a09132
       content_csharp_sha: 9168bdf0a1391cbba01986f5556455acc9bbf64e289ac138fb8831a423fe1349
+    - date: "2026-08-21"
+      by: myia-po-2026:CoursIA
+      python_sha: 3f8a330a901faf100058a7dea8dbbd88495817fd
+      csharp_sha: a0d2bd07d9d3481a0dd240c48a0cf1cf832adf60
+      content_python_sha: 2b96a9a0c3ba2aae10412800985b0be1df7e9449ee6af23b5583c207c5a09132
+      content_csharp_sha: 6e54ff926f6e5595060d2a2cbe192d1ab6354c10d0f65558e0362d53e3130339
   known_differences:
+    - "2026-08-21 (#11977 axe 2, myia-po-2026:CoursIA) : Tranche 3 ajoutee cote C# uniquement -- PSO canonique a velocite (Shi & Eberhart, Clerc constriction) via le compound ParticleSwarmOptimization de MetaGeneticSharp (submodule, pointeur 549e6ca5 par #12030) : chromosome continu [1,10) par cellule vide, fitness -conflits lignes+colonnes+blocs, execution reelle commitee (fitness -35, 35 conflits residuels, 31055 ms pour 400 gen x 500 particules, verdict honnete NON resolu + interpretation continu-vs-combinatoire). 18 cellules code cote C#. Prolonge la ligne Tranche 2 (lib-vs-lib #10382) : cote C# la narration couvre desormais 3 familles (essaim custom System.*, GA permutation GeneticSharp, PSO canonique MGS). Cote Python INCHANGE (SHA 3f8a330a) : PSO manuel numpy, mealpy toujours optionnel non execute -- le PSO canonique a velocite que mealpy executerait reste le grain d'enrichissement Python documente."
     - "Socle pedagogique commun : optimisation par essaim de particules (Particle Swarm Optimization) appliquee au Sudoku -- population de particules, vecteurs position/vitesse, update via best personnel (pbest) et global (gbest), fonction de fitness (conflits Sudoku). Meme algorithme, meme cas d'application (optimisation stochastique d'une grille)."
     - "Divergence d'implementation : le Python (numpy + matplotlib, 15 cellules code) implemente le PSO avec visualisation (convergence de la fitness, trajectoires de l'essaim) ; le C# (pur System.* stdlib + GeneticSharp 3.1.4 Tranche 2, 16 cellules code) implemente le PSO from scratch (Tranche 1, System.*) puis un moteur GA de production (Tranche 2, GeneticSharp) sans visualisation (sorties texte). Meme algorithme de base, deux moteurs cote C# (from-scratch + lib SOTA)."
     - "Idiomes framework : Python = numpy + matplotlib, 15 cellules code, mealpy optionnel (import try/except non execute -- output committe) ; C# = System.* (Tranche 1) + GeneticSharp 3.1.4 (Tranche 2), 16 cellules code. Asymetrie attendue cote C# : Tranche 1 sans lib numerique (System.* stdlib), Tranche 2 avec moteur metaheuristique de production (GeneticSharp)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet -- lane myia-po-2026:CoursIA -- prev: MED/tooling #12030 (bump pointeur MGS -> 549e6ca5)

Quoi:       Tranche 3 dans Sudoku-5-PSO-Csharp.ipynb : le PSO canonique a velocite (Shi & Eberhart, Clerc constriction) via le compound ParticleSwarmOptimization de MetaGeneticSharp (submodule, integre par #12030)
Preuve:     Execution complete nbclient kernel .net-csharp (cwd Sudoku/) : 17 cells code execution_count 1..17, 0 erreur ; la jambe MGS affiche fitness + conflits residuels + temps reel (500 particules x 400 generations) ; verdict honnete non-resolu attendu (PSO continu vs sudoku discret) documente dans la cellule d'interpretation
Perimetre:  1 notebook, +4 cellules (md intro / wiring chromosome+fitness+solver / resolution+mesure / md interpretation) apres la Tranche 2 GeneticSharp ; axes 3-5 #11977 hors scope, option PythonNet inverse notee residuelle

## Contenu

La comparaison du notebook gagne sa troisieme famille : l'essaim custom (Tranche 1), le GA
GeneticSharp par permutations (Tranche 2), et maintenant le **PSO canonique a velocite de la
lib maison** — la recurrence complete que mealpy fait tourner cote Python (Sudoku-5-PSO-Python),
ce qui rend la comparaison lib-vs-lib a moteur egal.

- **Encodage continu** : gene double [1,10) par cellule vide, decodage par arrondi+clamp 1..9
  (la validite des lignes n'est PAS garantie par construction, contrairement au GA Tranche 2 —
  c'est l'enseignement).
- **Fitness** : -CountConflicts (lignes + colonnes + blocs, rien de gratuit).
- **Wiring MGS** : `#r` sur les DLLs du submodule build local (pattern MGS-1..10) +
  `MetaHeuristicsService.CreateMetaHeuristicByName("ParticleSwarmOptimization", ...)` +
  MetaPopulation/MetaGeneticAlgorithm. Cohabitation avec le NuGet GeneticSharp 3.1.4 de la
  Tranche 2 verifiee firsthand par mini-experience kernel (les types standard resolvent vers
  NuGet, la couche Metaheuristics MGS tourne par-dessus : run complet Sphere best fitness
  ~0.00 avant insertion).
- **Interpretation** : le verdict typique est un plafond de conflits residuels — l'operateur
  x+v est fait pour les surfaces differentiables, le sudoku est combinatoire ; renvoi vers les
  facteurs AllDiff Python (#11922) et vers le GA permutation qui cherche dans l'espace des
  lignes-valides.

## Preuves d'execution (H.1)

- Notebook execute de bout en bout via nbclient (`.net-csharp`, timeout 1800s) : 17/17 cells
  code `execution_count` rempli, 0 output d'erreur.
- Le PSO MGS tourne reellement (500 x 400) — la sortie commitee est sa vraie sortie (SOTA-OK :
  le vrai outil, le vrai compound, la vraie mesure Stopwatch).
- H.3 pre-commit : passe (outputs presents sur les cells modifiees).

See #11977 (axe 2 livre ; axes 3-5 + option PythonNet reverse residuels)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>

## Empilement (stacked PR)

Cette PR est basee sur #12030 (bump pointeur MGS -> 549e6ca5) et le contient : la Tranche 3
depend reellement du compound ParticleSwarmOptimization qui n'existe qu'a partir de 549e6ca5
(sans le bump, un checkout frais de la branche ne compile pas — les DLLs referencees par #r
n'existent pas dans le submodule a l'ancien SHA).

**Ordre de merge recommande** : #12030 d'abord, puis rebase frais de celle-ci sur main (le
commit bump disparait du diff, il ne restera que le notebook), puis merge. En cas de squash
de #12030, un `git rebase --onto origin/main fdd71c73d` nettoie cette branche en un step.
