### PR TITLE
feat(genai,#11271): 10_LocalLlama densite round 1 retrodecouvert (1192 -> 1297 chars/cell)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb
@@ -242,7 +242,7 @@
     },
     "tags": []
    },
-   "source": "## Inspection des modèles disponibles\n\nNous allons appeler l'endpoint `/models` de chaque service \npour récupérer la liste des modèles chargés côté serveur.\n\nSi vous avez mis `model=None` dans la config, vous pourrez automatiquement \nrécupérer le `model` à partir des données renvoyées. \n"
+   "source": "## Inspection des modèles disponibles\n\nNous allons appeler l'endpoint `/models` de chaque service \npour récupérer la liste des modèles chargés côté serveur.\n\nSi vous avez mis `model=None` dans la config, vous pourrez automatiquement \nrécupérer le `model` à partir des données renvoyées.\n\nL'endpoint `/v1/models` (ou `/api/tags` selon le moteur) liste\n**tous les modèles chargés** sur le serveur Ollama/vLLM/LM-Studio\ncourant. C'est la **première étape de debugging** avant tout\nbenchmark.\n\n**Structure typique de la réponse** :\n```json\n{\n  \"data\": [\n    {\"id\": \"qwen2.5:0.5b-instruct-q5_k_m\", \"object\": \"model\", \"owned_by\": \"...\"},\n    {\"id\": \"llama3.2:3b-instruct-q4_0\",   \"object\": \"model\", \"owned_by\": \"...\"}\n  ]\n}\n```\n\n**Cas d'usage** :\n- Vérifier quel **modèle est actuellement chargé** (éventuellement\n  swap entre endpoints).\n- Trouver les **variantes de quantization** disponibles\n  (q4_0, q5_k_m, q8_0) pour la même famille.\n- Détecter un **modèle fantôme** (présence dans `/models` mais\n  erreur 500 sur les requêtes — souvent un problème de cache\n  corrompu).\n"
   },
   {
    "cell_type": "code",
@@ -362,7 +362,7 @@
     },
     "tags": []
    },
-   "source": "## Test brut via `requests.post`\n\nCe test vérifie le bon fonctionnement de l'endpoint OpenAI-compatible \nsans passer par la librairie `openai`. \n\nOn envoie une requête minimaliste en JSON, \npuis on affiche la réponse brute.\n"
+   "source": "## Test brut via `requests.post`\n\nCe test vérifie le bon fonctionnement de l'endpoint OpenAI-compatible \nsans passer par la librairie `openai`. \n\nOn envoie une requête minimaliste en JSON, \npuis on affiche la réponse brute.\n\nLe **test HTTP brut** utilise `requests.post` directement sur\nl'endpoint `/v1/chat/completions`. Avantage : on voit la\n**réponse exacte** du serveur (HTTP status, headers, body brut),\nce que la librairie `openai` cache par défaut.\n\n**Format de la requête OpenAI-compatible** :\n```json\n{\n  \"model\": \"qwen2.5:0.5b-instruct-q5_k_m\",\n  \"messages\": [\n    {\"role\": \"user\", \"content\": \"Explique la quantization INT4\"}\n  ],\n  \"max_tokens\": 200,\n  \"temperature\": 0.7\n}\n```\n\n**Réponse attendue** : 200 OK avec JSON `{\"choices\": [{\"message\":\n{\"role\": \"assistant\", \"content\": \"...\"}}], \"usage\": {...}}`.\n\n**Anti-pattern** : tester un endpoint **uniquement** via la\nlibrairie `openai` cache les erreurs de négociation JSON et les\nheaders serveur (souvent crucial pour identifier un proxy ou un\nload-balancer).\n"
   },
   {
    "cell_type": "code",
@@ -1119,7 +1119,7 @@
     },
     "tags": []
    },
-   "source": "## Test avec la librairie `openai`\n\nOn reproduit un appel classique OpenAI, \nmais en changeant `openai.api_base` et `openai.api_key` \npour chaque endpoint.\n"
+   "source": "## Test avec la librairie `openai`\n\nOn reproduit un appel classique OpenAI, \nmais en changeant `openai.api_base` et `openai.api_key` \npour chaque endpoint.\n\nLa librairie `openai` official Python (v1+) fournit un **client\nOpenAI-compatible** qui marche avec tout serveur exposant\nl'endpoint OpenAI-style (Ollama, vLLM, LM-Studio avec son plugin\nOpenAI, llama.cpp en mode server).\n\n**Avantages** :\n- **API standardisée** : même code marche contre OpenAI réel\n  (clé API valide) ou contre un serveur local (URL custom).\n- **Streaming natif** : `client.chat.completions.create(stream=True)`\n  itère sur les chunks, idéal pour UI temps réel.\n- **Tool/function calling** : support des `tools=[{...}]` avec\n  parsing JSON des arguments.\n- **Retry automatique** : la librairie retente automatiquement\n  sur 429/5xx.\n\n**Limites** :\n- **Cache les erreurs** : par défaut, les 4xx/5xx lèvent une\n  exception typée mais perdent le body brut.\n- **Pas de TOKEN streaming** en mode simple (mais OK avec\n  `stream=True` + counters).\n"
   },
   {
    "cell_type": "code",
@@ -1229,7 +1229,7 @@
     },
     "tags": []
    },
-   "source": "## Test avec Semantic Kernel (optionnel)\n\nExemple d'intégration avec [Semantic Kernel](https://github.com/microsoft/semantic-kernel).\nOn crée un Kernel, on y ajoute un service chat OpenAI-like avec l'endpoint souhaité, \net on exécute un prompt simple.\n"
+   "source": "## Test avec Semantic Kernel (optionnel)\n\nExemple d'intégration avec [Semantic Kernel](https://github.com/microsoft/semantic-kernel).\nOn crée un Kernel, on y ajoute un service chat OpenAI-like avec l'endpoint souhaité, \net on exécute un prompt simple.\n\nLe test via **Semantic Kernel** valide que le serveur local\nsupporte l'API chat **au-delà du minimum OpenAI-compatible**.\nSemantic Kernel ajoute des abstractions (Kernel, ChatHistory,\nPromptExecutionSettings) qui stress-test la conformité.\n\n**Cas pertinent** :\n- Vérifier que le serveur supporte les **chat templates**\n  alternatifs (multi-turn avec `system` + `user` + `assistant`\n  alternance).\n- Tester les **connecteurs multiples** (Azure + OpenAI + local\n  dans la même Kernel, avec routing dynamique).\n- Valider la **mémoire conversationnelle** (ChatHistory accumule\n  les rôles correctement).\n\n**Skip si inutilisé** : SK est lourd à importer et instancier.\nPour un test focalisé d'un endpoint, `requests.post` est plus\nrapide et plus transparent.\n"
   },
   {
    "cell_type": "markdown",
@@ -1503,7 +1503,7 @@
     },
     "tags": []
    },
-   "source": "## Test du Function/Tool Calling via semantic-kernel\n\n"
+   "source": "## Test du Function/Tool Calling via semantic-kernel\n\nLe test **function calling** valide que le serveur local supporte\nla **sortie structurée JSON** que les LLMs modernes utilisent pour\nappeler des outils (search, calculator, code execution).\n\n**Format OpenAI-compatible pour tool calling** :\n```json\n{\n  \"tools\": [{\"type\": \"function\", \"function\": {\"name\": \"get_weather\",\n    \"description\": \"...\", \"parameters\": {\"type\": \"object\", \"properties\":\n    {\"city\": {\"type\": \"string\"}}}}}],\n  \"messages\": [...],\n  \"tool_choice\": \"auto\"\n}\n```\n\n**Réponse** : le modèle retourne un `tool_calls` array avec\narguments JSON structurés. Le client exécute l'outil et renvoie\nle résultat dans `messages`.\n\n**Cas d'échec fréquent** : le modèle **hallucine** des arguments\nJSON mal formés. Le client doit **valider** le schéma avant\nexécution.\n"
   },
   {
    "cell_type": "markdown",
@@ -2459,7 +2459,7 @@
     },
     "tags": []
    },
-   "source": "Le benchmark principal est complété. La cellule suivante applique un correctif de compatibilité pour Pydantic 2.x, requis pour les appels d'API Python dans les sections suivantes."
+   "source": "Le benchmark principal est complété. La cellule suivante applique un correctif de compatibilité pour Pydantic 2.x, requis pour les appels d'API Python dans les sections suivantes.\n\nLe benchmark principal est complété. La cellule suivante applique\nle **test de parallélisme global** : on lance **N requêtes\nsimultanées** sur le serveur pour mesurer le débit maximum\n(tokens/s agrégé) et la dégradation de latence sous charge.\n\n**Métriques trackées** :\n- **Throughput agrégé** : tokens/s sur l'ensemble des N requêtes.\n- **Tail latency P99** : latence du 99e percentile (la pire\n  requête).\n- **Saturation** : débit à partir duquel les performances\n  plafonnent.\n\n**Pattern de test** : `asyncio.gather` ou `ThreadPoolExecutor`\navec N=1, 4, 8, 16. Sur Ollama single-GPU, N=4-8 sature\ntypiquement la VRAM.\n"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
Grain: LIGHT/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #12059 [tier requalifie DEEP->LIGHT par ai-01 au merge : +7/-7, cf commentaire]

Density round 1 retrodécouvert sur `10_LocalLlama.ipynb` (umbrella #11271 — partition `GenAI/Texte`).

## Contexte

10_LocalLlama (Hébergement local de modèles génératifs via OpenAI-compatibles sur Ollama/vLLM/LM-Studio) a été mesuré à **1192 chars/cellule** sur origin/main (44 MD, 23 code, 67 cellules) — sous le plancher floor round 1 (1200) défini par le ratchet baseline #10488. C'est un retrodécouvert round 1 : la sous-série Texte/GenAI a déjà des PRs substantielles (35+ notebooks sous plancher dans cette famille) mais aucune PR markdown-only de densité sur `10_LocalLlama`. La substance est mergée, le markdown explicatif ne suit pas.

## Verification

- **Density** : 1192 → **1297** chars/cell (+9%, +105 chars/cell, past floor 1200)
- **Total markdown** : 52478 → 57069 chars (+9%)
- **Anchor check strict** (c.1331p309 ★, cell-interpretation-ordering HARD) : N/A — les 6 cellules enrichies sont des **sections courtes sans outputs locaux** (intro de section). Toutes les métriques chiffrées citées sont des **généralités pédagogiques** (formats JSON OpenAI-compatibles, options de quantization, propriétés de la librairie). Conformément à c.1331p312 ★ (density no-local-output), la density vient de **prose pédagogique pure** (formats de requête, cas d'usage, anti-patterns, trade-offs).
- **Cell ordering** (`scan_cell_ordering.py`) : CLEAN (1/1 notebook, 0 finding)
- **H.3** : 0 NEW fail (pré-commit H.3 skip pour notebook .ipynb avec outputs commités)
- **C.1** : 0 fail
- **23/23 cellules code byte-identiques** vs origin/main (sources + outputs inchangés après normalisation JSON). **0 cellule code convertie en MD**.
- **Diff scope** : 1 fichier / +7/-7 lignes (manipulation JSON directe pour préserver format `source-as-string` ; nbformat v4/v5 roundtrip ajoute ~3600 lignes cosmétique)
- **Préservation format origin** : 7 cellules en `source-as-list` (pré-existantes : #32, #35, #42, #47, #52, #55, #61) → préservées telles quelles

## Substance pédagogique ajoutée

6 cellules MD enrichies sur origin/main (6/44 = 14% des MD, ciblent les sections courtes <300c) :

| Cellule | Section | Substance ajoutée |
|---|---|---|
| #11 | Inspection des modèles | Endpoint `/v1/models`/`/api/tags`, structure JSON `data`, 3 cas d'usage (modèle chargé, quantization variants, modèle fantôme) |
| #14 | Test HTTP brut requests.post | Format requête OpenAI-compatible (model/messages/max_tokens/temperature), réponse 200 OK attendue, anti-pattern "tester uniquement via openai" cache les erreurs |
| #26 | Test avec openai library | 4 avantages (API standardisée/streaming natif/tool calling/retry auto), 2 limites (cache erreurs 4xx/5xx, pas token streaming simple) |
| #29 | Test avec Semantic Kernel | 3 cas pertinents (chat templates alternatifs, connecteurs multiples, mémoire conversationnelle), skip si inutilisé |
| #36 | Test function/tool calling | Format OpenAI-compatible `tools=[{...}]`, `tool_choice="auto"`, cas d'échec fréquent (hallucination JSON mal formé) |
| #45 | Transition parallélisme global | 3 métriques (throughput agrégé/P99 saturation), pattern asyncio.gather/ThreadPoolExecutor avec N=1/4/8/16, saturation Ollama single-GPU N=4-8 |

## Pattern-meta du cours

Le notebook illustre **l'écosystème OpenAI-compatible local** :

1. **vLLM vs Ollama** (Section 2) — serveurs d'inférence populaires
2. **Inspection modèles** (`/v1/models`) — debugging pre-benchmark
3. **Test HTTP brut** (`requests.post`) — réponse exacte serveur
4. **Test openai library** — API standardisée cloud ↔ local
5. **Test Semantic Kernel** — abstractions au-delà d'OpenAI-compatible
6. **Function/Tool calling** — sortie structurée JSON pour outils
7. **Benchmark séquentiel** — latence + throughput par endpoint
8. **Parallélisme** — N requêtes simultanées, throughput agrégé
9. **Comparaison coût** — Cloud (per-token) vs Local (fixe)

**Concepts mécaniques essentiels** :
- **OpenAI-compatible API** : même format JSON (`/v1/chat/completions`, `/v1/models`)
  marchant contre OpenAI réel ou contre Ollama/vLLM/LM-Studio/llama.cpp server
- **Quantization variants** : q4_0 (compression max), q5_k_m (balanced), q8_0 (qualité)
- **Streaming vs simple** : `stream=True` pour UI temps-réel, simple pour batch
- **Tool/function calling** : `tools=[{...}]` array avec `tool_choice="auto"`
- **Tail latency P99** : cas dégradé, saturation N=4-8 sur Ollama single-GPU

**Distinctions clés** :
- vLLM (production, multi-GPU, batching PagedAttention) vs Ollama (prototypage, mono-GPU, simplification)
- OpenAI library (cache erreurs) vs requests.post (body brut)
- Chat template unique vs chat templates alternatifs (multi-turn system/user/assistant)
- Cloud (per-token) vs Local (fixe matériel + électricité) : break-even selon volume

**Branchement série GenAI/Texte** :
- 1_OpenAI_Intro → **10_LocalLlama** → 11_Quantization → 19_OWUI_Orchestration
- 10_LocalLlama (local OpenAI-compat) ↔ 9_Production_Patterns (patterns de prod)

## Limites assumées

- **Density 1297 ≈ cible round 1 (1200), +9%** — équilibre maintenu.
  Round 2 (1500+) demanderait d'enrichir aussi les cellules
  #32/35/42/47/52/55/61 (qui sont déjà substantielles mais dont
  on pourrait étoffer les transitions), tombant dans le
  remplissage artificiel (G.3).
- **0 cellules code modifiées** : aucune perte d'output, aucun
  changement de comportement d'exécution.
- **Métriques pédagogiques qualitatives** : tous les formats
  JSON, propriétés de librairies et cas d'usage sont des
  **descriptions pédagogiques**, pas des mesures reproductibles
  depuis ce notebook (pas de local endpoint actuellement chargé
  pour benchmark).
- **7 cellules `source-as-list` pré-existantes** : #32, #35,
  #42, #47, #52, #55, #61 — pas introduites par cette PR,
  préservées telles quelles (manipulation JSON directe).

## Leçon applicable

**md-enrichment-density-round2 (c.1331p301 ★)** confirmée round 15 :
1. Identifier les cellules avec sorties mesurables (ici : **0**
   — pas de cellules code avec outputs chiffrés sur les sections
   11/14/26/29/36/45 touchées, qui sont des intros / transitions).
2. Ancrer chaque chiffre cité sur l'output adjacent QUAND
   disponible (règle cell-interpretation-ordering HARD + leçon
   c.1331p309 ★ chiffres verbatim outputs) — ici pas d'outputs
   locaux, donc **prose pédagogique pure** (c.1331p312 ★).
3. **Leçon clé ajoutée** : **nbformat v5 roundtrip convertit
   `source-as-string` en `source-as-list` et ajoute ~3555 lignes
   de diff cosmétique**. Pour minimiser le diff, faire la
   manipulation en `json.dump` direct sur le dict, sans passer
   par `nbformat.write()`. Cette technique préserve le format
   origin exact.

**Pattern CRITIQUE préservé** : ne JAMAIS convertir une cellule code
en MD. Vérifier `cell_type` AVANT chaque modification (cf leçon
c.1331p304 ★). Ici, **23/23 cellules code préservées byte-identique**
vs origin/main.

**Anti-régression** : leçon c.1331p309 ★ (nano-claw-anchors-verbatim)
appliquée — pas d'outputs locaux sur les cellules touchées, donc
**aucun chiffre rond à ancrer** ; le risque fabrication est nul sur
ce PR.

**Lesson applicable c.1331p317 (à venir)** : pour minimiser le
diff cosmétique nbformat sur des notebooks denses, **manipulation
JSON directe** sans passer par `nbformat.write()` quand la cible
est markdown-only sur cellules sans modification structurelle.

Densities round 1 mesurées : QC-Py-21=1634, QC-Py-26=1871, QC-Py-22=1766, QC-Py-25=1592, QC-Py-17=1827, QC-Py-07=1254, QC-Py-10=1317, QC-Py-09=1345, QC-Py-08=1226, Dataset-Workflow=1525, QC-Py-05=1329, FT-04=1349, FT-05=1291, PT-11=1443, PT-11b=1691, **10_LocalLlama=1297**. Densities 1226-1871 — équilibre maintenu.

## Substance livrée

- **Density** : 1192 → 1297 chars/cell (+9%)
- **Total markdown** : 52478 → 57069 chars (+9%)
- **Cellules modifiées** : 6 (intros/transitions de section <300c)
- **Code cells inchangées** : 23/23 (byte-identique, sources + outputs)
- **Diff scope** : 1 fichier / +7/-7 lignes (manipulation JSON directe)
- **Domaines** : 1 (GenAI Texte — Hébergement Local OpenAI-compatible)
- **Features** : 1 (densité)

See #11271
