### PR TITLE
feat(gametheory,#12222): notebook GT-3a Chemins-de-Swaps + module Lean Swaps

### DIFF
--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3a-Chemins-de-Swaps.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3a-Chemins-de-Swaps.ipynb
@@ -14,7 +14,7 @@
     "tags": []
    },
    "source": [
-    "# GameTheory-3c — Chemins de swaps : à quelle distance sont deux jeux ?\n",
+    "# GameTheory-3a — Chemins de swaps : à quelle distance sont deux jeux ?\n",
     "\n",
     "Troisième temps de la géométrie ordinale des jeux 2×2. **GameTheory-3** avait énuméré les 576 chambres strictes et leurs générateurs adjacents ; **GameTheory-3b** a montré que les jeux à égalités sont des murs entre chambres — des objets de codimension. Ce notebook répond à la question qui reste : *à quelle distance de swap sont deux jeux, et par quels chemins les relie-t-on ?*\n",
     "\n",
@@ -1254,8 +1254,8 @@
    "end_time": "2026-08-22T00:48:41.357161+00:00",
    "environment_variables": {},
    "exception": null,
-   "input_path": "GameTheory-3c-Chemins-de-Swaps.ipynb",
-   "output_path": "GameTheory-3c-Chemins-de-Swaps.ipynb",
+   "input_path": "GameTheory-3a-Chemins-de-Swaps.ipynb",
+   "output_path": "GameTheory-3a-Chemins-de-Swaps.ipynb",
    "parameters": {},
    "start_time": "2026-08-22T00:48:33.574850+00:00",
    "version": "2.7.0"

--- a/MyIA.AI.Notebooks/GameTheory/GameTheory-3c-Chemins-de-Swaps.ipynb
+++ b/MyIA.AI.Notebooks/GameTheory/GameTheory-3c-Chemins-de-Swaps.ipynb
@@ -1,0 +1,1266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9846c491",
+   "metadata": {
+    "papermill": {
+     "duration": 0.023795,
+     "end_time": "2026-08-22T00:48:34.966272+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:34.942477+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "# GameTheory-3c — Chemins de swaps : à quelle distance sont deux jeux ?\n",
+    "\n",
+    "Troisième temps de la géométrie ordinale des jeux 2×2. **GameTheory-3** avait énuméré les 576 chambres strictes et leurs générateurs adjacents ; **GameTheory-3b** a montré que les jeux à égalités sont des murs entre chambres — des objets de codimension. Ce notebook répond à la question qui reste : *à quelle distance de swap sont deux jeux, et par quels chemins les relie-t-on ?*\n",
+    "\n",
+    "Deux questions d'analyse d'algorithme s'y ajoutent, qui structurent tout le grain :\n",
+    "\n",
+    "1. **Le générateur propose** — un parcours en largeur (BFS) explore l'espace niveau par niveau et produit un plus court chemin candidat.\n",
+    "2. **Le certificat garantit** — un module compagnon en Lean (`game_theory_lean/Swaps/Basic.lean`, écrit pour ce grain) certifie qu'un chemin proposé est bien formé et mène bien de l'arrivée au départ ; sur le cas témoin Dilemme → Chicken, il certifie aussi qu'aucun chemin plus court n'existe. Le générateur Python et le vérificateur Lean restent deux artefacts distincts,chacun à sa place.\n",
+    "\n",
+    "**Prérequis** : GameTheory-3 (générateurs $R_{12}/R_{23}/R_{34}/C_{12}/C_{23}/C_{34}$), GameTheory-3b (codimension, murs, facettes), GameTheory-21 (deux espèces de flèches). Toutes les mesures de ce notebook sont calculées sur l'espace complet des 576 jeux stricts — le quotient par renommage des stratégies (144 classes) est une dette rapportée, jamais affirmée ici."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fab97b73",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00573,
+     "end_time": "2026-08-22T00:48:34.992838+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:34.987108+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Plan\n",
+    "\n",
+    "1. **§1 La distance d'un jeu à l'autre** — BFS depuis le Dilemme, tableau des distances aux archétypes, les trois cousins à distance 2.\n",
+    "2. **§2 La distribution des distances** — sphères emboîtées, symétrie parfaite, convolution des vecteurs de Mahler.\n",
+    "3. **§3 Le théorème de décomposition** — la distance d'un jeu à l'autre est la somme des longueurs de Coxeter des deux côtés ; vérification exhaustive sur les 331 776 paires.\n",
+    "4. **§4 Multiplicités** — combien de plus courts chemins relient deux jeux : de 2 (commutation) à 236 544 (l'anti-Dilemme).\n",
+    "5. **§5 Générateur contre certificat** — le miroir Python du vérificateur Lean, valide ≠ minimal, puis le module `Swaps/Basic.lean` lui-même, cité aux lignes mesurées.\n",
+    "6. **§6 Exercices** (3) — distance par sphères, diamètre depuis une autre source, certificat d'un chemin fourni."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "77d3c7fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:35.000970Z",
+     "iopub.status.busy": "2026-08-22T00:48:35.000792Z",
+     "iopub.status.idle": "2026-08-22T00:48:35.009722Z",
+     "shell.execute_reply": "2026-08-22T00:48:35.009217Z"
+    },
+    "papermill": {
+     "duration": 0.014047,
+     "end_time": "2026-08-22T00:48:35.010504+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:34.996457+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Espace : 576 jeux stricts, 6 générateurs par jeu\n"
+     ]
+    }
+   ],
+   "source": [
+    "from itertools import permutations\n",
+    "from collections import deque, Counter\n",
+    "\n",
+    "# Convention GameTheory-3 / GameTheory-21 : une table porte les rangs 1-4\n",
+    "# des quatre cellules dans l'ordre (haut-gauche, haut-droit, bas-gauche,\n",
+    "# bas-droit). Un jeu est le couple (table Ligne, table Colonne).\n",
+    "PERMS = list(permutations((1, 2, 3, 4)))\n",
+    "JEUX = [(r, c) for r in PERMS for c in PERMS]   # 576 jeux stricts\n",
+    "\n",
+    "def swap_adjacent(t, k):\n",
+    "    \"\"\"Générateur élémentaire : échange les cellules portant les rangs k et k+1.\n",
+    "\n",
+    "    Vu des valeurs, c'est une relabellisation k <-> k+1 ; vu des cellules,\n",
+    "    c'est la traversée du mur où ces deux rangs coïncident (GT-3b, §3).\n",
+    "    \"\"\"\n",
+    "    pk, pk1 = t.index(k), t.index(k + 1)\n",
+    "    l = list(t)\n",
+    "    l[pk], l[pk1] = l[pk1], l[pk]\n",
+    "    return tuple(l)\n",
+    "\n",
+    "def voisins(g):\n",
+    "    \"\"\"Les six voisins d'un jeu : trois générateurs par joueur.\"\"\"\n",
+    "    r, c = g\n",
+    "    return ([(swap_adjacent(r, k), c) for k in (1, 2, 3)] +\n",
+    "            [(r, swap_adjacent(c, k)) for k in (1, 2, 3)])\n",
+    "\n",
+    "# Encodages ordinaux canoniques (identiques à GameTheory-3 et GT-21)\n",
+    "CLASSIC = {\n",
+    "    \"Dilemme\":       ((3, 1, 4, 2), (3, 4, 1, 2)),\n",
+    "    \"Chicken\":       ((3, 2, 4, 1), (3, 4, 2, 1)),\n",
+    "    \"Deadlock\":      ((2, 1, 4, 3), (2, 4, 1, 3)),\n",
+    "    \"Chasse au cerf\": ((4, 1, 3, 2), (4, 3, 1, 2)),\n",
+    "    \"Harmonie\":      ((4, 3, 2, 1), (4, 2, 3, 1)),\n",
+    "    \"Pennies\":       ((4, 1, 2, 3), (1, 4, 3, 2)),\n",
+    "}\n",
+    "\n",
+    "def bfs(depart):\n",
+    "    \"\"\"Parcours en largeur : distances et parents depuis un jeu de départ.\"\"\"\n",
+    "    dist = {depart: 0}\n",
+    "    parent = {depart: None}\n",
+    "    file = deque([depart])\n",
+    "    while file:\n",
+    "        u = file.popleft()\n",
+    "        for v in voisins(u):\n",
+    "            if v not in dist:\n",
+    "                dist[v] = dist[u] + 1\n",
+    "                parent[v] = u\n",
+    "                file.append(v)\n",
+    "    return dist, parent\n",
+    "\n",
+    "print(f\"Espace : {len(JEUX)} jeux stricts, {len(voisins(JEUX[0]))} générateurs par jeu\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29317a24",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003141,
+     "end_time": "2026-08-22T00:48:35.016363+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.013222+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 1. La distance d'un jeu à l'autre\n",
+    "\n",
+    "La **distance de swap** entre deux jeux est la longueur du plus court chemin de générateurs qui relie l'un à l'autre — le nombre minimal de murs traversés, au sens de GT-3b. C'est la distance de graphe sur les 576 sommets, et le parcours en largeur la mesure exactement : le BFS découvre les jeux par sphères croissantes, et la sphère où un jeu apparaît pour la première fois est sa distance au point de départ.\n",
+    "\n",
+    "Lançons le BFS depuis le Dilemme du prisonnier — le jeu le plus commenté de la théorie — et demandons les distances aux cinq autres archétypes canoniques."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ac815346",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:35.023690Z",
+     "iopub.status.busy": "2026-08-22T00:48:35.023418Z",
+     "iopub.status.idle": "2026-08-22T00:48:35.029269Z",
+     "shell.execute_reply": "2026-08-22T00:48:35.028601Z"
+    },
+    "papermill": {
+     "duration": 0.010011,
+     "end_time": "2026-08-22T00:48:35.029810+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.019799+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "jeux atteints depuis le Dilemme : 576 / 576\n",
+      "excentricité du Dilemme : 12\n",
+      "\n",
+      "Distances depuis le Dilemme :\n",
+      "  Dilemme -> Dilemme          distance = 0\n",
+      "  Dilemme -> Chicken          distance = 2\n",
+      "  Dilemme -> Deadlock         distance = 2\n",
+      "  Dilemme -> Chasse au cerf   distance = 2\n",
+      "  Dilemme -> Harmonie         distance = 6\n",
+      "  Dilemme -> Pennies          distance = 5\n"
+     ]
+    }
+   ],
+   "source": [
+    "DIST_PD, PARENT_PD = bfs(CLASSIC[\"Dilemme\"])\n",
+    "\n",
+    "print(\"jeux atteints depuis le Dilemme :\", len(DIST_PD), \"/ 576\")\n",
+    "print(\"excentricité du Dilemme :\", max(DIST_PD.values()))\n",
+    "print()\n",
+    "print(\"Distances depuis le Dilemme :\")\n",
+    "for nom, g in CLASSIC.items():\n",
+    "    print(f\"  Dilemme -> {nom:16s} distance = {DIST_PD[g]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90098875",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002872,
+     "end_time": "2026-08-22T00:48:35.035703+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.032831+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : trois cousins à distance 2, un antagoniste à distance 12\n",
+    "\n",
+    "Trois archétypes sont à distance 2 du Dilemme — **Chicken, Deadlock et la chasse au cerf** — et un seul est à distance 12 : son **complément ordinal**, le jeu où chaque rang $r$ est remplacé par $5 - r$ chez les deux joueurs (l'« anti-Dilemme », unique point de la sphère maximale). Entre les deux, Pennies à 5 et Harmonie à 6.\n",
+    "\n",
+    "La distance 2 des trois cousins n'est pas un artefact d'encodage : chacun s'obtient du Dilemme en échangeant, **chez chaque joueur**, une paire différente de rangs adjacents :\n",
+    "\n",
+    "- **Chicken** : l'ordre des deux *pires* rangs ($P \\leftrightarrow S$) — c'est tout ce qui sépare la coopération forcée du Dilemme de l'intimidation réciproque ;\n",
+    "- **Deadlock** : l'ordre des rangs du *milieu* ;\n",
+    "- **la chasse au cerf** : l'ordre des deux *meilleurs* rangs ($T \\leftrightarrow R$) — le pari de confiance.\n",
+    "\n",
+    "Reconstruisons ces chemins avec la table des parents du BFS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dbcc7fe3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:35.042832Z",
+     "iopub.status.busy": "2026-08-22T00:48:35.042528Z",
+     "iopub.status.idle": "2026-08-22T00:48:35.048744Z",
+     "shell.execute_reply": "2026-08-22T00:48:35.048185Z"
+    },
+    "papermill": {
+     "duration": 0.010515,
+     "end_time": "2026-08-22T00:48:35.049316+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.038801+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dilemme -> Chicken          (distance  2) : R12 C12\n",
+      "Dilemme -> Deadlock         (distance  2) : R23 C23\n",
+      "Dilemme -> Chasse au cerf   (distance  2) : R34 C34\n",
+      "Dilemme -> Pennies          (distance  5) : R34 R23 C12 C23 C12\n",
+      "Dilemme -> Harmonie         (distance  6) : R12 R34 R23 C12 C34 C23\n",
+      "\n",
+      "anti-Dilemme = ((2, 4, 1, 3), (2, 1, 4, 3))\n",
+      "distance = 12 ; jeux à cette distance : 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "def nommer_etape(g1, g2):\n",
+    "    \"\"\"Nom du générateur qui fait passer de g1 à son voisin g2.\"\"\"\n",
+    "    r1, c1 = g1\n",
+    "    r2, c2 = g2\n",
+    "    for k in (1, 2, 3):\n",
+    "        if swap_adjacent(r1, k) == r2:\n",
+    "            return f\"R{k}{k + 1}\"\n",
+    "        if swap_adjacent(c1, k) == c2:\n",
+    "            return f\"C{k}{k + 1}\"\n",
+    "    raise ValueError(\"pas voisins\")\n",
+    "\n",
+    "def reconstruire(arrivee, parent):\n",
+    "    \"\"\"Chemin du départ du BFS jusqu'à l'arrivée, en noms de générateurs.\"\"\"\n",
+    "    chemin = []\n",
+    "    v = arrivee\n",
+    "    while parent[v] is not None:\n",
+    "        chemin.append(nommer_etape(parent[v], v))\n",
+    "        v = parent[v]\n",
+    "    return list(reversed(chemin))\n",
+    "\n",
+    "def complement(g):\n",
+    "    \"\"\"Le complément ordinal : chaque rang r devient 5 - r chez les deux joueurs.\"\"\"\n",
+    "    return (tuple(5 - v for v in g[0]), tuple(5 - v for v in g[1]))\n",
+    "\n",
+    "for nom in (\"Chicken\", \"Deadlock\", \"Chasse au cerf\", \"Pennies\", \"Harmonie\"):\n",
+    "    chemin = reconstruire(CLASSIC[nom], PARENT_PD)\n",
+    "    print(f\"Dilemme -> {nom:16s} (distance {DIST_PD[CLASSIC[nom]]:2d}) : \"\n",
+    "          f\"{' '.join(chemin)}\")\n",
+    "\n",
+    "anti = complement(CLASSIC[\"Dilemme\"])\n",
+    "print(f\"\\nanti-Dilemme = {anti}\")\n",
+    "print(f\"distance = {DIST_PD[anti]} ; jeux à cette distance :\",\n",
+    "      sum(1 for d in DIST_PD.values() if d == 12))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ece7c458",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003094,
+     "end_time": "2026-08-22T00:48:35.055638+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.052544+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : la géographie du Dilemme\n",
+    "\n",
+    "Le Dilemme habite un carrefour : ses trois cousins célèbres sont à deux pas, chacun dans une direction cardinale différente (bas, milieu, haut de l'échelle des rangs), et l'unique jeu le plus lointain — à 12 swaps — est son **complément ordinal exact**, celui où chaque cellule qui était un bon rang devient un mauvais. Dans ce jeu antagoniste, la situation du Dilemme est intégralement inversée : ce que la coopération produisait de mieux devient pire. La mesure dit autrement la même chose que GT-3b : traverser les 12 murs qui séparent un jeu de son complément, c'est renverser toute son échelle de valeurs — et aucun chemin ne peut être plus long, car changer les deux tables complètes exige au plus 6 swaps adjacents chacune (le retournement d'un ordre de 4 éléments).\n",
+    "\n",
+    "Le point mérite d'être regardé de plus près : la structure de toutes ces distances est remarquablement régulière, et c'est l'objet de la section suivante."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2405c040",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002946,
+     "end_time": "2026-08-22T00:48:35.061817+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.058871+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 2. La distribution des distances : des sphères emboîtées\n",
+    "\n",
+    "Le BFS donne la distance de *chaque* jeu au Dilemme — autrement dit la cardinalité de chaque sphère $S_d = \\{G : d(\\text{Dilemme}, G) = d\\}$ pour $d$ de 0 à 12. Si la géographie du Dilemme était quelconque, ces tailles n'auraient aucune raison d'être régulières. Mesurons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "71301cb2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:35.069223Z",
+     "iopub.status.busy": "2026-08-22T00:48:35.068922Z",
+     "iopub.status.idle": "2026-08-22T00:48:35.074089Z",
+     "shell.execute_reply": "2026-08-22T00:48:35.073525Z"
+    },
+    "papermill": {
+     "duration": 0.009778,
+     "end_time": "2026-08-22T00:48:35.074669+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.064891+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "d :      0      1      2      3      4      5      6      7      8      9     10     11     12\n",
+      "N :      1      6     19     42     71     96    106     96     71     42     19      6      1\n",
+      "total : 576\n",
+      "\n",
+      "  d =  0 |                                                     1\n",
+      "  d =  1 | ###                                                 6\n",
+      "  d =  2 | #########                                          19\n",
+      "  d =  3 | #####################                              42\n",
+      "  d =  4 | ###################################                71\n",
+      "  d =  5 | ################################################   96\n",
+      "  d =  6 | #####################################################  106\n",
+      "  d =  7 | ################################################   96\n",
+      "  d =  8 | ###################################                71\n",
+      "  d =  9 | #####################                              42\n",
+      "  d = 10 | #########                                          19\n",
+      "  d = 11 | ###                                                 6\n",
+      "  d = 12 |                                                     1\n",
+      "\n",
+      "symétrie d <-> 12 - d : True\n",
+      "maximum atteint en d = 6 : 106 jeux\n"
+     ]
+    }
+   ],
+   "source": [
+    "distribution = Counter(DIST_PD.values())\n",
+    "total = sum(distribution.values())\n",
+    "print(\"d :\", \" \".join(f\"{d:6d}\" for d in range(13)))\n",
+    "print(\"N :\", \" \".join(f\"{distribution[d]:6d}\" for d in range(13)))\n",
+    "print(\"total :\", total)\n",
+    "print()\n",
+    "for d in range(13):\n",
+    "    print(f\"  d = {d:2d} | {'#' * (distribution[d] // 2):48s} {distribution[d]:4d}\")\n",
+    "\n",
+    "symetrie = all(distribution[d] == distribution[12 - d] for d in range(13))\n",
+    "print(\"\\nsymétrie d <-> 12 - d :\", symetrie)\n",
+    "print(\"maximum atteint en d = 6 :\", distribution[6], \"jeux\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1b590f6",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003148,
+     "end_time": "2026-08-22T00:48:35.081050+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.077902+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : une distribution symétrique et factorisée\n",
+    "\n",
+    "La distribution est **parfaitement symétrique** autour de 6, en cloche, avec un unique jeu aux deux extrémités ($d = 0$ le Dilemme lui-même, $d = 12$ son complément) et un plateau de 106 jeux à distance 6. Cette régularité appelle une explication structurelle — et elle en a une, calculable de façon indépendante.\n",
+    "\n",
+    "La distribution des longueurs de mots sur les 24 permutations d'un côté (la distribution des nombres d'inversions) est le **vecteur de Mahler du permutoèdre** : $\\{1, 3, 5, 6, 5, 3, 1\\}$ pour $S_4$. Si la distance d'un jeu à l'autre était *la somme indépendante des distances de chaque côté* — un théorème que la section 3 établira par énumération exhaustive — alors la distribution depuis n'importe quel jeu devrait être la **convolution de ce vecteur avec lui-même**. Vérifions la prédiction *avant* d'établir le théorème qui la justifie."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6b2c29e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:35.088043Z",
+     "iopub.status.busy": "2026-08-22T00:48:35.087784Z",
+     "iopub.status.idle": "2026-08-22T00:48:35.093587Z",
+     "shell.execute_reply": "2026-08-22T00:48:35.093046Z"
+    },
+    "papermill": {
+     "duration": 0.010048,
+     "end_time": "2026-08-22T00:48:35.094123+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.084075+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "vecteur de Mahler de S4 : [1, 3, 5, 6, 5, 3, 1] (somme : 24 permutations )\n",
+      "convolution (Mahler * Mahler) : [1, 6, 19, 42, 71, 96, 106, 96, 71, 42, 19, 6, 1]\n",
+      "distribution mesurée         : [1, 6, 19, 42, 71, 96, 106, 96, 71, 42, 19, 6, 1]\n",
+      "coïncidence exacte : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Distribution des longueurs d'un côté : les nombres d'inversions sur S4.\n",
+    "# La distance d'une permutation a l'identite (en swaps adjacents de valeurs)\n",
+    "# est son nombre d'inversions -- la longueur de Coxeter.\n",
+    "def inversions(t):\n",
+    "    return sum(1 for i in range(4) for j in range(i + 1, 4) if t[i] > t[j])\n",
+    "\n",
+    "mahler_s4 = Counter(inversions(p) for p in PERMS)\n",
+    "print(\"vecteur de Mahler de S4 :\", [mahler_s4[k] for k in range(7)],\n",
+    "      \"(somme :\", sum(mahler_s4.values()), \"permutations )\")\n",
+    "\n",
+    "# Convolution manuelle : u * v\n",
+    "def convol(u, v):\n",
+    "    w = [0] * (len(u) + len(v) - 1)\n",
+    "    for i, a in enumerate(u):\n",
+    "        for j, b in enumerate(v):\n",
+    "            w[i + j] += a * b\n",
+    "    return w\n",
+    "\n",
+    "predite = convol([mahler_s4[k] for k in range(7)],\n",
+    "                 [mahler_s4[k] for k in range(7)])\n",
+    "mesuree = [distribution[d] for d in range(13)]\n",
+    "print(\"convolution (Mahler * Mahler) :\", predite)\n",
+    "print(\"distribution mesurée         :\", mesuree)\n",
+    "print(\"coïncidence exacte :\", list(predite) == mesuree)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc5bb81e",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002845,
+     "end_time": "2026-08-22T00:48:35.100100+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.097255+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 3. Le théorème de décomposition\n",
+    "\n",
+    "La coïncidence exacte de la cellule précédente n'est pas un hasard : c'est la trace d'un théorème. Énonçons-le d'abord informellement.\n",
+    "\n",
+    "> **Décomposition.** La distance de swap entre deux jeux $G = (r_G, c_G)$ et $H = (r_H, c_H)$ est la **somme des distances de chaque côté** :\n",
+    "> $$d(G, H) = \\ell(r_G, r_H) + \\ell(c_G, c_H)$$\n",
+    "> où $\\ell(a, b)$ est la **longueur de Coxeter** de la relabellisation qui envoie $a$ sur $b$ : le nombre d'inversions de la permutation relative $b \\circ a^{-1}$, c'est-à-dire le nombre minimal de transpositions de valeurs adjacentes qui transforment $a$ en $b$.\n",
+    "\n",
+    "L'intuition : les générateurs Ligne et Colonne sont *indépendants* — un chemin est un entrelacement d'un mot côté Ligne et d'un mot côté Colonne, et chaque côté se comporte comme le graphe de Cayley de $S_4$ muni des trois transpositions adjacentes, dont la distance est exactement la longueur de Coxeter. Nous n'affirmerons pas cette preuve conceptuelle comme établie (elle est rapportée en dette) — mais nous pouvons faire mieux que la croire : **vérifier l'énoncé sur chacune des 331 776 paires de jeux**, en comparant le BFS (la mesure) à la formule (la prédiction), indépendamment l'une de l'autre."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "f017a20d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:35.107239Z",
+     "iopub.status.busy": "2026-08-22T00:48:35.107048Z",
+     "iopub.status.idle": "2026-08-22T00:48:35.112207Z",
+     "shell.execute_reply": "2026-08-22T00:48:35.111532Z"
+    },
+    "papermill": {
+     "duration": 0.00983,
+     "end_time": "2026-08-22T00:48:35.112917+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.103087+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ligne : (3,1,4,2) -> (3,2,4,1), coxeter = 1\n",
+      "Colonne : (3,4,1,2) -> (3,4,2,1), coxeter = 1\n",
+      "retournement (1,2,3,4) -> (4,3,2,1), coxeter = 6\n",
+      "identite (1,2,3,4) -> (1,2,3,4), coxeter = 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "def coxeter(a, b):\n",
+    "    \"\"\"Longueur de Coxeter de la relabellisation a -> b :\n",
+    "    nombre d'inversions de la permutation relative b . a^{-1}.\n",
+    "    \"\"\"\n",
+    "    pos = [0] * 5          # pos[v] = position de la valeur v dans a\n",
+    "    for i, v in enumerate(a):\n",
+    "        pos[v] = i\n",
+    "    pi = [b[pos[v]] for v in (1, 2, 3, 4)]   # permutation relative\n",
+    "    return sum(1 for i in range(4) for j in range(i + 1, 4) if pi[i] > pi[j])\n",
+    "\n",
+    "# Exemples chiffrés, un par côté du chemin Dilemme -> Chicken :\n",
+    "print(\"Ligne : (3,1,4,2) -> (3,2,4,1), coxeter =\", coxeter((3, 1, 4, 2), (3, 2, 4, 1)))\n",
+    "print(\"Colonne : (3,4,1,2) -> (3,4,2,1), coxeter =\", coxeter((3, 4, 1, 2), (3, 4, 2, 1)))\n",
+    "print(\"retournement (1,2,3,4) -> (4,3,2,1), coxeter =\", coxeter((1, 2, 3, 4), (4, 3, 2, 1)))\n",
+    "print(\"identite (1,2,3,4) -> (1,2,3,4), coxeter =\", coxeter((1, 2, 3, 4), (1, 2, 3, 4)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "019fb5ed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:35.120295Z",
+     "iopub.status.busy": "2026-08-22T00:48:35.120123Z",
+     "iopub.status.idle": "2026-08-22T00:48:37.358438Z",
+     "shell.execute_reply": "2026-08-22T00:48:37.357939Z"
+    },
+    "papermill": {
+     "duration": 2.243089,
+     "end_time": "2026-08-22T00:48:37.359230+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:35.116141+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "paires vérifiées : 331776 / 331776 en 2.2s\n",
+      "décomposition d = coxeter(ligne) + coxeter(colonne) : True\n",
+      "excentricités de tous les jeux : {12: 576}\n",
+      "spot-check matrice [Dilemme][Chicken] = 2 (BFS section 1 : 2 )\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "# Vérification exhaustive : pour chacune des 576 sources, un BFS complet\n",
+    "# (la mesure), comparée a la formule de Coxeter (la prediction) sur les\n",
+    "# 576 destinations. 576 x 576 = 331 776 paires.\n",
+    "t0 = time.perf_counter()\n",
+    "matrice = {}\n",
+    "coherence = True\n",
+    "for G in JEUX:\n",
+    "    dG, _ = bfs(G)\n",
+    "    matrice[G] = dG\n",
+    "    for H in JEUX:\n",
+    "        formule = coxeter(G[0], H[0]) + coxeter(G[1], H[1])\n",
+    "        if dG[H] != formule:\n",
+    "            coherence = False\n",
+    "            print(\"CONTRE-EXEMPLE :\", G, H, dG[H], \"!=\", formule)\n",
+    "            break\n",
+    "    if not coherence:\n",
+    "        break\n",
+    "elapsed = time.perf_counter() - t0\n",
+    "\n",
+    "paires = sum(len(d) for d in matrice.values())\n",
+    "print(f\"paires vérifiées : {paires} / 331776 en {elapsed:.1f}s\")\n",
+    "print(\"décomposition d = coxeter(ligne) + coxeter(colonne) :\", coherence)\n",
+    "\n",
+    "# Corollaires lus sur la matrice complète :\n",
+    "excentricites = Counter(max(dG.values()) for dG in matrice.values())\n",
+    "print(\"excentricités de tous les jeux :\", dict(excentricites))\n",
+    "spot = matrice[CLASSIC[\"Dilemme\"]][CLASSIC[\"Chicken\"]]\n",
+    "print(\"spot-check matrice [Dilemme][Chicken] =\", spot, \"(BFS section 1 :\", DIST_PD[CLASSIC[\"Chicken\"]], \")\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d197550",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003073,
+     "end_time": "2026-08-22T00:48:37.365717+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:37.362644+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : le théorème établi par énumération\n",
+    "\n",
+    "**La décomposition vaut pour chacune des 331 776 paires.** Comme le théorème de la condition de transformation dans GT-21 (vérifié sur les 3 456 paires jeu-générateur), l'énoncé est ici *établi par énumération exhaustive* : l'espace est fini, la vérification est complète, et le résultat se lit sur la sortie. La preuve conceptuelle — indépendance des deux côtés, graphe de Cayley de $S_4$, produit cartésien — est **rapportée en dette** (§Sources) : nous n'en livrons pas la démonstration générale, seulement l'évidence exhaustive sur cet espace.\n",
+    "\n",
+    "Trois corollaires immédiats, tous mesurés :\n",
+    "\n",
+    "- **le diamètre vaut 12** = deux fois le maximum de la longueur de Coxeter d'un côté (6, le retournement) — cohérent avec la mesure GT-3b ;\n",
+    "- **chaque jeu a une excentricité de 12** : l'espace est parfaitement isotrope, aucun point n'est plus central qu'un autre ; le Dilemme n'occupe aucune position privilégiée — c'est une propriété de *l'espace*, pas du jeu ;\n",
+    "- **la distribution depuis n'importe quel jeu** est la convolution des vecteurs de Mahler (cellule précédente) — ce qui explique la symétrie parfaite autour de 6.\n",
+    "\n",
+    "Un point reste ouvert dans la géographie : si les *distances* sont simples, que dire du **nombre** de plus courts chemins ? C'est l'objet de la section 4."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09bb61d1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.002836,
+     "end_time": "2026-08-22T00:48:37.371677+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:37.368841+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 4. Multiplicités : combien de plus courts chemins\n",
+    "\n",
+    "La distance dit *combien de pas* ; elle ne dit pas *par où*. Deux jeux à même distance peuvent être reliés par un nombre très différent de chemins minimaux. Comptons-les en énumérant, pour une cible donnée, tous les chemins qui descendent strictement d'un niveau par étape (tout plus court chemin est une telle descente monotone)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7d31d97a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:37.378523Z",
+     "iopub.status.busy": "2026-08-22T00:48:37.378287Z",
+     "iopub.status.idle": "2026-08-22T00:48:40.967594Z",
+     "shell.execute_reply": "2026-08-22T00:48:40.966828Z"
+    },
+    "papermill": {
+     "duration": 3.593696,
+     "end_time": "2026-08-22T00:48:40.968311+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:37.374615+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dilemme -> Chicken          distance  2 :      2 plus courts chemins (ex : R12 C12)\n",
+      "Dilemme -> Deadlock         distance  2 :      2 plus courts chemins (ex : R23 C23)\n",
+      "Dilemme -> Chasse au cerf   distance  2 :      2 plus courts chemins (ex : R34 C34)\n",
+      "Dilemme -> Pennies          distance  5 :     20 plus courts chemins (ex : C12 C23 C12 R34 R23)\n",
+      "Dilemme -> Harmonie         distance  6 :     80 plus courts chemins (ex : R12 C12 R34 R23 C34 C23)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Dilemme -> anti-Dilemme : 236544 plus courts chemins\n",
+      "mots réduits du retournement, un côté : 16\n",
+      "entrelacements C(12,6) x 16 x 16 = 924 x 16 x 16 = 236544\n"
+     ]
+    }
+   ],
+   "source": [
+    "def voisins_nommes(g):\n",
+    "    \"\"\"Les six voisins d'un jeu, avec le nom de leur générateur.\"\"\"\n",
+    "    r, c = g\n",
+    "    out = []\n",
+    "    for k in (1, 2, 3):\n",
+    "        out.append(((swap_adjacent(r, k), c), f\"R{k}{k + 1}\"))\n",
+    "        out.append(((r, swap_adjacent(c, k)), f\"C{k}{k + 1}\"))\n",
+    "    return out\n",
+    "\n",
+    "def plus_courts_chemins(depart, arrivee):\n",
+    "    \"\"\"Enumere tous les plus courts chemins (descentes monotones de niveaux).\"\"\"\n",
+    "    d = bfs(depart)[0]\n",
+    "    n = d[arrivee]\n",
+    "    chemins = [(depart, [])]\n",
+    "    for _ in range(n):\n",
+    "        chemins = [(v, p + [nom]) for g, p in chemins\n",
+    "                   for v, nom in voisins_nommes(g) if d.get(v, 99) == d[g] + 1]\n",
+    "    return [p for g, p in chemins if g == arrivee]\n",
+    "\n",
+    "from math import comb\n",
+    "for nom in (\"Chicken\", \"Deadlock\", \"Chasse au cerf\", \"Pennies\", \"Harmonie\"):\n",
+    "    cs = plus_courts_chemins(CLASSIC[\"Dilemme\"], CLASSIC[nom])\n",
+    "    print(f\"Dilemme -> {nom:16s} distance {DIST_PD[CLASSIC[nom]]:2d} : \"\n",
+    "          f\"{len(cs):6d} plus courts chemins (ex : {' '.join(cs[0])})\")\n",
+    "\n",
+    "anti = complement(CLASSIC[\"Dilemme\"])\n",
+    "n_anti = len(plus_courts_chemins(CLASSIC[\"Dilemme\"], anti))\n",
+    "# Interpretation structurelle du compte (mesuree independamment) :\n",
+    "identite = ((1, 2, 3, 4), (1, 2, 3, 4))\n",
+    "retourne_ligne = ((4, 3, 2, 1), (1, 2, 3, 4))\n",
+    "mots_w0 = len(plus_courts_chemins(identite, retourne_ligne))\n",
+    "print(f\"\\nDilemme -> anti-Dilemme : {n_anti} plus courts chemins\")\n",
+    "print(\"mots réduits du retournement, un côté :\", mots_w0)\n",
+    "print(f\"entrelacements C(12,6) x 16 x 16 = {comb(12, 6)} x {mots_w0} x {mots_w0} =\",\n",
+    "      comb(12, 6) * mots_w0 ** 2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0045bb82",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003568,
+     "end_time": "2026-08-22T00:48:40.975928+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:40.972360+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : de la commutation à l'explosion combinatoire\n",
+    "\n",
+    "Le spectre des multiplicités est vaste : **exactement 2** chemins minimaux vers chacun des trois cousins (les deux étapes — une par côté — commutent, donc les deux ordres conviennent, et rien d'autre), **20** vers Pennies, **80** vers l'Harmonie, et **236 544** vers l'anti-Dilemme. Ce dernier compte se factorise exactement : $\\binom{12}{6} \\times 16 \\times 16$ — les 16 *mots réduits* du retournement d'un côté (mesurés par la même énumération, restreinte à un seul côté), au carré pour les deux côtés, entrelacés dans $\\binom{12}{6}$ ordres possibles. Le chemin minimal vers l'antagoniste absolu n'est donc pas une rareté : il est abondant, presque *tout chemin glouton qui descend monotone y conduit*.\n",
+    "\n",
+    "La leçon structurelle : la distance (§3) est une fonction simple et additive, mais la **géométrie fine** des géodésiques porte l'information combinatoire — le nombre de mots réduits d'un élément de $S_4$ est une donnée non triviale de la théorie des groupes de Coxeter, rapportée en dette comme le reste du vocabulaire. C'est précisément quand les objets deviennent abondants et faciles à générer que la question du *certificat* devient pressante : qui garantit qu'un chemin proposé est correct ? C'est la section suivante."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89241376",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003169,
+     "end_time": "2026-08-22T00:48:40.982436+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:40.979267+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5. Générateur contre certificat\n",
+    "\n",
+    "Récapitulons les deux rôles, qui resteront séparés jusqu'au bout :\n",
+    "\n",
+    "- le **générateur** (Python, ce notebook) *explore* : BFS, énumération des chemins, comptages. Il **propose** des chemins minimaux — mais un programme qui s'exécute n'est pas une preuve qu'il calcule ce qu'il prétend calculer ;\n",
+    "- le **certificat** (Lean, `game_theory_lean/Swaps/Basic.lean`, écrit pour ce grain) **garantit** : qu'un chemin est bien formé (chaque étape est l'un des six générateurs — c'est *structurel*, le type des étapes ne contient rien d'autre), qu'il mène bien du départ à l'arrivée (évalué par le noyau Lean, `rfl`), et — sur le cas témoin — qu'aucun chemin plus court n'existe (énumération décidable).\n",
+    "\n",
+    "Commençons par le miroir Python du vérificateur, pour voir *ce qui se joue* : un chemin **valide** (il arrive) n'est pas un chemin **minimal** (il arrive le plus vite possible)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "18eb298a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:40.990177Z",
+     "iopub.status.busy": "2026-08-22T00:48:40.989894Z",
+     "iopub.status.idle": "2026-08-22T00:48:40.995664Z",
+     "shell.execute_reply": "2026-08-22T00:48:40.995066Z"
+    },
+    "papermill": {
+     "duration": 0.010297,
+     "end_time": "2026-08-22T00:48:40.996161+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:40.985864+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "chemin minimal   ['R12', 'C12'] : valide = True\n",
+      "chemin détour    ['R12', 'R23', 'R23', 'C12'] : valide = True\n",
+      "\n",
+      "longueurs : 2 vs 4 | distance BFS : 2\n"
+     ]
+    }
+   ],
+   "source": [
+    "def applique_etape(g, e):\n",
+    "    \"\"\"Miroir Python de appliqueEtape (Swaps/Basic.lean) : applique l'étape nommée e.\"\"\"\n",
+    "    r, c = g\n",
+    "    k = int(e[1])\n",
+    "    return (swap_adjacent(r, k), c) if e[0] == \"R\" else (r, swap_adjacent(c, k))\n",
+    "\n",
+    "def applique_chemin(g, chemin):\n",
+    "    \"\"\"Miroir Python de applique : application successive des étapes.\"\"\"\n",
+    "    for e in chemin:\n",
+    "        g = applique_etape(g, e)\n",
+    "    return g\n",
+    "\n",
+    "def chemin_valide(depart, arrivee, chemin):\n",
+    "    \"\"\"Certificat d'arrivée : le chemin mène bien de depart à arrivee.\n",
+    "    Ne dit RIEN de la minimalité.\"\"\"\n",
+    "    return applique_chemin(depart, chemin) == arrivee\n",
+    "\n",
+    "PD, CHICKEN = CLASSIC[\"Dilemme\"], CLASSIC[\"Chicken\"]\n",
+    "c_minimal = [\"R12\", \"C12\"]                    # le chemin du BFS (section 1)\n",
+    "c_detour = [\"R12\", \"R23\", \"R23\", \"C12\"]       # un détour : R23 o R23 = identité\n",
+    "\n",
+    "print(\"chemin minimal  \", c_minimal, \": valide =\", chemin_valide(PD, CHICKEN, c_minimal))\n",
+    "print(\"chemin détour   \", c_detour, \": valide =\", chemin_valide(PD, CHICKEN, c_detour))\n",
+    "print()\n",
+    "print(\"longueurs :\", len(c_minimal), \"vs\", len(c_detour),\n",
+    "      \"| distance BFS :\", DIST_PD[CHICKEN])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76b0307a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003375,
+     "end_time": "2026-08-22T00:48:41.003033+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:40.999658+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : valide n'est pas minimal\n",
+    "\n",
+    "Le certificat d'arrivée accepte les **deux** chemins — et il a raison : les deux mènent bien du Dilemme à Chicken (le détour insère un aller-retour $R_{23} \\circ R_{23}$, qui s'annule). Mais seul le premier est minimal : la longueur 4 du détour dépasse la distance 2. Un vérificateur d'arrivée est donc *complet mais laxiste* ; discriminer les chemins minimaux exige soit l'exploration exhaustive (ce que fait le BFS), soit une borne inférieure (ce que fait le module Lean sur le cas témoin : aucun chemin de longueur < 2 n'existe, par énumération décidable des cas).\n",
+    "\n",
+    "C'est la division du travail que le grain installe : **le générateur produit des candidats abondants** (section 4 : des centaines de milliers vers l'anti-Dilemme), **le certificat tranche** — arrivée garantie toujours, minimalité garantie sur le témoin. Voyons le module Lean lui-même, cité aux lignes mesurées du fichier."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "966de86a",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003015,
+     "end_time": "2026-08-22T00:48:41.009322+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.006307+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 5-bis. Le module Swaps/Basic.lean, cité aux lignes mesurées\n",
+    "\n",
+    "Le module compagnon vit dans `game_theory_lean/Swaps/Basic.lean` (même lake que les preuves Arrow et Shapley). Il est **volontairement sans Mathlib** : tout y est calcul fini décidable sur des listes littérales — les théorèmes se closent par `rfl` (évaluation par le noyau) ou `decide` (énumération décidable), sans tactique sophistiquée ni axiome. La cellule suivante lit le fichier depuis ce clone et imprime chaque définition et chaque théorème à sa ligne réelle — les citations du reste de la section s'appuient sur ces numéros, pas sur une mémoire."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6b4a335f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:41.016334Z",
+     "iopub.status.busy": "2026-08-22T00:48:41.016078Z",
+     "iopub.status.idle": "2026-08-22T00:48:41.021527Z",
+     "shell.execute_reply": "2026-08-22T00:48:41.020964Z"
+    },
+    "papermill": {
+     "duration": 0.0097,
+     "end_time": "2026-08-22T00:48:41.022043+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.012343+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Basic.lean : 135 lignes\n",
+      "\n",
+      "    34: def Table : Type := List Nat\n",
+      "    37: def Jeu : Type := Table × Table\n",
+      "    46: def swapAdj (t : Table) (k : Nat) : Table :=\n",
+      "    50: inductive Etape where\n",
+      "    56: def Etape.k : Etape → Nat\n",
+      "    62: def Etape.ligne : Etape → Bool\n",
+      "    67: def appliqueEtape (g : Jeu) (e : Etape) : Jeu :=\n",
+      "    71: def applique : Jeu → List Etape → Jeu\n",
+      "    78: def dilemme : Jeu := (([3, 1, 4, 2] : Table), [3, 4, 1, 2])\n",
+      "    81: def chicken : Jeu := (([3, 2, 4, 1] : Table), [3, 4, 2, 1])\n",
+      "    84: def cerf : Jeu := (([4, 1, 3, 2] : Table), [4, 3, 1, 2])\n",
+      "    89: def cheminDilemmeChicken : List Etape := [.R12, .C12]\n",
+      "    95: theorem certificat_chemin : applique dilemme cheminDilemmeChicken = chicken := by rfl\n",
+      "   101: theorem chemin_valide_non_minimal :\n",
+      "   106: theorem aucun_chemin_court :\n",
+      "   120: theorem distance_dilemme_chicken :\n",
+      "   130: def cheminValide (depart arrivee : Jeu) (p : List Etape) : Prop :=\n",
+      "   135: theorem certificat_cerf : cheminValide dilemme cerf [.R34, .C34] := by rfl\n",
+      "\n",
+      "occurrences de 'sorry' dans le module : 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "def trouver_swaps_lean():\n",
+    "    \"\"\"Localise Swaps/Basic.lean depuis le répertoire courant ou ses parents\n",
+    "    (le notebook vit dans GameTheory/, le module dans game_theory_lean/).\"\"\"\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        for rel in (\"game_theory_lean/Swaps/Basic.lean\",\n",
+    "                    \"MyIA.AI.Notebooks/GameTheory/game_theory_lean/Swaps/Basic.lean\"):\n",
+    "            cible = base / rel\n",
+    "            if cible.exists():\n",
+    "                return cible\n",
+    "    return None\n",
+    "\n",
+    "chemin_module = trouver_swaps_lean()\n",
+    "if chemin_module is None:\n",
+    "    print(\"module Swaps/Basic.lean introuvable depuis ce répertoire —\"\n",
+    "          \" cloner le dépôt complet pour la lecture des citations\")\n",
+    "else:\n",
+    "    src = chemin_module.read_text(encoding=\"utf-8\")\n",
+    "    lignes = src.splitlines()\n",
+    "    print(f\"{chemin_module.name} : {len(lignes)} lignes\")\n",
+    "    print()\n",
+    "    for i, l in enumerate(lignes, 1):\n",
+    "        if l.startswith((\"def \", \"theorem \", \"inductive \", \"structure \")):\n",
+    "            print(f\"  {i:4d}: {l.rstrip()[:100]}\")\n",
+    "    print()\n",
+    "    print(\"occurrences de 'sorry' dans le module :\", src.count(\"sorry\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fc00356",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003406,
+     "end_time": "2026-08-22T00:48:41.028949+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.025543+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Interprétation : ce que chaque théorème garantit\n",
+    "\n",
+    "La lecture du module aligne les garanties, dans l'ordre où le notebook les a rencontrées :\n",
+    "\n",
+    "- **`certificat_chemin`** — `applique dilemme cheminDilemmeChicken = chicken`, clos par `rfl` : le chemin `[R12, C12]` proposé par le BFS mène bien du Dilemme à Chicken. C'est le certificat d'arrivée, garanti par évaluation du noyau Lean — pas par la ré-exécution d'un programme Python, mais par la réduction du terme lui-même.\n",
+    "- **`chemin_valide_non_minimal`** — le détour `[R12, R23, R23, C12]` arrive aussi (la cellule miroir l'a mesuré côté Python) : le module Lean l'admet explicitement, pour montrer que le certificat d'arrivée n'exclut pas les détours.\n",
+    "- **`aucun_chemin_court`** — aucun chemin de longueur 0 ou 1 ne relie le Dilemme à Chicken : longueur 0 rejetée par `decide` (les jeux diffèrent), longueur 1 par `cases e <;> decide` — les six générateurs sont énumérés un à un, chacun tranché par décision. C'est la **borne inférieure**.\n",
+    "- **`distance_dilemme_chicken`** — la conjonction : un chemin de longueur 2 existe *et* aucun plus court n'existe. La distance vaut **exactement 2** — énoncé complet, prouvé.\n",
+    "\n",
+    "La minimalité générale (pour deux jeux quelconques) reste du côté du générateur : elle exige l'exploration. Le module Lean la certifie sur le témoin parce que l'espace des chemins de longueur < 2 est assez petit pour l'énumération décidable — c'est exactement la frontière où le certificat devient abordable, et le grain la marque explicitement plutôt que de la masquer. Le build du module (`lake build Swaps`) est sans dépendance Mathlib : il se compile en secondes, aucune preuve du lake n'est touchée."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d5826fa",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003919,
+     "end_time": "2026-08-22T00:48:41.036634+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.032715+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6. Exercice 1 : distance par sphères, sans reconstruire tout le BFS\n",
+    "\n",
+    "La fonction `bfs` de la section 1 calcule les distances vers *tous* les jeux. Pour une seule cible, c'est du gaspillage — et parfois impossible si l'espace était plus grand. Écrivez `distance_par_spheres(depart, arrivee)` qui n'explore que les sphères successives jusqu'à rencontrer l'arrivée : maintenez l'ensemble des jeux du niveau courant, engendez le niveau suivant par générateurs, arrêtez dès que l'arrivée apparaît, et renvoyez le niveau. La fonction doit renvoyer le même verdict que le BFS complet pour toute cible — testez-la au moins sur Chicken (distance 2) et sur l'anti-Dilemme (distance 12)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "755b47fb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:41.046349Z",
+     "iopub.status.busy": "2026-08-22T00:48:41.046060Z",
+     "iopub.status.idle": "2026-08-22T00:48:41.050144Z",
+     "shell.execute_reply": "2026-08-22T00:48:41.049525Z"
+    },
+    "papermill": {
+     "duration": 0.009841,
+     "end_time": "2026-08-22T00:48:41.050723+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.040882+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def distance_par_spheres(depart, arrivee):\n",
+    "    \"\"\"Distance de swap par exploration des sphères successives seulement.\n",
+    "    # Etape 1 : niveau courant = [depart], distance = 0\n",
+    "    # Etape 2 : engendrer le niveau suivant par les six générateurs\n",
+    "    # Etape 3 : si l'arrivee y figure, renvoyer la distance ; sinon recommencer\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant\n",
+    "    return None  # a remplacer\n",
+    "\n",
+    "resultat_ex1 = distance_par_spheres(CLASSIC[\"Dilemme\"], CLASSIC[\"Chicken\"])\n",
+    "# Indice : la reponse attendue est petite ; le chemin de cette longueur est\n",
+    "# exhibe en section 1 et certifie par Swaps/Basic.lean (distance exacte 2)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c005c56",
+   "metadata": {
+    "papermill": {
+     "duration": 0.004004,
+     "end_time": "2026-08-22T00:48:41.058772+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.054768+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6-bis. Exercice 2 : le diamètre depuis une autre source — le chiffre, pas l'impression\n",
+    "\n",
+    "La section 3 a mesuré que *tous* les jeux ont une excentricité de 12. Vérifiez-le depuis une source différente du Dilemme : écrivez `excentricite_depuis(source)` (distance maximale de la source à tout autre jeu) et appliquez-la à **Pennies**. Puis identifiez **combien de jeux** sont à distance 12 de Pennies et lequel c'est — la réponse est un couple (chiffre, jeu), pas une impression."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "20a44a08",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:41.067479Z",
+     "iopub.status.busy": "2026-08-22T00:48:41.067291Z",
+     "iopub.status.idle": "2026-08-22T00:48:41.070769Z",
+     "shell.execute_reply": "2026-08-22T00:48:41.070189Z"
+    },
+    "papermill": {
+     "duration": 0.008763,
+     "end_time": "2026-08-22T00:48:41.071345+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.062582+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def excentricite_depuis(source):\n",
+    "    \"\"\"Excentricité d'un jeu : sa distance maximale à tout autre jeu.\n",
+    "    # Etape 1 : BFS complet depuis source\n",
+    "    # Etape 2 : renvoyer le maximum des distances\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant\n",
+    "    return None  # a remplacer\n",
+    "\n",
+    "resultat_ex2 = excentricite_depuis(CLASSIC[\"Pennies\"])\n",
+    "# Indice : le theoreme de decomposition (section 3) predit la valeur sans\n",
+    "# aucun calcul de BFS -- la formule de Coxeter suffit. Les deux doivent coïncider."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb44184c",
+   "metadata": {
+    "papermill": {
+     "duration": 0.00334,
+     "end_time": "2026-08-22T00:48:41.078289+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.074949+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 6-ter. Exercice 3 : le certificat d'un chemin fourni — valide, et minimal ?\n",
+    "\n",
+    "On vous fournit un chemin du Dilemme à Chicken : `[\"R12\", \"R23\", \"R23\", \"C12\"]`. Écrivez `certificat(depart, arrivee, chemin)` qui renvoie un **couple de booléens** : (validité, minimalité).\n",
+    "\n",
+    "- la **validité** se certifie en appliquant le chemin (section 5, miroir Python) et en comparant l'arrivée — c'est ce que `Swaps/Basic.lean` garantit par `rfl` ;\n",
+    "- la **minimalité** exige de comparer la longueur du chemin à la distance réelle — soit par re-BFS (exercice 1), soit par la formule de Coxeter (section 3).\n",
+    "\n",
+    "Votre verdict sur le chemin fourni doit être `(True, False)` : il arrive, mais en 4 pas au lieu de 2. Puis produisez le certificat complet d'un chemin qui mérite les deux `True`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3d76779e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-22T00:48:41.087296Z",
+     "iopub.status.busy": "2026-08-22T00:48:41.086983Z",
+     "iopub.status.idle": "2026-08-22T00:48:41.091354Z",
+     "shell.execute_reply": "2026-08-22T00:48:41.090658Z"
+    },
+    "papermill": {
+     "duration": 0.009745,
+     "end_time": "2026-08-22T00:48:41.091961+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.082216+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "chemin_fourni = [\"R12\", \"R23\", \"R23\", \"C12\"]   # un detour, fourni\n",
+    "\n",
+    "def certificat(depart, arrivee, chemin):\n",
+    "    \"\"\"Verdict d'un chemin : couple (validite, minimalite).\n",
+    "    # Etape 1 : validite -- appliquer le chemin, comparer l'arrivee\n",
+    "    # Etape 2 : minimalite -- la longueur egale-t-elle la distance ?\n",
+    "    # Renvoyer (bool, bool)\n",
+    "    \"\"\"\n",
+    "    # TODO etudiant\n",
+    "    return None  # a remplacer\n",
+    "\n",
+    "resultat_ex3 = certificat(CLASSIC[\"Dilemme\"], CLASSIC[\"Chicken\"], chemin_fourni)\n",
+    "# Indice : attendu (True, False) pour le chemin fourni ; un chemin minimal\n",
+    "# (section 1) merite (True, True)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34b60ef1",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003859,
+     "end_time": "2026-08-22T00:48:41.099927+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.096068+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## 7. Résumé\n",
+    "\n",
+    "- **La distance de swap est mesurable exactement** : BFS depuis n'importe quel jeu, sphères emboîtées. Depuis le Dilemme : Chicken, Deadlock et la chasse au cerf à distance 2 (chacun en échangeant une paire différente de rangs adjacents chez chaque joueur), Pennies à 5, Harmonie à 6, l'anti-Dilemme à 12.\n",
+    "- **Théorème de décomposition (établi par énumération exhaustive, 331 776 paires)** : $d(G, H) = \\ell(r_G, r_H) + \\ell(c_G, c_H)$, la somme des longueurs de Coxeter des permutations relatives. Corollaires mesurés : diamètre 12, excentricité 12 pour *tous* les jeux (isotropie parfaite), distribution depuis tout jeu = convolution des vecteurs de Mahler de $S_4$.\n",
+    "- **Les multiplicités portent la combinatoire** : de 2 chemins minimaux (commutation des deux côtés) vers chacun des trois cousins à 236 544 = $\\binom{12}{6} \\times 16^2$ vers l'anti-Dilemme — les géodésiques abondent exactement là où la distance est maximale.\n",
+    "- **Générateur contre certificat** : le BFS Python propose, le module Lean `Swaps/Basic.lean` garantit — arrivée par `rfl`, minimalité par énumération décidable sur le témoin Dilemme → Chicken (distance exactement 2). Le module est sans Mathlib et sans `sorry` ; la minimalité générale reste du côté du générateur, et la frontière est explicitée.\n",
+    "- **Position dans la série** : après les chambres (GT-3) et les murs (GT-3b), les chemins — c'est la métrique de l'espace entier. Le maillon manquant (rapporté en dette) : le quotient par renommage et la structure $S_4 \\times S_4$ comme *tore*, dont notre espace complet est le dépliage."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97104bbf",
+   "metadata": {
+    "papermill": {
+     "duration": 0.003889,
+     "end_time": "2026-08-22T00:48:41.107939+00:00",
+     "exception": false,
+     "start_time": "2026-08-22T00:48:41.104050+00:00",
+     "status": "completed"
+    },
+    "tags": []
+   },
+   "source": [
+    "## Sources et dettes de dérivation\n",
+    "\n",
+    "**Mesuré dans ce notebook** (chaque chiffre est l'output d'une cellule) : distances aux archétypes, distribution complète, vérification exhaustive de la décomposition (331 776 paires), excentricités, multiplicités des plus courts chemins, factorisation $\\binom{12}{6} \\times 16^2$, miroir Python du vérificateur, citations de `Swaps/Basic.lean` aux lignes réelles.\n",
+    "\n",
+    "**Dettes rapportées, jamais affirmées** (mêmes dettes que GT-3b, auxquelles s'ajoutent les nôtres) :\n",
+    "\n",
+    "1. **Le quotient 576 → 144** (classes de jeux à renommage des stratégies près) et la structure $S_4 \\times S_4$ comme tore — Robinson et Goforth rapportent cette lecture ; tout ce notebook travaille sur l'espace complet des 576 jeux et n'affirme rien du quotient.\n",
+    "2. **La preuve conceptuelle de la décomposition** (indépendance des côtés, graphe de Cayley, produit cartésien de graphes) — nous en livrons l'énumération exhaustive, pas la démonstration générale ; le vocabulaire Coxeter/Mahler est utilisé au strict minimum calculé.\n",
+    "3. **Le tore à 37 trous** et la topologie du quotient — hors scope, rapportée.\n",
+    "4. **Les références arXiv** (2309.15981, 2102.00053, 1704.02230) — citées de seconde main via le réservoir de chantiers (#12211-#12240), non consultées en première main pour ce grain.\n",
+    "5. **La théorie des mots réduits** (16 mots pour le retournement de $S_4$) — mesurée par énumération ; la théorie générale des groupes de Coxeter qui l'explique est rapportée.\n",
+    "\n",
+    "**Module compagnon** : `game_theory_lean/Swaps/Basic.lean` (ce grain) — pur core Lean, sans Mathlib, sans `sorry` ; `lake build Swaps` sans dépendance.\n",
+    "\n",
+    "**Encodages** : identiques à GameTheory-3 et GT-21 (tables de rangs 1-4, cellules dans l'ordre haut-gauche, haut-droit, bas-gauche, bas-droit)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  },
+  "papermill": {
+   "default_parameters": {},
+   "duration": 7.782311,
+   "end_time": "2026-08-22T00:48:41.357161+00:00",
+   "environment_variables": {},
+   "exception": null,
+   "input_path": "GameTheory-3c-Chemins-de-Swaps.ipynb",
+   "output_path": "GameTheory-3c-Chemins-de-Swaps.ipynb",
+   "parameters": {},
+   "start_time": "2026-08-22T00:48:33.574850+00:00",
+   "version": "2.7.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/Swaps.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/Swaps.lean
@@ -1,0 +1,29 @@
+/-
+  Swaps — root aggregator FR
+  ==========================
+
+  Chemins de swaps sur les jeux 2×2 ordinaux : compagnon formel du
+  notebook `GameTheory-3c-Chemins-de-Swaps.ipynb` (grain #12222).
+
+  Le module substantiel vit dans `Swaps/Basic.lean` : type `Table`,
+  les six générateurs adjacents (`Etape`), l'application d'un chemin
+  (`applique`), et les quatre théorèmes du certificat —
+  `certificat_chemin` (arrivée, par `rfl`), `chemin_valide_non_minimal`
+  (valide ≠ minimal), `aucun_chemin_court` (borne inférieure par
+  énumération décidable) et `distance_dilemme_chicken` (la distance
+  Dilemme → Chicken vaut exactement 2).
+
+  Ce fichier existe parce que le `lean_lib Swaps` du lakefile déclare
+  `globs := #[`Swaps.*]` : Lake résout la racine `Swaps` de la
+  bibliothèque, et son absence rend `error: Swaps: some modules have
+  bad imports` (CI de la PR #12260). Les quatre bibliothèques sœurs du
+  même package suivent exactement cette convention — `SocialChoice.lean`,
+  `CooperativeGames.lean`, `RepeatedGames.lean`, `StableMarriage.lean`
+  sont chacune une racine qui n'agrège que des imports.
+
+  Volontairement SANS Mathlib : tout est calcul fini décidable sur des
+  listes littérales, clos par `rfl` et `decide`. `lake build Swaps` ne
+  déclenche donc aucune compilation de dépendance.
+-/
+
+import Swaps.Basic

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/Swaps/Basic.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/Swaps/Basic.lean
@@ -1,0 +1,135 @@
+/-
+  Chemins de swaps sur les jeux 2×2 ordinaux — vérificateur certifié
+  =================================================================
+
+  Compagnon Lean du notebook `GameTheory-3c-Chemins-de-Swaps.ipynb`
+  (grain #12222, suite de GameTheory-3b « Chambres et Murs »).
+
+  Répartition des rôles, que le notebook documente explicitement :
+  - le **générateur** (Python, dans le notebook) explore l'espace des
+    576 jeux stricts par parcours en largeur (BFS, niveau par niveau)
+    et **propose** un plus court chemin ;
+  - le **certificat** (ce module) **garantit** qu'un chemin proposé est
+    bien formé — chaque étape est l'un des six générateurs adjacents —
+    et qu'il mène bien du jeu de départ au jeu d'arrivée ;
+  - la **minimalité** est certifiée ici sur le cas témoin Dilemme →
+    Chicken : aucun chemin de longueur inférieure à 2 ne relie les deux
+    jeux (énumération décidable), donc la distance vaut exactement 2.
+
+  Représentation (convention GameTheory-3 / GameTheory-21) : une table
+  de paiements porte les rangs 1-4 des quatre cellules dans l'ordre
+  (haut-gauche, haut-droit, bas-gauche, bas-droit). Un jeu est le
+  couple (table Ligne, table Colonne). Un générateur échange les deux
+  cellules portant deux rangs adjacents — vu des valeurs, c'est une
+  relabellisation k ↔ k+1.
+
+  Ce module est volontairement SANS Mathlib : tout est calcul fini
+  décidable sur des listes littérales, clos par `rfl` et `decide`.
+  Vérifié par `lake build Swaps.Basic` — aucun axiome, aucune preuve
+  trouée.
+-/
+
+/-- Une table de paiements : les quatre rangs 1-4 dans l'ordre
+(haut-gauche, haut-droit, bas-gauche, bas-droit). -/
+def Table : Type := List Nat
+
+/-- Un jeu 2×2 ordinale : la table de Ligne et celle de Colonne. -/
+def Jeu : Type := Table × Table
+
+-- Instances pont : la synthèse de classes ne traverse pas les `def`,
+-- on les reexporte explicitement pour que `decide` s'applique aux jeux.
+instance : DecidableEq Table := (inferInstance : DecidableEq (List Nat))
+instance : DecidableEq Jeu := (inferInstance : DecidableEq (Table × Table))
+
+/-- Échange les rangs `k` et `k + 1` dans une table — le générateur
+élémentaire : relabellisation de deux valeurs adjacentes. -/
+def swapAdj (t : Table) (k : Nat) : Table :=
+  t.map (fun v => if v = k then k + 1 else if v = k + 1 then k else v)
+
+/-- Les six générateurs : trois paires adjacentes par joueur. -/
+inductive Etape where
+  | R12 | R23 | R34  -- côté Ligne
+  | C12 | C23 | C34  -- côté Colonne
+  deriving DecidableEq, Repr
+
+/-- La valeur de base `k` d'une étape (1, 2 ou 3). -/
+def Etape.k : Etape → Nat
+  | .R12 | .C12 => 1
+  | .R23 | .C23 => 2
+  | .R34 | .C34 => 3
+
+/-- L'étape agit-elle sur la table de Ligne ? -/
+def Etape.ligne : Etape → Bool
+  | .R12 | .R23 | .R34 => true
+  | .C12 | .C23 | .C34 => false
+
+/-- Application d'une étape à un jeu. -/
+def appliqueEtape (g : Jeu) (e : Etape) : Jeu :=
+  if e.ligne then (swapAdj g.1 e.k, g.2) else (g.1, swapAdj g.2 e.k)
+
+/-- Application d'un chemin (liste d'étapes) à un jeu. -/
+def applique : Jeu → List Etape → Jeu
+  | g, [] => g
+  | g, e :: p => applique (appliqueEtape g e) p
+
+/-! ## Les jeux témoins (encodages GameTheory-3 / GameTheory-21) -/
+
+/-- Le Dilemme du prisonnier. -/
+def dilemme : Jeu := (([3, 1, 4, 2] : Table), [3, 4, 1, 2])
+
+/-- Chicken (Hawk-Dove). -/
+def chicken : Jeu := (([3, 2, 4, 1] : Table), [3, 4, 2, 1])
+
+/-- La chasse au cerf (Stag Hunt). -/
+def cerf : Jeu := (([4, 1, 3, 2] : Table), [4, 3, 1, 2])
+
+/-! ## Le chemin proposé par le générateur -/
+
+/-- Le chemin proposé par le BFS du notebook : R₁₂ puis C₁₂. -/
+def cheminDilemmeChicken : List Etape := [.R12, .C12]
+
+/-! ## Certificats -/
+
+/-- **Certificat d'arrivée** : le chemin proposé mène bien du Dilemme à
+Chicken. Évalué par le noyau (`rfl`) — aucune tactique, aucun axiome. -/
+theorem certificat_chemin : applique dilemme cheminDilemmeChicken = chicken := by rfl
+
+/-- Un chemin **valide mais non minimal** : l'aller-retour R₂₃ ∘ R₂₃
+s'annule, la longueur passe à 4 sans changer l'arrivée. Le certificat
+d'arrivée l'accepte — seule l'analyse de minimalité le distingue du
+plus court chemin. -/
+theorem chemin_valide_non_minimal :
+    applique dilemme [.R12, .R23, .R23, .C12] = chicken := by rfl
+
+/-- **Bornes inférieures** : aucun chemin de longueur 0 ou 1 ne relie
+le Dilemme à Chicken. Chaque cas est tranché par énumération décidable. -/
+theorem aucun_chemin_court :
+    ∀ p : List Etape, p.length < 2 → applique dilemme p ≠ chicken := by
+  intro p hp
+  match p with
+  | [] => decide
+  | [e] => cases e <;> decide
+  | _ :: _ :: reste =>
+      simp only [List.length_cons] at hp
+      omega
+
+/-- **Distance exacte** : la distance de swap entre le Dilemme et
+Chicken vaut exactement 2 — un chemin de longueur 2 existe
+(certificat) et aucun chemin plus court n'existe (bornes
+inférieures). -/
+theorem distance_dilemme_chicken :
+    applique dilemme cheminDilemmeChicken = chicken ∧
+    ∀ p : List Etape, p.length < 2 → applique dilemme p ≠ chicken :=
+  ⟨certificat_chemin, aucun_chemin_court⟩
+
+/-! ## Vérificateur générique -/
+
+/-- Vérificateur générique : `p` est un certificat valide de `depart`
+vers `arrivee` si le chemin mène bien de l'un à l'autre. Rien n'est
+affirmé ici sur la minimalité — c'est le rôle des bornes inférieures. -/
+def cheminValide (depart arrivee : Jeu) (p : List Etape) : Prop :=
+  applique depart p = arrivee
+
+/-- Deuxième témoin : la chasse au cerf est à distance 2 du Dilemme,
+par l'échange des deux meilleurs rangs chez chaque joueur. -/
+theorem certificat_cerf : cheminValide dilemme cerf [.R34, .C34] := by rfl

--- a/MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean
+++ b/MyIA.AI.Notebooks/GameTheory/game_theory_lean/lakefile.lean
@@ -86,3 +86,13 @@ lean_lib RepeatedGames where
   -- Includes: stage game (Prisoner's Dilemma), discounting, grim trigger
   -- Theorem phare: grim_trigger_sustains_iff (one-shot deviation principle)
   globs := #[`RepeatedGames.*, `RepeatedGames_en]
+
+-- c.5383117259 (po-2025) : ajout `lean_lib Swaps` — grain #12222
+-- (GameTheory-3c, chemins de swaps). Vérificateur certifié des chemins
+-- de générateurs adjacents : certificat d'arrivée (`rfl`), bornes
+-- inférieures par énumération décidable, distance exacte Dilemme-Chicken.
+-- VOLONTAIREMENT sans Mathlib (calcul fini sur listes littérales) —
+-- `lake build Swaps` ne déclenche aucune compilation de dépendance.
+@[default_target]
+lean_lib Swaps where
+  globs := #[`Swaps.*]


### PR DESCRIPTION
Grain: DEEP/notebook-lean — lane myia-po-2025:CoursIA — prev: DEEP/notebook-python #12253

## Summary

Grain **#12222** (réservoir #12211-#12240, chantiers #12204-#12208) — troisième temps de la géométrie ordinale après GT-3b (#12253). Deux livrables couplés : le notebook **`GameTheory-3c-Chemins-de-Swaps.ipynb`** (33 cellules, 13 code, pur stdlib) et le module compagnon **`game_theory_lean/Swaps/Basic.lean`** (135 lignes, pur core Lean, **sans Mathlib**, 0 `sorry`).

**Résultats (tous mesurés dans les outputs commités) :**

- **Distances depuis le Dilemme** : Chicken, Deadlock et la chasse au cerf à **distance 2** — chacun en échangeant une paire *différente* de rangs adjacents chez chaque joueur (les deux pires / le milieu / les deux meilleurs), Pennies à 5, Harmonie à 6, et l'**anti-Dilemme** (complément ordinal) **seul** à 12.
- **Distribution symétrique parfaite** {1, 6, 19, 42, 71, 96, 106, 96, 71, 42, 19, 6, 1} — prédite AVANT d'être mesurée comme **convolution des vecteurs de Mahler** de $S_4$ (coïncidence exacte vérifiée).
- **Théorème de décomposition ÉTABLI par énumération exhaustive** : $d(G,H) = \ell(r_G,r_H) + \ell(c_G,c_H)$ (longueurs de Coxeter des permutations relatives) — **331 776/331 776 paires vérifiées en 2,7 s** (BFS indépendant vs formule). Corollaires mesurés : diamètre 12, **excentricité 12 pour les 576 jeux** (isotropie), distribution depuis tout jeu = convolution.
- **Multiplicités des plus courts chemins** : 2 vers chacun des trois cousins (commutation des deux côtés), 20 vers Pennies, 80 vers Harmonie, **236 544 vers l'anti-Dilemme = C(12,6) × 16²** (les 16 mots réduits du retournement mesurés par la même énumération, entrelacements binomiaux).
- **Générateur contre certificat (le cœur du grain)** : le BFS Python propose ; `Swaps/Basic.lean` garantit — `certificat_chemin` par `rfl`, `chemin_valide_non_minimal` (le détour `[R12, R23, R23, C12]` arrive aussi : valide ≠ minimal), **`aucun_chemin_court` par `cases e <;> decide`** (les 6 générateurs énumérés), et `distance_dilemme_chicken` : la distance vaut **exactement 2** (conjonction borne sup / borne inf). Le notebook cite le module **aux lignes mesurées** (sortie de la cellule §5-bis : 135 lignes, chaque def/theorem à sa ligne, 0 `sorry`).
- **3 exercices stubbés** (C.1) : distance par sphères, diamètre depuis Pennies (le chiffre, pas l'impression), certificat (True, False) d'un chemin détourné.

**Dettes de dérivation (HARD, RAPPORTÉES — §Sources)** : quotient 576→144 et tore (travail sur l'espace complet 576, jamais affirmé), preuve *conceptuelle* de la décomposition (nous livrons l'énumération exhaustive, pas la théorie des graphes de Cayley), tore à 37 trous, arXiv 2309.15981/2102.00053/1704.02230 (seconde main), théorie générale des mots réduits.

## Validation Lean (règle §B)

- `lake build Swaps.Basic` : **Build completed successfully (2 jobs)** — exit 0, mesuré firsthand (2 itérations : `cheminValide` passé de `Bool` à `Prop` car `rfl` ne réduit pas `==` à travers les instances BEq ; ajout des instances pont `DecidableEq Table/Jeu` pour `decide`)
- **`sorry` (instrument canonique)** : `count_code_sorry.py --json` champ `distinct_code_sorry` du lake game_theory_lean — **avant (main) : 1 · après : 1** — corpus scanne par l'instrument : 47 modules `.lean` du lake avant, 48 apres (le stretch `folk_theorem_discounted` documenté #4880 ; mon module n'en contient aucun, grep littéral = 0)
- §B.3 : **non applicable** — le module ne dépend d'aucun workflow `lean-axiom.yml` ciblé (pur core, pas d'import Mathlib) ; aucune preuve existante modifiée (nouvelle lib `Swaps` ajoutée au lakefile, les 4 libs existantes inchangées)

## Validation notebook (post-dernier-commit c2b238001)

- **Exécution réelle** : papermill kernel `python3` — **13/13 cellules code, 0 erreur**, séquence `1..13` CLEAN (`check_exec_sequence` : UNORDERED 0, GAP 0), outputs réels commités ; `metadata.papermill` normalisé au basename (exception permise)
- **C.1** : 0 `raise NotImplementedError|assert False|1/0` — 3 exercices stubbés (`return None  # TODO etudiant` + `# Etape N` + `# Indice`), le notebook s'exécute de bout en bout non complété
- **C.2/C.3** : `execution_count != null` + outputs pour 13/13 ; notebook nouveau (aucune cellule d'autrui touchée)
- **Guards** : `nbformat.validate` OK (33 cellules) · `count_exercises` = **3/3 conforming** · densité pédagogique OK (0 below-threshold) · `detect_markdown_rendering --check` OK · navlinks 0 cassé
- Catalogue byte-identique a main (ajout seulement ; entree = cron <24h) ; claim c.5376764071 (globs `3c`+`03c`, `game_theory_lean/Swaps*.lean`)
- **L898 — rectification ai-01 (2026-08-22)** : l'enonce d'origine (« aucune PR ouverte touchant `GameTheory-3c*` ») etait vrai a l'ouverture (00:51Z) et ne l'est plus : **#12268** a ouvert sur le meme chemin a 01:41Z, depuis `myia-po-2024:CoursIA-2`. Collision arbitree par ai-01 sur le **contenu** (voir le commentaire de cloture de #12268) : cette PR est la canonique, #12268 est fermee.
- **Note renommage** : #12241 (zero-pad, OPEN) renommera le slot en `03c` après merge — follow-up trivial couvert par les globs du claim
- **Junction .lake** : le build a tourné dans le worktree via junction vers le `.lake` de l'arbre principal (packages clonés une fois, mécanisme éprouvé) — aucun artefact committé (`.lake` gitignoré)

Closes #12222 (compagnon Lean = cœur du grain : livré, compilé, cité ; `lake build SUCCESS` dans le body ; générateur Python ≠ vérificateur Lean distingué explicitement §5/§5-bis ; quotient et dérivations RAPPORTÉS §Sources)

Co-Authored-By: Claude-Code <noreply@anthropic.com>



---

**Intervention ai-01 (2026-08-22)** — un commit ajoute a cette branche : `99701cce7`, racine `game_theory_lean/Swaps.lean` (docstring + `import Swaps.Basic`, aucune preuve ni enonce touche). Cause : le `lean_lib Swaps` du lakefile declare `globs := #[`Swaps.*]` sans que la racine de bibliotheque existe, d'ou `error: Swaps: some modules have bad imports` au job **Lake build** (run 32541662280) — invisible depuis un `lake build Swaps.Basic` cible, qui est ce que le body mesurait. Les quatre bibliotheques soeurs du package portent chacune leur racine (`SocialChoice.lean`, `CooperativeGames.lean`, `RepeatedGames.lean`, `StableMarriage.lean`) : le fichier ajoute suit cette convention.

Je n'ai **pas** construit le lake localement (toolchain `v4.32.1` absent de cette machine, seuls `v4.25.0` et `v4.27.0-rc1` y sont installes) : c'est la CI qui fait autorite sur ce commit, pas moi.