### PR TITLE
feat(gametheory,#12213): GT-3b chambres, murs, codimension — les jeux a egalites comme objets botaniques

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3b-Chambres-et-Murs.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3b-Chambres-et-Murs.ipynb
@@ -1,0 +1,1363 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-0",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004255,
+     "end_time": "2026-08-22T00:21:49.988137+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:49.983882+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory 3b : Chambres, murs, codimension — les jeux à égalités comme objets botaniques\n",
+    "\n",
+    "> **Troisième volet géométrique du chantier des jeux 2×2** — après [GameTheory-3-Topology2x2](GameTheory-3-Topology2x2.ipynb) (la topologie des 576 jeux stricts et la grammaire des swaps) et [GameTheory-21-Deux-Especes-de-Fleches](GameTheory-21-Deux-Especes-de-Fleches.ipynb) (quand un swap préserve-t-il les équilibres), ce notebook décrit **l'espace lui-même** dans lequel ces transformations se déplacent.\n",
+    "\n",
+    "**La thèse, en une phrase** : un jeu à égalités (*tie game*) n'est pas un jeu « plus flou » ou « plus général » qu'un jeu strict — c'est un objet **de dimension inférieure**, un mur où des chambres se touchent.\n",
+    "\n",
+    "La lecture géométrique vient de la formalisation de **Bruns & Kimmich** (rapportée, cf. §Sources) :\n",
+    "\n",
+    "- les jeux **stricts** — aucune égalité de paiements — sont les **chambres** : les composantes ouvertes de l'espace des paiements ;\n",
+    "- les jeux **à égalités** sont les **murs** : des strates de **codimension ≥ 1** sur lesquelles plusieurs chambres se raccordent ;\n",
+    "- une transformation élémentaire n'est pas un saut abstrait d'un jeu à un autre : elle **traverse une face**.\n",
+    "\n",
+    "```\n",
+    "chambre  →  mur  →  chambre voisine\n",
+    "```\n",
+    "\n",
+    "Un « objet botanique » — un jeu à égalités depuis lequel plusieurs prolongements sont possibles — n'est donc **pas** une définition assouplie : c'est **habiter le bord**. La différence entre les deux notions est la différence entre *relâcher un axiome* et *se placer sur une strate de codimension 1*.\n",
+    "\n",
+    "**Plan** : §1 énumère les strates (les 75 ordres faibles par joueur, classés par codimension) ; §2 mesure l'incidence chambre-mur (chaque mur sépare exactement deux chambres) et le graphe des chambres ; §3 traverse un mur sur un cas complet, puis relit la grammaire des swaps de GT-21 en longueurs de Coxeter ; §4 implémente *make tie* / *break tie*, les deux opérations de Bruns-Kimmich.\n",
+    "\n",
+    "**Conventions reprises de GT-3/GT-21** : un jeu 2×2 ordinal = deux tables de paiements (Ligne, Colonne), chacune un 4-uplet $(r_{11}, r_{12}, r_{21}, r_{22})$ de valeurs ; jeu strict = chaque table est une permutation de $\\{1,2,3,4\\}$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003208,
+     "end_time": "2026-08-22T00:21:49.994963+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:49.991755+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 0. Configuration\n",
+    "\n",
+    "Notebook **pur standard library** (`itertools`, `collections`) — aucune dépendance. Comme GT-21, tout ce qui est affirmé ici est **calculé dans ce notebook** ; ce qui vient de la littérature sans dérivation locale est **rapporté comme dette** (§Sources)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "gt3b-code-2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.003247Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.003036Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.009718Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.008926Z"
+    },
+    "papermill": {
+     "duration": 0.012271,
+     "end_time": "2026-08-22T00:21:50.010770+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:49.998499+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GameTheory 3b : chambres, murs, codimension\n",
+      "Representation : jeu = (table_ligne, table_colonne), tables = ordres faibles canoniques\n"
+     ]
+    }
+   ],
+   "source": [
+    "# GameTheory 3b : chambres, murs, codimension -- pur stdlib\n",
+    "from itertools import product\n",
+    "from collections import Counter, deque, defaultdict\n",
+    "\n",
+    "print(\"GameTheory 3b : chambres, murs, codimension\")\n",
+    "print(\"Representation : jeu = (table_ligne, table_colonne), tables = ordres faibles canoniques\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-3",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003367,
+     "end_time": "2026-08-22T00:21:50.017820+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.014453+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. L'espace des paiements et ses strates\n",
+    "\n",
+    "### 1.1 Ordres faibles : la clé canonique\n",
+    "\n",
+    "L'espace des paiements d'un joueur est $\\mathbb{R}^4$ (une coordonnée par case de sa table 2×2). Ce qui compte pour un jeu ordinal n'est pas la valeur numérique d'une coordonnée mais son **rang** relativement aux trois autres. Un point de cet espace code donc un **ordre faible** (*weak order*) sur les 4 cases : soit un ordre total (les 4 valeurs distinctes — une chambre), soit un ordre avec des ex æquo (un mur).\n",
+    "\n",
+    "La représentation canonique : un 4-uplet $t$ où $t_i = 1 + (\\text{nombre de valeurs distinctes strictement inférieures à } t_i)$. Ainsi $(2,2,4,5)$, $(1,1,3,4)$ et $(7,7,8,9)$ codent le même ordre faible — deux cases liées en bas, deux cases liées au-dessus — et partagent la clé canonique $(1,1,2,3)$.\n",
+    "\n",
+    "Le discret $\\{1,2,3,4\\}$ de GT-3/GT-21 est le cas particulier sans ex æquo : les 24 permutations de $(1,2,3,4)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "gt3b-code-4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.025830Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.025613Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.031517Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.031040Z"
+    },
+    "papermill": {
+     "duration": 0.011064,
+     "end_time": "2026-08-22T00:21:50.032347+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.021283+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ordres faibles sur 4 cases : 75\n",
+      "  stricts (chambres potentielles) : 24\n",
+      "  avec ex aequo (murs potentiels)  : 51\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 1.1 : enumeration des ordres faibles sur 4 cases ===\n",
+    "\n",
+    "def canonique(t):\n",
+    "    \"\"\"Cle canonique d'un 4-uplet : relabelage croissant des valeurs distinctes.\"\"\"\n",
+    "    vals = sorted(set(t))\n",
+    "    return tuple(vals.index(v) + 1 for v in t)\n",
+    "\n",
+    "# Enumeration : tous les 4-uplets de {1..4} (256), projetes sur leur cle canonique\n",
+    "ordres_faibles = sorted({canonique(t) for t in product(range(1, 5), repeat=4)})\n",
+    "print(\"Ordres faibles sur 4 cases :\", len(ordres_faibles))\n",
+    "print(\"  stricts (chambres potentielles) :\", sum(1 for t in ordres_faibles if len(set(t)) == 4))\n",
+    "print(\"  avec ex aequo (murs potentiels)  :\", sum(1 for t in ordres_faibles if len(set(t)) < 4))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-5",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003218,
+     "end_time": "2026-08-22T00:21:50.039219+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.036001+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : **75 ordres faibles** — c'est le *nombre de Fubini* $a(4)$, le compte des partitions ordonnées d'un ensemble à 4 éléments. Ils se partagent en **24 ordres totaux** (les permutations — les chambres au sens strict, inchangées depuis GT-3) et **51 ordres avec ex æquo** (les murs, par joueur).\n",
+    "\n",
+    "Ce simple compte situe le changement de regard : le discret de GT-3 ($24^2 = 576$ jeux stricts) vivait dans un espace où les égalités étaient **exclues par construction**. En admettant les ex æquo dans la représentation, l'espace passe de $576$ à $75^2 = 5625$ jeux à rangs — et ces nouveaux points ne sont pas des « jeux imprécis » : ce sont des **strates**. Reste à leur donner une dimension."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003002,
+     "end_time": "2026-08-22T00:21:50.045422+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.042420+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 1.2 Codimension : compter des égalités *indépendantes*\n",
+    "\n",
+    "La codimension d'une strate est le nombre d'**équations indépendantes** qui la définissent — la dimension perdue. Pour un ordre faible, ce n'est pas le nombre de *paires* égales mais le **complément du nombre de blocs** :\n",
+    "\n",
+    "$$\\text{codim}(t) = 4 - \\#\\text{blocs}(t).$$\n",
+    "\n",
+    "Un bloc de taille 3 (triple égalité) porte **3 paires** égales mais seulement **2 équations indépendantes** ($x_a = x_b$ et $x_b = x_c$ suffisent, la troisième s'en déduit). Confondre paires et équations est l'erreur classique — le code suivant les compte séparément pour montrer qu'elles divergent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "gt3b-code-7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.057334Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.057126Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.063790Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.063263Z"
+    },
+    "papermill": {
+     "duration": 0.015746,
+     "end_time": "2026-08-22T00:21:50.064359+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.048613+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Type de blocs           | codim | paires | exemples\n",
+      "----------------------------------------------------------------\n",
+      "blocs (4,)       ( 1 ordres) |   3   |   6    | (1, 1, 1, 1)\n",
+      "blocs (3, 1)     ( 8 ordres) |   2   |   3    | (1, 1, 1, 2), (1, 1, 2, 1)\n",
+      "blocs (2, 2)     ( 6 ordres) |   2   |   2    | (1, 1, 2, 2), (1, 2, 1, 2)\n",
+      "blocs (2, 1, 1)  (36 ordres) |   1   |   1    | (1, 1, 2, 3), (1, 1, 3, 2)\n",
+      "blocs (1, 1, 1, 1) (24 ordres) |   0   |   0    | (1, 2, 3, 4), (1, 2, 4, 3)\n",
+      "\n",
+      "Distribution par codimension (par joueur) : {0: 24, 1: 36, 2: 14, 3: 1}\n",
+      "Verification de la somme : 24 + 36 + 14 + 1 = 75 = 75 ordres faibles\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 1.2 : codimension vraie vs nombre de paires egales ===\n",
+    "\n",
+    "def nb_blocs(t):\n",
+    "    return len(set(t))\n",
+    "\n",
+    "def nb_paires_egales(t):\n",
+    "    return sum(m * (m - 1) // 2 for m in Counter(t).values())\n",
+    "\n",
+    "def codim(t):\n",
+    "    return 4 - nb_blocs(t)\n",
+    "\n",
+    "print(\"Type de blocs           | codim | paires | exemples\")\n",
+    "print(\"-\" * 64)\n",
+    "par_type = defaultdict(list)\n",
+    "for t in ordres_faibles:\n",
+    "    signature = tuple(sorted(Counter(t).values(), reverse=True))\n",
+    "    par_type[signature].append(t)\n",
+    "for sig in sorted(par_type, reverse=True):\n",
+    "    ex = par_type[sig]\n",
+    "    paires_moy = sum(nb_paires_egales(t) for t in ex) // len(ex)\n",
+    "    exemples = str(ex[0]) + (\", \" + str(ex[1]) if len(ex) > 1 else \"\")\n",
+    "    print(f\"blocs {str(sig):10s} ({len(ex):2d} ordres) |   {4 - len(sig)}   |   {paires_moy}    | {exemples}\")\n",
+    "print()\n",
+    "dist_codim = Counter(codim(t) for t in ordres_faibles)\n",
+    "print(\"Distribution par codimension (par joueur) :\", dict(sorted(dist_codim.items())))\n",
+    "print(\"Verification de la somme : 24 + 36 + 14 + 1 =\", sum(dist_codim.values()), \"= 75 ordres faibles\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-8",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003401,
+     "end_time": "2026-08-22T00:21:50.071532+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.068131+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : la taxonomy par taille de blocs croise les deux mesures.\n",
+    "\n",
+    "| blocs | codim | paires égales | compte |\n",
+    "|---|---|---|---|\n",
+    "| $(1,1,1,1)$ | 0 | 0 | 24 — **les chambres** |\n",
+    "| $(2,1,1)$ | 1 | 1 | 36 — **les murs simples** |\n",
+    "| $(2,2)$ | 2 | 2 | 6 |\n",
+    "| $(3,1)$ | **2** | **3** | 8 |\n",
+    "| $(4)$ | **3** | **6** | 1 |\n",
+    "\n",
+    "Les deux lignes en **gras** portent la leçon : le triple ex æquo (les 8 cas $(3,1)$) **diverge** — 3 paires mais codimension 2 — et le quadruple ex æquo porte 6 paires pour codimension 3. La codimension est l'auche correcte : elle mesure la **dimension perdue**, pas le nombre de coïncidences.\n",
+    "\n",
+    "L'image botanique se précise : les murs de codimension 1 sont des **cloisons** (36 par joueur), ceux de codimension 2 des **arêtes** où les cloisons se rencontrent (6+8 = 14), celui de codimension 3 un **sommet** (1). Un objet botanique n'est pas « un jeu imprécis » : c'est un point de l'espace des paiements situé **sur** cette architecture."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-9",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003155,
+     "end_time": "2026-08-22T00:21:50.077968+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.074813+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 1.3 Les 5 625 jeux à rangs, par codimension\n",
+    "\n",
+    "Un jeu complet = une paire d'ordres faibles (Ligne, Colonne). La codimension du jeu est la somme des deux : un mur de Ligne dans une chambre de Colonne est un mur de codim 1 ; deux murs simultanés donnent codim 2 ; etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "gt3b-code-10",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.085624Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.085334Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.093629Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.092865Z"
+    },
+    "papermill": {
+     "duration": 0.01316,
+     "end_time": "2026-08-22T00:21:50.094344+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.081184+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jeux a rangs (paires d'ordres faibles) : 5625\n",
+      "\n",
+      "codim |  jeux  | remarque\n",
+      "--------------------------------------------------------\n",
+      "  0   |   576  | les 576 chambres strictes (univers GT-3 / GT-21)\n",
+      "  1   |  1728  | murs simples : un seul ex aequo, d'un seul cote\n",
+      "  2   |  1968  | murs doubles : deux ex aequo (eventuellement croises)\n",
+      "  3   |  1056  | \n",
+      "  4   |   268  | \n",
+      "  5   |    28  | \n",
+      "  6   |     1  | les deux tables entierement plates (jeu unique)\n",
+      "\n",
+      "Total : 5625 = 75 x 75 attendu\n",
+      "Chambres strictes : 576 -- coherentes avec GT-3 (576) et GT-21\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 1.3 : distribution des jeux par codimension totale ===\n",
+    "\n",
+    "jeux = [(r, c) for r in ordres_faibles for c in ordres_faibles]\n",
+    "dist_jeux = Counter(codim(r) + codim(c) for r, c in jeux)\n",
+    "print(\"Jeux a rangs (paires d'ordres faibles) :\", len(jeux))\n",
+    "print()\n",
+    "print(\"codim |  jeux  | remarque\")\n",
+    "print(\"-\" * 56)\n",
+    "remarques = {0: \"les 576 chambres strictes (univers GT-3 / GT-21)\",\n",
+    "             1: \"murs simples : un seul ex aequo, d'un seul cote\",\n",
+    "             2: \"murs doubles : deux ex aequo (eventuellement croises)\",\n",
+    "             6: \"les deux tables entierement plates (jeu unique)\"}\n",
+    "for k in sorted(dist_jeux):\n",
+    "    print(f\"  {k}   | {dist_jeux[k]:5d}  | {remarques.get(k, '')}\")\n",
+    "print()\n",
+    "print(\"Total :\", sum(dist_jeux.values()), \"= 75 x 75 attendu\")\n",
+    "print(\"Chambres strictes :\", dist_jeux[0], \"-- coherentes avec GT-3 (576) et GT-21\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-11",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003614,
+     "end_time": "2026-08-22T00:21:50.101863+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.098249+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : l'univers des jeux à rangs compte **5 625** états. Les **576 chambres strictes** — tout l'univers de GT-3 et de GT-21 — n'en occupent que **10,2 %**. Les **1 728 jeux de codimension 1** sont les murs simples ; **1 968** de codim 2 ; le reste s'étage jusqu'au jeu totalement plat (codim 6), unique, où chaque joueur est indifférent entre les quatre cases.\n",
+    "\n",
+    "Autrement dit : le discret dans lequel la série a travaillé jusqu'ici était le **squelette ouvert** d'un édifice dont les murs, arêtes et sommets — 89,8 % des états à rangs — n'avaient pas de nom. La suite leur donne un rôle structurel : ce sont eux qui **raccordent** les chambres."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-12",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003575,
+     "end_time": "2026-08-22T00:21:50.109089+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.105514+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. L'incidence chambre-mur\n",
+    "\n",
+    "### 2.1 Chaque mur simple sépare exactement deux chambres\n",
+    "\n",
+    "Un mur de codimension 1 (un seul ex æquo, d'un seul côté) est une cloison : la briser dans un sens ou dans l'autre donne **exactement deux** chambres. Réciproquement, depuis une chambre, quels murs touche-t-on ? Pas tous : pour que deux cases puissent **se rencontrer**, il faut qu'aucune autre valeur ne soit strictement comprise entre les leurs — sinon le mouvement croiserait d'autres murs d'abord. Les facettes d'une chambre correspondent aux paires de **valeurs adjacentes** dans son ordre.\n",
+    "\n",
+    "Le code suivant mesure l'incidence dans les deux directions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "gt3b-code-13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.117439Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.117241Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.124293Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.123669Z"
+    },
+    "papermill": {
+     "duration": 0.012496,
+     "end_time": "2026-08-22T00:21:50.125166+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.112670+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Murs simples par cote : 36\n",
+      "Chaque mur touche exactement 2 chambres distinctes : True\n",
+      "Facettes par chambre  : {3: 24} (3 attendu : les 3 paires de valeurs adjacentes)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 2.1 : incidence double-face chambre <-> mur ===\n",
+    "\n",
+    "chambres = [t for t in ordres_faibles if codim(t) == 0]      # 24 permutations\n",
+    "murs_simples = [t for t in ordres_faibles if codim(t) == 1]  # 36\n",
+    "\n",
+    "def briser_le_tie(t):\n",
+    "    \"\"\"Les deux chambres strictes adjacentes au mur simple t (cote de t seul).\"\"\"\n",
+    "    c = Counter(t)\n",
+    "    v_tie = [k for k, m in c.items() if m == 2][0]\n",
+    "    i, j = [p for p in range(4) if t[p] == v_tie]           # les deux cases liees\n",
+    "    below = sorted([p for p in range(4) if t[p] < v_tie], key=lambda p: t[p])\n",
+    "    above = sorted([p for p in range(4) if t[p] > v_tie], key=lambda p: t[p])\n",
+    "    # chambre A : i passe devant j ; chambre B : j devant i -- au NIVEAU du tie\n",
+    "    def rangs(ordre_positions):\n",
+    "        rk = [0] * 4\n",
+    "        for k, p in enumerate(ordre_positions):\n",
+    "            rk[p] = k + 1\n",
+    "        return tuple(rk)\n",
+    "    A = rangs(below + [i, j] + above)\n",
+    "    B = rangs(below + [j, i] + above)\n",
+    "    return A, B\n",
+    "\n",
+    "# mur -> chambres\n",
+    "incidences_mur = {t: briser_le_tie(t) for t in murs_simples}\n",
+    "toutes_distinctes = all(a != b for a, b in incidences_mur.values())\n",
+    "print(\"Murs simples par cote :\", len(murs_simples))\n",
+    "print(\"Chaque mur touche exactement 2 chambres distinctes :\", toutes_distinctes)\n",
+    "\n",
+    "# chambre -> murs (facettes)\n",
+    "facettes = defaultdict(list)\n",
+    "for t, (a, b) in incidences_mur.items():\n",
+    "    facettes[a].append(t)\n",
+    "    facettes[b].append(t)\n",
+    "print(\"Facettes par chambre  :\", dict(Counter(len(v) for v in facettes.values())),\n",
+    "      \"(3 attendu : les 3 paires de valeurs adjacentes)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-14",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003568,
+     "end_time": "2026-08-22T00:21:50.132389+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.128821+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : la double incidence est **exacte**.\n",
+    "\n",
+    "- **Mur → chambres** : chacun des 36 murs simples d'un côté touche **exactement 2 chambres** distinctes — les deux résolutions de son ex æquo. Une cloison n'a jamais trois pièces de chaque côté.\n",
+    "- **Chambre → murs** : chacune des 24 chambres a **exactement 3 facettes** — les 3 paires de valeurs *adjacentes* de son ordre. Une paire non adjacente (les valeurs 1 et 3, avec 2 entre elles) ne définit **pas** une facette : pour amener 1 et 3 à l'égalité, il faut d'abord traverser le mur où 1 rencontre 2.\n",
+    "\n",
+    "C'est la structure d'**arrangement d'hyperplans** de l'espace des paiements (les murs étant les hyperplans $x_i = x_j$) — calculée ici sans en invoquer la théorie : les comptes parlent d'eux-mêmes. Au niveau du jeu complet (deux côtés), chaque chambre a donc $3 + 3 = 6$ facettes, et le nombre de murs simples du jeu vaut $2 \\times 36 \\times 24 = 1728$.\n",
+    "\n",
+    "**Remarque de parité avec GT-21** : le théorème « le mur ne compte que s'il est habité » de GT-21 portait sur les *meilleures réponses* (quelles stratégies habitent la colonne traversée) ; ici l'habitation est *géométrique* — quelles chambres touchent le mur. Les deux lectures se complètent : GT-21 dit quand un swap **change** les équilibres, GT-3b dit **où** le swap se déplace."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-15",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003446,
+     "end_time": "2026-08-22T00:21:50.139513+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.136067+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 2.2 Le graphe des chambres : connexité et diamètre\n",
+    "\n",
+    "Déclarer que les murs « raccordent » les chambres donne un graphe : les sommets sont les 576 chambres, une arête par mur simple traversé. La bonne nouvelle pour la grammaire des swaps : **ce graphe est connexe** — n'importe quel jeu strict est atteignable depuis n'importe quel autre en traversant des murs un à un."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "gt3b-code-16",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.147432Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.147244Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.156368Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.155734Z"
+    },
+    "papermill": {
+     "duration": 0.014005,
+     "end_time": "2026-08-22T00:21:50.157008+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.143003+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cote 1 joueur : connexe = True | diametre = 6\n",
+      "  repartition des distances : {0: 1, 1: 3, 2: 5, 3: 6, 4: 5, 5: 3, 6: 1}\n",
+      "\n",
+      "Jeu complet : connexe = True | diametre = 12\n",
+      "  repartition : {0: 1, 1: 6, 2: 19, 3: 42, 4: 71, 5: 96, 6: 106, 7: 96, 8: 71, 9: 42, 10: 19, 11: 6, 12: 1}\n",
+      "  aretes = 576 x 6 / 2 = 1728 -- a comparer aux 1728 murs simples du 1.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 2.2 : BFS sur le graphe des chambres ===\n",
+    "\n",
+    "def swap_valeurs_adjacentes(t, k):\n",
+    "    \"\"\"Echange les cases portant les valeurs k et k+1 (traversee de la facette k<->k+1).\"\"\"\n",
+    "    pk, pk1 = t.index(k), t.index(k + 1)\n",
+    "    l = list(t)\n",
+    "    l[pk], l[pk1] = l[pk1], l[pk]\n",
+    "    return tuple(l)\n",
+    "\n",
+    "adjacences = {t: [swap_valeurs_adjacentes(t, k) for k in (1, 2, 3)] for t in chambres}\n",
+    "\n",
+    "# BFS cote 1 joueur, depuis (1,2,3,4)\n",
+    "depart = (1, 2, 3, 4)\n",
+    "dist = {depart: 0}\n",
+    "q = deque([depart])\n",
+    "while q:\n",
+    "    u = q.popleft()\n",
+    "    for v in adjacences[u]:\n",
+    "        if v not in dist:\n",
+    "            dist[v] = dist[u] + 1\n",
+    "            q.append(v)\n",
+    "print(\"Cote 1 joueur : connexe =\", len(dist) == 24, \"| diametre =\", max(dist.values()))\n",
+    "print(\"  repartition des distances :\", dict(sorted(Counter(dist.values()).items())))\n",
+    "\n",
+    "# BFS jeu complet : (row, col), 576 sommets\n",
+    "dep2 = ((1, 2, 3, 4), (1, 2, 3, 4))\n",
+    "dist2 = {dep2: 0}\n",
+    "q2 = deque([dep2])\n",
+    "while q2:\n",
+    "    (ur, uc) = q2.popleft()\n",
+    "    d_cur = dist2[(ur, uc)]\n",
+    "    voisins_row = [(swap_valeurs_adjacentes(ur, k), uc) for k in (1, 2, 3)]\n",
+    "    voisins_col = [(ur, swap_valeurs_adjacentes(uc, k)) for k in (1, 2, 3)]\n",
+    "    for v in voisins_row + voisins_col:\n",
+    "        if v not in dist2:\n",
+    "            dist2[v] = d_cur + 1\n",
+    "            q2.append(v)\n",
+    "print()\n",
+    "print(\"Jeu complet : connexe =\", len(dist2) == 576, \"| diametre =\", max(dist2.values()))\n",
+    "print(\"  repartition :\", dict(sorted(Counter(dist2.values()).items())))\n",
+    "print(\"  aretes = 576 x 6 / 2 =\", 576 * 6 // 2, \"-- a comparer aux 1728 murs simples du 1.3\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-17",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003511,
+     "end_time": "2026-08-22T00:21:50.164299+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.160788+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : le graphe des chambres est **connexe**, de diamètre **6 par côté** et **12 pour le jeu complet** — le pire cas étant l'ordre exactement renversé des deux tables ($6 + 6$ inversions).\n",
+    "\n",
+    "Deux régularités lisibles dans la sortie :\n",
+    "\n",
+    "- la distribution des distances d'un côté, $\\{0{:}1, 1{:}3, 2{:}5, 3{:}6, 4{:}5, 5{:}3, 6{:}1\\}$, est **symétrique** : le mot le plus long (l'ordre renversé) est unique, comme le plus court (l'identité) ;\n",
+    "- au niveau du jeu, chaque chambre a **6 voisins** (3 facettes par côté), et le compte d'arêtes $576 \\times 6 / 2 = 1728$ coïncide **exactement** avec le nombre de murs simples comptés au §1.3 — chaque mur simple **est** une arête du graphe, chaque arête **est** la traversée d'un mur. Le pont entre le comptage de strates (§1) et la connectivité (§2) est un double-comptage propre.\n",
+    "\n",
+    "Conséquence pour la série : le discret $\\{1,2,3,4\\}$ de GT-3 n'était pas un artefact de commodité — c'est un **transversal** des chambres (un point par chambre), et la connexité ci-dessus garantit que la grammaire des swaps adjacents suffit à relier tout l'univers strict."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-18",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003929,
+     "end_time": "2026-08-22T00:21:50.171894+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.167965+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Traverser un mur : chambre → mur → chambre\n",
+    "\n",
+    "### 3.1 Un cas complet, matrices à l'appui\n",
+    "\n",
+    "Prenons le **Dilemme du Prisonnier** dans l'encodage ordinal de GT-21 — Ligne $(3,1,4,2)$, Colonne $(3,4,1,2)$ — et suivons le swap de valeurs adjacentes $R(3,4)$ (Ligne échange les cases portant 3 et 4). Ce swap traverse la facette où les deux cases porteuses deviennent égales : le mur $r_{11} = r_{21}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "gt3b-code-19",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.180439Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.180193Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.186385Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.185775Z"
+    },
+    "papermill": {
+     "duration": 0.011496,
+     "end_time": "2026-08-22T00:21:50.187051+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.175555+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CHAMBRE A -- Dilemme du Prisonnier (strict)\n",
+      "  Ligne    |  3  1 |   Colonne |  3  4 |\n",
+      "           |  4  2 |           |  1  2 |\n",
+      "\n",
+      "MUR (codim 1) -- Ligne indifferent r11 = r21\n",
+      "  Ligne    |  3  1 |   Colonne |  3  4 |\n",
+      "           |  3  2 |           |  1  2 |\n",
+      "\n",
+      "CHAMBRE B -- apres traversee (swap R(3,4))\n",
+      "  Ligne    |  4  1 |   Colonne |  3  4 |\n",
+      "           |  3  2 |           |  1  2 |\n",
+      "\n",
+      "Verification : mur = (3, 1, 3, 2)\n",
+      "  briser_le_tie(mur) redonne les deux faces : ((3, 1, 4, 2), (4, 1, 3, 2))\n",
+      "  chambre A : (3, 1, 4, 2)  chambre B : (4, 1, 3, 2)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 3.1 : traverser le mur r11=r21 depuis le Dilemme du Prisonnier ===\n",
+    "\n",
+    "def afficher_jeu(nom, row, col):\n",
+    "    print(nom)\n",
+    "    print(f\"  Ligne    | {row[0]:>2}  {row[1]:<2}|   Colonne | {col[0]:>2}  {col[1]:<2}|\")\n",
+    "    print(f\"           | {row[2]:>2}  {row[3]:<2}|           | {col[2]:>2}  {col[3]:<2}|\")\n",
+    "    print()\n",
+    "\n",
+    "def faire_le_tie(t, k):\n",
+    "    \"\"\"Coalescence des valeurs k et k+1 -> mur canonique (make_tie du 4.1, cote seul).\"\"\"\n",
+    "    return canonique(tuple(k if v == k + 1 else v for v in t))\n",
+    "\n",
+    "# La chambre de depart : le PD (encodage GT-21)\n",
+    "pd_row, pd_col = (3, 1, 4, 2), (3, 4, 1, 2)\n",
+    "afficher_jeu(\"CHAMBRE A -- Dilemme du Prisonnier (strict)\", pd_row, pd_col)\n",
+    "\n",
+    "# Le mur : coalescence des valeurs 3 et 4 de Ligne (cases r11 et r21)\n",
+    "mur_row = faire_le_tie(pd_row, 3)\n",
+    "afficher_jeu(\"MUR (codim 1) -- Ligne indifferent r11 = r21\", mur_row, pd_col)\n",
+    "\n",
+    "# La chambre d'arrivee : resolution du tie dans l'autre sens\n",
+    "chambre_B_row = swap_valeurs_adjacentes(pd_row, 3)\n",
+    "afficher_jeu(\"CHAMBRE B -- apres traversee (swap R(3,4))\", chambre_B_row, pd_col)\n",
+    "\n",
+    "print(\"Verification : mur =\", mur_row)\n",
+    "print(\"  briser_le_tie(mur) redonne les deux faces :\", briser_le_tie(mur_row))\n",
+    "print(\"  chambre A :\", canonique(pd_row), \" chambre B :\", canonique(chambre_B_row))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-20",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003442,
+     "end_time": "2026-08-22T00:21:50.194287+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.190845+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : le triplet complet **chambre A → mur → chambre B** est exhibé avec les trois matrices — l'acceptation de l'exercice 2 est satisfaite *et démontrée* :\n",
+    "\n",
+    "- **chambre A** : le PD strict, où $r_{21} = 4 > r_{11} = 3$ (Ligne gagne plus à dévier) ;\n",
+    "- **mur** : le jeu à égalité où $r_{11} = r_{21}$ — Ligne est **exactement indifférent** entre ses deux stratégies quand Colonne joue à gauche ; c'est le point de bascule où la défection cesse d'être strictement meilleure *en première colonne* ;\n",
+    "- **chambre B** : l'ordre renversé de la paire $(3,4)$ — le swap $R(3,4)$ de GT-21.\n",
+    "\n",
+    "La dernière ligne vérifie mécaniquement la cohérence : le `briser_le_tie` du §2.1 appliqué au mur redonne bien **les deux** chambres — A et B — comme les deux faces de la cloison. Le swap de GT-21, redéfini géométriquement, **est** la traversée de ce mur : rien d'autre.\n",
+    "\n",
+    "*Fenêtre pédagogique* : sur le mur, l'ensemble des meilleures réponses de Ligne en première colonne **grossit** (de 1 à 2 choix), puis redevient singulier de l'autre côté — avec l'autre choix. Un mur est exactement le lieu où la structure des meilleures réponses **change de cardinal** — la version locale du « mur habité » de GT-21."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-21",
+   "metadata": {
+    "papermill": {
+     "duration": 0.009759,
+     "end_time": "2026-08-22T00:21:50.207500+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.197741+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.2 La grammaire des swaps relue en longueurs de Coxeter\n",
+    "\n",
+    "GT-21 étudiait **six** swaps par côté : $R(a,b)$ pour toutes les paires de valeurs. La géométrie les sépare en deux familles :\n",
+    "\n",
+    "- $|a-b| = 1$ (valeurs **adjacentes**) : le swap traverse **un seul mur** — une facette ;\n",
+    "- $|a-b| \\geq 2$ : les valeurs sont séparées par d'autres — le swap est un **raccourci** qui enjambe plusieurs murs.\n",
+    "\n",
+    "La longueur exacte (nombre de traversées de facettes) d'une transposition de valeurs à distance $d$ est $2d-1$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "gt3b-code-22",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.215540Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.215328Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.220947Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.220218Z"
+    },
+    "papermill": {
+     "duration": 0.010489,
+     "end_time": "2026-08-22T00:21:50.221588+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.211099+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Swap  |  traversees de murs  |  statut\n",
+      "--------------------------------------------------\n",
+      "R(1,2)  |         1            |  facette (1 mur)\n",
+      "R(2,3)  |         1            |  facette (1 mur)\n",
+      "R(3,4)  |         1            |  facette (1 mur)\n",
+      "R(1,3)  |         3            |  raccourci (3 murs enjambes)\n",
+      "R(2,4)  |         3            |  raccourci (3 murs enjambes)\n",
+      "R(1,4)  |         5            |  raccourci (5 murs enjambes)\n",
+      "\n",
+      "R(1,3) applique a (1,2,3,4)      : (3, 2, 1, 4)\n",
+      "R(1,2) puis R(2,3) puis R(1,2)   : (3, 2, 1, 4)\n",
+      "Egalite (le raccourci = 3 facettes) : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 3.2 : les swaps GT-21 en longueurs de Coxeter ===\n",
+    "\n",
+    "print(\"Swap  |  traversees de murs  |  statut\")\n",
+    "print(\"-\" * 50)\n",
+    "for (a, b) in [(1, 2), (2, 3), (3, 4), (1, 3), (2, 4), (1, 4)]:\n",
+    "    d = abs(a - b)\n",
+    "    statut = \"facette (1 mur)\" if d == 1 else f\"raccourci ({2*d-1} murs enjambes)\"\n",
+    "    print(f\"R({a},{b})  |         {2*d-1}            |  {statut}\")\n",
+    "\n",
+    "# Verification : R(1,3) = R(1,2) puis R(2,3) puis R(1,2)\n",
+    "def appliquer_swap(t, a, b):\n",
+    "    return tuple(b if v == a else (a if v == b else v) for v in t)\n",
+    "\n",
+    "t0 = (1, 2, 3, 4)\n",
+    "direct = appliquer_swap(t0, 1, 3)\n",
+    "compose = appliquer_swap(appliquer_swap(appliquer_swap(t0, 1, 2), 2, 3), 1, 2)\n",
+    "print()\n",
+    "print(\"R(1,3) applique a (1,2,3,4)      :\", direct)\n",
+    "print(\"R(1,2) puis R(2,3) puis R(1,2)   :\", compose)\n",
+    "print(\"Egalite (le raccourci = 3 facettes) :\", direct == compose)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-23",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003519,
+     "end_time": "2026-08-22T00:21:50.228850+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.225331+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : la grammaire de GT-21 se recompose géométriquement.\n",
+    "\n",
+    "- les trois swaps **adjacents** $R(1,2)$, $R(2,3)$, $R(3,4)$ sont les **générateurs** : chacun traverse exactement un mur (une facette). Avec leurs homologues Colonne, ils engendrent tout le graphe des 576 chambres (§2.2) ;\n",
+    "- les trois **raccourcis** $R(1,3)$, $R(2,4)$, $R(1,4)$ enjambent respectivement 3, 3 et 5 murs. La décomposition est vérifiée dans la sortie : $R(1,3) = R(1,2) \\circ R(2,3) \\circ R(1,2)$ — le raccourci et la cascade de facettes aboutissent au **même** 4-uplet, mais la cascade *rencontre* les murs intermédiaires (des jeux à égalités où la structure des meilleures réponses peut basculer), quand le raccourci les saute.\n",
+    "\n",
+    "C'est la réponse géométrique à une question laissée ouverte par GT-21 : pourquoi certains swaps « ne comptent-ils » pas (préservation des équilibres) ? Parce qu'un swap n'agit sur les équilibres qu'à travers les murs qu'il traverse qui sont **effectivement habités** (au sens meilleures réponses de GT-21). Les facettes rencontrées par la cascade sont autant d'occasions de bascule ; le raccourci n'échantillonne que l'état final."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003831,
+     "end_time": "2026-08-22T00:21:50.236289+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.232458+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Make tie / break tie : les deux opérations de Bruns-Kimmich\n",
+    "\n",
+    "### 4.1 Les opérations, implémentées\n",
+    "\n",
+    "La description géométrique s'accompagne de deux opérations duuales (rapportées de Bruns-Kimmich, implémentées ici) :\n",
+    "\n",
+    "- **make tie** : depuis une chambre, rapprocher deux valeurs adjacentes jusqu'à l'égalité — on **pose** le jeu sur un mur (codim +1) ;\n",
+    "- **break tie** : depuis un mur, séparer l'ex æquo dans un sens ou dans l'autre — on **retombe** dans l'une des deux chambres adjacentes (codim −1).\n",
+    "\n",
+    "Ce sont exactement les briques des §2-3, promues au rang d'API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "gt3b-code-25",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.244468Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.244288Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.250240Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.249689Z"
+    },
+    "papermill": {
+     "duration": 0.011326,
+     "end_time": "2026-08-22T00:21:50.251290+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.239964+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Chambre (PD)        : ((3, 1, 4, 2), (3, 4, 1, 2))\n",
+      "make_tie(ligne, 3)  : ((3, 1, 3, 2), (3, 4, 1, 2))  (codim 1 )\n",
+      "break_tie(haut)     : ((3, 1, 4, 2), (3, 4, 1, 2)) -> retrouve le PD : True\n",
+      "break_tie(bas)      : ((4, 1, 3, 2), (3, 4, 1, 2)) -> l'autre chambre (chambre B du 3.1)\n",
+      "\n",
+      "Le mur porte bien 2 sorties distinctes : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 4.1 : make_tie / break_tie, operations duales ===\n",
+    "\n",
+    "def make_tie(jeu, cote, k):\n",
+    "    \"\"\"Coalesce les valeurs k et k+1 du cote donne -> jeu sur un mur (codim +1).\"\"\"\n",
+    "    row, col = jeu\n",
+    "    t = faire_le_tie(row, k) if cote == \"ligne\" else faire_le_tie(col, k)\n",
+    "    return (t, col) if cote == \"ligne\" else (row, t)\n",
+    "\n",
+    "def break_tie(jeu, cote, sens):\n",
+    "    \"\"\"Separe le premier ex aequo du cote donne, ordre 'haut' ou 'bas' -> chambre (codim -1).\"\"\"\n",
+    "    row, col = jeu\n",
+    "    t = row if cote == \"ligne\" else col\n",
+    "    c = Counter(t)\n",
+    "    v = [k for k, m in c.items() if m == 2]\n",
+    "    if not v:\n",
+    "        return jeu  # pas d'ex aequo : operation identite\n",
+    "    i, j = sorted(p for p in range(4) if t[p] == v[0])\n",
+    "    l = list(t)\n",
+    "    l[i], l[j] = (v[0], v[0] + 1) if sens == \"haut\" else (v[0] + 1, v[0])\n",
+    "    t2 = canonique(l)\n",
+    "    return (t2, col) if cote == \"ligne\" else (row, t2)\n",
+    "\n",
+    "# Demonstration : aller-retour complet depuis le PD\n",
+    "pd = ((3, 1, 4, 2), (3, 4, 1, 2))\n",
+    "mur = make_tie(pd, \"ligne\", 3)\n",
+    "retour_haut = break_tie(mur, \"ligne\", \"haut\")\n",
+    "retour_bas = break_tie(mur, \"ligne\", \"bas\")\n",
+    "print(\"Chambre (PD)        :\", pd)\n",
+    "print(\"make_tie(ligne, 3)  :\", mur, \" (codim\", codim(mur[0]) + codim(mur[1]), \")\")\n",
+    "print(\"break_tie(haut)     :\", retour_haut, \"-> retrouve le PD :\", retour_haut == pd)\n",
+    "print(\"break_tie(bas)      :\", retour_bas, \"-> l'autre chambre (chambre B du 3.1)\")\n",
+    "print()\n",
+    "print(\"Le mur porte bien 2 sorties distinctes :\", retour_haut != retour_bas)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-26",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003387,
+     "end_time": "2026-08-22T00:21:50.258515+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.255128+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : l'aller-retour est **mécaniquement vérifié**. `make_tie` fait perdre une dimension (le jeu quitte l'ouvert des chambres pour la cloison), `break_tie` la rend — dans **un des deux sens** : la sortie `haut` retrouve le PD d'origine, la sortie `bas` atterrit dans la chambre B du §3.1. Les deux sorties sont distinctes : c'est la matérialisation calculée du « plusieurs prolongements sont possibles » de la thèse botanique.\n",
+    "\n",
+    "Un jeu à égalités n'est donc **pas** une spécification incomplète d'un jeu strict : c'est un objet dont le **type** même est différent — un point de l'architecture, avec ses deux faces — et dont le prolongement exige un choix supplémentaire (un sens). Toute la différence entre *assouplir une définition* et *habiter le bord*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-27",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003546,
+     "end_time": "2026-08-22T00:21:50.265454+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.261908+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### 4.2 Trois archétypes au bout des murs\n",
+    "\n",
+    "Bruns-Kimmich (rapporté) décrivent les jeux 2×2 primitifs comme engendrés depuis des murs par *make/break tie*, sous trois archétypes : **indépendance**, **coordination**, **échange**. Nos implémentations permettent d'en donner des **instanciations calculées** — la définition exacte des archétypes dans la source relève de la dette de sources (§Sources) ; ce qui suit instancie chaque nom par un mur de géométrie naturelle, obtenu par `make_tie` et vérifié par `break_tie`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "gt3b-code-28",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.273397Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.273213Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.278325Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.277799Z"
+    },
+    "papermill": {
+     "duration": 0.010093,
+     "end_time": "2026-08-22T00:21:50.278928+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.268835+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Archetype       | mur obtenu (Ligne | Colonne)            | geometrie du tie\n",
+      "------------------------------------------------------------------------------------------\n",
+      "Independance    | (1, 2, 1, 3)       | (1, 3, 2, 4)       | vertical (r11 = r21)\n",
+      "Coordination    | (1, 2, 2, 3)       | (1, 2, 2, 3)       | anti-diagonal x2, codim 2\n",
+      "Echange         | (1, 1, 2, 3)       | (2, 1, 4, 3)       | horizontal (r11 = r12)\n",
+      "\n",
+      "Chaque mur se brise dans 2 sens -> chaque archetype borde 2 familles de jeux stricts.\n",
+      "(Instanciations de notre cru ; la definition source des archetypes : dette, cf. Sources.)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# === Section 4.2 : trois instanciations (RAPPORTEES, cf. Sources) ===\n",
+    "\n",
+    "print(\"Archetype       | mur obtenu (Ligne | Colonne)            | geometrie du tie\")\n",
+    "print(\"-\" * 90)\n",
+    "\n",
+    "# Independance : mur vertical Ligne (r11 = r21) -- Ligne indifferent entre ses\n",
+    "# deux strategies quand Colonne joue a gauche\n",
+    "base_ind = ((1, 3, 2, 4), (1, 3, 2, 4))\n",
+    "mur_ind = make_tie(base_ind, \"ligne\", 1)\n",
+    "print(f\"Independance    | {str(mur_ind[0]):18s} | {str(mur_ind[1]):18s} | vertical (r11 = r21)\")\n",
+    "\n",
+    "# Coordination : double mur anti-diagonal (r12 = r21 chez les deux joueurs)\n",
+    "base_co = ((1, 2, 3, 4), (1, 2, 3, 4))\n",
+    "mur_co = make_tie(make_tie(base_co, \"ligne\", 2), \"colonne\", 2)\n",
+    "print(f\"Coordination    | {str(mur_co[0]):18s} | {str(mur_co[1]):18s} | anti-diagonal x2, codim {codim(mur_co[0]) + codim(mur_co[1])}\")\n",
+    "\n",
+    "# Echange : mur horizontal Ligne (r11 = r12) -- le gain de Ligne en haut ne\n",
+    "# depend pas de la colonne de Colonne\n",
+    "base_ech = ((1, 2, 3, 4), (2, 1, 4, 3))\n",
+    "mur_ech = make_tie(base_ech, \"ligne\", 1)\n",
+    "print(f\"Echange         | {str(mur_ech[0]):18s} | {str(mur_ech[1]):18s} | horizontal (r11 = r12)\")\n",
+    "\n",
+    "print()\n",
+    "print(\"Chaque mur se brise dans 2 sens -> chaque archetype borde 2 familles de jeux stricts.\")\n",
+    "print(\"(Instanciations de notre cru ; la definition source des archetypes : dette, cf. Sources.)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-29",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003505,
+     "end_time": "2026-08-22T00:21:50.286106+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.282601+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "**Lecture de la sortie committée** : chaque archétype est matérialisé par un jeu mur obtenu **par calcul** depuis un jeu strict :\n",
+    "\n",
+    "- **indépendance** — mur *vertical* de Ligne ($r_{11} = r_{21}$) : Ligne exactement indifférent entre ses deux stratégies face à la colonne gauche ; brisé vers le haut ou le bas, ce mur fabrique les jeux où Ligne a une préférence stricte — c'est le voisinage des décisions *unilatérales* ;\n",
+    "- **coordination** — double mur *anti-diagonal* (codim 2, une **arête** de l'architecture) : les deux joueurs lisent leur duel sur la même paire de cases ; brisé dans le même sens des deux côtés → coordination pure, en sens opposés → conflit — le voisinage des jeux de rencontre ;\n",
+    "- **échange** — mur *horizontal* de Ligne ($r_{11} = r_{12}$) : le gain de Ligne en haut ne dépend pas de l'action de Colonne ; brisé, il fabrique les jeux où l'issue dépend du croisement des deux décisions — le voisinage des marchandages.\n",
+    "\n",
+    "Ces instanciations **calculées** bornent honnêtement ce que ce notebook établit : les opérations, les comptes, les incidences. La généalogie complète des 2×2 par archétypes — les trois primitives de Bruns-Kimmich — est **rapportée**, non dérivée : elle exige la source primaire (§Sources, dette n°4)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-30",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003474,
+     "end_time": "2026-08-22T00:21:50.293145+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.289671+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Exercices"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-31",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003541,
+     "end_time": "2026-08-22T00:21:50.300342+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.296801+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 1 — Énumérer les murs par codimension\n",
+    "\n",
+    "Reproduisez et étendez le comptage du §1 : énumérez les 75 ordres faibles, comptez-les par codimension, puis **par type de blocs** (tailles décroissantes). Vérifiez que la somme des comptes par type redonne 75, et que chaque type de mur $(2,1,1)$, $(2,2)$, $(3,1)$, $(4)$ est non vide.\n",
+    "\n",
+    "**Indice** : la signature de blocs s'obtient avec `Counter` ; la codimension est `4 - len(set(t))`. Pour le compte par type, regroupez par `tuple(sorted(Counter(t).values(), reverse=True))`.\n",
+    "\n",
+    "**Étape 1** : énumérer les 75 clés canoniques (§1.1). **Étape 2** : grouper par signature. **Étape 3** : afficher le compte par signature et vérifier la somme."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "gt3b-code-32",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.309457Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.309263Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.312804Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.312197Z"
+    },
+    "papermill": {
+     "duration": 0.009102,
+     "end_time": "2026-08-22T00:21:50.313403+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.304301+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 1 : a completer (compte par type de blocs)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 1 : enumeration des murs par codimension et par type de blocs\n",
+    "# TODO etudiant : reproduire la table du 1.2 (75 ordres faibles, 4 signatures de murs)\n",
+    "# Indice : signature = tuple(sorted(Counter(t).values(), reverse=True))\n",
+    "resultat_ex1 = {}  # TODO etudiant : {signature: nombre d'ordres faibles}\n",
+    "print(\"Exercice 1 : a completer (compte par type de blocs)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-33",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003758,
+     "end_time": "2026-08-22T00:21:50.321121+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.317363+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 2 — Traverser : exhiber un triplet complet\n",
+    "\n",
+    "Choisissez un jeu strict qui n'est **pas** le PD (par exemple le jeu de la poule mouillée — vérifiez son encodage ordinal avant de l'utiliser), une de ses facettes, et exhibez le triplet **(chambre A, mur, chambre B)** complet avec les trois matrices, comme au §3.1.\n",
+    "\n",
+    "**Indice** : une facette = une paire de valeurs adjacentes $(k, k+1)$ ; le mur s'obtient par `faire_le_tie(table, k)` ; la chambre B par `swap_valeurs_adjacentes(table, k)` ; vérifiez enfin que `briser_le_tie(mur)` contient bien les deux chambres.\n",
+    "\n",
+    "**Étape 1** : poser les tables du jeu choisi. **Étape 2** : choisir $k$ et construire le mur et la chambre B. **Étape 3** : vérifier la double incidence avec `briser_le_tie`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "gt3b-code-34",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.329601Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.329419Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.333086Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.332462Z"
+    },
+    "papermill": {
+     "duration": 0.00878,
+     "end_time": "2026-08-22T00:21:50.333722+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.324942+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 2 : a completer (triplet chambre-mur-chambre)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 2 : exhiber chambre -> mur -> chambre pour un autre jeu\n",
+    "# TODO etudiant : remplir les trois matrices et la verification\n",
+    "chambre_A = None  # TODO etudiant : (row, col) du jeu strict choisi\n",
+    "mur_ex2 = None    # TODO etudiant : le mur traverse (via faire_le_tie)\n",
+    "chambre_B = None  # TODO etudiant : la chambre d'arrivee (via swap_valeurs_adjacentes)\n",
+    "print(\"Exercice 2 : a completer (triplet chambre-mur-chambre)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-35",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003955,
+     "end_time": "2026-08-22T00:21:50.341516+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.337561+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Exercice 3 — Make tie / break tie : vers les archétypes\n",
+    "\n",
+    "Depuis le jeu **Stag Hunt** de GT-21 (Ligne $(4,1,3,2)$, Colonne $(4,3,1,2)$), construisez par `make_tie` un mur de chaque type : un mur Ligne, un mur Colonne, puis un double mur (codim 2). Pour chacun, appliquez `break_tie` dans les deux sens et observez les deux chambres de sortie — vous venez de cartographier le voisinage d'un jeu de coordination.\n",
+    "\n",
+    "**Indice** : le double mur s'obtient en composant deux `make_tie` successifs (comme au §4.2 pour la coordination). Les deux sens de `break_tie` doivent redonner deux jeux **stricts** distincts.\n",
+    "\n",
+    "**Étape 1** : construire les trois murs. **Étape 2** : pour chacun, briser dans les deux sens. **Étape 3** : vérifier que chaque paire de sorties est distincte et stricte."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "gt3b-code-36",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:21:50.350243Z",
+     "iopub.status.busy": "2026-08-22T00:21:50.350052Z",
+     "iopub.status.idle": "2026-08-22T00:21:50.354046Z",
+     "shell.execute_reply": "2026-08-22T00:21:50.353427Z"
+    },
+    "papermill": {
+     "duration": 0.009567,
+     "end_time": "2026-08-22T00:21:50.354928+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.345361+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exercice 3 : a completer (voisinage de Stag Hunt)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Exercice 3 : voisinage de Stag Hunt par make_tie / break_tie\n",
+    "# TODO etudiant : les trois murs (ligne, colonne, double) et leurs sorties\n",
+    "murs_ex3 = None     # TODO etudiant : {nom_du_mur: jeu_mur}\n",
+    "sorties_ex3 = None  # TODO etudiant : {nom_du_mur: (sortie_haut, sortie_bas)}\n",
+    "print(\"Exercice 3 : a completer (voisinage de Stag Hunt)\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "gt3b-md-37",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003853,
+     "end_time": "2026-08-22T00:21:50.362733+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:21:50.358880+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "**Ce que ce notebook établit (tout calculé, tout vérifié dans les sorties) :**\n",
+    "\n",
+    "1. l'univers des jeux 2×2 **à rangs** compte $75^2 = 5625$ états, dont les 576 jeux stricts ne sont que les chambres ouvertes (10,2 %) — le reste est l'architecture : 1728 murs simples, 1968 strates de codim 2, jusqu'au jeu totalement plat (codim 6, unique) ;\n",
+    "2. l'incidence est exacte : chaque mur simple sépare **exactement 2 chambres**, chaque chambre a **exactement 3 facettes** par côté — et les 1728 arêtes du graphe des chambres coïncident mur pour mur avec les 1728 strates de codim 1 ;\n",
+    "3. le graphe des chambres est **connexe**, de diamètre 6 par côté (12 pour le jeu) — avec la distribution symétrique des distances $\\{1,3,5,6,5,3,1\\}$ ;\n",
+    "4. la grammaire des swaps de GT-21 se recompose : les 3 swaps adjacents sont des traversées de facettes (1 mur), les 3 autres des raccourcis (3, 3 et 5 murs enjambés), avec $R(1,3) = R(1,2) \\circ R(2,3) \\circ R(1,2)$ vérifié ;\n",
+    "5. *make tie* / *break tie* sont implémentées et l'aller-retour est vérifié : un jeu à égalités est un objet **biface**, pas une définition relâchée.\n",
+    "\n",
+    "**Ce qui reste ouvert** — les quatre dettes de dérivation, à honorer depuis les sources primaires avant toute affirmation publique : le quotient $576 \\to 144$ (facteur exact à re-dériver), l'action du groupe $S_4 \\times S_4$, le tore à 37 trous, et la vérification firsthand des trois arXiv. Ce notebook ne les affirme pas : il les porte comme dette.\n",
+    "\n",
+    "**La phrase à retenir** : *un objet botanique n'est pas un objet plus flou — c'est un objet de dimension inférieure, depuis lequel plusieurs prolongements sont possibles.*\n",
+    "\n",
+    "## Sources et dettes\n",
+    "\n",
+    "- **Bruns & Kimmich** — la description géométrique (chambres/murs/strates, make/break tie, archétypes) est **rapportée** de leur formalisation des jeux 2×2, non dérivée de la source primaire ici (dette n°4). Tout ce que le notebook affirme chiffré (75, 5625, 1728, 3, 2, 6, 12) est **calculé localement** et reproductible en ré-exécutant.\n",
+    "- **Robinson & Goforth** — le tableau périodique des jeux 2×2 ; ancêtre Rapoport & Guyer. (L'attribution « Gale et Morris » qui circule dans certains transcripts est une hallucination corrigée.)\n",
+    "- **Dettes ouvertes (HARD)** : (1) quotient 576→144 à re-dériver ; (2) groupe $S_4 \\times S_4$ et son action ; (3) tore à 37 trous ; (4) arXiv 2309.15981, 2102.00053, 1704.02230 non ouverts firsthand.\n",
+    "- **Vocabulaire** : volontairement minimal — chambres, murs, strates, codimension, facettes. Aucun vocabulaire faisceautique au-delà de ce que le notebook calcule.\n",
+    "\n",
+    "*Chantier des jeux 2×2 — voir aussi* : [GT-3 Topology2x2](GameTheory-3-Topology2x2.ipynb) (l'espace et la grammaire) · [GT-21 Deux-Espèces-de-Flèches](GameTheory-21-Deux-Especes-de-Fleches.ipynb) (quand un swap est un morphisme) · GT-3c « chemin minimal de swaps » ([issue #12222](https://github.com/jsboige/CoursIA/issues/12222), à venir)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 1.97701,
+   "end_time": "2026-08-22T00:21:50.598847+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-3b-Chambres-et-Murs.ipynb",
+   "output_path": "GameTheory-3b-Chambres-et-Murs_output_20260822_022148.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-22T00:21:48.621837+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Grain: DEEP/notebook-python — lane myia-po-2025:CoursIA — prev: DEEP/notebook-dotnet #12251

## Summary

Nouveau notebook **`GameTheory-3b-Chambres-et-Murs.ipynb`** — grain **#12213** (réservoir #12211-#12240, chantiers #12204-#12208), dispatché par ai-01 (DM acké). La question de la thèse — *un jeu à égalités n'est pas un jeu plus flou, c'est un objet de dimension inférieure* — rendue calculable sur l'espace des jeux 2×2 à rangs : **38 cellules, 13 code, pur stdlib**.

**Résultats (tous mesurés dans les outputs commités) :**

- **75 ordres faibles par joueur** (nombre de Fubini $a(4)$) : 24 chambres + 51 murs. Codimension **vraie** (nombre d'équations indépendantes = 4 − nb de blocs) : $\{0{:}24, 1{:}36, 2{:}14, 3{:}1\}$ — avec la subtilité pédagogique mesurée : un triple ex æquo porte **3 paires** mais codim **2**.
- **5 625 jeux à rangs** ($75^2$), distribution par codim $\{0{:}576, 1{:}1728, 2{:}1968, 3{:}1056, 4{:}268, 5{:}28, 6{:}1\}$ — les 576 chambres strictes (univers GT-3/GT-21, cohérence vérifiée) n'occupent que **10,2 %** de l'espace.
- **Incidence exacte double-face** : chaque mur simple sépare **exactement 2 chambres** (36/36 vérifiés), chaque chambre a **exactement 3 facettes** (les paires de valeurs adjacentes — une paire non adjacente n'est pas une facette). Le pont : $576 \times 6/2 = 1728$ arêtes $= 1728$ murs simples — chaque arête **est** la traversée d'un mur (double comptage propre).
- **Graphe des chambres connexe**, diamètre 6/joueur (distribution symétrique $\{1,3,5,6,5,3,1\}$) et 12 pour le jeu complet (BFS 576 sommets).
- **Grammaire GT-21 recomposée** : les swaps adjacents $R(12)/R(23)/R(34)$ traversent **1 mur** (facettes, générateurs), les raccourcis $R(13)/R(24)$ enjambent **3 murs**, $R(14)$ **5** (longueur de Coxeter $2d-1$) ; décomposition $R(1,3) = R(1,2)\circ R(2,3)\circ R(1,2)$ vérifiée en sortie.
- **Acceptance ex 2 satisfaite et démontrée** : le triplet complet (chambre A = PD strict, mur $r_{11}{=}r_{21}$, chambre B) exhibé **avec les trois matrices**, cohérence vérifiée par `briser_le_tie` qui redonne exactement les deux faces.
- **make_tie / break_tie implémentées** (opérations de Bruns-Kimmich rapportées) : aller-retour PD vérifié, deux sorties distinctes ; trois instanciations d'archétypes (indépendance/coordination/échange) **calculées** et étiquetées instanciations de notre cru.

**Dettes de dérivation (HARD, conformément au body)** : les quatre points (quotient 576→144, action $S_4 \times S_4$, tore à 37 trous, arXiv 2309.15981/2102.00053/1704.02230) sont **RAPPORTÉS comme dette ouverte** dans §Sources — jamais affirmés. Vocabulaire minimal (chambres/murs/strates/codimension/facettes), aucun vocabulaire faisceautique au-delà de ce qui est calculé.

## Validation (post-dernier-commit ce630e292)

- **Exécution réelle** : papermill kernel `python3` — **13/13 cellules code, 0 erreur**, séquence `1..13` CLEAN, outputs réels commités ; `metadata.papermill` normalisé au basename (exception permise)
- **C.1** : 0 `raise NotImplementedError|assert False|1/0` — les 3 exercices sont stubbés (`return None`/`{}` vides + `# TODO etudiant` + `# Etape N` + `# Indice`), le notebook s'exécute de bout en bout non complété
- **C.2/C.3** : `execution_count != null` + outputs pour 13/13 cellules code
- **Guard markdown** : `detect_markdown_rendering --check` → OK ; `nbformat.validate` OK (38 cellules) ; navlinks 0 cassé ; **3 exercices détectés** (`count_exercises`) ; densité **1664 chars/cell**
- **Corrections en cours de route** (2 itérations avant commit) : `ex[1]` IndexError sur la signature à bloc unique ; **bug réel trouvé par dry-run** — `briser_le_tie` insérait la paire liée au milieu des autres valeurs au lieu du niveau du tie (les faces imprimées n'étaient pas les faces géométriques) → corrigé version level-aware, re-vérifié
- Catalogue byte-identique à main (nouveau fichier seulement ; entrée = cron <24h) ; L898 : aucune PR ouverte touchant `GameTheory-3b*` ; claim ai-01 c.5376571383 (globs `3b`+`03b`)
- **Note renommage** : #12241 (zero-pad, OPEN à la création) renommera le slot en `03b` après merge — renommage trivial en follow-up si nécessaire (couvert par les globs du claim)

Closes #12213 (les 3 critères d'acceptance satisfaits : compte par codimension reproductible ✓, cas complet chambre-mur-chambre avec matrices ✓, vocabulaire borné à ce qui est calculé ✓)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
