### PR TITLE
feat(tooling,#12174): picker annotates recent merged deliveries per drawn candidate

### DIFF
--- a/scripts/pick_idle_grain.py
+++ b/scripts/pick_idle_grain.py
@@ -134,6 +134,7 @@ def fetch_pool() -> list[dict]:
             "labels": labels,
             "age": age_days(it["createdAt"]),
             "idle": age_days(it["updatedAt"]),
+            "updated_at": it["updatedAt"],
             "genre": infer_genre(title, labels),
             "klass": (
                 "delivered" if "candidate-delivered" in labels
@@ -242,6 +243,54 @@ def check_claims(numbers: list[int], lane: str) -> dict[int, str]:
     return verdicts
 
 
+def recent_delivery(picks: list[dict]) -> dict[int, str]:
+    """Annote les candidats tires dont une PR mergee les reference plus
+    recemment que la derniere mise a jour de l'issue.
+
+    #12174 : le label ``candidate-delivered`` est pose par un workflow
+    ``schedule:`` quotidien, dans une flotte qui merge plusieurs PRs par heure
+    -- au tirage de 16:47Z, #12014 etait classee ``grain`` alors que #12077
+    (mergee 16:19Z) avait deja livre 3 de ses 4 items. Le body d'une issue est
+    date de sa redaction et un claim ne dit rien d'une livraison : la
+    recherche de PRs mergees est la troisieme surface de grounding, et ce
+    geste doit vivre dans l'outil qui propose le grain, pas dans la discipline
+    de qui le lit. Une requete par candidat tire, jamais un balayage du pool.
+
+    L'annotation **n'ecarte pas** le candidat (parite avec la doctrine
+    ``candidate-delivered`` : signale, ne ferme pas) : elle change ce qu'on
+    en dit, pas s'il est pris.
+    """
+    notes: dict[int, str] = {}
+    for p in picks:
+        n = p["number"]
+        try:
+            out = subprocess.run(
+                ["gh", "pr", "list", "--repo", REPO, "--state", "merged",
+                 "--limit", "20", "--search", f"{n} in:title,body",
+                 "--json", "number,mergedAt"],
+                capture_output=True, text=True, encoding="utf-8", check=True,
+                timeout=30,
+            ).stdout
+            prs = json.loads(out)
+        except Exception as exc:  # noqa: BLE001 - diagnostic best-effort
+            notes[n] = f"(recherche livraison indisponible: {type(exc).__name__})"
+            continue
+        if not prs:
+            continue
+        latest = max(prs, key=lambda pr: pr.get("mergedAt") or "")
+        merged = latest.get("mergedAt") or ""
+        # Fusion plus recente que la derniere activite de l'issue = le corps
+        # visible est potentiellement periéme par rapport au reel. Une fusion
+        # ANTERIEURE a updatedAt est deja digeree par le body (ou les
+        # commentaires) : pas d'annotation, sinon le signal noie.
+        if merged and merged > p.get("updated_at", ""):
+            extra = f" (+{len(prs) - 1} autres)" if len(prs) > 1 else ""
+            notes[n] = (f"LIVRAISON RECENTE : #{latest['number']} mergee {merged}{extra} "
+                        f"(issue non mise a jour depuis {p.get('updated_at', '?')}) "
+                        f"-> confronter le body au reel AVANT de dispatcher")
+    return notes
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -274,12 +323,14 @@ def main() -> int:
     )
 
     claims = check_claims([p["number"] for p in picks], args.lane) if args.check_claims else {}
+    delivery = recent_delivery(picks)
 
     if args.json:
         print(json.dumps({
             "lane": args.lane, "seed_src": seed_src,
             "pool": {k: len(v) for k, v in by_class.items()},
             "picks": picks, "claims": {str(k): v for k, v in claims.items()},
+            "recent_delivery": {str(k): v for k, v in delivery.items()},
         }, ensure_ascii=False, indent=2))
         return 0
 
@@ -301,6 +352,12 @@ def main() -> int:
               f"{p['genre']:<15}{mark} {p['weight']:>5}  {p['title'][:62]}")
         if p["number"] in claims:
             print(f"{'':>10} {'':>8} {'':>5} {'':>6}  claim: {claims[p['number']]}")
+        if p["number"] in delivery:
+            note = delivery[p["number"]]
+            head, sep, tail = note.partition("-> ")
+            print(f"{'':>10} {'':>8} {'':>5} {'':>6}  {head.strip()}")
+            if tail:
+                print(f"{'':>10} {'':>8} {'':>5} {'':>6}  -> {tail}")
     print()
     print("* = genre CONTENU (seul un genre CONTENU en DEEP/MED tient le plancher G-VAR-1).")
     print("inact = jours depuis la derniere activite. Une inactivite haute est le")

--- a/scripts/tests/test_pick_idle_grain.py
+++ b/scripts/tests/test_pick_idle_grain.py
@@ -1,0 +1,126 @@
+"""Tests for scripts/pick_idle_grain.py recent_delivery (#12174).
+
+Un detecteur se valide par ses faux negatifs, pas par ses hits. Le cas
+fondateur (2026-08-21) : #12014 tiree en urne grain a 16:47Z alors que
+#12077, mergee a 16:19Z, avait deja livre 3 de ses 4 items -- le label
+``candidate-delivered`` (workflow schedule: quotidien, dernier run 05:49Z)
+n'en savait rien. Le replay ci-dessous rejoue cet etat exact.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pick_idle_grain as pig  # noqa: E402
+
+
+class _FakeCompleted:
+    def __init__(self, stdout):
+        self.stdout = stdout
+
+
+def _patch_gh(monkeypatch, payloads, calls):
+    """payloads : liste (dans l'ordre des candidats) de listes de PRs JSON."""
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _FakeCompleted(json.dumps(payloads[len(calls) - 1]))
+    monkeypatch.setattr(pig.subprocess, "run", fake_run)
+
+
+def _pick(n=12014, updated_at="2026-08-21T05:13:00Z"):
+    return {"number": n, "klass": "grain", "updated_at": updated_at,
+            "title": "founding case", "age": 30, "idle": 0,
+            "genre": "slides", "weight": 1.0}
+
+
+def test_founding_case_12014_surfaces_12077(monkeypatch):
+    """#12174 controle positif : le tirage du 2026-08-21 doit nommer #12077.
+
+    Issue non touchee depuis 05:13Z, PR mergee 16:19:17Z -- l'ecart que le
+    label quotidien ne pouvait pas voir.
+    """
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12077, "mergedAt": "2026-08-21T16:19:17Z"},
+    ]], calls)
+    notes = pig.recent_delivery([_pick()])
+    assert 12014 in notes
+    assert "#12077" in notes[12014]
+    assert "16:19:17Z" in notes[12014]
+    assert "05:13:00Z" in notes[12014]
+    assert "confronter le body au reel" in notes[12014]
+
+
+def test_query_shape_bounded_one_per_candidate(monkeypatch):
+    """Cout borne : exactement une requete par candidat tire, jamais le pool.
+
+    La commande doit chercher les PRs MERGEES referencant le numero
+    (troisieme surface de grounding, cf #12174).
+    """
+    calls = []
+    _patch_gh(monkeypatch, [[], []], calls)
+    pig.recent_delivery([_pick(n=1), _pick(n=2)])
+    assert len(calls) == 2
+    for cmd, n in zip(calls, (1, 2)):
+        assert "--state" in cmd and "merged" in cmd
+        assert "--limit" in cmd and "20" in cmd
+        assert "--search" in cmd
+        assert cmd[cmd.index("--search") + 1] == f"{n} in:title,body"
+
+
+def test_merge_older_than_update_not_annotated(monkeypatch):
+    """Une fusion ANTERIEURE a la derniere activite de l'issue est deja
+    digeree par le body -- pas d'annotation, sinon le signal noie."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12077, "mergedAt": "2026-08-21T04:00:00Z"},
+    ]], calls)
+    notes = pig.recent_delivery([_pick(updated_at="2026-08-21T05:13:00Z")])
+    assert notes == {}
+
+
+def test_no_merged_pr_no_note(monkeypatch):
+    calls = []
+    _patch_gh(monkeypatch, [[]], calls)
+    assert pig.recent_delivery([_pick()]) == {}
+
+
+def test_candidate_stays_drawable(monkeypatch):
+    """L'annotation informe, elle n'ecarte pas (parite candidate-delivered) :
+    la fonction rend des notes, les picks passes ne sont ni filtres ni mutés."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12077, "mergedAt": "2026-08-21T16:19:17Z"},
+    ]], calls)
+    picks = [_pick()]
+    snapshot = dict(picks[0])
+    notes = pig.recent_delivery(picks)
+    assert len(picks) == 1 and picks[0] == snapshot
+    assert 12014 in notes  # annote ET toujours la, tirable
+
+
+def test_multiple_prs_latest_named_with_count(monkeypatch):
+    """Plusieurs PRs mergees referencent le numero : la plus recente porte la
+    note, le compte evite de lire 'la livraison' comme l'unique."""
+    calls = []
+    _patch_gh(monkeypatch, [[
+        {"number": 12077, "mergedAt": "2026-08-21T16:19:17Z"},
+        {"number": 12065, "mergedAt": "2026-08-20T10:00:00Z"},
+    ]], calls)
+    notes = pig.recent_delivery([_pick()])
+    assert "#12077" in notes[12014]
+    assert "(+1 autres)" in notes[12014]
+    assert "#12065" not in notes[12014]
+
+
+def test_gh_failure_annotated_best_effort(monkeypatch):
+    """Echec gh : l'absence d'annotation ne doit pas se lire comme 'aucune
+    livraison verifiee'."""
+    def boom(cmd, **kwargs):
+        raise pig.subprocess.TimeoutExpired(cmd, 30)
+    monkeypatch.setattr(pig.subprocess, "run", boom)
+    notes = pig.recent_delivery([_pick()])
+    assert "indisponible" in notes[12014]
+    assert "TimeoutExpired" in notes[12014]


### PR DESCRIPTION
Grain: LIGHT/tooling — lane myia-po-2023:CoursIA — prev: LIGHT/tooling #12210

Closes #12174

## Le defaut, corrige dans l'outil

`pick_idle_grain.py` classait une issue en urne `grain` alors qu'une PR mergee venait de livrer une partie de son contenu : le label `candidate-delivered` (workflow `schedule:` quotidien, dernier run 05:49Z le jour du cas) avait jusqu'a 24 h de retard, et ni `gh issue view` (body date de sa redaction) ni `check_lane_claim` (un claim ne dit rien d'une livraison) ne voient les merges. Le picker execute maintenant, pour chaque candidat tire, la troisieme surface de grounding :

```
gh pr list --state merged --limit 20 --search "<N> in:title,body" --json number,mergedAt
```

et annote toute fusion PLUS RECENTE que le `updatedAt` de l'issue :

```
grain      #10950  ...  S3-acculturation : QA visuel phase generative ...
                                LIVRAISON RECENTE : #11915 mergee 2026-08-21T17:47:28Z (+8 autres) (issue non mise a jour depuis 2026-08-20T11:10:23Z)
                                -> confronter le body au reel AVANT de dispatcher
```

Une fusion ANTERIEURE a `updatedAt` n'est pas annotee (deja digeree par le body) — sinon le signal noie. Plusieurs PRs : la plus recente porte la note + un compte `(+N autres)` qui empeche de lire « la livraison » comme l'unique. Echec gh : note best-effort `(recherche livraison indisponible)`, jamais un silence qui se lirait comme « verifie, rien ».

## Acceptance, point par point

- **Ligne nommant la PR + dates comparees** : rendue sous la ligne du candidat, `mergedAt` vs `updatedAt` litteraux.
- **Cout borne** : une requete par candidat tire (~8 par tirage), jamais un balayage du pool — teste (`test_query_shape_bounded_one_per_candidate` verifie le compte d'appels ET la forme de commande).
- **Candidat annote reste tirable** : la fonction rend des notes sans toucher aux picks — teste par snapshot non-mute (`test_candidate_stays_drawable`).
- **Controle positif** : replay de l'etat exact du 2026-08-21T16:47Z (issue #12014, `updated_at=05:13Z`) contre le depot REEL, sans mock :

```
LIVRAISON RECENTE : #12077 mergee 2026-08-21T16:19:17Z (issue non mise a jour depuis 2026-08-21T05:13:00Z) -> confronter le body au reel AVANT de dispatcher
```

Le detecteur attrape ce qu'il devait attraper.

## Verification integree live

Tirage complet `--lane myia-po-2023:CoursIA` : l'annotation surgit sur de vraies candidates delaissees — #3973 (EPIC readme : `updated_at` 2026-07-15, 20 PRs mergees la referencant depuis), #2874 (EPIC knot : `updated_at` 13:32Z du 20/08, livraison 16:27Z). La sortie `--json` porte la cle additive `recent_delivery` (consommateurs machine non touches).

## Validation

- Nouveau `scripts/tests/test_pick_idle_grain.py` : **7 passed** (cas fondateur, forme+borne de requete, fusion ancienne non annotee, non-filtrage, multi-PRs, echec gh, vide).
- Suites voisines `test_variation_light_cap.py` + `test_candidate_delivered.py` : **109 passed** — aucune interaction.
- 2 modules touches (picker + son test), markdown nul, notebook nul (H.3 non applicable), catalogue byte-identique a main.