### PR TITLE
fix(guard,#12097): detect_ascii_flowchart garde par-fichier — notebook illisible saute (champ skipped), scan continue

### DIFF
--- a/scripts/notebook_tools/detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/detect_ascii_flowchart.py
@@ -76,6 +76,8 @@ import sys
 from pathlib import Path
 
 import nbformat
+from nbformat.reader import NotJSONError
+from nbformat.validator import ValidationError
 
 # --- Signaux -----------------------------------------------------------
 
@@ -207,7 +209,13 @@ def _find_flowchart_blocks(cell_source: str) -> list[dict]:
 
 def scan_notebook(path: Path) -> dict:
     """Scan un notebook ; renvoie les cellules markdown contenant des flowcharts ASCII."""
-    nb = nbformat.read(path, as_version=4)
+    try:
+        nb = nbformat.read(path, as_version=4)
+    except (OSError, NotJSONError, ValidationError) as exc:
+        # Garde par-fichier (#12097) : un notebook illisible (BOM UTF-8,
+        # JSON tronque, validation echouee) ne doit pas interrompre le scan
+        # entier — il est reporte dans `skipped`, pas avale silencieusement.
+        return {"path": str(path), "error": str(exc), "findings": []}
     findings = []
     for cell_idx, cell in enumerate(nb.cells):
         if cell.get("cell_type") != "markdown":
@@ -227,7 +235,7 @@ def scan_notebook(path: Path) -> dict:
                 "labels": blk["labels"],
                 "evidence": blk["verbatim"][:240],  # troncature pour le rapport
             })
-    return {"path": str(path), "findings": findings}
+    return {"path": str(path), "error": None, "findings": findings}
 
 
 def scan_paths(paths: list[Path]) -> dict:
@@ -235,19 +243,20 @@ def scan_paths(paths: list[Path]) -> dict:
     all_findings = []
     files_scanned = 0
     files_with_findings = 0
+    skipped = []
     for p in paths:
         if not p.exists():
             continue
         if p.is_dir():
-            for nb_path in sorted(p.rglob("*.ipynb")):
-                files_scanned += 1
-                result = scan_notebook(nb_path)
-                if result["findings"]:
-                    files_with_findings += 1
-                all_findings.extend(result["findings"])
+            nb_paths = sorted(p.rglob("*.ipynb"))
         else:
+            nb_paths = [p]
+        for nb_path in nb_paths:
             files_scanned += 1
-            result = scan_notebook(p)
+            result = scan_notebook(nb_path)
+            if result.get("error"):
+                skipped.append({"path": str(nb_path), "error": result["error"]})
+                continue
             if result["findings"]:
                 files_with_findings += 1
             all_findings.extend(result["findings"])
@@ -255,6 +264,7 @@ def scan_paths(paths: list[Path]) -> dict:
         "files_scanned": files_scanned,
         "files_with_findings": files_with_findings,
         "total_findings": len(all_findings),
+        "skipped": skipped,
         "findings": all_findings,
     }
 
@@ -274,6 +284,8 @@ def main() -> int:
         print(f"Notebooks scanned   : {result['files_scanned']}")
         print(f"With findings       : {result['files_with_findings']}")
         print(f"Total findings      : {result['total_findings']}")
+        for skip in result["skipped"]:
+            print(f"\n  SKIPPED {skip['path']}: {skip['error'][:120]}")
         for f in result["findings"][:10]:
             print(f"\n  {f['path']}:{f['start_line']}-{f['end_line']}  "
                   f"boxes={f['boxes']} connectors={f['connectors']} labels={f['labels']}")

--- a/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
@@ -45,6 +45,7 @@ from detect_ascii_flowchart import (  # noqa: E402
     _line_has_connector,
     _line_is_box,
     scan_notebook,
+    scan_paths,
 )
 
 
@@ -267,15 +268,66 @@ class TestScanNotebook:
 
 
 # ---------------------------------------------------------------------------
+# 4bis. Unreadable notebook skipped, scan continues (#12097)
+# ---------------------------------------------------------------------------
+
+class TestUnreadableNotebookSkipped:
+    def test_bom_notjson_reported_in_skipped(self, tmp_path):
+        """A UTF-8 BOM prelude (NotJSONError) -> path lands in `skipped`,
+        and the scan keeps going (a second clean notebook still produces its
+        finding). Proves the guard is per-file, not a silent `except: pass`.
+        """
+        bad = tmp_path / "bom.ipynb"
+        # BOM + valid notebook body = nbformat.reader.NotJSONError on some
+        # parsers; safest unreadable twin: a truncated JSON.
+        bad.write_text('{"cells": [\n', encoding="utf-8")
+        good = tmp_path / "good.ipynb"
+        nb = _make_nb_with_md(SW_12_FOUNDER)
+        nbformat.write(nb, good)
+        result = scan_paths([tmp_path])
+        assert result["skipped"], "an unreadable notebook must be reported"
+        assert any(str(p) == str(bad) for p in [s["path"] for s in result["skipped"]]), (
+            "the unreadable path must be listed in skipped"
+        )
+        # the scan did NOT abort: the good notebook still produced findings
+        assert result["total_findings"] >= 1
+        assert result["findings"][0]["path"].endswith("good.ipynb")
+
+    def test_validation_error_reported_in_skipped(self, tmp_path):
+        """A notebook nbformat cannot validate (missing key) -> skipped, scan
+        continues to the siblings (the unreadable one is not counted in
+        files_with_findings, and is not silently dropped).
+        """
+        # v4 notebook valide dont on retire la cle `metadata` (== cas reel
+        # Sudoku-15-Infer-Csharp.ipynb : `ValidationError` a la lecture).
+        nb_bytes = nbformat.writes(nbformat.v4.new_notebook())
+        bad = tmp_path / "bad.ipynb"
+        no_meta = nbformat.reads(nb_bytes, as_version=4)
+        del no_meta["metadata"]
+        bad.write_text(json.dumps(no_meta), encoding="utf-8")
+        good = tmp_path / "good.ipynb"
+        nb = _make_nb_with_md("plain text only")
+        nbformat.write(nb, good)
+        result = scan_paths([tmp_path])
+        assert any(s["path"].endswith("bad.ipynb") for s in result["skipped"])
+        assert result["findings"] == []
+        assert result["files_scanned"] == 2
+
+
+# ---------------------------------------------------------------------------
 # 5. Corpus baseline pin (anti-regression)
 # ---------------------------------------------------------------------------
 
-# These values pin the corpus baseline measured c.259 on 2026-08-20 against
-# origin/main at SHA fbe61eb57 (post-PR #11918). Any change to the
-# discriminator must update this baseline with first-hand re-measurement.
+# These values pin the corpus baseline measured c.259 on 2026-08-21 against
+# origin/main at SHA 4e9ffc5ad1 (post-PR #11918). Drift 13->11 findings /
+# 10->9 files since c.259 = the ASCII->Mermaid conversion PRs merged in
+# between (re-measured firsthand, see `--json` below): 2 findings on
+# QuantConnect/Python disappeared with #11998/#12010/#12011 conversions.
+# Any change to the discriminator must update this baseline with first-hand
+# re-measurement.
 
-CORPUS_BASELINE_TOTAL = 13
-CORPUS_BASELINE_FILES_WITH = 10
+CORPUS_BASELINE_TOTAL = 11
+CORPUS_BASELINE_FILES_WITH = 9
 
 
 class TestCorpusBaseline:


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2023:CoursIA — prev: MED/notebook-conversion #11998

## Summary
- `detect_ascii_flowchart.py` appelait `nbformat.read` sans garde : un notebook illisible (BOM UTF-8 → `NotJSONError`, validation échouée → `ValidationError`) interrompait le **scan entier** → abstention globale. Le sibling `detect_ascii_workaround.py` porte déjà cette garde (L346-349).
- **Fix** : `try/except (OSError, NotJSONError, ValidationError)` par-fichier dans `scan_notebook` + champ `skipped: [{path, error}]` dans la sortie JSON de `scan_paths`. Le fichier sauté apparaît dans la sortie, jamais avalé silencieusement.
- Test : fixture BOM (`NotJSONError`) + fixture v4 sans `metadata` (`ValidationError`, cas réel Sudoku-15) — chaque test **assert la présence du chemin dans `skipped`**, pas seulement l'absence de crash.

## Acceptance (#12097)
1. **Positif** : les 12 tests existants restent verts (13 tests → 15, seuls 2 ajoutés, aucun modifié).
2. **Négatif** : `detect_ascii_flowchart.py MyIA.AI.Notebooks/ --json` → **exit 0**, JSON valide, `total_findings=11`, `skipped=1` listant exactement `Sudoku-15-Infer-Csharp.ipynb` avec son erreur (`missing an expected key: metadata`).
3. Test couvre le fichier illisible et vérifie la présence dans `skipped`.

## Baseline corpus (re-mesure firsthand)
- **baseline drift : 13 → 11 findings, fichiers-avec-findings 10 → 9** since c.259 pin (SHA fbe61eb57) : 2 conversions ASCII→Mermaid mergées entre-temps (#11998/#12010/#12011). Re-mesuré sur main `4e9ffc5ad1`, pins mis à jour.

## Test plan
```
python -m pytest scripts/notebook_tools/tests/test_detect_ascii_flowchart.py -q   # 15 passed
python scripts/notebook_tools/detect_ascii_flowchart.py MyIA.AI.Notebooks/ --json  # rc=0, skipped=[Sudoku-15]
```

See #12097 — garde par-fichier sur le modèle du sibling #3801.

