### PR TITLE
fix(lean,#12168): _resolve_repl_source_tag accepte les tags rc — filtre etendu + cle de tri totale

### DIFF
--- a/scripts/lean/setup_native_lean4_import.py
+++ b/scripts/lean/setup_native_lean4_import.py
@@ -252,6 +252,26 @@ def cmd_patch():
     return 0 if ("PATCHED" in out or "already" in out) else 1
 
 
+def _repl_tag_sort_key(t):
+    """Total order over repl tags: (maj, min, patch, is_release, rcN).
+
+    #12168: the key must be total over ``-rcN`` suffixes too -- the script's
+    own docstring advertises ``build-repl v4.30.0-rc2`` and REPL_TOOLCHAIN_TAGS
+    carries rc keys. rcN < release for the same triple (v4.30.0-rc2 precedes
+    v4.30.0): an rc is the candidate OF that release, so resolving "nearest
+    tag <= v4.30.0-rc2" must be able to land on the rc itself, never skip it.
+    Anything malformed sorts below everything rather than raising -- the old
+    ``int()`` KeyError/ValueError path silently degraded the resolver to None
+    (the misleading NO-SOURCE-TAG of #12168).
+    """
+    m = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)(?:-rc(\d+))?", t)
+    if not m:
+        return (-1, -1, -1, 0, 0)
+    maj, minor, patch, rc = m.groups()
+    return (int(maj), int(minor), int(patch), 0 if rc is not None else 1,
+            int(rc) if rc is not None else 0)
+
+
 def _resolve_repl_source_tag(tag):
     """Nearest repl-repo tag <= the requested toolchain tag, or None.
 
@@ -261,15 +281,15 @@ def _resolve_repl_source_tag(tag):
     """
     r = _wsl("git ls-remote --tags https://github.com/leanprover-community/repl.git",
              timeout=60)
-    tags = {m.group(1) for m in re.finditer(r"refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+)$",
-                                            r.stdout or "", re.M)}
+    # #12168: the filter used to drop rc tags outright -- while the docstring
+    # and REPL_TOOLCHAIN_TAGS both advertise them.
+    tags = {m.group(1) for m in re.finditer(
+        r"refs/tags/(v[0-9]+\.[0-9]+\.[0-9]+(?:-rc[0-9]+)?)$",
+        r.stdout or "", re.M)}
 
-    def key(t):
-        return tuple(int(p) for p in t[1:].split("."))
-
-    try:
-        want = key(tag)
-    except ValueError:
+    key = _repl_tag_sort_key
+    want = key(tag)
+    if want[0] < 0:
         return None
     lower = sorted((t for t in tags if key(t) <= want), key=key)
     return lower[-1] if lower else None

--- a/scripts/tests/test_setup_native_lean4_import.py
+++ b/scripts/tests/test_setup_native_lean4_import.py
@@ -1,0 +1,89 @@
+"""Tests for scripts/lean/setup_native_lean4_import.py (#12168).
+
+Positive controls required by the issue: a pattern set validates by its
+FALSE NEGATIVES, not its hits. The founding defect: the tag filter dropped
+``-rcN`` suffixes outright while the script's own docstring advertised
+``build-repl v4.30.0-rc2`` -- the resolver then reported the misleading
+NO-SOURCE-TAG (the tag exists upstream; the local filter had dropped it).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lean"))
+
+import setup_native_lean4_import as setup  # noqa: E402
+from setup_native_lean4_import import _repl_tag_sort_key as key  # noqa: E402
+
+
+def test_rc_precedes_release():
+    """#12168 controle positif 1 : key('v4.30.0-rc2') < key('v4.30.0')."""
+    assert key("v4.30.0-rc2") < key("v4.30.0")
+
+
+def test_rc_numeric_order():
+    """rc10 > rc9 numeriquement -- lexicographique donnerait 'rc10' < 'rc9'."""
+    assert key("v4.30.0-rc9") < key("v4.30.0-rc10")
+    assert key("v4.30.0-rc1") < key("v4.30.0-rc2")
+
+
+def test_release_below_next_rc():
+    """Une release reste sous le rc de la release suivante."""
+    assert key("v4.30.0") < key("v4.31.0-rc1")
+    assert key("v4.29.0") < key("v4.30.0-rc2")
+
+
+def test_malformed_sorts_below_everything_without_raising():
+    """L'ancien int() levait ValueError -> resilience None trompeuse. Un tag
+    malforme doit trier sous tout sans lever (fail-safe, jamais NO-SOURCE-TAG
+    mensonger sur un ensemble pourtant valide)."""
+    assert key("garbage")[0] == -1
+    assert key("garbage") < key("v0.0.0")
+
+
+class _FakeResult:
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def test_resolve_rc_tag_from_ls_remote(monkeypatch):
+    """#12168 controle positif 2 : build-repl v4.30.0-rc2 resout une source.
+
+    Replay du ls-remote sans reseau : le tag rc est present upstream et doit
+    etre resolu. Pre-fix, le filtre jetait 'v4.30.0-rc2' et la fonction rendait
+    None (NO-SOURCE-TAG mensonger).
+    """
+    ls_remote = "\n".join(
+        f"6c3a41e9d2f1b0a7c8d9e0f1a2b3c4d5e6f7a8b9\trefs/tags/{t}"
+        for t in ("v4.29.0", "v4.30.0-rc1", "v4.30.0-rc2", "v4.30.0", "v4.31.0")
+    )
+    monkeypatch.setattr(setup, "_wsl", lambda *a, **kw: _FakeResult(ls_remote))
+    assert setup._resolve_repl_source_tag("v4.30.0-rc2") == "v4.30.0-rc2"
+
+
+def test_resolve_nearest_below(monkeypatch):
+    """Le cas historique du docstring tient toujours : nearest <= v4.32.1."""
+    ls_remote = "\n".join(
+        f"6c3a41e9d2f1b0a7c8d9e0f1a2b3c4d5e6f7a8b9\trefs/tags/{t}"
+        for t in ("v4.31.0", "v4.32.0", "v4.33.0")
+    )
+    monkeypatch.setattr(setup, "_wsl", lambda *a, **kw: _FakeResult(ls_remote))
+    assert setup._resolve_repl_source_tag("v4.32.1") == "v4.32.0"
+
+
+def test_resolve_release_can_fall_on_its_own_rc(monkeypatch):
+    """v4.32.1 n'a pas de tag repl : nearest <= v4.32.1. Si upstream n'avait
+    que v4.32.1-rc1 et v4.31.0, le rc doit etre retenu (il est <= )."""
+    ls_remote = "\n".join(
+        f"6c3a41e9d2f1b0a7c8d9e0f1a2b3c4d5e6f7a8b9\trefs/tags/{t}"
+        for t in ("v4.31.0", "v4.32.1-rc1")
+    )
+    monkeypatch.setattr(setup, "_wsl", lambda *a, **kw: _FakeResult(ls_remote))
+    assert setup._resolve_repl_source_tag("v4.32.1") == "v4.32.1-rc1"
+
+
+def test_resolve_rejects_malformed_request(monkeypatch):
+    """Une demande mal formee rend None proprement (fail-safe d'origine)."""
+    monkeypatch.setattr(setup, "_wsl",
+                        lambda *a, **kw: _FakeResult("x\trefs/tags/v4.30.0\n"))
+    assert setup._resolve_repl_source_tag("not-a-tag") is None


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/slides #12202

Closes #12168

## Remède (les 3 points du body)

1. **Regex étendue** : `v[0-9]+\.[0-9]+\.[0-9]+(?:-rc[0-9]+)?$` — les tags rc entrent dans l'ensemble candidat (pré-fix : jamais candidats, d'où le NO-SOURCE-TAG mensonger alors que le tag existe upstream).
2. **`key()` total** : nouvelle fonction `_repl_tag_sort_key` → `(maj, min, patch, is_release, rcN)` avec **rcN < release** (`v4.30.0-rc2` précède `v4.30.0` — un rc est le candidat DE sa release). Les tags malformés trient sous tout **sans lever** : l'ancien chemin `int('0-rc2')` → ValueError → None dégradait silencieusement le résolveur.
3. **Contrôles positifs** : `test_rc_precedes_release` (`key('v4.30.0-rc2') < key('v4.30.0')`), plus rc numérique (`rc10 > rc9`, l'ordre lexicographique donnerait l'inverse), release < rc suivant, malformé sans exception, et la résolution de la demande rc elle-même depuis un ls-remote rejoué (monkeypatch `_wsl`, pas de réseau dans le test).

## Validation

- `python -m pytest scripts/tests/test_setup_native_lean4_import.py -q` : **8 passed** (nouveau fichier — le script n'avait aucune couverture).
- Suites voisines (`test_setup_hooks_selftest.py`, `test_verifier_cleanup.py`) : 15 passed, aucune interaction.
- **Live** (depuis le checkout principal, ls-remote réel de leanprover-community/repl) :
  - `resolve v4.30.0-rc2` → **`v4.30.0-rc2`** (pré-fix : `None` = le message trompeur fondateur) ;
  - `resolve v4.32.1` → `v4.32.0` (le cas historique du docstring tient toujours).
- NB diagnostiqué au passage : depuis un **worktree lié**, git-in-WSL échoue sur le pointeur `gitdir: D:/...` Windows lu comme chemin relatif (`fatal: not a git repository`) — interaction préexistante worktree×WSL, indépendante de ce fix, signalée ici pour trace.

## Non-collision

Aucune autre PR ouverte ne touche `scripts/lean/setup_native_lean4_import.py` (vérifié `gh pr list`). Un seul module + son test.
