### PR TITLE
fix(qc,#12153): research.ipynb SPY count 6→7 — md#5 contredit l'output cell#4

### DIFF
--- a/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research.ipynb
+++ b/MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research.ipynb
@@ -176,7 +176,7 @@
     "- **Taille** : entre 6 et 10 cellules par notebook (3 à 6 de code) — chaque stratégie tient en une session de recherche courte ; `research_volatility_regime_ml` est la plus fournie (10 cellules, 6 code).\n",
     "- **Univers** : 7 notebooks sur 8 déclarent leurs tickers equity via `add_equity` (littéral ou liste `tickers = [...]` — l'extraction couvre les deux formes). `research_commodity_term_structure` reste vide : sa stratégie est portée par des **contrats futures**, pas par des equities.\n",
     "- **Étalement** : `research_defensive_etf_rotation` pousse l'univers le plus large (9 tickers : equity, leveraged, inverse, volatilité, bonds) — c'est la logique « rotation conditionnelle » du concept, qui a besoin d'actifs de régimes opposés.\n",
-    "- **Base commune** : `SPY` apparaît dans 6 notebooks sur 8 — l'etf de référence sert d'ancre de marché pour la plupart des stratégies.\n",
+    "- **Base commune** : `SPY` apparaît dans 7 notebooks sur 8 — l'etf de référence sert d'ancre de marché pour la plupart des stratégies.\n",
     "\n",
     "Note d'exécution : dans le conteneur de recherche, le projet est monté en `/Lean/Launcher/bin/Debug/Notebooks` — c'est le point de montage, pas le nom du dossier projet, d'où « Projet : Notebooks » en première ligne. Le localisateur par marqueur (`main.py` + premier notebook de stratégie) retient ce répertoire quel que soit le montage.\n"
    ]


### PR DESCRIPTION
# fix(qc,#12153): research.ipynb SPY count 6→7 — md#5 contredit l'output cell#4

## Grain
Grain: LIGHT/notebook-python — lane myia-po-2025:CoursIA-2 — prev: LIGHT/delivered #12094

Refs #12153

## Diagnostic dérive (C.4)

**Cause = (b) claim antérieure fabriquée.** La cellule md#5 (id `81108379`, « Lecture du résultat ») affirmait « `SPY` apparaît dans **6 notebooks sur 8** », mais l'output de la cellule de code cell#4 (id `5c8b03ed`) liste **7 lignes** contenant SPY :

| Notebook | Tickers (extrait cell#4) | SPY |
|---|---|---|
| `research_asset_class_momentum` | BND,EFA,GSG,SPY,VNQ | ✓ |
| `research_commodity_term_structure` | (vide — futures) | ✗ |
| `research_defensive_etf_rotation` | BSV,QQQ,SPXL,SPY,SQQQ,TECL,TECS,TQQQ,UVXY | ✓ |
| `research_long_short_harvest` | GLD,SPY | ✓ |
| `research_macro_factor_rotation` | BND,GLD,SPY | ✓ |
| `research_piotroski_fscore` | SPY | ✓ |
| `research_puppies_of_dow` | DIA,SPY | ✓ |
| `research_volatility_regime_ml` | BIL,GLD,SPY,TLT | ✓ |

→ **7/8**, pas 6/8. La cellule md#5 dérivait de la vérité d'exécution.

**Verdict** : `CAUSE_FIXED`. Le défaut est une erreur de comptage dans la prose md#5, et la valeur corrigée (7) **provient directement de l'output** de la cellule précédente — donc verifiable au prochain passage kernel sans régression. Pas de ré-exécution nécessaire : la cellule md#5 n'est pas du code, c'est un commentaire markdown (C.2 non applicable — pas de cellule code touchée).

## Scope du fix

- 1 fichier : `MyIA.AI.Notebooks/QuantConnect/projects/Research-Executor/research.ipynb`
- 1 ligne modifiée : `cell[5].source[7]` (cellule md#5, « Lecture du résultat »)
- Diff : `+1 / -1` (byte-preserve, pas de reformatage JSON, source reste `list[str]`)
- EOL : `i/lf w/lf attr/text eol=lf` (vérifié — pas de pollution CRLF Windows)

## Validation

- Pre-commit (8 hooks) : tous PASS
  - `gitleaks` ✓
  - `strip .NET probeAddresses banner` ✓
  - `strip .NET Loading extensions from <NuGet cache>` ✓
  - `scrub absolute papermill input/output paths` ✓
  - `yaml_block_open_no_close` ✓
  - `Block NEW oversized markdown-rendering defects (frontmatter / setext)` ✓
  - `Auto-fix source-list-missing-newlines` ✓
  - `H.3 — refuse un-executed notebooks` ✓
- L298-L1 ★★ respecté : `cell['source']` reste `list[str]` après fix, pas de conversion str→list massive.

## Pas une régression

Cette PR ne supprime aucun contenu pédagogique et n'altère aucune cellule code exécutable. Elle corrige un fait numérique de la prose d'interprétation pour l'aligner sur l'output réel. Conforme à CLAUDE.md §E (doc primaire = français, conservé) et §C.1 (pas d'erreur volontaire).

## Suite immédiate (hors scope PR)

- Pas de cellules `# Solution` ou `# Exemple résolu` impactées (anti-régression OK).
- Aucune dépendance mise à jour.
- Aucun notebook ré-exécuté (le fix est sur cellule markdown, pas code).