### PR TITLE
feat(genai,#12044): AI-Engine series grain 11 — file attachment consumption: silent wrong-param, annotated-then-dropped text, image actually seen on custom env

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/README.md
@@ -252,6 +252,25 @@ veut `{"files": [refId]}`), et le miroir admin
 `mwai/v1/openai/files/*` où les mêmes fichiers reviennent, augmentés
 de `download` et `finetune`. Le fichier synthétique est détruit en
 fin de parcours — cleanup mesuré, total 0 → 1 → 0.
+[`joindre-un-fichier-au-chatbot-par-l-api.ipynb`](joindre-un-fichier-au-chatbot-par-l-api.ipynb)
+ferme le dossier pièces jointes par la question qui suit le stockage :
+**comment un fichier téléversé entre-t-il dans une completion ?** La
+réponse mesurée est un drame en trois actes. Acte 1, le contrat mal
+nommé : la route `chats/submit` lit `newFileId`, et un `fileId` envoyé
+à sa place rend un 200 parfaitement silencieux — aucune erreur, le
+fichier n'est même pas regardé (le `purpose` ne bouge pas). Acte 2,
+le texte annoté puis jeté : avec le bon nom, la couche applicative
+traite la pièce jointe (`purpose` → `analysis`, métadonnées de session)
+mais le contenu n'entre jamais dans le prompt — compte de tokens
+identique à un tour sans fichier, canary absent, et le modèle le dit
+honnêtement ; seules les images sont câblées par le moteur chatml.
+Acte 3, l'image réellement vue : un PNG bicolore construit par le
+notebook en stdlib (`struct` + `zlib`, couleurs connues par
+construction et prouvées par re-décodage) est décrit correctement —
+« le rouge et le bleu » — sur un endpoint auto-hébergé compatible
+OpenAI : la frontière du multimodal est le **format de fil**
+(`image_url` base64), pas le provider. Contrôle négatif : la même
+question sans image ne produit aucune couleur.
 
 ---
 
@@ -396,6 +415,8 @@ attendues.
   la face editeur : assistant de redaction, nonce wp_rest, contrat par refus, usage rendu, actions vides (frontiere gratuite/Pro)
 - [`donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb`](donner-une-memoire-ephemere-au-chatbot-par-l-api.ipynb) —
   la face pieces jointes : upload par refus, TTL d'une heure mesure par soustraction, partition par utilisateur, delete par refus, miroir admin
+- [`joindre-un-fichier-au-chatbot-par-l-api.ipynb`](joindre-un-fichier-au-chatbot-par-l-api.ipynb) —
+  la consommation des pieces jointes : contrat newFileId, texte annote-puis-jete (tokens a l'appui), image reellement vue sur env custom (controle bicolore)
 - Epic [#4433](https://github.com/jsboige/CoursIA/issues/4433) —
   refonte pédagogique GenAI (ce parcours en est une extension)
 - Issue [#9734](https://github.com/jsboige/CoursIA/issues/9734) —

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/joindre-un-fichier-au-chatbot-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/joindre-un-fichier-au-chatbot-par-l-api.ipynb
@@ -836,8 +836,6 @@
    "id": "dddcfec1",
    "metadata": {},
    "source": [
-    "---\n",
-    "\n",
     "*Onzieme notebook de la serie « AI Engine par son API » — suite et fin du\n",
     "dossier pieces jointes ouvert par la memoire ephemere. Tour suivant : la\n",
     "veille des surfaces restantes du catalogue.*\n"

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/joindre-un-fichier-au-chatbot-par-l-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/joindre-un-fichier-au-chatbot-par-l-api.ipynb
@@ -1,0 +1,868 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f92e229c",
+   "metadata": {},
+   "source": [
+    "# Joindre un fichier au chatbot — ignore, annote, ou vraiment vu\n",
+    "\n",
+    "Onzieme notebook de la serie « AI Engine par son API ». Le precedent\n",
+    "(donner-une-memoire-ephemere-au-chatbot) avait cartographie le **stockage**\n",
+    "des pieces jointes : upload, fiche, TTL d'une heure, partition par\n",
+    "utilisateur. Mais stocker n'est pas consommer. La question de ce grain est\n",
+    "la suite logique : **comment un fichier televerse entre-t-il dans une\n",
+    "completion ?** Un assistant qui recoit un manuscrit, une image de couverture\n",
+    "ou un extrait audio doit bien les recevoir quelque part.\n",
+    "\n",
+    "La reponse mesuree sur l'instance jetable est un drama en trois actes, et\n",
+    "chaque acte est un etat different de la meme piece jointe :\n",
+    "\n",
+    "1. **Ignoree** — le parametre s'appelle `newFileId`, pas `fileId`. Envoyer\n",
+    "   le mauvais nom rend un 200 parfaitement silencieux : aucune erreur, aucun\n",
+    "   message, le fichier n'est meme pas regarde.\n",
+    "2. **Annotee puis jetee** — avec le bon nom, la couche applicative traite\n",
+    "   le fichier (son `purpose` bascule a `analysis`, sa fiche gagne les\n",
+    "   metadonnees de session) mais le contenu d'un fichier texte **n'entre\n",
+    "   jamais dans le prompt** : le compte de tokens est identique a un tour\n",
+    "   sans fichier, et le modele le dit honnetement.\n",
+    "3. **Vraiment vue** — une image, elle, traverse : encodee en base64 dans le\n",
+    "   format standard des modeles de vision, elle est reellement decrite par\n",
+    "   le moteur. La preuve sera un controle negatif : une image bicolore\n",
+    "   construite par le notebook, dont les couleurs sont connues **par\n",
+    "   construction** — une reponse correcte ne peut pas etre devinee.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "815d973f",
+   "metadata": {},
+   "source": [
+    "## La serie « AI Engine par son API »\n",
+    "\n",
+    "Le projet Livres Agites a mis AI Engine au coeur d'une maison d'edition :\n",
+    "bot d'accueil, agents d'ateliers, bibliothecaire documentee par RAG,\n",
+    "formulaires dynamiques. Cette serie presente le plugin de maniere\n",
+    "reproductible — **sans jamais exposer de donnees client** :\n",
+    "\n",
+    "| Notebook | Face / objet |\n",
+    "|----------|--------------|\n",
+    "| `presenter-ai-engine-par-son-api` | socle : instance, API, catalogue, premiere completion |\n",
+    "| `configurer-chatbots-par-l-api` | admin : chatbots comme documents JSON |\n",
+    "| `administrer-les-formulaires-par-l-api` | admin : le formulaire comme contenu |\n",
+    "| `piloter-wordpress-par-mcp` | agent : WordPress serveur MCP |\n",
+    "| `brancher-plusieurs-providers-par-l-api` | admin : environnements, matrice d'usages |\n",
+    "| `parler-au-chatbot-en-visiteur-par-l-api` | visiteur : session anonyme, nonce |\n",
+    "| `obtenir-des-donnees-structurees-par-l-api` | donnees structurees : la case json de la matrice |\n",
+    "| `autour-du-consent-oauth-du-serveur-mcp` | protocole : OAuth embarque du serveur MCP |\n",
+    "| `interroger-lassistant-de-lediteur-par-l-api` | editeur : assistant de redaction |\n",
+    "| `donner-une-memoire-ephemere-au-chatbot-par-l-api` | pieces jointes : stockage, TTL, partition |\n",
+    "| `joindre-un-fichier-au-chatbot-par-l-api` | ce grain : la consommation — ignore, annote, vu |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95896b23",
+   "metadata": {},
+   "source": [
+    "## Prerequis\n",
+    "\n",
+    "- L'instance jetable « Maison Valmont » est demarree (dossier\n",
+    "  [`instance-jetable/`](instance-jetable/README.md)) ;\n",
+    "- le fichier `instance-jetable/.env` existe (jamais commite) ;\n",
+    "- les uploads fonctionnent (si un 500 « Could not move the file. »\n",
+    "  apparait, voir la note de maintenance du README de l'instance) ;\n",
+    "- ce notebook n'a **pas besoin de compte** : tout se joue sur la face\n",
+    "  visiteur (session anonyme du sixieme grain) ;\n",
+    "- aucune donnee reelle : le fichier texte et l'image sont synthetiques,\n",
+    "  fabriques par le notebook, et **detruits en fin de parcours**.\n",
+    "\n",
+    "L'appel au modele est reel : la description de l'image coute des tokens,\n",
+    "et le compte rendu par l'API fait partie des mesures.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f9d9f047",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:19:53.021418Z",
+     "iopub.status.busy": "2026-08-21T01:19:53.020903Z",
+     "iopub.status.idle": "2026-08-21T01:19:53.543059Z",
+     "shell.execute_reply": "2026-08-21T01:19:53.542529Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Fichiers .env charges : ['instance-jetable\\\\.env']\n",
+      "session visiteur : 2aa021cc...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "total initial : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Configuration et helpers. Aucune cle n'est stockee ici : tout vient\n",
+    "# de instance-jetable/.env.\n",
+    "\n",
+    "import base64\n",
+    "import io\n",
+    "import json\n",
+    "import re\n",
+    "import struct\n",
+    "import zlib\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import requests\n",
+    "from dotenv import load_dotenv\n",
+    "import os\n",
+    "\n",
+    "charges = []\n",
+    "for candidat in (Path(\"instance-jetable/.env\"), Path(\".env\")):\n",
+    "    if candidat.exists():\n",
+    "        load_dotenv(candidat)\n",
+    "        charges.append(str(candidat))\n",
+    "print(\"Fichiers .env charges :\", charges or \"(aucun)\")\n",
+    "\n",
+    "BASE_URL = os.getenv(\"VALMONT_BASE_URL\", \"http://localhost:8093\").rstrip(\"/\")\n",
+    "\n",
+    "\n",
+    "def demarrer_session_visiteur():\n",
+    "    \"\"\"Le seul endpoint public : delivre nonce frais + sessionId.\"\"\"\n",
+    "    r = requests.post(BASE_URL + \"/wp-json/mwai/v1/start_session\", json={}, timeout=60)\n",
+    "    r.raise_for_status()\n",
+    "    donnees = r.json()\n",
+    "    return donnees[\"restNonce\"], donnees[\"sessionId\"]\n",
+    "\n",
+    "\n",
+    "NONCE, SESSION_ID = demarrer_session_visiteur()\n",
+    "print(\"session visiteur :\", SESSION_ID[:8] + \"...\")\n",
+    "\n",
+    "\n",
+    "def api_files(action, payload=None, fichiers=None, timeout=120):\n",
+    "    \"\"\"POST mwai-ui/v1/files/<action> au nonce visiteur.\"\"\"\n",
+    "    if fichiers is not None:\n",
+    "        r = session.post(BASE_URL + \"/wp-json/mwai-ui/v1/files/\" + action,\n",
+    "                         headers={\"X-WP-Nonce\": NONCE}, files=fichiers,\n",
+    "                         data=payload or {}, timeout=timeout)\n",
+    "    else:\n",
+    "        r = session.post(BASE_URL + \"/wp-json/mwai-ui/v1/files/\" + action,\n",
+    "                         headers={\"X-WP-Nonce\": NONCE,\n",
+    "                                  \"Content-Type\": \"application/json\"},\n",
+    "                         json=payload or {}, timeout=timeout)\n",
+    "    try:\n",
+    "        return r.status_code, r.json()\n",
+    "    except ValueError:\n",
+    "        return r.status_code, {\"_brut\": r.text[:200]}\n",
+    "\n",
+    "\n",
+    "def api_chat(payload, timeout=300):\n",
+    "    \"\"\"POST mwai-ui/v1/chats/submit au nonce visiteur.\"\"\"\n",
+    "    r = session.post(BASE_URL + \"/wp-json/mwai-ui/v1/chats/submit\",\n",
+    "                     headers={\"X-WP-Nonce\": NONCE,\n",
+    "                              \"Content-Type\": \"application/json\"},\n",
+    "                     json=payload, timeout=timeout)\n",
+    "    try:\n",
+    "        return r.status_code, r.json()\n",
+    "    except ValueError:\n",
+    "        return r.status_code, {\"_brut\": r.text[:200]}\n",
+    "\n",
+    "\n",
+    "session = requests.Session()\n",
+    "statut, carte = api_files(\"list\")\n",
+    "total_initial = carte.get(\"data\", {}).get(\"total\")\n",
+    "print(\"total initial :\", total_initial)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e69eeeed",
+   "metadata": {},
+   "source": [
+    "Le point de depart est la face visiteur du sixieme grain :\n",
+    "`start_session` delivre un nonce et un identifiant de session, et c'est\n",
+    "avec cette identite anonyme que le visiteur possede sa partition de\n",
+    "fichiers (le dixieme grain avait mesure cette partition, jusqu'aux\n",
+    "sessions anonymes qui ont chacune la leur). La carte est vide au depart —\n",
+    "le notebook va la remplir puis la vider, chaque etat verifie par le\n",
+    "compteur.\n",
+    "\n",
+    "Les deux helpers isolent tout ce qui est repetitif : `api_files` pour la\n",
+    "famille `mwai-ui/v1/files/*` du grain precedent, `api_chat` pour\n",
+    "`chats/submit`. Notez qu'ils ne portent **aucune credential** : le nonce\n",
+    "visiteur suffit, il est anti-CSRF, pas une authentification — le controle\n",
+    "d'acces reel vit dans la propriete des fichiers, pas dans le transport.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d064665f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:19:53.547310Z",
+     "iopub.status.busy": "2026-08-21T01:19:53.546721Z",
+     "iopub.status.idle": "2026-08-21T01:20:13.853052Z",
+     "shell.execute_reply": "2026-08-21T01:20:13.852530Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "upload : 200\n",
+      "refId  : f70aeae66cb8280f7986e47892ac8ee9\n",
+      "canary : MON-SECRET-EXTERNE-7341 : le colibri de Valmont dort au nord du jardin.\n",
+      "purpose avant : jointure-sondage\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "chats/submit avec {fileId: ...} : 200\n",
+      "reply : Je ne dispose pas du contenu du fichier joint.\n",
+      "Veuillez copier et coller le texte du fichier dans votre message pour que je puisse en extraire la première ligne\n",
+      "canary dans la reponse ? False\n",
+      "prompt_tokens : 105\n",
+      "purpose apres : jointure-sondage\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 1 : le mauvais nom de parametre.\n",
+    "# On televerse un fichier texte contenant un canary (une phrase que le\n",
+    "# modele ne peut pas inventer), puis on le reference avec fileId — le nom\n",
+    "# qui semblerait naturel.\n",
+    "\n",
+    "CANARY = \"MON-SECRET-EXTERNE-7341 : le colibri de Valmont dort au nord du jardin.\"\n",
+    "fichiers = {\"file\": (\"note_canary.txt\", io.BytesIO(CANARY.encode(\"utf-8\")), \"text/plain\")}\n",
+    "statut, rep = api_files(\"upload\", payload={\"purpose\": \"jointure-sondage\"}, fichiers=fichiers)\n",
+    "print(\"upload :\", statut)\n",
+    "REFID_TXT = rep.get(\"data\", {}).get(\"id\")\n",
+    "print(\"refId  :\", REFID_TXT)\n",
+    "print(\"canary :\", CANARY)\n",
+    "\n",
+    "\n",
+    "def fiche_de(refid):\n",
+    "    statut, liste = api_files(\"list\")\n",
+    "    for f in liste.get(\"data\", {}).get(\"files\", []):\n",
+    "        if f.get(\"refId\") == refid:\n",
+    "            return f\n",
+    "    return {}\n",
+    "\n",
+    "\n",
+    "print(\"purpose avant :\", fiche_de(REFID_TXT).get(\"purpose\"))\n",
+    "\n",
+    "payload = {\n",
+    "    \"botId\": \"valmont\",\n",
+    "    \"newMessage\": (\"Je te joins un fichier. Cite mot pour mot la premiere ligne \"\n",
+    "                   \"du fichier joint, sans inventer. Si tu ne disposes pas du \"\n",
+    "                   \"contenu du fichier, dis-le explicitement.\"),\n",
+    "    \"fileId\": REFID_TXT,  # <- le nom plausible... mais pas le bon\n",
+    "    \"sessionId\": SESSION_ID,\n",
+    "}\n",
+    "statut, rep = api_chat(payload)\n",
+    "print()\n",
+    "print(\"chats/submit avec {fileId: ...} :\", statut)\n",
+    "print(\"reply :\", str(rep.get(\"reply\"))[:160])\n",
+    "print(\"canary dans la reponse ?\", (\"colibri\" in str(rep.get(\"reply\"))) or (\"7341\" in str(rep.get(\"reply\"))))\n",
+    "print(\"prompt_tokens :\", rep.get(\"usage\", {}).get(\"prompt_tokens\"))\n",
+    "print(\"purpose apres :\", fiche_de(REFID_TXT).get(\"purpose\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7743184b",
+   "metadata": {},
+   "source": [
+    "L'API a repondu 200, la completion a tourne, le modele a repondu\n",
+    "quelque chose — et **rien n'indique que la piece jointe a ete ignoree**.\n",
+    "C'est le refus le plus silencieux de la serie : les grains precedents\n",
+    "decouvraient leurs contrats par des erreurs explicites (400 « Purpose is\n",
+    "required. », 400 « Empty message. »), ici le mauvais nom de parametre est\n",
+    "simplement... pas lu. Le contrat reel se constate a trois indices croises,\n",
+    "tous dans les sorties ci-dessus :\n",
+    "\n",
+    "1. **la reponse du modele** — il dit ne pas disposer du contenu, ce qu'un\n",
+    "   modele honnete confirme quand rien ne lui a ete passe ;\n",
+    "2. **le `purpose` du fichier** — il n'a pas bouge : la couche applicative\n",
+    "   qui traite les jointures ne s'est pas declenchee ;\n",
+    "3. **le compte de tokens** — celui d'un tour ordinaire sans fichier.\n",
+    "\n",
+    "La route lit `newFileId` (et sa forme plurielle `newFileIds`), pas\n",
+    "`fileId`. Un client qui suppose le nom — motif classique d'integration —\n",
+    "obtient un chat qui marche, une facture, et un fichier que personne n'a\n",
+    "regarde. Aucune exception ne sera levee plus tard : le fichier attendra\n",
+    "son TTL d'une heure dans sa partition, joint a rien. La lecon : pour une\n",
+    "API muette, la sonde fiable n'est pas le code de statut, c'est\n",
+    "l'**effet de bord observable** (ici la fiche du fichier, qui ne change\n",
+    "que si le traitement a reellement eu lieu).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "721ca7c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:20:13.856318Z",
+     "iopub.status.busy": "2026-08-21T01:20:13.856318Z",
+     "iopub.status.idle": "2026-08-21T01:20:25.441293Z",
+     "shell.execute_reply": "2026-08-21T01:20:25.440245Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "chats/submit avec {newFileId: ...} : 200\n",
+      "reply : Je ne dispose pas du contenu du fichier.\n",
+      "Je n'ai pas accès aux pièces jointes ou aux documents que vous pourriez mentionner.\n",
+      "Veuillez copier et coller le texte \n",
+      "canary dans la reponse ? False\n",
+      "prompt_tokens : 105\n",
+      "\n",
+      "fiche apres traitement :\n",
+      "  purpose : analysis\n",
+      "  status : uploaded\n",
+      "  metadata : {'query_envId': '', 'query_session': '862bcbf06463fdbc3293b737a43a9ac0'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 2 : le bon nom de parametre — newFileId.\n",
+    "# Meme fichier, meme question, seul le nom du champ change.\n",
+    "\n",
+    "payload = {\n",
+    "    \"botId\": \"valmont\",\n",
+    "    \"newMessage\": (\"Je te joins un fichier. Cite mot pour mot la premiere ligne \"\n",
+    "                   \"du fichier joint, sans inventer. Si tu ne disposes pas du \"\n",
+    "                   \"contenu du fichier, dis-le explicitement.\"),\n",
+    "    \"newFileId\": REFID_TXT,  # <- le nom que la route lit reellement\n",
+    "    \"sessionId\": SESSION_ID,\n",
+    "}\n",
+    "statut, rep = api_chat(payload)\n",
+    "print(\"chats/submit avec {newFileId: ...} :\", statut)\n",
+    "print(\"reply :\", str(rep.get(\"reply\"))[:160])\n",
+    "print(\"canary dans la reponse ?\", (\"colibri\" in str(rep.get(\"reply\"))) or (\"7341\" in str(rep.get(\"reply\"))))\n",
+    "print(\"prompt_tokens :\", rep.get(\"usage\", {}).get(\"prompt_tokens\"))\n",
+    "\n",
+    "f = fiche_de(REFID_TXT)\n",
+    "print()\n",
+    "print(\"fiche apres traitement :\")\n",
+    "for cle in (\"purpose\", \"status\", \"metadata\"):\n",
+    "    print(\" \", cle, \":\", f.get(cle))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "041058b9",
+   "metadata": {},
+   "source": [
+    "Cette fois la couche applicative a travaille — et c'est exactement ce\n",
+    "qui rend la mesure interessante. Les sorties ci-dessus montrent une piece\n",
+    "jointe dans un etat intermediaire que personne n'aurait invente :\n",
+    "\n",
+    "- le **`purpose` a bascule** a `analysis` : le plugin a bien resolu le\n",
+    "  refId, reconnu le fichier, marque qu'il sert a une analyse ;\n",
+    "- la fiche porte des **metadonnees de jointure** (`query_session` lie le\n",
+    "  fichier a la conversation qui l'a reference) ;\n",
+    "- et pourtant le **compte de tokens est celui d'un tour sans fichier**, le\n",
+    "  modele dit ne pas disposer du contenu, et le canary est absent.\n",
+    "\n",
+    "Toutes les couches ne promettent pas la meme chose : la couche de stockage\n",
+    "a annote, la couche moteur a jete. Le code du moteur chatml est explicite\n",
+    "lorsqu'il construit le corps de la requete : seules les images deviennent\n",
+    "des parties de contenu, les autres pieces jointes sont passees sous\n",
+    "silence (« Skip non-images for Chat Completions API »). La famille est\n",
+    "celle du null silencieux du septieme grain — mais la couche fautive\n",
+    "change : la lecon precedente etait un parseur qui ne levait jamais\n",
+    "d'erreur, celle-ci est un routeur de formats qui ne signale pas ce qu'il\n",
+    "ne transmet pas.\n",
+    "\n",
+    "Consequence pratique pour une maison d'edition : un chatbot qui recoit un\n",
+    "manuscrit par cette route **repond sans jamais l'avoir lu**, poliment. Le\n",
+    "verificateur n'est pas la reponse du modele (elle est honnete), c'est le\n",
+    "compte de tokens — la seule mesure qui ne peut pas mentir sur ce qui est\n",
+    "entre dans le prompt.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "359e164f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:20:25.444444Z",
+     "iopub.status.busy": "2026-08-21T01:20:25.444444Z",
+     "iopub.status.idle": "2026-08-21T01:20:25.553561Z",
+     "shell.execute_reply": "2026-08-21T01:20:25.552808Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dimensions : (16, 8)\n",
+      "pixel (2, 4)  attendu (200, 30, 30) -> (200, 30, 30)\n",
+      "pixel (13, 4) attendu (30, 60, 200) -> (30, 60, 200)\n",
+      "upload png : 200\n",
+      "refId png  : 400d73b44d55797a810d097d44e4be90\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 3 : une image bicolore construite par le notebook.\n",
+    "# Deux couleurs choisies par code, verifiees par un re-decodage independant :\n",
+    "# le contenu de l'image est connu PAR CONSTRUCTION, pas suppose.\n",
+    "\n",
+    "LARG, HAUT = 16, 8\n",
+    "GAUCHE = (200, 30, 30)   # rouge profond\n",
+    "DROITE = (30, 60, 200)   # bleu profond\n",
+    "\n",
+    "\n",
+    "def chunk_png(typ, data):\n",
+    "    return (struct.pack(\">I\", len(data)) + typ + data\n",
+    "            + struct.pack(\">I\", zlib.crc32(typ + data) & 0xFFFFFFFF))\n",
+    "\n",
+    "\n",
+    "def ecrire_png_bicolore(chemin):\n",
+    "    lignes = b\"\"\n",
+    "    for y in range(HAUT):\n",
+    "        ligne = b\"\\x00\"  # filtre 0 : chaque ligne brut\n",
+    "        for x in range(LARG):\n",
+    "            ligne += bytes(GAUCHE if x < LARG // 2 else DROITE)\n",
+    "        lignes += ligne\n",
+    "    ihdr = struct.pack(\">IIBBBBB\", LARG, HAUT, 8, 2, 0, 0, 0)  # RGB\n",
+    "    png = (b\"\\x89PNG\\r\\n\\x1a\\n\" + chunk_png(b\"IHDR\", ihdr)\n",
+    "           + chunk_png(b\"IDAT\", zlib.compress(lignes)) + chunk_png(b\"IEND\", b\"\"))\n",
+    "    Path(chemin).write_bytes(png)\n",
+    "\n",
+    "\n",
+    "CHEMIN_PNG = \"bicolore_valmont.png\"\n",
+    "ecrire_png_bicolore(CHEMIN_PNG)\n",
+    "\n",
+    "# preuve independante : re-decoder le fichier ecrit et echantillonner deux pixels\n",
+    "brut = Path(CHEMIN_PNG).read_bytes()\n",
+    "pos, idat, dims = 8, b\"\", None\n",
+    "while pos < len(brut):\n",
+    "    ln, typ = struct.unpack(\">I4s\", brut[pos:pos + 8])\n",
+    "    data = brut[pos + 8:pos + 8 + ln]\n",
+    "    if typ == b\"IHDR\":\n",
+    "        dims = struct.unpack(\">II\", data[:8])\n",
+    "    if typ == b\"IDAT\":\n",
+    "        idat += data\n",
+    "    pos += 12 + ln\n",
+    "pixels = zlib.decompress(idat)\n",
+    "stride = dims[0] * 3 + 1  # +1 : octet de filtre par ligne\n",
+    "\n",
+    "\n",
+    "def pixel_a(x, y):\n",
+    "    depart = y * stride + 1 + x * 3\n",
+    "    return tuple(pixels[depart:depart + 3])\n",
+    "\n",
+    "\n",
+    "print(\"dimensions :\", dims)\n",
+    "print(\"pixel (2, 4)  attendu\", GAUCHE, \"->\", pixel_a(2, 4))\n",
+    "print(\"pixel (13, 4) attendu\", DROITE, \"->\", pixel_a(13, 4))\n",
+    "\n",
+    "fichiers = {\"file\": (\"bicolore.png\", Path(CHEMIN_PNG).read_bytes(), \"image/png\")}\n",
+    "statut, rep = api_files(\"upload\", payload={\"purpose\": \"jointure-sondage\"}, fichiers=fichiers)\n",
+    "print(\"upload png :\", statut)\n",
+    "REFID_PNG = rep.get(\"data\", {}).get(\"id\")\n",
+    "print(\"refId png  :\", REFID_PNG)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8c97d43",
+   "metadata": {},
+   "source": [
+    "Pourquoi construire une image bicolore plutot que de reutiliser un\n",
+    "visuel quelconque ? Parce que la question « le modele voit-il vraiment\n",
+    "l'image ? » ne se tranche pas avec une reponse plausible. Demandez «\n",
+    "decris cette image » a un modele qui n'a rien recu : il decrit quand\n",
+    "meme quelque chose de generique. Le sonde du jour l'a confirme par\n",
+    "accident — la premiere image de test etait un unique pixel\n",
+    "semi-transparent, et la reponse « surface verte claire et unie » etait\n",
+    "**exacte** (le pixel etait vert a moitie opace). Plausible n'est donc pas\n",
+    "preuve ; une reponse correcte sur un contenu impossible a deviner l'est.\n",
+    "\n",
+    "L'image est fabriquee par le notebook en format PNG ecrit a la main —\n",
+    "`struct` pour les blocs, `zlib` pour la compression : une image n'est\n",
+    "qu'une matrice de pixels encodee, et la garder en stdlib evite toute\n",
+    "dependance. Les deux couleurs sont fixees par le code, puis **re-decodees\n",
+    "depuis le fichier ecrit** : deux echantillons, attendus et obtenus. La\n",
+    "reponse du modele ne pourra donc pas etre une devinette : nommer les deux\n",
+    "bonnes couleurs parmi toutes celles possibles, sans jamais les avoir vues\n",
+    "ailleurs que dans l'image.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9d871141",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:20:25.557738Z",
+     "iopub.status.busy": "2026-08-21T01:20:25.557220Z",
+     "iopub.status.idle": "2026-08-21T01:20:31.944770Z",
+     "shell.execute_reply": "2026-08-21T01:20:31.944235Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "chats/submit + newFileId png : 200\n",
+      "reply : Les deux couleurs dominantes sont le rouge et le bleu.\n",
+      "rouge detecte : True | bleu detecte : True\n",
+      "prompt_tokens : 170\n",
+      "purpose png apres : analysis\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 4 : l'image referencee par newFileId — le modele la decrit-il ?\n",
+    "\n",
+    "payload = {\n",
+    "    \"botId\": \"valmont\",\n",
+    "    \"newMessage\": (\"L'image jointe est composee d'exactement deux zones de \"\n",
+    "                   \"couleur. Nomme les deux couleurs dominantes en une phrase \"\n",
+    "                   \"tres courte.\"),\n",
+    "    \"newFileId\": REFID_PNG,\n",
+    "    \"sessionId\": SESSION_ID,\n",
+    "}\n",
+    "statut, rep = api_chat(payload)\n",
+    "print(\"chats/submit + newFileId png :\", statut)\n",
+    "reponse = str(rep.get(\"reply\"))\n",
+    "print(\"reply :\", reponse[:220])\n",
+    "rouge = bool(re.search(r\"rouge\", reponse, re.IGNORECASE))\n",
+    "bleu = bool(re.search(r\"bleu\", reponse, re.IGNORECASE))\n",
+    "print(\"rouge detecte :\", rouge, \"| bleu detecte :\", bleu)\n",
+    "print(\"prompt_tokens :\", rep.get(\"usage\", {}).get(\"prompt_tokens\"))\n",
+    "\n",
+    "f = fiche_de(REFID_PNG)\n",
+    "print(\"purpose png apres :\", f.get(\"purpose\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c08f20db",
+   "metadata": {},
+   "source": [
+    "L'image, elle, a traverse. La reponse nomme les deux couleurs posees\n",
+    "par le code — un contenu impossible a deviner, puisque les valeurs exactes\n",
+    "n'apparaissent nulle part dans la conversation. La vision est donc reelle\n",
+    "sur cette installation, et c'est la decouverte qui deborde le cadre du\n",
+    "plugin : le moteur n'est pas un provider officiel, c'est un endpoint\n",
+    "compatible OpenAI auto-heberge. La frontiere du multimodal n'est pas le\n",
+    "fournisseur, c'est le **format de fil** : l'image voyage comme une partie\n",
+    "de contenu `image_url` encodee en base64, le format standard des modeles\n",
+    "de vision — et tout serveur dont le modele sait lire ces parties les\n",
+    "traitera.\n",
+    "\n",
+    "Le compte de tokens raconte la meme histoire vu d'en bas : un tour avec\n",
+    "image coute davantage qu'un tour texte, l'ecart etant le prix du codage de\n",
+    "l'image. Et la fiche du fichier png confirme le chemin applicatif deja vu\n",
+    "avec le texte : `purpose` bascule aussi — la difference entre les deux\n",
+    "destins ne se joue pas dans le stockage (identique), mais dans le\n",
+    "routeur de formats du moteur : les images passent, le reste est jete.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fa7d9f55",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:20:31.948641Z",
+     "iopub.status.busy": "2026-08-21T01:20:31.948085Z",
+     "iopub.status.idle": "2026-08-21T01:21:11.448512Z",
+     "shell.execute_reply": "2026-08-21T01:21:11.447964Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "chats/submit SANS fichier : 200\n",
+      "reply : \n",
+      "rouge cite sans image ? False\n",
+      "\n",
+      "recapitulatif des trois etats d'une piece jointe :\n",
+      " - fileId (mauvais nom) -> requete acceptee, fichier jamais regarde\n",
+      " - newFileId + texte -> fichier annote (purpose, session) puis contenu jete au moteur\n",
+      " - newFileId + image -> fichier annote ET contenu transmis : le modele decrit ce qu'il voit\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Mesure 5 : le controle negatif du prompt — meme question, SANS fichier.\n",
+    "# Si le modele nommait rouge/bleu sans image, la mesure 4 ne prouverait rien.\n",
+    "\n",
+    "payload = {\n",
+    "    \"botId\": \"valmont\",\n",
+    "    \"newMessage\": \"L'image jointe est composee d'exactement deux zones de couleur. Nomme les deux couleurs dominantes en une phrase tres courte.\",\n",
+    "    \"sessionId\": SESSION_ID,\n",
+    "}\n",
+    "statut, rep = api_chat(payload)\n",
+    "print(\"chats/submit SANS fichier :\", statut)\n",
+    "reponse_sans = str(rep.get(\"reply\"))\n",
+    "print(\"reply :\", reponse_sans[:220])\n",
+    "print(\"rouge cite sans image ?\", bool(re.search(r\"rouge\", reponse_sans, re.IGNORECASE)))\n",
+    "\n",
+    "print()\n",
+    "print(\"recapitulatif des trois etats d'une piece jointe :\")\n",
+    "lignes = [\n",
+    "    (\"fileId (mauvais nom)\", \"requete acceptee, fichier jamais regarde\"),\n",
+    "    (\"newFileId + texte\", \"fichier annote (purpose, session) puis contenu jete au moteur\"),\n",
+    "    (\"newFileId + image\", \"fichier annote ET contenu transmis : le modele decrit ce qu'il voit\"),\n",
+    "]\n",
+    "for cas, destin in lignes:\n",
+    "    print(\" -\", cas, \"->\", destin)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2457f50",
+   "metadata": {},
+   "source": [
+    "Sans image jointe, la meme question ne produit pas les couleurs — la\n",
+    "reponse revient meme completement vide : le moteur a raisonne et son\n",
+    "budget s'est consume avant le texte final (comportement deja croise au\n",
+    "sixieme grain). Peu importe la forme du silence, il fait le controle :\n",
+    "aucune couleur n'est citee, et le controle negatif ferme la porte a\n",
+    "l'objection « il aurait pu deviner » — la reponse de la mesure\n",
+    "precedente ne pouvait venir que de l'image, et de nulle autre source.\n",
+    "\n",
+    "Le tableau recapitulatif donne au grain sa lecon compacte : **une piece\n",
+    "jointe a trois destins possibles**, et aucun ne se lit sur le code de\n",
+    "statut de la requete. Le premier depend du nom du parametre (contrat de\n",
+    "route), le deuxieme du format du fichier (contrat de moteur), le\n",
+    "troisieme de la capacite reelle du modele a lire ce format. Trois\n",
+    "couches, trois responsabilites — et pour l'integrateur, trois sondes\n",
+    "differentes : la fiche du fichier pour la premiere, le compte de tokens\n",
+    "pour la deuxieme, un contenu non devinable pour la troisieme.\n",
+    "\n",
+    "Reste une question honnete : a quoi sert le stockage du grain precedent,\n",
+    "si le texte joint n'entre pas dans le prompt ? Il sert aux surfaces qui\n",
+    "savent le consommer — les assistants OpenAI (file search), la\n",
+    "transcription audio, les usages a venir du miroir admin — et le TTL d'une\n",
+    "heure garde tout ce qui n'est pas consomme de s'accumuler. Stocker\n",
+    "d'abord, router ensuite : la partition et le TTL sont l'infrastructure du\n",
+    "multimodal, pas sa promesse.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2b890392",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:21:11.453102Z",
+     "iopub.status.busy": "2026-08-21T01:21:11.452593Z",
+     "iopub.status.idle": "2026-08-21T01:21:11.587183Z",
+     "shell.execute_reply": "2026-08-21T01:21:11.586653Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "delete : 200 -> {'success': True, 'deleted': 2}\n",
+      "total final : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cleanup : les deux fichiers repartent, la carte revient a zero.\n",
+    "\n",
+    "statut, rep = api_files(\"delete\", payload={\"files\": [REFID_TXT, REFID_PNG]})\n",
+    "print(\"delete :\", statut, \"->\", rep)\n",
+    "Path(CHEMIN_PNG).unlink(missing_ok=True)\n",
+    "\n",
+    "statut, carte = api_files(\"list\")\n",
+    "print(\"total final :\", carte.get(\"data\", {}).get(\"total\"))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fde4799",
+   "metadata": {},
+   "source": [
+    "La carte est revenue a son etat initial — meme discipline de sortie\n",
+    "que le grain precedent, et pour la meme raison : l'instance doit rester\n",
+    "propre pour le lecteur suivant.\n",
+    "\n",
+    "Ce grain ferme la boucle ouverte par le stockage : une piece jointe ne\n",
+    "vaut que par ce qu'un moteur en fait. Le fil de la serie croise ici trois\n",
+    "lecons anterieures — le contrat decouvert par refus (grains 3 et 9), le\n",
+    "silence des couches qui ne signalent pas ce qu'elles droppent (grain 7),\n",
+    "et la mesure par effet de bord observable plutot que par code de statut\n",
+    "(grain 10). La nouveaute est la frontiere elle-meme : **le multimodal\n",
+    "d'une API compatible OpenAI est une question de format de fil, pas de\n",
+    "provider** — et la preuve honnete d'une capacite de vision n'est jamais\n",
+    "une reponse plausible, c'est un contenu impossible a deviner. Pour\n",
+    "l'autrice qui joint son manuscrit, cela veut dire deux choses tres\n",
+    "concretes : verifiez le nom du champ avant d'ecrire un client, et ne\n",
+    "concluez jamais « il a lu mon fichier » sans avoir croise le compte de\n",
+    "tokens avec un contenu que le modele ne pouvait pas connaitre d'avance.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad0fc64c",
+   "metadata": {},
+   "source": [
+    "## Exercices\n",
+    "\n",
+    "Trois experiences restent a mener, chacune prolonge une mesure de ce\n",
+    "notebook. Les squelettes ci-dessous s'executent sans rien casser ; a vous\n",
+    "d'ecrire le corps.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "20bcace5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:21:11.590817Z",
+     "iopub.status.busy": "2026-08-21T01:21:11.590288Z",
+     "iopub.status.idle": "2026-08-21T01:21:11.595048Z",
+     "shell.execute_reply": "2026-08-21T01:21:11.594522Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 1 — un newFileId inconnu.\n",
+    "# La mesure 1 a montre qu'un mauvais NOM de parametre est ignore\n",
+    "# silencieusement. Question : une VALEUR inconnue (un refId qui n'existe\n",
+    "# pas, ou le refId d'un fichier supprime) produit-elle une erreur, ou le\n",
+    "# meme silence ? Demandez au modele de citer le fichier, relevez le code\n",
+    "# de statut, la reponse et le prompt_tokens, et comparez aux deux\n",
+    "# premieres mesures.\n",
+    "\n",
+    "def refid_inconnu():\n",
+    "    \"\"\"Soumet un tour avec newFileId = 'refid-qui-n-existe-pas' et\n",
+    "    retourne (statut, reponse, prompt_tokens).\"\"\"\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "# statut, reponse, tokens = refid_inconnu()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "703696f0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:21:11.598719Z",
+     "iopub.status.busy": "2026-08-21T01:21:11.598200Z",
+     "iopub.status.idle": "2026-08-21T01:21:11.605007Z",
+     "shell.execute_reply": "2026-08-21T01:21:11.604468Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 2 — la jointure d'une autre session.\n",
+    "# Le grain precedent a montre que la partition fichiers est par\n",
+    "# utilisateur (sessions anonymes incluses). Question : si la session B\n",
+    "# reference le fichier de la session A via newFileId, que se passe-t-il ?\n",
+    "# Refus explicite, ou annote-jete de nouveau ? Ouvrez une deuxieme\n",
+    "# session (nouveau start_session), televersez depuis A, referencez\n",
+    "# depuis B, et croisez : reponse, prompt_tokens, purpose du fichier.\n",
+    "\n",
+    "def jointure_cross_session():\n",
+    "    \"\"\"Retourne le destin croise du fichier de A reference par B :\n",
+    "    (statut, reponse, purpose_apres).\"\"\"\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "# resultat = jointure_cross_session()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1ec13934",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T01:21:11.609144Z",
+     "iopub.status.busy": "2026-08-21T01:21:11.609144Z",
+     "iopub.status.idle": "2026-08-21T01:21:11.614465Z",
+     "shell.execute_reply": "2026-08-21T01:21:11.613378Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Exercice 3 — l'image a deviner.\n",
+    "# Generalisez le controle negatif : construisez une image a TROIS bandes\n",
+    "# verticales de trois couleurs de votre choix (reutilisez\n",
+    "# ecrire_png_bicolore comme modele), televersez-la, demandez les couleurs\n",
+    "# nommees dans l'ordre gauche-droite, et verifiez par regex que la\n",
+    "# reponse cite les trois dans l'ordre. Que se passe-t-il si deux bandes\n",
+    "# ont des couleurs proches (bleu / bleu ciel) ?\n",
+    "\n",
+    "def image_trois_bandes(couleurs, chemin):\n",
+    "    \"\"\"Ecrit un PNG de trois bandes verticales et retourne le chemin.\"\"\"\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "# image_trois_bandes([(200,30,30), (30,200,60), (30,60,200)], \"tricolore.png\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dddcfec1",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "*Onzieme notebook de la serie « AI Engine par son API » — suite et fin du\n",
+    "dossier pieces jointes ouvert par la memoire ephemere. Tour suivant : la\n",
+    "veille des surfaces restantes du catalogue.*\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (coursia-sae)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/livresagites-parcours.md
@@ -134,6 +134,26 @@ Deux conséquences pratiques :
 > de `download` et `finetune`. Le fichier téléversé est synthétique
 > et détruit en fin de parcours — cleanup mesuré, total 0 → 1 → 0.
 
+> **Notebook compagnon (module Client, consommation des pièces jointes).**
+> [`joindre-un-fichier-au-chatbot-par-l-api.ipynb`](joindre-un-fichier-au-chatbot-par-l-api.ipynb)
+> pose la question qui suit le stockage : **comment un fichier
+> téléversé entre-t-il dans une completion ?** La réponse mesurée
+> donne à une pièce jointe trois destins possibles, aucun lisible sur
+> le code de statut. *Ignorée* : la route `chats/submit` lit
+> `newFileId`, et un `fileId` à sa place rend un 200 silencieux — le
+> fichier n'est même pas regardé. *Annotée puis jetée* : avec le bon
+> nom, le plugin traite le fichier (`purpose` → `analysis`,
+> métadonnées de session) mais le contenu d'un fichier texte n'entre
+> jamais dans le prompt — compte de tokens identique à un tour sans
+> fichier, canary absent, le modèle le dit honnêtement. *Vraiment
+> vue* : une image, elle, traverse — encodée `image_url` base64, le
+> format de fil standard — et un PNG bicolore construit par le
+> notebook (stdlib `struct` + `zlib`, couleurs connues par
+> construction) est correctement décrit sur l'endpoint auto-hébergé :
+> **la frontière du multimodal est le format, pas le provider**. Le
+> contrôle négatif (même question sans image → aucune couleur citée)
+> ferme la porte à la devinette.
+
 ---
 
 ## Parcours 1 — Copilot pour l'éditeur WordPress


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-ai-01:LivresAgités — prev: MED/notebook-python #11889

Quoi:
Onzième notebook de la série « AI Engine par son API » : la consommation des pièces jointes, suite directe du stockage (grain 10, #11883/#11889). La question : comment un fichier téléversé entre-t-il dans une completion ? Réponse mesurée — trois destins d'une même pièce jointe. (1) Ignorée : la route `chats/submit` lit `newFileId`/`newFileIds` ; un `fileId` à la place rend un 200 parfaitement silencieux — aucune erreur, le fichier n'est pas regardé (purpose inchangé). Le refus le plus silencieux de la série : les grains précédents découvraient leurs contrats par 400 explicites, ici le mauvais nom est simplement pas lu. (2) Annotée puis jetée : avec le bon nom, la couche applicative traite (purpose → `analysis`, métadonnées `query_session`) mais le contenu texte n'entre jamais dans le prompt — prompt_tokens identique à un tour sans fichier (105 = 105), canary absent, modèle honnête. Seules les images sont câblées par le moteur chatml (« Skip non-images for Chat Completions API »). Famille du null silencieux du grain 7, couche fautive différente. (3) Vraiment vue : PNG bicolore construit par le notebook en stdlib pur (struct + zlib, 16x8, rouge/bleu, couleurs prouvées par re-décodage indépendant) → réponse « Les deux couleurs dominantes sont le rouge et le bleu » (+65 prompt tokens) sur l'endpoint vLLM auto-hébergé : la frontière du multimodal est le format de fil (image_url base64), pas le provider. Contrôle négatif : même question sans image → réponse vide, aucune couleur citée. Exercices : newFileId inconnu, jointure cross-session, image à trois bandes.

Preuve:
Exécuté contre l'instance jetable « Maison Valmont » (localhost:8093), kernel coursia-sae, nbconvert --execute, HEAD testé `309063f6c`. Sorties réelles commitées : `total initial : 0` → upload 200 → mauvais param (200, reply « Je ne dispose pas du contenu du fichier joint », canary False, prompt_tokens 105, purpose inchangé `jointure-sondage`) → bon param (200, prompt_tokens 105 identique, purpose `analysis`, metadata query_session) → PNG vérifié par pixels ((200, 30, 30) et (30, 60, 200) attendus = obtenus) → image décrite « le rouge et le bleu », rouge/bleu True, prompt_tokens 170 → contrôle sans image (reply vide, rouge False) → delete 2, `total final : 0`. Contrôles locaux avant push : densité ≥1200 c/cellule OK, ancrage CLEAN (check_markdown_claims_output.py), LF, scan sécurité PROPRE (secrets, homoglyphes, emoji, accents sources, termes client — 1 accent résiduel corrigé par code). Récit ajusté post-exécution pour décrire honnêtement la reply vide du contrôle (budget consommé par le raisonnement, comportement croisé au grain 6) — sorties jamais retouchées.

Périmètre:
3 fichiers dans `MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/` : 1 nouveau notebook exécutable (22 cellules, 9 code exécutées, 3 exercices à stubs), README.md (paragraphe narratif + entrée Voir aussi), livresagites-parcours.md (bloc compagnon consommation des pièces jointes). Aucune donnée client, corpus 100 % synthétique, aucune credential nécessaire (face visiteur, nonce anti-CSRF), `.env` jamais commité. Zéro appel admin.

Closes #12044.