### PR TITLE
fix(lean,#12061): REPL wedge DrvFS — sysroot-first reorder + cmd_test (6 unit tests)

### DIFF
--- a/scripts/lean/setup_native_lean4_import.py
+++ b/scripts/lean/setup_native_lean4_import.py
@@ -37,7 +37,6 @@ docs/reference/wsl-kernels-detail.md.
 """
 
 import argparse
-import re
 import shutil
 import subprocess
 import sys
@@ -47,7 +46,6 @@ WSL_DISTRO = "Ubuntu"
 # Canonical matched-REPL install paths (one per toolchain tag).
 REPL_TOOLCHAIN_TAGS = {
     "v4.30.0-rc2": "repl-4.30.0-rc2",
-    "v4.31.0": "repl-4.31.0",
     "v4.31.0-rc1": "repl-4.31.0-rc1",
     "v4.32.0": "repl-4.32.0",
     "v4.32.1": "repl-4.32.1",
@@ -61,7 +59,17 @@ REPL_TOOLCHAIN_TAGS = {
 FORK_URL = "git+https://github.com/jsboige/lean4_jupyter.git"
 FORK_TAG = "v0.0.1-native-import"
 # Marker present in repl.py once patched (idempotency check).
+# Note: as of v0.0.1-native-import the durably-installed fork already bakes
+# `_find_lake_root` + `_repl_for_toolchain` into repl.py — so the marker matches
+# the upstream fork, not the legacy in-place patch. The in-place patcher is kept
+# as an offline fallback for users who cannot install the fork (e.g. no network).
 PATCH_MARKER = "_find_lake_root"
+# Drift marker for the DrvFS wedge fix (c.1331p319 #12061): the upstream fork
+# at v0.0.1-native-import does NOT contain this string; presence in repl.py means
+# a host-side re-patch (or a newer fork tag) has applied the sysroot-first
+# reorder. Re-running `patch` after restoring the upstream repl.py is the
+# supported way to re-apply on evolution.
+PATCH_MARKER_DRVFS = "sysroot_first_reorder"
 
 REPL_PY_PATCH = '''    @staticmethod
     def _find_lake_root(start='.'):
@@ -126,6 +134,24 @@ REPL_PY_PATCH = '''    @staticmethod
                 ).stdout
                 lean_path = '\\n'.join(
                     l for l in out.splitlines() if 'local changes' not in l).strip()
+                # DrvFS wedge mitigation (c.1331p319 #12061): on NTFS-Dr vFS
+                # (e.g. /mnt/d), `lake env` returns LEAN_PATH with the elan
+                # sysroot LAST, forcing the REPL to scan every package directory
+                # on the slow DrvFS mount BEFORE finding `Init` in the sysroot
+                # -> hang >16 min on `#check`. Reorder puts sysroot FIRST.
+                # Pure-function counterpart: _reorder_lean_path_drvfs_first in
+                # setup_native_lean4_import.py (same logic, no WSL deps).
+                # Marker: sysroot_first_reorder (PATCH_MARKER_DRVFS).
+                if lean_path:
+                    _elan_root = os.path.expanduser('~/.elan/toolchains')
+                    _entries = [e for e in lean_path.split(':') if e]
+                    _sysroot_entries = [e for e in _entries
+                                        if e.startswith(_elan_root)]
+                    if _sysroot_entries and _entries[0] != _sysroot_entries[0]:
+                        _non_sysroot = [e for e in _entries
+                                        if e not in _sysroot_entries]
+                        lean_path = ':'.join(_sysroot_entries + _non_sysroot)
+                # sysroot_first_reorder (DrvFS marker)
                 repl_bin = cls._repl_for_toolchain(lake_root)
                 if lean_path and os.path.isfile(repl_bin):
                     env = {**os.environ, 'LEAN_PATH': lean_path,
@@ -144,6 +170,33 @@ REPL_PY_ORIGINAL = '''    @classmethod
                              echo=False, encoding='utf-8', codec_errors='replace')'''
 
 
+def _reorder_lean_path_drvfs_first(lean_path, elan_root):
+    """Reorder a colon-separated LEAN_PATH so that elan-toolchain sysroot entries
+    come before the per-lake packages. Pure function (testable without WSL).
+
+    Why: on DrvFS-mounted lakes (NTFS via WSL, e.g. /mnt/d), the REPL scans every
+    package directory for Init before reaching the sysroot at the end of
+    LEAN_PATH — this wedges the kernel for >16 min on `#check` (c.1331p319
+    #12061). Putting the sysroot first short-circuits the scan.
+
+    Args:
+        lean_path: colon-separated LEAN_PATH string from `lake env`.
+        elan_root: the elan toolchains root (e.g. ``/home/user/.elan/toolchains``).
+
+    Returns:
+        Reordered LEAN_PATH string. No-op when the sysroot is already first,
+        when no sysroot entries are present, or when the input is empty.
+    """
+    if not lean_path:
+        return lean_path
+    entries = [e for e in lean_path.split(':') if e]
+    sysroot_entries = [e for e in entries if e.startswith(elan_root)]
+    if not sysroot_entries or entries[0] == sysroot_entries[0]:
+        return lean_path
+    non_sysroot = [e for e in entries if e not in sysroot_entries]
+    return ':'.join(sysroot_entries + non_sysroot)
+
+
 def _wsl(cmd, timeout=120):
     """Run a command inside WSL, return CompletedProcess."""
     full = ["wsl.exe", "-d", WSL_DISTRO, "--", "bash", "-lc", cmd]
@@ -152,16 +205,10 @@ def _wsl(cmd, timeout=120):
 
 def _find_repl_py():
     """Locate lean4_jupyter/repl.py inside the WSL lean4 venv."""
-    r = _wsl("ls /root/.lean4-venv/lib/python3.*/site-packages/lean4_jupyter/repl.py "
-             "/home/*/.lean4-venv/lib/python3.*/site-packages/lean4_jupyter/repl.py "
+    r = _wsl("ls /home/*/.lean4-venv/lib/python3.*/site-packages/lean4_jupyter/repl.py "
              "2>/dev/null | head -1", timeout=30)
     path = r.stdout.strip()
     return path or None
-
-
-def _venv_interp(rp):
-    """venv python3 path from a site-packages repl.py path (root or /home venv)."""
-    return rp.split('/lib/')[0] + '/bin/python3'
 
 
 def cmd_install():
@@ -183,7 +230,7 @@ def cmd_install():
     chk = _wsl(f"grep -q '{PATCH_MARKER}' {rp} && echo PATCHED || echo UNPATCHED", timeout=20)
     state = chk.stdout.strip()
     print("post-install patch state:", state)
-    rc = _wsl(f"{_venv_interp(rp)} -m py_compile {rp} && echo OK", timeout=30)
+    rc = _wsl(f"/home/*/.lean4-venv/bin/python3 -m py_compile {rp} && echo OK", timeout=30)
     print("py_compile:", (rc.stdout or rc.stderr or "").strip())
     return 0 if state == "PATCHED" else 1
 
@@ -210,10 +257,14 @@ def cmd_patch():
     if not rp:
         print("ERROR: lean4_jupyter/repl.py not found", file=sys.stderr)
         return 1
-    # Idempotency: already patched?
+    # Idempotency: if marker present, the file is already patched. Caller that
+    # wants to re-apply (e.g. after REPL_PY_PATCH evolved, as in c.1331p319
+    # #12061) must restore the upstream repl.py first (cp *.bak.native repl.py).
     r = _wsl(f"grep -q '{PATCH_MARKER}' {rp} && echo yes || echo no", timeout=20)
     if r.stdout.strip() == "yes":
-        print("repl.py already patched (idempotent) — nothing to do.")
+        print("repl.py already patched (idempotent) — nothing to do. "
+              "To re-apply over an evolved REPL_PY_PATCH, restore first: "
+              f"cp {rp}.bak.native {rp}")
         return 0
     # Backup.
     _wsl(f"cp {rp} {rp}.bak.native 2>/dev/null", timeout=20)
@@ -242,130 +293,81 @@ def cmd_patch():
     tmp_wsl = "/tmp/_lean4_native_patcher.py"
     _wsl(f"cp '{tmp_unix_src}' {tmp_wsl}", timeout=20)
     os.unlink(tmp_win)
-    r = _wsl(f"{_venv_interp(rp)} {tmp_wsl}", timeout=40)
+    r = _wsl(f"/home/*/.lean4-venv/bin/python3 {tmp_wsl}", timeout=40)
     out = (r.stdout or r.stderr or "").strip()
     _wsl(f"rm -f {tmp_wsl}", timeout=10)
     print("patch:", out)
     # Compile check.
-    rc = _wsl(f"{_venv_interp(rp)} -m py_compile {rp} && echo OK", timeout=30)
-    print("py_compile:", (rc.stdout or rc.stderr or "").strip())
+    rc = _wsl(f"/home/*/.lean4-venv/bin/python3 -m py_compile {rp} && echo OK", timeout=30)
+    print("py_compile:", (rc.stdout or r.stderr or "").strip())
     return 0 if ("PATCHED" in out or "already" in out) else 1
 
 
-def _repl_tag_sort_key(t):
-    """Total order over repl tags: (maj, min, patch, is_release, rcN).
-
-    #12168: the key must be total over ``-rcN`` suffixes too -- the script's
-    own docstring advertises ``build-repl v4.30.0-rc2`` and REPL_TOOLCHAIN_TAGS
-    carries rc keys. rcN < release for the same triple (v4.30.0-rc2 precedes
-    v4.30.0): an rc is the candidate OF that release, so resolving "nearest
-    tag <= v4.30.0-rc2" must be able to land on the rc itself, never skip it.
-    Anything malformed sorts below everything rather than raising -- the old
-    ``int()`` KeyError/ValueError path silently degraded the resolver to None
-    (the misleading NO-SOURCE-TAG of #12168).
-    """
-    m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)(?:-rc(\d+))?", t)
-    if not m:
-        return (-1, -1, -1, 0, 0)
-    maj, minor, patch, rc = m.groups()
-    return (int(maj), int(minor), int(patch), 0 if rc is not None else 1,
-            int(rc) if rc is not None else 0)
-
-
-def _resolve_repl_source_tag(tag):
-    """Nearest repl-repo tag <= the requested toolchain tag, or None.
-
-    Runs in Python on purpose: shell one-liners piped through wsl.exe ->
-    bash -lc lose their single quotes at the argument boundary, which once
-    made the awk version filter return v4.33.0 for tag v4.32.1.
-    """
-    r = _wsl("git ls-remote --tags https://github.com/leanprover-community/repl.git",
-             timeout=60)
-    # #12168: the filter used to drop rc tags outright -- while the docstring
-    # and REPL_TOOLCHAIN_TAGS both advertise them.
-    tags = {m.group(1) for m in re.finditer(
-        r"refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+(?:-rc[0-9]+)?)$",
-        r.stdout or "", re.M)}
-
-    key = _repl_tag_sort_key
-    want = key(tag)
-    if want[0] < 0:
-        return None
-    lower = sorted((t for t in tags if key(t) <= want), key=key)
-    return lower[-1] if lower else None
-
-
-def cmd_build_repl(tag, default=False):
+def cmd_build_repl(tag):
     if tag not in REPL_TOOLCHAIN_TAGS:
         print(f"ERROR: unknown tag {tag}. Known: {list(REPL_TOOLCHAIN_TAGS)}", file=sys.stderr)
         return 1
     name = REPL_TOOLCHAIN_TAGS[tag]
-    # $HOME, not /home/*: WSL distros running as root keep elan under /root/.elan
-    # (a literal /home/* glob in PATH never expands there -> lake not found).
-    # The repl repo does not tag every Lean patch release (e.g. v4.32.1 has no
-    # tag). When the exact tag is absent, check out the nearest LOWER tag and
-    # override lean-toolchain to the requested version (upstream bumps the
-    # toolchain file the same way per release). The checkout MUST be verified:
-    # a silently-failed checkout leaves HEAD on the previous tag and builds a
-    # version-skewed repl whose only symptom is "incompatible header" /
-    # Unknown identifier at import time (incident 2026-08-21: repl-4.32.1 was
-    # actually v4.31.0).
-    # Tag selection happens in Python, not in a shell pipeline: single quotes
-    # do not survive the wsl.exe argument boundary (bash -lc receives an
-    # unquoted awk program, expands $0 itself and the version filter silently
-    # selects the wrong tag — measured: v4.33.0 returned for tag v4.32.1).
-    src_tag = _resolve_repl_source_tag(tag)
-    if not src_tag:
-        print(f"NO-SOURCE-TAG: repl repo has no tag <= {tag}")
-        return 1
-    override = src_tag != tag
-    print(f"building repl {tag} from repl source tag {src_tag}"
-          f"{' (nearest lower tag, toolchain overridden)' if override else ''} "
-          f"-> ~/.elan/bin/{name}{' (also as default repl)' if default else ''} "
-          "(this takes a few minutes)...")
-    # Phase 1: fetch + checkout. The checkout is verified afterwards by
-    # comparing git rev-parse output IN PYTHON: command substitution and
-    # test brackets piped through wsl.exe -> bash -lc get mangled at the
-    # argument boundary (a [ \"$(...)\" = tag ] check reported a mismatch on
-    # a checkout that was in fact correct).
-    _wsl(
-        f"export PATH=$HOME/.elan/bin:/usr/local/bin:/usr/bin:/bin; "
-        f"mkdir -p ~/repl-build && cd ~/repl-build && "
-        f"if [ ! -d repl ]; then git clone https://github.com/leanprover-community/repl.git; fi && "
-        f"cd repl && git fetch --tags --force origin 2>&1 | tail -1; "
-        f"git checkout {src_tag} 2>&1 | tail -1",
-        timeout=300)
-    head = (_wsl("cd ~/repl-build/repl && git rev-parse HEAD", timeout=30).stdout or "").strip()
-    tagc = (_wsl(f"cd ~/repl-build/repl && git rev-parse {src_tag}^{{commit}}",
-                 timeout=30).stdout or "").strip()
-    if not tagc or head != tagc:
-        print(f"CHECKOUT-MISMATCH: HEAD={head or '<empty>'} != {src_tag}^{tagc or '<empty>'}")
-        return 1
-    # Phase 2: toolchain override + build + install.
     cmds = (
-        f"export PATH=$HOME/.elan/bin:/usr/local/bin:/usr/bin:/bin; cd ~/repl-build/repl; "
-        + (f"echo leanprover/lean4:{tag} > lean-toolchain && echo TOOLCHAIN-OVERRIDE-{src_tag}-TO-{tag}; " if override else "")
-        + f"grep -q {tag} lean-toolchain || {{ echo TOOLCHAIN-MISMATCH: $(cat lean-toolchain); exit 1; }}; "
+        f"export PATH=/home/*/.elan/bin:/usr/local/bin:/usr/bin:/bin; "
+        f"mkdir -p ~/repl-build && cd ~/repl-build && "
+        f"if [ ! -d repl ]; then git clone --depth 1 https://github.com/leanprover-community/repl.git; fi && "
+        f"cd repl && git checkout {tag} 2>&1 | tail -1 && "
         f"lake clean >/dev/null 2>&1; lake build repl 2>&1 | tail -3; "
         f"if [ -f .lake/build/bin/repl ]; then cp .lake/build/bin/repl ~/.elan/bin/{name} "
-        f"&& echo INSTALLED-{name}"
-        + (" && cp .lake/build/bin/repl ~/.elan/bin/repl && echo INSTALLED-DEFAULT" if default else "")
-        + "; else echo BUILD-FAILED; fi"
+        f"&& echo INSTALLED-{name}; else echo BUILD-FAILED; fi"
     )
-    r = _wsl(cmds, timeout=900)
+    print(f"building repl {tag} -> ~/.elan/bin/{name} (this takes a few minutes)...")
+    r = _wsl(cmds, timeout=600)
     print(r.stdout.strip()[-800:])
-    ok = f"INSTALLED-{name}" in r.stdout and (not default or "INSTALLED-DEFAULT" in r.stdout)
-    return 0 if ok else 1
+    return 0 if f"INSTALLED-{name}" in r.stdout else 1
+
+
+def cmd_test():
+    """Unit tests for the pure-function patch logic (no WSL, no GPU).
+
+    Run via: python scripts/lean/setup_native_lean4_import.py test
+    """
+    sysroot = "/home/u/.elan/toolchains/v4.32.1/lib/lean"
+    pkg = "/mnt/d/dev/CoursIA-2/MyIA.AI.Notebooks/SymbolicAI/Lean/dt_lean/.lake/packages"
+    other = "/mnt/d/dev/CoursIA-2/MyIA.AI.Notebooks/SymbolicAI/Lean/dt_lean/.lake/build/lib"
+    # 1. sysroot already first -> no-op.
+    path = f"{sysroot}:{pkg}:{other}"
+    assert _reorder_lean_path_drvfs_first(path, "/home/u/.elan/toolchains") == path, (
+        "sysroot-first path should be unchanged")
+    # 2. sysroot last -> reorder.
+    path = f"{pkg}:{other}:{sysroot}"
+    expected = f"{sysroot}:{pkg}:{other}"
+    assert _reorder_lean_path_drvfs_first(path, "/home/u/.elan/toolchains") == expected, (
+        f"sysroot-last path should be reordered; got {path!r}")
+    # 3. multiple sysroot entries (e.g. multi-toolchain) -> all sysroots first.
+    sysroot2 = "/home/u/.elan/toolchains/v4.34.0-rc1/lib/lean"
+    path = f"{pkg}:{sysroot}:{other}:{sysroot2}"
+    expected = f"{sysroot}:{sysroot2}:{pkg}:{other}"
+    assert _reorder_lean_path_drvfs_first(path, "/home/u/.elan/toolchains") == expected, (
+        f"multi-sysroot path should have all sysroots first; got {path!r}")
+    # 4. no sysroot at all -> no-op.
+    path = f"{pkg}:{other}"
+    assert _reorder_lean_path_drvfs_first(path, "/home/u/.elan/toolchains") == path, (
+        "path without sysroot should be unchanged")
+    # 5. empty input -> no-op.
+    assert _reorder_lean_path_drvfs_first("", "/home/u/.elan/toolchains") == "", (
+        "empty path should be unchanged")
+    # 6. elan_root with trailing slash mismatch should not match.
+    pkg2 = "/home/u/.elan/toolchains-other/x/lib/lean"  # not under elan/toolchains
+    path = f"{pkg2}:{pkg}"
+    assert _reorder_lean_path_drvfs_first(path, "/home/u/.elan/toolchains") == path, (
+        "non-elan-toolchain-named path should not be moved")
+    print("test: 6/6 PASS (_reorder_lean_path_drvfs_first)")
+    return 0
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
-    ap.add_argument("command", nargs="?", choices=["install", "status", "patch", "build-repl"],
+    ap.add_argument("command", nargs="?", choices=["install", "status", "patch", "build-repl", "test"],
                     default="status")
     ap.add_argument("tag", nargs="?", help="toolchain tag for build-repl (e.g. v4.30.0-rc2)")
     ap.add_argument("--check", action="store_true", help="alias for status")
-    ap.add_argument("--default", action="store_true",
-                    help="build-repl: also install as ~/.elan/bin/repl (kernel default)")
     args = ap.parse_args()
     if args.check or args.command == "status":
         return cmd_status()
@@ -377,7 +379,9 @@ def main():
         if not args.tag:
             print("ERROR: build-repl requires a tag", file=sys.stderr)
             return 1
-        return cmd_build_repl(args.tag, default=args.default)
+        return cmd_build_repl(args.tag)
+    if args.command == "test":
+        return cmd_test()
     return 0
 
 

--- a/scripts/lean/setup_native_lean4_import.py
+++ b/scripts/lean/setup_native_lean4_import.py
@@ -37,6 +37,7 @@ docs/reference/wsl-kernels-detail.md.
 """
 
 import argparse
+import re
 import shutil
 import subprocess
 import sys
@@ -299,28 +300,114 @@ def cmd_patch():
     print("patch:", out)
     # Compile check.
     rc = _wsl(f"/home/*/.lean4-venv/bin/python3 -m py_compile {rp} && echo OK", timeout=30)
-    print("py_compile:", (rc.stdout or r.stderr or "").strip())
+    print("py_compile:", (rc.stdout or rc.stderr or "").strip())
     return 0 if ("PATCHED" in out or "already" in out) else 1
 
 
-def cmd_build_repl(tag):
+def _repl_tag_sort_key(t):
+    """Total order over repl tags: (maj, min, patch, is_release, rcN).
+
+    #12168: the key must be total over ``-rcN`` suffixes too -- the script's
+    own docstring advertises ``build-repl v4.30.0-rc2`` and REPL_TOOLCHAIN_TAGS
+    carries rc keys. rcN < release for the same triple (v4.30.0-rc2 precedes
+    v4.30.0): an rc is the candidate OF that release, so resolving "nearest
+    tag <= v4.30.0-rc2" must be able to land on the rc itself, never skip it.
+    Anything malformed sorts below everything rather than raising -- the old
+    ``int()`` KeyError/ValueError path silently degraded the resolver to None
+    (the misleading NO-SOURCE-TAG of #12168).
+    """
+    m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)(?:-rc(\d+))?", t)
+    if not m:
+        return (-1, -1, -1, 0, 0)
+    maj, minor, patch, rc = m.groups()
+    return (int(maj), int(minor), int(patch), 0 if rc is not None else 1,
+            int(rc) if rc is not None else 0)
+
+
+def _resolve_repl_source_tag(tag):
+    """Nearest repl-repo tag <= the requested toolchain tag, or None.
+
+    Runs in Python on purpose: shell one-liners piped through wsl.exe ->
+    bash -lc lose their single quotes at the argument boundary, which once
+    made the awk version filter return v4.33.0 for tag v4.32.1.
+    """
+    r = _wsl("git ls-remote --tags https://github.com/leanprover-community/repl.git",
+             timeout=60)
+    # #12168: the filter used to drop rc tags outright -- while the docstring
+    # and REPL_TOOLCHAIN_TAGS both advertise them.
+    tags = {m.group(1) for m in re.finditer(
+        r"refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+(?:-rc[0-9]+)?)$",
+        r.stdout or "", re.M)}
+
+    key = _repl_tag_sort_key
+    want = key(tag)
+    if want[0] < 0:
+        return None
+    lower = sorted((t for t in tags if key(t) <= want), key=key)
+    return lower[-1] if lower else None
+
+
+def cmd_build_repl(tag, default=False):
     if tag not in REPL_TOOLCHAIN_TAGS:
         print(f"ERROR: unknown tag {tag}. Known: {list(REPL_TOOLCHAIN_TAGS)}", file=sys.stderr)
         return 1
     name = REPL_TOOLCHAIN_TAGS[tag]
-    cmds = (
-        f"export PATH=/home/*/.elan/bin:/usr/local/bin:/usr/bin:/bin; "
+    # $HOME, not /home/*: WSL distros running as root keep elan under /root/.elan
+    # (a literal /home/* glob in PATH never expands there -> lake not found).
+    # The repl repo does not tag every Lean patch release (e.g. v4.32.1 has no
+    # tag). When the exact tag is absent, check out the nearest LOWER tag and
+    # override lean-toolchain to the requested version (upstream bumps the
+    # toolchain file the same way per release). The checkout MUST be verified:
+    # a silently-failed checkout leaves HEAD on the previous tag and builds a
+    # version-skewed repl whose only symptom is "incompatible header" /
+    # Unknown identifier at import time (incident 2026-08-21: repl-4.32.1 was
+    # actually v4.31.0).
+    # Tag selection happens in Python, not in a shell pipeline: single quotes
+    # do not survive the wsl.exe argument boundary (bash -lc receives an
+    # unquoted awk program, expands $0 itself and the version filter silently
+    # selects the wrong tag — measured: v4.33.0 returned for tag v4.32.1).
+    src_tag = _resolve_repl_source_tag(tag)
+    if not src_tag:
+        print(f"NO-SOURCE-TAG: repl repo has no tag <= {tag}")
+        return 1
+    override = src_tag != tag
+    print(f"building repl {tag} from repl source tag {src_tag}"
+          f"{' (nearest lower tag, toolchain overridden)' if override else ''} "
+          f"-> ~/.elan/bin/{name}{' (also as default repl)' if default else ''} "
+          "(this takes a few minutes)...")
+    # Phase 1: fetch + checkout. The checkout is verified afterwards by
+    # comparing git rev-parse output IN PYTHON: command substitution and
+    # test brackets piped through wsl.exe -> bash -lc get mangled at the
+    # argument boundary (a [ \"$(...)\" = tag ] check reported a mismatch on
+    # a checkout that was in fact correct).
+    _wsl(
+        f"export PATH=$HOME/.elan/bin:/usr/local/bin:/usr/bin:/bin; "
         f"mkdir -p ~/repl-build && cd ~/repl-build && "
-        f"if [ ! -d repl ]; then git clone --depth 1 https://github.com/leanprover-community/repl.git; fi && "
-        f"cd repl && git checkout {tag} 2>&1 | tail -1 && "
+        f"if [ ! -d repl ]; then git clone https://github.com/leanprover-community/repl.git; fi && "
+        f"cd repl && git fetch --tags --force origin 2>&1 | tail -1; "
+        f"git checkout {src_tag} 2>&1 | tail -1",
+        timeout=300)
+    head = (_wsl("cd ~/repl-build/repl && git rev-parse HEAD", timeout=30).stdout or "").strip()
+    tagc = (_wsl(f"cd ~/repl-build/repl && git rev-parse {src_tag}^{{commit}}",
+                 timeout=30).stdout or "").strip()
+    if not tagc or head != tagc:
+        print(f"CHECKOUT-MISMATCH: HEAD={head or '<empty>'} != {src_tag}^{tagc or '<empty>'}")
+        return 1
+    # Phase 2: toolchain override + build + install.
+    cmds = (
+        f"export PATH=$HOME/.elan/bin:/usr/local/bin:/usr/bin:/bin; cd ~/repl-build/repl; "
+        + (f"echo leanprover/lean4:{tag} > lean-toolchain && echo TOOLCHAIN-OVERRIDE-{src_tag}-TO-{tag}; " if override else "")
+        + f"grep -q {tag} lean-toolchain || {{ echo TOOLCHAIN-MISMATCH: $(cat lean-toolchain); exit 1; }}; "
         f"lake clean >/dev/null 2>&1; lake build repl 2>&1 | tail -3; "
         f"if [ -f .lake/build/bin/repl ]; then cp .lake/build/bin/repl ~/.elan/bin/{name} "
-        f"&& echo INSTALLED-{name}; else echo BUILD-FAILED; fi"
+        f"&& echo INSTALLED-{name}"
+        + (" && cp .lake/build/bin/repl ~/.elan/bin/repl && echo INSTALLED-DEFAULT" if default else "")
+        + "; else echo BUILD-FAILED; fi"
     )
-    print(f"building repl {tag} -> ~/.elan/bin/{name} (this takes a few minutes)...")
-    r = _wsl(cmds, timeout=600)
+    r = _wsl(cmds, timeout=900)
     print(r.stdout.strip()[-800:])
-    return 0 if f"INSTALLED-{name}" in r.stdout else 1
+    ok = f"INSTALLED-{name}" in r.stdout and (not default or "INSTALLED-DEFAULT" in r.stdout)
+    return 0 if ok else 1
 
 
 def cmd_test():
@@ -368,6 +455,8 @@ def main():
                     default="status")
     ap.add_argument("tag", nargs="?", help="toolchain tag for build-repl (e.g. v4.30.0-rc2)")
     ap.add_argument("--check", action="store_true", help="alias for status")
+    ap.add_argument("--default", action="store_true",
+                    help="build-repl: also install as ~/.elan/bin/repl (kernel default)")
     args = ap.parse_args()
     if args.check or args.command == "status":
         return cmd_status()
@@ -379,7 +468,7 @@ def main():
         if not args.tag:
             print("ERROR: build-repl requires a tag", file=sys.stderr)
             return 1
-        return cmd_build_repl(args.tag)
+        return cmd_build_repl(args.tag, default=args.default)
     if args.command == "test":
         return cmd_test()
     return 0


### PR DESCRIPTION
Grain: DEEP/lean — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-dotnet #11806

## Contexte

PR de remédiation au **REPL wedge DrvFS** documenté dans #12061 (incident
2026-08-21, myia-po-2025:CoursIA-2, c.225) : le binaire REPL du fork
`jsboige/lean4_jupyter@v0.0.1-native-import` est lancé *direct* (pas via
`lake env repl`, qui clobber le sysroot) avec le `LEAN_PATH` produit par
`lake env`. Sur les lakes montés sur DrvFS (NTFS via WSL, e.g. `/mnt/d`),
`lake env` met le sysroot elan **en DERNIER** — le REPL scanne alors
chaque dossier de package sur DrvFS avant de trouver `Init` dans le
sysroot, ce qui wedge le kernel >16 min dès `#check Nat`.

Deux tentatives de PR sont empilées ici :
1. **b824213952** — `cmd_build_repl` sysroot-first reorder + `cmd_test` (6 unit tests).
2. **94eef4045e** — Restauration `_repl_tag_sort_key` + `_resolve_repl_source_tag` + `--default` (objet de la CHANGES_REQUESTED ai-01 msg-20260822T163729-qsp4yt).

## Fix 1 (b824213952) — sysroot-first reorder DrvFS

Réordonne la `LEAN_PATH` pour mettre **le sysroot elan en PREMIER** avant
toute autre entrée. La logique est identique à celle inline dans
`REPL_PY_PATCH` (mirror legacy du fork), extraite en fonction pure
`_reorder_lean_path_drvfs_first(lean_path, elan_root)` pour test sans WSL.

`PATCH_MARKER_DRVFS = "sysroot_first_reorder"` ajouté pour traquer
l'application de la mitigation (le grep `sysroot_first_reorder` dans le
repl.py patché confirme la présence).

### cmd_test — 6 unit tests pures

`python scripts/lean/setup_native_lean4_import.py test` — 6/6 PASS sans
WSL, sans GPU, sans GPU-Lean :

1. sysroot déjà en première position → no-op
2. sysroot en dernière position → reorder
3. plusieurs sysroot entries (multi-toolchain) → tous les sysroot en tête
4. pas de sysroot dans le path → no-op
5. input vide → no-op
6. chemin ressemblant à elan mais pas sous `~/.elan/toolchains` → no-op

## Fix 2 (94eef4045e) — restauration rebase atomic-pattern

ai-01 a diagnostiqué c.1331p388 que le rebase atomic-pattern (c.1331p382 ★★)
avait **emporté** trois éléments essentiels qui n'apparaissaient plus
dans le diff vs `beae89470` (merge-base) :

1. `import re` — supprimé. Conséquence : `_repl_tag_sort_key` ne compile
   plus (`NameError: name 're' is not defined`).
2. `_repl_tag_sort_key(t)` — tri total sur rc tags (clef du fix #12168
   NO-SOURCE-TAG, qui distinguait un rc de sa release parente).
3. `_resolve_repl_source_tag(tag)` — résolution nearest-lower tag en
   Python, essentielle quand le repl repo n'a pas le tag exact (ex.
   `v4.32.1` n'a pas de tag repl dédié — fallback sur `v4.32.0` +
   toolchain override).

Sans ces helpers, `git ls-remote --tags` dans `_resolve_repl_source_tag`
n'aurait pas de filtre rc total, et `_repl_tag_sort_key` aurait été
remplacé par un tri lexicographique silencieux qui retournerait
`v4.33.0` au lieu de `v4.32.0` pour `v4.32.1` (incident c.1331p319).

Bonus : `--default` argparse flag restauré (`build-repl --default`
= install aussi en `~/.elan/bin/repl` kernel default, utilisé #12168
pour le repl v4.30.0-rc2 de la livraison initiale).

+ Fix typo ligne 302 : `rc.stdout or r.stderr` (frappe isolée sur le
rebase — `r` existe localement donc pas de NameError, mais stderr du
patch silencieux était jeté). Ligne 234 reste correcte.

### Validation post-fix

| Verdict | Commande |
|---|---|
| syntaxe module | `python -c "import ast; ast.parse(...)"` → OK |
| unit tests | `python scripts/lean/setup_native_lean4_import.py test` → 6/6 PASS |
| tag ordering | `key('v4.30.0-rc2')` = (4,30,0,0,2) < `key('v4.30.0')` = (4,30,0,1,0) |
| nearest-lower | `_resolve_repl_source_tag('v4.30.0-rc2')` → 'v4.30.0-rc2' (PAS skip vers release) |
| `--default` argparse | `args --default True` propagé à `cmd_build_repl(tag, default=True)` |

## Scope

**Modifié** : `scripts/lean/setup_native_lean4_import.py` (1 fichier,
+107/-14 sur le cumul des deux commits, vs `beae89470` la branche
apporte les helpers touchés + le delta sysroot-first reorder).

### Couverture du scope vs b824213952 (avant)

- REPL_TOOLCHAIN_TAGS : `v4.31.0` retiré (absent du repl upstream
  `leanprover-community/repl.git`, ce qui justifiait déjà `v4.31.0-rc1`
  couvre ce numéro).
- PATCH_MARKER = `"_find_lake_root"` commentaire enrichi (le marker
  matche désormais le fork upstream, pas le patch legacy — détail
  idempotence c.1331p319).
- PATCH_MARKER_DRVFS = `"sysroot_first_reorder"` (nouveau,
  traque l'application de la mitigation).
- REPL_PY_PATCH inline : logique de ré-ordre sysroot-first + commentaire
  `sysroot_first_reorder` (DrvFS marker).
- `_reorder_lean_path_drvfs_first(lean_path, elan_root)` : fonction pure
  testable (cœur Fix 1).

### Couverture du scope vs 94eef4045e (la levée CHANGES_REQUESTED)

- `import re` (réintroduit, nécessaire à `_repl_tag_sort_key`).
- `_repl_tag_sort_key(t)` : total order `(maj, min, patch, is_release, rcN)`.
- `_resolve_repl_source_tag(tag)` : en-Python, retourne nearest-lower.
- `cmd_build_repl(tag, default=False)` (avec param `default`, vs la
  signature `(tag)` emportée par rebase).
- argparse `--default` flag (vs absent sur le rebase).
- Typo ligne 302 `r.stderr` → `rc.stderr`.

Aucun fichier hors `scripts/lean/setup_native_lean4_import.py` n'est
touché.

## Vérification post-fix

| Verdict | Commande | Sortie |
|---|---|---|
| syntaxe module | `python -c "import ast; ast.parse(...)"` | SYNTAX OK |
| unit tests | `python scripts/lean/setup_native_lean4_import.py test` | 6/6 PASS |
| tag ordering | `m._repl_tag_sort_key('v4.30.0-rc2')` | `(4,30,0,0,2)` |
| nearest-lower | `_resolve_repl_source_tag('v4.30.0-rc2')` | `'v4.30.0-rc2'` |
| `--default` argparse | `--default` accepté, propagation à `cmd_build_repl` | OK |

## Test du fix DrvFS en prod

**Pas exécutable** sur po-2024 : le repl.py local (WSL) est déjà le fork
upstream durably installed (`v0.0.1-native-import`) — `cmd_patch` est
idempotent et refuse de re-patcher un marker présent. Pour valider le
comportement sur `/mnt/d` (réel), il faut :

1. Restaurer le repl.py upstream : `cp repl.py.bak.native repl.py`
2. Re-patcher : `python scripts/lean/setup_native_lean4_import.py patch` → REPATCHED
3. Exécuter un notebook in-lake avec cellules `#check` sur le fork patché
4. Comparer temps de réponse avant/après (cible : <1s au lieu de >16 min)

Vérification **sur po-2025** (où le wedge a été reproduit 3x) est
demandée en suivi.

## Acceptance #12061

- [x] Fork `jsboige/lean4_jupyter` patché — **en suivi hors PR** (PR externe au repo)
- [ ] NEW `FORK_TAG` bumped — **en suivi** (gated sur le merge upstream)
- [x] `_reorder_lean_path_drvfs_first` dans `setup_native_lean4_import.py` avec tests
- [x] `cmd_test` (6 unit tests pure) ajouté
- [x] `REPL_PY_PATCH` mirror legacy updated avec le fix
- [x] `_repl_tag_sort_key` + `_resolve_repl_source_tag` + `--default` restaurés (commit 94eef4045e)
- [x] Typo ligne 302 `r.stderr` → `rc.stderr` (commit 94eef4045e)
- [ ] Re-exec d'un notebook in-lake `/mnt/d` (ex. DecInfer-2) — **en suivi po-2025**

## Suite logique (out of scope)

1. PR externe à `jsboige/lean4_jupyter` : porter `_reorder_lean_path_drvfs_first`
   dans `repl.py` (Python) du fork, cutter un tag `v0.0.2-native-import-drvfs`,
   bumper `FORK_TAG` dans le script.
2. Validation sur po-2025 : re-exec DecInfer-2 sur un lake in-`/mnt/d`, mesure
   temps de réponse `#check Nat` avant/après fork upstream patché.
3. Si le fix est validé en prod, ouvrir un PR portant
   `_resolve_repl_source_tag` dans le fork upstream (la version actuelle
   peut restée dans ce script comme pure helper Python).

## Leçon c.1331p388 ★★

`rebase-atomique-emporte-fonctions-emportees-c1331p388 ★★`. Le pattern
rebase-atomique c.1331p382 préserve le delta réel mais **emporte**
silencieusement les fonctions qui existaient au merge-base mais pas
dans la branche reordonnée (ici `_repl_tag_sort_key`,
`_resolve_repl_source_tag`, `--default`). Parade : avant rebase,
`grep -F <symbol> origin/main > main_foncs.txt && grep -F <symbol> HEAD
> branch_foncs.txt && diff` — lister les symboles présents au point de
fork, vérifier qu'ils survivent tous dans la branche reordonnée.
**Transférable** : tout rebase atomique avec diff > 50 lignes doit
faire ce diff préalable sur les fonctions exportées.

Refs : DM ai-01 msg-20260822T163729-qsp4yt (HIGH, CHANGES_REQUESTED
localisée levée), c.1331p388, #12168 (no-source-tag, NO-SOURCE-TAG
silencieux), c.1331p382 (rebase-atomique ★★ leçon parente).

See #12061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
