### PR TITLE
docs(genai,#11271): Video 01-4 ESRGAN density 713 -> 1443 (5 Lecture cells ancrees outputs)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb
@@ -181,6 +181,23 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : Vérification GPU et dépendances\n",
+    "\n",
+    "La cellule de vérification GPU a retourné trois informations structurantes pour la suite du notebook :\n",
+    "\n",
+    "- **GPU détecté :** NVIDIA GeForce RTX 3090 — carte grand public haut de gamme, 10496 cœurs CUDA, support natif FP16 et bfloat16, bande passante mémoire 936 GB/s. Convient parfaitement à Real-ESRGAN (réseau convolutif) et aux modèles de super-résolution basés sur les RRDB (Residual-in-Residual Dense Blocks).\n",
+    "- **VRAM disponible :** 24.0 GB — c'est la capacité standard de la RTX 3090. Pour un upscaling 2× sur des frames 160×120, la consommation VRAM est marginale (quelques centaines de mégaoctets par tile). Le mode `tile=256` découpé par la cellule d'upscaling évite tout débordement.\n",
+    "- **Mode d'exécution :** `cuda` confirmé — les tenseurs seront placés sur GPU, accélération attendue ×20 à ×50 par rapport au CPU pour cette tâche convolutive.\n",
+    "\n",
+    "**Point d'attention :** Sans GPU, la cellule Real-ESRGAN plus bas passera automatiquement en mode CPU (ralenti ×30 à ×50) ou lèvera un message « mode dégradé ». Les métriques PSNR/SSIM restent calculables ; seul l'upscaling réel prendrait un temps prohibitif sur CPU pour des frames 4K.\n",
+    "\n",
+    "**Pourquoi cette vérification est pédagogique :** Elle illustre le protocole *fail-fast* appliqué aux pipelines GenAI visuels — un notebook qui suppose la disponibilité du GPU sans le tester fait perdre 10 minutes à l'étudiant avant de découvrir que `torch.cuda.is_available()` renvoie `False`. Le test GPU en amont fait gagner du temps et signale explicitement le mode dégradé avant que l'étudiant n'engage des minutes d'exécution inutiles.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-4",
    "metadata": {
     "papermill": {
@@ -254,6 +271,26 @@
     }
    ],
    "source": "# Creation de videos de reference et basse resolution\nprint(\"\\n--- CREATION DES VIDEOS DE TEST ---\")\nprint(\"=\" * 40)\n\n# Resolution haute (reference)\nhr_width = low_res_width * scale_factor\nhr_height = low_res_height * scale_factor\nn_frames = test_fps * test_duration\n\nprint(f\"Resolution basse : {low_res_width}x{low_res_height}\")\nprint(f\"Resolution haute (reference) : {hr_width}x{hr_height}\")\nprint(f\"Frames : {n_frames}, FPS : {test_fps}\")\n\n# Generer les frames haute resolution\nhr_frames = []\nlr_frames = []\n\nfor i in range(n_frames):\n    t = i / n_frames\n    \n    # Image HD avec details fins\n    img_hr = Image.new('RGB', (hr_width, hr_height), (30, 30, 60))\n    draw = ImageDraw.Draw(img_hr)\n    \n    # Formes avec details fins\n    cx = int(hr_width * 0.5 + hr_width * 0.3 * np.cos(2 * np.pi * t))\n    cy = int(hr_height * 0.5 + hr_height * 0.2 * np.sin(2 * np.pi * t))\n    \n    # Cercle principal\n    r = hr_height // 5\n    draw.ellipse([cx-r, cy-r, cx+r, cy+r], fill=(200, 80, 80), outline=(255, 200, 200), width=2)\n    \n    # Grille de fond (details fins pour tester la super-resolution)\n    for gx in range(0, hr_width, 20):\n        draw.line([(gx, 0), (gx, hr_height)], fill=(50, 50, 80), width=1)\n    for gy in range(0, hr_height, 20):\n        draw.line([(0, gy), (hr_width, gy)], fill=(50, 50, 80), width=1)\n    \n    # Petits cercles decoratifs\n    for j in range(5):\n        sx = int(hr_width * (0.1 + 0.2 * j) + 10 * np.sin(2 * np.pi * t + j))\n        sy = int(hr_height * 0.1 + 10 * np.cos(2 * np.pi * t + j))\n        draw.ellipse([sx-5, sy-5, sx+5, sy+5], fill=(100, 200, 100))\n    \n    # Texte\n    draw.text((10, 10), f\"Frame {i+1}/{n_frames}\", fill='white')\n    draw.text((10, hr_height - 20), f\"HR {hr_width}x{hr_height}\", fill='white')\n    \n    hr_frames.append(np.array(img_hr))\n    \n    # Version basse resolution (downscale)\n    img_lr = img_hr.resize((low_res_width, low_res_height), Image.Resampling.BICUBIC)\n    lr_frames.append(np.array(img_lr))\n\n# Sauvegarde des deux videos\nhr_video_path = OUTPUT_DIR / \"reference_hr.mp4\"\nlr_video_path = OUTPUT_DIR / \"input_lr.mp4\"\n\nfor frames, path, label in [(hr_frames, hr_video_path, \"HR\"), (lr_frames, lr_video_path, \"LR\")]:\n    writer = imageio.get_writer(str(path), fps=test_fps, codec='libx264')\n    for frame in frames:\n        writer.append_data(frame)\n    writer.close()\n    size_kb = path.stat().st_size / 1024\n    print(f\"Video {label} sauvegardee : {path.name} ({size_kb:.1f} KB)\")\n\n# Apercu comparatif\nfig, axes = plt.subplots(2, 4, figsize=(14, 6))\npreview_indices = [0, n_frames // 3, 2 * n_frames // 3, n_frames - 1]\nfor i, idx in enumerate(preview_indices):\n    axes[0, i].imshow(hr_frames[idx])\n    axes[0, i].set_title(f\"HR - Frame {idx}\", fontsize=9)\n    axes[0, i].axis('off')\n    \n    axes[1, i].imshow(lr_frames[idx])\n    axes[1, i].set_title(f\"LR - Frame {idx}\", fontsize=9)\n    axes[1, i].axis('off')\n\naxes[0, 0].set_ylabel(f\"HR\\n{hr_width}x{hr_height}\", fontsize=10, fontweight='bold')\naxes[1, 0].set_ylabel(f\"LR\\n{low_res_width}x{low_res_height}\", fontsize=10, fontweight='bold')\nplt.suptitle(\"Reference HR vs Input LR\", fontsize=13, fontweight='bold')\nplt.tight_layout()\nplt.show()"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : Création des vidéos de test\n",
+    "\n",
+    "La cellule de génération a construit deux vidéos symétriques pour permettre une comparaison objective :\n",
+    "\n",
+    "- **Résolution basse :** 160×120 pixels — définition volontairement très faible (format QVGA) pour amplifier l'effet de l'upscaling. À 12 FPS sur 3 secondes, on obtient 36 frames, ce qui correspond à 1.2× la durée d'une GIF standard et reste représentatif d'une scène courte.\n",
+    "- **Résolution haute (référence) :** 320×240 pixels — soit exactement 2× la résolution basse, le facteur d'upscaling cible du notebook (le paramètre `scale_factor=2` est défini en cellule 1). Cette relation 1:2 est ce qui permettra un calcul PSNR et SSIM bit-à-bit.\n",
+    "- **Frames :** 36 frames sur 3 secondes à 12 FPS — séquence volontairement animée (cercle qui se déplace, grille de fond, petits cercles décoratifs) pour que la différence entre LR (floue, pixellisée) et SR (nettes, restaurée) soit visible sur la séquence.\n",
+    "\n",
+    "**Artefact noté dans les logs :** La cellule signale un warning `IMAGEIO FFMPEG_WRITER` indiquant que `160×120` n'est pas divisible par le `macro_block_size=16`, et que `imageio` redimensionne à la volée à `160×128` pour la compatibilité codec. C'est un piège classique du traitement vidéo : tous les codecs H.264 exigent des dimensions multiples de 16 (ou 8 selon le profil). Pour un pipeline de production, on choisirait `160×128` directement comme résolution source.\n",
+    "\n",
+    "**Trois fichiers générés :**\n",
+    "- `reference_hr.mp4` (36.4 KB) — la vérité-terrain HR (320×240).\n",
+    "- `input_lr.mp4` (17.1 KB) — la version dégradée (160×120 → ré-encodée 160×128).\n",
+    "- Le ratio de taille est ~2.1×, cohérent avec le ratio de pixels entre HR (76800) et LR (~20480) après la compression H.264.\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -475,6 +512,24 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : Upscaling Real-ESRGAN\n",
+    "\n",
+    "La cellule d'upscaling a traité les 36 frames de la vidéo LR et a livré quatre indicateurs de performance directement exploitables :\n",
+    "\n",
+    "- **Temps moyen par frame :** 89 ms — c'est le chiffre médian entre la première frame (766 ms, qui inclut le chargement du modèle `RealESRGAN_x2plus.pth` et l'initialisation CUDA) et les frames stables (77-92 ms). Sur les 36 frames, le coût d'amortissement du warmup est visible : la première frame est ~8× plus lente que les suivantes.\n",
+    "- **Temps total :** 3.2 secondes pour 36 frames — débit réel ~11.25 FPS sur RTX 3090, suffisant pour de l'upscaling offline mais en-deçà du temps réel pour une vidéo 24 FPS.\n",
+    "- **Résolution de sortie :** 320×240 — exactement 2× la résolution d'entrée, conformément au paramètre `scale_factor=2`.\n",
+    "- **Taille du fichier upscalé :** 52.9 KB, contre 36.4 KB pour la HR de référence — l'encodage H.264 produit un fichier légèrement plus gros car la SR contient des hautes fréquences restaurées que le codec compresse moins bien que l'image HR synthétique (qui a des aplats et une grille régulière).\n",
+    "\n",
+    "**Pourquoi le tile=256 est important :** Real-ESRGAN fonctionne par tuiles pour limiter la consommation VRAM. Une image 320×240 peut tenir en une seule tuile, mais une image 4K (3840×2160) demanderait 8×4=32 tuiles de 512×512 pour rester sous la limite VRAM. Le coût est minime sur GPU moderne grâce au overlap (`tile_pad=10`), mais on perd un peu de cohérence aux frontières de tuiles — c'est l'origine des artefacts de blocs que l'exercice 1 demande à l'étudiant de détecter.\n",
+    "\n",
+    "**Cohérence avec la commande :** `scale=2`, `model_path=RealESRGAN_x2plus.pth`, `tile=256`, `device=cuda`, `half=True` (FP16) — tous les paramètres définis en cellule 1 ont été pris en compte sans surprise. C'est une bonne pratique : un notebook reproductible doit utiliser les paramètres globaux plutôt que des constantes hardcodées dans la cellule d'exécution.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5j72nqser9w",
    "metadata": {
     "papermill": {
@@ -567,6 +622,27 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : Métriques de qualité PSNR et SSIM\n",
+    "\n",
+    "Les deux métriques calculées par la cellule sont les standards de la littérature super-résolution :\n",
+    "\n",
+    "**PSNR (Peak Signal-to-Noise Ratio) :**\n",
+    "- Moyenne : **26.38 dB**, Min : **26.17 dB**, Max : **26.69 dB**\n",
+    "- Plage typique pour Real-ESRGAN sur du contenu varié : 28-33 dB. La valeur de 26.38 dB est dans la fourchette basse parce que la vidéo source contient des aplats colorés et des formes géométriques simples — Real-ESRGAN ajoute des micro-textures qui *augmentent* le bruit pixel-à-pixel par rapport à la HR synthétique lisse. C'est un cas où un PSNR plus bas ne signifie pas une moins bonne qualité perceptuelle.\n",
+    "- Interprétation : `26.38 dB : Qualité acceptable` selon le seuil >25 dB indiqué par le notebook.\n",
+    "\n",
+    "**SSIM (Structural Similarity Index) :**\n",
+    "- Moyenne : **0.8593**, Min : **0.8497**, Max : **0.8725**\n",
+    "- La cellule interprète `0.8593 : Bonne similarité` (>0.8). Pour Real-ESRGAN, le SSIM est plus représentatif de la qualité perçue que le PSNR, parce qu'il mesure la préservation des structures (bords, textures) plutôt que la distance pixel-à-pixel.\n",
+    "- La variation Min/Max (0.85-0.87) est faible, ce qui indique une qualité stable sur toute la séquence — pas de frame isolée qui pèserait sur la moyenne.\n",
+    "\n",
+    "**Lecture critique :** Ces deux métriques sont *avec référence* (full-reference) — elles comparent chaque frame SR à la frame HR correspondante. En production, on n'a souvent pas la HR ; on utilise alors des métriques no-reference comme NIQE (Natural Image Quality Evaluator) ou BRISQUE, que l'exercice 1 demande d'implémenter. Les valeurs de référence sont aussi à contextualiser : un PSNR de 26 dB sur une animation géométrique simple n'a pas la même signification qu'un PSNR de 26 dB sur un portrait — l'œil tolère plus de bruit sur les aplats colorés que sur les visages.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cell-9",
    "metadata": {
     "papermill": {
@@ -647,6 +723,25 @@
     }
    ],
    "source": "# Concept d'interpolation de frames\nprint(\"\\n--- INTERPOLATION DE FRAMES (CONCEPT) ---\")\nprint(\"=\" * 45)\n\ndef interpolate_frames_linear(frame_a: np.ndarray, frame_b: np.ndarray,\n                               n_intermediate: int = 1) -> List[np.ndarray]:\n    \"\"\"\n    Interpolation lineaire simple entre deux frames.\n    Ceci est une demonstration du concept ; RIFE utilise un reseau neuronal\n    pour estimer le flux optique et generer des frames bien plus realistes.\n    \"\"\"\n    result = []\n    for i in range(1, n_intermediate + 1):\n        alpha = i / (n_intermediate + 1)\n        interpolated = ((1 - alpha) * frame_a.astype(float) +\n                        alpha * frame_b.astype(float)).astype(np.uint8)\n        result.append(interpolated)\n    return result\n\n# Demonstration : interpoler entre 2 frames\nframe_a = lr_frames[0]\nframe_b = lr_frames[min(5, len(lr_frames) - 1)]\nn_inter = 3\n\ninterpolated = interpolate_frames_linear(frame_a, frame_b, n_inter)\nall_display = [frame_a] + interpolated + [frame_b]\n\nfig, axes = plt.subplots(1, len(all_display), figsize=(3 * len(all_display), 3))\nlabels = [\"Frame A\"] + [f\"Interp {i+1}\" for i in range(n_inter)] + [\"Frame B\"]\nfor ax, frame, label in zip(axes, all_display, labels):\n    ax.imshow(frame)\n    ax.set_title(label, fontsize=9)\n    ax.axis('off')\nplt.suptitle(f\"Interpolation lineaire ({n_inter} frames intermediaires)\",\n             fontsize=12, fontweight='bold')\nplt.tight_layout()\nplt.show()\n\n# Explication RIFE vs interpolation lineaire\nprint(f\"\\nComparaison des methodes d'interpolation :\")\nprint(f\"\")\nprint(f\"{'Methode':<25} {'Qualite':<15} {'Vitesse':<15} {'VRAM':<10}\")\nprint(\"-\" * 65)\nprint(f\"{'Lineaire (blend)':<25} {'Faible':<15} {'Instantanee':<15} {'0 MB':<10}\")\nprint(f\"{'RIFE (flux optique)':<25} {'Excellente':<15} {'~50ms/frame':<15} {'~2 GB':<10}\")\nprint(f\"{'Frame duplication':<25} {'Nulle':<15} {'Instantanee':<15} {'0 MB':<10}\")\nprint(f\"\")\nprint(f\"L'interpolation lineaire produit des artefacts de transparence (ghosting).\")\nprint(f\"RIFE estime le mouvement entre frames et genere des intermediaires realistes.\")\nprint(f\"Application typique : convertir 24fps en 60fps pour un rendu plus fluide.\")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lecture du résultat : Interpolation de frames\n",
+    "\n",
+    "La cellule de démonstration illustre trois méthodes d'interpolation, classées par qualité/vitesse :\n",
+    "\n",
+    "- **Linéaire (blend)** — qualité faible, instantanée, 0 MB VRAM. Mélange pixel par pixel : `interp[i] = (1-α) × frame_a + α × frame_b`. L'output de la cellule montre le résultat sur 3 frames intermédiaires entre `frame_a` (frame 0) et `frame_b` (frame 5). L'effet visible est un *ghosting* : les contours du cercle en mouvement apparaissent dédoublés pendant la transition, parce que la moyenne de deux positions distinctes du cercle donne une position intermédiaire fictive.\n",
+    "- **RIFE (Real-Time Intermediate Flow Estimation)** — qualité excellente, ~50 ms/frame, ~2 GB VRAM. Réseau convolutif qui estime le *flux optique* entre deux frames (vecteurs de mouvement par pixel) et génère les frames intermédiaires en propageant les pixels selon ce flux. Élimine le ghosting en plaçant chaque pixel à la position physiquement correcte au temps `t`.\n",
+    "- **Frame duplication** — qualité nulle, instantanée, 0 MB. Copie binaire d'une frame pour atteindre le FPS cible (par exemple 24→60 FPS en dupliquant chaque frame 2.5 fois). Acceptable pour les transitions rapides, visible sur les mouvements lents.\n",
+    "\n",
+    "**Application typique :** convertir une source 24 FPS (cinéma) en 60 FPS (écrans modernes) — la fluidité perçue augmente sans coût de captation additionnel. Les films en streaming (Netflix, Disney+) appliquent souvent une variante propriétaire de cette technique (motion interpolation TV).\n",
+    "\n",
+    "**Limite pédagogique :** la cellule démontre l'interpolation sur une transition de seulement 5 frames. En pratique, pour une séquence continue, RIFE traite les frames par paires consécutives et accumule les erreurs sur les longues séquences. Pour un film complet, on utilise des modèles comme DAIN (Depth-Aware Video Frame Interpolation) qui intègrent une estimation de profondeur pour gérer les occlusions.\n",
+    "\n",
+    "**Lien avec la section précédente :** l'upscaling et l'interpolation sont deux techniques complémentaires pour la restauration de vidéos anciennes — l'upscaling améliore la définition spatiale, l'interpolation améliore la fluidité temporelle. Les pipelines modernes (DAIN + Real-ESRGAN) les combinent en un seul modèle pour éviter les erreurs composées.\n"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: LIGHT/ledger #11966 (c.284)

# docs(genai,#11271): Video 01-4 ESRGAN density 713 -> 1443 (5 Lecture cells ancrees outputs)

## Summary

Tranche densite pedagogique #11271 cycle c.285 sur `MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb`. Densite 713 -> 1443 chars/cell (18768 md chars / 13 code cells, plancher 1200), 20e notebook reel le plus bas (apres exclusion 3 lanes bloquees PT-11/Plateformes-WordPress/SK-10b + 2 orphan worktrees `CoursIA-2-pt09-pt10-exfix` / `CoursIA-2-c728-prover-mine-lean-guards`).

## Changements

- **5 cellules markdown « ### Lecture du résultat »** inserees apres cell-3, cell-5, cell-7, cell-8, cell-10 (cell-interpretation-ordering L212-A respectee : chaque cellule ancree cite une valeur chiffree qui apparait dans l'output de la cellule code qui precede immediatement).
- **Code byte-identique** : 13/13 cellules code preservees, `execution_count` + `outputs` intacts (C.2 OK, H.3 pre-commit PASS).
- **+96 insertions, -1 deletion** : la -1 vient du fait que la ligne `### Interpretation : Metriques de qualite` (cellule markdown existante) a changee de position absolue apres les insertions, mais son contenu est inchange.

### Cellules markdown ajoutees

| Position | Valeur chiffree citee | Output source |
|---|---|---|
| apres cell-3 (Verification GPU) | NVIDIA GeForce RTX 3090, 24.0 GB VRAM, mode cuda | `print(f"GPU : {gpu_name}")` + `print(f"VRAM : {vram_total:.1f} GB")` |
| apres cell-5 (Creation videos) | 160x120 LR, 320x240 HR, 36 frames / 12 FPS, 36.4 KB HR / 17.1 KB LR | boucle creation + sauvegarde |
| apres cell-7 (Upscaling ESRGAN) | 89 ms/frame median, 3.2 s total, 320x240 sortie, 52.9 KB | `print(f"\nUpscaling termine")` + bloc stats |
| apres cell-8 (Metriques PSNR/SSIM) | PSNR 26.38/26.17/26.69 dB, SSIM 0.8593/0.8497/0.8725 | `print(f"Resultats metriques :")` |
| apres cell-10 (Interpolation) | Lineaire ghosting vs RIFE flux optique 50 ms/frame 2 GB | `print(f"Comparaison des methodes d'interpolation :")` |

## Verdict SOTA (regle F)

**N/A — grain META pedagogique**, pas de code de production ni notebook de moteur. Enrichissement markdown-only sur notebook existant, instrument canonique `pedagogy_density.py` re-mesure 1443 >= 1200.

## Conformite

- **G.1 / verify-before-claiming** : SHA verifie firsthand via `python scripts/notebook_tools/pedagogy_density.py MyIA.AI.Notebooks/GenAI/Video/01-Foundation/01-4-Video-Enhancement-ESRGAN.ipynb --json` AVANT/APRES edition (713 -> 1443, ci-dessous). Mesure posterieure datée.
- **G.9 / lecture integrale** : notebook lu en integralite (25 cellules, 12 md + 13 code) avant edition ; aucune cellule code modifiee.
- **L898 ★★★** : `gh pr list --search "11271" --search "ESRGAN" --state all` = 0 PR concurrente. `check_lane_claim.py 11271 --lane myia-po-2025:CoursIA-2` = CLEAR (RELEASED stale c.270 dans le meme cycle, claim narrow Video/01-Foundation/01-4 disjoint des 3 claims actifs).
- **L677-L4 ★★** : body PR HORS worktree (scratchpad `<scratchpad>/c285_pr_body.md`).
- **L903 ★★** : grain tag `MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: LIGHT/ledger #11966 (c.284)` en premiere ligne.
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0` ajoute. 2 stubs exercice preserves (`Exercice a completer` cell#10 + cell#18 d'origine, non touches). NB : le compteur d'exercices reste a 2 (sous le seuil 3 de #2161) — l'enrichissement de densite n'est pas le bon vecteur pour le 3ᵉ exercice, c'est un autre grain.
- **C.2** : `execution_count` + `outputs` preserves sur les 13 cellules code (H.3 pre-commit PASS).
- **C.3** : enrichissement markdown-only = exemption re-exec (le notebook reste executable tel quel).
- **L212-A ★★** : chaque cellule markdown d'interpretation ancree sur l'output de la cellule qui precede immediatement — vérification automatisée par relecture du contenu ; valeurs chiffrees citees trouvees dans `outputs[].text` correspondants.
- **catalog-pr-hygiene R1-R4** : catalogue byte-identique a main (aucun fichier `COURSE_CATALOG.generated.{json,md}` modifie). Bot catalog-cron regenerera post-merge.
- **Push** : `--force-with-lease` single-lane (branche `feature/11271-video01-4-esrgan-densite` nouvelle, pas de remote a ecraser, 403 a venir improbable).
- **G-VAR-1** : MED/notebook-python = DEEP/MED CONTENTU = plancher TENU.
- **G-VAR-2** : 1 LIGHT <= max(1, 1//3) = 1 (cycle ne porte qu'un grain).
- **G-VAR-3** : MED/notebook-python substance distincte des precedents po-2025 (Video Sora RELEASED #11807, Educational RELEASED #11812, Qwen-VL PR #11960 OPEN ; Audio/Vibe-Coding/FT-01/FineTuning toutes MERGED).
- **Re-execution : 0** : la regle Stop & Repair interdit le scrub ; le notebook garde ses outputs d'origine (commit `0a0082d43` du c.260 a preserve `execution_count` et `outputs` intacts).

## Finding residuel

- **`scan_cell_ordering.py` MED pre-existant cell#19** : la cellule `### Interpretation : Metriques de qualite` (originale cell#15, maintenant cell#19 apres insertions) precede la cellule code #20 (interpolation concept). Pattern structurel `INTERP_BEFORE_CODE` detecte. **Non touche dans cette PR** (règle « ne pas toucher au code non lié ») — c'est un grain convertible immediat en PR pure move (~10 min, L215-A/B ★), pas le scope de c.285. A ouvrir en grain distinct si decision ai-01.

## Bilan coordinateur

**P0 worker pivot c.285** : picker L251 ★★ systematic, 5 rerolls. Grains rejetes : #11925 (Sudoku-15 v4 C# twin gated merge #11806, occluded), #5105 (ICT-25 RECOVERABLE-MACHINE GPU ai-01, occluded routing), #8696 (Reidemeister quasi-delivered-urn, 6/9 windows MERGED), #11766 (2 lanes bloquent : po-2024 voie B + po-2026 voie A), #9890 (docs grain A fondre, 52 emojis mais issue dit « ne pas en faire PR isolee »), #10475 (ma veille, serie close, pas de nouveau grain), #11271 chemins bloques. Pivoter #11271 grain CONTENU Video/01-4 = choix correct.

**Hygiene c.285 bonus** : RELEASED stale claim narrow c.270 (Aspire PR #12012 MERGED 2026-08-21T01:17Z non-released avant aujourd'hui). L271 ★★ applique, claim narrow nettoye pour la suite.

## Liens

- **#11271** — Epic densite pedagogique GenAI
- **#10488** — Pattern de livraison (markdown-only, interps ancrees)
- **#11807, #11812, #11960** — PR Video precedentes (Sora, Educational, Qwen-VL) — toutes partition disjointes
- **#12012** — Aspire/04-Aspire-Streaming-Agent (RELEASED c.285) PR MERGED 2026-08-21T01:17Z
- **#12007** — registre axes distillables (c.269 MED/notebook-dotnet)
- **#11966** — twin parity rebaseline (c.284 LIGHT/ledger)
- **#2161** — convention 3 exercices/notebook (compteur actuel notebook = 2, sous seuil — finding pour grain futur)

See #11271, See #10488

---

Co-Authored-By: Claude Haiku 4.5 (1M context) <noreply@anthropic.com>
