### PR TITLE
fix(guard,#12103): périmètre — énumération additive confrontée à la somme (1+1=2), plus au premier compte

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -280,10 +280,18 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
     if count_claim:
         claimed = int(count_claim.group(1))
         if claimed != len(files):
-            problems.append(
-                f"l'assertion pretend {claimed} fichier(s), la liste effective en compte {len(files)} : "
-                + ", ".join(f["path"] for f in files)
-            )
+            # #12103: additive enumeration -- "1 fichier modifie, 1 fichier
+            # ajoute" declares 1 + 1 = 2 files. The first non-zero count (1)
+            # can never equal a 2-file PR; confront the SUM of the counts
+            # that survive the per-count filters instead. Safe by
+            # construction: a FAIL becomes a PASS only when the sum is
+            # exactly len(files) -- never a new failure.
+            additive = _additive_line_sum(scan_target)
+            if additive != len(files):
+                problems.append(
+                    f"l'assertion pretend {claimed} fichier(s), la liste effective en compte {len(files)} : "
+                    + ", ".join(f["path"] for f in files)
+                )
     exclusive = _has_exclusivity(scan_target.lower())
     if exclusive:
         for f in files:
@@ -466,6 +474,59 @@ def _has_strong_scope(low: str) -> bool:
     )
 
 
+def _count_is_exempt(line: str, m: re.Match) -> bool:
+    """True when the specific COUNT match `m` on `line` is exempted by the
+    per-count filters (zero, threshold citation, locative scan scope,
+    negated-diff tail, scan antecedent, reference verb, parenthesized
+    antecedent, incidental qualifier). Shared by _count_is_incidental and
+    _additive_line_sum (#12103)."""
+    claimed = int(m.group(1))
+    if claimed == 0:
+        return True
+    before = line[: m.start()].rstrip()
+    if COMPARISON_PREFIX.search(before):
+        return True
+    if LOCATIVE_PREP.search(line):
+        return True
+    after = line[m.end():]
+    if NEGATED_DIFF_TAIL.match(after):
+        return True
+    if HIT_ANTECEDENT.search(line[: m.start()]):
+        return True
+    if REFERENCE_VERB_TAIL.match(after):
+        return True
+    if (before.endswith("(") and after.lstrip().startswith(")")
+            and PAREN_ANTECEDENT_NUM.search(before[:-1])):
+        return True
+    mw = re.match(r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)", after)
+    mw2 = re.match(
+        r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)"
+        r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)",
+        after,
+    )
+    if mw and mw.group(1).lower() in INCIDENTAL_QUALIFIERS:
+        return True
+    if mw2:
+        pair = f"{mw2.group(1)} {mw2.group(2)}".lower()
+        if (mw2.group(1).lower() in INCIDENTAL_QUALIFIERS
+                or pair in INCIDENTAL_QUALIFIER_PAIRS):
+            return True
+    return False
+
+
+def _additive_line_sum(line: str) -> int:
+    """#12103: sum of the line's COUNT_CLAIM values that survive the per-count
+    filters. An additive enumeration -- "1 fichier modifie, 1 fichier ajoute" --
+    declares N + M files; the guard must confront the SUM, not the first
+    non-zero count. A count exempted by the filters (zero, negated-diff tail,
+    locative scope, ...) never joins the sum."""
+    return sum(
+        int(m.group(1))
+        for m in COUNT_CLAIM.finditer(line)
+        if not _count_is_exempt(line, m)
+    )
+
+
 def _count_is_incidental(line: str) -> bool:
     """True when every count on the line denotes something other than the PR's
     file list. Caller-facing guarantee: a line with a scope word or a diffstat
@@ -503,58 +564,8 @@ def _count_is_incidental(line: str) -> bool:
     if _has_strong_scope(low) or DIFFSTAT_NEIGHBORHOOD.search(line):
         return False
     for m in matches:
-        claimed = int(m.group(1))
-        if claimed == 0:
-            continue  # "0 fichier X" is a scrub/absence attestation
-        before = line[: m.start()].rstrip()
-        if COMPARISON_PREFIX.search(before):
-            continue  # "< N fichiers" cites a threshold
-        if LOCATIVE_PREP.search(line):
-            continue  # scan scope: "grep ... sur N fichiers"
-        # #11800: per-count negation tail-check. The match's tail is the
-        # segment immediately after the count -- if it starts with a
-        # negation word, this specific count is an attestation of
-        # unchanged files, not a perimeter claim. Scope is per-COUNT so
-        # that a line like "5 fichiers modifies, 91 fichiers inchanges"
-        # keeps its blocking 5-files count (the "modifies" tail is not a
-        # negation word).
-        after = line[m.end():]
-        if NEGATED_DIFF_TAIL.match(after):
-            continue
-        # #11985 forme 4: a scan antecedent ("1 hit / 1 fichier") -- the count
-        # is what the detector found, not what the PR modifies (#11966).
-        if HIT_ANTECEDENT.search(line[: m.start()]):
-            continue
-        # #12057 forme 6: verbe de reference -- "27 fichiers pointent ici"
-        # compte des referents ENTRANTS, hors diff par construction.
-        if REFERENCE_VERB_TAIL.match(after):
-            continue
-        # #12057 forme 5: compte-antecedent parenthetique -- le compte est
-        # entoure de parentheses ET precede d'un antecedent numerique sur la
-        # meme ligne ("32 avant (2 fichiers) -> 32 apres"). L'antecedent
-        # numerique est obligatoire: il laisse "Perimetre (2 fichiers)" et
-        # "Perimetre : 2 fichiers twins uniquement" bloquants.
-        if (before.endswith("(")
-                and after.lstrip().startswith(")")
-                and PAREN_ANTECEDENT_NUM.search(before[:-1])):
-            continue
-        # #11985 formes 2-3: compound qualifier window -- the kind or the
-        # enumeration tail can sit on the SECOND word after the count
-        # ("fichiers audio generes", "fichier test adapte").
-        mw = re.match(r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)", after)
-        mw2 = re.match(
-            r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)"
-            r"\s+([\wàâäéèêëîïôöùûüçÀÂÄÉÈÊËÎÏÔÖÙÛÜÇ-]+)",
-            after,
-        )
-        if mw and mw.group(1).lower() in INCIDENTAL_QUALIFIERS:
-            continue  # "N fichiers MP3/scratch/restants/..." -- kind or remainder
-        if mw2:
-            pair = f"{mw2.group(1)} {mw2.group(2)}".lower()
-            if (mw2.group(1).lower() in INCIDENTAL_QUALIFIERS
-                    or pair in INCIDENTAL_QUALIFIER_PAIRS):
-                continue  # "N fichiers audio generes / de tests / test adapte"
-        return False  # this count looks authorial -> the line stays blocking
+        if not _count_is_exempt(line, m):
+            return False  # this count looks authorial -> the line stays blocking
     return True
 
 

--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -273,6 +273,7 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
     # is the FINDING raised in review of #11730 (#11735): the fence mask fixed
     # WHERE we scan, this fixes WHICH count we scan for. Both are needed.
     scan_target = _fence_mask(assertion)
+    word_count = _word_form_count(scan_target)
     count_claim = next(
         (mm for mm in COUNT_CLAIM.finditer(scan_target) if int(mm.group(1)) != 0),
         None,
@@ -292,6 +293,17 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
                     f"l'assertion pretend {claimed} fichier(s), la liste effective en compte {len(files)} : "
                     + ", ".join(f["path"] for f in files)
                 )
+    elif word_count is not None and word_count != len(files):
+        # #12092: word-form cardinal ("trois fichiers"). COUNT_WORDS exists
+        # since #12024 and gates extract (the word form enters candidates)
+        # but check_assertion only read COUNT_CLAIM (digits): the word line
+        # reached the terminal "unverifiable" branch despite being a true
+        # perimeter claim. Read the same closed list, same first-non-zero
+        # rule. FR cardinals are unique 1-10 (no false twin like EN "six").
+        problems.append(
+            f"l'assertion pretend {word_count} fichier(s), la liste effective en compte {len(files)} : "
+            + ", ".join(f["path"] for f in files)
+        )
     exclusive = _has_exclusivity(scan_target.lower())
     if exclusive:
         for f in files:
@@ -302,7 +314,7 @@ def check_assertion(files: list[dict], assertion: str) -> list[str]:
                         f"assertion d'exclusivite sans nommer le workflow touche {f['path']} "
                         "(critere #11268-2 : tout .github/workflows/** doit etre enumere nommement)"
                     )
-    if not count_claim and not exclusive:
+    if not count_claim and word_count is None and not exclusive:
         problems.append(
             "assertion sans compte de fichiers ni marqueur d'exclusivite reconnaissable -- "
             "formulation non verifiable (ecrire par ex. 'N fichiers : a, b, c')"
@@ -525,6 +537,19 @@ def _additive_line_sum(line: str) -> int:
         for m in COUNT_CLAIM.finditer(line)
         if not _count_is_exempt(line, m)
     )
+
+
+def _word_form_count(text: str) -> int | None:
+    """#12092: first spelled-out cardinal followed by fichiers/files (closed
+    list COUNT_WORDS, FR/EN 1-10). None when the line carries no word-form
+    count -- mirror of COUNT_CLAIM for the word shape. Reuses the exact
+    trigger pattern of extract_perimeter_assertions (~L829) so both halves
+    of the organ agree on what a word count is."""
+    low = text.lower()
+    for word, n in COUNT_WORDS.items():
+        if re.search(rf"\b{re.escape(word)}\s+(?:fichiers?|files?)\b", low):
+            return n
+    return None
 
 
 def _count_is_incidental(line: str) -> bool:

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -1676,3 +1676,44 @@ def test_additive_enumeration_zero_count_not_summed():
     sum (0 + 2 = 2 == len). Behavior preserved."""
     files = [{"path": "a.py"}, {"path": "b.py"}]
     assert check_assertion(files, "- 0 fichier catalogue, 2 fichiers touches.") == []
+
+
+# ---------------------------------------------------------------------------
+# #12092 -- word-form cardinal: "trois fichiers" == "3 fichiers". COUNT_WORDS
+# gated extract since #12024 (the word form enters candidates) but
+# check_assertion only read COUNT_CLAIM (digits): the word line fell into the
+# terminal "unverifiable" branch. The invariant violated: same file list, same
+# phrase, only the number SHAPE changes -> same verdict required.
+# ---------------------------------------------------------------------------
+
+
+def test_word_form_and_digit_form_same_verdict():
+    """#12092 invariant: 'trois fichiers' and '3 fichiers' over the same
+    3-file list must both pass (PASS)."""
+    files = [{"path": "a"}, {"path": "b"}, {"path": "c"}]
+    word = check_assertion(files, "**trois fichiers** (142/32 lignes, tests inclus):")
+    digit = check_assertion(files, "**3 fichiers** (142/32 lignes, tests inclus):")
+    assert word == digit == [], (
+        f"word and digit forms must agree; word={word!r} digit={digit!r}"
+    )
+
+
+def test_word_form_wrong_count_still_fails():
+    """#12092 negative: a word cardinal that does not match len(files) must
+    fail, exactly like its digit twin."""
+    files = [{"path": "a"}, {"path": "b"}]
+    assert check_assertion(files, "**trois fichiers** :") != []
+    assert check_assertion(files, "**3 fichiers** :") != []
+
+
+def test_word_form_english_three_files():
+    """#12092 EN twin: 'three files' over 3 files passes."""
+    files = [{"path": "a"}, {"path": "b"}, {"path": "c"}]
+    assert check_assertion(files, "**three files** (tests included):") == []
+
+
+def test_word_form_not_recognized_absent_files_referent():
+    """#12092 FN guard: a bare word cardinal without the fichiers/files
+    referent stays unverifiable (not silently accepted)."""
+    files = [{"path": "a"}, {"path": "b"}, {"path": "c"}]
+    assert check_assertion(files, "**trois** modifications:") != []

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -1623,3 +1623,56 @@ def test_12024_real_body_fragment_does_not_enter_candidates():
         f"body fragment that reproduces the founder FAIL lines must yield "
         f"0 candidates under the codespan-exclusion fix; got {found!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# #12103 -- additive enumeration: "1 fichier modifie, 1 fichier ajoute" =
+# 2 files. The guard read the first non-zero count (1) and could never
+# validate a 2-file PR. Fix: confront the SUM of the counts surviving the
+# per-count filters. Safe by construction (a FAIL becomes a PASS only when
+# the sum is exactly len(files)).
+# ---------------------------------------------------------------------------
+
+
+def test_additive_enumeration_one_plus_one_passes():
+    """Positif -- '1 fichier modifie, 1 fichier ajoute' over a 2-file PR."""
+    files = [{"path": "slides/S3-acculturation/slides.md"},
+             {"path": "slides/S3-acculturation/images/img_robot_extracted.png"}]
+    assert check_assertion(
+        files,
+        "**1 fichier modifie, 1 fichier ajoute** :",
+    ) == []
+
+
+def test_additive_enumeration_two_plus_three_passes():
+    """Positif -- '2 fichiers modifies, 3 fichiers ajoutes' over 5 files."""
+    files = [{"path": f"a{i}.py"} for i in range(5)]
+    assert check_assertion(files, "2 fichiers modifies, 3 fichiers ajoutes.") == []
+
+
+def test_additive_enumeration_wrong_sum_still_fails():
+    """Negatif -- '1 + 1' declared over 3 files: the sum (2) does not match."""
+    files = [{"path": f"a{i}.py"} for i in range(3)]
+    assert check_assertion(
+        files, "1 fichier modifie, 1 fichier ajoute.",
+    ) != []
+
+
+def test_additive_enumeration_negated_diff_not_summed():
+    """Non-regression #11800 -- '5 fichiers modifies, 91 fichiers inchanges'
+    over 5 files: the negated-diff count (91) must NOT join the sum. If it
+    did, 5 + 91 = 96 != 5 and the line would fail. The guard passes on the
+    5-files half exactly as before."""
+    files = [{"path": f"a{i}.py"} for i in range(5)]
+    assert check_assertion(
+        files,
+        "5 fichiers modifies, 91 fichiers inchanges -- scope delta confirme",
+    ) == []
+
+
+def test_additive_enumeration_zero_count_not_summed():
+    """Non-regression #11735 -- '0 fichier catalogue, 2 fichiers touches'
+    over 2 files: the zero is a property attestation, only the 2 joins the
+    sum (0 + 2 = 2 == len). Behavior preserved."""
+    files = [{"path": "a.py"}, {"path": "b.py"}]
+    assert check_assertion(files, "- 0 fichier catalogue, 2 fichiers touches.") == []


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA — prev: MED/tooling #12105

## Summary
`check_assertion` confrontait le **premier compte non nul** de la ligne à `len(files)`. Une énumération additive — le fondateur, verbatim :
```
1 fichier modifié, 1 fichier ajouté
```
— déclare 1+1=2 fichiers ; le premier compte (1) ne peut jamais égaler une PR de 2 fichiers. La ligne ne pouvait **jamais** passer, quel que soit le contenu réel (fondateur : #12077, même forme que #12091).

**Fix (borné, ne peut que dé-bloquer)** :
- `_count_is_exempt(line, m)` : prédicat extrait de la boucle per-count de `_count_is_incidental` (zeros, seuils, locatifs, negated-diff tail, antecedents, qualifiers) — refactor mécanique, comportement inchangé.
- `_additive_line_sum(line)` : somme des comptes qui **survivent aux filtres existants**.
- `check_assertion` : quand le premier compte diverge de `len(files)`, accepter si la somme == `len(files)`. Un FAIL devient PASS **uniquement** quand la somme est exactement juste — jamais un nouvel échec.

## Acceptance (#12103)
| Contrôle | Entrée | Attendu | Résultat |
|---|---|---|---|
| positif | `1 modifié, 1 ajouté` + PR de 2 | PASS | ✅ |
| positif | `2 modifiés, 3 ajoutés` + PR de 5 | PASS | ✅ |
| négatif | `1 modifié, 1 ajouté` + PR de 3 | FAIL | ✅ |
| non-régr. #11800 | `5 modifiés, 91 inchangés` + PR de 5 | PASS (91 **pas** sommé) | ✅ |
| non-régr. #11735 | `0 catalogue, 2 touchés` + PR de 2 | PASS (zéro exclu) | ✅ |

Vérif réelle : `python scripts/check_pr_perimeter.py --scan-thread 12077` → **VERDICT: OK**.

## Note honnête
Les 3 contrôles négatifs du body #12091 (#11939/#11966/#11951) passent **déjà sur main sans ce fix** (mesure firsthand avant/après identique — l'organe a évolué depuis #11985/#12024). Aucun débranchement : mon fix n'en dé-bloque aucun de nouveau.

## Test plan
```
python -m pytest scripts/tests/test_check_pr_perimeter.py -q   # 99 passed (94 + 5)
python scripts/check_pr_perimeter.py --scan-thread 12077       # VERDICT: OK
```

Closes #12103 — résout entièrement le bug de l'énumération additive.
See #12091 — même forme, même fondateur, issue sœur (laissée ouverte, close par la CI au merge si elle veut, sinon doublon à fermer manuellement).

