### PR TITLE
feat(gametheory,#12237): nouveau notebook GT-21 Deux-Especes-de-Fleches (theoreme fini transformation vs morphisme)

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-21-Deux-Especes-de-Fleches.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-21-Deux-Especes-de-Fleches.ipynb
@@ -1,0 +1,1318 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9ffd0a0c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.05229,
+     "end_time": "2026-08-21T23:29:43.494114+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.441824+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-21 — Deux espèces de flèches : quand une transformation est-elle aussi un morphisme ?\n",
+    "\n",
+    "**Objectifs de ce notebook :**\n",
+    "\n",
+    "1. **Distinguer deux espèces de flèches** qui coexistent sur l'espace des jeux 2x2 ordinaux : les flèches qui *transforment* la structure (les swaps de rangs de Robinson-Goforth) et les flèches qui la *préservent* (les morphismes de jeux au sens Tohmé-Viglizzo).\n",
+    "2. **Rendre la question finie et décidable** : sur les 576 jeux stricts et les 6 générateurs adjacents, la question « ce générateur est-il un morphisme pour ce jeu ? » est une énumération de 3456 paires — pas un slogan.\n",
+    "3. **Exhiber un contre-exemple concret** où un swap détruit un équilibre de Nash qu'un morphisme aurait préservé.\n",
+    "4. **Énumérer l'intersection** : combien de paires (jeu, générateur) le générateur préserve-t-il ? Le compte doit être reproductible.\n",
+    "5. **Caractériser** la préservation par une condition simple sur le jeu de départ — et la vérifier exhaustivement, pas seulement la conjecturer.\n",
+    "\n",
+    "Ce notebook est une instanciation du **grain D5 du chantier 4** (issue #12207) : la première expérience de la « Loi III — les deux espèces de flèches » sur un univers fini où tout se vérifie. Il prolonge [`GameTheory-3-Topology2x2.ipynb`](GameTheory-3-Topology2x2.ipynb), dont il réutilise la représentation ordinale."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00534c79",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006056,
+     "end_time": "2026-08-21T23:29:43.514819+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.508763+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. Le problème : deux espèces de flèches sur le même espace\n",
+    "\n",
+    "La théorie des jeux dispose de deux traditions qui font circuler des flèches entre les jeux, et **elles ne font pas la même chose** :\n",
+    "\n",
+    "| Espèce | Ce qu'elle fait | Source |\n",
+    "|---|---|---|\n",
+    "| **Flèches qui PRÉSERVENT la structure** | morphismes de jeux : ils transportent les équilibres d'un jeu vers un autre jeu qui « joue pareil » | catégories concrètes de jeux de Tohmé-Viglizzo (`Gam_I`, `Gam`) |\n",
+    "| **Flèches qui TRANSFORMENT la structure** | swaps de rangs : ils changent les préférences d'un joueur, donc le jeu lui-même | topologie des jeux 2x2 de Robinson-Goforth |\n",
+    "\n",
+    "Un **swap de rangs** échange deux valeurs dans la table de gains d'un joueur — par exemple, permuter les rangs 1 et 2 du joueur Ligne. Ce n'est pas un changement de croyances ni d'actions : c'est un **changement des préférences elles-mêmes**, donc du monde descriptif. Un **morphisme de jeux**, à l'inverse, garantit que ce qui est rationnel ici l'est encore là-bas : les équilibres se transportent.\n",
+    "\n",
+    "La **Loi III** du chantier 4 s'énonce alors précisément :\n",
+    "\n",
+    "> Un swap change les préférences — il n'est donc **pas automatiquement** un morphisme. La question n'est pas « transformation ou morphisme ? » en général, mais **« pour ce jeu précis, ce générateur précis, préserve-t-il les équilibres ? »**.\n",
+    "\n",
+    "Et cette question, sur un univers fini, a une réponse mécanique."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24925b67",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004978,
+     "end_time": "2026-08-21T23:29:43.524059+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.519081+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### La question rendue finie\n",
+    "\n",
+    "L'univers de `GameTheory-3` est l'espace des **jeux 2x2 stricts ordinaux** : chaque joueur distribue les rangs 1-4 sur les quatre cases. Il y a $24 \\times 24 = 576$ tels jeux. La grammaire de Robinson-Goforth les fait bouger par **six générateurs adjacents** :\n",
+    "\n",
+    "- $R_{12}, R_{23}, R_{34}$ : échanger les rangs adjacents $(1,2)$, $(2,3)$ ou $(3,4)$ dans les gains du joueur Ligne ;\n",
+    "- $C_{12}, C_{23}, C_{34}$ : la même chose pour le joueur Colonne.\n",
+    "\n",
+    "Ces six swaps suffisent à engendrer tout le groupe $S_4 \\times S_4$ des permutations de rangs (les transpositions adjacentes engendrent $S_4$) : un jeu ne se décrit pas, **il se rejoint** depuis un autre.\n",
+    "\n",
+    "Sur cet espace, la question « transformation ou morphisme ? » devient une propriété **décidable par énumération** :\n",
+    "\n",
+    "$$576 \\text{ jeux} \\times 6 \\text{ générateurs} = 3456 \\text{ paires à trancher}.$$\n",
+    "\n",
+    "Réduction honnête de la notion de morphisme : dans les catégories de Tohmé-Viglizzo, un morphisme de jeux transporte aussi les stratégies. Ici, un swap **ne déplace aucune stratégie** — seule l'étiquette des gains change — donc l'application induite sur les profils est l'identité. L'espèce préservante se teste alors opérationnellement :\n",
+    "\n",
+    "> **Définition (finie).** Le générateur $g$ est un *morphisme pour le jeu $G$* si $g$ préserve l'ensemble des équilibres de Nash purs : $\\text{Nash}(G) = \\text{Nash}(g(G))$, la comparaison se faisant cellule à cellule (application identité).\n",
+    "\n",
+    "C'est cette définition que tout le notebook met à l'épreuve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "8e32ce37",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:43.534388Z",
+     "iopub.status.busy": "2026-08-21T23:29:43.533410Z",
+     "iopub.status.idle": "2026-08-21T23:29:43.611134Z",
+     "shell.execute_reply": "2026-08-21T23:29:43.610502Z"
+    },
+    "papermill": {
+     "duration": 0.087489,
+     "end_time": "2026-08-21T23:29:43.615581+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.528092+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Prisoner's Dilemma\n",
+      "================================\n",
+      "        C0        C1\n",
+      "R0  (3,3)     (1,4)\n",
+      "R1  (4,1)     (2,2)\n",
+      "\n",
+      "Stag Hunt\n",
+      "================================\n",
+      "        C0        C1\n",
+      "R0  (4,4)     (1,3)\n",
+      "R1  (3,1)     (2,2)\n",
+      "\n",
+      "Chicken (Hawk-Dove)\n",
+      "================================\n",
+      "        C0        C1\n",
+      "R0  (3,3)     (2,4)\n",
+      "R1  (4,2)     (1,1)\n",
+      "\n",
+      "Matching Pennies\n",
+      "================================\n",
+      "        C0        C1\n",
+      "R0  (4,1)     (1,4)\n",
+      "R1  (2,3)     (3,2)\n",
+      "\n",
+      "Deadlock\n",
+      "================================\n",
+      "        C0        C1\n",
+      "R0  (2,2)     (1,4)\n",
+      "R1  (4,1)     (3,3)\n",
+      "\n",
+      "Harmony\n",
+      "================================\n",
+      "        C0        C1\n",
+      "R0  (4,4)     (3,2)\n",
+      "R1  (2,3)     (1,1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from dataclasses import dataclass\n",
+    "from itertools import permutations\n",
+    "from typing import Dict, List, Set, Tuple\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "@dataclass\n",
+    "class OrdinalGame:\n",
+    "    \"\"\"\n",
+    "    Jeu 2x2 en representation ordinale (convention GameTheory-3).\n",
+    "\n",
+    "    Chaque matrice contient les rangs 1-4 pour les 4 cellules,\n",
+    "    numerotees :\n",
+    "        0 | 1\n",
+    "        -----\n",
+    "        2 | 3\n",
+    "    \"\"\"\n",
+    "    row_payoffs: Tuple[int, int, int, int]\n",
+    "    col_payoffs: Tuple[int, int, int, int]\n",
+    "    name: str = \"\"\n",
+    "\n",
+    "    def __post_init__(self):\n",
+    "        assert sorted(self.row_payoffs) == [1, 2, 3, 4], \"row_payoffs doit etre une permutation de 1-4\"\n",
+    "        assert sorted(self.col_payoffs) == [1, 2, 3, 4], \"col_payoffs doit etre une permutation de 1-4\"\n",
+    "\n",
+    "    def to_matrices(self) -> Tuple[np.ndarray, np.ndarray]:\n",
+    "        A = np.array([[self.row_payoffs[0], self.row_payoffs[1]],\n",
+    "                      [self.row_payoffs[2], self.row_payoffs[3]]])\n",
+    "        B = np.array([[self.col_payoffs[0], self.col_payoffs[1]],\n",
+    "                      [self.col_payoffs[2], self.col_payoffs[3]]])\n",
+    "        return A, B\n",
+    "\n",
+    "    def display(self):\n",
+    "        A, B = self.to_matrices()\n",
+    "        print(f\"\\n{self.name if self.name else 'Jeu'}\")\n",
+    "        print(\"=\" * 32)\n",
+    "        print(f\"        C0        C1\")\n",
+    "        print(f\"R0  ({A[0,0]},{B[0,0]})     ({A[0,1]},{B[0,1]})\")\n",
+    "        print(f\"R1  ({A[1,0]},{B[1,0]})     ({A[1,1]},{B[1,1]})\")\n",
+    "\n",
+    "    def __hash__(self):\n",
+    "        return hash((self.row_payoffs, self.col_payoffs))\n",
+    "\n",
+    "    def __eq__(self, other):\n",
+    "        return (self.row_payoffs == other.row_payoffs\n",
+    "                and self.col_payoffs == other.col_payoffs)\n",
+    "\n",
+    "\n",
+    "# Encodages ordinaux des jeux classiques (identiques a GameTheory-3)\n",
+    "CLASSIC_GAMES = {\n",
+    "    \"Prisoner's Dilemma\": OrdinalGame((3, 1, 4, 2), (3, 4, 1, 2), \"Prisoner's Dilemma\"),\n",
+    "    \"Stag Hunt\":          OrdinalGame((4, 1, 3, 2), (4, 3, 1, 2), \"Stag Hunt\"),\n",
+    "    \"Chicken\":            OrdinalGame((3, 2, 4, 1), (3, 4, 2, 1), \"Chicken (Hawk-Dove)\"),\n",
+    "    \"Matching Pennies\":   OrdinalGame((4, 1, 2, 3), (1, 4, 3, 2), \"Matching Pennies\"),\n",
+    "    \"Deadlock\":           OrdinalGame((2, 1, 4, 3), (2, 4, 1, 3), \"Deadlock\"),\n",
+    "    \"Harmony\":            OrdinalGame((4, 3, 2, 1), (4, 2, 3, 1), \"Harmony\"),\n",
+    "}\n",
+    "\n",
+    "for name, game in CLASSIC_GAMES.items():\n",
+    "    game.display()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5abae20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005948,
+     "end_time": "2026-08-21T23:29:43.632628+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.626680+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Lecture de la représentation\n",
+    "\n",
+    "Chaque case affiche `(gain Ligne, gain Colonne)` en rangs ordinaux — **le rang 4 est le meilleur** pour le joueur qui le reçoit. Deux observations qui serviront tout le long :\n",
+    "\n",
+    "- **Lecture par colonne** : dans la colonne $C_j$, le joueur Ligne compare ses deux gains ; le plus grand désigne sa **meilleure réponse** dans cette colonne. Symétriquement, le joueur Colonne se lit **par ligne**.\n",
+    "- **Stricteté** : chaque joueur place exactement une fois chaque rang 1-4 ; il n'y a **aucune égalité**, donc chaque colonne (resp. ligne) a une meilleure réponse unique de chaque côté. C'est ce qui rend l'espace fini et propre — les jeux à égalité (les « murs » du grain D2, issue #12213) sont un autre objet.\n",
+    "\n",
+    "Le Dilemme du Prisonnier se relit ainsi : pour Ligne, la colonne $C_0$ compare 3 et 4 (il préfère $R_1$ : déserter), la colonne $C_1$ compare 1 et 2 (il préfère encore $R_1$) — $R_1$ est une stratégie dominante, et l'équilibre unique $(R_1, C_1)$ est le pire outcome collectif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d1a61f4a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:43.643862Z",
+     "iopub.status.busy": "2026-08-21T23:29:43.643570Z",
+     "iopub.status.idle": "2026-08-21T23:29:43.651585Z",
+     "shell.execute_reply": "2026-08-21T23:29:43.650583Z"
+    },
+    "papermill": {
+     "duration": 0.015409,
+     "end_time": "2026-08-21T23:29:43.653325+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.637916+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Structure de Nash des jeux classiques :\n",
+      "====================================================\n",
+      "  Prisoner's Dilemma     1 equilibre(s) : (R1,C1)\n",
+      "  Stag Hunt              2 equilibre(s) : (R0,C0), (R1,C1)\n",
+      "  Chicken                2 equilibre(s) : (R0,C1), (R1,C0)\n",
+      "  Matching Pennies       0 equilibre(s) : aucun\n",
+      "  Deadlock               1 equilibre(s) : (R1,C1)\n",
+      "  Harmony                1 equilibre(s) : (R0,C0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def find_pure_nash(game: OrdinalGame) -> List[Tuple[int, int]]:\n",
+    "    \"\"\"Equilibres de Nash purs : cases ou chaque strategie est meilleure reponse a l'autre.\"\"\"\n",
+    "    A, B = game.to_matrices()\n",
+    "    equilibria = []\n",
+    "    for i in range(2):\n",
+    "        for j in range(2):\n",
+    "            row_br = A[i, j] >= A[1 - i, j]\n",
+    "            col_br = B[i, j] >= B[i, 1 - j]\n",
+    "            if row_br and col_br:\n",
+    "                equilibria.append((i, j))\n",
+    "    return equilibria\n",
+    "\n",
+    "\n",
+    "def describe_nash(profiles: List[Tuple[int, int]]) -> str:\n",
+    "    return \", \".join(f\"(R{i},C{j})\" for i, j in profiles) if profiles else \"aucun\"\n",
+    "\n",
+    "\n",
+    "print(\"Structure de Nash des jeux classiques :\")\n",
+    "print(\"=\" * 52)\n",
+    "for name, game in CLASSIC_GAMES.items():\n",
+    "    eq = find_pure_nash(game)\n",
+    "    print(f\"  {name:22s} {len(eq)} equilibre(s) : {describe_nash(eq)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1be1b82",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006523,
+     "end_time": "2026-08-21T23:29:43.669301+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.662778+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : la structure de Nash, signature du jeu\n",
+    "\n",
+    "L'ensemble des équilibres de Nash purs est la **signature stratégique** d'un jeu — c'est précisément ce qu'un morphisme de jeux s'engage à transporter. La collection classique couvre les quatre situations : un unique équilibre à dominance (Dilemme, Deadlock, Harmony), deux équilibres de coordination ou d'anti-coordination (Stag Hunt, Chicken), et **aucun équilibre pur** (Matching Pennies, où l'instabilité est le jeu).\n",
+    "\n",
+    "Ce qui va nous intéresser n'est pas la classification elle-même (c'est le sujet de GameTheory-3, §5-6) mais une question plus fine : **cette signature survit-elle au passage d'un générateur ?** Un jeu sans équilibre peut en acquérir un, un jeu à équilibre unique peut le voir déménager — ou tout perdre. Chacun de ces événements est une **destruction** au sens morphique : la flèche existe (le swap est toujours applicable), mais elle ne préserve pas."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "ac93a339",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:43.681431Z",
+     "iopub.status.busy": "2026-08-21T23:29:43.680885Z",
+     "iopub.status.idle": "2026-08-21T23:29:43.700615Z",
+     "shell.execute_reply": "2026-08-21T23:29:43.699030Z"
+    },
+    "papermill": {
+     "duration": 0.028471,
+     "end_time": "2026-08-21T23:29:43.703164+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.674693+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu de depart :\n",
+      "\n",
+      "Prisoner's Dilemma\n",
+      "================================\n",
+      "        C0        C1\n",
+      "R0  (3,3)     (1,4)\n",
+      "R1  (4,1)     (2,2)\n",
+      "  Nash : (R1,C1)\n",
+      "\n",
+      "Apres le generateur R12 (rangs 1 et 2 echanges pour Ligne) :\n",
+      "\n",
+      "Jeu\n",
+      "================================\n",
+      "        C0        C1\n",
+      "R0  (3,3)     (2,4)\n",
+      "R1  (4,1)     (1,2)\n",
+      "  Nash : (R0,C1)\n"
+     ]
+    }
+   ],
+   "source": [
+    "def swap_payoffs(payoffs: Tuple[int, int, int, int],\n",
+    "                  rank1: int, rank2: int) -> Tuple[int, int, int, int]:\n",
+    "    \"\"\"Echange deux valeurs de rang dans une table de gains (convention GameTheory-3).\"\"\"\n",
+    "    result = list(payoffs)\n",
+    "    for i in range(4):\n",
+    "        if result[i] == rank1:\n",
+    "            result[i] = rank2\n",
+    "        elif result[i] == rank2:\n",
+    "            result[i] = rank1\n",
+    "    return tuple(result)\n",
+    "\n",
+    "\n",
+    "def apply_generator(game: OrdinalGame, gen: str) -> OrdinalGame:\n",
+    "    \"\"\"Applique un des six generateurs adjacents R12/R23/R34/C12/C23/C34.\"\"\"\n",
+    "    player, r1, r2 = gen[0], int(gen[1]), int(gen[2])\n",
+    "    if player == \"R\":\n",
+    "        return OrdinalGame(swap_payoffs(game.row_payoffs, r1, r2), game.col_payoffs)\n",
+    "    return OrdinalGame(game.row_payoffs, swap_payoffs(game.col_payoffs, r1, r2))\n",
+    "\n",
+    "\n",
+    "GENERATORS = [\"R12\", \"R23\", \"R34\", \"C12\", \"C23\", \"C34\"]\n",
+    "\n",
+    "# Demonstration : le Dilemme du Prisonnier perd son rang 1<->2 cote Ligne\n",
+    "pd = CLASSIC_GAMES[\"Prisoner's Dilemma\"]\n",
+    "pd_r12 = apply_generator(pd, \"R12\")\n",
+    "\n",
+    "print(\"Jeu de depart :\")\n",
+    "pd.display()\n",
+    "print(f\"  Nash : {describe_nash(find_pure_nash(pd))}\")\n",
+    "\n",
+    "print(\"\\nApres le generateur R12 (rangs 1 et 2 echanges pour Ligne) :\")\n",
+    "pd_r12.display()\n",
+    "print(f\"  Nash : {describe_nash(find_pure_nash(pd_r12))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb14ef76",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00444,
+     "end_time": "2026-08-21T23:29:43.714107+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.709667+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : la grammaire en action — et le soupçon\n",
+    "\n",
+    "Le générateur $R_{12}$ a échangé les rangs 1 et 2 du joueur Ligne : la case $(R_0, C_1)$ est passée de 1 à 2 et la case $(R_1, C_1)$ de 2 à 1. Les **stratégies n'ont pas bougé**, les préférences ont changé — et la sortie mesure déjà le soupçon fondateur de la Loi III : dans la colonne $C_1$, Ligne comparait 1 et 2 (il préférait $R_1$) ; il compare maintenant 2 et 1 (il préfère $R_0$). **Sa meilleure réponse dans cette colonne s'est retournée**, et avec elle l'équilibre.\n",
+    "\n",
+    "Ce seul exemple montre les deux espèces à l'œuvre : la flèche $R_{12}$ **existe** toujours (c'est une transformation valide de l'espace) mais, pour ce jeu précis, elle **ne préserve pas** la signature de Nash. Reste à savoir si c'est un accident du Dilemme ou une structure de l'espace entier — c'est l'objet des sections suivantes. La réponse tiendra en une condition d'une ligne sur la table de gains du jeu de départ."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c83d5b98",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004198,
+     "end_time": "2026-08-21T23:29:43.722323+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.718125+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. L'espèce préservante : tester le morphisme, flèche par flèche\n",
+    "\n",
+    "La définition finie de la section 1 se implémente en une fonction : $g$ est un morphisme pour $G$ si et seulement si les ensembles de Nash coïncident **avant et après** l'application de $g$. Notons ce que cette comparaison ne demande pas : elle ne demande pas que le jeu soit « pareil » (les gains diffèrent en général), ni que les équilibres soient aux mêmes cases pour toujours — elle demande l'égalité des deux ensembles pour **cette** paire $(G, g)$.\n",
+    "\n",
+    "C'est bien une relation *locale* : le même générateur peut être morphisme pour un jeu et pas pour son voisin. L'espace des flèches se partitionne donc en\n",
+    "\n",
+    "- **flèches préservantes** — celles qui, pour ce jeu, transportent la signature de Nash intacte (l'identité sur les profils est alors compatible avec la structure de jeu) ;\n",
+    "- **flèches transformatrices** — celles qui cassent, déplacent ou créent des équilibres.\n",
+    "\n",
+    "Et parce que l'univers est fini, chacune des 3456 paires tombe d'un côté ou de l'autre **sans zone grise**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "a7ce6a4a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:43.736448Z",
+     "iopub.status.busy": "2026-08-21T23:29:43.735428Z",
+     "iopub.status.idle": "2026-08-21T23:29:43.757844Z",
+     "shell.execute_reply": "2026-08-21T23:29:43.754326Z"
+    },
+    "papermill": {
+     "duration": 0.032923,
+     "end_time": "2026-08-21T23:29:43.759604+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.726681+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Trancher quelques paires a la main :\n",
+      "========================================================\n",
+      "  Deadlock               + R12 : Nash (R1,C1)      -> (R1,C1)      => PRESERVE\n",
+      "  Deadlock               + R34 : Nash (R1,C1)      -> (R1,C1)      => PRESERVE\n",
+      "  Prisoner's Dilemma     + R12 : Nash (R1,C1)      -> (R0,C1)      => TRANSFORME\n",
+      "  Prisoner's Dilemma     + C12 : Nash (R1,C1)      -> (R1,C0)      => TRANSFORME\n",
+      "  Harmony                + C34 : Nash (R0,C0)      -> (R0,C0)      => PRESERVE\n",
+      "  Matching Pennies       + R23 : Nash aucun        -> aucun        => PRESERVE\n"
+     ]
+    }
+   ],
+   "source": [
+    "def est_morphisme_pour(game: OrdinalGame, gen: str) -> bool:\n",
+    "    \"\"\"\n",
+    "    Le generateur gen preserve-t-il l'ensemble des equilibres de Nash purs de game ?\n",
+    "\n",
+    "    Reduction finite : un swap ne deplace aucune strategie, donc la comparaison\n",
+    "    se fait sous l'application identite sur les profils.\n",
+    "    \"\"\"\n",
+    "    return set(find_pure_nash(game)) == set(find_pure_nash(apply_generator(game, gen)))\n",
+    "\n",
+    "\n",
+    "print(\"Trancher quelques paires a la main :\")\n",
+    "print(\"=\" * 56)\n",
+    "for game_name, gen in [\n",
+    "    (\"Deadlock\", \"R12\"),\n",
+    "    (\"Deadlock\", \"R34\"),\n",
+    "    (\"Prisoner's Dilemma\", \"R12\"),\n",
+    "    (\"Prisoner's Dilemma\", \"C12\"),\n",
+    "    (\"Harmony\", \"C34\"),\n",
+    "    (\"Matching Pennies\", \"R23\"),\n",
+    "]:\n",
+    "    g = CLASSIC_GAMES[game_name]\n",
+    "    g2 = apply_generator(g, gen)\n",
+    "    verdict = est_morphisme_pour(g, gen)\n",
+    "    print(f\"  {game_name:22s} + {gen} : \"\n",
+    "          f\"Nash {describe_nash(find_pure_nash(g)):12s} -> {describe_nash(find_pure_nash(g2)):12s} \"\n",
+    "          f\"=> {'PRESERVE' if verdict else 'TRANSFORME'}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "258c2da3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004194,
+     "end_time": "2026-08-21T23:29:43.768145+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.763951+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : deux espèces, même espace\n",
+    "\n",
+    "Les six verdicts mesurés racontent déjà la Loi III :\n",
+    "\n",
+    "- **Deadlock + $R_{12}$ : PRÉSERVÉ.** Pour Ligne, les colonnes comparent (2,4) et (1,3) — échanger 1 et 2 ne change aucun ordre interne de colonne : les meilleures réponses ne bougent pas, l'équilibre $(R_1, C_1)$ reste seul. La flèche transforme la *table* mais transporte la *structure* : elle est des deux espèces à la fois.\n",
+    "- **Prisoner's Dilemma + $R_{12}$ : TRANSFORMÉ.** La colonne $C_1$ comparait (1,2) ; après le swap elle compare (2,1) — la meilleure réponse de Ligne s'y retourne, et l'équilibre unique déménage de $(R_1, C_1)$ vers $(R_0, C_1)$.\n",
+    "- **Matching Pennies + $R_{23}$ : PRÉSERVÉ… trivialement.** L'ensemble vide est égal à lui-même : le jeu n'a pas d'équilibre pur avant ni après. La préservation ici ne dit rien d'intéressant — un cas limite qu'il faudra garder en tête en lisant les comptes de la section 4.\n",
+    "\n",
+    "Le point structurant : **le verdict n'appartient ni au générateur ni au jeu seul, mais à la paire**. C'est exactement pourquoi la question « un swap est-il un morphisme ? » est mal posée sans son jeu — et pourquoi l'énumération qui suit n'est pas un exercice de style."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea668c4f",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004244,
+     "end_time": "2026-08-21T23:29:43.778105+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.773861+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Exercice 1 : implémenter les deux espèces et produire un contre-exemple\n",
+    "\n",
+    "À vous de jouer : la fonction `contre_exemple` doit trouver, dans les jeux classiques, **une paire (jeu, générateur) où le swap détruit un équilibre** — c'est-à-dire où un équilibre de Nash du jeu de départ n'est plus équilibre dans le jeu d'arrivée. Un contre-exemple, pas un principe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "acd18e94",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:43.794450Z",
+     "iopub.status.busy": "2026-08-21T23:29:43.793148Z",
+     "iopub.status.idle": "2026-08-21T23:29:43.811233Z",
+     "shell.execute_reply": "2026-08-21T23:29:43.808469Z"
+    },
+    "papermill": {
+     "duration": 0.030562,
+     "end_time": "2026-08-21T23:29:43.813007+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.782445+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : contre-exemple de destruction d'equilibre par un swap\n"
+     ]
+    }
+   ],
+   "source": [
+    "def contre_exemple(games: Dict[str, OrdinalGame]) -> List[dict]:\n",
+    "    # TODO etudiant : trouver les paires (jeu, generateur) ou le swap DETRUIT un equilibre\n",
+    "    # Etape 1 : pour chaque jeu et chaque generateur des 6, calculer Nash avant et Nash apres\n",
+    "    # Etape 2 : garder les paires ou un equilibre du depart disparait (destruction stricte :\n",
+    "    #           un profil de Nash(G) absent de Nash(g(G)) -- pas seulement un deplacement)\n",
+    "    # Etape 3 : retourner une liste de dicts {jeu, generateur, nash_avant, nash_apres, detruit}\n",
+    "    # Indice : est_morphisme_pour dit si les ENSEMBLES sont egaux ; ici il faut regarder\n",
+    "    #          profil par profil -- un deplacement (ensemble different) n'est pas une destruction\n",
+    "    # Verifiez votre resultat : au moins un classique doit apparaitre avec une destruction stricte\n",
+    "    return []  # TODO etudiant : remplacer\n",
+    "\n",
+    "\n",
+    "# resultats_ex1 = contre_exemple(CLASSIC_GAMES)\n",
+    "# for r in resultats_ex1:\n",
+    "#     print(r[\"jeu\"], r[\"generateur\"], \":\", r[\"detruit\"])\n",
+    "print(\"Exercice a completer : contre-exemple de destruction d'equilibre par un swap\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79441c5e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004663,
+     "end_time": "2026-08-21T23:29:43.822601+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.817938+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exemple résolu : un équilibre détruit, un équilibre déplacé\n",
+    "\n",
+    "La démonstration guidée ci-dessous tranche la question sur le Dilemme du Prisonnier avec les deux générateurs qui l'attaquent le plus naturellement : $R_{12}$ (Ligne) et $C_{12}$ (Colonne). On regarde les profils un par un — c'est la distinction destruction/déplacement qui compte :\n",
+    "\n",
+    "- **déplacement** : l'équilibre de départ n'est plus là, mais un autre est apparu (la cardinalité est conservée) ;\n",
+    "- **destruction stricte** : un profil de Nash($G$) n'est plus Nash dans $g(G)$, sans compensation nécessaire — la signature perd un élément."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e48873ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:43.839304Z",
+     "iopub.status.busy": "2026-08-21T23:29:43.837607Z",
+     "iopub.status.idle": "2026-08-21T23:29:43.860641Z",
+     "shell.execute_reply": "2026-08-21T23:29:43.858894Z"
+    },
+    "papermill": {
+     "duration": 0.034941,
+     "end_time": "2026-08-21T23:29:43.862420+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.827479+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeu : Prisoner's Dilemma   Nash initial : (R1,C1)\n",
+      "==============================================================\n",
+      "  R12 : Nash apres (R0,C1)      | DEPLACEMENT : (R1,C1) -> (R0,C1)\n",
+      "  C12 : Nash apres (R1,C0)      | DEPLACEMENT : (R1,C1) -> (R1,C0)\n",
+      "  R34 : Nash apres (R1,C1)      | preservation\n",
+      "\n",
+      "Recherche d'une DESTRUCTION stricte dans les jeux classiques :\n",
+      "  Stag Hunt + R12 : perd (R1,C1) sans compensation\n",
+      "  Stag Hunt + R34 : perd (R0,C0) sans compensation\n",
+      "  Stag Hunt + C12 : perd (R1,C1) sans compensation\n",
+      "  Stag Hunt + C34 : perd (R0,C0) sans compensation\n",
+      "  Chicken + R12 : perd (R0,C1) sans compensation\n",
+      "  Chicken + R34 : perd (R1,C0) sans compensation\n",
+      "  Chicken + C12 : perd (R1,C0) sans compensation\n",
+      "  Chicken + C34 : perd (R0,C1) sans compensation\n"
+     ]
+    }
+   ],
+   "source": [
+    "def differencial_nash(game: OrdinalGame, gen: str) -> dict:\n",
+    "    \"\"\"Compare Nash avant/apres, profil par profil.\"\"\"\n",
+    "    avant = set(find_pure_nash(game))\n",
+    "    apres = set(find_pure_nash(apply_generator(game, gen)))\n",
+    "    return {\n",
+    "        \"generateur\": gen,\n",
+    "        \"avant\": avant,\n",
+    "        \"apres\": apres,\n",
+    "        \"detruits\": avant - apres,\n",
+    "        \"creees\": apres - avant,\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "pd = CLASSIC_GAMES[\"Prisoner's Dilemma\"]\n",
+    "print(f\"Jeu : Prisoner's Dilemma   Nash initial : {describe_nash(find_pure_nash(pd))}\")\n",
+    "print(\"=\" * 62)\n",
+    "for gen in [\"R12\", \"C12\", \"R34\"]:\n",
+    "    d = differencial_nash(pd, gen)\n",
+    "    if d[\"detruits\"] and d[\"creees\"]:\n",
+    "        nature = \"DEPLACEMENT : \" + describe_nash(list(d[\"detruits\"])) + \" -> \" + describe_nash(list(d[\"creees\"]))\n",
+    "    elif d[\"detruits\"]:\n",
+    "        nature = \"DESTRUCTION stricte : \" + describe_nash(list(d[\"detruits\"]))\n",
+    "    else:\n",
+    "        nature = \"preservation\" + (\" (deplacement : \" + describe_nash(list(d[\"creees\"])) + \")\" if d[\"creees\"] else \"\")\n",
+    "    print(f\"  {gen} : Nash apres {describe_nash(list(d['apres'])):12s} | {nature}\")\n",
+    "\n",
+    "# Le contre-exemple attendu par l'exercice 1 existe-t-il dans les classiques ?\n",
+    "print()\n",
+    "print(\"Recherche d'une DESTRUCTION stricte dans les jeux classiques :\")\n",
+    "trouve = False\n",
+    "for name, game in CLASSIC_GAMES.items():\n",
+    "    for gen in GENERATORS:\n",
+    "        d = differencial_nash(game, gen)\n",
+    "        if d[\"detruits\"] and not d[\"creees\"]:\n",
+    "            trouve = True\n",
+    "            print(f\"  {name} + {gen} : perd {describe_nash(list(d['detruits']))} sans compensation\")\n",
+    "if not trouve:\n",
+    "    print(\"  (aucune dans cet echantillon -- elargir l'espace)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da18b75b",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005274,
+     "end_time": "2026-08-21T23:29:43.872946+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.867672+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : trois régimes mesurés sur un seul jeu — et le mur habité\n",
+    "\n",
+    "Le Dilemme exhibe d'un coup les **trois régimes** possibles d'une flèche :\n",
+    "\n",
+    "- **$R_{12}$ et $C_{12}$ : déplacement.** L'équilibre unique déménage ($(R_1,C_1) \\to (R_0,C_1)$ pour le premier, $\\to (R_1,C_0)$ pour le second). L'ensemble change — pas morphisme — mais le jeu d'arrivée a toujours un équilibre : la richesse stratégique est transportée, pas amputée.\n",
+    "- **$R_{34}$ : préservation.** La colonne $C_0$ du Dilemme contient bien le couple adjacent $(3,4)$ pour Ligne — la flèche **traverse un mur** — et pourtant la signature de Nash ne bouge pas. Premier indice que la condition naïve « couple adjacent ⟹ transformation » est **fausse** : il faut comprendre pourquoi ce passage est invisible.\n",
+    "- Sur les autres classiques, **Stag Hunt et Chicken subissent des destructions strictes** : chacun de leurs deux équilibres peut être supprimé sans compensation par le bon générateur. C'est le contre-exemple dur que l'exercice 1 demande — une coordination qui **perd** une de ses sorties.\n",
+    "\n",
+    "Le vocabulaire géométrique du chantier 4 s'impose : dans la lecture Bruns-Kimmich (grain D2, issue #12213), les jeux stricts sont des **chambres** et les swaps adjacents traversent des **murs**. Mais le régime $R_{34}$ du Dilemme montre la subtilité : **un mur ne change la chambre Nash que s'il est habité** — si aucune meilleure réponse de Colonne ne pointe vers la colonne traversée, aucun équilibre ne vivait contre ce mur, et le passage est stratégiquement invisible. C'est cette intuition que la section 6 transforme en théorème vérifié."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c15fa41",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005155,
+     "end_time": "2026-08-21T23:29:43.883538+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.878383+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Énumération exhaustive : l'intersection des deux espèces\n",
+    "\n",
+    "L'échantillon des classiques ne suffit pas : la Loi III demande le compte **sur l'espace entier**. L'énumération ci-dessous génère les 576 jeux stricts (toutes paires de permutations de 1-4), applique chacun des 6 générateurs à chacun des jeux, et tranche les 3456 paires une par une. Trois mesures en sortent :\n",
+    "\n",
+    "1. le compte **par générateur** : combien de jeux chaque générateur préserve ;\n",
+    "2. la **distribution par jeu** : combien de générateurs transforment chaque jeu (de 0 à 6) ;\n",
+    "3. les **points fixes de la grammaire** : les jeux que les six générateurs préservent — les jeux « au cœur de leur chambre », inatteignables par un seul pas de la grammaire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "25a05053",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:43.901183Z",
+     "iopub.status.busy": "2026-08-21T23:29:43.899694Z",
+     "iopub.status.idle": "2026-08-21T23:29:44.002023Z",
+     "shell.execute_reply": "2026-08-21T23:29:44.001308Z"
+    },
+    "papermill": {
+     "duration": 0.113702,
+     "end_time": "2026-08-21T23:29:44.002942+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:43.889240+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeux stricts generes : 576  (24 x 24)\n",
+      "\n",
+      "Preservation par generateur (sur 576 jeux) :\n",
+      "==============================================\n",
+      "  R12 : 432 preserves / 144 transformes  (75.0 %)\n",
+      "  R23 : 432 preserves / 144 transformes  (75.0 %)\n",
+      "  R34 : 432 preserves / 144 transformes  (75.0 %)\n",
+      "  C12 : 432 preserves / 144 transformes  (75.0 %)\n",
+      "  C23 : 432 preserves / 144 transformes  (75.0 %)\n",
+      "  C34 : 432 preserves / 144 transformes  (75.0 %)\n",
+      "  TOTAL : 2592 paires preservantes sur 3456 (75.0 %)\n",
+      "\n",
+      "Distribution du nombre de generateurs transformateurs par jeu :\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  0 generateur(s) transformateur(s) : 100 jeux  ################\n",
+      "  1 generateur(s) transformateur(s) : 200 jeux  #################################\n",
+      "  2 generateur(s) transformateur(s) : 180 jeux  ##############################\n",
+      "  3 generateur(s) transformateur(s) :  80 jeux  #############\n",
+      "  4 generateur(s) transformateur(s) :  16 jeux  ##\n",
+      "\n",
+      "Points fixes (6/6 preserves) : 100 jeux\n"
+     ]
+    }
+   ],
+   "source": [
+    "def generate_all_ordinal_games() -> Set[OrdinalGame]:\n",
+    "    \"\"\"Les 576 jeux 2x2 stricts : 24 permutations de rangs par joueur.\"\"\"\n",
+    "    return {OrdinalGame(r, c)\n",
+    "            for r in permutations([1, 2, 3, 4])\n",
+    "            for c in permutations([1, 2, 3, 4])}\n",
+    "\n",
+    "\n",
+    "all_games = generate_all_ordinal_games()\n",
+    "print(f\"Jeux stricts generes : {len(all_games)}  (24 x 24)\")\n",
+    "print()\n",
+    "\n",
+    "# 1. Compte par generateur\n",
+    "print(\"Preservation par generateur (sur 576 jeux) :\")\n",
+    "print(\"=\" * 46)\n",
+    "total_preserve = 0\n",
+    "for gen in GENERATORS:\n",
+    "    n_pres = sum(est_morphisme_pour(g, gen) for g in all_games)\n",
+    "    total_preserve += n_pres\n",
+    "    print(f\"  {gen} : {n_pres:3d} preserves / {576 - n_pres:3d} transformes  \"\n",
+    "          f\"({100 * n_pres / 576:.1f} %)\")\n",
+    "\n",
+    "print(f\"  {'TOTAL':>4s} : {total_preserve} paires preservantes sur {576 * 6} \"\n",
+    "      f\"({100 * total_preserve / (576 * 6):.1f} %)\")\n",
+    "\n",
+    "# 2. Distribution par jeu : combien de generateurs transforment ce jeu\n",
+    "print()\n",
+    "print(\"Distribution du nombre de generateurs transformateurs par jeu :\")\n",
+    "par_jeu = {}\n",
+    "for g in all_games:\n",
+    "    n_trans = sum(not est_morphisme_pour(g, gen) for gen in GENERATORS)\n",
+    "    par_jeu[n_trans] = par_jeu.get(n_trans, 0) + 1\n",
+    "for k in sorted(par_jeu):\n",
+    "    barre = \"#\" * (par_jeu[k] // 6)\n",
+    "    print(f\"  {k} generateur(s) transformateur(s) : {par_jeu[k]:3d} jeux  {barre}\")\n",
+    "\n",
+    "# 3. Points fixes de la grammaire : 0 generateur transformateur\n",
+    "fixes = [g for g in all_games\n",
+    "         if all(est_morphisme_pour(g, gen) for gen in GENERATORS)]\n",
+    "print(f\"\\nPoints fixes (6/6 preserves) : {len(fixes)} jeux\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da585aff",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005119,
+     "end_time": "2026-08-21T23:29:44.013693+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.008574+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : la séparation nette existe — et elle est massive\n",
+    "\n",
+    "Les comptes mesurés établissent la Loi III sur l'univers entier :\n",
+    "\n",
+    "- **Chaque générateur préserve 432 jeux sur 576 (75 %) et en transforme 144 (25 %).** Un quart de l'espace change de signature de Nash à chaque pas de la grammaire — la séparation n'est ni marginale ni décorative. Et aucun générateur n'est « globalement » morphisme : l'espèce d'une flèche est une propriété de la paire.\n",
+    "- **La distribution par jeu est unanime** : chaque jeu est transformé par **au moins un** des six générateurs (aucun jeu à 0 n'échapperait… en fait si : 100 jeux sont préservés par les six — les « points fixes de la grammaire »), et 16 jeux sont transformés par **quatre** générateurs sur six — les plus exposés de l'espace. La masse (460 jeux) se concentre entre un et trois générateurs transformateurs.\n",
+    "- **2592 paires préservantes sur 3456** — dont les préservations triviales (les jeux sans équilibre pur, dont l'ensemble vide se préserve de lui-même) et les préservations *invisibles* découvertes en section 3 ($R_{34}$ sur le Dilemme) : le compte honnête les inclut, la lecture doit s'en souvenir.\n",
+    "\n",
+    "Le verdict du grain D5 s'écrit : **la séparation nette apparaît** — certaines flèches préservent, d'autres transforment, et le partage n'est ni uniforme ni arbitraire. La distribution a une forme ; une forme annonce une cause. La section suivante commence par se tromper dessus — c'est voulu."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f8f832ec",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005134,
+     "end_time": "2026-08-21T23:29:44.024031+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.018897+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Exercice 2 : cartographier l'intersection par structure de Nash\n",
+    "\n",
+    "Le compte global dit *combien* ; à vous de dire *quoi*. La fonction `cartographier_intersection` doit croiser l'énumération avec la **structure de Nash** des jeux de départ (nombre d'équilibres purs) pour répondre : les jeux préservés par un générateur sont-ils surtout des jeux sans équilibre (préservation triviale) ou surtout des jeux à équilibre unique ? La réponse mesure à quel point la préservation mesurée en section 4 est *substantielle*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "304a5a76",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:44.036037Z",
+     "iopub.status.busy": "2026-08-21T23:29:44.035718Z",
+     "iopub.status.idle": "2026-08-21T23:29:44.041188Z",
+     "shell.execute_reply": "2026-08-21T23:29:44.040372Z"
+    },
+    "papermill": {
+     "duration": 0.012704,
+     "end_time": "2026-08-21T23:29:44.042033+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.029329+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : cartographie preservation x structure de Nash\n"
+     ]
+    }
+   ],
+   "source": [
+    "def cartographier_intersection(games: Set[OrdinalGame]) -> Dict[str, Dict[str, int]]:\n",
+    "    # TODO etudiant : croiser preservation x structure de Nash des jeux de depart\n",
+    "    # Etape 1 : pour chaque jeu, calculer son nombre d'equilibres purs (0 a 4)\n",
+    "    # Etape 2 : pour chaque paire (jeu, generateur), enregistrer preserve/transforme\n",
+    "    # Etape 3 : aggreger en dict {nb_equilibres: {\"preserves\": X, \"transformes\": Y}}\n",
+    "    # Indice : find_pure_nash et est_morphisme_pour font tout le travail ;\n",
+    "    #          la question interessante est le RATIO preserves/transformes par strate\n",
+    "    # Verifiez : les jeux a 0 equilibre sont preserves a 100 % (ensemble vide), les autres non\n",
+    "    return {}  # TODO etudiant : remplacer\n",
+    "\n",
+    "\n",
+    "# carte = cartographier_intersection(all_games)\n",
+    "# for nb_eq, compteurs in sorted(carte.items()):\n",
+    "#     print(nb_eq, compteurs)\n",
+    "print(\"Exercice a completer : cartographie preservation x structure de Nash\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24f60a69",
+   "metadata": {
+    "papermill": {
+     "duration": 0.005964,
+     "end_time": "2026-08-21T23:29:44.053408+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.047444+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Caractérisation : quand un générateur préserve-t-il ?\n",
+    "\n",
+    "L'énumération a une forme ; cherchons la cause. Premier pas sûr — la mécanique des meilleures réponses :\n",
+    "\n",
+    "1. **Un swap $R_{(a,b)}$ ne peut retourner une meilleure réponse que dans une colonne qui contient les deux rangs échangés.** Dans une colonne donnée, la meilleure réponse de Ligne ne dépend que de l'**ordre** de ses deux gains ; échanger les valeurs $a$ et $b$ ne change aucun ordre… sauf dans une colonne dont les deux gains sont précisément $a$ et $b$ (l'ordre s'y inverse).\n",
+    "\n",
+    "On serait tenté de conclure : *« couple $\\{a,b\\}$ présent dans une colonne ⟹ transformation. »* C'est la **conjecture naïve** — et elle est **fausse** : le régime $R_{34}$ du Dilemme (section 3) la contredit déjà. La cellule suivante la teste sur tout l'espace, montre ses désaccords, puis construit la bonne condition en regardant **pourquoi** certains retournements sont invisibles :\n",
+    "\n",
+    "2. **Un retournement n'est visible dans l'ensemble de Nash que si la colonne traversée est aussi une colonne-maison pour l'autre joueur.** Le profil $(i, C_j)$ n'est équilibre que si $C_j$ est *aussi* la meilleure réponse de Colonne en ligne $i$. Si les meilleures réponses de Colonne (dans les deux lignes) pointent toutes **ailleurs** que vers $C_j$, aucun équilibre ne vit dans la colonne $C_j$ — ni avant ni après le retournement de Ligne : le mur est traversé, mais personne n'habitait contre.\n",
+    "\n",
+    "D'où la **caractérisation attendue** : $R_{(a,b)}$ transforme $G$ si et seulement si une colonne des gains de Ligne contient $\\{a, b\\}$ **et** cette colonne est la meilleure réponse de Colonne dans au moins une ligne (symétrique pour $C_{(a,b)}$ : la ligne contenant $\\{a,b\\}$ doit être la meilleure réponse de Ligne dans au moins une colonne). L'univers étant fini, tout cela se **vérifie**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3b11ca7d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:44.067106Z",
+     "iopub.status.busy": "2026-08-21T23:29:44.066504Z",
+     "iopub.status.idle": "2026-08-21T23:29:44.152866Z",
+     "shell.execute_reply": "2026-08-21T23:29:44.152291Z"
+    },
+    "papermill": {
+     "duration": 0.095422,
+     "end_time": "2026-08-21T23:29:44.154478+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.059056+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conjecture naive testee sur 3456 paires : 288 desaccords\n",
+      "  contre-exemple : R=(1, 3, 2, 4) C=(2, 4, 1, 3) + R12\n",
+      "    Nash avant [(1, 1)] / apres [(1, 1)] -> mur traverse mais equilibres intacts\n",
+      "\n",
+      "Condition verifiee sur 3456 paires : accords = 3456, desaccords = 0\n",
+      "La condition predit exactement les 3456 verdicts : theoreme etabli.\n",
+      "\n",
+      "Derivation pour R12 : 16 permutations sans paire (sur 24)\n",
+      "  -> 16 x 24 = 384 jeux preserves sans mur\n",
+      "  + 8 permutations avec paire x 6 arrangements Colonne ou le mur est inhabite\n",
+      "  = 384 + 48 = 432 jeux preserves attendus\n",
+      "  mesure section 4 : 432\n"
+     ]
+    }
+   ],
+   "source": [
+    "def colonne_contenant(game: OrdinalGame, r1: int, r2: int):\n",
+    "    \"\"\"Colonne (0 ou 1) dont les gains Ligne contiennent {r1, r2}, sinon None.\"\"\"\n",
+    "    if {game.row_payoffs[0], game.row_payoffs[2]} == {r1, r2}:\n",
+    "        return 0\n",
+    "    if {game.row_payoffs[1], game.row_payoffs[3]} == {r1, r2}:\n",
+    "        return 1\n",
+    "    return None\n",
+    "\n",
+    "\n",
+    "def condition_naive(game: OrdinalGame, gen: str) -> bool:\n",
+    "    \"\"\"Conjecture naive : preserve ssi le joueur vise n'a pas {a,b} dans une colonne/ligne.\"\"\"\n",
+    "    player, r1, r2 = gen[0], int(gen[1]), int(gen[2])\n",
+    "    if player == \"R\":\n",
+    "        return colonne_contenant(game, r1, r2) is None\n",
+    "    if {game.col_payoffs[0], game.col_payoffs[1]} == {r1, r2}:\n",
+    "        return False\n",
+    "    if {game.col_payoffs[2], game.col_payoffs[3]} == {r1, r2}:\n",
+    "        return False\n",
+    "    return True\n",
+    "\n",
+    "\n",
+    "def br_colonne(game: OrdinalGame) -> List[int]:\n",
+    "    \"\"\"Meilleure reponse de Colonne dans chaque ligne : [beta(0), beta(1)].\"\"\"\n",
+    "    _, B = game.to_matrices()\n",
+    "    return [0 if B[0, 0] > B[0, 1] else 1, 0 if B[1, 0] > B[1, 1] else 1]\n",
+    "\n",
+    "\n",
+    "def br_ligne(game: OrdinalGame) -> List[int]:\n",
+    "    \"\"\"Meilleure reponse de Ligne dans chaque colonne : [rho(0), rho(1)].\"\"\"\n",
+    "    A, _ = game.to_matrices()\n",
+    "    return [0 if A[0, 0] > A[1, 0] else 1, 0 if A[0, 1] > A[1, 1] else 1]\n",
+    "\n",
+    "\n",
+    "def condition_verifiee(game: OrdinalGame, gen: str) -> bool:\n",
+    "    \"\"\"\n",
+    "    Caracterisation etablie : gen preserve game ssi le joueur vise n'a PAS {a,b} dans\n",
+    "    une colonne/ligne, OU cette colonne/ligne n'est la meilleure reponse de l'AUTRE\n",
+    "    joueur dans AUCUNE ligne/colonne (le mur traverse n'est habite par personne).\n",
+    "    \"\"\"\n",
+    "    player, r1, r2 = gen[0], int(gen[1]), int(gen[2])\n",
+    "    if player == \"R\":\n",
+    "        j = colonne_contenant(game, r1, r2)\n",
+    "        return j is None or j not in br_colonne(game)\n",
+    "    i = None\n",
+    "    if {game.col_payoffs[0], game.col_payoffs[1]} == {r1, r2}:\n",
+    "        i = 0\n",
+    "    elif {game.col_payoffs[2], game.col_payoffs[3]} == {r1, r2}:\n",
+    "        i = 1\n",
+    "    return i is None or i not in br_ligne(game)\n",
+    "\n",
+    "\n",
+    "# Etape 1 : la conjecture naive echoue -- mesurons son echec\n",
+    "desaccords_naif = [(g, gen) for g in all_games for gen in GENERATORS\n",
+    "                   if est_morphisme_pour(g, gen) != condition_naive(g, gen)]\n",
+    "print(f\"Conjecture naive testee sur {576 * 6} paires : {len(desaccords_naif)} desaccords\")\n",
+    "g_ex, gen_ex = desaccords_naif[0]\n",
+    "print(f\"  contre-exemple : R={g_ex.row_payoffs} C={g_ex.col_payoffs} + {gen_ex}\")\n",
+    "print(f\"    Nash avant {sorted(find_pure_nash(g_ex))} / apres \"\n",
+    "      f\"{sorted(find_pure_nash(apply_generator(g_ex, gen_ex)))}\"\n",
+    "      f\" -> mur traverse mais equilibres intacts\")\n",
+    "\n",
+    "# Etape 2 : la condition verifiee predit-elle exactement les verdicts ?\n",
+    "accords = desaccords = 0\n",
+    "for g in all_games:\n",
+    "    for gen in GENERATORS:\n",
+    "        if est_morphisme_pour(g, gen) == condition_verifiee(g, gen):\n",
+    "            accords += 1\n",
+    "        else:\n",
+    "            desaccords += 1\n",
+    "            print(f\"  DESACCORD : {g.row_payoffs}/{g.col_payoffs} + {gen}\")\n",
+    "\n",
+    "print(f\"\\nCondition verifiee sur {576 * 6} paires : accords = {accords}, desaccords = {desaccords}\")\n",
+    "assert desaccords == 0, \"la caracterisation echoue sur au moins une paire\"\n",
+    "print(\"La condition predit exactement les 3456 verdicts : theoreme etabli.\")\n",
+    "\n",
+    "# Etape 3 : le compte se DERIVE au lieu d'etre constate\n",
+    "# 16 permutations Ligne sur 24 ne placent pas {1,2} dans une meme colonne\n",
+    "# (les partitions de {1,2,3,4} en deux paires de colonnes : {1,2}|{3,4} garde\n",
+    "# la paire ensemble, {1,3}|{2,4} et {1,4}|{2,3} la separent -- 2 sur 3) ->\n",
+    "# preservation certaine. Pour les 8 autres, il faut que les deux meilleures\n",
+    "# reponses de Colonne pointent hors de la colonne j* : 6 arrangements sur 24.\n",
+    "from itertools import permutations as _perm\n",
+    "sans_paire = [p for p in _perm([1, 2, 3, 4])\n",
+    "              if {p[0], p[2]} != {1, 2} and {p[1], p[3]} != {1, 2}]\n",
+    "print(f\"\\nDerivation pour R12 : {len(sans_paire)} permutations sans paire (sur 24)\")\n",
+    "print(f\"  -> {len(sans_paire)} x 24 = {len(sans_paire) * 24} jeux preserves sans mur\")\n",
+    "print(f\"  + 8 permutations avec paire x 6 arrangements Colonne ou le mur est inhabite\")\n",
+    "print(f\"  = {len(sans_paire) * 24} + {8 * 6} = {len(sans_paire) * 24 + 8 * 6} jeux preserves attendus\")\n",
+    "mesure = sum(est_morphisme_pour(g, \"R12\") for g in all_games)\n",
+    "print(f\"  mesure section 4 : {mesure}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc02f9aa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006144,
+     "end_time": "2026-08-21T23:29:44.167825+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.161681+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : le théorème vérifié — verdict explicite du grain D5\n",
+    "\n",
+    "La scène s'est jouée en deux actes, et c'est elle-même un enseignement :\n",
+    "\n",
+    "- **Acte 1 — la conjecture naïve meurt mesurée.** « Couple adjacent en colonne ⟹ transformation » échoue sur 288 paires : tous les cas de **murs inhabités**. Sur un univers fini, une conjecture ne se discute pas, elle se compte.\n",
+    "- **Acte 2 — la condition vraie prédit les 3456 verdicts sans exception.** $R_{(a,b)}$ transforme $G$ ssi la colonne qui contient $\\{a,b\\}$ dans les gains de Ligne est **aussi** une colonne de meilleure réponse de Colonne. Et le compte s'en **dérive** : $16 \\times 24$ jeux sans mur + $8 \\times 6$ jeux au mur inhabité $= 384 + 48 = 432$ — exactement la mesure de la section 4. Le compte n'est plus un constat, c'est une conséquence.\n",
+    "\n",
+    "**Verdict de l'exercice 3 de l'issue (explicité) :** oui, il existe une condition simple sur le jeu de départ qui prédit la préservation. Elle n'est pas *purement* une condition sur le joueur visé (comme le suggérait l'intuition) : elle **couple les deux tables** — la géométrie des rangs d'un côté, la direction des meilleures réponses de l'autre. C'est plus riche que prévu, et c'est vérifié exhaustivement.\n",
+    "\n",
+    "Relue en langage géométrique : **traverser un mur ne change de chambre Nash que si le mur est habité** — si aucune meilleure réponse de l'autre joueur ne pointe vers la colonne traversée, aucun équilibre ne vivait contre ce mur et le passage est stratégiquement invisible. La grammaire (swaps de rangs) et la géométrie (chambres/murs du grain D2) racontent la même histoire : les transitions se jouent *là où les préférences des deux joueurs se rencontrent*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b30c23c1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00501,
+     "end_time": "2026-08-21T23:29:44.178854+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.173844+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Exercice 3 : la condition survit-elle aux swaps non adjacents ?\n",
+    "\n",
+    "Les six générateurs adjacents engendrent tout $S_4 \\times S_4$, mais la caractérisation de la section 6 a été établie et vérifiée sur eux **seuls**. La tester sur les swaps **non adjacents** $(1,3)$, $(1,4)$, $(2,4)$ est le vrai test de généralité : l'argument (un retournement n'a lieu que dans une colonne contenant les deux rangs échangés, visible seulement si le mur est habité) ne mentionne jamais l'adjacence — donc la même condition devrait tenir telle quelle : *$R_{(a,b)}$ transforme $G$ ssi une colonne contient $\\{a,b\\}$ et cette colonne est une meilleure réponse de Colonne*. À vous de le mesurer — et de vérifier le compte attendu par la même dérivée combinatoire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5f4c7cb3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-21T23:29:44.191629Z",
+     "iopub.status.busy": "2026-08-21T23:29:44.191285Z",
+     "iopub.status.idle": "2026-08-21T23:29:44.197118Z",
+     "shell.execute_reply": "2026-08-21T23:29:44.196457Z"
+    },
+    "papermill": {
+     "duration": 0.014339,
+     "end_time": "2026-08-21T23:29:44.198423+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.184084+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice a completer : generalisation aux swaps non adjacents\n"
+     ]
+    }
+   ],
+   "source": [
+    "def preservations_swap_general(game: OrdinalGame, player: str,\n",
+    "                                a: int, b: int) -> bool:\n",
+    "    # TODO etudiant : generaliser la preservation aux swaps NON adjacents\n",
+    "    # Etape 1 : ecrire le swap (a, b) quelconque cote player (R ou C)\n",
+    "    # Etape 2 : mesurer la preservation comme en section 2\n",
+    "    # Etape 3 : comparer avec la condition generalisee \"aucune colonne/ligne ne contient {a,b}\"\n",
+    "    # Indice : swap_payoffs accepte deja n'importe quelle paire de rangs ;\n",
+    "    #          testez au minimum (1,3), (1,4), (2,4) -- les trois paires non adjacentes\n",
+    "    # Question bonus : chaque swap quelconque preserve-t-il aussi 384 jeux sur 576 ?\n",
+    "    #                  (la derivation combinatoire de la section 6 ne depend pas de l'adjacence)\n",
+    "    return None  # TODO etudiant : remplacer\n",
+    "\n",
+    "\n",
+    "# for paire in [(1, 3), (1, 4), (2, 4)]:\n",
+    "#     print(paire, preservations_swap_general(CLASSIC_GAMES[\"Stag Hunt\"], \"R\", *paire))\n",
+    "print(\"Exercice a completer : generalisation aux swaps non adjacents\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c622f158",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006085,
+     "end_time": "2026-08-21T23:29:44.209952+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.203867+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 8. Synthèse : la Loi III sur un univers fini\n",
+    "\n",
+    "Ce que l'univers fini a permis de trancher, ce que le slogan seul ne pouvait pas :\n",
+    "\n",
+    "1. **La séparation est nette et massive.** Sur 3456 paires (jeu, générateur), 2592 flèches préservent la signature de Nash et 864 la transforment. Aucun générateur n'est morphisme pour tout l'espace : l'espèce d'une flèche est une propriété **de la paire**, jamais du générateur seul ni du jeu seul.\n",
+    "2. **La cause couple les deux tables.** Un swap $R_{(a,b)}$ transforme $G$ si et seulement si une colonne des gains de Ligne contient $\\{a,b\\}$ **et** cette colonne est une colonne de meilleure réponse de Colonne. La conjecture naïve (condition sur le seul joueur visé) est **fausse** — 288 paires de murs inhabités la réfutent, et l'argument réfuté puis corrigé est resté dans le notebook à dessein.\n",
+    "3. **La géométrie et la grammaire coïncident.** Les 100 points fixes de la grammaire (jeux préservés par les six générateurs) et les 16 jeux les plus exposés (quatre générateurs transformateurs) dessinent la topologie de l'espace ; les murs se traversent partout, mais seuls les **murs habités** changent la chambre Nash. La lecture Bruns-Kimmich (grain D2) devient computationnelle.\n",
+    "4. **Prudence triviale.** Les jeux sans équilibre pur préservent trivialement leur ensemble vide — la Loi III est substantielle sur les signatures **non vides**, et l'exercice 2 demande de quantifier cette réserve.\n",
+    "\n",
+    "La strate 7 du voyage ICT (« certaines transformations changent le monde descriptif lui-même ») gagne ici son premier terrain calibré : changer les préférences n'est pas changer d'avis, et l'écart entre les deux se **mesure** — un quart de l'espace par pas de grammaire, seulement quand le mur traversé est habité."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b846364e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.006745,
+     "end_time": "2026-08-21T23:29:44.221850+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.215105+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 9. Résumé\n",
+    "\n",
+    "- **Deux espèces de flèches** coexistent sur l'espace des 576 jeux 2x2 stricts : les swaps de rangs (Robinson-Goforth), qui transforment les préférences, et les morphismes de jeux (Tohmé-Viglizzo), qui transportent les équilibres. Un swap n'est morphisme que **par paire**.\n",
+    "- **Définition finie** : $g$ est morphisme pour $G$ si $\\text{Nash}(G) = \\text{Nash}(g(G))$ (identité sur les profils). Décidable par énumération : 3456 paires.\n",
+    "- **Comptes mesurés** : chaque générateur adjacent préserve 432/576 jeux (75 %) et en transforme 144 ; 100 jeux sont des points fixes de la grammaire, 16 sont exposés à quatre générateurs.\n",
+    "- **Théorème établi** : $R_{(a,b)}$ transforme $G$ ssi une colonne des gains de Ligne contient $\\{a, b\\}$ **et** est meilleure réponse de Colonne dans au moins une ligne (symétrique pour $C$). Vérifié sur les 3456 paires ; le compte 432 s'en **dérive** ($16 \\times 24$ sans mur $+ 8 \\times 6$ au mur inhabité).\n",
+    "- **Contre-exemples exposés** : Stag Hunt et Chicken perdent **strictement** un équilibre (destruction sans compensation) ; le Dilemme ne fait que **déplacer** le sien ; son $R_{34}$ traverse un mur inhabité sans rien changer.\n",
+    "- **Lien aval** : la lecture chambres/murs (grain D2, #12213) est la même structure vue géométriquement ; le chemin minimal certifié (grain D3, #12205 en cible Lean) circulera dans ce graphe dont on sait maintenant quels arcs changent la chambre Nash.\n",
+    "\n",
+    "**A retenir :** *la question « transformation ou morphisme ? » n'a de sens que flèche par flèche — et sur un univers fini, chaque flèche se tranche. Le mur ne compte que s'il est habité.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ba7eae6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004698,
+     "end_time": "2026-08-21T23:29:44.231523+00:00",
+     "exception": false,
+     "start_time": "2026-08-21T23:29:44.226825+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Sources, attribution et dettes de vérification\n",
+    "\n",
+    "- **Robinson, D. & Goforth, D.** (2005), *The Topology of the 2×2 Games* — l'espace des jeux ordinaux stricts et ses swaps élémentaires. La représentation informatique et les 576 jeux viennent de [`GameTheory-3-Topology2x2.ipynb`](GameTheory-3-Topology2x2.ipynb).\n",
+    "- **Tohmé, F. & Viglizzo, I.** — catégories concrètes de jeux (`Gam_I`, `Gam`) pour l'espèce préservante. Cadrage cité depuis le chantier 4 (#12207) ; le présent notebook **réduit** la question morphique au test d'égalité des ensembles de Nash sous l'identité sur les profils — une instanciation, pas la théorie catégorique générale.\n",
+    "- **Bruns, B.** — transmutations et lecture chambres/murs, développées dans le grain D2 (#12213).\n",
+    "- **Dettes de vérification héritées du chantier 4** (statut RAPPORTÉ, non établi ici) : le quotient 576 → 144 et le tore à 37 trous sont cités par la source sans dérivation ; ce notebook travaille sur les **576 jeux complets** (sur ensemble du quotient, donc sans le supposer) et le compte par générateur en est indépendant. Les trois références arXiv du chantier n'ont pas été ouvertes firsthand.\n",
+    "\n",
+    "See #12237 · See #12207 (chantier 4) · See #12213 (grain D2, chambres et murs)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 3.308835,
+   "end_time": "2026-08-21T23:29:44.497322+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-21-Deux-Especes-de-Fleches.ipynb",
+   "output_path": "GameTheory-21-Deux-Especes-de-Fleches_output_20260822_012941.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-21T23:29:41.188487+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA — prev: MED/qc #12217

## Summary

Nouveau notebook **`GameTheory-21-Deux-Especes-de-Fleches.ipynb`** — grain **D5 du chantier 4** (#12207), tiré du picker (issue #12237, claim c.5376378205). La question de la Loi III — *quand une transformation est-elle aussi un morphisme ?* — rendue finie et décidable sur l'espace des 576 jeux 2x2 stricts × 6 générateurs adjacents (3456 paires).

**Résultats (tous mesurés dans les outputs commités) :**

- **Définition finie** du morphisme pour cet univers : `Nash(G) == Nash(g(G))` sous identité sur les profils (un swap ne déplace aucune stratégie — réduction honnête, argumentée en §1).
- **Énumération exhaustive** : chaque générateur préserve **432/576 jeux (75 %)**, en transforme 144 ; 2592/3456 paires préservantes ; distribution par jeu {0:100, 1:200, 2:180, 3:80, 4:16} ; **100 points fixes** de la grammaire.
- **Contre-exemples concrets** (acceptance ex. 1) : le Dilemme **déplace** son équilibre (R12/C12) mais le **préserve** sous R34 (mur traversé, inhabité) ; **Stag Hunt et Chicken subissent des destructions strictes** (perte d'un équilibre sans compensation, 4 générateurs chacun).
- **Théorème établi** (acceptance ex. 2+3) : un swap R(a,b) transforme G ssi une colonne des gains de Ligne contient {a,b} **et** cette colonne est meilleure réponse de Colonne dans au moins une ligne — *le mur ne compte que s'il est habité*. La **conjecture naïve** (condition sur le seul joueur visé) est d'abord présentée puis **réfutée mesurée** (288 désaccords) ; la condition vraie prédit les **3456/3456** verdicts (assertion) et le compte 432 s'en **dérive** (16×24 + 8×6 = 384+48).
- Verdict explicite de caractérisation : **condition simple trouvée et vérifiée exhaustivement** — elle couple les deux tables (géométrie des rangs × direction des meilleures réponses), plus riche que l'intuition initiale.

3 exercices étudiant stubbés (C.1 : `return []`/`return None`/`return {}` + `# TODO etudiant` + `# Etape N` + `# Indice`, le notebook s'exécute de bout en bout non complété) ; 1 « Exemple résolu » (jamais « Exercice corrigé »).

## Validation (post-dernier-commit 3e3e2dd81)

- **Exécution réelle** : kernel `python3` via papermill — **10/10 cellules code, 0 erreur**, séquence `1..10` CLEAN, outputs réels commités (chaque nombre de la prose ancré aux outputs : 432/144, 288 désaccords naïfs, 3456 accords, dérivation 384+48, distribution, destructions SH/CH, régimes PD)
- **C.1** : 0 `raise NotImplementedError` / `assert False` / `1/0`
- **C.2** : 10/10 cellules `execution_count != null` + outputs cohérents ; `metadata.papermill` normalisé au basename (exception permise)
- **Guard markdown** : `detect_markdown_rendering --check` → OK (aucun `---` de tête de cellule ; LaTeX et tableaux vérifiés au rendu)
- `nbformat.validate` OK (30 cellules, v4.5 ids) ; 3 exercices détectés ; densité `pedagogy_density.py` = **2353 chars/cell**
- **Machinerie réutilisée de GT-3** (représentation OrdinalGame, conventions, encodages classiques identiques — cellules citées) ; dettes de vérification du chantier 4 (quotient 576→144, tore 37 trous, arXiv non ouverts) explicitement rapportées RAPPORTÉ en §Sources, le notebook travaille sur les 576 complets sans supposer le quotient
- Catalogue byte-identique à main (nouveau fichier seulement ; entrée catalogue = cron <24h, pas d'inscription manuelle) ; L898 vérifié : seule PR GameTheory ouverte (#12241) = renommages 01-09, zéro intersection de fichiers

See #12237 (grain livré intégralement : les 3 critères d'acceptance satisfaits) · Closes #12237

Co-Authored-By: Claude-Code <noreply@anthropic.com>
