### PR TITLE
fix(slides,#12162): S3-acculturation deplace img_027/img_028 vers slide 20 (Algorithmes genetiques) + alts 4 figures

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -412,11 +412,6 @@ layout: two-cols
   - Algorithme A*
   - [Demo Pathfinding.js](#)
 
-<img src="./images/img_027.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Cycle d'un algorithme génétique" />
-<img src="./images/img_028.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Croisement sur le problème des huit reines" />
-
-</div>
-
 </div>
 
 
@@ -444,11 +439,10 @@ layout: two-cols
   - Sélection naturelle = combinaison
   - Algorithmes génétiques
 
-<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_030.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_031.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_032.png" class="max-h-[300px] max-w-full object-contain" alt="Représentations d'états : atomique, factorisée, structurée" />
-<img src="./images/img_033.png" class="max-h-[300px] max-w-full object-contain" alt="Niveaux d'abstraction imbriqués d'un espace d'états" />
+<div class="flex gap-2 flex-wrap items-start">
+<img src="./images/img_030.png" class="w-[180px] max-w-full max-h-[140px] object-contain" alt="Paysage d'optimisation avec trajectoire de descente" />
+<img src="./images/img_027.png" class="w-[180px] max-w-full max-h-[140px] object-contain" alt="Cycle d'un algorithme génétique : Initial Population → Fitness → Selection → Cross-Over → Mutation" />
+<img src="./images/img_028.png" class="w-[180px] max-w-full max-h-[140px] object-contain" alt="Croisement sur le problème des huit reines : deux parents combinés par croisement" />
 </div>
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA-2 — prev: MED/notebook-python #12177 (c.1331p340)

## fix(slides,#12162) — S3-acculturation : 2 figures AG + 1 paysage d'optimisation sur slide 20 (rebase post-#11915)

### Contexte (acceptance reformulée 2ᵉ fois, DM ai-01 msg-20260821T174928-5yzall)

Sur la base de fusion `280bbadc9` (post-#11915 merge), `img_027` (cycle AG : Initial Population → Fitness → Selection → Cross-Over → Mutation) et `img_028` (croisement AG sur les 8 reines) **étaient sur la slide 19** (Stratégies 1/2, recherches non informées/informées) **alors que leur sujet est la slide 20** (Stratégies 2/2, Algorithmes génétiques). Avant : img_030 (paysage d'optimisation) + img_031 (arbre minimax) + img_032 (représentations AIMA) + img_033 (cercles imbriqués) composaient un bloc `img-grid-2x2` mal aligné avec le sujet.

### Mesure ai-01 (verbatim, DM 16:43 PART 2/2 + 19:49 HIGH)

ai-01 a ouvert les 6 PNG un par un. Verdict sur la slide 20 :

| Fichier | Contenu réel | Verdict |
|---|---|---|
| `img_027` | cycle AG | ✅ **AG — déplacée** (cette PR) |
| `img_028` | croisement AG sur 8 reines | ✅ **AG — déplacée** (cette PR) |
| `img_030` | paysage d'optimisation + trajectoire | ✅ **déjà bien placée, conservée** |
| `img_031` | arbre minimax morpion | ❌ recherche adversariale — hors sujet → **retirée** |
| `img_032` | représentations AIMA (atomique/factorisée/structurée) | ❌ représentations d'agent — hors sujet → **retirée** |
| `img_033` | cercles imbriqués abstraction | ❌ abstraction d'états — hors sujet → **retirée** |

**Acceptance reformulée** :
- **2 figures AG** (img_027, img_028) déplacées de la slide 19 vers la slide 20 ✓
- **1 paysage d'optimisation** (img_030) conservé sur slide 20 ✓
- **0 image hors sujet** (img_031/032/033) sur slide 20 — retirées, à inventorier dans #12014
- Total : **3 figures correctement thématisées** sur slide 20, alignées avec « Stratégies 2/2 : paysages / recuit / génétiques »

### Composition slide 20 (arbitrage final)

```html
<div class="flex gap-2 flex-wrap items-start">
<img src="./images/img_030.png" ... alt="Paysage d'optimisation avec trajectoire de descente" />
<img src="./images/img_027.png" ... alt="Cycle d'un algorithme génétique : Initial Population → Fitness → Selection → Cross-Over → Mutation" />
<img src="./images/img_028.png" ... alt="Croisement sur le problème des huit reines : deux parents combinés par croisement" />
</div>
```

3 images 180×140 px en flex-wrap (≈ 370×290 px max), + titre H1 + 6 puces ≈ 540 px dans la colonne droite du thème `two-cols`. Cadre 552 px (canvas 980×552).

### Acceptance — version finale

1. ✅ img_027 et img_028 **retirées de la slide 19** (les 2 `<img>` orphelines du diff `+0/-2` sont parties)
2. ✅ img_027 et img_028 **insérées dans la slide 20** dans un flex 2×2-3 (3 figures au total : img_030 paysage conservé + img_027/028 AG déplacées)
3. ✅ img_031, img_032, img_033 **retirées de la slide 20** — leurs placements sont **hors sujet** (cf arbitrage ai-01), à rejoindre l'inventaire #12014
4. ✅ **Alts sur les 3 figures** : corrects, décrivent **réellement** le PNG (pas d'alt inventé pour une image mal placée — leçon c.1331p339 ★★ appliquée)
5. ✅ `scripts/notebook_tools/detect_markdown_rendering.py slides/S3-acculturation/slides.md --json` → **0 finding**
6. ✅ Rebase sur `origin/main` (post-#11915 merge `dd78401e2`) → conflits résolus manuellement (2 zones : suppression orphelins slide 19 + refonte slide 20)
7. ⚠️ **QA visuel Slidev `?clicks=99`** sur slides 19 et 20 → à ai-01 (po-2024 non-vision, règle `model-delegation.md`)
8. ⚠️ **Slidev composition advisory (#11923)** rouge muet sur cette PR — **PAS mon défaut** : ouvert en #12178, garde lui-même échoue depuis 16:35Z sans imprimer la cause. Aucune correction lane requise.

### Rebase — log

```
$ git rebase origin/main
Auto-merging slides/S3-acculturation/slides.md
CONFLICT (content): Merge conflict in slides/S3-acculturation/slides.md
# résolution manuelle : 2 zones de marqueurs <<<<<<< ======= >>>>>>>
# zone 1 (slide 19) : retrait orphelins img_027/028 (issue de la PR originale)
# zone 2 (slide 20) : refonte du img-grid-2x2 vers flex propre img_030/027/028

$ git rebase --continue
[detached HEAD 2d7872ce0] fix(slides,#12162): S3-acculturation deplace img_027/img_028 vers slide 20 (Algorithmes genetiques) + alts 4 figures
Successfully rebased and updated refs/heads/fix/12162-img027-028-slide20.

$ git push --force-with-lease
+ 0bcdcbab1...2d7872ce0 fix/12162-img027-028-slide20 -> fix/12162-img027-028-slide20 (forced update)
```

### Diff (HEAD `2d7872ce0` vs `280bbadc9`)

```
slides/S3-acculturation/slides.md | 14 +++++--------
1 file changed, 4 insertions(+), 10 deletions(-)
```

- `-2` orphelins img_027/028 retirés de slide 19
- `-4` img_031/032/033 retirés de slide 20 (hors sujet)
- `+4` flex propre avec img_030/027/028 (3 figures, 3 alts corrects)

### Pattern

- L271 (MGS narrow fix)
- L898 ★★★ collision check avant d'éditer : `gh pr list --search "12162"` = 1 PR (la mienne, OPEN), `check_lane_claim.py 12162` = CLEAR
- **c.1331p339 ★★** NEVER-invent-alt-for-misplaced-image — **réappliqué** ici : img_031/032/033 sont mal placées, je les **retire** au lieu d'inventer des alts
- **c.1331p316 ★** source-list-format-preserve (NotebookEdit) — pas applicable ici (slides.md texte brut)
- **c.1331p340 ★** cjk-source-list-edit-index-target — pas applicable ici

### Demande explicite à ai-01

1. **Lancer le QA visuel Slidev `?clicks=99`** sur slides 19 et 20 post-rebase — composition de 3 figures en flex 2×2-3 doit être jugée
2. Si débordement ou composition dégradée : options offertes (cf c.1331p339 body — 4 colonnes 1 ligne / retrait img_028 / retrait img_030)
3. **Merger #12172** une fois QA visuel validé
4. **Inventaire #12014** : img_031/032/033 à reclasser ailleurs (recherche adversariale / représentations agent / abstraction d'états)

See #12162, See #12014