### PR TITLE
fix(guards,#12064): detect code stubs moved into markdown cells (code_stmt_in_markdown + selfcheck wire-up)

### DIFF
--- a/.github/workflows/markdown-rendering-guard.yml
+++ b/.github/workflows/markdown-rendering-guard.yml
@@ -75,6 +75,14 @@ jobs:
       - name: "Install detector dependencies (pyyaml for the closure scan)"
         run: pip install pyyaml
 
+      # #12064: the embedded positive/negative controls were documented as
+      # "the guard workflow runs it" but nothing called --selfcheck -- a rule
+      # refactor losing an observed defect form would have passed CI silently.
+      # Runs the controls for ALL rules that carry them (yaml_block_open_no_close
+      # both outage forms, code_stmt_in_markdown stub/indent/fence game).
+      - name: "Rule selfcheck -- embedded positive/negative controls"
+        run: python scripts/notebook_tools/detect_markdown_rendering.py --selfcheck
+
       - name: "HARD gate -- fail on any NEW frontmatter / setext oversize"
         run: |
           if ! python scripts/notebook_tools/detect_markdown_rendering.py \

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb
@@ -14,8 +14,6 @@
     "tags": []
    },
    "source": [
-    "Grain: DEEP/notebook-python — lane myia-po-2024:CoursIA-2 — prev: DEEP/notebook-python #10283\n",
-    "\n",
     "# PT-11 — RLVR sur VRAI LLM (Qwen3.5-0.8B) + rewardspy.watch ONLINE + Z3 Tier-1 verifier\n",
     "\n",
     "**Serie** : Post-Training SOTA 2024-2025 (Epic #1742, PT-11 = sous-axe RLVR de #10289)\n",

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11b_multiseed_qwen35_4x100.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11b_multiseed_qwen35_4x100.ipynb
@@ -5,8 +5,6 @@
    "id": "e02ac28f",
    "metadata": {},
    "source": [
-    "Grain: DEEP/training — lane myia-po-2024:CoursIA-2 — prev: DEEP/training #10317\n",
-    "\n",
     "# PT-11b — RLVR multi-seed sur Qwen3.5-0.8B (4 seeds × 100 steps)\n",
     "\n",
     "## Objectif\n",

--- a/scripts/notebook_tools/detect_markdown_rendering.py
+++ b/scripts/notebook_tools/detect_markdown_rendering.py
@@ -105,6 +105,12 @@ RULE_SEVERITY = {
     "oversized_hint": WARN,
     "heading_in_list": WARN,
     "source_list_missing_newlines": ERROR,
+    # #12064: ERROR (bloquant) -- the corpus measure is 1 hit / 20,576 markdown
+    # cells (the true positive (A) PT_11 cell 5), reproduced by this lane. That
+    # precision is what buys blocking status; a wider pattern set would need
+    # its own FP re-measure first ([[handrolled-pattern-set-undercounts-silently]]
+    # cuts both ways: widening silently under- AND over-counts).
+    "code_stmt_in_markdown": ERROR,
 }
 
 # a line that is *only* dashes/equals of length >= 3 (setext underline / thematic break)
@@ -130,6 +136,24 @@ _HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.*)$")
 # drift gate on new hits is #11829 sous-issue #2. See #11829.
 _CONTAINER_HEADING_RE = re.compile(
     r"^(?:[ \t]*(?:[-*+]|\d+[.)]|>)[ \t]+){1,3}(#{1,6})\s+(.*\S)\s*$")
+
+# #12064 -- a bare code-statement line in a markdown cell. A stub MOVED from a
+# code cell into markdown renders as prose (not code), is invisible to
+# count_exercises.py (it counts code cells), and to the H.3 pre-commit (a
+# markdown cell has neither execution_count nor outputs to fail on) -- the
+# move doesn't satisfy H.3, it makes H.3 inapplicable. Observed on PR #11952
+# cells 15/17/19 (Console.WriteLine exercise stubs) and on main as PT_11
+# cell 5 (a Papermill `parameters` anchor that never executes, contradicting
+# the executed cell 4). The leading `(?: {0,3})` is load-bearing: a block
+# indented 4+ spaces is a legitimate markdown indented-code block and must
+# NOT match (measured: excluding it drops corpus noise by ~3x -- 3 hits
+# become 1). Pattern set deliberately narrow (8 forms, the observed class);
+# widening requires re-measuring FPs with new positive controls.
+_STMT_LINE_RE = re.compile(
+    r"^(?: {0,3})("
+    r"Console\.WriteLine\(|print\(|return\s+\S|import\s+\w|"
+    r"using\s+\w+;|def\s+\w+\(|var\s+\w+\s*=|#r\s+\"nuget)"
+)
 
 # single-element newline-stripping artifact: a markdown cell whose `source` is a
 # one-element list whose string has 0 '\n', starts with an ATX heading, and is long.
@@ -287,6 +311,44 @@ def _selfcheck() -> int:
     print("selfcheck OK: yaml_block_open_no_close fires on both observed forms "
           "(FallacyDetection/02 + SL-8), silent on bare divider / complete "
           "frontmatter / prose")
+
+    # ---- code_stmt_in_markdown (#12064) ----------------------------------------
+    # Positive control = the cell-15 fixture of PR #11952 verbatim; negatives =
+    # the two LEGITIMATE renderings of the same code (indented-4 block, fenced
+    # block) plus plain prose. Validates through scan_cell (the real entry
+    # point), not just the regex.
+    stmt_fixtures: list[tuple[str, str, bool]] = [
+        ("PR #11952 cell 15 (Console.WriteLine stub, bare)",
+         'Exercice 5 -- affichez la valeur.\nConsole.WriteLine("Exercice 5 a completer");\n',
+         True),
+        ("PT_11 cell 5 (parameters anchor, print())",
+         '# Set True for real training on GPU.\n'
+         'LOAD_MODEL_AND_TRAIN = False\n'
+         'print(f"LOAD_MODEL_AND_TRAIN = {LOAD_MODEL_AND_TRAIN}")\n',
+         True),
+        ("same stub, indented 4 spaces (legit code block)",
+         "Exercice 5 -- affichez la valeur.\n\n    Console.WriteLine(\"Exercice 5 a completer\");\n",
+         False),
+        ("same stub, inside a fence (legit code block)",
+         "Exercice 5 -- affichez la valeur.\n\n```csharp\nConsole.WriteLine(\"Exercice 5 a completer\");\n```\n",
+         False),
+        ("plain prose (no statement line)",
+         "# Titre\n\nUn paragraphe qui explique l'exercice, sans code nu.\n",
+         False),
+    ]
+    for name, src, expected in stmt_fixtures:
+        fired = any(f["rule"] == "code_stmt_in_markdown"
+                    for f in scan_cell({"cell_type": "markdown", "source": src}))
+        if fired != expected:
+            failed.append(f"{name}: code_stmt_in_markdown fired={fired}, expected={expected}")
+    if failed:
+        print("selfcheck FAIL:", file=sys.stderr)
+        for f in failed:
+            print(f"  !! {f}", file=sys.stderr)
+        return 1
+    print("selfcheck OK: code_stmt_in_markdown fires on both observed forms "
+          "(#11952 stub + PT_11 parameters anchor), silent on indented block / "
+          "fence / prose")
     return 0
 
 
@@ -523,6 +585,28 @@ def scan_cell(cell) -> list[dict]:
             "hash": _cell_hash(rule, text),
         })
         break
+
+    # ---- bare code statement in markdown (#12064) --------------------------------
+    # Fence-aware AND indent-aware: a statement inside a ``` fence renders as
+    # code (legit), and a block indented 4+ spaces is an indented-code block
+    # (legit). The `_STMT_LINE_RE` leading `(?: {0,3})` carries the indent
+    # exclusion; the `idx in fenced` skip carries the fence exclusion.
+    for idx, ln in enumerate(lines):
+        if idx in fenced:
+            continue
+        if _STMT_LINE_RE.match(ln):
+            rule = "code_stmt_in_markdown"
+            findings.append({
+                "rule": rule,
+                "severity": RULE_SEVERITY[rule],
+                "message": ("bare code statement in a markdown cell renders as prose, is "
+                            "invisible to count_exercises.py, and escapes the H.3 pre-commit "
+                            "(a markdown cell has no execution_count to be null). Either "
+                            "restore it as a code cell or wrap it in a ``` fence"),
+                "evidence": ln.strip()[:100],
+                "hash": _cell_hash(rule, text),
+            })
+            break  # one per cell is enough
 
     return findings
 

--- a/scripts/notebook_tools/markdown_rendering_baseline.json
+++ b/scripts/notebook_tools/markdown_rendering_baseline.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Baseline of known markdown-rendering violations. Burn down, do not grow. Regenerate with: python scripts/notebook_tools/detect_markdown_rendering.py --update-baseline --baseline <this file>",
-  "count": 1538,
+  "count": 1539,
   "hashes": [
     "0003f02b5512ca82",
     "003624867aaca533",
@@ -378,6 +378,7 @@
     "3b543cb23623e631",
     "3bf2761ba4b77097",
     "3c377f423d516048",
+    "3c3e8c1edb1f911c",
     "3c85f4dfd5b95969",
     "3cb9b58846a4fbc2",
     "3cdb59c1f0df70d3",

--- a/scripts/notebook_tools/tests/test_detect_markdown_rendering_stmt.py
+++ b/scripts/notebook_tools/tests/test_detect_markdown_rendering_stmt.py
@@ -1,0 +1,87 @@
+"""Tests for the CODE-STATEMENT-IN-MARKDOWN rule (#12064).
+
+A stub MOVED from a code cell into a markdown cell renders as prose, is
+invisible to count_exercises.py (it counts code cells), and escapes the H.3
+pre-commit (a markdown cell has neither execution_count nor outputs to fail
+on) -- the move does not satisfy H.3, it makes it inapplicable. Observed on
+PR #11952 (Console.WriteLine exercise stubs, cells 15/17/19) and on main as
+PT_11 cell 5 (a Papermill `parameters` anchor that never executes).
+
+Locks in, for detect_markdown_rendering.py (rule code_stmt_in_markdown):
+  - true positives: the cell-15 fixture of #11952 verbatim; the PT_11
+    parameters-anchor form
+  - true negatives: the two LEGITIMATE renderings of the same code
+    (indented-4 block, fenced block) and plain prose -- the acceptance's
+    false-negative game, without which a pattern set validates on its hits
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from detect_markdown_rendering import scan_cell  # noqa: E402
+
+
+def _rules(source: str) -> list[str]:
+    return [f["rule"] for f in scan_cell({"cell_type": "markdown", "source": source})]
+
+
+# ---------------------------------------------------------------------------
+# True positives -- the two observed forms (#12064 acceptance)
+# ---------------------------------------------------------------------------
+
+def test_pr11952_cell15_fixture_fires():
+    """Controle positif prescrit par l'acceptance : la cellule 15 de #11952
+    (stub d'exercice Console.WriteLine deplace en markdown sans fence)."""
+    src = ("Exercice 5 -- affichez la valeur.\n"
+           'Console.WriteLine("Exercice 5 a completer");\n')
+    assert "code_stmt_in_markdown" in _rules(src)
+
+
+def test_pt11_parameters_anchor_fires():
+    """Instance (A) mesuree sur main : l'ancre Papermill en markdown."""
+    src = ("# Set True for real training on GPU.\n"
+           "LOAD_MODEL_AND_TRAIN = False\n"
+           'print(f"LOAD_MODEL_AND_TRAIN = {LOAD_MODEL_AND_TRAIN}")\n')
+    assert "code_stmt_in_markdown" in _rules(src)
+
+
+def test_python_statement_forms_fire():
+    for line in ("import numpy as np\n", "return 42\n", "def solve(x):\n"):
+        assert "code_stmt_in_markdown" in _rules(line), line
+
+
+def test_csharp_statement_forms_fire():
+    for line in ("using System;\n", "var q = new Queue();\n", '#r "nuget: ...\n'):
+        assert "code_stmt_in_markdown" in _rules(line), line
+
+
+# ---------------------------------------------------------------------------
+# True negatives -- the legitimate renderings (acceptance: jeu de
+# faux-negatifs cote a cote, pas seulement les hits)
+# ---------------------------------------------------------------------------
+
+def test_indented_block_is_silent():
+    """Non-regression prescrite : un bloc indente 4 espaces est du code
+    markdown legitime (l'exclusion qui fait tomber le bruit corpus d'un
+    facteur ~3)."""
+    src = ("Exercice 5 -- affichez la valeur.\n\n"
+           '    Console.WriteLine("Exercice 5 a completer");\n')
+    assert "code_stmt_in_markdown" not in _rules(src)
+
+
+def test_fenced_block_is_silent():
+    src = ("Exercice 5 -- affichez la valeur.\n\n"
+           '```csharp\nConsole.WriteLine("Exercice 5 a completer");\n```\n')
+    assert "code_stmt_in_markdown" not in _rules(src)
+
+
+def test_plain_prose_is_silent():
+    src = "# Titre\n\nUn paragraphe qui parle de print() sans commencer par lui.\n"
+    assert "code_stmt_in_markdown" not in _rules(src)
+
+
+def test_prose_mentioning_print_midline_is_silent():
+    """`print(` mid-ligne n'est pas un statement nu : l'ancre ^ le garantit."""
+    src = "On utilisera print(...) pour afficher, puis return pour renvoyer.\n"
+    assert "code_stmt_in_markdown" not in _rules(src)


### PR DESCRIPTION
## Summary

Organe #12064 : un **stub de code déplacé en cellule `markdown`** rend en prose, est invisible à `count_exercises.py` (il compte les cellules code) et échappe au pre-commit **H.3** (une cellule markdown n'a ni `execution_count` ni `outputs` sur lesquels échouer) — le déplacement ne satisfait pas H.3, il le rend **inapplicable**. Formes observées : PR #11952 cells 15/17/19 (stubs `Console.WriteLine` d'exercices) et main PT_11 cell 5 (ancre Papermill `parameters` en markdown qui ne s'exécute jamais, contredisant la cellule 4 exécutée qui pose la valeur opposée).

## Ce qui est livré

| Élément | Détail |
|---|---|
| Règle `code_stmt_in_markdown` (ERROR) | ligne d'instruction nue **hors fence** et **hors bloc indenté 4 espaces** — la sonde de l'issue à l'identique (`Console.WriteLine(`, `print(`, `return X`, `import X`, `using X;`, `def x(`, `var x =`, `#r "nuget`). Le `(?: {0,3})` de tête est ce qui fait tomber le bruit corpus d'un facteur ~3 (3 hits → 1). Jeu de motifs volontairement étroit : tout élargissement exige sa propre re-mesure FP |
| Mesure corpus reproduite | **1 hit / 20 576 cellules markdown** = exactement le vrai positif (A) PT_11 cell 5 (`print(f"LOAD_MODEL_AND_TRAIN = ...")`) — mesure de l'issue reproduite par cette lane, d'où le statut **ERROR bloquant** (acceptance 5) |
| Instance (A) | **baselinée** (+1 hash chirurgical, CRLF préservé) — dette documentée jusqu'à son fix dans **#12028** (véhicule désigné par l'issue, lane po-2024 ; signalement posté). `--check --baseline` sur le corpus : **OK rc=0** |
| Instance (B) corrigée | le tag de coordination `Grain:` retiré de la cellule 0 des **2** notebooks PT_11* (2−/2− chacun, édition textuelle pure sans resérialisation ; la cellule 0 ouvre désormais directement sur le titre pédagogique) |
| Selfcheck câblé | le `_selfcheck` embarqué était documenté comme « the guard workflow runs it » — **rien ne l'appelait** (drift doc/réel réparé) : step ajouté dans `markdown-rendering-guard.yml` AVANT le HARD gate. Fixtures étendues : cell-15 #11952 + forme (A) + les 3 négatifs (indenté 4, fence, prose) |
| Suite pytest | `test_detect_markdown_rendering_stmt.py` : **8 tests** — les 2 formes observées, 4 formes statement (py + C#), et les 4 négatifs dont le **bloc indenté 4 espaces** prescrit par l'acceptance 1 |

## Validation

- `pytest` : 8/8 nouveaux + 26/26 (`test_scan_md_hierarchy_list_item` + `test_fix_source_newlines`, non-régression des règles existantes du détecteur).
- `--selfcheck` : 2× OK (yaml_block_open_no_close intact + nouvelle règle).
- `--check --baseline` sur `MyIA.AI.Notebooks` complet : **OK rc=0** (le hit (A) est baseliné, aucun nouveau ERROR).
- Contrôle positif réel : le scan désigne précisément `PT_11 cell#5` — pas un hit vague.

## Résiduel (hors scope, mesuré)

- **(A)** vit toujours sur main (baseliné) — son fix appartient à #12028 (cellule 5 → cellule code taguée `parameters` ou suppression au profit de la cellule 4). Signalement posté sur la PR.
- La baseline porte par ailleurs **3 WARN `heading_in_list` nouveaux** (SemanticKernel 10b cells 18/25/35) et **52 hashes brûlés** (violations corrigées depuis la dernière regen) — maintenance baseline = grain séparé, pas mélangé ici (diff baseline = +2/−1 chirurgical).
- Le scan porte sur `MyIA.AI.Notebooks/**` (périmètre de l'issue) ; `slides/`, `scripts/`, `GradeBookApp/` non mesurés (déclaré dans l'issue).

## Diff

6 fichiers, +181/−5 (dont +87 tests, +84 détecteur, +8 workflow, 2×2− notebooks, +2/−1 baseline).

Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling (#12085)
<!-- genre requalifie par ai-01 au merge : declare `tooling`, mais la PR pose `"code_stmt_in_markdown": ERROR`, un verdict susceptible de rougir -> `guard` (variation-protocol, discriminant guard/tooling). Le champ `prev:` est laisse tel qu'il a ete declare. -->

See #12064 (l'acceptance 2 « report 0 » sera atteinte quand (A) sera corrigé dans #12028 ; l'acceptance 3 est explicitement déléguée à ce véhicule par l'issue)

