### PR TITLE
fix(genai,#12128): tranche B heading_in_list — 171 remedes GenAI Image+Video + 9 separateurs hr

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-1-Qwen-Image-Edit-2509.ipynb
@@ -1028,11 +1028,11 @@
     "**Objectif** : Reprendre l'image de base du coffee shop et lui appliquer 3 styles artistiques différents en utilisant `create_img2img_workflow()` avec un `denoise` de 0.6.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Verifier que l'image de base est uploadee (variable `uploaded_name`)\n",
-    "- # Étape 2 : Définir 3 prompts d'edition avec des styles différents (impressionniste, anime, hyperrealiste)\n",
-    "- # Étape 3 : Utiliser `create_img2img_workflow(image_name=uploaded_name, prompt=..., denoise=0.6)`\n",
-    "- # Étape 4 : Executer chaque workflow et afficher les 3 résultats cote a cote\n",
-    "- # Indice : Avec `denoise=0.6`, le modèle preserve environ 40% de l'image originale. L'output_node pour img2img est \"12\"."
+    "- `# Étape 1` : Verifier que l'image de base est uploadee (variable `uploaded_name`)\n",
+    "- `# Étape 2` : Définir 3 prompts d'edition avec des styles différents (impressionniste, anime, hyperrealiste)\n",
+    "- `# Étape 3` : Utiliser `create_img2img_workflow(image_name=uploaded_name, prompt=..., denoise=0.6)`\n",
+    "- `# Étape 4` : Executer chaque workflow et afficher les 3 résultats cote a cote\n",
+    "- `# Indice` : Avec `denoise=0.6`, le modèle preserve environ 40% de l'image originale. L'output_node pour img2img est \"12\"."
    ]
   },
   {
@@ -1574,11 +1574,11 @@
     "**Objectif** : Créer un masque circulaire au centre de l'image de base et remplacer cette zone par un personnage ou un objet de votre choix.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Utiliser `create_circular_mask()` pour generer un masque circulaire (centre de l'image, rayon adapte)\n",
-    "- # Étape 2 : Uploader le masque avec `client.upload_mask()`\n",
-    "- # Étape 3 : Construire le workflow avec `create_inpaint_workflow()` en decrivant le nouvel élément\n",
-    "- # Étape 4 : Utiliser `denoise=0.9` pour un remplacement complet de la zone masquee\n",
-    "- # Indice : Le masque blanc définit la zone a modifier, le noir la zone a preserver. Le paramètre `feather` adoucit les bords pour une transition naturelle."
+    "- `# Étape 1` : Utiliser `create_circular_mask()` pour generer un masque circulaire (centre de l'image, rayon adapte)\n",
+    "- `# Étape 2` : Uploader le masque avec `client.upload_mask()`\n",
+    "- `# Étape 3` : Construire le workflow avec `create_inpaint_workflow()` en decrivant le nouvel élément\n",
+    "- `# Étape 4` : Utiliser `denoise=0.9` pour un remplacement complet de la zone masquee\n",
+    "- `# Indice` : Le masque blanc définit la zone a modifier, le noir la zone a preserver. Le paramètre `feather` adoucit les bords pour une transition naturelle."
    ]
   },
   {
@@ -2097,11 +2097,11 @@
     "**Objectif** : Modifier le workflow pour tester 3 combinaisons scheduler/sampler différentes et comparer les résultats sur un même prompt.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer un workflow avec `create_text2img_workflow()` et un prompt detaille\n",
-    "- # Étape 2 : Modifier le node KSampler (node \"9\") pour changer `scheduler` et `sampler_name`\n",
-    "- # Étape 3 : Tester : (a) `beta`/`euler` (defaut), (b) `normal`/`euler_ancestral`, (c) `karras`/`dpmpp_2m`\n",
-    "- # Étape 4 : Executer chaque variante et comparer la nettete, les couleurs et le temps de generation\n",
-    "- # Indice : Accedez au workflow comme un dictionnaire Python : `workflow[\"9\"][\"inputs\"][\"scheduler\"] = \"normal\"`"
+    "- `# Étape 1` : Créer un workflow avec `create_text2img_workflow()` et un prompt detaille\n",
+    "- `# Étape 2` : Modifier le node KSampler (node \"9\") pour changer `scheduler` et `sampler_name`\n",
+    "- `# Étape 3` : Tester : (a) `beta`/`euler` (defaut), (b) `normal`/`euler_ancestral`, (c) `karras`/`dpmpp_2m`\n",
+    "- `# Étape 4` : Executer chaque variante et comparer la nettete, les couleurs et le temps de generation\n",
+    "- `# Indice` : Accedez au workflow comme un dictionnaire Python : `workflow[\"9\"][\"inputs\"][\"scheduler\"] = \"normal\"`"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-2-FLUX-1-Advanced-Generation.ipynb
@@ -928,11 +928,11 @@
     "**Objectif** : Generer une même image avec 3 nombres de steps différents (1, 2, 4) et documenter les différences observees.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Choisir un prompt avec des details fins (textures, reflets, texte)\n",
-    "- # Étape 2 : Generer avec `flux.generate(num_inference_steps=1)`, puis `steps=2`, puis `steps=4`\n",
-    "- # Étape 3 : Afficher les 3 images cote a cote avec `plt.subplots(1, 3)`\n",
-    "- # Étape 4 : Noter pour chaque image le temps de generation et la qualite percue\n",
-    "- # Indice : Avec FLUX.1-schnell, `guidance_scale=0.0` (pas de guidance) est la valeur recommandee"
+    "- `# Étape 1` : Choisir un prompt avec des details fins (textures, reflets, texte)\n",
+    "- `# Étape 2` : Generer avec `flux.generate(num_inference_steps=1)`, puis `steps=2`, puis `steps=4`\n",
+    "- `# Étape 3` : Afficher les 3 images cote a cote avec `plt.subplots(1, 3)`\n",
+    "- `# Étape 4` : Noter pour chaque image le temps de generation et la qualite percue\n",
+    "- `# Indice` : Avec FLUX.1-schnell, `guidance_scale=0.0` (pas de guidance) est la valeur recommandee"
    ]
   },
   {
@@ -1665,11 +1665,11 @@
     "**Objectif** : Generer 6 variations d'un même prompt en changeant uniquement la seed, puis sélectionner la meilleure selon des critères objectifs.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un prompt creatif detaille\n",
-    "- # Étape 2 : Generer 6 images avec des seeds différentes (ex: 100, 200, 300, 400, 500, 600)\n",
-    "- # Étape 3 : Afficher les 6 images dans une grille 2x3\n",
-    "- # Étape 4 : Sélectionner la meilleure selon 3 critères : fidelite au prompt, qualite des details, coherence globale\n",
-    "- # Indice : Avec FLUX.1-schnell, chaque generation prend seulement 4 steps, donc 6 variations restent rapides"
+    "- `# Étape 1` : Définir un prompt creatif detaille\n",
+    "- `# Étape 2` : Generer 6 images avec des seeds différentes (ex: 100, 200, 300, 400, 500, 600)\n",
+    "- `# Étape 3` : Afficher les 6 images dans une grille 2x3\n",
+    "- `# Étape 4` : Sélectionner la meilleure selon 3 critères : fidelite au prompt, qualite des details, coherence globale\n",
+    "- `# Indice` : Avec FLUX.1-schnell, chaque generation prend seulement 4 steps, donc 6 variations restent rapides"
    ]
   },
   {
@@ -2191,11 +2191,11 @@
     "**Objectif** : Créer une affiche contenant un message personnalise en exploitant les capacites de rendu textuel de FLUX.1.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Choisir un type de visuel (affiche de film, couverture de livre, pancarte)\n",
-    "- # Étape 2 : Construire le prompt en encadrant le texte a generer avec des guillemets\n",
-    "- # Étape 3 : Preciser le style visuel (ex: \"vintage poster\", \"modern minimalist\")\n",
-    "- # Étape 4 : Generer avec `flux.generate(num_inference_steps=4, seed=42)`\n",
-    "- # Indice : FLUX.1 gere mieux les textes courts (2-5 mots). Evitez les phrases trop longues."
+    "- `# Étape 1` : Choisir un type de visuel (affiche de film, couverture de livre, pancarte)\n",
+    "- `# Étape 2` : Construire le prompt en encadrant le texte a generer avec des guillemets\n",
+    "- `# Étape 3` : Preciser le style visuel (ex: \"vintage poster\", \"modern minimalist\")\n",
+    "- `# Étape 4` : Generer avec `flux.generate(num_inference_steps=4, seed=42)`\n",
+    "- `# Indice` : FLUX.1 gere mieux les textes courts (2-5 mots). Evitez les phrases trop longues."
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-3-Stable-Diffusion-3-5.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-3-Stable-Diffusion-3-5.ipynb
@@ -885,10 +885,10 @@
     "**Objectif** : Generer un portrait avec le style \"Oil Painting\" en testant 3 valeurs de CFG (3.0, 5.0, 7.0) pour trouver le rendu optimal.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un prompt de portrait avec le style huile (ex: \"Portrait of a wise elderly man, oil painting style, Rembrandt lighting\")\n",
-    "- # Étape 2 : Boucler sur les valeurs CFG [3.0, 5.0, 7.0]\n",
-    "- # Étape 3 : Appeler `sd35.generate(prompt=..., guidance_scale=cfg, seed=42)` pour chaque valeur\n",
-    "- # Indice : Un CFG bas (3.0) donnera un style plus libre, un CFG haut (7.0) suivra le prompt plus fidelement"
+    "- `# Étape 1` : Définir un prompt de portrait avec le style huile (ex: \"Portrait of a wise elderly man, oil painting style, Rembrandt lighting\")\n",
+    "- `# Étape 2` : Boucler sur les valeurs CFG [3.0, 5.0, 7.0]\n",
+    "- `# Étape 3` : Appeler `sd35.generate(prompt=..., guidance_scale=cfg, seed=42)` pour chaque valeur\n",
+    "- `# Indice` : Un CFG bas (3.0) donnera un style plus libre, un CFG haut (7.0) suivra le prompt plus fidelement"
    ]
   },
   {
@@ -1384,10 +1384,10 @@
     "**Objectif** : Generer la même scene en 3 ratios d'aspect différents (1:1, 16:9, 9:16) et analyser comment la composition change.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un prompt contenant des éléments horizontaux et verticaux (ex: un personnage dans un paysage)\n",
-    "- # Étape 2 : Calculer les dimensions : 1024x1024 (1:1), 1344x768 (16:9), 768x1344 (9:16)\n",
-    "- # Étape 3 : Generer avec `sd35.generate(width=..., height=...)` en gardant le même seed\n",
-    "- # Indice : Les dimensions doivent etre des multiples de 8 pour etre compatibles avec le VAE"
+    "- `# Étape 1` : Définir un prompt contenant des éléments horizontaux et verticaux (ex: un personnage dans un paysage)\n",
+    "- `# Étape 2` : Calculer les dimensions : 1024x1024 (1:1), 1344x768 (16:9), 768x1344 (9:16)\n",
+    "- `# Étape 3` : Generer avec `sd35.generate(width=..., height=...)` en gardant le même seed\n",
+    "- `# Indice` : Les dimensions doivent etre des multiples de 8 pour etre compatibles avec le VAE"
    ]
   },
   {
@@ -1813,10 +1813,10 @@
     "**Objectif** : Generer 3 images avec le même prompt positif mais des negative prompts différents, puis comparer la qualite resultante.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Choisir un prompt detaille (ex: portrait ou paysage complexe)\n",
-    "- # Étape 2 : Définir 3 negative prompts de complexite croissante : (a) chaîne vide, (b) \"blurry, low quality\", (c) \"blurry, low quality, distorted, deformed, ugly, watermark\"\n",
-    "- # Étape 3 : Generer avec `sd35.generate()` en fixant le même `seed` pour chaque variation\n",
-    "- # Indice : Observez comment le negative prompt elimine progressivement les artefacts indesirables"
+    "- `# Étape 1` : Choisir un prompt detaille (ex: portrait ou paysage complexe)\n",
+    "- `# Étape 2` : Définir 3 negative prompts de complexite croissante : (a) chaîne vide, (b) \"blurry, low quality\", (c) \"blurry, low quality, distorted, deformed, ugly, watermark\"\n",
+    "- `# Étape 3` : Generer avec `sd35.generate()` en fixant le même `seed` pour chaque variation\n",
+    "- `# Indice` : Observez comment le negative prompt elimine progressivement les artefacts indesirables"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-4-Z-Image-Lumina2.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/02-Advanced/02-4-Z-Image-Lumina2.ipynb
@@ -320,7 +320,20 @@
   {
    "cell_type": "markdown",
    "id": "688517cc",
-   "source": "### Exercice 1 : Workflow personnalise avec paramètres avances\n\nLa fonction `create_zimage_workflow()` accepte des paramètres avances comme `scaling_watershed` et `proportional_attn`. Ces paramètres influencent la saturation et la coherence spatiale de l'image generee.\n\n**Objectif** : Créer un workflow personnalise en modifiant les paramètres avances de `create_zimage_workflow()` et observer l'impact sur le rendu final.\n\n**Indices** :\n- # Étape 1 : Generer une image de reference avec les paramètres par defaut (`scaling_watershed=0.3`, `proportional_attn=True`)\n- # Étape 2 : Generer une seconde image avec `scaling_watershed=0.0` (desaturation desactivee)\n- # Étape 3 : Generer une troisieme image avec `proportional_attn=False`\n- # Étape 4 : Comparer les 3 résultats pour identifier l'impact de chaque paramètre\n- # Indice : Modifiez directement les valeurs dans le dictionnaire retourne par `create_zimage_workflow()` ou créez votre propre fonction",
+   "source": [
+    "### Exercice 1 : Workflow personnalise avec paramètres avances\n",
+    "\n",
+    "La fonction `create_zimage_workflow()` accepte des paramètres avances comme `scaling_watershed` et `proportional_attn`. Ces paramètres influencent la saturation et la coherence spatiale de l'image generee.\n",
+    "\n",
+    "**Objectif** : Créer un workflow personnalise en modifiant les paramètres avances de `create_zimage_workflow()` et observer l'impact sur le rendu final.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Generer une image de reference avec les paramètres par defaut (`scaling_watershed=0.3`, `proportional_attn=True`)\n",
+    "- `# Étape 2` : Generer une seconde image avec `scaling_watershed=0.0` (desaturation desactivee)\n",
+    "- `# Étape 3` : Generer une troisieme image avec `proportional_attn=False`\n",
+    "- `# Étape 4` : Comparer les 3 résultats pour identifier l'impact de chaque paramètre\n",
+    "- `# Indice` : Modifiez directement les valeurs dans le dictionnaire retourne par `create_zimage_workflow()` ou créez votre propre fonction"
+   ],
    "metadata": {}
   },
   {
@@ -478,7 +491,20 @@
   {
    "cell_type": "markdown",
    "id": "db48c8cd",
-   "source": "### Exercice 2 : Comparaison de styles par prompt engineering\n\nLe même sujet peut etre interprete dans des styles visuels très différents selon le prompt. Z-Image (Lumina) repond bien aux mots-cles de style (photorealistic, watercolor, anime, etc.).\n\n**Objectif** : Generer 4 images du même sujet dans des styles différents et afficher une grille comparative.\n\n**Indices** :\n- # Étape 1 : Choisir un sujet neutre (ex: \"a ancient tree in a mystical forest\")\n- # Étape 2 : Créer 4 prompts en ajoutant des suffixes de style différents\n- # Étape 3 : Appeler `generate_z_image()` pour chaque prompt avec le même seed\n- # Étape 4 : Afficher les 4 résultats dans une grille 2x2 avec `plt.subplots(2, 2)`\n- # Indice : Utilisez `guidance=4.0` et `steps=20` pour un bon compromis qualite/vitesse",
+   "source": [
+    "### Exercice 2 : Comparaison de styles par prompt engineering\n",
+    "\n",
+    "Le même sujet peut etre interprete dans des styles visuels très différents selon le prompt. Z-Image (Lumina) repond bien aux mots-cles de style (photorealistic, watercolor, anime, etc.).\n",
+    "\n",
+    "**Objectif** : Generer 4 images du même sujet dans des styles différents et afficher une grille comparative.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Choisir un sujet neutre (ex: \"a ancient tree in a mystical forest\")\n",
+    "- `# Étape 2` : Créer 4 prompts en ajoutant des suffixes de style différents\n",
+    "- `# Étape 3` : Appeler `generate_z_image()` pour chaque prompt avec le même seed\n",
+    "- `# Étape 4` : Afficher les 4 résultats dans une grille 2x2 avec `plt.subplots(2, 2)`\n",
+    "- `# Indice` : Utilisez `guidance=4.0` et `steps=20` pour un bon compromis qualite/vitesse"
+   ],
    "metadata": {}
   },
   {
@@ -611,7 +637,19 @@
   {
    "cell_type": "markdown",
    "id": "d84fc48e",
-   "source": "### Exercice 3 : Exploration du paramètre guidance\n\nLe paramètre `guidance` contrôle l'adherence du modèle au prompt textuel. Une valeur basse (2.0) permet plus de liberte creative, tandis qu'une valeur haute (6.0) suit le prompt plus fidelement mais peut sur-saturer les couleurs.\n\n**Objectif** : Generer une image avec 3 valeurs de guidance différentes (2.0, 4.0, 6.0) et observer l'impact sur la fidelite au prompt et la qualite visuelle.\n\n**Indices** :\n- # Étape 1 : Choisir un prompt descriptif riche (ex: scene naturelle avec details)\n- # Étape 2 : Appeler `generate_z_image()` avec le même seed mais différentes valeurs de guidance\n- # Étape 3 : Afficher les 3 résultats cote a cote avec `plt.subplots` pour comparer\n- # Indice : Utilisez `seed=42` fixe pour isoler l'effet du guidance",
+   "source": [
+    "### Exercice 3 : Exploration du paramètre guidance\n",
+    "\n",
+    "Le paramètre `guidance` contrôle l'adherence du modèle au prompt textuel. Une valeur basse (2.0) permet plus de liberte creative, tandis qu'une valeur haute (6.0) suit le prompt plus fidelement mais peut sur-saturer les couleurs.\n",
+    "\n",
+    "**Objectif** : Generer une image avec 3 valeurs de guidance différentes (2.0, 4.0, 6.0) et observer l'impact sur la fidelite au prompt et la qualite visuelle.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Choisir un prompt descriptif riche (ex: scene naturelle avec details)\n",
+    "- `# Étape 2` : Appeler `generate_z_image()` avec le même seed mais différentes valeurs de guidance\n",
+    "- `# Étape 3` : Afficher les 3 résultats cote a cote avec `plt.subplots` pour comparer\n",
+    "- `# Indice` : Utilisez `seed=42` fixe pour isoler l'effet du guidance"
+   ],
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-1-Multi-Model-Comparison.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-1-Multi-Model-Comparison.ipynb
@@ -291,7 +291,28 @@
   {
    "cell_type": "markdown",
    "id": "9f0e0e49",
-   "source": "---\n\n## Exercice : Client API unifie avec gestion d'erreur avancee\n\n**Duree estimee :** 15-20 minutes\n\n### Objectif\nCréer un client unifie `ImageGenerator` qui encapsule les appels a Forge et ComfyUI avec une interface commune, incluant retry, timeout et fallback entre services.\n\n### Instructions\n1. Créer une classe `ImageGenerator` avec une méthode `generate(prompt, model, **kwargs)` unifiee\n2. Implementer le retry avec backoff exponentiel en cas d'indisponibilite d'un service\n3. Ajouter un mécanisme de fallback : si Forge echoue, essayer ComfyUI (et inversement)\n4. Logger chaque tentative (succes/echec, latence) dans un historique\n\n### Indices\n- # Étape 1 : La classe encapsule les deux fonctions `generate_forge` et `generate_z_image` existantes\n- # Étape 2 : Pour le retry, utiliser une boucle avec `time.sleep(2 ** attempt)` (backoff exponentiel)\n- # Indice : Le fallback consiste a essayer l'autre service si le premier retourne None\n- # Indice : Garder un attribut `self.history = []` et y append un dict a chaque tentative",
+   "source": [
+    "***\n",
+    "\n",
+    "## Exercice : Client API unifie avec gestion d'erreur avancee\n",
+    "\n",
+    "**Duree estimee :** 15-20 minutes\n",
+    "\n",
+    "### Objectif\n",
+    "Créer un client unifie `ImageGenerator` qui encapsule les appels a Forge et ComfyUI avec une interface commune, incluant retry, timeout et fallback entre services.\n",
+    "\n",
+    "### Instructions\n",
+    "1. Créer une classe `ImageGenerator` avec une méthode `generate(prompt, model, **kwargs)` unifiee\n",
+    "2. Implementer le retry avec backoff exponentiel en cas d'indisponibilite d'un service\n",
+    "3. Ajouter un mécanisme de fallback : si Forge echoue, essayer ComfyUI (et inversement)\n",
+    "4. Logger chaque tentative (succes/echec, latence) dans un historique\n",
+    "\n",
+    "### Indices\n",
+    "- `# Étape 1` : La classe encapsule les deux fonctions `generate_forge` et `generate_z_image` existantes\n",
+    "- `# Étape 2` : Pour le retry, utiliser une boucle avec `time.sleep(2 ** attempt)` (backoff exponentiel)\n",
+    "- `# Indice` : Le fallback consiste a essayer l'autre service si le premier retourne None\n",
+    "- `# Indice` : Garder un attribut `self.history = []` et y append un dict a chaque tentative"
+   ],
    "metadata": {}
   },
   {
@@ -427,7 +448,7 @@
    "cell_type": "markdown",
    "id": "e48e8f7d",
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Explorer l'impact des paramètres de generation\n",
     "\n",
@@ -446,10 +467,10 @@
     "4. Presenter les résultats dans un tableau avec une analyse des compromis\n",
     "\n",
     "### Indices\n",
-    "- # Étape 1 : Fixer le seed pour que les variations proviennent uniquement du paramètre change\n",
-    "- # Étape 2 : Utiliser `time.time()` pour mesurer le temps de chaque generation\n",
-    "- # Indice : Plus de steps = meilleure qualite mais plus lent (loi logarithmique)\n",
-    "- # Indice : CFG trop eleve = images saturees/bruitees, CFG trop bas = images floues"
+    "- `# Étape 1` : Fixer le seed pour que les variations proviennent uniquement du paramètre change\n",
+    "- `# Étape 2` : Utiliser `time.time()` pour mesurer le temps de chaque generation\n",
+    "- `# Indice` : Plus de steps = meilleure qualite mais plus lent (loi logarithmique)\n",
+    "- `# Indice` : CFG trop eleve = images saturees/bruitees, CFG trop bas = images floues"
    ],
    "metadata": {}
   },
@@ -483,7 +504,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Benchmark de Performance Multi-Modèles\n",
     "\n",

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb
@@ -1139,7 +1139,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Pipeline personnel avec sélection du meilleur style\n",
     "\n",
@@ -1156,10 +1156,10 @@
     "5. Afficher les 3 versions stylisees et le gagnant\n",
     "\n",
     "### Indices\n",
-    "- # Étape 1 : Créer un premier orchestrateur pour la generation initiale\n",
-    "- # Étape 2 : Créer un second orchestrateur pour les 3 styles en parallele\n",
-    "- # Étape 3 : Comparer les `quality_score` de chaque résultat\n",
-    "- # Indice : Les fonctions `apply_style_transfer` et `evaluate_quality` sont déjà définies dans le notebook"
+    "- `# Étape 1` : Créer un premier orchestrateur pour la generation initiale\n",
+    "- `# Étape 2` : Créer un second orchestrateur pour les 3 styles en parallele\n",
+    "- `# Étape 3` : Comparer les `quality_score` de chaque résultat\n",
+    "- `# Indice` : Les fonctions `apply_style_transfer` et `evaluate_quality` sont déjà définies dans le notebook"
    ]
   },
   {
@@ -1443,7 +1443,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Retry intelligent avec paramètres adaptatifs\n",
     "\n",
@@ -1459,10 +1459,10 @@
     "4. Visualiser l'evolution des scores avec matplotlib\n",
     "\n",
     "### Indices\n",
-    "- # Étape 1 : Commencer par copier la structure de `ConditionalPipeline`\n",
-    "- # Étape 2 : Ajouter une méthode `_enhance_prompt(prompt, attempt)` qui ajoute des qualificateurs\n",
-    "- # Etice : \"ultra detailed, masterpiece, best quality\" sont des mots-cles efficaces pour ameliorer le prompt\n",
-    "- # Indice : Changer le seed a chaque tentative pour explorer différentes generations"
+    "- `# Étape 1` : Commencer par copier la structure de `ConditionalPipeline`\n",
+    "- `# Étape 2` : Ajouter une méthode `_enhance_prompt(prompt, attempt)` qui ajoute des qualificateurs\n",
+    "- `# Indice` : \"ultra detailed, masterpiece, best quality\" sont des mots-cles efficaces pour ameliorer le prompt\n",
+    "- `# Indice` : Changer le seed a chaque tentative pour explorer différentes generations"
    ]
   },
   {
@@ -1758,7 +1758,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Tableau de bord de metriques d'orchestration\n",
     "\n",
@@ -1774,10 +1774,10 @@
     "4. Tester avec plusieurs exécutions paralleles et séquentielles\n",
     "\n",
     "### Indices\n",
-    "- # Étape 1 : Stocker les résultats dans un dictionnaire indexe par nom de workflow\n",
-    "- # Étape 2 : Pour `compare_models`, extraire les durees et statuts depuis les `TaskResult`\n",
-    "- # Indice : Utiliser `orchestrator.results` pour acceder aux details de chaque étape\n",
-    "- # Indice : Le goulot d'etranglement est l'étape avec la duree la plus elevee"
+    "- `# Étape 1` : Stocker les résultats dans un dictionnaire indexe par nom de workflow\n",
+    "- `# Étape 2` : Pour `compare_models`, extraire les durees et statuts depuis les `TaskResult`\n",
+    "- `# Indice` : Utiliser `orchestrator.results` pour acceder aux details de chaque étape\n",
+    "- `# Indice` : Le goulot d'etranglement est l'étape avec la duree la plus elevee"
    ]
   },
   {
@@ -2084,8 +2084,8 @@
    "end_time": "2026-08-20T14:32:27.763984",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-2-Workflow-Orchestration.ipynb",
+   "input_path": "03-2-Workflow-Orchestration.ipynb",
+   "output_path": "03-2-Workflow-Orchestration.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/03-Orchestration/03-3-Performance-Optimization.ipynb
@@ -692,7 +692,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Profilage d'un pipeline personnel\n",
     "\n",
@@ -708,10 +708,10 @@
     "4. Identifier quel paramètre (taille memoire ou temps de calcul) a le plus d'impact\n",
     "\n",
     "### Indices\n",
-    "- # Étape 1 : Définir deux fonctions utilisant `simulate_model_inference` avec des paramètres différents\n",
-    "- # Étape 2 : Encapsuler chaque appel dans un bloc `with profiler.profile(\"nom_test\"):`\n",
-    "- # Étape 3 : Utiliser `profiler.get_comparison_table()` pour afficher les résultats\n",
-    "- # Indice : Comparez par exemple un modèle 500MB/200ms vs 1500MB/500ms"
+    "- `# Étape 1` : Définir deux fonctions utilisant `simulate_model_inference` avec des paramètres différents\n",
+    "- `# Étape 2` : Encapsuler chaque appel dans un bloc `with profiler.profile(\"nom_test\"):`\n",
+    "- `# Étape 3` : Utiliser `profiler.get_comparison_table()` pour afficher les résultats\n",
+    "- `# Indice` : Comparez par exemple un modèle 500MB/200ms vs 1500MB/500ms"
    ]
   },
   {
@@ -1378,7 +1378,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Plan d'optimisation pour un scénario contraint\n",
     "\n",
@@ -1394,10 +1394,10 @@
     "4. Afficher les résultats sous forme de tableau comparatif\n",
     "\n",
     "### Indices\n",
-    "- # Étape 1 : Reutiliser `PrecisionManager`, `QuantizationConfig` et `OffloadingStrategy` du notebook\n",
-    "- # Étape 2 : Appliquer les recommandations de chaque classe et les combiner\n",
-    "- # Indice : L'ordre de priorite est : precision reduite > quantification > offloading > batch reduction\n",
-    "- # Indice : Utiliser `BatchOptimizer.estimate_optimal_batch_size()` pour le batch size"
+    "- `# Étape 1` : Reutiliser `PrecisionManager`, `QuantizationConfig` et `OffloadingStrategy` du notebook\n",
+    "- `# Étape 2` : Appliquer les recommandations de chaque classe et les combiner\n",
+    "- `# Indice` : L'ordre de priorite est : precision reduite > quantification > offloading > batch reduction\n",
+    "- `# Indice` : Utiliser `BatchOptimizer.estimate_optimal_batch_size()` pour le batch size"
    ]
   },
   {
@@ -3378,7 +3378,7 @@
     "tags": []
    },
    "source": [
-    "---\n",
+    "***\n",
     "\n",
     "## Exercice : Stratégie de cache personnalisee\n",
     "\n",
@@ -3394,10 +3394,10 @@
     "4. Tester avec une serie de prompts (dont certains repetes)\n",
     "\n",
     "### Indices\n",
-    "- # Étape 1 : Combiner les deux caches existants du notebook\n",
-    "- # Étape 2 : Pour `get_or_compute`, verifier le cache de résultats d'abord (plus rapide), puis le cache d'embeddings\n",
-    "- # Indice : Utiliser `time.time()` pour mesurer le temps economise par les hits cache\n",
-    "- # Indice : Suivre le pattern de `EmbeddingCache.get_stats()` pour vos metriques"
+    "- `# Étape 1` : Combiner les deux caches existants du notebook\n",
+    "- `# Étape 2` : Pour `get_or_compute`, verifier le cache de résultats d'abord (plus rapide), puis le cache d'embeddings\n",
+    "- `# Indice` : Utiliser `time.time()` pour mesurer le temps economise par les hits cache\n",
+    "- `# Indice` : Suivre le pattern de `EmbeddingCache.get_stats()` pour vos metriques"
    ]
   },
   {
@@ -3521,8 +3521,8 @@
    "end_time": "2026-08-20T13:58:25.947551",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-11947-hil\\MyIA.AI.Notebooks\\GenAI\\Image\\03-Orchestration\\03-3-Performance-Optimization.ipynb",
-   "output_path": "D:\\Dev\\CoursIA-11947-hil\\MyIA.AI.Notebooks\\GenAI\\Image\\03-Orchestration\\03-3-Performance-Optimization_output.ipynb",
+   "input_path": "03-3-Performance-Optimization.ipynb",
+   "output_path": "03-3-Performance-Optimization.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-3-Production-Integration.ipynb
@@ -965,10 +965,10 @@
     "\n",
     "**Indices** :\n",
     "- Parcourez `cost_tracker.cost_history` qui est une liste de dictionnaires\n",
-    "- # Étape 1 : Grouper les entrees par `api_name` et calculer le total par API\n",
-    "- # Étape 2 : Grouper les entrees par `opération` et calculer le total par type\n",
-    "- # Étape 3 : Calculer le cout moyen par transaction et identifier l'opération la plus couteuse\n",
-    "- # Indice : Utilisez des dictionnaires pour accumuler les sommes par catégorie"
+    "- `# Étape 1` : Grouper les entrees par `api_name` et calculer le total par API\n",
+    "- `# Étape 2` : Grouper les entrees par `opération` et calculer le total par type\n",
+    "- `# Étape 3` : Calculer le cout moyen par transaction et identifier l'opération la plus couteuse\n",
+    "- `# Indice` : Utilisez des dictionnaires pour accumuler les sommes par catégorie"
    ]
   },
   {
@@ -1433,10 +1433,10 @@
     "\n",
     "**Indices** :\n",
     "- Parcourez la liste des résultats de generation (chaque élément contient `prompt`, `url`, `quality_score`)\n",
-    "- # Étape 1 : Appeler `evaluate_image_quality()` pour chaque image (ou utiliser le score existant)\n",
-    "- # Étape 2 : Utiliser `passes_quality_check()` pour determiner la conformite de chaque image\n",
-    "- # Étape 3 : Agreger les résultats (taux de conformite, scores moyens, images rejetees)\n",
-    "- # Indice : Pensez a gerer le cas ou le lot est vide et a retourner un rapport structure avec statistiques"
+    "- `# Étape 1` : Appeler `evaluate_image_quality()` pour chaque image (ou utiliser le score existant)\n",
+    "- `# Étape 2` : Utiliser `passes_quality_check()` pour determiner la conformite de chaque image\n",
+    "- `# Étape 3` : Agreger les résultats (taux de conformite, scores moyens, images rejetees)\n",
+    "- `# Indice` : Pensez a gerer le cas ou le lot est vide et a retourner un rapport structure avec statistiques"
    ]
   },
   {
@@ -1839,10 +1839,10 @@
     "\n",
     "**Indices** :\n",
     "- Utilisez `get_dashboard_data()` du dashboard pour obtenir les metriques brutes\n",
-    "- # Étape 1 : Extraire les metriques de base (jobs, taux de succes, cout total)\n",
-    "- # Étape 2 : Calculer des indicateurs derives (cout par image, images par heure)\n",
-    "- # Étape 3 : Formater le rapport avec des seuils de statut (OK/WARNING/CRITICAL)\n",
-    "- # Indice : Un rapport de production inclut souvent des comparaisons avec des objectifs predefinis"
+    "- `# Étape 1` : Extraire les metriques de base (jobs, taux de succes, cout total)\n",
+    "- `# Étape 2` : Calculer des indicateurs derives (cout par image, images par heure)\n",
+    "- `# Étape 3` : Formater le rapport avec des seuils de statut (OK/WARNING/CRITICAL)\n",
+    "- `# Indice` : Un rapport de production inclut souvent des comparaisons avec des objectifs predefinis"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Image/04-Applications/04-4-Cross-Stitch-Pattern-Maker-Legacy.ipynb
@@ -740,10 +740,10 @@
     "\n",
     "**Indices** :\n",
     "- Comparez les dimensions `(width, height)` de l'image originale et reduite\n",
-    "- # Étape 1 : Calculer le ratio de compression (nombre de pixels original vs reduit)\n",
-    "- # Étape 2 : Calculer le nombre de pixels perdus (bordures non multiples de block_size)\n",
-    "- # Étape 3 : Calculer le pourcentage de perte par rapport a l'image originale\n",
-    "- # Indice : Les pixels perdus correspondent a `width % block_size` et `height % block_size` en bordure"
+    "- `# Étape 1` : Calculer le ratio de compression (nombre de pixels original vs reduit)\n",
+    "- `# Étape 2` : Calculer le nombre de pixels perdus (bordures non multiples de block_size)\n",
+    "- `# Étape 3` : Calculer le pourcentage de perte par rapport a l'image originale\n",
+    "- `# Indice` : Les pixels perdus correspondent a `width % block_size` et `height % block_size` en bordure"
    ]
   },
   {
@@ -985,10 +985,10 @@
     "\n",
     "**Indices** :\n",
     "- `dmc_codes` est un tableau numpy 2D de chaînes de caractères (codes DMC comme \"310\", \"498\", etc.)\n",
-    "- # Étape 1 : Identifier les codes uniques avec `np.unique()` et compter leurs occurrences\n",
-    "- # Étape 2 : Trier par frequence decroissante et calculer le pourcentage de chaque couleur\n",
-    "- # Étape 3 : Enrichir avec les noms de couleur depuis la base DMC (`DMC_COLORS`)\n",
-    "- # Indice : La base `DMC_COLORS` est une liste de dicts avec les cles `floss`, `name`, `red`, `green`, `blue`"
+    "- `# Étape 1` : Identifier les codes uniques avec `np.unique()` et compter leurs occurrences\n",
+    "- `# Étape 2` : Trier par frequence decroissante et calculer le pourcentage de chaque couleur\n",
+    "- `# Étape 3` : Enrichir avec les noms de couleur depuis la base DMC (`DMC_COLORS`)\n",
+    "- `# Indice` : La base `DMC_COLORS` est une liste de dicts avec les cles `floss`, `name`, `red`, `green`, `blue`"
    ]
   },
   {
@@ -1260,10 +1260,10 @@
     "\n",
     "**Indices** :\n",
     "- Utilisez `Image.resize()` de Pillow avec le filtre `Image.LANCZOS`\n",
-    "- # Étape 1 : Calculer les nouvelles dimensions arrondies au multiple inferieur de block_size\n",
-    "- # Étape 2 : Verifier si un redimensionnement est reellement necessaire\n",
-    "- # Étape 3 : Retourner l'image redimensionnee et les nouvelles dimensions\n",
-    "- # Indice : Les nouvelles dimensions doivent etre `width - (width % block_size)` et `height - (height % block_size)`"
+    "- `# Étape 1` : Calculer les nouvelles dimensions arrondies au multiple inferieur de block_size\n",
+    "- `# Étape 2` : Verifier si un redimensionnement est reellement necessaire\n",
+    "- `# Étape 3` : Retourner l'image redimensionnee et les nouvelles dimensions\n",
+    "- `# Indice` : Les nouvelles dimensions doivent etre `width - (width % block_size)` et `height - (height % block_size)`"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-1-HunyuanVideo-Generation.ipynb
@@ -758,10 +758,10 @@
     "Le negative prompt guide le modèle pour eviter certains artefacts, mais un negative prompt surcharge peut paradoxalement degrader les résultats. L'objectif est de trouver le bon equilibre.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir les catégories de termes negatives : `QUALITY_TERMS` (low quality, blurry, distorted, artifacts), `CONTENT_TERMS` (nsfw, violence, watermark, text, logo), `STYLE_TERMS` (cartoon, anime, painting, oversaturated)\n",
-    "- # Étape 2 : Implementer `analyze_negative_prompt()` qui decompose le negative prompt en tokens, les categorise, et detecte les redondances\n",
-    "- # Étape 3 : Implementer `optimize_negative_prompt()` qui supprime les doublons, retire les termes inutiles pour HunyuanVideo, et garde les plus impactants\n",
-    "- # Indice : HunyuanVideo est sensible aux termes \"blurry\" et \"distortion\" mais ignore souvent \"watermark\" dans le negative prompt"
+    "- `# Étape 1` : Définir les catégories de termes negatives : `QUALITY_TERMS` (low quality, blurry, distorted, artifacts), `CONTENT_TERMS` (nsfw, violence, watermark, text, logo), `STYLE_TERMS` (cartoon, anime, painting, oversaturated)\n",
+    "- `# Étape 2` : Implementer `analyze_negative_prompt()` qui decompose le negative prompt en tokens, les categorise, et detecte les redondances\n",
+    "- `# Étape 3` : Implementer `optimize_negative_prompt()` qui supprime les doublons, retire les termes inutiles pour HunyuanVideo, et garde les plus impactants\n",
+    "- `# Indice` : HunyuanVideo est sensible aux termes \"blurry\" et \"distortion\" mais ignore souvent \"watermark\" dans le negative prompt"
    ]
   },
   {
@@ -1047,10 +1047,10 @@
     "HunyuanVideo repond mieux aux prompts riches et structures qu'aux descriptions simples. Un prompt bien construit contient typiquement 4 a 6 éléments descriptifs distincts.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un dictionnaire `CAMERA_MOVES` avec les mouvements de camera (aerial shot, tracking shot, close-up, dolly zoom, crane shot, steadicam)\n",
-    "- # Étape 2 : Définir un dictionnaire `LIGHTING_SETUPS` avec les eclairages (golden hour, blue hour, dramatic backlight, soft diffused, studio lighting)\n",
-    "- # Étape 3 : Implementer `build_cinematic_prompt()` qui assemble sujet + action + camera + eclairage + style avec des separateurs naturels (virgules)\n",
-    "- # Indice : HunyuanVideo prefere les prompts en anglais avec un ordre sujet -> action -> camera -> eclairage -> style"
+    "- `# Étape 1` : Définir un dictionnaire `CAMERA_MOVES` avec les mouvements de camera (aerial shot, tracking shot, close-up, dolly zoom, crane shot, steadicam)\n",
+    "- `# Étape 2` : Définir un dictionnaire `LIGHTING_SETUPS` avec les eclairages (golden hour, blue hour, dramatic backlight, soft diffused, studio lighting)\n",
+    "- `# Étape 3` : Implementer `build_cinematic_prompt()` qui assemble sujet + action + camera + eclairage + style avec des separateurs naturels (virgules)\n",
+    "- `# Indice` : HunyuanVideo prefere les prompts en anglais avec un ordre sujet -> action -> camera -> eclairage -> style"
    ]
   },
   {
@@ -1296,10 +1296,10 @@
     "Les metriques objetives permettent de comparer quantitativement différentes configurations de generation, au-dela de l'evaluation visuelle subjective.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Implementer `sharpness_score()` qui mesure la nettete moyenne via le laplacien : `cv2.Laplacian(frame, cv2.CV_64F).var()` (ou un equivalent numpy)\n",
-    "- # Étape 2 : Implementer `temporal_consistency()` qui mesure la stabilite des différences inter-frames (ecart-type des différences : un ecart-type faible = mouvement regulier)\n",
-    "- # Étape 3 : Implementer `color_richness()` qui compte le nombre de couleurs uniques dans chaque frame (diversite chromatique)\n",
-    "- # Indice : Sans OpenCV, le laplacien peut etre approxime par `np.var(np.gradient(frame.astype(float)))`"
+    "- `# Étape 1` : Implementer `sharpness_score()` qui mesure la nettete moyenne via le laplacien : `cv2.Laplacian(frame, cv2.CV_64F).var()` (ou un equivalent numpy)\n",
+    "- `# Étape 2` : Implementer `temporal_consistency()` qui mesure la stabilite des différences inter-frames (ecart-type des différences : un ecart-type faible = mouvement regulier)\n",
+    "- `# Étape 3` : Implementer `color_richness()` qui compte le nombre de couleurs uniques dans chaque frame (diversite chromatique)\n",
+    "- `# Indice` : Sans OpenCV, le laplacien peut etre approxime par `np.var(np.gradient(frame.astype(float)))`"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-2-LTX-Video-Lightweight.ipynb
@@ -842,10 +842,10 @@
     "LTX-Video est concu pour etre leger (~8 GB VRAM), mais la consommation exacte depend de la resolution, du nombre de frames et de la precision numérique.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : La formule de base est : `base_vram + (width * height * num_frames * bytes_per_pixel) / 1e9` ou `base_vram` est le cout fixe du modèle (~5 GB en bfloat16) et `bytes_per_pixel` depend du dtype (2 pour float16/bfloat16)\n",
-    "- # Étape 2 : Le VAE slicing divise la consommation VAE par 2. Le CPU offload reduit encore la VRAM mais ralentit la generation\n",
-    "- # Étape 3 : Si la VRAM estimee depasse la VRAM disponible, proposer une configuration degradee (reduire frames puis resolution)\n",
-    "- # Indice : LTX-Video en bfloat16 utilise ~5 GB fixes + ~0.5 GB par 512x320x16 frames"
+    "- `# Étape 1` : La formule de base est : `base_vram + (width * height * num_frames * bytes_per_pixel) / 1e9` ou `base_vram` est le cout fixe du modèle (~5 GB en bfloat16) et `bytes_per_pixel` depend du dtype (2 pour float16/bfloat16)\n",
+    "- `# Étape 2` : Le VAE slicing divise la consommation VAE par 2. Le CPU offload reduit encore la VRAM mais ralentit la generation\n",
+    "- `# Étape 3` : Si la VRAM estimee depasse la VRAM disponible, proposer une configuration degradee (reduire frames puis resolution)\n",
+    "- `# Indice` : LTX-Video en bfloat16 utilise ~5 GB fixes + ~0.5 GB par 512x320x16 frames"
    ]
   },
   {
@@ -1188,10 +1188,10 @@
     "En mode image-to-video, le prompt ne decrit pas la scene (l'image le fait déjà) mais le mouvement souhaite. Cet exercice aide a formuler des prompts d'animation efficaces.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un dictionnaire `MOTION_CUES` qui associe des types de scenes (paysage, portrait, nature, urbain) a des mouvements naturels (nuages qui bougent, cheveux dans le vent, lumiere qui change)\n",
-    "- # Étape 2 : Detecter le type de scene a partir de mots-cles dans la description (ex: \"sky\" + \"clouds\" = paysage, \"person\" + \"face\" = portrait)\n",
-    "- # Étape 3 : Construire le prompt d'animation en combinant les mouvements naturels du type detecte avec des mots-cles de qualite (smooth, natural, subtle)\n",
-    "- # Indice : LTX-Video prefere des prompts d'animation courts et descriptifs (pas de phrases complexes)"
+    "- `# Étape 1` : Définir un dictionnaire `MOTION_CUES` qui associe des types de scenes (paysage, portrait, nature, urbain) a des mouvements naturels (nuages qui bougent, cheveux dans le vent, lumiere qui change)\n",
+    "- `# Étape 2` : Detecter le type de scene a partir de mots-cles dans la description (ex: \"sky\" + \"clouds\" = paysage, \"person\" + \"face\" = portrait)\n",
+    "- `# Étape 3` : Construire le prompt d'animation en combinant les mouvements naturels du type detecte avec des mots-cles de qualite (smooth, natural, subtle)\n",
+    "- `# Indice` : LTX-Video prefere des prompts d'animation courts et descriptifs (pas de phrases complexes)"
    ]
   },
   {
@@ -1495,10 +1495,10 @@
     "La coherence temporelle est un indicateur cle de la qualite video : des sauts brusques entre frames signalent des artefacts de generation, tandis qu'une variabilite trop faible indique un manque de mouvement.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Convertir chaque frame en `np.array` de type `float32` pour eviter les debordements\n",
-    "- # Étape 2 : Calculer la différence absolue moyenne (MAD) entre chaque paire de frames consecutives : `np.mean(np.abs(f1 - f2))`\n",
-    "- # Étape 3 : Définir des seuils de classification : variation < 5 = \"statique\", 5-20 = \"fluide\", 20-40 = \"mouvement rapide\", > 40 = \"instable\"\n",
-    "- # Indice : Une video de bonne qualite a une variabilite reguliere entre frames, sans pics soudains"
+    "- `# Étape 1` : Convertir chaque frame en `np.array` de type `float32` pour eviter les debordements\n",
+    "- `# Étape 2` : Calculer la différence absolue moyenne (MAD) entre chaque paire de frames consecutives : `np.mean(np.abs(f1 - f2))`\n",
+    "- `# Étape 3` : Définir des seuils de classification : variation < 5 = \"statique\", 5-20 = \"fluide\", 20-40 = \"mouvement rapide\", > 40 = \"instable\"\n",
+    "- `# Indice` : Une video de bonne qualite a une variabilite reguliere entre frames, sans pics soudains"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-3-Wan-Video-Generation.ipynb
@@ -862,10 +862,10 @@
     "Un prompt efficace pour Wan contient généralement 5 éléments : sujet, action, type de camera, eclairage et style. Cet exercice consiste a parser et structurer un prompt brut.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir des listes de mots-cles pour chaque catégorie : `CAMERA_WORDS` (pan, zoom, tracking, drone, close-up), `LIGHTING_WORDS` (golden hour, dramatic, soft, backlit), `STYLE_WORDS` (cinematic, 4K, slow motion, timelapse)\n",
-    "- # Étape 2 : Implementer `parse_prompt_components()` qui detecte la presence de chaque catégorie dans le texte\n",
-    "- # Étape 3 : Implementer `enrich_prompt()` qui ajoute les composants manquants avec des valeurs par defaut pertinentes\n",
-    "- # Indice : Wan comprend le francais, mais les mots-cles techniques en anglais (cinematic, golden hour) sont souvent plus efficaces"
+    "- `# Étape 1` : Définir des listes de mots-cles pour chaque catégorie : `CAMERA_WORDS` (pan, zoom, tracking, drone, close-up), `LIGHTING_WORDS` (golden hour, dramatic, soft, backlit), `STYLE_WORDS` (cinematic, 4K, slow motion, timelapse)\n",
+    "- `# Étape 2` : Implementer `parse_prompt_components()` qui detecte la presence de chaque catégorie dans le texte\n",
+    "- `# Étape 3` : Implementer `enrich_prompt()` qui ajoute les composants manquants avec des valeurs par defaut pertinentes\n",
+    "- `# Indice` : Wan comprend le francais, mais les mots-cles techniques en anglais (cinematic, golden hour) sont souvent plus efficaces"
    ]
   },
   {
@@ -1211,10 +1211,10 @@
     "Wan repond differemment aux mots-cles de mouvement (pan, zoom, drone, tracking). Cet exercice vise a quantifier ces différences.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir le dictionnaire `MOTION_KEYWORDS` qui mappe chaque type de mouvement a un template de prompt\n",
-    "- # Étape 2 : Pour chaque mouvement, construire le prompt complet en combinant le template avec la scene decrite\n",
-    "- # Étape 3 : Mesurer la variabilite inter-frames comme indicateur de la qualite du mouvement (différence moyenne entre frames consecutives)\n",
-    "- # Indice : utiliser `np.mean(np.abs(frame1.astype(float) - frame2.astype(float)))` pour mesurer la différence entre deux frames"
+    "- `# Étape 1` : Définir le dictionnaire `MOTION_KEYWORDS` qui mappe chaque type de mouvement a un template de prompt\n",
+    "- `# Étape 2` : Pour chaque mouvement, construire le prompt complet en combinant le template avec la scene decrite\n",
+    "- `# Étape 3` : Mesurer la variabilite inter-frames comme indicateur de la qualite du mouvement (différence moyenne entre frames consecutives)\n",
+    "- `# Indice` : utiliser `np.mean(np.abs(frame1.astype(float) - frame2.astype(float)))` pour mesurer la différence entre deux frames"
    ]
   },
   {
@@ -1532,10 +1532,10 @@
     "Chaque plateforme impose des contraintes spécifiques que le générateur video doit respecter pour un résultat optimal.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un dictionnaire `PLATFORM_SPECS` avec les specs de chaque plateforme (resolution max, ratio, duree max, fps)\n",
-    "- # Étape 2 : Implementer la logique de filtrage : si la duree demandee depasse la duree max, la reduire\n",
-    "- # Étape 3 : Ajuster la resolution pour respecter le ratio impose par la plateforme\n",
-    "- # Indice : YouTube = 16:9, 1080p, 60fps max ; TikTok = 9:16, 1080p, 30fps ; Instagram = 1:1 ou 9:16, 1080p, 30fps"
+    "- `# Étape 1` : Définir un dictionnaire `PLATFORM_SPECS` avec les specs de chaque plateforme (resolution max, ratio, duree max, fps)\n",
+    "- `# Étape 2` : Implementer la logique de filtrage : si la duree demandee depasse la duree max, la reduire\n",
+    "- `# Étape 3` : Ajuster la resolution pour respecter le ratio impose par la plateforme\n",
+    "- `# Indice` : YouTube = 16:9, 1080p, 60fps max ; TikTok = 9:16, 1080p, 30fps ; Instagram = 1:1 ou 9:16, 1080p, 30fps"
    ]
   },
   {
@@ -2067,8 +2067,8 @@
    "end_time": "2026-08-20T12:13:27.977290",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-10985-wan4\\MyIA.AI.Notebooks\\GenAI\\Video\\02-Advanced\\02-3-Wan-Video-Generation.ipynb",
-   "output_path": "D:\\Dev\\CoursIA-10985-wan4\\MyIA.AI.Notebooks\\GenAI\\Video\\02-Advanced\\02-3-Wan-Video-Generation_output.ipynb",
+   "input_path": "02-3-Wan-Video-Generation.ipynb",
+   "output_path": "02-3-Wan-Video-Generation.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/02-Advanced/02-5-LTX2-Audiovisual.ipynb
@@ -1173,10 +1173,10 @@
     "Le modèle 22B fait ~44 GB en FP16. La quantization reduit drastiquement cet encombrement : INT8 ~ 22 GB, INT4/NF4 ~ 11 GB. Mais il faut aussi compter le text encoder Gemma 3 12B et les activations de generation.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Calculer le cout du modèle selon la quantization. FP16 = 44 GB, INT8 = 22 GB, INT4/NF4 = 11 GB (règle : bits/16 * 44)\n",
-    "- # Étape 2 : Ajouter le cout du text encoder Gemma 3 12B (~6 GB en QAT quantized, ~24 GB en FP16)\n",
-    "- # Étape 3 : Ajouter le cout d'activation (~0.3 GB par 512x768x97 frames en INT4). Si total > VRAM disponible, proposer une config reduite (baisser frames puis resolution)\n",
-    "- # Indice : Le VAE slicing et le CPU offload reduisent encore la VRAM mais ralentissent la generation\n"
+    "- `# Étape 1` : Calculer le cout du modèle selon la quantization. FP16 = 44 GB, INT8 = 22 GB, INT4/NF4 = 11 GB (règle : bits/16 * 44)\n",
+    "- `# Étape 2` : Ajouter le cout du text encoder Gemma 3 12B (~6 GB en QAT quantized, ~24 GB en FP16)\n",
+    "- `# Étape 3` : Ajouter le cout d'activation (~0.3 GB par 512x768x97 frames en INT4). Si total > VRAM disponible, proposer une config reduite (baisser frames puis resolution)\n",
+    "- `# Indice` : Le VAE slicing et le CPU offload reduisent encore la VRAM mais ralentissent la generation\n"
    ]
   },
   {
@@ -1265,10 +1265,10 @@
     "Contrairement a un prompt video-only (ou le son est ajoute après), un prompt LTX-2 doit guider la **coherence audio-visuelle** (un eclat de rire = un visage qui rit, un orage = des eclairs et du tonnerre synchrone).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un dictionnaire `AV_CUES` associant des scenes a des paires (visuel, audio) coherentes (tempete -> eclairs + tonnerre ; foret -> feuilles + chants d'oiseaux ; rue -> voitures + klaxons)\n",
-    "- # Étape 2 : Detecter la scene dominante a partir de mots-cles dans la description visuelle\n",
-    "- # Étape 3 : Combiner la description visuelle + les indices audio coherents + des mots de qualite (cinematic, natural sound, synchronized) en un prompt LTX-2 unique\n",
-    "- # Indice : LTX-2 repond bien aux descriptions audio explicites (\"natural ambient sound\", \"clear dialogue\", \"dynamic foley\")\n"
+    "- `# Étape 1` : Définir un dictionnaire `AV_CUES` associant des scenes a des paires (visuel, audio) coherentes (tempete -> eclairs + tonnerre ; foret -> feuilles + chants d'oiseaux ; rue -> voitures + klaxons)\n",
+    "- `# Étape 2` : Detecter la scene dominante a partir de mots-cles dans la description visuelle\n",
+    "- `# Étape 3` : Combiner la description visuelle + les indices audio coherents + des mots de qualite (cinematic, natural sound, synchronized) en un prompt LTX-2 unique\n",
+    "- `# Indice` : LTX-2 repond bien aux descriptions audio explicites (\"natural ambient sound\", \"clear dialogue\", \"dynamic foley\")\n"
    ]
   },
   {
@@ -1352,10 +1352,10 @@
     "L'idee : comparer l'**enveloppe d'energie audio** (ou les onsets sonores apparaissent) a l'**energie de mouvement** des frames (ou l'image change le plus). Une bonne synchro = les pics d'audio coïncident avec les pics de mouvement (un coup = un son au même instant).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Extraire la piste audio du MP4 avec `av` (PyAV) et calculer l'enveloppe d'energie par fenêtre (RMS ou amplitude absolue moyenne par frame audio)\n",
-    "- # Étape 2 : Calculer l'energie de mouvement entre frames video consecutives : `np.mean(np.abs(f_t - f_{t-1}))` redimensionne a la même cadence que l'audio\n",
-    "- # Étape 3 : Calculer la cross-correlation decalee entre les deux enveloppes ; le lag au pic de correlation = decalage audio-video (ideal = 0). Un decalage < 40 ms est imperceptible\n",
-    "- # Indice : Utilisez `np.correlate(audio_env, motion_env, mode='full')` puis trouvez l'argmax\n"
+    "- `# Étape 1` : Extraire la piste audio du MP4 avec `av` (PyAV) et calculer l'enveloppe d'energie par fenêtre (RMS ou amplitude absolue moyenne par frame audio)\n",
+    "- `# Étape 2` : Calculer l'energie de mouvement entre frames video consecutives : `np.mean(np.abs(f_t - f_{t-1}))` redimensionne a la même cadence que l'audio\n",
+    "- `# Étape 3` : Calculer la cross-correlation decalee entre les deux enveloppes ; le lag au pic de correlation = decalage audio-video (ideal = 0). Un decalage < 40 ms est imperceptible\n",
+    "- `# Indice` : Utilisez `np.correlate(audio_env, motion_env, mode='full')` puis trouvez l'argmax\n"
    ]
   },
   {
@@ -1634,8 +1634,8 @@
    "end_time": "2026-08-20T20:46:15.847922",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:\\Dev\\CoursIA-10985-rot\\MyIA.AI.Notebooks\\GenAI\\Video\\02-Advanced\\02-5-LTX2-Audiovisual.ipynb",
-   "output_path": "D:\\Dev\\CoursIA-10985-rot\\MyIA.AI.Notebooks\\GenAI\\Video\\02-Advanced\\02-5-LTX2-Audiovisual_output.ipynb",
+   "input_path": "02-5-LTX2-Audiovisual.ipynb",
+   "output_path": "02-5-LTX2-Audiovisual.ipynb",
    "parameters": {
     "BATCH_MODE": "true"
    },

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-1-Educational-Video-Generation.ipynb
@@ -983,10 +983,10 @@
     "\n",
     "**Indices** :\n",
     "- Chaque slide a sa propre `duration`, les transitions ont une `transition_duration` fixe\n",
-    "- # Étape 1 : Sommer les durees de tous les slides\n",
-    "- # Étape 2 : Ajouter les transitions (N slides => N-1 transitions)\n",
-    "- # Étape 3 : Comparer avec la duree cible et calculer l'ecart\n",
-    "- # Indice : Le nombre de transitions est `len(slides) - 1` si au moins 2 slides"
+    "- `# Étape 1` : Sommer les durees de tous les slides\n",
+    "- `# Étape 2` : Ajouter les transitions (N slides => N-1 transitions)\n",
+    "- `# Étape 3` : Comparer avec la duree cible et calculer l'ecart\n",
+    "- `# Indice` : Le nombre de transitions est `len(slides) - 1` si au moins 2 slides"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-2-Creative-Video-Workflows.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-2-Creative-Video-Workflows.ipynb
@@ -972,10 +972,10 @@
     "\n",
     "**Indices** :\n",
     "- Convertissez les frames en `float32` avant les calculs pour eviter les debordements\n",
-    "- # Étape 1 : Calculer la différence absolue moyenne (MAE) par canal RGB\n",
-    "- # Étape 2 : Calculer la distance euclidienne moyenne par pixel\n",
-    "- # Étape 3 : Retourner un dictionnaire classe par intensite de transformation\n",
-    "- # Indice : Utilisez `np.mean(np.abs(original.astype(float) - transformed.astype(float)))` pour le MAE"
+    "- `# Étape 1` : Calculer la différence absolue moyenne (MAE) par canal RGB\n",
+    "- `# Étape 2` : Calculer la distance euclidienne moyenne par pixel\n",
+    "- `# Étape 3` : Retourner un dictionnaire classe par intensite de transformation\n",
+    "- `# Indice` : Utilisez `np.mean(np.abs(original.astype(float) - transformed.astype(float)))` pour le MAE"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Video/04-Applications/04-3-Sora-API-Cloud-Video.ipynb
@@ -1673,10 +1673,10 @@
     "**Indices** :\n",
     "- Le cout cloud est lineaire : `nb_videos * cout_par_video`\n",
     "- Le cout local est fixe : `amortissement_gpu_mensuel + electricite_mensuelle`\n",
-    "- # Étape 1 : Calculer le cout mensuel cloud pour un volume donne\n",
-    "- # Étape 2 : Calculer le cout mensuel local (amortissement + electricite)\n",
-    "- # Étape 3 : Trouver le volume ou les deux couts s'egalisent (point de bascule)\n",
-    "- # Indice : Le point de bascule est `cout_local_fixe / cout_par_video_cloud`"
+    "- `# Étape 1` : Calculer le cout mensuel cloud pour un volume donne\n",
+    "- `# Étape 2` : Calculer le cout mensuel local (amortissement + electricite)\n",
+    "- `# Étape 3` : Trouver le volume ou les deux couts s'egalisent (point de bascule)\n",
+    "- `# Indice` : Le point de bascule est `cout_local_fixe / cout_par_video_cloud`"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #12132

**Périmètre : 16 fichiers (GenAI/Image + GenAI/Video uniquement)** — claim paths-scoped posé sur #12128, disjoint de la tranche A (#12131, GenAI/Texte+Audio+Image/01) et des tranches C-F.

See #12128

## Summary

Tranche B de la remédiation `heading_in_list` : le marqueur `- # Étape N :` / `- # Indice :` au début d'une puce rend un `<h1>` 29 px **dans** le `<li>` (écrase la puce, casse la hiérarchie visuelle). Remède prescrit par l'issue : backtiquer le marqueur → `` - `# Étape N` : `` (rendu inline, taille de corps, puce préservée).

## Dénombrement

| Mesure | Valeur |
|---|---|
| Occurrences `heading_in_list` corrigées | **171** (avant : 171 sur la tranche → après : **0**, `fix_hint_headings --scan` vide) |
| Notebooks touchés | 16 (GenAI/Image 9, GenAI/Video 7) |
| Cas humain | 1 — `03-2-Workflow-Orchestration.ipynb` cell 18 `- # Etice : "ultra detailed..."` (coquille de « Indice » listée dans l'issue) → `` - `# Indice` : `` |
| Diff | 16 fichiers, +237/−178 — inclut le churn de normalisation `source` string→liste-de-lignes (les deux formes sont valides nbformat ; même profil que la tranche A #12131 : +487/−314 pour 303 fixes) |

## Fix compound — séparateurs `---` (pattern c.440-L1)

Le gate baseline (`detect_markdown_rendering.py --check --baseline`) FAILait avec **8 new ERROR** `yaml_block_open_no_close` sur 03-1/03-2/03-3 Orchestration : le hash de cellule changé par le fix heading fait resurger la dette **pré-existante** d'autres règles sur la même cellule (cliquet delta). Les deux fixes voyagent ensemble : `fix_hr_separator.py --apply` sur les 3 notebooks → 9 séparateurs `---` en puce convertis → gate **OK**.

## Acceptance (4 points du body de l'issue)

1. **Compte avant/après sur la tranche** : 171 → 0 (`fix_hint_headings.py --scan` sur `GenAI/Image` + `GenAI/Video`).
2. **Confirmation diff** : 171 lignes `+` matchant `` - `# (Indice|Étape|Etape) `` comptées par regex sur le diff ; churn de normalisation documenté ci-dessus.
3. **C.2 cellule-par-cellule** : snapshot pré-apply `(execution_count, n_outputs, sha1(source))` de chaque cellule code → re-check post-apply **byte-identique** (script dédié) — modifs markdown-only, aucune re-exécution requise (H.3 Passed au commit).
4. **Rendu de l'œil** : rendu markdown-it des 16 notebooks → 266 cellules markdown **CLEAN, 0 `<li>` contenant un `<h1-6>`** ; échantillons de prose vérifiés (`# Indice` inline dans la puce, puce préservée).

## Validation

- Pre-commit : gitleaks, probeAddresses, papermill-path strip, markdown-rendering NEW-defects, source-list-newlines, H.3 — **tous Passed** (commit `088b738de`).
- `metadata.papermill` `input/output_path` normalisés au basename sur les 3 notebooks porteurs (normalisation tolérée, exigée par le hook).
- Aucune cellule code touchée ; aucun output modifié ; aucun workflow/baseline modifié.

## Résiduel (pour le coordinateur)

- Baseline `markdown_rendering_baseline.json` **non régénérée** dans cette PR (volontairement) : la régénération post-merge est une action par-merge — la régénérer ici confliterait avec les tranches A et C-F. Cf directive issue : régénérer après chaque tranche mergée.
- Tranches C-F restantes (autres familles), claims à poser par les lanes suivantes.

## Test plan

- [ ] ai-01 : review rendu GitHub (backticks dans les listes, cell 18 de 03-2)
- [ ] ai-01 : merge + régénération baseline post-merge
