### PR TITLE
fix(guard,#12093): check_markdown_claims_output — renvoi de section lu comme claim numerique (FP GT-16 4/4)

### DIFF
--- a/scripts/check_markdown_claims_output.py
+++ b/scripts/check_markdown_claims_output.py
@@ -229,6 +229,20 @@ _VERSION_PREFIX_RE = re.compile(
 )
 
 
+# Tokens that mark a number as a SECTION reference ("La section 4.5",
+# "(§3.2)") rather than a quantitative claim. A section pointer is
+# structural -- it names another part of the document -- and must not
+# be cross-referenced against the previous code cell's output.
+# c.421 / #12093: GT-16 4/4 FPs were all of this form. A short decimal
+# like '4.5' passes the _substantive short-decimal test and used to be
+# reported as fabricated.
+_SECTION_REF_PREFIX_RE = re.compile(
+    r"(?i)(?:\b(?:section|sous[- ]?section|chapitre|chapter|annexe|appendix|"
+    r"partie|part|module|unite|unit|etape|legon|lesson|titre|semaine|week|"
+    r"tranche|volet)\b|§)\s*$"
+)
+
+
 def _is_version_token(prose: str, match_pos: int) -> bool:
     """Return True if the numeric match at `match_pos` follows a version
     prefix token (SMT-LIB, Python, .NET, v, Version=).
@@ -246,6 +260,24 @@ def _is_version_token(prose: str, match_pos: int) -> bool:
     if not stripped:
         return False
     return bool(_VERSION_PREFIX_RE.search(stripped))
+
+
+def _is_section_reference(prose: str, match_pos: int) -> bool:
+    """Return True if the numeric match at `match_pos` is a section reference
+    ("La section 4.5", "(§3.2)") -- a pointer to another part of the document,
+    not a quantitative claim. c.421 / #12093 (GT-16 4/4 FP).
+
+    Looks at the 40 chars BEFORE the match; if the deepest section-marker
+    token ends right before the number, the number names a section, not a
+    measurement. The marker may be a word ("section", "annexe") or the §
+    glyph directly abutting the number ("§3.2").
+    """
+    prefix_start = max(0, match_pos - 40)
+    prefix = prose[prefix_start:match_pos]
+    stripped = prefix.rstrip()
+    if not stripped:
+        return False
+    return bool(_SECTION_REF_PREFIX_RE.search(stripped))
 
 
 # Hints that mark an inline-code span as QUOTED text (exception message,
@@ -415,6 +447,8 @@ def check_notebook(path: Path) -> dict:
                 continue
             # FP filters (c.366): skip version-number citations and
             # numbers inside quoted exception/version/path spans.
+            if _is_section_reference(prose, match_pos):
+                continue
             if _is_version_token(prose, match_pos):
                 continue
             if _in_exception_code_span(prose, match_pos, match_end):

--- a/scripts/tests/test_check_markdown_claims_output.py
+++ b/scripts/tests/test_check_markdown_claims_output.py
@@ -54,6 +54,7 @@ sys.path.insert(0, str(ROOT / "scripts"))
 from check_markdown_claims_output import (  # noqa: E402
     _fuzzy_present,
     _is_md_heading_line,
+    _is_section_reference,
     _is_version_token,
     _in_exception_code_span,
     _lit_skip,
@@ -548,6 +549,73 @@ class TestVersionTokenHelper:
         prose = "Mathlib 4 contient ce lemme"
         pos = prose.find("4")
         assert _is_version_token(prose, pos)
+
+
+class TestSectionReferenceFilter:
+    """c.421 / #12093: a section reference ("La section 4.5", "(§3.2)")
+    is a pointer to another part of the document, not a quantitative
+    claim. GT-16 4/4 FPs were all of this form. The filter must drop
+    them WITHOUT suppressing a real fabrication."""
+
+    def test_section_word_prefix(self):
+        prose = "La section 4.5 vient de montrer que VCG peut perdre"
+        pos = prose.find("4.5")
+        assert _is_section_reference(prose, pos)
+
+    def test_section_in_parenthesis(self):
+        prose = "compatible avec VCG (section 4.5) : VCG est truthful"
+        pos = prose.find("4.5")
+        assert _is_section_reference(prose, pos)
+
+    def test_pilcrow_glyph(self):
+        prose = "L'enchere au second prix (§3.2), dite enchere de Vickrey"
+        pos = prose.find("3.2")
+        assert _is_section_reference(prose, pos)
+
+    def test_section_with_dot_in_number(self):
+        prose = "La section 6.1 enonce le theoreme de Gibbard-Satterthwaite"
+        pos = prose.find("6.1")
+        assert _is_section_reference(prose, pos)
+
+    def test_not_section_for_fabrication(self):
+        prose = "On attend ~0,09 % des parametres"
+        pos = prose.find("0,09")
+        assert not _is_section_reference(prose, pos)
+
+    def test_not_section_at_start(self):
+        prose = "0.09% de parametres"
+        assert not _is_section_reference(prose, 0)
+
+    def test_section_ref_cleared_on_gt16_shape(self, tmp_path: Path):
+        """The exact GT-16 FPs: 'La section 4.5' / 'section 4.5' /
+        'La section 6.1' / '(§3.2)' are all CLEAN (not fabricated)."""
+        cases = [
+            "La section 4.5 vient de montrer que VCG peut perdre.",
+            "VCG (section 4.5) est truthful par construction.",
+            "La section 6.1 enonce le theoreme de Gibbard-Satterthwaite.",
+            "L'enchere au second prix (§3.2), dite enchere de Vickrey.",
+        ]
+        for i, md in enumerate(cases):
+            nb = _mk_nb([
+                _code_cell("print('hello')", [_stream_output("hello")]),
+                _md_cell(md),
+            ])
+            nb_path = tmp_path / f"sec_{i}.ipynb"
+            nb_path.write_text(json.dumps(nb), encoding="utf-8")
+            res = check_notebook(nb_path)
+            assert res["verdict"] == "CLEAN", (i, md, res)
+
+    def test_real_fabrication_not_suppressed(self, tmp_path: Path):
+        """The filter must not blind the detector: a number truly absent
+        from the output is still flagged, even if the prose is rich."""
+        nb = _mk_nb([
+            _code_cell("print('loss=3.38 -> 1.93')", [_stream_output("loss=3.38 -> 1.93")]),
+            _md_cell("On observe une perte de 0,09 %, avec un ratio de 1,2 M."),
+        ])
+        nb_path = tmp_path / "real_section_neighbor.ipynb"
+        nb_path.write_text(json.dumps(nb), encoding="utf-8")
+        res = check_notebook(nb_path)
+        assert res["verdict"] == "FABRICATION_DETECTED", res
 
 
 class TestExceptionSpanHelper:


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #12119

**Périmètre : 2 fichiers** (+102/−0)

## Summary

Fix du faux positif « renvoi de section » dans `check_markdown_claims_output.py`. Un renvoi de section (`La section 4.5`, `(§3.2)`) est **structurel** — il pointe vers une autre partie du document — et non une mesure. Or `NUMERIC_RE` le matchait et `_substantive("4.5")` le laissait passer (décimal court), si bien que `GameTheory-16-MechanismDesign.ipynb` rendait `FABRICATION_DETECTED` sur **4 constats sur 4** — taux de faux positif **100 %** sur ce notebook.

`Closes #12093`.

## La règle

Nouveau filtre `_is_section_reference` : le nombre est ignoré si le 40 caractères le précédant se terminent par un marqueur de section (`section`, `sous-section`, `chapitre`, `annexe`, `partie`, `module`, `etape`, `legon`, `titre`, `semaine`, `tranche`, `volet`, …) ou par le glyphe `§` collé au nombre (`§3.2`). Câblé dans la boucle de scan, après le filtre `_substantive` et avant les filtres version/exceptions (c.366).

**Purement additif** : aucun filtre existant n'est modifié. Un nombre réellement absent de la sortie de la cellule de code précédente reste signalé.

## Validation

- `python scripts/check_markdown_claims_output.py MyIA.AI.Notebooks/GameTheory/GameTheory-16-MechanismDesign.ipynb` → **CLEAN** (avant : `FABRICATION_DETECTED`, 4 constats)
- Cas fondateur c.290 (prose `~1,2 M` / `~0,09 %` vs sortie `3,145,728` / `0,24`) → **toujours `FABRICATION_DETECTED`** (`['1.2', '0.09']`)
- `pytest scripts/tests/test_check_markdown_claims_output.py` → **63/63 PASS** (55 existants + 8 nouveaux : les 4 formes exactes de GT-16, la négative `0,09`, le début de chaîne, et un voisin réel non supprimé)
- `py_compile` : OK · scan corpus notebooks : `errors=0`, GT-16 sorti des FABs

## Test plan

- [ ] ai-01 : merge (les 709 FABs restantes sur le corpus sont du bruit pré-existant — matrices de payoff, ratios — hors scope #12093, non touché par ce filtre)
- [ ] Re-run advisory CI sur la PR → commentaire « ✅ No fabricated prose detected » ou résidus hors section
