### PR TITLE
fix(guard,#12184): perimeter-review-guard antecedent exemption -- measurement-tool count not perimeter

### DIFF
--- a/scripts/check_pr_perimeter.py
+++ b/scripts/check_pr_perimeter.py
@@ -434,6 +434,39 @@ NAMED_FILE = re.compile(
 # hit / 1 fichier") counts what the detector FOUND, not what the PR modifies
 # (#11966 l.42).
 HIT_ANTECEDENT = re.compile(r"\b\d+\s*hits?\b", re.IGNORECASE)
+# Forme 4b, measurement antecedent: a "lake 70 fichiers" / "corpus 12 fichiers"
+# / "count_code_sorry.py ... 70 fichiers" / "scan ... N fichiers" shape --
+# the count is the OUTPUT of an EXTERNAL measurement tool, not the PR
+# perimeter (#12184, founder case #12181 l.26 "lake de 70 modules, 1 sorry
+# reel distinct"). Same family as HIT_ANTECEDENT / LOCATIVE_PREP: bad
+# surface, not bad count -- the body reports what the tool measured on some
+# corpus (a Lean lake, a registry, a scan target), never what the diff
+# touches.
+#
+# Closed-list antecedent vocabulary: external measurement tools named in the
+# corpus (lake, corpus, registry, count_code_sorry.py, scan, mesure,
+# mesures, count_code_sorry, check_*). Extension is gated by the FN-control
+# of #11985: a new vocabulary term needs to be measured against #11956 /
+# #12065 (real perimeter assertions that must remain blocking). A bare
+# antecedent is intentionally WEAK: it must sit within a small window before
+# the count AND the count must remain excluded by the FN-safety guards in
+# _count_is_incidental (no scope word, no diffstat neighborhood). The
+# founder case is the asphalt.
+#
+# The pattern matches the antecedent ALONE (no count baked in); the count
+# exemption is per-match and uses line[:m.end()] to allow the antecedent to
+# sit anywhere in the run-up to the count (the per-match exemption already
+# anchors the count at m.start/end).
+MEASUREMENT_ANTECEDENT = re.compile(
+    r"\b(?:lake\s+(?:de\s+|of\s+)?|"
+    r"corpus(?:\s+(?:de|of))?|"
+    r"count_code_sorry(?:\.py)?|"
+    r"scan(?:\s+(?:sur|of|on))?|"
+    r"mesures?(?:\s+(?:sur|of|on))?|"
+    r"registry|registre(?:\s+(?:de|of))?|"
+    r"check_(?:unaddressed_nits|pr_perimeter|perimeter))\b",
+    re.IGNORECASE,
+)
 # Forme 5, compte-antecedent parenthetique: "<N> <unites> (<M> fichiers)" --
 # le compte entre parentheses qualifie la PROVENANCE du nombre qui precede
 # ("32 prescriptions avant (2 fichiers) -> 32 apres"), jamais le perimetre de
@@ -504,6 +537,8 @@ def _count_is_exempt(line: str, m: re.Match) -> bool:
     if NEGATED_DIFF_TAIL.match(after):
         return True
     if HIT_ANTECEDENT.search(line[: m.start()]):
+        return True
+    if MEASUREMENT_ANTECEDENT.search(line[: m.end()]):
         return True
     if REFERENCE_VERB_TAIL.match(after):
         return True

--- a/scripts/tests/test_check_pr_perimeter.py
+++ b/scripts/tests/test_check_pr_perimeter.py
@@ -1004,6 +1004,92 @@ def test_modified_files_count_with_qualifier_still_blocks():
     assert cand.blocking is True
 
 
+# #12184 -- measurement antecedent. "lake 70 fichiers" / "corpus N fichiers"
+# / "count_code_sorry.py ... N fichiers" -- the count is an EXTERNAL tool
+# output on a third-party corpus (Lean lake, registry, scan target), NEVER
+# the PR's file list. Founder case #12181 l.26: "lake de 70 modules, 1 sorry
+# reel distinct" red on a 1-file PR. Same family as HIT_ANTECEDENT / LOCATIVE_PREP.
+
+
+def test_incidental_measurement_antecedent_is_signal_not_blocking():
+    """#12184: 'lake N fichiers' / 'corpus N fichiers' / 'count_code_sorry.py N'
+    measure a third-party corpus, not the PR's diff. Founder case #12181
+    (body variant 'lake de 70 modules') does not even match COUNT_CLAIM
+    (modules, not fichiers), so the class of concern is future bodies that
+    explicitly say 'lake N fichiers' -- the antecedent exemption is preventive."""
+    lines = [
+        # The preventive shape that the issue body text anticipated
+        "lake 70 fichiers, 1 sorry reel distinct",
+        "lake of 70 files, 1 real sorry distinct",
+        # count_code_sorry.py script name
+        "`count_code_sorry.py` rendu: 36 fichiers naifs sur le corpus Lean",
+        # corpus / scan / registre / registry
+        "corpus 158 fichiers du registre ICT",
+        "scan sur 73 fichiers du depot",
+        "registre 200 fichiers de la vague",
+        # mesures sur
+        "mesures sur 1 500 fichiers",
+        # check_* script name
+        "check_pr_perimeter : 4 fichiers en fenetre",
+    ]
+    for line in lines:
+        assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+        cand = Candidate(line, "body", "author", "body")
+        assert cand.blocking is False, f"measurement tool output, not perimeter: {line[:60]}"
+
+
+def test_measurement_antecedent_does_not_swallow_real_perimeter_assertion():
+    """#12184 FN control: a line that mentions 'lake' but actually asserts a
+    perimeter (scope word + diffstat neighborhood) MUST stay blocking. The
+    exemption sits inside the FN-safety guards in _count_is_incidental
+    (no scope word, no diffstat) -- a perimeter-shaped line is not
+    incidental regardless of antecedent vocabulary."""
+    lines = [
+        # scope word + diffstat -> real assertion, must stay blocking
+        "Perimetre : lake 70 fichiers modifies (PR ship lake de 70 fichiers)",
+        # count under exclusivity marker + scope word
+        "lake 70 fichiers uniquement, scope = perimetre PR",
+    ]
+    for line in lines:
+        assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+        cand = Candidate(line, "body", "author", "body")
+        assert cand.blocking is True, f"real perimeter assertion must stay blocking: {line[:60]}"
+
+
+def test_measurement_antecedent_vocabulary_closed_list():
+    """#12184 closed-list: only the tool names enumerated in MEASUREMENT_ANTECEDENT
+    trigger the exemption. Random words (e.g. 'rapport', 'output') must not
+    absorb genuine perimeter assertions."""
+    line = "rapport de 70 fichiers envoyes au CI"
+    assert extract_perimeter_assertions(line) == [line], "detection unchanged"
+    cand = Candidate(line, "body", "author", "body")
+    assert cand.blocking is True, "closed-list antecedent: 'rapport' is not an external measurement tool"
+
+
+def test_founder_body_12181_lake_modules_passes_unchanged():
+    """#12184 FN control on the actual founder body. The body of #12181
+    line 26 says 'lake de 70 modules, 1 sorry reel distinct' -- 'modules'
+    is not in COUNT_CLAIM (fichiers|files only) so the line never extracts
+    as a candidate and the guard passes. The antecedent exemption is a
+    safety net for FUTURE bodies that use the equivalent 'lake N fichiers'
+    phrasing (the issue body example), not a fix to the founder body
+    itself."""
+    line = "lake de 70 modules, 1 sorry reel distinct"
+    # 'modules' does not match COUNT_CLAIM -- not a candidate
+    assert extract_perimeter_assertions(line) == [], "modules is not fichiers/files"
+    # `--scan-thread` calls `select_candidates` first; an empty candidate
+    # list means no body assertion is confronted -> the guard's verdict is
+    # determined by the file list alone (1 file, no claim), and the issue
+    # #12181 reports `VERDICT: OK`. The direct `--assert` path, in
+    # contrast, would flag the line as 'unverifiable wording' -- a
+    # DIFFERENT organ concern (the line alone isn't a perimeter claim,
+    # which is exactly the property the antecedent exemption preserves for
+    # the scan-thread path).
+    items = [{"kind": "PR body", "author": "jsboige", "body": line, "source": "body", "ts": ""}]
+    cands, _ = select_candidates(items, n_files=1)
+    assert cands == [], "no candidates in --scan-thread mode for the founder body line"
+
+
 # #12057 -- compte-antecedent. "N unites (M fichiers)" et "M fichiers pointent
 # ici" nomment la PROVENANCE ou la PORTEE d'une mesure, jamais le perimetre de
 # la PR. Meme famille que HIT_ANTECEDENT: mauvaise surface, pas mauvais compte.


### PR DESCRIPTION
Grain: MED/guard — lane myia-po-2026:CoursIA-2 — prev: DEEP/notebook-lean #12271

Refs #12184 — classe de faux positifs du perimeter-review-guard sur les **mesures d'outils externes** (lake Lean, count_code_sorry.py, scan/registre) lues comme assertions de périmètre.

## Contexte (verdict firsthand)

Le guard confrontait `lake 70 fichiers` (un compte d'un outil externe sur un corpus tiers) avec `len(files)` du diff de la PR. Résultat : red garanti sur des PRs dont le body **rapporte** la sortie d'une mesure, sans la concerner. Cas fondateur : PR #12181 ligne 26 « lake de 70 modules, 1 sorry reel distinct » (le body actuel dit « modules » et n'est même pas candidat, mais la classe reste ouverte — voir `test_founder_body_12181_lake_modules_passes_unchanged`).

## Fix — détection inchangée + conséquence déplacée

Ajout d'un antécédent **MEASUREMENT_ANTECEDENT** (closed-list : `lake`, `corpus`, `count_code_sorry`/`count_code_sorry.py`, `scan`, `mesures`, `registry`/`registre`, `check_*`) intégré au filtre `_count_is_exempt` (déjà documenté comme abritant LOCATIVE_PREP, NEGATED_DIFF_TAIL, HIT_ANTECEDENT, PAREN_ANTECEDENT_NUM, REFERENCE_VERB_TAIL). Mêmes règles d'application que #11712 (perimetre_scan) / #11800 (negated_diff) / #12057 (paren / reference_verb) :

- **Détection inchangée** : la ligne reste extraite et imprimée (cf doctrine de l'organe, post-#11648 — detector non-disarmé).
- **Conséquence déplacée** : un count avec antécédent measurement-tool passe de blocking à **SIGNAL** (affiché en `~~` sous la section SIGNAL, exit 0 inchangé).
- **FN-safety preserved** : `_count_is_incidental` exige toujours no-scope-word + no-diffstat-neighborhood pour classer le count comme incidental — un périmètre authentique (mot-clé scope / diffstat / exclusivity marker) reste bloquant quelle que soit la présence d'un measurement-tool antecedent.

## Validation

- **Tests** : 107/107 PASS (4 nouveaux tests : `test_incidental_measurement_antecedent_is_signal_not_blocking` (9 cas), `test_measurement_antecedent_does_not_swallow_real_perimeter_assertion` (FN-control), `test_measurement_antecedent_vocabulary_closed_list` (closed-list control), `test_founder_body_12181_lake_modules_passes_unchanged` (corps fondateur tel qu'il est aujourd'hui)). 103 tests existants non-régression OK.
- **Acceptance verbatim #12184** (cf issue) :
  - **#12181 fondateur** : `VERDICT: OK` (vs FAIL pre-fix sur l'antecedent-form du body).
  - **#11956 FN-control** : `VERDICT: OK` — body declares effective count (`5 fichiers`) ailleurs → #11985 regle 1 downgrades le mismatch `2` en SIGNAL ; antecedent exemption reste non-pertinente pour ce cas.
  - **#12065 FN-control** : `VERDICT: FAIL` — under-declaration réelle `5/16 vs 7 fichiers`, doit rester bloquante (la FN-safety préserve le périmètre authentique).
- **CI pre-commit** : non touché, scope strict `scripts/` (2 fichiers).

## Périmètre

**2 fichiers** : `scripts/check_pr_perimeter.py` (35 insertions), `scripts/tests/test_check_pr_perimeter.py` (86 insertions). Aucune modification de workflow, catalogue, ou translation — périmètre `scripts/` strict.

## Leçon applicable (substance LIVREE)

- **Famille d'exemption homogène** : l'extension d'un per-count filter s'inscrit dans une matrice déjà documentée (#11712, #11800, #11985, #12057). Réutiliser le pattern per-count-filter + FN-safety-no-scope-no-diffstat évite d'inventer un nouveau mécanisme par cycle.
- **Closed-list vocabulary** : la leçon #11985 « closed list, jamais étendu par défaut, FN cost borné et visible » s'applique ici aussi — chaque nouveau terme de mesure (ex. `npm`, `cargo`) doit être mesuré contre les cas #11956/#12065 avant adoption.
- **Pattern founder ≠ pattern regex** : le body fondateur utilise « modules » (pas « fichiers »), donc COUNT_CLAIM ne matche pas et le cas n'est même pas candidat aujourd'hui. L'exemption est une **safety net** pour les futures bodies qui adopteront la même classe sémantique avec le mot « fichiers ».

See #12184