### PR TITLE
fix(notebooks,#12064): tranche A PT_11 — cellule markdown 'parameters' supprimée, anchor sur cellule code

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb
@@ -179,7 +179,9 @@
      "start_time": "2026-08-14T10:06:21.603346+00:00",
      "status": "completed"
     },
-    "tags": []
+    "tags": [
+     "parameters"
+    ]
    },
    "outputs": [
     {
@@ -204,32 +206,6 @@
     "    print(\"(Mode CPU-safe : verifier Z3 + SymPy executes, training RLVR skip)\")\n",
     "else:\n",
     "    print(\"(Mode TRAINING : Qwen3.5-0.8B + GRPO + rewardspy.online)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7c51e9a1",
-   "metadata": {
-    "papermill": {
-     "duration": 0.007012,
-     "end_time": "2026-08-14T10:06:21.634395+00:00",
-     "exception": false,
-     "start_time": "2026-08-14T10:06:21.627383+00:00",
-     "status": "completed"
-    },
-    "tags": [
-     "parameters"
-    ]
-   },
-   "source": [
-    "# Papermill injects LOAD_MODEL_AND_TRAIN via -p flag (default False = CPU-safe mode)\n",
-    "# Set True for real training on GPU (>=4 Go VRAM).\n",
-    "LOAD_MODEL_AND_TRAIN = False\n",
-    "print(f\"LOAD_MODEL_AND_TRAIN = {LOAD_MODEL_AND_TRAIN}\")\n",
-    "if not LOAD_MODEL_AND_TRAIN:\n",
-    "    print(\"(Mode CPU-safe : verifier Z3 + SymPy executes, training RLVR skip)\")\n",
-    "else:\n",
-    "    print(\"(Mode TRAINING : Qwen3.5-0.8B + GRPO + rewardspy.online)\")\n"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #12118 (c.298)

**Périmètre : 1 fichier** (+4/-28 net, 1 feature, 1 famille)

- `MyIA.AI.Notebooks/GenAI/PostTraining/PT_11_grpo_qwen_rlvr_on_verifiers.ipynb`

# fix(notebooks,#12064): tranche (A) PT_11 — cellule markdown parameters supprimée, anchor déplacée sur cellule code

Issue #12064 (signalement user 2026-08-21) : **un stub de code dans une cellule markdown est invisible aux deux détecteurs** (`detect_markdown_rendering.py`, `count_exercises.py`). Le motif contourne H.3 : le pre-commit échoue sur cellule code avec `execution_count=null + outputs=[]` ; une cellule markdown n'a ni l'un ni l'autre, donc H.3 devient inapplicable (≠ satisfait). L'instrumentation pédagogique perd la trace.

Cette tranche couvre l'instance **(A)** signalée verbatim dans l'issue : cellule 5 de `PT_11_grpo_qwen_rlvr_on_verifiers.ipynb`. L'instance **(B)** (cellule 0 avec tag `Grain:` markdown sur PT_11 et PT_11b) est **déjà absente sur main** (vérifié firsthand — les 2 cellules 0 ne portent pas de tag `Grain:`, l'isolation upstream l'a déjà retirée entre temps). Restait donc uniquement (A).

## Diagnostic verbatim

| Cellule | Type | Contenu clé | Anomalie |
|---:|---|---|---|
| **cellule 4** | `code` (ec=2) | `import os` + `LOAD_MODEL_AND_TRAIN = True` + 3 prints | Ancre Papermill attendue (pas de tag `parameters`) |
| **cellule 5** | `markdown` (tags: `['parameters']`) | `# Papermill injects ...` + `LOAD_MODEL_AND_TRAIN = False` + 4 prints | **Markdown ≠ exécuté** + **valeur contradictoire** avec cellule 4 |

Deux définitions contradictoires de `LOAD_MODEL_AND_TRAIN` : cellule 4 = `True` (réellement exécutée, output commité), cellule 5 = `False` (statique markdown, jamais exécutée mais ancre `parameters` qui ne fonctionne pas). Tout lecteur qui passe par le tag Papermill `-p LOAD_MODEL_AND_TRAIN=false` sur cette cellule 5 pense overrider la valeur — la cellule ne s'exécute pas, l'override atterrit APRÈS cellule 4 qui a déjà figé `True`.

## Fix retenu (option 3 du body #12064)

> « la cellule 5 de `PT_11` devient une cellule `code` taguée `parameters`, ou disparait au profit de la cellule 4 »

**Option 3 = supprimer cellule 5, tag `parameters` ajouté à cellule 4** (single source of truth) :

1. **Cellule 4** : ajout du tag `parameters` à `metadata.tags` → Papermill peut maintenant insérer sa cellule d'override juste après, comme attendu. Le contenu de cellule 4 (constantes `True`, `42`, `100` + `os.getenv` overrides) reste inchangé.
2. **Cellule 5** : supprimée entièrement (la valeur contradictoire `LOAD_MODEL_AND_TRAIN = False` disparaît avec).
3. **Cellule 3 (markdown)**` inchangée : elle documente le switch (`True` = GPU training, `False` = CPU-safe) — la documentation reste valide, le défaut est maintenant cohérent avec le seul site de définition.

**Diff minimal** : +4 lignes (ajout tag dans `metadata.tags` de cellule 4) / -28 lignes (1 cellule markdown entière supprimée). Format `source` préservé (cellule 4 = list, cellule 5 = list — pas de reformatage c.298-L1 ★★).

## Conformité

- **L898 ★★★** : `gh pr list --search "PT_11_grpo"` vérifié → PR #12028 OPEN (density round 1) mais disjoint (touche cellule 0, pas cellule 4/5). PR #12029, #12031 voisines absentes.
- **L1500-B ★★★** : `gh issue view 12064` confirmé `state: OPEN` avant claim.
- **L275 ★★ règle « file-count declaration »** : périmètre **1 fichier** (énuméré top-line). Aucun CLAUDE.md, aucun `.claude/rules/*.md`, aucun README, aucun script de tooling commité.
- **C.1** : 0 erreur volontaire introduite. Cellule 5 supprimée = -1 stub.
- **C.2** : cellule 4 code byte-intacte (`execution_count: 2`, `outputs` préservés). Cellule 5 markdown sans output à préserver.
- **H.3** : pre-commit PASS. La cellule 4 conservée porte `execution_count != null` et `outputs != []` → pas concernée par H.3.
- **Stop & Repair (secrets-hygiene R6)** : N/A — outputs existants intacts, le seul changement est suppression d'une cellule markdown sans output.
- **catalog-pr-hygiene R1-R4** : catalogue byte-identique à main.
- **L677-L4 ★★** : body PR HORS worktree (scratchpad `<scratchpad>/c299_12064_pr_body.md`).
- **L903 ★★** : grain tag `MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: MED/notebook-python #12118 (c.298)` en première ligne.
- **Détecteurs** : `detect_markdown_rendering.py` (sans la règle instruction-markdown, hors scope cette PR — claim po-2026 epic-wide sur `scripts/notebook_tools/` disjoint) ne flag plus le stub cellule 5 (suppression directe).

## Périmètre déclaré = fichiers réel

**1 fichier** (énuméré top-line), +4/-28 net. Scope strict : 1 feature (résolution contradiction `parameters`), 1 domaine (GenAI PostTraining), 1 famille.

## Bilan coordinateur

**Pivot légitime c.299** : picker L251 ★★ a remonté **#12064** (grain `notebook-python` CONTENU, age 1j, inact 0j). Claim po-2026 epic-wide sur `scripts/notebook_tools/` (l'organe détecteur) bloque le scope scripts ; la présente PR claim narrow `paths: MyIA.AI.Notebooks/GenAI/PostTraining/PT_11*.ipynb` est **disjointe** (acceptance bullet 3-4 sur les notebooks eux-mêmes).

**Substance LIVRÉE** : 1 commit à venir, +4/-28 net sur 1 fichier. La cellule markdown `parameters` qui ne s'exécutait jamais est éliminée ; la cellule code cellule 4 devient l'unique anchor Papermill, tagué.

**Lane po-2025 plank tenu** : c.299 (MED/notebook-python CONTENU PR à venir). G-VAR-1 plank TENU par c.299. La delivered-urn attestation c.299a (issue #12041 fermée via [RELEASED] cmt 5368879239 + `gh issue close`) est une activité META secondaire qui ne concurrence pas le plank.

## Résiduel

**Disjoint du claim po-2026 epic-wide sur cet issue** :

- L'**organe** (règle instruction-markdown dans `detect_markdown_rendering.py` + fixture + test non-régression) est porté par PR de po-2026 (#12064 epic-wide). Cette PR ne le contient pas.
- L'**extension corpus** (acceptance bullet hors-scope) reste àtracker par ai-01.
- **PR #12028 OPEN** (density round 1 PT-11 par po-2024) — disjoint (cellule 0, pas cellule 4/5), aucun conflit de merge prévu.

## Liens

- **#12064** — issue umbrella, partial acceptance (1/5 bullets livré : instance A résolue)
- **`c.5368888913`** — claim narrow `paths: MyIA.AI.Notebooks/GenAI/PostTraining/PT_11*.ipynb`
- **PR #12028** — density round 1, lane po-2024, disjoint
- **PR #12080** — c.292 référence, lane po-2025 QC (c.299a delivered-urn attestation)
- **`scripts/notebook_tools/detect_markdown_rendering.py`** — instrument principal (claim po-2026 epic-wide)

Voir #12064 (instance A uniquement, le reste hors-scope cette tranche)