### PR TITLE
feat(genai,#11926): contrat SSE reel sur 04-Aspire-Streaming-Agent — TypedResults.ServerSentEvents + mesure des deltas d'arrivee

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/Aspire/04-Aspire-Streaming-Agent.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/04-Aspire-Streaming-Agent.ipynb
@@ -42,10 +42,10 @@
    "id": "4fcd1fcc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T21:46:47.600549Z",
-     "iopub.status.busy": "2026-08-17T21:46:47.594545Z",
-     "iopub.status.idle": "2026-08-17T21:46:50.528502Z",
-     "shell.execute_reply": "2026-08-17T21:46:50.523992Z"
+     "iopub.execute_input": "2026-08-21T18:29:39.691689Z",
+     "iopub.status.busy": "2026-08-21T18:29:39.685296Z",
+     "iopub.status.idle": "2026-08-21T18:29:48.242230Z",
+     "shell.execute_reply": "2026-08-21T18:29:48.235084Z"
     }
    },
    "outputs": [
@@ -54,7 +54,7 @@
       "text/html": [
        "\r\n",
        "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
+       "    <div id='dotnet-interactive-this-cell-36240.Microsoft.DotNet.Interactive.Http.HttpPort' style='display: none'>\r\n",
        "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
        "    </div>\r\n",
        "    <script type='text/javascript'>\r\n",
@@ -97,7 +97,7 @@
        "        // use probing to find host url and api resources\r\n",
        "        // load interactive helpers and language services\r\n",
        "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '42184.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
+       "        context: '36240.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
        "                paths:\r\n",
        "            {\r\n",
        "                'dotnet-interactive': `${root}resources`\r\n",
@@ -168,14 +168,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      ".NET 10.0.11\r\n"
+      ".NET 9.0.19\r\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Channels : System.Threading.Channels.Channel`1[[System.Int32, System.Private.CoreLib, Version=10.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]\r\n"
+      "Channels : System.Threading.Channels.Channel`1[[System.Int32, System.Private.CoreLib, Version=9.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]\r\n"
      ]
     },
     {
@@ -215,10 +215,10 @@
    "id": "c68001b9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T21:46:50.529502Z",
-     "iopub.status.busy": "2026-08-17T21:46:50.529502Z",
-     "iopub.status.idle": "2026-08-17T21:46:51.231447Z",
-     "shell.execute_reply": "2026-08-17T21:46:51.231447Z"
+     "iopub.execute_input": "2026-08-21T18:29:48.257353Z",
+     "iopub.status.busy": "2026-08-21T18:29:48.257060Z",
+     "iopub.status.idle": "2026-08-21T18:29:49.528473Z",
+     "shell.execute_reply": "2026-08-21T18:29:49.528187Z"
     }
    },
    "outputs": [
@@ -334,10 +334,10 @@
    "id": "2b840a99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T21:46:51.232451Z",
-     "iopub.status.busy": "2026-08-17T21:46:51.232451Z",
-     "iopub.status.idle": "2026-08-17T21:46:52.130010Z",
-     "shell.execute_reply": "2026-08-17T21:46:52.129476Z"
+     "iopub.execute_input": "2026-08-21T18:29:49.544539Z",
+     "iopub.status.busy": "2026-08-21T18:29:49.544251Z",
+     "iopub.status.idle": "2026-08-21T18:29:50.808063Z",
+     "shell.execute_reply": "2026-08-21T18:29:50.807840Z"
     }
    },
    "outputs": [
@@ -485,10 +485,10 @@
    "id": "3d89127a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T21:46:52.130515Z",
-     "iopub.status.busy": "2026-08-17T21:46:52.130515Z",
-     "iopub.status.idle": "2026-08-17T21:46:52.301979Z",
-     "shell.execute_reply": "2026-08-17T21:46:52.300979Z"
+     "iopub.execute_input": "2026-08-21T18:29:50.825320Z",
+     "iopub.status.busy": "2026-08-21T18:29:50.824950Z",
+     "iopub.status.idle": "2026-08-21T18:29:51.326545Z",
+     "shell.execute_reply": "2026-08-21T18:29:51.326299Z"
     }
    },
    "outputs": [],
@@ -538,10 +538,10 @@
    "id": "272e18de",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T21:46:52.302979Z",
-     "iopub.status.busy": "2026-08-17T21:46:52.302979Z",
-     "iopub.status.idle": "2026-08-17T21:46:52.475976Z",
-     "shell.execute_reply": "2026-08-17T21:46:52.474975Z"
+     "iopub.execute_input": "2026-08-21T18:29:51.336107Z",
+     "iopub.status.busy": "2026-08-21T18:29:51.335828Z",
+     "iopub.status.idle": "2026-08-21T18:29:51.620079Z",
+     "shell.execute_reply": "2026-08-21T18:29:51.619805Z"
     }
    },
    "outputs": [
@@ -629,10 +629,10 @@
    "id": "ede74e6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T21:46:52.475976Z",
-     "iopub.status.busy": "2026-08-17T21:46:52.475976Z",
-     "iopub.status.idle": "2026-08-17T21:46:52.499256Z",
-     "shell.execute_reply": "2026-08-17T21:46:52.499256Z"
+     "iopub.execute_input": "2026-08-21T18:29:51.639264Z",
+     "iopub.status.busy": "2026-08-21T18:29:51.638973Z",
+     "iopub.status.idle": "2026-08-21T18:29:51.804674Z",
+     "shell.execute_reply": "2026-08-21T18:29:51.804371Z"
     }
    },
    "outputs": [
@@ -708,10 +708,10 @@
    "id": "fa87d045",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T21:46:52.500256Z",
-     "iopub.status.busy": "2026-08-17T21:46:52.500256Z",
-     "iopub.status.idle": "2026-08-17T21:46:54.075829Z",
-     "shell.execute_reply": "2026-08-17T21:46:54.074831Z"
+     "iopub.execute_input": "2026-08-21T18:29:51.823270Z",
+     "iopub.status.busy": "2026-08-21T18:29:51.823002Z",
+     "iopub.status.idle": "2026-08-21T18:29:57.756909Z",
+     "shell.execute_reply": "2026-08-21T18:29:57.756646Z"
     }
    },
    "outputs": [
@@ -826,10 +826,10 @@
    "id": "6c659d9b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-17T21:46:54.076831Z",
-     "iopub.status.busy": "2026-08-17T21:46:54.076831Z",
-     "iopub.status.idle": "2026-08-17T21:46:54.158263Z",
-     "shell.execute_reply": "2026-08-17T21:46:54.158263Z"
+     "iopub.execute_input": "2026-08-21T18:29:57.775992Z",
+     "iopub.status.busy": "2026-08-21T18:29:57.775717Z",
+     "iopub.status.idle": "2026-08-21T18:29:57.998128Z",
+     "shell.execute_reply": "2026-08-21T18:29:57.997875Z"
     }
    },
    "outputs": [
@@ -892,6 +892,265 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a19f79df",
+   "metadata": {},
+   "source": [
+    "## A4 — Le contrat qui conserve la cadence : Server-Sent Events\n",
+    "\n",
+    "Reprenons la sortie de A3 : `/stream -> 200 : [{\"kind\":\"token\",\"payload\":\"Bonjour\"},{\"kind\":\"token\",\"payload\":\"monde\"},…]`. Le tableau JSON est **complet** quand il arrive. Or `AgentService` produit ses tokens un par un, avec `await Task.Delay(80, …)` entre deux écritures dans le canal — la cadence existe côté serveur, et le client ne la voit pas.\n",
+    "\n",
+    "C'est une propriété du **contrat HTTP**, pas du moteur : `StreamHandler.Handle` accumule dans une `List<AgentEvent>` et n'écrit la réponse qu'après l'événement `done`. Tant que ce contrat est le seul exposé, `Channel` + backpressure + `await foreach` sont indiscernables d'un `return liste` construit d'un coup. Le mécanisme est là ; la démonstration ne le montre pas.\n",
+    "\n",
+    "**Server-Sent Events** est le contrat qui le montre. C'est un format texte unidirectionnel — `event:` puis `data:` puis une ligne vide — que le serveur écrit au fil de l'eau sur une connexion maintenue ouverte, et que tout client HTTP peut lire ligne à ligne. En .NET 10, la minimal API l'expose directement :\n",
+    "\n",
+    "```csharp\n",
+    "public static async Task<IResult> Handle(StreamRequest request, AgentService service, CancellationToken ct)\n",
+    "{\n",
+    "    await service.SubmitAsync(new AgentRequest(request.Prompt), ct);\n",
+    "    return TypedResults.ServerSentEvents(Evenements(service, ct));   // IAsyncEnumerable<SseItem<string>>\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "`TypedResults.ServerSentEvents` prend un `IAsyncEnumerable<SseItem<T>>` : chaque élément est écrit **dès qu'il est produit** par l'énumérateur asynchrone, sans buffer intermédiaire. Le `Kind` de notre `AgentEvent` devient le champ `event:` du protocole, son `Payload` le champ `data:` — un client SSE standard distingue donc un `token` d'un `done` sans parser de JSON.\n",
+    "\n",
+    "Le service expose désormais **les deux** contrats sur le même canal (voir [`StreamingAgent.App/Program.cs`](StreamingAgent.App/Program.cs)). La cellule suivante les interroge l'un après l'autre et **horodate chaque arrivée** : c'est la mesure qui rend la différence visible, pas la prose."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "801f4fc2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T18:29:58.017638Z",
+     "iopub.status.busy": "2026-08-21T18:29:58.017321Z",
+     "iopub.status.idle": "2026-08-21T18:29:59.387639Z",
+     "shell.execute_reply": "2026-08-21T18:29:59.387359Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/stream      -> application/json\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                1 seule arrivee a t+378 ms, 187 octets d'un coup\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/stream-sse  -> text/event-stream\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                \"un\" a t+18 ms (delta 18 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                \"deux\" a t+115 ms (delta 97 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                \"trois\" a t+207 ms (delta 92 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                \"quatre\" a t+297 ms (delta 90 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                \"un deux trois quatre\" a t+394 ms (delta 97 ms)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Service arrete (processus termine).\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "using System.Diagnostics;\n",
+    "using System.IO;\n",
+    "using System.Net.Http;\n",
+    "using System.Text;\n",
+    "\n",
+    "// Deux contrats HTTP, un seul service : on mesure QUAND chaque token arrive.\n",
+    "var projet = Path.Combine(Environment.CurrentDirectory, \"StreamingAgent.App\");\n",
+    "Process proc = null;\n",
+    "\n",
+    "StringContent Charge() =>\n",
+    "    new StringContent(\"{\\\"prompt\\\":\\\"un deux trois quatre\\\"}\", Encoding.UTF8, \"application/json\");\n",
+    "\n",
+    "try\n",
+    "{\n",
+    "    proc = Process.Start(new ProcessStartInfo(\n",
+    "        \"dotnet\", \"run --no-build --project \\\"\" + projet + \"\\\" -- --urls http://127.0.0.1:5129\")\n",
+    "    {\n",
+    "        WorkingDirectory = projet,\n",
+    "    });\n",
+    "\n",
+    "    using var client = new HttpClient { BaseAddress = new Uri(\"http://127.0.0.1:5129\") };\n",
+    "    HttpResponseMessage health = null;\n",
+    "    for (var i = 0; i < 40 && health is null; i++)\n",
+    "    {\n",
+    "        try { health = await client.GetAsync(\"/health\"); }\n",
+    "        catch (HttpRequestException) { await Task.Delay(250); }\n",
+    "    }\n",
+    "\n",
+    "    // --- Contrat 1 : /stream, bufferise ---\n",
+    "    var chrono = Stopwatch.StartNew();\n",
+    "    var bufferise = await client.PostAsync(\"/stream\", Charge());\n",
+    "    var corps = await bufferise.Content.ReadAsStringAsync();\n",
+    "    Console.WriteLine($\"/stream      -> {bufferise.Content.Headers.ContentType}\");\n",
+    "    Console.WriteLine($\"                1 seule arrivee a t+{chrono.ElapsedMilliseconds} ms, {corps.Length} octets d'un coup\");\n",
+    "\n",
+    "    // --- Contrat 2 : /stream-sse, flux ---\n",
+    "    chrono.Restart();\n",
+    "    using var requete = new HttpRequestMessage(HttpMethod.Post, \"/stream-sse\") { Content = Charge() };\n",
+    "    using var reponse = await client.SendAsync(requete, HttpCompletionOption.ResponseHeadersRead);\n",
+    "    using var flux = await reponse.Content.ReadAsStreamAsync();\n",
+    "    using var lecteur = new StreamReader(flux);\n",
+    "\n",
+    "    Console.WriteLine($\"/stream-sse  -> {reponse.Content.Headers.ContentType}\");\n",
+    "    var precedent = 0L;\n",
+    "    string ligne;\n",
+    "    while ((ligne = await lecteur.ReadLineAsync()) is not null)\n",
+    "    {\n",
+    "        if (!ligne.StartsWith(\"data:\")) { continue; }\n",
+    "        var t = chrono.ElapsedMilliseconds;\n",
+    "        Console.WriteLine($\"                \\\"{ligne.Substring(5).Trim()}\\\" a t+{t} ms (delta {t - precedent} ms)\");\n",
+    "        precedent = t;\n",
+    "    }\n",
+    "}\n",
+    "finally\n",
+    "{\n",
+    "    if (proc is not null)\n",
+    "    {\n",
+    "        try { proc.Kill(entireProcessTree: true); } catch (InvalidOperationException) { }\n",
+    "        await proc.WaitForExitAsync();\n",
+    "        Console.WriteLine(\"Service arrete (processus termine).\");\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38b1889e",
+   "metadata": {},
+   "source": [
+    "### Interprétation — ce que les deltas mesurent\n",
+    "\n",
+    "Les valeurs citées ci-dessous sont celles de **l'exécution committée** : ce sont des mesures de temps, elles bougent de quelques millisecondes à chaque passage. Ce qui ne bouge pas, et qui est le propos, c'est leur **forme**.\n",
+    "\n",
+    "**1. Le `Content-Type` diffère, et il n'est pas cosmétique.** `/stream` répond `application/json` : le corps est un document, il n'a de sens que complet. `/stream-sse` répond `text/event-stream` — c'est cet en-tête qui autorise le client (et les proxys sur le trajet) à traiter la réponse comme un flux plutôt qu'à l'attendre entièrement. Un navigateur le consomme avec `EventSource` sans une ligne de JavaScript supplémentaire.\n",
+    "\n",
+    "**2. Le buffer n'est pas plus lent, il est plus tardif.** `/stream` rend son unique arrivée à `t+378 ms` ; le flux SSE rend son dernier événement à `t+394 ms` — seize millisecondes *plus tard*, le coût des écritures successives sur le socket. Autrement dit : à durée totale égale (le service travaille rigoureusement pareil dans les deux cas), **SSE ne fait rien gagner sur la fin**. Ce qu'il change est la **latence du premier octet utile** : `t+18 ms` contre `t+378 ms`, un facteur 21. Le client SSE tient le premier token pendant que le serveur produit encore les suivants — c'est exactement ce dont une interface d'agent a besoin pour afficher au fil de l'eau, et c'est un gain sur la *perception*, pas sur le débit.\n",
+    "\n",
+    "**3. Les deltas reproduisent le `Task.Delay(80)` du service.** Mesurés : `18, 97, 92, 90, 97 ms`. Les quatre derniers encadrent les 80 ms nominales, le surcoût étant la boucle d'événements du serveur plus la lecture ligne à ligne du client. C'est la vérification qui compte : elle prouve que la cadence traverse toute la chaîne — canal → `IAsyncEnumerable` → écriture SSE → socket → `StreamReader` — sans être aplatie par un buffer intermédiaire. Une série de deltas quasi nuls suivie d'un saut signalerait au contraire un buffer resté quelque part sur le trajet, **quel que soit l'en-tête annoncé**.\n",
+    "\n",
+    "**Le premier delta, lui, ne mesure pas la cadence** — `18 ms` au lieu de ~90. Ce n'est pas du bruit : `ExecuteAsync` écrit **avant** d'attendre (`WriteAsync(token)` puis `Task.Delay(80)`), donc le premier token est disponible dès que la requête est dépilée du canal entrant. Le dernier delta, `97 ms`, confirme la symétrie de l'autre bout : l'événement `done` suit un `Delay` complet après le dernier token, il n'est pas collé à lui.\n",
+    "\n",
+    "> **Ce que cette mesure ne dit pas.** Les valeurs sont prises sur `127.0.0.1`, sans proxy ni compression. Un intermédiaire qui bufferise — certains reverse-proxys le font par défaut sur `text/event-stream` — réintroduirait exactement le comportement de `/stream` sans qu'une ligne du service change. La mesure est donc à refaire côté déploiement, pas seulement côté code : c'est précisément ce que l'exercice 4 outille."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0d86502a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T18:29:59.408771Z",
+     "iopub.status.busy": "2026-08-21T18:29:59.408494Z",
+     "iopub.status.idle": "2026-08-21T18:29:59.562770Z",
+     "shell.execute_reply": "2026-08-21T18:29:59.562478Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 4 a completer : implementer Verdict(arrivees, seuilMs).\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  attendu pour arriveesFlux   (seuil 40) : FLUX   -- obtenu : (non implemente)\r\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  attendu pour arriveesBuffer (seuil 40) : BUFFER -- obtenu : (non implemente)\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "// EXERCICE 4 : distinguer un vrai flux d'un buffer, sans regarder le serveur.\n",
+    "//\n",
+    "// Le client ci-dessus fait confiance a l'en-tete `text/event-stream`. Mais un\n",
+    "// serveur peut annoncer cet en-tete et ecrire quand meme tout d'un coup : seule\n",
+    "// la MESURE tranche. Ecrire ici une fonction qui rend un verdict.\n",
+    "//\n",
+    "//   1. Prendre en entree la liste des instants d'arrivee (en ms) des lignes `data:`.\n",
+    "//   2. Calculer les deltas successifs, puis leur mediane.\n",
+    "//   3. Rendre \"FLUX\" si la mediane depasse un seuil passe en parametre,\n",
+    "//      \"BUFFER\" sinon -- un buffer produit des deltas quasi nuls entre les lignes,\n",
+    "//      puisqu'elles sortent du meme paquet.\n",
+    "//   4. Verifier le verdict sur les deux jeux d'instants ci-dessous.\n",
+    "//\n",
+    "// Indice : la mediane resiste au PREMIER delta, qui ne mesure pas la cadence.\n",
+    "// Le service ecrit son token avant d'attendre (`WriteAsync` puis `Delay`), donc\n",
+    "// le premier arrive nettement plus tot que les suivants (quelques dizaines de\n",
+    "// ms contre ~80-100). Une moyenne, elle, se laisse tirer vers le bas par lui.\n",
+    "\n",
+    "// Ordre de grandeur d'un flux cadence a ~80 ms (cf. la sortie de A4 -- les\n",
+    "// valeurs exactes changent a chaque execution, la FORME ne change pas).\n",
+    "var arriveesFlux = new long[] { 30, 125, 213, 314, 402 };\n",
+    "// Meme charge utile rendue d'un seul paquet : les lignes se suivent sans attente.\n",
+    "var arriveesBuffer = new long[] { 400, 400, 401, 401, 402 };\n",
+    "\n",
+    "string Verdict(long[] arrivees, long seuilMs)\n",
+    "{\n",
+    "    // TODO Etudiant : calculer les deltas, leur mediane, puis comparer au seuil.\n",
+    "    return null;\n",
+    "}\n",
+    "\n",
+    "Console.WriteLine(\"Exercice 4 a completer : implementer Verdict(arrivees, seuilMs).\");\n",
+    "Console.WriteLine($\"  attendu pour arriveesFlux   (seuil 40) : FLUX   -- obtenu : {Verdict(arriveesFlux, 40) ?? \"(non implemente)\"}\");\n",
+    "Console.WriteLine($\"  attendu pour arriveesBuffer (seuil 40) : BUFFER -- obtenu : {Verdict(arriveesBuffer, 40) ?? \"(non implemente)\"}\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "818e0870",
    "metadata": {},
    "source": [
@@ -904,8 +1163,9 @@
     "| File d'événements | `System.Threading.Channels` | `Writer`/`Reader`, backpressure, flux `await foreach` |\n",
     "| Cycle de vie | `BackgroundService` | `ExecuteAsync`, arrêt coopératif par `CancellationToken` |\n",
     "| Exposition | Minimal API typée .NET 10 | `TypedResults`, handler en classe, injection DI |\n",
+    "| Conservation de la cadence | `TypedResults.ServerSentEvents` | `IAsyncEnumerable<SseItem<T>>`, écriture au fil de l'eau, `text/event-stream` |\n",
     "\n",
-    "Dans le projet [`StreamingAgent.App/`](StreamingAgent.App/), ces trois briques forment un service réel : un `AgentService` hôte (canaux inbound/outbound) exposé par des endpoints typés (`/health`, `/greet`, `/stream`), vérifiable par `curl`. Le même contrat — flux d'événements, cycle de vie hôte, endpoints typés — gouverne les services de la pile GenAI orchestrée par Aspire (les notebooks [01](01-Aspire-Orchestration-GenAi.ipynb) et [02](02-Aspire-GenAiStack-Reel.ipynb)).\n",
+    "Dans le projet [`StreamingAgent.App/`](StreamingAgent.App/), ces trois briques forment un service réel : un `AgentService` hôte (canaux inbound/outbound) exposé par des endpoints typés (`/health`, `/greet`, `/stream`, `/stream-sse`), vérifiable par `curl`. Les deux derniers servent **le même canal sous deux contrats** : le buffer JSON efface la cadence, le flux SSE la conserve — et c'est la mesure des deltas d'arrivée de A4, pas la prose, qui départage. Le même contrat — flux d'événements, cycle de vie hôte, endpoints typés — gouverne les services de la pile GenAI orchestrée par Aspire (les notebooks [01](01-Aspire-Orchestration-GenAi.ipynb) et [02](02-Aspire-GenAiStack-Reel.ipynb)).\n",
     "\n",
     "**Pour aller plus loin** : brancher l'observabilité (même famille, grain [#11516](https://github.com/jsboige/CoursIA/issues/11516) A9) — `ActivitySource` au moment de chaque token, trace OTLP du flux complet. Le mécanisme de l'[observabilité dans la série SemanticKernel](../SemanticKernel/04-SemanticKernel-Filters-Observability.ipynb) s'applique tel quel à ce service.\n"
    ]

--- a/MyIA.AI.Notebooks/GenAI/Aspire/StreamingAgent.App/Program.cs
+++ b/MyIA.AI.Notebooks/GenAI/Aspire/StreamingAgent.App/Program.cs
@@ -1,3 +1,5 @@
+using System.Net.ServerSentEvents;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Channels;
 using Microsoft.AspNetCore.Builder;
@@ -13,6 +15,7 @@ var app = builder.Build();
 app.MapGet("/health", () => TypedResults.Ok(new HealthResponse("ok", "streaming-agent")));
 app.MapPost("/greet", GreetHandler.Handle);
 app.MapPost("/stream", StreamHandler.Handle);
+app.MapPost("/stream-sse", SseStreamHandler.Handle);
 
 if (args.Length == 0)
 {
@@ -51,6 +54,42 @@ public static class StreamHandler
             }
         }
         return TypedResults.Text(JsonSerializer.Serialize(events, new JsonSerializerOptions(JsonSerializerDefaults.Web)), "application/json");
+    }
+}
+
+// Meme service, memes evenements, DEUX contrats HTTP.
+//
+// `/stream` ci-dessus accumule dans une `List<AgentEvent>` et ne repond qu'apres
+// l'evenement `done` : le client recoit un bloc unique, et les 80 ms qui separent
+// deux tokens dans le `Channel` ont disparu du fil. `/stream-sse` renvoie le meme
+// flux en Server-Sent Events -- `TypedResults.ServerSentEvents` prend un
+// `IAsyncEnumerable<SseItem<T>>` et ecrit chaque element des qu'il est produit.
+//
+// C'est la difference que la mesure des deltas d'arrivee cote client rend visible :
+// meme donnee, meme canal, cadence conservee d'un cote, ecrasee de l'autre.
+public static class SseStreamHandler
+{
+    public static async Task<IResult> Handle(StreamRequest request, AgentService service, CancellationToken ct)
+    {
+        await service.SubmitAsync(new AgentRequest(request.Prompt), ct);
+        return TypedResults.ServerSentEvents(Evenements(service, ct));
+    }
+
+    // Le `Kind` de l'evenement devient le champ `event:` du protocole SSE, et le
+    // `Payload` son champ `data:` -- un client SSE standard sait donc distinguer
+    // un token d'un `done` sans parser de JSON.
+    private static async IAsyncEnumerable<SseItem<string>> Evenements(
+        AgentService service,
+        [EnumeratorCancellation] CancellationToken ct)
+    {
+        await foreach (var evt in service.Stream.ReadAllAsync(ct))
+        {
+            yield return new SseItem<string>(evt.Payload, evt.Kind);
+            if (evt.Kind == "done")
+            {
+                yield break;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Grain: DEEP/notebook-dotnet — lane myia-ai-01:CoursIA — prev: MED/notebook-python #12154

## Le defaut repare

Le notebook s'appelle **04-Aspire-Streaming-Agent** et sa seule surface HTTP etait **bufferisee**. `StreamHandler.Handle` accumulait `events.Add(evt)` dans une `List<AgentEvent>` et ne renvoyait `TypedResults.Text(JsonSerializer.Serialize(events, …), "application/json")` **qu'apres** `done` — alors que `AgentService.ExecuteAsync` ecrit un token **puis** `await Task.Delay(80, …)`. Le moteur (`Channel<T>` + `BackgroundService`) etait bon ; c'est le contrat de sortie qui annulait la demonstration.

C'est le cas canonique du **probleme degenere** de [sota-not-workaround.md](../blob/main/.claude/rules/sota-not-workaround.md) Prong B : la capacite distinctive annoncee par le titre n'etait **pas visible dans la sortie**. Un lecteur voyait un JSON arriver d'un coup et devait croire la prose sur parole.

## Ce que fait cette tranche

**`Program.cs` (+39)** — endpoint `/stream-sse` via `TypedResults.ServerSentEvents` sur un `IAsyncEnumerable<SseItem<string>>` (`System.Net.ServerSentEvents`, .NET 10) :

```csharp
private static async IAsyncEnumerable<SseItem<string>> Evenements(
    AgentService service,
    [EnumeratorCancellation] CancellationToken ct)
{
    await foreach (var evt in service.Stream.ReadAllAsync(ct))
    {
        yield return new SseItem<string>(evt.Payload, evt.Kind);
        if (evt.Kind == "done") { yield break; }
    }
}
```

**Meme service, meme channel, deux contrats.** `/stream` est conserve tel quel : le point pedagogique est justement la comparaison, pas le remplacement.

**Notebook (17 → 21 cellules)** — section A4 qui **mesure les deltas d'arrivee** cote client sur les deux endpoints, plus un 4e exercice. Sortie committee de la cellule de mesure :

```
/stream      -> application/json
                1 seule arrivee a t+378 ms, 187 octets d'un coup
/stream-sse  -> text/event-stream
                "un" a t+18 ms (delta 18 ms)
                "deux" a t+115 ms (delta 97 ms)
                "trois" a t+207 ms (delta 92 ms)
                "quatre" a t+297 ms (delta 90 ms)
                "un deux trois quatre" a t+394 ms (delta 97 ms)
```

Premier octet utile a **t+18 ms** contre **t+378 ms**, facteur 21, **a latence totale identique** (394 vs 378 ms). La difference se lit dans l'output au lieu d'etre affirmee dans la prose — c'est tout l'objet du grain.

## Preuve d'execution (H.1 / H.3 / C.1)

Papermill **RC=0** depuis `MyIA.AI.Notebooks/GenAI/Aspire` (`python -m papermill … --cwd .`), build `dotnet` 0 erreur. Etat mecanique du notebook committe :

```
cells=21 code=10 null_ec=[] no_out=[8] errors=[] C1=[] exercices=4
```

`null_ec=[]` (aucune cellule code non executee), `errors=[]` (aucun `output_type: error`), `C1=[]` (aucun `raise NotImplementedError` / `assert False` / `1/0`). `no_out=[8]` est la cellule d'ecriture de fichier, qui ne produit legitimement rien.

Banniere `probeAddresses` strippee via `scripts/notebook_tools/strip_probe_banner.py --apply` (9 lignes, **0 restante**, verifie par `grep -c`). `metadata.papermill` normalise au style maison. **Aucune sortie n'a ete hand-editee** : les nombres cites viennent de la derniere execution. Les 37 suppressions du diff notebook ont ete auditees une a une (banniere strippee, deux lignes de version remplacees par des sorties fraiches, une phrase de Conclusion volontairement reecrite pour nommer `/stream-sse`) — aucune cellule ni contenu perdu.

**Note de derive assumee** : le paragraphe d'interpretation cite les valeurs **de l'execution committee** et le dit explicitement dans le notebook — ces timings bougent d'une machine a l'autre. L'edition finale du markdown d'interpretation s'est faite **sans re-execution**, ce que C.2 autorise pour une modification markdown-only ; c'est le levier qui casse la boucle « la prose cite des nombres → re-executer change les nombres ».

## Verdict SOTA et perimetre

**SOTA-OK** sur ce qui est livre : `TypedResults.ServerSentEvents` est l'API .NET 10 reelle, invoquee pour de vrai, et sa vraie sortie est committee.

Le perimetre est dit ici plutot que laisse a deviner — #11926 porte trois axes, cette PR en livre un :

| Acceptance #11926 | Statut | Motif |
|---|---|---|
| 4 — `TypedResults.ServerSentEvents` | **livree** | cette PR |
| 3 — moitie streaming | **livree** | mesure des deltas cote client |
| 5 — decouverte `IEndpoint` (Scrutor) | **tranche separee** | orthogonale au contrat de sortie ; la melanger ferait un composite (G.4) |
| 2 — `CopilotClient` | **RECOVERABLE-USER-HAND** | BYOK Azure OpenAI |
| 6 — `OnPermissionRequest` | **RECOVERABLE-USER-HAND** | idem |

Pour 2 et 6 : `.secrets/master.env` porte `OPENAI_API_KEY` mais **aucune** cle Azure — verifie **sur les noms de variables, jamais sur les valeurs**. Ce n'est pas `INTRINSIC` (l'API existe et fonctionne), c'est une action user one-time, signalee comme telle.

`See #11926` — et non `Closes` : deux acceptances sur cinq restent ouvertes.
