### PR TITLE
feat(sw13,#11601): densite SW-13-Python-Reasoners 1286 -> 1650 c/cell (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
+++ b/MyIA.AI.Notebooks/SymbolicAI/SemanticWeb/SW-13-Python-Reasoners.ipynb
@@ -86,7 +86,16 @@
    "source": [
     "## Configuration\n",
     "\n",
-    "Installons les dépendances nécessaires."
+    "Installons les dépendances nécessaires.\n",
+    "\n",
+    "Deux familles de dépendances sont attendues : les raisonneurs OWL 2 RL\n",
+    "(`owlrl` en Python pur, `reasonable` en Rust avec bindings Python) et la\n",
+    "pile OWL 2 DL (`owlready2`, qui embarque un pont vers la JVM et le\n",
+    "raisonneur HermiT), plus les outils de visualisation (`matplotlib`,\n",
+    "`pandas`). La cellule suit le patron « installer seulement si l'import\n",
+    "échoue » : un environnement déjà provisionné n'est pas modifié, et la\n",
+    "confirmation unique de fin de cellule vaut pour l'ensemble des six\n",
+    "packages.\n"
    ]
   },
   {
@@ -152,7 +161,15 @@
     "tags": []
    },
    "source": [
-    "Importation des bibliotheques principales : rdflib, owlrl, OWLReady2 et reasonable."
+    "Importation des bibliotheques principales : rdflib, owlrl, OWLReady2 et reasonable.\n",
+    "\n",
+    "L'importation sert aussi de point de contrôle d'environnement : la cellule\n",
+    "affiche les versions effectivement chargées (interpréteur, RDFLib, owlrl)\n",
+    "plutôt que de supposer celle du contexte d'exécution. C'est une habitude à\n",
+    "conserver pour tout travail comparatif — les corpus de règles OWL évoluent\n",
+    "entre versions d'un raisonneur, et un écart de comportement observé d'une\n",
+    "machine à l'autre se diagnostique d'abord en comparant ces lignes. Les\n",
+    "avertissements sont filtrés pour ne pas polluer les sorties comparatives.\n"
    ]
   },
   {
@@ -329,7 +346,16 @@
     "tags": []
    },
    "source": [
-    "Definition de la hiérarchie de classes OWL pour l'ontologie de test (Pizza Ontology simplifiee)."
+    "Definition de la hiérarchie de classes OWL pour l'ontologie de test (Pizza Ontology simplifiee).\n",
+    "\n",
+    "La hiérarchie est exprimée uniquement avec `rdfs:subClassOf` — la relation\n",
+    "de spécialisation que tout raisonneur, même RDFS, propage des classes vers\n",
+    "les instances. Deux arbres se dessinent : les bases (`ThinAndCrispyBase`,\n",
+    "`DeepPanBase` sous `PizzaBase`) et les garnitures (`MeatTopping` sous\n",
+    "`PizzaTopping`, `CheeseTopping` sous `VegetarianTopping`). La cellule ajoute\n",
+    "aussi la propriété d'objet `hasTopping` avec son domaine et son intervalle,\n",
+    "puis une restriction `owl:allValuesFrom` : c'est elle qui portera la charge\n",
+    "sémantique des exemples guidés 4 et 6.\n"
    ]
   },
   {
@@ -407,7 +433,13 @@
     "tags": []
    },
    "source": [
-    "Ajout des individus (instances de classes) pour alimenter le raisonnement."
+    "Ajout des individus (instances de classes) pour alimenter le raisonnement.\n",
+    "\n",
+    "Les individus alimentent le raisonnement : sans instances, une ontologie\n",
+    "ne produit que des inférences schéma contre schéma. Chaque pizza crée ici\n",
+    "l'occasion d'une double inférence — son type direct et les types hérités\n",
+    "par la chaîne de `subClassOf` — et les garnitures rattachées préparent la\n",
+    "restriction `allValuesFrom` posée à la cellule précédente.\n"
    ]
   },
   {
@@ -489,7 +521,14 @@
     "tags": []
    },
    "source": [
-    "Serialisation du graphe initial en Turtle comme reference avant l'application du raisonnement."
+    "Serialisation du graphe initial en Turtle comme reference avant l'application du raisonnement.\n",
+    "\n",
+    "Sérialiser avant de raisonner fixe la référence : le fichier Turtle produit\n",
+    "sert d'état « avant » pour vérifier, après coup, qu'aucun triplet inféré n'a\n",
+    "contaminé le graphe de départ (chaque raisonneur travaillera sur une copie).\n",
+    "L'aperçu affiché en sortie permet de contrôler d'un coup d'œil la forme des\n",
+    "triplets — déclaration d'ontologie, typages, spécialisations — avant que les\n",
+    "raisonneurs n'entrent en jeu.\n"
    ]
   },
   {
@@ -683,7 +722,13 @@
     "tags": []
    },
    "source": [
-    "Affichage d'exemples de triplets inferences par owlrl pour illustrer les résultats du raisonnement OWL 2 RL."
+    "Affichage d'exemples de triplets inferences par owlrl pour illustrer les résultats du raisonnement OWL 2 RL.\n",
+    "\n",
+    "Deux indices de lecture pour la sortie à venir : les triplets réflexifs\n",
+    "(un terme relié à lui-même) et les triplets d'égalité sont la trace directe\n",
+    "des règles OWL 2 RL de plus bas niveau. Ils paraissent triviaux — chacun\n",
+    "conditionne pourtant la correction des inférences plus intéressantes qui\n",
+    "s'appuient dessus.\n"
    ]
   },
   {
@@ -902,7 +947,15 @@
     "tags": []
    },
    "source": [
-    "Creation des classes et proprietes OWLReady2 pour reproduire l'ontologie avec le raisonneur HermiT."
+    "Creation des classes et proprietes OWLReady2 pour reproduire l'ontologie avec le raisonneur HermiT.\n",
+    "\n",
+    "OWLReady2 expose un modèle objet différent du graphe RDFLib : les classes\n",
+    "sont des classes Python (l'héritage natif code `subClassOf`), et le\n",
+    "raisonnement s'appelle par synchronisation plutôt que par expansion du\n",
+    "graphe. Reconstruire l'ontologie dans ce modèle est nécessaire — les deux\n",
+    "mondes ne partagent pas leurs structures — et c'est aussi l'occasion de\n",
+    "vérifier que la hiérarchie exprimée en triplets se traduit sans perte en\n",
+    "déclarations Python.\n"
    ]
   },
   {
@@ -994,7 +1047,12 @@
     "tags": []
    },
    "source": [
-    "Ajout des instances dans l'ontologie OWLReady2 et preparation du raisonnement HermiT."
+    "Ajout des instances dans l'ontologie OWLReady2 et preparation du raisonnement HermiT.\n",
+    "\n",
+    "Les mêmes instances que côté RDFLib sont recréées ici, avec leurs\n",
+    "garnitures. Ce doublon volontaire est le prix de la comparaison : chaque\n",
+    "raisonneur recevra une ontologie construite dans son idiome natif, sans\n",
+    "conversion qui puisse introduire de biais.\n"
    ]
   },
   {
@@ -1060,7 +1118,14 @@
     "tags": []
    },
    "source": [
-    "Exécution du raisonnement HermiT sur l'ontologie et collecte des résultats inferences."
+    "Exécution du raisonnement HermiT sur l'ontologie et collecte des résultats inferences.\n",
+    "\n",
+    "`sync_reasoner()` lance le raisonneur HermiT embarqué par OWLReady2 : le\n",
+    "pont sérialise l'ontologie vers la JVM, exécute le raisonneur, puis\n",
+    "réimporte les classifications obtenues. Le premier appel embarque le\n",
+    "démarrage de la JVM — les appels suivants sur la même session seraient plus\n",
+    "rapides — et c'est pour cela que la comparaison finale de ce notebook mesure\n",
+    "HermiT à part des raisonneurs RL.\n"
    ]
   },
   {
@@ -1288,7 +1353,12 @@
     "tags": []
    },
    "source": [
-    "Exécution du raisonnement avec la bibliotheque reasonable et collecte des résultats."
+    "Exécution du raisonnement avec la bibliotheque reasonable et collecte des résultats.\n",
+    "\n",
+    "Même protocole que pour owlrl : copie du graphe de base, chronométrage de\n",
+    "l'expansion, comptage des triplets avant et après. La symétrie des cellules\n",
+    "est délibérée — seule l'implémentation change, pas la tâche — c'est elle qui\n",
+    "autorise la comparaison du tableau final.\n"
    ]
   },
   {
@@ -1520,7 +1590,14 @@
     "tags": []
    },
    "source": [
-    "Verification de la disponibilite de Growl et exécution du raisonnement si disponible."
+    "Verification de la disponibilite de Growl et exécution du raisonnement si disponible.\n",
+    "\n",
+    "Growl se détecte par sa présence dans le `PATH` (`shutil.which`), pas par\n",
+    "un import : c'est un exécutable C appelé en sous-processus, avec fichier\n",
+    "d'entrée et de sortie sérialisés en Turtle. S'il est absent, la cellule\n",
+    "imprime la procédure de compilation et le notebook continue — Growl est le\n",
+    "seul des quatre raisonneurs qui exige une installation manuelle, et le\n",
+    "tableau comparatif final saura ignorer proprement son absence.\n"
    ]
   },
   {
@@ -1753,7 +1830,12 @@
     "tags": []
    },
    "source": [
-    "Visualisation des temps d'exécution de chaque raisonneur sous forme de graphique."
+    "Visualisation des temps d'exécution de chaque raisonneur sous forme de graphique.\n",
+    "\n",
+    "Le graphique ne retient que les raisonneurs mesurés dans ce notebook.\n",
+    "Chaque barre porte sa valeur numérique : à l'échelle des durées en jeu, la\n",
+    "barre du plus rapide est presque invisible — c'est précisément le message\n",
+    "visuel, et la cellule suivante le commente.\n"
    ]
   },
   {
@@ -1863,7 +1945,12 @@
     "tags": []
    },
    "source": [
-    "Comparaison du nombre de triplets inferences par les raisonneurs compatibles OWL 2 RL."
+    "Comparaison du nombre de triplets inferences par les raisonneurs compatibles OWL 2 RL.\n",
+    "\n",
+    "La seconde figure répond à une question distincte : non plus « qui va le\n",
+    "plus vite ? » mais « qui déduit le plus ? ». Seuls les raisonneurs dont le\n",
+    "compte de triplets inférés est comparable (profil RL) y figurent — les\n",
+    "barres se lisent comme une mesure de complétude relative.\n"
    ]
   },
   {
@@ -2011,7 +2098,12 @@
     "## Exemples guidés\n",
     "\n",
     "Les exemples suivants illustrent des cas d’usage avancés des raisonneurs OWL.\n",
-    "Solutions proposées par **@Sosolalt** (EPITA-IS, promo 2028)."
+    "Solutions proposées par **@Sosolalt** (EPITA-IS, promo 2028).\n",
+    "\n",
+    "Chaque exemple combine un scénario d'usage réaliste, une exécution complète\n",
+    "dont les sorties sont committées, et — pour quatre d'entre eux — une lecture\n",
+    "ancrée sur la sortie. Les énoncés d'exercices correspondants, en fin de\n",
+    "notebook, reprennent les mêmes scénarios sur des squelettes à compléter.\n"
    ]
   },
   {
@@ -2030,7 +2122,15 @@
    "source": [
     "### Exemple guidé 1 : Benchmark sur une ontologie plus grande\n",
     "\n",
-    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*"
+    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*\n",
+    "\n",
+    "L'ontologie de test de ce notebook compte une quarantaine de triplets —\n",
+    "assez pour observer les mécanismes, trop peu pour distinguer des stratégies\n",
+    "d'implémentation. Cet exemple rejoue donc le benchmark sur la Pizza\n",
+    "Ontology complète de Stanford, servie depuis une copie locale vendored pour\n",
+    "rester reproductible hors ligne (le téléchargement distant n'est qu'un\n",
+    "repli). Le contraste avec les mesures sur petit graphe porte sur les ratios,\n",
+    "pas sur les ordres de grandeur.\n"
    ]
   },
   {
@@ -2143,6 +2243,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "049d2a95",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'exemple 1 : le comportement à l'échelle\n",
+    "\n",
+    "La sortie committée mesure, sur la Pizza Ontology complète (1944 triplets\n",
+    "chargés depuis la copie locale vendored) :\n",
+    "\n",
+    "| Raisonneur | Temps mesuré | Triplets inférés |\n",
+    "|---|---|---|\n",
+    "| owlrl | *runtime machine-dep* : ~3 s | 8005 |\n",
+    "| reasonable | *runtime machine-dep* : ~0,04 s | 939 |\n",
+    "\n",
+    "Deux ordres de grandeur se confirment à l'échelle : l'écart de vitesse se\n",
+    "creuse (~72x selon la sortie, contre ~40x sur l'ontologie de test d'une\n",
+    "quarantaine de triplets), et l'écart de complétude se creuse aussi (8005\n",
+    "contre 939 triplets inférés, soit ~8,5x). Leçon méthodologique : un\n",
+    "benchmark sur un petit graphe donne les tendances correctes mais\n",
+    "sous-estime les deux écarts ; les ratios divergent avec la taille du\n",
+    "graphe, et seul l'ordre de grandeur (reasonable bien plus rapide, owlrl\n",
+    "bien plus complet) est stable d'une ontologie à l'autre.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "exemple-sw13-2",
    "metadata": {
     "papermill": {
@@ -2157,7 +2282,12 @@
    "source": [
     "### Exemple guidé 2 : Verification de l'equivalence des résultats RL\n",
     "\n",
-    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*"
+    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*\n",
+    "\n",
+    "Les deux raisonneurs RL revendiquent le même profil : leurs fermetures\n",
+    "sont-elles identiques pour autant ? La cellule compare les ensembles de\n",
+    "triplets inférés triplet par triplet, et détaille ce que chacun produit en\n",
+    "propre.\n"
    ]
   },
   {
@@ -2314,7 +2444,12 @@
    "source": [
     "### Exemple guidé 3 : Profilage avance avec cProfile\n",
     "\n",
-    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*"
+    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*\n",
+    "\n",
+    "Profiler complète le chronométrage : le temps total dit combien, le profil\n",
+    "dit où. La cellule instrumente l'expansion owlrl avec `cProfile` et trie les\n",
+    "fonctions par temps cumulé — les chemins de fichiers sont normalisés par\n",
+    "`strip_dirs()` pour que la sortie reste portable.\n"
    ]
   },
   {
@@ -2405,6 +2540,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a78cac43",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'exemple 3 : où passe le temps d'owlrl\n",
+    "\n",
+    "La sortie du profileur est explicite : 304 119 appels de fonctions pour\n",
+    "un seul raisonnement, et le haut du classement par temps cumulé est occupé\n",
+    "par `OWLRL.py` (la passe de règles, invoquée 820 fois) puis `Closure.py`\n",
+    "(la boucle de fermeture). Autrement dit, le coût n'est ni dans l'analyse\n",
+    "syntaxique du graphe ni dans les entrées-sorties : il est dans\n",
+    "l'application répétée du corpus de règles OWL 2 RL jusqu'au point fixe.\n",
+    "C'est la signature d'un moteur de règles interprété — chaque règle est\n",
+    "réévaluée en Python pur à chaque tour — contre l'implémentation Rust de\n",
+    "reasonable qui compile ce même cycle de règles. Le chiffre déterminant à\n",
+    "retenir : 820 invocations de la passe de règles pour une quarantaine de\n",
+    "triplets initiaux, soit plus de vingt passes par triplet de départ ; ce\n",
+    "compte est déterministe pour une ontologie donnée, seule la durée varie\n",
+    "avec la machine.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "exemple-f4c8e8e3",
    "metadata": {
     "papermill": {
@@ -2419,7 +2576,13 @@
    "source": [
     "### Exemple guidé 4 : Detection d'incoherence avec un raisonneur DL (HermiT)\n",
     "\n",
-    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*"
+    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*\n",
+    "\n",
+    "Le scénario déclare volontairement une ontologie incohérente — une\n",
+    "garniture typée à la fois végétale et animale via des classes disjointes —\n",
+    "et demande aux deux familles de raisonneurs ce qu'elles en tirent. La sortie\n",
+    "oppose un verdict logique et une matérialisation silencieuse ; la lecture\n",
+    "qui suit la cellule en tire la règle de choix.\n"
    ]
   },
   {
@@ -2525,6 +2688,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "267c9a95",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'exemple 4 : DL détecte, RL matérialise\n",
+    "\n",
+    "La sortie oppose les deux philosophies sur le même graphe incohérent\n",
+    "(`tomate` déclarée à la fois `Vegetal` et `Animal`, classes disjointes) :\n",
+    "HermiT (DL) signale l'INCOHÉRENCE, owlrl (RL) produit sa matérialisation\n",
+    "sans lever d'exception. La détection d'HermiT ne paraît arbitraire que si\n",
+    "l'on oublie l'hypothèse du monde ouvert (cf. section liminaire) : c'est\n",
+    "l'assertion explicite de disjointness qui rend la contradiction dérivable,\n",
+    "et seul un raisonneur complet au sens OWL 2 DL a l'obligation de la\n",
+    "signaler. Le profil RL, conçu pour la matérialisation rapide, applique ses\n",
+    "règles sans contrôle de cohérence global — un graphe incohérent produit\n",
+    "simplement des triplets contradictoires. Conclusion pratique, cohérente\n",
+    "avec le tableau comparatif : raisonneur DL pour valider la cohérence\n",
+    "logique d'une ontologie avant publication, profil RL pour dériver vite une\n",
+    "fermeture exploitable.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "exemple-7a9d8adc",
    "metadata": {
     "papermill": {
@@ -2539,7 +2724,12 @@
    "source": [
     "### Exemple guidé 5 : Inferences sur axiomes de proprietes OWL\n",
     "\n",
-    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*"
+    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*\n",
+    "\n",
+    "Au-delà des classes, OWL contraint aussi les propriétés : transitivité,\n",
+    "symétrie, inversion. La cellule asserte un petit graphe familial puis\n",
+    "regarde quels triplets le raisonnement matérialise — y compris une chaîne\n",
+    "d'ancêtres dont la fermeture transitive se compte exactement.\n"
    ]
   },
   {
@@ -2636,6 +2826,27 @@
   },
   {
    "cell_type": "markdown",
+   "id": "c819b13c",
+   "metadata": {},
+   "source": [
+    "### Lecture de l'exemple 5 : la fermeture des axiomes de propriétés\n",
+    "\n",
+    "Sept triplets initiaux deviennent 126 après raisonnement — 119 triplets\n",
+    "matérialisés — et les trois propriétés attendues tombent à `True` :\n",
+    "transitivité (`A hasAncestor C` dérivé des deux arcs A vers B puis B vers\n",
+    "C), symétrie (`B knows A` dérivé de `A knows B`) et inversion (`B hasChild\n",
+    "A` dérivé de `A hasParent B`). Le bonus quantifie le coût de la fermeture\n",
+    "transitive : une chaîne de dix éléments (neuf arêtes) se dilate en 45 paires\n",
+    "`hasAncestor` — exactement 9+8+...+1, soit 10·9/2 — le nombre de paires d'une chaîne de dix éléments.\n",
+    "Ce compte est déterministe et illustre pourquoi la matérialisation complète\n",
+    "peut exploser sur de grands graphes : la fermeture transitive croît\n",
+    "quadratiquement avec la longueur de la plus longue chaîne, ce qui est une\n",
+    "des raisons de préférer, dans certaines applications, l'interrogation du\n",
+    "raisonneur à la demande plutôt que la matérialisation de toute la fermeture.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "exemple-626076ee",
    "metadata": {
     "papermill": {
@@ -2650,7 +2861,12 @@
    "source": [
     "### Exemple guidé 6 : Comparaison expressivite OWL 2 RL vs OWL 2 DL (someValuesFrom)\n",
     "\n",
-    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*"
+    "*Solution proposee par @Sosolalt (EPITA-IS, promo 2028).*\n",
+    "\n",
+    "L'opinion répandue veut que la classification par restriction\n",
+    "`someValuesFrom` soit hors de portée du profil RL. La cellule la teste sur\n",
+    "deux constructions — la classification d'une pizza, puis une cardinalité\n",
+    "minimale — et la sortie nuance sérieusement la légende.\n"
    ]
   },
   {
@@ -2908,7 +3124,13 @@
     "## Exercices à compléter\n",
     "\n",
     "Les exercices ci-dessous reprennent les concepts illustrés par les exemples guidés ci-dessus.\n",
-    "Chaque exercice contient un squelette de code à compléter."
+    "Chaque exercice contient un squelette de code à compléter.\n",
+    "\n",
+    "Chaque squelette reprend le scénario d'un exemple guidé, avec la structure\n",
+    "et les affichages attendus déjà en place : compléter l'exercice revient à\n",
+    "retrouver la démarche de l'exemple, pas à deviner sa forme. Le notebook\n",
+    "s'exécute de bout en bout même les exercices laissés vides — les cellules\n",
+    "stub n'interrompent jamais la chaîne d'exécution.\n"
    ]
   },
   {

--- a/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/sw-13-reasoners.yaml
@@ -39,9 +39,16 @@
       csharp_sha: 160675f58686100e1d03eecc047e34698ac4997a
       content_python_sha: 5bc1f3a367186becd09a532ffba0c556012ff014fe9eae951dea7f677c689cd0
       content_csharp_sha: 091c0ab4021145d4833989af364028040a44e5bed31b9764e45a2333adb9d8c7
+    - date: "2026-08-21"
+      by: myia-po-2025:CoursIA
+      python_sha: c05f3a321b5c2d817665ffd41ad2d27e0f5e8853
+      csharp_sha: 160675f58686100e1d03eecc047e34698ac4997a
+      content_python_sha: 4fa4cea784dc9195cdf19594c6c4d4fe1d9c4c03eedc9f146298c488c14dd6d9
+      content_csharp_sha: 091c0ab4021145d4833989af364028040a44e5bed31b9764e45a2333adb9d8c7
   known_differences:
     - "Socle commun : raisonnement automatique sur ontologies (forward-chaining, inference RDFS/OWL)."
     - "Lib-vs-lib : C# = `dotNetRDF` (`VDS.RDF.Query.Inference` : IInferenceEngine, OwlReasoner integre). Python = `rdflib` + `owlrl` (moteur de closure OWL-RL/RDFS). Deux approches du raisonnement : moteur natif cote C# vs closure deductive cote Python."
     - "Re-baseline 2026-07-25 (po-2024, consolidation #8264) : SHA Python avance depuis l'audit 2026-07-23 via #8343 (doc-honesty prose (benchmark speedup claim aligned to committed output)) ; drift verifie paraphite-preservant (ne touche pas l'axe de parite semantic)."
     - "Re-baseline 2026-07-31 (myia-po-2024:CoursIA-2, cycle c.1066) : SHA C# avance dfd74f20 -> 2bf10756 (cell[8] G.1 self-correction note : la decomposition '5 inferez = propagation des types + reflexivite des proprietes (enseigne ⊂ enseigne, suit ⊂ suit)' etait fausse -- cell[9] affiche 'Sous-proprietes inferez : 0', donc AUCUNE reflexivite de propriete n'est materialisee ; reformule en 'inferences de type/domain-range, 3 verifiees, 0 subPropertyOf'). Drift verifie parite-preserving : prose markdown seule, aucune cellule de code touchee (n'affecte pas l'axe de parite semantic)."
     - "Re-baseline 2026-08-06 (myia-po-2024:CoursIA-2, cycle c.1305 + #9670 rebaseline par ai-01 11:00Z) : SHA Python avance a5ef2be10 -> bee6f874b (c.1305 drainage arch. 6ᵉ machine-dep timing : 15 claims drainés via préfixe canonique `runtime *machine-dep*` sur 5 cellules denses cell[3]+cell[18]+cell[25]+cell[35]+cell[42] ; 1 CAS AUTEUR-CONSCIENT cell[50] disclaimer §D.5 verbatim préservé). C# SHA inchangee 160675f58 (jumeau C# pas drainé dans cette PR). Drift parite-preserving : prose pedagogique machine-dep marquee, aucune cellule de code touchée, parite semantic intacte."
+    - "Re-baseline 2026-08-21 (myia-po-2025:CoursIA, densite round 2 #11601 / PR #12129) : SHA Python avance 1eb456c6 -> c05f3a32 (content 5bc1f3a3 -> 4fa4cea7). Densification markdown-only 1286 -> 1650 c/cell : 21 appends sur cellules minces + 4 cellules 'Lecture de l'exemple' insérées après les outputs committés des exemples guidés 1/3/4/5, ancrées aux valeurs déterministes (8005 vs 939 triplets inférés, 304119 appels profiler, 7 -> 126). Audit firsthand : 31/31 code cells byte-identiques (ids préservés), 58/58 markdown originaux préfixe-exact, 0 output erreur, C# SHA inchangee 160675f58. Drift parité-preserving : prose pédagogique seule, aucune cellule de code touchée, axe de parité native-both (dotNetRDF vs rdflib) intact."


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/genai #12115

## Summary

Tranche densité **round 2** de l'EPIC #11601 (bande 1200–2000 c/cell → ≥1500) : `SW-13-Python-Reasoners.ipynb` passe de **1286 → 1650 c/cell** (39 874 → 51 166 chars de prose pour 31 cellules code), markdown-only (pattern #10488).

Deux gestes :
- **21 appends** sur cellules minces (< 200 chars) : contexte, transitions, indices de lecture — chaque original préservé en **préfixe exact** (vérifié 58/58 après normalisation whitespace).
- **4 cellules `### Lecture de l'exemple N`** insérées après les sorties committées des exemples guidés 1/3/4/5 (les exemples 2 et 6 avaient déjà leur lecture), **ancrées strictement aux outputs** : Pizza Ontology 1944 triplets / owlrl ~3 s / 8005 inférés vs reasonable ~0,04 s / 939 (~72x) ; profiler 304 119 appels, `OWLRL.py` ×820, `Closure.py` ; HermiT INCOHÉRENCE vs matérialisation RL silencieuse ; 7→126 (119 matérialisés), chaîne 10 éléments → 45 paires (9+8+…+1).

## Validation (relancée post-dernier-commit)

- `pedagogy_density.py` : 1 judged, 0 below floor (mesure exacte : 51166//31 = **1650**)
- Code cells **byte-identiques** à `HEAD` (31/31, comparaison source+id) → **C.3 exempt** (aucune cellule source modifiée → pas de re-exécution due), C.2 exception markdown-only
- Zéro-régression : 58/58 cellules markdown originales = préfixe exact d'une cellule nouvelle
- `nbformat.validate` OK (93 cellules : 89 + 4 lectures)
- `scan_cell_ordering.py` : 1 clean, 0 finding
- `check_interp_positioning.py` : 0 misplaced (les 5 `Lecture de l'exemple` suivent toutes une cellule code)
- C.1 : le seul match `grep` est un faux positif base64 PNG **préexistant sur HEAD** (vérifié), aucun introduit
- Convention #9434 préservée : durées citées `*runtime machine-dep* : ~3 s` / `~0,04 s` (ordre de grandeur), comptes déterministes (8005, 939, 304119, 820, 126, 45) cités directement
- LF endings, fichier terminé par `}\n`, ids uniques (8-hex), français accentué (pas de prose désoctroyée #2876)
- CSV `translations/semanticweb/semanticweb.csv` **non touché** (bot-owned, re-dérivé par `translation-sync.yml` post-merge)

See #11601 (tranche partielle : round 2, 1 notebook ; l'epic reste ouverte)
