### PR TITLE
fix(genai,#12165): tranche PostTraining heading_in_list — 54 remèdes PT_01..PT_06

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_01_intro_post_training.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_01_intro_post_training.ipynb
@@ -396,9 +396,9 @@
     "**Objectif** : ecrire une fonction qui prend la taille du modèle (en millions de paramètres) et la technique, et retourne l'estimation VRAM en Go en tenant compte du modèle de base, des adapters LoRA et des modèles supplementaires.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Calculer la taille de base (paramètres * 2 bytes pour bf16)\n",
-    "- # Étape 2 : Appliquer le multiplicateur selon la technique (SFT=1x, RLHF=3.5x, DPO=1.4x, GRPO=1.8x, RLVR=1.6x)\n",
-    "- # Indice : ajouter 1 Go pour les activations et l'optimizer state"
+    "- `# Étape 1` : Calculer la taille de base (paramètres * 2 bytes pour bf16)\n",
+    "- `# Étape 2` : Appliquer le multiplicateur selon la technique (SFT=1x, RLHF=3.5x, DPO=1.4x, GRPO=1.8x, RLVR=1.6x)\n",
+    "- `# Indice` : ajouter 1 Go pour les activations et l'optimizer state"
    ]
   },
   {
@@ -592,9 +592,9 @@
     "**Objectif** : ecrire une fonction qui prend en entree le nombre de samples, la technique choisie, et le type de GPU, puis retourne une estimation du cout en GPU-heures et en heures d'annotation.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir les facteurs multiplicatifs par technique (cf tableau section 2)\n",
-    "- # Étape 2 : Calculer le GPU-h (base SFT = 0.1 GPU-h / 1000 samples) et l'annotation\n",
-    "- # Indice : les facteurs sont SFT=1x, DPO=1.6x, GRPO=3.2x, RLVR=3.0x pour le compute"
+    "- `# Étape 1` : Définir les facteurs multiplicatifs par technique (cf tableau section 2)\n",
+    "- `# Étape 2` : Calculer le GPU-h (base SFT = 0.1 GPU-h / 1000 samples) et l'annotation\n",
+    "- `# Indice` : les facteurs sont SFT=1x, DPO=1.6x, GRPO=3.2x, RLVR=3.0x pour le compute"
    ]
   },
   {
@@ -802,9 +802,9 @@
     "**Objectif** : ecrire une fonction qui implemente la logique de decision (reponses gold disponibles ? préférences disponibles ? tâches verifiables ?) et retourne le nom de la technique avec une justification.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir les paramètres (`has_gold_answers`, `has_preferences`, `has_verifiable_tasks`)\n",
-    "- # Étape 2 : Implementer les branchements conditionnels suivant l'arbre de decision\n",
-    "- # Indice : la fonction peut retourner un tuple `(technique, raison)`"
+    "- `# Étape 1` : Définir les paramètres (`has_gold_answers`, `has_preferences`, `has_verifiable_tasks`)\n",
+    "- `# Étape 2` : Implementer les branchements conditionnels suivant l'arbre de decision\n",
+    "- `# Indice` : la fonction peut retourner un tuple `(technique, raison)`"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_02_sft_baseline.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_02_sft_baseline.ipynb
@@ -408,9 +408,9 @@
     "**Objectif** : ecrire une fonction `filtrer_haute_qualite` qui prend le dataset et un seuil de score, et retourne un nouveau dataset ne contenant que les exemples dont le score `score_chosen` depasse le seuil.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Acceder au champ `score_chosen` de chaque exemple\n",
-    "- # Étape 2 : Utiliser la méthode `filter()` des datasets HuggingFace ou une list comprehension\n",
-    "- # Indice : afficher la distribution des scores avant/après filtrage pour verifier"
+    "- `# Étape 1` : Acceder au champ `score_chosen` de chaque exemple\n",
+    "- `# Étape 2` : Utiliser la méthode `filter()` des datasets HuggingFace ou une list comprehension\n",
+    "- `# Indice` : afficher la distribution des scores avant/après filtrage pour verifier"
    ]
   },
   {
@@ -828,9 +828,9 @@
     "**Objectif** : ecrire une fonction qui, pour un rang `r` donne, calcule le nombre total de paramètres LoRA sur tous les modules cibles (q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Qwen3.5-0.8B a des dimensions cachees de 1024 (hidden_size). Chaque projection a une dimension d * d\n",
-    "- # Étape 2 : Pour chaque module, LoRA ajoute 2 matrices : A(d, r) + B(r, d) = 2 * d * r paramètres\n",
-    "- # Indice : il y a 8 modules cibles (6 projections attention + linear_attn.out_proj + 3 MLP par couche, certains partages), chacun avec des dimensions potentiellement différentes (attention vs MLP)"
+    "- `# Étape 1` : Qwen3.5-0.8B a des dimensions cachees de 1024 (hidden_size). Chaque projection a une dimension d * d\n",
+    "- `# Étape 2` : Pour chaque module, LoRA ajoute 2 matrices : A(d, r) + B(r, d) = 2 * d * r paramètres\n",
+    "- `# Indice` : il y a 8 modules cibles (6 projections attention + linear_attn.out_proj + 3 MLP par couche, certains partages), chacun avec des dimensions potentiellement différentes (attention vs MLP)"
    ]
   },
   {
@@ -1460,9 +1460,9 @@
     "**Objectif** : créer une classe `ConvergenceMonitor` qui accumule les valeurs de loss et fournit une méthode `rapport()` retournant un resume statistique (loss initial, loss final, delta, nombre de steps).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir une liste pour accumuler les valeurs de loss\n",
-    "- # Étape 2 : Implementer `enregistrer(loss_value)` et `rapport()`\n",
-    "- # Indice : le rapport peut inclure min, max, moyenne et delta (dernier - premier)"
+    "- `# Étape 1` : Définir une liste pour accumuler les valeurs de loss\n",
+    "- `# Étape 2` : Implementer `enregistrer(loss_value)` et `rapport()`\n",
+    "- `# Indice` : le rapport peut inclure min, max, moyenne et delta (dernier - premier)"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_03_dpo_direct_preference.ipynb
@@ -256,7 +256,7 @@
   {
    "cell_type": "markdown",
    "id": "d8740e47",
-   "source": "### Exercice 1 : Analyser la qualite des paires chosen/rejected\n\nLe dataset `ultrafeedback_binarized` contient des paires de préférences, mais leur qualite varie. L'objectif est d'implementer une fonction `analyser_paires` qui calcule des statistiques sur les paires : nombre de paires ou le score chosen est effectivement superieur au score rejected, et identification des paires ambigues (scores egaux ou proches).\n\n**Objectif** : ecrire une fonction qui parcourt le dataset et retourne un rapport sur la coherence des annotations (chosen devrait avoir un score superieur a rejected).\n\n**Indices** :\n- # Étape 1 : Comparer `score_chosen` et `score_rejected` pour chaque exemple\n- # Étape 2 : Compter les paires coherentes (chosen > rejected), egales et incoherentes (chosen < rejected)\n- # Indice : un dataset de bonne qualite devrait avoir majoritairement des paires coherentes",
+   "source": "### Exercice 1 : Analyser la qualite des paires chosen/rejected\n\nLe dataset `ultrafeedback_binarized` contient des paires de préférences, mais leur qualite varie. L'objectif est d'implementer une fonction `analyser_paires` qui calcule des statistiques sur les paires : nombre de paires ou le score chosen est effectivement superieur au score rejected, et identification des paires ambigues (scores egaux ou proches).\n\n**Objectif** : ecrire une fonction qui parcourt le dataset et retourne un rapport sur la coherence des annotations (chosen devrait avoir un score superieur a rejected).\n\n**Indices** :\n- `# Étape 1` : Comparer `score_chosen` et `score_rejected` pour chaque exemple\n- `# Étape 2` : Compter les paires coherentes (chosen > rejected), egales et incoherentes (chosen < rejected)\n- `# Indice` : un dataset de bonne qualite devrait avoir majoritairement des paires coherentes",
    "metadata": {}
   },
   {
@@ -536,7 +536,7 @@
   {
    "cell_type": "markdown",
    "id": "a70067e7",
-   "source": "### Exercice 2 : Analyse de sensibilite au paramètre beta\n\nLe paramètre `beta` contrôle la regularisation KL dans le loss DPO. L'objectif est d'implementer une fonction `simuler_dpo_loss` qui calcule la valeur du loss DPO pour différentes valeurs de beta, et de tracer la courbe de sensibilite.\n\n**Objectif** : implementer le calcul du loss DPO (sigmoid du log-ratio) pour des valeurs de beta variant de 0.01 a 1.0, avec des log-ratios simules, puis afficher la courbe.\n\n**Indices** :\n- # Étape 1 : Simuler un ecart de log-probabilites entre chosen et rejected (par exemple 0.5)\n- # Étape 2 : Calculer le loss = -log(sigmoid(beta * ecart)) pour chaque valeur de beta\n- # Indice : utiliser `numpy` pour generer les valeurs de beta et `matplotlib` pour tracer",
+   "source": "### Exercice 2 : Analyse de sensibilite au paramètre beta\n\nLe paramètre `beta` contrôle la regularisation KL dans le loss DPO. L'objectif est d'implementer une fonction `simuler_dpo_loss` qui calcule la valeur du loss DPO pour différentes valeurs de beta, et de tracer la courbe de sensibilite.\n\n**Objectif** : implementer le calcul du loss DPO (sigmoid du log-ratio) pour des valeurs de beta variant de 0.01 a 1.0, avec des log-ratios simules, puis afficher la courbe.\n\n**Indices** :\n- `# Étape 1` : Simuler un ecart de log-probabilites entre chosen et rejected (par exemple 0.5)\n- `# Étape 2` : Calculer le loss = -log(sigmoid(beta * ecart)) pour chaque valeur de beta\n- `# Indice` : utiliser `numpy` pour generer les valeurs de beta et `matplotlib` pour tracer",
    "metadata": {}
   },
   {
@@ -1251,7 +1251,7 @@
   {
    "cell_type": "markdown",
    "id": "30310b50",
-   "source": "### Exercice 3 : Implementation de la préférence accuracy\n\nLa section 9 presente la formule de la préférence accuracy mais l'evaluation est simulee. L'objectif est d'implementer la fonction `preference_accuracy` qui compare les log-probabilites de deux modèles (policy vs reference) sur des paires chosen/rejected.\n\n**Objectif** : ecrire une fonction qui, pour chaque paire, determine si le modèle assigne une probabilite plus elevee a chosen qu'a rejected, et retourne le taux de succes global.\n\n**Indices** :\n- # Étape 1 : Pour chaque paire, recuperer les log-probabilites de chosen et rejected\n- # Étape 2 : Comparer les log-probabilites normalisees (par la longueur de la sequence)\n- # Indice : en mode CPU-safe, simuler les log-probs avec des valeurs aleatoires pour tester la logique",
+   "source": "### Exercice 3 : Implementation de la préférence accuracy\n\nLa section 9 presente la formule de la préférence accuracy mais l'evaluation est simulee. L'objectif est d'implementer la fonction `preference_accuracy` qui compare les log-probabilites de deux modèles (policy vs reference) sur des paires chosen/rejected.\n\n**Objectif** : ecrire une fonction qui, pour chaque paire, determine si le modèle assigne une probabilite plus elevee a chosen qu'a rejected, et retourne le taux de succes global.\n\n**Indices** :\n- `# Étape 1` : Pour chaque paire, recuperer les log-probabilites de chosen et rejected\n- `# Étape 2` : Comparer les log-probabilites normalisees (par la longueur de la sequence)\n- `# Indice` : en mode CPU-safe, simuler les log-probs avec des valeurs aleatoires pour tester la logique",
    "metadata": {}
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_04_grpo_deepseek_r1.ipynb
@@ -472,9 +472,9 @@
     "**Objectif** : ecrire une fonction qui analyse une completion et retourne un score de coherence base sur la presence de connecteurs logiques, de numerotation structuree, et de longueur adequat.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir des patterns de connecteurs logiques (\"donc\", \"par consequent\", \"premierement\", \"en conclusion\")\n",
-    "- # Étape 2 : Compter le nombre de patterns trouves et normaliser par la longueur du texte\n",
-    "- # Indice : combiner avec un bonus pour les reponses de longueur intermediaire (ni trop courtes, ni trop longues)"
+    "- `# Étape 1` : Définir des patterns de connecteurs logiques (\"donc\", \"par consequent\", \"premierement\", \"en conclusion\")\n",
+    "- `# Étape 2` : Compter le nombre de patterns trouves et normaliser par la longueur du texte\n",
+    "- `# Indice` : combiner avec un bonus pour les reponses de longueur intermediaire (ni trop courtes, ni trop longues)"
    ]
   },
   {
@@ -713,9 +713,9 @@
     "**Objectif** : ecrire une fonction qui estime la VRAM consommee par GRPO selon la taille du modèle, la longueur des completions et le group size G.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Calculer la memoire de base du modèle (params * bytes) + les activations\n",
-    "- # Étape 2 : Ajouter G * max_completion_length * hidden_size * 2 bytes (log-probs stockees)\n",
-    "- # Indice : comparer G=2, 4, 8, 16 et verifier lesquels tiennent sur 8 Go"
+    "- `# Étape 1` : Calculer la memoire de base du modèle (params * bytes) + les activations\n",
+    "- `# Étape 2` : Ajouter G * max_completion_length * hidden_size * 2 bytes (log-probs stockees)\n",
+    "- `# Indice` : comparer G=2, 4, 8, 16 et verifier lesquels tiennent sur 8 Go"
    ]
   },
   {
@@ -1259,9 +1259,9 @@
     "**Objectif** : ecrire une fonction `calculer_avantages` qui prend une liste de rewards et retourne les avantages normalises selon la formule GRPO.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Calculer la moyenne et l'ecart-type du groupe\n",
-    "- # Étape 2 : Appliquer la normalisation : (reward - moyenne) / (ecart_type + epsilon)\n",
-    "- # Indice : ajouter un petit epsilon (1e-8) pour eviter la division par zero quand tous les rewards sont egaux"
+    "- `# Étape 1` : Calculer la moyenne et l'ecart-type du groupe\n",
+    "- `# Étape 2` : Appliquer la normalisation : (reward - moyenne) / (ecart_type + epsilon)\n",
+    "- `# Indice` : ajouter un petit epsilon (1e-8) pour eviter la division par zero quand tous les rewards sont egaux"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_05_rlvr_verifiable_rewards.ipynb
@@ -319,9 +319,9 @@
     "**Objectif** : ajouter au moins deux nouveaux patterns de detection a la fonction `extract_answer` existante.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Ajouter un pattern regex pour \"So the result is X\" et \"(X)\"\n",
-    "- # Étape 2 : Gerer la conversion de notation scientifique via `float()` natif\n",
-    "- # Indice : inserer les nouveaux patterns avant le fallback \"dernier nombre\" pour eviter les conflits"
+    "- `# Étape 1` : Ajouter un pattern regex pour \"So the result is X\" et \"(X)\"\n",
+    "- `# Étape 2` : Gerer la conversion de notation scientifique via `float()` natif\n",
+    "- `# Indice` : inserer les nouveaux patterns avant le fallback \"dernier nombre\" pour eviter les conflits"
    ]
   },
   {
@@ -512,9 +512,9 @@
     "**Objectif** : implementer `creer_dataset_geometrie` qui retourne une liste de problemes geometriques au format compatible avec le pipeline RLVR.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir les problemes (aire triangle, perimetre rectangle, volume sphere, etc.)\n",
-    "- # Étape 2 : Formater au format `{\"prompt\": [...], \"answer\": float}` comme GSM8K_SAMPLE\n",
-    "- # Indice : utiliser les formules geometriques standard pour calculer les reponses exactes"
+    "- `# Étape 1` : Définir les problemes (aire triangle, perimetre rectangle, volume sphere, etc.)\n",
+    "- `# Étape 2` : Formater au format `{\"prompt\": [...], \"answer\": float}` comme GSM8K_SAMPLE\n",
+    "- `# Indice` : utiliser les formules geometriques standard pour calculer les reponses exactes"
    ]
   },
   {
@@ -1286,9 +1286,9 @@
     "**Objectif** : ecrire une fonction qui retourne un reward entre 0 et 1 en fonction de la distance relative entre la reponse extraite et la ground truth.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Calculer l'erreur relative : `|predicted - ground_truth| / |ground_truth|`\n",
-    "- # Étape 2 : Mapper l'erreur a un score (0% erreur = 1.0, 5% erreur = 0.5, 10%+ = 0.0)\n",
-    "- # Indice : utiliser une fonction lineaire ou sigmoid pour le mapping"
+    "- `# Étape 1` : Calculer l'erreur relative : `|predicted - ground_truth| / |ground_truth|`\n",
+    "- `# Étape 2` : Mapper l'erreur a un score (0% erreur = 1.0, 5% erreur = 0.5, 10%+ = 0.0)\n",
+    "- `# Indice` : utiliser une fonction lineaire ou sigmoid pour le mapping"
    ]
   },
   {

--- a/MyIA.AI.Notebooks/GenAI/PostTraining/PT_06_eval_comparative.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/PostTraining/PT_06_eval_comparative.ipynb
@@ -174,9 +174,9 @@
     "**Objectif** : ecrire une fonction qui prend le nom d'une technique et retourne un dictionnaire structure avec toutes les informations essentielles pour un praticien.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Créer un dictionnaire de reference par technique avec tous les champs utiles\n",
-    "- # Étape 2 : Implementer la fonction de lookup avec validation du nom de technique\n",
-    "- # Indice : inclure les pieges spécifiques a chaque technique (references aux sections detaillees de PT-02 a PT-05)"
+    "- `# Étape 1` : Créer un dictionnaire de reference par technique avec tous les champs utiles\n",
+    "- `# Étape 2` : Implementer la fonction de lookup avec validation du nom de technique\n",
+    "- `# Indice` : inclure les pieges spécifiques a chaque technique (references aux sections detaillees de PT-02 a PT-05)"
    ]
   },
   {
@@ -356,9 +356,9 @@
     "**Objectif** : ecrire une fonction qui retourne un rapport de cout detaille (GPU-heures par étape, VRAM requise, cout annotation, duree estimee).\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir les couts unitaires par technique (GPU-h/1000 samples, annotation h/1000 samples)\n",
-    "- # Étape 2 : Calculer le cout cumulatif d'un pipeline multi-étapes\n",
-    "- # Indice : verifier si le GPU est suffisant pour chaque étape et lever un avertissement sinon"
+    "- `# Étape 1` : Définir les couts unitaires par technique (GPU-h/1000 samples, annotation h/1000 samples)\n",
+    "- `# Étape 2` : Calculer le cout cumulatif d'un pipeline multi-étapes\n",
+    "- `# Indice` : verifier si le GPU est suffisant pour chaque étape et lever un avertissement sinon"
    ]
   },
   {
@@ -592,9 +592,9 @@
     "**Objectif** : ecrire une fonction qui prend un scénario (type de domaine, budget GPU, disponibilite de données) et retourne un plan d'exécution ordonne.\n",
     "\n",
     "**Indices** :\n",
-    "- # Étape 1 : Définir les paramètres du scénario (`domaine`, `has_gpu`, `data_available`)\n",
-    "- # Étape 2 : Construire la liste ordonnee d'étapes selon les règles du decision framework\n",
-    "- # Indice : le pipeline SFT est toujours la première étape, ensuite DPO si préférences, GRPO/RLVR si rewards"
+    "- `# Étape 1` : Définir les paramètres du scénario (`domaine`, `has_gpu`, `data_available`)\n",
+    "- `# Étape 2` : Construire la liste ordonnee d'étapes selon les règles du decision framework\n",
+    "- `# Indice` : le pipeline SFT est toujours la première étape, ensuite DPO si préférences, GRPO/RLVR si rewards"
    ]
   },
   {


### PR DESCRIPTION
Grain: LIGHT/markdown-repair — lane myia-po-2023:CoursIA — prev: MED/notebook-python #12152 (PR #12167)

## Perimetre (declare en debut de body)

**6 fichiers, markdown uniquement** : `PT_01_intro_post_training` a `PT_06_eval_comparative` (serie GenAI/PostTraining). 53 lignes source markdown modifiees (54 remedes : PT_03 porte plusieurs remedes par ligne JSON car ses cellules ont une source en forme de string unique). Aucune cellule code touchee, outputs et `execution_count` intacts (verifie byte-identique a main sur les cellules code ; PT_01/02/04 ont une cellule 0 avec outputs vides PRE-EXISTANTS sur main, exec_count non-null — etat inchange).

Exclusions declarees : `PT_11_grpo_qwen_rlvr_on_verifiers` (PR #12028 ouverte, densite), `PT_11b_multiseed_qwen35_4x100` (residuels cells 7/13 signales dans #12167 — stacked PR, pas de double-edit du meme fichier).

## Rescopage du terrain AVANT edition (G.1)

L'offre DM citait les tetes GenAI/Image (02-1/02-2/02-4 a 14-15) — mesure ANTERIEURE au merge de la tranche B #12137 (GenAI Image+Video, 171 remedes). Verifie firsthand sur main frais : 02-1 et 02-2 clean, 02-4 residuel = 1 HINT-AS-HEADING (classe #12161, po-2025), pas de la classe ici. Les lanes Audio (#12131 ouverte), SemanticKernel (#12144/#12157 ouvertes), QC (#12141), RL (#12138) tiennent deja leurs tranches. PostTraining PT_01..06 = le plus gros bloc GenAI reellement libre.

## Correctif

Convention de la tranche B mergee (#12137) : le label migre en backticks —

```
- # Étape 1 : Définir des patterns...
-> - `# Étape 1` : Définir des patterns...
```

54 instances uniformes (`# Étape N :` x36, `# Indice :` x18) dans les cellules d'exercice, 9 par notebook (3 exercices x Étape1/Étape2/Indice). Chaque instance verifiee illegitime (marqueur de commentaire colle en migration code->markdown, ouvre un H1 dans la puce). Texte inchange, saut des fences respecte, formes de source preservees (string vs liste de lignes, piege : iterer une source string la convertit en liste de caracteres).

## Validation

- `scan_md_hierarchy.py` sur les 6 notebooks : **0 HEADING-IN-LIST, 0/6 flagged** (avant : 9 chacun).
- nbformat VALID x6 ; cellules code byte-identiques a main.
- Markdown-only : pas de re-execution requise (C.2), garde `markdown-rendering-guard` sain par construction (aucun `---` ajoute).

## Residuel GenAI de la classe (non couvert, libre)

Texte (7/8/9_Production : ~36), CaseStudies (barbie 18, recipe 9, medical 9), Vibe-Coding (8), PT_11b cells 7/13 (apres merge #12167). Le cliquet bloquant (#12107) empeche toute NOUVELLE occurrence.

See #12165 (tranche partielle de la classe 1040) — See #12128 (epic heading_in_list)
