### PR TITLE
fix(slides,#12014): alt backfill tranche 3 — 96 alt ajoutés/remplacés (audit vision sourcé)

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -757,7 +757,7 @@ layout: two-cols
   - Fair-play
 
 <div class="img-grid">
-<img src="./images/img_041.jpg" class="w-[220px] max-w-full max-h-[300px] object-contain" alt="Plan de transport aérien : Init, Goal et actions Load/Unload/Fly avec préconditions et effets" />
+<img src="./images/img_041.jpg" class="w-[220px] max-w-full max-h-[300px] object-contain" alt="Cartes à jouer disposées en spirale arc-en-ciel sur une table en bois" />
 
 </div>
 

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -548,7 +548,7 @@ layout: two-cols
 <div class="img-grid-2x2">
 <img src="./images/img_035.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Schéma de sémantique : énoncés reliés par « a pour conséquence » et « causent » aux aspects du monde réel" />
 <img src="./images/img_036.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
-<img src="./images/img_037.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Diagrammes de Venn des connecteurs logiques : ou, et, implication, équivalence" />
+<img src="./images/img_037.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Grammaire de la logique propositionnelle : Énoncé, ÉnoncéAtomique, priorité des opérateurs ¬, ∧, ∨, ⇒, ⇔" />
 
 </div>
 
@@ -634,7 +634,7 @@ layout: two-cols
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
 <img src="./images/img_038.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Table de vérité en français des connecteurs logiques P, Q (négation, conjonction, disjonction, implication)" />
-<img src="./images/img_039.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Grammaire BNF de la logique propositionnelle avec priorité des opérateurs" />
+<img src="./images/img_039.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Diagrammes de Venn des connecteurs logiques : (P ∨ Q), (P ∧ Q), (P ⇒ Q), (P ⇔ Q)" />
 <img src="./images/img_040.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
 </div>
 ---
@@ -793,8 +793,8 @@ layout: two-cols
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
 <img src="./images/img_043.png" class="max-h-[300px] max-w-full object-contain" alt="Graphe de planification : Start, Go(HWS), Go(SM), Buy(Drill/Milk/Bananas), Finish avec états At/Have" />
-<img src="./images/img_044.png" class="max-h-[300px] max-w-full object-contain" alt="Néon « Quiz time » rose et cyan" />
-<img src="./images/img_045.png" class="max-h-[300px] max-w-full object-contain" alt="Cartes à jouer vintage disposées en spirale arc-en-ciel sur une table en bois" />
+<img src="./images/img_044.png" class="max-h-[300px] max-w-full object-contain" alt="Décomposition HTN « Build House » : Obtain Permit, Construction et sous-tâches" />
+<img src="./images/img_045.png" class="max-h-[300px] max-w-full object-contain" alt="Plan de transport aérien en logique : Init, Goal, actions Load/Unload/Fly avec préconditions et effets" />
 <img src="./images/img_046.png" class="max-h-[300px] max-w-full object-contain" alt="Plan d'actions logiques : Load(C1,P1,SFO), Fly(P1,SFO,JFK), Unload (transport aérien)" />
 </div>
 ---
@@ -815,8 +815,8 @@ layout: two-cols
   - Linked Data
 
 <div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
-<img src="./images/img_048.png" class="w-full object-contain" alt="Découpage apprentissage/validation/test avec sélection de modèle par itérations" />
-<img src="./images/img_049.png" class="w-full object-contain" alt="Web décentralisé : deux ordinateurs reliés par une poignée de main, symboles Bitcoin et Ethereum" />
+<img src="./images/img_048.png" class="w-full object-contain" alt="Cartographie des médias et réseaux sociaux : TV, presse, blogs, forums, podcasts, partage vidéo et photo" />
+<img src="./images/img_049.png" class="w-full object-contain" alt="Architecture du web sémantique : Trust, Proof, Logic, Ontology, RDF, XML, URI, Unicode" />
 </div>
 
 <!-- Exemples : triplets RDF (sujet-predicat-objet), ontologies OWL, SPARQL -->
@@ -933,7 +933,7 @@ layout: two-cols
 <div class="img-grid">
 <img src="./images/img_052.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Ajustement d'un nuage de points par une courbe bleue oscillante, une droite rouge et un segment vert" />
 <img src="./images/img_053.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Surapprentissage : courbe orange très oscillante collée aux points, contre droite et segment de régression" />
-<img src="./images/img_054.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Découpage des données : échantillonnage, entraînement, validation, test avec sélection de modèle" />
+<img src="./images/img_054.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Courbe gaussienne centrée en 0, largeur σ (distribution normale)" />
 
 </div>
 
@@ -959,9 +959,9 @@ layout: two-cols
   - Observations bruitées
 
 <div class="img-grid">
-<img src="./images/img_055.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Arbre de décision « Faut-il attendre ? » : clients, attente estimée, faim, alternatives, bar, pluie" />
-<img src="./images/img_056.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Partition d'attributs par Clients? et Type? : ronds verts et rouges répartis en sous-ensembles" />
-<img src="./images/img_057.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Forêt aléatoire : un nœud X distribué vers plusieurs arbres, combinés par vote ou moyenne" />
+<img src="./images/img_055.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Chaîne de Markov cachée : états X₁ à Xₙ, observations E₁ à Eₙ" />
+<img src="./images/img_056.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Fourmis stylisées avec symboles x1 à x4 et ondes bleues et rouges (illustration intelligence en essaim)" />
+<img src="./images/img_057.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Réseau bayésien météo : soleil, nuages, pluie reliés par probabilités conditionnelles" />
 </div>
 
 
@@ -980,8 +980,8 @@ layout: two-cols
 - Apprentissage
 
 <div class="img-grid">
-<img src="./images/img_058.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Neurone biologique : dendrite, corps cellulaire, noyau, axone, synapse" />
-<img src="./images/img_059.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Données non séparables en 2D (points dans un cercle) et séparées dans un espace 3D par des plans" />
+<img src="./images/img_058.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Modèle à états cachés temporel : états X_t et observations Z_t au fil du temps" />
+<img src="./images/img_059.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Graphe orienté : nœuds bleus reliés par flèches pleines et pointillées" />
 
 </div>
 
@@ -1015,9 +1015,9 @@ layout: two-cols
 </div>
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_061.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Néon « Quiz time » rose et cyan" />
+<img src="./images/img_061.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Courbe d'utilité concave : utilité U en fonction du montant en dollars" />
 <img src="./images/img_062.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Diagramme d'influence : décision AirportSite, conséquences Deaths/Noise/Cost, utilité U" />
-<img src="./images/img_063.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Processus de décision markovien à six états S0-S5 avec actions, récompenses +5/-1 et probabilités" />
+<img src="./images/img_063.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Processus de décision markovien : états S0-S2, actions a0-a1, récompenses +5/-1, probabilités de transition" />
 <img src="./images/img_064.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Grille 3x3 de navigation avec flèches de politique, cases +1/-1, piège, et inégalité sur R(s)" />
 </div>
 ---
@@ -1057,7 +1057,7 @@ layout: two-cols
 <div class="img-grid">
 <img src="./images/img_067.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Matrice du dilemme du prisonnier : se taire/avouer, peines de (-1,-1) à (-8,-8)" />
 <img src="./images/img_068.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Arbre de jeu Stackelberg : Burn/Not Burn, Invade/Concede, Fight/Retreat avec utilités" />
-<img src="./images/img_069.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Matrice de gains du jeu Ballet/Fight : préférences croisées des deux joueurs (2,1) et (1,2)" />
+<img src="./images/img_069.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Arbre de jeu de poker en trois rues : Pre-flop, Flop, Turn avec Fold/Call/Check/Raise" />
 
 </div>
 
@@ -1085,7 +1085,7 @@ layout: two-cols
 - Purs et mixtes (2n+1)
 - Topologie
 
-<img src="./images/img_070.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Arbre de jeu de poker en trois rues : Pre-flop, Flop, Turn avec Fold/Call/Check/Raise" />
+<img src="./images/img_070.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Matrice de gains du jeu Ballet/Fight : préférences croisées des deux joueurs, valeurs (2,1) et (1,2)" />
 
 
 ::right::
@@ -1136,8 +1136,8 @@ layout: two-cols
 - Deepstack
 
 <div class="img-grid">
-<img src="./images/img_072.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Néon « Quiz time » violet et bleu" />
-<img src="./images/img_073.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Arbre de décision de poker avec nœuds de chance violets, nœuds d'action et terminaux triangulaires" />
+<img src="./images/img_072.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Composition abstraite : panneau jaune, point rouge et point bleu, bandes verticales" />
+<img src="./images/img_073.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Surface 3D incurvée en selle, rendu bleu translucide sans texte" />
 <img src="./images/img_074.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Surface 3D incurvée f(x,y) dans une boîte avec un point rouge marqué" />
 
 </div>
@@ -1217,7 +1217,7 @@ layout: two-cols
   - Jugement majoritaire
   - Scrutin bipartipludique
 
-<img src="./images/img_078.png" class="w-[280px] max-w-full max-h-[300px] object-contain" alt="Néon « Quiz time » violet sur fond noir" />
+<img src="./images/img_078.png" class="w-[280px] max-w-full max-h-[300px] object-contain" alt="Zone d'accord de négociation salariale : salages rejetés par chacun, fourchette 0 à 50 dollars" />
 
 
 
@@ -1449,10 +1449,10 @@ layout: two-cols
   - Réseaux adversériaux
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_098.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Cellule LSTM : portes sigmoïdes, tanh, multiplications, états cachés h entre les pas de temps" />
-<img src="./images/img_099.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Hiérarchie de caractéristiques CNN : bords et textures, motifs, objets, puis classifieur" />
+<img src="./images/img_098.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="RNN déroulé : cellule récurrente A, entrées x0 à xt, sorties h0 à ht" />
+<img src="./images/img_099.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Cellule récurrente LSTM : portes sigmoïdes σ, tanh, états cachés h entre les pas de temps" />
 <img src="./images/img_100.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="RNN à cinq cellules A alignées : entrées x0-x4, sorties h0-h4" />
-<img src="./images/img_101.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Image dégradée illisible (figure à régénérer — voir issue dédiée)" />
+<img src="./images/img_101.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Porte sigmoïde σ de cellule LSTM — rendu dégradé, figure à régénérer (voir issue dédiée)" />
 <img src="./images/img_102.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="GAN : bruit aléatoire, générateur produisant une image forgée, discriminateur classant réel/factice" />
 <img src="./images/img_103.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Bloc résiduel ResNet : deux couches, connexion identité, H(x)=F(x)+x" />
 </div>

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -200,7 +200,7 @@ layout: section
 - Pas de mémoire, réagit aux percepts courants
 - Regles condition → action (si obstacle, alors freiner)
 
-<img src="./images/img_010.png" class="w-[260px] max-w-full max-h-[220px] object-contain" />
+<img src="./images/img_010.png" class="w-[260px] max-w-full max-h-[220px] object-contain" alt="Tableau PEAS : cinq types d'agents avec mesure de performance, environnement, effecteurs, capteurs" />
 
 <img src="./images/img_011.png" class="absolute top-[290px] right-[20px] w-[360px] max-w-full max-h-[240px] object-contain" alt="Agent réflexe" />
 
@@ -287,7 +287,7 @@ layout: section
 - Passe du réactif au délibératif
 - Planifie ses actions par exploration
 
-<img src="./images/img_016.png" class="w-[300px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_016.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Carte de la Roumanie : Arad, Sibiu, Bucharest et distances routières (exemple canonique AIMA)" />
 
 **Résolution de problèmes**
 
@@ -305,7 +305,7 @@ layout: section
 
 **Itinéraire**
 
-<img src="./images/img_018.png" class="absolute top-[110px] right-[20px] w-[260px] max-h-[220px] object-contain" />
+<img src="./images/img_018.png" class="absolute top-[110px] right-[20px] w-[260px] max-h-[220px] object-contain" alt="Plateau de dames avec six pions noirs disposés sur l'échiquier" />
 
 - État initial, test de but
 - Transitions
@@ -357,8 +357,8 @@ layout: two-cols
   - Barque de 2 places
   - Jamais + de cannibales
 
-<img src="./images/img_023.png" class="w-[280px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_024.png" class="w-[460px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_023.png" class="w-[280px] max-w-full max-h-[300px] object-contain" alt="Graphe d'états avec frontière de recherche en pointillés rouges et valeurs d'évaluation 380-420" />
+<img src="./images/img_024.png" class="w-[460px] max-w-full max-h-[300px] object-contain" alt="Séquence d'arbres binaires A-G avec curseur sur le nœud en cours d'exploration" />
 
 
 
@@ -396,8 +396,8 @@ layout: two-cols
 - Bidirectionnelle
 - Ex: Où sont mes clefs ?
 
-<img src="./images/img_025.png" class="w-[300px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_026.png" class="w-[300px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_025.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Arbres binaires illustrant la recherche en profondeur, nœuds visités en gris foncé" />
+<img src="./images/img_026.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Arbre de recherche dense étalé en motif radial, avec nœuds Départ et But" />
 
 </div>
 
@@ -499,7 +499,7 @@ layout: two-cols
 - Expectiminimax
 - Méthodes de Monte-Carlo
 
-<img src="./images/img_031.png" class="w-[350px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_031.png" class="w-[350px] max-w-full max-h-[300px] object-contain" alt="Arbre minimax du morpion : niveaux MAX(X) et MIN(O), utilités -1/0/+1" />
 
 
 
@@ -546,9 +546,9 @@ layout: two-cols
   - Symétrie (rupture de)
 
 <div class="img-grid-2x2">
-<img src="./images/img_035.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_036.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_037.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_035.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Schéma de sémantique : énoncés reliés par « a pour conséquence » et « causent » aux aspects du monde réel" />
+<img src="./images/img_036.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
+<img src="./images/img_037.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Diagrammes de Venn des connecteurs logiques : ou, et, implication, équivalence" />
 
 </div>
 
@@ -606,8 +606,8 @@ layout: two-cols
 
 **Raisonnement**
 
-<img src="./images/img_035.png" class="w-[300px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_036.png" class="w-[300px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_035.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Schéma de sémantique : énoncés reliés par « a pour conséquence » et « causent » aux aspects du monde réel" />
+<img src="./images/img_036.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Illustration Winograd : ordinateur échangeant phrases et conclusions avec un humain et un robot" />
 
 
 
@@ -633,9 +633,9 @@ layout: two-cols
   - Problèmes NP-complets
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_038.png" class="w-[200px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_039.png" class="w-[200px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_040.png" class="w-[200px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_038.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Table de vérité en français des connecteurs logiques P, Q (négation, conjonction, disjonction, implication)" />
+<img src="./images/img_039.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Grammaire BNF de la logique propositionnelle avec priorité des opérateurs" />
+<img src="./images/img_040.png" class="w-[200px] max-w-full max-h-[300px] object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
 </div>
 ---
 layout: two-cols
@@ -666,7 +666,7 @@ layout: two-cols
 - Enemy(x,America) => Hostile(x)
 - Américain(x) ET Arme(y) ET Vend(x,y,z) ET Hostile(z) => Criminel(x)
 
-<img src="./images/img_040.png" class="w-[300px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_040.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Réseau sémantique : Mammals, Persons, Mary, John reliés par liens d'héritage et propriétés" />
 
 
 
@@ -757,7 +757,7 @@ layout: two-cols
   - Fair-play
 
 <div class="img-grid">
-<img src="./images/img_041.jpg" class="w-[220px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_041.jpg" class="w-[220px] max-w-full max-h-[300px] object-contain" alt="Plan de transport aérien : Init, Goal et actions Load/Unload/Fly avec préconditions et effets" />
 
 </div>
 
@@ -792,10 +792,10 @@ layout: two-cols
 - Décomposition hiérarchique
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_043.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_044.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_045.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_046.png" class="max-h-[300px] max-w-full object-contain" />
+<img src="./images/img_043.png" class="max-h-[300px] max-w-full object-contain" alt="Graphe de planification : Start, Go(HWS), Go(SM), Buy(Drill/Milk/Bananas), Finish avec états At/Have" />
+<img src="./images/img_044.png" class="max-h-[300px] max-w-full object-contain" alt="Néon « Quiz time » rose et cyan" />
+<img src="./images/img_045.png" class="max-h-[300px] max-w-full object-contain" alt="Cartes à jouer vintage disposées en spirale arc-en-ciel sur une table en bois" />
+<img src="./images/img_046.png" class="max-h-[300px] max-w-full object-contain" alt="Plan d'actions logiques : Load(C1,P1,SFO), Fly(P1,SFO,JFK), Unload (transport aérien)" />
 </div>
 ---
 
@@ -815,8 +815,8 @@ layout: two-cols
   - Linked Data
 
 <div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
-<img src="./images/img_048.png" class="w-full object-contain" alt="Autres Applications (1/2)" />
-<img src="./images/img_049.png" class="w-full object-contain" alt="Autres Applications (1/2)" />
+<img src="./images/img_048.png" class="w-full object-contain" alt="Découpage apprentissage/validation/test avec sélection de modèle par itérations" />
+<img src="./images/img_049.png" class="w-full object-contain" alt="Web décentralisé : deux ordinateurs reliés par une poignée de main, symboles Bitcoin et Ethereum" />
 </div>
 
 <!-- Exemples : triplets RDF (sujet-predicat-objet), ontologies OWL, SPARQL -->
@@ -893,7 +893,7 @@ layout: two-cols
 - Alternatives
 - Niveau de succès espéré
 
-<img src="./images/img_051.png" class="w-[350px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_051.png" class="w-[350px] max-w-full max-h-[300px] object-contain" alt="Nuage de points en croix sur un repère f(x) en fonction de x (données à ajuster)" />
 
 
 
@@ -931,9 +931,9 @@ layout: two-cols
   - Facteurs de distributions continues
 
 <div class="img-grid">
-<img src="./images/img_052.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_053.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_054.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_052.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Ajustement d'un nuage de points par une courbe bleue oscillante, une droite rouge et un segment vert" />
+<img src="./images/img_053.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Surapprentissage : courbe orange très oscillante collée aux points, contre droite et segment de régression" />
+<img src="./images/img_054.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Découpage des données : échantillonnage, entraînement, validation, test avec sélection de modèle" />
 
 </div>
 
@@ -959,9 +959,9 @@ layout: two-cols
   - Observations bruitées
 
 <div class="img-grid">
-<img src="./images/img_055.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_056.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_057.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_055.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Arbre de décision « Faut-il attendre ? » : clients, attente estimée, faim, alternatives, bar, pluie" />
+<img src="./images/img_056.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Partition d'attributs par Clients? et Type? : ronds verts et rouges répartis en sous-ensembles" />
+<img src="./images/img_057.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Forêt aléatoire : un nœud X distribué vers plusieurs arbres, combinés par vote ou moyenne" />
 </div>
 
 
@@ -980,8 +980,8 @@ layout: two-cols
 - Apprentissage
 
 <div class="img-grid">
-<img src="./images/img_058.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_059.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_058.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Neurone biologique : dendrite, corps cellulaire, noyau, axone, synapse" />
+<img src="./images/img_059.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Données non séparables en 2D (points dans un cercle) et séparées dans un espace 3D par des plans" />
 
 </div>
 
@@ -1015,10 +1015,10 @@ layout: two-cols
 </div>
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_061.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_062.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_063.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_064.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_061.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Néon « Quiz time » rose et cyan" />
+<img src="./images/img_062.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Diagramme d'influence : décision AirportSite, conséquences Deaths/Noise/Cost, utilité U" />
+<img src="./images/img_063.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Processus de décision markovien à six états S0-S5 avec actions, récompenses +5/-1 et probabilités" />
+<img src="./images/img_064.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Grille 3x3 de navigation avec flèches de politique, cases +1/-1, piège, et inégalité sur R(s)" />
 </div>
 ---
 layout: two-cols
@@ -1055,9 +1055,9 @@ layout: two-cols
 - Utilité espérée
 
 <div class="img-grid">
-<img src="./images/img_067.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_068.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_069.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_067.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Matrice du dilemme du prisonnier : se taire/avouer, peines de (-1,-1) à (-8,-8)" />
+<img src="./images/img_068.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Arbre de jeu Stackelberg : Burn/Not Burn, Invade/Concede, Fight/Retreat avec utilités" />
+<img src="./images/img_069.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Matrice de gains du jeu Ballet/Fight : préférences croisées des deux joueurs (2,1) et (1,2)" />
 
 </div>
 
@@ -1085,7 +1085,7 @@ layout: two-cols
 - Purs et mixtes (2n+1)
 - Topologie
 
-<img src="./images/img_070.png" class="w-[300px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_070.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Arbre de jeu de poker en trois rues : Pre-flop, Flop, Turn avec Fold/Call/Check/Raise" />
 
 
 ::right::
@@ -1136,9 +1136,9 @@ layout: two-cols
 - Deepstack
 
 <div class="img-grid">
-<img src="./images/img_072.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_073.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_074.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_072.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Néon « Quiz time » violet et bleu" />
+<img src="./images/img_073.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Arbre de décision de poker avec nœuds de chance violets, nœuds d'action et terminaux triangulaires" />
+<img src="./images/img_074.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Surface 3D incurvée f(x,y) dans une boîte avec un point rouge marqué" />
 
 </div>
 
@@ -1182,8 +1182,8 @@ layout: two-cols
   - Évolution de la confiance
 
 <div class="img-grid">
-<img src="./images/img_075.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_076.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_075.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Mécanismes institutionnels : acteurs, messages, mécanisme (engrenages), résultat" />
+<img src="./images/img_076.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Jeu itératif du prisonnier avec roue de stratégies : Copycat, Cheater, Cooperator, Grudger, Detective..." />
 
 </div>
 
@@ -1217,7 +1217,7 @@ layout: two-cols
   - Jugement majoritaire
   - Scrutin bipartipludique
 
-<img src="./images/img_078.png" class="w-[280px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_078.png" class="w-[280px] max-w-full max-h-[300px] object-contain" alt="Néon « Quiz time » violet sur fond noir" />
 
 
 
@@ -1285,7 +1285,7 @@ layout: two-cols
   - Critique
   - Générateur de problème
 
-<img src="./images/img_080.png" class="w-[350px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_080.png" class="w-[350px] max-w-full max-h-[300px] object-contain" alt="Agent d'apprentissage : critique, composant d'apprentissage, composant de performance, générateur de problèmes" />
 
 
 
@@ -1320,8 +1320,8 @@ layout: two-cols
   - Connaissance a priori / modèles
   - Feedback pour apprendre
 
-<img src="./images/img_081.png" class="w-[280px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_082.png" class="w-[280px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_081.png" class="w-[280px] max-w-full max-h-[300px] object-contain" alt="Nuage de points en croix sur un repère f(x) en fonction de x" />
+<img src="./images/img_082.png" class="w-[280px] max-w-full max-h-[300px] object-contain" alt="Ajustement du nuage par une courbe bleue oscillante, une droite rouge et un segment vert" />
 
 
 
@@ -1347,8 +1347,8 @@ layout: two-cols
   - Boosting
 
 <div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
-<img src="./images/img_083.png" class="w-full object-contain" alt="Caractéristiques (2/2)" />
-<img src="./images/img_084.png" class="w-full object-contain" alt="Caractéristiques (2/2)" />
+<img src="./images/img_083.png" class="w-full object-contain" alt="Surapprentissage : courbe orange oscillante collée aux points contre droite et segment de régression" />
+<img src="./images/img_084.png" class="w-full object-contain" alt="Découpage des données : échantillonnage, entraînement, validation, test avec sélection de modèle" />
 </div>
 ---
 
@@ -1374,10 +1374,10 @@ layout: two-cols
 - Ensemble
 
 <div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_085.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_086.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_087.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_088.png" class="max-h-[300px] max-w-full object-contain" />
+<img src="./images/img_085.png" class="max-h-[300px] max-w-full object-contain" alt="Arbre de décision « Faut-il attendre ? » (exemple restaurant)" />
+<img src="./images/img_086.png" class="max-h-[300px] max-w-full object-contain" alt="Table d'exemples d'entraînement : Autre, Bar, Vendredi, Faim, Clients, Prix, Pluie, Réservation, Type, Estimation — 12 exemples" />
+<img src="./images/img_087.png" class="max-h-[300px] max-w-full object-contain" alt="Partitions d'attributs Clients? et Type? : ronds verts et rouges séparés en sous-ensembles" />
+<img src="./images/img_088.png" class="max-h-[300px] max-w-full object-contain" alt="Forêt aléatoire : nœud X, arbres tree1-treeB, vote (classification) ou moyenne (régression)" />
 </div>
 ---
 
@@ -1406,8 +1406,8 @@ layout: two-cols
 <div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
 <img src="./images/img_090.png" class="max-h-[300px] max-w-full object-contain" />
 <img src="./images/img_091.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_092.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_093.png" class="max-h-[300px] max-w-full object-contain" />
+<img src="./images/img_092.png" class="max-h-[300px] max-w-full object-contain" alt="Réseau de neurones fully-connected : une entrée, quatre neurones cachés, dix sorties" />
+<img src="./images/img_093.png" class="max-h-[300px] max-w-full object-contain" alt="Fonctions d'activation : sigmoïde, tanh, ReLU, Leaky ReLU, Maxout, ELU — formules et courbes" />
 </div>
 ---
 
@@ -1428,9 +1428,9 @@ layout: two-cols
   - Sous-échantillonnage
 
 <div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_094.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_096.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_097.png" class="max-h-[300px] max-w-full object-contain" />
+<img src="./images/img_094.png" class="max-h-[300px] max-w-full object-contain" alt="Opération de convolution : volume d'entrée 7x7x3 et noyau 3x3x3 glissant sur la matrice" />
+<img src="./images/img_096.png" class="max-h-[300px] max-w-full object-contain" alt="Transfert learning : photo de voiture, extracteur de caractéristiques, caractéristiques de haut niveau, classifieur entraînable" />
+<img src="./images/img_097.png" class="max-h-[300px] max-w-full object-contain" alt="RNN déroulé : cellule A récurrente, entrées x0 à xt, sorties h0 à ht" />
 </div>
 ---
 
@@ -1449,12 +1449,12 @@ layout: two-cols
   - Réseaux adversériaux
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_098.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_099.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_100.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_101.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_102.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_103.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_098.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Cellule LSTM : portes sigmoïdes, tanh, multiplications, états cachés h entre les pas de temps" />
+<img src="./images/img_099.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Hiérarchie de caractéristiques CNN : bords et textures, motifs, objets, puis classifieur" />
+<img src="./images/img_100.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="RNN à cinq cellules A alignées : entrées x0-x4, sorties h0-h4" />
+<img src="./images/img_101.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Image dégradée illisible (figure à régénérer — voir issue dédiée)" />
+<img src="./images/img_102.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="GAN : bruit aléatoire, générateur produisant une image forgée, discriminateur classant réel/factice" />
+<img src="./images/img_103.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Bloc résiduel ResNet : deux couches, connexion identité, H(x)=F(x)+x" />
 </div>
 
 <!-- GANs : générateur vs discriminateur, portraits StyleGAN, deepfakes -->
@@ -1479,12 +1479,12 @@ layout: two-cols
 - LLMs : BERT (2018), GPT
 
 <div class="img-grid absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_104.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_105.jpg" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_106.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_107.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_108.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_109.png" class="w-[150px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_104.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Deux photos d'une femme lançant un frisbee dans un parc, légendées en anglais" />
+<img src="./images/img_105.jpg" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Attention mot à mot : traduction de « How was your day » avec poids d'importance colorés" />
+<img src="./images/img_106.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Autoencodeur variationnel : encodeur, mu/sigma, échantillonnage, décodeur, perte reconstruction + KL" />
+<img src="./images/img_107.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Graphe irrégulier versus grille de texte séquentielle — deux structures de données" />
+<img src="./images/img_108.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Pipeline GNN : graphe d'entrée, blocs GNN, graphe transformé, couche de classification, prédiction" />
+<img src="./images/img_109.png" class="w-[150px] max-w-full max-h-[300px] object-contain" alt="Architecture Transformer encodeur-décodeur avec auto-attention, exemple de traduction du tchèque" />
 </div>
 
 <!-- Transformer : encodeur-decodeur, self-attention multi-tetes, positional encoding -->
@@ -1510,10 +1510,10 @@ layout: two-cols
 - Mécanisme attentionnel
 
 <div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_110.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_111.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_112.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_113.png" class="max-h-[300px] max-w-full object-contain" />
+<img src="./images/img_110.png" class="max-h-[300px] max-w-full object-contain" alt="Trois paires image-légende : rue de Kyoto, aigle en vol, paysage montagneux" />
+<img src="./images/img_111.png" class="max-h-[300px] max-w-full object-contain" alt="CLIP : plongements image et texte comparés, mise à jour des modèles, verdict similaire ou non" />
+<img src="./images/img_112.png" class="max-h-[300px] max-w-full object-contain" alt="Chaîne de Markov de diffusion : bruitage progressif de xT vers x0 puis débruitage inverse" />
+<img src="./images/img_113.png" class="max-h-[300px] max-w-full object-contain" alt="U-Net de débruitage latent : encodeur, décodeur, attention croisée Q/K/V, conditionnements et pas de temps" />
 </div>
 
 <!-- Diffusion : bruit gaussien progressif → apprentissage du debruitage inverse -->
@@ -1539,10 +1539,10 @@ layout: two-cols
 - Astuce du noyau
 
 <div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_114.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_115.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_116.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_117.png" class="max-h-[300px] max-w-full object-contain" />
+<img src="./images/img_114.png" class="max-h-[300px] max-w-full object-contain" alt="Courbe en cloche gaussienne centrée en zéro, densité de probabilité" />
+<img src="./images/img_115.png" class="max-h-[300px] max-w-full object-contain" alt="Diagramme de Voronoi bicolore : points rouges et bleus, classification par cellules" />
+<img src="./images/img_116.png" class="max-h-[300px] max-w-full object-contain" alt="SVM : deux classes (étoiles rouges, triangles verts), hyperplan, marge, vecteurs de support" />
+<img src="./images/img_117.png" class="max-h-[300px] max-w-full object-contain" alt="Astuce du noyau : nuage 2D non séparable projeté en 3D où un plan sépare les classes" />
 </div>
 ---
 
@@ -1567,8 +1567,8 @@ layout: two-cols
 - Programmation logique inductive (Prolog)
 
 <div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
-<img src="./images/img_118.png" class="w-full object-contain" alt="Apprentissage et connaissances" />
-<img src="./images/img_119.png" class="w-full object-contain" alt="Apprentissage et connaissances" />
+<img src="./images/img_118.png" class="w-full object-contain" alt="Système d'apprentissage inductif fondé sur connaissances : exemples, connaissance du domaine, modèle induit" />
+<img src="./images/img_119.png" class="w-full object-contain" alt="Boucle agent-environnement : récompense, état, action" />
 </div>
 ---
 
@@ -1594,8 +1594,8 @@ layout: two-cols
   - Deep Q-learning
 
 <div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
-<img src="./images/img_120.png" class="w-full object-contain" alt="Apprentissage par renforcement" />
-<img src="./images/img_121.png" class="w-full object-contain" alt="Apprentissage par renforcement" />
+<img src="./images/img_120.png" class="w-full object-contain" alt="Boucle d'apprentissage par renforcement : agent, environnement, échanges récompense/état/action" />
+<img src="./images/img_121.png" class="w-full object-contain" alt="Jeu Atari Breakout : deux captures d'écran avec score — terrain classique du RL" />
 </div>
 ---
 layout: section
@@ -1652,9 +1652,9 @@ layout: two-cols
   - Machine reading
 
 <div class="img-grid">
-<img src="./images/img_122.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_123.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_124.png" class="w-[180px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_122.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Formule de probabilité jointe d'une séquence par chaîne de Markov : produit des P(ci | ci-2:i-1)" />
+<img src="./images/img_123.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Trois pictogrammes de sentiment : positif (pouce levé vert), neutre (main jaune), négatif (pouce rouge)" />
+<img src="./images/img_124.png" class="w-[180px] max-w-full max-h-[300px] object-contain" alt="Diagramme de Venn des tâches NLP et NLU avec listes de problèmes couverts" />
 
 </div>
 
@@ -1694,8 +1694,8 @@ layout: two-cols
   - Ambiguités, Modèles imbriqués
 
 <div class="img-grid">
-<img src="./images/img_125.png" class="w-[220px] max-w-full max-h-[300px] object-contain" />
-<img src="./images/img_126.png" class="w-[220px] max-w-full max-h-[300px] object-contain" />
+<img src="./images/img_125.png" class="w-[220px] max-w-full max-h-[300px] object-contain" alt="Règle de grammaire probabiliste PCFG : VP vers Verb (0,70) ou VP NP (0,30)" />
+<img src="./images/img_126.png" class="w-[220px] max-w-full max-h-[300px] object-contain" alt="Arbre syntaxique probabiliste de « Every wumpus smells » avec probabilités par nœud" />
 
 </div>
 
@@ -1717,10 +1717,10 @@ layout: two-cols
   - Modèles sémantiques profonds
 
 <div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_127.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_128.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_129.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_130.png" class="max-h-[300px] max-w-full object-contain" />
+<img src="./images/img_127.png" class="max-h-[300px] max-w-full object-contain" alt="Seq2seq avec attention : encodeur « hello how are you », décodeur allemand « hallo wie geht es dir »" />
+<img src="./images/img_128.png" class="max-h-[300px] max-w-full object-contain" alt="Résultats de recherche d'un modèle CLSM : requêtes et titres de documents retournés" />
+<img src="./images/img_129.png" class="max-h-[300px] max-w-full object-contain" alt="Signal audio analogique, version échantillonnée, et découpage en trames avec caractéristiques" />
+<img src="./images/img_130.png" class="max-h-[300px] max-w-full object-contain" alt="Traduction par interlingua : sémantique commune puis syntaxe et mots anglais/français (John loves Mary / Jean aime Marie)" />
 </div>
 ---
 
@@ -1745,9 +1745,9 @@ layout: two-cols
   - Entraînement en ligne
 
 <div class="img-stack absolute top-[110px] right-[20px] w-[460px]">
-<img src="./images/img_131.png" class="w-full object-contain" alt="Agents conversationnels" />
-<img src="./images/img_132.png" class="w-full object-contain" alt="Agents conversationnels" />
-<img src="./images/img_133.png" class="w-full object-contain" alt="Agents conversationnels" />
+<img src="./images/img_131.png" class="w-full object-contain" alt="Architecture Microsoft Bot Framework : service bot, connecteur, canaux (Skype, Slack, Facebook...)" />
+<img src="./images/img_132.png" class="w-full object-contain" alt="Interface LUIS : énoncé utilisateur annoté avec entité reconnue (réservation de congés)" />
+<img src="./images/img_133.png" class="w-full object-contain" alt="Pipeline de dialogue : prétraitement de l'entrée, NLU, gestion de dialogue, génération, sortie" />
 </div>
 ---
 layout: two-cols


### PR DESCRIPTION
Grain: LIGHT/slides — lane myia-po-2023:CoursIA — prev: MED/slides #12189

See #12014 (tranche 3 : backfill accessibilité des alt — la table source est l'audit vision 134/134 livré avec #12189).

## Summary

Backfill mécanique des alt manquants du deck S3-acculturation, chaque texte sourcé de la description factuelle établie par l'audit vision de la tranche 1 (4 sous-agents MiniMax M3, chaque PNG/JPG lu individuellement) :

- **86 `<img>` sans attribut alt du tout** (lecteur d'écran muet) → alt ajouté décrivant ce que l'image montre réellement (schémas : PEAS, minimax, MDP, Voronoi, LSTM, U-Net, CLIP... ; néons quiz ; photos).
- **11 alt = titre du slide recollé** (img_048/049/083/084/118/119/120/121/131/132/133 — les paires img-stack « Autres Applications », « Caractéristiques », « Apprentissage... », « Agents conversationnels ») → remplacés par la description réelle de chaque image.

Un fichier touché : `slides.md`, 97+/97-.

## Non-collision (délibérée)

Lignes volontairement non touchées, possédées par des PRs ouvertes :
- L62, L105, L1390, L1407, L1408 → **#12189** (tranche 1 : swaps img_004/005 et img_089/090)
- L415, L416, L448-451 → **#12172** (retravail slide GA + suppression img_031-033 de la grille)

L502 (img_031 minimax au slide « Jeux » — placement correct, non touchée par #12172) : alt ajouté ici.

Après merge de #12189 et #12172, il restera exactement **4 `<img>` sans alt** (img_030 L448, img_031 L449, img_090 L1407, img_091 L1408) — passe finale triviale en une PR de suivi.

## Correction de contamination (commit 5bf8a9d430 — 22 alts corrigés)

Le contrôle complet des 58 images référencées des batches 1/2, **par transcription du texte visible** (consigne anti-hallucination : ne citer que le texte lisible mot à mot), a révélé que **22 des alts backfillés décrivaient une autre image que la leur** (descriptions des batches initiaux hallucinées sur les images sans contexte). Corrections notables : img_037↔039 intervertis (grammaire/Venn), img_069↔070 (arbre poker/matrice Ballet-Fight), img_098↔099 (RNN/LSTM), img_044/045/048/049/054-059/061/063/072/073/078/101 entièrement redécrits (plan FOL, HTN Build House, médias sociaux, web sémantique, gaussienne, HMM, météo bayésienne, courbe d'utilité, MDP, négociation salariale...). **Aucun des 4 .png « néon » supposés n'est un néon** (transcriptions formelles) ; les seuls néons réels étaient les 10 .jpg orphelins supprimés par #12189/#12196 (img_065/066 « QUIZ TIME » transcrits a posteriori = suppressions validées). img_086/087/094 : transcription confirme les alts existants.

## Validation

- 0 réf cassée (tous les `src` existent, vérifié avant/après).
- 0 double-attribut alt (grep `alt="[^"]*".*alt="` = 0).
- 123 `<img>` portent un alt au total sur 127 refs (les 22 corrections remplacent, n'ajoutent pas).
- Aucun notebook touché (H.3 non applicable) ; markdown pur, aucune re-exécution requise.
- img_101 : transcription lit « σ » — porte sigmoïde LSTM ; alt honnête « rendu dégradé, figure à régénérer » conservé (#12197).
