### PR TITLE
exec(fort-boyard-python,#11112): re-exec kernel frais — exec-seq DUPLICATE -> CLEAN (13 -> 12 dirty)

### DIFF
--- a/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-python.ipynb
+++ b/MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-python.ipynb
@@ -2,8 +2,26 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "**Navigation** : [Index](README.md) | [<< Précédent](fort-boyard-csharp.ipynb)\n\n# Jeu de devinette : Père Fouras vs Laurent Jalabert\n\nDans ce notebook, nous allons simuler le duel légendaire entre le Père Fouras et Laurent Jalabert en utilisant Semantic Kernel avec des agents conversationnels.\n\nCe duel est l'occasion d'étudier une architecture d'orchestration multi-agents complète en miniature : un **kernel** qui héberge le service LLM, deux **agents** au persona opposé (celui qui sait, celui qui cherche), un **AgentGroupChat** qui arbitre l'alternance, et une **stratégie de terminaison** qui décide quand le jeu s'arrête. Ces quatre briques se retrouvent telles quelles dans tout système multi-agents sérieux — comité de revue, débat d'arguments, chaîne de validation — avec exactement les mêmes coutures."
+   "id": "a5914b35",
+   "metadata": {
+    "papermill": {
+     "duration": 0.024116,
+     "end_time": "2026-08-21T21:24:46.669841+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:24:46.645725+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Navigation** : [Index](README.md) | [<< Précédent](fort-boyard-csharp.ipynb)\n",
+    "\n",
+    "# Jeu de devinette : Père Fouras vs Laurent Jalabert\n",
+    "\n",
+    "Dans ce notebook, nous allons simuler le duel légendaire entre le Père Fouras et Laurent Jalabert en utilisant Semantic Kernel avec des agents conversationnels.\n",
+    "\n",
+    "Ce duel est l'occasion d'étudier une architecture d'orchestration multi-agents complète en miniature : un **kernel** qui héberge le service LLM, deux **agents** au persona opposé (celui qui sait, celui qui cherche), un **AgentGroupChat** qui arbitre l'alternance, et une **stratégie de terminaison** qui décide quand le jeu s'arrête. Ces quatre briques se retrouvent telles quelles dans tout système multi-agents sérieux — comité de revue, débat d'arguments, chaîne de validation — avec exactement les mêmes coutures."
+   ]
   },
   {
    "cell_type": "code",
@@ -11,16 +29,16 @@
    "id": "7ee7320f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:26:45.566696Z",
-     "iopub.status.busy": "2026-05-09T23:26:45.566071Z",
-     "iopub.status.idle": "2026-05-09T23:26:56.483824Z",
-     "shell.execute_reply": "2026-05-09T23:26:56.482041Z"
+     "iopub.execute_input": "2026-08-21T21:24:46.688923Z",
+     "iopub.status.busy": "2026-08-21T21:24:46.688540Z",
+     "iopub.status.idle": "2026-08-21T21:25:29.181084Z",
+     "shell.execute_reply": "2026-08-21T21:25:29.179678Z"
     },
     "papermill": {
-     "duration": 10.926308,
-     "end_time": "2026-05-09T23:26:56.486103",
+     "duration": 42.498947,
+     "end_time": "2026-08-21T21:25:29.182134+00:00",
      "exception": false,
-     "start_time": "2026-05-09T23:26:45.559795",
+     "start_time": "2026-08-21T21:24:46.683187+00:00",
      "status": "completed"
     },
     "tags": []
@@ -73,13 +91,49 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## 1. Installation et configuration\n\nCette cellule prépare l'environnement puis instancie le kernel :\n\n- **semantic-kernel** : le SDK d'orchestration — il fournit le `Kernel` (le conteneur de services), `ChatCompletionAgent` (un participant), `AgentGroupChat` (l'arbitre) et les stratégies de sélection/terminaison ;\n- **python-dotenv** : chargement sécurisé de la clé API depuis `.env` (jamais en dur dans le code) ;\n- **Logging** : configuré au niveau `INFO`, il rendra visible tout le mécanisme d'orchestration tour par tour — qui parle, quand la terminaison est évaluée, combien de tokens consommés.\n\nLe fichier `.env` doit contenir `OPENAI_API_KEY` pour l'authentification. Le modèle par défaut est `gpt-5-mini` (surchargé par `OPENAI_CHAT_MODEL_ID`)."
+   "id": "af6d85e3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004017,
+     "end_time": "2026-08-21T21:25:29.191638+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:29.187621+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Installation et configuration\n",
+    "\n",
+    "Cette cellule prépare l'environnement puis instancie le kernel :\n",
+    "\n",
+    "- **semantic-kernel** : le SDK d'orchestration — il fournit le `Kernel` (le conteneur de services), `ChatCompletionAgent` (un participant), `AgentGroupChat` (l'arbitre) et les stratégies de sélection/terminaison ;\n",
+    "- **python-dotenv** : chargement sécurisé de la clé API depuis `.env` (jamais en dur dans le code) ;\n",
+    "- **Logging** : configuré au niveau `INFO`, il rendra visible tout le mécanisme d'orchestration tour par tour — qui parle, quand la terminaison est évaluée, combien de tokens consommés.\n",
+    "\n",
+    "Le fichier `.env` doit contenir `OPENAI_API_KEY` pour l'authentification. Le modèle par défaut est `gpt-5-mini` (surchargé par `OPENAI_CHAT_MODEL_ID`)."
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "### Le mot a deviner\n\nLa variable `MOT_A_DEVINER` contient le mot que Laurent Jalabert doit trouver. Regardez bien où il vit : dans le code Python du notebook, **côté orchestrateur** — puis injecté dans le prompt du Père Fouras par f-string à la cellule suivante. Les instructions de Laurent Jalabert, elles, n'en contiennent qu'une description de rôle (« devine le mot en posant des questions fermées ») : l'agent devineur ne voit littéralement jamais la chaîne `anticonstitutionnellement` dans son prompt système.\n\nC'est l'asymétrie d'information qui fait le jeu — et c'est une propriété de conception, pas un accident : dans un vrai système multi-agents, chaque agent ne doit connaître que ce dont son rôle a besoin. La fonction `create_kernel()` crée l'instance du Kernel avec le service OpenAI configuré."
+   "id": "32b9ff73",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005636,
+     "end_time": "2026-08-21T21:25:29.202269+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:29.196633+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Le mot a deviner\n",
+    "\n",
+    "La variable `MOT_A_DEVINER` contient le mot que Laurent Jalabert doit trouver. Regardez bien où il vit : dans le code Python du notebook, **côté orchestrateur** — puis injecté dans le prompt du Père Fouras par f-string à la cellule suivante. Les instructions de Laurent Jalabert, elles, n'en contiennent qu'une description de rôle (« devine le mot en posant des questions fermées ») : l'agent devineur ne voit littéralement jamais la chaîne `anticonstitutionnellement` dans son prompt système.\n",
+    "\n",
+    "C'est l'asymétrie d'information qui fait le jeu — et c'est une propriété de conception, pas un accident : dans un vrai système multi-agents, chaque agent ne doit connaître que ce dont son rôle a besoin. La fonction `create_kernel()` crée l'instance du Kernel avec le service OpenAI configuré."
+   ]
   },
   {
    "cell_type": "code",
@@ -87,16 +141,16 @@
    "id": "35b9bb34",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:26:56.525270Z",
-     "iopub.status.busy": "2026-05-09T23:26:56.524414Z",
-     "iopub.status.idle": "2026-05-09T23:26:56.531446Z",
-     "shell.execute_reply": "2026-05-09T23:26:56.530133Z"
+     "iopub.execute_input": "2026-08-21T21:25:29.226079Z",
+     "iopub.status.busy": "2026-08-21T21:25:29.224760Z",
+     "iopub.status.idle": "2026-08-21T21:25:29.242155Z",
+     "shell.execute_reply": "2026-08-21T21:25:29.239667Z"
     },
     "papermill": {
-     "duration": 0.015068,
-     "end_time": "2026-05-09T23:26:56.533324",
+     "duration": 0.035727,
+     "end_time": "2026-08-21T21:25:29.243796+00:00",
      "exception": false,
-     "start_time": "2026-05-09T23:26:56.518256",
+     "start_time": "2026-08-21T21:25:29.208069+00:00",
      "status": "completed"
     },
     "tags": []
@@ -120,46 +174,117 @@
   {
    "cell_type": "markdown",
    "id": "a5658ac5",
-   "source": "### Exercice : Rendre le mot configurable\n\nActuellement, le mot a deviner est en dur dans le code. Pour rendre le jeu plus flexible, créez une fonction qui choisit un mot aleatoirement depuis une liste predefinie.\n\n**Objectif** : Completez la fonction `choisir_mot_aleatoire` qui selectionne un mot depuis la liste `MOTS_POSSIBLES` et retourne le mot choisi.\n\n**Indices** :\n- `# Étape 1` : Importez le module `random`\n- `# Étape 2` : Utilisez `random.choice()` sur la liste\n- `# Indice ` : Fixez le seed avec `random.seed(42)` pour la reproductibilite, puis appelez `random.choice()`",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "42c8e6e3",
-   "source": "# Exercice : Fonction de selection aleatoire du mot\nMOTS_POSSIBLES = [\n    \"python\", \"algorithmique\", \"intelligence\", \"programmation\",\n    \"ordinateur\", \"reseau\", \"database\", \"interface\"\n]\n\ndef choisir_mot_aleatoire(mots):\n    \"\"\"Choisit un mot aleatoirement depuis la liste donnee.\"\"\"\n    # TODO etudiant : importez random et utilisez random.choice()\n    return None  # TODO etudiant : remplacez par l'implementation\n\n# Test\nmot = choisir_mot_aleatoire(MOTS_POSSIBLES)\nprint(f\"Mot choisi: {mot}\")",
-   "metadata": {},
-   "execution_count": 1,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
+   "metadata": {
+    "papermill": {
+     "duration": 0.012809,
+     "end_time": "2026-08-21T21:25:29.264171+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:29.251362+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Rendre le mot configurable\n",
+    "\n",
+    "Actuellement, le mot a deviner est en dur dans le code. Pour rendre le jeu plus flexible, créez une fonction qui choisit un mot aleatoirement depuis une liste predefinie.\n",
+    "\n",
+    "**Objectif** : Completez la fonction `choisir_mot_aleatoire` qui selectionne un mot depuis la liste `MOTS_POSSIBLES` et retourne le mot choisi.\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Importez le module `random`\n",
+    "- `# Étape 2` : Utilisez `random.choice()` sur la liste\n",
+    "- `# Indice ` : Fixez le seed avec `random.seed(42)` pour la reproductibilite, puis appelez `random.choice()`"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Conception des prompts et instanciation des agents\n\nLes prompts système définissent la personnalité de chaque agent :\n\n- **Père Fouras** : donne des indices énigmatiques, parle en charades, ne révèle jamais le mot ;\n- **Laurent Jalabert** : pose des questions fermées (oui/non) pour deviner.\n\nChaque prompt suit la même anatomie en trois temps — **rôle** (« Tu es... »), **mission** (faire deviner / deviner), **contrainte de format** (charades / questions fermées). Les personas sont délibérément opposés : sans contrainte explicite, deux agents LLM sur le même modèle convergent rapidement vers un dialogue plat et coopératif qui court-circuite le jeu. La contrainte de format est ce qui force la dynamique question/réponse.\n\nNotez l'injection : le mot à deviner n'entre dans le système que par la f-string du prompt du Père Fouras. Chaque agent possédera ensuite son propre kernel (instance indépendante), un `name` unique pour l'identification dans les logs, et ses `instructions`. Les deux agents utilisent le même modèle OpenAI, mais avec des rôles différents — la spécialisation vient du prompt, pas du modèle."
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "42c8e6e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T21:25:29.304324Z",
+     "iopub.status.busy": "2026-08-21T21:25:29.303623Z",
+     "iopub.status.idle": "2026-08-21T21:25:29.330293Z",
+     "shell.execute_reply": "2026-08-21T21:25:29.326548Z"
+    },
+    "papermill": {
+     "duration": 0.055169,
+     "end_time": "2026-08-21T21:25:29.338273+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:29.283104+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mot choisi: None\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice : Fonction de selection aleatoire du mot\n",
+    "MOTS_POSSIBLES = [\n",
+    "    \"python\", \"algorithmique\", \"intelligence\", \"programmation\",\n",
+    "    \"ordinateur\", \"reseau\", \"database\", \"interface\"\n",
+    "]\n",
+    "\n",
+    "def choisir_mot_aleatoire(mots):\n",
+    "    \"\"\"Choisit un mot aleatoirement depuis la liste donnee.\"\"\"\n",
+    "    # TODO etudiant : importez random et utilisez random.choice()\n",
+    "    return None  # TODO etudiant : remplacez par l'implementation\n",
+    "\n",
+    "# Test\n",
+    "mot = choisir_mot_aleatoire(MOTS_POSSIBLES)\n",
+    "print(f\"Mot choisi: {mot}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74cb2fce",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023602,
+     "end_time": "2026-08-21T21:25:29.385713+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:29.362111+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conception des prompts et instanciation des agents\n",
+    "\n",
+    "Les prompts système définissent la personnalité de chaque agent :\n",
+    "\n",
+    "- **Père Fouras** : donne des indices énigmatiques, parle en charades, ne révèle jamais le mot ;\n",
+    "- **Laurent Jalabert** : pose des questions fermées (oui/non) pour deviner.\n",
+    "\n",
+    "Chaque prompt suit la même anatomie en trois temps — **rôle** (« Tu es... »), **mission** (faire deviner / deviner), **contrainte de format** (charades / questions fermées). Les personas sont délibérément opposés : sans contrainte explicite, deux agents LLM sur le même modèle convergent rapidement vers un dialogue plat et coopératif qui court-circuite le jeu. La contrainte de format est ce qui force la dynamique question/réponse.\n",
+    "\n",
+    "Notez l'injection : le mot à deviner n'entre dans le système que par la f-string du prompt du Père Fouras. Chaque agent possédera ensuite son propre kernel (instance indépendante), un `name` unique pour l'identification dans les logs, et ses `instructions`. Les deux agents utilisent le même modèle OpenAI, mais avec des rôles différents — la spécialisation vient du prompt, pas du modèle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "id": "bb0c742a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:26:56.575961Z",
-     "iopub.status.busy": "2026-05-09T23:26:56.575202Z",
-     "iopub.status.idle": "2026-05-09T23:26:56.581741Z",
-     "shell.execute_reply": "2026-05-09T23:26:56.580289Z"
+     "iopub.execute_input": "2026-08-21T21:25:29.409175Z",
+     "iopub.status.busy": "2026-08-21T21:25:29.408634Z",
+     "iopub.status.idle": "2026-08-21T21:25:29.422109Z",
+     "shell.execute_reply": "2026-08-21T21:25:29.417209Z"
     },
     "papermill": {
-     "duration": 0.015213,
-     "end_time": "2026-05-09T23:26:56.583995",
+     "duration": 0.026159,
+     "end_time": "2026-08-21T21:25:29.423579+00:00",
      "exception": false,
-     "start_time": "2026-05-09T23:26:56.568782",
+     "start_time": "2026-08-21T21:25:29.397420+00:00",
      "status": "completed"
     },
     "tags": []
@@ -183,25 +308,39 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Création des agents\n\n`ChatCompletionAgent` assemble les trois ingrédients préparés ci-dessus : un kernel (qui sait joindre le service), un nom (que l'orchestrateur affichera dans les logs), des instructions (le persona). Les deux agents sont créés de façon symétrique — seule la string d'instructions les distingue, ce qui rend le pattern trivialement extensible à un troisième participant (l'exercice suivant vous le fait construire)."
+   "id": "974eaf6c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.016091,
+     "end_time": "2026-08-21T21:25:29.446290+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:29.430199+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Création des agents\n",
+    "\n",
+    "`ChatCompletionAgent` assemble les trois ingrédients préparés ci-dessus : un kernel (qui sait joindre le service), un nom (que l'orchestrateur affichera dans les logs), des instructions (le persona). Les deux agents sont créés de façon symétrique — seule la string d'instructions les distingue, ce qui rend le pattern trivialement extensible à un troisième participant (l'exercice suivant vous le fait construire)."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "6b714cc8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:26:56.628269Z",
-     "iopub.status.busy": "2026-05-09T23:26:56.627383Z",
-     "iopub.status.idle": "2026-05-09T23:26:58.824358Z",
-     "shell.execute_reply": "2026-05-09T23:26:58.822991Z"
+     "iopub.execute_input": "2026-08-21T21:25:29.473483Z",
+     "iopub.status.busy": "2026-08-21T21:25:29.472424Z",
+     "iopub.status.idle": "2026-08-21T21:25:33.297656Z",
+     "shell.execute_reply": "2026-08-21T21:25:33.296313Z"
     },
     "papermill": {
-     "duration": 2.206024,
-     "end_time": "2026-05-09T23:26:58.826674",
+     "duration": 3.842389,
+     "end_time": "2026-08-21T21:25:33.298877+00:00",
      "exception": false,
-     "start_time": "2026-05-09T23:26:56.620650",
+     "start_time": "2026-08-21T21:25:29.456488+00:00",
      "status": "completed"
     },
     "tags": []
@@ -227,46 +366,117 @@
   {
    "cell_type": "markdown",
    "id": "d941de67",
-   "source": "### Exercice : Créer un troisieme agent \"Juge\"\n\nDans le jeu actuel, seuls deux agents interagissent. Un troisieme agent pourrait enrichir l'expérience.\n\n**Objectif** : Completez la definition de l'agent `juge` ci-dessous. Le Juge doit observer la conversation et donner des indices supplementaires si Laurent Jalabert est bloque (plus de 5 questions sans progresser).\n\n**Indices** :\n- `# Étape 1` : Definissez le prompt système du Juge avec sa mission\n- `# Étape 2` : Instanciez un `ChatCompletionAgent` avec un kernel et un nom uniques\n- `# Indice ` : Inspirez-vous de la creation de `pere_fouras` et `laurent_jalabert` ci-dessus",
-   "metadata": {}
+   "metadata": {
+    "papermill": {
+     "duration": 0.005357,
+     "end_time": "2026-08-21T21:25:33.308699+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:33.303342+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Créer un troisieme agent \"Juge\"\n",
+    "\n",
+    "Dans le jeu actuel, seuls deux agents interagissent. Un troisieme agent pourrait enrichir l'expérience.\n",
+    "\n",
+    "**Objectif** : Completez la definition de l'agent `juge` ci-dessous. Le Juge doit observer la conversation et donner des indices supplementaires si Laurent Jalabert est bloque (plus de 5 questions sans progresser).\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Definissez le prompt système du Juge avec sa mission\n",
+    "- `# Étape 2` : Instanciez un `ChatCompletionAgent` avec un kernel et un nom uniques\n",
+    "- `# Indice ` : Inspirez-vous de la creation de `pere_fouras` et `laurent_jalabert` ci-dessus"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "9cda1ac6",
-   "source": "# Exercice : Creation d'un agent Juge\n# Definissez le prompt et l'agent pour un troisieme participant\n\n# TODO etudiant : definissez le prompt systeme du Juge\nJUGE_PROMPT = None  # TODO etudiant : remplacez par le prompt\n\n# TODO etudiant : creez l'agent Juge en vous inspirant de pere_fouras et laurent_jalabert\n# juge = ChatCompletionAgent(\n#     kernel=create_kernel(),\n#     name=\"Juge\",\n#     instructions=JUGE_PROMPT,\n# )\n\nprint(\"Exercice a completer\")",
-   "metadata": {},
-   "execution_count": 1,
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T21:25:33.326780Z",
+     "iopub.status.busy": "2026-08-21T21:25:33.326487Z",
+     "iopub.status.idle": "2026-08-21T21:25:33.346372Z",
+     "shell.execute_reply": "2026-08-21T21:25:33.341186Z"
+    },
+    "papermill": {
+     "duration": 0.031364,
+     "end_time": "2026-08-21T21:25:33.350337+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:33.318973+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
+     "output_type": "stream",
      "text": [
       "Exercice a completer\n"
      ]
     }
+   ],
+   "source": [
+    "# Exercice : Creation d'un agent Juge\n",
+    "# Definissez le prompt et l'agent pour un troisieme participant\n",
+    "\n",
+    "# TODO etudiant : definissez le prompt systeme du Juge\n",
+    "JUGE_PROMPT = None  # TODO etudiant : remplacez par le prompt\n",
+    "\n",
+    "# TODO etudiant : creez l'agent Juge en vous inspirant de pere_fouras et laurent_jalabert\n",
+    "# juge = ChatCompletionAgent(\n",
+    "#     kernel=create_kernel(),\n",
+    "#     name=\"Juge\",\n",
+    "#     instructions=JUGE_PROMPT,\n",
+    "# )\n",
+    "\n",
+    "print(\"Exercice a completer\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Stratégie de terminaison personnalisée\n\nUn group chat a besoin de savoir quand s'arrêter — sinon les agents conversent indéfiniment. Semantic Kernel expose pour cela `TerminationStrategy`, dont on spécialise la méthode `should_agent_terminate` : appelée après chaque tour, elle reçoit l'historique complet et retourne un booléen.\n\nNotre implémentation est volontairement simple : elle regarde si `MOT_A_DEVINER` apparaît dans le **dernier message** (en minuscules). Deux remarques pour la suite :\n\n- c'est un test de **présence**, pas de **victoire** : dès que le mot est prononcé — y compris dans une question comme « est-ce que le mot est X ? » — la partie s'arrête. Observez la sortie de la partie plus bas : c'est exactement ce qui s'y produit ;\n- la comparaison est sensible aux variantes typographiques (accents, casse composée, espaces). L'exercice 3 vous demande de durcir cette détection.\n\nC'est le mécanisme d'arrêt **sémantique** ; il se double d'un filet de sécurité mécanique (`maximum_iterations`) configuré à la cellule suivante."
+   "id": "0b61a8c2",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008948,
+     "end_time": "2026-08-21T21:25:33.370770+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:33.361822+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Stratégie de terminaison personnalisée\n",
+    "\n",
+    "Un group chat a besoin de savoir quand s'arrêter — sinon les agents conversent indéfiniment. Semantic Kernel expose pour cela `TerminationStrategy`, dont on spécialise la méthode `should_agent_terminate` : appelée après chaque tour, elle reçoit l'historique complet et retourne un booléen.\n",
+    "\n",
+    "Notre implémentation est volontairement simple : elle regarde si `MOT_A_DEVINER` apparaît dans le **dernier message** (en minuscules). Deux remarques pour la suite :\n",
+    "\n",
+    "- c'est un test de **présence**, pas de **victoire** : dès que le mot est prononcé — y compris dans une question comme « est-ce que le mot est X ? » — la partie s'arrête. Observez la sortie de la partie plus bas : c'est exactement ce qui s'y produit ;\n",
+    "- la comparaison est sensible aux variantes typographiques (accents, casse composée, espaces). L'exercice 3 vous demande de durcir cette détection.\n",
+    "\n",
+    "C'est le mécanisme d'arrêt **sémantique** ; il se double d'un filet de sécurité mécanique (`maximum_iterations`) configuré à la cellule suivante."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "0cd9cee4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:26:58.861456Z",
-     "iopub.status.busy": "2026-05-09T23:26:58.860645Z",
-     "iopub.status.idle": "2026-05-09T23:26:58.871332Z",
-     "shell.execute_reply": "2026-05-09T23:26:58.869791Z"
+     "iopub.execute_input": "2026-08-21T21:25:33.383620Z",
+     "iopub.status.busy": "2026-08-21T21:25:33.382836Z",
+     "iopub.status.idle": "2026-08-21T21:25:33.397033Z",
+     "shell.execute_reply": "2026-08-21T21:25:33.394995Z"
     },
     "papermill": {
-     "duration": 0.020001,
-     "end_time": "2026-05-09T23:26:58.873634",
+     "duration": 0.024132,
+     "end_time": "2026-08-21T21:25:33.399240+00:00",
      "exception": false,
-     "start_time": "2026-05-09T23:26:58.853633",
+     "start_time": "2026-08-21T21:25:33.375108+00:00",
      "status": "completed"
     },
     "tags": []
@@ -295,30 +505,61 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "**Lecture du code.** `should_agent_terminate` commence par se protéger de l'historique vide, puis prend `history[-1]` — uniquement le dernier message, pas toute la conversation. La comparaison `MOT_A_DEVINER in last_message` est un test de sous-chaîne : insensible à la casse grâce au `.lower()` appliqué des deux côtés, mais aveugle aux accents et aux espaces parasites. La signature `async` n'est pas décorative : dans Semantic Kernel, la stratégie peut elle-même appeler un modèle (pour décider sémantiquement), d'où l'await potentiel — notre version est pure donc immédiate."
+   "id": "3ffaacc6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.0032,
+     "end_time": "2026-08-21T21:25:33.408159+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:33.404959+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture du code.** `should_agent_terminate` commence par se protéger de l'historique vide, puis prend `history[-1]` — uniquement le dernier message, pas toute la conversation. La comparaison `MOT_A_DEVINER in last_message` est un test de sous-chaîne : insensible à la casse grâce au `.lower()` appliqué des deux côtés, mais aveugle aux accents et aux espaces parasites. La signature `async` n'est pas décorative : dans Semantic Kernel, la stratégie peut elle-même appeler un modèle (pour décider sémantiquement), d'où l'await potentiel — notre version est pure donc immédiate."
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Configuration du groupe de discussion\n\nLe `AgentGroupChat` orchestre les deux agents. Sa configuration révèle la séparation des deux arbitrages d'un group chat :\n\n- la **sélection** (qui parle ensuite) — ici laissée au comportement par défaut, l'alternance séquentielle entre les agents listés ;\n- la **terminaison** (quand arrêter) — notre `FortBoyardTerminationStrategy`, avec deux paramètres : `agents=[laurent_jalabert]` (le critère n'est évalué qu'après une intervention du devineur — c'est lui qui peut gagner, pas le maître du jeu) et `maximum_iterations=20` (filet de sécurité mécanique : même si le mot n'est jamais prononcé, la boucle s'arrête).\n\n`AgentGroupChat` maintient par ailleurs l'historique partagé : chaque message devient visible pour les deux agents au tour suivant. C'est ce contexte commun croissant qui permet la cohérence du dialogue — et dont le coût en tokens devient visible dans les logs de la partie."
+   "id": "2614417a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003841,
+     "end_time": "2026-08-21T21:25:33.415221+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:33.411380+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Configuration du groupe de discussion\n",
+    "\n",
+    "Le `AgentGroupChat` orchestre les deux agents. Sa configuration révèle la séparation des deux arbitrages d'un group chat :\n",
+    "\n",
+    "- la **sélection** (qui parle ensuite) — ici laissée au comportement par défaut, l'alternance séquentielle entre les agents listés ;\n",
+    "- la **terminaison** (quand arrêter) — notre `FortBoyardTerminationStrategy`, avec deux paramètres : `agents=[laurent_jalabert]` (le critère n'est évalué qu'après une intervention du devineur — c'est lui qui peut gagner, pas le maître du jeu) et `maximum_iterations=20` (filet de sécurité mécanique : même si le mot n'est jamais prononcé, la boucle s'arrête).\n",
+    "\n",
+    "`AgentGroupChat` maintient par ailleurs l'historique partagé : chaque message devient visible pour les deux agents au tour suivant. C'est ce contexte commun croissant qui permet la cohérence du dialogue — et dont le coût en tokens devient visible dans les logs de la partie."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "id": "2426a062",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:26:58.896833Z",
-     "iopub.status.busy": "2026-05-09T23:26:58.896154Z",
-     "iopub.status.idle": "2026-05-09T23:26:58.902523Z",
-     "shell.execute_reply": "2026-05-09T23:26:58.901083Z"
+     "iopub.execute_input": "2026-08-21T21:25:33.424863Z",
+     "iopub.status.busy": "2026-08-21T21:25:33.424592Z",
+     "iopub.status.idle": "2026-08-21T21:25:33.430492Z",
+     "shell.execute_reply": "2026-08-21T21:25:33.429327Z"
     },
     "papermill": {
-     "duration": 0.014724,
-     "end_time": "2026-05-09T23:26:58.904632",
+     "duration": 0.012284,
+     "end_time": "2026-08-21T21:25:33.431522+00:00",
      "exception": false,
-     "start_time": "2026-05-09T23:26:58.889908",
+     "start_time": "2026-08-21T21:25:33.419238+00:00",
      "status": "completed"
     },
     "tags": []
@@ -337,30 +578,62 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "**Pourquoi « corrigée » ?** Le commentaire `# Bloc 6 - Configuration corrigée` rappelle une version antérieure où la stratégie n'avait ni liste d'agents ni plafond d'itérations : sans `agents=`, le critère était évalué après *chaque* intervention (y compris celle du Père Fouras — qui prononce le mot dans sa propre tête à chaque prompt) et sans `maximum_iterations`, une partie sans victoire tournait à l'infini. Les deux paramètres ne sont pas du réglage fin : ils sont ce qui rend l'arrêt *correct*."
+   "id": "fc576fcd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004281,
+     "end_time": "2026-08-21T21:25:33.440657+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:33.436376+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Pourquoi « corrigée » ?** Le commentaire `# Bloc 6 - Configuration corrigée` rappelle une version antérieure où la stratégie n'avait ni liste d'agents ni plafond d'itérations : sans `agents=`, le critère était évalué après *chaque* intervention (y compris celle du Père Fouras — qui prononce le mot dans sa propre tête à chaque prompt) et sans `maximum_iterations`, une partie sans victoire tournait à l'infini. Les deux paramètres ne sont pas du réglage fin : ils sont ce qui rend l'arrêt *correct*."
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Lancement de la partie !\n\nLa fonction `jouer_partie()` lance la conversation :\n\n1. elle sème un premier message `USER` (« Pere Fouras, donne-moi un indice ! ») — sans amorce, aucun agent n'a de raison de parler en premier ;\n2. elle itère sur `chat.invoke()`, qui retourne chaque message au fil de la conversation : l'orchestrateur sélectionne l'agent, l'invoque, évalue la terminaison, puis recommence ;\n3. chaque intervention est loggée avec le rôle de l'agent — les logs INFO montrent toute la mécanique : `Selected agent`, `Invoking agent`, l'appel HTTP vers l'API, l'usage de tokens, puis `Evaluating termination criteria`.\n\nExécutez la cellule et lisez la sortie **en entier** : c'est la meilleure radiographie d'un orchestrateur multi-agents que le dépôt puisse offrir."
+   "id": "8592df77",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005815,
+     "end_time": "2026-08-21T21:25:33.451116+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:25:33.445301+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Lancement de la partie !\n",
+    "\n",
+    "La fonction `jouer_partie()` lance la conversation :\n",
+    "\n",
+    "1. elle sème un premier message `USER` (« Pere Fouras, donne-moi un indice ! ») — sans amorce, aucun agent n'a de raison de parler en premier ;\n",
+    "2. elle itère sur `chat.invoke()`, qui retourne chaque message au fil de la conversation : l'orchestrateur sélectionne l'agent, l'invoque, évalue la terminaison, puis recommence ;\n",
+    "3. chaque intervention est loggée avec le rôle de l'agent — les logs INFO montrent toute la mécanique : `Selected agent`, `Invoking agent`, l'appel HTTP vers l'API, l'usage de tokens, puis `Evaluating termination criteria`.\n",
+    "\n",
+    "Exécutez la cellule et lisez la sortie **en entier** : c'est la meilleure radiographie d'un orchestrateur multi-agents que le dépôt puisse offrir."
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 9,
    "id": "fa58a484",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-09T23:26:58.928061Z",
-     "iopub.status.busy": "2026-05-09T23:26:58.927282Z",
-     "iopub.status.idle": "2026-05-09T23:27:30.523268Z",
-     "shell.execute_reply": "2026-05-09T23:27:30.522423Z"
+     "iopub.execute_input": "2026-08-21T21:25:33.460641Z",
+     "iopub.status.busy": "2026-08-21T21:25:33.460312Z",
+     "iopub.status.idle": "2026-08-21T21:26:22.613999Z",
+     "shell.execute_reply": "2026-08-21T21:26:22.611056Z"
     },
     "papermill": {
-     "duration": 31.605968,
-     "end_time": "2026-05-09T23:27:30.526659",
+     "duration": 49.161067,
+     "end_time": "2026-08-21T21:26:22.616388+00:00",
      "exception": false,
-     "start_time": "2026-05-09T23:26:58.920691",
+     "start_time": "2026-08-21T21:25:33.455321+00:00",
      "status": "completed"
     },
     "tags": []
@@ -370,797 +643,435 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:26:58,931 [INFO] Depart du duel Pere Fouras vs Laurent Jalabert !\n"
+      "2026-08-21 23:25:33,465 [INFO] Depart du duel Pere Fouras vs Laurent Jalabert !\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:26:58,932 [INFO] Mot a deviner : ANTICONSTITUTIONNELLEMENT\n"
+      "2026-08-21 23:25:33,466 [INFO] Mot a deviner : ANTICONSTITUTIONNELLEMENT\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:26:58,933 [INFO] Adding `1` agent chat messages\n"
+      "2026-08-21 23:25:33,468 [INFO] Adding `1` agent chat messages\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:26:58,934 [INFO] Selected agent at index 0 (ID: e03f8505-8323-4a08-a97d-8a0a089df486, name: Pere_Fouras)\n"
+      "2026-08-21 23:25:33,469 [INFO] Selected agent at index 0 (ID: 5711b741-0554-4f12-966e-c09f619af74b, name: Pere_Fouras)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:26:58,935 [INFO] Invoking agent Pere_Fouras\n"
+      "2026-08-21 23:25:33,470 [INFO] Invoking agent Pere_Fouras\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:02,426 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+      "2026-08-21 23:25:47,315 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:02,443 [INFO] OpenAI usage: CompletionUsage(completion_tokens=151, prompt_tokens=72, total_tokens=223, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
+      "2026-08-21 23:25:47,357 [INFO] OpenAI usage: CompletionUsage(completion_tokens=1165, prompt_tokens=72, total_tokens=1237, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=1024, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:02,445 [INFO] Evaluating termination criteria for e03f8505-8323-4a08-a97d-8a0a089df486\n"
+      "2026-08-21 23:25:47,358 [INFO] Evaluating termination criteria for 5711b741-0554-4f12-966e-c09f619af74b\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:02,446 [INFO] Agent e03f8505-8323-4a08-a97d-8a0a089df486 is out of scope\n"
+      "2026-08-21 23:25:47,359 [INFO] Agent 5711b741-0554-4f12-966e-c09f619af74b is out of scope\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:02,447 [INFO] [AuthorRole.ASSISTANT] : Écoute bien, moussaillon…\n",
+      "2026-08-21 23:25:47,359 [INFO] [AuthorRole.ASSISTANT] : Ahahaha... Un indice, tu veux ? Très bien, jeune aventurier, voici une charade du vieux Fort :\n",
       "\n",
-      "**Charade du Père Fouras :**  \n",
-      "- Mon **premier** est le contraire de *pour*.  \n",
-      "- Mon **deuxième** est ce que l’on appelle la règle suprême d’un pays, souvent écrite dans un grand texte.  \n",
-      "- Mon **troisième** évoque la manière d’agir, la **façon** dont on fait les choses (souvent en fin de mot).  \n",
-      "- Mon **tout** est un très long adverbe qui signifie : *d’une manière contraire à la règle suprême du pays*.\n",
+      "Mon premier refuse, s'oppose — on le trouve devant « virus » ou « systéme ».\n",
+      "Mon deuxième est le texte fondamental d'un État, celui qui fixe les règles et les droits.\n",
+      "Mon troisième est un adjectif qui signifie « conforme à ce même texte fondamental ».\n",
+      "Mon dernier transforme un adjectif en manière, il termine bien des adverbes.\n",
       "\n",
-      "Si tu veux, je peux te donner **le nombre de syllabes**… mais il faudra le mériter !\n"
+      "Mon tout décrit une manière d'agir qui va à l'encontre de la loi fondamentale. À toi de jouer : quelle est ta proposition ?\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:02,450 [INFO] Selected agent at index 1 (ID: b9819ccd-c568-4152-8a6f-1c49ef4e0d31, name: Laurent_Jalabert)\n"
+      "2026-08-21 23:25:47,360 [INFO] Selected agent at index 1 (ID: a098d8ee-c435-4103-bc5b-23f71fab15c0, name: Laurent_Jalabert)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:02,451 [INFO] Invoking agent Laurent_Jalabert\n"
+      "2026-08-21 23:25:47,361 [INFO] Invoking agent Laurent_Jalabert\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:04,022 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+      "2026-08-21 23:25:52,662 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:04,024 [INFO] OpenAI usage: CompletionUsage(completion_tokens=61, prompt_tokens=383, total_tokens=444, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
+      "2026-08-21 23:25:52,664 [INFO] OpenAI usage: CompletionUsage(completion_tokens=419, prompt_tokens=351, total_tokens=770, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=384, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:04,026 [INFO] Evaluating termination criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31\n"
+      "2026-08-21 23:25:52,665 [INFO] Evaluating termination criteria for a098d8ee-c435-4103-bc5b-23f71fab15c0\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:04,027 [INFO] Evaluated criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31, should terminate: False\n"
+      "2026-08-21 23:25:52,665 [INFO] Evaluated criteria for a098d8ee-c435-4103-bc5b-23f71fab15c0, should terminate: False\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:04,029 [INFO] [AuthorRole.ASSISTANT] : Je ne peux pas te donner un indice “Père Fouras” ici, parce que je dois **deviner le mot en posant des questions Oui/Non**.\n",
+      "2026-08-21 23:25:52,666 [INFO] [AuthorRole.ASSISTANT] : Jeu lancé ! Première question : est-ce que le mot que tu as en tête est en français ? (Oui / Non)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:25:52,666 [INFO] Selected agent at index 0 (ID: 5711b741-0554-4f12-966e-c09f619af74b, name: Pere_Fouras)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:25:52,667 [INFO] Invoking agent Pere_Fouras\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:25:59,717 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:25:59,719 [INFO] OpenAI usage: CompletionUsage(completion_tokens=784, prompt_tokens=436, total_tokens=1220, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=640, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:25:59,719 [INFO] Evaluating termination criteria for 5711b741-0554-4f12-966e-c09f619af74b\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:25:59,720 [INFO] Agent 5711b741-0554-4f12-966e-c09f619af74b is out of scope\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:25:59,721 [INFO] [AuthorRole.ASSISTANT] : Ahahahaha... Oui, jeune aventurier, le mot est bien en français !\n",
       "\n",
-      "On commence stratégique :\n",
+      "Un autre indice pour t'éclairer, puisque tu le demandes : mon tout est un adverbe très long, souvent cité parmi les plus longs du français. Il se compose d'un préfixe qui nie ou s'oppose, du nom qui désigne la loi fondamentale d'un État, d'un adjectif dérivé de ce nom et d'un suffixe qui transforme cet adjectif en manière d'agir.\n",
       "\n",
-      "**Est-ce un objet concret (qu’on peut toucher) ?** (Oui/Non)\n"
+      "À toi la parole : veux-tu une autre charade, un indice sur la longueur (nombre de syllabes) ou tu poses ta prochaine question ?\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:04,030 [INFO] Selected agent at index 0 (ID: e03f8505-8323-4a08-a97d-8a0a089df486, name: Pere_Fouras)\n"
+      "2026-08-21 23:25:59,722 [INFO] Selected agent at index 1 (ID: a098d8ee-c435-4103-bc5b-23f71fab15c0, name: Laurent_Jalabert)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:04,031 [INFO] Invoking agent Pere_Fouras\n"
+      "2026-08-21 23:25:59,722 [INFO] Invoking agent Laurent_Jalabert\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:07,012 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+      "2026-08-21 23:26:05,825 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:07,015 [INFO] OpenAI usage: CompletionUsage(completion_tokens=147, prompt_tokens=532, total_tokens=679, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
+      "2026-08-21 23:26:05,831 [INFO] OpenAI usage: CompletionUsage(completion_tokens=603, prompt_tokens=719, total_tokens=1322, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=576, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:07,017 [INFO] Evaluating termination criteria for e03f8505-8323-4a08-a97d-8a0a089df486\n"
+      "2026-08-21 23:26:05,832 [INFO] Evaluating termination criteria for a098d8ee-c435-4103-bc5b-23f71fab15c0\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:07,018 [INFO] Agent e03f8505-8323-4a08-a97d-8a0a089df486 is out of scope\n"
+      "2026-08-21 23:26:05,833 [INFO] Evaluated criteria for a098d8ee-c435-4103-bc5b-23f71fab15c0, should terminate: False\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:07,018 [INFO] [AuthorRole.ASSISTANT] : Écoute bien, moussaillon…\n",
+      "2026-08-21 23:26:05,833 [INFO] [AuthorRole.ASSISTANT] : Est-ce que le mot se termine par « -ment » ? (Oui / Non)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:05,834 [INFO] Selected agent at index 0 (ID: 5711b741-0554-4f12-966e-c09f619af74b, name: Pere_Fouras)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:05,835 [INFO] Invoking agent Pere_Fouras\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:08,833 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:08,851 [INFO] OpenAI usage: CompletionUsage(completion_tokens=183, prompt_tokens=788, total_tokens=971, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=128, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:08,857 [INFO] Evaluating termination criteria for 5711b741-0554-4f12-966e-c09f619af74b\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:08,862 [INFO] Agent 5711b741-0554-4f12-966e-c09f619af74b is out of scope\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:08,868 [INFO] [AuthorRole.ASSISTANT] : Ahahahaha... Oui, jeune aventurier, il se termine bien par « -ment » !\n",
       "\n",
-      "**Charade du Père Fouras :**  \n",
-      "- Mon **premier** est le contraire de *pour*.  \n",
-      "- Mon **deuxième** est la loi suprême d’un pays, gravée dans un grand texte.  \n",
-      "- Mon **troisième** est une terminaison qui veut dire **“de manière…”**.  \n",
-      "- Mon **tout** désigne quelque chose fait **en contradiction avec la loi suprême**… et c’est un mot si long qu’il ferait trembler la porte du Conseil des sages !\n",
+      "Veux-tu que je te donne le nombre de syllabes, une autre charade, ou préfères-tu tenter une proposition ?\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:08,875 [INFO] Selected agent at index 1 (ID: a098d8ee-c435-4103-bc5b-23f71fab15c0, name: Laurent_Jalabert)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:08,880 [INFO] Invoking agent Laurent_Jalabert\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:13,255 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:13,263 [INFO] OpenAI usage: CompletionUsage(completion_tokens=345, prompt_tokens=895, total_tokens=1240, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=320, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:13,264 [INFO] Evaluating termination criteria for a098d8ee-c435-4103-bc5b-23f71fab15c0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:13,265 [INFO] Evaluated criteria for a098d8ee-c435-4103-bc5b-23f71fab15c0, should terminate: False\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:13,266 [INFO] [AuthorRole.ASSISTANT] : Est-ce que le mot commence par « anti » ? (Oui / Non)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:13,267 [INFO] Selected agent at index 0 (ID: 5711b741-0554-4f12-966e-c09f619af74b, name: Pere_Fouras)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:13,268 [INFO] Invoking agent Pere_Fouras\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:16,185 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:16,202 [INFO] OpenAI usage: CompletionUsage(completion_tokens=241, prompt_tokens=960, total_tokens=1201, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=192, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:16,214 [INFO] Evaluating termination criteria for 5711b741-0554-4f12-966e-c09f619af74b\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:16,218 [INFO] Agent 5711b741-0554-4f12-966e-c09f619af74b is out of scope\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-08-21 23:26:16,226 [INFO] [AuthorRole.ASSISTANT] : Ahahahaha... Oui, jeune aventurier, il commence bien par « anti » !\n",
       "\n",
-      "Veux-tu un indice de plus : **le début (3 premières lettres)** ou **la fin (les 6 dernières)** ?\n"
+      "Veux-tu le nombre de syllabes, une autre charade, ou préfères-tu tenter une proposition ?\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:07,019 [INFO] Selected agent at index 1 (ID: b9819ccd-c568-4152-8a6f-1c49ef4e0d31, name: Laurent_Jalabert)\n"
+      "2026-08-21 23:26:16,231 [INFO] Selected agent at index 1 (ID: a098d8ee-c435-4103-bc5b-23f71fab15c0, name: Laurent_Jalabert)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:07,020 [INFO] Invoking agent Laurent_Jalabert\n"
+      "2026-08-21 23:26:16,237 [INFO] Invoking agent Laurent_Jalabert\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:09,091 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
+      "2026-08-21 23:26:22,561 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:09,094 [INFO] OpenAI usage: CompletionUsage(completion_tokens=69, prompt_tokens=835, total_tokens=904, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
+      "2026-08-21 23:26:22,581 [INFO] OpenAI usage: CompletionUsage(completion_tokens=543, prompt_tokens=1055, total_tokens=1598, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=512, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:09,095 [INFO] Evaluating termination criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31\n"
+      "2026-08-21 23:26:22,590 [INFO] Evaluating termination criteria for a098d8ee-c435-4103-bc5b-23f71fab15c0\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:09,096 [INFO] Evaluated criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31, should terminate: False\n"
+      "2026-08-21 23:26:22,594 [INFO] Evaluated criteria for a098d8ee-c435-4103-bc5b-23f71fab15c0, should terminate: True\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:09,097 [INFO] [AuthorRole.ASSISTANT] : Je dois jouer façon **Laurent Jalabert** et **deviner le mot uniquement avec des questions fermées (Oui/Non)**, donc je ne peux pas te donner un indice de Père Fouras.\n",
-      "\n",
-      "On démarre :\n",
-      "\n",
-      "**Le mot que tu as en tête est-il un nom commun ? (Oui/Non)**\n"
+      "2026-08-21 23:26:22,597 [INFO] [AuthorRole.ASSISTANT] : Est-ce que le mot que tu as choisi est « anticonstitutionnellement » ? (Oui / Non)\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2026-05-10 01:27:09,098 [INFO] Selected agent at index 0 (ID: e03f8505-8323-4a08-a97d-8a0a089df486, name: Pere_Fouras)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:09,099 [INFO] Invoking agent Pere_Fouras\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:11,916 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:11,918 [INFO] OpenAI usage: CompletionUsage(completion_tokens=158, prompt_tokens=1000, total_tokens=1158, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:11,919 [INFO] Evaluating termination criteria for e03f8505-8323-4a08-a97d-8a0a089df486\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:11,920 [INFO] Agent e03f8505-8323-4a08-a97d-8a0a089df486 is out of scope\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:11,921 [INFO] [AuthorRole.ASSISTANT] : Écoute bien, moussaillon…\n",
-      "\n",
-      "**Énigme du Père Fouras :**  \n",
-      "Je suis un **adverbe interminable**.  \n",
-      "Je décris ce qui se fait **contre** la règle suprême d’un pays, celle qui domine toutes les lois.\n",
-      "\n",
-      "**Charade :**  \n",
-      "- Mon **premier** est le contraire de *pour*.  \n",
-      "- Mon **deuxième** est la grande loi fondatrice d’un État.  \n",
-      "- Mon **troisième** est une terminaison qui signifie **“d’une manière…”**.\n",
-      "\n",
-      "Mon tout : *d’une manière contraire à la loi suprême*.\n",
-      "\n",
-      "Choisis ton supplice : veux-tu **le nombre de lettres** ou **le nombre de syllabes** ?\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:11,922 [INFO] Selected agent at index 1 (ID: b9819ccd-c568-4152-8a6f-1c49ef4e0d31, name: Laurent_Jalabert)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:11,923 [INFO] Invoking agent Laurent_Jalabert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:13,603 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:13,605 [INFO] OpenAI usage: CompletionUsage(completion_tokens=44, prompt_tokens=1325, total_tokens=1369, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:13,606 [INFO] Evaluating termination criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:13,608 [INFO] Evaluated criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31, should terminate: False\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:13,609 [INFO] [AuthorRole.ASSISTANT] : Je dois jouer à deviner le mot avec des questions **Oui/Non**, donc je ne peux pas donner d’indice.\n",
-      "\n",
-      "**Le mot est-il un adverbe ? (Oui/Non)**\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:13,610 [INFO] Selected agent at index 0 (ID: e03f8505-8323-4a08-a97d-8a0a089df486, name: Pere_Fouras)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:13,611 [INFO] Invoking agent Pere_Fouras\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:16,527 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:16,529 [INFO] OpenAI usage: CompletionUsage(completion_tokens=114, prompt_tokens=1440, total_tokens=1554, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:16,530 [INFO] Evaluating termination criteria for e03f8505-8323-4a08-a97d-8a0a089df486\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:16,531 [INFO] Agent e03f8505-8323-4a08-a97d-8a0a089df486 is out of scope\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:16,532 [INFO] [AuthorRole.ASSISTANT] : Très bien, moussaillon… prends cet indice sans que je trahisse le secret :\n",
-      "\n",
-      "Je suis un **adverbe démesurément long**, forgé autour de l’idée de **contredire** la **loi suprême d’un pays**, et je me termine par une expression qui veut dire **“d’une manière…”**.\n",
-      "\n",
-      "Veux-tu que je te donne :\n",
-      "1) **le nombre de lettres**, ou  \n",
-      "2) **les 4 premières lettres**, ou  \n",
-      "3) **les 6 dernières lettres** ?\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:16,533 [INFO] Selected agent at index 1 (ID: b9819ccd-c568-4152-8a6f-1c49ef4e0d31, name: Laurent_Jalabert)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:16,533 [INFO] Invoking agent Laurent_Jalabert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:18,122 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:18,124 [INFO] OpenAI usage: CompletionUsage(completion_tokens=60, prompt_tokens=1677, total_tokens=1737, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=1152))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:18,125 [INFO] Evaluating termination criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:18,126 [INFO] Evaluated criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31, should terminate: False\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:18,126 [INFO] [AuthorRole.ASSISTANT] : Je suis **Laurent Jalabert** et je dois deviner le mot uniquement avec des questions **Oui/Non** — pas d’indice.\n",
-      "\n",
-      "**Le mot est-il lié au droit / à la politique (lois, constitution, institutions) ? (Oui/Non)**\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:18,127 [INFO] Selected agent at index 0 (ID: e03f8505-8323-4a08-a97d-8a0a089df486, name: Pere_Fouras)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:18,127 [INFO] Invoking agent Pere_Fouras\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:20,735 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:20,739 [INFO] OpenAI usage: CompletionUsage(completion_tokens=139, prompt_tokens=1824, total_tokens=1963, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:20,740 [INFO] Evaluating termination criteria for e03f8505-8323-4a08-a97d-8a0a089df486\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:20,740 [INFO] Agent e03f8505-8323-4a08-a97d-8a0a089df486 is out of scope\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:20,741 [INFO] [AuthorRole.ASSISTANT] : Moussaillon… approche et tends l’oreille.\n",
-      "\n",
-      "**Mon indice :** c’est un mot **si long** qu’il semble fait pour un procès, et il veut dire : *“d’une manière contraire à la loi suprême d’un pays”*.\n",
-      "\n",
-      "**Charade :**  \n",
-      "- Mon **premier** est le contraire de **pour**.  \n",
-      "- Mon **deuxième** est la grande loi fondamentale d’un État.  \n",
-      "- Mon **troisième** est la terminaison qui signifie **“de façon…”**.\n",
-      "\n",
-      "À toi de jouer : veux-tu **le nombre de lettres** ou **les 6 dernières lettres** ?\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:20,742 [INFO] Selected agent at index 1 (ID: b9819ccd-c568-4152-8a6f-1c49ef4e0d31, name: Laurent_Jalabert)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:20,742 [INFO] Invoking agent Laurent_Jalabert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:22,109 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:22,112 [INFO] OpenAI usage: CompletionUsage(completion_tokens=62, prompt_tokens=2111, total_tokens=2173, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=1536))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:22,114 [INFO] Evaluating termination criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:22,114 [INFO] Evaluated criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31, should terminate: False\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:22,115 [INFO] [AuthorRole.ASSISTANT] : Je dois rester dans mon rôle (Laurent Jalabert) et **deviner le mot uniquement avec des questions fermées (Oui/Non)**, donc je ne peux pas te donner un indice.\n",
-      "\n",
-      "**Le mot se termine-t-il par “-ment” ? (Oui/Non)**\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:22,116 [INFO] Selected agent at index 0 (ID: e03f8505-8323-4a08-a97d-8a0a089df486, name: Pere_Fouras)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:22,117 [INFO] Invoking agent Pere_Fouras\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:24,891 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:24,893 [INFO] OpenAI usage: CompletionUsage(completion_tokens=165, prompt_tokens=2262, total_tokens=2427, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=1664))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:24,893 [INFO] Evaluating termination criteria for e03f8505-8323-4a08-a97d-8a0a089df486\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:24,894 [INFO] Agent e03f8505-8323-4a08-a97d-8a0a089df486 is out of scope\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:24,894 [INFO] [AuthorRole.ASSISTANT] : Moussaillon… voici ton indice, sans trahir le secret.\n",
-      "\n",
-      "**Énigme du Père Fouras :**  \n",
-      "Je suis un **adverbe gigantesque** qui signifie : *“d’une manière contraire à la loi suprême d’un pays”*.  \n",
-      "On m’emploie souvent quand une règle ou une décision ne respecte pas ce texte fondamental.\n",
-      "\n",
-      "**Charade :**  \n",
-      "- Mon **premier** est le contraire de **pour**.  \n",
-      "- Mon **deuxième** est le grand texte qui fonde les lois d’un État.  \n",
-      "- Mon **troisième** est une terminaison qui veut dire **“d’une manière…”**.\n",
-      "\n",
-      "Souhaites-tu maintenant **le nombre de lettres**… ou **les 6 dernières lettres** ?\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:24,895 [INFO] Selected agent at index 1 (ID: b9819ccd-c568-4152-8a6f-1c49ef4e0d31, name: Laurent_Jalabert)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:24,896 [INFO] Invoking agent Laurent_Jalabert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:26,203 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:26,206 [INFO] OpenAI usage: CompletionUsage(completion_tokens=59, prompt_tokens=2601, total_tokens=2660, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=1664))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:26,207 [INFO] Evaluating termination criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:26,207 [INFO] Evaluated criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31, should terminate: False\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:26,208 [INFO] [AuthorRole.ASSISTANT] : Je dois jouer **Laurent Jalabert** et **deviner le mot uniquement avec des questions Oui/Non**, donc je ne peux pas donner d’indice.\n",
-      "\n",
-      "**Est-ce que ce mot signifie “d’une manière contraire à la Constitution” ? (Oui/Non)**\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:26,209 [INFO] Selected agent at index 0 (ID: e03f8505-8323-4a08-a97d-8a0a089df486, name: Pere_Fouras)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:26,210 [INFO] Invoking agent Pere_Fouras\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:28,557 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:28,559 [INFO] OpenAI usage: CompletionUsage(completion_tokens=137, prompt_tokens=2746, total_tokens=2883, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=1664))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:28,560 [INFO] Evaluating termination criteria for e03f8505-8323-4a08-a97d-8a0a089df486\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:28,561 [INFO] Agent e03f8505-8323-4a08-a97d-8a0a089df486 is out of scope\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:28,562 [INFO] [AuthorRole.ASSISTANT] : Moussaillon… voici un indice, mais il faudra le mériter par ta réflexion.\n",
-      "\n",
-      "**Charade du Père Fouras :**  \n",
-      "- Mon **premier** est le contraire de *pour*.  \n",
-      "- Mon **deuxième** est le grand texte qui est au sommet des lois d’un pays.  \n",
-      "- Mon **troisième** est une terminaison qui signifie **« d’une manière… »**.\n",
-      "\n",
-      "Mon **tout** est un adverbe très long qui veut dire : **« d’une manière contraire à ce grand texte »**.\n",
-      "\n",
-      "Choisis : veux-tu **le nombre de lettres** ou **les 6 dernières lettres** ?\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:28,562 [INFO] Selected agent at index 1 (ID: b9819ccd-c568-4152-8a6f-1c49ef4e0d31, name: Laurent_Jalabert)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:28,563 [INFO] Invoking agent Laurent_Jalabert\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:30,515 [INFO] HTTP Request: POST https://api.openai.com/v1/chat/completions \"HTTP/1.1 200 OK\"\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:30,517 [INFO] OpenAI usage: CompletionUsage(completion_tokens=59, prompt_tokens=3029, total_tokens=3088, completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=0, audio_tokens=0, reasoning_tokens=0, rejected_prediction_tokens=0), prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=2432))\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:30,518 [INFO] Evaluating termination criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:30,518 [INFO] Evaluated criteria for b9819ccd-c568-4152-8a6f-1c49ef4e0d31, should terminate: True\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:30,519 [INFO] [AuthorRole.ASSISTANT] : Non. Je dois rester **Laurent Jalabert** et **deviner le mot uniquement avec des questions Oui/Non**, donc pas d’indice type Père Fouras.\n",
-      "\n",
-      "**Est-ce que le mot est “anticonstitutionnellement” ? (Oui/Non)**\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2026-05-10 01:27:30,519 [INFO] Partie terminee !\n"
+      "2026-08-21 23:26:22,600 [INFO] Partie terminee !\n"
      ]
     }
    ],
@@ -1188,38 +1099,171 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "**Lecture de la partie qui vient de se jouer.** La sortie raconte beaucoup plus qu'un duel :\n\n- **14 invocations** en alternance stricte — 7 tours de Père Fouras, 7 de Laurent Jalabert, en ~32 secondes (01:26:58 → 01:27:30). L'orchestrateur séquentiel fonctionne comme prévu : jamais deux interventions consécutives du même agent.\n- **Le Père Fouras joue son rôle à la lettre** : sa charade décompose réellement le mot — « mon premier est le contraire de *pour* » (contre-), « mon deuxième est le grand texte au sommet des lois » (constitution), « mon troisième est une terminaison \"d'une manière\" » (-ment). Le modèle n'a pas reçu la décomposition : il l'a reconstruite depuis le mot injecté.\n- **Laurent s'auto-corrige** : au dernier tour, il commence par « Non. Je dois rester Laurent Jalabert et deviner le mot uniquement avec des questions Oui/Non » — le modèle avait glissé vers un comportement du Père Fouras, et s'en est corrigé lui-même en relisant son propre prompt dans l'historique.\n- **La terminaison s'est déclenchée sur une question, pas sur une victoire** : le dernier message est « *Est-ce que le mot est \"anticonstitutionnellement\" ? (Oui/Non)* » — le log montre `should terminate: True` aussitôt après. Laurent a *prononcé* le mot, il ne l'a pas *confirmé* ; la réponse « Oui » n'aura jamais lieu. C'est la limite du test de sous-chaîne vue à la stratégie de terminaison — et exactement ce que l'exercice 3 vous propose de durcir.\n- **Le coût du contexte partagé est visible** : au premier tour, `prompt_tokens=72` ; au dernier, `prompt_tokens=3029` dont `cached_tokens=2432`. L'historique croît à chaque tour (tous les messages précédents sont renvoyés), et le caching de prompt d'OpenAI amortit la facture sur les tours suivants."
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9df42c85",
-   "source": "### Exercice : Analyser et modifier la stratégie de terminaison\n\nLa stratégie de terminaison actuelle detecte si le mot a deviner apparait dans le dernier message. Cependant, elle pourrait etre amelioree.\n\n**Objectif** : Completez la fonction `should_agent_terminate_enhanced` ci-dessous pour detecter également les variantes typographiques du mot (majuscules, accents, espaces supplementaires).\n\n**Indices** :\n- `# Étape 1` : Normalisez le dernier message (supprimez accents, mettez en minuscules, supprimez espaces)\n- `# Étape 2` : Comparez avec le mot cible normalise de la même facon\n- `# Indice ` : Utilisez `unicodedata.normalize('NFKD', text).encode('ASCII', 'ignore').decode()` pour supprimer les accents",
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "id": "b1f64c02",
-   "source": "import unicodedata\n\ndef normalize_text(text):\n    \"\"\"Normalise un texte pour comparaison robuste.\"\"\"\n    # TODO etudiant : implementez la normalisation\n    # Supprimez les accents, mettez en minuscules, supprimez les espaces\n    return None  # TODO etudiant : remplacez par l'implementation\n\ndef should_agent_terminate_enhanced(message_content, target_word):\n    \"\"\"Version amelioree de la detection du mot devine.\"\"\"\n    # TODO etudiant : utilisez normalize_text pour comparer\n    return False  # TODO etudiant : remplacez par la logique\n\n# Test de votre fonction\ntest_cases = [\n    (\"anticonstitutionnellement\", True),\n    (\"Anticonstitutionnellement\", True),\n    (\"ANTI CONSTITUTIONNEL LEMENT\", True),\n    (\"un autre mot\", False),\n]\nfor msg, expected in test_cases:\n    result = should_agent_terminate_enhanced(msg, MOT_A_DEVINER)\n    print(f\"Test '{msg[:30]}...' -> {result} (attendu: {expected})\")",
-   "metadata": {},
-   "execution_count": 1,
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stdout",
-     "text": [
-      "Exercice a completer\n"
-     ]
-    }
+   "id": "5fd957bd",
+   "metadata": {
+    "papermill": {
+     "duration": 0.008545,
+     "end_time": "2026-08-21T21:26:22.638285+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:26:22.629740+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la partie qui vient de se jouer.** La sortie raconte beaucoup plus qu'un duel :\n",
+    "\n",
+    "- **14 invocations** en alternance stricte — 7 tours de Père Fouras, 7 de Laurent Jalabert, en ~32 secondes (01:26:58 → 01:27:30). L'orchestrateur séquentiel fonctionne comme prévu : jamais deux interventions consécutives du même agent.\n",
+    "- **Le Père Fouras joue son rôle à la lettre** : sa charade décompose réellement le mot — « mon premier est le contraire de *pour* » (contre-), « mon deuxième est le grand texte au sommet des lois » (constitution), « mon troisième est une terminaison \"d'une manière\" » (-ment). Le modèle n'a pas reçu la décomposition : il l'a reconstruite depuis le mot injecté.\n",
+    "- **Laurent s'auto-corrige** : au dernier tour, il commence par « Non. Je dois rester Laurent Jalabert et deviner le mot uniquement avec des questions Oui/Non » — le modèle avait glissé vers un comportement du Père Fouras, et s'en est corrigé lui-même en relisant son propre prompt dans l'historique.\n",
+    "- **La terminaison s'est déclenchée sur une question, pas sur une victoire** : le dernier message est « *Est-ce que le mot est \"anticonstitutionnellement\" ? (Oui/Non)* » — le log montre `should terminate: True` aussitôt après. Laurent a *prononcé* le mot, il ne l'a pas *confirmé* ; la réponse « Oui » n'aura jamais lieu. C'est la limite du test de sous-chaîne vue à la stratégie de terminaison — et exactement ce que l'exercice 3 vous propose de durcir.\n",
+    "- **Le coût du contexte partagé est visible** : au premier tour, `prompt_tokens=72` ; au dernier, `prompt_tokens=3029` dont `cached_tokens=2432`. L'historique croît à chaque tour (tous les messages précédents sont renvoyés), et le caching de prompt d'OpenAI amortit la facture sur les tours suivants."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": "## Conclusion du jeu Fort Boyard\n\nCe notebook a illustré plusieurs concepts avancés de Semantic Kernel :\n\n### Concepts techniques démontrés\n\n1. **Agents conversationnels spécialisés** : chaque agent possède sa propre personnalité et son rôle — la spécialisation vient du prompt, pas du modèle ;\n2. **Stratégie de terminaison personnalisée** : détection automatique du succès (mot deviné), avec ses limites mesurées sur la vraie partie ;\n3. **AgentGroupChat** : orchestration d'un dialogue structuré entre deux agents — sélection (qui parle) et terminaison (quand arrêter) sont deux arbitrages distincts ;\n4. **Gestion du contexte** : maintien de l'historique partagé pour la cohérence — et son coût croissant en tokens, visible dans les logs (72 → 3029 prompt tokens sur 7 tours).\n\n### Applications pratiques\n\nCe pattern peut être adapté pour :\n- **Jeux éducatifs** : quiz interactifs, devinettes pédagogiques ;\n- **Interviews automatisées** : un agent questionne, l'autre répond ;\n- **Débat structuré** : deux agents défendent des positions opposées ;\n- **Scénarios de formation** : simulation de conversations professionnelles.\n\n### Points d'amélioration possibles\n\n- **Durcir la détection de victoire** (exercice 3) : normaliser accents et espaces, et exiger une *affirmation* plutôt qu'une *question* ;\n- **Compter les tours** pour afficher un score (« deviné en 7 questions ») ;\n- **Répondre à la question finale** : la partie s'arrête avant le « Oui » du Père Fouras — une stratégie à deux états (question posée → réponse attendue) ferait un vrai échange final."
+   "id": "9df42c85",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005307,
+     "end_time": "2026-08-21T21:26:22.649458+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:26:22.644151+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice : Analyser et modifier la stratégie de terminaison\n",
+    "\n",
+    "La stratégie de terminaison actuelle detecte si le mot a deviner apparait dans le dernier message. Cependant, elle pourrait etre amelioree.\n",
+    "\n",
+    "**Objectif** : Completez la fonction `should_agent_terminate_enhanced` ci-dessous pour detecter également les variantes typographiques du mot (majuscules, accents, espaces supplementaires).\n",
+    "\n",
+    "**Indices** :\n",
+    "- `# Étape 1` : Normalisez le dernier message (supprimez accents, mettez en minuscules, supprimez espaces)\n",
+    "- `# Étape 2` : Comparez avec le mot cible normalise de la même facon\n",
+    "- `# Indice ` : Utilisez `unicodedata.normalize('NFKD', text).encode('ASCII', 'ignore').decode()` pour supprimer les accents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "b1f64c02",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T21:26:22.662505Z",
+     "iopub.status.busy": "2026-08-21T21:26:22.662194Z",
+     "iopub.status.idle": "2026-08-21T21:26:22.668767Z",
+     "shell.execute_reply": "2026-08-21T21:26:22.667966Z"
+    },
+    "papermill": {
+     "duration": 0.013897,
+     "end_time": "2026-08-21T21:26:22.669489+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:26:22.655592+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test 'anticonstitutionnellement...' -> False (attendu: True)\n",
+      "Test 'Anticonstitutionnellement...' -> False (attendu: True)\n",
+      "Test 'ANTI CONSTITUTIONNEL LEMENT...' -> False (attendu: True)\n",
+      "Test 'un autre mot...' -> False (attendu: False)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import unicodedata\n",
+    "\n",
+    "def normalize_text(text):\n",
+    "    \"\"\"Normalise un texte pour comparaison robuste.\"\"\"\n",
+    "    # TODO etudiant : implementez la normalisation\n",
+    "    # Supprimez les accents, mettez en minuscules, supprimez les espaces\n",
+    "    return None  # TODO etudiant : remplacez par l'implementation\n",
+    "\n",
+    "def should_agent_terminate_enhanced(message_content, target_word):\n",
+    "    \"\"\"Version amelioree de la detection du mot devine.\"\"\"\n",
+    "    # TODO etudiant : utilisez normalize_text pour comparer\n",
+    "    return False  # TODO etudiant : remplacez par la logique\n",
+    "\n",
+    "# Test de votre fonction\n",
+    "test_cases = [\n",
+    "    (\"anticonstitutionnellement\", True),\n",
+    "    (\"Anticonstitutionnellement\", True),\n",
+    "    (\"ANTI CONSTITUTIONNEL LEMENT\", True),\n",
+    "    (\"un autre mot\", False),\n",
+    "]\n",
+    "for msg, expected in test_cases:\n",
+    "    result = should_agent_terminate_enhanced(msg, MOT_A_DEVINER)\n",
+    "    print(f\"Test '{msg[:30]}...' -> {result} (attendu: {expected})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28715d93",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005206,
+     "end_time": "2026-08-21T21:26:22.680232+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T21:26:22.675026+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion du jeu Fort Boyard\n",
+    "\n",
+    "Ce notebook a illustré plusieurs concepts avancés de Semantic Kernel :\n",
+    "\n",
+    "### Concepts techniques démontrés\n",
+    "\n",
+    "1. **Agents conversationnels spécialisés** : chaque agent possède sa propre personnalité et son rôle — la spécialisation vient du prompt, pas du modèle ;\n",
+    "2. **Stratégie de terminaison personnalisée** : détection automatique du succès (mot deviné), avec ses limites mesurées sur la vraie partie ;\n",
+    "3. **AgentGroupChat** : orchestration d'un dialogue structuré entre deux agents — sélection (qui parle) et terminaison (quand arrêter) sont deux arbitrages distincts ;\n",
+    "4. **Gestion du contexte** : maintien de l'historique partagé pour la cohérence — et son coût croissant en tokens, visible dans les logs (72 → 3029 prompt tokens sur 7 tours).\n",
+    "\n",
+    "### Applications pratiques\n",
+    "\n",
+    "Ce pattern peut être adapté pour :\n",
+    "- **Jeux éducatifs** : quiz interactifs, devinettes pédagogiques ;\n",
+    "- **Interviews automatisées** : un agent questionne, l'autre répond ;\n",
+    "- **Débat structuré** : deux agents défendent des positions opposées ;\n",
+    "- **Scénarios de formation** : simulation de conversations professionnelles.\n",
+    "\n",
+    "### Points d'amélioration possibles\n",
+    "\n",
+    "- **Durcir la détection de victoire** (exercice 3) : normaliser accents et espaces, et exiger une *affirmation* plutôt qu'une *question* ;\n",
+    "- **Compter les tours** pour afficher un score (« deviné en 7 questions ») ;\n",
+    "- **Répondre à la question finale** : la partie s'arrête avant le « Oui » du Père Fouras — une stratégie à deux états (question posée → réponse attendue) ferait un vrai échange final."
+   ]
   }
  ],
  "metadata": {
+  "cost": {
+   "api_provider": "openai",
+   "api_usd_est": 0.3,
+   "cpu_min": 3,
+   "external_account": "openai",
+   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
+   "gpu_min": 0,
+   "gpu_required": false,
+   "metadata_written": "2026-07-28",
+   "network": true,
+   "notes": "Jeu Fort-Boyard : 42 enigmes generees par OpenAIChatCompletion. Cout eleve (NB pedagogique = beaucoup de generations). Variante csharp (fort-boyard-csharp) sans LLM. Provenance: myia-po-2023:CoursIA-2 (c.946).",
+   "qcc_tokens_est": 0,
+   "reduced_pedagogical": null,
+   "reproducibility": "LOW",
+   "validator": "manual",
+   "vram_gb": 0,
+   "vram_tier": "LITE"
+  },
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -1235,37 +1279,19 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.14"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 48.29891,
-   "end_time": "2026-05-09T23:27:31.217484",
+   "duration": 117.815223,
+   "end_time": "2026-08-21T21:26:23.707885+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "MyIA.AI.Notebooks/GenAI/SemanticKernel/fort-boyard-python.ipynb",
-   "output_path": "SK-fort-boyard_v2.ipynb",
+   "input_path": "fort-boyard-python.ipynb",
+   "output_path": "fort-boyard-python.ipynb",
    "parameters": {},
-   "start_time": "2026-05-09T23:26:42.918574",
+   "start_time": "2026-08-21T21:24:25.892662+00:00",
    "version": "2.6.0"
-  },
-  "cost": {
-   "api_usd_est": 0.3,
-   "api_provider": "openai",
-   "qcc_tokens_est": 0,
-   "cpu_min": 3,
-   "gpu_min": 0,
-   "gpu_required": false,
-   "vram_gb": 0,
-   "vram_tier": "LITE",
-   "network": true,
-   "external_account": "openai",
-   "free_alternative": "MyIA.AI.Notebooks/GenAI/Texte/10_LocalLlama.ipynb",
-   "reduced_pedagogical": null,
-   "reproducibility": "LOW",
-   "metadata_written": "2026-07-28",
-   "validator": "manual",
-   "notes": "Jeu Fort-Boyard : 42 enigmes generees par OpenAIChatCompletion. Cout eleve (NB pedagogique = beaucoup de generations). Variante csharp (fort-boyard-csharp) sans LLM. Provenance: myia-po-2023:CoursIA-2 (c.946)."
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Grain: MED/notebook-python — lane myia-po-2025:CoursIA — prev: MED/qc #12188

## Summary

Tranche SemanticKernel de l'étage 3 de #11112 (rollout exec-seq famille-partitionné) : `fort-boyard-python.ipynb` passe **DUPLICATE → CLEAN** (dirty exec-seq dépôt : 13 → 12).

Re-exécution complète papermill sur kernel frais, cwd = dossier SemanticKernel (`env_path` résout `GenAI/.env`, model `gpt-5-mini`) : les 10 cellules code portent désormais `1..10` consécutifs, 0 erreur, conversation d'agents réelle rafraîchie dans les outputs.

## Validation (relancée post-dernier-commit)

- `check_exec_sequence.py` : verdict **CLEAN**, séquence `[1..10]` (mesure directe : 10 code cells, ec 1..10, 0 null)
- **0 erreur** d'exécution ; C.1 : 0 match `raise NotImplementedError|assert False|1/0`
- Sources **inchangees 10/10** après normalisation (les 3 diffs bruts = artefact sérialisation list↔string, aucun contenu modifié) → la PR ne change que outputs + execution_count (le livrable même de #11112)
- `nbformat.validate` OK ; papermill paths relatifs (scrub : 0 absolu)
- Pas de paire twin (`grep -rl fort-boyard twin_pairs.d/` → vide)
- Exercices stubbés intacts (éc 3/6/9 reçus en séquence)

## Descopé de la tranche (diagnostiqué, pas contourné)

Les deux autres notebooks DUPLICATE de mon claim ne sont **pas** des cas de re-exec :
- `Semantic-kernel-AutoInteractive.ipynb` : structurellement inexécutable (helpers .cs avec `namespace` → CS7021 sur tout mécanisme de chargement ; imports de dépendances commentés ; dernière cellule sans outputs sur HEAD). Diagnostic prouvé par 4 probes isolés → **issue #12194** ouverte avec pistes de réparation.
- `10-SemanticKernel-NotebookMaker.ipynb` : interactif (ipywidgets + `jupyter_ui_poll` + download template GitHub) — les variantes `-batch` existent précisément pour ça ; à traiter via variante batch ou session interactive dédiée.

Claim paths partiellement libéré sur #11112 (commentaire [RELEASED]).

See #11112 (tranche partielle : 1/3 notebooks de mon claim ; l'epic reste ouverte, 12 DIRTY restants)
