### PR TITLE
feat(gt7,#11601): densite GT-7-ExtensiveForm-Csharp 1243 -> 1804 c/cell (markdown-only)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm-Csharp.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-7-ExtensiveForm-Csharp.ipynb
@@ -238,7 +238,15 @@
    "source": [
     "## 2. Exemple : jeu d'entree sur le marche\n",
     "\n",
-    "Le **jeu d'entree** canonique : un entrant (J1) decide d'entrer (`In`) ou de rester dehors (`Out`). S'il entre, l'incumbent (J2) decide de `Fight` (guerre des prix) ou `Accommodate` (coexistence). C'est un jeu **parfait information** (chacun voit tout)."
+    "Le **jeu d'entree** canonique : un entrant (J1) decide d'entrer (`In`) ou de rester dehors (`Out`). S'il entre, l'incumbent (J2) decide de `Fight` (guerre des prix) ou `Accommodate` (coexistence). C'est un jeu **parfait information** (chacun voit tout).\n",
+    "\n",
+    "L'exemple est canonique en économie industrielle : il condense le dilemme de la\n",
+    "menace crédible dans cinq nœuds. En lisant la sortie de la cellule suivante,\n",
+    "repérer les trois ingrédients qui feront tout le restant du notebook — la\n",
+    "chronologie (J1 décide d'abord), l'arbre (chaque branche mène à un sous-jeu),\n",
+    "et les payoffs terminaux qui disent si la menace de l'incumbent tient. C'est\n",
+    "sur ce même jeu que la conversion en forme normale (section 7) et l'exercice 3\n",
+    "(nœud de nature) reviendront.\n"
    ]
   },
   {
@@ -304,7 +312,14 @@
    "source": [
     "### Rendu ASCII de l'arbre\n",
     "\n",
-    "Le Python utilise `matplotlib` + `networkx` pour dessiner l'arbre. Nous le rendons en **ASCII** : un parcours récursif avec indentation par profondeur, qui marque les noeuds de nature (N), les infosets (~), et les payoffs terminaux."
+    "Le Python utilise `matplotlib` + `networkx` pour dessiner l'arbre. Nous le rendons en **ASCII** : un parcours récursif avec indentation par profondeur, qui marque les noeuds de nature (N), les infosets (~), et les payoffs terminaux.\n",
+    "\n",
+    "Ce rendu textuel a un avantage pédagogique sur le dessin : il est\n",
+    "**déterministe et diffable**. Deux exécutions produisent exactement les mêmes\n",
+    "caractères, ce qui permet de comparer deux modèles nœud par nœud — le test de\n",
+    "non-régression du jumeau s'appuie sur cette propriété. La profondeur\n",
+    "d'indentation code le niveau dans l'arbre, le marqueur `~` les infosets, et\n",
+    "l'étoile `*` les feuilles : la grammaire du rendu est celle du modèle.\n"
    ]
   },
   {
@@ -405,7 +420,15 @@
    "source": [
     "## 3. Stratégies dans les jeux extensifs\n",
     "\n",
-    "Une **stratégie pure** en forme extensive est un **plan d'action complet** : pour chaque ensemble d'information du joueur, quelle action jouer. Ce n'est pas \"une action\", c'est un plan contingents (une action PAR infoset). Le nombre de stratégies pures d'un joueur = produit du nombre d'actions sur chacun de ses infosets."
+    "Une **stratégie pure** en forme extensive est un **plan d'action complet** : pour chaque ensemble d'information du joueur, quelle action jouer. Ce n'est pas \"une action\", c'est un plan contingents (une action PAR infoset). Le nombre de stratégies pures d'un joueur = produit du nombre d'actions sur chacun de ses infosets.\n",
+    "\n",
+    "La sortie confirme le compte : 2 stratégies pour chaque joueur ici, parce que\n",
+    "chacun n'a qu'un seul infoset à deux actions. La règle générale est un\n",
+    "**produit** : un joueur avec deux infosets de 2 et 3 actions a 2×3 = 6 plans\n",
+    "purs. C'est le premier indice de l'explosion combinatoire — l'exercice 2\n",
+    "(Card Game) fait passer J1 de 1 à 2 infosets, et sa forme normale quadrille\n",
+    "déjà ; le paradoxe de Chain-Store (exercice 1) pousse jusqu'à la séquence\n",
+    "d'entrants où la conversion exhaustive devient déraisonnable.\n"
    ]
   },
   {
@@ -493,7 +516,14 @@
     "\n",
     "La différence cruciale : en **information parfaite**, chaque infoset est un singleton (le joueur sait exactement ou il est). En **information imparfaite**, un infoset regroupe plusieurs noeuds : le joueur sait qu'il est a l'un d'entre eux mais ne sait pas lequel.\n",
     "\n",
-    "Le jeu **mouvement simultane** (Matching Pennies en forme extensive) : J1 joue Pile/Face, puis J2 joue Pile/Face **sans voir** le coup de J1. Les deux noeuds de decision de J2 sont dans le **même infoset** `j2_choice`."
+    "Le jeu **mouvement simultane** (Matching Pennies en forme extensive) : J1 joue Pile/Face, puis J2 joue Pile/Face **sans voir** le coup de J1. Les deux noeuds de decision de J2 sont dans le **même infoset** `j2_choice`.\n",
+    "\n",
+    "Le test opérationnel est mécanique : compter les nœuds de chaque infoset.\n",
+    "Tout infoset singleton = information parfaite ; tout infoset de cardinal > 1\n",
+    "encode une ignorance. La sortie de la cellule suivante imprimera le compte —\n",
+    "2 infosets dont un de cardinal 2 — et c'est cette asymétrie de cardinal entre\n",
+    "`j1` (1) et `j2_choice` (2) qui distingue structurellement ce jeu d'un jeu\n",
+    "séquentiel à information parfaite comme celui de la section 2.\n"
    ]
   },
   {
@@ -576,6 +606,26 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b555991c",
+   "metadata": {},
+   "source": [
+    "### Lecture du Matching Pennies : l'infoset comme encodage\n",
+    "\n",
+    "La sortie compte **2 infosets** — `j1` singleton, `j2_choice` de cardinal 2 —\n",
+    "et c'est tout le jeu : la simultanéité n'est pas une propriété du calendrier\n",
+    "mais de la **structure d'information**. En forme normale (GT-2), Matching\n",
+    "Pennies se jouait « en même temps » par hypothèse ; ici la simultanéité est\n",
+    "**encodée** dans l'arbre séquentiel par la fusion des deux nœuds de J2 en un\n",
+    "seul infoset — J2 sait qu'il doit choisir, mais pas où il est dans l'arbre.\n",
+    "Les payoffs reproduisent la matrice originale : diagonale `(1,-1)` et\n",
+    "`(-1,1)`, anti-diagonale inversée — jeu à somme nulle sans équilibre pur,\n",
+    "exactement le Matching Pennies de la GT-2. Leçon de structure : deux\n",
+    "représentations du même jeu, et le pont formel entre elles sera vérifié par\n",
+    "la conversion de la section 7.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "83843ffc",
    "metadata": {
     "papermill": {
@@ -590,7 +640,15 @@
    "source": [
     "## 5. Jeux avec hasard : noeuds de nature\n",
     "\n",
-    "Quand le hasard est implique (tirage de carte, de), on ajoute des **noeuds de nature** (`player == 0`) avec des probabilites sur chaque branche. Le jeu de carte simple : la Nature tire High/Low (p=0.5), J1 voit la carte et Bet/Check, puis si Bet J2 Call/Fold **sans voir la carte** (infoset partage)."
+    "Quand le hasard est implique (tirage de carte, de), on ajoute des **noeuds de nature** (`player == 0`) avec des probabilites sur chaque branche. Le jeu de carte simple : la Nature tire High/Low (p=0.5), J1 voit la carte et Bet/Check, puis si Bet J2 Call/Fold **sans voir la carte** (infoset partage).\n",
+    "\n",
+    "Le nœud de nature est le seul du modèle avec `Player = 0` : il ne décide\n",
+    "rien, il tire. La sortie suivante montre la conséquence structurelle —\n",
+    "l'arbre gagne un étage sous la racine, et les payoffs se lisent désormais en\n",
+    "**espérance** : traverser le nœud de nature pondère chaque branche par sa\n",
+    "probabilité. Ce mécanisme est exactement celui qu'exploite\n",
+    "`ExpectedPayoff` (section 7) lors de la conversion, et celui de l'annexe où\n",
+    "OpenSpiel tire les cartes de Kuhn Poker.\n"
    ]
   },
   {
@@ -674,6 +732,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "5b977403",
+   "metadata": {},
+   "source": [
+    "### Lecture du Card Game : information incomplète vs imparfaite\n",
+    "\n",
+    "La sortie fait coexister les trois natures de nœuds du modèle — `NATURE`\n",
+    "(tirage High/Low à p=0,5 chacune), nœuds de décision, feuilles `*` — et le\n",
+    "résumé des infosets porte la distinction conceptuelle de la section : J1 a\n",
+    "**deux infosets séparés** (`j1_H`, `j1_L`) parce qu'il voit sa carte, J2 en a\n",
+    "**un seul** (`j2_bet`) qui regroupe ses deux nœuds parce qu'il ne la voit\n",
+    "pas. C'est l'information **incomplète** au sens de Harsanyi : l'asymétrie de\n",
+    " savoir sur l'état tiré par la Nature. Les payoffs le reflètent — si J1 a\n",
+    "High et mise, `Call` perd 2 pour J2 ; s'il a Low, `Call` gagne 2 — de sorte\n",
+    "que la décision de J2 doit se faire en **espérance** sur la carte. Ce jeu est\n",
+    "la brique exacte du Kuhn Poker de l'annexe, qui généralise à trois cartes.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "00edfca3",
    "metadata": {
     "papermill": {
@@ -711,7 +788,15 @@
    "source": [
     "## 7. Conversion forme extensive -> forme normale\n",
     "\n",
-    "Tout jeu extensif peut etre converti en jeu **normal** (matrice de gains) : on enumere les stratégies pures de chaque joueur (plans contingents, section 3), puis pour chaque couple (s1, s2) on calcule le payoff espere en traversant l'arbre (les noeuds de nature etant ponderes par leurs probabilites). La matrice résultat est exactement le jeu normal equivalent."
+    "Tout jeu extensif peut etre converti en jeu **normal** (matrice de gains) : on enumere les stratégies pures de chaque joueur (plans contingents, section 3), puis pour chaque couple (s1, s2) on calcule le payoff espere en traversant l'arbre (les noeuds de nature etant ponderes par leurs probabilites). La matrice résultat est exactement le jeu normal equivalent.\n",
+    "\n",
+    "L'équivalence a un prix : la taille. La matrice croît comme le **produit des\n",
+    "stratégies pures** des deux joueurs — quadratique sur les petits jeux de ce\n",
+    "notebook, ingérable sur un jeu comme le Chain-Store multi-entrants. C'est ce\n",
+    "qui motive les deux représentations : la forme extensive pour **calculer**\n",
+    "(l'induction arrière ne visite chaque nœud qu'une fois), la forme normale pour\n",
+    "**raisonner** (outils de la GT-2 : dominances, équilibres mixtes). La cellule\n",
+    "suivante exécute la conversion sur les deux premiers jeux du notebook.\n"
    ]
   },
   {
@@ -899,7 +984,15 @@
    "source": [
     "## 9. Exercices\n",
     "\n",
-    "> **Convention** : stubs a completer (`null` + `// TODO etudiant`), jamais d'erreur volontaire — le notebook s'execute de bout en bout même non complete."
+    "> **Convention** : stubs a completer (`null` + `// TODO etudiant`), jamais d'erreur volontaire — le notebook s'execute de bout en bout même non complete.\n",
+    "\n",
+    "Les trois exercices sont ordonnés par difficulté croissante sur le même\n",
+    "socle : l'exercice 1 (Chain-Store) entraîne la **construction d'arbre** avec\n",
+    "observation séquentielle, l'exercice 2 (conversion du Card Game) réutilise le\n",
+    "mécanisme de la section 7 sur un jeu à information incomplète, l'exercice 3\n",
+    "(nœud de nature) modifie le jeu le plus simple pour y injecter du hasard\n",
+    "caché. Les squelettes sont auto-exécutables — incomplets, ils affichent la\n",
+    "consigne sans interrompre la chaîne.\n"
    ]
   },
   {
@@ -1311,6 +1404,29 @@
     "    Console.WriteLine((string)scope.report);\n",
     "}\n",
     "Console.WriteLine(\"PONT .NET -> pyspiel : OK -- le moteur de reference OpenSpiel confirme la structure extensive (infosets) du from-scratch et converge vers la valeur theorique de Kuhn (-1/18) via CFR\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f537fb9a",
+   "metadata": {},
+   "source": [
+    "### Lecture du pont OpenSpiel : CFR converge vers la valeur de Kuhn\n",
+    "\n",
+    "La sortie du pont est une **contre-épreuve chiffrée** du modèle from-scratch :\n",
+    "OpenSpiel confirme les attributs structurels (`Dynamics.SEQUENTIAL`,\n",
+    "`Information.IMPERFECT_INFORMATION`, `Utility.ZERO_SUM` — les trois propriétés\n",
+    "construites à la main dans les sections 2 à 6), puis le solveur parle. Après\n",
+    "**30 itérations** de Counterfactual Regret Minimization, la mesure\n",
+    "`NashConv` tombe à **0,0230** — l'écart exploitables à l'équilibre, proche de\n",
+    "zéro — et la valeur du jeu pour P0 vaut **-0,0571**, à comparer à la valeur\n",
+    "théorique de Kuhn (1950) : **-1/18 ≈ -0,0556**. L'écart résiduel (~0,0015)\n",
+    "est le coût des 30 itérations : CFR converge vers l'équilibre sans l'atteindre\n",
+    "en temps fini. Le signe négatif est structurel — le premier joueur de Kuhn\n",
+    "Poker est désavantagé, et c'est le même désavantage de premier-mouvant que le\n",
+    "jeu d'entree inversait en faveur de l'entrant informé. Le pont PythonNet fait\n",
+    "donc deux travaux : il invalide le verdict `INTRINSIC` hérité (l'axe 5 de\n",
+    "#10459) et il ancre le modèle pédagogique sur un moteur de référence.\n"
    ]
   }
  ],

--- a/scripts/notebook_tools/twin_pairs.d/gametheory-7-extensiveform.yaml
+++ b/scripts/notebook_tools/twin_pairs.d/gametheory-7-extensiveform.yaml
@@ -41,6 +41,12 @@
       csharp_sha: 812dd6be7131ebea762623175ba2be28ab0be97e
       content_python_sha: 8a9f706352a7b1b8dec1f1271d1f7f7d5c3d6659b9ee576f836702c9c23c73da
       content_csharp_sha: be9618e59547ca6cd326c06031ffa5e36cb7f9e0aadd1505289b29d8662e5b27
+    - date: "2026-08-21"
+      by: myia-po-2025:CoursIA
+      python_sha: 3759a8e1de531d7fbf4a1e43057ef42ac7efaf89
+      csharp_sha: 283b71425b2c5d6b7e4f2937935f9e7ecba3613f
+      content_python_sha: 8a9f706352a7b1b8dec1f1271d1f7f7d5c3d6659b9ee576f836702c9c23c73da
+      content_csharp_sha: 9b22f5f0c8c7b44eb415487cc61f681e5d6f95d304ae345c4b082213dbc9489b
   known_differences:
     - "Socle pedagogique commun : jeux sous forme extensive (arbre de jeu sequentiel avec noeuds de decision/terminal/chance + infosets), backward induction (induction en arriere) pour calculer les SPE (Subgame Perfect Equilibria), exemple canonique du jeu d'entree sur le marche (entrant vs incumbente)."
     - "Idiomes framework : Python = `@dataclass` + `networkx` (graphe arborescent + rendu matplotlib des arbres de jeu) + implementation manuelle de `backward_induction` + `ConvertToNormal` (reduction extensive-vers-normal) + section 6 OpenSpiel (`pyspiel.load_game('kuhn_poker')`, simulation + exploration d'arbre). C# = sections 1-7 en **BCL .NET pur 0 NuGet** (modele `GameNode` decision/terminal/chance + `ExtensiveFormGame` from-scratch) + **rendu ASCII de l'arbre** (pas de viz graphique, fidele a la contrainte 0-NuGet de la serie) + **annexe pont PythonNet** vers pyspiel (la section 6 conceptuelle rendue effective, reclassification RECOVERABLE-LOCAL)."


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2025:CoursIA — prev: MED/notebook-python #12129

## Summary

Tranche densité **round 2** de l'EPIC #11601 (bande 1200–2000 c/cell → ≥1500) : `GameTheory-7-ExtensiveForm-Csharp.ipynb` passe de **1243 → 1804 c/cell** (13 673 → 19 851 chars de prose pour 11 cellules code), markdown-only (pattern #10488).

Deux gestes :
- **7 appends** sur cellules minces (contexte économie industrielle, diffabilité du rendu ASCII, règle du produit des stratégies pures, test de cardinal des infosets, espérance aux nœuds de nature, prix de l'équivalence extensive↔normale, mapping exercices↔sections) — chaque original préservé en **préfixe exact** (vérifié 18/18 après normalisation whitespace).
- **3 cellules `### Lecture du …`** insérées après les sorties committées des cellules 11/13/28, ancrées strictement aux outputs : Matching Pennies (**2 infosets**, `j2_choice` cardinal 2, matrice diagonale `(1,-1)`), Card Game (`j1_H`/`j1_L` séparés vs `j2_bet` fusionné — information incomplète au sens de Harsanyi), pont OpenSpiel (**CFR 30 itérations, NashConv 0,0230, valeur -0,0571** vs théorie Kuhn **-1/18 ≈ -0,0556**, écart résiduel ~0,0015 = coût des itérations finies).

**Registre twin #8057** : append d'audit `GameTheory-7 ExtensiveForm` dans la même PR (`--update --pair` post-commit ; twin Python SHA inchangé, C# rebaseliné) — `check_twin_parity --check` : **157/157 OK, 0 DRIFT**.

## Validation (relancée post-dernier-commit)

- `pedagogy_density.py` : 1 judged, 0 below floor (mesure exacte : 19851//11 = **1804**)
- Code cells **byte-identiques** à `HEAD` (11/11, source+id) → **C.3 exempt** (aucune cellule code source modifiée), C.2 exception markdown-only
- Zéro-régression : 18/18 cellules markdown originales = préfixe exact d'une cellule nouvelle
- `nbformat.validate` OK (32 cellules : 29 + 3 lectures) ; ids uniques
- `scan_cell_ordering.py` : 1 clean, 0 finding · `check_interp_positioning.py` : 0 misplaced (les 3 Lectures suivent chacune une cellule code)
- C.1 : 0 match `raise NotImplementedError|assert False|1/0`
- Fins de ligne LF, fichier terminé `}\n` ; prose française accentuée ; comptes/valeurs cités = sorties committées déterministes (CFR 30 iter, NashConv, -1/18) — aucune durée machine-dép en prose
- CSV de traduction non touché (bot-owned)

See #11601 (tranche partielle : round 2, 1 notebook ; l'epic reste ouverte — 214 notebooks dans la bande)
