### PR TITLE
feat(qc,#12034): filtre capital-gain sur CSharp-CTG-Momentum — 2 bras QC Cloud, verdict NO BEATS honnête

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/Main.cs
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/Main.cs
@@ -85,6 +85,19 @@ namespace QuantConnect.Algorithm.CSharp
         private bool _rebalanceWeek = false;
         public bool RebalanceWeek { get { return _rebalanceWeek; } }
 
+        // === Capital-gain filter (#12034, consolidation QC research 21160) ===
+        // Cannon & Lynch (2025, Review of Finance 29(4)): return extrapolation — and thus
+        // the momentum premium — concentrates in non-dividend-paying ("capital-gain")
+        // stocks (1.417%/month vs 0.684% among dividend payers). When enabled, the
+        // weekly ranking excludes any stock that distributed at least one dividend over
+        // the trailing twelve months (history request on Dividend objects).
+        // Default OFF: the baseline strategy (slope momentum on OEF constituents) is
+        // unchanged unless the flag is flipped — the two arms are compared honestly.
+        private bool _filterDividendPayers = false;
+        private DateTime _lastDividendScan = DateTime.MinValue;
+        private readonly Dictionary<Symbol, bool> _paysDividend = new Dictionary<Symbol, bool>();
+        private static readonly TimeSpan DividendScanInterval = TimeSpan.FromDays(7);
+
         ///Broker fee to take into account to check if Cash is avalaible
         private const decimal BrokerFee = 0.005m;
 
@@ -137,21 +150,42 @@ namespace QuantConnect.Algorithm.CSharp
                 TimeRules.AfterMarketOpen("SPY", 1), ScheduledOnWednesday1MinuteAfterMarketOpen);
         }
 
+        // Capital-gain filter (#12034): refresh the TTM dividend-payer cache weekly.
+        // A stock that distributed >= 1 dividend over the trailing 365 days is a payer.
+        private void UpdateDividendPayerCache()
+        {
+            if (Time - _lastDividendScan < DividendScanInterval) return;
+            _lastDividendScan = Time;
+            _paysDividend.Clear();
+            var dividends = History<Dividend>(_customIndicators.Keys.ToList(), TimeSpan.FromDays(365));
+            foreach (var dataDict in dividends)
+            {
+                foreach (var kvp in dataDict)
+                {
+                    _paysDividend[kvp.Key] = true;
+                }
+            }
+        }
+
         // SECURITY RANKING, SELL, REBALANCE AND BUY
         private void ScheduledOnWednesday1MinuteAfterMarketOpen()
         {
             if (IsWarmingUp) return;
+
+            if (_filterDividendPayers) UpdateDividendPayerCache();
 
             // First, we order by slope and we take top 20% ranked
             var sortedEquityListBySlope = _customIndicators.Where(x => x.Value.IsReady)
             .OrderByDescending(x => x.Value.AnnualizedSlope)
             .Take(_topNStockOfSp500)
             .ToList();
-            // Second, we filter by minimum slope, above moving average and max gap
+            // Second, we filter by minimum slope, above moving average and max gap,
+            // and (flag on) by the capital-gain criterion: exclude TTM dividend payers.
             sortedEquityListBySlope = sortedEquityListBySlope
             .Where(x => x.Value.AnnualizedSlope > _minimumAnnualizedSlope
                 && Securities[x.Key].Price > x.Value.MovingAverage
-                && x.Value.Gap < _maximumGap).ToList();
+                && x.Value.Gap < _maximumGap
+                && (!_filterDividendPayers || !_paysDividend.ContainsKey(x.Key))).ToList();
 
             //Sell if security is not in list
             foreach (var security in Portfolio.Values.Where(x => x.Invested))

--- a/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/README.md
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/CSharp-CTG-Momentum/README.md
@@ -47,3 +47,40 @@ Stratégie momentum avec indicateurs custom avancés en C#.
 2. Compiler via QC cloud
 3. Lancer backtest via web UI
 4. Valider Sharpe >= 0.4 sur période étendue
+
+## Filtre capital-gain (#12034, consolidation QC research 21160)
+
+**Source primaire** : Cannon & Lynch (2025), *Return Extrapolation and Dividends*, Review of
+Finance 29(4), 1009-1042 (l'article QC cite le SSRN 3816782 ; la version publiée RoF est la
+référence canonique). Claim : l'extrapolation des rendements — et donc la prime de momentum —
+se concentre dans les actions qui ne paient pas de dividende (« capital-gain stocks »,
+1,417 %/mois vs 0,684 % chez les payeurs, écart non expliqué par les factor models standards).
+
+**Implémentation** : flag `_filterDividendPayers` dans `Main.cs` (défaut OFF = baseline
+inchangée). Quand ON, le classement hebdomadaire exclut toute action ayant distribué au moins
+un dividende sur les 365 derniers jours (`History<Dividend>` rafraîchi chaque semaine, cache
+`_paysDividend`). Motivation : donner au projet le pattern filtre-de-sélection factoriel du
+cours, à côté du `MarketRegimeFilter` existant — même emplacement logique (pré-sélection dans
+l'événement planifié), même approche de flag opt-in.
+
+**Comparaison honnête 2015-2025** (même projet QC Cloud 35425281, même période, mêmes coûts IB) :
+
+| Bras                        | Sharpe | CAGR   | MaxDD  | Ordres |
+|-----------------------------|--------|--------|--------|--------|
+| Baseline (filtre OFF)       | 0.451  | 15.0 % | 42.4 % | 961    |
+| Capital-gain (filtre ON)    | 0.259  | 7.9 %  | 24.7 % | 458    |
+
+**Verdict : NO BEATS.** Sur CE moteur (slope 90 j + régime SPY > SMA200, univers OEF S&P 100),
+le filtre capital-gain dégrade Sharpe et rendement — mais divise le drawdown (42 → 25 %) et le
+turnover (961 → 458 ordres). L'écart avec l'article (Sharpe 0.602 sur 1 000 actions, momentum
+12-1 mensuel à breakpoints NYSE) est instructif : le claim Cannon-Lynch porte sur le momentum
+canonique à formation mensuelle, pas sur le slope journalier 90 j. L'univers OEF (S&P 100,
+grandes capitalisations payant majoritairement des dividendes) est aussi le terrain le moins
+favorable au filtre — l'article opère sur les 1 000 plus liquides NYSE+NASDAQ+AMEX où les
+capital-gain stocks sont bien représentées. Le filtre reste pédagogiquement pertinent (pattern
+factoriel documenté + gestion du risque) et le flag OFF préserve la baseline ; le terrain
+naturel pour le retester serait un univers élargi (QC500), grain séparé.
+
+Sources : QuantConnect research 21160 (*Momentum in Capital-Gain Stocks*, lastmod 2026-08-17) ;
+verdict CONSOLIDATION documenté sur l'issue #12034 (lecture analytique + filtre du bouquet —
+aucun des 12 projets momentum existants n'excluait les payeurs de dividendes).


### PR DESCRIPTION
Grain: DEEP/qc -- lane myia-po-2026:CoursIA -- prev: MED/qc #12036 (cron qc-research-monitor)

Quoi:       PR de consolidation du verdict CONSOLIDATION #12034 (article QC research 21160, Momentum in Capital-Gain Stocks) : filtre capital-gain flaggé sur CSharp-CTG-Momentum + comparaison honnête 2 bras sur QC Cloud
Preuve:     2 backtests réels QC Cloud (projet 35425281, compileId 46fe0df8 baseline / e2f42845 filtre, même période 2015-2025, 2924 tradeableDates chacun) : baseline Sharpe 0.451 / CAGR 15.012 % / MaxDD 42.4 % / 961 ordres ; filtre Sharpe 0.259 / CAGR 7.919 % / MaxDD 24.7 % / 458 ordres. Verdict NO BEATS documenté, pas maquillé
Perimetre:  2 fichiers du projet CSharp-CTG-Momentum (Main.cs +38, README +62) ; baseline inchangée par défaut (flag OFF) ; lecture analytique livrée en commentaire #12034 (c.5363757059)

## Chaîne complète (première consommation du pipeline #11698, bout en bout)

1. **Sous-issue semée** par le cron livré #12036 (article le plus récent du sitemap).
2. **Lecture analytique** (commentaire #12034) : article lu en entier ; filtre du bouquet — 12 projets momentum existants, aucun n'exclut les payeurs de dividendes (grep `dividend` : seuls Dividend-Harvesting-ML et PuppiesOfTheDow les SÉLECTIONNENT, l'opposé conceptuel) ; source primaire vérifiée ET upgradée : Cannon & Lynch publié dans **Review of Finance 29(4), 1009-1042, 2025** (l'article QC cite le SSRN 3816782).
3. **Verdict CONSOLIDATION** → cette PR : enrichir le projet le plus proche (`CSharp-CTG-Momentum` : momentum single-stock, pattern filtre-de-sélection établi avec `MarketRegimeFilter.cs`).

## Implémentation

- Flag `_filterDividendPayers` (défaut **OFF** = baseline préservée byte-identique côté comportement).
- Cache TTM des payeurs (`_paysDividend`) rafraîchi chaque semaine via `History<Dividend>` (365 j glissants), exclusion dans le classement du scheduled event hebdo — même emplacement logique que MarketRegimeFilter, même philosophie opt-in.
- Fix API en route : itération `DataDictionary<Dividend>` directe (pas `.Value`), compile SUCCESS au 2e essai.

## Résultats — verdict NO BEATS (honnête)

| Bras | Sharpe | CAGR | MaxDD | Ordres |
|------|--------|------|-------|--------|
| Baseline (OFF) | 0.451 | 15.0 % | 42.4 % | 961 |
| Capital-gain (ON) | 0.259 | 7.9 % | 24.7 % | 458 |

Le filtre **dégrade** Sharpe et rendement sur CE moteur, mais **divise** le drawdown (42 → 25 %)
et le turnover (961 → 458). L'analyse de l'écart (dans le README) : le claim Cannon-Lynch porte
sur le momentum 12-1 mensuel à breakpoints NYSE sur les 1 000 plus liquides ; le moteur CTG est
un slope 90 j journalier sur l'univers OEF (S&P 100, grandes caps majoritairement dividendifères)
— le terrain le moins favorable au filtre. Retest sur univers QC500 = grain séparé documenté.

**Pourquoi livrer un NO BEATS** : la règle C exige un verdict honnête (BEATS / NO BEATS /
INCONCLUSIVE), jamais "promising". La valeur pédagogique est intacte : pattern factoriel
documenté + source primaire publiée + gestion du risque mesurée + enseignement sur les limites
du transfert d'un claim académique d'un terrain à l'autre. Le drapeau OFF préserve la baseline.

Closes #12034 (lecture analytique + verdict CONSOLIDATION + PR de consolidation)
See #11698 (première consommation complète du pipeline : semis → lecture → verdict → consolidation)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
