### PR TITLE
fix(notebooks,#12111): QC-Py-26 — escapes \/, 3 diagrammes mermaid, re-exec 1..17

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-26-LLM-Trading-Signals.ipynb
@@ -3,7 +3,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-b1db72be",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007219,
+     "end_time": "2026-08-21T10:27:27.559727",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:27.552508",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "\n",
     "## Objectifs d'Apprentissage\n",
@@ -43,7 +52,16 @@
   {
    "cell_type": "markdown",
    "id": "eaf02a92",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005715,
+     "end_time": "2026-08-21T10:27:27.578082",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:27.572367",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "> **[REFERENCE QC Cloud]**\n",
     "> Ce notebook illustre du code QuantConnect a executer dans l'IDE Cloud (https://www.quantconnect.com/research).\n",
@@ -74,7 +92,16 @@
   {
    "cell_type": "markdown",
    "id": "1bb3ca37",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009473,
+     "end_time": "2026-08-21T10:27:27.594665",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:27.585192",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -114,7 +141,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-f5b25118",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006817,
+     "end_time": "2026-08-21T10:27:27.609457",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:27.602640",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -136,15 +172,20 @@
     "\n",
     "### Cas d'Usage\n",
     "\n",
-    "```\n",
-    "                        LLMs en Trading\n",
-    "                              |\n",
-    "       +----------------------+----------------------+\n",
-    "       |                      |                      |\n",
-    "  Analyse de News        Interpretation        Generation\n",
-    "  - Sentiment            - Earnings calls      - Reports\n",
-    "  - Event extraction     - SEC filings         - Stratégies\n",
-    "  - Summarization        - Economic data       - Code\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    LLM[\"LLMs en Trading\"] --> News[\"Analyse de News\"]\n",
+    "    LLM --> Interp[\"Interpretation\"]\n",
+    "    LLM --> Gen[\"Generation\"]\n",
+    "    News --> N1[\"- Sentiment\"]\n",
+    "    News --> N2[\"- Event extraction\"]\n",
+    "    News --> N3[\"- Summarization\"]\n",
+    "    Interp --> I1[\"- Earnings calls\"]\n",
+    "    Interp --> I2[\"- SEC filings\"]\n",
+    "    Interp --> I3[\"- Economic data\"]\n",
+    "    Gen --> G1[\"- Reports\"]\n",
+    "    Gen --> G2[\"- Strategies\"]\n",
+    "    Gen --> G3[\"- Code\"]\n",
     "```\n",
     "\n",
     "### Avantages vs Limites\n",
@@ -162,8 +203,36 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "cell-497228b7",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:27.624781Z",
+     "iopub.status.busy": "2026-08-21T10:27:27.623765Z",
+     "iopub.status.idle": "2026-08-21T10:27:29.535033Z",
+     "shell.execute_reply": "2026-08-21T10:27:29.533681Z"
+    },
+    "papermill": {
+     "duration": 1.919805,
+     "end_time": "2026-08-21T10:27:29.536233",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:27.616428",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Anthropic not installed. Run: pip install anthropic\n",
+      "OpenAI disponible: True\n",
+      "Anthropic disponible: False\n",
+      "\n",
+      "Note: Ce notebook necessite des cles API valides pour les appels reels.\n",
+      "Les exemples utilisent des reponses simulees si les APIs ne sont pas configurees.\n"
+     ]
+    }
+   ],
    "source": [
     "# Imports et configuration\n",
     "\n",
@@ -209,7 +278,16 @@
   {
    "cell_type": "markdown",
    "id": "5f570345",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005935,
+     "end_time": "2026-08-21T10:27:29.548231",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.542296",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "On intègre ici un grand modèle de langage (LLM) pour analyser les actualités financières et en extraire des signaux de sentiment.\n",
     "\n",
@@ -238,13 +316,32 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "cell-e26a2bda",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:29.562978Z",
+     "iopub.status.busy": "2026-08-21T10:27:29.562663Z",
+     "iopub.status.idle": "2026-08-21T10:27:29.580706Z",
+     "shell.execute_reply": "2026-08-21T10:27:29.579272Z"
+    },
+    "papermill": {
+     "duration": 0.026456,
+     "end_time": "2026-08-21T10:27:29.581768",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.555312",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Configuration LLM:  OpenAI Key: Non configuree  Anthropic Key: Non configuree  OpenAI Model: gpt-4o-mini  Claude Model: claude-3-5-sonnet-20241022"
+      "Configuration LLM:\n",
+      "  OpenAI Key: Non configuree\n",
+      "  Anthropic Key: Non configuree\n",
+      "  OpenAI Model: gpt-4o-mini\n",
+      "  Claude Model: claude-3-5-sonnet-20241022\n"
      ]
     }
    ],
@@ -282,19 +379,37 @@
   {
    "cell_type": "markdown",
    "id": "6e284a3f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005734,
+     "end_time": "2026-08-21T10:27:29.593874",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.588140",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Interpretation** : L'output confirme un pattern honnete : **OpenAI Key: Non configuree**, **Anthropic Key: Non configuree**. C'est une **conception defensive** intentionnelle : la cellule de configuration detecte l'absence de cle API et bascule en **mode simule** plutot que de crasher. Cette approche suit la regle F (regle env/kernel : reparer, jamais contourner) — au lieu de cacher l'absence de cle derriere un fallback silencieux, le notebook **declare explicitement** que la cle manque et continue avec des donnees generees. Cote modeles, le defaut est **gpt-4o-mini** (OpenAI) et **claude-3-5-sonnet-20241022** (Anthropic), deux modeles SOTA 2024-2026 qui representent le compromis cout/qualite actuel du marche.\n",
     "\n",
     "Trois choses a observer sur la configuration : (1) la **detection automatique** des variables d'environnement (via `os.getenv`) distingue soigneusement entre cle absente, cle vide, et cle valide — c'est une pratique recommandee pour les notebooks partages (un etudiant qui re-execute ne doit pas voir le code crasher si un autre a oublie sa cle) ; (2) le **mode simule** n'est pas un **workaround degrade** au sens sota-not-workaround.md (le mode simule est explicitement labellise comme tel, et le notebook documente ses limites) — c'est une **graceful degradation** pedagogique ; (3) les **modeles choisis** (gpt-4o-mini et claude-3-5-sonnet, dans les modeles low-cost chacun chez son fournisseur) refletent la strategie budget/qualite documentee plus loin dans la cellule 9 (cost tracking).\n",
     "\n",
-    "L'envers du decor : le paysage des modeles low-cost a considerablement evolue depuis 2024. Des alternatives comme une **version mini actualisee** d'OpenAI, une **version haiku** d'Anthropic, ou des modeles open-source recents en 8B ou plus peuvent tenir le meme role a des couts encore plus bas. Pour une refonte du notebook en 2026, il faudrait ajouter une **boucle de negociation modele** qui teste plusieurs modeles en parallele et conserve le meilleur ratio qualit\\/prix. C'est exactement la problematique abordee dans les notebooks ML-Training-Pipeline (ML-3 a ML-12) sur le trade-off cout \\/ performance.\n"
+    "L'envers du decor : le paysage des modeles low-cost a considerablement evolue depuis 2024. Des alternatives comme une **version mini actualisee** d'OpenAI, une **version haiku** d'Anthropic, ou des modeles open-source recents en 8B ou plus peuvent tenir le meme role a des couts encore plus bas. Pour une refonte du notebook en 2026, il faudrait ajouter une **boucle de negociation modele** qui teste plusieurs modeles en parallele et conserve le meilleur ratio qualité/prix. C'est exactement la problematique abordee dans les notebooks ML-Training-Pipeline (ML-3 a ML-12) sur le trade-off cout / performance.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "175a0518",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006513,
+     "end_time": "2026-08-21T10:27:29.607594",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.601081",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -313,7 +428,7 @@
     "\n",
     "Pour une stratégie quotidienne analysant 10 articles par actif, 50 actifs :\n",
     "\n",
-    "```\n",
+    "```text\n",
     "Tokens par analyse: ~500 input + ~200 output\n",
     "Analyses par jour: 10 * 50 = 500\n",
     "Tokens par jour: 500 * 700 = 350,000\n",
@@ -352,13 +467,33 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "cell-8f196758",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:29.623771Z",
+     "iopub.status.busy": "2026-08-21T10:27:29.623771Z",
+     "iopub.status.idle": "2026-08-21T10:27:29.642931Z",
+     "shell.execute_reply": "2026-08-21T10:27:29.641597Z"
+    },
+    "papermill": {
+     "duration": 0.027985,
+     "end_time": "2026-08-21T10:27:29.643461",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.615476",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Usage Report:  Requests: 10  Input tokens: 5,000  Output tokens: 2,000  Estimated cost: $0.0019  Budget remaining: $4.9981"
+      "Usage Report:\n",
+      "  Requests: 10\n",
+      "  Input tokens: 5,000\n",
+      "  Output tokens: 2,000\n",
+      "  Estimated cost: $0.0019\n",
+      "  Budget remaining: $4.9981\n"
      ]
     }
    ],
@@ -431,7 +566,16 @@
   {
    "cell_type": "markdown",
    "id": "cf4c59a7",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006221,
+     "end_time": "2026-08-21T10:27:29.656557",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.650336",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Interpretation** : Les **chiffres de cout** sont **eclatants** : **10 requests** consomme **5,000 input tokens** et **2,000 output tokens**, pour un **cout estime de $0.0019** et un **budget restant de $4.9981** (sur un budget initial de $5.00). En ramenant a l'unite : **une fraction de cent par request**, soit **quelques fractions de cent par analyse sentiment**. C'est un ordre de grandeur minuscule, ce qui explique pourquoi l'IA generative a **democratise** la recherche financiere en 2023-2026 : un trader retail peut maintenant analyser des **milliers de sentiments par jour** pour le prix d'un petit cafe. Sur des strategies de production, des **centaines de milliers de sentiments par jour** couteraient quelques dizaines de dollars, ce qui reste tres inferieur aux couts de donnees traditionnelles (Bloomberg Terminal : $2 000+/mois).\n",
     "\n",
@@ -443,7 +587,16 @@
   {
    "cell_type": "markdown",
    "id": "3ee3c19b",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006126,
+     "end_time": "2026-08-21T10:27:29.669445",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.663319",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "### Exercice 1.1 : Estimation des couts API pour le trading\n",
@@ -461,8 +614,8 @@
     "- Determinez le PnL minimum requis pour couvrir les couts API\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : `cout_par_analyse = (input_tokens/1000)*prix_in + (output_tokens/1000)*prix_out`\n",
-    "- # Indice : PnL minimum = cout_annuel * (1 + marge)\n",
+    "- **Indice 1** : `cout_par_analyse = (input_tokens/1000)*prix_in + (output_tokens/1000)*prix_out`\n",
+    "- **Indice 2** : PnL minimum = cout_annuel * (1 + marge)\n",
     "\n",
     "### Lecture du résultat\n",
     "\n",
@@ -486,10 +639,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "cell-f3ce82c0",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:29.683847Z",
+     "iopub.status.busy": "2026-08-21T10:27:29.683847Z",
+     "iopub.status.idle": "2026-08-21T10:27:29.692206Z",
+     "shell.execute_reply": "2026-08-21T10:27:29.691593Z"
+    },
+    "papermill": {
+     "duration": 0.017318,
+     "end_time": "2026-08-21T10:27:29.693379",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.676061",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
    "source": [
     "# Exercice 1.1 : Estimation couts API\n",
     "# TODO etudiant : Calculer le cout quotidien d'un systeme LLM\n",
@@ -506,7 +682,16 @@
   {
    "cell_type": "markdown",
    "id": "4a75b81e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005897,
+     "end_time": "2026-08-21T10:27:29.705809",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.699912",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 1.2 : Estimation du cout mensuel d'une stratégie multi-actifs\n",
     "\n",
@@ -543,15 +728,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "cell-135ccd50",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:29.720582Z",
+     "iopub.status.busy": "2026-08-21T10:27:29.720582Z",
+     "iopub.status.idle": "2026-08-21T10:27:29.739047Z",
+     "shell.execute_reply": "2026-08-21T10:27:29.737757Z"
+    },
+    "papermill": {
+     "duration": 0.026187,
+     "end_time": "2026-08-21T10:27:29.739635",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.713448",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice a completer : Cout mensuel API multi-actifs\n"
      ]
     }
    ],
@@ -568,7 +768,16 @@
   {
    "cell_type": "markdown",
    "id": "ea999754",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006262,
+     "end_time": "2026-08-21T10:27:29.752915",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.746653",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -586,7 +795,7 @@
     "\n",
     "### Template de Prompt\n",
     "\n",
-    "```\n",
+    "```text\n",
     "[RÔLE]\n",
     "Tu es un analyste financier quantitatif...\n",
     "\n",
@@ -627,15 +836,50 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "cell-dad153f2",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:29.767579Z",
+     "iopub.status.busy": "2026-08-21T10:27:29.766937Z",
+     "iopub.status.idle": "2026-08-21T10:27:29.784563Z",
+     "shell.execute_reply": "2026-08-21T10:27:29.783460Z"
+    },
+    "papermill": {
+     "duration": 0.025394,
+     "end_time": "2026-08-21T10:27:29.784563",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.759169",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Templates de Prompts Disponibles:  1. SENTIMENT_ANALYSIS - Analyse de sentiment de news  2. EARNINGS_ANALYSIS - Analyse de resultats  3. MULTI_ASSET_SUMMARY - Resume multi-actifs  4. TECHNICAL_INTERPRETATION - Interpretation techniqueExemple de prompt formate (757 caracteres):You are a senior quantitative analyst at a hedge fund. Your task is to analyze financial news and determine the market sentiment for a specific stock.RULES:1. Focus on facts that could impact stock price in the next 1-5 days2. Ignore general market commentary unless directly relevant3. Weight recent information more heavily4. Consider both explicit statements and implicit implicationsOUTPUT FORMAT (JSON only, no other text):{    \"sentiment\": \"BULLISH\" | \"BEARISH\" | \"NEUTRAL\",    \"co..."
+      "Templates de Prompts Disponibles:\n",
+      "  1. SENTIMENT_ANALYSIS - Analyse de sentiment de news\n",
+      "  2. EARNINGS_ANALYSIS - Analyse de resultats\n",
+      "  3. MULTI_ASSET_SUMMARY - Resume multi-actifs\n",
+      "  4. TECHNICAL_INTERPRETATION - Interpretation technique\n",
+      "\n",
+      "Exemple de prompt formate (757 caracteres):\n",
+      "\n",
+      "You are a senior quantitative analyst at a hedge fund. Your task is to analyze \n",
+      "financial news and determine the market sentiment for a specific stock.\n",
+      "\n",
+      "RULES:\n",
+      "1. Focus on facts that could impact stock price in the next 1-5 days\n",
+      "2. Ignore general market commentary unless directly relevant\n",
+      "3. Weight recent information more heavily\n",
+      "4. Consider both explicit statements and implicit implications\n",
+      "\n",
+      "OUTPUT FORMAT (JSON only, no other text):\n",
+      "{\n",
+      "    \"sentiment\": \"BULLISH\" | \"BEARISH\" | \"NEUTRAL\",\n",
+      "    \"co...\n"
      ]
     }
    ],
@@ -761,19 +1005,37 @@
   {
    "cell_type": "markdown",
    "id": "31f5533f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.005956,
+     "end_time": "2026-08-21T10:27:29.798193",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.792237",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Interpretation** : La cellule expose **4 templates de prompts** specialises pour le trading : **SENTIMENT_ANALYSIS** (analyse de news), **EARNINGS_ANALYSIS** (resultats d'entreprise), **MULTI_ASSET_SUMMARY** (resume multi-actifs), **TECHNICAL_INTERPRETATION** (interpretation de signaux). Le **prompt formate** genere pour sentiment fait **757 caracteres** — c'est le patron verbatim qui sera envoye a l'API. Cette longueur est typique : un prompt professionnel tient en 500-1000 caracteres, combinant **system role** (tu es un analyste quant senior), **task** (analyse le sentiment de cette news), **format de sortie** (JSON avec sentiment, confidence, signal), et **exemples few-shot** optionnels. La structure est coherente avec les **bonnes pratiques 2024-2026** du prompt engineering SOTA (Brown et al. 2020, *Language Models are Few-Shot Learners* (GPT-3), arXiv:2005.14165, puis refinements OpenAI/Anthropic).\n",
     "\n",
     "Trois choses a observer sur la structure des prompts : (1) chaque template definit un **role specialise** (analyste quant, analyste financier, multi-actifs) qui **amorce la voix** du LLM — c'est la **technique role-priming** decrite dans les guides Anthropic 2024 ; (2) le **format JSON en sortie** est impose explicitement, ce qui evite le **parsing fragile** de texte libre et permet un **post-traitement deterministe** (extraction des champs `sentiment`, `confidence`, `signal`) ; (3) l'**exemple few-shot** (sample fictif de news) donne au modele un **template de raisonnement** a suivre, augmentant la coherence sur des cas ambigus. C'est un peu comme un **exemple resolu** en pedagogie : le modele apprend la structure par imitation, pas seulement par description des regles.\n",
     "\n",
-    "L'envers du decor : la **longeur 757 chars** est-elle optimale ? Des etudes 2024-2025 (notamment Anthropic Prompt Engineering Guide) montrent qu'au-dela de **~1 500 chars**, les prompts commencent a **diluer l'attention** du modele — le ratio signal\\/bruit baisse, et les conseils contradictoires (system role + few-shot + format) peuvent interferer. Pour une refonte en 2026, il faudrait **A/B tester** differentes longueurs (500 chars, 757 chars, 1 200 chars, 1 500 chars) et mesurer la **qualite de sortie** (calibration des sentiments, taux de JSON valide, distribution des confidences). C'est exactement le genre de validation que le CI H.7 P3 pourrait systematiser via **Promptfoo** ou **Braintrust**.\n"
+    "L'envers du decor : la **longeur 757 chars** est-elle optimale ? Des etudes 2024-2025 (notamment Anthropic Prompt Engineering Guide) montrent qu'au-dela de **~1 500 chars**, les prompts commencent a **diluer l'attention** du modele — le ratio signal/bruit baisse, et les conseils contradictoires (system role + few-shot + format) peuvent interferer. Pour une refonte en 2026, il faudrait **A/B tester** differentes longueurs (500 chars, 757 chars, 1 200 chars, 1 500 chars) et mesurer la **qualite de sortie** (calibration des sentiments, taux de JSON valide, distribution des confidences). C'est exactement le genre de validation que le CI H.7 P3 pourrait systematiser via **Promptfoo** ou **Braintrust**.\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "dc22c5fa",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006206,
+     "end_time": "2026-08-21T10:27:29.810618",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.804412",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -781,26 +1043,12 @@
     "\n",
     "### Architecture\n",
     "\n",
-    "```\n",
-    "News Feed\n",
-    "    |\n",
-    "    v\n",
-    "Preprocessing\n",
-    "  - Filtrage\n",
-    "  - Chunking\n",
-    "    |\n",
-    "    v\n",
-    "GPT-4 API\n",
-    "  - Prompt template\n",
-    "  - JSON parsing\n",
-    "    |\n",
-    "    v\n",
-    "Signal Processing\n",
-    "  - Aggregation\n",
-    "  - Confidence weighting\n",
-    "    |\n",
-    "    v\n",
-    "Trading Signal\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    A[\"News Feed\"] --> B[\"Preprocessing<br/>- Filtrage<br/>- Chunking\"]\n",
+    "    B --> C[\"GPT-4 API<br/>- Prompt template<br/>- JSON parsing\"]\n",
+    "    C --> D[\"Signal Processing<br/>- Aggregation<br/>- Confidence weighting\"]\n",
+    "    D --> E[\"Trading Signal\"]\n",
     "```\n",
     "\n",
     "### Lecture du résultat\n",
@@ -828,15 +1076,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "cell-f7c2f006",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:29.827506Z",
+     "iopub.status.busy": "2026-08-21T10:27:29.826951Z",
+     "iopub.status.idle": "2026-08-21T10:27:29.845449Z",
+     "shell.execute_reply": "2026-08-21T10:27:29.844177Z"
+    },
+    "papermill": {
+     "duration": 0.028904,
+     "end_time": "2026-08-21T10:27:29.846464",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.817560",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LLM Client initialise"
+      "LLM Client initialise\n"
      ]
     }
    ],
@@ -1001,7 +1264,16 @@
   {
    "cell_type": "markdown",
    "id": "93ed8b81",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007122,
+     "end_time": "2026-08-21T10:27:29.860459",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.853337",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "On post-traite les sorties du LLM pour transformer les scores de sentiment en signaux de trading quantifiables.\n",
     "\n",
@@ -1031,15 +1303,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "cell-611367e6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:29.877276Z",
+     "iopub.status.busy": "2026-08-21T10:27:29.876747Z",
+     "iopub.status.idle": "2026-08-21T10:27:29.954049Z",
+     "shell.execute_reply": "2026-08-21T10:27:29.952252Z"
+    },
+    "papermill": {
+     "duration": 0.086836,
+     "end_time": "2026-08-21T10:27:29.954599",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.867763",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Analyse de Sentiment - AAPL============================================================News 1:  Sentiment: BULLISH  Confidence: 0.80  Signal: 0.80  Source: simulatedNews 2:  Sentiment: NEUTRAL  Confidence: 0.50  Signal: 0.00  Source: simulatedNews 3:  Sentiment: BULLISH  Confidence: 0.80  Signal: 0.80  Source: simulatedSignal Agrege: 0.61 (confiance: 0.70)"
+      "Analyse de Sentiment - AAPL\n",
+      "============================================================\n",
+      "\n",
+      "News 1:\n",
+      "  Sentiment: BULLISH\n",
+      "  Confidence: 0.80\n",
+      "  Signal: 0.80\n",
+      "  Source: simulated\n",
+      "\n",
+      "News 2:\n",
+      "  Sentiment: NEUTRAL\n",
+      "  Confidence: 0.50\n",
+      "  Signal: 0.00\n",
+      "  Source: simulated\n",
+      "\n",
+      "News 3:\n",
+      "  Sentiment: BULLISH\n",
+      "  Confidence: 0.80\n",
+      "  Signal: 0.80\n",
+      "  Source: simulated\n",
+      "\n",
+      "Signal Agrege: 0.61 (confiance: 0.70)\n"
      ]
     }
    ],
@@ -1173,7 +1481,16 @@
   {
    "cell_type": "markdown",
    "id": "6be14a0a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008608,
+     "end_time": "2026-08-21T10:27:29.971341",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.962733",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Interpretation** : Le **resultat** presente 3 news analysees : **News 1 BULLISH** (confidence 0.80, signal 0.80), **News 2 NEUTRAL** (confidence 0.50, signal 0.00), **News 3 BULLISH** (confidence 0.80, signal 0.80). Le **signal agrege est 0.61** — un signal net positif, indiquant que la majorite des news concourent a un sentiment haussier. Le **0.61** est superieur a la **moyenne simple** des 3 signaux individuels, ce qui reflete probablement une **ponderation par les confidences** (les news BULLISH ont confidence 0.80, la NEUTRAL a 0.50) ou un **biais directionnel** dans la couche d'agregation. C'est typiquement le genre de detail **methode vs cumul** que le notebook documente mais qui meriterait etre explicite dans le code.\n",
     "\n",
@@ -1185,7 +1502,16 @@
   {
    "cell_type": "markdown",
    "id": "1afaca3a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008216,
+     "end_time": "2026-08-21T10:27:29.987994",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.979778",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "### Exercice 2.1 : Prompt engineering pour le sentiment financier\n",
@@ -1202,8 +1528,8 @@
     "- Affichez l'accuracy de chaque approche\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : Simulez les reponses LLM avec des fonctions mock\n",
-    "- # Indice : Labels pre-définis = `{'AAPL beats expectations': 1, 'Market crash fears': -1, ...}`\n",
+    "- **Indice 1** : Simulez les reponses LLM avec des fonctions mock\n",
+    "- **Indice 2** : Labels pre-définis = `{'AAPL beats expectations': 1, 'Market crash fears': -1, ...}`\n",
     "\n",
     "### Lecture du résultat\n",
     "\n",
@@ -1233,10 +1559,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "cell-5f783234",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:30.005111Z",
+     "iopub.status.busy": "2026-08-21T10:27:30.005111Z",
+     "iopub.status.idle": "2026-08-21T10:27:30.015237Z",
+     "shell.execute_reply": "2026-08-21T10:27:30.014529Z"
+    },
+    "papermill": {
+     "duration": 0.020658,
+     "end_time": "2026-08-21T10:27:30.016258",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:29.995600",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
    "source": [
     "# Exercice 2.1 : Prompt engineering compare\n",
     "# TODO etudiant : Comparer zero-shot, few-shot et chain-of-thought\n",
@@ -1253,7 +1602,16 @@
   {
    "cell_type": "markdown",
    "id": "26c58a21",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006192,
+     "end_time": "2026-08-21T10:27:30.033557",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.027365",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 2.2 : Prompt personnalise pour l'analyse de results d'entreprise\n",
     "\n",
@@ -1293,15 +1651,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "cell-f10d87fa",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:30.050721Z",
+     "iopub.status.busy": "2026-08-21T10:27:30.050721Z",
+     "iopub.status.idle": "2026-08-21T10:27:30.061712Z",
+     "shell.execute_reply": "2026-08-21T10:27:30.060856Z"
+    },
+    "papermill": {
+     "duration": 0.021236,
+     "end_time": "2026-08-21T10:27:30.063233",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.041997",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice a completer : Prompt d'analyse de results d'entreprise\n"
      ]
     }
    ],
@@ -1318,7 +1691,16 @@
   {
    "cell_type": "markdown",
    "id": "1b7dae92",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007811,
+     "end_time": "2026-08-21T10:27:30.080274",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.072463",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -1369,15 +1751,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 11,
    "id": "cell-f6dfba9f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:30.097547Z",
+     "iopub.status.busy": "2026-08-21T10:27:30.095986Z",
+     "iopub.status.idle": "2026-08-21T10:27:30.121893Z",
+     "shell.execute_reply": "2026-08-21T10:27:30.120621Z"
+    },
+    "papermill": {
+     "duration": 0.034013,
+     "end_time": "2026-08-21T10:27:30.122494",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.088481",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Chain-of-Thought Analysis - AAPL============================================================Resultat brut: {  \"sentiment\": \"BULLISH\",  \"confidence\": 0.9,  \"key_factors\": [    \"simulated_factor_1\",    \"simulated_factor_2\"  ],  \"price_impact\": \"MEDIUM\",  \"time_horizon\": \"5 days\",  \"_simulated\": true}..."
+      "Chain-of-Thought Analysis - AAPL\n",
+      "============================================================\n",
+      "\n",
+      "Resultat brut: {\n",
+      "  \"sentiment\": \"BULLISH\",\n",
+      "  \"confidence\": 0.9,\n",
+      "  \"key_factors\": [\n",
+      "    \"simulated_factor_1\",\n",
+      "    \"simulated_factor_2\"\n",
+      "  ],\n",
+      "  \"price_impact\": \"MEDIUM\",\n",
+      "  \"time_horizon\": \"5 days\",\n",
+      "  \"_simulated\": true\n",
+      "}...\n"
      ]
     }
    ],
@@ -1522,7 +1932,16 @@
   {
    "cell_type": "markdown",
    "id": "816abd81",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.008333,
+     "end_time": "2026-08-21T10:27:30.136571",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.128238",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Interpretation** : La cellule expose un **analyseur Chain-of-Thought** (CoT) sur AAPL. La sortie simulee montre un **sentiment BULLISH avec confidence 0.9**, **2 key_factors** simules, **price_impact MEDIUM**, **time_horizon 5 days**. Le **chain-of-thought** est une technique ou le LLM est invite a **decomposer son raisonnement** en etapes intermediates avant de donner la conclusion, ce qui ameliore la qualite des reponses sur des taches complexes (Wei et al. 2022, popularise par Anthropic 2024-2025). Ici, le notebook utilise CoT **sur une seule analyse**, pas sur un batch — c'est un compromis entre latence (CoT est 2-3x plus long en output) et qualite (raisonnement explicite).\n",
     "\n",
@@ -1534,7 +1953,16 @@
   {
    "cell_type": "markdown",
    "id": "7c4f1b6c",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009001,
+     "end_time": "2026-08-21T10:27:30.153921",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.144920",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -1593,15 +2021,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 12,
    "id": "cell-7e6df23f",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:30.169273Z",
+     "iopub.status.busy": "2026-08-21T10:27:30.168761Z",
+     "iopub.status.idle": "2026-08-21T10:27:30.196011Z",
+     "shell.execute_reply": "2026-08-21T10:27:30.194712Z"
+    },
+    "papermill": {
+     "duration": 0.03529,
+     "end_time": "2026-08-21T10:27:30.196585",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.161295",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Systeme Hybride LLM + Technique============================================================Signaux d'entree:  LLM Signal: 0.61 (conf: 0.70)  Technical Signal: 0.58 (conf: 1.00)Signal Fusionne:  Fused Signal: 0.52  Direction: BUY  Position Size: 35.4%"
+      "Systeme Hybride LLM + Technique\n",
+      "============================================================\n",
+      "\n",
+      "Signaux d'entree:\n",
+      "  LLM Signal: 0.61 (conf: 0.70)\n",
+      "  Technical Signal: 0.58 (conf: 1.00)\n",
+      "\n",
+      "Signal Fusionne:\n",
+      "  Fused Signal: 0.52\n",
+      "  Direction: BUY\n",
+      "  Position Size: 35.4%\n"
      ]
     }
    ],
@@ -1821,7 +2274,16 @@
   {
    "cell_type": "markdown",
    "id": "47ac0b4e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007625,
+     "end_time": "2026-08-21T10:27:30.211431",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.203806",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Interpretation** : Le **systeme hybride** combine un **LLM Signal: 0.61** (avec confidence 0.70) et un **Technical Signal: 0.58** (avec confidence 1.00). Le **Signal Fusionne est 0.52**, avec **Direction: BUY** et **Position Size: 35.4%**. La fusion est **plus conservative** que les deux inputs (0.52 < 0.58 < 0.61) parce que les **confiances different** : le LLM est moins sur (0.70) que le technique (1.00), ce qui **tire la moyenne ponderee vers le bas**. C'est exactement le but d'un systeme hybride : **etre plus prudent** quand les sources de signal **ne convergent pas fortement**. La **Position Size 35.4%** reflete cette prudence : sous les 50% en mode agressif, mais avec un signal directionnel clair qui justifie d'agir.\n",
     "\n",
@@ -1833,7 +2295,16 @@
   {
    "cell_type": "markdown",
    "id": "cd61905a",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.007754,
+     "end_time": "2026-08-21T10:27:30.226390",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.218636",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "### Exercice 3.1 : Impact du desaccord entre signaux LLM et techniques\n",
     "\n",
@@ -1877,15 +2348,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "cell-b7d8e4e7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:30.241750Z",
+     "iopub.status.busy": "2026-08-21T10:27:30.241209Z",
+     "iopub.status.idle": "2026-08-21T10:27:30.256093Z",
+     "shell.execute_reply": "2026-08-21T10:27:30.256093Z"
+    },
+    "papermill": {
+     "duration": 0.025954,
+     "end_time": "2026-08-21T10:27:30.257865",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.231911",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exercice a completer\n"
+      "Exercice a completer : Desaccord signaux LLM vs techniques\n"
      ]
     }
    ],
@@ -1902,7 +2388,16 @@
   {
    "cell_type": "markdown",
    "id": "3cde3b61",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.006991,
+     "end_time": "2026-08-21T10:27:30.271849",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.264858",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "On combine les signaux LLM avec les indicateurs techniques classiques pour construire une stratégie hybride texte/prix.\n",
     "\n",
@@ -1934,13 +2429,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 14,
    "id": "cell-54aa8a87",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:30.291844Z",
+     "iopub.status.busy": "2026-08-21T10:27:30.291316Z",
+     "iopub.status.idle": "2026-08-21T10:27:30.836806Z",
+     "shell.execute_reply": "2026-08-21T10:27:30.835552Z"
+    },
+    "papermill": {
+     "duration": 0.558264,
+     "end_time": "2026-08-21T10:27:30.837921",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.279657",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAPeCAYAAAB3GThSAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8fJSN1AAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdd3yN5//H8ffJlsTKEHvvTY2K1aI2VatV0RpVVXSgRmkJJaioUG3NGNGqSlGzWoqO2FRp7R1EECOSNpGc3x9+zjenCZJKcu7E6/l4eDTnuq/7vj/3cTW5vXOd6zaZzWazAAAAAAAAAACGYGfrAgAAAAAAAAAA/0NoCwAAAAAAAAAGQmgLAAAAAAAAAAZCaAsAAAAAAAAABkJoCwAAAAAAAAAGQmgLAAAAAAAAAAZCaAsAAAAAAAAABkJoCwAAAAAAAAAGQmgLAAAAAAAAAAZCaAsgSxoxYoTKlSuncuXKaefOnbYuJ5mdO3da6hsxYoSty8nyZs6caXk/v/32W1uXAwAAkOWsWbNG7du3V7Vq1VSuXDnVqlVLktSkSRPLfVZq3O/bpEmTjCwXqcTfB5B9Odi6AAC47/Lly/r000/122+/6cqVK3J2dpaHh4dKlSqlypUra+DAgbYuMcNdvnxZixcv1i+//KILFy4oMTFRBQoUUNWqVdWhQwfVq1fP1iUCAAAglWJiYrR8+XL98MMPOnHihGJiYuTt7a0yZcqodevWatWqlZycnDK8jv379+u9996T2WzO8HNlZRcuXFDTpk0tr48ePWrDagA86QhtARhCZGSkOnfurMjISEtbfHy8oqOjde7cOW3fvt0qtH3jjTfUuXNnSUr1rACj+/777zVixAjFxMRYtZ86dUqnTp3S5s2btWfPHhtVZ1udOnWyBNYlSpSwcTUAAACPduLECb3xxhs6f/68VXt4eLjCw8O1detWlS1bVhUqVMjwWrZu3WoJbF988UW1b99eDg734oCgoCD9888/GV4DACBtCG0BGEJISIglsK1Xr566d+8uV1dXhYeH6+DBg/rxxx+t+hcvXlzFixe3QaUZY//+/RoyZIji4+MlSVWrVlX37t2VP39+XblyRVu3btWvv/5q4yozX0xMjFxdXVWwYEEVLFjQ1uUAAACkyo0bN9S3b19dvHhRkpQvXz716dNH5cqV0507d7Rr165MXfLpypUrlq9bt25tWRpBkqpUqZJpdQAAUo/QFoAhHD582PL1yJEjrWbPdu3aVaNGjbLqP2LECK1cuVKStHjxYtWtW1eSlJiYqM8++0zLly/XzZs3VbVqVb3//vuaOHGidu3aJUnavHmzChcubPXxpzp16ui9997Txx9/rIMHD8rd3V2dO3fW22+/LTu7e8t/R0REaPr06Tp8+LAiIiIUHR0tNzc3lS9fXq+88oqaNWv2n69/8uTJlsC2Ro0aWrJkiRwdHS3b27dvr5MnT1rtExkZqdmzZ2vr1q26fPmyXFxcVKFCBb388stq1aqVpd+/r3PAgAGaMmWKTpw4oVKlSmnEiBGqW7euvvzyS82fP19XrlxRpUqVNHbsWJUvX95ynB49eljew++++07Lli3Thg0b9Pfff6tu3boaNWqUihYtaun/zTffaOPGjTp58qRu3LihhIQEFShQQA0bNtSAAQPk4eGR4rG//fZbhYSEaMuWLbpx44aOHj2qmTNn6tNPP5UkBQQEqGPHjpKkI0eOKCgoSAcOHNCtW7fk7u6u/Pnzq1q1anrjjTesgt6wsDAFBwfr999/1507d+Tp6al69erpjTfesPoFQNJzTZw4Ubdv39bSpUt16dIllSxZUiNHjmSZCgAA8FALFiywBLY5c+bUihUr5OPjY9nerFkz9evXT/b29pa2uLg4LVy4UOvWrdPZs2dlNptVrFgxtW3bVj179rRaRqFJkyYKDw+XJP3yyy+aMmWKtm7dqrt376px48YaO3as8uTJk+zj/pL06quvSrp3X7hkyRKrYyVdDuD69euaNGmSNm/eLJPJpCZNmjz0WQ3x8fEKCQnRmjVrdOrUKUlSmTJl5Ofnp+eff96q7/17/UKFCmnBggWaNGmSdu7cKUdHR7Vs2VKjRo2Ss7Oz1T5r167V119/rSNHjig2Nlb58uXTU089pQ8//FA5c+ZMcw3p4fr165o9e7Z++uknXbx4UTly5FCNGjX05ptvqnr16pLu/Tvn/r1rkyZN9Pnnn1v2j4iIUOPGjWU2m1WlShWtWLEiXa4jMTFRs2fP1rp163Tu3DmZzWZ5enqqbNmyeu6559SlS5d0ficAZARCWwCG4ObmZvl6+vTp6tOnj6pWrWq5Oc2RI0eqjjNx4kQtWbLE8nrXrl3q0aOHcuXK9dD9Tp8+rR49eujvv/+WJP3999/64osvVLhwYctNzaVLl5LNiLh586Z27typnTt3avLkyerQoUOq6kzq0qVL2r9/v+X14MGDrQLb+0qVKmX5+vz58+rWrVuy5SR27dqlXbt26fDhwxo6dGiyY5w9e1avv/665SNwf/75p15//XW9/PLLWrBggaXf/v379eabb2rTpk2Wj84l9fbbb+v06dOW11u3btVff/2l1atXK2/evJKkjRs36pdffkl2/rNnzyosLEwrV65MdjN+/9j//hhhSqKiotSrVy9dv37d0nbjxg3duHFDR44cUcuWLS2h7dKlSzV+/HirddwuX76slStXatOmTVq4cKGqVq2a7Byff/65VS1Hjx7VgAED9NNPPyl37tyPrBEAADyZ1q9fb/m6Z8+eVoHtfZ6enpav4+Li1Lt3b+3evduqz9GjR3X06FFt375dCxYsSHH9227dulndr2zYsEEODg6aOnXqf64/Li5Offr00Z9//mlpW716tY4cOZJi//j4ePXt21dhYWFW7QcPHtSwYcN07Ngxvffee8n2u3nzpl588UXduHHD0vb1118rb968evfddy1t77//vkJDQ632vb/MxNtvv62cOXP+5xr+q4sXL6pbt266fPmypS0+Pl7btm3Tb7/9pqCgIDVt2lSVKlVSqVKldPLkSf3666+Kjo6Wu7u7pHvLo92/P23fvr3lGI97HZ9//rlmzJhh1Xbp0iVdunRJt2/fJrQFsgg7WxcAAJLk6+tr+XrLli3q3r27atasqW7dumnBggXJ1nlNyalTpxQSEiJJsrOz04ABA/TFF1+oatWqltkDDxIZGamKFSvqs88+U48ePSzty5Yts3zt5eWlIUOGaObMmVq4cKEWL16syZMnW2aMJv2teVokvfm1t7dXjRo1HrmPv7+/JbCtU6eOPv/8c40cOdISgs6dO1e///57sv0iIiLk6+urOXPm6Omnn5Z0L6BesGCBunTpotmzZ6tkyZKS7t0I/zt0ve/GjRsKCAhQUFCQihQpYjn27NmzLX1at26tiRMnas6cOVqyZInmzJljCbVPnjypTZs2pXjsS5cuaeDAgZo/f75Gjhz5wPfgwIEDlsC2bdu2Cg4O1qxZszR8+HDVqVPHMkP60qVLCggIkNlslp2dnfr37685c+aoZcuWkqQ7d+5o5MiRKT6Y4/z58+rbt68+//xzy6zjO3fuaO3atQ+sCwAAPNnu3LljFaI+9dRTj9xn4cKFlsC2QIECCgwM1LRp0yy/gN69e7cWLlyY4r5///23Pv74Y40ZM8byi//169fr9u3bypcvn5YuXapGjRpZ+o8ePVpLly7V6NGjH1jPt99+awls8+TJo4kTJyooKOiB9+SLFy+2hIzVq1fXrFmzNGPGDMuzCObNm5fivWl0dLQ8PDw0c+ZMvf3225b2r7/+2vL1999/bwls7e3t1bt3b82ZM0eTJ09W/fr1ZTKZHquG/8rf398S2Hbo0EHz5s3T2LFj5erqqvj4eL3//vuW96tdu3aSpH/++Udbt261urb719WmTZt0u47NmzdLknLlyqWPP/5YCxcu1OTJk/XSSy/J29s7nd4BABmNmbYADKFz587avXu31qxZY2mLj4/Xvn37tG/fPn311VdasWLFQ2c3bt682RK8Pffcc3rrrbckSTVr1lSjRo0ss2hT4ujoqJkzZ8rLy0vPPvusVqxYodjYWJ07d87Sp3DhwvL29taiRYt07Ngx3b592yroO3PmjNVvzlPr9u3blq/z5s2b4izbpG7cuGEJU52cnDRjxgzL7NaIiAjLjNm1a9eqWrVqVvu6uLho6tSpcnd3V2xsrHbs2CFJKliwoMaPHy+TyaSTJ09qypQpku7NjE3JkCFDLB/zypUrl3r16iVJ+vHHHy0fm/P19dVnn32m3377TVeuXFFcXJzVMQ4dOmS5gU3qtdde06BBgyRJDRo0eOD7kHQGcP78+VWiRAnlz59fJpNJvXv3tmz7/vvvLUtPPPfcc3rnnXcs9e3du1eRkZE6ceKEjhw5kuxBIE2bNrXMWP77778tMz4e9L4AAABER0dbvc6XL98j90n6C+ExY8bo2WeflSS5urrqjTfekCStW7dOr7/+erJ9x44da1mma8uWLfr555+VkJCg8PBwlS9fXrVq1bJ87F6SypYta7WmbUruh36S9NZbb6lTp06SrO/7kvruu+8sX/fs2VN58uSRdC+svD/j87vvvkt2bypJ06ZNU4UKFdS8eXPLcgBRUVG6ffu2cubMqdWrV1v6vvbaaxo8eLDlddJPuT1ODWl148YNbdu2TZLk7e1tmblapkwZ1a9fXz/88INu3Lihn3/+WS1atFDbtm0VFBQks9ms77//Xm3btlVkZKT27dsn6d596f2Z1+lxHff/PZEjRw4VLVpU5cqVU44cOf7TpwIB2A6hLQBDsLe319SpU9WjRw9t3LhRO3bs0JEjR5SYmChJOnfunObPn291k/ZvSWc0JP2oe+7cuVWyZEmrj3f9W8mSJeXl5SXp3izdXLlyKTY2Vrdu3bL0WbhwoQICAh56HffXVU2L+2twSfc+8h8fH//Q4Pb+GmeSVLRoUUtgK1k/SOLMmTPJ9i1RooSlvqQBeKVKlSyzFJIeL2mgnFTS9zfp1+Hh4TKbzbpz545eeuklq4+L/VvS9zap+/9IeZRatWqpePHiOnPmjObNm6d58+bJzc1NlSpVUrt27dS5c2fZ2dlZLeOQtFZHR0dVqFDBMmP59OnTyULbOnXqWL6+f8MsPfh9AQAA+Pe94JUrV6yWuUpJ0vu2pGFc0nuXlO7tJKl27dqWr5PerzzoXis1kt5XJ72/TGk5qX/Xdv8X5P/27+czSPfeq6T3X/+uP2fOnFbHfuaZZx5Y83+t4b+4v06sdO8Te927d3/o+YoUKaIaNWpo3759+vnnnxUTE6NNmzZZ/q1zf2kEKX2uo3Pnzjpw4IAiIiL04osvymQyqUiRIqpXr5569eplmbULwNgIbQEYSrVq1Sw3qlevXpW/v7/lY/RJH1b2KPcDyNT69wzelNZxTbpW7muvvaYGDRrI0dFR/v7+OnbsmCRZbrzSIunDvhISEvT7778/cvbDgzzqupMGxPeXD5CS/+PivpSWDEiNH3/80RLYlixZUoMGDVK+fPl06NAhS/D9oGMnXd/tYXLkyKGvvvpKX331lXbt2qWTJ08qMjLSsq7vjRs3UpyNktSj3q+kayEnfVDIf31fAABA9ufm5qYiRYpYgs99+/b954eYpuaeNul9bNJ7WKPdr8TGxiZre9g9eEbUn1INGSnp+dq3b699+/YpNjZW27ZtsyyN4OrqmuYHGj/qOrp06SIfHx+tXbtWf/31l86cOaNz587p3Llz2rJli9avX//IZ34AsD3WtAVgCLt379adO3es2ry8vKw+wvOoQLRo0aKWr//44w/L1zdv3rQ8dfVxRERESLo3A+C9995TvXr1VLFiRV25cuWxjlugQAGrdWwDAwMtH+dP6v5v1IsWLWq5gT937pyioqIsfQ4ePGj5unjx4o9V18MkPU/SrwsVKiSTyWR5rySpe/fuat26tWrVqpVsiYSUpDZwN5vN8vDw0IABA7Ro0SL98ssv+vHHH+Xq6ipJlrA/6UyCpLXGx8dbzb5mxgEAAEgvrVu3tny9cOFCq3uj+65du2Z5AFfS+7ak9ytJ1y7NyHu7f7v/zALp3pJW9yWtLamktf3444+WB6gl/fOgNXkfJemx7y9JkNk1/FvS+/GiRYvqzz//THauQ4cOWZZrk6SWLVtaPk331Vdfac+ePZLuLcd1//41va7DbDarUaNGmjJlitasWaP9+/fr1VdflXRvZnDShyADMC5m2gIwhK+//lrbtm1Ty5YtVbt2beXLl0/Xrl3TF198YemT9KNZKWnatKmmTp0qs9msTZs2adasWapUqZIWL1780PVsU6tQoUI6c+aMbty4oTlz5qhcuXJavHix1dNu/6vhw4erR48elnV8u3fvrpdffln58+dXZGSkfvrpJ/3666/auXOn8ubNqwYNGujnn39WXFyc3nnnHfXs2VPnzp3Tl19+aTlm27ZtH7uuB5k2bZocHByUI0cOTZs2zdLetGlTSbI8NEOSQkNDVaRIEZ09e/Y/P6wtJfv27dOECRPUvHlzFStWTHnz5tXRo0ctf9f3A+IWLVpo6tSpio+P1w8//KAZM2aoWrVqWrVqlWVphNKlS1vNeAYAAHgcvXv31po1a3Tx4kXdunVLXbt2Ve/evVW2bFnduXNHu3bt0rfffqslS5YoT548atu2rY4ePSpJGjdunO7cuSOTyaSpU6dajnn/QVWZoUmTJtq+fbskacaMGXJxcZGrq6vVfV9S7dq1szxc94033tBrr72m/Pnz68qVKzp16pS2bNmiXr16WZ6JkBbt27e3rLE7b9483b17V3Xr1tWNGzf03Xffyd/fX4UKFcqQGpK+//f5+vrK19dXjRo10rZt23Tu3Dn1799fnTt3lpubmy5evKg///xTP/zwg5YtW6bChQtLurcEWcOGDbVlyxbt3LnT6vqSSo/reOutt+Tm5qannnpK+fPnV0JCglX4npqJFABsj9AWgGHcunVLy5cv1/Lly5Nt8/b2Vo8ePR66f4kSJeTn56clS5YoISHBslC/u7u7ChUqpPDw8Meqr2vXrpYHdAUGBkq6d/NVokQJq3VT/4saNWooMDBQI0aMUExMjH7//fdkT4VNurTBmDFj1K1bN0VGRmrHjh2WB4rd17dv33R5yMKDeHt7Wx44lrStX79+ku6tS+vt7a3IyEj9+eeflmUKatasaXngwuMym806fPjwA5fNuB9aFyhQQCNHjtT48eOVmJioWbNmWfVzc3NTQEBAmpfUAAAAeJA8efJo7ty5euONN3T+/HldvnxZEydOfGD/nj17atu2bdqzZ4/Cw8OTPcehdu3a6tmzZwZX/T+dOnXSsmXLdOTIEUVFRWnkyJGSHjzb95VXXtEvv/yisLAwnThxItl94uNo2bKlXnjhBa1cuVJ37961PMvgvvvLKGREDXPnzk3W5uzsLF9fX40dO1bdunXT5cuXtW3btofOAr6vXbt22rJli+W1p6enfH19rfqkx3Xcvn1bmzZt0sqVK5Nt8/Ly0tNPP53mYwLIfCyPAMAQBg4cqPfee08NGjRQ0aJF5erqKkdHRxUtWlTdunVTaGiovL29H3mckSNHWtZPdXZ2Vq1atbR48WKrNZty5Mjxn2rs2bOn3nnnHRUqVEg5cuRQnTp1tGjRolTVlRotWrTQhg0b1KdPH5UtW1aurq5ycXFRsWLF1LZtW0sILd37yNq3334rPz8/FS5cWI6OjnJ3d1ft2rX1ySefaOjQoelS04NMmzZNPXr0kIeHh1xcXNSoUSMtXbpUHh4eku4F5cHBwXr66afl6uoqHx8fvfXWW1YfEXtcJUqUUN++fVW9enV5eXnJwcFBrq6uqlKlij788EP17dvX0rd79+4KDg5Wo0aNlCdPHjk4OChfvnzq0KGDvv322wc+VAMAAOC/Kl26tL777juNHDlSTz31lPLkySNHR0cVKFBADRo00OTJky0PKHNyclJwcLCGDBmicuXKycXFRc7OzipbtqyGDBmiBQsWyMnJKdNqv19Pu3bt5O7uLnd3d7Vq1UqLFy9+YP958+Zp9OjRqlq1qtzc3OTs7KzChQvrmWee0YQJE/Tcc8/953omTZqkKVOmqE6dOsqZM6ccHR1VsGBBtWvXzrIubkbX8G8FCxbUypUr1adPH5UsWVLOzs5yc3NTyZIl1aFDB33++ecqUKCA1T5Nmza1epZE69atkz1LIz2u4+WXX1br1q0t/65ycHCQj4+P2rVrpy+//NJqMggA4zKZjbY6OQA8BrPZnGzGZFRUlJ599lnFxsYqV65c2rlzp9VDuJA6PXr00K5duyRJmzdvtnzUCwAAAAAApC+WRwCQrcyfP183b97UM888o4IFCyo8PFxBQUGWJ6y2bNmSwBYAAAAAABgaoS2AbCU2NlZz5szRnDlzkm0rVapUsvXBAAAAAAAAjIbQFkC2UqdOHT3zzDP666+/dP36dTk6Oqp48eJq1qyZevbsKTc3N1uXCAAAAAAA8FCsaQsAAAAAAAAABsLCjgAAAAAAAABgIIS2AAAAAAAAAGAghLYAAAAAAAAAYCA8iOxfIiNv27qEbMXR0V7x8Qm2LgPZEGMLGYFxhYzAuEpf3t45bV2C4XE/mxz/H8LWGIOwNcYgbI0xaC0197TMtEWGMplsXQGyK8YWMgLjChmBcQXYHv8fwtYYg7A1xiBsjTGYdoS2AAAAAAAAAGAghLYAAAAAAAAAYCCEtgAAAAAAAABgIIS2AAAAAAAAAGAghLYAAAAAAAAAYCCEtgAAAAAAAABgIIS2AAAAAAAAAGAghLYAAAAAAAAAYCCEtgAAAAAAAABgIIS2AAAAAAAAAGAghLYAAAAAAAAAYCCEtgAAAAAAAEA29/fff2vUqPfUvHljNWhQS7dv31bnzu20fPmXD92vQYNa2r59a+YUCQsHWxcAAAAAAACA7MnPL0emni8kJDZN/SdMGKvo6NsKCAhMcXvnzu3UtWs3de36crJtly5dVJcu7WVnZ6fQ0LXy9s5n2Xb16lV16tRGCQkJ+uab71SgQMEH1nDhwnktXrxAu3fv1I0bUfLy8lbFipXVrZufypevmKbreZgNG9bq998P6Isv5it37jxyd3fX3LmLlSNH5v4dIXWy3EzbpUuXqkmTJqpSpYq6dOmigwcPPrT/rVu35O/vrwYNGqhy5cpq0aKFtm3blknVAgAAAAAAIDvz8vLWxo3rrNo2bFgrLy/vR+575Mif6tPHT+fPn9V7772vkJBvNHHixypWrLg+/XR6utYZHn5BxYuXUMmSpeXp6SWTyaS8efPKxcUlXc+D9JGlZtquX79eAQEB8vf3V7Vq1bRo0SL16dNHGzdulKenZ7L+cXFx6tWrlzw9PRUUFCQfHx9dvHhRuXLlskH1AAAAeNLt3r1b8+fP16FDhxQZGalZs2apWbNmD91n586dmjRpko4fP64CBQqof//+6tixYyZVDAAAHqVVq7Zat26NevToZWlbv/47tWrVVgsXznvgfmazWRMmjFXhwkU1a9Y82dn9b25lmTLl1KVLN8vrkydPKChoqg4d+kMuLi5q3LiJBg16V66urpL+N2O4SpXq+vrrEMXH31XTps319ttD5ODgoIEDX9eBA/sk3VvuoHr1mvr00znJZhKfP39OkyaN119/HVbBgoX09ttDktUdEXFZn346Xbt375DJZKdq1arr7beHWmYTp1RL8+YtNHDgYDk43Isi4+LiNG/eF/rxx+8VFXVd+fL5qEePnmrbtoMk6dSpE5o1a4YOHtwvF5ccqlOnrgYNGqI8efL8h7+hrClLzbQNDg5W165d1alTJ5UuXVr+/v5ycXFRaGhoiv1DQ0N18+ZNzZo1S0899ZQKFy6sOnXqqHz58plcOQAAACDFxMSoXLlyGjNmTKr6nz9/Xv369VPdunW1evVqvfrqqxo9erR+/vnnDK4UAACkVoMGjRQdfUu//35AkvT77wd0+/Zt1a/f8KH7HT9+VKdPn9JLL3W3Cmzvy5kzpyQpNjZWgwcPVM6cOTVv3iKNHz9Je/bs0iefTLHqv2/fHl28eEEzZszWqFFjtWHDGq1fv0aSNHHix2rX7gVVrlxVq1dv1MSJHyc7X2JiokaNek8ODo6aPXuhhg4dqc8/n2nV5+7duxoyZJBcXV01a9Y8ff75fOXI4aohQwYpPj7+gbWsXfudpRZJ+uijMfrxx+/19ttDFRLyjd57733lyHEvgL59+7beequ/ypYtp3nzligwcIauX7+uDz8c8dD3M7vJMjNt4+LidPjwYfXr18/SZmdnJ19fX+3fvz/FfbZs2aLq1atr3Lhx2rx5szw8PNS2bVv17dtX9vb2mVU6AAAAIElq3LixGjdunOr+y5YtU+HChTVixL1/pJQqVUp79+7VwoUL1bDhw/8hCAAAMoeDg4OaN2+ldetWq1q16lq3brVatGhlmVX6IOfPn5ckFStW/KH9fvhho+Li4jR69DjL+rODB7+n4cMHq3//QfLwuPfp85w5c+ndd4fJ3t5exYoVV716DbR37y61b/+CcuXKLRcXFzk4OMjT0yvF8+zZs0tnz57RtGmfWpZ2eP31ARo69C1Ln82bNykxMVEjRnwgk8kkSXr//TFq2fIZ7d+/V3XqPJ1iLfXrN7TUcu7cWW3Z8oM++WSWateuK0kqVKiw5RyhoV+rbNly6tdvgKVt5MgP1bFjG507d1ZFixZ76PuVXWSZ0DYqKkoJCQnJlkHw9PTUqVOnUtzn/Pnz2rFjh9q1a6c5c+bo3Llz8vf31927dzVw4MAU93F0tNf/j7lM8eKLzpl3sjT4+ut/0uU4Dg6E48gYjC1kBMYVMgLjCo/jwIEDqlevnlVbgwYNNHHiRBtVBAAAUtKmzfN6443e6tdvgH76abNmz16ghISER+xlTtWxz549rdKly1g9MKxKlepKTEzUuXNnLaFtiRIlrSYpenp66dSpE6m+hjNnTitfvvxWa/FWrlzVqs+JE8cVHn5BzZs3smqPi4tTePgFy+t/1+Ll5aXjx49Lko4fPyZ7e3vVqPFUinWcOHFc+/bt0XPPJf8FdXj4BULb7MBsNsvT01Pjx4+Xvb29KleurIiICM2fP/+BoW18/KP+h0r/Go0oLi793of0PBaQFGMLGYFxhYzAuMJ/dfXqVXl5Wc+G8fLyUnR0tP7+++8UHxyS2ZMQsoJu33VRokHvuyXp6+dX2LoEZDB+gQdbs+UYNGXyDyUnp7Rdq52dSSaT6YH7mUySvb1ditsdHe0t/y1btpyKFy+uceNGq0SJEipfvpyOHTtq2Z7S/iVLlpAkhYefU+XKlR5ao52ddY1OTveWU3BwuFebnZ1Jjo6OVn0cHOwkmS1t9vbJj5P0+hwc7GQy6aHn+eefWJUvX0Hjxk1IVmfevHkfWMu95R/u1eLunsNy7JTG5j//xKphw0YaOPDtZNu8vLzT/HecVWWZ0DZv3ryyt7fXtWvXrNqvXbuW7Eb2Pm9vbzk4OFgl+yVLllRkZKTi4uLk5OSUoTUDAAAAmS2zJyFkBYlms8yJxg1t+cXOk4G/Z9iarcZgZk9WS+t1JiaaZTabH7if2SwlJCSmuP3+z9z4+ATFxSWodev2CgycpKFDRyguLiHZ9n8rXry0ihcvqZCQJWrcuFmydW1v376tnDlzqkiR4lq7do1u3oy2zLbdu3ef7OzsVLBgEcXFJaR4HQkJZiUm/q/t36//fX2FCxdTRMRlXbwYYcna9u//XZJ09+69PqVLl9MPP2ySu3tuubm5J7umB9ViNv/v3EWLllRiYqJ27txtWR4hqdKly2nbti3y9PRJcYmJJ+X7aZZ5EJmTk5MqVaqksLAwS1tiYqLCwsJUo0aNFPepWbOmzp07p8TEREvbmTNn5O3tTWALAAAAw/Py8tLVq1et2q5evSp3d/cUZ9kCAIC0i46O1vHjR63+RERctmyPjIxMtv3WrVvJjtOuXQetXfuj2rbtkKrzmkwmvf/+hzp//pwGDHhNYWG/KDz8gk6cOK5Fi+Zr5MghkqTmzVvJyclJEyaM0alTJ7Rv3x598snHatGitWVphPRQq1YdFSlSTBMmjNHx48f0++/7NWfOZ1Z9mjdvpdy582jEiCH6/ff9ungxXPv27dH06R/rypWIVJ2nQIGCatWqrQICxmn79q2WY2ze/IMkqVOnrrp165bGjh2lv/46rPDwC9q5M0wTJ/qnYsmJ7CPLzLSVpF69emn48OGqXLmyqlatqkWLFik2NlYdO3aUJA0bNkw+Pj4aMuTeoO7WrZtCQkI0YcIE+fn56ezZs5o9e7Z69Ohhy8sAAAAAUqV69eravn27Vdtvv/2m6tWr26YgAACyof3796pXr+5WbW3bPq8RIz6QJH311RJ99dUSq+0ffDBOVatWt2pzcHBQnjx50nTuihUra968xVq8eIEmT56gmzdvyNPTS5UrV9Vbbw2WJLm4uGjatE8VFDRVr732qlxcXNS4cRMNGvRu2i70Eezs7DRx4seaNGm8Xn/9VeXPX0DvvPOehgwZZOnj4uKiWbPm6PPPZ2rUqPcUExMjLy9vPfVUHbm5uaX6XEOGjNCcObMUGDhJt27dlI9PfvXo0UvSvSUQPv98vj7/fKbefXeg4uPjlD9/AdWtWy/ZbOTszGQ26qKqDxASEqL58+crMjJSFSpU0OjRo1WtWjVJUo8ePVSoUCFNmjTJ0n///v0KCAjQX3/9JR8fH3Xu3Fl9+/a1WjIhqcjI25lyHff5+eV4dCcbCAmJTZfjODnZPzHT1pG5GFvICIwrZATGVfry9s5p6xIey507d3Tu3DlJUocOHTRy5EjVrVtXuXPnVsGCBRUYGKiIiAhNmTJF0r0H67Zr104vv/yyOnXqpB07dmjChAmaPXu2GjZM/nAOKfPvZ7OCHhteNPTyCCFtltu6BGQwfhbA1hiDsDXGoLXU3NNmudA2oxHa3kNoC6NjbCEjMK6QERhX6Surh7Y7d+7UK6+8kqz9hRde0KRJkzRixAiFh4dryZIlVvsEBAToxIkTyp8/v958803LJ81SQmibHKEtbI2fBbA1xiBsjTFojdD2PyC0/X/d2qXLYUx2pnS7QeZmFknxDR8ZgXGFjMC4Sl9ZPbTNDIS2yRHawtb4WQBbYwzC1hiD1lJzT/vkLAQBAAAAAAAAAFkAoS0AAAAAAAAAGAihLQAAAAAAAAAYCKEtAAAAAAAAABgIoS0AAAAAAAAAGAihLQAAAAAAAAAYCKEtAAAAAAAAABgIoS0AAAAAAACQjubPn62ePV9+7OM0aFBL27dvffyC/l/nzu20fPmX6Xa8xzV//my1a9fccp0TJozVyJFDHrrPwIGvKygoMJMqtB0HWxcAAAAAAACA7MlvXddMPV9Im+Wp7tugQa2Hbu/Vq6/69On3uCU9ltWrNypnzlyZes47d6IVErJI27Zt0eXLl+TunlMlSpRSx46d1ajRszKZTOlynjNnTis4eK4mTpyqSpUqK2fOXKpZs5bMZnO6HD+rI7QFAAAAAADAE2f16o2Wrzdv/kHz53+hL78MtbTlyOFqi7KseHp6Zer5bt++rTff7KM7d+6ob9/+Kl++ouzt7XXgwD599tkM1axZWzlz5kyXc4WHX5AkNWzY2BIEOzk5pcuxswNCWwAAAAAAADxxkgai7u7uMplMVm1r1qzSsmUhunTpovLnL6DOnV9Sx45dLNuvXInQrFlB2rVrh+Lj41SsWAkNHjxclSpVtvTZuHGd5s37Qrdv39LTT/tq+PDRcnV1k3TvY/6lS5eRk5OT1qxZLUdHRz3/fEer2b0NGtTSxIlT1ajRM488Z3j4Bc2cOU2HDx/S33/HqlixEurXb4Bq166b6vdk9uxZunz5kr766lt5eXlb2osWLaZmzVpYQtVbt24pKGiqfv31Z8XHx6l69af0zjtDVaRIUUnS+vVrNGNGoPz9AzRjRqCuXIlQlSrV9f77Y+Tl5aX582crOHiuJKlhw9qSpF9+2aMJE8YqOvq2AgLuLX8QGxurqVMDtH37T3J1ddVLL/VIVnNcXJzmzPlMP/74vaKjb6tEiVLq33+Qataslapa7lu7drWWLVuq8PDzypUrlxo3bqLBg4dLuhdmz5o1Xb/8sk1xcfEqX76CBg0arDJlyqb6vU0r1rQFAAAAAAAAkti0aYPmzftCr7/+pkJCvlG/fgM0b94X2rBhrSQpJiZGAwe+rqtXIzVp0jQtXPiVXn75FZnNiZZjhIdf0M8/b9WUKZ9oypTpOnBgn5YsWWh1ng0b1srFJYfmzFmo/v0HaeHCedq9e0eKNT3qnDExMXr66foKCvpMCxYsVd269TR8+GBdvnw5VdecmJiozZs36bnnWloFtve5urrKweHe/M+JE8fq6NG/NHnyNH3xRbDMZrPee+9t3b1719L/77//1ldfLdEHH4zT7NnzdeXKZc2aNV2S1K1bD73//hhJ92Y8J531nNSsWUE6cGCfAgICNW3aLO3fv1fHjh216vPJJ1N0+PBB+ftP1KJFy/Tss800dOhbOn/+XIq1fPrpXKtaJGnlyhWaNm2K2rd/QYsWLdOkSdNUuHARy/YPPhiuqKjrmjp1hubPX6KyZcvrnXf669atm6l6b/8LZtoCAAAAAAAAScyfP1sDB76jxo2bSJIKFiyk06dPafXqb9WqVVv98MNG3bhxQ/PmLVauXLklySrkkySzOVGjRo21zKxt0aK19u7dbdWnVKky6t37dUlSkSJF9e23y7Vnz27Vrv10spoedc4yZcpazfzs27e/tm//Sb/+uk2dOr34yGu+efOGbt++pWLFij+03/nz5/TLL9v1+efzVaVKNUnSmDHj1bFjG23fvlVNmjSTJN29e1fvvfe+ChUqLCcne3Xs2FULF86TdC8Adne/t8zCg5aAiImJ0bp1q/XBB+NVq1YdSdLo0WP1wgutLX0uX76s9evXKDR0rSVofvnlHtq5M0zr169Rv34DktUiyaoWSVq0aL5eeqm7unbtZmmrUKGSJOn33w/or78Oa82aHywzjQcOfEc//7xVP/20Wc8/3/Hhb+x/RGgLAAAAAAAA/L/Y2FiFh1/QpEnjNWXKBEt7QkKC3NzcJUnHjx9T2bLlLOFpSvLnL2gJbKV74WRUVJRVn1Klyli9vtfneorHe9Q5Y2JitGDBHIWF/aJr164qISFB//zzjyIiUjfTNrUPADt79rTs7e1VseL/loHInTuPihYtprNnT1vaXFxcLCGp9PBrS0l4+AXFx8dbnSdXrtwqWrSY5fWpUyeUkJCgbt2sg9O4uDjlzv2/9+lhtURFXdfVq5GWYPjfTpw4ptjYWLVp09Sq/Z9//rGsy5sRCG0BAAAAAACA/xcbGyNJGj58tFVgKEl2dvdWGnV2dn7kce4vJXCfyWSyWj7hwX1SDk8fdc5Zs6Zr9+6dGjDgHRUuXETOzs4aPXq44uPvPnS/+/LkySt395w6e/ZMqvo/Slqu7b+KjY2Rvb295s9fIjs7e6ttOXLkSFUtj3pfY2Nj5OnppZkzZyfbdn+2cEZgTVsAAAAAAADg/3l4eMrLy1sXL4arcOEiVn8KFiwkSSpduoyOHz+aoWua/tujzvnHH7+rdet2atz4WZUqVVoeHp66fPliqo9vZ2enZs2a64cfNurq1chk22NiYnT37l0VK1ZCCQkJ+vPPQ5ZtN2/e0LlzZ1W8eIm0X9gDFCpUWA4ODlbnuXXrltVatWXKlFNCQoKioqKS/V09aNmFf3N1dVOBAgW1Z8+uFLeXK1de169fk729fbJz5MmT57Gu8WEIbQEAAAAAAIAk+vTppyVLgvXNN8t07txZnTx5QuvWfadly0IkSc2atZCHh6dGjhyqgwcPKDz8grZu3axDhw5mWE2POmfhwkW1bdsWHT9+VMePH5O//yglJqZtZuvrr7+pfPl89PrrPbVhw1qdPn1K58+f09q1q9W7d3fFxsaqSJGiatiwsSZPnqDffz+g48ePady4D+XtnU8NGz6Tbtfr6uqqtm2f12efBWnv3t06deqEJk4cK5Ppf3Fm0aLF1Lx5K3300Rht27ZFFy+G688/D2nJkmD99tsvqT5X796va9mypfrmm2U6f/6cjh49ohUrlkmSatWqq0qVqmjkyKHatWuHLl26qD/++F2zZ8/SkSN/ptv1/hvLIwAAAAAAAABJtGvXQc7OLvrqq8X67LMgubjkUKlSpdWly70HVTk6OuqTT2bp008/0Xvvva2EhAQVL15SgwcPy7CaHnXOQYPeVUDAOL3xRm/lzp1H3bu/qjt37qTpHLly5dbs2QsVErJQixYtUETEJeXMmUslS5bSm2++LXf3e2v6jhw5RkFBUzV8+DuKj49XtWo19fHHQcmWIXhcb775tmJjYzR8+LtydXXTSy91V3R0tFWf998fo0WL5uvTT6crMvKKcufOo0qVqsjXt2Gqz9OqVVv9888/Wr78S82aNV25c+fRs8/eW8PWZDJp6tQgzZnzmSZO9NeNG1Hy8PBU9eo1lTevR7peb1Imc3ovJpHFRUbeztTz+fnleHQnW+jWLl0OY7IzyZzG3+o8SEib5elyHGQPTk72iotLsHUZyGYYV8gIjKv05e2dceuGZReZfT+bFfTY8GK63ZNmBO5zsz9+FsDWGIOwNcagtdTc07I8AgAAAAAAAAAYCKEtAAAAAAAAABgIoS0AAAAAAAAAGAgPIkOWkcuvq61LSNGtENYgAwAAAAAAQPphpi0AAAAAAAAAGAihLQAAAAAAAAAYCKEtAAAAAAAAABgIoS0AAAAAAAAAGAihLQAAAAAAAAAYCKEtAAAAAAAAABgIoS0AAAAAAAAAGAihLQAAAAAAAAAYCKEtAAAAAAAAABgIoS0AAAAAAAAAGAihLQAAAAAAAAAYiIOtCwAAAE82P78cti4hmZCQWFuXAAAAAOAJxkxbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAIBMtXbpUTZo0UZUqVdSlSxcdPHjwof0XLlyoFi1aqGrVqmrcuLEmTpyof/75J5OqBQAAgC0Q2gIAAACZZP369QoICNCAAQO0cuVKlS9fXn369NG1a9dS7L9mzRoFBgZq4MCBWr9+vSZMmKD169dr2rRpmVw5AAAAMhOhLQAAAJBJgoOD1bVrV3Xq1EmlS5eWv7+/XFxcFBoammL//fv3q2bNmmrXrp0KFy6sBg0aqG3bto+cnQsAAICsjdAWAAAAyARxcXE6fPiwfH19LW12dnby9fXV/v37U9ynRo0aOnz4sCWkPX/+vLZt26bGjRtnSs0AAACwjSwX2qZ1DbD71q1bp3LlyunNN9/M4AoBAACA5KKiopSQkCBPT0+rdk9PT129ejXFfdq1a6e33npLL7/8sipVqqRmzZqpTp06euONNzKjZAAAANiIg60LSIv7a4D5+/urWrVqWrRokfr06aONGzcmu/lN6sKFC5o8ebJq1aqVidUCAAAAj2fnzp2aPXu2xowZo6pVq+rcuXOaMGGCZs2apQEDBqS4j6OjvUymTC7U4OxMJiUaeLqKk5O9rUtABnNw4O8YtsUYzN5efNHZ1iU8UmjoXVuXkOVkqdA26RpgkuTv76+tW7cqNDRUr7/+eor7JCQkaOjQoRo0aJD27t2rW7duZWbJAAAAgCQpb968sre3T/bQsWvXrsnLyyvFfYKCgtS+fXt16dJFklSuXDnFxMToww8/VP/+/WVnlzyJjI9PSP/is7hEs1nmRLOty3iguDj+zp4E/D3D1hiD2ZfZbNyfcffdvZvAGEwjA/++2dp/WQNMkmbNmiVPT0/LjS4AAABgC05OTqpUqZLCwsIsbYmJiQoLC1ONGjVS3Ofvv/9OFsza29+bLZUV/oEGAACA/ybLzLR92Bpgp06dSnGfPXv2aMWKFVq1alWqz5PZHyczGfWza3bpU1d6fhQtnUpKd3yczTb4eA8yAuPKNoz4szA9v7czrpBUr169NHz4cFWuXFlVq1bVokWLFBsbq44dO0qShg0bJh8fHw0ZMkSS9Oyzzyo4OFgVK1a0LI8QFBSkZ5991hLeAgAAIPvJMqFtWkVHR2vYsGEaP368PDw8Ur1fZn+czLAzJNLp42OJdkq3j6IZ9RNtTO+3Hd57ZATGVeYz4s/C9B4HjCvc17p1a12/fl0zZsxQZGSkKlSooHnz5lmWR7h06ZLVzNr+/fvLZDJp+vTpioiIkIeHh5599lm9++67troEAAAAZIIsE9qmdQ2w8+fPKzw8XP3797e0JSYmSpIqVqyojRs3qmjRohlbNAAAAPAvfn5+8vPzS3HbkiVLrF47ODho4MCBGjhwYGaUBgAAAIPIMqFt0jXAmjVrJul/a4CldNNbsmRJrVmzxqpt+vTpunPnjkaNGqX8+fNnSt0AAAAAAAAAkBZZJrSV0rYGmLOzs8qWLWu1f65cuSQpWTsAAAAAAAAAGEWWCm3TugYYAAAAAAAAAGQ1WSq0ldK2Bti/TZo0KSNKAgAAAAAAAIB0w7RUAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEAdbFwAAAAAga/Pzy2HrEh7K1N3WFQAAAKQNM20BAAAAAAAAwEAIbQEAAAAAAADAQAhtAQAAAAAAAMBACG0BAAAAAAAAwEAIbQEAAAAAAADAQAhtAQAAAAAAAMBACG0BAAAAAAAAwEAIbQEAAAAAAADAQAhtAQAAAAAAAMBACG0BAAAAAAAAwEAIbQEAAAAAAADAQAhtAQAAAAAAAMBAHGxdAAAAgNH4reuabscy2ZlkTjSny7FC2ixPl+MAAAAAMDZm2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIE42LoAAAAApE4uv662LiGZWyHLbV0CAAAAkO0w0xYAAAAAAAAADITQFgAAAAAAAAAMhNAWAAAAAAAAAAyE0BYAAAAAAAAADITQFgAAAAAAAAAMhNAWAAAAAAAAAAyE0BYAAAAAAAAADITQFgAAAAAAAAAMhNAWAAAAAAAAAAyE0BYAAAAAAAAADITQFgAAAAAAAAAMhNAWAAAAAAAAAAzEwdYFAAAAAAAAAMi+XlzdWeZEs63LeKCQNsttXUIyzLQFAAAAAAAAAAMhtAUAAAAAAAAAAyG0BQAAAAAAAAAD+c9r2sbFxen69etKTEy0ai9YsOBjFwUAAAAAAAAAT6o0h7ZnzpzR+++/r/3791u1m81mmUwm/fXXX+lWHAAAAAAAAAA8adIc2o4YMUIODg764osvlC9fPplMpoyoCwAAAAAAAACeSGkObY8cOaLQ0FCVKlUqI+oBAAAAAAAAgCdamh9EVqpUKUVFRWVELQAAAAAAAADwxEtVaBsdHW35M3ToUE2dOlU7d+5UVFSU1bbo6OiMrhcAAAAAAAAAsrVULY9Qq1Ytq7VrzWazevbsadWHB5EBAAAAAAAAwONLVWi7ePHijK4DAAAAAAAAAKBUhrZ16tSxfH3x4kUVKFDAauatdG+m7aVLl9K3OgAAAAAAAAB4wqT5QWRNmzbV9evXk7XfuHFDTZs2TZeiAAAAAAAAAOBJlebQ9v7atf8WExMjZ2fndCkKAAAAAAAAAJ5UqVoeQZICAgIkSSaTSdOnT1eOHDks2xISEnTw4EGVL18+/SsEAAAAAAAAgCdIqkPbP//8U9K9mbbHjh2To6OjZZuTk5PKly+v3r17p3+FAAAAAAAAAPAESXVou2TJEknSyJEjNWrUKLm7u2dYUQAAAAAAAADwpEp1aHvf/WUSAAAAAAAAAADpL82h7cCBA1NsN5lMcnJyUrFixdS2bVuVLFnysYsDAAAAAAAAgCeNXVp3cHd3144dO/Tnn3/KZDLJZDLpzz//1I4dO5SQkKD169fr+eef1969ezOiXgAAAMAm7t69q99++03Lli1TdHS0JCkiIkJ37tyxcWUAAADIbtI809bLy0tt27bVhx9+KDu7e5lvYmKiJkyYIDc3N33yyScaM2aMpk6dqq+++irdCwYAAAAyW3h4uF577TVdunRJcXFxql+/vtzd3TV37lzFxcVp3Lhxti4RAAAA2UiaZ9quWLFCr776qiWwlSQ7Ozv5+fnp66+/lslkUvfu3XX8+PF0LRQAAACwlQkTJqhy5cratWuXnJ2dLe3PPfecduzYkaZjLV26VE2aNFGVKlXUpUsXHTx48KH9b926JX9/fzVo0ECVK1dWixYttG3btv90HQAAAMga0jzTNiEhQadOnVKJEiWs2k+dOqXExERJkrOzs0wmU/pUCAAAANjY3r179dVXX8nJycmqvVChQoqIiEj1cdavX6+AgAD5+/urWrVqWrRokfr06aONGzfK09MzWf+4uDj16tVLnp6eCgoKko+Pjy5evKhcuXI99jUBAADAuNIc2j7//PMaNWqUzp8/r8qVK0uSDh06pC+++ELPP/+8JGn37t0qXbp0+lYKAAAA2EhiYqJlgkJSly9flpubW6qPExwcrK5du6pTp06SJH9/f23dulWhoaF6/fXXk/UPDQ3VzZs3tWzZMjk6OkqSChcu/B+vAgAAAFlFmkPbkSNHytPTU/PmzdPVq1cl3VvntmfPnurbt68kqX79+mrYsGH6VgoAAADYSP369bVo0SKNHz/e0nbnzh3NnDlTjRs3TtUx4uLidPjwYfXr18/SZmdnJ19fX+3fvz/FfbZs2aLq1atr3Lhx2rx5szw8PNS2bVv17dtX9vb2j3dRAAAAMKw0h7b29vbq37+/+vfvb3lqrru7u1WfggULpk91AAAAgAGMGDFCffr0UevWrRUXF6ehQ4fqzJkzyps3r6ZNm5aqY0RFRSkhISHZMgienp46depUivucP39eO3bsULt27TRnzhydO3dO/v7+unv3rgYOHPjY1wUAAABjSnNom9S/w1oAAAAgO8qfP79Wr16t9evX68iRI4qJiVHnzp3Vrl07ubi4ZNh5zWazPD09NX78eNnb26ty5cqKiIjQ/PnzHxjaOjraK7MfL2H051nYmUxKTPMjmDOPkxOzph/Xiy86P7qTDYWG3rV1CXjCOTjwfSY7M/rPYYmfxf9FmkPbq1evavLkyQoLC9P169dlNputtv/111/pVhwAAABgFA4ODmrfvr3at2//n/bPmzev7O3tde3aNav2a9euycvLK8V9vL295eDgYLUUQsmSJRUZGam4uLhkD0aTpPj4hP9U3+P4978JjCbRbJY50bg1xsVl/t9ZdmP0MXj3bgJ/z7A5xmD2ZfTvgRI/i/+LNIe2I0aM0KVLl/Tmm28qX758GVETAAAAYCizZ8+Wp6enOnfubNW+YsUKXb9+PcWHiP2bk5OTKlWqpLCwMDVr1kzSvQechYWFyc/PL8V9atasqbVr1yoxMVF2dvemp5w5c0be3t4pBrYAAADIHtIc2u7du1dffvmlKlSokBH1AAAAAIbz9ddfa+rUqcnay5Qpo3fffTdVoa0k9erVS8OHD1flypVVtWpVLVq0SLGxserYsaMkadiwYfLx8dGQIUMkSd26dVNISIgmTJggPz8/nT17VrNnz1aPHj3S7+IAAABgOGkObQsUKGDTaddLly7V/PnzFRkZqfLly+uDDz5Q1apVU+y7fPlyrVq1SsePH5ckVapUSYMHD35gfwAAACAlkZGR8vb2Ttbu4eGhyMjIVB+ndevWun79umbMmKHIyEhVqFBB8+bNsyyPcOnSJcuMWunevff8+fMVEBCg9u3by8fHR6+88or69u37+BcFAAAAw0pzaPv+++8rMDBQ/v7+Kly4cEbU9EDr169XQECA/P39Va1aNS1atEh9+vTRxo0bkz2FV5J27typNm3aqGbNmnJyctK8efPUu3dvrVu3Tj4+PplaOwAAALKuAgUKaN++fSpSpIhV+969e9O8ZJifn98Dl0NYsmRJsrYaNWpo+fLlaToHAAAAsrY0h7bvvvuuYmNj9dxzz8nFxUWOjo5W23ft2pVuxf1bcHCwunbtqk6dOkmS/P39tXXrVoWGhqb4kbTAwECr1x999JG+//57hYWFqUOHDhlWJwAAALKXLl26aOLEibp7966efvppSVJYWJg+/vhj9e7d28bVAQAAILv5TzNtbSEuLk6HDx9Wv379LG12dnby9fXV/v37U3WM2NhY3b17V7lz586oMgEAAJANvfbaa7px44b8/f0VHx8vSXJ2dtZrr71mdX8KAAAApIc0h7YvvPBCRtTxSFFRUUpISEi2DIKnp6dOnTqVqmNMnTpV+fLlk6+vb0aUCAAAgGzKZDLpvffe05tvvqmTJ0/KxcVFxYsXl5OTk61LAwAAQDaU5tBWks6dO6fQ0FCdP39eo0aNkqenp7Zt26aCBQuqTJky6V1jupgzZ47Wr1+vxYsXy9nZ+YH9HB3tZTJlXl2mzDxZWtilT112JpMS7R7dL3XHSp/jpDcnJ3tbl5DMiy8+eIzb0tdf/5Nux3JwMN77jqyPcWUbhvxZmI4/dLL7z0Ij/hzMSG5ubjzUFgAAABkuzaHtrl271LdvX9WsWVO7d+/Wu+++K09PTx09elShoaGaMWNGRtSpvHnzyt7eXteuXbNqv3btmuVpuw8yf/58zZkzR8HBwSpfvvxD+8bHJzx2rWlhNpsz9Xyplpg+dSXaSeb0OpZB36q4uMwdM6lh1HGV3u+VEd97ZH2Mq8xnyO9Z6fhDJ7v/LHxS/p+JiYnRnDlztGPHDl27dk2JiYlW2zdv3myjygAAAJAdpTm0DQwM1DvvvKNevXqpRo0alvann35aISEh6VpcUk5OTqpUqZLCwsLUrFkzSVJiYqLCwsIe+PRdSZo7d66++OILzZ8/X1WqVMmw+gAAAJB9jR49Wrt27dLzzz8vb29vY84QBwAAQLaR5tD22LFjmjp1arJ2Dw8PRUVFpUtRD9KrVy8NHz5clStXVtWqVbVo0SLFxsaqY8eOkqRhw4bJx8dHQ4YMkXRvSYQZM2YoMDBQhQoVUmRkpCTJ1dVVbm5uGVorAAAAso/t27dr9uzZeuqpp2xdCgAAAJ4AaQ5tc+bMqcjISBUpUsSq/a+//pKPj0+6FZaS1q1b6/r165oxY4YiIyNVoUIFzZs3z7I8wqVLl2Rn979F45YtW6b4+Hi99dZbVscZOHCgBg0alKG1AgAAIPvIlSuX8uTJY+syAAAA8IRIc2jbpk0bTZ06VUFBQTKZTEpMTNTevXs1efJkdejQIQNKtObn5/fA5RCWLFli9XrLli0ZXg8AAACyv7fffltBQUGaPHmycuTIYetyAAAAkM2lObR99913NW7cOD3zzDNKSEhQmzZtlJCQoLZt26p///4ZUSMAAABgU8HBwTp37px8fX1VuHBhOThY30avXLnSRpUBAAAgO0pTaGs2m3X16lWNHj1aAwYM0LFjx3Tnzh1VrFhRxYsXz6ASAQAAANu6/yBcAAAAIDOkObRt3ry51q5dq+LFi6tAgQIZVRcAAABgGAMHDrR1CQAAAHiC2D26S5LOdnYqVqyYbty4kUHlAAAAAMZ069YtffPNNwoMDLTcDx8+fFgRERG2LQwAAADZTppCW0kaMmSIpkyZomPHjmVEPQAAAIDhHDlyRC1atNDcuXO1YMEC3b59W5K0adMmBQYG2rg6AAAAZDdpfhDZ8OHDFRsbq+eff16Ojo5ycXGx2r5r1650Kw4AAAAwgkmTJumFF17QsGHDVKNGDUt748aNNXToUBtWBgCwNT+/HLYu4ZGWL4+zdQkA0ijNoe3IkSNlMpkyohYAAADAkP744w+NGzcuWbuPj48iIyNtUBEAAACyszSHth07dsyIOgAAAADDcnJyUnR0dLL2M2fOyMPDwwYVAQAAIDtL85q2FSpU0LVr15K1R0VFqUKFCulSFAAAAGAkTZo00axZsxQfH29pu3jxoqZOnarmzZvbsDIAAABkR2kObc1mc4rtcXFxcnR0fOyCAAAAAKMZMWKEYmJi5Ovrq3/++Uc9evRQ8+bN5ebmpnfffdfW5QEAACCbSfXyCIsXL5YkmUwmffPNN3J1dbVsS0xM1O7du1WyZMn0rxAAAACwsZw5cyo4OFh79uzR0aNHFRMTo0qVKsnX19fWpQEAACAbSnVou3DhQkn3ZtouW7ZMdnb/m6Tr6OiowoULy9/fP90LBAAAAIyiVq1aqlWrlq3LAAAAQDaX6tB2y5YtkqQePXro008/Ve7cuTOsKAAAAMDW7n/SLDVeeeWVDKwEAAAAT5pUh7b3LVmyxOr13bt39c8//8jNzS3digIAAABs7f4nze6LiopSbGyscuXKJUm6deuWcuTIIQ8PD0JbAAAApKs0zbS9ceOGOnbsaGn7/PPP9dlnnykhIUFPP/20PvnkE2bgAgAAIFu4/0kzSVqzZo2+/PJLTZgwwfIch1OnTumDDz7Qiy++aKsSAQAAkE3ZPbrLPcHBwYqNjbW83rdvn2bMmKE333xT06dP16VLl/TZZ59lSJEAAACALQUFBemDDz6wevBuyZIlNXLkSE2fPt12hQEAACBbSvVM2xMnTqhGjRqW199//718fX3Vv39/SZKzs7MmTJigkSNHpn+VAAAAgA1FRkbq7t27ydoTExN17do1G1QEAACA7CzVM23v3LmjPHnyWF7v3btX9erVs7wuXbq0rly5kq7FAQAAAEZQr149jRkzRocPH7a0HTp0SGPHjrW6JwYAAADSQ6pDWx8fH508eVLSvQD3yJEjVjNvb9y4IRcXl/SvEAAAALCxiRMnysvLS506dVLlypVVuXJldenSRZ6enpowYYKtywMAAEA2k+rlEVq2bKmJEyeqX79+2r59u7y9vVW9enXL9kOHDqlEiRIZUSMAAABgUx4eHpo7d65Onz6tU6dOSbq3pi33vwAAAMgIqQ5tBwwYoIiICE2YMEFeXl76+OOPZW9vb9m+du1aPfvssxlSJAAAAGAEJUqUIKgFAABAhkt1aOvi4qIpU6Y8cPuSJUvSpSAAAADACAICAvT222/L1dVVAQEBD+3Lw3gBAACQnlId2gIAAABPkj///FN37961fP0gJpMps0oCAADAE4LQFgAAAEjBqFGj5O7uLolPlQEAACBz2dm6AAAAAMCIXnjhBUVFRUmSmjZtavkaAAAAyGjMtAUAAABSkCtXLl24cEGenp4KDw+X2Wy2dUkAsqgXV3eWOdG430NC2iy3dQnIYIxBIOshtAUAAABS0Lx5c/n5+cnb21smk0mdOnWSnV3KH1TbvHlzJlcHAACA7CxVoe3ixYtTfcBXXnnlPxcDAAAAGMX48eP13HPP6dy5c/roo4/UpUsXubm52bosAAAAPAFSFdouXLgwVQczmUyEtgAAAMg2GjVqJEk6fPiwXnnlFcuDyQAAAICMlKrQdsuWLRldBwAAAGBYAQEBti4BAAAATxDWtAUAAAAeISYmRnPmzNGOHTt07do1JSYmWm1nTVsAAACkp/8U2l6+fFmbN2/WpUuXFB8fb7Vt5MiR6VIYAAAAYBSjR4/Wrl279Pzzz1seTAYAAABklDSHtmFhYerfv7+KFCmiU6dOqUyZMgoPD5fZbFbFihUzokYAAADAprZv367Zs2frqaeesnUpAAAAeALYpXWHwMBA9e7dW2vWrJGTk5NmzpyprVu3qnbt2mrZsmVG1AgAAADYVK5cuZQnTx5blwEAAIAnRJpD25MnT6pDhw6SJAcHB/39999yc3PT22+/rXnz5qV3fQAAAIDNvf322woKClJsbKytSwEAAMATIM3LI7i6ulrWsfX29ta5c+dUpkwZSVJUVFT6VgcAAAAYQHBwsM6dOydfX18VLlxYDg7Wt9ErV660UWUAAADIjtIc2larVk179+5VqVKl1LhxY02ePFnHjh3TDz/8oGrVqmVEjQAAAIBNNWvWzNYlAAAA4AmS5tB25MiRunPnjiRp0KBBunPnjtavX6/ixYtrxIgR6V4gAAAAYGsDBw60dQkAAAB4gqQ5tC1SpIjla1dXV40bNy5dCwIAAACM6tChQzp58qQkqUyZMqpYsaKNKwIAAEB2lObQ9r64uDhdv35diYmJVu0FCxZ87KIAAAAAI7l27Zreffdd7dq1S7ly5ZIk3bp1S3Xr1tUnn3wiDw8PG1cIAACA7CTNoe3p06c1atQo7d+/36rdbDbLZDLpr7/+SrfiAAAAACMYP3687ty5o3Xr1qlUqVKSpBMnTmj48OH66KOPNG3aNBtXCAAAgOzkP61p6+DgoC+++EL58uWTyWTKiLoAAAAAw/j5558VHBxsCWwlqXTp0hozZox69+5tw8oAAACQHaU5tD1y5IhCQ0OtblgBAACA7CwxMVGOjo7J2h0cHJItFwYAAAA8rjSHtqVKlVJUVFRG1AIAQJr5reuabscy2ZlkTjSny7FC2ixPl+MAMIann35aEyZMUGBgoHx8fCRJERERCggIUL169WxcHQAAALIbu7TuMHToUE2dOlU7d+5UVFSUoqOjrf4AAAAA2c2HH36o6OhoNW3aVM2aNVOzZs3UtGlTRUdH64MPPrB1eQAAAMhm0jzTtlevXpKknj17WrXzIDIAAABkVwUKFNDKlSv122+/6dSpU5LufQLN19fXxpUBAAAgO0pzaLt48eKMqAMAAAAwnLCwMI0fP17Lly+Xu7u76tevr/r160uSbt++rTZt2sjf31+1atWycaUAAADITtIc2tapUycj6gAAAAAMZ9GiReratavc3d2TbcuZM6defPFFBQcHE9oCAAAgXaU5tD1y5EiK7SaTSc7OzipYsKCcnJweuzAAAADA1o4ePar33nvvgdvr16+vBQsWZGJFAAAAeBKkObTt0KGDTCbTgw/o4KDWrVtr3LhxcnZ2fqziAAAAAFu6evWqHBwefMvs4OCg69evZ2JFAAAAeBLYpXWHTz/9VMWKFdO4ceO0atUqrVq1SuPGjVOJEiUUGBioCRMmaMeOHZo+fXoGlAsAAABkHh8fHx0/fvyB248ePSpvb+9MrAgAAABPgjTPtP3iiy80atQoNWzY0NJWrlw55c+fX0FBQVqxYoVcXV01adIkDR8+PF2LBQAAADJT48aNFRQUpIYNGyb7FNnff/+tmTNn6tlnn7VRdQAAAMiu0hzaHjt2TAULFkzWXrBgQR07dkySVL58eUVGRj5+dQAAAIAN9e/fX5s2bVKLFi3UvXt3lShRQpJ06tQpffnll0pISNAbb7xh4yoBAACQ3aQ5tC1ZsqTmzp2rcePGWR44Fh8fr7lz56pkyZKSpIiICHl6eqZvpQAAAEAm8/Ly0rJlyzR27FhNmzZNZrNZ0r2H8DZo0EAffvihvLy8bFwlAAAAsps0h7Yffvih+vfvr8aNG6tcuXKS7s2+TUhI0OzZsyVJ58+f18svv5y+lQIAAAA2UKhQIc2dO1c3b97U2bNnJUnFihVT7ty5bVwZAAAAsqs0h7Y1a9bU5s2btWbNGp05c0aS1LJlS7Vt21bu7u6SpA4dOqRnjQAAAIDN5c6dW1WrVrV1GQAAAHgCpDm0lSR3d3d169YtvWsBAAAAAAAAgCdeqkLbzZs3q1GjRnJ0dNTmzZsf2rdp06bpUhgAAAAAAAAAPIlSFdoOGDBAv/76qzw9PTVgwIAH9jOZTPrrr7/SrTgAAAAAAAAAeNKkKrQ9cuRIil8DAAAAAAAAANKXna0LAAAAAJ40S5cuVZMmTVSlShV16dJFBw8eTNV+69atU7ly5fTmm29mcIUAAACwpVSHtvv379dPP/1k1bZq1So1adJE9erV0wcffKC4uLh0LxAAAADITtavX6+AgAANGDBAK1euVPny5dWnTx9du3btoftduHBBkydPVq1atTKpUgAAANhKqkPbWbNm6fjx45bXR48e1ahRo+Tr66vXX39dP/30k2bPnp0hRQIAAADZRXBwsLp27apOnTqpdOnS8vf3l4uLi0JDQx+4T0JCgoYOHapBgwapSJEimVgtAAAAbCHVoe2RI0dUr149y+v169eratWq+uijj9SrVy+NGjVKGzZsyJAiAQAAgOwgLi5Ohw8flq+vr6XNzs5Ovr6+2r9//wP3mzVrljw9PdWlS5fMKBMAAAA2lqoHkUnSzZs35eXlZXm9a9cuNWrUyPK6SpUqunTpUvpWBwAAAGQjUVFRSkhIkKenp1W7p6enTp06leI+e/bs0YoVK7Rq1apUncPR0V4m0+NWmjamzD5hGtmZTEo08NM8nJzsbV1ClscYfDyMwcdj9PEnMQazO8bg4zPiGEx1aOvl5aULFy6oQIECiouL059//qm33nrLsv3OnTtydHTMkCIBAACAJ1F0dLSGDRum8ePHy8PDI1X7xMcnZHBVyZnN5kw/Z1okms0yJxq3xri4zP87y24Yg4+HMfh4jD7+JMZgdscYfHxGHIOpDm0bNWqkwMBADR06VD/++KNcXFz01FNPWbYfPXqU9bUAAACAh8ibN6/s7e2TPXTs2rVrVp9qu+/8+fMKDw9X//79LW2JiYmSpIoVK2rjxo0qWrRoxhYNAACATJfq0Pbtt9/WoEGD5OfnJ1dXV02ePFlOTk6W7aGhoWrQoEGGFAkAAABkB05OTqpUqZLCwsLUrFkzSfdC2LCwMPn5+SXrX7JkSa1Zs8aqbfr06bpz545GjRql/PnzZ0rdAAAAyFypDm09PDy0dOlS3b59W66urrK3t17rISgoSK6uruleIAAAAJCd9OrVS8OHD1flypVVtWpVLVq0SLGxserYsaMkadiwYfLx8dGQIUPk7OyssmXLWu2fK1cuSUrWDgAAgOwj1aHtfTlz5kyxPU+ePI9bCwBkulx+XW1dQopuhSy3dQkAgAzSunVrXb9+XTNmzFBkZKQqVKigefPmWZZHuHTpkuzsDPykDgAAAGS4NIe2AAAAAB6Pn59fisshSNKSJUseuu+kSZMyoiQAAAAYCL/CBwAAAAAAAAADIbQFAAAAAAAAAAPJcqHt0qVL1aRJE1WpUkVdunTRwYMHH9p/w4YNatmypapUqaJ27dpp27ZtmVQpAAAAAAAAAKRdlgpt169fr4CAAA0YMEArV65U+fLl1adPH127di3F/vv27dOQIUPUuXNnrVq1Sk2bNtWAAQN07NixTK4cAAAAAAAAAFInS4W2wcHB6tq1qzp16qTSpUvL399fLi4uCg0NTbH/4sWL1bBhQ7322msqVaqU3nnnHVWsWFEhISGZXDkAAAAAAAAApE6WCW3j4uJ0+PBh+fr6Wtrs7Ozk6+ur/fv3p7jPgQMHVK9ePau2Bg0a6MCBAxlZKgAAAAAAAAD8Z1kmtI2KilJCQoI8PT2t2j09PXX16tUU97l69aq8vLxS3R8AAAAAAAAAbM3B1gUYzccfT9Qffzz84Wbpyc6osfnX6VOYnZ1JiYnmdDlWB6O+V6+8ZOsKkjHquKrUfE+6HctkkszpMLSeyl/r8Q+SEQw4rvbuNebAeuqp9KsrPb9n9RpWOl2Ok54SnjLmeDfk96x0+jkoPQE/CzP5+9WGDesy9XwAAACALWSZ0DZv3ryyt7dP9tCxa9euJZtNe5+Xl1eyWbUP6y9J7733/uMXCwsnJ3vFxSXYugwYhN+6rul2LJOdSeZ0CEEWt1mWDtU8Gfz8cti6hBQtXhybbsdKz+9ZufzSb7ynl1uLGe+2wM9CAAAAAGllxPkaKXJyclKlSpUUFhZmaUtMTFRYWJhq1KiR4j7Vq1fXjh07rNp+++03Va9ePSNLBQAAAAAAAID/LMuEtpLUq1cvLV++XCtXrtTJkyc1duxYxcbGqmPHjpKkYcOGKTAw0NL/lVde0c8//6wFCxbo5MmTmjlzpg4dOiQ/Pz9bXQIAAAAAAAAAPFSWWR5Bklq3bq3r169rxowZioyMVIUKFTRv3jzLcgeXLl2SXZKF8WrWrKmpU6dq+vTpmjZtmooXL65Zs2apbNmytroEAAAAAAAAAHioLBXaSpKfn98DZ8ouWbIkWVurVq3UqlWrjC4LAAAAAAAAANJFlloeAQAAAAAAAACyO0JbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQQlsAAAAAAAAAMBBCWwAAAAAAAAAwEEJbAAAAAAAAADAQB1sXAABAdnQrZLmtSwAAAAAAZFHMtAUAAAAAAAAAAyG0BQAAAAAAAAADIbQFAAAAAAAAAAMhtAUAAAAAAAAAAyG0BQAAAAAAAAADIbQFAAAAAAAAAAMhtAUAAAAAAAAAAyG0BQAAAAAAAAADIbQFAAAAAAAAAAMhtAUAAAAAAAAAAyG0BQAAAAAAAAADIbQFAAAAAAAAAAMhtAUAAAAAAAAAAyG0BQAAAAAAAAADIbQFAAAAAAAAAAMhtAUAAAAAAAAAAyG0BQAAAAAAAAADIbQFAAAAAAAAAAMhtAUAAAAAAAAAAyG0BQAAAAAAAAADcbB1AQCeHCFtlqfbsZyc7BUXl5BuxwMAAAAAADAKZtoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAAAAAACAgRDaAgAAAAAAAICBENoCAAAAAAAAgIEQ2gIAAACZbOnSpWrSpImqVKmiLl266ODBgw/su3z5cr388suqXbu2ateurZ49ez60PwAAALI+QlsAAAAgE61fv14BAQEaMGCAVq5cqfLly6tPnz66du1aiv137typNm3aaPHixVq2bJkKFCig3r17KyIiIpMrBwAAQGYhtAUAAAAyUXBwsLp27apOnTqpdOnS8vf3l4uLi0JDQ1PsHxgYqO7du6tChQoqVaqUPvroIyUmJiosLCyTKwcAAEBmIbQFAAAAMklcXJwOHz4sX19fS5udnZ18fX21f//+VB0jNjZWd+/eVe7cuTOqTAAAANgYoS0AAACQSaKiopSQkCBPT0+rdk9PT129ejVVx5g6dary5ctnFfwCAAAge3GwdQEAAAAAUmfOnDlav369Fi9eLGdn5xT7ODray2TK3LpMmX3CNLIzmZRo4OkqTk72ti4hy2MMPh7G4OMx+viTGIPZHWPw8RlxDBLaAgAAAJkkb968sre3T/bQsWvXrsnLy+uh+86fP19z5sxRcHCwypcv/8B+8fEJ6VJrWpjN5kw/Z1okms0yJxq3xri4zP87y24Yg4+HMfh4jD7+JMZgdscYfHxGHIMGzrgBAACA7MXJyUmVKlWyeojY/YeK1ahR44H7zZ07V5999pnmzZunKlWqZEapAAAAsCFm2gIAAACZqFevXho+fLgqV66sqlWratGiRYqNjVXHjh0lScOGDZOPj4+GDBki6d6SCDNmzFBgYKAKFSqkyMhISZKrq6vc3Nxsdh0AAADIOIS2AAAAQCZq3bq1rl+/rhkzZigyMlIVKlTQvHnzLMsjXLp0SXZ2//tA3LJlyxQfH6+33nrL6jgDBw7UoEGDMrV2AAAAZA5CWwAAACCT+fn5yc/PL8VtS5YssXq9ZcuWzCgJAAAABsKatgAAAAAAAABgIIS2AAAAAAAAAGAghLYAAAAAAAAAYCCEtgAAAAAAAABgIIS2AAAAAAAAAGAghLYAAAAAAAAAYCAOti4gq/Pzy5Gp5wsJiU3zPhMmjFV09G0FBAQm29a5czt17dpNXbu+nGzbpUsX1aVLe9nZ2Sk0dK28vfNZtl29elWdOrVRQkKCvvnmOxUoUDDNdQEAAAAAAABIjpm2eCQvL29t3LjOqm3DhrXy8vK2UUUAAAAAAABA9pVlQtsbN25oyJAhqlmzpmrVqqX3339fd+7ceWj/8ePHq0WLFqpataqeeeYZffTRR7p9+3YmVp09tGrVVuvWrbFqW7/+O7Vq1dZGFQEAAAAAAADZV5YJbYcOHaoTJ04oODhYX3zxhfbs2aMPP/zwgf2vXLmiK1euaPjw4Vq7dq0CAgL0888/a9SoUZlYdfbQoEEjRUff0u+/H5Ak/f77Ad2+fVv16ze0bWEAAAAAAABANpQlQtuTJ0/q559/1kcffaRq1aqpVq1aGj16tNatW6eIiIgU9ylbtqxmzpypJk2aqGjRoqpXr57eeecdbdmyRXfv3s3kK8jaHBwc1Lx5K61bt1qStG7darVo0UoODiyJDAAAAAAAAKS3LBHa7t+/X7ly5VKVKlUsbb6+vrKzs9PBgwdTfZzo6Gi5u7sTNv4Hbdo8r59+2qxr167qp582q02b9rYuCQAAAAAAAMiWskR6efXqVXl4eFi1OTg4KHfu3IqMjEzVMa5fv67PPvtML7744kP7OTray2RKfW2mtHROB05O9mnex87OJJPJlOK+JpNkb2+X4jZHR3vLf8uWLafixYtr3LjRKlGihMqXL6djx45atj+oLgeHtNcLpAZjK/Nl9ve71Pov3xcfhHGFjMC4AgAAAJBWNg1tp06dqrlz5z60z/r16x/7PNHR0erXr59KlSqlgQMHPrRvfHxCmo5tNpsfp7Q0i4tLW32SlJholtlsTnFfs1lKSEhMcdv99yI+PkFxcQlq3bq9AgMnaejQEYqLS0i2PT1rBlKDsZW5Mvv7XWql9zhgXCEjMK4AAAAApIVNQ9vevXvrhRdeeGifIkWKyMvLS9evX7dqv3v3rm7evClvb++H7h8dHa3XXntNbm5umjVrlhwdHR+77qwoOjpax48ftWrLlSu3JCkyMjLZNh+fAsmO0a5dBz37bDO5u7tnXKEAAAAAAADAE86moa2Hh0eyZQ9SUqNGDd26dUuHDh1S5cqVJUk7duxQYmKiqlat+sD9oqOj1adPHzk5Oenzzz+Xs7NzutWe1ezfv1e9enW3amvb9nlJ0ldfLdFXXy2x2vbBB+NUtWp1qzYHBwflyZMnI8sEAAAAAAAAnnhZYk3bUqVKqWHDhvrggw/k7++v+Ph4jR8/Xm3atJGPj48kKSIiQq+++qqmTJmiqlWrKjo6Wr1791ZsbKw+/vhjRUdHKzo6WtK9sNjePn3WlwsJiU2X42SkUaPGatSosf9p319+2fPAbWXKlHvodgAAAAAAAABplyVCW+ne+rfjx4/Xq6++Kjs7OzVv3lyjR4+2bI+Pj9fp06cVG3svRD18+LB+//13SdJzzz1ndazNmzercOHCmVc8AAAAAAAAAKRSlglt8+TJo8DAwAduL1y4sI4e/d+6rHXr1rV6DQAAAAAAAABZgZ2tCwAAAAAAAAAA/A+hLQAAAAAAAAAYCKEtAAAAAAAAABgIoS0AAAAAAAAAGAihLQAAAAAAAAAYCKEtAAAAAAAAABgIoS0AAAAAAAAAGAihLf6T+fNnq2fPlx/7OA0a1NL27Vsfv6D/17lzOy1f/mW6HQ8AAAAAAADIbA62LiCr81vXNVPPF9Jmear7NmhQ66Hbe/Xqqz59+j1uSY9l9eqNypkzl01rAAAAAAAAAIyE0DYbW716o+XrzZt/0Pz5X+jLL0MtbTlyuNqiLCuenl62LgEAAAAAAAAwFELbbCxpIOru7i6TyWTVtmbNKi1bFqJLly4qf/4C6tz5JXXs2MWy/cqVCM2aFaRdu3YoPj5OxYqV0ODBw1WpUmVLn40b12nevC90+/YtPf20r4YPHy1XVzdJ0sCBr6ts2bJycHDUmjWr5ejoqOef72g1u7dBg1qaOHGqGjV65pHnDA+/oJkzp+nw4UP6++9YFStWQv36DVDt2nUz6i0EAAAAAAAAMh2h7RNq06YNmjfvCw0ePExlypTT8eNHNXnyBOXIkUOtWrVVTEyMBg58Xd7e+TRp0jR5enrq6NEjMpsTLccID7+gn3/eqilTPtHt27f14YcjtGTJQvXrN8DSZ926tXrxxZc1Z85CHTp0UBMn+qtq1WqqXfvpZDU96pwxMTF6+un6ev31N+Xo6KSNG9dp+PDB+vLLUOXPnz+j3zIAAAAAAAAgUxDaPqHmz5+tgQPfUePGTSRJBQsW0unTp7R69bdq1aqtfvhho27cuKF58xYrV67ckqTChYtYHcNsTtSoUWMtM2tbtGitvXt3W/UpXbqMevd+XZJUpEhRffvtcu3ZszvF0PZR5yxTpqzKlClred23b39t3/6Tfv11mzp1evFx3xIAAAAAAADAEAhtn0CxsbEKD7+gSZPGa8qUCZb2hIQEubm5S5KOHz+msmXLWcLTlOTPX9AS2Er3lmOIioqy6lOmTBmr1/f6XE/xeI86Z0xMjBYsmKOwsF907dpVJSQk6J9//lFExOWHXzAAAAAAAACQhRDaPoFiY2MkScOHj1bFipWtttnZ2UmSnJ2dH3kcBwfr4WMymayWT3hwH3OKx3vUOWfNmq7du3dqwIB3VLhwETk7O2v06OGKj7/7yFoBAAAAAACArMLO1gUg83l4eMrLy1sXL4arcOEiVn8KFiwk6d6yBsePH9WtWzczra5HnfOPP35X69bt1LjxsypVqrQ8PDx1+fLFTKsPAAAAAAAAyAyEtk+oPn36acmSYH3zzTKdO3dWJ0+e0Lp132nZshBJUrNmLeTh4amRI4fq4MEDCg+/oK1bN+vQoYMZVtOjzlm4cFFt27ZFx48f1fHjx+TvP0qJiSnP2gUAAAAAAACyKpZHeEK1a9dBzs4u+uqrxfrssyC5uORQqVKl1aVLN0mSo6OjPvlklj799BO9997bSkhIUPHiJTV48LAMq+lR5xw06F0FBIzTG2/0Vu7cedS9+6u6c+dOhtUDAAAAAAAA2ILJ/KAFRp9QkZG3bV1CtuLkZK+4uARbl4FsiLGV+fz8cti6hBSFhMSm27EYV8gIjKv05e2d09YlGJ4t7meN+jPiPlP39jIb+BNaIW2W27qELI8x+HgYg4/H6ONPYgxmd4zBx5fZYzA197QsjwAAAAAAAAAABkJoCwAAAAAAAAAGQmgLAAAAAAAAAAZCaAsAAAAAAAAABkJoCwAAAAAAAAAGQmgLAAAAAAAAAAZCaAsAAAAAAAAABkJoCwAAAAAAAAAGQmgLAAAAAAAAAAZCaItMdenSRTVoUEvHjx+1dSkAAAAAAACAITnYuoCsLpdf10w9362Q5WneZ8KEsdqwYW2y9mXLVqpw4SLpURYAAAAAAACAdEJo+4SoW9dX77//oVVbnjx5bVQNAAAAAAAAgAchtH1CODk5ytPTy6ptwoSxio6+rYCAQEtbUFCgjh8/qk8/nSNJ+umnHxUcPFcXLlyQi4uLypQpp0mTApUjRw5J0po1q7RsWYguXbqo/PkLqHPnl9SxYxfL8Q4fPqSJE8fr7NkzKlGilF55pXcmXC0AAAAAAACQdRHa4oGuXr2qsWNH6c0331KjRs8qJiZGv/++X2azWZK0adMGzZv3hQYPHqYyZcrp+PGjmjx5gnLkyKFWrdoqJiZGgwe/pVq16uqDD8br0qWLCgqaauOrAgAAAAAAAIyN0PYJ8dtvv+i55xpaXtet62uZLfsg165dVUJCgho3bqL8+QtIkkqVKm3ZPn/+bA0c+I4aN24iSSpYsJBOnz6l1au/VatWbfXDDxuVmGjWiBEfyNnZWSVLllJkZISmTp2UAVcIAAAAAAAAZA+Etk+IGjWe0tChIy2vXVxyaPbsTx+6T+nSZfTUU3X0yisvqU6dp1WnztN65pmmypUrl2JjYxUefkGTJo3XlCkTLPskJCTIzc1dknT27GmVLl1Gzs7Olu2VKlVN5ysDAAAAAAAAshdC2ydEjhw5VLhwEas2k8lkWergvrt371q+tre31/Tps/THH79r9+6dCg39WnPmfKY5cxbKxcVFkjR8+GhVrFjZ6hh2dnYZdBUAbCkkJNbWJQAAAAAA8EQgXXuC5cmTV9euXbVqO3HiqNVrk8mkqlWrq0+fflqwYKkcHR21fftP8vDwlJeXty5eDFfhwkWs/hQsWEiSVKxYCZ04cVz//POP5XiHD/+R8RcGAAAAAAAAZGGEtk+wp56qrSNH/tKGDWt1/vw5zZ8/W6dOnbRsP3z4kBYvXqAjR/7U5cuXtW3bT7pxI0rFipWQJPXp009LlgTrm2+W6dy5szp58oTWrftOy5aFSJKee66lTCZpypSPdPr0KYWF/WLZBgAAAAAAACBlLI/wBKtbt5569nxNn38+U3Fx/6hNm/Zq2bKNTp48IUlyc3PTgQP7tXz5V4qJuSMfn/waOPAd1atXX5LUrl0HOTu76KuvFuuzz4Lk4pJDpUqVVpcu3SRJrq6uCgwMUkDABPXu3V3Fi5dQ//6DNGrUMJtdMwAAAAAAAGB0hLaP6VbIcluX8EijRo194LY+ffqpT59+KW4rXryEpk2b+dBjN2/eUs2bt3zg9ipVqmrhwi+t2n75Zc9DjwkAAAAAAAA8yVgeAQAAAAAAAAAMhNAWAAAAAAAAAAyE0BYAAAAAAAAADITQFgAAAAAAAAAMhNAWAAAAAAAAAAyE0BYAAAAAAAAADITQFgAAAAAAAAAMhNAWAAAAAAAAAAyE0BYAAAAAAAAADITQFgAAAAAAAAAMhNAWAAAAyGRLly5VkyZNVKVKFXXp0kUHDx58aP8NGzaoZcuWqlKlitq1a6dt27ZlUqUAAACwBUJbAAAAIBOtX79eAQEBGjBggFauXKny5curT58+unbtWor99+3bpyFDhqhz585atWqVmjZtqgEDBujYsWOZXDkAAAAyC6EtAAAAkImCg4PVtWtXderUSaVLl5a/v79cXFwUGhqaYv/FixerYcOGeu2111SqVCm98847qlixokJCQjK5cgAAAGQWQlsAAAAgk8TFxenw4cPy9fW1tNnZ2cnX11f79+9PcZ8DBw6oXr16Vm0NGjTQgQMHMrJUAAAA2JCDrQswGm/vnLYuAQAAANlUVFSUEhIS5OnpadXu6empU6dOpbjP1atX5eXllaz/1atXU+xvi/vZ77/P9FOm0XpbF4AMxhiELRl//EmMweyNMZg9MdMWAAAAAAAAAAyE0BYAAADIJHnz5pW9vX2yh45du3Yt2Wza+7y8vJLNqn1YfwAAAGR9hLYAAABAJnFyclKlSpUUFhZmaUtMTFRYWJhq1KiR4j7Vq1fXjh07rNp+++03Va9ePSNLBQAAgA0R2gIAAACZqFevXlq+fLlWrlypkydPauzYsYqNjVXHjh0lScOGDVNgYKCl/yuvvKKff/5ZCxYs0MmTJzVz5kwdOnRIfn5+troEAAAAZDAeRAYAAABkotatW+v69euaMWOGIiMjVaFCBc2bN8+y3MGlS5dkZ/e/uRU1a9bU1KlTNX36dE2bNk3FixfXrFmzVLZsWVtdAgAAADIYM22RKvv371eFChX0+uuvP7DP2rVrVaFCBfn7+yfbtnPnTpUrV87yx9fXV4MGDdL58+ctfZo0aaKFCxdmRPkwkBEjRqhcuXL68MMPk23z9/dXuXLlNGLECEnS9evXNWbMGD3zzDOqXLmy6tevrz59+mjv3r2WfZo0aWI1tsqVK6dGjRpp5syZydr//QdZU2RkpD766CM999xzqlKlinx9ffXSSy/pyy+/VGxsrKXfvn371LdvX9WuXVtVqlRRu3btFBwcrISEhGTH/Omnn+Tn56caNWqoWrVq6tSpk7799tsUz//999/rlVdeUe3atVW1alW1aNFCI0eO1J9//mnp8+2336pWrVrpf/HIVA/62XfhwgWVK1dOFSpUUEREhNW2K1euqGLFiipXrpwuXLggSerRo8dDvxft2rVL0v++P86ZM8fqmD/++CPfs7IhPz8//fTTTzp06JC++eYbVatWzbJtyZIlmjRpklX/Vq1a6fvvv9ehQ4e0du1aNW7cOLNLtjnuR2Er3L8is3CfCyPinth2mGmLVFmxYoX8/Py0YsUKRUREyMfHJ8U+r732mr7++muNGDFCzs7Oyfps3LhRbm5uOnv2rD744AO98cYb+u6772Rvb58ZlwGDKFCggNavX6/3339fLi4ukqR//vlHa9euVcGCBS39Bg0apPj4eE2aNElFihTRtWvXFBYWphs3blgd76233lLXrl0tr+3t7eXs7KyXXnrJ0ta5c2d17drVqh+ynvPnz6tbt27KmTOn3n33XZUrV05OTk46evSoli9fLh8fHzVt2lQ//PCD3nnnHXXs2FGLFy9Wzpw5FRYWpo8//lj79+9XUFCQTCaTpHvhyMSJE9W3b1+NHTtWjo6O2rx5s8aMGaPjx49r+PDhlvN//PHHCg4OVo8ePfTWW2+pYMGCun79urZv367AwEDNnz/fVm8NMsCjfvb5+Pho1apV6tevn6Vt1apV8vHx0cWLFy1tM2fOVHx8vNW+8fHx6tevn5ycnKzCOmdnZ82dO1cvvviicufOnUFXBmRN3I/Clrh/RUbjPhdGxT2x7RDa4pHu3Lmj9evXKzQ0VFevXtXKlSv1xhtvWPU5f/689u/fr5kzZ2rnzp3atGmT2rVrl+xYnp6eypUrl/Lly6cBAwZo6NChOnv2rEqWLJlZlwMDqFixos6fP69Nmzapffv2kqRNmzapQIECKly4sCTp1q1b2rNnj5YsWaI6depIkgoVKqSqVasmO56bm5u8vb1TbL/P3t7+gf2QdYwdO1b29vYKDQ2Vq6urpb1IkSJq1qyZzGazYmJiNHr0aDVp0kTjx4+39OnSpYs8PT3Vv39/bdiwQa1bt9alS5c0efJkvfrqqxo8eLClb+/eveXo6KiPPvpILVu2VLVq1XTgwAHNmzdPo0aN0iuvvGLpW7BgQVWuXFlmszlz3gRkitT87OvQoYO+/fZbqxvU0NBQdejQQZ999pmlLU+ePMmOP3r0aEVFRWnFihVWoZKvr6/Onj2r2bNna9iwYel/YUAWxf0obI37V2Q07nNhRNwT2xbLI+CRNmzYoJIlS6pkyZJq3769QkNDk33T/vbbb9W4cWPlzJlT7du314oVKx553Pu/of73b1rwZPj3x3JCQ0MtD2CRJFdXV7m6uurHH39UXFycLUqEwURFRenXX39V9+7drW5kkzKZTPr1119148YN9e7dO9n2Jk2aqHjx4lq7dq2kex8Bi4+PT7Hviy++KFdXV0vftWvXytXVVS+//PIDz43sIzU/+5o0aaKbN29qz549kqQ9e/bo1q1bevbZZx967KVLl2rVqlWaMWOG8ufPb7XNzs5OgwcPVkhIiC5fvpy+FwVkYdyPwgi4f0VG4T4XRsU9sW0R2uKRVqxYYfltcsOGDXX79m3LWiOSlJiYqJUrV1r6tG7dWnv37rVaH+zfrly5ovnz58vHx0clSpTI2AuAIbVv31579+5VeHi4wsPDtW/fPssYkiQHBwdNmjRJq1atUq1atfTSSy9p2rRpOnLkSLJjTZ06VTVq1LD8Wbx4cWZeCjLJuXPnZDabk33PqFu3ruXv/uOPP9bp06clSaVKlUrxOCVLltSZM2ckSadPn1bOnDmVL1++ZP2cnJxUpEgRS98zZ86oSJEicnD434dUgoODrcbe7du30+FKYQSP+tknSY6OjpabV+neP97bt28vR0fHBx539+7dCggI0JgxY1SzZs0U+zz33HOqUKGCZsyYkU5XA2R93I/CCLh/RUbhPhdGxT2xbRHa4qFOnTqlP/74Q23btpV070akdevWVjMXfv31V8XGxloeiOHh4aH69etb/odNqnHjxqpevboaNmyo2NhYzZw5U05OTplzMTAUDw8PPfPMM1q5cqW+/fZbPfPMM/Lw8LDq06JFC/3888/6/PPP1bBhQ+3atUsdO3ZMtnB+nz59tGrVKsufDh06ZOKVwNZWrFihVatWqXTp0lazWjLjY1ydOnXSqlWr5O/vr5iYGD46lk2k5mfffZ06ddLGjRsVGRmpjRs3qlOnTg887sWLFy1rGHbp0uWhNQwdOlSrVq3SyZMnH+9igGyA+1EYBfevyGzc58KWuCe2Pda0xUOtWLFCd+/eVcOGDS1tZrNZTk5O+vDDD5UzZ06tWLFCN27csFo0OjExUUePHtVbb70lO7v//W5g6dKlcnd3l4eHh9zd3TP1WmA8nTp10rhx4yRJY8aMSbGPs7Oz6tevr/r162vAgAEaNWqUZs6cafVRtLx586pYsWKZUjNsp2jRojKZTJYZBvcVKVJE0v8+4np/hsLJkydT/K3tqVOnLLMTSpQoodu3b6e4oH5cXJzOnz+vunXrSpKKFy+uvXv3Kj4+3vJb41y5cilXrlxP9Ed2sqNH/exLqly5cipZsqQGDx6sUqVKqWzZsvrrr7+SHfPvv//WwIEDVbp0ab3//vuPrKF27dpq0KCBAgMDrb7fAU8i7kdhJNy/IiNwnwsj4p7Y9phpiwe6e/euVq9erREjRlj9Fnj16tXKly+f1q5dq6ioKG3evFmffPKJVZ9Vq1bp5s2b+uWXX6yOWbhwYRUtWpQbZEi69/GK+Ph43b17Vw0aNEjVPqVLl1ZMTEwGVwYjyps3r+rXr6+QkJCHjoH69f+PvfsOa+ps/wD+PVlsAQGxLEFRHChqRUVQ3NvWXa3jtdWqVdvaV9+qba11a99q66z258RZa7VWcdTRuq1S9x6oQFAEZK9Acn5/8JoSAWWEJMD3c11eJifPec59wkny5M5z7hMIOzs7rF+/Pt9jR48exaNHj7S/Fnfu3BlyubzAttu3b0d6erq2bY8ePZCeno6tW7fqaY/IFBXls+9l/fr1w/nz5185o+CLL75AYmIilixZonPq4atMmjQJf/zxBy5dulTi/SEq7zgeJVPD8SuVBY5zydRwTGwaONOWCvXnn38iKSkJ/fv3h42Njc5jnTt3xs6dO5GVlQU7Ozt069YtX3Hy4OBg7Ny5E23atCnyNmNiYvL9GuPi4gJbW9uS7wiZLKlUigMHDmhv55WQkIBPPvkE/fr1g4+PD6ysrHD9+nWsWbMGHTp0MEa4ZAJmzJiBwYMHo1+/fvjoo4/g4+MDQRBw7do1hIeHo0GDBrC0tMTMmTPx73//G9OnT8eQIUNgbW2Ns2fP4r///S+6dOmCbt26Ach9f5k8eTIWLlwIMzMzbe2lo0ePYvHixXj//fe1s7aaNGmC999/HwsXLkR0dDQ6deqEN954A7Gxsdi5cycEQdCZyaVWq/O9nykUikJrkJFpKMpnX97ZBgAwcOBAdO3aFVWqVCmwzzVr1uDQoUP44YcfoFarERsbq/O4jY2NdgZNXj4+PujVqxc2bdpUyr0iKr84HiVTw/ErlRWOc8mUcExsGpi0pULt3LkTrVq1yvcCBXJrNa1ZswY3btzA4MGDC7yaZOfOnfHZZ5/h+fPnRd7munXrsG7dOp1l33zzDd5+++3i7wCVC4XNcrGysoKfnx82btyIiIgI5OTkoHr16hgwYADGjh1r4CjJVHh4eGD37t1YvXo1Fi1ahJiYGMjlcnh7e+P999/XXvG2a9eucHR0xA8//IAhQ4YgKysLnp6eGDt2LP71r3/pvGeNGDEC7u7uWLduHUJCQqBWq+Ht7Y2vv/4636/EU6ZMQcOGDbFt2zb88ssvyMzMhIODA5o1a4affvpJ53hOT0/PV5/Ow8MDhw8fLrsniEqtKJ99qampOstlMlm+moZ5bd26FdnZ2Rg1alSBj8+fP7/Q070+/vhj7N+/vxh7QFSxcDxKpojjVyoLHOeSKeGY2DQIIqtJExEREREREREREZkM1rQlIiIiIiIiIiIiMiFM2hIRERERERERERGZECZtiYiIiIiIiIiIiEwIk7ZEREREREREREREJoRJWyIiIiIiIiIiIiITwqQtERERERERERERkQlh0paIiIiIiIiIiIjIhDBpS0RUCf3111/w8fFBcnJyqfpp3749NmzYoJ+giIiIiIiKiONZIqroZMYOgIiosnv+/DmWLFmC48ePIy4uDra2tqhbty7GjRuHN99809jhERERERG9EsezRET6x6QtEZGRffTRR8jOzsaCBQvg7u6O+Ph4nD17FomJicYOjYiIiIjotTieJSLSP5ZHICIyouTkZISFhWHy5Mlo2bIlXF1d0ahRI4wZMwYdOnTAtGnTMGbMGJ11srOzERAQgJ9//hkAMGzYMMyePRtz586Fv78/WrVqhR07diA9PR3Tpk1DkyZN0KlTJxw/fjzf9i9evIhevXqhYcOGGDhwIO7evavz+KFDh9CjRw/4+vqiffv2WLduXdk9GURERERU7nA8S0RUNpi0JSIyIktLS1haWuLIkSNQqVT5Hh8wYABOnjyJZ8+eaZf9+eefyMzMRPfu3bXLdu/eDXt7e/z8888YOnQovv76a3zyySdo0qQJdu/ejcDAQHz22WfIyMjQ6f+bb77B1KlTsXPnTlStWhVjx45FdnY2AOD69euYOHEiunfvjr1792LChAlYsmQJdu3aVUbPBhERERGVNxzPEhGVDSZtiYiMSCaTYcGCBfj111/RrFkzDBo0CIsXL8bt27cBAE2bNoWXlxf27NmjXeeXX35B165dYWVlpV32omaYp6cnxowZAzMzM9jb22PgwIHw9PTE+PHjkZiYiDt37uhsf8KECQgMDISPjw8WLFiA+Ph4HD58GACwfv16BAQEYPz48fDy8kLfvn0xZMgQrF271gDPDBERERGVBxzPEhGVDSZtiYiMrEuXLjh58iR++OEHtG7dGufPn0ffvn21MwAGDBigvR0XF4eTJ0+iX79+On34+Phob0ulUtjZ2aFOnTraZY6OjgCA+Ph4nfUaN26svW1nZwcvLy+Eh4cDAMLDw9G0aVOd9k2bNsXjx4+hVqtLuddEREREVFFwPEtEpH9M2hIRmQAzMzMEBgZi/Pjx2L59O/r06YNly5YBAN5++21ERkbi0qVL+O233+Dm5oZmzZrprC+T6V5XUhAEnWWCIAAARFEs4z0hIiIiosqI41kiIv1i0paIyAR5e3sjPT0dAGBvb4+OHTti165d2L17N/r27au37Vy+fFl7OykpCY8ePULNmjUBADVr1sTFixd12l+8eBGenp6QSqV6i4GIiIiIKh6OZ4mISkf2+iZERFRWEhIS8Mknn6Bfv37w8fGBlZUVrl+/jjVr1qBDhw7adgMGDMCYMWOg0WjQu3dvvW1/5cqVsLe3h4ODA7777jvtgBoA3n//ffTv3x8rVqxA9+7dcfnyZWzZsgUzZszQ2/aJiIiIqHzjeJaIqGwwaUtEZERWVlbw8/PDxo0bERERgZycHFSvXh0DBgzA2LFjte1atWqFatWqwdvbG87Oznrb/qRJkzB37lw8evQI9erVww8//ACFQgEAaNCgAb7//nssXboUP/zwA5ycnPDxxx/rdWYEEREREZVvHM8SEZUNQWRBGCIik5eWloY2bdpg/vz56Ny5s7HDISIiIiIqFo5niYiKhzNtiYhMmEajQUJCAtatW4cqVaqgffv2xg6JiIiIiKjIOJ4lIioZJm2JiExYdHQ0OnTogOrVq2PBggX5rqpLRERERGTKOJ4lIioZlkcgIiIiIiIiIiIiMiESYwdARERERERERERERP9g0paIiIiIiIiIiIjIhDBpS0RERERERERERGRCmLQlIiIiIiIiIiIiMiFM2hIRERERERERERGZECZtiYiIiIiIiIiIiEwIk7ZEREREREREREREJoRJWyIiIiIiIiIiIiITwqQtERERERERERERkQlh0paIiIiIiIiIiIjIhDBpS0RERERERERERGRCmLQlIiIiIiIiIiIiMiFM2hIRERERERERERGZECZtiYiIiIiIiIiIiEwIk7ZEREbg4+MDHx8ftG/fXu99Dxs2TNt/VFSU3vsvC+3bt9fGXFR//fWXdp2pU6eWYXT6N3XqVG3sf/31l7HDISIiIhNg6uOD8jz2IiIqj2TGDoCISmfZsmVYvny5zjKpVApbW1vUr18fw4cPR3BwsJGiI1P3119/Yfjw4fmWm5ubw83NDZ06dcIHH3wAKysrI0QHbNiwASkpKQCAjz76yCgxFNXTp0+xfPlynDlzBs+ePYOZmRmqVq2KWrVqwdfXFxMmTDB2iERERGRgHB/k6tq1Kx4+fKi9/9NPP6Fx48bGC6gSiIqKwu7duwEA9erVQ8eOHY0cEREVF5O2RBWQWq3G8+fPcerUKZw+fRrLly/nhzQVS2ZmJu7fv4/79+/j6NGj2L59e5kmbpcsWYKsrKx8y0NCQqBUKgHkT9rWr18fW7ZsAQA4OjqWWWxFERsbi/79+yM2Nla7LDs7G6mpqYiIiMCJEyd0vpSNHTsW/fv3B4BizS4mIiKi8oPjg1w3b97USdgCQGhoKJO2ZUypVGon9/Tp04ffB4nKISZtiSqQNm3aYMyYMUhMTMSyZctw+/ZtiKKIzZs380OaXsvJyQnff/89NBoNrl69iu+//x7Z2dm4e/cutm/fjpEjR5bZths2bFjsdWxsbNCsWbMyiKb4Nm/erP1CFhAQgCFDhsDS0hJKpRJXr17FkSNHdNp7enrC09PTCJESERGRoXB8kGvfvn35lh08eBDTpk2DRFI2FRvT09NhaWlZJn0TERkKa9oSVSAODg5o1qwZOnbsiPHjx2uXP3nyJF/b27dv49///jeCgoLg6+uL1q1b44svvsDTp0/ztc3MzMSqVavQp08fNGnSBI0bN0aPHj2wZMkSnXaxsbGYM2cOOnbsCF9fXzRr1gzDhg3DgQMHdNpFRUVp62ENGzYM586dQ9++fdGoUSP06dNHW8Nr69at6NChAxo2bIhBgwbh9u3bOv3krd16/fp1TJ48GU2aNEFgYCCWLVsGURRx+/ZtDBs2DI0aNULbtm0REhKSb/+ys7Oxfv169O3bF40bN0bjxo0xYMAA7NmzJ1/bvLVoHz16hLFjx6JJkyZo3rw5vvrqq3yzRZ8/f47PPvsMb775Jpo1a4bPPvsMz58/z9dvSWJRq9VYtmwZWrduDT8/PwwbNizfc1QcCoUCzZo1Q/PmzTFq1Cj06tVL+1hYWJj2tiiK+OmnnzBw4EA0adIEDRs2RNeuXbF48WJtKYMXoqKiMGnSJAQFBaFBgwZo1qwZunfvjmnTpunE+nJN2127dsHHx0c7yxb457l/0eZVddVKeixevXoVw4YNg5+fHwIDA/Hdd99Bo9G89rm7ceOG9va0adPQqVMnBAYGYuDAgZgzZw7++OMPnfYF1ax7sc+F/Vu2bJl2/eIcJ3/99RdGjBiB5s2bo0GDBmjZsiX69++POXPm5Pt7ERERkf7oY3wAABqNBsuXL0ebNm20Y75bt24VeB2D4o5tYmJiMG3aNLz11lto0aIFGjRogObNm2P48OH5ksolIYqidvxlZmaGDh06AACePXuGCxcu5Gtfmn29cOEC3nnnHTRq1AizZs3S9lmc7z1paWlYtmwZevbsiUaNGqFp06YYNmwYjh8/rtNOX99nACAyMhJffvkl2rVrB19fXwQEBGDixIl48OCBTru8Y8Vly5Zhz5496NmzJ3x9fdGlSxfs379f23bYsGE6JdB2797NesRE5RBn2hJVUKIoam9Xq1ZN57Hjx49jwoQJUKlU2mXPnj3Dzp07cfz4cWzbtg3u7u4AgNTUVAwdOhS3bt3S6eP+/fvIyMjAJ598AiB3sDF48OB8p3+dP38e58+fx40bNzB58uR8cT5+/BijR4/WJjtv3ryJ0aNH491338W6deu07S5duoRx48bh999/h0yW/63r008/RUREBIDcX9aXL1+OpKQk7NmzB8nJyQByk9dz586Ft7c3WrVqpY3xgw8+wNmzZ3X6u3r1Kj777DPcvXsX//nPf/JtLykpCe+88w4SExO1y3766SfY29vj008/BQCoVCqMHDkSN2/e1LbZs2dPoYnV4sYyd+5cbXkAADh//jyGDBkCW1vbAvsvLmtra53YgNzjatKkSQgNDdVp+/DhQ6xevRqHDx/G9u3bYWtri5ycHIwcORKPHj3StktJSUFKSgoePHiApk2bom7dunqJNa+SHosPHz7EsGHDkJmZCeCfHyvc3NwwYMCAV24zb+mI77//HiNHjkSjRo2gUCgAABYWFvrYNe2+FPU4CQ8Px+jRo7X7BAAJCQlISEjAtWvXMGzYMNjY2OgtNiIiIvqHvsYH8+bNw6ZNm7T3z58/j2HDhqFKlSqvXK8oY5snT55g165dOuslJSXhr7/+wl9//YWFCxeid+/eRYqzIBcvXkR0dDSA3LMCe/fujaNHjwLILZHQokULvezro0ePMHLkyHwTKIrzvSclJQXvvvsu7t69q22blZWlHUN+9dVXGDJkSL5tl+b7zI0bNzBixAjt9xUgd9LHgQMHcPz4cWzcuBGNGjXKt809e/YgMjJSZ/8nTZqEunXrombNmq98roio/OBMW6IKJD4+HmFhYThy5AhWrlypXT5o0CDt7YyMDEydOhUqlQoymQyffvop1q1bh1GjRgHInaE4c+ZMbfvvvvtOm7C1s7PDtGnTsGbNGkyfPh1eXl7adjNnztQmyZo3b44ffvgB06ZNg5mZGQDg//7v/3DlypV8McfExKBVq1b48ccf0bJlSwC5A8p169ZhwIABWL16tXbgoVQqcerUqQL3PS0tDYsXL8a///1v7bJNmzbB0dERK1aswODBg7XLt2/frr0dEhKiTX41btwYK1aswNKlS7X7tmbNmgLjTk1NRdWqVbFs2TJt4hrITdy+sGvXLm3C1s7ODvPmzcOSJUuQnp5e4D4UJ5YHDx5g69atAACJRIKPPvoIq1evRuPGjXVmp5aERqPBlStXdE5lq1OnDgDgwIED2oStra0tZs+ejRUrVmhnv4aHh2Px4sXa2y8Stq1atcKaNWuwevVqTJ8+HW3atIFcLi80huDgYGzZsgVOTk7aZVu2bNH+e5WSHouxsbGoX78+Vq5ciWHDhmmX5z1eCvPiRwAAOHbsGIYMGYKmTZti8ODBWLduXaF/87xe7POLfwsXLtQ+R3K5HAEBAQCKd5ycOXNG+0Vt+PDh2LBhA5YuXYqJEyfC19cXgiC8Ni4iIiIqGX2MD8LDw7F582YAuWO+8ePHY9WqVWjUqNFrx3xFGds4Ojpi0qRJWLZsGTZs2ICQkBAsXLgQVatWBQD88MMPxdrnl+X9ob9Lly5o3bq1Npl96NAh5OTk6GVfnz17hurVq+O///0vfvzxR3Ts2LFE33teJGyDg4Px448/YuHChdrx6Pz58ws8g7Gk32dEUcTUqVO1Cdv3338f69atw+TJkyGVSpGeno5p06bpTMZ5ITIyEv3798fq1au1Y0SNRoOff/4ZAPDll1/iyy+/1LZv06aNdow5duzYVz6XRGQ6ONOWqAI5ceIETpw4ob3v4OCAzz77DD169NAuO336tPb0/FatWmlrgrZr1w4HDhzQDiSeP38OOzs7ncTdokWLEBQUBABo3bo1hg4dCgBITEzUDj4UCgWWLl0Ke3t7ALmDmBe/MO/btw9+fn46MZubm+Pbb7+FtbU1MjIycO7cOQCAi4sLZs+eDUEQ8ODBA3zzzTcAcn/JLsjEiRO1+7lq1SrtIPirr75CQEAAmjZtim3btgGAdkYuAPz222/a2yNGjICdnR0AoFevXli6dKm2zctxA8DixYtRr149dO7cGXv37kV4eDgSEhKQkpICGxsb7SwCAPj444/Rr18/AECVKlXw3nvv5euvOLEcO3ZMO4Dr3Lmz9iIWb775Jlq3bo2MjIwCn6dXUSqVBV70okqVKtpZBXv37tXZp4EDBwIAPDw8tOUUDhw4gK+//lpnRrSTkxM8PT3h6uoKiUSiPXYK4+DgAAcHB+1MFABFql9bmmNRLpdj2bJlcHR0RLt27bBz505kZGToHC+F6d+/Py5cuKDz/GRnZ+PixYu4ePEitm3bhp07d75yFvSLfQaA5ORkTJ8+XTvDeebMmdr9L85xkvdv4ObmBm9vb+0Xjw8//PC1+0VEREQlp4/xwdGjR7Vjvk6dOuHjjz8GADRt2hRt2rTROZvmZUUZ27i5ucHJyQkbN27E3bt3kZKSopMkfPToEVJTU3XOwCoqtVqNQ4cOAcgdl7Vr1w5mZmZo27YtQkNDkZiYiNOnTyM4OLjU+yqRSLBq1SqdWaZHjhwp0fceuVyO9957D3K5HFZWVujUqRO2bt2K7OxsHDhwAO+//77Otkv6feb27dvaJHG9evW0pSOaNGmCRo0a4dKlS7h//z5u3LgBX19fnW3WrVsXc+fOBQDY29trf9B/8bf18fHROSPwRRk9IipfmLQlqsCeP3+Oe/fu6SzLe+XWl5O8L4iiiPDwcHh5eWk/7BUKhc5sgbweP36sHWB5eHhok2SA7gWm8p4m/4KXl5d2EJh3wNqgQQPtLMC8/RVWgzPvaUO2trbapO2L7b+YLQBA5/SjvDFNnDixwL5fricF5JYOqFevnvb+i8TZi/5tbGx0TlnK+zwUdIpTcWMprG8bGxt4eXnplGQojWbNmmH69OlwdXXNF2Pe/ahTpw4sLCyQkZGBpKQkPH/+HJ6enmjWrBnCwsKwZ88e7NmzB+bm5qhbty46deqE4cOH6yRl9aE0x2LNmjXh6OgIIHfgX6VKFWRkZOgcL4WRSqX49ttvMWzYMBw8eBDnzp3D7du3tTXjIiIisHbtWp2Z4IXJzs7GhAkTEB4eDgAYPXq0NuH/cuyvO046dOiA7777DomJiZg3bx7mzZsHW1tbNGrUCP369UO3bt1eGw8RERGVjD7GB3nHfC+Pd2vWrPnKMV9RxjYbNmzA/PnzX7kfycnJJUranjt3DnFxcQCAwMBAbR9du3bVzsANDQ3VJm1Ls681atTIVxaguN97kpKSAOSOxUaMGFHgdgr6XlDS7zN547t161aBpRdebPPlpK2/v7/29svfQ4io4mDSlqgC6dOnD+bMmYOzZ8/io48+QkZGBtasWYM333wT7du3L1ZfL8/UFAShRKdSv26dvPU08149trCBYUGnB73cvij9FEdBs1ZfnhGRd0ZjYTHqQ1Fm0Jb0lHcnJyd8//33AHIvFOHu7q4zCCwuiUSCH3/8ETt27MDp06fx4MEDREdH4/Lly7h8+TIiIiJ0LhJR1l73vLzqb1pUfn5+2hm8cXFxmDlzJn7//XcAuhcjeZXp06drL17RpUuXIiV6X/biOHFycsKuXbuwbds2XLx4EQ8ePEBiYiJOnjyJkydPQqPR6MzEJyIiIv3Tx/gAKP4Yryhjm7z1Y0eNGoWgoCDI5XLMnDlTOwu0KBdlLUje0gh//PFHgWd0HT16FFlZWdoyVi8Ud19fJKdLojhnqBXUVl/fZ4qzzbx/W6lUWqz+iKj8YNKWqIKRyWRo3bo1Ro0apb3a/JIlS7RJ27x1aPv06YMFCxbk6yMjIwMWFhbQaDSwtbVFUlISsrKycObMGQQGBuZr7+HhAUEQIIoiIiIikJCQoP01+erVq9p2np6e+txVvfD09NReGOzIkSPaCxHkVZJSAwDg7u6u/QX9+vXr2hkDeZ+TksaS97Hr169rb6ekpOj8al8cCoXitadNeXp6ameAXrt2TbtPd+/e1cZma2uLqlWrQhRFWFlZ4b333tOWg3j+/DkGDBiAqKgoHD58+LVJ27wDdo1GozMQLoixjsULFy6gfv36OhcccXR0RO/evbVfyoryhWf58uXYvXs3gNwZJt98802+Ly3FOU5EUYSrq6vOhdeuXbuG/v37AwB+//13Jm2JiIjKiD7GBx4eHtrb165d095OSkrSjslKIyYmBkDubM0XFzJNT0/Hs2fPStWvSqXC4cOHX9suNTUVx48fR+fOnUu1rwUleUv6vcfS0hKnTp3S+bsBuX+rF6Wr9CFvfM2bN9dJoL8cX0nkHTeXNPFORMbFpC1RBTV06FCsWbMGGRkZuH37Nk6dOoWgoCC0atUKVatWxfPnz/Hrr7/C1tYWrVq1gkajgVKpxMWLF3H79m3s378fEokEPXv21F74adKkSRg3bhxq1qyJyMhIHDt2DP/3f/8He3t7BAUF4eTJk1CpVJg4cSJGjBiBiIgI7cWyAKBnz57GejoK1atXL20CbOzYsRg1ahSqV6+OZ8+eITw8HMeOHcN7772Hvn37Frvv9u3ba0/DWrp0KczNzWFpaam9UFdpYmnfvj2+/fZbALmJtxUrVsDX1xebN28u0kUtSqpXr144duyYdp8UCgXs7e2xfPlybZtu3bpBEAQ8ffoUI0aMQLdu3eDt7Q0HBwdERUVpa4vlvYpvYWxtbREVFQUgdyZIgwYNYGNjU+BMDQBGOxZ/+uknHD9+HF27doW/vz+qVauG+Ph4rFq1Stsmb3mGguzfv1/7Q4u5uTlGjhypk5B3cXGBi4tLsY6Tffv2Yfv27ejYsSPc3NxgbW2trbMGFO1vQERERCWjj/FBhw4d8O2330IURe2Yr0GDBggJCXlljdeicnV1xaNHj5CYmIgff/wRPj4+CAkJ0amHWhInTpzQnqrfoEGDfGPpe/fuaS+Itm/fPnTu3Fnv+1rc7z09evTA1q1bkZ6ejpEjR2LYsGGwt7fH06dPce/ePfz++++YN28eWrRoUarn5oW6deuiTp06uHv3Ls6fP4/PPvsMXbt2hUwmg1KpxNWrV3HkyBFcuHChRP1XqVJFe/vvv//G8ePHYWVlBS8vL+11FIjItDFpS1RB2dnZoW/fvtqE69q1axEUFARLS0ssWLAAEyZMgEqlwoYNG7BhwwaddV/ULwWATz/9FGFhYbhz5w4SEhK0Be9fbjdjxgwMHjwYsbGxOHfunE5iCAA++OCDAi/mZWzDhw/HqVOncPbsWdy/fx9Tp07VW9/9+vXD9u3bcfv2bSQkJGDatGkACp/lWZxYatWqhUGDBmH79u1Qq9XaC1CZm5vD2dlZO2tC37p164bDhw9j//79SExM1LkqLZBbOy3v6fwPHz7EypUrC+yrKDM8W7RooT1tcN68eQAKn4nwgrGOxeTkZOzYsQM7duzI95iTk5POVZsLkrfOWmZmJj755BOdxydMmICPPvqoWMeJRqNBWFgYwsLCCnzcFH9IISIiqkhKOz7w8vLC0KFDsWnTJp0xn7W1NVxdXaFUKksV38CBA7UXyFq0aBGA3B/Bvby8Snz2FpD7Y/QLffv2zXcR2sTERPz8889Qq9U4fvw40tLS9L6vJf3ec/fuXVy6dAmXLl0q5l4XjyAIWLBgAUaMGIHk5GTtNSD0pVatWnByckJsbCyioqIwevRoAMD8+fNLNCGFiAzv1eeZElG59q9//Ut7WsyZM2e0xfuDg4Pxyy+/4O2330b16tUhl8thb2+PevXq4b333tPWNQVyazT99NNP+OSTT1C3bl2Ym5vDwsICtWrVwttvv61t5+7ujl27dmHo0KFwc3ODXC6HtbU1/P398d133+mcnm1KFAoF1qxZgy+//BKNGjWClZUVzMzM4ObmhrZt22Lu3Lno1KlTiftev349evXqBWtra1hbW6Nbt24ICQnRSyzTp0/HuHHj4OTkBDMzMzRt2hQbNmxAjRo1ShRvUQiCgEWLFmHmzJlo1KgRLC0toVAo4OnpidGjR2PHjh3aGlu2traYMGECmjdvDicnJ8jlcpibm8PHxwcTJ07E9OnTX7u98ePH45133kG1atWKXNvMGMfihAkT8J///AdBQUHw8PCApaUl5HI5PDw8MHjwYPzyyy9wcnLSy7aKc5w0adIEw4cPR4MGDWBvbw+pVAobGxs0a9YM3333HUsjEBERlSF9jQ+mTZuGjz76CNWqVYOZmRmaNWuGkJAQnZmUJT2FfsSIEZg4cSJcXV1hYWGB5s2bY+PGjaUat6Snp2vPzAJQ4LU17Ozs0KRJEwC5P1YfPXoUgP73tTjfe6pUqVLg9x5PT0906dIFixcvRuPGjYv5bLxagwYN8Ouvv2LQoEFwd3eHXC5HlSpVUKdOHQwaNChfkrk4ZDIZVq5ciTfffDNfqQciKh8EsSyvmENEREREREREJSaKYr4frxMSEtCuXTtkZGSgSpUq+Ouvv15b+788qEz7SkT0OiyPQERERERERGSi1q5di6SkJLRt2xYuLi5QKpVYsmSJ9sKjXbt2rTBJzMq0r0REr8OZtkREREREREQmatmyZToXfc2rVq1a2LJlC+zt7Q0cVdmoTPtKRPQ6nGlLREREREREZKKaN2+Otm3b4tatW3j+/Dnkcjk8PT3RsWNHjBgxokLVK61M+0pE9DqcaUtERERERERERERkQlgMhoiIiIiIiIiIiMiEMGlLREREREREREREZEKYtCUiIiIiIiIiIiIyIUzaEhEREREREREREZkQmbEDMDWxsSnGDqHCksulyM5WGzsMqkB4TJE+8XgifeLxVHacnGyMHYLJq2jjWb6eiMdA5SWKIhISnkMul8La2haCIBg7JDISvg9QRTsGijKm5UxbMhh+vpK+8ZgifeLxRPrE44lIf/h6Ih4DlZdGo8GFC+dx/vxf0Gg0xg6HjIjvA1QZjwEmbYmIiIiIiIiIiIhMCJO2RERERERERERERCaESVsiIiIiIiIiIiIiE8KkLREREREREREREZEJYdKWiIiIiIiIiIiIyIQwaUtERERERERERERkQmTGDoCIiIiIiIiI6GWCIKBOHR8oFFIIgmDscIiIDIpJWyIiIiIiIiIyORKJBF5eNaFQSKFSqY0dDlE+oijyBwUqM0zaEhERERERERERvcbDpHCciPoTN+Ku4X7iPajUKiikCnjb1UYDx4Zo49YWXrY1jR0mVRCCKIqisYMwJbGxKcYOocLir6OkbzymSJ94PJE+8XgqO05ONsYOweRVtPEsX0/EY6DyEkURyclJkMulsLCw5ozGSszY7wMxaU+x6soKnFaeREp2CmSCFBYyC0gFKdSiGhk5GcgR1bCR2yDQtTXG+o2Hs1V1o8VbERn7GNC3ooxpOdOWiIiIiIiIiEyORqPBuXNnIZNJ0LZtR0ilUmOHRJXQGeUpLApbiOhUJRwsHFDTomaBPyCIoogkVSIOPgzF1djLmOw/FQEugUaImCoKibEDICIiIiIiIiIiMjVnlKcw+9wMPEuPgaetF+zM7Aud8S0IAuzM7OFp64Vn6TGYdfYrnFGeMnDExhMR8QhvvdUF6elpRtn+w4fh6NOnOzIyMoyy/bLApC0REREREREREVEeT9OeYFHYQqSqUuBhUwNSoWgzvaWCFB42NZCqSsGisIWISXuqt5iuX7+KNm2a4z//+eSV7Q4fPog2bZpj0aKF+R67eDEMQUHNtP969eqML774D5TKKG2b/v17YceOrcWKbdWqFejXbyAsLa0K3E779oEYOnQg9uzZpbPehAmjsWTJonz97d+/F127tgUAzJ8/C4MHD0B2drZOm7NnT6Ft25a4c+c2vLxqokEDX/z005ZixW3KmLQlIiIiIiIiIiLKY/WVlYhOVcLNxr3Y9ZQFQYCbjTuiU5VYdWWF3mLat28P+vV7B5cvX0JcXOwr2v2Gd98djiNHDiErK6vANlu3/oJffz2I2bMX4OHDcEyZ8m+o1SWrGfv06VOcOXMS3bv3KnA7e/YcxObNO/D2232xaNEChIWdL1b/H3/8b6Snp2Ht2tXaZSkpKVi4cC5GjBgFH5+6AIDu3d/C7t07kZOTU6L9MDVM2hIREREREREREf1PeNIDnFaehIOFQ5Fn2L5MKkjhYO6A08qTeJgUXuqY0tPTcfToYfTp0w+tWgVi//69BbaLjlbi+vUrGDp0BNzdPXD8+B8FtrO3rwpHR0c0btwUI0Z8gEePwqFURpYotmPHDsPbuw6cnKoVuB0HB0e4uLhiwIBBeOMNF9y9e7tY/VtZWWP69JnYvn0zbty4DgBYunQRnJycMHToCG07f/8WSElJxuXLF0u0H6aGSVsiIiIiIiIiIqL/ORl1HKnZKbBV2JWqH1szO6Rkp+BE1J+ljunYscOoUcMTHh6e6Ny5O0JDf4Moivna7d+/FwEBQbC2tkaXLt0QGrrntX2bmZkBALKzSzZD9erVS6hbt94r24iiiHPnziAm5inq1/ct9jaaNfNHnz4DMHfuDBw7dgTHjh3Gl1/Ogkwm07aRy+Xw9q6DK1cuFbt/U8SkLRERERERERER0f/ciLsGqSAtdlmElwmCAJkgxa34G6WOKTR0Dzp37gYAaNEiAGlpqbh06W+dNhqNBvv370WXLrntOnTogqtXLyM6Wllov3Fxcdi+fROcnKrBw6NGiWJ7+vQpHB2dCnysb9/u6NSpNdq2bYnPPpuI9977AI0bNy3RdsaOHQ8A+PrrzzFmzHjUqOGZr42joxNiYvRXR9iYZK9vQkRERERERERkWIIgoFYtb8jlklInz4iK437iPVjILPTSl4XMAncT7pSqj4iIR7h58wbmzfsWACCTydC+fSeEhu5B06bNtO0uXPgLmZmZCAgIAgDY2dnB378FQkN/wwcffKjTZ9++3SGKIjIzM+HtXQdz5nwDuVxeoviysjKhUCgKfGzFiv+DpaUVVCoVbt26ge+++wZVqtiiT5/+xd6OmZk5Bg8ehqVLF2PAgMGFtDFDZmZmsfs2RUzaGtnQ0IHGDsFgBIkAUZN/6n5FtbnHDmOHQEREREREVG5JJBJ4e9eGQiGFSlWyCyQRFZcoilCpVSWuZfsyqSCFSq2CKIol/vFh3749UKvV6N27m06ccrkcn346BdbW1tp2yclJ6NAhUNtOo9Hg/v17GDlyDCSSf064X7Hi/2BlZQ17e3tYWlqVcO9y2dnZISUlpcDH3njDFTY2NgCAmjVr4ebN6wgJWadN2lpZWSEtLTXfeqmpKbCyss63XCqVQiot/Iec5ORkuLq6lnRXTAqTtkRERERERERERMid4a2QKpCqztJLf2pRDQupZYkTtjk5OTh4cD8mTJiI5s1b6jw2bdpkHDlyEL1790dSUiJOnTqOmTPnwcur5j/bV2swbtwonD9/Di1bttIuz5tMLa3atX3w6FHRLrYmkUiRlfXPc+vh4Ynz58/la3fnzm24u3sUO5aHDx+gXbv2xV7PFDFpS0REREREREQmRxRFpKWlQi6XQqGwYIkEMhhvu9o4G31aL31l5GSgqXOz1zcsxJkzp5CSkoyePXtrZ9S+EBzcHvv2/Ybevfvj0KH9qFLFFu3bd8r3WgkICMS+fXt0kravExsbi3v3dMs6ODu/gSpVquRr27x5ABYunAO1Wg2pVHeGckLCc6hUWcjOzsbNmzdw6NB+tG37T1K1d+9++OWXHfj++/+iZ8/eUCjkOHPmFI4cOYSFC78rcrwA8ORJNGJjn6FZsxbFWs9UMWlLRERERERERCZHo9Hg9OlTkMkkaNu2Y75kEFFZaeDYECeVJ0pV0gDI/eEhR1SjnkODEvexb98eNGvWPF/CFgDatm2PrVtDcP/+PYSG/oY2bdoVGG9wcHvMmfMVEhMTi7zdbds2Ydu2TTrLpk+fhS5duudr27JlK0ilUoSFnUeLFgE6j737bj8AuWUNqlWrjrff7ov33x+tfdzV1Q0rVvyIH39ciYkTxyEnJxseHp6YPXthsZLMAHDkyCH4+7dE9epvFGs9UyWIolh5iowWQWxswTU4ygpr2lZcrGlb9ljbivSJxxPpE4+nsuPkpJ/T+CoyQ49nyxpfT8RjoPJSq9U4cuR3Jm3J4O8DD5PCMeb396GQymFnZl/ifhIzE6DSZGN153Xwsq35+hXKsV9+2YHTp09g8eLlZdL/646B7OxsDBrUBzNmzEGjRo3LJAZ9KsqYVvLaFkRERERERERERJWEl21NBLq2RnxGPNRiyZLFalGN+Mx4BLq2rvAJWwB4++2+8PNrgvT0NKNsPybmKYYNe69cJGyLiuURiIiIiIiIiIiI8hjrNx5XYy8jKiUSHjY1ilUmQRRFRKVEwsXaFWP9xpdhlKZDJpPhX/8aabTtu7m5w83N3WjbLwucaUtERERERERERJSHs1V1TPafCmuFDSJSHhd5xq1aVCMi5TGsFTaY7D8VzlbVyzhSqqiYtCUiIiIiIiIiInpJgEsgpreciWqWzniU9BCJmQko7NJQoigiMTMBj5IeopqlM74KmIUAl0ADR0wVCcsjEBERERERERERFaCVaxBq2Xlj1ZUVOK08ifDkcMgEKSxkFpAKUqhFNTJyMpAjqmEjt0FXrx4Y6zeeM2yp1Ji0JSIiIiIykAsXLmDt2rW4fv06YmNjsWLFCnTs2PGV6/z1119YsGAB7t27hzfeeAMffvgh+vbta6CIiYiMRxAEeHp6QS6XFKueKJG+OVtVx4xWs/EwKRwnov7EzbjruJd4F6ocFSzklmjq3Az1HBqgjVvbSnHRMTKMcp203bp1K7Zt2walUgkAqF27NsaNG4fg4GAAwLBhw3D+/Hmddd555x3MmjXL4LESEREREaWnp8PHxwf9+vXDhAkTXts+MjISY8aMwaBBg/Dtt9/i7Nmz+PLLL+Hk5ITWrVsbIGIiIuORSCTw8akLhUIKlapo9USJylJVVEUzNIMnaiARAVALakghhZ1YFY5wQlVUNXaIVIGU66Rt9erVMXnyZNSoUQOiKOLXX3/F+PHjsXv3btSuXRsAMHDgQHz88cfadSwsLIwVLhERERFVcsHBwdoJBkWxfft2uLm5YerUqQCAWrVq4e+//8aGDRuYtCUiIjKQtLRUXLlyEUplJLKzVRAECWQyGQRBgFqtRnR0FJTKCNy8eQ2uru7w82sKKytrY4dN5Vy5Ttq2b99e5/6nn36Kbdu24fLly9qkrbm5OZycnIwRHhERERFRqVy+fBkBAQE6y4KCgjBv3jwjRUREZDiiKCIjIwM5OVJIpQqWSCCjUCojERZ2DqmpKbCwsISFhV2Bx6IoilCpsvDw4X3ExsbA3z8ALi5uRoiYKgqJsQPQF7VajdDQUKSnp6NJkyba5Xv37kWLFi3Qs2dPLFq0CBkZGUaMkoiIiIio6OLi4uDo6KizzNHREampqcjMzDRSVEREhqHRaHDy5HEcP/4nNBqNscOhSkipjMS5c6eQnp4GW1s7mJmZF/rjgSAIMDMzh62tHdLT03D27EkolZEGjtj4Zs+ejpCQdcYOo0gSExPRs2cnPHsWY+xQClSuZ9oCwJ07dzBo0CBkZWXB0tISK1asgLe3NwCgZ8+ecHFxQbVq1XDnzh18++23ePjwIZYvX27kqImIiIiIyoZcLkVFmowmk0mNHQIZGY+BykutBmQyCaRSCRQKKaRSHguVlTHeB1JTU3Hx4l/IzlbB1rbg2bUFk8LW1g7JyUm4ePEvVKvmWOpSCTNnfoXQ0L3o06cfpk37Uuexb76Zj507d6BHj16YMSP3Gk4JCc+xevUPOH36FJ4/j4eNTRXUrl0Ho0aNhp9fYwDA2293x5MnT3T6qlatGt56qw/WrFn9ynjOn79U4PK7d+/g7NkzmDbtSygUuX+zsWNHoU4dH/z73//Rabtv329YvPi/OHbspHZZZmYmQkLW49Chg3j69AksLa3w5pvN8MEHY+HjU0fb7scfV+H48T+wZctPBcYxduwoXLz4NwBALpfDzs4OPj710KvXW2jXrkOe/XVAjx49sX79j5g+/etX7rMxlPukrZeXF3799VekpKTg0KFDmDJlCjZv3gxvb2+888472nY+Pj5wcnLCiBEjEBERAQ8PjwL7M/QgV5BUoBH1a0gEAZoKM7f79V68QVHZ4QCe9InHE+kTjyfSF0dHR8TFxeksi4uLg7W1NczNzQtcJzu74l2shxcgIh4DlZNarUZOTu4MW5VKDeZsKzdDvw+EhV1AcnIKbG1tIYq55Q+Kw9raBklJibhw4QJatWpTqlg0GhHVqjnj8OFDmDDhU5iZ5Y4BsrKycPDgATg7V4dGI2qfo88+m4zs7Gx88cXXcHFxxfPn8fj77wuIj3+ubSOKwKhRY9GrV2/tdiQSKczMzNCrVx/tsg8++BfeequPTrvC/hbbt29Du3YdIJOZadtoNCLUajHfOnlf27n/q/DJJ2MRExOD8eMnokEDXzx/Ho9Nmzbg/feHYfnyVfDxaQAAUKs1EMXC49BoRPTq1QejRo2BWq3Gs2fPcOLEH/jii6no1q0Xpkz5Qtu2S5eeGDVqGD788GNUqWL76j+EgZX7pK1CoUCNGjUAAL6+vrh27RpCQkIwa9asfG39/PwAAI8fPy40aWvoQa6oKd6LvjzTSCrX/nJgaRh8nkmfeDyRPvF4In1o3LgxTpw4obPszJkzaNy4sXECIiIiqgSSkhKgVEbCwsICglCy2WeCIIG5uSWUykgkJSXC1tauVDH5+NSFUhmF48f/QOfO3QAAx4//AWfn6nBxcdG2S0lJwZUrl7Bs2Wo0afImAKB69TdQv75vvj4tLS3h4OBY4PIXJBJJoe3yUqvV+PPPo/jqqzkl2r8dO7bi+vVrWLduC2rXrqONe+7cbzB69AjMmTMTISE/FXnGs7m5uTbmatWc4evbEDVqeGL+/Flo374j/P1bAABq1qwFBwcnnDjxB3r27F2i2MtKhZv3qNFooFKpCnzs1q1bAMALkxERERGRUaSlpeHWrVvacWlUVBRu3bqF6OhoAMCiRYvw2WefadsPGjQIkZGR+Oabb/DgwQNs2bIFBw4cwIgRI4wRPhERUaUQFRWJ7GwVFAqzUvVjZmaG7GwVoqIi9BJXjx5vITR0r/Z+aOhv6NGjl04bCwsLWFhY4uTJPwvNj5WFBw/uITU1FXXr1ivR+ocPH4K/fwttwvYFiUSCgQPfxcOH4bh//26pYuzWrSdsbKrg+PE/dJbXr18fV65cLlXfZaFcz7RdtGgR2rRpgzfeeANpaWnYt28fzp8/j7Vr1yIiIgJ79+5FcHAw7OzscOfOHcyfPx/+/v6oW7eusUMnIiIiokro+vXrGD58uPb+/PnzAQB9+vTBggULEBsbq1Nfzt3dHatXr8b8+fMREhKC6tWrY86cOWjdurXBYyciIqos4uJiIQiSYtSxLZggCBAEAfHxsXqJq3Pn7li9egWePs0dK1y7dgUzZ87DpUt/a9vIZDJ88cUMLFw4F7/+ugs+Pj5o3PhNdOjQGd7etXX6++GHZfi///tBe3/06PEYMGBQiWJ7+vQppFIp7O2r5nts9+6fsW/frzrL1Go1FAqF9n5kZASaNm1WYN+enp4AgIiICNSu7VOi+IDcBLC7uweePo3WWe7o6IS7d++UuN+yUq6TtvHx8ZgyZQqePXsGGxsb+Pj4YO3atQgMDMSTJ09w9uxZhISEID09HW+88QY6d+6McePGGTtsIiIiIqqkWrRogTt3Cv9SsGDBggLX+fXXX8swKiIiIsorMfE5ZDL9pMxkMjkSEp7rpS97e3sEBARi//69EEURrVoFws7OLl+7tm07ICAgCFevXsKNG9dx7twZbN0agilTvkT37v/MzB08eJjO/dKUcMjKyoRcLi8w0d25czcMH/6+zrLjx49h06b1OsuKWze4JERRzBejQmGGzMzMMt92cZXrpO28efMKfeyNN97A5s2bDRgNEREREREREemLIAhwd/eAXF76GY9ERSWKItRqtd6OOUEQoFarC0wWlkSPHm/ju+++AQD8+9+fFdrOzMwM/v4t4e/fEiNGjMKCBbOxdu1qnSStnZ0d3NzcSx3Ti74yMzORnZ0NuVyu85iVlXW+7bw8I9fd3QOPHz8ssO9Hjx4BQKHXpyoqtVqNqKhI1KtXX2d5Skoy7O3tS9V3WahwNW2JiIiIiIiIqPyTSCSoX78BGjTwhUTC9AUZhiAIkEqlepv1KYoipFKp3pLALVoEIDs7Gzk5OWjePKDI63l6eiEzM0MvMRTE2zu3bMGjR+ElWr9jx84ICzuPe/d069ZqNBrs2LEVXl414e1dp5C1i+bAgX1ISUlG27YddJaHhz8oVdmFslKuZ9oSERERERERERHpk51dVURHR+mlr5ycbDg7V9dLXwAglUqxZcvP2tsvS0pKxPTpU9Gjx1uoVas2LC0tcfv2LWzduglBQcF6i+Nl9vb2qFOnLq5evVyiBOjAge/i5MnjmDLlU0yY8Cnq1/dFQkI8QkLW4/Hjh1i+fJVO4jsrKxP37umWnLK0tIKrqxsAIDMzE/HxcVCr1Xj27BlOnPgDO3ZsRe/e/XVq52ZmZuLOnVsYM2Z8Cfe87DBpS0REREREREQmSaVSAZD+7x+RYTg6OkGpjCh1SQNRFCGKIhwcnPQYXW65gcJYWFiifn1f/PTTVkRHRyEnJwfVqjmjV6/eGD78Pb3G8bJevXrj4MFQ9Ov3TrHXNTMzw9KlqxASsg4//ph7sTVLSys0bfomVq9ej7p1faBSqbXtIyMj8N57Q3T6ePPN5liyZCUAYO/e3di7dzfkcjmqVLGFj089zJw5H8HB7XTWOXnyTzg7V4efX5Nix1zWBNEQVX7LkdjYFINub2joQINuz5gEiQBRU3kOt809dhg7hApPoZDqvGkTlQaPJ9InHk9lx8nJxtghmDxDj2fLGl9PxGOg8lKr1Thy5HfIZBK0bduxwFmFVDkY+n0gKSkRv/8eCqlUCjMz8xL3k5mZCY1Gjc6de5TqIl/lRVZWJgYP7odZs+bD17eRXvsuq2Ng9OgR6N9/EDp37qr3vl+lKGNaFoUhIiIiIiIiIiL6H1tbO7i6uiMjIx2iqClRH6KoQWZmOlxd3StFwhYAzMzM8eWXM5GYmGjsUIokMTERwcHt0KlTF2OHUiCWRyAiIiIiIiIiIsrDz68pYmNjkJKSDBsb22KVSRBFESkpybC2toGfX9MyjNL05K0Xa+rs7OwwZMi/jB1GoTjTloiIiIiIiIiIKA8rK2v4+wdAoTBDSkpSkWfciqIGKSlJUCjM4O8f8Mr6s0SvwqQtERERERERERHRS1xc3NCyZRAsLa2QlJSIzMxMFHZpKFEUkZmZiaSkRFhaWiEgoDVcXNwMHDFVJCyPQEREREREREREVABXV3fY2dnjypWLUCojkZycCEEQIJPJIQgCRFFETk42RFGEXK6Al5c3/PyacoYtlRqTtkRERERERERERIWwsrJGq1ZtkJSUiKioCMTFxSIx8TlycnIgl8vh7FwdDg5OcHPzqDQXHaOyx6QtEREREREREZkcQRDg4uIKuVxSrItAERnKi+OykIoJRKXCpC0RERERERERmRyJRIKGDRtBoZBCpVIbOxyqxNLSUrXlEbKzVRAECWQyGQRBgFqtRnR0FJTKCNy8eQ2uru4sj0B6waQtERERERERERFRAZTKSISFnUNqagosLCxhYWFX4MxvURShUmXh4cP7iI2Ngb9/AC9ERqUiMXYAREREREREREQFUavVUKs5y5aMQ6mMxLlzp5CengZbWzuYmZkXWqpDEASYmZnD1tYO6elpOHv2JJTKSANHXH7Nnj0dISHrjB1GkSQmJqJnz0549iymTLfDmbZEREREREREZHLUajWOHPkdMpkEbdt2hFQqNXZIVImkpaUiLOwcVKos2NjYFrmusiBIYGNji5SUJISFnYOdnb1eSiXEx8dh06YNOHv2FGJjn8HKyhpubm7o3Lk7unXrCXNzc23ba9euYOPGtbh+/RpUqiy4ubmje/deGDBgcL7X0enTJ7Ft2ybcuXMbGo0aXl610LfvAHTv3itfDH/+eRS7dv2Mu3fvQKVSwdnZGQ0b+qF//3dQp05dAMD+/XuxdOkiHDz4Z5H37d69uzh79gwmTZqmXTZhwmjUru2DTz6ZpNO2oP6zsjKxefNGHD58CDExT2BpaYkmTZrh/fdHo2bNWtp2a9euxsmTx7Fhw9YC45gwYTQuX74IAJDL5bC1tUOdOnXRo0cvBAe317azs7ND1649sHbtakyb9lWR97O4mLQlIiIiIiIiIiLK48qVi0hNTYWtbdETti8IggAbmypISkrElSsX0apVm1LFolRGYdy4kbC2tsHo0eNRq5Y35HI5wsPv47ffdsPJyQlBQcEAgOPH/8BXX01F9+5vYdmy8bC2tkFY2HmsXLkU169fw+zZC7T7s3PndixduhhDhvwLkyZNhVwux8mTx/Htt/MRHv4AEyZM1MawcuVS/PTTFvTv/w5GjhwDZ+c3kJiYgHPnTmPVqhVYvHhZiffvl19+Qrt2HWBpaVnsdVUqFSZOHIeYmBiMHz8RDRr44vnzeGzatAFjxozAd9+thK9vwyL316tXH4waNQZqtRrPnj3DiRN/YMaMz9GtWy9MmfKFtl337r0watQwjB//CapUsS123EXBpC0REREREREREdH/JCUlQKmMhIWFBQShZJVFBUECc3NLKJWRSEpKhK2tXYnjWbRoIaRSGdas2QQLCwvtcldXN7Ru3RaiKAIAMjIy8M03cxAU1EYnwdirV2/Y21fF1Kn/xrFjh9GhQ2fExDzF8uXfY8CAwRgzZry27eDBQyGXy/D999+iXbuOaNDAF9evX8PWrSH45JPJGDBgkLZt9erVUbduPe32S0KtVuPPP4/iq6/mlGj9HTu24vr1a1i3bgtq167zv7jewNy532D06BFYsGA2Nm36qciJd3Nzczg4OAIAqlVzhq9vQ9So4Yn582ehffuO8PdvAQCoWbMWHByccOLEH+jZs3eJYn8d1rQlIiIiIiIiIiL6n6ioSGRnq6BQmJWqHzMzM2RnqxAVFVHiPpKSEnHhwjn06TNAJ2Gb14uE5Pnz55CUlITBg4flaxMU1Abu7h44cuQQgNxSBzk5OQW2ffvtfrCwsNS2PXLkECwsLNGnT/9Xbr8kHjy4h9TUVNStW69E6x8+fAj+/i20CdsXJBIJBg58F48eheP+/bsljg8AunXrCRubKjh+/A+d5fXr18eVK5dL1fercKYtERERERERERHR/8TFxUIQJKVKRgK5yUxBEBAfH1viPqKioiCKIjw8augs79GjA1QqFQCgT58BGDfuY0RGPgYA1KjhVWBfNWp4IjIyN4EcGRkBa2trODo65msnl8vh4uKq7S8yMgIuLq6Qyf5JI27fvhlr167W3t+9+wCsrYtfu/fp06eQSqWwt6+a77Hdu3/Gvn2/6ixTq9VQKBTa+5GREWjatFmBfXt6egIAIiIiULu2T7Fje0EikcDd3QNPn0brLHd0dMLdu3dK3O/rMGlLRERERERERET0P4mJz3USlKUhk8mRkPBcL33l9eOPGyGKImbO/BLZ2dk6j5WmXEFR9ejxNoKCgnHz5nXMmjW9xNvMysqEXC4vMEHeuXM3DB/+PgBALpcgO1uD48ePYdOm9TrtDLG/oijmi1GhMENmZmaZbZPlEYiIiIiIiIiIiJCbnFOr1aWeZfuCIAhQq9UlTiy6ublBEARERDzWWe7q6gY3N3eYmf1TwsHdPXc27uPHDwvs69GjR3B39/hfWw+kpqYiLi7/LODs7GxER0dp+3N3d0d0tBI5OTnaNjY2NnBzc4ejo1OJ9usFOzs7ZGZm5ks8A4CVlTXc3Nzh5uYOd3cPuLm555uR6+7u8cr9BQAPD49SxahWqxEVFYk33nDRWZ6Skgx7e/tS9f0qTNoSERERERERkckRBAHOzs6oXr263hJoRK8jCAKkUqneZm+KogipVFriY9jW1g7+/i2wa9cOZGRkvLJt8+YtUaWKLbZv35zvsVOnjiMqKgIdO3YBAAQHd4BMJsO2bfnb/vrrL8jIyNC27dixCzIy0rFr188l2odX8fbOLVvw6FF4idbv2LEzwsLO49493bq1Go0GO3ZshadnTXh71ylk7aI5cGAfUlKS0bZtB53l4eEPSlV24XVYHoGIiIiIiIiITI5EIkHjxk2hUEihUqmNHQ5VInZ2VREdHaWXvnJysuHsXL1UfUyaNBUffjgSo0YNw/vvj0atWrUhkQi4desmIiIew8cn9yJeFhYW+M9/puHrr7/AwoVz0a/fQFhZWeHvv89jxYqlaNu2A9q37wQAqF69OsaN+xjLl38PhUKBrl17QCaT4eTJP/HjjysxaNBQNGjgCwDw9W2EQYOGYsWK7xET8wRt2rSHs7Mz4uLiEBq6B4IgQCL5JymtVmtw755urVe5XAFPz/y1du3t7VGnTl1cvXq5RAnQgQPfxcmTxzFlyqeYMOFT1K/vi4SEeISErMfjxw/x3XcrdRLmWVmZ+WKztLSCq6sbACAzMxPx8XFQq9V49uwZTpz4Azt2bEXv3v11audmZmbizp1bGDNmfLFjLiombYmIiIiIiIiIiP7H0dEJSmVEgXVMi0MURYiiCAeH0pUQcHV1w7p1W7Bp0zqsWrUCsbEx2iTooEFD0bfvAG3bdu06ompVB2zcuA7jx4+CSqWCm5s7hg9/HwMHDtbZn4ED34WLiyu2bduMnTu3Q63WwMurJiZNmooePd7SiWHChImoV68Bfv11J0JDf0NmZiaqVnWAn18TrFq1HlZW/1yELCMjHe+9NyTfPvz0068F7l+vXr1x8GAo+vV7p9jPjZmZGZYuXYWQkHX48ccVePr0CSwtrdC06ZtYvXo9atb01mkfGRmRL7Y332yOJUtWAgD27t2NvXt3Qy6Xo0oVW/j41MPMmfMRHNxOZ52TJ/+Es3N1+Pk1KXbMRSWIhqjWW47ExqYYdHtDQwcadHvGJEgEiJrKc7ht7rHD2CFUePzFnfSJxxPpE4+nsuPkZGPsEEyeocezZY2vJ+IxQDwGyNDHQFJSIn7/PRRSqRRmZuYl7iczMxMajRqdO/eAra2d/gKsYLKyMjF4cD/MmjUfvr6NCmxjau8Do0ePQP/+g9C5c9cSrV+UMS1r2hIRERERERGRyVGr1Th06AAOHNgPtdp0kjVU8dna2sHV1R0ZGekQRU2J+hBFDTIz0+Hq6s6E7WuYmZnjyy9nIjEx0dihFEliYiKCg9uhU6cuZbodlkcgIiIiIiIiIiLKw8+vKWJjY5CSkgwbG9tilUkQRREpKcmwtraBn1/TMoyy4shbL9bU2dnZYciQf5X5djjTloiIiIiIiIiIKA8rK2v4+wdAoTBDSkpSkWfciqIGKSlJUCjM4O8foFPrlag4mLQlIiIiIiIiIiJ6iYuLG1q2DIKlpRWSkhKRmZmJwi4NJYoiMjMzkZSUCEtLKwQEtIaLi5uBI6aKhOURiIiIiIiIiIiICuDq6g47O3tcuXIRSmUkkpMTIQgCZDI5BEGAKIrIycmGKIqQyxXw8vKGn19TzrClUmPSloiIiIiIiIiIqBBWVtZo1aoNkpISERUVgbi4WCQmPkdOTg7kcjmcnavDwcEJbm4evOgY6Q2TtkRERERERERERK/xHM8RhjDcwDXcxz2oBBUUUMBbrI0GaAhLWMMWdsYOkyoIJm2JiIiIiIiIyOQIggBHR0fI5VIIgmDscKgSi0l7ilVXVuC08iRSslMgE6SwkFlAKkiRqs7C2ejTOKk8gS03QxDo2hpj/cbD2aq6scOmco5JWyIiIiIiIiIyORKJBG++6Q+FQgqVSm3scKiSOqM8hUVhCxGdqoSDhQNqWtQs8EcEURSRpErEwYehuBp7GZP9pyLAJdAIEVNFITF2AERERERERERERKbmjPIUZp+bgWfpMfC09YKdmX2hs74FQYCdmT08bb3wLD0Gs85+hTPKUwaO2PSEhZ3HkCH9oVYb54eXc+fOYMSId6HRaIyy/dJg0paIiIiIiIiIiCiPp2lPsChsIVJVKfCwqQGpIC3SelJBCg+bGkhVpWBR2ELEpD3VW0zXr19FmzbN8Z//fJLvsSdPohEU1Axt2jRHbOwzncfi4uIQHNwCQUHN8ORJNABgwoTRCApqVui/S5f+BgDMnfs1goKaYdOmDTp9njjxJ4KCmr025pUrl+Jf/xoJqTT3+du/f6/Odjp1ao333x+K48eP6azXv38v7NixNV9/a9euxogR70IURXzyyTj8+98T8rXZtetndO3aFs+exaBly1aQyWT4/fcDr43V1DBpS0REREREREQmR61W48iRQ/j994NGm6VHldfqKysRnaqEm417sWsqC4IANxt3RKcqserKCr3FtG/fHvTr9w4uX76EuLjYAts4Ojrh4MFQnWUHDuyDo6OTzrJ58/6LPXsO6vzbuXMfatashbp166N+fV9tW4XCDFu2bERycnKx4r1y5TKio6MQHNxeZ7mVlZV2m+vWbUGLFgH46qtpiIh4VOS+BUHA559/hZs3r+PXX3/RLo+OVuKHH5Zi4sT/oFo1ZwBAt249sXPnT8WK3RQwaUtEREREREREJkmt1kCtLn+nNVP5Fp70AKeVJ+Fg4VDkGbYvkwpSOJg74LTyJB4mhZc6pvT0dBw9ehh9+vRDq1aB2L9/b4HtunXridBQ3cf27/8N3br11FlWpYotHBwcdf5t3LgGSUmJmDfvvzAzM9O2bdasORwcHLB58/pixXz06CE0a9ZCpy8gN+H6Ypvu7h744IMPIQgC7t+/X6z+nZ2r45NPJmPFiiWIjlZCFEUsWDAb/v4t0bVrD227wMA2uH37JpTKqGL1b2xM2hIREREREREREf3PyajjSM1Oga3CrlT92JrZISU7BSei/ix1TMeOHUaNGp7w8PBE587dERr6G0RRzNcuKKgNUlOTceXKZQC5s11TUlIQGNj6lf3v2vUzDh4MxZw532hnqL4glUowevR47Ny5A8+exRQ55itXLqNu3XqvbKNWq3HgwD4AgI9P3SL3/UK3bj3RrJk/5s+fhV9++Qnh4Q/wn/98rtOmevXqqFrVAVeuXCp2/8YkM3YAREREREREREREpuJG3DVIBWmxyyK8TBAEyAQpbsXfKHVMoaF70LlzNwBAixYBSEtLxaVLf6NpU926sjKZDJ07d0No6B74+TVGaOgedOnSDTJZ4SnAy5cvYunSRZg0aSoaNvQrsE1wcDvUrl0Ha9euxrRpXxUp5piYJ/nKMgBAamoqOnXKTSJnZWVBJpPhs8++gKurW5H6fdlnn32BYcMG4sqVS5gz5xvY29vna+Po6IinT5+UqH9j4UxbIiIiIiIiIiKi/7mfeA8WMgu99GUhs8DdhDul6iMi4hFu3ryBTp26AMhNzLZv3wmhoXsKbN+jx9v444+jiI+Pwx9/HEWPHm8V2vfTp0/x5ZdT8NZbfdCrV+9XxvHhhx/h4MFQPHr0sEhxZ2VlQaEwy7fc0tIK69dvxfr1W7Fu3RaMHj0O3347H6dOnShSvy+zt6+Kt97qixo1PNGmTdsC25iZmSEzM7NE/RsLZ9oSEREREREREREBEEURKrWqxLVsXyYVpFCpVRBFscQzd/ft2wO1Wo3evbvpxCmXy/Hpp1NgbW2t075WLW/UqOGJr7/+Ap6enqhZ0xv37uVPHGdlZeLzzyfDy6smPv540mvjaNy4KZo3b4nVq5ejW7der21va2uHlJT8Fy+TSAS4ublr73t718b5839hy5aNCApqAyD3YmWpqan51k1NTc23vwAglUohlRae5kxOToadXf4ZuKaMSVsiIiIiIiIiIiLkljRQSBVIVWfppT+1qIaF1LLECducnBwcPLgfEyZMRPPmLXUemzZtMo4cOYjevfvnW69Hj7ewaNECTJ48tdC+FyyYg5SUZCxevPyV5RPyGjv2I7z33rtwd6/x2rZ16vgUeVauVCpBVtY/z7m7ew3cuXMrX7u7d2/Dw+P1284rKysLSmUU6tTxKdZ6xsakLRERERERERGZJHv7qpDLWdmRDMvbrjbORp/WS18ZORlo6tzs9Q0LcebMKaSkJKNnz975ZpgGB7fHvn2/FZi07dWrN9q161jgrFQA2Lo1BH/8cQQLF34HtToH8fFxOo9bW1vDzMw833q1anmjU6eu2Lnzp9fG3rx5Sxw4EJpvuSiK2u1lZWXhwoW/cP78OYwYMUrb5p133sX48R9g48a1CA5uD6kU2L9/P65fv4pJk6a8dtt53bhxDXK5Ar6+jYq1nrGV66Tt1q1bsW3bNiiVSgBA7dq1MW7cOAQHBwPI/cMvWLAA+/fvh0qlQlBQEGbMmAFHR0djhk1EREREREREryGVStG8eQsoFFKoVGpjh0OVSAPHhjipPFGqkgZAbnIyR1SjnkODEvexb98eNGvWvMDka9u27bF1awju378HKysrncdkMhns7OwK7Xf37p3IycnBpEkfFfj455/PQPfuBZdAGDVqLI4dO/za2Dt37oaVK5chIuIRPDw8tcvT0tLw9ttdAQAKhQLOztUxcuQYDBnyL22bhg398O23S7F+/f9h+/YtkEgkqFmzFpYs+QE1a3q/dtt5HTlyCJ07d4W5ef4ktCkTRFEUjR1ESR07dgxSqRQ1atSAKIr49ddfsXbtWuzevRu1a9fGjBkzcPz4ccyfPx82NjaYPXs2BEHA9u3bC+0zNjbFgHsADA0daNDtGZMgESBqyu3hVmybe+wwdggVHgdvpE88nkifeDyVHScnG2OHYPIMPZ4ta3w9EY8B4jFAhj4GHiaFY8zv70MhlcPOrOR1UBMzE6DSZGN153Xwsq2pxwjLjxUrliAtLRWfffZFqfop6TGQmJiId9/thzVrQuDi4lqqGPSpKGPacn2OQfv27REcHAxPT094eXnh008/haWlJS5fvoyUlBT88ssvmDp1KgICAuDr64t58+bh0qVLuHz5srFDJyIiIiIiIiIiE+RlWxOBrq0RnxEPtViyZLFaVCM+Mx6Brq0rbcIWAIYPfx/Vq78BjUZjlO0/fRqNSZOmmFTCtqjKddI2L7VajdDQUKSnp6NJkya4fv06srOz0apVK22bWrVqwcXFhUlbIiIiIiIiIhOnVqtx7NgRHD16GGo1Z9qSYY31Gw8Xa1dEpUSiuCepi6KIqJRIuFi7Yqzf+DKKsHywsbHB8OHvQyIxTgqybt366NChs1G2XVrluqYtANy5cweDBg1CVlYWLC0tsWLFCnh7e+PWrVuQy+WoUqWKTnsHBwfExsYW2p9cLkUpypUUmyAx4MaMTCII0FSYnwleT6GQGjuECk8m43NM+sPjifSJxxMREZF+ZGdnQxQr0RdJMhnOVtUx2X8qZp39ChEpj+Fm4w6p8PoxnlpUIyolEtYKG0z2nwpnq+oGiJYqonKftPXy8sKvv/6KlJQUHDp0CFOmTMHmzZtL3F92tmF/vatMNV41ksq1v6y5ZBh8nkmfeDyRPvF4IiIiIirfAlwCMb3lTCwKW4hHSQ/hYO4AWzO7Ai9OJooikrISEZ8ZDxdrV0z2n4oAl0AjRE0VRblP2ioUCtSoUQMA4Ovri2vXriEkJATdunVDdnY2kpOTdWbbxsfHw8nJyVjhEhERERERERFROdHKNQi17Lyx6soKnFaeRHhyOGSCFBYyC0gFKdSiGhk5GcgR1bCR26CrVw+M9RvPGbZUauU+afsyjUYDlUoFX19fyOVynD17Fl26dAEAhIeHIzo6Go0bNzZukEREREREREREVC44W1XHjFaz8TApHCei/sTNuOu4l3gXKrUKFlJLNHVuhnoODdDGrW2lvugY6Ve5TtouWrQIbdq0wRtvvIG0tDTs27cP58+fx9q1a2FjY4N+/fphwYIFsLW1hbW1NebMmYMmTZowaUtERERERERERMXiZVtTJykrimKBpRKI9KFcJ23j4+MxZcoUPHv2DDY2NvDx8cHatWsRGJhbM+Tzzz+HRCLBxx9/DJVKhaCgIMyYMcPIURMRERERERERUXnHhC2VpXKdtJ03b94rHzczM8OMGTOYqCUiIiIiIiIqh2xtbSGTSYwdBlUSnDlLpqRcJ22JiIiIiIiIqGKSSqVo2bIVFAopVCq1scOhCuhFjdobcddwP/EeVGoVFFIFvO1qo4FjQ9aoJaNi0paIiIiIiIiIiCqNmLSnWHVlBU4rTyIlOwUyQQoLmQWkghSp6iycjT6Nk8oT2HIzBIGurTHWbzycraobO2yqZJi0JSIiIiIiIiKiSuGM8hQWhS1EdKoSDhYOqGlRs8CSCKIoIkmViIMPQ3E19jIm+09FgEugESKmyoqFYYiIiIiIiIjI5KjVahw//gf+/PMY1GqWR6DSO6M8hdnnZuBZegw8bb1gZ2ZfaA1bQRBgZ2YPT1svPEuPwayzX+GM8pSBI6bKjElbIiIiIiIiIjJJmZmZyMjINHYYVAE8TXuCRWELkapKgYdNDUgFaZHWkwpSeNjUQKoqBYvCFiIm7WkZR0qUi0lbIiIiIiIiIiKq0FZfWYnoVCXcbNwLnV1bGEEQ4GbjjuhUJVZdWVFGERLpYtKWiIiIiIiIiIgqrPCkBzitPAkHC4ciz7B9mVSQwsHcAaeVJ/EwKVzPERLlx6QtERERERERERFVWCejjiM1OwW2CrtS9WNrZoeU7BSciPpTL3ERvQqTtkREREREREREVGHdiLsGqSAtdlmElwmCAJkgxa34G3qKjKhwTNoSEREREREREVGFdT/xHixkFnrpy0JmgbsJd/TSF9GryIwdABERERERERFRQaytrSGTcb4ZlZwoilCpVSWuZfsyqSCFSq2CKIqlnrlL9CpM2hIRERERERGRyZFKpQgMbA2FQgqVSm3scKicEgQBCqkCqeosvfSnFtWwkFoyYUtljj9XERERERERERFRheVtVxsZORl66SsjJwN17H300hfRqzBpS0REREREREREFVYDx4bIEdUQRbFU/YiiiBxRjXoODfQUGVHhmLQlIiIiIiIiIpOjVqtx+vRJnDx5Amo1yyNQybVxawsbuQ2SVIml6icpKxE2chu0cWurl7iIXoVJWyIiIiIiIiIySampqUhNTTV2GFTOednWRKBra8RnxEMtluwHALWoRnxmPAJdW8PLtqaeIyTKj0lbIiIiIiIiIiKq0Mb6jYeLtSuiUiKLXSZBFEVEpUTCxdoVY/3Gl1GERLqYtCUiIiIiIiIiogrN2ao6JvtPhbXCBhEpj4s841YtqhGR8hjWChtM9p8KZ6vqZRwpUS4mbYmIiIiIiIiIqMILcAnE9JYzUc3SGY+SHiIxM6HQWbeiKCIxMwGPkh6imqUzvgqYhQCXQANHTJWZzNgBEBERERERERERGUIr1yDUsvPGqisrcFp5EuHJ4ZAJUljILCAVpFCLamTkZCBHVMNGboOuXj0w1m88Z9iSwTFpS0RERERkYFu2bMHatWsRGxuLunXrYvr06WjUqFGBbXft2oVp06bpLFMoFLh27ZohQiUiIqpwnK2qY0ar2XiYFI4TUX/iZtx13Eu8C5VaBQupJZo6N0M9hwZo49aWFx0jo2HSloiIiIjIgPbv34/58+dj5syZ8PPzw8aNGzFy5EgcPHgQDg4OBa5jbW2NgwcPau8LgmCocImIjMrc3BxyOSs7Utnwsq2pk5QVRZGfsWQy+M5HRERERGRA69evx8CBA9GvXz94e3tj5syZMDc3xy+//FLoOoIgwMnJSfvP0dHRgBETERmHVCpFcHA7tG3bHlKp1NjhUCXAhC2ZEiZtiYiIiIgMRKVS4caNG2jVqpV2mUQiQatWrXDp0qVC10tPT0e7du0QHByMDz/8EPfu3TNEuERERERkJCyPQERERERkIAkJCVCr1fnKIDg4OCA8PLzAdby8vDBv3jz4+PggJSUF69atw6BBgxAaGorq1fNfFEUul6IiTRSSyTi7rrLjMUA8BojHAFXGY4BJWyIiIiIiE9akSRM0adJE53737t2xfft2TJw4MV/77Gy1AaMzDJWq4u0TFQ+PgcpJrVbjwoW/IJNJ0KSJP0skVHJ8H6DKdgwwaUtEREREZCD29vaQSqWIj4/XWR4fH1/kOrVyuRz16tVDREREWYRIRGRSkpKSIJOxsiMRVT585yMiIiIiMhCFQoEGDRrg7Nmz2mUajQZnz57VmU37Kmq1Gnfv3oWTk1NZhUlERERERsaZtkREREREBvTee+9hypQp8PX1RaNGjbBx40ZkZGSgb9++AIDPPvsMzs7OmDRpEgBg+fLlaNy4MWrUqIHk5GSsXbsW0dHRGDBggDF3g4iIiIjKEJO2REREREQG1L17dzx//hxLly5FbGws6tWrhzVr1mjLIzx58gQSyT8nxCUnJ2P69OmIjY2Fra0tGjRogO3bt8Pb29tYu0BEREREZUwQRVE0dhCmJDY2xaDbGxo60KDbMyZBIkDUVJ7DbXOPHcYOocJTKKSVrhA5lR0eT6RPPJ7KjpOTjbFDMHmGHs+WNb6eiMdA5aVWq3HkyO+QySRo27YjL0RWifF9gCraMVCUMS1r2hIRERERERERERGZEJZHICIiIiIiIiKTJJfLIZdzvhkRVT5M2hIRERERERGRyZFKpWjfvmOFOy2aiKgo+HMVERERERERERERkQlh0paIiIiIiIiIiIjIhLA8AhERERERERGZHLVajb//DoNcLkGjRk0hlUqNHRIRkcEwaUtEREREREREJikh4TlkMp4kTESVD9/5iIiIiIiIiIiIiEwIk7ZEREREREREREREJoRJWyIiIiIiIiIiIiITwqQtERERERERERERkQlh0paIiIiIiIiIiEyWKIrGDoHI4GTGDqA0Vq9ejd9//x3h4eEwNzdHkyZNMHnyZNSsWVPbZtiwYTh//rzOeu+88w5mzZpl6HCJiIiIiIiIqBikUgmkUs43q2weJoXjRNSfuBF3DfcT7yFHzIZMkMPbrjYaODZEG7e28LKt+fqOiMqxcp20PX/+PIYMGYKGDRtCrVZj8eLFGDlyJEJDQ2FpaaltN3DgQHz88cfa+xYWFsYIl4iIiIiIiIiKSCqVomPHLlAopFCp1MYOhwwgJu0pVl1ZgdPKk0jJToFMkMJCZgGpVIZMdSbORp/GSeUJbLkZgkDX1hjrNx7OVtWNHTZRmSjXSdu1a9fq3F+wYAECAgJw48YN+Pv7a5ebm5vDycnJ0OEREREREREREVERnFGewqKwhYhOVcLBwgE1LWpCEAQAgCARIGpySySIoogkVSIOPgzF1djLmOw/FQEugcYMnahMVKhzDFJSUgAAtra2Osv37t2LFi1aoGfPnli0aBEyMjKMER4REREREREREb3kjPIUZp+bgWfpMfC09YKdmb02YfsyQRBgZ2YPT1svPEuPwayzX+GM8pSBIyYqe+V6pm1eGo0G8+bNQ9OmTVGnTh3t8p49e8LFxQXVqlXDnTt38O233+Lhw4dYvny5EaMlIiIiIiIiolfRaDS4dOlvyOVS+Po2hkRSoead0f88TXuCRWELkapKgYdNjUKTtS+TClJ42NRARMpjLApbiFp23iyVQBVKhUnazpw5E/fu3cPWrVt1lr/zzjva2z4+PnBycsKIESMQEREBDw+PfP3I5VIU8f1BLwSJATdmZBJBgKYSfcYqFFJjh1DhyWR8jkl/eDyRPvF4IiIiKj1RFBEXFweZTAJRFI0dDpWR1VdWIjpVCU9bryInbF8QBAFuNu54lPQQq66swIxWs8soSiLDqxBJ21mzZuHPP//E5s2bUb36q39V8fPzAwA8fvy4wKRtdrZhi5u/qMlSGWgklWt/WSjfMPg8kz7xeCJ94vFERERE9GrhSQ9wWnkSDhYOkAol+9FbKkjhYO6A08qTeJgUDi/bmnqOksg4yvW8R1EUMWvWLBw+fBgbN26Eu7v7a9e5desWAPDCZERERERERERERnQy6jhSs1Ngq7ArVT+2ZnZIyU7Biag/9RIXkSko1zNtZ86ciX379mHlypWwsrJCbGwsAMDGxgbm5uaIiIjA3r17ERwcDDs7O9y5cwfz58+Hv78/6tata+ToiYiIiIiIiIgqrxtx1yAVpMUui/AyQRAgE6S4FX9DT5ERGV+5Ttpu27YNADBs2DCd5fPnz0ffvn0hl8tx9uxZhISEID09HW+88QY6d+6McePGGSNcIiIiIiIiIiL6n/uJ92Ahs9BLXxYyC9xNuKOXvohMQblO2t658+oX4xtvvIHNmzcbKBoiIiIiIiIiIioKURShUqtKXMv2ZVJBCpVaBVEUSz1zl8gUlOuatkREREREREREVP4IggCFVAG1qJ+Lt6pFNRRSBRO2VGEYdaatSqWCQqEwZghEREREREREZIKkUim6dOkGhUIKlUo/iT0yLd52tXE2+rRe+srIyUBT52Z66YvIFBg0aXv8+HHs378fYWFhePr0KTQaDSwsLFC/fn0EBgaib9++cHZ2NmRIRERERERERERkBA0cG+Kk8kSpSxqIoogcUY16Dg30GB2RcRkkaXv48GF8++23SEtLQ5s2bfDBBx+gWrVqMDc3R2JiIu7du4czZ85g5cqV6NOnDyZOnIiqVasaIjQiIiIiIiIiIjKCNm5tseVmCJJUibAzsy9xP0lZibCR26CNW1v9BUdkZAZJ2q5ZswbTpk1DmzZtIJEUXkY3JiYGmzZtwm+//YYRI0YYIjQiIiIiqgTmz59f5LbTpk0rw0iIiKioNBoNrl69DLlcinr1Gr4yn0Dlk5dtTQS6tsbBh6GwUVQp0UXJ1KIa8Znx6OrVA162NcsgSiLjMEjS9qeffipSO2dnZ0yePLmMoyEiIiKiyubmzZtFaseLlxARmQ5RFBETEwOZTIK6dX2NHQ6VkbF+43E19jKiUiLhYVOjWJ/FoigiKiUSLtauGOs3vgyjJDI8o16IDADS09Oh0WhgbW1t7FCIiIiIqILatGmTsUMgIiKiAjhbVcdk/6mYdfYrRKQ8hpuNe5Fm3KpFNaJSImGtsMFk/6lwtqpugGiJDMdo5xbcv38fffv2RdOmTeHv749evXrh2rVrxgqHiIiIiIiIiIiMIMAlENNbzkQ1S2c8SnqIxMwEiKJYYFtRFJGYmYBHSQ9RzdIZXwXMQoBLoIEjJip7Rptp+9VXX2Ho0KHo1q0bsrOzsWHDBkydOhWhoaHGComIiIiIKolr167hwIEDePLkCbKzs3UeW758uZGiIiIiqrxauQahlp03Vl1ZgdPKkwhPDodMkMJCZgGpVAa1OgcZORnIEdWwkdugq1cPjPUbzxm2VGEZbKbthx9+iJiYGO3958+fo3379rCwsECVKlUQHByMuLg4Q4VDRERERJVUaGgoBg8ejPDwcBw+fBg5OTm4d+8ezp07BxsbG2OHR0REVGk5W1XHjFazsbrzOoz1G49WLkGwVthALpHBWmGDQNfWGOs3Hqs7r8OMVrOZsKUKzWAzbd966y0MHz4cQ4YMwbBhwzB06FD07NkT/v7+yMnJwblz5/Dee+8ZKhwiIiIiqqRWrVqFadOmYciQIWjSpAm++OILuLm54auvvoKTk5OxwyMiIqr0vGxrwsu2pva+XC5BdrbGiBERGZ7BZtp269YNO3fuxP379zFw4EA0bdoUa9euRdOmTfHmm29i7dq1GDdunKHCISIiIqJKKjIyEsHBwQAAhUKB9PR0CIKAESNGYMeOHUaOjoiIiF4mCIKxQyAyOIPWtLWxscGsWbMQFhaGKVOmIDAwEJ988gksLCwMGQYRERERVWJVqlRBWloaAKBatWq4d+8efHx8kJycjIyMDCNHR0REL0ilUnTs2BkKhRRqtbGjISIyLIPNtAWAxMREXL9+HT4+Pti1axesra3Ru3dvHD9+3JBhEBEREVEl5u/vjzNnzgAAunbtirlz5+LLL7/EpEmTEBAQYOToiIgoL6lUCqlUauwwiIgMzmAzbffu3Ysvv/wS1tbWyMrKwsKFCzFhwgR069YNX3/9NXbt2oXp06fD0dHRUCERERERUSU0ffp0ZGVlAci9WK5cLsfFixfRuXNnfPjhh0aOjoiIiIjIgEnbxYsXY968eejRoweuX7+Ozz//HB06dECtWrWwadMm7NixA++88w6OHj1qqJCIiIiIqBKys7PT3pZIJBg9erTxgiEiokJpNBrcuHEdcrkEderUh0Ri0JOFiYiMymBJ2/T0dHh5eQEAPDw8kJmZqfP4wIED0aFDB0OFQ0RERESVmEajwePHjxEfHw9RFHUe8/f3N1JURESUlyiKiI5WQiaToHbtesYOh4jIoAyWtO3duzdGjx6NFi1a4Pr163jrrbfytXFwcDBUOERERERUSV2+fBmTJk1CdHR0voStIAi4deuWkSIjIiIiIsplsKTttGnT0KJFC4SHh6NPnz4ICgoy1KaJiIiIiLRmzJgBX19f/Pjjj3BycoIgCMYOiYiIiIhIh8GStgDQvn17tG/f3pCbJCIiIiLS8fjxYyxduhQ1atQwdihERERERAUySBXv0NDQIrd98uQJ/v777zKMhoiIiIgqs0aNGuHx48fGDoOIiIiIqFAGmWm7bds2LF++HH379kX79u1Rq1YtncdTUlJw8eJF/Pbbbzh9+jTmzp1riLCIiIiIqBIaNmwYFi5ciLi4ONSpUwcyme6QuG7dukaKjIiIiIgol0GStps3b8bRo0exefNmLF68GBYWFnB0dISZmRmSkpIQFxcHe3t79OnTB/v27YOjo6MhwiIiIiKiSuijjz4CAHz++efaZYIgQBRFXoiMiIiIiEyCwWradujQAR06dMDz589x8eJFKJVKZGVlwd7eHvXq1UP9+vUhkRikWgMRERERVWJHjx41dghERFQEUqkU7dp1gEIhBSA1djhERAZl0AuRAUDVqlXRsWNHQ2+WiIiIiAgA4OrqauwQiIioiBQKBRQKKVQqtbFDISIyKIMnbYmIiIiIjKmwmbaCIMDMzAweHh5wd3c3cFRERERERP9g0paIiIiIKpXx48dra9jmlbeu7ZtvvokVK1bA1tbWSFESEZFGo8Ht27cgl0tQq5YPSyoSUaXCdzwiIiIiqlTWr1+Phg0bYv369QgLC0NYWBjWr18PPz8/rF69Gps3b0ZiYiIWLlxo7FCJiCo1URQRGRmBiIiIfD+0ERFVdJxpS0RERESVyty5czFr1iw0bdpUuywgIAAKhQJfffUVQkND8fnnn+Pzzz83YpREREREVJkZbaatSqVCeHg4cnJyjBUCEREREVVCERERsLa2zrfc2toakZGRAIAaNWogISHB0KEREREREQEwwkzbjIwMzJ49G7/++isA4NChQ3B3d8fs2bPh7OyM0aNHGzokIiIiMoChoQONHYLBCBIBoqZynMa5uccOY4dQbA0aNMA333yDb775BlWrVgUAPH/+HP/973/RsGFDAMDjx49RvXp1Y4ZJRERERJWYwWfaLlq0CLdv30ZISAjMzMy0ywMCArB//35Dh0NERERElczcuXMRFRWFNm3aoFOnTujUqRPatGkDpVKJOXPmAADS09Px4YcfGjlSIiIiIqqsDD7T9ujRo/juu+/QuHFjneW1a9dGRESEocMhIiIiokqmZs2a2L9/P06dOoVHjx4BALy8vBAYGKi9MnnHjh2NGCERVWSiKEIQBGOHQUREJs7gSdvnz5/DwcEh3/KMjAx+cBERERGRQUgkErRp0wZt2rQxdihEVMElJSUiKioCcXGxSEx8DrVaDalUCju7qnB0dIKbmwdsbe2MHSYREZkYgydtfX198eeff2LYsGE6y3/++ed8s2+JiIiIiPQhJCQE77zzDszMzBASEvLKtsOHDzdQVERUkaWlpeLKlYtQKiORna2CIEggk8kgCALUajWio6OgVEbg5s1rcHV1h59fU1hZ5b9IYmUmkUjQunUwFAqp9kwIIqLKwuBJ208//RQffPAB7t+/D7VajZCQEDx48ACXLl3Cpk2bDB0OEREREVUCGzZsQK9evWBmZoYNGzYU2k4QBCZtiajUlMpIhIWdQ2pqCiwsLGFhYVfgmaWiKEKlysLDh/cRGxsDf/8AuLi4GSFi0yQIAiwtLaFQSKFSqY0dDhGRQRk8adusWTPs2bMHP/74I+rUqYPTp0+jfv362L59O3x8fAwdDhERERFVAseOHSvwNhGRvimVkTh37hRUqizY2tpBEAqfISoIAszMzKFQKJCSkoyzZ0+iZcsguLq6GzBiIiIyRQZP2gKAh4eH9sq8RERERETGlJOTg6ysLFhZWRk7FCIq59LSUhEWdg4qVRZsbGyLfN0WQZDAxsYWKSlJCAs7Bzs7e5ZKAKDRaHDv3l3I5RJ4enqzRAIRVSoGf8cbPnw4li9fnm95UlIST0UjIiIiojJz7Ngx7Nq1S2fZDz/8gCZNmsDf3x/vv/8+kpKSjBQdEVUEV65cRGpqKmxsqhT7QtuCIMDGpgpSU1Nw5crFMoqwfBFFEY8ePcTDhw8hiqKxwyEiMiiDJ23Pnz+PzZs3Y9y4cUhPT9cuz87OxoULFwwdDhERERFVEuvXr0dGRob2/sWLF7F06VKMGzcO33//PZ48eYKVK1caMUIiKs+SkhKgVEbCwsLilSURXkUQJDA3t4RSGYmkpET9BkhEROWKUc4t2LBhA+Li4vDOO+8gKirKGCEQERERUSVz//59NGnSRHv/0KFDaNWqFT788EN07twZU6dOxR9//GHECImoPIuKikR2tgoKhVmp+jEzM0N2tgpRURF6ioyIiMojoyRtnZycsHnzZtSpUwf9+/fHX3/9ZYwwiIiIiKgSSUtLg52dnfb+33//jYCAAO19b29vPHv2zAiREVFFEBcXC0GQFLsswssEQYAgCIiPj9VTZEREVB4ZPGn74gNMoVBg0aJFGD58OEaNGoWtW7caOhQiIiIiqkScnZ3x4MEDALkJ3Nu3b+vMvE1MTIS5ubmxwiOici4x8TlkMv1c61smkyMh4ble+iIiovJJP58oxfBy8fBx48ahVq1amDp1arH7Wr16NX7//XeEh4fD3NwcTZo0weTJk1GzZk1tm6ysLCxYsAD79++HSqVCUFAQZsyYAUdHx1LvCxERERGVH127dsW8efMwZswYnDhxAk5OTmjcuLH28evXr8PLy8t4ARJRuSWKItRqdaln2b4gCALUajVEUdRbn0REVL4YPGl79OhR2Nvb6yzr0qULvLy8cOPGjWL1df78eQwZMgQNGzaEWq3G4sWLMXLkSISGhsLS0hIAMG/ePBw/fhzff/89bGxsMHv2bEyYMAHbt2/X2z4RERERkekbP348YmJiMHfuXDg6OuK///0vpFKp9vF9+/ahXbt2RoyQiMorQRAglUqhVqv10p8oipBKpUzYEhFVYgZP2rq6uha4vE6dOqhTp06x+lq7dq3O/QULFiAgIAA3btyAv78/UlJS8Msvv+Dbb7/V1iubN28eunfvjsuXL+vMrCAiIiKiis3c3BzffPNNoY9v2rTJgNEQUUVjZ1cV0dH6udB2Tk42nJ2r66Wv8kwikSAwMAhyuRQSiVEuyUNEZDQGSdpOmDABCxYsgLW1NSZMmPDKtsuXLy/xdlJSUgAAtra2AHJPccvOzkarVq20bWrVqgUXFxcmbYmIiIiIiEhvHB2doFRGlLqkgSiKEEURDg5OeoyufBIEAdbWNlAopFCp9DOLmYiovDBI0tbGxqbA2/qk0Wgwb948NG3aVDtjNy4uDnK5HFWqVNFp6+DggNhYXomTiIiIiIiI9MPNzQM3b16DSpUFM7OSX9QwKysLcrkCbm4eeoyOiIjKG4MkbefPn1/gbX2aOXMm7t27h61bt5aqH7lcCkOWDRIkladGkUQQoKlEZ7QoFNLXN6JSkcn4HJP+8Hgqe/zMq5j4eUdElMvW1g6uru54+PA+FAoFBKH4HwSiqEFmZjq8vLxha2un/yDLGY1Gg/DwB5DLJXB392KJBCKqVAxe0/Zl58+fR0ZGBho3bqwta1Bcs2bNwp9//onNmzejevV/6v44OjoiOzsbycnJOrNt4+Pj4eRU8Kkm2dmGPeVC1IgG3Z4xaSSVa395+o5h8HkmfeLxVLYq02dAZfrM4+uGiOgffn5NERsbg5SUZNjY2BarTIIoikhJSYa1tQ38/JqWYZTlhyiKePDgPmQyCdzcPI0dDhGRQRnsZ6off/wR33//vfa+KIoYOXIkhg8fjjFjxqB79+64d+9esfoURRGzZs3C4cOHsXHjRri7u+s87uvrC7lcjrNnz2qXhYeHIzo6mvVsiYiIiIiISK+srKzh7x8AhcIMKSlJEEVNkdYTRQ1SUpKgUJjB3z8AVlbWZRwpERGZOoPNtD1w4AA++OAD7f2DBw8iLCwMW7ZsQa1atTBlyhQsX74cS5YsKXKfM2fOxL59+7By5UpYWVlp69Ta2NjA3NwcNjY26NevHxYsWABbW1tYW1tjzpw5aNKkCZO2RERERJVISEhIkdsOHz68DCMhoorOxcUNLVsGISzsHJKSEmFubgkzM7MCZ92KooisrCxkZqbD2toG/v4BcHFxM0LURERkagyWtI2KioKPj4/2/okTJ9ClSxe8+eabAIAPP/wQn3zySbH63LZtGwBg2LBhOsvnz5+Pvn37AgA+//xzSCQSfPzxx1CpVAgKCsKMGTNKsytEREREVM5s2LChSO0EQWDSlohKzdXVHXZ29rhy5SKUykgkJydCEATIZHIIggBRFJGTkw1RFCGXK+Dl5Q0/v6acYUtERFoGS9rm5ORAoVBo71+6dAn/+te/tPerVauGhISEYvV5586d17YxMzPDjBkzmKglIiIiqsSOHTtm7BB0bNmyBWvXrkVsbCzq1q2L6dOno1GjRoW2P3DgAJYsWQKlUglPT09MnjwZwcHBBoyYiIrLysoarVq1QVJSIqKiIhAXF4vExOdQq9WQSqVwdq4OBwcnuLl58KJjRESUj8GSth4eHrhw4QLc3d0RHR2NR48ewd/fX/v406dPYWdnZ6hwiIiIiIiMYv/+/Zg/fz5mzpwJPz8/bNy4ESNHjsTBgwfh4OCQr/3FixcxadIk/Pvf/0a7du2wd+9ejB8/Hrt27UKdOnWMsAdEVBy2tnY6SVlRFIt1gTIiIqqcDJa0HTJkCGbPno2wsDBcuXIFjRs3hre3t/bxc+fOoX79+oYKh4iIiIgqsadPn+Lo0aN48uQJsrOzdR6bNm1amW57/fr1GDhwIPr16wcg9zoNf/75J3755ReMHj06X/uQkBC0bt0ao0aNAgBMnDgRZ86cwebNmzFr1qx87dVqdaHbFgQBEomkSG0BQCqVGr0tUPYxaDQaiKJo0m0lEok20VeR24qiCI1G9+JdavU/f8+8x3BBbfMqz20B/b2Wy6otYJj3CI1GDY2m8HUMEwPfI4zd9gVTeH2aQlug8r1H5P0sMIXxSVm9lvMyWNJ24MCBkEgk+OOPP9CsWTNMmDBB5/Fnz55pB65ERERERGXl7Nmz+PDDD+Hu7o7w8HDUrl0bSqUSoiiW+SQClUqFGzduYMyYMdplEokErVq1wqVLlwpc5/LlyxgxYoTOsqCgIBw5cqTA9keO/F7o9h0dHfHmm/+c7fbHH0egVhf8BdHeviqaN2+hvX/8+B/5Etwv2NraomXLVtr7p06dQGZmZoFtra2tERjYWnv/3LkzSE1NLbCtubk5OnXqqL1/4cJfSEpKKrCtXC5H+/b/tP377zAkJDwvsK1UKkHHjl209y9d+htxcXEFtgWALl26aW9fvXoZMTExhbbt2LGz9svZjRvXER2tLLRtu3YdtCXkbt++hcjIiELbtm4dDEtLSwDAvXt38ejRw0LbBgYGwdraBgAQHv4ADx7cL7Rty5YB2lmgjx8/wt27hZeg8/dvjqpVc2eDR0VF4tatm4W2bdLkTVSrVg0A8ORJNK5fv1ZoWz+/xqhe/Q0AQEzMU1y5clnncZlMgpyc3OPU17chXF1zL9QVGxuLS5f+LrTfevXqw8OjBgAgIeE5Llw4X2jbOnV84OVVEwCQnJyEc+fOFtq2Vi1veHvXBgCkpaXi9OlThbb19PSCj09dAEBGRgZOnjxeaFt3dw/Ur98AQO57xR9/HC20rYuLKxo2zC2polarX/m6d3Z2RuPGTbX3y9N7hEQigVQqRUZGBo4dO5JvhrK5uTmCg9tp7/M9ouK+R3h45L7uC3qPyIvvEbkq4nvEi8+C4o4jTPU9YujQgYW2f8FgSVsA6N+/P/r371/gY19//bUhQyEiIiKiSmrRokV4//338fHHH6NJkyZYtmwZqlatismTJ6N169av76AUEhISoFar85VBcHBwQHh4eIHrxMXFwdHRMV/7wr4cSKUSFHbmtVwuhULxz2wPmexVbSU6beVyCURRUmBbmSx/25ycorWVySSQyQpuK5dLIJMVve3LMRTWVip9ua200LYAit32RULmVTG8aPuib322zft3Lk5bheL1+/ZPv69rKylyW91487eVSiUFtlUojLNveY+14rTNySl6W6DobdVqFPl5AIrf1tjvEba2VaBQyApMDL0cA98jKu57xIvPguK8n/A9omK9R7z4LCjuOKK8vUfkJYhFnZNbScTGphh0e0NDX59ZrygEiQBRU3kOt809dhg7hApPoZBCpXrdKZVERcPjqezxM69iMvTnnZOTTan7aNKkCfbs2QMPDw/4+/tj69atqF27Nm7fvo1x48aV6UXLYmJi0KZNG2zfvh1NmjTRLv/mm29w4cIF/Pzzz/nW8fX1xYIFC9CzZ0/tsi1btmDFihU4c+ZMvvZPnyYWun1TPPX5dW0tLBTa9+fycFojT30uXduCTg/O+xltaqco89Rnw7xHvGqcVt5OfeZ7RMnampnJoFKpTeL1aQptgcr3HpH3fcAUxielfS1Xr273yv4BA8+0JSIiIiIyNktLS+3peU5OToiIiEDt2rmnMSYkJJTptu3t7SGVShEfH6+zPD4+Pt9s2hccHR3zzap9Vfu8Xwxeh21z5f0CyrbGbSsIQr6/nVQqRUF/zoLaFqdfU24LmMZrw9htNRoNIiIeQ6GQ4o033F97LPE9ouK3NYXXpym0BYz/+jR028I+C0wh3jJ7bRS5JRERERFRBeDn54e//86tcRccHIyFCxfihx9+wOeffw4/P78y3bZCoUCDBg1w9uw/tfA0Gg3Onj2rM/M2r8aNG+PcuXM6y86cOYPGjRuXZahEREYniiLu3r2D27dvF/nCPUREFQVn2hIRERFRpTJt2jSkpaUBAD766COkpaVh//798PT0xNSpU8t8+++99x6mTJkCX19fNGrUCBs3bkRGRgb69u0LAPjss8/g7OyMSZMmAQCGDx+OYcOGYd26dQgODsb+/ftx/fp1zJo1q8xjJSIi/RNFMd9F1YiIXsakLRERERFVKu7u7trblpaWBk9+du/eHc+fP8fSpUsRGxuLevXqYc2aNdpyB0+ePNE5da5p06b49ttv8f3332Px4sXw9PTEihUrUKdOHYPGTUREJZOUlIioqAjExcUiMfE51Go1pFIp7OyqwtHRCW5uHrC1tTN2mERkYgyetE1PT8ePP/6Ic+fOIT4+Pl+R5aNHjxo6JCIiIiKqRK5evQpRFPOVQrhy5QokEgkaNmxY5jEMHToUQ4cOLfCxTZs25VvWrVs3dOvWrazDIiIiPUpLS8WVKxehVEYiO1sFQZBAJpNBEASo1WpER0dBqYzAzZvX4OrqDj+/prCysjZ22ERkIgyetP3yyy9x/vx5vP3223BycuIpAURERERkULNmzcKoUaPyJW1jYmLwf//3f/j555+NFBkREVUUSmUkwsLOITU1BRYWlrCwsCsw/yGKIlSqLDx8eB+xsTHw9w+Ai4ubESImIlNj8KTtiRMnsHr1arz55puG3jQRERERER48eIAGDRrkW16vXj3cv3/fCBEREVFFolRG4ty5U1CpsmBrawdBKPwa8IIgwMzMHAqFAikpyTh79iRatgyCq6t7oesQUeVQ+DtHGalSpQrs7OwMvVkiIiIiIgCAQqFAXFxcvuWxsbGQyXjJByIiKrm0tFSEhZ2DSpUFGxvbVyZs8xIECWxsbKFSZSEs7BzS0lLLOFIiMnUGT9p+8sknWLJkCTIyMgy9aSIiIiIiBAYGYvHixUhJSdEuS05OxnfffYdWrVoZMTIiIspLIpHA3785WrRooXOBRlN25cpFpKamwsamSrHLQQqCABubKkhNTcGVKxfLKEIiKi8MPpVg/fr1iIiIQKtWreDm5pZvNsPu3bsNHRIRERERVSJTpkzBkCFD0K5dO9SrVw8AcPv2bTg4OOCbb74xcnRERPSCIAioWtUBCoUUKpXa2OG8VlJSApTKSFhYWBR5hu3LBEECc3NLKJWRSEpKhK2tnX6DJKJyw+BJ244dOxp6k0REREREWs7Ozvjtt9+wd+9e3L59G+bm5ujXrx969OgBuVxu7PCIiKicioqKRHa2ChYWdqXqx8zMDMnJiYiKimDSlqgSM3jSdsKECYbeJBERERGRDktLS7zzzjvGDoOIiF5Bo9EgKioScrkUzs4uJl8iIS4uFoIgKXZZhJcJggBBEBAfH6unyIioPDLalRauX7+OBw8eAABq166N+vXrGysUIiIiIqrgjh49ijZt2kAul+Po0aOvbNuhQwcDRUVERK8iiiJu3boJmUyCatXeMHY4r5WY+FxvF7SUyeRISHiul76IqHwyeNI2Pj4en376Kc6fP48qVaoAyL3wQ4sWLfDdd9+hatWqhg6JiIiIiCq48ePH4/Tp03BwcMD48eMLbScIAm7dumXAyIiIqCIQRRFqtbrUs2xfEAQBarUaoijqrU8iKl8MnrSdPXs20tLSEBoailq1agEA7t+/jylTpmDOnDlYvHixoUOi/2/vzuOiqvv+j79nJVcURFzAvUZSRFwyQcOI1EvLNNL0ssy0xbLySi3LTG27ca3cLu6uTIuyWw2Flltb9GrRwtwtu8muygUuy5BUVFBwZn5/+GuuJlDR4MzAvJ6PxzweM9/zPef7OcOZcw6f8z3fAwAAUM19++23Zb4HAKAimEwmWSwWOZ0V88A0t9sti8VCwhYIYIYPCLNhwwZNmzbNk7CVpDZt2mjatGn67LPPjA4HAAAAAADgT6tXL0RnzpypkGWdOVOi+vW5ExkIZIb3tHW5XGU+lddqtcrlchkdDgAAAAJQVlaWsrKylJ+fX+ocNCUlxUdRAQCqsgYNwvTvfx/400MauN1uud1uhYaGVWB0AKoaw3vaXn311Xruued06NAhT9mhQ4eUkpKi7t27Gx0OAAAAAszChQs1atQoZWVl6ciRIyooKPB6AQBwKSIimslms6u4+PSfWs7p06dls9kVEdGsgiIDUBUZ3tN26tSpuu+++3TdddepUaNGkqSff/5Zl19+uWbPnm10OAAAAAgwy5cvV0pKigYOHOjrUAAA1UhwcD01bRqpvXu/l91ul8l08f3k3G6XTp0qVMuWbRQcXK/igwRQZRietG3cuLEyMjL0xRdf6Mcff5QktW7dWnFxcUaHAgAAgABUUlKiTp06+ToMAMAFmM1mxcZ2lt1ultls+I3ClyQmppPy8g7p+PEC1akTfFHDJLjdbh0/XqDatesoJobjFBDoDE/aSmefqhgfH6/4+HhfNA8AAIAAdsstt+jdd9/V2LFjfR0KAOA8TCaTGjZsKLvdouJip6/DKZdatWqra9fuysraoOPHj6lOnbrl6nHrdrt0/HiB7PYgde3aXbVq1TYgWgD+zJCkbVpamm699VYFBQUpLS3tvHVHjBhhREgAAAAIUKdPn9bKlSuVlZUlh8Mhq9X7lPjxxx/3UWQAgOqgSZMIXX11D23duknHjh3VZZfVVFBQUJm9bt1ut06fPq1TpwpVu3Ydde3aXU2aRPggagD+xpCk7auvvqobb7xRQUFBevXVV89Zz2QykbQFAABApdqzZ4/atm0rSfruu++8pv2Zp30DACqWy+XSTz8dlM1mUYMG4VVmiARJato0UvXq1deuXdv173/nqKDgqEwmk6xWm0wmk9xut86cKZHb7ZbNZlfLlm0UE9OJHrYAPAxJ2v7zn/8s8z0AAABgtNdff93XIQAAysHtdmv37q9ltZrVq1eSr8O5aLVq1VZc3DU6duyocnMP6PDhPB09+qucTqcsFovCwxspNDRMERHNeOgYgFIMH9N24cKFGj16tGrUqOFVfurUKS1evFgPPPCA0SEBAAAAAABUiuDgel5JWbfbzZ0dAC7I8KTtokWLNGzYsFJJ26KiIi1atIikLQAAACpVYWGh/vGPf2jTpk3Kz8+Xy+Xymr5+/XofRQYACAQkbAGUh+FJ23NdUfr2228VHBxsdDgAAAAIMFOmTNHmzZt10003KSwsjH+eAQAA4HcMS9p27dpVJpNJJpNJffr08To5djqdKiws1NChQ40KBwAAAAHqs88+00svvaTOnTv7OhQAAACgTIYlbSdPniy3263JkyfrwQcfVJ06dTzTbDabmjZtqtjYWKPCAQAAQICqW7eu6tWr5+swAAAAgHMyLGk7aNAgSVJERIRiY2Nls9mMahoAAADwGDdunObNm6eZM2eWes4CAAAA4A8MSdqeOHFCtWvXliRdeeWVOn36tE6fPl1m3d/qAQAAABVl4MCBXsNz7d+/X3FxcYqIiJDV6n1KnJGRYXR4AIAymM1mxcR0lM1mkdls9nU4AGAoQ5K2Xbt21caNGxUaGqouXbqU+bCH3x5Qlp2dbURIAAAACCBJSUm+DgEAcJFMJpMaNWosu92i4mKnr8MBAEMZkrR97bXXFBwcLElKS0szokkAAADA44EHHvB1CAAAAEC5GZK0veqqq8p8DwAAABjtq6++ktvtVkxMjFf5rl27ZDabFR0d7aPIAAC/53a7dejQz7LZLAoJCSvzrl0AqK4MHxTms88+09atWz2fly1bpptuukkTJkzQsWPHjA4HAAAAAebpp5/WTz/9VKr80KFDevrpp30QEQCgLC6XS7t27dTOnTvkcrl8HQ4AGMrwpO3s2bN18uRJSdKePXuUkpKihIQE5ebmasaMGUaHAwAAgADzww8/qF27dqXKo6Ki9P333/sgIgAAAMCbIcMj/F5ubq5at24tSfrwww+VmJio8ePH65tvvtE999xjdDgAAAAIMHa7XYcPH1ZkZKRXeV5enqxWw0+PAQAAgFIM72lrs9l06tQpSdIXX3yh+Ph4SVJwcLBOnDhhdDgAAAAIMPHx8Xr++ed1/PhxT1lBQYFeeOEFxcXF+TAyAAAA4CzDuxJ06tRJKSkp6tSpk77++mu9+OKLkqR9+/apUaNGRocDAACAADNp0iQN9n3flwAAM9lJREFUHz5c1157raKioiRJ3377rUJDQzVr1iwfRwcAAAD4oKft1KlTZbVa9cEHH2jatGkKDw+XdPYBZT179ryoZW3ZskVjxoxRjx495HA4tG7dOq/pjz32mBwOh9dr9OjRFbYuAAAAqHrCw8P1zjvv6JFHHlGbNm3Uvn17PfHEE3r33XfVuHFjX4cHAAAAGN/TtkmTJnrppZdKlU+ePPmil1VYWCiHw6Hk5GQ98MADZdbp2bOnUlJSPJ/tdvtFtwMAAIDqpWbNmrr11lt9HQYAAABQJp88acHpdGrdunX64YcfJEmXX365EhMTZbFYLmo5CQkJSkhIOG8du92usLCwS44VAAAA1U9mZqZWrFihnJwcrVixQk2bNtWrr76qiIgIJSUl+To8AIAkk8mk9u2jZbNZZDKZfB0OABjK8OER9u/fr379+mnSpEn66KOP9NFHH+mRRx5R//79deDAgQpvb/Pmzerevbv69OmjadOm6ciRIxXeBgAAAKqON998UzNmzNA111yjgoICuVwuSVLdunX12muv+Tg6AMBvzGazmjaNUEREhMxmw9MXAOBThve0ffbZZxUZGakVK1aoXr16kqQjR47okUce0bPPPqt//OMfFdZWz549df311ysiIkI5OTl6/vnndffdd2vFihXn7NV79gpehYVwQSZz4FwtNJtMcgXQcdZuv7ie47h4VivfMSoO21Pl45hXPVXF490bb7yhZ599VklJSV7nnu3bt9fMmTN9GBkAAABwluFJ2y1btnglbCWpfv36mjhxooYNG1ahbfXv39/z/rcHkSUlJXl635alpMRZoTFciNvlNrQ9X3KZA2t9i4uN3ZYCFd8zKhLbU+UKpGNAIB3zquLvJjc3V1FRUaXK7Xa7ioqKfBARAKAsbrdbeXl5stvNCg4OZYgEAAHF8D4gdrtdJ0+eLFV+8uRJ2Wy2Sm07MjJS9evX1/79+yu1HQAAAPiviIgIZWdnlyrfsGGDWrdu7YOIAABlcblc2rFjm7Zt2+YZygYAAoXhSdtevXpp6tSp2rVrl9xut9xut3bu3Knp06crMTGxUtv++eefdfToUR5MBgAAEIAWLlyooqIi3XnnnXr66ae1Zs0aSdJXX32l1NRUPf/887rrrrt8HCUAAADgg+ERpkyZokmTJunWW2+V1Xq2eafTqcTERD3xxBMXtayTJ096PbwsNzdX2dnZCg4OVnBwsBYuXKg+ffqoQYMGysnJ0ezZs9W8eXP17NmzQtcJAAAA/m/RokUaNmyYBg8erKCgIL344osqKirShAkT1LBhQ02ePNlreC0AAADAVwxP2tatW1epqanav3+/fvjhB0lS69at1bx584te1u7duzVixAjP55SUFEnSoEGDNH36dH333XfKzMzU8ePH1bBhQ8XHx2vcuHGy2+0VszIAAACoMtzu/4wzPGDAAA0YMEBFRUUqLCxUaGioDyMDAAAAvBmWtHW5XFq8eLH++c9/qqSkRN27d9cDDzygyy677JKX2a1bN+3Zs+ec01955ZVLXjYAAACqnz8+xKZGjRqqUaOGj6IBAAAAymZY0jY1NVULFy5UXFycgoKClJaWpvz8fE/vWAAAAKCy9enT54JPH9+8ebNB0QAAAABlMyxp+/bbb2vatGkaOnSoJOmLL77QPffco+eee05ms+HPQwMAAEAAevDBB1WnTh1fhwEAAACcl2FJ24MHDyohIcHzOS4uTiaTSb/88osaNWpkVBgAAAAIYP3792f8WgCoIkwmk6KirpTNZrngXRIAUN0YlrR1Op0KCgrybtxqVUlJiVEhAAAAIIDxDz8AVC1ms1nNmjWX3W5RcbHT1+EAgKEMS9q63W499thjstvtnrLi4mJNnz7d6+EPCxcuNCokAAAABBC32+3rEAAAAIByMSxpO2jQoFJlAwYMMKp5AAAABLhvv/3W1yEAAC6C2+3WkSO/ym63qFatYO6YABBQDEvapqSkGNUUAAAAAACo4lwul7Zs2Syr1axevZJksVh8HRIAGMbs6wAAAAAAAAAAAP9B0hYAAAAAAAAA/AhJWwAAAAAAAADwIyRtAQAAAAAAAMCPkLQFAAAAAAAAAD9C0hYAAAAAAAAA/IjV1wEAAAAAAAD8kclk0hVXOGS3W2QymXwdDgAYiqQtAAAAAADwO2azWS1btpLdblFxsdPX4QCAoRgeAQAAAAAAAAD8CD1tAQAAAACA33G73SooOCabzaIaNWozRAKAgEJPWwAAAAAA4HdcLpc2bcpSVtYXcrlcvg4HAAxF0hYAAAAAAAAA/AhJWwAAAAAAAADwIyRtAQAAAAAAAMCPkLQFAAAAAAAAAD9C0hYAAAAAAAAA/AhJWwAAAAAAAADwI1ZfBwAAAAAAAPBHJpNJrVu3kc1mlslk8nU4AGAokrYAAAAAAMDvmM1mtWlzuex2i4qLnb4OBwAMxfAIAAAAAAAAAOBH6GkLAAAAAAD8jtvt1smTJ2SzWWS312CIBAABhZ62AAAAAADA77hcLn3++UZt3LhBLpfL1+EAgKFI2gIAAAAAAACAHyFpCwAAAAAAAAB+hKQtAAAAYJCjR49qwoQJ6tSpk7p06aLJkyfr5MmT553n9ttvl8Ph8HpNnTrVoIgBAADgCzyIDAAAADDIxIkTlZeXp6VLl6qkpESTJ0/W1KlTNXfu3PPON2TIED300EOezzVq1KjsUAEAAOBDJG0BAAAAA/zwww/asGGD0tPTFR0dLUmaMmWK7rnnHj366KMKDw8/57yXXXaZwsLCjAoVAAAAPsbwCAAAAIABduzYobp163oStpIUFxcns9msr7766rzzvvvuu+rWrZtuuOEGzZ07V0VFRZUdLgAAAHyInrYAAACAAQ4fPqyQkBCvMqvVquDgYOXl5Z1zvhtuuEFNmjRRw4YNtWfPHs2ZM0d79+7VwoULy6xvs1lkMlVo6D5ltVp8HQJ8jG0gcLlcJl1+eWtZLBYFBVllNtPvLFCxH0AgbgMkbQEAAIA/Yc6cOXr55ZfPW2fNmjWXvPxbb73V897hcCgsLEwjR47UgQMH1KxZs1L1S0qcl9yWvyourn7rhIvDNhC4WrW6Qna75f9vA2wHgYz9AAJtGyBpCwAAAPwJo0aN0qBBg85bJzIyUg0aNNCvv/7qVX7mzBkdO3bsosarjYmJkSTt37+/zKQtAAAAqj6StgAAAMCfEBISUmrYg7LExsaqoKBAu3fvVvv27SVJmzZtksvlUocOHcrdXnZ2tiTxYDIA1Z7b7VZRUZHOnLHIYrHLVJ3GfgGAC2BAGAAAAMAArVu3Vs+ePfXkk0/qq6++0rZt2/TMM8+of//+Cg8PlyQdOnRIffv29TyY7MCBA1q0aJF2796t3NxcrV+/XpMmTVLXrl3Vtm1bX64OAFQ6l8ulDRs+1aeffiKXy+XrcADAUPS0BQAAAAwyZ84cPfPMM7rjjjtkNpvVu3dvTZkyxTO9pKREe/fuVVFRkSTJZrMpKytLaWlpKiwsVOPGjdW7d2/df//9vloFAAAAGICkLQAAAGCQevXqae7cueecHhERoT179ng+N27cWG+88YYRoQEAAMCPMDwCAAAAAAAAAPiRKp203bJli8aMGaMePXrI4XBo3bp1XtPdbrfmzZunHj16qEOHDho5cqT27dvnm2ABAAAAAAAAoByqdNK2sLBQDodD06ZNK3P6yy+/rNdff13Tp0/XypUrVaNGDY0ePVqnT582OFIAAAAAAAAAKJ8qPaZtQkKCEhISypzmdruVlpam++67T0lJSZKkWbNmKS4uTuvWrVP//v2NDBUAAAAAAAAAyqVK97Q9n9zcXOXl5SkuLs5TVqdOHcXExGjHjh0+jAwAAAAAAFyIyWRSZGQzNWvWTCaTydfhAIChqnRP2/PJy8uTJIWGhnqVh4aG6vDhw74ICQAAAAAAlJPZbNaVV7aT3W5RcbHT1+EAgKGqbdL2UtlsFhl5Ac9kDpyrhWaTSa5q27e7NLvd4usQqj2rle8YFYftqfJxzKueON4BAAAAFa/aJm3DwsIkSfn5+WrYsKGnPD8/X23btj3nfCUlxl69c7vchrbnSy5zYK0vV4KNwfeMisT2VLkC6RgQSMc8fjcAgMpUXFwsyfL/XwAQOKptH5CIiAiFhYUpKyvLU3bixAnt2rVLsbGxPowMAAAAAABciNPp1Mcfr9f69evkdHKREEBgqdI9bU+ePKkDBw54Pufm5io7O1vBwcFq0qSJRowYodTUVDVv3lwRERGaN2+eGjZsqKSkJB9GDQAAAAAAAADnVqWTtrt379aIESM8n1NSUiRJgwYN0owZM3T33XerqKhIU6dOVUFBgTp37qzFixcrKCjIVyEDAAAAAAAAwHlV6aRtt27dtGfPnnNON5lMGjdunMaNG2dgVAAAAAAAAABw6artmLYAAAAAAAAAUBWRtAUAAAAAAAAAP0LSFgAAAAAAAAD8SJUe0xYAAAAAAFRPJpNJTZo0lc1mlslk8nU4AGAokrYAAAAAAMDvmM1mRUd3kN1uUXGx09fhAIChGB4BAAAAAAAAAPwIPW0BAAAAAIBfcjqdctLJFkAAImkLAAAAAAD8jtPp1Lp1H8pqNatXryRZLBZfhwQAhmF4BAAAAAAAAADwIyRtAQAAAAAAAMCPkLQFAAAAAAAAAD9C0hYAAAAAAAAA/AhJWwAAAAAAAADwIyRtAQAAAAAAAMCPWH0dAAAAAAAAwB+ZTCaFh4fLZrPIZDL5OhwAMBRJWwAAAAAA4HfMZrM6duwku92i4mKnr8MBAEMxPAIAAAAAAAAA+BGStgAAAAAAAADgRxgeAQAAAAAA+B2n06l16z6U1WpWr15Jslgsvg4JAAxDT1sAAAAAAAAA8CMkbQEAAAAAAADAj5C0BQAAAAAAAAA/QtIWAAAAAAAAAPwISVsAAAAAAAAA8CMkbQEAAAAAAADAj1h9HQAAAAAAAMAfmUwmNWjQQDabRSaTydfhAIChSNoCAAAAAAC/Yzab1blzV9ntFhUXO30dDgAYiuERAAAAAAAAAMCPkLQFAAAAAAAAAD/C8AgAAAAAAMDvOJ1OffzxOlmtZvXsmSiLxeLrkADAMCRtAQAAAACAX3I6XeIZZAACEcMjAAAAAAAAAIAfIWkLAAAAAAAAAH6EpC0AAAAAAAAA+BGStgAAAAAAAADgR0jaAgAAAAAAAIAfsfo6AAAAAAAAgLLUrx8im43+ZgACD0lbAAAAAADgdywWi666qpvsdouKi52+DgcADMXlKgAAAAAAAADwIyRtAQAAAAAAAMCPMDwCAAAAAADwO06nU59++rFsNrPi4hJksVh8HRIAGIakLQAAAAAA8EslJSVyu7lJGEDgYc8HAAAAAAAAAH6EpC0AAAAAAAAA+JFqPTzCggULtHDhQq+yli1b6v333/dRRAAAAAAAAABwftU6aStJl19+uZYuXer5zMDlAAAAAAAAAPxZtU/aWiwWhYWF+ToMAAAAAAAAACiXap+03b9/v3r06KGgoCB17NhREyZMUJMmTXwdFgAAAAAAuIDg4GBZrTyOB0DgqdZJ2w4dOiglJUUtW7ZUXl6eFi1apOHDh+vdd99V7dq1y5zHZrPIZDIuRpPZwMZ8zGwyyRVAx1q7naE4KpvVyneMisP2VPk45lVPHO8AAJXFYrHo6qvjZLdbVFzs9HU4AGCoap20TUhI8Lxv27atYmJidO2112rt2rUaPHhwmfOUlBh7IHC73Ia250suc2CtLycVxuB7RkVie6pcgXQMCKRjHr8bAAAAoOIFSB+Qs+rWrasWLVrowIEDvg4FAAAAAAAAAMpUrXva/tHJkyeVk5PDg8kAAAAAAPBzTqdTGzd+JpvNrG7deshiYUgeAIGjWidtZ86cqWuvvVZNmjTRL7/8ogULFshsNuuGG27wdWgAAAAAAOACTp06pTNnAuomYQCQVM2Ttj///LPGjx+vo0ePKiQkRJ07d9bKlSsVEhLi69AAAAAAAAAAoEzVOmn7wgsv+DoEAAAAAAAAALgo3GMAAAAAAAAAAH6EpC0AAAAAAAAA+BGStgAAAAAAAADgR6r1mLYAAAAAAKDqql27tqxW+psBCDwkbQEAAAAAgN+xWCyKj+8pu92i4mKnr8MBAENxuQoAAAAAAAAA/AhJWwAAAAAAAADwIwyPAAAAAAAA/I7T6dSmTV/IajWrS5erZbFYfB0SABiGnrYAAACAAVJTUzV06FDFxMSoS5cu5ZrH7XZr3rx56tGjhzp06KCRI0dq3759lRsoAPiREydO6MSJE74OAwAMR9IWAAAAMEBJSYn69u2rYcOGlXuel19+Wa+//rqmT5+ulStXqkaNGho9erROnz5diZECAADA10jaAgAAAAZ46KGHNHLkSF1xxRXlqu92u5WWlqb77rtPSUlJatu2rWbNmqVffvlF69atq+RoAQAA4EskbQEAAAA/lJubq7y8PMXFxXnK6tSpo5iYGO3YscOHkQEAAKCykbQFAAAA/FBeXp4kKTQ01Ks8NDRUhw8f9kVIAAAAMIjV1wEAAAAAVdWcOXP08ssvn7fOmjVr1Lp1a4Mikmw2i0wmw5qrdFYrT4sPdGwDgcvplKxWsywWs+x2iywWtoVAxX4AgbgNkLQFAAAALtGoUaM0aNCg89aJjIy8pGWHhYVJkvLz89WwYUNPeX5+vtq2bXvO+UpKnJfUnj8rLq5+64SLwzYQmJxOp6xWu2w2s4qLnSJnG9jYDyDQtgGStgAAAMAlCgkJUUhISKUsOyIiQmFhYcrKylJUVJQk6cSJE9q1a5eGDRtWKW0CgD+xWCxKSLhWdrsl4JI1AMCYtgAAAIABDh48qOzsbB08eFBOp1PZ2dnKzs7WyZMnPXX69u2rjz76SJJkMpk0YsQIpaamav369dqzZ48effRRNWzYUElJSb5aDQAAABiAnrYAAACAAebPn6+MjAzP54EDB0qS0tLS1K1bN0nS3r17dfz4cU+du+++W0VFRZo6daoKCgrUuXNnLV68WEFBQYbGDgAAAGOZ3G6329dB+JO8vOMXrlSBbvvfIYa250sms0luV+Bsbm/0X+nrEKo9bpNCRWJ7qnwc86ono493YWF1DG2vKjL6fLaysX8G20Dgcjqd2rLlS1mtZsXGduVBZAGM/QCq2zZQnnNaetoCAAAAAAC/dOzYMVmtjOwIIPCw5wMAAAAAAAAAP0LSFgAAAAAAAAD8CElbAAAAAAAAAPAjJG0BAAAAAAAAwI+QtAUAAAAAAAAAP2L1dQAAAAAAAABlsdlsstnobwYg8JC0BQAAAAAAfsdisSgxMUl2u0XFxU5fhwMAhuJyFQAAAAAAAAD4EZK2AAAAAAAAAOBHGB4BAAAAAAD4HafTqW3btspmM6tDh06yWCy+DgkADEPSFgAAAAAA+KUjR36V1cpNwgACD3s+AAAAAAAAAPAjJG0BAAAAAAAAwI+QtAUAAAAAAAAAP0LSFgAAAAAAAAD8CElbAAAAAAAAAPAjJG0BAAAAAIBfsljMslhIXQAIPFZfBwAAAAAAAPBHFotFSUl9ZLdbVFzs9HU4AGAoLlcBAAAAAAAAgB8haQsAAAAAAAAAfoThEQAAAAAAgN9xuVzasWObbDaL2rfvKLOZfmcAAgdJWwAAAAAA4HfcbrcOHz4sq9Ust9vt63AAwFBcpgIAAAAAAAAAPxIQSdtly5YpMTFR0dHRGjx4sL766itfhwQAAAAAAAAAZar2Sds1a9YoJSVFY8eOVUZGhtq2bavRo0crPz/f16EBAAAAAAAAQCnVPmm7dOlSDRkyRMnJyWrTpo2eeuopXXbZZVq1apWvQwMAAAAAAACAUqp10ra4uFjffPON4uLiPGVms1lxcXHasWOHDyMDAAAAAAAAgLJV66TtkSNH5HQ6FRoa6lUeGhqqw4cP+ygqAAAAAAAAADg3q68D8DdhYXUMbe+DkWsNbQ8AAF/hmAcYw+jzWQCoTLfdNsTXIQCAT1Trnrb169eXxWIp9dCx/Px8NWjQwEdRAQAAAAAAAMC5Veukrd1uV7t27ZSVleUpc7lcysrKUmxsrA8jAwAAAAAAAICyVfvhEe68805NmjRJ7du3V4cOHfTaa6+pqKhIN998s69DAwAAAAAAAIBSqn3Stl+/fvr11181f/585eXlKSoqSosXL2Z4BAAAAAAAAAB+qVoPj/Cb2267TR9//LF2796tt956SzExMb4OqUrbsWOHoqKidM8995yzznvvvaeoqCg99dRTpaZ9+eWXcjgcnldcXJwefPBB5eTkeOokJibq1VdfrYzw4Qcee+wxORwOTZ06tdS0p556Sg6HQ4899pgk6ddff9W0adPUq1cvtW/fXvHx8Ro9erS2bdvmmScxMdFrm3I4HLrmmmu0YMGCUuV/fKFqycvL07PPPqvrr79e0dHRiouL09ChQ/Xmm2+qqKjIU2/79u26++671bVrV0VHR+vGG2/U0qVL5XQ6Sy3z448/1m233abY2FjFxMQoOTlZq1evLrP9Dz74QCNGjFDXrl3VoUMH9enTR48//rj+7//+z1Nn9erV6tKlS8WvPAxxrmNcbm6uHA6HoqKidOjQIa9pv/zyi6688ko5HA7l5uZKkm6//fbz7ns2b94s6T/7w3/84x9ey1y3bh37KASs1NRUDR06VDExMeXen7rdbs2bN089evRQhw4dNHLkSO3bt69yA0WlOXr0qCZMmKBOnTqpS5cumjx5sk6ePHneecra75Z1rgn/tGzZMiUmJio6OlqDBw/WV199dd76a9euVd++fT3neZ9++qlBkaKyXMw2sHr16lK/9+joaAOjRUXbsmWLxowZox49esjhcGjdunUXnOfLL7/UoEGD1L59e11//fXn/B+uKguIpC0qVnp6um677TZt2bKl1D+uv69z11136X//9391+vTpMuu8//772rBhg+bNm6d//etfGjNmTJkJFVRPjRs31po1a3Tq1ClP2enTp/Xee++pSZMmnrIHH3xQ2dnZmjFjhj744AOlpqbqqquu0tGjR72W99BDD2njxo2eV2ZmpkaNGuVV1qhRo1L1UHXk5ORo0KBB+vzzz/Xwww8rMzNTK1as0F133aVPPvlEX3zxhSTpo48+0u23365GjRopLS1Na9eu1YgRI5SamqqHH35Ybrfbs8zXX39d999/vzp16qS33npL77zzjvr3769p06Zp5syZXu3Pnj1bDz/8sKKiopSamqr3339fc+fOVWRkpObOnWvod4HKc6FjXHh4uDIzM73KMjMzFR4e7lW2YMECr33Nxo0b9fHHH+uKK65Q+/btvS4gBwUF6eWXX9axY8cqZZ2AqqakpER9+/bVsGHDyj3Pyy+/rNdff13Tp0/XypUrVaNGDY0ePfqc56HwbxMnTtT333+vpUuX6r//+7+1devWciVghwwZ4rXfffTRRw2IFn/WmjVrlJKSorFjxyojI0Nt27bV6NGjSz1Q/Dfbt2/XhAkTdMsttygzM1PXXXedxo4dq++++87gyFFRLnYbkKTatWuXOs9C1VVYWCiHw6Fp06aVq35OTo7uvfdedevWTW+//bbuuOMOTZkyRRs2bKjkSI1V7YdHQMU6efKk1qxZo1WrVunw4cPKyMjQmDFjvOrk5ORox44dWrBggb788kt9+OGHuvHGG0stKzQ0VHXr1lXDhg01duxYTZw4Ufv371erVq2MWh340JVXXqmcnBx9+OGHGjBggCTpww8/VOPGjRURESFJKigo0NatW/X666/rqquukiQ1bdpUHTp0KLW8WrVqKSwsrMzy31gslnPWg/+bPn26LBaLVq1apZo1a3rKIyMjlZSUJLfbrcLCQk2ZMkWJiYl65plnPHUGDx6s0NBQ3XfffVq7dq369eunn376STNnztQdd9yh8ePHe+qOGjVKNptNzz77rPr27auYmBjt3LlTixcv1hNPPKERI0Z46jZp0kTt27f3SgSj6irPMW7gwIFavXq17r33Xk/ZqlWrNHDgQP3973/3lNWrV6/U8qdMmaIjR44oPT1dQUFBnvK4uDjt379fL730EgkGQGcvxEoqd48Zt9uttLQ03XfffUpKSpIkzZo1S3FxcVq3bp369+9fabGi4v3www/asGGD0tPTPT3npkyZonvuuUePPvpoqYtkv3fZZZdxnlcFLV26VEOGDFFycrKks3feffLJJ1q1alWZd3empaWpZ8+euuuuuyRJf/vb3/TFF1/ojTfe0NNPP21o7KgYF7sNSJLJZOL3Xo0kJCQoISGh3PWXL1+uiIgIzx26rVu31rZt2/Tqq6+qZ8+elRWm4ehpi4uydu1atWrVSq1atdKAAQO0atWqUsmK1atXKyEhQXXq1NGAAQOUnp5+weVedtllks72rEDg+ONt6KtWrfJ6SGDNmjVVs2ZNrVu3TsXFxb4IEX7iyJEj+vzzzzV8+HCvhO3vmUwmff755zp69KhGjRpVanpiYqJatGih9957T9LZoQ5KSkrKrHvrrbeqZs2anrrvvfeeatasqb/+9a/nbBtVX3mOcYmJiTp27Ji2bt0qSdq6dasKCgp07bXXnnfZy5YtU2ZmpubPn69GjRp5TTObzRo/frzeeOMN/fzzzxW7UkAAyM3NVV5enuLi4jxlderUUUxMjHbs2OHDyHApduzYobp163rd6hwXFyez2XzBW+bfffdddevWTTfccIPmzp3rNXQS/FNxcbG++eYbr9+v2WxWXFzcOX+/O3fuVPfu3b3KevTooZ07d1ZmqKgkl7INSGd7Zl577bVKSEjQfffdp3/9619GhAs/ESj7AZK2uCjp6emeXpE9e/bU8ePHPePySZLL5VJGRoanTr9+/bRt2zav8Wr/6JdfftErr7yi8PBwtWzZsnJXAH5lwIAB2rZtm/7973/r3//+t7Zv3+7ZdiTJarVqxowZyszMVJcuXTR06FA9//zz+vbbb0sta86cOYqNjfW80tLSjFwVVLIDBw7I7XaX2kd069bN8zefPXu29u7dK+nsldaytGrVyjPG4d69e1WnTh01bNiwVD273a7IyEhP3X379ikyMlJW639uUFm6dKnXNnf8+PEKWFP40oWOcZJks9k8CV3p7MWmAQMGyGaznXO5W7ZsUUpKiqZNm6ZOnTqVWef6669XVFSU5s+fX0FrAwSOvLw8SWfv4vq90NBQHT582Bch4U84fPiwQkJCvMqsVquCg4M9f+uy3HDDDZo9e7bS0tJ0zz336O2339YjjzxS2eHiTzpy5IicTudF/X4PHz5c6sHi/N6rrkvZBlq2bKn/+q//0t///nfNnj1bbrdbQ4cO5eJ3AClrP9CgQQOdOHHCawjGqo7hEVBuP/74o77++mstWrRI0tmTp379+ik9PV3dunWTJH3++ecqKirydGsPCQlRfHy8Vq1apb/97W9ey0tISJDb7VZRUZHatm2rBQsWyG63G7pO8K2QkBD16tVLGRkZcrvd6tWrV6mT9D59+qhXr17aunWrdu7cqQ0bNmjx4sV69tlnvXrljh492utz/fr1DVsP+E56erpcLpcmTpzo1RvbiOEKkpOTlZiYqF27dumRRx5hiIQqrjzHuN8kJydr6NChGj9+vN5//32tWLHinGOyHzx4UA899JCGDBmiwYMHnzeGiRMn6o477tDo0aMrZqUAPzJnzhy9/PLL562zZs2ac150Q9VX3m3gUt16662e9w6HQ2FhYRo5cqQOHDigZs2aXfJyAfif3zpN/P5zv379tHz58lJ5B6AqI2mLcktPT9eZM2e8xgdxu92y2+2aOnWq6tSpo/T0dB09etTrASsul0t79uzRQw89JLP5P527ly1bptq1ayskJES1a9c2dF3gP5KTkz1jT51r0PGgoCDFx8crPj5eY8eO1RNPPKEFCxaUStI2b97ckJhhvGbNmslkMnl60v4mMjJS0n+GWPmtJ+4PP/xQZo/GH3/80ZMQaNmypY4fP65Dhw6VGh+vuLhYOTk5nmRdixYttG3bNpWUlHh6VNatW1d169blin41caFj3O85HA61atVK48ePV+vWrXXFFVcoOzu71DJPnTqlBx54QG3atNHkyZMvGEPXrl3Vo0cPzZ0712v/BlQHo0aN0qBBg85b57d9+sX6bUzD/Px8r7sn8vPz1bZt20taJipeebeBBg0a6Ndff/UqP3PmjI4dO3ZR41f+9v/I/v37Sdr6sfr168tisZR64FR+fn6pXnS/adCgQakemOerD/92KdvAH9lsNkVFRenAgQOVESL8UFn7gcOHD6t27dqe/w2rA4ZHQLmcOXNGb7/9th577DFlZmZ6Xm+//bYaNmyo9957T0eOHNH69ev1wgsveNXJzMzUsWPHtHHjRq9lRkREqFmzZiRsA1zPnj1VUlKiM2fOqEePHuWap02bNiosLKzkyOBP6tevr/j4eL3xxhvn/dvHx8erXr16Wrp0aalp69ev1759+3TDDTdIknr37i2bzVZm3eXLl6uwsNBTt3///iosLNSbb75ZQWsEf1KeY9wfJScna/PmzZ4HZpTliSee0NGjRzVv3jyvoTXOZ8KECfr4448ZhxPVTkhIiFq3bn3e16XecRUREaGwsDBlZWV5yk6cOKFdu3Z59cSCb5V3G4iNjVVBQYF2797tmXfTpk1yuVxlPoz2XH67mMaDivyb3W5Xu3btvH6/LpdLWVlZ5/z9duzYUZs2bfIq++KLL9SxY8fKDBWV5FK2gT9yOp367rvv+L0HkEDZD9DTFuXyySef6NixY7rllltUp04dr2m9e/dWenq6Tp8+rXr16ukvf/lLqYfyJCQkKD09Xddcc0252zx06FCpnktNmjRRcHDwpa8I/I7FYtHatWs973/vyJEjGjdunJKTk+VwOFSrVi3t3r1bixcv1nXXXeeLcOFD06ZN07Bhw5ScnKwHH3xQDodDJpNJX3/9tX788Ue1a9dONWvW1FNPPaXx48frySef1PDhw1W7dm1lZWVp9uzZ6tOnj/7yl79IOrs/mThxombOnKmgoCDPuKTr16/X888/r1GjRnl66cTGxmrUqFGaOXOmDh48qOuvv16NGzdWXl6e0tPTZTKZvO4kcDqdpfZfdrud2379VHmOcX98Cu2QIUPUt29f1a1bt8xlLl68WB988IFSU1PldDpLjcNYp06dMnsBOBwO3XjjjXr99df/5FoBVdfBgwd17NgxHTx40Gt/2qxZM9WqVUuS1LdvX02YMEHXX3+9TCaTRowYodTUVDVv3lwRERGaN2+eGjZsqKSkJF+uCi5B69at1bNnTz355JN66qmnVFJSomeeeUb9+/f33Blz6NAh3XHHHZo1a5Y6dOigAwcO6N1331VCQoLq1aunPXv2KCUlRV27dqW3dRVw5513atKkSWrfvr06dOig1157TUVFRZ67Th599FGFh4drwoQJkqQRI0bo9ttv15IlS5SQkKA1a9Zo9+7dnrv3UPVc7DawcOFCdezYUc2bN1dBQYFeeeUVHTx48IJDUcF/nTx50qundG5urrKzsxUcHKwmTZpo7ty5OnTokGbNmiVJGjp0qJYtW6ZZs2YpOTlZmzZt0tq1a/XSSy/5ahUqBUlblEt6erri4uJK/TMrnR1zdPHixfrmm280bNiwMp+i3rt3bz366KOlbnU6nyVLlmjJkiVeZbNmzdJNN9108SsAv3au3ta1atVSTEyMXnvtNR04cEBnzpxRo0aNNHjwYI0ZM8bgKOFrzZo1U0ZGhl566SXPQdtms6lNmzYaNWqU/vrXv0o6+498gwYNlJqaquHDh+v06dNq0aKFxowZozvuuMNrHzVy5EhFRkZqyZIlSktLk9PpVJs2bTR9+vRSPSgnTZqk6Oho/c///I9WrVqlU6dOKTQ0VF26dNGKFSu8tuPCwkINHDiwVPwfffRR5X1BuGTlOcadOHHCq9xqtZYag/v33nzzTZWUlOiuu+4qc3pKSso5h0B46KGH/tS4jkBVN3/+fGVkZHg+/7Y/TUtL8wxbs3fvXq8HQN59990qKirS1KlTVVBQoM6dO2vx4sUKCgoyNHZUjDlz5uiZZ57RHXfcIbPZrN69e2vKlCme6SUlJdq7d6+Kiooknb01OisrS2lpaSosLFTjxo3Vu3dv3X///b5aBVyEfv366ddff9X8+fOVl5enqKgoLV682HNr/E8//eR1cbxTp06aM2eOXnzxRT3//PNq0aKFFi1apCuuuMJXq4A/6WK3gYKCAj355JPKy8tTcHCw2rVrp+XLl6tNmza+WgX8Sbt379aIESM8n1NSUiRJgwYN0owZM5SXl6effvrJMz0yMlIvvfSSUlJSlJaWpkaNGunZZ58t1dGiqjO5eXIKAAAAAAAAAPgNxrQFAAAAAAAAAD9C0hYAAAAAAAAA/AhJWwAAAAAAAADwIyRtAQAAAAAAAMCPkLQFAAAAAAAAAD9C0hYAAAAAAAAA/AhJWwAAAAAAAADwIyRtAQAAAAAAAMCPkLQFgAD05ZdfyuFwqKCg4E8tJzExUa+++mrFBAUAAACUQ25urhwOh7Kzsw1v2+FwaN26dYa3CyDwkLQFAB/79ddfNW3aNPXq1Uvt27dXfHy8Ro8erW3btvk6NAAAAASgxx57TPfff/85p5/vwv1vCdWoqCgdOnTIa9ovv/yiK6+8Ug6HQ7m5uedcfk5OjiZMmKAePXooOjpa11xzje677z798MMPkqTGjRtr48aNuvzyyy9+5QCgirD6OgAACHQPPvigSkpKNGPGDEVGRio/P19ZWVk6evSor0MDAAAALkl4eLgyMzN17733esoyMzMVHh6ugwcPnnO+kpISjRo1Si1bttTChQsVFhamn3/+WZ999pmOHz8uSbJYLAoLC6v0dQAAX6KnLQD4UEFBgbZu3aqJEyfq6quvVtOmTdWhQwfde++9uu666/T44497nehKZ09ku3fvrrfeekuSdPvtt+uZZ57Rc889p65duyouLk4rV65UYWGhHn/8ccXGxur666/Xp59+Wqr97du368Ybb1R0dLSGDBmi7777zmv6Bx98oP79+6t9+/ZKTEzUkiVLKu/LAAAAQLUxcOBArV692qts1apVGjhw4Hnn+/7773XgwAFNmzZNHTt2VNOmTdW5c2c9/PDD6tixo6Syh0dYv369evfurejoaN1+++3KyMjwGg5s9erV6tKlizZs2KC//OUvio2N1ejRo/XLL794lvHVV1/pzjvvVLdu3dS5c2fddttt+uabbyrmCwGAi0TSFgB8qGbNmqpZs6bWrVun4uLiUtMHDx6sDRs2eJ1MfvLJJzp16pT69evnKcvIyFD9+vX11ltv6bbbbtP06dM1btw4xcbGKiMjQ/Hx8Xr00UdVVFTktfxZs2bpscceU3p6ukJCQjRmzBiVlJRIknbv3q2//e1v6tevn95991098MADmjdvXqmTbwAAAOCPEhMTdezYMW3dulWStHXrVhUUFOjaa68973whISEym8364IMP5HQ6y9VWTk6Oxo0bp+uuu05vv/22hg4dqhdeeKFUvVOnTmnJkiWaNWuW3njjDf3000+aOXOmZ/rJkyc1cOBAvfnmm1q5cqWaN2+ue+65RydOnLiINQeAikHSFgB8yGq1asaMGcrMzFSXLl00dOhQPf/88/r2228lSZ06dVLLli319ttve+ZZtWqV+vbtq1q1annK2rZtq/vvv18tWrTQvffeq6CgINWvX19DhgxRixYtNHbsWB09elR79uzxav+BBx5QfHy8HA6HZsyYofz8fH300UeSpKVLl6p79+4aO3asWrZsqZtvvlnDhw/XK6+8YsA3AwAAgKrMZrNpwIABWrVqlaSz57ADBgyQzWY773zh4eGaMmWK5s+fr65du2rEiBFatGiRcnJyzjnPihUr1LJlS02aNEmtWrVS//79NWjQoFL1SkpK9NRTTyk6Olrt2rXT8OHDtWnTJs/07t2766abblLr1q3VunVrPfPMMyoqKtKWLVsu8VsAgEtH0hYAfKxPnz7asGGDUlNT1bNnT23evFk333yzp0fr4MGDPe8PHz6sDRs2KDk52WsZDofD895isahevXq64oorPGUNGjSQJOXn53vN99stZpJUr149tWzZUj/++KMk6ccff1SnTp286nfq1En79+8vd68HAAAABK7k5GS9//77ysvL0/vvv1/qHPZchg8fro0bN2rOnDmKjY3V+++/r/79++vzzz8vs/7evXvVvn17r7IOHTqUqlejRg01a9bM87lhw4Ze58eHDx/WlClT1Lt3b3Xu3FmdO3dWYWHhecfgBYDKQtIWAPxAUFCQ4uPjNXbsWC1fvlyDBg3SggULJEk33XSTcnJytGPHDr3zzjuKiIhQly5dvOa3Wr2fK2kymbzKTCaTJMntdlfymgAAAABnORwOtWrVSuPHj1fr1q29OhVcSO3atZWYmKiHH35Y77zzjrp06aLU1NQ/FU9Z58y/Pz+eNGmSsrOz9cQTT2j58uXKzMxUvXr1PMOHAYCRSNoCgB9q06aNCgsLJUn169dXUlKSVq9erYyMDN18880V1s7OnTs9748dO6Z9+/apVatWkqRWrVpp+/btXvW3b9+uFi1ayGKxVFgMAAAAqL6Sk5O1efPmcveyLYvJZFKrVq0858d/1LJlS+3evdur7Ouvv77odrZv367bb79dCQkJuvzyy2W323XkyJFLihkA/izrhasAACrLkSNHNG7cOCUnJ8vhcKhWrVravXu3Fi9erOuuu85Tb/Dgwbr33nvlcrku+MTdi/H3v/9d9evXV2hoqF544QVPgliSRo0apVtuuUWLFi1Sv379tHPnTi1btkzTpk2rsPYBAADgn44fP67s7Gyvsnr16qlx48aSpEOHDpWa3qRJk1LLGTJkiPr27au6deuWq93s7GzNnz9fN910k9q0aSObzabNmzdr1apVuuuuu8qc59Zbb9Wrr76q2bNn65ZbblF2drYyMjIk/eeOs/Jo0aKF3nnnHUVHR+vEiROaNWuWLrvssnLPDwAViaQtAPhQrVq1FBMTo9dee00HDhzQmTNn1KhRIw0ePFhjxozx1IuLi1PDhg3Vpk0bhYeHV1j7EyZM0HPPPad9+/YpKipKqampstvtkqR27drpxRdf1Pz585WamqqwsDA99NBDFdrTFwAAAP5p8+bNpToL3HLLLXruueckSUuWLNGSJUu8ps+aNUudO3f2KrNarQoJCSl3u+Hh4WratKkWLVqk3NxcmUwmNW3aVA8++KBGjhxZ5jyRkZGaN2+eZs6cqbS0NHXs2FFjxozR9OnTPee25fHcc8/pySef1KBBg9S4cWM9/PDDmjVrVrnnB4CKZHIzwCEA+L2TJ0/qmmuuUUpKinr37u3rcAAAAAC/lpqaquXLl+vTTz/1dSgAcEnoaQsAfszlcunIkSNasmSJ6tatq8TERF+HBAAAAPidZcuWKTo6WvXr19e2bdv0yiuvaPjw4b4OCwAuGUlbAPBjBw8e1HXXXadGjRppxowZpZ54CwAAAEDav3+/UlNTdezYMTVp0kR33nmn7r33Xl+HBQCXjOERAAAAAAAAAMCPmH0dAAAAAAAAAADgP0jaAgAAAAAAAIAfIWkLAAAAAAAAAH6EpC0AAAAAAAAA+BGStgAAAAAAAADgR0jaAgAAAAAAAIAfIWkLAAAAAAAAAH6EpC0AAAAAAAAA+BGStgAAAAAAAADgR/4ffgbQHEnWaNMAAAAASUVORK5CYII=",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABW0AAAPdCAYAAADxjUr8AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjcsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvTLEjVAAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzs3QmcTfX/x/HPMAbZskULChUJ2UpRimihQqSsZa8sUREqWuylQlmKslZka0EqSVIqZcuSLVsKZc0ymPk/3t/+5/7unUUzzHJm5vV8PO5j5p5z7rnfe+4xPvdzP+fzDYuOjo42AAAAAAAAAIAvZErtAQAAAAAAAAAA/oekLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtgDTlyy+/tAcffNCuvfZaK1OmjFWvXt26dOlia9euDdmuRYsWduWVV9qzzz5rqWnmzJluHGXLlv3PbU+ePGmTJ0+2xo0bW4UKFaxcuXJ211132RtvvGHHjx+39Gjnzp3u+Oi2YsWK1B4OAABAilu0aJG1bdvWrrvuOrv66qutZs2a1rdvX9u9e3eyP/e4cePs5ptvDjyvYmr9VGw2duzYMz72qaeectu1adPG0poRI0a4sd9+++3mJ2n5mAJIeuHJsE8ASBazZ8+2nj17ut+zZMliOXPmtH379tmnn37qgt0pU6YEkqN58+a1QoUKWZ48edLEu3H06FFr166d/fjjj+5+1qxZLSwszH799Vd3+/zzz93ry549u6Un4eHh7n2SiIiI1B4OAABAiho4cKC988477vdMmTLZeeedZ7t27bL33nvP5s+fb1OnTrUSJUoky3Nv377dhgwZ4n7X8x45csTy589vBQsWtFOnTlmOHDmS5XkBAAlDpS2ANOP11193Pxs2bOiSm8uWLbPPPvvMLrroIjtx4kRINcDw4cNt8eLF9vjjj1ta0L9/f/ealJRV8PzTTz/Zzz//bM8884xL3v7yyy//We2QFhUuXNi9T7pdddVVqT0cAACAFDNnzpxAwlaVlYoFly9fbpMmTXKFBwcOHEjWq8b+/PPPkOKI77//3n2Z/v7777vYrFmzZsn23ACA/0bSFkCa4QWWqrDNli2b+71IkSIusdm6dWurWLHiGdsjKPDVJUeVK1d27RWUKP3www/ddtre412ur8Sp9l2lShWrVKmS9erVy1XEeo4dO+b2ccstt7hLyrSdWjesXLkyUa9r7969LlCWzp072z333OMqUFVt0bx5c7v//vutbt26saosPvjgA5fAvuaaa9zr6dSpk6vKjav1gJbrGJUvX95q167tKnf/+OMPe+SRR9yyG2+80d58883AY5UQ1+N0rFatWmVNmjRx7Rp0CZmqPoJt27bNtaioVq2aOw76+cQTT9iePXtivR9Kput3jVnbxNUeQW0ilKC/7bbb3Nh0qWDLli3thx9+CHne06dP2/jx461evXpubDfccIP16NHDfv/99ziPwW+//WZdu3Z1rSeuv/56Gzx4sNsHAABAavBiL7UnUAzjVbYqrtP9m266yd2C4xUldtVKQXGn4inFiQsXLgzZrxd3Kfn71ltvuf0rVlKcqnjIaw+gONNTp06dQDwcV3sEVeV26NDBPafak40ZMybO13Tw4EEXPyvW0hVw9evXt48//jhkG2//CxYssJdeesnFcNqv4mBdRRdMSWyNW/Gb4vGmTZvakiVLQrbRMVGCWa9Rx0X78V5nUjjT/vX5RIUHej1fffVVyOMUy2r5qFGj3H0Vmag4Q++pYuY77rjDJk6c+J/Pv3r1andFno6TxnDrrbe6/Wh/ANI32iMASDOUvNO3/gpu1A5BAagShFWrVnXB35ko2FWwowSkKCjWflTpGZ8nn3zSBWKZM2d2PWXVn7ZAgQKB6t2nn37aBaFKrp5//vkuSP32229dVayCSbU4SAhVNegSNC9gjqlfv36xlg0YMMAmTJgQcjmbqo6/+eYbV7GhZGcwBbtKMkdGRrqgu3v37u61KGGsSl4lWBU0lypVyiVwPQoGVfmhn1FRUbZ161Z77LHHXFK1Vq1abn8PPfSQu4xP7Q28lhUfffSRS5Lrg0IwL/hXUrp06dJxHo9XXnnF9Vfz2lwoUa4kspK6s2bNCiSvlYDVa/bez7///ttVrOjYq0JECf1geh16vXod2qcSvsWKFXMfdgAAAFKSYpKNGze63/WFekyNGjVyt2BKcioOU1yrVmGKUXVl1sMPP+zi0uAiBFFMqBhNsaJiOcWpajWmOEkxm+Ks/fv3u23VEkH346IYVwler4BCzzts2LBYbbsUFyrmVF9cxXp6jnXr1rnYWbFqzJhLX6Crb69iZsWpen16Xdq36At7xZn6Ql/LdVMSV8ljxYr6DKCEqp5T2yge1E/tR49VXOi14TpbCdm/Ymd9NtHngho1arjH6TOHErv6nNCgQQO3TMleJXa1LHfu3C6uVgGIzoX4rg5UjK5jcPjwYXec9F7u2LHDvX7FvoMGDTqn1wfA36i0BZBmKHl56aWXut+VeFTSVUGbErfqB6ZgLz4KpLyErbZVFa0SgAqA4qOgSEni7777zk16Jt436ArYoqOj3XgU+CoIVuAmhw4dss2bNyf4dQVXhp4piexR8OslbBXgKXhVolKJWiUjFbTHpOoFJT7fffddd1+BuwI/vT69JgWOom1iBt+qYFZiWQlhHQe9blVniILG4sWLu2qBr7/+2h0rr7pZHyJiUpA6b9489zyq3o2LxiTPPfec25+2vfPOO12S2Ku+UKWwl7BVslnvp+4XLVrU/vrrLxcAx6Qkrt4n7f/CCy90y2JWRAAAAKSE4EnGvLjkTBSTKRZWwlaVlorNlFD04ilVXgZf5SSKiXRlllcpKvoSXElYJQJfe+21wLaKi3VFVFy0D6+QQTGoYk9VCcecKFexsBK2ig0VFyqG876wf/XVV138HEzxqOam0GvxCjCCYzPFeHqMKo+9mFDbqdhBY5KXX37ZbePNDaF9aSJfJaODryI7WwnZv5dcV3zqfR7R1Xyi6ljF90uXLnWvLV++fC5m1WvRMVci+u2333bvVVwU4+rzysUXX+yeX8dBkxSrmEVFI4rLAaRfVNoCSDMUrKiCc+7cuYFvuJUgVaJSlQS63D84+Aym4FKUZFVLAdGlTHfffXcgkRnTvffe6wIr0WVMqqD9559/3P3gKgB9S672BsEJT2+7hAgOthISeHnJSh0PBZCqlNU4u3Xr5ioB1ApBSW0lSINfiyphlbzVclWbqg2DV1Fx2WWXubYOqoKISS0U1I5CNwX4amuwfv169xpV9apqWgWzSiarwkDBd3zHQJe1eRWwShqrGjcmVeCq8kQfPhSY6jI0tX4Ibg/hHQOtU+As2q+S+H369HFJ7JiXjKlCRBUSuulxCqYT8z4BAAAkFcViiYn/lLzzEntq96XiAlH7LiX/lNRVUrBx48aBxyhhqC/WvWpeTWorin8SM1mv18LKu8LNi431xb4XY4u+HPcS0mqLEExJTsWP3qTBovYAXlyoZKzaPHixmeJ7r+BCFcSq2vWuNlMVb65cuVyC1BubkrheotRLJiuOPBcJ3b+u/tMEbnp/9BrUTkxFCl4MHnxslIBVi4fg80CJeH2u0eNiuvzyy93rVcW03ltV9ap92ejRowPnAID0i6QtgDRDwagCPgWBuinIUY8nVX3q23wlC3V5kS7vismrqL3gggtClmsSs/gEXyLmXf4VHFSrmkBVA6qUVSCphGhcgfh/CR6Tglxdsh9MFQsKTL2g1qs2VdJWCVvPJZdcEvhd2wTvV9/EexT46VgquPR4rRziGrfaKHi8S8x0HJTg1XFRBYJmONZ9rde4Yh4rT1zvTUx9+/Z1+1UCWAGvF/QqyNdz6fh4xyD4NQffVxI5ZkI4+BjE9X4CAACklJjxX0wqRlDlrOIfxXtewla/e7GWF9MoVlM8GrNaMziW9eaDSGycGhxHx4zjYl4h5sVeSnbGdQWcqnWDk7ZnirX1nN44g7cL/l3FG942XpuHmMfwXCR0/yrmUDGEWm+pwEQJccWq+qmq6OBjoxg1eAK4/xqrihbUlkyFKfpMoMS3KnyVsFWxQseOHc/pNQLwN5K2ANIEVbFqMirRRFiqDFXFqFoCqPJTSVsFeQpW40oMeonHmEGSvrWOj5KbnuDkqGzatMn1BNNzaiIGVRvoUq3gQDShdMmXV/2qb+dVzRpMbQL0Lb+CQVWfeq9PY9fze2PTpFuemMdAl7PFFNeyuOh5vA8H3mV3ek61VFBrCFXa6oPHtGnTXGCp90ITZMQl+ANDfJQA7927t7utWbPGVZZMnz7dJehffPFFF6h6ry/4NXvtGrzgWUF98GWCwe8nAABAalLhgNo66eqoL774IqRCVlQVq9YC+rJaX2R7saxiP8Vm3pf5So56X2afKf6LGcsmhvfFd8w4Omai0Xt+TcDltVpQFali5LjmejhTrK0404uPg59XfWJVgasKVN30GvUcisdV8eodE8Wc5/KaRQUOCd2/WiQoaas2CN6EcposV1e6BR8bVT7PmDEj8DhVFnvbx0fPq6vElMhWewY9h6qrNQ+ENzkZgPSJnrYA0gTNGOtdFqWeqV4yTtWd3mRXCngU/MZFlxHJtm3bXJAjCvi8y5wSS5fve5UAqjJQ0KYZes+mgkFBe926dd3vCnBVWargUNWwqiz1LsvSLLziTXCggF0JTI1DExEocPPaPsSchOtcqG+WAkoda+81KuBURYRaMXhJUlXZKohVgvVsjoN3KZwmY1PVsnqmqZ2CEsAKSMWrIPGOgS4lU0WDl7D1+qYpuPWCZAAAAD9q3769+/nll1+6SkqvOlVtwNTnVBQLKaZRLOy1NNDkU4qZVLWpuRoUMyqJ6MVHSU0FBl4RheY4EBUa6Iv1YEosito0eK0NJk+e7MaudlZnmn8iJsWZ3sS6msdCCUu9XrUn02TBKmpQ0lf7Fh0vxapqj6UCCLVu8GLjM1EcrTg35k1jTcz+Vbig+FXrP/nkE7fMa8kWfGzUbk3vt9cDV++v5m2Iq/pW1ALOO376vKHWbprQTLG3xNcLF0D6QNkRgDRBwerzzz9v3bt3d98wq7JVgasCOCU4RbPpxtfbST24FPBociz1AVPFpgIv9YJV0JtYSloqWFLwqIBMgWVwP1hdTpUYmlhClRbqK6vXocBbr8ubsEFJXVXair5N16QTqnJVUnfUqFEuQNT2SlzrtSUljUmTHYjGo6qHLl26uPsKWKdOneoSyDrGCnyDe8lqoov4ZiKOi94/JW2VjFZQriSsEr/ee+RN9KAKDvX0UlWvKq3VUkHb6PlVyaAqXQAAAD9Tda2uKlKbKX1JrmpOVaR6cU/JkiWtR48egVhYk83qvpJ9SqSqClT9VZXMU+wT3NIqKTVo0MAlTjWPQ+vWrV28qcSmrrQKvqpJsaqSm7oiTa9NsbpiQVFi0muBkFCacFcJUsWiKl5Q7K1jo9et+Q6ka9eubhv1l1W/XW8bxZTqmftfVLmreDYmXWWmxHRi9q84VcUWikevvPLKQD9h0fgVKyvprZYGOjb6vKBt9fxeC7KYFBcrHlasfcstt7jHqdWC4mMVq3jJYADpE5W2ANIMJS4VtFSvXt0FLEqSqtergiD1evLaJ8RHwbAuU1KgqYBLAZM3k25ig0hVsqqfrTc5gC4bU18pb+ZbXbaUGKoiVhWrAnFNxCUapyoMlIRVW4TgicVUXaDlCgYV7GlbBXWqci1TpowlJR03r+2DqgjUQ1hJc9G3/gpmvWpjTfSm6g+vX6436UJiKAmr16eKYb02HV89/9ChQwMTN+hYaAIGVVpcccUVLpms5LA+VGiiiDP1KgYAAPALxTy60kpfkCsRqNhH8aUmgtUX48FffqvKUlci6YtrL3ZVUYKSvfpCP7noufS8+tJcv2uciv9ixt6Kr5XcVcJWX6KrWlUtzZRQVlFCYikhqUpTHRvtWzGhrp7zPg+Ikte66k4/tY0SurpCS+MtVarUOb/2xOxfSVyvgCS4ytajGFpJb8WpSvwqMfzoo4+6ydXio201abLeex1Tff658MILXYJYnx28KxEBpE9h0czCAiADWLdunUvmKfDVpWNKAupSMgVKixcvdslAVWsidg/hJUuWJGgCMQAAAAAAkDRojwAgQ1Dl58yZM9232qrKVVsEtVbQpfyq2vRaDwAAAAAAAKQ22iMAyBDUc0t9UtVKQS0VNHGXLm9S83/1hNXEAQAAAAAAAH5AewQAAAAAAAAA8BEqbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8Jtwxq797DqT2EdCdLlsx28uTp1B4G0inOL3B+IS3ib1fyKFgwVzLtOW0hno2Nf3PwC85F+AHnIfyCc/Hs4lkqbZFkwsI4mEg+nF9ITpxf4NwC0gf+nsMvOBfhB5yH8AvOxbND0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtAAAAAAAAAPgISVsAAAAAAAAA8BGStgAAAAAAAADgI+GpPQAAAAAAAAAgWPPm2VP0gEyefCxR21evXtmGDx9tFStWjrVu7tyPbPz4sfbBBx/F+dhOndrbihU/WZ8+/eyOO+qFrNu27Tdr1qyRXXNNRRs5cmy8z7969UqbNOltW7NmtUVFRVmpUqWtbduOdvXV5Swp7Ny5w55+uqdt3/6bPfBAC/v007nWunV7u/POu2Jtu3v379a48d02ffqHduGFFyXJ88PnlbYnTpyw3r17W+XKla169eo2fvz4eLfdsGGDPfDAA1auXDm766677LvvvkvRsQIAAAAAAAAJER4ebt98szjW8sWLv7SwsLAzPnbRoi+sa9eHrWTJK2zEiDE2evR4K1GipHXp0tFWrVqRJG/AjBnT3M9Jk6ZZkybN7M03J1qtWrWTZN9IB0nbIUOG2Jo1a2zChAnWt29fGzlypM2fPz/WdocPH7bWrVtbyZIl7aOPPrLatWtbp06d7K+//kqVcQMAAAAxRUZGWr169WzZsmXxHpy1a9da48aNrXz58nbvvfe6WBgAAKQ/5ctXtO+/X2YnT54MWb548SIrU6ZsvI/7558jNmTIAGvZsrW1b/+IS9Zeeull1rlzd7v++mo2atTwJBmfnqdkycvt4osvsdy5c1vevHkta9ZsSbJvpPGk7dGjR2369OnWp08fK1OmjEvEtm3b1qZMmRJr21mzZtl5551n/fr1s2LFilmXLl3cT4JcAAAA+OUKsu7du9vGjRvPGP+2b9/eXWU2c+ZMq1ChgnXo0MEtBwAA6UvZsuUsIiLCli//IbBs3769ri1BhQqV4n3cN9987RKq9933QKx1nTp1sx49ng7cX7NmlT38cBu79dbqrn3B7NkfBNb179/PRowYZs8+28tq1apmDRvWtfnzPwmsU4sH3VcbCLU/aNToLrdMTp06Za+8MsRuv/1ma9DgTlu6dEms4soXXnjG6tSpYffcc7sNHTrITpw47tb99NOPbl+zZn1g9evf4cambfXltketGJo2vdeNq2PH1vbrr+sD62bPnuFeS+3aN7o2E5s3b7L0yrdJ2/Xr17uTQMGqp1KlSrZy5UrXqyPY999/b7Vq1bLMmTMHls2YMcNq1KiRomMGAAAAYtq0aZPdd999tn379jMenLlz51rWrFmtR48eVqJECVe8kCNHjjivNAMAAGmbWiDccEN1W7JkcUiVbdWqN7jWCfHZtOlXK1bsUjvvvByx1qmf7GWXFXe///bbVuvS5WHXG3f8+MmuH+3Ika/aV199GdIC4corS9nEie9bjRo1bejQAXbkyBHr2vUJq1mztrvNmTPfLrigUMjzjBs3xiWPBw0aZi+8MMg++OC9kPWDBj3v9jNq1DgbOPAlW7durQ0bNiQkOa0WDy+/PML69x9qixYtDCSMly371gYOfN4lpSdMeM/16u3Ro5urSNaxevvtsfbYY0/a+PFTrHz5CtalSwc7dOiQpUe+nYhs7969rvRa3zp4ChQo4KoUDhw4YPny5Qss37Fjh+tl+8wzz9jChQvt4osvtp49e7okb3yyZMls/9EiJEk1aZLV/Oj9908k2b7Cw/+XNAeSGucXkhPnFzi3kJxUYHDddddZt27d7Jprrol3OxUnKH71+tjpZ8WKFW3FihXWsGFD3iQAANKZG2+sYa+8MtTMnnL3v/56kd19dwPbsmVzvI85fPiI5ciR8z/3/dFHs+yKK660Dh0edfeLFr3UJXKnTp1oNWrc4papJ26zZq3c723bdrDp09+1rVs3W9my5d0XyZI/f4GQ/UZHR9tHH822Tp0ecwlh6dKluz355GPu9127dtrXX39lc+cutJw5/x1n797PWPPm97sWDqIiTSWGixcv4do7XHfdDS6xq9c+Z85Mq137dqtfv5Hb9tFHH7Pw8Cx26NBBN/YWLR6yatVudOvatXvYvv32G1uwYK41anS/pTe+TdoeO3YsJGEr3v3gkmnRJWNjx461li1b2ptvvmmffPKJtWnTxubNm2cXXnhhnPs/efK0pSSd1H4UGXna1/sDOL+QUvj7Bc4tJJemTZsmuGhBczQEy58/f7wtFVK6CCEteODDxhbl07jb8/49/7s0FekXXwjDD9L6efhfk3EltYiIxB8v/V8c1+PCwzO5/6Pj22emTGGWOXMmq1btBuvX76Bt2fKr6x27du0aGzp0mG3bttVtE9fj8+U739asOfyf492+/Te7+uqyIdtVqHCNzZkzwy3T/osWLRpYHxGRx/0MC4sKrP93+b/r9Xr0uo4ePWQHDuy3q64qHVhXrlzZwPHYvHmru0K+QYM7QsajZX/+ucttIyVKXBb4PVeunBYdfdrtb8eObdawYaOgcWW27t0fd79v2/abjRo1wsaMeT2wX+UId+3acVbvn9/5NmmrjH7M5Kx3P1u20MbHaotQunRp18tWrrrqKvvmm29szpw51rFjxxQcNQAAAJC0RQsxY+LUKkJIC5SwjY7yd9KWLwkzDt5r+EFaPg9TuvjtbI6V/i+O63GnTkWZhh/fPqOiou306SjLlCnCqlS51r788ksrUqSYq1wND8/q1mmbuB5fsuSVNnnyRDtw4FCsFgkrV/5s778/1Z599gULD49widLgfZw4ccrtW8u0/8yZw2M9h+5764OPi16PXldkZFTIdv+uyxw4HidOnHQVtm+9NSmwzyxZMtnJk1FWsGBB++WXfydZjY7OFHj8v8/17+vVmLwxxnT69ClXrVu58rUhy9VOKi2f62mup22hQoVs//79rmQ6uPpACVvNWhdMb3rx4v/27PBceumltnv37hQbLwAAAJAcRQsxCxYAAED6Ub16DTeR15IlX9lNN/3btuBM1EogV65c9sEH78daN23aVNu7908XOxQtWiyQIPX88ssqt/xcnH/++ZYvX35bv/6XwLLgicK0f/WzVaX0JZcUcTe1On399dcsMvLkf+5f22/a9L+rjE6fPu0mHlu1aoVLbO/duyewX90mThxvv/yy2tIj31baqnJWjZfVw0sz6Mry5cutbNmylilTaK5ZvcF++OF/s+3Jli1brF69eik6ZgAAAOBcihb27dsXskz3L7jgAg4qAAA+tG7dL7G+cPX6vCpR+d13S0PW5cqV28qUuTpkmfqzagIwXeLfvXvP/3zO8847z7p0edz69+/nnkP9X0+ejLSZMz9w/V2HDx/jtmvQoLFNn/6eayVwxx31XGJz5szp1q1bj3N6zUrGNmzY2N56a4wVKnShSyCPGDEssP7SSy9zieXnnnvaunV70jJlymxDh/a3nDlzuW3/S6NGTax7905ukjH11tUkZ6oY1oRp99/fzAYNetGKFCnq1qn/7cKFn7k+t+mRb5O22bNnt/r161u/fv1swIABtmfPHhs/frwNHDgwUHWrN1vfHtx///02efJkGzFihN199902e/ZsNznZPffck9ovAwAAAEiQ8uXLu/kZdDmoPhDp508//US7LwBAhjR58jHzO/VXjem992a5n/v3/21PPPFvG0+PEo2jRo0LWZY3bz676qqrXetPVbEmRJ06d7gk6JQpE2zGjGkubihd+iobOXKs25cULlzYhgx5xd544zV7773JVqhQYevUqZvVrXu3nauWLVvb8ePHrW/f3m7cDz3UzoYNGxxY/8wzz9srrwyxrl0fceuvv/4GN/FYQijpreT122+/aX/9tc9KlbrKhgx51bJmzWa1atWxv//+2956a7T7edllxW3w4FdcEjc9Cov26wxZ/9/XS0nbBQsWuH4YmlzswQcfdOuuvPJKl8D1ZtJVFW7//v3dRA0lSpSwPn36WJUqVeLd9969hy0lNW+e3dL7H0E1fU6PPUTgD5xf4PxCWsTfruRRsOB/V2n4lWLYiRMn2nXXXRerEEGXEtauXdvq1q3rihLee+89mz9/vouFVVWT2vFsWtBiXhPf97SdXHdaag8BKYC///ADzkP4Befi2cWzvq209aptBw8e7G4xbdiwIeR+pUqVbObMmSk4uvSh+Sf3Jdm+wjKFJVmQTDALAAAygurVqwcKEVSkMGbMGOvbt69NmzbNJXjHjh0bZ8IWAAAA6Zuvk7YAAABAehKz8CDm/XLlytmsWf9eVgkAAICMK3RGLwAAAAAAAABAqiJpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAAAAAAAAwEfCU3sAAAAAAAAAQLDmn9yXogdkct1pCd62f/9+Nm/ex/GuHz58tFWsWDnRYxg3boz9/PNyGzlyrJ2N6tUrn/Vze3766Ufr0qWjLVnyY7zb/PnnH/bOO2/Zd98ttcOHD1mRIkWtSZNmdvvtdS0pnDhxwvr1623Lln1nV11Vxi688CK3vE+ffnFu36jRXda6dXu78867LD0haQsAAAAAAAAkUNeuT1jHjp3c71988Zm9995ke/PNCYH1uXPnSZVjOWfO/GR/7h07ttsjj7S1smXL2wsvDLK8efPZjz9+b0OHDrD9+/fbAw80P+fnWLbsW3d7441xVqBAQcuWLZtlRCRtAQAAAAAAgATKmTOnu3m/Z8qUyfLnL5Dqxy8lxvDyy4OsZMnLrX//IRYWFuaWXXzxJXbyZKSNGfO61at3j+XKleucnuOff464ZHCpUqUtIyNpCwAAAAAAACQRtQ8YNmywq0BV8lGX7bdq1cYyZ87s1qutwNixr9u2bb/ZJZcUtc6du1nlyte6dadPn7KXXx5sn34617JmzWrNmrW0++//t3q1U6f2VqXKdbZy5c+2YsXPdsEFhaxbtyftuuuuj9Ue4dixYzZixDBbtGihW1ejRk177LEn3D63bt3i1q1evco9X6lSV1mPHn3s0ksvO+Pr2rPnT1u+/AcbOvS1QMLWU69efbv88lKWPXv2wLYjRrzijoGS2rVr32aPPNLVIiIibO7cj9ytQoVKNnPmNDt9+rTVrXu3derUzbWdGDDgucDr6d27r2sZEdweYfbsGTZx4ng7cuSINW3aImQc0dHRNmHCOJs16wM7ceK4lStXwbp372mFCxcO7POZZ563yZPfsZ07d1jp0mXs6aefs4suutitX7fuFxs+fJj9+ut6K1iwkLVt28FuvfU2t07HXet0/C655BLXkuHmm2tZcmEiMgAAAAAAACAJKGnYp08Pl6x9++0pLun42WfzbdKkt936LVs2W8+e3eymm26xd9551yUEe/V63P76a59br0Rqlizh7rHNm7eykSNftd9+2xrYv5KVesykSe/b5ZdfYYMHv2hRUVGxxjFo0Au2atVKGzToZXvllddt9eoV9uabo9y2en71iX3nnak2atR4lzQdNWr4f762zZs3utdXuvRVsdaphUH58tdYeHi4nTx50rp0ediOHz/m+vMOGDDYli5dYm+88b/nWLNmlW3f/puNGjXOunXrYdOnv2c//rjMatWqbV26PO4S0mr3oPvB1DZh+PCXrX37R2z06PG2fv1a++OP3YH1M2a8bwsWzLO+fV+0MWPesXz58ln37o/aqVOnQnoHP/bYkzZu3CQ7ePCAOy6yf//f1q3bo+646vi3bPmQ61+8ceOv7v3p0eMxu/POejZx4nvWrFkr69//OZfITS4kbQEAAAAAAIAkoEpUJRFVuVq06KWu6vXRRx+zadPedes/+WSO6wf74INt3QReLVo8aPfd19RVjUrBghdY587dXcsBTe6VM2culyz1XH99dVe5q/Wq3lVF699//xUyhkOHDtmiRV9Y9+49rFy5a+zKK0vZk0/2dtWmmuSrfv17XVWr9qF1d9xRz1WP/pfDh/8dY44c/7aGiM+yZUtt37499swzL1iJEiWtSpVrXbXrrFnT7ejRo24bJY+9Y3TbbXe6lgvr1q21rFmzhbScyJo1tJ/tRx/Nttq1b3eTnhUvXsJ69XrWIiKyBtZPnTrJVfTquBcrdql73Toeqm726LhWqlTFihcvafXrN3LPK59/vsBy5crjEroal45zhw6PumM2c+Z0Vw19771N7JJLirgx3313A5s2baolF9ojAAAAAAAAAElg27atdujQQbvtthqBZUpQKvGnqs7t27fZlVeG9mpt1+7hwO+qgA1uPaAEZmRkZOC+Er2eHDlyuJ/BVaSya9cOVz0b3BO2fPkK7iZKVM6f/4mrUlW164YNG1xF6n/Jk+ffSc4OHz5sefPmjXc7VQZrnLlz5w4sK1u2nBuTxiaqRA5O/p53Xo5YryO+fdev3zBwP0+e8wOtDZQQVhK7b99eLunr0bHXBGrxHUO1iBC9N1dccUXIY73WFO+9N8m++eZrq137xsA6jTd4X0mNpC0AAAAAAACQBJSYVJWm2hLEpCSl2gecSXDC0KOWBJ64Hh+8Pr5tPEpstmvX0iU7q1e/ybVaUOL23Xcn23+54opSLqG8YcM6q1r1hpB16qGrNg+qKg6ufPWcPh0V8jNLliz/+TriE3MztZPwjr288MJgK1q0WMg2wQnkmMfHe94zHTftu06dO6xly9Yhy//r/TwXtEcAAAAAAAAAkkCRIsXcRGTnn5/XXUav2+7du1wfVSU8NfHYpk3/a3cgHTu2ts8//zTJjr8qTzXp2caN/3uer79eZK1bN3OTeu3bt9dNWNa0aUs3sZnGm5CEqaprq1Sp6loCxNxebR9WrVphhQoVdglTVbaq4tjzyy+r3JjUkuFcFC9ewtav/yVw/+jRf2znzp3u91y5crkK3r//3hc49hqPeumqiva/aPvNmzeFvLZnn+1lU6dOdO+rJi7z9qvb119/5frnJheStgAAAAAAAEASuPbaqq537PPPP+MSgJqoasiQAW6iLiUt1U921aqf7b33JrskoCYo27p1s11zTcUkO/6q6FXP19deG2pr165xbRDGjHnDKlW61rU4UFWskri7d//uesTOmDHNTR6WEJ07d7O1a3+xZ57p6fatZKiqdN94Y4R17NjJVbQqEazE8QsvPOuOwY8//mCvvDLU9aJVYvVc3HvvfbZw4ef24YezbNu232zw4P524sTxwPomTZra2LGjbMmSxS5xrAnZVq9e6aqf/4sqaQ8ePOiSvHrs3Lkf2ZIlX7nX07BhY1u/fp2NHfuGW7dgwXwbO/Z1K1z4QksutEcAAAAAAACAr0yuO83SIiVmBw0aZq++OtTat29l2bOfZ7fccqt16tTVrVel6YsvDrHRo0e4BOCllxa3wYNfsQIFCibpOLp2fdxeffUl69btUdeKoGbN2q53bkREhJsE7eWXB7teuZooTJOEKbm5d++e/9zvZZcVtzfeeMvGjx9rTz31uKt0VUL0qaeesTp1bg85Bq+8MsQdA/WNVcK2fftHz/l1lS9fwXr16mtvvjnKRowYZnXr3mMlS14RWP/AAy1cC4ihQ/vbP//8Y6VKXWXDho0IaY8QHyWUhw591V577WX74IP3XOK5b98X7fLLr3TrBw8eZqNGjbB3351kBQpcYJ06PeYSvcklLDqhDSPSmb17D6fo8zVvnt186YG7kmxXYZnCLDoqOkP/cUbyiYjIbJGR//anATi/kFbwtyt5FCx4bhUa6UVKx7NpQYt5TZIsHk0uxLkZA3//4Qech/ALzsWzi2dpjwAAAAAAAAAAPkLSFgAAAAAAAAB8hJ628KXcze8zPzo0mbYNAAAAAAAASF5U2gIAAAAAAACAj5C0BQAAAAAAAAAfIWkLAAAAAAAAAD5C0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8JDy1BwAAADKm5s2zmx9NnnwstYcAAAAAIIOj0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtAAAAAAAAAPgISVsAAAAAAAAA8BGStgAAAAAAAADgIyRtAQAAAAAAAMBHSNoCAAAAAAAAgI+QtAUAAAAAAAAAHyFpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAAAAAAAAwEdI2gIAAAAAAACAj5C0BQAAAAAAAAAfIWkLAAAAAAAAAD5C0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtAAAAkIxOnDhhvXv3tsqVK1v16tVt/Pjx8W772Wef2R133GEVKlSwBx54wH755RfeGwAAgAyIpC0AAACQjIYMGWJr1qyxCRMmWN++fW3kyJE2f/78WNtt3LjRHn/8cevQoYPNmTPHSpcu7X4/duwY7w8AAEAGQ9IWAAAASCZHjx616dOnW58+faxMmTJWu3Zta9u2rU2ZMiXWtt98842VLFnS6tevb0WLFrXu3bvb3r17bdOmTbw/AAAAGUym9HIpmWfnzp3ucrJly5alyBgBAACA+Kxfv95OnTrl4lNPpUqVbOXKlRYVFRWy7fnnn+8StMuXL3frZs6caTlz5nQJXAAAAGQs4ZZGLiX7/fffrWfPnnbRRRfZ7bffHu9j+vXr5yoaAAAAgNSmStm8efNaREREYFmBAgVcccKBAwcsX758geV33nmnLVy40Jo2bWqZM2e2TJky2ZgxYyxPnjxx7jtLlswWFpYiLyPNyBQWZlG+Lksxi4jInNpDQAoID+d9RurjPMwYmjTJan43Y8ap1B5CmhTu90vJ3nzzTXcpmW7q86VLyeJL2n744Yf2zz//pPhYAQAAgLioH21wwla8+5GRkSHL9+/f75K8zz77rJUvX97effdd69Wrl82aNcvy588fa98nT57moMcQFR1t0VHRvj4ukZG8bxkF7zX8gPMw/YuO9vf/e3Lq1GnOxbOQKT1cSuYFuUOHDrXnn38+hUcKAAAAxC1r1qyxkrPe/WzZsoUsf+mll+yKK66wZs2a2dVXX20vvPCCZc+e3WbMmMHhBQAAyGAypdVLyWIaNGiQNWjQwC6//PIUHikAAAAQt0KFCrniAhUjBMe5Stjmzp07ZNtffvnFSpUqFbiv9gi6rzZhAAAAyFjC08OlZEuXLnUTNnz88ccJ3n9K9wAL82vDsUxhvuwhloTDSlL0IEs99GMC51f649f/G5Pybz1/u1C6dGkLDw+3FStWuMl1RXFr2bJlXVI22AUXXGCbN28OWbZ161a3LQAAADKW8LR+Kdnx48dd36++ffvGusTsTFK6B5hve4wkYc8vJWyTqoeYX1uR0Q+I44/0i3/fKc+v/zcm9bnAuZWxqb1B/fr13WS5AwYMsD179tj48eNt4MCBgarbXLlyuTj2vvvus6eeesq1RlCLMM3voCpbXU0GAACAjCU8LVxKpuqE+C4lW7Vqle3YscO6dOkS8vh27dq5AJketwAAAEhNmkxMSdtWrVpZzpw5rXPnzlanTh23rnr16i6B27BhQ7vzzjvdpLpjxoyxP/74w1XpTpgwIc5JyAAAAJC+haf1S8nKlStnCxYsCHmsguAXX3zRqlWrluLjBgAAAGJW2w4ePNjdYtqwYUPI/caNG7sbAAAAMrbw9HApWbFixeKs1KUqAQAAAAAAAEBak0TTRiXfpWRlypRxl5I999xzsS4lmzt3bmoPEQAAAAAAAAAyRqVtYi8lS+g6AAAAAAAAAPAzX1faAgAAAAAAAEBGQ9IWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAAAAAAAAwEdI2gIAAAAAAACAj5C0BQAAAAAAAAAfIWkLAAAAAAAAAD4SntoDAAAAAJA2NG+e3fwsrFlqjwAAACBpUGkLAAAAAAAAAD5C0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtAAAAAAAAAPhIeGoPAAAAwE+af3Jfku0rLFOYRUdFJ8m+JtedliT7AQAAAOB/VNoCAAAAAAAAgI+QtAUAAAAAAAAAHyFpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAj4ak9AAAAAPy33M3v8+VhOjR5WmoPAQAAAEh3qLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtAAAAAAAAAPgISVsAAAAAAAAA8BGStgAAAAAAAADgIyRtAQAAAAAAAMBHSNoCAAAAAAAAgI+QtAUAAAAAAAAAHyFpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+Eh4ag8AAAAAAAAAQPrUZE4ji46KNj+bXHea+Q2VtgAAAAAAAADgIyRtAQAAAAAAAMBHSNoCAAAAAAAAgI+QtAUAAAAAAAAAHyFpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAAAAAAAAwEfCz+ZBR44csS1btlhkZKRFR0eHrKtSpUpSjQ0AAAAAAAAAMpxEJ20//vhj69Onj504cSLWurCwMFu3bl1SjQ0AAAAAAAAAMpxEJ21ffvlla9asmT3yyCOWM2fO5BkVAAAAAAAAAGRQie5pu3//fmvatCkJWwAAAAAAAADwQ9K2Zs2a9tlnnyXHWAAAAAAAAAAgw0tQe4RevXoFfj958qQNGTLEFixYYEWLFrVMmULzvgMHDszwBxUAAAAAAAAAUqynrfrY1q9f/6yfEAAAAAAAAABwjknb4OrZH374wa655hrLkiVLyDaRkZG2ePHihOwOAAAAAAAAAJBUPW1btmxphw8fjrV806ZN1r1798TuDgAAAAAAAACQ2ErbqVOn2vPPP29hYWEWHR1t1apVi3O7G264ISG7AwAAAAAAAACcS9K2adOmdvnll1tUVJS1atXKhg8fbnny5AmsVzI3e/bsdsUVVyRkdwAAAAAAAACAc52IrEqVKu7nF198YRdddJFL1AIAAAA4sxMnTthzzz1nCxYssGzZslnr1q3dLS4bNmywfv362S+//GLFihWzPn36WNWqVTnEAAAAGUyCk7aep556Ks6ErZZpcrKCBQvaHXfcYTfddFNSjREAAABIs4YMGWJr1qyxCRMm2O+//249e/Z0RRC33357yHaaN0LJ3Jo1a9qgQYNszpw51qlTJ/v0008tf/78qTZ+AAAApIGJyFRx+9NPP7nkbO3ate3WW2+1Cy+80JYvX24XXHCBa5OgCclmzJiRPCMGAAAA0oijR4/a9OnTXcVsmTJlXPzctm1bmzJlSqxtZ82aZeedd56rtFWVbZcuXdxPJXwBAACQsSS60vbbb7+1Xr16WbNmzUKWV6pUyVUDKADVJVzDhg2ze++9NynHCgAAAKSYDz/80N555x3bvn27S6hOnDjRFS60b98+wftYv369nTp1yipUqBASN48ePdrNF5Ep0/9qKL7//nurVauWZc6cObCMQggAAICMKdGVtmvXrrVq1arFWn7ttdfa6tWr3e9XX3217d69O2lGCAAAAKSwqVOnurYGDRs2tJMnTwZi3HHjxtnIkSMTvJ+9e/da3rx5LSIiIrCsQIECrs/tgQMHQrbdsWOH5cuXz5555hkXb993333uajYAAABkPImutC1VqpRNnjzZXeIV3NtWgW3JkiXd70reFi5cOGlHCgAAAKSQSZMm2Ysvvmg333yzvfzyy27ZPffcY+eff749++yzrtdsQhw7diwkYSve/cjIyFitFMaOHWstW7a0N9980z755BNr06aNzZs3z7UjiylLlsyW0nMD+30y4kxhYRaV6LKUlBUR8b9KapydJk2y+v7QzZhxKrWHAFh4OH9vMgK//98s/P+cQklbffPfrl07W7RokV111VVu2bp16+zIkSPuMi9VAzz55JMumAUAAADSIk0YVqJEiVjLixQpEqtC9kyyZs0aKznr3c+WLVvIcrVFKF26tOtlK4q1v/nmG9eCrGPHjrH2ffLkaUtp0dHR5mdR0dEWHeXvMUZGpvz7lt74/TyUU6dO817DF/ibk/6lhb+J/P+cQklbXRb22WefuW/+f/31Vxdc3njjjVa3bl03ccLOnTtt2rRpriIXAAAASIvKly9vs2fPts6dO4d8KBo/fryVK1cuwfspVKiQ7d+/3/W1DQ8PD7RMUMI2d+7cIduqX27x4sVDll166aW0HQMAAMiAEp20lZw5c1qTJk3iXHfJJZec65gAAACAVPX000+7Ccd0dZkqY5977jnbunWrHT9+3N56660E70eVs0rWrlixwipXruyW6cq0smXLhkxCJtdcc4398MMPIcu2bNli9erVS6JXBQAAgHSbtN21a5e9+uqrrm+tKgZilmF/8cUXSTY4TdCgAHnBggWuGqF169buFhcF1K+88oqb3VeJ48cee8zNvgsAAAAk1hVXXGGffvqpffTRR7Z582Y7ffq0iy3vvvtuy5EjR4L3kz17dqtfv77169fPBgwYYHv27HHVugMHDgxU3ebKlcvFuvfff7+bO2LEiBHueVTpq8nJ1EsXAAAAGUuik7Y9evRwl3g1a9bMVdwmJ83Yu2bNGpswYYLrK9azZ0+76KKL7Pbbbw/Zbv369W4yCI2tRo0atmTJEuvatat98MEHtGkAAADAWfnuu+9ce4NGjRq5+/3793dVsjfddFOi9tOrVy+XtG3VqpWLn9VyoU6dOm5d9erVXQK3YcOGdvHFF7sqXj2PJiRTT1391BgAAACQsSQ6abtq1SqbNWuWlSxZ0pKTZs+dPn26mzm3TJky7rZx40abMmVKrKTtxx9/bFWrVnUz7UqxYsVs4cKFbqZdeusCAAAgsSZNmuSu4tIkvB61OdDVXE899ZTdd999iaq2HTx4sLvFtGHDhpD7lSpVspkzZ/KGAQAAZHCJTtpqMoS///7bkpuqZ9V+oUKFCiFB7OjRoy0qKiqkB1iDBg3s5MmTsfZx+PDhZB8nAAAA0p+3337bXn75ZbvlllsCy3TVl/rSqjI2MUlbAAAAINmTtu3atXMTMzz00EOuojVLliwh66tUqWJJQf298ubNaxEREYFlBQoUcH1uDxw4YPny5Qss16VjwVSR++2337q+YAAAAEBiqR1Y0aJFYy2/7LLLbN++fRxQAAAA+K+nrWiCsJjCwsJs3bp1STKwY8eOhSRsxbuvGXzjoypg9QmrWLHiGSciy5Ils4WFWYrRsfGlTEk3rkxhYRaVKan2lTT7SWoREZnNj5o0yWp+9P77J5JsX+Hh/jz2SB84v1IH/zcmDv83pixd4aUJwVRVq/YGouIBXfUVfCUYAAAA4IukrdoWpISsWbPGSs569zW7blxU9aAK4OjoaBs+fHhIC4WYTp48bSlJY/KlqKQblxK20Um0vyQcVpKKjEzZ8yatn19Jfbz8evyRPnB+pTy//u3i/8bESa//dp599llr3bq1myhM7cFk+/bt7sqvN954I7WHBwAAgHQu0UlbOX36tH399df222+/uZlut27dasWLF7dcuXIl2cA0S64uS1NfW0364LVMUMI2d+7csbb/888/AxORTZw4MaR9AgAAAJAYao0wd+7cQMyreFTJWyVxM2fm6g8AAAD4LGm7e/duV3Vw8OBBd1MLgrfeest+/vln97NUqVJJMrDSpUu74HjFihVuwgdZvny5lS1bNlYF7dGjR61t27ZuuRK2BQsWTJIxAAAAIONSa64ztdsCAAAAkkuiO5A+//zzLomqqgOvx+ywYcPshhtusP79+yfZwNQ7rH79+tavXz9btWqVff755zZ+/PhANa2qbo8fP+5+HzNmjLtcbfDgwYF1uh0+fDjJxgMAAICMY+3atda0aVNXMKBigpg3AAAAwFeVtj/++KNNmzYt5LKwLFmy2COPPGINGjRI0sH16tXLJW1btWplOXPmdBOM1alTx63TpWmaGELtGT799FOXwG3cuHHI4zWeQYMGJemYAAAAkP717t3btf567bXXXBwKAAAA+Dppq56yf/31l1122WUhy9XXNqkDWlXbqnrWq6ANtmHDhsDv8+fPT9LnBQAAQMa2ZcsW++ijj6xYsWKpPRQAAABkQIluj3D//fe72XQXLVoUSNbOmDHDnnnmGWvUqFFyjBEAAABIUWqBsHnzZo46AAAA0kal7aOPPmq5c+d2bQuOHTtm7du3t/z589uDDz5obdq0SZ5RAgAAACnonnvusaefftq14lK1rdqBBdPcCwAAAIBvkrYff/yx3XXXXdaiRQs7evSonT592vX7AgAAANKLt956y7UFmzt3bqx1YWFhJG0BAADgr6Ttc889Z++//76df/75dt555yXPqAAAAIBUtHDhQo4/AAAA0k7S9rrrrnPVth07drSIiIjkGRUAAACQyg4fPmwffvih/fbbb/bwww/bypUrrWTJklakSJHUHhoAwAeaN89ufjZtWmRqDwFASiZt//rrL3vjjTds9OjRli9fPsuaNWvI+i+++OJcxgMAAACkul9//dVatWplF154ofu9ZcuWtmDBAuvevbuNGTPGrr322tQeIgAAANKxRCdt77vvPncDAAAA0qsXX3zRHnjgAevSpYtVqFDBLRs4cKArWhgyZIh98MEHqT1EAAAApGOJTtru2rXL2rRpY9mzh14GcOTIERs5cmRSjg0AAABIFatXr3aJ25juv/9+mzJlSqqMCQAAABlHgpK2W7ZscW0R5PXXX7dSpUpZnjx5QrbRZWPvvfeePfXUU8kzUgAAACCFqKJ269atVrRo0ZDlP/30k+XPn5/3AQAAAKmftN2zZ489+OCDgfudOnWKtY0qb9X3CwAAAEjr2rVrZ08//bSbfDc6Otq+++47mzVrlk2YMMG6deuW2sMDAABAOpegpG3VqlVt/fr17veaNWu6Hl6qPgAAAADSI7VBuOCCC2zcuHGWLVs218f2sssusxdeeMHuvPPO1B4eAAAA0rlE97RduHBhyP39+/dbzpw5LUuWLEk5LgAAACBVqVhBNwAAAMC3SdvPPvvMpk2b5iZkKFSokG3bts26du1qGzZssIiICGvWrJk9+eSTFhYWlrwjBgAAAJJBYibVjatdGAAAAJCiSdtPPvnEevbsaQ0aNHAJWlEvr927d9vYsWMtV65c9swzz7hJGdq0aZNkgwMAAABSyrJlywK/R0VF2fLly12LhNKlS7urytQuTPHvTTfdxJsCAACA1E/avvPOO9arVy9XTSurVq2ytWvXusTtjTfe6JZ1797dBg0aRNIWAAAAadKkSZMCv6t3bYkSJezZZ5+18PB/Q2ZNSKZ4d9++fak4SgAAAGQECUrabty4MaSi4Ouvv3ZtEGrVqhVYdvnll9vvv/+ePKMEAAAAUtDMmTPdzUvYiuJfTVCmq88AAACA5JQpIRupJcKJEycC97/55hu78MILrWTJkoFle/bssdy5cyfPKAEAAIAUpLYIKlSIacGCBVakSBHeCwAAAKR+pW3VqlXt3XffdX1rV65caT///LO1bt06ZJtx48ZZpUqVkmucAAAAQIp54oknXCuwL7/80kqVKuWWrV692tasWWOjRo3inQAAAEDqJ20VtLZs2dI+/vhj++eff1x/r44dO7p18+bNszfffNN27tzpErsAAABAWle7dm2bPXu2a5GwefNmt+yaa66xAQMGWNGiRVN7eAAAAEjnEpS0VWA6f/58W7p0qWXKlMluuOEG1zJBjhw5YhUrVrTXXnuNS8UAAACQbqgVWI8ePVJ7GAAAAMiAEpS0lWzZslnNmjVjLW/cuHFSjwkAAABIcbqybOTIkW6ehhYtWriJx+IzceLEFB0bAAAAMpYEJ20BAACA9Ozaa6+1LFmyuN+vu+661B4OAAAAMjCStgAAAICZzZkzx11Flj17dnc82rRpE/gdAAAASEmZUvTZAAAAAJ/at2+fbdy40f3++uuv27Fjx1J7SAAAAMigqLQFAAAAzKxevXrWtm3bQC/batWqxXtc1q1bxzEDEK8mcxpZdFS0r4/Q5LrTUnsISGach0AGSNr+10QMwZiUAQAAAGnRCy+8YM2aNbNDhw65SclGjBhhefLkSe1hAQAAIANKUNKWiRgAAACQEZQqVSpQiFCxYkULD+fCNAAAAKS8BEWhnTp1Sv6RAAAAAD5RoUIFmzVrlq1evdpOnTpl0dGhlzkPHDgw1cYGAACA9C/RpQOakOH999+3TZs22enTpwPLIyMjbe3atTZv3rykHiMAAACQovr06WMLFiywG2+80XLmzMnRBwAAgL+Ttk8//bQtXbrUbrjhBps/f77dcccdtm3bNleFQEUuAAAA0oPPPvvMXn/99TNORgYAAAD4Jmm7ePFie+2111zSduPGjfbggw/a1VdfbYMGDXL3AQAAgLQuV65cVqhQodQeBgAAADKoTIl9wIkTJ+zSSy91v19++eW2Zs0a93uTJk3sxx9/TPoRAgAAACns4Ycftv79+9vmzZtdT1sAAADA15W2JUqUcO0RGjVq5JK2y5cvt/vvv98OHz7sEroAAABAWvfmm2/anj17rF69enGuX7duXYqPCQAAABlHopO26lvbtWtXi4qKsnvuucfq1q1rHTt2tA0bNriJGgAAAIC0Tq2/AAAAgDSTtK1Vq5bNmzfPJW0vvPBCmzp1qs2ZM8cqVqxoLVq0SJ5RAgAAACno2muvdT9/++031yJBse9ll11mJUuW5H0AAACA/5K2UqRIkcDvpUqVcjcAAAAgvTh06JD16tXLvvjiC8uTJ4+dPn3a/vnnH6tSpYq9/vrrbqIyAAAAwDdJ2127dtmrr75qq1evdpMyREdHh6xXYAsAAACkZS+++KL98ccfNnfuXCtevLhbtmnTJnvqqads4MCBNmDAgNQeIgAAANKxRCdte/ToYfv377dmzZpZzpw5k2dUAAAAQCpauHChvf3224GErag1wrPPPmvt2rXjvQEAAIC/krarVq2yWbNm0c8LAAAA6VbWrFktU6ZMsZaHhYW5VgkAAABAcoodif6HSy+91P7+++/kGQ0AAADgAzVr1rTnnnvOtm/fHlimScnUNqFGjRqpOjYAAACkf4mutNXlYE8//bQ99NBDVqxYMcuSJUvIek3OAAAAAKRlTz75pD366KN22223We7cud2ygwcP2k033WTPPPNMag8PAAAA6dxZ9bQVVR7EdbnYunXrkmZkAAAAQCrYtm2bXXTRRTZp0iTbsGGDbd682bVL0BVnJUqU4D0BAACA/5K269evT56RAACQCM0/uS/JjldYpjCLjoo+5/1MrjstScYDIHVER0db//79berUqfbOO+/Ytddea1deeaW7PfLII/bll19aq1atrGfPnq5YAQAAAPBN0vaHH36Ic7kCV7VKKFiwoKtMAAAAANKSiRMn2ty5c+311193Cdtgb7zxhi1cuNB69eplRYsWtaZNm6baOAEAAJD+JTpp26dPH9u5c6dFRUVZnjx5XEXCoUOHXNJWN90vV66cjRgxwi644ILkGTUAAACQxKZNm+b61d5yyy3xTk72xBNPuOQuSVsAAAAkp0yJfUCDBg2sbNmyNm/ePFu2bJl9//339tlnn1nlypXdhA3ffPONFSpUyM2sCwAAAKQVu3btcsUHZ1K1alXbsWNHio0JAAAAGVOik7YTJkxwk5BddtllgWVFihRxFbhjxoyxfPnyWdeuXe3bb79N6rECAAAAySZ//vwucXsmf/zxh51//vm8CwAAAPBX0lb2798f57LTp08H7jM5AwAAANKS2rVruxZfJ0+ejHP9qVOnbOTIkVa9evUUHxsAAAAylkT3tG3UqJGbMbdbt2529dVXux62v/zyi7322muudYKSt0OHDo01eQMAAADgZ4888oiLdRs2bGgtWrRwsW6uXLns4MGDLt6dPHmy/fPPPzZkyJDUHioAAADSuUQnbR9//HHLkSOHvfLKK7Znzx63TBOONW/e3Nq0aWNLly618PBwe/bZZ5NjvAAAAECyyJ07t5uM7KWXXrJBgwbZsWPH3HIVKSh5e+edd1rnzp2tQIECvAMAAADwV9JWbQ8efvhhd1NVrRK0CmI9N954o7sBAAAAaY361WpCXRUgaMKxQ4cOuWVFixa1zJkzp/bwAAAAkEEkKGk7e/ZsV1kQERHhfj+T+vXrJ9XYAAAAgFShuLdEiRIcfQAAAPg3aTt8+HCrUaOGC171+5mqcEnaAgAAAAAAAEAyJ20XLlwY5+8AAAAAAAAAgFTsabtv3z7LmzdvoJ/X2rVr7bvvvrN8+fJZnTp17Lzzzkvi4QEAAAAAAABAxpIpIRv9888/1rFjRzfB2G+//eaWzZw50xo1amSTJk2yMWPG2F133WV//PFHco8XAAAAAAAAANK1BCVtR4wYYbt27bLJkydb8eLF7ejRo9a/f38rV66cLViwwObNm2fVq1e3l156KflHDAAAAAAAAAAZPWmrxGyfPn2sUqVKbrKxJUuWuOrbFi1aWJYsWdw2DRs2dMsBAAAAAAAAAGcvQUnbvXv3WtGiRQP3ly5d6vraqrrWU6BAATt27Ng5DAUAAAAAAAAAkKCkbaFChWzHjh3u9+joaPvqq6+sfPnylidPnsA2P//8s1144YUcUQAAACDIiRMnrHfv3la5cmVX9DB+/Pj/PD47d+60ChUq2LJlyziWAAAAGVB4Qja65557XA/brl272nfffWe7d++2xx9/PLB+/fr1NmzYMLv77ruTc6wAAABAmjNkyBBbs2aNTZgwwX7//Xfr2bOnXXTRRXb77bfH+5h+/fq5eSQAAACQMSUoafvwww/bkSNHXIWAetp26dLF6tWr59YNHjzY3n77bbv55pvddgAAAAD+pcTr9OnT7c0337QyZcq428aNG23KlCnxJm0//PBDN38EAAAAMq4EJW3Dw8OtV69e7hZT/fr17a677rKrrroqOcYHAAAApFm6Iu3UqVOu1YFHk/uOHj3aoqKiLFOm0G5l+/fvt6FDh7oWCl6RBAAAADKeBCVtz+TKK69MmpEAAAAA6Ywm9M2bN69FRESETOCrPrcHDhywfPnyhWw/aNAga9CggV1++eWpMFoAAACkm6QtAAAAgLgdO3YsJGEr3v3IyMiQ5UuXLrXly5fbxx9/nKDDmSVLZgsLS9kjr1ZpfpYpLMyiEjTVcuqJiMic2kNI8/x+HgrnYsbg93OR8zBj8Pt5KJyLZ4ekLQAAAJBMsmbNGis5693Pli1bYNnx48ft2Weftb59+4YsP5OTJ09bSouOjjY/i4qOtugof48xMjLl37f0xu/noXAuZgx+Pxc5DzMGv5+Hwrl4dkjaAgAAAMmkUKFCrk+t+tpqngivZYISs7lz5w5st2rVKtuxY4eb8DdYu3bt3BwSzz//PO8RAABABkLSFgAAAEgmpUuXdsnaFStWWOXKld0ytUAoW7ZsyCRk5cqVswULFoQ8tk6dOvbiiy9atWrVeH8AAAAyGJK2ADKc3M3vMz86NHlaag8BAJDEsmfP7ipl+/XrZwMGDLA9e/bY+PHjbeDAgYGq21y5crnK22LFisVZqZs/f37eFwAAgAzG5236AQAAgLStV69eVqZMGWvVqpU999xz1rlzZ1dFK9WrV7e5c+em9hABAADgM1TaAgAAAMlcbTt48GB3i2nDhg3xPu5M6wAAAJC+UWkLAAAAAAAAAD5C0hYAAAAAAAAAfMTXSdsTJ05Y79693Uy76velSRvis3btWmvcuLGVL1/e7r33XluzZk2KjhUAAAAAAAAA0n3SdsiQIS75OmHCBOvbt6+NHDnS5s+fH2u7o0ePWvv27V1yd+bMmVahQgXr0KGDWw4AAAAAAAAAaYlvk7ZKuE6fPt369OnjZtutXbu2tW3b1qZMmRJrW824mzVrVuvRo4eVKFHCPSZHjhxxJngBAAAAAAAAwM98m7Rdv369nTp1ylXNeipVqmQrV660qKiokG21TOvCwsLcff2sWLGirVixIsXHDQAAAAAAAADnItx8au/evZY3b16LiIgILCtQoIDrc3vgwAHLly9fyLYlS5YMeXz+/Plt48aN8e5/6NABtnr1KkspmfyaHn8/6QaWKVOYRUVFJ8m+6vv1eLW83/zIr+dXmTo/Jtm+9J1MdNKcXlapcGXzJZ+eX8uX+/MEq1TJf3+/HuoR+n+RX5yu5M9z3q9/u/i/0f9/u+bN+yTFnxMAAABISb5N2h47diwkYSve/cjIyARtG3O7YE8+2TtJxwsd88wWGXmaQ4GA5p/cl2RHIyxTmEUn0ZcCE+u+lyT7ySiaN89ufjRx4jHf/f3K3TzpzvmkdGgi53xq4f9GAAAAAGfDrzUurkdtzKSrdz9btmwJ2jbmdgAAAAAAAADgd75N2hYqVMj279/v+toGt0FQIjZ37tyxtt23b1/IMt2/4IILUmy8AAAAAAAAAJCuk7alS5e28PDwkMnEli9fbmXLlrVMMZrglS9f3n7++WeL/v+Gl/r5008/ueUAAAAAAAAAkJb4NmmbPXt2q1+/vvXr189WrVpln3/+uY0fP95atmwZqLo9fvy4+/3222+3Q4cOWf/+/W3Tpk3up/rc3nHHHan8KgAAAAAAAAAgnSRtpVevXlamTBlr1aqVPffcc9a5c2erU6eOW1e9enWbO3eu+z1nzpw2ZswYV4nbsGFDW7lypY0dO9bOO++8VH4FAAAAAAAAAJA44eZjqrYdPHiwu8W0YcOGkPvlypWzWbNmpeDoAAAAAAAAACCDVdoCAAAAAAAAQEZD0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPhKf2AAAASC8OTZ6W2kMAAAAAAKQDVNoCAAAAAAAAgI+QtAUAAAAAAAAAHyFpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAAAAAAAAwEdI2gIAAAAAAACAj5C0BQAAAAAAAAAfIWkLAAAAAAAAAD5C0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPhKe2gMAkH5NrjstyfYVEZHZIiNPJ9n+AAAAAAAA/IpKWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAAAAAAAAwEdI2gIAAAAAAACAj5C0BQAAAAAAAAAfIWkLAAAAAAAAAD5C0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtAAAAAAAAAPgISVsAAAAAAAAA8BGStgAAAAAAAADgIyRtAQAAAAAAAMBHSNoCAAAAAAAAgI+QtAUAAAAAAAAAHyFpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAACAZHTixAnr3bu3Va5c2apXr27jx4+Pd9tFixbZPffcYxUqVLC77rrLvvjiC94bAACADIikLQAAAJCMhgwZYmvWrLEJEyZY3759beTIkTZ//vxY261fv946depk9957r82ePdvuv/9+69q1q1sOAACAjCU8tQcAAAAApFdHjx616dOn25tvvmllypRxt40bN9qUKVPs9ttvD9n2448/tqpVq1rLli3d/WLFitnChQtt3rx5VqpUqVR6BQAAAEgNJG0BAACAZKIq2VOnTrl2B55KlSrZ6NGjLSoqyjJl+t+Fbw0aNLCTJ0/G2sfhw4d5fwAAADIYkrYAAABAMtm7d6/lzZvXIiIiAssKFCjg+tweOHDA8uXLF1heokSJkMeqIvfbb791bRLikiVLZgsLS9m3LiylnzCRMoWFWZTPG8BFRGRO7SGkeX4/D4VzMWPw+7nIeZgx+P08FM7Fs0PSFgAAAEgmx44dC0nYinc/MjIy3sf9/fff1rlzZ6tYsaLVqlUrzm1OnjxtKS06Otr8LCo62qKj/D3GyMiUf9/SG7+fh8K5mDH4/VzkPMwY/H4eCufi2fH599AAAABA2pU1a9ZYyVnvfrZs2eJ8zL59+6xVq1buQ9jw4cNDWigAAAAgYyACBAAAAJJJoUKFbP/+/a6vbXDLBCVsc+fOHWv7P//805o1a+YSuxMnTgxpnwAAAICMg6QtAAAAkExKly5t4eHhtmLFisCy5cuXW9myZWNV0B49etTatm3rlk+ePNklfAEAAJAxkbQFAAAAkkn27Nmtfv361q9fP1u1apV9/vnnNn78eGvZsmWg6vb48ePu9zFjxtj27dtt8ODBgXW6HT58mPcHAAAgg2EiMgAAACAZ9erVyyVt1ac2Z86cboKxOnXquHXVq1e3gQMHWsOGDe3TTz91CdzGjRuHPL5BgwY2aNAg3iMAAIAMhKQtAAAAkMzVtqqe9Spog23YsCHw+/z583kfAAAA4NAeAQAAAAAAAAB8hKQtAAAAAAAAAPgISVsAAAAAAAAA8BGStgAAAAAAAADgIyRtAQAAAAAAAMBHwlN7AGlF8+bZU/T5Jk8+lqjtq1evbMOHj7aKFSvHWjd37kc2fvxY++CDj+J8bKdO7W3Fip+sT59+dscd9ULWbdv2mzVr1siuuaaijRw5NpGvAgAAAAAAAEC6qbSNjo62l156yapWrWrXXnutDRkyxKKiouLdfsWKFXb//fdbhQoV7LbbbrPp06en6HjTuvDwcPvmm8Wxli9e/KWFhYWlypgAAAAAAACAjMi3lbZvv/22ffzxxzZy5Eg7deqUPfnkk5Y/f35r06ZNrG337t1r7dq1swceeMAGDRpkv/zyi/Xq1csKFixoN998c6qMP60pX76iff/9Mjt58qRlyZIlsHzx4kVWpkzZVB0bAAAAAAAAkJH4ttJ24sSJ1qVLF6tcubKrtn3iiSdsypQpcW77+eefW4ECBax79+526aWXWt26da1+/fr20UdxtwNAbGXLlrOIiAhbvvyHwLJ9+/bazp07rEKFShwyAAAAAAAAICNX2v7555+2e/duq1KlSmBZpUqVbNeuXbZnzx674IILQra/8cYbrXTp0rH2c+TIkRQZb3qgFgg33FDdlixZbFWr3hCostXvap0AAAAAAAAAIANX2qrdgQQnZ1VJK3/88Ues7S+55BK75pprAvf/+usv++STT+z6669PkfGmFzfeWMOWLv06cP/rrxfZTTfRXgIAAAAAAABISalWQnn8+HFXURuXo0ePup+6XN/j/R4ZGfmf++3cubNL8jZp0iTe7bJkyWyJmV8rpSfjiojInOjH6DXF9bjw8Ezutca3z0yZwixz5kxWrdoN1q/fQduy5Ve7+OJLbO3aNTZ06DDbtm2r2+a/xhQenvgxAwnF+ZV6/DoZ4dn8nYwP5xeSC+cWAAAAgDSVtF25cqW1bNkyznWadMxL0GbNmjXwu2TPnj3eff7zzz/2yCOP2G+//WZTp04947YnT55O1Hijo6MtJUVGJm583muK63GnTkWZhh/fPqOiou306SjLlCnCqlS51r788ksrUqSYXXNNRQsPz+rWaZuEjOlsxg0kFOdX6kjpv3+pdT5wfiG5cG4BAAAASDNJ2+uuu842bNgQ5zpV4A4dOtS1SVDrg+CWCQULFozzMepf27ZtW9u+fbtNmDDBTUiGxKtevYbNmvWBXXzxb3bTTbdwCAEAAAAAAIAU5ssZpgoVKmQXXXSRLV++PJC01e9aFnMSMomKirJOnTrZzp07bdKkSVaiRAnLiNat+yVW+whVy8qJEyfsu++WhqzLlSu3lSlzdciyatVutKFDB9iuXTuse/eeKTBqAAAAAAAAAL5P2soDDzxgL730khUuXNjdf/nll61169aB9X///bdrnZAjRw774IMPbNmyZTZq1CjLnTt3oCo3S5Ysdv755yfJeCZPPmZ+N2rUiFjL3ntvlvu5f//f9sQTXULWlS1b3kaNGheyLG/efHbVVVdb5syZk+zYAQAAAAAAAEgHSds2bdrYX3/95SpolUBs1KiRPfjgg4H1ut+gQQM36dinn37qqm07dOgQso9rr73WVd5mBEuW/BjvuksuKWJ33nlXvOtHjhwbcj9mIrdNm9DjCgAAAAAAACADJm2VqO3Vq5e7xWXhwoWB38eNC00yAgAAAAAAAEBalSm1BwAAAAAAAAAA+B+StgAAAAAAAADgIyRtAQAAAAAAAMBHSNoCAAAAAAAAgI+QtAUAAAAAAAAAHyFpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+Eh4ag8grWj+yX0p+nyT605L1Pb9+/ezefM+jnf98OGjrWLFyona57hxY+znn5fbyJFj7WxUr175rJ432E8//WhdunS0JUt+POt9AAAAAAAAAGkJSdt0omvXJ6xjx07u9y+++Mzee2+yvfnmhMD63LnzpPiY5syZnyrPCwAAAAAAAKRlJG3TiZw5c7qb93umTJksf/4CqTqm1H5+AAAAAAAAIC2ip20G8Oeff1jPnt2sVq1q1qjRXTZ+/Fg7ffp0YP133y211q2bufWtWj1gP/74fWDd6dOn7OWXB1udOjXsrrvquApeT6dO7W3ChHHWvXsnq1mzmt177z22bNm3Ie0R1N5Ajh07ZkOG9Lc776zlboMH97cTJ064dVu3bnH7qF37JqtZ8wZ75JG29ttvW1Po6AAAAAAAAAD+QtI2nYuOjrY+fXpY3rz57O23p1jv3n3ts8/m26RJb7v1W7Zsdgndm266xd5551279dbbrFevx+2vv/a59atXr7IsWcLdY5s3b2UjR74aklCdOHG8e8ykSe/bFVdcaYMHv2hRUVGxxjFo0Au2atVKGzToZXvllddt9eoV9uabo9y2ev4LL7zI3nlnqo0aNd4llEeNGp6CRwkAAAAAAADwD5K26dzy5T/YH3/sth49+ljRope6ScEeffQxmzbtXbf+k0/mWNmy5e3BB9takSJFrUWLB+2++5rakSNH3PqCBS+wzp2728UXX2JNmjSznDlz2ebNGwP7v/766nbnnXe59a1bt7U9e/60v//+K2QMhw4dskWLvrDu3XtYuXLX2JVXlrInn+xthQsXdtW29evfa506dXP70Lo77qjnqm8BAAAAAACAjIietunctm1b7dChg3bbbTUCy1TdqmTpwYMHbPv2bXbllaVDHtOu3cOB31UBGxYWFrivfrmRkZGB+0r0enLk+Len7qlTp0L2t2vXDlc9W6rU/56nfPkK7ib16zey+fM/sfXr19r27b/Zhg0bLF++fEl0BAAAAAAAAIC0haRtOqdkqSps1ZYgJiVZw8PPfApoQrO4Wi544np88Pr4tvEcPXrU2rVraXnynG/Vq9/kWi0ocfvuu//rnQsAAAAAAABkJLRHSOeKFCnmJiI7//y8dsklRdxt9+5dNm7cGFdBe8klRW3Tpv+1O5COHVvb559/mmRjuOiiiy1z5sy2ceP/nufrrxe5yc9+/nm57du314YPH21Nm7a0KlWuc+ONmfgFAAAAAAAAMgqStunctddWdb1jn3/+Gdu8eZOtXPmzDRkywLJly+YSqeonu2rVz/bee5Nt584dboKyrVs32zXXVEyyMaii9/bb69prrw21tWvXuDYIY8a8YZUqXWt58uSxY8eOuSTu7t2/20cfzbYZM6bZyZMnk+z5AQAAAAAAgLSE9ggJNLnuNEuLlJgdNGiYvfrqUGvfvpVlz36e3XLLrdapU1e3XpN/vfjiEBs9eoSNHfuGXXppcRs8+BUrUKBgko6ja9fH7dVXX7Ju3R61LFmyWM2atV3v3IiICDcJ2ssvD3a9ckuUKGndu/e0QYNesL179yTpGAAAAAAAAIC0ICw6g16Hvnfv4dQeQroTEZHZIiNPp/YwkE5xfqWe5s2zmx9NnnwsyfbF+YXkwrmVPAoWzJVMe05bUiOe9ev/CZ6wZndbdJS/P96k1WIQP/H7eSicixmD389FzsOMwe/noXAunl08S3sEAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtAAAAAAAAAPgISVsAAAAAAAAA8JHw1B5AWpG7+X0p+nyHJk9L1PaNGt1lf/yxO9bysmXL26hR4yyldOrU3ipUqGRt2nRIsecEAAAAAAAA0hOStulIly6PW61atUOWZcmSJdXGAwAAAAAAACDxSNqmIzlz5rT8+Quk9jAAAAAAAAAAnAN62mYAalkwbtyYwP3du3+36tUru5/yxRcL7IEHGlrNmjdY8+aNbfHiRYFt//zzD+vZs5vVqlXNtWAYP36snT59OrD+q6++tPvvb2i33lrdhg4dZFFRUSn86gAAAAAAAID0haRtBrd//9/2wgvPWosWD9nUqTPszjvvtn79+tihQwctOjra+vTpYXnz5rO3355ivXv3tc8+m2+TJr3tHrt16xZ79tmnrEGDe23cuMl26tQpW7VqRWq/JAAAAAAAACBNoz1COvLSSwPtlVeGhCz78MMFZ3zM3r17XLK1YMELrHDhC+2BB5pbyZKXW0REVlu+/Ac3udnYse9YpkyZrGjRS+3RRx+zAQOeswcfbGtz535k11xT0Zo0aeb29eSTPe3rrxcn62sEAAAAAAAA0juStulImzYdrEaNmiHLsmXLdsbHXH75lXbDDdWtW7dHrWjRYla9eg2766767nHbtm11Fbe33VYjsL3aH5w4ccIOHjxgv/22xUqWvCKwLjw8i11++f/uA0gfJk8+ltpDAAAAAAAgQyFpm46ojcEllxSJtTwsLCzkfnBPWq0bMuRVW7t2jS1ZstgWL/7SZs36wN544023naprBw16OdY+c+TI+f+/RYcsV+IWAAAAAAAAwNmjp20GkCVLFjt69Gjg/u+/7wr8vm3bbzZy5Kt21VVXW/v2j9ikSdOsUKFCtmzZt1akSDE3Edn55+d1yWDddu/e5SY1U7L3sstK2Lp1a0OqcDdt2pjirw8AAAAAAABIT0jaZgClSl1lX375ua1b94u7vfXW6MC6nDlz2uzZH9g777zlkrlLly6x3bt/tyuuKGXXXlvVChcubM8//4xt3rzJVq782YYMGeBaJ2TOnNnuvruBrV+/ziZMGGfbt/9mr702zP78c3eqvlYAAAAAAAAgraM9QgIdmjzN0qr7729mW7ZsskcfbW8FCxa0rl2fsB49HnPr8ucvYP37D7VRo0bYxIlvW968ea1Dh04uYSuDBg2zV18dau3bt7Ls2c+zW2651Tp16urWqfJ28OCXbfjwYTZhwni7+eabrWrVaqn6WgEAAAAAAIC0jqRtOvHBBx/Fuy537jwu+RpsyZIfA79fd9317haXiy++xIYOfS3efVepUtW1VJCIiMwWGfm/frkAAAAAAAAAEo/2CAAAAAAAAADgIyRtAQAAAAAAAMBHSNoCAAAAAAAAgI+QtAUAAAAAAAAAHyFpCwAAAAAAAAA+QtIWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAACAZHTixAnr3bu3Va5c2apXr27jx4+Pd9u1a9da48aNrXz58nbvvffamjVreG8AAAAyIJK2AAAAQDIaMmSIS75OmDDB+vbtayNHjrT58+fH2u7o0aPWvn17l9ydOXOmVahQwTp06OCWAwAAIGMhaQsAAAAkEyVcp0+fbn369LEyZcpY7dq1rW3btjZlypRY286dO9eyZs1qPXr0sBIlSrjH5MiRI84ELwAAANI3krYAAABAMlm/fr2dOnXKVc16KlWqZCtXrrSoqKiQbbVM68LCwtx9/axYsaKtWLGC9wcAACCDCbcMqmDBXKk9BAAAAKRze/futbx581pERERgWYECBVyf2wMHDli+fPlCti1ZsmTI4/Pnz28bN270TTz76afmc3NTewBIAf4/D4VzMSPw/7nIeZgR+P88FM7Fs0GlLQAAAJBMjh07FpKwFe9+ZGRkgraNuR0AAADSP5K2AAAAQDJRj9qYSVfvfrZs2RK0bcztAAAAkP6RtAUAAACSSaFChWz//v2ur21wGwQlYnPnzh1r23379oUs0/0LLriA9wcAACCDIWkLAAAAJJPSpUtbeHh4yGRiy5cvt7Jly1qmTKGhePny5e3nn3+26Ohod18/f/rpJ7ccAAAAGQtJWwAAACCZZM+e3erXr2/9+vWzVatW2eeff27jx4+3li1bBqpujx8/7n6//fbb7dChQ9a/f3/btGmT+6k+t3fccQfvDwAAQAZD0haxzJw506688kqbPn16nEdnx44dbv2TTz4Z72O9W6lSpaxixYrWpUsX27x5s9tm586dbp1+Iv3zzoXff/891rp3333XrRsxYkRg2Zo1a6xNmzZWoUIFd2vWrJl98803gfXe+RPX7ZVXXnH7im+9bjpHkTYdPXrUXn31VZfUKFeunF133XXub0vMWdVXr15tHTp0sMqVK7u/Pw888IBLksTlk08+scaNG7sqtuuvv946d+5s69evj3Nb/U3Uttqnd24uXLgwZBudY8uWLUvCVw0//7/YokULt3z27NmxHqP/87RO2wTvI66bt41+3nrrrXbixImQffH/ZtrXq1cvK1OmjLVq1cqee+4597emTp06bl316tVt7tx/Z1TOmTOnjRkzxlXiNmzY0FauXGljx4618847zzIiYlKkBmJXpAbiXPgd8XDqCE+l54WPKYlRtGhRmzNnjktQxKQPFlqvJMg///xjOXLkCFlfuHBh++CDDwKX9R04cMBeeOEFe/jhh23+/Pkp9jrgH1myZHHJrebNm4cs1zkUFhYWuP/HH3+4D7QPPfSQ9e7d263T+di+fXubOnVqyOWhSp5ceOGFIfvzPtTef//97qcuMdUH4yVLlgS2yZUrV7K9TiQf/a1p2rSpC2ifeuop94WQekROmTLFvd9KmhUpUsS+/vpre+SRR+y+++6zbt26uUl9vvzyS3v88cfd36COHTsG9qkEv6rdHnvsMbvlllvsyJEj9t5777n9jRo1yiVxPX369HF/+5544gmXYDl9+rQ7f7t27WpDhw51iWRkzP8Xvb9vqqQ809+3O++802688caQbfSFQ7t27eymm24K+WJ09OjR7txC+qq2HTx4sLvFtGHDhpD7+lJq1qxZKTg6/yImRWohdkVKIs5FWkA8nEqigSD79u2LLl26dPSsWbOir7zyyujt27fHOj716tWLfuedd6KrVKkSPWPGjJB1un/LLbfEeszPP/8cfcUVV0SvXbs2eseOHe53/UT6p/e6VatW0Q899FDI8sOHD0dXqFAhukGDBtHDhw93yyZMmBB99913x9qHHv/MM8+43xNz/nz33XduW6R9gwcPjq5WrVr0wYMH4zw/nn/++ejjx49H33DDDdHDhg2Ltc2nn37q/ratW7fO3V+zZk10qVKlor/55ptY277wwgvRNWrUcPuTRYsWub+HP/30U6xtX3/9dfc30aPzTecdMsb/i82bN3fnn/6WnThxIuRxjRo1im7SpInbJi5Hjx6Nvu2226KbNm0affr06cD+9H/o1VdfHb1169bAtvy/iYyImBSphdgVKY04F35HPJx6aI+AEKqEVSXi3Xff7WYqVlVRMPVX+/XXX91lyaoYSmglSObMmQPfWiPjqVWrln3//feuktGzaNEid/l6cKW2JmTZtWuXbdu2LeTxqkzSZfDImKKiotzfGlVgx5xpXYYMGeLatajaUZX9bdu2jbWNLkMuUaKEzZgxw93X1QC6VPmGG26Ita0qdf/8809XtettW6NGDdcSISb1pJwwYUISvVKkxf8XdV6oovu7774LLNP5o79j+r8yPoMGDbI9e/a4v2/Bk1Hdc889dsUVV9jzzz+fTK8ISBuISZGaiF2RUohzkRYQD6cekraIVfJ+8803uw+QNWvWdJccezMYy8cff2wXX3yxuzRZwcwPP/zgkmxnog+vr732mhUvXtwuu+wyjngGpAREoUKFbPHixYFln332mevdGEwTrWTLls1dRty6dWt766233JcEemyBAgVSYeTwg+3bt9vff//tkvxxUSJN5436IV966aXxtsBQL1r1uxVtq5nb45IvXz63H00YJJrxvVKlSnFuq/6T2h4Z9/9FLdf64P7Gao2gLzbDw+PuQvXVV1+5Vhxqu3HJJZeErNP+NGHVt99+G+hzCmRExKRITcSuSCnEuUgLiIdTD0lbBOzevdt++umnQCJNlWnqrafJMDz6AKkPraLKs4iIiFgTsGjCKW8SKfVlU6++ffv22bBhwwIVt8h4lOT3khqRkZFucjEtC5Y/f35X1XjvvffaunXrXK/Qu+66y/W5/euvv0K2rVevXuA88yaFQvqk3rWSJ0+ewLKlS5eGvP9169a1gwcPxlmJ69HjvX0lZFtV7XrPf/755wfW6fwNfm7d4ppoDxnj/0XR3zL1TvZ88cUXVrt27Tj3qfNJyVqt19+6uOgLBfVWHjhwYMgVCkBGQUwKPyB2RUogzoXfEQ+nLiYiQ8i3J7rEU5PsyLXXXusSF7osWRVuqjrT5Z7eh1dd1q5Li3Wp6KOPPhpS9TZp0qRAxZD2cabkCDJO4KsWB6dOnXIVZKpgUJI2Jk1kp8uCVWn2yy+/2KeffurOp6efftpNDuXRbNqqwPXo3EX65P39OHToUGCZEqXeF0YLFiywd9991/2t0RdE8dGl6Hnz5nW/J2Rb/Q30tg1+brV58Z5bVxK0aNHCXdqGjPf/oqdatWouya+/WZoQT9XZmuhOE43F1LdvX/fzv9ofaCI9ndu6UkVfXAEZCTEp/IDYFSmBOBd+RzycukjaIuQf4/Hjx0MuA9YM6epf8swzz7j1osvWPUpU6DJRVR15j9PloMWKFePIIoR3fuhc0aXDcVWhKRGrCrPrr7/eJfz1u25qyRFzxu2LLroo1mXFSJ/090SVrj///LOr3vdmYvf+znjJ//Lly9s777zjKha85GwwJdS8HqPaNma1pGfv3r32xx9/BNon6Dn13J6wsLDAc3P1QMb+f9Gj81FfYupqArXWUHI3uF+3R8lefRGlv3X/1VZDH+J69OhhvXr1OmNvXCA9IiaFHxC7IiUQ58LviIdTF+0R4GzdutXWrl3rqhlVQebdXnnlFXdppvqPzps3z02QErxeH0DV0zFmiwQgJiXz1VJDSQ1dRhyzn63oMmSvSjtm8oK+oRn73NFl5JrwK65LxVXtKmrFUrBgQXvjjTdibaMk2+bNmwOXozdq1Mg2bNjgvkCISRXd6qGs/YkuU9fEeUr6xvfcyJj/L8bVIiG+1gjq//7iiy9akyZN3N/ChND/uaroHTBgQJK9LsDviEnhF8SuSKnzjDgXfkU8nPqotEXg2xNVsunDpPrUenQJ++uvv27Tpk0LXAasZcE0o/ZHH33kPtgmhiYx27JlS8gyTdyiKjakT0pqqGpMlw/rFlP79u2tZcuWrt/jAw884CaUUqJMvW3btGmTKmOGP3Tu3NlVxiqB2qlTJytTpoyrqJ0+fbrrg6wex5qMTD1AH374YXcFQOPGje28885ziTQl2tSeo3Tp0m5/mkyxa9eu9uSTT1r37t3dRFJHjx51+5sxY4ZL3HotN5Rg0/n40EMPuXHoUnjtXwnfMWPGWMmSJUN63qqVzIkTJ0LGX6VKFVeNifTz/2LMLytvueUW1/pAE4o8++yzsfb31FNPudYK7dq1c9XcwVSxHd8XU9qnkrdARkFMCj8hdkVKIM6FXxEPpz6Stgj8Y9SET8EfTD1KVvTv399duhHXbOtaP3Xq1Dgr1s5EH2BjUoIuvtm2kfapL6R62sZVZSsVK1Z0l7crYaY2HMeOHXOXGqtnshJwyLiU8FQVtqptVUmr/tr6e6XWBeod6p1Taq2h/rZKqqkPqJKnStQq8R/zvOvQoYMVL17cxo8f75K62p8ua3///fddUjeYvpTSZZL6Wzd8+HA7efKkS9Y+9thjLqkX3FP5pZdeijV+9SalbUz6+38x+MsntenQ+aj/w+JKwH7//ffuZ1x//9QCxpuoMaYSJUq4v4f6ggDICIhJ4SfErkgJxLnwK+Lh1BcWrXIhAAAAAAAAAIAv0NMWAAAAAAAAAHyEpC0AAAAAAAAA+AhJWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAAAAAAAAwEdI2gIAAAAAAACAj5C0BQAAAAAAAAAfIWkLAKno5MmTNmLECKtVq5ZdffXVdvPNN9vAgQPtyJEjSfo8M2fOtJo1a5714/VY7QMAAACIiZgWAJJeeDLsEwCQQC+99JItXbrUXnzxRStSpIjt2LHD+vfvb9u2bbPRo0dzHAEAAOB7xLQAkPSotAWAVDRr1izr2rWrXX/99XbJJZe4n/369bMvv/zS9uzZw3sDAAAA3yOmBYCkR9IWAFJRWFiYfffddxYVFRVYVqFCBfvkk0/sm2++seuuu85OnToVWPfpp5+6FgrR0dGuZcEHH3xg9957r5UrV85at25tu3btss6dO1v58uXtnnvusY0bN4Y837Bhw6xixYp244032qRJk0LWqf3BHXfc4fbVsGFD++GHH1LgCAAAACCtI6YFgKRH0hYAUlHLli1d8lQJ2L59+7qk7PHjx61kyZJWp04d97uSup558+a5xKoCY3n11Vft8ccft6lTp9ratWutQYMGdsMNN7hkbvbs2V2S1qOE7oYNG+z999+37t272+DBg23ZsmWBhO0LL7xgHTp0sNmzZ7t9tG/f3v78889UOCoAAABIS4hpASDpkbQFgFT06KOP2tChQ61w4cI2bdo069Kli6uCnTFjhuXIkcNuueUWmz9/vtv22LFj9tVXX1ndunUDj1dFrBKsmsSsatWqdvnll9sDDzzgft599922ZcuWwLZZs2a1QYMGuXVK7t5111323nvvuXVKHLdo0cLq169vxYsXtyeeeMKuuOIKmzx5ciocFQAAAKQlxLQAkPRI2gJAKlNyVclTTUimSRyUVO3Tp4+tWbPG6tWrZ59//rlrkbBo0SK74IILXILWo8nLPNmyZbOLL7445L5m8g3eNm/evIH7V111lW3evNn9rp9qixDsmmuuCawHAAAAiGkBIOWQtAWAVLJ+/XpX+epRQlXVr6p6VeWt2iLcdNNNdvr0addfVq0T1BohWObMmUPuZ8oU/5/1mOvURzdLliyBKtyY9LzBvXYBAAAAYloASBkkbQEglSgp+vbbb7tetMEiIiJclWy+fPnc77Vr17bPPvvMTUwW3BohsXbs2OFaLHhWrVrlWiHIZZddZitXrgzZXve1HAAAACCmBYCURdIWAFJJmTJl7Oabb7ZHHnnEPvroI9u5c6etWLHCTUgWGRnpJiITtUjQxGKqvlXrhLN14sQJ69mzp23cuNG1Y1DlbqtWrdy6Bx980PWv1SRkW7dudW0aVAncqFGjJHu9AAAASH+IaQEgeYQn034BAAnw6quv2ujRo23kyJH2+++/23nnnWfVq1d3CdScOXO6ba677jo3Kdmdd955Tse0dOnSVqhQIbvvvvtcK4YBAwYE+uNq3/v27bPhw4fb3r173bbjx4+3EiVK8D4CAACAmBYAUlhYdHR0dEo/KQAg4Y4cOWLVqlWzjz/+OGTiMQAAACCtIKYFgMSh0hYAfErfqamFwYIFC6xChQokbAEAAJDmENMCwNmh0hYAfKxWrVqWOXNmGzVqFK0KAAAAkCYR0wJA4pG0BQAAAAAAAAAfyZTaAwAAAAAAAAAA/A9JWwAAAAAAAADwEZK2AAAAAAAAAOAjJG0BAAAAAAAAwEdI2gIAAAAAAACAj5C0BQAAAAAAAAAfIWkLAAAAAAAAAD5C0hYAAAAAAAAAfISkLQAAAAAAAAD4CElbAAAAAAAAAPARkrYAAAAAAAAA4CMkbQEAAAAAAADAR0jaAgAAAAAAAICPkLQFAAAAAAAAAB8haQsASFVRUVG8AwAAAAAxM4AgJG2BDK5FixZ25ZVXhtxKlSplFSpUsHr16tnbb7+d2kNM98f+2WefPed9zZw50+2rbNmy8W6zc+fOWO916dKl3Xtdt25de//99y25PPXUU+752rRpE1j2zz//2Msvv2xvvfVWol5Hcvnyyy/twQcftGuvvdbKlClj1atXty5dutjatWuT7X0DAABIq7FIYuO2SZMmBWLQkSNHJvv40pMff/zRGjZsmNrDAJDCSNoCcM477zwrVKiQuxUoUMBOnjxpGzdutEGDBpG4TYfy5cvn3us8efLYsWPHbNOmTS7wnzJlSrI8n55Hz6fn9bRq1crGjh1rJ06cCCzLnj27265w4cKWkmbPnm0dO3a0b7/91o4ePWo5c+a0ffv22aeffmr333+/rV69OrBt3rx5A8cOAACAWCRhPvjgg8DvM2bM4GqrBPrqq6+sWbNmtm7dOv6xARkMSVsAzl133WWLFy92tyVLlth3333nvuH3vhVH+jJq1Cj3Xut9VlXHpZde6pZPnDgxWZ6vV69e7vmGDh0aWHbkyJFY291xxx1uu88++8xS0uuvv+5+qoJBlQzLli1zY7joootcUlnJZc/w4cPdGB9//PEUHSMAAEi/0nsssmbNGlu/fr2Fh4e72++//25ff/11ag8rTYgrZgaQMZC0BRAnVRrecMMN7vf9+/eH9B9V0FirVi27+uqr3U8FjqrMDaYq3UceecQqV67sLr9XAPrxxx+HbHP8+HF79dVXrU6dOm5fN910kz3//PN24MCBWJdd3XfffS44VXJZl2A1adLENm/ebMuXL7d7773XLdMl/vomOuYl+S+99JKNHz/eatSoYddcc411797dBT/Tpk2zmjVrWvny5d1lZtu2bQsZ3/Tp0+3OO+8MjO3FF18MCZpGjBjh9q/L1hYtWmT33HOPG4fGGDwOL1Bt3ry5lStXzj2n9h2X3bt3W7du3dxx07hU5akkejBVgvbr18+uu+46d2yVED2XYO7CCy9076MogI5ZEaH3TsdNl+p16tTJfv3115BtVIXarl07d77o9d166602ZMiQkAramO0RdAy2bt3qftflcVp3psvsNmzY4I5z1apV3XM0aNDAVWgE855j8ODBbj+33Xab20/jxo1t1apVZzwGf/75Z+C8z5Ytm/u9SJEi9swzz1jr1q2tYsWK8V6S6D1vXDedIwk9n/RvSB/YNG6993p/W7ZsaT/88MMZxw4AANK+c4lFRPGzYhLFkIrZ+vfvbx9++KHbTtt7vBjlp59+cvuuUqWKVapUycWTijE9uhJL+7jllltc7KLt1Lph5cqV51Rle+ONN7qbKBaPy7vvvuviScV8qjDV5wrFvBq32n0Fx1/PPfeci0+1rWJtOXjwoHtt119/vYsF69evH+tzSEI+03jHefLkya6ll+JQHSt9XomMjHRFEGphobHpc8/ff/+dqP0nJHbVcn12CX7/guNLAOlbeGoPAID/KJjYsmWLzZ8/391XoOFRkKJAKiwszF0eriSfEk2//fabDRs2zG2jxyqpqp6lmTNndpe8//LLL64a4NSpUy5wUqCjhJQX+ClAVbCqy/O/+eYb11/1/PPPDzyv9v/www+7IFaPXbFihUsU/vXXX+45tF9d4v/YY4/ZwoUL3SXsHgU7CqLUAkIB6CeffOIuL9I4c+XK5ZLH33//vfXo0SPQ1/XNN990yV7ROPQ8qjjW61DgpucMTlp+/vnn7nVqbEpqBo9j+/btLujzAmEF1U8//bTbPpiS4w888IBL3GbJksWt//nnn93rHD16tEs6S9euXV0CW/SaZs2aZfPmzTvr91vJ0wULFgQ+HHgGDBhgEyZMCDyPEoyq+ND7884777jE4p49e+yhhx6yw4cPW9asWd12O3bssHHjxrljrvYacSlYsKB7v/W+5ciRw73/8dF7rXNFSWAddz2Perv17t3bvec9e/YM2V6vRUl67VPvh4JeJXw1dh3XuChBqmOqSmMl4G+++WarVq2aC86VYE5I6wePjoX3XnuvKyHn0yuvvOKOm+i80T5UZaPXr/e4RIkSZxwHAABIu84lFjl9+rSLF71En2Ir7edM7aaefPJJF4spBlEsrHhZLdK86l3Fqkp0ZsqUycUuSoSqjZRiFxUUKB5LKO3fS5rqi3ftU1d66XUqlrzgggsC2youeuGFF9zvERER7rOCksUxC0SCvxRXglSfEa644goX+2l7xYqq6FUsprhfr0uxrAoiEvqZxvPGG2+4+F2vWfGZPq/oWHifJbTsiy++cGPwHpuY/Z8pdtXnAR1/r6hFMeeZ4mYA6QuVtgAcJSu9b96VpL377rtd8k3JI30LLAoy3nvvPZf4UmCnhJKSldpGiVBvkgRVTiphqySTLntSpWDTpk0DzyMKYhSEKRhTAlAVs+orqqBEzxNzcgIFikpWajsvmNy1a5f7Fl4JVwU6oqApuP+oKMiZOnWqe6wqHEVBlqoTdPmZvhkXJccUVCqg8y5RGzNmjHudCk6LFy/uqhKUjA2mIEzf5mv/Srx549C+Ra9P9xXUqeJB+1AgpwRyMG2nhK2qI/ScOm4aowJRfbsvem1ewlbHQ/tSQKd9J4YS4DoW+oBw++23u/da2rdv734quPUStjreem06BkrU6rUokBc9v5KUF198sXu9aregwFb71XsZHR0d5/PrPPASxEr6eq8pLqoqVsJWVQwag8aipLjofdeHh2A6L1TZoO2eeOIJt0zHVVUaZ3oOr0WEkuz6oNOhQwf3YWngwIGx3qu4Wj/opkSszmnRsVJ1SELPJ+8YqGJEx1HbqTJXlRnqrwsAANKvc4lFlPz0ErbaVvGFvvBVjBYffdHutcryWqJ5V4opQaoYTuNRzKYE5Zw5c9y6Q4cOuavdEkNzBGgsig1VuauEdP78+d2X98FXTin57MVMilMVCyvO1yTJ8SVttVyJXm3buXNnN059JlGcpc8hiqe81hK6wk/bJ/QzjUdx6Ny5c91YlBj2PksorlP8q6vtRPuRxO7/TLGrWocFV1TrPVPsDCBjIGkLIBC4BU8SpW/ddSmOAgsvkFNQpwBOSURN2qRgSpWh3iXeCui87USX9igg07fpSvxpvZK14vUsVVJKly5J6dKlA8nduHqaeuuUvPMoKaZv0YMvGYvZKkCJaK3XN91KpIm+Kfe+aQ/en5LNqm71AmMFSXqdCsYUPAW/To8SpjoOolYPwfvyksFSr169QBsAVSKrLUEw77gpCakATc+ry6689gCqXPX2pQoKBfJ6TUp+qkVEYmhfqq7QsdK3/zoGumRLVdDBx1/JWFVu6D3U+aHWDaJqYn2guPzyy93xV7Cp91vVpDp3VBmsZL/Gdy6UTPYmXVCiVmPQWHT+qcdb8Fg9OsZeVbIuM4v5fsRFr/Ojjz5yl6cpSZo7d263XAlqJdO9Ly7ORMdS49KXBKok1qVrSuAm9HzS+S9qLaHXqiBfl/vpiwAlwQEAQPp1LrGIkn2iJKvaWslVV13lijDio9hRcZUqOb2iBi9WUrJR1aBKtirOVWGFVyARvF1iWyMoFlZspP17Y9M670t+Xf3ltRhQUYUqV/UZRYUK8SlWrJiL8xV/KinqxVWKsxTX6rWpuMK7qk19dRP6mcajzyo6thq3dwWi7iv5HPxZwnt8Yvd/NrErgIyB9ggAHPVhVfWnEoZKBu7du9cljbwknniX5ehbcK/vVrA//vgjUBUrwS0KYl7G41UOXnLJJSHLvfu6fDzkj9X/X94kwZe46zIuCb5EK2Z1Z3CbBa8KUmPzWhwEP1bBVXBP3TO9Tk/w69Q4NT59i699iVfloEReMF3e5CXuxHteBWhxBWkai7cvBdnBLRrOdPlbXFQ1oT618fHeH32ACE68Br9f2kZBsioiXnvtNVc1oEBYrQAUYOs8UqB6LoLPg+Dn1pg0NlU5xzxXgt8PryeceO9HXHQpmgJ5ne+6aVtVNSvxqioNfWjRv4mY72HwvvXFhKou9P4rAe61TEjo+dS3b1/3wUmXD6rdhdfyQr3NVGmtDyUAACB9OpdYxIsPg9sMiPcFd1yC4yWvZVdwDK2KVVWmKtZSDB4cN54ppopJX/J7/flVEatbMPWoVest9YZVFa8n+LXELHQIFvN4eHGXvjCPqzpZsVhCP9PE9VnC+xyiwhSP91nCOy6J3f/ZxK4AMgaStgBCqKp26NCh7rIbXdqjaltd8q3qRi8oUmDhVYWKEoyq/AwObJTQCw5SlFjTpVuqzNRzaF/6Nt2bTMDjXaYfMwDT88clvuX/tU1wwjOm4OfW5WXea4v5OuPbV8zqUh0PBawxg7aY9/W8OuaabMLr06oAXvvzAkRVbXrHU4lhb3nM4O9cecdAFbQK4L3XFPx+eduoykCTU+gDgy4bW7p0qbskTxWi3uRkcUlIFa6XlPee20vcakwaW/A44no/EvIcumRNPXNFfZwvu+wyd86oKluXqOmDkp5Pxzy+pK2qUXR+i6o5giu/E3o+6QOR+vTqponrtK36tOkDmyYtUzIcAACkP+cai3jxUszY0ouV4qJCg/jiJW/OAD2nWgCoUlStDGJOFJsQan8QX7ssjyYkU9I2+LUpttUX9HFNlBssOMkp3j5Usaov0b3kqcbvJVeDC0zO9JnmXD9LJHT//xW7nuuVawDSLtojAIhFlwB5l/urT5Oa7YtmS1XQoioAb5mSS0rYKZjzeslqwgRRwknBoxfwKRmlpvoKPLxLgNQfyrtESJfBe+0TgtsMpDQllb2ASv1ZvQShxqxjo55UiaEetaLKSa+HlY5fcJWt6DiKLo1TkldUYalLrlq1auXG4e1Ll8qp95W+gd+2bVvgsrOk4r0/et1KFuq5dbma17NXl9ypLYMu19P4VKmt91WXuqmfmJdMjlkFG9eHBV0qpkA6LkrSlixZ0v2uag+NQWNR+wUF8HrOcz1XNH6vilvtCzQhhjeut956y/2u86Fo0aJxPl6VsV5CVR+41PoiseeT3k+9DlWxqJew/q21bdvWJb3/6zgCAIC07VxjkcqVK7ufign1xbmox63mUjgb6qXqJVp1NZfiLRVxJLYCVMlSXbknuvpKX0gH3zQvgKi/v2IdVQZ7VbWK9by5JhQDJpQXT6s/r9fnV9W9Xryq6tuEfqY5W0m9/+Ck7pniZgDpD0lbAHHSt/ret9sKlBQ8qneT1ztVrRQUIKqPqQIyBZFej6dHH33UBZaqmvWqML1JrdSjU0FM8+bN3aQC3gyvCm50KZguJ1KSTtulFvXuUh9XUaCsqkl9W69KUvV/9RJpCaWEq9oZ6JIvzZir/en4xbyETQk/fTOvS9+UwNNxU1JUFbXqAaaAWcfG6wGm6gEdN40tqb+BV3Wsl3xU4lhjVgWEJo/Te6vKT9E4dUmdkpCaWEJJSE0OpzHrnPAC57h4VbOaaEPbBV8SF0wfXpQEVpWxxqCxeMG7WjDoPDoXapmh90NUKexN0KYEuRLooh6zavkQlz59+gR+V2Jej/du+pIiIeeT9q1jqQ9IqtrVvy29t5rEQho1anROrxEAAPjXucYimqzM66uq3reKIRSjx6xCTSjF9N4X8OqRq7hEPfc98cVsMalC2EtAK5ZVDBl8UxJVCUnFjarI1e9eay1NuKXXr2IQtd/y/FfMq3kDFC8r4atjoH0MGDDAfV5Rr2DFrQn9THO2knr/3uS9onNDV0UCyBhI2gKIkwKp/v37u8BI3+gq2PH6bmoyAPXXVDCkJGOLFi3ct+FeEKXZWtUzVUk8BZcKUFRtqGSUl3xSEKmqWgVm2pdmZVUPUO1r6tSpLtGVmh5++GGXLNQMsfo2W8k1JZWVYIwvYI6PkrP6hl/JOV2WpUulFMDVrl07ZDst1zHR5Gx6Ph0TJSQ1uZcCPY/eF7VQ0PY65hrXoEGDLKk999xzLjmrwFLJRJ0TSiyqgtqbnE4VERqzEsk6F3SuqEJC77MqMmL2Mg6mhKuOrypudYzimxVZH1r0nEp0alIOvR+q9NVEHd7EaOeqbt26rnJZSWEde70OnYNKQqtnr3fJYlz078CjhLuqy72bKiwSej7pixIdc702HW8dF12GqMDcm4QPAACkT+cSi3hX83iJUSVcFWNrwt7gnrWJSRLqC3Jvwlm1+lLcVrNmTbderbASwrsSrESJEm5fMakvrDchsTchmSYK1tV5XvGI4kD19fX812vRa1d8pdhZsaniS7Wb0D6V+PYk5DPNuUjK/Ss2VDGF3gc99kzxNYD0JSz6vxrMAAAAAAAAX1KLMSU99YW+2i/pS19dzaar31Sxqi9/lURMCwYOHOgqj4OrVWfPnu167OqL7uXLlydoTgsASA+YiAwAAAAAgDRKFavqHase+arKVVsutWHSVVtKcKplQFqhOQsWLFjgfteVZKos9SYO01VKJGwBZCRU2gIAAAAAkIZp8uCRI0e6SW+VsFUrstKlS1v79u3dHBNphfrlqjXYkiVLAv1w1Y5L7cMeeeQRV4ULABkFSVsAAAAAAAAA8BGawQAAAAAAAACAj5C0BQAAAAAAAAAfIWkLAAAAAAAAAD4SbhnU3r2HU3sI6VqWLJnt5MnTqT0MpDOcV+C8QlrA36rkV7BgrhR4Fv9Lj/Es/37AeQD+HoD/G5ARYoSCCYhnqbRFsggL48CC8wppA3+vwDkF+Ad/k8F5AP4egP8bQIyQwSttAQAAAACAv0RHR9v+/X9bRERmy5Ejj4XxbQ6ADIpKWwAAAAAA4AtRUVH2ww/f27Jly9zvAJBRkbQFAAAAAAAAAB8haQsAAAAAAAAAPkLSFgAAAAAAAAB8hKQtAAAAAAAAAPgISVsAAAAAAAAA8BGStgAAAAAAAMA5io6O5hgiyYQn3a4AAAAAAADOXlhYmF1xxZUWEZHZ/Q742daDW2zxzkX2y77VtunARos8HWkRmSOs5PmXW5kCZe2mS262y/IUT+1hIo0Ki86gXwPs3Xs4tYeQruk/2MjI06k9DKQznFfgvEJawN+q5FewYK4UeBb/S4/xLP9+wHkA/h4gLfzf8Oc/f9jola/bN7u+tsMnD1t4WGbLHp7dModlttPRp+3YqWN2Kvq05cqSy6pdfKN1LP+oFcpROLWHnaZF+PA8SO54lkpbAAAAAAAAIAGW7lpiL/842H4/ssvyZ89vxbMXj7MqXDWSByMP2Pytn9iqvSvsiSpP2fUXVeMYI8HoaQsAAAAAAHzBJboOHrADBw7QHxS+TNi+8F1f23P0T7s0z2V2fta88bbx0HKt13ba/vlvn3WPT2pz535k1atXto8/nh3n+t9/3+XWv/DCM/E+1rvdeGMVq1Onhj39dA/btu03t83u3b+7dfqZUFu2bLbOnTu438eNGxPyHDVr3mAPPtjUvv32m8D2Z3qO/v37uduJEyesceN7rHfvJ2Ntc/jwYatXr7aNHj3STp48aa1bN7P9+/+2tI6kLQAAAAAA8IWoqCj77rtv7dtvl7rfAb/445/drsL2SORhK5qrmGuFkBDaTtvrcXq8Wiskpc8//9QuvvgSmz9/bpzrv/higVu/ePEiO3r0aKz1F1xQyObMme9us2bNs9Gjx9nBgwetZ89uZ/1vcNiwwfbQQ+0C96++ulzgOSZNmma1a99mffr0SFQiOGvWrNa16+O2ePGX9sMPy0LWjRs32s477zx76KG2liVLFrv33ib2xhvDLa0jaQsAAAAAAACcwZiVb7iWCJfkKpLoSfK0vR6nx6sXblJRNeny5T+4BOnKlT+7qtq4krpKYoaHZ7FFi76ItT5TpkyWP38BdytQoIAVL17SOnToZDt37rDNmzcmekwrVvxkf//9l1WsWDmwLDw8PPAcSiA3a9bKChcubEuWLE7UvqtXv8mqVbvRXnvtZTt16pRbtnnzJps16wN7/PGnLGvWbG5ZnTp3uH3/8cduS8tI2gIAAAAAAADx2HJws5t0TD1sE1phG5Melz9bfrefrQe3JMmxXrjwc8uZM6dLUhYoUNDmz/8kZP3WrVtcUlMJ1KpVb7B58z5O0H7Dw/99jUr0JpYSqDfeePN/bpctW3Y7G127PmG7d++yOXNmuPvDh79sN99cy6677vrANqq2rVLlOpszZ6alZSRtAQAAAAAAgHh8vfMrO3LysOWJOP+cjlGerOfb4ZOHbfHORUlyrNX64Prrq7tq2WrVbnJJW/WFDq6yLVz4QitZ8nKrXr2Gq4L9r+rTvXv32JtvjrZixS61okWLJWo8em61LlDC9EzbqFWDKnlvuum/k7sxXXTRxdaixUP2zjvjbMGC+bZhw3rXNiEmjWHZsqWWloWn9gAAAAAAAAAAv/pl32pXKZvYtggx6fHhYZlt3V+/nPOY/vzzD1u9eqU1adLM3a9R4xabPfsDW7VqhZUvXyGQ1FWyVq6/vpplyRLhErsPPtg2ZD+1a9/ofj99OsoiI0/Y5ZdfYf369bfMmRNXVawetYcOHbRLL70sZLnG5D1HZGSknT592ho3fsAKFSp8Vq+9adOW7nX079/XunXrYfny5Y+1jcawadNG91yJfR1+QdIWAAAAAAAAiMemAxste/jZXc4fk/bz6/4N57wfJWQjIiICbQEqVKhkuXLldi0QlLRdt+6XkGpWTdRVpcq1sZK2aqswYsSYQFI5d+48litXrrMa04ED+93PPHlCK5KvvLK09e37ovv95MmTtnHjr/baa0Pd87Ru3d71vJW4Jj6LiopyrzOY7itZ/c47b9o99zSMcyx58uRxj1USOW/efJYW/V979wHeVPk9cPy0aVMKhRYKFMree8+yQRAUlSHiAmUoqIA/B4qgCAhuUVFQRJaIihMn+EOGbBDZe5XVIlhGS8vq/D/n9Z/8mg5soWnS5vt5njxJbt57c3tze3Nz7nnPS9A2l/T7pa94Ei9vL0lJ/l9Kfn43v/tXrl4FAAAAAACQw7Q7f3xS/HXXsk1Ll6PL0+XeSOaulj64evWqdO36Tyat0qzSFSuWypNPPmNeV08+Ocz+ugYx9X0187V+/Yb/rI/FImXLlpOcYPt7kpOTtLKsfbqfn5/De1SqVFlOn/5LFiyYb4K2hQoFmOkXL8alW2ZcXKyUL18x3XRdpmYOZ7YNk/8/JuXllXcrwxK0BQAAAAAAbkEDMFWqVBVfX+8b7ooO5ATdD60Wq8QlXc2R5SWlJIm/peAN7d/Hjx+TAwf2yxNPjDSDjKUeeGzcuDGycuXvZpCyrl1vlfvvf+B/752UJMOHD5HFi3+xB21zUtGi/5QpiImJkZIlC1yzrQaPtRyDLQtYa9Xu2rVTqlev6bC++/fvk5tu6prtdYmJiTYBac24zasI2gIAAAAAALegAyrpoElWq0Xi4zVbD3C9qkHVZP3JtTmyrMuJl6VxyP8CrddDs2i1jMEdd/R2KB1QuXJVmTNnpvz000IzoNhdd91jpqV28823ym+/LTYB3+zQQcyOHTvqME1LM6QOPoeEhEhQUJAcPnxQSpYMsU9PTEyUs2fPmMc6Tpq+/vXXC6RTp872Nn363C0ff/yhFClSROrUqSfnzp0zmbiaTdu+ffYHLNN6ttWr18jTF38I2gIAAAAAAACZqFO8nqyOXHXDJQ10/sSUJKkVXOeG69nefPMt6Wq9ql697pQpUyabcgQ1a9bO8PWFC7+W1at/z9Z7vvzy+HTTfv99g70erdJt06xZS9mxY7uEhbWxT9+1a4f06NHNfmEmOLi4yQJ+6KFH7G369r3PvDZ37iw5eTJSChb0l8aNm5l6u35+187azYiWgGjZsrXkZV4pusd4oKio2Fx9P2ra5m/UtM0dXG0H+xXyAo5VzleixPUNjpHf5Pb5bG7g/wfsB9AQhda19PW1iNXqn6ez5JB/vhuOxITL0CWDxGrxlSC/ote9nOgr5yU+OUE+unm2VAqsLPnRli1/ymuvTZSvvvrBZfvB5cuXpVevW2TOnM+ldOlQyavns3m3Gi8AAAAAAMhXdKCktWvXyJo1qzMcSR5wBQ2wti7TVs5ePmtq0l4Pne/slbNmOfk1YKu0xm5wcLBs2rTBZeuwZMliadWqrdsGbLOKoC0AAAAAAABwDY80GCahAWUkIvaEyQjPDm2v8+n8upz87umnR8snn8x2yXsnJCTId999LcOG/UfyOoK2AAAAAAAAwDWEFColI5s9JwHWwnI89liWM261nbbX+XR+XU5+p4MJTp06wyXv7evrK5988oWpm5vXEbQFAAAAAAAA/kVYaGsZ23KClCwYIkdjjpgatZll3ep0fV3bafsXw14y8wNZ9b8h3gAAAAAAAABkqlWZNlIlqKpM3z5N1kaulvAL4eLjZRF/H3+xeFlMZu3lxMuSmJIkhX0LS7dK3U1JBE/IsEXOImgLAAAA5IL4+Hjp3bu3jB07Vlq0aJFhmz179si4cePkwIEDUrVqVZkwYYLUrVuXzwcAADeiAdhxrSbKkZhwWRXxu+w5s0sORh+Q+MR48fctKI1Dmkqt4DrSrmyHfD3oGJwrT5VHOHbsmAwePFgaNWokHTp0kJkzZ9pfmzRpktSoUcPhNn/+fJeuLwAAAKCuXr0qTz31lBw8eDDTDXLp0iUZMmSING3aVL777jtzzjt06FAzHQAAuJ9iUkyaSlO5VbrLg/KgDPIaZO5vSbnVTNfXgXyfaZucnGxOYuvVqycLFy40AVw98Q0JCZHbb79dDh8+LE8//bT06tXLPk9AQIBL1xkAAAA4dOiQOU/9t5GmFy1aJH5+fvLss8+Kl5eXPP/887Jq1Sr59ddfTYYuAHgCPf5VrFhJfH29zWPAHV28GCfbt2+RyMgTkpAQL15e3uLj42P22aSkJDl5MkIiI4/Lnj07pUyZctKgQWMpVIgYFfJppu2ZM2ekVq1aMn78eKlYsaK0b99ewsLCZPPmzeZ1DdrWrl1bSpQoYb/5+/u7erUBAADg4f744w9TDuHLL7+8Zrvt27dLkyZN7EEKvW/cuLFs27Ytl9YUAFzP29tbatSoKTVr1jKPAXejgdqlSxfLkSOHxGKxSJEiQVKkSKAULFhI/P0Lmnt9rtP1dW2n7TWQC+TLTNuSJUvKu+++ax5rlsKWLVtk06ZNpuZXXFycnD592gRzAQAAAHdy3333ZaldVFSUqWObWnBw8DVLKgAAgNwN2G7YsEbi469KYGCQybDNjF589fMrIFarVWJjL8j69aulZcs2JvP2RrVp09Tcf/PNz1KqlOMAZ99//4289dZrMnDgwzJ48FAzbd++vTJjxjTZuXOHRtWkevWaMmDAYGnWrKV5/a+/Tspdd92R4Xs98MAgE3yeM+fjTNdnzJhxcuutt6ebrvG7ESOGyjPPjJEKFSqa9X7vvenSuPE/628za9ZHsnXrZpk6dYZ92okTx2XmzOny558bTZkpzcDv2bOP3HZbD3ubRYt+ktmzZ8g33/yU4Xq9/PJ4Wbz4Z/tz/SxCQ8vIHXf0lrvuusd+ofyjj6ZJ6dKhcscd/+u97w7yTNA2tU6dOsnJkyelY8eO0rVrV9m1a5fZ0NOnTzddyIKCgmTgwIEOpRIAAAAAd3b58mXzYyI1fa4DmGXE19ci+a3nsI+PxdWrADfAfuDZNMijx0MRi/j6WimRALc5JmjC4JYtG005hH8Ctln9EraY9hcuxJj5S5YsniOlErQcw4YNq6Vv33scpq9evdKsm8XiLVarxSQ5/uc/j8r99/eTkSP/KcH03//+KiNHPiEffzxb6tatZ84p1Ny586VkyRCH5RUsWNDc33VXX3O/c+d2GTVqpCxa9JtDeVJ9r7R+/vlHCQ0NlWrVqtin6Xulbavr6u3tZZ9+4MB+efTRhyUsrJVMmTJNihQpYoK6U6a8K/v375HRo1/4/22gZVT0fCnjfUSX2bnzzfLUU8+Y55cvX5I//9wkU6a8LZcuxcmQIY+Y6QMGDJT+/e+Vzp07m5iiu8iTQdv33nvPlEvQUgmvvvqq1KlTx+x0lStXln79+pkMXB2VV3eaLl26uMVJrpd3Pjuj/hfeXl6S7EE9WTI7QCB/flkjf2G/AvsU3IXWs00boNXnBQoUyLB9QkKS5Efx8fnz70L2sB94Lq0HumzZchOM6dChs8nwA9zhmKDBvgsXYiUwMFC0TP2/1apPKyCgsMTERJuYVatW7W54fbRO7sqVv0vPnnc51NrVbNpq1WpIUlKy2W5Lly41WaQPPPCQvd2AAQ/L1q1b5Ycfvpfq1WvbzykKFSoiRYoUzfD9ihTxM/f+/v8EnNO2S/sZ6faZNetjGTt2osNr+l5p2+q6Jien2KePH/+ihIW1kRdfnGhvc/vt5aRChSoyZMgACQtrK61atZHExGTzWWS2f+gy9eKPbV31vnv3MmaeyZNfl9tu6ynFi5cQP7+C0rx5S/nqqy9lwID/bSdXy5NBWx2MTGl69MiRI02pBM26tUXDa9asKUePHpUvvvgi06Btbp/kpiRn7585r9OArSf9ze7wBeIp2NZgv0JewLEK10MH2NXEhNT0uZYJAwAArhMTc96URtCxk65VEuFadL4CBQqa5WjwVrNvb0Tbtu1k2rQpJlBry9xdt26NNGjQ8P+z1f+XbXrq1EmJiDghZcv+rzTDCy+Md+pFkT/+2CBXrlyROnXqZmu+vXt3y6FDB2TcuEnpXqtZs7a0bNlafvppoQnaXq8uXW6RKVMmy/r1a+X223uaaa1bt5M33njZlINwl3ra7rEWWaAnrHp1IDWt+ZWQkGBS1NOmL2vWraaAAwAAAHlBgwYNTNaLLXPHNo6DTgcAAK6jAU8ti2C1/pNteiO9anQ5ERHHb3idKleuKsWLl5QNG9bbp61a9bu0bdvBoV2nTl3M+95/fx958slh8vnn8yQ8/JCUKFFSihULFmfZuHGdNG3aLNslTrT+rgbHK1aslOHr9es3kD17dt/Quun20Ozjo0fD7dO0zu65c2clPPywuIs8E7SNiIiQ4cOHOwRitZZtsWLF5NNPP5UBAwY4tN+3b58J3AIAAADuSgcf0ywU1a1bN7lw4YK8/PLLcujQIXOvmTK33HKLq1cTAACPduZMlMmUzW4AMi2dX29nz0blyHpptu3atavsJZU2bdogbdu2d2hTtGgx+fjjeWYAr4MHD8gHH7wnDzxwj6lze/78OYe2/fv3lS5d2tpvw4Y9fN3rpnVpK1RIH3gdOfI/Du+ht08/nWN/XWv/aikJr0y2deHCRUybG6XZyZcuXUoTyC0jBw7sE3fhk5dKImjt2jFjxsjo0aMlMjJS3nzzTXnkkUekUaNGMmPGDJk1a5Yph7BmzRr5/vvvZd68ea5ebQAAACBTbdq0MWM09O7d24zH8NFHH8m4cePkq6++kho1aphzXNsAIAAAwDWio8+Zgb9ygo+Pb7pg6fVq06a9vPDCKElMTJTNm/8w2bcapE1LBxd75pkx8vTTz5mg5IoVy+SbbxbI669Pktdee9ve7s03p5gMXJu0A6RmR3T0+QxLQDz33AtSu7ZjyQRdl0OHDprHRYoEmnmTk5MzLFOgAXRtc6MuXbooBQsWcpim9Ypz6rPxqKCt1tn44IMPZOLEiXL33XebVOn+/fvLAw88YKLvU6ZMMQOU6X2ZMmVk8uTJJpgLAAAAuIv9+/df83n9+vVl4cKFubxWAAAgM1quSAfIu9EsWxtdji5Pl3ujy6xfv6G537Fjm6xatVLatXMsjaA+/XSu1KpVW5o2bW6CoFoXVm+lS5eWqVPfdWhbqlRpUzYgZ3iZwGtaOvBX6tq6tuxZGw3oainUw4cPSbVq1dPNv3//XvP33AgdI+vEiePSt+99DtN1fa+3ZrFHB21tgzNMnTo1w9c6d+5sbgAAAAAAAEBO0MCqJhJqoDUnaLBWl5cTQWDN/g0La21KJKxbt0r695+drs2uXdtlz56dJmibmpYgCAoqKs6i5Ux1wLXsqlGjpgkqz579kbz66uR0g5Tp4GFpp2fXb7/9aoLKrVq1dZiu6xsc7Lw6v/k6aAsAAAAAAPIvDWSVK1defH1vvH4okFOCgorJyZMRObKsxMQECQkpJTlFa9i+8spLEhpaxtzS6tdvgIwYMVRee22i9OzZx5Rj2r9/n6lte999/cVZqlWrYbJlr8eYMS/K448/IuPHPy/33HO/KbOwc+dWef/9KXLbbT2lTZt2DlmzGzasS5e5W6dOXfvrZ8+eMY91rAAdIO2jjz6QBx8cJEWLFnUol3Dq1F9SvXpNcRcEbQEAAAAAgFvQ7tu1a9cRq9Ui8fE5k9kI3Cjt0h8ZefyGSxro/HoLDi6RYx9K8+ZhpqZt2gHIbOrVayBTpkyXTz6ZKU8+OUyuXr1iLowMHPiw3H57T3GWli3D5OWXJ1zXNtPavB99NFfmzPlYRo16Si5ejJOKFSvJ0KGPmaBtalqDduTIx9P9zR9+OMs8Xr78N3NThQoVkvLlK8gTT4yUW2+93WGenTt3mHq+lSpVFnfhlaJbzwNFRcXm6vv1+6WveBIvby9JSfacXWt+969cvQoegRM3sF8hL+BY5XwlShTOhXdxf7l9Ppsb+P8B+wE4HsAdvxu02/ySJb+YsgZ+fgWuezlXrlyR5OQkufnm7hkO0pWfaDmJe+/tLWPGjJOGDRu7/X7wyisTTKbygAEPibucz7pPdV0AAAAAAODx4uPjzQ1wFxpgLVOmnFy+fElSUtIPrpUVOt+VK5fMcvJ7wFZpgFtLM/zww3fi7mJiomXTpo3Sq1cfcScEbQEAAAAAgNtk561YsUyWLVuaYwM/ATmhQYPGZvCu2NgLpst/dmh7nU/n1+V4ittu62HqxB49ekTc2RdfzDc1bt0tmE5NWwAAAAAAAOAaChUKkGbNwmT9+tUSGxtjBrvy8vLOUoatBmytVj8zvy7Hk2pU22rLurNHHhku7ohMWwAAAAAAAOBfhIaWlZYt20jBgoVMl3qtUZtZ1q1O19e1nbYPC2tr5geyikxbAAAAAAAAIAu0Jm1QUFHZvn2LREaekAsXosXLy0t8fHzNvQZrExMTzL2vr1UqVapqSiJ4UoYtcgZBWwAAAAAAACCLNADbqlU7k0UbEXFczpyJkujoc5KYmCi+vr4SElJKgoNLSNmy5d2uTiryDsojAAAAAAAAADdIM21VNscpAzJEpi0AAAAAAACQRRcvxtnLIyQkxJsByXx8fEzQNikpSU6ejJDIyOOyZ89OU06B8gi4HgRtAQAAAACAW9CgV2hoGfH19bZnLQLuRAO1f/65QeLiYsXfv6D4+wdluK9qTdv4+Kty5MghiYo6Lc2ahTEQGbKFoC0AAAAAAHAL3t7eUq9efbFaLRIfn+Tq1QHSBWw3bFhjgrFaq1YzbDOjgVw/vwJitVolNvaCrF+/Wlq2bGMyb3PC5cuXZf78ubJixVI5deqU+PsXkEaNmsigQUOlcuUqDm337dsjs2fPkB07tklycopUqVJV7r23v7Rr1yHdcpcu/a98+eXnEh5+yASlGzRoKAMGPCzVqlVP1/bnn7+XH35YKMeOHTVB6urVa5jltmnTzt6mTZum8t5706Vx46ZZ+rvOnz8nTz/9uMyYMdes7+OPPyJr1vyZrt3w4UPM3zt48FD7tE2bNsi8eXPM36sDw9WqVVv69x9o2tm8/PJ4c//88//cp9Wnz+1y6tRf9s+wQIECUrVqNbMNWrQIs7cbMWKoPPXUKKlUqbI4CzVtAQAAAAAAgH8piaAZthqwLVw48JoB29S0nbbX+XR+Xc6NunTpkjz66GATYH3sscfl88+/kcmTp0rBgoXk0UcHycmTkfa2Gzeul8cee0hKlw6VqVM/lpkz50m7dh1lwoTnZd682Q7LnTXrI3n99UnSpUs3mTfvS3n77fdNcFqX+eeffzi0fe21iTJlytvSrVt3mT17vsyaNU9atmwtL774nAkkX68PPnhP7ryzryk3kR2//PKjPPvsk9KwYWOZOfNT+eCDmVKjRi158slh8uuvv2RrWY8//rT88MOvsnDhIvnoozlSr14DefbZJ2TTpo32NgMHPiyTJ78mzkSmLQAAAAAAcBtaEzSJJFu4Ga1hGxcXJ4GBgdku3aHtCxcuIjEx0WY5rVr9LxP1esyd+7HJSJ0//2spXLiwmVaqVGkZM2acnD59Wr788jN58sln5erVqyaz9J57+smQIY/Z5y9fvoKEhobKiy+OlrCwNiaLdv/+ffLJJ7Nk8uT3pVmzFva2zz77vMkWfuWVCfLFF9+Jn5+frF+/xgRJP/xwltStW9/etn//AZKUlChz5nwsHTt2zvbf9ddfJ2X16pXyzDNjsjXfmTNR8vbbr5vM19tv72mfPnToMPN5vf32G+ZvCg4unqXlBQQE2NsWL15CHnvsP3L27Bl5//23TTBbaeawBm23b98qDRo0Emcg0xYAAAAAALhNwHbp0iWyZMl/zWPAHcTEnDelEfz9/bOcYZuWzlegQEGzHA3eXq/k5GRZtOhnufvu++0B29TGjn3JZN+qtWtXm/e6774H0rVr376TVKhQURYt+sk8//nnH6RGjZoOAVubBx98yARGNWvX1jYsrLVDwNamb997ZcqU6df1t/3ww3fSokVLEyTOjiVLFptAa/fud6R7rU+fe8RisciyZUvkRtxxR28JDz8sEREn7NNat24nCxd+I85C0BYAAAAAAADIhAbqEhLixWr1u6FtpFmqupyIiOPXvYzIyAiJjj6faXZn8eLFTS1dpbVdy5WrYAKaGalfv6Hs3bvb3rZmzToZtitatKiUK1fe3nb37l1m3oxoiQZtfz02blyXYdD43+zbt1eqV69pamKnpWUWateuK3v2/LPu16tixUrm/ujRcPs0Xdc//thg6vk6A+URAAAAAAAAgExolqlmyma3LEJaOr/ezp6Nuu5l2LJ0ixQpYp+mtVbHjBlpfx4SUlrmz//KDICWUTauja1kg8pOW70vUiTQ/lp8fLx0736TQ/tPP/1aSpUqleW/KzExUQ4fPiQVKvwTHE2tS5e2kpaWfrANMHbhQowUKxYsmdG/S9vciEKFAuz1hG10EDJdrg5cpjWDcxpBWwAAAAAAACAT0dHnsj0wVqaBOB9fU4/2emnwVMXFxdqn6UBZc+Z8bh6vXLnc3mVf2547d/aawWgdaCyrbW1BUm2b+v19fX3t7x8V9beMGDFUUlKSs/V3adBYSz/Y1ic1Xbavr7ckJPxvmRMmvGB/rAHks2evve5am/ZGXLp00Z5JnPp9lX6ezgjaUh4BAAAAAAAAyIB2fdf6yjeaZWujy9HlXW+X+jJlyprBtXbu3GGfVqBAASlbtpy5FS1azD69Tp26Jgs0sxq6+/fvlZo1a9vbHjiwL8N2OgiXBmNtbWvXruPw/vo32d5fB0S7Pv9sXw3cplW2bDlTnsH2HnrTUhM2uj5HjhyWhISEDDNytaRBrVr/rPv1OnTooLmvXLmKfZotMJ1RWYacQNAWAAAAAAAAyIAGJHUgq5yqW6rL0eVdbxBYM351wK2vv/7Cnv2ZmgZXbVq2bCXBwcVl7txZ6dqtWLFUjh07Kt27326ed+/ew5QnWLXq93RtP/lklik/oMtTPXr0lnXrVsv+/fuu+f7ZoYFo3S4xMdkvY9C5cze5cuWKLFz4dbrXvv32K7l6NV5uuqmr3IhffvlRatSoJaGhZezToqP/CYZfqzTDjaA8AgAAAAAAAJCJoKBicvJkRI5sn8TEBAkJyXqt14wMGjRUtm/fJkOHDpRBg4aYYKIOTvbTTz/IL7/8IF26/BOg1AHJnn9+vIwa9aQJFt9+e0+Tlbtu3RqZMWOaDB48VKpVq2HaVqtWXR566BGZOPFFGTr0MQkLa2MCoT/9tNAELF977W17dqu+1qvXXfLEE4/J4MFDpHnzlpKcnCKrV/8un346VypWrOxQc1cHMNO6t6k1bNjYrIuNZqtWqVJNDh8+KA0aZDzIWWZ08LWnnx4lr78+SS5evCg33dTFTF+6dInMnz9XnnlmjGmTOrC8YcO6dBnMms2r4uLiTHaxxuk1S/nnn3+QZcuWyDvvTHOYR4PcGrAtUaKkOANBWwAAAAAA4BY0+zAkJER8fa8/ExHIaVoPNTLyuAl83sh+qfPrLTj4xuqrarBz6tQZ8tVXn5ss2oiI4+Lra5XatevKpElvSLt2HextmzRpJh9+OEvmzJkp//nPIybrVAO0Y8dOdGin+vcfKOXLV5QFC+bLjBkfitXqa4Kr06fPMfOk9sQTI6V+/Yby3XdfycyZH5lgtA7M9fDDj8odd/RyKF/w4Yfvp/sbFixYaMocpNaiRZjs2LFNeve+K9vbpGvXW03w9NNP58iXX/5TX1e3x+TJ79tr8dr8+ecf5pbaAw8MkiFDHjOP33tvsrnpZx0UVFSqV68pU6ZMTxdM1nXVgLWzjlVeKTmV353HREX9r2Bybuj3S1/xJF7eXpKS7Dm71vzuX7l6FTyC1WqR+PgkV68G8hn2K7BP5T0lSmQ+srEnye3z2dzAMRnsB+B4AHf8btBsyyVLfjHd9zV79Xpp5mpycpLcfHP3DAfc8nSRkREyeHA/+f77Xx2ycN1lP0hNw6l9+/aUF16YkO3M4Kyez1LTFgAAAAAAAMiEBljLlCknly9fsg8+lV0635Url8xyCNhmTEsUaOmFJUsWu/2+uGnTRlNy4XoCtllF0BYAAAAAAAC4hgYNGktAQGGJjb2Q7UHJtL3Op/PrcpC5YcOekO+++1oSEhLcejPp4GwjR4526nsQtAUAAAAAAG4hKSlJ/vvfxbJ48SLzGHAXhQoFSLNmYWK1+klsbEyWM261nbbX+XR+XQ4yp9mrc+d+Lr6+vm69maZN+1iqVKnq1PcgaAsAAAAAAAD8i9DQstKyZRspWLCQqXOrNWozy7rV6fq6ttP2YWFtzfxAVvlkuSUAAAAAAADgwbQmbVBQUdm+fYtERp6QCxeixcvLS3x8fM29BmsTExPMva+vVSpVqmpKIpBhi+wiaAsAAAAAAABkkQZgW7VqZ7JoIyKOy5kzURIdfU4SExNNt/6QkFISHFxCypYtz6BjuG4EbQEAAAAAAIBsOifn5E/5U3bLTjkkByXeK16sYpWqKdWkjtSTghIggRLEdsV1IWgLAAAAAAAAZNHpi6dk+vZpsjZytcQmxIqPl0X8ffzF4mWRuKSrsv7kWlkduUo+2zNPWpdpK480GCYhhUqxfZEtBG0BAAAAAACALFgXuUYm//m6nIyLlGD/YKnsX9nUsk1La9rGxEfLr0d+kR1R22Rks+ckLLQ12xhZ5p31pgAAAAAAAM6jwa/ixYtLiRIlMgyEAa4O2E7cME7+vnRaKgZWkiC/opnupzpdX9d22v6l9S+a+XPaokU/SZs2TeXnn793mD58+BAzffHin9PNc+zYUfOatkm9jIxutjZ637dvD7l69arDsv7666Rpp/eZ0XkGDbrf1ADesuVPh+W3b99C+vS5XT7/fJ7DPH363G7WK6O/V19T48aNkd69u8uVK1fStXviicfk0UcHmeD5Sy+NlU2bNkheQ9AWAAAAAAC4BW9vb2nSpJk0bdrMPAbcxamLf5kM27j4WClfuIIphZAV2k7b63w6v5ZWyElLl/5XypQpK7/+uijdaz4+PrJ27ap001etWuEQbL7ppi7yww+/OtzeeWeaWCwWCQv7X3bwyZOR8umnc7K9jvPnz5XWrds5DMpme58vv/xB/vOfp2Xu3FmybNmSbC13xIgnJS4uTubNm+0wfeXK5bJt2xZ55pkx5u8cNGiITJkyWRISEiQv4QgIAAAAAAAAXMNH2z8wJRHKFi6X7Sxwba/z6fxaCzennD9/TjZv3iQDBz4s27dvNUHV1Bo0aCx//LExXbBy1arfpU6devbnfn4FJDi4uP1WqFCAvPPOG1K3bn25997+9nalS4eajNgTJ45neR0vXbokX3+9QHr06O0w3fZepUqVkrZtO0iXLl1l2bLfsvX3Fy9eQgYNelgWLPjM/rdfvXpF3n//Hbnnnn5SuXJVM61s2XISElI620FhVyNoCwAAAAAAAGQiPOawGXRMa9hmNcM2LZ0vuECwWc6RmPAc2dbLly+VgIAAufnmW0wA89dff3F4vV69+mK1Wk1g1+bMmSiJiDghjRo1yXS5U6e+I2fOnJEXXpjgkPHeteutJhD69tuvZ3kdlyxZLOXLVzDrdy0FCvjL9ejT5x4pW7asfPDBFPP8888/Nes8cOBDDu3atGkn33//reQlBG0BAAAAAIBbSEpKMt29lyz51TwG3MHqiJUSlxArgdb/de+/HoF+QRKbECurIn7PkfXSzNGwsDYmSKnlBzRoqzVcU2f4tmrVRtasWeWQZduyZStTOiEj69evNcFNLVmgmbWp6fJGjnzOBIGzmrW6ceN6adasxTXbHDkSbpbXtestkl0+Pj7y1FOjZOXKFeZv06Dt008/Z7KHU9N12LNnl8TGxkpeQdAWAAAAAAC4jaSkZHMD3MXuMztNpuyNDo6n8/t4WWTv2d03vE6nT5+SnTu3m9ICqn37jqZEwI4d2xzatW3bXtatW21/vnr179Ku3T/zpKUDhb322kvSrl1H6d79jgzb1KxZW3r0uNOUILh06eK/rueBA/ukQoVK6aZ36dLW3Dp1aiX9+/eV0qVLS/PmYXI9GjZsLDff3E3Gjh1lgtQtWqRfTmhoGRPgPXhwv+QVBG0BAAAAAACATByKPij+PtfXfT8tXc6B8zceONTMVC19YAtQarmDwoWLyOLFPzu0a9aspQnG7t+/z2SZ7t69S1q0aJXhMt988xVz/+yzz1/zvYcMeUySk5Pl44+n/+t6Rkefl6Cg9BnKc+Z8bm5z534ub789Va5ejZdnn33C/rqPj495j7R0WkZZwv37DzLZ+VrfNyOajVy4cGE5f/685BUZ50IDAAAAAAAAHk7LDcQnxV93Ldu0dDm6PF3ujWTuahmRq1evSteu7e3TNGi5YsVSefLJZ+zTChQoYEoDrFmzUsqVqyCNGjWWggULplueBnt//325vPnmuxkGWVPT4OewYf+RV16ZcM3auEr/xoxKnejgYDbly1c06/TII4MkPPyQqZsbEFBYLl6MSzdfXFyseS0tPz8/h/uMJCeniLf3jWVL5yaCtgAAAAAAAEAmQUerxSpxSVdzZPskpSSJv6XgDQVsjx8/JgcO7JcnnhgpjRs3dagNO27cGFm50rFmbps27WXhwm+kTJmjpvRBWqdO/SXvvvum9OjR29TIzQodlOyXX36U999/+5rtihYNlgsXYv51ebZavLbSKFWqVJVdu3bK3Xc7ttuzZ7dUq1ZDskszdHU9ihUrLnkF5REAAAAAAACATFQNqiaXEy/nyPbR5VQvmv2gY9os2yJFAuWOO3qbrFTb7aabbpaKFSvLr786lkho3bqtHDp0QP74Y70ZsCytSZPGmdIK9933gJw9e8bhdq1yAjoAWFTU39dc1+rVq8vhwwfTTU/9Hvv27ZUPPnhPKlSoaIK1qlevPqb+7iefzJKIiBNy6NBBmT17hqxdu0p6975Lsuvo0SPmvmrVf5afF+SpTNtjx47JSy+9JFu2bJHAwEDp16+fPPTQQ+a1EydOyNixY2Xbtm0SGhoqY8aMkTZtsnZ1AAAAAAAAAMhIneL1ZHXkqhsuaaDzJ6YkSa3gOjdcz/bmm28xNW3T6tXrTpkyZbIZeMumaNFiUrt2XbFYLBmWPti2bYu5v/vunuleK1WqtHzzzU8ZrkfFipXk3nv7y6efzsl0XbV+7qJF6efv0aObudftqeUOmjdvIS+8MMHUnrUNePbmm+/KnDkzZf78T0xZA82wnTz5falWrbpklw7QVq9eAylUKEDyCq8UW/6xm9M05ltuuUXq1asnw4cPNwHcp556SsaPHy+33Xab9OjRw0TvH330UVm6dKl8+OGHsmjRIhPAzUhUVGyurn+/X/qKJ/Hy9pKU5Dyxa+WI+d2/cvUqeASr1SLx8elr4QDsV3AnHKucr0SJ9HXMPFFun8/mBv5/wH4ArX25efOf4uvrLfXrNzZBJng2d/huOBITLkOXDBKrxVeC/Ipe93Kir5yX+OQE+ejm2VIpsLJ4Aq1Le+edt8ncuV+YALCr9oMRI4bKbbf1MGUd8sr5bJ4pj3DmzBmpVauWCdJWrFhR2rdvL2FhYbJ582bZsGGDybTVLNwqVarI0KFDpWHDhvLtt9+6erUBAAAAAEAWaZBWM+5atGhJwBZuQwOsrcu0lbOXz5qatNdD5zt75axZjqcEbJVmtvbqdZf88MN3LluHY8eOyunTp0z5iLwkzwRtS5YsKe+++64EBASYdHIN1m7atEmaN28u27dvl9q1azuMftekSRNTKgEAAAAAAAC4EY80GCahAWUkIvaEfdCsrNL2Op/Or8vxNA8+OFjWrVsjMTHRLnn/2bNnmPq7Pj55qkps3gnaptapUye57777pFGjRtK1a1eJiooyQd3UgoOD5dSpUy5bRwAAAAAAAOQPIYVKychmz0mAtbAcjz2W5YxbbaftdT6dX5fjaQoUKCCffPKFBAamr6ebGyZMeEVatmwleU3eCjH/v/fee8+US9BSCa+++qpcvnw5XfFlfR4fH5/pMnx9LXIDtaOvq8arJ/H28pLkPHlJ4Pprq8D5fHzYzmC/gvvjWAUAwI3VtF25coWpaduqVXtKJMCthIW2lrEtJ8jkP1+XozFHJLhAsAT6BWU4OJlm18ZcjTYlETTDVgO2Oj+Qr4O2OhiZunr1qowcOVLuvPNOE7hNTQO2GsnPTEJC7hax9qRBuZQGbD3pb3Z1UXRPwrYG+xXyAo5VAABcv4SEBElJ8aAsIOQprcq0kSpBVWX69mmyNnK1hF8IFx8vi/j7+IvFy2Iyay8nXpbElCQp7FtYulXqbkoieGKGLTwkaKuZtVqjtnPnzvZpVatWNQfzEiVKSHh4eLr2aUsmAAAAAAAAADdCA7DjWk2UIzHhsirid9lzZpccjD4g8Unx4m8pKI1Dmkqt4DrSrmwHjxp0DB4atI2IiJDhw4fLypUrJSQkxEzbtWuXFCtWzAw6Nnv2bLly5Yo9u1YHKtPpAAAAAAAAQE7TgGzqoKyWRMioVAJwPbzzUkmEOnXqyJgxY+TQoUMmePvmm2/KI488Is2bN5fSpUvL6NGj5eDBgzJjxgzZsWOH9OnTx9WrDQAAAAAAAA9AwBYeGbS1WCzywQcfiL+/v9x9993y/PPPS//+/eWBBx6wvxYVFSW9e/eWH3/8UaZNmyahoaGuXm0AAAAAAAC4Oc2SBdxJnimPoLQswtSpUzN8rUKFCjJ//vxcXycAAAAAAADkLbZ6tLvP7JRD0QdNPVqrxSpVg6pJneL1qEcLl8tTQVsAAAAAAJC/BQYGio9PnukYjDzm9MVTMn37NFkbuVpiE2LFx8si/j7+YvGySFzSVVl/cq2sjlwln+2ZJ63LtJVHGgwzA48BuY2gLQAAAAAAcAta/rBly1ZitVokPj7J1auDfGZd5BqZ/OfrcjIuUoL9g6Wyf+UM69BqqYSY+Gj59cgvsiNqm4xs9pyEhbZ2yTrDc3HpCgAAAAAAAPk+YDtxwzj5+9JpqRhYSYL8imY6cJhO19e1nbZ/af2LZn4gNxG0BQAAAAAAQL516uJfJsM2Lj5WyheuYEohZIW20/Y6n86vpRWA3ELQFgAAAAAAuIWkpCRZuXKF/P77cvMYyAkfbf/AlEQoW7hcptm1mdH2Op/Or7VwgdxC0BYAAAAAALiNK1euyOXLV1y9GsgnwmMOm0HHtIZtVjNs09L5ggsEm+UciQnP8XUEMkLQFgAAAAAAAPnS6oiVEpcQK4HWoBtaTqBfkMQmxMqqiN9zbN2AayFoCwAAAAAAgHxp95mdJlM2u2UR0tL5fbwssvfs7hxbN+BaCNoCAAAAAAAgXzoUfVD8ffxzZFm6nAPn9+fIsoB/Q9AWAAAAAAAA+U5KSorEJ8Vfdy3btHQ5ujxdLuBsBG0BAAAAAACQ72hJA6vFKkkpSTmyPF2OLu9GSy0AWUHQFgAAAAAAuI2AgABzA3JC1aBqcjnxco4sS5dTvWiNHFkW8G98/rUFAAAAAABALrBYLNK6dVuxWi0SH58z2ZHwbHWK15PVkatMSYMbyZDV+RNTkqRWcJ0cXT8gM2TaAgAAAAAAIF9qV7aDFPYtLDHx0Te0nJir0WY5ujwgNxC0BQAAAAAAQL5UKbCytC7TVs5ePnvdtW11vrNXzprl6PKA3EDQFgAAAAAAuIWkpCRZu3a1rF69yjwGcsIjDYZJaEAZiYg9YcocZIe21/l0fl0OkFsI2gIAAAAAALcRFxdnbkBOCSlUSkY2e04CrIXleOyxLGfcajttr/Pp/LocILcQtAUAAAAAAEC+FhbaWsa2nCAlC4bI0ZgjEn3lfKZZtzpdX9d22v7FsJfM/EBu8snVdwMAAAAAAABcoFWZNlIlqKpM3z5N1kaulvAL4eLjZRF/H3+xeFlMZu3lxMuSmJJkBh3rVqm7KYlAhi1cgaAtAAAAAAAAPIIGYMe1mihHYsJlVcTvsufMLjkYfUDik+LF31JQGoc0lVrBdaRd2Q4MOgaXImgLAAAAONHVq1dlwoQJsmTJEilQoIAMGjTI3DLy6KOPyvLlyx2mTZ8+XTp27MhnBABADqoUWNkhKKslEby8vNjGcBsEbQEAAAAneuONN2TXrl3yySefyMmTJ2XUqFESGhoq3bp1S9f28OHD8uabb0pYWJh9WmBgIJ8PAABORsAW7oagLQAAAOAkly5dkq+//lo+/vhjqVOnjrkdPHhQPvvss3RB2/j4eImIiJB69epJiRIl+EwAeCztleDry7jpADwbR0EAAADASfbt2yeJiYnSqFEj+7QmTZrI9u3bJTk52aFteHi4yfIpV64cnwcAj2WxWKR9+47SoUMn8xgAPBWZtgAAAICTREVFSdGiRcVqtdqnFS9e3NS5jY6OlmLFijkEbQMCAuTZZ5+VP/74Q0qVKiUjRoyQ9u3bZ7hsX1+L5LfSez4+BGjAfgCOB+C7AZwjmPMidgQAAADAOS5fvuwQsFW251oOITUN2l65ckXatGkjQ4YMkd9++80MTPbll1+akglpJSQk5cuPLT4+f/5dyB72A7AfgGMCPP27gaAtAAAA4CR+fn7pgrO251qzMbXHHntM+vfvbx94rGbNmrJ792756quvMgzaAkB+lJSUJJs2bRQfH29p1KgZJRIAeCxq2gIAAABOEhISIufPnzd1bVOXTNCAbZEiRRxPzL297QFbm8qVK8vp06f5fAB4lJiYGHMDAE9G0BYAAABwklq1aomPj49s27bNPm3z5s0mc1aDtKk999xzMnr06HQDmWngFgAAAJ6FoC0AAADgJP7+/tKzZ08ZP3687NixQ5YuXSqzZ8+WBx54wJ51q3VsVadOneSnn36S77//Xo4dOyZTp041Ad5+/frx+QAAAHgYgrYAAACAE2n2bJ06deTBBx+UCRMmyIgRI+Tmm282r+mgY4sWLTKPddq4cePkww8/lNtuu02WL18uM2fOlLJly/L5AAAAeBgGIgMAAACcnG37+uuvm1ta+/fvd3h+1113mRsAAAA8G5m2AAAAAAAAAOBGyLQFAAAAAABuw9fXV3x9yTED4NkI2gIAAAAAALdgsVikU6fOYrVaJD4+ydWrAwAuw6UrAAAAAAAAAHAjBG0BAAAAAAAAwI1QHgEAAAAAALiFpKQk2bz5T1PTtn79xqZcAgB4IoK2AAAAAADAbZw/f058fOgYDMCzcRQEAAAAAAAAADdC0BYAAAAAAAAA3AhBWwAAAAAAAABwIwRtAQAAAAAA4JZSUlJcvQqAS+SpgchOnz4tL7/8smzYsEH8/Pzk1ltvlaeeeso8njRpknz66acO7ceOHSv9+vVz2foCAAAAAAAg647EhMuqiN9l95mdcij6oCSmJIiPl69UDaomdYrXk3ZlO0ilwMpsUuR7Pnnpysrjjz8uRYoUkc8++0xiYmJkzJgx4u3tLaNGjZLDhw/L008/Lb169bLPExAQ4NJ1BgAAAAAA2WOxeJsbPMvpi6dk+vZpsjZytcQmxIqPl0X8ffzFYvGRK0lXZP3JtbI6cpV8tmeetC7TVh5pMExCCpVy9WoDTpNngrbh4eGybds2Wbt2rRQvXtxM0yDu66+/bg/aDh48WEqUKOHqVQUAAAAAANfBYrFI585dxWq1SHx8EtvQQ6yLXCOT/3xdTsZFSrB/sFT2ryxeXl7mNS9vL0lJTrEn9MXER8uvR36RHVHbZGSz5yQstLWL1x5wjjxz6UqDsTNnzrQHbG3i4uLMTUsnVKxY0WXrBwAAAAAAgOwHbCduGCd/XzotFQMrSZBfUXvANi2drq9rO23/0voXzfxAfpRnMm21LELbtm3tz5OTk2X+/PnSsmVLk2Wr/7jTp0+XVatWSVBQkAwcONChVEJavr4WyeQY4BR6ZciTeHt5SXKeuSRw4/QqMJzPx4ftDPYruD+OVQAAAFlz6uJfJsM2Lj5WyheukGmwNi2Ll8W0Px57zMxfJagqpRKQ7+SZoG1ab775puzZs0e++eYb2b17t/nHrly5shl4bNOmTWYQMq1p26VLlwznT0jI3W4WtlR+T6EBW0/6m+m2w7ZG3sb/MNinAABwD5qgtXXrZpNoVbduQzOODfKvj7Z/YEoiaOZsVgO2Ntq+bOFycjTmiKmFO67VRKetJ+AKPnk1YPvJJ5/IO++8I9WrV5dq1apJx44dTYatqlmzphw9elS++OKLTIO2AAAAAADAvWjN0jNnzoiPj7d5jPwrPOawGXRMa9hq5uz10PmCCwSb5RyJCZdKgZVzfD0BV8lzl6wmTpwoc+bMMYHbrl27/q+myf8HbG0061br3AIAAAAAAMC9rI5YKXEJsRJodYznZFegX5DEJsTKqojfc2zdAHeQp4K2U6dOlQULFsjbb78t3bt3t0+fMmWKDBgwwKHtvn37TOAWAAAAAAAA7mX3mZ0mUza7ZRHS0vl9vCyy9+zuHFs3wB3kmaCtDjb2wQcfyMMPPyxNmjSRqKgo+01LI2gd21mzZsnx48fl888/l++//14GDRrk6tUGAAAAAABAGoeiD4q/j3+ObBddzoHz+9nGyFfyTE3bZcuWSVJSknz44Yfmltr+/ftNtu17771n7suUKSOTJ0+WRo0auWx9AQAAAAAAkJ7WK45Pir/uWrZp6XJ0ebrcG83cBdxFngnaDhkyxNwy07lzZ3MDAAAAAACA+9LAqtVilbikqzmyvKSUJPG3FCRgi3wlz5RHAAAAAAAAQP5QNaiaXE68nCPL0uVUL1ojR5YFuIs8k2kLAAAAAADyN4vFIl273iJWq0Xi45NcvTpwojrF68nqyFU3XNJA509MSZJawXVydP0AVyPTFgAAAAAAALmqXdkOUti3sMTER9/QcmKuRpvl6PKA/ISgLQAAAAAAAHJVpcDK0rpMWzl7+aypSXs9dL6zV86a5ejygPyEoC0AAAAAAHALycnJsm3bFtm6dYt5jPztkQbDJDSgjETEnjBlDrJD2+t8Or8uB8hvcqWm7YEDB2TPnj1y9uxZ8fb2luLFi0vt2rWlSpUqufH2AAAAAAAgD9BA3OnTp8XHx1tq1qzr6tWBk4UUKiUjmz0nL61/UY7HHpOyhcuJxcuSpQxbDdgGWAub+XU5QH7jtKBtTEyMfPbZZ/Lll1/KmTNnpGzZslK0aFFzpez8+fMSGRkppUqVkr59+8q9994rgYGBzloVAAAAAAAAuKGw0NYytuUEmfzn63I05ogEFwiWQL+gDAcn06C+1rDVkgiaYasBW50fyI+cErT9+uuv5aOPPpK2bdvKxIkTpWXLlmK1Wh3aXLx4UbZu3Sq//PKL9OjRQx599FG5++67nbE6AAAAAAAAcFOtyrSRKkFVZfr2abI2crWEXwgXHy+L+Pv4i8XiI0lJiXI58bIkpiSZQce6VepuSiKQYYv8zClB24iICFm4cKEULlw40zaFChWSNm3amJtm3s6ZM8cZqwIAAAAAAAA3pwHYca0mypGYcFkV8bvsObNLDkYfkMSUBPG3+EvjkKZSK7iOtCvbgUHH4BGcErR98skns9VeyyY89dRTzlgVAAAAwBg9enSWt8Srr77KVgMAwAUqBVZ2CMr6+npLQgKD0sHz5MpAZDY6GNnmzZtNDZKGDRtK/fr1c/PtAQAAAAAAkIdkVNsW8AS5FrSdOXOmGZhMg7VJSUkybdo06d+/vwwfPjy3VgEAAAAejOxZAAAAeHTQ9syZM1K8eHGHaV988YX89NNPEhAQYM+6HThwIEFbAAAA5Drt+bVs2TI5ePCgSSiwiY+PN+epmnAAAMh9FotFOne+WaxWi6Q6PAOAx3FK0Pb++++XDh06yMMPP2wP3laoUEHef/99M/BYcnKyCeBWqlTJGW8PAAAAXNPEiRPlm2++kdq1a8uOHTukUaNGcvz4cZN8cO+997L1AMDFgVu9pb6oBgCextsZC9WArAZpNXj7yiuvmJPft956S65evSpvvvmmvPPOO+Lv7y9TpkxxxtsDAAAA17Ro0SJzfrpgwQIpX768jB8/XlasWCHdu3eXhIQEth4AAADyX6at1WqV++67T+666y6TwaC1a9u2bSvDhg2TEiVKOOMtAQAAgCyLi4uTunXrmsfVq1c32bbVqlWToUOHyuDBg9mSAOAi2jN39+5d4uvrLdWr1xZvb6fkmgGA23Pq0c/X19d0L9PM26pVq8qDDz4oL7/8ssm8BQAAAFylXLlypnat0mCtBm1ttW5jY2P5YADARfQ4fPJkpERGRprHAOCpnJJpqye92sXsyJEjUrp0aRk1apT07dtXevfuLQsXLjTB27CwMBkyZIiULFnSGasAAAAAZGrQoEHyzDPPmISCW2+91Zyn+vj4yNatW6VJkyZsOQAAAOS/TFsN0nbr1k2+++47efTRR+XJJ580I/HqibCWTPjxxx+lZs2adD0DAACAS+g56YwZM8w4DFWqVJGpU6dKVFSUKZnw6quv8qkAAAAg/2Xanj9/3ozAW6lSJSlQoIAZgExvWutW6SiQffr0kV69ejnj7QEAAIB/1axZM/tjHX9BbwAAAEC+DdqOGDFCHnroIQkMDJSYmBjT/axw4cLp2mnwFgAAAMhtFy5ckNmzZ8vOnTslMTExXd3EefPm8aEAAAAgfwVt77//frnlllskIiJCSpUqRd1aAAAAuJVnn33WBGxvv/12CQgIcPXqAAAAAM4P2q5fv94MNFasWLEsz7Nu3Tpp1aqVM1YHAAAASHfuOX/+fKlfvz5bBgAAAJ4xENk333wj/fv3l8WLF8vFixczbXf58mX54Ycf5N577zXzAAAAALkhJCREvL2dcioMALgBWkaxY8eb5KabOlNSEYBHc0qm7eTJk2XDhg3y4YcfyqhRo0wGQ+XKlaVo0aKSnJws0dHRsn//ftm3b580bNhQhg8fLq1bt3bGqgAAAAAZlkcYP368PP7441KhQgXx9fV1eD00NJStBgAuooOYW60WiY9P4jMA4LG8UtKOupDDwsPDZc2aNbJnzx45d+6ceHl5SXBwsNSuXduM0Ksnya4QFRWbq+/X75e+4km8vL0kJdmpu5Zbmd/9K1evgkfgxA3sV8gLOFY5X4kS6Qe4za6aNWs6PNdzVKWnxvp479694u5y+3w2N/D/A/YDcDwA3w3whHOEElk4n3VKpm1qmmGrNwAAAMBdLFu2zNWrAADIgPbO3bdvr/j6ekuVKjUoZQPAY1HICwAAAB5Hs2kzummdWz8/P0lKyj+ZHACQl2iPhxMnjsvx48fNYwDwVE7PtAUAAADcTZcuXUw2l7IFBWwlEpSPj4907txZJk6cKAEBAS5bTwAAAHgmgrYAAMCpqOuev+XVuu4TJkyQmTNnygsvvGAGxlU7d+6UV155RW6//XZp2bKlvPnmm/Laa6/JpEmTXL26AAAA8DCURwAAAIDHef/9902Atk2bNiaTVm9hYWEms/azzz6T+vXry+jRo2Xp0qWuXlUAAAB4oFwJ2m7evFkef/xx6dGjh/z1118yY8YM+eWXX3LjrQEAAIB0Ll68aEogpKU1bWNjY81jDeQmJCSw9QDcEOqyAgDcsjzCkiVLTJZC37595ffff5fExERzgvzcc89JTEyM3Hfffc5eBQAAAMBB165dZcyYMfLiiy9K3bp1TVBl9+7dphSC1rK9fPmySTTQjFsAyI6YmGiJiDguZ85ESXT0OTOwocVikaCgYlK8eAkpW7a8BAYGsVEBAK4N2k6dOlXGjx9vaoMtWLDATBs0aJCUKFFC3nvvPYK2AAAAyHUarNVSCIMHDzZJBUoTC3r37i2jRo2StWvXmiDuW2+9xacDIEsuXoyT7du3SGTkCUlIiBcvL29zXNFBDjVwe/JkhERGHpc9e3ZKmTLlpEGDxlKoEAMdAgBcFLQ9duyYfXCH1DRr4fTp085+ewAAACAdPz8/k1Wr2bbh4eEmsFK+fHkpWLCgeV2zbfUGAFmhgdo//9wgcXGx4u9fUPz9g0ywNi3N6o+PvypHjhySqKjT0qxZmISGlmUjpylT07Zte7FaLeYxAHgqpx8Bq1atKqtXr043feHCheY1AAAAIDds2rTJnlWrj/Wm2bRaCkHr2Opj23QAyE7AdsOGNXLp0kVT9sDPr0CGAVul0/V1baft169fbeaH4zbSC2h6y2w7AoAncHqmrdazfeSRR2TDhg1mIIfp06eb7Ntdu3bJhx9+6Oy3BwAAAIz+/fubsgfBwcHmcWY0SLB37162GoAslUTQDFvNni1cODDLQUYtnaDtY2NjzPxBQUUplQAAyN2gbdOmTWXx4sXy+eefm+fR0dGmXMIbb7whoaGhzn57AAAAwNi3b1+GjwHgemkN27i4OAkMzHrA1kbbFy5cxAxcpstp1aodH4SIJCcny8GDB8TX11sqVqxKiQQAHsvpQds///xTGjVqJP/5z38cpl+6dMkMUjZ8+HBnrwIAAACQqaioKNmyZYvJwNWEAwDIipiY86a0gb+/v8mcvR46X4ECBc1yNHirZRM8ndb9PXr0iPj4eEuFClVcvToAkH9r2vbr1890P0s76JgGbadNm+bstwcAAAAMLdWlg49pQsHRo0fNtJUrV0qXLl1k1KhRMnToULnrrrvkwoULbDEA/yoi4oQkJMSL1ep3wwMj6nIiIo6z1QEAdrkyFKN2FenZs6esWbMmN94OAAAASGfGjBny22+/yYQJE6R06dISHx8vzz//vJQtW9YEb9evX2+mv/vuu2w9AP/qzJkokyl7o4Nl6fx6O3s2iq0OAMi9oK1++WhGw+OPPy7Dhg2TKVOmmO4OjAIJAACA3PTjjz/KuHHj5I477jCZbRqkPXPmjAwYMMAkGVitVnnggQdkyZIlfDAA/lV09Dnx8cmZioM+Pr5y/vw5tjoAIPeCthqgVffee698+umn8sMPP8jAgQOvq9uZlljQ4G/z5s2lbdu28uqrr8rVq1fNaydOnDAn3DrI2a233kpWLwAAABycPHlSatasaX+uQVtNJGjfvr19mmbaxsTEsOUA/Ovv3KSkpBxLRtLl6PJsv58BAMiV8gg29evXl2+//VYsFoupc5sd+uWlAdvLly/LZ599Ju+8846sWLHCdF/T1zSLt3jx4mb5PXr0MAOc6Yk5AAAAoIoVK2YGHbPRkgi1atWSEiVK2KcdOHDA4TkAZBZk1d+1ORVk1eXo8uiRCgDItaBtr169TPczm6JFi8rMmTOlT58+JpMhq8LDw2Xbtm0mu7ZatWpmZF8N4v7888+yYcMGk2n70ksvSZUqVcwgEppxqwFcAAAAQN18883y1ltvyf79+2XOnDly5MgRufPOO+0b5+zZs/L2229Lp06d2GAA/lVQUDFJTEzMkS2VmJggRYsWY6sDAHIvaKtB1oCAAIdpevXwiSeekOXLl2d5OZrxoMFezaZNLS4uTrZv3y61a9eWggUL2qc3adLEBHkBAAAApeeftgFy33zzTROwvf/++81r06dPl44dO4qvr69JDACAf1O8eAlJSUm+4WxbnV9vwcFk+Stvb29p3bqNtGnT1jwGAE+VM1XT07jpppvkm2++MVm1mqmQWRcPnb506dIsLbNIkSKmjq1NcnKyzJ8/X1q2bGm6uZUsWdKhfXBwsJw6deoG/xIAAADkF4UKFZKpU6eai/4qdWJB48aNZfLkySZwm1MDCwHI38qWLS979uyU+Pir4udX4LqXo+O0+PpazfLwT5wgIKCwWK0WiY9PYpMA8FhOOSPVerJ6UqxGjBjhjLcw2RF79uwxweG5c+ea0X5T0+fx8fGZzu/rq/WCJNd4eefim7kBby8vSfagi6J6QgHn8/FhO4P9Ki/iOzB/y4vfgWl7gSkd6BYAsiMwMEjKlCknR44cMr8/vbyy/wNIM3WvXLkklSpVNcsDAMCpQVutY5vR45wM2H7yySdmMLLq1aubmrnR0dEObTRgW6BA5lc7ExJy94pdSrJnjQKqAVtP+pu5Asy2Rt7G/7BzedL3geI7EAA8R4MGjSUq6rTExl6QwoUDszWQmJZE0Pk0q1SXg//1qg0PPyy+vt5SrlwlSiQA8FhOy4XcsWOHjB8/Xs6dO2ee6/2wYcOkUaNGpnzCZ599dl3LnThxohk4QgO3Xbt2NdNCQkLkzJkzDu30edqSCQAAAAAA5JRChQKkWbMwsVr9JDY2xmTOZoW20/Y6n86vy4Ft26TI4cOH5NChQzdcLxgA8jKnBG3XrVsn9913nxw/ftw+muZTTz1lpo8aNco81kHFvv3222wtV2uQLViwwIzq2717d/v0Bg0ayO7du+XKlSv2aZs3bzbTAQAAAABwltDQstKyZRspWLCQxMREm9+lmQUbdbq+ru20fVhYWzM/AAC5Uh7hww8/lEceecTUtlUHDx6UDRs2yJAhQ+See+4x07TbyEcffWRG7c2Kw4cPywcffGCW0aRJEzP4WOoaZKVLl5bRo0fLY489JitWrDCZvq+++qoz/jwAAAAAAOy0tm1QUFHZvn2LREaekAsXos1vXh8fX3OvwdrExARzr4OOaQ1bLYlAhi0AIFeDtrt27TJlDGxWrVplvqhs5QxU3bp15ejRo1le5rJlyyQpKckEhPWW2v79+01A9/nnn5fevXtLhQoVZNq0aRIaGppDfxEAAADyupo1a2a53uTevXtz7H11ZPgJEybIkiVLzJgLgwYNMreM6EC748aNkwMHDkjVqlXNfHreDMD9aQC2Vat2Jos2IuK4nDkTJdHR58zvWIvFIiEhpSQ4uISULVueQccAAK4J2tquJNpoWYRixYpJnTp17NNiY2OvOVBYWpphq7fMaKB2/vz5N7DWAAAAyM/mzZvnkvd94403TFKDDqR78uRJUy5Mkwu6devm0O7SpUvmfPf222+X1157Tb744gsZOnSo/Pbbb1KwYEGXrDuA7AsMDHIIyupv4+wMUAYAgNOCtjrY2K+//iqPPvqoqWu7ceNG6dOnj0MbPQmtV68enwIAAAByhZbUyoq///47x95TA7Fff/21fPzxxyaBQW9aOkwH5U0btF20aJH4+fnJs88+awI82otMe6zpebX2JktLs/cyo/N7e3tnqa3SLEBPaKuj0l9rYCN3aKufmy3Al5/bajttnxH9SPU12z58rbZp9/e81jYn/5ed1Ta3/5f1PjlZb47zc4zw3GOE7gZp9yV3+1/mGJE7x4ika7TPa8cIlwVtn3zySRkwYIDpAhYZGSlBQUEmgKvWr19vMmL1BFSzDQAAAIDcFh4eLm+99ZYZndx2sq4n1vHx8XLu3DlTpiAn7Nu3zwzMq0kNNjo+w/Tp0x2CUmr79u3mNdsPVr1v3LixbNu2LcOg7dKlSzJ93+LFi0uTJs3sz1esWCpJSRn/8CxatJg0b97C/nzlyhWSkJCQYdvAwEBp2bKV/fmaNascBgNOLSAgQFq3bmt/vmHDOomLi8uwrfbAa9++o/35pk0bJSYmJsO2vr6+0qlTZ/vzzZv/lPPnz2XY1mLxls6d/1eibevWzXLmzBnJTNeut9gf79ixTU6fPp1p286db7b/ONu9e5ecPBmZaduOHW8Sq9VqHu/bt1dOnDieadu2bdvbM6sPHjwgR48eybRt69ZtJCCgsHkcHn5YDh8+lGnbli3D7Nmfx44dlQMH9mfatlmz5lKsWLB5HBFxQvbuzfz/oVGjJlKyZEnz+K+/TsquXTszbdugQUMpVaq0eXz69CnZvn1bhu18fLylZs06UqbMPwN06Xgm+tllplat2lK+fAXzWPeFTZv+yLRt9eo1pFKlyubxhQsxsmHD+kzbVqlSVapWrWYeX7wYJ2vXrsm0bcWKlaRGjZrm8eXLl2X16pWZti1XrrzUrv1PL1Q95qxYsSzTtqGhZaRevfrmsR6rrvV/HxISIg0bNs7zxwg9Nupxz2LxksTEf46THCM8+xihxwTdF1KrW7cexwgPO0asW7dWoqMvZNg2Lx4j+vXrKy4J2mrdrV9++cUEbfUAe8stt5jyCGrnzp3mIKzd01KfvAIAAAC5ZezYsebHzeDBg+WVV14x2a2abPD555/Lyy+/nGPvo8GmokWL2gN2th9CWuc2Ojrafo5sa6t1bFMLDg42mbmZ/ZDIrMe1r69FrNb/ZXvoD97M23o7tNXnKSn/CyanpstJ2zYxMWtt9bnerrUOPj6WLLdN/TyztrqNHNtaMm2rstvWFrS91jrY2tqWnZNtU3/O2Wn7z7bO6jr8W1vvLLd1XF/LNT83x/V1zd+Wel/LTtvExKy3Fcl6W72+lNXtoLLb1l2OESkpXlKnTm37fqAXsNKuA8cIzzpG6L5w7fXlGOEJxwiLJevnBnnhGJEVXik3mqubR0VFxebq+/X75d8j6PmJl7eXpCR7zq41v/tXrl4Fj6AHwPj4a3ddANiv3A/fgfmbK74DS5T4J2voRtSvX1++/PJLqVWrltx7773y+OOPS1hYmCll8P3335vyBTlBlzVlyhRZsWKFfdqJEyekc+fOsnLlSilVqpR9+oMPPmgybXVdbHTerVu3yty5c9Mt+9Sp6DzZ9flabW3f9XmhWyPlEZxXHkH3g4QEyiN4anmEzM7981rXZ44ROXeMyOh3oLuVMaA8gvP/Py0W7Z2Qf8ojlCr1v9rnuZppCwAAALgzHx8fKVz4n+Bv5cqVZe/evSZo26pVK3n99ddz7H20Rq12f07N9jztoLyZtc1s8N7UPwz+DW3/kTpI9W9o69ztoMGOzPZLnZ76N/S12mZnue7YVtE24+2gzzPbjM7aZvzfu892SP1/dK19IW3b7Cw3L7RVtJUs7Qd5+RiR6TJueAkAAABAHqNlumbNmmXqqGlpr+XLl5tsiF27dpngaU7R+nHnz583dW1Tl0HQQGyRIkXStU1bJ02f22oBAoAn0Oy0I0fCze1aWY4AkN8RtAUAAIDHGT16tKxZs8bUsO3Ro4ecPXtWmjdvLk899ZTcd999OfY+Wn5Bs3p1UB2bzZs3S7169dJlYDRo0MCUQrB1pdP7LVu2mOkA4Cn02KeDYOlAjvmpmmN++lsA5A7KIwAAAMDj6IBfOmiuZtr6+/vLt99+K3/88YcEBQVJw4YNc+x9dNk9e/aU8ePHmwHP/v77b5k9e7a8+uqr9qxbLdOgmbfdunWTyZMnm4HQ7rnnHlmwYIEZhV4H9QUA5C0xMdESEXFczpyJkujoc6ZupnbDDgoqJsWLl5CyZctLYOC/17QE4LmcHrRNSEgwAzDs3LnTdAtLe3XJdsIKAAAA5BatFfvuu+9KmTJl5P7775eCBQvKe++9Z2ra1qlTR3x9fXM0q1eDtjrQWEBAgIwYMUJuvvlm81qbNm3M+XDv3r3Nax999JGMGzdOvvrqK6lRo4bMmDHDrBsAIG+4eDFOtm/fIpGRJyQhIV68vHRkeh9Tx1QDtydPRkhk5HHZs2enlClTTho0aCyFCgW4erUBeGLQ9vnnnzdZDG3btjUnogAAAICrTZo0yZQpeOmll+zTHnvsMRPI1ezbF154IUezbXVws4wGONu/f7/D8/r168vChQtz7L0BALlHA7V//rlB4uJixd+/oPj7B5lgbVqazBYff1WOHDkkUVGnpVmzMAkNLctHBSB3g7a//fabTJs2TVq3bu3stwIAAACyRJMK5syZY2rO2nTu3NkMBjZ06NAcDdoCADwjYLthwxoTjNWyB5phmxkN5Pr5FRCr1SqxsRdk/frV0rJlG5N5CwC5NhCZ1ujSk18AAADAXWiW09WrVzOcruW9AADITkkEzbDVgG3hwoHXDNimpu20vc6n8+tyACDXgraPPvqoGUzh8OHDpqYtAAAA4Gpdu3aVsWPHyp9//imXLl0yty1btpjas126dHH16gEA8hCtYRsXFyeFCxfJsBzCtWh7nU9LKuhyACDXyiN8/PHHZpTc2267LcPX9+7d6+xVAAAAANINDqZjL+jgYMnJyWaat7e39OzZU8aMGcPWAgAX0WNxs2bNxWq1mMfuLibmvCmNoPXLs5phm5bOV6BAQbOcmJhoU14BAJwetH3ttdfYygAAAHAr+uP67bfflgsXLsixY8fE19dXypYty8C5AOBimnlarFiwCdrGxyeJu4uIOCEJCfFm0LEb4efnJxcuREtExHGCtgByJ2jbvHlzc3/06FFTIkEzGSpVqiRVq1Z19lsDAAAAdps2bZJGjRqJj4+PeZzalStXHHqANWvWjC0HAPhXZ85EmUzZ7JZFSEvn19vZs1FsdQC5E7TV7AXtfrZs2TIJDAyUpKQkuXjxojkRnjZtmhmoDAAAAHC2/v37y9q1ayU4ONg8zoz+aKaEFwC4hiZ6afaqr69FQkJC3b5EQnT0OXMxMCf4+PjK+fPncmRZAPI+pwdtJ02aJKdOnZJFixZJ5cqVzbRDhw7Jc889J6+++qq88sorzl4FAAAAQPbt25fhYwCA+0hJSZG9e/eIj4+3lCxZWtx9XTUx7UazbG10Obo8XW5OLRNA3uX0oO3y5ctlzpw59oCt0tIIL774ojz88MPOfnsAAAAgU1FRUZKYmGh+IKcWGhrKVgMAXJMGVi0Wiwm05gT9LtLlEbAFkCtBWy2mnVF3BtsVJAAAACC3rVmzxiQR/PXXX+a5LavJdk95BABAVgQFFZOTJyNyZGMlJiZISEgpNjyA3AnadurUSSZMmCBvvfWWlC9f3j4omZZNaN++vbPfHgAAAEhn4sSJUr9+ffnwww8lICCALQQAuC7Fi5eQyMjjN1zSQOfXW3BwCT4JALkTtH3mmWdk2LBh0rVrVylSpIh9cLK2bdvK2LFjnf32AAAAQDo65sLMmTOlXLlybB0AwHUrW7a87NmzU+Ljr4qfX4HrXs7Vq1fF19dqlgcAuRK01UDtp59+agZ7CA8PN+USKlWq5FDjFgAAAMhNTZs2lc2bNxO0BQDckMDAIClTppwcOXJIrFareHmlLw/5b1JSkuXKlUtSqVJVszwAcFrQ9uTJk1K6dGnTNUAf24K3DRs2dGijGOQBAAAAua1Zs2amhNfvv/8uFSpUEF9fX4fXhw8fzocCAMiSBg0aS1TUaYmNvSCFCwdmq0yClkTQ+QICCpvlAIBTg7Zax3bt2rUSHBxsHmd0wGKQBwAAALiKnqvWrVtXzp49a26pMWo3ALiODmTeqFETsVq9MxzU3B0VKhQgzZqFyfr1qyU2NkYKFy6SpYxbzbDVgK3V6mfm1+UAgFODtsuWLZOiRYvaHwMAAADuRMt3AQDcj144K1mypFitFomPT5K8IjS0rLRs2Ub+/HODxMRES4ECBU15yMyS2LSGrZZE0AxbDdjq/ADg9KBtmTJl7I9Hjx4tU6dOtQ9CZnPu3Dl56KGH5LvvvnPGKgAAAADXpOMt7N+/3/xwTqtnz55sPQBAtmht26CgorJ9+xaJjDwhFy5Em6Ctj4+vuddgbWJigrnXQce0hq2WRCDDFkCuBW1XrVolO3bsMI83bdok06dPl4IFCzq0OXbsmERGRjrj7QEAAIBrmjt3rrz22msmsSAgwLE7qv6wJmgLAK6RnJwsf/11Unx9LVK8eEieKZFgowHYVq3amWzbiIjjcuZMlERHn5OkpCSxWCwSElJKgoNLSNmy5Rl0DEDuB20rVaokM2fONFeP9LZlyxaHwR30RFiDuC+//LIz3h4AAAC4po8//liee+45GTBgAFsKANyIxhB27dopPj7e0qFDZ8mrAgODHIKytnF9AMClQdty5crJvHnz7OURnn/++XQZDAAAAICrXLlyRW666SY+AABAriBgCyC7nNLP4OTJk+YqkhoxYoRcuHDBTMvoBgAAAOS2Hj16yOeff86GBwAAgOdk2nbq1EnWrl0rwcHB5rGt4HZaOn3v3r3OWAUAAADAQf/+/e2ZTgkJCbJ161ZZvHixlC1bNl3NRFuvMQAAACDfBG2XLVsmxYoVsz8GAAAAXK1FixYOz1u3bu2ydQEAAAByPWhbpkwZh8daHsHPz8/c9u3bJ2vWrJE6depIWFiYM94eAAAASGf48OEOz8+ePWvOU3UQXbVo0SJp1qyZlChRgq0HAACA/FfTNrWlS5dKu3btZPPmzXLs2DG5//77ZeHChfLYY4/J/Pnznf32AAAAQDrr16+XLl26yE8//eRQEuHWW281560AAABAvg7avvvuu/L4449Lq1at5Ouvv5bSpUvLL7/8Im+//bbMnj3b2W8PAAAApPP666/LI488Ys5TbRYsWCAPPfSQvPLKK2wxAHARrTHeoEFDadiwUbp64wDgSZx+BDx+/Ljccsst9vq2mtGgqlWrJufOnXP22wMAAADpHD16VLp165Zuup63Hjp0iC0GAC6iA0aWKlXaJHzZBo8EAE/k9KBtaGiobNy40XRBO3LkiHTq1MlM165oFStWdPbbAwAAAOlUrlxZFi9enG768uXLpXz58mwxAAAA5L+ByFLTLmfPPvusJCUlSYcOHaRevXqmO5p2P5s6daqz3x4AAABI54knnjBjLKxdu9YMkKv2798vf/75p7z//vtsMQBwkZSUFDl9+pT4+lqkWLESZNsC8FhOD9rqYA4tW7aU06dPS61atcy0u+66SwYPHizFixd39tsDAAAA6ehAuTo47jfffCPh4eHi4+MjNWvWlAkTJki5cuXYYgDgIsnJybJ9+zbx8fGWDh06i8Vi4bMA4JGcHrRVBQsWlJ07d8r3339vMm4rVapkgrkAAACAq+gYC6NHj5aYmBgJCAgwA95QPxEAAAAeUdP2wIEDcvPNN8uHH34oJ0+eNLcZM2aYoC2DPAAAAMBV3W/1/LRFixYSFhZmzlGfeeYZefHFFyU+Pp4PBQAAAPk7aPvyyy9L69at5bfffjP1wT744ANZunSptG/fXl555RVnvz0AAACQzrRp0+THH3+U1157TaxWq5nWq1cvU+P2jTfeYIsBAAAgfwdtt23bJg8//LCpE2bj6+trpm3duvW6lqnZD7fddpts3LjRPm3SpElSo0YNh9v8+fNz5G8AAABA/qL1bF966SXp2LGjvSSCJhrogLmLFy929eoBAADAwzm9pm2JEiXk+PHjUrlyZYfpOq1QoULZXt7Vq1fl6aefloMHDzpMP3z4sJmuGRI2WpsMAAAASOvs2bNSsmTJdNOLFCkily5dYoMBAAAgf2fa3nPPPfLCCy/I119/Lfv37ze3r776SsaOHSt33XVXtpalNXD79u1rAr5padC2du3aJkhsu/n7++fgXwIAAID8omXLljJr1iyHaXFxcfL222+bOrcAAABAvs60HTx4sFy+fFneeustMzKvKl68uAwYMEAGDRqUrWX98ccf5iT6ySeflIYNGzqcYJ8+fVoqVqyY4+sPAACA/GHTpk3SqFEjU7Zr/PjxMnz4cFMSQXtyPfbYY2YwstDQUDNAGQDANbRkTd269cTX12IvXwMAnsjpQVs9yI4YMcLctBuan5/fdZctuO+++zKcrlm2+j7Tp0+XVatWSVBQkAwcONChVAIAAAA82wMPPCBr1qyR4OBgKVWqlHzzzTeyfv16CQ8Pl8TERKlUqZK0adNGvL2d3hkNAJAJPQaXKVNWrFaLxMcnsZ0AeCynBW1/+OEH+e2338ygY507d5bu3bubE2Rn0BNtDdpq3dx+/fqZLAotv6DB4S5dumQ4zz9X7STXeHl71hVCby8vSfag3zt6QgHn8/FhO4P9Ki/iOzB/y0vfgSkpKemmhYWFmRsAAACQ74O2n3zyibzxxhvmBFizFkaNGmVq2T711FPOeDvp2bOnGflXM2xVzZo15ejRo/LFF19kGrRNSMjdK3Ypyel/JORnGrD1pL+ZK8Bsa+Rt/A87lyd9Hyi+A90bXW0BwP0vsEVFRYnV6i2BgcEctwF4LKcEbRcsWCAvv/yyCaaqJUuWyOjRo00tWmecKOsybQFbG8263bBhQ46/FwAAAPKuO++8M0vlD5YtW5Yr6wMAcJScnCxbt24WHx9v6dChs1gseadHBwC4fdD2xIkTDt3MOnXqZAYj+/vvvyUkJCTH32/KlCmydetWmTt3rn3avn37TOAWAAAAsNFxDwoXLswGAQAAgOcFbbUkgo7Ka38THx8zAFl8fLwz3s6URpgxY4bMmjXLlEPQASa+//57mTdvnlPeDwAAAHmP9s5y5jgLAAAAQE7JF0NF1a9f32Tb6uBnt912m3z66acyefJkadSokatXDQAAAG48EBkAAADgMZm2avHixRIQEOBQl+a3336TYsWKObSz1b3NLh3YLLXOnTubGwAAAJCRXr16md5fAAAAgEcGbUNDQ2X27NkO07Qb2vz589N1UbveoC0AAACQHa+++iobDAAAAJ4btF2+fLkzFgsAAAAAAAAA+Z7TyiMAAAAAAABkh/bIrVWrtvj6WsxjAPBUBG0BAAAAAIBb8Pb2lvLlK4jVapH4+CRXrw4AuIy3694aAAAAAAAAAJAWmbYAAAAAAMAtpKSkyPnz50ymbaFCgZRIAOCxyLQFAAAAAABuITk5WTZt+kM2btxoHgOApyJoCwAAAAAAAABuhKAtAAAAAAAAALgRgrYAAAAAAAAA4EYI2gIAAAAAAACAGyFoCwAAAAAAAABuhKAtAAAAAAAAALgRH1evAAAAAAAAgPLy8pLq1WuI1WoxjwHAUxG0BQAAAAAAbsHb21sqVapsgrbx8UmuXh0AcBnKIwAAAAAAAACAGyHTFgAAAAAAuIWUlBS5cCFGfH0t4u8fQIkEAB6LTFsAAAAAAOAWkpOTZcOG9bJ+/TrzGAA8FUFbAAAAAAAAAHAjBG0BAAAAAAAAwI0QtAUAAAAAAAAAN0LQFgAAAAAAAADcCEFbAAAAAAAAAHAjBG0BAAAAAAAAwI34uHoFAAAAAAAAlJeXl1SpUlV8fb3NYwDwVARtAQAAAACAW/D29paqVauJ1WqR+PgkV68OALgM5REAAAAAAAAAwI2QaQsAAAAAANxCSkqKXLwYJ76+FrFa/SmRAMBjkWkLAAAAAADcQnJysqxdu0bWrFltHgOApyJoCwAAAAAAAABuhKAtAAAA4MRuvm+99Za0bNlSmjdvLm+88cY1M8cmTZokNWrUcLjNnz+fzwcAAMDDUNMWAAAAcJI5c+bIzz//LFOnTpXExER55plnJDg4WAYPHpxh+8OHD8vTTz8tvXr1sk8LCAjg8wEAAPAwZNoCAAAATjJv3jx5/PHHpWnTpibbduTIkfLZZ59l2l6DtrVr15YSJUrYb/7+/nw+AAAAHoagLQAAAOAEp0+flr/++kuaNWtmn9akSROJjIyUv//+O137uLg4M0/FihX5PAAAADwc5REAAAAAJ4iKijL3JUuWtE8rXry4uT916pTDdFuWrZeXl0yfPl1WrVolQUFBMnDgQIdSCan5+lrEyyt/fXQ+PhZXrwLcAPuBZ0tK0n3AWywWb7FaLWKxcFzwdBwT4Kn7AUFbAAAA4DpduXLFZMdm5NKlS+bearXap9kex8fHp2sfHh5ugraVK1eWfv36yaZNm2Ts2LGmpm2XLl3StU9ISMqXn1t8fP78u5A97AeeSwdrLFu2gvj6ektCQrIJ4gIcE+CJ+wFBWwAAAOA6bd++XR544IEMX9NBx2wBWj8/P/tjlVGd2p49e0rHjh1Nhq2qWbOmHD16VL744osMg7YAkB95e3tLjRo1TZatpwVoACA1grYAAADAdWrRooXs378/w9c0A/fNN980ZRLKli3rUDJBBxhLS7NsbQFbG8263bBhA58PAACAh2EgMgAAAMAJQkJCJDQ0VDZv3myfpo91Wtp6tmrKlCkyYMAAh2n79u0zgVsA8BQpKSmmvIze9DEAeCoybQEAAAAnuffee+Wtt96SUqVKmeeTJ0+WQYMG2V8/d+6cKZ1QqFAhUxphxowZMmvWLFMOYc2aNfL999/LvHnz+HwAeFRN29WrV5rByDp06MxAZAA8FkFbAAAAwEkGDx4sZ8+eleHDh5vAQ58+fRyyafV5r169ZMSIEVK/fn2Tbfvee++Z+zJlypggb6NGjfh8AAAAPAxBWwAAAMBJNFA7evRoc8vI8uXLHZ537tzZ3AAAAODZqGkLAAAAAAAAAG4kTwZt4+Pj5bbbbpONGzfap504ccJ0NWvYsKHceuutpgYYAAAAAAAAAOQ1eS5oe/XqVXnqqafk4MGD9mk6ouSwYcOkePHi8u2330qPHj1M3bCTJ0+6dF0BAAAAAAAAIF/XtD106JA8/fTTJkib2oYNG0ym7YIFC6RgwYJSpUoVWb9+vQng6qAOAAAAAAAAAJBX5KlM2z/++ENatGghX375pcP07du3S+3atU3A1qZJkyaybds2F6wlAAAAAAC4Hl5eXlKuXHkpX768eQwAnipPZdred999GU6PioqSkiVLOkwLDg6WU6dOZbosX1+L5Obx38vbs75svL28JDlPXRK4MVarxdWr4BF8fNjOYL/Ki/gOzN/4DgQA5CRvb2+pXbuO+X6Jj09i4wLwWHkqaJuZy5cvi9VqdZimz3XAsswkJOTuwT8l2bGkQ36nAVtP+ps5mWBbI2/jf9i5POn7QPEdCAAAAOBG5YtcSD8/v3QBWn1eoEABl60TAAAAAADIPv09f60kLADwBPkiaBsSEiJnzpxxmKbP05ZMAAAAAAAA7ispKUlWrFgmy5YtNY8BwFPli6BtgwYNZPfu3XLlyhX7tM2bN5vpAAAAAAAAAJCX5IugbfPmzaV06dIyevRoOXjwoMyYMUN27Nghffr0cfWqAQAAAAAAAIDnBW0tFot88MEHEhUVJb1795Yff/xRpk2bJqGhoa5eNQAAAAAAAADIFh/Jo/bv3+/wvEKFCjJ//nyXrQ8AAAAAAAAA5IR8kWkLAAAAAAAAAPkFQVsAAAAAAAAAcCN5tjwCAAAAAADIX7y8vCQ0tIz4+nqbxwDgqQjaAgAAAAAAt+Dt7S316tUXq9Ui8fFJrl4dAHAZyiMAAAAAAAAAgBsh0xYAAAAAALiNpKQkSSLJFoCHI2gLAAAAAADcJmC7dOkS8fHxlg4dOovFYnH1KgGAS1AeAQAAAAAAAADcCEFbAAAAAAAAAHAjBG0BAAAAAAAAwI0QtAUAAAAAAAAAN0LQFgAAAAAAAADcCEFbAAAAAAAAAHAjPq5eAQAAAAAAAOXl5SUhISHi62sxjwHAUxG0BQAAAAAAbsHb21saNmwsVqtF4uOTXL06AOAylEcAAAAAAAAAADdC0BYAAAAAAAAA3AjlEQAAAAAAgFtISkqSpUuXiI+Pt3To0FksFourVwkAXIJMWwAAAAAAAABwIwRtAQAAAAAAAMCNELQFAAAAAAAAADdC0BYAAAAAAAAA3AhBWwAAAAAAAABwIwRtAQAAAAAAAMCN+Lh6BQAAAAAAAJSXl5cUL15cfH0t5jEAeCqCtgAAAAAAwC14e3tLkybNxGq1SHx8kqtXBwBchvIIAAAAAAAAAOBGCNoCAAAAAAAAgBuhPAIAAAAAAHALSUlJsmLFUvHx8Za2bTuJxWJx9SoBgEsQtAUAAAAAAG4jKSlZGIMMgKejPAIAAAAAAAAAuBGCtgAAAAAAAADgRgjaAgAAAAAAAIAbIWgLAAAAAAAAAG6EoC0AAAAAAAAAuBEfV68AAAAAAACATdGixcTXlxwzAJ6NoC0AAAAAAHALFotFmjdvIVarReLjk1y9OgDgMly6AgAAAAAAAAA3QtAWAAAAAAAAANwI5REAAAAAAIBbSEpKkpUrV5iatq1atTflEgDAExG0BQAAAAAAbiMhIUFSUugYDMCzcRQEAAAAAAAAADeSr4K2v/32m9SoUcPh9vjjj7t6tQAAAAAAAADAM8sjHDp0SDp27CgTJ060T/Pz83PpOgEAAAAAAACAxwZtDx8+LNWrV5cSJUq4elUAAAAAAAAA4Lp457egbcWKFV29GgAAAAAAAABw3fJN0DYlJUWOHDkia9aska5du0rnzp3lrbfekvj4eFevGgAAAAAAyKLAwEBzAwBPlm/KI5w8eVIuX74sVqtV3n33XYmIiJBJkybJlStX5IUXXkjX3tfXIl5eubd+Xt65+GZuwNvLS5LzzSWBf2e1Wly9Ch7Bx4ftDParvIjvwPyN70AAQE6yWCzSsmUr8/0SH5/ExgXgsfJN0LZMmTKyceNGczXOy8tLatWqJcnJyfLMM8/I6NGjzYE/tYSE3D34pySniCfRgK0n/c2cTLCtkbfxP+xcnvR9oPgOBAAAAHCj8lUuZFBQkAnY2lSpUkWuXr0qMTExLl0vAAAAAAAAAPC4oO3q1aulRYsWpkSCzd69e00gt1ixYi5dNwAAAAAA8O+SkpJk5coV8vvvy81jAPBU+SZo26hRI/Hz8zP1a8PDw2XlypXyxhtvyEMPPeTqVQMAAAAAAFmkY9NcvnyF7QXAo+WbmrYBAQEya9YseeWVV+TOO++UQoUKyT333EPQFgAAAAAAAECekm+CtqpatWoyZ84cV68GAAAAAAAAAFy3fFMeAQAAAAAAAADyA4K2AAAAAAAAAOBGCNoCAAAAAAAAgBvJVzVtAQAAAABA3h9o3MeHHDMAno2gLQAAAAAAcAsWi0Vat24rVqtF4uOTXL06AOAyXLoCAAAAAAAAADdC0BYAAAAAAAAA3AjlEQAAAAAAgFtISkqSDRvWmZq2TZu2NOUSAMATkWkLAAAAOFlKSooMGjRIvvvuu2u2O3HihAwYMEAaNmwot956q6xZs4bPBoDHiYuLMzcA8GQEbQEAAAAnSk5OlkmTJsnatWv/NbA7bNgwKV68uHz77bfSo0cPGT58uJw8eZLPBwAAwMNQHgEAAABwktOnT8vIkSMlIiJCihQpcs22GzZsMJm2CxYskIIFC0qVKlVk/fr1JoA7YsQIPiMAAAAPQqYtAAAA4CS7d++W0qVLm8Br4cKFr9l2+/btUrt2bROwtWnSpIls27aNzwcAAMDDkGkLAAAAOEmnTp3MLSuioqKkZMmSDtOCg4Pl1KlTTlo7AAAAuCuCtgAAAMB1unLliimBkJESJUo4ZM3+m8uXL4vVanWYps/j4+MzbO/raxEvL8lXfHwYJR7sB54uKUn3AW+xWLzFarWIxcJxwdPx3QBP3Q8I2gIAAADXSUsaPPDAAxm+Nm3aNOncuXOWl+Xn5yfR0dEO0zRgW6BAgQzbJyQkSX4UH58//y5kD/uB50pKShIfH6v4+nqb/YCYLRTHBHjifkDQFgAAALhOLVq0kP379+fI9gsJCZFDhw45TDtz5ky6kgkAkJ9pZm379h1Nlq2nBWgAIDUGIgMAAADcQIMGDczAZVpywWbz5s1mOgAAADwLQVsAAADARc6dOycXL140j5s3by6lS5eW0aNHy8GDB2XGjBmyY8cO6dOnD58PAACAhyFoCwAAALiIBmRnz55t7xL8wQcfSFRUlPTu3Vt+/PFHUxc3NDSUzweAR9W03bBhnaxbt9Y8BgBPRU1bAAAAIBcsX778X6dVqFBB5s+fz+cBwKPFxMSIjw85ZgA8G0dBAAAAAAAAAHAjBG0BAAAAAAAAwI0QtAUAAAAAAAAAN0LQFgAAAAAAAADcCEFbAAAAAAAAAHAjPq5eAQAAAAAAABtfX1/x9SXHDIBnI2gLAAAAAADcgsVikU6dOovVapH4+CRXrw4AuAyXrgAAAAAAAADAjRC0BQAAAAAAAAA3QnkEAAAAAADgFpKSkmTz5j9NTdv69RubcgkA4IkI2gIAAAAAALdx/vw58fGhYzAAz8ZREAAAAAAAAADcCEFbAAAAAAAAAHAjBG0BAAAAAAAAwI0QtAUAAAAAAAAAN0LQFgAAAAAAAADcCEFbAAAAAADgNiwWb3MDAE/m4+oVAAAAAAAAUBaLRTp37ipWq0Xi45PYKAA8FpeuAAAAAAAAAMCNELQFAAAAAAAAADdCeQQAAAAAAOAWkpOTZevWzeLra5G6dRuKtze5ZgA8E0FbAAAAAADgFlJSUuTMmTPi4+NtHgOAp+KSFQAAAAAAAAC4kXwVtL169aqMGTNGmjZtKm3atJHZs2e7epUAAAAAAAAAwHPLI7zxxhuya9cu+eSTT+TkySBXxOQAABkwSURBVJMyatQoCQ0NlW7durl61QAAAAAAAADAs4K2ly5dkq+//lo+/vhjqVOnjrkdPHhQPvvsM4K2AAAAAAAAAPKMfFMeYd++fZKYmCiNGjWyT2vSpIls377djD4JAAAAAAAAAHlBvgnaRkVFSdGiRcVqtdqnFS9e3NS5jY6Odum6AQAAAAAAAIDHlUe4fPmyQ8BW2Z7Hx8ena1+iRGHJTf8dsDhX3w8AAHfBdyDgHLl9PgsAuaVfv75sbAAeL99k2vr5+aULztqeFyhQwEVrBQAAAAAAAAAeGrQNCQmR8+fPm7q2qUsmaMC2SJEiLl03AAAAAAAAAPC4oG2tWrXEx8dHtm3bZp+2efNmqVevnnh755s/EwAAAAAAAEA+l2+imf7+/tKzZ08ZP3687NixQ5YuXSqzZ8+WBx54wNWrBgAAAAAAAACeF7RVo0ePljp16siDDz4oEyZMkBEjRsjNN9/s6tXK07777jupUaOGfP311xm+fuLECfP6M888k+m8tlvNmjWlcePG8vjjj8vhw4dNm4iICPOa3iP/su0DJ0+eTPfaF198YV57//337dN27dolgwcPlkaNGpnb/fffL2vXrrW/bttvMrq98847ZlmZva433TeRt1y6dEneffdd6datm9SvX19atGhhjiUHDx50aLdz504ZOnSoNG3a1Bxv7r33XnMRLyO//PKL3HXXXdKgQQMJCwsz3xn79u3LsK0eA7WtLtO2Ty5fvtyhje5bGzduzMG/Gu74/de/f38z/fvvv083j3636WvaJvUyMrrZ2uh9586d5erVqw7L4vsRniQlJUUGDRr0r9/Pet45YMAAadiwodx6662yZs2aXFtHOPfzf+utt6Rly5bSvHlzeeONNyQ5OTnT9pMmTUp3TJ0/fz4fUR6k331jxowx521t2rQxSVeZ2bNnj/287c477zS/F+CZ+8Kjjz6a7hiwYsWKXF1fOJeOT3Xbbbdd87eVpxwTfCQf0Wzb119/3dyQMzSoUb58efnhhx/MP0RaixYtMq9rUOTixYtSqFAhh9dLlSol33zzjf2ELDo6WiZOnGgOtL/++isfkwfx9fU1Qa5+/fo5TNd9x8vLy/781KlT5sLLwIEDzRe3vqb74ZAhQ+Tzzz83B2UbDaaULl3aYXkFCxY09/fcc4+537p1qwnGpf5hV7gwo23nJXpsue+++0zg9rnnnjMXgLSG+WeffWY+Zw2elStXTlavXi2PPfaY9O3bV5588kkzQKWewD399NPmmPPII4/Yl6mBfT0ZfOKJJ6Rjx44SFxcnCxYsMMv78MMPTRDX5vnnnzfHupEjR5qTyKSkJLPf/uc//5E333zTBJLhWd9/tuOZ9vC51vFMg0pt27Z1aKMXGh5++GFp166dQyBq+vTpZp8CPI0G515++WVzcVZ/oGVGzyOHDRsm1atXl2+//db8vw0fPtwcn0NDQ3N1nZGz5syZIz///LNMnTrVjE+iySDBwcHmAn5G9AKZfrf36tXLPi0gIICPJQ/SAL0GWj755BOT3DFq1Cjz/5z23ErPAfW3wO233y6vvfaaSfrQi/S//fab/dwfnrEv2I4Beg6e+nw9MDAwl9cYzgzg6zE+bXKOxx4TUoBMnDlzJqVWrVopCxcuTKlRo0bK8ePH07W57bbbUubOnZvSrFmzlG+//dbhNX3esWPHdPNs3bo1pXr16il79uxJOXHihHms98i/9DN+8MEHUwYOHOgwPTY2NqVRo0YpvXr1SnnvvffMtE8++STljjvuSLcMnX/s2LHmcXb2mw0bNpi2yLtef/31lNatW6fExMRkuF+89NJLKVeuXElp1apVyttvv52uzX//+19zLNu7d695vmvXrpSaNWumrF27Nl3biRMnprRv394sT/3+++/m+Ldly5Z0badNm2aOgTa6n+n+hvz9/devXz+z3+mx6+rVqw7z9enTJ+Xuu+82bTJy6dKllK5du6bcd999KUlJSfbl6Xdl3bp1U44cOWJvy/cjPMGpU6fM/0CHDh1SmjZtmu5cMrV169alNGzYMOXixYv2afq/aDt/QN6l37upP/vvv/8+w98QNm3btk1ZvXp1Lq0dnEX/l+vVq+dw7qTnVhl9h3799dcpnTp1SklOTjbP9b5Lly7XPGYgf+4Leu6l52jh4eG5vJbIDQcPHjSxgNtvv/2av62+9qBjQr4qj4CcpZmwmpF4xx13SMmSJU22UWqHDh2SAwcOmG7Kmkm0cOHCLC3XYrHYM5XgOW666Sb5448/TEajze+//266wKTO0NaBAyMjI+XYsWMO82sGvXaHh+dlYOmxRTOvixQpkuFVec3I0axHzeR/6KGH0rXRMjlVqlQxmVlKs/+1lE6rVq3StdVM3dOnT5usXVvb9u3bm5IIaWnNdM0GgOd9/+n+oJncGzZssE/T/UaPW/qdmBnNBPj777/N8Sz1IKk9evQw2YMvvfSSk/4iwD3t3r3b9JjR4/O/9YLZvn271K5d2yGDpkmTJg6DECPv0WPnX3/9Jc2aNXP4XPVcUI+Xael5pM5TsWLFXF5T5DQtSaWZ1anPsfSz1//1tOUxdJq+ZuvNovdasor/f8/bF8LDw83nr73skP9ovEDPpb/88strttvuQccEgra4ZtfQDh06mB+WnTp1Ml2QtWuajXZjKlOmjOmqrAG5TZs2mROsa9GTrClTpkjlypWlUqVKbH0PogGJkJAQWbVqlX2adl/QWo6p3XLLLVKgQAHTrVjr282cOdNcHNB5ixcv7oI1hysdP35czp07Z4L7GdGAmu4v2p1Kf8Bl9qNfv8S13q3StvXq1cuwXbFixcxydEBLpV/8ekKQEe2Kqe3hed9/Ol1fT13XWLtq6wVMH5+MK0+tXLnSlODQchtly5Z1eE2XpwOprl+/3nT1BjyF/n/pxbesHEujoqLMMT817UKvZZWQd+nnqlJ/trbzvYw+W+0WrT/OtaSMlpnRi2tZTRyB+332RYsWFavV6vDZa9dovRCfti3///lXdvYFDdrqOfizzz5rypb16dPHnGMhf9CSeFoiUUufXkuUBx0TCNoiQ3rFe8uWLfaAmmaqac29zZs329voD0s92VaaiaYH2bQDs2g9GttgUjp4kJ5cnTlzRt5++217xi08hwb3bUEOLS6u9et0WtqDrWY3ajHxvXv3mnpFWqtG69yePXvWoa3WvrPtX7bBoZC/aO3atHWq1q1b5/C5d+/eXWJiYjLMxLXR+W3Lykpb2wmizhMUFGR/Tffb1O+tt4wG2EP+/v5TeuxKPejFsmXLpEuXLhkuU/cjDdbq63psy4heSNCayq+++qpDjwQgL7ty5YrJQM/opvXosuPy5csOP+iVPtfjMvL+fpD6s7U9zuiztWXZaQLIjBkzTM3xsWPHmkQA5C2Z/U9n9Nnz/5+/ZWdf0GOAHlM0YKvJPRqH0LErbMkZ8AyXPeicIF8NRIaczTLSrp96MFQ6kqsGMvRKtma8aRaanmjZftRq93btaqxdSHWQCBu9+vHpp5/aM4l0GdcKliB/0yCHljjQ7i+aUabZtxqkTUsHsNNuwpp5pl0n//vf/5r96IUXXjCDRNnoybpm4NroPov8xXa8uHDhgn2aBkptF4iWLFliCs/rsUUvCGVGu1jqFXyVlbZ6zLO1Tf3eWtbF9t7ac6B///7XHOEa+e/7z6Z169YmuK/HKO2ip1nZOsBdRoMmjBs3ztz/W/kDHUBP92ntkaIXqoC8TrsvaimZjEybNi1db5tr0f/LtBlX+uNMe1sg7+4HWuLI9lnazuNsP7ozyrTSASB1AFHbBVXt8Xf06FFzLpDZhTO4J/280wZYbM/T/l9n1pb/f8/bF7SUmZ5/2xI69Big52JfffVVpj3pkP/4edAxgaAtMv3RqlewUncL1hHTtc6fXs3W15V2X7fRwIV2H9VsJNt82k20QoUKbGUYtv1C9xHtSpzRybUGYvULV0cD1UC/PtabluLQOpCp6YiiabsZI3/R44f+MNu6davJ1rf9iLMdV2xB/wYNGsjcuXNNRqMtOJuanszZao1q27RZk6m72mi3GttJn76nvreNZvfY3pveAp75/Wej+6FerNTeA1pSQ4O7qetz22iwVy886bHt37qA60UK7e43evToa9bGBfIK3Y/379+fI8vSi7Q6nkJqegEubfdI5K39QC+Aaq8q/f61ndPZSiaUKFEiXXv9Hk7dA0Zp1m3qGuPIG/R/Ws/bNJnDVlpIP3sNuqRN8tG2aS+48//vmfuCLREs7TEg7fcD8rcQDzomUB4B6Rw5ckT27Nljsho1o8x2e+edd0yXTe1+tHjxYjNwSurX9Yep1pdJWyIBsNEvYe3CokEO7VacUYaNdku2ZWenpl/Y1A/1zH1Gu5PrgF8ZdRnXH3tKS6/oj7sPPvggXRsNtmkNPFu3dK19pT8e9cJBWprJrTW0dHlKu6vrgHka9M3sveFZ338ZlUjIrDSC1nmfNGmS3H333ebYlxX63aoZva+88kqO/V1AfqAX3PRYrBdVbPQCnE5H3v7hrRfhU19M1cc6LaMf39oTYcCAAekGMdKgDfKWWrVqmfO81AMH6WevF85TD9ap9P9cL6Lb6svrvf5m4P/f8/aF5557zlzcTo1jgOdp4EHHBIK2yDDLSK9g649M7b5uu+nAUFWrVjVdD2zdglO/rgdbHQxAA7paNDw7dBAzHaAq9S31oC/IPzTI8fXXX5sMyYxG/RwyZIj5/LX+ow4YpWU4tH6yZmEMHDjQJesM1xoxYoQJyGoAVQOwWl9US7Ro1uN7771nMiL1SrzWAtV9S4NkGpTVdvPmzTMndlqWQ49Rtm5U//nPf0yXTL1AoO20vc6nI5i/9tpr9i6aGmi79957zb6nbbWOlgaAP/roI3n44YfNMTF1xo+uV9pjmdZcQv74/kt7UVK76Oq+s2bNGvM4Lf1hodkguq9oxkjqmw6wlxktp5DRqOmAp9H/k4sXL5rHms1eunRpc0zXMiSava7HXL0Qh7xNv2ffeust2bhxo7lNnjzZoZxC6v1Aj7X6u2HWrFlmsNLPP//cHJtT9/5D3qA9VrTchZZD0/9lvZg+e/Zs+2ev35W2izTdunUz5apefvllk1Gp93p+pQMYw7P2BR1T56effjL/9/o7cerUqSbA269fPxf/FXC2KA89JlAeARn+aNWBn9IWdradVOk/hHYPzqhmjL6uJ08ZZbBdi/6wTUuzKTIbhRt5l9aJ1K4vmdWxa9y4senmrhmPegKuB1/teqy1knWwCXjmiZwGTDXbVjNp9QRNj09aukBriNr2JS2poTXttE6i1gPVi0caqNWAf9r9bejQoSYrR08INYtSl6cBgS+//NIEdVPTrEsNDOuxTYPECQkJJoD3xBNPmOBe6lrK+qMzLa1RSpmY/PP9l/pik1580v1Qv6sy6gnwxx9/mPuMjnda8sU2MGNaVapUMcc/vTgAeDINyPbq1ctcvNOSNPodoBd1e/fubY6rerzXjEzkbYMHDzaDzQ4fPtx8zvq5p86mTb0f6DFXs231+1jv9ViqQV6td4+8Ry/CaKBOz9u0x6Z+xjoAqO03g16Q1/93fU2/E/WipiYQ1ahRw1y4KViwoKv/BOTyvqDTdD/Q34o6GHC1atXMgGSUzMv/2njoMcErhXRGAAAAAAAAAHAblEcAAAAAAAAAADdC0BYAAAAAAAAA3AhBWwAAAAAAAABwIwRtAQAAAAAAAMCNELQFAAAAAAAAADdC0BYAAAAAAAAA3AhBWwAAAAAAAABwIwRtAQAAAAAAAMCNELQFABdKSEiQ999/X2666SapW7eudOjQQV599VWJi4vL0ff57rvvpFOnTtc9v86rywAAAED+V6NGDdm4ceN1nVf279/fzP/999+ne+3w4cPmNW2TmWPHjsmIESOkWbNm0qBBA7nzzjvl559/tr+u66XLyA2cAwNwJR+XvjsAeLi33npL1q1bJ5MmTZJy5crJiRMn5OWXXzYnq9OnT3f16gEAAADZ5uvrK8uXL5eePXs6TF+6dKl4eXllOt/ly5flgQcekI4dO8pnn30mfn5+smbNGhk1apRZZteuXaVRo0ZmGgDkdwRtAcCFFi5cKK+88oqEhYWZ52XLlpXx48fL/fffL3///beULFmSzwcAAAB5StOmTU1gNT4+XqxWq0PQtmHDhpnOp8kMly5dMufDNhUqVJA9e/bIV199ZYK2urwSJUo4/W8AAFejPAIAuJBmGmzYsEGSk5Pt0zR74JdffpG1a9dKixYtJDEx0f7af//7X1NCISUlxXTX+uabb0yXsfr168ugQYMkMjLSdCfTrmQ9evSQgwcPOrzf22+/LY0bN5a2bdvKp59+mq6r2y233GKW1bt3b9m0aVMubAEAAADkN3o+q1myep5rc/r0adObTM9vM+Pt7S0XL16Ubdu2OUx/+umnTc+0jMojaE+1AQMGmPPf22+/XWbNmmUv36Dnt1qK4b333jPvq8FkLUWm59JKg8r6XM+N69SpY+b78ssvc3x7AMD1IGgLAC6k3b80eKoniOPGjTNB2StXrkjVqlXl5ptvNo9Tn+wuXrzYBFZt3creffddcxL7+eefmwyEXr16SatWrUww19/f3wRpbTSgu3//fnMi+tRTT8nrr79ur1WmJ7QTJ06UoUOHmvpjuowhQ4aYk2sAAAAgOzT4qokGWiIhdZatBkd9fDLv8KvnoJUqVZJ77rlH7r33Xpk6daps375dihUrJqVLl07XXpMb9Py1SJEi8u2335rzV50nta1bt8qRI0fkiy++kLFjx8q8efNMRq+aMWOG/P7772aMiV9//dWUc9Bz4jNnzvCBA3A5grYA4ELDhg2TN998U0qVKmW6fD3++OPmZFZPOgsVKmTqeekJpK3G18qVK6V79+72+TUjVk9udRCzli1bSrVq1cwJrt7fcccdEh4ebm+r2Q6vvfaaeU2Du5qJsGDBAvOaBo41C0FPVCtXriwjR46U6tWry/z5812wVQAAAJDX6UC7K1assD9ftmyZdOnS5Zrz6PmqJiMMHDhQTp06ZYKpffv2NeeuR48eTddekxv++usvU25Mkx70/LZfv34ObZKSkkwgVs9xtSdazZo1ZefOneY1fazjSWjJBh1f4pFHHjEDBWf0XgCQ2wjaAoCLaXBVg6d6xV8HJtOg6vPPPy+7du2S2267zWQlaBaBZgFojVsN0NroyaVNgQIFpEyZMg7P9aQzdduiRYvan9euXduM4Kv0XssipKYnr7bXAQAAgOxo3bq1REdHy+7du+XChQum5IEmJ/ybwMBAM/CYBnx/+ukneeKJJ0yPMU1uSEt7kWlmbkBAgMM5bGrBwcEOr+tjW/mxzp07y9WrV01ig2bp2soqaKAXAFyNoC0AuMi+ffvMCaKNBlQ1O0CzXjXzVjMH2rVrZ04atb6slk7Q0gipWSyWdF3RMpP2Na2jq6Pw2rIa0tL3TV1rFwAAAMgqLdWlPcK0RIL2FmvevLnpSXYt2vNs0aJF9ufa8+vRRx81iQ0aoD137ly6c2FbfVqbtM9TD4SWts0777wjzzzzjCnZoD3OqGcLwJ0QtAUAF9Gg6Jw5c0wt2rQnlpolq7W79LF2I/vtt9/MwGSpSyNklw7SoCUWbHbs2GG6iSnNUNB6Yanpc50OAAAA3EiJhKyURlAHDhyQjz/+OF3igNas1fPi1BmzSnuoaSmDuLg4+zTN7M0q7e2mdW61NNitt95qP1dOG/gFAFfIvAI4AMCpdIRaHaDhscceM4OJ6Si7OujBwoULzUi2OhCZ0hIJWl+rQoUK5sT0emnXL+1qNmLECNm8ebPJ3LXVtNURd7UkQ5UqVczIu1pTN20mMAAAADyHXuDX88fUmjVrZu51sNxVq1alK2ug55Gp6fgMOtju8ePH5cUXX8zSIL06KO7w4cNl8ODBpjTYoUOHzOC6999/f7qs2bCwMDNAmQZedZ6DBw+agcZ0XbIiKCjIBJW1/JgOwKu1cZWeiwOAqxG0BQAXevfdd2X69OlmlNuTJ09KwYIFpU2bNmYAMFsmQYsWLUxXMr36fyNq1aolISEhZjAHLcWgJ6W2+ri6bA0Yv/feexIVFWXazp492wRxAQAA4Hm0JEFaS5YsMfdnz56Vhx9+2OG1xo0byxdffJGunqyOm6DlB7QX2b8pX768WcaUKVNMEDY2NlZCQ0OlT58+JoibUfkvHaxMg7Y6yJj2ItOBetMGlDOj58Pjx483vdn0PPmuu+4yJRf27t1rypQBgCt5pZD3DwBuTbt76UAOP//8s8PAYwAAAIAn0+CxlhpLPcDZzJkzTQ1dHScCAPIyatoCgJvSa2q//vqr6UqmpRMI2AIAAACOdKCyzz//XCIjI2XdunXyySefSLdu3dhMAPI8Mm0BwM0Hb9AuWh9++CGlCgAAAIA0li5dasop6IBkxYsXl3vuuUeGDBkiXl5ebCsAeRpBWwAAAAAAAABwI5RHAAAAAAAAAAA3QtAWAAAAAAAAANwIQVsAAAAAAAAAcCMEbQEAAAAAAADAjRC0BQAAAAAAAAA3QtAWAAAAAAAAANwIQVsAAAAAAAAAcCMEbQEAAAAAAABA3Mf/AVmL/pnQv4JRAAAAAElFTkSuQmCC",
       "text/plain": [
        "<Figure size 1400x1000 with 4 Axes>"
       ]
@@ -2069,7 +2579,16 @@
   {
    "cell_type": "markdown",
    "id": "c02ed42e",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009032,
+     "end_time": "2026-08-21T10:27:30.854907",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.845875",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Interpretation** : La figure presente **4 panneaux** (1400x1000 pixels) visualisant le **systeme hybride** sur l'echantillon de test. Chaque panneau capture un aspect complementaire de la decision : (a) la **distribution des signaux LLM vs technique** (scatter ou pairplot), (b) la **serie temporelle des signaux fusionnes** au cours du temps, (c) les **points de desaccord** (zones ou LLM et technique divergent fortement), et (d) la **courbe de position size** en fonction du temps ou du signal. La structure 4-panel est classique pour les **systemes de decision hybrides** : un panneau pour la **nature** des signaux, un pour leur **dynamique**, un pour les **conflits**, et un pour les **consequences operationnelles** (position size).\n",
     "\n",
@@ -2081,7 +2600,16 @@
   {
    "cell_type": "markdown",
    "id": "81966997",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010726,
+     "end_time": "2026-08-21T10:27:30.874212",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.863486",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "### Exercice 3.2 : Système de vote LLM multi-modèles\n",
@@ -2098,8 +2626,8 @@
     "- Testez sur 20 headlines et affichez la matrice de confusion\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice : Chaque LLM est une fonction `lambda headline: signal` avec un biais\n",
-    "- # Indice : `np.sign()` pour le signal final\n",
+    "- **Indice 1** : Chaque LLM est une fonction `lambda headline: signal` avec un biais\n",
+    "- **Indice 2** : `np.sign()` pour le signal final\n",
     "\n",
     "### Lecture du résultat\n",
     "\n",
@@ -2133,10 +2661,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "cell-19a79b4c",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:30.895459Z",
+     "iopub.status.busy": "2026-08-21T10:27:30.894839Z",
+     "iopub.status.idle": "2026-08-21T10:27:30.912456Z",
+     "shell.execute_reply": "2026-08-21T10:27:30.911249Z"
+    },
+    "papermill": {
+     "duration": 0.029372,
+     "end_time": "2026-08-21T10:27:30.913617",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.884245",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer\n"
+     ]
+    }
+   ],
    "source": [
     "# Exercice 3.2 : Systeme de vote LLM\n",
     "# TODO etudiant : Implementer un ensemble multi-LLM avec vote pondere\n",
@@ -2153,7 +2704,16 @@
   {
    "cell_type": "markdown",
    "id": "4505e5bb",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010127,
+     "end_time": "2026-08-21T10:27:30.933558",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.923431",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "***\n",
     "\n",
@@ -2161,23 +2721,13 @@
     "\n",
     "### Architecture pour Production\n",
     "\n",
-    "```\n",
-    "EXTERNE (API Keys secrets)\n",
-    "        |\n",
-    "        v\n",
-    "QuantConnect Scheduled Event (Daily)\n",
-    "        |\n",
-    "        v\n",
-    "Fetch News (NewsAPI, TiingoNews)\n",
-    "        |\n",
-    "        v\n",
-    "LLM Analysis (OpenAI/Anthropic)\n",
-    "        |\n",
-    "        v\n",
-    "Signal Fusion\n",
-    "        |\n",
-    "        v\n",
-    "Alpha Model Insights\n",
+    "```mermaid\n",
+    "flowchart TD\n",
+    "    A[\"EXTERNE (API Keys secrets)\"] --> B[\"QuantConnect Scheduled Event (Daily)\"]\n",
+    "    B --> C[\"Fetch News (NewsAPI, TiingoNews)\"]\n",
+    "    C --> D[\"LLM Analysis (OpenAI/Anthropic)\"]\n",
+    "    D --> E[\"Signal Fusion\"]\n",
+    "    E --> F[\"Alpha Model Insights\"]\n",
     "```\n",
     "\n",
     "### Lecture du résultat\n",
@@ -2208,9 +2758,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 16,
    "id": "cell-179f3b53",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:30.960927Z",
+     "iopub.status.busy": "2026-08-21T10:27:30.960371Z",
+     "iopub.status.idle": "2026-08-21T10:27:30.974447Z",
+     "shell.execute_reply": "2026-08-21T10:27:30.973933Z"
+    },
+    "papermill": {
+     "duration": 0.028792,
+     "end_time": "2026-08-21T10:27:30.976269",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.947477",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -2525,7 +3090,16 @@
   {
    "cell_type": "markdown",
    "id": "453a7213",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.010436,
+     "end_time": "2026-08-21T10:27:30.996099",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:30.985663",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "On évalue la valeur ajoutée des signaux LLM par rapport à une stratégie de référence purement basée sur les prix.\n",
     "\n",
@@ -2560,15 +3134,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 17,
    "id": "cell-33a88029",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T10:27:31.015866Z",
+     "iopub.status.busy": "2026-08-21T10:27:31.015309Z",
+     "iopub.status.idle": "2026-08-21T10:27:31.036493Z",
+     "shell.execute_reply": "2026-08-21T10:27:31.035128Z"
+    },
+    "papermill": {
+     "duration": 0.032155,
+     "end_time": "2026-08-21T10:27:31.037583",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:31.005428",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "======================================================================RESUME : LLM TRADING SIGNALS======================================================================1. PROMPT ENGINEERING   - Instructions specifiques et structurees   - Format de sortie JSON   - Exemples few-shot si necessaire   - Temperature basse (0.2-0.4) pour coherence2. GESTION DES COUTS   - Budget quotidien strict   - Modeles economiques (gpt-4o-mini, haiku)   - Caching des resultats   - Batching des requetes3. ROBUSTESSE   - Fallback vers signaux techniques   - Validation du JSON   - Retry avec backoff   - Logging complet4. SYSTEME HYBRIDE   - Ne jamais se fier au LLM seul   - Fusion avec indicateurs objectifs   - Bonus pour accord LLM/technique   - Penalite pour desaccord5. PRODUCTION   - API keys en secrets QuantConnect   - Scheduled events quotidiens   - Monitoring des couts en temps reel   - Alertes sur erreurs APIESTIMATION DES COUTS MENSUELS:  - 20 actifs x 1 analyse/jour x 30 jours = 600 requetes  - GPT-4o-mini: ~$3-5/mois  - GPT-4o: ~$15-25/mois  - Claude 3.5 Sonnet: ~$20-30/mois"
+      "======================================================================\n",
+      "RESUME : LLM TRADING SIGNALS\n",
+      "======================================================================\n",
+      "\n",
+      "1. PROMPT ENGINEERING\n",
+      "   - Instructions specifiques et structurees\n",
+      "   - Format de sortie JSON\n",
+      "   - Exemples few-shot si necessaire\n",
+      "   - Temperature basse (0.2-0.4) pour coherence\n",
+      "\n",
+      "2. GESTION DES COUTS\n",
+      "   - Budget quotidien strict\n",
+      "   - Modeles economiques (gpt-4o-mini, haiku)\n",
+      "   - Caching des resultats\n",
+      "   - Batching des requetes\n",
+      "\n",
+      "3. ROBUSTESSE\n",
+      "   - Fallback vers signaux techniques\n",
+      "   - Validation du JSON\n",
+      "   - Retry avec backoff\n",
+      "   - Logging complet\n",
+      "\n",
+      "4. SYSTEME HYBRIDE\n",
+      "   - Ne jamais se fier au LLM seul\n",
+      "   - Fusion avec indicateurs objectifs\n",
+      "   - Bonus pour accord LLM/technique\n",
+      "   - Penalite pour desaccord\n",
+      "\n",
+      "5. PRODUCTION\n",
+      "   - API keys en secrets QuantConnect\n",
+      "   - Scheduled events quotidiens\n",
+      "   - Monitoring des couts en temps reel\n",
+      "   - Alertes sur erreurs API\n",
+      "\n",
+      "\n",
+      "ESTIMATION DES COUTS MENSUELS:\n",
+      "  - 20 actifs x 1 analyse/jour x 30 jours = 600 requetes\n",
+      "  - GPT-4o-mini: ~$3-5/mois\n",
+      "  - GPT-4o: ~$15-25/mois\n",
+      "  - Claude 3.5 Sonnet: ~$20-30/mois\n"
      ]
     }
    ],
@@ -2623,7 +3251,16 @@
   {
    "cell_type": "markdown",
    "id": "cell-ec437b8f",
-   "metadata": {},
+   "metadata": {
+    "papermill": {
+     "duration": 0.009972,
+     "end_time": "2026-08-21T10:27:31.056305",
+     "exception": false,
+     "start_time": "2026-08-21T10:27:31.046333",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "source": [
     "**Synthese finale** : Le notebook a couvert **6 techniques complementaires** pour integraire des LLM dans une strategie de trading : (1) **gestion de couts** (quelques fractions de cent par analyse, dominée par l'input), (2) **prompt engineering** (4 templates specialises, prompt formate de quelques centaines de caracteres, format JSON impose), (3) **analyse de sentiment** (sortie simulee montrant 2 BULLISH 1 NEUTRAL, signal agrege superieur a la moyenne arithmetique des 3 news), (4) **chain-of-thought** (confidence elevee sur horizon temporel explicite, price_impact categorise), (5) **systeme hybride** (fusion conservative a partir de LLM et Tech, position size de l'ordre de 35%), (6) **integration QuantConnect** (algorithme de production genere automatiquement en Python). Trois resultats pedagogiques cle : (a) le **mode simule** est une graceful degradation SOTA, pas un workaround degrade — les sorties sont **explicitement labellisees** comme simulees, et le notebook documente ses limites ; (b) la **fusion de signaux** est plus conservative que les inputs individuels, ce qui reflete la **prudence epistemique** des strategies hybrides ; (c) le **ratio signal/prix** est tellement favorable a l'IA generative en 2026 (des milliers de sentiments par jour pour un cout modeste) que la barriere d'entree au trading algorithmique assistE par LLM est tombee a zero.\n",
     "\n",
@@ -2653,8 +3290,28 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.11.0"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 6.105308,
+   "end_time": "2026-08-21T10:27:31.514835",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "QC-Py-26-LLM-Trading-Signals.ipynb",
+   "output_path": "qcpy26_executed.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-21T10:27:25.409527",
+   "version": "2.6.0"
   },
   "qc_reference": true
  },


### PR DESCRIPTION
Grain: MED/qc — lane myia-po-2023:CoursIA — prev: MED/guard #12109

## Summary

Rendu GitHub de `QC-Py-26-LLM-Trading-Signals.ipynb` signalé par le user (post-#12009) — les trois classes restantes de l'issue, sur ce seul notebook.

1. **Escapes `\/`** (3 occurrences, cells 7/17) : `qualit\/prix` → `qualité/prix`, `cout \/ performance` → `cout / performance`, `signal\/bruit` → `signal/bruit`. `\/` est un échappement markdown valide qui rend un `/` nu — corruption invisible-comme-backslash, visible-comme-lettre-manquante.
2. **Diagrammes ASCII → mermaid** (cells 3 arbre « LLMs en Trading », 18 pipeline News Feed→Trading Signal, 40 pipeline production QuantConnect). La cellule 30 (architecture hybride pondérations 0.4) est déjà couverte par **PR #11998** — `See #12111`. Cells 8 (listing de coûts) et 15 (template `[RÔLE]/[TASK]/[FORMAT]`) : fences taguées `text`, volontairement pas en mermaid.
3. **Re-exec papermill end-to-end** (RECOVERABLE-LOCAL : mock déterministe, pas de clé, pas de QC Cloud — le seul `from AlgorithmImports import *` est dans un littéral de chaîne, cell 41).

## Test plan

- **Mermaid vérifié au rendu** (pas seulement la syntaxe) : les 3 graphes passent `mermaid.parse()` avec le moteur mermaid v11 (le même que GitHub rend nativement) → `PARSE OK` ×3.
- **Papermill** : `execution_count` = `[1..17]` strictement croissant, **0 erreur**. Les 3 cellules à `execution_count: null` AVEC outputs (14/26/34) portent leur compteur ; le compteur orphelin `1` entre `9` et `10` (cell 41) est normalisé. Outputs d'exercices `Exercice a completer` **conservés avec compteurs** (stub C.1 conforme, pas supprimés).
- Gates locaux : `detect_md_content_loss --base origin/main` = 0 finding ; `fix_hr_separator --check` = 0 ; `detect_markdown_rendering` = 0 violation ; `validate_pr_notebooks` = PASS (17 cells) ; 0 escape restant ; 0 chemin machine dans les outputs.
- **Bonus hors-scope-issue requis par CI** : 6 indices en `- # Indice :` (cells 11/23/38, pré-existants sur main, hash **hors baseline** → bloqueraient le gate heading_in_list promu bloquant #12107) corrigés en `- **Indice N** :` — geste de remédiation #11947/#12107, contenu préservé.

Verdict SOTA : `RECOVERABLE-LOCAL` (papermill local, aucune action user).

See #12111, See #11998
