### PR TITLE
fix(slides,#12162): img_027+028 (algorithmes genetiques) deplacees slide 19 vers slide 20

### DIFF
--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -412,9 +412,6 @@ layout: two-cols
   - Algorithme A*
   - [Demo Pathfinding.js](#)
 
-<img src="./images/img_027.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Cycle d'un algorithme génétique" />
-<img src="./images/img_028.png" class="w-[300px] max-w-full max-h-[300px] object-contain" alt="Croisement sur le problème des huit reines" />
-
 </div>
 
 </div>
@@ -443,6 +440,11 @@ layout: two-cols
   - Ex: Perdus en foret
   - Sélection naturelle = combinaison
   - Algorithmes génétiques
+
+<div class="grid grid-cols-2 gap-4 mt-2">
+<img src="./images/img_027.png" class="max-h-[200px] max-w-full object-contain" alt="Cycle d'un algorithme génétique : initial population → fitness → sélection → croisement → mutation" />
+<img src="./images/img_028.png" class="max-h-[200px] max-w-full object-contain" alt="Croisement sur le problème des huit reines : deux échiquiers parents combinés par addition et permutation" />
+</div>
 
 <div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
 <img src="./images/img_030.png" class="max-h-[300px] max-w-full object-contain" />

--- a/slides/S3-acculturation/slides.md
+++ b/slides/S3-acculturation/slides.md
@@ -441,16 +441,17 @@ layout: two-cols
   - Sélection naturelle = combinaison
   - Algorithmes génétiques
 
-<div class="grid grid-cols-2 gap-4 mt-2">
-<img src="./images/img_027.png" class="max-h-[200px] max-w-full object-contain" alt="Cycle d'un algorithme génétique : initial population → fitness → sélection → croisement → mutation" />
-<img src="./images/img_028.png" class="max-h-[200px] max-w-full object-contain" alt="Croisement sur le problème des huit reines : deux échiquiers parents combinés par addition et permutation" />
+<div class="absolute top-[130px] right-[20px] w-[560px] flex flex-col gap-2">
+<div class="flex gap-2">
+<img src="./images/img_027.png" class="w-[275px] max-h-[120px] max-w-full object-contain" alt="Cycle d'un algorithme génétique : initial population → fitness → sélection → croisement → mutation" />
+<img src="./images/img_028.png" class="w-[275px] max-h-[120px] max-w-full object-contain" alt="Croisement sur le problème des huit reines : deux échiquiers parents combinés par addition et permutation" />
 </div>
-
-<div class="img-grid-2x2 absolute top-[130px] right-[20px] w-[400px]">
-<img src="./images/img_030.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_031.png" class="max-h-[300px] max-w-full object-contain" />
-<img src="./images/img_032.png" class="max-h-[300px] max-w-full object-contain" alt="Représentations d'états : atomique, factorisée, structurée" />
-<img src="./images/img_033.png" class="max-h-[300px] max-w-full object-contain" alt="Niveaux d'abstraction imbriqués d'un espace d'états" />
+<div class="img-grid-2x2">
+<img src="./images/img_030.png" class="max-h-[140px] max-w-full object-contain" alt="Paysage d'optimisation avec trajectoire de descente" />
+<img src="./images/img_031.png" class="max-h-[140px] max-w-full object-contain" />
+<img src="./images/img_032.png" class="max-h-[140px] max-w-full object-contain" alt="Représentations d'états : atomique, factorisée, structurée" />
+<img src="./images/img_033.png" class="max-h-[140px] max-w-full object-contain" alt="Niveaux d'abstraction imbriqués d'un espace d'états" />
+</div>
 </div>
 
 


### PR DESCRIPTION
Grain: MED/slides — lane myia-po-2024:CoursIA-2 — prev: DEEP/lean #12073 (c.1331p388)

## fix(slides,#12162) — composition slide 20 corrigée : img_027/028 dans le bloc absolu, plus de débordement

### Diagnostic (verbatim ai-01, DM msg-20260822T172751-2j700a HIGH)

> Mesure, avec l'instrument que l'acceptance nomme (.slidev-layout vs #slide-content) :
>   main       slide 20 : layout_h=720  content_h=720  -> tient
>   #12193     slide 20 : layout_h=884  content_h=720  -> déborde de 164 px
>   #12172     slide 20 : layout_h=889  content_h=720  -> déborde de 169 px
>
> Les deux figures déplacées atterrissent à y=671 dans un viewport de 720 :
>   img_027  x=63   y=671  566x172  -> bas à 843
>   img_028  x=650  y=671  566x166  -> bas à 837
> 49 px visibles sur 172. Les deux planches sont tranchées par le bord de la slide, et img_027 recouvre le pied de page.

### Cause racine

Le diff original (commit `4fa6e457c6`) ajoutait un `<div class="grid grid-cols-2 gap-4 mt-2">` EN FLUX, juste sous les puces « Algorithmes génétiques » de la colonne droite du layout `two-cols` SANS `::right::`. Comme la slide 20 a déjà un texte dense (titre H1 + 6 puces ≈ 200 px) **avant** la grille, le grid en flux atterrit sous la ligne de flottaison 720 px.

### Correctif (commit `b0da8fccb8`)

**Suppression** du grid en flux. **Intégration** des 6 vignettes dans un nouveau conteneur **absolu** `top-[130px] right-[20px] w-[560px] flex flex-col gap-2` :

```
Row 1 (flex-row gap-2)        : img_027 + img_028 (w-[275px] max-h-[120px])
Row 2 (img-grid-2x2 conservé) : img_030 + img_031 + img_032 + img_033
                                (max-h-[140px] max-w-full object-contain)
```

**Calcul de hauteur** :
- Row 1 : max-h 120 px → 120 px
- Gap row : 8 px
- Row 2 : 2 × 140 + 8 = 288 px
- Total : 416 px depuis y=130 → fin **y=546** → marge de **174 px** avant 720 viewport

**Alts ajoutés** :
- `img_030` : « Paysage d'optimisation avec trajectoire de descente » (absent sur main, récupéré de #12172)

**Elargissement** du bloc absolu de `w-[400px]` à `w-[560px]` pour absorber les 2 vignettes de la row 1 + la grille 2x2 row 2.

### Mesure attendue post-fix

| Métrique | Avant (#12193) | Après (#12193 amend) |
|---|---|---|
| layout_h slide 20 | 884 px | ~546 px (130 + 416) |
| content_h slide 20 | 720 px | 720 px |
| Débordement vertical | +164 px | **0** |
| img_027 visible | 49/172 px (28%) | **120/120 px (100%)** |
| img_028 visible | 49/166 px (29%) | **120/120 px (100%)** |
| img_030 alt | absent | présent |
| Vignettes height | max-h-300 px (déborde) | max-h-140 px (borné) |
| Total 6 images sur slide 20 | non (4 + 2 hors sujet) | **oui (img-grid-2x2 + row 1)** |

### Périmètre (scope atomic)

- 1 fichier `slides/S3-acculturation/slides.md`
- +10 / -9 (sur le commit d'amend uniquement)
- Aucune touche sur la slide 19 (déjà correcte : img_027/028 retirées, fermeture `</div>` valide)
- Aucun script, aucun workflow, aucun README touché

### Validation

- `python3 scripts/notebook_tools/detect_markdown_rendering.py slides/S3-acculturation/slides.md --json` → **0 finding**
- Structure HTML cohérente (les `<div>` ouvrent/ferment en équilibre)
- Slidev build local : pas de node_modules sur po-2024 → rendu visuel **routé vers ai-01** (capacity-driven, règle `model-delegation.md`)

### Demande ai-01

Re-rendre les slides 19 et 20 à `?clicks=99` après ce push et vérifier :
1. **Composition bornée** : plus de débordement vertical sur slide 20
2. **Lecture des 6 vignettes** : img_027 et img_028 sont lisibles (120 px de haut × 275 px de large chacune, ratio 3.3:1 respecté par `object-contain`)
3. **img-grid-2x2 fonctionnelle** : la grille 2x2 row 2 affiche img_030 (paysage) + img_031 (minimax) + img_032 (représentations) + img_033 (cercles)
4. **Slide 19 non-cassée** : `</div>` ouvrent/ferment (vérification manuelle déjà passée, le diff ne touche pas cette slide)

### Conformité

- **Titre de grain** : MED/slides — composition corrigée après rendu ai-01 = « étend de la substance existante avec ré-exécution/vérification » (litmus MED du `variation-protocol.md` §1)
- **G-VAR-1** : grain CONTENU DEEP/MED — `slides` reste CONTENU quand on écrit/positionne le contenu du deck
- **G-VAR-2** : 0 LIGHT ce cycle → OK
- **G-VAR-3** : `slides` ≠ `qc` ni `notebook-lean` (cycles précédents dette PR #12033 c.1331p347, #12073 c.1331p388) → OK
- **Catalog-pr-hygiene** : pas de régénération catalogue, marqueurs `CATALOG-STATUS` inchangés
- **Secrets hygiene** : pas de literal inline, pas de scrub d'output

### PR #12172 — fermeture arbitrée

`FERMER #12172` (décision ai-01, msg-20260822T172751-2j700a) :
- Son diff retire un `</div>` de trop en slide 19 (casse le build)
- Elle supprime img_031/032/033 alors que l'acceptance demandait de porter la grille à 6 images (pas à 3)
- Récupéré d'elle : **alt img_030** « Paysage d'optimisation avec trajectoire de descente »
- Avant fermeture : aucune réutilisation du code de #12172 dans #12193, sauf l'alt (citation explicite)

### Refs

DM ai-01 msg-20260822T172751-2j700a (HIGH) · commit `b0da8fccb8` · branche `fix/12162-s3-img027-028-slide20` · issue #12162 · PR #12172 (fermeture arbitrée) · PR #12073 (c.1331p388 précédent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)