### PR TITLE
fix(tooling,#12145): une lane dont le workspace contient un espace se bloque elle-meme

### DIFF
--- a/.github/workflows/slides-composition-advisory.yml
+++ b/.github/workflows/slides-composition-advisory.yml
@@ -16,8 +16,16 @@ name: Slides Composition Advisory
 #
 # ADVISORY, jamais bloquant sur les constats : les findings sortent en
 # ::warning file=,line= (annotations de PR), exit 0. Exit 1 uniquement sur
-# META-défaillance du gate lui-même (zéro deck découvert alors que slides/
-# a changé — un gate qui énumère zéro cible est vert et muet, #8807 trap 1).
+# META-défaillance du gate lui-même — trois causes, même classe (#8807 trap 1,
+# « un gate qui énumère zéro cible est vert et muet ») :
+#   (a) zéro deck découvert alors que slides/ a changé ;
+#   (b) binaire slidev introuvable — aucun deck n'est mesurable ;
+#   (c) deck découvert mais serveur jamais prêt — ce deck n'est PAS mesuré.
+# (b) et (c) sont ajoutées après coup (#12147) : le gate a rendu trois verts
+# les 20-21/08 sans mesurer une seule slide — chemin node_modules faux d'un
+# niveau, puis warning + continue + exit 0. Un vert qui n'a rien mesuré est
+# indiscernable d'un vert qui n'a rien trouvé : c'est ce que ces trois causes
+# séparent.
 #
 # Le contrôle positif (slide 5 S3-acculturation @ 6cabc826b DOIT être
 # signalée) vit côté tests locaux : run_composition_control.py — nécessite
@@ -119,6 +127,16 @@ jobs:
             exit 0
           fi
 
+          # Le binaire vit dans slides/node_modules : npm ci tourne avec
+          # working-directory: slides, et le cache porte sur slides/node_modules.
+          # Chemin ABSOLU -- un relatif depuis $DIR suppose une profondeur de deck
+          # que la branche `find` ci-dessus ne garantit pas.
+          SLIDEV_BIN="$PWD/slides/node_modules/.bin/slidev"
+          if [ ! -x "$SLIDEV_BIN" ]; then
+            echo "::error title=Composition gate meta-failure::binaire slidev introuvable a $SLIDEV_BIN -- aucun deck ne peut etre mesure"
+            exit 1
+          fi
+
           META_FAIL=0
           PORT=8890
           for MD in $MAPS; do
@@ -126,15 +144,22 @@ jobs:
             PORT=$((PORT+1))
             echo "### $MD" >> "$GITHUB_STEP_SUMMARY"
             cp "$MD" "$DIR/dev.md"
-            (cd "$DIR" && ../../node_modules/.bin/slidev dev.md --port "$PORT" --open false \
+            (cd "$DIR" && "$SLIDEV_BIN" dev.md --port "$PORT" --open false \
                > /tmp/slidev_$PORT.log 2>&1 &)
             for i in $(seq 1 40); do
               curl -sf "http://localhost:$PORT/" > /dev/null && break
               sleep 3
             done
             if ! curl -sf "http://localhost:$PORT/" > /dev/null; then
-              echo "::warning file=$MD::Serveur slidev jamais prêt — deck non mesuré (voir slides-build-advisory pour le build)"
-              echo "Serveur jamais prêt — non mesuré." >> "$GITHUB_STEP_SUMMARY"
+              # Un deck DECOUVERT mais NON MESURE est une meta-defaillance au meme
+              # titre que « zero deck decouvert » (#8807 trap 1) : dans les deux cas
+              # le gate est vert et muet, indiscernable d'un deck sain. Il rougit
+              # donc, et imprime sa cause au lieu de la laisser dans /tmp.
+              echo "::error title=Composition gate meta-failure::$MD decouvert mais serveur slidev jamais pret -- deck NON MESURE (le vert de ce job ne dirait rien de sa composition)"
+              echo "Serveur jamais pret -- deck NON MESURE (meta-defaillance)." >> "$GITHUB_STEP_SUMMARY"
+              echo "--- tail /tmp/slidev_$PORT.log ---"
+              tail -40 "/tmp/slidev_$PORT.log" 2>/dev/null || echo "(aucun log serveur)"
+              META_FAIL=1
               rm -f "$DIR/dev.md"; kill %1 2>/dev/null || true; continue
             fi
             python scripts/notebook_tools/scan_slidev_composition.py \
@@ -143,6 +168,13 @@ jobs:
               --github-annotations \
               --out "/tmp/report_$PORT.json" > /tmp/scan_$PORT.log 2>&1
             SCAN_EXIT=$?
+            # --github-annotations ecrit sur STDOUT ; la redirection ci-dessus les
+            # enterre dans /tmp, ou GitHub ne les lit jamais -- le gate mesurait
+            # sans jamais annoter. On les rejoue ici, ce que l'acceptance de #11923
+            # demande explicitement (« file=,line= exploitable en annotation CI »).
+            # grep APRES l'affectation de SCAN_EXIT : un pipe rendrait le statut du
+            # dernier maillon, pas celui du scanner.
+            grep -E '^::(warning|error) ' "/tmp/scan_$PORT.log" || true
             python - "$MD" "/tmp/report_$PORT.json" "$SCAN_EXIT" >> "$GITHUB_STEP_SUMMARY" <<'PYEOF'
           import json, sys
           md, rp, exit_code = sys.argv[1], sys.argv[2], int(sys.argv[3])
@@ -160,4 +192,10 @@ jobs:
             rm -f "$DIR/dev.md"
             kill %1 2>/dev/null || true
           done
+          # Les CONSTATS restent advisory (exit 0) : c'est la doctrine de ce gate.
+          # Seule la META-defaillance rougit -- un gate qui n'a PAS mesure doit se
+          # distinguer d'un gate qui a mesure et n'a rien trouve.
+          if [ "$META_FAIL" -ne 0 ]; then
+            exit 1
+          fi
           exit 0

--- a/scripts/grain_tag.py
+++ b/scripts/grain_tag.py
@@ -142,8 +142,32 @@ _GRAIN_FULL_RE = re.compile(
 # and `**Lane** :` (after `*` is stripped -> `Lane :`). The lane is structural
 # (the worker's workspace) and may sit anywhere in the body -- extracted
 # independently of the Grain line (#9485 point 4).
+# A workspace name MAY contain spaces (`myia-po-2025:Microsoft VS Code`, the
+# Mistral lane). Truncating at the first blank made that lane DIFFERENT FROM
+# ITSELF for `check_lane_claim`: it read `myia-po-2025:Microsoft` from the
+# lane's own claim, compared it to the untruncated `--lane`, and reported the
+# lane as blocked by itself (#12145). Continuation words are admitted under
+# three constraints, each of which is a false positive the pattern must NOT
+# produce:
+#   * `(?-i:[A-Z0-9])` -- a continuation starts with an upper-case letter or
+#     a digit. IGNORECASE is disabled LOCALLY, otherwise the flag would make
+#     that class match lower case and the pattern would swallow running prose
+#     ("lane myia-x:W and it works"). This is what separates a workspace name
+#     from a sentence.
+#   * `(?![A-Za-z0-9._-])` -- forces maximal munch on the word, so the
+#     `(?![:@])` that follows cannot be defeated by backtracking into it
+#     (`prev` would otherwise match as `pre` with a lookahead on `v`).
+#   * `{0,3}` -- bounds the reach. No cluster workspace needs more, and the
+#     bound keeps a malformed marker from eating a paragraph.
+# Dash annotations (" -- ", em dash, en dash) and parenthetical ones stop the
+# match by construction: none of their opening characters is in the
+# continuation class -- the same bounds `_extract_paths_clause` already uses
+# in check_lane_claim.py.
 _LANE_RE = re.compile(
-    r"lane\s*:?\s+([A-Za-z0-9._-]+:[A-Za-z0-9._-]+)", re.IGNORECASE
+    r"lane\s*:?\s+"
+    r"([A-Za-z0-9._-]+:[A-Za-z0-9._-]+"
+    r"(?:[ \t]+(?-i:[A-Z0-9])[A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})",
+    re.IGNORECASE,
 )
 
 # Fallback lane token for claim comments that omit the `lane` keyword (#10395
@@ -161,8 +185,14 @@ _LANE_RE = re.compile(
 # the search to the marker line -- URLs, time stamps and code tokens that
 # happen to contain a colon are NOT lane IDs. Token shape: `myia-<slug>:<ws>`
 # (lowercase, hyphens allowed) or any single-word `lower:Pascal` pair.
+# Same space tolerance as `_LANE_RE` -- the sibling has to move with it, or a
+# claim that omits the literal `lane` keyword keeps truncating. Fixing one
+# half of a duplicated mechanism and not grepping for the other is the
+# recurring shape of this class of bug (#12145). No IGNORECASE on this one,
+# so `[A-Z0-9]` already means upper case.
 _LANE_FALLBACK_RE = re.compile(
-    r"\b(myia-[A-Za-z0-9._-]+:[A-Za-z][A-Za-z0-9._-]*)\b"
+    r"\b(myia-[A-Za-z0-9._-]+:[A-Za-z][A-Za-z0-9._-]*"
+    r"(?:[ \t]+[A-Z0-9][A-Za-z0-9._-]*(?![A-Za-z0-9._-])(?![:@])){0,3})"
 )
 
 # `prev` (case-insensitive), optional colon, whitespace, then the SAME

--- a/scripts/tests/test_grain_tag.py
+++ b/scripts/tests/test_grain_tag.py
@@ -610,3 +610,75 @@ def test_grain_separator_forms_still_accepted_after_boundary_fix():
         assert g is not None, body
         assert g["tier"] == "LIGHT", body
         assert g["genre"] == "guard", body
+
+# --- workspace containing spaces (#12145) ----------------------------------
+#
+# `myia-po-2025:Microsoft VS Code` is a real cluster lane. Truncating it at the
+# first blank made it DIFFERENT FROM ITSELF in check_lane_claim: the lane read
+# `myia-po-2025:Microsoft` from its own [CLAIMED] comment, compared it to the
+# untruncated `--lane`, and reported itself as a blocking lane.
+#
+# Half of these cases are non-regressions and false-positive guards, not hits.
+# A pattern that admits spaces is validated by what it REFUSES to swallow --
+# a dash separator, an annotation key, running prose -- far more than by the
+# one string it was written for.
+
+def test_lane_workspace_with_spaces():
+    g = gt.extract_lane("[CLAIMED] lane myia-po-2025:Microsoft VS Code -- paths: a/**")
+    assert g == "myia-po-2025:Microsoft VS Code"
+
+
+def test_lane_workspace_with_spaces_no_annotation():
+    g = gt.extract_lane("[CLAIMED] lane myia-po-2025:Microsoft VS Code")
+    assert g == "myia-po-2025:Microsoft VS Code"
+
+
+def test_lane_workspace_with_spaces_paren_annotation():
+    # #12052 form: parenthetical annotation, space then opening paren.
+    g = gt.extract_lane("[CLAIMED] lane myia-po-2025:Microsoft VS Code (Phase 2)")
+    assert g == "myia-po-2025:Microsoft VS Code"
+
+
+def test_lane_hyphenated_workspace_unchanged():
+    # The non-regression that matters most: the hyphen inside `CoursIA-2` must
+    # stay part of the name, never be read as the start of an annotation.
+    g = gt.extract_lane("[CLAIMED] lane myia-po-2024:CoursIA-2 -- paths: b/**")
+    assert g == "myia-po-2024:CoursIA-2"
+
+
+def test_lane_stops_at_em_and_en_dash():
+    for dash in ("\u2014", "\u2013"):
+        g = gt.extract_lane("[CLAIMED] lane myia-x:W %s paths: c/**" % dash)
+        assert g == "myia-x:W", dash
+
+
+def test_lane_stops_at_plain_hyphen_separator():
+    # ` - ` is the separator several bodies use instead of an em dash. Admitting
+    # spaces must not make the lane eat it (the hyphen IS in the token class).
+    body = "Grain: MED/guard - lane myia-ai-01:CoursIA - prev: MED/tooling #12102"
+    assert gt.extract_lane(body) == "myia-ai-01:CoursIA"
+
+
+def test_lane_stops_before_lowercase_annotation_key():
+    assert gt.extract_lane("lane myia-ai-01:CoursIA prev: MED/guard #1") == "myia-ai-01:CoursIA"
+
+
+def test_lane_does_not_swallow_prose():
+    # The upper-case-initial constraint on continuation words is what keeps a
+    # sentence from becoming part of the lane name. Both languages, because the
+    # dashboards carry both.
+    assert gt.extract_lane("La lane myia-ai-01:CoursIA a livre trois PRs.") == "myia-ai-01:CoursIA"
+    assert gt.extract_lane("lane myia-x:W and it works fine") == "myia-x:W"
+
+
+def test_lane_fallback_twin_moves_with_the_primary(  ):
+    # #10395 fallback (marker line, no literal `lane` keyword). Fixing one half
+    # of a duplicated mechanism and not the other leaves the defect whole in the
+    # copy -- so the twin carries the same case.
+    line = "[CLAIMED] myia-po-2025:Microsoft VS Code -- paths: a/**"
+    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-po-2025:Microsoft VS Code"
+
+
+def test_lane_fallback_historical_form_unchanged():
+    line = "[CLAIMED] #9764 - myia-po-2025:CoursIA 2026-08-07T00:52Z"
+    assert gt.extract_lane("no lane keyword here", marker_line=line) == "myia-po-2025:CoursIA"


### PR DESCRIPTION
Grain: MED/tooling — lane myia-ai-01:CoursIA — prev: MED/guard #12150

## Le défaut

`grain_tag.extract_lane()` tronquait un nom de lane au premier blanc :

```
>>> extract_lane('[CLAIMED] lane myia-po-2025:Microsoft VS Code -- paths: a/**')
'myia-po-2025:Microsoft'
```

La lane Mistral était donc **différente d'elle-même** aux yeux de
`check_lane_claim.py`, qui compare la valeur passée en `--lane` (non tronquée)
au nom lu dans le commentaire (tronqué). Résultat sur une lane qui avait
pourtant correctement posé sa claim :

```
my_lane        : "myia-po-2025:Microsoft VS Code"
my_active_claim: false
blocking_lanes : ["myia-po-2025:Microsoft"]      ← elle-même
```

Le protocole est **fail-CLOSED** par conception, donc le défaut se manifestait
du bon côté — personne ne mergeait par erreur. Mais il immobilisait une lane sur
son propre travail, et c'est la lane la plus récente du cluster, dont c'est la
première livraison.

## Le correctif

Le segment workspace admet des mots de continuation, sous **trois** contraintes.
Chacune est un faux positif que le motif ne doit pas produire :

| Contrainte | Ce qu'elle empêche |
|---|---|
| `(?-i:[A-Z0-9])` — la continuation commence par une majuscule ou un chiffre | `lane myia-x:W and it works` → le motif avalerait la phrase. **`IGNORECASE` est désactivé localement** : laissé global, le drapeau rendrait cette classe insensible à la casse et la contrainte serait vide |
| `(?![A-Za-z0-9._-])` — munch maximal sur le mot | `prev` matcherait comme `pre` + un lookahead sur `v`, ce qui défait le `(?![:@])` par retour arrière |
| `{0,3}` — portée bornée | un marqueur malformé avalerait un paragraphe |

Les annotations à tiret (` -- `, cadratin, demi-cadratin) et parenthétiques
arrêtent le motif **par construction** : aucun de leurs caractères d'ouverture
n'appartient à la classe de continuation. Mêmes bornes que celles que
`_extract_paths_clause` applique déjà à la clause `paths:` dans
`check_lane_claim.py`.

**Le jumeau bouge avec.** `_LANE_FALLBACK_RE` (#10395, pour les claims qui
omettent le mot-clé `lane`) reçoit la même tolérance. Corriger une moitié d'un
mécanisme dupliqué sans greper l'autre laisse le défaut entier dans la copie —
c'est la forme récurrente de cette classe de bug, et elle m'a déjà eu deux fois
(#11532 puis #11627, deux heures plus tard).

## Contrôles — 10 tests, dont 6 qui ne sont pas des hits

`253 passed` sur `test_grain_tag.py` + `test_check_lane_claim.py` +
`test_lane_claim_required.py`.

| Entrée | Attendu | Rôle |
|---|---|---|
| `lane myia-po-2025:Microsoft VS Code -- paths: a/**` | `…Microsoft VS Code` | le défaut lui-même |
| `lane myia-po-2025:Microsoft VS Code` | idem | sans clause |
| `lane myia-po-2025:Microsoft VS Code (Phase 2)` | idem | annotation parenthétique (#12052) |
| **`lane myia-po-2024:CoursIA-2 -- paths: b/**`** | **`myia-po-2024:CoursIA-2`** | **le garde-fou qui compte** : le tiret reste dans le nom |
| `lane myia-x:W — paths: c/**` (et `–`) | `myia-x:W` | cadratin / demi-cadratin |
| `Grain: … - lane myia-ai-01:CoursIA - prev: …` | `myia-ai-01:CoursIA` | séparateur à tiret **simple** — le `-` est dans la classe, c'est le cas piégeux |
| `lane myia-ai-01:CoursIA prev: MED/guard #1` | `myia-ai-01:CoursIA` | clé d'annotation minuscule |
| `La lane myia-ai-01:CoursIA a livré trois PRs.` | `myia-ai-01:CoursIA` | prose française |
| `lane myia-x:W and it works fine` | `myia-x:W` | prose anglaise |
| `[CLAIMED] myia-po-2025:Microsoft VS Code -- paths:` (sans mot-clé) | `…Microsoft VS Code` | le jumeau fallback |
| `[CLAIMED] #9764 - myia-po-2025:CoursIA 2026-08-07T00:52Z` | `myia-po-2025:CoursIA` | non-régression fallback historique |

Un motif qui admet l'espace se valide par ce qu'il **refuse** d'avaler, bien
plus que par la chaîne pour laquelle il a été écrit.

## Vérification de bout en bout, sur l'issue réelle

```
$ python scripts/check_lane_claim.py 12110 --lane "myia-po-2025:Microsoft VS Code"
"my_active_claim": true
"blocking_lanes": []
"paths": ["MyIA.AI.Notebooks/QuantConnect/Python/QC-Py-21-*.ipynb"]
CLEAR: no other lane claims #12110 (resuming your own active claim).
```

Le contournement communiqué à la lane en attendant — « quand la lane bloquante
est un préfixe de la tienne, c'est toi-même, ignore le `BLOCKED` » — devient
inutile. Un contournement demande à chaque agent de se rappeler une exception,
ce qu'un organe est précisément là pour éviter.

## Portée

`grain_tag.extract_lane` est le **lecteur unique** de lane (#9485) : le tag
Grain, l'organe G-VAR-2 et le gate bloquant `lane-claim-guard.yml` passent tous
par lui. Ce correctif est donc sur le chemin par lequel toutes les lanes se
déconflictent — d'où la densité de non-régressions ci-dessus plutôt qu'un
raccourci glissé dans un cycle de merge.

Closes #12145
