### PR TITLE
fix(genai,#12128): tranche F1 heading_in_list SemanticKernel 01-08 — 96 remedes

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb
@@ -742,10 +742,10 @@
     "L'analyse de sentiment est un cas d'usage classique des LLMs. Vous allez créer une fonction qui prend un texte en entree et retourne une analyse structuree (positif/negatif/neutre + score).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Ecrire un template qui demande au LLM d'analyser le sentiment et de formater la reponse\n",
-    "- # Étape 2 : Specifier le format de sortie attendu dans le prompt (ex: \"SENTIMENT: positif | CONFIANCE: 0.8 | RAISON: ...\")\n",
-    "- # Étape 3 : Tester avec 3 textes de sentiments différents\n",
-    "- # Indice : Demander explicitement un format structure dans le prompt force le LLM a etre consistent"
+    "- `# Étape 1` : Ecrire un template qui demande au LLM d'analyser le sentiment et de formater la reponse\n",
+    "- `# Étape 2` : Specifier le format de sortie attendu dans le prompt (ex: \"SENTIMENT: positif | CONFIANCE: 0.8 | RAISON: ...\")\n",
+    "- `# Étape 3` : Tester avec 3 textes de sentiments différents\n",
+    "- `# Indice` : Demander explicitement un format structure dans le prompt force le LLM a etre consistent"
    ]
   },
   {
@@ -1018,10 +1018,10 @@
     "La `temperature` est le paramètre le plus important pour contrôler le comportement d'un LLM : 0 = déterministe, 1 = creatif, 2 = très aleatoire. Vous allez créer un générateur de titres et tester plusieurs valeurs de temperature.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer un template qui genere 3 propositions de titre pour un article donne\n",
-    "- # Étape 2 : Configurer les execution_settings avec `temperature` variable\n",
-    "- # Étape 3 : Tester avec temperature 0.0, 0.5 et 1.5 et comparer les résultats\n",
-    "- # Indice : `OpenAIChatPromptExecutionSettings(service_id=\"default\", temperature=0.0)` pour le contrôle"
+    "- `# Étape 1` : Créer un template qui genere 3 propositions de titre pour un article donne\n",
+    "- `# Étape 2` : Configurer les execution_settings avec `temperature` variable\n",
+    "- `# Étape 3` : Tester avec temperature 0.0, 0.5 et 1.5 et comparer les résultats\n",
+    "- `# Indice` : `OpenAIChatPromptExecutionSettings(service_id=\"default\", temperature=0.0)` pour le contrôle"
    ]
   },
   {
@@ -1351,10 +1351,10 @@
     "Vous avez vu comment créer des fonctions sémantiques inline (TLDR) et comment passer des arguments dynamiques (KernelArguments). Vous allez maintenant combiner ces deux concepts pour créer un traducteur configurable.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir un template avec deux variables `{{$input}}` (texte) et `{{$language}}` (langue cible)\n",
-    "- # Étape 2 : Configurer `PromptTemplateConfig` avec les InputVariable correspondants\n",
-    "- # Étape 3 : Invoquer la fonction avec différentes langues cibles (espagnol, allemand, japonais)\n",
-    "- # Indice : Inspirez-vous du template TLDR mais ajoutez la variable `{{$language}}`"
+    "- `# Étape 1` : Définir un template avec deux variables `{{$input}}` (texte) et `{{$language}}` (langue cible)\n",
+    "- `# Étape 2` : Configurer `PromptTemplateConfig` avec les InputVariable correspondants\n",
+    "- `# Étape 3` : Invoquer la fonction avec différentes langues cibles (espagnol, allemand, japonais)\n",
+    "- `# Indice` : Inspirez-vous du template TLDR mais ajoutez la variable `{{$language}}`"
    ]
   },
   {
@@ -1567,8 +1567,8 @@
    "end_time": "2026-06-07T19:21:26.017551",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb",
-   "output_path": "MyIA.AI.Notebooks/GenAI/SemanticKernel/01-SemanticKernel-Intro.ipynb",
+   "input_path": "01-SemanticKernel-Intro.ipynb",
+   "output_path": "01-SemanticKernel-Intro.ipynb",
    "parameters": {},
    "start_time": "2026-06-07T19:20:27.284953",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/02-SemanticKernel-Advanced.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/02-SemanticKernel-Advanced.ipynb
@@ -488,10 +488,10 @@
     "Le chat basique avec `ChatHistory` accumule tous les messages indefiniment. En production, il faut tronquer l'historique quand il devient trop long, tout en preservant le message système.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer une fonction `trim_history(history, max_messages)` qui garde le message système + N derniers echanges\n",
-    "- # Étape 2 : Compter les messages et verifier si `len(history.messages) > max_messages`\n",
-    "- # Étape 3 : Reconstruire un nouvel historique avec le system message + les messages recents\n",
-    "- # Indice : Le message système est toujours `history.messages[0]` (ou filtrer par rôle `AuthorRole.SYSTEM`)"
+    "- `# Étape 1` : Créer une fonction `trim_history(history, max_messages)` qui garde le message système + N derniers echanges\n",
+    "- `# Étape 2` : Compter les messages et verifier si `len(history.messages) > max_messages`\n",
+    "- `# Étape 3` : Reconstruire un nouvel historique avec le system message + les messages recents\n",
+    "- `# Indice` : Le message système est toujours `history.messages[0]` (ou filtrer par rôle `AuthorRole.SYSTEM`)"
    ]
   },
   {
@@ -945,10 +945,10 @@
     "Le Function Calling automatique est puissant quand les plugins offrent des fonctions bien decrites avec des types précis. Vous allez créer un plugin que le LLM pourra appeler automatiquement pour convertir des unites dans une conversation.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer deux fonctions `celsius_to_fahrenheit` et `km_to_miles` avec `@kernel_function`\n",
-    "- # Étape 2 : Ajouter des descriptions claires et des annotations de type pour les paramètres\n",
-    "- # Étape 3 : Tester avec une requête naturelle comme \"Combien font 37 degrés Celsius en Fahrenheit ?\"\n",
-    "- # Indice : `F = C * 9/5 + 32` et `miles = km * 0.621371`"
+    "- `# Étape 1` : Créer deux fonctions `celsius_to_fahrenheit` et `km_to_miles` avec `@kernel_function`\n",
+    "- `# Étape 2` : Ajouter des descriptions claires et des annotations de type pour les paramètres\n",
+    "- `# Étape 3` : Tester avec une requête naturelle comme \"Combien font 37 degrés Celsius en Fahrenheit ?\"\n",
+    "- `# Indice` : `F = C * 9/5 + 32` et `miles = km * 0.621371`"
    ]
   },
   {
@@ -1773,10 +1773,10 @@
     "Quand on genere plusieurs reponses, il est utile de mesurer leur diversite (pour eviter des reponses trop similaires) et de sélectionner automatiquement la meilleure (la plus longue, la plus diverse, etc.).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Extraire les mots uniques de chaque reponse avec `set(response.split())`\n",
-    "- # Étape 2 : Calculer le coefficient de Jaccard entre chaque paire de reponses (intersection / union)\n",
-    "- # Étape 3 : Sélectionner la reponse avec le plus grand vocabulaire unique\n",
-    "- # Indice : `len(set1 & set2) / len(set1 | set2)` donne le score de Jaccard"
+    "- `# Étape 1` : Extraire les mots uniques de chaque reponse avec `set(response.split())`\n",
+    "- `# Étape 2` : Calculer le coefficient de Jaccard entre chaque paire de reponses (intersection / union)\n",
+    "- `# Étape 3` : Sélectionner la reponse avec le plus grand vocabulaire unique\n",
+    "- `# Indice` : `len(set1 & set2) / len(set1 | set2)` donne le score de Jaccard"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb
@@ -276,10 +276,10 @@
     "L'agent Parrot utilise des instructions fixees en dur. En production, on veut généralement créer des agents dynamiquement avec différentes personnalites (support client, expert technique, tuteur, etc.) sans dupliquer le code.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir `create_personality_agent(name, personality, domain)` qui retourne un agent configure\n",
-    "- # Étape 2 : Configurer le Kernel et le service dans la fonction (ou les recevoir en paramètre)\n",
-    "- # Étape 3 : Tester avec 3 personnalites : \"formel\", \"humoristique\", \"pedagogique\"\n",
-    "- # Indice : Injecter la personnalite dans les `instructions` de l'agent"
+    "- `# Étape 1` : Définir `create_personality_agent(name, personality, domain)` qui retourne un agent configure\n",
+    "- `# Étape 2` : Configurer le Kernel et le service dans la fonction (ou les recevoir en paramètre)\n",
+    "- `# Étape 3` : Tester avec 3 personnalites : \"formel\", \"humoristique\", \"pedagogique\"\n",
+    "- `# Indice` : Injecter la personnalite dans les `instructions` de l'agent"
    ]
   },
   {
@@ -1015,10 +1015,10 @@
     "L'exercice precede demontre comment le MenuPlugin est appele automatiquement. Vous allez reproduire ce pattern avec un plugin de recherche qui simule des résultats pour un agent \"Researcher\".\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer une classe `ResearchPlugin` avec une méthode `search` decoree de `@kernel_function`\n",
-    "- # Étape 2 : Ajouter le plugin au kernel et configurer `FunctionChoiceBehavior.Auto()`\n",
-    "- # Étape 3 : Créer un agent `ChatCompletionAgent` avec ce kernel et tester une question de recherche\n",
-    "- # Indice : Simulez les résultats avec un dictionnaire `{sujet: \"Résultats simules pour...\"}`"
+    "- `# Étape 1` : Créer une classe `ResearchPlugin` avec une méthode `search` decoree de `@kernel_function`\n",
+    "- `# Étape 2` : Ajouter le plugin au kernel et configurer `FunctionChoiceBehavior.Auto()`\n",
+    "- `# Étape 3` : Créer un agent `ChatCompletionAgent` avec ce kernel et tester une question de recherche\n",
+    "- `# Indice` : Simulez les résultats avec un dictionnaire `{sujet: \"Résultats simules pour...\"}`"
    ]
   },
   {
@@ -1436,10 +1436,10 @@
     "La `ApprovalTerminationStrategy` utilisee precedemment est basique et peut echouer si le mot exact n'apparait pas. Vous allez créer une version plus robuste qui supporte plusieurs mots-cles et insensibilite a la casse.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Heriter de `TerminationStrategy` et implementer `should_agent_terminate`\n",
-    "- # Étape 2 : Verifier si le dernier message contient l'un des mots-cles (case-insensitive)\n",
-    "- # Étape 3 : Limiter la verification aux agents specifies dans `agents` (comme ApprovalTerminationStrategy)\n",
-    "- # Indice : `any(kw in history[-1].content.lower() for kw in self.keywords)`"
+    "- `# Étape 1` : Heriter de `TerminationStrategy` et implementer `should_agent_terminate`\n",
+    "- `# Étape 2` : Verifier si le dernier message contient l'un des mots-cles (case-insensitive)\n",
+    "- `# Étape 3` : Limiter la verification aux agents specifies dans `agents` (comme ApprovalTerminationStrategy)\n",
+    "- `# Indice` : `any(kw in history[-1].content.lower() for kw in self.keywords)`"
    ]
   },
   {
@@ -1933,8 +1933,8 @@
    "end_time": "2026-08-17T04:00:17.558585",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:/Dev/CoursIA-11112-cs/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb",
-   "output_path": "D:/Dev/CoursIA-11112-cs/MyIA.AI.Notebooks/GenAI/SemanticKernel/03-SemanticKernel-Agents.ipynb",
+   "input_path": "03-SemanticKernel-Agents.ipynb",
+   "output_path": "03-SemanticKernel-Agents.ipynb",
    "parameters": {},
    "start_time": "2026-08-17T03:59:54.193284",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb
@@ -310,10 +310,10 @@
     "En production, il est essentiel de proteger les APIs externes contre les appels excessifs. Vous allez créer un filtre qui bloque les appels si le nombre d'invocations depasse un seuil configurable dans les N dernières secondes.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Maintenir une liste `call_timestamps = []` avec les horodatages de chaque appel\n",
-    "- # Étape 2 : Avant chaque appel, filtrer les timestamps plus anciens que la fenêtre (ex: 60s)\n",
-    "- # Étape 3 : Si le nombre de timestamps restants depasse la limite, lever une exception\n",
-    "- # Indice : `time.time()` retourne le timestamp actuel en secondes"
+    "- `# Étape 1` : Maintenir une liste `call_timestamps = []` avec les horodatages de chaque appel\n",
+    "- `# Étape 2` : Avant chaque appel, filtrer les timestamps plus anciens que la fenêtre (ex: 60s)\n",
+    "- `# Étape 3` : Si le nombre de timestamps restants depasse la limite, lever une exception\n",
+    "- `# Indice` : `time.time()` retourne le timestamp actuel en secondes"
    ]
   },
   {
@@ -523,10 +523,10 @@
     "Le caching est un pattern fondamental en production : si une fonction pure (comme une addition) est appelee plusieurs fois avec les mêmes arguments, on retourne le résultat en cache au lieu de re-executer. Ce principe s'applique aussi aux appels LLM couteux.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer un dictionnaire global `cache = {}` pour stocker les résultats\n",
-    "- # Étape 2 : Construire une cle de cache unique a partir du nom de fonction et des arguments\n",
-    "- # Étape 3 : Si la cle existe dans le cache, définir `context.result` et retourner (sans appeler `next`)\n",
-    "- # Indice : `f\"{context.function.plugin_name}.{context.function.name}:{sorted(context.arguments.items())}\"` pour la cle"
+    "- `# Étape 1` : Créer un dictionnaire global `cache = {}` pour stocker les résultats\n",
+    "- `# Étape 2` : Construire une cle de cache unique a partir du nom de fonction et des arguments\n",
+    "- `# Étape 3` : Si la cle existe dans le cache, définir `context.result` et retourner (sans appeler `next`)\n",
+    "- `# Indice` : `f\"{context.function.plugin_name}.{context.function.name}:{sorted(context.arguments.items())}\"` pour la cle"
    ]
   },
   {
@@ -754,10 +754,10 @@
     "En production, il est crucial d'empêcher les données personnelles (PII) d'atteindre les services LLM externes. Vous allez implementer un filtre qui remplace les patterns sensibles par des masques avant l'appel API.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Utiliser des expressions regulieres (module `re`) pour detecter emails et telephones\n",
-    "- # Étape 2 : Remplacer les patterns detectes par `[EMAIL_CACHE]` et `[TEL_CACHE]`\n",
-    "- # Étape 3 : Appliquer le filtre sur `context.rendered_prompt` après le rendu du template\n",
-    "- # Indice : `re.sub(r'[\\w.+-]+@[\\w-]+\\.[\\w.]+', '[EMAIL_CACHE]', text)` pour les emails"
+    "- `# Étape 1` : Utiliser des expressions regulieres (module `re`) pour detecter emails et telephones\n",
+    "- `# Étape 2` : Remplacer les patterns detectes par `[EMAIL_CACHE]` et `[TEL_CACHE]`\n",
+    "- `# Étape 3` : Appliquer le filtre sur `context.rendered_prompt` après le rendu du template\n",
+    "- `# Indice` : `re.sub(r'[\\w.+-]+@[\\w-]+\\.[\\w.]+', '[EMAIL_CACHE]', text)` pour les emails"
    ]
   },
   {
@@ -1846,8 +1846,8 @@
    "end_time": "2026-08-17T03:53:52.123615",
    "environment_variables": {},
    "exception": null,
-   "input_path": "D:/Dev/CoursIA-11112-cs/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb",
-   "output_path": "D:/Dev/CoursIA-11112-cs/MyIA.AI.Notebooks/GenAI/SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb",
+   "input_path": "04-SemanticKernel-Filters-Observability.ipynb",
+   "output_path": "04-SemanticKernel-Filters-Observability.ipynb",
    "parameters": {},
    "start_time": "2026-08-17T03:53:28.856378",
    "version": "2.6.0"

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/05-SemanticKernel-VectorStores.ipynb
@@ -369,10 +369,10 @@
     "La similarite cosinus est la metrique fondamentale pour evaluer la proximite sémantique entre textes dans un vector store. Comprendre cette metrique est essentiel pour debugger les résultats de recherche vectorielle.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Implementer le produit scalaire (sum(a[i] * b[i]))\n",
-    "- # Étape 2 : Calculer les normes L2 de chaque vecteur (sqrt(sum(x^2)))\n",
-    "- # Étape 3 : Diviser le produit scalaire par le produit des normes\n",
-    "- # Indice : Les vecteurs OpenAI sont déjà normalises, donc le produit scalaire seul suffit"
+    "- `# Étape 1` : Implementer le produit scalaire (sum(a[i] * b[i]))\n",
+    "- `# Étape 2` : Calculer les normes L2 de chaque vecteur (sqrt(sum(x^2)))\n",
+    "- `# Étape 3` : Diviser le produit scalaire par le produit des normes\n",
+    "- `# Indice` : Les vecteurs OpenAI sont déjà normalises, donc le produit scalaire seul suffit"
    ]
   },
   {
@@ -613,10 +613,10 @@
     "Le schema `DocumentRecord` utilise precedemment est minimal. En production, les records vectoriels contiennent des metadonnees riches pour filtrer les recherches (par date, auteur, domaine).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Ajouter des champs DATA pour auteur (str), annee (int) et domaine (str)\n",
-    "- # Étape 2 : Créer la collection avec ce nouveau schema\n",
-    "- # Étape 3 : Inserer 2-3 records d'exemple avec ces metadonnees\n",
-    "- # Indice : Chaque champ DATA supplementaire necessite une annotation `VectorStoreField(field_type=FieldTypes.DATA)`"
+    "- `# Étape 1` : Ajouter des champs DATA pour auteur (str), annee (int) et domaine (str)\n",
+    "- `# Étape 2` : Créer la collection avec ce nouveau schema\n",
+    "- `# Étape 3` : Inserer 2-3 records d'exemple avec ces metadonnees\n",
+    "- `# Indice` : Chaque champ DATA supplementaire necessite une annotation `VectorStoreField(field_type=FieldTypes.DATA)`"
    ]
   },
   {
@@ -1375,10 +1375,10 @@
     "Dans un système RAG en production, il est crucial de mesurer si la reponse du LLM est effectivement ancre dans le contexte fourni. Vous allez créer une fonction `evaluate_rag_response` qui compare la reponse avec les documents sources.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Comparer les mots-cles de la reponse avec ceux du contexte\n",
-    "- # Étape 2 : Calculer un score de couverture (fraction des documents sources utilises)\n",
-    "- # Étape 3 : Detecter les informations de la reponse absentes du contexte\n",
-    "- # Indice : Utilisez des ensembles de mots (set) pour la comparaison lexicale"
+    "- `# Étape 1` : Comparer les mots-cles de la reponse avec ceux du contexte\n",
+    "- `# Étape 2` : Calculer un score de couverture (fraction des documents sources utilises)\n",
+    "- `# Étape 3` : Detecter les informations de la reponse absentes du contexte\n",
+    "- `# Indice` : Utilisez des ensembles de mots (set) pour la comparaison lexicale"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/06-SemanticKernel-ProcessFramework.ipynb
@@ -424,10 +424,10 @@
     "**Objectif** : Implementer une fonction `translate_content_step()` qui traduit le contenu genere vers une langue cible.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Ajouter un champ `translated_content` et `target_language` au `ContentState`\n",
-    "- # Étape 2 : Utiliser le service LLM pour traduire `draft_content` vers la langue cible\n",
-    "- # Étape 3 : Adapter le pipeline pour generer, traduire, puis reviewer la traduction\n",
-    "- # Indice : Specifier explicitement le contexte de traduction dans le prompt (\"traduis en anglais en preservant le ton et le style\")"
+    "- `# Étape 1` : Ajouter un champ `translated_content` et `target_language` au `ContentState`\n",
+    "- `# Étape 2` : Utiliser le service LLM pour traduire `draft_content` vers la langue cible\n",
+    "- `# Étape 3` : Adapter le pipeline pour generer, traduire, puis reviewer la traduction\n",
+    "- `# Indice` : Specifier explicitement le contexte de traduction dans le prompt (\"traduis en anglais en preservant le ton et le style\")"
    ]
   },
   {
@@ -803,10 +803,10 @@
     "**Objectif** : Implementer une classe `PipelineMetrics` qui collecte les metriques d'exécution d'un workflow.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Enregistrer le temps de debut et fin de chaque step avec `time.time()`\n",
-    "- # Étape 2 : Compter les appels LLM et estimer le cout (GPT-4o: ~$2.50/1M input tokens)\n",
-    "- # Étape 3 : Produire un rapport avec le temps total, le taux de succes par step et le cout estime\n",
-    "- # Indice : Utiliser un decorator ou un contexte (`__enter__`/`__exit__`) pour mesurer automatiquement chaque step"
+    "- `# Étape 1` : Enregistrer le temps de debut et fin de chaque step avec `time.time()`\n",
+    "- `# Étape 2` : Compter les appels LLM et estimer le cout (GPT-4o: ~$2.50/1M input tokens)\n",
+    "- `# Étape 3` : Produire un rapport avec le temps total, le taux de succes par step et le cout estime\n",
+    "- `# Indice` : Utiliser un decorator ou un contexte (`__enter__`/`__exit__`) pour mesurer automatiquement chaque step"
    ]
   },
   {
@@ -1045,10 +1045,10 @@
     "**Objectif** : Implementer une classe `WorkflowBuilder` qui permet de construire un pipeline dynamiquement.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer une classe avec une méthode `add_step(name, function)` et `add_condition(step_name, condition_fn)`\n",
-    "- # Étape 2 : Implementer `run(initial_state)` qui execute les steps en sequence, en verifiant les conditions\n",
-    "- # Étape 3 : Ajouter une méthode `get_execution_plan()` qui retourne l'ordre d'exécution prevu\n",
-    "- # Indice : Stocker les steps dans une liste ordonnee et les conditions dans un dict indexe par nom de step"
+    "- `# Étape 1` : Créer une classe avec une méthode `add_step(name, function)` et `add_condition(step_name, condition_fn)`\n",
+    "- `# Étape 2` : Implementer `run(initial_state)` qui execute les steps en sequence, en verifiant les conditions\n",
+    "- `# Étape 3` : Ajouter une méthode `get_execution_plan()` qui retourne l'ordre d'exécution prevu\n",
+    "- `# Indice` : Stocker les steps dans une liste ordonnee et les conditions dans un dict indexe par nom de step"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/07-SemanticKernel-MultiModal.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/07-SemanticKernel-MultiModal.ipynb
@@ -1732,18 +1732,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.13.3"
-  },
-  "papermill": {
-   "default_parameters": {},
-   "duration": 101.4659,
-   "end_time": "2026-08-17T04:14:47.775480",
-   "environment_variables": {},
-   "exception": null,
-   "input_path": "07-SemanticKernel-MultiModal.ipynb",
-   "output_path": "07-SemanticKernel-MultiModal.ipynb",
-   "parameters": {},
-   "start_time": "2026-08-17T04:13:06.309580",
-   "version": "2.6.0"
   }
  },
  "nbformat": 4,

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/07-SemanticKernel-MultiModal.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/07-SemanticKernel-MultiModal.ipynb
@@ -305,10 +305,10 @@
     "**Objectif** : Implementer une fonction `build_dalle_prompt()` qui construit un prompt optimise pour la generation d'images.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Accepter en entree un sujet, un style artistique, et un format (carre, paysage, portrait)\n",
-    "- # Étape 2 : Structurer le prompt avec les éléments cles : sujet principal, arriere-plan, eclairage, style artistique\n",
-    "- # Étape 3 : Ajouter des mots-cles de qualite (\"highly detailed\", \"professional photography\") selon le style\n",
-    "- # Indice : Les prompts DALL-E 3 efficaces font généralement 50-100 mots et specifient le medium (photographie, aquarelle, 3D render)"
+    "- `# Étape 1` : Accepter en entree un sujet, un style artistique, et un format (carre, paysage, portrait)\n",
+    "- `# Étape 2` : Structurer le prompt avec les éléments cles : sujet principal, arriere-plan, eclairage, style artistique\n",
+    "- `# Étape 3` : Ajouter des mots-cles de qualite (\"highly detailed\", \"professional photography\") selon le style\n",
+    "- `# Indice` : Les prompts DALL-E 3 efficaces font généralement 50-100 mots et specifient le medium (photographie, aquarelle, 3D render)"
    ]
   },
   {
@@ -402,7 +402,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_31172\\3092659129.py:12: DeprecationWarning: generate_image is deprecated. Use generate_images.\n",
+      "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\3092659129.py:12: DeprecationWarning: generate_image is deprecated. Use generate_images.\n",
       "  image_result = await dalle_service.generate_image(\n"
      ]
     },
@@ -821,7 +821,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Audio cree: C:\\Users\\jsboi\\AppData\\Local\\Temp\\test_audio.mp3\n",
+      "Audio cree: <USER_PATH>\\AppData\\Local\\Temp\\test_audio.mp3\n",
       "Texte original: Bonjour, ceci est un test de transcription audio avec Whisper.\n"
      ]
     },
@@ -1039,7 +1039,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Audio genere: C:\\Users\\jsboi\\AppData\\Local\\Temp\\output_speech.mp3\n",
+      "Audio genere: <USER_PATH>\\AppData\\Local\\Temp\\output_speech.mp3\n",
       "Taille: 93312 bytes\n"
      ]
     },
@@ -1113,10 +1113,10 @@
     "**Objectif** : Implementer une fonction `estimate_multimodal_cost()` qui calcule le cout estime d'une opération multi-modale.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir les tarifs de chaque service (DALL-E: $0.04/image, Whisper: $0.006/min, TTS: $15/1M chars, GPT-4o: $2.50/1M tokens)\n",
-    "- # Étape 2 : Estimer la duree audio a partir de la taille du texte (environ 150 mots/minute)\n",
-    "- # Étape 3 : Calculer le cout total pour un pipeline complet et retourner un breakdown par service\n",
-    "- # Indice : Un token correspond environ a 4 caractères en anglais, 2-3 caractères en francais"
+    "- `# Étape 1` : Définir les tarifs de chaque service (DALL-E: $0.04/image, Whisper: $0.006/min, TTS: $15/1M chars, GPT-4o: $2.50/1M tokens)\n",
+    "- `# Étape 2` : Estimer la duree audio a partir de la taille du texte (environ 150 mots/minute)\n",
+    "- `# Étape 3` : Calculer le cout total pour un pipeline complet et retourner un breakdown par service\n",
+    "- `# Indice` : Un token correspond environ a 4 caractères en anglais, 2-3 caractères en francais"
    ]
   },
   {
@@ -1297,7 +1297,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "C:\\Users\\jsboi\\AppData\\Local\\Temp\\ipykernel_31172\\2780968288.py:32: DeprecationWarning: generate_image is deprecated. Use generate_images.\n",
+      "<USER_PATH>\\AppData\\Local\\Temp\\ipykernel_<pid>\\2780968288.py:32: DeprecationWarning: generate_image is deprecated. Use generate_images.\n",
       "  image_url = await dalle.generate_image(\n"
      ]
     },
@@ -1439,10 +1439,10 @@
     "**Objectif** : Implementer une fonction `resilient_multimodal_pipeline()` avec retry logic et cache.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Encapsuler chaque étape dans un try/except avec retry (max 3 tentatives)\n",
-    "- # Étape 2 : Maintenir un dict `_cache` pour eviter de regenerer les mêmes résultats\n",
-    "- # Étape 3 : Retourner un rapport detaillant quelles étapes ont reussi/echoue et le cout estime\n",
-    "- # Indice : Utiliser `asyncio.sleep()` entre les retries pour respecter les rate limits"
+    "- `# Étape 1` : Encapsuler chaque étape dans un try/except avec retry (max 3 tentatives)\n",
+    "- `# Étape 2` : Maintenir un dict `_cache` pour eviter de regenerer les mêmes résultats\n",
+    "- `# Étape 3` : Retourner un rapport detaillant quelles étapes ont reussi/echoue et le cout estime\n",
+    "- `# Indice` : Utiliser `asyncio.sleep()` entre les retries pour respecter les rate limits"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/08-SemanticKernel-MCP.ipynb
@@ -399,10 +399,10 @@
     "**Objectif** : Implementer une fonction `categorize_mcp_servers()` qui classe les serveurs par domaine d'expertise et capacite.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Parcourir la liste des serveurs et extraire le domaine a partir du nom et de la description\n",
-    "- # Étape 2 : Compter le nombre d'outils par serveur et identifier les doublons potentiels\n",
-    "- # Étape 3 : Retourner un dict avec les catégories (storage, devops, web, data) et les serveurs associes\n",
-    "- # Indice : Les mots-cles dans la description indiquent le domaine (\"fichiers\" = storage, \"GitHub\" = devops, \"scraping\" = web, \"SQL\" = data)"
+    "- `# Étape 1` : Parcourir la liste des serveurs et extraire le domaine a partir du nom et de la description\n",
+    "- `# Étape 2` : Compter le nombre d'outils par serveur et identifier les doublons potentiels\n",
+    "- `# Étape 3` : Retourner un dict avec les catégories (storage, devops, web, data) et les serveurs associes\n",
+    "- `# Indice` : Les mots-cles dans la description indiquent le domaine (\"fichiers\" = storage, \"GitHub\" = devops, \"scraping\" = web, \"SQL\" = data)"
    ]
   },
   {
@@ -808,10 +808,10 @@
     "**Objectif** : Implementer un plugin `ValidatedFilesystemPlugin` qui ajoute une couche de validation aux opérations fichier.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Verifier que les chemins demandes restent dans le repertoire autorise (securite path traversal)\n",
-    "- # Étape 2 : Limiter la taille des fichiers lisibles et ecrits\n",
-    "- # Étape 3 : Utiliser `os.path.realpath()` et comparer avec le `root_path` pour la securite\n",
-    "- # Indice : Une tentative de path traversal comme `../../etc/passwd` doit etre detectee et rejetee"
+    "- `# Étape 1` : Verifier que les chemins demandes restent dans le repertoire autorise (securite path traversal)\n",
+    "- `# Étape 2` : Limiter la taille des fichiers lisibles et ecrits\n",
+    "- `# Étape 3` : Utiliser `os.path.realpath()` et comparer avec le `root_path` pour la securite\n",
+    "- `# Indice` : Une tentative de path traversal comme `../../etc/passwd` doit etre detectee et rejetee"
    ]
   },
   {
@@ -1028,10 +1028,10 @@
     "**Objectif** : Implementer un plugin `DirectoryAnalyzerPlugin` qui combine analyse de fichiers et statistiques.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer une classe avec des méthodes `count_files_by_extension()` et `get_directory_tree()`\n",
-    "- # Étape 2 : Utiliser `os.walk()` pour parcourir recursivement les sous-repertoires\n",
-    "- # Étape 3 : Decorater chaque méthode avec `@kernel_function` pour l'integration SK\n",
-    "- # Indice : Retourner les résultats sous forme de JSON string pour que le LLM puisse les interpreter"
+    "- `# Étape 1` : Créer une classe avec des méthodes `count_files_by_extension()` et `get_directory_tree()`\n",
+    "- `# Étape 2` : Utiliser `os.walk()` pour parcourir recursivement les sous-repertoires\n",
+    "- `# Étape 3` : Decorater chaque méthode avec `@kernel_function` pour l'integration SK\n",
+    "- `# Indice` : Retourner les résultats sous forme de JSON string pour que le LLM puisse les interpreter"
    ]
   },
   {


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2023:CoursIA-2 — prev: MED/notebook-python #12139

**Périmètre : 8 fichiers** — `GenAI/SemanticKernel/01..08` (claim paths-scoped posé sur #12128, issuecomment-5370003453)

See #12128

## Summary

Tranche **F1** (solde) de la remédiation `heading_in_list` : le marqueur `- # Étape N :` / `- # Indice :` au début d'une puce rend un `<h1>` 29 px **dans** le `<li>`. Remède prescrit : backtiquer le marqueur → `` - `# Étape N` : ``.

**Contexte du pivot** : le dispatch ai-01 (msg-20260821T123205) désignait la tranche A `GenAI/Audio/**` (239 occ / 23 notebooks) — mais celle-ci était **déjà livrée** par PR #12131 (po-2026, OPEN, chiffres identiques) avant l'envoi du steer ; la tranche D (Probas) a été claimée par po-2026:CoursIA à 12:37Z et la tranche E (QuantConnect) livrée par #12141 à 12:42Z. Tranches A-E couvertes → je prends le premier bloc libre du solde : **SemanticKernel 01-08**.

## Dénombrement

| Mesure | Valeur |
|---|---|
| Occurrences corrigées | **96** (scan avant : 96 → après : **0**, `fix_hint_headings --scan`) |
| Notebooks | 8 (01-Intro, 02-Advanced, 03-Agents, 04-Filters-Observability, 05-VectorStores, 06-ProcessFramework, 07-MultiModal, 08-MCP) |
| Diff | +212/−189 |
| Exclusions volontaires | `10b-…batch-parameterized.ipynb` (touché par PR #12125 ai-01) ; solde SemanticKernel (09, 10, 10a, divers) laissé pour F2 |

## Acceptance (4 points prescrits par ai-01)

1. **Compte avant/après** : 96 → 0 (`fix_hint_headings.py --scan` sur les 8 fichiers).
2. **Confirmation diff** : 96 lignes `` + `` `` - `# (Étape|Indice)` `` sur le diff ; churn = normalisation nbformat + LF.
3. **C.2 cellule-par-cellule** : snapshot pré-apply (sha1 source, `execution_count`, `n_outputs`) de chaque cellule code → post-apply **identique** — markdown-only, 0 re-exécution requise (H.3 Passed).
4. **Rendu de l'œil** : markdown-it 159 cellules markdown **CLEAN, 0 `<h1>` dans `<li>`** ; échantillon vérifié (01-Intro : `` - `# Étape 1` : Écrire un template… `` rend inline dans la puce).

## Bonus

- `07-MultiModal` : 4 lignes de banner .NET « Loading extensions from \<NuGet cache\> » (machine-username leak) strippées par le **hook officiel** `strip-dotnet-nuget-ext` au commit — normalisation tolérée (secrets-hygiene règle 6, même classe que `probeAddresses` strip).

## Validation

- Gate baseline `detect_markdown_rendering --check` : **OK sans fix compound** (aucune dette `yaml_block` pré-existante sur ces cellules — contrairement aux tranches A/B).
- Pre-commit : gitleaks, probeAddresses, nuget-ext, papermill-path, markdown-rendering, source-list-newlines, H.3 — **tous Passed** (commit `f538a788a`).
- Catalogue byte-identique à main ; 0 workflow, 0 baseline touchés.

## Résiduel (tranches restantes sur #12128)

- **F2** : SemanticKernel solde (09, 10, 10a, AutoInteractive, NotebookMaker divers, fort-boyard ×2, Créateur de mail, Notebook-Generated ; 10b après merge #12125) ≈ 85 occ.
- **F3** : PostTraining (~60 occ / 8), Texte (~36 / 3), CaseStudies (~36 / 4), SymbolicAI Planners/Lean/SL (~40 / 7), ML (~15 / 2), Vibe-Coding (8 / 2).
- Fichiers `_output.ipynb` (2) à arbitrer (artefacts d'exécution trackés).

## Test plan

- [ ] ai-01 : review rendu GitHub (backticks dans les listes des 8 notebooks)
- [ ] ai-01 : merge
