### PR TITLE
feat(guard,#11874): diagnostic REPL lean4-wsl a controle positif (REPL_LAKE_ONLY/BROKEN/HEALTHY)

### DIFF
--- a/scripts/notebook_tools/check_lean4_wsl_repl.py
+++ b/scripts/notebook_tools/check_lean4_wsl_repl.py
@@ -1,0 +1,200 @@
+"""Diagnostic a controle positif du REPL lean4-wsl (#11874).
+
+Contexte : le kernel Jupyter lean4-wsl lance `lake env repl` (via le wrapper
+~/.lean4-kernel-wrapper.py). Le mecanisme de casse documente sur #11874
+(ai-01, experience controlee) : le binaire `repl` ne trouve sa stdlib QUE si le
+toolchain RESOLU par le cwd correspond a sa version de compilation — un repl
+compile pour v4.30.0 dans un environnement resolu v4.32.1 rend
+`Unknown constant OfNat` sur le controle le plus elementaire possible
+(`#eval 2+2`), et les imports impossibles rendent `{"env": N}` MUET
+(aucun message d'erreur) — une sonde sans controle positif lit un kernel mort
+comme un kernel silencieux. Le health-check du kernel lui-meme
+(`#eval Lean.versionString` sans controle du resultat) ne detecte rien.
+
+Cet outil execute la recette a controle positif du body de #11874 et rend un
+verdict executable sur toute machine du cluster :
+
+  REPL_HEALTHY          tous les controles positifs passent sur tous les chemins
+  REPL_LAKE_ONLY        repl via lake OK, repl nu KO (etat latent typique :
+                        le kernel marche tant que le cwd est un lake matchant ;
+                        le fallback stub et /tmp sont casses)
+  REPL_STDLIB_BROKEN    meme via lake, le controle positif echoue (mismatch
+                        toolchain binaire/toolchain resolu) — kernel inutilisable
+  REPL_MISSING          binaire repl introuvable
+  REPL_TIMEOUT          le repl ne repond pas dans le delai
+
+Sondes par chemin (chaque chemin = un process repl frais) :
+  1. controle positif   : `#eval 2+2` (env null) -> doit rendre "4"
+  2. import bidon       : `import Totally.Bogus.Xyz` -> doit ERREUR (une
+                          reponse muette {"env": N} sans message = ENV_ID_MUTE,
+                          danger documente, non bloquant en soi)
+  3. version toolchain  : lit lean-toolchain du cwd quand present
+
+Usage :
+  python scripts/notebook_tools/check_lean4_wsl_repl.py                     # repl nu + stub + lakes par defaut
+  python scripts/notebook_tools/check_lean4_wsl_repl.py --lake ~/proj/mon_lake
+  python scripts/notebook_tools/check_lean4_wsl_repl.py --json              # sortie machine-lisible
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+
+WSL_DISTRO = "Ubuntu"
+WSL_PREFIX = ["wsl.exe", "-d", WSL_DISTRO, "--"]
+PROBE_TIMEOUT = 90
+STUB_DIR = "~/lean-projects/notebook_context"
+BOGUS_IMPORT = "Totally.Bogus.Xyz"
+
+# Reponses du protocole REPL : les commandes sont separees par une ligne vide
+# (double \n) ; le repl rend un JSON par commande sur stdin puis EOF.
+
+
+def wsl_bash(cmd: str, timeout: int = PROBE_TIMEOUT) -> tuple[int, str]:
+    """Execute une commande bash dans WSL, rend (exit_code, stdout+stderr)."""
+    proc = subprocess.run(
+        WSL_PREFIX + ["bash", "-lc", cmd],
+        capture_output=True, text=True, timeout=timeout, encoding="utf-8", errors="replace",
+    )
+    return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
+
+
+def spawn_repl(cwd: str | None, repl_cmd: str, payload: str) -> tuple[str, str]:
+    """Lance le repl via bash -lc, injecte payload, rend (stdout+stderr, meta).
+
+    Le cd doit se produire AVANT le pipeline : `timeout` ne peut pas executer
+    le builtin `cd` (exit 125 silencieux -> sonde vide).
+    """
+    prefix = f"cd {cwd} && " if cwd else ""
+    cmd = f'{prefix}printf {json.dumps(payload)} | timeout {PROBE_TIMEOUT} {repl_cmd}'
+    returncode, out = wsl_bash(cmd)
+    return out, f"exit={returncode}"
+
+
+def parse_repl_json(raw: str) -> dict | None:
+    """Extrait le premier objet JSON de la sortie brute du repl."""
+    m = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not m:
+        return None
+    try:
+        return json.loads(m.group(0))
+    except json.JSONDecodeError:
+        return None
+
+
+def probe_path(cwd: str | None, repl_cmd: str, label: str, toolchain: str | None) -> dict:
+    """Sonde un chemin d'execution du repl : controle positif + import bidon."""
+    result = {"label": label, "cwd": cwd, "repl_cmd": repl_cmd, "toolchain": toolchain,
+              "positive": None, "positive_data": None, "bogus_mute": None}
+    # 1. controle positif : #eval 2+2 -> "4"
+    payload = '{"cmd": "#eval 2+2", "env": null}\n\n'
+    raw, meta = spawn_repl(cwd, repl_cmd, payload)
+    parsed = parse_repl_json(raw)
+    if parsed is None:
+        result["positive"] = "TIMEOUT_OR_UNPARSEABLE"
+        result["positive_data"] = (raw or "")[:200]
+        return result
+    messages = parsed.get("messages", [])
+    if any("4" == (m.get("data") or "").strip() for m in messages):
+        result["positive"] = "OK"
+    elif any("Unknown constant" in (m.get("data") or "") for m in messages):
+        result["positive"] = "STDLIB_BROKEN"
+        result["positive_data"] = messages[0].get("data", "")[:120]
+    else:
+        result["positive"] = "OTHER"
+        result["positive_data"] = json.dumps(messages[:1], ensure_ascii=False)[:200]
+    # 2. import bidon : doit ERREUR ; reponse muette = danger documente
+    payload = f'{{"cmd": "import {BOGUS_IMPORT}", "env": null}}\n\n'
+    raw, _ = spawn_repl(cwd, repl_cmd, payload)
+    parsed = parse_repl_json(raw)
+    if parsed is not None:
+        has_error = any((m.get("severity") == "error") for m in parsed.get("messages", []))
+        # muet = reponse valide SANS message d'erreur alors que l'import est impossible
+        result["bogus_mute"] = (not has_error) and ("env" in parsed)
+    return result
+
+
+def read_toolchain(dir_wsl: str) -> str | None:
+    rc, out = wsl_bash(f'cat {dir_wsl}/lean-toolchain 2>/dev/null')
+    return out.strip() if rc == 0 and out.strip() else None
+
+
+def classify(results: list[dict]) -> tuple[str, str]:
+    """Verdict global a partir des sondes. Fonction pure (testee unitairement)."""
+    if not results:
+        return "REPL_MISSING", "aucune sonde executable (repl introuvable ?)"
+    positives = [r["positive"] for r in results]
+    if all(p == "OK" for p in positives):
+        notes = [r["label"] for r in results if r.get("bogus_mute")]
+        mute_note = f" ; import bidon MUET sur {', '.join(notes)} (danger documente, cf #11874)" if notes else ""
+        return "REPL_HEALTHY", "controle positif OK sur tous les chemins" + mute_note
+    lake_ok = [r for r in results if r["label"] == "lake" and r["positive"] == "OK"]
+    broken = [r for r in results if r["positive"] == "STDLIB_BROKEN"]
+    if lake_ok and broken and not all(r["positive"] == "STDLIB_BROKEN" for r in results):
+        return ("REPL_LAKE_ONLY",
+                f"repl via lake OK ({lake_ok[0]['toolchain']}), repl nu casse ({', '.join(r['label'] for r in broken)}) "
+                "— mismatch toolchain binaire/toolchain resolu (cf #11874) ; le kernel ne marche que dans un lake matchant")
+    if broken:
+        return ("REPL_STDLIB_BROKEN",
+                f"controle positif #eval 2+2 echoue partout : {', '.join(r['label'] + '->' + str(r['positive_data'])[:60] for r in broken)}")
+    if all(p in ("TIMEOUT_OR_UNPARSEABLE",) for p in positives):
+        return "REPL_TIMEOUT", "aucune reponse parsable du repl sur aucun chemin"
+    return "REPL_UNCERTAIN", f"sondes heterogenes : {positives}"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--lake", action="append", default=[],
+                    help="lake a sonder via `lake env repl` (repeter pour plusieurs)")
+    ap.add_argument("--skip-stub", action="store_true",
+                    help="ne pas sonder le stub fallback ~/lean-projects/notebook_context")
+    ap.add_argument("--json", action="store_true", help="sortie JSON machine-lisible")
+    args = ap.parse_args()
+
+    # repl nu (PATH) depuis /tmp : le chemin d'un kernel sans lake
+    rc, which = wsl_bash("which repl")
+    results = []
+    if rc == 0 and which.strip():
+        results.append(probe_path("/tmp", "repl", "bare_path_tmp", None))
+    else:
+        print("WARN : binaire repl introuvable sur le PATH WSL", file=sys.stderr)
+
+    # stub fallback du wrapper
+    if not args.skip_stub:
+        rc, _ = wsl_bash(f"test -d {STUB_DIR}")
+        if rc == 0:
+            results.append(probe_path(
+                STUB_DIR, "repl", "stub_fallback", read_toolchain(STUB_DIR)))
+
+    # lakes explicites + lakes par defaut du miroir
+    lakes = list(args.lake) or ["~/lean-projects/mimo_lean"]
+    for lake in lakes:
+        rc, _ = wsl_bash(f"test -f {lake}/lakefile.lean -o -f {lake}/lakefile.toml")
+        if rc == 0:
+            results.append(probe_path(
+                lake, "lake env repl", "lake", read_toolchain(lake)))
+        else:
+            print(f"WARN : lake introuvable : {lake}", file=sys.stderr)
+
+    verdict, detail = classify(results)
+    report = {"verdict": verdict, "detail": detail, "probes": results}
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=1))
+    else:
+        print(f"VERDICT : {verdict}")
+        print(f"  {detail}")
+        for r in results:
+            print(f"  [{r['label']:14s}] toolchain={r.get('toolchain') or '-':24s} "
+                  f"positif={r['positive']:22s} bidon_muet={r.get('bogus_mute')}")
+    # exit codes : 0 sain/lake-only (etat documente), 1 casse, 2 incertain
+    return 0 if verdict in ("REPL_HEALTHY", "REPL_LAKE_ONLY") else (1 if verdict == "REPL_STDLIB_BROKEN" else 2)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/notebook_tools/tests/test_check_lean4_wsl_repl.py
+++ b/scripts/notebook_tools/tests/test_check_lean4_wsl_repl.py
@@ -1,0 +1,76 @@
+"""Tests unitaires des fonctions pures de check_lean4_wsl_repl (#11874).
+
+Les sondes reelles (WSL + repl) sont couvertes par le run documente dans la PR
+(REPL_LAKE_ONLY sur po-2026) — pas par ces tests.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from check_lean4_wsl_repl import classify, parse_repl_json  # noqa: E402
+
+
+def P(positive, label, **kw):
+    r = {"label": label, "positive": positive, "positive_data": None, "bogus_mute": None}
+    r.update(kw)
+    return r
+
+
+def test_parse_extracts_json_from_noisy_output():
+    raw = 'some lake warning\n{"messages": [{"severity": "info", "data": "4"}], "env": 0}\n'
+    parsed = parse_repl_json(raw)
+    assert parsed is not None and parsed["env"] == 0
+
+
+def test_parse_returns_none_on_garbage():
+    assert parse_repl_json("no json here") is None
+    assert parse_repl_json("") is None
+
+
+def test_classify_healthy_all_paths():
+    verdict, _ = classify([P("OK", "bare_path_tmp"), P("OK", "stub_fallback"), P("OK", "lake")])
+    assert verdict == "REPL_HEALTHY"
+
+
+def test_classify_healthy_notes_mute_imports():
+    verdict, detail = classify([P("OK", "bare_path_tmp", bogus_mute=True), P("OK", "lake")])
+    assert verdict == "REPL_HEALTHY"
+    assert "MUET" in detail and "bare_path_tmp" in detail
+
+
+def test_classify_lake_only_latent_state():
+    # etat documente sur po-2026 : repl nu et stub casses, lake OK
+    verdict, detail = classify([
+        P("STDLIB_BROKEN", "bare_path_tmp", positive_data="Unknown constant `OfNat`"),
+        P("STDLIB_BROKEN", "stub_fallback", positive_data="Unknown constant `OfNat`"),
+        P("OK", "lake", toolchain="leanprover/lean4:v4.32.1"),
+    ])
+    assert verdict == "REPL_LAKE_ONLY"
+    assert "v4.32.1" in detail and "bare_path_tmp" in detail
+
+
+def test_classify_fully_broken_ai01_state():
+    # etat documente sur ai-01 avant remede : meme via lake, le controle echoue
+    verdict, _ = classify([
+        P("STDLIB_BROKEN", "bare_path_tmp", positive_data="Unknown constant `OfNat`"),
+        P("STDLIB_BROKEN", "lake", positive_data="Unknown constant `OfNat`"),
+    ])
+    assert verdict == "REPL_STDLIB_BROKEN"
+
+
+def test_classify_all_timeout():
+    verdict, _ = classify([P("TIMEOUT_OR_UNPARSEABLE", "bare_path_tmp"),
+                           P("TIMEOUT_OR_UNPARSEABLE", "lake")])
+    assert verdict == "REPL_TIMEOUT"
+
+
+def test_classify_empty_is_missing():
+    verdict, _ = classify([])
+    assert verdict == "REPL_MISSING"
+
+
+def test_classify_heterogeneous_is_uncertain():
+    verdict, _ = classify([P("OTHER", "bare_path_tmp"), P("OK", "lake")])
+    assert verdict == "REPL_UNCERTAIN"


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: DEEP/qc #12039

Quoi:       Instrument de diagnostic du REPL lean4-wsl a controle positif, executable sur toute machine du cluster — volet "outil" de #11874
Preuve:     Run reel po-2026 : VERDICT REPL_LAKE_ONLY (3 sondes differenciees, decouverte au passage : le stub fallback v4.30.0 de po-2026 est AUSSI casse) + tests unitaires 9/9 + sortie --json verifiee
Perimetre:  2 nouveaux fichiers scripts/notebook_tools (outil + tests), rien d'autre

## Pourquoi un controle positif

Le body de #11874 (experience controlee ai-01) etablit le mecanisme : le binaire `repl`
ne trouve sa stdlib que si le toolchain RESOLU par le cwd correspond a sa version de
compilation. Les symptomes sont specialement pernicieux :

- `#eval 2+2` rend `Unknown constant OfNat` (stdlib absente) — pas un hang, une reponse ;
- un import impossible rend `{"env": N}` **MUET** — aucune erreur ;
- le health-check du kernel (`#eval Lean.versionString` sans verifier le resultat) ne
  detecte rien.

Donc toute sonde sans controle positif lit un kernel mort comme un kernel silencieux.
L'outil force chaque chemin a prouver qu'il peut calculer `2+2`.

## L'outil

`check_lean4_wsl_repl.py` sonde 3 chemins d'execution du kernel (chacun = process
repl frais) :

| Chemin | Ce qu'il teste |
|--------|----------------|
| `bare_path_tmp` | repl nu du PATH depuis /tmp (kernel sans lake) |
| `stub_fallback` | ~/lean-projects/notebook_context (fallback du wrapper) |
| `lake` | `lake env repl` dans un lake (defaut mimo_lean, --lake configurable) |

Par chemin : controle positif `#eval 2+2` -> "4" / import bidon doit ERREUR (reponse
muette = flag `bogus_mute`, danger documente non bloquant) / lecture du lean-toolchain
resolu. Verdicts : `REPL_HEALTHY` / `REPL_LAKE_ONLY` (etat latent : kernel utilisable
seulement dans un lake matchant) / `REPL_STDLIB_BROKEN` (etat ai-01 pre-remede) /
`REPL_MISSING` / `REPL_TIMEOUT` / `REPL_UNCERTAIN`. Exit codes 0/1/2 pour CI.

## Run reel po-2026 (preuve)

```
VERDICT : REPL_LAKE_ONLY
  repl via lake OK (v4.32.1), repl nu casse (bare_path_tmp, stub_fallback)
  [bare_path_tmp ] toolchain=-                      positif=STDLIB_BROKEN  bidon_muet=True
  [stub_fallback ] toolchain=leanprover/lean4:v4.30.0 positif=STDLIB_BROKEN  bidon_muet=True
  [lake          ] toolchain=leanprover/lean4:v4.32.1 positif=OK            bidon_muet=True
```

**Decouverte firsthand** : le meme mecanisme que celui documente par ai-01 est latent
sur po-2026 — le repl nu du PATH (recompile recent) ne trouve pas sa stdlib depuis
/tmp, ET le stub fallback du wrapper (v4.30.0) est casse aussi. Un notebook execute
hors lake echouerait presentement de facon silencieuse sur cette machine. Le lake
mimo_lean (v4.32.1) fonctionne, d'ou le verdict differencie.

## Bug fixe en route (documente dans le code)

`timeout 90 cd ~/lake && repl` rend un faux TIMEOUT_OR_UNPARSEABLE : `timeout` ne peut
pas executer le builtin `cd` (exit 125 silencieux, pipeline vide). Le cd passe dans le
pipeline bash AVANT timeout.

## Tests

9/9 (`pytest scripts/notebook_tools/tests/test_check_lean4_wsl_repl.py`) : classify
sur les 5 etats + healthy-avec-mute + parse JSON bruite. Les sondes reelles sont
couvertes par le run documente ci-dessus, pas par les tests.

See #11874 (volet instrument ; le remede machine — rebuild du repl pour matcher v4.32.1
— est le volet ai-01 ; cet outil rendra le verdict verifiable apres repair)

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
