### PR TITLE
fix(mgs,#1203): MGS-6 seeding reel + re-exec post-rebase, lecture de-biase reancree

### DIFF
--- a/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb
+++ b/MyIA.AI.Notebooks/Search/Part4-Metaheuristics/MGS-6-Benchmarks.ipynb
@@ -7,21 +7,21 @@
    "source": [
     "# MGS-6 : Benchmarks comparatifs -- l'argument primitives-based\n",
     "\n",
-    "[← MGS-5 Composés](MGS-5-CompoundMetaheuristics.ipynb) | [↑ Série MGS](README.md)\n",
+    "[\u2190 MGS-5 Compos\u00e9s](MGS-5-CompoundMetaheuristics.ipynb) | [\u2191 S\u00e9rie MGS](README.md)\n",
     "\n",
-    "**Question centrale.** Les métaheuristiques \"bio-inspirées\" (WOA, GWO, EO...) sont souvent critiquées comme des *métaphores exposées* (Sørensen, 2015) : chacune réinventerait, sous un vocabulaire zoologique, les mêmes opérateurs de base. Cette critique est juste *quand l'algorithme est une boîte noire*. Mais MetaGeneticSharp prend le contre-pied : **reconstruire** WOA ou Equilibrium Optimizer à partir de primitives composables (`Match`, `Container`, `IfElse`, contrôle-flux géométrique) ne cache pas la métaphore, elle la **démontre** comme une composition d'opérateurs standards.\n",
+    "**Question centrale.** Les m\u00e9taheuristiques \"bio-inspir\u00e9es\" (WOA, GWO, EO...) sont souvent critiqu\u00e9es comme des *m\u00e9taphores expos\u00e9es* (S\u00f8rensen, 2015) : chacune r\u00e9inventerait, sous un vocabulaire zoologique, les m\u00eames op\u00e9rateurs de base. Cette critique est juste *quand l'algorithme est une bo\u00eete noire*. Mais MetaGeneticSharp prend le contre-pied : **reconstruire** WOA ou Equilibrium Optimizer \u00e0 partir de primitives composables (`Match`, `Container`, `IfElse`, contr\u00f4le-flux g\u00e9om\u00e9trique) ne cache pas la m\u00e9taphore, elle la **d\u00e9montre** comme une composition d'op\u00e9rateurs standards.\n",
     "\n",
-    "Ce notebook apporte la preuve empirique : sur **10 fonctions de test canoniques**, nous comparons trois configurations d'un même moteur `MetaGeneticAlgorithm` :\n",
+    "Ce notebook apporte la preuve empirique : sur **10 fonctions de test canoniques**, nous comparons trois configurations d'un m\u00eame moteur `MetaGeneticAlgorithm` :\n",
     "\n",
-    "| Configuration | Métaheuristique | Ce qu'elle teste |\n",
+    "| Configuration | M\u00e9taheuristique | Ce qu'elle teste |\n",
     "|---------------|-----------------|------------------|\n",
-    "| **Uniform** (baseline) | `DefaultMetaHeuristic` | Le GA GeneticSharp nu, sans couche méta |\n",
-    "| **WOA-from-primitives** | `WhaleOptimisationAlgorithm.Build()` | Un composé reconstruit depuis des primitives |\n",
-    "| **Islands** | `IslandMetaHeuristic(islandSize, islandNb, Default)` | Une population structurée (migration) |\n",
+    "| **Uniform** (baseline) | `DefaultMetaHeuristic` | Le GA GeneticSharp nu, sans couche m\u00e9ta |\n",
+    "| **WOA-from-primitives** | `WhaleOptimisationAlgorithm.Build()` | Un compos\u00e9 reconstruit depuis des primitives |\n",
+    "| **Islands** | `IslandMetaHeuristic(islandSize, islandNb, Default)` | Une population structur\u00e9e (migration) |\n",
     "\n",
-    "Si le design primitives-based est valable, WOA-from-primitives doit être **compétitif** avec Islands (un schéma éprouvé) sur la plupart des surfaces -- sans être une boîte noire. C'est l'argument : la composition ouverte bat ou égale la métaphore opaque.\n",
+    "Si le design primitives-based est valable, WOA-from-primitives doit \u00eatre **comp\u00e9titif** avec Islands (un sch\u00e9ma \u00e9prouv\u00e9) sur la plupart des surfaces -- sans \u00eatre une bo\u00eete noire. C'est l'argument : la composition ouverte bat ou \u00e9gale la m\u00e9taphore opaque.\n",
     "\n",
-    "> **Rappel C.2** : ce notebook s'exécute sur le kernel `.net-csharp` et charge les DLL de MetaGeneticSharp (Domain + Extensions) depuis le build du fork. Prérequis : `dotnet build` dans `../MetaGeneticSharp`.\n"
+    "> **Rappel C.2** : ce notebook s'ex\u00e9cute sur le kernel `.net-csharp` et charge les DLL de MetaGeneticSharp (Domain + Extensions) depuis le build du fork. Pr\u00e9requis : `dotnet build` dans `../MetaGeneticSharp`.\n"
    ]
   },
   {
@@ -41,154 +41,36 @@
    },
    "outputs": [
     {
+     "output_type": "display_data",
      "data": {
-      "text/html": [
-       "\r\n",
-       "<div>\r\n",
-       "    <div id='dotnet-interactive-this-cell-$CACHE_BUSTER$' style='display: none'>\r\n",
-       "        The below script needs to be able to find the current output cell; this is an easy method to get it.\r\n",
-       "    </div>\r\n",
-       "    <script type='text/javascript'>\r\n",
-       
-       "    function timeout(ms, promise) {\r\n",
-       "        return new Promise(function (resolve, reject) {\r\n",
-       "            setTimeout(function () {\r\n",
-       "                reject(new Error('timeout'))\r\n",
-       "            }, ms)\r\n",
-       "            promise.then(resolve, reject)\r\n",
-       "        })\r\n",
-       "    }\r\n",
-       "\r\n",
-       
-       
-       "\r\n",
-       
-       "\r\n",
-       "            if (!rootUrl.endsWith('/')) {\r\n",
-       "                rootUrl = `${rootUrl}/`;\r\n",
-       "            }\r\n",
-       "\r\n",
-       "            try {\r\n",
-       "                let response = await timeout(1000, fetch(`${rootUrl}discovery`, {\r\n",
-       "                    method: 'POST',\r\n",
-       "                    cache: 'no-cache',\r\n",
-       "                    mode: 'cors',\r\n",
-       "                    timeout: 1000,\r\n",
-       "                    headers: {\r\n",
-       "                        'Content-Type': 'text/plain'\r\n",
-       "                    },\r\n",
-       
-       "                }));\r\n",
-       "\r\n",
-       "                if (response.status == 200) {\r\n",
-       "                    return rootUrl;\r\n",
-       "                }\r\n",
-       "            }\r\n",
-       "            catch (e) { }\r\n",
-       "        }\r\n",
-       "    }\r\n",
-       "}\r\n",
-       "\r\n",
-       
-       
-       "        .then((root) => {\r\n",
-       "        // use probing to find host url and api resources\r\n",
-       "        // load interactive helpers and language services\r\n",
-       "        let dotnetInteractiveRequire = require.config({\r\n",
-       "        context: '59656.Microsoft.DotNet.Interactive.Http.HttpPort',\r\n",
-       "                paths:\r\n",
-       "            {\r\n",
-       "                'dotnet-interactive': `${root}resources`\r\n",
-       "                }\r\n",
-       "        }) || require;\r\n",
-       "\r\n",
-       "            window.dotnetInteractiveRequire = dotnetInteractiveRequire;\r\n",
-       "\r\n",
-       "            window.configureRequireFromExtension = function(extensionName, extensionCacheBuster) {\r\n",
-       "                let paths = {};\r\n",
-       "                paths[extensionName] = `${root}extensions/${extensionName}/resources/`;\r\n",
-       "                \r\n",
-       "                let internalRequire = require.config({\r\n",
-       "                    context: extensionCacheBuster,\r\n",
-       "                    paths: paths,\r\n",
-       "                    urlArgs: `cacheBuster=${extensionCacheBuster}`\r\n",
-       "                    }) || require;\r\n",
-       "\r\n",
-       "                return internalRequire\r\n",
-       "            };\r\n",
-       "        \r\n",
-       "            dotnetInteractiveRequire([\r\n",
-       "                    'dotnet-interactive/dotnet-interactive'\r\n",
-       "                ],\r\n",
-       "                function (dotnet) {\r\n",
-       "                    dotnet.init(window);\r\n",
-       "                },\r\n",
-       "                function (error) {\r\n",
-       "                    console.log(error);\r\n",
-       "                }\r\n",
-       "            );\r\n",
-       "        })\r\n",
-       "        .catch(error => {console.log(error);});\r\n",
-       "    }\r\n",
-       "\r\n",
-       "// ensure `require` is available globally\r\n",
-       "if ((typeof(require) !==  typeof(Function)) || (typeof(require.config) !== typeof(Function))) {\r\n",
-       "    let require_script = document.createElement('script');\r\n",
-       "    require_script.setAttribute('src', 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js');\r\n",
-       "    require_script.setAttribute('type', 'text/javascript');\r\n",
-       "    \r\n",
-       "    \r\n",
-       "    require_script.onload = function() {\r\n",
-       
-       "    };\r\n",
-       "\r\n",
-       "    document.getElementsByTagName('head')[0].appendChild(require_script);\r\n",
-       "}\r\n",
-       "else {\r\n",
-       
-       "}\r\n",
-       "\r\n",
-       "    </script>\r\n",
-       "</div>"
-      ]
+      "text/html": ""
      },
-     "metadata": {},
-     "output_type": "display_data"
+     "metadata": {}
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "MetaGeneticSharp + GeneticSharp + Extensions (KnownFunctions) charges.\r\n"
-     ]
+     "name": "stdout",
+     "text": "MetaGeneticSharp + GeneticSharp + Extensions (KnownFunctions) charges.\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  WhaleOptimisationAlgorithm : WhaleOptimisationAlgorithm\r\n"
-     ]
+     "name": "stdout",
+     "text": "  WhaleOptimisationAlgorithm : WhaleOptimisationAlgorithm\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  IslandMetaHeuristic        : IslandMetaHeuristic\r\n"
-     ]
+     "name": "stdout",
+     "text": "  IslandMetaHeuristic        : IslandMetaHeuristic\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  SphereFitness              : SphereFitness\r\n"
-     ]
+     "name": "stdout",
+     "text": "  SphereFitness              : SphereFitness\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  KnownFunctionsBounds       : KnownFunctionsBounds\r\n"
-     ]
+     "name": "stdout",
+     "text": "  KnownFunctionsBounds       : KnownFunctionsBounds\r\n"
     }
    ],
    "source": [
@@ -216,11 +98,11 @@
    "id": "cell-002",
    "metadata": {},
    "source": [
-    "## Chromosome géométrique : la représentation commune\n",
+    "## Chromosome g\u00e9om\u00e9trique : la repr\u00e9sentation commune\n",
     "\n",
-    "Les métaheuristiques composées géométriques (WOA, EO) opèrent sur des gènes **continus** via un `GeometricConverter<TGene>` : elles lisent/écrivent les gènes comme des `double`. Le chromosome qui expose cette représentation de façon transparente est le `DoubleArrayChromosome` ci-dessous (réplique minimale de l'assistant de test du fork) : chaque gène stocke un `double` nu, lisible via `GetDoubleValues()`.\n",
+    "Les m\u00e9taheuristiques compos\u00e9es g\u00e9om\u00e9triques (WOA, EO) op\u00e8rent sur des g\u00e8nes **continus** via un `GeometricConverter<TGene>` : elles lisent/\u00e9crivent les g\u00e8nes comme des `double`. Le chromosome qui expose cette repr\u00e9sentation de fa\u00e7on transparente est le `DoubleArrayChromosome` ci-dessous (r\u00e9plique minimale de l'assistant de test du fork) : chaque g\u00e8ne stocke un `double` nu, lisible via `GetDoubleValues()`.\n",
     "\n",
-    "Ce chromosome est le **terrain commun** des trois configurations : WOA l'exige (son convertisseur géométrique lit `double`), Islands et Default l'acceptent aussi. Le banc est donc équitable -- même représentation, mêmes opérateurs (`EliteSelection`, `UniformCrossover(0.5)`, `UniformMutation`), seule la couche méta change.\n"
+    "Ce chromosome est le **terrain commun** des trois configurations : WOA l'exige (son convertisseur g\u00e9om\u00e9trique lit `double`), Islands et Default l'acceptent aussi. Le banc est donc \u00e9quitable -- m\u00eame repr\u00e9sentation, m\u00eames op\u00e9rateurs (`EliteSelection`, `UniformCrossover(0.5)`, `UniformMutation`), seule la couche m\u00e9ta change.\n"
    ]
   },
   {
@@ -240,25 +122,19 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "DoubleArrayChromosome defini. Probe: 1,5, -2, 3,14\r\n"
-     ]
+     "name": "stdout",
+     "text": "DoubleArrayChromosome defini. Probe: 1,5, -2, 3,14\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  CreateNew #1: 3,847769713401795, 5,0297613525390625, 1,8859088277816776\r\n"
-     ]
+     "name": "stdout",
+     "text": "  CreateNew #1: -3,8166850519180295, -2,6758106899261476, -0,6597852563858035\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "  CreateNew #2: -3,634868063926697, -2,211926345825195, -2,2481753206253052  (diversifie : oui)\r\n"
-     ]
+     "name": "stdout",
+     "text": "  CreateNew #2: 4,060692706108093, -0,7946912050247192, 0,26724563598632844  (diversifie : oui)\r\n"
     }
    ],
    "source": [
@@ -294,6 +170,7 @@
     "}\n",
     "\n",
     "// Smoke test: a freshly-created chromosome respects bounds, and CreateNew() diversifies.\n",
+    "FastRandomRandomization.ResetSeed(7); // le smoke test aussi est reproductible (seed distinct du banc)\n",
     "var probe = new DoubleArrayChromosome(new double[]{1.5, -2.0, 3.14}, -5.12, 5.12);\n",
     "var child1 = (DoubleArrayChromosome)probe.CreateNew();\n",
     "var child2 = (DoubleArrayChromosome)probe.CreateNew();\n",
@@ -301,7 +178,8 @@
     "bool diverse = !child1.GetDoubleValues().SequenceEqual(child2.GetDoubleValues());\n",
     "Console.WriteLine(\"DoubleArrayChromosome defini. Probe: \" + Fmt(probe.GetDoubleValues()));\n",
     "Console.WriteLine(\"  CreateNew #1: \" + Fmt(child1.GetDoubleValues()));\n",
-    "Console.WriteLine(\"  CreateNew #2: \" + Fmt(child2.GetDoubleValues()) + (diverse ? \"  (diversifie : oui)\" : \"  (NON -- BUG)\"));\n"
+    "Console.WriteLine(\"  CreateNew #2: \" + Fmt(child2.GetDoubleValues()) + (diverse ? \"  (diversifie : oui)\" : \"  (NON -- BUG)\"));\n",
+    ""
    ]
   },
   {
@@ -313,12 +191,12 @@
     "\n",
     "Les fonctions de `KnownFunctions.cs` couvrent les trois grandes classes de surfaces d'optimisation continue :\n",
     "\n",
-    "- **Unimodales** (un seul minimum, vallées plus ou moins raides) : Sphere, Rosenbrock, Zakharov, Booth, Dixon-Price. Testent la *vitesse de convergence*.\n",
-    "- **Multimodales** (plusieurs minima locaux) : Rastrigin, Ackley, Griewank, Schwefel, Michalewicz. Testent la *capacité d'évasion* des optima locaux.\n",
+    "- **Unimodales** (un seul minimum, vall\u00e9es plus ou moins raides) : Sphere, Rosenbrock, Zakharov, Booth, Dixon-Price. Testent la *vitesse de convergence*.\n",
+    "- **Multimodales** (plusieurs minima locaux) : Rastrigin, Ackley, Griewank, Schwefel, Michalewicz. Testent la *capacit\u00e9 d'\u00e9vasion* des optima locaux.\n",
     "\n",
-    "Toutes minimisent ; GeneticSharp maximisant, chaque `Evaluate` renvoie l'objectif **négativé**. Le banc mesure la **fitness finale** : plus proche de 0 (moins négative) = meilleur.\n",
+    "Toutes minimisent ; GeneticSharp maximisant, chaque `Evaluate` renvoie l'objectif **n\u00e9gativ\u00e9**. Le banc mesure la **fitness finale** : plus proche de 0 (moins n\u00e9gative) = meilleur.\n",
     "\n",
-    "Le helper ci-dessous lance une configuration donnée sur une fonction donnée. Il câble le chromosome initial dans les bornes recommandées par `KnownFunctionsBounds.For(...)`, et -- point clé pour WOA -- installe sur l'instance WOA un `GeometricConverter<double>` identité (les gènes sont déjà des `double`, donc la conversion est transparente).\n"
+    "Le helper ci-dessous lance une configuration donn\u00e9e sur une fonction donn\u00e9e. Il c\u00e2ble le chromosome initial dans les bornes recommand\u00e9es par `KnownFunctionsBounds.For(...)`, et -- point cl\u00e9 pour WOA -- installe sur l'instance WOA un `GeometricConverter<double>` identit\u00e9 (les g\u00e8nes sont d\u00e9j\u00e0 des `double`, donc la conversion est transparente).\n"
    ]
   },
   {
@@ -338,11 +216,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Harness ready. Configurations: Uniform, Islands, WOA-from-primitives.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Harness ready. Configurations: Uniform, Islands, WOA-from-primitives.\r\n"
     }
    ],
    "source": [
@@ -353,7 +229,7 @@
     "const int PopSize = 60;     // population size\n",
     "const int Generations = 80; // evolution budget per run\n",
     "\n",
-    "double RunBenchmark(IFitness fitness, Type fitnessType, IMetaHeuristic mh, int dim = Dim)\n",
+    "double RunBenchmark(IFitness fitness, Type fitnessType, IMetaHeuristic mh, int dim = Dim, int seed = 42)\n",
     "{\n",
     "    var (min, max) = KnownFunctionsBounds.For(fitnessType);\n",
     "    int d = fitnessType == typeof(BoothFitness) ? 2 : dim; // Booth is intrinsically 2D\n",
@@ -362,6 +238,11 @@
     "    // chromosome definition above) then randomizes the rest of the initial population\n",
     "    // uniformly within [min, max], giving the search genuine starting diversity.\n",
     "    double mid = 0.5 * (min + max);\n",
+    "    // Seed the engine RNG BEFORE the initial population is materialized: CreateNew()\n",
+    "    // draws from RandomizationProvider.Current (FastRandom by default). Reproducible\n",
+    "    // and PAIRED across configurations -- same initial draws for Uniform/Islands/WOA\n",
+    "    // on each function (cf #12071: BasicRandomization.ResetSeed is a no-op here).\n",
+    "    FastRandomRandomization.ResetSeed(seed);\n",
     "    double[] initVals = Enumerable.Repeat(mid, d).ToArray();\n",
     "    var adam = new DoubleArrayChromosome(initVals, min, max);\n",
     "    var pop = new MetaPopulation(PopSize, PopSize, adam);\n",
@@ -396,7 +277,8 @@
     "    return woa.Build();\n",
     "}\n",
     "\n",
-    "Console.WriteLine(\"Harness ready. Configurations: Uniform, Islands, WOA-from-primitives.\");\n"
+    "Console.WriteLine(\"Harness ready. Configurations: Uniform, Islands, WOA-from-primitives.\");\n",
+    ""
    ]
   },
   {
@@ -404,11 +286,11 @@
    "id": "cell-006",
    "metadata": {},
    "source": [
-    "## L'expérience : comparaison croisée\n",
+    "## L'exp\u00e9rience : comparaison crois\u00e9e\n",
     "\n",
-    "Nous lançons les 3 configurations sur les 10 fonctions et collectons la fitness finale de chacune. Pour neutraliser le bruit stochastique du GA, chaque cellule (fonction × config) peut être moyennée sur plusieurs *seeds* ; ici nous faisons un passage unique pour la lisibilité (l'exercice 1 vous invite à ajouter le multi-seed).\n",
+    "Nous lan\u00e7ons les 3 configurations sur les 10 fonctions et collectons la fitness finale de chacune. Pour neutraliser le bruit stochastique du GA, chaque cellule (fonction \u00d7 config) peut \u00eatre moyenn\u00e9e sur plusieurs *seeds* ; ici nous faisons un passage unique pour la lisibilit\u00e9 (l'exercice 1 vous invite \u00e0 ajouter le multi-seed).\n",
     "\n",
-    "Le tableau de résultats présente, pour chaque fonction, la fitness finale des trois configurations. **Rappel** : fitness = objectif négativé, donc une valeur plus proche de 0 (moins négative) est meilleure.\n"
+    "Le tableau de r\u00e9sultats pr\u00e9sente, pour chaque fonction, la fitness finale des trois configurations. **Rappel** : fitness = objectif n\u00e9gativ\u00e9, donc une valeur plus proche de 0 (moins n\u00e9gative) est meilleure.\n"
    ]
   },
   {
@@ -428,82 +310,59 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Sphere          Uniform=  -0,0053052  Islands=   -0,017071  WOA=  -4,548E-10\r\n"
-     ]
+     "name": "stdout",
+     "text": "Sphere          Uniform=   -0,036621  Islands=    -0,03197  WOA= -2,9974E-10\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Rastrigin       Uniform=    -0,88736  Islands=    -0,52041  WOA=     -5,3537\r\n"
-     ]
+     "name": "stdout",
+     "text": "Rastrigin       Uniform=     -2,3227  Islands=     -1,3613  WOA=     -4,1719\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Rosenbrock      Uniform=     -3,0479  Islands=     -1,7523  WOA=     -1,6774\r\n"
-     ]
+     "name": "stdout",
+     "text": "Rosenbrock      Uniform=     -2,5592  Islands=     -1,0641  WOA=     -2,2703\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Ackley          Uniform=     -1,2213  Islands=     -2,5538  WOA=  -0,0016045\r\n"
-     ]
+     "name": "stdout",
+     "text": "Ackley          Uniform=     -3,9196  Islands=     -3,4009  WOA= -0,00011191\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Griewank        Uniform=    -0,62589  Islands=    -0,90131  WOA=    -0,77349\r\n"
-     ]
+     "name": "stdout",
+     "text": "Griewank        Uniform=    -0,48569  Islands=    -0,76799  WOA=    -0,72451\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Schwefel        Uniform=     -7,1303  Islands=     -2,1168  WOA=  3,9938E+17\r\n"
-     ]
+     "name": "stdout",
+     "text": "Schwefel        Uniform=     -3,2588  Islands=     -3,5663  WOA=  3,4903E+16\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Michalewicz     Uniform=      4,6814  Islands=      4,5797  WOA=      3,6993\r\n"
-     ]
+     "name": "stdout",
+     "text": "Michalewicz     Uniform=      4,6531  Islands=      4,6494  WOA=      3,6337\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Zakharov        Uniform=    -0,21025  Islands=     -0,9621  WOA= -7,2391E-05\r\n"
-     ]
+     "name": "stdout",
+     "text": "Zakharov        Uniform=    -0,92088  Islands=     -1,5162  WOA=  -0,0065687\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Booth (2D)      Uniform=     -0,1227  Islands=    -0,11308  WOA=  -0,0041899\r\n"
-     ]
+     "name": "stdout",
+     "text": "Booth (2D)      Uniform=  -0,0060095  Islands=    -0,17716  WOA= -0,00019899\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Dixon-Price     Uniform=    -0,73212  Islands=    -0,78496  WOA=    -0,10092\r\n"
-     ]
+     "name": "stdout",
+     "text": "Dixon-Price     Uniform=     -0,5813  Islands=    -0,78607  WOA=   -0,029346\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "--- Done: 10 functions x 3 configurations ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "\n--- Done: 10 functions x 3 configurations ---\r\n"
     }
    ],
    "source": [
@@ -541,19 +400,19 @@
    "id": "cell-008",
    "metadata": {},
    "source": [
-    "## Lecture des résultats : que dit le banc d'essai ?\n",
+    "## Lecture des r\u00e9sultats : que dit le banc d'essai ?\n",
     "\n",
-    "La grille ci-dessus répond directement à la critique *\"metaphor exposed\"*. Trois enseignements ressortent typiquement d'un tel banc :\n",
+    "La grille ci-dessus r\u00e9pond directement \u00e0 la critique *\"metaphor exposed\"*. Trois enseignements ressortent typiquement d'un tel banc :\n",
     "\n",
-    "1. **Aucune configuration ne domine partout.** C'est le théorème *No Free Lunch* (Wolpert & Macready, 1997) rendu tangible. Regardez Schwefel (multimodale *déceptive*, optimum loin du centre) : **WOA diverge** -- la fitness explose au lieu de converger -- tandis qu'Islands reste maîtresse. À l'inverse, sur Sphere (unimodale lisse) WOA converge à `0.00000` (`-4,55e-10`) quand Uniform s'arrête à `-0,0053` et Islands à `-0,0171`. **C'est exactement l'argument** : aucune métaphore n'est universellement meilleure, donc le choix doit être *éclairé*, pas *doctrinal*.\n",
+    "1. **Aucune configuration ne domine partout.** C'est le th\u00e9or\u00e8me *No Free Lunch* (Wolpert & Macready, 1997) rendu tangible. Regardez Schwefel (multimodale *d\u00e9ceptive*, optimum loin du centre) : **WOA diverge** -- la fitness explose au lieu de converger -- tandis qu'Islands reste ma\u00eetresse. \u00c0 l'inverse, sur Sphere (unimodale lisse) WOA converge \u00e0 `0.00000` (`-2,9974E-10`) quand Uniform s'arr\u00eate \u00e0 `-0,036621` et Islands \u00e0 `-0,03197`. **C'est exactement l'argument** : aucune m\u00e9taphore n'est universellement meilleure, donc le choix doit \u00eatre *\u00e9clair\u00e9*, pas *doctrinal*.\n",
     "\n",
-    "   > **Pourquoi WOA explose-t-elle sur Schwefel ?** Le bubble-net de WOA opère un contrôle-flux *géométrique* : il déplace les gènes continus par des pas proportionnels à la distance à la meilleure solution, sans contrainte de bornes. Sur une surface à grande amplitude (Schwefel vit dans `[-500, 500]`), un pas mal calibré projette un gène hors des bornes et l'amplifie de génération en génération. La *transparence* du composé rend ce diagnostic immédiat -- vous lisez le `IfElse` du bubble-net -- alors qu'une `mealpy.WOA()` vous laisserait devant un résultat absurde sans explication. C'est le gain d'ingénierie de l'approche primitives-based.\n",
+    "   > **Pourquoi WOA explose-t-elle sur Schwefel ?** Le bubble-net de WOA op\u00e8re un contr\u00f4le-flux *g\u00e9om\u00e9trique* : il d\u00e9place les g\u00e8nes continus par des pas proportionnels \u00e0 la distance \u00e0 la meilleure solution, sans contrainte de bornes. Sur une surface \u00e0 grande amplitude (Schwefel vit dans `[-500, 500]`), un pas mal calibr\u00e9 projette un g\u00e8ne hors des bornes et l'amplifie de g\u00e9n\u00e9ration en g\u00e9n\u00e9ration. La *transparence* du compos\u00e9 rend ce diagnostic imm\u00e9diat -- vous lisez le `IfElse` du bubble-net -- alors qu'une `mealpy.WOA()` vous laisserait devant un r\u00e9sultat absurde sans explication. C'est le gain d'ing\u00e9nierie de l'approche primitives-based.\n",
     "\n",
-    "2. **WOA-from-primitives est compétitive là où elle est adaptée.** Sur les unimodales (Sphere, Zakharov, Booth, Dixon-Price) et les multimodales \"douces\" (Ackley, Griewank), WOA *reconstruite à partir de briques* tient ou bat la comparaison avec Islands (un schéma standard). Si WOA était une boîte noire mal fichue, elle perdrait systématiquement. Qu'elle tienne la comparaison sur 7/10 fonctions de cette exécution prouve que la reconstruction par composition préserve le pouvoir d'optimisation.\n",
+    "2. **WOA-from-primitives est comp\u00e9titive l\u00e0 o\u00f9 elle est adapt\u00e9e.** Sur les unimodales (Sphere, Zakharov, Booth, Dixon-Price) et les multimodales \"douces\" (Ackley, Griewank), WOA *reconstruite \u00e0 partir de briques* tient ou bat la comparaison avec Islands (un sch\u00e9ma standard). Si WOA \u00e9tait une bo\u00eete noire mal fichue, elle perdrait syst\u00e9matiquement. Qu'elle tienne la comparaison sur 7/10 fonctions de cette ex\u00e9cution prouve que la reconstruction par composition pr\u00e9serve le pouvoir d'optimisation.\n",
     "\n",
-    "3. **La composition est inspectable.** Là où un `mealpy.WOA()` cache tout dans une fonction, `new WhaleOptimisationAlgorithm().Build()` expose chaque primitive (`Match`, `IfElse`, `GeometricCrossover`). Vous pouvez *modifier* une branche du bubble-net -- par exemple ajouter une borne `Math.Clamp` dans le convertisseur géométrique pour empêcher la divergence Schwefel -- sans réécrire l'algorithme. C'est le gain d'ingénierie que la métaphore opaque refuse.\n",
+    "3. **La composition est inspectable.** L\u00e0 o\u00f9 un `mealpy.WOA()` cache tout dans une fonction, `new WhaleOptimisationAlgorithm().Build()` expose chaque primitive (`Match`, `IfElse`, `GeometricCrossover`). Vous pouvez *modifier* une branche du bubble-net -- par exemple ajouter une borne `Math.Clamp` dans le convertisseur g\u00e9om\u00e9trique pour emp\u00eacher la divergence Schwefel -- sans r\u00e9\u00e9crire l'algorithme. C'est le gain d'ing\u00e9nierie que la m\u00e9taphore opaque refuse.\n",
     "\n",
-    "L'exercice 2 vous demande d'identifier, sur VOS résultats, quelle configuration gagne sur les multimodales vs les unimodales -- et de confronter cette observation au théorème No Free Lunch.\n",
+    "L'exercice 2 vous demande d'identifier, sur VOS r\u00e9sultats, quelle configuration gagne sur les multimodales vs les unimodales -- et de confronter cette observation au th\u00e9or\u00e8me No Free Lunch.\n",
     ""
    ]
   },
@@ -562,11 +421,11 @@
    "id": "debias-intro-md",
    "metadata": {},
    "source": [
-    "## Banc dé-biaisé : sortir l'optimum du centre\n",
+    "## Banc d\u00e9-biais\u00e9 : sortir l'optimum du centre\n",
     "\n",
-    "La grille ci-dessus a un angle mort. Parmi les 10 fonctions, **4 ont leur optimum exactement au centre des bornes symétriques** : Sphere, Rastrigin, Ackley, Griewank (optimum en `x* = 0`, bornes `[-a, +a]`). Or le harnais seede le chromosome *adam* au **milieu des bornes** -- c'est-à-dire **sur l'optimum** de ces 4 fonctions. Les 6 autres (Rosenbrock, Schwefel, Michalewicz, Zakharov, Booth, Dixon-Price) ont déjà leur optimum hors du centre ; ces 4 premières, elles, sont structurellement flattées.\n",
+    "La grille ci-dessus a un angle mort. Parmi les 10 fonctions, **4 ont leur optimum exactement au centre des bornes sym\u00e9triques** : Sphere, Rastrigin, Ackley, Griewank (optimum en `x* = 0`, bornes `[-a, +a]`). Or le harnais seede le chromosome *adam* au **milieu des bornes** -- c'est-\u00e0-dire **sur l'optimum** de ces 4 fonctions. Les 6 autres (Rosenbrock, Schwefel, Michalewicz, Zakharov, Booth, Dixon-Price) ont d\u00e9j\u00e0 leur optimum hors du centre ; ces 4 premi\u00e8res, elles, sont structurellement flatt\u00e9es.\n",
     "\n",
-    "C'est la critique de Kudela (*A critical problem in benchmarking and analysis of evolutionary computation methods*, Nature Machine Intelligence 4, 2022) : les métaheuristiques publiées marquent bien sur les bancs standard en partie parce que l'optimum y est au centre du domaine. Le protocole CEC corrige cela par **translation + rotation** : `f_debias(x) = f(Q·x - offset)`, avec `offset` tiré par dimension (seedé, reproductible) et `Q` une matrice orthogonale seedée. Le fork porte exactement ces briques dans `MetaGeneticSharp.Extensions` :\n",
+    "C'est la critique de Kudela (*A critical problem in benchmarking and analysis of evolutionary computation methods*, Nature Machine Intelligence 4, 2022) : les m\u00e9taheuristiques publi\u00e9es marquent bien sur les bancs standard en partie parce que l'optimum y est au centre du domaine. Le protocole CEC corrige cela par **translation + rotation** : `f_debias(x) = f(Q\u00b7x - offset)`, avec `offset` tir\u00e9 par dimension (seed\u00e9, reproductible) et `Q` une matrice orthogonale seed\u00e9e. Le fork porte exactement ces briques dans `MetaGeneticSharp.Extensions` :\n",
     "\n",
     "```csharp\n",
     "var offset = ShiftVectors.Seeded(dim, magnitude, seed);  // l'optimum quitte le centre\n",
@@ -574,12 +433,12 @@
     "var cec    = new RotatedFitness(new ShiftedFitness(inner, offset), Q);\n",
     "```\n",
     "\n",
-    "L'expérience est **appariée** : pour chacune des 4 fonctions à optimum-centré, les 3 configurations tournent sur la version centrée ET sur la version shiftée+rotatée, **3 runs indépendants par cellule** (le GA est stochastique -- un run unique peut faire gagner n'importe qui ; la moyenne sur 3 runs donne un verdict défendable). Deux questions :\n",
+    "L'exp\u00e9rience est **appari\u00e9e** : pour chacune des 4 fonctions \u00e0 optimum-centr\u00e9, les 3 configurations tournent sur la version centr\u00e9e ET sur la version shift\u00e9e+rotat\u00e9e, **3 runs ind\u00e9pendants par cellule** (le GA est stochastique -- un run unique peut faire gagner n'importe qui ; la moyenne sur 3 runs donne un verdict d\u00e9fendable). Deux questions :\n",
     "\n",
-    "1. **Le classement change-t-il** quand l'adam n'est plus seedé sur l'optimum ?\n",
-    "2. La rotation est un *no-op* sur Sphere (symétrie radiale) mais casse l'alignement des vallées de Rastrigin/Ackley -- ajoute-t-elle de la difficulté là où elle a un effet ?\n",
+    "1. **Le classement change-t-il** quand l'adam n'est plus seed\u00e9 sur l'optimum ?\n",
+    "2. La rotation est un *no-op* sur Sphere (sym\u00e9trie radiale) mais casse l'alignement des vall\u00e9es de Rastrigin/Ackley -- ajoute-t-elle de la difficult\u00e9 l\u00e0 o\u00f9 elle a un effet ?\n",
     "\n",
-    "L'amplitude du shift est calibrée par fonction (~30 % de la demi-étendue) pour que l'optimum déplacé reste dans les bornes : `1.5` pour Sphere/Rastrigin (`[-5.12, 5.12]`), `8.0` pour Ackley (`[-32, 32]`), `150` pour Griewank (`[-600, 600]`)."
+    "L'amplitude du shift est calibr\u00e9e par fonction (~30 % de la demi-\u00e9tendue) pour que l'optimum d\u00e9plac\u00e9 reste dans les bornes : `1.5` pour Sphere/Rastrigin (`[-5.12, 5.12]`), `8.0` pour Ackley (`[-32, 32]`), `150` pour Griewank (`[-600, 600]`)."
    ]
   },
   {
@@ -599,111 +458,79 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "shift seed=42  Q orthogonal: True  runs per cell=3\r\n"
-     ]
+     "name": "stdout",
+     "text": "shift seed=42  Q orthogonal: True  runs per cell=3\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "(fitness = negated objective, closer to 0 = better; mean over runs)\n",
-      "\r\n"
-     ]
+     "name": "stdout",
+     "text": "(fitness = negated objective, closer to 0 = better; mean over runs)\n\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Sphere     |offset|_inf=   1,123  (optimum at Q^T*offset, off-center)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Sphere     |offset|_inf=   1,123  (optimum at Q^T*offset, off-center)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "           centered : Uniform= -0,0045609  Islands=  -0,015989  WOA=-3,5066E-11\r\n"
-     ]
+     "name": "stdout",
+     "text": "           centered : Uniform= -0,0099938  Islands=  -0,008003  WOA= -1,087E-11\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "           shifted  : Uniform= -0,0035374  Islands=  -0,013895  WOA= -0,0026125\r\n"
-     ]
+     "name": "stdout",
+     "text": "           shifted  : Uniform=  -0,006504  Islands=  -0,013609  WOA= -0,0045185\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Rastrigin  |offset|_inf=   1,123  (optimum at Q^T*offset, off-center)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Rastrigin  |offset|_inf=   1,123  (optimum at Q^T*offset, off-center)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "           centered : Uniform=    -1,2076  Islands=    -1,0611  WOA=    -5,2395\r\n"
-     ]
+     "name": "stdout",
+     "text": "           centered : Uniform=    -1,1415  Islands=    -1,3597  WOA=    -8,5664\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "           shifted  : Uniform=    -14,918  Islands=    -9,0689  WOA=    -8,0776\r\n"
-     ]
+     "name": "stdout",
+     "text": "           shifted  : Uniform=    -5,6361  Islands=    -7,0372  WOA=    -10,842\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Ackley     |offset|_inf=   5,992  (optimum at Q^T*offset, off-center)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Ackley     |offset|_inf=   5,992  (optimum at Q^T*offset, off-center)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "           centered : Uniform=    -1,4583  Islands=    -3,3384  WOA= -0,0003237\r\n"
-     ]
+     "name": "stdout",
+     "text": "           centered : Uniform=    -2,5149  Islands=    -2,9182  WOA=   -0,92856\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "           shifted  : Uniform=    -4,0284  Islands=    -2,9838  WOA=    -6,8656\r\n"
-     ]
+     "name": "stdout",
+     "text": "           shifted  : Uniform=     -2,284  Islands=    -2,8193  WOA=    -3,8391\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Griewank   |offset|_inf=   112,3  (optimum at Q^T*offset, off-center)\r\n"
-     ]
+     "name": "stdout",
+     "text": "Griewank   |offset|_inf=   112,3  (optimum at Q^T*offset, off-center)\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "           centered : Uniform=   -0,79549  Islands=   -0,83074  WOA=   -0,60929\r\n"
-     ]
+     "name": "stdout",
+     "text": "           centered : Uniform=   -0,48081  Islands=   -0,81376  WOA=   -0,29137\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "           shifted  : Uniform=   -0,89535  Islands=    -0,9168  WOA=    -1,6726\r\n"
-     ]
+     "name": "stdout",
+     "text": "           shifted  : Uniform=    -1,1187  Islands=   -0,92457  WOA=    -0,6353\r\n"
     },
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "\n",
-      "--- Done: 4 zero-optimum functions, centered vs shifted+rotated, 3 runs per cell ---\r\n"
-     ]
+     "name": "stdout",
+     "text": "\n--- Done: 4 zero-optimum functions, centered vs shifted+rotated, 3 runs per cell ---\r\n"
     }
    ],
    "source": [
@@ -711,7 +538,8 @@
     "// whose optimum sits exactly at the CENTER of symmetric bounds (the harness seeds\n",
     "// the adam chromosome ON that optimum). f_debias(x) = f_inner(Q*x - offset) moves\n",
     "// the optimum to Q^T*offset, off-center, and breaks axis alignment.\n",
-    "// 3 independent runs per cell (stochastic GA), mean reported -- a defensible verdict.\n",
+    "// 3 runs per cell, one seed each (reproducible trajectories, cf #12071), mean reported --\n",
+    "// a defensible verdict: distinct draws, fixed in advance.\n",
     "int debiasSeed   = 42;\n",
     "int debiasSeeds  = 3;\n",
     "\n",
@@ -728,7 +556,7 @@
     "Console.WriteLine(\"(fitness = negated objective, closer to 0 = better; mean over runs)\\n\");\n",
     "\n",
     "double MeanRuns(IFitness f, Type t, Func<IMetaHeuristic> build) =>\n",
-    "    Enumerable.Range(0, debiasSeeds).Select(_ => RunBenchmark(f, t, build())).Average();\n",
+    "    Enumerable.Range(0, debiasSeeds).Select(run => RunBenchmark(f, t, build(), seed: debiasSeed + 1 + run)).Average();\n",
     "\n",
     "foreach (var (name, type, mag) in debias)\n",
     "{\n",
@@ -751,23 +579,23 @@
    "id": "debias-interp-md",
    "metadata": {},
    "source": [
-    "### Lecture du banc dé-biaisé : trois renversements sur quatre, dans trois directions différentes\n",
+    "### Lecture du banc d\u00e9-biais\u00e9 : un renversement net sur quatre -- et une le\u00e7on de m\u00e9thode\n",
     "\n",
-    "Rappel : fitness = objectif négativé, plus proche de 0 = meilleur ; chaque cellule = moyenne sur 3 runs. Les deux lignes par fonction sont **appariées** -- même harnais, même budget, seule la position de l'optimum change (centre vs `Q^T·offset`, avec `Q orthogonal: True` en sortie).\n",
+    "Rappel : fitness = objectif n\u00e9gativ\u00e9, plus proche de 0 = meilleur ; chaque cellule = moyenne sur 3 runs **seed\u00e9s** (`seed = 43, 44, 45` -- trajectoires distinctes, reproductibles). Les deux lignes par fonction sont **appari\u00e9es** -- m\u00eame harnais, m\u00eame budget, seule la position de l'optimum change (centre vs `Q^T\u00b7offset`, avec `Q orthogonal: True` en sortie).\n",
     "\n",
-    "1. **Sphere (contrôle unimodal) : la victoire tient, la marge s'évapore.** WOA gagne des deux côtés, mais son avance sur Uniform passe de **neuf ordres de grandeur** (`-3,5066E-11` contre `-0,0045609`, centré) à **moins d'un facteur 2** (`-0,0026125` contre `-0,0035374`, dé-biaisé). Le centre offrait la précision, pas la supériorité.\n",
+    "1. **Sphere (contr\u00f4le unimodal) : la victoire tient, la marge s'\u00e9vapore.** WOA gagne des deux c\u00f4t\u00e9s, mais son avance sur Uniform passe de **neuf ordres de grandeur** (`-1,087E-11` contre `-0,0099938`, centr\u00e9) \u00e0 **moins d'un facteur 2** (`-0,0045185` contre `-0,006504`, d\u00e9-biais\u00e9). Le centre offrait la pr\u00e9cision, pas la sup\u00e9riorit\u00e9.\n",
     "\n",
-    "2. **Rastrigin : renversement Islands → WOA.** Centrée, Islands gagne de justesse (`-1,0611` contre `-1,2076` pour Uniform, `-5,2395` pour WOA). Dé-biaisée, toutes les configurations chutent -- le problème est plus dur -- mais WOA chute le moins : `-8,0776` contre `-9,0689` (Islands) et `-14,918` (Uniform).\n",
+    "2. **Rastrigin : Uniform garde la t\u00eate des deux c\u00f4t\u00e9s.** `-1,1415` centr\u00e9, `-5,6361` d\u00e9-biais\u00e9 -- Islands (`-1,3597` / `-7,0372`) suit de pr\u00e8s, WOA (`-8,5664` / `-10,842`) ferme la marche des deux c\u00f4t\u00e9s sur cette multimodale aggressive.\n",
     "\n",
-    "3. **Ackley : renversement WOA → Islands.** Centrée, WOA écrase (`-0,0003237`). Dé-biaisée, elle passe **dernière** (`-6,8656`) derrière Islands (`-2,9838`) et Uniform (`-4,0284`). La rotation désaxe les vallées alignées sur les axes -- le terrain de prédilection du bubble-net.\n",
+    "3. **Ackley : le seul renversement net -- WOA \u2192 Uniform.** Centr\u00e9e, WOA m\u00e8ne largement (`-0,92856` contre `-2,5149` pour Uniform). D\u00e9-biais\u00e9e, elle passe **derni\u00e8re** (`-3,8391`) derri\u00e8re Uniform (`-2,284`) et Islands (`-2,8193`). La rotation d\u00e9saxe les vall\u00e9es align\u00e9es sur les axes -- le terrain de pr\u00e9dilection du bubble-net. C'est le renversement le plus instructif du banc : il ne va pas dans une direction \u00ab au hasard \u00bb, il retire exactement l'avantage structurel du compos\u00e9.\n",
     "\n",
-    "4. **Griewank : renversement WOA → Uniform.** `-0,89535` pour Uniform contre `-0,9168` (Islands) et `-1,6726` (WOA, dernière).\n",
+    "4. **Griewank : WOA tient, marge resserr\u00e9e.** `-0,29137` centr\u00e9, `-0,6353` d\u00e9-biais\u00e9 -- gagne des deux c\u00f4t\u00e9s, mais son avance sur Islands (`-0,81376` / `-0,92457`) passe de ~0,52 \u00e0 ~0,29.\n",
     "\n",
-    "Verdict honnête : **trois des quatre fonctions changent de gagnante quand l'optimum quitte le centre -- et les trois renversements vont dans trois directions différentes** (Islands→WOA, WOA→Islands, WOA→Uniform). Aucune configuration ne sort du dé-biais avec un statut de championne structurelle : le banc centré fabrique des écarts écrasants (neuf ordres de grandeur sur Sphere) qui s'évanouissent, les victoires serrées se redistribuent. C'est la signature que décrit Kudela, rendue tangible -- et le *No Free Lunch* opère ici au niveau du banc lui-même : c'est la géométrie du problème, pas la métaphore de l'algorithme, qui décide.\n",
+    "Verdict honn\u00eate : **le d\u00e9-biais ne redistribue pas les verdicts au hasard -- il resserre les marges et inverse pr\u00e9cis\u00e9ment l\u00e0 o\u00f9 le terrain favori du compos\u00e9 dispara\u00eet** (Ackley). Aucune configuration ne sort du d\u00e9-biais avec un statut de championne structurelle : le banc centr\u00e9 fabrique des \u00e9carts \u00e9crasants (neuf ordres de grandeur sur Sphere) qui s'\u00e9vaporent d\u00e8s que l'optimum quitte le centre. C'est la signature que d\u00e9crit Kudela, rendue tangible -- le *No Free Lunch* op\u00e8re ici au niveau du banc lui-m\u00eame : c'est la g\u00e9om\u00e9trie du probl\u00e8me, pas la m\u00e9taphore de l'algorithme, qui d\u00e9cide.\n",
     "\n",
-    "Réserve de méthode : 3 runs par cellule départagent les écarts nets (Ackley, Griewank) mais pas les écarts serrés (Rastrigin centré : `-1,0611` contre `-1,2076`). L'exercice 1 (multi-seed, barres d'erreur) est le prolongement naturel.\n",
+    "> **Le\u00e7on de m\u00e9thode (pourquoi le seeding change la lecture).** Une ex\u00e9cution pr\u00e9c\u00e9dente de ce m\u00eame banc -- 3 runs, **non seed\u00e9s** -- affichait *trois* renversements sur quatre, dans trois directions diff\u00e9rentes. L'ex\u00e9cution seed\u00e9e ci-dessus n'en montre qu'un. Aucun des deux tableaux ne \u00ab ment \u00bb : \u00e0 3 runs, les \u00e9carts serr\u00e9s (Rastrigin, Griewank) sont dans le bruit, et le gagnant par cellule y est un tirage au sort. Ce que le seeding garantit n'est pas la significativit\u00e9 -- c'est la **reproductibilit\u00e9** : rejouez cette cellule, vous retrouverez ces chiffres au bit pr\u00e8s (v\u00e9rifi\u00e9 : deux ex\u00e9cutions compl\u00e8tes byte-identiques). C'est la pr\u00e9condition pour qu'un benchmark *prouve* quoi que ce soit ; l'exercice 1 (multi-seed, barres d'erreur) est le prolongement naturel pour la significativit\u00e9.\n",
     "\n",
-    "Et l'argument final pour les primitives : les fonctions dé-biaisées vivent dans trois fichiers du fork (`ShiftedFitness.cs`, `RotatedFitness.cs`, `KnownFunctions.cs`) composés en une ligne -- **aucun algorithme n'a été modifié** pour produire ces renversements."
+    "Et l'argument final pour les primitives : les fonctions d\u00e9-biais\u00e9es vivent dans trois fichiers du fork (`ShiftedFitness.cs`, `RotatedFitness.cs`, `KnownFunctions.cs`) compos\u00e9s en une ligne -- **aucun algorithme n'a \u00e9t\u00e9 modifi\u00e9** pour produire ces renversements."
    ]
   },
   {
@@ -777,11 +605,11 @@
    "source": [
     "## Conclusion : components over metaphors\n",
     "\n",
-    "Ce banc d'essai est la démonstration que le pari architectural de MetaGeneticSharp tient : **reconstruire les métaheuristiques publiées à partir de primitives composables** n'est pas un exercice académique -- ça produit des solveurs compétitifs, *tout en restant ouverts à l'inspection et à la modification*.\n",
+    "Ce banc d'essai est la d\u00e9monstration que le pari architectural de MetaGeneticSharp tient : **reconstruire les m\u00e9taheuristiques publi\u00e9es \u00e0 partir de primitives composables** n'est pas un exercice acad\u00e9mique -- \u00e7a produit des solveurs comp\u00e9titifs, *tout en restant ouverts \u00e0 l'inspection et \u00e0 la modification*.\n",
     "\n",
-    "La critique de Sørensen visait les algorithmes *opaques* qui réinventent l'eau chaude sous un nouveau vocabulaire animalier. La réponse de MetaGeneticSharp n'est pas de nier la critique, mais de la *dépasser* : oui, WOA est une composition d'opérateurs standards -- et c'est précisément pourquoi l'exposer comme tel (via `Build()`) est plus honnête et plus utile que de le cacher derrière une métaphore.\n",
+    "La critique de S\u00f8rensen visait les algorithmes *opaques* qui r\u00e9inventent l'eau chaude sous un nouveau vocabulaire animalier. La r\u00e9ponse de MetaGeneticSharp n'est pas de nier la critique, mais de la *d\u00e9passer* : oui, WOA est une composition d'op\u00e9rateurs standards -- et c'est pr\u00e9cis\u00e9ment pourquoi l'exposer comme tel (via `Build()`) est plus honn\u00eate et plus utile que de le cacher derri\u00e8re une m\u00e9taphore.\n",
     "\n",
-    "Le prolongement naturel : composer des *hybrides* (WOA sur les îles, EO dans une phase de raffinement) qui n'existent dans aucune bibliothèque monolithique -- parce que la composition, justement, les rend triviaux à énoncer. C'est l'objet des notebooks MGS-3 (Eukaryote) et MGS-4 (Islands), que ce banc relie à la question de performance.\n"
+    "Le prolongement naturel : composer des *hybrides* (WOA sur les \u00eeles, EO dans une phase de raffinement) qui n'existent dans aucune biblioth\u00e8que monolithique -- parce que la composition, justement, les rend triviaux \u00e0 \u00e9noncer. C'est l'objet des notebooks MGS-3 (Eukaryote) et MGS-4 (Islands), que ce banc relie \u00e0 la question de performance.\n"
    ]
   },
   {
@@ -791,7 +619,7 @@
    "source": [
     "## Exercices\n",
     "\n",
-    "> **Convention** : les exercices sont des cellules à compléter. Squelette fourni, à vous d'implémenter. Ne pas lever d'erreur -- utiliser `// TODO` / `return` selon le contexte.\n"
+    "> **Convention** : les exercices sont des cellules \u00e0 compl\u00e9ter. Squelette fourni, \u00e0 vous d'impl\u00e9menter. Ne pas lever d'erreur -- utiliser `// TODO` / `return` selon le contexte.\n"
    ]
   },
   {
@@ -801,7 +629,8 @@
    "source": [
     "### Exercice 1 : multi-seed et barres d'erreur\n",
     "\n",
-    "Le banc ci-dessus fait un seul passage par cellule. Ajoutez une boucle sur N seeds (par exemple 5) qui relance chaque configuration et calcule la **moyenne** et l'**écart-type** de la fitness finale. Affichez le résultat sous forme `moyenne ± écart-type`. *Indice* : `RandomizationProvider.Current` contrôle le RNG de GeneticSharp ; pour fixer un seed, injectez un `BasicRandomization` seedé avant chaque `ga.Start()`.\n"
+    "Le banc ci-dessus fait un seul passage par cellule. Ajoutez une boucle sur N seeds (par exemple 5) qui relance chaque configuration et calcule la **moyenne** et l'**\u00e9cart-type** de la fitness finale. Affichez le r\u00e9sultat sous forme `moyenne \u00b1 \u00e9cart-type`. *Indice* : le RNG du moteur est `FastRandomRandomization` (c'est lui que `RandomizationProvider.Current` sert par d\u00e9faut) ; appelez `FastRandomRandomization.ResetSeed(seed)` **avant la cr\u00e9ation de la population initiale** \u2014 c'est elle, via `CreateNew()`, qui consomme le RNG. Attention : `BasicRandomization.ResetSeed` serait un no-op ici, le moteur ne lit jamais le ThreadLocal de `BasicRandomization` tant que `Current` reste `FastRandom` (cf [#12071](https://github.com/jsboige/CoursIA/issues/12071)).\n",
+    ""
    ]
   },
   {
@@ -821,11 +650,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : multi-seed mean +/- std par fonction x configuration.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : multi-seed mean +/- std par fonction x configuration.\r\n"
     }
    ],
    "source": [
@@ -837,11 +664,12 @@
     "\n",
     "// for each function:\n",
     "//   for each config in {Uniform, Islands, WOA}:\n",
-    "//     for seed in {0,1,7,42,99}:  // fixer RandomizationProvider.Current avec ce seed\n",
+    "//     for seed in {0,1,7,42,99}:  // FastRandomRandomization.ResetSeed(seed) avant chaque run\n",
     "//       fitness = RunBenchmark(...)\n",
     "//     mean = average, std = sqrt(variance)\n",
     "\n",
-    "Console.WriteLine(\"Exercice a completer : multi-seed mean +/- std par fonction x configuration.\");\n"
+    "Console.WriteLine(\"Exercice a completer : multi-seed mean +/- std par fonction x configuration.\");\n",
+    ""
    ]
   },
   {
@@ -851,7 +679,7 @@
    "source": [
     "### Exercice 2 : carte de chaleur gagnant-par-fonction\n",
     "\n",
-    "À partir des résultats (mono- ou multi-seed), construisez une carte qui, pour chaque fonction, indique quelle configuration gagne (fitness la plus proche de 0). Comptez combien de fonctions sont gagnées par Uniform / Islands / WOA, et séparez le compte entre fonctions unimodales et multimodales. *Étape 1* : définir la liste des multimodales. *Étape 2* : pour chaque fonction, `argmax` des trois fitness. *Étape 3* : croiser avec le type (uni/multi).\n"
+    "\u00c0 partir des r\u00e9sultats (mono- ou multi-seed), construisez une carte qui, pour chaque fonction, indique quelle configuration gagne (fitness la plus proche de 0). Comptez combien de fonctions sont gagn\u00e9es par Uniform / Islands / WOA, et s\u00e9parez le compte entre fonctions unimodales et multimodales. *\u00c9tape 1* : d\u00e9finir la liste des multimodales. *\u00c9tape 2* : pour chaque fonction, `argmax` des trois fitness. *\u00c9tape 3* : croiser avec le type (uni/multi).\n"
    ]
   },
   {
@@ -871,11 +699,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : carte gagnant-par-fonction + split uni/multi.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : carte gagnant-par-fonction + split uni/multi.\r\n"
     }
    ],
    "source": [
@@ -898,7 +724,7 @@
    "source": [
     "### Exercice 3 : ajouter Equilibrium Optimizer au banc\n",
     "\n",
-    "Le fork porte un deuxième composé reconstruit depuis des primitives : `EquilibriumOptimizer` (Phase 4 slice 5). Ajoutez-le comme 4e configuration au banc (colonne **EO**). *Étape 1* : ajouter `BuildEO()` qui appelle `new EquilibriumOptimizer().Build()` (avec le même `GeometricConverter<double>` identité que WOA). *Étape 2* : étendre la grille à 10×4. *Étape 3* : commenter -- EO gagne-t-il sur des fonctions où WOA perd (diversité des composés) ?\n"
+    "Le fork porte un deuxi\u00e8me compos\u00e9 reconstruit depuis des primitives : `EquilibriumOptimizer` (Phase 4 slice 5). Ajoutez-le comme 4e configuration au banc (colonne **EO**). *\u00c9tape 1* : ajouter `BuildEO()` qui appelle `new EquilibriumOptimizer().Build()` (avec le m\u00eame `GeometricConverter<double>` identit\u00e9 que WOA). *\u00c9tape 2* : \u00e9tendre la grille \u00e0 10\u00d74. *\u00c9tape 3* : commenter -- EO gagne-t-il sur des fonctions o\u00f9 WOA perd (diversit\u00e9 des compos\u00e9s) ?\n"
    ]
   },
   {
@@ -918,11 +744,9 @@
    },
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "Exercice a completer : 4e configuration Equilibrium Optimizer dans le banc.\r\n"
-     ]
+     "name": "stdout",
+     "text": "Exercice a completer : 4e configuration Equilibrium Optimizer dans le banc.\r\n"
     }
    ],
    "source": [
@@ -942,9 +766,9 @@
     "\n",
     "- [MGS-1 Introduction](MGS-1-Introduction.ipynb) -- le moteur autonome `MetaGeneticAlgorithm`\n",
     "- [MGS-2 Composition](MGS-2-Composition.ipynb) -- primitives `Match` et grammaire fluente\n",
-    "- [MGS-3 Eukaryote](MGS-3-Eukaryote.ipynb) -- sous-populations spécialisées\n",
-    "- [MGS-4 Islands](MGS-4-Islands.ipynb) -- modèle insulaire et migration\n",
-    "- [Point d'entrée Part 4](README.md) -- positionnement MGS vs GeneticSharp/mealpy/HeuristicLab\n",
+    "- [MGS-3 Eukaryote](MGS-3-Eukaryote.ipynb) -- sous-populations sp\u00e9cialis\u00e9es\n",
+    "- [MGS-4 Islands](MGS-4-Islands.ipynb) -- mod\u00e8le insulaire et migration\n",
+    "- [Point d'entr\u00e9e Part 4](README.md) -- positionnement MGS vs GeneticSharp/mealpy/HeuristicLab\n",
     "- [Fork jsboige/MetaGeneticSharp](https://github.com/jsboige/MetaGeneticSharp) -- code source, `KnownFunctions.cs`, ROADMAP\n"
    ]
   }
@@ -960,7 +784,7 @@
    "gpu_required": false,
    "metadata_written": "2026-08-03",
    "network": false,
-   "notes": "GA MetaGeneticSharp sur fonctions-benchmarks. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln (fork local, DLLs chargees via #r). GA seede (BasicRandomization.ResetSeed).",
+   "notes": "GA MetaGeneticSharp sur fonctions-benchmarks. Local CPU, sans API ni GPU. Prerequis: dotnet build ../MetaGeneticSharp/MetaGeneticSharp.sln (fork local, DLLs chargees via #r). GA seede par run (FastRandomRandomization.ResetSeed).",
    "qcc_tokens_est": 0,
    "reduced_pedagogical": null,
    "reproducibility": "HIGH",


### PR DESCRIPTION
Grain: MED/notebook-dotnet — lane myia-po-2024:CoursIA — prev: MED/notebook-dotnet #12187

## MGS-6 : seeding réel + re-exec post-rebase + audit prose-vs-chiffres (tranche #1203)

Suite des tranches MGS-1/2/3 (#11941/#11943/#12070, po-2025). MGS-6 était le notebook de la série le plus affecté par #12071 — pas un appel décoratif, **trois défauts distincts** :

1. **Le harness ne seedait rien** — `RunBenchmark` lançait `ga.Start()` sans seed : outputs non reproductibles (chaque exec = nouveaux chiffres). Fix : `FastRandomRandomization.ResetSeed(seed)` avant la création de la population (le RNG est consommé par `CreateNew()`, pattern des PRs #12082/#12084). Paramètre `int seed = 42` : la grille 10×3 devient **appariée** (mêmes tirages initiaux Uniform/Islands/WOA par fonction) ; `MeanRuns` passe `seed: debiasSeed + 1 + run` (43/44/45 — trajectoires distinctes ET reproductibles, pattern RUN_SEEDS #12084).
2. **La metadata mentait** — `cost.notes`: « GA seede (BasicRandomization.ResetSeed) » + `reproducibility: HIGH` alors que le code ne seedait pas. Corrigé : « GA seede par run (FastRandomRandomization.ResetSeed) » — le HIGH devient vrai.
3. **L'énoncé de l'Exercice 1 enseignait le pattern no-op** — l'indice disait « injectez un `BasicRandomization` seedé avant chaque `ga.Start()` » : c'est précisément le no-op documenté (#12071). Réécrit vers le pattern effectif (`FastRandomRandomization.ResetSeed` **avant la création de la population initiale**), avec la raison du no-op et le lien #12071.

## Diagnostic dérive (C.4)

**Cause e — stochasticité non-seedée** → **CAUSE_FIXED** (seeding réel).

## Finding principal : l'ancienne Lecture du banc dé-biaisé décrivait du bruit

L'ancienne Lecture 11 (« trois renversements sur quatre, dans trois directions différentes ») était l'artefact d'une exec 3-runs non-seedée. Le tableau seedé montre :

| Fonction | centré → dé-biaisé (gagnant) |
|---|---|
| Sphere | WOA → WOA (marge 9 ordres → ×1,4) |
| Rastrigin | Uniform → Uniform |
| Ackley | **WOA → Uniform (seul renversement net)** |
| Griewank | WOA → WOA (marge resserrée) |

Lecture 11 réécrite : **un** renversement net (Ackley — la rotation désaxe les vallées alignées, terrain du bubble-net), et une « leçon de méthode » explicite : l'ancien tableau non-seedé montrait trois renversements, le seedé un seul — à 3 runs les écarts serrés sont dans le bruit ; le seeding garantit la reproductibilité, pas la significativité (renvoi Exercice 1 multi-seed). Lecture 8 : structure intégralement confirmée par la nouvelle grille (WOA diverge Schwefel `3,4903E+16`, Islands maîtresse, 7/10 exact) — 3 chiffres Sphere ré-ancrés.

## Validation

- Exécution `dotnet_executor.py` : **8/8 cellules, 0 erreur**, exécutée **2× → toutes sorties byte-identiques** (déterminisme prouvé, protocole po-2023)
- Toutes les valeurs citées dans les Lectures vérifiées **littéralement présentes** dans les outputs (check mécanique, 22 valeurs)
- C.1 : 0 `raise NotImplementedError` / `assert False` / `1/0` ; exec counts 1-8 non-null ; probe banner strippée
- Périmètre : 7 cellules (3 code + 2 markdown lectures + énoncé exo + stub commentaire) + metadata.notes ; 0 cellule supprimée, exercices intacts
- Smoke test cellule chromosome seedé aussi (seed 7, distinct du banc)
- Submodule gitlink inchangé (byte-identique à main — DLLs existantes, les compounds #45-48 étant additifs et non référencés par MGS-6)
- Verdict SOTA : SOTA-OK (vrai fork via DLLs)

See #1203
