### PR TITLE
fix(guards,#12074): CONDITIONAL_LIFT preserves explicit author lifts (offset discriminant)

### DIFF
--- a/scripts/audit/nit_lift_authorship.py
+++ b/scripts/audit/nit_lift_authorship.py
@@ -7,7 +7,7 @@ Borner la levee d'une reserve a son auteur (piste Hermes) rendrait l'organe
 plus strict ; la decision exige la mesure. Ce script compagnon NE TOUCHE PAS
 l'organe gate (`check_unaddressed_nits.py`) : il reutilise son modele de
 donnees et ses memes predicats (classify, can_lift, LIFT_MARKERS,
-CONDITIONAL_LIFT, CITERS) pour classifier chaque levee observee sur un
+_lift_cancelled, CITERS) pour classifier chaque levee observee sur un
 corpus de PRs mergees :
 
   SELF      — la reserve est levee par son propre auteur
@@ -86,7 +86,7 @@ def measure_pr(pr_data: dict) -> dict:
         for c in (pr_data.get("comments") or [])
         if nits.can_lift(c)
         and nits.has_marker(c.get("body", ""), nits.LIFT_MARKERS)
-        and not nits.CONDITIONAL_LIFT.search(nits._strip_quoted(c.get("body", "")))
+        and not nits._lift_cancelled(nits._strip_quoted(c.get("body", "")))
     ]
     comment_lifts = [(t, a) for (t, a) in comment_lifts if t is not None]
     explicit_lifts = [(t, a) for (t, a) in explicit_lifts if t is not None]

--- a/scripts/check_unaddressed_nits.py
+++ b/scripts/check_unaddressed_nits.py
@@ -65,12 +65,18 @@ pratique sur ce depot mais ce n'est pas une preuve d'identite : un nit user
 poste via `gh` serait manque (faux negatif), un agent collant du CRLF serait
 signale a tort (faux positif). Le gate signale, l'humain tranche.
 
-Limite honnete du CONDITIONAL_LIFT (#11201)
--------------------------------------------
-La regex neutralise le marqueur « je merge » au niveau du BODY ENTIER : un
-commentaire contenant a la fois une annonce vraie (« c'est bon, je merge ») et
-une construction conditionnelle (« corrige X et je merge ») est integralement
-de-leve — l'annonce vraie y perd son effet (faux positif possible). La branche
+Limite honnete du CONDITIONAL_LIFT (#11201, resserree #12074)
+-------------------------------------------------------------
+La regex neutralise le marqueur « je merge » quand la construction est
+conditionnelle. #12074 a resserre la neutralisation : un marqueur de levee
+EXPLICITE par son auteur (« je leve ma reserve », « Levee de mon
+CHANGES_REQUESTED ») EN AMONT du match conditionnel preserve le LIFT — « je
+leve ma reserve et je merge » est la formulation naturelle d'une levee, le
+« et je merge » n'y est que la consequence annoncee (comparaison d'offsets,
+cf `_lift_cancelled`). Residuel assume : une annonce NON explicite (« c'est
+bon, je merge ») coexistant avec une construction conditionnelle dans le meme
+body reste integralement de-levee (faux positif possible) — rescaper « je
+merge »/« Merge. » rouvrirait #11201 par la porte de service. La branche
 « des » peut aussi matcher « je merge des PRs » (pluriel direct, pas « dès »).
 Choix assume : le cout d'un faux positif (un flag a trier) est inferieur au
 cout du faux negatif corrige ici (un nit invisible fondu dans sa propre
@@ -169,6 +175,20 @@ CONDITIONAL_LIFT = re.compile(
     r"(et je merge|puis je merge|ensuite je merge"
     r"|je merge (?:dès|des|une fois|quand|après|apres|si\b))", re.I)
 
+# #12074 — marqueurs de levee EXPLICITE par son auteur : quand l'un d'eux
+# PRECEDE le match CONDITIONAL_LIFT, la construction n'est pas une condition —
+# « je leve ma reserve et je merge » : la levee est acquise, le merge n'en est
+# que la consequence annoncee. Distinct des annonces generiques (« je merge »,
+# « Merge. ») : les rescaper rouvrirait #11201 (« corrige X et je merge »
+# redeviendrait une levee). Miroir des entrees d'auteur de LIFT_MARKERS —
+# casse preservee et accents normalises par `_unaccent`, comme pour ces
+# derniers.
+EXPLICIT_LIFT_MARKERS = (
+    "Je lève", "Je leve", "je lève", "je leve",
+    "Levée de", "Levee de", "levée de", "levee de",
+    "Lève la", "Leve la", "lève la", "leve la",
+)
+
 # #11246 — use vs mention : CONDITIONAL_LIFT lisait les exemples CITES du motif
 # comme des usages. Une review qui explique « corrige X et je merge » se
 # flaggait elle-meme (2/15 findings de l'audit --limit 400 : les 2 seules
@@ -185,6 +205,27 @@ _QUOTED_RANGES = re.compile(r"```.*?```|«.*?»|`[^`]*`", re.DOTALL)
 def _strip_quoted(body: str) -> str:
     """Retire les segments cites (guillemets typo, backtick, bloc code)."""
     return _QUOTED_RANGES.sub(" ", body)
+
+
+def _lift_cancelled(stripped: str) -> bool:
+    """#12074 — le CONDITIONAL_LIFT n'annule le LIFT que si AUCUN marqueur de
+    levee explicite d'auteur ne precede le match conditionnel.
+
+    « **Je leve mon CHANGES_REQUESTED** et je merge. » s'auto-bloquait : le
+    « et je merge » annulait le LIFT au niveau du body entier, le commentaire
+    de levee etait re-compte comme un nit de plus, et la reserve qu'il levait
+    redevenait vivante. Le discriminateur est la POSITION — ce qui PRECEDE le
+    connecteur decide : antecedent imperatif (« corrige X et je merge ») =
+    condition bloquante ; antecedent de levee accomplie = consequence
+    annoncee. Les offsets sont compares sur la meme chaine passee par
+    `_strip_quoted` : une levee CITEE (« ... ») ne rescape rien (use vs
+    mention, #11246). `_unaccent` preserve la longueur, donc les offsets de la
+    chaine stripee restent ceux de la chaine originale.
+    """
+    for m in CONDITIONAL_LIFT.finditer(stripped):
+        if not has_marker(stripped[: m.start()], EXPLICIT_LIFT_MARKERS):
+            return True
+    return False
 
 # #11636 — use vs mention, 2e reformulation de la classe #11246 : un rapport
 # de correction qui NOMME le verdict qu'il corrige n'emet pas de reserve. Cas
@@ -594,10 +635,11 @@ def classify(author: str, body: str) -> str | None:
     if author in BOT_LOGINS or not body:
         return None
     stripped = body.lstrip()
-    if has_marker(body, LIFT_MARKERS) and not CONDITIONAL_LIFT.search(_strip_quoted(body)):
+    if has_marker(body, LIFT_MARKERS) and not _lift_cancelled(_strip_quoted(body)):
         return None  # annonce de levee / de merge : resolution, pas reserve
-    # (construction conditionnelle « et je merge » : voir CONDITIONAL_LIFT —
-    # l'annonce conditionnee n'est pas une levee, le commentaire continue)
+    # (construction conditionnelle « et je merge » : voir _lift_cancelled —
+    # l'annonce conditionnee n'est pas une levee, SAUF levee explicite d'auteur
+    # en amont (#12074) ; le commentaire continue sinon)
     if has_live_marker(body, (VERDICT_POSITIVE,)):
         return None  # verdict structurel positif rendu : il decide, la prose ne compte plus
     # #11636 : la recherche porte le body nettoye de ses verdicts MENTIONNES —
@@ -731,7 +773,7 @@ def analyse(pr_data: dict, threads: list[dict], cutoff: datetime) -> dict:
         for c in (pr_data.get("comments") or [])
         if can_lift(c)
         and has_marker(c.get("body", ""), LIFT_MARKERS)
-        and not CONDITIONAL_LIFT.search(_strip_quoted(c.get("body", "")))
+        and not _lift_cancelled(_strip_quoted(c.get("body", "")))
     ]
     explicit_lifts = [x for x in explicit_lifts if x[0] is not None]
 

--- a/scripts/tests/test_check_unaddressed_nits.py
+++ b/scripts/tests/test_check_unaddressed_nits.py
@@ -615,6 +615,43 @@ def test_annonce_vraie_est_une_levee():
     assert mod.classify("myia-ai-01", "C'est bon, je merge.") is None
 
 
+# --- #12074 : « je leve ma reserve et je merge » s'auto-bloquait. Le LIFT
+# etait annule au niveau du BODY ENTIER par le seul « et je merge », meme quand
+# la phrase portait la levee explicite deja accomplie EN AMONT (cas fondateur
+# #11953 : le commentaire de levee re-compte comme un nit, la reserve qu'il
+# levait redevenue vivante). Le discriminateur est la POSITION : un marqueur de
+# levee d'auteur avant le match conditionnel rend la construction announcee
+# (consequence), pas conditionnelle. Les trois cas COTE A COTE — c'est le
+# controle par faux negatif qui protege la classe : sans le troisieme, le
+# correctif se validerait par ses hits et rouvrirait #11201 sous une autre
+# forme.
+
+def test_levee_explicite_puis_et_je_merge_leve():
+    """Cas fondateur #11953 : la formulation naturelle d'une levee par son
+    auteur ne doit plus s'auto-bloquer."""
+    assert mod.classify(
+        "myia-ai-01",
+        "**Je leve mon CHANGES_REQUESTED** et je merge."
+    ) is None
+
+
+def test_levee_explicite_avant_merge_conditionnel_ci_leve():
+    """Le conditionnel porte sur la CI, pas sur une demande a l'auteur."""
+    assert mod.classify(
+        "myia-ai-01",
+        "Levee de ma CHANGES_REQUESTED. Je merge des que la CI passe."
+    ) is None
+
+
+def test_reserve_emise_puis_et_je_merge_reste_un_nit():
+    """Antecedent imperatif, aucune levee en amont : la condition reste
+    bloquante (controle faux-positif de la paire)."""
+    assert mod.classify(
+        "myia-ai-01",
+        "CHANGES_REQUESTED : corrige la ligne 19 et je merge."
+    ) == "BOT-CONCERN"
+
+
 # --- #11246 : use vs mention. CONDITIONAL_LIFT lisait les exemples CITES du
 # motif comme des usages : une review expliquant « corrige X et je merge » se
 # flaggait elle-meme (2/15 findings de l'audit --limit 400, les 2 seules


### PR DESCRIPTION
## Summary

Correctif #12074 : le `CONDITIONAL_LIFT` du merge-gate annulait le LIFT au niveau du **body entier** dès qu'un « et je merge » s'y trouvait — y compris quand la phrase portait une **levee explicite déjà accomplie en amont**. « **Je leve mon CHANGES_REQUESTED** et je merge. » s'auto-bloquait : le commentaire de levee était re-compté comme un nit de plus, et la reserve qu'il levait redevenait vivante (cas fondateur #11953, mesuré par re-post differentiel dans l'issue).

**Le discriminateur est la POSITION** (le remède prescrit par l'issue) : un marqueur de levee explicite d'auteur **en amont** du match conditionnel préserve le LIFT — le « et je merge » n'y est que la conséquence annoncée. Implémenté par comparaison d'offsets (`_lift_cancelled`), sur la même chaîne passée par `_strip_quoted` : une levee CITEE (« … ») ne rescape rien (sémantique use-vs-mention #11246 préservée).

**Garde anti-retour #11201** : les annonces génériques (« je merge », « Merge. ») ne sont PAS rescapées — `EXPLICIT_LIFT_MARKERS` est strictement le miroir des entrées d'auteur de `LIFT_MARKERS` (`Je leve/je lève`, `Levee de/Levée de`, `lève la/leve la`). « Corrige la ligne 19 et je merge » reste une condition bloquante.

## Les 3 contrôles faux-négatif, côte à côte (prescrits par l'issue)

| Corps | Attendu |
|---|---|
| `**Je leve mon CHANGES_REQUESTED** et je merge.` | **LIFT** (était : nit) |
| `Levee de ma CHANGES_REQUESTED. Je merge des que la CI passe.` | **LIFT** (le conditionnel porte sur la CI, pas sur une demande à l'auteur) |
| `CHANGES_REQUESTED : corrige la ligne 19 et je merge.` | **nit** (doit le rester — antécédent impératif, aucune levee en amont) |

## Mesure corpus (l'audit demandé par l'issue)

Sonde sur les **400 dernières PRs mergees** (mêmes prédicats que le module, `gh pr list --json comments,reviews`) :

- corps avec match `CONDITIONAL_LIFT` : **12**
- rescapés par levee explicite en amont : **2** — #11953 (comment jsboige, le cas fondateur) et #11615 (review ai-01)
- restent conditionnels (correctement bloquants) : **10** — le discriminateur ne sur-rescue pas

## Validation

- `pytest` : **137/137** (3 nouveaux + tous les existants, dont la paire minimale #11201 `test_lift_conditionnel_nest_pas_une_levee` qui reste BOT-CONCERN, et les cas cités #11246).
- **Gate end-to-end sur #11953 avec la formulation d'origine** : `OK PR #11953 — aucun nit non leve. (rc=0)` — était `BLOCKED` avant le fix (2 nits : la levee elle-même + la reserve qu'elle levait).
- Audit compagnon `nit_lift_authorship.py` mis à jour en lockstep (même prédicat `_lift_cancelled`, docstring corrigée) — pas de divergence gate/audit.
- Docstring « Limite honnete du CONDITIONAL_LIFT » resserrée : le résiduel assumé (annonce NON explicite + condition dans le même body) est documenté comme tel.

## Diff

3 fichiers, +91/−12. Aucun notebook touché, catalogue byte-identique à main.

Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-dotnet (#12084)

Closes #12074
