### PR TITLE
fix(guard,#11962): re-piquer le baseline ASCII-flowchart 11->6 / 9->4 (rouge sur main)

### DIFF
--- a/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
+++ b/scripts/notebook_tools/tests/test_detect_ascii_flowchart.py
@@ -320,14 +320,18 @@ class TestUnreadableNotebookSkipped:
 
 # These values pin the corpus baseline measured c.259 on 2026-08-21 against
 # origin/main at SHA 4e9ffc5ad1 (post-PR #11918). Drift 13->11 findings /
-# 10->9 files since c.259 = the ASCII->Mermaid conversion PRs merged in
-# between (re-measured firsthand, see `--json` below): 2 findings on
-# QuantConnect/Python disappeared with #11998/#12010/#12011 conversions.
+# 11->6 findings / 9->4 files, re-mesure firsthand le 2026-08-21 : les PRs de
+# conversion ASCII->Mermaid mergees depuis ont resorbe 5 constats. Le pin
+# n'avait pas suivi, donc le test echouait sur `main` pour TOUTE PR touchant
+# des notebooks -- un cliquet qui rougit dans le bon sens reste un cliquet
+# casse tant qu'on ne le re-pique pas. Reste 6 constats sur 4 notebooks :
+# GenAI/Vibe-Coding/.../03-Claude-CLI-References (c21), QC-Py-14 (c80, x2),
+# QC-Py-17 (c43, x2), QC-Py-22 (c48).
 # Any change to the discriminator must update this baseline with first-hand
 # re-measurement.
 
-CORPUS_BASELINE_TOTAL = 11
-CORPUS_BASELINE_FILES_WITH = 9
+CORPUS_BASELINE_TOTAL = 6
+CORPUS_BASELINE_FILES_WITH = 4
 
 
 class TestCorpusBaseline:


### PR DESCRIPTION
Grain: LIGHT/guard — lane myia-ai-01:CoursIA — prev: LIGHT/tooling #12151

## Le defaut

`TestCorpusBaseline::test_corpus_baseline_pinned` echoue **sur `main`**, donc
sur toute PR touchant des notebooks. Verifie firsthand avant de toucher quoi
que ce soit :

```
git checkout main
python -m pytest scripts/notebook_tools/tests/test_detect_ascii_flowchart.py::TestCorpusBaseline -q
-> AssertionError: Corpus baseline drift: expected 11, got 6
```

Le corpus s'est **ameliore** : les PRs de conversion ASCII -> Mermaid mergees
depuis le pin ont resorbe 5 constats. Le pin n'a pas suivi.

Un cliquet qui rougit dans le bon sens reste un cliquet casse : tant qu'il
l'est, son rouge est **indiscernable** d'une vraie regression. Il a bloque
#12164 (compagnon Lean ERC-20) qui ne touche aucun des notebooks concernes.

## Re-mesure firsthand

```
python scripts/notebook_tools/detect_ascii_flowchart.py MyIA.AI.Notebooks --json
  total_findings       11 -> 6
  files_with_findings   9 -> 4
```

Les 6 constats restants sont **nommes dans le commentaire du pin** plutot que
laisses en chiffre nu — GenAI/Vibe-Coding/03-Claude-CLI-References (c21),
QC-Py-14 (c80, x2), QC-Py-17 (c43, x2), QC-Py-22 (c48). Un pin qui ne dit pas
ce qu'il epingle se re-perime en silence.

## Verification

`15 passed` sur le fichier de test complet, dont les 4 controles de faux
positifs (table markdown, boite unique, mermaid deja converti, markdown nu).

## Note de cap — exception ecrite (G-VAR-2)

Ce grain est **LIGHT/guard** et ma lane est au-dela de son plafond du jour
(`lane_grains=4`, `light_genre=3`, `cap=1` — mesure
`variation_light_cap.py --genre-signals`). Je le livre quand meme et je l'ecris
plutot que de le maquiller : il ne s'agit pas de piocher une veine facile mais
de retirer un rouge **repo-wide** rencontre en passe de merge, qui bloque des
PRs de contenu sans rapport. Le prochain grain de la lane sera DEEP/MED de
CONTENU (#12165, tranche par famille).

See #11962
