### PR TITLE
fix(ci,#12095): G-VAR-3 prev_genre depuis la sequence mergee, pas le champ declare fige

### DIFF
--- a/.github/workflows/variation-tag-guard.yml
+++ b/.github/workflows/variation-tag-guard.yml
@@ -837,13 +837,33 @@ jobs:
             COMMENTS_ARG="--comments-file /tmp/pr_comments.json"
           fi
 
+          # Merged PRs, to resolve the lane's REAL predecessor (#12095): the
+          # declared `prev:` is frozen at open time, so a lane merging grains
+          # while the PR sits open made this gate block PRs the rule never
+          # aimed at (#11963 measured `prev: MED/guard #11841` exact at
+          # redaction but followed by four merged grains -- real predecessor
+          # `notebook-python`). Same data source as the G-VAR-2 job above
+          # (`gh pr list --state merged`); no `merged:$TODAY` search here --
+          # the predecessor may sit on any past day, the script sorts by
+          # mergedAt itself. A fetch failure degrades to the declared `prev:`
+          # (the flag stays absent), never to a crash or a silent pass.
+          gh pr list --state merged --limit 100 \
+            --json number,body,mergedAt \
+            > /tmp/merged_prs.json 2>/dev/null || rm -f /tmp/merged_prs.json
+
+          MERGED_ARG=""
+          if [ -s /tmp/merged_prs.json ]; then
+            MERGED_ARG="--merged-prs-file /tmp/merged_prs.json"
+          fi
+
           # The helper emits one JSON verdict and exits 0 (pass/advisory) or
           # 1 (block on LIGHT adjacency). The &&/|| list captures RC on BOTH
           # branches and is exempt from errexit (same fix as
           # check-variation-tag-required).
-          # shellcheck disable=SC2086  # COMMENTS_ARG is a deliberate 0-or-2 token split
+          # shellcheck disable=SC2086  # COMMENTS_ARG/MERGED_ARG are deliberate 0-or-2 token splits
           python3 scripts/ci/variation_adjacency_guard.py \
-            --body-file /tmp/pr_body.txt $COMMENTS_ARG > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+            --body-file /tmp/pr_body.txt $COMMENTS_ARG $MERGED_ARG \
+            > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
 
           if [ -s /tmp/verdict.err ]; then
             echo "--- helper stderr ---"
@@ -1007,8 +1027,18 @@ jobs:
             COMMENTS_ARG="--comments-file /tmp/pr_comments.json"
           fi
 
-          # shellcheck disable=SC2086  # deliberate 0-or-2 token split
-          python3 scripts/ci/variation_adjacency_guard.py             --body-file /tmp/pr_body.txt $COMMENTS_ARG             > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
+          # Merged PRs for the lane's REAL predecessor (#12095) -- same
+          # plumbing as the pull_request job above.
+          gh pr list --state merged --limit 100 \
+            --json number,body,mergedAt \
+            > /tmp/merged_prs.json 2>/dev/null || rm -f /tmp/merged_prs.json
+          MERGED_ARG=""
+          if [ -s /tmp/merged_prs.json ]; then
+            MERGED_ARG="--merged-prs-file /tmp/merged_prs.json"
+          fi
+
+          # shellcheck disable=SC2086  # deliberate 0-or-2 token splits
+          python3 scripts/ci/variation_adjacency_guard.py             --body-file /tmp/pr_body.txt $COMMENTS_ARG $MERGED_ARG             > /tmp/verdict.json 2>/tmp/verdict.err && RC=0 || RC=$?
           if [ -s /tmp/verdict.err ]; then echo "--- helper stderr ---"; cat /tmp/verdict.err; fi
           echo "--- verdict ---"; cat /tmp/verdict.json 2>/dev/null || echo "(vide)"
 

--- a/scripts/ci/variation_adjacency_guard.py
+++ b/scripts/ci/variation_adjacency_guard.py
@@ -23,7 +23,17 @@ Reads the PR body, parses the Grain tag + its `prev:` field (both through
 the SHARED extractor `scripts/grain_tag.py`, so this organ and the guard
 never diverge on what a tag is), normalises both genres through the SAME
 alias table as the G-VAR-2 organ (`variation_light_cap.canonicalize_genre`),
-and compares:
+and compares. Since #12095 the predecessor genre comes from the MERGED
+sequence when the caller provides it (`--merged-prs-file`, resolved through
+`resolve_merged_prev_genre`): the `prev:` field is frozen at PR-open time, so
+a lane that merges grains while the PR sits open made the gate block PRs the
+rule never aimed at (#11963 measured `prev: MED/guard #11841` exact at
+redaction but followed by four merged grains -- the real predecessor was
+`notebook-python`). The declared `prev:` keeps its documentary value
+(exposed as `declared_prev_genre`) but is the source of truth ONLY when the
+lane has no merged grain to consult (a first grain, or a fetch failure --
+never a crash). The verdict reports which source it used in `prev_source`
+(`merged-sequence` | `declared`). Comparing:
 
   * **BLOCK** (exit 1) when `genre == prev_genre` AND the genre is in the
     LIGHT set `{guard, ledger, docs, readme, test}` -- the absolute ban of
@@ -136,7 +146,51 @@ def parse_override(comments: list[dict] | None) -> dict | None:
     return None
 
 
-def check(body: str | None, override: dict | None = None) -> dict:
+def resolve_merged_prev_genre(merged_prs: list[dict] | None, lane: str | None) -> tuple:
+    """Return the lane's REAL predecessor: (canonical_genre, pr_number).
+
+    G-VAR-3 adjacency is a property of the MERGED sequence of the lane, which
+    moves while a PR sits open. The `prev:` field in the body is frozen at
+    open time, so a PR acquires a false violation purely by aging -- issue
+    #11963 measured a `prev: MED/guard #11841` that was exact at redaction
+    (2026-08-20T08:27Z) but preceded by four grains merged since (#12025,
+    #12022, #12059, #12063, the last being `LIGHT/notebook-python`): the
+    declared field said `guard`, the real predecessor was `notebook-python`,
+    and the gate blocked a PR the rule never aimed at. The same mechanism
+    produces the symmetric false negative (a lane that merged the SAME genre
+    while the PR sat open passes despite real adjacency).
+
+    `merged_prs` is the list `gh pr list --state merged --json
+    number,body,mergedAt` returns -- the same data source as
+    variation_light_cap.py --replay. Each PR is attributed to a lane through
+    the SAME extractor as the gate (`grain_tag.parse_grain_tag`), so this
+    organ never diverges from the guard on what a tag is. Returns
+    ``(genre, pr_number)`` for the most recent lane-attributed PR with a
+    parseable Grain tag, or ``(None, None)`` when no such PR exists -- the
+    caller then falls back to the declared `prev:` field (a lane with no
+    merged grain has no merged sequence to consult). The genre is
+    canonicalised so the comparison uses the SAME alias table as the gate.
+    """
+    if not merged_prs or not lane:
+        return (None, None)
+    lane_prs = []
+    for pr in merged_prs:
+        g = gt.parse_grain_tag(pr.get("body"))
+        if g is None or g["lane"] != lane:
+            continue
+        genre = canonicalize_genre(g["genre"])
+        if genre is None:
+            continue
+        lane_prs.append((pr.get("mergedAt") or "", pr.get("number"), genre))
+    if not lane_prs:
+        return (None, None)
+    # Most recent first. `mergedAt` is ISO-8601, lexicographic == chronological.
+    lane_prs.sort(key=lambda t: t[0], reverse=True)
+    return (lane_prs[0][2], lane_prs[0][1])
+
+
+def check(body: str | None, override: dict | None = None,
+          merged_prev: tuple | None = None) -> dict:
     """Return the adjacency verdict for a PR body.
 
     Pure function so unit tests pin each branch without going through the
@@ -173,19 +227,45 @@ def check(body: str | None, override: dict | None = None) -> dict:
     # invisible -- variation-protocol §1 warns that two invented labels suffice
     # to never trip the ban.
     genre = canonicalize_genre(g["genre"])
-    prev_genre = canonicalize_genre(pv["genre"])
     lane = g["lane"]
+    declared_prev_genre = canonicalize_genre(pv["genre"])
+    declared_prev_pr = pv["pr_number"]
+
+    # Effective predecessor (#12095): the MERGED sequence is the source of
+    # truth -- the adjacency is a property of what the lane actually merged,
+    # not of what the author believed at open time. The declared `prev:` keeps
+    # its documentary value (it says what the author believed) but stops being
+    # the gate's authority. Fall back to the declared field when the lane has
+    # no merged grain to consult (a first grain, or a lane that has never
+    # merged).
+    if merged_prev is not None and merged_prev[0] is not None:
+        prev_genre = merged_prev[0]
+        prev_pr = merged_prev[1]
+        prev_source = "merged-sequence"
+    else:
+        prev_genre = declared_prev_genre
+        prev_pr = declared_prev_pr
+        prev_source = "declared"
+
     if genre is None or prev_genre is None:
         return {
             "guard_pass": True, "blocking": False, "adjacent": False,
             "genre": genre, "prev_genre": prev_genre, "lane": lane,
+            "prev_source": prev_source,
+            "declared_prev_genre": declared_prev_genre, "prev_pr": prev_pr,
             "reason": "genre or prev-genre not normalisable -- adjacency not evaluable",
         }
+
+    src_note = ""
+    if prev_source == "merged-sequence" and prev_pr:
+        src_note = f" (predecesseur reel: #{prev_pr}, sequence mergee)"
 
     if genre != prev_genre:
         return {
             "guard_pass": True, "blocking": False, "adjacent": False,
             "genre": genre, "prev_genre": prev_genre, "lane": lane,
+            "prev_source": prev_source,
+            "declared_prev_genre": declared_prev_genre, "prev_pr": prev_pr,
             "reason": f"genres differ ({genre} vs {prev_genre}) -- no adjacency",
         }
 
@@ -202,6 +282,8 @@ def check(body: str | None, override: dict | None = None) -> dict:
                 "overridden": True,
                 "override_author": override["author"],
                 "override_next": override["next_genre"],
+                "prev_source": prev_source,
+                "declared_prev_genre": declared_prev_genre, "prev_pr": prev_pr,
                 "reason": (
                     f"G-VAR-3: adjacence {genre} apres {prev_genre} REELLE, "
                     f"mais levee par {override['author']} au titre de la "
@@ -209,7 +291,7 @@ def check(body: str | None, override: dict | None = None) -> dict:
                     f"le remplacant »). Prochain grain nomme pour la lane "
                     f"{lane} : {override['next_genre']}. Le travail ecrit "
                     f"n'est pas jete ; la lane change de genre au grain "
-                    f"suivant."
+                    f"suivant.{src_note}"
                 ),
             }
         hint = ""
@@ -223,18 +305,22 @@ def check(body: str | None, override: dict | None = None) -> dict:
             "guard_pass": False, "blocking": True, "adjacent": True,
             "genre": genre, "prev_genre": prev_genre, "lane": lane,
             "overridden": False,
+            "prev_source": prev_source,
+            "declared_prev_genre": declared_prev_genre, "prev_pr": prev_pr,
             "reason": (
                 f"G-VAR-3: {genre} succede a {prev_genre} -- deux grains LIGHT "
                 f"consecutifs pour la lane {lane}. La regle est un ban absolu "
                 f"(§2): piochez un grain d'UN AUTRE genre, ne retaguez pas "
                 f"le meme travail (#11170). Tenu > 24 h : le coordinateur "
                 f"tranche par `[G-VAR-3 OVERRIDE] lane {lane} -- next: "
-                f"<genre>` (section 3), il ne laisse pas vieillir.{hint}"
+                f"<genre>` (section 3), il ne laisse pas vieillir.{hint}{src_note}"
             ),
         }
     return {
         "guard_pass": True, "blocking": False, "adjacent": True,
         "genre": genre, "prev_genre": prev_genre, "lane": lane,
+        "prev_source": prev_source,
+        "declared_prev_genre": declared_prev_genre, "prev_pr": prev_pr,
         "reason": (
             f"adjacence {genre}->{prev_genre} hors liste LIGHT : §2 l'autorise "
             f"si chaque grain est une substance genument distincte -- "
@@ -250,6 +336,11 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--comments-file", metavar="FILE", default=None,
                    help="JSON list of {author, body} PR comments, scanned for "
                         "a coordinator [G-VAR-3 OVERRIDE] marker (#11708)")
+    p.add_argument("--merged-prs-file", metavar="FILE", default=None,
+                   help="JSON list of merged PRs {number, body, mergedAt}, to "
+                        "resolve the lane's real predecessor from the merged "
+                        "sequence instead of the frozen `prev:` field (#12095). "
+                        "Same data source as variation_light_cap.py --replay.")
     args = p.parse_args(argv)
 
     try:
@@ -269,7 +360,18 @@ def main(argv: list[str] | None = None) -> int:
             print(json.dumps({"warning": f"comments unreadable: {e}"}),
                   file=sys.stderr)
 
-    verdict = check(body, override=override)
+    merged_prev = None
+    if args.merged_prs_file:
+        try:
+            with open(args.merged_prs_file, encoding="utf-8") as f:
+                merged_prs = json.load(f)
+            g = gt.parse_grain_tag(body)
+            merged_prev = resolve_merged_prev_genre(merged_prs, g["lane"] if g else None)
+        except (OSError, ValueError) as e:
+            print(json.dumps({"warning": f"merged-prs unreadable: {e}"}),
+                  file=sys.stderr)
+
+    verdict = check(body, override=override, merged_prev=merged_prev)
     print(json.dumps(verdict, ensure_ascii=False))
     return 0 if verdict["guard_pass"] else 1
 

--- a/scripts/tests/test_variation_adjacency_guard.py
+++ b/scripts/tests/test_variation_adjacency_guard.py
@@ -248,3 +248,109 @@ def test_parse_override_empty_and_malformed():
     assert vag.parse_override([]) is None
     assert vag.parse_override(
         [{"author": "myia-ai-01", "body": "rien a voir"}]) is None
+
+
+# --- merged-sequence predecessor (#12095) ----------------------------------
+#
+# G-VAR-3 adjacency is a property of the MERGED sequence, which moves while a
+# PR sits open. The `prev:` field is frozen at open time, so a PR acquires a
+# false violation purely by aging. These cases pin BOTH directions from issue
+# #11963 -- the false positive (declared guard, real predecessor
+# notebook-python -> pass) and the symmetric false negative (declared
+# notebook-python, real predecessor guard -> still blocks) -- plus the
+# no-merged-PR fallback and the other-lane isolation.
+
+_MERGED_LANE = "myia-po-2024:CoursIA-2"
+
+# The #11963 shape: `prev: MED/guard #11841` was exact at redaction
+# (2026-08-20T08:27Z), but the lane merged four grains since, the last being
+# notebook-python. The declared field says `guard`, the real predecessor is
+# `notebook-python` -- the gate must not block a PR the rule never aimed at.
+_MERGED_11963 = [
+    {"number": 12025, "mergedAt": "2026-08-20T23:30:00Z",
+     "body": "Grain: DEEP/notebook-python -- lane myia-po-2024:CoursIA-2 -- prev: MED/tooling #1"},
+    {"number": 12022, "mergedAt": "2026-08-21T03:16:00Z",
+     "body": "Grain: DEEP/notebook-python -- lane myia-po-2024:CoursIA-2 -- prev: MED/tooling #2"},
+    {"number": 12059, "mergedAt": "2026-08-21T03:17:00Z",
+     "body": "Grain: DEEP/notebook-python -- lane myia-po-2024:CoursIA-2 -- prev: MED/tooling #3"},
+    {"number": 12063, "mergedAt": "2026-08-21T04:25:00Z",
+     "body": "Grain: LIGHT/notebook-python -- lane myia-po-2024:CoursIA-2 -- prev: MED/tooling #4"},
+]
+
+
+def test_resolve_merged_prev_genre_picks_last_lane_pr():
+    mp = vag.resolve_merged_prev_genre(_MERGED_11963, _MERGED_LANE)
+    assert mp == ("notebook-python", 12063)
+
+
+def test_resolve_skips_other_lanes_and_untagged():
+    merged = _MERGED_11963 + [
+        {"number": 12100, "mergedAt": "2026-08-21T05:00:00Z",
+         "body": "Grain: LIGHT/guard -- lane myia-po-2023:CoursIA -- prev: MED/tooling #5"},
+        {"number": 12101, "mergedAt": "2026-08-21T05:30:00Z",
+         "body": "No Grain tag here."},
+    ]
+    mp = vag.resolve_merged_prev_genre(merged, _MERGED_LANE)
+    assert mp == ("notebook-python", 12063)
+
+
+def test_11963_declared_guard_merged_notebook_python_passes():
+    # The issue's measured case: the declared `prev: MED/guard #11841` was
+    # exact at redaction, but the real predecessor from the merged sequence is
+    # notebook-python. The gate must PASS -- this is the false positive #12095
+    # fixes (a PR blocked by the passage of time, not by its own genre).
+    body = ("Grain: MED/guard -- lane myia-po-2024:CoursIA-2 -- "
+            "prev: MED/guard #11841")
+    v = vag.check(body, merged_prev=vag.resolve_merged_prev_genre(
+        _MERGED_11963, _MERGED_LANE))
+    assert v["guard_pass"] is True
+    assert v["blocking"] is False
+    assert v["prev_genre"] == "notebook-python"
+    assert v["prev_source"] == "merged-sequence"
+    assert v["prev_pr"] == 12063
+    assert v["declared_prev_genre"] == "guard"
+
+
+def test_symmetric_false_negative_still_blocks():
+    # Positive control (same invocation): the lane REALLY merged a guard last.
+    # Even if the declared prev announces a different genre, the gate must
+    # still block -- the symmetric false negative the issue names.
+    body = ("Grain: MED/guard -- lane myia-po-2024:CoursIA-2 -- "
+            "prev: MED/notebook-python #12063")
+    merged = [
+        {"number": 12025, "mergedAt": "2026-08-20T23:30:00Z",
+         "body": "Grain: DEEP/notebook-python -- lane myia-po-2024:CoursIA-2 -- prev: MED/tooling #1"},
+        {"number": 12063, "mergedAt": "2026-08-21T04:25:00Z",
+         "body": "Grain: LIGHT/guard -- lane myia-po-2024:CoursIA-2 -- prev: MED/tooling #2"},
+    ]
+    v = vag.check(body, merged_prev=vag.resolve_merged_prev_genre(merged, _MERGED_LANE))
+    assert v["guard_pass"] is False
+    assert v["blocking"] is True
+    assert v["prev_genre"] == "guard"
+    assert v["prev_source"] == "merged-sequence"
+
+
+def test_no_merged_pr_falls_back_to_declared():
+    # A lane with no merged grain has no merged sequence to consult: the gate
+    # falls back to the declared `prev:` (the pre-#12095 behaviour), no crash,
+    # and the verdict is honest about the source.
+    v = vag.check(_BLOCKED, merged_prev=vag.resolve_merged_prev_genre([], "myia-po-2026:CoursIA"))
+    assert v["guard_pass"] is False
+    assert v["blocking"] is True
+    assert v["prev_source"] == "declared"
+    # A declaring-different-genre case passes too, same fallback.
+    v2 = vag.check(
+        "Grain: LIGHT/guard -- lane myia-po-2026:CoursIA -- prev: MED/tooling #12063",
+        merged_prev=vag.resolve_merged_prev_genre(None, "myia-po-2026:CoursIA"))
+    assert v2["guard_pass"] is True
+    assert v2["prev_source"] == "declared"
+
+
+def test_merged_sequence_other_lane_ignored():
+    # A merged PR from ANOTHER lane must not become this lane's predecessor.
+    merged = [
+        {"number": 12025, "mergedAt": "2026-08-20T23:30:00Z",
+         "body": "Grain: LIGHT/guard -- lane myia-po-2023:CoursIA -- prev: MED/tooling #1"},
+    ]
+    mp = vag.resolve_merged_prev_genre(merged, "myia-po-2026:CoursIA")
+    assert mp == (None, None)


### PR DESCRIPTION
Grain: MED/guard -- lane myia-po-2026:CoursIA -- prev: MED/notebook-python (#12124)

fix(ci,#12095): G-VAR-3 -- prev_genre depuis la sequence MERGEE de la lane, pas le champ declare fige

## Defaut mesure (#11963)

Le gate `Require genre diversity vs prev` calculait l'adjacence depuis le champ **`prev:` auto-declare dans le body**, fige a l'ouverture de la PR. Or l'adjacence est une propriete de la **sequence mergee de la lane**, qui bouge pendant que la PR reste ouverte : **une PR acquiert une fausse violation par le seul ecoulement du temps**, sans faute de son auteur.

Cas #11963 : `prev: MED/guard #11841` etait **exact a la redaction** (merge 08:27Z, PR ouverte 14:09Z). Depuis, la lane a merge 4 grains (#12025/#12022/#12059/#12063), le dernier `LIGHT/notebook-python`. Predecesseur **reel** : notebook-python. Sequence effective `notebook-python -> guard` : aucune repetition. Le gate a bloque une PR que la regle n'a jamais visee -- et la lane avait livre 3 grains DEEP dans l'intervalle, l'exact oppose de la monoculture que G-VAR-3 existe pour attraper.

Symetrie : le meme mecanisme produit un **faux negatif** (lane qui merge le MEME genre pendant que la PR vieillit -> passe malgre l'adjacence reelle).

## Fix

- **`resolve_merged_prev_genre(merged_prs, lane)`** : derniere PR mergee de la lane, meme source de donnees que `variation_light_cap.py --replay` (`gh pr list --state merged --json number,body,mergedAt`), attribution par le MEME extracteur (`grain_tag.parse_grain_tag`), genre canonicalise par la MEME table d'alias. Retourne `(genre, pr_number)` ou `(None, None)`.
- **`check(merged_prev=...)`** : la sequence mergee devient la **source de verite** du predecesseur. Le champ declare garde sa valeur documentaire (`declared_prev_genre` dans le verdict) et reste le **repli documente** quand la lane n'a aucune PR mergee -- jamais de crash.
- Le verdict expose `prev_source` (`merged-sequence` | `declared`) et `prev_pr` (le predecesseur reel cite dans le reason des branches bloquantes/advisory).
- **Wiring CI** : les 2 jobs (`check-variation-adjacency-required` pull_request + `check-variation-adjacency-comment` issue_comment) fetchent les PRs mergees et passent `--merged-prs-file`. Echec de fetch -> repli sur le champ declare (le flag reste absent), jamais de crash ni de pass silencieux.

## Acceptance (3 criteres de l'issue, tous couverts par tests)

| Critere | Test | Verdict |
|---|---|---|
| 1. #11963 : declare `guard`, lane a merge `notebook-python` depuis | `test_11963_declared_guard_merged_notebook_python_passes` | gate **PASSE** |
| 2. Controle positif : lane a reellement merge un `guard` juste avant, declare annonce un autre genre | `test_symmetric_false_negative_still_blocks` | gate **BLOQUE** (faux negatif symetrique ferme) |
| 3. Aucune PR mergee pour la lane | `test_no_merged_pr_falls_back_to_declared` | **repli documente** sur le champ declare, sans crash |

+ `test_resolve_merged_prev_genre_picks_last_lane_pr` (tri mergedAt, dernier gagne), `test_resolve_skips_other_lanes_and_untagged`, `test_merged_sequence_other_lane_ignored` (isolation inter-lanes).

## Verifications

- `pytest scripts/tests/test_variation_adjacency_guard.py` : **29 passed** (23 existants inchanges + 6 nouveaux).
- Suites apparentees : `test_variation_tag_comment_trigger.py` + `test_variation_light_cap.py` + `test_grain_tag.py` : **131 + 49 passed** -- aucune regression des organes voisins.
- **E2E sur donnees reelles** (CLI, repo vivant) : PR #12124 -> `{"prev_source": "merged-sequence", "prev_genre": "notebook-python", "prev_pr": 12094, "declared_prev_genre": "tooling", ...}` -- le gate mesure desormais la grandeur qu'il pretend mesurer (advisory honnete sur une vraie adjacence DEEP, au lieu d'un pass aveugle sur un prev declare perime).
- YAML workflow valide (les 2 jobs adjacency parsent).

## Perimetre

3 fichiers, +248/-10 : le gate, ses tests, le wiring CI. Un seul sujet (G-VAR-3 source de verite), aucun fichier catalogue touche.

## Note hors scope

Le champ `prev: none (premier grain)` court-circuite toujours (exemption premier grain) : la faire biaiser par la sequence mergee serait un changement de semantique distinct, hors acceptance de #12095.

## Closes

Closes #12095 (les 3 criteres d'acceptation verifies par tests).

Co-Authored-By: Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>
