### PR TITLE
feat(claim,#12072): signal structure pour les clauses de scope hors ligne de marqueur

### DIFF
--- a/scripts/check_lane_claim.py
+++ b/scripts/check_lane_claim.py
@@ -247,6 +247,19 @@ _ANNOTATION_SUFFIX_RE = re.compile(r"\s+(?:--|—|–)\s+")
 # before the opening paren so legitimate filename characters (e.g. a glob
 # with a paren in it -- rare but possible) are not cut.
 _PAREN_ANNOTATION_RE = re.compile(r" \(")
+# #12072 -- off-marker scope declaration. `_PATHS_CLAUSE_RE` reads the `paths:`
+# clause ONLY on the marker line (`[^\n]*?` forbids the newline): a clause
+# written on its OWN line in a separate paragraph is read as None -> epic-wide,
+# silently, while the declaring lane believes it scoped. This regex finds a
+# scope-declaration-shaped line ANYWHERE in the body (line-start `paths:` /
+# `Paths:` / `Path :`, case-insensitive, same decoration tolerance as the
+# marker regexes) so the event can expose it and the lint can say so instead of
+# staying silent. Used only as a SIGNAL (`scope_declared_off_marker`) -- the
+# claim is NOT re-classified (see #12072: re-reading an off-marker prose line
+# as the machine clause would make the scope depend on an heuristic).
+_OFF_MARKER_SCOPE_RE = re.compile(
+    r"(?im)^[ \t]*(?:[#>*+-]{1,6}[ \t]*)*(?:\*\*|__)?[ \t]*paths?\s*:\s*([^\n]+?)\s*$"
+)
 
 
 class ClaimEvent(dict):
@@ -316,6 +329,22 @@ class ClaimEvent(dict):
         filters `others` by scope intersection (`_filter_by_claim_scope`).
         """
         return self.get("paths")
+
+    @property
+    def scope_declared_off_marker(self) -> list[str]:
+        """#12072 -- scope-declaration lines found OFF the marker line.
+
+        Non-empty ONLY on an epic-wide event (`paths is None`) whose comment
+        nevertheless contains a line-start `paths?` clause elsewhere (e.g. a
+        `Paths: ...` paragraph under the `[CLAIMED]` line). The reducer could
+        not read that clause (`_PATHS_CLAUSE_RE` is marker-line-anchored), so
+        the claim reduced to EPIC-WIDE while the declaring lane believed it
+        scoped. This field is a SIGNAL, not a re-classification: the claim is
+        NOT lifted back to a scoped state (that would make the scope depend on
+        a heuristic). Consumers (JSON summary, lint WARN) use it to say so
+        explicitly instead of staying silent.
+        """
+        return self.get("scope_declared_off_marker") or []
 
     @property
     def unparseable_scope(self) -> list[str]:
@@ -403,7 +432,20 @@ def _parse_claim_events(comment: dict) -> list[ClaimEvent]:
     # Les blocs fences sont de la citation, jamais un acte (voir
     # `_mask_fenced_blocks`). Le masque preserve les longueurs, donc les
     # offsets restent valides sur `body` -- que `_line_for_match` relit.
-    for m in _MARKER_RE.finditer(_mask_fenced_blocks(body)):
+    masked_body = _mask_fenced_blocks(body)
+    # #12072 -- pre-computed off-marker scope declaration lines. `_PATHS_CLAUSE_RE`
+    # only ever reads the marker's OWN line, so a `paths:`/`Paths:`/`Path :`
+    # clause written on a separate line of the same comment is dead prose from
+    # the reducer's point of view (epic-wide, silently). We scan the fenced-masked
+    # body once and hand each event its own matching lines: the masked body
+    # preserves offsets, so `_line_for_match` can still resolve verbatim text on
+    # the real `body`. The clause regex is line-anchored to a line STARTING with
+    # `paths?`, so it can never match the marker line itself (which starts with
+    # the bracket after decoration) -- no overlap with the marker's own clause.
+    off_marker_scope_lines = [
+        _line_for_match(body, om).strip() for om in _OFF_MARKER_SCOPE_RE.finditer(masked_body)
+    ]
+    for m in _MARKER_RE.finditer(masked_body):
         marker = m.group(1).upper()
         line = _line_for_match(body, m)
         if marker in _OPEN:
@@ -436,6 +478,14 @@ def _parse_claim_events(comment: dict) -> list[ClaimEvent]:
             # accidental empty" -- the exact defect that motivated #10597.
             unparseable_scope=_unparseable_scope_in(paths) if paths else [],
             intent=_intent_from_line(line),
+            # #12072 -- structured signal for a scope declared OFF the marker
+            # line (line-start `paths?` elsewhere in the comment, e.g. a
+            # `Paths: ...` paragraph below the `[CLAIMED]` line). The reducer
+            # read `paths is None` -> the claim reduced to EPIC-WIDE while the
+            # declaring lane believed it scoped. The field only exists when
+            # the marker's OWN line carried no clause (a captured scope needs
+            # no warning); the lint layer decides how loudly to say so.
+            scope_declared_off_marker=off_marker_scope_lines if paths is None else [],
             # #11755: the body is needed downstream by `_lint_claim_events`
             # to mine for an inferred `Path:` clause when the marker has no
             # `paths:` field. Carrying it on the event (one extra reference)
@@ -1045,6 +1095,13 @@ def _lint_claim_events(
     re-classified (legacy semantics preserved -- see #11755 Piste 1 rationale).
     The lane keeps its epic-wide read; the warning is a usability nudge to
     reissue with the explicit clause.
+
+    #12072: distinct from the #11755 nudge, when the event carries the
+    structured `scope_declared_off_marker` signal (a line-start `paths?`
+    clause on a SEPARATE line of the comment), an explicit WARN names the
+    faulty line and the expected marker-line syntax. Fires only on the
+    signal -- an intentional epic-wide declaration (no off-marker clause)
+    stays silent, so the lint never penalises a deliberate full-lane lock.
     """
     if tracked is None:
         tracked = _git_tracked_files(repo_root)
@@ -1065,6 +1122,22 @@ def _lint_claim_events(
         if ev.get("action") not in ("open", "override"):
             continue
         if ev.paths is None:
+            # #12072 -- the structured off-marker signal. Fires ONLY when the
+            # comment declares a scope somewhere other than the marker line
+            # (a `Paths:`/`path:`/`Path :` line in a separate paragraph): the
+            # reducer could not read it, so the claim reduced to EPIC-WIDE
+            # while the writer believed it scoped. Explicit intent stays
+            # legitimate (no signal -> no noise); the claim is NOT re-scoped.
+            off_marker = ev.scope_declared_off_marker
+            if off_marker:
+                print(
+                    f"WARN: scope declare hors ligne de marqueur -- cette "
+                    f"declaration n'est PAS lue (#12072) : "
+                    f"{off_marker[0]!r} (lane {ev.lane or '?'}). "
+                    f"La clause paths: doit etre SUR la ligne du marqueur : "
+                    f"`[CLAIMED] lane <machine:workspace> -- paths: <g1>, <g2>`.",
+                    file=sys.stderr,
+                )
             inferred = _infer_paths_from_body(ev.get("_body"))
             inferred_str = (
                 " ; chemin(s) inféré(s) du body : "
@@ -1279,6 +1352,14 @@ def _run_check(payload: dict, my_lane: str, stale_threshold=None,
                 # when it covers the whole scope the claim is lifted to
                 # epic-wide (a broken claim is not a permissive claim).
                 "empty_scope": ev.get("empty_scope") or [],
+                # #12072 -- the off-marker scope-declaration witness. Non-empty
+                # ONLY on an epic-wide claim (`paths` is null) whose comment
+                # still declares a `paths?` clause on a separate line (e.g. a
+                # `Paths: ...` paragraph under the `[CLAIMED]` line). The
+                # reducer could not read it (marker-line-anchored clause), so
+                # the claim reduced to epic-wide while the writer believed it
+                # scoped. Signal only -- never re-scopes the claim.
+                "scope_declared_off_marker": ev.scope_declared_off_marker,
             }
             for ln, ev in sorted(active.items())
         },

--- a/scripts/tests/test_check_lane_claim.py
+++ b/scripts/tests/test_check_lane_claim.py
@@ -3039,3 +3039,189 @@ def test_fence_mask_preserves_offsets_for_verbatim_line_extraction():
     events = clc._parse_claim_events(comment(body, "2026-08-20T01:00:00Z"))
     assert len(events) == 1
     assert events[0].paths == ["a/**"], "la clause paths est relue sur la ligne originale"
+
+
+# --- #12072: clause de scope HORS ligne de marqueur -- signal structure -------
+#
+# Defaut mesure sur #10382 (2026-08-20T19:15:42Z, po-2023) : une clause
+# `Paths: ...` ecrite sur SA PROPRE ligne (paragraphe separe sous le marqueur)
+# est invisible pour `_PATHS_CLAUSE_RE` (ancre a la ligne du marqueur, `[^\n]*?`
+# interdit le saut de ligne) -> le claim reduit a EPIC-WIDE en silence, alors
+# que la lane declarante croyait avoir scope. #12072 expose le signal
+# `scope_declared_off_marker` (structure, JSON + WARN) SANS re-classifier le
+# claim (relire une ligne de prose comme la clause machine rendrait le scope
+# dependant d'une heuristique).
+
+
+def test_off_marker_scope_signal_on_separate_line():
+    # #12072 acceptance (3) -- le controle par faux negatif : la clause sur
+    # une ligne SEPAREE doit produire le signal. Reproduction exacte du corps
+    # de la mesure (ligne `Paths: ...` sous le marqueur, #10382).
+    body = (
+        "[CLAIMED] tranche search-7-mcts-and-beyond -- "
+        "lane myia-po-2023:CoursIA\n"
+        "\n"
+        "Paths: `scripts/notebook_tools/twin_pairs.d/"
+        "search-7-mcts-and-beyond.yaml`. Grain: MED/tooling. "
+        "Scope disjoint des PRs en vol.\n"
+    )
+    evs = clc._parse_claim_events(comment(body, "2026-08-20T19:15:42Z"))
+    assert len(evs) == 1
+    ev = evs[0]
+    assert ev.paths is None, "la clause hors-marqueur ne doit PAS etre lue comme paths"
+    assert ev.scope_declared_off_marker == [
+        "Paths: `scripts/notebook_tools/twin_pairs.d/"
+        "search-7-mcts-and-beyond.yaml`. Grain: MED/tooling. "
+        "Scope disjoint des PRs en vol.",
+    ], "la ligne fautive est exposee verbatim"
+
+
+def test_off_marker_scope_signal_form_variants():
+    # #12072 breadth -- les 4 formes observees de la declaration hors-ligne :
+    # `Paths:` capitalise, `paths:` minuscule, `Path :` avec espace avant le
+    # deux-points, et puce/gras (tolerance de decoration identique aux regex
+    # de marqueur, #10906). Toutes produisent le signal.
+    forms = [
+        "Paths: scripts/check_lane_claim.py\n",
+        "paths: scripts/check_lane_claim.py\n",
+        "Path : scripts/check_lane_claim.py\n",
+        "- **Paths :** scripts/check_lane_claim.py\n",
+    ]
+    for extra in forms:
+        body = "[CLAIMED] lane myia-po-2024:CoursIA\n\n" + extra
+        evs = clc._parse_claim_events(comment(body, "2026-08-20T12:00:00Z"))
+        assert len(evs) == 1, extra
+        assert evs[0].paths is None, extra
+        assert len(evs[0].scope_declared_off_marker) == 1, extra
+
+
+def test_off_marker_scope_signal_absent_without_declaration():
+    # Controle positif : un epic-wide INTENTIONNEL (aucune clause hors-ligne)
+    # ne produit AUCUN signal. Le lint ne doit pas bruiter un verrou plein
+    # scope delibere.
+    body = "[CLAIMED] lane myia-po-2024:CoursIA\n"
+    evs = clc._parse_claim_events(comment(body, "2026-08-20T12:00:00Z"))
+    assert len(evs) == 1
+    assert evs[0].paths is None
+    assert evs[0].scope_declared_off_marker == []
+
+
+def test_off_marker_scope_signal_absent_when_clause_on_marker_line():
+    # Controle croise : la clause SUR la ligne du marqueur est lue par le
+    # reducer -> `paths` non-None -> aucun signal off-marker (rien de perdu,
+    # rien a signaler). Le signal ne se leve que pour une declaration NON
+    # capturee.
+    body = "[CLAIMED] lane myia-po-2024:CoursIA -- paths: scripts/**\n"
+    evs = clc._parse_claim_events(comment(body, "2026-08-20T12:00:00Z"))
+    assert len(evs) == 1
+    assert evs[0].paths == ["scripts/**"]
+    assert evs[0].scope_declared_off_marker == []
+
+
+def test_off_marker_scope_signal_ignores_fenced_citation():
+    # Une `Paths:` citee dans un bloc fence est de la citation (meme logique
+    # que `_MARKER_RE` vs `_mask_fenced_blocks`) : le masque remplace le
+    # contenu du fence, donc aucune declaration off-marker n'est detectee.
+    body = (
+        "[CLAIMED] lane myia-po-2024:CoursIA\n"
+        "\n"
+        "```\n"
+        "Paths: scripts/check_lane_claim.py\n"
+        "```\n"
+    )
+    evs = clc._parse_claim_events(comment(body, "2026-08-20T12:00:00Z"))
+    assert len(evs) == 1
+    assert evs[0].paths is None
+    assert evs[0].scope_declared_off_marker == [], (
+        "citer un scope dans un fence n'est pas en declarer un"
+    )
+
+
+def test_off_marker_scope_signal_mid_sentence_is_prose():
+    # Une mention de `paths:` EN PHRASE (pas en debut de ligne) n'est pas une
+    # declaration de scope -- meme logique d'ancrage que `_INFERRED_PATH_PATTERNS`
+    # (#11755 : la forme "discussion" ne nourrit pas l'inference).
+    body = (
+        "[CLAIMED] lane myia-po-2024:CoursIA\n"
+        "\n"
+        "on discute des paths: a, b en prose, ce n'est pas un scope\n"
+    )
+    evs = clc._parse_claim_events(comment(body, "2026-08-20T12:00:00Z"))
+    assert len(evs) == 1
+    assert evs[0].scope_declared_off_marker == []
+
+
+def test_lint_warns_off_marker_scope_on_epic_wide(capsys):
+    # #12072 acceptance (2) -- la sortie humaine : sur un claim epic-wide
+    # portant le signal, le lint imprime explicitement que le commentaire
+    # declare un scope NON applique, avec la ligne fautive et la syntaxe
+    # attendue. Le claim n'est PAS re-scope (verdict inchange).
+    body = (
+        "[CLAIMED] lane myia-po-2024:CoursIA-2 -- tranche 04-7\n"
+        "\n"
+        "Paths: MyIA.AI.Notebooks/GenAI/Audio/04-7-TTS-Voice-Benchmark.ipynb\n"
+    )
+    events = clc._parse_claim_events(comment(body, "2026-08-20T12:00:00Z"))
+    clc._lint_claim_events(events, issue_number=12072)
+    captured = capsys.readouterr()
+    assert "scope declare hors ligne de marqueur" in captured.err, (
+        "le WARN doit nommer explicitement le defaut (#12072)"
+    )
+    assert "04-7-TTS-Voice-Benchmark.ipynb" in captured.err, (
+        "la ligne fautive doit etre exposee verbatim"
+    )
+    assert "paths: <g1>, <g2>" in captured.err, (
+        "la syntaxe attendue (clause SUR la ligne du marqueur) doit etre rappelee"
+    )
+
+
+def test_lint_silent_on_intentional_epic_wide(capsys):
+    # Controle : un epic-wide INTENTIONNEL (pas de clause hors-ligne) ne
+    # produit que l'INFO legacy #11755 -- JAMAIS le WARN #12072. Le lint ne
+    # penalise pas un verrou plein scope delibere.
+    body = "[CLAIMED] lane myia-po-2024:CoursIA-2\n"
+    events = clc._parse_claim_events(comment(body, "2026-08-20T12:00:00Z"))
+    clc._lint_claim_events(events, issue_number=12072)
+    captured = capsys.readouterr()
+    assert "INFO: marqueur CLAIMED epic-wide" in captured.err, (
+        "l'INFO legacy #11755 reste pour retro-compat"
+    )
+    assert "hors ligne de marqueur" not in captured.err, (
+        "aucun WARN #12072 sans declaration hors-ligne"
+    )
+
+
+def test_run_check_summary_exposes_scope_declared_off_marker(capsys):
+    # #12072 acceptance (1) -- le champ structure monte dans le JSON de sortie
+    # sous `active_claims.<lane>.scope_declared_off_marker`, a cote des autres
+    # temoins (unparseable_scope, empty_scope). Vide sur un claim sans signal.
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA-2 -- tranche 04-7\n"
+            "\n"
+            "Paths: MyIA.AI.Notebooks/GenAI/Audio/04-7-TTS-Voice-Benchmark.ipynb\n",
+            "2026-08-20T12:00:00Z",
+        ),
+    )
+    rc = clc._run_check(p, "myia-po-2025:CoursIA")
+    assert rc == 1  # epic-wide (paths None) -> bloque
+    out = capsys.readouterr().out
+    assert '"scope_declared_off_marker"' in out
+    assert "04-7-TTS-Voice-Benchmark.ipynb" in out
+    # Le claim n'est PAS re-scope : `paths` reste null dans le JSON.
+    assert '"paths": null' in out
+
+
+def test_run_check_summary_off_marker_field_empty_without_signal(capsys):
+    # Controle : un claim epic-wide sans declaration hors-ligne expose le
+    # champ avec une liste vide (consistance du schema JSON, meme logique que
+    # `unparseable_scope`/`empty_scope` toujours presents).
+    p = payload(
+        comment(
+            "[CLAIMED] lane myia-po-2024:CoursIA-2\n",
+            "2026-08-20T12:00:00Z",
+        ),
+    )
+    clc._run_check(p, "myia-po-2025:CoursIA")
+    out = capsys.readouterr().out
+    assert '"scope_declared_off_marker": []' in out


### PR DESCRIPTION
Grain: MED/tooling — lane myia-po-2026:CoursIA — prev: MED/notebook-python (#12108)

## Problème (mesuré sur #10382)

Une clause `Paths: ...` écrite sur **sa propre ligne** (paragraphe séparé sous le `[CLAIMED]`) était invisible pour `_PATHS_CLAUSE_RE` (ancre à la ligne du marqueur, `[^\n]*?` interdit le saut de ligne) → le claim réduisait à **EPIC-WIDE en silence**, pendant que la lane déclarante croyait avoir scoped. Reproduction exacte : #10382 commentaire 2026-08-20T19:15:42Z (po-2023), `Paths: \`scripts/notebook_tools/twin_pairs.d/search-7-mcts-and-beyond.yaml\`. Grain: MED/tooling...`

## Correctif (issue #12072)

Le correctif expose un **témoin structuré** sans re-classifier le claim (relire une ligne de prose comme la clause machine rendrait le scope dépendant d'une heuristique) :

1. **`_OFF_MARKER_SCOPE_RE`** : détection line-start `paths?` hors marqueur (`Paths:` / `paths:` / `Path :`, casse insensible, même tolérance de décoration que les regex de marqueur), scannée sur le body **masqué** (fence = citation, jamais un acte). Ne peut jamais matcher la ligne du marqueur (ancre `paths?` après décoration vs `[`).
2. **Champ `scope_declared_off_marker`** sur l'événement : non vide **uniquement** quand `paths is None` (un scope capturé n'a rien à signaler). Propriété typée + docstring.
3. **WARN explicite** dans `_lint_claim_events` : nomme la ligne fautive verbatim + syntaxe attendue (`[CLAIMED] lane <machine:workspace> -- paths: <g1>, <g2>`). Un epic-wide **intentionnel** (sans clause hors-ligne) reste silencieux — l'INFO legacy #11755 demeure pour rétro-compat.
4. **Champ dans le JSON** `active_claims.<lane>.scope_declared_off_marker` (à côté de `unparseable_scope` / `empty_scope`).

## Validation

| Vérification | Résultat |
|---|---|
| `pytest scripts/tests/test_check_lane_claim.py` (racine repo) | **177 passed** (167 existants + 10 nouveaux) |
| `pytest scripts/tests/test_lane_claim_required.py` | **27 passed** (importer dépendant) |
| `pytest scripts/tests/test_grain_tag.py` | **49 passed** (dépendance) |
| E2E sur le corps #10382 as-posté | WARN #12072 + champ JSON verbatim, `paths` reste `None` |
| Catalogue | byte-identique à main |
| Hooks pre-commit | gitleaks + 7 hooks PASSED |

### Tests nouveaux (contrôle faux-négatif = acceptance 3 de l'issue)

- `test_off_marker_scope_signal_on_separate_line` : reproduction exacte #10382 → signal produit, `paths` None, ligne verbatim.
- `test_off_marker_scope_signal_form_variants` : 4 formes (`Paths:` / `paths:` / `Path :` / puce-gras).
- Contrôles : epic-wide intentionnel → **pas** de signal ; clause sur la ligne du marqueur → `paths` non-None, pas de signal ; fence cité → pas de signal ; mention `paths:` en phrase → prose, pas de signal.
- Lint : WARN présent quand signal, absent sinon ; JSON présent/vide.

## See

- **See #12072** (correctif partiel : le détecteur signale, les lanes concernées doivent corriger leurs claims — action par-lane).
- **See #11755** (l'INFO legacy d'inférence de chemin reste en place, non bruité).