### PR TITLE
fix(secrets): retirer le hash bcrypt inline de validate_auth.py + les prints de prefixe de token

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/validate_auth.py
+++ b/MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/validate_auth.py
@@ -18,7 +18,7 @@ print(f"Validating ComfyUI Auth at {BASE_URL}")
 
 def test_token(token_name, token_value):
     print(f"\n--- Testing with {token_name} ---")
-    print(f"Token: {token_value[:10]}...")
+    print(f"Token: {'fourni' if token_value else '(absent)'}")
     
     headers = {"Authorization": f"Bearer {token_value}"}
     try:
@@ -38,16 +38,23 @@ def test_token(token_name, token_value):
 print("\n--- Testing Client Auto-Discovery ---")
 try:
     client = create_client()
-    print(f"Client loaded token: {client.api_token[:10] if client.api_token else 'None'}...")
+    print(f"Client loaded token: {'configure' if client.api_token else '(non configure)'}")
     stats = client.get_system_stats()
     print("✅ Success with Auto-Discovery!")
 except Exception as e:
     print(f"❌ Failed with Auto-Discovery: {e}")
 
-# Test 2: Explicit check with known hash (sanity check)
-# This hash is what we expect the server to use
-EXPECTED_HASH = "$2b$12$6707ngR1uLGnTOFpgBRZDunYJ9PrnE7J86byQKxSZ1EQAQwbz/1Zy"
-success_hash = test_token("EXPECTED HASH TOKEN", EXPECTED_HASH)
+# Test 2: explicit check against the token the server is configured with.
+# The value lives in .secrets/master.env (gitignored) and is propagated to each
+# consumer .env by scripts/secrets/render_envs.py -- never inline here.
+EXPECTED_HASH = os.getenv("COMFYUI_API_TOKEN")
+if not EXPECTED_HASH:
+    print("")
+    print("[skip] COMFYUI_API_TOKEN absent de l'environnement.")
+    print("       Renseigner .secrets/master.env puis:")
+    print("         python scripts/secrets/render_envs.py")
+    sys.exit(1)
+success_hash = test_token("COMFYUI_API_TOKEN", EXPECTED_HASH)
 
 if success_hash:
     print("\n✅ VALIDATION SUCCESSFUL: Authentication is working correctly.")

--- a/docs/archive/suivis/genai-image/phase-29-corrections-qwen-20251031-111200/rapports/22-installation-complete-test-final-20251210-140149.md
+++ b/docs/archive/suivis/genai-image/phase-29-corrections-qwen-20251031-111200/rapports/22-installation-complete-test-final-20251210-140149.md
@@ -34,7 +34,7 @@ Installation MASTER en 7 parties pour ComfyUI Qwen avec authentification.
 - **État**: success
 - **Hash synchronisé**: True
 - **Token**: `2%=tVJ6@!Nc(7#VTvj-Bh3^nm0WY-L...`
-- **Hash**: `$2b$12$6707ngR1uLGnTOFpgBRZDun...`
+- **Hash**: `[redacted]` (cf. secrets-hygiene regle 2)
 - **Message**: Credentials synchronisés
 
 ### PARTIE 4 : Redémarrage Docker


### PR DESCRIPTION
`Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #12090`

## Ce qui était committé

`MyIA.AI.Notebooks/GenAI/00-GenAI-Environment/validate_auth.py` portait, depuis `22a009a64` (2025-12-10), **trois** violations de [`secrets-hygiene.md`](.claude/rules/secrets-hygiene.md) dans 55 lignes :

| Ligne | Contenu | Règle violée |
|---|---|---|
| 21 | `print(f"Token: {token_value[:10]}...")` | règle 6 cas (C) — source-leak, pattern nommé **verbatim** |
| 41 | `print(f"Client loaded token: {client.api_token[:10] ...}...")` | idem |
| 48 | `EXPECTED_HASH = "$2b$12$…"` (60 car., **complet**), passé en `Bearer` | règle 2 — « JAMAIS de littéraux inline » |

CodeQL le signalait déjà : `py/clear-text-logging-sensitive-data` HIGH, alerte ouverte sur le scan par défaut. Ce n'était pas un faux positif.

## Correctif

- Le littéral cède la place à `os.getenv("COMFYUI_API_TOKEN")` — **sans fallback littéral** — avec sortie explicite (`exit 1`) et renvoi vers `.secrets/master.env` + `render_envs.py` quand la variable manque. C'est le pattern prescrit par la règle 3.
- Les deux `print` de préfixe deviennent des indicateurs de présence (`'configure'` / `'(non configure)'`), le correctif littéralement écrit dans la règle 6.
- Le seul autre fichier tracé portant ce **hash** (un rapport archivé) le voit rédigé.

## Ce que je n'ai *pas* touché, et pourquoi

Le rapport archivé porte aussi un préfixe de **mot de passe** en clair. Je l'ai d'abord rédigé, puis restauré après mesure :

- il est **tronqué** (30 car. suivis de `...`) ;
- **12 rapports frères** le portent à l'identique — en rédiger 1 sur 13 produit de l'incohérence, pas de la sécurité ;
- `.gitleaks.toml` (l. 60 et 253) le **documente explicitement** comme échantillon d'alphabet allowlisté, issu d'un `docker-compose-no-auth.yml` archivé.

Autrement dit : cette valeur-là a déjà été triée en connaissance de cause. Le hash de 60 caractères, lui, ne l'était pas.

## Rotation

La valeur committée **ne correspond pas** au `COMFYUI_API_TOKEN` courant de `.secrets/master.env` — comparaison par égalité, la valeur n'a jamais été imprimée. **Le credential a déjà été rotaté.** Pas de réécriture d'historique (règle 5) ; si une machine du cluster tourne encore sur l'ancien token, c'est à elle de rotater.

## Vérifications

```
$ python -c "import ast,pathlib;ast.parse(...)"     -> SYNTAX OK
$ git grep -c '6707ngR1uLGnTOFpgBRZDun' -- .        -> 0
$ grep -nE 'api_token\[|token_value\[' validate_auth.py -> aucune
$ pre-commit  (gitleaks)                            -> Passed
```

Aucun notebook n'est modifié : C.2/C.3 sans objet, pas de ré-exécution due.

See #12101 (triage des 19 alertes `clear-text-*` restantes) · See #12100 (les commentaires `# codeql[…]` sont inertes ici)
