### PR TITLE
fix(guards,#12075): auto-fix decorative --- cell openers at pre-commit (fix-hr-separator hook)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,27 @@ repos:
         files: '\.ipynb$'
         stages: [pre-commit]
 
+      - id: fix-hr-separator
+        name: Auto-fix decorative '---' cell openers (yaml_block_open_no_close)
+        description: |
+          Auto-converts a decorative `---` opening a markdown cell into `***`
+          (same `<hr>` render, no YAML semantics) on staged notebooks — the
+          fix for the `yaml_block_open_no_close` rule that the
+          markdown-rendering guard below blocks. The density rollouts
+          (#11601/#11271) prefix enriched cells with a decorative `---`,
+          which opened a Pandoc YAML metadata block that never closes: 140
+          occurrences across 14 open PRs at #12075. Declared BEFORE the
+          blocking guard so the pipeline auto-fixes then verifies (same
+          pattern as fix-source-newlines). The tool does not touch code
+          blocks, setext underlines, or a real cell-0 frontmatter; outputs
+          and execution_count are byte-intact (no re-execution, no falsified
+          proof). See #11451 (tool) and #12075 (this wiring).
+        entry: python scripts/notebook_tools/fix_hr_separator.py --apply
+        language: system
+        pass_filenames: true
+        files: '\.ipynb$'
+        stages: [pre-commit]
+
       - id: markdown-rendering-guard
         name: Block NEW oversized markdown-rendering defects (frontmatter / setext)
         description: |

--- a/scripts/check_hooks_parity.py
+++ b/scripts/check_hooks_parity.py
@@ -26,7 +26,8 @@ names a target it stopped watching.
 
 The PyYAML-aware walker in this script reads the YAML structure
 instead of line regexes, so the pairing is correct (gitleaks has no
-entry, and the five local hooks are each paired with their own entry).
+entry, and every local hook is paired with its own entry -- the count
+follows the config: 7 as of #12075).
 
 What it checks
 --------------


### PR DESCRIPTION
## Summary

Piste **(a)** de #12075 : le correctif des 14 PRs bloquées existait déjà (`fix_hr_separator.py`, bâti pour #11451) mais **rien ne l'invoquait au moment du commit** — chaque lane devait y penser après coup, et le patron d'écriture des rollouts de densité réintroduisait le défaut à chaque tranche. Ce PR câble l'outil en **hook pre-commit auto-fix**, sur le pattern maison `fix-source-newlines` :

- **hook `fix-hr-separator`** (`--apply`, `pass_filenames: true`, `files: '\.ipynb$'`) déclaré **AVANT** le hook bloquant `markdown-rendering-guard` — l'ordre de déclaration est l'ordre d'exécution, donc le pipeline **répare puis vérifie** : un `---` décoratif committé est converti en `***` (même rendu `<hr>`, aucune sémantique YAML), et le gate d'aval confirme.
- L'outil ne touche ni les blocs de code, ni les soulignements setext, ni un vrai frontmatter de cellule 0 ; **outputs et `execution_count` byte-intacts** (aucune re-exécution, aucune preuve falsifiée — rapporté par l'issue, revérifié par le contrôle e2e ci-dessous).

## Contrôle end-to-end (wiring prouvé, pas supposé)

Fixture reproduisant le patron du rollout (2 cellules markdown ouvrant sur `---` + 1 cellule code avec output commité) :

| Étape | Résultat |
|---|---|
| `detect_markdown_rendering --check` avant | **rc=1** (2 × `yaml_block_open_no_close`) |
| `fix_hr_separator --apply` | 2 séparateurs convertis, rc=0 |
| `--check` après | **rc=0** |
| Intégrité | cellule code : `execution_count: 1`, outputs 1 — intacts |
| **`pre-commit run fix-hr-separator` sur fixture sale** | le hook **déclaré** s'exécute et convertit (pre-commit invoque bien l'entry) |

## Validation

- `pytest test_fix_hr_separator.py` : **10/10** ; `test_detect_markdown_rendering_stmt.py` : 8/8 (non-régression).
- `setup_hooks.py --check-parity` : **7 local hooks wired** (le nouveau reconnu), validate-config OK, gitleaks 8.24.3 inchangé.
- Docstring `check_hooks_parity.py` : le compte figé « five local hooks » datait d'avant les strip-hooks — remplacé par un compte qui suit la config (7).

## Hypothèse consignée (choix (a) vs (b))

L'issue marquait les deux pistes « à arbitrer ». Piste (a) retenue par cette lane car **additive et lane-agnostique** (protège toute tranche future, quelle que soit la lane et son gabarit) ; la piste (b) (corriger le gabarit d'enrichissement pour émettre `***` directement) reste à arbitrer côté coord — le patron vit dans les écritures du rollout #11601. **L'action par-lane sur les 14 PRs existantes reste aux lanes propriétaires** (aucune de ces PRs n'est à ma lane) — toutefois les tranches futures n'auront plus le défaut : le pre-commit le convertit avant le push.

## Diff

2 fichiers, +23/−1 (aucun notebook, catalogue byte-identique).

Grain: MED/tooling -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python (#12094)

See #12075 (piste a ; piste b + action par-lane restent ouvertes)
