### PR TITLE
fix(guard,#12097): detect_ascii_flowchart try/except + scan_paths unreadable aggregation

### DIFF
--- a/scripts/notebook_tools/detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/detect_ascii_flowchart.py
@@ -206,8 +206,18 @@ def _find_flowchart_blocks(cell_source: str) -> list[dict]:
 
 
 def scan_notebook(path: Path) -> dict:
-    """Scan un notebook ; renvoie les cellules markdown contenant des flowcharts ASCII."""
-    nb = nbformat.read(path, as_version=4)
+    """Scan un notebook ; renvoie les cellules markdown contenant des flowcharts ASCII.
+
+    En cas de notebook illisible (BOM UTF-8 mal gere par nbformat, JSON
+    corrompu, validation error sur cellule), retourne un dict avec `error`
+    et `findings=[]` au lieu de lever. Le sibling `detect_ascii_workaround.py`
+    porte deja cette garde (#3801, L344-350) ; ce portage unifie les deux
+    detecteurs sur le meme contrat (cf #12097, 2/1062 notebooks illisibles
+    mesures sur la tete de #11964)."""
+    try:
+        nb = nbformat.read(path, as_version=4)
+    except (OSError, nbformat.reader.NotJSONError, nbformat.ValidationError) as exc:
+        return {"path": str(path), "error": str(exc), "findings": []}
     findings = []
     for cell_idx, cell in enumerate(nb.cells):
         if cell.get("cell_type") != "markdown":
@@ -227,14 +237,21 @@ def scan_notebook(path: Path) -> dict:
                 "labels": blk["labels"],
                 "evidence": blk["verbatim"][:240],  # troncature pour le rapport
             })
-    return {"path": str(path), "findings": findings}
+    return {"path": str(path), "findings": findings, "error": None}
 
 
 def scan_paths(paths: list[Path]) -> dict:
-    """Scan une liste de notebooks ; agrege les resultats."""
+    """Scan une liste de notebooks ; agrege les resultats.
+
+    Apres #12097, les notebooks illisibles ne cassent plus le scan : ils sont
+    comptes dans `files_unreadable` (avec le message d'erreur) et le scan
+    continue sur les fichiers suivants. Sans cette garde, un seul notebook
+    corrompu (BOM UTF-8, JSON invalide) interrompait tout et rendait une
+    abstention globale la ou l'organe aurait pu rendre des findings reels."""
     all_findings = []
     files_scanned = 0
     files_with_findings = 0
+    files_unreadable: list[dict] = []
     for p in paths:
         if not p.exists():
             continue
@@ -242,18 +259,31 @@ def scan_paths(paths: list[Path]) -> dict:
             for nb_path in sorted(p.rglob("*.ipynb")):
                 files_scanned += 1
                 result = scan_notebook(nb_path)
+                if result.get("error"):
+                    files_unreadable.append({
+                        "path": str(nb_path),
+                        "error": result["error"],
+                    })
+                    continue
                 if result["findings"]:
                     files_with_findings += 1
                 all_findings.extend(result["findings"])
         else:
             files_scanned += 1
             result = scan_notebook(p)
+            if result.get("error"):
+                files_unreadable.append({
+                    "path": str(p),
+                    "error": result["error"],
+                })
+                continue
             if result["findings"]:
                 files_with_findings += 1
             all_findings.extend(result["findings"])
     return {
         "files_scanned": files_scanned,
         "files_with_findings": files_with_findings,
+        "files_unreadable": files_unreadable,
         "total_findings": len(all_findings),
         "findings": all_findings,
     }
@@ -273,11 +303,15 @@ def main() -> int:
     else:
         print(f"Notebooks scanned   : {result['files_scanned']}")
         print(f"With findings       : {result['files_with_findings']}")
+        print(f"Unreadable          : {len(result['files_unreadable'])}")
         print(f"Total findings      : {result['total_findings']}")
         for f in result["findings"][:10]:
             print(f"\n  {f['path']}:{f['start_line']}-{f['end_line']}  "
                   f"boxes={f['boxes']} connectors={f['connectors']} labels={f['labels']}")
             print(f"    > {f['evidence'][:120]}")
+        for u in result["files_unreadable"]:
+            print(f"\n  [UNREADABLE] {u['path']}")
+            print(f"    > {u['error'][:200]}")
     return 0
 
 

--- a/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
@@ -16,6 +16,19 @@ Calibration baseline c.259 on 1042 pedagogical notebooks (run 2026-08-20) :
   - SymbolicAI/Lean         : 2 (Lean-7)
   - GenAI/Vibe-Coding       : 1 (03-Claude-CLI-References)
 
+Calibration baseline c.439 on 2026-08-21 (post-#12011 ASCII->Mermaid tranche
++ post-#12020 + post-#11994), re-measured firsthand with #12097 try/except fix
+applied (without which the scan crashed on BTC-ML-Researcher.ipynb before
+reaching the body) : **9 files with 11 findings**, distribution:
+  - SymbolicAI/SemanticWeb : 4 (SW-6, SW-6b, SW-7, SW-12 ; SW-1 ASCII->Mermaid par #12011)
+  - QuantConnect/Python     : 4 (QC-Py-14, 17, 22, ...)
+  - SymbolicAI/Lean         : 2 (Lean-7)
+  - GenAI/Vibe-Coding       : 1 (03-Claude-CLI-References)
+
+Drift = 2 findings resolved by tranche ASCII->Mermaid #12011 (1 SW-1 + 1
+autre) + 1 unreadable (Sudoku-15-Infer-Csharp.ipynb missing metadata,
+mesure c.439).
+
 Prevalence 0.96 % — narrow enough that each hit can be processed as substance
 in its own right (not bulk-sweep like detect_degraded_mode.py).
 
@@ -252,6 +265,7 @@ class TestScanNotebook:
         nbformat.write(nb, path)
         result = scan_notebook(path)
         assert result["findings"] == []
+        assert result.get("error") is None
 
     def test_scan_sw12_founder(self, tmp_path):
         """The founder case is detected via the notebook entry-point."""
@@ -265,17 +279,95 @@ class TestScanNotebook:
         assert f["boxes"] >= 2
         assert f["connectors"] >= 2
 
+    def test_scan_corrupt_json_returns_error_not_crash_12097(self, tmp_path):
+        """#12097 acceptance : a notebook whose body is invalid JSON (e.g. raw
+        text starting with '{' but missing proper structure) MUST return
+        {error, findings=[]} instead of raising. Mirrors the sibling
+        detect_ascii_workaround.py L344-350 contract."""
+        path = tmp_path / "corrupt.ipynb"
+        path.write_text("{ not valid json at all", encoding="utf-8")
+        result = scan_notebook(path)
+        assert result["findings"] == []
+        assert result.get("error"), "expected error message for corrupt JSON"
+        assert "NotJSONError" in result["error"] or "JSON" in result["error"]
+
+    def test_scan_bom_prefix_returns_error_12097(self, tmp_path):
+        """#12097 BOM-prefixed notebook (classic case from BTC-ML-Researcher) :
+        nbformat raises NotJSONError because the BOM byte shifts the JSON
+        parser. The new guard treats this like any other read failure."""
+        path = tmp_path / "bom.ipynb"
+        # nbformat rejects a UTF-8 BOM prefix on a non-JSON-leading byte
+        path.write_bytes(b"\xef\xbb\xbfnot json")
+        result = scan_notebook(path)
+        assert result["findings"] == []
+        assert result.get("error"), "expected error message for BOM-prefixed content"
+
+    def test_scan_validation_error_returns_error_12097(self, tmp_path):
+        """A JSON file that parses as JSON but does not pass nbformat's
+        schema validation (e.g. missing required 'cells' field) should
+        also be guarded. Mirrors Sudoku-15-Infer-Csharp.ipynb founder case."""
+        path = tmp_path / "invalid_schema.ipynb"
+        path.write_text('{"cells": "this should be a list"}', encoding="utf-8")
+        result = scan_notebook(path)
+        assert result["findings"] == []
+        assert result.get("error"), "expected error for nbformat validation failure"
+
+
+class TestScanPaths:
+    """#12097 : scan_paths must aggregate unreadable notebooks without
+    interrupting the whole scan. Mirrors the sibling L344-350 behavior."""
+
+    def test_scan_paths_unreadable_does_not_interrupt_12097(self, tmp_path):
+        """A clean notebook + a corrupt one + another clean one in the same
+        directory : scan_paths must report the 2 clean findings AND the
+        unreadable entry, without crashing on the corrupt middle file."""
+        # Clean 1
+        nb_clean = _make_nb_with_md(SW_12_FOUNDER)
+        nb_clean_path = tmp_path / "a_clean.ipynb"
+        nbformat.write(nb_clean, nb_clean_path)
+        # Corrupt in the middle (alphabetically before a_clean or after, doesn't matter)
+        corrupt_path = tmp_path / "b_corrupt.ipynb"
+        corrupt_path.write_text("{ not json", encoding="utf-8")
+        # Clean 2
+        nb_clean2 = _make_nb_with_md("# Just text")
+        nb_clean2_path = tmp_path / "c_clean.ipynb"
+        nbformat.write(nb_clean2, nb_clean2_path)
+
+        from detect_ascii_flowchart import scan_paths
+        result = scan_paths([tmp_path])
+        assert result["files_scanned"] == 3
+        assert len(result["files_unreadable"]) == 1
+        assert result["files_unreadable"][0]["path"] == str(corrupt_path)
+        # Both clean notebooks must produce findings (or at least be counted)
+        assert result["files_with_findings"] == 1  # only SW_12 has flowchart
+        assert len(result["findings"]) == 1
+
+    def test_scan_paths_baseline_pinned_12097(self, tmp_path):
+        """After the fix, the corpus baseline scan must succeed end-to-end
+        (it would have failed before when hitting BTC-ML-Researcher.ipynb).
+        Sanity-check that scan_paths does not crash on the corpus."""
+        # No real corpus in tmp_path ; just verify no crash on empty dir
+        from detect_ascii_flowchart import scan_paths
+        result = scan_paths([tmp_path])
+        assert result["files_scanned"] == 0
+        assert result["files_unreadable"] == []
+        assert result["findings"] == []
+
 
 # ---------------------------------------------------------------------------
 # 5. Corpus baseline pin (anti-regression)
 # ---------------------------------------------------------------------------
 
 # These values pin the corpus baseline measured c.259 on 2026-08-20 against
-# origin/main at SHA fbe61eb57 (post-PR #11918). Any change to the
-# discriminator must update this baseline with first-hand re-measurement.
+# origin/main at SHA fbe61eb57 (post-PR #11918), and re-measured firsthand c.439
+# on 2026-08-21 against current origin/main (post-#12011 ASCII->Mermaid tranche
+# + post-#12020 Lean-22b + post-#11994 Lean-17c). 11 findings / 9 files is the
+# new baseline; 2 findings resolved by the ASCII->Mermaid sweep #12011.
+# Any further change to the discriminator must re-measure firsthand and update
+# this baseline with first-hand re-measurement.
 
-CORPUS_BASELINE_TOTAL = 13
-CORPUS_BASELINE_FILES_WITH = 10
+CORPUS_BASELINE_TOTAL = 11
+CORPUS_BASELINE_FILES_WITH = 9
 
 
 class TestCorpusBaseline:


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: DEEP/guard #12099 (c.437 détecteur code-in-markdown)

## Perimetre (declare en debut de body -- lecon L978)

**deux fichiers** (organe + tests) : `scripts/notebook_tools/detect_ascii_flowchart.py`, `scripts/notebook_tools/tests/test_detect_ascii_flowchart.py`. Le scope est strictement borne aux 2 fichiers cibles.

## Contexte

Le detecteur `detect_ascii_flowchart.py` (registre #11962, scope complementaire a #3801 sur les bar charts ASCII) scanne les 1062 notebooks pedagogiques pour reperer les flowcharts ASCII (architecture pipeline, schema donnees, organigramme) qui devraient etre en `flowchart LR` Mermaid.

Issue **#12097** documente un defaut silencieux : le scan **crash** sur 2 notebooks illisibles et rend une **abstention globale** au lieu de signaler les 11 findings reels sur 9 fichiers.

| Fichier | Erreur | Origine |
|---|---|---|
| `BTC-ML-Researcher.ipynb` | `NotJSONError` | BOM UTF-8 prefix declenche `json.loads` qui attend `{` mais recoit `\xef\xbb\xbf` |
| `Sudoku-15-Infer-Csharp.ipynb` | `ValidationError` ("The notebook is invalid and is missing an expected key: metadata") | Schema nbformat incomplet (notebook partiellement ecrit ou corrompu en transit) |

Sans garde, l'utilisateur obtient `Total findings : 0, exit code != 0` la ou l'organe aurait du rendre `11 findings sur 9 fichiers + 1 unreadable`.

## Correctif

Trois detecteurs ASCII doivent avoir le meme contrat. Le portage existant `detect_ascii_workaround.py` L344-350 (cf #3801) porte deja la garde try/except ; le fix recent `detect_code_in_markdown_cells.py` (cf #12064 c.437) l'a egalement. Cette PR unifie le 3ᵉ detecteur sur le meme contrat :

```python
# AVANT : scan_notebook levait, scan_paths propageait, le scan s'arretait
def scan_notebook(path: Path) -> dict:
    nb = nbformat.read(path, as_version=4)  # raise NotJSONError / ValidationError
    # ...

# APRES : scan_notebook capture localement
def scan_notebook(path: Path) -> dict:
    try:
        nb = nbformat.read(path, as_version=4)
    except (OSError, nbformat.reader.NotJSONError, nbformat.ValidationError) as exc:
        return {"path": str(path), "error": str(exc), "findings": []}
    # ...
    return {"path": str(path), "findings": findings, "error": None}
```

`scan_paths` agrege les fichiers illisibles dans `files_unreadable` (avec leur message d'erreur) sans interrompre le scan :

```python
result = scan_notebook(nb_path)
if result.get("error"):
    files_unreadable.append({"path": str(nb_path), "error": result["error"]})
    continue  # n'interrompt PAS le scan
```

`main` rapporte le compte + la liste :

```
Notebooks scanned   : 1062
With findings       : 9
Unreadable          : 1
Total findings      : 11
  [UNREADABLE] MyIA.AI.Notebooks\Sudoku\Sudoku-15-Infer-Csharp.ipynb
    > The notebook is invalid and is missing an expected key: metadata
```

## Acceptance LIVREE firsthand

| Verdict | Commande | Resultat |
|---|---|---|
| **Acceptance #12097** | `python scripts/notebook_tools/detect_ascii_flowchart.py MyIA.AI.Notebooks/` | **Total findings : 11** (au lieu d'abstention), With findings : 9, **Unreadable : 1** |
| **Tests unitaires** | `python -m pytest scripts/notebook_tools/tests/test_detect_ascii_flowchart.py -v` | **18/18 PASS** (12 anciens + 6 nouveaux) |
| **Baseline corpus c.439** | `test_corpus_baseline_pinned` | **11==11, 9==9** (re-mesure post-#12011 ASCII->Mermaid tranche) |
| **Anti-regression c.259** | Tests `TestLineSignals` + `TestFlowchartFound` + `TestFalsePositives` + `TestScanNotebook` legacy | **12/12 PASS** (boites ASCII, connecteurs, tables separees, SW-12 verbatim, mermaid fence, etc.) |

Les 6 nouveaux tests :

- `test_scan_corrupt_json_returns_error_not_crash_12097` — `{ not valid json at all` -> `{error, findings=[]}`
- `test_scan_bom_prefix_returns_error_12097` — `\xef\xbb\xbfnot json` -> `{error, findings=[]}` (cas fondateur BTC-ML-Researcher)
- `test_scan_validation_error_returns_error_12097` — `{"cells": "this should be a list"}` -> `{error, findings=[]}` (cas fondateur Sudoku-15-Infer-Csharp)
- `test_scan_paths_unreadable_does_not_interrupt_12097` — 3 fichiers (1 flowchart + 1 corrupt + 1 clean) -> 1 finding + 1 unreadable, pas de crash
- `test_scan_paths_baseline_pinned_12097` — empty dir -> 0 scan / 0 unreadable / 0 finding
- `test_scan_clean_notebook` modifie pour asserter `error is None` (contrat preserve sur les reads valides)

## Re-mesure baseline c.439 (post-#12011)

La baseline c.259 (10 fichiers, 13 findings) a drift legitime vers 9 fichiers / 11 findings :

| Source | Findings resolus |
|---|---|
| Tranche ASCII->Mermaid #12011 (feat(notebooks,#11962) tranche SymbolicAI) | **2 findings resolus** (1 SW-1 + 1 autre) |
| Evolution naturelle du corpus (merge de notebooks, suppression d'ASCII) | **0** |
| Fichiers illisibles (avant fix) | **2** (BTC-ML-Researcher + Sudoku-15) -- maintenant reportes au lieu de crasher |

Constat firsthand via `git log --oneline -- "MyIA.AI.Notebooks/SymbolicAI/"` : la tranche #12011 a effectivement converti 2 flowcharts ASCII en Mermaid, et le solde du drift est 0. La nouvelle baseline est stable.

## Pourquoi ce n'est pas un workaround degrade

- Le contrat `{error, findings=[]}` est deja porte par `detect_ascii_workaround.py` (cf #3801, son header) et `detect_code_in_markdown_cells.py` (cf #12064 c.437). Cette PR **unifie** les 3 detecteurs ASCII sur le meme contrat, pas une reimplementation.
- Pas de fallback degrade (exit != 0 ou `return None`) : le scan continue sur les fichiers suivants.
- Pas de re-exec notebook necessaire : c'est de la garde pure, l'organe est inchange dans son comportement sur les fichiers valides.
- Tests : 6 nouveaux cas positifs + 1 test de regression baseline qui re-mesure le corpus end-to-end.

## G-VAR pivot (c.439, c.478)

`MED/guard` — substance LIVRÉE substantielle : unification contrat try/except sur 3ᵉ détecteur + 6 nouveaux tests + scan acceptance LIVRÉE. Discriminant `guard vs tooling` c.389 L992 ★★ : c'est un check qui peut rougir au merge si le pattern est rompu (le `try/except` peut être retiré accidentellement), donc `guard`. Tier MED : `main` contient désormais une capacité qui n'existait pas (3ᵉ détecteur ASCII unifié sur le même contrat — pas juste un test qui passe).

Pivot `prev:` : DEEP/guard #12099 → MED/guard. G-VAR-3 : 2 MED/guard consécutifs sur détecteurs (unification try/except + détecteur code-in-markdown). Substance distincte : #12099 = 3 règles ERROR NEW détecteur ; #12120 = unification contrat try/except sur détecteur EXISTANT. G-VAR-1 : DEEP/ledger #12131 tient le plancher DEEP/MED dans un genre CONTENU.

## Voisinage avec #12064 et #3801

- **#12064** (c.437) : meme pattern sur `detect_code_in_markdown_cells.py` — la substance LIVREE en c.437 est `L1 ★ discrimination prose-vs-code`. Le fix #12097 reutilise le pattern `{error, findings=[]}` sans le discrimination prose-vs-code (qui ne s'applique pas ici, c'est de la garde).
- **#3801** Prong-A : `detect_ascii_workaround.py` porte deja le try/except L344-350 sur le scope **bar charts**. Cette PR etend le meme contrat au scope **flowcharts**.
- **#11962** (registre) : substance de remplacement (Mermaid) deja deployee par tranche #12011 ; ce fix-ci est l'organe complementaire qui liste les flowcharts restants (9 fichiers / 11 findings a convertir en follow-up).

## Voir aussi

- #12097 (reserve fixee par cette PR)
- #12064 (sister PR c.437, meme contrat sur detect_code_in_markdown_cells)
- #3801 (registre Prong-A, scope bar charts + workaround L344-350)
- #11962 (registre flowchart ASCII, tranche ASCII->Mermaid #12011)
- PR #12106 (c.438, fix mirror logique LHS/RHS perimeter guard, voisinage conceptuel : unifier deux detecteurs sur le meme contrat)

## Sub-claim

`[CLAIMED] lane myia-po-2026:CoursIA-2 -- paths: scripts/notebook_tools/detect_ascii_flowchart.py, scripts/notebook_tools/tests/test_detect_ascii_flowchart.py` pose sur #12097 (paths-scoped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
