### PR TITLE
fix(guard,#12158): signal GENRE-UNKNOWN -- un mot hors enumeration close est un trou d'adjacence, pas un genre de plus

### DIFF
--- a/.github/workflows/variation-light-genre.yml
+++ b/.github/workflows/variation-light-genre.yml
@@ -166,6 +166,8 @@ jobs:
           SIG_RUN=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-RUN'))" 2>/dev/null || echo "False")
           SIG_CAPEXC=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('CAP-EXCEEDED-BY-GENRE'))" 2>/dev/null || echo "False")
           SIG_MISMATCH=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-MISMATCH'))" 2>/dev/null || echo "False")
+          SIG_UNKNOWN=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('signals',{}).get('GENRE-UNKNOWN'))" 2>/dev/null || echo "False")
+          UNKNOWN_WORD=$(python3 -c "import json; print(json.load(open('/tmp/signals.json')).get('candidate_genre_unknown_word') or '')" 2>/dev/null || echo "")
           TALLY=$(python3 -c "import json; t=json.load(open('/tmp/signals.json')).get('tally',{}); print(f\"declared={t.get('light_declared',0)} genre={t.get('light_genre',0)} cap={t.get('cap',1)}\")" 2>/dev/null || echo "inconnu")
           # #10341 -- the three aggregate signals (TIER-INFLATION, GENRE-RUN,
           # CAP-EXCEEDED-BY-GENRE) measure the LANE-DAY, not the candidate.
@@ -188,7 +190,8 @@ jobs:
             "variation-tier-inflation:FEF2C0:TIER-INFLATION:declared LIGHT << effective LIGHT-genre (#10020, advisory)" \
             "variation-genre-run:FEF2C0:GENRE-RUN:>= 2 grains consecutifs du meme genre LIGHT pour la lane (#10020, advisory)" \
             "variation-genre-cap-exceeded:FBCA04:CAP-EXCEEDED-BY-GENRE:light_genre > cap partage G-VAR-2 (#10020, advisory)" \
-            "variation-genre-mismatch:FEF2C0:GENRE-MISMATCH:declared genre != genre infere depuis les chemins du diff (#10020, advisory)"
+            "variation-genre-mismatch:FEF2C0:GENRE-MISMATCH:declared genre != genre infere depuis les chemins du diff (#10020, advisory)" \
+            "variation-genre-unknown:FBCA04:GENRE-UNKNOWN:genre canonise hors enumeration close -- trou d'adjacence G-VAR-3, requalifier dans le body (#12158, advisory)"
           do
             LABEL=$(echo "$LABEL_PAIR" | cut -d: -f1)
             COLOR=$(echo "$LABEL_PAIR" | cut -d: -f2)
@@ -206,6 +209,7 @@ jobs:
               GENRE-RUN)             SIGVAR="SIG_RUN"; MAY_LABEL_INNOCENT="no" ;;
               CAP-EXCEEDED-BY-GENRE) SIGVAR="SIG_CAPEXC"; MAY_LABEL_INNOCENT="no" ;;
               GENRE-MISMATCH)        SIGVAR="SIG_MISMATCH"; MAY_LABEL_INNOCENT="yes" ;;
+              GENRE-UNKNOWN)         SIGVAR="SIG_UNKNOWN"; MAY_LABEL_INNOCENT="yes" ;;
               *)
                 echo "Signal non reconnnu : ${SIGNAL} (PR ${PR_NUMBER})"
                 SIGVAR="__UNDEFINED__"
@@ -253,6 +257,8 @@ jobs:
           - **CAP-EXCEEDED-BY-GENRE** : light_genre > cap partage G-VAR-2 (tally : ${TALLY})"
           [ "$SIG_MISMATCH" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
           - **GENRE-MISMATCH** : declared genre != genre infere depuis les chemins du diff"
+          [ "$SIG_UNKNOWN" = "True" ] && ACTIVE_LINES="${ACTIVE_LINES}
+          - **GENRE-UNKNOWN** : le genre canonise \\\`${UNKNOWN_WORD:-?}\\\` est hors enumeration close -- trou d'adjacence G-VAR-3, requalifier le genre dans le body (#12158)"
 
           # #10341 nuance : si la PR courante est CONTENU (non LIGHT-genre)
           # et qu'un signal agrege est actif, le dire explicitement -- le
@@ -271,7 +277,7 @@ jobs:
           **G-VAR-2/3 GENRE signals** (advisory, non bloquant, #10020).
           La lane \\\`${LANE}\\\` voit ces signaux actifs sur les mergees du jour (UTC ${TODAY}) :${ACTIVE_LINES}
 
-          G-VAR-2 plafonne a **max(1, grains_mergees_du_jour // 3) LIGHT par lane et par jour, toutes categories LIGHT confondues** -- un RATIO, pas un plafond plat ; le cap calcule du jour est dans le tally ci-dessus. G-VAR-3 interdit deux genres LIGHT consecutifs. Les signaux ci-dessus rendent le fait VISIBLE (labels \`variation-tier-inflation\`, \\\`variation-genre-run\\\`, \\\`variation-genre-cap-exceeded\\\`, \\\`variation-genre-mismatch\\\`) -- la decision de merge reste au coordinateur."
+          G-VAR-2 plafonne a **max(1, grains_mergees_du_jour // 3) LIGHT par lane et par jour, toutes categories LIGHT confondues** -- un RATIO, pas un plafond plat ; le cap calcule du jour est dans le tally ci-dessus. G-VAR-3 interdit deux genres LIGHT consecutifs. Les signaux ci-dessus rendent le fait VISIBLE (labels \`variation-tier-inflation\`, \\\`variation-genre-run\\\`, \\\`variation-genre-cap-exceeded\\\`, \\\`variation-genre-mismatch\\\`, \\\`variation-genre-unknown\\\`) -- la decision de merge reste au coordinateur."
             EXISTING_ID=$(gh pr view "$PR_NUMBER" --json comments --jq '.comments[] | select(.body | startswith("'"$MARK"'")) | .id' 2>/dev/null | head -1 || echo "")
             if [ -n "$EXISTING_ID" ]; then
               gh api -X PATCH "repos/${GH_REPO}/issues/comments/${EXISTING_ID}" \

--- a/scripts/tests/test_variation_light_cap.py
+++ b/scripts/tests/test_variation_light_cap.py
@@ -1637,3 +1637,63 @@ def test_genre_signals_picker_command_absent_when_clean():
     out = json.loads(proc.stdout)
     assert out["picker_command"] is None
     assert out["signals"]["VEIN-RUN"] is False
+
+
+# --- #12158 : GENRE-UNKNOWN --------------------------------------------------
+#
+# L'enumeration des genres est close pour proteger G-VAR-3 : un mot hors
+# table ne peut JAMAIS egaler le genre precedent, donc l'adjacence est
+# inatteignable par simple choix de mot. Le defaut : canonicalize_genre()
+# rendait le mot tel quel, en silence. Le remede n'est PAS d'elargir la
+# table au coup par coup (whack-a-mole) mais de SIGNALER (GENRE-UNKNOWN),
+# avec seulement les synonymes mesures a cible evidente ajoutes.
+
+def test_genre_unknown_positive_control_invented_genre():
+    # Controle positif OBLIGATOIRE (#12158 remede 3) : un genre invente DOIT
+    # lever GENRE-UNKNOWN. Sans lui, un signal qui ne se declenche jamais est
+    # indiscernable d'un signal debranche.
+    sig = vlc.compute_signals([], "myia-po-2023:CoursIA",
+                              candidate_genre="zzz-nonexistent")
+    assert sig["signals"]["GENRE-UNKNOWN"] is True
+    # Le mot signale est le CANONISE (la regle composet reduit `zzz-nonexistent`
+    # a sa queue `nonexistent`, qui reste hors table) -- c'est la preuve du
+    # hors-table, pas le body d'origine.
+    assert sig["candidate_genre_unknown_word"] == "nonexistent"
+    # Un simple mot sans tiret reste lui-meme.
+    sig2 = vlc.compute_signals([], "myia-po-2023:CoursIA",
+                               candidate_genre="zzznoexist")
+    assert sig2["signals"]["GENRE-UNKNOWN"] is True
+    assert sig2["candidate_genre_unknown_word"] == "zzznoexist"
+
+
+def test_genre_unknown_silent_on_canonical_and_aliased():
+    # Un genre canonique OU un alias qui reduit vers un canonique ne leve
+    # PAS le signal -- sinon le signal serait un bruit de fond permanent.
+    for genre in ("tooling", "genai", "translation", "scripts", "infra",
+                  "csp", "infra-tooling"):
+        sig = vlc.compute_signals([], "myia-po-2023:CoursIA",
+                                  candidate_genre=genre)
+        assert sig["signals"]["GENRE-UNKNOWN"] is False, genre
+        assert sig["candidate_genre_unknown_word"] is None, genre
+
+
+def test_genre_unknown_on_measured_fallthrough_words():
+    # Les cas mesures du body de l'issue : chacun doit soit reduire vers un
+    # canonique (scripts/infra -> tooling, csp -> research-code), soit lever
+    # le signal (genai-reexec : compose dont la queue `reexec` n'est ni
+    # canonique ni aliassee -- laisser au signal, decision explicite #12158).
+    assert vlc.canonicalize_genre("scripts") == "tooling"
+    assert vlc.canonicalize_genre("infra") == "tooling"
+    assert vlc.canonicalize_genre("csp") == "research-code"
+    sig = vlc.compute_signals([], "myia-po-2023:CoursIA",
+                              candidate_genre="genai-reexec")
+    assert sig["signals"]["GENRE-UNKNOWN"] is True
+    assert sig["candidate_genre_unknown_word"] == "reexec"
+
+
+def test_genre_unknown_absent_when_no_genre_claimed():
+    # Pas de genre declare -> pas de signal (symetrie avec GENRE-MISMATCH).
+    sig = vlc.compute_signals([], "myia-po-2023:CoursIA",
+                              candidate_genre=None)
+    assert sig["signals"]["GENRE-UNKNOWN"] is False
+    assert sig["candidate_genre_unknown_word"] is None

--- a/scripts/variation_light_cap.py
+++ b/scripts/variation_light_cap.py
@@ -471,6 +471,12 @@ _GENRE_ALIASES = {
     "test-coverage": "test",
     "data": "ledger",
     "slidev": "slides",              # outil -> type de travail (cf #11059)
+    # #12158 -- measured good-faith synonyms that were falling through
+    # silently (each one was an adjacency hole: an unknown word can never
+    # equal the previous genre, so G-VAR-3 was unreachable by word choice).
+    "scripts": "tooling",
+    "infra": "tooling",
+    "csp": "research-code",
 }
 
 # Compoments `<famille>-<genre>` always reduce to the head genre (the family
@@ -807,6 +813,10 @@ def compute_signals(
       * `GENRE-MISMATCH`         -- `candidate_genre is not None` AND
                                     `_genre_from_paths(candidate_files)` is
                                     not None AND the two disagree.
+      * `GENRE-UNKNOWN`          -- `canonicalize_genre(candidate_genre)`
+                                    returned a word outside the closed GENRES
+                                    enumeration (#12158): an adjacency hole,
+                                    surfaced for coordinator requalification.
       * `VEIN-RUN`               -- ANY vein in `vein_runs()` of `count >= 2`.
                                     The 5th axis (#11343): a (lane, issue#)
                                     pair cited by 2+ PRs of the lane on the
@@ -870,6 +880,14 @@ def compute_signals(
     # the GENRE-RUN threshold, the same adjacency convention.
     vein_list = vein_runs(merged_prs, target_lane)
 
+    # GENRE-UNKNOWN (#12158): the canonical folding produced a word that is
+    # NOT in the closed enumeration. By construction such a word can never
+    # equal the previous genre, so it silently defeats G-VAR-3 adjacency --
+    # the signal surfaces it so the coordinator can requalify in the body
+    # (what the protocol already asks; it lacked the visibility). The word
+    # itself rides along in `candidate_genre_unknown_word`.
+    genre_unknown = can_canon is not None and can_canon not in GENRES
+
     return {
         "lane": target_lane,
         "tally": tally,
@@ -880,11 +898,13 @@ def compute_signals(
             "CAP-EXCEEDED-BY-GENRE": cap_exceeded,
             "GENRE-MISMATCH": genre_mismatch,
             "VEIN-RUN": bool(vein_list),
+            "GENRE-UNKNOWN": genre_unknown,
         },
         "long_runs": long_runs,
         "vein_runs": vein_list,
         "inferred_genre_from_paths": inferred,
         "candidate_genre_canonical": can_canon,
+        "candidate_genre_unknown_word": can_canon if genre_unknown else None,
         # Whether the OPEN candidate is itself a LIGHT-genre grain, i.e. a
         # CONTRIBUTOR to the pattern the three aggregate signals denounce.
         # False when the candidate is CONTENT (genai/lean/qc/notebook-.../)


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/slides #12196

Closes #12158

## Remède appliqué (les 3 points du body)

1. **Signal `GENRE-UNKNOWN`** dans la sortie `--genre-signals` (`compute_signals()`), vrai quand `canonicalize_genre()` rend un mot absent de l'énumération close `GENRES`. Le mot hors table sort dans `candidate_genre_unknown_word` — c'est le canonisé (la preuve du hors-table), pas le body d'origine : `zzz-nonexistent` → la règle composé rend `nonexistent`, qui est hors table. Le workflow `variation-light-genre.yml` lit le signal, pose le label `variation-genre-unknown` (couleur FBCA04) et ajoute la ligne diagnostique avec le mot dans le commentaire idempotent. Le label est **candidate-scoped** comme GENRE-MISMATCH (exempt du gate #10341 : son sujet est la candidate par construction).
2. **Alias des synonymes mesurés à cible évidente** : `scripts` → `tooling`, `infra` → `tooling`, `csp` → `research-code`. `genai-reexec` délibérément laissé au signal (queue `reexec` ni canonique ni aliasée — décision explicite du body de l'issue).
3. **Contrôle positif obligatoire** : `test_genre_unknown_positive_control_invented_genre` — `zzz-nonexistent` DOIT lever le signal (+ variante sans tiret `zzznoexist` qui reste elle-même). Trois autres tests : silence sur canoniques/aliasés, les mots mesurés (`scripts/infra/csp` réduisent, `genai-reexec` signale `reexec`), pas de signal sans genre déclaré.

## Validation

- `python -m pytest scripts/tests/test_variation_light_cap.py -q` : **99 passed** (95 existants + 4 nouveaux).
- YAML workflow : `yaml.safe_load` OK.
- CLI en mode replay : body `LIGHT/scripts` → `candidate_genre_canonical: tooling`, `GENRE-UNKNOWN: False` ; body `LIGHT/genai-reexec` → `GENRE-UNKNOWN: True`, mot `reexec`.
- Trois modules touchés : l'organe, son test, le workflow consommateur (même livrable atomique — sans le workflow le signal sortait dans le JSON mais aucun label, et le merge-gate lit les labels).

## Non-collision

Aucune autre PR ouverte ne touche `scripts/variation_light_cap.py` ou le workflow `variation-light-genre.yml`.
