### PR TITLE
feat(search,#1203): MGS-3 re-exec post-rebase + seeds appariees - prose recallee sur valeurs deterministes

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-3-Eukaryote.ipynb
@@ -144,7 +144,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '29384.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '57720.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -508,14 +508,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Valeurs       : [77,61, 85,64]\r\n"
+      "  Valeurs       : [12,73, 23,87]\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Fitness       : -88,2500\r\n"
+      "  Fitness       : -38,4000\r\n"
      ]
     },
     {
@@ -571,7 +571,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fitness herite  : -88,2500\r\n"
+      "    Fitness herite  : -38,4000\r\n"
      ]
     },
     {
@@ -613,7 +613,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "    Fitness herite  : -88,2500\r\n"
+      "    Fitness herite  : -38,4000\r\n"
      ]
     },
     {
@@ -641,7 +641,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Valeurs : [77,61, 85,64]\r\n"
+      "  Valeurs : [12,73, 23,87]\r\n"
      ]
     },
     {
@@ -657,6 +657,8 @@
     "// We create a parent chromosome and slice it into 2 sub-chromosomes\n",
     "\n",
     "// Parent: 2 floating-point genes, each 16 bits with 2 decimal places, range [0, 100]\n",
+    "// Graine fixe : valeurs du chromosome parent reproductibles d une execution a l autre\n",
+    "GeneticSharp.FastRandomRandomization.ResetSeed(7);\n",
     "var parent = new FloatingPointChromosome(\n",
     "    new double[] { 0, 0 },\n",
     "    new double[] { 100, 100 },\n",
@@ -935,7 +937,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Genes : [80,41, 76,42]\r\n"
+      "  Genes : [43,56, 89,66]\r\n"
      ]
     },
     {
@@ -951,6 +953,8 @@
     "// We create a population, slice it into sub-populations, and inspect the structure\n",
     "\n",
     "// Create parent population\n",
+    "// Graine fixe : population initiale reproductible d une execution a l autre\n",
+    "GeneticSharp.FastRandomRandomization.ResetSeed(8);\n",
     "var adamSub = new FloatingPointChromosome(\n",
     "    new double[] { 0, 0 },\n",
     "    new double[] { 100, 100 },\n",
@@ -1112,7 +1116,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Meilleur chromosome : position=49,91, vitesse=22,83\r\n"
+      "  Meilleur chromosome : position=50,00, vitesse=33,52\r\n"
      ]
     },
     {
@@ -1126,7 +1130,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Distance totale     : 2,2600\r\n"
+      "  Distance totale     : 8,5200\r\n"
      ]
     },
     {
@@ -1150,6 +1154,8 @@
     "// Sub-population 1 (velocity): NoOpMetaHeuristic (parents pass through unchanged)\n",
     "// Uses same pattern as EukaryoteMetaHeuristicTests (EliteSelection, UniformCrossover, UniformMutation)\n",
     "\n",
+    "// Graine fixe : trajectoire de la demo reproductible d une execution a l autre\n",
+    "GeneticSharp.FastRandomRandomization.ResetSeed(9);\n",
     "var eukaryoteMh = BuildEukaryote();\n",
     "\n",
     "var adamEuk = new FloatingPointChromosome(\n",
@@ -1290,14 +1296,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,0100     "
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " 0,0100     "
+      " 0,0500     "
      ]
     },
     {
@@ -1318,6 +1317,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      " 0,6000     "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "\r\n"
      ]
     },
@@ -1332,35 +1338,35 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1,4100     "
+      " 1,9500     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 2,0400     "
+      " 0,6600     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 1,8600     "
+      " 4,1900     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 0,6300     "
+      " 1,2900     "
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 7,3100     "
+      " 1,0400     "
      ]
     },
     {
@@ -1381,21 +1387,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Uniforme moyenne  : 0,0060\r\n"
+      "  Uniforme moyenne  : 0,1320\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Heterogene moyenne: 2,6500\r\n"
+      "  Heterogene moyenne: 1,8260\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  Amelioration      : -44066,7%\r\n"
+      "  Amelioration      : -1283,3%\r\n"
      ]
     },
     {
@@ -1433,9 +1439,14 @@
     "var eukResults = new List<double>();\n",
     "var uniResults = new List<double>();\n",
     "\n",
+    "// Graines appairees : au run k, les deux configurations repartent du meme flux aleatoire\n",
+    "// (seed 42+k), et ce flux est reproductible d'une execution a l'autre. FastRandomRandomization\n",
+    "// est le provider du moteur ; BasicRandomization.ResetSeed n'affecterait pas le GA.\n",
     "for (int run = 0; run < 5; run++)\n",
     "{\n",
+    "    GeneticSharp.FastRandomRandomization.ResetSeed(42 + run);\n",
     "    eukResults.Add(RunWithEukaryote(BuildEukaryote(), \"Eukaryote\"));\n",
+    "    GeneticSharp.FastRandomRandomization.ResetSeed(42 + run);\n",
     "    uniResults.Add(RunWithEukaryote(BuildEukaryoteUniform(), \"Uniform\"));\n",
     "}\n",
     "\n",
@@ -1486,7 +1497,7 @@
    "source": [
     "### Mesure : la configuration Default+NoOp peut-elle gagner ?\n",
     "\n",
-    "La cellule precedente montre l'heterogene (Default+NoOp) perdante de plus de 440x sur le cone lisse (Amelioration -44066,7% a la cellule precedente). La prose ci-dessus suggerait que l'heterogene devient pertinente \"quand les dimensions ont des caracteristiques tres differentes\". Verifions cette affirmation **empiriquement** : construisons un paysage ou la position est **rugueuse** (Rastrigin1D, nombreux optima locaux) et la vitesse est un **pic etroit** (Gaussienne centree en 25), puis comparons Default+NoOp vs Default+Default en balayant la largeur du pic. Si l'heterogene a un avantage structurel, il devrait apparaitre sur au moins une de ces largeurs."
+    "La cellule precedente montre l'heterogene (Default+NoOp) perdante d'un facteur ~14 en moyenne sur le cone lisse (moyennes 1,8260 vs 0,1320, soit une Amelioration de -1283,3% -- graines appairees 42-46, reproductibles d'une execution a l'autre). La prose ci-dessus suggerait que l'heterogene devient pertinente \"quand les dimensions ont des caracteristiques tres differentes\". Verifions cette affirmation **empiriquement** : construisons un paysage ou la position est **rugueuse** (Rastrigin1D, nombreux optima locaux) et la vitesse est un **pic etroit** (Gaussienne centree en 25), puis comparons Default+NoOp vs Default+Default en balayant la largeur du pic. Si l'heterogene a un avantage structurel, il devrait apparaitre sur au moins une de ces largeurs."
    ]
   },
   {
@@ -1541,28 +1552,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0,5      0,001          4,916          Uniform     \r\n"
+      "0,5      5,104          10,000         Uniform     \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1        0,027          4,758          Uniform     \r\n"
+      "1        0,007          10,000         Uniform     \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2        0,014          1,296          Uniform     \r\n"
+      "2        0,030          7,829          Uniform     \r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "5        0,017          1,268          Uniform     \r\n"
+      "5        0,000          3,324          Uniform     \r\n"
      ]
     },
     {
@@ -1607,9 +1618,13 @@
     "foreach (var sigma in new double[] { 0.5, 1.0, 2.0, 5.0 })\n",
     "{\n",
     "    double u = 0, h = 0;\n",
+    "    // Graines appairees : les 3 runs d'une ligne sigma partagent leurs flux entre les deux\n",
+    "    // configurations (seed 100+i), reproductibles d'une execution a l'autre.\n",
     "    for (int i = 0; i < 3; i++)\n",
     "    {\n",
+    "        GeneticSharp.FastRandomRandomization.ResetSeed(100 + i);\n",
     "        u += RunObjective(BuildEukaryoteUniform(), sigma) / 3.0;\n",
+    "        GeneticSharp.FastRandomRandomization.ResetSeed(100 + i);\n",
     "        h += RunObjective(BuildEukaryote(), sigma) / 3.0;\n",
     "    }\n",
     "    Console.WriteLine(string.Format(\"{0,-8} {1,-14:F3} {2,-14:F3} {3,-12}\", sigma, u, h, u < h ? \"Uniform\" : \"Hetero\"));\n",
@@ -1626,7 +1641,7 @@
     "\n",
     "**Resultat** : sur **chaque** largeur de pic (sigma 0.5 a 5), l'uniforme (Default+Default) bat l'heterogene (Default+NoOp). La vitesse figee par `NoOpMetaHeuristic` ne peut pas atteindre un pic etroit que la vitesse evoluee (`DefaultMetaHeuristic`) rejoint systematiquement : l'elitisme combine au crossover fait converger Default vers la cible meme sous mutation, tandis que NoOp fige la vitesse a sa valeur initiale et ne peut l'ameliorer.\n",
     "\n",
-    "**Conclusion mesuree** : le couplage Default+NoOp utilise dans ce notebook est **structurellement desavantage** sur toute dimension a cible unique. Il ne peut donc PAS illustrer la victoire heterogene decrite dans la prose ci-dessus. L'ecart de -44066,7% observe sur le cone lisse n'est pas un defaut du moteur eukaryote : c'est la consequence attendue d'avoir assigne `NoOpMetaHeuristic` (une non-strategie) a une dimension qui aurait besoin d'evoluer.\n",
+    "**Conclusion mesuree** : le couplage Default+NoOp utilise dans ce notebook est **structurellement desavantage** sur toute dimension a cible unique. Il ne peut donc PAS illustrer la victoire heterogene decrite dans la prose ci-dessus. L'ecart de -1283,3% observe sur le cone lisse n'est pas un defaut du moteur eukaryote : c'est la consequence attendue d'avoir assigne `NoOpMetaHeuristic` (une non-strategie) a une dimension qui aurait besoin d'evoluer.\n",
     "\n",
     "**Quand l'heterogene gagne vraiment** : il faut une **specialisation reelle** des sous-heuristiques -- une exploration forte (mutation amplifiee) sur une partition au paysage rugueux, et une exploitation fine (faible mutation) sur une partition au paysage lisse. Ce genre de specialisation par partition est precisement l'objet de l'**Exercice 3** (implementer un `SubPopulationMetaHeuristic` personnalise). Le demo ci-dessus, lui, isole proprement l'effet de chaque sous-heuristique par partition -- capacite distinctive de l'eukaryote -- et montre que NoOp est un point de comparaison (le pire cas), pas une strategie gagnante."
    ]
@@ -1885,6 +1900,18 @@
    "name": "C#",
    "pygments_lexer": "csharp",
    "version": "13.0"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 5.119813,
+   "end_time": "2026-08-21T04:20:21.288135+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "MGS-3-Eukaryote.ipynb",
+   "output_path": "_exec_MGS-3.final.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-21T04:20:16.168322+00:00",
+   "version": "2.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-dotnet -- lane myia-po-2025:CoursIA -- prev: DEEP/lean #12029

## Summary

Tranche re-exec post-rebase de MGS-3-Eukaryote (suite #11941 MGS-1 / #11943 MGS-2, EPIC #1203) : re-execution complete contre le moteur rebase (GeneticSharp imbrique `4406ad7`, submodule `549e6ca`), audit prose-vs-chiffres, et **fix a la cause** de la derive constatee (seeding apparie) -- pas un simple re-align de surface.

## Diagnostic derive (C.4)

- **Cause : (e) stochasticite non-seedee.** La prose MD 17/19 citait `-44066,7%` / `440x`, valeurs d'un run non-seede. Le run frais (meme source, meme moteur) donnait `-31,1%` : chaque exec produisait un autre ecart, et la prose citait une valeur qui n'existait plus dans l'output adjacent.
- **Verdict : CAUSE_FIXED.** `FastRandomRandomization.ResetSeed` apparies : cell 15 runs k -> seed `42+k` (les deux configurations d'un meme run partent du meme flux -- comparaison appariee), cell 18 runs i -> seed `100+i` (les 3 runs d'une ligne sigma partagent leurs flux entre configs), demos cells 6/9/12 -> seeds `7/8/9`.
- **Determinisme prouve** : 2 execs completes consecutives -> **10/10 outputs byte-identiques** (verifie par diff programmatique, pas visuellement).
- Prose MD 17/19 recallee sur les valeurs seedees stables : moyennes `1,8260` vs `0,1320` (Amelioration `-1283,3%`, facteur ~14), sigma sweep `Uniform` gagnant 4/4 (`5,104/0,007/0,030/0,000` vs `10,000/10,000/7,829/3,324`). Conclusions qualitatives **inchangees** (l'uniforme bat l'heterogene partout) -- seul le nombre cite etait perime.

## Finding lateral (serie MGS-4..19) -- non fixe ici

Le pattern de seeding utilise par les notebooks MGS-4 a MGS-19 (`BasicRandomization.ResetSeed(seed)`, ex. MGS-4 cell 27) est un **no-op pour le GA** : le moteur consomme `RandomizationProvider.Current` = `FastRandomRandomization` par defaut, et `BasicRandomization.ResetSeed` ne touche que le champ statique de `BasicRandomization`. Seul `FastRandomRandomization.ResetSeed` remplace le ThreadLocal (`FastRandomRandomization.cs:49`). Ces notebooks croient etre seedes et ne le sont pas -- a tracker en issue separee (un grain par notebook ou un fix de serie), hors scope de cette PR.

## Exec proofs

- `execute_notebook` sync kernel `.net-csharp` : 10/10 cells, 0 erreur, `execution_count` 1..10, temps ~5.2 s (probleme trivial 2 genes, 50 generations x 40 individus)
- Moteur : `dotnet build MetaGeneticSharp.sln` Debug + Release **0 erreur** (clone frais du submodule `549e6ca` + GeneticSharp imbrique init)
- `validate_pr_notebooks.py origin/main <nb>` : **1/1 PASS** (10 cells .net-csharp)
- `strip_probe_banner.py --apply` : 9 lignes probeAddresses retirees ; `metadata.papermill` au basename
- 0 violation C.1 (`raise NotImplementedError|assert False|1/0` : 0 match)
- Perimetre : 1 seul fichier, catalogue non touche (byte-identique a main)

See #1203
