### PR TITLE
fix(tooling): claims-output scanner normalizes FR decimal commas on both sides (#12076)

### DIFF
--- a/scripts/check_markdown_claims_output.py
+++ b/scripts/check_markdown_claims_output.py
@@ -151,6 +151,22 @@ def _output_text(outputs: list) -> str:
     return "\n".join(chunks)
 
 
+def _normalize_output_text(out_text: str) -> str:
+    """Rewrite comma-formatted numbers in an output text to their _normalize_num
+    form (#12076): francophone decimal commas ('1,8260' -> '1.8260') and
+    anglophone thousands ('3,145,728' -> '3145.728') -- the same heuristic the
+    CITED token already goes through. Used for the direct search only: a claim
+    normalized to '1.8260' used to be searched against the RAW output ('1,8260')
+    and only survived through the fuzzy fallback, whose clause (c) caps the
+    magnitude run at 12 digits -- making the verdict depend on how many digits
+    happen to follow in the same output."""
+    return re.sub(
+        r"(?<![A-Za-z0-9])\d+(?:,\d+)+(?![A-Za-z0-9])",
+        lambda m: _normalize_num(m.group(0)),
+        out_text,
+    )
+
+
 def _lit_skip(source: str) -> bool:
     """Tell: a markdown cell is a literature block (long prose) vs a quantitative
     interpolation cell. We DON'T skip on length alone: c.290 pathologie sat in
@@ -381,7 +397,11 @@ def check_notebook(path: Path) -> dict:
         if not any_output:
             skipped_no_output += 1
             continue
-        out_text = "\n".join(out_chunks)
+        raw_out_text = "\n".join(out_chunks)
+        # #12076: the direct search compares normalized claim vs normalized
+        # output; the fuzzy fallback keeps the RAW text (its comma-gate, clause
+        # (c), reads large-number signals from the commas themselves).
+        out_text = _normalize_output_text(raw_out_text)
         # Extract numeric claims from the markdown prose. We iterate via
         # finditer so we get (span_start, span_end, raw) for each match
         # -- this is needed for the version-token and inline-code-span
@@ -401,7 +421,7 @@ def check_notebook(path: Path) -> dict:
                 continue
             # Search the normalized form in the output text (plus adjacent
             # variants: e.g. "0.24" present in "0.2385")
-            if norm not in out_text and not _fuzzy_present(norm, out_text):
+            if norm not in out_text and not _fuzzy_present(norm, raw_out_text):
                 findings.append({
                     "markdown_cell": idx,
                     "code_cell": prev_code_idxs[0],

--- a/scripts/tests/test_check_markdown_claims_output.py
+++ b/scripts/tests/test_check_markdown_claims_output.py
@@ -581,3 +581,63 @@ class TestExceptionSpanHelper:
         result = _in_exception_code_span(src, pos, end)
         assert result is True or result is False  # weak pin
 
+
+
+class TestFrDecimalOutputNormalization:
+    """#12076: the output text goes through the same comma->dot normalization
+    as the cited token (direct search only), so a francophone-decimal output
+    matches DIRECTLY instead of surviving through the 12-digit-bounded fuzzy
+    fallback. Before the fix, the verdict depended on how many digits happened
+    to follow in the same output."""
+
+    def test_fr_decimal_claim_matched_directly_in_fr_output(self, tmp_path: Path):
+        """The exact #12070 cell-15 shape: prose '1,8260', output printing
+        '1,8260' surrounded by other comma-decimals -- CLEAN, no finding."""
+        nb = _mk_nb([
+            _code_cell("print(stats)", [
+                _stream_output(
+                    "      Uniforme moyenne  : 0,1320\n"
+                    "      Heterogene moyenne: 1,8260\n"
+                    "      Amelioration      : -1283,3%\n"
+                ),
+            ]),
+            _md_cell("L'analyse donne une moyenne heterogene de 1,8260 contre 0,1320 en uniforme."),
+        ])
+        nb_path = tmp_path / "fr_direct.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        res = check_notebook(nb_path)
+        assert res["verdict"] == "CLEAN", res
+
+    def test_verdict_independent_of_trailing_digit_count(self, tmp_path: Path):
+        """The property the issue establishes: same cited number, same prose,
+        only the number of digits that FOLLOW in the same output changes --
+        both must give the same verdict. Pre-fix, the long tail flipped to
+        FABRICATION through the fuzzy (c) 12-digit bound."""
+        tails = [
+            "1,8260 fin\n",
+            "1,8260 puis 0,9999999999999999 et 2,718281828459045 fin\n",
+        ]
+        verdicts = []
+        for i, tail in enumerate(tails):
+            nb = _mk_nb([
+                _code_cell("print(x)", [_stream_output("moyenne: " + tail)]),
+                _md_cell("La moyenne heterogene constatee est 1,8260."),
+            ])
+            nb_path = tmp_path / f"tail_{i}.ipynb"
+            nb_path.write_text(json.dumps(nb), encoding="utf-8")
+            verdicts.append(check_notebook(nb_path)["verdict"])
+        assert verdicts == ["CLEAN", "CLEAN"], verdicts
+
+    def test_fabrication_still_detected_against_fr_output(self, tmp_path: Path):
+        """The fix must not blind the detector: a number truly absent from a
+        comma-formatted output is still flagged."""
+        nb = _mk_nb([
+            _code_cell("print(x)", [_stream_output("Uniforme moyenne : 0,1320")]),
+            _md_cell("La moyenne heterogene constatee est 1,8260."),
+        ])
+        nb_path = tmp_path / "fr_fab.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        res = check_notebook(nb_path)
+        assert res["verdict"] == "FABRICATION_DETECTED", res
+        norms = {f["normalized"] for f in res["findings"]}
+        assert "1.8260" in norms, res


### PR DESCRIPTION
## Summary

Fixe #12076 : le scanner `check_markdown_claims_output.py` normalisait le nombre **cité** (`1,8260` -> `1.8260`) mais cherchait dans la sortie **brute**. Sur toute sortie formatee en francais, le match direct ne pouvait pas toucher et le verdict ne survivait que par le rattrapage `_fuzzy_present`, dont la clause (c) est bornee a 12 chiffres de queue -- le verdict dependait du **nombre de chiffres qui suivent dans la meme sortie**, propriete sans rapport avec le fait que la prose soit fabriquee ou non.

## Patch (2 fichiers, +82/-2)

- Nouvelle fonction `_normalize_output_text` : reecrit les nombres a virgule de la sortie (decimal FR `1,8260`->`1.8260`, milliers EN `3,145,728`->`3145.728`) via la **meme heuristique** `_normalize_num` que le token cite.
- La recherche **directe** porte sur la sortie normalisee ; le rattrapage fuzzy garde le texte **brut** a dessein : sa comma-gate (clause (c)) lit les virgules comme signal de grand nombre, et le pin c.290 (`3,1 M` vs `3,145,728`) en depend -- toucher au fuzzy aurait casse ce pin.

## Preuves

- **Tests 55/55** (52 existants + 3 nouveaux dont le test-propriete de l'issue). Controle negatif sans le fix : seul le test `test_verdict_independent_of_trailing_digit_count` echoue (le cas FR court passait par la bequille fuzzy, exactement comme le documente l'issue : "FR court -> ok, FR + 13 lig -> FABRICATION").
- **Notebook reel de #12070** (MGS-3-Eukaryote) : 4 findings -> **1**. Le restant est la classe (2) de l'issue (`UniformCrossover(0.5)` cite du **source** de la cellule, pas de son output) -- l'issue la reserve explicitement a un arbitrage separe, hors scope ici.
- **Sweep repo-wide 1047 notebooks** (la metrique que l'issue demandait) : 5288 -> **4809** findings (-479), 310 -> **320** CLEAN. Aucun finding n'apparait post-fix qui n'existait pas pre-fix (le patch ne peut qu'ajouter des matches, jamais en retirer -- verifie mecaniquement et sur echantillon).

## Residuel signale (regle 3)

La classe (2) (parametre de code cite en prose) reste : ~4800 findings repo-wide y sont majoritairement imputables. Arbitrage propose par l'issue : elargir la surface au source de la cellule precedente, ou documenter comme bruit connu. Grain separe.

Grain: LIGHT/tooling -- lane myia-po-2026:CoursIA -- prev: DEEP/research-code (MGS PR 46)

Closes #12076

🤖 Generated with [Claude Code](https://claude.com/claude-code)
