### PR TITLE
fix(notebooks,#12128): tranche E QuantConnect heading_in_list + hr_separator compound (500 reparations, 18 notebooks)

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "**Référence** : Broad, J. (2025). *Hands-On AI Trading with Python*, Chapitre 6, Exercice 4.\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Objectifs d'apprentissage\n",
     "\n",
@@ -41,7 +41,7 @@
     "|-----------|--------|\n",
     "| [Catalogue ML-Training](README.md) | -- |\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Introduction\n",
     "\n",
@@ -565,11 +565,11 @@
     "**Contexte** : Les features actuelles incluent le log-rendement, la volatilité 20j et le momentum 5j. D'autres combinaisons pourraient mieux capturer les régimes.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Essayez d'ajouter la volatilité 5j (`returns.rolling(5).std()`) et le volume de rendement (`returns.abs().rolling(10).mean()`)\n",
-    "- # Indice 2 : Utilisez `features.describe()` pour verifier les statistiques descriptives\n",
-    "- # Étape 1 : Ajouter au moins 2 nouvelles features au DataFrame `features`\n",
-    "- # Étape 2 : Verifier les correlations entre features avec `features.corr()`\n",
-    "- # Étape 3 : Sélectionner un sous-ensemble non-correle pour le HMM"
+    "- `# Indice 1 : Essayez d'ajouter la volatilité 5j (`returns.rolling(5).std()`) et le volume de rendement (`returns.abs().rolling(10).mean()`)`\n",
+    "- `# Indice 2 : Utilisez `features.describe()` pour verifier les statistiques descriptives`\n",
+    "- `# Étape 1 : Ajouter au moins 2 nouvelles features au DataFrame `features``\n",
+    "- `# Étape 2 : Verifier les correlations entre features avec `features.corr()``\n",
+    "- `# Étape 3 : Sélectionner un sous-ensemble non-correle pour le HMM`"
    ]
   },
   {
@@ -1116,11 +1116,11 @@
     "**Contexte** : La stratégie actuelle utilise simplement l'état decode par Viterbi comme signal. En pratique, on peut utiliser les probabilités a posteriori des états pour filtrer les signaux a faible confiance.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Utilisez `model_2s.predict_proba(X_scaled)` pour obtenir les probabilités d'appartenance a chaque état\n",
-    "- # Indice 2 : Ne génère un signal que si la probabilité de l'état dominant dépasse un seuil (ex: 0.7)\n",
-    "- # Étape 1 : Calculer les probabilités a posteriori pour chaque observation\n",
-    "- # Étape 2 : Définir un seuil de confiance et filtrer les signaux\n",
-    "- # Étape 3 : Comparer le nombre de trades et la performance avec la stratégie sans filtre"
+    "- `# Indice 1 : Utilisez `model_2s.predict_proba(X_scaled)` pour obtenir les probabilités d'appartenance a chaque état`\n",
+    "- `# Indice 2 : Ne génère un signal que si la probabilité de l'état dominant dépasse un seuil (ex: 0.7)`\n",
+    "- `# Étape 1 : Calculer les probabilités a posteriori pour chaque observation`\n",
+    "- `# Étape 2 : Définir un seuil de confiance et filtrer les signaux`\n",
+    "- `# Étape 3 : Comparer le nombre de trades et la performance avec la stratégie sans filtre`"
    ]
   },
   {
@@ -2407,11 +2407,11 @@
     "**Contexte** : Les coûts de transaction en crypto varient selon l'exchange et la taille des ordres. La valeur par défaut est 10 bps, mais certains brokers facturent plus.\n",
     "\n",
     "**Indices** :\n",
-    "- # Indice 1 : Appelez `walk_forward_hmm()` avec différentes valeurs de `cost_bps` : [0, 5, 10, 20, 50]\n",
-    "- # Indice 2 : Pour chaque valeur, calculez le Sharpe moyen et le nombre de trades moyen\n",
-    "- # Étape 1 : Executer le walk-forward avec cost_bps=0 (pas de coûts) comme référence\n",
-    "- # Étape 2 : Executer avec cost_bps=5, 10, 20, 50\n",
-    "- # Étape 3 : Tracer la courbe Sharpe vs cost_bps et identifier le seuil de rentabilité"
+    "- `# Indice 1 : Appelez `walk_forward_hmm()` avec différentes valeurs de `cost_bps` : [0, 5, 10, 20, 50]`\n",
+    "- `# Indice 2 : Pour chaque valeur, calculez le Sharpe moyen et le nombre de trades moyen`\n",
+    "- `# Étape 1 : Executer le walk-forward avec cost_bps=0 (pas de coûts) comme référence`\n",
+    "- `# Étape 2 : Executer avec cost_bps=5, 10, 20, 50`\n",
+    "- `# Étape 3 : Tracer la courbe Sharpe vs cost_bps et identifier le seuil de rentabilité`"
    ]
   },
   {
@@ -3203,7 +3203,7 @@
     "- **Ensemble de HMM** : combiner les prédictions de plusieurs HMM (différents seeds, différents nombres d'états) pour réduire la variance\n",
     "- **Horizons multiples** : appliquer le signal HMM sur différentes horizons de rebalancement (journalier, hebdomadaire) pour optimiser le ratio signal/bruit\n",
     "\n",
-    "---\n",
+    "***\n",
     "\n",
     "## Navigation\n",
     "\n",


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA-2 — prev: LIGHT/notebook-python #12114 (c.297 fix_hr_separator)

## Périmètre (diff effectif post-rebase c.1301+359)

**1 fichier UNIQUEMENT** : `MyIA.AI.Notebooks/QuantConnect/ML-Training-Pipeline/hmm_alpha_research.ipynb` (+18/−18, markdown-only, 27 cellules code byte-identiques — C.3 exempt de re-exécution).

## Historique de la tranche E (répa c.1301+359)

La tranche E originelle (c.1301+~320, commit `c66dd05f8`) portait **500 réparations sur 18 notebooks QC** (110 `heading_in_list` + 390 `yaml_block_open_no_close`). Pendant ses 39 h d'attente, **3 commits sur main ont absorbé la substance de 17 des 18 fichiers** :

- #12247 — réintroductions QC-Py-17/22/25 (MERGED)
- #12332 — tranche 2 : 8 notebooks non contestés (MERGED)
- #12366 — les 41 `heading_in_list` hors baseline (MERGED, absorbait aussi les soldes QC-Py)

Vérifié firsthand avant le rebase : détecteur non-gated sur `origin/main` ne montre **plus aucun défaut** dans les 17 QC-Py — seule `hmm_alpha_research.ipynb` conservait 3 `heading_in_list` (cells 13/29/53, dette baselinée). `ML-Training-Pipeline/` n'était couvert par aucune des 3 PR absorbantes.

**Rebase** : conflits UU sur les 17 fichiers absorbés → résolus en prenant **main** (substance déjà là, duplication écartée) ; `hmm_alpha_research.ipynb` s'applique proprement (main ne l'a jamais touché). `--force-with-lease` sur branche à lane unique (L284). Push muet interdit : ce body + le commentaire documentent la réparation.

## Substance restante LIVRÉE firsthand

`hmm_alpha_research.ipynb` : 18 lignes markdown réparées — fixes `heading_in_list` (h1 parasites sous puces → backticks, motif `fix_hint_headings.py` canonique) + les `yaml_block_open_no_close` composés sur les mêmes cellules (le fix modifie le hash de cellule → tout autre défaut pré-existant resurgerait au gate, les deux fixes sont donc conjoints par construction, c.440-L1).

## Acceptance (post-rebase, relancée sur la tête fraîche `d547e6e68`)

- détecteur non-gated sur le fichier : **0 violation** (était 3 `heading_in_list`)
- détecteur gated `--check --baseline markdown_rendering_baseline.json` sur `QuantConnect/**` : **OK: no new ERROR-level** (aucune résurgence composée)
- 27 cellules code byte-identiques à main (`source` + `execution_count` + `outputs`) — C.2/H.3 intacts, C.3 markdown-only
- `validate_pr_notebooks.py HEAD` : **PASS** (27 cells)
- non enregistré au registre twin (`twin_pairs.d`) — aucun rebaseline dû
- catalogue byte-identique à main (R1)

## Références

- Issue **#12128** (pathologie des tailles de police d'indices, tranches A-F)
- Absorbants : #12247 · #12332 · #12366
- Amend c.1301+324 (grain tag + reformulations close-keyword) : historique, substance inchangée
