### PR TITLE
chore(harness,#12051): deporter recits et justifications de sota-not-workaround (-851 ch injectes/session)

### DIFF
--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -33,7 +33,7 @@ Le defaut paresseux (« ASCII art / reimplementation jouet / 'Java absent' / 'ke
 | 5 | **`PythonNet`** (pont CPython) **(NEW c.8243)** | **La lib a-t-elle un binding Python ?** Si oui, le pont `.NET → CPython → pyspiel`-like est disponible via `pythonnet 3.0.5` + `Runtime.PythonDLL` — pas d'`INTRINSIC` sans l'avoir teste. |
 | 6 | **Lib differente a role equivalent** | Un autre moteur SOTA .NET tient-il le role ? (cf PyMC ↔ Infer.NET, OR-Tools ↔ choco, mealpy ↔ MetaGeneticSharp) |
 
-**Regle d'enforcement** : un verdict `INTRINSIC` dont le body **ne repond pas nominativement les 6 axes** (y compris « axe 5 N/A parce que la cible n'a pas de binding Python, vérifié sur PyPI au commit SHA … ») est **incomplet** → **`CHANGES_REQUESTED`** ([pr-review-discipline.md](pr-review-discipline.md) §H).
+**Regle d'enforcement** : un verdict `INTRINSIC` dont le body **ne repond pas nominativement les 6 axes** (y compris « axe 5 N/A parce que la cible n'a pas de binding Python, vérifié sur PyPI au commit SHA … ») est **incomplet** → **`CHANGES_REQUESTED`** ([pr-review-discipline.md](pr-review-discipline.md) §H). La taxonomie des 5 verdicts est **inchangee** : seul l'etablissement d'`INTRINSIC` se durcit.
 
 **Origine** (#10459) : 3 verdicts `INTRINSIC` OpenSpiel convergents, aucun n'ayant examine l'axe PythonNet ; l'axe est desormais **prouve** par 5 PRs mergees. Deuxieme omission apres `IKVM`. Recit, verbatim user et mesures : [detail §2](../../docs/reference/sota-verdicts-detail.md).
 

--- a/.claude/rules/sota-not-workaround.md
+++ b/.claude/rules/sota-not-workaround.md
@@ -1,6 +1,6 @@
 # SOTA : vrai outil + probleme non-trivial — install/invoke/re-plug, faire valoir le moteur (HARD)
 
-S'applique a **tous les agents** (workers po-* + coordinateur ai-01) **ET a tous les reviewers (humains ET bots** clusterManager-Myia : Hermes primaire, NanoClaw audit). Source : mandat user 2026-06-21 (3 messages : outil **installe ou invoque**, sinon **branche/rebranche** — au besoin sur la machine au bon env ; tenir un **registre** + resserrer le harnais ET les bots, le **reflexe workaround degrade** etant le defaut a corriger ; **problemes trop basiques** a complexifier pour faire valoir les moteurs). Registre = **EPIC #3801**. Consolide CLAUDE.md section F (reparer, jamais contourner) + [repair-not-consecrate](../../docs/reference/regles-validation-detail.md) + l'audit a 2 axes (committed <-> achievable).
+S'applique a **tous les agents** (workers po-* + coordinateur ai-01) **ET a tous les reviewers (humains ET bots** clusterManager-Myia : Hermes primaire, NanoClaw audit). Source : mandat user 2026-06-21, 3 messages — verbatim en [detail §1](../../docs/reference/sota-verdicts-detail.md). Registre = **EPIC #3801**. Consolide CLAUDE.md section F (reparer, jamais contourner) + [repair-not-consecrate](../../docs/reference/regles-validation-detail.md) + l'audit a 2 axes (committed <-> achievable).
 
 **Verbatims du mandat, incidents d'axes, mesures anti-fabrication** : [docs/reference/sota-verdicts-detail.md](../../docs/reference/sota-verdicts-detail.md).
 
@@ -22,7 +22,7 @@ Le defaut paresseux (« ASCII art / reimplementation jouet / 'Java absent' / 'ke
 
 ### Procedure d'etablissement INTRINSIC — checklist 6 axes obligatoire (NEW c.8243, #10459)
 
-Un verdict `INTRINSIC` est le plus restrictif des 5 (il declare une impossibilite), et c'est **le plus dangéreux** a laisser passer sans verification : il justifie une substitution durable dans le code, qui devient invisible pour les auditeurs suivants. Pour cette raison, **chaque verdict `INTRINSIC` doit repondre nominativement les 6 axes** suivants, par « non applicable, parce que… » ou « oui, mais testé, résultat : ... » :
+`INTRINSIC` declare une impossibilite : il justifie une substitution durable, invisible pour les auditeurs suivants. Donc **chaque verdict `INTRINSIC` doit repondre nominativement les 6 axes** suivants, par « non applicable, parce que… » ou « oui, mais testé, résultat : ... » :
 
 | # | Axe | Question a repondre dans le body PR |
 |---|---|---|
@@ -33,9 +33,9 @@ Un verdict `INTRINSIC` est le plus restrictif des 5 (il declare une impossibilit
 | 5 | **`PythonNet`** (pont CPython) **(NEW c.8243)** | **La lib a-t-elle un binding Python ?** Si oui, le pont `.NET → CPython → pyspiel`-like est disponible via `pythonnet 3.0.5` + `Runtime.PythonDLL` — pas d'`INTRINSIC` sans l'avoir teste. |
 | 6 | **Lib differente a role equivalent** | Un autre moteur SOTA .NET tient-il le role ? (cf PyMC ↔ Infer.NET, OR-Tools ↔ choco, mealpy ↔ MetaGeneticSharp) |
 
-**Regle d'enforcement** : un verdict `INTRINSIC` dont le body **ne repond pas nominativement les 6 axes** (y compris « axe 5 N/A parce que la cible n'a pas de binding Python, vérifié sur PyPI au commit SHA … ») est **incomplet** → **`CHANGES_REQUESTED`** ([pr-review-discipline.md](pr-review-discipline.md) §H). La liste des 5 verdicts est conservee ; c'est **la procedure d'etablissement** d'`INTRINSIC` qui se durcit.
+**Regle d'enforcement** : un verdict `INTRINSIC` dont le body **ne repond pas nominativement les 6 axes** (y compris « axe 5 N/A parce que la cible n'a pas de binding Python, vérifié sur PyPI au commit SHA … ») est **incomplet** → **`CHANGES_REQUESTED`** ([pr-review-discipline.md](pr-review-discipline.md) §H).
 
-**Origine de la 6ᵉ entree** (#10459) : trois verdicts `INTRINSIC` OpenSpiel convergents dans 3 PRs distinctes, aucun n'ayant examine l'axe PythonNet — alors que le depot certifiait deja le pont (SK-09, `SOTA-OK` au ledger #3801). L'axe est desormais **prouve** par 5 PRs mergees posant le pont `.NET → CPython → pyspiel`. Deuxieme omission d'axe apres `IKVM` : une regle non explicite ne se corrige pas par plus de vigilance, elle demande un **organe** (la checklist). Verbatim user, PRs et mesures : [sota-verdicts-detail.md §2](../../docs/reference/sota-verdicts-detail.md).
+**Origine** (#10459) : 3 verdicts `INTRINSIC` OpenSpiel convergents, aucun n'ayant examine l'axe PythonNet ; l'axe est desormais **prouve** par 5 PRs mergees. Deuxieme omission apres `IKVM`. Recit, verbatim user et mesures : [detail §2](../../docs/reference/sota-verdicts-detail.md).
 
 ### Stop & Repair — JAMAIS hand-editer une sortie de cellule (mandat user 2026-06-22)
 
@@ -72,4 +72,4 @@ Les bots **DOIVENT** poster `CHANGES_REQUESTED` quand une PR notebook (interne/c
 - [anti-regression.md](anti-regression.md) — ne pas stripper le code reel
 - [three-exercises-per-notebook.md](three-exercises-per-notebook.md) — richesse pedagogique (exercices)
 - **EPIC #3801** — registre axe-2 SOTA + problem-richness, par famille (GenAI/po-2023 en tete)
-- **#10459** — omission d'axe PythonNet dans la taxonomie bucket-3 (3 verdicts INTRINSIC OpenSpiel reclasses, 5 PRs livrees). La checklist 6 axes de ce fichier est l'organe qui ferme la classe d'incidents.
+- **#10459** — omission d'axe PythonNet, close par la checklist 6 axes ([detail §2](../../docs/reference/sota-verdicts-detail.md))


### PR DESCRIPTION
Grain: MED/docs -- lane myia-ai-01:claudish -- prev: MED/refactor #12054

Deuxième cible de mon claim #12051, après la fusion secrets ([#12054](https://github.com/jsboige/CoursIA/pull/12054)). Worktree dédié, zéro écriture dans l'arbre principal.

## Mesure — unité nommée

Corrigé après le diagnostic d'écart d'unité de la lane `CoursIA` (DM `msg-20260821T020511-6s0knh`). **La bonne grandeur est le caractère injecté** : LF (le blob git est normalisé), frontmatter retiré (il n'est pas réinjecté). Le ratio a été mesuré en *caractères injectés par token* — le diviseur doit donc recevoir des caractères injectés, pas des octets de working tree.

| | avant | après | delta |
|---|---|---|---|
| **caractères injectés** (LF, sans frontmatter) | 9 213 | 8 456 | **−757 ch (−8,2 %)** |
| ≈ tokens/session (÷ 2,15) | | | **~−352 tok** |
| blob git (LF), pour re-vérification | 9 302 o | 8 538 o | −764 o |
| prescriptions impératives | 16 | **16** | **0 perdue** |

<sub>Le premier jet de cette PR annonçait « −783 o / −308 tok » : il comparait un « avant » en blob **LF** à un « après » en working tree **CRLF** (−75 o de lignes), puis divisait des **octets** par un ratio mesuré en **caractères**. Deux erreurs de sens opposé. Commit amendé, branche non partagée et sans review à ce moment.</sub>

## Ce qui bouge

Le fichier **dupliquait son propre fichier de détail**. Rien de neuf n'a été écrit : `docs/reference/sota-verdicts-detail.md` portait déjà les cinq blocs. Coupe pure + pointeurs précis.

| | bloc déporté | destination | gain |
|---|---|---|---|
| A | paraphrase du mandat user 2026-06-21 | §1 (les 3 messages verbatim) | −224 |
| B | justification du durcissement `INTRINSIC` | — (resserrée sur place) | −151 |
| C | ~~note de changement « la liste des 5 verdicts est conservée »~~ **restaurée après revue** — c'est une clause de *cadrage* (la checklist ne remplace pas la taxonomie), pas du récit ; je l'avais mal classée | reste dans la règle | −108 **+94** |
| D | récit d'incident #10459 (SK-09, l'« organe », le pont pyspiel) | §2 | −293 |
| E | redondance **triple** du même incident en « Voir aussi » | §2 | −75 |

**Vérification avant coupe** — 17 sondes de couverture sur le fichier de détail, **0 absente**. Protocole de l'issue respecté : la destination est vérifiée **avant** que la source ne soit retirée.

## Garde-fous

- **16 → 16 prescriptions**, aucune perdue.
- Les **16 repères cités par nom ailleurs** survivent : `Prong A` / `Prong B` (cités par `model-delegation.md`, `docs/genai/audio-embed-pattern.md`, `docs/ict/dissolution-scalaires.md`, le ledger #3801), `Stop & Repair`, `5 verdicts`, `checklist 6 axes`, et les 5 verdicts nommés.
- Les **8 titres sont intacts** → aucune ancre entrante ne casse (27 référents pointent ici ; aucun via `#ancre`, tous par lien nu ou par nom de concept — vérifié).
- `secrets-hygiene.md` règle 6 et `pr-review-discipline.md` §H restent référencés.
- CRLF et UTF-8 no-BOM préservés dans le working tree. Hook `gitleaks` : Passed.

## Délibérément conservé, contre le compteur

La section **« Vérification anti-fabrication »** pèse **0 prescription** au compteur de mots-clés — et je l'ai gardée. Elle porte l'instruction opérante de sa section (« on **mesure** d'abord la discrimination firsthand »), et le paragraphe anti-exemple nomme deux pièges qu'un auditeur doit savoir reconnaître : le faux positif **Mycielski** (greedy *et* DSATUR trouvent χ — le folklore ne reproduit pas) et le faux signal **`grep '.minimize('`** sur MiniZinc, qui renvoie `opt=0` sur des notebooks qui traitent bel et bien l'optimisation.

**Le compteur de prescriptions est un garde-fou contre la perte, pas une définition de ce qui est opérant.** Couper sur le compteur seul aurait vidé cette section de son instruction.

<sub>**Divisor corrigé une seconde et dernière fois — 2,54 → 2,15.** En écrivant l'instrument de mesure demandé par la lane `CoursIA` (`d:/claudish/scripts/harness-injection-measure.py`), le ratio 2,54 que j'avais rapporté **ne s'est pas reproduit** : sur la même population de captures, apparié par `(pid, reqN)` et cadré sur CoursIA (86 paires, 86/86 servies par cache), la médiane est **2,15** (p10 1,97 · p90 2,42). Je ne sais pas reconstruire le chemin qui donnait 2,54 et je ne le défends donc pas. Le divisor plus petit **augmente** le gain annoncé — la correction ne va pas dans le sens qui m'arrange. **Le chiffre dur de cette PR reste le delta en caractères injectés, re-vérifiable par n'importe qui ; la conversion en tokens est un ordre de grandeur.**</sub>

Refs #12051





