### PR TITLE
fix(guard,#12092): check_assertion lit COUNT_WORDS (mirror LHS/RHS) — un perimetre en toutes lettres n'est plus 'non verifiable'

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -277,11 +277,35 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
         (mm for mm in COUNT_CLAIM.finditer(scan_target) if int(mm.group(1)) != 0),
         None,
     )
+    # #12092 mirror: COUNT_WORDS (closed list FR/EN cardinals 1-10, see ~L98)
+    # was already read by extract_perimeter_assertions to flip
+    # body_declares_effective_count, but check_assertion only consulted
+    # COUNT_CLAIM -- so "trois fichiers" survived as a candidate upstream
+    # and died here as "non verifiable". Both halves of the organe must read
+    # the same vocabulary or the spelled-out form is structurally unpassable.
+    word_claim = None
+    if not count_claim:
+        for word, n in COUNT_WORDS.items():
+            if n == 0:
+                continue
+            pat = re.compile(
+                rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b",
+                re.IGNORECASE,
+            )
+            if pat.search(scan_target):
+                word_claim = n
+                break
     if count_claim:
         claimed = int(count_claim.group(1))
         if claimed != len(files):
             problems.append(
                 f"l'assertion pretend {claimed} fichier(s), la liste effective en compte {len(files)} : "
+                + ", ".join(f["path"] for f in files)
+            )
+    elif word_claim is not None:
+        if word_claim != len(files):
+            problems.append(
+                f"l'assertion pretend {word_claim} fichier(s), la liste effective en compte {len(files)} : "
                 + ", ".join(f["path"] for f in files)
             )
     exclusive = _has_exclusivity(scan_target.lower())
@@ -294,7 +318,7 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
                         f"assertion d'exclusivite sans nommer le workflow touche {f['path']} "
                         "(critere #11268-2 : tout .github/workflows/** doit etre enumere nommement)"
                     )
-    if not count_claim and not exclusive:
+    if not count_claim and word_claim is None and not exclusive:
         problems.append(
             "assertion sans compte de fichiers ni marqueur d'exclusivite reconnaissable -- "
             "formulation non verifiable (ecrire par ex. 'N fichiers : a, b, c')"

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -79,6 +79,60 @@ def test_unverifiable_wording_is_flagged():
     assert any("non verifiable" in p for p in problems)
 
 
+# --- #12092 -- check_assertion must also read COUNT_WORDS (closed FR/EN
+# cardinals 1-10). Before the fix, "trois fichiers" over a 3-file PR was
+# rejected as "non verifiable" even though the numeric form "3 fichiers"
+# passed. The mirror logic existed in extract_perimeter_assertions but the
+# RHS of the organe never consulted it.
+
+def test_count_words_fr_three_files_passes_12092():
+    """Acceptance #12092: 'trois fichiers' over a 3-file list must pass
+    (the founding PR #11951 body that was wrongly blocked)."""
+    assert check_assertion(
+        FILES_11227, "**trois fichiers** (142/32 lignes, tests inclus):"
+    ) == []
+
+
+def test_count_words_en_three_files_passes_12092():
+    """English equivalent of the acceptance: 'three files' over 3 files."""
+    assert check_assertion(
+        FILES_11227, "**three files** (142/32 lines, tests included):"
+    ) == []
+
+
+def test_count_words_fr_mismatch_still_fails_12092():
+    """A misspelled count in words is still a real mismatch (deux vs 3)."""
+    problems = check_assertion(
+        FILES_11227, "**deux fichiers** (142/32 lignes, tests inclus):"
+    )
+    assert problems, "deux fichiers over 3 files must fail"
+    assert any("2" in p and "3" in p for p in problems)
+
+
+def test_count_words_en_mismatch_still_fails_12092():
+    """English counterpart: 'two files' over 3 files still fails."""
+    problems = check_assertion(
+        FILES_11227, "**two files** (142/32 lines, tests included):"
+    )
+    assert problems, "two files over 3 files must fail"
+
+
+def test_count_words_does_not_match_when_word_is_in_prose_12092():
+    """Anti-pattern: the word 'trois' alone, without 'fichiers|files',
+    is still not a perimeter claim. Negative control."""
+    problems = check_assertion(
+        FILES_11227, "Les trois considerations precedentes ne sont pas verifiees."
+    )
+    assert any("non verifiable" in p for p in problems)
+
+
+def test_numeric_form_still_works_unchanged_12092():
+    """Regression check: the numeric form must keep working."""
+    assert check_assertion(
+        FILES_11227, "**3 fichiers** (142/32 lignes, tests inclus):"
+    ) == []
+
+
 def test_sorry_baseline_down_is_tighten_up_is_loosen():
     moves = extract_baseline_moves(DIFF_11227)
     m = [x for x in moves if x.key == "sorry-baseline"]


### PR DESCRIPTION
## Perimetre (declare en debut de body -- lecon L978)

**deux fichiers** (organe + tests) : `scripts/check_pr_perimeter.py`, `scripts/tests/test_check_pr_perimeter.py`. Le compte `**trois fichiers**` mentionne dans le contexte ci-dessous designe l'autre PR (la PR #11951 deblokee), pas le perimetre de cette PR.

## Contexte

`check_pr_perimeter.py` (l'organe de verite des perimetres PR, deploye via
[perimeter-review-guard](.github/workflows/perimeter-review-guard.yml))
bloquait **PR #11951** dont la declaration de perimetre etait pourtant
exacte :

```
**trois fichiers** (142/32 lignes, tests inclus):
```

Liste effective de la PR : **3 fichiers**. La declaration est juste.
Le verdict rendu etait :

```
VERDICT: FAIL
  !! [PR body / jsboige] assertion sans compte de fichiers ni marqueur
     d'exclusivite reconnaissable -- formulation non verifiable
```

Issue **#12092** documente la cause : `extract_perimeter_assertions` lit
`COUNT_WORDS` (cardinaux FR/EN 1-10, closed list introduite par #12024)
pour flagger `body_declares_effective_count` au niveau LHS, mais
`check_assertion` ne consulte que `COUNT_CLAIM` (chiffres) au niveau
RHS. La forme en lettres survit comme candidat amont, meurt comme
"non verifiable" aval. L'extension #12024 avait **deplace** le defaut
sans le fermer.

## Correctif

Mirror logique de `extract_perimeter_assertions` (ligne ~1127) applique
a `check_assertion` (ligne ~275). Meme closed list `COUNT_WORDS`, meme
pattern `\bWORD\s+(?:fichiers?|files?)\b`, meme precedence : on tente
d'abord le match numerique ; s'il echoue, on tente le match en lettres.
La branche terminale "non verifiable" exige maintenant l'absence des
**deux** formes.

```python
# #12092 mirror
word_claim = None
if not count_claim:
    for word, n in COUNT_WORDS.items():
        if n == 0:
            continue
        pat = re.compile(
            rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b",
            re.IGNORECASE,
        )
        if pat.search(scan_target):
            word_claim = n
            break
```

Le `n == 0` reste filtre par symetrie avec le pattern en chiffres
(`int(mm.group(1)) != 0`).

## Acceptance LIVREE firsthand

| Verdict | Commande | Resultat |
|---|---|---|
| **Acceptance #12092** | `python scripts/check_pr_perimeter.py 11951 --scan-thread` | **VERDICT: OK** |
| **Controle positif #11939** (declare 1 pour 3) | `python scripts/check_pr_perimeter.py 11939 --assert "**1 fichier** modifie"` | **VERDICT: FAIL** |
| **Controle positif #11966** (declare 4 pour 7) | `python scripts/check_pr_perimeter.py 11966 --assert "**4 fichiers**"` | **VERDICT: FAIL** |
| Tests unitaires | `python -m pytest scripts/tests/test_check_pr_perimeter.py -v` | **100/100 PASS** (94 anciens + 6 nouveaux) |

Les 6 nouveaux tests :

- `test_count_words_fr_three_files_passes_12092` — `trois fichiers` sur 3 fichiers -> `[]`
- `test_count_words_en_three_files_passes_12092` — `three files` sur 3 fichiers -> `[]`
- `test_count_words_fr_mismatch_still_fails_12092` — `deux fichiers` sur 3 fichiers -> fail
- `test_count_words_en_mismatch_still_fails_12092` — `two files` sur 3 fichiers -> fail
- `test_count_words_does_not_match_when_word_is_in_prose_12092` — `trois` seul (sans `fichiers|files`) reste non verifiable
- `test_numeric_form_still_works_unchanged_12092` — regression check `3 fichiers` -> `[]`

Aucune regression sur les tests existants : `#11985` (multi-rule body
extraction), `#12024` (codespan exclusion), `#12064` (markdown rendering
guard) tous verts.

## Voisinage avec #12091

L'issue **#12091** documente un defaut analogue mais distinct :
"1 fichier modifie, 1 fichier ajoute" additionne `1+1` mais est lu
comme `1`. Les deux touchent `check_assertion` et se corrigent au meme
endroit ; ils peuvent etre traites dans une PR ulterieure, les
criteres d'acceptation sont separes (le mien : mirror `COUNT_WORDS` ;
celui de #12091 : decomposition additive).

## Pourquoi ce n'est pas un workaround degrade

- Le miroir existait deja dans `extract_perimeter_assertions` : c'est
  un **alignement LHS/RHS**, pas une reimplementation.
- Meme closed list, meme regex, meme precedence : la PR est strictement
  mecanique.
- Tests : 6 nouveaux (positif FR, positif EN, mismatch FR, mismatch EN,
  anti-pattern prose, regression numerique).
- Controle positif exige par l'issue : les **vraies** fausses assertions
  restent FAIL, verifie firsthand sur les PRs #11939 et #11966.

## Voir aussi

- #12092 (reserve, classe de defaut documentee)
- #12091 (autre defaut `check_assertion` analogue, distinct)
- #12024 (introduction de `COUNT_WORDS` closed list, miroir cote LHS)
- PR #11951 (PR deblokee par ce fix, scope lean twin parity)

## Sub-claim

`[CLAIMED] lane myia-po-2026:CoursIA-2 -- paths: scripts/check_pr_perimeter.py, scripts/tests/test_check_pr_perimeter.py` pose sur #12092 (paths-scoped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
